### PR TITLE
LinearAlgebra.Sparse

### DIFF
--- a/modules/packages/BLAS.chpl
+++ b/modules/packages/BLAS.chpl
@@ -2070,8 +2070,8 @@ module BLAS {
 
       :returns: Scalar value of dot product
   */
-  proc dot(X: [?xD]?eltType,  Y: [?yD] eltType, incY: c_int = 1, incX: c_int = 1):eltType
-  where xD: domain(1) && yD: domain(1) {
+  proc dot(X: [?xD]?eltType,  Y: [?yD] eltType, incY: c_int = 1, incX: c_int = 1) : eltType
+  where xD.rank == 1 && yD.rank == 1 {
 
     const N = xD.size: c_int;
 

--- a/modules/packages/BLAS.chpl
+++ b/modules/packages/BLAS.chpl
@@ -2070,10 +2070,10 @@ module BLAS {
 
       :returns: Scalar value of dot product
   */
-  proc dot(X: [?D]?eltType,  Y: [D]eltType, incY: c_int = 1, incX: c_int = 1):eltType
-  where D.rank == 1 {
+  proc dot(X: [?xD]?eltType,  Y: [?yD] eltType, incY: c_int = 1, incX: c_int = 1):eltType
+  where xD: domain(1) && yD: domain(1) {
 
-    const N = D.size: c_int;
+    const N = xD.size: c_int;
 
     select eltType {
       when real(32) do{

--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -869,13 +869,13 @@ Sparse Linear Algebra Interface
 -------------------------------
 
 ``LinearAlgebra.Sparse`` follows the same conventions and interface choices
- as the parent module, ``LinearAlgebra``, with few exceptions. These
- exceptions are detailed below.
+as the parent module, ``LinearAlgebra``, with few exceptions. These
+exceptions are detailed below.
 
 
 **Sparse Domains**
 
-In Chapel, implicit changes to the index set of a sparse array must be made
+In Chapel, changes to the index set of a sparse array must be made
 directly on the sparse domain. When working with sparse arrays that will
 require index modification, it is necessary to maintain access to their sparse
 domains as well. As a result of this, the sparse linear algebra interface
@@ -893,7 +893,7 @@ A common usage of this interface might look like this:
   // The above is equivalent to:
   // var A: [D] int;
 
-  // Add nonzero indices to the sparse domain along the diagonal
+  // Add indices to the sparse domain along the diagonal
   D += (0,0);
   D += (1,1);
   D += (2,2);
@@ -987,7 +987,11 @@ module Sparse {
 
   /* Return a CSR matrix with domain and values of ``A``
 
-    ``A`` can be a dense or sparse matrix.
+    If ``A`` is dense, only the indices holding nonzero elements are added
+    to the sparse matrix returned.
+
+    If ``A`` is sparse (CSR), the returned sparse matrix will be a copy of ``A``
+    casted to ``eltType``
    */
   proc CSRMatrix(A: [?Dom] ?Atype, type eltType=Atype) where Dom.rank == 2 && isCSArr(A) {
     var M: [Dom] eltType = A: eltType;
@@ -1294,7 +1298,7 @@ module Sparse {
   /* Matrix division (solve) */
   pragma "no doc"
   proc _array.div(A) where isCSArr(this) && isCSArr(A) {
-    halt("Matrix division not yet supported for sparse matrices */");
+    compilerError("Matrix division not yet supported for sparse matrices */");
   }
 
   //

--- a/test/modules/packages/linearalgebra/correctness/correctness.chpl
+++ b/test/modules/packages/linearalgebra/correctness/correctness.chpl
@@ -485,10 +485,15 @@ config const correctness = true;
 
   var   Dom: sparse subdomain(parentDom) dmapped CS(),
         Dom2: sparse subdomain(parentDom2) dmapped CS(),
-        IDom: sparse subdomain (parentDom) dmapped CS();
+        IDom: sparse subdomain (parentDom) dmapped CS(),
+        tDom: sparse subdomain (parentDom2) dmapped CS(),
+        tDomT: sparse subdomain (parentDom2) dmapped CS();
+
 
   // Identity sparse domain
   IDom += [(0,0), (1,1), (2,2)];
+  tDom += [(0,0), (1,0), (2,0), (3,0)];
+  tDomT += [(0,0), (0,1), (0,2), (0,3)];
 
 
   /* Rows */
@@ -580,14 +585,25 @@ config const correctness = true;
   /* dot - matrix-scalar */
   {
     var A: [IDom] real = 1;
-    var B: [IDom] real = dot(A, 2);
-    var C: [IDom] real = dot(2, A);
+    var B = dot(A, 2);
+    var C = dot(2, A);
     assertEqual(A.domain, B.domain, "dot(A, 2)");
     assertEqual(A.domain, C.domain, "dot(2, A)");
     assertEqual(B, C, "matrix-scalar");
     var A2: A.type = 2*A;
     assertEqual(A2, B, "dot(A, 2)");
     assertEqual(A2, C, "dot(2, A)");
+  }
+
+  /* transpose */
+  {
+    var A: [tDom] int = 1;
+    var B = transpose(A);
+
+    assertEqual(B.domain, tDomT, "transpose(A)");
+    for i in A.domain.dim(1) {
+      assertEqual(A[i,0], B[0, i], "transpose(A) values");
+    }
   }
 
 }

--- a/test/modules/packages/linearalgebra/correctness/correctness.chpl
+++ b/test/modules/packages/linearalgebra/correctness/correctness.chpl
@@ -473,6 +473,125 @@ config const correctness = true;
   assertFalse(isSquare(Rect), "isSquare(Rect)");
 }
 
+//
+// LinearAlgebra.Sparse
+//
+
+{
+  use LinearAlgebra.Sparse;
+
+  const parentDom = {0..#3, 0..#3},
+        parentDom2 = {0..#4, 0..#6};
+
+  var   Dom: sparse subdomain(parentDom) dmapped CS(),
+        Dom2: sparse subdomain(parentDom2) dmapped CS(),
+        IDom: sparse subdomain (parentDom) dmapped CS();
+
+  // Identity sparse domain
+  IDom += [(0,0), (1,1), (2,2)];
+
+
+  /* Rows */
+  {
+    var D = CSRDomain(3);
+    assertEqual(D, Dom, "CSRDomain(3)");
+  }
+
+  /* Dimensions */
+  {
+    var D = CSRDomain(3, 3);
+    assertEqual(D, Dom, "CSRDomain(3, 3)");
+  }
+
+  /* Range */
+  {
+    var D = CSRDomain(0..#3);
+    assertEqual(D, Dom, "CSRDomain(0..#3)");
+  }
+
+  /* Ranges */
+  {
+    var D = CSRDomain(0..#4, 0..#6);
+    assertEqual(D, Dom2, "CSRDomain(0..#4, 0..#6)");
+  }
+
+  /* Domain - CSR */
+  {
+    var D = CSRDomain(Dom);
+    assertEqual(D, Dom, "CSRDomain(Dom)");
+  }
+
+  /* Domain - Dense */
+  {
+    var D = CSRDomain(parentDom);
+    assertEqual(D, Dom, "CSRDomain(parentDom)");
+  }
+
+  /* Array - Dense -> CSR */
+  {
+    var I = eye(3,3);
+    var A = CSRMatrix(I);
+    assertEqual(A.domain, IDom, "CSRMatrix(I)");
+  }
+
+  /* Array - CSR -> CSR */
+  {
+    var A: [Dom] real;
+    var M = CSRMatrix(A);
+    assertEqual(M.domain, Dom, "CSRDomain(A)");
+  }
+
+  /* Array - CSR real -> CSR int */
+  {
+    var A: [Dom] real;
+    var M = CSRMatrix(A, eltType=int);
+    assertEqual(M.domain, Dom, "CSRMatrix(A)");
+    assertTrue(isIntType(M.eltType), "CSRMatrix(A, eltType=int)");
+  }
+
+  // TODO: more interesting cases for dot..
+
+  /* dot - matrix-matrix */
+  {
+    var A: [Dom] real;
+    var I: [IDom] real;
+    var AI = dot(A, I);
+    assertEqual(AI, A, "dot(A, I)");
+  }
+
+  /* dot - matrix-vector */
+  {
+    var A: [IDom] real = 1;
+    var v: [0..#3] real = 2;
+    var Av = dot(A, v);
+    var A2 = 2*A;
+    assertEqual(Av, A2);
+  }
+
+  /* dot - vector-matrix */
+  {
+    var A: [IDom] real = 1;
+    var v: [0..#3] real = 2;
+    var Av = dot(v, A);
+    var A2 = 2*A;
+    assertEqual(Av, A2);
+  }
+
+  /* dot - matrix-scalar */
+  {
+    var A: [IDom] real = 1;
+    var B: [IDom] real = dot(A, 2);
+    var C: [IDom] real = dot(2, A);
+    assertEqual(A.domain, B.domain, "dot(A, 2)");
+    assertEqual(A.domain, C.domain, "dot(2, A)");
+    assertEqual(B, C, "matrix-scalar");
+    var A2: A.type = 2*A;
+    assertEqual(A2, B, "dot(A, 2)");
+    assertEqual(A2, C, "dot(2, A)");
+  }
+
+}
+
 
 //
 // Helpers

--- a/test/modules/packages/linearalgebra/correctness/correctness.chpl
+++ b/test/modules/packages/linearalgebra/correctness/correctness.chpl
@@ -532,6 +532,11 @@ config const correctness = true;
     assertEqual(D, Dom, "CSRDomain(parentDom)");
   }
 
+  // TODO:
+  // CSRDomain(dom)
+  // CSRMatrix(dom) (dense/sparse)
+
+
   /* Array - Dense -> CSR */
   {
     var I = eye(3,3);


### PR DESCRIPTION
This PR adds a `LinearAlgebra.Sparse` submodule for sparse linear algebra support.

### Features

This submodule supports the following functionality for `CS()` (CSR) arrays and domains:

- `CSRDomain` 
  - creation of `CS()` sparse domains
- `CSRMatrix` 
  - creation of `CS()` sparse arrays
- `dot`
- `transpose`
- `plus`
- `minus`
- `times`
- `elementDiv`

### Testing

- [x] `start_test test/modules/packages/linearalgebra/`