### PR TITLE
Use initial value of outer variable upon reduce intent

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -3074,7 +3074,7 @@ module ChapelArray {
     // true everywhere
     //
     if isArrayType(this.eltType) {
-      var ret: bool;
+      var ret = true;
       forall (thisArr, thatArr) in zip(this, that) with (&& reduce ret) do
         ret &&= thisArr.equals(thatArr);
       return ret;

--- a/test/parallel/forall/vass/3types-1-wrapped-plus.chpl
+++ b/test/parallel/forall/vass/3types-1-wrapped-plus.chpl
@@ -27,6 +27,7 @@ class MyOp: ReduceScanOp {
   proc identity           return new Rstate(eltType);
   proc accumulate(state)  { value.stField += state.stField; }
   proc accumulateOntoState(ref state, elm)   { state.stField += elm; }
+  proc initialAccumulate(outerVar)   { accumulateOntoState(value, outerVar.outField); }
   proc combine(other)     { value.stField += other.value.stField; }
   proc generate()         return new Routput(eltType, value.stField);
   proc clone()            return new MyOp(eltType=eltType);

--- a/test/parallel/forall/vass/3types-1-wrapped-plus.good
+++ b/test/parallel/forall/vass/3types-1-wrapped-plus.good
@@ -1,3 +1,3 @@
-3types-1-wrapped-plus.chpl:43: In function 'main':
-3types-1-wrapped-plus.chpl:48: warning: Rstate(int(64))
+3types-1-wrapped-plus.chpl:44: In function 'main':
+3types-1-wrapped-plus.chpl:49: warning: Rstate(int(64))
 result = 4950

--- a/test/parallel/forall/vass/3types-3-sum-of-booleans.chpl
+++ b/test/parallel/forall/vass/3types-3-sum-of-booleans.chpl
@@ -25,6 +25,10 @@
     /* accumulate a single element onto the state */
     proc accumulateOntoState(ref state, elm)  { state = state + elm; }
 
+    /* accumulate the initial value of the outer variable onto the state */
+    // make it an error if things don't work smoothly
+    proc initialAccumulate(outerVar)  { assert(outerVar==(0:outerVar.type)); }
+
     // Note: 'this' can be accessed by multiple calls to combine()
     // concurrently. The Chapel implementation serializes such calls
     // with a lock on 'this'.

--- a/test/parallel/forall/vass/array-reduce-intents.chpl
+++ b/test/parallel/forall/vass/array-reduce-intents.chpl
@@ -11,10 +11,12 @@ var dataM: [dataDom] int = [i in 1..n] i % b + 1;
 var dataB: [dataDom] int = 1..n;
 
 type HistM = [1..b] int;
-var histoM: HistM;
+var histoM: HistM = 1;
 
 type HistB = [1..n] uint(8);
-var histoBA, histoBO, histoBX: HistB;
+var histoBA: HistB = _band_id(uint(8));
+var histoBO: HistB = _bor_id(uint(8));
+var histoBX: HistB = _bxor_id(uint(8));
 
 proc showBits(name: string, histo: HistB) {
   writeln(name, " =");
@@ -41,6 +43,8 @@ proc main {
   showBits("histoBA", histoBA);
   showBits("histoBO", histoBO);
   showBits("histoBX", histoBX);
+
+  histoBX = _bxor_id(uint(8));
 
   forall d in dataB with (^ reduce histoBX)
   {

--- a/test/parallel/forall/vass/array-reduce-intents2.chpl
+++ b/test/parallel/forall/vass/array-reduce-intents2.chpl
@@ -11,7 +11,8 @@ var dataM: [dataDom] int = [i in 1..n] i % b + 1;
 var dataB: [dataDom] int = 1..n;
 
 type HistM = [1..b] int;
-var histoM, histoP: HistM;
+var histoM: HistM = 1;
+var histoP: HistM = 0;
 
 proc main {
 

--- a/test/parallel/forall/vass/reduce-assign-1.chpl
+++ b/test/parallel/forall/vass/reduce-assign-1.chpl
@@ -11,7 +11,14 @@ proc showBits(name: string, arg: int) {
 
 proc main {
 
-  var xSum, xProd, xMax, xMin, bAnd, bOr, bXor, xUser: int;
+  var xSum = 0,
+      xProd = 1,
+      xMax = min(int),
+      xMin = max(int),
+      bAnd = -1,
+      bOr  = 0,
+      bXor = 0,
+      xUser = 0;
 
   forall a in A with (+ reduce xSum, * reduce xProd,
                       max reduce xMax, min reduce xMin,
@@ -37,7 +44,7 @@ proc main {
   showBits("^ reduce:  ", bXor);
   writeln("user reduce: ", xUser);
 
-  var lAnd, lOr: bool;
+  var lAnd = true, lOr = false;
 
   forall (b1,b2) in zip(B1,B2) with (&& reduce lAnd, || reduce lOr) {
     lAnd reduce= b1;

--- a/test/parallel/forall/vass/ri-1.chpl
+++ b/test/parallel/forall/vass/ri-1.chpl
@@ -45,6 +45,7 @@ proc main {
     xxx = iii * 10 + zzz;
   }
   writeln(xxx);
+  xxx = 0;
   forall jjj in myiter() with (+ reduce xxx, + reduce yyy) {
     xxx += zzz;
     yyy = zzz;

--- a/test/parallel/forall/vass/ri-4-arrdom.chpl
+++ b/test/parallel/forall/vass/ri-4-arrdom.chpl
@@ -69,42 +69,42 @@ proc writeConfig(msg) {
 /////////// testing - domains ///////////
 
 proc domain11test(ri: int) {
-  var red = 5;
+  var red = 11;
   forall (i,j) in D1 with (+ reduce red) {
     red += i + 2*j;
   }
   const result1d = red;
-  check(result1d, 3 * d * sum1(d), ri, "single domain");
+  check(result1d, 11 + 3 * d * sum1(d), ri, "single domain");
 }
 
 proc domain12test(ri: int) {
-  var red1 = 5, red2 = 6;
+  var red1 = 12, red2 = 13;
   forall (i,j) in D1 with (+ reduce red1, + reduce red2) {
     red1 += i;
     red2 += j;
   }
-  check(red1, d * sum1(d), ri, "single domain - red1");
-  check(red2, d * sum1(d), ri, "single domain - red2");
+  check(red1, 12 + d * sum1(d), ri, "single domain - red1");
+  check(red2, 13 + d * sum1(d), ri, "single domain - red2");
 }
 
 proc domain21test(ri: int) {
-  var red = 5;
+  var red = 14;
   forall ((i1,j1),(i2,j2)) in zip(D1,D2) with (+ reduce red) {
     red += i1*2 + j1*3 + i2*4 + j2*5;
   }
   const result1d = red;
-  check(result1d, 5 * d * sum1(d) + 9 * d * sum0(d),
+  check(result1d, 14 + 5 * d * sum1(d) + 9 * d * sum0(d),
         ri, "zippered domains");
 }
 
 proc domain22test(ri: int) {
-  var red1 = 5, red2 = 6;
+  var red1 = 15, red2 = 16;
   forall ((i1,j1),(i2,j2)) in zip(D1,D2) with (+ reduce red1, + reduce red2) {
     red1 += i1*2 + j1*3;
     red2 += i2*4 + j2*5;
   }
-  check(red1, 5 * d * sum1(d), ri, "zippered domains - red1");
-  check(red2, 9 * d * sum0(d), ri, "zippered domains - red2");
+  check(red1, 15 + 5 * d * sum1(d), ri, "zippered domains - red1");
+  check(red2, 16 + 9 * d * sum0(d), ri, "zippered domains - red2");
 }
 
 /////////// testing - arrays ///////////
@@ -117,31 +117,31 @@ proc initArrays() {
 }
 
 proc array1test(ri: int) {
-  var red = 5;
+  var red = 21;
   forall a1 in A1 with (+ reduce red) {
     red += a1;
   }
   const result1d = red;
-  check(result1d, 3 * d * sum1(d), ri, "single array");
+  check(result1d, 21 + 3 * d * sum1(d), ri, "single array");
 }
 
 proc array21test(ri: int) {
-  var red = 5.5;
+  var red = 22.5;
   forall (a1,a2) in zip(A1,A2) with (+ reduce red) {
     red += 2*a1 + 3*a2;
   }
   const result1d = red;
-  check(result1d, 18 * d * sum1(d), ri, "zippered arrays");
+  check(result1d, 22.5 + 18 * d * sum1(d), ri, "zippered arrays");
 }
 
 proc array22test(ri: int) {
-  var red1 = 5, red2 = 6.6;
+  var red1 = 23, red2 = 24.6;
   forall (a1,a2) in zip(A1,A2) with (+ reduce red1, + reduce red2) {
     red1 += a1;
     red2 += a2;
   }
-  check(red1, 3 * d * sum1(d), ri, "zippered arrays - red1");
-  check(red2, 4 * d * sum1(d), ri, "zippered arrays - red2");
+  check(red1, 23   + 3 * d * sum1(d), ri, "zippered arrays - red1");
+  check(red2, 24.6 + 4 * d * sum1(d), ri, "zippered arrays - red2");
 }
 
 /////////// checking ///////////

--- a/test/parallel/forall/vass/ri-5-c.chpl
+++ b/test/parallel/forall/vass/ri-5-c.chpl
@@ -2,7 +2,7 @@
 
 config const n = 10;
 
-var tot: int;
+var tot = 0;
 forall a in 1..n with (+ reduce tot) do
   tot += a;
 
@@ -13,48 +13,50 @@ writeln(tot);
 var D = {1..n};
 var A: [D] int = D;
 var tot1, tot2, tot3: int;
+proc reset() { tot1 = 0; tot2 = 1; tot3 = 0; }
+reset();
 
 forall (a1,a2) in zip(1..n,1..n) with (+ reduce tot1, * reduce tot2) {
   tot1 += a1;
   tot2 *= a2;
 }
-writeln((tot1,tot2));
+writeln((tot1,tot2)); reset();
 
 forall (a1,a2) in zip(1..n,D) with (+ reduce tot1, * reduce tot2) {
   tot1 += a1;
   tot2 *= a2;
 }
-writeln((tot1,tot2));
+writeln((tot1,tot2)); reset();
 
 forall (a1,a2) in zip(1..n,A) with (+ reduce tot1, * reduce tot2) {
   tot1 += a1;
   tot2 *= a2;
 }
-writeln((tot1,tot2));
+writeln((tot1,tot2)); reset();
 
 forall (a1,a2) in zip(D,1..n) with (+ reduce tot1, * reduce tot2) {
   tot1 += a1;
   tot2 *= a2;
 }
-writeln((tot1,tot2));
+writeln((tot1,tot2)); reset();
 
 forall (a1,a2) in zip(A,1..n) with (+ reduce tot1, * reduce tot2) {
   tot1 += a1;
   tot2 *= a2;
 }
-writeln((tot1,tot2));
+writeln((tot1,tot2)); reset();
 
 forall (a1,a2) in zip(A,D) with (+ reduce tot1, * reduce tot2) {
   tot1 += a1;
   tot2 *= a2;
 }
-writeln((tot1,tot2));
+writeln((tot1,tot2)); reset();
 
 forall (a1,a2) in zip(D,A) with (+ reduce tot1, * reduce tot2) {
   tot1 += a1;
   tot2 *= a2;
 }
-writeln((tot1,tot2));
+writeln((tot1,tot2)); reset();
 
 forall (a1,a2,a3) in zip(A,D,1..n)
   with (+ reduce tot1, * reduce tot2, | reduce tot3)
@@ -63,7 +65,7 @@ forall (a1,a2,a3) in zip(A,D,1..n)
   tot2 *= a2;
   tot3 |= a3;
 }
-writeln((tot1,tot2,tot3));
+writeln((tot1,tot2,tot3)); reset();
 
 forall (a1,a2,a3) in zip(D,1..n,A)
   with (+ reduce tot1, * reduce tot2, | reduce tot3)
@@ -72,7 +74,7 @@ forall (a1,a2,a3) in zip(D,1..n,A)
   tot2 *= a2;
   tot3 |= a3;
 }
-writeln((tot1,tot2,tot3));
+writeln((tot1,tot2,tot3)); reset();
 
 forall (a1,a2,a3) in zip(1..n,A,D)
   with (+ reduce tot1, * reduce tot2, | reduce tot3)
@@ -81,4 +83,4 @@ forall (a1,a2,a3) in zip(1..n,A,D)
   tot2 *= a2;
   tot3 |= a3;
 }
-writeln((tot1,tot2,tot3));
+writeln((tot1,tot2,tot3)); reset();

--- a/test/parallel/forall/vass/ri-6-named.chpl
+++ b/test/parallel/forall/vass/ri-6-named.chpl
@@ -27,6 +27,7 @@ proc main {
   writeln("n = ", n);
 
   var maxPos, maxNeg, minPos, minNeg, sumLib, sumUsr: int;
+  maxNeg = min(int); minPos = max(int); // others can start at 0
 
   forall arrElm in ARR with (max reduce maxPos, max reduce maxNeg,
                              min reduce minPos, min reduce minNeg,

--- a/test/parallel/forall/vass/ri-7-initAccum.chpl
+++ b/test/parallel/forall/vass/ri-7-initAccum.chpl
@@ -1,0 +1,40 @@
+// Check that the outer var's initial value is accumulated too.
+
+config const n = 3;
+
+var AAA: [1..n] int = 1..n;
+
+const plusOp = new PlusReduceOp(eltType = int);
+
+var xPlus = [400, 500];
+var xUser = 600;
+var xOp = 700;
+  
+forall aaa in AAA with (
+                        + reduce xPlus,
+                        PlusReduceOp reduce xUser,
+                        plusOp reduce xOp
+                        )
+{
+  xPlus reduce= aaa;
+  xUser reduce= aaa;
+  xOp   reduce= aaa;
+}
+
+writeln("plus:        ", xPlus);
+writeln("user reduce: ", xUser);
+writeln("user op:     ", xOp);
+
+delete plusOp;
+
+class PlusReduceOp: ReduceScanOp {
+  type eltType;
+  var  value: eltType;
+  proc identity         return 0: eltType;
+  proc accumulate(elm)  { value = value + elm; }
+  proc accumulateOntoState(ref state, elm) { state = state + elm; }
+  proc initialAccumulate(elm)  { writef("initialAccumulate(%t)\n", elm); accumulate(elm); }
+  proc combine(other)   { value = value + other.value; }
+  proc generate()       return value;
+  proc clone()          return new PlusReduceOp(eltType=eltType);
+}

--- a/test/parallel/forall/vass/ri-7-initAccum.good
+++ b/test/parallel/forall/vass/ri-7-initAccum.good
@@ -1,0 +1,5 @@
+initialAccumulate(600)
+initialAccumulate(700)
+plus:        406 506
+user reduce: 606
+user op:     706


### PR DESCRIPTION
Up to now, we had discarded the initial value of the outer variable used in a forall loop with a reduce intent. For example:

    var x = 7;
    forall 1..10 with (+ reduce x) {
      x += 1;
    }
    writeln(x);

had produced 10 instead of 17.

Responding to multiple user requests, and as discussed on the internal mailing list, this PR changes the behavior to take the initial value into consideration.

For user-defined reductions, this will be done by calling a method on the reduction class instance that is used in the forall loop. This call will be made before invoking the parallel iterator. The call will be:

    globalOp.initialAccumulate(outerVariable);

if it is available, otherwise it will be:

    globalOp.accumulate(outerVariable);

It is a compilation error if neither is available or applicable.

In the above example, "outerVariable" is "x".

I also adjusted the tests that relied on the old behavior.

Resolves #6738.