### PR TITLE
Fix a dsiPartialThese bug exposed by changing growth factor

### DIFF
--- a/test/users/engin/partial_reduction_support/modules/dsiMethods.chpl
+++ b/test/users/engin/partial_reduction_support/modules/dsiMethods.chpl
@@ -106,11 +106,11 @@ proc DefaultSparseDom.__private_findRowRange(r) {
   var done: atomic bool;
   begin with (ref end) {
     var found: bool;
-    (found, end) = binarySearch(indices, ((...r),endDummy));
+    (found, end) = binarySearch(indices, ((...r),endDummy), hi=nnz);
     done.write(true);
   }
   var found: bool;
-  (found, start) = binarySearch(indices, ((...r),startDummy));
+  (found, start) = binarySearch(indices, ((...r),startDummy), hi=nnz);
   done.waitFor(true);
   return start..min(nnz,end-1);
 }


### PR DESCRIPTION
partialThese methods were added as self-contained tests for partial reduction support. One of the helpers had a bug that was exposed by changing sparse growth factor in #6936 

This PR fixes the bug. `test/users/engin/partial_reduction_support` passed a no-local test.