### PR TITLE
Fix record type alias bug with initializers

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -4985,7 +4985,13 @@ static void resolveNew(CallExpr* call) {
             if (isBlockStmt(call->parentExpr) == true) {
               call->insertBefore(def);
             } else {
-              call->parentExpr->insertBefore(def);
+              Expr* parent = call->parentExpr;
+              parent->insertBefore(def);
+
+              if (isClass(at) == false) {
+                call->replace(new SymExpr(newTmp));
+                parent->insertBefore(call);
+              }
             }
 
             if (isClass(at) == true) {

--- a/test/types/records/hilde/callConstructorThruTypeFn.chpl
+++ b/test/types/records/hilde/callConstructorThruTypeFn.chpl
@@ -8,9 +8,10 @@ record R {
   proc init(i : int) { _i = i; }
 }
 
-record S : R {
+record S {
+  var _i : int;
   var _r : real;
-  proc init(i : int) { _r = 3.1416; super.init(i); }
+  proc init(i : int) { _i = i; _r = 3.1416; super.init(); }
 }
 
 proc chooseARecordType(param derived = false) type {

--- a/test/types/records/hilde/callConstructorThruTypeFn.chpl
+++ b/test/types/records/hilde/callConstructorThruTypeFn.chpl
@@ -5,12 +5,12 @@
 
 record R {
   var _i : int;
-  proc R(i : int) { _i = i; }
+  proc init(i : int) { _i = i; }
 }
 
 record S : R {
   var _r : real;
-  proc S(i : int) { _i = i; _r = 3.1416; }
+  proc init(i : int) { _r = 3.1416; super.init(i); }
 }
 
 proc chooseARecordType(param derived = false) type {

--- a/test/types/records/hilde/callConstructorThruTypeVar.chpl
+++ b/test/types/records/hilde/callConstructorThruTypeVar.chpl
@@ -5,7 +5,7 @@
 
 record R {
   var _i : int;
-  proc R(i : int) { _i = i; }
+  proc init(i : int) { _i = i; }
 }
 
 type T = R;


### PR DESCRIPTION
Prior to this change, the conversion of constructors to initializers for
code that utilized type aliases on records was failing with the output:

`error: illegal use of function that does not return a value: 'init'`

This was because the AST for calls of the form `var a = new alias(args);`
was being maladjusted - we would end up with:

`call(PRIM_MOVE, a, call('init', tmp: Foo, args))`

instead of:

```
call('init', tmp: Foo, args);
call(PRIM_MOVE, a, tmp);
```

This changes modifies the handling of PRIM_NEW during resolution
to insert the correct AST.

It also commits the conversion of these two tests to use initializers,
which was what brought our attention to this issue.  All initializers
involved would benefit from Phase 1 as the default.  I also modified
one of them further to remove record inheritance, which was
still present.

Passed test/classes/initializers with futures.  Passed a full std/
paratest run.