### PR TITLE
Add more checking to compileline for --llvm

### DIFF
--- a/util/config/compileline
+++ b/util/config/compileline
@@ -78,6 +78,20 @@ for my $arg (@ARGV) {
     $ENV{"CHPL_ORIG_TARGET_COMPILER"}=`$chpl_home_dir/util/chplenv/chpl_compiler.py --target`;
     $ENV{"CHPL_TARGET_COMPILER"}="clang-included";
 
+    my $chpl_llvm = "";
+    if(defined $ENV{"CHPL_LLVM"}) {
+      $chpl_llvm = $ENV{"CHPL_LLVM"};
+    }
+    if(defined $ENV{"CHPL_MAKE_LLVM"}) {
+      $chpl_llvm = $ENV{"CHPL_MAKE_LLVM"};
+    }
+    if($chpl_llvm eq "") {
+      $chpl_llvm = `$chpl_home_dir/util/chplenv/chpl_llvm.py`;
+    }
+    if($chpl_llvm eq "none") {
+      print STDERR "Cannot get --llvm configuration with CHPL_LLVM=none\n";
+      exit 1;
+    }
     # get the name of main.o and check that it exits.
     $maino=`$make -f $chpl_home_dir/runtime/etc/Makefile.include printmaino`;
     chomp $maino;


### PR DESCRIPTION
I confused myself for longer than I care to admit by trying to use extern blocks in a compiler built with LLVM but with CHPL_LLVM=none set when I was running it.
Here I just add some error checking in compileline, near where everything was going off the rails in that situation, to hopefully allow the next person who accidentally enters this unreasonable configuration to quickly diagnose it.

Testing:
 * build compiler with CHPL_LLVM=llvm
 * check hello works with or without --llvm
 * unset CHPL_LLVM
 * check hello works with or without --llvm; also an extern block works
 * export CHPL_LLVM=none
 * try an extern block test or --llvm compile, see new error

- [x] full local testing.
- [x] full local CHPL_LLVM=llvm testing
- [x] full local --llvm testing

Trivial and not reviewed.