### PR TITLE
Fix annotation checker regex bug

### DIFF
--- a/util/test/check_annotations.py
+++ b/util/test/check_annotations.py
@@ -111,7 +111,7 @@ def compute_pr_to_dates():
     for line in git_log.splitlines():
         split_line = line.split(' ::: ')
         date = split_line[0]
-        pr_num = re.match(r'.*#(\d+)', split_line[1]).group(1)
+        pr_num = re.match(r'Merge pull request #(\d+)', split_line[1]).group(1)
         pr_to_date_dict[pr_num] = parse_date(date)
 
     return pr_to_date_dict


### PR DESCRIPTION
Use regex that won't find other PR numbers in the merge message. For example, the old regex would find '123' in a merge message like "Merge pull request #500 that deals with #123"