### PR TITLE
Resolve timeVectorArray regressions

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -2609,7 +2609,7 @@ module ChapelArray {
     inline proc resizeAllocRange(r2: range, factor=arrayAsVecGrowthFactor,
                                  param direction=1, param grow=1) {
       // This should only be called for 1-dimensional arrays
-      const r = this._value.dataAllocRange;
+      ref r = this._value.dataAllocRange;
       const lo = r.low,
             hi = r.high,
             size = r.size;

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -2609,7 +2609,7 @@ module ChapelArray {
     inline proc resizeAllocRange(r2: range, factor=arrayAsVecGrowthFactor,
                                  param direction=1, param grow=1) {
       // This should only be called for 1-dimensional arrays
-      ref r = this._value.dataAllocRange;
+      const ref r = this._value.dataAllocRange;
       const lo = r.low,
             hi = r.high,
             size = r.size;

--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -1075,6 +1075,8 @@ timeVectorArray:
     - Allow domains to implement specialized assignment (#6722)
   09/13/17:
     - Support arrays as args to array.{push_front,push_back,insert} (#7180)
+  09/16/17:
+    - Resolve timeVectorArray regressions (#7333)
 
 dynamic:
   02/28/17:


### PR DESCRIPTION
Performance restored for `push_back`, and `pop_front`, by taking `const ref` of `dataAllocRange` rather than creating a local copy.
