### PR TITLE
Temporary workaround for gcc - mpich conflict on cray internal test system

### DIFF
--- a/util/cron/common-whitebox.bash
+++ b/util/cron/common-whitebox.bash
@@ -98,7 +98,18 @@ if [ "${COMPILER}" == "cray" ] ; then
 fi
 
 # Then load the selected compiler
-load_target_compiler ${COMPILER}
+case ${COMPILER} in
+( gnu )
+    # TEMPORARY WORKAROUND for gcc-mpich conflict on cray internal test system 2017-06-07
+    module unload cray-mpich
+    load_target_compiler ${COMPILER}
+    module load cray-mpich
+    ;;
+( * )
+    load_target_compiler ${COMPILER}
+    ;;
+esac
+
 
 # Do minor fixups
 case $COMPILER in


### PR DESCRIPTION
Changes the build script that runs one automated nightly Chapel test series (test-xc-wb, for whitebox).  No effect on Chapel itself. 

It is a temporary workaround for a specific problem on this internal system, so Chapel testing may proceed. 