### PR TITLE
Remove an unnecessary / from a path we check

### DIFF
--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -316,7 +316,7 @@ static void setupChplHome(const char* argv0) {
       int rc;
       rc = snprintf(TEST_HOME, FILENAME_MAX, "%s/%s/%s",
                   get_configured_prefix(), // e.g. /usr
-                  "/share/chapel",
+                  "share/chapel",
                   majMinorVers);
       if ( rc >= FILENAME_MAX ) USR_FATAL("Installed pathname too long");
 


### PR DESCRIPTION
Checked that --prefix and --chpl-home configure/make/make install works.
Checked that test/compflags/ferguson/home works.

Trivial and not reviewed.

- [x] full local testing