### PR TITLE
Eliminate memory leak in PrivateDist

### DIFF
--- a/modules/dists/PrivateDist.chpl
+++ b/modules/dists/PrivateDist.chpl
@@ -202,4 +202,9 @@ proc PrivateArr.dsiSerialWrite(x) {
   }
 }
 
-const PrivateSpace: domain(1) dmapped new dmap(new Private());
+const privateDist = new Private();
+const PrivateSpace: domain(1) dmapped new dmap(privateDist);
+
+proc deinit() {
+  delete privateDist;
+}

--- a/test/extern/sungeun/externProcInClassShouldBeError.chpl
+++ b/test/extern/sungeun/externProcInClassShouldBeError.chpl
@@ -126,3 +126,5 @@ const D = {5..9};
 // c.bar();
 
 }
+
+forall l in localePrivate do delete l;

--- a/test/multilocale/deitz/needMultiLocales/test_frag_main.chpl
+++ b/test/multilocale/deitz/needMultiLocales/test_frag_main.chpl
@@ -73,3 +73,9 @@ proc chpl_recv_int(out data: int, loc) {
     b.signal$.writeXF(true);
   b.lock$;
 }
+
+proc deinit() {
+  forall p in PrivateSpace do
+    forall l in LocaleSpace do
+      delete buffer[p][l];
+}

--- a/test/parallel/taskPar/sungeun/private.chpl
+++ b/test/parallel/taskPar/sungeun/private.chpl
@@ -87,3 +87,5 @@ for l in 0..#numLocales {
   if y != nPerLocale then
     halt("localePrivate[",l,"].temps[].y value is incorrect! (y=",y,")");
 }
+
+forall l in localePrivate do delete l;


### PR DESCRIPTION
There is a minor memory leak when using `PrivateDist`, due to a module-level instance of `Private()` never gets freed. This PR introduces a module-level deinit to ensure the module-level instance of `Private()` is deallocated at the end of programs.

When checking the tests that use `PrivateDist`, I discovered some obvious memory leaks that could be fixed in the tests (user-code), so I went ahead and did this. However, I did not address *all* memory leaks in these tests.

- [x] Confirm all tests that use `PrivateDist` pass locally (`gasnet` and `none`)
    - Double checked that no modules utilize `PrivateDist` either

```
> start_test
    extern/sungeun/externProcInClassShouldBeError.chpl
    modules/vass/SSCA2-with-Private-1.chpl
    modules/vass/SSCA2-with-Private-2.chpl
    multilocale/deitz/needMultiLocales/dist/test_private_space.chpl
    multilocale/deitz/needMultiLocales/test_frag_main.chpl
    optimizations/cache-remote/ferguson/correctness/atomic.chpl
    optimizations/cache-remote/ferguson/correctness/atomic1.chpl
    parallel/taskPar/sungeun/private.chpl

...

[Summary: #Successes = 7 | #Failures = 0 | #Futures = 1 | #Warnings = 0 ]
```