### PR TITLE
fix PRIM_ARRAY_SET_FIRST on a ref with --no-local

### DIFF
--- a/compiler/passes/insertWideReferences.cpp
+++ b/compiler/passes/insertWideReferences.cpp
@@ -411,7 +411,7 @@ static QualifiedType getNarrowType(BaseAST* bs) {
 }
 
 static Type* getElementType(BaseAST* bs) {
-  Type* arrType = getNarrowType(bs).type();
+  Type* arrType = getNarrowType(bs->getValType()).type();
   INT_ASSERT(arrType->symbol->hasFlag(FLAG_DATA_CLASS));
 
   return getDataClassType(arrType->symbol)->type;


### PR DESCRIPTION
The following used not to work with --no-local:

    proc init_elts(ref x: _ddata(int)) {
      var i:int, elm:int;
      __primitive("array_set_first", x, i, elm);
    }

This simple change fixes that.

Testing: linux64 --verify; gasnet on multilocale tests.
