### PR TITLE
Init field named expr

### DIFF
--- a/compiler/include/InitNormalize.h
+++ b/compiler/include/InitNormalize.h
@@ -59,8 +59,6 @@ public:
   bool            isPhase1()                                             const;
   bool            isPhase2()                                             const;
 
-
-
   void            checkPhase(BlockStmt* block);
 
   Expr*           completePhase1(Expr* insertBefore);
@@ -125,15 +123,15 @@ private:
   DefExpr*        toLocalField(SymExpr*  expr)                           const;
   DefExpr*        toLocalField(CallExpr* expr)                           const;
 
-  DefExpr*        toLocalField(AggregateType* at, SymExpr*  expr)        const;
-  DefExpr*        toLocalField(AggregateType* at, CallExpr* expr)        const;
+  DefExpr*        toLocalField(AggregateType* at, const char* name)      const;
+  DefExpr*        toLocalField(AggregateType* at, SymExpr*    expr)      const;
+  DefExpr*        toLocalField(AggregateType* at, CallExpr*   expr)      const;
 
   DefExpr*        toSuperField(SymExpr* expr)                            const;
 
-  DefExpr*        toSuperField(AggregateType* at, SymExpr*  expr)        const;
-  DefExpr*        toSuperField(AggregateType* at, CallExpr* expr)        const;
-
-  DefExpr*        fieldByName(AggregateType* at,  const char*  name)     const;
+  DefExpr*        toSuperField(AggregateType* at, const char* name)      const;
+  DefExpr*        toSuperField(AggregateType* at, SymExpr*    expr)      const;
+  DefExpr*        toSuperField(AggregateType* at, CallExpr*   expr)      const;
 
   const char*     phaseToString(InitPhase phase)                         const;
 

--- a/test/classes/initializers/named-argument-class.bad
+++ b/test/classes/initializers/named-argument-class.bad
@@ -1,8 +1,0 @@
-named-argument-class.chpl:12: internal error: INI0459 chpl Version 1.16.0 pre-release (d16267e)
-Note: This source location is a guess.
-
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
-and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
-please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
-

--- a/test/classes/initializers/named-argument-class.future
+++ b/test/classes/initializers/named-argument-class.future
@@ -1,1 +1,0 @@
-bug: compiler assertion failure when calling intializer with named argument

--- a/test/classes/initializers/named-argument-proc.bad
+++ b/test/classes/initializers/named-argument-proc.bad
@@ -1,8 +1,0 @@
-named-argument-proc.chpl:8: internal error: INI0553 chpl Version 1.16.0 pre-release (d16267e)
-Note: This source location is a guess.
-
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
-and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
-please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
-

--- a/test/classes/initializers/named-argument-proc.future
+++ b/test/classes/initializers/named-argument-proc.future
@@ -1,1 +1,0 @@
-bug: compiler assertion error when calling function with named argument


### PR DESCRIPTION
@benharsh generated a test with a field initializer that included a named-expression and
found that it caused an internal FATAL.  He was kind enough to introduce two futures.

Some incomplete code, conservatively, rejected this expression during analysis.
This simple PR accepts these expressions and converts the two futures to two passing
tests.


Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.  Ran a portion
of release/ for all configurations.  Passed start_test with -futures on classes/initializers on darwin.
Passed single-locale paratest on linux64.

