### PR TITLE
Use == instead of strcmp on astr'ed strings

### DIFF
--- a/compiler/AST/AstToText.cpp
+++ b/compiler/AST/AstToText.cpp
@@ -93,7 +93,7 @@ void AstToText::appendName(FnSymbol* fn)
   {
     appendThisIntent(fn);
 
-    if (strcmp(fn->name, "this") == 0)
+    if (fn->name == astrThis)
     {
       appendClassName(fn);
     }
@@ -1039,7 +1039,7 @@ void AstToText::appendExpr(CallExpr* expr, bool printingType)
         mText += "..";
       }
 
-      else if (strcmp(fnName, ".")                           == 0)
+      else if ((fnName != astrSdot)                          == 0)
       {
         SymExpr* symExpr1 = toSymExpr(expr->get(1));
         SymExpr* symExpr2 = toSymExpr(expr->get(2));
@@ -1050,7 +1050,7 @@ void AstToText::appendExpr(CallExpr* expr, bool printingType)
           {
             ArgSymbol* sym1 = toArgSymbol(symExpr1->symbol());
 
-            if (strcmp(sym1->name, "this") == 0)
+            if (sym1->name == astrThis)
             {
               appendExpr(symExpr2, printingType);
             }
@@ -1066,7 +1066,7 @@ void AstToText::appendExpr(CallExpr* expr, bool printingType)
           {
             VarSymbol* sym1 = toVarSymbol(symExpr1->symbol());
 
-            if (strcmp(sym1->name, "this") == 0)
+            if (sym1->name == astrThis)
             {
               appendExpr(symExpr2, printingType);
             }

--- a/compiler/AST/UseStmt.cpp
+++ b/compiler/AST/UseStmt.cpp
@@ -264,7 +264,7 @@ bool UseStmt::isValid(Expr* expr) const {
     retval = true;
 
   } else if (CallExpr* call = toCallExpr(expr)) {
-    if (call->isNamed(".") == true) {
+    if (call->isNamedAstr(astrSdot) == true) {
       if (isValid(call->get(1)) == true) {
         if (SymExpr* rhs = toSymExpr(call->get(2))) {
           VarSymbol* v = toVarSymbol(rhs->symbol());

--- a/compiler/AST/astutil.cpp
+++ b/compiler/AST/astutil.cpp
@@ -417,8 +417,8 @@ int isDefAndOrUse(SymExpr* se) {
 
       if (arg->intent == INTENT_REF ||
           arg->intent == INTENT_INOUT ||
-          (strcmp(fn->name, "=") == 0   &&
-           fn->getFormal(1)      == arg &&
+          (fn->name == astrSequals &&
+           fn->getFormal(1) == arg &&
            isRecord(arg->type))) {
 
           // special case for record-wrapped types originated in

--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -2442,7 +2442,7 @@ buildFunctionSymbol(FnSymbol*   fn,
   fn->thisTag = thisTag;
 
   if ((fn->name[0] == '~' && fn->name[1] != '\0') ||
-      (strcmp(fn->name, "deinit") == 0))
+      (fn->name == astrDeinit))
     fn->addFlag(FLAG_DESTRUCTOR);
 
   if (receiver)

--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -1194,8 +1194,7 @@ FnSymbol* CallExpr::theFnSymbol() const {
   return retval;
 }
 
-
-bool CallExpr::isNamed(const char* name) {
+bool CallExpr::isNamed(const char* name) const {
   if (SymExpr* base = toSymExpr(baseExpr))
     if (strcmp(base->symbol()->name, name) == 0)
       return true;
@@ -1207,6 +1206,18 @@ bool CallExpr::isNamed(const char* name) {
   return false;
 }
 
+// 'name' must be canonicalized
+bool CallExpr::isNamedAstr(const char* name) const {
+  if (SymExpr* base = toSymExpr(baseExpr))
+    if (base->symbol()->name == name)
+      return true;
+
+  if (UnresolvedSymExpr* base = toUnresolvedSymExpr(baseExpr))
+    if (base->unresolved == name)
+      return true;
+
+  return false;
+}
 
 int CallExpr::numActuals() const {
   return argList.length;
@@ -1231,7 +1242,7 @@ FnSymbol* CallExpr::findFnSymbol(void) {
 }
 
 bool CallExpr::isCast(void) {
-  return isNamed("_cast");
+  return isNamedAstr(astr_cast);
 }
 
 Expr* CallExpr::castFrom(void) {
@@ -1248,7 +1259,7 @@ Expr* CallExpr::castTo(void) {
 
 CallExpr* createCast(BaseAST* src, BaseAST* toType)
 {
-  CallExpr* expr = new CallExpr("_cast", toType, src);
+  CallExpr* expr = new CallExpr(astr_cast, toType, src);
   return expr;
 }
 
@@ -1599,7 +1610,7 @@ Expr* ForallExpr::getFirstExpr() {
 
 NamedExpr::NamedExpr(const char* init_name, Expr* init_actual) :
   Expr(E_NamedExpr),
-  name(init_name),
+  name(astr(init_name)),
   actual(init_actual)
 {
   gNamedExprs.add(this);

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -2367,6 +2367,25 @@ FlagSet getRecordWrappedFlags(Symbol* s) {
   return s->flags & mask;
 }
 
+
+// cache some popular strings
+
+const char* astrSdot = NULL;
+const char* astrSequals = NULL;
+const char* astr_cast = NULL;
+const char* astrDeinit = NULL;
+const char* astrTag = NULL;
+const char* astrThis = NULL;
+
+void initAstrConsts() {
+  astrSdot    = astr(".");
+  astrSequals = astr("=");
+  astr_cast   = astr("_cast");
+  astrDeinit  = astr("deinit");
+  astrTag     = astr("tag");
+  astrThis    = astr("this");
+}
+
 /************************************* | **************************************
 *                                                                             *
 * Create a temporary, with FLAG_TEMP and (optionally) FLAG_CONST.             *

--- a/compiler/include/expr.h
+++ b/compiler/include/expr.h
@@ -270,7 +270,8 @@ public:
 
   FnSymbol*       theFnSymbol()                                          const;
 
-  bool            isNamed(const char*);
+  bool            isNamed(const char*)                                   const;
+  bool            isNamedAstr(const char*)                               const;
 
   int             numActuals()                                           const;
   Expr*           get(int index)                                         const;

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -650,6 +650,15 @@ void       verifyInTree(BaseAST* ast, const char* msg);
 const char* retTagDescrString(RetTag    retTag);
 const char* intentDescrString(IntentTag intent);
 
+// cache some popular strings
+extern const char* astrSdot;
+extern const char* astrSequals;
+extern const char* astr_cast;
+extern const char* astrDeinit;
+extern const char* astrTag;
+extern const char* astrThis;
+void initAstrConsts();
+
 // Return true if the arg must use a C pointer whether or not
 // pass-by-reference intents are used.
 bool argMustUseCPtr(Type* t);

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -1237,6 +1237,7 @@ int main(int argc, char* argv[]) {
 
 
     initFlags();
+    initAstrConsts();
     initRootModule();
     initPrimitive();
     initPrimitiveTypes();

--- a/compiler/optimizations/bulkCopyRecords.cpp
+++ b/compiler/optimizations/bulkCopyRecords.cpp
@@ -37,7 +37,7 @@ static bool isAssignment(FnSymbol* fn)
 {
   if (! fn->hasFlag(FLAG_ASSIGNOP))
     return false;
-  if (strcmp(fn->name, "="))
+  if (fn->name != astrSequals)
     return false;
 
   return true;

--- a/compiler/passes/ResolveScope.cpp
+++ b/compiler/passes/ResolveScope.cpp
@@ -459,7 +459,7 @@ Symbol* ResolveScope::lookup(Expr* expr) const {
 
   // A dotted reference (<object>.<field>) to a field in an object
   } else if (CallExpr* call = toCallExpr(expr)) {
-    if (call->isNamed(".") == true) {
+    if (call->isNamedAstr(astrSdot) == true) {
       retval = getFieldFromPath(call);
 
     } else {

--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -273,7 +273,7 @@ static void fixup_accessor(AggregateType* ct, Symbol *field,
   collect_asts(fn, asts);
   for_vector(BaseAST, ast, asts) {
     if (CallExpr* call = toCallExpr(ast)) {
-      if (call->isNamed(field->name) && call->numActuals() == 2) {
+      if (call->isNamedAstr(field->name) && call->numActuals() == 2) {
         if (call->get(1)->typeInfo() == dtMethodToken &&
             call->get(2)->typeInfo() == ct) {
           Expr* arg2 = call->get(2);
@@ -789,7 +789,7 @@ static void build_enum_enumerate_function(EnumType* et) {
 
 static void build_enum_cast_function(EnumType* et) {
   // integral value to enumerated type cast function
-  FnSymbol* fn = new FnSymbol("_cast");
+  FnSymbol* fn = new FnSymbol(astr_cast);
   fn->addFlag(FLAG_COMPILER_GENERATED);
   ArgSymbol* arg1 = new ArgSymbol(INTENT_BLANK, "t", dtAny);
   arg1->addFlag(FLAG_TYPE_VARIABLE);
@@ -835,7 +835,7 @@ static void build_enum_cast_function(EnumType* et) {
   normalize(fn);
 
   // string to enumerated type cast function
-  fn = new FnSymbol("_cast");
+  fn = new FnSymbol(astr_cast);
   fn->addFlag(FLAG_COMPILER_GENERATED);
   arg1 = new ArgSymbol(INTENT_BLANK, "t", dtAny);
   arg1->addFlag(FLAG_TYPE_VARIABLE);
@@ -1019,7 +1019,7 @@ static void build_record_cast_function(AggregateType* ct) {
   if (ct->symbol->hasFlag(FLAG_TUPLE))
     return;
 
-  FnSymbol* fn = new FnSymbol("_cast");
+  FnSymbol* fn = new FnSymbol(astr_cast);
   fn->addFlag(FLAG_COMPILER_GENERATED);
   fn->addFlag(FLAG_INLINE);
   ArgSymbol* t = new ArgSymbol(INTENT_BLANK, "t", dtAny);
@@ -1564,10 +1564,10 @@ static void buildDefaultReadWriteFunctions(AggregateType* ct) {
 
 
 static void buildStringCastFunction(EnumType* et) {
-  if (function_exists("_cast", dtString, et))
+  if (function_exists(astr_cast, dtString, et))
     return;
 
-  FnSymbol* fn = new FnSymbol("_cast");
+  FnSymbol* fn = new FnSymbol(astr_cast);
   fn->addFlag(FLAG_COMPILER_GENERATED);
   ArgSymbol* t = new ArgSymbol(INTENT_BLANK, "t", dtAny);
   t->addFlag(FLAG_TYPE_VARIABLE);

--- a/compiler/passes/checkParsed.cpp
+++ b/compiler/passes/checkParsed.cpp
@@ -130,14 +130,10 @@ checkNamedArguments(CallExpr* call) {
   }
 }
 
-static const char* dotAstr;
-static const char* deinitAstr;
 static VarSymbol*  deinitStrLiteral;
 
 static void setupForCheckExplicitDeinitCalls() {
   SET_LINENO(rootModule); // for --minimal-modules
-  dotAstr = astr(".");
-  deinitAstr = astr("deinit");
   deinitStrLiteral = new_CStringSymbol("deinit");
 }
 
@@ -152,9 +148,9 @@ static void setupForCheckExplicitDeinitCalls() {
 //
 static void checkExplicitDeinitCalls(CallExpr* call) {
   if (UnresolvedSymExpr* target = toUnresolvedSymExpr(call->baseExpr)) {
-    if (target->unresolved == deinitAstr)
+    if (target->unresolved == astrDeinit)
       USR_FATAL_CONT(call, "direct calls to deinit() are not allowed");
-    else if (target->unresolved == dotAstr)
+    else if (target->unresolved == astrSdot)
       if (SymExpr* arg2 = toSymExpr(call->get(2)))
         if (arg2->symbol() == deinitStrLiteral)
           // OK to invoke explicitly from chpl__delete()
@@ -254,7 +250,7 @@ checkFunction(FnSymbol* fn) {
     if (fn->getFormal(1)->intent != INTENT_REF)
       USR_WARN(fn, "The left operand of '=' and '<op>=' should have 'ref' intent.");
 
-  if (!strcmp(fn->name, "this") && fn->hasFlag(FLAG_NO_PARENS))
+  if ((fn->name == astrThis) && fn->hasFlag(FLAG_NO_PARENS))
     USR_FATAL_CONT(fn, "method 'this' must have parentheses");
 
   if (!strcmp(fn->name, "these") && fn->hasFlag(FLAG_NO_PARENS))

--- a/compiler/passes/cleanup.cpp
+++ b/compiler/passes/cleanup.cpp
@@ -205,7 +205,7 @@ static void destructureTupleAssignment(CallExpr* call) {
   CallExpr* parent = toCallExpr(call->parentExpr);
 
   if (parent               != NULL &&
-      parent->isNamed("=") == true &&
+      parent->isNamedAstr(astrSequals) &&
       parent->get(1)       == call) {
     VarSymbol* rtmp = newTemp();
     Expr*      S1   = new CallExpr(PRIM_MOVE, rtmp, parent->get(2)->remove());

--- a/compiler/passes/denormalize.cpp
+++ b/compiler/passes/denormalize.cpp
@@ -252,7 +252,7 @@ bool isDenormalizable(Symbol* sym,
     SafeExprAnalysis& analysisData) {
 
   if(sym && !(toFnSymbol(sym) || toArgSymbol(sym) || toTypeSymbol(sym))) {
-    if(strcmp(sym->name, "this") != 0) { //avoid issue with --baseline
+    if(sym->name != astrThis) { //avoid issue with --baseline
       SymExpr *use = NULL;
       Expr *usePar = NULL;
       Expr *def = NULL;

--- a/compiler/passes/externCResolve.cpp
+++ b/compiler/passes/externCResolve.cpp
@@ -283,7 +283,7 @@ static const char* convertTypedef(ModuleSymbol*           module,
 void convertDeclToChpl(ModuleSymbol* module,
                        const char*   name,
                        Vec<Expr*>&   results) {
-  if (name == NULL || !externC || !strcmp(".", name) || !strcmp("", name))
+  if (name == NULL || !externC || name == astrSdot || !strcmp("", name))
    return;
 
   //If module doesn't have an extern block, we shouldn't be here.

--- a/compiler/passes/initializerRules.cpp
+++ b/compiler/passes/initializerRules.cpp
@@ -1019,7 +1019,7 @@ static bool isMethodCall(CallExpr* callExpr) {
   bool retval = false;
 
   if (CallExpr* base = toCallExpr(callExpr->baseExpr)) {
-    if (base->isNamed(".") == true) {
+    if (base->isNamedAstr(astrSdot) == true) {
       if (SymExpr* lhs = toSymExpr(base->get(1))) {
         if (ArgSymbol* arg = toArgSymbol(lhs->symbol())) {
           retval = arg->hasFlag(FLAG_ARG_THIS);
@@ -1094,7 +1094,7 @@ static const char* initName(CallExpr* expr) {
   const char* retval = NULL;
 
   if (expr->numActuals()                    ==    2 &&
-      expr->isNamed(".")                    == true &&
+      expr->isNamedAstr(astrSdot)           == true &&
       isStringLiteral(expr->get(2), "init") == true) {
 
     if (isSymbolThis(expr->get(1)) == true) {
@@ -1108,7 +1108,7 @@ static const char* initName(CallExpr* expr) {
       // "super" is a expr to a field accessor for classes
       } else if (CallExpr* subExpr = toCallExpr(expr->get(1))) {
         if (subExpr->numActuals()                     == 2    &&
-            subExpr->isNamed(".")                     == true &&
+            subExpr->isNamedAstr(astrSdot)            == true &&
             isSymbolThis(subExpr->get(1))             == true &&
             isStringLiteral(subExpr->get(2), "super") == true) {
           retval = "super";
@@ -1497,7 +1497,7 @@ static DefExpr* toLocalFieldInit(AggregateType* at, CallExpr* callExpr) {
 static DefExpr* toLocalField(AggregateType* at, CallExpr* expr) {
   DefExpr* retval = NULL;
 
-  if (expr->isNamed(".") == true) {
+  if (expr->isNamedAstr(astrSdot)) {
     SymExpr* base = toSymExpr(expr->get(1));
     SymExpr* name = toSymExpr(expr->get(2));
 
@@ -1584,7 +1584,7 @@ static bool isAssignment(CallExpr* callExpr) {
 static bool isSimpleAssignment(CallExpr* callExpr) {
   bool retval = false;
 
-  if (callExpr->isNamed("=") == true) {
+  if (callExpr->isNamedAstr(astrSequals) == true) {
     retval = true;
   }
 
@@ -1994,9 +1994,9 @@ static void phase1Analysis(FnSymbol* fn) {
 static
 const char* getFieldName(Expr* curExpr) {
   if (CallExpr* call = toCallExpr(curExpr)) {
-    if (call->isNamed("=")) {
+    if (call->isNamedAstr(astrSequals)) {
       if (CallExpr* inner = toCallExpr(call->get(1))) {
-        if (inner->isNamed(".")) {
+        if (inner->isNamedAstr(astrSdot)) {
           SymExpr* potenThis = toSymExpr(inner->get(1));
           if (potenThis && potenThis->symbol()->hasFlag(FLAG_ARG_THIS)) {
             // It's an access of this!
@@ -2303,7 +2303,7 @@ static InitStyle findInitStyleInner(CallExpr* call) {
   InitStyle retval = STYLE_NONE;
 
   if (call->numActuals()                    ==    2 &&
-      call->isNamed(".")                    == true &&
+      call->isNamedAstr(astrSdot)           == true &&
       isStringLiteral(call->get(2), "init") == true) {
 
     if (isSymbolThis(call->get(1)) == true) {
@@ -2317,7 +2317,7 @@ static InitStyle findInitStyleInner(CallExpr* call) {
       // "super" is a call to a field accessor for classes
       } else if (CallExpr* subCall = toCallExpr(call->get(1))) {
         if (subCall->numActuals()                     == 2    &&
-            subCall->isNamed(".")                     == true &&
+            subCall->isNamedAstr(astrSdot)            == true &&
             isSymbolThis(subCall->get(1))             == true &&
             isStringLiteral(subCall->get(2), "super") == true) {
           retval = STYLE_SUPER_INIT;

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -590,7 +590,7 @@ static void resolveUnresolvedSymExpr(UnresolvedSymExpr* usymExpr) {
 
   const char* name = usymExpr->unresolved;
 
-  if (strcmp(name, ".") == 0 || usymExpr->parentSymbol == NULL) {
+  if (name == astrSdot || usymExpr->parentSymbol == NULL) {
 
   } else if (Symbol* sym = lookup(name, usymExpr)) {
     FnSymbol* fn = toFnSymbol(sym);
@@ -894,7 +894,7 @@ static void checkIdInsideWithClause(Expr*              exprInAst,
 }
 
 static void resolveModuleCall(CallExpr* call) {
-  if (call->isNamed(".") == true) {
+  if (call->isNamedAstr(astrSdot) == true) {
     if (SymExpr* se = toSymExpr(call->get(1))) {
       if (ModuleSymbol* mod = toModuleSymbol(se->symbol())) {
         SET_LINENO(call);
@@ -1047,7 +1047,7 @@ static bool tryCResolve(ModuleSymbol*                     module,
 
 static void resolveEnumeratedTypes() {
   forv_Vec(CallExpr, call, gCallExprs) {
-    if (call->isNamed(".")) {
+    if (call->isNamedAstr(astrSdot)) {
       SET_LINENO(call);
 
       if (SymExpr* first = toSymExpr(call->get(1))) {

--- a/compiler/resolution/callDestructors.cpp
+++ b/compiler/resolution/callDestructors.cpp
@@ -769,7 +769,7 @@ createClonedFnWithRetArg(FnSymbol* fn, FnSymbol* useFn)
         CallExpr* parent   = toCallExpr(move->parentExpr);
 
         if (calledFn                    != NULL &&
-            strcmp(calledFn->name, "=") ==    0 &&
+            calledFn->name       == astrSequals &&
             // Filter out case handled above.
             (!parent || !parent->isPrimitive(PRIM_MOVE))) {
           replacementHelper(move, ret, arg, useFn);
@@ -852,7 +852,7 @@ static void replaceUsesOfFnResultInCaller(CallExpr*      move,
   // If this isn't a call expression, we've got problems.
   if (CallExpr* useCall = toCallExpr(firstUse->parentExpr)) {
     if (FnSymbol* useFn = useCall->resolvedFunction()) {
-      if ((strcmp(useFn->name, "=") == 0 && firstUse == useCall->get(2)) ||
+      if ((useFn->name == astrSequals && firstUse == useCall->get(2)) ||
           useFn->hasFlag(FLAG_AUTO_COPY_FN)                              ||
           useFn->hasFlag(FLAG_INIT_COPY_FN)) {
         Symbol*   actual = NULL;
@@ -915,7 +915,7 @@ static void replaceUsesOfFnResultInCaller(CallExpr*      move,
 
         } else {
           // We assume the useFn is an assignment.
-          if (strcmp(useFn->name, "=") != 0) {
+          if (useFn->name != astrSequals) {
             INT_FATAL(useFn, "should be an assignment function");
             return;
           } else {
@@ -1185,7 +1185,7 @@ static void insertAutoCopyTemps() {
         CallExpr* defCall = toCallExpr(def->parentExpr);
         if (defCall->isPrimitive(PRIM_MOVE)) {
           CallExpr* rhs = toCallExpr(defCall->get(2));
-          if (!rhs || !rhs->isNamed("=")) {
+          if (!rhs || !rhs->isNamedAstr(astrSequals)) {
             // We enter this block if:
             // - rhs is a variable (!rhs), or
             // - rhs is a call but not to =

--- a/compiler/resolution/callInfo.cpp
+++ b/compiler/resolution/callInfo.cpp
@@ -50,7 +50,7 @@ CallInfo::CallInfo(CallExpr* icall, bool checkonly, bool initOkay) :
     bool isThis = false;
     if (NamedExpr* named = toNamedExpr(actual)) {
       actualNames.add(named->name);
-      if (initOkay && !strcmp(named->name, "this"))
+      if (initOkay && named->name == astrThis)
         isThis = true;
       actual = named->actual;
     } else {

--- a/compiler/resolution/implementForallIntents.cpp
+++ b/compiler/resolution/implementForallIntents.cpp
@@ -942,13 +942,13 @@ static VarSymbol* localizeYieldForExtendLeader(Expr* origRetExpr, Expr* ref) {
   for (Expr* curr = ref->prev; curr; curr = curr->prev)
     if (CallExpr* call = toCallExpr(curr))
       if (call->isPrimitive(PRIM_MOVE) ||
-          call->isNamed("="))
+          call->isNamedAstr(astrSequals))
         if (SymExpr* dest = toSymExpr(call->get(1)))
           if (dest->symbol() == origRetSym) {
             VarSymbol* newOrigRet = newTemp("localRet", origRetSym->type);
             call->insertBefore(new DefExpr(newOrigRet));
             dest->setSymbol(newOrigRet);
-            if (call->isNamed("=")) {
+            if (call->isNamedAstr(astrSequals)) {
               // We are "initializing" localRet, not "assigning" to it.
               // An autoCopy of the r.h.s. will be inserted by a later pass.
               // David requests creating a new CallExpr instead of patching

--- a/compiler/resolution/postFold.cpp
+++ b/compiler/resolution/postFold.cpp
@@ -118,7 +118,7 @@ Expr* postFold(Expr* expr) {
           expr->replace(result);
         }
       }
-      if (call->isNamed("=")) {
+      if (call->isNamedAstr(astrSequals)) {
         if (SymExpr* lhs = toSymExpr(call->get(1))) {
           if (lhs->symbol()->hasFlag(FLAG_MAYBE_PARAM) || lhs->symbol()->isParameter()) {
             if (paramMap.get(lhs->symbol())) {
@@ -230,7 +230,7 @@ Expr* postFold(Expr* expr) {
               lhs->symbol()->addFlag(FLAG_TYPE_VARIABLE);
             }
             if (FnSymbol* fn = rhs->resolvedFunction()) {
-              if (!strcmp(fn->name, "=") && fn->retType == dtVoid) {
+              if (fn->name == astrSequals && fn->retType == dtVoid) {
                 call->replace(rhs->remove());
                 result = rhs;
                 set = true;
@@ -454,7 +454,7 @@ Expr* postFold(Expr* expr) {
         //
         // The substitution usually happens before resolution, so for
         // assignment, we key off of the name :-(
-        if (call->isPrimitive(PRIM_MOVE) || call->isNamed("=")) {
+        if (call->isPrimitive(PRIM_MOVE) || call->isNamedAstr(astrSequals)) {
           if (sym->symbol()->hasFlag(FLAG_RVV)) {
             makeNoop(call);
           }

--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -127,7 +127,7 @@ Expr* preFold(CallExpr* call) {
     }
   }
 
-  if (call->isNamed("this")) {
+  if (call->isNamedAstr(astrThis)) {
     SymExpr* base = toSymExpr(call->get(2));
     if (!base) {
       if (NamedExpr* nb = toNamedExpr(call->get(2)))

--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -1125,7 +1125,7 @@ FnSymbol*
 promotionWrap(FnSymbol* fn, CallInfo* info, bool buildFastFollowerChecks) {
 
   Vec<Symbol*>* actuals = &info->actuals;
-  if (!strcmp(fn->name, "="))
+  if (fn->name == astrSequals)
     return fn;
   // Don't try to promotion wrap _ref type constructor
   if (fn->hasFlag(FLAG_TYPE_CONSTRUCTOR))


### PR DESCRIPTION
One of the motivations for using astr() is to allow comparing strings
using pointer equality (on canonicalized pointers) instead of strcmp().
This change leverages that in a few cases that are executed frequently
during compilation.

* These globals contain canonicalized strings as follows:
```
astrSdot    "."
astrSequals "="
astr_cast   "_cast"
astrDeinit  "deinit"
astrTag     "tag"
astrThis    "this"
```
(I introduced "tag" because I'd like to use it in an upcoming bug fix.)
(The S in astrSdot et al. stands for a "symbol", to distinguish from a word.)

* Most comparisons against those strings are replaced with ==.

* Also added isNamedAstr() as a companion to isNamed()
for use when the argument is canonicalized.
Engaged it is most cases where it fits.

I did not switch to using astrXXX globals for uses like `new CallExpr(".", ...)`
because (a) these occur a lot in the source files, probably not as much
during compilation, (b) it does not save us from a hashtable lookup
for each occurrence.

While there, fixed NamedExpr::name to canonicalize it as well.

testing: linux64 --verify, gasnet --verify
