### PR TITLE
fix compilation error when using Spawn

### DIFF
--- a/modules/standard/Spawn.chpl
+++ b/modules/standard/Spawn.chpl
@@ -467,10 +467,9 @@ module Spawn {
           if sys_getenv(c"PE_PRODUCT_LIST", env_c_str)==1 {
             env_str = env_c_str;
             if env_str.count("HUGETLB") > 0 then
-              throw SystemError.fromSyserr(EINVAL,
-                  "spawn with more than 1 locale ",
-                  "for CHPL_COMM=ugni with hugepages currently ",
-                  "requires stdin, stdout, stderr=FORWARD");
+              throw SystemError.fromSyserr(
+                  EINVAL,
+                  "spawn with more than 1 locale for CHPL_COMM=ugni with hugepages currently requires stdin, stdout, stderr=FORWARD");
           }
         }
 


### PR DESCRIPTION
One call to `SystemError.fromSyserr()` in Spawn accidentally used multiple strings instead of just one, leading to compilation errors in some tests. Thanks to @ronawho for catching this.