### PR TITLE
Convert bradc tests to init

### DIFF
--- a/test/classes/initializers/generics/genericInitError.bad
+++ b/test/classes/initializers/generics/genericInitError.bad
@@ -1,0 +1,2 @@
+genericInitError.chpl:4: In initializer:
+genericInitError.chpl:4: error: can't omit initialization of field "t", no type or default value provided

--- a/test/classes/initializers/generics/genericInitError.chpl
+++ b/test/classes/initializers/generics/genericInitError.chpl
@@ -1,0 +1,9 @@
+class C {
+  type t;
+
+  proc init(type t) {
+    this.t = t;
+  }
+}
+
+var myC = new C(real);

--- a/test/classes/initializers/generics/genericInitError.future
+++ b/test/classes/initializers/generics/genericInitError.future
@@ -1,0 +1,12 @@
+error message: tailor generic initialization error messages to note phase 2
+
+This test is incorrect because it does not initialize generic field
+'t' in phase 1 of its initializer.  However, the current error message
+only says that an initialization of 't' is required and not found,
+suggesting that only the first phase of the initializer was examined.
+I think that this will be confusing to someone unfamiliar with phase 1
+vs. 2 semantics who will look at the code and say "of course it's
+initialized!"  It may also be an argument for either (a) making phase
+1 the default or (b) permitting generic fieldst to be initialized in
+either phase given that they're compile-time evaluated (so effectively
+a phase 0?)

--- a/test/classes/initializers/generics/genericInitError.good
+++ b/test/classes/initializers/generics/genericInitError.good
@@ -1,0 +1,2 @@
+genericInitError.chpl:4: In initializer:
+genericInitError.chpl:4: error: can't initialize type fields like `t` in phase 2 of an initializer

--- a/test/functions/bradc/namedArgs/forceNamedArgs-createdummy.chpl
+++ b/test/functions/bradc/namedArgs/forceNamedArgs-createdummy.chpl
@@ -1,5 +1,5 @@
 class dummyarg {
-  proc dummyarg() {
+  proc init() {
     compilerError("can't create an object of type 'dummyarg' -- use named argument passing to call this routine");
   }
 }

--- a/test/functions/bradc/namedArgs/forceNamedArgs.chpl
+++ b/test/functions/bradc/namedArgs/forceNamedArgs.chpl
@@ -1,5 +1,5 @@
 class dummyarg {
-  proc dummyarg() {
+  proc init() {
     compilerError("can't create an object of type 'dummyarg' -- use named argument passing to call this routine");
   }
 }

--- a/test/parallel/sync/bradc/syncArrInit2.chpl
+++ b/test/parallel/sync/bradc/syncArrInit2.chpl
@@ -1,8 +1,9 @@
 class C {
   const irng: int;
 
-  proc C(v1: int) {
+  proc init(v1: int) {
     irng = v1;
+    super.init();
   }
 }
 

--- a/test/reductions/bradc/manual/threeclasstypes-construct.chpl
+++ b/test/reductions/bradc/manual/threeclasstypes-construct.chpl
@@ -15,10 +15,11 @@ class mysumreduce {
     return x;
   }
 
-  proc mysumreduce(type in_t) {
+  proc init(type in_t) {
     intype = in_t;
     statetype = in_t;
     outtype = in_t;
+    super.init();
   }
 }
 

--- a/test/reductions/bradc/manual/threeclasstypes-construct.good
+++ b/test/reductions/bradc/manual/threeclasstypes-construct.good
@@ -1,3 +1,1 @@
-threeclasstypes-construct.chpl:18: error: constructor for class 'mysumreduce' requires a generic argument called 'intype'
-threeclasstypes-construct.chpl:18: error: constructor for class 'mysumreduce' requires a generic argument called 'statetype'
-threeclasstypes-construct.chpl:18: error: constructor for class 'mysumreduce' requires a generic argument called 'outtype'
+result is: 55

--- a/test/reductions/bradc/manual/threeclasstypes-construct2.chpl
+++ b/test/reductions/bradc/manual/threeclasstypes-construct2.chpl
@@ -15,7 +15,11 @@ class mysumreduce {
     return x;
   }
 
-  proc mysumreduce(type intype, type statetype=intype, type outtype=intype) {
+  proc init(type intype, type statetype=intype, type outtype=intype) {
+    this.intype = intype;
+    this.statetype = statetype;
+    this.outtype = outtype;
+    super.init();
   }
 }
 

--- a/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc.chpl
+++ b/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc.chpl
@@ -219,7 +219,7 @@ class MeetingPlace {
   //
   // Initialize the number of meetings that should take place
   //
-  proc MeetingPlace(numMeetings) {
+  proc init(numMeetings) {
     state.write(numMeetings << bitsPerChameneosID);
   }
 


### PR DESCRIPTION
This takes a pass over tests in issue #6530 that have `bradc` in the path, attempting to convert them from constructors to initializers.  Most cases were easy, though a few were more challenging / not possible (that I could tell).

Specifically, converting helper module `test/studies/hpcc/common/bradc/BradsBlock1DPar.chpl` led to two issues:

* the first was that I introduced a `this.idxType = idxType;` line into `LocBlock1DDist`s `init()` routine which led to the compiler complaining that `idxType` had not been initialized.  What it's really trying to say is that it wasn't initialized in phase 1 of the initializer, but to a programmer who's not familiar with our phase 1 vs. phase 2 semantics, this would be confusing since it apparently is initialized.  I filed a new "error message" future test against this called `test/classes/initializers/generics/genericInitError.chpl` and can file an issue against it if Mike / Lydia agree with the intent and can confirm there isn't an outstanding issue already.

* the second is that the initialization `boundingBox = bbox` in `Block1DDist`s `init()` routine results in an error saying `cannot assign expression of type domain(1,int(64),false) to field of type _unknown` even though `boundingBox` is declared to be `domain(1, idxType)`.  Interestingly, the line given for this error is wrong (the initializer's `proc` declaration line) if the assignment is in phase 2, but correct if it's in phase 1.

The rest were fairly easy to convert.  For future reference, cases where I had to use a super.init() which seemed regrettable included:

* initializing a `const` field (in `test/parallel/sync/bradc/syncArrInit2.chpl`)
* initializing generic fields (in `test/reductions/bradc/manual/threeclasstypes-construct*.chpl`)