### PR TITLE
Revert #6952 Define SIZE_MAX if needed for runtime

### DIFF
--- a/runtime/include/chpl-comm.h
+++ b/runtime/include/chpl-comm.h
@@ -250,9 +250,6 @@ void chpl_comm_get_registered_heap(void** start_p, size_t* size_p);
 //   only free it elsewhere if this function returns false.
 //
 #ifndef CHPL_COMM_IMPL_REG_MEM_ALLOC_THRESHOLD
-#ifndef SIZE_MAX
-  #define SIZE_MAX (~((size_t)0))
-#endif
   #define CHPL_COMM_IMPL_REG_MEM_ALLOC_THRESHOLD() SIZE_MAX
 #endif
 static inline


### PR DESCRIPTION
@dmk42 says that SIZE_MAX is a system constant and messing with it may cause trouble. Given that pre-6952 code compiles fine with gcc 6.3 that we use for nightly testing, I am backing this out to be on the safe side.
