### PR TITLE
Convert makeNoop(CallExpr*) to CallExpr::convertToNoop()

### DIFF
--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -788,7 +788,6 @@ void DefExpr::accept(AstVisitor* visitor) {
 *                                                                           *
 ************************************* | ************************************/
 
-
 void DefExpr::prettyPrint(std::ostream *o) {
   *o << "<DefExprType>";
 }
@@ -801,7 +800,6 @@ static void callExprHelper(CallExpr* call, BaseAST* arg) {
   else
     INT_FATAL(call, "Bad argList in CallExpr constructor");
 }
-
 
 /************************************* | **************************************
 *                                                                             *
@@ -1390,6 +1388,37 @@ bool CallExpr::isRefExternStarTuple(Symbol* formal, Expr* actual) const {
     retval = true;
 
   return retval;
+}
+
+//
+// 2017/07/09: resolveBlockStmt() currently relies on
+//
+//    void for_exprs_postorder(expr, blockStmt);
+//
+// to traverse the sub-expressions within a given block-stmt.  This
+// implementation choice complicates any transformation that would otherwise
+// replace one statement with a different one; a simple use of
+//
+//    node->replace(other);
+//
+// is likely to interfere with the internal sequencing within this macro.
+//
+// The work-around is to insert the new, fully resolved, statement
+// immediately before the "current" statement and then convert the current
+// statement in to a NOOP.  This will ensure that statements will be
+// sequenced correctly.
+//
+
+void CallExpr::convertToNoop() {
+  if (baseExpr != NULL) {
+    baseExpr->remove();
+  }
+
+  while (numActuals() > 0) {
+    get(1)->remove();
+  }
+
+  primitive = primitives[PRIM_NOOP];
 }
 
 /************************************* | **************************************

--- a/compiler/AST/primitive.cpp
+++ b/compiler/AST/primitive.cpp
@@ -740,15 +740,3 @@ bool getSettingPrimitiveDstSrc(CallExpr* call, Expr** dest, Expr** src)
 
   return false;
 }
-
-void makeNoop(CallExpr* call) {
-  if (call->baseExpr)
-    call->baseExpr->remove();
-
-  while (call->numActuals())
-    call->get(1)->remove();
-
-  call->primitive = primitives[PRIM_NOOP];
-}
-
-

--- a/compiler/include/expr.h
+++ b/compiler/include/expr.h
@@ -277,6 +277,8 @@ public:
   Expr*           get(int index)                                         const;
   FnSymbol*       findFnSymbol();
 
+  void            convertToNoop();
+
 private:
   GenRet          codegenPrimitive();
   GenRet          codegenPrimMove();

--- a/compiler/include/primitive.h
+++ b/compiler/include/primitive.h
@@ -253,29 +253,31 @@ enum PrimitiveTag {
 };
 
 class PrimitiveOp { public:
-  PrimitiveTag tag;
-  const char *name;
+  PrimitiveTag  tag;
+  const char*   name;
   QualifiedType (*returnInfo)(CallExpr*);
-  bool isEssential; // has effects visible outside of the function
-  bool passLineno;  // pass line number and filename to this primitive
+  bool          isEssential; // has effects visible outside of the function
+  bool          passLineno;  // pass line number and filename to this primitive
 
-  PrimitiveOp(PrimitiveTag atag, const char *aname, QualifiedType (*areturnInfo)(CallExpr*));
+  PrimitiveOp(PrimitiveTag  atag,
+              const char*   aname,
+              QualifiedType (*areturnInfo)(CallExpr*));
 };
 
 extern HashMap<const char *, StringHashFns, PrimitiveOp *> primitives_map;
 
-extern PrimitiveOp* primitives[NUM_KNOWN_PRIMS];
-
-void printPrimitiveCounts(const char* passName);
-void initPrimitive();
+extern PrimitiveOp*     primitives[NUM_KNOWN_PRIMS];
 
 extern Vec<const char*> memDescsVec;
+
+void       printPrimitiveCounts(const char* passName);
+
+void       initPrimitive();
+
 VarSymbol* newMemDesc(const char* str);
+
 VarSymbol* newMemDesc(Type* type);
 
-
-bool getSettingPrimitiveDstSrc(CallExpr* call, Expr** dest, Expr** src);
-
-void makeNoop(CallExpr* call);
+bool       getSettingPrimitiveDstSrc(CallExpr* call, Expr** dest, Expr** src);
 
 #endif

--- a/compiler/resolution/postFold.cpp
+++ b/compiler/resolution/postFold.cpp
@@ -179,36 +179,54 @@ Expr* postFold(Expr* expr) {
               if (VarSymbol* rhsVar = toVarSymbol(rhs->symbol())) {
                 if (rhsVar->immediate) {
                   paramMap.put(lhs->symbol(), rhsVar);
+
                   lhs->symbol()->defPoint->remove();
-                  makeNoop(call);
+
+                  call->convertToNoop();
+
                   set = true;
                 }
               }
+
               if (EnumSymbol* rhsv = toEnumSymbol(rhs->symbol())) {
                 paramMap.put(lhs->symbol(), rhsv);
+
                 lhs->symbol()->defPoint->remove();
-                makeNoop(call);
+
+                call->convertToNoop();
+
                 set = true;
               }
             }
           }
+
           if (Symbol* lhsSym = lhs->symbol()) {
             if (lhsSym->isParameter()) {
               if (!lhsSym->hasFlag(FLAG_TEMP)) {
                 if (!isLegalParamType(lhsSym->type)) {
-                  USR_FATAL_CONT(call, "'%s' is not of a supported param type", lhsSym->name);
+                  USR_FATAL_CONT(call,
+                                 "'%s' is not of a supported param type",
+                                 lhsSym->name);
+
                 } else if (!set) {
-                  USR_FATAL_CONT(call, "Initializing parameter '%s' to value not known at compile time", lhsSym->name);
+                  USR_FATAL_CONT(call,
+                                 "Initializing parameter '%s' to value "
+                                 "not known at compile time",
+                                 lhsSym->name);
                   lhs->symbol()->removeFlag(FLAG_PARAM);
                 }
+
               } else /* this is a compiler temp */ {
                 if (lhsSym->hasFlag(FLAG_RVV) && !set) {
-                  USR_FATAL_CONT(call, "'param' functions cannot return non-'param' values");
+                  USR_FATAL_CONT(call,
+                                 "'param' functions cannot return "
+                                 "non-'param' values");
                 }
               }
             }
           }
         }
+
         if (!set) {
           if (lhs->symbol()->hasFlag(FLAG_MAYBE_TYPE)) {
             // Add FLAG_TYPE_VARIABLE when relevant
@@ -260,6 +278,7 @@ Expr* postFold(Expr* expr) {
             // TODO -- remove this? Or explain its purpose?
             lhs->symbol()->removeFlag(FLAG_EXPR_TEMP);
         }
+
         if (!set) {
           if (CallExpr* rhs = toCallExpr(call->get(2))) {
             if (rhs->isPrimitive(PRIM_NO_INIT)) {
@@ -268,12 +287,13 @@ Expr* postFold(Expr* expr) {
               // further and so this statement can't be removed until
               // resolveRecordInitializers
               if (!isAggregateType(rhs->get(1)->getValType())) {
-                makeNoop(call);
+                call->convertToNoop();
               }
             }
           }
         }
       }
+
     } else if (call->isPrimitive(PRIM_GET_MEMBER)) {
       Type* baseType = call->get(1)->getValType();
       const char* memberName = get_string(call->get(2));
@@ -456,14 +476,17 @@ Expr* postFold(Expr* expr) {
         // assignment, we key off of the name :-(
         if (call->isPrimitive(PRIM_MOVE) || call->isNamedAstr(astrSequals)) {
           if (sym->symbol()->hasFlag(FLAG_RVV)) {
-            makeNoop(call);
+            call->convertToNoop();
           }
+
           return result;
         }
       }
 
-      if (sym->symbol()->type != dtUnknown && sym->symbol()->type != val->type) {
+      if (sym->symbol()->type != dtUnknown &&
+          sym->symbol()->type != val->type) {
         Symbol* toSym = sym->symbol();
+
         if (!toSym->hasFlag(FLAG_TYPE_VARIABLE)) {
           // This assertion is here to ensure compatibility with old code.
           // Todo: remove after 1.15 release.


### PR DESCRIPTION
This is a simple PR that converts the function void makeNoop(CallExpr* expr) 
to be void CallExpr::convertToNoop();


While working on a record initializer issue that @benharsh recently surfaced I
determined that I would be making an additional use of the makeNoop() hack
as a work-around for a resolve issue.

I am taking this opportunity to convert this simple function to the equivalent
simple method using a name that helps to remind the reader that this is mutating
an existing CallExpr rather than constructing a new one.



Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.
Ran start_test on a portion of release/ for each configuration.
Also compiled with CHPL_LLVM=llvm on linux64 and tested a portion of release/

Passed a single-locale paratest.
