### PR TITLE
check if thrown errors are nil

### DIFF
--- a/compiler/AST/wellknown.cpp
+++ b/compiler/AST/wellknown.cpp
@@ -56,7 +56,7 @@ FnSymbol *gChplPropagateError;
 FnSymbol *gSaveTaskErrorFn;
 FnSymbol *gSaveLineInErrorFn;
 FnSymbol *gChplForallError;
-FnSymbol *gChplNilThrownError;
+FnSymbol *gChplCheckNilError;
 
 /************************************* | **************************************
 *                                                                             *
@@ -293,8 +293,8 @@ static WellKnownFn sWellKnownFns[] = {
   },
 
   {
-    "chpl_nil_thrown_error",
-    &gChplNilThrownError,
+    "chpl_check_nil_error",
+    &gChplCheckNilError,
     FLAG_UNKNOWN
   },
 };

--- a/compiler/AST/wellknown.cpp
+++ b/compiler/AST/wellknown.cpp
@@ -53,7 +53,7 @@ FnSymbol *gSetDynamicEndCount;
 FnSymbol *gChplDeleteError;
 FnSymbol *gChplUncaughtError;
 FnSymbol *gChplPropagateError;
-FnSymbol *gChplSaveTaskErrorFn;
+FnSymbol *gChplSaveTaskError;
 FnSymbol *gChplFixThrownError;
 FnSymbol *gChplForallError;
 
@@ -275,7 +275,7 @@ static WellKnownFn sWellKnownFns[] = {
 
   {
     "chpl_save_task_error",
-    &gChplSaveTaskErrorFn,
+    &gChplSaveTaskError,
     FLAG_UNKNOWN
   },
 

--- a/compiler/AST/wellknown.cpp
+++ b/compiler/AST/wellknown.cpp
@@ -47,15 +47,16 @@ FnSymbol *gBuildTupleType;
 FnSymbol *gBuildTupleTypeNoRef;
 FnSymbol *gBuildStarTupleType;
 FnSymbol *gBuildStarTupleTypeNoRef;
-FnSymbol *gChplDeleteError;
 FnSymbol *gPrintModuleInitFn;
 FnSymbol *gGetDynamicEndCount;
 FnSymbol *gSetDynamicEndCount;
+FnSymbol *gChplDeleteError;
 FnSymbol *gChplUncaughtError;
 FnSymbol *gChplPropagateError;
 FnSymbol *gSaveTaskErrorFn;
 FnSymbol *gSaveLineInErrorFn;
 FnSymbol *gChplForallError;
+FnSymbol *gChplNilThrownError;
 
 /************************************* | **************************************
 *                                                                             *
@@ -238,12 +239,6 @@ static WellKnownFn sWellKnownFns[] = {
   },
 
   {
-    "chpl_delete_error",
-    &gChplDeleteError,
-    FLAG_UNKNOWN
-  },
-
-  {
     "printModuleInit",
     &gPrintModuleInitFn,
     FLAG_PRINT_MODULE_INIT_FN
@@ -258,6 +253,12 @@ static WellKnownFn sWellKnownFns[] = {
   {
     "chpl_task_setDynamicEndCount",
     &gSetDynamicEndCount,
+    FLAG_UNKNOWN
+  },
+
+  {
+    "chpl_delete_error",
+    &gChplDeleteError,
     FLAG_UNKNOWN
   },
 
@@ -291,6 +292,11 @@ static WellKnownFn sWellKnownFns[] = {
     FLAG_UNKNOWN
   },
 
+  {
+    "chpl_nil_thrown_error",
+    &gChplNilThrownError,
+    FLAG_UNKNOWN
+  },
 };
 
 void gatherWellKnownFns() {

--- a/compiler/AST/wellknown.cpp
+++ b/compiler/AST/wellknown.cpp
@@ -53,10 +53,9 @@ FnSymbol *gSetDynamicEndCount;
 FnSymbol *gChplDeleteError;
 FnSymbol *gChplUncaughtError;
 FnSymbol *gChplPropagateError;
-FnSymbol *gSaveTaskErrorFn;
-FnSymbol *gSaveLineInErrorFn;
+FnSymbol *gChplSaveTaskErrorFn;
+FnSymbol *gChplFixThrownError;
 FnSymbol *gChplForallError;
-FnSymbol *gChplCheckNilError;
 
 /************************************* | **************************************
 *                                                                             *
@@ -276,13 +275,13 @@ static WellKnownFn sWellKnownFns[] = {
 
   {
     "chpl_save_task_error",
-    &gSaveTaskErrorFn,
+    &gChplSaveTaskErrorFn,
     FLAG_UNKNOWN
   },
 
   {
-    "chpl_save_line_in_error",
-    &gSaveLineInErrorFn,
+    "chpl_fix_thrown_error",
+    &gChplFixThrownError,
     FLAG_UNKNOWN
   },
 
@@ -292,11 +291,6 @@ static WellKnownFn sWellKnownFns[] = {
     FLAG_UNKNOWN
   },
 
-  {
-    "chpl_check_nil_error",
-    &gChplCheckNilError,
-    FLAG_UNKNOWN
-  },
 };
 
 void gatherWellKnownFns() {

--- a/compiler/include/wellknown.h
+++ b/compiler/include/wellknown.h
@@ -55,14 +55,15 @@ extern FnSymbol *gBuildTupleType;
 extern FnSymbol *gBuildTupleTypeNoRef;
 extern FnSymbol *gBuildStarTupleType;
 extern FnSymbol *gBuildStarTupleTypeNoRef;
-extern FnSymbol *gChplDeleteError;
 extern FnSymbol *gPrintModuleInitFn;
 extern FnSymbol *gGetDynamicEndCount;
 extern FnSymbol *gSetDynamicEndCount;
+extern FnSymbol *gChplDeleteError;
 extern FnSymbol *gChplUncaughtError;
 extern FnSymbol *gChplPropagateError;
 extern FnSymbol *gSaveTaskErrorFn;
 extern FnSymbol *gSaveLineInErrorFn;
 extern FnSymbol *gChplForallError;
+extern FnSymbol *gChplNilThrownError;
 
 #endif

--- a/compiler/include/wellknown.h
+++ b/compiler/include/wellknown.h
@@ -61,9 +61,8 @@ extern FnSymbol *gSetDynamicEndCount;
 extern FnSymbol *gChplDeleteError;
 extern FnSymbol *gChplUncaughtError;
 extern FnSymbol *gChplPropagateError;
-extern FnSymbol *gSaveTaskErrorFn;
-extern FnSymbol *gSaveLineInErrorFn;
+extern FnSymbol *gChplSaveTaskErrorFn;
+extern FnSymbol *gChplFixThrownError;
 extern FnSymbol *gChplForallError;
-extern FnSymbol *gChplCheckNilError;
 
 #endif

--- a/compiler/include/wellknown.h
+++ b/compiler/include/wellknown.h
@@ -61,7 +61,7 @@ extern FnSymbol *gSetDynamicEndCount;
 extern FnSymbol *gChplDeleteError;
 extern FnSymbol *gChplUncaughtError;
 extern FnSymbol *gChplPropagateError;
-extern FnSymbol *gChplSaveTaskErrorFn;
+extern FnSymbol *gChplSaveTaskError;
 extern FnSymbol *gChplFixThrownError;
 extern FnSymbol *gChplForallError;
 

--- a/compiler/include/wellknown.h
+++ b/compiler/include/wellknown.h
@@ -64,6 +64,6 @@ extern FnSymbol *gChplPropagateError;
 extern FnSymbol *gSaveTaskErrorFn;
 extern FnSymbol *gSaveLineInErrorFn;
 extern FnSymbol *gChplForallError;
-extern FnSymbol *gChplNilThrownError;
+extern FnSymbol *gChplCheckNilError;
 
 #endif

--- a/compiler/passes/errorHandling.cpp
+++ b/compiler/passes/errorHandling.cpp
@@ -382,18 +382,18 @@ bool ErrorHandlingVisitor::enterCallExpr(CallExpr* node) {
     SymExpr*   thrownExpr    = toSymExpr(node->get(1)->remove());
     VarSymbol* thrownError   = toVarSymbol(thrownExpr->symbol());
 
-    VarSymbol* nilErrorTemp  = newTemp("nil_error", dtError);
-    CallExpr*  checkNilError = new CallExpr(gChplNilThrownError,
+    VarSymbol* notNilError   = newTemp("not_nil_error", dtError);
+    CallExpr*  checkNilError = new CallExpr(gChplCheckNilError,
                                             castToError(thrownError));
 
-    throwBlock->insertAtTail(new DefExpr(nilErrorTemp));
-    throwBlock->insertAtTail(new CallExpr(PRIM_MOVE, nilErrorTemp, checkNilError));
-    throwBlock->insertAtTail(new CallExpr(gSaveLineInErrorFn, nilErrorTemp));
+    throwBlock->insertAtTail(new DefExpr(notNilError));
+    throwBlock->insertAtTail(new CallExpr(PRIM_MOVE, notNilError, checkNilError));
+    throwBlock->insertAtTail(new CallExpr(gSaveLineInErrorFn, notNilError));
 
     if (insideTry) {
-      throwBlock->insertAtTail(setOuterErrorAndGotoHandler(thrownError));
+      throwBlock->insertAtTail(setOuterErrorAndGotoHandler(notNilError));
     } else if (outError != NULL) {
-      throwBlock->insertAtTail(setOutGotoEpilogue(thrownError));
+      throwBlock->insertAtTail(setOutGotoEpilogue(notNilError));
     } else {
       INT_FATAL(node, "cannot throw in a non-throwing function");
     }

--- a/modules/internal/ChapelError.chpl
+++ b/modules/internal/ChapelError.chpl
@@ -54,8 +54,10 @@ module ChapelError {
   }
 
   class NilThrownError : Error {
-    proc NilThrownError() {
-      this.msg = "thrown error was nil";
+    const nil_msg = "thrown error was nil";
+
+    proc message() {
+      return nil_msg;
     }
   }
 
@@ -309,7 +311,7 @@ module ChapelError {
   // This function is called to check if a thrown error is nil.
   // If so, a NilThrownError is returned.
   pragma "no doc"
-  proc chpl_nil_thrown_error(err: Error):Error {
+  proc chpl_check_nil_error(err: Error):Error {
     if err != nil then
       return err;
 

--- a/modules/internal/ChapelError.chpl
+++ b/modules/internal/ChapelError.chpl
@@ -255,16 +255,16 @@ module ChapelError {
   pragma "no doc"
   pragma "insert line file info"
   proc chpl_fix_thrown_error(err: Error): Error {
-    var err_fix: Error = err;
-    if err_fix == nil then
-      err_fix = new NilThrownError();
+    var fixErr: Error = err;
+    if fixErr == nil then
+      fixErr = new NilThrownError();
 
     const line = __primitive("_get_user_line");
     const fileId = __primitive("_get_user_file");
-    err_fix.thrownLine = line;
-    err_fix.thrownFileId = fileId;
+    fixErr.thrownLine = line;
+    fixErr.thrownFileId = fileId;
 
-    return err_fix;
+    return fixErr;
   }
   pragma "no doc"
   proc chpl_delete_error(err: Error) {

--- a/modules/internal/ChapelError.chpl
+++ b/modules/internal/ChapelError.chpl
@@ -54,10 +54,10 @@ module ChapelError {
   }
 
   class NilThrownError : Error {
-    const nil_msg = "thrown error was nil";
+    const nil_thrown_msg = "thrown error was nil";
 
     proc message() {
-      return nil_msg;
+      return nil_thrown_msg;
     }
   }
 

--- a/modules/internal/ChapelError.chpl
+++ b/modules/internal/ChapelError.chpl
@@ -53,6 +53,12 @@ module ChapelError {
     }
   }
 
+  class NilThrownError : Error {
+    proc NilThrownError() {
+      this.msg = "thrown error was nil";
+    }
+  }
+
   // Used by the runtime to accumulate errors. This type
   // supports adding errors concurrently but need not support
   // iterating over the errors concurrently. Errors
@@ -299,5 +305,14 @@ module ChapelError {
       return err;
     // If err wasn't a taskError, wrap it in one
     return new TaskErrors(err);
+  }
+  // This function is called to check if a thrown error is nil.
+  // If so, a NilThrownError is returned.
+  pragma "no doc"
+  proc chpl_nil_thrown_error(err: Error):Error {
+    if err != nil then
+      return err;
+
+    return new NilThrownError();
   }
 }

--- a/modules/internal/ChapelError.chpl
+++ b/modules/internal/ChapelError.chpl
@@ -253,7 +253,7 @@ module ChapelError {
     return ret;
   }
   pragma "no doc"
-  pragma "replace nil, insert line file info"
+  pragma "insert line file info"
   proc chpl_fix_thrown_error(err: Error): Error {
     var err_fix: Error = err;
     if err_fix == nil then

--- a/test/errhandling/psahabu/throw-nil.chpl
+++ b/test/errhandling/psahabu/throw-nil.chpl
@@ -1,0 +1,7 @@
+proc throwsNil() throws {
+  writeln("throwing nil");
+  throw nil;
+  writeln("fail: did not throw NilThrownError");
+}
+
+try! throwsNil();

--- a/test/errhandling/psahabu/throw-nil.good
+++ b/test/errhandling/psahabu/throw-nil.good
@@ -1,0 +1,4 @@
+throwing nil
+uncaught NilThrownError: thrown error was nil
+  throw-nil.chpl:3: thrown here
+  throw-nil.chpl:7: uncaught here


### PR DESCRIPTION
Before, throwing a nil error would result in a no-op. The team determined that it would be beneficial for users to see that they had thrown nil by generating a `NilThrownError` and throwing that instead. This PR combines that functionality with the previously existing `gSaveLineInErrorFn`, now renamed to `gChplFixThrownError`.

While there, reorganized `gChplDeleteError` and renamed `gSaveTaskErrorFn` to `gChplSaveTaskError`.

- [x] passes linux64+flat testing