### PR TITLE
Copy init 2

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -4468,7 +4468,8 @@ static void resolveInitVar(CallExpr* call) {
     SymExpr*       rhs = toSymExpr(call->get(2));
 
     // The LHS will "own" the record
-    if (rhs->symbol()->hasFlag(FLAG_INSERT_AUTO_DESTROY) == false) {
+    if (rhs->symbol()->hasFlag(FLAG_INSERT_AUTO_DESTROY) == false &&
+        rhs->symbol()->hasFlag(FLAG_TEMP)                == true) {
       dst->type       = src->type;
 
       call->primitive = primitives[PRIM_MOVE];

--- a/test/classes/initializers/copy-init-2.chpl
+++ b/test/classes/initializers/copy-init-2.chpl
@@ -13,14 +13,6 @@ record MyRecord {
     super.init();
   }
 
-  proc init(other : MyRecord) {
-    writeln('    MyRecord.init(other : MyRecord)');
-
-    id       = other.id + 1;
-
-    super.init();
-  }
-
   proc deinit() {
     writeln('    MyRecord.deinit() ', this);
   }
@@ -45,12 +37,12 @@ proc main() {
 
 
 
-proc fnCall(arg100 : MyRecord) {
+proc fnCall(arg100) {
   {
     writeln(' ');
     writeln('  fnCall        CopyInit     rec101 with ', arg100);
 
-    var rec101 : MyRecord = arg100;
+    var rec101 = arg100;
 
     writeln(' ');
     writeln('  fnCall        De-Init      rec101      ', rec101);
@@ -59,7 +51,7 @@ proc fnCall(arg100 : MyRecord) {
   writeln(' ');
 
   {
-    var rec200 : MyRecord = returnRec();
+    var rec200 = returnRec();
 
     writeln(' ');
     writeln('  fnCall        De-Init      rec200      ', rec200);
@@ -71,7 +63,7 @@ proc fnCall(arg100 : MyRecord) {
 
 
 
-proc returnRec() : MyRecord {
+proc returnRec() {
   writeln('    returnRec   DefaultInit  rec200');
 
   var rec200 : MyRecord;

--- a/test/classes/initializers/copy-init-2.good
+++ b/test/classes/initializers/copy-init-2.good
@@ -1,0 +1,2 @@
+copy-init-2.chpl:40: In function 'fnCall':
+copy-init-2.chpl:45: error: No copy constructor for initializer

--- a/test/classes/initializers/copy-init-3.chpl
+++ b/test/classes/initializers/copy-init-3.chpl
@@ -45,12 +45,12 @@ proc main() {
 
 
 
-proc fnCall(arg100 : MyRecord) {
+proc fnCall(arg100) {
   {
     writeln(' ');
     writeln('  fnCall        CopyInit     rec101 with ', arg100);
 
-    var rec101 : MyRecord = arg100;
+    var rec101 = arg100;
 
     writeln(' ');
     writeln('  fnCall        De-Init      rec101      ', rec101);
@@ -59,7 +59,7 @@ proc fnCall(arg100 : MyRecord) {
   writeln(' ');
 
   {
-    var rec200 : MyRecord = returnRec();
+    var rec200 = returnRec();
 
     writeln(' ');
     writeln('  fnCall        De-Init      rec200      ', rec200);
@@ -71,7 +71,7 @@ proc fnCall(arg100 : MyRecord) {
 
 
 
-proc returnRec() : MyRecord {
+proc returnRec() {
   writeln('    returnRec   DefaultInit  rec200');
 
   var rec200 : MyRecord;

--- a/test/classes/initializers/copy-init-3.good
+++ b/test/classes/initializers/copy-init-3.good
@@ -1,0 +1,20 @@
+main            DefaultInit  rec100
+    MyRecord.init()
+ 
+  fnCall        CopyInit     rec101 with (id = 100)
+    MyRecord.init(other : MyRecord)
+ 
+  fnCall        De-Init      rec101      (id = 101)
+    MyRecord.deinit() (id = 101)
+ 
+    returnRec   DefaultInit  rec200
+    MyRecord.init()
+    returnRec   No De-Init
+ 
+  fnCall        De-Init      rec200      (id = 200)
+    MyRecord.deinit() (id = 200)
+ 
+
+
+main            De-Init      rec100      (id = 100)
+    MyRecord.deinit() (id = 100)


### PR DESCRIPTION
Trivial fix for a copy-init bug

Consider

var x : MyRecord;
var y = x;

where MyRecord defines initializers.  The initialization of 'y' should invoke the copy-initializer
for MyRecord but, before this PR, it did not.  This was fixed by a trivial update to the resolution
of PRIM_INIT_VAR for records with initializers.


Added two tests to help lock in the required behavior.

Compiled/tested in the conventional ways.  Also verified that mem-leak metrics were
unaffected.
