### PR TITLE
Disable affinity for travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ compiler:
 
 matrix:
   include:
-    - env: NIGHTLY_TEST_SETTINGS=true CHPL_SMOKE_SKIP_DOC=true TEST_COMMAND="./util/buildRelease/smokeTest"
+    - env: NIGHTLY_TEST_SETTINGS=true QTHREAD_AFFINITY=no CHPL_SMOKE_SKIP_DOC=true TEST_COMMAND="./util/buildRelease/smokeTest"
     - env: NIGHTLY_TEST_SETTINGS=true CHPL_SMOKE_SKIP_MAKE_CHECK=true TEST_COMMAND="./util/buildRelease/smokeTest"
     - env: TEST_COMMAND="make test-venv && CHPL_HOME=$PWD ./util/run-in-venv.bash ./util/test/check_annotations.py"
       git:


### PR DESCRIPTION
Something about the recent trusty upgrade seems to have left us unable to set
affinity correctly. Disable it for now (this effectively reverts #4986)