### PR TITLE
Add some error checking for DeferStmt to checkParsed

### DIFF
--- a/compiler/AST/DeferStmt.cpp
+++ b/compiler/AST/DeferStmt.cpp
@@ -95,3 +95,119 @@ GenRet DeferStmt::codegen() {
   GenRet ret;
   return ret;
 }
+
+// supporting checkDefersDoNotBreakOrReturn()
+
+class CheckDeferVisitor : public AstVisitorTraverse {
+
+public:
+  CheckDeferVisitor();
+
+  // We are checking for 'break' or 'return'
+  virtual bool   enterCallExpr       (CallExpr*          node);
+  virtual bool   enterGotoStmt       (GotoStmt*          node);
+
+  // We don't want to enter inner functions
+  virtual bool   enterFnSym          (FnSymbol*          node);
+
+  // Track loops, so we can know if a 'break' is inside a loop or not
+  virtual bool   enterWhileDoStmt    (WhileDoStmt*       node);
+  virtual void   exitWhileDoStmt     (WhileDoStmt*       node);
+
+  virtual bool   enterDoWhileStmt    (DoWhileStmt*       node);
+  virtual void   exitDoWhileStmt     (DoWhileStmt*       node);
+
+  virtual bool   enterCForLoop       (CForLoop*          node);
+  virtual void   exitCForLoop        (CForLoop*          node);
+
+  virtual bool   enterForLoop        (ForLoop*           node);
+  virtual void   exitForLoop         (ForLoop*           node);
+
+  virtual bool   enterParamForLoop   (ParamForLoop*      node);
+  virtual void   exitParamForLoop    (ParamForLoop*      node);
+
+private:
+  int loopDepth;
+
+  void enterLoop() {
+    loopDepth++;
+  }
+  void exitLoop() {
+    loopDepth--;
+  }
+};
+
+CheckDeferVisitor::CheckDeferVisitor() {
+  loopDepth = 0;
+}
+
+bool CheckDeferVisitor::enterCallExpr(CallExpr* node) {
+  if (node->isPrimitive(PRIM_RETURN))
+    USR_FATAL_CONT(node, "return cannot be used within a defer statement");
+  return true;
+}
+bool CheckDeferVisitor::enterGotoStmt(GotoStmt* node) {
+  if (loopDepth == 0)
+    USR_FATAL_CONT(node, "break cannot be used within a defer statement");
+  return true;
+}
+
+bool CheckDeferVisitor::enterFnSym(FnSymbol* node) {
+  return false;
+}
+
+bool CheckDeferVisitor::enterWhileDoStmt(WhileDoStmt* node) {
+  enterLoop();
+  return true;
+}
+void CheckDeferVisitor::exitWhileDoStmt(WhileDoStmt* node) {
+  exitLoop();
+}
+bool CheckDeferVisitor::enterDoWhileStmt(DoWhileStmt* node) {
+  enterLoop();
+  return true;
+}
+void CheckDeferVisitor::exitDoWhileStmt(DoWhileStmt* node) {
+  exitLoop();
+}
+bool CheckDeferVisitor::enterCForLoop(CForLoop* node) {
+  enterLoop();
+  return true;
+}
+void CheckDeferVisitor::exitCForLoop(CForLoop* node) {
+  exitLoop();
+}
+bool CheckDeferVisitor::enterForLoop(ForLoop* node) {
+  enterLoop();
+  return true;
+}
+void CheckDeferVisitor::exitForLoop(ForLoop* node) {
+  exitLoop();
+}
+bool CheckDeferVisitor::enterParamForLoop(ParamForLoop* node) {
+  enterLoop();
+  return true;
+}
+void CheckDeferVisitor::exitParamForLoop(ParamForLoop* node) {
+  exitLoop();
+}
+
+void checkDefersAfterParsing()
+{
+  forv_Vec(DeferStmt, defer, gDeferStmts) {
+  
+    // Check that there are no top-level defers;
+    // each defer must be in a function (other than module init).
+    if (isModuleSymbol(defer->parentSymbol))
+      USR_FATAL_CONT(defer, "defer can only be used within a function");
+
+    // Make sure the DeferStmt does not include a break that is outside
+    // of a loop.
+
+    // Make sure that a DeferStmt never includes a return
+
+    CheckDeferVisitor visitor;
+    defer->body()->accept(&visitor);
+  }
+
+}

--- a/compiler/include/DeferStmt.h
+++ b/compiler/include/DeferStmt.h
@@ -51,4 +51,6 @@ private:
   BlockStmt*          _body;
 };
 
+void checkDefersAfterParsing();
+
 #endif

--- a/compiler/passes/checkParsed.cpp
+++ b/compiler/passes/checkParsed.cpp
@@ -21,12 +21,13 @@
 
 #include "passes.h"
 
-#include "stmt.h"
-#include "expr.h"
 #include "astutil.h"
-#include "stringutil.h"
-#include "stlUtil.h"
+#include "DeferStmt.h"
 #include "docsDriver.h"
+#include "expr.h"
+#include "stmt.h"
+#include "stlUtil.h"
+#include "stringutil.h"
 
 
 static void checkNamedArguments(CallExpr* call);
@@ -108,6 +109,8 @@ checkParsed() {
   }
 
   checkExportedNames();
+
+  checkDefersAfterParsing();
 }
 
 
@@ -353,5 +356,3 @@ checkExportedNames()
     names.put(name, true);
   }
 }
-
-


### PR DESCRIPTION
In particular, a defer statement containing a top-level 'break' or a
'return' not in an inner function is a program error that the compiler
should report.

Continues PR #6524.

Tests of this new functionality will be added in a following PR (#6526).

Reviewed by @noakesmichael - thanks!
Passed full local testing (along with PR #6526).