### PR TITLE
Stop forcing pre C++11 ABI for cray-prgenv builds

### DIFF
--- a/make/compiler/Makefile.cray-prgenv
+++ b/make/compiler/Makefile.cray-prgenv
@@ -33,15 +33,6 @@ RANLIB = ranlib
 # flags
 #
 
-# gcc 5.1 introduced a new libstdc++ ABI to conform with the C11 standard, but
-# it is incompatible with the old ABI. If Chapel third-party/runtime C++ code
-# (e.g. re2) is built with the new ABI, the generated code must also use the
-# new ABI or we'll get link errors. However, it's possible for a user to use an
-# older version of gcc than the one used to build the runtime/third-party, so
-# we force the use of the old ABI so our libs can be linked with code that's
-# using either ABI.
-CXXFLAGS += -D_GLIBCXX_USE_CXX11_ABI=0
-
 DEBUG_CFLAGS = -g
 OPT_CFLAGS = -O3
 


### PR DESCRIPTION
gcc 5.1 introduced a new libstdc++ ABI to conform with the C++11 standard, but
it was incompatible with the old ABI. When we initially upgraded our gen
compiler to gcc 5.1 we still wanted to be able to use gcc 4 as a target
compiler, so we built with `-D_GLIBCXX_USE_CXX11_ABI=0`.

However, GLIBCXX_USE_CXX11_ABI=0 is now causing link errors for newer versions
of cce, so this just stops forcing the old ABI. The last gcc 4.X is over 2
years old at this point, and a Cray (especially one that has Chapel installed)
will have a newer default.

This effectively reverts #3565, which also has more details on the original
motivation for throwing `-D_GLIBCXX_USE_CXX11_ABI=0`.