### PR TITLE
Remove LayoutCSR from docs

### DIFF
--- a/modules/Makefile
+++ b/modules/Makefile
@@ -127,7 +127,6 @@ DISTS_TO_DOCUMENT = \
 	dists/dims/BlockDim.chpl \
 	dists/dims/ReplicatedDim.chpl \
 	layouts/LayoutCS.chpl \
-	layouts/LayoutCSR.chpl \
 
 INTERNAL_MODULES_TO_DOCUMENT =                \
 	internal/Atomics.chpl                 \

--- a/modules/dists/fixDistDocs.perl
+++ b/modules/dists/fixDistDocs.perl
@@ -17,7 +17,6 @@ chdir $TEMPDIR or die "Could not cd to $TEMPDIR";
 
 my $errors = 0;
 
-process("../layouts/LayoutCSR.rst");
 process("../layouts/LayoutCS.rst");
 process("BlockDist.rst");
 process("CyclicDist.rst");


### PR DESCRIPTION
`LayoutCSR` is deprecated in 1.16 and the docs should be removed accordingly.