### PR TITLE
Propagate Chapel-managed state in comm-ugni fork_call_common

### DIFF
--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -5562,7 +5562,8 @@ void fork_call_common(int locale, c_sublocid_t subloc,
                                 .fast         = do_fast_fork,
                                 .blocking     = blocking,
                                 .payload_size = payload_size,
-                                .fid          = fid };
+                                .fid          = fid,
+                                .state        = arg->task_bundle.state };
 
   fork_small_call_info_t *f_sc = &f.sc;
 


### PR DESCRIPTION
This is a follow-on to PR #6765.
It should fix testing failures with SSCA2 and CHPL_COMM=ugni.

Verified that the following tests that were failing with CHPL_COMM=ugni now pass:
 * parallel/bundles/bundles-multilocale.chpl
 * release/examples/benchmarks/ssca2/SSCA2_main

Additionally verified that the hello tests still pass.

Trivial and not reviewed.