### PR TITLE
Improve some "multiply-defined" errors

### DIFF
--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -1164,6 +1164,23 @@ static void lookup(const char*           name,
 
                    std::vector<Symbol*>& symbols);
 
+// Show what symbols from 'symbols' conflict with the given 'sym'.
+static void printConflictingSymbols(std::vector<Symbol*>& symbols, Symbol* sym)
+{
+  Symbol* sampleFunction = NULL;
+  for_vector(Symbol, another, symbols) if (another != sym)
+  {
+    if (isFnSymbol(another))
+      sampleFunction = another;
+    else
+      USR_PRINT(another, "also defined here", another->name);
+  }
+
+  if (sampleFunction)
+    USR_PRINT(sampleFunction,
+              "also defined as a function here (and possibly elsewhere)");
+}
+
 // Given a name and a calling context, determine the symbol referred to
 // by that name in the context of that call
 Symbol* lookup(const char* name, BaseAST* context) {
@@ -1186,7 +1203,9 @@ Symbol* lookup(const char* name, BaseAST* context) {
 
     for_vector(Symbol, sym, symbols) {
       if (isFnSymbol(sym) == false) {
-        USR_FATAL_CONT(sym, "Symbol %s multiply defined", name);
+        USR_FATAL_CONT(sym, "symbol %s is multiply defined", name);
+        printConflictingSymbols(symbols, sym);
+        break;
       }
     }
 

--- a/test/modules/deitz/test_use_error.good
+++ b/test/modules/deitz/test_use_error.good
@@ -1,2 +1,2 @@
-test_use_error.chpl:2: error: Symbol x multiply defined
-test_use_error.chpl:6: error: Symbol x multiply defined
+test_use_error.chpl:2: error: symbol x is multiply defined
+test_use_error.chpl:6: note: also defined here

--- a/test/modules/diten/test_use_chain_resolution2.good
+++ b/test/modules/diten/test_use_chain_resolution2.good
@@ -1,2 +1,2 @@
-test_use_chain_resolution2.chpl:2: error: Symbol aaa multiply defined
-test_use_chain_resolution2.chpl:14: error: Symbol aaa multiply defined
+test_use_chain_resolution2.chpl:2: error: symbol aaa is multiply defined
+test_use_chain_resolution2.chpl:14: note: also defined here

--- a/test/modules/lydia/useNamingConflict.bad
+++ b/test/modules/lydia/useNamingConflict.bad
@@ -1,2 +1,2 @@
-useNamingConflict.chpl:2: error: Symbol foo multiply defined
-useNamingConflict.chpl:6: error: Symbol foo multiply defined
+useNamingConflict.chpl:2: error: symbol foo is multiply defined
+useNamingConflict.chpl:6: note: also defined here

--- a/test/modules/vass/multiply-defined-error-with-fn.chpl
+++ b/test/modules/vass/multiply-defined-error-with-fn.chpl
@@ -1,0 +1,26 @@
+// extract from test/users/npadmana/mpi/ring.chpl
+// which uses MPI and Barriers (just once)
+
+use MPIvass;
+use BarriersVass;
+use BarriersVass2;
+
+proc main() {
+  var sendBarrier = new Barrier(numLocales);
+}
+
+module MPIvass {
+  proc Barrier(comm: int) { }
+}
+
+module BarriersVass {
+  record Barrier {
+    proc Barrier(numTasks: int) { }
+  }
+}
+
+module BarriersVass2 {
+  record Barrier {
+    proc Barrier(numTasks: int) { }
+  }
+}

--- a/test/modules/vass/multiply-defined-error-with-fn.good
+++ b/test/modules/vass/multiply-defined-error-with-fn.good
@@ -1,0 +1,3 @@
+multiply-defined-error-with-fn.chpl:17: error: symbol Barrier is multiply defined
+multiply-defined-error-with-fn.chpl:23: note: also defined here
+multiply-defined-error-with-fn.chpl:13: note: also defined as a function here (and possibly elsewhere)

--- a/test/modules/vass/use-depth.bad
+++ b/test/modules/vass/use-depth.bad
@@ -1,2 +1,2 @@
-use-depth.chpl:23: error: Symbol z multiply defined
-use-depth.chpl:33: error: Symbol z multiply defined
+use-depth.chpl:23: error: symbol z is multiply defined
+use-depth.chpl:33: note: also defined here

--- a/test/modules/vass/use-depth.good
+++ b/test/modules/vass/use-depth.good
@@ -1,2 +1,2 @@
-use-depth.chpl:21: error: Symbol x multiply defined
-use-depth.chpl:37: error: Symbol x multiply defined
+use-depth.chpl:21: error: symbol z is multiply defined
+use-depth.chpl:37: note: also defined here

--- a/test/types/enum/lydia/use/namingConflictOtherEnum.good
+++ b/test/types/enum/lydia/use/namingConflictOtherEnum.good
@@ -1,2 +1,2 @@
-namingConflictOtherEnum.chpl:4: error: Symbol a multiply defined
-namingConflictOtherEnum.chpl:6: error: Symbol a multiply defined
+namingConflictOtherEnum.chpl:4: error: symbol a is multiply defined
+namingConflictOtherEnum.chpl:6: note: also defined here

--- a/test/types/enum/lydia/use/namingConflictOtherModule.good
+++ b/test/types/enum/lydia/use/namingConflictOtherModule.good
@@ -1,2 +1,2 @@
-namingConflictOtherModule.chpl:4: error: Symbol a multiply defined
-namingConflictOtherModule.chpl:8: error: Symbol a multiply defined
+namingConflictOtherModule.chpl:4: error: symbol a is multiply defined
+namingConflictOtherModule.chpl:8: note: also defined here

--- a/test/visibility/except/noResolveConflict.good
+++ b/test/visibility/except/noResolveConflict.good
@@ -1,2 +1,2 @@
-noResolveConflict.chpl:2: error: Symbol foo multiply defined
-noResolveConflict.chpl:11: error: Symbol foo multiply defined
+noResolveConflict.chpl:2: error: symbol foo is multiply defined
+noResolveConflict.chpl:11: note: also defined here


### PR DESCRIPTION
Before this change the "multiply defined" error did not indicate
the conflicting definition when it was a function.
This change ensures that when the conflict is between a variable
and a function, the compiler points to the function as well.

I was affected by the lack of the function reference
when I compiled this test: users/npadmana/mpi/ring.chpl
whose extract I am also adding as
  test/modules/vass/multiply-defined-error-with-fn.chpl

To implement this, I created a separate function
that iterates over the symbols the second time, for clarity
and simplicity.

While there, I added "is" and switched to the more conventional
"note: also defined here".

- [x] test under linux64 --verify
