### PR TITLE
Renamed flattenScopelessBlock to BlockStmt::flattenAndRemove().

### DIFF
--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -1376,7 +1376,7 @@ buildForallLoopStmt(Expr*      indices,
   loopBody->forallIntents = forall_intents;
   // forallIntents will be processed during implementForallIntents1().
 
-  // ensure it's normal; prevent flatten_scopeless_block() in cleanup.cpp
+  // ensure it's normal; prevent flattenAndRemove() in cleanup.cpp
   loopBody->blockTag = BLOCK_NORMAL;
 
   // NB these copies do not get blockIntent updates below.

--- a/compiler/AST/stmt.cpp
+++ b/compiler/AST/stmt.cpp
@@ -259,6 +259,17 @@ BlockStmt::canFlattenChapelStmt(const BlockStmt* stmt) const {
   return retval;
 }
 
+//
+// "Remove the curly braces":
+// move all contents out of this BlockStmt and remove it.
+//
+void BlockStmt::flattenAndRemove() {
+  for_alist(stmt, this->body)
+    this->insertBefore(stmt->remove());
+  INT_ASSERT(this->body.length == 0);
+  this->remove();
+}
+
 Expr*
 BlockStmt::getFirstChild() {
   Expr* retval = NULL;

--- a/compiler/include/stmt.h
+++ b/compiler/include/stmt.h
@@ -113,6 +113,7 @@ public:
   virtual bool        deadBlockCleanup();
 
   void                appendChapelStmt(BlockStmt* stmt);
+  void                flattenAndRemove();
 
   void                insertAtHead(Expr* ast);
   void                insertAtTail(Expr* ast);

--- a/compiler/passes/cleanup.cpp
+++ b/compiler/passes/cleanup.cpp
@@ -40,8 +40,6 @@ static void normalizeNestedFunctionExpressions(FnSymbol* fn);
 
 static void normalizeLoopIterExpressions(FnSymbol* fn);
 
-static void flattenScopelessBlock(BlockStmt* block);
-
 static void destructureTupleAssignment(CallExpr* call);
 
 static void flattenPrimaryMethod(TypeSymbol* ts, FnSymbol* fn);
@@ -95,7 +93,7 @@ static void cleanup(ModuleSymbol* module) {
 
     if (BlockStmt* block = toBlockStmt(ast)) {
       if (block->blockTag == BLOCK_SCOPELESS && block->list != NULL) {
-        flattenScopelessBlock(block);
+        block->flattenAndRemove();
       }
 
     } else if (CallExpr* call = toCallExpr(ast)) {
@@ -181,22 +179,6 @@ static void normalizeLoopIterExpressions(FnSymbol* fn) {
   } else {
     parent->defPoint->insertBefore(def);
   }
-}
-
-/************************************* | **************************************
-*                                                                             *
-* Move the statements in a block out of the block                             *
-*                                                                             *
-************************************** | *************************************/
-
-static void flattenScopelessBlock(BlockStmt* block) {
-  for_alist(stmt, block->body) {
-    stmt->remove();
-
-    block->insertBefore(stmt);
-  }
-
-  block->remove();
 }
 
 /************************************* | **************************************


### PR DESCRIPTION
This method has a wider applicability than its name suggests.
I will need it in the upcoming #5295.

Tested: linux64 --verify; gasnet.
