### PR TITLE
Enable privatization for SparseBlock

### DIFF
--- a/modules/dists/SparseBlockDist.chpl
+++ b/modules/dists/SparseBlockDist.chpl
@@ -60,7 +60,7 @@ class SparseBlockDom: BaseSparseDomImpl {
   type sparseLayoutType;
   param stridable: bool = false;  // TODO: remove default value eventually
   const dist: Block(rank, idxType, sparseLayoutType);
-  const whole: domain(rank=rank, idxType=idxType, stridable=stridable);
+  var whole: domain(rank=rank, idxType=idxType, stridable=stridable);
   var locDoms: [dist.targetLocDom] LocSparseBlockDom(rank, idxType, stridable,
       sparseLayoutType);
 
@@ -378,28 +378,28 @@ class SparseBlockArr: BaseSparseArr {
 
 
   proc dsiAccess(i: rank*idxType) ref {
-    //    local { // TODO: Turn back on once privatization is on
-      if myLocArr != nil && myLocArr.locDom.dsiMember(i) {
+    local {
+      if myLocArr != nil && myLocArr.locDom.parentDom.member(i) {
         return myLocArr.dsiAccess(i);
-        //      }
+      }
     }
     return locArr[dom.dist.targetLocsIdx(i)].dsiAccess(i);
   }
   proc dsiAccess(i: rank*idxType)
   where shouldReturnRvalueByValue(eltType) {
-    //    local { // TODO: Turn back on once privatization is on
-      if myLocArr != nil && myLocArr.locDom.dsiMember(i) {
+    local {
+      if myLocArr != nil && myLocArr.locDom.parentDom.member(i) {
         return myLocArr.dsiAccess(i);
-        //      }
+      }
     }
     return locArr[dom.dist.targetLocsIdx(i)].dsiAccess(i);
   }
   proc dsiAccess(i: rank*idxType) const ref
   where shouldReturnRvalueByConstRef(eltType) {
-    //    local { // TODO: Turn back on once privatization is on
-      if myLocArr != nil && myLocArr.locDom.dsiMember(i) {
+    local {
+      if myLocArr != nil && myLocArr.locDom.parentDom.member(i) {
         return myLocArr.dsiAccess(i);
-        //      }
+      }
     }
     return locArr[dom.dist.targetLocsIdx(i)].dsiAccess(i);
   }
@@ -662,14 +662,15 @@ proc LocSparseBlockArr.dsiSerialWrite(f) {
 }
 
 
-proc SparseBlockDom.dsiSupportsPrivatization() param return false;
+proc SparseBlockDom.dsiSupportsPrivatization() param return true;
 
 proc SparseBlockDom.dsiGetPrivatizeData() return (dist.pid, whole.dims());
 
 proc SparseBlockDom.dsiPrivatize(privatizeData) {
   var privdist = chpl_getPrivatizedCopy(dist.type, privatizeData(1));
-  var c = new SparseBlockDom(rank=rank, idxType=idxType, stridable=stridable,
-      dist=privdist, whole=whole);
+  var c = new SparseBlockDom(rank=rank, idxType=idxType,
+      sparseLayoutType=sparseLayoutType, dist=privdist, whole=whole,
+      parentDom=parentDom);
   for i in c.dist.targetLocDom do
     c.locDoms(i) = locDoms(i);
   c.whole = {(...privatizeData(2))};
@@ -684,13 +685,15 @@ proc SparseBlockDom.dsiReprivatize(other, reprivatizeData) {
   whole = {(...reprivatizeData)};
 }
 
-proc SparseBlockArr.dsiSupportsPrivatization() param return false;
+proc SparseBlockArr.dsiSupportsPrivatization() param return true;
 
 proc SparseBlockArr.dsiGetPrivatizeData() return dom.pid;
 
 proc SparseBlockArr.dsiPrivatize(privatizeData) {
   var privdom = chpl_getPrivatizedCopy(dom.type, privatizeData);
-  var c = new SparseBlockArr(eltType=eltType, rank=rank, idxType=idxType, stridable=stridable, dom=privdom);
+  var c = new SparseBlockArr(sparseLayoutType=sparseLayoutType,
+      eltType=eltType, rank=rank, idxType=idxType, stridable=stridable,
+      dom=privdom);
   for localeIdx in c.dom.dist.targetLocDom {
     c.locArr(localeIdx) = locArr(localeIdx);
     if c.locArr(localeIdx).locale.id == here.id then


### PR DESCRIPTION
This commit enables privatization for the SparseBlock distribution,
resulting in significantly less communication.

A minor change was made to dsiAccess to check index membership in a
dense domain instead of a sparse domain to improve performance.

[ written by @e-kayrakli, committed by @benharsh ]

Testing:
- [x] full local
- [x] subset with gasnet
  - [x] distributions/bradc/spsBlk
  - [x] sparse/engin/
  - [x] users/engin/