### PR TITLE
Fix no-local bug with ref-intent and virtual method calls

### DIFF
--- a/compiler/passes/insertWideReferences.cpp
+++ b/compiler/passes/insertWideReferences.cpp
@@ -961,12 +961,20 @@ static void addKnownWides() {
         }
       }
     }
+    else if (call->isPrimitive(PRIM_VIRTUAL_METHOD_CALL)) {
+      int i = 0;
+      for_actuals(actual, call) {
+        if (SymExpr* se = toSymExpr(actual)) {
+          if (i > 1 && actual_to_formal(se)->isRef()) {
+            setWide(call, se->symbol());
+          }
+        }
+        ++i;
+      }
+    }
     else if (call->isPrimitive(PRIM_HEAP_REGISTER_GLOBAL_VAR) ||
              call->isPrimitive(PRIM_CHPL_COMM_ARRAY_GET) ||
-             call->isPrimitive(PRIM_VIRTUAL_METHOD_CALL) ||
              call->isPrimitive(PRIM_CHPL_COMM_GET)) { // TODO: Is this necessary?
-      // For virtual method calls: do we need to widen the actual if the formal
-      // doesn't have the ref intent?
       for_actuals(actual, call) {
         if (SymExpr* se = toSymExpr(actual)) {
           if (typeCanBeWide(se->symbol())) {

--- a/compiler/passes/insertWideReferences.cpp
+++ b/compiler/passes/insertWideReferences.cpp
@@ -965,6 +965,8 @@ static void addKnownWides() {
              call->isPrimitive(PRIM_CHPL_COMM_ARRAY_GET) ||
              call->isPrimitive(PRIM_VIRTUAL_METHOD_CALL) ||
              call->isPrimitive(PRIM_CHPL_COMM_GET)) { // TODO: Is this necessary?
+      // For virtual method calls: do we need to widen the actual if the formal
+      // doesn't have the ref intent?
       for_actuals(actual, call) {
         if (SymExpr* se = toSymExpr(actual)) {
           if (typeCanBeWide(se->symbol())) {

--- a/compiler/passes/insertWideReferences.cpp
+++ b/compiler/passes/insertWideReferences.cpp
@@ -965,7 +965,7 @@ static void addKnownWides() {
       int i = 0;
       for_actuals(actual, call) {
         if (SymExpr* se = toSymExpr(actual)) {
-          if (i > 1 && actual_to_formal(se)->isRef()) {
+          if (i > 1 && actual_to_formal(se)->isRefOrWideRef()) {
             setWide(call, se->symbol());
           }
         }

--- a/compiler/passes/insertWideReferences.cpp
+++ b/compiler/passes/insertWideReferences.cpp
@@ -963,6 +963,7 @@ static void addKnownWides() {
     }
     else if (call->isPrimitive(PRIM_HEAP_REGISTER_GLOBAL_VAR) ||
              call->isPrimitive(PRIM_CHPL_COMM_ARRAY_GET) ||
+             call->isPrimitive(PRIM_VIRTUAL_METHOD_CALL) ||
              call->isPrimitive(PRIM_CHPL_COMM_GET)) { // TODO: Is this necessary?
       for_actuals(actual, call) {
         if (SymExpr* se = toSymExpr(actual)) {

--- a/test/optimizations/widepointers/refOverride.chpl
+++ b/test/optimizations/widepointers/refOverride.chpl
@@ -1,0 +1,30 @@
+// Adapted from user submitted code in GitHub issue #6642
+
+class SuperPrinter {
+  //for faulty behavior this formal must have an explicit ref intent
+  proc print(ref data) {
+    writeln("SuperPrinter: ", data.x);
+  }
+}
+
+class SubPrinter : SuperPrinter {
+  proc print(ref data) {
+    writeln("Subprinter: ", data.x);
+  }
+}
+
+class Foo { var x = 10; }
+
+proc main() {
+  var printer: SuperPrinter;
+  printer = new SubPrinter();
+
+  //
+  // At the time this test was created, IWR was widening all formals in
+  // virtual methods but was failing to widen the corresponding actuals. This
+  // resulted in a compile-time failure when the backend compiler encountered
+  // the type mismatch between a narrow/local actual and a wide formal.
+  //
+  var data = new Foo();
+  printer.print(data);
+}

--- a/test/optimizations/widepointers/refOverride.good
+++ b/test/optimizations/widepointers/refOverride.good
@@ -1,0 +1,1 @@
+Subprinter: 10


### PR DESCRIPTION
A user submitted a test that failed to compile due to a type
mismatch between an actual and a formal. This test had the
ref-intent on a formal in a virtual method. Virtual method
formals are automatically widened in all cases, so the actual
should have also been widened.

Testing:
- [x] full no-local
- [x] full gasnet
- [x] check stencil PRK performance for local field optimization