### PR TITLE
Add DeferStmt to ASTVisitor & co

### DIFF
--- a/compiler/AST/AstCount.cpp
+++ b/compiler/AST/AstCount.cpp
@@ -257,6 +257,14 @@ bool AstCount::enterGotoStmt(GotoStmt* node) {
 void AstCount::exitGotoStmt(GotoStmt* node) {
 }
 
+bool AstCount::enterDeferStmt(DeferStmt* node) {
+  numDeferStmt++;
+  return true;
+}
+
+void AstCount::exitDeferStmt(DeferStmt* node) {
+}
+
 bool AstCount::enterTryStmt(TryStmt* node) {
   numTryStmt++;
   return true;

--- a/compiler/AST/AstDump.cpp
+++ b/compiler/AST/AstDump.cpp
@@ -524,6 +524,7 @@ bool AstDump::enterGotoStmt(GotoStmt* node) {
   return true;
 }
 
+
 //
 // ForwardingStmt
 //
@@ -534,6 +535,25 @@ bool AstDump::enterForwardingStmt(ForwardingStmt* node) {
 
 void AstDump::exitForwardingStmt(ForwardingStmt* node) {
   write(")");
+}
+
+
+//
+// DeferStmt
+//
+bool AstDump::enterDeferStmt(DeferStmt* node) {
+  newline();
+  write("Defer");
+  newline();
+  write("{");
+  ++mIndent;
+  return true;
+}
+
+void AstDump::exitDeferStmt(DeferStmt* node) {
+  --mIndent;
+  newline();
+  write("}");
 }
 
 

--- a/compiler/AST/AstLogger.cpp
+++ b/compiler/AST/AstLogger.cpp
@@ -196,6 +196,13 @@ bool AstLogger::enterForwardingStmt(ForwardingStmt* node) {
 void AstLogger::exitForwardingStmt(ForwardingStmt* node) {
 }
 
+bool AstLogger::enterDeferStmt(DeferStmt* node) {
+  return true;
+}
+
+void AstLogger::exitDeferStmt(DeferStmt* node) {
+}
+
 bool AstLogger::enterTryStmt(TryStmt* node) {
   return true;
 }

--- a/compiler/AST/AstVisitorTraverse.cpp
+++ b/compiler/AST/AstVisitorTraverse.cpp
@@ -273,6 +273,16 @@ void AstVisitorTraverse::exitForwardingStmt(ForwardingStmt* node)
 
 }
 
+bool AstVisitorTraverse::enterDeferStmt(DeferStmt* node)
+{
+  return true;
+}
+
+void AstVisitorTraverse::exitDeferStmt(DeferStmt* node)
+{
+
+}
+
 bool AstVisitorTraverse::enterTryStmt(TryStmt* node)
 {
   return true;

--- a/compiler/AST/CollapseBlocks.cpp
+++ b/compiler/AST/CollapseBlocks.cpp
@@ -402,6 +402,20 @@ void CollapseBlocks::exitForwardingStmt(ForwardingStmt* node)
 
 }
 
+bool CollapseBlocks::enterDeferStmt(DeferStmt* node)
+{
+  // Defer statements really need to be lowered *before*
+  // running CollapseBlocks. Otherwise, how can we know
+  // what variables or defer blocks are "in scope"?
+  INT_ASSERT("Defer statement discovered in CollapseBlocks");
+  return true;
+}
+
+void CollapseBlocks::exitDeferStmt(DeferStmt* node)
+{
+
+}
+
 bool CollapseBlocks::enterTryStmt(TryStmt* node)
 {
   return true;

--- a/compiler/AST/DeferStmt.cpp
+++ b/compiler/AST/DeferStmt.cpp
@@ -47,13 +47,13 @@ BlockStmt* DeferStmt::body() const {
 }
 
 void DeferStmt::accept(AstVisitor* visitor) {
-/*  if (visitor->enterDeferStmt(this)) {
+  if (visitor->enterDeferStmt(this)) {
     if (_body) {
       _body->accept(visitor);
     }
 
     visitor->exitDeferStmt(this);
-  }*/
+  }
 }
 
 DeferStmt* DeferStmt::copyInner(SymbolMap* map) {

--- a/compiler/include/AstCount.h
+++ b/compiler/include/AstCount.h
@@ -136,6 +136,9 @@ foreach_ast(decl_members);
   virtual bool   enterGotoStmt       (GotoStmt*          node);
   virtual void   exitGotoStmt        (GotoStmt*          node);
 
+  virtual bool   enterDeferStmt      (DeferStmt*         node);
+  virtual void   exitDeferStmt       (DeferStmt*         node);
+
   virtual bool   enterTryStmt        (TryStmt*           node);
   virtual void   exitTryStmt         (TryStmt*           node);
 

--- a/compiler/include/AstDump.h
+++ b/compiler/include/AstDump.h
@@ -99,6 +99,9 @@ public:
   virtual bool     enterForwardingStmt (ForwardingStmt*     node);
   virtual void     exitForwardingStmt  (ForwardingStmt*     node);
 
+  virtual bool     enterDeferStmt   (DeferStmt*         node);
+  virtual void     exitDeferStmt    (DeferStmt*         node);
+
   virtual bool     enterTryStmt     (TryStmt*           node);
   virtual void     exitTryStmt      (TryStmt*           node);
 

--- a/compiler/include/AstLogger.h
+++ b/compiler/include/AstLogger.h
@@ -120,6 +120,9 @@ public:
   virtual bool   enterForwardingStmt (ForwardingStmt*    node);
   virtual void   exitForwardingStmt  (ForwardingStmt*    node);
 
+  virtual bool   enterDeferStmt      (DeferStmt*         node);
+  virtual void   exitDeferStmt       (DeferStmt*         node);
+
   virtual bool   enterTryStmt        (TryStmt*           node);
   virtual void   exitTryStmt         (TryStmt*           node);
 

--- a/compiler/include/AstVisitor.h
+++ b/compiler/include/AstVisitor.h
@@ -52,6 +52,7 @@ class ExternBlockStmt;
 class CondStmt;
 class GotoStmt;
 class ForwardingStmt;
+class DeferStmt;
 class TryStmt;
 class CatchStmt;
 
@@ -158,6 +159,9 @@ public:
 
   virtual bool   enterGotoStmt       (GotoStmt*          node) = 0;
   virtual void   exitGotoStmt        (GotoStmt*          node) = 0;
+
+  virtual bool   enterDeferStmt      (DeferStmt*         node) = 0;
+  virtual void   exitDeferStmt       (DeferStmt*         node) = 0;
 
   virtual bool   enterTryStmt        (TryStmt*           node) = 0;
   virtual void   exitTryStmt         (TryStmt*           node) = 0;

--- a/compiler/include/AstVisitorTraverse.h
+++ b/compiler/include/AstVisitorTraverse.h
@@ -128,6 +128,9 @@ public:
   virtual bool   enterForwardingStmt (ForwardingStmt*    node);
   virtual void   exitForwardingStmt  (ForwardingStmt*    node);
 
+  virtual bool   enterDeferStmt      (DeferStmt*         node);
+  virtual void   exitDeferStmt       (DeferStmt*         node);
+
   virtual bool   enterTryStmt        (TryStmt*           node);
   virtual void   exitTryStmt         (TryStmt*           node);
 

--- a/compiler/include/CollapseBlocks.h
+++ b/compiler/include/CollapseBlocks.h
@@ -116,6 +116,9 @@ public:
   virtual bool   enterForwardingStmt (ForwardingStmt*    node);
   virtual void   exitForwardingStmt  (ForwardingStmt*    node);
 
+  virtual bool   enterDeferStmt      (DeferStmt*         node);
+  virtual void   exitDeferStmt       (DeferStmt*         node);
+
   virtual bool   enterTryStmt        (TryStmt*           node);
   virtual void   exitTryStmt         (TryStmt*           node);
 


### PR DESCRIPTION
Continuing PR #6526, this PR adds support for `defer` statements
to ASTVisitor and the derived AST visitors.

Passed full local testing

Reviewed by @noakesmichael - thanks!