### PR TITLE
Struct forward declarations in c2chapel

### DIFF
--- a/tools/c2chapel/c2chapel.py
+++ b/tools/c2chapel/c2chapel.py
@@ -314,6 +314,10 @@ def genStruct(struct, name=""):
 
     ret = "extern record " + name + " {"
     foundTypes.add(name)
+
+    if not struct.decls:
+        print()
+        return
     
     members = ""
     warnKeyword = False

--- a/tools/c2chapel/c2chapel.py
+++ b/tools/c2chapel/c2chapel.py
@@ -315,6 +315,7 @@ def genStruct(struct, name=""):
     ret = "extern record " + name + " {"
     foundTypes.add(name)
 
+    # Forward Declaration
     if not struct.decls:
         print()
         return

--- a/tools/c2chapel/test/miscTypedef.chpl
+++ b/tools/c2chapel/test/miscTypedef.chpl
@@ -17,6 +17,7 @@ extern proc retStruct(a : my_int, b : my_int, r : renamedStruct) : fancyStruct;
 
 extern proc tdPointer(ref a : fancyStruct, ref b : c_ptr(renamedStruct)) : void;
 
+
 // ==== c2chapel typedefs ====
 
 extern record fancyStruct {

--- a/tools/c2chapel/test/miscTypedef.chpl
+++ b/tools/c2chapel/test/miscTypedef.chpl
@@ -18,6 +18,12 @@ extern proc retStruct(a : my_int, b : my_int, r : renamedStruct) : fancyStruct;
 extern proc tdPointer(ref a : fancyStruct, ref b : c_ptr(renamedStruct)) : void;
 
 
+
+extern record forwardStruct {
+  var a : c_int;
+  var b : c_int;
+}
+
 // ==== c2chapel typedefs ====
 
 extern record fancyStruct {
@@ -26,6 +32,8 @@ extern record fancyStruct {
   var c : renamedStruct;
   var d : simpleStruct;
 }
+
+extern type fwdStruct = forwardStruct;
 
 extern type my_int = c_int;
 

--- a/tools/c2chapel/test/miscTypedef.h
+++ b/tools/c2chapel/test/miscTypedef.h
@@ -30,3 +30,5 @@ typedef struct {
   int i;
   char c;
 } *recp;
+
+struct emprty_struct;

--- a/tools/c2chapel/test/miscTypedef.h
+++ b/tools/c2chapel/test/miscTypedef.h
@@ -31,4 +31,4 @@ typedef struct {
   char c;
 } *recp;
 
-struct emprty_struct;
+struct empty_struct;

--- a/tools/c2chapel/test/miscTypedef.h
+++ b/tools/c2chapel/test/miscTypedef.h
@@ -32,3 +32,12 @@ typedef struct {
 } *recp;
 
 struct empty_struct;
+
+struct forwardStruct;
+typedef struct forwardStruct fwdStruct;
+
+struct forwardStruct {
+  int a;
+  int b;
+};
+


### PR DESCRIPTION
Fixed struct forward declaration corner case in c2chapel. Nothing needs to be emitted by c2chapel for this type of forward declaration so this fix makes it so that the program does not show an error/stop. 