### PR TITLE
Fix references to PRK .graph files

### DIFF
--- a/test/GRAPHFILES
+++ b/test/GRAPHFILES
@@ -80,7 +80,7 @@ performance/bharshbarg/forall-dom-range.graph
 performance/bharshbarg/arr-forall.graph
 performance/bharshbarg/views-forall-index.graph
 performance/bharshbarg/views-forall-iter.graph
-studies/prk/stencil/prk-stencil-time.graph
+studies/prk/Stencil/prk-stencil-time.graph
 types/string/ferguson/temporary-copies.graph
 types/string/psahabu/perf/arguments.graph
 types/string/psahabu/perf/search.graph
@@ -167,12 +167,12 @@ studies/isx/isx-no-return.graph
 studies/isx/isx-per-task.graph
 release/examples/benchmarks/isx/isx-release.graph
 # suite: PRK benchmarks
-studies/prk/synch_p2p/prk-synch_p2p.graph
-studies/prk/synch_p2p/prk-synch_p2p-time.graph
-studies/prk/stencil/prk-stencil.graph
-studies/prk/stencil/prk-stencil-time.graph
-studies/prk/transpose/prk-transpose.graph
-studies/prk/transpose/prk-transpose-time.graph
+studies/prk/Synch_p2p/prk-synch_p2p.graph
+studies/prk/Synch_p2p/prk-synch_p2p-time.graph
+studies/prk/Stencil/prk-stencil.graph
+studies/prk/Stencil/prk-stencil-time.graph
+studies/prk/Transpose/prk-transpose.graph
+studies/prk/Transpose/prk-transpose-time.graph
 # suite: NAS Parallel benchmarks
 npb/cg/cg.graph
 npb/cg/cg-a.graph

--- a/test/ML-GRAPHFILES
+++ b/test/ML-GRAPHFILES
@@ -10,7 +10,7 @@ release/examples/benchmarks/hpcc/ra.ml-perf.graph
 release/examples/benchmarks/hpcc/stream-ep.ml-perf.graph
 release/examples/benchmarks/hpcc/stream.ml-perf.graph
 release/examples/benchmarks/hpcc/variants/stream-promoted.ml-perf.graph
-studies/prk/stencil/prk-stencil.ml-perf.graph
+studies/prk/Stencil/prk-stencil.ml-perf.graph
 release/examples/benchmarks/ssca2/SSCA2_main.ml-time.graph
 studies/lulesh/bradc/lulesh-dense.ml-time.graph
 release/examples/benchmarks/miniMD/miniMD.ml-time.graph
@@ -29,7 +29,7 @@ release/examples/benchmarks/hpcc/stream-ep.ml-perf.graph
 release/examples/benchmarks/hpcc/stream.ml-perf.graph
 release/examples/benchmarks/hpcc/variants/stream-promoted.ml-perf.graph
 release/examples/benchmarks/ssca2/SSCA2_main.ml-perf.graph
-studies/prk/stencil/prk-stencil.ml-perf.graph
+studies/prk/Stencil/prk-stencil.ml-perf.graph
 
 # suite: - NAS Parallel Benchmarks (perf)
 npb/ep/mcahir/ep.ml-perf.graph
@@ -46,7 +46,7 @@ release/examples/benchmarks/hpcc/variants/stream-promoted.ml-perf.graph
 # suite: - SSCA (perf)
 release/examples/benchmarks/ssca2/SSCA2_main.ml-perf.graph
 # suite: - PRK (perf)
-studies/prk/stencil/prk-stencil.ml-perf.graph
+studies/prk/Stencil/prk-stencil.ml-perf.graph
 
 # suite: <empty>
 # suite: All (time)
@@ -67,8 +67,8 @@ release/examples/benchmarks/miniMD/miniMD.ml-time.graph
 studies/isx/isx.ml-time.graph
 studies/isx/isx-hand-optimized.ml-time.graph
 release/examples/benchmarks/isx/isx-release.ml-time.graph
-studies/prk/stencil/optimized/prk-stencil-opt.ml-time.graph
-studies/prk/stencil/prk-stencil.ml-time.graph
+studies/prk/Stencil/optimized/prk-stencil-opt.ml-time.graph
+studies/prk/Stencil/prk-stencil.ml-time.graph
 # suite: - NAS Parallel Benchmarks (time)
 npb/ep/mcahir/ep.ml-time.graph
 users/npadmana/npb-mg/mg.ml-time.graph
@@ -92,8 +92,8 @@ studies/isx/isx.ml-time.graph
 studies/isx/isx-hand-optimized.ml-time.graph
 release/examples/benchmarks/isx/isx-release.ml-time.graph
 # suite: - PRK (time)
-studies/prk/stencil/optimized/prk-stencil-opt.ml-time.graph
-studies/prk/stencil/prk-stencil.ml-time.graph
+studies/prk/Stencil/optimized/prk-stencil-opt.ml-time.graph
+studies/prk/Stencil/prk-stencil.ml-time.graph
 
 
 # suite: <empty>


### PR DESCRIPTION
PR #6405 uppercased some of the PRK directories, but missed updating the
references to them in GRAPHFILES and ML-GRAPHFILES