### PR TITLE
Tweak isConstValWillNotChange()

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -219,7 +219,7 @@ bool Symbol::isConstant() const {
   return false;
 }
 
-bool Symbol::isConstValWillNotChange() const {
+bool Symbol::isConstValWillNotChange() {
   return false;
 }
 
@@ -580,11 +580,12 @@ bool VarSymbol::isConstant() const {
 }
 
 
-bool VarSymbol::isConstValWillNotChange() const {
+bool VarSymbol::isConstValWillNotChange() {
   // todo: how about QUAL_CONST ?
   return qual == QUAL_CONST_VAL         ||
          hasFlag(FLAG_REF_TO_IMMUTABLE) ||
-         (hasFlag(FLAG_CONST) && !hasFlag(FLAG_REF_VAR));
+         (hasFlag(FLAG_CONST) &&
+          !(hasFlag(FLAG_REF_VAR) || isRef()));
 }
 
 
@@ -825,7 +826,7 @@ static void isConstValWillNotChangeHelp(IntentTag intent,
   return; // dummy
 }  
 
-bool ArgSymbol::isConstValWillNotChange() const {
+bool ArgSymbol::isConstValWillNotChange() {
   if (hasFlag(FLAG_REF_TO_IMMUTABLE))
     return true;
 
@@ -1020,7 +1021,7 @@ bool ShadowVarSymbol::isConstant() const {
   return false; // dummy
 }
 
-bool ShadowVarSymbol::isConstValWillNotChange() const {
+bool ShadowVarSymbol::isConstValWillNotChange() {
   //
   // This is written to only be called post resolveIntents
   //

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -127,7 +127,7 @@ public:
                                   BaseAST* newAst)               = 0;
 
   virtual bool       isConstant()                              const;
-  virtual bool       isConstValWillNotChange()                 const;
+  virtual bool       isConstValWillNotChange();
   virtual bool       isImmediate()                             const;
   virtual bool       isParameter()                             const;
           bool       isRenameable()                            const;
@@ -280,7 +280,7 @@ public:
   void replaceChild(BaseAST* old_ast, BaseAST* new_ast);
 
   virtual bool       isConstant()                              const;
-  virtual bool       isConstValWillNotChange()                 const;
+  virtual bool       isConstValWillNotChange();
   virtual bool       isImmediate()                             const;
   virtual bool       isParameter()                             const;
   virtual bool       isType()                                  const;
@@ -346,7 +346,7 @@ public:
 
   // New interface
   virtual bool    isConstant()                              const;
-  virtual bool    isConstValWillNotChange()                 const;
+  virtual bool    isConstValWillNotChange();
   virtual bool    isParameter()                             const;
 
   virtual bool    isVisible(BaseAST* scope)                 const;
@@ -391,7 +391,7 @@ public:
 
   virtual void    replaceChild(BaseAST* oldAst, BaseAST* newAst);
   virtual bool    isConstant()                              const;
-  virtual bool    isConstValWillNotChange()                 const;
+  virtual bool    isConstValWillNotChange();
 
   const char* intentDescrString() const;
   bool        isReduce()          const { return intent == TFI_REDUCE;  }


### PR DESCRIPTION
VarSymbol::isConstValWillNotChange() was discussed in #7302.
There is a concern that the check for FLAG_CONST may not do the right thing.

This change softens that concern by excluding additional things
for which isConstValWillNotChange() returns 'true' when hasFlag(FLAG_CONST).

Before, it excluded things with hasFlag(FLAG_REF_VAR).
Now, it also excludes isRef() things.

I did not dare to replace hasFlag(FLAG_REF_VAR) with isRef() because
the two tests seem disjoint.

The ideal solution will probably include neither of these two conditions,
relying on the qualifier instead. Our representation is not there yet.

I had to make isConstValWillNotChange() a non-const method
because it calls isRef() and that one is non-const. Fixing that
is an entirely different story and requires massive const-ization
of the compiler.
