### PR TITLE
Fix futures that were failing

### DIFF
--- a/test/errhandling/psahabu/forall-errors.bad
+++ b/test/errhandling/psahabu/forall-errors.bad
@@ -1,3 +1,3 @@
-uncaught TaskErrors: 4 errors: Error: iteration: 1 ... Error: iteration: 5
-  forall-errors.chpl:4: thrown here
-  forall-errors.chpl:4: uncaught here
+forall-errors.chpl:11: In function 'main':
+forall-errors.chpl:12: error: call to throwing function throwingFn without try or try! (strict mode)
+forall-errors.chpl:4: note: throwing function throwingFn defined here

--- a/test/errhandling/psahabu/forall-errors.chpl
+++ b/test/errhandling/psahabu/forall-errors.chpl
@@ -1,10 +1,14 @@
 pragma "error mode strict"
+module TestModule {
 
-proc throwingFn() throws {
-  forall i in 1..5 {
-    throw new Error("iteration: " + i);
+  proc throwingFn() throws {
+    forall i in 1..5 {
+      throw new Error("iteration: " + i);
+    }
+    return "OK";
   }
-  return "OK";
-}
 
-writeln(throwingFn());
+  proc main() {
+    writeln(throwingFn());
+  }
+}

--- a/test/io/ferguson/read-class-reorder3.bad
+++ b/test/io/ferguson/read-class-reorder3.bad
@@ -1,5 +1,5 @@
 a is {a = 1, b = 2, x = 3, y = 4}
 writing {b=5,y=7,a=4,x=6}
-uncaught SystemError: bad format in channel.read(ref a:Child) with path "test.txt" offset 9
+uncaught BadFormatError: bad format (in channel.read(ref a:Child) with path "test.txt" offset 9)
   read-class-reorder3.chpl:26: thrown here
   read-class-reorder3.chpl:26: uncaught here


### PR DESCRIPTION
Addresses failures with two futures in matching their .bad files.

Passed full local futures testing.

Trivial testing change, not reviewed.