### PR TITLE
Fix ignored attributes error in Qthreads header

### DIFF
--- a/third-party/qthread/qthread-src/include/qthread/qthread.hpp
+++ b/third-party/qthread/qthread-src/include/qthread/qthread.hpp
@@ -14,7 +14,11 @@
 template <bool> class OnlyTrue;
 template <> class OnlyTrue<true>
 {};
+#if __cplusplus >= 201103
+#define QTHREAD_STATIC_ASSERT(X) static_assert(X, #X)
+#else
 #define QTHREAD_STATIC_ASSERT(X) (void)sizeof(OnlyTrue<(bool)(X)>)
+#endif
 #define QTHREAD_CHECKSIZE(X)     QTHREAD_STATIC_ASSERT(sizeof(X) == sizeof(aligned_t))
 
 #define QTHREAD_CHECKINTEGER(X)  QTHREAD_STATIC_ASSERT(std::numeric_limits<X>::is_integer)

--- a/third-party/qthread/qthread-src/include/qthread/qthread.hpp
+++ b/third-party/qthread/qthread-src/include/qthread/qthread.hpp
@@ -15,7 +15,7 @@ template <bool> class OnlyTrue;
 template <> class OnlyTrue<true>
 {};
 #if __cplusplus >= 201103
-#define QTHREAD_STATIC_ASSERT(X) static_assert(X, #X)
+#define QTHREAD_STATIC_ASSERT(X) static_assert((X), #X)
 #else
 #define QTHREAD_STATIC_ASSERT(X) (void)sizeof(OnlyTrue<(bool)(X)>)
 #endif


### PR DESCRIPTION
This change fixes issue #6230 by fixing an error in a Qthreads header.

This tested change is being pushed immediately to fix nightly testing, but post-commit review is requested from @ronawho and @gbtitus .  This change or something like it will need to be contributed back to the Qthreads folks.

BACKGROUND:
The problem with the `assert()` macro is that it is executable, so it can only appear inside functions and operate at run time.  C11 and C\+\+11 added a `static_assert()` expression that can appear almost anywhere and takes effect at compile time.

Qthreads wanted to use `static_assert()` in their C\+\+ code, but also wanted to be compatible with earlier versions of the language.  Therefore, they invented their own macro, `QTHREAD_STATIC_ASSERT()` which was cleverly implemented to work in a similar way.  Unfortunately, their implementation provokes a warning from the C\+\+14 checking done by gcc 7.1, and our use of \-Werror turns this warning into an error during the nightly tests, as well as when CHPL_DEVELOPER=true.

The warning is only a problem with very recent compilers, so the fix only has to apply to recent compilers.  The fix presented here uses the real `static_assert()` whenever C\+\+11 or later is being used, thus avoiding the warning that we turn into an error.

Also see issue #6230 for additional detail.