### PR TITLE
Increase the amount of oversubscription paratest.chapcs does

### DIFF
--- a/util/test/paratest.chapcs
+++ b/util/test/paratest.chapcs
@@ -96,18 +96,16 @@ def get_num_shared_jobs_running():
 
 def get_good_nodepara():
     """
-    Get a "good" nodepara value: use up to 3 for comm=none testing, but limit
-    to 1 for comm!=none since that's already oversubscribed.
-
-    TODO: Consider increasing nodepara if no other shared jobs are running.
-    Note: need to wait to do this until everybody's using slurm on chapcs.
+    Get a "good" nodepara value: default to 3 for comm=none testing, and
+    2 for comm!=none since that's already oversubscribed. If no other shared
+    jobs are running bump the nodepara by 1.
     """
 
     nodepara = 3
     if chpl_comm.get() != 'none':
-        nodepara = 1
-#    if get_num_shared_jobs_running() == 0:
-#        nodepara += 1
+        nodepara = 2
+    if get_num_shared_jobs_running() == 0:
+        nodepara += 1
     return nodepara
 
 


### PR DESCRIPTION
Bump from nodepara 1 to 2 for gasnet testing. I routinely use nodepara 2 for
gasnet testing and have never encountered any timeouts.

Additionally, if there's no other shared jobs running on the system
(effectively nobody else doing a paratest) bump nodepara by 1.

If chapcs is empty, this should allow a comm=none paratest to finish in ~20
minutes, and a comm=gasnet paratest to finish in ~30 minutes