### PR TITLE
LLVM vectorization improvements

### DIFF
--- a/compiler/codegen/CForLoop.cpp
+++ b/compiler/codegen/CForLoop.cpp
@@ -40,6 +40,10 @@ static llvm::MDNode* generateLoopMetadata(bool vectorize)
   auto tmpNode        = llvm::MDNode::getTemporary(ctx, llvm::None);
   args.push_back(tmpNode.get());
 
+  // llvm.loop.vectorize.enable metadata is only used to either:
+  // 1) Explicitly disable vectorization of particular loop
+  // 2) Print warning when vectorization is enabled (using metadata) and vectorization didn't occur
+  // This means enabling vectorization using this metadata is not necessary for llvm vectorizer to vectorize loop
   if(vectorize)
   {
     llvm::Metadata *loopVectorizeEnable[] = { llvm::MDString::get(ctx, "llvm.loop.vectorize.enable"),
@@ -172,7 +176,7 @@ GenRet CForLoop::codegen()
 
     llvm::MDNode* loopMetadata = nullptr;
     if(fNoVectorize == false && isOrderIndependent()) {
-      loopMetadata = generateLoopMetadata(true);
+      loopMetadata = generateLoopMetadata(false);
       info->loopStack.emplace(loopMetadata, true);
     }
 

--- a/compiler/codegen/CForLoop.cpp
+++ b/compiler/codegen/CForLoop.cpp
@@ -31,7 +31,7 @@
 #ifdef HAVE_LLVM
 
 
-static llvm::MDNode* generateLoopMetadata(bool vectorize)
+static llvm::MDNode* generateLoopMetadata(bool addVectorizeEnableMetadata)
 {
   GenInfo* info = gGenInfo;
   auto &ctx = info->module->getContext();
@@ -44,7 +44,7 @@ static llvm::MDNode* generateLoopMetadata(bool vectorize)
   // 1) Explicitly disable vectorization of particular loop
   // 2) Print warning when vectorization is enabled (using metadata) and vectorization didn't occur
   // This means enabling vectorization using this metadata is not necessary for llvm vectorizer to vectorize loop
-  if(vectorize)
+  if(addVectorizeEnableMetadata)
   {
     llvm::Metadata *loopVectorizeEnable[] = { llvm::MDString::get(ctx, "llvm.loop.vectorize.enable"),
                                               llvm::ConstantAsMetadata::get(llvm::ConstantInt::get(llvm::Type::getInt1Ty(ctx), true))};

--- a/compiler/codegen/expr.cpp
+++ b/compiler/codegen/expr.cpp
@@ -389,6 +389,13 @@ llvm::StoreInst* codegenStoreLLVM(llvm::Value* val,
   llvm::MDNode* tbaa = NULL;
   if( USE_TBAA && valType ) tbaa = valType->symbol->llvmTbaaNode;
   if( tbaa ) ret->setMetadata(llvm::LLVMContext::MD_tbaa, tbaa);
+
+  if(!info->loopStack.empty()) {
+    const auto &loopData = info->loopStack.top();
+    if(loopData.parallel)
+      ret->setMetadata(StringRef("llvm.mem.parallel_loop_access"), loopData.loopMetadata);
+  }
+
   return ret;
 }
 
@@ -433,6 +440,13 @@ llvm::LoadInst* codegenLoadLLVM(llvm::Value* ptr,
     if( isConst ) tbaa = valType->symbol->llvmConstTbaaNode;
     else tbaa = valType->symbol->llvmTbaaNode;
   }
+
+  if(!info->loopStack.empty()) {
+    const auto &loopData = info->loopStack.top();
+    if(loopData.parallel)
+      ret->setMetadata(llvm::StringRef("llvm.mem.parallel_loop_access"), loopData.loopMetadata);
+  }
+
   if( tbaa ) ret->setMetadata(llvm::LLVMContext::MD_tbaa, tbaa);
   return ret;
 }

--- a/compiler/codegen/expr.cpp
+++ b/compiler/codegen/expr.cpp
@@ -392,6 +392,9 @@ llvm::StoreInst* codegenStoreLLVM(llvm::Value* val,
 
   if(!info->loopStack.empty()) {
     const auto &loopData = info->loopStack.top();
+    // Currently, the parallel_loop_access metadata refers to the
+    // innermost loop the instruction is in, while for some cases
+    // this could refer to the group of loops it is in.
     if(loopData.parallel)
       ret->setMetadata(StringRef("llvm.mem.parallel_loop_access"), loopData.loopMetadata);
   }

--- a/compiler/include/codegen.h
+++ b/compiler/include/codegen.h
@@ -45,6 +45,19 @@ class CCodeGenAction;
 
 #endif
 
+/* This class contains information helpful in generating
+ * code for nested loops. */
+struct LoopData
+{
+#ifdef HAVE_LLVM
+  LoopData(llvm::MDNode *loopMetadata, bool parallel)
+    : loopMetadata(loopMetadata), parallel(parallel)
+  { }
+  llvm::MDNode* loopMetadata;
+  bool parallel; /* There is no dependency between loops */
+#endif
+};
+
 /* GenInfo is meant to be a global variable which stores
  * the code generator state - e.g. FILE* to print C to
  * or LLVM module in which to generate.
@@ -77,6 +90,8 @@ struct GenInfo {
   llvm::Module *module;
   llvm::IRBuilder<> *builder;
   LayeredValueTable *lvt;
+
+  std::stack<LoopData> loopStack;
 
   // Clang Stuff
   std::string clangCC;

--- a/test/compflags/coodie/llvmPrintIr/llvmPrintIrBasic.chpl
+++ b/test/compflags/coodie/llvmPrintIr/llvmPrintIrBasic.chpl
@@ -1,4 +1,5 @@
 proc mainTest()
 {
+  writeln("Hello world!");
 }
 mainTest();

--- a/test/compflags/coodie/llvmPrintIr/llvmPrintIrFull.chpl
+++ b/test/compflags/coodie/llvmPrintIr/llvmPrintIrFull.chpl
@@ -1,4 +1,5 @@
 proc mainTest()
 {
+  writeln("Hello world!");
 }
 mainTest();

--- a/test/compflags/coodie/llvmPrintIr/llvmPrintIrNone.chpl
+++ b/test/compflags/coodie/llvmPrintIr/llvmPrintIrNone.chpl
@@ -1,4 +1,5 @@
 proc mainTest()
 {
+  writeln("Hello world!");
 }
 mainTest();


### PR DESCRIPTION
This branch introduces improvements to LLVM vectorization. 

Improvements relate to adding "llvm.mem.parallel_loop_access" metadata to instructions inside parallel loops. Specifically we add the metadata to loads and stores in loops marked as order independent (vectorizeOnly for example). There are two ways of adding metadata to loops:
1) Metadata refers to the innermost loop instruction is in.
2) Metadata refers to the stack of nested loops that instruction is in.

Implementation covers only 1).