### PR TITLE
Support throw in forall statements

### DIFF
--- a/compiler/passes/errorHandling.cpp
+++ b/compiler/passes/errorHandling.cpp
@@ -702,9 +702,8 @@ bool ErrorCheckingVisitor::enterCallExpr(CallExpr* node) {
 
 static void markImplicitThrows(FnSymbol* fn, std::set<FnSymbol*>* visited, implicitThrowsReasons_t* reasons)
 {
-  // Currently, only task functions can be implicitly throws.
-  // Future: include iterators and any task functions.
-  if (!isTaskFun(fn)) // TODO: for foralls && !fn->isIterator())
+  // Currently, only task functions or iterators can be implicitly throws.
+  if (!isTaskFun(fn) && !fn->isIterator())
     return;
 
   // If we already visited this function, don't visit it again.

--- a/compiler/passes/parallel.cpp
+++ b/compiler/passes/parallel.cpp
@@ -27,6 +27,7 @@
 #include "driver.h"
 #include "errorHandling.h"
 #include "expr.h"
+#include "errorHandling.h"
 #include "files.h"
 #include "optimizations.h"
 #include "resolution.h"

--- a/compiler/passes/parallel.cpp
+++ b/compiler/passes/parallel.cpp
@@ -27,7 +27,6 @@
 #include "driver.h"
 #include "errorHandling.h"
 #include "expr.h"
-#include "errorHandling.h"
 #include "files.h"
 #include "optimizations.h"
 #include "resolution.h"

--- a/compiler/resolution/lowerIterators.cpp
+++ b/compiler/resolution/lowerIterators.cpp
@@ -1327,7 +1327,7 @@ expandBodyForIteratorInline(ForLoop*       forLoop,
 }
 
 /*
- A Goto ErrorHandling label in the body of an loop will not
+ A Goto ErrorHandling label in the body of a loop will not
  be properly handled when the iterator is inlined into a task
  function because the label will be outside of the task function.
 

--- a/test/chplvis/tree.chpl
+++ b/test/chplvis/tree.chpl
@@ -25,7 +25,7 @@ iter treeiter ( param tag: iterKind, n: int, id: int=0) : int
    if (id < n) {
      yield id;
 
-     // recursive ... but still have to yeild here
+     // recursive ... but still have to yield here
      cobegin {
        if 2*id+1 < n then on Locales[2*id+1] do
          for z in treeiter(n=n, id=2*id + 1, tag=iterKind.standalone) do yield z;

--- a/test/errhandling/parallel/forall-iterator-throws-follower.chpl
+++ b/test/errhandling/parallel/forall-iterator-throws-follower.chpl
@@ -1,0 +1,44 @@
+config const n = 10;
+config const t = 2;
+
+
+iter myiter(nn: int, nt: int) throws {
+  for i in 0..#nt {
+    for j in i*nn..#nn {
+      yield j;
+    }
+  }
+}
+
+// coforall loop in leader should NOT get vector pragma
+iter myiter(nn: int, nt: int, param tag: iterKind) throws where tag == iterKind.leader {
+  coforall i in 0..#nt {
+    yield i*nn..#nn;
+  }
+}
+
+// for loop in follower with yield should get vector pragma
+iter myiter(nn:int, nt: int, followThis, param tag: iterKind) throws where tag == iterKind.follower {
+  throw new Error("Test error");
+  for i in followThis {
+    yield i;
+  }
+}
+
+proc test() {
+  try {
+    writeln("before forall block");
+    forall i in myiter(n,t) {
+      writeln(i);
+    }
+    writeln("after forall block");
+  } catch errors: ErrorGroup {
+    for e in errors { 
+      writeln("Caught group error e ", e.msg);
+    }
+  } catch e {
+    writeln("Caught other error ", e.msg);
+  }
+}
+
+test();

--- a/test/errhandling/parallel/forall-iterator-throws-follower.good
+++ b/test/errhandling/parallel/forall-iterator-throws-follower.good
@@ -1,0 +1,3 @@
+before forall block
+Caught group error e Test error
+Caught group error e Test error

--- a/test/errhandling/parallel/forall-iterator-throws-setup.chpl
+++ b/test/errhandling/parallel/forall-iterator-throws-setup.chpl
@@ -1,0 +1,54 @@
+config const n = 10;
+config const t = 2;
+
+
+iter myiter(nn: int, nt: int) throws {
+
+  throw new Error("Test error");
+
+  for i in 0..#nt {
+    for j in i*nn..#nn {
+      yield j;
+    }
+  }
+}
+
+iter myiter(nn: int, nt: int, param tag: iterKind) throws where tag == iterKind.standalone {
+  throw new Error("Test error");
+
+  coforall i in 0..#nt {
+    for j in i*nn..#nn {
+      yield j;
+    }
+  }
+}
+
+// coforall loop in leader should NOT get vector pragma
+iter myiter(nn: int, nt: int, param tag: iterKind) throws where tag == iterKind.leader {
+  throw new Error("Test error");
+
+  coforall i in 0..#nt {
+    yield i*nn..#nn;
+  }
+}
+
+// for loop in follower with yield should get vector pragma
+iter myiter(nn:int, nt: int, followThis, param tag: iterKind) throws where tag == iterKind.follower {
+  for i in followThis {
+    yield i;
+  }
+}
+
+proc test() {
+  try {
+    writeln("before forall block");
+    forall i in myiter(n,t) {
+      writeln(i);
+    }
+    writeln("after forall block");
+  } catch e {
+    writeln("Caught error ", e.msg);
+  }
+}
+
+test();

--- a/test/errhandling/parallel/forall-iterator-throws-setup.good
+++ b/test/errhandling/parallel/forall-iterator-throws-setup.good
@@ -1,0 +1,2 @@
+before forall block
+Caught error Test error

--- a/test/errhandling/parallel/forall-iterator-throws.chpl
+++ b/test/errhandling/parallel/forall-iterator-throws.chpl
@@ -1,0 +1,56 @@
+config const n = 10;
+config const t = 2;
+
+
+iter myiter(nn: int, nt: int) throws {
+  for i in 0..#nt {
+    for j in i*nn..#nn {
+      if j == 1 then
+        throw new Error("test error");
+      yield j;
+    }
+  }
+}
+
+iter myiter(nn: int, nt: int, param tag: iterKind) throws where tag == iterKind.standalone {
+  coforall i in 0..#nt {
+    for j in i*nn..#nn {
+      if j == 1 then
+        throw new Error("test error");
+      yield j;
+    }
+  }
+}
+
+// coforall loop in leader should NOT get vector pragma
+iter myiter(nn: int, nt: int, param tag: iterKind) throws where tag == iterKind.leader {
+  coforall i in 0..#nt {
+    yield i*nn..#nn;
+  }
+}
+
+// for loop in follower with yield should get vector pragma
+iter myiter(nn:int, nt: int, followThis, param tag: iterKind) throws where tag == iterKind.follower {
+  for i in followThis {
+    if i == 1 then
+      throw new Error("test error");
+    yield i;
+  }
+}
+
+proc test() {
+  try {
+    writeln("before forall block");
+    forall i in myiter(n,t) {
+    }
+    writeln("after forall block");
+  } catch errors: ErrorGroup {
+    for e in errors { 
+      writeln("Caught group error e ", e.msg);
+    }
+  } catch e {
+    writeln("Caught other error ", e.msg);
+  }
+}
+
+test();

--- a/test/errhandling/parallel/forall-iterator-throws.good
+++ b/test/errhandling/parallel/forall-iterator-throws.good
@@ -1,0 +1,2 @@
+before forall block
+Caught group error e test error

--- a/test/errhandling/parallel/forall-range-throws.chpl
+++ b/test/errhandling/parallel/forall-range-throws.chpl
@@ -1,0 +1,20 @@
+config const n = 1000;
+
+proc test() {
+  try {
+    writeln("before forall block");
+    forall i in 1..n {
+      if i == 1 then
+        throw new Error("test error");
+    }
+    writeln("after forall block");
+  } catch errors: ErrorGroup {
+    for e in errors { 
+      writeln("Caught group error e ", e.msg);
+    }
+  } catch e {
+    writeln("Caught other error ", e.msg);
+  }
+}
+
+test();

--- a/test/errhandling/parallel/forall-range-throws.good
+++ b/test/errhandling/parallel/forall-range-throws.good
@@ -1,0 +1,2 @@
+before forall block
+Caught group error e test error

--- a/test/errhandling/parallel/forall-range-throws.skipif
+++ b/test/errhandling/parallel/forall-range-throws.skipif
@@ -1,0 +1,2 @@
+# See issue #7046
+CHPL_LOCALE_MODEL == numa

--- a/test/errhandling/parallel/forall-throws.chpl
+++ b/test/errhandling/parallel/forall-throws.chpl
@@ -1,0 +1,52 @@
+config const n = 10;
+config const t = 2;
+
+
+iter myiter(nn: int, nt: int) {
+  for i in 0..#nt {
+    for j in i*nn..#nn {
+      yield j;
+    }
+  }
+}
+
+iter myiter(nn: int, nt: int, param tag: iterKind) where tag == iterKind.standalone {
+  coforall i in 0..#nt {
+    for j in i*nn..#nn {
+      yield j;
+    }
+  }
+}
+
+// coforall loop in leader should NOT get vector pragma
+iter myiter(nn: int, nt: int, param tag: iterKind) where tag == iterKind.leader {
+  coforall i in 0..#nt {
+    yield i*nn..#nn;
+  }
+}
+
+// for loop in follower with yield should get vector pragma
+iter myiter(nn:int, nt: int, followThis, param tag: iterKind) where tag == iterKind.follower {
+  for i in followThis {
+    yield i;
+  }
+}
+
+proc test() {
+  try {
+    writeln("before forall block");
+    forall i in myiter(n,t) {
+      if i == 1 then
+        throw new Error("test error");
+    }
+    writeln("after forall block");
+  } catch errors: ErrorGroup {
+    for e in errors { 
+      writeln("Caught group error e ", e.msg);
+    }
+  } catch e {
+    writeln("Caught other error ", e.msg);
+  }
+}
+
+test();

--- a/test/errhandling/parallel/forall-throws.good
+++ b/test/errhandling/parallel/forall-throws.good
@@ -1,0 +1,2 @@
+before forall block
+Caught group error e test error


### PR DESCRIPTION
This PR adds support and tests for throw used in the context of forall statements.
This is a complex task because of the way in which lowerIterators works directly with task functions - including possibly inlining them.

The approach of this PR is to adjust lowerIterators to fix up the error handling constructs in a way that the follow-on parallel pass can understand. A reasonable alternative design would be to perform lowerIterators before the errorHandling pass - but that is impossible right now because lowerIterators needs to be after callDestructors and errorHandling needs to be before callDestructors.

Anyway, this PR modifies lowerIterators as follows:
 * Adjusts expandBodyForIteratorInline to more obviously track whether or not it is processing a task function and to include an argument indicating if the calling context should update the CallExpr to pass in a dummy error argument.
 * Add fixupErrorHandlingExits, which is called from expandBodyForIteratorInline. fixupErrorHandlingExits handles error-handling structures that are no longer legal because they refer outside of the function. These might be referring to goto targets outside of the current function or to formals outside of the current function. Either way, this function translates it to use the task error argument and exit the task function on an error. (The parallel pass will take care of adding any error saved in the error argument to a list of errors encountered in subtasks).
 * Add replaceErrorArgumentWithEnclosingError, which is called from expandIteratorInline. This function adjusts certain error-handling patterns to use the out error argument instead of an enclosing variable. That is needed because a task function in a forall iterator needs to send the error to the list of sub-task errors rather than trying to exit control flow otherwise.
 * Added other support routines to help these two new functions.


Reviewed by @vasslitvinov - thanks!

- [x] full local testing
- [x] passes Hellos and test/errhandling in a GASNet configuration 
- [x] passes Hellos and test/errhandling in a NUMA configuration