### PR TITLE
Fix error handling compiler errors from nightly testing

### DIFF
--- a/modules/dists/BlockCycDist.chpl
+++ b/modules/dists/BlockCycDist.chpl
@@ -321,15 +321,15 @@ proc BlockCyclic.dsiNewRectangularDom(param rank: int, type idxType,
 // output distribution
 //
 proc BlockCyclic.writeThis(x) {
-  x.writeln("BlockCyclic");
-  x.writeln("-------");
-  x.writeln("distributes: ", lowIdx, "...");
-  x.writeln("in chunks of: ", blocksize);
-  x.writeln("across locales: ", targetLocales);
-  x.writeln("indexed via: ", targetLocDom);
-  x.writeln("resulting in: ");
+  x <~> "BlockCyclic\n";
+  x <~> "-------\n";
+  x <~> "distributes: " <~> lowIdx <~> "..." <~> "\n";
+  x <~> "in chunks of: " <~> blocksize <~> "\n";
+  x <~> "across locales: " <~> targetLocales <~> "\n";
+  x <~> "indexed via: " <~> targetLocDom <~> "\n";
+  x <~> "resulting in: " <~> "\n";
   for locid in targetLocDom do
-    x.writeln("  [", locid, "] ", locDist(locid));
+    x <~> "  [" <~> locid <~> "] " <~> locDist(locid) <~> "\n";
 }
 
 //
@@ -464,7 +464,7 @@ proc LocBlockCyclic.writeThis(x) {
   on this {
     localeid = here.id;
   }
-  x.write("locale ", localeid, " owns blocks: ", myStarts);
+  x <~> "locale " <~> localeid <~> " owns blocks: " <~> myStarts;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -564,7 +564,7 @@ iter BlockCyclicDom.these(param tag: iterKind, followThis) where tag == iterKind
 // output domain
 //
 proc BlockCyclicDom.dsiSerialWrite(x) {
-  x.write(whole);
+  x <~> whole;
 }
 
 //
@@ -709,7 +709,7 @@ proc LocBlockCyclicDom.computeFlatInds() {
 // output local domain piece
 //
 proc LocBlockCyclicDom.writeThis(x) {
-  x.write(myStarts);
+  x <~> myStarts;
 }
 
 proc LocBlockCyclicDom.enumerateBlocks() {
@@ -908,16 +908,16 @@ proc BlockCyclicArr.dsiSerialWrite(f) {
   for dim in 1..rank do
     i(dim) = dom.dsiDim(dim).low;
   label next while true {
-    f.write(dsiAccess(i));
+    f <~> dsiAccess(i);
     if i(rank) <= (dom.dsiDim(rank).high - dom.dsiDim(rank).stride:idxType) {
-      f.write(" ");
+      f <~> " ";
       i(rank) += dom.dsiDim(rank).stride:idxType;
     } else {
       for dim in 1..rank-1 by -1 {
         if i(dim) <= (dom.dsiDim(dim).high - dom.dsiDim(dim).stride:idxType) {
           i(dim) += dom.dsiDim(dim).stride:idxType;
           for dim2 in dim+1..rank {
-            f.writeln();
+            f <~> "\n";
             i(dim2) = dom.dsiDim(dim2).low;
           }
           continue next;
@@ -1077,7 +1077,7 @@ proc LocBlockCyclicArr.this(i) ref {
 //
 proc LocBlockCyclicArr.writeThis(x) {
   // note on this fails; see writeThisUsingOn.chpl
-  x.write(myElems);
+  x <~> myElems;
 }
 
 // sungeun: This doesn't appear to be used yet, so I left it, but it

--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -550,14 +550,15 @@ proc Block.dsiNewSparseDom(param rank: int, type idxType, dom: domain) {
 // output distribution
 //
 proc Block.writeThis(x) {
-  x.writeln("Block");
-  x.writeln("-------");
-  x.writeln("distributes: ", boundingBox);
-  x.writeln("across locales: ", targetLocales);
-  x.writeln("indexed via: ", targetLocDom);
-  x.writeln("resulting in: ");
+  x <~> "Block" <~> "\n";
+  x <~> "-------" <~> "\n";
+  x <~> "distributes: " <~> boundingBox <~> "\n";
+  x <~> "across locales: " <~> targetLocales <~> "\n";
+  x <~> "indexed via: " <~> targetLocDom <~> "\n";
+  x <~> "resulting in: " <~> "\n";
   for locid in targetLocDom do
-    x.writeln("  [", locid, "] locale ", locDist(locid).locale.id, " owns chunk: ", locDist(locid).myChunk);
+    x <~> "  [" <~> locid <~> "] locale " <~> locDist(locid).locale.id <~>
+      " owns chunk: " <~> locDist(locid).myChunk <~> "\n";
 }
 
 proc Block.dsiIndexToLocale(ind: idxType) where rank == 1 {
@@ -767,7 +768,7 @@ iter BlockDom.these(param tag: iterKind, followThis) where tag == iterKind.follo
 // output domain
 //
 proc BlockDom.dsiSerialWrite(x) {
-  x.write(whole);
+  x <~> whole;
 }
 
 //
@@ -1092,16 +1093,16 @@ proc BlockArr.dsiSerialWrite(f) {
   for dim in 1..rank do
     i(dim) = dom.dsiDim(dim).low;
   label next while true {
-    f.write(dsiAccess(i));
+    f <~> dsiAccess(i);
     if i(rank) <= (dom.dsiDim(rank).high - dom.dsiDim(rank).stride:strType) {
-      if ! binary then f.write(" ");
+      if ! binary then f <~> " ";
       i(rank) += dom.dsiDim(rank).stride:strType;
     } else {
       for dim in 1..rank-1 by -1 {
         if i(dim) <= (dom.dsiDim(dim).high - dom.dsiDim(dim).stride:strType) {
           i(dim) += dom.dsiDim(dim).stride:strType;
           for dim2 in dim+1..rank {
-            f.writeln();
+            f <~> "\n";
             i(dim2) = dom.dsiDim(dim2).low;
           }
           continue next;

--- a/modules/dists/CyclicDist.chpl
+++ b/modules/dists/CyclicDist.chpl
@@ -1,15 +1,15 @@
 /*
  * Copyright 2004-2017 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -49,7 +49,7 @@ config param disableCyclicLazyRAD = defaultDisableLazyRADOpt;
 //     dataParTasksPerLocale, dataParIgnoreRunningTasks, dataParMinGranularity
 //   supports RAD opt, Bulk Transfer optimization, localSubdomain
 //   disableCyclicLazyRAD
-//   
+//
 /*
 This Cyclic distribution maps indices to locales in a round-robin pattern
 starting at a given index.
@@ -183,7 +183,7 @@ class Cyclic: BaseDist {
              dataParIgnoreRunningTasks=getDataParIgnoreRunningTasks(),
              dataParMinGranularity=getDataParMinGranularity(),
              param rank: int = _determineRankFromStartIdx(startIdx),
-             type idxType = _determineIdxTypeFromStartIdx(startIdx)) 
+             type idxType = _determineIdxTypeFromStartIdx(startIdx))
     where isTuple(startIdx) || isIntegralType(startIdx.type) {
     var tupleStartIdx: rank*idxType;
     if isTuple(startIdx) then tupleStartIdx = startIdx;
@@ -211,7 +211,7 @@ class Cyclic: BaseDist {
       var ranges: rank*range;
       for param i in 1..rank do {
         var thisRange = targetLocales.domain.dim(i);
-        ranges(i) = 0..#thisRange.length; 
+        ranges(i) = 0..#thisRange.length;
       }
       targetLocDom = {(...ranges)};
       targetLocs = reshape(targetLocales, targetLocDom);
@@ -343,7 +343,7 @@ proc Cyclic.dsiNewRectangularDom(param rank: int, type idxType, param stridable:
   var dom = new CyclicDom(rank=rank, idxType=idxType, dist = this, stridable=stridable);
   dom.dsiSetIndices(inds);
   return dom;
-} 
+}
 
 //
 // Given a tuple of scalars of type t or range(t) match the shape but
@@ -369,10 +369,11 @@ proc _cyclic_matchArgsShape(type rangeType, type scalarType, args) type {
 }
 
 proc Cyclic.writeThis(x) {
-  x.writeln(this.type:string);
-  x.writeln("------");
+  x <~> this.type:string <~> "\n";
+  x <~> "------\n";
   for locid in targetLocDom do
-    x.writeln(" [", locid, "=", targetLocs(locid), "] owns chunk: ", locDist(locid).myChunk); 
+    x <~> " [" <~> locid <~> "=" <~> targetLocs(locid) <~> "] owns chunk: " <~>
+      locDist(locid).myChunk <~> "\n";
 }
 
 proc Cyclic.targetLocsIdx(i: idxType) {
@@ -521,13 +522,14 @@ proc CyclicDom.dsiAssignDomain(rhs: domain, lhsPrivate:bool) {
 
 proc CyclicDom.dsiSerialWrite(x) {
   if verboseCyclicDistWriters {
-    x.writeln(this.type:string);
-    x.writeln("------");
+    x <~> this.type:string <~> "\n";
+    x <~> "------\n";
     for loc in dist.targetLocDom {
-      x.writeln("[", loc, "=", dist.targetLocs(loc), "] owns ", locDoms(loc).myBlock);
+      x <~> "[" <~> loc <~> "=" <~> dist.targetLocs(loc) <~> "] owns " <~>
+        locDoms(loc).myBlock <~> "\n";
     }
   } else {
-    x.write(whole);
+    x <~> whole;
   }
 }
 
@@ -1030,13 +1032,13 @@ proc CyclicArr.doiUseBulkTransferStride(B) {
          || (oneDData && chpl__getActualArray(B).oneDData);
 }
 
-//For assignments of the form: "Cyclic = any" 
+//For assignments of the form: "Cyclic = any"
 //where "any" means any array that implements the bulk transfer interface
 proc CyclicArr.doiBulkTransferFrom(Barg, viewDom)
 {
   if debugCyclicDistBulkTransfer then
     writeln("In CyclicArr.doiBulkTransferFrom()");
-  
+
   if this.rank == Barg.rank {
     const Dest = this;
     const Src = chpl__getActualArray(Barg);
@@ -1044,7 +1046,7 @@ proc CyclicArr.doiBulkTransferFrom(Barg, viewDom)
     type el = Dest.idxType;
     coforall i in Dest.dom.dist.targetLocDom do // for all locales
       on Dest.dom.dist.targetLocs(i)
-      { 
+      {
         var regionDest = Dest.dom.locDoms(i).myBlock[viewDom];
         const regionSrc = Src.dom.locDoms(i).myBlock[srcView];
         if regionDest.numIndices>0
@@ -1052,7 +1054,7 @@ proc CyclicArr.doiBulkTransferFrom(Barg, viewDom)
           const ini=bulkCommConvertCoordinate(regionDest.first, viewDom, srcView);
           const end=bulkCommConvertCoordinate(regionDest.last, viewDom, srcView);
           const sb=chpl__tuplify(regionSrc.stride);
-        
+
           var r1,r2: rank * range(idxType = el,stridable = true);
           r2=regionDest.dims();
           //In the case that the number of elements in dimension t for r1 and r2
@@ -1063,7 +1065,7 @@ proc CyclicArr.doiBulkTransferFrom(Barg, viewDom)
             if r1[t].length != r2[t].length then
               r1[t] = (ini[t]:el..end[t]:el by (end[t] - ini[t]):el/(r2[t].length-1));
           }
-         
+
           if debugCyclicDistBulkTransfer then
             writeln("B[",(...r1),"] ToDR A[",regionDest, "] ");
 
@@ -1073,13 +1075,13 @@ proc CyclicArr.doiBulkTransferFrom(Barg, viewDom)
   }
 }
 
-//For assignments of the form: DR = Cyclic 
+//For assignments of the form: DR = Cyclic
 //(default rectangular array = cyclic distributed array)
 proc CyclicArr.doiBulkTransferToDR(Barg, viewDom)
 {
   if debugCyclicDistBulkTransfer then
     writeln("In CyclicArr.doiBulkTransferToDR()");
-  
+
   if this.rank == Barg.rank {
     const Src = this;
     const Dest = chpl__getActualArray(Barg);
@@ -1094,7 +1096,7 @@ proc CyclicArr.doiBulkTransferToDR(Barg, viewDom)
           const ini=bulkCommConvertCoordinate(inters.first, viewDom, destView);
           const end=bulkCommConvertCoordinate(inters.last, viewDom, destView);
           const sa = chpl__tuplify(destView.stride); //return a tuple
-          
+
           //r2 is the domain to refer the elements of A in locale j
           //r1 is the domain to refer the corresponding elements of B
           var r1,r2: rank * range(idxType = el,stridable = true);
@@ -1107,8 +1109,8 @@ proc CyclicArr.doiBulkTransferToDR(Barg, viewDom)
             if r1[t].length != r2[t].length then
               r1[t] = (ini[t]:el..end[t]:el by (end[t] - ini[t]):el/(r2[t].length-1));
           }
-              
-          if debugCyclicDistBulkTransfer then 
+
+          if debugCyclicDistBulkTransfer then
             writeln(" A[",(...r1),"] = B[",(...r2), "]");
 
           Barg[(...r1)] = Src.locArr[j].myElems[(...r2)];
@@ -1117,13 +1119,13 @@ proc CyclicArr.doiBulkTransferToDR(Barg, viewDom)
   }
 }
 
-//For assignments of the form: Cyclic = DR 
+//For assignments of the form: Cyclic = DR
 //(cyclic distributed array = default rectangular)
 proc CyclicArr.doiBulkTransferFromDR(Barg, viewDom)
 {
   if debugCyclicDistBulkTransfer then
     writeln("In CyclicArr.doiBulkTransferFromDR()");
-  
+
   if this.rank == Barg.rank {
     const Dest = this;
     const Src = chpl__getActualArray(Barg);
@@ -1138,7 +1140,7 @@ proc CyclicArr.doiBulkTransferFromDR(Barg, viewDom)
           const ini=bulkCommConvertCoordinate(inters.first, viewDom, srcView);
           const end=bulkCommConvertCoordinate(inters.last, viewDom, srcView);
           const sb = chpl__tuplify(srcView.stride); //return a tuple
-          
+
           var r1,r2: rank * range(idxType = el,stridable = true);
           r2=inters.dims();
           //In the case that the number of elements in dimension t for r1 and r2
@@ -1149,7 +1151,7 @@ proc CyclicArr.doiBulkTransferFromDR(Barg, viewDom)
             if r1[t].length != r2[t].length then
               r1[t] = (ini[t]:el..end[t]:el by (end[t] - ini[t]):el/(r2[t].length-1));
           }
-          
+
           if debugCyclicDistBulkTransfer then
               writeln("A[",(...r2),"] = B[",(...r1), "] ");
 

--- a/modules/dists/DimensionalDist2D.chpl
+++ b/modules/dists/DimensionalDist2D.chpl
@@ -737,7 +737,7 @@ proc DimensionalDom.dimSpecifier(param dim: int) {
 //== writing
 
 proc DimensionalDom.dsiSerialWrite(f): void {
-  f.write(whole);
+  f <~> whole;
 }
 
 

--- a/modules/dists/OldReplicatedDist.chpl
+++ b/modules/dists/OldReplicatedDist.chpl
@@ -429,7 +429,7 @@ proc OldReplicatedDom.dsiSerialWrite(f): void {
   // redirect to DefaultRectangular
   redirectee()._value.dsiSerialWrite(f);
   if printReplicatedLocales {
-    f.write(" replicated over ");
+    f <~> " replicated over ";
     var temp : [1..0] locale;
     for idx in dist.targetLocDom.sorted() {
       temp.push_back(dist.targetLocales[idx]);
@@ -573,9 +573,10 @@ proc OldReplicatedArr.dsiSerialWrite(f): void {
   var neednl = false;
   for idx in dom.dist.targetLocDom.sorted() {
 //  on locArr {  // may cause deadlock
-      if neednl then f.write("\n"); neednl = true;
+      if neednl then f <~> "\n";
+      neednl = true;
       if printReplicatedLocales then
-        f.write(localArrs[idx].locale, ":\n");
+        f <~> localArrs[idx].locale <~> ":\n";
       localArrs[idx].arrLocalRep._value.dsiSerialWrite(f);
 //  }
   }
@@ -586,9 +587,10 @@ proc chpl_serialReadWriteRectangular(f, arr, dom) where chpl__getActualArray(arr
   const actual = chpl__getActualArray(arr);
   for idx in actual.dom.dist.targetLocDom.sorted() {
     on actual.localArrs[idx] {
-      if neednl then f.write("\n"); neednl = true;
+      if neednl then f <~> "\n";
+      neednl = true;
       if printReplicatedLocales then
-        f.write(actual.localArrs[idx].locale, ":\n");
+        f <~> actual.localArrs[idx].locale <~> ":\n";
       chpl_serialReadWriteRectangularHelper(f, arr, dom);
     }
   }

--- a/modules/dists/PrivateDist.chpl
+++ b/modules/dists/PrivateDist.chpl
@@ -75,7 +75,7 @@ class Private: BaseDist {
   }
 
   proc writeThis(x) {
-    x.writeln("Private Distribution");
+    x <~> "Private Distribution\n";
   }
   // acts like a singleton
   proc dsiClone() return this;
@@ -104,7 +104,7 @@ class PrivateDom: BaseRectangularDom {
       yield i;
   }
 
-  proc dsiSerialWrite(x) { x.write("Private Domain"); }
+  proc dsiSerialWrite(x) { x <~> "Private Domain"; }
 
   proc dsiBuildArray(type eltType)
     return new PrivateArr(eltType=eltType, rank=rank, idxType=idxType, stridable=stridable, dom=this);
@@ -194,8 +194,8 @@ iter PrivateArr.these(param tag: iterKind, followThis) ref where tag == iterKind
 proc PrivateArr.dsiSerialWrite(x) {
   var first: bool = true;
   for i in dom {
-    if first then first = !first; else write(" ");
-    write(dsiAccess(i));
+    if first then first = !first; else x <~> " ";
+    x <~> dsiAccess(i);
   }
 }
 

--- a/modules/dists/SparseBlockDist.chpl
+++ b/modules/dists/SparseBlockDist.chpl
@@ -175,16 +175,16 @@ class SparseBlockDom: BaseSparseDomImpl {
   //
   proc dsiSerialWrite(f) {
     if (rank == 1) {
-      f.write("{");
+      f <~> "{";
       for locdom in locDoms do {
         // on locdom do {
         if (locdom.dsiNumIndices) {
-            f.write(" ");
+            f <~> " ";
             locdom.dsiSerialWrite(f);
           }
           //}
       }
-      f.write("}");
+      f <~> "}";
     } else {
       compilerError("Can't write out multidimensional sparse distributed domains yet");
     }
@@ -662,16 +662,16 @@ proc LocSparseBlockArr.this(i) ref {
 //
 proc SparseBlockArr.dsiSerialWrite(f) {
   if (rank == 1) {
-    f.write("[");
+    f <~> "[";
     for locarr in locArr do {
       // on locdom do {
       if (locarr.locDom.dsiNumIndices) {
-        f.write(" ");
+        f <~> " ";
         locarr.dsiSerialWrite(f);
       }
       // }
     }
-    f.write("]");
+    f <~> "]";
   } else {
     compilerError("Can't write out multidimensional sparse distributed arrays yet");
   }

--- a/modules/dists/StencilDist.chpl
+++ b/modules/dists/StencilDist.chpl
@@ -504,14 +504,15 @@ proc Stencil.dsiNewRectangularDom(param rank: int, type idxType,
 // output distribution
 //
 proc Stencil.writeThis(x) {
-  x.writeln("Stencil");
-  x.writeln("-------");
-  x.writeln("distributes: ", boundingBox);
-  x.writeln("across locales: ", targetLocales);
-  x.writeln("indexed via: ", targetLocDom);
-  x.writeln("resulting in: ");
+  x <~> "Stencil\n";
+  x <~> "-------\n";
+  x <~> "distributes: " <~> boundingBox <~> "\n";
+  x <~> "across locales: " <~> targetLocales <~> "\n";
+  x <~> "indexed via: " <~> targetLocDom <~> "\n";
+  x <~> "resulting in: " <~> "\n";
   for locid in targetLocDom do
-    x.writeln("  [", locid, "] locale ", locDist(locid).locale.id, " owns chunk: ", locDist(locid).myChunk);
+    x <~> "  [" <~> locid <~> "] locale " <~> locDist(locid).locale.id <~>
+      " owns chunk: " <~> locDist(locid).myChunk <~> "\n";
 }
 
 proc Stencil.dsiIndexToLocale(ind: idxType) where rank == 1 {
@@ -713,7 +714,7 @@ iter StencilDom.these(param tag: iterKind, followThis) where tag == iterKind.fol
 // output domain
 //
 proc StencilDom.dsiSerialWrite(x) {
-  x.write(whole);
+  x <~> whole;
 }
 
 //
@@ -1213,16 +1214,16 @@ proc StencilArr.dsiSerialWrite(f) {
   for dim in 1..rank do
     i(dim) = dom.dsiDim(dim).low;
   label next while true {
-    f.write(dsiAccess(i));
+    f <~> dsiAccess(i);
     if i(rank) <= (dom.dsiDim(rank).high - dom.dsiDim(rank).stride:strType) {
-      if ! binary then f.write(" ");
+      if ! binary then f <~> " ";
       i(rank) += dom.dsiDim(rank).stride:strType;
     } else {
       for dim in 1..rank-1 by -1 {
         if i(dim) <= (dom.dsiDim(dim).high - dom.dsiDim(dim).stride:strType) {
           i(dim) += dom.dsiDim(dim).stride:strType;
           for dim2 in dim+1..rank {
-            f.writeln();
+            f <~> "\n";
             i(dim2) = dom.dsiDim(dim2).low;
           }
           continue next;

--- a/modules/internal/ArrayViewRankChange.chpl
+++ b/modules/internal/ArrayViewRankChange.chpl
@@ -354,13 +354,13 @@ module ArrayViewRankChange {
       for d in 1..downrank do
         if !collapsedDim(d) {
           if first {
-            write("{");
+            f <~> "{";
             first = false;
           } else
-            write(", ");
-          write(downDom.dsiDim(d));
+            f <~> ", ";
+          f <~> downDom.dsiDim(d);
         }
-      write("}");
+      f <~> "}";
     }
 
     proc dsiMyDist() {

--- a/modules/internal/ChapelIO.chpl
+++ b/modules/internal/ChapelIO.chpl
@@ -137,7 +137,7 @@ function resolution error if the class NoRead is read.
     var x: int;
     var y: int;
     proc writeThis(f) {
-      f.writeln("hello");
+      f <~> "hello";
     }
     // Note that no readThis function will be generated.
   }
@@ -622,16 +622,12 @@ module ChapelIO {
         } else {
           start = new ioLiteral("(");
         }
-        //writeln("BEFORE READING START");
-        //writeln("ERROR IS ", reader.error():int);
         reader.readwrite(start);
-        //writeln("POST ERROR IS ", reader.error():int);
       }
   
       var needsComma = false;
   
       if ! reader.error() {
-        //writeln("READING FIELDS\n");
         readThisFieldsDefaultImpl(reader, t, x, needsComma);
       }
       if ! reader.error() {
@@ -646,10 +642,7 @@ module ChapelIO {
         } else {
           end = new ioLiteral(")");
         }
-        //writeln("BEFORE READING END ERROR IS ", reader.error():int);
-        //writeln("BEFORE READING END OFFSET IS ", reader.offset());
         reader.readwrite(end);
-        //writeln("AFTER READING END ERROR IS ", reader.error():int);
       }
     }
   

--- a/modules/internal/ChapelIteratorSupport.chpl
+++ b/modules/internal/ChapelIteratorSupport.chpl
@@ -76,10 +76,10 @@ module ChapelIteratorSupport {
     var first: bool = true;
     for e in this {
       if !first then
-        f.write(" ");
+        f <~> " ";
       else
         first = false;
-      f.write(e);
+      f <~> e;
     }
   }
 

--- a/modules/internal/tasktable/on/ChapelTaskTable.chpl
+++ b/modules/internal/tasktable/on/ChapelTaskTable.chpl
@@ -158,9 +158,11 @@ module ChapelTaskTable {
     if (chpldev_taskTable == nil) then return;
   
     for taskID in chpldev_taskTable.dom {
-      stderr.writeln("- ", chpl_lookupFilename(chpldev_taskTable.map[taskID].filename):string,
-                     ":",  chpldev_taskTable.map[taskID].lineno,
-                     " is ", chpldev_taskTable.map[taskID].state);
+      try! stderr.writeln(
+             "- ",
+             chpl_lookupFilename(chpldev_taskTable.map[taskID].filename):string,
+             ":",  chpldev_taskTable.map[taskID].lineno,
+             " is ", chpldev_taskTable.map[taskID].state);
     }
   }
   

--- a/modules/layouts/LayoutCS.chpl
+++ b/modules/layouts/LayoutCS.chpl
@@ -538,13 +538,14 @@ class CSDom: BaseSparseDomImpl {
   }
 
   proc dsiSerialWrite(f) {
-    f.writeln("{");
+    f <~> "{\n";
     if this.compressRows {
       for r in rowRange {
         const lo = startIdx(r),
               hi = stopIdx(r);
         for c in lo..hi {
-          f.write(" (", r, ", ", idx(c), ")", if (c==hi) then "\n" else "");
+          f <~> " (" <~> r <~> ", " <~> idx(c) <~> ")" <~>
+            if (c==hi) then "\n" else "";
         }
       }
     } else {
@@ -553,11 +554,12 @@ class CSDom: BaseSparseDomImpl {
         const lo = startIdx(c),
               hi = stopIdx(c);
         for r in lo..hi {
-          f.write(" (", idx(r), ", ", c, ")", if (r==hi) then "\n" else "");
+          f <~> " (" <~> idx(r) <~> ", " <~> c <~> ")" <~>
+            if (r==hi) then "\n" else "";
         }
       }
     }
-    f.writeln("}");
+    f <~> "}\n";
   }
 
 } // CSDom
@@ -640,7 +642,7 @@ class CSArr: BaseSparseArrImpl {
         const lo = dom.startIdx(r);
         const hi = dom.stopIdx(r);
         for c in lo..hi {
-          f.write(data(c), if (c==hi) then "\n" else " ");
+          f <~> data(c) <~> if (c==hi) then "\n" else " ";
         }
       }
     } else {
@@ -648,7 +650,7 @@ class CSArr: BaseSparseArrImpl {
         const lo = dom.startIdx(c);
         const hi = dom.stopIdx(c);
         for r in lo..hi {
-          f.write(data(r), if (r==hi) then "\n" else " ");
+          f <~> data(r) <~> if (r==hi) then "\n" else " ";
         }
       }
     }

--- a/modules/packages/BLAS.chpl
+++ b/modules/packages/BLAS.chpl
@@ -640,7 +640,7 @@ module BLAS {
         n = Bdom.dim(2).size : c_int;
 
     if m != n then
-      halt("Non-square array of dimensions %ix%i passed to trmm".format(m, n));
+      try! halt("Non-square array of dimensions %ix%i passed to trmm".format(m, n));
 
     // Set strides if necessary
     var _ldA = getLeadingDim(A, order),
@@ -698,7 +698,7 @@ module BLAS {
         n = Bdom.dim(2).size : c_int;
 
     if m != n then
-      halt("Non-square array of dimensions %ix%i passed to TRSM".format(m, n));
+      try! halt("Non-square array of dimensions %ix%i passed to TRSM".format(m, n));
 
     // Set strides if necessary
     var _ldA = getLeadingDim(A, order),

--- a/modules/packages/BLAS.chpl
+++ b/modules/packages/BLAS.chpl
@@ -169,6 +169,7 @@ in memory.
     - related: general RequireMKL module
   - More consistent documentation
   - Support banded/packed matrix routines
+  - Consider replacing the `halt` calls with `throws`
 
 */
 module BLAS {
@@ -980,7 +981,7 @@ module BLAS {
         n = Adom.dim(2).size : c_int;
 
     if m != n then
-      halt("Non-square array of dimensions %ix%i passed to hemv".format(m, n));
+      try! halt("Non-square array of dimensions %ix%i passed to hemv".format(m, n));
 
     // Set strides if necessary
     var _ldA = getLeadingDim(A, order);
@@ -1013,7 +1014,7 @@ module BLAS {
         n = Adom.dim(2).size : c_int;
 
     if m != n then
-      halt("Non-square array of dimensions %ix%i passed to her".format(m, n));
+      try! halt("Non-square array of dimensions %ix%i passed to her".format(m, n));
 
     // TODO -- Assert alpha is real
 
@@ -1048,7 +1049,7 @@ module BLAS {
         n = Adom.dim(2).size : c_int;
 
     if m != n then
-      halt("Non-square array of dimensions %ix%i passed to her2".format(m, n));
+      try! halt("Non-square array of dimensions %ix%i passed to her2".format(m, n));
 
 
     // Set strides if necessary
@@ -1318,7 +1319,7 @@ module BLAS {
         n = Adom.dim(2).size : c_int;
 
     if m != n then
-      halt("Non-square array of dimensions %ix%i passed to symv".format(m, n));
+      try! halt("Non-square array of dimensions %ix%i passed to symv".format(m, n));
 
     var _ldA = getLeadingDim(A, order);
 
@@ -1353,7 +1354,7 @@ module BLAS {
         n = Adom.dim(2).size : c_int;
 
     if m != n then
-      halt("Non-square array of dimensions %ix%i passed to syr".format(m, n));
+      try! halt("Non-square array of dimensions %ix%i passed to syr".format(m, n));
 
     var _ldA = getLeadingDim(A, order);
 
@@ -1388,7 +1389,7 @@ module BLAS {
         n = Adom.dim(2).size : c_int;
 
     if m != n then
-      halt("Non-square array of dimensions %ix%i passed to syr2".format(m, n));
+      try! halt("Non-square array of dimensions %ix%i passed to syr2".format(m, n));
 
     var _ldA = getLeadingDim(A, order);
 
@@ -1605,7 +1606,7 @@ module BLAS {
         n = Adom.dim(2).size : c_int;
 
     if m != n then
-      halt("Non-square array of dimensions %ix%i passed to trmv".format(m, n));
+      try! halt("Non-square array of dimensions %ix%i passed to trmv".format(m, n));
 
     // Set strides if necessary
     var _ldA = getLeadingDim(A, order);
@@ -1649,7 +1650,7 @@ module BLAS {
         n = Adom.dim(2).size : c_int;
 
     if m != n then
-      halt("Non-square array of dimensions %ix%i passed to trsv".format(m, n));
+      try! halt("Non-square array of dimensions %ix%i passed to trsv".format(m, n));
 
     // Set strides if necessary
     var _ldA = getLeadingDim(A, order);

--- a/modules/standard/SysError.chpl
+++ b/modules/standard/SysError.chpl
@@ -68,7 +68,7 @@ class SystemError : Error {
   }
 
   proc writeThis(f) {
-    try! f.write(msg);
+    f <~> msg;
   }
 
   /*

--- a/test/distributions/bradc/assoc/UserMapAssoc.chpl
+++ b/test/distributions/bradc/assoc/UserMapAssoc.chpl
@@ -152,15 +152,15 @@ class UserMapAssoc : BaseDist {
   //
   // print out the distribution
   //
-  proc WriteThis(x) {
-    x.writeln("UserMapAssoc");
-    x.writeln("-------");
-    x.writeln("distributed using: ", mapper);
-    x.writeln("across locales: ", targetLocales);
-    x.writeln("indexed via: ", targetLocDom);
-    x.writeln("resulting in: ");
+  proc writeThis(x) {
+    x <~> "UserMapAssoc\n";
+    x <~> "-------\n";
+    x <~> "distributed using: " <~> mapper <~> "\n";
+    x <~> "across locales: " <~> targetLocales <~> "\n";
+    x <~> "indexed via: " <~> targetLocDom <~> "\n";
+    x <~> "resulting in: " <~> "\n";
     //for locid in targetLocDom do
-    //  x.writeln("  [", locid, "] ", locDist(locid));
+    //  x <~> "  [" <~> locid <~> "] " <~> locDist(locid) <~> "\n";
   }
 
   //
@@ -439,7 +439,7 @@ class UserMapAssocDom: BaseAssociativeDom {
       //
       //        ("locale" + here.id + " owns: ").writeThis(x);
 
-        x.write(locDom);
+        x <~> locDom;
       //      }
   }
 
@@ -763,11 +763,11 @@ class UserMapAssocArr: BaseArr {
         if first {
           first = false;
         } else {
-          x.write(" ");
+          x <~> " ";
         }
       }
-      x.write(locArr);
-      stdout.flush();
+      x <~> locArr;
+      try! stdout.flush();
     }
   }
 

--- a/test/studies/comd/elegant/arrayOfStructs/util/AccumStencilDist.chpl
+++ b/test/studies/comd/elegant/arrayOfStructs/util/AccumStencilDist.chpl
@@ -602,7 +602,7 @@ iter AccumStencilDom.these(param tag: iterKind, followThis) where tag == iterKin
 // output domain
 //
 proc AccumStencilDom.dsiSerialWrite(x) {
-  x.write(whole);
+  x <~> whole;
 }
 
 //
@@ -1004,16 +1004,16 @@ proc AccumStencilArr.dsiSerialWrite(f) {
   for dim in 1..rank do
     i(dim) = dom.dsiDim(dim).low;
   label next while true {
-    f.write(dsiAccess(i));
+    f <~> dsiAccess(i);
     if i(rank) <= (dom.dsiDim(rank).high - dom.dsiDim(rank).stride:strType) {
-      if ! binary then f.write(" ");
+      if ! binary then f <~> " ";
       i(rank) += dom.dsiDim(rank).stride:strType;
     } else {
       for dim in 1..rank-1 by -1 {
         if i(dim) <= (dom.dsiDim(dim).high - dom.dsiDim(dim).stride:strType) {
           i(dim) += dom.dsiDim(dim).stride:strType;
           for dim2 in dim+1..rank {
-            f.writeln();
+            f <~> "\n";
             i(dim2) = dom.dsiDim(dim2).low;
           }
           continue next;


### PR DESCRIPTION
Fixes error-handling related compilation errors from nightly testing and applies the `<~>` workaround  for the problem described in #7261 in more places in module code and in test code we might like to be module code soon.

Trivial and not reviewed.

- [x] verified that test/modules/packages/blas passes
- [x] verified that fifo deadlock detection/report works again
- [x] test/distributions with quickstart
- [x] test/distributions/robust/arithmetic/trivial/test_writeln with default, block, cyclic, replicated
- [x] full local testing