### PR TITLE
Enhanced viewFlags()

### DIFF
--- a/compiler/AST/flags.cpp
+++ b/compiler/AST/flags.cpp
@@ -19,9 +19,8 @@
 
 #include "flags.h"
 
-#include "baseAST.h"
+#include "expr.h"
 #include "stringutil.h"
-#include "symbol.h"
 
 
 typedef Map<const char*, int> FlagMap;
@@ -71,6 +70,35 @@ void writeFlags(FILE* fp, Symbol* sym) {
   }
 }
 
+static const char* qualDebugStr(Qualifier q) {
+    switch (q) {
+      case QUAL_UNKNOWN:
+        return "unknown";
+      case QUAL_CONST:
+        return "const";
+      case QUAL_REF:
+        return "ref";
+      case QUAL_CONST_REF:
+        return "const-ref";
+      case QUAL_PARAM:
+        return "param";
+      case QUAL_VAL:
+        return "val";
+      case QUAL_NARROW_REF:
+        return "narrow-ref";
+      case QUAL_WIDE_REF:
+        return "wide-ref";
+
+      case QUAL_CONST_VAL:
+        return "const-val";
+      case QUAL_CONST_NARROW_REF:
+        return "const-narrow-ref";
+      case QUAL_CONST_WIDE_REF:
+        return "const-wide-ref";
+    }
+    INT_FATAL("Unhandled Qualifier");
+    return "UNKNOWN-QUAL";
+}
 
 // these affect what viewFlags() prints
 bool viewFlagsShort   = true;
@@ -79,12 +107,7 @@ bool viewFlagsName    = false;
 bool viewFlagsComment = false;
 bool viewFlagsExtras  = true;
 
-void viewFlags(BaseAST* ast) {
-  if (!viewFlagsShort && !viewFlagsName && !viewFlagsComment) {
-    viewFlagsName = true;
-  }
-
-  if (Symbol* sym = toSymbol(ast)) {
+static void viewSymbolFlags(Symbol* sym) {
     for (int flagNum = FLAG_FIRST; flagNum <= FLAG_LAST; flagNum++) {
       if (sym->flags[flagNum]) {
         if (viewFlagsName) {
@@ -115,9 +138,11 @@ void viewFlags(BaseAST* ast) {
           fprint_imm(stdout, *toVarSymbol(sym)->immediate, true);
           printf("\n");
         }
+        printf("qual %s\n", qualDebugStr(vs->qual));
 
       } else if (ArgSymbol* as = toArgSymbol(sym)) {
-        printf("%s arg\n", as->intentDescrString());
+        printf("%s arg  qual %s\n",
+               as->intentDescrString(), qualDebugStr(as->qual));
 
       } else if (toTypeSymbol(sym)) {
         printf("a TypeSymbol\n");
@@ -141,9 +166,37 @@ void viewFlags(BaseAST* ast) {
         printf("unknown symbol kind\n");
       }
     }
+}
 
+static void viewFlagsHelper(BaseAST* ast, Symbol* sym, const char* msg) {
+  printf("%d: %s %d\n", ast->id, msg, sym->id);
+  viewSymbolFlags(sym);
+}
+  
+void viewFlags(BaseAST* ast) {
+  if (!viewFlagsShort && !viewFlagsComment)
+    viewFlagsName = true;
+  if (Symbol* sym = toSymbol(ast)) {
+    viewSymbolFlags(sym);
+  } else if (Type* type = toType(ast)) {
+    viewFlagsHelper(ast, type->symbol, "is a type, showing its Symbol");
+  } else if (SymExpr* se = toSymExpr(ast)) {
+    viewFlagsHelper(ast, se->symbol(), "is a SymExpr, showing its Symbol");
+  } else if (DefExpr* def = toDefExpr(ast)) {
+    viewFlagsHelper(ast, def->sym, "is a DefExpr, showing its Symbol");
   } else {
-    printf("[%d]: not a Symbol, has no flags\n", ast->id);
+    // more cases
+    bool handled = false;
+    if (CallExpr* call = toCallExpr(ast)) {
+      if (SymExpr* se = toSymExpr(call->baseExpr)) {
+        viewFlagsHelper(ast, se->symbol(),
+                        "is a CallExpr, showing its baseExpr Symbol");
+        handled = true;
+      }
+    }
+    if (!handled)
+      printf("%d: is a %s (does not support Flags)\n",
+             ast->id, ast->astTagAsString());
   }
 }
 

--- a/compiler/AST/flags.cpp
+++ b/compiler/AST/flags.cpp
@@ -70,36 +70,6 @@ void writeFlags(FILE* fp, Symbol* sym) {
   }
 }
 
-static const char* qualDebugStr(Qualifier q) {
-    switch (q) {
-      case QUAL_UNKNOWN:
-        return "unknown";
-      case QUAL_CONST:
-        return "const";
-      case QUAL_REF:
-        return "ref";
-      case QUAL_CONST_REF:
-        return "const-ref";
-      case QUAL_PARAM:
-        return "param";
-      case QUAL_VAL:
-        return "val";
-      case QUAL_NARROW_REF:
-        return "narrow-ref";
-      case QUAL_WIDE_REF:
-        return "wide-ref";
-
-      case QUAL_CONST_VAL:
-        return "const-val";
-      case QUAL_CONST_NARROW_REF:
-        return "const-narrow-ref";
-      case QUAL_CONST_WIDE_REF:
-        return "const-wide-ref";
-    }
-    INT_FATAL("Unhandled Qualifier");
-    return "UNKNOWN-QUAL";
-}
-
 // these affect what viewFlags() prints
 bool viewFlagsShort   = true;
 bool viewFlagsPragma  = false;
@@ -138,11 +108,11 @@ static void viewSymbolFlags(Symbol* sym) {
           fprint_imm(stdout, *toVarSymbol(sym)->immediate, true);
           printf("\n");
         }
-        printf("qual %s\n", qualDebugStr(vs->qual));
+        printf("qual %s\n", qualifierToStr(vs->qual));
 
       } else if (ArgSymbol* as = toArgSymbol(sym)) {
         printf("%s arg  qual %s\n",
-               as->intentDescrString(), qualDebugStr(as->qual));
+               as->intentDescrString(), qualifierToStr(as->qual));
 
       } else if (toTypeSymbol(sym)) {
         printf("a TypeSymbol\n");

--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -111,6 +111,66 @@ void Type::setDestructor(FnSymbol* fn) {
 
 /************************************* | **************************************
 *                                                                             *
+* Qualifier and QualifiedType                                                 *
+*                                                                             *
+************************************** | *************************************/
+
+
+const char* qualifierToStr(Qualifier q) {
+    switch (q) {
+      case QUAL_UNKNOWN:
+        return "unknown";
+
+      case QUAL_CONST:
+        return "const";
+      case QUAL_REF:
+        return "ref";
+      case QUAL_CONST_REF:
+        return "const-ref";
+
+      case QUAL_PARAM:
+        return "param";
+
+      case QUAL_VAL:
+        return "val";
+      case QUAL_NARROW_REF:
+        return "narrow-ref";
+      case QUAL_WIDE_REF:
+        return "wide-ref";
+
+      case QUAL_CONST_VAL:
+        return "const-val";
+      case QUAL_CONST_NARROW_REF:
+        return "const-narrow-ref";
+      case QUAL_CONST_WIDE_REF:
+        return "const-wide-ref";
+    }
+
+    INT_FATAL("Unhandled Qualifier");
+    return "UNKNOWN-QUAL";
+}
+
+bool QualifiedType::isRefType() const {
+  return _type->symbol->hasFlag(FLAG_REF);
+}
+
+bool QualifiedType::isWideRefType() const {
+  return _type->symbol->hasFlag(FLAG_WIDE_REF);
+}
+
+const char* QualifiedType::qualStr() const {
+  if (isRefType())
+    return qualifierToStr(QUAL_REF);
+
+  if (isWideRefType())
+    return qualifierToStr(QUAL_WIDE_REF);
+
+  // otherwise
+  return qualifierToStr(_qual);
+}
+
+/************************************* | **************************************
+*                                                                             *
 *                                                                             *
 *                                                                             *
 ************************************** | *************************************/
@@ -194,14 +254,6 @@ std::string PrimitiveType::docsDirective() {
 
 void PrimitiveType::accept(AstVisitor* visitor) {
   visitor->visitPrimType(this);
-}
-
-bool QualifiedType::isRefType() const {
-  return _type->symbol->hasFlag(FLAG_REF);
-}
-
-bool QualifiedType::isWideRefType() const {
-  return _type->symbol->hasFlag(FLAG_WIDE_REF);
 }
 
 EnumType::EnumType() :

--- a/compiler/include/type.h
+++ b/compiler/include/type.h
@@ -154,6 +154,8 @@ enum Qualifier {
   QUAL_CONST_WIDE_REF
 };
 
+const char* qualifierToStr(Qualifier q);
+
 // A QualifiedType is basically a tuple of (qualifier, type).
 // Shorter names, such as QualType and QualT have been proposed.
 // A QualifiedType is only expected to be meaningful during and
@@ -270,44 +272,7 @@ public:
     return _qual;
   }
 
-  const char* qualStr() const {
-    Qualifier q = _qual;
-
-    if (isRefType()) {
-      q = QUAL_REF;
-    } else if (isWideRefType()) {
-      q = QUAL_WIDE_REF;
-    }
-
-    switch (q) {
-      case QUAL_UNKNOWN:
-        return "unknown";
-      case QUAL_CONST:
-        return "const";
-      case QUAL_REF:
-        return "ref";
-      case QUAL_CONST_REF:
-        return "const-ref";
-      case QUAL_PARAM:
-        return "param";
-      case QUAL_VAL:
-        return "val";
-      case QUAL_NARROW_REF:
-        return "narrow-ref";
-      case QUAL_WIDE_REF:
-        return "wide-ref";
-
-      case QUAL_CONST_VAL:
-        return "const-val";
-      case QUAL_CONST_NARROW_REF:
-        return "const-narrow-ref";
-      case QUAL_CONST_WIDE_REF:
-        return "const-wide-ref";
-    }
-    INT_FATAL("Unhandled Qualifier");
-    return "UNKNOWN-QUAL";
-  }
-
+  const char* qualStr() const;
 
 private:
   Type*      _type;


### PR DESCRIPTION
For additional debugging convenience:

* Also display the type qualifier.

* When given a Type, DefExpr, of SymExpr, redirect to the corresponding Symbol instead of giving up.

While there, in a separate commit moved the "Qualifier to string" conversion into `qualifierToStr(Qualifier q)` and to type.cpp, out of type.h. Also brought together Qualifier-related code within type.cpp.