### PR TITLE
Add some tests to verify that setting inherited generic fields errors correctly

### DIFF
--- a/test/classes/initializers/generics/inheritance/setParentField-param.chpl
+++ b/test/classes/initializers/generics/inheritance/setParentField-param.chpl
@@ -1,0 +1,23 @@
+class Foo {
+  param p;
+
+  proc init() {
+    p = 2;
+    super.init();
+  }
+}
+
+class Bar : Foo {
+  var x: int;
+
+  proc init(xVal) {
+    x = xVal;
+    p = 6;
+    super.init();
+  }
+}
+
+var bar = new Bar(4);
+writeln(bar.type: string);
+writeln(bar);
+delete bar;

--- a/test/classes/initializers/generics/inheritance/setParentField-param.good
+++ b/test/classes/initializers/generics/inheritance/setParentField-param.good
@@ -1,0 +1,2 @@
+setParentField-param.chpl:13: In initializer:
+setParentField-param.chpl:15: error: can't set value of field "p" from parent type during phase 1 of initialization

--- a/test/classes/initializers/generics/inheritance/setParentField-type.chpl
+++ b/test/classes/initializers/generics/inheritance/setParentField-type.chpl
@@ -1,0 +1,23 @@
+class Foo {
+  type t;
+
+  proc init() {
+    t = bool;
+    super.init();
+  }
+}
+
+class Bar : Foo {
+  var x: int;
+
+  proc init(xVal) {
+    x = xVal;
+    t = real;
+    super.init();
+  }
+}
+
+var bar = new Bar(4);
+writeln(bar.type: string);
+writeln(bar);
+delete bar;

--- a/test/classes/initializers/generics/inheritance/setParentField-type.good
+++ b/test/classes/initializers/generics/inheritance/setParentField-type.good
@@ -1,0 +1,2 @@
+setParentField-type.chpl:13: In initializer:
+setParentField-type.chpl:15: error: can't set value of field "t" from parent type during phase 1 of initialization

--- a/test/classes/initializers/generics/inheritance/setParentField-var.chpl
+++ b/test/classes/initializers/generics/inheritance/setParentField-var.chpl
@@ -1,0 +1,22 @@
+class Foo {
+  var v;
+
+  proc init() {
+    v = 2;
+    super.init();
+  }
+}
+
+class Bar : Foo {
+  var x: int;
+
+  proc init(xVal) {
+    x = xVal;
+    v = x + 2;
+    super.init();
+  }
+}
+
+var bar = new Bar(4);
+writeln(bar);
+delete bar;

--- a/test/classes/initializers/generics/inheritance/setParentField-var.good
+++ b/test/classes/initializers/generics/inheritance/setParentField-var.good
@@ -1,0 +1,2 @@
+setParentField-var.chpl:13: In initializer:
+setParentField-var.chpl:15: error: can't set value of field "v" from parent type during phase 1 of initialization


### PR DESCRIPTION
One each for generic var, param, and type fields (though these tests are rather
toys, as the parent initializer assumes it handles everything)