### PR TITLE
update Buffers and Path modules to use error handling

### DIFF
--- a/modules/standard/Buffers.chpl
+++ b/modules/standard/Buffers.chpl
@@ -146,10 +146,10 @@ module Buffers {
     this.home = here;
   }
   pragma "no doc"
-  proc bytes.bytes(len:int(64)) {
+  proc bytes.bytes(len:int(64)) throws {
     var error:syserr = ENOERR;
     error = qbytes_create_calloc(this._bytes_internal, len);
-    if error then ioerror(error, "in bytes constructor");
+    if error then try ioerror(error, "in bytes constructor");
     // The buffer is retained internally on construction, but only on success.
     this.home = here;
   }
@@ -164,10 +164,10 @@ module Buffers {
     return ret;
   }
   pragma "no doc"
-  private proc create_iobuf():bytes {
+  private proc create_iobuf():bytes throws {
     var err:syserr = ENOERR;
     var ret = create_iobuf(err);
-    if err then ioerror(err, "in create_iobuf");
+    if err then try ioerror(err, "in create_iobuf");
     return ret;
   }
 
@@ -311,11 +311,11 @@ module Buffers {
     error = qbuffer_create(this._buf_internal);
   }
   pragma "no doc"
-  proc buffer.buffer() {
+  proc buffer.buffer() throws {
     var error:syserr = ENOERR;
     this.home = here;
     error = qbuffer_create(this._buf_internal);
-    if error then ioerror(error, "in buffer constructor");
+    if error then try ioerror(error, "in buffer constructor");
   }
   /*
      defaultOf appears to be unnecessary since the initializer
@@ -361,19 +361,19 @@ module Buffers {
   }
 
   pragma "no doc"
-  proc buffer.flatten(range:buffer_range) {
+  proc buffer.flatten(range:buffer_range) throws {
   //proc buffer.flatten(range:buffer_range):bytes {
     var error:syserr = ENOERR;
     var ret:bytes = new bytes();
     ret = this.flatten(range,error);
-    if error then ioerror(error, "in buffer.flatten");
+    if error then try ioerror(error, "in buffer.flatten");
     return ret;
   }
 
   // TODO -- shouldn't have to write this this way!
   pragma "init copy fn"
   pragma "no doc"
-  proc chpl__initCopy(x: buffer) {
+  proc chpl__initCopy(x: buffer) throws {
     if x.home == here {
       qbuffer_retain(x._buf_internal);
       return x;
@@ -402,7 +402,7 @@ module Buffers {
         err = bulk_put_buffer(there_uid, ptr, len, x._buf_internal,
                               qbuffer_begin(x._buf_internal),
                               qbuffer_end(x._buf_internal));
-        if err then ioerror(err, "in buffer init copy");
+        if err then try ioerror(err, "in buffer init copy");
       }
 
       ret.append(b);
@@ -411,7 +411,7 @@ module Buffers {
   }
 
   pragma "no doc"
-  proc =(ref ret:buffer, x:buffer) {
+  proc =(ref ret:buffer, x:buffer) throws {
     ret.home = here;
     // retain -- release
     if( x.home == ret.home ) {
@@ -453,7 +453,7 @@ module Buffers {
         err = bulk_put_buffer(there_uid, ptr, len, x._buf_internal,
                               qbuffer_begin(x._buf_internal),
                               qbuffer_end(x._buf_internal));
-        if err then ioerror(err, "in buffer assignment");
+        if err then try ioerror(err, "in buffer assignment");
       }
 
       ret.append(b);
@@ -498,10 +498,10 @@ module Buffers {
   }
 
   pragma "no doc"
-  proc buffer.append(b:bytes, skip_bytes:int(64) = 0, len_bytes:int(64) = b.len) {
+  proc buffer.append(b:bytes, skip_bytes:int(64) = 0, len_bytes:int(64) = b.len) throws {
     var err:syserr = ENOERR;
     this.append(b, skip_bytes, len_bytes, err);
-    if err then ioerror(err, "in buffer.append");
+    if err then try ioerror(err, "in buffer.append");
   }
 
   /* Append a :record:`buffer` object to a :record:`buffer`.
@@ -522,10 +522,10 @@ module Buffers {
     }
   }
   pragma "no doc"
-  proc buffer.append(buf:buffer, part:buffer_range = buf.all()) {
+  proc buffer.append(buf:buffer, part:buffer_range = buf.all()) throws {
     var err:syserr = ENOERR;
     this.append(buf, part, err);
-    if err then ioerror(err, "in buffer.append");
+    if err then try ioerror(err, "in buffer.append");
   }
 
   /* Prepend a :record:`bytes` object to a :record:`buffer`.
@@ -547,10 +547,10 @@ module Buffers {
     }
   }
   pragma "no doc"
-  proc buffer.prepend(b:bytes, skip_bytes:int(64) = 0, len_bytes:int(64) = b.len) {
+  proc buffer.prepend(b:bytes, skip_bytes:int(64) = 0, len_bytes:int(64) = b.len) throws {
     var err:syserr = ENOERR;
     this.prepend(b, skip_bytes, len_bytes, err);
-    if err then ioerror(err, "in buffer.prepend");
+    if err then try ioerror(err, "in buffer.prepend");
   }
 
   /* :return: a :record:`buffer_iterator` to the start of a buffer */
@@ -686,10 +686,10 @@ module Buffers {
   }
 
   pragma "no doc"
-  proc buffer.copyout(it:buffer_iterator, out value):buffer_iterator {
+  proc buffer.copyout(it:buffer_iterator, out value):buffer_iterator throws {
     var err:syserr = ENOERR;
     var ret = this.copyout(it, value, err);
-    if err then ioerror(err, "in buffer.copyout");
+    if err then try ioerror(err, "in buffer.copyout");
     return ret;
   }
 
@@ -757,10 +757,10 @@ module Buffers {
   }
 
   pragma "no doc"
-  proc buffer.copyin( it:buffer_iterator, value):buffer_iterator {
+  proc buffer.copyin( it:buffer_iterator, value):buffer_iterator throws {
     var err:syserr = ENOERR;
     var ret = this.copyin(it, value, err);
-    if err then ioerror(err, "in buffer.copyin");
+    if err then try ioerror(err, "in buffer.copyin");
     return ret;
   }
 }

--- a/modules/standard/Buffers.chpl
+++ b/modules/standard/Buffers.chpl
@@ -373,7 +373,7 @@ module Buffers {
   // TODO -- shouldn't have to write this this way!
   pragma "init copy fn"
   pragma "no doc"
-  proc chpl__initCopy(x: buffer) throws {
+  proc chpl__initCopy(x: buffer) {
     if x.home == here {
       qbuffer_retain(x._buf_internal);
       return x;
@@ -402,7 +402,7 @@ module Buffers {
         err = bulk_put_buffer(there_uid, ptr, len, x._buf_internal,
                               qbuffer_begin(x._buf_internal),
                               qbuffer_end(x._buf_internal));
-        if err then try ioerror(err, "in buffer init copy");
+        if err then try! ioerror(err, "in buffer init copy");
       }
 
       ret.append(b);

--- a/modules/standard/Path.chpl
+++ b/modules/standard/Path.chpl
@@ -93,10 +93,10 @@ proc realPath(out error: syserr, name: string): string {
    :return: A canonical version of the argument.
    :rtype: `string`
 */
-proc realPath(name: string): string {
+proc realPath(name: string): string throws {
   var err: syserr = ENOERR;
   var ret = realPath(err, name);
-  if err != ENOERR then ioerror(err, "in realPath of", name);
+  if err != ENOERR then try ioerror(err, "in realPath of", name);
   return ret;
 }
 
@@ -129,10 +129,10 @@ proc file.realPath(out error: syserr): string {
             occur
    :rtype: `string`
 */
-proc file.realPath(): string {
+proc file.realPath(): string throws {
   var err: syserr = ENOERR;
   var ret = realPath(err);
-  if err != ENOERR then ioerror(err, "in file.realPath");
+  if err != ENOERR then try ioerror(err, "in file.realPath");
   return ret;
 }
 
@@ -218,10 +218,10 @@ proc file.realPath(): string {
   :return: The parent directory of the file
   :rtype: `string`
  */
- proc file.getParentName(): string {
+ proc file.getParentName(): string throws {
    var err: syserr = ENOERR;
    var ret = getParentName(err);
-   if err != ENOERR then ioerror(err, "in file.getParentName");
+   if err != ENOERR then try ioerror(err, "in file.getParentName");
    return ret;
  }
 


### PR DESCRIPTION
Several procedures in `Buffers` and `Path` would halt if they encountered an error, but this PR enables users to handle a `SystemError` if they prefer. No tests were handling a syserr from `Buffers` or `Path`.

- [x] passes linux64+flat testing