### PR TITLE
Remove undefined behavior from a test

### DIFF
--- a/test/spec/marybeth/casts.chpl
+++ b/test/spec/marybeth/casts.chpl
@@ -9,18 +9,6 @@ writeln(z);
 
 var m = 2: int(64);
 var n = 2: int(32);
-var i = 1;
-var j = 1;
 
-while (n > 0) do {
-  n *= 2;
-  i += 1;
-}
-
-while (m > 0) do {
-  m *= 2;
-  j += 1;
-}
-
-writeln("For 32-bit integers, 2 ** (",i,") overflows.");
-writeln("For 64-bit integers, 2 ** (",j,") overflows.");
+writeln("The maximum 32-bit integer is: ", max(n.type));
+writeln("The maximum 64-bit integer is: ", max(m.type));

--- a/test/spec/marybeth/casts.chpl
+++ b/test/spec/marybeth/casts.chpl
@@ -7,8 +7,20 @@ writeln(x);
 writeln(y);
 writeln(z);
 
-var m = 2: int(64);
-var n = 2: int(32);
+var m = 2: uint(64);
+var n = 2: uint(32);
+var i = 1;
+var j = 1;
 
-writeln("The maximum 32-bit integer is: ", max(n.type));
-writeln("The maximum 64-bit integer is: ", max(m.type));
+while (n > 0) do {
+  n *= 2;
+  i += 1;
+}
+
+while (m > 0) do {
+  m *= 2;
+  j += 1;
+}
+
+writeln("For 32-bit integers, 2 ** (",i,") overflows.");
+writeln("For 64-bit integers, 2 ** (",j,") overflows.");

--- a/test/spec/marybeth/casts.good
+++ b/test/spec/marybeth/casts.good
@@ -1,5 +1,5 @@
 2.56 + 9.0i
 3.12 + 8.7i
 (4.2, 6.1)
-For 32-bit integers, 2 ** (31) overflows.
-For 64-bit integers, 2 ** (63) overflows.
+The maximum 32-bit integer is: 2147483647
+The maximum 64-bit integer is: 9223372036854775807

--- a/test/spec/marybeth/casts.good
+++ b/test/spec/marybeth/casts.good
@@ -1,5 +1,5 @@
 2.56 + 9.0i
 3.12 + 8.7i
 (4.2, 6.1)
-The maximum 32-bit integer is: 2147483647
-The maximum 64-bit integer is: 9223372036854775807
+For 32-bit integers, 2 ** (32) overflows.
+For 64-bit integers, 2 ** (64) overflows.


### PR DESCRIPTION
There was undefined behavior in `test/marybeth/casts` that was being used to detect the undefined behavior of a signed overflow.  This change replaces the signed integers with unsigned integers, eliminating the undefined behavior but still achieving the intended test.