### PR TITLE
Retire a passing future for initializers

### DIFF
--- a/test/classes/initializers/multilocale/dependence.future
+++ b/test/classes/initializers/multilocale/dependence.future
@@ -1,5 +1,0 @@
-feature request: new initializer story
-
-This test is not expected to pass until at least part of the initializers story
-is on master.  Make it a future so that Lydia can stay in step with master
-without disrupting testing overly much.


### PR DESCRIPTION
Retire a passing multi-locale initializer future that is similar to a newly failing single-locale test.
