### PR TITLE
Copy constructor for Toml class

### DIFF
--- a/test/modules/packages/Toml/TOML.chpl
+++ b/test/modules/packages/Toml/TOML.chpl
@@ -434,6 +434,20 @@ Parser module with the Toml class for the Chapel TOML library.
        this.tag = fieldArr;
      }
 
+     // Clone
+     proc init(root: Toml) {
+       this.boo = root.boo;
+       this.i = root.i;
+       this.re = root.re;
+       this.dom = root.dom;
+       this.arr = root.arr;
+       this.dt = root.dt;
+       this.s = root.s;
+       this.D = root.D;
+       this.A = root.A;
+       this.tag = root.tag;
+     }
+
 
      /* Returns the index of the table path given as a parameter */
      proc this(tbl: string) ref : Toml {

--- a/test/modules/packages/Toml/TOML.chpl
+++ b/test/modules/packages/Toml/TOML.chpl
@@ -440,11 +440,11 @@ Parser module with the Toml class for the Chapel TOML library.
        this.i = root.i;
        this.re = root.re;
        this.dom = root.dom;
-       this.arr = root.arr;
+       for idx in root.dom do this.arr[idx] = new Toml(root.arr[idx]);
        this.dt = root.dt;
        this.s = root.s;
        this.D = root.D;
-       this.A = root.A;
+       for idx in root.D do this.A[idx] = new Toml(root.A[idx]);
        this.tag = root.tag;
      }
 

--- a/test/modules/packages/Toml/test/UTomlTest.chpl
+++ b/test/modules/packages/Toml/test/UTomlTest.chpl
@@ -36,33 +36,14 @@ proc main() {
   var tbl2D: domain(string);
   var tbl2: [tbl2D] Toml;
   var tomlData2: Toml = tbl2;
-  /*
-  tomlData2["A.B"] = new Toml(tomlData["A.B"]);
-  writeln(tomlData["A.B"]);                 // uncomment to see subtable error
-  writeln("Should be the same as");
-  writeln(tomlData2["A.B"]);
-*/
 
-  // to reproduce error from earlier(deconstruction)
+  // copy Toml A.B in tomlData to Toml A in TomlData2
   tomlData2["A"] = new Toml(tomlData["A"]);
   writeln(tomlData["A"]);
   writeln("Should be the same as");
   writeln(tomlData2["A"]);
 
-  var tbl3D: domain(string);
-  var tbl3: [tbl3D] Toml;
-  var tomlData3: Toml = tbl3;
-  var example: Toml = "works";
-  tomlData3["thisone"] = example;
-
-  // copy a tbl from tomlData
-  tomlData2["thisone"] = new Toml(tomlData3["thisone"]);
-  writeln(tomlData3["thisone"].toString());                   // this works
-  writeln("Should be the same as:");
-  writeln(tomlData2["thisone"].toString());
-
-
-  delete tomlData2;  // without copy constuctor, error here
+  delete tomlData2;  
   delete tomlData;
   tomlChannel.close();
 }

--- a/test/modules/packages/Toml/test/UTomlTest.chpl
+++ b/test/modules/packages/Toml/test/UTomlTest.chpl
@@ -30,6 +30,39 @@ proc main() {
   writeln("KV pairs in table A.C");
   writeln(tomlData["A.C"]);
 
+ 
+  // Test of the copy constructor
+  // New Toml
+  var tbl2D: domain(string);
+  var tbl2: [tbl2D] Toml;
+  var tomlData2: Toml = tbl2;
+  /*
+  tomlData2["A.B"] = new Toml(tomlData["A.B"]);
+  writeln(tomlData["A.B"]);                 // uncomment to see subtable error
+  writeln("Should be the same as");
+  writeln(tomlData2["A.B"]);
+*/
+
+  // to reproduce error from earlier(deconstruction)
+  tomlData2["A"] = new Toml(tomlData["A"]);
+  writeln(tomlData["A"]);
+  writeln("Should be the same as");
+  writeln(tomlData2["A"]);
+
+  var tbl3D: domain(string);
+  var tbl3: [tbl3D] Toml;
+  var tomlData3: Toml = tbl3;
+  var example: Toml = "works";
+  tomlData3["thisone"] = example;
+
+  // copy a tbl from tomlData
+  tomlData2["thisone"] = new Toml(tomlData3["thisone"]);
+  writeln(tomlData3["thisone"].toString());                   // this works
+  writeln("Should be the same as:");
+  writeln(tomlData2["thisone"].toString());
+
+
+  delete tomlData2;  // without copy constuctor, error here
   delete tomlData;
   tomlChannel.close();
 }

--- a/test/modules/packages/Toml/test/UTomlTest.good
+++ b/test/modules/packages/Toml/test/UTomlTest.good
@@ -34,3 +34,32 @@ name = "Ben"
 job = "programmer"
 
 
+
+[B]
+name = "sam"
+number = 7
+job = "programmer"
+
+[B.C]
+new-key-added = true
+
+[C]
+name = "Ben"
+job = "programmer"
+
+
+Should be the same as
+
+[B]
+name = "sam"
+number = 7
+job = "programmer"
+
+[B.C]
+new-key-added = true
+
+[C]
+name = "Ben"
+job = "programmer"
+
+

--- a/test/modules/packages/Toml/test/arrays.good
+++ b/test/modules/packages/Toml/test/arrays.good
@@ -5,5 +5,7 @@ booleans = [true, false]
 arrays = [["hello"], [1, 2, 3, 4, 5, 6, 7]]
 mixed = [[1, 2], ["a", "b"], [1.1, 2.1]]
 real = [3.4]
+single = [9]
+bool = [true]
 
 


### PR DESCRIPTION
This PR adds a copy constructor for the Toml library. This is very useful in the creation of .lock files and therefore is needed in the TOML library for Mason. Also added is a corner case for arrays that should have been included in the first pr. 

@ben-albrecht 