### PR TITLE
Add past few releases to testReleasesPerformance script

### DIFF
--- a/util/pastPerformance/testReleasesPerformance
+++ b/util/pastPerformance/testReleasesPerformance
@@ -115,9 +115,13 @@ export CHPL_TEST_PERF_DATE="03/29/16"
 export CHPL_HOME=$chpl_release_home/chapel-1.13.1
 testReleasePerformance
 
-unset CHPL_TEST_PERF_DATE
-export CHPL_HOME=$CHPL_HOME_ORIG
-$CHPL_TEST_UTIL_DIR/start_test --gen-graphs
+export CHPL_TEST_PERF_DATE="09/27/16"
+export CHPL_HOME=$chpl_release_home/chapel-1.14.0
+testReleasePerformance
+
+export CHPL_TEST_PERF_DATE="03/27/17"
+export CHPL_HOME=$chpl_release_home/chapel-1.15.0
+testReleasePerformance
 
 #
 # ADD NEW RELEASES HERE AS THEY ARE CREATED.
@@ -125,6 +129,12 @@ $CHPL_TEST_UTIL_DIR/start_test --gen-graphs
 # (The date should be the date of the release branch, which should
 # match the date in $CHPL_HOME/util/test/perf/perfgraph.js)
 #
+
+unset CHPL_TEST_PERF_DATE
+export CHPL_HOME=$CHPL_HOME_ORIG
+$CHPL_TEST_UTIL_DIR/start_test --gen-graphs
+
+
 
 
 


### PR DESCRIPTION
Somehow, these have been overlooked as part of the release procedure.
Noticed this in gathering release-over-release numbers in anticipation
of the 1.16 release.