### PR TITLE
Add a warning for secondary initializers defined in other modules

### DIFF
--- a/test/classes/initializers/secondary/inDiffModule.future
+++ b/test/classes/initializers/secondary/inDiffModule.future
@@ -1,5 +1,0 @@
-feature request: new initializer story
-
-This test is not expected to pass until at least part of the initializers story
-is on master.  Make it a future so that Lydia can stay in step with master
-without disrupting testing overly much.

--- a/test/classes/initializers/secondary/inDiffModule.good
+++ b/test/classes/initializers/secondary/inDiffModule.good
@@ -1,1 +1,3 @@
+inDiffModule.chpl:22: warning: initializers defined outside the module where the type was originally defined may cause issues
+inDiffModule.chpl:22: note: This will no longer be a problem when constructors are deprecated
 {x = 10, y = false}

--- a/test/classes/initializers/secondary/inDiffModule2.future
+++ b/test/classes/initializers/secondary/inDiffModule2.future
@@ -1,0 +1,11 @@
+bug: support secondary initializers defined in other modules
+
+This test wants to match against the secondary initializer defined in the same
+module as the call, but instead tries to utilize the default constructor.
+
+With --force-initializers, we run into an ambiguity between the explicit
+initializer and the default one.
+
+While it was hoped that deprecating constructors would ultimately resolve this
+issue, the --force-initializers failure indicates that there is likely a little
+more work to be done.

--- a/test/classes/initializers/secondary/inDiffModule2.good
+++ b/test/classes/initializers/secondary/inDiffModule2.good
@@ -1,2 +1,4 @@
+inDiffModule2.chpl:14: warning: initializers defined outside the module where the type was originally defined may cause issues
+inDiffModule2.chpl:14: note: This will no longer be a problem when constructors are deprecated
 In secondary initializer of class Foo
 {x = 10, y = true}

--- a/test/classes/initializers/secondary/inDiffModule3.chpl
+++ b/test/classes/initializers/secondary/inDiffModule3.chpl
@@ -1,6 +1,20 @@
 // Verified the behavior of types with only secondary initializers when the
 // initializer is defined in a module outside of the module where the type is
 // originally defined.
+
+// Variation on inDiffModule.chpl where the modules are defined in a different
+// order
+module B {
+  use A;
+
+  proc Foo.init(xVal) {
+    writeln("In secondary initializer of class Foo");
+    x = xVal;
+    y = xVal > 5;
+    super.init();
+  }
+}
+
 module A {
   class Foo {
     var x: int;
@@ -13,16 +27,5 @@ module A {
     // create those).
     writeln(f); // expect 10, false
     delete f;
-  }
-}
-
-module B {
-  use A;
-
-  proc Foo.init(xVal) {
-    writeln("In secondary initializer of class Foo");
-    x = xVal;
-    y = xVal > 5;
-    super.init();
   }
 }

--- a/test/classes/initializers/secondary/inDiffModule3.good
+++ b/test/classes/initializers/secondary/inDiffModule3.good
@@ -1,0 +1,3 @@
+inDiffModule3.chpl:10: warning: initializers defined outside the module where the type was originally defined may cause issues
+inDiffModule3.chpl:10: note: This will no longer be a problem when constructors are deprecated
+{x = 10, y = false}

--- a/test/classes/initializers/secondary/inDiffModuleBothSecondaryAndPrimary.chpl
+++ b/test/classes/initializers/secondary/inDiffModuleBothSecondaryAndPrimary.chpl
@@ -1,0 +1,36 @@
+// Verified the behavior of types with only secondary initializers when the
+// initializer is defined in a module outside of the module where the type is
+// originally defined.
+
+// Variation on inDiffModule.chpl where the modules are defined in a different
+// order
+module B {
+  use A;
+
+  proc Foo.init(xVal: int) {
+    writeln("In secondary initializer of class Foo");
+    x = xVal;
+    y = xVal > 5;
+    super.init();
+  }
+}
+
+module A {
+  class Foo {
+    var x: int;
+    var y = false;
+
+    proc init(yVal: bool) {
+      writeln("In primary initializer of class Foo");
+      x = 3;
+      y = yVal;
+      super.init();
+    }
+  }
+
+  proc main() {
+    var f = new Foo(true);
+    writeln(f); // expect 3, true
+    delete f;
+  }
+}

--- a/test/classes/initializers/secondary/inDiffModuleBothSecondaryAndPrimary.good
+++ b/test/classes/initializers/secondary/inDiffModuleBothSecondaryAndPrimary.good
@@ -1,0 +1,4 @@
+inDiffModuleBothSecondaryAndPrimary.chpl:10: warning: initializers defined outside the module where the type was originally defined may cause issues
+inDiffModuleBothSecondaryAndPrimary.chpl:10: note: This will no longer be a problem when constructors are deprecated
+In primary initializer of class Foo
+{x = 3, y = true}

--- a/test/classes/initializers/secondary/inDiffModuleBothSecondaryAndPrimary2.chpl
+++ b/test/classes/initializers/secondary/inDiffModuleBothSecondaryAndPrimary2.chpl
@@ -1,17 +1,25 @@
 // Verified the behavior of types with only secondary initializers when the
 // initializer is defined in a module outside of the module where the type is
 // originally defined.
+
+// Variation on inDiffModuleBothSecondaryAndPrimary.chpl where the modules are
+// defined in a different order
 module A {
   class Foo {
     var x: int;
     var y = false;
+
+    proc init(yVal: bool) {
+      writeln("In primary initializer of class Foo");
+      x = 3;
+      y = yVal;
+      super.init();
+    }
   }
 
   proc main() {
-    var f = new Foo(10);
-    // Should only use the default constructor (or default initializer when we
-    // create those).
-    writeln(f); // expect 10, false
+    var f = new Foo(true);
+    writeln(f); // expect 3, true
     delete f;
   }
 }
@@ -19,7 +27,7 @@ module A {
 module B {
   use A;
 
-  proc Foo.init(xVal) {
+  proc Foo.init(xVal: int) {
     writeln("In secondary initializer of class Foo");
     x = xVal;
     y = xVal > 5;

--- a/test/classes/initializers/secondary/inDiffModuleBothSecondaryAndPrimary2.good
+++ b/test/classes/initializers/secondary/inDiffModuleBothSecondaryAndPrimary2.good
@@ -1,0 +1,4 @@
+inDiffModuleBothSecondaryAndPrimary2.chpl:30: warning: initializers defined outside the module where the type was originally defined may cause issues
+inDiffModuleBothSecondaryAndPrimary2.chpl:30: note: This will no longer be a problem when constructors are deprecated
+In primary initializer of class Foo
+{x = 3, y = true}


### PR DESCRIPTION
These initializers can run into problems when the type relies on the default
constructor or initializer in its defining scope.

I also made them stop counting towards whether the type defined an initializer,
so that the scope in which they were defined could use the default constructor
or initializer.  This changed which of the secondary initializer tests worked and
which didn't, I believe for the better.

I chose to make this error happen regardless of whether the defining type has
an explicit initializer in its defining module due to uncertainty on the order
in which the potentially problematic initializer was encountered relative to the
type.  I could instead make a note that an initializer in this category was
encountered and then wait until all initializers have been found to determine
whether to output this error (though it would mean maintaining a notion of which
initializers fell under this category), if my reviewer thought that was
worthwhile.

Testing updates:
Add the warning to all the .good files of tests involving secondary initializers
defined in outside modules.

Fix an issue where inDiffModule.chpl was failing to clean up after itself
(because the earlier version of the program was failing during compilation).

Add three new tests to cover some variations I hadn't covered yet, including
when the module with the secondary initializer was defined prior to the module
with the type that relied on the default constructor, and both orders for when
the type has a remote secondary and a primary initializer.

Tested over classes/initializers with futures, and a full paratest.  I looked
at the impact of --force-initializers on the test that fails today - it seems as if there
is more to resolve than just "use initializers by default", unfortunately.