### PR TITLE
chplspell: Don't check generated files

### DIFF
--- a/util/devel/chplspell
+++ b/util/devel/chplspell
@@ -65,7 +65,6 @@ DEFAULTDIRS=(
 	     doc/rst/platforms   doc/rst/technotes  doc/rst/tools
 	     doc/rst/users-guide doc/rst/usingchapel
 	     test/release
-	     test/studies/shootout
 	     .github
 )
 

--- a/util/devel/chplspell
+++ b/util/devel/chplspell
@@ -59,14 +59,14 @@ LATEXGLOBS=("-name" "*.tex")
 # Directories under doc/ are listed explicitly to exclude directories
 # generated via "make docs".  The generated files are generated from
 # other files we're already spellchecking.
-DEFAULTDIRS=( \
-	     compiler man modules runtime spec \
-	     doc/rst/developer   doc/rst/language   doc/rst/meta  \
-	     doc/rst/platforms   doc/rst/technotes  doc/rst/tools \
-	     doc/rst/users-guide doc/rst/usingchapel              \
-	     test/release/examples/benchmarks/shootout \
-	     test/release/examples/primers \
-	     test/studies/shootout \
+DEFAULTDIRS=(
+	     compiler man modules runtime spec
+	     doc/rst/developer   doc/rst/language   doc/rst/meta
+	     doc/rst/platforms   doc/rst/technotes  doc/rst/tools
+	     doc/rst/users-guide doc/rst/usingchapel
+	     test/release/examples/benchmarks/shootout
+	     test/release/examples/primers
+	     test/studies/shootout
 	     .github
 )
 # TODO: test/release
@@ -75,7 +75,7 @@ DEFAULTDIRS=( \
 # otherwise not suited for DEFAULTDIRS.  (The latter must have their
 # paths fully specified.  We don't search for these; just a straight-up
 # match in $CHPL_HOME.)
-DEFAULTFILES=("COPYRIGHT" "LICENSE*" "README*" "*.md" "*.rst" \
+DEFAULTFILES=("COPYRIGHT" "LICENSE*" "README*" "*.md" "*.rst"
 	      "test/ANNOTATIONS.yaml" "doc/README.rst")
 
 # Filter out files with "too much" noise.  LAPACK.chpl is over 20k

--- a/util/devel/chplspell
+++ b/util/devel/chplspell
@@ -81,8 +81,11 @@ DEFAULTFILES=("COPYRIGHT" "LICENSE*" "README*" "*.md" "*.rst"
 # Any files with these basenames will be skipped when we encounter them
 # handling entire directories.  This setting has no impact on files specified
 # specifically on the command line.
-FILTEROUT="bison-chapel.cpp bison-chapel.h flex-chapel.cpp flex-chapel.h \
-           LAPACK.chpl"
+FILTEROUT="compiler/parser/bison-chapel.cpp \
+           compiler/include/bison-chapel.h  \
+           compiler/parser/flex-chapel.cpp  \
+           compiler/include/flex-chapel.h   \
+           modules/packages/LAPACK.chpl"
 
 
 # Here endeth the configuration options.  The rest of the script
@@ -219,10 +222,9 @@ if [ $JUSTARGS == 0 ]; then
 
 	# Filter out files listed in $FILTEROUT
 	for file in "${NFILES[@]}"; do
-	    b=$(basename "$file")
 	    KEEP=1
 	    for filter in $FILTEROUT; do
-		if [ "$b" == "$filter" ]; then
+		if [ "$file" != "${file#$filter}" ]; then
 		    KEEP=0
 		    break;
 		fi
@@ -233,10 +235,9 @@ if [ $JUSTARGS == 0 ]; then
 	done
 
 	for file in "${LFILES[@]}"; do
-	    b=$(basename "$file")
 	    KEEP=1
 	    for filter in $FILTEROUT; do
-		if [ "$b" == "$filter" ]; then
+		if [ "$file" != "${file#$filter}" ]; then
 		    KEEP=0
 		    break;
 		fi

--- a/util/devel/chplspell
+++ b/util/devel/chplspell
@@ -60,10 +60,7 @@ LATEXGLOBS=("-name" "*.tex")
 # generated via "make docs".  The generated files are generated from
 # other files we're already spellchecking.
 DEFAULTDIRS=(
-	     compiler man modules runtime spec
-	     doc/rst/developer   doc/rst/language   doc/rst/meta
-	     doc/rst/platforms   doc/rst/technotes  doc/rst/tools
-	     doc/rst/users-guide doc/rst/usingchapel
+	     compiler man modules runtime spec doc
 	     test/release
 	     .github
 )
@@ -85,6 +82,10 @@ FILTEROUT="compiler/parser/bison-chapel.cpp \
            compiler/include/bison-chapel.h  \
            compiler/parser/flex-chapel.cpp  \
            compiler/include/flex-chapel.h   \
+           doc/rst/builtins                 \
+           doc/rst/modules                  \
+           doc/rst/primers                  \
+           doc/rst/examples                 \
            modules/packages/LAPACK.chpl"
 
 

--- a/util/devel/chplspell
+++ b/util/devel/chplspell
@@ -50,28 +50,33 @@ NORMALGLOBS=("-name" "*.chpl"  "-o"
              "-name" "*.h"     "-o"
              "-name" "README*" "-o"
              "-name" "*.md"    "-o"
-             "-name" "*.rst"   "-o"
-             "-name" "*.1" )
-# *.1 are man pages
+             "-name" "*.rst" )
 
 # Latex files to look for when recursing through directories.
 # These are tracked separately because scspell needs --no-c-escapes for them.
 LATEXGLOBS=("-name" "*.tex")
 
+# Directories under doc/ are listed explicitly to exclude directories
+# generated via "make docs".  The generated files are generated from
+# other files we're already spellchecking.
 DEFAULTDIRS=( \
-	     compiler doc man modules runtime spec \
+	     compiler man modules runtime spec \
+	     doc/rst/developer   doc/rst/language   doc/rst/meta  \
+	     doc/rst/platforms   doc/rst/technotes  doc/rst/tools \
+	     doc/rst/users-guide doc/rst/usingchapel              \
 	     test/release/examples/benchmarks/shootout \
 	     test/release/examples/primers \
 	     test/studies/shootout \
 	     .github
 )
-# TODO: tools util test/release
+# TODO: test/release
 
 # DEFAULTFILES are just files in $CHPL_HOME or in a directory
 # otherwise not suited for DEFAULTDIRS.  (The latter must have their
 # paths fully specified.  We don't search for these; just a straight-up
 # match in $CHPL_HOME.)
-DEFAULTFILES=("COPYRIGHT" "LICENSE*" "README*" "*.md" "*.rst" "test/ANNOTATIONS.yaml")
+DEFAULTFILES=("COPYRIGHT" "LICENSE*" "README*" "*.md" "*.rst" \
+	      "test/ANNOTATIONS.yaml" "doc/README.rst")
 
 # Filter out files with "too much" noise.  LAPACK.chpl is over 20k
 # lines of mostly noise, which qualifies.
@@ -80,7 +85,7 @@ DEFAULTFILES=("COPYRIGHT" "LICENSE*" "README*" "*.md" "*.rst" "test/ANNOTATIONS.
 # handling entire directories.  This setting has no impact on files specified
 # specifically on the command line.
 FILTEROUT="bison-chapel.cpp bison-chapel.h flex-chapel.cpp flex-chapel.h \
-           LAPACK.chpl LAPACK.rst"
+           LAPACK.chpl"
 
 
 # Here endeth the configuration options.  The rest of the script

--- a/util/devel/chplspell
+++ b/util/devel/chplspell
@@ -64,12 +64,10 @@ DEFAULTDIRS=(
 	     doc/rst/developer   doc/rst/language   doc/rst/meta
 	     doc/rst/platforms   doc/rst/technotes  doc/rst/tools
 	     doc/rst/users-guide doc/rst/usingchapel
-	     test/release/examples/benchmarks/shootout
-	     test/release/examples/primers
+	     test/release
 	     test/studies/shootout
 	     .github
 )
-# TODO: test/release
 
 # DEFAULTFILES are just files in $CHPL_HOME or in a directory
 # otherwise not suited for DEFAULTDIRS.  (The latter must have their

--- a/util/devel/chplspell
+++ b/util/devel/chplspell
@@ -43,7 +43,8 @@ if ! $RIVENV $SCSPELL --help > /dev/null 2> /dev/null; then
     exit 1
 fi
 
-# Normal files to look for when recursing through directories.
+# Normal files to look for when searching directories.
+# This is used to build a commandline for /usr/bin/find.
 NORMALGLOBS=("-name" "*.chpl"  "-o"
              "-name" "*.cpp"   "-o"
              "-name" "*.c"     "-o"
@@ -56,11 +57,8 @@ NORMALGLOBS=("-name" "*.chpl"  "-o"
 # These are tracked separately because scspell needs --no-c-escapes for them.
 LATEXGLOBS=("-name" "*.tex")
 
-# Directories under doc/ are listed explicitly to exclude directories
-# generated via "make docs".  The generated files are generated from
-# other files we're already spellchecking.
 DEFAULTDIRS=(
-	     compiler man modules runtime spec doc
+	     compiler doc man modules runtime spec
 	     test/release
 	     .github
 )
@@ -72,16 +70,19 @@ DEFAULTDIRS=(
 DEFAULTFILES=("COPYRIGHT" "LICENSE*" "README*" "*.md" "*.rst"
 	      "test/ANNOTATIONS.yaml" "doc/README.rst")
 
-# Filter out files with "too much" noise.  LAPACK.chpl is over 20k
-# lines of mostly noise, which qualifies.
+# Filter out files we don't want to spellcheck.
+
+# This includes generated files (generated from files that are
+# spellechecked), and files with "too much noise": LAPACK.chpl is
+# over 20k lines of unique tokens.
 #
-# Any files with these basenames will be skipped when we encounter them
-# handling entire directories.  This setting has no impact on files specified
-# specifically on the command line.
-FILTEROUT="compiler/parser/bison-chapel.cpp \
-           compiler/include/bison-chapel.h  \
-           compiler/parser/flex-chapel.cpp  \
+# Any files whose full path relative to $CHPL_HOME has one of these as
+# a prefix will be skipped.  This setting has no impact on files
+# specified specifically on the command line.
+FILTEROUT="compiler/include/bison-chapel.h  \
            compiler/include/flex-chapel.h   \
+           compiler/parser/bison-chapel.cpp \
+           compiler/parser/flex-chapel.cpp  \
            doc/rst/builtins                 \
            doc/rst/modules                  \
            doc/rst/primers                  \
@@ -200,7 +201,7 @@ if [ $JUSTARGS == 0 ]; then
 	cd $CHPL_HOME
 	# Now that we're in $CHPL_HOME, use [*] to expand the globs in
 	# $DEFAULTFILES.  This is ok since DEFAULTFILES doesn't
-	# contain any filesnames with spaces etc.  DEFAULTDIRS has no
+	# contain any filenames with spaces etc.  DEFAULTDIRS has no
 	# globs.
 	NORMALFILES=(${DEFAULTFILES[*]})
 	TARGETDIRS=("${DEFAULTDIRS[@]}")

--- a/util/devel/chplspell-dictionary
+++ b/util/devel/chplspell-dictionary
@@ -3737,16 +3737,6 @@ disubprogram
 optos
 toctree
 
-FILEID: 329ba602-b6bd-11e6-9740-843835579daa
-dedup
-ingroup
-lasthash
-lastid
-lastpath
-lcrypto
-lssl
-openssl
-
 FILEID: fcd32732-b78b-11e6-9740-843835579daa
 entrantly
 

--- a/util/devel/chplspell-dictionary
+++ b/util/devel/chplspell-dictionary
@@ -3516,46 +3516,11 @@ ztrmv
 ztrsm
 ztrsv
 
-FILEID: 86ba5826-4400-11e6-907f-843835579daa
-fanns
-
-FILEID: a70ca160-4400-11e6-907f-843835579daa
-ntide
-
-FILEID: a88fa2a8-4400-11e6-907f-843835579daa
-cagtgagccgagatcgcgccactgcactccagcctgg
-gagttcgagaccagcctggccaacatggtgaaacccc
-gcgacagagcgagactccgtctcaaaaa
-ggcaggagaatcgcttgaacccgggaggcggaggttg
-ggccgggcgcggtggctcacgcctgtaatcccagcac
-ggcgcgcgcctgtaatcccagctactcgggaggctga
-gtctctactaaaaatacaaaaattagccgggcgtggt
-tttgggaggccgaggcgggcggatcacctgaggtcag
-
 FILEID: c6909e2e-4400-11e6-907f-843835579daa
 ggta
 ggtatt
 ggtattttaatt
 ggtattttaatttatagt
-
-FILEID: dfd55fc8-4400-11e6-907f-843835579daa
-bytex
-
-FILEID: e19084d2-4400-11e6-907f-843835579daa
-bytex
-
-FILEID: e28376ba-4400-11e6-907f-843835579daa
-bytex
-
-FILEID: 07b07cbc-4401-11e6-907f-843835579daa
-cursos
-javaopt
-recursos
-ufcg
-
-FILEID: 262b888a-4401-11e6-907f-843835579daa
-piececell
-piecelist
 
 FILEID: 4bfc193a-4401-11e6-907f-843835579daa
 accct
@@ -3579,9 +3544,6 @@ tttaccct
 
 FILEID: 560979a4-4401-11e6-907f-843835579daa
 atcggctauamkrywwssyrkmvbhddhbvnn
-
-FILEID: 73d37e6c-4401-11e6-907f-843835579daa
-partred
 
 FILEID: d86303d0-4d88-11e6-907f-843835579daa
 ribution
@@ -4223,9 +4185,6 @@ ddatas
 
 FILEID: cc606fa4-fd7e-11e6-980e-10ddb1d4c3d5
 taskfn
-
-FILEID: 44484c44-fd7f-11e6-980e-10ddb1d4c3d5
-nucls
 
 FILEID: 12c3b64e-0c12-11e7-980e-10ddb1d4c3d5
 toktext

--- a/util/devel/chplspell-dictionary
+++ b/util/devel/chplspell-dictionary
@@ -3577,12 +3577,6 @@ twopt
 FILEID: b4905dc4-5f88-11e6-90f0-10ddb1d4c3d5
 synccls
 
-FILEID: 5655c140-644c-11e6-90f0-10ddb1d4c3d5
-binarytrees
-fastaredux
-regexredux
-threadring
-
 FILEID: 59041530-69c5-11e6-90f0-10ddb1d4c3d5
 asize
 diarray

--- a/util/devel/chplspell-dictionary
+++ b/util/devel/chplspell-dictionary
@@ -3693,13 +3693,6 @@ writerange
 FILEID: eb31abc0-8068-11e6-ab60-00a0cc3ee663
 taskparallel
 
-FILEID: 0c6ba076-814e-11e6-b915-843835579daa
-inds
-itermethod
-
-FILEID: 058f379e-814f-11e6-b915-843835579daa
-strt
-
 FILEID: 5094b6c0-8220-11e6-b915-843835579daa
 taskparallel
 
@@ -3709,12 +3702,6 @@ haxx
 jobtracker
 namenode
 tasktracker
-
-FILEID: e296667a-8222-11e6-b915-843835579daa
-testu
-
-FILEID: 9f42cc46-8223-11e6-b915-843835579daa
-testu
 
 FILEID: b557a264-8ab5-11e6-b915-843835579daa
 chpldocumentation

--- a/util/devel/chplspell-dictionary.fileids.json
+++ b/util/devel/chplspell-dictionary.fileids.json
@@ -622,38 +622,20 @@
     "test/release/examples/benchmarks/shootout/README"
   ],
   "b53f219e-718d-11e6-8e91-843835579daa": [
-    "test/release/examples/benchmarks/shootout/fasta.chpl",
-    "test/studies/shootout/fasta/bradc/fasta-blc-numa.chpl",
-    "test/studies/shootout/fasta/bradc/fasta-blc.chpl",
-    "test/studies/shootout/fasta/psahabu/fasta-plain.chpl",
-    "test/studies/shootout/submitted/fasta.chpl"
+    "test/release/examples/benchmarks/shootout/fasta.chpl"
   ],
   "c6909e2e-4400-11e6-907f-843835579daa": [
-    "test/release/examples/benchmarks/shootout/knucleotide.chpl",
-    "test/studies/shootout/k-nucleotide/bharshbarg/knucleotide-associative.chpl",
-    "test/studies/shootout/k-nucleotide/bharshbarg/knucleotide-chaining.chpl",
-    "test/studies/shootout/k-nucleotide/bharshbarg/knucleotide-elegant.chpl",
-    "test/studies/shootout/k-nucleotide/bharshbarg/knucleotide-strings.chpl",
-    "test/studies/shootout/k-nucleotide/bradc/knucleotide-blc.chpl",
-    "test/studies/shootout/submitted/knucleotide.chpl"
+    "test/release/examples/benchmarks/shootout/knucleotide.chpl"
   ],
   "617a3c5c-dfc3-11e6-93be-10ddb1d4c3d5": [
-    "test/release/examples/benchmarks/shootout/mandelbrot-fast.chpl",
-    "test/studies/shootout/mandelbrot/bradc/mandelbrot-blc.chpl",
-    "test/studies/shootout/submitted/mandelbrot2.chpl"
+    "test/release/examples/benchmarks/shootout/mandelbrot-fast.chpl"
   ],
   "4bfc193a-4401-11e6-907f-843835579daa": [
     "test/release/examples/benchmarks/shootout/regexdna-redux.chpl",
-    "test/release/examples/benchmarks/shootout/regexdna.chpl",
-    "test/studies/shootout/regex-dna/bharshbarg/regexdna.chpl",
-    "test/studies/shootout/submitted/regexdna.chpl",
-    "test/studies/shootout/submitted/regexredux.chpl"
+    "test/release/examples/benchmarks/shootout/regexdna.chpl"
   ],
   "560979a4-4401-11e6-907f-843835579daa": [
-    "test/release/examples/benchmarks/shootout/revcomp.chpl",
-    "test/studies/shootout/reverse-complement/bharshbarg/revcomp-begin.chpl",
-    "test/studies/shootout/reverse-complement/bradc/revcomp-blc.chpl",
-    "test/studies/shootout/submitted/revcomp.chpl"
+    "test/release/examples/benchmarks/shootout/revcomp.chpl"
   ],
   "7fcc0bd0-b85f-11e6-9740-843835579daa": [
     "test/release/examples/benchmarks/ssca2/README"
@@ -723,40 +705,7 @@
     "test/studies/dedup/dedup-local.chpl",
     "test/studies/dedup/dedup-spawn-sort.chpl"
   ],
-  "86ba5826-4400-11e6-907f-843835579daa": [
-    "test/studies/shootout/fannkuch-redux/bharshbarg/fannkuch-redux-coforall.chpl"
-  ],
-  "a88fa2a8-4400-11e6-907f-843835579daa": [
-    "test/studies/shootout/fasta/caseyb/fasta.chpl",
-    "test/studies/shootout/fasta/kbrady/fasta-lines.chpl"
-  ],
-  "a70ca160-4400-11e6-907f-843835579daa": [
-    "test/studies/shootout/fasta/kbrady/fasta-enum.chpl"
-  ],
-  "dfd55fc8-4400-11e6-907f-843835579daa": [
-    "test/studies/shootout/mandelbrot/jacobnelson/mandelbrot-fancy.chpl"
-  ],
-  "e19084d2-4400-11e6-907f-843835579daa": [
-    "test/studies/shootout/mandelbrot/lydia/mandelbrot-no-dist.chpl"
-  ],
-  "e28376ba-4400-11e6-907f-843835579daa": [
-    "test/studies/shootout/mandelbrot/lydia/mandelbrot-unzipped.chpl"
-  ],
-  "07b07cbc-4401-11e6-907f-843835579daa": [
-    "test/studies/shootout/meteor/lydchels/README"
-  ],
-  "262b888a-4401-11e6-907f-843835579daa": [
-    "test/studies/shootout/meteor/lydchels/tests/piececell_test.chpl",
-    "test/studies/shootout/meteor/lydchels/tests/piecelist_test.chpl",
-    "test/studies/shootout/meteor/lydchels/tests/run_tests.chpl"
-  ],
-  "73d37e6c-4401-11e6-907f-843835579daa": [
-    "test/studies/shootout/spectral-norm/README"
-  ],
   "5655c140-644c-11e6-90f0-10ddb1d4c3d5": [
     "test/studies/shootout/submitted/README.md"
-  ],
-  "44484c44-fd7f-11e6-980e-10ddb1d4c3d5": [
-    "test/studies/shootout/submitted/fasta2.chpl"
   ]
 }

--- a/util/devel/chplspell-dictionary.fileids.json
+++ b/util/devel/chplspell-dictionary.fileids.json
@@ -195,9 +195,6 @@
   "606babf2-1d86-11e6-a3a6-10ddb1d4c3d5": [
     "compiler/util/llvmUtil.cpp"
   ],
-  "0c6ba076-814e-11e6-b915-843835579daa": [
-    "doc/rst/builtins/internal/ChapelArray.rst"
-  ],
   "97641a68-1e44-11e6-a3a6-10ddb1d4c3d5": [
     "doc/rst/developer/bestPractices/CompilerDebugging.txt"
   ],
@@ -263,109 +260,11 @@
   "d819ca0c-1e45-11e6-a3a6-10ddb1d4c3d5": [
     "doc/rst/developer/hdfs_and_chapel/intro.tex"
   ],
-  "610c0354-1f11-11e6-a3a6-10ddb1d4c3d5": [
-    "doc/rst/modules/dists/BlockCycDist.rst",
-    "modules/dists/BlockCycDist.chpl",
-    "modules/dists/DSIUtil.chpl"
-  ],
-  "854734a2-1f0f-11e6-a3a6-10ddb1d4c3d5": [
-    "doc/rst/modules/dists/DimensionalDist2D.rst",
-    "modules/dists/DimensionalDist2D.chpl"
-  ],
-  "3efba760-1f11-11e6-a3a6-10ddb1d4c3d5": [
-    "doc/rst/modules/dists/ReplicatedDist.rst",
-    "modules/dists/OldReplicatedDist.chpl",
-    "modules/dists/ReplicatedDist.chpl"
-  ],
-  "347ba0d8-1f11-11e6-a3a6-10ddb1d4c3d5": [
-    "doc/rst/modules/dists/dims/ReplicatedDim.rst",
-    "modules/dists/dims/ReplicatedDim.chpl"
-  ],
-  "71a525f2-43ff-11e6-907f-843835579daa": [
-    "doc/rst/modules/packages/BLAS.rst",
-    "doc/rst/modules/packages/BLAS/C_BLAS.rst",
-    "modules/packages/BLAS.chpl"
-  ],
-  "2127a88e-1f1a-11e6-a3a6-10ddb1d4c3d5": [
-    "doc/rst/modules/packages/Curl.rst",
-    "modules/packages/Curl.chpl"
-  ],
-  "f8a68c5e-1f19-11e6-a3a6-10ddb1d4c3d5": [
-    "doc/rst/modules/packages/FFTW.rst",
-    "modules/packages/FFTW.chpl"
-  ],
-  "cc606fa4-fd7e-11e6-980e-10ddb1d4c3d5": [
-    "doc/rst/modules/packages/Futures.rst",
-    "modules/packages/Futures.chpl"
-  ],
-  "6cd27e0c-7b82-11e6-ab60-00a0cc3ee663": [
-    "doc/rst/modules/packages/HDFS.rst",
-    "modules/packages/HDFS.chpl"
-  ],
-  "40d00fe6-1a82-11e7-980e-10ddb1d4c3d5": [
-    "doc/rst/modules/packages/LinearAlgebra.rst",
-    "modules/packages/LinearAlgebra.chpl"
-  ],
-  "69fe0f48-1f2a-11e6-a3a6-10ddb1d4c3d5": [
-    "doc/rst/modules/packages/MPI.rst",
-    "doc/rst/modules/packages/MPI/C_Env.rst",
-    "doc/rst/modules/packages/MPI/C_MPI.rst",
-    "modules/packages/MPI.chpl"
-  ],
-  "058f379e-814f-11e6-b915-843835579daa": [
-    "doc/rst/modules/packages/RecordParser.rst"
-  ],
-  "24a5f32a-792f-11e6-807a-843835579daa": [
-    "doc/rst/modules/packages/ZMQ.rst",
-    "modules/packages/ZMQ.chpl"
-  ],
-  "c0254978-0c13-11e7-980e-10ddb1d4c3d5": [
-    "doc/rst/modules/standard/DateTime.rst",
-    "modules/standard/DateTime.chpl"
-  ],
-  "fbc85e3e-1f2e-11e6-a3a6-10ddb1d4c3d5": [
-    "doc/rst/modules/standard/FileSystem.rst",
-    "modules/standard/FileSystem.chpl"
-  ],
-  "55301aa8-1f2e-11e6-a3a6-10ddb1d4c3d5": [
-    "doc/rst/modules/standard/IO.rst",
-    "modules/standard/IO.chpl"
-  ],
-  "e296667a-8222-11e6-b915-843835579daa": [
-    "doc/rst/modules/standard/Random/NPBRandom.rst"
-  ],
-  "9f42cc46-8223-11e6-b915-843835579daa": [
-    "doc/rst/modules/standard/Random/PCGRandom.rst"
-  ],
-  "f8d11ee0-1f2f-11e6-a3a6-10ddb1d4c3d5": [
-    "doc/rst/modules/standard/Regexp.rst",
-    "modules/standard/Regexp.chpl"
-  ],
-  "d41572f2-1f2c-11e6-a3a6-10ddb1d4c3d5": [
-    "doc/rst/modules/standard/SysBasic.rst",
-    "modules/standard/SysBasic.chpl"
-  ],
   "59b9a50c-1a83-11e7-980e-10ddb1d4c3d5": [
     "doc/rst/platforms/arm.rst"
   ],
   "3916e364-dfc3-11e6-93be-10ddb1d4c3d5": [
     "doc/rst/platforms/aws.rst"
-  ],
-  "8c00fe52-31db-11e6-a3a6-10ddb1d4c3d5": [
-    "doc/rst/primers/LAPACKlib.rst",
-    "test/release/examples/primers/LAPACKlib.chpl"
-  ],
-  "57dcb2ce-31db-11e6-a3a6-10ddb1d4c3d5": [
-    "doc/rst/primers/distributions.rst",
-    "test/release/examples/primers/distributions.chpl"
-  ],
-  "5d456562-31db-11e6-a3a6-10ddb1d4c3d5": [
-    "doc/rst/primers/domains.rst",
-    "test/release/examples/primers/domains.chpl"
-  ],
-  "9b2d18d4-31db-11e6-a3a6-10ddb1d4c3d5": [
-    "doc/rst/primers/learnChapelInYMinutes.rst",
-    "test/release/examples/primers/learnChapelInYMinutes.chpl"
   ],
   "a78ba0d8-8220-11e6-b915-843835579daa": [
     "doc/rst/technotes/auxIO.rst"
@@ -406,8 +305,19 @@
   "28bf43b2-2add-11e6-a3a6-10ddb1d4c3d5": [
     "man/confchpldoc.rst"
   ],
+  "610c0354-1f11-11e6-a3a6-10ddb1d4c3d5": [
+    "modules/dists/BlockCycDist.chpl",
+    "modules/dists/DSIUtil.chpl"
+  ],
   "f705d2b6-1f0e-11e6-a3a6-10ddb1d4c3d5": [
     "modules/dists/CyclicDist.chpl"
+  ],
+  "854734a2-1f0f-11e6-a3a6-10ddb1d4c3d5": [
+    "modules/dists/DimensionalDist2D.chpl"
+  ],
+  "3efba760-1f11-11e6-a3a6-10ddb1d4c3d5": [
+    "modules/dists/OldReplicatedDist.chpl",
+    "modules/dists/ReplicatedDist.chpl"
   ],
   "6c8e8208-1f0f-11e6-a3a6-10ddb1d4c3d5": [
     "modules/dists/SparseBlockDist.chpl"
@@ -420,6 +330,9 @@
   ],
   "37795eb0-1f11-11e6-a3a6-10ddb1d4c3d5": [
     "modules/dists/dims/BlockDim.chpl"
+  ],
+  "347ba0d8-1f11-11e6-a3a6-10ddb1d4c3d5": [
+    "modules/dists/dims/ReplicatedDim.chpl"
   ],
   "0e29860c-1a83-11e7-980e-10ddb1d4c3d5": [
     "modules/internal/ArrayViewRankChange.chpl"
@@ -451,8 +364,29 @@
   "9c75ae66-1f18-11e6-a3a6-10ddb1d4c3d5": [
     "modules/layouts/LayoutCSR.chpl"
   ],
+  "71a525f2-43ff-11e6-907f-843835579daa": [
+    "modules/packages/BLAS.chpl"
+  ],
+  "2127a88e-1f1a-11e6-a3a6-10ddb1d4c3d5": [
+    "modules/packages/Curl.chpl"
+  ],
+  "f8a68c5e-1f19-11e6-a3a6-10ddb1d4c3d5": [
+    "modules/packages/FFTW.chpl"
+  ],
+  "cc606fa4-fd7e-11e6-980e-10ddb1d4c3d5": [
+    "modules/packages/Futures.chpl"
+  ],
+  "6cd27e0c-7b82-11e6-ab60-00a0cc3ee663": [
+    "modules/packages/HDFS.chpl"
+  ],
+  "40d00fe6-1a82-11e7-980e-10ddb1d4c3d5": [
+    "modules/packages/LinearAlgebra.chpl"
+  ],
   "f8a06e7e-1f18-11e6-a3a6-10ddb1d4c3d5": [
     "modules/packages/LinearAlgebraJama.chpl"
+  ],
+  "69fe0f48-1f2a-11e6-a3a6-10ddb1d4c3d5": [
+    "modules/packages/MPI.chpl"
   ],
   "3a59da00-3376-11e6-a3a6-10ddb1d4c3d5": [
     "modules/packages/MatrixMarket.chpl"
@@ -462,14 +396,32 @@
     "runtime/include/chpl-visual-debug.h",
     "runtime/src/chpl-visual-debug.c"
   ],
+  "24a5f32a-792f-11e6-807a-843835579daa": [
+    "modules/packages/ZMQ.chpl"
+  ],
   "ebcca246-1f2f-11e6-a3a6-10ddb1d4c3d5": [
     "modules/standard/Buffers.chpl"
+  ],
+  "c0254978-0c13-11e7-980e-10ddb1d4c3d5": [
+    "modules/standard/DateTime.chpl"
+  ],
+  "fbc85e3e-1f2e-11e6-a3a6-10ddb1d4c3d5": [
+    "modules/standard/FileSystem.chpl"
+  ],
+  "55301aa8-1f2e-11e6-a3a6-10ddb1d4c3d5": [
+    "modules/standard/IO.chpl"
   ],
   "7de3ce6c-3f64-11e6-907f-843835579daa": [
     "modules/standard/Math.chpl"
   ],
   "6ba10a44-1f2f-11e6-a3a6-10ddb1d4c3d5": [
     "modules/standard/Random.chpl"
+  ],
+  "f8d11ee0-1f2f-11e6-a3a6-10ddb1d4c3d5": [
+    "modules/standard/Regexp.chpl"
+  ],
+  "d41572f2-1f2c-11e6-a3a6-10ddb1d4c3d5": [
+    "modules/standard/SysBasic.chpl"
   ],
   "e9347814-1f30-11e6-a3a6-10ddb1d4c3d5": [
     "modules/standard/Types.chpl"
@@ -730,8 +682,20 @@
   "d86303d0-4d88-11e6-907f-843835579daa": [
     "test/release/examples/hello4-datapar-dist.chpl"
   ],
+  "8c00fe52-31db-11e6-a3a6-10ddb1d4c3d5": [
+    "test/release/examples/primers/LAPACKlib.chpl"
+  ],
   "03dbf2b0-31dc-11e6-a3a6-10ddb1d4c3d5": [
     "test/release/examples/primers/README"
+  ],
+  "57dcb2ce-31db-11e6-a3a6-10ddb1d4c3d5": [
+    "test/release/examples/primers/distributions.chpl"
+  ],
+  "5d456562-31db-11e6-a3a6-10ddb1d4c3d5": [
+    "test/release/examples/primers/domains.chpl"
+  ],
+  "9b2d18d4-31db-11e6-a3a6-10ddb1d4c3d5": [
+    "test/release/examples/primers/learnChapelInYMinutes.chpl"
   ],
   "e8974bb8-8068-11e6-ab60-00a0cc3ee663": [
     "test/release/examples/primers/ranges.chpl"

--- a/util/devel/chplspell-dictionary.fileids.json
+++ b/util/devel/chplspell-dictionary.fileids.json
@@ -595,13 +595,7 @@
   ],
   "04d69f54-b85e-11e6-9740-843835579daa": [
     "test/release/examples/benchmarks/lulesh/lulesh.chpl",
-    "test/release/examples/benchmarks/lulesh/luleshInit.chpl",
-    "test/studies/lulesh/bradc/lulesh-dense.chpl",
-    "test/studies/lulesh/bradc/tests/lulesh-eof.chpl",
-    "test/studies/lulesh/bradc/tests/lulesh-eof2.chpl",
-    "test/studies/lulesh/bradc/xyztuple/lulesh-dense-3tuple.chpl",
-    "test/studies/lulesh/bradc/xyztuple/luleshInit3.chpl",
-    "test/studies/lulesh/intelVectBug/lulesh.chpl"
+    "test/release/examples/benchmarks/lulesh/luleshInit.chpl"
   ],
   "d522708e-b85e-11e6-9740-843835579daa": [
     "test/release/examples/benchmarks/miniMD/README"
@@ -696,13 +690,5 @@
   ],
   "a717e780-d45d-11e6-b38c-acbc32c4f96b": [
     "test/release/examples/users-guide/base/typeAliases.chpl"
-  ],
-  "329ba602-b6bd-11e6-9740-843835579daa": [
-    "test/studies/dedup/dedup-distributed-ints.chpl",
-    "test/studies/dedup/dedup-distributed-strings.chpl",
-    "test/studies/dedup/dedup-extern.chpl",
-    "test/studies/dedup/dedup-externblock.chpl",
-    "test/studies/dedup/dedup-local.chpl",
-    "test/studies/dedup/dedup-spawn-sort.chpl"
   ]
 }

--- a/util/devel/chplspell-dictionary.fileids.json
+++ b/util/devel/chplspell-dictionary.fileids.json
@@ -704,8 +704,5 @@
     "test/studies/dedup/dedup-externblock.chpl",
     "test/studies/dedup/dedup-local.chpl",
     "test/studies/dedup/dedup-spawn-sort.chpl"
-  ],
-  "5655c140-644c-11e6-90f0-10ddb1d4c3d5": [
-    "test/studies/shootout/submitted/README.md"
   ]
 }


### PR DESCRIPTION
chplspell: Exclude generated files from chplspell

Some make rules generate new files from existing (source) files.
Since chplspell already checks the source files, and any typos need to
be fixed in the source files, maintaining chplspell dictionary entries
for the generated files is a waste of time and effort.

Don't include files generated by "make docs" and "make man".  Remove
their dictionary entries too.

Also, check test/release by default.
