### PR TITLE
Fix this prediff for GASNet

### DIFF
--- a/test/compflags/ferguson/ccflags-order.prediff
+++ b/test/compflags/ferguson/ccflags-order.prediff
@@ -30,7 +30,18 @@ for my $line (@lines) {
 open OUTFILE, ">$execout" or die "can't open $execout for writing $!";
 
 foreach my $line (@out_lines) {
-  print OUTFILE $line . "\n";
+  # Remove redundant words
+  my @words = split(/ +|[{}]/, $line);
+
+  @uniq_words = ( );
+  $last_word = "";
+  for my $w (@words) {
+    if ($w ne $last_word) {
+      push(@uniq_words, $w);
+    }
+    $last_word = $w;
+  }
+  print OUTFILE join(' ', @uniq_words) . "\n";
 }
 
 close(OUTFILE);


### PR DESCRIPTION
GASNet configurations now add two -O3 options. Add unique-ifying of the
output of this test so that does not cause failures, as we used to have.