### PR TITLE
Add a note on rebasing to ContributorInfo

### DIFF
--- a/doc/rst/developer/bestPractices/ContributorInfo.rst
+++ b/doc/rst/developer/bestPractices/ContributorInfo.rst
@@ -440,7 +440,7 @@ If you want to understand the changes that occurred upstream, see
 How to modify git history
 +++++++++++++++++++++++++
 
-The following commands are **may cause problems** if the changes they overwrite
+The following commands **may cause problems** if the changes they overwrite
 have been pulled by other repositories.
 
 Fixing a commit message:
@@ -449,7 +449,7 @@ Fixing a commit message:
 
     git commit --amend
 
-Un-do the last commit (leaving changed files in your working directory)
+Un-do the last commit (leaving changed files in your working directory):
 
 .. code-block:: bash
 

--- a/doc/rst/developer/bestPractices/ContributorInfo.rst
+++ b/doc/rst/developer/bestPractices/ContributorInfo.rst
@@ -455,6 +455,12 @@ Un-do the last commit (leaving changed files in your working directory)
 
     git reset --soft HEAD~1
 
+Reapplying changes from the current branch onto an updated version of master:
+
+.. code-block:: bash
+
+    git rebase master
+
 Pushing such changes to your repository (again, **this may cause problems** if
 other repositories have pulled the changes):
 


### PR DESCRIPTION
Adds it under "How To Modify Git History", the section for things that
are useful, but may cause problems if the changes have already been
pulled.

Also, fix a couple of things I noticed while here - One of the sections
was missing a colon, and one of the sentences had "commands are may
cause", instead of just "commands may cause"

Resolves #6748 