### PR TITLE
Fix queries on generic type declarations when the type defines an initializer

### DIFF
--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -1305,7 +1305,16 @@ static Symbol* determineQueriedField(CallExpr* call) {
     // field queried by position
     int position = var->immediate->int_value();
     Vec<ArgSymbol*> args;
-    for_formals(arg, ct->defaultTypeConstructor) {
+
+    FnSymbol* typeConstruct = ct->defaultTypeConstructor;
+    AggregateType* source   = ct->instantiatedFrom;
+    while (typeConstruct == NULL) {
+      INT_ASSERT(source != NULL);
+      typeConstruct = source->defaultTypeConstructor;
+      source = source->instantiatedFrom;
+    }
+
+    for_formals(arg, typeConstruct) {
       args.add(arg);
     }
     for (int i = 2; i < call->numActuals(); i++) {

--- a/test/classes/initializers/generics/genericArgUsesTypeQuery.bad
+++ b/test/classes/initializers/generics/genericArgUsesTypeQuery.bad
@@ -1,8 +1,0 @@
-genericArgUsesTypeQuery.chpl:9: internal error: MIS0558 chpl Version 1.16.0 pre-release (c0bf20b)
-Note: This source location is a guess.
-
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
-and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
-please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
-

--- a/test/classes/initializers/generics/genericArgUsesTypeQuery.future
+++ b/test/classes/initializers/generics/genericArgUsesTypeQuery.future
@@ -1,5 +1,0 @@
-bug: using type query field as default argument in generic initializer
-
-Something about this use of a type query field as the default for
-another argument in this generic class's initializer results in
-an internal error.


### PR DESCRIPTION
Prior to this change, the default initializers test run had 10 failures
associated with attempting a query on the type declaration of a type using a
default initializer.

This error was because determineQueriedField in preFold was assuming that the
type always had a defaultTypeConstructor - however, in the case of generic types
with initializers, this is not the case.  To fix this, I grabbed the default
type constructor from the generic source type for the concrete instantiation,
and iterated over that (since the arguments will match)

With this change, all 10 failures now pass.  It also allows the future
classes/initializers/generics/genericArgUsesTypeQuery to pass, so I removed the
.bad and .future file for that test.

Testing:
- [x] classes/initializers with futures
- [x] full standard paratest
- [x] paratest with --force-initializers