### PR TITLE
Have test use an explicit binary name

### DIFF
--- a/test/compflags/diten/savec.chpl
+++ b/test/compflags/diten/savec.chpl
@@ -11,7 +11,7 @@ if ret != 0 then
 
 ret = system(("rm a.out").c_str());
 if ret != 0 then
-  halt("Error removing savec directory");
+  halt("Error removing a.out directory");
 
 ret = system(("make -f " + outdir + "/Makefile > /dev/null 2>&1").c_str());
 if ret != 0 then
@@ -19,7 +19,7 @@ if ret != 0 then
 
 ret = system(("rm a.out").c_str());
 if ret != 0 then
-  halt("Error removing savec directory");
+  halt("Error removing a.out directory");
 
 ret = system(("rm -r " + outdir).c_str());
 if ret != 0 then

--- a/test/compflags/diten/savec.chpl
+++ b/test/compflags/diten/savec.chpl
@@ -5,13 +5,21 @@ var ret: int;
 
 extern proc system(s: c_string): int(32);
 
-ret = system((CHPL_HOME+"/bin/"+CHPL_HOST_PLATFORM+"/"+"chpl --savec " + outdir + " " + filename).c_str());
+ret = system((CHPL_HOME+"/bin/"+CHPL_HOST_PLATFORM+"/"+"chpl -o a.out --savec " + outdir + " " + filename).c_str());
 if ret != 0 then
   halt("Error compiling Chapel code");
+
+ret = system(("rm a.out").c_str());
+if ret != 0 then
+  halt("Error removing savec directory");
 
 ret = system(("make -f " + outdir + "/Makefile > /dev/null 2>&1").c_str());
 if ret != 0 then
   halt("Error compiling C code");
+
+ret = system(("rm a.out").c_str());
+if ret != 0 then
+  halt("Error removing savec directory");
 
 ret = system(("rm -r " + outdir).c_str());
 if ret != 0 then

--- a/test/compflags/diten/savec.chpl
+++ b/test/compflags/diten/savec.chpl
@@ -9,17 +9,17 @@ ret = system((CHPL_HOME+"/bin/"+CHPL_HOST_PLATFORM+"/"+"chpl -o a.out --savec " 
 if ret != 0 then
   halt("Error compiling Chapel code");
 
-ret = system(("rm a.out").c_str());
+ret = system(("rm a.out*").c_str());
 if ret != 0 then
-  halt("Error removing a.out directory");
+  halt("Error removing a.out executable(s)");
 
 ret = system(("make -f " + outdir + "/Makefile > /dev/null 2>&1").c_str());
 if ret != 0 then
   halt("Error compiling C code");
 
-ret = system(("rm a.out").c_str());
+ret = system(("rm a.out*").c_str());
 if ret != 0 then
-  halt("Error removing a.out directory");
+  halt("Error removing a.out executable(s)");
 
 ret = system(("rm -r " + outdir).c_str());
 if ret != 0 then


### PR DESCRIPTION
This test core dumped in one configuration last night, and my best
guess as to why is that the test tries to overwrite the executables
that are being used to run it while it runs which could cause problems
(maybe?).  Here, I'm working around that by having the test specify
an explicit executable name (a.out) and removing that executable between
compiles (along with a.out_real, via a.out*, if it exists).