### PR TITLE
Quiet test_record_of_domain_type future under valgrind

### DIFF
--- a/test/arrays/deitz/part3/test_record_of_domain_type.bad
+++ b/test/arrays/deitz/part3/test_record_of_domain_type.bad
@@ -1,4 +1,3 @@
-{1..3}
 (x = {1..0})
 Thread
 Conditional jump or move depends on uninitialised value(s)

--- a/test/arrays/deitz/part3/test_record_of_domain_type.prediff
+++ b/test/arrays/deitz/part3/test_record_of_domain_type.prediff
@@ -9,9 +9,9 @@ if grep -q '^==[0-9]*== ' $outfile; then
   # Preserve the original output.
   mv $outfile $temp
 
-  # Grab the first two lines of the program output
-  # because they should be deterministic.
-  grep -v ^= $temp | head -2 > $outfile
+  # Grab the second line of the program output
+  # because it should be deterministic.
+  grep -v ^= $temp | head -2 | tail -n1 > $outfile
 
   # Add the first two lines of valgrind output, cleaned up.
   grep ^= $temp | sed 's@^=[^ ]*= @@;s@Thread.*@Thread@' | head -2 >> $outfile


### PR DESCRIPTION
test_record_of_domain_type started sporadically failing to match the .bad file
with #7222. For some reason the first line of output is occasionally missing a
"{". This happens to the 3rd line as well, so the prediff already filters it
out. Instead of investigating this further, just update the prediff to only
grab the second line of output. That seems to be stable (passes 1,000 trials)