### PR TITLE
Generate an error if a method is invoked in phase1 of an initializer

### DIFF
--- a/test/classes/initializers/phase1/methodCall.chpl
+++ b/test/classes/initializers/phase1/methodCall.chpl
@@ -1,21 +1,31 @@
 class MethodTooEarly {
-  var i: int;
+  var i : int;
 
-  proc init(iVal: int) {
-    myMethod(); // Uh oh!
+  proc init(iVal : int) {
+    myMethod();   // *** Invalid.  Still in phase1
+    myMethod(20); // *** Invalid.  Still in phase1
+
     i = iVal;
+
     super.init();
   }
 
-  // This method demonstrates why it would be bad to access a method before the
-  // instance had finished Phase 1 of initialization
+  // This method demonstrates why it would be bad to access a method
+  // before the instance had finished Phase 1 of initialization
   proc myMethod() {
     writeln("My i value is: ", i);
+  }
+
+
+  // This method demonstrates why it would be bad to access a method
+  // before the instance had finished Phase 1 of initialization
+  proc myMethod(x : int) {
+    writeln("My i value is: ", i + x);
   }
 }
 
 proc main() {
-  var c: MethodTooEarly = new MethodTooEarly(3);
+  var c : MethodTooEarly = new MethodTooEarly(3);
 
   delete c;
 }

--- a/test/classes/initializers/phase1/methodCall.future
+++ b/test/classes/initializers/phase1/methodCall.future
@@ -1,5 +1,0 @@
-feature request: new initializer story
-
-This test is not expected to pass until at least part of the initializers story
-is on master.  Make it a future so that Lydia can stay in step with master
-without disrupting testing overly much.

--- a/test/classes/initializers/phase1/methodCall.good
+++ b/test/classes/initializers/phase1/methodCall.good
@@ -1,1 +1,2 @@
-methodCall.chpl:5: error: attempted method call too early during initialization
+methodCall.chpl:4: In initializer:
+methodCall.chpl:5: error: cannot call a method during phase 1 of initialization


### PR DESCRIPTION
This simple non-generic initializer PR generates an error if a method is invoked in phase1 of
an initializer and then retires the associated future.


Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64
Passed start_test on a small portion of release/ for each of these configs
Passed a single-locale paratest on gcc/linux64
