### PR TITLE
Fix whitespace in mason's default .chpl file

### DIFF
--- a/tools/mason/MasonNew.chpl
+++ b/tools/mason/MasonNew.chpl
@@ -113,7 +113,7 @@ proc makeBasicToml(name: string) {
 proc makeProjectFiles(name: string) {
   mkdir(name + "/src");
   const libTemplate = '/* Documentation for ' + name +
-    ' */\nmodule '+ name + ' {\n   writeln("New library: '+ name +'");\n}';
+    ' */\nmodule '+ name + ' {\n  writeln("New library: '+ name +'");\n}';
   var lib = open(name+'/src/'+name+'.chpl', iomode.cw);
   var libWriter = lib.writer();
   libWriter.write(libTemplate);


### PR DESCRIPTION
Mason's default .chpl file should use two spaces, not three.

TODO: should we add an option to let users specify tabs/4-spaces/2-spaces?

Testing:
- [x] test/mason
  - [x] OS X
  - [x] linux