### PR TITLE
Improve mason build process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,8 +134,7 @@ chplvis: compiler third-party-fltk FORCE
 	cd tools/chplvis && $(MAKE) install
 
 mason: compiler chpldoc FORCE
-	cd tools/mason && $(MAKE)
-	cd tools/mason && $(MAKE) install
+	cd tools/mason && $(MAKE) && $(MAKE) install
 
 
 third-party-fltk: FORCE

--- a/doc/rst/tools/mason/mason.rst
+++ b/doc/rst/tools/mason/mason.rst
@@ -20,12 +20,9 @@ In ``$CHPL_HOME`` run the following:
    make mason
 
 
-This will create the hidden ``.mason/`` directory in ``MASON_HOME``, which
-defaults to your ``$HOME`` if unset. It builds the mason binary so that the 
-command line interface can be used. The mason registry is also downloaded from
-github so that a user can start to rely on mason to specify project dependencies.
-This installs mason in the same place as the chapel compiler (``chpl``)
-so that mason can be used anywhere in the user's file system.
+It builds the mason binary so that the command line interface can be used.
+This installs mason in the same place as the chapel compiler (``chpl``) so that
+mason can be used anywhere in the user's file system.
 
 
 To remove mason, change directory to ``$CHPL_HOME/tools/mason`` and run:
@@ -35,8 +32,7 @@ To remove mason, change directory to ``$CHPL_HOME/tools/mason`` and run:
    make clean
 
       
-To remove mason and the mason-registry change directory to ``$CHPL_HOME/tools/mason``
-and run:
+To remove mason change directory to ``$CHPL_HOME/tools/mason`` and run:
 
 .. code-block:: sh
 
@@ -182,6 +178,9 @@ Mason-Registry
 The initial mason registry is a GitHub repository containing a list of versioned manifest files.
 
 `Mason-Registry <https://github.com/chapel-lang/mason-registry>`_.
+
+The registry will be downloaded to ``$MASON_HOME/registry`` by ``mason update``
+if a registry at that location does not already exist.
 
 The registry consists of the following hierarchy:
 

--- a/tools/mason/Makefile
+++ b/tools/mason/Makefile
@@ -52,7 +52,7 @@ endif
 	@echo "Registry - $(registry)"
 	@git -C $(MASON_HOME)/.mason/ clone $(REGISTRY) registry
 	@echo "Building Mason..."
-	@chpl mason.chpl
+	@./buildMason
 
 install: mason
 ifneq ($(wildcard $(link)),)
@@ -66,7 +66,7 @@ endif
 
 update:
 	@echo "Re-building Mason..."
-	@chpl mason.chpl
+	@./buildMason
 
 clean:
 	@echo "Removing Mason..."

--- a/tools/mason/Makefile
+++ b/tools/mason/Makefile
@@ -47,7 +47,7 @@ mason: $(MASON_SOURCES)
         exit 1;\
 	fi;
 	@echo "Building Mason..."
-	@./buildMason
+	@chplBinDir=$(bdir) ./buildMason
 
 install: mason
 ifneq ($(wildcard $(link)),)
@@ -61,7 +61,7 @@ endif
 
 update:
 	@echo "Re-building Mason..."
-	@./buildMason
+	@chplBinDir=$(bdir) ./buildMason
 
 clean:
 	@echo "Removing Mason..."

--- a/tools/mason/Makefile
+++ b/tools/mason/Makefile
@@ -27,6 +27,8 @@ endif
 
 include $(CHPL_MAKE_HOME)/make/Makefile.base
 
+unexport CHPL_MAKE_SETTINGS_NO_NEWLINES
+
 bdir=$(CHPL_BIN_DIR)
 link=$(bdir)/mason
 

--- a/tools/mason/Makefile
+++ b/tools/mason/Makefile
@@ -44,13 +44,6 @@ mason: $(MASON_SOURCES)
         echo "CHPL_REGEXP=re2 is required to build mason"; \
         exit 1;\
 	fi;
-	@mkdir -p $(MASON_HOME)/.mason/src
-ifneq ($(wildcard $(registry)),)
-	@echo "Removing old registry..."
-	@rm -rf $(MASON_HOME)/.mason/registry
-endif
-	@echo "Registry - $(registry)"
-	@git -C $(MASON_HOME)/.mason/ clone $(REGISTRY) registry
 	@echo "Building Mason..."
 	@./buildMason
 

--- a/tools/mason/Makefile
+++ b/tools/mason/Makefile
@@ -72,5 +72,3 @@ endif
 
 
 clobber: clean
-	@echo "Removing Registry..."
-	rm -rf $(MASON_HOME)/.mason/registry

--- a/tools/mason/MasonBuild.chpl
+++ b/tools/mason/MasonBuild.chpl
@@ -178,19 +178,20 @@ proc genSourceList(lockFile: Toml) {
 /* Clones the git repository of each dependency into
    the src code dependency pool */
 proc getSrcCode(sourceList: [?d] 3*string, show) {
-  var destination = MASON_HOME +'/.mason/src/';
+  var baseDir = MASON_HOME +'/.mason/src/';
   forall (srcURL, name, version) in sourceList {
     const nameVers = name + "-" + version;
+    const destination = baseDir + nameVers;
     if !depExists(nameVers) {
       writeln("Downloading dependency: " + nameVers);
-      var getDependency = "git clone -qn "+ srcURL + ' ' + destination + nameVers+'/';
-      var checkout = "git -C "+ destination + nameVers + " checkout -q v" + version;
+      var getDependency = "git clone -qn "+ srcURL + ' ' + destination +'/';
+      var checkout = "git checkout -q v" + version;
       if show {
-	getDependency = "git clone -n " + srcURL + ' ' + destination + nameVers + '/';
-	checkout = "git -C "+ destination + nameVers + " checkout v" + version;
+	getDependency = "git clone -n " + srcURL + ' ' + destination + '/';
+	checkout = "git checkout v" + version;
       }
       runCommand(getDependency);
-      runCommand(checkout);
+      gitC(destination, checkout);
     }
   }
 }

--- a/tools/mason/MasonUpdate.chpl
+++ b/tools/mason/MasonUpdate.chpl
@@ -105,8 +105,8 @@ proc updateRegistry(tf: string) {
   }
   // Registry has moved or does not exist
   else {
-    mkdir(masonHome + '/.mason');
-    mkdir(masonHome + '/.mason/src');
+    mkdir(masonHome + '/.mason', parents=true);
+    mkdir(masonHome + '/.mason/src', parents=true);
     const localRegistry = getRegistryDir();
     mkdir(localRegistry, parents=true);
     const registry = "https://github.com/chapel-lang/mason-registry";

--- a/tools/mason/MasonUpdate.chpl
+++ b/tools/mason/MasonUpdate.chpl
@@ -99,9 +99,9 @@ proc updateRegistry(tf: string) {
   const masonHome = MASON_HOME;
   const registryHome = getRegistryDir();
   if isDir(registryHome) {
-    var pullRegistry = 'git -C ' + registryHome + '/ pull -q origin master';
+    var pullRegistry = 'git pull -q origin master';
     if tf == "Mason.toml" then writeln("Updating mason-registry");
-    runCommand(pullRegistry);
+    gitC(registryHome, pullRegistry);
   }
   // Registry has moved or does not exist
   else {
@@ -110,9 +110,9 @@ proc updateRegistry(tf: string) {
     const localRegistry = getRegistryDir();
     mkdir(localRegistry, parents=true);
     const registry = "https://github.com/chapel-lang/mason-registry";
-    const cloneRegistry = 'git -C ' + localRegistry + ' clone -q ' + registry + ' .';
+    const cloneRegistry = 'git clone -q ' + registry + ' .';
     writeln('Could not find Registry...cloning registry...');
-    runCommand(cloneRegistry);
+    gitC(localRegistry, cloneRegistry);
   }
 }
 

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -174,3 +174,12 @@ proc getChapelVersionStr() {
   return chplVersion;
 }
 
+proc gitC(newDir, command) {
+  const oldDir = here.cwd();
+  here.chdir(newDir);
+
+  runCommand(command);
+
+  here.chdir(oldDir);
+}
+

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -75,18 +75,18 @@ proc depExists(dependency: string) {
 
 proc MASON_HOME: string {
   // possible locations
-  var masonHome = getEnv("MASON_HOME");
-  var home = getEnv('HOME');
-  if masonHome == '' {
-    if isDir(home + '/.mason') then
-      return home;
-    else {
-      writeln("Mason could not find MASON_HOME");
-      writeln("Consider setting MASON_HOME in your .bashrc");
-      halt();
-    }
+  const envHome   = getEnv("MASON_HOME");
+  const home      = getEnv('HOME');
+  const masonHome = if envHome != "" then envHome else home;
+
+  const dotMason = masonHome + "/.mason";
+
+  if isDir(dotMason) == false {
+    writeln(dotMason + " not found, creating...");
+    mkdir(dotMason);
   }
-  else return masonHome;
+
+  return masonHome;
 }
 
 record VersionInfo {

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -83,7 +83,7 @@ proc MASON_HOME: string {
 
   if isDir(dotMason) == false {
     writeln(dotMason + " not found, creating...");
-    mkdir(dotMason);
+    mkdir(dotMason, parents=true);
   }
 
   return masonHome;

--- a/tools/mason/README.rst
+++ b/tools/mason/README.rst
@@ -5,7 +5,7 @@ mason
 
 Mason is Chapel's package manager
 
-For even more detail about mason and about submitting a package see -> doc/{rst,html}/tools/mason/mason.{rst,html}
+For more detail about mason and about submitting a package see -> doc/{rst,html}/tools/mason/mason.{rst,html}
 
 
 
@@ -20,13 +20,13 @@ In the mason directory found in ``$CHPL_HOME/tools/mason`` run the following:
    make
    make install
 
-This will create the hidden ``.mason/`` directory in ``MASON_HOME``, which
-defaults to your ``$HOME`` if unset. It builds the mason binary so that the
-command line interface can be used. The mason registry is also downloaded from
-github so that a user can start to rely on mason to specify project
-dependencies. This installs mason in the same place as the chapel compiler (``chpl``)
-so that mason can be used anywhere in the user's file system.
+It builds the mason binary so that the command line interface can be used. This
+installs mason in the same place as the chapel compiler (``chpl``) so that
+mason can be used anywhere in the user's file system.
 
+
+The ``mason update`` command will download the registry to ``$MASON_HOME/registry``
+if it there is not already a registry at that location.
 
 
 To remove mason, change directory to ``$CHPL_HOME/tools/mason`` and run:
@@ -35,10 +35,3 @@ To remove mason, change directory to ``$CHPL_HOME/tools/mason`` and run:
 
    make clean
 
-
-To remove mason and the mason-registry change directory to ``$CHPL_HOME/tools/mason``
-and run:
-
-.. code-block:: sh
-
-   make clobber

--- a/tools/mason/buildMason
+++ b/tools/mason/buildMason
@@ -8,7 +8,7 @@ if command -v module > /dev/null 2>&1 ; then
   module unload $(module list 2>&1 | \grep "craype-hugepage" | sed -e"s:[0-9]*)::g")
 fi
 
-if ! chpl mason.chpl ; then
+if ! $chplBinDir/chpl mason.chpl ; then
   echo
   echo "Error building mason. Check that you have built a runtime configuration that supports:
   CHPL_COMM=none

--- a/tools/mason/buildMason
+++ b/tools/mason/buildMason
@@ -1,0 +1,18 @@
+#!/usr/bin/env sh
+
+export CHPL_COMM=none
+export CHPL_LAUNCHER=none
+
+if command -v module > /dev/null 2>&1 ; then
+  echo "Unloading hugepages..."
+  module unload $(module list 2>&1 | \grep "craype-hugepage" | sed -e"s:[0-9]*)::g")
+fi
+
+if ! chpl mason.chpl ; then
+  echo
+  echo "Error building mason. Check that you have built a runtime configuration that supports:
+  CHPL_COMM=none
+  CHPL_LAUNCHER=none
+  CHPL_REGEXP=re2"
+  exit 1;
+fi


### PR DESCRIPTION
This commit updates mason's Makefile to only build mason with:
CHPL_COMM=none
CHPL_LAUNCHER=none
CHPL_REGEXP=re2

It also unloads hugepages if the 'module' command is available. This is an attempt to detect that we're on a Cray, in which case we don't want or need hugepages.

Instead of using 'git -C', use ``chdir`` instead in order to be compatible with older versions of git.

$MASON_HOME/.mason will now be created on the first call to 'mason update' instead of at installation time.