### PR TITLE
Convert requiresImplicitDestroy() to return a bool

### DIFF
--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -80,8 +80,10 @@ bool       isInstantiation(Type* sub, Type* super);
 // explain call stuff
 bool explainCallMatch(CallExpr* call);
 
-FnSymbol* requiresImplicitDestroy(CallExpr* call);
+bool requiresImplicitDestroy(CallExpr* call);
+
 bool isLeaderIterator(FnSymbol* fn);
+
 bool isStandaloneIterator(FnSymbol* fn);
 
 bool isDispatchParent(Type* t, Type* pt);

--- a/compiler/resolution/callDestructors.cpp
+++ b/compiler/resolution/callDestructors.cpp
@@ -984,19 +984,23 @@ changeRetToArgAndClone(CallExpr* move,
 }
 
 
-static void
-returnRecordsByReferenceArguments() {
+static void returnRecordsByReferenceArguments() {
   forv_Vec(CallExpr, call, gCallExprs) {
-    if (call->parentSymbol) {
-      if (FnSymbol* fn = requiresImplicitDestroy(call)) {
-        if (fn->hasFlag(FLAG_EXTERN))
-          continue;
-        CallExpr* move = toCallExpr(call->parentExpr);
-        INT_ASSERT(move->isPrimitive(PRIM_MOVE) ||
-                   move->isPrimitive(PRIM_ASSIGN));
-        SymExpr* lhs = toSymExpr(move->get(1));
-        INT_ASSERT(!lhs->symbol()->hasFlag(FLAG_TYPE_VARIABLE));
-        changeRetToArgAndClone(move, lhs->symbol(), call, fn);
+    if (call->parentSymbol != NULL) {
+      if (requiresImplicitDestroy(call) == true) {
+        FnSymbol* fn = call->resolvedFunction();
+
+        if (fn->hasFlag(FLAG_EXTERN) == false) {
+          CallExpr* move = toCallExpr(call->parentExpr);
+          SymExpr*  lhs  = toSymExpr(move->get(1));
+
+          INT_ASSERT(move->isPrimitive(PRIM_MOVE)   == true||
+                     move->isPrimitive(PRIM_ASSIGN) == true);
+
+          INT_ASSERT(lhs->symbol()->hasFlag(FLAG_TYPE_VARIABLE) == false);
+
+          changeRetToArgAndClone(move, lhs->symbol(), call, fn);
+        }
       }
     }
   }

--- a/compiler/resolution/postFold.cpp
+++ b/compiler/resolution/postFold.cpp
@@ -263,7 +263,7 @@ Expr* postFold(Expr* expr) {
           if (lhs->symbol()->hasFlag(FLAG_EXPR_TEMP) &&
               !lhs->symbol()->hasFlag(FLAG_TYPE_VARIABLE)) {
             if (CallExpr* rhsCall = toCallExpr(call->get(2))) {
-              if (requiresImplicitDestroy(rhsCall)) {
+              if (requiresImplicitDestroy(rhsCall) == true) {
                 // this still seems to be necessary even if
                 // isUserDefinedRecord(lhs->symbol()->type) == true
                 // see call-expr-tmp.chpl for example


### PR DESCRIPTION
Trivial: Revise signature of requiresImplicitDestroy()


Before this PR there was a function FnSymbol* requiresImplicitDestroy(CallExpr* call).
This function returned NULL if 'call' does not require an implicit destroy and pointer
to the resolved function if it did i.e. the result of call->resolvedFunction().

This function is used twice; in one instance the caller uses it as a predicate, and in the
other instance the caller is also interested in the resolved function.

After this PR this function returns a bool and the second call site is updated to obtain
the resolved function on true.

Completed standard compilation/testing protocol
