### PR TITLE
Fix use of stdint.h by C++ code

### DIFF
--- a/runtime/include/qio/qbuffer.h
+++ b/runtime/include/qio/qbuffer.h
@@ -24,10 +24,6 @@
 #ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS 1
 #endif
-// This macro set to obtain SIZE_MAX
-#ifndef __STDC_LIMIT_MACROS
-#define __STDC_LIMIT_MACROS 1
-#endif
 
 #include "sys_basic.h"
 #include "qio_error.h"
@@ -38,15 +34,6 @@
 
 #include <inttypes.h>
 #include <stdint.h>
-
-// Last resort way to get SIZE_MAX. This should be correct,
-// but we'd rather use the system's definition... which should
-// theoretically be provided by the above (__STDC_LIMIT_MACROS+stdint.h)
-// but that isn't happening for me on GCC 4.7.2 when this file is included
-// by a C++ program.
-#ifndef SIZE_MAX
-#define SIZE_MAX (~((size_t)0))
-#endif
 
 #include <sys/uio.h>
 #include "deque.h"

--- a/runtime/include/sys_basic.h
+++ b/runtime/include/sys_basic.h
@@ -77,6 +77,9 @@
 #ifndef __STDC_CONSTANT_MACROS
 #define __STDC_CONSTANT_MACROS
 #endif
+#ifndef __STDC_LIMIT_MACROS
+#define __STDC_LIMIT_MACROS
+#endif
 
 #include <sys/types.h>
 #include <unistd.h>


### PR DESCRIPTION
In #457 , there was a workaround to get `SIZE_MAX` when it should have been available to C\+\+ runtime code but was not.

Another such case was found, and #6952 was an attempt at another workaround.  This was reverted in #6954 .

Both problems were due to `__STDC_LIMIT_MACROS` not being set on the first inclusion of `<stdint.h>`.  Setting this macro before subsequent inclusions was too late because the inclusion guard had already been set.  This change sets `__STDC_LIMIT_MACROS` before the first inclusion so that no workarounds are needed.

This issue only affects old C\+\+ compilers such as gcc 4.7.2.  Newer compilers do not need `__STDC_LIMIT_MACROS` set to retrieve the macros from `<stdint.h>`.

Tested with gcc 4.7.2, gcc 6.3.0, and clang (latest Mac release).

Since this has affected many people over the years, I will not merge until the following people have had a chance to look at it.
@gbtitus @mppf @ronawho @vasslitvinov 
