### PR TITLE
Clean up after chplCompile test

### DIFF
--- a/test/patterns/cltools/fileCompile/chplCompile.good
+++ b/test/patterns/cltools/fileCompile/chplCompile.good
@@ -1,2 +1,1 @@
 chpl samplefile.chpl -o samplefile
-Hello World!

--- a/test/patterns/cltools/fileCompile/chplCompile.good
+++ b/test/patterns/cltools/fileCompile/chplCompile.good
@@ -1,1 +1,2 @@
 chpl samplefile.chpl -o samplefile
+Hello World!

--- a/test/patterns/cltools/fileCompile/chplCompile.prediff
+++ b/test/patterns/cltools/fileCompile/chplCompile.prediff
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+outfile=$2
+exe=./samplefile
+
+$exe -nl 1 >> $outfile 2>&1  &&  rm -f $exe ${exe}_real

--- a/test/patterns/cltools/fileCompile/chplCompile.prediff
+++ b/test/patterns/cltools/fileCompile/chplCompile.prediff
@@ -1,5 +1,4 @@
 #!/bin/bash
 
 exe=./samplefile
-set -x
 rm -f $exe ${exe}_real

--- a/test/patterns/cltools/fileCompile/chplCompile.prediff
+++ b/test/patterns/cltools/fileCompile/chplCompile.prediff
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-outfile=$2
 exe=./samplefile
-
-$exe -nl 1 >> $outfile 2>&1  &&  rm -f $exe ${exe}_real
+set -x
+rm -f $exe ${exe}_real


### PR DESCRIPTION
Remove the generated executable after testing.

At first I had the .prediff also run the generated executable,
to test the compilation output. The prediff would say
"./samplefile -nl 1". However, while discussing with Sam,
I talked myself out of it. The reason being that on some
systems this may not work because of missing setup
like environment variables, launcher redirect/options, etc.

We also considered adding `--no-codegen`
to the compilation command. We decided
that it's prettier without it.
