### PR TITLE
Add skipif files to skip Crypto tests on non-linux64 and if OpenSSL is old

### DIFF
--- a/test/modules/packages/Crypto/saru.skipif
+++ b/test/modules/packages/Crypto/saru.skipif
@@ -1,0 +1,2 @@
+# skip non-linux64 platforms for now
+CHPL_TARGET_PLATFORM != linux64

--- a/test/modules/packages/Crypto/saru/aes/aesTest1.skipif
+++ b/test/modules/packages/Crypto/saru/aes/aesTest1.skipif
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+reqMajor=1
+reqMinor=0
+reqPatch=1
+
+version=`openssl version | sed -e 's/^OpenSSL \([^ ]*\) .*$/\1/'`
+major=`echo $version | sed -e 's/\..*$//'`
+minor=`echo $version | sed -e 's/.*\.\([^\.]*\)\..*$/\1/'`
+patch=`echo $version | sed -e 's/.*\.//'`
+
+# Skip if the OpenSSL version is too old
+if [[ $major < $reqMajor ]] ; then
+  echo True
+elif [[ $minor < $reqMinor ]] ; then
+  echo True
+elif [[ $patch < $reqPatch ]] ; then
+  echo True
+else
+  echo False
+fi

--- a/test/modules/packages/Crypto/saru/kdf/pbkdf2-1.skipif
+++ b/test/modules/packages/Crypto/saru/kdf/pbkdf2-1.skipif
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+reqMajor=1
+reqMinor=0
+reqPatch=1
+
+version=`openssl version | sed -e 's/^OpenSSL \([^ ]*\) .*$/\1/'`
+major=`echo $version | sed -e 's/\..*$//'`
+minor=`echo $version | sed -e 's/.*\.\([^\.]*\)\..*$/\1/'`
+patch=`echo $version | sed -e 's/.*\.//'`
+
+# Skip if the OpenSSL version is too old
+if [[ $major < $reqMajor ]] ; then
+  echo True
+elif [[ $minor < $reqMinor ]] ; then
+  echo True
+elif [[ $patch < $reqPatch ]] ; then
+  echo True
+else
+  echo False
+fi

--- a/test/modules/packages/Crypto/saru/kdf/pbkdf2-2.skipif
+++ b/test/modules/packages/Crypto/saru/kdf/pbkdf2-2.skipif
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+reqMajor=1
+reqMinor=0
+reqPatch=1
+
+version=`openssl version | sed -e 's/^OpenSSL \([^ ]*\) .*$/\1/'`
+major=`echo $version | sed -e 's/\..*$//'`
+minor=`echo $version | sed -e 's/.*\.\([^\.]*\)\..*$/\1/'`
+patch=`echo $version | sed -e 's/.*\.//'`
+
+# Skip if the OpenSSL version is too old
+if [[ $major < $reqMajor ]] ; then
+  echo True
+elif [[ $minor < $reqMinor ]] ; then
+  echo True
+elif [[ $patch < $reqPatch ]] ; then
+  echo True
+else
+  echo False
+fi


### PR DESCRIPTION
Some of the Crypto tests require OpenSSL 1.0.1 or newer, so skip them if
it isn't available.

OpenSSL isn't installed by default on most non-Linux platforms, so skip the
tests on non-linux64.