### PR TITLE
Resolve 1

### DIFF
--- a/compiler/include/initializerResolution.h
+++ b/compiler/include/initializerResolution.h
@@ -32,8 +32,6 @@ void modAndResolveInitCall (CallExpr* call, AggregateType* typeToNew);
 
 void temporaryInitializerFixup(CallExpr* call);
 
-void removeAggTypeFieldInfo();
-
 void resolveInitializer(CallExpr* call);
 
 #endif

--- a/compiler/include/initializerResolution.h
+++ b/compiler/include/initializerResolution.h
@@ -20,15 +20,15 @@
 #ifndef _INITIALIZER_RESOLUTION_H_
 #define _INITIALIZER_RESOLUTION_H_
 
-// Defines the resolution strategy for initializers.  This is different than
-// how normal generic functions are handled and how generic constructors are
-// handled, as we want to have the this argument for the type in the initializer
-// argument list, and want to utilize Phase 1 of the initializer body to
-// determine the generic instantiation of it.
-class AggregateType;
-class CallExpr;
+// Defines the resolution strategy for initializers.
 
-void temporaryInitializerFixup(CallExpr* call);
+// This is different than how normal generic functions are handled
+// and how generic constructors are handled, as we want to have the
+// this argument for the type in the initializer argument list,
+// and want to utilize Phase 1 of the initializer body to determine
+//  the generic instantiation of it.
+
+class CallExpr;
 
 void resolveInitializer(CallExpr* call);
 

--- a/compiler/include/initializerResolution.h
+++ b/compiler/include/initializerResolution.h
@@ -28,8 +28,6 @@
 class AggregateType;
 class CallExpr;
 
-void modAndResolveInitCall (CallExpr* call, AggregateType* typeToNew);
-
 void temporaryInitializerFixup(CallExpr* call);
 
 void resolveInitializer(CallExpr* call);

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5192,6 +5192,10 @@ static void resolveNewHandleGenericInitializer(CallExpr*      call,
   call->insertAtHead(new NamedExpr("this", new SymExpr(new_temp)));
   call->insertAtHead(new SymExpr(gMethodToken));
 
+  temporaryInitializerFixup(call);
+
+  resolveDefaultGenericType(call);
+
   resolveInitializer(call);
 
   // Because initializers determine the type they utilize based on the

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -7537,32 +7537,50 @@ static void cleanupVoidVarsAndFields() {
   }
 }
 
+/************************************* | **************************************
+*                                                                             *
+* pruneResolvedTree -- prunes and cleans the AST after                        *
+* of the function calls and types have been resolved                          *
+*                                                                             *
+************************************** | *************************************/
 
-//
-// pruneResolvedTree -- prunes and cleans the AST after all of the
-// function calls and types have been resolved
-//
-static void
-pruneResolvedTree() {
+static void removeAggTypeFieldInfo();
+
+static void pruneResolvedTree() {
   removeUnusedFunctions();
-  if (fRemoveUnreachableBlocks)
+
+  if (fRemoveUnreachableBlocks) {
     deadBlockElimination();
+  }
+
   removeRandomPrimitives();
+
   replaceTypeArgsWithFormalTypeTemps();
+
   removeParamArgs();
 
   removeAggTypeFieldInfo();
 
   removeUnusedModuleVariables();
+
   removeUnusedTypes();
+
   removeActualNames();
+
   removeFormalTypeAndInitBlocks();
+
   removeTypeBlocks();
+
   removeInitFields();
+
   removeWhereClauses();
+
   removeMootFields();
+
   expandInitFieldPrims();
+
   cleanupAfterRemoves();
+
   cleanupVoidVarsAndFields();
 }
 
@@ -7928,6 +7946,26 @@ static void removeParamArgs()
   }
 }
 
+static void removeAggTypeFieldInfo() {
+  forv_Vec(AggregateType, at, gAggregateTypes) {
+    if (at->symbol->defPoint && at->symbol->defPoint->parentSymbol) {
+      // Still in the tree
+      if (at->initializerStyle != DEFINES_CONSTRUCTOR) {
+        // Defined an initializer (so we left its init
+        // and exprType information in the tree)
+        for_fields(field, at) {
+          if (field->defPoint->exprType) {
+            field->defPoint->exprType->remove();
+          }
+
+          if (field->defPoint->init) {
+            field->defPoint->init->remove();
+          }
+        }
+      }
+    }
+  }
+}
 
 static void removeRandomPrimitives()
 {
@@ -8588,5 +8626,16 @@ static void setScalarPromotionType(AggregateType* at) {
     }
   }
 }
+
+
+
+
+
+
+
+
+
+
+
 
 

--- a/compiler/resolution/initializerResolution.cpp
+++ b/compiler/resolution/initializerResolution.cpp
@@ -324,50 +324,6 @@ gatherInitCandidates(Vec<ResolutionCandidate*>& candidates,
 /* end of function resolution steal */
 
 
-void modAndResolveInitCall (CallExpr* call, AggregateType* typeToNew) {
-  // Convert the PRIM_NEW to a normal call
-  call->primitive = NULL;
-  call->baseExpr  = call->get(1)->remove();
-
-  parent_insert_help(call, call->baseExpr);
-
-  VarSymbol* new_temp  = newTemp("new_temp", typeToNew);
-  DefExpr*   def       = new DefExpr(new_temp);
-
-  if (isBlockStmt(call->parentExpr) == true) {
-    call->insertBefore(def);
-
-  } else {
-    call->parentExpr->insertBefore(def);
-  }
-
-  // Invoking an instance method
-  call->insertAtHead(new NamedExpr("this", new SymExpr(new_temp)));
-  call->insertAtHead(new SymExpr(gMethodToken));
-
-  resolveInitializer(call);
-
-  // Because initializers determine the type they utilize based on the
-  // execution of Phase 1, if the type is generic we will need to update the
-  // type of the actual we are sending in for the this arg
-  if (typeToNew->symbol->hasFlag(FLAG_GENERIC) == true) {
-    new_temp->type = call->resolvedFunction()->_this->type;
-
-    if (isClass(typeToNew) == true) {
-      // use the allocator instead of directly calling the init method
-      // Need to convert the call into the right format
-      call->baseExpr->replace(new UnresolvedSymExpr("_new"));
-      call->get(1)->replace(new SymExpr(new_temp->type->symbol));
-      call->get(2)->remove();
-      // Need to resolve the allocator
-      resolveCall(call);
-      resolveFns(call->resolvedFunction());
-
-      def->remove();
-    }
-  }
-}
-
 void resolveInitializer(CallExpr* call) {
   // From resolveExpr() (removed the tryStack stuff)
   callStack.add(call);

--- a/compiler/resolution/initializerResolution.cpp
+++ b/compiler/resolution/initializerResolution.cpp
@@ -356,10 +356,6 @@ void resolveInitCall(CallExpr* call) {
     gdbShouldBreakHere();
   }
 
-  temporaryInitializerFixup(call);
-
-  resolveDefaultGenericType(call);
-
   // Make a CallInfo which doesn't care if the this argument is
   // generic, but otherwise should result in the same behavior.
   CallInfo info(call, false, true);

--- a/compiler/resolution/initializerResolution.cpp
+++ b/compiler/resolution/initializerResolution.cpp
@@ -737,37 +737,3 @@ static bool isRefWrapperForNonGenericRecord(AggregateType* at) {
 
   return retval;
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-void removeAggTypeFieldInfo() {
-  forv_Vec(AggregateType, at, gAggregateTypes) {
-    if (at->symbol->defPoint && at->symbol->defPoint->parentSymbol) {
-      // Still in the tree
-      if (at->initializerStyle != DEFINES_CONSTRUCTOR) {
-        // Defined an initializer (so we left its init and exprType information
-        // in the tree)
-        for_fields(field, at) {
-          if (field->defPoint->exprType) {
-            field->defPoint->exprType->remove();
-          }
-          if (field->defPoint->init) {
-            field->defPoint->init->remove();
-          }
-          // Remove the init and exprType information.
-        }
-      }
-    }
-  }
-}

--- a/compiler/resolution/initializerResolution.cpp
+++ b/compiler/resolution/initializerResolution.cpp
@@ -63,8 +63,6 @@ static void makeActualsVector(const CallExpr* call,
                               const CallInfo& info,
                               std::vector<ArgSymbol*>& actualIdxToFormal);
 
-static bool isRefWrapperForNonGenericRecord(AggregateType* at);
-
 // Rewrite of instantiateSignature, for initializers.  Removed some bits,
 // modified others.
 /** Instantiate enough of the function for it to make it through the candidate
@@ -621,71 +619,3 @@ static void makeActualsVector(const CallExpr* call,
   }
 }
 
-void temporaryInitializerFixup(CallExpr* call) {
-  if (UnresolvedSymExpr* usym = toUnresolvedSymExpr(call->baseExpr)) {
-    // Support super.init() calls (for instance) when the super type does not
-    // define either an initializer or a constructor.  Also ignores errors from
-    // improperly inserted .init() calls (so be sure to check here if something
-    // is behaving oddly - Lydia, 08/19/16)
-    if (strcmp(usym->unresolved, "init") == 0 &&
-        call->numActuals()               >= 2 &&
-        !isNamedExpr(call->get(2))) {
-      // Arg 2 will be a NamedExpr to "this" if we're in an intentionally
-      // inserted initializer call
-      SymExpr* _mt = toSymExpr(call->get(1));
-      SymExpr* sym = toSymExpr(call->get(2));
-
-      INT_ASSERT(sym != NULL);
-
-      if (AggregateType* ct = toAggregateType(sym->symbol()->type)) {
-
-        if (isRefWrapperForNonGenericRecord(ct) == false &&
-            ct->initializerStyle                == DEFINES_NONE_USE_DEFAULT) {
-          // Transitioning to a default initializer world. (Lydia note 03/14/17)
-          if (strcmp(ct->defaultInitializer->name, "init") == 0)
-            return;
-
-          // This code should be removed when the compiler generates
-          // initializers as the default method of construction and
-          // initialization for a type (Lydia note, 08/19/16)
-          usym->unresolved = astr("_construct_", ct->symbol->name);
-
-          _mt->remove();
-        }
-      }
-    }
-  }
-}
-
-
-//
-// Noakes 2017/03/26
-//   The function temporaryInitializerFixup is designed to update
-//   certain calls to init() while the initializer update matures.
-//
-//   Unfortunately this transformation is triggered incorrectly for uses of
-//           this.init(...);
-//
-//   inside initializers for non-generic records.
-//
-//   For those uses of init() the "this" argument has currently has type
-//   _ref(<Record>) rather than <Record>
-//
-//  This rather unfortunate function catches this case and enables the
-//  transformation to be skipped.
-//
-static bool isRefWrapperForNonGenericRecord(AggregateType* at) {
-  bool retval = false;
-
-  if (isClass(at)                           == true &&
-      strncmp(at->symbol->name, "_ref(", 5) == 0    &&
-      at->fields.length                     == 1) {
-    Symbol* sym = toDefExpr(at->fields.head)->sym;
-
-    if (strcmp(sym->name, "_val") == 0) {
-      retval = isNonGenericRecordWithInitializers(sym->type);
-    }
-  }
-
-  return retval;
-}


### PR DESCRIPTION
Early work on initializers cloned/specialized portions of normalize.cpp and functionResolution.cpp so
that initializers could advance without breaking the main control flow.

I recently started looking at the code of initializerResolution.cpp to try to better understand the
steps in resolving generics in general and generic initializers more specifically.  This lead to
opportunities to reintegrate portions of initializerResolution.cpp back in to functionResolution.cpp
and, to my surprise, an effort to start to untangle the control flow that originates from
resolveNormalCall().

This is the first of a series of straight forward updates to initializerResolution.cpp (henceforth
IR.cpp) and functionResolution.cpp (FR.cpp) to merge the result of that work to master.


This PR has 6 simple commits.  A fair amount of code is shuffled around but the changes
are simple and there should not be any change in behavior.





1. I noticed that removeAggTypeFieldInfo() in IR.cpp was just a helper function for pruneResolvedTree()
in FR.cpp.  Moved it.


2. I noticed that modAndResolveInitCall() in IR.cpp implemented one arm of a conditional in a portion
of the implementation of resolveNew().  Moved it and renamed it.

3. I noticed that temporaryInitializerFixup() and resolveDefaultGenericType() were called in series 
twice in the code base; once in resolveNormalCall() and once in resolveInitCall(). Separately there
are two paths to resolveInitCall(); one that starts with resolveNormalCall() and one that starts with
resolveNewHandlerGenericInitializer().  This means that this pair of calls will occur twice for the
initializer path that started with resolveNormalCall().  This appears to be benign in practice but it
is undesirable.   Moved the calls that were in resolveInitCall() to the appropriate point in
resolveNewHandlerGenericInitializer().

4. The previous commit means that both calls to temporaryInitializerFixup() are in FR.cpp.
Moved it from IR.cpp to FR.cpp

5. After these commits, IR.cpp contains just clones/specialization of a modest portion of
resolveNormalCall() and portions of findVisibleFunctions() and findVisibleCandidates().
Shuffled the functions in to a more natural order.

6. When the functions that implement visibleFunctions/visibleCandidates were cloned to IR.cpp
some of the function signatures had defined input vs. output parameters in an unconventional way.
This was fixed for the mainline but not for IR.cpp.  The final commit addresses this.


Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.  Ran start_test on a
small portion of release/ for each configuration.   Passed a full single-locale parapets with futures.