### PR TITLE
Pass -Wno-error when building parser with intel compiler

### DIFF
--- a/make/compiler/Makefile.intel
+++ b/make/compiler/Makefile.intel
@@ -62,7 +62,7 @@ CXX11_STD := $(shell test $(DEF_CXX_VER) -lt 201103 && echo -std=gnu++11)
 #  592 : squelch use-before-def problems -- we'll rely on valgrind to catch them
 
 COMP_CXXFLAGS = $(CXX_STD) $(CPPFLAGS) $(CXXFLAGS)
-COMP_CXXFLAGS_NONCHPL = -wr111,193,1418,1419,2215,2259,170
+COMP_CXXFLAGS_NONCHPL = -wr111,193,1418,1419,2215,2259,170 -Wno-error
 
 RUNTIME_CFLAGS = $(C_STD) $(CPPFLAGS) $(CFLAGS) -wr181,188
 RUNTIME_CXXFLAGS = $(CXX_STD) $(CPPFLAGS) $(CXXFLAGS)


### PR DESCRIPTION
Should resolve testing errors with parser generated by bison 3.

The intel compiler was producing an error along the lines of
```
  flex-chapel.cpp(2705): error #1628: function declared with "noreturn" does return
```

This has to do with `yy_fatal_error` being marked with `yynoreturn`, which uses `__attribute__((__noreturn__))` under some ifdefing for GCC.

I verified that this adjustment allows the compiler to build with icc in the configuration that failed before (e.g. `touch compiler/parser/flex-chapel.cpp && make DEBUG=1 WARNINGS=1 compiler`). A reasonable alternative would be to include `-wr1628` in the same compiler options for the bison-generated parser.

Checked Hellos run in quickstart + host&target intel compiler.
Checked Hellos run in standard config + host&target intel compiler.