### PR TITLE
Document a case that triggers an INT_FATAL in dead code elimination

### DIFF
--- a/test/modules/noakes/mod-init-fails.bad
+++ b/test/modules/noakes/mod-init-fails.bad
@@ -1,0 +1,7 @@
+internal error: DEA0464 chpl Version 1.16.0 pre-release (d37cfd2)
+
+Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
+please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
+the filename + line number above may be useful in working around the issue.
+

--- a/test/modules/noakes/mod-init-fails.chpl
+++ b/test/modules/noakes/mod-init-fails.chpl
@@ -1,0 +1,71 @@
+module Main {
+  use M1;
+  use M2;
+  use M3;
+  use M4;
+
+  writeln();
+  writeln('M.1: Module Main');
+
+  proc main() {
+    writeln();
+    writeln('Hello');
+  }
+}
+
+
+
+module M1 {
+  use M2;
+  use M3;
+  use M4;
+
+  writeln('1.6: Module M1');
+  writeln();
+
+  module M2 {
+    writeln('1.1: Module M1.M2');
+  }
+}
+
+
+
+module M2 {
+  use M1;
+  use M3;
+  use M4;
+
+  writeln('2.2: Module M2');
+
+  module M1 {
+    writeln('2.1: Module M2.M1');
+  }
+}
+
+
+
+module M3 {
+  use M1;
+  use M2;
+  use M4;
+
+  writeln('1.5: Module M3');
+
+  module M2 {
+    writeln('1.2: Module M3.M2');
+  }
+}
+
+
+
+module M4 {
+  use M1;
+  use M2;
+  use M3;
+
+  writeln('1.4: Module M4');
+
+  module M3 {
+    writeln('1.3: Module M4.M3');
+  }
+}

--- a/test/modules/noakes/mod-init-fails.future
+++ b/test/modules/noakes/mod-init-fails.future
@@ -1,0 +1,7 @@
+bug: program generates an internal error in dead code elimination
+
+---
+
+The top level module M2 is unused and so M2 and M2.M1 are unused but,
+for some reason, neither module has an init function by this point.
+This is explicitly noted and trapped.

--- a/test/modules/noakes/mod-init-works.chpl
+++ b/test/modules/noakes/mod-init-works.chpl
@@ -1,0 +1,71 @@
+module Main {
+  use ChapelStandard.M1;
+  use ChapelStandard.M2;
+  use ChapelStandard.M3;
+  use ChapelStandard.M4;
+
+  writeln();
+  writeln('M.1: Module Main');
+
+  proc main() {
+    writeln();
+    writeln('Hello');
+  }
+}
+
+
+
+module M1 {
+  use M2;
+  use M3;
+  use M4;
+
+  writeln('1.6: Module M1');
+  writeln();
+
+  module M2 {
+    writeln('1.1: Module M1.M2');
+  }
+}
+
+
+
+module M2 {
+  use M1;
+  use M3;
+  use M4;
+
+  writeln('2.2: Module M2');
+
+  module M1 {
+    writeln('2.1: Module M2.M1');
+  }
+}
+
+
+
+module M3 {
+  use M1;
+  use M2;
+  use M4;
+
+  writeln('1.5: Module M3');
+
+  module M2 {
+    writeln('1.2: Module M3.M2');
+  }
+}
+
+
+
+module M4 {
+  use M1;
+  use M2;
+  use M3;
+
+  writeln('1.4: Module M4');
+
+  module M3 {
+    writeln('1.3: Module M4.M3');
+  }
+}

--- a/test/modules/noakes/mod-init-works.good
+++ b/test/modules/noakes/mod-init-works.good
@@ -1,0 +1,13 @@
+1.1: Module M1.M2
+1.2: Module M3.M2
+1.3: Module M4.M3
+1.4: Module M4
+1.5: Module M3
+1.6: Module M1
+
+2.1: Module M2.M1
+2.2: Module M2
+
+M.1: Module Main
+
+Hello


### PR DESCRIPTION
This PR contains two tests that appear nearly identical such that one test compiles and generates
the expected output and the other program halts during compilation with an internal error.

Both programs have 5 top level modules with complicated dependencies and nesting.  It is not
immediately obvious but the failing program contains at least one pair of nested modules
that are unused.  However these modules cannot be reclaimed correctly during dead code
elimination.  The passing program has trivial modifications that cause all the modules to be
live.

Tested on clang/darwin and gcc/linux64
