### PR TITLE
Fix two "typos"

### DIFF
--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -1383,7 +1383,7 @@ static void buildDefaultInitField(AggregateType*         at,
 
 
         //
-        // Type infererence required if this is a param or variable field
+        // Type inference is required if this is a param or variable field
         //
         } else if (defPoint->exprType == NULL && defPoint->init != NULL) {
           VarSymbol* tmp      = newTemp();

--- a/compiler/resolution/postFold.cpp
+++ b/compiler/resolution/postFold.cpp
@@ -95,8 +95,6 @@ static void insertValueTemp(Expr* insertPoint, Expr* actual);
     }                                                                   \
   }
 
-#include "AstDumpToNode.h"
-
 Expr* postFold(Expr* expr) {
   Expr* retval = expr;
 


### PR DESCRIPTION
Trivial: Fix two "typos" from two different recent PRs.

Fix a spelling error in a comment and remove an unexpected #include 
that I noticed in a file that was recently updated.

These changes are so tiny that I am merging with abbreviated testing.
