### PR TITLE
Fix typos in CPtr.chpl and Statements.tex

### DIFF
--- a/modules/internal/CPtr.chpl
+++ b/modules/internal/CPtr.chpl
@@ -288,7 +288,7 @@ module CPtr {
 
     .. warning::
 
-      This method is intendend for C interoporability. To enhance
+      This method is intended for C interoperability. To enhance
       flexibility, it is possible to request the sizes of Chapel types.
       However, be aware:
 

--- a/modules/internal/CPtr.chpl
+++ b/modules/internal/CPtr.chpl
@@ -401,7 +401,7 @@ module CPtr {
     :arg c: the byte value to use
     :arg n: the number of bytes of b to fill
 
-    :returns: b
+    :returns: s
    */
   inline proc c_memset(s, c:integral, n: integral)
   where isAnyCPtr(s.type) {

--- a/spec/Statements.tex
+++ b/spec/Statements.tex
@@ -853,7 +853,7 @@ associated clean-up action will be executed when the loop running the
 iterator exits. \chpl{defer} actions inside a loop body are executed
 when that iteration completes.
 
-The following progam demonstrates a simple use of \chpl{defer}
+The following program demonstrates a simple use of \chpl{defer}
 to create an action to be executed when returning from a function:
 
 \begin{chapelexample}{defer1.chpl}


### PR DESCRIPTION
Fix typos in CPtr.chpl and Statements.tex