### PR TITLE
Resolve push_back / pop_front regressions w/ inline

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -2644,7 +2644,7 @@ module ChapelArray {
     pragma "no doc"
     /* Internal helper method to reallocate an array */
     inline proc reallocateArray(newRange: range, param direction=1,
-                         debugMsg="reallocateArray")
+                                debugMsg="reallocateArray")
     {
       on this._value {
         const check = if direction > 0 then newRange.high else newRange.low;

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -2643,7 +2643,7 @@ module ChapelArray {
 
     pragma "no doc"
     /* Internal helper method to reallocate an array */
-    proc reallocateArray(newRange: range, param direction=1,
+    inline proc reallocateArray(newRange: range, param direction=1,
                          debugMsg="reallocateArray")
     {
       on this._value {

--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -1077,6 +1077,8 @@ timeVectorArray:
     - Support arrays as args to array.{push_front,push_back,insert} (#7180)
   09/16/17:
     - Resolve timeVectorArray regressions (#7333)
+  09/19/17:
+    - Resolve push_back / pop_front regressions w/ inline (#7397)
 
 dynamic:
   02/28/17:

--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -1077,7 +1077,7 @@ timeVectorArray:
     - Support arrays as args to array.{push_front,push_back,insert} (#7180)
   09/16/17:
     - Resolve timeVectorArray regressions (#7333)
-  09/19/17:
+  09/20/17:
     - Resolve push_back / pop_front regressions w/ inline (#7397)
 
 dynamic:


### PR DESCRIPTION
This PR resolves the `push_back` / `pop_front` regressions introduced back in #7180 and partially resolved in #7333. 

I'm skeptical that this was a meaningful performance regression in the first place, as the `pop_front` code path never interacts with the `reallocateArray` method. Furthermore, the addition of this `inline` reverses the performance improvements for `push_front`. I suspect cache effects are at play. Nevertheless, this change restores performance when testing on `chap04`:

```
test/arrays/diten/timeVectorArray.chpl

# Branch    PushBack    SumElements PopBack     PushFront   PopFront
  pre-#7180 0.765558    0.037761    0.762172    0.712351    0.766423
  master    0.903462    0.037960    0.761222    0.607732    0.824006
  this PR   0.754051    0.037753    0.761761    0.714192    0.764555
```

For reference, here are the regressions:
- [chapcs](http://chapel.sourceforge.net/perf/chapcs/?startdate=2017/09/07&enddate=2017/09/19&graphs=arrayvectoroperations)
- [chap04](http://chapel.sourceforge.net/perf/chap04/?startdate=2017/09/07&enddate=2017/09/19&graphs=arrayvectoroperations)

Also, preemptively annotated this change.