### PR TITLE
fix tests broken by error handling in IO

### DIFF
--- a/test/io/ferguson/read-class-reorder3.bad
+++ b/test/io/ferguson/read-class-reorder3.bad
@@ -1,3 +1,3 @@
 a is {a = 1, b = 2, x = 3, y = 4}
 writing {b=5,y=7,a=4,x=6}
-read-class-reorder3.chpl:26: error: bad format in channel.read(ref a:Child) with path "test.txt" offset 9
+read-class-reorder3.chpl:26: error: uncaught error - bad format in channel.read(ref a:Child) with path "test.txt" offset 9

--- a/test/modules/standard/Spawn/spawn-error.good
+++ b/test/modules/standard/Spawn/spawn-error.good
@@ -1,1 +1,1 @@
-spawn-error.chpl:5: error: No such file or directory encountered when launching subprocess
+spawn-error.chpl:5: error: uncaught error - No such file or directory encountered when launching subprocess

--- a/test/modules/standard/Spawn/spawn-error2.good
+++ b/test/modules/standard/Spawn/spawn-error2.good
@@ -1,1 +1,1 @@
-spawn-error2.chpl:7: error: No such file or directory encountered when launching subprocess
+spawn-error2.chpl:7: error: uncaught error - No such file or directory encountered when launching subprocess


### PR DESCRIPTION
Fixes the tests broken by the merge of #6963:
- spawn-error
- spawn-error2
- read-class-reorder3 (future test)