### PR TITLE
Add Symbol::getInitialization(), use it in parallel.cpp

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -418,13 +418,11 @@ Expr* Symbol::getInitialization() const {
       }
     }
 
-    if (isDef || isUse) {
+    if (isDef) {
+      // first use/def of the variable is a def (normal case)
+      return stmt->getStmtExpr();
 
-      if (isDef) {
-        // first use/def of the variable is a def (normal case)
-        return stmt->getStmtExpr();
-      }
-
+    } else if (isUse) {
       bool handled = false;
 
       // handle PRIM_MOVE refTmp, PRIM_ADDR_OF curSym or

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -379,6 +379,84 @@ SymExpr* Symbol::getSingleDef() const {
 }
 
 
+Expr* Symbol::getInitialization() const {
+  // In theory, this should be the first "def" for the symbol,
+  // but that might be obfuscated by PRIM_ADDR_OF.
+
+  FnSymbol* fn = toFnSymbol(defPoint->parentSymbol);
+  ModuleSymbol* mod = toModuleSymbol(defPoint->parentSymbol);
+  if (fn == NULL && mod != NULL ) {
+    // Global variables are initialized in their module init function
+    fn = mod->initFn;
+  }
+
+  Expr* stmt;
+  // We'll search statements starting with stmt for the one
+  // initializing our variable.
+  if (mod != NULL) {
+    stmt = fn->body->body.head;
+  } else {
+    stmt = defPoint->getStmtExpr()->next;
+  }
+
+  const Symbol *curSym = this;
+  const Symbol *refSym = NULL;
+
+  while (stmt != NULL) {
+    std::vector<SymExpr*> symExprs;
+    collectSymExprs(stmt, symExprs);
+
+    bool isDef = false;
+    bool isUse = false;
+
+    for_vector(SymExpr, se, symExprs) {
+      Symbol* sym = se->symbol();
+      if (sym == curSym || sym == refSym) {
+        int result = isDefAndOrUse(se);
+        isDef |= (result & 1);
+        isUse |= (result & 2);
+      }
+    }
+
+    if (isDef || isUse) {
+
+      if (isDef) {
+        // first use/def of the variable is a def (normal case)
+        return stmt->getStmtExpr();
+      }
+
+      bool handled = false;
+
+      // handle PRIM_MOVE refTmp, PRIM_ADDR_OF curSym or
+      // handle PRIM_MOVE refTmp, PRIM_SET_REFERENCE curSym
+      if (CallExpr* call = toCallExpr(stmt)) {
+        if (call->isPrimitive(PRIM_MOVE)) {
+          SymExpr* dstSe = toSymExpr(call->get(1));
+          CallExpr* getRef = toCallExpr(call->get(2));
+
+          if (getRef != NULL) {
+            if (getRef->isPrimitive(PRIM_ADDR_OF) ||
+                getRef->isPrimitive(PRIM_SET_REFERENCE)) {
+              // Start looking for the first def of the captured reference
+
+              INT_ASSERT(dstSe);
+              // Doesn't handle multiple refs before finding initialization
+              INT_ASSERT(refSym == NULL);
+              refSym = dstSe->symbol();
+              handled = true;
+            }
+          }
+        }
+      }
+
+      INT_ASSERT(handled); // did we encounter new AST pattern?
+    }
+    stmt = stmt->next;
+  }
+
+  INT_FATAL(defPoint, "couldn't find initialization");
+  return NULL;
+}
 
 
 bool Symbol::isImmediate() const {

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -168,6 +168,15 @@ public:
   SymExpr*           getSingleUse()                            const;
   // Return the single def of this Symbol, or NULL if there are 0 or >= 2
   SymExpr*           getSingleDef()                            const;
+
+  // The compiler really ought to view a call to `init` that
+  // constructs a const record as the single "def". However it
+  // might consider it a "use" for various reasons. This method
+  // is useful for finding such cases.
+  // This function finds the statement expression that is responsible
+  // for initializing this symbol.
+  Expr*              getInitialization()                       const;
+
 protected:
                      Symbol(AstTag      astTag,
                             const char* init_name,

--- a/compiler/passes/parallel.cpp
+++ b/compiler/passes/parallel.cpp
@@ -1198,10 +1198,10 @@ static void findHeapVarsAndRefs(Map<Symbol*, Vec<SymExpr*>*>& defMap,
 
         for_defs(se, defMap, def->sym) {
           if (firstDef == NULL)
-	    firstDef = se->getStmtExpr();
+            firstDef = se->getStmtExpr();
         }
 
-	INT_ASSERT(firstDef == NULL || firstDef == initialization);
+        INT_ASSERT(firstDef == NULL || firstDef == initialization);
 
         initialization->insertAfter(new CallExpr(PRIM_PRIVATE_BROADCAST,
                                                  def->sym));

--- a/compiler/passes/parallel.cpp
+++ b/compiler/passes/parallel.cpp
@@ -918,7 +918,8 @@ replicateGlobalRecordWrappedVars(DefExpr *def) {
     INT_ASSERT(stmt == initialization);
     stmt->insertAfter(new CallExpr(PRIM_PRIVATE_BROADCAST, def->sym));
   } else {
-    INT_ASSERT(0);
+    // This branch should go away if this INT_FATAL never fires.
+    INT_FATAL("could not find initialization");
     mod->initFn->insertBeforeEpilogue(new CallExpr
                                      (PRIM_PRIVATE_BROADCAST, def->sym));
   }

--- a/test/classes/initializers/records/const-record.skipif
+++ b/test/classes/initializers/records/const-record.skipif
@@ -1,2 +1,0 @@
-# This test currently fails under gasnet
-CHPL_COMM != none


### PR DESCRIPTION
In this first commit, parallel.cpp computes the initialization point two
ways - the old way and also the new way. The intent is to verify that the
new code behaves the same.

In a future commit, we'll need to remove the old implementation.

Passed quickstart+gasnet testing.
Passed qthreads+gasnet testing.
Passed full local testing.

Reviewed by @benharsh - thanks!
