### PR TITLE
Fix LLVM testing failures from PR #6856

### DIFF
--- a/compiler/codegen/expr.cpp
+++ b/compiler/codegen/expr.cpp
@@ -108,6 +108,8 @@ static GenRet codegen_prim_get_real(GenRet, Type*, bool real);
 
 static int codegen_tmp = 1;
 
+#define LOCALE_ID_TYPE dtLocaleID->typeInfo()
+
 /************************************ | *************************************
 *                                                                           *
 *                                                                           *

--- a/compiler/codegen/type.cpp
+++ b/compiler/codegen/type.cpp
@@ -36,6 +36,7 @@
 #include "stringutil.h"
 #include "symbol.h"
 #include "vec.h"
+#include "wellknown.h"
 
 
 
@@ -400,7 +401,7 @@ void AggregateType::codegenDef() {
         if( fLLVMWideOpt ) {
           // These are here so that the types are generated during codegen..
           if( ! info->globalToWideInfo.localeIdType ) {
-            Type* localeType = LOCALE_ID_TYPE;
+            Type* localeType = dtLocaleID->typeInfo();
             info->globalToWideInfo.localeIdType = localeType->codegen().type;
           }
           if( ! info->globalToWideInfo.nodeIdType ) {

--- a/compiler/include/type.h
+++ b/compiler/include/type.h
@@ -509,8 +509,6 @@ GenRet codegenImmediate(Immediate* i);
 #define CLASS_ID_TYPE dtInt[INT_SIZE_32]
 #define UNION_ID_TYPE dtInt[INT_SIZE_64]
 #define SIZE_TYPE dtInt[INT_SIZE_64]
-#define LOCALE_TYPE dtLocale->typeInfo()
-#define LOCALE_ID_TYPE dtLocaleID->typeInfo()
 #define NODE_ID_TYPE dtInt[INT_SIZE_32]
 
 #define is_arithmetic_type(t)                        \


### PR DESCRIPTION
type.h previously included this line,

    #define LOCALE_ID_TYPE dtLocaleID->typeInfo()

which was only used for LLVM code generation. But type.h didn't itself include wellknown.h, where dtLocaleID is now defined. That caused compilation failures for CHPL_LLVM configurations.

 So I replaced one use of this macro in codegen/type.cpp with its definition, and I moved the define to codegen/expr.cpp where most of the uses are.

I would expect we could entirely remove LOCALE_ID_TYPE and replace it with just dtLocaleID but here I'm making a more conservative change since my goal is simply to repair testing.

- [x] full local testing
- [x] Hellos pass with --llvm

Trivial and not reviewed.