### PR TITLE
Fix constness error with stringify function

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -3352,7 +3352,7 @@ proc _stringify_tuple(tup:?t) where isTuple(t)
     Writes each argument, possibly using a `writeThis` method,
     to a string and returns the result.
   */
-proc stringify(args ...?k):string {
+proc stringify(const args ...?k):string {
   if _can_stringify_direct(args) {
     // As an optimization, use string concatenation for
     // all primitive type stringify...

--- a/test/functions/ferguson/ref-pair/constArrayHalt.chpl
+++ b/test/functions/ferguson/ref-pair/constArrayHalt.chpl
@@ -1,0 +1,5 @@
+
+proc main() {
+  const A : [1..10] int;
+  halt(A);
+}

--- a/test/functions/ferguson/ref-pair/constArrayHalt.good
+++ b/test/functions/ferguson/ref-pair/constArrayHalt.good
@@ -1,0 +1,1 @@
+constArrayHalt.chpl:4: error: halt reached - 0 0 0 0 0 0 0 0 0 0


### PR DESCRIPTION
The lack of the 'const' intent on stringify's formals was causing constness failures for standard functions like halt, warning, and assert. For example, the compiler would emit a failure if a user passed a const array to halt(). This is similar to the solution from writeln.

Testing:
- [x] full local