### PR TITLE
Do `make docs` as part of the post-merge smoke test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ script:
   - ./util/buildRelease/smokeTest
 
 env:
-  - NIGHTLY_TEST_SETTINGS=true
+  - NIGHTLY_TEST_SETTINGS=true CHPL_SMOKE_SKIP_DOC=true
 
 sudo: false

--- a/util/buildRelease/smokeTest
+++ b/util/buildRelease/smokeTest
@@ -106,14 +106,16 @@ num_procs=$(python -c "import multiprocessing; print(multiprocessing.cpu_count()
 # in $CHPL_HOME where the hello*.chpl tests are copied and run.
 export CHPL_CHECK_INSTALL_DIR=$CHPL_HOME
 
-# Compile chapel and make sure `make check` works. Compile first with parallel
-# execution, but call `make check` without it.
-make -j${num_procs} $chpl_make_args && \
-    CHPL_CHECK_DEBUG=1 make $chpl_make_args check || exit 2
+if [ "${CHPL_SMOKE_SKIP_MAKE_CHECK}" != "true" ] ; then
+    # Compile chapel and make sure `make check` works. Compile first with parallel
+    # execution, but call `make check` without it.
+    make -j${num_procs} $chpl_make_args && \
+        CHPL_CHECK_DEBUG=1 make $chpl_make_args check || exit 2
+fi
 
-if [ "${TRAVIS}" != "true" ] ; then
-    # Build chpldoc and make sure the chpldoc primer runs. Build chpldoc with
-    # parallel execution, but call `make check-chpldoc` without it.
+if [ "${CHPL_SMOKE_SKIP_DOC}" != "true" ] ; then
+    # Build chpldoc, make sure the chpldoc primer runs, and the docs build.
     make -j${num_procs} $chpl_make_args chpldoc && \
-        make $chpl_make_args check-chpldoc || exit 2
+        make $chpl_make_args check-chpldoc && \
+        make docs || exit 2
 fi

--- a/util/test/checkCopyrights.bash
+++ b/util/test/checkCopyrights.bash
@@ -41,9 +41,11 @@ files_wo_copy=$(find $source_dirs \
     -name \*.lex -o \
     -name \*.y -o \
     -name \*.ypp | \
-    grep -v compiler/include/bison-chapel.h  | \
-    grep -v compiler/include/flex-chapel.h   | \
-    grep -v compiler/parser/bison-chapel.cpp | \
+    grep -v compiler/codegen/reservedSymbolNames.h | \
+    grep -v compiler/include/bison-chapel.h        | \
+    grep -v compiler/include/flex-chapel.h         | \
+    grep -v compiler/parser/bison-chapel.cpp       | \
+    grep -v modules/standard/gen/*/SysCTypes.chpl  | \
     xargs grep -i -L "${copyright_pattern}")
 
 # Now check the Make* files in CHPL_HOME.


### PR DESCRIPTION
Do `make docs` after building chpldoc.

Adds some generated files to the copyright exclude list so it's easier to run
the smoke test locally

Adds CHPL_SMOKE_SKIP_MAKE_CHECK and CHPL_SMOKE_SKIP_DOC as ways to skip steps
in the smoke test so we can parallelize these checks in travis.