### PR TITLE
Drop work-around internal module BaseStringType from String.chpl

### DIFF
--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -31,13 +31,6 @@
  *
  */
 
-private module BaseStringType {
-  use ChapelStandard;
-
-  // TODO: figure out why I can't move this definition into `module String`
-  type bufferType = c_ptr(uint(8));
-}
-
 // Note - the I/O module has
 // :proc:`string.format` and :proc:`stringify`.
 // It might be worth moving them here for documentation - KB Feb 2016
@@ -63,18 +56,19 @@ private module BaseStringType {
     allowing users to specify the encoding for individual strings.
  */
 module String {
-  use BaseStringType;
+  use ChapelStandard;
   use CString;
   use SysCTypes;
   use StringCasts;
+
+  // Growth factor to use when extending the buffer for appends
+  private config param chpl_stringGrowthFactor = 1.5;
 
   //
   // Externs and constants used to implement strings
   //
 
-  private param chpl_string_min_alloc_size: int = 16;
-  // Growth factor to use when extending the buffer for appends
-  private config param chpl_stringGrowthFactor = 1.5;
+  private        param chpl_string_min_alloc_size: int = 16;
 
   // TODO (EJR: 02/25/16): see if we can remove this explicit type declaration.
   // chpl_mem_descInt_t is really a well known compiler type since the compiler
@@ -86,6 +80,8 @@ module String {
   // TODO: define my own mem descriptors?
   private extern const CHPL_RT_MD_STR_COPY_REMOTE: chpl_mem_descInt_t;
   private extern const CHPL_RT_MD_STR_COPY_DATA: chpl_mem_descInt_t;
+
+  type        bufferType         = c_ptr(uint(8));
 
   private inline proc chpl_string_comm_get(dest: bufferType, src_loc_id: int(64),
                                            src_addr: bufferType, len: integral) {

--- a/test/modules/sungeun/init/printModuleInitOrder.good
+++ b/test/modules/sungeun/init/printModuleInitOrder.good
@@ -3,7 +3,6 @@ Initializing Modules:
     CPtr
     CString
     String
-     BaseStringType
      SysCTypes
      StringCasts
     ChapelDebugPrint


### PR DESCRIPTION
When Kyle was working on string-as-record he attempted to define

type bufferType = c_ptr(uint(8));

in the module String.  There is a comment that indicates this failed to compile at the time
but not much information on what went wrong.  In the end he defined another top level module
BaseStringType that contained just this definition and then 'used' this module from String.
He did include a comment to indicate that someone should figure out why he had to do this.


Michael and I happened to trip over this helper-module the other day and then Brad wondered
if it was still necessary.  Turns out it's not.  I haven't made any effort to determine what change
in the compiler solved this problem; just happy it's fixed.


This PR moves the type alias in to String, drops the module, and updates the .good file for
printModuleInitOrder to account for the change in set of modules.

Passed a single-locale paratest with -futures on gcc/linux64.
