### PR TITLE
Fix deinitialization order in AutoDestroyScope::variablesDestroy

### DIFF
--- a/test/classes/deinitializers/fieldorder.good
+++ b/test/classes/deinitializers/fieldorder.good
@@ -1,8 +1,8 @@
 checking helpers F1-F4
-F1.deinit()
-F2.deinit()
-F3.deinit()
 F4.deinit()
+F3.deinit()
+F2.deinit()
+F1.deinit()
 checking field order in RR
 F2.deinit()
 F1.deinit()

--- a/test/types/records/ferguson/destroy-order.chpl
+++ b/test/types/records/ferguson/destroy-order.chpl
@@ -1,0 +1,20 @@
+record R {
+  var x: int;
+  proc deinit() {
+    writeln("Destroying ", x);
+  }
+}
+
+config const check = true;
+
+proc foo() {
+  var one = new R(1);
+  var two = new R(2);
+
+  if check {
+    var three = new R(3);
+    var four = new R(4);
+  }
+}
+
+foo();

--- a/test/types/records/ferguson/destroy-order.good
+++ b/test/types/records/ferguson/destroy-order.good
@@ -1,0 +1,4 @@
+Destroying 4
+Destroying 3
+Destroying 2
+Destroying 1


### PR DESCRIPTION
Variables need to be deinitialized in the reverse declaration order
(because they could refer to each other - or memory managed by each
other). Here I add a new test that checks deinitialization order in a way
that is meant to trigger different behavior in
AutoDestroyScope::variablesDestroy. Indeed, this new test reveals a
problem with the deinitialization order of variables declared in simple
nested blocks.

Then I fix AutoDestroyScope::variablesDestroy to deinitialize such
examples in the correct order. I did that by adding a PRIM_NOOP at the
end of blocks without a terminating GOTO; then in any case the
autoDestroy calls are added in reverse declaration order. This PRIM_NOOP
is added simply as a placeholder that the following code can insert
before and it is removed after it is no longer useful for this purpose.

Passed full local testing.
Reviewed by @noakesmichael - thanks!