### PR TITLE
Add 'label' to the set of reserved words in the emacs highlighting mode

### DIFF
--- a/highlight/emacs/chpl-mode.el
+++ b/highlight/emacs/chpl-mode.el
@@ -163,7 +163,7 @@ or variable identifier (that's being defined)."
 
 (c-lang-defconst c-simple-stmt-kwds
   "Statement keywords followed by an expression or nothing."
-  chpl '("break" "continue" "return" "yield"))
+  chpl '("break" "continue" "label" "return" "yield"))
 
 (c-lang-defconst c-label-kwds
   "Keywords introducing colon terminated labels in blocks."


### PR DESCRIPTION
User Takeshi Yamamoto noted that 'label' was not highlighted by the Chapel emacs mode (despite being in the language since time immemorial), and proposed the attached trivial fix which seems to work for me.
