### PR TITLE
Remove numa-localization support from jemalloc shim

### DIFF
--- a/runtime/include/chpl-mem.h
+++ b/runtime/include/chpl-mem.h
@@ -164,16 +164,11 @@ void* chpl_mem_array_alloc(size_t nmemb, size_t eltSize, c_sublocid_t subloc,
     if (p == NULL) {
       p = chpl_mem_allocMany(nmemb, eltSize, CHPL_RT_MD_ARRAY_ELEMENTS,
                              lineno, filename);
-      // TODO is this right?
       do_localize = (subloc == c_sublocid_all) ? true : false;
     }
 
     if (do_localize) {
-      if (subloc == c_sublocid_all) {
-        // TODO can this be removed? I think it's multi-ddata only?
-        chpl_topo_setMemSubchunkLocality(p, size, true, NULL);
-      }
-      else if (isActualSublocID(subloc)) {
+      if (isActualSublocID(subloc)) {
         chpl_topo_setMemLocality(p, size, true, subloc);
       }
     }

--- a/runtime/include/chpl-mem.h
+++ b/runtime/include/chpl-mem.h
@@ -29,7 +29,6 @@
 #include "arg.h"
 #include "chpl-comm.h"
 #include "chpl-mem-hook.h"
-#include "chplsys.h"
 #include "chpl-topo.h"
 #include "chpltypes.h"
 #include "chpl-tasks.h"
@@ -65,10 +64,6 @@ void chpl_mem_exit(void);
 
 int chpl_mem_inited(void);
 
-// predeclared here because we need them below; actual definitions
-// are near the end
-static chpl_bool chpl_mem_localizes(void);
-static size_t chpl_mem_localizationThreshold(void);
 
 static inline
 void* chpl_mem_allocMany(size_t number, size_t size,
@@ -169,11 +164,13 @@ void* chpl_mem_array_alloc(size_t nmemb, size_t eltSize, c_sublocid_t subloc,
     if (p == NULL) {
       p = chpl_mem_allocMany(nmemb, eltSize, CHPL_RT_MD_ARRAY_ELEMENTS,
                              lineno, filename);
-      do_localize = !chpl_mem_localizes();
+      // TODO is this right?
+      do_localize = (subloc == c_sublocid_all) ? true : false;
     }
 
     if (do_localize) {
       if (subloc == c_sublocid_all) {
+        // TODO can this be removed? I think it's multi-ddata only?
         chpl_topo_setMemSubchunkLocality(p, size, true, NULL);
       }
       else if (isActualSublocID(subloc)) {
@@ -264,29 +261,6 @@ void chpl_mem_layerExit(void);
 void* chpl_mem_layerAlloc(size_t, int32_t lineno, int32_t filename);
 void* chpl_mem_layerRealloc(void*, size_t, int32_t lineno, int32_t filename);
 void chpl_mem_layerFree(void*, int32_t lineno, int32_t filename);
-
-//
-// Does the implementation provide allocated memory that is already
-// localized to the calling sublocale?  That is, when the locale model
-// has sublocales and an allocation is done while running on one, will
-// the allocated memory be localized to that sublocale?  Note that the
-// answer doesn't have to be completely truthful, but inaccuracy can
-// result in poor performance for applications sensitive to sublocale
-// (NUMA, for example) affinity.
-//
-#ifndef CHPL_MEM_IMPL_LOCALIZES
-  #define CHPL_MEM_IMPL_LOCALIZES() false
-#endif
-
-static inline
-chpl_bool chpl_mem_localizes(void) {
-  return CHPL_MEM_IMPL_LOCALIZES();
-}
-
-static inline
-size_t chpl_mem_localizationThreshold(void) {
-  return chpl_topo_getNumNumaDomains() * 2 * chpl_getHeapPageSize();
-}
 
 #else // LAUNCHER
 

--- a/runtime/include/mem/jemalloc/chpl-mem-impl.h
+++ b/runtime/include/mem/jemalloc/chpl-mem-impl.h
@@ -31,9 +31,7 @@
 #endif
 
 #include "jemalloc/jemalloc.h"
-#include "chpltypes.h"
 
-#define MALLOCX_NO_FLAGS 0
 
 // Default configuration of jemalloc names the routines
 // like je_malloc, je_free, etc; but the Chapel configuration
@@ -50,6 +48,9 @@
 #define CHPL_JE_FREE CHPL_JE_(free)
 #define CHPL_JE_NALLOCX CHPL_JE_(nallocx)
 #define CHPL_JE_MALLCTL CHPL_JE_(mallctl)
+
+
+#define MALLOCX_NO_FLAGS 0
 
 static inline void* chpl_calloc(size_t n, size_t size) {
   return CHPL_JE_CALLOC(n,size);
@@ -79,14 +80,5 @@ static inline size_t chpl_good_alloc_size(size_t minSize) {
   if (minSize == 0) { return 0; }
   return CHPL_JE_NALLOCX(minSize, MALLOCX_NO_FLAGS);
 }
-
-
-chpl_bool chpl_mem_impl_localizes(void);
-
-#define CHPL_MEM_IMPL_LOCALIZES() chpl_mem_impl_localizes()
-
-
-// TODO (EJR 03/11/16): Can/should we consider using the extended API? See JIRA
-// issue 190 (https://chapel.atlassian.net/browse/CHAPEL-190) for more info.
 
 #endif

--- a/runtime/src/mem/jemalloc/mem-jemalloc.c
+++ b/runtime/src/mem/jemalloc/mem-jemalloc.c
@@ -28,8 +28,6 @@
 #include "chpl-comm.h"
 #include "chpl-mem.h"
 #include "chplmemtrack.h"
-#include "chplsys.h"
-#include "chpl-topo.h"
 #include "chpltypes.h"
 #include "error.h"
 
@@ -44,111 +42,12 @@
 #define USE_JE_CHUNK_HOOKS
 #endif
 
-//
-// Information about shared heaps gotten from the comm layer.
-//
-typedef struct shared_heap {
+static struct shared_heap {
   void* base;
   size_t size;
   size_t cur_offset;
   pthread_mutex_t alloc_lock;
-} shared_heap_t;
-
-static shared_heap_t* heaps;
-
-static int get_num_heaps(void) {
-  static int num_heaps = -1;
-
-  if (num_heaps < 0) {
-    //
-    // Initialize: without multiple NUMA domains we definitely don't
-    // need multiple heaps.  Even with multiple NUMA domains we might
-    // not need multiple heaps, if other constraints aren't satisfied.
-    //
-    void* heap_base;
-    size_t heap_size;
-
-    chpl_comm_get_registered_heap(&heap_base, &heap_size);
-    if (heap_base == NULL) {
-      num_heaps = 0;
-    } else {
-      num_heaps = chpl_topo_getNumNumaDomains();
-      if (num_heaps < 1) {
-        num_heaps = 1;
-      } else if (!chpl_mem_impl_localizes()) {
-        num_heaps = 1;
-      }
-    }
-  }
-
-  return num_heaps;
-}
-
-static inline int get_nearby_heap(void) {
-  if (get_num_heaps() == 1) {
-    return 0;
-  } else {
-    int hpi = chpl_topo_getThreadLocality();
-    if (!isActualSublocID(hpi) || hpi >= get_num_heaps()) {
-      chpl_internal_error("unexpected heap index");
-    }
-    return hpi;
-  }
-}
-
-
-// helper routine to initialize the table of heaps
-static void setupLocalizedHeaps(void* heap_base, size_t heap_size) {
-  const int num_heaps = get_num_heaps();
-  int hpi;
-  char* subchunk_base;
-  size_t* subchunk_sizes;
-
-  heaps = (shared_heap_t*) CHPL_JE_MALLOC(num_heaps * sizeof(*heaps));
-  if (heaps == NULL) {
-    chpl_internal_error("cannot allocate heaps");
-  }
-
-  if (num_heaps <= 1) {
-    heaps[0].base = heap_base;
-    heaps[0].size = heap_size;
-    heaps[0].cur_offset = 0;
-    if (pthread_mutex_init(&heaps[0].alloc_lock, NULL) != 0) {
-      chpl_internal_error("cannot init chunk_alloc lock");
-    }
-
-    return;
-  }
-
-  subchunk_sizes =
-    (size_t*) CHPL_JE_MALLOC(num_heaps * sizeof(*subchunk_sizes));
-  if (subchunk_sizes == NULL) {
-    chpl_internal_error("cannot allocate subchunk_sizes");
-  }
-
-  chpl_topo_setMemSubchunkLocality(heap_base, heap_size, true,
-                                   subchunk_sizes);
-
-  subchunk_base = (char*) heap_base;
-  for (hpi = 0; hpi < num_heaps; hpi++) {
-    heaps[hpi].base = subchunk_base;
-    heaps[hpi].size = subchunk_sizes[hpi];
-    heaps[hpi].cur_offset = 0;
-    if (pthread_mutex_init(&heaps[hpi].alloc_lock, NULL) != 0) {
-      chpl_internal_error("cannot init chunk_alloc lock");
-    }
-    subchunk_base += heaps[hpi].size;
-
-    //
-    // The chpl_topo_setMemSubchunkLocality() call above isn't
-    // having the effect we desire, for reasons that are mostly but
-    // not completely understood.  So for now, to get the locality
-    // we want, touch the pages into existence while executing on
-    // the desired NUMA domains.
-    //
-    chpl_topo_touchMemFromSubloc(heaps[hpi].base, heaps[hpi].size, true, hpi);
-  }
-}
+} heap; // static, will be "zero" initialized automatically
 
 
 // compute aligned index into our shared heap, alignment must be a power of 2
@@ -174,44 +73,39 @@ static inline void* alignHelper(void* base_ptr, size_t offset, size_t alignment)
 // mmap/sbrk.) Grab memory out of the shared heap and give it to jemalloc.
 static void* chunk_alloc(void *chunk, size_t size, size_t alignment, bool *zero, bool *commit, unsigned arena_ind) {
 
-  int hpi;
   void* cur_chunk_base = NULL;
   size_t cur_heap_size;
 
-  // which heap?
-  hpi = get_nearby_heap();
-
   // this function can be called concurrently and it looks like jemalloc
   // doesn't call it inside a lock, so we need to protect it ourselves
-  pthread_mutex_lock(&heaps[hpi].alloc_lock);
+  pthread_mutex_lock(&heap.alloc_lock);
 
   // compute our current aligned pointer into the shared heap
   //
   //   jemalloc 4.5.0 man: "The alignment parameter is always a power of two at
   //   least as large as the chunk size."
-  cur_chunk_base = alignHelper(heaps[hpi].base, heaps[hpi].cur_offset,
-                               alignment);
+  cur_chunk_base = alignHelper(heap.base, heap.cur_offset, alignment);
 
   // jemalloc 4.5.0 man: "If chunk is not NULL, the returned pointer must be
   // chunk on success or NULL on error"
   if (chunk && chunk != cur_chunk_base) {
-    pthread_mutex_unlock(&heaps[hpi].alloc_lock);
+    pthread_mutex_unlock(&heap.alloc_lock);
     return NULL;
   }
 
-  cur_heap_size = (uintptr_t)cur_chunk_base - (uintptr_t)heaps[hpi].base;
+  cur_heap_size = (uintptr_t)cur_chunk_base - (uintptr_t)heap.base;
 
   // If there's not enough space on the heap for this allocation, return NULL
-  if (size > heaps[hpi].size - cur_heap_size) {
-    pthread_mutex_unlock(&heaps[hpi].alloc_lock);
+  if (size > heap.size - cur_heap_size) {
+    pthread_mutex_unlock(&heap.alloc_lock);
     return NULL;
   }
 
   // Update the current pointer, now that we've past any early returns.
-  heaps[hpi].cur_offset = cur_heap_size + size;
+  heap.cur_offset = cur_heap_size + size;
 
   // now that cur_heap_offset is updated, we can unlock
-  pthread_mutex_unlock(&heaps[hpi].alloc_lock);
+  pthread_mutex_unlock(&heap.alloc_lock);
 
   // jemalloc 4.5.0 man: "Zeroing is mandatory if *zero is true upon entry."
   if (*zero) {
@@ -371,19 +265,12 @@ static void get_small_and_large_class_sizes(size_t* classes) {
   }
 }
 
-// helper routine to determine if an address is not part of any shared heap
-static chpl_bool addressNotInAnyHeap(void* ptr) {
-  const int num_heaps = get_num_heaps();
+// helper routine to determine if an address is not part of the shared heap
+static chpl_bool addressNotInHeap(void* ptr) {
   uintptr_t u_ptr = (uintptr_t)ptr;
-  int hpi;
-  for (hpi = 0; hpi < num_heaps; hpi++) {
-    uintptr_t u_base = (uintptr_t)heaps[hpi].base;
-    uintptr_t u_top =  u_base + heaps[hpi].size;
-    if (u_ptr >= u_base && u_ptr < u_top) {
-      return false;
-    }
-  }
-  return true;
+  uintptr_t u_base = (uintptr_t)heap.base;
+  uintptr_t u_top = u_base + heap.size;
+  return (u_ptr < u_base) || (u_ptr > u_top);
 }
 
 // grab (and leak) whatever memory jemalloc got on it's own, that's not in
@@ -418,18 +305,15 @@ static void useUpMemNotInHeap(void) {
       if ((p = CHPL_JE_MALLOC(alloc_size)) == NULL) {
         chpl_internal_error("could not use up memory outside of shared heap");
       }
-    } while (addressNotInAnyHeap(p));
+    } while (addressNotInHeap(p));
     CHPL_JE_FREE(p);
   }
 }
 
-// Have jemalloc use our shared heap. Localize the shared heap, initialize all
-// the arenas, then replace the chunk hooks with our custom ones, and finally
-// use up any memory jemalloc got from the system that's not in our shared
-// heap.
-static void initializeSharedHeap(void* heap_base, size_t heap_size) {
-  setupLocalizedHeaps(heap_base, heap_size);
-
+// Have jemalloc use our shared heap. Initialize all the arenas, then replace
+// the chunk hooks with our custom ones, and finally use up any memory jemalloc
+// got from the system that's not in our shared heap.
+static void initializeSharedHeap(void) {
   initialize_arenas();
 
   replaceChunkHooks();
@@ -454,7 +338,13 @@ void chpl_mem_layerInit(void) {
   //   jemalloc 4.5.0 man: "Once, when the first call is made to one of the
   //   memory allocation routines, the allocator initializes its internals"
   if (heap_base != NULL) {
-    initializeSharedHeap(heap_base, heap_size);
+    heap.base = heap_base;
+    heap.size = heap_size;
+    heap.cur_offset = 0;
+    if (pthread_mutex_init(&heap.alloc_lock, NULL) != 0) {
+      chpl_internal_error("cannot init chunk_alloc lock");
+    }
+    initializeSharedHeap();
   } else {
     void* p;
     if ((p = CHPL_JE_MALLOC(1)) == NULL) {
@@ -466,28 +356,8 @@ void chpl_mem_layerInit(void) {
 
 
 void chpl_mem_layerExit(void) {
-  const int num_heaps = get_num_heaps();
-  int hpi;
-
-  for (hpi = 0; hpi < num_heaps; hpi++) {
-    if (heaps[hpi].base != NULL) {
-      // ignore errors, we're exiting anyways
-      (void) pthread_mutex_destroy(&heaps[hpi].alloc_lock);
-    }
+  if (heap.base != NULL) {
+    // ignore errors, we're exiting anyways
+    (void) pthread_mutex_destroy(&heap.alloc_lock);
   }
-}
-
-
-chpl_bool chpl_mem_impl_localizes(void) {
-  //
-  // For now, we only NUMA-localize the comm layer desired shared heap
-  // if we're using the ugni comm layer.  ugni is the simpler case
-  // because it's only used on Cray X* compute blades which are a
-  // real-memory architecture.  We'll tackle comm=gasnet later; that's
-  // more complicated because GASNet is used on all sorts of systems,
-  // some virtual-memory, and we can't just go touching all the pages.
-  //
-  return (get_num_heaps() > 1
-          && strcmp(CHPL_LOCALE_MODEL, "flat") != 0
-          && strcmp(CHPL_COMM, "ugni") == 0);
 }

--- a/runtime/src/mem/jemalloc/mem-jemalloc.c
+++ b/runtime/src/mem/jemalloc/mem-jemalloc.c
@@ -47,7 +47,7 @@ static struct shared_heap {
   size_t size;
   size_t cur_offset;
   pthread_mutex_t alloc_lock;
-} heap; // static, will be "zero" initialized automatically
+} heap;
 
 
 // compute aligned index into our shared heap, alignment must be a power of 2
@@ -270,7 +270,7 @@ static chpl_bool addressNotInHeap(void* ptr) {
   uintptr_t u_ptr = (uintptr_t)ptr;
   uintptr_t u_base = (uintptr_t)heap.base;
   uintptr_t u_top = u_base + heap.size;
-  return (u_ptr < u_base) || (u_ptr > u_top);
+  return (u_ptr < u_base) || (u_ptr >= u_top);
 }
 
 // grab (and leak) whatever memory jemalloc got on it's own, that's not in


### PR DESCRIPTION
This effectively reverts #5689. This cripples the already mothballed (but still
somewhat available) multi-ddata support, so we should pobably remove it
completely.

This simplifies the jemalloc shim in preparation for the jemalloc 5.0 upgrade
which will require non-trivial updates to our allocation hooks.