### PR TITLE
Adjusted a call to chpl_glob in the modules.

### DIFF
--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -777,7 +777,7 @@ iter glob(pattern: string = "*", param tag: iterKind): string
   use chpl_glob_c_interface;
   var glb : glob_t;
 
-  const err = chpl_glob(pattern:c_string, 0, glb);
+  const err = chpl_glob(pattern.localize().c_str(), 0, glb);
   // TODO: Handle error cases better
   if (err != 0 && err != GLOB_NOMATCH) then
     __primitive("chpl_error", c"unhandled error in glob()");


### PR DESCRIPTION
Replaced pattern:c_string with pattern.localize().c_str()
for consistency with other uses of chpl_glob in FileSystem module.
