### PR TITLE
Fix writeThis in network atomics module

### DIFF
--- a/modules/internal/NetworkAtomics.chpl
+++ b/modules/internal/NetworkAtomics.chpl
@@ -183,7 +183,7 @@ module NetworkAtomics {
     }
 
     proc const writeThis(x) {
-      x.write(read());
+      x <~> read();
     }
   }
 
@@ -374,7 +374,7 @@ module NetworkAtomics {
     }
 
     proc const writeThis(x) {
-      x.write(read());
+      x <~> read();
     }
   }
 
@@ -565,7 +565,7 @@ module NetworkAtomics {
     }
 
     proc const writeThis(x) {
-      x.write(read());
+      x <~> read();
     }
   }
 
@@ -755,8 +755,8 @@ module NetworkAtomics {
       _v = value;
     }
 
-    proc writeThis(const x) {
-      x.write(read());
+    proc const writeThis(x) {
+      x <~> read();
     }
   }
 
@@ -847,7 +847,7 @@ inline proc compareExchangeWeak(expected:bool, desired:bool,
     }
 
     proc const writeThis(x) {
-      x.write(read());
+      x <~> read();
     }
   }
 
@@ -1005,7 +1005,7 @@ inline proc compareExchangeWeak(expected:bool, desired:bool,
     }
 
     proc const writeThis(x) {
-      x.write(read());
+      x <~> read();
     }
   }
 


### PR DESCRIPTION
Continuation/bug-fix of #7245. That PR adjusted several `writeThis` methods to
use `<~>` instead of `channel.write` since the operator saves an error code in
the channel instead of throwing. This was a workaround for the problem
discussed in issue #7261.

This makes the same change for network atomics, which was missed in that PR.