### PR TITLE
Remove -Winline from GASNET_OPT_CFLAGS

### DIFF
--- a/third-party/gasnet/Makefile.setup
+++ b/third-party/gasnet/Makefile.setup
@@ -15,7 +15,8 @@ include $(GASNET_INC_MAKEFILE)
 
 ifeq ($(CC),$(notdir $(GASNET_CC)))
 CHPL_GASNET_CFLAGS_ALL = $(GASNET_MISC_CPPFLAGS) $(GASNET_DEFINES) $(GASNET_INCLUDES) $(GASNET_MISC_CFLAGS) $(MANUAL_CFLAGS) $(CHPL_GASNET_MORE_CFLAGS)
-OPT_CFLAGS += $(GASNET_OPT_CFLAGS)
+# Remove -Winline from GASNet's provided flags
+OPT_CFLAGS += $(GASNET_OPT_CFLAGS:-Winline=)
 CHPL_GASNET_LDFLAGS = $(GASNET_LDFLAGS)
 else
 # If GASNet is using a different compiler from the rest of the Chapel build,
@@ -27,7 +28,8 @@ else
 CHPL_GASNET_CFLAGS_ALL = $(GASNET_DEFINES) $(GASNET_INCLUDES) $(CHPL_GASNET_MORE_CFLAGS)
 endif
 
-# Remove -Winline from Gasnet's provided flags
+# Remove -Winline from GASNet's provided flags
+# (might not be needed if it always comes in GASNET_OPT_CFLAGS)
 CHPL_GASNET_CFLAGS = $(CHPL_GASNET_CFLAGS_ALL:-Winline=)
 ifneq (, $(filter $(CHPL_MAKE_TARGET_PLATFORM),cray-xe cray-xk cray-xc) )
 CHPL_GASNET_CFLAGS += -DGASNET_NEEDS_MAX_SEGSIZE


### PR DESCRIPTION
We previously had been removing -Winline from the other GASNet flags, but in
practice it seems to come in GASNET_OPT_CFLAGS, so remove it there too.

This PR leaves the old removal of -Winline from CHPL_GASNET_CFLAGS_ALL in
place in case -Winline can appear there in the future or in some other
configuration.

This PR addresses testing failures from PR #7031.

Trivial and not reviewed.