### PR TITLE
Enlarge registered memory tables and report if/when they overflow.

### DIFF
--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -378,7 +378,7 @@ static size_t hugepage_size;
 // uGNI memory domain handles for each memory region of interest to us.
 // mem_region_map contains a copy of every node's mem_regions.
 //
-#define MAX_MEM_REGIONS 100
+#define MAX_MEM_REGIONS 1000
 
 typedef struct {
   uint64_t         addr;
@@ -2734,6 +2734,13 @@ void* chpl_comm_impl_regMemAlloc(size_t size)
                size, mr_i, mr->addr, (int) mem_regions.mreg_cnt);
     }
   } else {
+    static int spoke = 0;
+
+    if (!spoke) {
+      chpl_warning("out of registered memory region table entries!", 0, 0);
+      spoke = 1;
+    }
+
     DBG_P_LP(DBGF_MEMREG,
              "chpl_regMemAlloc(%#zx): no free table entries",
              size);


### PR DESCRIPTION
In comm=ugni we record the registered memory regions in a fixed-size
table.  Here, greatly increase that table's size (from 100 entries to
1000) and add a warning emitted the first time we discover that we want
more entries but don't have any.  The ISx test, when run on compute
nodes with high core counts, was silently running out of such table
entries, dropping back to allocating arrays out of the regular heap, and
then running out of memory.  With this change it should no longer do
this, but if it or any other test overflows the table at least we'll
know that has happened.

Note that expanding the tables arguably makes it even more imperative
that we improve the scalability of the broadcast and search algorithms
used on them.