### PR TITLE
Dynamically determine location of FileCheck

### DIFF
--- a/test/llvm/PREDIFF
+++ b/test/llvm/PREDIFF
@@ -4,7 +4,9 @@ OUTFILE=$2
 
 TMPFILE="$outfile.prediff.tmp"
 
-FILECHECK=${CHPL_HOME}/third-party/llvm/install/linux64-gnu/bin/FileCheck
+PLATFORM=`$CHPL_HOME/util/chplenv/chpl_platform.py --host`
+COMPILER=`$CHPL_HOME/util/chplenv/chpl_compiler.py --host`
+FILECHECK=${CHPL_HOME}/third-party/llvm/install/${PLATFORM}-${COMPILER}/bin/FileCheck
 
 mv $OUTFILE $TMPFILE
 $FILECHECK --input-file $TMPFILE $TESTNAME.chpl 2> $OUTFILE


### PR DESCRIPTION
The location of the FileCheck program used in LLVM tests was hardcoded in `test/llvm/PREDIFF` for `linux64-gnu` systems.  This change dynamically determines the platform and compiler so the tests can be run on other systems.

Tested on `linux64-gnu` and `darwin-clang`.
