### PR TITLE
Remove on-statement from channel.lines()

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -3278,28 +3278,26 @@ inline proc channel.read(ref args ...?k,
  */
 iter channel.lines() {
 
-  on this.home {
-    this.lock();
+  this.lock();
 
-    // Save iostyle
-    const saved_style: iostyle = this._style();
+  // Save iostyle
+  const saved_style: iostyle = this._style();
 
-    // Update iostyle
-    var newline_style: iostyle = this._style();
-    newline_style.string_format = QIO_STRING_FORMAT_TOEND;
-    newline_style.string_end = 0x0a; // '\n'
-    this._set_style(newline_style);
+  // Update iostyle
+  var newline_style: iostyle = this._style();
+  newline_style.string_format = QIO_STRING_FORMAT_TOEND;
+  newline_style.string_end = 0x0a; // '\n'
+  this._set_style(newline_style);
 
-    // Iterate over lines
-    for line in this.itemReader(string, this.kind) {
-      yield line;
-    }
-
-    // Set the iostyle back to original state
-    this._set_style(saved_style);
-
-    this.unlock();
+  // Iterate over lines
+  for line in this.itemReader(string, this.kind) {
+    yield line;
   }
+
+  // Set the iostyle back to original state
+  this._set_style(saved_style);
+
+  this.unlock();
 }
 
 


### PR DESCRIPTION
Removed `on` statement from serial `channel.lines()` iterator.

This was causing an error for multilocale programs calling `channel.lines()` because a serial iterator cannot `yield` from within an `on` statement.