### PR TITLE
Converted withClause() to forallIntents() in ForallStmt

### DIFF
--- a/compiler/AST/AstCount.cpp
+++ b/compiler/AST/AstCount.cpp
@@ -180,6 +180,14 @@ void AstCount::visitForallIntents(ForallIntents* clause) {
   numForallIntents++;
 }
 
+bool AstCount::enterForallIntent(ForallIntent* intent) {
+  numForallIntent++;
+  return true;
+}
+
+void AstCount::exitForallIntent(ForallIntent* intent) {
+}
+
 bool AstCount::enterForallStmt(ForallStmt* node)
 {
   numForallStmt++;

--- a/compiler/AST/AstLogger.cpp
+++ b/compiler/AST/AstLogger.cpp
@@ -130,6 +130,13 @@ void AstLogger::exitBlockStmt(BlockStmt* node) {
 void AstLogger::visitForallIntents(ForallIntents* clause) {
 }
 
+bool AstLogger::enterForallIntent(ForallIntent* intent) {
+  return true;
+}
+
+void AstLogger::exitForallIntent(ForallIntent* intent) {
+}
+
 bool AstLogger::enterForallStmt(ForallStmt* node) {
   return true;
 }

--- a/compiler/AST/AstPrintDocs.cpp
+++ b/compiler/AST/AstPrintDocs.cpp
@@ -176,6 +176,11 @@ bool AstPrintDocs::enterBlockStmt(BlockStmt* node) {
 }
 
 
+bool AstPrintDocs::enterForallIntent(ForallIntent* intent) {
+  return false;
+}
+
+
 bool AstPrintDocs::enterForallStmt(ForallStmt* node) {
   return false;
 }

--- a/compiler/AST/AstVisitorTraverse.cpp
+++ b/compiler/AST/AstVisitorTraverse.cpp
@@ -178,6 +178,16 @@ void AstVisitorTraverse::visitForallIntents(ForallIntents* clause)
 
 }
 
+bool AstVisitorTraverse::enterForallIntent(ForallIntent* intent)
+{
+  return true;
+}
+
+void AstVisitorTraverse::exitForallIntent(ForallIntent* intent)
+{
+
+}
+
 bool AstVisitorTraverse::enterForallStmt(ForallStmt* node)
 {
   return true;

--- a/compiler/AST/CollapseBlocks.cpp
+++ b/compiler/AST/CollapseBlocks.cpp
@@ -141,6 +141,12 @@ void CollapseBlocks::visitForallIntents(ForallIntents* clause) {
   INT_ASSERT(false);
 }
 
+bool CollapseBlocks::enterForallIntent(ForallIntent* intent) {
+  // This should not be invoked.
+  INT_ASSERT(false);
+  return false;
+}
+
 bool CollapseBlocks::enterForallStmt(ForallStmt* node) {
   return enterBlockStmt(node->loopBody());
 }
@@ -338,6 +344,11 @@ void CollapseBlocks::visitUseStmt(UseStmt* node)
 }
 
 void CollapseBlocks::exitBlockStmt(BlockStmt* node)
+{
+
+}
+
+void CollapseBlocks::exitForallIntent(ForallIntent* intent)
 {
 
 }

--- a/compiler/AST/baseAST.cpp
+++ b/compiler/AST/baseAST.cpp
@@ -84,9 +84,9 @@ void printStatistics(const char* pass) {
   int nStmt = nBlockStmt + nCondStmt + nDeferStmt + nGotoStmt + nUseStmt + nExternBlockStmt + nForallStmt + nTryStmt + nForwardingStmt + nCatchStmt;
   int kStmt = kBlockStmt + kCondStmt + kDeferStmt + kGotoStmt + kUseStmt + kExternBlockStmt + kForallStmt + kTryStmt + kForwardingStmt + kCatchStmt;
   int nExpr = nUnresolvedSymExpr + nSymExpr + nDefExpr + nCallExpr +
-    nContextCallExpr + nForallExpr + nNamedExpr;
+    nContextCallExpr + nForallExpr + nForallIntent+ nNamedExpr;
   int kExpr = kUnresolvedSymExpr + kSymExpr + kDefExpr + kCallExpr +
-    kContextCallExpr + kForallExpr + kNamedExpr;
+    kContextCallExpr + kForallExpr + kForallIntent + kNamedExpr;
   int nSymbol = nModuleSymbol+nVarSymbol+nArgSymbol+nTypeSymbol+nFnSymbol+nEnumSymbol+nLabelSymbol;
   int kSymbol = kModuleSymbol+kVarSymbol+kArgSymbol+kTypeSymbol+kFnSymbol+kEnumSymbol+kLabelSymbol;
   int nType = nPrimitiveType+nEnumType+nAggregateType;
@@ -478,6 +478,10 @@ const char* BaseAST::astTagAsString() const {
 
     case E_ForwardingStmt:
       retval = "ForwardingStmt";
+      break;
+
+    case E_ForallIntent:
+      retval = "ForallIntent";
       break;
 
     case E_ForallStmt:

--- a/compiler/AST/foralls.cpp
+++ b/compiler/AST/foralls.cpp
@@ -733,7 +733,7 @@ void lowerForallStmts() {
     if (parent->isIterator() && !parent->hasFlag(FLAG_INLINE_ITERATOR))
       USR_FATAL_CONT(fs, "invalid use of parallel construct in serial iterator");
 
-    // Forall intents aka fs->withClause() should have already been handled.
+    // Forall intents aka fs->forallIntents() should have already been handled.
 
     CallExpr* parIterCall = toCallExpr(fs->firstIteratedExpr());
     INT_ASSERT(parIterCall && !parIterCall->next); // expected

--- a/compiler/AST/view.cpp
+++ b/compiler/AST/view.cpp
@@ -135,7 +135,7 @@ list_ast(BaseAST* ast, BaseAST* parentAst = NULL, int indent = 0) {
       if (expr == pfs->loopBody()) {
         printf("\n%6c", ' ');
         for (int i = 0; i < indent; i++) printf(" ");
-        if (pfs->withClause()->numVars() == 0)
+        if (pfs->numForallIntents() == 0)
           printf("with() ");
         printf("do\n");
         indent -= 2;
@@ -272,7 +272,7 @@ list_ast(BaseAST* ast, BaseAST* parentAst = NULL, int indent = 0) {
         for (int i = 0; i < indent; i++) printf(" ");
         printf("in%s", pfs->zippered() ? " zip" : "");
       } else if (expr == pfs->iteratedExpressions().tail &&
-                 pfs->withClause()->numVars() > 0)
+                 pfs->numForallIntents() > 0)
       {
         printf("\n      ");
         for (int i = 0; i < indent; i++) printf(" ");

--- a/compiler/include/AstCount.h
+++ b/compiler/include/AstCount.h
@@ -107,6 +107,9 @@ foreach_ast(decl_members);
   virtual void   exitBlockStmt       (BlockStmt*         node);
 
   virtual void   visitForallIntents  (ForallIntents*   clause);
+  virtual bool   enterForallIntent   (ForallIntent*    intent);
+  virtual void   exitForallIntent    (ForallIntent*    intent);
+
   virtual bool   enterForallStmt     (ForallStmt*        node);
   virtual void   exitForallStmt      (ForallStmt*        node);
 

--- a/compiler/include/AstLogger.h
+++ b/compiler/include/AstLogger.h
@@ -91,6 +91,9 @@ public:
   virtual void   exitBlockStmt       (BlockStmt*         node);
 
   virtual void   visitForallIntents  (ForallIntents*   clause);
+  virtual bool   enterForallIntent   (ForallIntent*    intent);
+  virtual void   exitForallIntent    (ForallIntent*    intent);
+
   virtual bool   enterForallStmt     (ForallStmt*        node);
   virtual void   exitForallStmt      (ForallStmt*        node);
 

--- a/compiler/include/AstPrintDocs.h
+++ b/compiler/include/AstPrintDocs.h
@@ -44,6 +44,7 @@ public:
 
   virtual bool   enterBlockStmt   (BlockStmt*         node);
   virtual bool   enterForallStmt  (ForallStmt*        node);
+  virtual bool   enterForallIntent(ForallIntent*    intent);
   virtual bool   enterWhileDoStmt (WhileDoStmt*       node);
   virtual bool   enterDoWhileStmt (DoWhileStmt*       node);
   virtual bool   enterCForLoop    (CForLoop*          node);

--- a/compiler/include/AstVisitor.h
+++ b/compiler/include/AstVisitor.h
@@ -42,6 +42,7 @@ class UnresolvedSymExpr;
 class UseStmt;
 class BlockStmt;
 class ForallIntents;
+class ForallIntent;
 class ForallStmt;
 class WhileDoStmt;
 class DoWhileStmt;
@@ -131,6 +132,9 @@ public:
   virtual void   exitBlockStmt       (BlockStmt*         node) = 0;
 
   virtual void   visitForallIntents  (ForallIntents*   clause) = 0;
+  virtual bool   enterForallIntent   (ForallIntent*    intent) = 0;
+  virtual void   exitForallIntent    (ForallIntent*    intent) = 0;
+
   virtual bool   enterForallStmt     (ForallStmt*        node) = 0;
   virtual void   exitForallStmt      (ForallStmt*        node) = 0;
 

--- a/compiler/include/AstVisitorTraverse.h
+++ b/compiler/include/AstVisitorTraverse.h
@@ -99,6 +99,9 @@ public:
   virtual void   exitBlockStmt       (BlockStmt*         node);
 
   virtual void   visitForallIntents  (ForallIntents*   clause);
+  virtual bool   enterForallIntent   (ForallIntent*    intent);
+  virtual void   exitForallIntent    (ForallIntent*    intent);
+
   virtual bool   enterForallStmt     (ForallStmt*        node);
   virtual void   exitForallStmt      (ForallStmt*        node);
 

--- a/compiler/include/CollapseBlocks.h
+++ b/compiler/include/CollapseBlocks.h
@@ -87,6 +87,9 @@ public:
   virtual void   exitBlockStmt       (BlockStmt*         node);
 
   virtual void   visitForallIntents  (ForallIntents*   clause);
+  virtual bool   enterForallIntent   (ForallIntent*    intent);
+  virtual void   exitForallIntent    (ForallIntent*    intent);
+
   virtual bool   enterForallStmt     (ForallStmt*        node);
   virtual void   exitForallStmt      (ForallStmt*        node);
 

--- a/compiler/include/ForallStmt.h
+++ b/compiler/include/ForallStmt.h
@@ -22,7 +22,47 @@
 
 #include "stmt.h"
 
-// forall loop statement
+
+//////////////////////////
+    // a forall intent //
+   //////////////////////////
+
+class ForallIntent : public Expr 
+{
+public:
+  TFITag intent()      const;
+  Expr*  variable()    const;  // non-NULL always
+  Expr*  reduceExpr()  const;  // non-NULL only for reduce intents
+  bool   isReduce()    const;
+
+  ForallIntent(TFITag intent, Expr* var, Expr* reduceExpr = NULL);
+
+  // Expr interface
+  DECLARE_COPY(ForallIntent);
+  virtual void    replaceChild(Expr* old_ast, Expr* new_ast);
+  virtual Expr*   getFirstChild();
+  virtual Expr*   getFirstExpr();
+  virtual Expr*   getNextExpr(Expr* expr);
+  virtual void    verify();
+  virtual GenRet  codegen();
+  virtual void    accept(AstVisitor* visitor);
+
+private:
+  TFITag fiIntent;
+  Expr*  fiVar;
+  Expr*  riSpec;
+};
+
+// accessor implementations
+inline TFITag ForallIntent::intent()     const { return fiIntent; }
+inline Expr*  ForallIntent::variable()   const { return fiVar; }
+inline Expr*  ForallIntent::reduceExpr() const { return riSpec; }
+inline bool   ForallIntent::isReduce()   const { return fiIntent==TFI_REDUCE; }
+
+
+///////////////////////////////////
+    // forall loop statement //
+///////////////////////////////////
 
 class ForallStmt : public Stmt
 {
@@ -32,10 +72,8 @@ public:
   AList&     iteratedExpressions();  // SymExprs, CallExprs
   AList&     intentVariables();      // (future) DefExprs of LoopIntentVars
   BlockStmt* loopBody()       const; // the body of the forall loop
-  // todo: remove this in favor of intentVariables
-  ForallIntents* withClause() const; // forall intents
-
-  ~ForallStmt();
+  // todo: remove 'forallIntents' in favor of intentVariables()
+  AList&     forallIntents();        // forall intents
 
   DECLARE_COPY(ForallStmt);
 
@@ -52,33 +90,42 @@ public:
   static BlockStmt* build(Expr* indices, Expr* iterator, ForallIntents* fi,
                           BlockStmt* body, bool zippered = false);
   // helpers
-  Expr* firstIteratedExpr() const;
-  int   numIteratedExprs() const;
-  bool isIteratedExpression(Expr* expr);
-  int  reduceIntentIdx(Symbol* var); // todo: replace with LoopIntentVars
+  Expr* firstIteratedExpr()        const;
+  int   numIteratedExprs()         const;
+  bool  isIteratedExpression(Expr* expr);
+  int   reduceIntentIdx(Symbol* var); // todo: replace with ForallIntents
+  int           numForallIntents()         const;
+  ForallIntent* getForallIntent(int index) const; //todo use LoopIntentVars
 
 private:
   bool           fZippered;
   AList          fIterVars;
   AList          fIterExprs;
   AList          fIntentVars;  // may be empty
+  AList          fFIntents;    // todo: use fIntentVars instead
   BlockStmt*     fLoopBody;    // always present
-  ForallIntents* fWith;   // always present; todo: replace with intentVariables
 
-  ForallStmt(bool zippered, BlockStmt* body, ForallIntents* with);
+  ForallStmt(bool zippered, BlockStmt* body);
 };
 
 // accessor implementations
-inline bool   ForallStmt::zippered() const       { return fZippered; }
-inline AList& ForallStmt::inductionVariables()   { return fIterVars; }
-inline AList& ForallStmt::iteratedExpressions()  { return fIterExprs; }
+inline bool   ForallStmt::zippered()       const { return fZippered;   }
+inline AList& ForallStmt::inductionVariables()   { return fIterVars;   }
+inline AList& ForallStmt::iteratedExpressions()  { return fIterExprs;  }
 inline AList& ForallStmt::intentVariables()      { return fIntentVars; }
-inline BlockStmt*     ForallStmt::loopBody()   const { return fLoopBody; }
-inline ForallIntents* ForallStmt::withClause() const { return fWith; }
+inline AList& ForallStmt::forallIntents()        { return fFIntents;   }
+inline BlockStmt* ForallStmt::loopBody()   const { return fLoopBody;   }
 
 // conveniences
-inline Expr* ForallStmt::firstIteratedExpr() const { return fIterExprs.head; }
-inline int   ForallStmt::numIteratedExprs() const { return fIterExprs.length; }
+inline Expr* ForallStmt::firstIteratedExpr() const { return fIterExprs.head;  }
+inline int   ForallStmt::numIteratedExprs()  const { return fIterExprs.length;}
+inline int   ForallStmt::numForallIntents()  const { return fFIntents.length; }
+inline ForallIntent* ForallStmt::getForallIntent(int index) const
+  { return toForallIntent(fFIntents.get(index)); }
+
+#define for_forall_intents(FI,TEMP,FS)           \
+  for_alist(TEMP,(FS)->forallIntents())          \
+    if (ForallIntent* FI = toForallIntent(TEMP))
 
 // helpers
 ForallStmt* enclosingForallStmt(Expr* expr);

--- a/compiler/include/baseAST.h
+++ b/compiler/include/baseAST.h
@@ -71,6 +71,7 @@
   macro(CondStmt) sep                              \
   macro(GotoStmt) sep                              \
   macro(DeferStmt) sep                             \
+  macro(ForallIntent) sep                          \
   macro(ForallStmt) sep                            \
   macro(TryStmt) sep                               \
   macro(ForwardingStmt) sep                        \
@@ -154,6 +155,7 @@ enum AstTag {
   E_BlockStmt,
   E_CondStmt,
   E_GotoStmt,
+  E_ForallIntent,
   E_ForallStmt,
   E_ExternBlockStmt,
 
@@ -340,6 +342,7 @@ def_is_ast(BlockStmt)
 def_is_ast(CondStmt)
 def_is_ast(GotoStmt)
 def_is_ast(DeferStmt)
+def_is_ast(ForallIntent)
 def_is_ast(ForallStmt)
 def_is_ast(TryStmt)
 def_is_ast(ForwardingStmt)
@@ -386,6 +389,7 @@ def_to_ast(BlockStmt)
 def_to_ast(CondStmt)
 def_to_ast(GotoStmt)
 def_to_ast(DeferStmt)
+def_to_ast(ForallIntent)
 def_to_ast(ForallStmt)
 def_to_ast(TryStmt)
 def_to_ast(ForwardingStmt)
@@ -563,19 +567,17 @@ static inline const CallExpr* toConstCallExpr(const BaseAST* a)
   case E_CatchStmt:                                                     \
     AST_CALL_CHILD(_a, CatchStmt, _body, call, __VA_ARGS__);            \
     break;                                                              \
-  case E_ForallStmt: {                                                  \
+  case E_ForallIntent:                                                  \
+    AST_CALL_CHILD(_a, ForallIntent, variable(), call, __VA_ARGS__);    \
+    AST_CALL_CHILD(_a, ForallIntent, reduceExpr(), call, __VA_ARGS__);  \
+    break;                                                              \
+  case E_ForallStmt:                                                          \
     AST_CALL_LIST (_a, ForallStmt, inductionVariables(),  call, __VA_ARGS__); \
     AST_CALL_LIST (_a, ForallStmt, iteratedExpressions(), call, __VA_ARGS__); \
     AST_CALL_LIST (_a, ForallStmt, intentVariables(),     call, __VA_ARGS__); \
-    ForallIntents* fi = ((ForallStmt*)_a)->withClause();                \
-    AST_CALL_STDVEC(fi->fiVars,  Expr,              call, __VA_ARGS__); \
-    AST_CALL_STDVEC(fi->riSpecs, Expr,              call, __VA_ARGS__); \
-    AST_CALL_CHILD(fi, ForallIntents, iterRec,      call, __VA_ARGS__); \
-    AST_CALL_CHILD(fi, ForallIntents, leadIdx,      call, __VA_ARGS__); \
-    AST_CALL_CHILD(fi, ForallIntents, leadIdxCopy,  call, __VA_ARGS__); \
-    AST_CALL_CHILD(_a, ForallStmt,    loopBody(),   call, __VA_ARGS__); \
-    break;                                                              \
-  }                                                                     \
+    AST_CALL_LIST (_a, ForallStmt, forallIntents(),       call, __VA_ARGS__); \
+    AST_CALL_CHILD(_a, ForallStmt, loopBody(),            call, __VA_ARGS__); \
+    break;                                                                    \
   case E_ModuleSymbol:                                                  \
     AST_CALL_CHILD(_a, ModuleSymbol, block, call, __VA_ARGS__);         \
     break;                                                              \

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -1084,11 +1084,9 @@ static SymExpr* callUsedInRiSpec(Expr* call, CallExpr* parent) {
     SymExpr* destSE = toSymExpr(parent->get(1));
     Symbol* dest = destSE->symbol();
     SymExpr* riSpecMaybe = dest->firstSymExpr();
-    if (ForallStmt* fs = toForallStmt(riSpecMaybe->parentExpr)) {
-      for_vector(Expr, riSpec, fs->withClause()->riSpecs)
-        if (riSpecMaybe == riSpec)
-          return riSpecMaybe;
-    }
+    if (ForallIntent* fi = toForallIntent(riSpecMaybe->parentExpr))
+      if (riSpecMaybe == fi->reduceExpr())
+        return riSpecMaybe;
   }
   return NULL;
 }

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -880,15 +880,11 @@ static void errorDotInsideWithClause(UnresolvedSymExpr* origUSE,
 static void checkIdInsideWithClause(Expr*              exprInAst,
                                     UnresolvedSymExpr* origUSE) {
   // A 'with' clause for a forall loop.
-  if (ForallStmt* parent = toForallStmt(exprInAst->parentExpr)) {
-      ForallIntents* fi = parent->withClause();
-      for_vector(Expr, fiVar, fi->fiVars) {
-        if (exprInAst == fiVar) {
-          errorDotInsideWithClause(origUSE, "forall loop");
-          return;
-        }
-      }
-  }
+  if (ForallIntent* fi = toForallIntent(exprInAst->parentExpr))
+    if (exprInAst == fi->variable()) {
+      errorDotInsideWithClause(origUSE, "forall loop");
+      return;
+    }
 
   // A 'with' clause for a task construct.
   if (Expr* parent1 = exprInAst->parentExpr) {

--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -889,12 +889,14 @@ Expr* preFold(CallExpr* call) {
     int rOpIdx = (int)(toVarSymbol(rOpIdxSE->symbol())->immediate->int_value());
     Expr* rhs = call->get(3)->remove();
     Expr* lhs = call->get(2)->remove();
-    ForallIntents* fi = enclosingForallStmt(call)->withClause();
-    INT_ASSERT(rOpIdx >= 0 && rOpIdx < fi->numVars());
+    ForallStmt* fs = enclosingForallStmt(call);
+    // indexing should be legitimate - rOpIdx computed by reduceIntentIdx()
+    ForallIntent* fi = fs->getForallIntent(rOpIdx);
+
     INT_ASSERT(!strcmp(toSymExpr(lhs)->symbol()->name,
-                       toSymExpr(fi->fiVars[rOpIdx])->symbol()->name));
-    INT_ASSERT(fi->isReduce(rOpIdx));
-    Symbol* globalOp = toSymExpr(fi->riSpecs[rOpIdx])->symbol();
+                       toSymExpr(fi->variable())->symbol()->name));
+    INT_ASSERT(fi->isReduce());
+    Symbol* globalOp = toSymExpr(fi->reduceExpr())->symbol();
     INT_ASSERT(isReduceOp(globalOp->type));
     result = new_Expr("accumulateOntoState(%S,%S,%E,%E)",
                       gMethodToken, globalOp, lhs, rhs);


### PR DESCRIPTION
We prefer forall intents to be AST nodes.
Cf. prior to this change they were in a non-AST class ForallIntents,
which was pointed to by ForallStmt::withClause().

Here we introduce ForallIntent and ForallStmt::forallIntents().
'forallIntents()' is an AList with one ForallIntent per one
Chapel-level forall intent.

Note the two class names are similar. Plural ForallIntents
is the non-AST class in BlockStmt::forallIntents representing
the entire with clause.
Singular ForallIntent is the new AST node representing
a single intent/variable, stored in ForallStmt::forallIntents()
AList.

In retrospect, I probably should have gone straight to
LoopIntentVar as per #6514. However, this change
is a simpler and more immediate improvement over #5295 
and one that Michael and I have wanted for a while.

The next steps, independent of each other, are:

* Retire BlockStmt::forallIntents and the ForallIntents class.
This means switching ALL forall loops to new representation,
probably based on ForallStmt at least initially.

* Move from ForallIntent class to LoopIntentVar class.

Testing: linux64 - full paratest; gasnet - spot check.

The commits before the rebase were bb84e1b..69baa92

Visitor changes are in a separate commit.