### PR TITLE
Add a symbolic value for "all sublocales".

### DIFF
--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -80,6 +80,14 @@ module ChapelLocale {
   extern const c_sublocid_none: chpl_sublocID_t;
   pragma "no doc"
   extern const c_sublocid_any: chpl_sublocID_t;
+  pragma "no doc"
+  extern const c_sublocid_all: chpl_sublocID_t;
+
+  pragma "no doc"
+  inline proc chpl_isActualSublocID(subloc: chpl_sublocID_t)
+    return (subloc != c_sublocid_none
+            && subloc != c_sublocid_any
+            && subloc != c_sublocid_all);
 
   /*
     ``locale`` is the abstract class from which the various

--- a/modules/internal/localeModels/knl/LocaleModel.chpl
+++ b/modules/internal/localeModels/knl/LocaleModel.chpl
@@ -513,11 +513,11 @@ module LocaleModel {
     proc localeIDtoLocale(id : chpl_localeID_t) {
       const node = chpl_nodeFromLocaleID(id);
       const subloc = chpl_sublocFromLocaleID(id);
-      if chpl_isActualSublocID(subloc) then
-        return (myLocales[node:int].getChild(subloc:int)):locale;
-      else if (subloc == numaDomainForAny(
-                        (myLocales[node:int]:LocaleModel).numSublocales)) then
+      if subloc == numaDomainForAny(
+                    (myLocales[node:int]:LocaleModel).numSublocales) then
         return ((myLocales[node:int]:LocaleModel).hbm):locale;
+      else if chpl_isActualSublocID(subloc) then
+        return (myLocales[node:int].getChild(subloc:int)):locale;
       else
         return (myLocales[node:int]):locale;
     }

--- a/modules/internal/localeModels/knl/LocaleModel.chpl
+++ b/modules/internal/localeModels/knl/LocaleModel.chpl
@@ -70,19 +70,19 @@ module LocaleModel {
   //
   // e.g. on a 2 NUMA domain system:
   // subloc could be:
-  //   c_sublocid_any == -2 for any NUMA domain
+  //   < 0 (c_sublocid_*) for a symbolic NUMA domain
   //   0 for NUMA domain 0
   //   1 for NUMA domain 1
   // with 2 memory kinds:
   //   0 for DDR
   //   1 for HBM
   //
-  // -2 == packSublocID(2, c_sublocid_any,  0)
-  //  0 == packSublocID(2, 0,  0)
-  //  1 == packSublocID(2, 1,  0)
-  //  2 == packSublocID(2, 0,  1)
-  //  3 == packSublocID(2, 1,  1)
-  //  4 == packSublocID(2, c_sublocid_any,  1)
+  // < 0 == packSublocID(2, c_sublocid_*,  0)
+  //   0 == packSublocID(2, 0,  0)
+  //   1 == packSublocID(2, 1,  0)
+  //   2 == packSublocID(2, 0,  1)
+  //   3 == packSublocID(2, 1,  1)
+  //   4 == packSublocID(2, c_sublocid_any,  1)
   //
 
   private inline proc defaultMemoryKind() param return memoryKindDDR();
@@ -100,8 +100,8 @@ module LocaleModel {
   proc packSublocID(nNumaDomains:int, subloc:int, memoryKind:int)
   {
     var whichNuma = subloc;
-    if whichNuma == c_sublocid_none then
-      return c_sublocid_none;
+    if whichNuma == c_sublocid_none || whichNuma == c_sublocid_all then
+      return whichNuma;
 
     if whichNuma == c_sublocid_any ||
       whichNuma == numaDomainForAny(nNumaDomains) {
@@ -513,13 +513,13 @@ module LocaleModel {
     proc localeIDtoLocale(id : chpl_localeID_t) {
       const node = chpl_nodeFromLocaleID(id);
       const subloc = chpl_sublocFromLocaleID(id);
-      if (subloc == c_sublocid_none) || (subloc == c_sublocid_any) then
-        return (myLocales[node:int]):locale;
+      if chpl_isActualSublocID(subloc) then
+        return (myLocales[node:int].getChild(subloc:int)):locale;
       else if (subloc == numaDomainForAny(
                         (myLocales[node:int]:LocaleModel).numSublocales)) then
         return ((myLocales[node:int]:LocaleModel).hbm):locale;
       else
-        return (myLocales[node:int].getChild(subloc:int)):locale;
+        return (myLocales[node:int]):locale;
     }
 
     proc deinit() {

--- a/modules/internal/localeModels/numa/LocaleModel.chpl
+++ b/modules/internal/localeModels/numa/LocaleModel.chpl
@@ -267,10 +267,10 @@ module LocaleModel {
     proc localeIDtoLocale(id : chpl_localeID_t) {
       const node = chpl_nodeFromLocaleID(id);
       const subloc = chpl_sublocFromLocaleID(id);
-      if (subloc == c_sublocid_none) || (subloc == c_sublocid_any) then
-        return (myLocales[node:int]):locale;
-      else
+      if chpl_isActualSublocID(subloc) then
         return (myLocales[node:int].getChild(subloc:int)):locale;
+      else
+        return (myLocales[node:int]):locale;
     }
 
     proc deinit() {

--- a/runtime/include/chpltypes.h
+++ b/runtime/include/chpltypes.h
@@ -110,12 +110,15 @@ typedef int32_t c_sublocid_t;
 #define FORMAT_c_sublocid_t PRId32
 typedef int64_t c_localeid_t;
 
-// These are special values that mean "no sublocale and "any sublocale".
+// These are special values that mean "no", "any", and "all sublocales",
+// respectively.
 #define c_sublocid_none_val -1
 #define c_sublocid_any_val  -2
+#define c_sublocid_all_val  -3
 
 static const c_sublocid_t c_sublocid_none = c_sublocid_none_val;
 static const c_sublocid_t c_sublocid_any  = c_sublocid_any_val;
+static const c_sublocid_t c_sublocid_all  = c_sublocid_all_val;
 
 static inline int isActualSublocID(c_sublocid_t subloc) {
   return subloc >= 0;

--- a/runtime/include/tasks/qthreads/tasks-qthreads.h
+++ b/runtime/include/tasks/qthreads/tasks-qthreads.h
@@ -193,7 +193,7 @@ void chpl_task_setSubloc(c_sublocid_t full_subloc)
 {
     qthread_shepherd_id_t curr_shep;
 
-    assert(full_subloc != c_sublocid_none);
+    assert(isActualSublocID(full_subloc) || full_subloc == c_sublocid_any);
 
     // Only change sublocales if the caller asked for a particular one,
     // which is not the current one, and we're a (movable) task.

--- a/runtime/src/tasks/fifo/tasks-fifo.c
+++ b/runtime/src/tasks/fifo/tasks-fifo.c
@@ -627,7 +627,7 @@ void chpl_task_addToTaskList(chpl_fn_int_t fid,
   task_pool_p curr_ptask = get_current_ptask();
   bool serial_state = curr_ptask->bundle.serial_state;
 
-  assert(subloc == 0 || subloc == c_sublocid_any);
+  assert(subloc == c_sublocid_any);
 
   if (serial_state) {
     (*chpl_ftable[fid])(arg);

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -900,7 +900,7 @@ void chpl_task_addToTaskList(chpl_fn_int_t       fid,
     chpl_bool serial_state = chpl_task_getSerial();
     chpl_fn_p requested_fn = chpl_ftable[fid];
 
-    assert(full_subloc != c_sublocid_none);
+    assert(isActualSublocID(full_subloc) || full_subloc == c_sublocid_any);
 
     PROFILE_INCR(profile_task_addToTaskList,1);
 


### PR DESCRIPTION
We've long had symbolic values for "no sublocale" and "any sublocale",
in both the module and runtime code.  Here add a symbolic value for "all
sublocales", wanted for some upcoming work in memory localization.

While here, I also modified a tasks=fifo `assert()` that would have let a
caller pass `sublocale==0` to `chpl_task_addToTaskList()`; that should not
occur.