### PR TITLE
Add a future with Brad's request for the omitted initialization insertion point

### DIFF
--- a/test/classes/initializers/phase1/loopUpdate.bad
+++ b/test/classes/initializers/phase1/loopUpdate.bad
@@ -1,0 +1,2 @@
+loopUpdate.chpl:5: In initializer:
+loopUpdate.chpl:7: error: Field used before it is initialized

--- a/test/classes/initializers/phase1/loopUpdate.chpl
+++ b/test/classes/initializers/phase1/loopUpdate.chpl
@@ -1,0 +1,16 @@
+class Params {
+  var numProbSizes: int;
+  var N: [1..numProbSizes] int;
+
+  proc init() {
+    numProbSizes = 3;
+    for n in N do n = 10;
+    super.init();
+  }
+}
+
+var ListOfParams = new Params();
+
+writeln(ListOfParams);
+
+delete ListOfParams;

--- a/test/classes/initializers/phase1/loopUpdate.future
+++ b/test/classes/initializers/phase1/loopUpdate.future
@@ -1,0 +1,12 @@
+feature request: omitted initialization insertion point
+
+Brad suggested that it might be good to have code like this be valid.  The
+compiler is already inserting omitted initialization for the array, but the
+current implementation places the omitted initialization right before the
+super.init() call, making the `for` loop access a field before it has been
+initialized.  If the omitted initialization was placed right after the last
+initialized field, then the `for` loop would be valid.
+
+Is this desirable, or letting users write a bug?  Should this be part of the
+specification, or left as an implementation detail (and so maybe undefined
+behavior)?  See discussion in https://github.com/chapel-lang/chapel/issues/6568

--- a/test/classes/initializers/phase1/loopUpdate.good
+++ b/test/classes/initializers/phase1/loopUpdate.good
@@ -1,0 +1,1 @@
+{numProbSizes = 3, N = 10 10 10}


### PR DESCRIPTION
Brad thinks we should have omitted initialization be inserted right after the
last explicit initialization, rather than just before the next or the
`super.init()` call (as it is today).  This would enable loops like the one in
this test to be Phase 1 operations, as the initialization would occur prior to
their operation.