### PR TITLE
Remove _arrAlias field

### DIFF
--- a/modules/dists/BlockCycDist.chpl
+++ b/modules/dists/BlockCycDist.chpl
@@ -805,7 +805,7 @@ proc BlockCyclicArr.setup() {
   }
 }
 
-proc BlockCyclicArr.dsiDestroyArr(isslice:bool) {
+proc BlockCyclicArr.dsiDestroyArr() {
   coforall localeIdx in dom.dist.targetLocDom {
     on dom.dist.targetLocales(localeIdx) {
       delete locArr(localeIdx);

--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -917,7 +917,7 @@ proc BlockArr.setup() {
   if doRADOpt && disableBlockLazyRAD then setupRADOpt();
 }
 
-proc BlockArr.dsiDestroyArr(isslice:bool) {
+proc BlockArr.dsiDestroyArr() {
   coforall localeIdx in dom.dist.targetLocDom {
     on locArr(localeIdx) {
       delete locArr(localeIdx);
@@ -1287,10 +1287,6 @@ proc BlockArr.doiCanBulkTransfer(viewDom) {
   if viewDom.stridable then
     for param i in 1..rank do
       if viewDom.dim(i).stride != 1 then return false;
-
-  // See above note regarding aliased arrays
-  if disableAliasedBulkTransfer then
-    if _arrAlias != nil then return false;
 
   return true;
 }

--- a/modules/dists/CyclicDist.chpl
+++ b/modules/dists/CyclicDist.chpl
@@ -714,7 +714,7 @@ proc CyclicArr.setup() {
   if doRADOpt && disableCyclicLazyRAD then setupRADOpt();
 }
 
-proc CyclicArr.dsiDestroyArr(isslice:bool) {
+proc CyclicArr.dsiDestroyArr() {
   coforall localeIdx in dom.dist.targetLocDom {
     on dom.dist.targetLocs(localeIdx) {
       delete locArr(localeIdx);

--- a/modules/dists/DimensionalDist2D.chpl
+++ b/modules/dists/DimensionalDist2D.chpl
@@ -1046,7 +1046,7 @@ proc DimensionalArr.dsiPostReallocate() {
   // nothing for now
 }
 
-proc DimensionalArr.dsiDestroyArr(isslice: bool) {
+proc DimensionalArr.dsiDestroyArr() {
   coforall desc in localAdescs do
     on desc do
       delete desc;

--- a/modules/dists/OldReplicatedDist.chpl
+++ b/modules/dists/OldReplicatedDist.chpl
@@ -594,7 +594,7 @@ proc chpl_serialReadWriteRectangular(f, arr, dom) where chpl__getActualArray(arr
   }
 }
 
-proc OldReplicatedArr.dsiDestroyArr(isslice:bool) {
+proc OldReplicatedArr.dsiDestroyArr() {
   coforall localeIdx in dom.dist.targetLocDom {
     on dom.dist.targetLocales(localeIdx) do
       delete localArrs(localeIdx);

--- a/modules/dists/ReplicatedDist.chpl
+++ b/modules/dists/ReplicatedDist.chpl
@@ -541,7 +541,7 @@ proc chpl_serialReadWriteRectangular(f, arr, dom) where chpl__getActualArray(arr
     chpl_serialReadWriteRectangularHelper(f, arr, dom);
 }
 
-proc ReplicatedArr.dsiDestroyArr(isslice:bool) {
+proc ReplicatedArr.dsiDestroyArr() {
   coforall (loc, locArr) in zip(dom.dist.targetLocales, localArrs) {
     on loc do
       delete locArr;

--- a/modules/dists/SparseBlockDist.chpl
+++ b/modules/dists/SparseBlockDist.chpl
@@ -729,10 +729,6 @@ proc SparseBlockArr.doiCanBulkTransfer() {
     for param i in 1..rank do
       if dom.whole.dim(i).stride != 1 then return false;
 
-  // See above note regarding aliased arrays
-  if disableAliasedBulkTransfer then
-    if _arrAlias != nil then return false;
-
   return true;
 }
 

--- a/modules/dists/StencilDist.chpl
+++ b/modules/dists/StencilDist.chpl
@@ -1002,7 +1002,7 @@ proc StencilArr.setup() {
   if doRADOpt && disableStencilLazyRAD then setupRADOpt();
 }
 
-proc StencilArr.dsiDestroyArr(isslice : bool) {
+proc StencilArr.dsiDestroyArr() {
   coforall localeIdx in dom.dist.targetLocDom {
     on locArr(localeIdx) {
       if !ignoreFluff then
@@ -1383,7 +1383,6 @@ iter StencilArr.dsiBoundaries(param tag : iterKind) where tag == iterKind.standa
 pragma "no copy return"
 proc _array.noFluffView() {
   var a = _value.dsiNoFluffView();
-  a._arrAlias = _value;
   return _newArray(a);
 }
 
@@ -1701,10 +1700,6 @@ proc StencilArr.doiCanBulkTransfer(viewDom) {
   if dom.stridable then
     for param i in 1..rank do
       if viewDom.dim(i).stride != 1 then return false;
-
-  // See above note regarding aliased arrays
-  if disableAliasedBulkTransfer then
-    if _arrAlias != nil then return false;
 
   return true;
 }

--- a/modules/internal/ArrayViewRankChange.chpl
+++ b/modules/internal/ArrayViewRankChange.chpl
@@ -868,7 +868,7 @@ module ArrayViewRankChange {
       return this;
     }
 
-    proc dsiDestroyArr(isalias:bool) {
+    proc dsiDestroyArr() {
       if ownsArrInstance {
         _delete_arr(_ArrInstance, _isPrivatized(_ArrInstance));
       }

--- a/modules/internal/ArrayViewReindex.chpl
+++ b/modules/internal/ArrayViewReindex.chpl
@@ -689,7 +689,7 @@ module ArrayViewReindex {
       return this;
     }
 
-    proc dsiDestroyArr(isalias:bool) {
+    proc dsiDestroyArr() {
       if ownsArrInstance {
         _delete_arr(_ArrInstance, _isPrivatized(_ArrInstance));
       }

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -551,7 +551,8 @@ module ChapelArray {
   // test/users/bugzilla/bug794133/ for more details and examples.
   //
   proc chpl_incRefCountsForDomainsInArrayEltTypes(arr:BaseArr, type eltType) {
-    if (isArrayType(eltType)) {
+    if isArrayType(eltType) {
+      arr._decEltRefCounts = true;
       var ev: eltType;
       ev.domain._value.add_containing_arr(arr);
       chpl_incRefCountsForDomainsInArrayEltTypes(arr, ev.eltType);
@@ -559,7 +560,10 @@ module ChapelArray {
   }
 
   proc chpl_decRefCountsForDomainsInArrayEltTypes(arr:BaseArr, type eltType) {
-    if (isArrayType(eltType)) {
+    if isArrayType(eltType) {
+      if arr._decEltRefCounts == false then
+        halt("Decrementing array's elements' ref counts without having incremented first!");
+
       var ev: eltType;
       const refcount = ev.domain._value.remove_containing_arr(arr);
       if refcount == 0 then

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1199,19 +1199,7 @@ module DefaultRectangular {
       }
     }
 
-    proc dsiDestroyArr(isalias:bool) {
-
-      // data in an array alias will be destroyed when the original array
-      // is destroyed.
-      if isalias {
-        // A multi-ddata alias nevertheless has its own mData.
-        if !defRectSimpleDData {
-          _ddata_free(mData, mdNumChunks);
-        }
-
-        return;
-      }
-
+    proc dsiDestroyArr() {
       if dom.dsiNumIndices > 0 {
         pragma "no copy" pragma "no auto destroy" var dr = dataChunk(0);
         pragma "no copy" pragma "no auto destroy" var dv = __primitive("deref", dr);
@@ -1816,7 +1804,7 @@ module DefaultRectangular {
         str = copy.str;
         origin = copy.origin;
         factoredOffs = copy.factoredOffs;
-        dsiDestroyArr(false);
+        dsiDestroyArr();
         if defRectSimpleDData {
           data = copy.data;
         } else {

--- a/test/studies/comd/elegant/arrayOfStructs/util/AccumStencilDist.chpl
+++ b/test/studies/comd/elegant/arrayOfStructs/util/AccumStencilDist.chpl
@@ -789,7 +789,7 @@ proc AccumStencilArr.setup() {
   if doRADOpt && disableAccumStencilLazyRAD then setupRADOpt();
 }
 
-proc AccumStencilArr.dsiDestroyArr(isslice : bool) {
+proc AccumStencilArr.dsiDestroyArr() {
   coforall localeIdx in dom.dist.targetLocDom {
     on locArr(localeIdx) {
       if !ignoreFluff then
@@ -1216,7 +1216,6 @@ iter AccumStencilArr.dsiBoundaries(param tag : iterKind) where tag == iterKind.s
 pragma "no copy return"
 proc _array.noFluffView() {
   var a = _value.dsiNoFluffView();
-  a._arrAlias = _value;
   return _newArray(a);
 }
 
@@ -1528,10 +1527,6 @@ proc AccumStencilArr.doiCanBulkTransfer(viewDom) {
   if dom.stridable then
     for param i in 1..rank do
       if viewDom.dim(i).stride != 1 then return false;
-
-  // See above note regarding aliased arrays
-  if disableAliasedBulkTransfer then
-    if _arrAlias != nil then return false;
 
   return true;
 }


### PR DESCRIPTION
The _arrAlias field was created when we still implemented slices in
closed-form. With the advent of ArrayViews, this is no longer necessary
and _arrAlias was basically only used to determine if we needed to
decrement the reference counts for array elements that are arrays.

This commit replaces the _arrAlias field with a bool field named
'_decEltRefCounts'. This field is set when the utility function
chpl_incRefCountsForDomainsInArrayEltTypes is called. The _delete_arr
function in ChapelDistribution will now check this field to determine if
we need to call chpl_decRefCountsForDomainsInArrayEltTypes.

Consequently, the 'isslice' bool formal of the 'dsiDestroyArr' method is
no longer necessary.

Testing:
- [x] full local
- [x] full gasnet