### PR TITLE
IO.channel.lines (serial-only)

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -3291,8 +3291,7 @@ iter channel.lines() {
     this._set_style(newline_style);
 
     // Iterate over lines
-    var lineReader = new ItemReader(string, this.kind, this.locking, this);
-    for line in lineReader {
+    for line in this.itemReader(string, this.kind) {
       yield line;
     }
 

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -3267,6 +3267,17 @@ inline proc channel.read(ref args ...?k,
   return !error;
 }
 
+/* Iterate over all of the lines in a channel.
+    Only serial iteration is supported.
+
+   :returns: an object which yields strings read from the file
+ */
+proc channel.lines() {
+  var ret = new ItemReader(string, channel.kind, channel.locking, this);
+  return ret;
+}
+
+
 pragma "no doc"
 proc _can_stringify_direct(t) param : bool {
   if (t.type == string ||

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -3272,7 +3272,7 @@ inline proc channel.read(ref args ...?k,
   Iterate over all of the lines in a channel.
   Only serial iteration is supported.
 
-  :returns: an object which yields strings read from the file
+  :yields: lines read by the channel
  */
 iter channel.lines() {
   var local_style: iostyle;

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -3268,10 +3268,11 @@ inline proc channel.read(ref args ...?k,
 }
 
 
-/* Iterate over all of the lines in a channel.
-    Only serial iteration is supported.
+/*
+  Iterate over all of the lines in a channel.
+  Only serial iteration is supported.
 
-   :returns: an object which yields strings read from the file
+  :returns: an object which yields strings read from the file
  */
 iter channel.lines() {
   var local_style: iostyle;

--- a/test/exercises/c-ray/c-ray.chpl
+++ b/test/exercises/c-ray/c-ray.chpl
@@ -438,7 +438,7 @@ proc loadScene() {
   const expectedArgs = ['l'=>4, 'c'=>8, 's'=>10];
 
   // loop over the lines from the input file, counting them
-  for (rawLine, lineno) in zip(infile.readlines(), 1..) {
+  for (rawLine, lineno) in zip(infile.lines(), 1..) {
     // drop any comments (text following '#')
     const linePlusComment = rawLine.split('#', maxsplit=1, ignoreEmpty=false),
           line = linePlusComment[1];
@@ -544,11 +544,4 @@ inline proc crossProduct(v1, v2) {
   return (v1(Y)*v2(Z) - v1(Z)*v2(Y),
           v1(Z)*v2(X) - v1(X)*v2(Z),
           v1(X)*v2(Y) - v1(Y)*v2(X));
-}
-
-iter channel.readlines() {
-  var line: string;
-
-  while (this.readline(line)) do
-    yield line;
 }

--- a/test/exercises/c-ray/forStudents/c-ray.chpl
+++ b/test/exercises/c-ray/forStudents/c-ray.chpl
@@ -479,7 +479,7 @@ proc loadScene() {
   const expectedArgs = ['l'=>4, 'c'=>8, 's'=>10];
 
   // loop over the lines from the input file, counting them
-  for (rawLine, lineno) in zip(infile.readlines(), 1..) {
+  for (rawLine, lineno) in zip(infile.lines(), 1..) {
     // drop any comments (text following '#')
     const linePlusComment = rawLine.split('#', maxsplit=1, ignoreEmpty=false),
           line = linePlusComment[1];
@@ -585,11 +585,4 @@ inline proc crossProduct(v1, v2) {
   return (v1(Y)*v2(Z) - v1(Z)*v2(Y),
           v1(Z)*v2(X) - v1(X)*v2(Z),
           v1(X)*v2(Y) - v1(Y)*v2(X));
-}
-
-iter channel.readlines() {
-  var line: string;
-
-  while (this.readline(line)) do
-    yield line;
 }

--- a/test/modules/standard/IO/channel/lines.chpl
+++ b/test/modules/standard/IO/channel/lines.chpl
@@ -1,0 +1,8 @@
+use IO;
+
+var c = open('lines.good', iomode.r);
+
+for line in c.lines() {
+  write(line);
+}
+

--- a/test/modules/standard/IO/channel/lines.chpl
+++ b/test/modules/standard/IO/channel/lines.chpl
@@ -1,6 +1,9 @@
 use IO;
 
-var c = open('lines.good', iomode.r);
+config param locking=true,
+             ioKind=iokind.dynamic;
+
+var c = openreader('lines.good', kind=ioKind, locking=locking);
 
 for line in c.lines() {
   write(line);

--- a/test/modules/standard/IO/channel/lines.compopts
+++ b/test/modules/standard/IO/channel/lines.compopts
@@ -1,0 +1,3 @@
+-s locking=true -s ioKind=iokind.dynamic
+-s locking=false -s ioKind=iokind.dynamic
+-s locking=true -s ioKind=iokind.native

--- a/test/modules/standard/IO/channel/lines.good
+++ b/test/modules/standard/IO/channel/lines.good
@@ -1,0 +1,6 @@
+
+We can only see a short distance ahead,
+but we can see plenty there that needs to be done.
+
+    - Alan Turing
+


### PR DESCRIPTION
This PR adds `channel.lines()` iterator to the IO module.

We have always intended to support this, but haven't yet due to challenges in supporting a parallel `channel.lines()`. This PR only adds support for a serial `channel.lines()`.

This implementation was derived from `file.lines()`, with all of the arguments inferred from the `channel` object's fields.

This PR also updates `c-ray.chpl` examples to use `channel.lines()`, which were previously using a custom `channel.readlines()` iterator.

Note: `channel.lines()` is implemented as an iterator, whereas `file.lines()` is a procedure that returns an iterable object (`ItemReader`). It would be ideal to update `file.lines()` to also be an iterator in the future.

- [x] Test all flavors of `channels`
  - [x] vanilla `channel`
  - [x] non-vanilla `channel.kind`
  - [x] non-vanilla `channel.locking`