### PR TITLE
Support offsetted domains in LinearAlgebra.diag()

### DIFF
--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -589,11 +589,6 @@ private inline proc _raw(D: domain(1), i) {
 //
 
 
-private proc diag(A: [?Adom] ?eltType, k=0) where Adom.stridable {
-  // TODO: reindex to non-strided
-  return diag(A, k);
-}
-
 /*
    Return a Vector containing the diagonal elements of ``A`` if the argument ``A`` is of rank 2.
    Return a diagonal Matrix whose diagonal contains elements of ``A`` if argument ``A`` is of rank 1.

--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -131,10 +131,14 @@ use BLAS;
 /* Return a vector (1D array) over domain ``{0..#length}``*/
 proc Vector(length, type eltType=real) {
   if (length <= 0) then halt("Vector length must be > 0");
-  var V: [0..#length] eltType;
-  return V;
+  return Vector(0..#length, eltType);
 }
 
+
+/* Return a vector (1D array) over domain ``{space}`` */
+proc Vector(space: range, type eltType=real) {
+  return Vector({space}, eltType);
+}
 
 /* Return a vector (1D array) over domain ``Dom`` */
 proc Vector(Dom: domain(1), type eltType=real) {
@@ -169,7 +173,7 @@ proc Vector(x: ?t, Scalars...?n, type eltType) where isNumericType(t) {
 
   V[0] = x: eltType;
 
-  for i in 1..n do V[i] = Scalars[i]: eltType;
+  forall i in 1..n do V[i] = Scalars[i]: eltType;
 
   return V;
 }
@@ -178,23 +182,33 @@ proc Vector(x: ?t, Scalars...?n, type eltType) where isNumericType(t) {
 /* Return a square matrix (2D array) over domain ``{0..#rows, 0..#rows}``*/
 proc Matrix(rows, type eltType=real) where isIntegral(rows) {
   if rows <= 0 then halt("Matrix dimensions must be > 0");
-  var M: [0..#rows, 0..#rows] eltType;
-  return M;
+  return Matrix(0..#rows, 0..#rows, eltType);
 }
 
 
 /* Return a matrix (2D array) over domain ``{0..#rows, 0..#cols}``*/
 proc Matrix(rows, cols, type eltType=real) where isIntegral(rows) && isIntegral(cols) {
   if rows <= 0 || cols <= 0 then halt("Matrix dimensions must be > 0");
-  var M: [0..#rows, 0..#cols] eltType;
-  return M;
+  return Matrix(0..#rows, 0..#cols, eltType);
+}
+
+
+/* Return a square matrix (2D array) over domain ``{space, space}`` */
+proc Matrix(space: range, type eltType=real) {
+  return Matrix({space, space}, eltType);
+}
+
+
+/* Return a matrix (2D array) over domain ``{rowSpace, colSpace}`` */
+proc Matrix(rowSpace: range, colSpace: range, type eltType=real) {
+  return Matrix({rowSpace, colSpace}, eltType);
 }
 
 
 /* Return a matrix (2D array) over domain ``Dom`` */
 proc Matrix(Dom: domain(2), type eltType=real) where Dom.rank == 2 {
-  var M: [Dom] eltType;
-  return M;
+  var A: [Dom] eltType;
+  return A;
 }
 
 
@@ -575,93 +589,82 @@ private inline proc _raw(D: domain(1), i) {
 //
 
 
+private proc diag(A: [?Adom] ?eltType, k=0) where Adom.stridable {
+  // TODO: reindex to non-strided
+  return diag(A, k);
+}
+
 /*
    Return a Vector containing the diagonal elements of ``A`` if the argument ``A`` is of rank 2.
    Return a diagonal Matrix whose diagonal contains elements of ``A`` if argument ``A`` is of rank 1.
  */
-proc diag(A: [?Adom] ?eltType, k=0){
-  //This should be printed at compile time-"This function only supports 0-based non-strided arrays,
-  //including the vectors and matrices created from this module."
-
-  if(Adom.rank == 2) then{
-    if(k==0) then{
+proc diag(A: [?Adom] ?eltType, k=0) {
+  if (Adom.rank == 2) {
+    if (k == 0) then
       return _diag_vec(A);
-    }
-    else{
+    else
       return _diag_vec(A, k);
-    }
   }
-  else if(Adom.rank == 1) then {
+  else if (Adom.rank == 1) then
     return _diag_mat(A);
-  }
-  else{
-    compilerError("A must have rank 2 or less");
-  }
-
+  else compilerError("A must have rank 2 or less");
 }
 
-private proc _diag_vec(A:[?Adom] ?eltType){
+private proc _diag_vec(A:[?Adom] ?eltType) {
+  const (m, n) = Adom.shape;
+  const d = if m < n then 1 else 2;
+  const dim = Adom.dim(d);
 
-  //better way to do this if type of Adom.dim(1) and Adom.dim(2) can be determined
-  if(Adom.dim(1).length<Adom.dim(2).length) then{
-    var diagonal = Vector(Adom.dim(1).length, eltType);
-    forall i in Adom.dim(1) do{
-      diagonal[i] = A[i,i];
-    }
-    return diagonal;
-  }
-  else{
-    var diagonal = Vector(Adom.dim(2).length, eltType);
-    forall i in Adom.dim(2) do{
-      diagonal[i] = A[i,i];
-    }
-    return diagonal;
-  }
+  var diagonal = Vector(dim, eltType);
+
+  forall i in dim do
+    diagonal[i] = A[i,i];
+
+  return diagonal;
 }
 
-private proc _diag_vec(A:[?Adom] ?eltType, k){
-  if(k>0){
-    //Upper diagonal
-    if(Adom.dim(2).length<k) then halt("k is out of range");
-    var length:int;
-    if((Adom.dim(2).length-k)<Adom.dim(1).length) then{
-      length = Adom.dim(2).length - k;
-    }
-    else{
-      length = Adom.dim(1).length;
-    }
-    var diagonal = Vector(length, eltType);
-    forall i in Adom.dim(1)(..length-1) do{
-      diagonal[i] = A[i,i+k];
-    }
+private proc _diag_vec(A:[?Adom] ?eltType, k) {
+  const (m, n) = Adom.shape;
+  const d = if m < n then 1 else 2;
+  const dim = Adom.dim(d);
+
+  if k > 0 {
+    // Upper diagonal
+    if m < k then halt("k is out of range");
+
+    var length = min(m, n - k);
+    const space = dim.first..#length;
+    var diagonal = Vector(space, eltType);
+
+    forall i in space do
+      diagonal[i] = A[i, i+k];
+
     return diagonal;
   }
   else{
-    //Lower diagonal
-    if(Adom.dim(1).length<abs(k)) then halt("k is out of range");
-    var length:int;
-    if((Adom.dim(1).length-abs(k))<Adom.dim(2).length) then {
-      length = Adom.dim(1).length - abs(k);
-    }
-    else{
-      length = Adom.dim(2).length;
-    }
-    var diagonal = Vector(length, eltType);
-    forall i in Adom.dim(1)(..length-1) do{
-      diagonal[i] = A[i+abs(k),i];
-    }
+    // Lower diagonal
+    const K = abs(k);
+    if m < K then halt("k is out of range");
+
+    var length = min(n, m - K);
+    const space = dim.first..#length;
+    var diagonal = Vector(space, eltType);
+
+    forall i in space do
+      diagonal[i] = A[i+K, i];
+
     return diagonal;
   }
 }
 
 private proc _diag_mat(A:[?Adom] ?eltType){
-  var diagonal = Matrix(Adom.dim(1).length, eltType);
-  forall i in Adom.dim(1) do{
+  var diagonal = Matrix(Adom.dim(1), eltType);
+
+  forall i in Adom.dim(1) do
     diagonal[i, i] = A[i];
-  }
+
   return diagonal;
 }
-
 
 
 /*

--- a/test/modules/packages/linearalgebra/correctness/correctness.chpl
+++ b/test/modules/packages/linearalgebra/correctness/correctness.chpl
@@ -197,8 +197,8 @@ config const correctness = true;
   }
 }
 
-/* dot - calls matMult && inner*/
 
+/* dot - calls matMult && inner*/
 
 {
 
@@ -359,10 +359,10 @@ config const correctness = true;
                  [7,8,9],
                  eltType=real);
   var v = Vector(1,5,9);
-  var matrix = Matrix([1,0,0],
-                      [0,5,0],
-                      [0,0,9],
-                      eltType=real);
+  var vMat = Matrix([1,0,0],
+                    [0,5,0],
+                    [0,0,9],
+                    eltType=real);
   var M1 = Matrix([1,2,3,4],
                   [5,6,7,8],
                   [9,0,1,2],
@@ -371,11 +371,27 @@ config const correctness = true;
   var v12 = Vector(3,8);
   var v13 = Vector([9]);
 
-  assertEqual(v, diag(M), "diag(M)");
-  assertEqual(matrix, diag(v),"diag(v)");
-  assertEqual(v11,diag(M1),"diag(M1)");
-  assertEqual(v12,diag(M1,2),"diag(M1,2)");
-  assertEqual(v13,diag(M1,-2),"diag(M1,-2)");
+  assertEqual(v,    diag(M),        "diag(M)");
+  assertEqual(vMat, diag(v),        "diag(v)");
+  assertEqual(v11,  diag(M1),       "diag(M1)");
+  assertEqual(v12,  diag(M1,2),     "diag(M1,2)");
+  assertEqual(v13,  diag(M1,-2),    "diag(M1,-2)");
+
+  // Now let's try with offsets
+
+  ref rM = M.reindex(1..3, 1..3);
+  ref rv = v.reindex(1..3);
+  ref rvMat = vMat.reindex(1..3, 1..3);
+  ref rM1 = M1.reindex(1..3, 1..4);
+  ref rv11 = v11.reindex(1..3);
+  ref rv12 = v12.reindex(1..2);
+  ref rv13 = v13.reindex(1..1);
+
+  assertEqual(rv,   diag(rM),       "diag(M)");
+  assertEqual(rvMat,diag(rv),       "diag(v)");
+  assertEqual(rv11, diag(rM1),      "diag(M1)");
+  assertEqual(rv12, diag(rM1,2),    "diag(M1,2)");
+  assertEqual(rv13, diag(rM1,-2),   "diag(M1,-2)");
 }
 
 /* tril & triu */

--- a/test/modules/packages/linearalgebra/correctness/correctness.chpl
+++ b/test/modules/packages/linearalgebra/correctness/correctness.chpl
@@ -14,13 +14,29 @@ config const verbose=false;
 //
 
 {
-  const Dom = {0..#10};
-  const MDom = {0..#3, 0..#3};
+  const Dom = {0..#10},
+        MDom = {0..#3, 0..#3},
+        MDom2 = {0..#4, 0..#6};
+
+  //
+  // Vectors
+  //
 
   /* Dimensions */
   {
     var v = Vector(10);
     assertEqual(v.domain, Dom, "Vector(10)");
+  }
+
+  /* Range */
+  {
+    var v = Vector(0..#10);
+    assertEqual(v.domain, Dom, "Vector(0..#10)");
+  }
+  {
+    var v = Vector(1..#10);
+    const d = {1..#10};
+    assertEqual(v.domain, d, "Vector(1..#10)");
   }
 
   /* Domain */
@@ -37,6 +53,10 @@ config const verbose=false;
     assertEqual(v.domain, Dom, "Vector(A)");
   }
 
+  //
+  // Matrices
+  //
+
 
   /* Rows */
   {
@@ -44,11 +64,22 @@ config const verbose=false;
     assertEqual(M.domain, MDom, "Matrix(3)");
   }
 
-
   /* Dimensions */
   {
     var M = Matrix(3, 3);
     assertEqual(M.domain, MDom, "Matrix(3, 3)");
+  }
+
+  /* Range */
+  {
+    var M = Matrix(0..#3);
+    assertEqual(M.domain, MDom, "Matrix(0..#3)");
+  }
+
+  /* Ranges */
+  {
+    var M = Matrix(0..#4, 0..#6);
+    assertEqual(M.domain, MDom2, "Matrix(0..#4, 0..#6)");
   }
 
   /* Domain */

--- a/test/modules/packages/linearalgebra/correctness/correctness.chpl
+++ b/test/modules/packages/linearalgebra/correctness/correctness.chpl
@@ -7,7 +7,7 @@ use LinearAlgebra;
    Many of these tests are trivial and can be expanded upon in the future.
 */
 
-config const verbose=false;
+config const correctness = true;
 
 //
 // Initializers
@@ -463,7 +463,7 @@ config const verbose=false;
 //
 
 proc assertEqual(X, Y, msg="") {
-  if verbose then writeln(msg);
+  if !correctness then writeln(msg);
   if X != Y {
     writeln("Test Failed: ", msg);
     writeln(X, ' != ', Y);
@@ -473,7 +473,7 @@ proc assertEqual(X, Y, msg="") {
 
 proc assertEqual(X: [], Y: [], msg="") where isArrayValue(X) && isArrayValue(Y)
 {
-  if verbose then writeln(msg);
+  if !correctness then writeln(msg);
   if X.shape != Y.shape {
     writeln("Test Failed: ", msg);
     writeln(X, '\n!=\n', Y);
@@ -487,7 +487,7 @@ proc assertEqual(X: [], Y: [], msg="") where isArrayValue(X) && isArrayValue(Y)
 
 
 proc assertEqual(X: _tuple, Y: _tuple, msg="") {
-  if verbose then writeln(msg);
+  if !correctness then writeln(msg);
   if X.size != Y.size {
     writeln("Test Failed: ", msg);
     writeln(X, '\n!=\n', Y);
@@ -504,7 +504,7 @@ proc assertEqual(X: _tuple, Y: _tuple, msg="") {
 }
 
 proc assertTrue(x: bool, msg="") {
-  if verbose then writeln(msg);
+  if !correctness then writeln(msg);
   if !x {
     writeln("Test Failed: ", msg);
     writeln("boolean is false");
@@ -512,7 +512,7 @@ proc assertTrue(x: bool, msg="") {
 }
 
 proc assertFalse(x: bool, msg="") {
-  if verbose then writeln(msg);
+  if !correctness then writeln(msg);
   if x {
     writeln("Test Failed: ", msg);
     writeln("boolean is true");


### PR DESCRIPTION
Previously, `LinearAlgebra.diag()` only supported arrays declared over 0-based domains (with a `TODO` to throw an error if otherwise). This PR takes a different route on that `TODO` and adds support for non-0-based domains.

`diag()` and its helper procedures underwent significant refactoring as well.


Additionally, this PR introduces range-initializers for `Matrix` and `Vector`, e.g.

```chpl
var v = Vector(1..10);      // 10-element vector
var m = Matrix(1..4);       // square 4x4 matrix
var m = Matrix(1..4, 1..3); // 4x3 matrix
```

These overloads were utilized by the `diag()` procedures.

- [x] `test/modules/packages/LinearAlgebra` passes locally with MKL