### PR TITLE
Set the line number before copying leader iterators in implementForallIntents

### DIFF
--- a/compiler/resolution/implementForallIntents.cpp
+++ b/compiler/resolution/implementForallIntents.cpp
@@ -826,6 +826,7 @@ static Map<FnSymbol*,FnSymbol*> pristineLeaderIterators;
 
 
 static FnSymbol* copyLeaderFn(FnSymbol* origFn, bool ignore_isResolved) {
+  SET_LINENO(origFn->defPoint);
   FnSymbol* copyFn = origFn->copy();
   copyFn->addFlag(FLAG_INVISIBLE_FN);
   origFn->defPoint->insertAfter(new DefExpr(copyFn));

--- a/test/functions/iterators/elliot/dynamicDispatch/virtual-par-iters.bad
+++ b/test/functions/iterators/elliot/dynamicDispatch/virtual-par-iters.bad
@@ -1,7 +1,2 @@
-internal error: BAS0313 chpl Version 1.16.0 pre-release (f8e9da11d6)
-
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
-and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
-please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
-
+1
+virtual-par-iters.chpl:18: error: halt reached - Should not be called...

--- a/test/functions/iterators/elliot/dynamicDispatch/virtual-par-iters.future
+++ b/test/functions/iterators/elliot/dynamicDispatch/virtual-par-iters.future
@@ -1,1 +1,1 @@
-bug: virtual parallel iterators cause compiler segfault (#6998)
+bug: parallel iterators don't dynamically dispatch correctly (#6998)


### PR DESCRIPTION
Issue #6998 hit an internal error because the line number was not set when
adding an AST. Set the line number with SET_LINENO to fix the internal error.

The test from #6998 still fails because dynamic dispatch doesn't appear to
be working on leader iterators. Oddly, after removing the halts from that
test, the parent leader is called, but the child follower is called.

Update a test's .bad and .future files to match the new failure mode.