### PR TITLE
Trim a bad cut/paste from a previous PR

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -3837,6 +3837,12 @@ static void registerParamPreference(int&                  paramPrefers,
   }
 }
 
+/************************************* | **************************************
+*                                                                             *
+*                                                                             *
+*                                                                             *
+************************************** | *************************************/
+
 DisambiguationContext::DisambiguationContext(CallInfo& info) {
   actuals = &info.actuals;
   scope   = (info.scope) ? info.scope : getVisibilityBlock(info.call);
@@ -3862,14 +3868,6 @@ DisambiguationContext::forPair(int newI, int newJ) {
 
   return *this;
 }
-
-  Vec<Symbol*>* actuals;
-  Expr*         scope;
-  bool          explain;
-  int           i;
-  int           j;
-
-
 
 /************************************* | **************************************
 *                                                                             *


### PR DESCRIPTION
I noticed some errant cut/paste text from a recent PR.  Tidying up.

Even though this is completely trivial, I performed my standard compile/test protocol.
