### PR TITLE
Fix using_chapel_module()

### DIFF
--- a/util/chplenv/chpl_home_utils.py
+++ b/util/chplenv/chpl_home_utils.py
@@ -18,10 +18,6 @@ def get_chpl_home():
     return chpl_home
 
 @memoize
-def get_chpl_module_home():
-    return os.environ.get('CHPL_MODULE_HOME', '')
-
-@memoize
 def get_chpl_third_party():
     default = os.path.join(get_chpl_home(), 'third-party')
     chpl_third_party = overrides.get('CHPL_THIRD_PARTY', default)
@@ -29,9 +25,8 @@ def get_chpl_third_party():
 
 @memoize
 def using_chapel_module():
-    chpl_home = os.path.normpath(overrides.get('CHPL_HOME', ''))
-    chpl_module_home = os.path.normpath(get_chpl_module_home())
-    if chpl_home != '':
-        return chpl_home == chpl_module_home
+    chpl_home = overrides.get('CHPL_HOME', None)
+    chpl_module_home = os.environ.get('CHPL_MODULE_HOME', None)
+    if chpl_home and chpl_module_home:
+        return os.path.normpath(chpl_home) == os.path.normpath(chpl_module_home)
     return False
-


### PR DESCRIPTION
In #6946 I changed using_chapel_module() to do a normpath on CHPL_HOME and
CHPL_MODULE_HOME before comparing them. If both were unset, this would
incorrectly result in the function thinking the chapel module was being used,
which resulted in building the runtime for the lowest common denominator on the
whiteboxes.

This updates using_chapel_module() to only do the normpath after checking if
CHPL_HOME and CHPL_MODULE_HOME were actually set.