### PR TITLE
Define dtObject as an AggregateType* rather than a Type*

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -32,6 +32,8 @@
 #include "stringutil.h"
 #include "symbol.h"
 
+AggregateType* dtObject            = NULL;
+
 AggregateType* dtString            = NULL;
 AggregateType* dtArray             = NULL;
 AggregateType* dtBaseArr           = NULL;
@@ -1623,3 +1625,40 @@ void AggregateType::addRootType() {
     }
   }
 }
+
+DefExpr* defineObjectClass() {
+  // The base object class looks like this:
+  //
+  //   class object {
+  //     chpl__class_id chpl__cid;
+  //   }
+  //
+  // chpl__class_id is an int32_t field identifying the classes
+  //  in the program.  We never create the actual field within the
+  //  IR (it is directly generated in the C code).  It might
+  //  be the right thing to do, so I made an attempt at adding the
+  //  field.  Unfortunately, we would need some significant changes
+  //  throughout compilation, and it seemed to me that the it might result
+  //  in possibly more special case code.
+  //
+  DefExpr* retval = buildClassDefExpr("object",
+                                      NULL,
+                                      AGGREGATE_CLASS,
+                                      NULL,
+                                      new BlockStmt(),
+                                      FLAG_UNKNOWN,
+                                      NULL);
+
+  retval->sym->addFlag(FLAG_OBJECT_CLASS);
+
+  // Prevents removal in pruneResolvedTree().
+  retval->sym->addFlag(FLAG_GLOBAL_TYPE_SYMBOL);
+  retval->sym->addFlag(FLAG_NO_OBJECT);
+
+  dtObject = toAggregateType(retval->sym->type);
+
+  INT_ASSERT(isAggregateType(dtObject));
+
+  return retval;
+}
+

--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -767,40 +767,6 @@ static VarSymbol* createSymbol(PrimitiveType* primType, const char* name) {
 *                                                                             *
 ************************************** | *************************************/
 
-DefExpr* defineObjectClass() {
-  // The base object class looks like this:
-  //
-  //   class object {
-  //     chpl__class_id chpl__cid;
-  //   }
-  //
-  // chpl__class_id is an int32_t field identifying the classes
-  //  in the program.  We never create the actual field within the
-  //  IR (it is directly generated in the C code).  It might
-  //  be the right thing to do, so I made an attempt at adding the
-  //  field.  Unfortunately, we would need some significant changes
-  //  throughout compilation, and it seemed to me that the it might result
-  //  in possibly more special case code.
-  //
-  DefExpr* retval = buildClassDefExpr("object",
-                                      NULL,
-                                      AGGREGATE_CLASS,
-                                      NULL,
-                                      new BlockStmt(),
-                                      FLAG_UNKNOWN,
-                                      NULL);
-
-  retval->sym->addFlag(FLAG_OBJECT_CLASS);
-
-  // Prevents removal in pruneResolvedTree().
-  retval->sym->addFlag(FLAG_GLOBAL_TYPE_SYMBOL);
-  retval->sym->addFlag(FLAG_NO_OBJECT);
-
-  dtObject = retval->sym->type;
-
-  return retval;
-}
-
 void initChplProgram(DefExpr* objectDef) {
   theProgram           = new ModuleSymbol("chpl__Program",
                                           MOD_INTERNAL,

--- a/compiler/include/AggregateType.h
+++ b/compiler/include/AggregateType.h
@@ -182,6 +182,8 @@ private:
   bool                        mIsGeneric;
 };
 
+extern AggregateType* dtObject;
+
 extern AggregateType* dtString;
 extern AggregateType* dtArray;
 extern AggregateType* dtBaseArr;
@@ -194,5 +196,7 @@ extern AggregateType* dtMainArgument;
 extern AggregateType* dtOnBundleRecord;
 extern AggregateType* dtTaskBundleRecord;
 extern AggregateType* dtError;
+
+DefExpr* defineObjectClass();
 
 #endif

--- a/compiler/include/type.h
+++ b/compiler/include/type.h
@@ -389,52 +389,49 @@ private:
 #endif
 
 // internal types
-TYPE_EXTERN Type* dtAny;
-TYPE_EXTERN Type* dtIteratorRecord;
-TYPE_EXTERN Type* dtIteratorClass;
-TYPE_EXTERN Type* dtIntegral;
-TYPE_EXTERN Type* dtAnyComplex;
-TYPE_EXTERN Type* dtNumeric;
-TYPE_EXTERN Type* dtAnyEnumerated;
-TYPE_EXTERN PrimitiveType* dtNil;
-TYPE_EXTERN PrimitiveType* dtUnknown;
-TYPE_EXTERN PrimitiveType* dtVoid;
-TYPE_EXTERN PrimitiveType* dtValue;
-TYPE_EXTERN PrimitiveType* dtMethodToken;
-TYPE_EXTERN PrimitiveType* dtTypeDefaultToken;
-TYPE_EXTERN PrimitiveType* dtModuleToken;
+TYPE_EXTERN Type*             dtAny;
+TYPE_EXTERN Type*             dtIteratorRecord;
+TYPE_EXTERN Type*             dtIteratorClass;
+TYPE_EXTERN Type*             dtIntegral;
+TYPE_EXTERN Type*             dtAnyComplex;
+TYPE_EXTERN Type*             dtNumeric;
+TYPE_EXTERN Type*             dtAnyEnumerated;
+
+TYPE_EXTERN PrimitiveType*    dtNil;
+TYPE_EXTERN PrimitiveType*    dtUnknown;
+TYPE_EXTERN PrimitiveType*    dtVoid;
+TYPE_EXTERN PrimitiveType*    dtValue;
+TYPE_EXTERN PrimitiveType*    dtMethodToken;
+TYPE_EXTERN PrimitiveType*    dtTypeDefaultToken;
+TYPE_EXTERN PrimitiveType*    dtModuleToken;
 
 // primitive types
 // Anything declared as PrimitiveType* can now also be declared as Type*
 // This change was made to allow dtComplex to be represented by a record.
-TYPE_EXTERN PrimitiveType* dtBool;
-TYPE_EXTERN PrimitiveType* dtBools[BOOL_SIZE_NUM];
-TYPE_EXTERN PrimitiveType* dtInt[INT_SIZE_NUM];
-TYPE_EXTERN PrimitiveType* dtUInt[INT_SIZE_NUM];
-TYPE_EXTERN PrimitiveType* dtReal[FLOAT_SIZE_NUM];
-TYPE_EXTERN PrimitiveType* dtImag[FLOAT_SIZE_NUM];
-TYPE_EXTERN Type* dtComplex[COMPLEX_SIZE_NUM];
-TYPE_EXTERN PrimitiveType* dtSymbol;
-TYPE_EXTERN PrimitiveType* dtFile;
-TYPE_EXTERN PrimitiveType* dtOpaque;
-TYPE_EXTERN PrimitiveType* dtTaskID;
-TYPE_EXTERN PrimitiveType* dtSyncVarAuxFields;
-TYPE_EXTERN PrimitiveType* dtSingleVarAuxFields;
+TYPE_EXTERN PrimitiveType*    dtBool;
+TYPE_EXTERN PrimitiveType*    dtBools[BOOL_SIZE_NUM];
+TYPE_EXTERN PrimitiveType*    dtInt[INT_SIZE_NUM];
+TYPE_EXTERN PrimitiveType*    dtUInt[INT_SIZE_NUM];
+TYPE_EXTERN PrimitiveType*    dtReal[FLOAT_SIZE_NUM];
+TYPE_EXTERN PrimitiveType*    dtImag[FLOAT_SIZE_NUM];
+TYPE_EXTERN PrimitiveType*    dtSymbol;
+TYPE_EXTERN PrimitiveType*    dtFile;
+TYPE_EXTERN PrimitiveType*    dtOpaque;
+TYPE_EXTERN PrimitiveType*    dtTaskID;
+TYPE_EXTERN PrimitiveType*    dtSyncVarAuxFields;
+TYPE_EXTERN PrimitiveType*    dtSingleVarAuxFields;
 
-TYPE_EXTERN PrimitiveType* dtStringC; // the type of a C string (unowned)
-TYPE_EXTERN PrimitiveType* dtStringCopy; // the type of a C string (owned)
-TYPE_EXTERN PrimitiveType* dtCVoidPtr; // the type of a C void* (unowned)
-TYPE_EXTERN PrimitiveType* dtCFnPtr;   // a C function pointer (unowned)
+TYPE_EXTERN PrimitiveType*    dtStringC; // the type of a C string (unowned)
+TYPE_EXTERN PrimitiveType*    dtStringCopy; // the type of a C string (owned)
+TYPE_EXTERN PrimitiveType*    dtCVoidPtr; // the type of a C void* (unowned)
+TYPE_EXTERN PrimitiveType*    dtCFnPtr;   // a C function pointer (unowned)
 
-// base object type (for all classes)
-TYPE_EXTERN Type* dtObject;
+TYPE_EXTERN Type*             dtComplex[COMPLEX_SIZE_NUM];
 
-
-TYPE_EXTERN Map<Type*,Type*> wideClassMap; // class -> wide class
-TYPE_EXTERN Map<Type*,Type*> wideRefMap;   // reference -> wide reference
+TYPE_EXTERN Map<Type*, Type*> wideClassMap; // class -> wide class
+TYPE_EXTERN Map<Type*, Type*> wideRefMap;   // reference -> wide reference
 
 void     initPrimitiveTypes();
-DefExpr* defineObjectClass();
 void     initChplProgram(DefExpr* objectDef);
 void     initCompilerGlobals();
 
@@ -447,7 +444,6 @@ bool is_real_type(Type*);
 bool is_imag_type(Type*);
 bool is_complex_type(Type*);
 bool is_enum_type(Type*);
-#define is_arithmetic_type(t) (is_int_type(t) || is_uint_type(t) || is_real_type(t) || is_imag_type(t) || is_complex_type(t))
 bool isLegalParamType(Type*);
 int  get_width(Type*);
 bool isClass(Type* t);
@@ -506,11 +502,23 @@ bool isPOD(Type* t);
 
 // defined in codegen.cpp
 GenRet codegenImmediate(Immediate* i);
+
+
+
+
 #define CLASS_ID_TYPE dtInt[INT_SIZE_32]
 #define UNION_ID_TYPE dtInt[INT_SIZE_64]
 #define SIZE_TYPE dtInt[INT_SIZE_64]
 #define LOCALE_TYPE dtLocale->typeInfo()
 #define LOCALE_ID_TYPE dtLocaleID->typeInfo()
 #define NODE_ID_TYPE dtInt[INT_SIZE_32]
+
+#define is_arithmetic_type(t)                        \
+        (is_int_type(t)        ||                    \
+         is_uint_type(t)       ||                    \
+         is_real_type(t)       ||                    \
+         is_imag_type(t)       ||                    \
+         is_complex_type(t))
+
 
 #endif


### PR DESCRIPTION
Before this PR dtObject was declared with static type Type* in type.{h,cpp}.
This PR redefines it to have static type AggregateType* in AggregateType.{h,cpp}

Passed standard testing profile.  Also sanity checked with CHPL_LLVM=llvm
