### PR TITLE
Fix minor CoMD-AoS bugs

### DIFF
--- a/test/studies/comd/elegant/arrayOfStructs/CoMD.ml-execopts
+++ b/test/studies/comd/elegant/arrayOfStructs/CoMD.ml-execopts
@@ -1,1 +1,1 @@
---nxyz 100 --xproc 2 --yproc 2 --zproc 2 --doeam=0
+--nxyz 100 --xproc 2 --yproc 2 --zproc 2 --doeam=false

--- a/test/studies/comd/elegant/arrayOfStructs/util/Configs.chpl
+++ b/test/studies/comd/elegant/arrayOfStructs/util/Configs.chpl
@@ -62,8 +62,8 @@ if xproc == 1 && yproc == 1 && zproc == 1 {
     halt("Number of locales must match xproc * yproc * zproc: ",
          xproc, " * ", yproc, " * ", zproc, " != ", numLocales);
 
-  const ReshapedDom     = {1..xproc, 1..yproc, 1..zproc};
-  const ReshapedLocales = reshape(Locales, ReshapedDom);
+  ReshapedDom     = {1..xproc, 1..yproc, 1..zproc};
+  ReshapedLocales = reshape(Locales, ReshapedDom);
 }
 
 


### PR DESCRIPTION
1) '0' is not a valid value for a bool
2) Accidentally set a local ``ReshapedLocales`` instead of the global, leading to
  errors in the distribution.