### PR TITLE
Default executable name based on main module name not a.out

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -1888,6 +1888,12 @@ void codegen(void) {
       USR_WARN("C code generation for packed pointers not supported");
   }
 
+  // Set the executable name if it isn't set already.
+  if (executableFilename[0] == '\0') {
+    ModuleSymbol* mainMod = ModuleSymbol::mainModule();
+    strncpy(executableFilename, mainMod->name, sizeof(executableFilename));
+  }
+
   if( llvmCodegen ) {
 #ifndef HAVE_LLVM
     USR_FATAL("This compiler was built without LLVM support");

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -48,7 +48,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
-char               executableFilename[FILENAME_MAX + 1] = "a.out";
+char               executableFilename[FILENAME_MAX + 1] = "";
 char               saveCDir[FILENAME_MAX + 1]           = "";
 
 std::string ccflags;

--- a/test/compflags/ferguson/default-binary-name/sub_test
+++ b/test/compflags/ferguson/default-binary-name/sub_test
@@ -1,0 +1,62 @@
+#! /usr/bin/env python
+
+import subprocess
+import sys
+import os
+
+if len(sys.argv)!=2:
+  print 'usage: sub_test COMPILER'
+  sys.exit(0)
+
+# Find the base installation
+compiler=sys.argv[1]
+if not os.access(compiler,os.R_OK|os.X_OK):
+  Fatal('Cannot execute compiler \''+compiler+'\'')
+
+# find current directory
+
+def run(source, exe_name, compopts, expect): 
+  p = subprocess.Popen([compiler, source] + compopts,
+                       stdout=subprocess.PIPE)
+  myoutput = p.communicate()[0]
+  sys.stdout.write(myoutput)
+  if p.returncode != 0:
+    sys.stdout.write("[Error matching compiler output for %s (%s)]\n"%(source, exe_name))
+    sys.exit(1)
+  else:
+    sys.stdout.write("[Success compiling %s (%s)]\n"%(source, exe_name))
+
+  returncode = -1
+  myoutput = ""
+
+  if os.access(exe_name,os.R_OK|os.X_OK):
+
+    numlocales = "0"
+    if "NUMLOCALES" in os.environ:
+      numlocales = os.environ['NUMLOCALES']
+
+    if numlocales == "0":
+      p = subprocess.Popen(["./%s" % exe_name], stdout=subprocess.PIPE)
+    else:
+      p = subprocess.Popen(["./%s" % exe_name, "-nl%s" % numlocales],
+          stdout=subprocess.PIPE)
+
+    myoutput = p.communicate()[0]
+    returncode = p.returncode
+
+  myoutput = myoutput.strip()
+  if returncode == 0 and myoutput == expect:
+    sys.stdout.write("[Success matching program output for %s (%s)]\n"%(source, exe_name))
+  else:
+    sys.stdout.write("[Error matching program output for %s (%s)]\n"%(source, exe_name))
+
+  if os.access(exe_name, os.F_OK):
+    os.remove(exe_name)
+  if os.access(exe_name + "_real", os.F_OK):
+    os.remove(exe_name + "_real")
+
+
+run("test-default-binary-name.chpl", "test-default-binary-name", [], "Hello")
+run("test-default-binary-name.chpl", "test_exe", ["-o", "test_exe"], "Hello")
+run("test-default-binary-name-main-module.chpl", "M1", ["--main-module", "M1"], "M1 main")
+run("test-default-binary-name-main-module.chpl", "M2", ["--main-module", "M2"], "M2 main")

--- a/test/compflags/ferguson/default-binary-name/sub_test
+++ b/test/compflags/ferguson/default-binary-name/sub_test
@@ -60,3 +60,10 @@ run("test-default-binary-name.chpl", "test-default-binary-name", [], "Hello")
 run("test-default-binary-name.chpl", "test_exe", ["-o", "test_exe"], "Hello")
 run("test-default-binary-name-main-module.chpl", "M1", ["--main-module", "M1"], "M1 main")
 run("test-default-binary-name-main-module.chpl", "M2", ["--main-module", "M2"], "M2 main")
+
+# finally, test with setting the binary name with the enivronment variable.
+# this is last so we don't have to worry about restoring the environment
+# variable.
+#
+os.environ["CHPL_EXE_NAME"] = "test_exe_env"
+run("test-default-binary-name.chpl", "test_exe_env", [], "Hello")

--- a/test/compflags/ferguson/default-binary-name/test-default-binary-name-main-module.chpl
+++ b/test/compflags/ferguson/default-binary-name/test-default-binary-name-main-module.chpl
@@ -1,0 +1,11 @@
+module M1 {
+  proc main() {
+    writeln("M1 main");
+  }
+}
+ 
+module M2 {
+  proc main() {
+    writeln("M2 main");
+  }
+}

--- a/test/compflags/ferguson/default-binary-name/test-default-binary-name.chpl
+++ b/test/compflags/ferguson/default-binary-name/test-default-binary-name.chpl
@@ -1,0 +1,1 @@
+writeln("Hello");


### PR DESCRIPTION
Closes #6283.

Following the proposal in that issue, the default executable name is now based upon the main module (which is typically the name of the .chpl file supplied on the command line).

Adds a custom sub_test-based test to check that this works correctly. The normal sub_test script always supplies a `-o` argument and that is why a custom script is used to test this feature.

Verified new test passes with quickstart+GASNet.
Passed full local testing.

Reviewed by @daviditen - thanks!