### PR TITLE
Fix Several ArrayViewReindex Leaks

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -2382,7 +2382,7 @@ module ChapelArray {
       pragma "no auto destroy"
       const updom = {(...d.dims())};
 
-      const redist = new ArrayViewReindexDist(downdist = _getDistribution(thisDomClass.dist),
+      const redist = new ArrayViewReindexDist(downdist = thisDomClass.dist,
                                               updom = updom._value,
                                               downdomPid = dompid,
                                               downdomInst = dom);


### PR DESCRIPTION
1) For whatever reason, using _getDistribution in the constructor
resulted in a new instance of 'thisDomClass.dist'. Instead we can just
pass the class straight in.

2) Free 'updom' in dsiSetIndices if it is not nil. Before we were
writing over 'updom' and never freeing it.

3) Delete 'downdomInst' if we point it to a class that ArrayViewReindex
allocated. This state is tracked in the new 'ownsDownDomInst' field.

Testing:
- [x] full local
- [x] full gasnet
- [x] dist-replicated, dist-cyclic
- [x] sporadic valgrind testing