### PR TITLE
Suppress unneeded warning from CCE 8.6 - floating point values

### DIFF
--- a/make/compiler/Makefile.cray-prgenv-cray
+++ b/make/compiler/Makefile.cray-prgenv-cray
@@ -25,6 +25,9 @@ CRAYPE_GEN_CFLAGS += -hnomessage=186
 # certain cases of __asm__
 CRAYPE_GEN_CFLAGS += -hnomessage=3140
 
+# Suppress warnings about floating-point value cannot be represented exactly.
+CRAYPE_GEN_CFLAGS += -hnomessage=1046
+
 # Could set CRAYPE_COMP_CXXFLAGS, CRAYPE_GEN_CFLAGS
 
 FAST_FLOAT_GEN_CFLAGS = -hfp2


### PR DESCRIPTION
Replaces PR #6836 