### PR TITLE
Don't set serial=true on main for fifo tasks

### DIFF
--- a/runtime/src/chpl-init.c
+++ b/runtime/src/chpl-init.c
@@ -222,9 +222,6 @@ void chpl_std_module_init(void) {
   chpl__heapAllocateGlobals(); // allocate global vars on heap for multilocale
 
   if (chpl_nodeID == 0) {
-    // OK, we can create tasks now.
-    chpl_task_setSerial(false);
-
     //
     // This just sets all of the initialization predicates to false.
     // Must occur before any other call to a chpl__init_<foo> function.

--- a/runtime/src/tasks/fifo/tasks-fifo.c
+++ b/runtime/src/tasks/fifo/tasks-fifo.c
@@ -325,8 +325,7 @@ static void setup_main_thread_private_data(void)
   tp->ptask->next         = NULL;
   tp->ptask->prev         = NULL;
 
-  // serial_state starts out true; it is set to false in chpl_std_module_init().
-  tp->ptask->bundle.serial_state    = true;
+  tp->ptask->bundle.serial_state    = false;
   tp->ptask->bundle.countRunning    = false;
   tp->ptask->bundle.is_executeOn    = false;
   tp->ptask->bundle.lineno          = 0;


### PR DESCRIPTION
Historically, for fifo, the main thread has started with serial_state = true, and then chpl_std_module_init sets serial_state = false. In this PR we stop doing that. Thissimplifies the job of  for migrating EndCounts to task-local storage which I am working on for another PR.

This relevant historical commits are:

  * 66f249c2db3840c90b62bc1d5ee715b2994e4c47 / r19091
    (seemed to have something to do with taskTable)
  * cea12bed11aa94f78b0f40a30ffe85a9864d0be3 / r19070
    "We need to initialize chpldev_taskTable and its domain before calling
    chpl_task_callMain(), but only if we are tracking tasks."
  * f9ccf66536170fafea91705734031cd81b180afb / r19222
    added guards that should make the serial_state business unnecessary

Verified that test/parallel/cobegin/hilde/reports.chpl seems to work just as well with this PR as it did before, even with GASNet+fifo.

Passed full local testing.
Passed hellos with quickstart+GASNet.

Reviewed by @gbtitus - thanks!