### PR TITLE
Add compilation errors for when initializers involve error handling

### DIFF
--- a/test/classes/initializers/errors/errHandling/initThrows.chpl
+++ b/test/classes/initializers/errors/errHandling/initThrows.chpl
@@ -1,0 +1,14 @@
+// Verifies we currently don't allow initializers to be declared as throws
+// We hope to eventually allow it.
+class Foo {
+  var x: int;
+
+  proc init() throws {
+    x = 10;
+    super.init();
+  }
+}
+
+var foo = new Foo();
+writeln(foo);
+delete foo;

--- a/test/classes/initializers/errors/errHandling/initThrows.good
+++ b/test/classes/initializers/errors/errHandling/initThrows.good
@@ -1,0 +1,1 @@
+initThrows.chpl:6: error: initializers are not yet allowed to throw errors

--- a/test/classes/initializers/errors/errHandling/initWithThrow.chpl
+++ b/test/classes/initializers/errors/errHandling/initWithThrow.chpl
@@ -1,0 +1,16 @@
+// Verifies we currently don't allow initializers to have throw statements in
+// their body.
+// We hope to eventually allow it.
+class Foo {
+  var x: int;
+
+  proc init() {
+    x = 10;
+    throw new Error();
+    super.init();
+  }
+}
+
+var foo = new Foo();
+writeln(foo);
+delete foo;

--- a/test/classes/initializers/errors/errHandling/initWithThrow.good
+++ b/test/classes/initializers/errors/errHandling/initWithThrow.good
@@ -1,0 +1,2 @@
+initWithThrow.chpl:7: In initializer:
+initWithThrow.chpl:9: error: Error handling structures are not yet allowed in initializers

--- a/test/classes/initializers/errors/errHandling/initWithThrow.good
+++ b/test/classes/initializers/errors/errHandling/initWithThrow.good
@@ -1,2 +1,2 @@
 initWithThrow.chpl:7: In initializer:
-initWithThrow.chpl:9: error: Error handling structures are not yet allowed in initializers
+initWithThrow.chpl:9: error: initializers are not yet allowed to throw errors

--- a/test/classes/initializers/errors/errHandling/initWithTry.chpl
+++ b/test/classes/initializers/errors/errHandling/initWithTry.chpl
@@ -1,0 +1,20 @@
+// Verifies we currently don't allow initializers to have try statements in
+// their body.
+// We hope to eventually allow it.
+class Foo {
+  var x: int;
+
+  proc init() {
+    x = 10;
+    try outerFunc();
+    super.init();
+  }
+}
+
+proc outerFunc() throws {
+  throw new Error();
+}
+
+var foo = new Foo();
+writeln(foo);
+delete foo;

--- a/test/classes/initializers/errors/errHandling/initWithTry.good
+++ b/test/classes/initializers/errors/errHandling/initWithTry.good
@@ -1,0 +1,2 @@
+initWithTry.chpl:7: In initializer:
+initWithTry.chpl:9: error: Error handling structures are not yet allowed in initializers

--- a/test/classes/initializers/errors/errHandling/initWithTry.good
+++ b/test/classes/initializers/errors/errHandling/initWithTry.good
@@ -1,2 +1,2 @@
 initWithTry.chpl:7: In initializer:
-initWithTry.chpl:9: error: Error handling structures are not yet allowed in initializers
+initWithTry.chpl:9: error: Only catch-less try! statements are allowed in initializers for now

--- a/test/classes/initializers/errors/errHandling/initWithTry2.chpl
+++ b/test/classes/initializers/errors/errHandling/initWithTry2.chpl
@@ -1,0 +1,22 @@
+// Verifies we currently don't allow initializers to have try statements in
+// their body.
+// We hope to eventually allow it.
+class Foo {
+  var x: int;
+
+  proc init() {
+    x = 10;
+    try {
+      outerFunc();
+    }
+    super.init();
+  }
+}
+
+proc outerFunc() throws {
+  throw new Error();
+}
+
+var foo = new Foo();
+writeln(foo);
+delete foo;

--- a/test/classes/initializers/errors/errHandling/initWithTry2.good
+++ b/test/classes/initializers/errors/errHandling/initWithTry2.good
@@ -1,0 +1,2 @@
+initWithTry2.chpl:7: In initializer:
+initWithTry2.chpl:9: error: Error handling structures are not yet allowed in initializers

--- a/test/classes/initializers/errors/errHandling/initWithTry2.good
+++ b/test/classes/initializers/errors/errHandling/initWithTry2.good
@@ -1,2 +1,2 @@
 initWithTry2.chpl:7: In initializer:
-initWithTry2.chpl:9: error: Error handling structures are not yet allowed in initializers
+initWithTry2.chpl:9: error: Only catch-less try! statements are allowed in initializers for now

--- a/test/classes/initializers/errors/errHandling/initWithTryBang.chpl
+++ b/test/classes/initializers/errors/errHandling/initWithTryBang.chpl
@@ -1,0 +1,22 @@
+// Verifies we currently don't allow initializers to have try! statements in
+// their body.
+// We hope to eventually allow it.
+class Foo {
+  var x: int;
+
+  proc init() {
+    x = 10;
+    try! {
+      outerFunc();
+    }
+    super.init();
+  }
+}
+
+proc outerFunc() throws {
+  throw new Error();
+}
+
+var foo = new Foo();
+writeln(foo);
+delete foo;

--- a/test/classes/initializers/errors/errHandling/initWithTryBang.chpl
+++ b/test/classes/initializers/errors/errHandling/initWithTryBang.chpl
@@ -1,6 +1,5 @@
-// Verifies we currently don't allow initializers to have try! statements in
-// their body.
-// We hope to eventually allow it.
+// Verifies we currently allow initializers to have try! statements in their
+// body, as long as it doesn't have a catch block
 class Foo {
   var x: int;
 

--- a/test/classes/initializers/errors/errHandling/initWithTryBang.good
+++ b/test/classes/initializers/errors/errHandling/initWithTryBang.good
@@ -1,0 +1,2 @@
+initWithTryBang.chpl:7: In initializer:
+initWithTryBang.chpl:9: error: Error handling structures are not yet allowed in initializers

--- a/test/classes/initializers/errors/errHandling/initWithTryBang.good
+++ b/test/classes/initializers/errors/errHandling/initWithTryBang.good
@@ -1,2 +1,3 @@
-initWithTryBang.chpl:7: In initializer:
-initWithTryBang.chpl:9: error: Error handling structures are not yet allowed in initializers
+uncaught Error: 
+  initWithTryBang.chpl:16: thrown here
+  initWithTryBang.chpl:19: uncaught here

--- a/test/classes/initializers/errors/errHandling/initWithTryBang2.bad
+++ b/test/classes/initializers/errors/errHandling/initWithTryBang2.bad
@@ -1,0 +1,3 @@
+uncaught Error: 
+  initWithTryBang2.chpl:14: thrown here
+  initWithTryBang2.chpl:17: uncaught here

--- a/test/classes/initializers/errors/errHandling/initWithTryBang2.chpl
+++ b/test/classes/initializers/errors/errHandling/initWithTryBang2.chpl
@@ -1,6 +1,5 @@
-// Verifies we currently don't allow initializers to have try! statements in
-// their body.
-// We hope to eventually allow it.
+// Verifies we currently allow initializers to have try! statements in their
+// body, as long as it doesn't have a catch block.
 class Foo {
   var x: int;
 

--- a/test/classes/initializers/errors/errHandling/initWithTryBang2.chpl
+++ b/test/classes/initializers/errors/errHandling/initWithTryBang2.chpl
@@ -1,0 +1,20 @@
+// Verifies we currently don't allow initializers to have try! statements in
+// their body.
+// We hope to eventually allow it.
+class Foo {
+  var x: int;
+
+  proc init() {
+    x = 10;
+    try! outerFunc();
+    super.init();
+  }
+}
+
+proc outerFunc() throws {
+  throw new Error();
+}
+
+var foo = new Foo();
+writeln(foo);
+delete foo;

--- a/test/classes/initializers/errors/errHandling/initWithTryBang2.future
+++ b/test/classes/initializers/errors/errHandling/initWithTryBang2.future
@@ -1,0 +1,5 @@
+bug: wrong line number reported for uncaught error
+
+This test (as well as initWithTryBang.chpl and tryBangDeeper.chpl) reports the
+uncaught error on the variable initialization line, rather than the try! line
+in the initializer itself.

--- a/test/classes/initializers/errors/errHandling/initWithTryBang2.good
+++ b/test/classes/initializers/errors/errHandling/initWithTryBang2.good
@@ -1,0 +1,2 @@
+initWithTryBang2.chpl:7: In initializer:
+initWithTryBang2.chpl:9: error: Error handling structures are not yet allowed in initializers

--- a/test/classes/initializers/errors/errHandling/initWithTryBang2.good
+++ b/test/classes/initializers/errors/errHandling/initWithTryBang2.good
@@ -1,2 +1,3 @@
-initWithTryBang2.chpl:7: In initializer:
-initWithTryBang2.chpl:9: error: Error handling structures are not yet allowed in initializers
+uncaught Error: 
+  initWithTryBang2.chpl:14: thrown here
+  initWithTryBang2.chpl:8: uncaught here

--- a/test/classes/initializers/errors/errHandling/initWithTryBangCatch.chpl
+++ b/test/classes/initializers/errors/errHandling/initWithTryBangCatch.chpl
@@ -1,0 +1,24 @@
+// Verifies we currently don't allow initializers to have try! statements with
+// catch blocks in their body.
+// We hope to eventually allow it.
+class Foo {
+  var x: int;
+
+  proc init() {
+    try! {
+      outerFunc();
+      x = 10;
+    } catch {
+      writeln("Look ma, I caught an error!");
+    }
+    super.init();
+  }
+}
+
+proc outerFunc() throws {
+  throw new Error();
+}
+
+var foo = new Foo();
+writeln(foo);
+delete foo;

--- a/test/classes/initializers/errors/errHandling/initWithTryBangCatch.good
+++ b/test/classes/initializers/errors/errHandling/initWithTryBangCatch.good
@@ -1,0 +1,2 @@
+initWithTryBangCatch.chpl:7: In initializer:
+initWithTryBangCatch.chpl:8: error: Only catch-less try! statements are allowed in initializers for now

--- a/test/classes/initializers/errors/errHandling/initWithTryCatch.chpl
+++ b/test/classes/initializers/errors/errHandling/initWithTryCatch.chpl
@@ -1,0 +1,24 @@
+// Verifies we currently don't allow initializers to have try statements in
+// their body.
+// We hope to eventually allow it.
+class Foo {
+  var x: int;
+
+  proc init() {
+    x = 10;
+    try {
+      outerFunc();
+    } catch {
+      writeln("Look ma, I caught an error!");
+    }
+    super.init();
+  }
+}
+
+proc outerFunc() throws {
+  throw new Error();
+}
+
+var foo = new Foo();
+writeln(foo);
+delete foo;

--- a/test/classes/initializers/errors/errHandling/initWithTryCatch.chpl
+++ b/test/classes/initializers/errors/errHandling/initWithTryCatch.chpl
@@ -5,9 +5,9 @@ class Foo {
   var x: int;
 
   proc init() {
-    x = 10;
     try {
       outerFunc();
+      x = 10;
     } catch {
       writeln("Look ma, I caught an error!");
     }

--- a/test/classes/initializers/errors/errHandling/initWithTryCatch.good
+++ b/test/classes/initializers/errors/errHandling/initWithTryCatch.good
@@ -1,0 +1,2 @@
+initWithTryCatch.chpl:7: In initializer:
+initWithTryCatch.chpl:9: error: Error handling structures are not yet allowed in initializers

--- a/test/classes/initializers/errors/errHandling/initWithTryCatch.good
+++ b/test/classes/initializers/errors/errHandling/initWithTryCatch.good
@@ -1,2 +1,2 @@
 initWithTryCatch.chpl:7: In initializer:
-initWithTryCatch.chpl:9: error: Error handling structures are not yet allowed in initializers
+initWithTryCatch.chpl:8: error: Only catch-less try! statements are allowed in initializers for now

--- a/test/classes/initializers/errors/errHandling/tryBangDeeper.chpl
+++ b/test/classes/initializers/errors/errHandling/tryBangDeeper.chpl
@@ -1,0 +1,22 @@
+// Verifies we currently don't allow initializers to have try! statements in
+// their body, even when the statement is wrapped by something else.
+// We hope to eventually allow it.
+class Foo {
+  var x: int;
+
+  proc init() {
+    x = 10;
+    {
+      try! outerFunc();
+    }
+    super.init();
+  }
+}
+
+proc outerFunc() throws {
+  throw new Error();
+}
+
+var foo = new Foo();
+writeln(foo);
+delete foo;

--- a/test/classes/initializers/errors/errHandling/tryBangDeeper.good
+++ b/test/classes/initializers/errors/errHandling/tryBangDeeper.good
@@ -1,2 +1,0 @@
-tryBangDeeper.chpl:7: In initializer:
-tryBangDeeper.chpl:10: error: Error handling structures are not yet allowed in initializers

--- a/test/classes/initializers/errors/errHandling/tryBangDeeper.good
+++ b/test/classes/initializers/errors/errHandling/tryBangDeeper.good
@@ -1,0 +1,2 @@
+tryBangDeeper.chpl:7: In initializer:
+tryBangDeeper.chpl:10: error: Error handling structures are not yet allowed in initializers

--- a/test/classes/initializers/errors/errHandling/tryDeeper.chpl
+++ b/test/classes/initializers/errors/errHandling/tryDeeper.chpl
@@ -1,4 +1,4 @@
-// Verifies we currently don't allow initializers to have try! statements in
+// Verifies we currently don't allow initializers to have try statements in
 // their body, even when the statement is wrapped by something else.
 // We hope to eventually allow it.
 class Foo {
@@ -7,7 +7,7 @@ class Foo {
   proc init() {
     x = 10;
     {
-      try! outerFunc();
+      try outerFunc();
     }
     super.init();
   }

--- a/test/classes/initializers/errors/errHandling/tryDeeper.good
+++ b/test/classes/initializers/errors/errHandling/tryDeeper.good
@@ -1,0 +1,2 @@
+tryDeeper.chpl:7: In initializer:
+tryDeeper.chpl:10: error: Only catch-less try! statements are allowed in initializers for now

--- a/test/classes/initializers/parentCall/syncStatements.bad
+++ b/test/classes/initializers/parentCall/syncStatements.bad
@@ -1,0 +1,2 @@
+syncStatements.chpl:7: In initializer:
+syncStatements.chpl:9: error: Error handling structures are not yet allowed in initializers

--- a/test/classes/initializers/parentCall/syncStatements.bad
+++ b/test/classes/initializers/parentCall/syncStatements.bad
@@ -1,2 +1,2 @@
 syncStatements.chpl:7: In initializer:
-syncStatements.chpl:9: error: Error handling structures are not yet allowed in initializers
+syncStatements.chpl:9: error: Only catch-less try! statements are allowed in initializers for now

--- a/test/classes/initializers/parentCall/syncStatements.future
+++ b/test/classes/initializers/parentCall/syncStatements.future
@@ -1,0 +1,4 @@
+feature request: support sync statements in initializers
+
+Due to their implicit try wrapping, we cannot support sync statements in
+initializers today (see #7098 and #6145)

--- a/test/classes/initializers/phase1/syncStatements.bad
+++ b/test/classes/initializers/phase1/syncStatements.bad
@@ -1,1 +1,2 @@
-{x = 0}
+syncStatements.chpl:7: In initializer:
+syncStatements.chpl:8: error: Error handling structures are not yet allowed in initializers

--- a/test/classes/initializers/phase1/syncStatements.bad
+++ b/test/classes/initializers/phase1/syncStatements.bad
@@ -1,2 +1,2 @@
 syncStatements.chpl:7: In initializer:
-syncStatements.chpl:8: error: Error handling structures are not yet allowed in initializers
+syncStatements.chpl:8: error: Only catch-less try! statements are allowed in initializers for now

--- a/test/classes/initializers/siblingCall/syncStatements.bad
+++ b/test/classes/initializers/siblingCall/syncStatements.bad
@@ -1,2 +1,2 @@
 syncStatements.chpl:8: In initializer:
-syncStatements.chpl:9: error: Error handling structures are not yet allowed in initializers
+syncStatements.chpl:9: error: Only catch-less try! statements are allowed in initializers for now

--- a/test/classes/initializers/siblingCall/syncStatements.bad
+++ b/test/classes/initializers/siblingCall/syncStatements.bad
@@ -1,0 +1,2 @@
+syncStatements.chpl:8: In initializer:
+syncStatements.chpl:9: error: Error handling structures are not yet allowed in initializers

--- a/test/classes/initializers/siblingCall/syncStatements.future
+++ b/test/classes/initializers/siblingCall/syncStatements.future
@@ -1,0 +1,4 @@
+feature request: support sync statements in initializers
+
+Due to their implicit try wrapping, we cannot support sync statements in
+initializers today (see #7098 and #6145)


### PR DESCRIPTION
While we would like to be able to allow throw, try, and try! inside an
initializer during Phase 2 only, we didn't have time to implement that this
release.  Instead, add a temporary error about using those structures (with
the except of try! without a catch block, as it will cause an execution halt
and thus will not return the instance in a bad state), and declaring an
initializer as throws.

Adds 9 tests to verify the new error messages, covering:
- declaring the initializer as throws
- having a throw in an initializer body (currently just checks Phase 1)
- having a `try stmt` in an initializer body (ditto above)
- having a `try { stmts }` in an initializer body (ditto above)
- having a `try! stmt` in an initializer body (ditto above)
- having a `try! { stmts }` in an initializer body (ditto above)
- having a `try { stmts } catch { stmts }` in an initializer body (ditto above)
- having a `try! { stmts } catch { stmts }` in an initializer body (ditto above)
- having one of the above in an initializer body when it is not a top level
  statement (ditto above)

Testing: running a full paratest w/ futures