### PR TITLE
Refactor prim init

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5069,24 +5069,6 @@ Expr* resolvePrimInit(CallExpr* call) {
 
   SET_LINENO(call);
 
-  if (type->defaultValue ||
-      type->symbol->hasFlag(FLAG_TUPLE)) {
-    // Very special case for the method token.
-    // Unfortunately, dtAny cannot (currently) bind to dtMethodToken, so
-    // inline proc _defaultOf(type t) where t==_MT cannot be written in module
-    // code.
-    // Maybe it would be better to indicate which calls are method calls
-    // through the use of a flag.  Until then, we just fake in the needed
-    // result and short-circuit the resolution of _defaultOf(type _MT).
-    if (type == dtMethodToken) {
-      Expr* retval = new SymExpr(gMethodToken);
-
-      call->replace(retval);
-
-      return retval;
-    }
-  }
-
   if (AggregateType* at = toAggregateType(type)) {
     if (at->defaultInitializer                      != NULL &&
         type->symbol->hasFlag(FLAG_ITERATOR_RECORD) == true) {


### PR DESCRIPTION
This is a reasonably simple "close the gap" PR.  No change in behavior.


@benharsh developed a trivial test that exposes a bug when creating arrays of records if the
record has an initializer.  The fix for this bug includes revisions to resolvePrimInit() and resolveMove().

This PR straightens out resolvePrimInit() as a precursor to applying the bug fix.

Submitted as four relatively simple commits to help confirm that this should match
the behavior of the existing code.

Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.
Passed a small portion of start_test release/ on all 4 configs.
Passed a single-locale paratest.