### PR TITLE
Fix chplCompile environment issue

### DIFF
--- a/test/patterns/cltools/fileCompile/chplCompile.execenv
+++ b/test/patterns/cltools/fileCompile/chplCompile.execenv
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+
+import os
+import sys
+
+sys.stdout.write("PATH=$CHPL_HOME/bin/%s:$PATH" % os.getenv("CHPL_HOST_PLATFORM"))


### PR DESCRIPTION
Prepend the PATH for this test with the directory containing the chpl binary in case the environment isn't set up for it, as is the case in our nightly testing.