### PR TITLE
Emit warning suppression flag in the correct order

### DIFF
--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -198,7 +198,7 @@ endif
 ifeq ($(GNU_GCC_SUPPORTS_STRICT_OVERFLOW),1)
 # -Wno-strict-overflow is needed only because the way we code range iteration
 # (ChapelRangeBase.chpl:793) generates code which can overflow.
-GEN_CFLAGS += -Wno-strict-overflow
+SQUASH_WARN_GEN_CFLAGS += -Wno-strict-overflow
 # -fstrict-overflow was introduced in GCC 4.2 and is on by default.  When on,
 # it allows the compiler to assume that integer sums will not overflow, which
 #  can change the programs runtime behavior (when -O2 or greater is tossed).


### PR DESCRIPTION
For a long time, we have been emitting gcc's `-Wno-strict-overflow` flag when compiling the generated code, but we never noticed until gcc 7 that it was placed on the command line in the wrong order.  We had been putting it before `-Wall` which caused it to be overridden.  This change places it after `-Wall`.

This fixes the test `modules/packages/LinearAlgebraJama/TestMatrix` when run with `--fast`.
