### PR TITLE
Fix memory leaks with coforall/cobegin+errors

### DIFF
--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -1588,12 +1588,13 @@ static BlockStmt* buildLoweredCoforall(Expr* indices,
     block->insertAtHead(new CallExpr("_upEndCount", coforallCount, countRunningTasks, numTasks));
     block->insertAtHead(new CallExpr(PRIM_MOVE, numTasks, new CallExpr(".", iterator,  new_CStringSymbol("size"))));
     block->insertAtHead(new DefExpr(numTasks));
+    block->insertAtTail(new DeferStmt(new CallExpr("_endCountFree", coforallCount)));
     block->insertAtTail(new CallExpr("_waitEndCount", coforallCount, countRunningTasks, numTasks));
   } else {
     taskBlk->insertBefore(new CallExpr("_upEndCount", coforallCount, countRunningTasks));
+    block->insertAtTail(new DeferStmt(new CallExpr("_endCountFree", coforallCount)));
     block->insertAtTail(new CallExpr("_waitEndCount", coforallCount, countRunningTasks));
   }
-  block->insertAtTail(new CallExpr("_endCountFree", coforallCount));
 
   block->insertAtHead(new CallExpr(PRIM_MOVE, coforallCount, new CallExpr("_endCountAlloc", useLocalEndCount)));
   block->insertAtHead(new DefExpr(coforallCount));
@@ -2962,8 +2963,8 @@ buildCobeginStmt(CallExpr* byref_vars, BlockStmt* block) {
 
   block->insertAtHead(new CallExpr(PRIM_MOVE, cobeginCount, new CallExpr("_endCountAlloc", /* forceLocalTypes= */gTrue)));
   block->insertAtHead(new DefExpr(cobeginCount));
+  block->insertAtTail(new DeferStmt(new CallExpr("_endCountFree", cobeginCount)));
   block->insertAtTail(new CallExpr("_waitEndCount", cobeginCount));
-  block->insertAtTail(new CallExpr("_endCountFree", cobeginCount));
 
   block->astloc = cobeginCount->astloc; // grab the location of 'cobegin' kw
   return block;

--- a/compiler/passes/createTaskFunctions.cpp
+++ b/compiler/passes/createTaskFunctions.cpp
@@ -222,7 +222,7 @@ static Expr* findTailInsertionPoint(Expr* fromHere, bool isCoforall) {
 
   // MPF 2017-08-25:
   // This used to also cover _endCountFree, but now it is in
-  // a DeferStmt before _waitEndCount, so funding _waitEndCount is
+  // a DeferStmt before _waitEndCount, so finding _waitEndCount is
   // sufficient.
   return result;
 }

--- a/compiler/passes/createTaskFunctions.cpp
+++ b/compiler/passes/createTaskFunctions.cpp
@@ -220,12 +220,11 @@ static Expr* findTailInsertionPoint(Expr* fromHere, bool isCoforall) {
 
   INT_ASSERT(result);
 
-  CallExpr* freeEC = toCallExpr(result->next);
-
-  // Currently these two calls come together.
-  INT_ASSERT(freeEC && freeEC->isNamed("_endCountFree"));
-
-  return freeEC;
+  // MPF 2017-08-25:
+  // This used to also cover _endCountFree, but now it is in
+  // a DeferStmt before _waitEndCount, so funding _waitEndCount is
+  // sufficient.
+  return result;
 }
 
 /*


### PR DESCRIPTION
Recent work on error handling with coforall/cobegin made waitEndCount
possibly throw. In that event, the following call (which was to
_endCountFree) would not run. This lead to 48-byte memory leaks in a
variety of tests in test/errhandling/parallel.

This commit fixes the issue by putting the call to _endCountFree in a
DeferStmt just before waitEndCount.

- [x] verified no memory leaks in test/errhandling/parallel (when recent other PRs are included)
- [x] full local testing
- [x] test/errorhandling with gasnet

Reviewed by @psahabu - thanks!