### PR TITLE
Fix --llvm test failures for Crypto module

### DIFF
--- a/compiler/codegen/expr.cpp
+++ b/compiler/codegen/expr.cpp
@@ -3418,7 +3418,13 @@ GenRet CallExpr::codegen() {
 #ifdef HAVE_LLVM
       // We might have to convert the return from the function
       // if clang did some structure-expanding.
-      if (this->typeInfo() != dtVoid) {
+
+      bool returnedValueUsed = false;
+      if (CallExpr* parentCall = toCallExpr(this->parentExpr))
+        if (parentCall->isPrimitive(PRIM_MOVE))
+          returnedValueUsed = true;
+
+      if (returnedValueUsed && this->typeInfo() != dtVoid) {
         GenRet ty = this->typeInfo();
 
         INT_ASSERT(ty.type);

--- a/modules/packages/Crypto.chpl
+++ b/modules/packages/Crypto.chpl
@@ -1008,7 +1008,11 @@ module Crypto {
 
     extern proc OpenSSL_add_all_digests();
     extern proc EVP_get_digestbyname(name: c_string): CONST_EVP_MD_PTR;
-    extern proc EVP_MD_CTX_init(ref ctx: EVP_MD_CTX): c_int;
+
+    // EVP_MD_CTX_init is documented to have void return type
+    // but in some versions of OpenSSL it becomes a #define that returns int.
+    // For other versions, it actually returns void.
+    extern proc EVP_MD_CTX_init(ref ctx: EVP_MD_CTX): void;
     extern proc EVP_DigestInit_ex(ref ctx: EVP_MD_CTX, types: CONST_EVP_MD_PTR, impl: ENGINE_PTR): c_int;
     extern proc EVP_DigestUpdate(ref ctx: EVP_MD_CTX, const d: c_void_ptr, cnt: size_t): c_int;
     extern proc EVP_DigestFinal_ex(ref ctx: EVP_MD_CTX, md: c_ptr(c_uchar), ref s: c_uint): c_int;

--- a/test/extern/ferguson/return-int-pretend-void.chpl
+++ b/test/extern/ferguson/return-int-pretend-void.chpl
@@ -1,0 +1,14 @@
+require "return-int-pretend-void.h";
+
+extern proc foo():void;  // actually, foo() returns c_int
+extern proc bar():c_int; // actually, bar() returns void
+
+// The intent of this test is to lock in behavior that
+// tolerates some inconsistency in the return type,
+// provided that the returned value is never used.
+proc test() {
+  foo();
+  bar();
+}
+
+test();

--- a/test/extern/ferguson/return-int-pretend-void.good
+++ b/test/extern/ferguson/return-int-pretend-void.good
@@ -1,0 +1,2 @@
+Returning 4
+Returning void

--- a/test/extern/ferguson/return-int-pretend-void.h
+++ b/test/extern/ferguson/return-int-pretend-void.h
@@ -1,0 +1,9 @@
+#include <stdio.h>
+
+static int foo(void) {
+  printf("Returning 4\n");
+  return 4;
+}
+static void bar(void) {
+  printf("Returning void\n");
+}


### PR DESCRIPTION
* EVP_MD_CTX_init is documented to return void, so change its return type
* Adjusted the LLVM backend so this type of mismatch won't cause an error if the returned value is never used. (See below for more on this).
* Adds a test to lock in this behavior. This test would fail under `--llvm` without the above adjustment.

About the type mismatch we are tolerating:

With the C backend, if we are wrong about the return type of a function declared with `extern proc`, nothing bad comes of it unless a returned value is actually used.

This commit adjusts --llvm code generation to behave similarly and adds a test to verify the behavior. This is an alternative way to fix the issue with EVP_MD_CTX_init.

- [x] verified functionality on Mac OS X with `start_test test/modules/packages/Crypto/saru/* --compopts '-I  /usr/local/opt/openssl/include -L /usr/local/opt/openssl/lib'`
- [x] full local testing
- [x] full local --llvm testing

Reviewed by @dmk42 - thanks!