### PR TITLE
Quiet bulkcomm rankChange failure under --fast

### DIFF
--- a/test/optimizations/bulkcomm/bharshbarg/rankChange.compopts
+++ b/test/optimizations/bulkcomm/bharshbarg/rankChange.compopts
@@ -1,1 +1,1 @@
--smaxDims=4 -suseBulkTransferStride
+-smaxDims=4 -suseBulkTransferStride --inline-iterators-yield-limit 4


### PR DESCRIPTION
Quiet optimizations/bulkcomm/bharshbarg/rankChange regression under --fast
testing by limiting direct iterating inlining to 4 yields.

This test has a recursive iterator that ends up with a lot of yields. For some
reason, compilation is now timing out with --fast under gcc. Curiously
`inline-iterators-yield-limit 10` only adds 20% more to the generated code
size, but takes gcc compilation time from 30s to over 20 minutes (I never let
compilation finish, so who knows how long it takes.) For clang I only see a 10%
increase in compilation time, so I suspect we may be triggering a gcc bug or an
aggressive loop optimization limit. For now just limit the amount of inlining
we do.