### PR TITLE
Delete the class instances I create for these futures

### DIFF
--- a/test/types/enum/lydia/declaredInClass-constructor.chpl
+++ b/test/types/enum/lydia/declaredInClass-constructor.chpl
@@ -5,7 +5,7 @@
 proc main() {
   var sampleBug = new Sample();
   writeln(sampleBug.tag);
-
+  delete sampleBug;
 }
 
 

--- a/test/types/enum/lydia/declaredInClass-initializer.chpl
+++ b/test/types/enum/lydia/declaredInClass-initializer.chpl
@@ -5,7 +5,7 @@
 proc main() {
   var sampleBug = new Sample();
   writeln(sampleBug.tag);
-
+  delete sampleBug;
 }
 
 

--- a/test/types/enum/lydia/declaredInClass1.chpl
+++ b/test/types/enum/lydia/declaredInClass1.chpl
@@ -5,7 +5,7 @@
 proc main() {
   var sampleBug = new Sample();
   writeln(sampleBug.tag);
-
+  delete sampleBug;
 }
 
 

--- a/test/types/enum/lydia/declaredInClass2.chpl
+++ b/test/types/enum/lydia/declaredInClass2.chpl
@@ -5,7 +5,7 @@
 proc main() {
   var sampleBug = new Sample();
   writeln(sampleBug.tag);
-
+  delete sampleBug;
 }
 
 

--- a/test/types/enum/lydia/useAtClassScope.chpl
+++ b/test/types/enum/lydia/useAtClassScope.chpl
@@ -5,7 +5,7 @@
 proc main() {
   var sampleBug = new Sample();
   writeln(sampleBug.tag);
-
+  delete sampleBug;
 }
 
 enum classTag { field1,


### PR DESCRIPTION
Doesn't matter right now because they don't compile, but we don't want to start
leaking memory when they do