### PR TITLE
Quiet sub_test warning for CHPL_TEST_MULTILOCALE_ONLY

### DIFF
--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -1235,7 +1235,7 @@ for testname in testsrc:
                                          numlocales, maxLocalesAvailable))
                 continue
         if os.getenv('CHPL_TEST_MULTILOCALE_ONLY') and (numlocales <= 1):
-            sys.stdout.write('[Warning: skipping {0} because it does not '
+            sys.stdout.write('[Skipping {0} because it does not '
                              'use more than one locale]\n'
                              .format(os.path.join(localdir, test_filename)))
             continue


### PR DESCRIPTION
Previously sub_test printed out a warning for each test that was being skipped.
This caused nightly test failures (and has never been hepful), so remove the
warning.

We quited a similar warning in #5312