### PR TITLE
Fix annotation for EP multilocale performance change

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -239,6 +239,9 @@ all:
     - Make the multi-ddata specific fields in DR arrays 'void' when not using them (#5723)
   05/03/17:
     - Flag some compiler temps as const (#6154)
+  06/08/17:
+    - text: upgrade gnu target compiler from 6.3.0 to 7.1.0
+      config: Single node XC, 16 node XC
 
 
 AllCompTime:
@@ -377,10 +380,6 @@ ep-b:
     - added -E to tests which would benefit from it
   11/22/14:
     - revert -E use for nightly on 21st (which failed, unrelatedly)
-
-ep.ml-perf:
-  06/08/17:
-    - Mothball multi-ddata (#6390)
 
 fannkuch-redux:
   07/22/14:


### PR DESCRIPTION
Elliot rightly realized that this was instead a result of the gcc target
compiler upgrade, which had a broader impact (but was difficult to tell in
other cases because there was so much noise on the jobs).  Update the
annotation accordingly.

Verified with the annotations checker script