### PR TITLE
Enable GASNet's multi-comm-domain support for gemini/aries

### DIFF
--- a/runtime/src/comm/gasnet/comm-gasnet.c
+++ b/runtime/src/comm/gasnet/comm-gasnet.c
@@ -779,11 +779,27 @@ static void set_max_segsize() {
 #endif
 }
 
+static void set_num_comm_domains() {
+  char num_cpus_val[22]; // big enough for an unsigned 64-bit quantity
+  int num_cpus;
+
+  num_cpus = chpl_getNumPhysicalCpus(true) + 1;
+
+  snprintf(num_cpus_val, sizeof(num_cpus_val), "%d", num_cpus);
+  if (setenv("GASNET_DOMAIN_COUNT", num_cpus_val, 0) != 0) {
+    chpl_error("Cannot setenv(\"GASNET_DOMAIN_COUNT\")", 0, 0);
+  }
+
+  if (setenv("GASNET_AM_DOMAIN_POLL_MASK", "3", 0) != 0) {
+    chpl_error("Cannot setenv(\"GASNET_AM_DOMAIN_POLL_MASK\")", 0, 0);
+  }
+}
+
 void chpl_comm_init(int *argc_p, char ***argv_p) {
 //  int status; // Some compilers complain about unused variable 'status'.
 
   set_max_segsize();
-
+  set_num_comm_domains();
   assert(sizeof(gasnet_handlerarg_t)==sizeof(uint32_t));
 
   gasnet_init(argc_p, argv_p);

--- a/third-party/gasnet/Makefile
+++ b/third-party/gasnet/Makefile
@@ -40,6 +40,7 @@ endif
 
 ifneq (, $(filter $(CHPL_MAKE_TARGET_PLATFORM),cray-xe cray-xc cray-xk))
 CHPL_GASNET_CFG_OPTIONS += --enable-pthreads
+CHPL_GASNET_CFG_OPTIONS += --enable-gni-multi-domain
 ifeq ($(CHPL_MAKE_COMM_SUBSTRATE),gemini)
 else
 ifeq ($(CHPL_MAKE_COMM_SUBSTRATE),aries)


### PR DESCRIPTION
Build GASNet with --enable-gni-multi-domain. gni-multi-domain enables using
multiple communication domains instead of just one. This is similar to what we
do with comm=ugni.

We set GASNET_DOMAIN_COUNT=<num_phys_cores+1> and GASNET_AM_DOMAIN_POLL_MASK=3.
We want GASNET_DOMAIN_COUNT to be the number of pthreads we'll have. We default
to num_cores plus one for the progress thread.

GASNET_AM_DOMAIN_POLL_MASK=3 (down from a default of 255) controls how often
explicit or implicit calls to gasnet_AMPoll will actually poll for active
messages. The default of 255 can significantly hurt performance of applications
like lulesh, hpl, and a few other apps. GASNET_AM_DOMAIN_POLL_MASK=3 seems to
be the sweet spot for us. Enabling multi-domain support will significantly
improve some benchmarks like ra-rmo, ptrans, miniMD, and others though there
will be some non-trivial regressions for fft and ra-on.

See https://github.com/chapel-lang/chapel/issues/5703 for more info

Regressions:
 - fft and ra-on/ra-atomic are 50% slower

Improvements:
 - ra-rmo is 20X faster
 - ptrans is 4X faster
 - miniMD is 3.5X faster
 - lulesh is 2.5X faster
 - hpl is 2X faster