### PR TITLE
Skip LLNL CoMD for memory leaks testing

### DIFF
--- a/test/studies/comd/llnl/CoMD.skipif
+++ b/test/studies/comd/llnl/CoMD.skipif
@@ -1,0 +1,1 @@
+CHPL_MEM_LEAK_TESTING == true


### PR DESCRIPTION
The original reference does not delete classes, so just skip for memory leaks testing