### PR TITLE
Remove -pthread from LLVM link step

### DIFF
--- a/compiler/util/clangUtil.cpp
+++ b/compiler/util/clangUtil.cpp
@@ -2218,6 +2218,11 @@ void makeBinaryLLVM(void) {
   options += " ";
   options += ldflags;
 
+  // We may need to add the -pthread flag here for the link step
+  // if we start doing link-time optimization.  For now, leave it
+  // out because its unnecessary inclusion causes a warning message
+  // on Macs.
+
   // Now, if we're doing a multilocale build, we have to make a launcher.
   // For this reason, we create a makefile. codegen_makefile
   // also gives us the name of the temporary place to save

--- a/compiler/util/clangUtil.cpp
+++ b/compiler/util/clangUtil.cpp
@@ -2218,8 +2218,6 @@ void makeBinaryLLVM(void) {
   options += " ";
   options += ldflags;
 
-  options += " -pthread";
-
   // Now, if we're doing a multilocale build, we have to make a launcher.
   // For this reason, we create a makefile. codegen_makefile
   // also gives us the name of the temporary place to save


### PR DESCRIPTION
The `-pthread` flag is needed when compiling with LLVM.  However, when linking, it is not needed.  In the last couple of weeks, a new version of clang installed on Macs has started issuing a warning message when the flag is used where it is not needed. This causes the Chapel tests to fail with LLVM on Macs because of the extra output text.

This PR keeps the `-pthread` flag when compiling, but removes it when linking.  This was tested across Mac, Cray, and Linux systems in various configurations that included the different third-party packages.

If we ever do link-time optimization, where LLVM emits a .bc file instead of a .o file from a compilation, it is possible that we will need to add this flag back.