### PR TITLE
Improve domain.add documentation

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1294,6 +1294,8 @@ module ChapelArray {
 
     /* Add index ``i`` to this domain. This method is also available
        as the ``+=`` operator.
+
+       The domain must be irregular.
      */
     proc add(i) {
       return _value.dsiAdd(i);


### PR DESCRIPTION
Adds a note to domain.add method to indicate that it is only applicable for irregular domains.