### PR TITLE
Fix how we exclude nodes for paratest.chapcs

### DIFF
--- a/util/test/paratest.chapcs
+++ b/util/test/paratest.chapcs
@@ -29,24 +29,41 @@ def run_command_wrapper(command):
     return output_lines
 
 
-def get_num_exclusive_nodes():
+def expand_hostnames(hostname):
     """
-    Get the number of nodes reserved exclusively on the chapel partition
+    Expand a possibly shorthand nodelist into all the full hostnames. e.g
+    expands 'chapcs[07-08]' to '[chapcs07, chapcs08]'
     """
-    # Grab the "SHARED,NODES" info for all jobs. For each exclusive (SHARED=no)
-    # job add up the number of nodes it's using
+    scontrol_cmd = ['scontrol', 'show', 'hostname', hostname]
+    scontrol_out = run_command_wrapper(scontrol_cmd)
+    return scontrol_out
+
+
+def get_exclusive_nodes():
+    """
+    Get the nodes reserved exclusively on the chapel partition. Returns tuple
+    of (num_exclusive_nodes, exclusive_hostnames)
+    """
+    # Grab the "SHARED;NODES;NODELIST;REQ_NODES" info for all jobs. For each
+    # exclusive (SHARED=no) job, track the nodes allocated/requested or the
+    # number of nodes requested if no specific nodes were allocated/requested.
     squeue_cmd = ['squeue',
                   '--partition=chapel',
                   '--noheader',
-                  '--format="%h,%D"']
+                  '--format="%h;%D;%N;%n"']
     squeue_out = run_command_wrapper(squeue_cmd)
     num_exclusive_nodes = 0
+    exclusive_hostnames = set()
     for line in squeue_out:
-        shared, num_nodes = line.split(',')
+        shared, num_nodes, nodelist, req_nodes = line.split(';')
         if shared == 'no':
-            num_exclusive_nodes += int(num_nodes)
-
-    return num_exclusive_nodes
+            nodes = nodelist or req_nodes
+            if nodes:
+                exclusive_hostnames.update(expand_hostnames(nodes))
+            else:
+                num_exclusive_nodes += int(num_nodes)
+    num_exclusive_nodes += len(exclusive_hostnames)
+    return (num_exclusive_nodes, exclusive_hostnames)
 
 
 def get_num_non_exclusive_nodes():
@@ -61,7 +78,7 @@ def get_num_non_exclusive_nodes():
                  '--format="%D"']
     sinfo_out = run_command_wrapper(sinfo_cmd)
     num_online_nodes = int(sinfo_out[0])
-    num_non_exclusive_nodes = num_online_nodes - get_num_exclusive_nodes()
+    num_non_exclusive_nodes = num_online_nodes - get_exclusive_nodes()[0]
     return num_non_exclusive_nodes
 
 
@@ -108,10 +125,14 @@ def run_paratest(args):
 
     salloc_cmd = ['salloc',
                   '--nodes={0}'.format(num_free_nodes),
-                  '--immediate',
+                  '--immediate=60',
                   '--partition=chapel',
                   '--share',
                   '--nice']
+
+    exclude_set = get_exclusive_nodes()[1]
+    if exclude_set:
+        salloc_cmd.append('--exclude={0}'.format(','.join(exclude_set)))
 
     paratest_path = os.path.join(os.path.dirname(__file__), 'paratest.server')
 


### PR DESCRIPTION
Previously we would double count exclusive reservations on the same node and
we'd sometimes try to grab a node that was exclusively reserved. This fixes
both of these problems and avoids errors that caused messages along the lines of:

    salloc: error: Unable to allocate resources: Immediate execution impossible
    salloc: error: Unable to allocate resources: Requested nodes are busy

Problem 1 (double counting exclusive reservations):

    SHARED   NODES  NODELIST  REQ_NODES
    no       1                chapcs11
    no       1                chapcs11

we used to just count how many jobs had exclusive reservations, so here we'd
calculate that 2 nodes were reserved exclusively, when in fact only 1 was.

Problem 2 (reserving the wrong nodes):

    SHARED   NODES  NODELIST       REQ_NODES
    no       1                     chapcs11
    yes      1      chapcs10       chapcs10
    yes      12     chapcs[00-11]

we used to see that only one node was being used exclusively, so we'd try to
grab 11 nodes. However, to "load balance" slurm would try to grab chapcs11 since
chapcs10 has 2 jobs on it while others just had (even though chapcs11 had an
exclusive reservation out for it.)

Now we calculate how many nodes are reserved exclusively and maintain a list of
the nodes that have been explicitly requested, and we'll exclude them from our
salloc. e.g. instead of:

    salloc --nodes=11 --immediate

we do:

    salloc --nodes=11 --exclude=chapcs11 --immediate=60

Note that even excluding chapcs11 explicitly it takes slurm a little while to
figure out that it has enough nodes (I haven no idea why) so the immediate=60
is required.