### PR TITLE
Improve .prediff for test_record_of_array_type

### DIFF
--- a/test/arrays/deitz/part3/test_record_of_array_type.prediff
+++ b/test/arrays/deitz/part3/test_record_of_array_type.prediff
@@ -3,13 +3,17 @@
 outfile=$2
 temp=$outfile.tmp
 
-# First, grab the program output.
-# Filter out valgrind output and some nondeterministic output.
-grep -v ^= $outfile | \
-  grep -v '^timedexec:' | \
-  grep -v '(x = (x = 0.0))' > $temp
+# Process the output only if valgrind saw an issue.
+if grep -q '^==[0-9]*== ' $outfile; then
 
-# Then, add the first two lines of valgrind output, cleaned up.
-grep ^= $outfile | sed 's@^=[^ ]*= @@;s@Thread.*@Thread@' | head -2 >> $temp
+  # Preserve the original output.
+  mv $outfile $temp
 
-mv $temp $outfile
+  # Grab the first two lines of the program output
+  # because they should be deterministic.
+  grep -v ^= $temp | head -2 > $outfile
+
+  # Add the first two lines of valgrind output, cleaned up.
+  grep ^= $temp | sed 's@^=[^ ]*= @@;s@Thread.*@Thread@' | head -2 >> $outfile
+
+fi


### PR DESCRIPTION
The program output after the first two lines is more unpredictable
than I hoped for in #6953. Given that currently there is
memory corruption, this is understandable.

So, if valgrind turns up errors, retain only the first two lines
of the program output. Those happen before valgrind encounters
the first issue. If there are no valgrind errors, retain the
output without the modification.

Note that valgrind output and program output may occur in any order
w.r.t. each other, probably because one goes to stdin and the other
to stderr. So we can't just grab the first four lines.

As Lydia notes, this test can still potentially time out.
If this causes noise in nightly testing, let us revisit.
Maybe remove .bad and .prediff altogether, like it was
before #6953.