### PR TITLE
Bad new

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5025,6 +5025,19 @@ static void resolveNew(CallExpr* call) {
 
           resolveExpr(call);
         }
+
+      } else if (PrimitiveType* pt = toPrimitiveType(type)) {
+        const char* name = pt->symbol->name;
+
+        USR_FATAL(call, "invalid use of 'new' on primitive %s", name);
+
+      } else if (EnumType* et = toEnumType(type)) {
+        const char* name = et->symbol->name;
+
+        USR_FATAL(call, "invalid use of 'new' on enum %s", name);
+
+      } else {
+        USR_FATAL(call, "new must be applied to a record or class");
       }
     }
 

--- a/test/expressions/new-expr/new-on-domain.chpl
+++ b/test/expressions/new-expr/new-on-domain.chpl
@@ -1,0 +1,5 @@
+proc main() {
+  var x : int = new domain(1);
+
+  writeln(x);
+}

--- a/test/expressions/new-expr/new-on-domain.good
+++ b/test/expressions/new-expr/new-on-domain.good
@@ -1,0 +1,2 @@
+new-on-domain.chpl:1: In function 'main':
+new-on-domain.chpl:2: error: invalid use of 'new' on chpl__buildDomainRuntimeType

--- a/test/expressions/new-expr/new-on-enum.chpl
+++ b/test/expressions/new-expr/new-on-enum.chpl
@@ -1,0 +1,9 @@
+enum Color {
+  red, orange, yellow, green, blue, indigo, violet
+}
+
+proc main() {
+  var x : int = new Color;
+
+  writeln(x);
+}

--- a/test/expressions/new-expr/new-on-enum.good
+++ b/test/expressions/new-expr/new-on-enum.good
@@ -1,0 +1,2 @@
+new-on-enum.chpl:5: In function 'main':
+new-on-enum.chpl:6: error: invalid use of 'new' on enum Color

--- a/test/expressions/new-expr/new-on-prim.chpl
+++ b/test/expressions/new-expr/new-on-prim.chpl
@@ -1,0 +1,5 @@
+proc main() {
+  var x : int = new int;
+
+  writeln(x);
+}

--- a/test/expressions/new-expr/new-on-prim.good
+++ b/test/expressions/new-expr/new-on-prim.good
@@ -1,0 +1,2 @@
+new-on-prim.chpl:1: In function 'main':
+new-on-prim.chpl:2: error: invalid use of 'new' on primitive int(64)


### PR DESCRIPTION
I reviewed a small change to resolveNew() this morning and noted it was getting a little
wooly.

When I took a second look it seemed to me that some simple user-level errors e.g.
var x = new int;

were simply being ignored. I confirmed that this statement was largely ignored by
resolve() and ultimately generated an INT_FATAL much deeper in the pipeline.

In this PR I 

1. catch non-aggregate types and generate more pleasing error messages,

2. add a few tests to help lock in the error messages for inappropriate uses of new,

3. take the opportunity to break the monolithic implementation of resolveNew() 
in to a few helpers.  These changes do not affect behavior.


Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.
Ran start_test on a small portion of release/ for all 4 configs.
Passed a single-locale paratest with futures
