### PR TITLE
Resolve expr 2

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5945,6 +5945,8 @@ void resolveBlockStmt(BlockStmt* blockStmt) {
 *                                                                             *
 ************************************** | *************************************/
 
+static Expr* resolveExprResolveEachCall(ContextCallExpr* cc);
+
 static Expr* resolveExprHandleTryFailure(FnSymbol* fn);
 
 static Expr* resolveExpr(Expr* expr) {
@@ -6007,89 +6009,8 @@ static Expr* resolveExpr(Expr* expr) {
       // For ContextCallExprs, be sure to resolve all of the
       // functions that could be called.
       if (ContextCallExpr* cc = toContextCallExpr(call->parentExpr)) {
-        CallExpr* refCall = NULL;
-        CallExpr* valueCall = NULL;
-        CallExpr* constRefCall = NULL;
+        expr = resolveExprResolveEachCall(cc);
 
-        cc->getCalls(refCall, valueCall, constRefCall);
-
-        FnSymbol* refFn = refCall?refCall->resolvedFunction():NULL;
-        FnSymbol* valueFn = valueCall?valueCall->resolvedFunction():NULL;
-        FnSymbol* constRefFn = constRefCall?constRefCall->resolvedFunction():NULL;
-
-        if (refFn)
-          resolveFns(refFn);
-        if (valueFn)
-          resolveFns(valueFn);
-        if (constRefFn)
-          resolveFns(constRefFn);
-
-        // TODO: pull this error checking out into a function call.
-
-        // Error checking. First, check all or none are iterators.
-        int n = 0;
-        int nIterator = 0;
-        if (refFn) {
-          n++;
-          nIterator += refFn->isIterator();
-        }
-        if (valueFn) {
-          n++;
-          nIterator += valueFn->isIterator();
-        }
-        if (constRefFn) {
-          n++;
-          nIterator += constRefFn->isIterator();
-        }
-        if (nIterator != 0 && nIterator != n) {
-          USR_FATAL_CONT(cc, "invalid ref return pair: mixing proc and iter");
-          if (refFn)
-            USR_FATAL_CONT(refFn, "here");
-          if (valueFn)
-            USR_FATAL_CONT(valueFn, "here");
-          if (constRefFn)
-            USR_FATAL_CONT(constRefFn, "here");
-        }
-        // Next, check that the return types match.
-        // This error is skipped for iterators because
-        // the return type of an iterator is e.g. an iterator record
-        // which is not the same as the yielded type.
-        if (nIterator == 0) {
-          Type* firstType = NULL;
-          bool typeError = false;
-          if (refFn) {
-            firstType = refFn->retType->getValType();
-          }
-          if (valueFn) {
-            Type* retType = valueFn->retType->getValType();
-            if (firstType == NULL)
-              firstType = retType;
-            if (firstType != retType)
-              typeError = true;
-          }
-          if (constRefFn) {
-            Type* retType = constRefFn->retType->getValType();
-            if (firstType != retType)
-              typeError = true;
-          }
-
-          if (typeError) {
-            USR_FATAL_CONT(cc, "invalid return intent overload: return types differ");
-            if (refFn)
-              USR_FATAL_CONT(refFn, "function returns %s",
-                             toString(refFn->retType));
-            if (valueFn)
-              USR_FATAL_CONT(valueFn, "function returns %s",
-                             toString(valueFn->retType));
-            if (constRefFn)
-              USR_FATAL_CONT(constRefFn, "function returns %s",
-                             toString(constRefFn->retType));
-            USR_STOP();
-          }
-        }
-
-        // Proceed using the designated call option
-        expr = getDesignatedCall(cc);
       } else {
         INT_ASSERT(call->isResolved());
         resolveFns(call->resolvedFunction());
@@ -6187,6 +6108,92 @@ static Expr* resolveExpr(Expr* expr) {
   }
 
   return postFold(expr);
+}
+
+static Expr* resolveExprResolveEachCall(ContextCallExpr* cc) {
+  CallExpr* refCall = NULL;
+  CallExpr* valueCall = NULL;
+  CallExpr* constRefCall = NULL;
+
+  cc->getCalls(refCall, valueCall, constRefCall);
+
+  FnSymbol* refFn = refCall?refCall->resolvedFunction():NULL;
+  FnSymbol* valueFn = valueCall?valueCall->resolvedFunction():NULL;
+  FnSymbol* constRefFn = constRefCall?constRefCall->resolvedFunction():NULL;
+
+  if (refFn)
+    resolveFns(refFn);
+  if (valueFn)
+    resolveFns(valueFn);
+  if (constRefFn)
+    resolveFns(constRefFn);
+
+  // TODO: pull this error checking out into a function call.
+
+  // Error checking. First, check all or none are iterators.
+  int n = 0;
+  int nIterator = 0;
+  if (refFn) {
+    n++;
+    nIterator += refFn->isIterator();
+  }
+  if (valueFn) {
+    n++;
+    nIterator += valueFn->isIterator();
+  }
+  if (constRefFn) {
+    n++;
+    nIterator += constRefFn->isIterator();
+  }
+  if (nIterator != 0 && nIterator != n) {
+    USR_FATAL_CONT(cc, "invalid ref return pair: mixing proc and iter");
+    if (refFn)
+      USR_FATAL_CONT(refFn, "here");
+    if (valueFn)
+      USR_FATAL_CONT(valueFn, "here");
+    if (constRefFn)
+      USR_FATAL_CONT(constRefFn, "here");
+  }
+  // Next, check that the return types match.
+  // This error is skipped for iterators because
+  // the return type of an iterator is e.g. an iterator record
+  // which is not the same as the yielded type.
+  if (nIterator == 0) {
+    Type* firstType = NULL;
+    bool typeError = false;
+    if (refFn) {
+      firstType = refFn->retType->getValType();
+    }
+    if (valueFn) {
+      Type* retType = valueFn->retType->getValType();
+      if (firstType == NULL)
+        firstType = retType;
+      if (firstType != retType)
+        typeError = true;
+    }
+    if (constRefFn) {
+      Type* retType = constRefFn->retType->getValType();
+      if (firstType != retType)
+        typeError = true;
+    }
+
+    if (typeError) {
+      USR_FATAL_CONT(cc, "invalid return intent overload: return types differ");
+      if (refFn)
+        USR_FATAL_CONT(refFn, "function returns %s",
+                       toString(refFn->retType));
+      if (valueFn)
+        USR_FATAL_CONT(valueFn, "function returns %s",
+                       toString(valueFn->retType));
+      if (constRefFn)
+        USR_FATAL_CONT(constRefFn, "function returns %s",
+                       toString(constRefFn->retType));
+      USR_STOP();
+    }
+  }
+
+  // Proceed using the designated call option
+  return getDesignatedCall(cc);
 }
 
 static Expr* resolveExprHandleTryFailure(FnSymbol* fn) {

--- a/test/functions/ferguson/ref-pair/ref-return-two-types.good
+++ b/test/functions/ferguson/ref-pair/ref-return-two-types.good
@@ -1,3 +1,3 @@
 ref-return-two-types.chpl:18: error: invalid return intent overload: return types differ
-ref-return-two-types.chpl:12: error: function returns real(64)
 ref-return-two-types.chpl:5: error: function returns R
+ref-return-two-types.chpl:12: error: function returns real(64)

--- a/test/functions/ferguson/ref-pair/ref-return-two-types2.good
+++ b/test/functions/ferguson/ref-pair/ref-return-two-types2.good
@@ -1,3 +1,3 @@
 ref-return-two-types2.chpl:18: error: invalid return intent overload: return types differ
-ref-return-two-types2.chpl:12: error: function returns real(64)
 ref-return-two-types2.chpl:5: error: function returns R
+ref-return-two-types2.chpl:12: error: function returns real(64)


### PR DESCRIPTION
Continue to simplify resolveExpr()

This PR extracts the core block that handles a ContextCallExpr*.  That code has
been converted to three functions; a primary helper and then two secondary helpers.

Compiled/tested with standard protocol
