### PR TITLE
Tidy up CPtr.chpl chpldocs, add it to generated list

### DIFF
--- a/modules/Makefile
+++ b/modules/Makefile
@@ -128,19 +128,20 @@ DISTS_TO_DOCUMENT = \
 	dists/dims/ReplicatedDim.chpl \
 	layouts/LayoutCSR.chpl \
 
-INTERNAL_MODULES_TO_DOCUMENT =          \
+INTERNAL_MODULES_TO_DOCUMENT =                \
 	internal/Atomics.chpl                 \
 	internal/ChapelArray.chpl             \
 	internal/ChapelComplex_forDocs.chpl   \
 	internal/ChapelIO.chpl                \
 	internal/ChapelIteratorSupport.chpl   \
-	internal/ChapelLocale.chpl    \
+	internal/ChapelLocale.chpl            \
 	internal/UtilMisc_forDocs.chpl 	      \
 	internal/ChapelRange.chpl             \
 	internal/String.chpl                  \
 	internal/ChapelSyncvar.chpl           \
-	internal/ChapelTuple.chpl \
-	internal/ChapelEnv.chpl
+	internal/ChapelTuple.chpl             \
+	internal/ChapelEnv.chpl               \
+	internal/CPtr.chpl
 
 
 documentation: $(SYS_CTYPES_MODULE_DOC)

--- a/modules/internal/CPtr.chpl
+++ b/modules/internal/CPtr.chpl
@@ -43,15 +43,15 @@ module CPtr {
     Represents a local C pointer for the purpose of C integration. This class
     represents the equivalent to a C language pointer. Instances of this class
     support assignment to other instances or nil, == or != comparison with a
-    c_void_ptr or with nil, and casting to another c_ptr type or to the
-    c_void_ptr type.
+    `c_void_ptr` or with `nil`, and casting to another `c_ptr` type or to the
+    `c_void_ptr` type.
 
-    As with a Chapel class, a c_ptr can be tested non-nil simply
+    As with a Chapel class, a `c_ptr` can be tested non-nil simply
     by including it in an if statement conditional, like so:
 
     .. code-block:: chapel
 
-      var x: c_ptr;
+      var x: c_ptr = c_ptrTo(...);
       if x then do writeln("x is not nil");
       if !x then do writeln("x is nil");
 

--- a/modules/internal/CPtr.chpl
+++ b/modules/internal/CPtr.chpl
@@ -17,7 +17,13 @@
  * limitations under the License.
  */
 
-/* A Chapel version of a C pointer. */
+/*
+   This module contains Chapel types that can serve as C pointer
+   types for the purposes of interoperability and methods to work
+   with them.
+
+   See also :ref:`readme-extern`.
+ */
 module CPtr {
   use ChapelStandard;
 
@@ -26,16 +32,22 @@ module CPtr {
 
   // To generate legal C prototypes, we have to manually instantiate this
   // prototype for each pointer type that might be associated with 'x'.
+
   /* :returns: true if the passed value is a NULL pointer (ie 0) */
   pragma "no prototype"
+  pragma "no doc"
   extern proc is_c_nil(x):bool;
 
   /*
-    A local C pointer class used in C integration. This class represents the
-    equivalent to a C language pointer. Instances of this class support
-    assignment to other instances or nil, == or != comparison with a c_void_ptr
-    or with nil, and casting to another c_ptr type or to the c_void_ptr type.
-    In addition, c_ptr works within an if statement directly like so:
+
+    Represents a local C pointer for the purpose of C integration. This class
+    represents the equivalent to a C language pointer. Instances of this class
+    support assignment to other instances or nil, == or != comparison with a
+    c_void_ptr or with nil, and casting to another c_ptr type or to the
+    c_void_ptr type.
+
+    As with a Chapel class, a c_ptr can be tested non-nil simply
+    by including it in an if statement conditional, like so:
 
     .. code-block:: chapel
 
@@ -216,12 +228,14 @@ module CPtr {
   extern proc c_pointer_return(ref x:?t):c_ptr(t);
 
 
-  /* Returns a :type:`c_ptr` to a Chapel rectangular array.
-    Note that the existence of this c_ptr has no impact on the lifetime of the
-    array. The returned pointer will be invalid if the original array is
-    freed or even reallocated. Any domain assignment will probably make
-    this c_ptr invalid. If the array's data is stored in more than one chunk
-    the procedure will halt the program with an error message.
+  /*
+
+    Returns a :type:`c_ptr` to a Chapel rectangular array.  Note that the
+    existence of this :type:`c_ptr` has no impact on the lifetime of the array.
+    The returned pointer will be invalid if the original array is freed or even
+    reallocated. Domain assignment could make this c_ptr invalid. If
+    the array's data is stored in more than one chunk the procedure will halt
+    the program with an error message.
 
     :arg arr: the array for which we should retrieve a pointer
     :returns: a pointer to the array data
@@ -252,7 +266,7 @@ module CPtr {
   /* Returns a :type:`c_ptr` to any Chapel object.
     Note that the existence of the c_ptr has no impact of the lifetime
     of the object. In many cases the object will be stack allocated and
-    could go out of scope even if this c_ptr remains.
+    could go out of scope even if this :type:`c_ptr` remains.
 
     :arg x: the by-reference argument to get a pointer to. The argument should
             not be an array or domain (there is a different overload for arrays).
@@ -270,12 +284,15 @@ module CPtr {
     return c_pointer_return(x);
   }
 
+  pragma "no doc"
   inline proc c_ptrTo(x: c_fn_ptr) {
     return x;
   }
+  pragma "no doc"
   proc c_fn_ptr.this() {
     compilerError("Can't call a C function pointer within Chapel");
   }
+  pragma "no doc"
   proc c_fn_ptr.this(args...) {
     compilerError("Can't call a C function pointer within Chapel");
   }
@@ -346,7 +363,7 @@ module CPtr {
   proc isAnyCPtr(type t) param return false;
 
   /*
-    Copies n (potentially overlapping) bytes from memory area src to memory
+    Copies n potentially overlapping bytes from memory area src to memory
     area dest.
 
     This is a simple wrapper over the C memmove() function.
@@ -362,7 +379,7 @@ module CPtr {
   }
 
   /*
-    Copies n (non-overlapping) bytes from memory area src to memory
+    Copies n non-overlapping bytes from memory area src to memory
     area dest. Use :proc:`c_memmove` if memory areas do overlap.
 
     This is a simple wrapper over the C memcpy() function.
@@ -401,7 +418,7 @@ module CPtr {
     :arg c: the byte value to use
     :arg n: the number of bytes of b to fill
 
-    :returns: b
+    :returns: s
    */
   inline proc c_memset(s, c:integral, n: integral)
   where isAnyCPtr(s.type) {

--- a/modules/internal/CPtr.chpl
+++ b/modules/internal/CPtr.chpl
@@ -43,10 +43,10 @@ module CPtr {
     Represents a local C pointer for the purpose of C integration. This class
     represents the equivalent to a C language pointer. Instances of this class
     support assignment to other instances or nil, == or != comparison with a
-    `c_void_ptr` or with `nil`, and casting to another `c_ptr` type or to the
-    `c_void_ptr` type.
+    ``c_void_ptr`` or with ``nil``, and casting to another ``c_ptr`` type or to
+    the ``c_void_ptr`` type.
 
-    As with a Chapel class, a `c_ptr` can be tested non-nil simply
+    As with a Chapel class, a ``c_ptr`` can be tested non-nil simply
     by including it in an if statement conditional, like so:
 
     .. code-block:: chapel
@@ -233,7 +233,7 @@ module CPtr {
     Returns a :type:`c_ptr` to a Chapel rectangular array.  Note that the
     existence of this :type:`c_ptr` has no impact on the lifetime of the array.
     The returned pointer will be invalid if the original array is freed or even
-    reallocated. Domain assignment could make this c_ptr invalid. If
+    reallocated. Domain assignment could make this :type:`c_ptr` invalid. If
     the array's data is stored in more than one chunk the procedure will halt
     the program with an error message.
 
@@ -264,7 +264,7 @@ module CPtr {
   }
 
   /* Returns a :type:`c_ptr` to any Chapel object.
-    Note that the existence of the c_ptr has no impact of the lifetime
+    Note that the existence of the :type:`c_ptr` has no impact of the lifetime
     of the object. In many cases the object will be stack allocated and
     could go out of scope even if this :type:`c_ptr` remains.
 
@@ -301,7 +301,7 @@ module CPtr {
   private extern const CHPL_RT_MD_ARRAY_ELEMENTS:chpl_mem_descInt_t;
 
   /*
-    Return the size in bytes of a type, as with the C `sizeof` built-in.
+    Return the size in bytes of a type, as with the C ``sizeof`` built-in.
 
     .. warning::
 
@@ -310,7 +310,7 @@ module CPtr {
       However, be aware:
 
          * Chapel types are not necessarily stored in contiguous memory
-         * Behavior of `c_sizeof` with Chapel types may change
+         * Behavior of ``c_sizeof`` with Chapel types may change
          * Behavior given a Chapel class type is not well-defined
    */
   inline proc c_sizeof(type x): size_t {
@@ -366,7 +366,7 @@ module CPtr {
     Copies n potentially overlapping bytes from memory area src to memory
     area dest.
 
-    This is a simple wrapper over the C memmove() function.
+    This is a simple wrapper over the C ``memmove()`` function.
 
     :arg dest: the destination memory area to copy to
     :arg src: the source memory area to copy from
@@ -397,7 +397,7 @@ module CPtr {
   /*
     Compares the first n bytes of memory areas s1 and s2
 
-    This is a simple wrapper over the C memcmp() function.
+    This is a simple wrapper over the C ``memcmp()`` function.
 
     :returns: returns an integer less than, equal to, or greater than zero if
               the first n bytes of s1 are found, respectively, to be less than,
@@ -412,7 +412,7 @@ module CPtr {
   /*
     Fill bytes of memory with a particular byte value.
 
-    This is a simple wrapper over the C memset() function.
+    This is a simple wrapper over the C ``memset()`` function.
 
     :arg s: the destination memory area to fill
     :arg c: the byte value to use

--- a/modules/internal/fixInternalDocs.sh
+++ b/modules/internal/fixInternalDocs.sh
@@ -246,4 +246,11 @@ fixTitle "Chapel Environment Variables" $file
 replace " = AppendExpr.Call09" "" $file
 removeUsage $file
 
-## End of ChapelEnv##
+## End of ChapelEnv ##
+
+## CPtr ##
+
+file="./CPtr.rst"
+removeUsage $file
+
+## End of CPtr ##


### PR DESCRIPTION
I recently noticed we were chpldoc'ing these functions but never rendering them.

Future Work: generalize to document all C types, functions, and methods discussed in the C-interop documentation extern.rst.

Reviewed by @ben-albrecht - thanks!