### PR TITLE
Make the field Type::destructor be a private member variable

### DIFF
--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -42,17 +42,15 @@
 
 static bool isDerivedType(Type* type, Flag flag);
 
-Type::Type(AstTag astTag, Symbol* init_defaultVal) :
-  BaseAST(astTag),
-
-  symbol(NULL),
-  refType(NULL),
-  hasGenericDefaults(false),
-  defaultValue(init_defaultVal),
-  destructor(NULL),
-  isInternalType(false),
-  instantiatedFrom(NULL),
-  scalarPromotionType(NULL) {
+Type::Type(AstTag astTag, Symbol* iDefaultVal) : BaseAST(astTag) {
+  symbol              = NULL;
+  refType             = NULL;
+  hasGenericDefaults  = false;
+  defaultValue        = iDefaultVal;
+  destructor          = NULL;
+  isInternalType      = false;
+  instantiatedFrom    = NULL;
+  scalarPromotionType = NULL;
 }
 
 Type::~Type() {
@@ -62,10 +60,9 @@ Type::~Type() {
 void Type::verify() {
 }
 
-void Type::addSymbol(TypeSymbol* newsymbol) {
-  symbol = newsymbol;
+void Type::addSymbol(TypeSymbol* newSymbol) {
+  symbol = newSymbol;
 }
-
 
 bool Type::inTree() {
   if (symbol)
@@ -101,6 +98,23 @@ Symbol* Type::getField(const char* name, bool fatal) {
   return NULL;
 }
 
+bool Type::hasDestructor() const {
+  return destructor != NULL;
+}
+
+FnSymbol* Type::getDestructor() const {
+  return destructor;
+}
+
+void Type::setDestructor(FnSymbol* fn) {
+  destructor = fn;
+}
+
+/************************************* | **************************************
+*                                                                             *
+*                                                                             *
+*                                                                             *
+************************************** | *************************************/
 
 PrimitiveType::PrimitiveType(Symbol *init, bool internalType) :
   Type(E_PrimitiveType, init)
@@ -134,7 +148,6 @@ PrimitiveType::copyInner(SymbolMap* map) {
 void PrimitiveType::replaceChild(BaseAST* old_ast, BaseAST* new_ast) {
   INT_FATAL(this, "Unexpected case in PrimitiveType::replaceChild");
 }
-
 
 
 void PrimitiveType::verify() {

--- a/compiler/include/type.h
+++ b/compiler/include/type.h
@@ -57,45 +57,56 @@ class IteratorInfo;
 
 class Type : public BaseAST {
 public:
-  virtual Type*    copy(SymbolMap* map = NULL, bool internal = false) = 0;
+  virtual Type*          copy(SymbolMap* map      = NULL,
+                              bool       internal = false)                 = 0;
 
   // Interface for BaseAST
-  virtual GenRet   codegen();
-  virtual bool     inTree();
-  virtual QualifiedType qualType();
-  virtual void     verify();
+  virtual GenRet         codegen();
+  virtual bool           inTree();
+  virtual QualifiedType  qualType();
+  virtual void           verify();
 
-  virtual void     codegenDef();
-  virtual void     codegenPrototype();
+  virtual void           codegenDef();
+  virtual void           codegenPrototype();
 
   // only used for heterogeneous compilations in which we need to define
   // what our data structures are for the point of conversions
-  virtual int      codegenStructure(FILE* outfile, const char* baseoffset);
+  virtual int            codegenStructure(FILE*       outfile,
+                                          const char* baseoffset);
 
-  virtual Symbol*  getField(const char* name, bool fatal = true);
+  virtual Symbol*        getField(const char* name, bool fatal = true);
 
-  void             addSymbol(TypeSymbol* newSymbol);
+  void                   addSymbol(TypeSymbol* newSymbol);
 
-  bool             isDefaultIntentConst()                                const;
+  bool                   isDefaultIntentConst()                          const;
 
-  TypeSymbol*      symbol;
-  AggregateType*   refType;  // pointer to references for non-reference types
-  Vec<FnSymbol*>   methods;
+  // get/set on the type destructor
+  bool                   hasDestructor()                                 const;
+  FnSymbol*              getDestructor()                                 const;
+  void                   setDestructor(FnSymbol* fn);
 
-  bool             hasGenericDefaults; // all generic fields have defaults
+  TypeSymbol*            symbol;
 
-  Symbol*          defaultValue;
-  FnSymbol*        destructor;
+  // pointer to references for non-reference types
+  AggregateType*         refType;
+
+  Vec<FnSymbol*>         methods;
+
+  // all generic fields have defaults
+  bool                   hasGenericDefaults;
+
+  Symbol*                defaultValue;
 
   // Used only in PrimitiveType; replace with flag?
-  bool             isInternalType;
+  bool                   isInternalType;
 
-  Type*            instantiatedFrom;
-  Type*            scalarPromotionType;
+  Type*                  instantiatedFrom;
+  Type*                  scalarPromotionType;
 
-  SymbolMap        substitutions;
-  Vec<Type*>       dispatchChildren;   // dispatch hierarchy
-  Vec<Type*>       dispatchParents;    // dispatch hierarchy
+  SymbolMap              substitutions;
+
+  Vec<Type*>             dispatchChildren;   // dispatch hierarchy
+  Vec<Type*>             dispatchParents;    // dispatch hierarchy
 
   // Only used for LLVM.
   std::map<std::string, int> GEPMap;
@@ -106,6 +117,8 @@ protected:
 
 private:
   virtual void     replaceChild(BaseAST* old_ast, BaseAST* new_ast) = 0;
+
+  FnSymbol*        destructor;
 };
 
 #define forv_Type(_p, _v) forv_Vec(Type, _p, _v)

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -6034,30 +6034,29 @@ resolveFns(FnSymbol* fn) {
     //
     // resolve destructor
     //
-    if (ct) {
-      if (!ct->destructor &&
-          !ct->symbol->hasFlag(FLAG_REF) &&
-          !isTupleContainingOnlyReferences(ct)) {
-        BlockStmt* block = new BlockStmt();
-        VarSymbol* tmp   = newTemp(ct);
-        CallExpr*  call  = new CallExpr("deinit", gMethodToken, tmp);
+    if (ct                                  != NULL  &&
+        ct->hasDestructor()                 == false &&
+        ct->symbol->hasFlag(FLAG_REF)       == false &&
+        isTupleContainingOnlyReferences(ct) == false) {
+      BlockStmt* block = new BlockStmt();
+      VarSymbol* tmp   = newTemp(ct);
+      CallExpr*  call  = new CallExpr("deinit", gMethodToken, tmp);
 
-        // In case resolveCall drops other stuff into the tree ahead of the
-        // call, we wrap everything in a block for safe removal.
+      // In case resolveCall drops other stuff into the tree ahead
+      // of the call, we wrap everything in a block for safe removal.
 
-        block->insertAtHead(call);
+      block->insertAtHead(call);
 
-        fn->insertAtHead(block);
-        fn->insertAtHead(new DefExpr(tmp));
+      fn->insertAtHead(block);
+      fn->insertAtHead(new DefExpr(tmp));
 
-        resolveCallAndCallee(call);
+      resolveCallAndCallee(call);
 
-        ct->destructor = call->resolvedFunction();
+      ct->setDestructor(call->resolvedFunction());
 
-        block->remove();
+      block->remove();
 
-        tmp->defPoint->remove();
-      }
+      tmp->defPoint->remove();
     }
   }
 
@@ -6579,7 +6578,7 @@ bool propagateNotPOD(Type* t) {
         if (at->symbol->hasFlag(FLAG_IGNORE_NOINIT)      == true  ||
             isCompilerGenerated(autoCopyMap[at])         == false ||
             isCompilerGenerated(autoDestroyMap.get(at))  == false ||
-            isCompilerGenerated(at->destructor)          == false) {
+            isCompilerGenerated(at->getDestructor())     == false) {
           retval = true;
         }
 

--- a/compiler/resolution/tuples.cpp
+++ b/compiler/resolution/tuples.cpp
@@ -428,21 +428,22 @@ TupleInfo getTupleInfo(std::vector<TypeSymbol*>& args,
     }
 
     // Build the value constructor
-    {
-      newType->defaultInitializer = makeConstructTuple(args,
-                                                       typeCtorArgs,
-                                                       newTypeSymbol,
-                                                       tupleModule,
-                                                       instantiationPoint,
-                                                       noref,
-                                                       sizeType);
-    }
+    newType->defaultInitializer = makeConstructTuple(args,
+                                                     typeCtorArgs,
+                                                     newTypeSymbol,
+                                                     tupleModule,
+                                                     instantiationPoint,
+                                                     noref,
+                                                     sizeType);
+
 
     // Build the value destructor
     FnSymbol* dtor = makeDestructTuple(newTypeSymbol,
                                        tupleModule,
                                        instantiationPoint);
-    newType->destructor = dtor;
+
+    newType->setDestructor(dtor);
+
     newType->methods.add(dtor);
 
     // Resolve it so it stays in AST


### PR DESCRIPTION
This is a simple close-the-gap PR.

@ben-albrecht made me aware of a problem that @npadmana exposed with a specific program
that was using class inheritance.  The program "happens" to fail in the C compiler because of
confusion in handling type destructors within resolution.  More work is needed on this if only
to create a well-defined issue.


Exploring this bug was complicated by the fact the Type::destructor is a public member variable
and so can be read/written freely.  It was useful and relatively easy to convert this to be a
private member variable with a public setter/getter pair and then track targeted undesirable
read/writes via these methods.



Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64. 
Ran a fraction of release/ for each configuration.
Passed a single-locale paratest

Also compiled with CHPL_LLVM=llvm on gcc/linux64
