### PR TITLE
Supporting throw + on

### DIFF
--- a/compiler/include/errorHandling.h
+++ b/compiler/include/errorHandling.h
@@ -20,6 +20,8 @@
 #ifndef _ERROR_HANDLING_H_
 #define _ERROR_HANDLING_H_
 
+class BlockStmt;
+
 void lowerErrorHandling();
 
 #endif

--- a/compiler/passes/errorHandling.cpp
+++ b/compiler/passes/errorHandling.cpp
@@ -445,13 +445,6 @@ private:
   bool fnCanThrow; // only used for error checking
 
   bool   catchesNotExhaustive(TryStmt* tryStmt);
-
-  AList     setOutGotoEpilogue(VarSymbol* error);
-  AList     errorCond         (VarSymbol* errorVar, BlockStmt* thenBlock,
-                               BlockStmt* elseBlock = NULL);
-  CallExpr* haltExpr          ();
-
-  CanThrowVisitor();
 };
 
 CanThrowVisitor::CanThrowVisitor(bool inThrowingFn, bool makeCompileErrors) {

--- a/compiler/passes/errorHandling.cpp
+++ b/compiler/passes/errorHandling.cpp
@@ -524,7 +524,7 @@ bool CanThrowVisitor::enterCallExpr(CallExpr* node) {
     canThrow = true;
 
     if (insideTry) {
-      // OK. non-exaustive try handled in try handling.
+      // OK, error checking for this case done in try handling
     } else if (fnCanThrow == true) {
       // OK, fn can throw
     } else if (errors == true) {

--- a/compiler/passes/errorHandling.cpp
+++ b/compiler/passes/errorHandling.cpp
@@ -432,8 +432,6 @@ public:
 
   virtual bool enterTryStmt  (TryStmt*   node);
   virtual void exitTryStmt   (TryStmt*   node);
-  virtual bool enterCatchStmt(CatchStmt*   node);
-  virtual void exitCatchStmt (CatchStmt*   node);
   virtual bool enterCallExpr (CallExpr*  node);
 
   bool throws() { return canThrow; }
@@ -479,7 +477,7 @@ void CanThrowVisitor::exitTryStmt(TryStmt* node) {
 
 bool CanThrowVisitor::catchesNotExhaustive(TryStmt* tryStmt) {
 
-  bool       hasCatchAll = false;
+  bool hasCatchAll = false;
 
   for_alist(c, tryStmt->_catches) {
     if (errors && hasCatchAll)
@@ -505,13 +503,6 @@ bool CanThrowVisitor::catchesNotExhaustive(TryStmt* tryStmt) {
   }
 
   return !hasCatchAll;
-}
-
-bool CanThrowVisitor::enterCatchStmt(CatchStmt* node) {
-  return true;
-}
-
-void CanThrowVisitor::exitCatchStmt(CatchStmt* node) {
 }
 
 bool CanThrowVisitor::enterCallExpr(CallExpr* node) {

--- a/compiler/passes/errorHandling.cpp
+++ b/compiler/passes/errorHandling.cpp
@@ -126,6 +126,8 @@ try {
 }
 */
 
+namespace {
+
 class ErrorHandlingVisitor : public AstVisitorTraverse {
 
 public:
@@ -373,6 +375,8 @@ AList ErrorHandlingVisitor::errorCond(VarSymbol* errorVar,
 CallExpr* ErrorHandlingVisitor::haltExpr() {
   return new CallExpr(PRIM_RT_ERROR, new_CStringSymbol("uncaught error"));
 }
+
+} /* end anon namespace */
 
 void lowerErrorHandling() {
   if (!fMinimalModules)

--- a/modules/internal/ChapelError.chpl
+++ b/modules/internal/ChapelError.chpl
@@ -28,7 +28,7 @@ module ChapelError {
     }
   }
 
-  export proc chpl_delete_error(err: Error) {
+  proc chpl_delete_error(err: Error) {
     delete err;
   }
 }

--- a/test/errhandling/mferguson/on-throw.chpl
+++ b/test/errhandling/mferguson/on-throw.chpl
@@ -1,0 +1,18 @@
+proc test() throws {
+
+  for i in 1..10 {
+    on Locales[numLocales-1] {
+      writeln(i);
+      if i == 4 then
+        throw new Error("test");
+    }
+  }
+}
+
+try {
+  writeln("before test");
+  test();
+  writeln("after test");
+} catch {
+  writeln("caught error");
+}

--- a/test/errhandling/mferguson/on-throw.good
+++ b/test/errhandling/mferguson/on-throw.good
@@ -1,0 +1,6 @@
+before test
+1
+2
+3
+4
+caught error

--- a/test/errhandling/psahabu/illegal-throw.good
+++ b/test/errhandling/psahabu/illegal-throw.good
@@ -1,1 +1,2 @@
+illegal-throw.chpl:1: In function 'illegalThrow':
 illegal-throw.chpl:2: error: cannot throw in a non-throwing function

--- a/test/errhandling/psahabu/needs-catchall.good
+++ b/test/errhandling/psahabu/needs-catchall.good
@@ -1,1 +1,2 @@
+needs-catchall.chpl:3: In function 'doesNotThrow':
 needs-catchall.chpl:4: error: try without a catchall in a non-throwing function


### PR DESCRIPTION
This PR takes a series of steps to improve error handling with a goal of providing initial support for a 'throw' that propagates out of an 'on' statement.

* adds canBlockThrow as a way of computing if a block could throw
* in lowerErrorHandling, detects compiler-generated on statement functions that can throw, and marks these as `throws`.
* Removes export from `chpl_delete_error` since it should not assume argument is a narrow pointer.
* Adds a simple workaround for a c-compilation error - uses PRIM_ASSIGN in one place in error handling lowering.
* Adds a simple test of on + throws
* Moves error handling checking to new CanThrowVisitor; changed fatal errors in ErrorHandlingVisitor to internal errors (since these should all be found by the previous checking).

Passed full local testing

The new test, test/errhandling/mferguson/on-throw.chpl, passes with quickstart+gasnet.

Reviewed by @psahabu - thanks!