### PR TITLE
This PR adjusts SSCA2 modules to use implicit module

### DIFF
--- a/test/release/examples/benchmarks/ssca2/SSCA2_Modules/SSCA2_RMAT_graph_generator.chpl
+++ b/test/release/examples/benchmarks/ssca2/SSCA2_Modules/SSCA2_RMAT_graph_generator.chpl
@@ -1,534 +1,529 @@
-pragma "error mode fatal"
-module SSCA2_RMAT_graph_generator
+// +=========================================================================+
+// |             RMAT approximate power law graph generator                  |
+// |                                 and                                     |
+// |                           SSCA #2 Kernel 1                              |
+// |                                                                         |
+// |  Generate approximate power law graph                                   |
+// |                                                                         |
+// |  This procedure accepts a generic graph representation which must       |
+// |  provide only the capabilities to:                                      |
+// |    1. add a vertex to a neighbor list for some other vertex             |
+// |    2. assign an integer weight to an entry in an associated weight list |
+// |                                                                         |
+// |  The RMAT procedure implicitly assumes that vertices are integers       |
+// |  in the range [0, 2^SCALE].  So vertices are integers in this           |
+// |  procedure and edges are pairs of integers.                             |
+// |                                                                         |
+// |  This implementation first generates the RMAT graph as a list of        |
+// |  triples, using an array of edges and an associated array of weights.   |
+// |  These are transformed into the Chapel graph representation using       |
+// |  native Chapel syntax for associative and sparse domains and arrays.    |
+// |  That transformation is Kernel 1 of the SSCA #2 benchmark.              |
+// |                                                                         |
+// |  The code uses two auxiliary procedures for clarity and to help the     |
+// |  compiler use more abstract, higher level, code.                        |
+// +=========================================================================+
 
-{
-  // +=========================================================================+
-  // |             RMAT approximate power law graph generator                  |
-  // |                                 and                                     |
-  // |                           SSCA #2 Kernel 1                              |
-  // |                                                                         |
-  // |  Generate approximate power law graph                                   |
-  // |                                                                         |
-  // |  This procedure accepts a generic graph representation which must       |
-  // |  provide only the capabilities to:                                      |
-  // |    1. add a vertex to a neighbor list for some other vertex             |
-  // |    2. assign an integer weight to an entry in an associated weight list |
-  // |                                                                         |
-  // |  The RMAT procedure implicitly assumes that vertices are integers       |
-  // |  in the range [0, 2^SCALE].  So vertices are integers in this           |
-  // |  procedure and edges are pairs of integers.                             |
-  // |                                                                         |
-  // |  This implementation first generates the RMAT graph as a list of        |
-  // |  triples, using an array of edges and an associated array of weights.   |
-  // |  These are transformed into the Chapel graph representation using       |
-  // |  native Chapel syntax for associative and sparse domains and arrays.    |
-  // |  That transformation is Kernel 1 of the SSCA #2 benchmark.              |
-  // |                                                                         |
-  // |  The code uses two auxiliary procedures for clarity and to help the     |
-  // |  compiler use more abstract, higher level, code.                        |
-  // +=========================================================================+
+use SSCA2_compilation_config_params, Time, BlockDist;
 
-  use SSCA2_compilation_config_params, Time, BlockDist;
+// File names to dump the edge list and the constructed graph, resp.
+// By default, printouts, if requested, are traditional.
+config const rmatEdgeGenFile = "";
+config const rmatGraphConFile = "";
 
-  // File names to dump the edge list and the constructed graph, resp.
-  // By default, printouts, if requested, are traditional.
-  config const rmatEdgeGenFile = "";
-  config const rmatGraphConFile = "";
+// These control which variations of the code to run.
+config const newEG = true;      // do new-style edge generation?
+config const parEG = true;      // do newEG permutations in parallel?
+config const numDepths = -1;    // number of edge tweaks; -1 for baseline
+config const edgeChecks = true; // run edge consistency checks?
+config const parGC = true;      // do Graph Generation in parallel?
+// Set to false for parallel computation (=> faster but not reproducible).
+config param SERIAL_GRAPH_GEN = REPRODUCIBLE_PROBLEMS;
 
-  // These control which variations of the code to run.
-  config const newEG = true;      // do new-style edge generation?
-  config const parEG = true;      // do newEG permutations in parallel?
-  config const numDepths = -1;    // number of edge tweaks; -1 for baseline
-  config const edgeChecks = true; // run edge consistency checks?
-  config const parGC = true;      // do Graph Generation in parallel?
-  // Set to false for parallel computation (=> faster but not reproducible).
-  config param SERIAL_GRAPH_GEN = REPRODUCIBLE_PROBLEMS;
+var stopwatch : Timer;
 
-  var stopwatch : Timer;
+record directed_vertex_pair {
+  var start = 1: int;
+  var end   = 1: int;
+}
 
-  record directed_vertex_pair {
-    var start = 1: int;
-    var end   = 1: int; 
+
+// ============================
+// Quadrant selection algorithm
+// ============================
+
+inline proc directed_vertex_pair.assign_quadrant
+  (u: real, a: real, b: real, c: real, d: real, bit: int)
+  {
+    // ---------------------------------------------------------------------
+    // The heart of the RMAT random graph generator is a procedure that
+    // assigns a single bit of the edge starting and ending vertex by
+    // assigning the edge with specified probability to one of the four
+    // quadrants of a 2 x 2 grid.
+    //
+    // Chapel is able to promote this conditional-based scalar procedure to
+    // array operations where it is not able to promote conditional code
+    // directly.
+    //
+    // Determine randomly in which quadrant of the grid a point lies,
+    // based on the following picture:
+    //
+    //     +---------------------------+
+    //     | u < a         | u < a+b   |
+    //     |-------------+-------------|
+    //     | u < a + b + c | otherwise |
+    //     +---------------------------+
+    //
+    // The probability of the edge falling in the upper left quadrant is  a,
+    // in the upper right quadrant, b, the lower left quadrant  c
+    // and the lower right quadrant  d, where the probabilities are
+    // normalized to sum to one.
+    // ---------------------------------------------------------------------
+
+    var start_inc = 0;
+    var end_inc   = 0;
+
+    if u <= a then
+      {}
+    else if u <= a + b then
+      { end_inc = 1;}
+    else if u <= a + b + c then
+      { start_inc = 1;}
+    else
+      { start_inc = 1; end_inc = 1;};
+
+    this.start += bit * start_inc;
+    this.end   += bit * end_inc;
   }
 
 
-  // ============================
-  // Quadrant selection algorithm
-  // ============================
+// ====================================
+// Main RMAT Graph Generation Procedure
+// ====================================~
 
-  inline proc directed_vertex_pair.assign_quadrant
-    (u: real, a: real, b: real, c: real, d: real, bit: int)
-    {
-      // ---------------------------------------------------------------------
-      // The heart of the RMAT random graph generator is a procedure that
-      // assigns a single bit of the edge starting and ending vertex by
-      // assigning the edge with specified probability to one of the four
-      // quadrants of a 2 x 2 grid.
-      //
-      // Chapel is able to promote this conditional-based scalar procedure to
-      // array operations where it is not able to promote conditional code
-      // directly. 
-      //
-      // Determine randomly in which quadrant of the grid a point lies, 
-      // based on the following picture:
-      //
-      //     +---------------------------+
-      //     | u < a         | u < a+b   |
-      //     |-------------+-------------|
-      //     | u < a + b + c | otherwise |
-      //     +---------------------------+
-      //
-      // The probability of the edge falling in the upper left quadrant is  a,
-      // in the upper right quadrant, b, the lower left quadrant  c
-      // and the lower right quadrant  d, where the probabilities are
-      // normalized to sum to one.
-      // ---------------------------------------------------------------------
+proc Gen_RMAT_graph ( a : real,
+                     b : real,
+                     c : real,
+                     d : real,
+                     vertex_domain,
+                     SCALE :int,
+                     N_VERTICES : int,
+                     n_raw_edges : int,
+                     MAX_EDGE_WEIGHT :int,
+                     G )
 
-      var start_inc = 0;
-      var end_inc   = 0;
+  { use Random;
+    use analyze_RMAT_graph_associative_array;
 
-      if u <= a then
-	{}
-      else if u <= a + b then
-	{ end_inc = 1;}
-      else if u <= a + b + c then
-	{ start_inc = 1;}
+    if PRINT_TIMING_STATISTICS then stopwatch.start ();
+
+    const vertex_range = 1..N_VERTICES,
+          edge_range   = 1..n_raw_edges;
+
+    const edge_domain =
+      if DISTRIBUTION_TYPE == "BLOCK" then
+        {edge_range} dmapped Block ( {edge_range} )
       else
-	{ start_inc = 1; end_inc = 1;};
-
-      this.start += bit * start_inc;
-      this.end   += bit * end_inc;
-    }
-
-
-  // ====================================
-  // Main RMAT Graph Generation Procedure
-  // ====================================~
-
-  proc Gen_RMAT_graph ( a : real, 
-		       b : real, 
-		       c : real, 
-		       d : real, 
-                       vertex_domain,
-		       SCALE :int,
-		       N_VERTICES : int,
-		       n_raw_edges : int,
-		       MAX_EDGE_WEIGHT :int,
-		       G ) 
-
-    { use Random;
-      use analyze_RMAT_graph_associative_array;
-
-      if PRINT_TIMING_STATISTICS then stopwatch.start ();
-
-      const vertex_range = 1..N_VERTICES, 
-	    edge_range   = 1..n_raw_edges;
-
-      const edge_domain = 
-        if DISTRIBUTION_TYPE == "BLOCK" then
-          {edge_range} dmapped Block ( {edge_range} )
-        else
-          {edge_range} ;
-
-      var Edges       : [edge_domain] directed_vertex_pair;
-      // TODO: fold edge weight into directed_vertex_pair
-      var Edge_Weight : [edge_domain] int;
-      var permutation : [vertex_domain] int = vertex_range;
-
-       // ---------------------------------------------------------------
-      // The RMAT algorithm is based on recursively sub-dividing a grid.
-      // In this case, the grid is square of order 2^SCALE by 2^SCALE.
-      // So exactly "SCALE" steps of recursion will be required and the
-      // recursion can be implemented directly by iteration.
-      // ---------------------------------------------------------------
-
-      // -----------------------------------------------------------------
-      // Note on random number generators -- the RMAT generator creates
-      // 5*SCALE vectors of length 2**SCALE.  The dependence on powers
-      // of two provides an opportunity to expose statistical correlations
-      // in the pseudo-random numbers.  This certainly occurs with the
-      // current Chapel Random module.  The "skips" in the random number
-      // sequence dramatically change the results.  Without them, the
-      // Chapel RMAT matrices are inconsistent with what is seen in
-      // other implementations.
-      // -----------------------------------------------------------------
-      
-      writeln ("Random graph generated by stride of 1 in one random stream",
-	       " with skips" );
-      if newEG then
-        writeln("Using the new edge generation scheme, ",
-                if parEG then "in parallel" else "serially");
-      if SERIAL_GRAPH_GEN then
-        writeln("Serializing certain parallel loops");
-
-      const numDep = if numDepths == -1 then SCALE else numDepths;
-      if numDep != SCALE then
-        writeln("randomizing with ", numDep, " depths instead of ",
-                SCALE, " depths");
-
-    if newEG {
-      // new edge generation
-
-      var rndPos = 1;
-      const seed = if REPRODUCIBLE_PROBLEMS then 0556707007
-                                            else SeedGenerator.oddCurrentTime;
-
-      const delta = n_raw_edges + 1; // 1 corresponds to 'skip' in "old" code
-      rndPos += 1;                   // start with a skip
-      var bit = 1 << numDep;
-
-      for depth in 1..numDep {
-        bit >>= 1;
-        const bitCst = bit;
-
-        forall (e, r1, r2, r3, r4, r5) in zip(Edges,
- // RandomPrivate_iterate() generates a random number per elem of edge_domain
- // starting at 'start'-th point in the random number stream for 'seed'.
- NPBRandomPrivate_iterate(real, edge_domain, seed, start=rndPos+0*delta),
- NPBRandomPrivate_iterate(real, edge_domain, seed, start=rndPos+1*delta),
- NPBRandomPrivate_iterate(real, edge_domain, seed, start=rndPos+2*delta),
- NPBRandomPrivate_iterate(real, edge_domain, seed, start=rndPos+3*delta),
- NPBRandomPrivate_iterate(real, edge_domain, seed, start=rndPos+4*delta)) {
-         local {
-
-          var Noisy_a = a * (0.95 + 0.1 * r1);
-          var Noisy_b = b * (0.95 + 0.1 * r2);
-          var Noisy_c = c * (0.95 + 0.1 * r3);
-          var Noisy_d = d * (0.95 + 0.1 * r4);
-
-	  var norm     = 1.0 / (Noisy_a + Noisy_b + Noisy_c + Noisy_d);
-	  Noisy_a *= norm;
-	  Noisy_b *= norm;
-	  Noisy_c *= norm;
-	  Noisy_d *= norm;
-
-          e.assign_quadrant(r5, Noisy_a, Noisy_b, Noisy_c, Noisy_d, bitCst);
-
-         }  // local
-        }  // forall
-
-        rndPos += delta * 5;
-
-      }  // for depth
-
-      forall (w, rnd) in zip(Edge_Weight,
-        NPBRandomPrivate_iterate(real, edge_domain, seed, start=rndPos-1))
-      do
-       local do
-        w = floor (1 + rnd * MAX_EDGE_WEIGHT) : int;
-      rndPos += n_raw_edges;
-
-      if parEG {
-        var permutation$ : [vertex_domain] sync int = vertex_range;
-
-        serial(SERIAL_GRAPH_GEN) {
-          forall (v, rnd) in zip(vertex_domain,
-            NPBRandomPrivate_iterate(real, edge_domain, seed, start=rndPos-1))
-          {
-            const u = floor (1 + rnd * N_VERTICES) : int;
-            if u != v {
-              // All this does is permutation$(u) <=> permutation$(v).
-              // Implementation notes:
-              // * Lock the smaller index first, to ensure progress.
-              // * Access each of the two sync vars on its locale.
-              // * Factors out the 'on's that are implicit in
-              //   the accesses to the sync variables into explicit 'on's.
-              // * Factors out indexing into permutation$ using
-              //   by-reference argument passing.
-
-              const (ix1, ix2) = if v <= u then (v, u) else (u, v);
-              swapTwo(permutation$(ix1), permutation$(ix2));
-
-              proc swapTwo(p1$: sync int, p2$: sync int): void {
-                on p1$ {
-                  const label1 = p1$;
-                  var label2: int;
-                  on p2$ {
-                    label2 = p2$;
-                    p2$ = label1;
-                  }
-                  p1$ = label2;
-                }
-              }  // proc swapTwo
-            }
-          }  // forall
-        }
-        rndPos += N_VERTICES;
-
-        forall (pm, pm$) in zip(permutation, permutation$) {
-          pm = pm$.readXX();
-        }
-
-      } else {  // !parEG
-        for (v, rnd) in zip(vertex_domain,
-          NPBRandomPrivate_iterate(real, vertex_domain, seed, start=rndPos-1))
-        {
-          const new_id = floor (1 + rnd * N_VERTICES) : int;
-          permutation (v) <=> permutation (new_id);
-        }
-        rndPos += N_VERTICES;
-
-      } // if parEG
-
-    } else {  // !newEG
-
-      // Random Numbers return in the range [0.0, 1.0)
-
-      var Rand_Gen = if REPRODUCIBLE_PROBLEMS then 
-	               new NPBRandomStream (real, seed = 0556707007)
-		     else
-		       new NPBRandomStream (real);
-
-      var   Noisy_a     : [edge_domain] real,
-            Noisy_b     : [edge_domain] real,
-            Noisy_c     : [edge_domain] real,
-            Noisy_d     : [edge_domain] real,
-            norm        : [edge_domain] real,
-            Unif_Random : [edge_domain] real;
-
-      var bit = 1 << numDep;
-      var   skip : real;
-
-      for depth in 1..numDep do {
-	  bit >>= 1;
-
-	  // randomize the coefficients, tweaking them by numbers in [-.05, .05)
-
-	  skip = Rand_Gen.getNext ();
-	  Rand_Gen.fillRandom (Unif_Random);
-	  Noisy_a = a * (0.95 + 0.1 * Unif_Random);
-
-	  skip = Rand_Gen.getNext ();
-	  Rand_Gen.fillRandom (Unif_Random);
-	  Noisy_b = b * (0.95 + 0.1 * Unif_Random);
-
-	  skip = Rand_Gen.getNext ();
-	  Rand_Gen.fillRandom (Unif_Random);
-	  Noisy_c = c * (0.95 + 0.1 * Unif_Random);
-
-	  skip = Rand_Gen.getNext ();
-	  Rand_Gen.fillRandom (Unif_Random);
-	  Noisy_d = d * (0.95 + 0.1 * Unif_Random);
-
-	  norm     = 1.0 / (Noisy_a + Noisy_b + Noisy_c + Noisy_d);
-	  Noisy_a *= norm;
-	  Noisy_b *= norm;
-	  Noisy_c *= norm;
-	  Noisy_d *= norm;
-
-	  skip = Rand_Gen.getNext ();
-	  Rand_Gen.fillRandom (Unif_Random);
-
-	  Edges.assign_quadrant ( Unif_Random, Noisy_a, Noisy_b, 
-				     Noisy_c, Noisy_d, bit );
-	};
-
-      // ---------------------------------------------------------------------
-      // Assign weights to edges randomly, then randomly relabel the vertices
-      // to avoid locality from the obvious imbalance that will arise when
-      // one of the coefficients is clearly larger than the others
-      // ---------------------------------------------------------------------
-
-      Rand_Gen.fillRandom ( Unif_Random  );
-      Edge_Weight = floor (1 + Unif_Random * MAX_EDGE_WEIGHT) : int;
-
-      Rand_Gen.fillRandom ( Unif_Random (vertex_range) );
-
-      for v in vertex_range do
-	{ var new_id : int;
-	  new_id = floor (1 + Unif_Random (v) * N_VERTICES) : int;
-	  permutation (v) <=> permutation (new_id);
-	};
-
-      delete Rand_Gen;
-    } // if newEG
-
-      forall e in Edges do {
-        e.start = permutation(e.start);
-        e.end   = permutation(e.end);
-      }
-
-      if PRINT_TIMING_STATISTICS then {
-	stopwatch.stop ();
-	writeln ( "Elapsed time for Edge Generation: ", stopwatch.elapsed (), 
-		  " seconds");
-	stopwatch.clear ();
-      }
-
-      if DEBUG_WEIGHT_GENERATOR then {
-	writeln ();
-       if rmatEdgeGenFile != "" {
-        writeln("writing edges to ", rmatEdgeGenFile);
-        const fl = open(rmatEdgeGenFile, iomode.cw);
-        const ch = fl.writer();
-	for (ed, w) in zip(Edges, Edge_Weight) do
-          ch.writeln (ed.start, " ", ed.end, " ", w);
-        ch.close();
-        fl.close();
-       } else
-	for e in edge_range do
-	  writeln ("edge (", e, ") : (", Edges(e), ", ", 
-		   Edge_Weight (e), ")" );
-      }
-
-      // --------------------------
-      // Graph consistency checking
-      // --------------------------
-
-      if edgeChecks {
-        // Check that 'permutation' was a permutation.
-        var permuteCounts : [vertex_domain] atomic int;
-        forall p in permutation do
-          permuteCounts[p].add(1);
-        forall (pc, ix) in zip(permuteCounts, vertex_domain) do
-          if !(pc.read() == 1) then halt(
-               "'permutation' is not a permutation: vertex ", ix,
-               " is mentioned ", pc.read(), " times");
-
-        // Sanity checks on edges and weights.
-        forall (e, w) in zip(Edges, Edge_Weight) {
-
-          if !(e.start > 0) then halt(
-	       "edge start vertices out of low end of range");
-
-          if !(e.end > 0) then halt( 
-	       "edge end vertices out of low end of range");
-
-          if !(e.start <= 2**SCALE) then halt( 
-	       "edge start vertices out of high end of range");
-
-          if !(e.end <= 2**SCALE) then halt( 
-	       "edge end vertices out of high end of range");
-
-          if !(w > 0) then halt( 
-	       "edge weight out of low end of range");
-
-          if !(w <= MAX_EDGE_WEIGHT) then halt(  
-	       "edge weight out of high end of range");
-        }
-        // exit the scope to enable memory deallocation, if any
-      }
-
-      writeln (); writeln ("Vertex Set in G:", G.vertices);
-
-      // ----------------------------------------------------------
-      // Kernel 1: assemble graph from list of triples.
-      // Include only non-self incident edges.
-      // In case of (start, end) duplicates, the first triple wins.
-      // Alternatively, could skip the member(v) check (so the last triple
-      // wins) or also use += instead of = (to sum duplicates' weights).
-      // ----------------------------------------------------------
-
-      var firstAvailNeighbor$: [vertex_domain] sync int = initialFirstAvail;
-
-      writeln("Starting Graph Generation ",
-              if parGC then "in parallel" else "serially");
-      if PRINT_TIMING_STATISTICS then stopwatch.start ();
-
-      var collisions = 0, self_edges = 0;
-
-    if parGC {
-
-      var self_edges$: atomic int;
+        {edge_range} ;
+
+    var Edges       : [edge_domain] directed_vertex_pair;
+    // TODO: fold edge weight into directed_vertex_pair
+    var Edge_Weight : [edge_domain] int;
+    var permutation : [vertex_domain] int = vertex_range;
+
+     // ---------------------------------------------------------------
+    // The RMAT algorithm is based on recursively sub-dividing a grid.
+    // In this case, the grid is square of order 2^SCALE by 2^SCALE.
+    // So exactly "SCALE" steps of recursion will be required and the
+    // recursion can be implemented directly by iteration.
+    // ---------------------------------------------------------------
+
+    // -----------------------------------------------------------------
+    // Note on random number generators -- the RMAT generator creates
+    // 5*SCALE vectors of length 2**SCALE.  The dependence on powers
+    // of two provides an opportunity to expose statistical correlations
+    // in the pseudo-random numbers.  This certainly occurs with the
+    // current Chapel Random module.  The "skips" in the random number
+    // sequence dramatically change the results.  Without them, the
+    // Chapel RMAT matrices are inconsistent with what is seen in
+    // other implementations.
+    // -----------------------------------------------------------------
+
+    writeln ("Random graph generated by stride of 1 in one random stream",
+             " with skips" );
+    if newEG then
+      writeln("Using the new edge generation scheme, ",
+              if parEG then "in parallel" else "serially");
+    if SERIAL_GRAPH_GEN then
+      writeln("Serializing certain parallel loops");
+
+    const numDep = if numDepths == -1 then SCALE else numDepths;
+    if numDep != SCALE then
+      writeln("randomizing with ", numDep, " depths instead of ",
+              SCALE, " depths");
+
+  if newEG {
+    // new edge generation
+
+    var rndPos = 1;
+    const seed = if REPRODUCIBLE_PROBLEMS then 0556707007
+                                          else SeedGenerator.oddCurrentTime;
+
+    const delta = n_raw_edges + 1; // 1 corresponds to 'skip' in "old" code
+    rndPos += 1;                   // start with a skip
+    var bit = 1 << numDep;
+
+    for depth in 1..numDep {
+      bit >>= 1;
+      const bitCst = bit;
+
+      forall (e, r1, r2, r3, r4, r5) in zip(Edges,
+// RandomPrivate_iterate() generates a random number per elem of edge_domain
+// starting at 'start'-th point in the random number stream for 'seed'.
+NPBRandomPrivate_iterate(real, edge_domain, seed, start=rndPos+0*delta),
+NPBRandomPrivate_iterate(real, edge_domain, seed, start=rndPos+1*delta),
+NPBRandomPrivate_iterate(real, edge_domain, seed, start=rndPos+2*delta),
+NPBRandomPrivate_iterate(real, edge_domain, seed, start=rndPos+3*delta),
+NPBRandomPrivate_iterate(real, edge_domain, seed, start=rndPos+4*delta)) {
+       local {
+
+        var Noisy_a = a * (0.95 + 0.1 * r1);
+        var Noisy_b = b * (0.95 + 0.1 * r2);
+        var Noisy_c = c * (0.95 + 0.1 * r3);
+        var Noisy_d = d * (0.95 + 0.1 * r4);
+
+        var norm     = 1.0 / (Noisy_a + Noisy_b + Noisy_c + Noisy_d);
+        Noisy_a *= norm;
+        Noisy_b *= norm;
+        Noisy_c *= norm;
+        Noisy_d *= norm;
+
+        e.assign_quadrant(r5, Noisy_a, Noisy_b, Noisy_c, Noisy_d, bitCst);
+
+       }  // local
+      }  // forall
+
+      rndPos += delta * 5;
+
+    }  // for depth
+
+    forall (w, rnd) in zip(Edge_Weight,
+      NPBRandomPrivate_iterate(real, edge_domain, seed, start=rndPos-1))
+    do
+     local do
+      w = floor (1 + rnd * MAX_EDGE_WEIGHT) : int;
+    rndPos += n_raw_edges;
+
+    if parEG {
+      var permutation$ : [vertex_domain] sync int = vertex_range;
+
       serial(SERIAL_GRAPH_GEN) {
-        forall (e, w) in zip(Edges, Edge_Weight) do {
-          const u = e.start;
-          const v = e.end;
+        forall (v, rnd) in zip(vertex_domain,
+          NPBRandomPrivate_iterate(real, edge_domain, seed, start=rndPos-1))
+        {
+          const u = floor (1 + rnd * N_VERTICES) : int;
+          if u != v {
+            // All this does is permutation$(u) <=> permutation$(v).
+            // Implementation notes:
+            // * Lock the smaller index first, to ensure progress.
+            // * Access each of the two sync vars on its locale.
+            // * Factors out the 'on's that are implicit in
+            //   the accesses to the sync variables into explicit 'on's.
+            // * Factors out indexing into permutation$ using
+            //   by-reference argument passing.
 
-          if ( v == u ) then {
-            // self-edge, ignore
-            self_edges$.add(1);
-          } else {
-            // Both the vertex and firstAvail must be passed by reference.
-            // TODO: possibly compute how many neighbors the vertex has, first.
-            // Then allocate that big of a neighbor list right away.
-            // That way there will be no need for a sync, just an atomic.
-            G.Row[u].addEdgeOnVertex(u, v, w, firstAvailNeighbor$[u]);
+            const (ix1, ix2) = if v <= u then (v, u) else (u, v);
+            swapTwo(permutation$(ix1), permutation$(ix2));
+
+            proc swapTwo(p1$: sync int, p2$: sync int): void {
+              on p1$ {
+                const label1 = p1$;
+                var label2: int;
+                on p2$ {
+                  label2 = p2$;
+                  p2$ = label1;
+                }
+                p1$ = label2;
+              }
+            }  // proc swapTwo
           }
+        }  // forall
+      }
+      rndPos += N_VERTICES;
+
+      forall (pm, pm$) in zip(permutation, permutation$) {
+        pm = pm$.readXX();
+      }
+
+    } else {  // !parEG
+      for (v, rnd) in zip(vertex_domain,
+        NPBRandomPrivate_iterate(real, vertex_domain, seed, start=rndPos-1))
+      {
+        const new_id = floor (1 + rnd * N_VERTICES) : int;
+        permutation (v) <=> permutation (new_id);
+      }
+      rndPos += N_VERTICES;
+
+    } // if parEG
+
+  } else {  // !newEG
+
+    // Random Numbers return in the range [0.0, 1.0)
+
+    var Rand_Gen = if REPRODUCIBLE_PROBLEMS then
+                     new NPBRandomStream (real, seed = 0556707007)
+                   else
+                     new NPBRandomStream (real);
+
+    var   Noisy_a     : [edge_domain] real,
+          Noisy_b     : [edge_domain] real,
+          Noisy_c     : [edge_domain] real,
+          Noisy_d     : [edge_domain] real,
+          norm        : [edge_domain] real,
+          Unif_Random : [edge_domain] real;
+
+    var bit = 1 << numDep;
+    var   skip : real;
+
+    for depth in 1..numDep do {
+        bit >>= 1;
+
+        // randomize the coefficients, tweaking them by numbers in [-.05, .05)
+
+        skip = Rand_Gen.getNext ();
+        Rand_Gen.fillRandom (Unif_Random);
+        Noisy_a = a * (0.95 + 0.1 * Unif_Random);
+
+        skip = Rand_Gen.getNext ();
+        Rand_Gen.fillRandom (Unif_Random);
+        Noisy_b = b * (0.95 + 0.1 * Unif_Random);
+
+        skip = Rand_Gen.getNext ();
+        Rand_Gen.fillRandom (Unif_Random);
+        Noisy_c = c * (0.95 + 0.1 * Unif_Random);
+
+        skip = Rand_Gen.getNext ();
+        Rand_Gen.fillRandom (Unif_Random);
+        Noisy_d = d * (0.95 + 0.1 * Unif_Random);
+
+        norm     = 1.0 / (Noisy_a + Noisy_b + Noisy_c + Noisy_d);
+        Noisy_a *= norm;
+        Noisy_b *= norm;
+        Noisy_c *= norm;
+        Noisy_d *= norm;
+
+        skip = Rand_Gen.getNext ();
+        Rand_Gen.fillRandom (Unif_Random);
+
+        Edges.assign_quadrant ( Unif_Random, Noisy_a, Noisy_b,
+                                   Noisy_c, Noisy_d, bit );
+      };
+
+    // ---------------------------------------------------------------------
+    // Assign weights to edges randomly, then randomly relabel the vertices
+    // to avoid locality from the obvious imbalance that will arise when
+    // one of the coefficients is clearly larger than the others
+    // ---------------------------------------------------------------------
+
+    Rand_Gen.fillRandom ( Unif_Random  );
+    Edge_Weight = floor (1 + Unif_Random * MAX_EDGE_WEIGHT) : int;
+
+    Rand_Gen.fillRandom ( Unif_Random (vertex_range) );
+
+    for v in vertex_range do
+      { var new_id : int;
+        new_id = floor (1 + Unif_Random (v) * N_VERTICES) : int;
+        permutation (v) <=> permutation (new_id);
+      };
+
+    delete Rand_Gen;
+  } // if newEG
+
+    forall e in Edges do {
+      e.start = permutation(e.start);
+      e.end   = permutation(e.end);
+    }
+
+    if PRINT_TIMING_STATISTICS then {
+      stopwatch.stop ();
+      writeln ( "Elapsed time for Edge Generation: ", stopwatch.elapsed (),
+                " seconds");
+      stopwatch.clear ();
+    }
+
+    if DEBUG_WEIGHT_GENERATOR then {
+      writeln ();
+     if rmatEdgeGenFile != "" {
+      writeln("writing edges to ", rmatEdgeGenFile);
+      const fl = open(rmatEdgeGenFile, iomode.cw);
+      const ch = fl.writer();
+      for (ed, w) in zip(Edges, Edge_Weight) do
+        ch.writeln (ed.start, " ", ed.end, " ", w);
+      ch.close();
+      fl.close();
+     } else
+      for e in edge_range do
+        writeln ("edge (", e, ") : (", Edges(e), ", ",
+                 Edge_Weight (e), ")" );
+    }
+
+    // --------------------------
+    // Graph consistency checking
+    // --------------------------
+
+    if edgeChecks {
+      // Check that 'permutation' was a permutation.
+      var permuteCounts : [vertex_domain] atomic int;
+      forall p in permutation do
+        permuteCounts[p].add(1);
+      forall (pc, ix) in zip(permuteCounts, vertex_domain) do
+        if !(pc.read() == 1) then halt(
+             "'permutation' is not a permutation: vertex ", ix,
+             " is mentioned ", pc.read(), " times");
+
+      // Sanity checks on edges and weights.
+      forall (e, w) in zip(Edges, Edge_Weight) {
+
+        if !(e.start > 0) then halt(
+             "edge start vertices out of low end of range");
+
+        if !(e.end > 0) then halt(
+             "edge end vertices out of low end of range");
+
+        if !(e.start <= 2**SCALE) then halt(
+             "edge start vertices out of high end of range");
+
+        if !(e.end <= 2**SCALE) then halt(
+             "edge end vertices out of high end of range");
+
+        if !(w > 0) then halt(
+             "edge weight out of low end of range");
+
+        if !(w <= MAX_EDGE_WEIGHT) then halt(
+             "edge weight out of high end of range");
+      }
+      // exit the scope to enable memory deallocation, if any
+    }
+
+    writeln (); writeln ("Vertex Set in G:", G.vertices);
+
+    // ----------------------------------------------------------
+    // Kernel 1: assemble graph from list of triples.
+    // Include only non-self incident edges.
+    // In case of (start, end) duplicates, the first triple wins.
+    // Alternatively, could skip the member(v) check (so the last triple
+    // wins) or also use += instead of = (to sum duplicates' weights).
+    // ----------------------------------------------------------
+
+    var firstAvailNeighbor$: [vertex_domain] sync int = initialFirstAvail;
+
+    writeln("Starting Graph Generation ",
+            if parGC then "in parallel" else "serially");
+    if PRINT_TIMING_STATISTICS then stopwatch.start ();
+
+    var collisions = 0, self_edges = 0;
+
+  if parGC {
+
+    var self_edges$: atomic int;
+    serial(SERIAL_GRAPH_GEN) {
+      forall (e, w) in zip(Edges, Edge_Weight) do {
+        const u = e.start;
+        const v = e.end;
+
+        if ( v == u ) then {
+          // self-edge, ignore
+          self_edges$.add(1);
+        } else {
+          // Both the vertex and firstAvail must be passed by reference.
+          // TODO: possibly compute how many neighbors the vertex has, first.
+          // Then allocate that big of a neighbor list right away.
+          // That way there will be no need for a sync, just an atomic.
+          G.Row[u].addEdgeOnVertex(u, v, w, firstAvailNeighbor$[u]);
         }
       }
-
-      self_edges = self_edges$.read();
-
-    } else {  // !parGC
-
-      for e in edge_range do {
-	const u = Edges (e).start;
-	const v = Edges (e).end  ;
-
-	if ( v == u ) then {
-          // self-edge, ignore
-          self_edges += 1;
-        } else {
-          const w = Edge_Weight(e);
-          // Both the vertex and firstAvail must be passed by reference.
-          // TODO: skip locking in this serial version.
-          G.Row[u].addEdgeOnVertex(u, v, w, firstAvailNeighbor$[u]);
-	}
-      }
-
-    } // if parGC
-
-      forall (vx, firstAvail$) in zip(G.Row, firstAvailNeighbor$) do
-        vx.tidyNeighbors(firstAvail$);
-
-      if PRINT_TIMING_STATISTICS then {
-	stopwatch.stop ();
-	writeln ( "Elapsed time for Kernel 1: ", stopwatch.elapsed (), 
-		  " seconds");
-	stopwatch.clear ();
-      }
-
-      G.num_edges = + reduce [v in G.vertices] G.n_Neighbors (v);
-
-      writeln ( "# of raw edges generated  ", n_raw_edges );
-      writeln ( "# of duplicate edges      ", "not counted" /*collisions*/ );
-      writeln ( "# of self edges           ", self_edges );
-      writeln ( "# of edges in final graph ", G.num_edges );
-
-      if DEBUG_GRAPH_GENERATOR then {
-       writeln ();
-       if rmatGraphConFile != "" {
-        writeln("writing neighbor lists to ", rmatGraphConFile);
-        const fl = open(rmatGraphConFile, iomode.cw);
-        const ch = fl.writer();
-        for (u, vx) in zip(G.vertices, G.Row) do
-          for (v, w) in vx.neighborList do
-            ch.writeln(u, " ", v, " ", w);
-        ch.close();
-        fl.close();
-       } else {
-	writeln ("tuples denote (edge, weight)");
-	writeln ();
-	for u in G.vertices do {
-	  write ( "row ", u, ": [", G.n_Neighbors (u), "] " );
-	  for (v,w) in G .NeighborPairs (u) do
-	    write ( (v, w) );
-	  writeln (); 
-	}
-       }
-      }
-
-      var max_edges = max reduce [v in vertex_range] G.n_Neighbors (v);
-      writeln ("max number of outgoing edges ", max_edges);
-      if !DEBUG_NEIGHBOR_HISTOGRAM {
-        var zero_edge_vs = + reduce [v in G.Row] (v.numNeighbors() == 0):int;
-        writeln("number of disconnected vertices ", zero_edge_vs);
-      }
-
-     if DEBUG_NEIGHBOR_HISTOGRAM {
-      var edge_count : [0..max_edges] int = 0;
-
-      for v in G.vertices do
-	edge_count (G.n_Neighbors (v)) += 1;
-
-      writeln ("histograph of node distributions by number of outgoing edges");
-      writeln ( "# edges  # nodes");
-      for count in 0..max_edges do
-	writeln ( count, "  ", edge_count (count) );
-     }
-
-      writeln ();
-      
     }
-}
+
+    self_edges = self_edges$.read();
+
+  } else {  // !parGC
+
+    for e in edge_range do {
+      const u = Edges (e).start;
+      const v = Edges (e).end  ;
+
+      if ( v == u ) then {
+        // self-edge, ignore
+        self_edges += 1;
+      } else {
+        const w = Edge_Weight(e);
+        // Both the vertex and firstAvail must be passed by reference.
+        // TODO: skip locking in this serial version.
+        G.Row[u].addEdgeOnVertex(u, v, w, firstAvailNeighbor$[u]);
+      }
+    }
+
+  } // if parGC
+
+    forall (vx, firstAvail$) in zip(G.Row, firstAvailNeighbor$) do
+      vx.tidyNeighbors(firstAvail$);
+
+    if PRINT_TIMING_STATISTICS then {
+      stopwatch.stop ();
+      writeln ( "Elapsed time for Kernel 1: ", stopwatch.elapsed (),
+                " seconds");
+      stopwatch.clear ();
+    }
+
+    G.num_edges = + reduce [v in G.vertices] G.n_Neighbors (v);
+
+    writeln ( "# of raw edges generated  ", n_raw_edges );
+    writeln ( "# of duplicate edges      ", "not counted" /*collisions*/ );
+    writeln ( "# of self edges           ", self_edges );
+    writeln ( "# of edges in final graph ", G.num_edges );
+
+    if DEBUG_GRAPH_GENERATOR then {
+     writeln ();
+     if rmatGraphConFile != "" {
+      writeln("writing neighbor lists to ", rmatGraphConFile);
+      const fl = open(rmatGraphConFile, iomode.cw);
+      const ch = fl.writer();
+      for (u, vx) in zip(G.vertices, G.Row) do
+        for (v, w) in vx.neighborList do
+          ch.writeln(u, " ", v, " ", w);
+      ch.close();
+      fl.close();
+     } else {
+      writeln ("tuples denote (edge, weight)");
+      writeln ();
+      for u in G.vertices do {
+        write ( "row ", u, ": [", G.n_Neighbors (u), "] " );
+        for (v,w) in G .NeighborPairs (u) do
+          write ( (v, w) );
+        writeln ();
+      }
+     }
+    }
+
+    var max_edges = max reduce [v in vertex_range] G.n_Neighbors (v);
+    writeln ("max number of outgoing edges ", max_edges);
+    if !DEBUG_NEIGHBOR_HISTOGRAM {
+      var zero_edge_vs = + reduce [v in G.Row] (v.numNeighbors() == 0):int;
+      writeln("number of disconnected vertices ", zero_edge_vs);
+    }
+
+   if DEBUG_NEIGHBOR_HISTOGRAM {
+    var edge_count : [0..max_edges] int = 0;
+
+    for v in G.vertices do
+      edge_count (G.n_Neighbors (v)) += 1;
+
+    writeln ("histograph of node distributions by number of outgoing edges");
+    writeln ( "# edges  # nodes");
+    for count in 0..max_edges do
+      writeln ( count, "  ", edge_count (count) );
+   }
+
+    writeln ();
+
+  }

--- a/test/release/examples/benchmarks/ssca2/SSCA2_Modules/io_RMAT_graph.chpl
+++ b/test/release/examples/benchmarks/ssca2/SSCA2_Modules/io_RMAT_graph.chpl
@@ -2,522 +2,517 @@
 // Input/output of an RMAT graph to files in binary format.
 // Presently, uses the XMT/KM RMAT graph storage format for SSCA#2.
 //
-pragma "error mode fatal"
-module io_RMAT_graph
-{
-  use SSCA2_compilation_config_params, Time, ReplicatedDist;
-
-  //
-  // The data is stored in 5 files per graph.
-  // The individual files' names are obtained by appending
-  // the following strings to the "prefix" arg of the functions
-  // Writeout_RMAT_graph() and Readin_RMAT_graph().
-  //
-  config const VE_FILENAME     = "vertex_edge_info.data";
-  config const SV2_FILENAME    = "sv2_snapshot.data";
-  config const EV2_FILENAME    = "ev2_snapshot.data";
-  config const START_FILENAME  = "start_snapshot.data";
-  config const WEIGHT_FILENAME = "weight_snapshot.data";
-  config type  IONumType       = int(64);
-  config param IOendianness    = iokind.big;
-  config const IOserial        = false;
-  config const IOsingleTaskPerLocale = true;
-
-  // Debugging-related settings.
-  config const IOprogress      = true;
-  config var progressFrequency = 100000;
-  config const IOgate          = false;
-
-  //
-  // Writeout_RMAT_graph()
-  //   Writes out the graph to files.
-  //   The file names are a concatenation of 'snapshot_prefix'
-  //     and the *_FILENAME constants above.
-  //   The debugging style is specified by 'dstyle' and is described below
-  //     (see proc interpretDStyle()).
-  //
-  proc Writeout_RMAT_graph(G, snapshot_prefix:string, dstyle = "-"): void {
-    writeln("writing RMAT graph with ", graphNumVertices(G), " vertices, ",
-          graphTotalEdges(G), " edges to '", snapshot_prefix, "'*");
-
-    var stopwatch : Timer;
-    if PRINT_TIMING_STATISTICS then stopwatch.start ();
-
-    param wri = true;
-
-    const (dON, dRow, dEdge) = interpretDStyle(dstyle);
-    // this presently would leak too much string memory
-    //proc debugRow(msg...)  { if dRow then write((...msg)); }
-    // ... but this is not called in a loop
-    proc debug(msg...) { if dON then writeln((...msg)); }
-
-    const veCount = createGraphChannel(snapshot_prefix, VE_FILENAME, wri);
-    writeNum(veCount, graphNumVertices(G));
-    writeNum(veCount, graphTotalEdges(G));
-    veCount.close();
-
-    const sv = createGraphChannel(snapshot_prefix, SV2_FILENAME, wri);
-    const ev = createGraphChannel(snapshot_prefix, EV2_FILENAME, wri);
-    const ww = createGraphChannel(snapshot_prefix, WEIGHT_FILENAME, wri);
-    const sta = createGraphChannel(snapshot_prefix, START_FILENAME, wri);
-
-    // Tracks the starting index for each vertex, 0-based, for START_FILENAME.
-    var startIx = 0: IONumType;
-    resetProgress();
-
-    // iterate sequentially
-    for (u, ux) in zip(G.vertices, G.Row) {
-      if dRow then write("row ", u, ": [", ux.numNeighbors(), "] ");
-      if dEdge then writeln(dstyle, " vertex ", u);
-      writeNum(sta, startIx);
-
-      for (v, w) in ux.neighborList {
-        if dRow then write((v, w));
-        if dEdge then writeln(dstyle, " ", u, " ", v, " ", w);
-        writeNum(sv, u-1);
-        writeNum(ev, v-1);
-        writeNum(ww, w);
-        startIx += 1;
-        if dON && reportProgress() then
-          writeln("processing...  vertex ", u, "  edge ", startIx);
-      }
-      if dRow then writeln();
-    }
-
-    const numVertices = G.vertices.numIndices;
-    debug("done writing ", numVertices, " vertices, ", startIx, " edges");
-    assert(startIx == graphTotalEdges(G));
-    const sb = numBytes(IONumType);
-    debug("file sizes  ", 2 * sb, "  ", (graphNumVertices(G) + 2) * sb,
-          "  ", graphTotalEdges(G) * sb);
-    writeNum(sta, startIx);
-    writeNum(sta, startIx);
-
-    sv.close();
-    ev.close();
-    ww.close();
-    sta.close();
-
-    if PRINT_TIMING_STATISTICS then {
-      stopwatch.stop ();
-      writeln ( "Elapsed time for writing RMAT graph: ", stopwatch.elapsed (),
-                " seconds");
-      stopwatch.clear ();
-    }
-
-    write("DONE writing RMAT graph");
-    if dON then write(" to '", snapshot_prefix, "'*");
-    //else write(" with ", numVertices, " vertices, ", startIx, " edges");
-    writeln(); writeln();
-
-  } // Writeout_RMAT_graph()
-
-  //
-  // For each data file, we create one Chapel 'file' per locale when parallel.
-  // Cheap-to-compute decls are here, the rest are in Readin_RMAT_graph().
-  //
-  param repfileLow = 1, repfileHi = 5,
-        repfileSV = 1, repfileEV = 2, repfileWW = 3,
-        repfileSTA = 4, repfileST2 = 5;
-  const repfileBase = {repfileLow .. repfileHi};
-
-  //
-  // Readin_RMAT_graph()
-  //   Reads in the graph from files.
-  //   The file names and the debugging style are the same as
-  //   for Writeout_RMAT_graph().
-  //
-  proc Readin_RMAT_graph(G, snapshot_prefix:string, dstyle = "-"): void {
-    writeln("reading RMAT graph with ", graphNumVertices(G), " vertices",
-            if IOserial then " serially" else
-              if DISTRIBUTION_TYPE == "BLOCK" && IOsingleTaskPerLocale
-                then " in parallel, 1 task per locale" else " in parallel",
-            " from '", snapshot_prefix, "'*");
-
-    var stopwatch : Timer;
-    if PRINT_TIMING_STATISTICS then stopwatch.start ();
-
-    param rea = false;
-
-    const (dON, dRow, dEdge) = interpretDStyle(dstyle);
-    // this presently would leak too much string memory
-    //proc debugRow(msg...)  { if dRow then write((...msg)); }
-    // ... but this is not called in a loop
-    proc debug(msg...) { if dON then writeln((...msg)); }
-
-    const veCount = createGraphChannel(snapshot_prefix, VE_FILENAME, rea);
-    const vCount    = readNum(veCount),
-          eCount    = readNum(veCount);
-    ensureEOFofDataFile(veCount, snapshot_prefix, VE_FILENAME);
-    veCount.close();
-
-    G.num_edges = eCount;
-    debug("files contain  ", vCount, " vertices  ", eCount, " edges");
-    const sb = numBytes(IONumType);
-    debug("expected file sizes  ", 2*sb, "  ", (vCount+2)*sb, "  ", eCount*sb);
-
-    if vCount != graphNumVertices(G) then
-      reportNumVerticesError(G, snapshot_prefix, vCount);
-
-    ref GRow = G.Row;
-    const uxIDs = GRow.domain.dim(1);
-    type VType = uxIDs.idxType;
-    compilerAssert(!uxIDs.stridable); // for efficiency
-
-    if IOserial {
-      const sv = createGraphChannel(snapshot_prefix, SV2_FILENAME, rea);
-      const ev = createGraphChannel(snapshot_prefix, EV2_FILENAME, rea);
-      const ww = createGraphChannel(snapshot_prefix, WEIGHT_FILENAME, rea);
-      const sta = createGraphChannel(snapshot_prefix, START_FILENAME, rea);
-
-      var startIxCnt = 0:IONumType, startIxData = readNum(sta);
-      if startIxCnt != startIxData then
-        halt("the first index in ", snapshot_prefix, START_FILENAME,
-             " is ", startIxData, " but should be ", startIxCnt);
-
-      for u in uxIDs do
-        readOneVertex(GRow, VType, vCount, u, dON, dRow, dEdge, dstyle,
-                      sv, ev, ww, startIxData = readNum(sta), startIxCnt);
-
-      debug("done reading ", vCount, " vertices, ", startIxData, " edges");
-
-      // one more entry in 'sta'
-      startIxData = readNum(sta);
-      if startIxData != startIxCnt then
-        myerror("wrong last entry in ", snapshot_prefix, START_FILENAME,
-                "  expected ", startIxCnt, "  got ", startIxData);
-      if startIxData != eCount then
-        myerror(snapshot_prefix, VE_FILENAME, " claimed ", eCount,
-                " edges, the other files gave ", startIxData, " edges");
-
-      ensureEOFofDataFile(sv, snapshot_prefix, SV2_FILENAME);
-      ensureEOFofDataFile(ev, snapshot_prefix, EV2_FILENAME);
-      ensureEOFofDataFile(ww, snapshot_prefix, WEIGHT_FILENAME);
-      ensureEOFofDataFile(sta, snapshot_prefix, START_FILENAME);
-
-      sv.close();
-      ev.close();
-      ww.close();
-      sta.close();
-
-    } else {
-      // !IOserial
-      const repfileMap = new Replicated(Locales);
-      const repfileDom = repfileBase dmapped new dmap(repfileMap);
-      var repfiles: [repfileDom] file;
-
-      coforall l in Locales do on l {
- repfiles[repfileSV] = createGraphFile(snapshot_prefix, SV2_FILENAME, rea);
- repfiles[repfileEV] = createGraphFile(snapshot_prefix, EV2_FILENAME, rea);
- repfiles[repfileWW] = createGraphFile(snapshot_prefix, WEIGHT_FILENAME, rea);
- repfiles[repfileSTA] = createGraphFile(snapshot_prefix, START_FILENAME, rea);
- repfiles[repfileST2] = createGraphFile(snapshot_prefix, START_FILENAME, rea);
-      }
-
-     if DISTRIBUTION_TYPE == "BLOCK" && IOsingleTaskPerLocale {
-        coforall locDom in GRow._value.dom.locDoms do on locDom {
-          const myIDs = locDom.myBlock.dim(1);
-
-          // All work is done in graphReaderReal() iterator.
-          for graphReaderReal(GRow, uxIDs, VType, vCount, eCount, repfiles,
-                              dON, dRow, dEdge, dstyle, myIDs) do;
-        }
-
-     } else {
-      // !IOsingleTaskPerLocale && !IOserial
-
-      // All work is done in graphReaderIterator() follower iterator.
-      // GRow is used only to distribute/parallelize the computation.
-      forall (_,_) in zip(GRow,
-        graphReaderIterator(GRow, uxIDs, VType, vCount, eCount, repfiles,
-                            dON, dRow, dEdge, dstyle))
-          do;
-
-     } // if IOsingleTaskPerLocale
-
-      coforall l in Locales do on l {
-          repfiles[repfileSV].close();
-          repfiles[repfileEV].close();
-          repfiles[repfileWW].close();
-          repfiles[repfileSTA].close();
-          repfiles[repfileST2].close();
-      }
-
-    } // if IOserial
-
-    if PRINT_TIMING_STATISTICS then {
-      stopwatch.stop ();
-      writeln ( "Elapsed time for reading RMAT graph: ", stopwatch.elapsed (),
-                " seconds");
-      stopwatch.clear ();
-    }
-
-    write("DONE reading RMAT graph");
-    if dON then write(" from '", snapshot_prefix, "'*");
-    else        write(" with ", vCount, " vertices, ", eCount, " edges");
-    writeln(); writeln();
-
-  } // Readin_RMAT_graph()
-
-
-  ///////// parallel Readin_RMAT_graph helpers /////////
-
-  // For use with IOgate=true: allows only a single graphReaderIterator
-  // follower invocation at a time.
-  var IOgate$: sync bool;
-
-  // Seems we need this serial iterator declaration to keep the compiler happy.
-  // But it is not implemented. Use --IOserial instead.
-  //
-  iter graphReaderIterator(GRow, uxIDs, type VType, vCount, eCount, repfiles,
-                           dON, dRow, dEdge, dstyle) {
-    halt("serial graphReaderIterator should not be invoked");
-    yield 0:VType;
-
-  }
-
-  // This is the follower iterator.
-  // We do not need the leader iterator.
-  //
-  iter graphReaderIterator(GRow, uxIDs, type VType, vCount, eCount, repfiles,
-                           dON, dRow, dEdge, dstyle,
-                           param tag: iterKind, followThis)
-    where tag == iterKind.follower
-  {
-    // ensure we got unstridable range with VType-typed indices
-    compilerAssert(followThis.type ==
-                   1*range(VType, BoundedRangeType.bounded, false));
-
-    const myIDs = unDensify(followThis(1), uxIDs);
-
-    // Redirect to graphReaderReal() iterator.
-    for dummy in graphReaderReal(GRow, uxIDs, VType, vCount, eCount, repfiles,
-                                 dON, dRow, dEdge, dstyle, myIDs)
-      do yield dummy;
-  }
-
-  // This iterator reads the part of the graph corresponding to myIDs,
-  // on the locale where it is run.
-  //
-  iter graphReaderReal(GRow, uxIDs, type VType, vCount, eCount, repfiles,
-                       dON, dRow, dEdge, dstyle, myIDs)
-  {
-    if IOgate then IOgate$ = true;
-
-    compilerAssert(!myIDs.stridable); // for efficiency, also for v1,v2
-    // start/end IDs
-    const v1 = myIDs.low, v2 = myIDs.high;
-    //writeln("loc ", here.id, "  myIDs ", v1, "..", v2, "  of ", uxIDs);
-
-    // These indices better be all local, so take advantage of that.
-    ref GRowLocal = GRow.localSlice(myIDs);
-
-    // Returns the offset of edgeStart[v] in staf, 1 <= v <= numVertices+2.
-    proc staOffsetForVID(v: int) return (v-1) * numBytes(IONumType);
-    // Returns the offset of startVertex/endVertex/weight[e] in
-    //  svf, evf, wwf, resp; 1 <= e <= numEdges.
-    proc svOffsetForEID(e: int) return (e-1) * numBytes(IONumType);
-
-    // We need to read edgeStart(v1) and edgeStart(v2) (in the terminology
-    // of the commit message for r19646) - to determine the span of
-    // the channels sv, ev, ww.
-    // Then we need everything in between - to know how many edges
-    // each vertex has.
-    //
-    // But we need to avoid the undefined behavior when
-    // channels refer to overlapping parts of a file.
-    // So we read edgeStart(v1) from 'ST2' and the rest from 'STA'.
-    //
-    const sta_v1 = repfiles[repfileST2].reader(kind = IOendianness,
-                                               locking = false,
-                                               start = staOffsetForVID(v1),
-                                               end = staOffsetForVID(v1+1));
-    const sta1 = readNum(sta_v1) + 1;
-    sta_v1.close();
-
-    // We read edgeStart(v2) from its own channel.
-    const sta_v2 = repfiles[repfileSTA].reader(IOendianness, false,
-                              staOffsetForVID(v2+1), staOffsetForVID(v2+1+1));
-    const sta2 = readNum(sta_v2);
-    sta_v2.close();
-
-    //writeln("edgeStart ", sta1, "..", sta2);
-    if !(sta1 < sta2) then
-      halt("parallel graph I/O for a small number of vertices is not supported\n",
-           "  loc ", here.id, "  myIDs ", v1, "..", v2, "  of ", uxIDs,
-           "  edgeStart ", sta1, "..", sta2);
-
-    // We access only our parts these files.
-    const sv = repfiles[repfileSV].reader(IOendianness, false,
-                          svOffsetForEID(sta1), svOffsetForEID(sta2+1));
-    const ev = repfiles[repfileEV].reader(IOendianness, false,
-                          svOffsetForEID(sta1), svOffsetForEID(sta2+1));
-    const ww = repfiles[repfileWW].reader(IOendianness, false,
-                          svOffsetForEID(sta1), svOffsetForEID(sta2+1));
-
-    // 'sta' covers edgeStart(v1+1..v2).
-    // Do not include v1, as another process will be reading it from its 'STA'.
-    const sta = repfiles[repfileSTA].reader(IOendianness, false,
-                           staOffsetForVID(v1+1), staOffsetForVID(v2+1+1));
-
-    var startIxCnt = sta1 - 1;
-
-    for u in v1:VType..v2:VType {
-      readOneVertex(GRowLocal, VType, vCount, u, dON, dRow, dEdge, dstyle,
-                    sv, ev, ww, startIxData = readNum(sta), startIxCnt);
-
-      // this needs to look like an iterator
-      yield u;
-
-    } // for u
-
-    if startIxCnt != sta2 then
-      halt("*** mismatch ***  ", startIxCnt, " vs. ", sta2);
-
-    sv.close();
-    ev.close();
-    ww.close();
-    sta.close();
-
-    if IOgate then IOgate$;
-  } // graphReaderReal
-
-  proc readOneVertex(GRow, type VType, vCount, u, dON, dRow, dEdge, dstyle,
-                     sv, ev, ww, startIxData, inout startIxCnt)
-  {
-    const numEdges = startIxData - startIxCnt;
-    if dRow then write("row ", u, ": [", numEdges, "] ");
+use SSCA2_compilation_config_params, Time, ReplicatedDist;
+
+//
+// The data is stored in 5 files per graph.
+// The individual files' names are obtained by appending
+// the following strings to the "prefix" arg of the functions
+// Writeout_RMAT_graph() and Readin_RMAT_graph().
+//
+config const VE_FILENAME     = "vertex_edge_info.data";
+config const SV2_FILENAME    = "sv2_snapshot.data";
+config const EV2_FILENAME    = "ev2_snapshot.data";
+config const START_FILENAME  = "start_snapshot.data";
+config const WEIGHT_FILENAME = "weight_snapshot.data";
+config type  IONumType       = int(64);
+config param IOendianness    = iokind.big;
+config const IOserial        = false;
+config const IOsingleTaskPerLocale = true;
+
+// Debugging-related settings.
+config const IOprogress      = true;
+config var progressFrequency = 100000;
+config const IOgate          = false;
+
+//
+// Writeout_RMAT_graph()
+//   Writes out the graph to files.
+//   The file names are a concatenation of 'snapshot_prefix'
+//     and the *_FILENAME constants above.
+//   The debugging style is specified by 'dstyle' and is described below
+//     (see proc interpretDStyle()).
+//
+proc Writeout_RMAT_graph(G, snapshot_prefix:string, dstyle = "-"): void {
+  writeln("writing RMAT graph with ", graphNumVertices(G), " vertices, ",
+        graphTotalEdges(G), " edges to '", snapshot_prefix, "'*");
+
+  var stopwatch : Timer;
+  if PRINT_TIMING_STATISTICS then stopwatch.start ();
+
+  param wri = true;
+
+  const (dON, dRow, dEdge) = interpretDStyle(dstyle);
+  // this presently would leak too much string memory
+  //proc debugRow(msg...)  { if dRow then write((...msg)); }
+  // ... but this is not called in a loop
+  proc debug(msg...) { if dON then writeln((...msg)); }
+
+  const veCount = createGraphChannel(snapshot_prefix, VE_FILENAME, wri);
+  writeNum(veCount, graphNumVertices(G));
+  writeNum(veCount, graphTotalEdges(G));
+  veCount.close();
+
+  const sv = createGraphChannel(snapshot_prefix, SV2_FILENAME, wri);
+  const ev = createGraphChannel(snapshot_prefix, EV2_FILENAME, wri);
+  const ww = createGraphChannel(snapshot_prefix, WEIGHT_FILENAME, wri);
+  const sta = createGraphChannel(snapshot_prefix, START_FILENAME, wri);
+
+  // Tracks the starting index for each vertex, 0-based, for START_FILENAME.
+  var startIx = 0: IONumType;
+  resetProgress();
+
+  // iterate sequentially
+  for (u, ux) in zip(G.vertices, G.Row) {
+    if dRow then write("row ", u, ": [", ux.numNeighbors(), "] ");
     if dEdge then writeln(dstyle, " vertex ", u);
+    writeNum(sta, startIx);
 
-    // we know how many neighbors we have for this vertex
-    //
-    GRow(u).ndom = 1..numEdges;
-    ref neighborList = GRow(u).neighborList;
-
-    for ix in 1..numEdges {
-      const curStart = readNum(sv)+1,
-        v = (readNum(ev)+1):VType,
-        w = readNum(ww):VType;
-
-      // initial reporting
+    for (v, w) in ux.neighborList {
       if dRow then write((v, w));
       if dEdge then writeln(dstyle, " ", u, " ", v, " ", w);
-
-      // sanity checks
-      if curStart != u then
-        myerror("*** start vertex mismatch: expected ",
-                u, ", got ", curStart);
-      if v < 1 || v > vCount then
-        myerror("*** illegal end vertex number: ", v);
-
-      // record the edge in the vertex
-      neighborList(ix) = nleMake(v, w);
-
-      // more reporting
-      startIxCnt += 1;
+      writeNum(sv, u-1);
+      writeNum(ev, v-1);
+      writeNum(ww, w);
+      startIx += 1;
       if dON && reportProgress() then
-        writeln("processing...  vertex ", u, "  edge ", startIxCnt);
+        writeln("processing...  vertex ", u, "  edge ", startIx);
     }
     if dRow then writeln();
-
-    // because we run the loop exactly the right number of times
-    assert(startIxCnt == startIxData);
-
-  } // readOneVertex
-
-  ///////// helpers /////////
-
-  //
-  // 'dstyle' specifies the debugging style:
-  //   "-"        no debug output, just start/end/summary
-  //   "summary"  verbose summary - do not use when measuring performance
-  //                while IOprogress=true
-  //   "row"      DEBUG_GRAPH_GENERATOR-style one line per row
-  //   otherwise  one line per edge (enables sorting), prefixed by 'dstyle'
-  //
-  proc interpretDStyle(dstyle:string) {
-    const dON   = dstyle != "-";
-    const dVerb = dstyle == "summary";
-    const dRow  = dstyle == "row";
-    // otherwise
-    const dEdge = dON && !(dRow || dVerb);
-
-    return (dON, dRow, dEdge);
   }
 
-  //
-  // For debugging, we are making these errors non-fatal.
-  // Especially useful with --checkOnlyOnRead.
-  //
-  proc myerror(args...) {
-    try! stderr.writeln("ERROR: ", (...args));
-    try! stderr.writeln("(proceeding nonetheless)");
+  const numVertices = G.vertices.numIndices;
+  debug("done writing ", numVertices, " vertices, ", startIx, " edges");
+  assert(startIx == graphTotalEdges(G));
+  const sb = numBytes(IONumType);
+  debug("file sizes  ", 2 * sb, "  ", (graphNumVertices(G) + 2) * sb,
+        "  ", graphTotalEdges(G) * sb);
+  writeNum(sta, startIx);
+  writeNum(sta, startIx);
+
+  sv.close();
+  ev.close();
+  ww.close();
+  sta.close();
+
+  if PRINT_TIMING_STATISTICS then {
+    stopwatch.stop ();
+    writeln ( "Elapsed time for writing RMAT graph: ", stopwatch.elapsed (),
+              " seconds");
+    stopwatch.clear ();
   }
 
-  proc reportNumVerticesError(G, snapshot_prefix, vCount) {
-    const vcountLog2 =
-      if vCount <= 0 then -1:int(64) else floor(log2(vCount)):int(64);
-    const helpMessage =
-      if vCount <= 0 then "Note: got 0 or negative vertex count."
-      else if exp2(vcountLog2:real(64)) == vCount:real(64) then
-        "Pass --SCALE=" + vcountLog2:string + " to suppress the error."
-      else "Note: got a vertex count that is not a power of 2.";
+  write("DONE writing RMAT graph");
+  if dON then write(" to '", snapshot_prefix, "'*");
+  //else write(" with ", numVertices, " vertices, ", startIx, " edges");
+  writeln(); writeln();
 
-    myerror("inconsistent vertex count: graph ", graphNumVertices(G), " vs. ",
-            vCount, " in ", snapshot_prefix, VE_FILENAME, "\n", helpMessage);
-  }
+} // Writeout_RMAT_graph()
 
-  ///////// progress indicator /////////
+//
+// For each data file, we create one Chapel 'file' per locale when parallel.
+// Cheap-to-compute decls are here, the rest are in Readin_RMAT_graph().
+//
+param repfileLow = 1, repfileHi = 5,
+      repfileSV = 1, repfileEV = 2, repfileWW = 3,
+      repfileSTA = 4, repfileST2 = 5;
+const repfileBase = {repfileLow .. repfileHi};
 
-  var progressCount = 0;
-  proc resetProgress() {
-    progressCount = 0;
-  }
-  proc reportProgress() {
-    if !IOprogress then return false;
-    var result = false;
-    progressCount -= 1;
-    if progressCount <= 0 {
-      result = true;
-      progressCount = progressFrequency;
+//
+// Readin_RMAT_graph()
+//   Reads in the graph from files.
+//   The file names and the debugging style are the same as
+//   for Writeout_RMAT_graph().
+//
+proc Readin_RMAT_graph(G, snapshot_prefix:string, dstyle = "-"): void {
+  writeln("reading RMAT graph with ", graphNumVertices(G), " vertices",
+          if IOserial then " serially" else
+            if DISTRIBUTION_TYPE == "BLOCK" && IOsingleTaskPerLocale
+              then " in parallel, 1 task per locale" else " in parallel",
+          " from '", snapshot_prefix, "'*");
+
+  var stopwatch : Timer;
+  if PRINT_TIMING_STATISTICS then stopwatch.start ();
+
+  param rea = false;
+
+  const (dON, dRow, dEdge) = interpretDStyle(dstyle);
+  // this presently would leak too much string memory
+  //proc debugRow(msg...)  { if dRow then write((...msg)); }
+  // ... but this is not called in a loop
+  proc debug(msg...) { if dON then writeln((...msg)); }
+
+  const veCount = createGraphChannel(snapshot_prefix, VE_FILENAME, rea);
+  const vCount    = readNum(veCount),
+        eCount    = readNum(veCount);
+  ensureEOFofDataFile(veCount, snapshot_prefix, VE_FILENAME);
+  veCount.close();
+
+  G.num_edges = eCount;
+  debug("files contain  ", vCount, " vertices  ", eCount, " edges");
+  const sb = numBytes(IONumType);
+  debug("expected file sizes  ", 2*sb, "  ", (vCount+2)*sb, "  ", eCount*sb);
+
+  if vCount != graphNumVertices(G) then
+    reportNumVerticesError(G, snapshot_prefix, vCount);
+
+  ref GRow = G.Row;
+  const uxIDs = GRow.domain.dim(1);
+  type VType = uxIDs.idxType;
+  compilerAssert(!uxIDs.stridable); // for efficiency
+
+  if IOserial {
+    const sv = createGraphChannel(snapshot_prefix, SV2_FILENAME, rea);
+    const ev = createGraphChannel(snapshot_prefix, EV2_FILENAME, rea);
+    const ww = createGraphChannel(snapshot_prefix, WEIGHT_FILENAME, rea);
+    const sta = createGraphChannel(snapshot_prefix, START_FILENAME, rea);
+
+    var startIxCnt = 0:IONumType, startIxData = readNum(sta);
+    if startIxCnt != startIxData then
+      halt("the first index in ", snapshot_prefix, START_FILENAME,
+           " is ", startIxData, " but should be ", startIxCnt);
+
+    for u in uxIDs do
+      readOneVertex(GRow, VType, vCount, u, dON, dRow, dEdge, dstyle,
+                    sv, ev, ww, startIxData = readNum(sta), startIxCnt);
+
+    debug("done reading ", vCount, " vertices, ", startIxData, " edges");
+
+    // one more entry in 'sta'
+    startIxData = readNum(sta);
+    if startIxData != startIxCnt then
+      myerror("wrong last entry in ", snapshot_prefix, START_FILENAME,
+              "  expected ", startIxCnt, "  got ", startIxData);
+    if startIxData != eCount then
+      myerror(snapshot_prefix, VE_FILENAME, " claimed ", eCount,
+              " edges, the other files gave ", startIxData, " edges");
+
+    ensureEOFofDataFile(sv, snapshot_prefix, SV2_FILENAME);
+    ensureEOFofDataFile(ev, snapshot_prefix, EV2_FILENAME);
+    ensureEOFofDataFile(ww, snapshot_prefix, WEIGHT_FILENAME);
+    ensureEOFofDataFile(sta, snapshot_prefix, START_FILENAME);
+
+    sv.close();
+    ev.close();
+    ww.close();
+    sta.close();
+
+  } else {
+    // !IOserial
+    const repfileMap = new Replicated(Locales);
+    const repfileDom = repfileBase dmapped new dmap(repfileMap);
+    var repfiles: [repfileDom] file;
+
+    coforall l in Locales do on l {
+repfiles[repfileSV] = createGraphFile(snapshot_prefix, SV2_FILENAME, rea);
+repfiles[repfileEV] = createGraphFile(snapshot_prefix, EV2_FILENAME, rea);
+repfiles[repfileWW] = createGraphFile(snapshot_prefix, WEIGHT_FILENAME, rea);
+repfiles[repfileSTA] = createGraphFile(snapshot_prefix, START_FILENAME, rea);
+repfiles[repfileST2] = createGraphFile(snapshot_prefix, START_FILENAME, rea);
     }
-    return result;
-  }
 
-  ///////// graph helpers /////////
+   if DISTRIBUTION_TYPE == "BLOCK" && IOsingleTaskPerLocale {
+      coforall locDom in GRow._value.dom.locDoms do on locDom {
+        const myIDs = locDom.myBlock.dim(1);
 
-  proc graphTotalEdges(G)  return + reduce [v in G.Row] v.numNeighbors();
-  proc graphNumVertices(G) return G.vertices.numIndices;
+        // All work is done in graphReaderReal() iterator.
+        for graphReaderReal(GRow, uxIDs, VType, vCount, eCount, repfiles,
+                            dON, dRow, dEdge, dstyle, myIDs) do;
+      }
 
-  ///////// I/O helpers /////////
+   } else {
+    // !IOsingleTaskPerLocale && !IOserial
 
-  proc createGraphChannel(prefix:string, suffix:string, param forWriting:bool) {
-    const f = createGraphFile(prefix, suffix, forWriting);
-    const chan = if forWriting
-      then f.writer(IOendianness, false)
-      else f.reader(IOendianness, false);
-    return chan;
-  }
+    // All work is done in graphReaderIterator() follower iterator.
+    // GRow is used only to distribute/parallelize the computation.
+    forall (_,_) in zip(GRow,
+      graphReaderIterator(GRow, uxIDs, VType, vCount, eCount, repfiles,
+                          dON, dRow, dEdge, dstyle))
+        do;
 
-  proc createGraphFile(prefix:string, suffix:string, param forWriting:bool) {
-    return open(prefix+suffix,
-                if forWriting then iomode.cw else iomode.r,
-                IOHINT_SEQUENTIAL);
-  }
+   } // if IOsingleTaskPerLocale
 
-  proc ensureEOFofDataFile(chan, snapshot_prefix, file_suffix): void {
-    var temp:IONumType;
-    try! {
-      chan.read(temp);
-    } catch e: SystemError {
-      // temp==0 is a workaround for unending large files
-      if e.err != EEOF && temp != 0 then
-        myerror("did not reach EOF in '", snapshot_prefix, file_suffix,
-                "'  the next value is ", temp);
+    coforall l in Locales do on l {
+        repfiles[repfileSV].close();
+        repfiles[repfileEV].close();
+        repfiles[repfileWW].close();
+        repfiles[repfileSTA].close();
+        repfiles[repfileST2].close();
     }
+
+  } // if IOserial
+
+  if PRINT_TIMING_STATISTICS then {
+    stopwatch.stop ();
+    writeln ( "Elapsed time for reading RMAT graph: ", stopwatch.elapsed (),
+              " seconds");
+    stopwatch.clear ();
   }
 
-  proc writeNum(ch, num): void { ch.write(num:IONumType); }
-  proc readNum(ch): IONumType  return ch.read(IONumType);
+  write("DONE reading RMAT graph");
+  if dON then write(" from '", snapshot_prefix, "'*");
+  else        write(" with ", vCount, " vertices, ", eCount, " edges");
+  writeln(); writeln();
+
+} // Readin_RMAT_graph()
+
+
+///////// parallel Readin_RMAT_graph helpers /////////
+
+// For use with IOgate=true: allows only a single graphReaderIterator
+// follower invocation at a time.
+var IOgate$: sync bool;
+
+// Seems we need this serial iterator declaration to keep the compiler happy.
+// But it is not implemented. Use --IOserial instead.
+//
+iter graphReaderIterator(GRow, uxIDs, type VType, vCount, eCount, repfiles,
+                         dON, dRow, dEdge, dstyle) {
+  halt("serial graphReaderIterator should not be invoked");
+  yield 0:VType;
 
 }
+
+// This is the follower iterator.
+// We do not need the leader iterator.
+//
+iter graphReaderIterator(GRow, uxIDs, type VType, vCount, eCount, repfiles,
+                         dON, dRow, dEdge, dstyle,
+                         param tag: iterKind, followThis)
+  where tag == iterKind.follower
+{
+  // ensure we got unstridable range with VType-typed indices
+  compilerAssert(followThis.type ==
+                 1*range(VType, BoundedRangeType.bounded, false));
+
+  const myIDs = unDensify(followThis(1), uxIDs);
+
+  // Redirect to graphReaderReal() iterator.
+  for dummy in graphReaderReal(GRow, uxIDs, VType, vCount, eCount, repfiles,
+                               dON, dRow, dEdge, dstyle, myIDs)
+    do yield dummy;
+}
+
+// This iterator reads the part of the graph corresponding to myIDs,
+// on the locale where it is run.
+//
+iter graphReaderReal(GRow, uxIDs, type VType, vCount, eCount, repfiles,
+                     dON, dRow, dEdge, dstyle, myIDs)
+{
+  if IOgate then IOgate$ = true;
+
+  compilerAssert(!myIDs.stridable); // for efficiency, also for v1,v2
+  // start/end IDs
+  const v1 = myIDs.low, v2 = myIDs.high;
+  //writeln("loc ", here.id, "  myIDs ", v1, "..", v2, "  of ", uxIDs);
+
+  // These indices better be all local, so take advantage of that.
+  ref GRowLocal = GRow.localSlice(myIDs);
+
+  // Returns the offset of edgeStart[v] in staf, 1 <= v <= numVertices+2.
+  proc staOffsetForVID(v: int) return (v-1) * numBytes(IONumType);
+  // Returns the offset of startVertex/endVertex/weight[e] in
+  //  svf, evf, wwf, resp; 1 <= e <= numEdges.
+  proc svOffsetForEID(e: int) return (e-1) * numBytes(IONumType);
+
+  // We need to read edgeStart(v1) and edgeStart(v2) (in the terminology
+  // of the commit message for r19646) - to determine the span of
+  // the channels sv, ev, ww.
+  // Then we need everything in between - to know how many edges
+  // each vertex has.
+  //
+  // But we need to avoid the undefined behavior when
+  // channels refer to overlapping parts of a file.
+  // So we read edgeStart(v1) from 'ST2' and the rest from 'STA'.
+  //
+  const sta_v1 = repfiles[repfileST2].reader(kind = IOendianness,
+                                             locking = false,
+                                             start = staOffsetForVID(v1),
+                                             end = staOffsetForVID(v1+1));
+  const sta1 = readNum(sta_v1) + 1;
+  sta_v1.close();
+
+  // We read edgeStart(v2) from its own channel.
+  const sta_v2 = repfiles[repfileSTA].reader(IOendianness, false,
+                            staOffsetForVID(v2+1), staOffsetForVID(v2+1+1));
+  const sta2 = readNum(sta_v2);
+  sta_v2.close();
+
+  //writeln("edgeStart ", sta1, "..", sta2);
+  if !(sta1 < sta2) then
+    halt("parallel graph I/O for a small number of vertices is not supported\n",
+         "  loc ", here.id, "  myIDs ", v1, "..", v2, "  of ", uxIDs,
+         "  edgeStart ", sta1, "..", sta2);
+
+  // We access only our parts these files.
+  const sv = repfiles[repfileSV].reader(IOendianness, false,
+                        svOffsetForEID(sta1), svOffsetForEID(sta2+1));
+  const ev = repfiles[repfileEV].reader(IOendianness, false,
+                        svOffsetForEID(sta1), svOffsetForEID(sta2+1));
+  const ww = repfiles[repfileWW].reader(IOendianness, false,
+                        svOffsetForEID(sta1), svOffsetForEID(sta2+1));
+
+  // 'sta' covers edgeStart(v1+1..v2).
+  // Do not include v1, as another process will be reading it from its 'STA'.
+  const sta = repfiles[repfileSTA].reader(IOendianness, false,
+                         staOffsetForVID(v1+1), staOffsetForVID(v2+1+1));
+
+  var startIxCnt = sta1 - 1;
+
+  for u in v1:VType..v2:VType {
+    readOneVertex(GRowLocal, VType, vCount, u, dON, dRow, dEdge, dstyle,
+                  sv, ev, ww, startIxData = readNum(sta), startIxCnt);
+
+    // this needs to look like an iterator
+    yield u;
+
+  } // for u
+
+  if startIxCnt != sta2 then
+    halt("*** mismatch ***  ", startIxCnt, " vs. ", sta2);
+
+  sv.close();
+  ev.close();
+  ww.close();
+  sta.close();
+
+  if IOgate then IOgate$;
+} // graphReaderReal
+
+proc readOneVertex(GRow, type VType, vCount, u, dON, dRow, dEdge, dstyle,
+                   sv, ev, ww, startIxData, inout startIxCnt)
+{
+  const numEdges = startIxData - startIxCnt;
+  if dRow then write("row ", u, ": [", numEdges, "] ");
+  if dEdge then writeln(dstyle, " vertex ", u);
+
+  // we know how many neighbors we have for this vertex
+  //
+  GRow(u).ndom = 1..numEdges;
+  ref neighborList = GRow(u).neighborList;
+
+  for ix in 1..numEdges {
+    const curStart = readNum(sv)+1,
+      v = (readNum(ev)+1):VType,
+      w = readNum(ww):VType;
+
+    // initial reporting
+    if dRow then write((v, w));
+    if dEdge then writeln(dstyle, " ", u, " ", v, " ", w);
+
+    // sanity checks
+    if curStart != u then
+      myerror("*** start vertex mismatch: expected ",
+              u, ", got ", curStart);
+    if v < 1 || v > vCount then
+      myerror("*** illegal end vertex number: ", v);
+
+    // record the edge in the vertex
+    neighborList(ix) = nleMake(v, w);
+
+    // more reporting
+    startIxCnt += 1;
+    if dON && reportProgress() then
+      writeln("processing...  vertex ", u, "  edge ", startIxCnt);
+  }
+  if dRow then writeln();
+
+  // because we run the loop exactly the right number of times
+  assert(startIxCnt == startIxData);
+
+} // readOneVertex
+
+///////// helpers /////////
+
+//
+// 'dstyle' specifies the debugging style:
+//   "-"        no debug output, just start/end/summary
+//   "summary"  verbose summary - do not use when measuring performance
+//                while IOprogress=true
+//   "row"      DEBUG_GRAPH_GENERATOR-style one line per row
+//   otherwise  one line per edge (enables sorting), prefixed by 'dstyle'
+//
+proc interpretDStyle(dstyle:string) {
+  const dON   = dstyle != "-";
+  const dVerb = dstyle == "summary";
+  const dRow  = dstyle == "row";
+  // otherwise
+  const dEdge = dON && !(dRow || dVerb);
+
+  return (dON, dRow, dEdge);
+}
+
+//
+// For debugging, we are making these errors non-fatal.
+// Especially useful with --checkOnlyOnRead.
+//
+proc myerror(args...) {
+  try! stderr.writeln("ERROR: ", (...args));
+  try! stderr.writeln("(proceeding nonetheless)");
+}
+
+proc reportNumVerticesError(G, snapshot_prefix, vCount) {
+  const vcountLog2 =
+    if vCount <= 0 then -1:int(64) else floor(log2(vCount)):int(64);
+  const helpMessage =
+    if vCount <= 0 then "Note: got 0 or negative vertex count."
+    else if exp2(vcountLog2:real(64)) == vCount:real(64) then
+      "Pass --SCALE=" + vcountLog2:string + " to suppress the error."
+    else "Note: got a vertex count that is not a power of 2.";
+
+  myerror("inconsistent vertex count: graph ", graphNumVertices(G), " vs. ",
+          vCount, " in ", snapshot_prefix, VE_FILENAME, "\n", helpMessage);
+}
+
+///////// progress indicator /////////
+
+var progressCount = 0;
+proc resetProgress() {
+  progressCount = 0;
+}
+proc reportProgress() {
+  if !IOprogress then return false;
+  var result = false;
+  progressCount -= 1;
+  if progressCount <= 0 {
+    result = true;
+    progressCount = progressFrequency;
+  }
+  return result;
+}
+
+///////// graph helpers /////////
+
+proc graphTotalEdges(G)  return + reduce [v in G.Row] v.numNeighbors();
+proc graphNumVertices(G) return G.vertices.numIndices;
+
+///////// I/O helpers /////////
+
+proc createGraphChannel(prefix:string, suffix:string, param forWriting:bool) {
+  const f = createGraphFile(prefix, suffix, forWriting);
+  const chan = if forWriting
+    then f.writer(IOendianness, false)
+    else f.reader(IOendianness, false);
+  return chan;
+}
+
+proc createGraphFile(prefix:string, suffix:string, param forWriting:bool) {
+  return open(prefix+suffix,
+              if forWriting then iomode.cw else iomode.r,
+              IOHINT_SEQUENTIAL);
+}
+
+proc ensureEOFofDataFile(chan, snapshot_prefix, file_suffix): void {
+  var temp:IONumType;
+  try! {
+    chan.read(temp);
+  } catch e: SystemError {
+    // temp==0 is a workaround for unending large files
+    if e.err != EEOF && temp != 0 then
+      myerror("did not reach EOF in '", snapshot_prefix, file_suffix,
+              "'  the next value is ", temp);
+  }
+}
+
+proc writeNum(ch, num): void { ch.write(num:IONumType); }
+proc readNum(ch): IONumType  return ch.read(IONumType);

--- a/test/studies/ssca2/graphio/SSCA2_RMAT_graph_generator.chpl
+++ b/test/studies/ssca2/graphio/SSCA2_RMAT_graph_generator.chpl
@@ -1,603 +1,597 @@
-pragma "error mode fatal"
-module SSCA2_RMAT_graph_generator
-
-{
-  // +=========================================================================+
-  // |             RMAT approximate power law graph generator                  |
-  // |                                 and                                     |
-  // |                           SSCA #2 Kernel 1                              |
-  // |                                                                         |
-  // |  Generate approximate power law graph                                   |
-  // |                                                                         |
-  // |  This procedure accepts a generic graph representation which must       |
-  // |  provide only the capabilities to:                                      |
-  // |    1. add a vertex to a neighbor list for some other vertex             |
-  // |    2. assign an integer weight to an entry in an associated weight list |
-  // |                                                                         |
-  // |  The RMAT procedure implicitly assumes that vertices are integers       |
-  // |  in the range [0, 2^SCALE].  So vertices are integers in this           |
-  // |  procedure and edges are pairs of integers.                             |
-  // |                                                                         |
-  // |  This implementation first generates the RMAT graph as a list of        |
-  // |  triples, using an array of edges and an associated array of weights.   |
-  // |  These are transformed into the Chapel graph representation using       |
-  // |  native Chapel syntax for associative and sparse domains and arrays.    |
-  // |  That transformation is Kernel 1 of the SSCA #2 benchmark.              |
-  // |                                                                         |
-  // |  The code uses two auxiliary procedures for clarity and to help the     |
-  // |  compiler use more abstract, higher level, code.                        |
-  // +=========================================================================+
-
-  use SSCA2_compilation_config_params;
-
-  record directed_vertex_pair {
-    var start = 1: int;
-    var end   = 1: int;
-  }
-
-  proc +(l: directed_vertex_pair, r: directed_vertex_pair)
-      return new directed_vertex_pair (l.start + r.start, l.end + r.end);
-
-
-  // ============================
-  // Quadrant selection algorithm
-  // ============================
-
-  proc assign_quadrant ( u: real, a: real, b: real, c: real, d : real,
-			bit : int ) : directed_vertex_pair
-    {
-      // ---------------------------------------------------------------------
-      // The heart of the RMAT random graph generator is a procedure that
-      // assigns a single bit of the edge starting and ending vertex by
-      // assigning the edge with specified probability to one of the four
-      // quadrants of a 2 x 2 grid.
-      //
-      // Chapel is able to promote this conditional-based scalar procedure to
-      // array operations where it is not able to promote conditional code
-      // directly.
-      //
-      // Determine randomly in which quadrant of the grid a point lies,
-      // based on the following picture:
-      //
-      //     +---------------------------+
-      //     | u < a         | u < a+b   |
-      //     |-------------+-------------|
-      //     | u < a + b + c | otherwise |
-      //     +---------------------------+
-      //
-      // The probability of the edge falling in the upper left quadrant is  a,
-      // in the upper right quadrant, b, the lower left quadrant  c
-      // and the lower right quadrant  d, where the probabilities are
-      // normalized to sum to one.
-      // ---------------------------------------------------------------------
-
-      var start_inc = 0;
-      var end_inc   = 0;
-      var edge : directed_vertex_pair;
-
-      if u <= a then
-	{}
-      else if u <= a + b then
-	{ end_inc = 1;}
-      else if u <= a + b + c then
-	{ start_inc = 1;}
-      else
-	{ start_inc = 1; end_inc = 1;};
-
-      edge.start = bit * start_inc;
-      edge.end   = bit * end_inc;
-      return ( edge );
-    }
-
-
-  // ====================================
-  // Main RMAT Graph Generation Procedure
-  // ====================================~
-
-  proc Gen_RMAT_graph ( a : real,
-		       b : real,
-		       c : real,
-		       d : real,
-		       SCALE :int,
-		       N_VERTICES : int,
-		       n_raw_edges : int,
-		       MAX_EDGE_WEIGHT :int,
-		       G )
-
-    { use Random;
-      writeln("generating RMAT graph");
-
-      const vertex_range = 1..N_VERTICES,
-	    edge_range   = 1..n_raw_edges,
-	    rand_range   = 1..n_raw_edges + 1;
-
-      // Random Numbers return in the range [0.0, 1.0)
-
-      var Rand_Gen = if REPRODUCIBLE_PROBLEMS then
-	               new NPBRandomStream (real, seed = 0556707007)
-		     else
-		       new NPBRandomStream (real);
-
-      var   Noisy_a     : [edge_range] real,
-	    Noisy_b     : [edge_range] real,
-            Noisy_c     : [edge_range] real,
-            Noisy_d     : [edge_range] real,
-            norm        : [edge_range] real,
-	    Unif_Random : [edge_range] real,
-	    Edges       = [edge_range] new directed_vertex_pair ();
-
-       // ---------------------------------------------------------------
-      // The RMAT algorithm is based on recursively sub-dividing a grid.
-      // In this case, the grid is square of order 2^SCALE by 2^SCALE.
-      // So exactly "SCALE" steps of recursion will be required and the
-      // recursion can be implemented directly by iteration.
-      // ---------------------------------------------------------------
-
-      // -----------------------------------------------------------------
-      // Note on random number generators -- the RMAT generator creates
-      // 5*SCALE vectors of length 2**SCALE.  The dependence on powers
-      // of two provides an opportunity to expose statistical correlations
-      // in the pseudo-random numbers.  This certainly occurs with the
-      // current Chapel Random module.  The "skips" in the random number
-      // sequence dramatically change the results.  Without them, the
-      // Chapel RMAT matrices are inconsistent with what is seen in
-      // other implementations.
-      // -----------------------------------------------------------------
-
-      writeln ("Random graph generated by stride of 1 in one random stream",
-	       " with skips" );
-
-      var bit = 1 << SCALE;
-      var   skip : real;
-
-      for depth in 1..SCALE do {
-	  bit >>= 1;
-
-	  // randomize the coefficients, tweaking them by numbers in [-.05, .05)
-
-	  skip = Rand_Gen.getNext ();
-	  Rand_Gen.fillRandom (Unif_Random);
-	  Noisy_a = a * (0.95 + 0.1 * Unif_Random);
-
-	  skip = Rand_Gen.getNext ();
-	  Rand_Gen.fillRandom (Unif_Random);
-	  Noisy_b = b * (0.95 + 0.1 * Unif_Random);
-
-	  skip = Rand_Gen.getNext ();
-	  Rand_Gen.fillRandom (Unif_Random);
-	  Noisy_c = c * (0.95 + 0.1 * Unif_Random);
-
-	  skip = Rand_Gen.getNext ();
-	  Rand_Gen.fillRandom (Unif_Random);
-	  Noisy_d = d * (0.95 + 0.1 * Unif_Random);
-
-	  norm     = 1.0 / (Noisy_a + Noisy_b + Noisy_c + Noisy_d);
-	  Noisy_a *= norm;
-	  Noisy_b *= norm;
-	  Noisy_c *= norm;
-	  Noisy_d *= norm;
-
-	  skip = Rand_Gen.getNext ();
-	  Rand_Gen.fillRandom (Unif_Random);
-
-	  Edges += assign_quadrant ( Unif_Random, Noisy_a, Noisy_b,
-				     Noisy_c, Noisy_d, bit );
-
-	};
-
-      // ---------------------------------------------------------------------
-      // Assign weights to edges randomly, then randomly relabel the vertices
-      // to avoid locality from the obvious imbalance that will arise when
-      // one of the coefficients is clearly larger than the others
-      // ---------------------------------------------------------------------
-
-      var permutation : [vertex_range] int = vertex_range;
-      var Edge_Weight : [edge_range] int;
-
-      Rand_Gen.fillRandom ( Unif_Random  );
-      Edge_Weight = floor (1 + Unif_Random * MAX_EDGE_WEIGHT) : int;
-
-      Rand_Gen.fillRandom ( Unif_Random (vertex_range) );
-
-      for v in vertex_range do
-	{ var new_id : int;
-	  new_id = floor (1 + Unif_Random (v) * N_VERTICES) : int;
-	  permutation (v) <=> permutation (new_id);
-	};
-
-      var node_count : [vertex_range] int = 0;
-
-      //      for e in edge_range do {
-      //	Edges(e).start = permutation (Edges(e).start);
-      //	Edges(e).end   = permutation (Edges(e).end  );
-      //      }
-      Edges.start = permutation (Edges.start);
-      Edges.end   = permutation (Edges.end  );
-
-      if DEBUG_GRAPH_GENERATOR || DEBUG_WEIGHT_GENERATOR then {
-	writeln ();
-	for e in edge_range do
-	  writeln ("edge (", e, ") : (", Edges(e), ", ",
-		   Edge_Weight (e), ")" );
-      }
-
-      // --------------------------
-      // Graph consistency checking
-      // --------------------------
-
-      assert ( Edges.start > 0,
-	       "edge start vertices out of low end of range");
-
-      assert ( Edges.end > 0,
-	       "edge end vertices out of low end of range");
-
-      assert ( Edges.start <= 2**SCALE,
-	       "edge start vertices out of high end of range");
-
-      assert ( Edges.end <= 2**SCALE,
-	       "edge end vertices out of high end of range");
-
-      assert ( Edge_Weight > 0,
-	       "edge weight out of low end of range");
-
-      assert ( Edge_Weight <= MAX_EDGE_WEIGHT,
-	       "edge weight out of high end of range");
-
-      writeln (); writeln ("Vertex Set in G:", G.vertices);
-
-      // ----------------------------------------------------------
-      // Kernel 1: assemble graph from list of triples.  Include
-      // only non-self incident edges.  in case of duplicates, last
-      // in wins (+= instead of = works to take sum of weights)
-      // ----------------------------------------------------------
-
-      var collisions = 0, self_edges = 0;
-      for e in edge_range do {
-	var u = Edges (e).start;
-	var v = Edges (e).end  ;
-
-	if ( v != u ) then {
-	  if G.Neighbors (u).member(v) then {
-	    collisions += 1;
-	  }
-	  else {
-	    G.Neighbors (u).add (v);
-	    G.Row(u).Weight (v) = Edge_Weight (e);
-	  }
-	}
-	else
-	  self_edges += 1;
-      }
-
-      writeln ( "# of raw edges generated  ", n_raw_edges );
-      writeln ( "# of duplicate edges      ", collisions );
-      writeln ( "# of self edges           ", self_edges );
-      writeln ( "# of edges in final graph ", graphTotalEdges(G));
-
-      if DEBUG_GRAPH_GENERATOR || DEBUG_WEIGHT_GENERATOR then {
-	writeln ();
-	writeln ("tuples denote (edge, weight)");
-	writeln ();
-	for u in G.vertices do {
-	  write ( "row ", u, ": [", G.n_Neighbors (u), "] " );
-	  for (v,w) in (G .Neighbors (u), G.edge_weight (u) ) do
-	    write ( (v, w) );
-	  writeln ();
-	}
-      }
-
-      var max_edges = max reduce [v in vertex_range] G.n_Neighbors (v);
-
-      var edge_count : [0..max_edges] int = 0;
-
-      for v in G.vertices do
-	edge_count (G.n_Neighbors (v)) += 1;
-
-      writeln ("histograph of node distributions by number of outgoing edges");
-      writeln ( "# edges  # nodes");
-      for count in 0..max_edges do
-	writeln ( count, "  ", edge_count (count) );
-
-      writeln ();
-
-    }
-
-  //
-  // RMAT graph I/O
-  //
-  // Uses the XMT/KM RMAT graph storage format for SSCA#2.
-  //
-
-  config const VE_FILENAME     = "vertex_edge_info.data";
-  config const SV2_FILENAME    = "sv2_snapshot.data";
-  config const EV2_FILENAME    = "ev2_snapshot.data";
-  config const START_FILENAME  = "start_snapshot.data";
-  config const WEIGHT_FILENAME = "weight_snapshot.data";
-  config type  IONumType       = int(64);
-
-  config const checkOnlyOnRead = false;
-
-  ///////// progress indicator /////////
-
-  config var progressFrequency = 100000;
-  var progressCount = 0;
-  proc resetProgress() {
-    progressCount = 0;
-  }
-  proc reportProgress() {
-    var result = false;
-    progressCount -= 1;
-    if progressCount <= 0 {
-      result = true;
-      progressCount = progressFrequency;
-    }
-    return result;
-  }
-
-  ///////// graph helpers /////////
-
-  proc graphTotalEdges(G)  return + reduce [v in G.vertices] G.n_Neighbors(v);
-  proc graphNumVertices(G) return G.vertices.numIndices;
-
-  ///////// I/O helpers /////////
-
-  proc createGraphChannel(prefix:string, suffix:string, param forWriting:bool) {
-    const f = open(prefix+suffix,
-                   if forWriting then iomode.cw else iomode.r,
-                   IOHINT_SEQUENTIAL);
-    const chan = if forWriting
-      then f.writer(iokind.big, false)
-      else f.reader(iokind.big, false);
-    return chan;
-  }
-
-  proc ensureEOFofDataFile(chan, snapshot_prefix, file_suffix): void {
-    var temp:IONumType;
-    try! {
-      chan.read(temp);
-    } catch e: SystemError {
-      // temp==0 is a workaround for unending large files
-      if e.err != EEOF && temp != 0 then
-        myerror("did not reach EOF in '", snapshot_prefix, file_suffix,
-                "'  the next value is ", temp);
-    }
-  }
-
-  proc writeNum(ch, num): void { ch.write(num:IONumType); }
-  proc readNum(ch): IONumType  return ch.read(IONumType);
-
-  ///////// misc /////////
-
-  proc reportNumVerticesError(G, snapshot_prefix, vCount) {
-    const vcountLog2 =
-      if vCount <= 0 then -1:int(64) else floor(log2(vCount)):int(64);
-    const helpMessage =
-      if vCount <= 0 then "Note: got 0 or negative vertex count."
-      else if exp2(vcountLog2:real(64)) == vCount:real(64) then
-        "Pass --SCALE=" + vcountLog2:string + " to suppress the error."
-      else "Note: got a vertex count that is not a power of 2.";
-
-    myerror("inconsistent vertex count: graph ", graphNumVertices(G), " vs. ",
-            vCount, " in ", snapshot_prefix, VE_FILENAME, "\n", helpMessage);
-  }
-
-  proc interpretDStyle(dstyle:string) {
-    const dON   = dstyle != "-";
-    const dVerb = dstyle == "summary";
-    const dRow  = dstyle == "row";
-    // otherwise
-    const dEdge = dON && !(dRow || dVerb);
-
-    return (dON, dRow, dEdge);
-  }
-
-  //
-  // For debugging, we are making these errors non-fatal.
-  // Especially useful with --checkOnlyOnRead.
-  //
-  proc myerror(args...) {
-    stderr.writeln("ERROR: ", (...args));
-    stderr.writeln("(proceeding nonetheless)");
-  }
-
-  ///////// interface functions: /////////
-  ////////   Writeout_RMAT_graph  ////////
-  ////////   Readin_RMAT_graph    ////////
-
-  //
-  // Write out the graph to files starting with 'snapshot_prefix'
-  // and ending with _FILENAME constants above.
-  //
-  // 'dstyle' - debug style:
-  //   "-"        no debug output, just start/end/summary
-  //   "summary"  verbose summary
-  //   "row"      DEBUG_GRAPH_GENERATOR-style one line per row
-  //   otherwise  one line per edge (enables sorting), prefixed by 'dstyle'
-  //
-  proc Writeout_RMAT_graph(G, snapshot_prefix:string, dstyle = "-"): void {
-    writeln("writing RMAT graph with ", graphNumVertices(G), " vertices, ",
-          graphTotalEdges(G), " edges to '", snapshot_prefix, "'*");
-
-    param wri = true;
-
-    const (dON, dRow, dEdge) = interpretDStyle(dstyle);
-    // this presently would leak too much string memory
-    //proc debugRow(msg...)  { if dRow then write((...msg)); }
-    // ... but this is not called in a loop
-    proc debug(msg...) { if dON then writeln((...msg)); }
-
-    const veCount = createGraphChannel(snapshot_prefix, VE_FILENAME, wri);
-    writeNum(veCount, graphNumVertices(G));
-    writeNum(veCount, graphTotalEdges(G));
-    veCount.close();
-
-    const sv = createGraphChannel(snapshot_prefix, SV2_FILENAME, wri);
-    const ev = createGraphChannel(snapshot_prefix, EV2_FILENAME, wri);
-    const ww = createGraphChannel(snapshot_prefix, WEIGHT_FILENAME, wri);
-    const sta = createGraphChannel(snapshot_prefix, START_FILENAME, wri);
-
-    // Tracks the starting index for each vertex, 0-based, for START_FILENAME.
-    var startIx = 0: IONumType;
-    resetProgress();
-
-    // iterate sequentially
-    for u in G.vertices {
-      if dRow then write("row ", u, ": [", G.n_Neighbors(u), "] ");
-      if dEdge then writeln(dstyle, " vertex ", u);
-      writeNum(sta, startIx);
-
-      for v in G.Neighbors(u).sorted() {
-        const w = G.Row(u).Weight(v);
-        if dRow then write((v, w));
-        if dEdge then writeln(dstyle, " ", u, " ", v, " ", w);
-        writeNum(sv, u-1);
-        writeNum(ev, v-1);
-        writeNum(ww, w);
-        startIx += 1;
-        if dON && reportProgress() then
-          writeln("processing...  vertex ", u, "  edge ", startIx);
-      }
-      if dRow then writeln();
-    }
-
-    const numVertices = G.vertices.numIndices;
-    debug("done writing ", numVertices, " vertices, ", startIx, " edges");
-    assert(startIx == graphTotalEdges(G));
-    const sb = numBytes(IONumType);
-    debug("file sizes  ", 2 * sb, "  ", (graphNumVertices(G) + 2) * sb,
-          "  ", graphTotalEdges(G) * sb);
-    writeNum(sta, startIx);
-    writeNum(sta, startIx);
-
-    sv.close();
-    ev.close();
-    ww.close();
-    sta.close();
-
-    write("DONE writing RMAT graph");
-    if dON then write(" to '", snapshot_prefix, "'*");
-    //else write(" with ", numVertices, " vertices, ", startIx, " edges");
-    writeln(); writeln();
-
-  } // Writeout_RMAT_graph()
-
-  //
-  // Read in the graph from the files as for Writeout_RMAT_graph().
-  // 'dstyle' - debug style, same as for Writeout_RMAT_graph().
-  //
-  proc Readin_RMAT_graph(G, snapshot_prefix:string, dstyle = "-"): void {
-    writeln("reading RMAT graph with ", graphNumVertices(G), " vertices",
-            " from '", snapshot_prefix, "'*");
-
-    param rea = false;
-
-    const (dON, dRow, dEdge) = interpretDStyle(dstyle);
-    // this presently would leak too much string memory
-    //proc debugRow(msg...)  { if dRow then write((...msg)); }
-    // ... but this is not called in a loop
-    proc debug(msg...) { if dON then writeln((...msg)); }
-
-    const veCount = createGraphChannel(snapshot_prefix, VE_FILENAME, rea);
-    const vCount    = readNum(veCount),
-          eCount    = readNum(veCount);
-    ensureEOFofDataFile(veCount, snapshot_prefix, VE_FILENAME);
-    veCount.close();
-
-    debug("files contain  ", vCount, " vertices  ", eCount, " edges");
-    const sb = numBytes(IONumType);
-    debug("expected file sizes  ", 2*sb, "  ", (vCount+2)*sb, "  ", eCount*sb);
-
-    if vCount != graphNumVertices(G) then
-      reportNumVerticesError(G, snapshot_prefix, vCount);
-
-    const sv = createGraphChannel(snapshot_prefix, SV2_FILENAME, rea);
-    const ev = createGraphChannel(snapshot_prefix, EV2_FILENAME, rea);
-    const ww = createGraphChannel(snapshot_prefix, WEIGHT_FILENAME, rea);
-    const sta = createGraphChannel(snapshot_prefix, START_FILENAME, rea);
-
-    // see whether the edges in the data file are ordered, for each edge
-    //var outOfOrderCnt = 0, prevEnd = 0:IONumType;
-
-    var startIxCnt = 0:IONumType, startIxData = readNum(sta);
-    if startIxCnt != startIxData then
-      halt("the first index in ", snapshot_prefix, START_FILENAME,
-           " is ", startIxData, " but should be ", startIxCnt);
-    resetProgress();
-    type VType = index(G.vertices);
-
-    for u in 1..(vCount:VType) {
-      startIxData = readNum(sta);
-      //prevEnd = min(prevEnd.type);
-      const numEdges = startIxData - startIxCnt;
-      if dRow then write("row ", u, ": [", numEdges, "] ");
-      if dEdge then writeln(dstyle, " vertex ", u);
-
-      for 1..numEdges {
-        const curStart = readNum(sv)+1,
-              v = (readNum(ev)+1):VType,
-              w = readNum(ww):VType;
-
-        // initial reporting
-        if dRow then write((v, w));
-        if dEdge then writeln(dstyle, " ", u, " ", v, " ", w);
-
-        // sanity checks
-        if curStart != u then
-          myerror("*** start vertex mismatch: expected ",
-                  u, ", got ", curStart);
-        if v < 1 || v > vCount then
-          myerror("*** illegal end vertex number: ", v);
-
-        // add the edge to the graph
-        if !checkOnlyOnRead {
-          G.Neighbors (u).add (v);
-          G.Row(u).Weight (v) = w;
-        }
-
-        // more reporting
-        startIxCnt += 1;
-        //if v <= prevEnd then
-        //  outOfOrderCnt += 1;
-        if dON && reportProgress() then
-          writeln("processing...  vertex ", u, "  edge ", startIxCnt);
-                  //("  outOfOrderCnt ", outOfOrderCnt);
-        //prevEnd = v;
-      }
-      if dRow then writeln();
-
-      // because we run the loop exactly the right number of times
-      assert(startIxCnt == startIxData);
-
-    } // for G.vertices
-
-    debug("done reading ", vCount, " vertices, ", startIxData, " edges");
-    //debug(if outOfOrderCnt then "outOfOrder edges: " + outOfOrderCnt:string
-    //        else "all edges are inOrder");
-
-    // one more entry in 'sta'
-    startIxData = readNum(sta);
-    if startIxData != startIxCnt then
-      myerror("wrong last entry in ", START_FILENAME,
-            "  expected ", startIxCnt, "  got ", startIxData);
-    if startIxData != eCount then
-      myerror(snapshot_prefix, VE_FILENAME, " claimed ", eCount,
-            " edges, the other files gave ", startIxData, " edges");
-
-    ensureEOFofDataFile(sv, snapshot_prefix, SV2_FILENAME);
-    ensureEOFofDataFile(ev, snapshot_prefix, EV2_FILENAME);
-    ensureEOFofDataFile(ww, snapshot_prefix, WEIGHT_FILENAME);
-    ensureEOFofDataFile(sta, snapshot_prefix, START_FILENAME);
-
-    sv.close();
-    ev.close();
-    ww.close();
-    sta.close();
-
-    write("DONE reading RMAT graph");
-    if dON then write(" from '", snapshot_prefix, "'*");
-    else        write(" with ", vCount, " vertices, ", eCount, " edges");
-    writeln(); writeln();
-
-  } // Readin_RMAT_graph()
+// +=========================================================================+
+// |             RMAT approximate power law graph generator                  |
+// |                                 and                                     |
+// |                           SSCA #2 Kernel 1                              |
+// |                                                                         |
+// |  Generate approximate power law graph                                   |
+// |                                                                         |
+// |  This procedure accepts a generic graph representation which must       |
+// |  provide only the capabilities to:                                      |
+// |    1. add a vertex to a neighbor list for some other vertex             |
+// |    2. assign an integer weight to an entry in an associated weight list |
+// |                                                                         |
+// |  The RMAT procedure implicitly assumes that vertices are integers       |
+// |  in the range [0, 2^SCALE].  So vertices are integers in this           |
+// |  procedure and edges are pairs of integers.                             |
+// |                                                                         |
+// |  This implementation first generates the RMAT graph as a list of        |
+// |  triples, using an array of edges and an associated array of weights.   |
+// |  These are transformed into the Chapel graph representation using       |
+// |  native Chapel syntax for associative and sparse domains and arrays.    |
+// |  That transformation is Kernel 1 of the SSCA #2 benchmark.              |
+// |                                                                         |
+// |  The code uses two auxiliary procedures for clarity and to help the     |
+// |  compiler use more abstract, higher level, code.                        |
+// +=========================================================================+
+
+use SSCA2_compilation_config_params;
+
+record directed_vertex_pair {
+  var start = 1: int;
+  var end   = 1: int;
 }
 
+proc +(l: directed_vertex_pair, r: directed_vertex_pair)
+    return new directed_vertex_pair (l.start + r.start, l.end + r.end);
+
+
+// ============================
+// Quadrant selection algorithm
+// ============================
+
+proc assign_quadrant ( u: real, a: real, b: real, c: real, d : real,
+                      bit : int ) : directed_vertex_pair
+  {
+    // ---------------------------------------------------------------------
+    // The heart of the RMAT random graph generator is a procedure that
+    // assigns a single bit of the edge starting and ending vertex by
+    // assigning the edge with specified probability to one of the four
+    // quadrants of a 2 x 2 grid.
+    //
+    // Chapel is able to promote this conditional-based scalar procedure to
+    // array operations where it is not able to promote conditional code
+    // directly.
+    //
+    // Determine randomly in which quadrant of the grid a point lies,
+    // based on the following picture:
+    //
+    //     +---------------------------+
+    //     | u < a         | u < a+b   |
+    //     |-------------+-------------|
+    //     | u < a + b + c | otherwise |
+    //     +---------------------------+
+    //
+    // The probability of the edge falling in the upper left quadrant is  a,
+    // in the upper right quadrant, b, the lower left quadrant  c
+    // and the lower right quadrant  d, where the probabilities are
+    // normalized to sum to one.
+    // ---------------------------------------------------------------------
+
+    var start_inc = 0;
+    var end_inc   = 0;
+    var edge : directed_vertex_pair;
+
+    if u <= a then
+      {}
+    else if u <= a + b then
+      { end_inc = 1;}
+    else if u <= a + b + c then
+      { start_inc = 1;}
+    else
+      { start_inc = 1; end_inc = 1;};
+
+    edge.start = bit * start_inc;
+    edge.end   = bit * end_inc;
+    return ( edge );
+  }
+
+
+// ====================================
+// Main RMAT Graph Generation Procedure
+// ====================================~
+
+proc Gen_RMAT_graph ( a : real,
+                     b : real,
+                     c : real,
+                     d : real,
+                     SCALE :int,
+                     N_VERTICES : int,
+                     n_raw_edges : int,
+                     MAX_EDGE_WEIGHT :int,
+                     G )
+
+  { use Random;
+    writeln("generating RMAT graph");
+
+    const vertex_range = 1..N_VERTICES,
+          edge_range   = 1..n_raw_edges,
+          rand_range   = 1..n_raw_edges + 1;
+
+    // Random Numbers return in the range [0.0, 1.0)
+
+    var Rand_Gen = if REPRODUCIBLE_PROBLEMS then
+                     new NPBRandomStream (real, seed = 0556707007)
+                   else
+                     new NPBRandomStream (real);
+
+    var   Noisy_a     : [edge_range] real,
+          Noisy_b     : [edge_range] real,
+          Noisy_c     : [edge_range] real,
+          Noisy_d     : [edge_range] real,
+          norm        : [edge_range] real,
+          Unif_Random : [edge_range] real,
+          Edges       = [edge_range] new directed_vertex_pair ();
+
+     // ---------------------------------------------------------------
+    // The RMAT algorithm is based on recursively sub-dividing a grid.
+    // In this case, the grid is square of order 2^SCALE by 2^SCALE.
+    // So exactly "SCALE" steps of recursion will be required and the
+    // recursion can be implemented directly by iteration.
+    // ---------------------------------------------------------------
+
+    // -----------------------------------------------------------------
+    // Note on random number generators -- the RMAT generator creates
+    // 5*SCALE vectors of length 2**SCALE.  The dependence on powers
+    // of two provides an opportunity to expose statistical correlations
+    // in the pseudo-random numbers.  This certainly occurs with the
+    // current Chapel Random module.  The "skips" in the random number
+    // sequence dramatically change the results.  Without them, the
+    // Chapel RMAT matrices are inconsistent with what is seen in
+    // other implementations.
+    // -----------------------------------------------------------------
+
+    writeln ("Random graph generated by stride of 1 in one random stream",
+             " with skips" );
+
+    var bit = 1 << SCALE;
+    var   skip : real;
+
+    for depth in 1..SCALE do {
+        bit >>= 1;
+
+        // randomize the coefficients, tweaking them by numbers in [-.05, .05)
+
+        skip = Rand_Gen.getNext ();
+        Rand_Gen.fillRandom (Unif_Random);
+        Noisy_a = a * (0.95 + 0.1 * Unif_Random);
+
+        skip = Rand_Gen.getNext ();
+        Rand_Gen.fillRandom (Unif_Random);
+        Noisy_b = b * (0.95 + 0.1 * Unif_Random);
+
+        skip = Rand_Gen.getNext ();
+        Rand_Gen.fillRandom (Unif_Random);
+        Noisy_c = c * (0.95 + 0.1 * Unif_Random);
+
+        skip = Rand_Gen.getNext ();
+        Rand_Gen.fillRandom (Unif_Random);
+        Noisy_d = d * (0.95 + 0.1 * Unif_Random);
+
+        norm     = 1.0 / (Noisy_a + Noisy_b + Noisy_c + Noisy_d);
+        Noisy_a *= norm;
+        Noisy_b *= norm;
+        Noisy_c *= norm;
+        Noisy_d *= norm;
+
+        skip = Rand_Gen.getNext ();
+        Rand_Gen.fillRandom (Unif_Random);
+
+        Edges += assign_quadrant ( Unif_Random, Noisy_a, Noisy_b,
+                                   Noisy_c, Noisy_d, bit );
+
+      };
+
+    // ---------------------------------------------------------------------
+    // Assign weights to edges randomly, then randomly relabel the vertices
+    // to avoid locality from the obvious imbalance that will arise when
+    // one of the coefficients is clearly larger than the others
+    // ---------------------------------------------------------------------
+
+    var permutation : [vertex_range] int = vertex_range;
+    var Edge_Weight : [edge_range] int;
+
+    Rand_Gen.fillRandom ( Unif_Random  );
+    Edge_Weight = floor (1 + Unif_Random * MAX_EDGE_WEIGHT) : int;
+
+    Rand_Gen.fillRandom ( Unif_Random (vertex_range) );
+
+    for v in vertex_range do
+      { var new_id : int;
+        new_id = floor (1 + Unif_Random (v) * N_VERTICES) : int;
+        permutation (v) <=> permutation (new_id);
+      };
+
+    var node_count : [vertex_range] int = 0;
+
+    //      for e in edge_range do {
+    //	Edges(e).start = permutation (Edges(e).start);
+    //	Edges(e).end   = permutation (Edges(e).end  );
+    //      }
+    Edges.start = permutation (Edges.start);
+    Edges.end   = permutation (Edges.end  );
+
+    if DEBUG_GRAPH_GENERATOR || DEBUG_WEIGHT_GENERATOR then {
+      writeln ();
+      for e in edge_range do
+        writeln ("edge (", e, ") : (", Edges(e), ", ",
+                 Edge_Weight (e), ")" );
+    }
+
+    // --------------------------
+    // Graph consistency checking
+    // --------------------------
+
+    assert ( Edges.start > 0,
+             "edge start vertices out of low end of range");
+
+    assert ( Edges.end > 0,
+             "edge end vertices out of low end of range");
+
+    assert ( Edges.start <= 2**SCALE,
+             "edge start vertices out of high end of range");
+
+    assert ( Edges.end <= 2**SCALE,
+             "edge end vertices out of high end of range");
+
+    assert ( Edge_Weight > 0,
+             "edge weight out of low end of range");
+
+    assert ( Edge_Weight <= MAX_EDGE_WEIGHT,
+             "edge weight out of high end of range");
+
+    writeln (); writeln ("Vertex Set in G:", G.vertices);
+
+    // ----------------------------------------------------------
+    // Kernel 1: assemble graph from list of triples.  Include
+    // only non-self incident edges.  in case of duplicates, last
+    // in wins (+= instead of = works to take sum of weights)
+    // ----------------------------------------------------------
+
+    var collisions = 0, self_edges = 0;
+    for e in edge_range do {
+      var u = Edges (e).start;
+      var v = Edges (e).end  ;
+
+      if ( v != u ) then {
+        if G.Neighbors (u).member(v) then {
+          collisions += 1;
+        }
+        else {
+          G.Neighbors (u).add (v);
+          G.Row(u).Weight (v) = Edge_Weight (e);
+        }
+      }
+      else
+        self_edges += 1;
+    }
+
+    writeln ( "# of raw edges generated  ", n_raw_edges );
+    writeln ( "# of duplicate edges      ", collisions );
+    writeln ( "# of self edges           ", self_edges );
+    writeln ( "# of edges in final graph ", graphTotalEdges(G));
+
+    if DEBUG_GRAPH_GENERATOR || DEBUG_WEIGHT_GENERATOR then {
+      writeln ();
+      writeln ("tuples denote (edge, weight)");
+      writeln ();
+      for u in G.vertices do {
+        write ( "row ", u, ": [", G.n_Neighbors (u), "] " );
+        for (v,w) in (G .Neighbors (u), G.edge_weight (u) ) do
+          write ( (v, w) );
+        writeln ();
+      }
+    }
+
+    var max_edges = max reduce [v in vertex_range] G.n_Neighbors (v);
+
+    var edge_count : [0..max_edges] int = 0;
+
+    for v in G.vertices do
+      edge_count (G.n_Neighbors (v)) += 1;
+
+    writeln ("histograph of node distributions by number of outgoing edges");
+    writeln ( "# edges  # nodes");
+    for count in 0..max_edges do
+      writeln ( count, "  ", edge_count (count) );
+
+    writeln ();
+
+  }
+
+//
+// RMAT graph I/O
+//
+// Uses the XMT/KM RMAT graph storage format for SSCA#2.
+//
+
+config const VE_FILENAME     = "vertex_edge_info.data";
+config const SV2_FILENAME    = "sv2_snapshot.data";
+config const EV2_FILENAME    = "ev2_snapshot.data";
+config const START_FILENAME  = "start_snapshot.data";
+config const WEIGHT_FILENAME = "weight_snapshot.data";
+config type  IONumType       = int(64);
+
+config const checkOnlyOnRead = false;
+
+///////// progress indicator /////////
+
+config var progressFrequency = 100000;
+var progressCount = 0;
+proc resetProgress() {
+  progressCount = 0;
+}
+proc reportProgress() {
+  var result = false;
+  progressCount -= 1;
+  if progressCount <= 0 {
+    result = true;
+    progressCount = progressFrequency;
+  }
+  return result;
+}
+
+///////// graph helpers /////////
+
+proc graphTotalEdges(G)  return + reduce [v in G.vertices] G.n_Neighbors(v);
+proc graphNumVertices(G) return G.vertices.numIndices;
+
+///////// I/O helpers /////////
+
+proc createGraphChannel(prefix:string, suffix:string, param forWriting:bool) {
+  const f = open(prefix+suffix,
+                 if forWriting then iomode.cw else iomode.r,
+                 IOHINT_SEQUENTIAL);
+  const chan = if forWriting
+    then f.writer(iokind.big, false)
+    else f.reader(iokind.big, false);
+  return chan;
+}
+
+proc ensureEOFofDataFile(chan, snapshot_prefix, file_suffix): void {
+  var temp:IONumType;
+  try! {
+    chan.read(temp);
+  } catch e: SystemError {
+    // temp==0 is a workaround for unending large files
+    if e.err != EEOF && temp != 0 then
+      myerror("did not reach EOF in '", snapshot_prefix, file_suffix,
+              "'  the next value is ", temp);
+  }
+}
+
+proc writeNum(ch, num): void { ch.write(num:IONumType); }
+proc readNum(ch): IONumType  return ch.read(IONumType);
+
+///////// misc /////////
+
+proc reportNumVerticesError(G, snapshot_prefix, vCount) {
+  const vcountLog2 =
+    if vCount <= 0 then -1:int(64) else floor(log2(vCount)):int(64);
+  const helpMessage =
+    if vCount <= 0 then "Note: got 0 or negative vertex count."
+    else if exp2(vcountLog2:real(64)) == vCount:real(64) then
+      "Pass --SCALE=" + vcountLog2:string + " to suppress the error."
+    else "Note: got a vertex count that is not a power of 2.";
+
+  myerror("inconsistent vertex count: graph ", graphNumVertices(G), " vs. ",
+          vCount, " in ", snapshot_prefix, VE_FILENAME, "\n", helpMessage);
+}
+
+proc interpretDStyle(dstyle:string) {
+  const dON   = dstyle != "-";
+  const dVerb = dstyle == "summary";
+  const dRow  = dstyle == "row";
+  // otherwise
+  const dEdge = dON && !(dRow || dVerb);
+
+  return (dON, dRow, dEdge);
+}
+
+//
+// For debugging, we are making these errors non-fatal.
+// Especially useful with --checkOnlyOnRead.
+//
+proc myerror(args...) {
+  stderr.writeln("ERROR: ", (...args));
+  stderr.writeln("(proceeding nonetheless)");
+}
+
+///////// interface functions: /////////
+////////   Writeout_RMAT_graph  ////////
+////////   Readin_RMAT_graph    ////////
+
+//
+// Write out the graph to files starting with 'snapshot_prefix'
+// and ending with _FILENAME constants above.
+//
+// 'dstyle' - debug style:
+//   "-"        no debug output, just start/end/summary
+//   "summary"  verbose summary
+//   "row"      DEBUG_GRAPH_GENERATOR-style one line per row
+//   otherwise  one line per edge (enables sorting), prefixed by 'dstyle'
+//
+proc Writeout_RMAT_graph(G, snapshot_prefix:string, dstyle = "-"): void {
+  writeln("writing RMAT graph with ", graphNumVertices(G), " vertices, ",
+        graphTotalEdges(G), " edges to '", snapshot_prefix, "'*");
+
+  param wri = true;
+
+  const (dON, dRow, dEdge) = interpretDStyle(dstyle);
+  // this presently would leak too much string memory
+  //proc debugRow(msg...)  { if dRow then write((...msg)); }
+  // ... but this is not called in a loop
+  proc debug(msg...) { if dON then writeln((...msg)); }
+
+  const veCount = createGraphChannel(snapshot_prefix, VE_FILENAME, wri);
+  writeNum(veCount, graphNumVertices(G));
+  writeNum(veCount, graphTotalEdges(G));
+  veCount.close();
+
+  const sv = createGraphChannel(snapshot_prefix, SV2_FILENAME, wri);
+  const ev = createGraphChannel(snapshot_prefix, EV2_FILENAME, wri);
+  const ww = createGraphChannel(snapshot_prefix, WEIGHT_FILENAME, wri);
+  const sta = createGraphChannel(snapshot_prefix, START_FILENAME, wri);
+
+  // Tracks the starting index for each vertex, 0-based, for START_FILENAME.
+  var startIx = 0: IONumType;
+  resetProgress();
+
+  // iterate sequentially
+  for u in G.vertices {
+    if dRow then write("row ", u, ": [", G.n_Neighbors(u), "] ");
+    if dEdge then writeln(dstyle, " vertex ", u);
+    writeNum(sta, startIx);
+
+    for v in G.Neighbors(u).sorted() {
+      const w = G.Row(u).Weight(v);
+      if dRow then write((v, w));
+      if dEdge then writeln(dstyle, " ", u, " ", v, " ", w);
+      writeNum(sv, u-1);
+      writeNum(ev, v-1);
+      writeNum(ww, w);
+      startIx += 1;
+      if dON && reportProgress() then
+        writeln("processing...  vertex ", u, "  edge ", startIx);
+    }
+    if dRow then writeln();
+  }
+
+  const numVertices = G.vertices.numIndices;
+  debug("done writing ", numVertices, " vertices, ", startIx, " edges");
+  assert(startIx == graphTotalEdges(G));
+  const sb = numBytes(IONumType);
+  debug("file sizes  ", 2 * sb, "  ", (graphNumVertices(G) + 2) * sb,
+        "  ", graphTotalEdges(G) * sb);
+  writeNum(sta, startIx);
+  writeNum(sta, startIx);
+
+  sv.close();
+  ev.close();
+  ww.close();
+  sta.close();
+
+  write("DONE writing RMAT graph");
+  if dON then write(" to '", snapshot_prefix, "'*");
+  //else write(" with ", numVertices, " vertices, ", startIx, " edges");
+  writeln(); writeln();
+
+} // Writeout_RMAT_graph()
+
+//
+// Read in the graph from the files as for Writeout_RMAT_graph().
+// 'dstyle' - debug style, same as for Writeout_RMAT_graph().
+//
+proc Readin_RMAT_graph(G, snapshot_prefix:string, dstyle = "-"): void {
+  writeln("reading RMAT graph with ", graphNumVertices(G), " vertices",
+          " from '", snapshot_prefix, "'*");
+
+  param rea = false;
+
+  const (dON, dRow, dEdge) = interpretDStyle(dstyle);
+  // this presently would leak too much string memory
+  //proc debugRow(msg...)  { if dRow then write((...msg)); }
+  // ... but this is not called in a loop
+  proc debug(msg...) { if dON then writeln((...msg)); }
+
+  const veCount = createGraphChannel(snapshot_prefix, VE_FILENAME, rea);
+  const vCount    = readNum(veCount),
+        eCount    = readNum(veCount);
+  ensureEOFofDataFile(veCount, snapshot_prefix, VE_FILENAME);
+  veCount.close();
+
+  debug("files contain  ", vCount, " vertices  ", eCount, " edges");
+  const sb = numBytes(IONumType);
+  debug("expected file sizes  ", 2*sb, "  ", (vCount+2)*sb, "  ", eCount*sb);
+
+  if vCount != graphNumVertices(G) then
+    reportNumVerticesError(G, snapshot_prefix, vCount);
+
+  const sv = createGraphChannel(snapshot_prefix, SV2_FILENAME, rea);
+  const ev = createGraphChannel(snapshot_prefix, EV2_FILENAME, rea);
+  const ww = createGraphChannel(snapshot_prefix, WEIGHT_FILENAME, rea);
+  const sta = createGraphChannel(snapshot_prefix, START_FILENAME, rea);
+
+  // see whether the edges in the data file are ordered, for each edge
+  //var outOfOrderCnt = 0, prevEnd = 0:IONumType;
+
+  var startIxCnt = 0:IONumType, startIxData = readNum(sta);
+  if startIxCnt != startIxData then
+    halt("the first index in ", snapshot_prefix, START_FILENAME,
+         " is ", startIxData, " but should be ", startIxCnt);
+  resetProgress();
+  type VType = index(G.vertices);
+
+  for u in 1..(vCount:VType) {
+    startIxData = readNum(sta);
+    //prevEnd = min(prevEnd.type);
+    const numEdges = startIxData - startIxCnt;
+    if dRow then write("row ", u, ": [", numEdges, "] ");
+    if dEdge then writeln(dstyle, " vertex ", u);
+
+    for 1..numEdges {
+      const curStart = readNum(sv)+1,
+            v = (readNum(ev)+1):VType,
+            w = readNum(ww):VType;
+
+      // initial reporting
+      if dRow then write((v, w));
+      if dEdge then writeln(dstyle, " ", u, " ", v, " ", w);
+
+      // sanity checks
+      if curStart != u then
+        myerror("*** start vertex mismatch: expected ",
+                u, ", got ", curStart);
+      if v < 1 || v > vCount then
+        myerror("*** illegal end vertex number: ", v);
+
+      // add the edge to the graph
+      if !checkOnlyOnRead {
+        G.Neighbors (u).add (v);
+        G.Row(u).Weight (v) = w;
+      }
+
+      // more reporting
+      startIxCnt += 1;
+      //if v <= prevEnd then
+      //  outOfOrderCnt += 1;
+      if dON && reportProgress() then
+        writeln("processing...  vertex ", u, "  edge ", startIxCnt);
+                //("  outOfOrderCnt ", outOfOrderCnt);
+      //prevEnd = v;
+    }
+    if dRow then writeln();
+
+    // because we run the loop exactly the right number of times
+    assert(startIxCnt == startIxData);
+
+  } // for G.vertices
+
+  debug("done reading ", vCount, " vertices, ", startIxData, " edges");
+  //debug(if outOfOrderCnt then "outOfOrder edges: " + outOfOrderCnt:string
+  //        else "all edges are inOrder");
+
+  // one more entry in 'sta'
+  startIxData = readNum(sta);
+  if startIxData != startIxCnt then
+    myerror("wrong last entry in ", START_FILENAME,
+          "  expected ", startIxCnt, "  got ", startIxData);
+  if startIxData != eCount then
+    myerror(snapshot_prefix, VE_FILENAME, " claimed ", eCount,
+          " edges, the other files gave ", startIxData, " edges");
+
+  ensureEOFofDataFile(sv, snapshot_prefix, SV2_FILENAME);
+  ensureEOFofDataFile(ev, snapshot_prefix, EV2_FILENAME);
+  ensureEOFofDataFile(ww, snapshot_prefix, WEIGHT_FILENAME);
+  ensureEOFofDataFile(sta, snapshot_prefix, START_FILENAME);
+
+  sv.close();
+  ev.close();
+  ww.close();
+  sta.close();
+
+  write("DONE reading RMAT graph");
+  if dON then write(" from '", snapshot_prefix, "'*");
+  else        write(" with ", vCount, " vertices, ", eCount, " edges");
+  writeln(); writeln();
+
+} // Readin_RMAT_graph()

--- a/test/studies/ssca2/graphio/analyze_RMAT_graph_associative_array.chpl
+++ b/test/studies/ssca2/graphio/analyze_RMAT_graph_associative_array.chpl
@@ -1,143 +1,138 @@
-module analyze_RMAT_graph_associative_array {
+// These control whether graphs are generated and/or written out.
+// The filename of "-" disables the corresponding operation.
+config const gFilename      = "graphio.1.";
+config const gDstyle        = "-";
+config const refFilenameIn  = "graphio.1.";
+config const refDstyleIn    = "-";
+config const refFilenameOut = "graphio.2.";
+config const refDstyleOut   = "-";
 
-  // These control whether graphs are generated and/or written out.
-  // The filename of "-" disables the corresponding operation.
-  config const gFilename      = "graphio.1.";
-  config const gDstyle        = "-";
-  config const refFilenameIn  = "graphio.1.";
-  config const refDstyleIn    = "-";
-  config const refFilenameOut = "graphio.2.";
-  config const refDstyleOut   = "-";
+// +========================================================================+
+// |  Define associative array-based representations for general sparse     |
+// |  graphs. Provide execution template to generate a random RMAT graph    |
+// |  of a specified size and execute and verify SSCA2 kernels 2 through 4. |
+// =========================================================================+
 
-  // +========================================================================+
-  // |  Define associative array-based representations for general sparse     |
-  // |  graphs. Provide execution template to generate a random RMAT graph    |
-  // |  of a specified size and execute and verify SSCA2 kernels 2 through 4. |
-  // =========================================================================+
+proc  generate_and_analyze_associative_array_RMAT_graph_representation {
 
-  proc  generate_and_analyze_associative_array_RMAT_graph_representation {
+  // -----------------------------------------------------------------
+  // compute a random power law graph with 2^SCALE vertices, using
+  // the RMAT generator. Initially generate a list of triples.
+  // Then convert it to a Chapel representation of a sparse graph,
+  // timing this step (Kernel 1).  Finally, execute Kernels 2, 3 and 4
+  // of SSCA #2, using identically the same code as in the various
+  // torus cases.
+  // -----------------------------------------------------------------
 
-    // -----------------------------------------------------------------
-    // compute a random power law graph with 2^SCALE vertices, using 
-    // the RMAT generator. Initially generate a list of triples. 
-    // Then convert it to a Chapel representation of a sparse graph, 
-    // timing this step (Kernel 1).  Finally, execute Kernels 2, 3 and 4
-    // of SSCA #2, using identically the same code as in the various
-    // torus cases.
-    // -----------------------------------------------------------------
+  use SSCA2_compilation_config_params, SSCA2_execution_config_consts;
 
-    use SSCA2_compilation_config_params, SSCA2_execution_config_consts;
-  
-    use SSCA2_driver, SSCA2_RMAT_graph_generator;
+  use SSCA2_driver, SSCA2_RMAT_graph_generator;
 
-    use BlockDist;
+  use BlockDist;
 
-    var n_raw_edges = 8 * N_VERTICES;
+  var n_raw_edges = 8 * N_VERTICES;
 
-    assert ( SCALE > 1, "SCALE must be greater than 1");
+  assert ( SCALE > 1, "SCALE must be greater than 1");
 
-    select SCALE {
-      when 2 do n_raw_edges = N_VERTICES / 2;
-      when 3 do n_raw_edges = N_VERTICES;
-      when 4 do n_raw_edges = 2 * N_VERTICES;
-      when 5 do n_raw_edges = 4 * N_VERTICES;
-      }
-
-    writeln ('-------------------------------------');
-    writeln ('Order of RMAT generated graph:', N_VERTICES);
-    writeln ('          number of raw edges:', n_raw_edges);
-    writeln ('-------------------------------------');
-    writeln ();
-
-    // ------------------------------------------------------------------------
-    // The data structures below are chosen to implement an irregular (sparse)
-    // graph using associative domains and arrays.  
-    // Each node in the graph has a list of neighbors and a corresponding list
-    // of (integer) weights for the implicit edges.  
-    // The list of neighbors is really just a set; the only properties we need
-    // are that we be able to build it (add vertices to it) and that we be
-    // able to iterate over it.  Those properties are satisfied by Chapel's
-    // associative domains, so each neighbor set is represented by an
-    // associative domain.  The weights are an integer array over the 
-    // neighbor domain.
-    //
-    // We would have liked to have defined the global set of neighbors as
-    // an array of associative domains, but that is not supported in Chapel.
-    // Consequently we build an array of records, where each record provides
-    // the neighbor set and the weights for a particular node.  The name
-    // "row_struct" anticipates the planned use of sparse matrices for this same
-    // kind of graph structure.  
-    // ------------------------------------------------------------------------
-
-    const vertex_domain = 
-      if DISTRIBUTION_TYPE == "BLOCK" then
-        {1..N_VERTICES} dmapped Block ( {1..N_VERTICES} )
-      else
-	    {1..N_VERTICES} ;
-
-    record row_struct {
-      type vertex;
-      var Row_Neighbors : domain (vertex);
-      var Weight        : [Row_Neighbors] int;
-    }
-	
-    class Associative_Graph {
-      const vertices;
-      var   Row      : [vertices] row_struct (index (vertices));
-
-      proc   Neighbors  ( v : index (vertices) ) ref
-        {return Row (v).Row_Neighbors;}
-
-      iter   edge_weight (v : index (vertices) ) ref {
-        for w in Row (v).Weight do
-          yield w;}  // var iterator to avoid a copy
-
-      // Simply forward the domain's parallel iterator
-      // FYI: no fast follower opt
-      iter   edge_weight(v : index (vertices), param tag: iterKind)
-      where tag == iterKind.leader {
-        for block in Row(v).Weight._value.these(tag) do
-          yield block;
-      }
-
-      iter   edge_weight(v : index (vertices), param tag: iterKind, followThis)
-      where tag == iterKind.follower {
-        for elem in Row(v).Weight._value.these(tag, followThis) do
-          yield elem;
-      }
-
-      proc   n_Neighbors (v : index (vertices) ) 
-      {return Row (v).Row_Neighbors.numIndices;}
+  select SCALE {
+    when 2 do n_raw_edges = N_VERTICES / 2;
+    when 3 do n_raw_edges = N_VERTICES;
+    when 4 do n_raw_edges = 2 * N_VERTICES;
+    when 5 do n_raw_edges = 4 * N_VERTICES;
     }
 
-    var G = new Associative_Graph (vertex_domain);
+  writeln ('-------------------------------------');
+  writeln ('Order of RMAT generated graph:', N_VERTICES);
+  writeln ('          number of raw edges:', n_raw_edges);
+  writeln ('-------------------------------------');
+  writeln ();
 
-    // ------------------------------------------------------------------
-    // generate RMAT graph of the specified size, based on input config
-    // values for quadrant assignment.
-    // ------------------------------------------------------------------
+  // ------------------------------------------------------------------------
+  // The data structures below are chosen to implement an irregular (sparse)
+  // graph using associative domains and arrays.
+  // Each node in the graph has a list of neighbors and a corresponding list
+  // of (integer) weights for the implicit edges.
+  // The list of neighbors is really just a set; the only properties we need
+  // are that we be able to build it (add vertices to it) and that we be
+  // able to iterate over it.  Those properties are satisfied by Chapel's
+  // associative domains, so each neighbor set is represented by an
+  // associative domain.  The weights are an integer array over the
+  // neighbor domain.
+  //
+  // We would have liked to have defined the global set of neighbors as
+  // an array of associative domains, but that is not supported in Chapel.
+  // Consequently we build an array of records, where each record provides
+  // the neighbor set and the weights for a particular node.  The name
+  // "row_struct" anticipates the planned use of sparse matrices for this same
+  // kind of graph structure.
+  // ------------------------------------------------------------------------
 
-  if gFilename != "-" {
-    Gen_RMAT_graph ( RMAT_a, RMAT_b, RMAT_c, RMAT_d, 
-		     SCALE, N_VERTICES, n_raw_edges, MAX_EDGE_WEIGHT, G );
+  const vertex_domain =
+    if DISTRIBUTION_TYPE == "BLOCK" then
+      {1..N_VERTICES} dmapped Block ( {1..N_VERTICES} )
+    else
+          {1..N_VERTICES} ;
 
-    // write it out, read it back in, write the new one out so we can compare
-    Writeout_RMAT_graph ( G, gFilename, gDstyle );
+  record row_struct {
+    type vertex;
+    var Row_Neighbors : domain (vertex);
+    var Weight        : [Row_Neighbors] int;
   }
 
-    execute_SSCA2 ( G );
-    writeln (); writeln ();
-    delete G;
+  class Associative_Graph {
+    const vertices;
+    var   Row      : [vertices] row_struct (index (vertices));
 
-    // Let's also read a graph and write it back out.
-    if refFilenameIn != "-" {
-      const Ref = new Associative_Graph (vertex_domain);
-      Readin_RMAT_graph ( Ref, refFilenameIn, refDstyleIn );
-      if !checkOnlyOnRead && refFilenameOut != "-" then
-        Writeout_RMAT_graph ( Ref, refFilenameOut, refDstyleOut );
-      delete Ref;
+    proc   Neighbors  ( v : index (vertices) ) ref
+      {return Row (v).Row_Neighbors;}
+
+    iter   edge_weight (v : index (vertices) ) ref {
+      for w in Row (v).Weight do
+        yield w;}  // var iterator to avoid a copy
+
+    // Simply forward the domain's parallel iterator
+    // FYI: no fast follower opt
+    iter   edge_weight(v : index (vertices), param tag: iterKind)
+    where tag == iterKind.leader {
+      for block in Row(v).Weight._value.these(tag) do
+        yield block;
     }
+
+    iter   edge_weight(v : index (vertices), param tag: iterKind, followThis)
+    where tag == iterKind.follower {
+      for elem in Row(v).Weight._value.these(tag, followThis) do
+        yield elem;
+    }
+
+    proc   n_Neighbors (v : index (vertices) )
+    {return Row (v).Row_Neighbors.numIndices;}
   }
 
+  var G = new Associative_Graph (vertex_domain);
+
+  // ------------------------------------------------------------------
+  // generate RMAT graph of the specified size, based on input config
+  // values for quadrant assignment.
+  // ------------------------------------------------------------------
+
+if gFilename != "-" {
+  Gen_RMAT_graph ( RMAT_a, RMAT_b, RMAT_c, RMAT_d,
+                   SCALE, N_VERTICES, n_raw_edges, MAX_EDGE_WEIGHT, G );
+
+  // write it out, read it back in, write the new one out so we can compare
+  Writeout_RMAT_graph ( G, gFilename, gDstyle );
 }
 
+  execute_SSCA2 ( G );
+  writeln (); writeln ();
+  delete G;
+
+  // Let's also read a graph and write it back out.
+  if refFilenameIn != "-" {
+    const Ref = new Associative_Graph (vertex_domain);
+    Readin_RMAT_graph ( Ref, refFilenameIn, refDstyleIn );
+    if !checkOnlyOnRead && refFilenameOut != "-" then
+      Writeout_RMAT_graph ( Ref, refFilenameOut, refDstyleOut );
+    delete Ref;
+  }
+}


### PR DESCRIPTION
Adjusts SSCA2 modules that do I/O to use an implicit module instead of using a pragma to opt-in to "error mode fatal". That way, it will work release-over-release and also we don't have to include the pragma in test/release.

Discussed with @bradcray.
Verified the test/release/examples/benchmarks/ssca2 and test/studies/ssca2 pass.