### PR TITLE
Drop Vundle plugin installation instructions

### DIFF
--- a/highlight/vim/README.rst
+++ b/highlight/vim/README.rst
@@ -55,21 +55,6 @@ must be somewhere under the home directory.
 .. _vim-plug: https://github.com/junegunn/vim-plug
 
 
-Vundle Installation:
---------------------
-
-For users of the `Vundle`_ plugin manager, the vim Chapel support can be loaded
-as a local file. To do this, add the following line to the ``.vimrc``, between
-the ``call vundle#begin()`` and ``call vundle#end()`` lines:
-
-.. code-block:: vim
-
-   Plugin 'file:///path/to/chapel/highlight/vim'
-
-Where ``/path/to/chapel`` is the absolute path to the Chapel repository.
-
-.. _Vundle: https://github.com/VundleVim/Vundle.vim
-
 Manual Installation:
 --------------------
 


### PR DESCRIPTION
Dropping instructions for Vundle until #6788 can be resolved.