### PR TITLE
Significantly reduce nondeterminism in the compiler

### DIFF
--- a/compiler/AST/baseAST.cpp
+++ b/compiler/AST/baseAST.cpp
@@ -57,6 +57,48 @@ static int uid = 1;
 
 #define sum_gvecs(type) g##type##s.n
 
+#define def_vec_hash(SomeType) \
+    template<> \
+    uintptr_t _vec_hasher(SomeType* obj) { \
+      if (obj == NULL) { \
+        return 0; \
+      } else { \
+        return (uintptr_t)((BaseAST*)obj)->id; \
+      } \
+    }
+
+def_vec_hash(SymExpr)
+def_vec_hash(UnresolvedSymExpr)
+def_vec_hash(DefExpr)
+def_vec_hash(ContextCallExpr)
+def_vec_hash(ForallExpr)
+def_vec_hash(NamedExpr)
+def_vec_hash(UseStmt)
+def_vec_hash(BlockStmt)
+def_vec_hash(CondStmt)
+def_vec_hash(GotoStmt)
+def_vec_hash(DeferStmt)
+def_vec_hash(ForallStmt)
+def_vec_hash(TryStmt)
+def_vec_hash(ForwardingStmt)
+def_vec_hash(CatchStmt)
+def_vec_hash(ExternBlockStmt)
+def_vec_hash(Expr)
+def_vec_hash(ModuleSymbol)
+def_vec_hash(VarSymbol)
+def_vec_hash(ArgSymbol)
+def_vec_hash(TypeSymbol)
+def_vec_hash(FnSymbol)
+def_vec_hash(EnumSymbol)
+def_vec_hash(LabelSymbol)
+def_vec_hash(Symbol)
+def_vec_hash(PrimitiveType)
+def_vec_hash(EnumType)
+def_vec_hash(AggregateType)
+def_vec_hash(Type)
+
+#undef def_vec_hash
+
 //
 // Throughout printStatistics(), "n" indicates the number of nodes;
 // "k" indicates how many KiB memory they occupy: k = n * sizeof(node) / 1024.

--- a/compiler/AST/baseAST.cpp
+++ b/compiler/AST/baseAST.cpp
@@ -57,45 +57,28 @@ static int uid = 1;
 
 #define sum_gvecs(type) g##type##s.n
 
+// Increment ID by one to avoid weird edge case where 'obj' somehow has an
+// AST ID of zero. Our home-grown Vec will do something like "!v[k]" on a
+// MapElem, where 'k' is a BaseAST*. If we return zero here when 'k' is not
+// NULL, Vec will stop searching before the correct MapElem is found.
+//
+// TODO: how can something have an AST ID of zero? Uninitialized memory??
+// For future reference, the 'arrays.chpl' primer would fail if we did not
+// increment here.
 #define def_vec_hash(SomeType) \
     template<> \
     uintptr_t _vec_hasher(SomeType* obj) { \
       if (obj == NULL) { \
         return 0; \
       } else { \
-        return (uintptr_t)((BaseAST*)obj)->id; \
+        return 1 + (uintptr_t)((BaseAST*)obj)->id; \
       } \
     }
 
-def_vec_hash(SymExpr)
-def_vec_hash(UnresolvedSymExpr)
-def_vec_hash(DefExpr)
-def_vec_hash(ContextCallExpr)
-def_vec_hash(ForallExpr)
-def_vec_hash(NamedExpr)
-def_vec_hash(UseStmt)
-def_vec_hash(BlockStmt)
-def_vec_hash(CondStmt)
-def_vec_hash(GotoStmt)
-def_vec_hash(DeferStmt)
-def_vec_hash(ForallStmt)
-def_vec_hash(TryStmt)
-def_vec_hash(ForwardingStmt)
-def_vec_hash(CatchStmt)
-def_vec_hash(ExternBlockStmt)
-def_vec_hash(Expr)
-def_vec_hash(ModuleSymbol)
-def_vec_hash(VarSymbol)
-def_vec_hash(ArgSymbol)
-def_vec_hash(TypeSymbol)
-def_vec_hash(FnSymbol)
-def_vec_hash(EnumSymbol)
-def_vec_hash(LabelSymbol)
-def_vec_hash(Symbol)
-def_vec_hash(PrimitiveType)
-def_vec_hash(EnumType)
-def_vec_hash(AggregateType)
-def_vec_hash(Type)
+foreach_ast(def_vec_hash);
+def_vec_hash(Symbol);
+def_vec_hash(Type);
+def_vec_hash(BaseAST);
 
 #undef def_vec_hash
 

--- a/compiler/AST/baseAST.cpp
+++ b/compiler/AST/baseAST.cpp
@@ -57,21 +57,13 @@ static int uid = 1;
 
 #define sum_gvecs(type) g##type##s.n
 
-// Increment ID by one to avoid weird edge case where 'obj' somehow has an
-// AST ID of zero. Our home-grown Vec will do something like "!v[k]" on a
-// MapElem, where 'k' is a BaseAST*. If we return zero here when 'k' is not
-// NULL, Vec will stop searching before the correct MapElem is found.
-//
-// TODO: how can something have an AST ID of zero? Uninitialized memory??
-// For future reference, the 'arrays.chpl' primer would fail if we did not
-// increment here.
 #define def_vec_hash(SomeType) \
     template<> \
     uintptr_t _vec_hasher(SomeType* obj) { \
       if (obj == NULL) { \
         return 0; \
       } else { \
-        return 1 + (uintptr_t)((BaseAST*)obj)->id; \
+        return (uintptr_t)((BaseAST*)obj)->id; \
       } \
     }
 

--- a/compiler/adt/vec.cpp
+++ b/compiler/adt/vec.cpp
@@ -58,6 +58,21 @@ unsigned int prime2[] = {
   4194301, 8388593, 16777213, 33554393, 67108859, 134217689,
   268435399, 536870909
 };
+
+template<>
+uintptr_t _vec_hasher(const char* obj) {
+  uintptr_t h = 0;
+  while (obj != NULL && *obj) h = h * 27 + (unsigned char)*obj++;
+  return h;
+}
+template<>
+uintptr_t _vec_hasher(unsigned int obj) {
+  return obj;
+}
+template<>
+uintptr_t _vec_hasher(int obj) {
+  return obj;
+}
   
 // binary search over intervals
 static int

--- a/compiler/include/baseAST.h
+++ b/compiler/include/baseAST.h
@@ -415,6 +415,86 @@ def_to_ast(ParamForLoop);
 
 #undef def_to_ast
 
+#define def_hash_ast(SomeType) \
+  namespace std { \
+    template<> struct less<SomeType*> { \
+      bool operator()(const SomeType* lhs, const SomeType* rhs) const { \
+        if (lhs == NULL && rhs != NULL) return true; \
+        if (lhs != NULL && rhs == NULL) return false; \
+        if (lhs == NULL && rhs == NULL) return false; \
+        return ((BaseAST*)lhs)->id < ((BaseAST*)rhs)->id; \
+      } \
+    }; \
+  }
+
+def_hash_ast(SymExpr)
+def_hash_ast(UnresolvedSymExpr)
+def_hash_ast(DefExpr)
+def_hash_ast(ContextCallExpr)
+def_hash_ast(ForallExpr)
+def_hash_ast(NamedExpr)
+def_hash_ast(UseStmt)
+def_hash_ast(BlockStmt)
+def_hash_ast(CondStmt)
+def_hash_ast(GotoStmt)
+def_hash_ast(DeferStmt)
+def_hash_ast(ForallStmt)
+def_hash_ast(TryStmt)
+def_hash_ast(ForwardingStmt)
+def_hash_ast(CatchStmt)
+def_hash_ast(ExternBlockStmt)
+def_hash_ast(Expr)
+def_hash_ast(ModuleSymbol)
+def_hash_ast(VarSymbol)
+def_hash_ast(ArgSymbol)
+def_hash_ast(TypeSymbol)
+def_hash_ast(FnSymbol)
+def_hash_ast(EnumSymbol)
+def_hash_ast(LabelSymbol)
+def_hash_ast(Symbol)
+def_hash_ast(PrimitiveType)
+def_hash_ast(EnumType)
+def_hash_ast(AggregateType)
+def_hash_ast(Type)
+
+#undef def_hash_ast
+
+#define def_vec_hash(SomeType) \
+    template<> \
+    uintptr_t _vec_hasher(SomeType* obj);
+
+def_vec_hash(SymExpr)
+def_vec_hash(UnresolvedSymExpr)
+def_vec_hash(DefExpr)
+def_vec_hash(ContextCallExpr)
+def_vec_hash(ForallExpr)
+def_vec_hash(NamedExpr)
+def_vec_hash(UseStmt)
+def_vec_hash(BlockStmt)
+def_vec_hash(CondStmt)
+def_vec_hash(GotoStmt)
+def_vec_hash(DeferStmt)
+def_vec_hash(ForallStmt)
+def_vec_hash(TryStmt)
+def_vec_hash(ForwardingStmt)
+def_vec_hash(CatchStmt)
+def_vec_hash(ExternBlockStmt)
+def_vec_hash(Expr)
+def_vec_hash(ModuleSymbol)
+def_vec_hash(VarSymbol)
+def_vec_hash(ArgSymbol)
+def_vec_hash(TypeSymbol)
+def_vec_hash(FnSymbol)
+def_vec_hash(EnumSymbol)
+def_vec_hash(LabelSymbol)
+def_vec_hash(Symbol)
+def_vec_hash(PrimitiveType)
+def_vec_hash(EnumType)
+def_vec_hash(AggregateType)
+def_vec_hash(Type)
+
+#undef def_vec_hash
+
 static inline LcnSymbol* toLcnSymbol(BaseAST* a)
 {
   return isLcnSymbol(a) ? (LcnSymbol*) a : NULL;

--- a/compiler/include/baseAST.h
+++ b/compiler/include/baseAST.h
@@ -83,6 +83,7 @@
 #define for_alive_in_Vec(TYPE, VAR, VEC)           \
   forv_Vec(TYPE, VAR, VEC) if (VAR->inTree())
 
+class BaseAST;
 class AstVisitor;
 class Expr;
 class GenRet;
@@ -104,6 +105,17 @@ class QualifiedType;
 #define proto_classes(type) class type
 foreach_ast(proto_classes);
 #undef proto_classes
+
+#define def_vec_hash(SomeType) \
+    template<> \
+    uintptr_t _vec_hasher(SomeType* obj);
+
+foreach_ast(def_vec_hash);
+def_vec_hash(Symbol);
+def_vec_hash(Type);
+def_vec_hash(BaseAST);
+
+#undef def_vec_hash
 
 //
 // declare global vectors for all AST node types
@@ -457,43 +469,15 @@ def_hash_ast(EnumType)
 def_hash_ast(AggregateType)
 def_hash_ast(Type)
 
+def_hash_ast(LoopStmt);
+def_hash_ast(WhileStmt);
+def_hash_ast(WhileDoStmt);
+def_hash_ast(DoWhileStmt);
+def_hash_ast(ForLoop);
+def_hash_ast(CForLoop);
+def_hash_ast(ParamForLoop);
+
 #undef def_hash_ast
-
-#define def_vec_hash(SomeType) \
-    template<> \
-    uintptr_t _vec_hasher(SomeType* obj);
-
-def_vec_hash(SymExpr)
-def_vec_hash(UnresolvedSymExpr)
-def_vec_hash(DefExpr)
-def_vec_hash(ContextCallExpr)
-def_vec_hash(ForallExpr)
-def_vec_hash(NamedExpr)
-def_vec_hash(UseStmt)
-def_vec_hash(BlockStmt)
-def_vec_hash(CondStmt)
-def_vec_hash(GotoStmt)
-def_vec_hash(DeferStmt)
-def_vec_hash(ForallStmt)
-def_vec_hash(TryStmt)
-def_vec_hash(ForwardingStmt)
-def_vec_hash(CatchStmt)
-def_vec_hash(ExternBlockStmt)
-def_vec_hash(Expr)
-def_vec_hash(ModuleSymbol)
-def_vec_hash(VarSymbol)
-def_vec_hash(ArgSymbol)
-def_vec_hash(TypeSymbol)
-def_vec_hash(FnSymbol)
-def_vec_hash(EnumSymbol)
-def_vec_hash(LabelSymbol)
-def_vec_hash(Symbol)
-def_vec_hash(PrimitiveType)
-def_vec_hash(EnumType)
-def_vec_hash(AggregateType)
-def_vec_hash(Type)
-
-#undef def_vec_hash
 
 static inline LcnSymbol* toLcnSymbol(BaseAST* a)
 {

--- a/compiler/include/map.h
+++ b/compiler/include/map.h
@@ -75,7 +75,7 @@ template <class K, class C> class MapElem {
   C     value;
   bool operator==(MapElem &e) { return e.key == key; }
 
-  operator uintptr_t()     { return (uintptr_t) key; }
+  operator uintptr_t()     { return _vec_hasher(key); }
 
   MapElem()                 : key(0)                     { }
   MapElem(K akey, C avalue) : key(akey),  value(avalue)  { }

--- a/compiler/include/map.h
+++ b/compiler/include/map.h
@@ -83,6 +83,11 @@ template <class K, class C> class MapElem {
   MapElem(unsigned long x)                               { assert(!x); key = 0; }
 };
 
+template<class K, class C>
+uintptr_t _vec_hasher(MapElem<K,C> obj) {
+  return _vec_hasher(obj.key);
+}
+
 template <class K, class C> class Map : public Vec<MapElem<K,C> > {
  public:
   using Vec<MapElem<K, C> >::n;
@@ -247,8 +252,7 @@ template <class K, class C> inline void
 Map<K,C>::get_values(Vec<C> &values) {
   for (int i = 0; i < n; i++)
     if (v[i].key)
-      values.set_add(v[i].value);
-  values.set_to_vec();
+      values.add(v[i].value);
 }
 
 template <class K, class C> inline MapElem<K,C> *

--- a/compiler/include/map.h
+++ b/compiler/include/map.h
@@ -75,7 +75,14 @@ template <class K, class C> class MapElem {
   C     value;
   bool operator==(MapElem &e) { return e.key == key; }
 
-  operator uintptr_t()     { return _vec_hasher(key); }
+  //
+  // A Map needs some way of indicating whether a slot is full or empty.
+  // We use the pointer value of a key to indicate that status. Note that
+  // a key can be a BaseAST, which can be deleted over the course of
+  // compilation. Therefore, we cannot access the memory pointed to by
+  // this key in order to test full/empty status.
+  //
+  operator uintptr_t()     { return (uintptr_t)key; }
 
   MapElem()                 : key(0)                     { }
   MapElem(K akey, C avalue) : key(akey),  value(avalue)  { }

--- a/compiler/include/vec.h
+++ b/compiler/include/vec.h
@@ -64,6 +64,11 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #define SET_MAX_PROBE           5
 #define SET_INITIAL_INDEX       2
 
+template<typename T>
+uintptr_t _vec_hasher(T obj) {
+  return (uintptr_t)obj;
+}
+
 template <class C, int S = VEC_INTEGRAL_SIZE>  // S must be a power of 2
 class Vec {
  public:
@@ -393,7 +398,7 @@ template <class C, int S> C *
 Vec<C,S>::set_add_internal(C c) {
   int j, k;
   if (n) {
-    uintptr_t h = (uintptr_t)c;
+    uintptr_t h = _vec_hasher(c);
     h = h % n;
     for (k = h, j = 0;
          k < n && j < SET_MAX_PROBE;
@@ -418,7 +423,7 @@ template <class C, int S> C *
 Vec<C,S>::set_in_internal(C c) {
   int j, k;
   if (n) {
-    uintptr_t h = (uintptr_t)c;
+    uintptr_t h = _vec_hasher(c);
     h = h % n;
     for (k = h, j = 0;
          k < n && j < SET_MAX_PROBE;

--- a/compiler/include/vec.h
+++ b/compiler/include/vec.h
@@ -64,10 +64,19 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #define SET_MAX_PROBE           5
 #define SET_INITIAL_INDEX       2
 
+// Do not define the generic variation of _vec_hasher, requiring us to write
+// a _vec_hasher for potential types.
+//
+// This will help prevent us from hashing on pointer values as we once did.
 template<typename T>
-uintptr_t _vec_hasher(T obj) {
-  return (uintptr_t)obj;
-}
+uintptr_t _vec_hasher(T obj);
+
+template<>
+uintptr_t _vec_hasher(const char* obj);
+template<>
+uintptr_t _vec_hasher(unsigned int obj);
+template<>
+uintptr_t _vec_hasher(int obj);
 
 template <class C, int S = VEC_INTEGRAL_SIZE>  // S must be a power of 2
 class Vec {


### PR DESCRIPTION
This PR implements templated functions that hash BaseAST-inheriting classes based on their AST IDs. For a long time we have hashed on the pointer value which can change from run to run, which made debugging the compiler difficult due to differing AST IDs.

To test the effectiveness of this PR I compiled HPCC stream and saved the generated code with --gen-ids as a reference point. I then compiled with the same flags roughly ten times. On master there were on average 80,000 lines different between the reference and a given run's generated code. With this PR, there are no differences run to run.

For our home-grown Map and Vec classes, I have implemented a templated function called ``_vec_hasher``. I have left the fully generic version of this function undefined, forcing us to consider what the hash of an object should be lest we mistakenly use pointer values in the future.

For c++ standard containers I have implemented the ``less`` comparator, which compares AST IDs.

I have also modified ``Map:: get_values`` such that it will no longer return a Vec of unique values. This method seemed to only be used for virtual methods and children, where the values were pointers to a Vec<FnSymbol*>. Instead of trying to figure out what a good hash of a Vec would be, I observed that we do not re-use values across different keys. This means that ``Map::get_values`` need not attempt to create a Vec of unique values.

Testing:
- [x] full local
- [x] full no-local
- [x] full gasnet