### PR TITLE
Fix fifo bug that resulted in not creating enough threads

### DIFF
--- a/runtime/src/tasks/fifo/tasks-fifo.c
+++ b/runtime/src/tasks/fifo/tasks-fifo.c
@@ -1359,14 +1359,9 @@ task_pool_p add_to_task_pool(chpl_fn_int_t fid, chpl_fn_p fp,
     chpl_thread_mutexUnlock(&taskTable_lock);
   }
 
-  //
-  // If we now have more tasks than threads to run them on (taking
-  // into account that the current parent of a structured parallel
-  // construct can run at least one of that construct's children),
-  // try to start another thread.
-  //
-  if (queued_task_cnt > idle_thread_cnt &&
-      (p_task_list_head == NULL || ptask->list_next != NULL || is_begin_stmt)) {
+  // If we now have more tasks than threads to run them on, try to start
+  // another thread
+  if (queued_task_cnt > idle_thread_cnt) {
     maybe_add_thread();
   }
 

--- a/runtime/src/tasks/fifo/tasks-fifo.c
+++ b/runtime/src/tasks/fifo/tasks-fifo.c
@@ -765,7 +765,11 @@ void chpl_task_startMovedTask(chpl_fn_int_t  fid, chpl_fn_p fp,
 
 
 chpl_taskID_t chpl_task_getId(void) {
-  return get_current_ptask()->bundle.id;
+  task_pool_p ptask = get_current_ptask();
+  if (ptask)
+    return ptask->bundle.id;
+  else
+    return (chpl_taskID_t) -1;
 }
 
 chpl_bool chpl_task_idEquals(chpl_taskID_t id1, chpl_taskID_t id2) {

--- a/test/parallel/coforall/stonea/reports.good
+++ b/test/parallel/coforall/stonea/reports.good
@@ -27,3 +27,4 @@ Waiting at: reports.chpl:8
 Waiting at: reports.chpl:8
 Waiting at: reports.chpl:8
 Waiting at: reports.chpl:8
+Waiting for more work

--- a/test/parallel/taskPool/figueroa/TotalThreads.good
+++ b/test/parallel/taskPool/figueroa/TotalThreads.good
@@ -1,3 +1,3 @@
-4 threads have been created up till now.
+5 threads have been created up till now.
 N of these is/are idle.
 3 tasks are running, but 2 are blocked at the moment.


### PR DESCRIPTION
Fix our thread creation logic in fifo so that we actually create enough
pthreads to host all of our queued tasks.

Previously, we attempted to create an additional pthread iff there weren't
enough idle threads for the current number of tasks, with the understanding
that for structured parallel constructs (coforall/cobegin) the parent will be
able to run one of the tasks. However, the code for determining if the parent
will be able to help was wrong, which sometimes resulted in too few threads,
which would lead to deadlock for parallel/taskCount/runningTaskCount/ and
exercises/boundedBuffer-old/boundedBuffer2. This updates our thread creation
logic to ignore the parent task and just always create a task if there are more
queued tasks than idle threads.

For simple coforalls/cobegins, we'll up end creating one more pthread than we
actually need, which isn't ideal, but is far easier than a more principled
solution. Doing so allows us to consider removing chpl_task_executeTasksInList,
although I didn't take that step here because that is more work than I want to
do right now and it will cause tests that try to run with only 1 thread to
fail. See https://github.com/chapel-lang/chapel/issues/7223 fore more info.

This fixes a sporadic deadlock for exercises/boundedBuffer-old/boundedBuffer2
and parallel/taskCount/runningTaskCount/single-locale/{coforall,combined}.
Passes 10,000 trials for those tests and full quickstart testing.
