### PR TITLE
Make blc knucleotide use parSafe=true

### DIFF
--- a/test/studies/shootout/k-nucleotide/bradc/knucleotide-blc.chpl
+++ b/test/studies/shootout/k-nucleotide/bradc/knucleotide-blc.chpl
@@ -7,7 +7,7 @@
 
 use Sort;
 
-config param tableSize = 1 << 16,
+config param tableSize = 2**16,
              columns = 61;
 
 
@@ -81,7 +81,7 @@ proc writeCount(data, param str) {
 
 
 proc calculate(data, param nclSize) {
-  var freqDom: domain(int, parSafe=false),
+  var freqDom: domain(int),
       freqs: [freqDom] int;
 
   //
@@ -92,7 +92,7 @@ proc calculate(data, param nclSize) {
   var lock$: sync bool = true;
   const numTasks = here.maxTaskPar;
   coforall tid in 1..numTasks {
-    var myDom: domain(int, parSafe=false),
+    var myDom: domain(int),
         myArr: [myDom] int;
 
     for i in tid..(data.size-nclSize) by numTasks do
@@ -123,7 +123,7 @@ forall i in toChar.domain do
 inline proc decode(in data, param nclSize) {
   var ret: string;
 
-  for param i in 1..nclSize {
+  for i in 1..nclSize {
     ret = toChar[(data & 3)] + ret;
     data >>= 2;
   }
@@ -135,7 +135,7 @@ inline proc decode(in data, param nclSize) {
 inline proc hash(str, beg, param size) {
   var data = 0;
 
-  for param i in 0..size-1 {
+  for i in 0..size-1 {
     data <<= 2;
     data |= toNum[str[beg+i]];
   }


### PR DESCRIPTION
In making some adjustments to how associative domains/arrays do
locking, @benharsh speculated about whether the improvements
would be such that we could stop throwing 'parSafe=false' on
k-nucleotide.  Here, I'm making my study variation of the
benchmark use 'parSafe=true' to test this hypothesis.  I also
made a few other minor, mostly cosmetic, changes to bring my
code more in-line with the release version.