### PR TITLE
Gcc63 linux test

### DIFF
--- a/util/cron/test-linux64-gcc63.bash
+++ b/util/cron/test-linux64-gcc63.bash
@@ -5,8 +5,8 @@
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common.bash
 
-source /data/cf/chapel/setup_gcc71.bash     # host-specific setup for target compiler
+source /data/cf/chapel/setup_gcc63.bash     # host-specific setup for target compiler
 
-export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-gcc71"
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-gcc63"
 
 $CWD/nightly -cron -examples ${nightly_args}

--- a/util/cron/test-linux64-gcc63.bash
+++ b/util/cron/test-linux64-gcc63.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Test default configuration on examples only, on linux64, with compiler gcc-7.1
+# Test default configuration on examples only, on linux64, with compiler gcc-6.3
 
 CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $CWD/common.bash


### PR DESCRIPTION
Now that gcc 7.1 is the default for linux64, test 6.3 only on release/examples.