### PR TITLE
Delete some user-allocated classes in stencil.chpl

### DIFF
--- a/test/functions/vass/ref-intent-bug-2big.chpl
+++ b/test/functions/vass/ref-intent-bug-2big.chpl
@@ -72,6 +72,11 @@ proc GlobalInfo.init() {
   }
 }
 
+proc GlobalInfo.deinit() {
+  forall inf in infos do
+    delete inf;
+}
+
 // Here are all our local domains. WI <- Working Indices.
 const WI = new GlobalInfo();
 
@@ -132,9 +137,20 @@ proc GlobalData.init(nameArg: string) {
   }  // forall
 }  // GlobalData constructor
 
+proc GlobalData.deinit() {
+  forall dat in datas do
+    delete dat;
+}
+
 // Our two global arrays, to switch between.
 const WA = new GlobalData("WA"),
       WB = new GlobalData("WB");
+
+proc deinit() {
+  delete WA;
+  delete WB;
+  delete WI;
+}
 
 // Reuse the name for an indexing operation.
 // This does not access neighbor caches.

--- a/test/optimizations/bulkcomm/asenjo/stencilDR/v2/stencil.chpl
+++ b/test/optimizations/bulkcomm/asenjo/stencilDR/v2/stencil.chpl
@@ -68,6 +68,11 @@ proc GlobalInfo.init() {
   }
 }
 
+proc GlobalInfo.deinit() {
+  forall inf in infos do
+    delete inf;
+}
+
 // Here are all our local domains. WI <- "Working Indices".
 const WI = new GlobalInfo();
 
@@ -135,9 +140,20 @@ proc GlobalData.init(nameArg: string) {
   }  // forall
 }  // GlobalData constructor
 
+proc GlobalData.deinit() {
+  forall dat in datas do
+    delete dat;
+}
+
 // Our two global arrays, to switch between.
 const WA = new GlobalData("WA"),
       WB = new GlobalData("WB");
+
+proc deinit() {
+  delete WA;
+  delete WB;
+  delete WI;
+}
 
 // Reuse the name for an indexing operation.
 // This does not access neighbor caches.


### PR DESCRIPTION
This change closes some user-allocated memory leaks in v2/stencil.chpl
and in ref-intent-bug-2big.chpl which appears to be a code clone of
the same.

At this point, these tests are only leaking what appear to be domain
map-related data structures.