### PR TITLE
Add resolvedOrVirtualFunction, fix issue #6542

### DIFF
--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -1198,6 +1198,30 @@ void CallExpr::setResolvedFunction(FnSymbol* fn) {
   }
 }
 
+// This function returns the resolved function, if it's totally resolved,
+// or some resolved virtual function (probably a virtual parent that
+// won't actually called at runtime) if it's a virtual method call.
+// This function is useful for transformations on calls that work
+// depending on the called function's signature (since the virtual
+// parent and children will have the same signature).
+FnSymbol* CallExpr::resolvedOrVirtualFunction() const {
+  // The common case of a user-level call to a resolved function
+  FnSymbol* fn = this->resolvedFunction();
+
+  // Also handle the PRIMOP for a virtual method call
+  if (fn == NULL)
+  {
+    if (this->isPrimitive(PRIM_VIRTUAL_METHOD_CALL) == true)
+    {
+      SymExpr* arg1 = toSymExpr(this->get(1));
+
+      fn = toFnSymbol(arg1->symbol());
+    }
+  }
+
+  return fn;
+}
+
 FnSymbol* CallExpr::theFnSymbol() const {
   FnSymbol* retval = NULL;
 

--- a/compiler/include/expr.h
+++ b/compiler/include/expr.h
@@ -273,6 +273,7 @@ public:
   bool            isResolved()                                           const;
   FnSymbol*       resolvedFunction()                                     const;
   void            setResolvedFunction(FnSymbol* fn);
+  FnSymbol*       resolvedOrVirtualFunction()                            const;
 
   FnSymbol*       theFnSymbol()                                          const;
 

--- a/compiler/passes/errorHandling.cpp
+++ b/compiler/passes/errorHandling.cpp
@@ -323,15 +323,7 @@ bool ErrorHandlingVisitor::enterCallExpr(CallExpr* node) {
   bool insideTry = !tryStack.empty();
 
   // The common case of a user-level call to a resolved function
-  FnSymbol* calledFn = node->resolvedFunction();
-
-  // Also handle the PRIMOP for a virtual method call
-  if (calledFn == NULL) {
-    if (node->isPrimitive(PRIM_VIRTUAL_METHOD_CALL)) {
-        SymExpr* arg1 = toSymExpr(node->get(1));
-        calledFn = toFnSymbol(arg1->symbol());
-    }
-  }
+  FnSymbol* calledFn = node->resolvedOrVirtualFunction();
 
   if (calledFn != NULL) {
     if (calledFn->throwsError()) {

--- a/compiler/resolution/callDestructors.cpp
+++ b/compiler/resolution/callDestructors.cpp
@@ -162,19 +162,9 @@ void ReturnByRef::returnByRefCollectCalls(RefMap& calls)
 
 FnSymbol* ReturnByRef::theTransformableFunction(CallExpr* call)
 {
-  // The common case of a user-level call to a resolved function
-  FnSymbol* theCall = call->resolvedFunction();
-
+  // The common case is a user-level call to a resolved function
   // Also handle the PRIMOP for a virtual method call
-  if (theCall == NULL)
-  {
-    if (call->isPrimitive(PRIM_VIRTUAL_METHOD_CALL) == true)
-    {
-      SymExpr* arg1 = toSymExpr(call->get(1));
-
-      theCall = toFnSymbol(arg1->symbol());
-    }
-  }
+  FnSymbol* theCall = call->resolvedOrVirtualFunction();
 
   return (theCall && isTransformableFunction(theCall)) ? theCall : NULL;
 }
@@ -506,7 +496,7 @@ void ReturnByRef::transform()
     }
     else
     {
-      FnSymbol* calledFn = call->resolvedFunction();
+      FnSymbol* calledFn = call->resolvedOrVirtualFunction();
 
       if (!calledFn->hasFlag(FLAG_NEW_ALIAS_FN)) {
         // fixupNewAlias removes some - but not all - calls

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -8093,7 +8093,7 @@ static void insertReturnTemps() {
   //
   forv_Vec(CallExpr, call, gCallExprs) {
     if (call->parentSymbol) {
-      if (FnSymbol* fn = call->resolvedFunction()) {
+      if (FnSymbol* fn = call->resolvedOrVirtualFunction()) {
         if (fn->retType != dtVoid) {
           ContextCallExpr* contextCall = toContextCallExpr(call->parentExpr);
           Expr*            contextCallOrCall; // insert before, remove it

--- a/test/classes/elliot/non-captured-virtual-return.bad
+++ b/test/classes/elliot/non-captured-virtual-return.bad
@@ -1,7 +1,0 @@
-internal error: MIS0558 chpl Version 1.16.0 pre-release (45e89ca37f)
-
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
-and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
-please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
-

--- a/test/classes/elliot/non-captured-virtual-return.future
+++ b/test/classes/elliot/non-captured-virtual-return.future
@@ -1,1 +1,0 @@
-bug: not capturing return value of virtual calls casues compiler segfault (#6542)


### PR DESCRIPTION
This PR takes two steps to fix issue #6542:
  1. It introduces a function, `CallExpr::resolvedOrVirtualFunction`, factoring out a code pattern used already in callDestructors and errorHandling. The pattern is to find the resolved function, or, for a PRIM_VIRTUAL_METHOD_CALL, find one of the possible virtual methods that could be called at runtime. This function is appropriate to call for code that identifies calls to transform based upon the signature of the called function.
 2. It calls this function in two places in order to resolve issue #6542.

What was going wrong with issue #6542? The compiler includes a transformation that happens during resolution, `insertReturnTemps`, which finds all calls to functions that return a value that don't use the result of that return. In that case it adds a temporary variable to capture the returned value.

Code in callDestructors / ReturnByRef relied on calls to transformable functions having a variable to capture the returned value.

In the case of virtual method calls, `insertReturnTemps` was not transforming the call, and so the code pattern in issue #6542 led to failed assertions in callDestructors.

The important part of this fix is to adjust `insertReturnTemps` to handle virtual calls (PRIM_VIRTUAL_METHOD_CALL).

Passed full local testing.
Reviewed by @noakesmichael - thanks!