### PR TITLE
PRK Sparse Distributed

### DIFF
--- a/test/GRAPHFILES
+++ b/test/GRAPHFILES
@@ -169,10 +169,12 @@ studies/isx/isx-no-return.graph
 studies/isx/isx-per-task.graph
 release/examples/benchmarks/isx/isx-release.graph
 # suite: PRK benchmarks
-studies/prk/Synch_p2p/prk-synch_p2p.graph
-studies/prk/Synch_p2p/prk-synch_p2p-time.graph
+studies/prk/Sparse/prk-sparse.graph
+studies/prk/Sparse/prk-sparse-time.graph
 studies/prk/Stencil/prk-stencil.graph
 studies/prk/Stencil/prk-stencil-time.graph
+studies/prk/Synch_p2p/prk-synch_p2p.graph
+studies/prk/Synch_p2p/prk-synch_p2p-time.graph
 studies/prk/Transpose/prk-transpose.graph
 studies/prk/Transpose/prk-transpose-time.graph
 # suite: NAS Parallel benchmarks

--- a/test/studies/prk/Sparse/prk-sparse-time.graph
+++ b/test/studies/prk/Sparse/prk-sparse-time.graph
@@ -1,0 +1,5 @@
+perfkeys: Avg time (s): 
+files: sparse-csr.dat
+graphkeys: CSR
+graphtitle: PRK sparse time
+ylabel: Time (seconds)

--- a/test/studies/prk/Sparse/prk-sparse.graph
+++ b/test/studies/prk/Sparse/prk-sparse.graph
@@ -1,0 +1,5 @@
+perfkeys: Rate (MFlops/s):
+files: sparse-csr.dat
+graphkeys: CSR
+graphtitle: PRK sparse
+ylabel: Rate (MFlops/s)

--- a/test/studies/prk/Sparse/sparse.chpl
+++ b/test/studies/prk/Sparse/sparse.chpl
@@ -39,8 +39,8 @@ var rowDistLocArr: [rowDistLocDom] locale;
 rowDistLocArr[0..#numLocales, 0] = Locales[0..#numLocales];
 
 // Domains & Distributions
-const vectorSpace = {0..#size2},
-      matrixSpace = {0..#size2, 0..#size2},
+const vectorSpace = {1..size2},
+      matrixSpace = {1..size2, 1..size2},
       resultDist = if distributed then new dmap(new Block(vectorSpace))
                    else defaultDist,
       parentDist = new dmap(new Block(matrixSpace,
@@ -75,7 +75,7 @@ proc main() {
 
     // Update vector (across locales for distributed case)
     coforall loc in Locales do on loc {
-      [i in vectorDom] vector[i] += i+1;
+      [i in vectorDom] vector[i] += i;
     }
 
     forall i in resultDom {
@@ -103,7 +103,8 @@ proc initialize() {
   var indBuf: [indBufDom] 2*int;
 
   // Initialize sparse domain
-  for row in vectorSpace {
+  for v in vectorSpace {
+    const row = v - 1;
     const i = row%size,
           j = row/size;
 
@@ -118,6 +119,7 @@ proc initialize() {
       bufIdx += 4;
     }
   }
+  indBuf += (1, 1);
   if distributed {
     matrixDom.bulkAdd(indBuf, preserveInds=false);
   } else {
@@ -130,9 +132,9 @@ proc initialize() {
 
   // Initialize sparse matrix values
   if distributed {
-    [(i,j) in matrixDom] matrix[i,j] = 1.0/(j+1);
+    [(i,j) in matrixDom] matrix[i,j] = 1.0/(j);
   } else {
-    [(i,j) in matrixDomCSR] matrix[i,j] = 1.0/(j+1);
+    [(i,j) in matrixDomCSR] matrix[i,j] = 1.0/(j);
   }
 
   t.stop();

--- a/test/studies/prk/Sparse/sparse.chpl
+++ b/test/studies/prk/Sparse/sparse.chpl
@@ -4,16 +4,23 @@
    Contributed by Engin Kayraklioglu (GWU)
 */
 use BlockDist;
-use Time;
 use LayoutCSR;
+use ReplicatedDist;
+use Time;
+use VisualDebug;
 
 param PRKVERSION = "2.17";
 
-config const lsize = 5,
+             /* Logarithmic linear size of grid, s.t. numElements = 4**lsize */
+config const lsize = 4,
+             /* Designates number of non-zeroes per row (4*r + 1)*/
              radius = 2,
-             iterations = 10,
-             correctness = false,
-             scramble = true;
+             /* Number of times multiplication is performed */
+             iterations = 2,
+             /* Convert all linearized grid indices by reversing their bits */
+             scramble = true,
+             /* Only print correctness string */
+             correctness = false;
 
 const lsize2 = 2*lsize,
       size = 1<<lsize,
@@ -21,93 +28,150 @@ const lsize2 = 2*lsize,
       stencilSize = 4*radius+1,
       sparsity = stencilSize:real/size2;
 
-// create vector domain
-const vectorDom = {0..#size2};
+const rowDistLocDom = {0..#numLocales, 0..0};
+var rowDistLocArr: [rowDistLocDom] locale;
+rowDistLocArr[0..#numLocales, 0] = Locales[0..#numLocales];
 
-const parentDom = {0..#size2, 0..#size2};
-var matrixDom: sparse subdomain(parentDom) dmapped CSR();
+const vectorSpace = 0..#size2,
+      vectorDom = {vectorSpace},
+      vectorDomRepl = vectorDom dmapped Replicated(),
+      parentDom = {vectorSpace, vectorSpace} dmapped Block({vectorSpace, vectorSpace}, rowDistLocArr, sparseLayoutType=CSR);
 
-// temporary index buffer for fast initialization
-const indBufDom = {0..#(size2*stencilSize)};
-var indBuf: [indBufDom] 2*int;
+//config const N = 8;
+//config type sparseLayoutType = DefaultDist;
+//const ParentDom = {0..#N, 0..#N} dmapped Block({0..#N, 0..#N}, sparseLayoutType=sparseLayoutType);
+//var SparseDom: sparse subdomain(ParentDom);
+//var SparseMat: [SparseDom] int;
+//var diagInds: [{0..#N*2}] 2*int;
 
-//initialize sparse domain
-for row in 0..#size2 {
-  const i = row%size;
-  const j = row/size;
+//const dist = if CHPL_COMM=='none' then CSR() else
+const matrixDom: sparse subdomain(parentDom);
 
-  var bufIdx = row*stencilSize;
-
-  indBuf[bufIdx] = (row, reverse(LIN(i,j)));
-  for r in 1..radius {
-    indBuf[bufIdx+1] = (row, reverse(LIN((i+r)%size,j)));
-    indBuf[bufIdx+2] = (row, reverse(LIN((i-r+size)%size,j)));
-    indBuf[bufIdx+3] = (row, reverse(LIN(i, (j+r)%size)));
-    indBuf[bufIdx+4] = (row, reverse(LIN(i, (j-r+size)%size)));
-    bufIdx += 4;
-  }
-}
-matrixDom.bulkAdd(indBuf, preserveInds=false);
-
-//do a sanitiy check to make sure we have created correct numver of
-//indicese in the sparse domain
-if matrixDom.numIndices != size2*stencilSize then
-  halt("Incorrect number of indices created");
-
-var matrix: [matrixDom] real;
-[(i,j) in matrixDom] matrix[i,j] = 1.0/(j+1);
-
-var vector: [vectorDom] real;
-var result: [vectorDom] real;
-vector = 0;
-result = 0;
-
-if !correctness {
-  // Print information before main loop
-  writeln("Parallel Research Kernels Version ", PRKVERSION);
-  writeln("Sparse matrix-dense vector multiplication");
-  writeln("Max parallelism      = ", here.maxTaskPar);
-  writeln("Matrix order         = ", size2);
-  writeln("Stencil diameter     = ", 2*radius+1);
-  writeln("Sparsity             = ", sparsity);
-  writeln("Number of iterations = ", iterations);
-  writeln("Indexes are ", if !scramble then "not " else "", "scrambled");
-}
+var matrix: [matrixDom] real,
+    vector: [vectorDom] real,
+    vectorRepl: [vectorDomRepl] real,
+    result: [vectorDom] real;
 
 var t = new Timer();
-for niter in 0..iterations {
 
-  if niter == 1 then t.start();
-  [i in vectorDom] vector[i] += i+1;
+proc main() {
 
-  forall i in matrix.domain.dim(1) do
-    for j in matrix.domain.dimIter(2,i) do
-    result[i] += matrix[i,j] * vector[j];
+  t.start();
+  initialize();
+  t.stop();
+
+  writeln('Initialization time: ', t.elapsed());
+  t.clear();
+
+  printInfo();
+
+  startVdebug('kernel');
+  for niter in 0..iterations {
+
+    if niter == 1 then t.start();
+
+    [i in vectorDom] vector[i] += i+1;
+
+    // Replicate across all locales
+    forall (r,v) in zip(vectorRepl,vector) do r = v;
+
+    forall i in matrixDom.dim(1) {
+      var temp = 0.0;
+      for j in matrixDom.dimIter(2,i) {
+        temp += matrix[i,j] * vectorRepl[j];
+      }
+      result[i] += temp;
+    }
+  }
+  t.stop();
+  stopVdebug();
+
+  verifyResult();
 }
-t.stop();
 
-// verify the result
-const epsilon = 1e-8;
-const referenceSum = 0.5 * matrixDom.numIndices * (iterations+1) *
-    (iterations+2);
-const vectorSum = + reduce result;
-if abs(vectorSum-referenceSum) > epsilon then
-  halt("VALIDATION FAILED!. Reference sum = ", referenceSum,
-      " Vector sum = ", vectorSum);
 
-writeln("Validation successful");
+proc initialize() {
+  // Temporary index buffer for fast initialization
+  const indBufDom = {0..#(size2*stencilSize)};
+  var indBuf: [indBufDom] 2*int;
 
-if !correctness {
-  const nflop = 2.0*matrixDom.numIndices;
-  const avgTime = t.elapsed()/iterations;
-  writeln("Rate (MFlops/s): ", 1e-6*nflop/avgTime, " Avg time (s): ",
-      avgTime);
+  // Initialize sparse domain
+  for row in vectorSpace {
+    const i = row%size,
+          j = row/size;
+
+    var bufIdx = row*stencilSize;
+
+    indBuf[bufIdx] = (row, reverse(LIN(i,j)));
+    for r in 1..radius {
+      indBuf[bufIdx+1] = (row, reverse(LIN((i+r)%size,j)));
+      indBuf[bufIdx+2] = (row, reverse(LIN((i-r+size)%size,j)));
+      indBuf[bufIdx+3] = (row, reverse(LIN(i, (j+r)%size)));
+      indBuf[bufIdx+4] = (row, reverse(LIN(i, (j-r+size)%size)));
+      bufIdx += 4;
+    }
+  }
+  matrixDom.bulkAdd(indBuf, preserveInds=false);
+
+  // Sanity check the number of indices in the sparse domain
+  if matrixDom.numIndices != size2*stencilSize then
+    halt("Incorrect number of indices created");
+
+  // Initialize sparse matrix values
+  [(i,j) in matrixDom] matrix[i,j] = 1.0/(j+1);
 }
 
+
+proc printInfo() {
+  if !correctness {
+    writeln("Parallel Research Kernels Version ", PRKVERSION);
+    writeln("Sparse matrix-dense vector multiplication");
+    writeln("Max parallelism      = ", here.maxTaskPar);
+    writeln("Matrix order         = ", size2);
+    writeln("Stencil diameter     = ", 2*radius+1);
+    writeln("Sparsity             = ", sparsity);
+    writeln("Number of iterations = ", iterations);
+    writeln("Indexes are ", if !scramble then "not " else "", "scrambled");
+  }
+}
+
+
+proc verifyResult() {
+  const epsilon = 1e-8;
+  const referenceSum = 0.5 * matrixDom.numIndices * (iterations+1) *
+      (iterations+2);
+  const vectorSum = + reduce result;
+  if abs(vectorSum-referenceSum) > epsilon then
+    halt("VALIDATION FAILED!. Reference sum = ", referenceSum,
+        " Vector sum = ", vectorSum);
+
+  writeln("Validation successful");
+
+  if !correctness {
+    const nflop = 2.0*matrixDom.numIndices;
+    const avgTime = t.elapsed()/iterations;
+    writeln("Rate (MFlops/s): ", 1e-6*nflop/avgTime, " Avg time (s): ",
+        avgTime);
+  }
+}
+
+
+/* Linearize grid index */
 inline proc LIN(i, j) {
   return (i+(j<<lsize));
 }
 
+/* Code below reverses bits in unsigned integer stored in a 64-bit word.
+   Bit reversal is with respect to the largest integer that is going to be
+   ranked for the particular run of the code, to make sure the reversal
+   constitutes a true permutation. Hence, the final result needs to be shifted
+   to the right.
+   Example: if largest integer being processed is 0x000000ff = 255 =
+   0000...0011111111 (binary), then the unshifted reversal of 0x00000006 = 6 =
+   0000...0000000110 (binary) would be 011000000...0000 = 3*2^61, which is
+   outside the range of the original sequence 0-255. Setting shift_in_bits to
+   2log(256) = 8, the final result is shifted the the right by 64-8=56 bits,
+   so we get 000...0001100000 (binary) = 96, which is within the proper range */
 proc reverse(xx) {
   if !scramble then return xx;
 
@@ -121,3 +185,15 @@ proc reverse(xx) {
   x = ((x >> 32) & 0x00000000ffffffff) | ((x << 32) & 0xffffffff00000000);
   return (x>>(64-lsize2)):int;
 }
+
+// TODO add prefetch checks for fast iteration
+iter SparseBlockDom.dimIter(param dim, idx) {
+  var targetLocRow = dist.targetLocsIdx((idx, whole.dim(dim).low));
+  /*writeln("dimIter idx: ", idx, " targetLocRow ", targetLocRow);*/
+  for l in dist.targetLocales.domain.dim(dim) {
+    for idx in locDoms[(targetLocRow[1], l)].mySparseBlock.dimIter(dim, idx) {
+      yield idx;
+    }
+  }
+}
+

--- a/test/studies/prk/Sparse/sparse.compopts
+++ b/test/studies/prk/Sparse/sparse.compopts
@@ -1,2 +1,2 @@
--s correctness=true
--s correctness=true -s scramble=false
+-s correctness=true -s -s VisualDebugOn=false
+-s correctness=true -s scramble=false -s VisualDebugOn=false

--- a/test/studies/prk/Sparse/sparse.compopts
+++ b/test/studies/prk/Sparse/sparse.compopts
@@ -1,0 +1,2 @@
+-s correctness=true
+-s correctness=true -s scramble=false

--- a/test/studies/prk/Sparse/sparse.compopts
+++ b/test/studies/prk/Sparse/sparse.compopts
@@ -1,2 +1,2 @@
--s correctness=true -s -s VisualDebugOn=false
+-s correctness=true -s VisualDebugOn=false
 -s correctness=true -s scramble=false -s VisualDebugOn=false

--- a/test/studies/prk/Sparse/sparse.execopts
+++ b/test/studies/prk/Sparse/sparse.execopts
@@ -1,1 +1,0 @@
---correctness --iterations=2 --lsize=3

--- a/test/studies/prk/Sparse/sparse.perfcompopts
+++ b/test/studies/prk/Sparse/sparse.perfcompopts
@@ -1,1 +1,1 @@
--s iterations=10 -s lsize=10 -s radius=4 # sparse-csr
+-s iterations=10 -s lsize=10 -s radius=4 -s VisualDebugOn=false # sparse-csr

--- a/test/studies/prk/Sparse/sparse.perfcompopts
+++ b/test/studies/prk/Sparse/sparse.perfcompopts
@@ -1,0 +1,1 @@
+-s iterations=10 -s lsize=10 -s radius=4 # sparse-csr

--- a/test/studies/prk/Sparse/sparse.perfkeys
+++ b/test/studies/prk/Sparse/sparse.perfkeys
@@ -1,0 +1,3 @@
+Rate (MFlops/s): 
+Avg time (s): 
+Validation successful


### PR DESCRIPTION
This PR adds a distributed Sparse PRK to the shared-memory Sparse PRK, and refactors the code.

- Added distributed implementation (fused with shared kernel)
- Switched to 1-based indexing
- Encapsulated non-kernel code in functions
- Encapsulated domain-definitions in functions (to hide `if distributed` logic)
- Added documentation
- Performance testing added


### Performance-impacting changes

- `temp` for storing partial sums.


### TODO

- [x] Change vector-update to use block-like communication pattern (#6682).
- [ ] Report performance delta of shared-memory test before/after this PR
- [ ] multilocale performance testing
    - 16 locales
- [x] cleanup / void distribution definitions

### Future work
- Further investigate if `vector` is large enough to warrant updates in parallel
   - Update with `vector += vectorDom;`?
- Capture performance delta of iterating over a sparse vs. indexing into it in a separate set of tests

