### PR TITLE
Retire future for non-broadcasted string

### DIFF
--- a/test/multilocale/bradc/globalConstRepl.chpl
+++ b/test/multilocale/bradc/globalConstRepl.chpl
@@ -22,7 +22,6 @@ on Locales[(here.id + 1) % numLocales] {
   writeln("i is ", i, " and is on locale: ", i.locale.id);
   writeln("c is ", c, " and is on locale: ", c.locale.id);
   writeln("e is ", e, " and is on locale: ", e.locale.id);
-  // This line should be commented out once stringConstRepl.future is retired
-  // writeln("s is ", s, " and is on locale: ", s.locale.id);
+  writeln("s is ", s, " and is on locale: ", s.locale.id);
   writeln("myR is ", myR, " and is on locale: ", myR.locale.id);
 }

--- a/test/multilocale/bradc/globalConstRepl.comm-none.good
+++ b/test/multilocale/bradc/globalConstRepl.comm-none.good
@@ -5,4 +5,5 @@ r is 3.4 and is on locale: 0
 i is 5.6i and is on locale: 0
 c is 7.8 + 9.0i and is on locale: 0
 e is red and is on locale: 0
+s is hi and is on locale: 0
 myR is (i = 11) and is on locale: 0

--- a/test/multilocale/bradc/globalConstRepl.good
+++ b/test/multilocale/bradc/globalConstRepl.good
@@ -5,4 +5,5 @@ r is 3.4 and is on locale: 1
 i is 5.6i and is on locale: 1
 c is 7.8 + 9.0i and is on locale: 1
 e is red and is on locale: 1
+s is hi and is on locale: 1
 myR is (i = 11) and is on locale: 1

--- a/test/multilocale/bradc/stringConstRepl.bad
+++ b/test/multilocale/bradc/stringConstRepl.bad
@@ -1,1 +1,0 @@
-s is hi and is on locale: 0

--- a/test/multilocale/bradc/stringConstRepl.chpl
+++ b/test/multilocale/bradc/stringConstRepl.chpl
@@ -1,5 +1,0 @@
-const s: string = "hi";
-
-on Locales[(here.id + 1) % numLocales] {
-  writeln("s is ", s, " and is on locale: ", s.locale.id);
-}

--- a/test/multilocale/bradc/stringConstRepl.comm-none.good
+++ b/test/multilocale/bradc/stringConstRepl.comm-none.good
@@ -1,1 +1,0 @@
-s is hi and is on locale: 0

--- a/test/multilocale/bradc/stringConstRepl.future
+++ b/test/multilocale/bradc/stringConstRepl.future
@@ -1,4 +1,0 @@
-bug: Global const strings are not replicated.
-
-Note that once this future is retired, the test should be removed and
-the appropriate line in globalConstRepl.chpl should be uncommented.

--- a/test/multilocale/bradc/stringConstRepl.good
+++ b/test/multilocale/bradc/stringConstRepl.good
@@ -1,1 +1,0 @@
-s is hi and is on locale: 1

--- a/test/multilocale/bradc/stringConstRepl.skipif
+++ b/test/multilocale/bradc/stringConstRepl.skipif
@@ -1,1 +1,0 @@
-CHPL_COMM==none


### PR DESCRIPTION
As of #7050 the 'stringConstRepl' future can be removed. A note in the .future file recommended that broadcasted strings be enabled in the 'globalConstRepl' test.