### PR TITLE
Optimize updateFluff

### DIFF
--- a/modules/dists/StencilDist.chpl
+++ b/modules/dists/StencilDist.chpl
@@ -32,12 +32,6 @@
 // mapped to by the distribution.
 //
 
-//
-// TO DO List
-//
-// 1. refactor pid fields from distribution, domain, and array classes
-//
-
 use BlockDist;
 use DSIUtil;
 use ChapelUtil;
@@ -306,6 +300,9 @@ class StencilDom: BaseRectangularDom {
 // stridable: generic domain stridable parameter
 // myBlock: a non-distributed domain that defines the local indices
 //
+// NeighDom will be a rectangular domain where each dimension is the range
+// -1..1
+//
 class LocStencilDom {
   param rank: int;
   type idxType;
@@ -365,6 +362,7 @@ class LocStencilArr {
   var locRADLock: atomicbool; // This will only be accessed locally
                               // force the use of processor atomics
 
+  // TODO: use void type when packed update is disabled
   var recvBufs, sendBufs : [locDom.NeighDom] [locDom.bufDom] eltType;
   var sendRecvFlag : [locDom.NeighDom] atomic bool;
 
@@ -1015,7 +1013,7 @@ proc StencilDom.setup() {
         forall (recvS, recvD, sendS, sendD, N, L) in zip(myLocDom.recvSrc, myLocDom.recvDest,
                                                          myLocDom.sendSrc, myLocDom.sendDest,
                                                          myLocDom.Neighs, ND) {
-          if !zeruTuple(L) && recvS.size != 0 {
+          if !zeroTuple(L) && recvS.size != 0 {
             var other = -1 * L;
 
             proc checker(me, myDom, them, themDom) {

--- a/modules/dists/StencilDist.chpl
+++ b/modules/dists/StencilDist.chpl
@@ -54,6 +54,18 @@ use CommDiagnostics;
 config param debugStencilDist = false;
 config param debugStencilDistBulkTransfer = false;
 
+// TODO: part of constructor?
+config param stencilDistAllowPackedUpdateFluff = true;
+
+// Instructs the _packedUpdate method to only perform the optimized buffer
+// packing if the number of GETs/PUTs would be greater than or equal to the
+// value in this config const.
+//
+// Currently disabled until we can find a way to determine a good value.
+//
+// TODO: find better heuristic through experimentation
+config const stencilDistPackedUpdateMinChunks = 1;
+
 // Re-uses these flags from BlockDist:
 //   - disableAliasedBulkTransfer
 //   - sanityCheckDistribution
@@ -300,7 +312,9 @@ class LocStencilDom {
   param stridable: bool;
   var myBlock, myFluff: domain(rank, idxType, stridable);
   var NeighDom: domain(rank);
-  var Dest, Src: [NeighDom] domain(rank, idxType, stridable);
+  var bufDom : domain(1);
+  var recvDest, recvSrc,
+      sendDest, sendSrc: [NeighDom] domain(rank, idxType, stridable);
   var Neighs: [NeighDom] rank*int;
 }
 
@@ -351,6 +365,9 @@ class LocStencilArr {
   var locRADLock: atomicbool; // This will only be accessed locally
                               // force the use of processor atomics
 
+  var recvBufs, sendBufs : [locDom.NeighDom] [locDom.bufDom] eltType;
+  var sendRecvFlag : [locDom.NeighDom] atomic bool;
+
   // These functions will always be called on this.locale, and so we do
   // not have an on statement around the while loop below (to avoid
   // the repeated on's from calling testAndSet()).
@@ -389,7 +406,7 @@ proc Stencil.Stencil(boundingBox: domain,
   this.fluff = fluff;
 
   // can't have periodic if there's no fluff
-  this.periodic = periodic && !zeroTuple(fluff);
+  this.periodic = periodic && !isZeroTuple(fluff);
 
   setupTargetLocalesArray(targetLocDom, this.targetLocales, targetLocales);
 
@@ -872,7 +889,7 @@ proc StencilDom.dsiLocalSlice(param stridable: bool, ranges) {
 }
 
 proc StencilDom.setup() {
-  coforall localeIdx in dist.targetLocDom do {
+  coforall localeIdx in dist.targetLocDom {
     on dist.targetLocales(localeIdx) {
       ref myLocDom = locDoms(localeIdx);
 
@@ -888,69 +905,126 @@ proc StencilDom.setup() {
 
       if myLocDom == nil {
         myLocDom = new LocStencilDom(rank, idxType, stridable,
-                                             dist.getChunk(whole, localeIdx), NeighDom=ND);
+                                     dist.getChunk(whole, localeIdx),
+                                     NeighDom=ND);
       } else {
         myLocDom.myBlock = dist.getChunk(whole, localeIdx);
       }
 
-      if !zeroTuple(fluff) && myLocDom.myBlock.numIndices!=0 then {
+      if !isZeroTuple(fluff) && myLocDom.myBlock.numIndices != 0 then {
         myLocDom.myFluff = myLocDom.myBlock.expand(fluff*abstr);
-      }
-      else {
+      } else {
         myLocDom.myFluff = myLocDom.myBlock;
       }
 
-      if !zeroTuple(fluff) && myLocDom.myBlock.size > 0 {
+      if !isZeroTuple(fluff) && myLocDom.myBlock.size > 0 {
         //
         // Recompute Src and Dest domains, later used to update fluff regions
         //
-        for (S, D, off) in zip(myLocDom.Src, myLocDom.Dest, ND) {
-          const to = if isTuple(off) then off else (off,);
-          var dr : rank*whole.dim(1).type;
-          for i in 1..rank {
-            const fa = fluff(i) * abstr(i);
-            const cur = myLocDom.myBlock.dim(i);
-            if to(i) < 0 then
-              dr(i) = cur.first - fa .. cur.first-abstr(i);
-            else if to(i) > 0 then
-              dr(i) = cur.last+abstr(i)..cur.last+fa;
-            else
-              dr(i) = cur.first..cur.last;
-            if stridable then
-              dr(i) = dr(i) by cur.stride;
-          }
-          D = {(...dr)};
-          assert(wholeFluff.member(D.first) && wholeFluff.member(D.last), "StencilDist: Error computing destination slice.");
-          if periodic then S = D;
-        }
+        const blockDims = myLocDom.myBlock.dims();
+        var bufLen = 1;
+        forall (recvS, recvD, sendS, sendD, N, L) in zip(myLocDom.recvSrc, myLocDom.recvDest,
+                                                         myLocDom.sendSrc, myLocDom.sendDest,
+                                                         myLocDom.Neighs, ND)
+          with ( max reduce bufLen) {
 
-        for (N, L) in zip(myLocDom.Neighs, ND) {
-          if zeroTuple(L) then continue;
-          if rank == 1 then
-            N(1) = localeIdx + L;
-          else
-            N = localeIdx + L;
-        }
-
-        if periodic {
-          for (S, D, N, L) in zip(myLocDom.Src, myLocDom.Dest, myLocDom.Neighs, ND) {
-            if zeroTuple(L) then continue; // Skip center
-
-            var offset : rank*idxType;
+          // if L is a tuple of zeroes then we are in the center, which needs
+          // no updating.
+          if !isZeroTuple(L) {
+            const to = chpl__tuplify(L);
+            var dr : rank*whole.dim(1).type;
             for i in 1..rank {
-              if S.dim(i).low > whole.dim(i).high then
-                offset(i) = -whole.dim(i).size * abstr(i);
-              else if S.dim(i).high < whole.dim(i).low then
-                offset(i) = whole.dim(i).size * abstr(i);
+              const fa = fluff(i) * abstr(i);
+              const cur = blockDims(i);
+
+              // TODO: simplify?
+              if to(i) < 0 then
+                dr(i) = cur.first - fa .. cur.first-abstr(i);
+              else if to(i) > 0 then
+                dr(i) = cur.last+abstr(i)..cur.last+fa;
+              else
+                dr(i) = cur.first..cur.last;
+
+              if stridable then
+                dr(i) = dr(i) by cur.stride;
             }
 
-            S = S.translate(offset);
-            if rank == 1 then
-              N(1) = dist.targetLocsIdx(S.first);
-            else
-              N = dist.targetLocsIdx(S.first);
-            assert(whole.member(S.first) && whole.member(S.last), "StencilDist: Failure to compute Src slice.");
-            assert(dist.targetLocDom.member(N), "StencilDist: Error computing neighbor index.");
+            // destination indices in the fluff region
+            recvD = {(...dr)};
+            assert(wholeFluff.member(recvD.first) && wholeFluff.member(recvD.last), "StencilDist: Error computing destination slice.");
+
+            if whole.member(recvD.first) && whole.member(recvD.last) {
+              // sending to an adjacent locale
+              recvS = recvD;
+              N = chpl__tuplify(dist.targetLocsIdx(recvS.first));
+            } else if periodic {
+              // sending to a non-adjacent locale
+              var offset : rank*idxType;
+              for i in 1..rank {
+                const wd = whole.dim(i);
+                const rd = recvD.dim(i);
+                const mult = if rd.low > wd.high then -1
+                             else if rd.high < wd.low then 1
+                             else 0;
+                offset(i) = mult * wd.size * abstr(i);
+              }
+              recvS = recvD.translate(offset);
+              N = chpl__tuplify(dist.targetLocsIdx(recvS.first));
+
+              assert(whole.member(recvS.first) && whole.member(recvS.last), "StencilDist: Failure to compute Src slice.");
+              assert(dist.targetLocDom.member(N), "StencilDist: Error computing neighbor index.");
+            } else {
+              // No communication needed in this direction
+              assert(recvS.size == 0);
+              N = chpl__tuplify(localeIdx);
+
+              // zero out recvD so we can test its size later to determine if
+              // communication needs to happen
+              recvD = recvS;
+            }
+
+            if recvS.size != 0 {
+              const offset = -1 * L * fluff * abstr;
+              sendS = recvD.translate(offset);
+              sendD = recvS.translate(offset);
+            }
+
+            bufLen = max(bufLen, recvD.size, recvS.size);
+
+            if recvS.size != 0 && debugStencilDist {
+              writeln("L = ", L, ": ");
+              writeln("RECV: ", here, ".", recvD, " = ", dist.targetLocales[N], ".", recvS);
+              writeln("SEND: ", here, ".", sendS, " = ", dist.targetLocales[N], ".", sendD);
+            }
+          }
+        }
+        myLocDom.bufDom = {1..bufLen};
+      }
+    }
+  }
+
+  // Validate the compute send/recv src/dest domains
+  if debugStencilDist {
+    coforall localeIdx in dist.targetLocDom {
+      on dist.targetLocales(localeIdx) {
+        var nearest : rank*range;
+        for param i in 1..rank do nearest(i) = -1..1;
+        const ND : domain(rank) = nearest;
+        ref myLocDom = locDoms(localeIdx);
+
+        forall (recvS, recvD, sendS, sendD, N, L) in zip(myLocDom.recvSrc, myLocDom.recvDest,
+                                                         myLocDom.sendSrc, myLocDom.sendDest,
+                                                         myLocDom.Neighs, ND) {
+          if !zeruTuple(L) && recvS.size != 0 {
+            var other = -1 * L;
+
+            proc checker(me, myDom, them, themDom) {
+              writeln(dist.targetLocales(me), ".", myDom, " == ", dist.targetLocales(them), ".", themDom);
+              assert(myDom == themDom, "StencilDist Error: failure to match recv and send domains.");
+            }
+
+            checker(localeIdx, recvS, N, locDoms[N].sendSrc[other]);
+            checker(localeIdx, recvD, N, locDoms[N].sendDest[other]);
           }
         }
       }
@@ -1013,9 +1087,7 @@ proc StencilArr.setupRADOpt() {
 }
 
 proc StencilArr.setup() {
-  var thisid = this.locale.id;
-  var nearest : rank*range;
-  for param i in 1..nearest.size do nearest(i) = -1..1;
+  const thisid = this.locale.id;
   coforall localeIdx in dom.dist.targetLocDom {
     on dom.dist.targetLocales(localeIdx) {
       const locDom = dom.getLocDom(localeIdx);
@@ -1299,14 +1371,14 @@ proc _extendTuple(type t, idx, args) {
   return tup;
 }
 
-private inline proc zeroTuple(t) {
+private inline proc isZeroTuple(t) {
   if isTuple(t) {
     for param i in 1..t.size do
       if t(i) != 0 then return false;
   } else if isIntegral(t) {
     return t == 0;
   }
-  else compilerError("Incorrect usage of 'zeroTuple' utility function.");
+  else compilerError("Incorrect usage of 'isZeroTuple' utility function.");
   return true;
 }
 
@@ -1322,7 +1394,7 @@ iter StencilArr.dsiBoundaries() {
   for i in dom.dist.targetLocDom {
     var LSA = locArr[i];
     ref myLocDom = LSA.locDom;
-    for (D, N, L) in zip(myLocDom.Dest, myLocDom.Neighs, myLocDom.NeighDom) {
+    for (D, N, L) in zip(myLocDom.recvDest, myLocDom.Neighs, myLocDom.NeighDom) {
       const target = i + L;
       const low = dom.dist.targetLocDom.low;
       const high = dom.dist.targetLocDom.high;
@@ -1354,7 +1426,7 @@ iter StencilArr.dsiBoundaries(param tag : iterKind) where tag == iterKind.standa
     on dom.dist.targetLocales(i) {
       var LSA = locArr[i];
       ref myLocDom = LSA.locDom;
-      forall (D, N, L) in zip(myLocDom.Dest, myLocDom.Neighs, myLocDom.NeighDom) {
+      forall (D, N, L) in zip(myLocDom.recvDest, myLocDom.Neighs, myLocDom.NeighDom) {
         const target = i + L;
         const low = dom.dist.targetLocDom.low;
         const high = dom.dist.targetLocDom.high;
@@ -1436,22 +1508,141 @@ proc _array.updateFluff() {
   _value.dsiUpdateFluff();
 }
 
-// copy over into cache
-proc StencilArr.dsiUpdateFluff() {
-  if zeroTuple(dom.fluff) then return;
+//
+// On each locale, update the local cache by fetching data from neighbors.
+//
+proc StencilArr.naiveUpdateFluff() {
   coforall i in dom.dist.targetLocDom {
     on dom.dist.targetLocales(i) {
       ref myLocDom = locArr[i].locDom;
-      forall (S, D, N, L) in zip(myLocDom.Src, myLocDom.Dest,
+      forall (S, D, N, L) in zip(myLocDom.recvSrc, myLocDom.recvDest,
           myLocDom.Neighs, myLocDom.NeighDom) {
-        if !zeroTuple(L) {
-          if !dom.dist.targetLocDom.member(i+L) && dom.periodic then
-            locArr[i].myElems[D] = locArr[N].myElems[S];
-          else if dom.dist.targetLocDom.member(N) then
-            locArr[i].myElems[D] = locArr[N].myElems[D];
+        // A source domain of size zero indicates that no communication
+        // is necessary.
+        //
+        // if "L" is zero, that indicates we are at the center of the stencil
+        // and do not need to update
+        if !isZeroTuple(L) && S.size != 0 {
+          locArr[i].myElems[D] = locArr[N].myElems[S];
         }
       }
     }
+  }
+}
+
+//
+// TODO: GET or PUT the data? Does it matter for performance?
+//
+// TODO: should we avoid doing the packed transfer for dense-ish regions?
+// e.g. {1..5, 1..100} might only require 5 GETs/PUTs
+//
+// This is an optimized variant of the naiveUpdateFluff method. This variant
+// packs elements into a buffer such that we only do one GET/PUT. This is
+// most beneficial when the communicated region would require many GETs in
+// the naive approach. For example, Let's say we have a 10x10 domain with
+// a fluff of (1,1). Our wholeFluff domain would be {0..11, 0..11}. When we go
+// to communicate the region {1..10,1..1}, the naive method requires 10 GETs or
+// PUTs, whereas the packed method requires just one.
+//
+// On each locale:
+// 1) Repeat the following for each region of data that other locales will
+//    want:
+//    to fetch:
+//    a) Serialize/pack the region of data into a 1D buffer array. This is the
+//       buffer that other locales will read from.
+//    b) Write 'true' to an atomic flag on the local that intends to read from
+//       the buffer that was just populated.
+// 2) Once we have prepared our local data for reading, repeat the following
+//    for each region of data that *our* cache wants to update:
+//    a) Wait for the corresponding atomic flag to be 'true' so that we know
+//       it is safe to fetch the data from the remote locale. Reset the flag to
+//       false afterwards.
+//    b) Bulk-copy the remote buffer into a local buffer
+//    c) Copy elements from the local buffer into the cache
+//
+proc StencilArr._packedUpdate() {
+  coforall i in dom.dist.targetLocDom {
+    on dom.dist.targetLocales(i) {
+      var myLocDom = locArr[i].locDom;
+
+      proc translateIdx(idx) {
+        return -1 * chpl__tuplify(idx);
+      }
+
+      // BHARSH TODO: can we fuse these two foralls? My current concern is that
+      // by waiting we might prevent another iteration running and possibly
+      // find ourselves in a deadlock.
+      forall (D, S, recvIdx, sendBufIdx) in zip(myLocDom.sendDest, myLocDom.sendSrc,
+                                                myLocDom.Neighs,
+                                                myLocDom.NeighDom) {
+        // If S.size == 0, no communication is required
+        if S.size != 0 {
+          const chunkSize  = max(1, S.dim(rank).length); // avoid divide by zero
+          const numChunks = S.size / chunkSize;
+          if numChunks >= stencilDistPackedUpdateMinChunks {
+            const recvBufIdx = translateIdx(sendBufIdx);
+
+            // Pack the buffer
+            //
+            // TODO: Should we have a serialization helper for N-dimensional
+            // DefaultRectangulars into 1-dimension arrays?
+            ref src = locArr[i].myElems[S];
+            ref buf = locArr[i].sendBufs[sendBufIdx];
+            local for (s, i) in zip(src, buf.domain.first..#src.size) do buf[i] = s;
+
+            if debugStencilDist then
+              writeln("Filled ", here, ".", S, " for ", dom.dist.targetLocales(recvIdx), "::", recvBufIdx);
+            locArr[recvIdx].sendRecvFlag[recvBufIdx].write(true);
+          } else {
+            // 'naive' update
+            locArr[recvIdx].myElems[D] = locArr[i].myElems[S];
+          }
+        }
+      }
+      forall (D, S, srcIdx, recvBufIdx) in zip(myLocDom.recvDest, myLocDom.recvSrc,
+                                               myLocDom.Neighs,
+                                               myLocDom.NeighDom) {
+        const chunkSize  = max(1, S.dim(rank).length); // avoid divide by zero
+        const numChunks = S.size / chunkSize;
+
+        // If we did a naive update in the previous loop, this iteration does
+        // not need to do anything.
+        if S.size != 0 && numChunks >= stencilDistPackedUpdateMinChunks {
+          const srcBufIdx = translateIdx(recvBufIdx);
+          if debugStencilDist then
+            writeln(here, "::", recvBufIdx, " WAITING");
+          locArr[i].sendRecvFlag[recvBufIdx].waitFor(true); // Can we read yet?
+          locArr[i].sendRecvFlag[recvBufIdx].write(false);  // reset for next call
+
+          locArr[i].recvBufs[recvBufIdx][1..D.size] = locArr[srcIdx].sendBufs[srcBufIdx][1..D.size];
+
+          ref dest = locArr[i].myElems[D];
+          ref buf = locArr[i].recvBufs[recvBufIdx];
+          local for (d, i) in zip(dest, buf.domain.first..#dest.size) do d = buf[i];
+        }
+      }
+    }
+  }
+}
+
+proc StencilArr.shouldDoPackedUpdate() param : bool {
+  return stencilDistAllowPackedUpdateFluff &&
+         chpl__supportedDataTypeForBulkTransfer(eltType);
+}
+
+// Update caches
+//
+// TODO: allow a bool argument here?
+//
+// TODO: allow for some kind of user-defined packing/unpacking for complicated
+// types?
+proc StencilArr.dsiUpdateFluff() {
+  if isZeroTuple(dom.fluff) then return;
+
+  if shouldDoPackedUpdate() {
+    this._packedUpdate();
+  } else {
+    this.naiveUpdateFluff();
   }
 }
 
@@ -1469,8 +1660,8 @@ proc StencilArr.dsiReallocate(d: domain) {
   //
 }
 
+// Call this *after* the domain has been reallocated
 proc StencilArr.dsiPostReallocate() {
-  // Call this *after* the domain has been reallocated
   if doRADOpt then setupRADOpt();
 }
 

--- a/modules/dists/StencilDist.chpl
+++ b/modules/dists/StencilDist.chpl
@@ -1509,6 +1509,14 @@ proc _array.updateFluff() {
 //
 // On each locale, update the local cache by fetching data from neighbors.
 //
+// TODO: What's the best way to deal with the repeated `locArr[i]` expressions?
+// Note that this is actually `this.locArr[i]`, where 'this' is on the locale
+// where the coforall-on starts. What we really want is something like this:
+//
+// const curLocArr = chpl_getPrivatizedCopy(this.type, this.pid).locArr[i];
+//
+// Ideally the compiler could do something like this for us...
+//
 proc StencilArr.naiveUpdateFluff() {
   coforall i in dom.dist.targetLocDom {
     on dom.dist.targetLocales(i) {
@@ -1544,8 +1552,7 @@ proc StencilArr.naiveUpdateFluff() {
 //
 // On each locale:
 // 1) Repeat the following for each region of data that other locales will
-//    want:
-//    to fetch:
+//    want to fetch:
 //    a) Serialize/pack the region of data into a 1D buffer array. This is the
 //       buffer that other locales will read from.
 //    b) Write 'true' to an atomic flag on the local that intends to read from

--- a/test/distributions/bharshbarg/stencil/periodic.compopts
+++ b/test/distributions/bharshbarg/stencil/periodic.compopts
@@ -1,0 +1,3 @@
+-sstencilDistAllowPackedUpdateFluff=false
+-sstencilDistAllowPackedUpdateFluff=true
+-sstencilDistAllowPackedUpdateFluff=true -sstencilDistPackedUpdateMinChunks=10

--- a/test/distributions/bharshbarg/stencil/rankChange.chpl
+++ b/test/distributions/bharshbarg/stencil/rankChange.chpl
@@ -1,6 +1,6 @@
 use StencilDist;
 
-config const n = 5;
+config const n = 10;
 
 proc main() {
   var Dom = {1..n,1..n};


### PR DESCRIPTION
The original updateFluff implementation might end up using many GETs or
PUTs for noncontiguous chunks of memory. This commit implements a
variant of updateFluff that packs the elements into a buffer to be used
in a single GET or PUT, and is unpacked on the destination locale. This
optimization will fire if the element types can be bulk-transferred.

To implement this change, the StencilDom.setup() method was modified
such that each locale now knows how to send its own indices or how to
fetch indices. This information is stored arrays of domains which are
used in the optimized updateFluff method.

This optimized variant can be disabled with the new config param:
  stencilDistAllowPackedUpdateFluff

This optimization was motivated by the Stencil PRK when we observed that
our updateFluff stage was performing significantly worse than the
reference's corresponding stage. This commit improves our performance
depending on the comm layer used. In gasnet-mpi, we see a 10x
improvement. In ugni-qthreads, a 3x improvement.

Minor style cleanups were made while working on this change.

Testing:
- [x] full local
- [x] full gasnet
- [x] miniMD performance not impacted (as expected)
- [x] numa testing for distributions/bharshbarg/stencil/