### PR TITLE
Update InitNormalize to recognize PRIM_BLOCK_COFORALL_ON

### DIFF
--- a/compiler/passes/InitNormalize.cpp
+++ b/compiler/passes/InitNormalize.cpp
@@ -47,16 +47,17 @@ InitNormalize::InitNormalize(BlockStmt* block, const InitNormalize& curr) {
   mPhase      = curr.mPhase;
 
   if (CallExpr* blockInfo = block->blockInfoGet()) {
-    if (blockInfo->isPrimitive(PRIM_BLOCK_BEGIN)   == true) {
+    if        (blockInfo->isPrimitive(PRIM_BLOCK_BEGIN)       == true) {
       mBlockType = cBlockBegin;
 
-    } else if (blockInfo->isPrimitive(PRIM_BLOCK_COBEGIN) == true) {
+    } else if (blockInfo->isPrimitive(PRIM_BLOCK_COBEGIN)     == true) {
       mBlockType = cBlockCobegin;
 
-    } else if (blockInfo->isPrimitive(PRIM_BLOCK_COFORALL) == true) {
+    } else if (blockInfo->isPrimitive(PRIM_BLOCK_COFORALL)    == true ||
+               blockInfo->isPrimitive(PRIM_BLOCK_COFORALL_ON) == true) {
       mBlockType = cBlockCoforall;
 
-    } else{
+    } else {
       INT_ASSERT(false);
     }
 


### PR DESCRIPTION
A recent update for initializers added support for the use of coforall statements within initializers
and then updated some tests to exploit this feature.

This PR extends that work in a trivial way to support the injection of coforall-on blocks when
--no-local is thrown.


Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.
Ran a small portion of start_test on release/

Passed a full paratest with --no-local.



