### PR TITLE
Simplify ErrorGroup.writeThis

### DIFF
--- a/modules/internal/ChapelError.chpl
+++ b/modules/internal/ChapelError.chpl
@@ -113,56 +113,43 @@ module ChapelError {
     }
 
     proc writeThis(f) {
-      f <~> "ErrorGroup with ";
-
-      var Msgs:domain(string);
-      var byMsg:[Msgs] list(Error);
       var n = 0;
-
-      for e in these() {
-        Msgs += e.msg;
-        byMsg[e.msg].append(e);
-        n += 1;
-      }
-
-      if n > 1 then
-        f <~> n <~> " errors";
-
 
       var minMsg:string;
       var maxMsg:string;
-      for msg in Msgs {
-        if minMsg == "" || msg < minMsg then
-          minMsg = msg;
-        if maxMsg == "" || msg > maxMsg then
-          maxMsg = msg;
-      }
-
       var first:Error;
       var last:Error;
 
+      for e in these() {
+        if minMsg == "" || e.msg < minMsg then
+          minMsg = e.msg;
+        if maxMsg == "" || e.msg > maxMsg then
+          maxMsg = e.msg;
+
+        n += 1;
+      }
+
       // Set first and last.
       {
-        const ref minErrs = byMsg[minMsg];
-        for e in minErrs {
-          if first == nil then
-            first = e;
-          last = e;
-        }
-        if minMsg != maxMsg {
-          const ref maxErrs = byMsg[maxMsg];
-          for e in maxErrs {
+        for e in these() {
+          if e.msg == minMsg {
             if first == nil then
               first = e;
             last = e;
           }
         }
+        if minMsg != maxMsg {
+          for e in these() {
+            if e.msg == maxMsg {
+              last = e;
+            }
+          }
+        }
       }
 
-      var nMsgs = Msgs.size;
-
-      if nMsgs > 1 then
-        f <~> " and " <~> nMsgs <~> " messages:: ";
+      f <~> "ErrorGroup with ";
+      if n > 1 then
+        f <~> n <~> " errors: ";
 
       if first != last then
         f <~> first <~> " ... " <~> last;

--- a/test/errhandling/parallel/strict/coforall-throws-catch-strict.good
+++ b/test/errhandling/parallel/strict/coforall-throws-catch-strict.good
@@ -1,2 +1,2 @@
 before test
-Caught errors ErrorGroup with 10 errors and 10 messages:: {msg = 1} ... {msg = 9}
+Caught errors ErrorGroup with 10 errors: {msg = 1} ... {msg = 9}


### PR DESCRIPTION
The previous ErrorGroup.writeThis used an associative array but its only
purpose was to print out the number of unique error messages encountered.
But it had the nasty side effect of significantly impacting compilation
speed.

Since it's not necessarily important to print out the number of unique
error messages, this PR changes that writeThis to no longer use an
associative array.  It's arguably better not to be allocating a lot of
memory in code run in a catch block, anyway, in case (in the future) we
are processing an error indicating that we are low on memory.

- [x] full local testing

Reviewed by @noakesmichael - thanks!