### PR TITLE
Change a use of the array alias operator to a ref variable

### DIFF
--- a/test/studies/amr/lib/amr/BergerRigoutsosClustering.chpl
+++ b/test/studies/amr/lib/amr/BergerRigoutsosClustering.chpl
@@ -427,7 +427,7 @@ proc CandidateDomain.inflectionCut ()
     
     if D.dim(d).length >= 4 {
 
-      var sig => signatures(d).array;
+      ref sig = signatures(d).array;
       var stride = D.stride(d);
 
       //===> Search for cuts ===>


### PR DESCRIPTION
The compilation for studies/amr/advection/amr/AMR_AdvectionCTU_driver.chpl was
encountering the array alias deprecation warning during compilation, but
because its prediff was removing compilation output, we didn't see it in the
output for the test.  As part of my default initializers investigation, I
encountered an unrelated error with this test and when I performed a compile
outside of start_test, saw the warning message and so decided to update the test
before it broke when the operator was no longer valid syntax.

Since the code updated was in a helper module, I ran a sanity full paratest and
everything passed