### PR TITLE
Fix PRIM_WIDE_MAKE for NUMA locale model

### DIFF
--- a/compiler/codegen/expr.cpp
+++ b/compiler/codegen/expr.cpp
@@ -3543,7 +3543,8 @@ GenRet CallExpr::codegenPrimitive() {
 
 
     ret = codegenCast(narrowType, raddr, true);
-    if (fLocal == false) {
+
+    if (requireWideReferences()) {
       ret = codegenWideAddr(locale, ret);
     }
 


### PR DESCRIPTION
NUMA locale model uses wide pointers too; just checking fLocal was too simplistic.

Checked that Hello works with
 * NUMA qthreads
 * NUMA qthreads + gasnet
 * flat qthreads
 * flat qthreads + gasnet

Trivial and not reviewed.