### PR TITLE
Tidy up const-ness for Immediate methods, add string_value

### DIFF
--- a/compiler/ifa/num.cpp
+++ b/compiler/ifa/num.cpp
@@ -51,7 +51,7 @@ sprint_complex_val(char* str, double real, double imm) {
 }
 
 int 
-snprint_imm(char *str, size_t max, char *control_string, Immediate &imm) {
+snprint_imm(char *str, size_t max, char *control_string, const Immediate &imm) {
   int res = -1;
   switch (imm.const_kind) {
     case NUM_KIND_NONE:
@@ -117,7 +117,7 @@ snprint_imm(char *str, size_t max, char *control_string, Immediate &imm) {
 }
 
 int 
-snprint_imm(char *str, size_t max, Immediate &imm) {
+snprint_imm(char *str, size_t max, const Immediate &imm) {
   int res = -1;
   switch (imm.const_kind) {
     case NUM_KIND_NONE:
@@ -189,7 +189,7 @@ snprint_imm(char *str, size_t max, Immediate &imm) {
 }
 
 int 
-fprint_imm(FILE *fp, Immediate &imm, bool showType) {
+fprint_imm(FILE *fp, const Immediate &imm, bool showType) {
   int res = -1;
   switch (imm.const_kind) {
     case NUM_KIND_NONE:

--- a/compiler/ifa/num.h
+++ b/compiler/ifa/num.h
@@ -121,13 +121,14 @@ class Immediate { public:
     const char *v_string;
   };
 
-  int64_t  int_value( void);
-  int64_t  commid_value( void);
-  uint64_t uint_value( void);
-  uint64_t bool_value( void);
+  int64_t  int_value( void)     const;
+  int64_t  commid_value( void)  const;
+  uint64_t uint_value( void)    const;
+  uint64_t bool_value( void)    const;
+  const char* string_value( void)const;
   // calls int_value, uint_value, or bool_value as appropriate.
-  int64_t  to_int( void);
-  uint64_t to_uint( void);
+  int64_t  to_int( void)        const;
+  uint64_t to_uint( void)       const;
 
   Immediate& operator=(const Immediate&);
   Immediate& operator=(bool b) {
@@ -142,6 +143,8 @@ class Immediate { public:
     v_string = s;
     return *this;
   }
+
+  explicit
   Immediate(bool b) :
     const_kind(NUM_KIND_BOOL),
     string_kind(STRING_KIND_STRING),
@@ -163,13 +166,13 @@ class Immediate { public:
 };
 
 inline uint64_t
-Immediate::bool_value( void) {
+Immediate::bool_value( void) const {
   INT_ASSERT(const_kind == NUM_KIND_BOOL);
   return v_bool;
 }
 
 inline int64_t
-Immediate::int_value( void) {
+Immediate::int_value( void) const {
   int64_t val = 0;
   INT_ASSERT(const_kind == NUM_KIND_INT);
   switch (num_index) {
@@ -183,8 +186,18 @@ Immediate::int_value( void) {
   return val;
 }
 
+inline const char*
+Immediate::string_value( void) const {
+  INT_ASSERT(const_kind == CONST_KIND_STRING);
+  INT_ASSERT(string_kind == STRING_KIND_STRING ||
+             string_kind == STRING_KIND_C_STRING);
+
+  return v_string;
+}
+
+
 inline int64_t
-Immediate::commid_value( void) {
+Immediate::commid_value( void) const {
   INT_ASSERT(const_kind == NUM_KIND_COMMID &&
              num_index == INT_SIZE_64);
   return v_int64;
@@ -192,7 +205,7 @@ Immediate::commid_value( void) {
 
 
 inline uint64_t
-Immediate::uint_value( void) {
+Immediate::uint_value( void) const {
   uint64_t val = 0;
   INT_ASSERT(const_kind == NUM_KIND_UINT);
   switch (num_index) {
@@ -207,7 +220,7 @@ Immediate::uint_value( void) {
 }
 
 inline int64_t
-Immediate::to_int( void) {
+Immediate::to_int( void) const {
   int64_t val = 0;
   switch (const_kind) {
     case NUM_KIND_INT : val = int_value();  break;
@@ -221,7 +234,7 @@ Immediate::to_int( void) {
 
 
 inline uint64_t
-Immediate::to_uint( void) {
+Immediate::to_uint( void) const {
   uint64_t val = 0;
   switch (const_kind) {
     case NUM_KIND_INT : val = int_value();  break;
@@ -276,9 +289,9 @@ ImmHashFns::equal(Immediate *imm1, Immediate *imm2) {
   return !memcmp(imm1, imm2, sizeof(*imm1));
 }
 
-int fprint_imm(FILE *fp, Immediate &imm, bool showType = false);
-int snprint_imm(char *s, size_t max, Immediate &imm);
-int snprint_imm(char *str, size_t max, char *control_string, Immediate &imm);
+int fprint_imm(FILE *fp, const Immediate &imm, bool showType = false);
+int snprint_imm(char *s, size_t max, const Immediate &imm);
+int snprint_imm(char *str, size_t max, char *control_string, const Immediate &imm);
 void coerce_immediate(Immediate *from, Immediate *to);
 void fold_result(Immediate *imm1, Immediate *imm2, Immediate *imm);
 void fold_constant(int op, Immediate *im1, Immediate *im2, Immediate *imm);


### PR DESCRIPTION
When working on a (currently shelved) effort to improve function resolution with a cache, I needed to make some minor changes to Immediate to better handle const-ness.

 * adds const decorators on several Immediate methods and arguments
 * uses `explicit` to disable implicit conversion from bool to Immediate
 * adds string_value as a sister to int_value etc that works in a similar manner.

Passed full local testing.
Trivial and not reviewed.