### PR TITLE
Add lowering of DeferStmt in addAutoDestroyCalls

### DIFF
--- a/compiler/include/AutoDestroyScope.h
+++ b/compiler/include/AutoDestroyScope.h
@@ -20,7 +20,9 @@
 #ifndef _AUTO_DESTROY_SCOPE_H_
 #define _AUTO_DESTROY_SCOPE_H_
 
+class BaseAST;
 class BlockStmt;
+class DeferStmt;
 class Expr;
 class FnSymbol;
 class VarSymbol;
@@ -34,6 +36,8 @@ public:
                                             const BlockStmt*        block);
 
   void                     variableAdd(VarSymbol* var);
+
+  void                     deferAdd(DeferStmt* var);
 
   bool                     handlingFormalTemps(const Expr* stmt) const;
 
@@ -49,7 +53,7 @@ private:
 
   bool                     mLocalsHandled;     // Manage function epilogue
   std::vector<VarSymbol*>  mFormalTemps;       // Temps for out/inout formals
-  std::vector<VarSymbol*>  mLocals;
+  std::vector<BaseAST*>    mLocalsAndDefers;   // VarSymbol* or DeferStmt*
 };
 
 #endif

--- a/compiler/include/AutoDestroyScope.h
+++ b/compiler/include/AutoDestroyScope.h
@@ -54,6 +54,10 @@ private:
   bool                     mLocalsHandled;     // Manage function epilogue
   std::vector<VarSymbol*>  mFormalTemps;       // Temps for out/inout formals
   std::vector<BaseAST*>    mLocalsAndDefers;   // VarSymbol* or DeferStmt*
+  // note: mLocalsAndDefers contains both VarSymbol and DeferStmt in
+  // order to create a single stack for cleanup operations to be executed.
+  // In particular, the ordering between defer blocks and locals matters,
+  // in addition to the ordering within each group.
 };
 
 #endif

--- a/compiler/resolution/AutoDestroyScope.cpp
+++ b/compiler/resolution/AutoDestroyScope.cpp
@@ -141,6 +141,8 @@ void AutoDestroyScope::variablesDestroy(Expr*      refStmt,
       BaseAST*  localOrDefer = mLocalsAndDefers[count - i];
       VarSymbol* var = toVarSymbol(localOrDefer);
       DeferStmt* defer = toDeferStmt(localOrDefer);
+      // This code only handles VarSymbols and DeferStmts.
+      INT_ASSERT(var || defer);
 
       if (var != NULL && var != excludeVar) {
         if (FnSymbol* autoDestroyFn = autoDestroyMap.get(var->type)) {

--- a/compiler/resolution/AutoDestroyScope.cpp
+++ b/compiler/resolution/AutoDestroyScope.cpp
@@ -142,6 +142,8 @@ void AutoDestroyScope::variablesDestroy(Expr*      refStmt,
       VarSymbol* var = toVarSymbol(localOrDefer);
       DeferStmt* defer = toDeferStmt(localOrDefer);
       // This code only handles VarSymbols and DeferStmts.
+      // It handles both in one vector because the order
+      // of interleaving matters.
       INT_ASSERT(var || defer);
 
       if (var != NULL && var != excludeVar) {

--- a/test/statements/defer/destroy-order-defer.chpl
+++ b/test/statements/defer/destroy-order-defer.chpl
@@ -1,0 +1,26 @@
+record R {
+  var x: int;
+  proc deinit() {
+    writeln("Destroying ", x);
+  }
+}
+
+config const check = true;
+
+proc foo() {
+  defer { writeln("defer pre 1"); }
+  var one = new R(1);
+  defer { writeln("defer post 1"); }
+  var two = new R(2);
+  defer { writeln("defer post 2"); }
+
+  if check {
+    defer { writeln("defer pre 3"); }
+    var three = new R(3);
+    defer { writeln("defer post 3"); }
+    var four = new R(4);
+    defer { writeln("defer post 4"); }
+  }
+}
+
+foo();

--- a/test/statements/defer/destroy-order-defer.good
+++ b/test/statements/defer/destroy-order-defer.good
@@ -1,0 +1,10 @@
+defer post 4
+Destroying 4
+defer post 3
+Destroying 3
+defer pre 3
+defer post 2
+Destroying 2
+defer post 1
+Destroying 1
+defer pre 1


### PR DESCRIPTION
* tracks VarSymbols and DeferStmts in AutoDestroyScope in a
  single vector because the order of interleaving matters
* copies DeferStmt bodies to appropriate place in
  AutoDestroyScope::variablesDestroy
* removes all DeferStmts in addAutoDestroyCalls
  since by the end of that function they have been lowered.
* Adds a new test of defer and variable deinitialization order.

Continues PR #6523.

Reviewed by @noakesmichael - thanks!
Passed full local testing.