### PR TITLE
Add debugSummary() and debugParentSym(), invoked from gdb.commands.

### DIFF
--- a/compiler/AST/view.cpp
+++ b/compiler/AST/view.cpp
@@ -699,6 +699,42 @@ int debugID(BaseAST* ast) {
   return ast ? ast->id : -1;
 }
 
+// "debug summary": print key pieces of info
+void debugSummary(int id) {
+  if (BaseAST* ast = aid09(id))
+    debugSummary(ast);
+  else
+    printf("%s\n", aidNotFoundError("debugSummary", id));
+}
+void debugSummary(BaseAST* ast) {
+  if (ast)
+    printf("%d   %s   %s\n", ast->id, ast->astTagAsString(), debugLoc(ast));
+  else
+    printf("<debugSummary: NULL>\n");
+}
+
+// find the Parent Symbol
+BaseAST* debugParentSym(int id) {
+  if (BaseAST* ast = aid09(id))
+    return debugParentSym(ast);
+  else {
+    printf("%s\n", aidNotFoundError("debugParentSym", id));
+    return NULL;
+  }
+}
+BaseAST* debugParentSym(BaseAST* ast) {
+  if (!ast)
+    return NULL;
+  else if (Expr* expr = toExpr(ast))
+    return expr->parentSymbol;
+  else if (Symbol* sym = toSymbol(ast))
+    return sym->defPoint->parentSymbol;
+  else {
+    printf("<debugParentSym: node %d is neither Expr nor Symbol>\n", ast->id);
+    return NULL;
+  }
+}
+
 
 //
 // map_view: print the contents of a SymbolMap

--- a/compiler/etc/gdb.commands
+++ b/compiler/etc/gdb.commands
@@ -45,8 +45,9 @@ define loc
  p ::stringLoc($arg0)
 end
 define locid
-  # evaluate $arg0 only once
-  set $eval_temp = ($arg0)
-  printf "%d  %s\n", debugID($eval_temp), debugLoc($eval_temp)
+  call debugSummary($arg0)
+end
+define parentlocid
+  call debugSummary(debugParentSym($arg0))
 end
 break gdbShouldBreakHere

--- a/compiler/include/view.h
+++ b/compiler/include/view.h
@@ -88,6 +88,9 @@ const char* debugLoc(BaseAST* ast);
 
 int debugID(int id);
 int debugID(BaseAST* ast);
-
+void debugSummary(int id);
+void debugSummary(BaseAST* ast);
+BaseAST* debugParentSym(int id);
+BaseAST* debugParentSym(BaseAST* ast);
 
 #endif


### PR DESCRIPTION
Have the 'locid' command in gdb also print the AST tag of the node.
Add 'parentlocid' command to print info about the parentSymbol of the node.

Do that by introducing the C functions debugSummary() and debugParentSym()
in view.cpp.

For example:

```
(gdb) locid 411899
411899   CallExpr   w.chpl:9
(gdb) locidps 411899
189585   FnSymbol   w.chpl:9
(gdb) locid 189585
189585   FnSymbol   w.chpl:9
```

