### PR TITLE
Limit cce to -hipa2 when buildling jemalloc

### DIFF
--- a/third-party/jemalloc/Makefile
+++ b/third-party/jemalloc/Makefile
@@ -18,6 +18,17 @@ CHPL_JEMALLOC_CFG_OPTIONS += --prefix=$(JEMALLOC_INSTALL_DIR) \
 			     --with-jemalloc-prefix=$(CHPL_JEMALLOC_PREFIX) \
 			     --with-private-namespace=chpl_
 
+# Can't build under CCE with high levels of interprocedural analysis on. We get
+# runtime errors with -hipa3 (the default) or higher so limit to -hipa2.
+ifeq ($(CHPL_MAKE_TARGET_COMPILER),cray-prgenv-cray)
+ifeq ($(OPTIMIZE), 1)
+CFLAGS += -hipa2
+else
+CFLAGS += -hipa0
+endif
+endif
+
+
 # Unless the user explicitly asks for stats gathering, disable it since
 # there is some runtime overhead of this capability
 ifeq (, $(CHPL_JEMALLOC_ENABLE_STATS))


### PR DESCRIPTION
Some currently undiagnosed bug is causing runtime errors if jemalloc is built
with cce 8.6 with high levels of interprocedural analysis, so limit to hipa2.

Note that jemalloc automatically throws hipa2 for cce 8.4.X because a bug
prevented jemalloc from building. So here we're really just always forcing
hipa2 for all cce versions.

This is similar to #3279/#3307