### PR TITLE
Require deinit functions to have parentheses.

### DIFF
--- a/compiler/passes/cleanup.cpp
+++ b/compiler/passes/cleanup.cpp
@@ -48,8 +48,6 @@ static void applyAtomicTypeToPrimaryMethod(TypeSymbol* ts, FnSymbol* fn);
 
 static void changeCastInWhere(FnSymbol* fn);
 
-static void addParensToDeinitFns(FnSymbol* fn);
-
 static void fixupVoidReturnFn(FnSymbol* fn);
 
 void cleanup() {
@@ -110,7 +108,6 @@ static void cleanup(ModuleSymbol* module) {
         }
 
         changeCastInWhere(fn);
-        addParensToDeinitFns(fn);
         fixupVoidReturnFn(fn);
       }
     }
@@ -392,18 +389,5 @@ static void changeCastInWhere(FnSymbol* fn) {
         }
       }
     }
-  }
-}
-
-/************************************* | **************************************
-*                                                                             *
-* Make paren-less decls act as paren-ful.                                     *
-* Otherwise "arg.deinit()" in proc chpl__delete(arg) would not resolve.       *
-*                                                                             *
-************************************** | *************************************/
-
-static void addParensToDeinitFns(FnSymbol* fn) {
-  if (fn->hasFlag(FLAG_DESTRUCTOR)) {
-    fn->removeFlag(FLAG_NO_PARENS);
   }
 }

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -228,9 +228,13 @@ void normalize() {
                     "destructor name must match class/record name "
                     "or deinit()");
 
-        } else {
-          fn->name = astrDeinit;
         }
+
+        if (!notDeinit && fn->hasFlag(FLAG_NO_PARENS)) {
+          USR_FATAL_CONT(fn, "deinitializers must have parentheses");
+        }
+
+        fn->name = astrDeinit;
       }
 
     // make sure methods don't attempt to overload operators
@@ -337,6 +341,8 @@ static void handleModuleDeinitFn(ModuleSymbol* mod) {
   if (!deinitFn)
     // We could alternatively create an empty function here.
     return;
+  if (deinitFn->hasFlag(FLAG_NO_PARENS))
+    USR_FATAL_CONT(deinitFn, "module deinit() functions must have parentheses");
 
   deinitFn->name = astr("chpl__deinit_", mod->name);
   deinitFn->removeFlag(FLAG_DESTRUCTOR);

--- a/test/classes/deinitializers/deinitParenlessError.chpl
+++ b/test/classes/deinitializers/deinitParenlessError.chpl
@@ -1,0 +1,8 @@
+
+class C {
+  var x: int;
+  proc deinit { writeln("C.deinit"); }
+}
+
+var c = new C();
+delete c;

--- a/test/classes/deinitializers/deinitParenlessError.good
+++ b/test/classes/deinitializers/deinitParenlessError.good
@@ -1,0 +1,1 @@
+deinitParenlessError.chpl:4: error: deinitializers must have parentheses

--- a/test/modules/vass/deinit-parenless-error.chpl
+++ b/test/modules/vass/deinit-parenless-error.chpl
@@ -1,0 +1,6 @@
+
+proc deinit {
+  writeln("module.deinit");
+}
+
+writeln("hi");

--- a/test/modules/vass/deinit-parenless-error.good
+++ b/test/modules/vass/deinit-parenless-error.good
@@ -1,0 +1,1 @@
+deinit-parenless-error.chpl:2: error: module deinit() functions must have parentheses

--- a/test/studies/amr/lib/level/LevelSolution_def.chpl
+++ b/test/studies/amr/lib/level/LevelSolution_def.chpl
@@ -35,7 +35,7 @@ class LevelSolution {
   //| >  deinitializer   | >
   //|/...................|/
   
-  proc deinit
+  proc deinit()
   {
     delete old_data;
     delete current_data;

--- a/test/types/records/vass/deinit-parenless-error.chpl
+++ b/test/types/records/vass/deinit-parenless-error.chpl
@@ -1,0 +1,7 @@
+
+record R {
+  var x: int;
+  proc deinit { writeln("R.deinit"); }
+}
+
+var r: R;

--- a/test/types/records/vass/deinit-parenless-error.good
+++ b/test/types/records/vass/deinit-parenless-error.good
@@ -1,0 +1,1 @@
+deinit-parenless-error.chpl:4: error: deinitializers must have parentheses


### PR DESCRIPTION
Our group consensus has moved towards requiring deinit functions
to have parentheses, as a style preference. This PR implements that.
This is both for class/record deinitializers and for module deinit functions.

Luckily, normalize() already iterates over all the former and all the latter.
This PR adds a simple check to each.

We used to remove FLAG_NO_PARENS from all deinit functions in the parser.
This is so that deinit resolves the same whether with parens or not.
This PR removes that removal so that normalization can detect
paren-less deinits.

- [x] test under linux64 --verify
