### PR TITLE
Remove future for missing autoCopy

### DIFF
--- a/test/types/records/ferguson/leak-futures/return-ref-arg.future
+++ b/test/types/records/ferguson/leak-futures/return-ref-arg.future
@@ -1,1 +1,0 @@
-bug: copy initialization should be added when returning ref arg

--- a/test/types/records/ferguson/leak-futures/return-ref-arg.skipif
+++ b/test/types/records/ferguson/leak-futures/return-ref-arg.skipif
@@ -1,2 +1,0 @@
-# shows a double-free, so skip if not valgrind
-CHPL_TEST_VGRND_EXE!=on


### PR DESCRIPTION
un-futurize this test, which now passes due to #7089.