### PR TITLE
Bump git depth for annotation checker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ matrix:
     - env: NIGHTLY_TEST_SETTINGS=true CHPL_SMOKE_SKIP_DOC=true TEST_COMMAND="./util/buildRelease/smokeTest"
     - env: NIGHTLY_TEST_SETTINGS=true CHPL_SMOKE_SKIP_MAKE_CHECK=true TEST_COMMAND="./util/buildRelease/smokeTest"
     - env: TEST_COMMAND="make test-venv && CHPL_HOME=$PWD ./util/run-in-venv.bash ./util/test/check_annotations.py"
+      git:
+        depth: 100000
     - env: TEST_COMMAND="./util/devel/lookForBadAlloc"
       addons:
         apt:


### PR DESCRIPTION
The annotation checker uses the current git repo to check that PR numbers match
up with commit dates. By default, travis limits the git depth to 50, so we were
only checking "recent" commits. This bumps the default to 100,000 (which should
effectively be a full clone of the currrent branch.)

This only adds ~45 seconds for the annotation checker config, so it should
still finish well before the `make check` configs.