### PR TITLE
Fix bug with named arguments to send "this" to a function from an initializer

### DIFF
--- a/compiler/passes/initializerRules.cpp
+++ b/compiler/passes/initializerRules.cpp
@@ -610,6 +610,9 @@ static bool hasReferenceToThis(Expr* expr) {
       }
     }
 
+  } else if (NamedExpr* named = toNamedExpr(expr)) {
+    retval = hasReferenceToThis(named->actual);
+
   } else {
     INT_ASSERT(false);
   }

--- a/test/classes/initializers/named-argument-to-send-this-bad.future
+++ b/test/classes/initializers/named-argument-to-send-this-bad.future
@@ -1,5 +1,0 @@
-bug: should generate error message when namedExpr used to send "this" to a function
-
-At the time of writing, our compiler generates an internal error instead of the
-appropriate error message.  I believe this is because we don't expect to send
-"this" as a named argument.


### PR DESCRIPTION
Prior to this change, `foo(x=this);` would result in an internal error if it
was within an initializer.  This change allows us to recognize NamedExprs and
respond to them appropriately.

Remove the .future file for the test tracking this problem.

Passed classes/initializers with futures, and a full paratest