### PR TITLE
Close main remaining leak in AMR code

### DIFF
--- a/test/studies/amr/lib/misc/MultiDomain_def.chpl
+++ b/test/studies/amr/lib/misc/MultiDomain_def.chpl
@@ -62,9 +62,12 @@ class MultiDomain
   var root: MDNode(rank,stridable);
 
 
-  proc initialize ()
+  proc init (param rank=0, param stridable=false)
   {
+    this.rank = rank;
+    this.stridable = stridable;
     root = new MDNode( rank, stridable );
+    super.init();
   }
 
 
@@ -74,7 +77,7 @@ class MultiDomain
   proc copy ()
   {
     const new_mD = new MultiDomain(rank,stridable);
-    new_mD.root = root.copy();
+    root.copy(new_mD.root);  // the initializer has already allocated 'root', so pass it in for re-use
     return new_mD;
   }
 
@@ -241,9 +244,10 @@ class MDNode
   }
 
 
-  proc copy () : MDNode(rank,stridable)
+  proc copy (in new_node: MDNode(rank, stridable) = nil) : MDNode(rank,stridable)
   {
-    const new_node = new MDNode(rank, stridable);
+    if new_node == nil then
+      new_node = new MDNode(rank, stridable);
 
     new_node.Domain     = Domain;
     new_node.bisect_dim = bisect_dim;


### PR DESCRIPTION
It turns out that when Jonathan was creating a copy of a MultiDomain,
the initialize() method was creating a new root node which would then
get overwritten when assigning the result of the MDNode.copy() method
(which also allocates a new node) to it.  Here, I changed the copy()
method to take an optional node as its argument and to use it if it's
fed in; otherwise, to allocate one.  This closed the leak.

While here, I changed the initialize() method into a normal init()
method.