### PR TITLE
Use a temporary domain to track indices to remove in associative &= operator

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -3075,9 +3075,12 @@ module ChapelArray {
   }
 
   proc &=(ref a :domain, b: domain) where (a.type == b.type) && isAssociativeDom(a) {
+    var removeSet: domain(a.idxType);
     for e in a do
       if !b.member(e) then
-        a.remove(e);
+        removeSet += e;
+    for e in removeSet do
+      a.remove(e);
   }
 
   proc ^(a :domain, b: domain) where (a.type == b.type) && isAssociativeDom(a) {

--- a/test/domains/diten/assocDomIntersect.chpl
+++ b/test/domains/diten/assocDomIntersect.chpl
@@ -1,0 +1,26 @@
+config const nTrials = 100;
+
+var D1: domain(int);
+var D2: domain(int);
+
+proc setupDoms(ref D1, ref D2) {
+  use Random;
+  D1.clear();
+  D2.clear();
+  var rs = makeRandomStream(real);
+  for i in 1..1000 {
+    var rnd1 = (rs.getNext()*10000):int;
+    var rnd2 = (rs.getNext()*10000):int;
+    if !D1.member(rnd1) then
+      D1 += rnd1;
+    if !D2.member(rnd2) then
+      D2 += rnd2;
+  }
+}
+
+for i in 1..nTrials {
+  setupDoms(D1, D2);
+  var oldSize = D1.size;
+  D1 &= D2;
+  assert(oldSize >= D1.size);
+}

--- a/test/domains/diten/assocDomIntersect.future
+++ b/test/domains/diten/assocDomIntersect.future
@@ -1,4 +1,0 @@
-bug: domain intersect/assign causes out of bounds access
-
-The domain intersect/assign operator is removing elements from the domain
-while iterating over it, resulting in an out of bounds access.

--- a/test/domains/diten/assocDomIntersect.future
+++ b/test/domains/diten/assocDomIntersect.future
@@ -1,0 +1,4 @@
+bug: domain intersect/assign causes out of bounds access
+
+The domain intersect/assign operator is removing elements from the domain
+while iterating over it, resulting in an out of bounds access.


### PR DESCRIPTION
Use a temporary domain to store the indices to remove in the &= operator
so that we don't remove indices while iterating over them.

Added a test that does domain intersections of random domains that failed
before this PR with an index out of bounds error.

Passed linux64 paratest with --verify.