### PR TITLE
Update and extend the initializers technote

### DIFF
--- a/doc/rst/technotes/initializers.rst
+++ b/doc/rst/technotes/initializers.rst
@@ -287,6 +287,7 @@ Bugs
   initializer in its original module
 - nested types when the outer type and/or the inner type defines an initializer
   and the outer type and/or the inner type is generic.
+- others
 
 Other TODOs
 +++++++++++
@@ -295,3 +296,5 @@ Other TODOs
 - Improve some slightly cryptic error messages
 - Ensure we *always* error when a method is called in Phase 1 (we only sometimes
   do today)
+- Extend on statement support to allow field initialization within its bounds
+  after getting larger team buy in.

--- a/doc/rst/technotes/initializers.rst
+++ b/doc/rst/technotes/initializers.rst
@@ -328,7 +328,7 @@ Please report any bugs encountered using the guidance described at the `bugs`_
 page.
 
 .. _bugs:
-   http://chapel.cray.com/docs/master/usingchapel/bugs.html
+   http://chapel.cray.com/docs/latest/usingchapel/bugs.html
 
 Compiler Generated Initializers
 +++++++++++++++++++++++++++++++
@@ -379,7 +379,7 @@ direction for this support can be found in the `noinit section`_ of CHIP 10.
 Bugs
 ++++
 
-- secondary initializers in outside modules when type doesn't define an
+- secondary initializers in outside modules when the type doesn't define an
   initializer in its original module
 - nested types when the outer type and/or the inner type defines an initializer
   and the outer type and/or the inner type is generic.

--- a/doc/rst/technotes/initializers.rst
+++ b/doc/rst/technotes/initializers.rst
@@ -27,8 +27,8 @@ The Initializer Method
 ----------------------
 
 An initializer is a method on a class or record named "init".  It is invoked
-by the `new` operator, where the type name and initializer arguments are
-preceded with the `new` keyword.
+by the ``new`` operator, where the type name and initializer arguments are
+preceded with the ``new`` keyword.
 
 If the program declares a type initializer method, it is a user-defined
 initializer.  If the program declares no initializers or constructors for a
@@ -61,16 +61,16 @@ is assumed to be entirely composed of Phase 2 statements.  Otherwise, any
 code prior to the phase division indicator is considered to be in Phase 1, and
 any code following it is considered to be in Phase 2.
 
-Note that aside from `try!` statements without a `catch` block, error handling
-constructs are not allowed in initializers.  An initializer cannot be declared
-as `throws`.  See `Interaction With Error Handling`_.
+Note that aside from ``try!`` statements without a ``catch`` block, error
+handling constructs are not allowed in initializers.  An initializer cannot be
+declared as ``throws``.  See `Interaction With Error Handling`_.
 
 Phase 1
 +++++++
 
 The code residing in Phase 1 must follow a set of strong requirements.
 
-Other methods on the `this` instance cannot be called.  The `this` instance
+Other methods on the ``this`` instance cannot be called.  The ``this`` instance
 may not be passed to another function.
 
 Fields must be initialized in declaration order; however, fields can be omitted.
@@ -118,13 +118,13 @@ of prior fields.  However, later fields may not be referenced.
 
 Parent fields may not be accessed or initialized during Phase 1.
 
-`const` fields may be initialized during Phase 1.  Local variables may
-be created and used.  Functions that are not methods on the `this` instance
-may be called, so long as `this` is not provided as an argument.
+``const`` fields may be initialized during Phase 1.  Local variables may
+be created and used.  Functions that are not methods on the ``this`` instance
+may be called, so long as ``this`` is not provided as an argument.
 
 Loops and parallel statements are allowed during Phase 1, but field
-initialization within them is forbidden.  `on` statements whose bodies extend
-into Phase 2 are not allowed, but more limited `on` statements are acceptable.
+initialization within them is forbidden.  ``on`` statements whose bodies extend
+into Phase 2 are not allowed, but more limited ``on`` statements are acceptable.
 
 When Phase 1 of the initializer body has completed and the phase division
 indicator has been processed, it can safely be assumed that all fields are in
@@ -160,11 +160,11 @@ indicator is allowed.  It is forbidden to have both calls, or multiple of
 either, in a single control flow path.  It is forbidden to enclose the phase
 division indicator in a parallel statement, on statement, or a loop statement.
 If the phase division indicator is enclosed by a conditional, it must be a
-`param` conditional.
+``param`` conditional.
 
 If no phase division indicator is provided, an argument-less first form call
 will be inserted at the beginning of the body.  The
-`Compiler Generated Initializer`_ will also include an argument-less first form
+`Compiler Generated Initializers`_ will also include an argument-less first form
 call after completing the initialization of its fields.  If the parent type has
 defined an initializer that this call cannot resolve to, attempts to initialize
 the child with the compiler generated initializer will result in an error.
@@ -176,11 +176,11 @@ Phase 2
 Code in Phase 2 is functionally similar to other methods on the type, and less
 restrictive than code in Phase 1.  Modifications to the fields are considered
 assignment rather than initialization.  Other methods may be called on the
-`this` instance, and the `this` instance may be passed as an argument to another
-function.  Parent fields may be accessed.
+``this`` instance, and the ``this`` instance may be passed as an argument to
+another function.  Parent fields may be accessed.
 
-As in other methods, code in Phase 2 may not redefine `const`, `param`, and
-`type` fields.
+As in other methods, code in Phase 2 may not redefine ``const``, ``param``, and
+``type`` fields.
 
 
 Copy Initializers
@@ -228,14 +228,17 @@ Remaining Work
 With the 1.16.0 release, support for initializers is mostly stable with a few
 bugs and some unimplemented features remaining.  It is recommended for
 developers writing new classes and records to write initializers when possible.
-Please report any bugs encountered using the guidance described
-[here](http://chapel.cray.com/docs/master/usingchapel/bugs.html)
+Please report any bugs encountered using the guidance described at the `bugs`_
+page.
+
+.. _bugs:
+   http://chapel.cray.com/docs/master/usingchapel/bugs.html
 
 Compiler Generated Initializers
 +++++++++++++++++++++++++++++++
 
 Prototypical support of compiler generated initializers has been added.  With
-the 1.16.0 release and the developer-oriented flag `--force-initializers`,
+the 1.16.0 release and the developer-oriented flag ``--force-initializers``,
 user-defined classes will attempt to generate default initializers instead of
 default constructors.  User-defined records, and records and classes defined in
 the internal, standard, or package modules will not yet generate default
@@ -249,28 +252,33 @@ Interaction With Error Handling
 +++++++++++++++++++++++++++++++
 
 Due to time constraints, the 1.16.0 release went out with very limited support
-for error handling constructs: an initializer cannot be declared as `throws`,
-and only `try!` statements without `catch` blocks are allowed in the body.
+for error handling constructs: an initializer cannot be declared as ``throws``,
+and only ``try!`` statements without ``catch`` blocks are allowed in the body.
 
-In later releases, we hope to support `throw`, and `try` and `try!` statements
-with `catch` blocks during Phase 2, allowing initializers to be declared as
-`throws`.  It may be possible to allow these constructs in Phase 1, though for
-simplicity's sake they will likely still be banned around field initialization
-statements and forbidden from crossing the Phase 1/Phase 2 divide.
+In later releases, we hope to support ``throw``, and ``try`` and ``try!``
+statements with ``catch`` blocks during Phase 2, allowing initializers to be
+declared as ``throws``.  It may be possible to allow these constructs in Phase
+1, though for simplicity's sake they will likely still be banned around field
+initialization statements and forbidden from crossing the Phase 1/Phase 2
+divide.
 
-In the world where initializers can `throw`, we will only allow child classes
-to `throw` if the parent initializer `throws` (though there may be complications
-with chains of initializers, such as an initializer that calls another
-initializer on the type, which calls a parent initializer that `throws`, etc.).
+In the world where initializers can ``throw``, we will only allow child classes
+to ``throw`` if the parent initializer ``throws`` (though there may be
+complications with chains of initializers, such as an initializer that calls
+another initializer on the type, which calls a parent initializer that
+``throws``, etc.).
 
 
 Noinit
 ++++++
 
-Variable initialization when provided the `noinit` keyword in place of an
+Variable initialization when provided the ``noinit`` keyword in place of an
 initial value for a class or record should generate a call to an initializer
-that has defined what `noinit` means for that type.  More details on the
-direction for this support can be found [here] (https://github.com/chapel-lang/chapel/blob/master/doc/rst/developer/chips/10.rst#noinit)
+that has defined what ``noinit`` means for that type.  More details on the
+direction for this support can be found in the `noinit section`_ of CHIP 10.
+
+.. _noinit section:
+   https://github.com/chapel-lang/chapel/blob/master/doc/rst/developer/chips/10.rst#noinit
 
 Bugs
 ++++

--- a/doc/rst/technotes/initializers.rst
+++ b/doc/rst/technotes/initializers.rst
@@ -12,11 +12,10 @@ than the original methods known as constructors.
 A discussion of the current design and rationale is provided in
 `CHIP 10 <https://github.com/chapel-lang/chapel/blob/master/doc/rst/developer/chips/10.rst>`_.
 
-Release Chapel 1.15.0 provides a strong preview implementation of this
-new feature. This initial implementation is not of production quality
-and has not been heavily tested, but the basic features are working
-and it is believed that adventurous developers will have success using
-init methods in new code.
+Release Chapel 1.16.0 provides a strong preview implementation of this
+new feature.  Though some known bugs remain, the feature is rapidly
+approaching full support and developers should feel encouraged to
+write initializers where previously they had relied on constructors.
 
 It is anticipated that the implementation will continue to advance
 steadily after this release and that many aspects of the internal
@@ -24,111 +23,267 @@ implementation of Chapel will transition from constructor methods to
 initializer methods during this release.
 
 
-Stability
----------
+The Initializer Method
+----------------------
 
-The functionality of an initializer method has four major aspects
+An initializer is a method on a class or record named "init".  It is invoked
+by the `new` operator, where the type name and initializer arguments are
+preceded with the `new` keyword.
 
-  - user-defined code that runs in phase 2
+If the program declares a type initializer method, it is a user-defined
+initializer.  If the program declares no initializers or constructors for a
+class or record, a compiler generated constructor for that type is created
+automatically (see below for the status on `Compiler Generated Initializers`_).
 
-  - user-defined code that runs in phase 1
+User-Defined Initializers
+-------------------------
 
-  - compiler generated code that runs in phase 1
+A user-defined initializer is an initializer method explicitly declared in the
+program.  An initializer declaration has the same syntax as a method
+declaration, except that the name of the function is "init", and there is no
+return type specifier.
 
-  - the generation of effective user-facing diagnostic messages
+When an initializer is called, the usual function resolution mechanism is
+applied to determine which user-defined initializer to invoke.
 
-in approximate order of robustness and maturity.
-
-The user-defined code that executes in phase 2 of an initializer is
-comparable to the user-defined code in any method and is likely to
-behave in the expected way.
-
-The user-defined code that executes in phase 1 of an initializer has
-many of the same properties and is also expected to behave well.
-However there are more restrictions on user-defined code for phase 1
-and the compiler may fail to apply these restrictions correctly.  The
-most likely error is that the compiler will accept phase 1 code that
-it should reject but it is possible that there will be situations in
-which valid code is rejected.
-
-The design for initializer methods attempts to define predictable
-default behaviors within phase 1 and then rely on the compiler to
-insert these defaults when appropriate.  The intent is to reduce the
-amount of code that the type designer is responsible for.  This
-includes the generation of code using field-level default
-declarations.  Defining and implementing these default behaviors
-relies on relatively less mature code within the compiler.
-
-We believe that initializer methods are ready for use in application code
-but we also expect that the implementation will mature significantly
-during the 1.15 release.  We encourage their use but recognize that they
-may prove to be less robust than we would like at the start of the release.
-If you do choose to experiment with this feature then please do not
-hesitate to seek help, report bugs, or offer suggestions.
-
-Generic records and classes, i.e. records or classes in which the
-definition of the type of one or more fields is parameterized are less
-well developed than records and classes for which the type of every
-fields can be inferred directly from the type declaration.
+In contrast to user-defined constructors for generic classes and records,
+user-defined initializers do not require an argument per generic field.
 
 
-Status
-------
 
-As of the 1.15.0 release, support for initializers includes the following:
+The Initializer Body
+--------------------
 
-- Methods named "init" on a type are utilized during the creation of an
-  instance of that type.
+The code written in an initializer can be divided into two categories,
+referred to as "Phase 1" and "Phase 2" for the remainder of this document.
+When the phase division indicator is not present, the body of an initializer
+is assumed to be entirely composed of Phase 2 statements.  Otherwise, any
+code prior to the phase division indicator is considered to be in Phase 1, and
+any code following it is considered to be in Phase 2.
 
-- An error message is generated if both a constructor and an initializer is
-  defined on a type.
+Note that aside from `try!` statements without a `catch` block, error handling
+constructs are not allowed in initializers.  An initializer cannot be declared
+as `throws`.  See `Interaction With Error Handling`_.
 
-- User-defined initializers whose body consists of only Phase 2 statements
-  appear to be fully supported
+Phase 1
++++++++
 
-- User-defined initializers with Phase 1 statements that explicitly initialize
-  all of the fields appear to be well supported
+The code residing in Phase 1 must follow a set of strong requirements.
 
-  - Some errors remain with omitted field initialization in Phase 1, notably
-    with utilizing ``param`` fields in the omitted initialization of another
-    field, and with utilizing some record fields.
+Other methods on the `this` instance cannot be called.  The `this` instance
+may not be passed to another function.
 
-- Many checks against Phase 1 and Phase 2 rules are implemented, including:
+Fields must be initialized in declaration order; however, fields can be omitted.
+Omitted fields are given the declared initial value if present, or the default
+of its declared type.  Fields with neither a declared initial value or declared
+type cannot be omitted.
 
-  - Forbidding the update of ``const`` fields during Phase 2
-  - Forbidding the initialization of fields in parallel statements during
-    Phase 1
-  - Forbidding the initialization of fields in loops during Phase 1
-  - Forbidding ``super.init()`` and ``this.init()`` calls in parallel
-    statements
-  - Forbidding ``super.init()`` and ``this.init()`` calls in loops
-  - Forbidding access to a field prior to its initialization in Phase 1
-  - Forbidding the initialization of fields prior to ``this.init()`` calls
-  - Limiting the access of parent fields during Phase 1 of initialization
+.. code-block:: chapel
 
-- Support for initializers on generic classes when instances infer their type
-  from the result of a ``new`` call or another instance.
+   class Foo {
+     var bar = 10;
+     var baz = false;
+     var dip: real;
 
-  - As a result, generic fields no longer require an argument sharing their
-    name in the initializer argument list.
+     proc init(barVal, dipVal) {
+       bar = barVal;
+       // omitted initialization: baz = false;
+       dip = dipVal;
+       super.init();
+     }
+   }
 
-- Support for copy initializers
-- Support for deinitializers, as a replacement of destructors.
+   var foo = new Foo(11, 2.0);
 
-  - Library types were converted to use deinitializers.
+Both explicit and implicit initialization of a field can depend on the values
+of prior fields.  However, later fields may not be referenced.
 
-Remaining todo items include:
 
-- Support for compiler generated initializers
-- Improve the error message for out of order field initialization during
-  Phase 1
-- Forbid the utilization of methods on the type during Phase 1 of
-  initialization, as well as the use of ``this`` as an argument to a function.
-- Full support for ``param`` conditional situations
-- Resolve an issue with secondary initializers
-- Support for instance declarations of generic instantiations, i.e. ``var x:
-  Foo(t);``
-- Resolve an issue with generic initializers and records (relates to records
-  being passed by ``ref`` to the initializer method)
+.. code-block:: chapel
+
+   class Foo2 {
+     var bar = 10;
+     var baz = 5;
+     var dip = baz * 3;
+
+     proc init(barVal) {
+       bar = barVal;
+       baz = divceil(bar, 2);
+       // omitted initialization: dip = baz * 3;
+       super.init();
+     }
+   }
+
+   var foo2 = new Foo2(11);
+
+Parent fields may not be accessed or initialized during Phase 1.
+
+`const` fields may be initialized during Phase 1.  Local variables may
+be created and used.  Functions that are not methods on the `this` instance
+may be called, so long as `this` is not provided as an argument.
+
+Loops and parallel statements are allowed during Phase 1, but field
+initialization within them is forbidden.  `on` statements whose bodies extend
+into Phase 2 are not allowed, but more limited `on` statements are acceptable.
+
+When Phase 1 of the initializer body has completed and the phase division
+indicator has been processed, it can safely be assumed that all fields are in
+a usable state.
+
+Phase Division Indicator
+++++++++++++++++++++++++
+
+An explicit call to another initializer ends Phase 1 and begins Phase 2.  This
+call takes one of two forms:
+
+Form 1: call to an initializer defined on the parent type
+
+.. code-block:: chapel
+
+   super.init();
+
+Form 2: call to another initializer defined on the same type
+
+.. code-block:: chapel
+
+   this.init();
+
+If the type has no parent, an argument-less call of the first form will still be
+valid, but otherwise treated as a no-op.
+
+When using the second form, field initialization statements are not permitted in
+Phase 1, though other statements are allowed.  Omitted field initialization will
+not be inserted prior to calls of the second form.
+
+For a single control flow path through the body, only one phase division
+indicator is allowed.  It is forbidden to have both calls, or multiple of
+either, in a single control flow path.  It is forbidden to enclose the phase
+division indicator in a parallel statement, on statement, or a loop statement.
+If the phase division indicator is enclosed by a conditional, it must be a
+`param` conditional.
+
+If no phase division indicator is provided, an argument-less first form call
+will be inserted at the beginning of the body.  The
+`Compiler Generated Initializer`_ will also include an argument-less first form
+call after completing the initialization of its fields.  If the parent type has
+defined an initializer that this call cannot resolve to, attempts to initialize
+the child with the compiler generated initializer will result in an error.
+
+
+Phase 2
++++++++
+
+Code in Phase 2 is functionally similar to other methods on the type, and less
+restrictive than code in Phase 1.  Modifications to the fields are considered
+assignment rather than initialization.  Other methods may be called on the
+`this` instance, and the `this` instance may be passed as an argument to another
+function.  Parent fields may be accessed.
+
+As in other methods, code in Phase 2 may not redefine `const`, `param`, and
+`type` fields.
+
+
+Copy Initializers
+-----------------
+
+An initializer may be defined to control the behavior when a copy of an instance
+is made.  This initializer is define with a single argument on the same type
+as the type being created:
+
+.. code-block:: chapel
+
+   class Foo {
+     var x: int;
+     var wasCopied = false;
+
+     proc init(xVal: int) {
+       x = xVal;
+       super.init();
+     }
+
+     // copy initializer
+     proc init(other: Foo) {
+       x = other.x;
+       wasCopied = true;
+       super.init();
+     }
+   }
+
+   var foo1 = new Foo(5);
+   var foo2 = new Foo(foo1); // user inserted copy
+   writeln(foo1);
+   writeln(foo2);
+   delete foo1;
+   delete foo2;
+
+For more details on when the copy initializer would be called, please refer to
+`CHIP 13 - When Do Records and Array Copies Occur`_
+
+.. _CHIP 13 - When Do Records and Array Copies Occur:
+   https://github.com/chapel-lang/chapel/blob/master/doc/rst/developer/chips/13.rst
+
+Remaining Work
+--------------
+
+With the 1.16.0 release, support for initializers is mostly stable with a few
+bugs and some unimplemented features remaining.  It is recommended for
+developers writing new classes and records to write initializers when possible.
+Please report any bugs encountered using the guidance described
+[here](http://chapel.cray.com/docs/master/usingchapel/bugs.html)
+
+Compiler Generated Initializers
++++++++++++++++++++++++++++++++
+
+Prototypical support of compiler generated initializers has been added.  With
+the 1.16.0 release and the developer-oriented flag `--force-initializers`,
+user-defined classes will attempt to generate default initializers instead of
+default constructors.  User-defined records, and records and classes defined in
+the internal, standard, or package modules will not yet generate default
+initializers with this flag.  However, there are still failures with even that
+limited application.
+
+It is anticipated that compiler generated initializers will be fully supported
+in the next release.
+
+Interaction With Error Handling
++++++++++++++++++++++++++++++++
+
+Due to time constraints, the 1.16.0 release went out with very limited support
+for error handling constructs: an initializer cannot be declared as `throws`,
+and only `try!` statements without `catch` blocks are allowed in the body.
+
+In later releases, we hope to support `throw`, and `try` and `try!` statements
+with `catch` blocks during Phase 2, allowing initializers to be declared as
+`throws`.  It may be possible to allow these constructs in Phase 1, though for
+simplicity's sake they will likely still be banned around field initialization
+statements and forbidden from crossing the Phase 1/Phase 2 divide.
+
+In the world where initializers can `throw`, we will only allow child classes
+to `throw` if the parent initializer `throws` (though there may be complications
+with chains of initializers, such as an initializer that calls another
+initializer on the type, which calls a parent initializer that `throws`, etc.).
+
+
+Noinit
+++++++
+
+Variable initialization when provided the `noinit` keyword in place of an
+initial value for a class or record should generate a call to an initializer
+that has defined what `noinit` means for that type.  More details on the
+direction for this support can be found [here] (https://github.com/chapel-lang/chapel/blob/master/doc/rst/developer/chips/10.rst#noinit)
+
+Bugs
+++++
+
+- secondary initializers in outside modules when type doesn't define an
+  initializer in its original module
+- nested types when the outer type and/or the inner type defines an initializer
+  and the outer type and/or the inner type is generic.
+
+Other TODOs
++++++++++++
+
 - Convert library types to utilize initializers instead of constructors
-- Support ``noinit``
+- Improve some slightly cryptic error messages
+- Ensure we *always* error when a method is called in Phase 1 (we only sometimes
+  do today)

--- a/doc/rst/technotes/initializers.rst
+++ b/doc/rst/technotes/initializers.rst
@@ -47,8 +47,8 @@ program.  An initializer declaration has the same syntax as a method
 declaration, except that the name of the function is "init", and there is no
 return type specifier.
 
-When an initializer is called, the usual function resolution mechanism is
-applied to determine which user-defined initializer to invoke.
+When an initializer is invoked, the usual function resolution mechanism is
+applied to determine which user-defined initializer is required.
 
 The following example shows a class with two initializers:
 
@@ -80,10 +80,6 @@ The following example shows a class with two initializers:
 The first initializer lets the user specify the initial coordinates and the
 second initializer lets the user specify the initial message when creating a
 MessagePoint.
-
-In contrast to user-defined constructors for generic classes and records,
-user-defined initializers do not require an argument per generic field.
-
 
 
 The Initializer Body
@@ -264,6 +260,23 @@ another function.  Parent fields may be accessed.
 
 As in other methods, code in Phase 2 may not redefine ``const``, ``param``, and
 ``type`` fields.
+
+
+Generics
+--------
+
+A class or record with a ``param`` field, ``type`` field, or a ``var`` /
+``const`` field with no type or initial value is considered generic over that
+field.  Generic fields are treated similarly to other fields, with some
+exceptions.  Only generic fields are capable of being declared without a type or
+initial value, so only those generic fields without either must have an explicit
+initialization in Phase 1 - other generic fields may rely on omitted
+initialization like other fields do.  Like ``const`` fields, ``type`` and
+``param`` fields may not be updated during Phase 2.
+
+Note: user-defined constructors for generic classes and records required an
+argument per generic field and did not allow generic fields to be set during the
+constructor body.  Initializers do not have this constraint.
 
 
 Copy Initializers


### PR DESCRIPTION
While for last release, the emphasis was on "some things work, others don't",
the message for this release is "most things work except for these known
sticking points".  Hopefully, the final cut of this technote for the release
will be promotable to the spec next release, modulo some minor tweaks if we
change some of the rules with more experience.

With that in mind, change a little of the introductory paragraph, then add a
more robust description of the initializer method and its various rules, trying
to mimic the style of the spec's constructor section as much as possible.  I
remove the "Status" section in favor of a "Remaining Work" section (title can
change).  The "Remaining Work" section contains some more detailed callouts for
compiler generated initializers and the error handling support, minor notes on
noinit and the known remaining bugs, and then a list of other TODO items that
didn't fall under the previous categories.

Verified the output when looking at it via github.  I intend to look at the generated
docs output once the content has been finalized.