### PR TITLE
mod-scope :- LLVM simplify call sites for tryCResolve

### DIFF
--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -645,7 +645,7 @@ static void resolveUnresolvedSymExpr(UnresolvedSymExpr* usymExpr) {
     updateMethod(usymExpr);
 
 #ifdef HAVE_LLVM
-    if (externC == true && tryCResolve(usymExpr->getModule(), name) == true) {
+    if (tryCResolve(usymExpr->getModule(), name) == true) {
       // Try resolution again since the symbol should exist now
       resolveUnresolvedSymExpr(usymExpr);
     }
@@ -946,8 +946,7 @@ static void resolveModuleCall(CallExpr* call) {
           }
 
 #ifdef HAVE_LLVM
-        } else if (externC                                 == true &&
-                   tryCResolve(call->getModule(), mbrName) == true) {
+        } else if (tryCResolve(call->getModule(), mbrName) == true) {
           // Try to resolve again now that the symbol should
           // be in the table
           resolveModuleCall(call);
@@ -970,9 +969,15 @@ static bool tryCResolve(ModuleSymbol*                     module,
                         llvm::SmallSet<ModuleSymbol*, 24> visited);
 
 static bool tryCResolve(ModuleSymbol* module, const char* name) {
-  llvm::SmallSet<ModuleSymbol*, 24> visited;
+  bool retval = false;
 
-  return tryCResolve(module, name, visited);
+  if (externC == true) {
+    llvm::SmallSet<ModuleSymbol*, 24> visited;
+
+    retval = tryCResolve(module, name, visited);
+  }
+
+  return retval;
 }
 
 static bool tryCResolve(ModuleSymbol*                     module,


### PR DESCRIPTION
There has been a long standing bug that prevents invocations of constructors,
and now initializers, using an explicit module reference.

For example the following currently fails on master

                   var x : MyClass = new M1.MyClass(10, 20, 30);

This is the first in a sequence of "close the gap" PRs to merge a set of changes that
resolve this defect.

This is a trivial PR that simplifies the call sites to tryCResolve().  This functionality is
within a CHPL_LLVM guard and so is being merged separately.

Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.  Ran a
small portion of start on release/.  Naturally there were no problems with this.

Compiled with CHPL_LLVM=llvm on liinux64 and passed a full paratest with futures
and --llvm.
