### PR TITLE
Add DeferStmt.h and DeferStmt.cpp

### DIFF
--- a/compiler/AST/DeferStmt.cpp
+++ b/compiler/AST/DeferStmt.cpp
@@ -61,9 +61,9 @@ DeferStmt* DeferStmt::copyInner(SymbolMap* map) {
   return copy;
 }
 
-void DeferStmt::replaceChild(Expr* old_ast, Expr* new_ast) {
-  if (old_ast == _body) {
-    _body = toBlockStmt(new_ast);
+void DeferStmt::replaceChild(Expr* oldAst, Expr* newAst) {
+  if (oldAst == _body) {
+    _body = toBlockStmt(newAst);
   }
 }
 

--- a/compiler/AST/DeferStmt.cpp
+++ b/compiler/AST/DeferStmt.cpp
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2004-2017 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "DeferStmt.h"
+
+#include "AstVisitor.h"
+#include "AstVisitorTraverse.h"
+#include "CatchStmt.h"
+
+BlockStmt* DeferStmt::build(BlockStmt* body) {
+  return buildChplStmt(new DeferStmt(body));
+}
+
+BlockStmt* DeferStmt::buildChplStmt(Expr* expr) {
+  return new BlockStmt(expr, BLOCK_SCOPELESS);
+}
+
+DeferStmt::DeferStmt(BlockStmt* body)
+  : Stmt(E_DeferStmt),
+   _body(body) {
+
+  gDeferStmts.add(this);
+}
+
+DeferStmt::~DeferStmt() {
+
+}
+
+BlockStmt* DeferStmt::body() const {
+  return _body;
+}
+
+void DeferStmt::accept(AstVisitor* visitor) {
+/*  if (visitor->enterDeferStmt(this)) {
+    if (_body) {
+      _body->accept(visitor);
+    }
+
+    visitor->exitDeferStmt(this);
+  }*/
+}
+
+DeferStmt* DeferStmt::copyInner(SymbolMap* map) {
+  DeferStmt* copy = new DeferStmt(COPY_INT(_body));
+  return copy;
+}
+
+void DeferStmt::replaceChild(Expr* old_ast, Expr* new_ast) {
+  if (old_ast == _body) {
+    _body = toBlockStmt(new_ast);
+  }
+}
+
+Expr* DeferStmt::getFirstChild() {
+  return _body;
+}
+
+Expr* DeferStmt::getFirstExpr() {
+  if (_body) {
+    return _body->getFirstExpr();
+  }
+  return NULL;
+}
+
+Expr* DeferStmt::getNextExpr(Expr* expr) {
+  return this;
+}
+
+void DeferStmt::verify() {
+  Stmt::verify(E_DeferStmt);
+
+  if (!_body) {
+    INT_FATAL(this, "DeferStmt::verify. _body is missing");
+  }
+}
+
+GenRet DeferStmt::codegen() {
+  INT_FATAL("DeferStmt should be removed before codegen");
+  GenRet ret;
+  return ret;
+}

--- a/compiler/AST/Makefile.share
+++ b/compiler/AST/Makefile.share
@@ -24,6 +24,7 @@ AST_SRCS =                                          \
            build.cpp                                \
            CatchStmt.cpp                            \
            checkAST.cpp                             \
+           DeferStmt.cpp                            \
            dominator.cpp                            \
            expr.cpp                                 \
            iterator.cpp                             \

--- a/compiler/AST/astutil.cpp
+++ b/compiler/AST/astutil.cpp
@@ -22,6 +22,7 @@
 #include "baseAST.h"
 #include "CatchStmt.h"
 #include "CForLoop.h"
+#include "DeferStmt.h"
 #include "ForLoop.h"
 #include "expr.h"
 #include "passes.h"

--- a/compiler/AST/baseAST.cpp
+++ b/compiler/AST/baseAST.cpp
@@ -22,6 +22,7 @@
 #include "astutil.h"
 #include "CForLoop.h"
 #include "CatchStmt.h"
+#include "DeferStmt.h"
 #include "driver.h"
 #include "expr.h"
 #include "ForLoop.h"
@@ -79,8 +80,8 @@ void printStatistics(const char* pass) {
 
   foreach_ast(decl_counters);
 
-  int nStmt = nCondStmt + nBlockStmt + nGotoStmt + nUseStmt + nTryStmt;
-  int kStmt = kCondStmt + kBlockStmt + kGotoStmt + kUseStmt + kExternBlockStmt + kTryStmt + kForwardingStmt + kCatchStmt;
+  int nStmt = nBlockStmt + nCondStmt + nDeferStmt + nGotoStmt + nUseStmt + nExternBlockStmt + nTryStmt + nForwardingStmt + nCatchStmt;
+  int kStmt = kBlockStmt + kCondStmt + kDeferStmt + kGotoStmt + kUseStmt + kExternBlockStmt + kTryStmt + kForwardingStmt + kCatchStmt;
   int nExpr = nUnresolvedSymExpr + nSymExpr + nDefExpr + nCallExpr +
     nContextCallExpr + nForallExpr + nNamedExpr;
   int kExpr = kUnresolvedSymExpr + kSymExpr + kDefExpr + kCallExpr +
@@ -450,6 +451,10 @@ const char* BaseAST::astTagAsString() const {
 
     case E_CondStmt:
       retval = "CondStmt";
+      break;
+
+    case E_DeferStmt:
+      retval = "DeferStmt";
       break;
 
     case E_GotoStmt:

--- a/compiler/AST/view.cpp
+++ b/compiler/AST/view.cpp
@@ -27,6 +27,7 @@
 #include "AstDumpToNode.h"
 #include "CForLoop.h"
 #include "CatchStmt.h"
+#include "DeferStmt.h"
 #include "expr.h"
 #include "ForLoop.h"
 #include "iterator.h"

--- a/compiler/include/DeferStmt.h
+++ b/compiler/include/DeferStmt.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2004-2017 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _DEFER_STMT_H_
+#define _DEFER_STMT_H_
+
+#include "stmt.h"
+
+class DeferStmt : public Stmt
+{
+
+public:
+
+  BlockStmt*          body() const;
+
+  // To be invoked by the parser; returns a BlockStmt
+  // containing the DeferStmt.
+  static BlockStmt*   build(BlockStmt* body);
+
+                      DeferStmt(BlockStmt* body);
+                      ~DeferStmt();
+
+  void                accept(AstVisitor* visitor);
+  void                replaceChild(Expr* old_ast, Expr* new_ast);
+  Expr*               getFirstChild();
+  Expr*               getFirstExpr();
+  Expr*               getNextExpr(Expr* expr);
+  void                verify();
+  GenRet              codegen();
+  DECLARE_COPY(DeferStmt);
+private:
+  static BlockStmt*   buildChplStmt(Expr* expr);
+                      DeferStmt();
+
+  BlockStmt*          _body;
+};
+
+void checkDefersAfterParsing();
+
+#endif

--- a/compiler/include/DeferStmt.h
+++ b/compiler/include/DeferStmt.h
@@ -51,6 +51,4 @@ private:
   BlockStmt*          _body;
 };
 
-void checkDefersAfterParsing();
-
 #endif

--- a/compiler/include/baseAST.h
+++ b/compiler/include/baseAST.h
@@ -70,6 +70,7 @@
   macro(BlockStmt) sep                             \
   macro(CondStmt) sep                              \
   macro(GotoStmt) sep                              \
+  macro(DeferStmt) sep                             \
   macro(TryStmt) sep                               \
   macro(ForwardingStmt) sep                        \
   macro(CatchStmt) sep                             \
@@ -146,6 +147,7 @@ enum AstTag {
   E_ForwardingStmt,
   E_NamedExpr,
   E_UseStmt,
+  E_DeferStmt,
   E_TryStmt,
   E_CatchStmt,
   E_BlockStmt,
@@ -335,6 +337,7 @@ def_is_ast(UseStmt)
 def_is_ast(BlockStmt)
 def_is_ast(CondStmt)
 def_is_ast(GotoStmt)
+def_is_ast(DeferStmt)
 def_is_ast(TryStmt)
 def_is_ast(ForwardingStmt)
 def_is_ast(CatchStmt)
@@ -379,6 +382,7 @@ def_to_ast(UseStmt)
 def_to_ast(BlockStmt)
 def_to_ast(CondStmt)
 def_to_ast(GotoStmt)
+def_to_ast(DeferStmt)
 def_to_ast(TryStmt)
 def_to_ast(ForwardingStmt)
 def_to_ast(CatchStmt)
@@ -544,6 +548,9 @@ static inline const CallExpr* toConstCallExpr(const BaseAST* a)
     break;                                                              \
   case E_ForwardingStmt:                                                \
     AST_CALL_CHILD(_a, ForwardingStmt, toFnDef, call, __VA_ARGS__);     \
+    break;                                                              \
+  case E_DeferStmt:                                                     \
+    AST_CALL_CHILD(_a, DeferStmt, body(), call, __VA_ARGS__);           \
     break;                                                              \
   case E_TryStmt:                                                       \
     AST_CALL_CHILD(_a, TryStmt, _body, call, __VA_ARGS__);             \

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -33,6 +33,7 @@
 #include "callInfo.h"
 #include "CatchStmt.h"
 #include "CForLoop.h"
+#include "DeferStmt.h"
 #include "driver.h"
 #include "expr.h"
 #include "ForLoop.h"


### PR DESCRIPTION
This PR adds a new AST node to represent a `defer` statement. Defer statements are described in CHIP 8 and are a more general form of `finally` in C++. These are important to support in order to complete the error handling support.

Subsequent PRs will add parsing, lowering, and error checking support for DeferStmts.

Reviewed by @noakesmichael - thanks!
Passed full local testing.