### PR TITLE
Adjust string pass/return test

### DIFF
--- a/test/types/string/psahabu/perf/arguments.chpl
+++ b/test/types/string/psahabu/perf/arguments.chpl
@@ -3,34 +3,64 @@ use Time;
 config const n = 100000000;
 config const timing = true;
 
-// passing
 var pass = "passing a string";
 var acc = 0;
-var tPassing: Timer;
-if timing then tPassing.start();
-for i in 1..n {
-  acc += receive(pass);
+
+test();
+
+// passing
+proc testPassing():Timer {
+  var tPassing: Timer;
+  if timing then tPassing.start();
+  for i in 1..n {
+    acc += receive(pass);
+  }
+  if timing then tPassing.stop();
+  return tPassing;
 }
-if timing then tPassing.stop();
 
 // returning
-var tReturning: Timer;
-if timing then tReturning.start();
-var keepAlive: int;
-for i in 1..n {
-  var s = send(i);
-  keepAlive += s.len;
+proc testReturning():Timer {
+  var tReturning: Timer;
+  if timing then tReturning.start();
+  var keepAlive: int;
+  for i in 1..n {
+    var s = send(i);
+    keepAlive += s.len;
+  }
+  if timing then tReturning.stop();
+  return tReturning;
 }
-if timing then tReturning.stop();
-
-if timing {
-  writeln("passing: ", tPassing.elapsed());
-  writeln("returning: ", tReturning.elapsed());
+proc testReturningItoa():Timer {
+  var tReturning: Timer;
+  if timing then tReturning.start();
+  var keepAlive: int;
+  for i in 1..(n/10) {
+    var s = send_itoa(i);
+    keepAlive += s.len;
+  }
+  if timing then tReturning.stop();
+  return tReturning;
 }
-if acc == n * pass.len then
-  writeln("SUCCESS");
 
-// procs
+
+proc test() {
+  var tPassing = testPassing();
+  var tReturning = testReturning();
+  var tReturningItoa = testReturningItoa();
+
+  if timing {
+    writeln("passing: ", tPassing.elapsed());
+    writeln("returning: ", tReturning.elapsed());
+    writeln("returning itoa: ", tReturningItoa.elapsed());
+  }
+
+  // acc set in testPassing
+  if acc == n * pass.len then
+    writeln("SUCCESS");
+}
+
+
 proc receive(test: string) {
   return test.len;
 }
@@ -44,4 +74,8 @@ proc send(l: int): string {
   } else {
     return "string";
   }
+}
+
+proc send_itoa(l: int): string {
+  return l:string;
 }

--- a/test/types/string/psahabu/perf/arguments.chpl
+++ b/test/types/string/psahabu/perf/arguments.chpl
@@ -11,35 +11,35 @@ test();
 // passing
 proc testPassing():Timer {
   var tPassing: Timer;
-  if timing then tPassing.start();
+  tPassing.start();
   for i in 1..n {
     acc += receive(pass);
   }
-  if timing then tPassing.stop();
+  tPassing.stop();
   return tPassing;
 }
 
 // returning
 proc testReturning():Timer {
   var tReturning: Timer;
-  if timing then tReturning.start();
+  tReturning.start();
   var keepAlive: int;
   for i in 1..n {
     var s = send(i);
     keepAlive += s.len;
   }
-  if timing then tReturning.stop();
+  tReturning.stop();
   return tReturning;
 }
 proc testReturningItoa():Timer {
   var tReturning: Timer;
-  if timing then tReturning.start();
+  tReturning.start();
   var keepAlive: int;
   for i in 1..(n/10) {
     var s = send_itoa(i);
     keepAlive += s.len;
   }
-  if timing then tReturning.stop();
+  tReturning.stop();
   return tReturning;
 }
 

--- a/test/types/string/psahabu/perf/arguments.graph
+++ b/test/types/string/psahabu/perf/arguments.graph
@@ -1,5 +1,5 @@
-perfkeys: passing:, returning:
+perfkeys: passing:, returning:, returning itoa:
 repeat-files: arguments.dat
-graphkeys: pass to proc, return from proc
+graphkeys: pass to proc, return from proc, return itoa from proc
 ylabel: Time (seconds)
 graphtitle: Passing and returning strings

--- a/test/types/string/psahabu/perf/arguments.perfkeys
+++ b/test/types/string/psahabu/perf/arguments.perfkeys
@@ -1,3 +1,4 @@
 passing:
 returning:
+returning itoa:
 verify:-1: SUCCESS


### PR DESCRIPTION
It looks like this test relies on some extreme amounts of optimization
from GCC that only reliably apply when the tested loops are in functions.
PR #7019 seemed to slow down the returning strings path, but it seems
that the reason was that a GCC optimization wasn't as effective with the
error-handling changes, due to the code pattern in the (seemingly
unrelated to the loops) waitEndCount. Moving the loops to their own
function lets GCC avoid confusion.

Additionally, this PR adds a 3rd line to the graph to measure the time
for constructing and returning a string created on the heap, since
strings referring to global constant strings behave slightly differently.

Reviewed by @psahabu - thanks!