### PR TITLE
Add gasnet-fast testing for darwin

### DIFF
--- a/util/cron/test-darwin.bash
+++ b/util/cron/test-darwin.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Test default configuration on mac os x.
+# Test default configuration on darwin
 
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common.bash

--- a/util/cron/test-gasnet.fast.darwin.bash
+++ b/util/cron/test-gasnet.fast.darwin.bash
@@ -1,14 +1,15 @@
 #!/usr/bin/env bash
 #
-# Test gasnet (segment everything) against full suite on darwin
+# Test gasnet (segment fast) against hellos on darwin
 
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common-gasnet.bash
+export CHPL_GASNET_SEGMENT=fast
 
 # Use relay SMTP server, since postfix does not reliably start when test
 # machine is rebooted.
 export CHPL_UTIL_SMTP_HOST=relaya
 
-export CHPL_NIGHTLY_TEST_CONFIG_NAME="gasnet.darwin"
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="gasnet.fast.darwin"
 
-$CWD/nightly -cron
+$CWD/nightly -cron -hellos


### PR DESCRIPTION
Test the hellos for gasnet-fast on darwin. GASNet 1.28.2 fixed pshm support for
OSX, but we don't currently run a config that tests that mode.