### PR TITLE
Convert studies/amr from constructors to initializers, mostly...

### DIFF
--- a/test/studies/amr/lib/amr/AMRHierarchy_def.chpl
+++ b/test/studies/amr/lib/amr/AMRHierarchy_def.chpl
@@ -61,7 +61,7 @@ class AMRHierarchy {
 
 
   //|\''''''''''''''''''''|\
-  //| >    constructor    | >
+  //| >    initializer    | >
   //|/....................|/
   proc init (
     x_low:             dimension*real,
@@ -149,11 +149,11 @@ class AMRHierarchy {
 
   }
   // /|''''''''''''''''''''/|
-  //< |    constructor    < |
+  //< |    initializer    < |
   // \|....................\|
 
   //|\''''''''''''''''''''|\
-  //| >     destructor    | >
+  //| >   deinitializer   | >
   //|/....................|/
 
   proc deinit() {
@@ -166,7 +166,7 @@ class AMRHierarchy {
   }
 
   // /|''''''''''''''''''''/|
-  //< |     destructor    < |
+  //< |   deinitializer   < |
   // \|....................\|
 
 
@@ -570,7 +570,7 @@ class PhysicalBoundary
 
 
   //|\''''''''''''''''''''|\
-  //| >    constructor    | >
+  //| >    initializer    | >
   //|/....................|/
   
   proc init ( level: Level ) 
@@ -591,13 +591,13 @@ class PhysicalBoundary
 
   }
   // /|''''''''''''''''''''/|
-  //< |    constructor    < |
+  //< |    initializer    < |
   // \|....................\|
 
 
 
   //|\'''''''''''''''''''|\
-  //| >    destructor    | >
+  //| >  deinitializer   | >
   //|/...................|/
   
   proc deinit () 
@@ -605,7 +605,7 @@ class PhysicalBoundary
     for multidomain in multidomains do delete multidomain;
   }
   // /|'''''''''''''''''''/|
-  //< |    destructor    < |
+  //< |  deinitializer   < |
   // \|...................\|
 
 
@@ -652,11 +652,11 @@ class Flagger {
 
 
 //|\"""""""""""""""""""""""""""""""""""""""""""""|\
-//| >    AMRHierarchy constructor, file-based    | >
+//| >    AMRHierarchy initializer, file-based    | >
 //|/_____________________________________________|/
 //
 //-----------------------------------------------------------------
-// Alternate constructor in which all numerical parameters for the
+// Alternate initializer in which all numerical parameters for the
 // hierarchy are provided using an input file.  This allows those
 // parameters to be changed without recompiling the code.
 //-----------------------------------------------------------------
@@ -708,7 +708,7 @@ proc AMRHierarchy.init (
 
 }
 // /|"""""""""""""""""""""""""""""""""""""""""""""/|
-//< |    AMRHierarchy constructor, file-based    < |
+//< |    AMRHierarchy initializer, file-based    < |
 // \|_____________________________________________\|
 
 

--- a/test/studies/amr/lib/amr/AMRHierarchy_def.chpl
+++ b/test/studies/amr/lib/amr/AMRHierarchy_def.chpl
@@ -63,7 +63,7 @@ class AMRHierarchy {
   //|\''''''''''''''''''''|\
   //| >    constructor    | >
   //|/....................|/
-  proc AMRHierarchy (
+  proc init (
     x_low:             dimension*real,
     x_high:            dimension*real,
     n_coarsest_cells:  dimension*int,
@@ -79,10 +79,11 @@ class AMRHierarchy {
     this.x_high            = x_high;
     this.n_coarsest_cells  = n_coarsest_cells;
     this.n_ghost_cells     = n_ghost_cells;
-    this.max_n_levels      = max_n_levels;
     this.ref_ratio         = ref_ratio;
-    this.target_efficiency = target_efficiency;
+    this.max_n_levels      = max_n_levels;
     this.flagger           = flagger;
+    this.target_efficiency = target_efficiency;
+    super.init();
 
 
     //---- Create the base level ----
@@ -572,7 +573,7 @@ class PhysicalBoundary
   //| >    constructor    | >
   //|/....................|/
   
-  proc PhysicalBoundary ( level: Level ) 
+  proc init ( level: Level ) 
   {
     for grid in level.grids {
 
@@ -660,7 +661,7 @@ class Flagger {
 // parameters to be changed without recompiling the code.
 //-----------------------------------------------------------------
 
-proc AMRHierarchy.AMRHierarchy (
+proc AMRHierarchy.init (
   file_name:  string,
   flagger:    Flagger,
   inputIC:    func(dimension*real,real))
@@ -694,16 +695,16 @@ proc AMRHierarchy.AMRHierarchy (
   parameter_file.close();
 
   //==== Create and return hierarchy ====
-  delete this;
-  this = new AMRHierarchy(x_low,
-                          x_high,
-			  n_coarsest_cells,
-			  n_ghost_cells,
-			  max_n_levels,
-			  ref_ratio,
-			  target_efficiency,
-			  flagger,
-			  inputIC);
+  this.init(
+            x_low,
+            x_high,
+            n_coarsest_cells,
+            n_ghost_cells,
+            max_n_levels,
+            ref_ratio,
+            target_efficiency,
+            flagger,
+            inputIC);
 
 }
 // /|"""""""""""""""""""""""""""""""""""""""""""""/|

--- a/test/studies/amr/lib/amr/BergerRigoutsosClustering.chpl
+++ b/test/studies/amr/lib/amr/BergerRigoutsosClustering.chpl
@@ -160,7 +160,7 @@ class CandidateDomain {
 
 
   //|\'''''''''''''''''''|\
-  //| >    destructor    | >
+  //| >  deinitializer   | >
   //|/...................|/
 
   proc deinit ()
@@ -168,7 +168,7 @@ class CandidateDomain {
     for i in 1..rank do delete signatures(i);
   }
   // /|'''''''''''''''''''/|
-  //< |    destructor    < |
+  //< |  deinitializer   < |
   // \|...................\|
 
 

--- a/test/studies/amr/lib/cfboundary/CoarseningTransfer.chpl
+++ b/test/studies/amr/lib/cfboundary/CoarseningTransfer.chpl
@@ -33,7 +33,7 @@ class GridInvalidRegion {
   //| >    constructor    | >
   //|/....................|/
   
-  proc GridInvalidRegion (
+  proc init (
     grid:         Grid,
     parent_level: Level,
     fine_level:   Level )

--- a/test/studies/amr/lib/cfboundary/CoarseningTransfer.chpl
+++ b/test/studies/amr/lib/cfboundary/CoarseningTransfer.chpl
@@ -30,7 +30,7 @@ class GridInvalidRegion {
     
   
   //|\''''''''''''''''''''|\
-  //| >    constructor    | >
+  //| >    initializer    | >
   //|/....................|/
   
   proc init (
@@ -53,7 +53,7 @@ class GridInvalidRegion {
     }
   }
   // /|''''''''''''''''''''/|
-  //< |    constructor    < |
+  //< |    initializer    < |
   // \|....................\|
   
   
@@ -74,13 +74,13 @@ class GridInvalidRegion {
   
   
   //|\'''''''''''''''''''|\
-  //| >    destructor    | >
+  //| >  deinitializer   | >
   //|/...................|/
   
   proc deinit () {}
 
   // /|'''''''''''''''''''/|
-  //< |    destructor    < |
+  //< |  deinitializer   < |
   // \|...................\|
   
 }
@@ -137,7 +137,7 @@ class LevelInvalidRegion {
 
 
   //|\'''''''''''''''''''|\
-  //| >    destructor    | >
+  //| >  deinitializer   | >
   //|/...................|/
   
   proc deinit ()
@@ -145,7 +145,7 @@ class LevelInvalidRegion {
     for region in grid_invalid_regions do delete region;
   }
   // /|'''''''''''''''''''/|
-  //< |    destructor    < |
+  //< |  deinitializer   < |
   // \|...................\|
   
 

--- a/test/studies/amr/lib/cfboundary/RefiningTransfer.chpl
+++ b/test/studies/amr/lib/cfboundary/RefiningTransfer.chpl
@@ -31,7 +31,7 @@ class GridCFGhostRegion {
 
   
   //|\''''''''''''''''''''|\
-  //| >    constructor    | >
+  //| >    initializer    | >
   //|/....................|/
   
   proc init (
@@ -85,13 +85,13 @@ class GridCFGhostRegion {
 
   }
   // /|''''''''''''''''''''/|
-  //< |    constructor    < |
+  //< |    initializer    < |
   // \|....................\|
 
 
 
   //|\'''''''''''''''''''|\
-  //| >    destructor    | >
+  //| >  deinitializer   | >
   //|/...................|/
   
   proc deinit ()
@@ -99,7 +99,7 @@ class GridCFGhostRegion {
     for multidomain in transfer_regions do delete multidomain;
   }
   // /|'''''''''''''''''''/|
-  //< |    destructor    < |
+  //< |  deinitializer   < |
   // \|...................\|
   
 
@@ -179,7 +179,7 @@ class LevelCFGhostRegion {
   
   
   //|\'''''''''''''''''''|\
-  //| >    destructor    | >
+  //| >  deinitializer   | >
   //|/...................|/
   
   proc deinit ()
@@ -187,7 +187,7 @@ class LevelCFGhostRegion {
     for region in grid_cf_ghost_regions do delete region;
   }
   // /|'''''''''''''''''''/|
-  //< |    destructor    < |
+  //< |  deinitializer   < |
   // \|...................\|
   
   
@@ -305,7 +305,7 @@ class GridCFGhostSolution {
   
   
   //|\'''''''''''''''''''|\
-  //| >    destructor    | >
+  //| >  deinitializer   | >
   //|/...................|/
   
   proc deinit () {
@@ -316,7 +316,7 @@ class GridCFGhostSolution {
 
   }
   // /|'''''''''''''''''''/|
-  //< |    destructor    < |
+  //< |  deinitializer   < |
   // \|...................\|
 
 
@@ -450,7 +450,7 @@ class LevelCFGhostSolution {
  
  
   //|\'''''''''''''''''''|\
-  //| >    destructor    | >
+  //| >  deinitializer   | >
   //|/...................|/
   
   proc deinit () 
@@ -458,7 +458,7 @@ class LevelCFGhostSolution {
     for solution in grid_cf_ghost_solutions do delete solution;
   }
   // /|'''''''''''''''''''/|
-  //< |    destructor    < |
+  //< |  deinitializer   < |
   // \|...................\|
   
   

--- a/test/studies/amr/lib/cfboundary/RefiningTransfer.chpl
+++ b/test/studies/amr/lib/cfboundary/RefiningTransfer.chpl
@@ -21,8 +21,8 @@ class GridCFGhostRegion {
   //|/...............|/
 
   const grid:             Grid;
-  const coarse_neighbors: domain(Grid);
-  const transfer_regions:  [coarse_neighbors] MultiDomain(dimension,stridable=true);
+  var coarse_neighbors: domain(Grid);
+  var transfer_regions:  [coarse_neighbors] MultiDomain(dimension,stridable=true);
   
   // /|'''''''''''''''/|
   //< |    fields    < |
@@ -34,13 +34,14 @@ class GridCFGhostRegion {
   //| >    constructor    | >
   //|/....................|/
   
-  proc GridCFGhostRegion (
+  proc init (
     grid:         Grid,
     parent_level: Level,
     coarse_level: Level)
   {
         
     this.grid = grid;
+    super.init();
     
     
     //==== Calculate refinement ratio ====

--- a/test/studies/amr/lib/grid/GridSolution_def.chpl
+++ b/test/studies/amr/lib/grid/GridSolution_def.chpl
@@ -25,7 +25,7 @@ class GridSolution {
   
 
   //|\''''''''''''''''''''|\
-  //| >    constructor    | >
+  //| >    initializer    | >
   //|/....................|/
   
   proc init (grid: Grid) {
@@ -35,13 +35,13 @@ class GridSolution {
     super.init();
   }
   // /|''''''''''''''''''''/|
-  //< |    constructor    < |
+  //< |    initializer    < |
   // \|....................\|
   
   
   
   //|\'''''''''''''''''''|\
-  //| >    destructor    | >
+  //| >  deinitializer   | >
   //|/...................|/
   
   proc deinit () 
@@ -50,7 +50,7 @@ class GridSolution {
     delete current_data;
   }
   // /|'''''''''''''''''''/|
-  //< |    destructor    < |
+  //< |  deinitializer   < |
   // \|...................\|
   
   

--- a/test/studies/amr/lib/grid/GridSolution_def.chpl
+++ b/test/studies/amr/lib/grid/GridSolution_def.chpl
@@ -28,10 +28,11 @@ class GridSolution {
   //| >    constructor    | >
   //|/....................|/
   
-  proc GridSolution (grid: Grid) {
+  proc init (grid: Grid) {
     this.grid = grid;
     old_data =     new GridVariable(grid = grid);
     current_data = new GridVariable(grid = grid);
+    super.init();
   }
   // /|''''''''''''''''''''/|
   //< |    constructor    < |

--- a/test/studies/amr/lib/grid/GridVariable_def.chpl
+++ b/test/studies/amr/lib/grid/GridVariable_def.chpl
@@ -47,13 +47,13 @@ class GridVariable {
 
 
   //|\'''''''''''''''''''|\
-  //| >    destructor    | >
+  //| >  deinitializer   | >
   //|/...................|/
   
   proc deinit () {}
   
   // /|'''''''''''''''''''/|
-  //< |    destructor    < |
+  //< |  deinitializer   < |
   // \|...................\|
 
 }

--- a/test/studies/amr/lib/grid/Grid_def.chpl
+++ b/test/studies/amr/lib/grid/Grid_def.chpl
@@ -49,7 +49,7 @@ class Grid {
 
 
   //|\''''''''''''''''''''|\
-  //| >    constructor    | >
+  //| >    initializer    | >
   //|/....................|/
   
   proc init (
@@ -129,19 +129,19 @@ class Grid {
 
   }
   // /|''''''''''''''''''''/|
-  //< |    Constructor    < |
+  //< |    Initializer    < |
   // \|....................\|
 
 
 
   //|\'''''''''''''''''''|\
-  //| >    destructor    | >
+  //| >  deinitializer   | >
   //|/...................|/
 
   proc deinit () { delete ghost_domains; }
   
   // /|'''''''''''''''''''/|
-  //< |    destructor    < |
+  //< |  deinitializer   < |
   // \|...................\|
 
 
@@ -151,7 +151,7 @@ class Grid {
   //|/..........................|/
 
   //--------------------------------------------------------------
-  // Performs some basic sanity checks on the constructor inputs.
+  // Performs some basic sanity checks on the initializer inputs.
   //--------------------------------------------------------------
 
   proc sanityChecks () {

--- a/test/studies/amr/lib/grid/Grid_def.chpl
+++ b/test/studies/amr/lib/grid/Grid_def.chpl
@@ -40,8 +40,8 @@ class Grid {
 
   const dx: dimension*real;
           
+  const cells:          domain(dimension, stridable=true);
   const extended_cells: domain(dimension, stridable=true);
-  const cells:          subdomain(extended_cells);
   
   // const ghost_domains: MultiDomain(dimension, stridable=true);
   const ghost_domains: List( domain(dimension, stridable=true) );
@@ -52,7 +52,7 @@ class Grid {
   //| >    constructor    | >
   //|/....................|/
   
-  proc Grid (
+  proc init (
     x_low:         dimension*real,
     x_high:        dimension*real,
     i_low:         dimension*int,
@@ -66,9 +66,6 @@ class Grid {
     this.i_low         = i_low;
     this.n_cells       = n_cells;
     this.n_ghost_cells = n_ghost_cells;
-
-    //==== Sanity check ====
-    sanityChecks();
 
     //==== dx ====
     dx = (x_high - x_low) / n_cells;
@@ -103,6 +100,10 @@ class Grid {
     //-------------------------------------------------------------
 
     ghost_domains = new List( domain(dimension,stridable=true) );
+    super.init();
+
+    //==== Sanity check ====
+    sanityChecks();
 
     var inner_location: dimension*int;
     for d in dimensions do inner_location(d) = loc1d.inner;

--- a/test/studies/amr/lib/level/LevelSolution_def.chpl
+++ b/test/studies/amr/lib/level/LevelSolution_def.chpl
@@ -17,7 +17,7 @@ class LevelSolution {
 
 
   //|\''''''''''''''''''''|\
-  //| >    constructor    | >
+  //| >    initializer    | >
   //|/....................|/
   proc init(level: Level) {
     this.level  = level;
@@ -26,13 +26,13 @@ class LevelSolution {
     current_data = new LevelVariable(level = level);
   }
   // /|''''''''''''''''''''/|
-  //< |    constructor    < |
+  //< |    initializer    < |
   // \|....................\|
 
 
 
   //|\'''''''''''''''''''|\
-  //| >    destructor    | >
+  //| >  deinitializer   | >
   //|/...................|/
   
   proc deinit
@@ -41,7 +41,7 @@ class LevelSolution {
     delete current_data;
   }
   // /|'''''''''''''''''''/|
-  //< |    destructor    < |
+  //< |  deinitializer   < |
   // \|...................\|
 
 }

--- a/test/studies/amr/lib/level/LevelSolution_def.chpl
+++ b/test/studies/amr/lib/level/LevelSolution_def.chpl
@@ -19,8 +19,9 @@ class LevelSolution {
   //|\''''''''''''''''''''|\
   //| >    constructor    | >
   //|/....................|/
-  proc LevelSolution(level: Level) {
+  proc init(level: Level) {
     this.level  = level;
+    super.init();
     old_data     = new LevelVariable(level = level);
     current_data = new LevelVariable(level = level);
   }

--- a/test/studies/amr/lib/level/LevelSolution_def.chpl
+++ b/test/studies/amr/lib/level/LevelSolution_def.chpl
@@ -21,9 +21,9 @@ class LevelSolution {
   //|/....................|/
   proc init(level: Level) {
     this.level  = level;
-    super.init();
     old_data     = new LevelVariable(level = level);
     current_data = new LevelVariable(level = level);
+    super.init();
   }
   // /|''''''''''''''''''''/|
   //< |    initializer    < |

--- a/test/studies/amr/lib/level/LevelVariable_def.chpl
+++ b/test/studies/amr/lib/level/LevelVariable_def.chpl
@@ -41,7 +41,7 @@ class LevelVariable {
 
 
   //|\'''''''''''''''''''|\
-  //| >    destructor    | >
+  //| >  deinitializer   | >
   //|/...................|/
 
   proc deinit ()
@@ -50,7 +50,7 @@ class LevelVariable {
   }
 
   // /|'''''''''''''''''''/|
-  //< |    destructor    < |
+  //< |  deinitializer   < |
   // \|...................\|
 
 

--- a/test/studies/amr/lib/level/Level_def.chpl
+++ b/test/studies/amr/lib/level/Level_def.chpl
@@ -37,8 +37,8 @@ class Level {
   // the level.
   //--------------------------------------------------------------
   
+  const possible_cells:       domain(dimension, stridable=true);
   const possible_ghost_cells: domain(dimension, stridable=true);
-  const possible_cells:       subdomain(possible_ghost_cells);
 
 
   //==== Child grid info ====
@@ -62,7 +62,7 @@ class Level {
   //| >    constructor    | >
   //|/....................|/
 
-  proc Level(
+  proc init(
     x_low: dimension*real,
     x_high: dimension*real,
     n_cells: dimension*int,
@@ -90,7 +90,8 @@ class Level {
     // must be multiplied by 2 because a cell is 2 indices wide.
     //---------------------------------------------------------------
 
-    possible_ghost_cells = possible_cells.expand(2*n_ghost_cells);    
+    possible_ghost_cells = possible_cells.expand(2*n_ghost_cells);
+    super.init();
 
   }
   // /|''''''''''''''''''''/|
@@ -321,7 +322,7 @@ class SiblingGhostRegion {
   //| >    constructor    | >
   //|/....................|/
   
-  proc SiblingGhostRegion (
+  proc init (
     level: Level,
     grid:  Grid)
   {

--- a/test/studies/amr/lib/level/Level_def.chpl
+++ b/test/studies/amr/lib/level/Level_def.chpl
@@ -59,7 +59,7 @@ class Level {
 
 
   //|\''''''''''''''''''''|\
-  //| >    constructor    | >
+  //| >    initializer    | >
   //|/....................|/
 
   proc init(
@@ -95,13 +95,13 @@ class Level {
 
   }
   // /|''''''''''''''''''''/|
-  //< |    constructor    < |
+  //< |    initializer    < |
   // \|....................\|
   
   
   
   //|\'''''''''''''''''''|\
-  //| >    destructor    | >
+  //| >  deinitializer   | >
   //|/...................|/
   
   proc deinit () 
@@ -114,7 +114,7 @@ class Level {
     }
   }
   // /|'''''''''''''''''''/|
-  //< |    destructor    < |
+  //< |  deinitializer   < |
   // \|...................\|
   
   
@@ -319,7 +319,7 @@ class SiblingGhostRegion {
   
   
   //|\''''''''''''''''''''|\
-  //| >    constructor    | >
+  //| >    initializer    | >
   //|/....................|/
   
   proc init (
@@ -340,19 +340,19 @@ class SiblingGhostRegion {
     }
   }
   // /|''''''''''''''''''''/|
-  //< |    constructor    < |
+  //< |    initializer    < |
   // \|....................\|
   
   
   
   //|\'''''''''''''''''''|\
-  //| >    destructor    | >
+  //| >  deinitializer   | >
   //|/...................|/
   
   proc deinit () {}
 
   // /|'''''''''''''''''''/|
-  //< |    destructor    < |
+  //< |  deinitializer   < |
   // \|...................\|
   
   


### PR DESCRIPTION
This conversion was more interesting than most and was illuminating to me because it demonstrated to some extent how much more flexible our constructors implementation has been compared to initializers (not to say that means constructors are better...).

Here are some notes:

* test/studies/amr/lib/amr/BergerRigoutsosCLustering.chpl was unable to be converted due to its use of nested classes.  See PR #6677 for some simplified examples that show similar errors.

* AMRHierarchy used to 'delete this' and then set 'this = new AMRHierarchy(...)' -- this converted fairly cleanly to a sibling `this.init()` call.  I still feel a little surprised that this worked so easily without more effort on my part.

* In some cases, fields had to be reordered in order to meet the phase 1 constraints.

* often super.init()s had to be inserted to take care of const initializations in phase 1

* some consts had to be converted to vars due to how they were initialized (e..g, an associative domain that had keys added to it within the body of the initializer).  Lydia points out that a workaround is to use a var temp and then assign it to the const field once it's ready.

* the following pattern came up a few times:

```chapel
const bigD: domain(2);
const smallD: subdomain(bigD);

proc init() {
  smallD = {1..n, 1..N};
  bigD = smallD.expand(1);
}
```

which is interesting in that bigD has to be initialized in phase 1 before smallD, causing a bit of a cycle.  I fixed this by converting the subdomain into a normal domain.  Other options may have been to make them vars and initialize them in phase 2 or to use some temps to set up initial values and then copy into the const fields...?

