### PR TITLE
Future showing issue with non-generic copy-init

### DIFF
--- a/test/types/records/ferguson/copy-init/copy-init-issue.chpl
+++ b/test/types/records/ferguson/copy-init/copy-init-issue.chpl
@@ -1,0 +1,29 @@
+record MyRecord {
+  var y:int;
+  proc init(x:int) {
+    y = x;
+    super.init();
+  }
+  proc init(from:MyRecord) {
+    y = from.y;
+    writeln("copy init");
+  }
+  proc deinit() {
+    writeln("deinit ", y);
+  }
+}
+
+proc foo(i:int, j = 4):MyRecord  {
+  return new MyRecord(i);
+}
+
+proc test() {
+  var x = foo(1);
+  writeln(x);
+  var y = foo(2);
+  writeln(y);
+  var z = foo(3);
+  writeln(z);
+}
+
+test();

--- a/test/types/records/ferguson/copy-init/copy-init-issue.future
+++ b/test/types/records/ferguson/copy-init/copy-init-issue.future
@@ -1,0 +1,9 @@
+bug: copy init not resolving in this example
+
+A copy initializer declared as a proc init(other:MyRecord) should resolve
+and work for both instances where the compiler wants to add an initCopy
+and when it wants to add an autoCopy.  In particular, certain operations
+on records can cause callDestructors to add an autoCopy, such as
+returning a global by value.
+
+

--- a/test/types/records/ferguson/copy-init/copy-init-issue.good
+++ b/test/types/records/ferguson/copy-init/copy-init-issue.good
@@ -1,0 +1,6 @@
+(y = 1)
+(y = 2)
+(y = 3)
+deinit 3
+deinit 2
+deinit 1


### PR DESCRIPTION
I ran in to this issue while working on some error-handling test cases.

I thought that we had concrete copy-init working but it seems not to be the case.

I think this is related to PR #6103.