### PR TITLE
resolveNormalCall :- Begin to partition resolveNormalCall()

### DIFF
--- a/compiler/include/initializerResolution.h
+++ b/compiler/include/initializerResolution.h
@@ -29,7 +29,8 @@
 //  the generic instantiation of it.
 
 class CallExpr;
+class FnSymbol;
 
-void resolveInitializer(CallExpr* call);
+FnSymbol* resolveInitializer(CallExpr* call);
 
 #endif

--- a/compiler/resolution/initializerResolution.cpp
+++ b/compiler/resolution/initializerResolution.cpp
@@ -52,7 +52,7 @@ static void makeRecordInitWrappers(CallExpr* call);
 *                                                                             *
 ************************************** | *************************************/
 
-void resolveInitializer(CallExpr* call) {
+FnSymbol* resolveInitializer(CallExpr* call) {
   // From resolveExpr() (removed the tryStack stuff)
   callStack.add(call);
 
@@ -75,6 +75,8 @@ void resolveInitializer(CallExpr* call) {
   }
 
   callStack.pop();
+
+  return call->resolvedFunction();
 }
 
 /************************************* | **************************************


### PR DESCRIPTION
Before this PR resolveNormalCall() was a single function spanning about 300 lines
with convoluted control flow and multiple exit points.  This PR begins the process
to partition this function into a modest number of small functions with more
manageable control flow.

This commit simplifies the entry point to resolveNormalCall() to clarify the dispatch
to resolveInitializer() and the recent update for CallInfo.

Passed standard compile/testing protocol.
