### PR TITLE
Fix for multilocale timing in PRK-DGEMM

### DIFF
--- a/test/studies/prk/DGEMM/dgemm.chpl
+++ b/test/studies/prk/DGEMM/dgemm.chpl
@@ -87,7 +87,7 @@ else {
             CC: [blockDom] dtype;
 
         for niter in 0..iterations {
-          if tid==0 && niter==1 then t.start();
+          if here.id==0 && tid==0 && niter==1 then t.start();
 
           for (jj,kk) in {myChunk by blockSize, vecRange by blockSize} {
             const jMax = min(jj+blockSize-1, myChunk.high);


### PR DESCRIPTION
PRK-DGEMM was coded to run in a multilocale setting but wasn't tested. I discovered a bug in starting the timer for multilocale setup and fixed it in this PR.

P.S. This PR does *not* add multilocale testing.

The test in question passes with standard linux64 config.