### PR TITLE
Do not reap module that contain a single type definition

### DIFF
--- a/test/users/engin/deadModuleWithEnum/deadModuleWithEnum.bad
+++ b/test/users/engin/deadModuleWithEnum/deadModuleWithEnum.bad
@@ -1,7 +1,0 @@
-internal error: DEAnnnn chpl Version mmmm
-
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
-and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
-please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
-

--- a/test/users/engin/deadModuleWithEnum/deadModuleWithEnum.future
+++ b/test/users/engin/deadModuleWithEnum/deadModuleWithEnum.future
@@ -1,1 +1,0 @@
-bug: dead module with an enum causes internal error


### PR DESCRIPTION
Before this PR deadCodeElimination would generate an internal error if it encountered
a module with precisely 1 definition and that definition was not the module init function.

Meanwhile the compiler will remove the module init function for a module that consists
solely of type declarations.  The edge case for deadModule() is then a module with a
single type declaration.

This simple PR merely accepts this edge case and retains the type and the module.
More analysis could be used to determine if it is safe to remove the type and then the
module.

It also retires the future that had been created for this edge case.

Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.
Ran start_test over a small portion of release/ for all 4 configurations.
Passed a single-locale paratest on gcc/linux64 with futures.
