### PR TITLE
Introduce ForallStmt AST node

### DIFF
--- a/compiler/AST/ForallStmt.cpp
+++ b/compiler/AST/ForallStmt.cpp
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2004-2017 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ForallStmt.h"
+#include "AstVisitor.h"
+#include "passes.h"
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// ForallStmt represents a forall loop statement
+//
+/////////////////////////////////////////////////////////////////////////////
+
+ForallStmt::ForallStmt(bool zippered, BlockStmt* body, ForallIntents* with):
+  Stmt(E_ForallStmt),
+  fZippered(zippered),
+  fLoopBody(body),
+  fWith(with)
+{
+  fIterVars.parent = this;
+  fIterExprs.parent = this;
+  fIntentVars.parent = this;
+  gForallStmts.add(this);
+}
+
+ForallStmt::~ForallStmt() {
+  delete fWith;
+}
+
+ForallStmt* ForallStmt::copyInner(SymbolMap* map) {
+  ForallStmt* _this  = new ForallStmt(fZippered,
+                                      COPY_INT(fLoopBody),
+                                      COPY_INT(fWith));
+  for_alist(expr, fIterVars)
+    _this->fIterVars.insertAtTail(COPY_INT(expr));
+  for_alist(expr, fIterExprs)
+    _this->fIterExprs.insertAtTail(COPY_INT(expr));
+  for_alist(expr, fIntentVars)
+    _this->fIntentVars.insertAtTail(COPY_INT(expr));
+
+  return _this;
+}
+
+void ForallStmt::replaceChild(Expr* oldAst, Expr* newAst) {
+  if (oldAst == fLoopBody) {
+    if (!newAst)
+      fLoopBody = NULL;
+    else if (BlockStmt* newBlock = toBlockStmt(newAst))
+      fLoopBody = newBlock;
+    else
+      // It is caller responsibility to make newAst fit.
+      INT_ASSERT(false);
+
+  } else if (fWith->replaceChildFI(oldAst, newAst)) {
+      // replaceChildFI took care of it
+
+  } else {
+    // We did not find oldAst in our ForallStmt.
+    INT_ASSERT(false);
+  }
+}
+
+// Todo: are these checks done elsewhere?
+static void verifyList(AList& list, Expr* parent) {
+  INT_ASSERT(list.parent == parent);
+  for_alist(expr, list) {
+    INT_ASSERT(expr->list == &list);
+    INT_ASSERT(expr->parentExpr == parent);
+  }
+}
+
+void ForallStmt::verify() {
+  Expr::verify(E_ForallStmt);
+
+  INT_ASSERT(fIterVars.length == fIterExprs.length);
+  if (fZippered) INT_ASSERT(fIterVars.length > 0);
+  else           INT_ASSERT(fIterVars.length == 1);
+
+  verifyList(fIterVars, this);
+  verifyList(fIterExprs, this);
+  verifyList(fIntentVars, this);
+  for_alist(expr, fIterVars)
+    INT_ASSERT(isDefExpr(expr));
+  for_alist(expr, fIntentVars)
+    INT_ASSERT(isDefExpr(expr));
+
+  INT_ASSERT(fLoopBody);
+  verifyParent(fLoopBody);
+  verifyNotOnList(fLoopBody);
+  // should be a normal block
+  INT_ASSERT(fLoopBody->blockTag == BLOCK_NORMAL);
+  INT_ASSERT(!fLoopBody->blockInfoGet());
+  INT_ASSERT(!fLoopBody->isLoopStmt());
+  INT_ASSERT(!fLoopBody->useList);
+  INT_ASSERT(!fLoopBody->userLabel);
+  INT_ASSERT(!fLoopBody->byrefVars);
+  INT_ASSERT(!fLoopBody->forallIntents);
+
+  INT_ASSERT(fWith);
+
+  // Currently ForallStmt are gone during resolve().
+  INT_ASSERT(!resolved);
+}
+
+void ForallStmt::accept(AstVisitor* visitor) {
+/* TODO once AstVisitor is updated:
+  if (visitor->enterForallStmt(this)) {
+    for_alist(next_ast, fIter)
+      next_ast->accept(visitor);
+    // not doing: fIter->accept(visitor);
+    fWith->acceptFI(visitor); // aka visitor->visitForallIntents(fWith);
+    fMBlock->accept(visitor); // includes loopBody
+    visitor->exitForallStmt(this);
+  }
+*/
+}
+
+Expr* ForallStmt::getFirstChild() {
+  return fIterVars.head;
+}
+
+Expr* ForallStmt::getFirstExpr() {
+  if (Expr* iv = fIterVars.head->getFirstExpr())
+    return iv;
+  else if (Expr* ie = fIterExprs.head->getFirstExpr())
+    return ie;
+
+  // we must have found something
+  INT_ASSERT(false);
+  return NULL; //dummy
+}
+
+Expr* ForallStmt::getNextExpr(Expr* expr) {
+  if (expr == fIterVars.tail)
+    return fIterExprs.head;
+
+  if (expr == fIterExprs.tail) {
+    if (Expr* inv = fIntentVars.head)
+      return inv;
+    else
+      return fLoopBody->getFirstExpr();
+  }
+
+  // Should we also descend into fWith?
+
+  if (expr == fIntentVars.tail)
+    return fLoopBody->getFirstExpr();
+
+  return this;
+}
+
+// Is 'expr' an iterable-expression for 'this' ?
+bool ForallStmt::isIteratedExpression(Expr* expr) {
+  return expr->list && expr->list == &fIterExprs;
+}
+
+// Return the enclosing forall statement for 'expr', or NULL if none.
+ForallStmt* enclosingForallStmt(Expr* expr) {
+  for (Expr* curr = expr->parentExpr; curr; curr = curr->parentExpr)
+    if (ForallStmt* fs = toForallStmt(curr))
+      return fs;
+  return NULL;
+}
+
+// If 'var' is listed in this's with-clause with a reduce intent,
+// return its position in the with-clause, otherwise return -1.
+int ForallStmt::reduceIntentIdx(Symbol* var) {
+  ForallIntents* fi = withClause();
+  int nv = fi->numVars();
+  for (int i = 0; i < nv; i++)
+    if (fi->isReduce(i))
+      if (SymExpr* varSE = toSymExpr(fi->fiVars[i]))
+        if (varSE->symbol() == var)
+          return i;
+
+  // Did not see 'var' with a reduce intent.
+  return -1;
+}
+
+GenRet ForallStmt::codegen() {
+  INT_ASSERT(false); // should not be invoked
+  GenRet ret;
+  return ret;
+}
+
+BlockStmt* ForallStmt::build(Expr* indices, Expr* iterator, ForallIntents* fi,
+                             BlockStmt* body, bool zippered) {
+  // TODO
+  return (BlockStmt*)NULL;
+}

--- a/compiler/AST/Makefile.share
+++ b/compiler/AST/Makefile.share
@@ -37,6 +37,7 @@ AST_SRCS =                                          \
            symbol.cpp                               \
            TryStmt.cpp                              \
            UseStmt.cpp                              \
+           ForallStmt.cpp                           \
            type.cpp                                 \
            view.cpp                                 \
                                                     \

--- a/compiler/AST/astutil.cpp
+++ b/compiler/AST/astutil.cpp
@@ -23,6 +23,7 @@
 #include "CatchStmt.h"
 #include "CForLoop.h"
 #include "DeferStmt.h"
+#include "ForallStmt.h"
 #include "ForLoop.h"
 #include "expr.h"
 #include "passes.h"

--- a/compiler/AST/baseAST.cpp
+++ b/compiler/AST/baseAST.cpp
@@ -25,6 +25,7 @@
 #include "DeferStmt.h"
 #include "driver.h"
 #include "expr.h"
+#include "ForallStmt.h"
 #include "ForLoop.h"
 #include "log.h"
 #include "ModuleSymbol.h"
@@ -80,8 +81,8 @@ void printStatistics(const char* pass) {
 
   foreach_ast(decl_counters);
 
-  int nStmt = nBlockStmt + nCondStmt + nDeferStmt + nGotoStmt + nUseStmt + nExternBlockStmt + nTryStmt + nForwardingStmt + nCatchStmt;
-  int kStmt = kBlockStmt + kCondStmt + kDeferStmt + kGotoStmt + kUseStmt + kExternBlockStmt + kTryStmt + kForwardingStmt + kCatchStmt;
+  int nStmt = nBlockStmt + nCondStmt + nDeferStmt + nGotoStmt + nUseStmt + nExternBlockStmt + nForallStmt + nTryStmt + nForwardingStmt + nCatchStmt;
+  int kStmt = kBlockStmt + kCondStmt + kDeferStmt + kGotoStmt + kUseStmt + kExternBlockStmt + kForallStmt + kTryStmt + kForwardingStmt + kCatchStmt;
   int nExpr = nUnresolvedSymExpr + nSymExpr + nDefExpr + nCallExpr +
     nContextCallExpr + nForallExpr + nNamedExpr;
   int kExpr = kUnresolvedSymExpr + kSymExpr + kDefExpr + kCallExpr +
@@ -463,6 +464,10 @@ const char* BaseAST::astTagAsString() const {
 
     case E_ForwardingStmt:
       retval = "ForwardingStmt";
+      break;
+
+    case E_ForallStmt:
+      retval = "ForallStmt";
       break;
 
     case E_ExternBlockStmt:

--- a/compiler/AST/view.cpp
+++ b/compiler/AST/view.cpp
@@ -29,6 +29,7 @@
 #include "CatchStmt.h"
 #include "DeferStmt.h"
 #include "expr.h"
+#include "ForallStmt.h"
 #include "ForLoop.h"
 #include "iterator.h"
 #include "log.h"

--- a/compiler/include/ForallStmt.h
+++ b/compiler/include/ForallStmt.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2004-2017 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _FORALL_STMT_H_
+#define _FORALL_STMT_H_
+
+#include "stmt.h"
+
+// forall loop statement
+
+class ForallStmt : public Stmt
+{
+public:
+  bool       zippered()       const; // was 'zip' keyword used?
+  AList&     inductionVariables();   // DefExprs, one per iterated expr
+  AList&     iteratedExpressions();  // SymExprs, CallExprs
+  AList&     intentVariables();      // (future) DefExprs of LoopIntentVars
+  BlockStmt* loopBody()       const; // the body of the forall loop
+  // todo: remove this in favor of intentVariables
+  ForallIntents* withClause() const; // forall intents
+
+  ~ForallStmt();
+
+  DECLARE_COPY(ForallStmt);
+
+  virtual void        replaceChild(Expr* oldAst, Expr* newAst);
+  virtual void        verify();
+  virtual void        accept(AstVisitor* visitor);
+  virtual GenRet      codegen();
+
+  virtual Expr*       getFirstChild();
+  virtual Expr*       getFirstExpr();
+  virtual Expr*       getNextExpr(Expr* expr);
+
+  // for the parser
+  static BlockStmt* build(Expr* indices, Expr* iterator, ForallIntents* fi,
+                          BlockStmt* body, bool zippered);
+  // helpers
+  bool isIteratedExpression(Expr* expr);
+  int  reduceIntentIdx(Symbol* var); // todo: replace with LoopIntentVars
+
+private:
+  bool           fZippered;
+  AList          fIterVars;
+  AList          fIterExprs;
+  AList          fIntentVars;  // may be empty
+  BlockStmt*     fLoopBody;    // always present
+  ForallIntents* fWith;   // always present; todo: replace with intentVariables
+
+  ForallStmt(bool zippered, BlockStmt* body, ForallIntents* with);
+};
+
+ForallStmt* enclosingForallStmt(Expr* expr);
+
+inline bool   ForallStmt::zippered() const       { return fZippered; }
+inline AList& ForallStmt::inductionVariables()   { return fIterVars; }
+inline AList& ForallStmt::iteratedExpressions()  { return fIterExprs; }
+inline AList& ForallStmt::intentVariables()      { return fIntentVars; }
+inline BlockStmt*     ForallStmt::loopBody()   const { return fLoopBody; }
+inline ForallIntents* ForallStmt::withClause() const { return fWith; }
+
+#endif

--- a/compiler/include/baseAST.h
+++ b/compiler/include/baseAST.h
@@ -71,6 +71,7 @@
   macro(CondStmt) sep                              \
   macro(GotoStmt) sep                              \
   macro(DeferStmt) sep                             \
+  macro(ForallStmt) sep                            \
   macro(TryStmt) sep                               \
   macro(ForwardingStmt) sep                        \
   macro(CatchStmt) sep                             \
@@ -153,6 +154,7 @@ enum AstTag {
   E_BlockStmt,
   E_CondStmt,
   E_GotoStmt,
+  E_ForallStmt,
   E_ExternBlockStmt,
 
   E_ModuleSymbol,
@@ -338,6 +340,7 @@ def_is_ast(BlockStmt)
 def_is_ast(CondStmt)
 def_is_ast(GotoStmt)
 def_is_ast(DeferStmt)
+def_is_ast(ForallStmt)
 def_is_ast(TryStmt)
 def_is_ast(ForwardingStmt)
 def_is_ast(CatchStmt)
@@ -383,6 +386,7 @@ def_to_ast(BlockStmt)
 def_to_ast(CondStmt)
 def_to_ast(GotoStmt)
 def_to_ast(DeferStmt)
+def_to_ast(ForallStmt)
 def_to_ast(TryStmt)
 def_to_ast(ForwardingStmt)
 def_to_ast(CatchStmt)
@@ -553,12 +557,25 @@ static inline const CallExpr* toConstCallExpr(const BaseAST* a)
     AST_CALL_CHILD(_a, DeferStmt, body(), call, __VA_ARGS__);           \
     break;                                                              \
   case E_TryStmt:                                                       \
-    AST_CALL_CHILD(_a, TryStmt, _body, call, __VA_ARGS__);             \
+    AST_CALL_CHILD(_a, TryStmt, _body, call, __VA_ARGS__);              \
     AST_CALL_LIST(_a, TryStmt, _catches, call, __VA_ARGS__);            \
     break;                                                              \
   case E_CatchStmt:                                                     \
-    AST_CALL_CHILD(_a, CatchStmt, _body, call, __VA_ARGS__);           \
+    AST_CALL_CHILD(_a, CatchStmt, _body, call, __VA_ARGS__);            \
     break;                                                              \
+  case E_ForallStmt: {                                                  \
+    AST_CALL_LIST (_a, ForallStmt, inductionVariables(),  call, __VA_ARGS__); \
+    AST_CALL_LIST (_a, ForallStmt, iteratedExpressions(), call, __VA_ARGS__); \
+    AST_CALL_LIST (_a, ForallStmt, intentVariables(),     call, __VA_ARGS__); \
+    ForallIntents* fi = ((ForallStmt*)_a)->withClause();                \
+    AST_CALL_STDVEC(fi->fiVars,  Expr,              call, __VA_ARGS__); \
+    AST_CALL_STDVEC(fi->riSpecs, Expr,              call, __VA_ARGS__); \
+    AST_CALL_CHILD(fi, ForallIntents, iterRec,      call, __VA_ARGS__); \
+    AST_CALL_CHILD(fi, ForallIntents, leadIdx,      call, __VA_ARGS__); \
+    AST_CALL_CHILD(fi, ForallIntents, leadIdxCopy,  call, __VA_ARGS__); \
+    AST_CALL_CHILD(_a, ForallStmt,    loopBody(),   call, __VA_ARGS__); \
+    break;                                                              \
+  }                                                                     \
   case E_ModuleSymbol:                                                  \
     AST_CALL_CHILD(_a, ModuleSymbol, block, call, __VA_ARGS__);         \
     break;                                                              \

--- a/compiler/include/foralls.h
+++ b/compiler/include/foralls.h
@@ -41,6 +41,7 @@ const char* tfiTagDescrString(TFITag tfiTag);
 
 //
 // ForallIntents: with clause/forall intents
+// TODO: replace with LoopIntentVars / ForallStmt::intentVariables
 //
 class ForallIntents {
 public:

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -36,6 +36,7 @@
 #include "DeferStmt.h"
 #include "driver.h"
 #include "expr.h"
+#include "ForallStmt.h"
 #include "ForLoop.h"
 #include "initializerResolution.h"
 #include "iterator.h"


### PR DESCRIPTION
Introduce ForallStmt AST node

This introduces node declaration and basic functions for the work in #5295.
This code is not yet intended to be actually used by the compiler.

#6514 outlines our target goal for forall and intent representation and
lowering. This is the first step in that direction.

Pre-rebase individual commits are available from vasslitvinov clone:

960f481 Follow-ups on review feedback
9cf2a00 Brought it closer to the target #6514
30c568a Another edit based on review suggestions
8ea3925 Edits based on review suggestions
67253e6 Added a separate constructor, per reviewer request
6122589 Added comments for clarity
45045dd Introduce ForallStmt AST node
ed38633 Merge pull request #6521 from lydia-duncan/removeDeprecated
...
