### PR TITLE
Fix perf graph generation when --perflabel "label" is used

### DIFF
--- a/util/start_test
+++ b/util/start_test
@@ -519,7 +519,11 @@ def compiler_performance():
 
 
 def generate_graph_files_graphs():
-    exec_graph_list = os.path.join(test_dir, "GRAPHFILES")
+    graphfiles_prefix = ''
+    if args.perflabel != "perf":
+        graphfiles_prefix = args.perflabel.upper()
+
+    exec_graph_list = os.path.join(test_dir, "{0}GRAPHFILES".format(graphfiles_prefix))
 
     logger.write("[Executing genGraphs for {0} in {1}"
             .format(exec_graph_list, perf_html_dir))


### PR DESCRIPTION
start_test always used $CHPL_HOME/test/GRAPHFILES as the graphfile list even if
a perflabel was being used. We never noticed this before because we manually
call gengraphs for the `--perflabel ml-` graphs.

@mppf stumbled on this while trying to add a "cc-" label in #6604