### PR TITLE
Change to IWR to support error handling

### DIFF
--- a/compiler/passes/insertWideReferences.cpp
+++ b/compiler/passes/insertWideReferences.cpp
@@ -997,7 +997,10 @@ static void propagateVar(Symbol* sym) {
       if (!call->isPrimitive(PRIM_VIRTUAL_METHOD_CALL)) {
         SymExpr* actual = toSymExpr(formal_to_actual(call, sym));
         DEBUG_PRINTF("\tRef types have to match: %s (%d) in call %d\n", actual->symbol()->cname, actual->symbol()->id, call->id);
-        setValWide(sym, actual->symbol());
+        if (actual->isRefOrWideRef())
+          setValWide(sym, actual->symbol());
+        else
+          setWide(sym, actual->symbol());
       }
     }
   }


### PR DESCRIPTION
error handling was creating a error:Error variable and passing it to a function argument with ref intent (but not ref type).  This fix adjusts IWR to widen the error variable in this case when the argument is also wide (instead of generating a temporary wide class).

- [x] full local testing
- [x] full local --no-local testing
- [x] full GASNet testing

Reviewed by @benharsh - thanks!
