### PR TITLE
String uses BaseStringType, so add it to ChapelStandard

### DIFF
--- a/modules/internal/ChapelStandard.chpl
+++ b/modules/internal/ChapelStandard.chpl
@@ -25,6 +25,7 @@ module ChapelStandard {
 
   // Internal modules.
   use CPtr;
+  use BaseStringType;
   use CString;
   use String;
   use ChapelDebugPrint;


### PR DESCRIPTION
This is a 1-line change to make ChapelStandard more consistent.