### PR TITLE
Init undefined field

### DIFF
--- a/compiler/passes/initializerRules.cpp
+++ b/compiler/passes/initializerRules.cpp
@@ -567,7 +567,10 @@ static CallExpr* createCallToSuperInit(FnSymbol* fn) {
 static bool hasReferenceToThis(Expr* expr) {
   bool retval = false;
 
-  if (SymExpr* symExpr = toSymExpr(expr)) {
+  if (isUnresolvedSymExpr(expr) == true) {
+    retval = false;
+
+  } else if (SymExpr* symExpr = toSymExpr(expr)) {
     if (ArgSymbol* arg = toArgSymbol(symExpr->symbol())) {
       retval = arg->hasFlag(FLAG_ARG_THIS);
     }

--- a/test/classes/initializers/field-undefined.chpl
+++ b/test/classes/initializers/field-undefined.chpl
@@ -1,0 +1,21 @@
+class Foo {
+  var a : int;
+  var b : int;
+  var t : int;
+
+  proc init(_a : int, _b : int, _c : int) {
+    a = _a;
+    b = _b;
+    c = _c;
+
+    super.init();
+  }
+}
+
+proc main() {
+  var c = new Foo(10, 20, 3);
+
+  writeln(c);
+
+  delete c;
+}

--- a/test/classes/initializers/field-undefined.good
+++ b/test/classes/initializers/field-undefined.good
@@ -1,0 +1,2 @@
+field-undefined.chpl:6: In initializer:
+field-undefined.chpl:9: error: 'c' undeclared (first use this function)


### PR DESCRIPTION
A trivial fix for a trivial initializer bug


Before this PR the compiler might generate an INT_FATAL when examining a statement
that included an undefined name.  This PR updates the gap in logic and adds a simple
test to lock in this fix.

Abbreviated testing on darwin for the initializer tests.
