### PR TITLE
Improve isConstValWillNotChange()

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -567,7 +567,8 @@ bool VarSymbol::isConstant() const {
 
 
 bool VarSymbol::isConstValWillNotChange() const {
-  return hasFlag(FLAG_CONST);
+  return (hasFlag(FLAG_CONST) && !hasFlag(FLAG_REF_VAR)) ||
+         hasFlag(FLAG_REF_TO_CONST);
 }
 
 
@@ -778,12 +779,14 @@ bool ArgSymbol::isConstant() const {
   return retval;
 }
 
+// keep in sync with isConstValWillNotChange() in visibleFunctions.cpp
 bool ArgSymbol::isConstValWillNotChange() const {
   //
   // This is written to only be called post resolveIntents
   //
   assert (intent != INTENT_BLANK && intent != INTENT_CONST);
-  return (intent == INTENT_CONST_IN);
+  return intent == INTENT_CONST_IN ||
+         hasFlag(FLAG_REF_TO_CONST);
 }
 
 

--- a/compiler/resolution/visibleFunctions.cpp
+++ b/compiler/resolution/visibleFunctions.cpp
@@ -265,6 +265,8 @@ static void handleTaskIntentArgs(CallExpr* call, FnSymbol* taskFn,
 // with blank and 'const' intents.
 //
 static bool isConstValWillNotChange(Symbol* sym) {
+  if (sym->hasFlag(FLAG_REF_TO_CONST))
+    return true;
   if (ArgSymbol* arg = toArgSymbol(sym)) {
     IntentTag cInt = concreteIntent(arg->intent, arg->type->getValType());
     return cInt == INTENT_CONST_IN;


### PR DESCRIPTION
In Symbol::isConstValWillNotChange() :

* Do not return 'true' for VarSymbols corresponding to 'const ref' aliases.

* Return 'true' when the symbol has the flag FLAG_REF_TO_CONST.

Do the same in the standalone function isConstValWillNotChange(), too.
