### PR TITLE
Simplify API to wrappers.cpp.  Reduce 4 exported functions to just 1.

### DIFF
--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -155,8 +155,6 @@ public:
 
 void explainGatherCandidate(Vec<ResolutionCandidate*>& candidates,
                             CallInfo& info, CallExpr* call);
-void wrapAndCleanUpActuals(ResolutionCandidate* best, CallInfo& info,
-                           bool buildFastFollowerChecks);
 
 /** Contextual info used by the disambiguation process.
  *
@@ -231,10 +229,7 @@ void insertFormalTemps(FnSymbol* fn);
 void insertAndResolveCasts(FnSymbol* fn);
 void ensureInMethodList(FnSymbol* fn);
 
-FnSymbol* defaultWrap(FnSymbol* fn, std::vector<ArgSymbol*>* actualFormals,  CallInfo* info);
-void reorderActuals(FnSymbol* fn, std::vector<ArgSymbol*>* actualFormals,  CallInfo* info);
-void coerceActuals(FnSymbol* fn, CallInfo* info);
-FnSymbol* promotionWrap(FnSymbol* fn, CallInfo* info, bool buildFastFollowerChecks);
+
 
 FnSymbol* getAutoCopy(Type* t);
 FnSymbol* getAutoDestroy(Type* t);

--- a/compiler/include/wrappers.h
+++ b/compiler/include/wrappers.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2004-2017 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _WRAPPERS_H_
+#define _WRAPPERS_H_
+
+#include <vector>
+
+class ArgSymbol;
+class CallInfo;
+class FnSymbol;
+
+FnSymbol* wrapAndCleanUpActuals(FnSymbol*                fn,
+                                CallInfo&                info,
+                                std::vector<ArgSymbol*>* actualIdxToFormal,
+                                bool                     fastFollowerChecks);
+
+#endif

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -60,6 +60,7 @@
 #include "visibleFunctions.h"
 #include "wellknown.h"
 #include "WhileStmt.h"
+#include "wrappers.h"
 
 #include "../ifa/prim_data.h"
 
@@ -252,6 +253,10 @@ static FnSymbol* findGenMainFn();
 static void printCallGraph(FnSymbol* startPoint = NULL,
                            int indent = 0,
                            std::set<FnSymbol*>* alreadyCalled = NULL);
+
+static void wrapAndCleanUpActuals(ResolutionCandidate* best,
+                                  CallInfo&            info,
+                                  bool                 fastFollowerChecks);
 
 
 bool ResolutionCandidate::computeAlignment(CallInfo& info) {
@@ -3805,13 +3810,13 @@ void explainGatherCandidate(Vec<ResolutionCandidate*>& candidates,
   }
 }
 
-void wrapAndCleanUpActuals(ResolutionCandidate* best, CallInfo& info,
-                           bool buildFastFollowerChecks) {
-  INT_ASSERT(best->fn);
-  best->fn = defaultWrap(best->fn, &best->actualIdxToFormal, &info);
-  reorderActuals(best->fn, &best->actualIdxToFormal, &info);
-  coerceActuals(best->fn, &info);
-  best->fn = promotionWrap(best->fn, &info, buildFastFollowerChecks);
+static void wrapAndCleanUpActuals(ResolutionCandidate* best,
+                                  CallInfo&            info,
+                                  bool                 fastFollowerChecks) {
+  best->fn = wrapAndCleanUpActuals(best->fn,
+                                   info,
+                                   &best->actualIdxToFormal,
+                                   fastFollowerChecks);
 }
 
 void resolveNormalCallCompilerWarningStuff(FnSymbol* resolvedFn) {


### PR DESCRIPTION
While chasing a bug I got pulled in to wrappers.cpp.  While there I noticed that it
exported 4 functions but these functions were called in a simple sequence in
almost exactly the same way from just two locations in the code.


This trivial PR implements a single entry point to wrappers.cpp, converts the previous 4
entry points to be file static, and then updates the call points within initializerResolution.cpp
and functionResolution.cpp to use this entry point.

Passed the conventional testing profile
