### PR TITLE
AstDumpToNode support for ForallStmt

### DIFF
--- a/compiler/AST/AstDumpToNode.cpp
+++ b/compiler/AST/AstDumpToNode.cpp
@@ -25,6 +25,7 @@
 #include "driver.h"
 #include "expr.h"
 #include "flags.h"
+#include "ForallStmt.h"
 #include "ForLoop.h"
 #include "log.h"
 #include "ParamForLoop.h"
@@ -166,7 +167,7 @@ void AstDumpToNode::writeNodeID(BaseAST* node,
     const char* sa = spaceAfter  ? " " : "";
 
     if (compact)
-      fprintf(mFP, "%s%d%s",   sb, node->id, sa);
+      fprintf(mFP, "%s%d%s",  sb, node->id, sa);
     else
       fprintf(mFP, "%s%7d%s", sb, node->id, sa);
   }
@@ -386,6 +387,62 @@ bool AstDumpToNode::enterBlockStmt(BlockStmt* node)
   newline();
   exitNode(node);
   write(false, "", true);
+
+  return false;
+}
+
+//
+//
+//
+
+bool AstDumpToNode::enterForallIntent(ForallIntent* node)
+{
+  enterNode(node);
+  mOffset = mOffset + 2;
+
+  fprintf(mFP, " %s", tfiTagDescrString(node->intent()));
+
+  newline();
+  fputs("variable:   ", mFP);
+  node->variable()->accept(this);
+
+  if (node->isReduce()) {
+    newline();
+    fputs("reduceExpr: ", mFP);
+    node->reduceExpr()->accept(this);
+  }
+
+  mOffset = mOffset - 2;
+  if (!compact) newline();
+  exitNode(node);
+
+  return false;
+}
+
+//
+//
+//
+
+bool AstDumpToNode::enterForallStmt(ForallStmt* node)
+{
+  enterNode(node);
+  write(false, "", true);
+
+  if (node->zippered())
+    write(true, "zip", true);
+  mOffset = mOffset + 2;
+
+  writeField("inductionVariables:  ", node->inductionVariables());
+  writeField("iteratedExpressions: ", node->iteratedExpressions());
+  writeField("intentVariables:     ", node->intentVariables());
+  writeField("forallIntents:       ", node->forallIntents());
+
+  newline();
+  writeField("loopBody: ", 10, node->loopBody());
+
+  mOffset = mOffset - 2;
+  newline();
+  exitNode(node);
 
   return false;
 }
@@ -716,6 +773,7 @@ bool AstDumpToNode::enterDefExpr(DefExpr* node)
   if (node->sym                 != 0 &&
       node->exprType            == 0 &&
       node->init                == 0 &&
+      compact                   == false &&
       isModuleSymbol(node->sym) == false &&
       isFnSymbol(node->sym)     == false &&
       isArgSymbol(node->sym)    == false)
@@ -928,18 +986,14 @@ bool AstDumpToNode::enterFnSym(FnSymbol* node)
 bool AstDumpToNode::enterCallExpr(CallExpr* node)
 {
   if (node->primitive == 0)
-    fprintf(mFP, "#<%-13s", "Call");
+    fprintf(mFP, compact ? "%s%s " : "%s%-13s", delimitEnter, "Call");
 
   else if (node->isPrimitive(PRIM_RETURN))
-    fprintf(mFP, "#<%-13s", "Return");
+    fprintf(mFP, compact ? "%s%s " : "%s%-13s", delimitEnter, "Return");
 
   else
-  {
-    char name[128];
-
-    sprintf(name, "PrimOp %s", node->primitive->name);
-    fprintf(mFP, "#<%-25s", name);
-  }
+    fprintf(mFP, compact ? "%sPrimOp %s " : "%sPrimOp %-18s",
+            delimitEnter, node->primitive->name);
 
   writeNodeID(node, false, false);
 
@@ -957,14 +1011,6 @@ bool AstDumpToNode::enterCallExpr(CallExpr* node)
       write(" on");
   }
 
-  if (compact)
-  {
-    if (PrimitiveOp* primitive = node->primitive)
-    {
-      fprintf(mFP, " '%s'", primitive->name);
-    }
-  }
-
   if (node->baseExpr)
   {
     newline();
@@ -978,7 +1024,7 @@ bool AstDumpToNode::enterCallExpr(CallExpr* node)
   }
 
   mOffset = mOffset - 2;
-  newline();
+  if (!compact) newline();
   exitNode(node);
 
   return false;
@@ -1014,7 +1060,7 @@ bool AstDumpToNode::enterNamedExpr(NamedExpr* node)
 {
   enterNode(node);
 
-  fprintf(mFP, "(%s =", node->name);
+  fprintf(mFP, compact ? " %s " : "(%s =", node->name);
   mNeedSpace = true;
 
   return true;
@@ -1022,7 +1068,9 @@ bool AstDumpToNode::enterNamedExpr(NamedExpr* node)
 
 void AstDumpToNode::exitNamedExpr(NamedExpr* node)
 {
-  write(false, ")", true);
+  if (!compact)
+    write(")");
+  exitNode(node);
 }
 
 //
@@ -1764,11 +1812,11 @@ void AstDumpToNode::writeSymbolCompact(Symbol* sym) const
   else
   {
     writeNodeID(sym, false, true);
-    fprintf(mFP, "%s", sym->astTagAsString());
+    fprintf(mFP, "%s %s", sym->astTagAsString(), sym->name);
 
   }
 
-  fprintf(mFP, "%s", delimitExit);
+  fputs(delimitExit, mFP);
 }
 
 void AstDumpToNode::ast_symbol(const char* tag, Symbol* sym, bool def)
@@ -1892,7 +1940,10 @@ int AstDumpToNode::writeQual(QualifiedType qual) const
 {
   const char* name = qual.qualStr();
 
-  fprintf(mFP, "qual: %-16s", name);
+  if (compact)
+    fprintf(mFP, " qual: %s", name);
+  else
+    fprintf(mFP, "qual: %-16s", name);
 
   return 6 + ((int) strlen(name));
 }
@@ -1982,6 +2033,29 @@ void AstDumpToNode::writeField(const char* msg, int offset, BaseAST* field) {
     field->accept(this);
     mOffset = mOffset - offset;
   }
+}
+
+void AstDumpToNode::writeField(const char* msg, AList& list) {
+  if (list.length == 0) return;
+
+  newline();
+  write(false, msg, false);
+  int offset = strlen(msg);
+
+  if (!compact) mOffset = mOffset + offset;
+
+  bool need_newline = compact ? true : false;
+  for_alist(next_ast, list)
+  {
+    if (need_newline)
+      newline();
+    else
+      need_newline = true;
+    next_ast->accept(this);
+  }
+
+  if (!compact) mOffset = mOffset - offset;
+  if (!compact) newline();
 }
 
 void AstDumpToNode::write(const char* text)

--- a/compiler/include/AstDumpToNode.h
+++ b/compiler/include/AstDumpToNode.h
@@ -22,6 +22,7 @@
 
 #include "AstLogger.h"
 
+#include "alist.h"
 #include <cstdio>
 
 class BaseAST;
@@ -118,6 +119,10 @@ public:
 
   virtual bool     enterBlockStmt      (BlockStmt*         node);
 
+  virtual bool     enterForallIntent   (ForallIntent*    intent);
+
+  virtual bool     enterForallStmt     (ForallStmt*        node);
+
   virtual bool     enterWhileDoStmt    (WhileDoStmt*       node);
 
   virtual bool     enterDoWhileStmt    (DoWhileStmt*       node);
@@ -158,23 +163,12 @@ private:
 
   void             newline();
 
-  void             logEnter(BaseAST* node);
-  void             logEnter(BaseAST* node, const char* fmt, ...);
-  void             logEnter(const char* fmt, ...);
-
-  void             logExit (BaseAST* node);
-  void             logExit (const char* fmt, ...);
-
-  void             logVisit(BaseAST* node);
-  void             logVisit(const char* fmt, ...);
-
-  void             logWrite(const char* fmt, ...);
-
   // enable compact mode
   void             enterNode(BaseAST* node)                             const;
   void             enterNodeSym(Symbol* node, const char* name = 0)     const;
   void             exitNode(BaseAST* node, bool addNewline = false)     const;
   void             writeField(const char* msg, int offset, BaseAST* field);
+  void             writeField(const char* msg, AList& list);
   void             writeLongString(const char* msg, const char* arg)    const;
   void             writeNodeID(BaseAST* node,
                                bool     spaceBefore,


### PR DESCRIPTION
These changes are my first shot at supporting ForallStmt
in AstDumpToNode visitor. We can improve as we gain experience.

While there, smoothen a couple of other aspects of AstDumpToNode.

Removed logEnter, logExit, logVisit, logWrite from AstDumpToNode.h
because they are not defined or used anywhere.