### PR TITLE
APU locale model

### DIFF
--- a/modules/internal/LocaleModelHelpAPU.chpl
+++ b/modules/internal/LocaleModelHelpAPU.chpl
@@ -1,5 +1,7 @@
 /*
  * Copyright 2017 Advanced Micro Devices, Inc.
+ * Copyright 2004-2017 Cray Inc.
+ * Other additional copyright holders may be indicated within.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/internal/LocaleModelHelpAPU.chpl
+++ b/modules/internal/LocaleModelHelpAPU.chpl
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2017 Advanced Micro Devices, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module LocaleModelHelpAPU {
+
+  param localeModelHasSublocales = true;
+
+  use LocaleModelHelpSetup;
+  use LocaleModelHelpRuntime;
+
+  //////////////////////////////////////////
+  //
+  // utilities
+  //
+  inline
+  proc chpl_getSubloc() {
+    extern proc chpl_task_getSubloc(): chpl_sublocID_t;
+    return chpl_task_getSubloc();
+  }
+
+  //////////////////////////////////////////
+  //
+  // support for "on" statements
+  //
+
+  //
+  // runtime interface
+  //
+  extern proc chpl_task_setSubloc(subloc: int(32));
+
+  //
+  // returns true if an executeOn can be handled directly
+  // by running the function in question.
+  // Applies to execute on and execute on fast.
+  // When performing a blocking on, the compiler will emit this sequence:
+  //
+  //  if (chpl_doDirectExecuteOn(targetLocale))
+  //         onStatementBodyFunction( args ... );
+  //  else
+  //         chpl_executeOn / chpl_executeOnFast
+  //
+  export
+  proc chpl_doDirectExecuteOn(loc: chpl_localeID_t // target locale
+                             ):bool {
+    const dnode =  chpl_nodeFromLocaleID(loc);
+    const dsubloc =  chpl_sublocFromLocaleID(loc);
+
+    if (dnode != chpl_nodeID) {
+      return false; // need to move to different node
+    } else {
+      var origSubloc = chpl_task_getRequestedSubloc();
+      if (dsubloc==c_sublocid_any || dsubloc==origSubloc) {
+        return true;
+      } else {
+        return false; // need to move to different sublocale
+      }
+    }
+  }
+
+  //
+  // regular "on"
+  //
+  pragma "insert line file info"
+  export
+  proc chpl_executeOn(loc: chpl_localeID_t, // target locale
+                      fn: int,              // on-body function idx
+                      args: chpl_comm_on_bundle_p,     // function args
+                      args_size: size_t     // args size
+                     ) {
+    const dnode =  chpl_nodeFromLocaleID(loc);
+    const dsubloc =  chpl_sublocFromLocaleID(loc);
+    if (dsubloc == 0) {
+        warning("executing on CPU");
+    }
+    else if (dsubloc == 1) {
+        warning("executing on GPU");
+    }
+
+   if dnode != chpl_nodeID {
+      chpl_comm_execute_on(dnode, dsubloc, fn, args, args_size);
+    } else {
+      // run directly on this node
+      var origSubloc = chpl_task_getRequestedSubloc();
+      if (dsubloc==c_sublocid_any || dsubloc==origSubloc) {
+        chpl_ftable_call(fn, args);
+      } else {        
+        // move to a different sublocale
+        chpl_task_setSubloc(dsubloc);
+        chpl_ftable_call(fn, args);
+        chpl_task_setSubloc(origSubloc);
+      }
+    }
+  }
+
+  //
+  // fast "on" (doesn't do anything that could deadlock a comm layer,
+  // in the Active Messages sense)
+  //
+  pragma "insert line file info"
+  export
+  proc chpl_executeOnFast(loc: chpl_localeID_t, // target locale
+                          fn: int,              // on-body function idx
+                          args: chpl_comm_on_bundle_p,     // function args
+                          args_size: size_t     // args size
+                         ) {
+    const dnode =  chpl_nodeFromLocaleID(loc);
+    const dsubloc =  chpl_sublocFromLocaleID(loc);
+    if dnode != chpl_nodeID {
+      chpl_comm_execute_on_fast(dnode, dsubloc, fn, args, args_size);
+    } else {
+      var origSubloc = chpl_task_getRequestedSubloc();
+      if (dsubloc==c_sublocid_any || dsubloc==origSubloc) {
+        chpl_ftable_call(fn, args);
+      } else {
+        // move to a different sublocale
+        chpl_task_setSubloc(dsubloc);
+        chpl_ftable_call(fn, args);
+        chpl_task_setSubloc(origSubloc);
+      }
+    }
+  }
+
+  //
+  // nonblocking "on" (doesn't wait for completion)
+  //
+  pragma "insert line file info"
+  export
+  proc chpl_executeOnNB(loc: chpl_localeID_t, // target locale
+                        fn: int,              // on-body function idx
+                        args: chpl_comm_on_bundle_p,     // function args
+                        args_size: size_t     // args size
+                       ) {
+    //
+    // If we're in serial mode, we should use blocking rather than
+    // non-blocking "on" in order to serialize the execute_ons.
+    //
+    const dnode =  chpl_nodeFromLocaleID(loc);
+    const dsubloc =  chpl_sublocFromLocaleID(loc);
+    if dnode == chpl_nodeID {
+      if __primitive("task_get_serial") then
+        chpl_ftable_call(fn, args);
+      else
+        chpl_comm_taskCallFTable(fn, args, args_size, dsubloc);
+    } else {
+      if __primitive("task_get_serial") then
+        chpl_comm_execute_on(dnode, dsubloc, fn, args, args_size);
+      else
+        chpl_comm_execute_on_nb(dnode, dsubloc, fn, args, args_size);
+    }
+  }
+}

--- a/modules/internal/LocaleModelHelpSetup.chpl
+++ b/modules/internal/LocaleModelHelpSetup.chpl
@@ -168,12 +168,7 @@ module LocaleModelHelpSetup {
   }
 
   proc helpSetupLocaleAPU(dst:LocaleModel, out local_name:string, out numSublocales) {
-    const _node_id = chpl_nodeID: int;
-
     helpSetupLocaleFlat(dst, local_name);
-
-    extern proc chpl_task_getNumSublocales(): int(32);
-    numSublocales = chpl_task_getNumSublocales();
 
     extern proc chpl_task_getMaxPar(): uint(32);
 
@@ -184,13 +179,6 @@ module LocaleModelHelpSetup {
     //    if (initHsa == 1) {
     //      halt("Could not initialize HSA");
     //    }
-
-    var comm, spawnfn : c_string;
-    extern proc chpl_nodeName() : c_string;
-    if sys_getenv("CHPL_COMM".c_str(), comm) == 0 && comm == "gasnet" &&
-       sys_getenv("GASNET_SPAWNFN".c_str(), spawnfn) == 0 && spawnfn == "L"
-    then local_name = chpl_nodeName():string + "-" + _node_id : string;
-    else local_name = chpl_nodeName():string;
 
     // Hardcode two sublocales, 1 CPU and 1 GPU
     numSublocales = 2;

--- a/modules/internal/localeModels/apu/LocaleModel.chpl
+++ b/modules/internal/localeModels/apu/LocaleModel.chpl
@@ -1,5 +1,7 @@
 /*
  * Copyright 2017 Advanced Micro Devices, Inc.
+ * Copyright 2004-2017 Cray Inc.
+ * Other additional copyright holders may be indicated within.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/internal/localeModels/apu/LocaleModel.chpl
+++ b/modules/internal/localeModels/apu/LocaleModel.chpl
@@ -222,7 +222,7 @@ module LocaleModel {
 
     proc deinit() {
       if (debugAPULocale) {
-	chpl_debug_writeln("** Destructing CPU/GPU locales and shutting down HSA.");
+        chpl_debug_writeln("** Destructing CPU/GPU locales and shutting down HSA.");
       }
       delete CPU;
       delete GPU;

--- a/modules/internal/localeModels/apu/LocaleModel.chpl
+++ b/modules/internal/localeModels/apu/LocaleModel.chpl
@@ -1,0 +1,293 @@
+/*
+ * Copyright 2017 Advanced Micro Devices, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// LocaleModel.chpl
+//
+// This provides a flat locale model architectural description.  The
+// locales contain memory and a multi-core processor with homogeneous
+// cores, and we ignore any affinity (NUMA effects) between the
+// processor cores and the memory.  This architectural description is
+// backward compatible with the architecture implicitly provided by
+// releases 1.6 and preceding.
+//
+module LocaleModel {
+
+  use LocaleModelHelpAPU;
+  use LocaleModelHelpMem;
+
+  //
+  // The task layer calls these to convert between full sublocales and
+  // execution sublocales.  Full sublocales may contain more information
+  // in some locale models, but not in this one.
+  //
+  export
+  proc chpl_localeModel_sublocToExecutionSubloc(full_subloc:chpl_sublocID_t)
+  {
+    return full_subloc;  // execution sublocale is same as full sublocale
+  }
+
+  export
+  proc chpl_localeModel_sublocMerge(full_subloc:chpl_sublocID_t,
+                                    execution_subloc:chpl_sublocID_t)
+  {
+    return execution_subloc;  // no info needed from full sublocale
+  }
+
+  class CPULocale : AbstractLocaleModel {
+    const sid: chpl_sublocID_t;
+    const name: string;
+
+    proc chpl_id() return (parent:LocaleModel)._node_id; // top-level node id
+    proc chpl_localeid() {
+      return chpl_buildLocaleID((parent:LocaleModel)._node_id:chpl_nodeID_t,
+                                sid);
+    }
+    proc chpl_name() return name;
+
+    proc CPULocale() {
+    }
+
+    proc CPULocale(_sid, _parent) {
+      sid = _sid;
+      parent = _parent;
+      name = parent.chpl_name() + "-CPU" + sid;
+    }
+
+    proc writeThis(f) {
+      parent.writeThis(f);
+      f <~> '.'+name;
+    }
+
+    proc getChildCount(): int { return 0; }
+    iter getChildIndices() : int {
+      halt("No children to iterate over.");
+      yield -1;
+    }
+    proc addChild(loc:locale) {
+      halt("Cannot add children to this locale type.");
+    }
+    proc getChild(idx:int) : locale { return nil; }
+  }
+
+  class GPULocale : AbstractLocaleModel {
+    const sid: chpl_sublocID_t;
+    const name: string;
+
+    proc chpl_id() return (parent:LocaleModel)._node_id; // top-level node id
+    proc chpl_localeid() {
+      return chpl_buildLocaleID((parent:LocaleModel)._node_id:chpl_nodeID_t,
+                                sid);
+    }
+    proc chpl_name() return name;
+
+    proc GPULocale() {
+    }
+    proc ~GPULocale() {
+     extern proc hsa_shutdown(): void ;
+
+     // Comment out this until runtime support for HSA is added
+
+     //     hsa_shutdown();
+    }
+
+
+    proc GPULocale(_sid, _parent) {
+      sid = _sid;
+      parent = _parent;
+      name = parent.chpl_name() + "-GPU" + sid;
+    }
+
+    proc writeThis(f) {
+      parent.writeThis(f);
+      f <~> '.'+name;
+    }
+
+    proc getChildCount(): int { return 0; }
+    iter getChildIndices() : int {
+      halt("No children to iterate over.");
+      yield -1;
+    }
+    proc addChild(loc:locale) {
+      halt("Cannot add children to this locale type.");
+    }
+    proc getChild(idx:int) : locale { return nil; }
+  }
+
+  const chpl_emptyLocaleSpace: domain(1) = {1..0};
+  const chpl_emptyLocales: [chpl_emptyLocaleSpace] locale;
+
+  //
+  // The node model
+  //
+  class LocaleModel : AbstractLocaleModel {
+    const _node_id : int;
+    const local_name : string;
+
+    const numSublocales: int;
+    var GPU: GPULocale;
+    var CPU: CPULocale;
+
+    // This constructor must be invoked "on" the node
+    // that it is intended to represent.  This trick is used
+    // to establish the equivalence the "locale" field of the locale object
+    // and the node ID portion of any wide pointer referring to it.
+    proc LocaleModel() {
+      if doneCreatingLocales {
+        halt("Cannot create additional LocaleModel instances");
+      }
+      setup();
+    }
+
+    proc LocaleModel(parent_loc : locale) {
+      if doneCreatingLocales {
+        halt("Cannot create additional LocaleModel instances");
+      }
+      parent = parent_loc;
+      setup();
+    }
+
+    proc chpl_id() return _node_id;     // top-level locale (node) number
+    proc chpl_localeid() {
+      return chpl_buildLocaleID(_node_id:chpl_nodeID_t, c_sublocid_any);
+    }
+    proc chpl_name() return local_name;
+
+
+    proc writeThis(f) {
+      // Most classes will define it like this:
+      //      f <~> name;
+      // but here it is defined thus for backward compatibility.
+      f <~> new ioLiteral("LOCALE") <~> _node_id;
+    }
+
+    proc getChildSpace() {
+      halt("error!");
+      return {0..#numSublocales};
+    }
+
+    proc getChildCount() return 0;
+
+    iter getChildIndices() : int {
+      for idx in {0..#numSublocales} do // chpl_emptyLocaleSpace do
+        yield idx;
+    }
+
+    proc getChild(idx:int) : locale {
+      if idx == 1
+        then return GPU;
+      else
+        return CPU;
+    }
+
+    iter getChildren() : locale  {
+      halt("in here");
+      for idx in {0..#numSublocales} {
+        if idx == 1
+          then yield GPU;
+        else
+          yield CPU;
+      }
+    }
+
+    proc getChildArray() {
+      halt ("in get child Array");
+      return chpl_emptyLocales;
+    }
+
+
+    //------------------------------------------------------------------------{
+    //- Implementation (private)
+    //-
+    proc setup() {
+      _node_id = chpl_nodeID: int;
+
+      helpSetupLocaleAPU(this, local_name, numSublocales);
+    }
+    //------------------------------------------------------------------------}
+ }
+
+  //
+  // An instance of this class is the default contents 'rootLocale'.
+  //
+  // In the current implementation a platform-specific architectural description
+  // may overwrite this instance or any of its children to establish a more customized
+  // representation of the system resources.
+  //
+  class RootLocale : AbstractRootLocale {
+
+    const myLocaleSpace: domain(1) = {0..numLocales-1};
+    var myLocales: [myLocaleSpace] locale;
+
+    proc RootLocale() {
+      parent = nil;
+      nPUsPhysAcc = 0;
+      nPUsPhysAll = 0;
+      nPUsLogAcc = 0;
+      nPUsLogAll = 0;
+      maxTaskPar = 0;
+    }
+
+    // The setup() function must use chpl_initOnLocales() to iterate (in
+    // parallel) over the locales to set up the LocaleModel object.
+    // In addition, the initial 'here' must be set.
+    proc setup() {
+      helpSetupRootLocaleAPU(this);
+    }
+
+    // Has to be globally unique and not equal to a node ID.
+    // We return numLocales for now, since we expect nodes to be
+    // numbered less than this.
+    // -1 is used in the abstract locale class to specify an invalid node ID.
+    proc chpl_id() return numLocales;
+    proc chpl_localeid() {
+      return chpl_buildLocaleID(numLocales:chpl_nodeID_t, c_sublocid_none);
+    }
+    proc chpl_name() return local_name();
+    proc local_name() return "rootLocale";
+
+    proc writeThis(f) {
+      f <~> name;
+    }
+
+    proc getChildCount() return this.myLocaleSpace.numIndices;
+
+    proc getChildSpace() return this.myLocaleSpace;
+
+    iter getChildIndices() : int {
+      for idx in this.myLocaleSpace do
+        yield idx;
+    }
+
+    proc getChild(idx:int) return this.myLocales[idx];
+
+    iter getChildren() : locale  {
+      for loc in this.myLocales do
+        yield loc;
+    }
+
+    proc getDefaultLocaleSpace() const ref return this.myLocaleSpace;
+    proc getDefaultLocaleArray() const ref return myLocales;
+
+    proc localeIDtoLocale(id : chpl_localeID_t) {
+      const node = chpl_nodeFromLocaleID(id);
+      const subloc = chpl_sublocFromLocaleID(id);
+      if (subloc == c_sublocid_none) || (subloc == c_sublocid_any) then
+        return (myLocales[node:int]):locale;
+      else
+        return (myLocales[node:int].getChild(subloc:int)):locale;
+    }
+  }
+}

--- a/modules/internal/localeModels/apu/LocaleModel.chpl
+++ b/modules/internal/localeModels/apu/LocaleModel.chpl
@@ -219,6 +219,14 @@ module LocaleModel {
       helpSetupLocaleAPU(this, local_name, numSublocales);
     }
     //------------------------------------------------------------------------}
+
+    proc deinit() {
+      if (debugAPULocale) {
+	chpl_debug_writeln("** Destructing CPU/GPU locales and shutting down HSA.");
+      }
+      delete CPU;
+      delete GPU;
+    }
  }
 
   //
@@ -290,6 +298,11 @@ module LocaleModel {
         return (myLocales[node:int]):locale;
       else
         return (myLocales[node:int].getChild(subloc:int)):locale;
+    }
+
+    proc deinit() {
+      for loc in myLocales do
+        delete loc;
     }
   }
 }

--- a/runtime/include/localeModels/apu/chpl-locale-model.h
+++ b/runtime/include/localeModels/apu/chpl-locale-model.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017 Advanced Micro Devices, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _chpl_locale_model_h_
+#define _chpl_locale_model_h_
+
+#include "sys_basic.h"
+#include "chpltypes.h"
+
+//
+// This is the type of a global locale ID.
+//
+typedef struct {
+  int32_t node;
+  int32_t subloc;
+} chpl_localeID_t;
+
+//
+// This is the initializer for a chpl_localeID_t.  This macro is
+// referenced explicitly in the compiler, in symbol.cpp.
+//
+#define CHPL_LOCALEID_T_INIT  {0, 0}
+
+//
+// This is the external copy constructor for a chpl_localeID_t, specified
+// by the module code for a hsa locale model.
+//
+static inline
+chpl_localeID_t chpl__initCopy_chpl_rt_localeID_t(chpl_localeID_t initial) {
+  return initial;
+}
+
+//
+// These functions are used by the module code to assemble and
+// disassemble global locale IDs.
+//
+static inline
+chpl_localeID_t chpl_rt_buildLocaleID(c_nodeid_t node, c_sublocid_t subloc) {
+   chpl_localeID_t loc = { node, subloc };
+  return loc;
+}
+
+static inline
+c_nodeid_t chpl_rt_nodeFromLocaleID(chpl_localeID_t loc) {
+  return loc.node;
+}
+
+static inline
+c_sublocid_t chpl_rt_sublocFromLocaleID(chpl_localeID_t loc) {
+  return loc.subloc;
+}
+
+//
+// These functions are exported from the locale model for use by
+// the tasking layer to convert between a full sublocale and an
+// execution sublocale.
+//
+extern
+c_sublocid_t chpl_localeModel_sublocToExecutionSubloc(
+                  c_sublocid_t full_subloc);
+
+extern
+c_sublocid_t chpl_localeModel_sublocMerge(c_sublocid_t full_subloc,
+                  c_sublocid_t execution_subloc);
+
+#endif // _chpl_locale_model_h_

--- a/runtime/include/localeModels/apu/chpl-locale-model.h
+++ b/runtime/include/localeModels/apu/chpl-locale-model.h
@@ -1,5 +1,7 @@
 /*
  * Copyright 2017 Advanced Micro Devices, Inc.
+ * Copyright 2004-2017 Cray Inc.
+ * Other additional copyright holders may be indicated within.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This defines a locale model for an AMD Accelerated Processing Unit (APU).

APUs consist of a CPU and an integrated GPU. This PR is the first part of a larger set of changes to allow targeting of GPUs from Chapel code. The hierarchical sublocale functionality is used so users can write code such as:

```
on Locale[0].GPU {
  // GPU code
}
```

This change will eventually require the HSA runtime to also be installed on the system being run. For now, the calls to the HSA runtime have been commented out, until the required runtime changes are checked in later. Additionally, we are currently hardcoding a single CPU and GPU sublocale. This could also change after more runtime components are added. The compiler changes to generate GPU executable code will be another PR added in the future.