### PR TITLE
Un-futurize passing futures

### DIFF
--- a/test/errhandling/ferguson/it-throws-noinline.compopts
+++ b/test/errhandling/ferguson/it-throws-noinline.compopts
@@ -1,0 +1,3 @@
+--inline-iterators-yield-limit 1
+# This test is meant to work with a non-inlined iterator
+# It uses an iterator with 2 yields to do that

--- a/test/errhandling/modes/implicit-relaxed-try-nothrows-inner.bad
+++ b/test/errhandling/modes/implicit-relaxed-try-nothrows-inner.bad
@@ -1,5 +1,0 @@
-In outer implicit module
-in test
-uncaught Error: 
-  ./ThrowError.chpl:2: thrown here
-  implicit-relaxed-try-nothrows-inner.chpl:6: uncaught here

--- a/test/errhandling/modes/implicit-relaxed-try-nothrows-inner.future
+++ b/test/errhandling/modes/implicit-relaxed-try-nothrows-inner.future
@@ -1,1 +1,0 @@
-bug: default for module is fatal errors

--- a/test/errhandling/modes/implicit-relaxed-try-nothrows.bad
+++ b/test/errhandling/modes/implicit-relaxed-try-nothrows.bad
@@ -1,4 +1,0 @@
-should not compile
-uncaught Error: 
-  ./ThrowError.chpl:2: thrown here
-  implicit-relaxed-try-nothrows.chpl:6: uncaught here

--- a/test/errhandling/modes/implicit-relaxed-try-nothrows.future
+++ b/test/errhandling/modes/implicit-relaxed-try-nothrows.future
@@ -1,1 +1,0 @@
-bug: default for module is fatal errors


### PR DESCRIPTION
Fixing some passing futures from nightly testing.
The it-throws-noinline future just needed a compopt to disable iterator inlining of the relevant iterator after PR #7270.