### PR TITLE
Run `make docs` as part of travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,12 @@ os:
 compiler:
   - gcc
 
-script:
-  - ./util/buildRelease/smokeTest
+matrix:
+  include:
+    - env: NIGHTLY_TEST_SETTINGS=true CHPL_SMOKE_SKIP_DOC=true TEST_COMMAND="./util/buildRelease/smokeTest"
+    - env: NIGHTLY_TEST_SETTINGS=true CHPL_SMOKE_SKIP_MAKE_CHECK=true TEST_COMMAND="./util/buildRelease/smokeTest"
 
-env:
-  - NIGHTLY_TEST_SETTINGS=true CHPL_SMOKE_SKIP_DOC=true
+script:
+  - (eval "$TEST_COMMAND")
 
 sudo: false


### PR DESCRIPTION
Build and test chpldoc and the online documentation as part of travis testing.

Note that `make docs` will run in a separate/concurrent travis instance, so it
won't add any time to the travis check. Parallelization strategy taken from
https://gist.github.com/jamesarosen/e29076bd81a099f0f72e
