### PR TITLE
Support grow by more than 1 in resizeAllocRange

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -2608,9 +2608,10 @@ module ChapelArray {
       // This should only be called for 1-dimensional arrays
       const lo = r.low,
             hi = r.high,
-            size = hi - lo + 1;
+            size = r.size;
+
       if grow > 0 {
-        const newSize = max(size+1, (size*factor):int); // Always grow by at least 1.
+        const newSize = max(size+1, (size*factor):int, r2.size); // Always grow by at least 1.
         if direction > 0 {
           return lo..#newSize;
         } else {

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -2618,6 +2618,7 @@ module ChapelArray {
           return ..hi#-newSize;
         }
       } else {
+        // TODO: grow <= 0 is not tested for |r2.size - r1.size| > 1
         const newSize = min(size-1, (size/factor):int);
         if direction > 0 {
           var newRange = lo..#newSize;

--- a/test/arrays/methods/internal/resizeAllocRange.chpl
+++ b/test/arrays/methods/internal/resizeAllocRange.chpl
@@ -1,0 +1,33 @@
+/* Test to exercise the Grow code paths in _array.resizeAllocRange */
+
+// Dummy array to call methods on
+var Array = [1];
+
+
+//
+// direction = +1
+//
+
+// Grow by 1, small (r1+1)
+assert(Array.resizeAllocRange(1..3, 1..4) == 1..4);
+
+// Grow by 1, large (1.5x)
+assert(Array.resizeAllocRange(1..100, 1..1) == 1..150);
+
+// Grow by more than 1 (r2)
+assert(Array.resizeAllocRange(1..3, 1..7) == 1..7);
+
+
+//
+// direction = -1
+//
+
+// Grow by 1, small (r1+1)
+assert(Array.resizeAllocRange(1..3, 1..4, direction=-1) == 0..3);
+
+// Grow by 1, large (1.5x)
+assert(Array.resizeAllocRange(1..100, 1..1, direction=-1) == -49..100);
+
+// Grow by more than 1 (r2)
+assert(Array.resizeAllocRange(1..3, 1..7, direction=-1) == -3..3);
+

--- a/test/arrays/methods/internal/resizeAllocRange.compopts
+++ b/test/arrays/methods/internal/resizeAllocRange.compopts
@@ -1,0 +1,1 @@
+-s arrayAsVecGrowthFactor=1.5


### PR DESCRIPTION
`resizeAllocRange` only expected a difference of `1` between range sizes `r` and `r2`.  Consequently, it assumes `r.size+1` or `r.size*1.5` will be sufficiently large to accommodate `r2`.

This worked previously, because all the calls to `resizeAllocRange` only had a size delta of `1`. However, In #7180 we need to make bulk array resizes, which breaks down this assumption.

This PR modifies `resizeAllocRange` to account for `r2.size` when resizing, to accommodate any range delta `> 1`.

I also added a test for this functionality.

## Testing

- [x] linux64