### PR TITLE
Group the helpers for promotionWrap()

### DIFF
--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -915,68 +915,374 @@ static void addArgCoercion(FnSymbol*  fn,
 ************************************** | *************************************/
 
 static FnSymbol*
-buildEmptyWrapper(FnSymbol* fn, CallInfo* info) {
-  FnSymbol* wrapper = new FnSymbol(fn->name);
-  // TODO: Make this less verbose by bulk-copying flags from the original
-  // function and then negating flags we don't want.
-  wrapper->addFlag(FLAG_WRAPPER);
-  wrapper->addFlag(FLAG_INVISIBLE_FN);
-  wrapper->addFlag(FLAG_INLINE);
-  if (fn->hasFlag(FLAG_INIT_COPY_FN))
-    wrapper->addFlag(FLAG_INIT_COPY_FN);
-  if (fn->hasFlag(FLAG_AUTO_COPY_FN))
-    wrapper->addFlag(FLAG_AUTO_COPY_FN);
-  if (fn->hasFlag(FLAG_AUTO_DESTROY_FN))
-    wrapper->addFlag(FLAG_AUTO_DESTROY_FN);
-  if (fn->hasFlag(FLAG_DONOR_FN))
-    wrapper->addFlag(FLAG_DONOR_FN);
-  if (fn->hasFlag(FLAG_NO_PARENS))
-    wrapper->addFlag(FLAG_NO_PARENS);
-  if (fn->hasFlag(FLAG_CONSTRUCTOR))
-    wrapper->addFlag(FLAG_CONSTRUCTOR);
-  if (fn->hasFlag(FLAG_FIELD_ACCESSOR))
-    wrapper->addFlag(FLAG_FIELD_ACCESSOR);
-  if (fn->hasFlag(FLAG_REF_TO_CONST))
-    wrapper->addFlag(FLAG_REF_TO_CONST);
-  if (!fn->isIterator()) { // getValue is var, not iterator
-    wrapper->retTag = fn->retTag;
+buildPromotionWrapper(FnSymbol*  fn,
+                      SymbolMap* promotionSubs,
+                      CallInfo*  info,
+                      bool       buildFastFollowerChecks);
+
+static void
+fixUnresolvedSymExprsForPromotionWrapper(FnSymbol* wrapper,
+                                         FnSymbol* fn);
+
+static void
+buildPromotionFastFollowerCheck(bool                  isStatic,
+                                bool                  addLead,
+                                CallInfo*             info,
+                                FnSymbol*             wrapper,
+                                std::set<ArgSymbol*>& requiresPromotion);
+
+
+static FnSymbol* promotionWrap(FnSymbol* fn,
+                               CallInfo* info,
+                               bool      buildFastFollowerChecks) {
+
+  Vec<Symbol*>* actuals = &info->actuals;
+
+  if (fn->name == astrSequals) {
+    return fn;
   }
-  if (fn->hasFlag(FLAG_METHOD))
-    wrapper->addFlag(FLAG_METHOD);
-  if (fn->hasFlag(FLAG_METHOD_PRIMARY))
-    wrapper->addFlag(FLAG_METHOD_PRIMARY);
-  if (fn->hasFlag(FLAG_ASSIGNOP))
-    wrapper->addFlag(FLAG_ASSIGNOP);
-  wrapper->instantiationPoint = getVisibilityBlock(info->call);
-  if (fn->hasFlag(FLAG_DEFAULT_CONSTRUCTOR))
-    wrapper->addFlag(FLAG_DEFAULT_CONSTRUCTOR);
-  if (fn->hasFlag(FLAG_COMPILER_GENERATED))
-    wrapper->addFlag(FLAG_WAS_COMPILER_GENERATED);
-  wrapper->addFlag(FLAG_COMPILER_GENERATED);
+
+  // Don't try to promotion wrap _ref type constructor
+  if (fn->hasFlag(FLAG_TYPE_CONSTRUCTOR)) {
+    return fn;
+  }
+
+  bool      promotion_wrapper_required = false;
+  int       j                          = -1;
+  SymbolMap promoted_subs;
+
+  for_formals(formal, fn) {
+    j++;
+
+    Type*   actualType = actuals->v[j]->type;
+    Symbol* actualSym  = actuals->v[j];
+    bool    promotes   = false;
+
+    if (isRecordWrappedType(actualType)) {
+      makeRefType(actualType);
+
+      actualType = actualType->refType;
+
+      INT_ASSERT(actualType);
+    }
+
+    if (canDispatch(actualType, actualSym, formal->type, fn, &promotes)) {
+      if (promotes) {
+        promotion_wrapper_required = true;
+        promoted_subs.put(formal, actualType->symbol);
+      }
+    }
+  }
+
+  if (promotion_wrapper_required) {
+    if (fReportPromotion) {
+      USR_WARN(info->call, "promotion on %s", toString(info));
+    }
+
+    promoted_subs.put(fn, (Symbol*)info->call->square);
+
+    FnSymbol* wrapper = checkCache(promotionsCache, fn, &promoted_subs);
+
+    if (wrapper == NULL) {
+      wrapper = buildPromotionWrapper(fn,
+                                      &promoted_subs,
+                                      info,
+                                      buildFastFollowerChecks);
+      addCache(promotionsCache, fn, wrapper, &promoted_subs);
+    }
+
+    resolveFormals(wrapper);
+
+    return wrapper;
+
+  } else {
+    return fn;
+  }
+}
+
+static FnSymbol* buildPromotionWrapper(FnSymbol*  fn,
+                                       SymbolMap* promotion_subs,
+                                       CallInfo*  info,
+                                       bool       buildFastFollowerChecks) {
+  SET_LINENO(info->call);
+
+  FnSymbol* wrapper = buildEmptyWrapper(fn, info);
+
+  wrapper->addFlag(FLAG_PROMOTION_WRAPPER);
+
+  // Special case: When promoting a default constructor, the promotion wrapper
+  // itself is no longer a default constructor.
+  wrapper->removeFlag(FLAG_DEFAULT_CONSTRUCTOR);
+
+  wrapper->cname = astr("_promotion_wrap_", fn->cname);
+
+  std::set<ArgSymbol*> requiresPromotion;
+  CallExpr*            indicesCall  = new CallExpr("_build_tuple");
+  CallExpr*            iteratorCall = new CallExpr("_build_tuple");
+  CallExpr*            actualCall   = new CallExpr(fn);
+  bool                 zippered     = true;
+  int                  i            = 1;
+
+  for_formals(formal, fn) {
+    SET_LINENO(formal);
+
+    ArgSymbol* new_formal = copyFormalForWrapper(formal);
+
+    if (Symbol* p = paramMap.get(formal)) {
+      paramMap.put(new_formal, p);
+    }
+
+    if (fn->_this == formal) {
+      wrapper->_this = new_formal;
+    }
+
+    if (Symbol* sub = promotion_subs->get(formal)) {
+      TypeSymbol* ts = toTypeSymbol(sub);
+
+      requiresPromotion.insert(new_formal);
+
+      if (!ts) {
+        INT_FATAL(fn, "error building promotion wrapper");
+      }
+
+      new_formal->type = ts->type;
+
+      wrapper->insertFormalAtTail(new_formal);
+
+      iteratorCall->insertAtTail(new_formal);
+
+      // Rely on the 'destructureIndices' function in build.cpp to create a
+      // VarSymbol and DefExpr for these indices. This solves a problem where
+      // these 'p_i_' variables were declared outside of the loop body's scope.
+      const char* name = astr("p_i_", istr(i));
+
+      indicesCall->insertAtTail(new UnresolvedSymExpr(name));
+
+      actualCall->insertAtTail(new UnresolvedSymExpr(name));
+
+    } else {
+      wrapper->insertFormalAtTail(new_formal);
+      actualCall->insertAtTail(new_formal);
+    }
+
+    i++;
+  }
+
+  // Convert 1-tuples to their contents for the second half of this function
+  Expr* indices = indicesCall;
+
+  if (indicesCall->numActuals() == 1) {
+    indices = indicesCall->get(1)->remove();
+  }
+
+  Expr* iterator = iteratorCall;
+
+  if (iteratorCall->numActuals() == 1) {
+    iterator = iteratorCall->get(1)->remove();
+    zippered = false;
+  }
+
+  if ((!fn->hasFlag(FLAG_EXTERN) && fn->getReturnSymbol() == gVoid) ||
+      (fn->hasFlag(FLAG_EXTERN) && fn->retType == dtVoid)) {
+      wrapper->insertAtTail(new BlockStmt(buildForallLoopStmt(indices, iterator, /*byref_vars=*/ NULL, new BlockStmt(actualCall), zippered)));
+
+  } else {
+    wrapper->addFlag(FLAG_ITERATOR_FN);
+    wrapper->removeFlag(FLAG_INLINE);
+
+
+    // Build up the leader iterator
+    SymbolMap leaderMap;
+    FnSymbol* lifn       = wrapper->copy(&leaderMap);
+
+    INT_ASSERT(! lifn->hasFlag(FLAG_RESOLVED));
+
+    iteratorLeaderMap.put(wrapper,lifn);
+
+    lifn->body = new BlockStmt(); // indices are not used in leader
+
+    form_Map(SymbolMapElem, e, leaderMap) {
+      if (Symbol* s = paramMap.get(e->key)) {
+        paramMap.put(e->value, s);
+      }
+    }
+
+    ArgSymbol* lifnTag = new ArgSymbol(INTENT_PARAM, "tag", gLeaderTag->type);
+
+    // Leader iterators are always inlined.
+    lifn->addFlag(FLAG_INLINE_ITERATOR);
+
+    lifn->insertFormalAtTail(lifnTag);
+
+    lifn->where = new BlockStmt(new CallExpr("==", lifnTag, gLeaderTag));
+
+    VarSymbol* leaderIndex    = newTemp("p_leaderIndex");
+    VarSymbol* leaderIterator = newTemp("p_leaderIterator");
+
+    leaderIterator->addFlag(FLAG_EXPR_TEMP);
+
+    lifn->insertAtTail(new DefExpr(leaderIterator));
+
+    if (zippered == false) {
+      lifn->insertAtTail(new CallExpr(PRIM_MOVE, leaderIterator, new CallExpr("_toLeader", iterator->copy(&leaderMap))));
+    } else {
+      lifn->insertAtTail(new CallExpr(PRIM_MOVE, leaderIterator, new CallExpr("_toLeaderZip", iterator->copy(&leaderMap))));
+    }
+
+    BlockStmt* body = new BlockStmt(new CallExpr(PRIM_YIELD, leaderIndex));
+    BlockStmt* loop = ForLoop::buildForLoop(new SymExpr(leaderIndex), new SymExpr(leaderIterator), body, false, zippered);
+
+    lifn->insertAtTail(loop);
+
+    theProgram->block->insertAtTail(new DefExpr(lifn));
+
+    toBlockStmt(body->parentExpr)->insertAtHead(new DefExpr(leaderIndex));
+
+    normalize(lifn);
+
+    lifn->addFlag(FLAG_GENERIC);
+    lifn->instantiationPoint = getVisibilityBlock(info->call);
+
+    // Build up the follower iterator
+    SymbolMap followerMap;
+    FnSymbol* fifn = wrapper->copy(&followerMap);
+
+    INT_ASSERT(! fifn->hasFlag(FLAG_RESOLVED));
+
+    iteratorFollowerMap.put(wrapper,fifn);
+
+    form_Map(SymbolMapElem, e, followerMap) {
+      if (Symbol* s = paramMap.get(e->key)) {
+        paramMap.put(e->value, s);
+      }
+    }
+
+    ArgSymbol* fifnTag      = new ArgSymbol(INTENT_PARAM, "tag", gFollowerTag->type);
+    fifn->insertFormalAtTail(fifnTag);
+
+    ArgSymbol* fifnFollower = new ArgSymbol(INTENT_BLANK, iterFollowthisArgname, dtAny);
+
+    fifn->insertFormalAtTail(fifnFollower);
+
+    ArgSymbol* fastFollower = new ArgSymbol(INTENT_PARAM, "fast", dtBool, NULL, new SymExpr(gFalse));
+
+    fifn->insertFormalAtTail(fastFollower);
+
+    fifn->where = new BlockStmt(new CallExpr("==", fifnTag, gFollowerTag));
+
+    VarSymbol* followerIterator = newTemp("p_followerIterator");
+
+    followerIterator->addFlag(FLAG_EXPR_TEMP);
+
+    fifn->insertAtTail(new DefExpr(followerIterator));
+
+    if (zippered == false) {
+      fifn->insertAtTail(new CondStmt(new SymExpr(fastFollower),
+                         new CallExpr(PRIM_MOVE, followerIterator, new CallExpr("_toFastFollower", iterator->copy(&followerMap), fifnFollower)),
+                         new CallExpr(PRIM_MOVE, followerIterator, new CallExpr("_toFollower", iterator->copy(&followerMap), fifnFollower))));
+    } else {
+      fifn->insertAtTail(new CondStmt(new SymExpr(fastFollower),
+                         new CallExpr(PRIM_MOVE, followerIterator, new CallExpr("_toFastFollowerZip", iterator->copy(&followerMap), fifnFollower)),
+                         new CallExpr(PRIM_MOVE, followerIterator, new CallExpr("_toFollowerZip", iterator->copy(&followerMap), fifnFollower))));
+    }
+
+    BlockStmt* followerBlock = new BlockStmt();
+    Symbol*    yieldTmp      = newTemp("p_yield");
+
+    yieldTmp->addFlag(FLAG_EXPR_TEMP);
+
+    followerBlock->insertAtTail(new DefExpr(yieldTmp));
+    followerBlock->insertAtTail(new CallExpr(PRIM_MOVE, yieldTmp, actualCall->copy(&followerMap)));
+    followerBlock->insertAtTail(new CallExpr(PRIM_YIELD, yieldTmp));
+
+    fifn->insertAtTail(ForLoop::buildForLoop(indices->copy(&followerMap), new SymExpr(followerIterator), followerBlock, false, zippered));
+
+    theProgram->block->insertAtTail(new DefExpr(fifn));
+
+    normalize(fifn);
+
+    fifn->addFlag(FLAG_GENERIC);
+
+    fifn->instantiationPoint = getVisibilityBlock(info->call);
+
+    fixUnresolvedSymExprsForPromotionWrapper(fifn, fn);
+
+    if (!fNoFastFollowers && buildFastFollowerChecks) {
+      // Build up the static (param) fast follower check functions
+      buildPromotionFastFollowerCheck(/*isStatic=*/true,  /*addLead=*/false, info, wrapper, requiresPromotion);
+      buildPromotionFastFollowerCheck(/*isStatic=*/true,  /*addLead=*/true,  info, wrapper, requiresPromotion);
+
+      // Build up the dynamic fast follower check functions
+      buildPromotionFastFollowerCheck(/*isStatic=*/false, /*addLead=*/false, info, wrapper, requiresPromotion);
+      buildPromotionFastFollowerCheck(/*isStatic=*/false, /*addLead=*/true,  info, wrapper, requiresPromotion);
+    }
+
+
+    // Finish building the serial iterator. We stopped mid-way so the common
+    // code could be copied for the leader/follower
+    BlockStmt* yieldBlock = new BlockStmt();
+
+    yieldTmp = newTemp("p_yield");
+
+    yieldTmp->addFlag(FLAG_EXPR_TEMP);
+
+    yieldBlock->insertAtTail(new DefExpr(yieldTmp));
+    yieldBlock->insertAtTail(new CallExpr(PRIM_MOVE, yieldTmp, actualCall));
+    yieldBlock->insertAtTail(new CallExpr(PRIM_YIELD, yieldTmp));
+
+    wrapper->insertAtTail(new BlockStmt(ForLoop::buildForLoop(indices, iterator, yieldBlock, false, zippered)));
+  }
+
+  fn->defPoint->insertBefore(new DefExpr(wrapper));
+
+  normalize(wrapper);
+
+  fixUnresolvedSymExprsForPromotionWrapper(wrapper, fn);
+
   return wrapper;
 }
 
+static void fixUnresolvedSymExprsForPromotionWrapper(FnSymbol* wrapper,
+                                                     FnSymbol* fn) {
+  // Fix the UnresolvedSymExprs we inserted to the actualCall. For each
+  // call to `fn`, pick out any UnresolvedSymExprs and look in the loop
+  // body for a corresponding DefExpr.
 
-//
-// copy a formal and make the copy have blank intent. If the formal to copy has
-// out intent or inout intent, flag the copy to make sure it is a reference
-// If the formal is ref intent, leave it as ref on the wrapper formal.
-//
-static ArgSymbol* copyFormalForWrapper(ArgSymbol* formal) {
-  ArgSymbol* wrapperFormal = formal->copy();
-  if (formal->intent == INTENT_OUT || formal->intent == INTENT_INOUT ||
-      formal->hasFlag(FLAG_WRAP_WRITTEN_FORMAL)) {
-    wrapperFormal->addFlag(FLAG_WRAP_WRITTEN_FORMAL);
+  std::vector<CallExpr*> calls;
+
+  collectCallExprs(wrapper, calls);
+
+  for_vector(CallExpr, call, calls) {
+    if (call->resolvedFunction() == fn) {
+      for_actuals(actual, call) {
+        if (UnresolvedSymExpr* unsym = toUnresolvedSymExpr(actual)) {
+          std::vector<DefExpr*> defs;
+          BlockStmt*            callBlock = NULL;
+          BlockStmt*            loop      = NULL;
+          bool                  found = false;
+
+          callBlock = toBlockStmt(call->getStmtExpr()->parentExpr);
+          loop      = toBlockStmt(callBlock->parentExpr);
+
+          INT_ASSERT(loop && loop->isLoopStmt());
+
+          collectDefExprs(loop, defs);
+
+          for_vector(DefExpr, def, defs) {
+            if (strcmp(def->sym->name, unsym->unresolved) == 0) {
+              unsym->replace(new SymExpr(def->sym));
+
+              found = true;
+              break;
+            }
+          }
+
+          INT_ASSERT(found);
+        }
+      }
+    }
   }
-  if (formal->intent != INTENT_REF && formal->intent != INTENT_CONST_REF) {
-    wrapperFormal->intent = INTENT_BLANK;
-  }
-  return wrapperFormal;
 }
-
-////
-//// promotion wrapper code
-////
 
 //
 // In order for fast followers to trigger, the invoking loop requires a static
@@ -989,8 +1295,9 @@ static ArgSymbol* copyFormalForWrapper(ArgSymbol* formal) {
 //
 // i.e. we build up something like:
 //
-//    // _iteratorRecord has a field for each formal in the promoted function. e.g.
-//    // `A + 2.0 * C` results in a record with fields for each array and the real
+//    _iteratorRecord has a field for each formal in the promoted function.
+//    `A + 2.0 * C` results in a record with fields for each array and the real
+//
 //    proc chpl__dynamicFastFollowCheck(x: _iteratorRecord, lead) {
 //      // tuple that only has elements for fields that require promotion
 //      var promotion_tup: recordToPromotionTuple(x);
@@ -1010,15 +1317,16 @@ static ArgSymbol* copyFormalForWrapper(ArgSymbol* formal) {
 // in during iterator lowering, we replace the primitive with the actual field.
 //
 static void
-buildPromotionFastFollowerCheck(bool isStatic,
-                                bool addLead,
-                                CallInfo* info,
-                                FnSymbol* wrapper,
+buildPromotionFastFollowerCheck(bool                  isStatic,
+                                bool                  addLead,
+                                CallInfo*             info,
+                                FnSymbol*             wrapper,
                                 std::set<ArgSymbol*>& requiresPromotion) {
   const char* fnName = isStatic ? "chpl__staticFastFollowCheck" : "chpl__dynamicFastFollowCheck";
   const char* forwardFnName = astr(fnName, "Zip") ;
 
   FnSymbol* fastFollowCheckFn = new FnSymbol(fnName);
+
   if (isStatic) {
     fastFollowCheckFn->retTag = RET_PARAM;
   } else {
@@ -1026,298 +1334,161 @@ buildPromotionFastFollowerCheck(bool isStatic,
   }
 
   ArgSymbol* x = new ArgSymbol(INTENT_BLANK, "x", dtIteratorRecord);
+
   fastFollowCheckFn->insertFormalAtTail(x);
 
   ArgSymbol* lead = new ArgSymbol(INTENT_BLANK, "lead", dtAny);
+
   if (addLead) {
     fastFollowCheckFn->insertFormalAtTail(lead);
   }
 
 
   CallExpr* buildTuple = new CallExpr("_build_tuple_always_allow_ref");
+
   for_formals(formal, wrapper) {
     if (requiresPromotion.count(formal) > 0) {
       Symbol* field = new VarSymbol(formal->name, formal->type);
+
       fastFollowCheckFn->insertAtTail(new DefExpr(field));
+
       fastFollowCheckFn->insertAtTail(new CallExpr(PRIM_MOVE, field, new CallExpr(PRIM_ITERATOR_RECORD_FIELD_VALUE_BY_FORMAL, x, formal)));
+
       buildTuple->insertAtTail(new SymExpr(field));
     }
   }
+
   fastFollowCheckFn->where = new BlockStmt(new CallExpr("==", new CallExpr(PRIM_TYPEOF, x), new CallExpr(PRIM_TYPEOF, info->call->copy())));
 
   Symbol* p_tup = newTemp("p_tup");
+
   fastFollowCheckFn->insertAtTail(new DefExpr(p_tup));
   fastFollowCheckFn->insertAtTail(new CallExpr(PRIM_MOVE, p_tup, buildTuple));
 
   Symbol* returnTmp = newTemp("p_ret");
+
   returnTmp->addFlag(FLAG_EXPR_TEMP);
   returnTmp->addFlag(FLAG_MAYBE_PARAM);
+
   fastFollowCheckFn->insertAtTail(new DefExpr(returnTmp));
+
   if (addLead) {
     fastFollowCheckFn->insertAtTail(new CallExpr(PRIM_MOVE, returnTmp, new CallExpr(forwardFnName, p_tup, lead)));
   } else {
     fastFollowCheckFn->insertAtTail(new CallExpr(PRIM_MOVE, returnTmp, new CallExpr(forwardFnName, p_tup)));
   }
+
   fastFollowCheckFn->insertAtTail(new CallExpr(PRIM_RETURN, returnTmp));
 
   theProgram->block->insertAtTail(new DefExpr(fastFollowCheckFn));
+
   normalize(fastFollowCheckFn);
+
   fastFollowCheckFn->addFlag(FLAG_GENERIC);
+
   fastFollowCheckFn->instantiationPoint = getVisibilityBlock(info->call);
 }
 
+/************************************* | **************************************
+*                                                                             *
+*                                                                             *
+*                                                                             *
+************************************** | *************************************/
 
-static void fixUnresolvedSymExprsForPromotionWrapper(FnSymbol* wrapper, FnSymbol* fn) {
-  // Fix the UnresolvedSymExprs we inserted to the actualCall. For each
-  // call to `fn`, pick out any UnresolvedSymExprs and look in the loop
-  // body for a corresponding DefExpr.
+static FnSymbol* buildEmptyWrapper(FnSymbol* fn, CallInfo* info) {
+  FnSymbol* wrapper = new FnSymbol(fn->name);
 
-  std::vector<CallExpr*> calls;
-  collectCallExprs(wrapper, calls);
-  for_vector(CallExpr, call, calls) {
-    if (call->resolvedFunction() == fn) {
-      for_actuals(actual, call) {
-        if (UnresolvedSymExpr* unsym = toUnresolvedSymExpr(actual)) {
-          // Get the StmtExpr in case 'call' returns something
-          BlockStmt* callBlock = toBlockStmt(call->getStmtExpr()->parentExpr);
-          INT_ASSERT(callBlock);
-          BlockStmt* loop = toBlockStmt(callBlock->parentExpr);
-          INT_ASSERT(loop && loop->isLoopStmt());
-          std::vector<DefExpr*> defs;
-          collectDefExprs(loop, defs);
-          bool found = false;
-          for_vector(DefExpr, def, defs) {
-            if (strcmp(def->sym->name, unsym->unresolved) == 0) {
-              unsym->replace(new SymExpr(def->sym));
-              found = true;
-              break;
-            }
-          }
-          INT_ASSERT(found);
-        }
-      }
-    }
-  }
-}
+  wrapper->addFlag(FLAG_WRAPPER);
 
-static FnSymbol*
-buildPromotionWrapper(FnSymbol* fn,
-                      SymbolMap* promotion_subs,
-                      CallInfo* info,
-                      bool buildFastFollowerChecks) {
-  SET_LINENO(info->call);
-  FnSymbol* wrapper = buildEmptyWrapper(fn, info);
-  wrapper->addFlag(FLAG_PROMOTION_WRAPPER);
-  // Special case: When promoting a default constructor, the promotion wrapper
-  // itself is no longer a default constructor.
-  wrapper->removeFlag(FLAG_DEFAULT_CONSTRUCTOR);
-  wrapper->cname = astr("_promotion_wrap_", fn->cname);
-  CallExpr* indicesCall = new CallExpr("_build_tuple"); // destructured in build
-  CallExpr* iteratorCall = new CallExpr("_build_tuple");
-  CallExpr* actualCall = new CallExpr(fn);
-  bool zippered = true;
-  int i = 1;
-  std::set<ArgSymbol*> requiresPromotion;
-  for_formals(formal, fn) {
-    SET_LINENO(formal);
-    ArgSymbol* new_formal = copyFormalForWrapper(formal);
-    if (Symbol* p = paramMap.get(formal))
-      paramMap.put(new_formal, p);
-    if (fn->_this == formal)
-      wrapper->_this = new_formal;
-    if (Symbol* sub = promotion_subs->get(formal)) {
-      requiresPromotion.insert(new_formal);
-      TypeSymbol* ts = toTypeSymbol(sub);
-      if (!ts)
-        INT_FATAL(fn, "error building promotion wrapper");
-      new_formal->type = ts->type;
-      wrapper->insertFormalAtTail(new_formal);
-      iteratorCall->insertAtTail(new_formal);
+  wrapper->addFlag(FLAG_INVISIBLE_FN);
 
-      // Rely on the 'destructureIndices' function in build.cpp to create a
-      // VarSymbol and DefExpr for these indices. This solves a problem where
-      // these 'p_i_' variables were declared outside of the loop body's scope.
-      const char* name = astr("p_i_", istr(i));
-      indicesCall->insertAtTail(new UnresolvedSymExpr(name));
-      actualCall->insertAtTail(new UnresolvedSymExpr(name));
-    } else {
-      wrapper->insertFormalAtTail(new_formal);
-      actualCall->insertAtTail(new_formal);
-    }
-    i++;
+  wrapper->addFlag(FLAG_INLINE);
+
+  if (fn->hasFlag(FLAG_INIT_COPY_FN)) {
+    wrapper->addFlag(FLAG_INIT_COPY_FN);
   }
 
-  // Convert 1-tuples to their contents for the second half of this function
-  Expr* indices = indicesCall;
-  if (indicesCall->numActuals() == 1)
-    indices = indicesCall->get(1)->remove();
-
-  Expr* iterator = iteratorCall;
-  if (iteratorCall->numActuals() == 1) {
-    iterator = iteratorCall->get(1)->remove();
-    zippered = false;
+  if (fn->hasFlag(FLAG_AUTO_COPY_FN)) {
+    wrapper->addFlag(FLAG_AUTO_COPY_FN);
   }
 
-  if ((!fn->hasFlag(FLAG_EXTERN) && fn->getReturnSymbol() == gVoid) ||
-      (fn->hasFlag(FLAG_EXTERN) && fn->retType == dtVoid)) {
-      wrapper->insertAtTail(new BlockStmt(buildForallLoopStmt(indices, iterator, /*byref_vars=*/ NULL, new BlockStmt(actualCall), zippered)));
-  } else {
-    wrapper->addFlag(FLAG_ITERATOR_FN);
-    wrapper->removeFlag(FLAG_INLINE);
-
-
-    // Build up the leader iterator
-    SymbolMap leaderMap;
-    FnSymbol* lifn = wrapper->copy(&leaderMap);
-    INT_ASSERT(! lifn->hasFlag(FLAG_RESOLVED));
-    iteratorLeaderMap.put(wrapper,lifn);
-    lifn->body = new BlockStmt(); // indices are not used in leader
-    form_Map(SymbolMapElem, e, leaderMap) {
-      if (Symbol* s = paramMap.get(e->key))
-        paramMap.put(e->value, s);
-    }
-    ArgSymbol* lifnTag = new ArgSymbol(INTENT_PARAM, "tag", gLeaderTag->type);
-    lifn->addFlag(FLAG_INLINE_ITERATOR); // Leader iterators are always inlined.
-    lifn->insertFormalAtTail(lifnTag);
-    lifn->where = new BlockStmt(new CallExpr("==", lifnTag, gLeaderTag));
-    VarSymbol* leaderIndex = newTemp("p_leaderIndex");
-    VarSymbol* leaderIterator = newTemp("p_leaderIterator");
-    leaderIterator->addFlag(FLAG_EXPR_TEMP);
-    lifn->insertAtTail(new DefExpr(leaderIterator));
-
-    if( !zippered ) {
-      lifn->insertAtTail(new CallExpr(PRIM_MOVE, leaderIterator, new CallExpr("_toLeader", iterator->copy(&leaderMap))));
-    } else {
-      lifn->insertAtTail(new CallExpr(PRIM_MOVE, leaderIterator, new CallExpr("_toLeaderZip", iterator->copy(&leaderMap))));
-    }
-
-    BlockStmt* body = new BlockStmt(new CallExpr(PRIM_YIELD, leaderIndex));
-    BlockStmt* loop = ForLoop::buildForLoop(new SymExpr(leaderIndex), new SymExpr(leaderIterator), body, false, zippered);
-    lifn->insertAtTail(loop);
-    theProgram->block->insertAtTail(new DefExpr(lifn));
-    toBlockStmt(body->parentExpr)->insertAtHead(new DefExpr(leaderIndex));
-    normalize(lifn);
-    lifn->addFlag(FLAG_GENERIC);
-    lifn->instantiationPoint = getVisibilityBlock(info->call);
-
-
-    // Build up the follower iterator
-    SymbolMap followerMap;
-    FnSymbol* fifn = wrapper->copy(&followerMap);
-    INT_ASSERT(! fifn->hasFlag(FLAG_RESOLVED));
-    iteratorFollowerMap.put(wrapper,fifn);
-    form_Map(SymbolMapElem, e, followerMap) {
-      if (Symbol* s = paramMap.get(e->key))
-        paramMap.put(e->value, s);
-    }
-    ArgSymbol* fifnTag = new ArgSymbol(INTENT_PARAM, "tag", gFollowerTag->type);
-    fifn->insertFormalAtTail(fifnTag);
-    ArgSymbol* fifnFollower = new ArgSymbol(INTENT_BLANK, iterFollowthisArgname, dtAny);
-    fifn->insertFormalAtTail(fifnFollower);
-    ArgSymbol* fastFollower = new ArgSymbol(INTENT_PARAM, "fast", dtBool, NULL, new SymExpr(gFalse));
-    fifn->insertFormalAtTail(fastFollower);
-    fifn->where = new BlockStmt(new CallExpr("==", fifnTag, gFollowerTag));
-    VarSymbol* followerIterator = newTemp("p_followerIterator");
-    followerIterator->addFlag(FLAG_EXPR_TEMP);
-    fifn->insertAtTail(new DefExpr(followerIterator));
-
-    if( !zippered ) {
-      fifn->insertAtTail(new CondStmt(new SymExpr(fastFollower),
-                         new CallExpr(PRIM_MOVE, followerIterator, new CallExpr("_toFastFollower", iterator->copy(&followerMap), fifnFollower)),
-                         new CallExpr(PRIM_MOVE, followerIterator, new CallExpr("_toFollower", iterator->copy(&followerMap), fifnFollower))));
-    } else {
-      fifn->insertAtTail(new CondStmt(new SymExpr(fastFollower),
-                         new CallExpr(PRIM_MOVE, followerIterator, new CallExpr("_toFastFollowerZip", iterator->copy(&followerMap), fifnFollower)),
-                         new CallExpr(PRIM_MOVE, followerIterator, new CallExpr("_toFollowerZip", iterator->copy(&followerMap), fifnFollower))));
-    }
-
-    BlockStmt* followerBlock = new BlockStmt();
-    Symbol* yieldTmp = newTemp("p_yield");
-    yieldTmp->addFlag(FLAG_EXPR_TEMP);
-    followerBlock->insertAtTail(new DefExpr(yieldTmp));
-    followerBlock->insertAtTail(new CallExpr(PRIM_MOVE, yieldTmp, actualCall->copy(&followerMap)));
-    followerBlock->insertAtTail(new CallExpr(PRIM_YIELD, yieldTmp));
-    fifn->insertAtTail(ForLoop::buildForLoop(indices->copy(&followerMap), new SymExpr(followerIterator), followerBlock, false, zippered));
-    theProgram->block->insertAtTail(new DefExpr(fifn));
-    normalize(fifn);
-    fifn->addFlag(FLAG_GENERIC);
-    fifn->instantiationPoint = getVisibilityBlock(info->call);
-    fixUnresolvedSymExprsForPromotionWrapper(fifn, fn);
-
-    if (!fNoFastFollowers && buildFastFollowerChecks) {
-      // Build up the static (param) fast follower check functions
-      buildPromotionFastFollowerCheck(/*isStatic=*/true,  /*addLead=*/false, info, wrapper, requiresPromotion);
-      buildPromotionFastFollowerCheck(/*isStatic=*/true,  /*addLead=*/true,  info, wrapper, requiresPromotion);
-
-      // Build up the dynamic fast follower check functions
-      buildPromotionFastFollowerCheck(/*isStatic=*/false, /*addLead=*/false, info, wrapper, requiresPromotion);
-      buildPromotionFastFollowerCheck(/*isStatic=*/false, /*addLead=*/true,  info, wrapper, requiresPromotion);
-    }
-
-
-    // Finish building the serial iterator. We stopped mid-way so the common
-    // code could be copied for the leader/follower
-    BlockStmt* yieldBlock = new BlockStmt();
-    yieldTmp = newTemp("p_yield");
-    yieldTmp->addFlag(FLAG_EXPR_TEMP);
-    yieldBlock->insertAtTail(new DefExpr(yieldTmp));
-    yieldBlock->insertAtTail(new CallExpr(PRIM_MOVE, yieldTmp, actualCall));
-    yieldBlock->insertAtTail(new CallExpr(PRIM_YIELD, yieldTmp));
-    wrapper->insertAtTail(new BlockStmt(ForLoop::buildForLoop(indices, iterator, yieldBlock, false, zippered)));
+  if (fn->hasFlag(FLAG_AUTO_DESTROY_FN)) {
+    wrapper->addFlag(FLAG_AUTO_DESTROY_FN);
   }
-  fn->defPoint->insertBefore(new DefExpr(wrapper));
-  normalize(wrapper);
-  fixUnresolvedSymExprsForPromotionWrapper(wrapper, fn);
+
+  if (fn->hasFlag(FLAG_DONOR_FN)) {
+    wrapper->addFlag(FLAG_DONOR_FN);
+  }
+
+  if (fn->hasFlag(FLAG_NO_PARENS)) {
+    wrapper->addFlag(FLAG_NO_PARENS);
+  }
+
+  if (fn->hasFlag(FLAG_CONSTRUCTOR)) {
+    wrapper->addFlag(FLAG_CONSTRUCTOR);
+  }
+
+  if (fn->hasFlag(FLAG_FIELD_ACCESSOR)) {
+    wrapper->addFlag(FLAG_FIELD_ACCESSOR);
+  }
+
+  if (fn->hasFlag(FLAG_REF_TO_CONST)) {
+    wrapper->addFlag(FLAG_REF_TO_CONST);
+  }
+
+  if (!fn->isIterator()) { // getValue is var, not iterator
+    wrapper->retTag = fn->retTag;
+  }
+
+  if (fn->hasFlag(FLAG_METHOD)) {
+    wrapper->addFlag(FLAG_METHOD);
+  }
+
+  if (fn->hasFlag(FLAG_METHOD_PRIMARY)) {
+    wrapper->addFlag(FLAG_METHOD_PRIMARY);
+  }
+
+  if (fn->hasFlag(FLAG_ASSIGNOP)) {
+    wrapper->addFlag(FLAG_ASSIGNOP);
+  }
+
+  wrapper->instantiationPoint = getVisibilityBlock(info->call);
+
+  if (fn->hasFlag(FLAG_DEFAULT_CONSTRUCTOR)) {
+    wrapper->addFlag(FLAG_DEFAULT_CONSTRUCTOR);
+  }
+
+  if (fn->hasFlag(FLAG_COMPILER_GENERATED)) {
+    wrapper->addFlag(FLAG_WAS_COMPILER_GENERATED);
+  }
+
+  wrapper->addFlag(FLAG_COMPILER_GENERATED);
 
   return wrapper;
 }
 
+/************************************* | **************************************
+*                                                                             *
+* copy a formal and make the copy have blank intent. If the formal to copy    *
+* has out intent or inout intent, flag the copy to make sure it is a          *
+* reference.                                                                  *
+*                                                                             *
+* If the formal is ref intent, leave it as ref on the wrapper formal.         *
+*                                                                             *
+************************************** | *************************************/
 
-static FnSymbol* promotionWrap(FnSymbol* fn,
-                               CallInfo* info,
-                               bool      buildFastFollowerChecks) {
-  Vec<Symbol*>* actuals = &info->actuals;
+static ArgSymbol* copyFormalForWrapper(ArgSymbol* formal) {
+  ArgSymbol* wrapperFormal = formal->copy();
 
-  if (fn->name == astrSequals)
-    return fn;
-  // Don't try to promotion wrap _ref type constructor
-  if (fn->hasFlag(FLAG_TYPE_CONSTRUCTOR))
-    return fn;
-  bool promotion_wrapper_required = false;
-  SymbolMap promoted_subs;
-  int j = -1;
-  for_formals(formal, fn) {
-    j++;
-    Type* actualType = actuals->v[j]->type;
-    Symbol* actualSym = actuals->v[j];
-
-    if (isRecordWrappedType(actualType)) {
-      makeRefType(actualType);
-      actualType = actualType->refType;
-      INT_ASSERT(actualType);
-    }
-
-    bool promotes = false;
-    if (canDispatch(actualType, actualSym, formal->type, fn, &promotes)){
-      if (promotes) {
-        promotion_wrapper_required = true;
-        promoted_subs.put(formal, actualType->symbol);
-      }
-    }
+  if (formal->intent == INTENT_OUT ||
+      formal->intent == INTENT_INOUT ||
+      formal->hasFlag(FLAG_WRAP_WRITTEN_FORMAL)) {
+    wrapperFormal->addFlag(FLAG_WRAP_WRITTEN_FORMAL);
   }
-  if (promotion_wrapper_required) {
-    if (fReportPromotion)
-      USR_WARN(info->call, "promotion on %s", toString(info));
 
-    promoted_subs.put(fn, (Symbol*)info->call->square); // add value of square to cache
-
-    FnSymbol* wrapper = checkCache(promotionsCache, fn, &promoted_subs);
-    if (wrapper == NULL) {
-      wrapper = buildPromotionWrapper(fn, &promoted_subs, info, buildFastFollowerChecks);
-      addCache(promotionsCache, fn, wrapper, &promoted_subs);
-    }
-    resolveFormals(wrapper);
-    return wrapper;
+  if (formal->intent != INTENT_REF && formal->intent != INTENT_CONST_REF) {
+    wrapperFormal->intent = INTENT_BLANK;
   }
-  return fn;
+
+  return wrapperFormal;
 }


### PR DESCRIPTION
This simple PR groups the helper functions for promotionWrap() and places them in a natural
order. No change in behavior.
    
Compiled/tested in the standard ways.
