### PR TITLE
Mod scope 3

### DIFF
--- a/compiler/passes/checkNormalized.cpp
+++ b/compiler/passes/checkNormalized.cpp
@@ -1,15 +1,15 @@
 /*
  * Copyright 2004-2017 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,12 +17,10 @@
  * limitations under the License.
  */
 
-// checkNormalized.cpp
-
 #include "passes.h"
 
-#include "expr.h"
 #include "astutil.h"
+#include "expr.h"
 #include "stlUtil.h"
 
 
@@ -30,89 +28,91 @@ static void checkFunctionSignatures();
 static void checkPrimNew();
 
 
-void
-checkNormalized(void) {
+void checkNormalized() {
   checkFunctionSignatures();
   checkPrimNew();
 }
 
 
-static void checkFunctionSignatures()
-{
+static void checkFunctionSignatures() {
   forv_Vec(FnSymbol, fn, gFnSymbols) {
     if (fn->isIterator()) {
-      if (fn->retTag == RET_TYPE)
+      if (fn->retTag == RET_TYPE) {
         USR_FATAL_CONT(fn, "iterators may not yield or return types");
-      if (fn->retTag == RET_PARAM)
+      }
+
+      if (fn->retTag == RET_PARAM) {
         USR_FATAL_CONT(fn, "iterators may not yield or return parameters");
-    } else if (fn->hasFlag(FLAG_CONSTRUCTOR) &&
-               !fn->hasFlag(FLAG_DEFAULT_CONSTRUCTOR)) {
-      if (fn->retExprType)
+      }
+
+    } else if (fn->hasFlag(FLAG_CONSTRUCTOR)         == true &&
+               fn->hasFlag(FLAG_DEFAULT_CONSTRUCTOR) == false) {
+      if (fn->retExprType != NULL) {
         USR_FATAL_CONT(fn, "initializers may not declare a return type");
+      }
+
       for_formals(formal, fn) {
         std::vector<SymExpr*> symExprs;
+
         collectSymExprs(formal, symExprs);
+
         for_vector(SymExpr, se, symExprs) {
           if (se->symbol() == fn->_this) {
-            USR_FATAL_CONT(se, "invalid access of class member in initializer argument list");
+            USR_FATAL_CONT(se,
+                           "invalid access of class member in "
+                           "initializer argument list");
+
             break;
           }
         }
       }
-    } else if (fn->hasFlag(FLAG_DESTRUCTOR)) {
-      if (fn->retExprType)
+
+    } else if (fn->hasFlag(FLAG_DESTRUCTOR) == true) {
+      if (fn->retExprType != NULL) {
         USR_FATAL_CONT(fn, "destructors may not declare a return type");
+      }
     }
   }
 }
 
+static void checkPrimNew() {
+  forv_Vec(CallExpr, call, gCallExprs) {
+    if (call->parentSymbol          != NULL &&
+        call->isPrimitive(PRIM_NEW) == true) {
 
-static void checkPrimNew()
-{
-  forv_Vec(CallExpr, call, gCallExprs)
-  {
-    // Ignore calls that are not in the tree.
-    if (!call->parentSymbol)
-      continue;
+      if (call->numActuals() >= 1) {
+        Expr*    arg1     = call->get(1);
+        SymExpr* se       = toSymExpr(arg1);
+        Expr*    typeExpr = NULL;
 
-    // We are only interested in 'new' primitives.
-    if (!call->isPrimitive(PRIM_NEW))
-      continue;
+        // Extract the type expression
+        if (se != NULL && se->symbol() == gModuleToken) {
+          typeExpr = call->get(3);
+        } else {
+          typeExpr = call->get(1);
+        }
 
-    // The 1st operand of a new should be a type
-    // the remaining operands are arguments
-    if (Expr* typeExpr = call->get(1))
-    {
-      if (isUnresolvedSymExpr(typeExpr))
-        // We can't know anything more about this symbol until resolution.
-        // So let it pass
-        continue;
+        if        (isUnresolvedSymExpr(typeExpr) == true) {
 
-      if (isTypeExpr(typeExpr))
-        // If we know the expression represents a type, that's also good.
-        continue;
+        } else if (isTypeExpr(typeExpr)          == true) {
 
-      if (isCallExpr(typeExpr))
-        // Sometimes the type expression is a (partial) callExpr
-        // This happens with nested classes, e.g.
-        // new this.someType()
-        continue;
+        } else if (isCallExpr(typeExpr)          == true) {
 
-      if (SymExpr* se = toSymExpr(typeExpr))
-        if (se->symbol()->hasFlag(FLAG_MAYBE_TYPE))
-          // E.g. new gettype()
-          // where gettype is a parentheses-less method returning a type
-          continue;
+        } else if (SymExpr* se = toSymExpr(typeExpr)) {
+          if (se->symbol()->hasFlag(FLAG_MAYBE_TYPE) == false) {
+            USR_FATAL_CONT(call,
+                           "'new' must be followed by a type expression");
+          }
 
-      // Fail by default
-      // (We may need additional filters above, to pass expected cases.)
-      USR_FATAL_CONT(call, "'new' must be followed by a type expression");
-    }
-    else
-    {
-      // 'new' must always have an operand.
-      USR_FATAL_CONT(call, "invalid use of 'new'");
+        } else {
+          USR_FATAL_CONT(call, "'new' must be followed by a type expression");
+        }
+
+      } else {
+        USR_FATAL_CONT(call, "invalid use of 'new'");
+      }
     }
   }
+
   USR_STOP();
 }

--- a/test/users/ferguson/module_new.bad
+++ b/test/users/ferguson/module_new.bad
@@ -1,8 +1,2 @@
-module_new.chpl:9: internal error: NOR0785 chpl Version 1.16.0 pre-release (1f7d29f)
-Note: This source location is a guess.
-
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
-and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
-please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
-
+module_new.chpl:8: In function 'main':
+module_new.chpl:9: error: invalid use of 'new' on primitive tmodule=

--- a/test/users/ferguson/module_new.chpl
+++ b/test/users/ferguson/module_new.chpl
@@ -7,5 +7,9 @@ module M {
 module Y {
   proc main() {
     var y = new M.X(1);
+
+    writeln('y = ', y);
+
+    delete y;
   }
 }


### PR DESCRIPTION
Continue to apply updates to support new expressions with explicit module references.

This PR

1. makes small updates to two routines in normalize.cpp that handle PRIM_NEW
statements so that they recognize ModuleToken/ModuleValue pairs and observe
the required ordering.

2. tweaks the PRIM_NEW routine in checkNormalized.cpp to recognize
ModuleToken/ModuleValue pairs.

3. Updates the .bad file for an existing future to reflect the progress being made
    
Followed the expected compilation/testing protocol.

