### PR TITLE
Update some more tests to use initializers

### DIFF
--- a/test/classes/ferguson/const-override-bug.chpl
+++ b/test/classes/ferguson/const-override-bug.chpl
@@ -16,8 +16,9 @@ class myNumaDomain : myAbstractLocaleModel {
   const name: string;
   proc chpl_name() return name;
 
-  proc myNumaDomain() {
+  proc init() {
     name = "test";
+    super.init();
   }
 }
 

--- a/test/types/records/const-checking/constructors.chpl
+++ b/test/types/records/const-checking/constructors.chpl
@@ -4,15 +4,11 @@ record RECTYPE {
   var VARFIELD: int;
   const CONSTFIELD: int;
 
-  proc RECTYPE() {
+  proc init() {
     writeln("RECTYPE constructor");
     VARFIELD   = 200;
     CONSTFIELD = 300;
-    initRT();
-  }
-
-  proc initialize() {
-    writeln("RECTYPE.initialize()");
+    super.init();
     initRT();
   }
 

--- a/test/types/records/const-checking/constructors.good
+++ b/test/types/records/const-checking/constructors.good
@@ -2,14 +2,10 @@ Note: this test is about record field accesses, not about
 how constructors and initialize() are currently invoked.
 If/when the latter changes, the .good should be adjusted.
 
-RECTYPE.initialize()
-RECTYPE.initRT()
 RECTYPE constructor
 RECTYPE.initRT()
 (VARFIELD = 401, CONSTFIELD = 901)
 
-RECTYPE.initialize()
-RECTYPE.initRT()
 RECTYPE constructor
 RECTYPE.initRT()
 (VARFIELD = 401, CONSTFIELD = 901)

--- a/test/types/records/const-checking/tuples-and-records.chpl
+++ b/test/types/records/const-checking/tuples-and-records.chpl
@@ -8,7 +8,7 @@ record RRR {
   var varfield2: 3*int;
   const cstfield1: (int,real);
   const cstfield2: 3*int;
-  proc RRR() {
+  proc init() {
     varfield1(1) = 1111;
     varfield2(2) = 1111;
     varfield2(g) = 1111;

--- a/test/users/ferguson/recordConstructor.chpl
+++ b/test/users/ferguson/recordConstructor.chpl
@@ -5,7 +5,7 @@ proc doit():int {
 
 record R {
   var x:int = doit();
-  proc R() {
+  proc init() {
     writeln("R constructor");
     x = 15;
   }

--- a/test/users/ferguson/refcnt.chpl
+++ b/test/users/ferguson/refcnt.chpl
@@ -1,6 +1,6 @@
 class RefCount {
   var count:int;
-  proc RefCount() {
+  proc init() {
     writeln("Initializing a RefCount");
     count = 1;
   }


### PR DESCRIPTION
Continuing the saga of issue #6530.

Verified that the updated tests pass in a quickstart config.
Passed full local testing.