### PR TITLE
Deleted bad file for future test

### DIFF
--- a/test/modules/packages/Toml/test/quoteKeyPeriod.bad
+++ b/test/modules/packages/Toml/test/quoteKeyPeriod.bad
@@ -1,1 +1,0 @@
-../TOML.chpl:451: error: halt reached - Error - no index found for "this.key"


### PR DESCRIPTION
This PR is the fix for the test failure in the Toml Library. The test was failing because the future had a line number that kept changing as additions were made to the library so I am going to remove it to reduce noise. 