### PR TITLE
Add a check for passing "this" to a function in phase1 of an initializer

### DIFF
--- a/test/classes/initializers/phase1/accessThisBad.chpl
+++ b/test/classes/initializers/phase1/accessThisBad.chpl
@@ -1,16 +1,17 @@
 class ThisTooEarly {
-  var r: real;
+  var r : real;
 
-  proc init(rVal: real) {
+  proc init(rVal : real) {
     foo(this); // Uh oh!
+
     r = rVal;
+
     super.init();
+
+    foo(this); // OK!
   }
 }
 
-// The function exists so that we can pass a "this" instance to it before we've
-// finished initializing in Phase 1, to verify that this particular behavior is
-// not allowed
 proc foo(x: ThisTooEarly) {
   writeln(x.r);
 }
@@ -19,5 +20,6 @@ proc main() {
   var c: ThisTooEarly = new ThisTooEarly(5);
 
   foo(c);
+
   delete c;
 }

--- a/test/classes/initializers/phase1/accessThisBad.future
+++ b/test/classes/initializers/phase1/accessThisBad.future
@@ -1,5 +1,0 @@
-feature request: new initializer story
-
-This test is not expected to pass until at least part of the initializers story
-is on master.  Make it a future so that Lydia can stay in step with master
-without disrupting testing overly much.

--- a/test/classes/initializers/phase1/accessThisBad.good
+++ b/test/classes/initializers/phase1/accessThisBad.good
@@ -1,1 +1,2 @@
-accessThisBad.chpl:5: error: attempted utilization of "this" too early in initializer
+accessThisBad.chpl:4: In initializer:
+accessThisBad.chpl:5: error: can't pass "this" as an actual to a function during phase 1 of initialization


### PR DESCRIPTION
This is a simple update that generates an error if "this" is passed as an actual to a function
in phase1.  Retire the associated future.

Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.
Passed start_test on a small portion of release/
Passed single-locale paratest on gcc/linux64
