### PR TITLE
Have initializers error if a field is explicitly used in the argument list

### DIFF
--- a/compiler/include/initializerRules.h
+++ b/compiler/include/initializerRules.h
@@ -23,6 +23,8 @@
 class AggregateType;
 class FnSymbol;
 
+void      errorOnFieldsInArgList(FnSymbol* fn);
+
 void      preNormalizeFields(AggregateType* at);
 void      preNormalizeInitMethod(FnSymbol* fn);
 FnSymbol* buildClassAllocator(FnSymbol* initMethod);

--- a/compiler/passes/checkNormalized.cpp
+++ b/compiler/passes/checkNormalized.cpp
@@ -21,6 +21,7 @@
 
 #include "astutil.h"
 #include "expr.h"
+#include "initializerRules.h"
 #include "stlUtil.h"
 
 
@@ -51,21 +52,7 @@ static void checkFunctionSignatures() {
         USR_FATAL_CONT(fn, "initializers may not declare a return type");
       }
 
-      for_formals(formal, fn) {
-        std::vector<SymExpr*> symExprs;
-
-        collectSymExprs(formal, symExprs);
-
-        for_vector(SymExpr, se, symExprs) {
-          if (se->symbol() == fn->_this) {
-            USR_FATAL_CONT(se,
-                           "invalid access of class member in "
-                           "initializer argument list");
-
-            break;
-          }
-        }
-      }
+      errorOnFieldsInArgList(fn);
 
     } else if (fn->hasFlag(FLAG_DESTRUCTOR) == true) {
       if (fn->retExprType != NULL) {

--- a/compiler/passes/initializerRules.cpp
+++ b/compiler/passes/initializerRules.cpp
@@ -172,6 +172,30 @@ void preNormalizeInitMethod(FnSymbol* fn) {
 
   } else {
     preNormalize(fn);
+
+    errorOnFieldsInArgList(fn);
+  }
+}
+
+// Generates an error if a field is used in the argument list to an initializer
+// or constructor
+// Lydia NOTE 09/14/17: Make this static and unexported once constructors are
+// deprecated
+void errorOnFieldsInArgList(FnSymbol* fn) {
+  for_formals(formal, fn) {
+    std::vector<SymExpr*> symExprs;
+
+    collectSymExprs(formal, symExprs);
+
+    for_vector(SymExpr, se, symExprs) {
+      if (se->symbol() == fn->_this) {
+        USR_FATAL_CONT(se,
+                       "invalid access of class member in "
+                       "initializer argument list");
+
+        break;
+      }
+    }
   }
 }
 

--- a/test/classes/initializers/constAndParamInHeader.future
+++ b/test/classes/initializers/constAndParamInHeader.future
@@ -1,3 +1,0 @@
-bug: Failing to report that a field has been used too early in an
-initializer; in fact as a default value for a formal for an init
-method


### PR DESCRIPTION
Constructors had implemented this error, but since initializers are not marked
with FLAG_CONSTRUCTOR, they were skipping this check in checkNormalize.
This meant that we would error obscurely during function resolution instead.  Make
the check a function in its own right, move the definition to initializerRules,
and have the original location and preNormalizeInitMethod call it.

Once constructors are deprecated, we can stop exporting this function and make
it static to the file (this final situation is why I decided to move the
operation to initializerRules, as it makes sense to keep that code as much
together as possible.)

Removes the .future file for classes/initializers/constAndParamInHeader.chpl

Testing:  passed classes/initializers with futures, and a full paratest.