### PR TITLE
Func resolve tweaks

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -88,20 +88,34 @@ public:
 //#
 //# Global Variables
 //#
-bool            resolved         = false;
-int             explainCallLine  = 0;
-bool            tryFailure       = false;
-bool            beforeLoweringForallStmts = true;
+char                             arrayUnrefName[] = "array_unref_ret_tmp";
 
-char            arrayUnrefName[] = "array_unref_ret_tmp";
+bool                             resolved                  = false;
+bool                             tryFailure                = false;
+bool                             beforeLoweringForallStmts = true;
 
-SymbolMap       paramMap;
+int                              explainCallLine           = 0;
 
-Vec<CallExpr*>  callStack;
-Vec<CallExpr*>  inits;
-Vec<CondStmt*>  tryStack;
+SymbolMap                        paramMap;
 
-Vec<BlockStmt*> standardModuleSet;
+Vec<CallExpr*>                   callStack;
+Vec<CallExpr*>                   inits;
+
+Vec<CondStmt*>                   tryStack;
+
+Vec<BlockStmt*>                  standardModuleSet;
+
+std::map<CallExpr*, CallExpr*>   eflopiMap;
+
+std::map<Type*,     FnSymbol*>   autoCopyMap;
+std::map<Type*,     Serializers> serializeMap;
+
+Map<Type*,          FnSymbol*>   autoDestroyMap;
+Map<Type*,          FnSymbol*>   unaliasMap;
+Map<Type*,          FnSymbol*>   valueToRuntimeTypeMap;
+Map<FnSymbol*,      FnSymbol*>   iteratorLeaderMap;
+Map<FnSymbol*,      FnSymbol*>   iteratorFollowerMap;
+
 
 
 //#
@@ -113,7 +127,7 @@ static Vec<FnSymbol*> resolvedFormals;
 
 static Map<Type*,Type*> runtimeTypeMap; // map static types to runtime types
                                         // e.g. array and domain runtime types
-Map<Type*,FnSymbol*> valueToRuntimeTypeMap; // convertValueToRuntimeType
+
 static Map<Type*,FnSymbol*> runtimeTypeToValueMap; // convertRuntimeTypeToValue
 
 // map of compiler warnings that may need to be reissued for repeated
@@ -126,15 +140,7 @@ static Map<Type*,FnSymbol*> runtimeTypeToValueMap; // convertRuntimeTypeToValue
 static Map<FnSymbol*,const char*> innerCompilerWarningMap;
 static Map<FnSymbol*,const char*> outerCompilerWarningMap;
 
-std::map<Type*,FnSymbol*> autoCopyMap; // type to chpl__autoCopy function
-Map<Type*,FnSymbol*> autoDestroyMap; // type to chpl__autoDestroy function
-Map<Type*,FnSymbol*> unaliasMap; // type to chpl__unalias function
 
-std::map<Type*, Serializers> serializeMap;
-
-Map<FnSymbol*,FnSymbol*> iteratorLeaderMap; // iterator->leader map for promotion
-Map<FnSymbol*,FnSymbol*> iteratorFollowerMap; // iterator->leader map for promotion
-std::map<CallExpr*, CallExpr*> eflopiMap; // for-loops over par iterators
 
 //#
 //# Static Function Declarations

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -167,7 +167,6 @@ static bool
 isMoreVisible(Expr* expr, FnSymbol* fn1, FnSymbol* fn2);
 static CallExpr* userCall(CallExpr* call);
 static void reissueCompilerWarning(const char* str, int offset);
-static Expr* resolveTypeExpr(Expr* expr);
 static Type* resolveDefaultGenericTypeSymExpr(SymExpr* se);
 
 static FnSymbol* resolveNormalCall(CallExpr* call, bool checkonly=false);
@@ -349,33 +348,49 @@ hasUserAssign(Type* type) {
   return !compilerAssign;
 }
 
+/************************************* | **************************************
+*                                                                             *
+*                                                                             *
+*                                                                             *
+************************************** | *************************************/
+
 bool hasAutoCopyForType(Type* type) {
-  std::map<Type*,FnSymbol*>::iterator it = autoCopyMap.find(type);
+  std::map<Type*, FnSymbol*>::iterator it = autoCopyMap.find(type);
+
   return autoCopyMap.find(type) != autoCopyMap.end() && it->second != NULL;
 }
 
 // This function is intended to protect gets from the autoCopyMap so that
 // we can insert NULL values for a type and avoid segfaults
 FnSymbol* getAutoCopyForType(Type* type) {
-  std::map<Type*,FnSymbol*>::iterator it = autoCopyMap.find(type);
+  std::map<Type*, FnSymbol*>::iterator it = autoCopyMap.find(type);
+
   if (it == autoCopyMap.end() || it->second == NULL) {
-    INT_FATAL(type, "Trying to obtain autoCopy for type '%s',"
-                    " which defines none", type->symbol->name);
+    INT_FATAL(type,
+              "Trying to obtain autoCopy for type '%s', which defines none",
+              type->symbol->name);
   }
+
   return it->second;
 }
 
-void getAutoCopyTypeKeys(Vec<Type*> &keys) {
-  for (std::map<Type*, FnSymbol*>::iterator it = autoCopyMap.begin();
-       it != autoCopyMap.end(); ++it) {
+void getAutoCopyTypeKeys(Vec<Type*>& keys) {
+  std::map<Type*, FnSymbol*>::iterator it;
+
+  for (it = autoCopyMap.begin(); it != autoCopyMap.end(); ++it) {
     keys.add(it->first);
   }
 }
 
+/************************************* | **************************************
+*                                                                             *
+*                                                                             *
+*                                                                             *
+************************************** | *************************************/
+
 // This function is called by generic instantiation
 // for the default initCopy function in ChapelBase.chpl.
-bool fixupDefaultInitCopy(FnSymbol* fn, FnSymbol* newFn, CallExpr* call)
-{
+bool fixupDefaultInitCopy(FnSymbol* fn, FnSymbol* newFn, CallExpr* call) {
   ArgSymbol* arg = newFn->getFormal(1);
 
   if (AggregateType* ct = toAggregateType(arg->type)) {


### PR DESCRIPTION
Trivial clean up in functionResolution.cpp

This PR collects a handful of trivial clean up operations within functionResolution.cpp that I
notice from time to time when debugging but consistently fail to ever apply to master.  These
are things like formatting to 80 columns, cleaning up indentation errors, and other minor
non-functional cleanup.

Passed the conventional compilation/testing protocol.