### PR TITLE
Update the module search path technote

### DIFF
--- a/doc/rst/technotes/module_search.rst
+++ b/doc/rst/technotes/module_search.rst
@@ -3,8 +3,8 @@
 Module Search Paths
 ===================
 
-This README describes how modules are located by the current Cray implementation
-of Chapel.
+This document describes how modules are located by the current Cray
+implementation of Chapel.
 
 Internal modules are always loaded by a chapel program *as if* the
 statement ``use ChapelStandard;`` has been inserted ahead of the first
@@ -12,22 +12,20 @@ statement in the main module.  Unlike standard modules, internal modules cannot
 be overridden.
 
 The compiler uses three module search paths: one for internal modules, one for
-standard modules and one for user modules.  The user path first includes all the
-paths used to specify module files directly on the ``chpl`` command line and
-then includes the paths specified via ``-M`` commands or through
-the ``CHPL_MODULE_PATH`` environment variable.
+standard and package modules, and one for user modules.  The user path first
+includes all the paths used to specify module files directly on the ``chpl``
+command line and then includes the paths specified via ``-M`` commands or
+through the ``CHPL_MODULE_PATH`` environment variable.
 
 The module search paths are initialized as follows:
 
     * Internal
-        * ``$CHPL_HOME/modules/internal/localeModels/$CHPL_LOCALE_MODEL``
-        * ``$CHPL_HOME/modules/internal/tasks/$CHPL_TASKS``
-        * ``$CHPL_HOME/modules/internal/comm/$CHPL_COMM``
-        * ``$CHPL_HOME/modules/internal``
+        * various directories under ``$CHPL_HOME/modules/internal``
 
     * Standard
         * ``$CHPL_HOME/modules/standard/gen/$CHPL_TARGET_PLATFORM-$CHPL_TARGET_COMPILER``
         * ``$CHPL_HOME/modules/standard``
+        * ``$CHPL_HOME/modules/packages``
         * ``$CHPL_HOME/modules/layouts``
         * ``$CHPL_HOME/modules/dists``
         * ``$CHPL_HOME/modules/dists/dims``
@@ -40,6 +38,7 @@ loaded, the internal module path is searched first.  If a module is found there,
 it is marked as internal.  Otherwise, it is skipped.
 
 The user's modules are parsed next.  If a module named in a use statement is not
-found, the standard version is loaded instead if it exists.  Otherwise, a
-file-not-found error will be issued.  If both user and standard versions of a
-module exist, the user is warned that the standard version is being overridden.
+found, the standard or package version is loaded instead if it exists.
+Otherwise, a file-not-found error will be issued.  If both a user version and a
+Chapel provided version of a module exists, the user is warned that the Chapel
+provided version is being overridden.

--- a/doc/rst/technotes/module_search.rst
+++ b/doc/rst/technotes/module_search.rst
@@ -38,7 +38,6 @@ loaded, the internal module path is searched first.  If a module is found there,
 it is marked as internal.  Otherwise, it is skipped.
 
 The user's modules are parsed next.  If a module named in a use statement is not
-found, the standard or package version is loaded instead if it exists.
-Otherwise, a file-not-found error will be issued.  If both a user version and a
-Chapel provided version of a module exists, the user is warned that the Chapel
-provided version is being overridden.
+found, the standard version is loaded instead if it exists.  Otherwise, a
+file-not-found error will be issued.  If both user and standard versions of a
+module exists, the user is warned that the standard version is being overridden.


### PR DESCRIPTION
While looking through technote examples, I noticed that this document was out of
date; specificially, it was missing the package module directory.  This change
fixes that oversight.

Details:
- Brad asked that I change the word "README" to something else in the opening
  paragraph
- change the entry for standard modules in the list of module search paths to
  include the packages directory.
- For maintainability, at Brad's recommendation, replace the individual
  directories in the "internal" module list with a general mention.