### PR TITLE
Start testing c2chapel nightly

### DIFF
--- a/tools/c2chapel/Makefile
+++ b/tools/c2chapel/Makefile
@@ -28,7 +28,8 @@ endif
 
 include $(CHPL_MAKE_HOME)/make/Makefile.base
 
-link=$(CHPL_BIN_DIR)/c2chapel
+bdir=$(CHPL_BIN_DIR)
+link=$(bdir)/c2chapel
 
 VERSION=2.17
 TAR=release_v$(VERSION).tar.gz
@@ -81,4 +82,5 @@ ifneq ($(wildcard $(link)),)
 	@echo
 endif
 	@echo "Installing symbolic link..."
+	mkdir -p $(bdir)
 	ln -s $(shell pwd)/c2chapel $(link)

--- a/util/cron/test-c2chapel.bash
+++ b/util/cron/test-c2chapel.bash
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+#
+# Run tests that use generated c2chapel files
+
+CWD=$(cd $(dirname $0) ; pwd)
+source $CWD/common.bash
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="c2chapel"
+
+export CHPL_NIGHTLY_TEST_DIRS="c2chapel/"
+$CWD/nightly -cron


### PR DESCRIPTION
* Add cron script for test-c2chapel Jenkins job
* Fix c2chapel's Makefile so its "make install" works when run in a clean Git workspace
  (without needing to run a top-level "make" first)