### PR TITLE
Convert bare field references to this.<foo> for RHS of field initializers

### DIFF
--- a/test/classes/initializers/phase1/arrayDependence.chpl
+++ b/test/classes/initializers/phase1/arrayDependence.chpl
@@ -1,13 +1,13 @@
 class Foo {
-  const D:domain(2);
-  const A:[D] int;
+  const D : domain(2);
+  const A : [D] int;
 
-  proc init(n:int) {
-    D = {1..n, 1..n};
+  proc init(n : int) {
+    D = { 1 .. n, 1 .. n };
+
     super.init();
   }
 }
-
 
 var a = new Foo(10);
 

--- a/test/classes/initializers/phase1/arrayDependence.future
+++ b/test/classes/initializers/phase1/arrayDependence.future
@@ -1,5 +1,0 @@
-feature request: new initializer story
-
-This test is not expected to pass until at least part of the initializers story
-is on master.  Make it a future so that Lydia can stay in step with master
-without disrupting testing overly much.


### PR DESCRIPTION
This simple PR adds support to expand a"bare" field references to a qualified field reference
when inserting omitted fields.  The first instance of applying this is for an array i.e.

class Foo {
  const D : domain(2);
  const A : [D] int;

  proc init(n : int) {
    D = { 1 .. n, 1 .. n };

    super.init();
  }
}

Before this PR, the inserted statement for A used an unqualified reference to D and
ultimately failed in the backend.

This PR also retires the associated future.


Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.
Passed start_test for a small portion of release/ on all configurations.

Passed a single-locale paratest with -futures
