### PR TITLE
Convert remaining shootouts and users/npadmana to use initializers

### DIFF
--- a/test/users/npadmana/twopt/Histogram.chpl
+++ b/test/users/npadmana/twopt/Histogram.chpl
@@ -11,7 +11,9 @@ module Histogram {
     var lo, hi,dx, invdx : [1..dim] real;
     var arr : [Dhist] atomic real;
 
-    proc UniformBins(param dim : int, nbins : dim*int, limits : dim*(real,real)) {
+    proc init(param dim : int, nbins : dim*int, limits : dim*(real,real)) {
+      this.dim = dim;
+      super.init();
       var dd : dim*range;
       this.nbins = nbins;
       for param ii in 1..dim {

--- a/test/users/npadmana/twopt/do_smu_soa.chpl
+++ b/test/users/npadmana/twopt/do_smu_soa.chpl
@@ -50,7 +50,7 @@ class Particle3D {
   var _tmp : [Dpart] real;
   var _n1, _ndx : [Dpart] int;
 
-  proc Particle3D(npart1 : int, random : bool = false) {
+  proc init(npart1 : int, random : bool = false) {
     npart = npart1;
     Darr = {ParticleAttrib, 0.. #npart};
     Dpart = {0.. #npart};

--- a/test/users/vass/barrierWF.chpl
+++ b/test/users/vass/barrierWF.chpl
@@ -29,11 +29,12 @@ class BarrierWF {
   var counts: 2 * atomic int;
 
   // constructor
-  proc BarrierWF(numTasks: int) {
+  proc init(numTasks: int) {
     // otherwise the barrier conditions are hosed
     if numTasks <= 0 then halt("BarrierWF constructor expects numTasks>0",
                                " but received ", numTasks);
     tasks = numTasks;
+    super.init();
     setup(1);
   }
 


### PR DESCRIPTION
Update these tests to use initializers rather than constructors.

* Histogram.chpl needed a super.init() due to a need to initialize a param field and could be added to the list of tests that might benefit from auto-hoisting of generic fields to phase 1.
* barrierWF.chpl needed a super.init() due to its initialization of a const field and could me added to the list of tests that might benefit from permitting const assignments in phase 2.
