### PR TITLE
Add annotations for the last week

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -267,6 +267,9 @@ all:
       config: 16 node XC
   08/15/17:
     - add error handling to the IO module (#6890)
+  09/06/17:
+    - text: Improve the accuracy of our running task counter (#7193)
+      config: 16 node XC
 
 
 AllCompTime:
@@ -1067,6 +1070,8 @@ timeVectorArray:
     - upgrade jemalloc to 4.4.0 (#5278)
   07/26/17:
     - Allow domains to implement specialized assignment (#6722)
+  09/13/17:
+    - Support arrays as args to array.{push_front,push_back,insert} (#7180)
 
 dynamic:
   02/28/17:


### PR DESCRIPTION
## Performance Triage for 09/14/2017

### Graphs with deltas

- [chapcs](http://chapel.sourceforge.net/perf/chapcs/?startdate=2017/09/01&enddate=2017/09/14&graphs=arrayvectoroperations,compilationtime,memoryleaksforalltests,numberoftestswithleaks,jacobiastsize,jacobiemittedcodesize,epstreamfragmented,reductionstimesec)
  - Array vector operations improvements/regressions attributed to #7180
    - A patch for the regressions is in progress
  - **Not annotated:**
    - Minor compiler performance regression
      - [compiler performance suite](http://chapel.sourceforge.net/perf/chap01/?suite=top10compilationpasstimings)
    - Minor AST size regression (synced with compiler performance)
    - Memory leak bumps (resolved)
- [16-node](http://chapel.sourceforge.net/perf/16-node-xc/?startdate=2017/08/08&enddate=2017/09/14&configs=gnuugniqthreads,gnugasnetaries,gnugasnetmpi&graphs=hpccfftperfgflopsn220)
  - FFT improvement attributed to #7193

### EP Stream & Reductions

- Performance continues to behave surprisingly - performance improved for both `16 node` and `chapcs` on 09/05
  - @ronawho asserts that the single locale performance regression this is not due to #7193, but it seems like a crazy coincidence to not be..
  - The fact that it improved for `chapcs` and `chap04` hints that there was a real improvement.
- Reductions performance returned upon chapcs reboot on 08/09
- [chapcs](http://chapel.sourceforge.net/perf/chapcs/?startdate=2016/03/10&enddate=2017/09/14&graphs=epstreamfragmented,reductionstimesec)
- [chap04](http://chapel.sourceforge.net/perf/chap04/?startdate=2016/03/10&enddate=2017/09/14&graphs=epstreamfragmented,reductionstimesec)

### Compiler Performance Data Contaminated

Best guess: Clock skew impacting `--print-passes` timings:

- [Impacted data](http://chapel.sourceforge.net/perf/chap01/?startdate=2017/01/06&enddate=2017/09/13&graphs=averagecompilationtimeperpass,topaveragecompilationtimeperpass)
- Potential follow-ups to this:
  -  Remove impacted dates from perf data
  - Patch `--print-passes` to be more robust against clock skew
    - More principled solution: monotonic clock
    - Easy fix: `if time < 0 return 0`

### Testing

```
> ./check_annotations.py
No fatal annotation errors detected
```
