### PR TITLE
Print res msg

### DIFF
--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -197,11 +197,11 @@ FnSymbol* getUnalias(Type* t);
 bool isPOD(Type* t);
 
 // resolution errors and warnings
-void printResolutionErrorAmbiguous(CallInfo&                  info,
-                                   Vec<ResolutionCandidate*>& candidates);
+void printResolutionErrorUnresolved(CallInfo&                  info,
+                                    Vec<FnSymbol*>&            visibleFns);
 
-void printResolutionErrorUnresolved(Vec<FnSymbol*>& visibleFns,
-                                    CallInfo*       info);
+void printResolutionErrorAmbiguous (CallInfo&                  info,
+                                    Vec<ResolutionCandidate*>& candidates);
 
 void resolveNormalCallCompilerWarningStuff(FnSymbol* resolvedFn);
 

--- a/compiler/resolution/callInfo.cpp
+++ b/compiler/resolution/callInfo.cpp
@@ -125,57 +125,57 @@ void CallInfo::haltNotWellFormed() const {
   }
 }
 
-const char* toString(CallInfo* info) {
+const char* CallInfo::toString() {
   bool        method = false;
   bool        _this  = false;
   int         start  = 0;
   const char* retval = "";
 
-  if (info->actuals.n            >  1 &&
-      info->actuals.head()->type == dtMethodToken) {
+  if (actuals.n            >  1 &&
+      actuals.head()->type == dtMethodToken) {
     method = true;
     start  =    2;
   }
 
-  if (info->name == astrThis) {
+  if (name == astrThis) {
     _this  =  true;
     method = false;
     start  =     2;
   }
 
   if (method == true) {
-    if (info->actuals.v[1] &&
-        info->actuals.v[1]->hasFlag(FLAG_TYPE_VARIABLE)) {
-      retval = astr(retval, "type ", toString(info->actuals.v[1]->type), ".");
+    if (actuals.v[1] &&
+        actuals.v[1]->hasFlag(FLAG_TYPE_VARIABLE)) {
+      retval = astr(retval, "type ", ::toString(actuals.v[1]->type), ".");
 
     } else {
-      retval = astr(retval,          toString(info->actuals.v[1]->type), ".");
+      retval = astr(retval,          ::toString(actuals.v[1]->type), ".");
     }
   }
 
   if (developer                                   == false &&
-      strncmp("_type_construct_", info->name, 16) == 0) {
-    retval = astr(retval, info->name+16);
+      strncmp("_type_construct_", name, 16) == 0) {
+    retval = astr(retval, name+16);
 
   } else if (developer == false &&
-             strncmp("_construct_", info->name, 11) == 0) {
-    retval = astr(retval, info->name + 11);
+             strncmp("_construct_", name, 11) == 0) {
+    retval = astr(retval, name + 11);
     retval = astr(retval, ".init");
 
   } else if (_this == false) {
-    retval = astr(retval, info->name);
+    retval = astr(retval, name);
   }
 
-  if (info->call->methodTag == false) {
-    if (info->call->square == true) {
+  if (call->methodTag == false) {
+    if (call->square == true) {
       retval = astr(retval, "[");
     } else {
       retval = astr(retval, "(");
     }
   }
 
-  for (int i = start; i < info->actuals.n; i++) {
-    Symbol*        sym  = info->actuals.v[i];
+  for (int i = start; i < actuals.n; i++) {
+    Symbol*        sym  = actuals.v[i];
     VarSymbol*     var  = toVarSymbol(sym);
     Type*          type = sym->type;
     AggregateType* at   = toAggregateType(type);
@@ -185,8 +185,8 @@ const char* toString(CallInfo* info) {
       retval = astr(retval, ", ");
     }
 
-    if (info->actualNames.v[i] != NULL) {
-      retval = astr(retval, info->actualNames.v[i], "=");
+    if (actualNames.v[i] != NULL) {
+      retval = astr(retval, actualNames.v[i], "=");
     }
 
     if (type->symbol->hasFlag(FLAG_ITERATOR_RECORD)   == true &&
@@ -194,7 +194,7 @@ const char* toString(CallInfo* info) {
       retval = astr(retval, "promoted expression");
 
     } else if (sym->hasFlag(FLAG_TYPE_VARIABLE) == true) {
-      retval = astr(retval, "type ", toString(type));
+      retval = astr(retval, "type ", ::toString(type));
 
     } else if (var != NULL && var->immediate != NULL) {
       if (var->immediate->const_kind == CONST_KIND_STRING) {
@@ -210,12 +210,12 @@ const char* toString(CallInfo* info) {
       }
 
     } else {
-      retval = astr(retval, toString(type));
+      retval = astr(retval, ::toString(type));
     }
   }
 
-  if (info->call->methodTag == false) {
-    if (info->call->square == true) {
+  if (call->methodTag == false) {
+    if (call->square == true) {
       retval = astr(retval, "]");
     } else {
       retval = astr(retval, ")");

--- a/compiler/resolution/callInfo.h
+++ b/compiler/resolution/callInfo.h
@@ -34,6 +34,8 @@ public:
 
   void             haltNotWellFormed()                                   const;
 
+  const char*      toString();
+
   CallExpr*        call;        // call expression
   BlockStmt*       scope;       // module scope as in M.call
 
@@ -42,7 +44,5 @@ public:
   Vec<Symbol*>     actuals;     // actual symbols
   Vec<const char*> actualNames; // named arguments
 };
-
-const char* toString(CallInfo* info);
 
 #endif

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -2491,11 +2491,11 @@ void printResolutionErrorAmbiguous(CallInfo&                  info,
     USR_FATAL_CONT(call,
                    "ambiguous access of '%s' by '%s'",
                    toString(info.actuals.v[1]->type),
-                   toString(&info));
+                   info.toString());
 
   } else {
     const char* entity = "call";
-    const char* str    = toString(&info);
+    const char* str    = info.toString();
 
     if (strncmp("_type_construct_", info.name, 16) == 0) {
       entity = "type specifier";
@@ -2637,7 +2637,7 @@ void printResolutionErrorUnresolved(Vec<FnSymbol*>& visibleFns,
         USR_FATAL_CONT(call,
                        "unresolved access of '%s' by '%s'",
                        toString(info->actuals.v[1]->type),
-                       toString(info));
+                       info->toString());
       }
 
     } else {
@@ -2661,10 +2661,10 @@ static void generateMsg(Vec<FnSymbol*>& visibleFns, CallInfo* info) {
 
     INT_ASSERT(mod);
 
-    str = astr(mod->name, ".", toString(info));
+    str = astr(mod->name, ".", info->toString());
 
   } else {
-    str = toString(info);
+    str = info->toString();
   }
 
   if (strncmp("_type_construct_", info->name, 16) == 0) {

--- a/compiler/resolution/initializerResolution.cpp
+++ b/compiler/resolution/initializerResolution.cpp
@@ -116,11 +116,10 @@ static void resolveInitCall(CallExpr* call) {
 
     if (best == NULL) {
       if (call->partialTag == false) {
-        if (candidates.n > 0) {
-          printResolutionErrorAmbiguous(info, candidates);
-
+        if (candidates.n == 0) {
+          printResolutionErrorUnresolved(info, visibleFns);
         } else {
-          printResolutionErrorUnresolved(visibleFns, &info);
+          printResolutionErrorAmbiguous (info, candidates);
         }
       }
 

--- a/compiler/resolution/visibleFunctions.cpp
+++ b/compiler/resolution/visibleFunctions.cpp
@@ -126,18 +126,21 @@ void findVisibleFunctions(CallInfo&       info,
 
   if ((explainCallLine && explainCallMatch(call)) ||
       call->id == explainCallID) {
-    USR_PRINT(call, "call: %s", toString(&info));
+    USR_PRINT(call, "call: %s", info.toString());
 
-    if (visibleFns.n == 0)
+    if (visibleFns.n == 0) {
       USR_PRINT(call, "no visible functions found");
 
-    bool first = true;
+    } else {
+      bool first = true;
 
-    forv_Vec(FnSymbol, visibleFn, visibleFns) {
-      USR_PRINT(visibleFn, "%s %s",
-                first ? "visible functions are:" : "                      ",
-                toString(visibleFn));
-      first = false;
+      forv_Vec(FnSymbol, visibleFn, visibleFns) {
+        USR_PRINT(visibleFn,
+                  "%s %s",
+                  first ? "visible functions are:" : "                      ",
+                  toString(visibleFn));
+        first = false;
+      }
     }
   }
 }

--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -976,7 +976,7 @@ static FnSymbol* promotionWrap(FnSymbol* fn,
 
   if (promotion_wrapper_required) {
     if (fReportPromotion) {
-      USR_WARN(info->call, "promotion on %s", toString(info));
+      USR_WARN(info->call, "promotion on %s", info->toString());
     }
 
     promoted_subs.put(fn, (Symbol*)info->call->square);


### PR DESCRIPTION
Trivial update to signature of printResolutionErrorUnresolved().


I noticed that printResolutionErrorUnresolved() and printResolutionErrorAmbiguous() had
different signatures.  Updated printResolutionErrorUnresolved() to follow the preferred
style.

Conventional compilation/testing protocol.
