### PR TITLE
 Improve well-known functions to work after resolution 

### DIFF
--- a/compiler/AST/astutil.cpp
+++ b/compiler/AST/astutil.cpp
@@ -34,6 +34,7 @@
 #include "TryStmt.h"
 #include "type.h"
 #include "virtualDispatch.h"
+#include "wellknown.h"
 #include "WhileStmt.h"
 
 #include "oldCollectors.h" // Deprecated. To be removed.
@@ -782,6 +783,13 @@ visitVisibleFunctions(Vec<FnSymbol*>& fns, Vec<TypeSymbol*>& types)
   forv_Vec(FnSymbol, fn, gFnSymbols)
     if (fn->hasFlag(FLAG_EXPORT))
       pruneVisit(fn, fns, types);
+
+  // Mark non-generic well-known functions as visible
+  std::vector<FnSymbol*> wellKnownFns = getWellKnownFunctions();
+  for_vector(FnSymbol, fn, wellKnownFns) {
+    if (!fn->hasFlag(FLAG_GENERIC))
+      pruneVisit(fn, fns, types);
+  }
 
   pruneVisitFn(gAddModuleFn, fns, types);
   forv_Vec(ModuleSymbol, mod, gModuleSymbols) {

--- a/compiler/AST/astutil.cpp
+++ b/compiler/AST/astutil.cpp
@@ -784,11 +784,10 @@ visitVisibleFunctions(Vec<FnSymbol*>& fns, Vec<TypeSymbol*>& types)
     if (fn->hasFlag(FLAG_EXPORT))
       pruneVisit(fn, fns, types);
 
-  // Mark non-generic well-known functions as visible
+  // Mark well-known functions as visible
   std::vector<FnSymbol*> wellKnownFns = getWellKnownFunctions();
   for_vector(FnSymbol, fn, wellKnownFns) {
-    if (!fn->hasFlag(FLAG_GENERIC))
-      pruneVisit(fn, fns, types);
+    pruneVisit(fn, fns, types);
   }
 
   pruneVisitFn(gAddModuleFn, fns, types);

--- a/compiler/AST/wellknown.cpp
+++ b/compiler/AST/wellknown.cpp
@@ -260,9 +260,21 @@ std::vector<FnSymbol*> getWellKnownFunctions()
 
   for (int i = 0; i < nEntries; ++i) {
     WellKnownFn& wkfn = sWellKnownFns[i];
-    fns.push_back(*wkfn.fn);
+    if (*wkfn.fn != NULL)
+      fns.push_back(*wkfn.fn);
   }
 
   return fns;
+}
+
+void clearGenericWellKnownFunctions()
+{
+  int nEntries = sizeof(sWellKnownFns) / sizeof(sWellKnownFns[0]);
+
+  for (int i = 0; i < nEntries; ++i) {
+    WellKnownFn& wkfn = sWellKnownFns[i];
+    if ((*wkfn.fn)->hasFlag(FLAG_GENERIC))
+      *wkfn.fn = NULL;
+  }
 }
 

--- a/compiler/AST/wellknown.cpp
+++ b/compiler/AST/wellknown.cpp
@@ -273,7 +273,7 @@ void clearGenericWellKnownFunctions()
 
   for (int i = 0; i < nEntries; ++i) {
     WellKnownFn& wkfn = sWellKnownFns[i];
-    if ((*wkfn.fn)->hasFlag(FLAG_GENERIC))
+    if (*wkfn.fn != NULL && (*wkfn.fn)->hasFlag(FLAG_GENERIC))
       *wkfn.fn = NULL;
   }
 }

--- a/compiler/include/wellknown.h
+++ b/compiler/include/wellknown.h
@@ -29,5 +29,6 @@ void gatherWellKnownTypes();
 void gatherWellKnownFns();
 
 std::vector<FnSymbol*> getWellKnownFunctions();
+void clearGenericWellKnownFunctions();
 
 #endif

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -6984,8 +6984,10 @@ static void resolveOther() {
 
   std::vector<FnSymbol*> fns = getWellKnownFunctions();
   for_vector(FnSymbol, fn, fns) {
-    if (!fn->hasFlag(FLAG_GENERIC))
+    if (!fn->hasFlag(FLAG_GENERIC)) {
+      resolveFormals(fn);
       resolveFns(fn);
+    }
   }
 }
 
@@ -7467,10 +7469,19 @@ static void removeCopyFns(Type* t) {
 static void removeUnusedFunctions() {
   std::set<FnSymbol*> concreteWellKnownFunctionsSet;
 
+  // Generic well-known functions will no longer be
+  // well-known (since after resolution they can't be
+  // instantiated, and the generic fn is removed).
+  // So remove generic well-known functions from the list.
+  clearGenericWellKnownFunctions();
+
+  // Concrete well-known functions need to be preserved,
+  // so track them in a set.
   std::vector<FnSymbol*> fns = getWellKnownFunctions();
   for_vector(FnSymbol, fn, fns) {
-    if (!fn->hasFlag(FLAG_GENERIC))
-      concreteWellKnownFunctionsSet.insert(fn);
+    // These should have just been removed
+    INT_ASSERT(!fn->hasFlag(FLAG_GENERIC));
+    concreteWellKnownFunctionsSet.insert(fn);
   }
 
   // Remove unused functions


### PR DESCRIPTION
In implementing prototype error handling support within tasks, I needed to create some Chapel functions that can be called during code generation. We do this right now by marking such functions as `export` but I couldn't do that because I needed my function to take a wide pointer argument.

So, this PR makes minor adjustments to the compiler in order to keep the list of well-known-functions respected and accurate after function resolution.

In particular it:
 * adds well-known functions to the set of visible functions in visitVisibleFunctions (so that the prune pass does not remove them)
 * adjusts `removeUnusedFunctions()` in function resolution to remove any generic well-known functions from the list, since these cannot be used after resolution (at least in the current compiler).

Passed full local testing.
Reviewed by @noakesmichael - thanks!