### PR TITLE
Free strings leaked by Regex.subn() / qio_regexp_replace()

### DIFF
--- a/modules/standard/Regexp.chpl
+++ b/modules/standard/Regexp.chpl
@@ -929,7 +929,6 @@ record regexp {
     } else {
       nreplaced = qio_regexp_replace(_regexp, repl.localize().c_str(), repl.length, text.localize().c_str(), text.length, pos, endpos, global, replaced, replaced_len);
     }
-    writeln("replaced.type = ", replaced.type:string);
     const ret = replaced:string;
     chpl_free_c_string_copy(replaced);
     return (ret, nreplaced);

--- a/modules/standard/Regexp.chpl
+++ b/modules/standard/Regexp.chpl
@@ -413,6 +413,7 @@ proc compile(pattern: string, utf8=true, posix=false, literal=false, nocapture=f
   opts.dotnl = dotnl;
   opts.nongreedy = nongreedy;
 
+  // TODO: At present, 'ret' is leaked
   var ret:regexp;
   qio_regexp_create_compile(pattern.localize().c_str(), pattern.length, opts, ret._regexp);
   if ! qio_regexp_ok(ret._regexp) {
@@ -928,7 +929,9 @@ record regexp {
     } else {
       nreplaced = qio_regexp_replace(_regexp, repl.localize().c_str(), repl.length, text.localize().c_str(), text.length, pos, endpos, global, replaced, replaced_len);
     }
+    writeln("replaced.type = ", replaced.type:string);
     const ret = replaced:string;
+    chpl_free_c_string_copy(replaced);
     return (ret, nreplaced);
   }
 

--- a/modules/standard/Regexp.chpl
+++ b/modules/standard/Regexp.chpl
@@ -929,8 +929,7 @@ record regexp {
     } else {
       nreplaced = qio_regexp_replace(_regexp, repl.localize().c_str(), repl.length, text.localize().c_str(), text.length, pos, endpos, global, replaced, replaced_len);
     }
-    const ret = replaced:string;
-    chpl_free_c_string_copy(replaced);
+    const ret = new string(replaced, needToCopy=false);
     return (ret, nreplaced);
   }
 

--- a/runtime/include/qio/qbuffer.h
+++ b/runtime/include/qio/qbuffer.h
@@ -467,11 +467,11 @@ qioerr qbuffer_memset(qbuffer_t* buf, qbuffer_iter_t start, qbuffer_iter_t end, 
 #ifdef _chplrt_H_
 
 #include "chpl-mem.h"
-#define qio_malloc(size) chpl_mem_alloc(size, CHPL_RT_MD_IO_BUFFER, 0, 0)
-#define qio_calloc(nmemb, size) chpl_mem_allocManyZero(nmemb, size, CHPL_RT_MD_IO_BUFFER, 0, 0)
-#define qio_realloc(ptr, size) chpl_mem_realloc(ptr, size, CHPL_RT_MD_IO_BUFFER, 0, 0)
+#define qio_malloc(size) chpl_mem_alloc(size, CHPL_RT_MD_IO_BUFFER, __LINE__, 0)
+#define qio_calloc(nmemb, size) chpl_mem_allocManyZero(nmemb, size, CHPL_RT_MD_IO_BUFFER, __LINE__, 0)
+#define qio_realloc(ptr, size) chpl_mem_realloc(ptr, size, CHPL_RT_MD_IO_BUFFER, __LINE__, 0)
 #define qio_memalign(boundary, size)  chpl_memalign(boundary, size)
-#define qio_free(ptr) chpl_mem_free(ptr, 0, 0)
+#define qio_free(ptr) chpl_mem_free(ptr, __LINE__, 0)
 #define qio_memcpy(dest, src, num) chpl_memcpy(dest, src, num)
 
 typedef chpl_bool qio_bool;


### PR DESCRIPTION
This PR closes our current top memory leak which relates to a c_string returned by our C regular expression library that Chapel never frees.  I took the approach of stealing the c_string into a Chapel string to avoid a copy rather than simply freeing the c_string (which also closes the leak).

Before:
```
16         1414348    io buffer or bytes
```

After:
```
4          544        io buffer or bytes
```


I also diagnosed the source of these remaining leaks (also in regexp), but have not figured out how to close them yet.  I marked the case with a TODO in the source for the time being.

While here, I added __LINE__ information to QIO memory calls to help determine which allocations / reallocations are being leaked.  Supplying a file number is more challenging because we don't have a good way to map runtime files to integers at present, but the line number alone is typically enough to hone in on the offending line by doing, say 'git grep -n qio_malloc' and looking for the line that was reported in the verbose memory trace.

I tested this by:
* spot-checking memory leaks and performance figures for regexp.chpl, both of which seem to have improved
* running valgrind testing on all regexp tests using an older version of re2 that passes valgrind testing
* running complete linux64 testing