### PR TITLE
Fix printing c_void_ptr on cygwin-32 and --llvm

### DIFF
--- a/compiler/util/llvmUtil.cpp
+++ b/compiler/util/llvmUtil.cpp
@@ -234,6 +234,11 @@ llvm::Value *convertValueToType(
     return builder->CreateIntToPtr(value, newType);
   }
 
+  //Pointer to integer
+  if(newType->isIntegerTy() && curType->isPointerTy()) {
+    return builder->CreatePtrToInt(value, newType);
+  }
+
   //Pointers
   if(newType->isPointerTy() && curType->isPointerTy()) {
     if( newType->getPointerAddressSpace() !=

--- a/modules/internal/CPtr.chpl
+++ b/modules/internal/CPtr.chpl
@@ -91,7 +91,7 @@ module CPtr {
       ch <~> "(nil)";
     } else {
       var err:syserr = ENOERR;
-      ch.writef(error=err, "0x%xu", this:uint(64):c_uintptr);
+      ch.writef(error=err, "0x%xu", this:c_uintptr);
       if err then
         ch.setError(err);
     }

--- a/modules/internal/CPtr.chpl
+++ b/modules/internal/CPtr.chpl
@@ -143,8 +143,8 @@ module CPtr {
   }
   pragma "no doc"
   inline proc _cast(type t, x)
-  where (t:c_intptr||t:c_uintptr||t:int(64)||t:uint(64)) &&
-        (x.type:c_void_ptr||x.type:c_ptr) {
+  where (t:c_intptr || t:c_uintptr || t:int(64) || t:uint(64)) &&
+        (x.type:c_void_ptr || x.type:c_ptr) {
     return __primitive("cast", t, x);
   }
 

--- a/modules/internal/CPtr.chpl
+++ b/modules/internal/CPtr.chpl
@@ -91,7 +91,7 @@ module CPtr {
       ch <~> "(nil)";
     } else {
       var err:syserr = ENOERR;
-      ch.writef(error=err, "0x%xu", this:c_uintptr);
+      ch.writef(error=err, "0x%xu", this:uint(64):c_uintptr);
       if err then
         ch.setError(err);
     }
@@ -142,13 +142,14 @@ module CPtr {
     return __primitive("cast", t, x);
   }
   pragma "no doc"
-  inline proc _cast(type t, x) where t:uint(64) && x.type:c_ptr {
+  inline proc _cast(type t, x) where t:c_intptr && x.type:c_ptr {
     return __primitive("cast", t, x);
   }
   pragma "no doc"
-  inline proc _cast(type t, x) where t:uint(64) && x.type:c_void_ptr {
+  inline proc _cast(type t, x) where t:c_uintptr && x.type:c_void_ptr {
     return __primitive("cast", t, x);
   }
+
 
   pragma "compiler generated"
   pragma "last resort"

--- a/modules/internal/CPtr.chpl
+++ b/modules/internal/CPtr.chpl
@@ -142,14 +142,11 @@ module CPtr {
     return __primitive("cast", t, x);
   }
   pragma "no doc"
-  inline proc _cast(type t, x) where t:c_intptr && x.type:c_ptr {
+  inline proc _cast(type t, x)
+  where (t:c_intptr||t:c_uintptr||t:int(64)||t:uint(64)) &&
+        (x.type:c_void_ptr||x.type:c_ptr) {
     return __primitive("cast", t, x);
   }
-  pragma "no doc"
-  inline proc _cast(type t, x) where t:c_uintptr && x.type:c_void_ptr {
-    return __primitive("cast", t, x);
-  }
-
 
   pragma "compiler generated"
   pragma "last resort"

--- a/modules/internal/CPtr.chpl
+++ b/modules/internal/CPtr.chpl
@@ -91,7 +91,7 @@ module CPtr {
       ch <~> "(nil)";
     } else {
       var err:syserr = ENOERR;
-      ch.writef(error=err, "0x%xu", this:uint(64));
+      ch.writef(error=err, "0x%xu", this:c_uintptr);
       if err then
         ch.setError(err);
     }


### PR DESCRIPTION
Verified test/io/nspark passes on cygwin, linux64, linux64 --llvm.

Passed full local testing.
Reviewed by @ronawho - thanks!