### PR TITLE
Add a new .compopts file to suppress a new warning message from cce/8.6.*

### DIFF
--- a/test/release/examples/users-guide/base/floatValues.compopts
+++ b/test/release/examples/users-guide/base/floatValues.compopts
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+
+# With cce/8.6.0.*, floatValues.chpl emits new warning messages like,
+#
+# CC-1046 craycc: WARNING File = floatValues.c, Line = 39
+#   The floating-point value cannot be represented exactly.
+#   myReal_chpl = 0x1p-1;
+#                 ^
+#
+# which earlier cce versions did not. This suppresses that warning message.
+
+import os
+
+if os.getenv('CHPL_TARGET_COMPILER', '') == 'cray-prgenv-cray':
+    print('--ccflags -hnomessage=1046')
+else:
+    # sub_test throws a warning in the console log if the compopts string is empty,
+    # and that makes the test result a "Warning" instead of "Success".
+    # This --cc-warnings seems to be a harmless, non-null compopts string.
+    print('--cc-warnings')


### PR DESCRIPTION
Adds -hnomessage=1046 for Cray cce compiler, to suppress this warning message in 
examples/users-guide/base/floatValues.chpl  : 

CC-1046 craycc: WARNING File = floatValues.c, Line = 39

  The floating-point value cannot be represented exactly.
  myReal_chpl = 0x1p-1;

