### PR TITLE
add ./tmp to toplevel gitignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ tags
 /build
 /lib
 /tar
+/tmp
 
 # Compiler ignores.
 /compiler/BROWSE


### PR DESCRIPTION
A handy ./tmp subdirectory for dev and test miscellany, 
which Git will ignore (but git clean -fdx will still wipe). 
