### PR TITLE
add .notest for patterns/grep.chpl

### DIFF
--- a/test/patterns/grep.notest
+++ b/test/patterns/grep.notest
@@ -1,0 +1,1 @@
+Enable this test after adding .good etc.


### PR DESCRIPTION
The test added in #6442 is not ready for testing in our test system, e.g. there is no .good file. Adding .notest for now to avoid affecting nightly testing.
