### PR TITLE
Improved forall intents

### DIFF
--- a/compiler/resolution/implementForallIntents.cpp
+++ b/compiler/resolution/implementForallIntents.cpp
@@ -2192,7 +2192,7 @@ static void addActualsToParCallNew(CallExpr* parCall, FIIvec& fivec,
     FIinfo& info = fivec[idx];
     Symbol* ovar  = outerVars[idx];
     Symbol* globalOp = info.reduceGVar;
-    Symbol* actual;
+    Symbol* actual = NULL;
 
     // Pass 'ovar' into the parallel iterator.
     //


### PR DESCRIPTION
Improved handling of forall intents

### Representation and code improvements

* add FIinfo class to store intent information

* propagate the exact intent information to those parts of
  implementForallIntents.cpp that need it

* streamline the code, removing some unwanted special cases

### Semantics and generated code

* all VarSymbols in the loop body that represent shadow variables
  are now aliases, i.e. "refs", to the shadow variables created
  within the parallel iterator (which is extended to do so
  by extendLeaderNew()); this resolves #6351

* the outer variable is passed to the extendLeaderNew()-extended parallel
  iterator by the intent that corresponds to the forall intent
  i.e. by value for '[const] in' and by reference for '[const] ref'

* remove the warning "Arrays, domains, and distributions currently can be
  passed into the forall loop by 'const', 'ref' or 'const ref' intent only"

* fix several forall-intent futures
  (to be merged separately)

### Future work - code clarity

* We may want to make heavier use of FIinfo instead of passing
outerVars and shadowVars vectors around.

* Right now FIinfo::svar is very lightly used. Also we have both
FIinfo::reduceGVar and FIinfo::reduceMark for a reduce intent.
Some of these could be either removed or utilized more extensively.

  Note that outer vars and shadow vars are going to change as we
descend into task functions in extendLeaderNew / propagateExtraLeaderArgsNew.
Up to that point, however, we may want to fold outerVars and shadowVars
vectors into 'fivec'.

### Future work - semantics and AST

Do we want to continue on the path of handling ALL outer variables
uniformly w.r.t. passing them to the parallel iterator and yielding
them into the shadow variables?  For example, we do not need to
pass through the variables passed by 'ref' intent or 'const'
variables passed by 'const ref' intent.

* isOuterVarNew() has the check for FLAG_CONST. It excludes a
const variable from being handled as an outer variable.
This is incorrect when the variable is passed by 'in' intent.
Ex. test/parallel/forall/in-intents/both-arr-dom-const-var

  If I remove this check, a few tests break, ex.
arrays/bradc/workarounds/arrayOfArray
arrays/deitz/jacobi5*
arrays/deitz/matrix
Interestingly, they break in a seemingly-unrelated, much later
spot in the compiler.

  Maybe the thing to do is to remove this check, however
later in createShadowVarsNew() prune those 'const' variables
that are passed by 'const ref' intent. While there, may as well
complain if one is passed by 'ref' intent.

* createShadowVarsNew() also prunes variables for INTENT_REF
and INTENT_REF_MAYBE_CONST. I.e. we do not create shadow variables
for these two intents, so the body of the loop refers directly
to the outer variable. Is this what we want? as much as possible?

  We have to do at least something for 'const ref' intent.
In the case when the outer variable is not const, we want
constness checking in the body of the loop to see the shadow
variable as a const.

  Also, is relying on lexical scoping any different than
passing these through, in terms of the generated code?
They will end up being passed through the task functions anyway
when those task functions are flattened, right?

### Status

- [x] testing: linux64 --verify
- [x] testing: gasnet (an earlier version passed)
- [x] LCALS inner_prod slowdown - fix if needed (consult with David I)

