### PR TITLE
Expand a type alias

### DIFF
--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -1037,84 +1037,6 @@ static void insertRetMove(FnSymbol* fn, VarSymbol* retval, CallExpr* ret) {
 
 /************************************* | **************************************
 *                                                                             *
-* If se is a type alias, resolves it recursively, or fails and returns NULL.  *
-*                                                                             *
-************************************** | *************************************/
-
-static TypeSymbol* expandTypeAlias(SymExpr* se) {
-  TypeSymbol* retval = NULL;
-
-  while (se != NULL && retval == NULL) {
-    Symbol* sym = se->symbol();
-
-    if (TypeSymbol* ts = toTypeSymbol(sym)) {
-      retval = ts;
-
-    } else if (VarSymbol* vs = toVarSymbol(sym)) {
-      if (vs->isType() == true) {
-        // The definition in the init field of its declaration.
-        DefExpr* def = vs->defPoint;
-
-        se = toSymExpr(def->init);
-
-      } else {
-        se = NULL;
-      }
-
-    } else {
-      se = NULL;
-    }
-  }
-
-  return retval;
-}
-
-//
-// These helpers handle RiSpec (Reduce Intent Specification) i.e.:
-//
-//   forall ... with (<RiSpec> reduce <outer variable>) { ... }
-//
-// In particular, they implement RiSpecs of the form type(someArg).
-// See e.g. test/parallel/forall/vass/3types-*.
-// We want to keep these reduce intents in their original form
-// until we process reduce intents later.
-//
-// We do it here to avoid transforming it into _type_construct_C ( ... ).
-// That would be incorrect because this is a special syntax for reduce intent.
-//
-static SymExpr* callUsedInRiSpec(Expr* call, CallExpr* parent) {
-  if (parent && parent->isPrimitive(PRIM_MOVE)) {
-    SymExpr* destSE = toSymExpr(parent->get(1));
-    Symbol* dest = destSE->symbol();
-    SymExpr* riSpecMaybe = dest->firstSymExpr();
-    if (ForallIntent* fi = toForallIntent(riSpecMaybe->parentExpr))
-      if (riSpecMaybe == fi->reduceExpr())
-        return riSpecMaybe;
-  }
-  return NULL;
-}
-//
-// This function partially un-does normalization
-// so that reduce intents specs (see above) don't get messed up.
-//
-static void restoreReduceIntentSpecCall(SymExpr* riSpec, CallExpr* call) {
-  Symbol* temp = riSpec->symbol();
-  // Verify the pattern that occurs if callUsedInRiSpec() returns true.
-  // If any of these fail, either the pattern changed or callUsedInRiSpec()
-  // returns true when it shouldn't.
-  INT_ASSERT(temp->firstSymExpr() == riSpec); // see callUsedInRiSpec
-  INT_ASSERT(temp->lastSymExpr()->next == call); // 'move'
-  // 'temp' has only 2 SymExprs
-  INT_ASSERT(riSpec->symbolSymExprsNext == temp->lastSymExpr());
-  // Remove 'temp'.
-  temp->defPoint->remove();
-  call->parentExpr->remove();
-  // Put 'call' back into riSpec.
-  riSpec->replace(call->remove());
-}
-
-/************************************* | **************************************
-*                                                                             *
 * Normalize constructor/type constructor calls.                               *
 *   a call whose base expression is a symbol referring to an aggregate type   *
 *   is converted to a call to the default type constructor for that class,    *
@@ -1128,6 +1050,9 @@ static void restoreReduceIntentSpecCall(SymExpr* riSpec, CallExpr* call) {
 *   to chpl_buildDistType().                                                  *
 *                                                                             *
 ************************************** | *************************************/
+
+static SymExpr* callUsedInRiSpec(Expr* call, CallExpr* parent);
+static void     restoreReduceIntentSpecCall(SymExpr* riSpec, CallExpr* call);
 
 static void callConstructor(CallExpr* call) {
   if (SymExpr* se = toSymExpr(call->baseExpr)) {
@@ -1224,6 +1149,62 @@ static void callConstructor(CallExpr* call) {
       }
     }
   }
+}
+
+//
+// These helpers handle RiSpec (Reduce Intent Specification) i.e.:
+//
+//   forall ... with (<RiSpec> reduce <outer variable>) { ... }
+//
+// In particular, they implement RiSpecs of the form type(someArg).
+// See e.g. test/parallel/forall/vass/3types-*.
+// We want to keep these reduce intents in their original form
+// until we process reduce intents later.
+//
+// We do it here to avoid transforming it into _type_construct_C ( ... ).
+// That would be incorrect because this is a special syntax for reduce intent.
+//
+static SymExpr* callUsedInRiSpec(Expr* call, CallExpr* parent) {
+  SymExpr* retval = NULL;
+
+  if (parent != NULL && parent->isPrimitive(PRIM_MOVE) == true) {
+    SymExpr* destSE      = toSymExpr(parent->get(1));
+    Symbol*  dest        = destSE->symbol();
+    SymExpr* riSpecMaybe = dest->firstSymExpr();
+
+    if (ForallIntent* fi = toForallIntent(riSpecMaybe->parentExpr)) {
+      if (riSpecMaybe == fi->reduceExpr()) {
+        retval = riSpecMaybe;
+      }
+    }
+  }
+
+  return retval;
+}
+
+//
+// This function partially un-does normalization
+// so that reduce intents specs (see above) don't get messed up.
+//
+static void restoreReduceIntentSpecCall(SymExpr* riSpec, CallExpr* call) {
+  Symbol* temp = riSpec->symbol();
+
+  // Verify the pattern that occurs if callUsedInRiSpec() returns true.
+  // If any of these fail, either the pattern changed or callUsedInRiSpec()
+  // returns true when it shouldn't.
+  INT_ASSERT(temp->firstSymExpr()      == riSpec);
+  INT_ASSERT(temp->lastSymExpr()->next == call);
+
+  // 'temp' has only 2 SymExprs
+  INT_ASSERT(riSpec->symbolSymExprsNext == temp->lastSymExpr());
+
+  // Remove 'temp'.
+  temp->defPoint->remove();
+
+  call->parentExpr->remove();
+
+  // Put 'call' back into riSpec.
+  riSpec->replace(call->remove());
 }
 
 /************************************* | **************************************
@@ -2739,6 +2720,40 @@ static void updateInitMethod(FnSymbol* fn) {
   } else {
     INT_FATAL(fn, "initializer on non-class type");
   }
+}
+
+/************************************* | **************************************
+*                                                                             *
+* If se is a type alias, resolves it recursively, or fails and returns NULL.  *
+*                                                                             *
+************************************** | *************************************/
+
+static TypeSymbol* expandTypeAlias(SymExpr* se) {
+  TypeSymbol* retval = NULL;
+
+  while (se != NULL && retval == NULL) {
+    Symbol* sym = se->symbol();
+
+    if (TypeSymbol* ts = toTypeSymbol(sym)) {
+      retval = ts;
+
+    } else if (VarSymbol* vs = toVarSymbol(sym)) {
+      if (vs->isType() == true) {
+        // The definition in the init field of its declaration.
+        DefExpr* def = vs->defPoint;
+
+        se = toSymExpr(def->init);
+
+      } else {
+        se = NULL;
+      }
+
+    } else {
+      se = NULL;
+    }
+  }
+
+  return retval;
 }
 
 /************************************* | **************************************

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -118,6 +118,8 @@ static void add_to_where_clause(ArgSymbol* formal,
                                 Expr*      expr,
                                 CallExpr*  query);
 
+static TypeSymbol* expandTypeAlias(SymExpr* se);
+
 /************************************* | **************************************
 *                                                                             *
 *                                                                             *
@@ -810,7 +812,7 @@ static void processSyntacticDistributions(CallExpr* call) {
   if (call->isNamed("chpl__distributed")) {
     if (CallExpr* distCall = toCallExpr(call->get(1))) {
       if (SymExpr* distClass = toSymExpr(distCall->baseExpr)) {
-        if (TypeSymbol* ts = toTypeSymbol(distClass->symbol())) {
+        if (TypeSymbol* ts = expandTypeAlias(distClass)) {
           if (isDistClass(ts->type) == true) {
             CallExpr* newExpr = new CallExpr(PRIM_NEW, distCall->remove());
 
@@ -1039,7 +1041,7 @@ static void insertRetMove(FnSymbol* fn, VarSymbol* retval, CallExpr* ret) {
 *                                                                             *
 ************************************** | *************************************/
 
-static TypeSymbol* resolveTypeAlias(SymExpr* se) {
+static TypeSymbol* expandTypeAlias(SymExpr* se) {
   TypeSymbol* retval = NULL;
 
   while (se != NULL && retval == NULL) {
@@ -1140,7 +1142,7 @@ static void callConstructor(CallExpr* call) {
       parentParent = toCallExpr(parent->parentExpr);
     }
 
-    if (TypeSymbol* ts = resolveTypeAlias(se)) {
+    if (TypeSymbol* ts = expandTypeAlias(se)) {
       at = toAggregateType(ts->type);
     }
 


### PR DESCRIPTION
@ben-albrecht reported a problem with some new code that revealed that a dmap expression
would not work with a type-alias.

@benharsh and I collaborated and identified a small change to the normalization of the
underlying AST that resolved this problem.

Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.
Passed start_test on a small fraction of release/ for each configuration
Passed a single-locale paratest
