### PR TITLE
Fix forVersusWhilePerf.chpl

### DIFF
--- a/test/statements/lydia/forVersusWhilePerf.c
+++ b/test/statements/lydia/forVersusWhilePerf.c
@@ -15,16 +15,13 @@ static double now_time(void) {
     (double)(t.tv_usec);
 }
 
-static const int numIters = 1000000;
-static const int ntrials = 10000;
+int64_t numIters = 1000000;
+int64_t ntrials = 10000;
 
-int c_trial() {
-  int i, j;
-  double starttimeFor, endtimeFor;
-  double starttimeWhile, endtimeWhile;
-  int result = 0;
-  int result2 = 0;
-  starttimeFor = now_time();
+int64_t for_loop()
+{
+  int64_t result = 0;
+  int64_t i, j;
   for (i = 0; i < ntrials; i++) {
     for (j = 0; j < numIters; j++) {
       if (j % 2 == 1) {
@@ -34,9 +31,13 @@ int c_trial() {
       }
     }
   }
-  endtimeFor = now_time();
-  starttimeWhile = now_time();
-  i = 0;
+  return result;
+}
+
+int64_t while_loop()
+{
+  int64_t result2 = 0;
+  int64_t i = 0, j;
   while (i < ntrials) {
     j = 0;
     while (j < numIters) {
@@ -49,15 +50,26 @@ int c_trial() {
     }
     i++;
   }
+  return result2;
+}
+
+int64_t c_trial() {
+  double starttimeFor, endtimeFor;
+  double starttimeWhile, endtimeWhile;
+  starttimeFor = now_time();
+  int64_t result = for_loop();
+  endtimeFor = now_time();
+  starttimeWhile = now_time();
+  int64_t result2 = while_loop();
   endtimeWhile = now_time();
 
   if (result != result2) {
-    printf("These results should have matched, got %d and %d\n", result, result2);
+    printf("These results should have matched, got %ld and %ld\n", result, result2);
   } else {
     printf("C verification successful\n");
   }
-  printf("C for loop took %f seconds for %d iterations %d times\n", (endtimeFor-starttimeFor)/(1000*1000), numIters, ntrials);
-  printf("C while loop took %f seconds for %d iterations %d times\n", (endtimeWhile-starttimeWhile)/(1000*1000), numIters, ntrials);
+  printf("C for loop took %f seconds for %ld iterations %ld times\n", (endtimeFor-starttimeFor)/(1000*1000), numIters, ntrials);
+  printf("C while loop took %f seconds for %ld iterations %ld times\n", (endtimeWhile-starttimeWhile)/(1000*1000), numIters, ntrials);
 
   return result;
 }

--- a/test/statements/lydia/forVersusWhilePerf.chpl
+++ b/test/statements/lydia/forVersusWhilePerf.chpl
@@ -32,7 +32,7 @@ proc while_loop()
       else
         res2 = res2 / 2;
       j += 1;
-    } 
+    }
     i += 1;
   }
   return res2;
@@ -54,7 +54,7 @@ proc main() {
   
   if verbose {
     writeln("For loop underwent ", numIterations, " iterations ", numTrials,
-            " times in ", t1.elapsed(TimeUnits.milliseconds)/1000, " seconds");
+          " times in ", t1.elapsed(TimeUnits.milliseconds)/1000, " seconds");
     writeln("While loop underwent ", numIterations, " iterations ", numTrials,
           " times in ", t2.elapsed(TimeUnits.milliseconds)/1000, " seconds");
     var res3 = c_trial();

--- a/test/statements/lydia/forVersusWhilePerf.chpl
+++ b/test/statements/lydia/forVersusWhilePerf.chpl
@@ -4,12 +4,11 @@ config const numIterations = 1000000;
 config const numTrials = 10000;
 config const verbose = false;
 
-extern proc c_trial(): int;
+extern proc c_trial(): int(64);
 
-proc main() {
-  var t1, t2: Timer;
-  var res1, res2 = 0;
-  t1.start();
+proc for_loop()
+{
+  var res1 = 0;
   for i in 1..#numTrials {
     for j in 1..#numIterations {
       if j % 2 == 0 then
@@ -18,8 +17,12 @@ proc main() {
         res1 = res1 / 2;
     }
   }
-  t1.stop();
-  t2.start();
+  return res1;
+}
+
+proc while_loop()
+{
+  var res2 = 0;
   var i = 0;
   while (i < numTrials) {
     var j = 0;
@@ -29,9 +32,19 @@ proc main() {
       else
         res2 = res2 / 2;
       j += 1;
-    }
+    } 
     i += 1;
   }
+  return res2;
+}
+
+proc main() {
+  var t1, t2: Timer;
+  t1.start();
+  var res1 = for_loop();
+  t1.stop();
+  t2.start();
+  var res2 = while_loop();
   t2.stop();
   if (res1 != res2) {
     writeln("These results should have matched, got ", res1, " and ", res2);
@@ -43,7 +56,7 @@ proc main() {
     writeln("For loop underwent ", numIterations, " iterations ", numTrials,
             " times in ", t1.elapsed(TimeUnits.milliseconds)/1000, " seconds");
     writeln("While loop underwent ", numIterations, " iterations ", numTrials,
-            " times in ", t2.elapsed(TimeUnits.milliseconds)/1000, " seconds");
+          " times in ", t2.elapsed(TimeUnits.milliseconds)/1000, " seconds");
     var res3 = c_trial();
     if (res1 != res3) {
       writeln("Chapel results did not match C results");

--- a/test/statements/lydia/forVersusWhilePerf.h
+++ b/test/statements/lydia/forVersusWhilePerf.h
@@ -1,1 +1,3 @@
-int c_trial(void);
+int64_t c_trial(void);
+int64_t for_loop(void);
+int64_t while_loop(void);


### PR DESCRIPTION
Looking at current performance graphs one can notice that in case of LLVM chapel's version of this test there is slight performance degradation, after some investigation I realized that this test is not written well due to few factors:

- Chapel's default size for integer is 64-bits while in case of C it is usually 32-bits, so the tests had different performance due to usage of different types of integers, in this case there was better performance for C version.
- Chapel's version cannot perform constant propagation due to marking variables as "config const". C's version uses "static const" what enables to do constant propagation which reduces register pressure, that in this case made some difference.

After changing all "int" to "int64_t" and "static const int64_t" to "int64_t" the Chapel's version performance closely matches the C version performance.

I guess @lydia-duncan is the best person to review this PR since she wrote those tests in first place.