### PR TITLE
Workaround to avoid recursive iterator leading to use-after-free bug

### DIFF
--- a/modules/internal/DefaultAssociative.chpl
+++ b/modules/internal/DefaultAssociative.chpl
@@ -756,6 +756,21 @@ module DefaultAssociative {
     proc dsiLocalSubdomain() {
       return _newDomain(dom);
     }
+
+    proc dsiDestroyArr() {
+      //
+      // BHARSH 2017-09-08: Workaround to avoid recursive iterator generation.
+      //
+      // If this method didn't exist, the compiler would incorrectly think
+      // that there was recursion between Replicated, DefaultAssociative, and
+      // DefaultRectangular due to virtual method dispatch on dsiDestroyArr.
+      //
+      // The generated recursive iterator would result in a use-after-free bug
+      // for the following test under --no-local:
+      //
+      // users/npadmana/bugs/replicated_invalid_ref_return/replicated_bug.chpl
+      //
+    }
   }
   
   


### PR DESCRIPTION
If this method didn't exist, the compiler would incorrectly think
that there was recursion between Replicated, DefaultAssociative, and
DefaultRectangular due to virtual method dispatch on dsiDestroyArr.

The generated recursive iterator would result in a use-after-free bug
for the following test under --no-local:
users/npadmana/bugs/replicated_invalid_ref_return/replicated_bug.chpl

The use-after-free bug involves heap allocated variables. The parallel() pass inserts a free() for a heap-allocated var just after the call to a recursive iterator body. The body of this function spawns a single coforall-on task that uses the heap var, meaning that the task may execute after the heap var is free'd.

Testing:
- [x] full local
- [x] full no-local