### PR TITLE
Demonstrate an error sequencing module uses

### DIFF
--- a/test/modules/noakes/mod-init-order-fails.chpl
+++ b/test/modules/noakes/mod-init-order-fails.chpl
@@ -1,0 +1,18 @@
+module M1 {
+  use M2;
+  use M4;
+
+  proc main() {
+    writeln('Hello world');
+  }
+}
+
+module M2 {
+  use M3;
+
+  module M3 {
+    module M4 {
+
+    }
+  }
+}

--- a/test/modules/noakes/mod-init-order-fails.future
+++ b/test/modules/noakes/mod-init-order-fails.future
@@ -1,0 +1,6 @@
+bug: Failure to correctly resolve a use statement
+
+---
+
+The module M1 fails to 'use' M2.M3.M4 if M1 appears before M2.
+This programs compiles if M2 preceeds M1 (see mod-init-order-works.chpl)

--- a/test/modules/noakes/mod-init-order-works.chpl
+++ b/test/modules/noakes/mod-init-order-works.chpl
@@ -1,0 +1,18 @@
+module M2 {
+  use M3;
+
+  module M3 {
+    module M4 {
+
+    }
+  }
+}
+
+module M1 {
+  use M2;
+  use M4;
+
+  proc main() {
+    writeln('Hello world');
+  }
+}

--- a/test/modules/noakes/mod-init-order-works.good
+++ b/test/modules/noakes/mod-init-order-works.good
@@ -1,0 +1,1 @@
+Hello world


### PR DESCRIPTION
While looking at a portion of the resolution logic that is implemented in scopeResolve.cpp it
seemed to me that the current implementation walks UseStmts in an order that could cause
valid programs to fail.

This PR contains two versions of "the same" program.  One compiles and executes in the
expected fashion.  The second, a future, fails to compile.

Tested against master on clang/darwin and gcc/linux64
