### PR TITLE
Add a check for virtual parallel iterators

### DIFF
--- a/test/functions/iterators/elliot/dynamicDispatch/parallel-virtual-par-iters.bad
+++ b/test/functions/iterators/elliot/dynamicDispatch/parallel-virtual-par-iters.bad
@@ -1,7 +1,2 @@
-parallel-virtual-par-iters.chpl:5: internal error: AGG0594 chpl Version 1.16.0 pre-release (8c0c688f09)
-
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
-and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
-please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
-
+parallel-virtual-par-iters.chpl:20: error: virtual parallel iterators are not yet supported (see issue #6998)
+parallel-virtual-par-iters.chpl:21: error: virtual parallel iterators are not yet supported (see issue #6998)

--- a/test/functions/iterators/elliot/dynamicDispatch/remote-virtual-par-iters.bad
+++ b/test/functions/iterators/elliot/dynamicDispatch/remote-virtual-par-iters.bad
@@ -1,7 +1,2 @@
-remote-virtual-par-iters.chpl:5: internal error: AGG0594 chpl Version 1.16.0 pre-release (983cc1d626)
-
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
-and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
-please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
-
+remote-virtual-par-iters.chpl:20: error: virtual parallel iterators are not yet supported (see issue #6998)
+remote-virtual-par-iters.chpl:21: error: virtual parallel iterators are not yet supported (see issue #6998)

--- a/test/functions/iterators/elliot/dynamicDispatch/serial-virtual-par-iters.bad
+++ b/test/functions/iterators/elliot/dynamicDispatch/serial-virtual-par-iters.bad
@@ -1,7 +1,2 @@
-serial-virtual-par-iters.chpl:5: internal error: AGG0594 chpl Version 1.16.0 pre-release (8c0c688f09)
-
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
-and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
-please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
-
+serial-virtual-par-iters.chpl:20: error: virtual parallel iterators are not yet supported (see issue #6998)
+serial-virtual-par-iters.chpl:21: error: virtual parallel iterators are not yet supported (see issue #6998)

--- a/test/functions/iterators/elliot/dynamicDispatch/trivial-virtual-par-iters.bad
+++ b/test/functions/iterators/elliot/dynamicDispatch/trivial-virtual-par-iters.bad
@@ -1,2 +1,2 @@
-1
-trivial-virtual-par-iters.chpl:18: error: halt reached - Should not be called...
+trivial-virtual-par-iters.chpl:18: error: virtual parallel iterators are not yet supported (see issue #6998)
+trivial-virtual-par-iters.chpl:19: error: virtual parallel iterators are not yet supported (see issue #6998)


### PR DESCRIPTION
Issue a compiler error if virtual parallel iterators are used. They are
currently not working, so issue a clear compiler error instead of either
runtime failures or uninterpretable compiler errors.