### PR TITLE
Move global well-known types/fns to wellknown.h/.cpp

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -35,17 +35,6 @@
 AggregateType* dtObject            = NULL;
 
 AggregateType* dtString            = NULL;
-AggregateType* dtArray             = NULL;
-AggregateType* dtBaseArr           = NULL;
-AggregateType* dtBaseDom           = NULL;
-AggregateType* dtDist              = NULL;
-AggregateType* dtTuple             = NULL;
-AggregateType* dtLocale            = NULL;
-AggregateType* dtLocaleID          = NULL;
-AggregateType* dtMainArgument      = NULL;
-AggregateType* dtOnBundleRecord    = NULL;
-AggregateType* dtTaskBundleRecord  = NULL;
-AggregateType* dtError             = NULL;
 
 AggregateType::AggregateType(AggregateTag initTag) :
   Type(E_AggregateType, NULL) {

--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -33,6 +33,7 @@
 #include "stringutil.h"
 #include "symbol.h"
 #include "type.h"
+#include "wellknown.h"
 
 #include <map>
 #include <utility>

--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -34,6 +34,7 @@
 #include "stmt.h"
 #include "stringutil.h"
 #include "type.h"
+#include "wellknown.h"
 #include "WhileStmt.h"
 
 

--- a/compiler/AST/primitive.cpp
+++ b/compiler/AST/primitive.cpp
@@ -24,6 +24,7 @@
 #include "stringutil.h"
 #include "type.h"
 #include "resolution.h"
+#include "wellknown.h"
 
 static QualifiedType
 returnInfoUnknown(CallExpr* call) {

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -87,21 +87,10 @@ VarSymbol* gPrivatization = NULL;
 VarSymbol* gLocal = NULL;
 VarSymbol* gNodeID = NULL;
 VarSymbol *gModuleInitIndentLevel = NULL;
-FnSymbol *gPrintModuleInitFn = NULL;
 FnSymbol* gAddModuleFn = NULL;
-FnSymbol* gChplHereAlloc = NULL;
-FnSymbol* gChplHereFree = NULL;
-FnSymbol* gChplDoDirectExecuteOn = NULL;
 FnSymbol *gGenericTupleTypeCtor = NULL;
 FnSymbol *gGenericTupleInit = NULL;
 FnSymbol *gGenericTupleDestroy = NULL;
-FnSymbol *gBuildTupleType = NULL;
-FnSymbol *gBuildStarTupleType = NULL;
-FnSymbol *gBuildTupleTypeNoRef = NULL;
-FnSymbol *gBuildStarTupleTypeNoRef = NULL;
-FnSymbol* gChplDeleteError = NULL;
-FnSymbol *gGetDynamicEndCount = NULL;
-FnSymbol *gSetDynamicEndCount = NULL;
 
 
 std::map<FnSymbol*,int> ftableMap;

--- a/compiler/AST/wellknown.cpp
+++ b/compiler/AST/wellknown.cpp
@@ -23,6 +23,34 @@
 #include "expr.h"
 #include "symbol.h"
 
+// The well-known types
+AggregateType* dtArray;
+AggregateType* dtBaseArr;
+AggregateType* dtBaseDom;
+AggregateType* dtDist;
+AggregateType* dtError;
+AggregateType* dtLocale;
+AggregateType* dtLocaleID;
+AggregateType* dtMainArgument;
+AggregateType* dtOnBundleRecord;
+AggregateType* dtTaskBundleRecord;
+AggregateType* dtTuple;
+
+
+// The well-known functions
+FnSymbol *gChplHereAlloc;
+FnSymbol *gChplHereFree;
+FnSymbol *gChplDoDirectExecuteOn;
+FnSymbol *gBuildTupleType;
+FnSymbol *gBuildTupleTypeNoRef;
+FnSymbol *gBuildStarTupleType;
+FnSymbol *gBuildStarTupleTypeNoRef;
+FnSymbol *gChplDeleteError;
+FnSymbol *gPrintModuleInitFn;
+FnSymbol *gGetDynamicEndCount;
+FnSymbol *gSetDynamicEndCount;
+
+
 /************************************* | **************************************
 *                                                                             *
 *                                                                             *
@@ -66,15 +94,15 @@ struct WellKnownType
 // These types are a required part of the compiler/module interface.
 static WellKnownType sWellKnownTypes[] = {
   { "_array",                &dtArray,            false },
-  { "_tuple",                &dtTuple,            false },
-  { "locale",                &dtLocale,           true  },
-  { "chpl_localeID_t",       &dtLocaleID,         false },
   { "BaseArr",               &dtBaseArr,          true  },
   { "BaseDom",               &dtBaseDom,          true  },
   { "BaseDist",              &dtDist,             true  },
+  { "locale",                &dtLocale,           true  },
+  { "chpl_localeID_t",       &dtLocaleID,         false },
   { "chpl_main_argument",    &dtMainArgument,     false },
   { "chpl_comm_on_bundle_t", &dtOnBundleRecord,   false },
   { "chpl_task_bundle_t",    &dtTaskBundleRecord, false },
+  { "_tuple",                &dtTuple,            false },
   { "Error",                 &dtError,            true  }
 };
 

--- a/compiler/codegen/expr.cpp
+++ b/compiler/codegen/expr.cpp
@@ -34,6 +34,7 @@
 #include "type.h"
 #include "virtualDispatch.h"
 #include "WhileStmt.h"
+#include "wellknown.h"
 
 
 #ifndef __STDC_FORMAT_MACROS

--- a/compiler/include/AggregateType.h
+++ b/compiler/include/AggregateType.h
@@ -185,17 +185,6 @@ private:
 extern AggregateType* dtObject;
 
 extern AggregateType* dtString;
-extern AggregateType* dtArray;
-extern AggregateType* dtBaseArr;
-extern AggregateType* dtBaseDom;
-extern AggregateType* dtDist;
-extern AggregateType* dtTuple;
-extern AggregateType* dtLocale;
-extern AggregateType* dtLocaleID;
-extern AggregateType* dtMainArgument;
-extern AggregateType* dtOnBundleRecord;
-extern AggregateType* dtTaskBundleRecord;
-extern AggregateType* dtError;
 
 DefExpr* defineObjectClass();
 

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -702,24 +702,11 @@ extern VarSymbol *gPrivatization;
 extern VarSymbol *gLocal;
 extern VarSymbol *gNodeID;
 extern VarSymbol *gModuleInitIndentLevel;
-extern FnSymbol *gPrintModuleInitFn;
 extern FnSymbol *gAddModuleFn;
-extern FnSymbol *gChplHereAlloc;
-extern FnSymbol *gChplHereFree;
-extern FnSymbol *gChplDoDirectExecuteOn;
+
 extern FnSymbol *gGenericTupleTypeCtor;
 extern FnSymbol *gGenericTupleInit;
 extern FnSymbol *gGenericTupleDestroy;
-extern FnSymbol *gChplDeleteError;
-extern FnSymbol *gGetDynamicEndCount;
-extern FnSymbol *gSetDynamicEndCount;
-
-// These global symbols point to generic functions that
-// will be instantiated.
-extern FnSymbol *gBuildTupleType;
-extern FnSymbol *gBuildStarTupleType;
-extern FnSymbol *gBuildTupleTypeNoRef;
-extern FnSymbol *gBuildStarTupleTypeNoRef;
 
 extern Symbol *gSyncVarAuxFields;
 extern Symbol *gSingleVarAuxFields;

--- a/compiler/include/wellknown.h
+++ b/compiler/include/wellknown.h
@@ -22,6 +22,7 @@
 
 #include <vector>
 
+class AggregateType;
 class FnSymbol;
 
 void gatherIteratorTags();
@@ -30,5 +31,32 @@ void gatherWellKnownFns();
 
 std::vector<FnSymbol*> getWellKnownFunctions();
 void clearGenericWellKnownFunctions();
+
+// The well-known types
+extern AggregateType* dtArray;
+extern AggregateType* dtBaseArr;
+extern AggregateType* dtBaseDom;
+extern AggregateType* dtDist;
+extern AggregateType* dtError;
+extern AggregateType* dtLocale;
+extern AggregateType* dtLocaleID;
+extern AggregateType* dtMainArgument;
+extern AggregateType* dtOnBundleRecord;
+extern AggregateType* dtTaskBundleRecord;
+extern AggregateType* dtTuple;
+
+// The well-known functions
+extern FnSymbol *gChplHereAlloc;
+extern FnSymbol *gChplHereFree;
+extern FnSymbol *gChplDoDirectExecuteOn;
+extern FnSymbol *gBuildTupleType;
+extern FnSymbol *gBuildTupleTypeNoRef;
+extern FnSymbol *gBuildStarTupleType;
+extern FnSymbol *gBuildStarTupleTypeNoRef;
+extern FnSymbol *gChplDeleteError;
+extern FnSymbol *gPrintModuleInitFn;
+extern FnSymbol *gGetDynamicEndCount;
+extern FnSymbol *gSetDynamicEndCount;
+
 
 #endif

--- a/compiler/passes/addInitGuards.cpp
+++ b/compiler/passes/addInitGuards.cpp
@@ -36,6 +36,7 @@
 #include "build.h"
 #include "stmt.h"
 #include "stringutil.h"
+#include "wellknown.h"
 
 static void addModuleInitBlocks();
 static void addInitGuards();

--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -30,6 +30,7 @@
 #include "stmt.h"
 #include "stringutil.h"
 #include "symbol.h"
+#include "wellknown.h"
 
 static bool mainReturnsInt;
 

--- a/compiler/passes/createTaskFunctions.cpp
+++ b/compiler/passes/createTaskFunctions.cpp
@@ -24,6 +24,7 @@
 #include "resolution.h"
 #include "stmt.h"
 #include "stlUtil.h"
+#include "wellknown.h"
 
 // 'markPruned' replaced deletion from SymbolMap, which does not work well.
 Symbol*           markPruned      = NULL;

--- a/compiler/passes/errorHandling.cpp
+++ b/compiler/passes/errorHandling.cpp
@@ -25,6 +25,7 @@
 #include "stmt.h"
 #include "symbol.h"
 #include "TryStmt.h"
+#include "wellknown.h"
 
 #include <stack>
 

--- a/compiler/passes/insertWideReferences.cpp
+++ b/compiler/passes/insertWideReferences.cpp
@@ -191,6 +191,7 @@
 #include "stringutil.h"
 #include "timer.h"
 #include "view.h"
+#include "wellknown.h"
 
 #include <map>
 #include <queue>

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -33,6 +33,7 @@
 #include "stringutil.h"
 #include "TransformLogicalShortCircuit.h"
 #include "typeSpecifier.h"
+#include "wellknown.h"
 
 #include <cctype>
 #include <set>

--- a/compiler/passes/parallel.cpp
+++ b/compiler/passes/parallel.cpp
@@ -33,6 +33,7 @@
 #include "stmt.h"
 #include "stringutil.h"
 #include "symbol.h"
+#include "wellknown.h"
 
 // Notes on
 //   makeHeapAllocations()    //invoked from parallel()

--- a/compiler/resolution/tuples.cpp
+++ b/compiler/resolution/tuples.cpp
@@ -34,6 +34,7 @@
 #include "stringutil.h"
 #include "symbol.h"
 #include "visibleFunctions.h"
+#include "wellknown.h"
 
 #include <cstdlib>
 #include <inttypes.h>


### PR DESCRIPTION
The (relatively new) files wellknown.h and wellknown.cpp are responsible for managing certain types and functions that are identified during parse time and are known to the compiler.

This PR simply moves the global variables managed by wellknown.h/.cpp to be declared in those files. I think that represents an improvement since it keeps the managed globals close to where they are managed.

This is a trivial clean-up.
Discussed with @noakesmichael, who agreed this is an improvement.
Passed full local testing.