### PR TITLE
Enable testing LCALS in correctness testing

### DIFF
--- a/test/release/examples/benchmarks/lcals/LCALSEnums.chpl
+++ b/test/release/examples/benchmarks/lcals/LCALSEnums.chpl
@@ -92,4 +92,9 @@ module LCALSEnums {
     NUM_WEIGHT_GROUPS
   }
 
+  enum OutputStyle {
+    MINIMAL,   // no timing/checksum output
+    REFERENCE, // output matching the reference code
+    PERF_TEST  // output formatted for perf testing
+  }
 }

--- a/test/release/examples/benchmarks/lcals/LCALSMain.chpl
+++ b/test/release/examples/benchmarks/lcals/LCALSMain.chpl
@@ -131,7 +131,8 @@ module main {
 
     const cache_size = 0;
     const host_name = here.name;
-    writeln("\n Running loop suite on ", host_name);
+    if outputFormat != 0 then
+      writeln("\n Running loop suite on ", host_name);
 
     allocateLoopSuiteRunInfo(host_name,
                              num_suite_passes,
@@ -160,12 +161,24 @@ module main {
     }
 
     writeln("\n generate reports....");
-    if !perfTesting {
-      generateTimingReport(run_variants, output_dirname);
-      generateChecksumReport(run_variants, output_dirname);
-      generateFOMReport(run_variants, output_dirname);
-    } else {
-      generatePerfTimingReport(run_variants);
+
+    select outputFormat {
+      when 0 {
+        // no timing or checksum output
+      }
+      when 1 {
+        // match what the reference code does
+        generateTimingReport(run_variants, output_dirname);
+        generateChecksumReport(run_variants, output_dirname);
+        generateFOMReport(run_variants, output_dirname);
+      }
+      when 2 {
+        //
+        generatePerfTimingReport(run_variants);
+      }
+      otherwise {
+        writeln("Unexpected output format: ", outputFormat);
+      }
     }
 
     checkChecksums(run_variants, run_loop, run_loop_length);

--- a/test/release/examples/benchmarks/lcals/LCALSMain.chpl
+++ b/test/release/examples/benchmarks/lcals/LCALSMain.chpl
@@ -131,7 +131,7 @@ module main {
 
     const cache_size = 0;
     const host_name = here.name;
-    if outputFormat != 0 then
+    if outputFormat != OutputStyle.MINIMAL then
       writeln("\n Running loop suite on ", host_name);
 
     allocateLoopSuiteRunInfo(host_name,
@@ -163,17 +163,17 @@ module main {
     writeln("\n generate reports....");
 
     select outputFormat {
-      when 0 {
+      when OutputStyle.MINIMAL {
         // no timing or checksum output
       }
-      when 1 {
+      when OutputStyle.REFERENCE {
         // match what the reference code does
         generateTimingReport(run_variants, output_dirname);
         generateChecksumReport(run_variants, output_dirname);
         generateFOMReport(run_variants, output_dirname);
       }
-      when 2 {
-        //
+      when OutputStyle.PERF_TEST {
+        // format times for nightly perf testing
         generatePerfTimingReport(run_variants);
       }
       otherwise {

--- a/test/release/examples/benchmarks/lcals/LCALSMain.compopts
+++ b/test/release/examples/benchmarks/lcals/LCALSMain.compopts
@@ -1,0 +1,3 @@
+# This code takes too much time with bounds checks enabled. Don't print timing
+# or checksum output, or else we'd have to filter it out in testing
+--no-bounds-checks -soutputFormat=0

--- a/test/release/examples/benchmarks/lcals/LCALSMain.compopts
+++ b/test/release/examples/benchmarks/lcals/LCALSMain.compopts
@@ -1,3 +1,3 @@
 # This code takes too much time with bounds checks enabled. Don't print timing
 # or checksum output, or else we'd have to filter it out in testing
---no-bounds-checks -soutputFormat=0
+--no-bounds-checks -soutputFormat=OutputStyle.MINIMAL

--- a/test/release/examples/benchmarks/lcals/LCALSMain.execopts
+++ b/test/release/examples/benchmarks/lcals/LCALSMain.execopts
@@ -1,0 +1,1 @@
+--run_shortLoops=false --run_mediumLoops=false

--- a/test/release/examples/benchmarks/lcals/LCALSMain.good
+++ b/test/release/examples/benchmarks/lcals/LCALSMain.good
@@ -1,0 +1,16 @@
+
+ allocateLoopSuiteRunInfo...
+
+ defineLoopSuiteRunInfo...
+
+ allocateLoopData...
+
+ run suite: pass = 0
+	 run loop variant ---> RAW
+	 run loop variant ---> RAW_OMP
+
+ generate reports....
+
+ freeLoopSuiteRunInfo...
+
+ DONE!!! 

--- a/test/release/examples/benchmarks/lcals/LCALSMain.perfcompopts
+++ b/test/release/examples/benchmarks/lcals/LCALSMain.perfcompopts
@@ -1,1 +1,1 @@
--soutputFormat=2 --no-ieee-float
+-soutputFormat=OutputStyle.PERF_TEST --no-ieee-float

--- a/test/release/examples/benchmarks/lcals/LCALSMain.perfcompopts
+++ b/test/release/examples/benchmarks/lcals/LCALSMain.perfcompopts
@@ -1,1 +1,1 @@
--sperfTesting=true --no-ieee-float
+-soutputFormat=2 --no-ieee-float

--- a/test/release/examples/benchmarks/lcals/LCALSMain.skipif
+++ b/test/release/examples/benchmarks/lcals/LCALSMain.skipif
@@ -1,7 +1,5 @@
-# This test takes too long if --fast is not used so only run it for
-# performance testing.  It takes to long for no-local configurations,
-# so skip it for comm != none and --no-local too.
-CHPL_TEST_PERF != on
+# This test takes to long for no-local configurations, so skip it for
+# comm != none and --no-local.
 CHPL_COMM != none
 COMPOPTS <= --no-local
 

--- a/test/release/examples/benchmarks/lcals/LCALSParams.chpl
+++ b/test/release/examples/benchmarks/lcals/LCALSParams.chpl
@@ -1,10 +1,9 @@
 module LCALSParams {
+  use LCALSEnums;
+
   config param realSize = 64;
 
-  // outputFormat == 0 -> no timing/checksum output
-  // outputFormat == 1 -> output matching the reference code
-  // outputFormat == 2 -> output formatted for perf testing
-  config param outputFormat = 1;
+  config param outputFormat: OutputStyle = OutputStyle.REFERENCE;
   type Real_type = real(realSize);
   type Complex_type = complex(2*realSize);
 

--- a/test/release/examples/benchmarks/lcals/LCALSParams.chpl
+++ b/test/release/examples/benchmarks/lcals/LCALSParams.chpl
@@ -1,6 +1,10 @@
 module LCALSParams {
   config param realSize = 64;
-  config param perfTesting = false;
+
+  // outputFormat == 0 -> no timing/checksum output
+  // outputFormat == 1 -> output matching the reference code
+  // outputFormat == 2 -> output formatted for perf testing
+  config param outputFormat = 1;
   type Real_type = real(realSize);
   type Complex_type = complex(2*realSize);
 

--- a/test/release/examples/benchmarks/lcals/RunCRawLoops.chpl
+++ b/test/release/examples/benchmarks/lcals/RunCRawLoops.chpl
@@ -329,6 +329,8 @@ module RunCRawLoops {
                 xx[k] = 0.0;
                 ix[k] = grd[k]:int;
                 xi[k] = ix[k]:real;
+                // ix[k] == 0, so the accesses of ex[ix[k]-1] and dex[ix[k]-1]
+                // are out of bounds. This also happens in the reference version.
                 ex1[k] = ex[ix[k]-1];
                 dex1[k] = dex[ix[k]-1];
               }


### PR DESCRIPTION
LCALS has only been getting tested for performance testing because with bounds
checks it takes way to long to run. Add a .compopts file with
'--no-bounds-checks' to enable it to run in regular correctness testing.

Modified/added the test config files to run the large loop size for the RAW and
RAW_OMP variants for correctness.

Modified a config param to allow selecting between three output formats:
* MINIMAL: Don't print timing/checksum dumps
* REFERENCE: Like the reference code
* PERF_TEST: Formatted nicely for perf testing

I tried running with bounds checking, and hit an out of bounds error at around
the 40 minute mark. Looking into this, I found that the reference version also
accesses the array out of bounds with index -1.  I added a comment mentioning
this where it happens.

Tested on linux64 and OSX with correctness and performance testing modes.