### PR TITLE
Simplify resolveUninsertedCall()

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -158,8 +158,7 @@ std::map<CallExpr*, CallExpr*> eflopiMap; // for-loops over par iterators
 //#
 static bool hasRefField(Type *type);
 static bool typeHasRefField(Type *type);
-static FnSymbol* resolveUninsertedCall(Type* type, CallExpr* call,
-                                       bool checkonly=false);
+static FnSymbol* resolveUninsertedCall(Type* type, CallExpr* call);
 static bool hasUserAssign(Type* type);
 static void resolveOther();
 static FnSymbol*
@@ -338,7 +337,7 @@ resolveUninsertedCall(BlockStmt* insideBlock,
 
 // Resolve a call to do with a particular type.
 static FnSymbol*
-resolveUninsertedCall(Type* type, CallExpr* call, bool checkonly) {
+resolveUninsertedCall(Type* type, CallExpr* call) {
 
   BlockStmt* insideBlock = NULL;
   Expr* beforeExpr = NULL;
@@ -354,7 +353,7 @@ resolveUninsertedCall(Type* type, CallExpr* call, bool checkonly) {
     insideBlock = chpl_gen_main->body;
   }
 
-  return resolveUninsertedCall(insideBlock, beforeExpr, call, checkonly);
+  return resolveUninsertedCall(insideBlock, beforeExpr, call, false);
 }
 
 //

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -3368,22 +3368,21 @@ static FnSymbol* resolveUninsertedCall(BlockStmt* insideBlock,
                                        CallExpr*  call);
 
 static FnSymbol* resolveUninsertedCall(Type* type, CallExpr* call) {
-  AggregateType* at          = toAggregateType(type);
-  BlockStmt*     insideBlock = NULL;
-  Expr*          beforeExpr  = NULL;
+  AggregateType* at     = toAggregateType(type);
+  FnSymbol*      retval = NULL;
 
   if (at && at->defaultInitializer) {
-    if (at->defaultInitializer->instantiationPoint) {
-      insideBlock = at->defaultInitializer->instantiationPoint;
+    if (BlockStmt* point = at->defaultInitializer->instantiationPoint) {
+      retval = resolveUninsertedCall(point, NULL, call);
     } else {
-      beforeExpr = at->symbol->defPoint;
+      retval = resolveUninsertedCall(NULL, at->symbol->defPoint, call);
     }
 
   } else {
-    insideBlock = chpl_gen_main->body;
+    retval = resolveUninsertedCall(chpl_gen_main->body, NULL, call);
   }
 
-  return resolveUninsertedCall(insideBlock, beforeExpr, call);
+  return retval;
 }
 
 static FnSymbol* resolveUninsertedCall(BlockStmt* insideBlock,
@@ -3398,7 +3397,7 @@ static FnSymbol* resolveUninsertedCall(BlockStmt* insideBlock,
     beforeExpr->insertBefore(block);
 
   } else {
-    INT_ASSERT(insideBlock != NULL || beforeExpr != NULL);
+    INT_ASSERT(false);
   }
 
   block->insertAtHead(call);

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -3371,15 +3371,14 @@ static FnSymbol* resolveUninsertedCall(Type* type, CallExpr* call) {
   AggregateType* at     = toAggregateType(type);
   FnSymbol*      retval = NULL;
 
-  if (at && at->defaultInitializer) {
-    if (BlockStmt* point = at->defaultInitializer->instantiationPoint) {
-      retval = resolveUninsertedCall(point, NULL, call);
-    } else {
-      retval = resolveUninsertedCall(NULL, at->symbol->defPoint, call);
-    }
+  if (at == NULL || at->defaultInitializer == NULL) {
+    retval = resolveUninsertedCall(chpl_gen_main->body, NULL, call);
+
+  } else if (BlockStmt* point = at->defaultInitializer->instantiationPoint) {
+    retval = resolveUninsertedCall(point, NULL, call);
 
   } else {
-    retval = resolveUninsertedCall(chpl_gen_main->body, NULL, call);
+    retval = resolveUninsertedCall(NULL, at->symbol->defPoint, call);
   }
 
   return retval;
@@ -3388,7 +3387,7 @@ static FnSymbol* resolveUninsertedCall(Type* type, CallExpr* call) {
 static FnSymbol* resolveUninsertedCall(BlockStmt* insideBlock,
                                        Expr*      beforeExpr,
                                        CallExpr*  call) {
-  BlockStmt* block = new BlockStmt();
+  BlockStmt* block = new BlockStmt(call);
 
   if (insideBlock) {
     insideBlock->insertAtHead(block);
@@ -3399,8 +3398,6 @@ static FnSymbol* resolveUninsertedCall(BlockStmt* insideBlock,
   } else {
     INT_ASSERT(false);
   }
-
-  block->insertAtHead(call);
 
   resolveCall(call);
 


### PR DESCRIPTION
I noticed that the implementations for resolveUninsertedCall() accept a "check only" formal but
that, in practice, it is always false.  Eliminate this formal and leverage this to simplify the code.

Compiled with/without CHPL_DEVELOPER on clang/dawin and gcc/linux64.
Ran start_test on a small portion of release/ for all 4 configs.
Passed a single-locale paratest
