### PR TITLE
Change the name of the 'Barrier' module to the plural 'Barriers'

### DIFF
--- a/modules/Makefile
+++ b/modules/Makefile
@@ -68,6 +68,7 @@ $(SYS_CTYPES_MODULE_DOC): $(MAKE_SYS_BASIC_TYPES)
 MODULES_TO_DOCUMENT = \
 	standard/Assert.chpl \
 	standard/Barrier.chpl \
+	standard/Barriers.chpl \
 	standard/BigInteger.chpl \
 	standard/BitOps.chpl \
 	standard/Buffers.chpl \

--- a/modules/standard/Barrier.chpl
+++ b/modules/standard/Barrier.chpl
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2004-2017 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Deprecated. Use the module :mod:`Barriers` instead. */
+module Barrier {
+  use Barriers;
+
+  compilerWarning("the 'Barrier' module has been renamed 'Barriers' and the 'Barrier' name is deprecated");
+}

--- a/modules/standard/Barriers.chpl
+++ b/modules/standard/Barriers.chpl
@@ -55,7 +55,7 @@
    this barrier implementation is optimized and as the task-team concept is
    implemented and optimized.
 */
-module Barrier {
+module Barriers {
   /* An enumeration of the different barrier implementations.  Used to choose
      the implementation to use when constructing a new barrier object.
 

--- a/test/deprecated/BarrierModuleRenamed.chpl
+++ b/test/deprecated/BarrierModuleRenamed.chpl
@@ -1,0 +1,1 @@
+use Barrier;

--- a/test/deprecated/BarrierModuleRenamed.good
+++ b/test/deprecated/BarrierModuleRenamed.good
@@ -1,0 +1,1 @@
+$CHPL_HOME/modules/standard/Barrier.chpl:24: warning: the 'Barrier' module has been renamed 'Barriers' and the 'Barrier' name is deprecated

--- a/test/parallel/taskPar/diten/barrierCheck.chpl
+++ b/test/parallel/taskPar/diten/barrierCheck.chpl
@@ -1,4 +1,4 @@
-use Barrier;
+use Barriers;
 
 config const nTasks = 4;
 config const printSpinCount = false;

--- a/test/parallel/taskPar/diten/copyBarrier.chpl
+++ b/test/parallel/taskPar/diten/copyBarrier.chpl
@@ -1,4 +1,4 @@
-use Barrier;
+use Barriers;
 
 config const nTasks = 4;
 

--- a/test/parallel/taskPar/sungeun/barrier/basic.chpl
+++ b/test/parallel/taskPar/sungeun/barrier/basic.chpl
@@ -1,4 +1,4 @@
-use Barrier;
+use Barriers;
 use BlockDist;
 
 config const numTasks = 31;

--- a/test/parallel/taskPar/sungeun/barrier/commDiags.chpl
+++ b/test/parallel/taskPar/sungeun/barrier/commDiags.chpl
@@ -1,4 +1,4 @@
-use Barrier;
+use Barriers;
 use BlockDist;
 use CommDiagnostics;
 

--- a/test/parallel/taskPar/sungeun/barrier/reuse.chpl
+++ b/test/parallel/taskPar/sungeun/barrier/reuse.chpl
@@ -1,4 +1,4 @@
-use Barrier;
+use Barriers;
 use BlockDist;
 
 config const printResults = false;

--- a/test/parallel/taskPar/sungeun/barrier/split-phase.chpl
+++ b/test/parallel/taskPar/sungeun/barrier/split-phase.chpl
@@ -1,4 +1,4 @@
-use Barrier;
+use Barriers;
 use BlockDist;
 
 config const numTasks = 31;

--- a/test/release/examples/benchmarks/isx/isx.chpl
+++ b/test/release/examples/benchmarks/isx/isx.chpl
@@ -15,9 +15,9 @@
 
 //
 // We want to use block-distributed arrays (BlockDist), barrier
-// synchronization (Barrier), and timers (Time).
+// synchronization (Barriers), and timers (Time).
 //
-use BlockDist, Barrier, Time;
+use BlockDist, Barriers, Time;
 
 //
 // The type of key to use when sorting.

--- a/test/release/examples/benchmarks/lcals/RunSPMDRawLoops.chpl
+++ b/test/release/examples/benchmarks/lcals/RunSPMDRawLoops.chpl
@@ -6,7 +6,7 @@ module RunSPMDRawLoops {
    */
 
   use LCALSDataTypes;
-  use Timer, Barrier, RangeChunk;
+  use Timer, Barriers, RangeChunk;
 
   proc runSPMDRawLoops(loop_stats:[] LoopStat, run_loop:[] bool, ilength: LoopLength) {
     var loop_suite_run_info = getLoopSuiteRunInfo();

--- a/test/release/examples/benchmarks/ssca2/SSCA2_Modules/SSCA2_kernels.chpl
+++ b/test/release/examples/benchmarks/ssca2/SSCA2_Modules/SSCA2_kernels.chpl
@@ -15,7 +15,7 @@ module SSCA2_kernels
 //  +==========================================================================+
 
 { 
-  use SSCA2_compilation_config_params, Time, Barrier;
+  use SSCA2_compilation_config_params, Time, Barriers;
 
   var stopwatch : Timer;
 

--- a/test/studies/cholesky/jglewis/version2/elemental/block_distribution/elemental_cholesky_symmetric_index_ranges_block.chpl
+++ b/test/studies/cholesky/jglewis/version2/elemental/block_distribution/elemental_cholesky_symmetric_index_ranges_block.chpl
@@ -56,7 +56,7 @@ module elemental_cholesky_symmetric_index_ranges_block {
   // via its native task parallelism constructs.  The lack of a standard way
   // to replicate data and computation across tasks requires this emulation of
   // the SPMD style.  We expect that later versions will fit the native Chapel
-  // execution model more closely.  Barriers are implemented in the Barrier
+  // execution model more closely.  Barriers are implemented in the Barriers
   // standard module for synchronization beyond the specific functionality of
   // coforall and sync statements.
   // =========================================================================
@@ -70,7 +70,7 @@ module elemental_cholesky_symmetric_index_ranges_block {
   // the implementation of such local declarations.
   // =========================================================================
 
-  use BlockDist, Barrier;
+  use BlockDist, Barriers;
 
   use elemental_schur_complement, 
       locality_info, 

--- a/test/studies/cholesky/jglewis/version2/elemental/elemental_cholesky_symmetric_index_ranges.chpl
+++ b/test/studies/cholesky/jglewis/version2/elemental/elemental_cholesky_symmetric_index_ranges.chpl
@@ -53,7 +53,7 @@ module elemental_cholesky_symmetric_index_ranges {
   // via its native task parallelism constructs.  The lack of a standard way
   // to replicate data and computation across tasks requires this emulation of
   // the SPMD style.  We expect that later versions will fit the native Chapel
-  // execution model more closely.  Barriers are implemented in the Barrier
+  // execution model more closely.  Barriers are implemented in the Barriers
   // standard module for synchronization beyond the specific functionality of
   // coforall and sync statements.
   // =========================================================================
@@ -67,7 +67,7 @@ module elemental_cholesky_symmetric_index_ranges {
   // the implementation of such local declarations.
   // =========================================================================
 
-  use CyclicDist, Barrier;
+  use CyclicDist, Barriers;
 
   use elemental_schur_complement, 
       locality_info, 

--- a/test/studies/cholesky/jglewis/version2/elemental/elemental_cholesky_symmetric_index_ranges_alt.chpl
+++ b/test/studies/cholesky/jglewis/version2/elemental/elemental_cholesky_symmetric_index_ranges_alt.chpl
@@ -53,7 +53,7 @@ module elemental_cholesky_symmetric_index_ranges_alt {
   // via its native task parallelism constructs.  The lack of a standard way
   // to replicate data and computation across tasks requires this emulation of
   // the SPMD style.  We expect that later versions will fit the native Chapel
-  // execution model more closely.  Barriers are implemented in the Barrier
+  // execution model more closely.  Barriers are implemented in the Barriers
   // standard module for synchronization beyond the specific functionality of
   // coforall and sync statements.
   // =========================================================================
@@ -67,7 +67,7 @@ module elemental_cholesky_symmetric_index_ranges_alt {
   // the implementation of such local declarations.
   // =========================================================================
 
-  use CyclicDist, Barrier;
+  use CyclicDist, Barriers;
 
   use elemental_schur_complement, 
       local_reduced_matrix_cyclic_partition_alt,

--- a/test/studies/cholesky/jglewis/version2/elemental/fully_blocked/elemental_cholesky_fully_blocked.chpl
+++ b/test/studies/cholesky/jglewis/version2/elemental/fully_blocked/elemental_cholesky_fully_blocked.chpl
@@ -53,7 +53,7 @@ module elemental_cholesky_fully_blocked {
   // via its native task parallelism constructs.  The lack of a standard way
   // to replicate data and computation across tasks requires this emulation of
   // the SPMD style.  We expect that later versions will fit the native Chapel
-  // execution model more closely.  Barriers are implemented in the Barrier
+  // execution model more closely.  Barriers are implemented in the Barriers
   // standard module for synchronization beyond the specific functionality of
   // coforall and sync statements.
   // =========================================================================
@@ -67,7 +67,7 @@ module elemental_cholesky_fully_blocked {
   // the implementation of such local declarations.
   // =========================================================================
 
-  use CyclicDist, Barrier;
+  use CyclicDist, Barriers;
 
   use blocked_elemental_schur_complement, 
       locality_info, 

--- a/test/studies/cholesky/jglewis/version2/elemental/strided/elemental_cholesky_symmetric_strided.chpl
+++ b/test/studies/cholesky/jglewis/version2/elemental/strided/elemental_cholesky_symmetric_strided.chpl
@@ -53,7 +53,7 @@ module elemental_cholesky_symmetric_strided {
   // via its native task parallelism constructs.  The lack of a standard way
   // to replicate data and computation across tasks requires this emulation of
   // the SPMD style.  We expect that later versions will fit the native Chapel
-  // execution model more closely.  Barriers are implemented in the Barrier
+  // execution model more closely.  Barriers are implemented in the Barriers
   // standard module for synchronization beyond the specific functionality of
   // coforall and sync statements.
   // =========================================================================
@@ -67,7 +67,7 @@ module elemental_cholesky_symmetric_strided {
   // the implementation of such local declarations.
   // =========================================================================
 
-  use CyclicDist, Barrier;
+  use CyclicDist, Barriers;
 
   use elemental_schur_complement,
       locality_info_strided, 

--- a/test/studies/cholesky/jglewis/version2/elemental/unsymmetric_indices/elemental_cholesky_unsymmetric_index_ranges.chpl
+++ b/test/studies/cholesky/jglewis/version2/elemental/unsymmetric_indices/elemental_cholesky_unsymmetric_index_ranges.chpl
@@ -53,7 +53,7 @@ module elemental_cholesky_unsymmetric_index_ranges {
   // via its native task parallelism constructs.  The lack of a standard way
   // to replicate data and computation across tasks requires this emulation of
   // the SPMD style.  We expect that later versions will fit the native Chapel
-  // execution model more closely.  Barriers are implemented in the Barrier
+  // execution model more closely.  Barriers are implemented in the Barriers
   // standard module for synchronization beyond the specific functionality of
   // coforall and sync statements.
   // =========================================================================
@@ -67,7 +67,7 @@ module elemental_cholesky_unsymmetric_index_ranges {
   // the implementation of such local declarations.
   // =========================================================================
 
-  use CyclicDist, Barrier;
+  use CyclicDist, Barriers;
 
   use elemental_gen_schur_complement, 
       locality_info, 

--- a/test/studies/isx/isx-bucket-spmd.chpl
+++ b/test/studies/isx/isx-bucket-spmd.chpl
@@ -11,9 +11,9 @@
 
 //
 // We want to use block-distributed arrays (BlockDist), barrier
-// synchronization (Barrier), and timers (Time).
+// synchronization (Barriers), and timers (Time).
 //
-use BlockDist, Barrier, Time;
+use BlockDist, Barriers, Time;
 
 //
 // The type of key to use when sorting.

--- a/test/studies/isx/isx-hand-optimized.chpl
+++ b/test/studies/isx/isx-hand-optimized.chpl
@@ -15,9 +15,9 @@
 
 //
 // We want to use block-distributed arrays (BlockDist), barrier
-// synchronization (Barrier), and timers (Time).
+// synchronization (Barriers), and timers (Time).
 //
-use BlockDist, Barrier, Time;
+use BlockDist, Barriers, Time;
 
 //
 // The type of key to use when sorting.

--- a/test/studies/isx/isx-no-return.chpl
+++ b/test/studies/isx/isx-no-return.chpl
@@ -12,9 +12,9 @@
 
 //
 // We want to use block-distributed arrays (BlockDist), barrier
-// synchronization (Barrier), and timers (Time).
+// synchronization (Barriers), and timers (Time).
 //
-use BlockDist, Barrier, Time;
+use BlockDist, Barriers, Time;
 
 //
 // The type of key to use when sorting.

--- a/test/studies/isx/isx-per-task.chpl
+++ b/test/studies/isx/isx-per-task.chpl
@@ -15,9 +15,9 @@
 
 //
 // We want to use block-distributed arrays (BlockDist), barrier
-// synchronization (Barrier), and timers (Time).
+// synchronization (Barriers), and timers (Time).
 //
-use BlockDist, Barrier, Time;
+use BlockDist, Barriers, Time;
 
 //
 // The type of key to use when sorting.

--- a/test/studies/ssca2/rachels/SSCA2_kernels.chpl
+++ b/test/studies/ssca2/rachels/SSCA2_kernels.chpl
@@ -15,7 +15,7 @@ module SSCA2_kernels
 //  +==========================================================================+
 
 { 
-  use SSCA2_compilation_config_params, Time, Barrier;
+  use SSCA2_compilation_config_params, Time, Barriers;
 
   var stopwatch : Timer;
 

--- a/test/studies/stencil9/stencil9-explicit.chpl
+++ b/test/studies/stencil9/stencil9-explicit.chpl
@@ -1,4 +1,4 @@
-use BlockDist, Barrier;
+use BlockDist, Barriers;
 
 config const n = 10;
 

--- a/test/users/npadmana/mpi/ring.chpl
+++ b/test/users/npadmana/mpi/ring.chpl
@@ -1,7 +1,7 @@
 use MPI;
 use C_MPI;
 use Time;
-use Barrier;
+use Barriers;
 
 enum BarrierType {None, Chapel, MPI};
 


### PR DESCRIPTION
Previously, the `Barrier` module and the `Barrier` record shared a name, which
could lead to problems, as discussed in issue #6979. Update the name of the
module to `Barriers`.

One other idea was to change the name of the record to all lowercase `barrier`,
and change the constructor to an `init` function, but then the `barrier`
method looked like a constructor, so would also need to change names.
Updating the module name appears to be a lower impact change.

The `Barrier` module can still be used by its old name, but now generates
a deprecated warning.

Update tests to use the new module name.  Added a test for the deprecated
warning.

Passed a regular Linux64 paratest.