### PR TITLE
Preliminary "whitespace" shuffle to clean up resolveMove() and helpers

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -2945,84 +2945,6 @@ static Symbol* getBaseSymForConstCheck(CallExpr* call) {
 }
 
 
-// If 'call' is an access to a const thing, for example a const field
-// or a field of a const record, set const flag(s) on the symbol
-// that stores the result of 'call'.
-static void setFlagsAndCheckForConstAccess(Symbol* dest,
-                                         CallExpr* call, FnSymbol* resolvedFn)
-{
-  // Is the outcome of 'call' a reference to a const?
-  bool refConst = resolvedFn->hasFlag(FLAG_REF_TO_CONST);
-  // Another flag that's relevant.
-  const bool constWCT = resolvedFn->hasFlag(FLAG_REF_TO_CONST_WHEN_CONST_THIS);
-  // The second flag does not make sense when the first flag is set.
-  INT_ASSERT(!(refConst && constWCT));
-
-  // The symbol whose field is accessed, if applicable:
-  Symbol* baseSym = NULL;
-
-  if (refConst) {
-    if (resolvedFn->hasFlag(FLAG_FIELD_ACCESSOR) &&
-        // promotion wrappers are not handled currently
-        !resolvedFn->hasFlag(FLAG_PROMOTION_WRAPPER)
-        )
-      baseSym = getBaseSymForConstCheck(call);
-
-  } else if (resolvedFn->hasFlag(FLAG_NEW_ALIAS_FN) &&
-             dest->hasFlag(FLAG_ARRAY_ALIAS)) {
-    if (!dest->isConstant()) {
-      // We are creating a var alias - ensure aliasee is not const either.
-      SymExpr* aliaseeSE = toSymExpr(call->get(2));
-      INT_ASSERT(aliaseeSE);
-      if (aliaseeSE->symbol()->isConstant())
-        USR_FATAL_CONT(call, "creating a non-const alias '%s' of a const array or domain", dest->name);
-    }
-  } else if (constWCT) {
-    baseSym = getBaseSymForConstCheck(call);
-    if (baseSym->isConstant()               ||
-        baseSym->hasFlag(FLAG_REF_TO_CONST) ||
-        baseSym->hasFlag(FLAG_CONST)
-       )
-      refConst = true;
-    else
-      // The result is not constant.
-      baseSym = NULL;
-
-  } else if (dest->hasFlag(FLAG_ARRAY_ALIAS)        &&
-             resolvedFn->hasFlag(FLAG_AUTO_COPY_FN))
-  {
-    INT_ASSERT(false); // should not happen
-  }
-
-  // Do not consider it const if it is an access to 'this'
-  // in a constructor. Todo: will need to reconcile with UMM.
-  // btw (baseSym != NULL) ==> (refConst == true).
-  if (baseSym) {
-    // Aside: at this point 'baseSym' can have reference or value type,
-    // seemingly without a particular rule.
-    if (baseSym->hasFlag(FLAG_ARG_THIS)   &&
-        isInConstructorLikeFunction(call)
-        )
-      refConst = false;
-  }
-
-  if (refConst) {
-    if (isReferenceType(dest->type))
-      dest->addFlag(FLAG_REF_TO_CONST);
-    else
-      dest->addFlag(FLAG_CONST);
-
-    if (baseSym && baseSym->hasFlag(FLAG_ARG_THIS))
-      // 'call' can be a field accessor or an array element accessor or ?
-      dest->addFlag(FLAG_REF_FOR_CONST_FIELD_OF_THIS);
-
-    // Propagate this flag.  btw (recConst && constWCT) ==> (baseSym != NULL)
-    if (constWCT && baseSym->hasFlag(FLAG_REF_FOR_CONST_FIELD_OF_THIS))
-      dest->addFlag(FLAG_REF_FOR_CONST_FIELD_OF_THIS);
-  }
-}
-
-
 // Report an error when storing a sync or single variable into a tuple.
 // This is because currently we deallocate memory excessively in this case.
 void checkForStoringIntoTuple(CallExpr* call, FnSymbol* resolvedFn)
@@ -3911,41 +3833,6 @@ void printTaskOrForallConstErrorNote(Symbol* aVar) {
           }
 }
 
-// We do some const-related work upon PRIM_MOVE
-static void setConstFlagsAndCheckUponMove(Symbol* lhs, Expr* rhs) {
-  // If this assigns into a loop index variable from a non-var iterator,
-  // mark the variable constant.
-  if (SymExpr* rhsSE = toSymExpr(rhs)) {
-    // If RHS is this special variable...
-    if (rhsSE->symbol()->hasFlag(FLAG_INDEX_OF_INTEREST)) {
-      INT_ASSERT(lhs->hasFlag(FLAG_INDEX_VAR));
-      Type* rhsType = rhsSE->symbol()->type;
-      // ... and not of a reference type
-      // todo: differentiate based on ref-ness, not _ref type
-      // todo: not all const if it is zippered and one of iterators is var
-      if (!isReferenceType(rhsType) && !isTupleContainingAnyReferences(rhsType))
-       // ... and not an array (arrays are always yielded by reference)
-       if (!rhsSE->symbol()->type->symbol->hasFlag(FLAG_ARRAY))
-        // ... then mark LHS constant.
-        lhs->addFlag(FLAG_CONST);
-    }
-  } else if (CallExpr* rhsCall = toCallExpr(rhs)) {
-    if (rhsCall->isPrimitive(PRIM_GET_MEMBER)) {
-      if (SymExpr* rhsBase = toSymExpr(rhsCall->get(1))) {
-        if (rhsBase->symbol()->hasFlag(FLAG_CONST) ||
-            rhsBase->symbol()->hasFlag(FLAG_REF_TO_CONST)
-            )
-          lhs->addFlag(FLAG_REF_TO_CONST);
-      } else {
-        INT_ASSERT(false); // PRIM_GET_MEMBER of a non-SymExpr??
-      }
-    } else if (FnSymbol* resolvedFn = rhsCall->resolvedFunction()) {
-        setFlagsAndCheckForConstAccess(lhs, rhsCall, resolvedFn);
-    }
-  }
-}
-
-
 static void resolveTupleAndExpand(CallExpr* call) {
   SymExpr* se = toSymExpr(call->get(1));
   int size = 0;
@@ -4368,56 +4255,70 @@ static bool hasCopyConstructor(AggregateType* ct) {
 *                                                                             *
 ************************************** | *************************************/
 
+static void moveSetConstFlagsAndCheck(Symbol* lhs, Expr* rhs);
+
+static void moveSetFlagsAndCheckForConstAccess(Symbol*   lhs,
+                                               CallExpr* rhsCall,
+                                               FnSymbol* resolvedFn);
+
+
 static void resolveMove(CallExpr* call) {
-  if (call->id == breakOnResolveID )
+  if (call->id == breakOnResolveID) {
     gdbShouldBreakHere();
+  }
 
-  Expr* rhs = call->get(2);
-  Symbol* lhs = NULL;
-  if (SymExpr* se = toSymExpr(call->get(1)))
-    lhs = se->symbol();
-  INT_ASSERT(lhs);
+  Expr*     rhs           = call->get(2);
+  bool      rhsIsTypeExpr = isTypeExpr(rhs);
+  Type*     rhsType       = rhs->typeInfo();
 
-  FnSymbol* fn = toFnSymbol(call->parentSymbol);
-  bool isReturn = fn ? lhs == fn->getReturnSymbol() : false;
-  bool rhsIsTypeExpr = isTypeExpr(rhs);
+  Symbol*   lhs           = toSymExpr(call->get(1))->symbol();
+  Type*     lhsType       = lhs->type;
 
-  if (lhs->hasFlag(FLAG_TYPE_VARIABLE) && !rhsIsTypeExpr) {
-    if (isReturn) {
-      if (!call->parentSymbol->hasFlag(FLAG_RUNTIME_TYPE_INIT_FN))
+  FnSymbol* fn            = toFnSymbol(call->parentSymbol);
+  bool      isReturn      = fn ? lhs == fn->getReturnSymbol() : false;
+
+  if (lhs->hasFlag(FLAG_TYPE_VARIABLE) == true && rhsIsTypeExpr == false) {
+    if (isReturn == true) {
+      if (fn->hasFlag(FLAG_RUNTIME_TYPE_INIT_FN) == false)
         USR_FATAL(call, "illegal return of value where type is expected");
+
     } else {
       USR_FATAL(call, "illegal assignment of value to type");
     }
   }
 
-  if (!lhs->hasFlag(FLAG_TYPE_VARIABLE) && !lhs->hasFlag(FLAG_MAYBE_TYPE) && rhsIsTypeExpr) {
-    if (isReturn) {
+  if (lhs->hasFlag(FLAG_TYPE_VARIABLE) == false &&
+      lhs->hasFlag(FLAG_MAYBE_TYPE)    == false &&
+      rhsIsTypeExpr                    == true) {
+    if (isReturn == true) {
       USR_FATAL(call, "illegal return of type where value is expected");
+
     } else {
-      if (lhs->hasFlag(FLAG_CHPL__ITER))
-        USR_FATAL(call, "unable to iterate over type '%s'",
+      if (lhs->hasFlag(FLAG_CHPL__ITER) == true) {
+        USR_FATAL(call,
+                  "unable to iterate over type '%s'",
                   toString(rhs->getValType()));
-      else
+      } else {
         USR_FATAL(call, "illegal assignment of type to value");
+      }
     }
   }
 
-  // do not resolve function return type yet
-  // except for constructors
-  if (fn && call->parentExpr != fn->where && call->parentExpr != fn->retExprType &&
-      isReturn && fn->_this != lhs) {
+  // do not resolve function return type yet except for constructors
+  if (isReturn         == true            &&
+      fn->retType      == dtUnknown       &&
 
-    if (fn->retType == dtUnknown) {
-      return;
-    }
+      call->parentExpr != fn->where       &&
+      call->parentExpr != fn->retExprType &&
+      fn->_this        != lhs) {
+    return;
   }
-
-  Type* rhsType = rhs->typeInfo();
 
   // This is a workaround for order-of-resolution problems with
   // extern type aliases
-  if (rhsIsTypeExpr && rhs->typeInfo() == dtUnknown && isSymExpr(rhs)) {
+  if (rhsIsTypeExpr   == true      &&
+      rhs->typeInfo() == dtUnknown &&
+      isSymExpr(rhs)  == true) {
     // Try resolving type aliases now.
     rhsType = resolveTypeAlias(toSymExpr(rhs));
   }
@@ -4425,7 +4326,7 @@ static void resolveMove(CallExpr* call) {
   if (rhsType == dtVoid) {
     if (CallExpr* rhsCall = toCallExpr(rhs)) {
       if (FnSymbol* rhsFn = rhsCall->resolvedFunction()) {
-        if (rhsFn->hasFlag(FLAG_VOID_NO_RETURN_VALUE)) {
+        if (rhsFn->hasFlag(FLAG_VOID_NO_RETURN_VALUE) == true) {
           USR_FATAL(userCall(call),
                     "illegal use of function that does not "
                     "return a value: '%s'",
@@ -4439,22 +4340,28 @@ static void resolveMove(CallExpr* call) {
   // in buildForLoopExpr would be an _array instead of a ref(_array)
   // in 4-init-array-forexpr.chpl. This could be improved with
   // QualifiedType.
-  if (lhs->hasFlag(FLAG_MAYBE_REF) && !isReferenceType(rhsType)) {
+  if (lhs->hasFlag(FLAG_MAYBE_REF) == true &&
+      isReferenceType(rhsType)     == false) {
     if (SymExpr* se = toSymExpr(rhs)) {
       if (ArgSymbol* arg = toArgSymbol(se->symbol())) {
         if (concreteIntent(arg->intent, arg->type) & INTENT_FLAG_REF) {
           makeRefType(rhsType);
+
           rhsType = rhsType->refType;
 
           // Add PRIM_ADDR_OF
           //  (this won't be necessary with QualifiedType/PRIM_SET_REFERENCE)
           VarSymbol* addrOfTmp = newTemp("moveAddr", rhsType);
+          SymExpr*   newRhs    = new SymExpr(addrOfTmp);
+
           call->insertBefore(new DefExpr(addrOfTmp));
-          call->insertBefore(new CallExpr(PRIM_MOVE, addrOfTmp,
-                                        new CallExpr(PRIM_ADDR_OF,
-                                                     rhs->copy())));
-          SymExpr* newRhs = new SymExpr(addrOfTmp);
+          call->insertBefore(new CallExpr(PRIM_MOVE,
+                                          addrOfTmp,
+                                          new CallExpr(PRIM_ADDR_OF,
+                                                       rhs->copy())));
+
           rhs->replace(newRhs);
+
           rhs = newRhs;
         }
       }
@@ -4462,116 +4369,266 @@ static void resolveMove(CallExpr* call) {
   }
 
   if (lhs->type == dtUnknown || lhs->type == dtNil) {
-    if (lhs->id == breakOnResolveID )
+    if (lhs->id == breakOnResolveID) {
       gdbShouldBreakHere();
+    }
 
     INT_ASSERT(rhsType);
+
     lhs->type = rhsType;
+    lhsType   = rhsType;
   }
 
-  Type* lhsType = lhs->type;
-
-  setConstFlagsAndCheckUponMove(lhs, rhs);
+  moveSetConstFlagsAndCheck(lhs, rhs);
 
   if (CallExpr* call = toCallExpr(rhs)) {
     if (FnSymbol* fn = call->resolvedFunction()) {
       if (rhsType == dtUnknown) {
-        USR_FATAL_CONT(fn, "unable to resolve return type of function '%s'", fn->name);
+        USR_FATAL_CONT(fn,
+                       "unable to resolve return type of function '%s'",
+                       fn->name);
         USR_FATAL(rhs, "called recursively at this point");
       }
     }
   }
-  if (rhsType == dtUnknown)
-    USR_FATAL(call, "unable to resolve type");
 
-  if (rhsType == dtNil && lhsType != dtNil && !isClass(lhsType))
-    USR_FATAL(userCall(call), "type mismatch in assignment from nil to %s",
+  if (rhsType == dtUnknown) {
+    USR_FATAL(call, "unable to resolve type");
+  }
+
+  if (rhsType == dtNil && lhsType != dtNil && isClass(lhsType) == false) {
+    USR_FATAL(userCall(call),
+              "type mismatch in assignment from nil to %s",
               toString(lhsType));
-  Type* lhsBaseType = lhsType->getValType();
-  Type* rhsBaseType = rhsType->getValType();
-  bool isChplHereAlloc = false;
-  // Fix up calls inserted by callChplHereAlloc()
+  }
+
+  Type* lhsBaseType     = lhsType->getValType();
+  Type* rhsBaseType     = rhsType->getValType();
+  bool  isChplHereAlloc = false;
+
   if (CallExpr* rhsCall = toCallExpr(rhs)) {
-    // Here we are going to fix up calls inserted by
-    // callChplHereAlloc() and callChplHereFree()
-    //
-    // Currently this code assumes that such primitives are only
-    // inserted by the compiler.  TODO: Add a check to make sure
-    // these are the ones added by the above functions.
-    //
     if (rhsCall->isPrimitive(PRIM_SIZEOF)) {
-      // Fix up arg to sizeof(), as we may not have known the
-      // type earlier
+      // Fix up arg to sizeof(), as we may not have known the type earlier
       SymExpr* sizeSym = toSymExpr(rhsCall->get(1));
+
       INT_ASSERT(sizeSym);
-      rhs->replace(new CallExpr(PRIM_SIZEOF, sizeSym->symbol()->typeInfo()->symbol));
+
+      rhs->replace(new CallExpr(PRIM_SIZEOF,
+                                sizeSym->symbol()->typeInfo()->symbol));
       return;
+
     } else if (rhsCall->isPrimitive(PRIM_CAST_TO_VOID_STAR)) {
       if (isReferenceType(rhsCall->get(1)->typeInfo())) {
         // Add a dereference as needed, as we did not have complete
         // type information earlier
-        SymExpr* castVar = toSymExpr(rhsCall->get(1));
-        INT_ASSERT(castVar);
-        VarSymbol* derefTmp = newTemp("castDeref", castVar->typeInfo()->getValType());
+        SymExpr*   castVar  = toSymExpr(rhsCall->get(1));
+        VarSymbol* derefTmp = newTemp("castDeref",
+                                      castVar->typeInfo()->getValType());
+
         call->insertBefore(new DefExpr(derefTmp));
-        call->insertBefore(new CallExpr(PRIM_MOVE, derefTmp,
+        call->insertBefore(new CallExpr(PRIM_MOVE,
+                                        derefTmp,
                                         new CallExpr(PRIM_DEREF,
                                                      new SymExpr(castVar->symbol()))));
+
         rhsCall->replace(new CallExpr(PRIM_CAST_TO_VOID_STAR,
                                       new SymExpr(derefTmp)));
       }
+
     } else if (rhsCall->resolvedFunction() == gChplHereAlloc) {
-      // Insert cast below for calls to chpl_here_*alloc()
       isChplHereAlloc = true;
     }
   }
-  if (!isChplHereAlloc && rhsType != dtNil &&
-      rhsBaseType != lhsBaseType &&
-      !isDispatchParent(rhsBaseType, lhsBaseType))
-    USR_FATAL(userCall(call), "type mismatch in assignment from %s to %s",
-              toString(rhsType), toString(lhsType));
-  if (isChplHereAlloc ||
-      (rhsType != lhsType && isDispatchParent(rhsBaseType, lhsBaseType))) {
+
+
+
+  if (isChplHereAlloc                            == false       &&
+      rhsType                                    != dtNil       &&
+      rhsBaseType                                != lhsBaseType &&
+      isDispatchParent(rhsBaseType, lhsBaseType) == false) {
+    USR_FATAL(userCall(call),
+              "type mismatch in assignment from %s to %s",
+              toString(rhsType),
+              toString(lhsType));
+
+  } else if (isChplHereAlloc == true) {
     Symbol* tmp = newTemp("cast_tmp", rhsType);
+
     call->insertBefore(new DefExpr(tmp));
     call->insertBefore(new CallExpr(PRIM_MOVE, tmp, rhs->remove()));
-    call->insertAtTail(new CallExpr(PRIM_CAST,
-                                    isChplHereAlloc ? lhs->type->symbol :
-                                    lhsBaseType->symbol, tmp));
+
+    call->insertAtTail(new CallExpr(PRIM_CAST, lhs->type->symbol,   tmp));
+
+  } else if (rhsType                                    != lhsType &&
+             isDispatchParent(rhsBaseType, lhsBaseType) == true) {
+    Symbol* tmp = newTemp("cast_tmp", rhsType);
+
+    call->insertBefore(new DefExpr(tmp));
+    call->insertBefore(new CallExpr(PRIM_MOVE, tmp, rhs->remove()));
+
+    call->insertAtTail(new CallExpr(PRIM_CAST, lhsBaseType->symbol, tmp));
   }
 
-  // Fix up PRIM_COERCE : remove it if it has a param RHS.
-  CallExpr* rhsCall = toCallExpr(rhs);
 
-  if (rhsCall && rhsCall->isPrimitive(PRIM_COERCE)) {
-    SymExpr* toCoerceSE = toSymExpr(rhsCall->get(1));
-    if (toCoerceSE) {
-      Symbol* toCoerceSym = toCoerceSE->symbol();
-      bool promotes = false;
-      // This transformation is normally handled in insertCasts
-      // but we need to do it earlier for parameters. We can't just
-      // call insertCasts here since that would dramatically change the
-      // resolution order (and would be apparently harder to get working).
-      if (toCoerceSym->isParameter() ||
-          toCoerceSym->hasFlag(FLAG_TYPE_VARIABLE) ) {
-        // Can we coerce from the argument to the function return type?
-        // Note that rhsType here is the function return type (since
-        // that is what the primitive returns as its type).
-        if (toCoerceSym->type == rhsType ||
-            canParamCoerce(toCoerceSym->type, toCoerceSym, rhsType)) {
-          // Replacing the arguments to the move works, but for
-          // some reason replacing the whole move doesn't.
-          call->get(1)->replace(new SymExpr(lhs));
-          call->get(2)->replace(new SymExpr(toCoerceSym));
-        } else if (canCoerce(toCoerceSym->type, toCoerceSym, rhsType,
-                             NULL, &promotes)) {
-          // any case that doesn't param coerce but does coerce will
-          // be handled in insertCasts later.
-        } else {
-          USR_FATAL(userCall(call), "type mismatch in return from %s to %s",
-                    toString(toCoerceSym->type), toString(rhsType));
+
+
+  // Fix up PRIM_COERCE : remove it if it has a param RHS.
+  if (CallExpr* rhsCall = toCallExpr(rhs)) {
+    if (rhsCall->isPrimitive(PRIM_COERCE)) {
+      if (SymExpr* toCoerceSE = toSymExpr(rhsCall->get(1))) {
+        Symbol* toCoerceSym = toCoerceSE->symbol();
+        bool    promotes    = false;
+
+        // This transformation is normally handled in insertCasts
+        // but we need to do it earlier for parameters. We can't just
+        // call insertCasts here since that would dramatically change the
+        // resolution order (and would be apparently harder to get working).
+        if (toCoerceSym->isParameter() ||
+            toCoerceSym->hasFlag(FLAG_TYPE_VARIABLE) ) {
+          // Can we coerce from the argument to the function return type?
+          // Note that rhsType here is the function return type (since
+          // that is what the primitive returns as its type).
+          if (toCoerceSym->type == rhsType ||
+              canParamCoerce(toCoerceSym->type, toCoerceSym, rhsType)) {
+            // Replacing the arguments to the move works, but for
+            // some reason replacing the whole move doesn't.
+            call->get(1)->replace(new SymExpr(lhs));
+            call->get(2)->replace(new SymExpr(toCoerceSym));
+
+          } else if (canCoerce(toCoerceSym->type,
+                               toCoerceSym,
+                               rhsType,
+                               NULL,
+                               &promotes) == true) {
+
+            // any case that doesn't param coerce but does coerce will
+            // be handled in insertCasts later.
+          } else {
+            USR_FATAL(userCall(call),
+                      "type mismatch in return from %s to %s",
+                      toString(toCoerceSym->type),
+                      toString(rhsType));
+          }
         }
       }
+    }
+  }
+}
+
+static void moveSetConstFlagsAndCheck(Symbol* lhs, Expr* rhs) {
+  // If this assigns into a loop index variable from a non-var iterator,
+  // mark the variable constant.
+  if (SymExpr* rhsSE = toSymExpr(rhs)) {
+    // If RHS is this special variable...
+    if (rhsSE->symbol()->hasFlag(FLAG_INDEX_OF_INTEREST)) {
+      Type* rhsType = rhsSE->symbol()->type;
+
+      INT_ASSERT(lhs->hasFlag(FLAG_INDEX_VAR));
+
+      // ... and not of a reference type
+      // ... and not an array (arrays are always yielded by reference)
+      // todo: differentiate based on ref-ness, not _ref type
+      // todo: not all const if it is zippered and one of iterators is var
+      if (isReferenceType(rhsType)                           == false &&
+          isTupleContainingAnyReferences(rhsType)            == false &&
+          rhsSE->symbol()->type->symbol->hasFlag(FLAG_ARRAY) == false) {
+        // ... then mark LHS constant.
+        lhs->addFlag(FLAG_CONST);
+      }
+    }
+
+  } else if (CallExpr* rhsCall = toCallExpr(rhs)) {
+    if (rhsCall->isPrimitive(PRIM_GET_MEMBER)) {
+      if (SymExpr* rhsBase = toSymExpr(rhsCall->get(1))) {
+        if (rhsBase->symbol()->hasFlag(FLAG_CONST) ||
+            rhsBase->symbol()->hasFlag(FLAG_REF_TO_CONST)) {
+          lhs->addFlag(FLAG_REF_TO_CONST);
+        }
+
+      } else {
+        INT_ASSERT(false); // PRIM_GET_MEMBER of a non-SymExpr??
+      }
+
+    } else if (FnSymbol* resolvedFn = rhsCall->resolvedFunction()) {
+      moveSetFlagsAndCheckForConstAccess(lhs, rhsCall, resolvedFn);
+    }
+  }
+}
+
+// If 'call' is an access to a const thing, for example a const field
+// or a field of a const record, set const flag(s) on the symbol
+// that stores the result of 'call'.
+static void moveSetFlagsAndCheckForConstAccess(Symbol*   lhs,
+                                               CallExpr* rhsCall,
+                                               FnSymbol* resolvedFn) {
+  bool    refConst = resolvedFn->hasFlag(FLAG_REF_TO_CONST);
+  bool    constWCT = resolvedFn->hasFlag(FLAG_REF_TO_CONST_WHEN_CONST_THIS);
+  Symbol* baseSym  = NULL;
+
+  INT_ASSERT(refConst == false || constWCT == false);
+
+  if (refConst == true) {
+    if (resolvedFn->hasFlag(FLAG_FIELD_ACCESSOR)    == true &&
+        resolvedFn->hasFlag(FLAG_PROMOTION_WRAPPER) == false) {
+      baseSym = getBaseSymForConstCheck(rhsCall);
+    }
+
+  } else if (resolvedFn->hasFlag(FLAG_NEW_ALIAS_FN) == true &&
+             lhs->hasFlag(FLAG_ARRAY_ALIAS)         == true) {
+    if (lhs->isConstant() == false) {
+      // We are creating a var alias - ensure aliasee is not const either.
+      SymExpr* aliaseeSE = toSymExpr(rhsCall->get(2));
+
+      INT_ASSERT(aliaseeSE);
+
+      if (aliaseeSE->symbol()->isConstant() == true) {
+        USR_FATAL_CONT(rhsCall,
+                       "creating a non-const alias '%s' of a const array "
+                       "or domain",
+                       lhs->name);
+      }
+    }
+
+  } else if (constWCT == true) {
+    baseSym = getBaseSymForConstCheck(rhsCall);
+
+    if (baseSym->isConstant()               == true ||
+        baseSym->hasFlag(FLAG_REF_TO_CONST) == true ||
+        baseSym->hasFlag(FLAG_CONST)        == true) {
+      refConst = true;
+
+    } else {
+      baseSym = NULL;
+    }
+
+  } else if (lhs->hasFlag(FLAG_ARRAY_ALIAS)         == true &&
+             resolvedFn->hasFlag(FLAG_AUTO_COPY_FN) == true) {
+    INT_ASSERT(false);
+  }
+
+  // Do not consider it const if it is an access to 'this' in a constructor.
+  if (baseSym) {
+    if (baseSym->hasFlag(FLAG_ARG_THIS)   == true &&
+        isInConstructorLikeFunction(rhsCall) == true) {
+      refConst = false;
+    }
+  }
+
+  if (refConst) {
+    if (isReferenceType(lhs->type) == true) {
+      lhs->addFlag(FLAG_REF_TO_CONST);
+    } else {
+      lhs->addFlag(FLAG_CONST);
+    }
+
+    if (baseSym != NULL && baseSym->hasFlag(FLAG_ARG_THIS) == true) {
+      // 'call' can be a field accessor or an array element accessor or ?
+      lhs->addFlag(FLAG_REF_FOR_CONST_FIELD_OF_THIS);
+    }
+
+    if (constWCT                                           == true &&
+        baseSym->hasFlag(FLAG_REF_FOR_CONST_FIELD_OF_THIS) == true) {
+      lhs->addFlag(FLAG_REF_FOR_CONST_FIELD_OF_THIS);
     }
   }
 }


### PR DESCRIPTION
This is a logically trivial "close the gap" PR although the apparent deltas might
suggest otherwise.

I have a branch that addresses a recent initializer bug that @benharsh surfaced for arrays
of records if the record has an initializer.  I needed to edit resolution for PRIM_INIT and
PRIM_MOVE and that required determining how they worked.

resolveMove() is a currently about 400 lines of text spread over just 3 convoluted procedures.
This PR pulls them in to one location within the file and does a little preliminary cleanup.
There is no changes in behavior for this PR.

compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.
Passed start_test on a small portion of release on all four configurations.
Passed a single-locale paratest for gcc/linux64 with futures.


