### PR TITLE
Fix dead module elimination bug

### DIFF
--- a/compiler/AST/ModuleSymbol.cpp
+++ b/compiler/AST/ModuleSymbol.cpp
@@ -654,7 +654,10 @@ void ModuleSymbol::moduleUseRemove(ModuleSymbol* mod) {
     // The dead module may have used other modules.  If so add them
     // to the current module
     forv_Vec(ModuleSymbol, modUsedByDeadMod, mod->modUseList) {
-      if (modUseList.index(modUsedByDeadMod) < 0 && modUsedByDeadMod != mod) {
+      if (modUseList.index(modUsedByDeadMod) < 0 && modUsedByDeadMod != this) {
+        if (modUsedByDeadMod == mod) {
+          INT_FATAL("Dead module using itself");
+        }
         SET_LINENO(this);
 
         if (inBlock == true) {

--- a/compiler/AST/ModuleSymbol.cpp
+++ b/compiler/AST/ModuleSymbol.cpp
@@ -654,7 +654,7 @@ void ModuleSymbol::moduleUseRemove(ModuleSymbol* mod) {
     // The dead module may have used other modules.  If so add them
     // to the current module
     forv_Vec(ModuleSymbol, modUsedByDeadMod, mod->modUseList) {
-      if (modUseList.index(modUsedByDeadMod) < 0) {
+      if (modUseList.index(modUsedByDeadMod) < 0 && modUsedByDeadMod != mod) {
         SET_LINENO(this);
 
         if (inBlock == true) {

--- a/test/optimizations/deadCodeElimination/bharshbarg/deadModuleUse.chpl
+++ b/test/optimizations/deadCodeElimination/bharshbarg/deadModuleUse.chpl
@@ -1,0 +1,24 @@
+
+//
+// This test exists to ensure an old bug does not resurface.
+//
+// The bug was that when we DCE'd module 'A', we added 'use B' to module B's
+// use-list. Then when we DCE'd module 'B', we added that 'use B' to
+// deadModuleUse's use-list. This resulted in a failure during codegen because
+// a CallExpr for B's initFn was still in the tree despite B being dead.
+//
+
+module A {
+  use B;
+}
+module B {
+  use A;
+}
+
+module deadModuleUse {
+  use A;
+
+  proc main() {
+    writeln("success");
+  }
+}

--- a/test/optimizations/deadCodeElimination/bharshbarg/deadModuleUse.good
+++ b/test/optimizations/deadCodeElimination/bharshbarg/deadModuleUse.good
@@ -1,0 +1,1 @@
+success


### PR DESCRIPTION
This PR fixes a DCE bug with modules that use each other and adds a test to catch this kind of error going forward.

Testing:
- [x] full local