### PR TITLE
makeBinaryLLVM: initialize `point` to avoid a GCC error

### DIFF
--- a/compiler/util/clangUtil.cpp
+++ b/compiler/util/clangUtil.cpp
@@ -2062,7 +2062,11 @@ void makeBinaryLLVM(void) {
     PassManagerBuilder::addGlobalExtension(PassManagerBuilder::EP_EnabledOnOptLevel0, addGlobalToWide);
 
     // Add IR dumping pass if necessary
-    PassManagerBuilder::ExtensionPointTy point;
+    // point is initialized to a dummy value; it is set
+    // in getIrDumpExtensionPoint.
+    PassManagerBuilder::ExtensionPointTy point =
+                  PassManagerBuilder::EP_EarlyAsPossible;
+
     if (getIrDumpExtensionPoint(llvmPrintIrStageNum, point)) {
       printf("Adding IR dump extension at %i for %s\n", point, llvmPrintIrCName);
       PassManagerBuilder::addGlobalExtension(point, addDumpIrPass);


### PR DESCRIPTION
To resolve a failure from nightly testing. Reproduced the error and checked that this resolves it.

Note that the error was only visible with
  `make WARNINGS=1 OPTIMIZE=1`

which is not the default build setting I normally use. Travis would have caught this, but it doesn't build with CHPL_LLVM=llvm.

Trivial and not reviewed.
