### PR TITLE
Make c_ptr and c_void_ptr objects printable

### DIFF
--- a/modules/internal/CPtr.chpl
+++ b/modules/internal/CPtr.chpl
@@ -353,7 +353,7 @@ module CPtr {
 
     :arg data: the c_ptr to memory that was allocated
     */
-  inline proc c_free(data: c_ptr) {
+  inline proc c_free(data: c_void_ptr) {
     chpl_here_free(data);
   }
 

--- a/modules/internal/CPtr.chpl
+++ b/modules/internal/CPtr.chpl
@@ -79,6 +79,18 @@ module CPtr {
     inline proc deref() ref {
       return __primitive("array_get", this, 0);
     }
+    /* Print this pointer */
+    inline proc writeThis(ch) {
+      (this:c_void_ptr).writeThis(ch);
+    }
+  }
+
+  pragma "no doc"
+  inline proc c_void_ptr.writeThis(ch) {
+    if this == c_nil then
+      ch.writef("(nil)");
+    else
+      ch.writef("0x%xu", this:uint(64));
   }
 
   pragma "no doc"
@@ -125,7 +137,14 @@ module CPtr {
   inline proc _cast(type t, x) where t:c_void_ptr && x.type:object {
     return __primitive("cast", t, x);
   }
-
+  pragma "no doc"
+  inline proc _cast(type t, x) where t:uint(64) && x.type:c_ptr {
+    return __primitive("cast", t, x);
+  }
+  pragma "no doc"
+  inline proc _cast(type t, x) where t:uint(64) && x.type:c_void_ptr {
+    return __primitive("cast", t, x);
+  }
 
   pragma "compiler generated"
   pragma "last resort"

--- a/test/io/nspark/print-cptr.chpl
+++ b/test/io/nspark/print-cptr.chpl
@@ -1,0 +1,22 @@
+record Foo {
+  var mem = c_nil:c_ptr(uint(64));
+}
+
+record Bar {
+  var mem = c_nil;
+}
+
+writeln("c_nil = ", c_nil);
+
+var foo: Foo;
+writeln("foo = ", foo);
+foo = new Foo(mem=c_malloc(uint(64), 256));
+writeln("foo = ", foo);
+
+var bar: Bar;
+writeln("bar = ", bar);
+bar = new Bar(mem=c_malloc(uint(64), 256):c_void_ptr);
+writeln("bar = ", bar);
+
+c_free(foo.mem);
+c_free(bar.mem);

--- a/test/io/nspark/print-cptr.good
+++ b/test/io/nspark/print-cptr.good
@@ -1,0 +1,5 @@
+c_nil = (nil)
+foo = (mem = (nil))
+foo = (mem = 0x???)
+bar = (mem = (nil))
+bar = (mem = 0x???)

--- a/test/io/nspark/print-cptr.prediff
+++ b/test/io/nspark/print-cptr.prediff
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+outfile=$2
+cat $outfile | sed 's/0x[0-9A-Fa-f][0-9A-Fa-f]*/0x???/' > $outfile.tmp
+mv $outfile.tmp $outfile


### PR DESCRIPTION
Per the title, this PR makes `c_ptr` and `c_void_ptr` objects printable.

This PR would close #7097 to my satisfaction.