### PR TITLE
Add a future for the issue I recently opened on default values for sync args

### DIFF
--- a/test/types/sync/lydia/defaultValArg.bad
+++ b/test/types/sync/lydia/defaultValArg.bad
@@ -1,0 +1,2 @@
+defaultValArg.chpl:6: error: unresolved call 'foo(int(64))'
+defaultValArg.chpl:1: note: candidates are: foo(x$: syncint = 3)

--- a/test/types/sync/lydia/defaultValArg.chpl
+++ b/test/types/sync/lydia/defaultValArg.chpl
@@ -1,0 +1,6 @@
+proc foo (x$: sync int = 3) {
+  var val = x$;
+  writeln(val);
+}
+
+foo();

--- a/test/types/sync/lydia/defaultValArg.future
+++ b/test/types/sync/lydia/defaultValArg.future
@@ -1,0 +1,7 @@
+error message: default value for sync/single arguments should be disallowed?
+
+#7172
+
+The behavior of this code is an open question - the only thing that is certain
+is that the `unresolved call` output is confusing and suboptimal.  Please
+consult the related GitHub issue for more information.

--- a/test/types/sync/lydia/defaultValArg.good
+++ b/test/types/sync/lydia/defaultValArg.good
@@ -1,0 +1,1 @@
+defaultValArg.chpl:1: error: cannot define a default value for a sync/single argument


### PR DESCRIPTION
See issue #7172 for more information.  I arbitrarily chose option A (give a
reasonable error message instead of the unresolved call one) as the
"good" output, but that can easily change based on discussion.