### PR TITLE
Avoid LLVM assert when --llvm-print-ir=missing

### DIFF
--- a/compiler/util/clangUtil.cpp
+++ b/compiler/util/clangUtil.cpp
@@ -2276,7 +2276,7 @@ void makeBinaryLLVM(void) {
   mysystem(makecmd, "Make Binary - Building Launcher and Copying");
 
 #ifdef HAVE_LLVM
-  if(llvmStageNum::FULL == llvmPrintIrStageNum)
+  if(llvmStageNum::FULL == llvmPrintIrStageNum && llvmPrintIrCName != NULL)
       printLlvmIr(getFunctionLLVM(llvmPrintIrCName), llvmStageNum::FULL);
 #endif
 }


### PR DESCRIPTION
Trivial, avoids an LLVM assert if the argument to --llvm-print-ir is not found.

Passed full local testing.