### PR TITLE
Re-enable -Wunused for GASNet-related files

### DIFF
--- a/make/compiler/Makefile.clang
+++ b/make/compiler/Makefile.clang
@@ -158,7 +158,6 @@ RUNTIME_CXXFLAGS += $(WARN_CXXFLAGS)
 #
 CHPL_GASNET_MORE_CFLAGS = -Wno-strict-prototypes -Wno-missing-prototypes
 ifndef CHPL_COMM_DEBUG
-CHPL_GASNET_MORE_CFLAGS += -Wno-unused
 endif
 endif
 ifdef CHPL_COMM_DEBUG

--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -230,7 +230,6 @@ RUNTIME_CXXFLAGS += $(WARN_CXXFLAGS)
 #
 CHPL_GASNET_MORE_CFLAGS = -Wno-strict-prototypes -Wno-missing-prototypes
 ifndef CHPL_COMM_DEBUG
-CHPL_GASNET_MORE_CFLAGS += -Wno-unused
 endif
 endif
 ifdef CHPL_COMM_DEBUG

--- a/runtime/src/comm/gasnet/comm-gasnet.c
+++ b/runtime/src/comm/gasnet/comm-gasnet.c
@@ -292,7 +292,6 @@ size_t setup_large_fork_task(large_fork_task_t* dst, large_fork_t* f, size_t nby
   chpl_comm_bundleData_t comm  = { .caller = f->hdr.caller,
                                    .ack    = f->hdr.ack };
   chpl_comm_on_bundle_t bundle = { .comm =  comm };
-  chpl_comm_on_bundle_t *bptr  = &dst->bundle;
 
   // Copy task-local data to the new task
   bundle.task_bundle.state = f->hdr.state;
@@ -753,7 +752,6 @@ static void set_max_segsize_env_var(size_t size) {
 }
 
 static void set_max_segsize() {
-  FILE* file = NULL;
   size_t size;
 
   if ((size = chpl_comm_getenvMaxHeapSize()) != 0) {
@@ -1231,7 +1229,6 @@ void  chpl_comm_get(void* addr, c_nodeid_t node, void* raddr,
       // the registered memory segment.
       int local_in_segment;
       void* local_buf = NULL;
-      size_t buf_sz = 0;
       size_t max_chunk = gasnet_AMMaxLongReply();
       size_t start;
 
@@ -1555,8 +1552,6 @@ void  execute_on_common(c_nodeid_t node, c_sublocid_t subloc,
 void  chpl_comm_execute_on(c_nodeid_t node, c_sublocid_t subloc,
                      chpl_fn_int_t fid,
                      chpl_comm_on_bundle_t *arg, size_t arg_size) {
-  done_t  done;
-
   if (chpl_nodeID == node) {
     assert(0);
     chpl_ftable_call(fid, arg);
@@ -1614,8 +1609,6 @@ void  chpl_comm_execute_on_nb(c_nodeid_t node, c_sublocid_t subloc,
 void  chpl_comm_execute_on_fast(c_nodeid_t node, c_sublocid_t subloc,
                           chpl_fn_int_t fid,
                           chpl_comm_on_bundle_t *arg, size_t arg_size) {
-  done_t  done;
-
   if (chpl_nodeID == node) {
     assert(0);
     chpl_ftable_call(fid, arg);


### PR DESCRIPTION
As of GASNet 1.28.2, we can compile GASNet's headers with -Wunused
(see https://upc-bugs.lbl.gov/bugzilla/show_bug.cgi?id=2538),
so no longer need to throw -Wno-unused when compiling our runtime
files that #include them.  This turned up a few unused variables
which I removed.