### PR TITLE
Create LLVM TBAA metadata for structs

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -2288,7 +2288,7 @@ GenInfo::GenInfo(
        :   cfile(NULL), cLocalDecls(), cStatements(),
            lineno(-1), filename(NULL), parseOnly(parseOnlyIn),
            // the rest of these are only in GenInfo with HAVE_LLVM
-           module(NULL), builder(NULL), lvt(NULL),
+           module(NULL), builder(NULL), MDHelper(NULL), lvt(NULL),
            clangCC(clangCcIn),
            clangCXX(clangCxxIn),
            compileline(compilelineIn),
@@ -2314,6 +2314,7 @@ GenInfo::GenInfo(
   if( ! parseOnly ) {
     module = new llvm::Module(moduleName, llvmContext);
     builder = new llvm::IRBuilder<>(module->getContext());
+    MDHelper = new llvm::MDBuilder(module->getContext());
   }
 
   lvt = new LayeredValueTable();

--- a/compiler/codegen/expr.cpp
+++ b/compiler/codegen/expr.cpp
@@ -432,7 +432,8 @@ llvm::StoreInst* codegenStoreLLVM(llvm::Value* val,
   GenInfo *info = gGenInfo;
   llvm::StoreInst* ret = info->builder->CreateStore(val, ptr);
   llvm::MDNode* tbaa = NULL;
-  if( USE_TBAA && valType ) tbaa = valType->symbol->llvmTbaaAccessTag;
+  if( USE_TBAA && valType && !valType->symbol->llvmTbaaStructCopyNode )
+    tbaa = valType->symbol->llvmTbaaAccessTag;
   if( tbaa ) ret->setMetadata(llvm::LLVMContext::MD_tbaa, tbaa);
 
   if(!info->loopStack.empty()) {
@@ -490,7 +491,7 @@ llvm::LoadInst* codegenLoadLLVM(llvm::Value* ptr,
   GenInfo* info = gGenInfo;
   llvm::LoadInst* ret = info->builder->CreateLoad(ptr);
   llvm::MDNode* tbaa = NULL;
-  if( USE_TBAA && valType ) {
+  if( USE_TBAA && valType && !valType->symbol->llvmTbaaStructCopyNode ) {
     if( isConst ) tbaa = valType->symbol->llvmConstTbaaAccessTag;
     else tbaa = valType->symbol->llvmTbaaAccessTag;
   }

--- a/compiler/codegen/symbol.cpp
+++ b/compiler/codegen/symbol.cpp
@@ -902,12 +902,10 @@ void TypeSymbol::codegenMetadata() {
   llvm::LLVMContext& ctx = info->module->getContext();
   // Create the TBAA root node if necessary.
   if( ! info->tbaaRootNode ) {
-    LLVM_METADATA_OPERAND_TYPE* Ops[1];
-    Ops[0] = llvm::MDString::get(ctx, "Chapel types");
-    info->tbaaRootNode = llvm::MDNode::get(ctx, Ops);
+    info->tbaaRootNode = info->MDHelper->createTBAARoot("Chapel types");
   }
 
-  // Set the llvmTbaaNode to non-NULL so that we can
+  // Set the llvmTbaaTypeDescriptor to non-NULL so that we can
   // avoid recursing.
   llvmTbaaTypeDescriptor = info->tbaaRootNode;
 
@@ -952,46 +950,15 @@ void TypeSymbol::codegenMetadata() {
       is_real_type(type) || is_imag_type(type) || is_enum_type(type) ||
       isClass(type) || hasEitherFlag(FLAG_REF,FLAG_WIDE_REF) ||
       hasEitherFlag(FLAG_DATA_CLASS,FLAG_WIDE_CLASS) ) {
-    // Now create tbaa metadata, one for const and one for not.
-    {
-      LLVM_METADATA_OPERAND_TYPE* Ops[2];
-      Ops[0] = llvm::MDString::get(ctx, cname);
-      Ops[1] = parent;
-      llvmTbaaTypeDescriptor = llvm::MDNode::get(ctx, Ops);
-    }
-    {
-      LLVM_METADATA_OPERAND_TYPE* Ops[3];
-      Ops[0] = llvmTbaaTypeDescriptor;
-      Ops[1] = llvmTbaaTypeDescriptor;
-      Ops[2] = llvm_constant_as_metadata(
-                   llvm::ConstantInt::get(llvm::Type::getInt64Ty(ctx), 0));
-      llvmTbaaAccessTag = llvm::MDNode::get(ctx, Ops);
-    }
-    {
-      LLVM_METADATA_OPERAND_TYPE* Ops[4];
-      Ops[0] = llvmTbaaTypeDescriptor;
-      Ops[1] = llvmTbaaTypeDescriptor;
-      Ops[2] = llvm_constant_as_metadata(
-                   llvm::ConstantInt::get(llvm::Type::getInt64Ty(ctx), 0));
-      Ops[3] = llvm_constant_as_metadata(
-                   llvm::ConstantInt::get(llvm::Type::getInt64Ty(ctx), 1));
-      llvmConstTbaaAccessTag = llvm::MDNode::get(ctx, Ops);
-    }
-  }
+    llvmTbaaTypeDescriptor =
+      info->MDHelper->createTBAAScalarTypeNode(cname, parent, 0);
+  } else if (ct && !isUnion(type) && !hasFlag(FLAG_STAR_TUPLE)) {
+    // Create the TBAA struct type descriptors and tbaa.struct metadata nodes.
+    llvm::SmallVector<LLVM_METADATA_OPERAND_TYPE*, 16> TypeOps;
+    llvm::SmallVector<LLVM_METADATA_OPERAND_TYPE*, 16> CopyOps;
+    llvm::SmallVector<LLVM_METADATA_OPERAND_TYPE*, 16> ConstCopyOps;
 
-  // Don't try to create tbaa.struct metadata for non-struct.
-  if( isUnion(type) ||
-      hasFlag(FLAG_STAR_TUPLE) ||
-      hasFlag(FLAG_REF) ||
-      hasFlag(FLAG_DATA_CLASS) ||
-      hasEitherFlag(FLAG_WIDE_REF,FLAG_WIDE_CLASS) ) {
-    return;
-  }
-
-  if( ct ) {
-    // Now create the tbaa.struct metadata nodes.
-    llvm::SmallVector<LLVM_METADATA_OPERAND_TYPE*, 16> Ops;
-    llvm::SmallVector<LLVM_METADATA_OPERAND_TYPE*, 16> ConstOps;
+    TypeOps.push_back(llvm::MDString::get(ctx,cname));
 
     const char* struct_name = ct->classStructName(true);
     llvm::Type* struct_type_ty = info->lvt->getType(struct_name);
@@ -1010,15 +977,32 @@ void TypeSymbol::codegenMetadata() {
       unsigned gep = ct->getMemberGEP(field->cname);
       llvm::Constant* off = llvm::ConstantExpr::getOffsetOf(struct_type, gep);
       llvm::Constant* sz = llvm::ConstantExpr::getSizeOf(fieldType);
-      Ops.push_back(llvm_constant_as_metadata(off));
-      Ops.push_back(llvm_constant_as_metadata(sz));
-      Ops.push_back(field->type->symbol->llvmTbaaAccessTag);
-      ConstOps.push_back(llvm_constant_as_metadata(off));
-      ConstOps.push_back(llvm_constant_as_metadata(sz));
-      ConstOps.push_back(field->type->symbol->llvmConstTbaaAccessTag);
+      TypeOps.push_back(field->type->symbol->llvmTbaaTypeDescriptor);
+      TypeOps.push_back(llvm_constant_as_metadata(off));
+      CopyOps.push_back(llvm_constant_as_metadata(off));
+      CopyOps.push_back(llvm_constant_as_metadata(sz));
+      CopyOps.push_back(field->type->symbol->llvmTbaaAccessTag);
+      ConstCopyOps.push_back(llvm_constant_as_metadata(off));
+      ConstCopyOps.push_back(llvm_constant_as_metadata(sz));
+      ConstCopyOps.push_back(field->type->symbol->llvmConstTbaaAccessTag);
     }
-    llvmTbaaStructCopyNode = llvm::MDNode::get(ctx, Ops);
-    llvmConstTbaaStructCopyNode = llvm::MDNode::get(ctx, ConstOps);
+    llvmTbaaTypeDescriptor = llvm::MDNode::get(ctx, TypeOps);
+    llvmTbaaStructCopyNode = llvm::MDNode::get(ctx, CopyOps);
+    llvmConstTbaaStructCopyNode = llvm::MDNode::get(ctx, ConstCopyOps);
+  }
+  if (llvmTbaaTypeDescriptor != info->tbaaRootNode) {
+    // Create tbaa access tags, one for const and one for not.
+    // The createTBAAStructTagNode() method works for both scalars
+    // and aggregates, referencing the whole object.
+    llvmTbaaAccessTag =
+      info->MDHelper->createTBAAStructTagNode(llvmTbaaTypeDescriptor,
+                                              llvmTbaaTypeDescriptor,
+                                              /*Offset=*/0);
+    llvmConstTbaaAccessTag =
+      info->MDHelper->createTBAAStructTagNode(llvmTbaaTypeDescriptor,
+                                              llvmTbaaTypeDescriptor,
+                                              /*Offset=*/0,
+                                              /*IsConstant=*/true);
   }
 #endif
 }

--- a/compiler/include/codegen.h
+++ b/compiler/include/codegen.h
@@ -89,6 +89,7 @@ struct GenInfo {
   // If we're generating LLVM, the following are available
   llvm::Module *module;
   llvm::IRBuilder<> *builder;
+  llvm::MDBuilder *MDHelper;
   LayeredValueTable *lvt;
 
   std::stack<LoopData> loopStack;

--- a/compiler/include/llvmUtil.h
+++ b/compiler/include/llvmUtil.h
@@ -39,6 +39,7 @@
 #include "llvm/IR/IntrinsicInst.h"
 #include "llvm/IR/Attributes.h"
 #include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/MDBuilder.h"
 #include "llvm/IR/DataLayout.h"
 #define LLVM_TARGET_DATA llvm::DataLayout
 #define LLVM_ATTRIBUTE llvm::Attribute


### PR DESCRIPTION
Create type-based alias analysis (TBAA) type descriptors for structs.
Also cleans up code by using an MDBuilder to build some metadata.
Could use further refinement by making use of TBAA metadata on struct field accesses.
