### PR TITLE
Add a linux64 test for gcc 7.1

### DIFF
--- a/util/cron/test-linux64-gcc71.bash
+++ b/util/cron/test-linux64-gcc71.bash
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#
+# Test default configuration on examples only, on linux64, with compiler gcc-7.1
+
+CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
+source $CWD/common.bash
+
+source /data/cf/chapel/setup_gcc71.bash     # host-specific setup for target compiler
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-gcc71"
+
+$CWD/nightly -cron -examples ${nightly_args}


### PR DESCRIPTION
This allows us to try out gcc 7.1 on linux64 in preparation for it becoming the default there.  It is already the default on the whiteboxes.