### PR TITLE
Update two more initializer tests after Mike's improvements from yesterday

### DIFF
--- a/test/parallel/sync/bradc/syncArrInit.chpl
+++ b/test/parallel/sync/bradc/syncArrInit.chpl
@@ -1,8 +1,9 @@
 class C {
   const irng: range;
 
-  proc C(v1: int) {
+  proc init(v1: int) {
     irng = v1..v1;
+    super.init();
   }
 }
 

--- a/test/types/records/noakes/return.chpl
+++ b/test/types/records/noakes/return.chpl
@@ -12,7 +12,7 @@ record Rec
   var copy   : bool;
   var freed  : bool;
 
-  proc Rec()
+  proc init()
   {
     sID          = sID + 1;
     sAllocated   = sAllocated + 1;
@@ -22,8 +22,31 @@ record Rec
     copy         = false;
     freed        = false;
 
+    super.init();
+
     if (sDebug == true) then
       writeln("Constructing Rec       id:  ", id);
+  }
+
+  proc init(other: Rec) {
+    sID          = sID + 1;
+    sAllocated   = sAllocated + 1;
+
+    canary = other.canary;
+    id     = sID;
+    copy   = true;
+    freed  = false;
+
+    super.init();
+
+    if (sDebug == true) then
+      writeln("copying Rec other: ", other.id);
+
+    if other.canary != 0xBABEBABE then
+      writeln("copying with uninitialized record!");
+
+    if other.freed  == true then
+      writeln("copying a record that has been freed!");
   }
 
   proc deinit()
@@ -57,49 +80,6 @@ proc = (ref lhs: Rec, rhs : Rec)
   if rhs.freed  == true then
     writeln("= operator: RHS has been freed");
 }
-
-//
-// Need to override the default initCopy as it does not
-// invoked the constructor.
-
-pragma "init copy fn"
-proc chpl__initCopy(arg : Rec) {
-  if (sDebug == true) then
-    writeln("initCopying  Rec       arg: ", arg.id);
-
-  if arg.canary != 0xBABEBABE then
-    writeln("autoCopy with uninitialized record!");
-
-  if arg.freed  == true then
-    writeln("autoCopy with a record that has been freed!");
-
-  var ret : Rec;
-
-  return ret;
-}
-
-pragma "donor fn"
-pragma "auto copy fn"
-proc chpl__autoCopy(arg : Rec) {
-  if (sDebug == true) then
-    writeln("autoCopying  Rec       arg: ", arg.id);
-
-  pragma "no auto destroy"
-  var ret : Rec;
-
-  if arg.canary != 0xBABEBABE then
-    writeln("autoCopy with uninitialized record!");
-
-  if arg.freed  == true then
-    writeln("autoCopy with a record that has been freed!");
-
-  ret.copy   = true;
-
-  return ret;
-}
-
-
-
 
 
 proc main()

--- a/test/types/records/sungeun/ctorWithOnFn.chpl
+++ b/test/types/records/sungeun/ctorWithOnFn.chpl
@@ -1,7 +1,9 @@
 record R0 {
   var home: locale;
+
+  proc init() { }
 }
-proc R0.R0(r1:R1) {
+proc R0.init(r1:R1) {
   on r1.home {
     this.home = r1.home;
   }


### PR DESCRIPTION
With Mike's improvements to copy initializers, and my improvement to
PRIM_SET_MEMBER while supporting nested concrete classes, these tests
now compile and run as expected with a constructor to initializer conversion.

Details:
test/types/records/noakes/return.chpl:
Removed the autoCopy and initCopy functions as they are no longer necessary.
These initializers would benefit from Phase 1 as the default.

test/types/records/sungeun/ctorWithOnFn.chpl:
Converts R0's constructor into an initializer and adds a zero-argument
initializer (since we don't generate that when an explicit initializer is
present).
If we decide to allow on clauses around field initialization, this test would
benefit from Phase 1 as the default.

test/parallel/sync/bradc/syncArrInit.chpl:
This test would benefit from Phase 1 as the default, or the ability to set const
fields in Phase 2.

Passed a sanity paratest