### PR TITLE
Comm-counts perf testing

### DIFF
--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -36,6 +36,7 @@ $examples = 0;
 $performance = 0;
 $performancedescription = "";
 $performanceconfigs = "";
+$perflabel = "";
 $releasePerformance = 0;
 $compperformance = 0;
 $compperformancedescription = "";
@@ -100,6 +101,8 @@ while (@ARGV) {
         $performancedescription = shift @ARGV;
     } elsif ($flag eq "-performance-configs") {
         $performanceconfigs = shift @ARGV;
+    } elsif ($flag eq "-perflabel") {
+        $perflabel = shift @ARGV;
     } elsif ($flag eq "-releasePerformance") {
         $releasePerformance = 1;
     } elsif ($flag eq "-compperformance") {
@@ -649,6 +652,9 @@ if ($performance == 1) {
     }
     if ($performanceconfigs ne "") {
        $testflags = "$testflags -performance-configs \"$performanceconfigs\"";
+    }
+    if ($perflabel ne "") {
+       $testflags = "$testflags -perflabel \"$perflabel\"";
     }
 
 }

--- a/util/cron/test-perf.chapcs.cc.bash
+++ b/util/cron/test-perf.chapcs.cc.bash
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+# Run -perflabel cc- performance tests on a chapcs machine with gasnet
+
+CWD=$(cd $(dirname $0) ; pwd)
+
+export CHPL_TEST_PERF_CONFIG_NAME='chapcs'
+
+source $CWD/common-perf.bash
+source $CWD/common-gasnet.bash
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.cc"
+
+SHORT_NAME=cc
+START_DATE=08/17/17
+
+perf_args="-performance-description $SHORT_NAME -sync-dir-suffix $SHORT_NAME -perflabel cc-"
+perf_args="${perf_args} -performance -numtrials 5 -startdate $START_DATE"
+
+# "make check" will fail on chapcs because Gasnet wants to use ibv.
+#  The warning message causes the good-output v. test-output comparison to fail.
+
+#  -no-buildcheck skips the "make check"
+nightly_args=-no-buildcheck
+
+$CWD/nightly -cron ${nightly_args} ${perf_args}

--- a/util/cron/test-perf.comm-counts.bash
+++ b/util/cron/test-perf.comm-counts.bash
@@ -9,7 +9,7 @@ export CHPL_TEST_PERF_CONFIG_NAME='chapcs'
 source $CWD/common-perf.bash
 source $CWD/common-gasnet.bash
 
-export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.cc"
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.comm-counts"
 
 SHORT_NAME=cc
 START_DATE=08/17/17


### PR DESCRIPTION
First cut at Jenkins job script for Comm-counts perf testing, req by @mppf . 
Also see https://github.com/chapel-lang/chapel/pull/6604

Perf data goes into /data/sea/chapel/NightlyPerformance/chapcs/cc
(http://chapel.sourceforge.net/perf/chapcs/cc/)