### PR TITLE
Remove the .future and .bad file for this now passing test

### DIFF
--- a/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc-ideal.bad
+++ b/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc-ideal.bad
@@ -1,2 +1,0 @@
-chameneosredux-blc-ideal.chpl:119: In function 'haveMeetings':
-chameneosredux-blc-ideal.chpl:147: error: illegal access of iterator or promoted expression

--- a/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc-ideal.future
+++ b/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc-ideal.future
@@ -1,8 +1,0 @@
-bug: can't use forall expressions within an initializer
-
-I expect that this is the same bug as in issue #5935.  Even after this
-bug is fixed, it may be that I'm using generic fields more
-aggressively than I should be permitted to (or that our implementation
-will permit for the time being), in which case this future may need to
-be updated further.  But this is an intriguing version of the benchmark
-to strive for.


### PR DESCRIPTION
The change to allow initializers on generic types to follow a more similar
code path to initializers on concrete types allowed this test to finally pass.