### PR TITLE
Repair the array-loc test.

### DIFF
--- a/test/runtime/gbt/topo/array-loc.chpl
+++ b/test/runtime/gbt/topo/array-loc.chpl
@@ -36,7 +36,7 @@ extern proc chpl_topo_getMemLocality(p: c_ptr): chpl_sublocID_t;
     for i in 0..#A._value.mdNumChunks {
       const size = A.domain.numIndices / A._value.mdRLen
                    * A._value.mData(i).pdr.length;
-      const loc = checkMemLocalityWhole(c_ptrTo(A._value.mData(i).data(0)),
+      const loc = checkMemLocalityWhole(c_ptrTo(A._value.mData(i).data(A._value.mData(i).dataOff)),
                                         size, A.eltType, i:chpl_sublocID_t);
       if loc != localityRight {
         locality = loc;

--- a/test/runtime/gbt/topo/array-loc.suppressif
+++ b/test/runtime/gbt/topo/array-loc.suppressif
@@ -1,1 +1,9 @@
-CHPL_LOCALE_MODEL == numa
+#!/usr/bin/env bash
+
+if $CHPL_HOME/util/printchplenv --make \
+     | grep CHPL_MAKE_THIRD_PARTY_LINK_ARGS \
+     | grep -q -e '-lnuma' ; then
+  echo 1
+else
+  echo 0
+fi


### PR DESCRIPTION
Modify the array-loc.suppressif file so that it only suppresses a
failure when libnuma was linked in, which we take as indicating that we
should have tried to localize the array memory.  For the time being, in
this case the test fails because we can't actually localize without the
multi-ddata feature, which has been mothballed.  The test doesn't fail
if libnuma isn't linked in, because in that case it reports "unknown"
locality and expects the same.

Also, adjust the code that computes the memory address whose locality we
key off of.  This was broken by #6060 though I didn't realize it at the
time.  Note, though, that this fix is only needed for the multi-ddata
case, so I'm actually cleaning up unused code here