### PR TITLE
Add a test to make sure building from --savec generated code works

### DIFF
--- a/test/compflags/diten/savec.chpl
+++ b/test/compflags/diten/savec.chpl
@@ -1,0 +1,18 @@
+const outdir = "savec_output";
+const filename = "savec.chpl";
+
+var ret: int;
+
+extern proc system(s: c_string): int(32);
+
+ret = system(("chpl --savec " + outdir + " " + filename).c_str());
+if ret != 0 then
+  halt("Error compiling Chapel code");
+
+ret = system(("make -f " + outdir + "/Makefile > /dev/null 2>&1").c_str());
+if ret != 0 then
+  halt("Error compiling C code");
+
+ret = system(("rm -r " + outdir).c_str());
+if ret != 0 then
+  halt("Error removing savec directory");

--- a/test/compflags/diten/savec.future
+++ b/test/compflags/diten/savec.future
@@ -1,0 +1,5 @@
+bug: building from saved C source fails for multilocale
+
+PR #6772 is believed to be the cause of this bug. Once it is fixed, this
+.future file and the .skipif should be removed so that this is tested in all
+configurations.

--- a/test/compflags/diten/savec.skipif
+++ b/test/compflags/diten/savec.skipif
@@ -1,0 +1,1 @@
+CHPL_COMM == none


### PR DESCRIPTION
This test currently fails for CHPL_COMM != none, so is filed as a .future
that is skipped if CHPL_COMM == none.  Once the problem is fixed, both the
.future and the .skipif should be removed.

@ben-albrecht said that PR #6772 is the cause of this failure.