### PR TITLE
Tweak text of .future to assist in categorizing remaining non-generic futures

### DIFF
--- a/test/classes/initializers/phase1/unorderedFields-preferred.future
+++ b/test/classes/initializers/phase1/unorderedFields-preferred.future
@@ -1,4 +1,4 @@
-feature request: new initializer story
+error message: improve field ordering messages
 
 This test currently generates an error message about a field
 being initialized more than once.  It would be nicer if it


### PR DESCRIPTION
A trivial change to the header portion of an existing initializer .future to
simplify tracking and categorization for remaining non-generic initializers

