### PR TITLE
remove unused iterable expression in a zippered forall

### DIFF
--- a/test/release/examples/benchmarks/miniMD/explicit/helpers/forces.chpl
+++ b/test/release/examples/benchmarks/miniMD/explicit/helpers/forces.chpl
@@ -373,7 +373,7 @@ class ForceLJ : Force {
         // by using an atomic variable, we can make the outer loop parallel
         var eng, vir : atomic real;
 
-        forall (b,p,c) in zip(Me.Bins, Me.Pos[Me.Real], Me.Count[Me.Real], Me.Real) {
+        forall (b,p,c) in zip(Me.Bins, Me.Pos[Me.Real], Me.Count[Me.Real]) {
           for (a, x) in zip(b[1..c],p[1..c]) {
             for(n,i) in a.neighs[1..a.ncount] {
               const del = x - Me.Pos[n][i];


### PR DESCRIPTION
There are 4 iterable expressions and 3 index variables in this zippered forall loop in miniMD code. I am removing the 4th iterable expression as unused and because this situation will be a user error in my upcoming ForallStmt PR.

Suggested by @benharsh .

Passes linux64 and gasnet testing.
