### PR TITLE
Make privateDist an owned object

### DIFF
--- a/modules/dists/PrivateDist.chpl
+++ b/modules/dists/PrivateDist.chpl
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+use OwnedObject only Owned;
+
 //
 // Private Distribution, Domain, and Array
 //  Defines PrivateSpace, an instance of PrivateDom
@@ -202,10 +204,5 @@ proc PrivateArr.dsiSerialWrite(x) {
   }
 }
 
-const privateDist = new Private();
-const PrivateSpace: domain(1) dmapped new dmap(privateDist);
-
-pragma "no doc"
-proc deinit() {
-  delete privateDist;
-}
+const privateDist = new Owned(new Private());
+const PrivateSpace: domain(1) dmapped new dmap(privateDist.borrow());


### PR DESCRIPTION
This avoids the record deinit ordering problem described in #6726, and fixes the memory-bug regression introduced in #6695.

- [x] valgrind testing
  - `modules/vass/SSCA2-with-Private-1`
  - `modules/vass/SSCA2-with-Private-2`
  - `parallel/taskPar/sungeun/private`
- [x] gasnet testing
  - `multilocale/deitz/needMultiLocales/dist/test_private_space`
  - `multilocale/deitz/needMultiLocales/test_frag_main`
