### PR TITLE
Switch elegant miniMD to initializers

### DIFF
--- a/test/classes/initializers/miscBlocks.bad
+++ b/test/classes/initializers/miscBlocks.bad
@@ -1,0 +1,8 @@
+miscBlocks.chpl:3: internal error: INI0057 chpl Version 1.16.0 pre-release (69722b5)
+Note: This source location is a guess.
+
+Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
+please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
+the filename + line number above may be useful in working around the issue.
+

--- a/test/classes/initializers/miscBlocks.chpl
+++ b/test/classes/initializers/miscBlocks.chpl
@@ -1,0 +1,7 @@
+
+class Foo {
+  proc init() {
+    coforall i in 1..here.maxTaskPar do writeln("Hello from task ", i);
+    coforall loc in Locales do on loc do writeln("Hello from ", here);
+  }
+}

--- a/test/classes/initializers/miscBlocks.future
+++ b/test/classes/initializers/miscBlocks.future
@@ -1,0 +1,1 @@
+bug: compiler current fails if a coforall exists within an initializer

--- a/test/release/examples/benchmarks/miniMD/helpers/forces.chpl
+++ b/test/release/examples/benchmarks/miniMD/helpers/forces.chpl
@@ -10,6 +10,8 @@ class Force {
 
   var wipetime, maintime: real;
 
+  proc init() {}
+
   proc compute(store : bool) : void {}
 }
 
@@ -45,7 +47,7 @@ class ForceEAM : Force  {
 
   var funcfl : Funcfl;
 
-  proc ForceEAM(cf : real) {
+  proc init(cf : real) {
     // use the fluff domain already calculated for communication
     cutforcesq = cf*cf;
     coeff("Cu_u6.eam");
@@ -307,7 +309,7 @@ class ForceEAM : Force  {
 
 // Lennard-Jones potential
 class ForceLJ : Force {
-  proc ForceLJ(cf : real) {
+  proc init(cf : real) {
     cutforcesq = cf * cf;
   }
 


### PR DESCRIPTION
Also adds a future for a compiler failure when a coforall is within an initializer.