### PR TITLE
Detect the premature use of a field in phase1

### DIFF
--- a/test/classes/initializers/phase1/badDependence.chpl
+++ b/test/classes/initializers/phase1/badDependence.chpl
@@ -1,25 +1,23 @@
 class ManyFields {
-  var f2: int;
-  var f3: int;
-  var f4 = 12;
-  var f5 = 3;
+  var f2 : int;
+  var f3 : int;
+  var f4        = 12;
+  var f5        =  3;
 
-  proc init(val: int) {
-    // f1, though omitted, has a dependence on a later field.  Giving it the
-    // declaration value then violates the rules of phase 1
+  proc init(val : int) {
     f2 = f5 + 4; // Depends on a later field's explicit initialization.  Uh oh!
     f3 = f4 - 2; // Depends on an omitted later field.  Uh oh!
-    // f4's implicit reliance on f5 is also bad
+
     f5 = val;
+
     super.init();
-    // The proper way to write this is in Phase 2, or by relying on the val
-    // argument.  You may also choose to initialize these fields with noinit
-    // during Phase 1
   }
 }
 
 proc main() {
   var c: ManyFields = new ManyFields(2);
+
   writeln(c);
+
   delete c;
 }

--- a/test/classes/initializers/phase1/badDependence.future
+++ b/test/classes/initializers/phase1/badDependence.future
@@ -1,5 +1,0 @@
-feature request: new initializer story
-
-This test is not expected to pass until at least part of the initializers story
-is on master.  Make it a future so that Lydia can stay in step with master
-without disrupting testing overly much.

--- a/test/classes/initializers/phase1/badDependence.good
+++ b/test/classes/initializers/phase1/badDependence.good
@@ -1,2 +1,2 @@
-badDependence.chpl:11: error: Phase 1 initialization of field "f2" does not match field declaration order
-badDependence.chpl:12: error: Phase 1 initialization of field "f3" does not match field declaration order
+badDependence.chpl:7: In initializer:
+badDependence.chpl:8: error: Field used before it is initialized


### PR DESCRIPTION
This simple update to pre-normalization of class/record initialization

1) generates an error message if a field is accessed before it is initialized

2) retires the existing future for this check

Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.
Passed start_test on a small portion of release/ on with each config
Passed single-locale paratest with -futures
