### PR TITLE
split FLAG_REF_TO_IMMUTABLE from FLAG_REF_TO_CONST

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -818,7 +818,8 @@ bool ArgSymbol::isConstValWillNotChange() const {
   if (hasFlag(FLAG_REF_TO_IMMUTABLE))
     return true;
 
-  bool absIntent, result;
+  bool absIntent = false;
+  bool result    = false;
   isConstValWillNotChangeHelp(intent, result, absIntent);
 
   if (absIntent) {

--- a/compiler/include/flags_list.h
+++ b/compiler/include/flags_list.h
@@ -270,11 +270,12 @@ symbolFlag( FLAG_REDUCESCANOP , ypr, "ReduceScanOp" , "the ReduceScanOp class" )
 symbolFlag( FLAG_REF , ypr, "ref" , ncm )
 symbolFlag( FLAG_REF_FOR_CONST_FIELD_OF_THIS , npr, "reference to a const field of 'this'" , ncm )
 symbolFlag( FLAG_REF_ITERATOR_CLASS , npr, "ref iterator class" , ncm )
-// Does FLAG_REF_TO_CONST means reference to immutable?
-// maybe it is intended to, but that is not true in
-// setFlagsAndCheckForConstAccess
+// "ref to const" is like Chapel's 'const ref' variable:
+// * it is illegal to modify the referenced thing through this variable
+// * the referenced thing may change, observably through this variable
 symbolFlag( FLAG_REF_TO_CONST , npr, "reference to a const" , "a temp or a function that returns a reference to a Chapel const, e.g. an accessor to a const field or its result" )
 symbolFlag( FLAG_REF_TO_CONST_WHEN_CONST_THIS , ypr, "reference to const when const this" , "a function that returns a reference to a Chapel const when 'this' is const" )
+symbolFlag( FLAG_REF_TO_IMMUTABLE , npr, "ref to immutable" , "a reference to something that never changes during its lifetime")
 symbolFlag( FLAG_REF_VAR , ypr, "ref var" , "reference variable" )
 symbolFlag( FLAG_REMOVABLE_ARRAY_ACCESS, ypr, "removable array access", "array access calls that can be replaced with a reference")
 symbolFlag( FLAG_REMOVABLE_AUTO_COPY , ypr, "removable auto copy" , ncm )

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -114,6 +114,7 @@ public:
 
   virtual bool       isConstant()                              const;
   virtual bool       isConstValWillNotChange()                 const;
+  virtual bool       isConstValWillNotChange_AnyIntent()       const;
   virtual bool       isImmediate()                             const;
   virtual bool       isParameter()                             const;
           bool       isRenameable()                            const;
@@ -267,6 +268,7 @@ public:
 
   virtual bool       isConstant()                              const;
   virtual bool       isConstValWillNotChange()                 const;
+  virtual bool       isConstValWillNotChange_AnyIntent()       const;
   virtual bool       isImmediate()                             const;
   virtual bool       isParameter()                             const;
   virtual bool       isType()                                  const;
@@ -329,6 +331,7 @@ public:
   // New interface
   virtual bool    isConstant()                              const;
   virtual bool    isConstValWillNotChange()                 const;
+  virtual bool    isConstValWillNotChange_AnyIntent()       const;
   virtual bool    isParameter()                             const;
 
   virtual bool    isVisible(BaseAST* scope)                 const;

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -114,7 +114,6 @@ public:
 
   virtual bool       isConstant()                              const;
   virtual bool       isConstValWillNotChange()                 const;
-  virtual bool       isConstValWillNotChange_AnyIntent()       const;
   virtual bool       isImmediate()                             const;
   virtual bool       isParameter()                             const;
           bool       isRenameable()                            const;
@@ -268,7 +267,6 @@ public:
 
   virtual bool       isConstant()                              const;
   virtual bool       isConstValWillNotChange()                 const;
-  virtual bool       isConstValWillNotChange_AnyIntent()       const;
   virtual bool       isImmediate()                             const;
   virtual bool       isParameter()                             const;
   virtual bool       isType()                                  const;
@@ -331,7 +329,6 @@ public:
   // New interface
   virtual bool    isConstant()                              const;
   virtual bool    isConstValWillNotChange()                 const;
-  virtual bool    isConstValWillNotChange_AnyIntent()       const;
   virtual bool    isParameter()                             const;
 
   virtual bool    isVisible(BaseAST* scope)                 const;

--- a/compiler/optimizations/inferConstRefs.cpp
+++ b/compiler/optimizations/inferConstRefs.cpp
@@ -205,7 +205,7 @@ ConstInfo::ConstInfo(Symbol* s) {
     fnUses = fn->firstSymExpr();
   }
 
-  finalizedRefToConst = sym->hasFlag(FLAG_REF_TO_CONST);
+  finalizedRefToConst = sym->hasFlag(FLAG_REF_TO_IMMUTABLE);
 
   curTodo = 0;
   alreadyCalled = false;
@@ -589,7 +589,7 @@ static bool inferRefToConst(Symbol* sym) {
   INT_ASSERT(sym->isRef());
 
   bool isConstRef = sym->qualType().getQual() == QUAL_CONST_REF;
-  const bool wasRefToConst = sym->hasFlag(FLAG_REF_TO_CONST);
+  const bool wasRefToConst = sym->hasFlag(FLAG_REF_TO_IMMUTABLE);
 
   ConstInfo* info = infoMap[sym];
 
@@ -695,7 +695,7 @@ static bool inferRefToConst(Symbol* sym) {
   if (isFirstCall) {
     if (isRefToConst) {
       INT_ASSERT(info->finalizedRefToConst == false);
-      sym->addFlag(FLAG_REF_TO_CONST);
+      sym->addFlag(FLAG_REF_TO_IMMUTABLE);
     }
 
     info->reset();
@@ -712,7 +712,7 @@ static bool inferRefToConst(Symbol* sym) {
 // properties can be applied:
 // 1) QUAL_CONST_VAL
 // 2) QUAL_CONST_REF / INTENT_CONST_REF
-// 3) FLAG_REF_TO_CONST
+// 3) FLAG_REF_TO_IMMUTABLE
 //
 void inferConstRefs() {
   // Build a map from Symbols to ConstInfo. This is somewhat like

--- a/compiler/optimizations/remoteValueForwarding.cpp
+++ b/compiler/optimizations/remoteValueForwarding.cpp
@@ -335,8 +335,8 @@ static bool shouldSerialize(ArgSymbol* arg) {
     //
     // BHARSH TODO: This seems a bit flimsy. If 'arg' is a reference to a
     // const domain (as written by the user), why doesn't it have the flag
-    // FLAG_REF_TO_CONST? That said, we don't seem to be leaking...
-    retval = arg->intent == INTENT_CONST_REF && arg->hasFlag(FLAG_REF_TO_CONST);
+    // FLAG_REF_TO_IMMUTABLE? That said, we don't seem to be leaking...
+    retval = arg->intent == INTENT_CONST_REF && arg->hasFlag(FLAG_REF_TO_IMMUTABLE);
   } else {
     retval = hasSerializer;
   }
@@ -423,7 +423,7 @@ static bool canForwardValue(Map<Symbol*, Vec<SymExpr*>*>& defMap,
         // never written to, we can simply RVF the class pointer.
         retval = true;
       } else {
-        retval = arg->hasFlag(FLAG_REF_TO_CONST);
+        retval = arg->hasFlag(FLAG_REF_TO_IMMUTABLE);
       }
     } else {
       retval = false;
@@ -468,7 +468,7 @@ static bool isSufficientlyConst(ArgSymbol* arg) {
       !arg->type->symbol->hasFlag(FLAG_REF)) {
     retval = true;
 
-  } else if (arg->hasFlag(FLAG_REF_TO_CONST)) {
+  } else if (arg->hasFlag(FLAG_REF_TO_IMMUTABLE)) {
     retval = true;
 
   // otherwise, conservatively assume it varies

--- a/compiler/passes/flattenFunctions.cpp
+++ b/compiler/passes/flattenFunctions.cpp
@@ -220,8 +220,8 @@ addVarsToFormals(FnSymbol* fn, SymbolMap* vars) {
       ArgSymbol* arg = new ArgSymbol(intent, sym->name, type);
       if (sym->hasFlag(FLAG_ARG_THIS))
           arg->addFlag(FLAG_ARG_THIS);
-      if (sym->hasFlag(FLAG_REF_TO_CONST))
-          arg->addFlag(FLAG_REF_TO_CONST);
+      if (sym->hasFlag(FLAG_REF_TO_IMMUTABLE))
+          arg->addFlag(FLAG_REF_TO_IMMUTABLE);
       if (sym->hasFlag(FLAG_CONST_DUE_TO_TASK_FORALL_INTENT))
           arg->addFlag(FLAG_CONST_DUE_TO_TASK_FORALL_INTENT);
 

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -3853,8 +3853,6 @@ static void testArgMapping(FnSymbol*                    fn1,
 *                                                                             *
 ************************************** | *************************************/
 
-static bool  isConstValWillNotChange(Symbol* sym);
-
 static void  captureTaskIntentValues(int        argNum,
                                      ArgSymbol* formal,
                                      Expr*      actual,
@@ -3947,7 +3945,7 @@ static void handleTaskIntentArgs(CallInfo& info, FnSymbol* taskFn) {
       // records and strings are (incorrectly) captured at the point
       // when the task function/arg bundle is created.
       if (taskFn->hasFlag(FLAG_COBEGIN_OR_COFORALL) == true &&
-          isConstValWillNotChange(varActual)        == false &&
+          !varActual->isConstValWillNotChange_AnyIntent()   &&
           (concreteIntent(formal->intent, formal->type->getValType())
            & INTENT_FLAG_IN)) {
         // skip dummy_locale_arg: chpl_localeID_t
@@ -3968,25 +3966,6 @@ static void handleTaskIntentArgs(CallInfo& info, FnSymbol* taskFn) {
     // gatherCandidates() would not instantiate it, for some reason.
     taskFn->removeFlag(FLAG_GENERIC);
   }
-}
-
-//
-// Allow invoking isConstValWillNotChange() even on formals
-// with blank and 'const' intents.
-//
-static bool isConstValWillNotChange(Symbol* sym) {
-  bool retval = false;
-
-  if (ArgSymbol* arg = toArgSymbol(sym)) {
-    IntentTag cInt = concreteIntent(arg->intent, arg->type->getValType());
-
-    retval = cInt == INTENT_CONST_IN;
-
-  } else {
-    retval = sym->isConstValWillNotChange();
-  }
-
-  return retval;
 }
 
 //

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -3945,7 +3945,7 @@ static void handleTaskIntentArgs(CallInfo& info, FnSymbol* taskFn) {
       // records and strings are (incorrectly) captured at the point
       // when the task function/arg bundle is created.
       if (taskFn->hasFlag(FLAG_COBEGIN_OR_COFORALL) == true &&
-          !varActual->isConstValWillNotChange_AnyIntent()   &&
+          varActual->isConstValWillNotChange()      == false &&
           (concreteIntent(formal->intent, formal->type->getValType())
            & INTENT_FLAG_IN)) {
         // skip dummy_locale_arg: chpl_localeID_t

--- a/compiler/resolution/implementForallIntents.cpp
+++ b/compiler/resolution/implementForallIntents.cpp
@@ -2393,7 +2393,7 @@ static void implementForallIntents2NewWrap(ForallStmt* fs, FnSymbol* dest,
 
     if (curFormal->isRef() &&
         curArg->isConstValWillNotChange())
-      curFormal->addFlag(FLAG_REF_TO_CONST);
+      curFormal->addFlag(FLAG_REF_TO_IMMUTABLE);
 
     wCall->insertAtTail(curFormal);
     wDest->insertFormalAtTail(curFormal);


### PR DESCRIPTION
#### Now, two "const" flags

* FLAG_REF_TO_CONST means "illegal to modify through this reference"

* FLAG_REF_TO_IMMUTABLE means "the referenced thing does not change
during its lifetime"

Replaced the uses of the former with the latter when appropriate.

Besides code changes, this also takes a stand on the terminology,
* "const" means "illegal to modify",
* "immutable" means "will not change".

#### Enhanced isConstValWillNotChange()

It can now be invoked on ArgSymbols with abstract intents, too,
as long as can compute concreteIntent().

Looking at the implementation of isConstValWillNotChange(),
I did not see why it shouldn't work for an abstract intent.

#### Future work

The FLAG_REF_TO_CONST-illegal-to-modify really should be retired
in favor of QUAL_CONST_REF and INTENT_CONST_REF.
