### PR TITLE
Fix nonscalar types when used for type fields w/ initializers

### DIFF
--- a/compiler/passes/InitNormalize.cpp
+++ b/compiler/passes/InitNormalize.cpp
@@ -342,15 +342,40 @@ void InitNormalize::genericFieldInitTypeInference(Expr*    insertBefore,
   if (SymExpr* initSym = toSymExpr(initExpr)) {
     Type* type = initSym->symbol()->type;
 
-    if (isPrimitiveScalar(type) == true) {
+    if (isTypeVar == true) {
+      VarSymbol*  tmp;
+
+      if (type == dtAny) {
+        tmp = newTemp("tmp");
+      } else {
+        tmp = newTemp("tmp", type);
+      }
+      DefExpr*    tmpDefn   = new DefExpr(tmp);
+      CallExpr*   tmpInit   = new CallExpr(PRIM_MOVE, tmp, initExpr);
+
+      tmp->addFlag(FLAG_TYPE_VARIABLE);
+
+      Symbol*    _this    = mFn->_this;
+      Symbol*    name     = new_CStringSymbol(field->sym->name);
+      CallExpr*  fieldSet = new CallExpr(PRIM_INIT_FIELD, _this, name, tmp);
+
+      if (isFieldAccessible(initExpr) == false) {
+        INT_ASSERT(false);
+      }
+
+      updateFieldsMember(initExpr);
+
+      insertBefore->insertBefore(tmpDefn);
+      insertBefore->insertBefore(tmpInit);
+      insertBefore->insertBefore(fieldSet);
+
+    } else if (isPrimitiveScalar(type) == true) {
       VarSymbol*  tmp       = newTemp("tmp", type);
       DefExpr*    tmpDefn   = new DefExpr(tmp);
       CallExpr*   tmpInit   = new CallExpr(PRIM_MOVE, tmp, initExpr);
 
       if (isParam == true) {
         tmp->addFlag(FLAG_PARAM);
-      } else if (isTypeVar == true) {
-        tmp->addFlag(FLAG_TYPE_VARIABLE);
       }
 
       Symbol*     name      = new_CStringSymbol(field->sym->name);
@@ -374,8 +399,6 @@ void InitNormalize::genericFieldInitTypeInference(Expr*    insertBefore,
 
       if (isParam == true) {
         tmp->addFlag(FLAG_PARAM);
-      } else if (isTypeVar == true) {
-        tmp->addFlag(FLAG_TYPE_VARIABLE);
       }
 
       Symbol*    _this    = mFn->_this;
@@ -400,6 +423,27 @@ void InitNormalize::genericFieldInitTypeInference(Expr*    insertBefore,
     if (initCall->isPrimitive(PRIM_NEW) == true) {
       INT_ASSERT(false);
 
+    } else if (isTypeVar == true) {
+      VarSymbol* tmp      = newTemp("tmp");
+      DefExpr*   tmpDefn  = new DefExpr(tmp);
+      CallExpr*  tmpInit  = new CallExpr(PRIM_MOVE, tmp, initExpr);
+
+      tmp->addFlag(FLAG_TYPE_VARIABLE);
+
+      Symbol*    _this    = mFn->_this;
+      Symbol*    name     = new_CStringSymbol(field->sym->name);
+      CallExpr*  fieldSet = new CallExpr(PRIM_INIT_FIELD, _this, name, tmp);
+
+      if (isFieldAccessible(initExpr) == false) {
+        INT_ASSERT(false);
+      }
+
+      updateFieldsMember(initExpr);
+
+      insertBefore->insertBefore(tmpDefn);
+      insertBefore->insertBefore(tmpInit);
+      insertBefore->insertBefore(fieldSet);
+
     } else {
       VarSymbol* tmp      = newTemp("tmp");
       DefExpr*   tmpDefn  = new DefExpr(tmp);
@@ -407,8 +451,6 @@ void InitNormalize::genericFieldInitTypeInference(Expr*    insertBefore,
 
       if (isParam == true) {
         tmp->addFlag(FLAG_PARAM);
-      } else if (isTypeVar == true) {
-        tmp->addFlag(FLAG_TYPE_VARIABLE);
       }
 
       Symbol*    _this    = mFn->_this;

--- a/test/functions/nspark/generic-varargs1.bad
+++ b/test/functions/nspark/generic-varargs1.bad
@@ -1,2 +1,0 @@
-generic-varargs1.chpl:5: In initializer:
-generic-varargs1.chpl:6: error: illegal assignment of type to value

--- a/test/functions/nspark/generic-varargs1.future
+++ b/test/functions/nspark/generic-varargs1.future
@@ -1,6 +1,0 @@
-feature request: restore varargs capability to initializers on generic types
-
-In making the switch over to unify generic and concrete types with initializers,
-this test regressed.  I believe it is because there was previously an error with
-varargs for concrete types that hadn't been exposed.  I'm going to fix that
-independent of this change, so hopefully it won't fail for long.


### PR DESCRIPTION
In the new normalization of initializers on generic types that I added,
some branches used PRIM_INIT_VAR, but that isn't a valid operation on type
variables.  Rearrange the contents of genericFieldInitTypeInference to
accommodate this.

This allows functions/nspark/generic-varargs1.chpl to pass again, so I
removed the .future and .bad file added last week.

Passed test/classes/initializers with futures and a full paratest.