### PR TITLE
Better error message upon incorrect 'delete'

### DIFF
--- a/compiler/main/checks.cpp
+++ b/compiler/main/checks.cpp
@@ -54,6 +54,7 @@ static void checkAggregateTypes(); // Checks that class and record types have
                                    // constructors.
 static void checkResolveRemovedPrims(void); // Checks that certain primitives
                                             // are removed after resolution
+static void checkNoRecordDeletes();  // No 'delete' on records.
 static void checkTaskRemovedPrims(); // Checks that certain primitives are
                                      // removed after task functions are
                                      // created.
@@ -465,6 +466,7 @@ static void check_afterResolution()
   checkReturnTypesHaveRefTypes();
   if (fVerify)
   {
+    checkNoRecordDeletes();
     checkTaskRemovedPrims();
     checkResolveRemovedPrims();
 // Disabled for now because user warnings should not be logged multiple times:
@@ -620,6 +622,16 @@ checkResolveRemovedPrims(void) {
       }
     }
   }
+}
+
+static void checkNoRecordDeletes() {
+  // No need to do for_alive_in_Vec - there shouldn't be any, period.
+  // User errors are to be detected by chpl__delete() in the modules.
+  forv_Vec(CallExpr, call, gCallExprs)
+    if (FnSymbol* fn = call->resolvedFunction())
+      if(fn->hasFlag(FLAG_DESTRUCTOR))
+        if (!isClass(call->get(1)->typeInfo()->getValType()))
+          INT_FATAL(call, "delete not on a class");
 }
 
 static void

--- a/compiler/passes/checkResolved.cpp
+++ b/compiler/passes/checkResolved.cpp
@@ -415,31 +415,6 @@ checkReturnPaths(FnSymbol* fn) {
   }
 }
 
-
-// This test must be run after resolution, since it depends on the knowledge of
-// whether the type of delete's operand is a record type.
-// But it cannot be run after the compiler adds its own record deletes
-// TODO: This violates the "no magic" principle, so the check and associated
-// language in the spec should be considered for removal.
-// In addition, the ability for user code to explicitly call deletes on fields
-// of record type may be necessary for UMM, but this is yet to be demonstrated.
-static void
-checkNoRecordDeletes(CallExpr* call)
-{
-  FnSymbol* fn = call->resolvedFunction();
-
-  // Note that fn can (legally) be null if the call is primitive.
-  if (fn && fn->hasFlag(FLAG_DESTRUCTOR)) {
-    // Statements of the form 'delete x' (PRIM_DELETE) are replaced
-    //  during the normalize pass with a call to the destructor
-    //  followed by a call to chpl_mem_free(), so here we just check
-    //  if the type of the variable being passed to chpl_mem_free()
-    //  is a record.
-    if (isRecord(call->get(1)->typeInfo()->getValType()))
-      USR_FATAL_CONT(call, "delete not allowed on records");
-  }
-}
-
 static void
 checkBadAddrOf(CallExpr* call)
 {
@@ -480,10 +455,7 @@ static void
 checkCalls()
 {
   forv_Vec(CallExpr, call, gCallExprs)
-  {
-    checkNoRecordDeletes(call);
     checkBadAddrOf(call);
-  }
 }
 
 

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -2607,12 +2607,6 @@ printResolutionErrorUnresolved(Vec<FnSymbol*>& visibleFns, CallInfo* info) {
                      toString(info->actuals.v[1]->type),
                      toString(info->actuals.v[0]->type));
     }
-  } else if (!strcmp("free", info->name)) {
-    if (info->actuals.n > 0 &&
-        isRecord(info->actuals.v[2]->type))
-      USR_FATAL_CONT(call, "delete not allowed on records");
-    else
-      needToReport = true;
   } else if (!strcmp("these", info->name)) {
     if (info->actuals.n == 2 &&
         info->actuals.v[0]->type == dtMethodToken) {

--- a/test/arrays/compilerErrors/array-delete.chpl
+++ b/test/arrays/compilerErrors/array-delete.chpl
@@ -1,0 +1,3 @@
+
+var A: [1..3] int;
+delete A;

--- a/test/arrays/compilerErrors/array-delete.good
+++ b/test/arrays/compilerErrors/array-delete.good
@@ -1,0 +1,1 @@
+array-delete.chpl:3: error: 'delete' is not allowed on non-class type [domain(1,int(64),false)] int(64)

--- a/test/domains/compilerErrors/domain-delete.chpl
+++ b/test/domains/compilerErrors/domain-delete.chpl
@@ -1,0 +1,4 @@
+// formerly BenA's types/records/compilerErrors/deleteRecordMessage
+
+var D = {1..10};
+delete D;

--- a/test/domains/compilerErrors/domain-delete.good
+++ b/test/domains/compilerErrors/domain-delete.good
@@ -1,0 +1,1 @@
+domain-delete.chpl:4: error: 'delete' is not allowed on non-class type domain(1,int(64),false)

--- a/test/types/records/compilerErrors/deleteRecordMessage.bad
+++ b/test/types/records/compilerErrors/deleteRecordMessage.bad
@@ -1,1 +1,0 @@
-$CHPL_HOME/modules/internal/ChapelBase.chpl:1225: error: delete not allowed on records

--- a/test/types/records/compilerErrors/deleteRecordMessage.chpl
+++ b/test/types/records/compilerErrors/deleteRecordMessage.chpl
@@ -1,2 +1,0 @@
-var D = {1..10};
-delete D;

--- a/test/types/records/compilerErrors/deleteRecordMessage.future
+++ b/test/types/records/compilerErrors/deleteRecordMessage.future
@@ -1,5 +1,0 @@
-error message: deleting record error gives an unhelpful line number
-
-Deleting non-user-defined records, e.g. a domain, array, or distribution,
-results in an error message that points to ChapelBase.chpl. The error should
-point to the line number where the record is deleted.

--- a/test/types/records/compilerErrors/deleteRecordMessage.good
+++ b/test/types/records/compilerErrors/deleteRecordMessage.good
@@ -1,1 +1,0 @@
-deleteRecordMessage.chpl:2: error: delete not allowed on records

--- a/test/types/records/sungeun/destructor2.good
+++ b/test/types/records/sungeun/destructor2.good
@@ -1,1 +1,1 @@
-destructor2.chpl:7: error: delete not allowed on records
+destructor2.chpl:7: error: 'delete' is not allowed on records


### PR DESCRIPTION
When `delete` is invoked on something that's not a class
or an "extern" class, report an error with line number
pointing to the location of the `delete`.

Before this change, this already happened when `delete` was
on a record. Now this happens for all other erroneous cases.

While there:

* Make it an error to invoke `delete` on `nil`.
* Make it a compiler verification check after each pass after resolution that there are no deletes on records.
* Remove the same check in the compiler that used to be done once and reported a user error. Explanation: now the user error is reported by the (updated) module code.
* Remove a compiler check that "free" is not invoked on records. There is nothing special about "free".
* Move the test types/records/compilerErrors/deleteRecordMessage to domains/vass/domain-delete (because that's what it does).