### PR TITLE
Update about.prediff to add new expected paths

### DIFF
--- a/test/execflags/sungeun/about.prediff
+++ b/test/execflags/sungeun/about.prediff
@@ -41,6 +41,9 @@ with open(goodfile, 'w') as gfh:
     p = subprocess.Popen([printchplenv, '--simple'],
                          stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     chplenv = p.communicate()[0]
+    chplenv += "CHPL_RUNTIME_INCL="+chpl_home+"/runtime/include\n"
+    chplenv += "CHPL_RUNTIME_LIB="+chpl_home+"/lib\n"
+    chplenv += "CHPL_THIRD_PARTY="+chpl_home+"/third-party\n"
     for env in sorted(chplenv.split()):
         tenv = env.split('=')
         gfh.write('  %s: %s\n'%(tenv[0], tenv[1]))


### PR DESCRIPTION
(Look Mom, I can write Python with no references to documentation!)

This fixes a mistake I made in merging Michael's fix in #6795 -- thinking of it as exclusively an installation change, and having updated the installation, I failed to anticipate its effect on the output of the --about command (which I've never been that familiar with), so didn't bother to run testing.   Oops.

This fixes the issue by having the .prediff that generates the about.chpl test's .good file to plug in the expected values of those paths.  I believe it should be as robust as the current prediff's determination of CHPL_HOME, so should fix the errors, but if @mppf and/or @ben-albrecht could watch over any additional fallout after I leave tonight, that would be much appreciated.
