### PR TITLE
fix isRecord() to return false for sync/single

### DIFF
--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1647,6 +1647,8 @@ module ChapelBase {
       isArrayType(t)  ||
       isRangeType(t)  ||
       isTupleType(t)  ||
+      isSyncType(t)   ||
+      isSingleType(t) ||
       isAtomicType(t)
     then
       return false;

--- a/test/users/vass/isX/README
+++ b/test/users/vass/isX/README
@@ -28,4 +28,5 @@ and added to version control for ease of use.
 
 * isX.sync-by-const.chpl
 
-This test is a bug future, created by hand.
+This test checks isInt() for int vs. sync int formals.
+It was created by hand.

--- a/test/users/vass/isX/isX.byBlankArgs-compWarns.good
+++ b/test/users/vass/isX/isX.byBlankArgs-compWarns.good
@@ -308,33 +308,21 @@ isArrayValue
 isArrayType
 
 _syncvar(int(64))
-isRecord
-isRecordValue
-isRecordType
 isSync
 isSyncValue
 isSyncType
 
 _syncvar(real(64))
-isRecord
-isRecordValue
-isRecordType
 isSync
 isSyncValue
 isSyncType
 
 _singlevar(int(64))
-isRecord
-isRecordValue
-isRecordType
 isSingle
 isSingleValue
 isSingleType
 
 _singlevar(real(64))
-isRecord
-isRecordValue
-isRecordType
 isSingle
 isSingleValue
 isSingleType

--- a/test/users/vass/isX/isX.module-writeln.chpl
+++ b/test/users/vass/isX/isX.module-writeln.chpl
@@ -1798,7 +1798,7 @@ report(isAtomicValue(rng2), "isAtomicValue");
 report(isAtomicType(rng2.type), "isAtomicType");
 writeln("  .");
 
-write("new dmap(new DefaultDist()) (dmp)");
+write("defaultDist (dmp)");
 report(isBool(dmp), "isBool");
 report(isBoolValue(dmp), "isBoolValue");
 report(isBoolType(dmp.type), "isBoolType");

--- a/test/users/vass/isX/isX.module-writeln.good
+++ b/test/users/vass/isX/isX.module-writeln.good
@@ -27,15 +27,15 @@ RecordSmall (rec1)  isRecord  isRecordValue  isRecordType  .
 UnionType (unn)  isUnion  isUnionValue  isUnionType  .
 range (rng1)  isRange  isRangeValue  isRangeType  .
 range(uint(8), BoundedRangeType.boundedNone, true) (rng2)  isRange  isRangeValue  isRangeType  .
-new dmap(new DefaultDist()) (dmp)  isDmap  isDmapValue  isDmapType  .
+defaultDist (dmp)  isDmap  isDmapValue  isDmapType  .
 DomType1 (dom1)  isDomain  isDomainValue  isDomainType  .
 DomType2 (dom2)  isDomain  isDomainValue  isDomainType  .
 ArrType1 (arr1)  isArray  isArrayValue  isArrayType  .
 ArrType2 (arr2)  isArray  isArrayValue  isArrayType  .
-sync int (syInt)  isRecord  isRecordValue  isRecordType  isSync  isSyncValue  isSyncType  .
-sync real (syReal)  isRecord  isRecordValue  isRecordType  isSync  isSyncValue  isSyncType  .
-single int (siInt)  isRecord  isRecordValue  isRecordType  isSingle  isSingleValue  isSingleType  .
-single real (siReal)  isRecord  isRecordValue  isRecordType  isSingle  isSingleValue  isSingleType  .
+sync int (syInt)  isSync  isSyncValue  isSyncType  .
+sync real (syReal)  isSync  isSyncValue  isSyncType  .
+single int (siInt)  isSingle  isSingleValue  isSingleType  .
+single real (siReal)  isSingle  isSingleValue  isSingleType  .
 atomic int (aInt)  isAtomic  isAtomicValue  isAtomicType  .
 atomic real (aReal)  isAtomic  isAtomicValue  isAtomicType  .
 

--- a/test/users/vass/isX/src/isX.byBlankArgs-compWarns.decls-chpl
+++ b/test/users/vass/isX/src/isX.byBlankArgs-compWarns.decls-chpl
@@ -87,7 +87,7 @@ var unn:  UnionType;
 
 var rng1: range;
 var rng2: range(uint(8), BoundedRangeType.boundedNone, true);
-var dmp = new dmap(new DefaultDist());
+var dmp = defaultDist;
 var dom1: DomType1;
 var dom2: DomType2;
 var arr1: ArrType1;
@@ -103,7 +103,7 @@ var aReal:  atomic real;
 
 /////////////////////////////////////////////////////////////////////////////
 
-proc report(param is: bool, param msg: c_string) {
+proc report(param is: bool, param msg: string) {
   if is then compilerWarning(msg);
 }
 

--- a/test/users/vass/isX/src/isX.byBlankArgs-compWarns.py
+++ b/test/users/vass/isX/src/isX.byBlankArgs-compWarns.py
@@ -39,7 +39,7 @@ varList = [
   ("rng1", "range"),
   ("rng2", "range(uint(8), BoundedRangeType.boundedNone, true)"),
 
-  ("dmp",  "new dmap(new DefaultDist())"),
+  ("dmp",  "defaultDist"),
   ("dom1", "DomType1"),
   ("dom2", "DomType2"),
   ("arr1", "ArrType1"),

--- a/test/users/vass/isX/src/isX.gen
+++ b/test/users/vass/isX/src/isX.gen
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-# This script generates this file:
-
 srcDir=`dirname $0`
 
 function doit() {

--- a/test/users/vass/isX/src/isX.module-writeln.decls-chpl
+++ b/test/users/vass/isX/src/isX.module-writeln.decls-chpl
@@ -91,7 +91,7 @@ var unn:  UnionType;
 
 var rng1: range;
 var rng2: range(uint(8), BoundedRangeType.boundedNone, true);
-var dmp = new dmap(new DefaultDist());
+var dmp = defaultDist;
 var dom1: DomType1;
 var dom2: DomType2;
 var arr1: ArrType1;

--- a/test/users/vass/isX/src/isX.module-writeln.py
+++ b/test/users/vass/isX/src/isX.module-writeln.py
@@ -39,7 +39,7 @@ varList = [
   ("rng1", "range"),
   ("rng2", "range(uint(8), BoundedRangeType.boundedNone, true)"),
 
-  ("dmp",  "new dmap(new DefaultDist())"),
+  ("dmp",  "defaultDist"),
   ("dom1", "DomType1"),
   ("dom2", "DomType2"),
   ("arr1", "ArrType1"),

--- a/test/users/vass/type-tests.good
+++ b/test/users/vass/type-tests.good
@@ -64,11 +64,11 @@ type-tests.chpl:27: warning: atomic is a record: false
 type-tests.chpl:27: warning: atomic is a union:  false
 type-tests.chpl:27: warning: atomic is an atomic
 type-tests.chpl:28: warning: sync is a class:  false
-type-tests.chpl:28: warning: sync is a record: true
+type-tests.chpl:28: warning: sync is a record: false
 type-tests.chpl:28: warning: sync is a union:  false
 type-tests.chpl:28: warning: sync is a sync
 type-tests.chpl:29: warning: single is a class:  false
-type-tests.chpl:29: warning: single is a record: true
+type-tests.chpl:29: warning: single is a record: false
 type-tests.chpl:29: warning: single is a union:  false
 type-tests.chpl:29: warning: single is a single
 type-tests.chpl:30: error: done


### PR DESCRIPTION
isRecord() started returning true for sync/single
when the latter became implemented as records.
Now it doesn't any more.

While there, I updated the "isX" test suite
so that the .chpl files that are on master
match the .chpl files that are automatically
generated by isX/src/isX.gen

passes linux64 and gasnet testing