### PR TITLE
Clean up after 'mason new' test

### DIFF
--- a/test/mason/chplVersion/mason-chpl-version-new.chpl
+++ b/test/mason/chplVersion/mason-chpl-version-new.chpl
@@ -13,4 +13,7 @@ proc main() {
   const fi = open("newTest/Mason.toml", iomode.r);
   for line in fi.lines() do write(line);
   fi.close();
+
+  rmTree("newTest");
+  assert(isDir("newTest") == false);
 }


### PR DESCRIPTION
Remove 'newTest' directory now that rmTree bug with hidden files is fixed.