### PR TITLE
Fix a tautological compare that clang detects

### DIFF
--- a/compiler/util/llvmDumpIR.cpp
+++ b/compiler/util/llvmDumpIR.cpp
@@ -48,7 +48,7 @@ namespace {
     bool runOnFunction(Function &F) override {
       if (llvmPrintIrCName != NULL && F.getName() == llvmPrintIrCName) {
         printLlvmIr(&F, stage);
-      } else if (llvmPrintIrName != NULL && F.getName() == llvmPrintIrName) {
+      } else if (llvmPrintIrName[0] != '\0' && F.getName() == llvmPrintIrName) {
         printLlvmIr(&F, stage);
       }
       return false;


### PR DESCRIPTION
Verified that this solves the build error for CHPL_LLVM on Mac OS X.
Verified Hello World still works on linux with or without --llvm.
Verified test/compflags/coodie/ still passes on linux.

Trivial and not reviewed.