### PR TITLE
6/29 triage annotations

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -254,6 +254,8 @@ all:
   06/20/17:
     - text: revert gnu target compiler from 7.1.0 to 6.3.0
       config: Single node XC, 16 node XC
+  06/21/17:
+    - change tmp directory
 
 
 AllCompTime:

--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -481,8 +481,6 @@ hpl_performance:
 hpl.hpcc2012.ml-perf:
   03/03/17:
     - Modified test as part of array views (#5338)
-  06/19/17:
-    - Reduce amount of locking in associative array dsiAccess (#6244)
 
 hpl.hpcc2012.ml-time:
   03/03/17:
@@ -772,6 +770,8 @@ prk-stencil:
     - blockDist for useStencilDist output matrix and more (#3705)
   05/06/16:
     - Problem size increased from --order=1000 to --order=32000 (#3813)
+  06/13/17:
+    - Optimize updateFluff (#6418)
 
 prk-stencil.ml-perf:
   04/08/16:
@@ -788,10 +788,14 @@ prk-stencil.ml-perf:
     - Use nonblocking transactions for strided transfers (#6262)
   06/06/17:
     - Increase the PRK stencil problem size (#6380)
+  06/13/17:
+    - Optimize updateFluff (#6418)
 
 prk-stencil-time:
   05/11/17:
     - Move chpl_getPrivatizedClass() into chpl-privatization.h (#6212)
+  06/13/17:
+    - Optimize updateFluff (#6418)
 
 prk-transpose: &transpose-base
   05/04/17:

--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -251,6 +251,9 @@ all:
   06/16/17:
     - text: revert gnu target compiler from 7.1.0 to 6.3.0
       config: chapcs, chap04
+  06/20/17:
+    - text: revert gnu target compiler from 7.1.0 to 6.3.0
+      config: Single node XC, 16 node XC
 
 
 AllCompTime:
@@ -285,6 +288,10 @@ array-of-strings-read:
 arr-forall:
   03/24/15:
     - with CCE, bug fix to avoid vectorizing when not valid
+
+array_iter:
+  06/19/17:
+    - Reduce amount of locking in associative array dsiAccess (#6244)
 
 arguments:
   03/10/17:
@@ -472,6 +479,8 @@ hpl_performance:
 hpl.hpcc2012.ml-perf:
   03/03/17:
     - Modified test as part of array views (#5338)
+  06/19/17:
+    - Reduce amount of locking in associative array dsiAccess (#6244)
 
 hpl.hpcc2012.ml-time:
   03/03/17:
@@ -682,6 +691,14 @@ meteor:
   08/10/16:
     - Updated meteor's lock to yield less frequently (#4300)
 
+mg-b:
+  05/23/17:
+    - Fix NPB MG (#6284)
+  06/13/17:
+    - Optimize updateFluff (#6418)
+  06/22/17:
+    - Only perform packed updateFluff when there are multiple locales (#6512)
+
 mg.ml-time:
   05/11/17:
     - Move chpl_getPrivatizedClass() into chpl-privatization.h (#6212)
@@ -769,14 +786,10 @@ prk-stencil.ml-perf:
     - Use nonblocking transactions for strided transfers (#6262)
   06/06/17:
     - Increase the PRK stencil problem size (#6380)
-  06/13/17:
-    - Optimize updateFluff (#6418)
 
 prk-stencil-time:
   05/11/17:
     - Move chpl_getPrivatizedClass() into chpl-privatization.h (#6212)
-  06/13/17:
-    - Optimize updateFluff (#6418)
 
 prk-transpose: &transpose-base
   05/04/17:
@@ -818,10 +831,14 @@ regexdna:
     - implemented good_alloc_size for jemalloc(#3446)
   04/20/17:
     - Update RE2 (#6024)
+  06/22/17:
+    - Free strings leaked by Regex.subn() / qio_regexp_replace() (#6509)
 
 regexdna-redux:
   04/20/17:
     - Update RE2 (#6024)
+  06/22/17:
+    - Free strings leaked by Regex.subn() / qio_regexp_replace() (#6509)
 
 return-array-8: &return-array-base
   03/04/17:
@@ -921,6 +938,10 @@ temporary-copies:
     - Likely cache effects
   04/20/17:
     - Update RE2 (#6024)
+
+twopt-paircount:
+  06/22/17:
+    - Free strings leaked by Regex.subn() / qio_regexp_replace() (#6509)
 
 search:
   04/20/17:


### PR DESCRIPTION
- XC reverting to gcc 6.3
- new tmp dir
- less locking on associative arrays
- regex leak improvements
- updateFluff fix