### PR TITLE
Have DimensionalDist2D clean up after itself

### DIFF
--- a/modules/dists/DimensionalDist2D.chpl
+++ b/modules/dists/DimensionalDist2D.chpl
@@ -907,7 +907,7 @@ proc DimensionalArr.isAlias
   return this.dom != this.allocDom;
 
 
-//== creation
+//== creation and destruction
 
 // create a new array over this domain
 proc DimensionalDom.dsiBuildArray(type eltType)
@@ -928,6 +928,13 @@ proc DimensionalDom.dsiBuildArray(type eltType)
 
   assert(!result.isAlias);
   return result;
+}
+
+
+proc DimensionalDom.dsiDestroyDom() {
+  coforall desc in localDdescs do
+    on desc do
+      delete desc;
 }
 
 
@@ -1036,12 +1043,6 @@ proc DimensionalArr.dsiReallocate(d: domain) {
 
 proc DimensionalArr.dsiPostReallocate() {
   // nothing for now
-}
-
-proc DimensionalDom.dsiDestroyDom() {
-  coforall desc in localDdescs do
-    on desc do
-      delete desc;
 }
 
 proc DimensionalArr.dsiDestroyArr(isslice: bool) {

--- a/modules/dists/DimensionalDist2D.chpl
+++ b/modules/dists/DimensionalDist2D.chpl
@@ -1038,6 +1038,18 @@ proc DimensionalArr.dsiPostReallocate() {
   // nothing for now
 }
 
+proc DimensionalDom.dsiDestroyDom() {
+  coforall desc in localDdescs do
+    on desc do
+      delete desc;
+}
+
+proc DimensionalArr.dsiDestroyArr(isslice: bool) {
+  coforall desc in localAdescs do
+    on desc do
+      delete desc;
+}
+
 
 /// iterators ///////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
Implement the dsiDestroy*() routines for DimensionalDist2D in the obvious way
to have them clean up the per-locale local descriptors.

I'm not sure whether or not there's more that I'm missing, but this
makes a significant impact on our number 1 leaking test, schurComplement, and
passes correctness testing for all tests that use DimensionalDist2D.