### PR TITLE
Fixed a numa failure due to #5295

### DIFF
--- a/test/users/engin/partial_reduction_support/modules/dsiMethods.chpl
+++ b/test/users/engin/partial_reduction_support/modules/dsiMethods.chpl
@@ -40,7 +40,8 @@ iter DefaultRectangularDom.dsiPartialThese(param onlyDim, otherIdx,
   }
 
 iter DefaultRectangularDom.dsiPartialThese(param onlyDim, otherIdx,
-    param tag: iterKind) where tag == iterKind.standalone {
+    param tag: iterKind) where tag == iterKind.standalone &&
+    __primitive("method call resolves", ranges(onlyDim), "these", tag) {
 
     if !dsiPartialDomain(onlyDim).member(otherIdx) then return;
     for i in ranges(onlyDim).these(tag) do yield i;


### PR DESCRIPTION
This is another case where one standalone iterator redirects to another,
so the availability of the former depends on the availability of the latter.

This change adds the same check to the where-clause as has been done
throughout #5295. An improvement is called for in #5255.

There are probably other standalone iterators in dsiMethods.chpl
that would benefit from a similar change. However I am leaving them alone
for now so we can apply a principled fix when we address #5255.
