### PR TITLE
Chameneos initializer updates

### DIFF
--- a/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc-ideal.bad
+++ b/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc-ideal.bad
@@ -1,0 +1,8 @@
+chameneosredux-blc-ideal.chpl:56: internal error: INI0465 chpl Version 1.16.0 pre-release (5007c1a)
+Note: This source location is a guess.
+
+Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
+please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
+the filename + line number above may be useful in working around the issue.
+

--- a/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc-ideal.chpl
+++ b/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc-ideal.chpl
@@ -53,7 +53,7 @@ record Population {
   // construct the population in terms of an array of colors passed in
   //
   proc init(colors) {
-    chameneos = new Chameneos(colors.domain, colors);
+    chameneos = new Chameneos(1..colors.size, colors);
     super.init();
   }
 

--- a/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc-ideal.chpl
+++ b/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc-ideal.chpl
@@ -53,7 +53,7 @@ record Population {
   // construct the population in terms of an array of colors passed in
   //
   proc init(colors) {
-    chameneos = [i in colors.domain] new Chameneos(i, colors[i]);
+    chameneos = new Chameneos(colors.domain, colors);
     super.init();
   }
 

--- a/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc-ideal.future
+++ b/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc-ideal.future
@@ -1,0 +1,5 @@
+bug: internal error for generic argument formed by promoted initializer call
+
+This test generates an internal error in spite of its similarity to
+../elliot/chameneosredux-ejr.chpl.  Seems like this should be legal,
+or even if not, should not be an internal error.

--- a/test/studies/shootout/chameneos-redux/elliot/chameneosredux-ejr.chpl
+++ b/test/studies/shootout/chameneos-redux/elliot/chameneosredux-ejr.chpl
@@ -58,7 +58,7 @@ record Population {
   //
   proc init(colors) {
     chamSpace = colors.domain;
-    chameneos = new Chameneos(chamSpace, colors);
+    chameneos = new Chameneos(1..colors.size, colors);
     super.init();
   }
 

--- a/test/studies/shootout/chameneos-redux/elliot/chameneosredux-ejr.chpl
+++ b/test/studies/shootout/chameneos-redux/elliot/chameneosredux-ejr.chpl
@@ -58,9 +58,8 @@ record Population {
   //
   proc init(colors) {
     chamSpace = colors.domain;
+    chameneos = new Chameneos(chamSpace, colors);
     super.init();
-    forall i in chamSpace do
-      chameneos[i] = new Chameneos(i, colors[i]);
   }
 
   //
@@ -98,7 +97,7 @@ record Population {
   //
   // Delete the chameneos objects.
   //
-  proc ~Population {
+  proc deinit() {
     for c in chameneos do
       delete c;
   }


### PR DESCRIPTION
While reviewing release-over-release performance numbers and looking at chameneos versions, I was reminded that now that initializers are much improved, we can write nicer initializers for our chameneos versions.  This PR:

* moves a phase 2 array assignment in Elliot's version's initializer into a phase 1 assignment and uses promotion of a constructor (a forall expression could be used instead if that felt like the right clarity / code size tradeoff)
* copies my "ideal" version to the "blc" version now that it's working to get timings on it (the previous blc version was virtually identical to the submitted version 2.  The main difference between this version and Elliot's is the use of a generic field rather than explicit domain/array fields.  Since my "ideal" version was never timed for performance, this will give us a first opportunity to do so
* creates a new (futurized) ideal version that results in an internal error in the compiler.  Interestingly, it uses concepts from Elliot's (the promoted constructor) and mine (the generic field) either of which works separately, but which blow up when used together.