### PR TITLE
Two fields

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -448,6 +448,20 @@ AggregateType* AggregateType::getInstantiationMulti(SymbolMap& subs,
   return instantiation;
 }
 
+bool AggregateType::isInstantiatedFrom(const AggregateType* base) const {
+  const AggregateType* type   = this;
+  bool                 retval = false;
+
+  while (type != NULL && retval == false) {
+    if (type == base) {
+      retval = true;
+    } else {
+      type = type->instantiatedFrom;
+    }
+  }
+
+  return retval;
+}
 
 int AggregateType::getFieldPosition(const char* name, bool fatal) {
   Vec<Type*> next, current;

--- a/compiler/include/AggregateType.h
+++ b/compiler/include/AggregateType.h
@@ -79,8 +79,12 @@ public:
   bool                        setNextGenericField();
 
   AggregateType*              getInstantiation(Symbol* sym, int index);
+
   AggregateType*              getInstantiationMulti(SymbolMap& subs,
                                                     FnSymbol* fn);
+
+  bool                        isInstantiatedFrom(const AggregateType* base)
+                                                                         const;
 
   const char*                 classStructName(bool standalone);
 

--- a/test/classes/initializers/generics/reuse-init-multiple-types.bad
+++ b/test/classes/initializers/generics/reuse-init-multiple-types.bad
@@ -1,3 +1,0 @@
-reuse-init-multiple-types.chpl:24: error: unresolved call 'Foo.init(type int(64), type int(64))'
-reuse-init-multiple-types.chpl:15: note: candidates are: Foo.init(type t1Val, type t2Val)
-deleted module lines

--- a/test/classes/initializers/generics/reuse-init-multiple-types.chpl
+++ b/test/classes/initializers/generics/reuse-init-multiple-types.chpl
@@ -1,9 +1,6 @@
-//
-// 2017-07-25 Future
-//
-// It is not possible to make two instances of the same generic type
-// when there are multiple type fields.
-//
+// Confirm that it is possible to create two instances of a generic
+// class if the class has multiple generic fields.  Until 08/03/2017
+// this only worked for one generic field.
 
 class Foo {
   type t1;

--- a/test/classes/initializers/generics/reuse-init-multiple-types.future
+++ b/test/classes/initializers/generics/reuse-init-multiple-types.future
@@ -1,7 +1,0 @@
-bug: cannot make multiple instances of a generic type with multiple type fields
-
-This test generates a resolution error when attempting to create a second
-instance of a specialization of a generic record with multiple type fields
-
-Note: when this test is fixed, please remove the prediff and update the
-expected output accordingly.

--- a/test/classes/initializers/generics/reuse-init-multiple-types.good
+++ b/test/classes/initializers/generics/reuse-init-multiple-types.good
@@ -1,1 +1,3 @@
-deleted module lines
+true
+{x1 = 0, x2 = 0}
+{x1 = 0, x2 = 0}

--- a/test/classes/initializers/generics/reuse-init-multiple-types.prediff
+++ b/test/classes/initializers/generics/reuse-init-multiple-types.prediff
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-output=$2
-cat $output | sed '/^\$CHPL_HOME\/modules\// d' > $output.tmp
-echo "deleted module lines" >> $output.tmp
-mv $output.tmp $output


### PR DESCRIPTION
We determined that it was not possible to create multiple instances of the same specialization
of a generic class if the class has multiple generic fields. However similar tests with just one
generic field passed.

The current implementation of Generic types requires that the "instantiated from" relationship
between types be transitive.  Before this PR,  canDispatch() only considered a single step.
This PR adds a transitive test and extends canDispatch to use it.

This PR includes the conversion of the current future to a passing test.

Compiled/tested in the conventional way




