### PR TITLE
Fix short-string serialization bug

### DIFF
--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -216,7 +216,7 @@ module String {
     proc chpl__serialize() {
       var data : chpl__inPlaceBuffer;
       if len <= CHPL_SHORT_STRING_SIZE {
-        c_memcpy(chpl__getInPlaceBufferData(data), buff, len);
+        chpl_string_comm_get(chpl__getInPlaceBufferData(data), locale_id, buff, len);
       }
       return new __serializeHelper(len, buff, _size, locale_id, data);
     }


### PR DESCRIPTION
chpl__serialize for short-strings was always doing a c_memcpy even when
the string's data was located on another locale. Using the
chpl_string_comm_get utility fixes this bug.

Testing:
- [x] full local
- [x] full gasnet