### PR TITLE
Mark const variables using llvm.invariant.start

### DIFF
--- a/compiler/codegen/expr.cpp
+++ b/compiler/codegen/expr.cpp
@@ -385,29 +385,10 @@ GenRet codegenWideAddrWithAddr(GenRet base, GenRet newAddr, Type* wideType = NUL
 // Set USE_TBAA to 1 to emit TBAA metadata with loads and stores.
 #define USE_TBAA 1
 
-
-static
-bool isPointerToPointerType(llvm::Type* type)
-{
-  llvm::PointerType *ptrType = llvm::dyn_cast<llvm::PointerType>(type);
-
-  if(!ptrType)
-    return false;
-
-  llvm::PointerType *ptrToPtrType = llvm::dyn_cast<llvm::PointerType>(ptrType->getElementType());
-  if(!ptrToPtrType)
-    return false;
-  return true;
-}
-
 static
 void codegenInvariantStart(llvm::Value *val, llvm::Value *addr)
 {
   GenInfo *info = gGenInfo;
-
-  if(isPointerToPointerType(addr->getType()))
-    return;
-
 
   llvm::Type *int8PtrTy =
     llvm::Type::getInt8Ty(info->llvmContext)->getPointerTo(0);
@@ -524,7 +505,7 @@ llvm::LoadInst* codegenLoadLLVM(GenRet ptr,
     else valType = ptr.chplType->getValType();
   }
 
-  return codegenLoadLLVM(ptr.val, valType, ptr.canBeMarkedAsConstAfterStore);
+  return codegenLoadLLVM(ptr.val, valType);
 }
 
 #endif

--- a/compiler/codegen/expr.cpp
+++ b/compiler/codegen/expr.cpp
@@ -392,8 +392,15 @@ void codegenInvariantStart(llvm::Value *val, llvm::Value *addr)
 
   llvm::Type *int8PtrTy =
     llvm::Type::getInt8Ty(info->llvmContext)->getPointerTo(0);
+
+  #if HAVE_LLVM_VER >= 40
+  llvm::Type *objectPtr = { int8PtrTy };
+  llvm::Function *invariantStart =
+    llvm::Intrinsic::getDeclaration(info->module, llvm::Intrinsic::invariant_start, objectPtr);
+  #else
   llvm::Function *invariantStart =
     llvm::Intrinsic::getDeclaration(info->module, llvm::Intrinsic::invariant_start);
+  #endif
 
   const llvm::DataLayout& dataLayout = info->module->getDataLayout();
 
@@ -468,6 +475,8 @@ llvm::StoreInst* codegenStoreLLVM(GenRet val,
     val.val = v;
   }
 
+  INT_ASSERT(!(ptr.alreadyStored && ptr.canBeMarkedAsConstAfterStore));
+  ptr.alreadyStored = true;
   return codegenStoreLLVM(val.val, ptr.val, valType, ptr.canBeMarkedAsConstAfterStore);
 }
 // Create an LLVM load instruction possibly adding

--- a/compiler/codegen/expr.cpp
+++ b/compiler/codegen/expr.cpp
@@ -387,9 +387,28 @@ GenRet codegenWideAddrWithAddr(GenRet base, GenRet newAddr, Type* wideType = NUL
 
 
 static
+bool isPointerToPointerType(llvm::Type* type)
+{
+  llvm::PointerType *ptrType = llvm::dyn_cast<llvm::PointerType>(type);
+
+  if(!ptrType)
+    return false;
+
+  llvm::PointerType *ptrToPtrType = llvm::dyn_cast<llvm::PointerType>(ptrType->getElementType());
+  if(!ptrToPtrType)
+    return false;
+  return true;
+}
+
+static
 void codegenInvariantStart(llvm::Value *val, llvm::Value *addr)
 {
   GenInfo *info = gGenInfo;
+
+  if(isPointerToPointerType(addr->getType()))
+    return;
+
+
   llvm::Type *int8PtrTy =
     llvm::Type::getInt8Ty(info->llvmContext)->getPointerTo(0);
   llvm::Function *invariantStart =

--- a/compiler/codegen/expr.cpp
+++ b/compiler/codegen/expr.cpp
@@ -468,6 +468,7 @@ llvm::StoreInst* codegenStoreLLVM(GenRet val,
     val.val = v;
   }
 
+  val.alreadyStored = true;
   return codegenStoreLLVM(val.val, ptr.val, valType, val.canBeMarkedAsConstAfterStore);
 }
 // Create an LLVM load instruction possibly adding
@@ -505,7 +506,7 @@ llvm::LoadInst* codegenLoadLLVM(GenRet ptr,
     else valType = ptr.chplType->getValType();
   }
 
-  return codegenLoadLLVM(ptr.val, valType, isConst);
+  return codegenLoadLLVM(ptr.val, valType, ptr.canBeMarkedAsConstAfterStore && ptr.alreadyStored);
 }
 
 #endif

--- a/compiler/codegen/expr.cpp
+++ b/compiler/codegen/expr.cpp
@@ -146,9 +146,9 @@ GenRet SymExpr::codegen() {
         INT_FATAL(this, "!!!!!!! UNHANDLED SYM EXPR !!!!!!!");
       }
     }
-    ret.canBeMarkedAsConstAfterStore = var->isConstValWillNotChange();
 #endif
   }
+  ret.canBeMarkedAsConstAfterStore = var->isConstValWillNotChange();
   return ret;
 }
 
@@ -386,6 +386,7 @@ GenRet codegenWideAddrWithAddr(GenRet base, GenRet newAddr, Type* wideType = NUL
 #define USE_TBAA 1
 
 
+static
 void codegenInvariantStart(llvm::Value *val, llvm::Constant *addr)
 {
   GenInfo *info = gGenInfo;
@@ -469,7 +470,7 @@ llvm::StoreInst* codegenStoreLLVM(GenRet val,
   }
 
   val.alreadyStored = true;
-  return codegenStoreLLVM(val.val, ptr.val, valType, val.canBeMarkedAsConstAfterStore);
+  return codegenStoreLLVM(val.val, ptr.val, valType, ptr.canBeMarkedAsConstAfterStore);
 }
 // Create an LLVM load instruction possibly adding
 // appropriate metadata based upon the Chapel type of ptr.

--- a/compiler/include/genret.h
+++ b/compiler/include/genret.h
@@ -102,10 +102,6 @@ public:
   // Specifically: use "llvm.invariant.start"
   bool canBeMarkedAsConstAfterStore;
 
-  // Mark as true when store to memory has been already done
-  bool alreadyStored;
-
-
   // always set if available
   // note that the chplType of a GenRet corresponds to the Chapel
   // type of the result of codegenValue on it - that is, chplType
@@ -127,7 +123,7 @@ public:
                    // called type, since LLVM native integer types do not
                    // include signed-ness.
                    
-  GenRet() : c(), val(NULL), type(NULL), canBeMarkedAsConstAfterStore(false), alreadyStored(false), chplType(NULL), isLVPtr(GEN_VAL), isUnsigned(false) { }
+  GenRet() : c(), val(NULL), type(NULL), canBeMarkedAsConstAfterStore(false), chplType(NULL), isLVPtr(GEN_VAL), isUnsigned(false) { }
   // Allow implicit conversion from AST elements.
   GenRet(BaseAST* ast) {
     *this = baseASTCodegen(ast);

--- a/compiler/include/genret.h
+++ b/compiler/include/genret.h
@@ -98,6 +98,11 @@ public:
   void* type;
 #endif
 
+  // Used to mark variables as const after they are stored
+  // Specifically: use "llvm.invariant.start"
+  bool canBeMarkedAsConstAfterStore;
+
+
   // always set if available
   // note that the chplType of a GenRet corresponds to the Chapel
   // type of the result of codegenValue on it - that is, chplType
@@ -119,7 +124,7 @@ public:
                    // called type, since LLVM native integer types do not
                    // include signed-ness.
                    
-  GenRet() : c(), val(NULL), type(NULL), chplType(NULL), isLVPtr(GEN_VAL), isUnsigned(false) { }
+  GenRet() : c(), val(NULL), type(NULL), chplType(NULL), isLVPtr(GEN_VAL), isUnsigned(false), canBeMarkedAsConstAfterStore(false) { }
   // Allow implicit conversion from AST elements.
   GenRet(BaseAST* ast) {
     *this = baseASTCodegen(ast);

--- a/compiler/include/genret.h
+++ b/compiler/include/genret.h
@@ -131,18 +131,12 @@ public:
   // Allow implicit conversion from AST elements.
   GenRet(BaseAST* ast) {
     *this = baseASTCodegen(ast);
-    canBeMarkedAsConstAfterStore = false;
-    alreadyStored = false;
   }
   GenRet(int x) {
     *this = baseASTCodegenInt(x);
-    canBeMarkedAsConstAfterStore = false;
-    alreadyStored = false;
   }
   GenRet(const char* str) {
     *this = baseASTCodegenString(str);
-    canBeMarkedAsConstAfterStore = false;
-    alreadyStored = false;
   }
 
   // Return true if this GenRet is empty

--- a/compiler/include/genret.h
+++ b/compiler/include/genret.h
@@ -102,6 +102,11 @@ public:
   // Specifically: use "llvm.invariant.start"
   bool canBeMarkedAsConstAfterStore;
 
+  // Mark pointers we already stored to, used to assert
+  // the assumption that store to const memory
+  // is the only store to that memory
+  bool alreadyStored;
+
   // always set if available
   // note that the chplType of a GenRet corresponds to the Chapel
   // type of the result of codegenValue on it - that is, chplType
@@ -123,7 +128,7 @@ public:
                    // called type, since LLVM native integer types do not
                    // include signed-ness.
                    
-  GenRet() : c(), val(NULL), type(NULL), canBeMarkedAsConstAfterStore(false), chplType(NULL), isLVPtr(GEN_VAL), isUnsigned(false) { }
+  GenRet() : c(), val(NULL), type(NULL), canBeMarkedAsConstAfterStore(false), alreadyStored(false), chplType(NULL), isLVPtr(GEN_VAL), isUnsigned(false) { }
   // Allow implicit conversion from AST elements.
   GenRet(BaseAST* ast) {
     *this = baseASTCodegen(ast);

--- a/compiler/include/genret.h
+++ b/compiler/include/genret.h
@@ -102,6 +102,9 @@ public:
   // Specifically: use "llvm.invariant.start"
   bool canBeMarkedAsConstAfterStore;
 
+  // Mark as true when store to memory has been already done
+  bool alreadyStored;
+
 
   // always set if available
   // note that the chplType of a GenRet corresponds to the Chapel
@@ -124,16 +127,22 @@ public:
                    // called type, since LLVM native integer types do not
                    // include signed-ness.
                    
-  GenRet() : c(), val(NULL), type(NULL), chplType(NULL), isLVPtr(GEN_VAL), isUnsigned(false), canBeMarkedAsConstAfterStore(false) { }
+  GenRet() : c(), val(NULL), type(NULL), canBeMarkedAsConstAfterStore(false), alreadyStored(false), chplType(NULL), isLVPtr(GEN_VAL), isUnsigned(false) { }
   // Allow implicit conversion from AST elements.
   GenRet(BaseAST* ast) {
     *this = baseASTCodegen(ast);
+    canBeMarkedAsConstAfterStore = false;
+    alreadyStored = false;
   }
   GenRet(int x) {
     *this = baseASTCodegenInt(x);
+    canBeMarkedAsConstAfterStore = false;
+    alreadyStored = false;
   }
   GenRet(const char* str) {
     *this = baseASTCodegenString(str);
+    canBeMarkedAsConstAfterStore = false;
+    alreadyStored = false;
   }
 
   // Return true if this GenRet is empty


### PR DESCRIPTION
This PR marks const variables using llvm.invariant.start.

I am not 100% sure if I check for constness correctly, I have huge difficulties understanding what chapel compiler is doing, @mppf should be able to see instantly if I add this in correct spots. 