### PR TITLE
Mason doc, runtime/compile args, TOML update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ chplvis: compiler third-party-fltk FORCE
 	cd tools/chplvis && $(MAKE)
 	cd tools/chplvis && $(MAKE) install
 
-mason: compiler FORCE
+mason: compiler chpldoc FORCE
 	cd tools/mason && $(MAKE)
 	cd tools/mason && $(MAKE) install
 

--- a/doc/rst/tools/mason/mason.rst
+++ b/doc/rst/tools/mason/mason.rst
@@ -79,7 +79,7 @@ When invoked, ``mason build [ options ]`` will do the following:
 
     - Invoke build.
     - Run the resulting executable out of ``target/``, if it exists.
-    - All options not recongized by ``mason`` will be forwarded to the executable.
+    - All options not recognized by ``mason`` will be forwarded to the executable.
         
 For example, after ``mason run [ options ]``, the project directory appears as so::
 
@@ -137,7 +137,7 @@ To try out different values at runtime, pass the values for ``number`` to ``maso
 
    For the case when a flag intended for the ``chpl`` compiler or executable is recognized by 
    ``mason build`` or ``mason run``, respectively, the flag can be thrown after ``--`` 
-   to override this conflict. For example, ``mason run -- -nl 4``. Intsead of mason recognizing
+   to override this conflict. For example, ``mason run -- -nl 4``. Instead of mason recognizing
    this argument, this command will run the executable over 4 locales.
 
 

--- a/doc/rst/tools/mason/mason.rst
+++ b/doc/rst/tools/mason/mason.rst
@@ -73,11 +73,13 @@ When invoked, ``mason build [ options ]`` will do the following:
     - Run update to make sure any manual manifest edits are reflected in the dependency code.
     - Build ``MyPackage.chpl`` in the ``src/`` directory. 
     - All packages are compiled into binaries and placed into ``target/``
+    - All options not recognized by ``mason`` will be forwarded to the chapel compiler(``chpl``)
 
 ``mason run [ options ]`` will, in turn:
 
     - Invoke build.
-    - Run the resulting executable out of target/, if it exists.
+    - Run the resulting executable out of ``target/``, if it exists.
+    - All options not recongized by ``mason`` will be forwarded to the executable.
         
 For example, after ``mason run [ options ]``, the project directory appears as so::
 
@@ -89,13 +91,17 @@ For example, after ``mason run [ options ]``, the project directory appears as s
 	MyPackage.chpl
       target/
 	debug/
-      	release/
+       (release/)
 	  MyPackage
+
 	
-   
-Projects can also be multiple files. Mason handles this by forwarding all arguments
-not recognized by Mason to the chapel compiler(``chpl``). For example, lets say MyPackage's
-structure is as follows::
+For projects that span multiple files, the main module is designated by the module that 
+shares the name with the package directory and the name field in the ``Mason.toml``.
+
+
+For projects that span multiple sub-directories within ``src``, sub-directories must be passed 
+to Mason with the ``-M  <src/subdirectory>`` flag which is forwarded to the chapel compiler. For example, lets say
+MyPackage's structure is as follows::
 
 
     MyPackage/
@@ -104,29 +110,35 @@ structure is as follows::
       src/
 	MyPackage.chpl
 	MySubPackage.chpl
-      util/
-	MyPackageUtils.chpl
+        util/
+	  MyPackageUtils.chpl
       target/
 	debug/
-	 MyPackage
+	  MyPackage
 
 
 If MyPackage needs multiple files in different directories like the example above,
 then call ``mason build`` with the ``-M`` flag followed by the local dependencies.
-A full command of this example would be: 
+A full command of this example would be:: 
 
-  ``mason build -M util/MyPackageUtils.chpl -M src/MySubPackage.chpl``
+  mason build -M src/util/MyPackageUtils.chpl
 
 
-The same goes to execution options at runtime. When calling ``mason run``, any arguments after
-``mason run`` not recognized by mason are forwarded to the runtime environment. For example,
-a chapel program built in mason might have a ``config const number`` that corresponds to a 
-value used in ``MyPackage.chpl``. To try out different values at runtime, pass the values for
-``number`` to ``mason run`` as follows:
 
-    ``mason run --number=100``
-    ``mason run --number=1000``
+For an example of forwarding arguments in a call to ``mason run``, a chapel program built in 
+mason might have a ``config const number`` that corresponds to a value used in ``MyPackage.chpl``.
+To try out different values at runtime, pass the values for ``number`` to ``mason run`` as follows::
 
+      mason run --number=100
+      mason run --number=1000
+
+
+.. note:: 
+
+   For the case when a flag intended for the ``chpl`` compiler or executable is recognized by 
+   ``mason build`` or ``mason run``, respectively, the flag can be thrown after ``--`` 
+   to override this conflict. For example, ``mason run -- -nl 4``. Intsead of mason recognizing
+   this argument, this command will run the executable over 4 locales.
 
 
 

--- a/doc/rst/tools/mason/mason.rst
+++ b/doc/rst/tools/mason/mason.rst
@@ -104,17 +104,18 @@ structure is as follows::
       src/
 	MyPackage.chpl
 	MySubPackage.chpl
-	MySubPackage2.chpl
+      util/
+	MyPackageUtils.chpl
       target/
 	debug/
 	 MyPackage
 
 
-If MyPackage needs all the files in ``src``(MyPackage, MySubPackage, and MySubPackage2), 
+If MyPackage needs multiple files in different directories like the example above,
 then call ``mason build`` with the ``-M`` flag followed by the local dependencies.
 A full command of this example would be: 
 
-  ``mason build -M src/MySubPackage.chpl -M src/MySubPackage2.chpl``
+  ``mason build -M util/MyPackageUtils.chpl -M src/MySubPackage.chpl``
 
 
 The same goes to execution options at runtime. When calling ``mason run``, any arguments after

--- a/doc/rst/tools/mason/mason.rst
+++ b/doc/rst/tools/mason/mason.rst
@@ -93,8 +93,38 @@ For example, after ``mason run [ options ]``, the project directory appears as s
 	  MyPackage
 	
    
+Projects can also be multiple files. Mason handles this by forwarding all arguments
+not recognized by Mason to the chapel compiler(``chpl``). For example, lets say MyPackage's
+structure is as follows::
 
 
+    MyPackage/
+      Mason.toml
+      Mason.lock
+      src/
+	MyPackage.chpl
+	MySubPackage.chpl
+	MySubPackage2.chpl
+      target/
+	debug/
+	 MyPackage
+
+
+If MyPackage needs all the files in ``src``(MyPackage, MySubPackage, and MySubPackage2), 
+then call ``mason build`` with the ``-M`` flag followed by the local dependencies.
+A full command of this example would be: 
+
+  ``mason build -M src/MySubPackage.chpl -M src/MySubPackage2.chpl``
+
+
+The same goes to execution options at runtime. When calling ``mason run``, any arguments after
+``mason run`` not recognized by mason are forwarded to the runtime environment. For example,
+a chapel program built in mason might have a ``config const number`` that corresponds to a 
+value used in ``MyPackage.chpl``. To try out different values at runtime, pass the values for
+``number`` to ``mason run`` as follows:
+
+    ``mason run --number=100``
+    ``mason run --number=1000``
 
 
 

--- a/test/mason/simple.good
+++ b/test/mason/simple.good
@@ -1,13 +1,13 @@
 
-[_MasonTest1]
-name = "_MasonTest1"
-version = "0.2.0"
-source = "https://github.com/Spartee/_MasonTest1"
-
 [root]
 name = "Tester"
 version = "0.1.0"
 author = "Sam Partee"
 dependencies = ["_MasonTest1 0.2.0 https://github.com/Spartee/_MasonTest1"]
+
+[_MasonTest1]
+name = "_MasonTest1"
+version = "0.2.0"
+source = "https://github.com/Spartee/_MasonTest1"
 
 

--- a/test/modules/packages/Toml/TOML.chpl
+++ b/test/modules/packages/Toml/TOML.chpl
@@ -513,9 +513,14 @@ Parser module with the Toml class for the Chapel TOML library.
 
      pragma "no doc"
      proc printHelp(flat: [?d] Toml, f:channel) {
+       if d.member('root') {
+	 f.writeln('[root]');
+	 printValues(f, flat['root']);
+	 d.remove('root');
+       }
        for k in d.sorted() {
-         f.writeln('[', k, ']');
-         printValues(f, flat[k]);
+	 f.writeln('[', k, ']');
+	 printValues(f, flat[k]);
        }
      }
 

--- a/tools/mason/MasonHelp.chpl
+++ b/tools/mason/MasonHelp.chpl
@@ -21,7 +21,7 @@ proc masonHelp() {
   writeln('    update      Update/Generate Mason.lock');
   writeln('    build       Compile the current project');
   writeln('    clean       Remove the target directory');
-  //writeln('    doc         Build this project\'s and its dependencies\' documentation');
+  writeln('    doc         Build this project\'s documentation');
   //writeln('    init        Create a new mason project in an existing directory');
   writeln('    run         Build and execute src/<project name>.chpl');
 }

--- a/tools/mason/mason.chpl
+++ b/tools/mason/mason.chpl
@@ -49,6 +49,7 @@ proc main(args: [] string) {
   when 'build' do masonBuild(args);
   when 'update' do UpdateLock();
   when 'run' do masonRun(args);
+  when 'doc' do masonDoc(args);
   when 'clean' do masonClean();
   when '--list' do masonList();
   when '-h' do masonHelp();
@@ -116,10 +117,28 @@ proc masonClean() {
   runCommand('rm -rf target');
 }
 
+ 
+proc masonDoc(args) {
+  var toDoc = basename(getEnv('PWD'));
+  var project = toDoc + '.chpl';
+  if isDir('src/') {
+    if isFile('src/' + project) {
+      var command = 'chpldoc src/' + project;
+      writeln(command);
+      runCommand(command);
+    }
+  }
+  else {
+    writeln('Mason could not find the project to document!');
+    runCommand('chpldoc');
+  }
+}
+
+
 
 // TODO
 proc masonInit(args) {}
-proc masonDoc(args) {}
+
 
 
 proc printVersion() {


### PR DESCRIPTION
This Pr includes three features: an update to the documentation on runtime and compile time args; the mason doc command, and an update to the TOML library.  Two of these features are listed and will by crossed off the mason issue #7106. 

First, an update to the documentation about how mason now supports forwarding all compile time and runtime arguments with examples that are hopefully clear. This was one of the first bits of feedback we got, so it was important that it got documented well.

Second, a first pass at a ``mason doc`` procedure has been introduced. It does not currently document dependencies, but does document the main file of the project. Documenting dependencies will be a "next step".

Third, the toml library has been adjusted so that if any Mason.lock file is generated, we now ensure that, for readability, the main project signified by "[root]" will always be printed at the top of the lock file. 

All local testing had passed for these changes. 

