### PR TITLE
Forwarding bug fixes

### DIFF
--- a/compiler/AST/foralls.cpp
+++ b/compiler/AST/foralls.cpp
@@ -545,6 +545,9 @@ static void resolveParallelIteratorAndIdxVar(ForallStmt* pfs,
   // Set QualifiedType of the index variable.
   QualifiedType iType = fsIterYieldType(parIter, iterCall);
   VarSymbol* idxVar = parIdxVar(pfs);
+
+  if (idxVar->id == breakOnResolveID)
+    gdbShouldBreakHere();
   idxVar->type = iType.type();
   idxVar->qual = iType.getQual();
 }

--- a/compiler/AST/stmt.cpp
+++ b/compiler/AST/stmt.cpp
@@ -1002,6 +1002,7 @@ ForwardingStmt::ForwardingStmt(DefExpr* toFnDef) :
   toFnDef(toFnDef),
   fnReturningForwarding(NULL),
   type(NULL),
+  scratchFn(NULL),
   named(),
   renamed(),
   except(false)
@@ -1018,6 +1019,7 @@ ForwardingStmt::ForwardingStmt(DefExpr* toFnDef, std::set<const char*>* args, bo
   toFnDef(toFnDef),
   fnReturningForwarding(NULL),
   type(NULL),
+  scratchFn(NULL),
   named(),
   renamed(),
   except(exclude)

--- a/compiler/include/stmt.h
+++ b/compiler/include/stmt.h
@@ -289,6 +289,10 @@ public:
   // (i.e. the type of the expression to forward to).
   // Used during resolution to avoid repeated work.
   Type*               type;
+  // Contains a function that resolution can use to store some expressions
+  // it computes. This function should remain in the tree for proper
+  // scoping comparisons during resolution, but isn't needed after that.
+  FnSymbol*           scratchFn;
 
   // The names of symbols from an 'except' or 'only' list
   std::set<const char *> named;

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -3003,10 +3003,10 @@ static bool populateForwardingMethods(CallInfo& info) {
       scratch->addFlag(FLAG_COMPILER_GENERATED);
 
       Expr* where = getInsertPointForTypeFunction(at);
-      if (BlockStmt* stmt = toBlockStmt(where))
-        stmt->insertAtHead(new DefExpr(scratch));
+      if (BlockStmt* block = toBlockStmt(where))
+        block->insertAtHead(new DefExpr(scratch));
       else
-        stmt->insertBefore(new DefExpr(scratch));
+        where->insertBefore(new DefExpr(scratch));
 
       normalize(scratch);
 

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -1683,6 +1683,7 @@ static void reissueCompilerWarning(const char* str, int offset) {
         !from->getFunction()->hasFlag(FLAG_COMPILER_GENERATED))
       break;
   }
+  gdbShouldBreakHere();
   USR_WARN(from, "%s", str);
 }
 
@@ -6601,6 +6602,7 @@ static void resolveExprMaybeIssueError(CallExpr* call) {
     if (call->isPrimitive(PRIM_ERROR) == true) {
       USR_FATAL(from, "%s", str);
     } else {
+      gdbShouldBreakHere();
       USR_WARN (from, "%s", str);
     }
 

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -2756,7 +2756,7 @@ static void findVisibleFunctionsAndCandidates(
   CallExpr* call = info.call;
   FnSymbol* fn   = call->resolvedFunction();
 
-  // First, try finding candidates without delegation
+  // First, try finding candidates without forwarding
   if (fn != NULL) {
     visibleFns.add(fn);
 
@@ -2768,7 +2768,7 @@ static void findVisibleFunctionsAndCandidates(
 
   findVisibleCandidates(info, visibleFns, candidates);
 
-  // If no candidates were found and it's a method, try delegating
+  // If no candidates were found and it's a method, try forwarding
   if (candidates.n             == 0 &&
       call->numActuals()       >= 1 &&
       call->get(1)->typeInfo() == dtMethodToken) {
@@ -3001,6 +3001,11 @@ static bool populateForwardingMethods(CallInfo& info) {
 
 
       int        i        = 0;
+
+      // The test call should have the same parentheses-less/partial
+      // properties as the call we are working with.
+      test->methodTag = forCall->methodTag;
+      test->partialTag = forCall->partialTag;
 
       for_actuals(actual, forCall) {
         if (i > 1) { // skip method token, object

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -3110,6 +3110,11 @@ static bool populateForwardingMethods(CallInfo& info) {
       // Never give an error when returning 'void' from a forwarding fn
       fn->removeFlag(FLAG_VOID_NO_RETURN_VALUE);
 
+      // Also, don't consider it an iterator, since instead it is a
+      // function returning an iterator.
+      //  (e.g. proc these() return _value.these(); )
+      fn->removeFlag(FLAG_ITERATOR_FN);
+
       fn->addFlag(FLAG_METHOD);
       fn->addFlag(FLAG_INLINE);
       fn->addFlag(FLAG_FORWARDING_FN);

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -1960,7 +1960,9 @@ static void collectVisibleMethodsNamed(Type*                   t,
     for (size_t i = maxChildMethods; i < methods.size(); i++) {
       bool remove = false;
       for (size_t j = 0; j < maxChildMethods; j++) {
-        if (signatureMatch(methods[i], methods[j])) {
+        if (methods[i] != NULL &&
+            methods[j] != NULL &&
+            signatureMatch(methods[i], methods[j])) {
           remove = true;
           break;
         }

--- a/test/classes/ferguson/forwarding/d-parenless-and-call.chpl
+++ b/test/classes/ferguson/forwarding/d-parenless-and-call.chpl
@@ -16,6 +16,8 @@ proc test() {
   var ii = new Inner(1);
   var c = new C(ii);
   c.getit(2);
+  delete c;
+  delete ii;
 }
 
 

--- a/test/classes/ferguson/forwarding/d-parenless-and-call.chpl
+++ b/test/classes/ferguson/forwarding/d-parenless-and-call.chpl
@@ -1,0 +1,22 @@
+class Inner {
+  var x: int;
+  proc this(y:int) {
+    writeln("In Inner(", x, ").this(", y, ")");
+  }
+}
+
+class C {
+  forwarding var inner;
+  proc getit {
+    return inner;
+  }
+}
+
+proc test() {
+  var ii = new Inner(1);
+  var c = new C(ii);
+  c.getit(2);
+}
+
+
+test();

--- a/test/classes/ferguson/forwarding/d-parenless-and-call.good
+++ b/test/classes/ferguson/forwarding/d-parenless-and-call.good
@@ -1,0 +1,1 @@
+In Inner(1).this(2)

--- a/test/classes/ferguson/forwarding/forwarding-generic-bug.chpl
+++ b/test/classes/ferguson/forwarding/forwarding-generic-bug.chpl
@@ -1,0 +1,16 @@
+class C {
+  proc helper(x) {
+    writeln("HI ", x.type:string);
+  }
+}
+
+class Wrapper {
+  forwarding var inner;
+}
+
+var b = new C();
+b.helper(42);
+var f = new Wrapper(b);
+f.helper(b);
+var ff = new Wrapper(f);
+ff.helper(f);

--- a/test/classes/ferguson/forwarding/forwarding-generic-bug.chpl
+++ b/test/classes/ferguson/forwarding/forwarding-generic-bug.chpl
@@ -1,3 +1,6 @@
+// This test began life as a bug report
+// from a branch using forwarding for _array._value.
+
 class C {
   proc helper(x) {
     writeln("HI ", x.type:string);

--- a/test/classes/ferguson/forwarding/forwarding-generic-bug.good
+++ b/test/classes/ferguson/forwarding/forwarding-generic-bug.good
@@ -1,0 +1,3 @@
+HI int(64)
+HI C
+HI Wrapper(C)


### PR DESCRIPTION
This PR fixes several bugs with forwarding discovered in the effort to try to use forwarding from _array records to their _value.

Bugs fixed:
 * test calls were not kept in the AST, which caused problems with generic instantiation, because these can use the instantiation point of a generic (which was NULL).
 * methodTag/partialTag were not handled correctly in the test call
 * forwarding of iterators was not working correctly 
 
While there, added some compiler breakpoints:
 * before a few resolution warnings
 * for breakOnResolveID, if the type of that ID is established in resolveParallelIteratorAndIdxVar

- [x] full local testing

Reviewed by @vasslitvinov -thanks!