### PR TITLE
Fix errors + inheritance

### DIFF
--- a/compiler/passes/errorHandling.cpp
+++ b/compiler/passes/errorHandling.cpp
@@ -323,7 +323,18 @@ void ErrorHandlingVisitor::lowerCatches(const TryInfo& info) {
 bool ErrorHandlingVisitor::enterCallExpr(CallExpr* node) {
   bool insideTry = !tryStack.empty();
 
-  if (FnSymbol* calledFn = node->resolvedFunction()) {
+  // The common case of a user-level call to a resolved function
+  FnSymbol* calledFn = node->resolvedFunction();
+
+  // Also handle the PRIMOP for a virtual method call
+  if (calledFn == NULL) {
+    if (node->isPrimitive(PRIM_VIRTUAL_METHOD_CALL)) {
+        SymExpr* arg1 = toSymExpr(node->get(1));
+        calledFn = toFnSymbol(arg1->symbol());
+    }
+  }
+
+  if (calledFn != NULL) {
     if (calledFn->throwsError()) {
 
       SET_LINENO(node);

--- a/compiler/resolution/virtualDispatch.cpp
+++ b/compiler/resolution/virtualDispatch.cpp
@@ -390,7 +390,25 @@ static void addToVirtualMaps(FnSymbol* pfn, AggregateType* ct) {
               USR_FATAL_CONT(pfn, "conflicting return type specified for '%s: %s'", toString(pfn), pfn->retType->symbol->name);
               USR_FATAL_CONT(fn, "  overridden by '%s: %s'", toString(fn), fn->retType->symbol->name);
               USR_STOP();
+            } else if (fn->throwsError() != pfn->throwsError()) {
+              USR_FATAL_CONT(fn, "conflicting throws for '%s'", toString(fn));
+              const char* pfnThrowing = NULL;
+              const char* fnThrowing = NULL;
+
+              if (pfn->throwsError()) {
+                pfnThrowing = "throwing";
+                fnThrowing = "non-throwing";
+              } else {
+                pfnThrowing = "non-throwing";
+                fnThrowing = "throwing";
+              }
+
+              USR_FATAL_CONT(pfn, "%s function '%s'",pfnThrowing,toString(pfn));
+              USR_FATAL_CONT(fn, "overridden by %s function '%s'",
+                             fnThrowing, toString(fn));
+              USR_STOP();
             }
+
             {
               Vec<FnSymbol*>* fns = virtualChildrenMap.get(pfn);
               if (!fns) fns = new Vec<FnSymbol*>();

--- a/test/errhandling/ferguson/e-inherit-nothrows-throws.chpl
+++ b/test/errhandling/ferguson/e-inherit-nothrows-throws.chpl
@@ -1,0 +1,21 @@
+class C {
+  proc foo() { writeln("C.foo()");}
+}
+
+class D : C {
+  proc foo() throws { writeln("D.foo()"); }
+}
+
+var c = new C();
+var d = new D();
+var dc:C = new D();
+
+try { c.foo(); } catch { writeln("c.foo threw"); }
+try { d.foo(); } catch { writeln("d.foo threw"); }
+try {dc.foo(); } catch { writeln("dc.foo threw"); }
+
+delete c;
+delete d;
+delete dc;
+
+writeln("Fini");

--- a/test/errhandling/ferguson/e-inherit-nothrows-throws.good
+++ b/test/errhandling/ferguson/e-inherit-nothrows-throws.good
@@ -1,0 +1,3 @@
+e-inherit-nothrows-throws.chpl:6: error: conflicting throws for 'D.foo()'
+e-inherit-nothrows-throws.chpl:2: error: non-throwing function 'C.foo()'
+e-inherit-nothrows-throws.chpl:6: error: overridden by throwing function 'D.foo()'

--- a/test/errhandling/ferguson/e-inherit-throws-nothrows.chpl
+++ b/test/errhandling/ferguson/e-inherit-throws-nothrows.chpl
@@ -1,0 +1,21 @@
+class C {
+  proc foo() throws { writeln("C.foo()");}
+}
+
+class D : C {
+  proc foo() { writeln("D.foo()"); }
+}
+
+var c = new C();
+var d = new D();
+var dc:C = new D();
+
+try { c.foo(); } catch { writeln("c.foo threw"); }
+try { d.foo(); } catch { writeln("d.foo threw"); }
+try {dc.foo(); } catch { writeln("dc.foo threw"); }
+
+delete c;
+delete d;
+delete dc;
+
+writeln("Fini");

--- a/test/errhandling/ferguson/e-inherit-throws-nothrows.good
+++ b/test/errhandling/ferguson/e-inherit-throws-nothrows.good
@@ -1,0 +1,3 @@
+e-inherit-throws-nothrows.chpl:6: error: conflicting throws for 'D.foo()'
+e-inherit-throws-nothrows.chpl:2: error: throwing function 'C.foo()'
+e-inherit-throws-nothrows.chpl:6: error: overridden by non-throwing function 'D.foo()'

--- a/test/errhandling/ferguson/e-inherit.chpl
+++ b/test/errhandling/ferguson/e-inherit.chpl
@@ -1,0 +1,32 @@
+config const cthrow = false;
+config const dthrow = false;
+
+class C {
+  proc foo() throws {
+    writeln("C.foo()");
+    if cthrow then
+      throw new Error("test error C");
+  }
+}
+
+class D : C {
+  proc foo() throws {
+    writeln("D.foo()");
+    if dthrow then
+      throw new Error("test error D");
+  }
+}
+
+var c = new C();
+var d = new D();
+var dc:C = new D();
+
+try { c.foo(); } catch { writeln("c.foo threw"); }
+try { d.foo(); } catch { writeln("d.foo threw"); }
+try {dc.foo(); } catch { writeln("dc.foo threw"); }
+
+delete c;
+delete d;
+delete dc;
+
+writeln("Fini");

--- a/test/errhandling/ferguson/e-inherit.ct.good
+++ b/test/errhandling/ferguson/e-inherit.ct.good
@@ -1,0 +1,5 @@
+C.foo()
+c.foo threw
+D.foo()
+D.foo()
+Fini

--- a/test/errhandling/ferguson/e-inherit.dt.good
+++ b/test/errhandling/ferguson/e-inherit.dt.good
@@ -1,0 +1,6 @@
+C.foo()
+D.foo()
+d.foo threw
+D.foo()
+dc.foo threw
+Fini

--- a/test/errhandling/ferguson/e-inherit.execopts
+++ b/test/errhandling/ferguson/e-inherit.execopts
@@ -1,0 +1,3 @@
+--cthrow=false --dthrow=false # e-inherit.ok.good
+--cthrow=true  --dthrow=false # e-inherit.ct.good
+--cthrow=false --dthrow=true  # e-inherit.dt.good

--- a/test/errhandling/ferguson/e-inherit.ok.good
+++ b/test/errhandling/ferguson/e-inherit.ok.good
@@ -1,0 +1,4 @@
+C.foo()
+D.foo()
+D.foo()
+Fini


### PR DESCRIPTION
Fixes #6315.

In addition to making throwing functions work with inheritance at all, this PR also adds a compilation error in the event that an overridden function has a different throws/not throwing option.

Passed full local testing.
Reviewed by @psahabu - thanks!