### PR TITLE
Add a test showing ambiguous param overloads cause a segfault

### DIFF
--- a/test/functions/resolution/ambig-param-overloads.bad
+++ b/test/functions/resolution/ambig-param-overloads.bad
@@ -1,0 +1,8 @@
+ambig-param-overloads.chpl:13: internal error: MIS0558 chpl Version 1.16.0 pre-release (2624f85)
+Note: This source location is a guess.
+
+Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
+please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
+the filename + line number above may be useful in working around the issue.
+

--- a/test/functions/resolution/ambig-param-overloads.chpl
+++ b/test/functions/resolution/ambig-param-overloads.chpl
@@ -1,0 +1,14 @@
+record R {
+  param flag;
+  var x: int = 42;
+}
+
+proc R.getX where flag return x;
+proc R.getX param where !flag return 0;
+proc R.getX param where !flag return 0;
+
+var myR1 = new R(false);
+var myR2 = new R(true);
+
+writeln(myR1.getX);
+writeln(myR2.getX);

--- a/test/functions/resolution/ambig-param-overloads.future
+++ b/test/functions/resolution/ambig-param-overloads.future
@@ -1,0 +1,1 @@
+bug: seg fault on ambiguous overloaded param function

--- a/test/functions/resolution/ambig-param-overloads.good
+++ b/test/functions/resolution/ambig-param-overloads.good
@@ -1,0 +1,3 @@
+ambig-param-overloads.chpl:13: error: ambiguous call 'R(false).getX'
+ambig-param-overloads.chpl:7: note: candidates are: getX _mt: _MT, this: R
+ambig-param-overloads.chpl:8: note:                 getX _mt: _MT, this: R


### PR DESCRIPTION
This test demonstrates that if we have ambiguous param overloads of a
method, we get a segfault rather than an ambiguous call error.
Removing the params causes a more normal response.  I haven't tried
other variations like a non-generic record or a non-method call (or a
parentheses-ful call).