### PR TITLE
Fix distribution alignment issues with iteration

### DIFF
--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -839,6 +839,8 @@ iter BlockDom.these(param tag: iterKind) where tag == iterKind.leader {
 // natural composition and might help with my fears about how
 // stencil communication will be done on a per-locale basis.
 //
+// TODO: Can we just re-use the DefaultRectangularDom follower here?
+//
 iter BlockDom.these(param tag: iterKind, followThis) where tag == iterKind.follower {
   proc anyStridable(rangeTuple, param i: int = 1) param
       return if i == rangeTuple.size then rangeTuple(i).stridable
@@ -854,7 +856,7 @@ iter BlockDom.these(param tag: iterKind, followThis) where tag == iterKind.follo
     // not checking here whether the new low and high fit into idxType
     var low = (stride * followThis(i).low:strType):idxType;
     var high = (stride * followThis(i).high:strType):idxType;
-    t(i) = ((low..high by stride:strType) + whole.dim(i).low by followThis(i).stride:strType).safeCast(t(i).type);
+    t(i) = ((low..high by stride:strType) + whole.dim(i).alignedLow by followThis(i).stride:strType).safeCast(t(i).type);
   }
   for i in {(...t)} {
     yield i;
@@ -1130,7 +1132,7 @@ iter BlockArr.these(param tag: iterKind, followThis, param fast: bool = false) r
     // NOTE: Not bothering to check to see if these can fit into idxType
     var low = followThis(i).low * abs(stride):idxType;
     var high = followThis(i).high * abs(stride):idxType;
-    myFollowThis(i) = ((low..high by stride) + dom.whole.dim(i).low by followThis(i).stride).safeCast(myFollowThis(i).type);
+    myFollowThis(i) = ((low..high by stride) + dom.whole.dim(i).alignedLow by followThis(i).stride).safeCast(myFollowThis(i).type);
     lowIdx(i) = myFollowThis(i).low;
   }
 

--- a/modules/dists/CyclicDist.chpl
+++ b/modules/dists/CyclicDist.chpl
@@ -621,7 +621,7 @@ iter CyclicDom.these(param tag: iterKind, followThis) where tag == iterKind.foll
   for param i in 1..rank {
     // NOTE: unsigned idxType with negative stride will not work
     const wholestride = whole.dim(i).stride:chpl__signedType(idxType);
-    t(i) = ((followThis(i).low*wholestride:idxType)..(followThis(i).high*wholestride:idxType) by (followThis(i).stride*wholestride)) + whole.dim(i).low;
+    t(i) = ((followThis(i).low*wholestride:idxType)..(followThis(i).high*wholestride:idxType) by (followThis(i).stride*wholestride)) + whole.dim(i).alignedLow;
   }
   if debugCyclicDist then
     writeln(here.id, ": follower maps to: ", t);
@@ -875,7 +875,7 @@ iter CyclicArr.these(param tag: iterKind, followThis, param fast: bool = false) 
     const      lo = (followThis(i).low * iStride):idxType,
                hi = (followThis(i).high * iStride):idxType,
            stride = (followThis(i).stride*wholestride):strType;
-    t(i) = (lo..hi by stride) + dom.whole.dim(i).low;
+    t(i) = (lo..hi by stride) + dom.whole.dim(i).alignedLow;
   }
   const myFollowThis = {(...t)};
   if fast {

--- a/modules/dists/StencilDist.chpl
+++ b/modules/dists/StencilDist.chpl
@@ -363,8 +363,8 @@ class LocStencilArr {
   }
 }
 
-private proc makeZero(param rank : int) {
-  var ret : rank*int;
+private proc makeZero(param rank : int, type idxType) {
+  var ret : rank*idxType;
   return ret;
 }
 //
@@ -377,7 +377,7 @@ proc Stencil.Stencil(boundingBox: domain,
                 dataParMinGranularity=getDataParMinGranularity(),
                 param rank = boundingBox.rank,
                 type idxType = boundingBox.idxType,
-                fluff: rank*idxType = makeZero(rank), 
+                fluff: rank*idxType = makeZero(rank, idxType),
                 periodic: bool = false,
                 param ignoreFluff = false) {
   if rank != boundingBox.rank then
@@ -787,7 +787,7 @@ iter StencilDom.these(param tag: iterKind, followThis) where tag == iterKind.fol
     // not checking here whether the new low and high fit into idxType
     var low = (stride * followThis(i).low:strType):idxType;
     var high = (stride * followThis(i).high:strType):idxType;
-    t(i) = ((low..high by stride:strType) + whole.dim(i).low by followThis(i).stride:strType).safeCast(t(i).type);
+    t(i) = ((low..high by stride:strType) + whole.dim(i).alignedLow by followThis(i).stride:strType).safeCast(t(i).type);
   }
   for i in {(...t)} {
     yield i;
@@ -1187,7 +1187,7 @@ iter StencilArr.these(param tag: iterKind, followThis, param fast: bool = false)
     // NOTE: Not bothering to check to see if these can fit into idxType
     var low = followThis(i).low * abs(stride):idxType;
     var high = followThis(i).high * abs(stride):idxType;
-    myFollowThis(i) = ((low..high by stride) + dom.whole.dim(i).low by followThis(i).stride).safeCast(myFollowThis(i).type);
+    myFollowThis(i) = ((low..high by stride) + dom.whole.dim(i).alignedLow by followThis(i).stride).safeCast(myFollowThis(i).type);
     lowIdx(i) = myFollowThis(i).low;
   }
 

--- a/test/distributions/robust/arithmetic/basics/test_domain_align.chpl
+++ b/test/distributions/robust/arithmetic/basics/test_domain_align.chpl
@@ -1,0 +1,53 @@
+use driver_domains;
+
+var x1: Dom1D.type;
+var x2: Dom2D.type;
+
+test(x1);
+test(x2);
+
+proc compare(D, R, a, s=2) {
+  writeln("Testing ", D, "[.. by ", s, " align ", a, "]");
+  const ranges = rangeTuple(D.rank, .. by s align a);
+  const dd = D[(...ranges)];
+  const rr = R[(...ranges)];
+
+  type yieldType = if rr.rank == 1 then rr.idxType else rr.rank*rr.idxType;
+  var tracker : domain(yieldType);
+
+  forall i in rr do tracker.add(i);
+  assert(tracker.size == rr.size);
+
+  {
+    var failures : int;
+    for i in dd do if !tracker.member(i) then failures += 1;
+
+    write("\tserial iter: ");
+    if failures == 0 then writeln("SUCCESS");
+    else writeln(failures, " FAILURES");
+  }
+
+  {
+    var failures : atomic int;
+    forall i in dd do if !tracker.member(i) then failures.add(1);
+
+    const f = failures.read();
+    write("\tleader/follower: ");
+    if f == 0 then writeln("SUCCESS");
+    else writeln(f, " FAILURES");
+  }
+}
+
+proc test(ref D) {
+  D = rangeTuple(D.rank, 1..10);
+  var R : domain(D.rank, D.idxType, D.stridable) = D;
+
+  compare(D, R, 0);
+  compare(D, R, 1);
+}
+
+proc rangeTuple(param rank : int, rng) {
+  var ret : rank*rng.type;
+  for param i in 1..rank do ret(i) = rng;
+  return ret;
+}

--- a/test/distributions/robust/arithmetic/basics/test_domain_align.good
+++ b/test/distributions/robust/arithmetic/basics/test_domain_align.good
@@ -1,0 +1,12 @@
+Testing {1..10}[.. by 2 align 0]
+	serial iter: SUCCESS
+	leader/follower: SUCCESS
+Testing {1..10}[.. by 2 align 1]
+	serial iter: SUCCESS
+	leader/follower: SUCCESS
+Testing {1..10, 1..10}[.. by 2 align 0]
+	serial iter: SUCCESS
+	leader/follower: SUCCESS
+Testing {1..10, 1..10}[.. by 2 align 1]
+	serial iter: SUCCESS
+	leader/follower: SUCCESS

--- a/test/distributions/robust/arithmetic/driver.chpl
+++ b/test/distributions/robust/arithmetic/driver.chpl
@@ -1,6 +1,6 @@
-use BlockDist, CyclicDist, BlockCycDist, ReplicatedDist;
+use BlockDist, CyclicDist, BlockCycDist, ReplicatedDist, StencilDist;
 
-enum DistType { default, block, cyclic, blockcyclic, replicated };
+enum DistType { default, block, cyclic, blockcyclic, replicated, stencil };
 
 config param distType: DistType = if CHPL_COMM=="none" then DistType.default
                                                        else DistType.block;
@@ -62,6 +62,15 @@ proc setupDistributions() {
             new dmap(new Replicated()),
             new dmap(new Replicated()),
             new dmap(new Replicated())
+           );
+  }
+  if distType == DistType.stencil {
+    return (
+            new dmap(new Stencil(rank=1, boundingBox=Space1)),
+            new dmap(new Stencil(rank=2, boundingBox=Space2)),
+            new dmap(new Stencil(rank=3, boundingBox=Space3)),
+            new dmap(new Stencil(rank=4, boundingBox=Space4)),
+            new dmap(new Stencil(rank=2, idxType=int(32), boundingBox=Space2D32))
            );
   }
   halt("unexpected 'distType': ", distType);


### PR DESCRIPTION
Issue #6383 concerned a bug with iteration over an align'd Block-distributed domain. The serial iterator yielded the correct indices, but the parallel iterator seemingly ignored alignment entirely. After adding a new test, it became apparent that other distributions had a similar problem. The general fix is to use ``alignedLow`` instead of ``low``.

I also added a StencilDist option to the distribution robustness suite, but only checked StencilDist with this new test.

Testing:
- [x] full local
- [x] full gasnet
- [x] dist-cyclic
- [x] dist-replicated