### PR TITLE
Recursive skipif for ZMQ

### DIFF
--- a/test/modules/packages/ZMQ.skipif
+++ b/test/modules/packages/ZMQ.skipif
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+
+# The ZMQ package requires the zmq library.
+#
+# Installation of the ZMQ library is detected with the find_library function,
+# which looks for the appropriate dynamic library (e.g. libzmq.so).
+# Note that if the dynamic library is found, this test assumes that the
+# header and static library are available.
+
+from __future__ import print_function
+from ctypes.util import find_library
+
+print(find_library('zmq') is None)

--- a/test/modules/packages/ZMQ/SKIPIF
+++ b/test/modules/packages/ZMQ/SKIPIF
@@ -1,15 +1,8 @@
 #!/usr/bin/env python
 
-# The ZMQ package requires the zmq library.
-# Additionally, this testing is disabled currently for multi-locale runs.
-#
-# Installation of the ZMQ library is detected with the find_library function,
-# which looks for the appropriate dynamic library (e.g. libzmq.so).
-# Note that if the dynamic library is found, this test assumes that the
-# header and static library are available.
+# These tests are disabled currently for multi-locale runs.
 
 from __future__ import print_function
-from ctypes.util import find_library
 from os import environ
 
-print((find_library('zmq') is None) or (environ['CHPL_COMM'] != 'none'))
+print(environ['CHPL_COMM'] != 'none')

--- a/test/modules/packages/ZMQ/multilocale/SKIPIF
+++ b/test/modules/packages/ZMQ/multilocale/SKIPIF
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
-from ctypes.util import find_library
 from os import environ
 
-print((find_library('zmq') is None) or (environ['CHPL_COMM'] == 'none'))
+print(environ['CHPL_COMM'] == 'none')


### PR DESCRIPTION
Add a recursive `ZMQ.skipif` to skip all `ZMQ` tests if `zmq` C library is not found.

Specify `CHPL_COMM` requirements on a per-directory basis with a directory `SKIPIF`

### Testing

- [x] `CHPL_COMM=none`
- [x] `CHPL_COMM=gasnet` 