### PR TITLE
Disambiguation 2

### DIFF
--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -143,8 +143,10 @@ void renameInstantiatedTypeString(TypeSymbol* sym, VarSymbol* var);
 
 FnSymbol* determineRootFunc(FnSymbol* fn);
 
-void determineAllSubs(FnSymbol* fn, FnSymbol* root, SymbolMap& subs,
-                      SymbolMap& all_subs);
+void determineAllSubs(FnSymbol*  fn,
+                      FnSymbol*  root,
+                      SymbolMap& subs,
+                      SymbolMap& allSubs);
 
 FnSymbol* instantiateFunction(FnSymbol*  fn,
                               FnSymbol*  root,
@@ -169,10 +171,8 @@ private:
 
 
 ResolutionCandidate*
-disambiguateByMatch(Vec<ResolutionCandidate*>&   candidates,
-                    const DisambiguationContext& DC,
-                    bool                         ignoreWhere,
-                    Vec<ResolutionCandidate*>&   ambiguous);
+disambiguateForInit(CallInfo&                    info,
+                    Vec<ResolutionCandidate*>&   candidates);
 
 // Regular resolve functions
 void      resolveFormals(FnSymbol* fn);

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -3216,12 +3216,27 @@ static bool populateForwardingMethods(CallInfo& info) {
 
 #define EXPLAIN(...)                                  \
         if (developer && DC.explain) fprintf(stderr, __VA_ARGS__)
+
 #else
 
 #define EXPLAIN(...)
 
 #endif
 
+
+static ResolutionCandidate*
+disambiguateByMatch(Vec<ResolutionCandidate*>&   candidates,
+                    const DisambiguationContext& DC,
+                    bool                         ignoreWhere,
+                    Vec<ResolutionCandidate*>&   ambiguous);
+
+
+static ResolutionCandidate*
+disambiguateByMatch(Vec<ResolutionCandidate*>&   candidates,
+                    const DisambiguationContext& DC,
+                    bool                         ignoreWhere,
+                    bool                         forGenericInit,
+                    Vec<ResolutionCandidate*>&   ambiguous);
 
 static int  compareSpecificity(ResolutionCandidate*         candidate1,
                                ResolutionCandidate*         candidate2,
@@ -3239,6 +3254,14 @@ static void testArgMapping(FnSymbol*                    fn1,
                            int                          i,
                            int                          j,
                            DisambiguationState&         DS);
+
+ResolutionCandidate*
+disambiguateForInit(CallInfo& info, Vec<ResolutionCandidate*>& candidates) {
+  DisambiguationContext     DC(info);
+  Vec<ResolutionCandidate*> ambiguous;
+
+  return disambiguateByMatch(candidates, DC, false, ambiguous);
+}
 
 static int disambiguateByMatch(CallInfo&                  info,
                                Vec<ResolutionCandidate*>& candidates,
@@ -3391,30 +3414,21 @@ static int disambiguateByMatch(CallInfo&                  info,
   return retval;
 }
 
-/** Find the best candidate from a list of candidates.
- *
- * This function finds the best Chapel function from a set of candidates, given
- * a call site.  This is an implementation of 13.14.3 of the Chapel language
- * specification (page 106).
- *
- * \param candidates A list of the candidate functions, from which the best
- *                   match is selected.
- * \param mostSpecificSet  On return, stores the set of candidates that
- *                         are not known to be worse than any other,
- *                         in the event that this set has 1 member.
- * \param DC         The disambiguation context.
- * \param ignoreWhere Set to `true` to ignore `where` clauses when
- *                    deciding if one match is better than another.
- *                    This is important for resolving return intent
- *                    overloads.
- *
- * \return NULL or the single most specific candidate
- */
-ResolutionCandidate*
+static ResolutionCandidate*
 disambiguateByMatch(Vec<ResolutionCandidate*>&   candidates,
                     const DisambiguationContext& DC,
                     bool                         ignoreWhere,
-                    Vec<ResolutionCandidate*>&   mostSpecificSet) {
+                    Vec<ResolutionCandidate*>&   ambiguous) {
+  return disambiguateByMatch(candidates, DC, ignoreWhere, false, ambiguous);
+}
+
+
+static ResolutionCandidate*
+disambiguateByMatch(Vec<ResolutionCandidate*>&   candidates,
+                    const DisambiguationContext& DC,
+                    bool                         ignoreWhere,
+                    bool                         forGenericInit,
+                    Vec<ResolutionCandidate*>&   ambiguous) {
   // MPF note: A more straightforwardly O(n) version of this
   // function did not appear to be faster. See history of this comment.
 
@@ -3423,7 +3437,6 @@ disambiguateByMatch(Vec<ResolutionCandidate*>&   candidates,
   std::vector<bool> notBest(candidates.n, false);
 
   for (int i = 0; i < candidates.n; ++i) {
-
     EXPLAIN("##########################\n");
     EXPLAIN("# Considering function %d #\n", i);
     EXPLAIN("##########################\n\n");
@@ -3486,7 +3499,7 @@ disambiguateByMatch(Vec<ResolutionCandidate*>&   candidates,
 
   for (int i = 0; i < candidates.n; ++i) {
     if (notBest[i] == false) {
-      mostSpecificSet.add(candidates.v[i]);
+      ambiguous.add(candidates.v[i]);
     }
   }
 

--- a/compiler/resolution/initializerResolution.cpp
+++ b/compiler/resolution/initializerResolution.cpp
@@ -97,10 +97,8 @@ static void resolveInitCall(CallExpr* call) {
     info.haltNotWellFormed(true);
 
   } else {
-    DisambiguationContext     DC(info);
     Vec<FnSymbol*>            visibleFns;
     Vec<ResolutionCandidate*> candidates;
-    Vec<ResolutionCandidate*> ambiguous;
     ResolutionCandidate*      best        = NULL;
 
     findVisibleFunctions(info, visibleFns);
@@ -109,7 +107,7 @@ static void resolveInitCall(CallExpr* call) {
 
     explainGatherCandidate(info, candidates);
 
-    best = disambiguateByMatch(candidates, DC, false, ambiguous);
+    best = disambiguateForInit(info, candidates);
 
     if (best == NULL) {
       if (call->partialTag == false) {

--- a/test/classes/initializers/generics/reuse-class-instantiation2.chpl
+++ b/test/classes/initializers/generics/reuse-class-instantiation2.chpl
@@ -1,0 +1,50 @@
+class MyClass {
+  var x;
+  var y;
+
+  proc init(_x : int, _y : int) {
+    writeln('Concrete');
+
+    x = _x;
+    y = _y;
+
+    super.init();
+  }
+
+  proc init(_x, _y) {
+    writeln('Generic');
+
+    x = _x;
+    y = _y;
+
+    super.init();
+  }
+}
+
+
+
+proc main() {
+  var c1 = new MyClass(10, 20);
+  var c2 = new MyClass(20, 30);
+  var c3 = new MyClass(30, 40);
+
+  var c5 = new MyClass(false, 40.0);
+  var c6 = new MyClass( true, 50.0);
+  var c7 = new MyClass( true, 60.0);
+
+  writeln('c1 ', c1);
+  writeln('c2 ', c2);
+  writeln('c3 ', c3);
+
+  writeln('c5 ', c5);
+  writeln('c6 ', c6);
+  writeln('c7 ', c7);
+
+  delete c7;
+  delete c6;
+  delete c5;
+
+  delete c3;
+  delete c2;
+  delete c1;
+}

--- a/test/classes/initializers/generics/reuse-class-instantiation2.good
+++ b/test/classes/initializers/generics/reuse-class-instantiation2.good
@@ -1,0 +1,12 @@
+Concrete
+Concrete
+Concrete
+Generic
+Generic
+Generic
+c1 {x = 10, y = 20}
+c2 {x = 20, y = 30}
+c3 {x = 30, y = 40}
+c5 {x = false, y = 40.0}
+c6 {x = true, y = 50.0}
+c7 {x = true, y = 60.0}


### PR DESCRIPTION
A pragmatic work-around for a problem when disambiguating initializers for generic types


Before this PR it was relatively easy to write a program that would fail to resolve if a generic
class had a mixture of generic and non-generic initializers.  Initially all of the candidate
initializers have a _this formal with the generic type.  Resolution of new expressions may
create specialized initializers with a _this formal that is a specialized concrete type.

The code for resolving generic initializers understands these issues and constructs an
appropriate set of candidates but the original version of disambiguateByMatch() did not
have corresponding logic.

This PR, effectively, passes a flag down the call chain that indicates when
disambiguateByMatch() is being invoked with a curated set of initializers. In that case
the core function can ignore the _this formal.  It is easy to agree this is specialized/fragile
but a more general approach seems likely to lead down the slippery slope of overhauling
the resolution of methods vs. functions.


The first two commits introduce and propagate this flag.  The third commit adds a passing
test that failed before these changes


Followed my standard compilation/testing protocol.
