### PR TITLE
Skip RVF and makeHeapAllocations if there are no on-statements

### DIFF
--- a/compiler/optimizations/remoteValueForwarding.cpp
+++ b/compiler/optimizations/remoteValueForwarding.cpp
@@ -67,7 +67,7 @@ static void replaceRecordWrappedRefs();
 ************************************** | *************************************/
 
 void remoteValueForwarding() {
-  if (fNoRemoteValueForwarding == false) {
+  if (fNoRemoteValueForwarding == false && requireOutlinedOn()) {
     inferConstRefs();
     computeUsesDotLocale();
     Map<Symbol*, Vec<SymExpr*>*> defMap;

--- a/compiler/passes/parallel.cpp
+++ b/compiler/passes/parallel.cpp
@@ -1505,7 +1505,9 @@ void parallel() {
 
   reprivatizeIterators();
 
-  makeHeapAllocations();
+  if (requireOutlinedOn()) {
+    makeHeapAllocations();
+  }
 
   insertEndCounts();
 

--- a/compiler/util/misc.cpp
+++ b/compiler/util/misc.cpp
@@ -87,7 +87,7 @@ bool requireWideReferences() {
 // on-clause is a no-op and execute the associated statement locally.
 //
 bool requireOutlinedOn() {
-  return !fLocal || strcmp(CHPL_LOCALE_MODEL, "flat") != 0;
+  return requireWideReferences();
 }
 
 const char* cleanFilename(const char* name) {


### PR DESCRIPTION
By skipping these sections of the compiler that are useless without
on-statements, we can slightly improve compilation speed.

Testing:
- [x] full local
- [x] full gasnet
- [x] numa examples/