### PR TITLE
Update Cygwin test configs to be slightly less machine-dependent.

### DIFF
--- a/test/modules/standard/FileSystem/fsouza/chown/permission_error.suppressif
+++ b/test/modules/standard/FileSystem/fsouza/chown/permission_error.suppressif
@@ -1,2 +1,9 @@
+#!/usr/bin/env bash
+
 # Fails when run as a windows service, see JIRA issue 81
-SERVICE_ID == jenkinsslave-c__jenkins_chapel-ci
+
+if test "$OS" = Windows_NT -a -n "$SERVICE_ID"; then
+  echo 1
+else
+  echo 0
+fi

--- a/util/cron/test-cygwin32.bat
+++ b/util/cron/test-cygwin32.bat
@@ -8,7 +8,7 @@ IF "%WORKSPACE%"=="" GOTO ErrExit
 REM NOTE: This is pretty messy, but it is the only way I could figure out how to
 REM       get the correct environment setup and then invoke
 REM       nightly. (thomasvandoren, 2014-07-14)
-c:\cygwin\bin\bash -exc "export PATH='/usr/local/bin:/usr/bin:/cygdrive/c/ProgramData/Oracle/Java/javapath:/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/Wbem:/cygdrive/c/Windows/System32/WindowsPowerShell/v1.0:/cygdrive/c/Program Files/SysinternalsSuite:/cygdrive/c/Program Files/emacs-24.4/bin' ; export CHPL_TEST_LIMIT_RUNNING_EXECUTABLES=yes ; export CHPL_HOME=$PWD ; num_procs=`python -c 'import multiprocessing; print(multiprocessing.cpu_count())/2'` ; for i in $(seq 1 $num_procs); do echo 'localhost'; done > $CHPL_HOME/test/NODES/$num_procs-localhost ; export CHPL_UTIL_SMTP_HOST=relaya ; source $CHPL_HOME/util/cron/common.bash && export CHPL_NIGHTLY_TEST_CONFIG_NAME="cygwin32" && $CHPL_HOME/util/cron/nightly -cron -parnodefile $CHPL_HOME/test/NODES/$num_procs-localhost"
+c:\cygwin\bin\bash -exc "export PATH='/usr/local/bin:/usr/bin:/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/Wbem:/cygdrive/c/Program Files/SysinternalsSuite' ; export CHPL_TEST_LIMIT_RUNNING_EXECUTABLES=yes ; export CHPL_HOME=$PWD ; num_procs=`python -c 'import multiprocessing; print (multiprocessing.cpu_count()+1)/2'` ; for i in $(seq 1 $num_procs); do echo localhost; done > $CHPL_HOME/test/NODES/$num_procs-localhost ; export CHPL_UTIL_SMTP_HOST=relaya ; source $CHPL_HOME/util/cron/common.bash && export CHPL_NIGHTLY_TEST_CONFIG_NAME="cygwin32" && $CHPL_HOME/util/cron/nightly -cron -parnodefile $CHPL_HOME/test/NODES/$num_procs-localhost"
 GOTO End
 
 :ErrExit

--- a/util/cron/test-cygwin64.bat
+++ b/util/cron/test-cygwin64.bat
@@ -8,7 +8,7 @@ IF "%WORKSPACE%"=="" GOTO ErrExit
 REM NOTE: This is pretty messy, but it is the only way I could figure out how to
 REM       get the correct environment setup and then invoke
 REM       nightly. (thomasvandoren, 2014-07-14)
-c:\cygwin64\bin\bash -exc "export PATH='/usr/local/bin:/usr/bin:/cygdrive/c/windows/system32:/cygdrive/c/windows:/cygdrive/c/windows/System32/Wbem:/cygdrive/c/windows/System32/WindowsPowerShell/v1.0:/cygdrive/c/Program Files/SysinternalsSuite:/usr/bin:/cygdrive/c/emacs-24.3/bin' ; export CHPL_TEST_LIMIT_RUNNING_EXECUTABLES=yes ; export CHPL_HOME=$PWD ; num_procs=`python -c 'import multiprocessing; print(multiprocessing.cpu_count())/2'` ; for i in $(seq 1 $num_procs); do echo 'localhost'; done > $CHPL_HOME/test/NODES/$num_procs-localhost ; export CHPL_UTIL_SMTP_HOST=relaya ; source $CHPL_HOME/util/cron/common.bash && export CHPL_NIGHTLY_TEST_CONFIG_NAME="cygwin64" && $CHPL_HOME/util/cron/nightly -cron -parnodefile $CHPL_HOME/test/NODES/$num_procs-localhost"
+c:\cygwin64\bin\bash -exc "export PATH='/usr/local/bin:/usr/bin:/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/Wbem:/cygdrive/c/Program Files/SysinternalsSuite' ; export CHPL_TEST_LIMIT_RUNNING_EXECUTABLES=yes ; export CHPL_HOME=$PWD ; num_procs=`python -c 'import multiprocessing; print (multiprocessing.cpu_count()+1)/2'` ; for i in $(seq 1 $num_procs); do echo localhost; done > $CHPL_HOME/test/NODES/$num_procs-localhost ; export CHPL_UTIL_SMTP_HOST=relaya ; source $CHPL_HOME/util/cron/common.bash && export CHPL_NIGHTLY_TEST_CONFIG_NAME="cygwin64" && $CHPL_HOME/util/cron/nightly -cron -parnodefile $CHPL_HOME/test/NODES/$num_procs-localhost"
 GOTO End
 
 :ErrExit


### PR DESCRIPTION
These minor changes only affect the nightly Cygwin test jobs, and
make them slightly less dependent on machine-specific details.

1. Change a *.suppressif file to allow any Windows Service ID to be
   recognized, not just the specific Service name used on our test
   machine.

2. Trivial clean-ups in the test-cygwinXX.bat scripts.