### PR TITLE
Printchplenv distinguish config env

### DIFF
--- a/util/chplenv/overrides.py
+++ b/util/chplenv/overrides.py
@@ -197,11 +197,12 @@ def get(var, default=None):
 
 @memoize
 def get_environ(var, default=None):
-    """ Check if variable has a default defined somewhere and return value """
+    """ Check if variable has a default defined in the environment and return value """
     return os.environ.get(var) or default
 
+@memoize
 def get_chplconfig(var, default=None):
-    """ Check if variable has a default defined somewhere and return value """
+    """ Check if variable has a default defined in a chplconfig file and return value """
     return chplconfig.get(var) or default
 
 

--- a/util/chplenv/overrides.py
+++ b/util/chplenv/overrides.py
@@ -195,6 +195,15 @@ def get(var, default=None):
     """ Check if variable has a default defined somewhere and return value """
     return os.environ.get(var) or chplconfig.get(var) or default
 
+@memoize
+def get_environ(var, default=None):
+    """ Check if variable has a default defined somewhere and return value """
+    return os.environ.get(var) or default
+
+def get_chplconfig(var, default=None):
+    """ Check if variable has a default defined somewhere and return value """
+    return chplconfig.get(var) or default
+
 
 def allvars():
     """ Generate overrides currently set via environment/chplconfig """

--- a/util/printchplenv
+++ b/util/printchplenv
@@ -202,9 +202,13 @@ def print_mode(mode='list', anonymize=False):
 
 def print_var(env_var, value, mode, short_name='', filters=None):
     if mode == 'list' or mode == 'debug':
-        user_set = overrides.get(env_var.strip(), '')
+        user_set = overrides.get_environ(env_var.strip(), '')
         if user_set:
           user_set = ' *'
+        else:
+          user_set = overrides.get_chplconfig(env_var.strip(), '')
+          if user_set:
+            user_set = ' <'
         stdout.write("{1}: {2}{0}\n".format(user_set, env_var, value))
     elif mode == 'make':
         make_env_var = env_var.replace("CHPL_", "CHPL_MAKE_", 1).lstrip()

--- a/util/printchplenv
+++ b/util/printchplenv
@@ -208,7 +208,7 @@ def print_var(env_var, value, mode, short_name='', filters=None):
         else:
           user_set = overrides.get_chplconfig(env_var.strip(), '')
           if user_set:
-            user_set = ' <'
+            user_set = ' @'
         stdout.write("{1}: {2}{0}\n".format(user_set, env_var, value))
     elif mode == 'make':
         make_env_var = env_var.replace("CHPL_", "CHPL_MAKE_", 1).lstrip()


### PR DESCRIPTION
I got into some confusion the other day due to a lingering chplconfig file that I wasn't aware of, made worse because printchplenv doesn't distinguish between variables set in the environment vs. a chplconfig file (which led to my questions in #6972).  This is my Python-ignorant attempt to have the `[print]chplenv` scripts be able to distinguish between those two cases.