### PR TITLE
Fix gasnet installed

### DIFF
--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -261,10 +261,13 @@ static void setChplHomeDerivedVars() {
 
 static void saveChplHomeDerivedInEnv() {
   int rc;
+  envMap["CHPL_RUNTIME_LIB"] = strdup(CHPL_RUNTIME_LIB);
   rc = setenv("CHPL_RUNTIME_LIB", CHPL_RUNTIME_LIB, 1);
   if( rc ) USR_FATAL("Could not setenv CHPL_RUNTIME_LIB");
+  envMap["CHPL_RUNTIME_INCL"] = strdup(CHPL_RUNTIME_INCL);
   rc = setenv("CHPL_RUNTIME_INCL", CHPL_RUNTIME_INCL, 1);
   if( rc ) USR_FATAL("Could not setenv CHPL_RUNTIME_INCL");
+  envMap["CHPL_THIRD_PARTY"] = strdup(CHPL_THIRD_PARTY);
   rc = setenv("CHPL_THIRD_PARTY", CHPL_THIRD_PARTY, 1);
   if( rc ) USR_FATAL("Could not setenv CHPL_THIRD_PARTY");
 }

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -66,6 +66,9 @@ extern const char* CHPL_WIDE_POINTERS;
 extern const char* CHPL_LLVM;
 extern const char* CHPL_AUX_FILESYS;
 extern const char* CHPL_UNWIND;
+extern const char* CHPL_RUNTIME_LIB;
+extern const char* CHPL_RUNTIME_INCL;
+extern const char* CHPL_THIRD_PARTY;
 extern const int CHPL_STACK_CHECKS;
 extern const int CHPL_CACHE_REMOTE;
 

--- a/runtime/src/launch/amudprun/Makefile.share
+++ b/runtime/src/launch/amudprun/Makefile.share
@@ -22,7 +22,7 @@ LAUNCHER_SRCS = \
 # is this the right time to set this variable?  Or is user code
 # compile time
 #
-RUNTIME_CFLAGS += -DLAUNCH_PATH="$(THIRD_PARTY_DIR)/amudprun/$(AMUDPRUN_INSTALL_SUBDIR)/bin/"
+RUNTIME_CFLAGS += -DLAUNCH_PATH="amudprun/$(AMUDPRUN_INSTALL_SUBDIR)/bin/"
 
 SVN_SRCS = $(LAUNCHER_SRCS)
 SRCS = $(SVN_SRCS)

--- a/runtime/src/launch/amudprun/launch-amudprun.c
+++ b/runtime/src/launch/amudprun/launch-amudprun.c
@@ -23,9 +23,13 @@
 #include "chpl-mem.h"
 #include "error.h"
 
+// To get CHPL_THIRD_PARTY from chpl invocation
+#include "chplcgfns.h"
+
 #define LAUNCH_PATH_HELP WRAP_TO_STR(LAUNCH_PATH)
 #define WRAP_TO_STR(x) TO_STR(x)
 #define TO_STR(x) #x
+
 
 extern char** environ;
 static void add_env_options(int* argc, char** argv[]) {
@@ -92,9 +96,9 @@ static char** chpl_launch_create_argv(const char *launch_cmd,
 }
 
 int chpl_launch(int argc, char* argv[], int32_t numLocales) {
-  int len = strlen(WRAP_TO_STR(LAUNCH_PATH)) + strlen("amudprun") + 1;
+  int len = strlen(CHPL_THIRD_PARTY) + strlen(WRAP_TO_STR(LAUNCH_PATH)) + strlen("amudprun") + 2;
   char *cmd = chpl_mem_allocMany(len, sizeof(char), CHPL_RT_MD_COMMAND_BUFFER, -1, 0);
-  snprintf(cmd, len, "%samudprun", WRAP_TO_STR(LAUNCH_PATH));
+  snprintf(cmd, len, "%s/%samudprun", CHPL_THIRD_PARTY, WRAP_TO_STR(LAUNCH_PATH));
 
   return chpl_launch_using_exec(cmd,
                                 chpl_launch_create_argv(cmd, argc, argv,


### PR DESCRIPTION
Helps with #6793.

Fix gasnet installed

[developed by @mppf, reviewed by @bradcray]

GASNet install was not working because the path that the launcher uses to access amudprun and the like was hard-coded in the runtime to point to the location from which Chapel was built, not where it was installed.  This change captures these key paths at compile-time, relative to the compiler's installation, and has the runtime query those when invoking the launcher instead.

So far, this change is specific to the amudprun launcher.  The equivalent changes would be required for other GASNet launchers in sibling directories.  Noting that in the original issue #6793 as a placeholder.

- [x] testing