### PR TITLE
Make chameneos versions all use initializers rather than constructors

### DIFF
--- a/test/release/examples/benchmarks/shootout/chameneosredux-fast.chpl
+++ b/test/release/examples/benchmarks/shootout/chameneosredux-fast.chpl
@@ -219,7 +219,7 @@ class MeetingPlace {
   //
   // Initialize the number of meetings that should take place
   //
-  proc MeetingPlace(numMeetings) {
+  proc init(numMeetings) {
     state.write(numMeetings << bitsPerChameneosID);
   }
 

--- a/test/release/examples/benchmarks/shootout/chameneosredux.chpl
+++ b/test/release/examples/benchmarks/shootout/chameneosredux.chpl
@@ -242,7 +242,7 @@ class MeetingPlace {
   //
   // Initialize the number of meetings that should take place
   //
-  proc MeetingPlace(numMeetings) {
+  proc init(numMeetings) {
     state.write(numMeetings << bitsPerChameneosID);
   }
 

--- a/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc-ideal.chpl
+++ b/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc-ideal.chpl
@@ -233,7 +233,7 @@ class MeetingPlace {
   //
   // Initialize the number of meetings that should take place
   //
-  proc MeetingPlace(numMeetings) {
+  proc init(numMeetings) {
     state.write(numMeetings << bitsPerChameneosID);
   }
 

--- a/test/studies/shootout/chameneos-redux/elliot/chameneosredux-ejr.chpl
+++ b/test/studies/shootout/chameneos-redux/elliot/chameneosredux-ejr.chpl
@@ -56,8 +56,9 @@ record Population {
   //
   // construct the population in terms of an array of colors passed in
   //
-  proc Population(colors) {
+  proc init(colors) {
     chamSpace = colors.domain;
+    super.init();
     forall i in chamSpace do
       chameneos[i] = new Chameneos(i, colors[i]);
   }
@@ -238,7 +239,7 @@ class MeetingPlace {
   //
   // Initialize the number of meetings that should take place
   //
-  proc MeetingPlace(numMeetings) {
+  proc init(numMeetings) {
     state.write(numMeetings << bitsPerChameneosID);
   }
 

--- a/test/studies/shootout/chameneos-redux/hannah/chameneos-redux-cas.chpl
+++ b/test/studies/shootout/chameneos-redux/hannah/chameneos-redux-cas.chpl
@@ -31,7 +31,7 @@ class MeetingPlace {
 
   /* constructor for MeetingPlace, sets the
      number of meetings to take place */
-  proc MeetingPlace() {
+  proc init() {
     state.write((numMeetings << MEET_COUNT_SHIFT) : uint(32));
   }
 

--- a/test/studies/shootout/chameneos-redux/hannah/chameneos-redux-multiple-meeting-places.chpl
+++ b/test/studies/shootout/chameneos-redux/hannah/chameneos-redux-multiple-meeting-places.chpl
@@ -150,7 +150,7 @@ proc populate (size : int) {
   const colorsDefault10  = (color.blue, color.red, color.yellow, color.red,
                             color.yellow, color.blue, color.red, color.yellow,
                             color.red, color.blue);
-  const D : domain(1) = [1..size];
+  const D : domain(1) = {1..size};
   var population : [D] Chameneos;
 
   if (size == 10) {
@@ -245,11 +245,8 @@ proc main() {
 
     const forest : MeetingPlace = new MeetingPlace();
 
-    const D : domain(1) = [1..numMeetings];
-    const meetingPlaces : [D] MeetingPlace;
-    for i in D {
-      meetingPlaces(i) = new MeetingPlace();
-    }
+    const D : domain(1) = {1..numMeetings};
+    const meetingPlaces : [D] MeetingPlace = [i in D] new MeetingPlace();
 
     const population1 = populate(numChameneos1);
     const population2 = populate(numChameneos2);

--- a/test/studies/shootout/chameneos-redux/hannah/chameneos-redux-v1.chpl
+++ b/test/studies/shootout/chameneos-redux/hannah/chameneos-redux-v1.chpl
@@ -35,7 +35,7 @@ class MeetingPlace {
 
   /* constructor for MeetingPlace, sets the
      number of meetings to take place */
-  proc MeetingPlace() {
+  proc init() {
     spotsLeft$.writeXF(numMeetings*2);
   }
 

--- a/test/studies/shootout/chameneos-redux/hannah/chameneos-redux.chpl
+++ b/test/studies/shootout/chameneos-redux/hannah/chameneos-redux.chpl
@@ -29,7 +29,7 @@ class MeetingPlace {
 
   /* constructor for MeetingPlace, sets the
      number of meetings to take place */
-  proc MeetingPlace() {
+  proc init() {
     spotsLeft$.writeXF(numMeetings*2);
   }
 

--- a/test/studies/shootout/chameneos-redux/lydia/chameneos-redux-lydia.chpl
+++ b/test/studies/shootout/chameneos-redux/lydia/chameneos-redux-lydia.chpl
@@ -31,7 +31,7 @@ class MeetingPlace {
 
   /* constructor for MeetingPlace, sets the
      number of meetings to take place */
-  proc MeetingPlace() {
+  proc init() {
     state.write(numMeetings << MEET_COUNT_SHIFT);
   }
 

--- a/test/studies/shootout/chameneos-redux/lydia/chameneos-redux-waitFor.chpl
+++ b/test/studies/shootout/chameneos-redux/lydia/chameneos-redux-waitFor.chpl
@@ -27,7 +27,7 @@ class MeetingPlace {
 
   /* constructor for MeetingPlace, sets the
      number of meetings to take place */
-  proc MeetingPlace() {
+  proc init() {
     state.write(numMeetings << MEET_COUNT_SHIFT);
   }
 

--- a/test/studies/shootout/chameneos-redux/lydia/chameneos-redux-yield.chpl
+++ b/test/studies/shootout/chameneos-redux/lydia/chameneos-redux-yield.chpl
@@ -29,7 +29,7 @@ class MeetingPlace {
 
   /* constructor for MeetingPlace, sets the
      number of meetings to take place */
-  proc MeetingPlace() {
+  proc init() {
     state.write(numMeetings << MEET_COUNT_SHIFT);
   }
 

--- a/test/studies/shootout/submitted/chameneosredux.chpl
+++ b/test/studies/shootout/submitted/chameneosredux.chpl
@@ -245,7 +245,7 @@ class MeetingPlace {
   //
   // Initialize the number of meetings that should take place
   //
-  proc MeetingPlace(numMeetings) {
+  proc init(numMeetings) {
     state.write(numMeetings << bitsPerChameneosID);
   }
 


### PR DESCRIPTION
This updates the chameneos tests to use initializers rather than
constructors.  The only one that was particularly interesting was
one of Elliot's that needed super.init() for the Population record
due to using a loop to initialize the array, similar to other patterns
that @lydia-duncan and I have discussed in previous initializer
conversion PRs.

I also updated a .notest Hannah version, though it has other problems.