### PR TITLE
Solve parent bug

### DIFF
--- a/compiler/passes/initializerRules.cpp
+++ b/compiler/passes/initializerRules.cpp
@@ -393,11 +393,15 @@ static InitNormalize preNormalize(BlockStmt*    block,
 
       // Stmt is assignment to a super field
       } else if (DefExpr* field = toSuperFieldInit(state.type(), callExpr)) {
-        USR_FATAL(stmt,
-                  "can't set value of field \"%s\" from parent type "
-                  "during phase 1 of initialization",
-                  field->sym->name);
-
+        // Only valid during Phase 2
+        if (state.isPhase2() == false) {
+          USR_FATAL(stmt,
+                    "can't set value of field \"%s\" from parent type "
+                    "during phase 1 of initialization",
+                    field->sym->name);
+        } else {
+          stmt = stmt->next;
+        }
       // No action required
       } else {
         if (state.fieldUsedBeforeInitialized(stmt) == true) {

--- a/test/classes/initializers/phase2/setParent.bad
+++ b/test/classes/initializers/phase2/setParent.bad
@@ -1,2 +1,0 @@
-setParent.chpl:11: In initializer:
-setParent.chpl:13: error: can't set value of field "parentInt" from parent type during phase 1 of initialization

--- a/test/classes/initializers/phase2/setParent.future
+++ b/test/classes/initializers/phase2/setParent.future
@@ -1,1 +1,0 @@
-bug: compiler complains about phase 1 error despite code being in phase 2


### PR DESCRIPTION
Ben pointed out we were giving the "phase 1" error for updates to parent fields,
regardless of whether we were actually in Phase 1 or not.  This change allows us
to distinguish between appropriate updates to parent fields in Phase 2 and
incorrect initialization of parent fields during Phase 1

Passed test/classes/initializers with futures and a full std paratest