### PR TITLE
Use full filenames for project dependencies in mason

### DIFF
--- a/tools/mason/Makefile
+++ b/tools/mason/Makefile
@@ -35,11 +35,12 @@ REGISTRY=https://github.com/chapel-lang/mason-registry
 
 registry = $(MASON_HOME)/.mason/registry/
 
+MASON_SOURCES=MasonBuild.chpl MasonHelp.chpl MasonNew.chpl MasonUpdate.chpl MasonUtils.chpl mason.chpl
 
 all: mason
 
 
-mason:	
+mason: $(MASON_SOURCES)
 	@if [ $(shell $(CHPL_MAKE_HOME)/util/chplenv/chpl_regexp.py) != re2 ]; then \
         echo "CHPL_REGEXP=re2 is required to build mason"; \
         exit 1;\


### PR DESCRIPTION
When a project named Project has a dependency named Foo-1.0.0, mason uses
the compile line:
`chpl src/Project.chpl -o target/debug/Project -M $MASON_HOME/src/Foo-1.0.0/src`

But we'd rather have it specify the dependencies source filename and specify
a main module:
`chpl src/Project -o target/debug/Project --main-module Project $MASON_HOME/src/Foo-1.0.0/src/Foo.chpl`

Modify `genSourceList()` to return a 3-tuple containing
(source URL, name, version) where before it combined name and version into
a single string.  Modify the two functions that call it to expect this.

Update the generated compile command to match what we'd like shown above.

Update the mason Makefile so it rebuilds when the mason source code changes.

Passed a linux64 paratest.