### PR TITLE
Re-enable parallel make support for GASNet

### DIFF
--- a/third-party/gasnet/Makefile
+++ b/third-party/gasnet/Makefile
@@ -95,15 +95,10 @@ gasnet-config: FORCE
 	$(XTRA_CONFIG_COMMAND)
 	cd $(GASNET_BUILD_DIR) && $(CHPL_GASNET_ENV_VARS) $(GASNET_SUBDIR)/$(CHPL_GASNET_CFG_SCRIPT) --prefix=$(GASNET_INSTALL_DIR) $(CHPL_GASNET_CFG_OPTIONS) --disable-seq --enable-par --disable-parsync $(CHPL_GASNET_CFG_OPTIONS)
 
-#
-# Force serial make using -j1, to avoid the problem documented by
-#     https://upc-bugs.lbl.gov/bugzilla/show_bug.cgi?id=3389
-# which can corrupt gasnet_config.h.
-#
-gasnet-build: gasnet-config
-	cd $(GASNET_BUILD_DIR) && $(MAKE) -j1 all
+gasnet-build: FORCE
+	cd $(GASNET_BUILD_DIR) && $(MAKE) all
 
-gasnet-install: gasnet-build
+gasnet-install: FORCE
 	cd $(GASNET_BUILD_DIR) && $(MAKE) install
 	$(XTRA_POST_INSTALL_COMMAND)
 
@@ -116,7 +111,7 @@ gasnet-install: gasnet-build
 post-install: FORCE
 	$(foreach mkfile, $(MKFILES), sed -i -e "s;$(GASNET_INSTALL_DIR);"'$$(GASNET_INSTALL_DIR);g' $(mkfile) &&) true
 
-gasnet: gasnet-install
+gasnet: gasnet-config gasnet-build gasnet-install
 
 FORCE:
 


### PR DESCRIPTION
GASNet 1.28.2 fixed support for parallel make, so stop forcing serial make.
This effectively reverts #4911