### PR TITLE
Adjust test for gcc 6.3 error

### DIFF
--- a/test/memory/ferguson/test.c
+++ b/test/memory/ferguson/test.c
@@ -7,6 +7,9 @@
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
 #endif
+#ifndef _DEFAULT_SOURCE
+#define _DEFAULT_SOURCE
+#endif
 
 #include <stdlib.h>
 #include <stdio.h>


### PR DESCRIPTION
I noticed this test was failing on my Ubuntu 17.04 system.
Fix is simple and repeats work done in sys_basic.h by adjusting test.c.

Trivial and not reviewed.