### PR TITLE
Refactor Perf Graphs HTML

### DIFF
--- a/util/test/perf/index.html
+++ b/util/test/perf/index.html
@@ -25,8 +25,6 @@
 
   </head>
   <body onload="perfGraphInit()">
-    <center><h2 id="titleElem"></h2></center>
-    <center><h4 id="dateElem"></h4></center>
     <script>
       <!-- hide
            function jumpto(x){
@@ -37,32 +35,40 @@
            }
            // end hide -->
     </script>
-    <table>
-      <tr>
-        <td id="graphSelectionPane" class="graphSelectionPane">
-            <p id='toggleConf'><em>Toggle configurations</em></p>
-            <p><em>Select a test suite</em></p>
-            <div id="suiteMenu"></div>
-            <p><strong>OR</strong></p>
-            <p><em>Select and display specific tests</em></p>
-            <input type="button" onclick="displaySelectedGraphs()"
-            value="Display">
-             <input type="button" onclick="clearDates()"
-            value="Clear Dates">
-            <br>
-            <input type="button" onclick="selectAllGraphs()"
-            value="Select All">
-            <input type="button" onclick="unselectAllGraphs()"
-            value="Unselect All">
-            <p>Filter: <input type="text" name="filterBox"></p>
-            <div id="graphlist" class="graphList"></div>
-          <td valign="top">
-            <div id="graphdisplay" class=graphdisplay></div>
-          </td>
-          <td id="legenddisplay" valign="top">
-        </td>
-      </tr>
-    </table>
+    <div id="graphSelectionPane">
+      <a id="homeLink"
+         class="grayButton simpleLink"
+         href="http://chapel.sourceforge.net/perf/">Home</a>
+
+      <p id='toggleConf'><em>Toggle configurations</em></p>
+      <p><em>Select a test suite</em></p>
+      <div id="suiteMenu"></div>
+
+      <p><em>Select and display specific tests</em></p>
+
+      <div id="buttonMenu">
+        <button class="grayButton" onclick="displaySelectedGraphs()">Display</button>
+        <button class="grayButton" onclick="clearDates()">Clear Dates</button>
+
+        <button class="grayButton" onclick="selectAllGraphs()">Select All</button>
+        <button class="grayButton" onclick="unselectAllGraphs()">Unselect All</button>
+      </div>
+
+      <p>Filter: <input type="text" name="filterBox"></p>
+
+      <div id="graphlist">
+        <!-- populated with checkboxes by javascript -->
+      </div>
+    </div> <!-- End of graph selection pane -->
+
+    <div id="titleDiv">
+      <center><h2 id="titleElem"></h2></center>
+      <center><h4 id="dateElem"></h4></center>
+    </div>
+
+    <div id="graphdisplay">
+      <!-- populated with graphs by javascript -->
+    </div>
 
     <script src="perfgraph.js"></script>
   </body>

--- a/util/test/perf/perfgraph.css
+++ b/util/test/perf/perfgraph.css
@@ -1,24 +1,67 @@
 body {
     font-family: "Arial";
 }
-.graphdisplay {
+
+#graphdisplay {
     margin-left: 375px;
 }
+
+#graphSelectionPane {
+    padding-left: 20px;
+    padding-right: 20px;
+    position:fixed;
+    vertical-align: top;
+    border-right: 1px solid black;
+    height: 100%;
+}
+
+#graphlist {
+    overflow-y: auto;
+    overflow-x: hidden;
+    display: inline-block;
+}
+
+#titleDiv {
+  margin-bottom: 30px;
+}
+
+#homeLink {
+  margin-left: 10px;
+  margin-top: 10px;
+  font-size: 20px;
+}
+
+#buttonMenu {
+  width: 300px;
+}
+#buttonMenu .grayButton {
+  min-width: 80px;
+}
+
 .graph {
     vertical-align: top;
     white-space: nowrap;
     font-size: 11px;
 }
+div.graphContainer {
+  /* width of graph + legend */
+  width: 1100px;
+  display: inline-block;
+}
 div.perfGraph {
     vertical-align: top;
     width: 700px;
     height: 300px;
+    float: left;
 }
 div.gspacer {
+    display: inline-block;
     width: 700px;
     height: 30px;
+    margin-bottom: 20px;
 }
 div.perfLegend {
+    float:left;
     vertical-align: top;
     width: 400px;
     height: 300px;
@@ -27,29 +70,46 @@ div.perfLegend {
 span.highlight {
     border: 1px solid grey;
 }
-div.lspacer {
-    width: 400px;
-    height: 30px;
-}
-.graphSelectionPane {
-    padding-left: 20px;
-    padding-right: 20px;
-    position:fixed;
-    vertical-align: top;
-    border-right: 1px solid black;
-}
-.graphList {
-    margin-top: 10px;
-    overflow-y: auto;
-    overflow-x: hidden;
-}
+
 .toggle {
     height: 20px;
     border: 1px solid grey;
     padding: 0px 5px;
     margin: 5px 10px 0px 0px;
 }
+.toggle:focus {
+  outline: 0;
+}
+
 .blackAnnotation {
   color: black !important;
   border-color: black !important;
+}
+
+.grayButton {
+  background-color: #d8d8d8;
+  border: 1px solid black;
+  font-size: 13px;
+  text-align: center;
+  padding: 3px 3px;
+  margin: 2px;
+}
+
+.grayButton:hover {
+  background-color: #b7b8bc;
+}
+.grayButton:active {
+  transform: scale(.9);
+}
+.grayButton:focus {
+  outline: 0;
+}
+
+.simpleLink {
+  color: black;
+  text-decoration: none;
+}
+.simpleLink:visited {
+  color: black;
+  text-decoration: none;
 }

--- a/util/test/perf/perfgraph.js
+++ b/util/test/perf/perfgraph.js
@@ -124,12 +124,12 @@ while (curThirdDate.isBefore(Date.today())) {
 
 // array of currently displayed graphs
 var gs = [];
+
 // used to prevent multiple redraws of graphs when syncing x-axis zooms
 var globalBlockRedraw = false;
 
 // The main elements that all the graphs and graph legends will be put in
-var parent = document.getElementById('graphdisplay');
-var legend = document.getElementById('legenddisplay');
+var graphPane = document.getElementById('graphdisplay');
 
 // setup the default configuration even if it's not multi-conf
 var multiConfs = configurations.length != 0;
@@ -194,6 +194,7 @@ function doFilter() {
 function filterFn() {
   if (filterBox.value != lastFilterVal) {
     doFilter();
+    setDygraphPanePos();
   }
 }
 
@@ -205,34 +206,31 @@ $(document).ready(function() {
 // for graph expansion because we need to be able to add the expanded graphs
 // after the graph that is being expanded and there may be other graphs
 // after it so we don't just want to put the expanded graphs at the end.
-function getNextDivs(afterDiv, afterLDiv) {
+function getNextDivs(afterDiv) {
 
   // if divs were specified, create new divs that follow those, else just put
-  // these divs at the end
+  // these divs at the end (indicated by 'beforeDiv == null')
   var beforeDiv = null;
-  var beforeLDiv = null;
-  if (afterDiv && afterLDiv &&
-      afterDiv.nextSibling && afterLDiv.nextSibling) {
-    beforeDiv = afterDiv.nextSibling.nextSibling;
-    beforeLDiv = afterLDiv.nextSibling.nextSibling;
+  if (afterDiv && afterDiv.nextSibling) {
+    beforeDiv = afterDiv.nextSibling;
   }
+
+  var container = document.createElement('div');
+  container.className = 'graphContainer';
+  graphPane.insertBefore(container, beforeDiv);
 
   // create the graph/legend divs and spacers
   var div = document.createElement('div');
   div.className = 'perfGraph';
-  parent.insertBefore(div, beforeDiv);
-
-  var gspacer = document.createElement('div');
-  gspacer.className = 'gspacer';
-  parent.insertBefore(gspacer, beforeDiv);
+  container.appendChild(div);
 
   var ldiv = document.createElement('div');
   ldiv.className = 'perfLegend';
-  legend.insertBefore(ldiv, beforeLDiv);
+  container.appendChild(ldiv);
 
-  var lspacer = document.createElement('div');
-  lspacer.className = 'lspacer';
-  legend.insertBefore(lspacer, beforeLDiv);
+  var gspacer = document.createElement('div');
+  gspacer.className = 'gspacer';
+  container.appendChild(gspacer);
 
   function addButtonHelper(buttonText) {
     var button = document.createElement('input');
@@ -244,8 +242,8 @@ function getNextDivs(afterDiv, afterLDiv) {
     return button;
   }
 
-  var logToggle = addButtonHelper('log');
-  var annToggle = addButtonHelper('annotations');
+  var logToggle        = addButtonHelper('log');
+  var annToggle        = addButtonHelper('annotations');
   var screenshotToggle = addButtonHelper('screenshot');
   var closeGraphToggle = addButtonHelper('close');
 
@@ -257,7 +255,7 @@ function getNextDivs(afterDiv, afterLDiv) {
     screenshotToggle: screenshotToggle,
     closeGraphToggle: closeGraphToggle,
     gspacer: gspacer,
-    lspacer: lspacer
+    container: container,
   }
 }
 
@@ -419,7 +417,7 @@ function expandGraphs(graph, graphInfo, graphDivs, graphData, graphLabels) {
     }
     newData = transpose(newData);
 
-    var newDivs = getNextDivs(graphDivs.div, graphDivs.ldiv);
+    var newDivs = getNextDivs(graphDivs.container);
     expandInfo = { colors: newColors }
     genDygraph(newInfo, newDivs, newData, newLabels, expandInfo);
   }
@@ -467,20 +465,14 @@ function setupScreenshotToggle(g, graphInfo, screenshotToggle) {
 
 // g: A DyGraph object
 function hideGraph(g) {
-  $(g.maindiv_).hide();
-  $(g.divs.ldiv).hide();
-  $(g.divs.gspacer).hide();
-  $(g.divs.lspacer).hide();
+  $(g.divs.container).hide();
 }
 
 function showGraph(g) {
   if (g.removed) {
     return;
   }
-  $(g.maindiv_).show();
-  $(g.divs.ldiv).show();
-  $(g.divs.gspacer).show();
-  $(g.divs.lspacer).show();
+  $(g.divs.container).show();
 }
 
 // Setup the close graph button
@@ -519,19 +511,30 @@ function setupCloseGraphToggle(g, graphInfo, closeGraphToggle) {
 // and legend and just render that one.
 function captureScreenshot(g, graphInfo) {
 
-  var gWidth = g.divs.div.clientWidth + g.divs.ldiv.clientWidth;
+  // 100 padding
+  var gWidth = g.divs.div.clientWidth + g.divs.ldiv.clientWidth + 100;
   var gHeight = g.divs.div.clientHeight;
 
   var captureCanvas = document.createElement('canvas');
   captureCanvas.width = gWidth;
   captureCanvas.height = gHeight;
   var ctx = captureCanvas.getContext('2d');
+  var label = graphInfo.ylabel;
+
+  var restoreOpts = {
+    showRoller: true,
+    ylabel: label,
+  };
+
+  var tempOpts = {
+    showRoller: false,
+    ylabel: '',
+  };
 
   // html2canvas doesn't render transformed ccs3 text (like our ylabel.) We
   // make the label inivisible and we also hide the roll button box since
   // theres no point in capturing it in a screenshot
-  g.updateOptions({showRoller: false, ylabel:''});
-  var label = graphInfo.ylabel;
+  g.updateOptions(tempOpts);
 
   // generate the graph
   html2canvas(g.divs.div, {
@@ -559,7 +562,7 @@ function captureScreenshot(g, graphInfo) {
           window.open(captureCanvas.toDataURL());
 
           // restore the roll box and ylabel
-          g.updateOptions({showRoller: true, ylabel:label});
+          g.updateOptions(restoreOpts);
         }
       });
     }
@@ -978,6 +981,7 @@ function perfGraphInit() {
     var elem = document.createElement('div');
     elem.className = 'graph';
     elem.innerHTML = '<input id="graph' + i + '" type="checkbox">' + allGraphs[i].title;
+    elem.title = allGraphs[i].title;
     graphlist.appendChild(elem);
   }
 
@@ -985,10 +989,25 @@ function perfGraphInit() {
 
   setGraphsFromURL();
   displaySelectedGraphs();
-
-  disableFilterBox(false);
 }
 
+// We don't know the width of the graph selection pane until the list of
+// graph names are added. Once that is done figure out the position of pane
+// that holds the dygraphs. This is needed since the graph selection pane
+// is 'fixed' meaning it's outside the normal flow and other elements act
+// like it doesn't exist so we have to manually move the graph display to
+// avoid overlap. After the page is setup, the graph selection pane size
+// only changes if the browser zoom changes.
+function setDygraphPanePos() {
+  var gl = parseInt($("#graphlist").outerWidth());
+  var bm = parseInt($("#buttonMenu").outerWidth());
+  var selectPaneWidth = Math.max(gl, bm);
+  $('#graphSelectionPane').css({ 'width': selectPaneWidth});
+
+  var margin = parseInt($('#graphSelectionPane').outerWidth());
+  $('#graphdisplay').css({ 'margin-left': margin });
+  $('#titleDiv').css({ 'margin-left': margin });
+}
 
 // We use 'fixed' css positioning to keep the graph selection pane always
 // visible (scrolls when the page scrolls.) However we don't want it to scroll
@@ -1011,18 +1030,6 @@ function setupGraphSelectionPane() {
     setGraphListHeight();
     setGraphSelectionPanePos();
   });
-
-  // We don't know the width of the graph selection pane until the list of
-  // graph names are added. Once that is done figure out the position of pane
-  // that holds the dygraphs. This is needed since the graph selection pane
-  // is 'fixed' meaning it's outside the normal flow and other elements act
-  // like it doesn't exist so we have to manually move the graph display to
-  // avoid overlap. After the page is setup, the graph selection pane size
-  // only changes if the browser zoom changes.
-  function setDygraphPanePos() {
-    var selectPaneWidth = parseInt($("#graphSelectionPane").outerWidth());
-    $('#graphdisplay').css({ 'margin-left': selectPaneWidth });
-  }
 
   // set the selection pane's horizontal positional based on the scroll so the
   // selection pane isn't always visible when scrolling horizontally. Some
@@ -1274,9 +1281,8 @@ function selectSuite(suite) {
 
 function displaySelectedGraphs() {
   // Clean up divs
-  while (parent.childNodes.length > 0) {
-    parent.removeChild(parent.childNodes[0]);
-    legend.removeChild(legend.childNodes[0]);
+  while (graphPane.childNodes.length > 0) {
+    graphPane.removeChild(graphPane.childNodes[0]);
   }
 
   // clean up all the dygraphs
@@ -1310,6 +1316,7 @@ function displaySelectedGraphs() {
   setURLFromGraphs(normalizeForURL(findSelectedSuite()));
   // set the dropdown box selection
   document.getElementsByName('jumpmenu')[0].value = findSelectedSuite();
+  setDygraphPanePos();
 }
 
 


### PR DESCRIPTION
This commit is primarily a refactoring and cleanup of the HTML and CSS
we use for our performance graphs. The main refactoring changes are:
- Get rid of tables in index.html
- use CSS IDs over classes when possible
- Eliminate 'legenddisplay' and use a container div for graphs

Some new additions are:
- 'Home' button in upper left corner
- New visual style for existing buttons in graph selection pane
- alt-text for graph pane checkboxes
- The LHS pane border is now dynamically set upon filtering

As a result, the HTML and Javascript are simpler and easier to modify.