### PR TITLE
Skip LCALS correctness testing in some configurations

### DIFF
--- a/test/release/examples/benchmarks/lcals/LCALSMain.skipif
+++ b/test/release/examples/benchmarks/lcals/LCALSMain.skipif
@@ -1,5 +1,11 @@
 # This test takes to long for no-local configurations, so skip it for
-# comm != none and --no-local.
+# comm != none and --no-local. Same for valgrind.
 CHPL_COMM != none
 COMPOPTS <= --no-local
-
+CHPL_TEST_VGRND_EXE == on
+# Some checksums differ from expected values on the following configurations.
+# I think it is caused by sizeof(long double) being less than 16.
+CHPL_TARGET_PLATFORM == cygwin32
+CHPL_TARGET_PLATFORM == cygwin64
+CHPL_TARGET_PLATFORM == linux32
+CHPL_TARGET_COMPILER == cray-prgenv-cray


### PR DESCRIPTION
Skip valgrind testing because it takes too long and timed out.

Skip linux32, cygwin, CCE because the checksums don't match what is expected
in a few kernels.  I verified that the arrays match what is expected in a
failing kernel on linux32, so I believe it is the checksum calculation itself
that is going wrong.  I think the most likely culprit is that
sizeof(long double) is less than 16 in these configurations, and a long double
is used to calculate the checksums.