### PR TITLE
Add six new tests of appropriate error messages for instance declaration errors

### DIFF
--- a/test/classes/initializers/errors/bothGeneric-lhsConsRhsInit.chpl
+++ b/test/classes/initializers/errors/bothGeneric-lhsConsRhsInit.chpl
@@ -1,0 +1,22 @@
+// Verify behavior when both the type with a constructor and
+// the type with an initializer are generic
+class hasInit {
+  var x;
+
+  proc init(xVal) {
+    x = xVal;
+    super.init();
+  }
+}
+
+class hasConstruct {
+  var x;
+
+  proc hasConstruct(x) {
+    this.x = x;
+  }
+}
+
+var hi: hasConstruct(int) = new hasInit(10);
+writeln(hi);
+delete hi;

--- a/test/classes/initializers/errors/bothGeneric-lhsConsRhsInit.good
+++ b/test/classes/initializers/errors/bothGeneric-lhsConsRhsInit.good
@@ -1,0 +1,1 @@
+bothGeneric-lhsConsRhsInit.chpl:20: error: type mismatch in assignment from hasInit(int(64)) to hasConstruct(int(64))

--- a/test/classes/initializers/errors/bothGeneric-lhsInitRhsCons.chpl
+++ b/test/classes/initializers/errors/bothGeneric-lhsInitRhsCons.chpl
@@ -1,0 +1,22 @@
+// Verify behavior both the type with an initializer and
+// the type with a constructor are generic
+class hasInit {
+  var x;
+
+  proc init(xVal) {
+    x = xVal;
+    super.init();
+  }
+}
+
+class hasConstruct {
+  var x;
+
+  proc hasConstruct(x) {
+    this.x = x;
+  }
+}
+
+var hi: hasInit(int) = new hasConstruct(10);
+writeln(hi);
+delete hi;

--- a/test/classes/initializers/errors/bothGeneric-lhsInitRhsCons.good
+++ b/test/classes/initializers/errors/bothGeneric-lhsInitRhsCons.good
@@ -1,0 +1,1 @@
+bothGeneric-lhsInitRhsCons.chpl:20: error: type mismatch in assignment from hasConstruct(int(64)) to hasInit(int(64))

--- a/test/classes/initializers/errors/generic-lhsConsRhsInit.chpl
+++ b/test/classes/initializers/errors/generic-lhsConsRhsInit.chpl
@@ -1,0 +1,22 @@
+// Verify behavior when the type with a constructor is generic,
+// but the type with an initializer is concrete
+class hasInit {
+  var x: int;
+
+  proc init(xVal) {
+    x = xVal;
+    super.init();
+  }
+}
+
+class hasConstruct {
+  var x;
+
+  proc hasConstruct(x) {
+    this.x = x;
+  }
+}
+
+var hi: hasConstruct(int) = new hasInit(10);
+writeln(hi);
+delete hi;

--- a/test/classes/initializers/errors/generic-lhsConsRhsInit.good
+++ b/test/classes/initializers/errors/generic-lhsConsRhsInit.good
@@ -1,0 +1,1 @@
+generic-lhsConsRhsInit.chpl:20: error: type mismatch in assignment from hasInit to hasConstruct(int(64))

--- a/test/classes/initializers/errors/generic-lhsConsRhsInit2.chpl
+++ b/test/classes/initializers/errors/generic-lhsConsRhsInit2.chpl
@@ -1,0 +1,22 @@
+// Verify behavior when the type with a constructor is concrete,
+// but the type with an initializer is generic
+class hasInit {
+  var x;
+
+  proc init(xVal) {
+    x = xVal;
+    super.init();
+  }
+}
+
+class hasConstruct {
+  var x: int;
+
+  proc hasConstruct(xVal) {
+    x = xVal;
+  }
+}
+
+var hi: hasConstruct = new hasInit(10);
+writeln(hi);
+delete hi;

--- a/test/classes/initializers/errors/generic-lhsConsRhsInit2.good
+++ b/test/classes/initializers/errors/generic-lhsConsRhsInit2.good
@@ -1,0 +1,1 @@
+generic-lhsConsRhsInit2.chpl:20: error: type mismatch in assignment from hasInit(int(64)) to hasConstruct

--- a/test/classes/initializers/errors/generic-lhsInitRhsCons.chpl
+++ b/test/classes/initializers/errors/generic-lhsInitRhsCons.chpl
@@ -1,0 +1,22 @@
+// Verify behavior when the type with an initializer is generic,
+// but the type with a constructor is concrete
+class hasInit {
+  var x;
+
+  proc init(xVal) {
+    x = xVal;
+    super.init();
+  }
+}
+
+class hasConstruct {
+  var x: int;
+
+  proc hasConstruct(xVal) {
+    x = xVal;
+  }
+}
+
+var hi: hasInit(int) = new hasConstruct(10);
+writeln(hi);
+delete hi;

--- a/test/classes/initializers/errors/generic-lhsInitRhsCons.good
+++ b/test/classes/initializers/errors/generic-lhsInitRhsCons.good
@@ -1,0 +1,1 @@
+generic-lhsInitRhsCons.chpl:20: error: type mismatch in assignment from hasConstruct to hasInit(int(64))

--- a/test/classes/initializers/errors/generic-lhsInitRhsCons2.chpl
+++ b/test/classes/initializers/errors/generic-lhsInitRhsCons2.chpl
@@ -1,0 +1,22 @@
+// Verify behavior when the type with an initializer is concrete,
+// but the type with a constructor is generic
+class hasInit {
+  var x: int;
+
+  proc init(xVal) {
+    x = xVal;
+    super.init();
+  }
+}
+
+class hasConstruct {
+  var x;
+
+  proc hasConstruct(x) {
+    this.x = x;
+  }
+}
+
+var hi: hasInit = new hasConstruct(10);
+writeln(hi);
+delete hi;

--- a/test/classes/initializers/errors/generic-lhsInitRhsCons2.good
+++ b/test/classes/initializers/errors/generic-lhsInitRhsCons2.good
@@ -1,0 +1,1 @@
+generic-lhsInitRhsCons2.chpl:20: error: type mismatch in assignment from hasConstruct(int(64)) to hasInit


### PR DESCRIPTION
Covers variations of declaring the type to be one that defines a [constructor |
initializer] while the new expression calls a type that defines the opposite.
Previous variations only involved concrete types - these ones cover when either
the constructor type or the initializer type is generic, or when both are.

All six pass.