### PR TITLE
Partially revert #6695

### DIFF
--- a/modules/dists/PrivateDist.chpl
+++ b/modules/dists/PrivateDist.chpl
@@ -202,10 +202,6 @@ proc PrivateArr.dsiSerialWrite(x) {
   }
 }
 
-const privateDist = new Private();
-const PrivateSpace: domain(1) dmapped new dmap(privateDist);
+// TODO: Fix 'new Private()' leak -- Discussed in #6726
+const PrivateSpace: domain(1) dmapped new dmap(new Private());
 
-pragma "no doc"
-proc deinit() {
-  delete privateDist;
-}


### PR DESCRIPTION
The quick-fix from #6695 did not account for the domain accessing the domain map during domain deinitialization. 

Solutions to this problem are being discussed in #6726 

This change reverts the changes to `PrivateDist.chpl`, but does not revert the leak-fixes to user-code tests.