### PR TITLE
Fix a bug for ambiguous param methods

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -3347,7 +3347,10 @@ static int disambiguateByMatch(CallInfo&                  info,
       // If there are *any* type/param candidates, we need to cause ambiguity
       // if they are not selected... including consideration of where clauses.
       bestValue  = disambiguateByMatch(candidates, DC, false, ambiguous);
-      retval     = 1;
+      if (bestValue)
+        retval = 1;
+      else
+        retval = 0;
 
     } else {
       if (nRef > 1 || nConstRef > 1 || nValue > 1) {

--- a/test/functions/resolution/ambig-param-overloads.bad
+++ b/test/functions/resolution/ambig-param-overloads.bad
@@ -1,8 +1,0 @@
-ambig-param-overloads.chpl:13: internal error: MIS0558 chpl Version 1.16.0 pre-release (2624f85)
-Note: This source location is a guess.
-
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
-and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
-please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
-

--- a/test/functions/resolution/ambig-param-overloads.future
+++ b/test/functions/resolution/ambig-param-overloads.future
@@ -1,1 +1,0 @@
-bug: seg fault on ambiguous overloaded param function


### PR DESCRIPTION
The disambiguateByMatch function was incorrectly returning 1 match when there
was no best match in this case. When there is no best match, return 0 instead.

Remove a .future and .bad for a test revealing this bug.  Fixes issue #6997.

Passed a full Linux64 paratest.