### PR TITLE
Move --no-local performance testing from 1-node-xc to chapcs

### DIFF
--- a/util/cron/test-perf.chapcs.no-local.bash
+++ b/util/cron/test-perf.chapcs.no-local.bash
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#
+
+CWD=$(cd $(dirname $0) ; pwd)
+
+export CHPL_TEST_PERF_CONFIG_NAME='chapcs'
+
+source $CWD/common-perf.bash
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.no-local"
+
+perf_args="-performance-description no-local -performance-configs default:v,no-local:v -sync-dir-suffix no-local"
+perf_args="${perf_args} -performance -numtrials 5 -startdate 09/13/17"
+
+nightly_args="${nightly_args} -no-local"
+
+$CWD/nightly -cron ${nightly_args} ${perf_args}

--- a/util/cron/test-perf.chapcs.numa.bash
+++ b/util/cron/test-perf.chapcs.numa.bash
@@ -11,6 +11,6 @@ source $CWD/common-numa.bash
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.numa"
 
 perf_args="-performance-description numa -performance-configs default:v,numa:v -sync-dir-suffix numa"
-perf_args="${perf_args} -performance -numtrials 5 -startdate 01/15/16"
+perf_args="${perf_args} -performance -numtrials 1 -startdate 01/15/16"
 
 $CWD/nightly -cron ${nightly_args} ${perf_args}


### PR DESCRIPTION
We care about --no-local performance, but 1-node-xc performance results are way
too variable for us to do effective triage. Move testing to chapcs, which
should be much more stable and allow us to run tests that require stdin.

This will run on the same machine as numa, so drop numa numtrials down to 1
since we don't care about those results much right now.

Closes https://github.com/chapel-lang/chapel/issues/6321