### PR TITLE
Improve qio error

### DIFF
--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -365,7 +365,8 @@ proc copyFile(out error: syserr, src: string, dest: string) {
     destChnl.write(line[0..#numRead]);
   }
   if error == EEOF then error = ENOERR;
-  destChnl.flush();
+  destChnl.close();
+  srcChnl.close();
 
   srcFile.close();
   destFile.close();

--- a/runtime/include/qio/qio.h
+++ b/runtime/include/qio/qio.h
@@ -52,7 +52,6 @@ typedef enum {
   QIO_FDFLAG_READABLE = 2,
   QIO_FDFLAG_WRITEABLE = 4,
   QIO_FDFLAG_SEEKABLE = 8,
-  //QIO_FDFLAG_CLOSED = 16, // means channel/file was closed.
 } qio_fdflag_t;
 
 typedef uint32_t qio_hint_t;
@@ -498,6 +497,7 @@ typedef struct qio_file_s {
   void* file_info; // Holds the file information (as a user defined struct)
 
   qio_fdflag_t fdflags;
+  bool closed;
   qio_hint_t hints;
 
   int64_t initial_length;

--- a/runtime/src/qio/qio.c
+++ b/runtime/src/qio/qio.c
@@ -836,6 +836,7 @@ qioerr qio_file_init(qio_file_t** file_out, FILE* fp, fd_t fd, qio_hint_t iohint
   file->use_fp = usefilestar;
   file->buf = NULL;
   file->fdflags = fdflags;
+  file->closed = false;
   file->initial_length = initial_length;
   file->initial_pos = initial_pos;
   file->fsfns = NULL; // Dont have anything so set it to NULL
@@ -931,6 +932,7 @@ qioerr qio_file_init_usr(qio_file_t** file_out, void* file_info, qio_hint_t iohi
   file->use_fp = 0;
   file->buf = NULL;
   file->fdflags = (qio_fdflag_t) flags;
+  file->closed = false;
   file->initial_length = initial_length;
   file->initial_pos = initial_pos;
   file->fs_info = fs_info;
@@ -1021,6 +1023,8 @@ qioerr _qio_file_do_close(qio_file_t* f)
     f->fd = -1;
   }
 
+  f->closed = true;
+
   qio_unlock(& f->lock);
 
   return err;
@@ -1028,17 +1032,6 @@ qioerr _qio_file_do_close(qio_file_t* f)
 
 qioerr qio_file_close(qio_file_t* f)
 {
-  // TODO - we could check to see if
-  // there are references to the file
-  // but we'd have to do it with
-  // atomic-safe load.
-  //
-  // This check is currently disabled
-  // b/c of reference counting bugs
-  // in Chapel.
-  //
-  //if( f->ref_cnt > 1 ) return EINVAL;
-
   return _qio_file_do_close(f);
 }
 
@@ -1232,6 +1225,7 @@ qioerr qio_file_open_mem_ext(qio_file_t** file_out, qbuffer_t* buf, qio_fdflag_t
   file->fp = NULL;
   file->fd = -1;
   file->fdflags = fdflags;
+  file->closed = false;
   file->hints = choose_io_method(file, iohints, 0, qbuffer_len(file->buf),
                                  (fdflags & QIO_FDFLAG_READABLE) > 0,
                                  (fdflags & QIO_FDFLAG_WRITEABLE) > 0,
@@ -1817,6 +1811,9 @@ qioerr _qio_channel_final_flush_unlocked(qio_channel_t* ch)
 
   if( type == QIO_CHTYPE_CLOSED ) return 0;
   if( ! ch->file ) return 0;
+  if ( ch->file->closed )
+    QIO_RETURN_CONSTANT_ERROR(EINVAL, "file closed before channel closed --"
+        " please close all channels before closing the file");
 
   err = _qio_channel_flush_unlocked(ch);
   if( ! err ) {
@@ -1907,7 +1904,11 @@ void _qio_channel_destroy(qio_channel_t* ch)
 
   err = _qio_channel_final_flush_unlocked(ch);
   if( err ) {
-    fprintf(stderr, "qio_channel_final_flush returned fatal error %i\n", qio_err_to_int(err));
+    const char* msg = qio_err_msg(err);
+    if (msg == NULL)
+      msg = "system error";
+    fprintf(stderr, "qio_channel_final_flush returned fatal error %i %s\n",
+        qio_err_to_int(err), msg);
     assert( !err );
     abort();
   }

--- a/runtime/src/qio/qio_error.c
+++ b/runtime/src/qio/qio_error.c
@@ -47,7 +47,8 @@ qioerr qio_err_local_ptr_to_err(const struct qio_err_s* a)
 
 
 const char* qio_err_msg(qioerr a) {
-  intptr_t num = (intptr_t) a;  if( num == 0 ) return 0;
+  intptr_t num = (intptr_t) a;
+  if( num == 0 ) return 0;
   if( num & 1 ) {
     // byte-aligned so can't be an error record.
     return NULL;

--- a/test/io/ferguson/close-file-before-channel.chpl
+++ b/test/io/ferguson/close-file-before-channel.chpl
@@ -1,0 +1,11 @@
+//This program is in error; the test
+// is just to lock in that we get a reasonable error message.
+
+proc test() {
+  var file = open("test.txt", iomode.cw);
+  var chan = file.writer();
+  chan.write("hello");
+  file.close();
+}
+
+test();

--- a/test/io/ferguson/close-file-before-channel.good
+++ b/test/io/ferguson/close-file-before-channel.good
@@ -1,1 +1,1 @@
-qio_channel_final_flush returned fatal error 22 file closed before channel closed -- please close all channels before closing the file
+qio_channel_final_flush returned fatal error 22 file closed before writing channel closed -- please close all writing channels before closing the file

--- a/test/io/ferguson/close-file-before-channel.good
+++ b/test/io/ferguson/close-file-before-channel.good
@@ -1,0 +1,1 @@
+qio_channel_final_flush returned fatal error 22 file closed before channel closed -- please close all channels before closing the file

--- a/test/io/ferguson/close-file-before-channel.prediff
+++ b/test/io/ferguson/close-file-before-channel.prediff
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+testname=$1
+outfile=$2
+
+grep -i "qio_channel_final_flush returned fatal error" $outfile > $outfile.2
+if [ $? -eq 0 ]
+then
+  mv $outfile.2 $outfile
+else
+  echo OtherError > $outfile
+fi


### PR DESCRIPTION
This PR is meant to be an improvement upon PR #6281. It is intended solely to improve the error message one gets if you close a file before closing the channels over that file.

Solves an issue pointed out by @upcrob - thanks!
Reviewed by @ronawho - thanks!

- [x] full local testing