### PR TITLE
Fix printMemAllocs

### DIFF
--- a/test/memory/shannon/printMemAllocs.chpl
+++ b/test/memory/shannon/printMemAllocs.chpl
@@ -11,39 +11,45 @@ var South : domain(2) = {n+1..n+1, 1..n};
 var A : [BigR] real;
 var Temp : [R] real;
 
-forall (i,j) in BigR {
-  A(i,j) = 0.0;
-}
-
-forall (i,j) in South {
-  A(i,j) = 1.0;
-}
-
-if (verbose) {
-  writeln("Initial configuration:");
-  writeln(A);
-}
-
 var iteration : int = 0;
 var delta : real = 1.0;
 
-while (delta > epsilon) {
-  forall (i,j) in R {
-    Temp(i,j) = (A(i-1,j) + A(i+1,j) + A(i,j-1) + A(i,j+1)) / 4.0;
+{ // these curly braces keep compiler-added
+  // temporary values from being reported
+  // in the below printMemAllocs...
+  // printMemAllocs prints entries for
+  // whatever is currently allocated.
+
+  forall (i,j) in BigR {
+    A(i,j) = 0.0;
   }
-  delta = 0.0;
-  for (i,j) in R {
-    delta = max(delta, Temp(i,j)-A(i,j));
-    A(i,j) = Temp(i,j);
+
+  forall (i,j) in South {
+    A(i,j) = 1.0;
   }
-  iteration += 1;
+
   if (verbose) {
-    writeln("iteration: ", iteration);
-    writeln("delta:     ", delta);
+    writeln("Initial configuration:");
     writeln(A);
   }
-}
 
+  while (delta > epsilon) {
+    forall (i,j) in R {
+      Temp(i,j) = (A(i-1,j) + A(i+1,j) + A(i,j-1) + A(i,j+1)) / 4.0;
+    }
+    delta = 0.0;
+    for (i,j) in R {
+      delta = max(delta, Temp(i,j)-A(i,j));
+      A(i,j) = Temp(i,j);
+    }
+    iteration += 1;
+    if (verbose) {
+      writeln("iteration: ", iteration);
+      writeln("delta:     ", delta);
+      writeln(A);
+    }
+  }
+}
 printMemAllocs(1000);
 
 writeln("Jacobi computation complete.");

--- a/test/memory/shannon/printMemAllocs2.chpl
+++ b/test/memory/shannon/printMemAllocs2.chpl
@@ -9,4 +9,4 @@ var d = new C();
 var e = new C();
 var f = new C();
 
-printMemAllocs(240, true);
+printMemAllocs(240);

--- a/test/memory/shannon/printMemAllocs2.chpl
+++ b/test/memory/shannon/printMemAllocs2.chpl
@@ -10,3 +10,8 @@ var e = new C();
 var f = new C();
 
 printMemAllocs(240);
+
+delete c;
+delete d;
+delete e;
+delete f;

--- a/test/memory/shannon/printMemAllocs2.execopts
+++ b/test/memory/shannon/printMemAllocs2.execopts
@@ -1,2 +1,1 @@
---memtrack
-
+--memTrack

--- a/test/memory/shannon/printMemAllocs2.future
+++ b/test/memory/shannon/printMemAllocs2.future
@@ -1,7 +1,0 @@
-semantic: memory testing
-
-What exactly is this testing?
-
-Was:
-bug: no way to distinguish new's that are explicit in user code from those
-that are not

--- a/test/memory/shannon/printMemAllocs2.good
+++ b/test/memory/shannon/printMemAllocs2.good
@@ -1,13 +1,9 @@
-
-================================================================================
-----------------------
-***Allocated Memory***
-----------------------
-Size:    Number:  Total:   Address:    Description:
-(bytes)           (bytes)  
-================================================================================
-8        32       256      0xnnnnnnnn  _data
-8        32       256      0xnnnnnnnn  _data
-8        32       256      0xnnnnnnnn  _data
-8        32       256      0xnnnnnnnn  _data
+=================================================================================================================
+Allocated Memory (Bytes)         Number   Size     Total    Description                      Address             
+=================================================================================================================
+printMemAllocs2.chpl:7           32       8        256      array elements                   0xnnnnnnnn  
+printMemAllocs2.chpl:8           32       8        256      array elements                   0xnnnnnnnn  
+printMemAllocs2.chpl:9           32       8        256      array elements                   0xnnnnnnnn  
+printMemAllocs2.chpl:10          32       8        256      array elements                   0xnnnnnnnn  
+=================================================================================================================
 


### PR DESCRIPTION
Note that printMemAllocs prints out currently allocated memory, and this test is meant to exercise that function.

PR #6942 changed the way that _freeIterator calls are added. In particular, it changed to use DeferStmt to add these calls. That generally improved correctenss but created an issue with this test in --baseline configurations.  In that configuration, the _freeIterator statement was added just after printMemAllocs when before the PR it was added just before. The reason for this has to do with the way that DeferStmt works - namely, it adds the defered statement at the end of the block. Currently, our forall scaffolding (at least in --baseline) doesn't add an enclosing block, so the block that the DeferStmt applied to was the block containing printMemAllocs, so the _freeIterator call ran after it).

While it's conceivable that this issue might impact other tests, it semes to only occur in --baseline. Additionally, the memory is getting freed, just not exactly where it was before. Thus I'm viewing it more as a curiousity and adding a simple workaround to the test. The workaround is to simply enclose the looops in the test in a block, so that the DeferStmt will run at the end of that block and before the call to printMemAllocs.

While there, cleaned up printMemAllocs2 and made it a regular test (see commits for details).  Verified that both printMemAllocs variants pass with or without --baseline.

Test update, not reviewed.
