### PR TITLE
Extend parallel array initialization to POD arrays

### DIFF
--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -675,7 +675,7 @@ module ChapelBase {
       initMethod = ArrayInit.noInit;
     } else if initMethod == ArrayInit.heuristicInit {
       // Heuristically determine if we should do parallel initialization. The
-      // current heuristic really just checks that we have a numeric array that's
+      // current heuristic really just checks that we have a POD array that's
       // at least 2MB. This value was chosen experimentally: Any smaller and the
       // cost of a forall (mostly the task creation) outweighs the benefit of
       // using multiple tasks. This was tested on a 2 core laptop, 8 core
@@ -686,19 +686,18 @@ module ChapelBase {
       // arrays of aggregate types where at one field is an array. The issue is
       // basically that an array's domain stores a linked list of all its arrays
       // and removal becomes expensive when addition and removal occur in
-      // different orders. We don't currently have a good way to check if an
-      // aggregate type contains arrays, so we limit parallel init to numeric
-      // types.
+      // different orders.
       //
       // Long term we probably want to store the domain's arrays as an
       // associative domain or some data structure with < log(n) find/add/remove
       // times. Currently we can't do that because the domain's arrays are part
-      // of the base domain, so we have a circular reference. As a stepping
-      // stone, we could do parallel init for plain old data (POD) types.
-      if !isNumericType(t) {
+      // of the base domain, so we have a circular reference.
+      if !isPODType(t) {
         initMethod = ArrayInit.serialInit;
       } else {
-        param elemsizeInBytes = numBytes(t);
+        extern proc sizeof(type t): size_t;
+        const elemsizeInBytes = if isNumericType(t) then numBytes(t)
+                                else sizeof(t).safeCast(int);
         const arrsizeInBytes = s.safeCast(int) * elemsizeInBytes;
         param heuristicThresh = 2 * 1024 * 1024;
         const heuristicWantsPar = arrsizeInBytes > heuristicThresh;


### PR DESCRIPTION
Ideally we want to be able to do parallel initialization for arrays of all
types, but we're currently blocked by an issue with arrays-of-arrays. The
problem is basically that an array's domain stores a linked list of all its
arrays and removal becomes expensive when addition and removal occur in
different orders. Long term we probably want to store the domain's arrays as an
associative domain or some data structure with < log(n) find/add/remove times.

We used to limit parallel array initialization to numeric types to workaround
the array-of-arrays issue. This just extends parallel array initialization to
support arrays of POD types as well.

This is motivated by an nbody simulation @npadmana is working on that uses a
large array of POD records.