### PR TITLE
Attempt to rewrite array-vs-ddata perf test to unify two cases

### DIFF
--- a/test/arrays/diten/time_array_vs_ddata.chpl
+++ b/test/arrays/diten/time_array_vs_ddata.chpl
@@ -6,16 +6,21 @@ config const niters = 10000000;
 config param printTimes = false;
 
 proc main {
-  var A: [0..#n] int;
-  var AA = _ddata_allocate(int, n);
   var t = new Timer();
-  t.start();
-  for j in 0..#niters {
-    for i in 0..#n {
-      A[i] += i;
+
+  {
+    var A: [0..#n] int;
+    t.start();
+    for j in 0..#niters {
+      for i in 0..#n {
+        A[i] += i;
+      }
     }
+    t.stop();
+    for i in 0..#n do
+      if A[i] != niters*i then
+        writeln("error: A[",i,"] = ", A[i]);
   }
-  t.stop();
 
   if printTimes {
     writeln("array ", t.elapsed());
@@ -23,17 +28,23 @@ proc main {
 
   t.clear();
 
-  t.start();
-  for j in 0..#niters {
-    for i in 0..#n {
-      AA[i] += i;
+  {
+    var A = _ddata_allocate(int, n);
+    t.start();
+    for j in 0..#niters {
+      for i in 0..#n {
+        A[i] += i;
+      }
     }
+    t.stop();
+    _ddata_free(A, n);
+    for i in 0..#n do
+      if A[i] != niters*i then
+        writeln("error: A[",i,"] = ", A[i]);
   }
-  t.stop();
-  writeln(AA[n-1] == A[n-1]);
+
+  writeln(true);
   if printTimes {
     writeln("ddata ", t.elapsed());
   }
-
-  _ddata_free(AA, n);
 }

--- a/test/arrays/diten/time_array_vs_ddata.chpl
+++ b/test/arrays/diten/time_array_vs_ddata.chpl
@@ -37,10 +37,10 @@ proc main {
       }
     }
     t.stop();
-    _ddata_free(A, n);
     for i in 0..#n do
       if A[i] != niters*i then
         writeln("error: A[",i,"] = ", A[i]);
+    _ddata_free(A, n);
   }
 
   writeln(true);


### PR DESCRIPTION
The goal of this rewrite is to remove some surprising performance
deltas we see in which ddata is slower than arrays even though
arrays wrap ddatas.  The approach I've taken here is to allocate
each data structure just before the loop that times it rather
than allocating each at program start and then running the loops.
To do this, I also changed how the verification takes place since
both arrays no longer live simultaneously.

Experiments by Elliot and myself suggest that this fixes the
strange inversion we were seeing before.