### PR TITLE
Add PRIM_WIDE_MAKE

### DIFF
--- a/compiler/AST/primitive.cpp
+++ b/compiler/AST/primitive.cpp
@@ -61,6 +61,19 @@ returnInfoStringCopy(CallExpr* call) {
 }
 
 static QualifiedType
+returnInfoWideMake(CallExpr* call) {
+  Type* t1 = call->get(1)->typeInfo();
+  if (t1->symbol->hasFlag(FLAG_REF))
+    INT_FATAL("ref not supported here yet");
+
+  if (wideClassMap.get(t1))
+    t1 = wideClassMap.get(t1);
+
+  return QualifiedType(t1, QUAL_VAL);
+}
+
+
+static QualifiedType
 returnInfoLocaleID(CallExpr* call) {
   return QualifiedType(dtLocaleID, QUAL_VAL);
 }
@@ -604,6 +617,7 @@ initPrimitive() {
 
   prim_def(PRIM_LOGICAL_FOLDER, "_paramFoldLogical", returnInfoBool);
 
+  prim_def(PRIM_WIDE_MAKE, "_wide_make", returnInfoWideMake, false, true);
   prim_def(PRIM_WIDE_GET_LOCALE, "_wide_get_locale", returnInfoLocaleID, false, true);
   // MPF - 10/9/2015 - neither _wide_get_node nor _wide_get_addr
   // is used in the module or test code. insertWideReferences uses

--- a/compiler/codegen/expr.cpp
+++ b/compiler/codegen/expr.cpp
@@ -3531,6 +3531,23 @@ GenRet CallExpr::codegenPrimitive() {
     codegenIsSpecialPrimitive(NULL, this, ret);
     break;
 
+  case PRIM_WIDE_MAKE: {
+    // (type, localeID, addr)
+    Type* narrowType = get(1)->typeInfo();
+    GenRet locale = get(2)->codegen();
+    GenRet raddr = codegenValue(get(3)->codegen());
+
+    INT_ASSERT(!narrowType->symbol->hasFlag(FLAG_WIDE_CLASS));
+
+    ret = codegenCast(narrowType, raddr, true);
+    if (fLocal == false) {
+      ret = codegenWideAddr(locale, ret);
+    }
+
+    break;
+  }
+
+
   case PRIM_WIDE_GET_LOCALE: {
     if (get(1)->isWideRef() ||
         get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS)) {

--- a/compiler/codegen/expr.cpp
+++ b/compiler/codegen/expr.cpp
@@ -3534,10 +3534,13 @@ GenRet CallExpr::codegenPrimitive() {
   case PRIM_WIDE_MAKE: {
     // (type, localeID, addr)
     Type* narrowType = get(1)->typeInfo();
+    if (narrowType->symbol->hasFlag(FLAG_WIDE_CLASS)) {
+      narrowType = narrowType->getField("addr")->typeInfo();
+    }
+    INT_ASSERT(!narrowType->symbol->hasFlag(FLAG_WIDE_CLASS));
     GenRet locale = get(2)->codegen();
     GenRet raddr = codegenValue(get(3)->codegen());
 
-    INT_ASSERT(!narrowType->symbol->hasFlag(FLAG_WIDE_CLASS));
 
     ret = codegenCast(narrowType, raddr, true);
     if (fLocal == false) {

--- a/compiler/include/primitive.h
+++ b/compiler/include/primitive.h
@@ -176,6 +176,9 @@ enum PrimitiveTag {
 
   PRIM_LOGICAL_FOLDER,          // Help fold logical && and ||
 
+  PRIM_WIDE_MAKE,               // create a wide pointer from
+                                // (type, localeID, addr)
+
   PRIM_WIDE_GET_LOCALE,         // Returns the "locale" portion of a wide pointer.
 
   PRIM_WIDE_GET_NODE,           // Get just the node portion of a wide pointer.

--- a/compiler/optimizations/optimizeOnClauses.cpp
+++ b/compiler/optimizations/optimizeOnClauses.cpp
@@ -176,6 +176,9 @@ classifyPrimitive(CallExpr *call) {
       return FAST_NOT_LOCAL;
     }
 
+  case PRIM_WIDE_MAKE:
+    return FAST_NOT_LOCAL;
+
 // I think these can always return true. <hilde>
 // But that works only if the remote get is removed from code generation.
   case PRIM_WIDE_GET_LOCALE:

--- a/compiler/passes/insertWideReferences.cpp
+++ b/compiler/passes/insertWideReferences.cpp
@@ -958,6 +958,9 @@ static void addKnownWides() {
               setWide(cause, lhs);
             }
           }
+        } else if (rhs->isPrimitive(PRIM_WIDE_MAKE)) {
+          INT_ASSERT(isObj(lhs));
+          setWide(rhs, lhs);
         }
       }
     }

--- a/compiler/util/exprAnalysis.cpp
+++ b/compiler/util/exprAnalysis.cpp
@@ -271,6 +271,7 @@ bool SafeExprAnalysis::isSafePrimitive(CallExpr* ce) {
     case PRIM_DYNAMIC_CAST:
     case PRIM_ARRAY_GET:
     case PRIM_ARRAY_GET_VALUE:
+    case PRIM_WIDE_MAKE:
     case PRIM_WIDE_GET_LOCALE:
     case PRIM_WIDE_GET_NODE:
     case PRIM_WIDE_GET_ADDR:

--- a/test/expressions/ferguson/make-wide.chpl
+++ b/test/expressions/ferguson/make-wide.chpl
@@ -1,0 +1,45 @@
+class C {
+  var x: int;
+}
+
+proc test() {
+
+  var c:C;
+  
+  on Locales[numLocales-1] {
+    c = new C(1);
+  }
+
+  var loc = __primitive("_wide_get_locale", c);
+  var adr = __primitive("_wide_get_addr", c);
+
+  var b = __primitive("_wide_make", C, loc, adr);
+
+  assert( b == c );
+
+  delete c;
+}
+
+proc test2() {
+  var c:C;
+  
+  on Locales[numLocales-1] {
+    c = new C(1);
+  }
+
+  var loc = __primitive("_wide_get_locale", c);
+  var adr = __primitive("_wide_get_addr", c);
+
+  var b = __primitive("_wide_make", C, loc, adr);
+  var loc2 = __primitive("_wide_get_locale", b);
+  var adr2 = __primitive("_wide_get_addr", b);
+
+  assert( b == c );
+  assert( loc == loc2 );
+  assert( adr == adr2 );
+
+  delete c;
+}
+
+test();
+test2();


### PR DESCRIPTION
The new primitive constructs a wide class instance pointer from a local pointer, a localeID, and a type.

Passed full local testing.
Reviewed by @benharsh - thanks!