### PR TITLE
Fix bug in forwarding generic methods

### DIFF
--- a/test/classes/bharshbarg/generic-forwarding.bad
+++ b/test/classes/bharshbarg/generic-forwarding.bad
@@ -1,2 +1,0 @@
-generic-forwarding.chpl:16: error: unresolved call 'Upper(int(64)).something(Upper(int(64)))'
-generic-forwarding.chpl:4: note: candidates are: Lower.something(foo)

--- a/test/classes/bharshbarg/generic-forwarding.future
+++ b/test/classes/bharshbarg/generic-forwarding.future
@@ -1,1 +1,0 @@
-bug: failure to compile invocation of forwarded method from generic field


### PR DESCRIPTION
Support for forwarding didn't find methods in the methods list for the
type the forwarded-to-type was instantiated from. This commit fixes that
by introducing a new function, collectMethodsNamed, to do so.

Resolves the future added in PR #6634.

Passed test/classes/ferguson/forwarding.

- [x] full local testing

Reviewed by @vasslitvinov - thanks!