### PR TITLE
Removed OwnedObject; Reduced memory leaks

### DIFF
--- a/test/modules/packages/Toml/TOML.chpl
+++ b/test/modules/packages/Toml/TOML.chpl
@@ -726,7 +726,6 @@ pragma "no doc"
          }
          else {
 	   var ptrhold = currentLine;
-	   var ptrhol2 = tokenlist[tokenD.first];
 	   tokenlist.remove(tokenD.first);
            currentLine = tokenlist[tokenD.first];
 	   delete ptrhold;


### PR DESCRIPTION
This PR fixes the debugger for the toml parser as well as a few minor improvements in functionality and code cleanliness. The use of the OwnedObject module was the reason for the breakage of the debugger. OwnedObject also prevented the toml parser from deleting unnecessary tokens. This has also been fixed. 