### PR TITLE
C2Chapel fix for Enums/Typedef Enums

### DIFF
--- a/tools/c2chapel/c2chapel.py
+++ b/tools/c2chapel/c2chapel.py
@@ -346,8 +346,21 @@ def genVar(decl):
 
 def genEnum(decl):
     if type(decl) == c_ast.Enum:
+        if decl.name: 
+            genComment("Enum: " + decl.name)
+        else: 
+            genComment("Enum: anonymous")
         for val in decl.values.enumerators:
             print("extern const " + val.name + " :c_int;")
+        print("\n")
+
+def genTypeEnum(decl):
+    if type(decl.type) == c_ast.Enum:
+        for child in decl.children():
+            for val in child[1].children():
+                for value in val[1].enumerators:
+                    print("extern const " + value.name + " :" + decl.declname + ";")
+        print("\n")
 
 # Simple visitor to all function declarations
 class ChapelVisitor(c_ast.NodeVisitor):
@@ -420,8 +433,9 @@ def genTypedefs(defs):
                 genComment("Typedef'd pointer to struct")
                 print("extern type " + node.name + ";\n")
             elif type(node.type.type) == c_ast.Enum:
-                genComment("typedef enum")
+                genComment(node.name + " enum")
                 print("extern type " + node.name + " = c_int;")
+                genTypeEnum(node.type)
             else:
                 genTypeAlias(node)
 

--- a/tools/c2chapel/c2chapel.py
+++ b/tools/c2chapel/c2chapel.py
@@ -314,7 +314,7 @@ def genStruct(struct, name=""):
 
     ret = "extern record " + name + " {"
     foundTypes.add(name)
-
+    
     members = ""
     warnKeyword = False
     for decl in struct.decls:
@@ -342,6 +342,12 @@ def genVar(decl):
     ty   = toChapelType(decl.type)
     print("extern var " + name + " : " + ty + ";")
     print()
+
+
+def genEnum(decl):
+    if type(decl) == c_ast.Enum:
+        for val in decl.values.enumerators:
+            print("extern const " + val.name + " :c_int;")
 
 # Simple visitor to all function declarations
 class ChapelVisitor(c_ast.NodeVisitor):
@@ -371,11 +377,14 @@ class ChapelVisitor(c_ast.NodeVisitor):
                 self.visit_Struct(c)
             elif type(c) == c_ast.FuncDecl:
                 self.visit_FuncDecl(c)
+            elif type(c) == c_ast.Enum:
+                genEnum(c)
             elif type(c) == c_ast.TypeDecl or type(c) == c_ast.PtrDecl or type(c) == c_ast.ArrayDecl:
                 genVar(node)
             else:
                 node.show()
                 raise Exception("Unhandled declaration")
+
 
 
 def genTypeAlias(node):
@@ -410,6 +419,9 @@ def genTypedefs(defs):
             elif isPointerToStruct(node.type):
                 genComment("Typedef'd pointer to struct")
                 print("extern type " + node.name + ";\n")
+            elif type(node.type.type) == c_ast.Enum:
+                genComment("typedef enum")
+                print("extern type " + node.name + " = c_int;")
             else:
                 genTypeAlias(node)
 

--- a/tools/c2chapel/test/enum.chpl
+++ b/tools/c2chapel/test/enum.chpl
@@ -5,10 +5,23 @@ require "enum.h";
 
 // Note: Generated with fake std headers
 
+// Enum: anonymous
 extern const TEST_STATUS_PASSED :c_int;
 extern const TEST_STATUS_FAILED :c_int;
+
+
+// Enum: direction
+extern const NORTH :c_int;
+extern const SOUTH :c_int;
+extern const EAST :c_int;
+extern const WEST :c_int;
+
+
+// Enum: anonymous
 extern const PASSED :c_int;
 extern const FAILED :c_int;
+
+
 extern proc test_file(e : test_error) : c_int;
 
 extern record test_status {
@@ -17,5 +30,12 @@ extern record test_status {
 
 // ==== c2chapel typedefs ====
 
-// typedef enum
+// test_error enum
 extern type test_error = c_int;
+extern const ENUM_ERROR :test_error;
+extern const ENUM_WVALUES_ERROR :test_error;
+extern const TD_ENUM_ERROR :test_error;
+extern const FUNC_ENUM_ERROR :test_error;
+extern const STRUCT_ENUM_ERROR :test_error;
+
+

--- a/tools/c2chapel/test/enum.chpl
+++ b/tools/c2chapel/test/enum.chpl
@@ -1,0 +1,21 @@
+// Generated with c2chapel version 0.1.0
+
+// Header given to c2chapel:
+require "enum.h";
+
+// Note: Generated with fake std headers
+
+extern const TEST_STATUS_PASSED :c_int;
+extern const TEST_STATUS_FAILED :c_int;
+extern const PASSED :c_int;
+extern const FAILED :c_int;
+extern proc test_file(e : test_error) : c_int;
+
+extern record test_status {
+  var current_status : test_error;
+}
+
+// ==== c2chapel typedefs ====
+
+// typedef enum
+extern type test_error = c_int;

--- a/tools/c2chapel/test/enum.h
+++ b/tools/c2chapel/test/enum.h
@@ -7,6 +7,15 @@ enum
   TEST_STATUS_FAILED
 };
 
+
+enum direction {
+  NORTH,
+  SOUTH,
+  EAST,
+  WEST
+};
+
+
 /* Enum with values */
 enum 
 {
@@ -29,4 +38,4 @@ int test_file(test_error e);
 
 
 /* struct with enum as a field */
-struct test_status { test_error current_status; }; 
+struct test_status { test_error current_status; };

--- a/tools/c2chapel/test/enum.h
+++ b/tools/c2chapel/test/enum.h
@@ -1,0 +1,32 @@
+
+/* Header file for enum test script */
+/* Enum without values */
+enum 
+{
+  TEST_STATUS_PASSED,
+  TEST_STATUS_FAILED
+};
+
+/* Enum with values */
+enum 
+{
+  PASSED = 1,
+  FAILED = 2
+};
+
+typedef enum 
+{
+  ENUM_ERROR = 1,
+  ENUM_WVALUES_ERROR = 2,
+  TD_ENUM_ERROR = 3,
+  FUNC_ENUM_ERROR = 4,
+  STRUCT_ENUM_ERROR = 5
+}test_error;
+
+
+/* Function with enum as argument */
+int test_file(test_error e);
+
+
+/* struct with enum as a field */
+struct test_status { test_error current_status; }; 


### PR DESCRIPTION
c2chapel now accepts enums as well as typedef'd enums. The fix is relatively straightforward as c2chapel emits an "extern const" for each enumerated value and an "extern type" for each typedef'd enum.  The test script added to the /test directory details a few different uses of Enums as well as typedef'd enums. 