### PR TITLE
Mod scope 2

### DIFF
--- a/test/users/ferguson/module_new.bad
+++ b/test/users/ferguson/module_new.bad
@@ -1,2 +1,8 @@
-module_new.chpl:8: In function 'main':
-module_new.chpl:9: error: unresolved call 'X.init(1)'
+module_new.chpl:9: internal error: NOR0785 chpl Version 1.16.0 pre-release (1f7d29f)
+Note: This source location is a guess.
+
+Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
+please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
+the filename + line number above may be useful in working around the issue.
+


### PR DESCRIPTION
Continue to apply updates to support new expressions with explicit module references.

The compiler detects explicit module references during scopeResolve and "encodes'
this information by inserting the pair [ gModuleToken, module ] into the appropriate
CallExpr. This encoding is referenced in several passes and is eventually removed during
function resolution.

Before this PR the pair was inserted in to simple call expressions but was overlooked for
constructor call expressions. This PR modifies resolveModuleCall() (in scopeResolve.cpp)
to recognize an explicit module reference in a constructor call expression and insert the
required marker pair.

Followed the expected compilation/testing profile
