### PR TITLE
Fix const record init error

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -2376,6 +2376,7 @@ FlagSet getRecordWrappedFlags(Symbol* s) {
 const char* astrSdot = NULL;
 const char* astrSequals = NULL;
 const char* astr_cast = NULL;
+const char* astrInit = NULL;
 const char* astrDeinit = NULL;
 const char* astrTag = NULL;
 const char* astrThis = NULL;
@@ -2384,6 +2385,7 @@ void initAstrConsts() {
   astrSdot    = astr(".");
   astrSequals = astr("=");
   astr_cast   = astr("_cast");
+  astrInit    = astr("init");
   astrDeinit  = astr("deinit");
   astrTag     = astr("tag");
   astrThis    = astr("this");

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -654,6 +654,7 @@ const char* intentDescrString(IntentTag intent);
 extern const char* astrSdot;
 extern const char* astrSequals;
 extern const char* astr_cast;
+extern const char* astrInit;
 extern const char* astrDeinit;
 extern const char* astrTag;
 extern const char* astrThis;

--- a/compiler/resolution/cullOverReferences.cpp
+++ b/compiler/resolution/cullOverReferences.cpp
@@ -2111,6 +2111,11 @@ static void lateConstCheck(std::map<BaseAST*, BaseAST*> & reasonNotConst)
           error = false;
         }
 
+        // A 'const' record should be able to be initialized
+        if (calledFn->name == astrInit) {
+          error = false;
+        }
+
         // For now, ignore errors with tuple construction/build_tuple
         if (calledFn->hasFlag(FLAG_BUILD_TUPLE) ||
             (calledFn->hasFlag(FLAG_CONSTRUCTOR) &&

--- a/test/classes/initializers/records/const-record.bad
+++ b/test/classes/initializers/records/const-record.bad
@@ -1,5 +1,0 @@
-const-record.chpl:10: error: const actual is passed to 'ref' formal 'this' of init()
-const-record.chpl:2: note: to formal of type Foo
-const-record.chpl:6: note: passed as ref here
-const-record.chpl:3: note: to ref formal here
-const-record.chpl:6: note: passed as ref here

--- a/test/classes/initializers/records/const-record.future
+++ b/test/classes/initializers/records/const-record.future
@@ -1,1 +1,0 @@
-bug: compiler error when initializing const record


### PR DESCRIPTION
PR #6818 added a future for a bug @benharsh noticed. This PR makes a simple change to fix the bug. While there, it adds `astrInit` for use by the compiler, next to `astrDeinit`.

Passed full local testing.
Reviewed by @benharsh - thanks!