### PR TITLE
Quiet multi-locale task-counting tests

### DIFF
--- a/test/parallel/taskCount/runningTaskCount/innerCoforall.chpl
+++ b/test/parallel/taskCount/runningTaskCount/innerCoforall.chpl
@@ -1,7 +1,7 @@
 use Barriers;
 
 config const tasksPerLoc = 4;
-var taskCounts: [0..#numLocales, 0..#tasksPerLoc] string;
+var taskCounts: [0..#numLocales, 0..#tasksPerLoc] (int, int);
 
 proc main() {
   for loc in Locales do on loc {
@@ -11,8 +11,9 @@ proc main() {
       const taskID = (loc.id * tasksPerLoc) + tid;
       const rt = here.runningTasks();
       barrier.barrier();
-      taskCounts[loc.id, tid] = "TASK " + taskID + ": running = "+ rt;
+      taskCounts[loc.id, tid] = (taskID, rt);
     }
   }
-  for taskCount in taskCounts do writeln(taskCount);
+  for taskCount in taskCounts do
+    writeln("TASK " + taskCount(1) + ": running = " + taskCount(2));
 }

--- a/test/parallel/taskCount/runningTaskCount/innerOuterCoforall.chpl
+++ b/test/parallel/taskCount/runningTaskCount/innerOuterCoforall.chpl
@@ -1,7 +1,7 @@
 use Barriers;
 
 config const tasksPerLoc = 4;
-var taskCounts: [0..#numLocales, 0..#tasksPerLoc] string;
+var taskCounts: [0..#numLocales, 0..#tasksPerLoc] (int, int);
 
 proc main() {
   coforall loc in Locales do on loc {
@@ -11,8 +11,9 @@ proc main() {
       const taskID = (loc.id * tasksPerLoc) + tid;
       const rt = here.runningTaskCounter.read();
       barrier.barrier();
-      taskCounts[loc.id, tid] = "TASK " + taskID + ": running = "+ rt;
+      taskCounts[loc.id, tid] = (taskID, rt);
     }
   }
-  for taskCount in taskCounts do writeln(taskCount);
+  for taskCount in taskCounts do 
+    writeln("TASK " + taskCount(1) + ": running = " + taskCount(2));
 }

--- a/test/parallel/taskCount/runningTaskCount/outerCoforall.chpl
+++ b/test/parallel/taskCount/runningTaskCount/outerCoforall.chpl
@@ -1,9 +1,10 @@
-var taskCounts: [0..#numLocales] string;
+var taskCounts: [0..#numLocales] (int, int);
 
 proc main() {
   coforall loc in Locales do on loc {
     const rt = here.runningTasks();
-    taskCounts[loc.id] = "TASK " + loc.id + ": running = "+ rt;
+    taskCounts[loc.id] = (loc.id, rt);
   }
-  for taskCount in taskCounts do writeln(taskCount);
+  for taskCount in taskCounts do
+    writeln("TASK " + taskCount(1) + ": running = " + taskCount(2));
 }


### PR DESCRIPTION
Some of the multi-locale task-counting tests were sporadically reporting more
tasks on locale 0. It turns out this was because we were writing the taskID and
runningTaskCounter into a string and storing it into an array that lives on
locale 0. Doing this ended up creating a task on locale 0 to allocate space for
the string, which could mess with the task counter on locale 0.

Instead just use an array of ints and create the string afterwards. This passes
5,000 trials for parallel/taskCount/runningTaskCount/ under gasnet-everything