### PR TITLE
Updates for field instantiatedFrom

### DIFF
--- a/compiler/include/type.h
+++ b/compiler/include/type.h
@@ -100,7 +100,8 @@ public:
   // Used only in PrimitiveType; replace with flag?
   bool                   isInternalType;
 
-  Type*                  instantiatedFrom;
+  AggregateType*         instantiatedFrom;
+
   Type*                  scalarPromotionType;
 
   SymbolMap              substitutions;


### PR DESCRIPTION
While performing a preliminary investigation of a possible issue for generic records I noted that
there is a field

Type* Type::instantiatedFrom;


It would be more sensible for this to be

AggregateType* AggregateType::instantiatedFrom;

Fortunately this field is not used too widely and it appears
tractable to migrate it.  In particular it is not subject to the
dtValue problem that needs to be resolved for
Type::dispatchParents/dispatchChildren. 

As a first step, convert this field to be

AggregateType* Type::instantiatedFrom;

Standard testing process. As this updates a header file I also compiled with CHPL_LLVM=llvm
and ran start_test on a small fraction of release/

