### PR TITLE
Fix bug with recursive/nested makes

### DIFF
--- a/runtime/etc/Makefile.exe
+++ b/runtime/etc/Makefile.exe
@@ -19,6 +19,9 @@
 # Makefile.exe
 #
 
+# Clear this variable, otherwise CHPL_MAKE_ALL_VARS will be ignored
+CHPL_MAKE_SETTINGS_NO_NEWLINES=
+
 include $(CHPL_MAKE_HOME)/runtime/etc/Makefile.include
 
 all: $(TMPBINNAME)


### PR DESCRIPTION
This commit fixes a bug where CHPL_MAKE_ALL_VARS would be ignored if
`chpl` was invoked from a make session that included
$CHPL_HOME/make/Makefile.base. This could lead to the executable being
built with the wrong runtime.

For example, consider the following Makefile:
```
CHPL_MAKE_HOME=$(CHPL_HOME)
include $(CHPL_MAKE_HOME)/make/Makefile.base

all:
	CHPL_COMM=none chpl hello.chpl
```

Let's also say that we only have a gasnet build of the runtime (i.e.
no build for CHPL_COMM=none).

On linux, invoking 'make' will result in a successful build of hello.chpl
despite the lack of CHPL_COMM=none support in the runtime.

CHPL_MAKE_SETTINGS_NO_NEWLINES is set by the top-level make and will
use the current environment when invoking printchplenv. This locks in
paths for CHPL_COMM=gasnet. When the 'chpl' compiler invokes 'make',
Makefile.base sees that CHPL_MAKE_SETTINGS_NO_NEWLINES is already set
and thinks it does not need to be computed again. So despite specifying
CHPL_COMM=none, we build with CHPL_COMM=gasnet (silently!).

By unsetting CHPL_MAKE_SETTINGS_NO_NEWLINES in Makefile.exe we can force
that variable to be computed again using the CHPL_MAKE_ALL_VARS variable
emitted by the compiler.