### PR TITLE
Add --permit-unhandled-module-errors flag

### DIFF
--- a/compiler/include/driver.h
+++ b/compiler/include/driver.h
@@ -184,6 +184,8 @@ extern bool fReportScalarReplace;
 extern bool fReportDeadBlocks;
 extern bool fReportDeadModules;
 
+extern bool fPermitUnhandledModuleErrors;
+
 extern bool debugCCode;
 extern bool optimizeCCode;
 extern bool specializeCCode;

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -189,6 +189,7 @@ bool fReportPromotion = false;
 bool fReportScalarReplace = false;
 bool fReportDeadBlocks = false;
 bool fReportDeadModules = false;
+bool fPermitUnhandledModuleErrors = false;
 bool printCppLineno = false;
 bool userSetCppLineno = false;
 int num_constants_per_variable = 1;
@@ -873,6 +874,7 @@ static ArgumentDescription arg_desc[] = {
  {"print-callgraph", ' ', NULL, "Print a representation of the callgraph for the program", "N", &fPrintCallGraph, "CHPL_PRINT_CALLGRAPH", NULL},
  {"print-callstack-on-error", ' ', NULL, "print the Chapel call stack leading to each error or warning", "N", &fPrintCallStackOnError, "CHPL_PRINT_CALLSTACK_ON_ERROR", NULL},
  {"set", 's', "<name>[=<value>]", "Set config param value", "S", NULL, NULL, readConfig},
+ {"permit-unhandled-module-errors", ' ', NULL, "Permit unhandled errors in explicit modules; such errors halt at runtime", "N", &fPermitUnhandledModuleErrors, "CHPL_PERMIT_UNHANDLED_MODULE_ERRORS", NULL},
  {"task-tracking", ' ', NULL, "Enable [disable] runtime task tracking", "N", &fEnableTaskTracking, "CHPL_TASK_TRACKING", NULL},
  {"warn-const-loops", ' ', NULL, "Enable [disable] warnings for some 'while' loops with constant conditions", "N", &fWarnConstLoops, "CHPL_WARN_CONST_LOOPS", NULL},
  {"warn-special", ' ', NULL, "Enable [disable] special warnings", "n", &fNoWarnSpecial, "CHPL_WARN_SPECIAL", setWarnSpecial},

--- a/compiler/passes/errorHandling.cpp
+++ b/compiler/passes/errorHandling.cpp
@@ -911,7 +911,8 @@ static error_checking_mode_t computeErrorCheckingMode(FnSymbol* fn)
     // No mode was chosen explicitly, find the default.
 
     ModuleSymbol* mod = fn->getModule();
-    if (mod->hasFlag(FLAG_IMPLICIT_MODULE))
+    if (mod->hasFlag(FLAG_IMPLICIT_MODULE) ||
+        fPermitUnhandledModuleErrors)
       mode = ERROR_MODE_FATAL;
     else
       mode = ERROR_MODE_RELAXED;

--- a/man/chpl.rst
+++ b/man/chpl.rst
@@ -533,6 +533,14 @@ OPTIONS
     For boolean configuration variables, the value can be omitted, causing
     the default value to be toggled.
 
+**--[no-]permit-unhandled-module-errors**
+
+    Normally, the compiler ensures that all errors are handled for code
+    inside of a module declaration (unless the module overrides that
+    behavior). This flag overrides this default, so that the compiler
+    will compile code in a module that does not handle its errors. If any
+    error comes up during execution, it will cause the program to halt.
+
 **--[no-]task-tracking**
 
     Enable [disable] the Chapel-implemented task tracking table that

--- a/test/compflags/bradc/help/userhelp.good
+++ b/test/compflags/bradc/help/userhelp.good
@@ -126,6 +126,9 @@ Miscellaneous Options:
       --[no-]print-callstack-on-error print the Chapel call stack leading to
                                       each error or warning
   -s, --set <name>[=<value>]          Set config param value
+      --[no-]permit-unhandled-module-errors
+                                      Permit unhandled errors in explicit
+                                      modules; such errors halt at runtime
       --[no-]task-tracking            Enable [disable] runtime task tracking
       --[no-]warn-const-loops         Enable [disable] warnings for some
                                       'while' loops with constant conditions

--- a/test/errhandling/modes/permit-unhandled-module-errors.chpl
+++ b/test/errhandling/modes/permit-unhandled-module-errors.chpl
@@ -1,0 +1,13 @@
+module mymodule {
+  use ThrowError;
+
+  proc propError() {
+    throwAnError();
+  }
+
+  try {
+    propError();
+  } catch {
+    writeln("in catch");
+  }
+}

--- a/test/errhandling/modes/permit-unhandled-module-errors.compopts
+++ b/test/errhandling/modes/permit-unhandled-module-errors.compopts
@@ -1,0 +1,1 @@
+--permit-unhandled-module-errors

--- a/test/errhandling/modes/permit-unhandled-module-errors.good
+++ b/test/errhandling/modes/permit-unhandled-module-errors.good
@@ -1,0 +1,3 @@
+uncaught Error: 
+  ./ThrowError.chpl:2: thrown here
+  permit-unhandled-module-errors.chpl:5: uncaught here


### PR DESCRIPTION
This flag overrides the default behavior of requiring that errors are
handled in code inside an explicit module declaration.

Closes issue #7292.

- [x] full local testing

Reviewed by @psahabu - thanks!