### PR TITLE
Resolve 7

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -2635,6 +2635,317 @@ static FnSymbol* resolveNormalCall(CallInfo& info, bool checkOnly) {
 
     return NULL;
 
+
+
+  } else if (numMatches == 1) {
+    ResolutionCandidate* best    = NULL;
+    bool                 refPair = false;
+
+    if        (bestRef      != NULL) {
+      best = bestRef;
+
+    } else if (bestValue    != NULL) {
+      best = bestValue;
+
+    } else if (bestConstRef != NULL) {
+      best = bestConstRef;
+    }
+
+
+    {
+      int nBestRef      = bestRef      != NULL ? 1 : 0;
+      int nBestValue    = bestValue    != NULL ? 1 : 0;
+      int nBestConstRef = bestConstRef != NULL ? 1 : 0;
+
+      refPair = (nBestRef + nBestValue + nBestConstRef > 1) ? true : false;
+    }
+
+    // If we are working with a return intent overload:
+    //    'refCall'      will invoke the ref   function bestRef->fn
+    //    'valueCall'    will invoke the value function bestValue->fn
+    //    'constRefCall' will invoke the value function bestConstRef->fn
+    //  we will manipulate these three side by side.
+    // and 'call' will be the first of these.
+    CallExpr* refCall      = NULL;
+    CallExpr* valueCall    = NULL;
+    CallExpr* constRefCall = NULL;
+
+    if (refPair == true) {
+      bool first = true;
+
+      if (bestRef != NULL) {
+        refCall = call;
+        first   = false;
+      }
+
+      // might not have had a ref call, so maybe value is first
+      if (bestValue != NULL) {
+        if (first == true) {
+          valueCall = call;
+          first     = false;
+
+        } else {
+          valueCall = call->copy();
+
+          call->insertAfter(valueCall);
+        }
+      }
+
+      // by here, usedCall must be true.
+      if (bestConstRef != NULL) {
+        constRefCall = call->copy();
+
+        call->insertAfter(constRefCall);
+      }
+    }
+
+    if (best != NULL && best->fn != NULL) {
+      /*
+       * Finish instantiating the body.  This is a noop if the function wasn't
+       * partially instantiated.
+       */
+
+      if (refPair == false) {
+        instantiateBody(best->fn);
+
+      } else {
+        if (refCall) {
+          instantiateBody(bestRef->fn);
+        }
+
+        if (valueCall) {
+          instantiateBody(bestValue->fn);
+        }
+
+        if (constRefCall) {
+          instantiateBody(bestConstRef->fn);
+        }
+      }
+
+      if (explainCallLine && explainCallMatch(call)) {
+        USR_PRINT(best->fn, "best candidate is: %s", toString(best->fn));
+      }
+    }
+
+    // Future work note: the repeated check to best and best->fn means that we
+    // could probably restructure this function to a better form.
+    if (call->partialTag == true &&
+        (best                              == NULL ||
+         best->fn                          == NULL ||
+         best->fn->hasFlag(FLAG_NO_PARENS) == false)) {
+      if (best != NULL) {
+        // MPF 2016-0106 - this appears to be dead code
+        // at least in a full single-locale test run.
+
+        // best is deleted below with the other candidates
+        best = NULL;
+      }
+
+    } else if (best == NULL) {
+      if (tryStack.n) {
+        // MPF -- doesn't this leak memory for the ResolutionCandidates?
+        if (checkOnly == false) {
+          tryFailure = true;
+        }
+
+        return NULL;
+
+      } else {
+        // if we're just checking, don't print errors
+        if (checkOnly == false) {
+          if (candidates.n > 0) {
+            Vec<FnSymbol*> candidateFns;
+
+            // MPF: we could choose to only print the best matches here
+            forv_Vec(ResolutionCandidate*, candidate, candidates) {
+              candidateFns.add(candidate->fn);
+            }
+
+            printResolutionErrorAmbiguous(candidateFns, &info);
+
+          } else {
+            printResolutionErrorUnresolved(visibleFns, &info);
+          }
+        }
+      }
+
+    } else {
+      wrapAndCleanUpActuals(best, info, true);
+
+      // for return intent overload, ref call must be first, so above
+      // case would handle it.
+      if (valueCall != NULL && valueCall != call) {
+        CallInfo tmpInfo;
+
+        if (tmpInfo.isNotWellFormed(valueCall) == true) {
+          if (checkOnly == false) {
+            tmpInfo.haltNotWellFormed();
+          }
+
+        } else {
+          wrapAndCleanUpActuals(bestValue, tmpInfo, false);
+        }
+      }
+
+      if (constRefCall != NULL) {
+        CallInfo tmpInfo;
+
+        if (tmpInfo.isNotWellFormed(constRefCall) == true) {
+          if (checkOnly == false) {
+            tmpInfo.haltNotWellFormed();
+          }
+
+        } else {
+          wrapAndCleanUpActuals(bestConstRef, tmpInfo, false);
+        }
+      }
+    }
+
+    FnSymbol* resolvedFn         = NULL;
+    FnSymbol* resolvedRefFn      = NULL;
+    FnSymbol* resolvedValueFn    = NULL;
+    FnSymbol* resolvedConstRefFn = NULL;
+
+    if (best         != NULL) resolvedFn         = best->fn;
+    if (bestRef      != NULL) resolvedRefFn      = bestRef->fn;
+    if (bestValue    != NULL) resolvedValueFn    = bestValue->fn;
+    if (bestConstRef != NULL) resolvedConstRefFn = bestConstRef->fn;
+
+    // Only keep it a ref-pair if a ref version is present and
+    // we have options that resolved.
+    if (refPair == true) {
+      int nBestRef      = resolvedRefFn      != NULL ? 1 : 0;
+      int nBestValue    = resolvedValueFn    != NULL ? 1 : 0;
+      int nBestConstRef = resolvedConstRefFn != NULL ? 1 : 0;
+
+      refPair = (nBestRef + nBestValue + nBestConstRef > 1) ? true : false;
+    }
+
+    forv_Vec(ResolutionCandidate*, candidate, candidates) {
+      delete candidate;
+    }
+
+    if (call->partialTag == true) {
+      if (resolvedFn == NULL) {
+        if (valueCall    != NULL) valueCall->remove();
+        if (constRefCall != NULL) constRefCall->remove();
+
+        return NULL;
+
+      } else {
+        call->partialTag = false;
+      }
+    }
+
+
+    if (checkOnly == false) {
+      if (resolvedFn                               != NULL        &&
+          resolvedFn->name                         == astrSequals &&
+          isRecord(resolvedFn->getFormal(1)->type) == true        &&
+          resolvedFn->getFormal(2)->type           == dtNil) {
+        USR_FATAL(userCall(call),
+                  "type mismatch in assignment from nil to %s",
+                  toString(resolvedFn->getFormal(1)->type));
+      }
+
+      if (resolvedFn == NULL) {
+        INT_FATAL(call, "unable to resolve call");
+      }
+    }
+
+    if (resolvedFn != NULL && call->parentSymbol != NULL) {
+      SET_LINENO(call);
+
+      if (refPair == true) {
+        if (refCall      != NULL && resolvedRefFn      != NULL) {
+          refCall->baseExpr->replace(new SymExpr(resolvedRefFn));
+        }
+
+        if (valueCall    != NULL && resolvedValueFn    != NULL) {
+          valueCall->baseExpr->replace(new SymExpr(resolvedValueFn));
+        }
+
+        if (constRefCall != NULL && resolvedConstRefFn != NULL) {
+          constRefCall->baseExpr->replace(new SymExpr(resolvedConstRefFn));
+        }
+
+        // Replace the call with a new ContextCallExpr containing 2 or 3 calls
+        ContextCallExpr* contextCall = new ContextCallExpr();
+
+        call->insertAfter(contextCall);
+
+        // note: call is one of refCall, valueCall, constRefCall
+        if (refCall      != NULL) refCall->remove();
+        if (valueCall    != NULL) valueCall->remove();
+        if (constRefCall != NULL) constRefCall->remove();
+
+        contextCall->setRefValueConstRefOptions(refCall,
+                                                valueCall,
+                                                constRefCall);
+
+      } else {
+        call->baseExpr->replace(new SymExpr(resolvedFn));
+
+        if (valueCall    != NULL && valueCall    != call) {
+          // value call was added but didn't resolve right. Remove it.
+          valueCall->remove();
+        }
+
+        if (constRefCall != NULL && constRefCall != call) {
+          // const ref call was added but didn't resolve right. Remove it.
+          constRefCall->remove();
+        }
+
+        // If we aren't working with a ref not-ref return intent pair,
+        // adjust the returned value to have flag FLAG_REF_TO_CONST,
+        // but disable this behavior for constructors, so that they
+        // can set 'const' fields.
+        if (resolvedFn->retTag == RET_CONST_REF) {
+          if (CallExpr* parentCall = toCallExpr(call->parentExpr)) {
+            if (parentCall->isPrimitive(PRIM_MOVE) == true) {
+              if (SymExpr* lhsSe = toSymExpr(parentCall->get(1))) {
+                if (VarSymbol* lhs = toVarSymbol(lhsSe->symbol())) {
+                  if (lhs->hasFlag(FLAG_EXPR_TEMP) == true) {
+                    Symbol* parSym = parentCall->parentSymbol;
+
+                    if (FnSymbol* inFn = toFnSymbol(parSym)) {
+                      if (isConstructorLikeFunction(inFn) == false) {
+                        lhs->addFlag(FLAG_REF_TO_CONST);
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    if (checkOnly == false) {
+      if (resolvedFn->hasFlag(FLAG_MODIFIES_CONST_FIELDS) == true) {
+        // Not allowed if it is not called directly from a constructor.
+        if (isInConstructorLikeFunction(call) == false ||
+            getBaseSymForConstCheck(call)->hasFlag(FLAG_ARG_THIS) == false) {
+          USR_FATAL_CONT(call,
+                         "illegal call to %s() - it modifies 'const' fields "
+                         "of 'this', therefore it can be invoked only "
+                         "directly from a constructor on the object "
+                         "being constructed",
+                         resolvedFn->name);
+        }
+      }
+
+      lvalueCheck(call);
+
+      checkForStoringIntoTuple(call, resolvedFn);
+
+      resolveNormalCallCompilerWarningStuff(resolvedFn);
+    }
+
+    return resolvedFn;
+
+
   } else {
     ResolutionCandidate* best    = NULL;
     bool                 refPair = false;

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -2651,154 +2651,19 @@ static FnSymbol* resolveNormalCall(CallInfo& info, bool checkOnly) {
       best = bestConstRef;
     }
 
+    instantiateBody(best->fn);
 
-    {
-      int nBestRef      = bestRef      != NULL ? 1 : 0;
-      int nBestValue    = bestValue    != NULL ? 1 : 0;
-      int nBestConstRef = bestConstRef != NULL ? 1 : 0;
-
-      refPair = (nBestRef + nBestValue + nBestConstRef > 1) ? true : false;
+    if (explainCallLine && explainCallMatch(call)) {
+      USR_PRINT(best->fn, "best candidate is: %s", toString(best->fn));
     }
 
-    // If we are working with a return intent overload:
-    //    'refCall'      will invoke the ref   function bestRef->fn
-    //    'valueCall'    will invoke the value function bestValue->fn
-    //    'constRefCall' will invoke the value function bestConstRef->fn
-    //  we will manipulate these three side by side.
-    // and 'call' will be the first of these.
-    CallExpr* refCall      = NULL;
-    CallExpr* valueCall    = NULL;
-    CallExpr* constRefCall = NULL;
-
-    if (refPair == true) {
-      bool first = true;
-
-      if (bestRef != NULL) {
-        refCall = call;
-        first   = false;
-      }
-
-      // might not have had a ref call, so maybe value is first
-      if (bestValue != NULL) {
-        if (first == true) {
-          valueCall = call;
-          first     = false;
-
-        } else {
-          valueCall = call->copy();
-
-          call->insertAfter(valueCall);
-        }
-      }
-
-      // by here, usedCall must be true.
-      if (bestConstRef != NULL) {
-        constRefCall = call->copy();
-
-        call->insertAfter(constRefCall);
-      }
-    }
-
-    if (best != NULL && best->fn != NULL) {
-      /*
-       * Finish instantiating the body.  This is a noop if the function wasn't
-       * partially instantiated.
-       */
-
-      if (refPair == false) {
-        instantiateBody(best->fn);
-
-      } else {
-        if (refCall) {
-          instantiateBody(bestRef->fn);
-        }
-
-        if (valueCall) {
-          instantiateBody(bestValue->fn);
-        }
-
-        if (constRefCall) {
-          instantiateBody(bestConstRef->fn);
-        }
-      }
-
-      if (explainCallLine && explainCallMatch(call)) {
-        USR_PRINT(best->fn, "best candidate is: %s", toString(best->fn));
-      }
-    }
-
-    // Future work note: the repeated check to best and best->fn means that we
-    // could probably restructure this function to a better form.
-    if (call->partialTag == true &&
-        (best                              == NULL ||
-         best->fn                          == NULL ||
-         best->fn->hasFlag(FLAG_NO_PARENS) == false)) {
-      if (best != NULL) {
-        // MPF 2016-0106 - this appears to be dead code
-        // at least in a full single-locale test run.
-
-        // best is deleted below with the other candidates
-        best = NULL;
-      }
-
-    } else if (best == NULL) {
-      if (tryStack.n) {
-        // MPF -- doesn't this leak memory for the ResolutionCandidates?
-        if (checkOnly == false) {
-          tryFailure = true;
-        }
-
-        return NULL;
-
-      } else {
-        // if we're just checking, don't print errors
-        if (checkOnly == false) {
-          if (candidates.n > 0) {
-            Vec<FnSymbol*> candidateFns;
-
-            // MPF: we could choose to only print the best matches here
-            forv_Vec(ResolutionCandidate*, candidate, candidates) {
-              candidateFns.add(candidate->fn);
-            }
-
-            printResolutionErrorAmbiguous(candidateFns, &info);
-
-          } else {
-            printResolutionErrorUnresolved(visibleFns, &info);
-          }
-        }
-      }
+    if (call->partialTag                  ==  true &&
+        best->fn->hasFlag(FLAG_NO_PARENS) == false) {
+      best = NULL;
 
     } else {
       wrapAndCleanUpActuals(best, info, true);
 
-      // for return intent overload, ref call must be first, so above
-      // case would handle it.
-      if (valueCall != NULL && valueCall != call) {
-        CallInfo tmpInfo;
-
-        if (tmpInfo.isNotWellFormed(valueCall) == true) {
-          if (checkOnly == false) {
-            tmpInfo.haltNotWellFormed();
-          }
-
-        } else {
-          wrapAndCleanUpActuals(bestValue, tmpInfo, false);
-        }
-      }
-
-      if (constRefCall != NULL) {
-        CallInfo tmpInfo;
-
-        if (tmpInfo.isNotWellFormed(constRefCall) == true) {
-          if (checkOnly == false) {
-            tmpInfo.haltNotWellFormed();
-          }
-
-        } else {
-          wrapAndCleanUpActuals(bestConstRef, tmpInfo, false);
-        }
-      }
     }
 
     FnSymbol* resolvedFn         = NULL;
@@ -2811,15 +2676,6 @@ static FnSymbol* resolveNormalCall(CallInfo& info, bool checkOnly) {
     if (bestValue    != NULL) resolvedValueFn    = bestValue->fn;
     if (bestConstRef != NULL) resolvedConstRefFn = bestConstRef->fn;
 
-    // Only keep it a ref-pair if a ref version is present and
-    // we have options that resolved.
-    if (refPair == true) {
-      int nBestRef      = resolvedRefFn      != NULL ? 1 : 0;
-      int nBestValue    = resolvedValueFn    != NULL ? 1 : 0;
-      int nBestConstRef = resolvedConstRefFn != NULL ? 1 : 0;
-
-      refPair = (nBestRef + nBestValue + nBestConstRef > 1) ? true : false;
-    }
 
     forv_Vec(ResolutionCandidate*, candidate, candidates) {
       delete candidate;
@@ -2827,9 +2683,6 @@ static FnSymbol* resolveNormalCall(CallInfo& info, bool checkOnly) {
 
     if (call->partialTag == true) {
       if (resolvedFn == NULL) {
-        if (valueCall    != NULL) valueCall->remove();
-        if (constRefCall != NULL) constRefCall->remove();
-
         return NULL;
 
       } else {
@@ -2853,65 +2706,27 @@ static FnSymbol* resolveNormalCall(CallInfo& info, bool checkOnly) {
       }
     }
 
-    if (resolvedFn != NULL && call->parentSymbol != NULL) {
+
+    if (resolvedFn != NULL) {
       SET_LINENO(call);
 
-      if (refPair == true) {
-        if (refCall      != NULL && resolvedRefFn      != NULL) {
-          refCall->baseExpr->replace(new SymExpr(resolvedRefFn));
-        }
+      call->baseExpr->replace(new SymExpr(resolvedFn));
 
-        if (valueCall    != NULL && resolvedValueFn    != NULL) {
-          valueCall->baseExpr->replace(new SymExpr(resolvedValueFn));
-        }
+      // If we aren't working with a ref not-ref return intent pair,
+      // adjust the returned value to have flag FLAG_REF_TO_CONST,
+      // but disable this behavior for constructors, so that they
+      // can set 'const' fields.
+      if (resolvedFn->retTag == RET_CONST_REF) {
+        if (CallExpr* parentCall = toCallExpr(call->parentExpr)) {
+          if (parentCall->isPrimitive(PRIM_MOVE) == true) {
+            if (SymExpr* lhsSe = toSymExpr(parentCall->get(1))) {
+              if (VarSymbol* lhs = toVarSymbol(lhsSe->symbol())) {
+                if (lhs->hasFlag(FLAG_EXPR_TEMP) == true) {
+                  Symbol* parSym = parentCall->parentSymbol;
 
-        if (constRefCall != NULL && resolvedConstRefFn != NULL) {
-          constRefCall->baseExpr->replace(new SymExpr(resolvedConstRefFn));
-        }
-
-        // Replace the call with a new ContextCallExpr containing 2 or 3 calls
-        ContextCallExpr* contextCall = new ContextCallExpr();
-
-        call->insertAfter(contextCall);
-
-        // note: call is one of refCall, valueCall, constRefCall
-        if (refCall      != NULL) refCall->remove();
-        if (valueCall    != NULL) valueCall->remove();
-        if (constRefCall != NULL) constRefCall->remove();
-
-        contextCall->setRefValueConstRefOptions(refCall,
-                                                valueCall,
-                                                constRefCall);
-
-      } else {
-        call->baseExpr->replace(new SymExpr(resolvedFn));
-
-        if (valueCall    != NULL && valueCall    != call) {
-          // value call was added but didn't resolve right. Remove it.
-          valueCall->remove();
-        }
-
-        if (constRefCall != NULL && constRefCall != call) {
-          // const ref call was added but didn't resolve right. Remove it.
-          constRefCall->remove();
-        }
-
-        // If we aren't working with a ref not-ref return intent pair,
-        // adjust the returned value to have flag FLAG_REF_TO_CONST,
-        // but disable this behavior for constructors, so that they
-        // can set 'const' fields.
-        if (resolvedFn->retTag == RET_CONST_REF) {
-          if (CallExpr* parentCall = toCallExpr(call->parentExpr)) {
-            if (parentCall->isPrimitive(PRIM_MOVE) == true) {
-              if (SymExpr* lhsSe = toSymExpr(parentCall->get(1))) {
-                if (VarSymbol* lhs = toVarSymbol(lhsSe->symbol())) {
-                  if (lhs->hasFlag(FLAG_EXPR_TEMP) == true) {
-                    Symbol* parSym = parentCall->parentSymbol;
-
-                    if (FnSymbol* inFn = toFnSymbol(parSym)) {
-                      if (isConstructorLikeFunction(inFn) == false) {
-                        lhs->addFlag(FLAG_REF_TO_CONST);
-                      }
+                  if (FnSymbol* inFn = toFnSymbol(parSym)) {
+                    if (isConstructorLikeFunction(inFn) == false) {
+                      lhs->addFlag(FLAG_REF_TO_CONST);
                     }
                   }
                 }
@@ -2921,6 +2736,7 @@ static FnSymbol* resolveNormalCall(CallInfo& info, bool checkOnly) {
         }
       }
     }
+
 
     if (checkOnly == false) {
       if (resolvedFn->hasFlag(FLAG_MODIFIES_CONST_FIELDS) == true) {


### PR DESCRIPTION
Continue to refine resolveNormalCall().
    
This PR focusses on the case in which 1 candidate
is returned.
    
The first commit extends the if-then stmt with a
conditional for numMatches == 1 and inserts a clone
of the original body in to this branch.
    
The next two commits simplify the arm for
numMatches == 1  to exploit the knowledge that
best != NULL and there is no "ref-pair".
    
Compiled/tested with the standard protocol.
