### PR TITLE
Remove SSCA2_commDiags from .gitignore since I removed the test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -376,7 +376,6 @@ tags
 /test/studies/ssca2/graphio/graphio.2.ev2_snapshot.data
 /test/studies/ssca2/graphio/graphio.2.start_snapshot.data
 /test/studies/ssca2/graphio/graphio.2.weight_snapshot.data
-/test/studies/ssca2/performance/SSCA2_kernels.chpl
 /test/studies/ssca2/rachels/SSCA2_main.RMAT.good
 /test/studies/ssca2/rachels/SSCA2_main.1Dtorus.good
 /test/studies/ssca2/rachels/SSCA2_main.2Dtorus.good


### PR DESCRIPTION
This should've gone in with my previous PR, but I overlooked it.