### PR TITLE
Update .bad file w.r.t. rank-change changes

### DIFF
--- a/test/arrays/tmacd/promotionLosesArrayShape.bad
+++ b/test/arrays/tmacd/promotionLosesArrayShape.bad
@@ -1,7 +1,7 @@
 ====== N ======
 0 0
 0 0
-[ArrayViewRankChangeDom(2,int(64),false,3*bool,3*int(64),ArrayViewRankChangeDist(DefaultDist,3*bool,3*int(64)))] int(64)
+[ArrayViewRankChangeDom(2,int(64),false,3*bool,3*int(64),int(64),ArrayViewRankChangeDist(DefaultDist,3*bool,3*int(64)))] int(64)
 ====== NN =====
 0 0 0 0
 [domain(1,int(64),false)] int(64)


### PR DESCRIPTION
My changes to add privatization to the rank-change array view
changed the bad output of this test.  Updating the .bad file
to reflect the new type signature.