### PR TITLE
Add debugGetTheIteratorFn()

### DIFF
--- a/compiler/AST/view.cpp
+++ b/compiler/AST/view.cpp
@@ -897,6 +897,20 @@ void whocalls(int id) {
     }
   }
 
+  int fItAll = 0, fItMatch = 0, fItNonTreeMatch = 0;
+  forv_Vec(BlockStmt, block, gBlockStmts) {
+    if (ForLoop* loop = toForLoop(block)) {
+      fItAll++;
+      if (SymExpr* it = loop->iteratorGet())
+        if (Symbol* ic = it->symbol())
+          if (FnSymbol* iterator = debugGetTheIteratorFn(ic))
+            if (iterator->id == id)
+              printf("  ForLoop %d  iterator sym %d  %s  %s\n",
+                     loop->id, ic->id, parentMsg(loop, &fItMatch,
+                       &fItNonTreeMatch), debugLoc(loop));
+    }
+  }
+
   int vmtMatch = 0, vmtAll = 0;
   for (int i = 0; i < virtualMethodTable.n; i++) {
     if (virtualMethodTable.v[i].key) {
@@ -920,8 +934,38 @@ void whocalls(int id) {
 
   printf("  %d of %d calls", callMatch, callAll);
   if (callNonTreeMatch) printf(", also %d not in tree", callNonTreeMatch);
-  printf(".  %d of %d for-loops", forMatch, forAll);
-  if (forNonTreeMatch) printf(", also %d not in tree", forNonTreeMatch);
-  printf(".  %d of %d in VMT.  %d of %d in FT.\n",
-         vmtMatch, vmtAll, ftMatch, ftAll);
+  printf(".  %d of %d for-loops", forMatch+fItMatch, forAll+fItAll);
+  int forNontree = forNonTreeMatch + fItNonTreeMatch;
+  if (forNontree) printf(", also %d not in tree", forNontree);
+  printf(".  %d of %d in VMT+FT.\n", vmtMatch+ftMatch, vmtAll+ftAll);
+}
+
+FnSymbol* debugGetTheIteratorFn(int id) {
+  if (BaseAST* ast = aidWithError(id, "debugGetTheIteratorFn"))
+    return debugGetTheIteratorFn(ast);
+  else
+    return NULL;
+}
+
+FnSymbol* debugGetTheIteratorFn(BaseAST* ast) {
+  if (!ast) {
+    printf("<debugGetTheIteratorFn: NULL>\n");
+    return NULL;
+  }
+  else if (Symbol* sym = toSymbol(ast))
+    return debugGetTheIteratorFn(sym);
+  else if (Type* type = toType(ast))
+    return debugGetTheIteratorFn(type);
+  else if (ForLoop* fl = toForLoop(ast))
+    return debugGetTheIteratorFn(fl->iteratorGet()->symbol());
+  else if (SymExpr* se = toSymExpr(ast))
+    return debugGetTheIteratorFn(se->symbol());
+  else {
+    printf("<don't know how to get the iterator for node %d>\n", ast->id);
+    return NULL;
+  }
+}
+
+FnSymbol* debugGetTheIteratorFn(Symbol* sym) {
+  return sym ? debugGetTheIteratorFn(sym->type) : NULL;
 }

--- a/compiler/include/view.h
+++ b/compiler/include/view.h
@@ -76,6 +76,12 @@ void        fnsWithName(const char* name, Vec<FnSymbol*>& fnVec);
 void        whocalls(int id);
 void        whocalls(BaseAST* ast);
 
+FnSymbol*   debugGetTheIteratorFn(int id);
+FnSymbol*   debugGetTheIteratorFn(BaseAST* ast);
+FnSymbol*   debugGetTheIteratorFn(Symbol* sym);
+FnSymbol*   debugGetTheIteratorFn(Type* type);
+FnSymbol*   debugGetTheIteratorFn(ForLoop* forLoop);
+
 // NB these return the same static buffer
 const char* stringLoc(int id);
 const char* stringLoc(BaseAST* ast);

--- a/compiler/resolution/lowerIterators.cpp
+++ b/compiler/resolution/lowerIterators.cpp
@@ -90,6 +90,32 @@ FnSymbol* getTheIteratorFn(Type* icType)
   }
 }
 
+FnSymbol* debugGetTheIteratorFn(Type* type) {
+  FnSymbol* result = NULL;
+  if (AggregateType* agg = toAggregateType(type)) {
+    if (agg->symbol->hasFlag(FLAG_TUPLE))
+      result = getTheIteratorFn(agg);
+    else if (agg->symbol->hasFlag(FLAG_ITERATOR_CLASS))
+      result = getTheIteratorFn(agg);
+    else if (agg->symbol->hasFlag(FLAG_ITERATOR_RECORD))
+      if (IteratorInfo* ii = agg->iteratorInfo)
+        result = ii->iterator;
+  }
+  if (result && result->hasFlag(FLAG_AUTO_II))
+    if (AggregateType* rettype = toAggregateType(result->retType))
+      if (FnSymbol* newresult = debugGetTheIteratorFn(rettype))
+        result = newresult;
+  return result;
+}
+
+FnSymbol* debugGetTheIteratorFn(ForLoop* forLoop) {
+  if (forLoop)
+    if (SymExpr* iteratorSE = forLoop->iteratorGet())
+      return debugGetTheIteratorFn(iteratorSE->symbol()->type);
+  // otherwise
+  return NULL;
+}
+
 
 // This consistency check should probably be moved earlier in the compilation.
 // It needs to be after resolution because it sets FLAG_INLINE_ITERATOR.


### PR DESCRIPTION
debugGetTheIteratorFn() allows us to get conveniently from a ForLoop id or an iterator type
to the corresponding iterator FnSymbol in the debugger. I included a special adjustment that
returns the iterator corresponding to the _getIterator function, if the latter
is encountered first. Compared to getTheIteratorFn(), the "debug" variety
is safer for use in the debugger because it simply returns NULL where the production
version would trip over one of many INT_ASSERTs.

debugGetTheIteratorFn() is now also invoked from whocalls() to detect
if the FnSymbol is used as the iterator in a ForLoop.

Aside: I placed two key debugGetTheIteratorFn implementations in lowerIterators.cpp
so they can be kept up-to-date with getTheIteratorFn().