### PR TITLE
Initialize error vars

### DIFF
--- a/compiler/passes/errorHandling.cpp
+++ b/compiler/passes/errorHandling.cpp
@@ -213,6 +213,7 @@ void ErrorHandlingVisitor::exitTryStmt(TryStmt* node) {
 
   BlockStmt* tryBody = info.tryBody;
 
+  tryBody->insertAtHead(new CallExpr(PRIM_MOVE, info.errorVar, gNil));
   tryBody->insertAtHead(new DefExpr(info.errorVar));
   tryBody->insertAtTail(new DefExpr(info.handlerLabel));
 
@@ -337,6 +338,7 @@ bool ErrorHandlingVisitor::enterCallExpr(CallExpr* node) {
         errorVar = newTemp("error", dtError);
         errorVar->addFlag(FLAG_ERROR_VARIABLE);
         insert->insertBefore(new DefExpr(errorVar));
+        insert->insertBefore(new CallExpr(PRIM_MOVE, errorVar, gNil));
 
         if (outError != NULL)
           errorPolicy->insertAtTail(setOutGotoEpilogue(errorVar));

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -4175,7 +4175,7 @@ record ItemReader {
   }
 
   /* iterate through all items of that type read from the channel */
-  iter these() {
+  iter these() throws {
     while true {
       var x:ItemType;
       var gotany = ch.read(x);
@@ -4183,19 +4183,6 @@ record ItemReader {
       yield x;
     }
   }
-
-  /* It would be nice to be able to handle errors
-     when reading with these()
-     but it's not clear how to get the error argument
-     out. Exceptions would sort us out...
-  iter these(out error:syserr) {
-    while true {
-      var x:ItemType;
-      var gotany = ch.read(x, error=error);
-      if ! gotany then break;
-      yield x;
-    }
-  }*/
 }
 
 /* Create and return an :record:`ItemReader` that can yield read values of


### PR DESCRIPTION
Before this change, they would get initialized during
code generation, but not necessarily when in an iterator
class.

Additionally this PR marks ItemReader.these as throws since it calls read which can throw.

- [x] full local testing

Reviewed by @psahabu - thanks!