### PR TITLE
Adjusted a couple of tests to avoid failures on master.

### DIFF
--- a/test/classes/ferguson/forwarding/call-forwarded-omit-this.bad
+++ b/test/classes/ferguson/forwarding/call-forwarded-omit-this.bad
@@ -1,4 +1,4 @@
 call-forwarded-omit-this.chpl:27: In function 'bad':
 call-forwarded-omit-this.chpl:28: error: unresolved call 'area()'
 call-forwarded-omit-this.chpl:5: note: candidates are: MyCircleImpl.area()
-call-forwarded-omit-this.chpl:25: note:                 MyCircle.area()
+call-forwarded-omit-this.chpl:14: note:                 MyCircle.area()

--- a/test/classes/initializers/records/const-record.skipif
+++ b/test/classes/initializers/records/const-record.skipif
@@ -1,0 +1,2 @@
+# This test currently fails under gasnet
+CHPL_COMM != none


### PR DESCRIPTION
* The line number reported by the compiler changed perhaps due to #6849.
I am updating the .bad file:

  test/classes/ferguson/forwarding/call-forwarded-omit-this.bad

* This test was de-futurized in #6832. However, it still fails
under gasnet. I am temporarily adding a skipif with CHPL_COMM != none
to reduce disturbance to nightly testing.

  test/classes/initializers/records/const-record.skipif

@mppf please follow up.