### PR TITLE
Fix bulk-transfer rank change compilation failures

### DIFF
--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -1574,11 +1574,11 @@ proc BlockArr.doiBulkTransferToDR(Barg, viewDom)
   if debugBlockDistBulkTransfer then
     writeln("In BlockArr.doiBulkTransferToDR()");
 
-  if this.rank == Barg.rank {
-    const Src = this;
-    const Dest = chpl__getActualArray(Barg);
-    const destView = chpl__getViewDom(Barg);
-    type el = Src.idxType;
+  const Src = this;
+  const Dest = chpl__getActualArray(Barg);
+  const destView = chpl__getViewDom(Barg);
+  type el = Src.idxType;
+  if this.rank == Dest.rank {
     coforall j in Src.dom.dist.targetLocDom do
       on Src.dom.dist.targetLocales(j)
       {
@@ -1614,10 +1614,10 @@ proc BlockArr.doiBulkTransferFromDR(Barg, viewDom)
   if debugBlockDistBulkTransfer then
     writeln("In BlockArr.doiBulkTransferFromDR");
 
-  if this.rank == Barg.rank {
-    const Dest = this;
-    const srcView = chpl__getViewDom(Barg);
-    type el = Dest.idxType;
+  const Dest    = this;
+  const srcView = chpl__getViewDom(Barg);
+  type el       = Dest.idxType;
+  if this.rank == srcView.rank {
     coforall j in Dest.dom.dist.targetLocDom do
       on Dest.dom.dist.targetLocales(j)
       {

--- a/modules/dists/CyclicDist.chpl
+++ b/modules/dists/CyclicDist.chpl
@@ -1039,11 +1039,11 @@ proc CyclicArr.doiBulkTransferFrom(Barg, viewDom)
   if debugCyclicDistBulkTransfer then
     writeln("In CyclicArr.doiBulkTransferFrom()");
 
-  if this.rank == Barg.rank {
-    const Dest = this;
-    const Src = chpl__getActualArray(Barg);
-    const srcView = chpl__getViewDom(Barg);
-    type el = Dest.idxType;
+  const Dest = this;
+  const Src = chpl__getActualArray(Barg);
+  const srcView = chpl__getViewDom(Barg);
+  type el = Dest.idxType;
+  if this.rank == Src.rank {
     coforall i in Dest.dom.dist.targetLocDom do // for all locales
       on Dest.dom.dist.targetLocs(i)
       {
@@ -1069,7 +1069,7 @@ proc CyclicArr.doiBulkTransferFrom(Barg, viewDom)
           if debugCyclicDistBulkTransfer then
             writeln("B[",(...r1),"] ToDR A[",regionDest, "] ");
 
-          Barg._value.doiBulkTransferToDR(Dest.locArr[i].myElems[regionDest], Barg.domain[(...r1)]);
+          Barg._value.doiBulkTransferToDR(Dest.locArr[i].myElems[regionDest], {(...r1)});
         }
       }
   }
@@ -1082,11 +1082,11 @@ proc CyclicArr.doiBulkTransferToDR(Barg, viewDom)
   if debugCyclicDistBulkTransfer then
     writeln("In CyclicArr.doiBulkTransferToDR()");
 
-  if this.rank == Barg.rank {
-    const Src = this;
-    const Dest = chpl__getActualArray(Barg);
-    const destView = chpl__getViewDom(Barg);
-    type el = Src.idxType;
+  const Src = this;
+  const Dest = chpl__getActualArray(Barg);
+  const destView = chpl__getViewDom(Barg);
+  type el = Src.idxType;
+  if this.rank == Dest.rank {
     coforall j in Src.dom.dist.targetLocDom do // for all locales
       on Src.dom.dist.targetLocs(j)
       {
@@ -1126,11 +1126,11 @@ proc CyclicArr.doiBulkTransferFromDR(Barg, viewDom)
   if debugCyclicDistBulkTransfer then
     writeln("In CyclicArr.doiBulkTransferFromDR()");
 
-  if this.rank == Barg.rank {
-    const Dest = this;
-    const Src = chpl__getActualArray(Barg);
-    const srcView = chpl__getViewDom(Barg);
-    type el = Dest.idxType;
+  const Dest = this;
+  const Src = chpl__getActualArray(Barg);
+  const srcView = chpl__getViewDom(Barg);
+  type el = Dest.idxType;
+  if this.rank == Src.rank {
     coforall j in Dest.dom.dist.targetLocDom do // for all locales
       on Dest.dom.dist.targetLocs(j)
       {

--- a/modules/dists/StencilDist.chpl
+++ b/modules/dists/StencilDist.chpl
@@ -1861,11 +1861,11 @@ proc StencilArr.doiBulkTransferFrom(Barg, viewDom)
   if debugStencilDistBulkTransfer then
     writeln("In StencilArr.doiBulkTransferFrom()");
 
-  if this.rank == Barg.rank {
-    const Dest = this;
-    const Src = chpl__getActualArray(Barg);
-    const srcView = chpl__getViewDom(Barg);
-    type el = Dest.idxType;
+  const Dest = this;
+  const Src = chpl__getActualArray(Barg);
+  const srcView = chpl__getViewDom(Barg);
+  type el = Dest.idxType;
+  if this.rank == Src.rank {
     coforall i in Dest.dom.dist.targetLocDom do // for all locales
       on Dest.dom.dist.targetLocales(i)
       {
@@ -1890,7 +1890,7 @@ proc StencilArr.doiBulkTransferFrom(Barg, viewDom)
           if debugStencilDistBulkTransfer then
               writeln("B{",(...r1),"}.ToDR",regionDest);
 
-          Barg._value.doiBulkTransferToDR(Dest.locArr[i].myElems[regionDest], Barg.domain[(...r1)]);
+          Barg._value.doiBulkTransferToDR(Dest.locArr[i].myElems[regionDest], {(...r1)});
         }
       }
   }
@@ -1903,11 +1903,11 @@ proc StencilArr.doiBulkTransferToDR(Barg, viewDom)
   if debugStencilDistBulkTransfer then
     writeln("In StencilArr.doiBulkTransferToDR()");
 
-  if this.rank == Barg.rank {
-    const Src = this;
-    const Dest = chpl__getActualArray(Barg);
-    const destView = chpl__getViewDom(Barg);
-    type el = Src.idxType;
+  const Src = this;
+  const Dest = chpl__getActualArray(Barg);
+  const destView = chpl__getViewDom(Barg);
+  type el = Src.idxType;
+  if this.rank == Dest.rank {
     coforall j in Src.dom.dist.targetLocDom do
       on Src.dom.dist.targetLocales(j)
       {
@@ -1943,10 +1943,10 @@ proc StencilArr.doiBulkTransferFromDR(Barg, viewDom)
   if debugStencilDistBulkTransfer then
     writeln("In StencilArr.doiBulkTransferFromDR");
 
-  if this.rank == Barg.rank {
-    const Dest = this;
-    const srcView = chpl__getViewDom(Barg);
-    type el = Dest.idxType;
+  const Dest = this;
+  const srcView = chpl__getViewDom(Barg);
+  type el = Dest.idxType;
+  if this.rank == srcView.rank {
     coforall j in Dest.dom.dist.targetLocDom do
       on Dest.dom.dist.targetLocales(j)
       {

--- a/test/distributions/robust/arithmetic/collapsing/rankChangeAssign.chpl
+++ b/test/distributions/robust/arithmetic/collapsing/rankChangeAssign.chpl
@@ -1,0 +1,114 @@
+
+use Random;
+
+use driver;
+use driver_domains;
+use driver_arrays;
+
+config const seed = 1234;
+
+config const debug = false;
+
+proc DEBUG() { if debug then writeln(); }
+proc DEBUG(const args ...?n) {
+  if debug then writeln((...args));
+}
+
+test(DistType.default);
+test(DistType.block);
+test(DistType.cyclic);
+
+proc test(param DT : DistType) {
+  DEBUG();
+  DEBUG("==================================================");
+  DEBUG(DT:string, " VS ", distType:string);
+  DEBUG();
+  const (oneD, _, threeD, _, _) = setupDistributions(DT);
+
+  const localOne   : domain(1) dmapped oneD   = Space1;
+  const localThree : domain(3) dmapped threeD = Space3;
+
+  var arrOne   : [localOne]   int;
+  var arrThree : [localThree] int;
+
+  // DT.1D = distType.2D[rankchange];
+  assign(arrOne, A2D, 1);
+
+  // distType.2D[rankchange] = DT.1D
+  assign(A2D, arrOne, 1);
+
+  // DT.3D[rankchange] = distType.4D[rankchange]
+  assign(arrThree, A4D, 2);
+
+  // distType.4D[rankchange] = DT.3D[rankchange]
+  assign(A4D, arrThree, 2);
+  DEBUG("==================================================");
+}
+
+proc assign(left, right, param rank:int) {
+  const leftDom  = {(...left.domain.dims())};
+  const rightDom = {(...right.domain.dims())};
+
+  proc buildSlice(dom, param targetRank:int) {
+    param numCollapsed = dom.rank - targetRank;
+    param numFull      = dom.rank - numCollapsed;
+
+    if numCollapsed == 0 {
+      var ret : numFull * dom.dim(1).type;
+      return ret;
+    } else {
+      var collapsed : numCollapsed * dom.dim(1).idxType;
+      var full      : numFull * dom.dim(1).type;
+      var ret = ((...collapsed), (...full));
+      return ret;
+    }
+  }
+
+  proc fillSlice(ref slice, A, B) {
+    for param i in 1..A.rank {
+      slice(i) = if isRange(slice(i)) then A.dim(1)[B.dim(1)]
+                 else A.dim(1).first;
+    }
+  }
+
+  var lslice = buildSlice(leftDom, rank);
+  var rslice = buildSlice(rightDom, rank);
+
+  fillSlice(lslice, leftDom, rightDom);
+  fillSlice(rslice, rightDom, leftDom);
+
+  DEBUG();
+  DEBUG("--------------------------------------------------");
+  DEBUG("Target rank = ", rank);
+  DEBUG();
+  DEBUG("LHS type  : ", left.type:string);
+  DEBUG("LHS dom   : ", leftDom);
+  DEBUG("LHS slice : ", lslice);
+  DEBUG();
+  DEBUG("RHS type  : ", right.type:string);
+  DEBUG("RHS dom   : ", rightDom);
+  DEBUG("RHS slice : ", rslice);
+
+  assign(left, lslice, right, rslice);
+  DEBUG();
+  DEBUG("SUCCESS");
+
+  DEBUG("--------------------------------------------------");
+}
+
+proc assign(left, lslice, right, rslice) {
+  // make copies
+  var LHS = left;
+  var RHS = right;
+
+  fillRandom(RHS, seed);
+
+  ref leftView = LHS[(...lslice)];
+  ref rightView = RHS[(...rslice)];
+
+  leftView = rightView;
+
+  forall (L, R) in zip(leftView, rightView) {
+    assert(L == R);
+  }
+}

--- a/test/distributions/robust/arithmetic/driver.chpl
+++ b/test/distributions/robust/arithmetic/driver.chpl
@@ -18,8 +18,8 @@ const Space3 = {1..n3, 1..n3, 1..n3};
 const Space4 = {1..n4, 1..n4, 1..n4, 1..n4};
 const Space2D32 = {n5-o5:int(32)..n5, n5..n5+o5:int(32)};
 
-proc setupDistributions() {
-  if distType == DistType.default {
+proc setupDistributions(param DT : DistType) {
+  if DT == DistType.default {
     return (
             defaultDist,
             defaultDist,
@@ -28,7 +28,7 @@ proc setupDistributions() {
             defaultDist,
            );
   }
-  if distType == DistType.block {
+  if DT == DistType.block {
     return (
             new dmap(new Block(rank=1, boundingBox=Space1)),
             new dmap(new Block(rank=2, boundingBox=Space2)),
@@ -37,7 +37,7 @@ proc setupDistributions() {
             new dmap(new Block(rank=2, idxType=int(32), boundingBox=Space2D32))
            );
   }
-  if distType == DistType.cyclic {
+  if DT == DistType.cyclic {
     return (
             new dmap(new Cyclic(startIdx=0)),
             new dmap(new Cyclic(startIdx=(0,0))),
@@ -46,7 +46,7 @@ proc setupDistributions() {
             new dmap(new Cyclic(startIdx=(0:int(32), 0:int(32))))
            );
   }
-  if distType == DistType.blockcyclic {
+  if DT == DistType.blockcyclic {
     return (
             new dmap(new BlockCyclic(startIdx=(0,), blocksize=(3,))),
             new dmap(new BlockCyclic(startIdx=(0,0), blocksize=(3,3))),
@@ -55,7 +55,7 @@ proc setupDistributions() {
             new dmap(new BlockCyclic(startIdx=(0:int(32),0:int(32)), blocksize=(2:int(32),3:int(32))))
            );
   }
-  if distType == DistType.replicated {
+  if DT == DistType.replicated {
     return (
             new dmap(new Replicated()),
             new dmap(new Replicated()),
@@ -64,7 +64,7 @@ proc setupDistributions() {
             new dmap(new Replicated())
            );
   }
-  if distType == DistType.stencil {
+  if DT == DistType.stencil {
     return (
             new dmap(new Stencil(rank=1, boundingBox=Space1)),
             new dmap(new Stencil(rank=2, boundingBox=Space2)),
@@ -73,10 +73,10 @@ proc setupDistributions() {
             new dmap(new Stencil(rank=2, idxType=int(32), boundingBox=Space2D32))
            );
   }
-  halt("unexpected 'distType': ", distType);
+  halt("unexpected 'distType': ", DT);
 }
 
-const (Dist1D, Dist2D, Dist3D, Dist4D, Dist2D32) = setupDistributions();
+const (Dist1D, Dist2D, Dist3D, Dist4D, Dist2D32) = setupDistributions(distType);
 
 //
 // creates a tuple of size 'rank' initialized with values 'x'


### PR DESCRIPTION
This PR fixes various compile-time errors due to rank mismatches. A new test has been added to test the cross product of rank changes between default, Block, and Cyclic distributions.

Testing:
- [x] full gasnet
- [x] dist-cyclic
- [x] dist-replicated