### PR TITLE
Improve addAutoDestroyCalls for loops that break

### DIFF
--- a/compiler/resolution/addAutoDestroyCalls.cpp
+++ b/compiler/resolution/addAutoDestroyCalls.cpp
@@ -199,6 +199,7 @@ static void walkBlock(FnSymbol*         fn,
           case GOTO_RETURN:
           case GOTO_CONTINUE:
           case GOTO_BREAK:
+          case GOTO_ERROR_HANDLING:
             scope.insertAutoDestroys(fn, stmt);
             break;
 
@@ -206,7 +207,6 @@ static void walkBlock(FnSymbol*         fn,
           case GOTO_GETITER_END:
           case GOTO_ITER_RESUME:
           case GOTO_ITER_END:
-          case GOTO_ERROR_HANDLING:
            // MDN 2016/03/18 Need to revisit these cases
            break;
         }

--- a/test/types/records/ferguson/deinit/break-in-do-while.chpl
+++ b/test/types/records/ferguson/deinit/break-in-do-while.chpl
@@ -1,0 +1,26 @@
+record R {
+  var x: int;
+  proc deinit() {
+    writeln("Destroying ", x);
+  }
+}
+
+proc foo() {
+
+  var count = 0;
+
+  do {
+    writeln("creating 1");
+    var one = new R(1);
+    
+    break;
+
+    writeln("creating 2");
+    var two = new R(2);
+
+    count += 1;
+
+  } while count < 2;
+}
+
+foo();

--- a/test/types/records/ferguson/deinit/break-in-do-while.future
+++ b/test/types/records/ferguson/deinit/break-in-do-while.future
@@ -1,0 +1,3 @@
+bug: do-while with break does not work right
+
+see issue #6535

--- a/test/types/records/ferguson/deinit/break-in-do-while.good
+++ b/test/types/records/ferguson/deinit/break-in-do-while.good
@@ -1,0 +1,2 @@
+creating 1
+Destroying 1

--- a/test/types/records/ferguson/deinit/break-in-for-iter1.bad
+++ b/test/types/records/ferguson/deinit/break-in-for-iter1.bad
@@ -1,0 +1,6 @@
+Creating 0
+Creating 1
+1
+Destroying 1
+Creating 2
+2

--- a/test/types/records/ferguson/deinit/break-in-for-iter1.chpl
+++ b/test/types/records/ferguson/deinit/break-in-for-iter1.chpl
@@ -1,0 +1,33 @@
+record R {
+  var x: int;
+  proc init(x:int) {
+    this.x = x;
+    super.init();
+    writeln("Creating ", x);
+  }
+  proc deinit() {
+    writeln("Destroying ", x);
+  }
+}
+
+iter myIter() {
+  var r = new R(0);
+
+  for i in 1..10 {
+    var r2 = new R(i);
+    yield i;
+  }
+}
+
+config const breakOnIter = 2;
+
+proc foo() {
+
+  for i in myIter() {
+    writeln(i);
+    if i == breakOnIter then
+      break;
+  }
+}
+
+foo();

--- a/test/types/records/ferguson/deinit/break-in-for-iter1.future
+++ b/test/types/records/ferguson/deinit/break-in-for-iter1.future
@@ -1,0 +1,3 @@
+bug: iterator locals not deinitialized if caller breaks
+
+see issue #6540

--- a/test/types/records/ferguson/deinit/break-in-for-iter1.good
+++ b/test/types/records/ferguson/deinit/break-in-for-iter1.good
@@ -1,0 +1,8 @@
+Creating 0
+Creating 1
+1
+Destroying 1
+Creating 2
+2
+Destroying 2
+Destroying 0

--- a/test/types/records/ferguson/deinit/break-in-for-iter2.bad
+++ b/test/types/records/ferguson/deinit/break-in-for-iter2.bad
@@ -1,0 +1,2 @@
+Creating 0
+Creating 1

--- a/test/types/records/ferguson/deinit/break-in-for-iter2.chpl
+++ b/test/types/records/ferguson/deinit/break-in-for-iter2.chpl
@@ -1,0 +1,29 @@
+record R {
+  var x: int;
+  proc init(x:int) {
+    this.x = x;
+    super.init();
+    writeln("Creating ", x);
+  }
+  proc deinit() {
+    writeln("Destroying ", x);
+  }
+}
+
+iter myIter() {
+  var r = new R(0);
+
+  for i in 1..10 {
+    var r2 = new R(i);
+    yield i;
+  }
+}
+
+proc foo() {
+
+  for i in myIter() {
+    break;
+  }
+}
+
+foo();

--- a/test/types/records/ferguson/deinit/break-in-for-iter2.future
+++ b/test/types/records/ferguson/deinit/break-in-for-iter2.future
@@ -1,0 +1,3 @@
+bug: iterator locals not deinitialized if caller breaks
+
+see issue #6540

--- a/test/types/records/ferguson/deinit/break-in-for-iter2.good
+++ b/test/types/records/ferguson/deinit/break-in-for-iter2.good
@@ -1,0 +1,4 @@
+Creating 0
+Creating 1
+Destroying 1
+Destroying 0

--- a/test/types/records/ferguson/deinit/break-in-for.chpl
+++ b/test/types/records/ferguson/deinit/break-in-for.chpl
@@ -1,0 +1,23 @@
+record R {
+  var x: int;
+  proc deinit() {
+    writeln("Destroying ", x);
+  }
+}
+
+proc foo() {
+
+  var count = 0;
+
+  for count in 1..2 {
+    writeln("creating 1");
+    var one = new R(1);
+    
+    break;
+
+    writeln("creating 2");
+    var two = new R(2);
+  }
+}
+
+foo();

--- a/test/types/records/ferguson/deinit/break-in-for.good
+++ b/test/types/records/ferguson/deinit/break-in-for.good
@@ -1,0 +1,2 @@
+creating 1
+Destroying 1

--- a/test/types/records/ferguson/deinit/break-in-while.chpl
+++ b/test/types/records/ferguson/deinit/break-in-while.chpl
@@ -1,0 +1,26 @@
+record R {
+  var x: int;
+  proc deinit() {
+    writeln("Destroying ", x);
+  }
+}
+
+proc foo() {
+
+  var count = 0;
+
+  while count < 1 {
+    writeln("creating 1");
+    var one = new R(1);
+    
+    break;
+
+    writeln("creating 2");
+    var two = new R(2);
+
+    count += 1;
+
+  }
+}
+
+foo();

--- a/test/types/records/ferguson/deinit/break-in-while.good
+++ b/test/types/records/ferguson/deinit/break-in-while.good
@@ -1,0 +1,2 @@
+creating 1
+Destroying 1

--- a/test/types/records/ferguson/deinit/for-iter.chpl
+++ b/test/types/records/ferguson/deinit/for-iter.chpl
@@ -1,0 +1,29 @@
+record R {
+  var x: int;
+  proc init(x:int) {
+    this.x = x;
+    super.init();
+    writeln("Creating ", x);
+  }
+  proc deinit() {
+    writeln("Destroying ", x);
+  }
+}
+
+iter myIter() {
+  var r = new R(0);
+
+  for i in 1..3 {
+    var r2 = new R(i);
+    yield i;
+  }
+}
+
+proc foo() {
+
+  for i in myIter() {
+    writeln(i);
+  }
+}
+
+foo();

--- a/test/types/records/ferguson/deinit/for-iter.good
+++ b/test/types/records/ferguson/deinit/for-iter.good
@@ -1,0 +1,11 @@
+Creating 0
+Creating 1
+1
+Destroying 1
+Creating 2
+2
+Destroying 2
+Creating 3
+3
+Destroying 3
+Destroying 0

--- a/test/types/records/ferguson/deinit/return-in-do-while.chpl
+++ b/test/types/records/ferguson/deinit/return-in-do-while.chpl
@@ -1,0 +1,26 @@
+record R {
+  var x: int;
+  proc deinit() {
+    writeln("Destroying ", x);
+  }
+}
+
+proc foo() {
+
+  var count = 0;
+
+  do {
+    writeln("creating 1");
+    var one = new R(1);
+    
+    return;
+
+    writeln("creating 2");
+    var two = new R(2);
+
+    count += 1;
+
+  } while count < 2;
+}
+
+foo();

--- a/test/types/records/ferguson/deinit/return-in-do-while.future
+++ b/test/types/records/ferguson/deinit/return-in-do-while.future
@@ -1,0 +1,3 @@
+bug: do-while with return does not work right
+
+see issue #6535

--- a/test/types/records/ferguson/deinit/return-in-do-while.good
+++ b/test/types/records/ferguson/deinit/return-in-do-while.good
@@ -1,0 +1,2 @@
+creating 1
+Destroying 1

--- a/test/types/records/ferguson/deinit/return-in-for.chpl
+++ b/test/types/records/ferguson/deinit/return-in-for.chpl
@@ -1,0 +1,23 @@
+record R {
+  var x: int;
+  proc deinit() {
+    writeln("Destroying ", x);
+  }
+}
+
+proc foo() {
+
+  var count = 0;
+
+  for count in 1..2 {
+    writeln("creating 1");
+    var one = new R(1);
+    
+    return;
+
+    writeln("creating 2");
+    var two = new R(2);
+  }
+}
+
+foo();

--- a/test/types/records/ferguson/deinit/return-in-for.good
+++ b/test/types/records/ferguson/deinit/return-in-for.good
@@ -1,0 +1,2 @@
+creating 1
+Destroying 1

--- a/test/types/records/ferguson/deinit/return-in-while.chpl
+++ b/test/types/records/ferguson/deinit/return-in-while.chpl
@@ -1,0 +1,26 @@
+record R {
+  var x: int;
+  proc deinit() {
+    writeln("Destroying ", x);
+  }
+}
+
+proc foo() {
+
+  var count = 0;
+
+  while count < 1 {
+    writeln("creating 1");
+    var one = new R(1);
+    
+    return;
+
+    writeln("creating 2");
+    var two = new R(2);
+
+    count += 1;
+
+  }
+}
+
+foo();

--- a/test/types/records/ferguson/deinit/return-in-while.good
+++ b/test/types/records/ferguson/deinit/return-in-while.good
@@ -1,0 +1,2 @@
+creating 1
+Destroying 1

--- a/test/types/records/ferguson/leak-futures/iterate-loop-break.future
+++ b/test/types/records/ferguson/leak-futures/iterate-loop-break.future
@@ -1,1 +1,3 @@
 bug: iterator 1 leaks memory if caller breaks out of loop
+
+see issue #6540

--- a/test/types/records/ferguson/leak-futures/iterate-loop-break2.future
+++ b/test/types/records/ferguson/leak-futures/iterate-loop-break2.future
@@ -1,1 +1,3 @@
 bug: iterator 2 leaks memory if caller breaks out of loop
+
+see issue #6540

--- a/test/types/records/ferguson/leak-futures/iterate-twice-break.future
+++ b/test/types/records/ferguson/leak-futures/iterate-twice-break.future
@@ -1,1 +1,3 @@
 bug: non-inlined iterator leaks memory if caller breaks out of loop
+
+see issue #6540


### PR DESCRIPTION
Improve addAutoDestroyCalls to better handle loops. The previous implementation was running in to problems with simple loops that ended it a single goto statement (i.e. a loop body ending in a `break`). This PR resolves this issue, adds tests that now pass, and also adds some related futures.

Passed full local testing.
Reviewed by @noakesmichael - thanks!