### PR TITLE
Improve try compiler error

### DIFF
--- a/compiler/passes/errorHandling.cpp
+++ b/compiler/passes/errorHandling.cpp
@@ -537,7 +537,7 @@ static void printReason(BaseAST* node, implicitThrowsReasons_t* reasons)
       if (calledFn->throwsError()) {
         if (reasons->count(calledFn)) {
           BaseAST* reason = (*reasons)[calledFn];
-          USR_PRINT(reason, " is reason function throws");
+          USR_PRINT(reason, "is reason function throws");
           printReason(reason, reasons);
         }
       }
@@ -799,10 +799,18 @@ bool ErrorCheckingVisitor::enterCallExpr(CallExpr* node) {
             inThrowingFunction = parentFn->throwsError();
           }
           if (mode == ERROR_MODE_STRICT) {
-            USR_FATAL_CONT(node, "throwing call without try or try! (strict mode)");
+            USR_FATAL_CONT(node, "call to throwing function %s "
+                                 "without try or try! (strict mode)",
+                                 calledFn->name);
+            USR_PRINT(calledFn, "throwing function %s defined here",
+                                calledFn->name);
             printReason(node, reasons);
           } else if (mode == ERROR_MODE_RELAXED && !inThrowingFunction) {
-            USR_FATAL_CONT(node, "throwing call in non-throwing function without try or try! (relaxed mode)");
+            USR_FATAL_CONT(node, "call to throwing function %s "
+                                 "without throws, try, or try! (relaxed mode)",
+                                 calledFn->name);
+            USR_PRINT(calledFn, "throwing function %s defined here",
+                                calledFn->name);
             printReason(node, reasons);
           }
         }

--- a/compiler/passes/errorHandling.cpp
+++ b/compiler/passes/errorHandling.cpp
@@ -537,7 +537,7 @@ static void printReason(BaseAST* node, implicitThrowsReasons_t* reasons)
       if (calledFn->throwsError()) {
         if (reasons->count(calledFn)) {
           BaseAST* reason = (*reasons)[calledFn];
-          USR_PRINT(reason, "is reason function throws");
+          USR_PRINT(reason, "call to throwing function here");
           printReason(reason, reasons);
         }
       }

--- a/test/errhandling/modes/implicit-relaxed-try-nothrows-inner.good
+++ b/test/errhandling/modes/implicit-relaxed-try-nothrows-inner.good
@@ -1,2 +1,3 @@
 implicit-relaxed-try-nothrows-inner.chpl:5: In function 'propError':
-implicit-relaxed-try-nothrows-inner.chpl:6: error: throwing call in non-throwing function without try or try! (relaxed mode)
+implicit-relaxed-try-nothrows-inner.chpl:6: error: call to throwing function throwAnError without throws, try, or try! (relaxed mode)
+./ThrowError.chpl:1: note: throwing function throwAnError defined here

--- a/test/errhandling/modes/implicit-relaxed-try-nothrows.good
+++ b/test/errhandling/modes/implicit-relaxed-try-nothrows.good
@@ -1,2 +1,3 @@
 implicit-relaxed-try-nothrows.chpl:5: In function 'propError':
-implicit-relaxed-try-nothrows.chpl:6: error: throwing call in non-throwing function without try or try! (relaxed mode)
+implicit-relaxed-try-nothrows.chpl:6: error: call to throwing function throwAnError without throws, try, or try! (relaxed mode)
+./ThrowError.chpl:1: note: throwing function throwAnError defined here

--- a/test/errhandling/modes/relaxed-try-nothrows.good
+++ b/test/errhandling/modes/relaxed-try-nothrows.good
@@ -1,2 +1,3 @@
 relaxed-try-nothrows.chpl:5: In function 'propError':
-relaxed-try-nothrows.chpl:6: error: throwing call in non-throwing function without try or try! (relaxed mode)
+relaxed-try-nothrows.chpl:6: error: call to throwing function throwAnError without throws, try, or try! (relaxed mode)
+./ThrowError.chpl:1: note: throwing function throwAnError defined here

--- a/test/errhandling/modes/strict-nested-try.good
+++ b/test/errhandling/modes/strict-nested-try.good
@@ -1,2 +1,3 @@
 strict-nested-try.chpl:7: In function 'propError':
-strict-nested-try.chpl:8: error: throwing call without try or try! (strict mode)
+strict-nested-try.chpl:8: error: call to throwing function throwAnError without try or try! (strict mode)
+./ThrowError.chpl:1: note: throwing function throwAnError defined here

--- a/test/errhandling/modes/strict-try-nothrows.good
+++ b/test/errhandling/modes/strict-try-nothrows.good
@@ -1,2 +1,3 @@
 strict-try-nothrows.chpl:5: In function 'propError':
-strict-try-nothrows.chpl:6: error: throwing call without try or try! (strict mode)
+strict-try-nothrows.chpl:6: error: call to throwing function throwAnError without try or try! (strict mode)
+./ThrowError.chpl:1: note: throwing function throwAnError defined here

--- a/test/errhandling/modes/strict-try.good
+++ b/test/errhandling/modes/strict-try.good
@@ -1,2 +1,3 @@
 strict-try.chpl:5: In function 'propError':
-strict-try.chpl:6: error: throwing call without try or try! (strict mode)
+strict-try.chpl:6: error: call to throwing function throwAnError without try or try! (strict mode)
+./ThrowError.chpl:1: note: throwing function throwAnError defined here

--- a/test/errhandling/parallel/strict/coforall-throws-strict-error.good
+++ b/test/errhandling/parallel/strict/coforall-throws-strict-error.good
@@ -1,4 +1,4 @@
 coforall-throws-strict-error.chpl:3: In function 'test':
 coforall-throws-strict-error.chpl:4: error: call to throwing function coforall_fn without try or try! (strict mode)
 coforall-throws-strict-error.chpl:4: note: throwing function coforall_fn defined here
-coforall-throws-strict-error.chpl:5: note: is reason function throws
+coforall-throws-strict-error.chpl:5: note: call to throwing function here

--- a/test/errhandling/parallel/strict/coforall-throws-strict-error.good
+++ b/test/errhandling/parallel/strict/coforall-throws-strict-error.good
@@ -1,3 +1,4 @@
 coforall-throws-strict-error.chpl:3: In function 'test':
-coforall-throws-strict-error.chpl:4: error: throwing call without try or try! (strict mode)
-coforall-throws-strict-error.chpl:5: note:  is reason function throws
+coforall-throws-strict-error.chpl:4: error: call to throwing function coforall_fn without try or try! (strict mode)
+coforall-throws-strict-error.chpl:4: note: throwing function coforall_fn defined here
+coforall-throws-strict-error.chpl:5: note: is reason function throws


### PR DESCRIPTION
Improve the compiler error messages that were previously `throwing call in non-throwing function without try or try!` to include more information and to remove unnecessary spaces.

- [x] full local testing

Reviewed by @lydia-duncan and @psahabu - thanks!