### PR TITLE
Complete migration of instantiatedFrom field

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -57,6 +57,8 @@ AggregateType::AggregateType(AggregateTag initTag) :
   iteratorInfo           = NULL;
   doc                    = NULL;
 
+  instantiatedFrom       = NULL;
+
   fields.parent          = this;
   inherits.parent        = this;
 

--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -49,7 +49,6 @@ Type::Type(AstTag astTag, Symbol* iDefaultVal) : BaseAST(astTag) {
   defaultValue        = iDefaultVal;
   destructor          = NULL;
   isInternalType      = false;
-  instantiatedFrom    = NULL;
   scalarPromotionType = NULL;
 }
 

--- a/compiler/include/AggregateType.h
+++ b/compiler/include/AggregateType.h
@@ -120,6 +120,8 @@ public:
                               // fields in an aggregate type.
   bool                        wantsDefaultInitializer();
 
+  AggregateType*              instantiatedFrom;
+
   InitializerStyle            initializerStyle;
 
   bool                        initializerResolved;

--- a/compiler/include/type.h
+++ b/compiler/include/type.h
@@ -100,8 +100,6 @@ public:
   // Used only in PrimitiveType; replace with flag?
   bool                   isInternalType;
 
-  AggregateType*         instantiatedFrom;
-
   Type*                  scalarPromotionType;
 
   SymbolMap              substitutions;


### PR DESCRIPTION
This simple PR completes the migration of

Type* Type::instantiatedField to AggregateType::AggregateType:::instantiatedField.

Update was easier than I anticipated.

Compiled on the conventional clang/gcc configurations and also sanity checked LLVM.
