### PR TITLE
Further conversions of constructors to initializers, after bug fixes

### DIFF
--- a/test/classes/figueroa/RecordConstructor1.chpl
+++ b/test/classes/figueroa/RecordConstructor1.chpl
@@ -1,6 +1,6 @@
 record R {
   var c: int;
-  proc R () {c = 2;}
+  proc init () {c = 2;}
 }
 
 var a: R;

--- a/test/functions/vass/ref-intent-bug-2big.chpl
+++ b/test/functions/vass/ref-intent-bug-2big.chpl
@@ -118,15 +118,15 @@ proc GlobalData.init(nameArg: string) {
     proc storecache(ref cache, dx, dy, slicex, slicey) {
       const ind = (ix+dx, iy+dy);
       if !gridDist.member(ind) {
-	msg1("  ", ind, "  no neighbor");
-	return;
+        msg1("  ", ind, "  no neighbor");
+        return;
       }
       const nbr = datas[ind]; // our neighbor
       on nbr {
-	msg1("  ", ind, "  slice at [", slicex, ",", slicey, "]");
+        msg1("  ", ind, "  slice at [", slicex, ",", slicey, "]");
         pragma "no auto destroy"
-	ref slice = nbr.ldata[slicex, slicey];
-	cache = slice._value;
+          ref slice = nbr.ldata[slicex, slicey];
+        cache = slice._value;
       }
     }  // storecache()
   }  // forall

--- a/test/functions/vass/ref-intent-bug-2big.chpl
+++ b/test/functions/vass/ref-intent-bug-2big.chpl
@@ -66,7 +66,7 @@ class GlobalInfo {
 }
 
 // constructor for GlobalInfo
-proc GlobalInfo.GlobalInfo() {
+proc GlobalInfo.init() {
   coforall ((ix,iy), inf) in zip(gridDist, infos) do on inf {
     inf = new LocalInfo(mygx=ix, mygy=iy);
   }
@@ -96,8 +96,9 @@ class GlobalData {
 }
 
 // constructor for GlobalData
-proc GlobalData.GlobalData(nameArg: string) {
+proc GlobalData.init(nameArg: string) {
   name=nameArg;
+  super.init();
   coforall (inf, dat, loc) in zip(WI.infos, datas, gridLocales) do on loc {
     dat = new LocalData(inf);
     // sanity checks

--- a/test/parallel/forall/vass/alist-error.chpl
+++ b/test/parallel/forall/vass/alist-error.chpl
@@ -3,11 +3,13 @@
 use Random;
 class A {
   var X: domain(int);
-  proc A(N: int) {
+
+  proc init(N: int) {
     var R = new RandomStream(real, 13);
     this.X = [x in 1..N] x;
     var Y = [x in this.X] R.getNext();
     delete R;
+    super.init();
   }
 }
 var a = new A(100);

--- a/test/studies/madness/aniruddha/madchap/FTree.chpl
+++ b/test/studies/madness/aniruddha/madchap/FTree.chpl
@@ -178,12 +178,13 @@ class FTree {
     const coeffDom: domain(1);
     const tree    : [LocaleSpace] LocTree;
 
-    proc FTree(order: int) {
+    proc init(order: int) {
         if order == 0 then
             halt("FTree must be initialized with an order > 0");
 
         this.order = order;
         this.coeffDom = {0..order-1};
+        super.init();
 
         coforall loc in Locales do
             on loc do tree[loc.id] = new LocTree(coeffDom);

--- a/test/studies/matrixMult/stonea/distributed/simpleBlockDist.chpl
+++ b/test/studies/matrixMult/stonea/distributed/simpleBlockDist.chpl
@@ -10,9 +10,9 @@ const localesAcross = sqrt(numLocales) : int;
 const blkSize = n / localesAcross : int;
 
 record WrappedArray {
-    proc WrappedArray() { }
+    proc init() { }
 
-    proc WrappedArray(row, col, numRows, numCols) {
+    proc init(row, col, numRows, numCols) {
         dom = {row..row+numRows-1, col..col+numCols-1};
     }
 


### PR DESCRIPTION
Updates five tests to use initializers instead of constructors.  Notes and
details below.  Note that 4 of these updates could not be performed
prior to a couple of recent bug fixes.

test/classes/figueroa/RecordConstructor1.chpl:
This test would benefit from Phase 1 as the default.

test/functions/vass/ref-intent-bug-2big.chpl:
Used to fail due to the presence of coforalls in the body.  This test
would benefit from being able to assign const fields in Phase 2.

test/parallel/forall/vass/alist-error.chpl:
Used to fail due to issues with initializing fields via iterator expressions.
Would benefit from Phase 1 as the default.

test/studies/madness/aniruddha/madchap/FTree.chpl:
Used to fail due to the presence of coforalls in the body.  This initializer
would benefit from being able to assign const fields in Phase 2.  One
other helper module for the madness tests remains to update, due to
an issue with copyPropagation that I am hoping will be resolved by
removing the pass ;)

test/studies/matrixMult/stonea/distributed/simpleBlockDist.chpl:
The non-trivial initializer would benefit from Phase 1 as the default.
Used to fail due to an issue with non-generic records and initializing
local variables with a type specified by type arguments.

Passed full standard paratest.