### PR TITLE
Update tests to use explicit initializers instead of constructors, part 2

### DIFF
--- a/test/classes/forwarding/dynDispatchVsForward.chpl
+++ b/test/classes/forwarding/dynDispatchVsForward.chpl
@@ -18,7 +18,7 @@ class E: C {
   forwarding var myD: D;
 }
 
-proc E.E() {
+proc E.init() {
   myD = new D();
 }
 

--- a/test/release/examples/benchmarks/lcals/LCALSDataTypes.chpl
+++ b/test/release/examples/benchmarks/lcals/LCALSDataTypes.chpl
@@ -120,7 +120,7 @@ module LCALSDataTypes {
     var real_zones: [zoneDom] int;
     var n_real_zones: int;
 
-    proc ADomain(ilen: LoopLength, ndims: int) {
+    proc init(ilen: LoopLength, ndims: int) {
       var rzmax: int;
       this.ndims = ndims;
       NPNL = 2;

--- a/test/release/examples/benchmarks/lcals/Timer.chpl
+++ b/test/release/examples/benchmarks/lcals/Timer.chpl
@@ -72,7 +72,7 @@ module Timer {
     var t: TimerImpl;
     var was_run: bool;
 
-    proc LoopTimer(timerType: TimerType = defaultTimerType) {
+    proc init(timerType: TimerType = defaultTimerType) {
       if timerType == TimerType.Chapel {
         t = new ChapelTimer();
       } else if timerType == TimerType.Clock then {


### PR DESCRIPTION
Mike fixed the bug with `new` statements, so these constructors could
safely be converted to initializers.

Passed a clean checkout.