### PR TITLE
Convert misc tests from constructors to initializers

### DIFF
--- a/test/classes/hilde/callUserDefaultConstructor.chpl
+++ b/test/classes/hilde/callUserDefaultConstructor.chpl
@@ -3,7 +3,7 @@
 
 class C
 {
-  proc C() { writeln("Called C()."); }
+  proc init() { writeln("Called C()."); }
   proc deinit() { writeln("Called ~C()."); }
 }
 

--- a/test/optimizations/bulkcomm/asenjo/stencilDR/v2/stencil.chpl
+++ b/test/optimizations/bulkcomm/asenjo/stencilDR/v2/stencil.chpl
@@ -62,7 +62,7 @@ class GlobalInfo {
 }
 
 // constructor for GlobalInfo
-proc GlobalInfo.GlobalInfo() {
+proc GlobalInfo.init() {
   forall ((ix,iy), inf) in zip(gridDist, infos) {
     inf = new LocalInfo(mygx=ix, mygy=iy);
   }
@@ -95,8 +95,9 @@ class GlobalData {
 }
 
 // constructor for GlobalData
-proc GlobalData.GlobalData(nameArg: string) {
+proc GlobalData.init(nameArg: string) {
   name=nameArg;
+  super.init();
   forall (inf, dat, loc) in zip(WI.infos, datas, gridLocales) {
     dat = new LocalData(inf);
     // sanity checks

--- a/test/studies/graph500/v2/defs.chpl
+++ b/test/studies/graph500/v2/defs.chpl
@@ -117,7 +117,10 @@ module Graph500_defs
 //      proc   n_Neighbors (v : vertex_id )
 //      {return Vertices(v).neighbor_count;}
 
-      proc Graph (my_vertices, Histogram){
+      proc init (my_vertices, Histogram){
+        this.my_vertices = my_vertices;
+        this.Histogram = Histogram;
+        super.init();
          forall i in my_vertices {
             Vertices[i].nd = {1..Histogram[i]};
          }

--- a/test/users/shetag/tensor-workaround.chpl
+++ b/test/users/shetag/tensor-workaround.chpl
@@ -34,13 +34,13 @@ class Vector {
   // comment can/should be reverted (the introduction of the 'd' field
   // above and the three routines that follow).
   //
-  proc Vector(initN: int, initA: [1..initN] elemType) {
+  proc init(initN: int, initA: [1..initN] elemType) {
     n = initN;
     d = {1..n};
     a = initA;
   }
 
-  proc Vector(initN: int) {
+  proc init(initN: int) {
     n = initN;
     d = {1..n};
   }


### PR DESCRIPTION
These represented low-hanging, not-obviously-owned fruit.

* stencil.chpl needed a super.init() due to a const field
* graph500/v2 needed a super.init() due to completely generic fields

The others were straightforward