### PR TITLE
Changes to parallel.cpp to support on+throw

### DIFF
--- a/compiler/passes/parallel.cpp
+++ b/compiler/passes/parallel.cpp
@@ -151,7 +151,7 @@ static void create_arg_bundle_class(FnSymbol* fn, CallExpr* fcall, ModuleSymbol*
 
   // add the function args as fields in the class
   int i = 0;    // Fields are numbered for uniqueness.
-  for_actuals(arg, fcall) {
+  for_formals_actuals(formal, arg, fcall) {
     SymExpr *s = toSymExpr(arg);
     Symbol  *var = s->symbol(); // arg or var
 
@@ -180,7 +180,9 @@ static void create_arg_bundle_class(FnSymbol* fn, CallExpr* fcall, ModuleSymbol*
     // If it's a record-wrapped type we can just bit-copy into the arg bundle.
     // BHARSH TODO: This really belongs in RVF
     // BHARSH TODO: Use 'formal->isRef()' instead of the var's ref-ness
-    if (!isRecordWrappedType(var->getValType()) && !autoCopy && var->isRef()) field->qual = QUAL_REF;
+    if (!isRecordWrappedType(var->getValType()) && !autoCopy &&
+        // TODO - can we remove var->isRef()
+        (formal->isRef() || var->isRef())) field->qual = QUAL_REF;
 
     ctype->fields.insertAtTail(new DefExpr(field));
     i++;


### PR DESCRIPTION
Before this change, the argument bundle for an on statement that can throw was storing an Error variable by value instead of by reference.

This PR adjusts for the situation by updating create_arg_bundle_class to consider the intent of the on-statement body formal. However the first attempt at doing so did not function correctly, because apparently parallel.cpp needs to generate QUAL_VAL fields for some on-function formals that are references. Since this seems to depend on const-ness, it's likely that moving that concern to RVF would be worthwhile. It's also likely that index variables need to be by value.

- [ ] full local testing
- [ ] full --no-local testing