### PR TITLE
Do not call findVisibleFunctions() if callExpr->resolvedFunction() != NULL

### DIFF
--- a/compiler/resolution/visibleFunctions.cpp
+++ b/compiler/resolution/visibleFunctions.cpp
@@ -57,11 +57,6 @@ public:
   Map<const char*, Vec<FnSymbol*>*>     visibleFunctions;
 };
 
-// map: (block id) -> (map: sym -> sym)
-typedef std::map<int, SymbolMap*> CapturedValueMap;
-
-static CapturedValueMap                       capturedValues;
-
 static Map<BlockStmt*, VisibleFunctionBlock*> visibleFunctionMap;
 static Map<BlockStmt*, BlockStmt*>            visibilityBlockCache;
 
@@ -75,24 +70,6 @@ static int                                    nVisibleFunctions       = 0;
 
 static void  buildVisibleFunctionMap();
 
-static void  handleTaskIntentArgs(CallExpr* call,
-                                  FnSymbol* taskFn,
-                                  CallInfo& info);
-
-static bool  isConstValWillNotChange(Symbol* sym);
-
-static void  captureTaskIntentValues(int        argNum,
-                                     ArgSymbol* formal,
-                                     Expr*      actual,
-                                     Symbol*    varActual,
-                                     CallInfo&  info,
-                                     CallExpr*  call,
-                                     FnSymbol*  taskFn);
-
-static void  verifyTaskFnCall(BlockStmt* parent, CallExpr* call);
-
-static Expr* parentToMarker(BlockStmt* parent, CallExpr* call);
-
 void findVisibleFunctions(CallInfo&       info,
                           Vec<FnSymbol*>& visibleFns) {
   CallExpr* call = info.call;
@@ -104,24 +81,23 @@ void findVisibleFunctions(CallInfo&       info,
     buildVisibleFunctionMap();
   }
 
-  if (!call->isResolved()) {
-    if (!info.scope) {
-      getVisibleFunctions(info.name, call, visibleFns);
-    } else {
-      BlockStmt* block = info.scope;
-      // all functions in standard modules are stored in a single block
-      if (standardModuleSet.set_in(block))
-        block = theProgram->block;
+  INT_ASSERT(call->isResolved() == false);
 
-      if (VisibleFunctionBlock* vfb = visibleFunctionMap.get(block)) {
-        if (Vec<FnSymbol*>* fns = vfb->visibleFunctions.get(info.name)) {
-          visibleFns.append(*fns);
-        }
+  if (BlockStmt* block = info.scope) {
+    // all functions in standard modules are stored in a single block
+    if (standardModuleSet.set_in(block) != NULL) {
+      block = theProgram->block;
+    }
+
+    if (VisibleFunctionBlock* vfb = visibleFunctionMap.get(block)) {
+      if (Vec<FnSymbol*>* fns = vfb->visibleFunctions.get(info.name)) {
+        visibleFns.append(*fns);
       }
     }
+
   } else {
-    visibleFns.add(call->resolvedFunction());
-    handleTaskIntentArgs(call, call->resolvedFunction(), info);
+    getVisibleFunctions(info.name, call, visibleFns);
+
   }
 
   if ((explainCallLine && explainCallMatch(call)) ||
@@ -176,208 +152,6 @@ static void buildVisibleFunctionMap() {
     }
   }
   nVisibleFunctions = gFnSymbols.n;
-}
-
-//
-// Copy the type of the actual into the type of the corresponding formal
-// of a task function. (I think resolution wouldn't make this happen
-// automatically and correctly in all cases.)
-// Also do captureTaskIntentValues() when needed.
-//
-static void handleTaskIntentArgs(CallExpr* call, FnSymbol* taskFn,
-                                 CallInfo& info)
-{
-  INT_ASSERT(taskFn);
-  if (!needsCapture(taskFn)) {
-    // A task function should have args only if it needsCapture.
-    if (taskFn->hasFlag(FLAG_ON)) {
-      // Documenting the current state: fn_on gets a chpl_localeID_t arg.
-      INT_ASSERT(call->numActuals() == 1);
-    } else {
-      INT_ASSERT(!isTaskFun(taskFn) || call->numActuals() == 0);
-    }
-    return;
-  }
-
-  int argNum = -1;
-  for_formals_actuals(formal, actual, call) {
-    argNum++;
-    SymExpr* symexpActual = toSymExpr(actual);
-    if (!symexpActual) {
-      // We add NamedExpr args in propagateExtraLeaderArgs().
-      NamedExpr* namedexpActual = toNamedExpr(actual);
-      INT_ASSERT(namedexpActual);
-      symexpActual = toSymExpr(namedexpActual->actual);
-    }
-    INT_ASSERT(symexpActual); // because of how we invoke a task function
-    Symbol* varActual = symexpActual->symbol();
-
-    // If 'call' is in a generic function, it is supposed to have been
-    // instantiated by now. Otherwise our task function has to remain generic.
-    INT_ASSERT(!varActual->type->symbol->hasFlag(FLAG_GENERIC));
-
-    // Need to copy varActual->type even for type variables.
-    // BTW some formals' types may have been set in createTaskFunctions().
-    formal->type = varActual->type;
-
-    // If the actual is a ref, still need to capture it => remove ref.
-    if (isReferenceType(varActual->type)) {
-      Type* deref = varActual->type->getValType();
-      // todo: replace needsCapture() with always resolveArgIntent(formal)
-      // then checking (formal->intent & INTENT_FLAG_IN)
-      if (needsCapture(deref)) {
-        formal->type = deref;
-        // If the formal has a ref intent, DO need a ref type => restore it.
-        resolveArgIntent(formal);
-        if (formal->intent & INTENT_FLAG_REF) {
-          formal->type = varActual->type;
-        }
-        if (varActual->isConstant()) {
-          int newIntent = formal->intent | INTENT_FLAG_CONST;
-          // and clear INTENT_FLAG_MAYBE_CONST flag
-          newIntent &= ~ INTENT_FLAG_MAYBE_CONST;
-          formal->intent = (IntentTag)(newIntent);
-        }
-      }
-    }
-
-    if (varActual->hasFlag(FLAG_TYPE_VARIABLE))
-      formal->addFlag(FLAG_TYPE_VARIABLE);
-
-    // This does not capture records/strings that are passed
-    // by blank or const intent. As of this writing (6'2015)
-    // records and strings are (incorrectly) captured at the point
-    // when the task function/arg bundle is created.
-    if (taskFn->hasFlag(FLAG_COBEGIN_OR_COFORALL) &&
-        !isConstValWillNotChange(varActual) &&
-        (concreteIntent(formal->intent, formal->type->getValType())
-         & INTENT_FLAG_IN))
-      // skip dummy_locale_arg: chpl_localeID_t
-      if (argNum != 0 || !taskFn->hasFlag(FLAG_ON))
-        captureTaskIntentValues(argNum, formal, actual, varActual, info, call,
-                                taskFn);
-  }
-
-  // Even if some formals are (now) types, if 'taskFn' remained generic,
-  // gatherCandidates() would not instantiate it, for some reason.
-  taskFn->removeFlag(FLAG_GENERIC);
-}
-
-//
-// Allow invoking isConstValWillNotChange() even on formals
-// with blank and 'const' intents.
-//
-static bool isConstValWillNotChange(Symbol* sym) {
-  if (ArgSymbol* arg = toArgSymbol(sym)) {
-    IntentTag cInt = concreteIntent(arg->intent, arg->type->getValType());
-    return cInt == INTENT_CONST_IN;
-  }
-  return sym->isConstValWillNotChange();
-}
-
-//
-// Generate code to store away the value of 'varActual' before
-// the cobegin or the coforall loop starts. Use this value
-// instead of 'varActual' as the actual to the task function,
-// meaning (later in compilation) in the argument bundle.
-//
-// This is to ensure that all task functions use the same value
-// for their respective formal when that has an 'in'-like intent,
-// even if 'varActual' is modified between creations of
-// the multiple task functions.
-//
-static void captureTaskIntentValues(int        argNum,
-                                    ArgSymbol* formal,
-                                    Expr*      actual,
-                                    Symbol*    varActual,
-                                    CallInfo&  info,
-                                    CallExpr*  call,
-                                    FnSymbol*  taskFn) {
-  BlockStmt* parent = toBlockStmt(call->parentExpr);
-  INT_ASSERT(parent);
-  if (taskFn->hasFlag(FLAG_ON) && !parent->isForLoop()) {
-    // coforall ... { on ... { .... }} ==> there is an intermediate BlockStmt
-    parent = toBlockStmt(parent->parentExpr);
-    INT_ASSERT(parent);
-  }
-  if (fVerify && (argNum == 0 || (argNum == 1 && taskFn->hasFlag(FLAG_ON))))
-    verifyTaskFnCall(parent, call); //assertions only
-  Expr* marker = parentToMarker(parent, call);
-  if (varActual->hasFlag(FLAG_NO_CAPTURE_FOR_TASKING)) {
-      // No need to worry about this.
-      return;
-  }
-  if (varActual->defPoint->parentExpr == parent) {
-    // Index variable of the coforall loop? Do not capture it!
-    INT_ASSERT(varActual->hasFlag(FLAG_COFORALL_INDEX_VAR));
-    return;
-  }
-  SymbolMap*& symap = capturedValues[parent->id];
-  Symbol* captemp = NULL;
-  if (symap)
-    captemp = symap->get(varActual);
-  else
-    symap = new SymbolMap();
-  if (!captemp) {
-    captemp = newTemp(astr(formal->name, "_captemp"), formal->type);
-    marker->insertBefore(new DefExpr(captemp));
-    // todo: once AMM is in effect, drop chpl__autoCopy - do straight move
-    if (hasAutoCopyForType(formal->type)) {
-      FnSymbol* autoCopy = getAutoCopy(formal->type);
-      marker->insertBefore("'move'(%S,%S(%S))", captemp, autoCopy, varActual);
-    } else if (isReferenceType(varActual->type) &&
-             !isReferenceType(captemp->type))
-      marker->insertBefore("'move'(%S,'deref'(%S))", captemp, varActual);
-    else
-      marker->insertBefore("'move'(%S,%S)", captemp, varActual);
-    symap->put(varActual, captemp);
-  }
-  actual->replace(new SymExpr(captemp));
-  Symbol*& iact = info.actuals.v[argNum];
-  INT_ASSERT(iact == varActual);
-  iact = captemp;
-}
-
-
-// Ensure 'parent' is the block before which we want to do the capturing.
-static void verifyTaskFnCall(BlockStmt* parent, CallExpr* call) {
-  if (call->isNamed("coforall_fn") || call->isNamed("on_fn")) {
-    INT_ASSERT(parent->isForLoop());
-  } else if (call->isNamed("cobegin_fn")) {
-    DefExpr* first = toDefExpr(parent->getFirstExpr());
-    // just documenting the current state
-    INT_ASSERT(first && !strcmp(first->sym->name, "_cobeginCount"));
-  } else {
-    INT_ASSERT(call->isNamed("begin_fn"));
-  }
-}
-
-//
-// Returns the expression that we want to capture before.
-//
-// Why not just 'parent'? In users/shetag/fock/fock-dyn-prog-cntr.chpl,
-// we cannot do parent->insertBefore() because parent->list is null.
-// That's because we have: if ... then cobegin ..., so 'parent' is
-// immediately under CondStmt. This motivated me for cobegins to capture
-// inside of the 'parent' block, at the beginning of it.
-//
-static Expr* parentToMarker(BlockStmt* parent, CallExpr* call) {
-  if (call->isNamed("cobegin_fn")) {
-    // I want to be cute and keep _cobeginCount def and move
-    // as the first two statements in the block.
-    DefExpr* def = toDefExpr(parent->body.head);
-    INT_ASSERT(def);
-    // Just so we know what we are doing.
-    INT_ASSERT(!strcmp((def->sym->name), "_cobeginCount"));
-    CallExpr* move = toCallExpr(def->next);
-    INT_ASSERT(move);
-    SymExpr* arg1 = toSymExpr(move->get(1));
-    INT_ASSERT(arg1->symbol() == def->sym);
-    // And this is where we want to insert:
-    return move->next;
-  }
-  // Otherwise insert before 'parent'
-  return parent;
 }
 
 /************************************* | **************************************
@@ -597,12 +371,6 @@ void visibleFunctionsClear() {
   visibleFunctionMap.clear();
 
   visibilityBlockCache.clear();
-
-  for (std::map<int, SymbolMap*>::iterator it = capturedValues.begin();
-       it != capturedValues.end();
-       ++it) {
-    delete it->second;
-  }
 }
 
 /************************************* | **************************************


### PR DESCRIPTION
Trivial migration of some logic from visibleFunctions.cpp to functionResolution.cpp


I noticed that findVisibleFunctions() provided special handling for the case in which
callExpr->resolvedFunction() is not NULL. At the time I was momentarily surprised
that we could even get in to this function with a "resolved callExpr".

Not only is there a special path for this form of CallExpr but additional logic is
applied to this small subset of CallExpr that seems "unexpected" if one assumes
the goal is to find the visible functions for a "name".

This PR transfers all of this "special handling" from visibleFunctions.cpp to
functionResolution.cpp so that visibleFunctions.cpp can be focussed on its
traditional role.

At some point I will revisit the handling of "resolved" CallExprs within functionResolution.cpp


Passed conventional compilation/testing protocol with the exception of the recent regression
for 1 test under --no-local that was surfaced with PR 7163.


