### PR TITLE
Skip LCALS correctness testing in --baseline testing

### DIFF
--- a/test/release/examples/benchmarks/lcals/LCALSMain.skipif
+++ b/test/release/examples/benchmarks/lcals/LCALSMain.skipif
@@ -1,8 +1,9 @@
 # This test takes to long for no-local configurations, so skip it for
-# comm != none and --no-local. Same for valgrind.
+# comm != none and --no-local. Same for valgrind and --baseline.
 CHPL_COMM != none
 COMPOPTS <= --no-local
 CHPL_TEST_VGRND_EXE == on
+COMPOPTS <= --baseline
 # Some checksums differ from expected values on the following configurations.
 # I think it is caused by sizeof(long double) being less than 16.
 CHPL_TARGET_PLATFORM == cygwin32

--- a/test/release/examples/benchmarks/lcals/LCALSMain.skipif
+++ b/test/release/examples/benchmarks/lcals/LCALSMain.skipif
@@ -1,4 +1,4 @@
-# This test takes to long for no-local configurations, so skip it for
+# This test takes too long for no-local configurations, so skip it for
 # comm != none and --no-local. Same for valgrind and --baseline.
 CHPL_COMM != none
 COMPOPTS <= --no-local


### PR DESCRIPTION
Skip LCALS in --baseline testing because it takes too long and times out.