### PR TITLE
Fix memory annotations that used # within description

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -692,7 +692,7 @@ memleaks:
   07/14/17:
     - Have reindex domains/distributions preserve locality (#5757)
   07/25/17:
-    - fix leaks introduced by reindex views in #5757 (#6776)
+    - fix leaks introduced by reindex views in PR 5757 (#6776)
 
 memleaksfull:
   07/08/14:
@@ -729,7 +729,7 @@ memleaksfull:
   07/14/17:
     - Have reindex domains/distributions preserve locality (#5757)
   07/25/17:
-    - fix leaks introduced by reindex views in #5757 (#6776)
+    - fix leaks introduced by reindex views in PR 5757 (#6776)
 
 meteor:
   12/18/13:


### PR DESCRIPTION
Something about the use of a # in my description of some leak changes
seems to have truncated the description in the online graphs, so
I've reworded to avoid the hash in hopes that that helps.