### PR TITLE
Add user error for returning wrong tuple size

### DIFF
--- a/compiler/resolution/tuples.cpp
+++ b/compiler/resolution/tuples.cpp
@@ -570,7 +570,7 @@ static void instantiate_tuple_init(FnSymbol* fn) {
 ************************************** | *************************************/
 
 static void
-instantiate_tuple_cast(FnSymbol* fn)
+instantiate_tuple_cast(FnSymbol* fn, CallExpr* context)
 {
   // Adjust any formals for blank-intent tuple behavior now
   resolveFormals(fn);
@@ -583,6 +583,12 @@ instantiate_tuple_cast(FnSymbol* fn)
 
   VarSymbol* retv = new VarSymbol("retv", toT);
   block->insertAtTail(new DefExpr(retv));
+
+  if (fromT->numFields() != toT->numFields()) {
+    USR_FATAL_CONT(context, "tuple size mismatch (expected %d, got %d)", 
+                   toT->numFields()-1, fromT->numFields()-1);
+    return;
+  }
 
   // Starting at field 2 to skip the size field
   for (int i=2; i<=toT->fields.length; i++) {
@@ -899,7 +905,7 @@ fixupTupleFunctions(FnSymbol* fn,
   if (fn->hasFlag(FLAG_TUPLE_CAST_FN) &&
       newFn->getFormal(1)->getValType()->symbol->hasFlag(FLAG_TUPLE) &&
       fn->getFormal(2)->getValType()->symbol->hasFlag(FLAG_TUPLE) ) {
-    instantiate_tuple_cast(newFn);
+    instantiate_tuple_cast(newFn, instantiatedForCall);
     return true;
   }
 

--- a/test/types/tuple/errors/returnWrongSize.chpl
+++ b/test/types/tuple/errors/returnWrongSize.chpl
@@ -1,0 +1,10 @@
+proc foo(param small): (int, int, int) {
+  if small then
+    return (1,2);
+  else
+    return (1,2,3,4);
+}
+
+writeln(foo(true));
+writeln(foo(false));
+

--- a/test/types/tuple/errors/returnWrongSize.good
+++ b/test/types/tuple/errors/returnWrongSize.good
@@ -1,0 +1,4 @@
+returnWrongSize.chpl:1: In function 'foo':
+returnWrongSize.chpl:3: error: tuple size mismatch (expected 3, got 2)
+returnWrongSize.chpl:1: In function 'foo':
+returnWrongSize.chpl:5: error: tuple size mismatch (expected 3, got 4)


### PR DESCRIPTION
This resolves issue #6961 in which returning a tuple of the wrong size resulted in an internal error in some cases and the ignoring of the extra fields in other cases.  Here, we do an explicit size check before entering the code in question and issue an error if there's a mismatch.  Added a new test to lock in the error message.

