### PR TITLE
Skip this test under --llvm

### DIFF
--- a/test/parallel/taskCompare/elliot/empty-omp-taskspawn.skipif
+++ b/test/parallel/taskCompare/elliot/empty-omp-taskspawn.skipif
@@ -1,4 +1,8 @@
 # cce doesn't support running omp constructs from a pthread
 CHPL_TARGET_COMPILER==cray-prgenv-cray
 # older versions of clang don't support openmp
+# newer versions of clang require libomp-dev which might not be installed
+# additionally, libomp might not be available for static linking
 CHPL_TARGET_COMPILER==clang
+# same issues as CHPL_TARGET_COMPILER=clang apply to --llvm
+COMPOPTS <= --llvm


### PR DESCRIPTION
For various reasons including a missing dependency, compiling OpenMP code from the Chapel compiler with --llvm doesn't work after the LLVM 4 upgrade. Skip the test that was doing that since it's not essential to test it in this configuration.

Discussed with @ronawho .