### PR TITLE
resolveNormalCall :- Improve CallInfo

### DIFF
--- a/compiler/resolution/callInfo.h
+++ b/compiler/resolution/callInfo.h
@@ -1,15 +1,15 @@
 /*
  * Copyright 2004-2017 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,25 +17,31 @@
  * limitations under the License.
  */
 
-#ifndef _CALLINFO_H_
-#define _CALLINFO_H_
+#ifndef _CALL_INFO_H_
+#define _CALL_INFO_H_
 
-#include "chpl.h"
+#include "vec.h"
 
 class BlockStmt;
 class CallExpr;
 class Symbol;
-class Type;
 
 class CallInfo {
- public:
+public:
+                   CallInfo();
+
+  bool             isNotWellFormed(CallExpr* call,
+                                   bool      forInit = false);
+
+  void             haltNotWellFormed(bool forInit = false)               const;
+
   CallExpr*        call;        // call expression
   BlockStmt*       scope;       // module scope as in M.call
+
   const char*      name;        // function name
+
   Vec<Symbol*>     actuals;     // actual symbols
   Vec<const char*> actualNames; // named arguments
-  bool             badcall;     // the call is an error but checkonly set
-  CallInfo(CallExpr* icall, bool checkonly, bool initOkay = false);
 };
 
 #endif


### PR DESCRIPTION
Before this PR, CallInfo was implemented as a single constructor that accepted a CallExpr*
and a pair of boolean flags.  There were two problems with the constructor

1. In some call-paths the constructor would halt with a USR_FATAL but in other cases it
would quietly fail and set a field to indicate that construction had failed.  In those cases
it was the responsibility of the caller to check the flag.  Inevitably there was a call path in
which this field could potentially be set but was not checked.  I suspect that this was
benign in practice but it is an inadvisable practice.

2. The constructor might destructively mutate the CallExpr*.  This is infrequent in practice
but there are paths in which a single CallExpr* is wrapped in a CallInfo more than once.  This
has the potential to be the source of an annoying bug at some point.


This PR addresses the first problem but not the second problem.

1. It splits the complex constructor in to a trivial constructor, an "init" function that returns
a bool to indicate whether the operation was successful or not, and a "halt-with-message"
function that makes the appropriate calls to USR_FATAL when desired.

2. It updates the call sites to reflect this simple update to the API.

Passed my conventional compile/test protocol.
