### PR TITLE
Added two verify() variants.

### DIFF
--- a/compiler/include/expr.h
+++ b/compiler/include/expr.h
@@ -41,6 +41,9 @@ public:
   virtual QualifiedType qualType();
   virtual void    verify();
 
+  void verify(AstTag expectedTag); // ensure tag is as expected, then verify()
+  void verifyParent(const Expr* child); // verify proper child->parentExpr
+
   // New interface
   virtual Expr*   copy(SymbolMap* map = NULL, bool internal = false)   = 0;
   virtual void    replaceChild(Expr* old_ast, Expr* new_ast)           = 0;


### PR DESCRIPTION
verify(expectedTag) and verifyParent() factor out common operations
in our verify() methods.

To show their utility, I applied them where possible in expr.cpp.
A nice effect is a reduction in code size.

Given that it is an internal error that is raised if there are issues,
I stayed with minimalistic error messages (in agreement with Michael).