### PR TITLE
Add FLAG_LAST_RESORT, use it

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -685,6 +685,7 @@ void AggregateType::buildTypeConstructor() {
   fn->cname = astr("_type_construct_", symbol->cname);
 
   fn->addFlag(FLAG_COMPILER_GENERATED);
+  fn->addFlag(FLAG_LAST_RESORT);
   fn->retTag = RET_TYPE;
 
   if (symbol->hasFlag(FLAG_REF)   == true) {
@@ -900,6 +901,7 @@ void AggregateType::buildConstructor() {
   fn->addFlag(FLAG_DEFAULT_CONSTRUCTOR);
   fn->addFlag(FLAG_CONSTRUCTOR);
   fn->addFlag(FLAG_COMPILER_GENERATED);
+  fn->addFlag(FLAG_LAST_RESORT);
 
   if (symbol->hasFlag(FLAG_REF) == true) {
     fn->addFlag(FLAG_REF);

--- a/compiler/include/flags_list.h
+++ b/compiler/include/flags_list.h
@@ -69,14 +69,14 @@ symbolFlag( FLAG_COERCE_TEMP , npr, "coerce temp" , "a temporary that was stores
 symbolFlag( FLAG_CODEGENNED , npr, "codegenned" , "code has been generated for this type" )
 symbolFlag( FLAG_COFORALL_INDEX_VAR , npr, "coforall index var" , ncm )
 symbolFlag( FLAG_COMMAND_LINE_SETTING , ypr, "command line setting" , ncm )
-// The compiler-generated flag is already overloaded in three ways.  We may
-// want to split it if this becomes cumbersome:
-// 1. In resolution, functions marked as compiler-generated are considered only if
-// no functions without that flag (i.e. user-supplied) functions are found.
-// 2. In printing filename/lineno information in error messages (when developer
-// == false), the callstack is searched ignoring compiler-generated functions.
-// 3. Assignment operations flagged as 'compiler generated' shall contain only
-// field assignments and assignment primitives.
+// The compiler-generated flag has these meanings:
+// 1. In various parts of the compiler, when printing printing filename/lineno
+//    information in error messages, callstack locations marked
+//    compiler-generated may be ignored when developer == false.
+// 2. In relation to determination of POD types when "compiler generated"
+//    applies to assignment, copy, initialization routines
+// 3. When additional checking for user-written code can be relaxed
+//    for functions added by the compiler (e.g. with error handling)
 symbolFlag( FLAG_COMPILER_GENERATED , ypr, "compiler generated" , "marks functions that are compiler-generated or supplied by an internal module" )
 symbolFlag( FLAG_COMPILER_ADDED_WHERE , npr, "compiler added where" , "marks functions that have a where clause only because compiler added one" )
 
@@ -155,6 +155,10 @@ symbolFlag( FLAG_ITERATOR_CLASS , npr, "iterator class" , ncm )
 symbolFlag( FLAG_ITERATOR_FN , npr, "iterator fn" , ncm )
 symbolFlag( FLAG_ITERATOR_RECORD , npr, "iterator record" , ncm )
 symbolFlag( FLAG_ITERATOR_WITH_ON , npr, "iterator with on" , "iterator which contains an on block" )
+// In resolution, functions marked as last-resort are considered only if
+// no functions without that flag are found. This usually is used to create
+// a pattern enabling user-supplied replacement of default behavior.
+symbolFlag( FLAG_LAST_RESORT , ypr, "last resort" , "overload of last resort in resolution" )
 symbolFlag( FLAG_LOCALE_MODEL_ALLOC , ypr, "locale model alloc" , "locale model specific alloc" )
 symbolFlag( FLAG_LOCALE_MODEL_FREE , ypr, "locale model free" , "locale model specific free" )
 symbolFlag( FLAG_LOCALE_PRIVATE , ypr, "locale private" , ncm )

--- a/compiler/include/flags_list.h
+++ b/compiler/include/flags_list.h
@@ -70,7 +70,7 @@ symbolFlag( FLAG_CODEGENNED , npr, "codegenned" , "code has been generated for t
 symbolFlag( FLAG_COFORALL_INDEX_VAR , npr, "coforall index var" , ncm )
 symbolFlag( FLAG_COMMAND_LINE_SETTING , ypr, "command line setting" , ncm )
 // The compiler-generated flag has these meanings:
-// 1. In various parts of the compiler, when printing printing filename/lineno
+// 1. In various parts of the compiler, when printing filename/lineno
 //    information in error messages, callstack locations marked
 //    compiler-generated may be ignored when developer == false.
 // 2. In relation to determination of POD types when "compiler generated"

--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -646,6 +646,7 @@ static void build_record_equality_function(AggregateType* ct) {
 
   FnSymbol* fn = new FnSymbol("==");
   fn->addFlag(FLAG_COMPILER_GENERATED);
+  fn->addFlag(FLAG_LAST_RESORT);
   ArgSymbol* arg1 = new ArgSymbol(INTENT_BLANK, "_arg1", ct);
   arg1->addFlag(FLAG_MARKED_GENERIC);
   ArgSymbol* arg2 = new ArgSymbol(INTENT_BLANK, "_arg2", ct);
@@ -675,6 +676,7 @@ static void build_record_inequality_function(AggregateType* ct) {
 
   FnSymbol* fn = new FnSymbol("!=");
   fn->addFlag(FLAG_COMPILER_GENERATED);
+  fn->addFlag(FLAG_LAST_RESORT);
   ArgSymbol* arg1 = new ArgSymbol(INTENT_BLANK, "_arg1", ct);
   arg1->addFlag(FLAG_MARKED_GENERIC);
   ArgSymbol* arg2 = new ArgSymbol(INTENT_BLANK, "_arg2", ct);
@@ -705,6 +707,7 @@ static void build_enum_size_function(EnumType* et) {
   // Build a function that returns the length of the enum specified
   FnSymbol* fn = new FnSymbol("size");
   fn->addFlag(FLAG_COMPILER_GENERATED);
+  fn->addFlag(FLAG_LAST_RESORT);
   fn->addFlag(FLAG_NO_PARENS);
   fn->addFlag(FLAG_METHOD);
   fn->insertFormalAtTail(new ArgSymbol(INTENT_BLANK, "_mt", dtMethodToken));
@@ -741,6 +744,7 @@ static void build_enum_first_function(EnumType* et) {
   // specified, also known as the default.
   FnSymbol* fn = new FnSymbol("chpl_enum_first");
   fn->addFlag(FLAG_COMPILER_GENERATED);
+  fn->addFlag(FLAG_LAST_RESORT);
   // Making this compiler generated allows users to define what the
   // default is for a particular enum.  They can also redefine the
   // _defaultOf function for the enum to obtain this functionality (and
@@ -776,6 +780,7 @@ static void build_enum_enumerate_function(EnumType* et) {
   // Each enum type has its own chpl_enum_enumerate function.
   FnSymbol* fn = new FnSymbol("chpl_enum_enumerate");
   fn->addFlag(FLAG_COMPILER_GENERATED);
+  fn->addFlag(FLAG_LAST_RESORT);
   ArgSymbol* arg = new ArgSymbol(INTENT_BLANK, "t", dtAny);
   arg->addFlag(FLAG_TYPE_VARIABLE);
   fn->insertFormalAtTail(arg);
@@ -799,6 +804,7 @@ static void build_enum_cast_function(EnumType* et) {
   // integral value to enumerated type cast function
   FnSymbol* fn = new FnSymbol(astr_cast);
   fn->addFlag(FLAG_COMPILER_GENERATED);
+  fn->addFlag(FLAG_LAST_RESORT);
   ArgSymbol* arg1 = new ArgSymbol(INTENT_BLANK, "t", dtAny);
   arg1->addFlag(FLAG_TYPE_VARIABLE);
   ArgSymbol* arg2 = new ArgSymbol(INTENT_BLANK, "_arg2", dtIntegral);
@@ -845,6 +851,7 @@ static void build_enum_cast_function(EnumType* et) {
   // string to enumerated type cast function
   fn = new FnSymbol(astr_cast);
   fn->addFlag(FLAG_COMPILER_GENERATED);
+  fn->addFlag(FLAG_LAST_RESORT);
   arg1 = new ArgSymbol(INTENT_BLANK, "t", dtAny);
   arg1->addFlag(FLAG_TYPE_VARIABLE);
   arg2 = new ArgSymbol(INTENT_BLANK, "_arg2", dtString);
@@ -895,6 +902,7 @@ static void build_enum_assignment_function(EnumType* et) {
   FnSymbol* fn = new FnSymbol("=");
   fn->addFlag(FLAG_ASSIGNOP);
   fn->addFlag(FLAG_COMPILER_GENERATED);
+  fn->addFlag(FLAG_LAST_RESORT);
   fn->addFlag(FLAG_INLINE);
   ArgSymbol* arg1 = new ArgSymbol(INTENT_REF, "_arg1", et);
   ArgSymbol* arg2 = new ArgSymbol(INTENT_BLANK, "_arg2", et);
@@ -915,6 +923,7 @@ static void build_record_assignment_function(AggregateType* ct) {
   FnSymbol* fn = new FnSymbol("=");
   fn->addFlag(FLAG_ASSIGNOP);
   fn->addFlag(FLAG_COMPILER_GENERATED);
+  fn->addFlag(FLAG_LAST_RESORT);
 
   ArgSymbol* arg1 = new ArgSymbol(INTENT_REF, "_arg1", ct);
   arg1->addFlag(FLAG_MARKED_GENERIC); // TODO: Check if we really want this.
@@ -975,6 +984,7 @@ static void build_extern_init_function(Type* type)
   FnSymbol* fn = new FnSymbol("_defaultOf");
   fn->addFlag(FLAG_INLINE);
   fn->addFlag(FLAG_COMPILER_GENERATED);
+  fn->addFlag(FLAG_LAST_RESORT);
   ArgSymbol* arg = new ArgSymbol(INTENT_BLANK, "t", type);
   arg->addFlag(FLAG_TYPE_VARIABLE);
   fn->insertFormalAtTail(arg);
@@ -999,6 +1009,7 @@ static void build_extern_assignment_function(Type* type)
   fn->addFlag(FLAG_ASSIGNOP);
   type->symbol->addFlag(FLAG_POD);
   fn->addFlag(FLAG_COMPILER_GENERATED);
+  fn->addFlag(FLAG_LAST_RESORT);
   fn->addFlag(FLAG_INLINE);
 
   ArgSymbol* arg1 = new ArgSymbol(INTENT_REF, "_arg1", type);
@@ -1029,6 +1040,7 @@ static void build_record_cast_function(AggregateType* ct) {
 
   FnSymbol* fn = new FnSymbol(astr_cast);
   fn->addFlag(FLAG_COMPILER_GENERATED);
+  fn->addFlag(FLAG_LAST_RESORT);
   fn->addFlag(FLAG_INLINE);
   ArgSymbol* t = new ArgSymbol(INTENT_BLANK, "t", dtAny);
   t->addFlag(FLAG_TYPE_VARIABLE);
@@ -1055,6 +1067,7 @@ static void build_union_assignment_function(AggregateType* ct) {
   FnSymbol* fn = new FnSymbol("=");
   fn->addFlag(FLAG_ASSIGNOP);
   fn->addFlag(FLAG_COMPILER_GENERATED);
+  fn->addFlag(FLAG_LAST_RESORT);
   ArgSymbol* arg1 = new ArgSymbol(INTENT_REF, "_arg1", ct);
   ArgSymbol* arg2 = new ArgSymbol(INTENT_BLANK, "_arg2", ct);
   fn->insertFormalAtTail(arg1);
@@ -1126,6 +1139,7 @@ static void build_record_copy_function(AggregateType* ct) {
 
   fn->addFlag(FLAG_INIT_COPY_FN);
   fn->addFlag(FLAG_COMPILER_GENERATED);
+  fn->addFlag(FLAG_LAST_RESORT);
 
   arg->addFlag(FLAG_MARKED_GENERIC);
 
@@ -1231,6 +1245,7 @@ static void build_record_hash_function(AggregateType *ct) {
 
   FnSymbol *fn = new FnSymbol("chpl__defaultHash");
   fn->addFlag(FLAG_COMPILER_GENERATED);
+  fn->addFlag(FLAG_LAST_RESORT);
   ArgSymbol *arg = new ArgSymbol(INTENT_BLANK, "r", ct);
   arg->addFlag(FLAG_MARKED_GENERIC);
   fn->insertFormalAtTail(arg);
@@ -1284,6 +1299,7 @@ static void buildDefaultInitializer(AggregateType* ct) {
   // flag to this function, but if I do, then I will need to do something
   // different in wrappers.cpp.
   fn->addFlag(FLAG_COMPILER_GENERATED);
+  fn->addFlag(FLAG_LAST_RESORT);
 
   fn->insertFormalAtTail(new ArgSymbol(INTENT_BLANK, "_mt", dtMethodToken));
 
@@ -1513,6 +1529,7 @@ static void buildDefaultOfFunction(AggregateType* ct) {
     arg->addFlag(FLAG_TYPE_VARIABLE);
 
     fn->addFlag(FLAG_COMPILER_GENERATED);
+    fn->addFlag(FLAG_LAST_RESORT);
     fn->addFlag(FLAG_INLINE);
 
     fn->insertFormalAtTail(arg);
@@ -1711,6 +1728,7 @@ static void buildDefaultReadWriteFunctions(AggregateType* ct) {
   if ( makeReadThisAndWriteThis && ! hasWriteThis ) {
     FnSymbol* fn = new FnSymbol("writeThis");
     fn->addFlag(FLAG_COMPILER_GENERATED);
+    fn->addFlag(FLAG_LAST_RESORT);
     fn->addFlag(FLAG_INLINE);
     fn->cname = astr("_auto_", ct->symbol->name, "_write");
     fn->_this = new ArgSymbol(INTENT_BLANK, "this", ct);
@@ -1744,6 +1762,7 @@ static void buildDefaultReadWriteFunctions(AggregateType* ct) {
   if ( makeReadThisAndWriteThis && ! hasReadThis ) {
     FnSymbol* fn = new FnSymbol("readThis");
     fn->addFlag(FLAG_COMPILER_GENERATED);
+    fn->addFlag(FLAG_LAST_RESORT);
     fn->addFlag(FLAG_INLINE);
     fn->cname = astr("_auto_", ct->symbol->name, "_read");
     fn->_this = new ArgSymbol(INTENT_BLANK, "this", ct);
@@ -1780,6 +1799,7 @@ static void buildStringCastFunction(EnumType* et) {
 
   FnSymbol* fn = new FnSymbol(astr_cast);
   fn->addFlag(FLAG_COMPILER_GENERATED);
+  fn->addFlag(FLAG_LAST_RESORT);
   ArgSymbol* t = new ArgSymbol(INTENT_BLANK, "t", dtAny);
   t->addFlag(FLAG_TYPE_VARIABLE);
   fn->insertFormalAtTail(t);
@@ -1815,6 +1835,8 @@ void buildDefaultDestructor(AggregateType* ct) {
 
   FnSymbol* fn = new FnSymbol("deinit");
   fn->addFlag(FLAG_COMPILER_GENERATED);
+  fn->addFlag(FLAG_LAST_RESORT);
+  fn->addFlag(FLAG_LAST_RESORT);
   fn->addFlag(FLAG_DESTRUCTOR);
   fn->addFlag(FLAG_INLINE);
 

--- a/compiler/passes/initializerRules.cpp
+++ b/compiler/passes/initializerRules.cpp
@@ -900,6 +900,7 @@ FnSymbol* buildClassAllocator(FnSymbol* initMethod) {
 
   fn->addFlag(FLAG_METHOD);
   fn->addFlag(FLAG_COMPILER_GENERATED);
+  fn->addFlag(FLAG_LAST_RESORT);
 
   fn->retType = at;
 

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -3169,6 +3169,8 @@ static bool populateForwardingMethods(CallInfo& info) {
       if (thisType->symbol->hasFlag(FLAG_GENERIC))
         fn->addFlag(FLAG_GENERIC);
 
+      fn->addFlag(FLAG_LAST_RESORT);
+
       fn->retTag = method->retTag;
 
       ArgSymbol* mt    = new ArgSymbol(INTENT_BLANK, "_mt", dtMethodToken);

--- a/compiler/resolution/initializerResolution.cpp
+++ b/compiler/resolution/initializerResolution.cpp
@@ -196,7 +196,7 @@ static void doGatherInitCandidates(CallInfo&                  info,
                                    bool                       lastResort,
                                    Vec<ResolutionCandidate*>& candidates) {
   forv_Vec(FnSymbol, visibleFn, visibleFns) {
-    // Only consider user functions or compiler-generated functions
+    // Only consider functions marked with/without FLAG_LAST_RESORT
     if (visibleFn->hasFlag(FLAG_LAST_RESORT) == lastResort) {
 
       // Some expressions might resolve to methods without parenthesis.

--- a/compiler/resolution/initializerResolution.cpp
+++ b/compiler/resolution/initializerResolution.cpp
@@ -193,11 +193,11 @@ static void gatherInitCandidates(CallInfo&                  info,
 
 static void doGatherInitCandidates(CallInfo&                  info,
                                    Vec<FnSymbol*>&            visibleFns,
-                                   bool                       generated,
+                                   bool                       lastResort,
                                    Vec<ResolutionCandidate*>& candidates) {
   forv_Vec(FnSymbol, visibleFn, visibleFns) {
     // Only consider user functions or compiler-generated functions
-    if (visibleFn->hasFlag(FLAG_COMPILER_GENERATED) == generated) {
+    if (visibleFn->hasFlag(FLAG_LAST_RESORT) == lastResort) {
 
       // Some expressions might resolve to methods without parenthesis.
       // If the call is marked with methodTag, it indicates the called

--- a/compiler/resolution/tuples.cpp
+++ b/compiler/resolution/tuples.cpp
@@ -103,6 +103,7 @@ FnSymbol* makeTupleTypeCtor(std::vector<ArgSymbol*> typeCtorArgs,
   }
   typeCtor->addFlag(FLAG_ALLOW_REF);
   typeCtor->addFlag(FLAG_COMPILER_GENERATED);
+  typeCtor->addFlag(FLAG_LAST_RESORT);
   typeCtor->addFlag(FLAG_INLINE);
   typeCtor->addFlag(FLAG_INVISIBLE_FN);
   typeCtor->addFlag(FLAG_TYPE_CONSTRUCTOR);
@@ -141,6 +142,7 @@ FnSymbol* makeBuildTupleType(std::vector<ArgSymbol*> typeCtorArgs,
   }
   buildTupleType->addFlag(FLAG_ALLOW_REF);
   buildTupleType->addFlag(FLAG_COMPILER_GENERATED);
+  buildTupleType->addFlag(FLAG_LAST_RESORT);
   buildTupleType->addFlag(FLAG_INLINE);
   buildTupleType->addFlag(FLAG_INVISIBLE_FN);
   buildTupleType->addFlag(FLAG_BUILD_TUPLE);
@@ -176,6 +178,7 @@ FnSymbol* makeBuildStarTupleType(std::vector<ArgSymbol*> typeCtorArgs,
   }
   buildStarTupleType->addFlag(FLAG_ALLOW_REF);
   buildStarTupleType->addFlag(FLAG_COMPILER_GENERATED);
+  buildStarTupleType->addFlag(FLAG_LAST_RESORT);
   buildStarTupleType->addFlag(FLAG_INLINE);
   buildStarTupleType->addFlag(FLAG_INVISIBLE_FN);
   buildStarTupleType->addFlag(FLAG_BUILD_TUPLE);
@@ -246,6 +249,7 @@ FnSymbol* makeConstructTuple(std::vector<TypeSymbol*>& args,
 
   ctor->addFlag(FLAG_ALLOW_REF);
   ctor->addFlag(FLAG_COMPILER_GENERATED);
+  ctor->addFlag(FLAG_LAST_RESORT);
   ctor->addFlag(FLAG_INLINE);
   ctor->addFlag(FLAG_INVISIBLE_FN);
   ctor->addFlag(FLAG_DEFAULT_CONSTRUCTOR);
@@ -287,6 +291,7 @@ FnSymbol* makeDestructTuple(TypeSymbol* newTypeSymbol,
   dtor->insertFormalAtTail(dtor->_this);
 
   dtor->addFlag(FLAG_COMPILER_GENERATED);
+  dtor->addFlag(FLAG_LAST_RESORT);
   dtor->addFlag(FLAG_INLINE);
   dtor->addFlag(FLAG_INVISIBLE_FN);
   dtor->addFlag(FLAG_DESTRUCTOR);

--- a/compiler/resolution/visibleCandidates.cpp
+++ b/compiler/resolution/visibleCandidates.cpp
@@ -70,12 +70,12 @@ void findVisibleCandidates(CallInfo&                  info,
 
 static void gatherCandidates(CallInfo&                  info,
                              Vec<FnSymbol*>&            visibleFns,
-                             bool                       compilerGenerated,
+                             bool                       lastResort,
                              Vec<ResolutionCandidate*>& candidates) {
   forv_Vec(FnSymbol, fn, visibleFns) {
     // Consider either the user-defined functions or the compiler-generated
     // functions based on the input 'compilerGenerated'.
-    if (fn->hasFlag(FLAG_COMPILER_GENERATED) == compilerGenerated) {
+    if (fn->hasFlag(FLAG_LAST_RESORT) == lastResort) {
 
       // Consider
       //

--- a/compiler/resolution/visibleCandidates.cpp
+++ b/compiler/resolution/visibleCandidates.cpp
@@ -73,8 +73,8 @@ static void gatherCandidates(CallInfo&                  info,
                              bool                       lastResort,
                              Vec<ResolutionCandidate*>& candidates) {
   forv_Vec(FnSymbol, fn, visibleFns) {
-    // Consider either the user-defined functions or the compiler-generated
-    // functions based on the input 'compilerGenerated'.
+    // Only consider functions marked with/without FLAG_LAST_RESORT
+    // (where existence of the flag matches the lastResort argument)
     if (fn->hasFlag(FLAG_LAST_RESORT) == lastResort) {
 
       // Consider

--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -1458,6 +1458,10 @@ static FnSymbol* buildEmptyWrapper(FnSymbol* fn, CallInfo* info) {
     wrapper->addFlag(FLAG_DEFAULT_CONSTRUCTOR);
   }
 
+  if (fn->hasFlag(FLAG_LAST_RESORT)) {
+    wrapper->addFlag(FLAG_LAST_RESORT);
+  }
+
   if (fn->hasFlag(FLAG_COMPILER_GENERATED)) {
     wrapper->addFlag(FLAG_WAS_COMPILER_GENERATED);
   }

--- a/modules/internal/CPtr.chpl
+++ b/modules/internal/CPtr.chpl
@@ -128,18 +128,21 @@ module CPtr {
 
 
   pragma "compiler generated"
+  pragma "last resort"
   pragma "no doc"
   inline proc _defaultOf(type t) where t == c_void_ptr {
       return __primitive("cast", t, nil);
   }
 
   pragma "compiler generated"
+  pragma "last resort"
   pragma "no doc"
   inline proc _defaultOf(type t) where t:c_ptr {
       return __primitive("cast", t, nil);
   }
 
   pragma "compiler generated"
+  pragma "last resort"
   pragma "no doc"
   inline proc _defaultOf(type t) where t == c_fn_ptr {
       return __primitive("cast", t, nil);

--- a/modules/internal/CString.chpl
+++ b/modules/internal/CString.chpl
@@ -351,10 +351,10 @@ module CString {
     return __primitive("string_select", this, lo, hi, r2.stride);
   }
 
-  pragma "compiler generated" // avoids param string to c_string coercion
+  pragma "last resort" // avoids param string to c_string coercion
   inline proc param c_string.length param
     return __primitive("string_length", this);
-  pragma "compiler generated" // avoids param string to c_string coercion
+  pragma "last resort" // avoids param string to c_string coercion
   inline proc _string_contains(param a: c_string, param b: c_string) param
     return __primitive("string_contains", a, b);
 

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -623,6 +623,7 @@ module ChapelArray {
 
   // pragma is a workaround for ref-pair vs generic/specific overload resolution
   pragma "compiler generated"
+  pragma "last resort"
   proc chpl__ensureDomainExpr(x...) {
     return chpl__buildDomainExpr((...x));
   }

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -94,10 +94,9 @@ module ChapelBase {
 
   inline proc =(ref a, b: a.type) where isClassType(a.type)
   { __primitive("=", a, b); }
-  // Because resolution prefers user-defined versions to ones marked as "compiler
-  // generated", it is desirable to add that flag to this default version.
-  // In that way, a user-supplied version of assignment will override this one.
+
   pragma "compiler generated"
+  pragma "last resort" // so user-supplied assignment will override this one.
     // The CG pragma is needed because this function interferes with
     // assignments defined for sync and single class types.
   inline proc =(ref a, b:_nilType) where isClassType(a.type) {
@@ -1118,6 +1117,7 @@ module ChapelBase {
   }
 
   pragma "compiler generated"
+  pragma "last resort"
   pragma "init copy fn"
   inline proc chpl__initCopy(x: _tuple) {
     // body inserted during generic instantiation
@@ -1125,6 +1125,7 @@ module ChapelBase {
 
   // Catch-all initCopy implementation:
   pragma "compiler generated"
+  pragma "last resort"
   pragma "init copy fn"
   inline proc chpl__initCopy(const x) {
     // body adjusted during generic instantiation
@@ -1132,6 +1133,7 @@ module ChapelBase {
   }
 
   pragma "compiler generated"
+  pragma "last resort"
   pragma "donor fn"
   pragma "auto copy fn"
   inline proc chpl__autoCopy(x: _tuple) {
@@ -1139,6 +1141,7 @@ module ChapelBase {
   }
 
   pragma "compiler generated"
+  pragma "last resort"
   pragma "donor fn"
   pragma "unref fn"
   inline proc chpl__unref(x: _tuple) {
@@ -1146,6 +1149,7 @@ module ChapelBase {
   }
 
 
+  pragma "compiler generated"
   pragma "donor fn"
   pragma "auto copy fn"
   inline proc chpl__autoCopy(ir: _iteratorRecord) {
@@ -1154,11 +1158,13 @@ module ChapelBase {
   }
 
   pragma "compiler generated"
+  pragma "last resort"
   pragma "donor fn"
   pragma "auto copy fn"
   inline proc chpl__autoCopy(const x) return chpl__initCopy(x);
 
   pragma "compiler generated"
+  pragma "last resort"
   pragma "unalias fn"
   inline proc chpl__unalias(x) {
     pragma "no copy" var ret = x;
@@ -1185,14 +1191,17 @@ module ChapelBase {
   inline proc chpl__maybeAutoDestroyed(x) param return true;
 
   pragma "compiler generated"
+  pragma "last resort"
   pragma "auto destroy fn"
   inline proc chpl__autoDestroy(x: object) { }
 
   pragma "compiler generated"
+  pragma "last resort"
   pragma "auto destroy fn"
   inline proc chpl__autoDestroy(type t)  { }
 
   pragma "compiler generated"
+  pragma "last resort"
   pragma "auto destroy fn"
   inline proc chpl__autoDestroy(x: ?t) {
     __primitive("call destructor", x);
@@ -1693,6 +1702,7 @@ module ChapelBase {
 
   // analogously to proc =(ref a, b:_nilType) where isClassType(a.type)
   pragma "compiler generated"
+  pragma "last resort"
   inline proc =(ref a, b:_nilType) where isExternClassType(a.type)
   { __primitive("=", a, nil); }
 

--- a/modules/internal/ChapelIO.chpl
+++ b/modules/internal/ChapelIO.chpl
@@ -729,13 +729,13 @@ module ChapelIO {
   //
   // Convert 'x' to a string just the way it would be written out.
   //
-  // This is marked as compiler generated so it doesn't take precedence over
+  // This is marked as last resort so it doesn't take precedence over
   // generated casts for types like enums
   //
   // This version only applies to non-primitive types
   // (primitive types should support :string directly)
   pragma "no doc"
-  pragma "compiler generated"
+  pragma "last resort"
   proc _cast(type t, x) where t == string && ! isPrimitiveType(x.type) {
     return stringify(x);
   }

--- a/modules/internal/ChapelTuple.chpl
+++ b/modules/internal/ChapelTuple.chpl
@@ -98,13 +98,13 @@ module ChapelTuple {
     // body inserted during generic instantiation
   }
 
-  pragma "compiler generated"
+  pragma "last resort"
   proc *(type t, param p: int) {
     compilerError("<type>*<param int> not supported.  If you're trying to specify a homogeneous tuple type, use <param int>*<type>.");
   }
 
-  // compiler generated since if this resolves some other way, OK
-  pragma "compiler generated"
+  // last resort since if this resolves some other way, OK
+  pragma "last resort"
   proc *(p: int, type t) type {
     compilerError("tuple size must be static");
   }
@@ -147,6 +147,7 @@ module ChapelTuple {
   // tuple assignment
   //
   pragma "compiler generated"
+  pragma "last resort"
   inline proc =(ref x: _tuple, y: _tuple) where x.size == y.size {
     for param i in 1..x.size do
       x(i) = y(i);

--- a/modules/internal/MemConsistency.chpl
+++ b/modules/internal/MemConsistency.chpl
@@ -29,7 +29,7 @@ module MemConsistency {
   //  return memory_order_seq_cst;
 
   pragma "no instantiation limit"
-  pragma "compiler generated"
+  pragma "last resort"
   pragma "no doc"
   inline proc _defaultOf(type t) where t == memory_order {
     pragma "no doc"

--- a/modules/minimal/internal/ChapelBase.chpl
+++ b/modules/minimal/internal/ChapelBase.chpl
@@ -33,6 +33,7 @@ module ChapelBase {
   }
 
   pragma "compiler generated"
+  pragma "last resort"
   pragma "unalias fn"
   inline proc chpl__unalias(x) {
     pragma "no copy" var ret = x;

--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -212,7 +212,7 @@ module Random {
 
   // remove this deprecation version when appropriate
   pragma "no doc"
-  pragma "compiler generated"
+  pragma "last resort"
   proc makeRandomStream(seed: int(64) = SeedGenerator.oddCurrentTime,
                         param parSafe: bool = true,
                         type eltType = real(64),
@@ -596,7 +596,7 @@ module Random {
 
       // remove this deprecation version when appropriate
       pragma "no doc"
-      pragma "compiler generated"
+      pragma "last resort"
       proc RandomStream(seed: int(64) = SeedGenerator.currentTime,
                         param parSafe: bool = true,
                         type eltType = real(64)) {
@@ -2099,7 +2099,7 @@ module Random {
       }
 
       pragma "no doc"
-      pragma "compiler generated"
+      pragma "last resort"
       proc NPBRandomStream(seed: int(64) = SeedGenerator.oddCurrentTime,
                            param parSafe: bool = true,
                            type eltType = real(64)) {


### PR DESCRIPTION
FLAG_COMPILER_GENERATED previously included multiple overloaded meanings.  The most confusing of these overloaded meanings was that a function marked with FLAG_COMPILER_GENERATED is only selected during resolution if no candidate functions without that flag are found. This was sometimes used to create a last-resort function for errors (such as with deprecation errors) even though the function involved is not compiler generated (or even internal to the implementation, as happened in Random.chpl).

This PR creates a new flag, FLAG_LAST_RESORT, to request specifically this behavior in function resolution.

To implement the change, I looked at every use of FLAG_COMPILER_GENERATED in the compiler and modules.

When FLAG_COMPILER_GENERATED was added to a function, I generally also added FLAG_LAST_RESORT. In some cases I was confident that the intent was *only* to make the function last-resort in resolution (as with cases where the function exists to produce an error message). In those cases I removed the FLAG_COMPILER_GENERATED from the function.

When FLAG_COMPILER_GENERATED was checked, I verified that its use made sense - e.g. that it is controlling error output or had to do with identifying POD types. I updated the comment in flags_list.h for FLAG_COMPILER_GENERATED to reflect my understanding of what impact this flag has.

Of course, I updated the resolution portion that preferred functions without FLAG_COMPILER_GENERATED to instead check for FLAG_LAST_RESORT.

Passed full local testing. 44358cb722d58bd0a7fd3b7656bdfd588efaef03
- [x] final full local testing

Reviewed by @lydia-duncan - thanks!