### PR TITLE
Resolve expr 5

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5864,9 +5864,13 @@ static Expr* resolveExpr(Expr* expr) {
     }
   }
 
+  INT_ASSERT(tryFailure == false);
+
   if (CallExpr* call = toCallExpr(expr)) {
     expr = preFold(call);
   }
+
+  INT_ASSERT(tryFailure == false);
 
   if (expr                      != NULL      &&
       fn                        != NULL      &&
@@ -5874,6 +5878,8 @@ static Expr* resolveExpr(Expr* expr) {
       isParamResolved(fn, expr) == true) {
     return expr;
   }
+
+  INT_ASSERT(tryFailure == false);
 
   if (DefExpr* def = toDefExpr(expr)) {
     if (def->sym->hasFlag(FLAG_CHPL__ITER) == true) {
@@ -5887,6 +5893,8 @@ static Expr* resolveExpr(Expr* expr) {
     }
 
     callStack.add(call);
+
+    INT_ASSERT(tryFailure == false);
 
     resolveCall(call);
 
@@ -5911,10 +5919,14 @@ static Expr* resolveExpr(Expr* expr) {
 
     if (tryFailure == false) {
       callStack.pop();
+
+    } else {
+      return resolveExprHandleTryFailure(fn);
     }
   }
 
   if (tryFailure == true) {
+    INT_ASSERT(false);
     return resolveExprHandleTryFailure(fn);
   }
 

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5853,8 +5853,13 @@ static Expr* resolveExpr(Expr* expr) {
 
     if (ForallStmt* pfs = toForallStmt(expr->parentExpr)) {
       if (pfs->isIteratedExpression(expr) == true) {
-        // Note: this may set expr=NULL, tryFailure=true.
-        expr = resolveParallelIteratorAndForallIntents(pfs, se);
+        CallExpr* call = resolveParallelIteratorAndForallIntents(pfs, se);
+
+        if (tryFailure == false) {
+          expr = call;
+        } else {
+          return resolveExprHandleTryFailure(fn);
+        }
       }
     }
   }

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5864,13 +5864,9 @@ static Expr* resolveExpr(Expr* expr) {
     }
   }
 
-  INT_ASSERT(tryFailure == false);
-
   if (CallExpr* call = toCallExpr(expr)) {
     expr = preFold(call);
   }
-
-  INT_ASSERT(tryFailure == false);
 
   if (expr                      != NULL      &&
       fn                        != NULL      &&
@@ -5878,8 +5874,6 @@ static Expr* resolveExpr(Expr* expr) {
       isParamResolved(fn, expr) == true) {
     return expr;
   }
-
-  INT_ASSERT(tryFailure == false);
 
   if (DefExpr* def = toDefExpr(expr)) {
     if (def->sym->hasFlag(FLAG_CHPL__ITER) == true) {
@@ -5923,11 +5917,6 @@ static Expr* resolveExpr(Expr* expr) {
     } else {
       return resolveExprHandleTryFailure(fn);
     }
-  }
-
-  if (tryFailure == true) {
-    INT_ASSERT(false);
-    return resolveExprHandleTryFailure(fn);
   }
 
   if (SymExpr* symExpr = toSymExpr(expr)) {


### PR DESCRIPTION
Continue trivial refactoring of resolveExpr()

The focus of this PR was to manage the data-flow for tryFailure.

1. Make it clear that resolveParallelIteratorAndForallIntents() may set tryFailure
or else return a CallExpr*

2. Add a few asserts to verify the constraints on tryFailure.  Run paratest with
-futures for both single-locale and --no-local

3. Remove the asserts and make the relevant revisions for tryFailure

