### PR TITLE
Allow deadBlockElimination to remove unreachable do-while loops

### DIFF
--- a/compiler/optimizations/deadCodeElimination.cpp
+++ b/compiler/optimizations/deadCodeElimination.cpp
@@ -658,8 +658,11 @@ static void deleteUnreachableBlocks(FnSymbol* fn, BasicBlockSet& reachable)
         condStmt->remove();
 
       else if (doWhileStmt && doWhileStmt->condExprGet() == expr)
-        // Do nothing. (NOTE 3)
-        ;
+        if (doWhileStmt->length() == 0)
+          doWhileStmt->remove();
+        else
+          // Do nothing. (NOTE 3)
+          ;
 
       else if (whileStmt   && whileStmt->condExprGet()   == expr)
         // If the expr is the condition expression of a while statement,
@@ -794,4 +797,4 @@ static void deadGotoElimination(FnSymbol* fn)
 //# 3. Even if the condition of a DoWhileLoop is dead, the loop cannot be
 //#    removed because a DoWhileLoop must execute at least once. We _could_
 //#    remove the condition variable, but the compiler expects a non-null expr
-//#    to be there.
+//#    to be there. However, if the loop body is empty, we can remove it.


### PR DESCRIPTION
PR #6631 fixed a bug in deadBlockElimination by preventing deadBlockElimination
from removing do-while loops just because the block containing the condition
variable was dead. This effectively meant that do-while loops could never be
dead block eliminated even if the entire loop was unreachable e.g.

```chapel
proc bar() {
  return 0;
  do { writeln("in loop"); } while true;
}
bar();
```

would leave an empty do-while loop. This updates deadBlockElimination to allow
removing the entire do-while loop if it's empty. The body of the loop (the
writeln above) is removed by dead block elimination since the body is
unreachable, which leaves the loop empty and allows it to be removed.

Note that there's no real harm (other than generated code bloat) to leaving the
empty do-while loop around. Only user code (not compiler transformations) will
introduce this sort of dead loops. That said a cce warning was complaining
about a loop being unreachable, so rather than just quieting the warning, I
opted to remove the loop.
