### PR TITLE
Improve annotation checker

### DIFF
--- a/util/test/check_annotations.py
+++ b/util/test/check_annotations.py
@@ -1,39 +1,41 @@
 #!/usr/bin/env python
+""" Do basic validation and checks on the ANNOTATIONS.yaml file
 
-import annotate
+This is a kinda-ugly script that does basic validation of ANNOTATIONS.yaml
+since we always manage to screw it up and cause nightly testing noise.
+
+It does the following:
+ - "parses" all annotations by calling annotate.get() for each .graph listed
+   in $CHPL_HOME/test/*GRAPHFILES for all date ranges.
+ - checks that all the "group" (graph) names listed in the annotations file
+   have corresponding .graph files
+ - checks that all the configs used in the annotations file are "known"
+ - checks that annotation dates are not the same as the merge date
+   (annotation dates are supposed to be for the first "affected" date
+ """
+
+from __future__ import print_function
 
 import os
 import re
 import subprocess
 import sys
 import time
-import traceback
 
-#
-# This is a kinda-ugly script that does basic validation of ANNOTATIONS.yaml
-# since we always manage to screw it up and cause nightly testing noise.
-#
-# It does the following:
-#  - "parses" all annotations by calling annotate.get() for each .graph listed
-#    in $CHPL_HOME/test/*GRAPHFILES for all date ranges.
-#  - checks that all the "group" (graph) names listed in the annotations file
-#    have corresponding .graph files
-#  - checks that all the configs used in the annotations file are "known"
-#  - checks that annotation dates are not the same as the merge date
-#    (annotation dates are supposed to be for the first "affected" date
-#
-# TODOs:
-#  - make a non-stop mode (currently it exits on the first error)
-#    - and have better error/warning reporting
-#  - add some form of testing (maybe like what we do for updateDatFiles.py with
-#    performance/compiler/elliot/updateDatFiles)
-#  - run this as part of the smoke test
-#
+import annotate
+
+chplenv_dir = os.path.join(os.path.dirname(__file__), '..', 'chplenv')
+sys.path.insert(0, os.path.abspath(chplenv_dir))
+
+from chpl_home_utils import get_chpl_home
 
 def main():
-    chpl_home = os.environ.get('CHPL_HOME')
+    """
+    Parse and do some basic validation of the ANNOTATIONS.yaml file
+    """
+    chpl_home = get_chpl_home()
     test_dir = os.path.join(chpl_home, 'test')
-    ann_path=os.path.join(test_dir, 'ANNOTATIONS.yaml')
+    ann_path = os.path.join(test_dir, 'ANNOTATIONS.yaml')
 
     ann_data = annotate.load(ann_path)
     graph_list = get_graph_names(test_dir)
@@ -45,57 +47,57 @@ def main():
 
     print("\nNo fatal annotation errors detected")
 
-# Parse $CHPL_HOME/test/*GRAPHFILES and return the basenames of all .graph
-# files listed
 def get_graph_names(test_dir):
+    """Parse test_dir/*GRAPHFILES and return basenames for all .graph files"""
     graph_list = []
     GRAPHFILES_files = [f for f in os.listdir(test_dir) if f.endswith("GRAPHFILES")]
     for GRAPHFILE in GRAPHFILES_files:
-        with open (os.path.join(test_dir, GRAPHFILE), 'r') as f:
+        with open(os.path.join(test_dir, GRAPHFILE), 'r') as f:
             for l in f.readlines():
-		l = l.strip()
-		if l.startswith('#') or len(l) == 0:
-		    continue
-		graph_list.append(os.path.basename(l).replace('.graph', ''))
+                l = l.strip()
+                if not l or l.startswith('#'):
+                    continue
+                graph_list.append(os.path.basename(l).replace('.graph', ''))
     return graph_list
 
-# Parse a string into a date
 def parse_date(value, dateformat='%Y-%m-%d'):
+    """Parse a string into a date"""
     return time.strptime(value.strip(), dateformat)
 
-# Parse annotations for every possible graph for all valid date ranges
 def try_parsing_annotations(ann_data, graph_list):
+    """Parse annotations for every possible graph for all valid date ranges"""
     for graph in graph_list:
         try:
-            annotate.get(ann_data, graph, '', parse_date('2001-01-01'), parse_date('2100-12-31'), '')
-        except:
+            start_date = parse_date('2001-01-01')
+            end_date = parse_date('2100-12-31')
+            annotate.get(ann_data, graph, '', start_date, end_date, '')
+        except Exception as e:
             print('Error parsing annotations for "{0}"\n'.format(graph))
-            traceback.print_exc()
-            exit(-1)
+            raise e
 
-# Check that all graph names listed in the annotation file have an associated
-# .graph in $CHPL_HOME/test/*GRAPHFILES
 def check_graph_names(ann_data, graph_list):
+    """Check that graph names in the annotation file are listed in GRAPHFILES"""
     for graph in ann_data:
-        if graph != 'all' and graph not in (graph_list):
+        if graph != 'all' and graph not in graph_list:
             print('Warning: no .graph file found for "{0}"'.format(graph))
 
-# Check that all the configs used in the annotation file are "known"
 def check_configs(ann_data):
+    """Check that all the configs used in the annotation file are 'known'"""
     known_configs = {'shootout', 'chap03', 'chap04', 'bradc-lnx', 'chapcs',
                      '16 node XC', 'Single node XC'}
     for graph in ann_data:
-        for date, annotations in ann_data[graph].iteritems():
+        for _, annotations in ann_data[graph].iteritems():
             for ann in annotations:
                 if isinstance(ann, dict) and 'config' in ann:
                     configs = ann['config'].split(',')
                     for config in configs:
                         config = config.strip()
                         if config not in known_configs:
-                            print('Warning: config "{0}" for graph "{1}" not recognized'.format(config, graph))
+                            print('Warning: config "{0}" for graph "{1}" not '
+                                  'recognized'.format(config, graph))
 
-# Helper function to compute a map of PR numbers to commit dates
 def compute_pr_to_dates():
+    """Helper function to compute a map of PR numbers to commit dates"""
     pr_to_date_dict = {}
     git_cmd = 'git log --grep "^Merge pull request #" --date=short --pretty=format:"%ad ::: %s"'
     p = subprocess.Popen(git_cmd, stdout=subprocess.PIPE, shell=True)
@@ -108,10 +110,11 @@ def compute_pr_to_dates():
 
     return pr_to_date_dict
 
-# Check annotation dates aren't the same as the date the PR was committed. This
-# check could be beefed up to check that dates are within a week or so of the
-# commit date
 def check_pr_number_dates(ann_data):
+    """
+    Check that annotation dates aren't the same as commit date. This could be
+    beefed up to check that dates are within a week or so of the commit date
+    """
     pr_to_date_dict = compute_pr_to_dates()
     for graph in ann_data:
         for date, annotations in ann_data[graph].iteritems():
@@ -125,7 +128,9 @@ def check_pr_number_dates(ann_data):
                     if pr_num in pr_to_date_dict:
                         pr_date = pr_to_date_dict[pr_num]
                         if pr_date == date:
-                            print('Warning: annotation date for "{0}: {1}" appears to be the same as the commit date'.format(graph, text))
+                            print('Warning: annotation date for "{0}: {1}" '
+                                  'appears to be the same as the commit '
+                                  'date'.format(graph, text))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Exit with a non-zero exit-code if the annotation checker finds any warnings

The annotation checker is now being run as part the travis smoke test so
warnings won't be caught unless there's a non-zero exit code. The warnings
aren't fatal (won't screw up nightly testing), but they should still be caught
before merging.

Also does some misc cleanup to the script:

  - use docstrings instead of # comments
  - remove outdated comments
  - use get_chpl_home() instead of just looking for $CHPL_HOME
  - trim down some long lines
  - cleanup other misc things suggested by the linter

