### PR TITLE
FileSystem.rmTree should handle hidden files

### DIFF
--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -1252,14 +1252,14 @@ proc remove(name: string) throws {
 
 private proc rmTreeHelper(out error: syserr, root: string) {
   // Go through all the files in this current directory and remove them
-  for filename in listdir(path=root, dirs=false, files=true, listlinks=true) {
+  for filename in listdir(path=root, dirs=false, files=true, listlinks=true, hidden=true) {
     var name = root + "/" + filename;
     remove(error, name);
     if (error != ENOERR) then return;
   }
   // Then traverse all the directories within this current directory and have
   // them handle cleaning up their contents and themselves
-  for dirname in listdir(path=root, dirs=true, files=false, listlinks=true) {
+  for dirname in listdir(path=root, dirs=true, files=false, listlinks=true, hidden=true) {
     var fullpath = root + "/" + dirname;
     var dirIsLink = isLink(error, fullpath);
     if (error != ENOERR) then return;

--- a/test/modules/standard/FileSystem/bharshbarg/rmTreeHidden.chpl
+++ b/test/modules/standard/FileSystem/bharshbarg/rmTreeHidden.chpl
@@ -1,0 +1,31 @@
+
+use FileSystem;
+
+const dirName = "rmTree_test";
+
+proc makeHiddenFile(dir:string, fname:string) {
+  var fi = open(dir + "/." + fname, iomode.cw);
+  var w  = fi.writer();
+  w.writeln("Hello, world!");
+  w.close();
+  fi.close();
+}
+
+proc main() {
+  assert(isDir(dirName) == false);
+
+  mkdir(dirName);
+
+  assert(isDir(dirName) == true);
+
+  makeHiddenFile(dirName, "hidden");
+  makeHiddenFile(dirName, "foo");
+
+  const nested = dirName + "/.nested";
+  mkdir(nested);
+  makeHiddenFile(nested, "foobar");
+
+  rmTree(dirName);
+
+  assert(isDir(dirName) == false);
+}


### PR DESCRIPTION
Prior to this PR, FileSystem.rmTree would fail to remove a directory containing hidden files. This is easily fixed by passing 'hidden=true' to ``listdir`` in ``rmTreeHelper``.

Testing:
- [x] full local on linux64
- [x] test/modules/standard/FileSystem on Mac
  - [x] local
  - [x] gasnet