### PR TITLE
Mason: Compile options in toml file

### DIFF
--- a/test/mason/masonNewTest.compopts
+++ b/test/mason/masonNewTest.compopts
@@ -1,1 +1,1 @@
--M ../../tools/mason/
+-M ../../tools/mason/ -M ../modules/packages/Toml/

--- a/tools/mason/MasonBuild.chpl
+++ b/tools/mason/MasonBuild.chpl
@@ -69,6 +69,10 @@ proc BuildProgram(release: bool, show: bool, compopts: [?d] string) {
     var sourceList = genSourceList(lockFile);
     getSrcCode(sourceList, show);
 
+    // Get compile flags
+    var cmpFlags = getCompopts(lockFile);
+    if cmpFlags != ' ' then compopts.push_back(cmpFlags);
+
     // Compile Program
     if compileSrc(lockFile, binLoc, show, release, compopts) {
       writeln("Build Successful\n");

--- a/tools/mason/MasonBuild.chpl
+++ b/tools/mason/MasonBuild.chpl
@@ -69,16 +69,17 @@ proc BuildProgram(release: bool, show: bool, compopts: [?d] string) {
     var sourceList = genSourceList(lockFile);
     getSrcCode(sourceList, show);
 
-    // Get compile flags
-    var cmpFlags = getCompopts(lockFile);
-    if cmpFlags != ' ' then compopts.push_back(cmpFlags);
+    // Checks if dependencies exist and retrieves them for compilation
+    if lockFile.pathExists('root.compopts') {
+      const cmpFlags = lockFile["root"]["compopts"].s;
+      compopts.push_back(cmpFlags);
+    }
 
     // Compile Program
     if compileSrc(lockFile, binLoc, show, release, compopts) {
       writeln("Build Successful\n");
     }
     else writeln("Build Failed");
-
     // Close memory
      delete lockFile;
      toParse.close();

--- a/tools/mason/MasonUpdate.chpl
+++ b/tools/mason/MasonUpdate.chpl
@@ -64,6 +64,7 @@ proc genLock(lock: Toml, lf) {
 }
 
 
+/* Pulls the mason-registry. Cloning if !exist */
 proc updateRegistry(tf: string) {
   const masonHome = MASON_HOME;
   const registryHome = masonHome + '/.mason/registry';

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -22,7 +22,7 @@
 /* A helper file of utilities for Mason */
 use Spawn;
 use FileSystem;
-use TOML;
+
 
 /* Gets environment variables for spawn commands */
 extern proc getenv(name : c_string) : c_string;
@@ -32,15 +32,6 @@ proc getEnv(name: string): string {
   return value:string;
 }
 
-
-/* Retrieves the compilation flags from lock file */
-proc getCompopts(lock: Toml) {
-  if lock.pathExists('root.compopts') {
-    var compopts = lock['root']['compopts'].s;
-    return compopts;
-  }
-  else return ' ';
-}
 
 
 /* Uses the Spawn module to create a subprocess */

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -18,9 +18,11 @@
  */
 
 
+
 /* A helper file of utilities for Mason */
 use Spawn;
 use FileSystem;
+use TOML;
 
 /* Gets environment variables for spawn commands */
 extern proc getenv(name : c_string) : c_string;
@@ -28,6 +30,16 @@ proc getEnv(name: string): string {
   var cname: c_string = name.c_str();
   var value = getenv(cname);
   return value:string;
+}
+
+
+/* Retrieves the compilation flags from lock file */
+proc getCompopts(lock: Toml) {
+  if lock.pathExists('root.compopts') {
+    var compopts = lock['root']['compopts'].s;
+    return compopts;
+  }
+  else return ' ';
 }
 
 


### PR DESCRIPTION
This PR is a feature for mason that allows users to put their compopts right in the ``Mason.toml`` file as listed in issue #7106. When this feature is used, the format for the ``Mason.toml`` will be a follows:

``` toml
[brick]
name = "MyProject"
version = "0.1.0"
compopts = "-M /test/somePackage"

[dependencies]
```

This is a step towards being able to support C dependencies. I do not believe this will conflict with the changes that @daviditen is proposing in #7310 but I am mentioning him in this just in case. 

This change has passed testing on my linux64 machine. 