### PR TITLE
Resolve init 1

### DIFF
--- a/compiler/AST/PartialCopyData.cpp
+++ b/compiler/AST/PartialCopyData.cpp
@@ -31,9 +31,20 @@ PartialCopyData::PartialCopyData() {
 }
 
 PartialCopyData::~PartialCopyData() {
-
   partialCopyMap.clear();
   varargNewFormals.clear();
+}
+
+// Return true if there is an entry for 'fn' in the partialCopyFnMap
+bool hasPartialCopyData(const FnSymbol* fn) {
+  std::map<int, PartialCopyData>::iterator it     = sFnMap.find(fn->id);
+  bool                                     retval = false;
+
+  if (it != sFnMap.end()) {
+    retval = true;
+  }
+
+  return retval;
 }
 
 // Return the entry for 'fn' in partialCopyFnMap or NULL if it does not exist.

--- a/compiler/include/PartialCopyData.h
+++ b/compiler/include/PartialCopyData.h
@@ -46,12 +46,16 @@ public:
 
 };
 
+bool             hasPartialCopyData(const FnSymbol* fn);
+
 PartialCopyData* getPartialCopyData(FnSymbol* fn);
+
 PartialCopyData& addPartialCopyData(FnSymbol* fn);
 
 void             clearPartialCopyData(FnSymbol* fn);
-void             clearPartialCopyDataFnMap();
-void             checkEmptyPartialCopyDataFnMap();
 
+void             clearPartialCopyDataFnMap();
+
+void             checkEmptyPartialCopyDataFnMap();
 
 #endif

--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -38,7 +38,7 @@ static void build_chpl_entry_points();
 static void build_accessor(AggregateType* ct, Symbol* field, bool setter);
 static void build_accessors(AggregateType* ct, Symbol* field);
 
-static void buildDefaultInitializer(AggregateType* ct);
+static void buildDefaultInitializer(AggregateType* at);
 
 static void buildDefaultOfFunction(AggregateType* ct);
 
@@ -1286,13 +1286,22 @@ static void build_record_hash_function(AggregateType *ct) {
 *                                                                             *
 ************************************** | *************************************/
 
-static void buildDefaultInitializer(AggregateType* ct) {
+static void buildDefaultInitField(AggregateType*               at,
+                                  FnSymbol*                    fn,
+                                  std::set<const char*>&       names);
+
+static bool buildDefaultInitSuper(AggregateType*               at,
+                                  FnSymbol*                    fn,
+                                  const std::set<const char*>& names);
+
+static void buildDefaultInitializer(AggregateType* at) {
   // No need to remake the default initializer if we have already made one!
-  if (ct->defaultInitializer &&
-      strcmp(ct->defaultInitializer->name, "init") == 0)
+  if (at->defaultInitializer                       != NULL &&
+      strcmp(at->defaultInitializer->name, "init") ==    0)
     return;
 
   FnSymbol* fn = new FnSymbol("init");
+
   fn->cname = fn->name;
 
   // Lydia NOTE 06/16/17: I don't think I want to add the DEFAULT_CONSTRUCTOR
@@ -1303,54 +1312,85 @@ static void buildDefaultInitializer(AggregateType* ct) {
 
   fn->insertFormalAtTail(new ArgSymbol(INTENT_BLANK, "_mt", dtMethodToken));
 
-  fn->_this = new ArgSymbol(INTENT_BLANK, "this", ct);
+  fn->_this = new ArgSymbol(INTENT_BLANK, "this", at);
 
   fn->_this->addFlag(FLAG_ARG_THIS);
+
   fn->insertFormalAtTail(fn->_this);
 
-  std::set<const char*> fieldNamesSet;
+  std::set<const char*> names;
 
-  for_fields(field1, ct) {
-    SET_LINENO(field1);
-    if (VarSymbol* field = toVarSymbol(field1)) {
-      if (!field->hasFlag(FLAG_SUPER_CLASS) /* &&
-          strcmp(field->name, "_promotionType") &&
-          strcmp(field->name, "outer")*/) {
+  buildDefaultInitField(at, fn, names);
+
+  if (buildDefaultInitSuper(at, fn, names) == true) {
+    DefExpr* def = new DefExpr(fn);
+
+    at->defaultInitializer = fn;
+
+    at->symbol->defPoint->insertBefore(def);
+
+    fn->addFlag(FLAG_METHOD);
+    fn->addFlag(FLAG_METHOD_PRIMARY);
+
+    reset_ast_loc(def, at->symbol);
+
+    normalize(fn);
+
+    at->methods.add(fn);
+
+    if (at->isClass() == true && at->isGeneric() == false) {
+      normalize(buildClassAllocator(fn));
+    }
+  }
+}
+
+static void buildDefaultInitField(AggregateType*         at,
+                                  FnSymbol*              fn,
+                                  std::set<const char*>& names) {
+  for_fields(fieldDefExpr, at) {
+    SET_LINENO(fieldDefExpr1);
+
+    if (VarSymbol* field = toVarSymbol(fieldDefExpr)) {
+      if (field->hasFlag(FLAG_SUPER_CLASS) == false
+          /*                                       &&
+             strcmp(field->name, "_promotionType") &&
+             strcmp(field->name, "outer")
+          */) {
         // Lydia NOTE 06/16/17: The above cases are commented out because I
         // wanted to focus on basic support first.  I suspect these will be
         // useful when I do try to support iterators and nested classes/records
 
         ArgSymbol* arg = new ArgSymbol(INTENT_BLANK,
                                        field->name,
-                                       dtUnknown/*,
-                                                  field->type*/);
-        // Lydia NOTE 06/16/17: I suspect that field->type (which is commented
-        // out) will not be useful to us in dtUnknown's place at this point in
-        // the compiler, but would like to leave it here in case it proves
-        // useful in the future.
+                                       dtUnknown);
 
-        fieldNamesSet.insert(field->name);
+        names.insert(field->name);
 
         // Insert initialization for each field from the argument provided.
         SET_LINENO(field);
 
-        if (field->hasFlag(FLAG_PARAM))
+        if (field->hasFlag(FLAG_PARAM) == true) {
           arg->intent = INTENT_PARAM;
-        if (field->isType())
+        }
+
+        if (field->isType() == true) {
           arg->addFlag(FLAG_TYPE_VARIABLE);
+        }
 
         // set up the ArgSymbol appropriately for the type and initialization
         // from the field declaration.
-        if (!field->defPoint->init) {
+        if (field->defPoint->init == NULL) {
           if (field->defPoint->exprType != NULL) {
             Expr* initVal = new SymExpr(gTypeDefaultToken);
+
             arg->defaultExpr = new BlockStmt(initVal);
           }
+
         } else {
           arg->defaultExpr = new BlockStmt(field->defPoint->init->copy());
         }
 
-        if (!field->defPoint->exprType) {
+        if (field->defPoint->exprType == NULL) {
           arg->type = dtAny;
 
           if (field->defPoint->init != NULL) {
@@ -1367,14 +1407,16 @@ static void buildDefaultInitializer(AggregateType* ct) {
 
             BlockStmt* typeExpr = new BlockStmt(new DefExpr(tmp), BLOCK_TYPE);
 
-            typeExpr->insertAtTail(new CallExpr(PRIM_MOVE, tmp,
+            typeExpr->insertAtTail(new CallExpr(PRIM_MOVE,
+                                                tmp,
                                                 field->defPoint->init->copy()));
             // Lydia NOTE 06/16/17: I believe we don't need to make an initCopy
             // call for the field's init (like the default constructor version
-            // attempts).  I might have missed something, though, so if it turns
-            // out we do need that initCopy, use this instead of the above
-            // statement:
-            // typeExpr->insertAtTail(new CallExpr(PRIM_MOVE, tmp,
+            // attempts).  I might have missed something, though, so if it
+            // turns out we do need that initCopy, use this instead of the
+            // above statement:
+            // typeExpr->insertAtTail(new CallExpr(PRIM_MOVE,
+            //                                     tmp,
             //                                     new CallExpr("chpl__initCopy",
             //                                                  field->defPoint->init->copy())));
 
@@ -1382,6 +1424,7 @@ static void buildDefaultInitializer(AggregateType* ct) {
 
             arg->typeExpr = typeExpr;
           }
+
         } else {
           arg->typeExpr = new BlockStmt(field->defPoint->exprType->copy(),
                                         BLOCK_SCOPELESS);
@@ -1389,22 +1432,32 @@ static void buildDefaultInitializer(AggregateType* ct) {
 
         fn->insertFormalAtTail(arg);
 
-        CallExpr* setField = new CallExpr(PRIM_INIT_FIELD, fn->_this,
-                                          new_CStringSymbol(field->name), arg);
-        fn->insertAtTail(setField);
+        fn->insertAtTail(new CallExpr(PRIM_INIT_FIELD,
+                                      fn->_this,
+                                      new_CStringSymbol(field->name),
+                                      arg));
       }
     }
   }
+}
+
+static bool buildDefaultInitSuper(AggregateType*               at,
+                                  FnSymbol*                    fn,
+                                  const std::set<const char*>& names) {
+  bool retval = true;
 
   // Lydia NOTE 06/16/17: be sure to avoid applying this to tuples, too!
-  if (!ct->symbol->hasFlag(FLAG_REF) && isClass(ct)) {
-    if (ct->dispatchParents.n > 0 && !ct->symbol->hasFlag(FLAG_EXTERN)) {
-      if (AggregateType* parent = toAggregateType(ct->dispatchParents.v[0])) {
+  if (isClass(at) == true && at->symbol->hasFlag(FLAG_REF) == false) {
+    if (at->dispatchParents.n            >      0 &&
+        at->symbol->hasFlag(FLAG_EXTERN) == false) {
+      if (AggregateType* parent = toAggregateType(at->dispatchParents.v[0])) {
         if (parent->initializerStyle != DEFINES_CONSTRUCTOR) {
           CallExpr* superPortion = new CallExpr(".",
                                                 new SymExpr(fn->_this),
                                                 new_CStringSymbol("super"));
+
           SymExpr*  initPortion  = new SymExpr(new_CStringSymbol("init"));
+
           CallExpr* base         = new CallExpr(".", superPortion, initPortion);
           CallExpr* superCall    = new CallExpr(base);
 
@@ -1412,74 +1465,66 @@ static void buildDefaultInitializer(AggregateType* ct) {
             // We want to call the compiler-generated all-fields initializer
 
             // First, ensure we have a default initializer for the parent
-            if (!parent->defaultInitializer) {
+            if (parent->defaultInitializer == NULL) {
               // ... but only if it is valid to do so
               if (parent->wantsDefaultInitializer()) {
                 buildDefaultInitializer(parent);
               }
 
-              if (!parent->defaultInitializer) {
+              if (parent->defaultInitializer == NULL) {
                 // The parent might have inherited from a class that defines
-                // any initializer but not one without arguments.  In this case,
-                // we shouldn't define a default initializer or constructor for
-                // this class either.
-                return;
+                // any initializer but not one without arguments.
+                // In this case, we shouldn't define a default initializer
+                // for this class either.
+                return false;
               }
-
             }
+
             // Otherwise, we are good to go!
 
             // Add an argument per argument in the parent initializer
             for_formals(formal, parent->defaultInitializer) {
-              if (formal->hasFlag(FLAG_ARG_THIS) ||
-                  formal->type == dtMethodToken ||
-                  formal->hasFlag(FLAG_IS_MEME)) {
+              if (formal->type                   == dtMethodToken ||
+                  formal->hasFlag(FLAG_ARG_THIS) == true ||
+                  formal->hasFlag(FLAG_IS_MEME)  == true) {
                 continue;
               }
 
               // Skip arguments shadowed by this class' fields
-              if (fieldNamesSet.find(formal->name) != fieldNamesSet.end()) {
+              if (names.find(formal->name) != names.end()) {
                 continue;
               }
 
               DefExpr* superArg = formal->defPoint->copy();
+
               fn->insertFormalAtTail(superArg);
+
               superCall->insertAtTail(superArg->sym);
             }
 
           } else {
             INT_ASSERT(parent->initializerStyle == DEFINES_INITIALIZER);
-            // We want to call a user-defined no-argument initializer.  Insert
-            // no arguments
+            // We want to call a user-defined no-argument initializer.
+            // Insert no arguments
           }
 
           fn->body->insertAtTail(superCall);
+
         } else {
-          USR_FATAL(ct, "Cannot create default initializer on type '%s'"
-                    ", which inherits from type '%s' that defines a "
-                    "constructor", ct->symbol->name, parent->symbol->name);
+          USR_FATAL(at,
+                    "Cannot create default initializer on type '%s', "
+                    "which inherits from type '%s' that defines a constructor",
+                    at->symbol->name,
+                    parent->symbol->name);
           // The parent has defined a constructor, we cannot have a default
           // initializer call that constructor via super.init();
-          return;
+          return false;
         }
       }
     }
   }
 
-  ct->defaultInitializer = fn;
-
-  DefExpr* def = new DefExpr(fn);
-  ct->symbol->defPoint->insertBefore(def);
-  fn->addFlag(FLAG_METHOD);
-  fn->addFlag(FLAG_METHOD_PRIMARY);
-  reset_ast_loc(def, ct->symbol);
-  normalize(fn);
-  ct->methods.add(fn);
-
-  if (!ct->isGeneric() && ct->isClass()) {
-    FnSymbol* allocator = buildClassAllocator(fn);
-    normalize(allocator);
-  }
+  return retval;
 }
 
 /************************************* | **************************************


### PR DESCRIPTION
This PR refactors a small amount of logic associated with generic initializers



The primary goal of this PR is to begin to clarify the role of the prim-op PRIM_INIT_FIELD
across the normalize, build-default-functions, and function-resolution passes.  This prim-op
is inserted during the former two passes and is consumed in the final pass.  It plays an
important role in converting a generic class/record to a specialized class/record during
function-resolution.

There are three functions in InitNormalize.cpp that insert this prim-op for generic fields;
these functions are partitioned based on whether the type/init exprs for the generic field
are NULL or non-NULL.  None of these functions are affected by this PR.

Before this PR buildDefaultInitializer() was a fairly substantial function that inserted this
prim-op for both generic and non-generic fields.

1. This PR splits this function in to three functions; the primary driver and two helper functions.
The first helper inserts AST for every local field, and the second helper attempts to invoke super.init.

2. Shuffles the logic within the helper for the local fields to be more consistent with
normalize i.e. separate the cases of typeExpr/initExpr set to NULL or non-NULL.
However it continues to use PRIM_INIT_FIELD for every field.  This is done in 2 commits
to help to simplify/clarify the transformations.


This PR also sweeps up a change to add the predicate bool hasPartialCopyData() to
PartialCopyData.  This class plays a role in specializing generic functions.

Followed standard protocol for compilation/testing.

