### PR TITLE
Add .good file for assignReindex for gasnet+numa testing

### DIFF
--- a/test/distributions/robust/arithmetic/performance/multilocale/assignReindex.lm-numa.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/assignReindex.lm-numa.good
@@ -1,0 +1,2 @@
+(execute_on = 12, execute_on_nb = 6) (get = 101, put = 1, execute_on = 6, execute_on_fast = 2) (get = 101, put = 1, execute_on_fast = 2) (get = 101, put = 1, execute_on_fast = 2)
+(execute_on_nb = 3) (get = 130, execute_on_fast = 1) (get = 130, execute_on_fast = 1) (get = 85, execute_on_fast = 1)


### PR DESCRIPTION
I overlooked this configuration because I was comparing to a test
that didn't need a special .good file for it.  Sorry for the noise.