### PR TITLE
Resolve 4

### DIFF
--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -157,7 +157,7 @@ public:
 };
 
 void explainGatherCandidate(Vec<ResolutionCandidate*>& candidates,
-                            CallInfo& info, CallExpr* call);
+                            CallInfo&                  info);
 
 /** Contextual info used by the disambiguation process.
  *

--- a/compiler/resolution/initializerResolution.cpp
+++ b/compiler/resolution/initializerResolution.cpp
@@ -107,7 +107,7 @@ static void resolveInitCall(CallExpr* call) {
 
   gatherInitCandidates(info, visibleFns, candidates);
 
-  explainGatherCandidate(candidates, info, call);
+  explainGatherCandidate(candidates, info);
 
   Expr* scope   = (info.scope) ? info.scope : getVisibilityBlock(call);
 


### PR DESCRIPTION
Continue to refactor resolveNormalCall()

1. Extract the logic to collect the visibleFunctions and visibleCandidates
in to a single helper.

2. Relocate the helper functions for the new helper with the helper.

3. Simplify the API to populateForwardingMethods().
