### PR TITLE
Relax filter of which functions will be stack-traced

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -782,7 +782,7 @@ static void genUnwindSymbolTable(){
   if(strcmp(CHPL_UNWIND, "none") != 0){
     // Gets only user symbols
     forv_Vec(FnSymbol, fn, gFnSymbols) {
-      if(strncmp(fn->name, "chpl_", 5)) {
+      if(strncmp(fn->name, "chpl_", 5) || fn->hasFlag(FLAG_MODULE_INIT)) {
         symbols.push_back(fn);
       }
     }

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -782,7 +782,7 @@ static void genUnwindSymbolTable(){
   if(strcmp(CHPL_UNWIND, "none") != 0){
     // Gets only user symbols
     forv_Vec(FnSymbol, fn, gFnSymbols) {
-      if(strncmp(fn->cname, "chpl_", 5)) {
+      if(strncmp(fn->name, "chpl_", 5)) {
         symbols.push_back(fn);
       }
     }

--- a/test/runtime/panzone/fact-linenum.good
+++ b/test/runtime/panzone/fact-linenum.good
@@ -1,7 +1,8 @@
 fact-linenum.chpl:2: error: halt reached
 Stacktrace
 
-halt() at $CHPL_HOME/modules/internal/ChapelIO.chpl:679
+halt() at $CHPL_HOME/modules/internal/ChapelIO.chpl:662
 fact() at fact-linenum.chpl:2
 fact() at fact-linenum.chpl:3
 fact() at fact-linenum.chpl:3
+chpl__init_fact-linenum() at fact-linenum.chpl:1

--- a/test/runtime/panzone/fact-stacktrace.good
+++ b/test/runtime/panzone/fact-stacktrace.good
@@ -1,7 +1,8 @@
 fact-stacktrace.chpl:2: error: halt reached
 Stacktrace
 
-halt() at $CHPL_HOME/modules/internal/ChapelIO.chpl:679
+halt() at $CHPL_HOME/modules/internal/ChapelIO.chpl:662
 fact() at fact-stacktrace.chpl:1
 fact() at fact-stacktrace.chpl:1
 fact() at fact-stacktrace.chpl:1
+chpl__init_fact-stacktrace() at fact-stacktrace.chpl:1

--- a/test/runtime/panzone/stacktrace.good
+++ b/test/runtime/panzone/stacktrace.good
@@ -1,7 +1,8 @@
 stacktrace.chpl:2: error: halt reached
 Stacktrace
 
-halt() at $CHPL_HOME/modules/internal/ChapelIO.chpl:679
+halt() at $CHPL_HOME/modules/internal/ChapelIO.chpl:662
 a() at stacktrace.chpl:1
 b() at stacktrace.chpl:5
 c() at stacktrace.chpl:9
+chpl__init_stacktrace() at stacktrace.chpl:1


### PR DESCRIPTION
For some time now, I've been feeling as though there are functions
missing from the CHPL_UNWIND output that shouldn't be -- most notably,
top-level user code like module initialization code and main().  It
turns out that this was due to the filter used in codegen to limit
which functions will be traceable and which not was too strict, based
on the C identifier having the prefix of 'chpl_' which eliminates such
routines.

Here, I apply the same test to the 'name' field such that
anything we munge with 'chpl' to avoid conflicts with C (like 'main')
will still be reported while also opening up reporting to module init
routines so that top-level code will show up in the backtrace.  This
improves the output significantly for me.  It may be that even this
test is a bit silly (e.g., maybe there's a flag that we should be cueing off of
rather than basing it on a string prefix), but this was a simple fix
that will make my use of CHPL_UNWIND much better, so it seemed
worthwhile on its own without getting distracted by trying to find the
optimal solution right now.

Updated existing stacktrace tests to reflect the new output (and the
moved location of halt() which wasn't caught before due to lack of
testing on this directory).