### PR TITLE
Add tests to cover an issue with initializers and enums found by Sam

### DIFF
--- a/test/classes/initializers/phase1/enumField.chpl
+++ b/test/classes/initializers/phase1/enumField.chpl
@@ -1,0 +1,31 @@
+enum Color {red, blue, green};
+use Color;
+
+class Foo {
+  var a: Color;
+  var b: Color = green;
+  var c = red;
+
+  var d: Color; // omit
+  var e: Color = green; // omit
+  var f = red; // omit
+
+  var g: Color;
+  var h: Color = green;
+  var i = red;
+
+  proc init(val: Color) {
+    a = val;
+    b = val;
+    c = val;
+
+    g = blue;
+    h = red;
+    i = green;
+    super.init();
+  }
+}
+
+var foo = new Foo(blue);
+writeln(foo);
+delete foo;

--- a/test/classes/initializers/phase1/enumField.good
+++ b/test/classes/initializers/phase1/enumField.good
@@ -1,0 +1,1 @@
+{a = blue, b = blue, c = blue, d = red, e = green, f = red, g = blue, h = red, i = green}

--- a/test/classes/initializers/phase1/enumFieldExplicitType.chpl
+++ b/test/classes/initializers/phase1/enumFieldExplicitType.chpl
@@ -1,0 +1,30 @@
+enum Color {red, blue, green};
+
+class Foo {
+  var a: Color;
+  var b: Color = Color.green;
+  var c = Color.red;
+
+  var d: Color; // omit
+  var e: Color = Color.green; // omit
+  var f = Color.red; // omit
+
+  var g: Color;
+  var h: Color = Color.green;
+  var i = Color.red;
+
+  proc init(val: Color) {
+    a = val;
+    b = val;
+    c = val;
+
+    g = Color.blue;
+    h = Color.red;
+    i = Color.green;
+    super.init();
+  }
+}
+
+var foo = new Foo(Color.blue);
+writeln(foo);
+delete foo;

--- a/test/classes/initializers/phase1/enumFieldExplicitType.good
+++ b/test/classes/initializers/phase1/enumFieldExplicitType.good
@@ -1,0 +1,1 @@
+{a = blue, b = blue, c = blue, d = red, e = green, f = red, g = blue, h = red, i = green}

--- a/test/classes/initializers/phase1/enumFieldNoUseBad.bad
+++ b/test/classes/initializers/phase1/enumFieldNoUseBad.bad
@@ -1,4 +1,4 @@
-enumFieldNoUseBad.chpl:7: internal error: INI0553 chpl Version 1.16.0 pre-release (b5d30f2)
+enumFieldNoUseBad.chpl:9: internal error: INI0553 chpl Version 1.16.0 pre-release (b5d30f2)
 Note: This source location is a guess.
 
 Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),

--- a/test/classes/initializers/phase1/enumFieldNoUseBad.bad
+++ b/test/classes/initializers/phase1/enumFieldNoUseBad.bad
@@ -1,0 +1,8 @@
+enumFieldNoUseBad.chpl:7: internal error: INI0553 chpl Version 1.16.0 pre-release (b5d30f2)
+Note: This source location is a guess.
+
+Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
+please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
+the filename + line number above may be useful in working around the issue.
+

--- a/test/classes/initializers/phase1/enumFieldNoUseBad.chpl
+++ b/test/classes/initializers/phase1/enumFieldNoUseBad.chpl
@@ -1,0 +1,16 @@
+enum Color {red, blue, green};
+// use Color; // Uncommenting this line allows blue to be accessed without
+// the `Color.` prefix.
+
+class Foo {
+  var a: Color;
+
+  proc init() {
+    a = blue;
+    super.init();
+  }
+}
+
+var foo = new Foo();
+writeln(foo);
+delete foo;

--- a/test/classes/initializers/phase1/enumFieldNoUseBad.future
+++ b/test/classes/initializers/phase1/enumFieldNoUseBad.future
@@ -1,0 +1,10 @@
+error message: Initializer verification is hiding an enum error message
+
+This test should generate an error message for the user, because they are
+trying to access one of the enum's constant values without either the type
+prefix or `use`ing the enum.  However, we never reach the error message that
+normally gets generated - instead, we blow up during the verification of the
+initializer.  Initializers should let this go through so the normal message is
+given.
+
+The same is also likely true of bad methods, I suspect.

--- a/test/classes/initializers/phase1/enumFieldNoUseBad.good
+++ b/test/classes/initializers/phase1/enumFieldNoUseBad.good
@@ -1,0 +1,1 @@
+enumFieldNoUseBad.chpl:8: error: 'blue' undeclared (first use this function)


### PR DESCRIPTION
Exercises using enums in fields both with the enum type prefix and with a use
statement to allow unprefixed access.  Also shows what happens when you
incorrectly try to perform unprefixed access when a 'use' has not occurred -
normally, this gives you an error during function resolution (because it looks
like it might be a method) but it is tripping our initializers implementation
up and never reaching that nice error message.

Verified a fresh checkout