### PR TITLE
compiler inserts deferred delete error into catch statements

### DIFF
--- a/test/errhandling/psahabu/nil-check-catchall.chpl
+++ b/test/errhandling/psahabu/nil-check-catchall.chpl
@@ -1,0 +1,12 @@
+use ThrowError;
+
+try {
+  try {
+    throwAnError();
+  } catch e {
+    writeln("caught Error from try");
+    throwAnError();
+  }
+} catch {
+  writeln("caught error from named catchall");
+}

--- a/test/errhandling/psahabu/nil-check-catchall.good
+++ b/test/errhandling/psahabu/nil-check-catchall.good
@@ -1,0 +1,2 @@
+caught Error from try
+caught error from named catchall

--- a/test/errhandling/psahabu/nil-check-filter.chpl
+++ b/test/errhandling/psahabu/nil-check-filter.chpl
@@ -1,0 +1,12 @@
+use ThrowError;
+
+try {
+  try {
+    throw new OtherError();
+  } catch e: OtherError {
+    writeln("caught OtherError from try");
+    throwAnError();
+  }
+} catch {
+  writeln("caught error from catch filter");
+}

--- a/test/errhandling/psahabu/nil-check-filter.good
+++ b/test/errhandling/psahabu/nil-check-filter.good
@@ -1,0 +1,2 @@
+caught OtherError from try
+caught error from catch filter


### PR DESCRIPTION
## Motivation

When a new error is thrown from a catch block, the old error is leaked. This bug is detailed in #7331.

``` chapel
try {
  throw new SomeError();
} catch e {
  writeln("handling error " + e.msg);
  throw new DifferentError();
  // delete e is dead code eliminated
  // e is never deleted
}
```

## Solution

### deferred delete

Instead of inserting `delete e` at the end of the catch block, it is inserted at the beginning of the catch block as a `DeferStmt`:

``` chapel
} catch e {
  // compiler inserted
  defer {
    if e then delete e;
  }
  throw new DifferentError();
}
```

### nil-out error variable if thrown

The deferred delete is effective, but `e` should not always be deleted:

``` chapel
} catch e {
  defer {
    if e then delete e;
  }
  // psuedo-code lowering of throw
  var thrownError = cleanError(e);
  throw thrownError;
  // DeferStmt implementation causes double free of error
}
```

To pre-empt this possibility, the compiler will insert checks before throws in catch blocks and nil-out `e`:

``` chapel
} catch e {
  defer {
    if e then delete e;
  }
  var thrownError = cleanError(e);
  if thrownError == e then e = nil;
  throw thrownError;
  // DeferStmt does not free e
}
```

### note

The solution could be simplified if `delete nil;` were a no-op rather than a fatal error. In that case, the defer block would not need a conditional check.

- [x] passes linux64+flat testing