### PR TITLE
Turn off affinity for whitebox testing to (hopefully) avoid timeouts

### DIFF
--- a/util/cron/test-xc-wb.bash
+++ b/util/cron/test-xc-wb.bash
@@ -7,6 +7,17 @@ source $CWD/functions.bash
 source $CWD/common-whitebox.bash
 source $CWD/common-localnode-paratest.bash
 
+# Whitebox testing runs multiple paratests concurrently (-nodepara 2 for up to
+# 4 configs.) We limit the number of running executables, but we use a file as
+# a lock to do that, which is racey. Limit the amount of spinwaiting we do and
+# turn off affinity since they'll be a lot compiles and maybe 2 executables
+# running concurrently. Note that we don't disable affinity for pgi because
+# its lack of atomics combined with no affinity has led to timeouts.
+export QT_SPINCOUNT=300
+if [ "${COMPILER}" != "pgi" ] ; then
+  export QT_AFFINITY=no
+fi
+
 # Run the tests!
 nightly_args="-cron $(get_nightly_paratest_args)"
 log_info "Calling nightly with args: ${nightly_args}"


### PR DESCRIPTION
We've been seeing sporadic timeouts for whitebox testing since mid May. For
most of the timeouts it looks like 2 executables were running at the same time,
and we know that multiple qthreads instances don't play well together. We try
to limit to 1 running executable with CHPL_TEST_LIMIT_RUNNING_EXECUTABLES, but
that uses a file as a lock, which can be racey.

To hopefully avoid timeouts when that race does occur, disable qthreads
affinity and limit the amount of spinwaiting qthreads does. Note that we don't
disable affinity for pgi, because pgi doesn't support atomics. This forces
qthreads to use mutexes instead of spinlocks, which when combined with
disabling affinity has lead to timeouts in the past.

Note that this is similar to previous attempts like #4060 and #3684, except
that we don't disable affinity for pgi. Also note that back then multiple
executables were running together all the time since we weren't using
CHPL_TEST_LIMIT_RUNNING_EXECUTABLES, but now that should only happen on rare
occasions.