### PR TITLE
Update tests to use initializers instead of constructors

### DIFF
--- a/test/classes/diten/test_destructor.chpl
+++ b/test/classes/diten/test_destructor.chpl
@@ -6,7 +6,7 @@ record R {
 // private:
   var c: C;
 // public:
-  proc R(a:int, b:int) {
+  proc init(a:int, b:int) {
     writeln("R");
     c = new C(a, b);
   }

--- a/test/classes/diten/test_destructor2.chpl
+++ b/test/classes/diten/test_destructor2.chpl
@@ -6,7 +6,7 @@ record R {
 // private:
   var c, c2: C;
 // public:
-  proc R(a:int, b:int) {
+  proc init(a:int, b:int) {
     writeln("R");
     c = new C(a, b);
   }

--- a/test/classes/diten/test_destructor4.chpl
+++ b/test/classes/diten/test_destructor4.chpl
@@ -1,6 +1,6 @@
 record R {
   var n: int;
-  proc R(n: int) {
+  proc init(n: int) {
     this.n = n;
     writeln("Construct R: ", this.n);
   }

--- a/test/modules/standard/datetime/testDatetimeTZ.chpl
+++ b/test/modules/standard/datetime/testDatetimeTZ.chpl
@@ -4,7 +4,12 @@ class FixedOffset: TZInfo {
   var offset: timedelta;
   var name: string;
   var dstoffset: timedelta;
-  proc FixedOffset(offset: int, name, dstoffset:int=42) {
+  proc init(offset: timedelta, name: string, dstoffset: timedelta = new timedelta(minutes=42)) {
+    this.offset = offset;
+    this.name = name;
+    this.dstoffset = dstoffset;
+  }
+  proc init(offset: int, name, dstoffset:int=42) {
     this.offset = new timedelta(minutes=offset);
     this.name = name;
     this.dstoffset = new timedelta(minutes=dstoffset);
@@ -247,7 +252,7 @@ proc test_tzinfo_timetuple() {
   // DST flag.
   class DST: TZInfo {
     var dstvalue: timedelta;
-    proc DST(i) {
+    proc init(i) {
       dstvalue = new timedelta(minutes=i);
     }
     proc dst(dt) {
@@ -277,7 +282,7 @@ proc test_tzinfo_timetuple() {
 proc test_utctimetuple() {
   class DST: TZInfo {
     var dstvalue: timedelta;
-    proc DST(dstvalue) {
+    proc init(dstvalue) {
       this.dstvalue = new timedelta(minutes=dstvalue);
     }
     proc dst(dt) {
@@ -287,9 +292,9 @@ proc test_utctimetuple() {
 
   class UOFS: DST {
     var uofs: timedelta;
-    proc UOFS(uofs, dofs=0) {
-      this.dstvalue = new timedelta(dofs);
+    proc init(uofs, dofs=0) {
       this.uofs = new timedelta(minutes=uofs);
+      super.init(dofs);
     }
     proc utcoffset(dt) {
       return uofs;
@@ -506,7 +511,7 @@ proc test_mixed_compare() {
   // In datetime w/ identical tzinfo objects, utcoffset is ignored.
   class Varies: TZInfo {
     var offset: timedelta;
-    proc Varies() {
+    proc init() {
       offset = new timedelta(minutes=22);
     }
     proc utcoffset(dt: datetime) {

--- a/test/modules/standard/datetime/testTimezone.chpl
+++ b/test/modules/standard/datetime/testTimezone.chpl
@@ -4,7 +4,14 @@ class FixedOffset: TZInfo {
   var offset: timedelta;
   var name: string;
   var dstoffset: timedelta;
-  proc FixedOffset(offset: int, name, dstoffset:int=42) {
+
+  proc init(offset: timedelta, name: string, dstoffset: timedelta=new timedelta(42)) {
+    this.offset = offset;
+    this.name = name;
+    this.dstoffset = dstoffset;
+  }
+
+  proc init(offset: int, name, dstoffset:int=42) {
     this.offset = new timedelta(minutes=offset);
     this.name = name;
     this.dstoffset = new timedelta(minutes=dstoffset);
@@ -147,7 +154,7 @@ proc test_mixed_compare() {
   class Varies: TZInfo {
     var offset: timedelta;
     var name = "Var";
-    proc Varies() {
+    proc init() {
       offset = new timedelta(minutes=22);
     }
     proc utcoffset(dt: datetime) {

--- a/test/studies/parboil/BFS/Deque.chpl
+++ b/test/studies/parboil/BFS/Deque.chpl
@@ -19,7 +19,9 @@ module Deque {
   record deque {
     type eltType;
     var d: deque_t;
-    proc deque(type eltType) {
+    proc init(type eltType) {
+      this.eltType = eltType;
+      super.init();
       deque_init(sizeof(eltType), d, 0);
     }
     proc deinit() {

--- a/test/types/void/void-variable-def.chpl
+++ b/test/types/void/void-variable-def.chpl
@@ -15,7 +15,7 @@ proc vartype() type {
 
 class c {
   var v: vartype();
-  proc c() { if enabled then v = 5; }
+  proc init() { if enabled then v = 5; }
 }
 
 writeln(new c());


### PR DESCRIPTION
Update tests matching patterns: \*diten\*, \*datetime\*, \*parboil\*, \*types/void\*
to use initializers instead of constructors.

These could all be phase 1:
classes/diten/test_destructor.chpl
classes/diten/test_destructor2.chpl
modules/standard/datetime/testTimezone.chpl
modules/standard/datetime/testDatetimeTZ.chpl

This would benefit from generic fields being phase independent:
studies/parboil/BFS/bfs.chpl

These are not updated yet because they were non-trivial to update:
distributions/diten/testCyclic.chpl
reductions/diten/deleteReductionClass.chpl
modules/standard/datetime/testTimezoneConversions.chpl