### PR TITLE
Enable gmp under pgi

### DIFF
--- a/third-party/gmp/Makefile
+++ b/third-party/gmp/Makefile
@@ -17,20 +17,9 @@ CHPL_GMP_CFG_OPTIONS += --host=$(CHPL_MAKE_TARGET_PLATFORM)-unknown-linux-gnu
 GMP_CROSS_COMPILED=yes
 endif
 
-#
-# We have problems (involving alloca()) with PGI-built gmp.  These are
-# used below and record whether we're building on Cray X* with PGI and,
-# if so, whether it's a speculative build.
-#
-GMP_CRAY_X_PGI=no
-GMP_SPECULATIVE_CRAY_X_PGI=no
-ifneq (, $(filter cray-x%,$(CHPL_MAKE_TARGET_PLATFORM)))
-ifneq (, $(filter %pgi,$(CHPL_MAKE_TARGET_COMPILER)))
-GMP_CRAY_X_PGI=yes
-ifeq (yes, $(GMP_SPECULATIVE))
-GMP_SPECULATIVE_CRAY_X_PGI=yes
-endif
-endif
+# Disable use of alloca for pgi, it seems to cause stack overflows.
+ifneq (, $(findstring pgi,$(CHPL_MAKE_TARGET_COMPILER)))
+CHPL_GMP_CFG_OPTIONS += --disable-alloca
 endif
 
 #
@@ -73,19 +62,12 @@ $(GMP_BUILD_SUBDIR):
 
 
 $(GMP_H_FILE): $(GMP_BUILD_SUBDIR)
-ifeq (yes, $(GMP_SPECULATIVE_CRAY_X_PGI))
-	$(info Speculative build of gmp squashed due to PGI target compiler on Cray X*.)
-else
-ifeq (yes, $(GMP_CRAY_X_PGI))
-	$(warning Forced gmp build with PGI on Cray X* fails some Chapel tests.)
-endif
 	cd $(GMP_BUILD_DIR) && $(GMP_SUBDIR)/configure CC='$(CC)' CFLAGS='$(CFLAGS) $(CHPL_GMP_CFLAGS)' CXX='$(CXX)' CXXFLAGS='$(CXXFLAGS) $(CHPL_GMP_CXXFLAGS)' $(CHPL_GMP_ABI_ARG) --prefix=$(GMP_INSTALL_DIR) $(CHPL_GMP_CFG_OPTIONS)
 	cd $(GMP_BUILD_DIR) && $(MAKE)
 ifeq ($(GMP_CROSS_COMPILED),no)
 	cd $(GMP_BUILD_DIR) && $(MAKE) check
 endif
 	cd $(GMP_BUILD_DIR) && $(MAKE) install
-endif
 
 gmp: $(GMP_H_FILE)
 


### PR DESCRIPTION
PR #1843 squashed speculative builds of gmp under pgi because of problems
involving alloca (basically a stack overflow.)

This just disables alloca under pgi to avoid the issue. As always, I don't
actually care about pgi, but this makes the makefile easier to read.