### PR TITLE
Include inherited methods when collecting methods for forwarding

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -2132,10 +2132,15 @@ static void collectVisibleMethodsNamed(Type*                   t,
     }
   }
 
-  // Collect also methods from whatever type t is instantiated from
   if (AggregateType* at = toAggregateType(t)) {
+    // Collect also methods from whatever type t is instantiated from
     if (at->instantiatedFrom != NULL) {
       collectVisibleMethodsNamed(at->instantiatedFrom, nameAstr, methods);
+    }
+
+    // Collect also methods from a parent class type
+    forv_Vec(Type, parent, at->dispatchParents) {
+      collectVisibleMethodsNamed(parent, nameAstr, methods);
     }
   }
 }

--- a/test/classes/ferguson/forwarding/forward-inherited.chpl
+++ b/test/classes/ferguson/forwarding/forward-inherited.chpl
@@ -1,0 +1,16 @@
+class Parent {
+  proc f() { writeln("Parent f called");}
+}
+
+class Child : Parent {
+  proc g() { writeln("Child g called");}
+}
+
+record wrapper {
+  var c:Child;
+  forwarding c;
+}
+
+var w : wrapper = new wrapper(new Child());
+w.f();
+w.g();

--- a/test/classes/ferguson/forwarding/forward-inherited.good
+++ b/test/classes/ferguson/forwarding/forward-inherited.good
@@ -1,0 +1,2 @@
+Parent f called
+Child g called


### PR DESCRIPTION
This was an omission from collectVisibleMethodsNamed.
The new test shows a case where it was not working before.

Thanks to @LouisJenkinsCS for pointing out the issue.

- [x] full local testing

Reviewed by @vasslitvinov - thanks!