### PR TITLE
Add path to 'chpl' into system command in case it isn't in user's path

### DIFF
--- a/test/compflags/diten/savec.chpl
+++ b/test/compflags/diten/savec.chpl
@@ -5,7 +5,7 @@ var ret: int;
 
 extern proc system(s: c_string): int(32);
 
-ret = system(("chpl --savec " + outdir + " " + filename).c_str());
+ret = system((CHPL_HOME+"/bin/"+CHPL_HOST_PLATFORM+"/"+"chpl --savec " + outdir + " " + filename).c_str());
 if ret != 0 then
   halt("Error compiling Chapel code");
 


### PR DESCRIPTION
@vasslitvinov pointed out that this test doesn't work if 'chpl' isn't in the user's path.  Here, I'm updating the test to form an absolute path to 'chpl' to deal with that potential problem.