### PR TITLE
Copy init 1

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -4455,11 +4455,11 @@ static void resolveInitVar(CallExpr* call) {
   Symbol*  src     = srcExpr->symbol();
   Type*    srcType = src->type;
 
-  if (dst->hasFlag(FLAG_NO_COPY)                         == true)  {
+  if (dst->hasFlag(FLAG_NO_COPY)               == true)  {
     call->primitive = primitives[PRIM_MOVE];
     resolveMove(call);
 
-  } else if (isPrimitiveScalar(srcType)                  == true)  {
+  } else if (isPrimitiveScalar(srcType)        == true)  {
     call->primitive = primitives[PRIM_MOVE];
     resolveMove(call);
 

--- a/test/classes/initializers/copy-init-1.chpl
+++ b/test/classes/initializers/copy-init-1.chpl
@@ -1,0 +1,87 @@
+var globalId = 0;
+
+record MyRecord {
+  var id : int;
+
+  proc init() {
+    writeln('    MyRecord.init()');
+
+    globalId = globalId + 100;
+
+    id       = globalId;
+
+    super.init();
+  }
+
+  proc init(other : MyRecord) {
+    writeln('    MyRecord.init(other : MyRecord)');
+
+    id       = other.id + 1;
+
+    super.init();
+  }
+
+  proc deinit() {
+    writeln('    MyRecord.deinit() ', this);
+  }
+
+}
+
+
+
+
+proc main() {
+  writeln('main            DefaultInit  rec100');
+
+  var rec100 : MyRecord;
+
+  fnCall(rec100);
+
+  writeln();
+  writeln();
+
+  writeln('main            De-Init      rec100      ', rec100);
+}
+
+
+
+
+proc fnCall(arg100 : MyRecord) {
+  {
+    writeln(' ');
+    writeln('  fnCall        CopyInit     rec101 with ', arg100);
+
+    var rec101 : MyRecord = arg100;
+
+    writeln(' ');
+    writeln('  fnCall        De-Init      rec101      ', rec101);
+  }
+
+  writeln(' ');
+
+  {
+    var rec200 : MyRecord = returnRec();
+
+    writeln(' ');
+    writeln('  fnCall        De-Init      rec200      ', rec200);
+  }
+
+  writeln(' ');
+}
+
+
+
+
+proc returnRec() : MyRecord {
+  writeln('    returnRec   DefaultInit  rec200');
+
+  var rec200 : MyRecord;
+
+  writeln('    returnRec   No De-Init');
+
+  return rec200;
+}
+
+
+
+

--- a/test/classes/initializers/copy-init-1.good
+++ b/test/classes/initializers/copy-init-1.good
@@ -1,0 +1,20 @@
+main            DefaultInit  rec100
+    MyRecord.init()
+ 
+  fnCall        CopyInit     rec101 with (id = 100)
+    MyRecord.init(other : MyRecord)
+ 
+  fnCall        De-Init      rec101      (id = 101)
+    MyRecord.deinit() (id = 101)
+ 
+    returnRec   DefaultInit  rec200
+    MyRecord.init()
+    returnRec   No De-Init
+ 
+  fnCall        De-Init      rec200      (id = 200)
+    MyRecord.deinit() (id = 200)
+ 
+
+
+main            De-Init      rec100      (id = 100)
+    MyRecord.deinit() (id = 100)


### PR DESCRIPTION
A simple update to a portion of normalize for DefExpr for records with initializers

Before this PR the normalization of DefExpr for records with initializers had two bugs -



1. Consider

var x : MyRecord;
var y : MyRecord = x;

The initialization of y was being implemented as a default-init followed by an assignment
rather than as a copy initialization



2. Consider

var y : MyRecord = returnMyRecord();

The initialization of y was also being implemented as a default-init followed by an
assignment rather than as a simple PRIM_MOVE.


The first commit for this PR makes trivial changes to the handling of DefExpr
normalization for records with initializers to solve both of these errors.  The
second commit adds a test to help lock the corrected behavior in.






Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.
Passed a small fraction of start_test release/ for these configurations.

Passed a paratest for gcc/linux64 with futures.

Confirmed that the leak-metrics are unaffected.
