### PR TITLE
Remove task counting vestiges from the runtime

### DIFF
--- a/runtime/include/chpl-tasks.h
+++ b/runtime/include/chpl-tasks.h
@@ -330,17 +330,6 @@ size_t chpl_task_getCallStackSize(void);
 uint32_t chpl_task_getNumQueuedTasks(void);
 
 //
-// returns the number of tasks that are running on the current locale,
-// including any that may be blocked waiting for something.
-// Note that the value returned could be larger than the limit on the maximum
-// number of threads, since a thread could be "suspended," particularly if it
-// is waiting at the end of a cobegin, e.g.  In this case, it could be
-// executing a task inside the cobegin, so in effect the same thread would be
-// executing more than one task.
-//
-uint32_t chpl_task_getNumRunningTasks(void);
-
-//
 // returns the number of tasks that are blocked waiting on a sync or single
 // variable.
 // Note that this information may only available if the program is run with

--- a/runtime/src/tasks/fifo/tasks-fifo.c
+++ b/runtime/src/tasks/fifo/tasks-fifo.c
@@ -95,7 +95,6 @@ static volatile task_pool_p
                            task_pool_tail;     // tail of task pool
 
 static int                 queued_task_cnt;    // number of tasks in task pool
-static int                 running_task_cnt;   // number of running tasks
 static int64_t             extra_task_cnt;     // number of tasks being run by
                                                //   threads occupied already
 static int                 blocked_thread_cnt; // number of threads that
@@ -335,7 +334,6 @@ void chpl_task_init(void) {
   chpl_thread_mutexInit(&task_id_lock);
   chpl_thread_mutexInit(&task_list_lock);
   queued_task_cnt = 0;
-  running_task_cnt = 1;                     // only main task running
   blocked_thread_cnt = 0;
   idle_thread_cnt = 0;
   extra_task_cnt = 0;
@@ -844,14 +842,11 @@ size_t chpl_task_getCallStackSize(void) {
   return chpl_thread_getCallStackSize();
 }
 
-uint32_t chpl_task_getNumQueuedTasks(void) { return queued_task_cnt; }
-
-uint32_t chpl_task_getNumRunningTasks(void) {
-  chpl_internal_error("chpl_task_getNumRunningTasks() called");
-  return 1;
+uint32_t chpl_task_getNumQueuedTasks(void) {
+  return queued_task_cnt;
 }
 
-int32_t  chpl_task_getNumBlockedTasks(void) {
+int32_t chpl_task_getNumBlockedTasks(void) {
   if (blockreport) {
     int numBlockedTasks;
 
@@ -1188,14 +1183,12 @@ thread_begin(void* ptask_void) {
       progress_cnt++;
 
     //
-    // start new task; increment running count and remove task from pool
-    // also add to task to task-table (structure in ChapelRuntime that keeps
-    // track of currently running tasks for task-reports on deadlock or
-    // Ctrl+C).
+    // start new task; remove task from pool also add to task to task-table
+    // (structure in ChapelRuntime that keeps track of currently running tasks
+    // for task-reports on deadlock or Ctrl+C).
     //
     ptask = task_pool_head;
     idle_thread_cnt--;
-    running_task_cnt++;
 
     dequeue_task(ptask);
 
@@ -1239,10 +1232,8 @@ thread_begin(void* ptask_void) {
     chpl_thread_mutexLock(&threading_lock);
 
     //
-    // finished task; decrement running count and increment idle count
+    // finished task; increment idle count
     //
-    assert(running_task_cnt > 0);
-    running_task_cnt--;
     idle_thread_cnt++;
 
     // end critical section

--- a/runtime/src/tasks/massivethreads/tasks-massivethreads.c
+++ b/runtime/src/tasks/massivethreads/tasks-massivethreads.c
@@ -738,20 +738,6 @@ uint32_t chpl_task_getNumQueuedTasks(void) {
 }
 
 //
-// returns the number of tasks that are running on the current locale,
-// including any that may be blocked waiting for something.
-// Note that the value returned could be larger than the limit on the maximum
-// number of threads, since a thread could be "suspended," particularly if it
-// is waiting at the end of a cobegin, e.g.  In this case, it could be
-// executing a task inside the cobegin, so in effect the same thread would be
-// executing more than one task.
-//
-uint32_t chpl_task_getNumRunningTasks(void) {
-  chpl_internal_error("chpl_task_getNumRunningTasks() called");
-  return 1;
-}
-
-//
 // returns the number of tasks that are blocked waiting on a sync or single
 // variable.
 // Note that this information may only available if the program is run with

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -1074,12 +1074,6 @@ uint32_t chpl_task_getNumQueuedTasks(void)
     return qthread_readstate(NODE_BUSYNESS);
 }
 
-uint32_t chpl_task_getNumRunningTasks(void)
-{
-    chpl_internal_error("chpl_task_getNumRunningTasks() called");
-    return 1;
-}
-
 int32_t chpl_task_getNumBlockedTasks(void)
 {
     // This isn't accurate, but in the absence of better information


### PR DESCRIPTION
Remove chpl_task_getNumRunningTasks() from the runtime interface.
chpl_task_getNumRunningTasks was "deprecated" with bdc315e5172, and #7193
moved the remaining task-counting code from the runtime into the
compiler/modules so there's no reason to keep this interface around.