### PR TITLE
Update test/types/records/hilde/refCountedType.chpl to use initializers

### DIFF
--- a/test/types/records/hilde/refCountedType.chpl
+++ b/test/types/records/hilde/refCountedType.chpl
@@ -27,12 +27,17 @@ class Impl
 record Handle
 {
   var _impl : Impl;
-//  ctor Handle() { _impl = nil; } // Future
-//  ctor Handle(val: real) { _impl = new Impl(1, val); }
-  proc Handle(val: real) { _impl = new Impl(1, val); }
 
-// Copy-constructors are not yet implemented.  See chpl__initCopy() below.
-//  ctor Handle(ref h: Handle) { _impl = h._impl; _impl.retain(); }
+  proc init() { _impl = nil; }
+
+  proc init(val: real) { _impl = new Impl(1, val); }
+
+  proc init(other: Handle) {
+    if other._impl == nil then halt("Illegal copy of uninitialized Handle.");
+    _impl = other._impl;
+    _impl.retain();
+  }
+
 
 // Destructor
   proc deinit() { this.release_helper(); }
@@ -50,28 +55,6 @@ record Handle
   proc value return _impl.value;
   proc freed return _impl.freed;
 }
-
-// Copy-constructor implementation
-// This should really be named chpl__autoCopy in the current vernacular, but
-// that is really moot under the assumption that both will be replaced by a
-// proper copy-constructor.
-// The argument should have ref intent, which is also a minor point.
-pragma "init copy fn"
-proc chpl__initCopy(h: Handle)
-{
-  if h._impl == nil then halt("Illegal copy of uninitialized Handle.");
-
-  h._impl.retain();
-  return h;
-  // The returned value is copied bit-by-bit into the storage allocated to hold
-  // it in the caller, but without calling the copy-constructor (which, of
-  // course, would cause infinite recursion.
-  // The caller is responsible for calling ~Handle() on the value thus
-  // initialized, or memory will be leaked.
-}
-
-// The incorrectly-implemented POD optimization causes the chpl__initCopy routine to
-// fail to be called.
 
 // Assignment
 // proc =(ref lhs: Handle, ref rhs:Handle)


### PR DESCRIPTION
Convert the constructor into an initializer and add a copy initializer and no
argument initializer.  Removes the comments for Tom H.'s expected new
constructor syntax and removes the chpl__initCopy definition since the
copy initializer works.

These initializers would benefit from Phase 1 as the default

Passed a full paratest with futures