### PR TITLE
Convert TBAA to LLVM 4.0 format

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -800,8 +800,9 @@ void ArgSymbol::accept(AstVisitor* visitor) {
 TypeSymbol::TypeSymbol(const char* init_name, Type* init_type) :
   Symbol(E_TypeSymbol, init_name, init_type),
     llvmType(NULL),
-    llvmTbaaNode(NULL), llvmConstTbaaNode(NULL),
-    llvmTbaaStructNode(NULL), llvmConstTbaaStructNode(NULL),
+    llvmTbaaTypeDescriptor(NULL),
+    llvmTbaaAccessTag(NULL), llvmConstTbaaAccessTag(NULL),
+    llvmTbaaStructCopyNode(NULL), llvmConstTbaaStructCopyNode(NULL),
     llvmDIType(NULL),
     doc(NULL)
 {

--- a/compiler/codegen/expr.cpp
+++ b/compiler/codegen/expr.cpp
@@ -395,7 +395,7 @@ llvm::StoreInst* codegenStoreLLVM(llvm::Value* val,
   GenInfo *info = gGenInfo;
   llvm::StoreInst* ret = info->builder->CreateStore(val, ptr);
   llvm::MDNode* tbaa = NULL;
-  if( USE_TBAA && valType ) tbaa = valType->symbol->llvmTbaaNode;
+  if( USE_TBAA && valType ) tbaa = valType->symbol->llvmTbaaAccessTag;
   if( tbaa ) ret->setMetadata(llvm::LLVMContext::MD_tbaa, tbaa);
 
   if(!info->loopStack.empty()) {
@@ -448,8 +448,8 @@ llvm::LoadInst* codegenLoadLLVM(llvm::Value* ptr,
   llvm::LoadInst* ret = info->builder->CreateLoad(ptr);
   llvm::MDNode* tbaa = NULL;
   if( USE_TBAA && valType ) {
-    if( isConst ) tbaa = valType->symbol->llvmConstTbaaNode;
-    else tbaa = valType->symbol->llvmTbaaNode;
+    if( isConst ) tbaa = valType->symbol->llvmConstTbaaAccessTag;
+    else tbaa = valType->symbol->llvmTbaaAccessTag;
   }
 
   if(!info->loopStack.empty()) {
@@ -2710,8 +2710,8 @@ void codegenCallMemcpy(GenRet dest, GenRet src, GenRet size,
     llvm::MDNode* tbaaTag = NULL;
     llvm::MDNode* tbaaStructTag = NULL;
     if( pointedToType ) {
-      tbaaTag = pointedToType->symbol->llvmTbaaNode;
-      tbaaStructTag = pointedToType->symbol->llvmTbaaStructNode;
+      tbaaTag = pointedToType->symbol->llvmTbaaAccessTag;
+      tbaaStructTag = pointedToType->symbol->llvmTbaaStructCopyNode;
     }
     // For structures, ONLY set the tbaa.struct metadata, since
     // generally speaking simple tbaa tags don't make sense for structs.
@@ -2780,7 +2780,7 @@ void codegenCopy(GenRet dest, GenRet src, Type* chplType=NULL)
   if( ! info->cfile ) {
     bool useMemcpy = false;
 
-    if( chplType && chplType->symbol->llvmTbaaStructNode ) {
+    if( chplType && chplType->symbol->llvmTbaaStructCopyNode ) {
       // Always use memcpy for things for which we've developed LLVM
       // struct nodes for alias analysis, since as far as we know, we
       // can't use tbaa.struct for load/store.

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -359,19 +359,21 @@ class TypeSymbol : public Symbol {
   // and cache it if it has.
 #ifdef HAVE_LLVM
   llvm::Type* llvmType;
-  llvm::MDNode* llvmTbaaNode;
-  llvm::MDNode* llvmConstTbaaNode;
-  llvm::MDNode* llvmTbaaStructNode;
-  llvm::MDNode* llvmConstTbaaStructNode;
+  llvm::MDNode* llvmTbaaTypeDescriptor;
+  llvm::MDNode* llvmTbaaAccessTag;
+  llvm::MDNode* llvmConstTbaaAccessTag;
+  llvm::MDNode* llvmTbaaStructCopyNode;
+  llvm::MDNode* llvmConstTbaaStructCopyNode;
   llvm::MDNode* llvmDIType;
 #else
   // Keep same layout so toggling HAVE_LLVM
   // will not lead to build errors without make clean
   void* llvmType;
-  void* llvmTbaaNode;
-  void* llvmConstTbaaNode;
-  void* llvmTbaaStructNode;
-  void* llvmConstTbaaStructNode;
+  void* llvmTbaaTypeDescriptor;
+  void* llvmTbaaAccessTag;
+  void* llvmConstTbaaAccessTag;
+  void* llvmTbaaStructCopyNode;
+  void* llvmConstTbaaStructCopyNode;
   void* llvmDIType;
 #endif
 


### PR DESCRIPTION
This converts from the old TBAA to the new struct-path TBAA format for LLVM.

There used to be just one kind of TBAA node for normal accesses.  Now there are two: the type descriptor and the access tag.  The access tag points to the type descriptor, and `!tbaa` annotations should always use the access tag.

This change only converts the format.  In the long run, handling of struct members needs improvement.  They are correct, just suboptimal because right now they can alias with anything of the member type.