### PR TITLE
Add another test of type fields and default values for type arguments

### DIFF
--- a/test/classes/initializers/generics/typeArgDefaultValue2.chpl
+++ b/test/classes/initializers/generics/typeArgDefaultValue2.chpl
@@ -1,0 +1,24 @@
+// This test exercises when a generic type argument to an initializer on a
+// generic class with a type field has a default value
+
+class Foo {
+  type t = bool;
+  var x: t;
+
+  proc init(type tVal = bool) {
+    t = tVal;
+    super.init();
+  }
+}
+
+var foo1 = new Foo(int); // specifies a different value
+var foo2 = new Foo(); // relies on the default value
+var foo3 = new Foo(bool); // specifies the same value as the default
+
+writeln(foo1);
+writeln(foo2);
+writeln(foo3);
+
+delete foo1;
+delete foo2;
+delete foo3;

--- a/test/classes/initializers/generics/typeArgDefaultValue2.good
+++ b/test/classes/initializers/generics/typeArgDefaultValue2.good
@@ -1,0 +1,3 @@
+{x = 0}
+{x = false}
+{x = false}


### PR DESCRIPTION
I got myself confused when looking at the test/studies/hpcc/ changes and
convinced myself there was something wrong with default values for type
arguments when the type field being assigned to was declared with an initial
value.  Turns out the problem was I had only partially converted the constructor
into an initializer (having forgotten to update the name).  But I wrote this
test when investigating and it worked just fine so might as well keep it.

Passed a fresh checkout