### PR TITLE
Use the Barrier module in SSCA2 instead of defining its own barrier

### DIFF
--- a/test/release/examples/benchmarks/ssca2/SSCA2_Modules/SSCA2_kernels.chpl
+++ b/test/release/examples/benchmarks/ssca2/SSCA2_Modules/SSCA2_kernels.chpl
@@ -15,7 +15,7 @@ module SSCA2_kernels
 //  +==========================================================================+
 
 { 
-  use SSCA2_compilation_config_params, Time;
+  use SSCA2_compilation_config_params, Time, Barrier;
 
   var stopwatch : Timer;
 
@@ -326,9 +326,9 @@ module SSCA2_kernels
           BCaux[s].path_count$.write(1.0);
         }
 
-        const barrier = tpv.barrier;
+        var barrier = new Barrier(numLocales);
 
-        coforall loc in Locales with (ref remaining) do on loc {
+        coforall loc in Locales with (ref remaining, ref barrier) do on loc {
           Active_Level[here.id].Members.clear();
           Active_Level[here.id].next.Members.clear();
           if vertex_domain.dist.idxToLocale(s) == here {
@@ -496,7 +496,6 @@ module SSCA2_kernels
       if DELETE_KERNEL4_DS {
         coforall t in TPVSpace do on t {
           var tpv = TPV[t];
-          delete tpv.barrier;
           var al = tpv.Active_Level;
           coforall loc in Locales do on loc {
             var level = al[here.id];
@@ -573,7 +572,6 @@ module SSCA2_kernels
     const vertex_domain;
     var used  : atomic bool;
     var BCaux : [vertex_domain] taskPrivateArrayData(index(vertex_domain));
-    var barrier = new Barrier(numLocales);
     var Active_Level : [PrivateSpace] Level_Set (Sparse_Vertex_List);
   }
 
@@ -593,80 +591,6 @@ module SSCA2_kernels
     }
     proc releaseTPV(tid) {
       this.TPV[tid].used.clear();
-    }
-  }
-
-  //
-  // reusable barrier implementation
-  //
-  class Barrier {
-    param reusable = true;
-    var n: int;
-    var count: atomic int;
-    var tasksFinished: [PrivateSpace] atomic bool;
-
-    proc Barrier(_n: int) {
-      reset(_n);
-    }
-  
-    inline proc reset(_n: int) {
-      on this {
-        n = _n;
-        count.write(n);
-        for loc in tasksFinished {
-          loc.write(false);
-        }
-      }
-    }
-  
-    inline proc barrier() {
-      const myc = count.fetchSub(1);
-      if myc <= 1 {
-        if tasksFinished[here.id].read() {
-          halt("too many callers to barrier()");
-        } 
-        for loc in tasksFinished {
-          loc.write(true);
-        }
-        if reusable {
-          count.waitFor(n-1);
-          count.add(1);
-          for loc in tasksFinished {
-            loc.clear();
-          }
-        }
-      } else {
-        tasksFinished[here.id].waitFor(true);
-        if reusable {
-          count.add(1);
-          tasksFinished[here.id].waitFor(false);
-        }
-      }
-    }
-  
-    inline proc notify() {
-      const myc = count.fetchSub(1);
-      if myc <= 1 {
-        if tasksFinished[here.id].read() {
-          halt("too many callers to notify()");
-        }
-        for loc in tasksFinished {
-          loc.write(true);
-        }
-      }
-   }
-  
-    inline proc wait() {
-      tasksFinished[here.id].waitFor(true);
-      if reusable {
-        var sum = count.fetchAdd(1);
-        if sum == n-1 then tasksFinished.clear();
-        else tasksFinished[here.id].waitFor(false);
-      }
-    }
-  
-    inline proc check() {
-      return tasksFinished[here.id].read();
     }
   }
 }


### PR DESCRIPTION
SSCA2 has its own Barrier class that is very similar to the Barrier record
in the standard modules.  Delete that class and use the one in the modules
instead.

The barrier it was using was stored in a "Task Private Variables" data
structure, but after switching to the Barrier record, it was calling a
NULL virtual method.  Instead, just declare a barrier variable right before
it is used.  Also, pass the barrier to a coforall with 'ref' intent.

Updated the version in test/studies/ssca2/rachaels/ in the same way.

Tested with "start_test test/release/examples/benchmarks/ssca2" and
"start_test test/studies/ssca2/rachaels" with and without gasnet.

Tested the release version for performance on 16 nodes of Cray XC, and
performance appears to be no worse than before, and possibly better.