### PR TITLE
Fix for mason testing error on Cygwin

### DIFF
--- a/test/mason/PREEXEC
+++ b/test/mason/PREEXEC
@@ -6,7 +6,7 @@ REGISTRY=https://github.com/chapel-lang/mason-registry
 MASON_HOME=$PWD
 
 # Make fake MASON_HOME
-mkdir -p /$MASON_HOME/.mason
+mkdir $MASON_HOME/.mason
 
 # Clone registry
 if [ ! -d $MASON_HOME/.mason/registry ] ; then

--- a/test/mason/SKIPIF
+++ b/test/mason/SKIPIF
@@ -5,6 +5,6 @@ mason requires CHPL_COMM=none (local)
 """
 
 from __future__ import print_function
+from os import environ
 
-
-print('CHPL_COMM' != 'none' or 'CHPL_REGEXP' != 're2')
+print(environ['CHPL_COMM'] != 'none' or environ['CHPL_REGEXP'] != 're2')

--- a/test/mason/SKIPIF
+++ b/test/mason/SKIPIF
@@ -5,6 +5,6 @@ mason requires CHPL_COMM=none (local)
 """
 
 from __future__ import print_function
-from os import environ
 
-print(environ['CHPL_COMM'] != 'none')
+
+print('CHPL_COMM' != 'none' or 'CHPL_REGEXP' != 're2')


### PR DESCRIPTION
This is an update to the PREEXEC and the SKIPIF for mason. This will make mason testing pass on cygwin. 