### PR TITLE
Code generation fixes for on+throws

### DIFF
--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -971,6 +971,10 @@ bool isClass(Type* t) {
   return false;
 }
 
+bool isClassOrNil(Type* t) {
+  if (t == dtNil) return true;
+  return isClass(t);
+}
 
 bool isRecord(Type* t) {
   if (AggregateType* ct = toAggregateType(t))

--- a/compiler/include/type.h
+++ b/compiler/include/type.h
@@ -439,6 +439,7 @@ bool is_enum_type(Type*);
 bool isLegalParamType(Type*);
 int  get_width(Type*);
 bool isClass(Type* t);
+bool isClassOrNil(Type* t);
 bool isRecord(Type* t);
 bool isUnion(Type* t);
 


### PR DESCRIPTION
These changes were developed in order to get on+throws working.

Before these changes, codegenWideAddr, when passed a class value, would return a class value with .isLVPtr = GEN_WIDE_PTR. That doesn't make sense because the wide class is already a value (our compiler treats class instances as values; e.g. classes are passed by "in" intent of the pointer value). This changes codegenWideAddr to return .isLVPtr = GEN_VAL for class instances and removes some accommodations in related code (mostly calls to codegenAddrOf that are no longer necessary).

Passed release/examples/primers/ and release/examples/users-guide/ with GASNet+fifo.
- [x] full local testing
- [x] full GASNet testing

Reviewed by @benharsh - thanks!
