### PR TITLE
Squash most mason leaks

### DIFF
--- a/modules/packages/TOML.chpl
+++ b/modules/packages/TOML.chpl
@@ -350,37 +350,74 @@ pragma "no doc"
 
  pragma "no doc"
  proc =(ref t: Toml, s: string) {
-   t = new Toml(s);
+   if t == nil {
+     t = new Toml(s);
+   } else {
+     t.tag = fieldString;
+     t.s = s;
+   }
  }
 
  pragma "no doc"
  proc =(ref t: Toml, i: int) {
-   t = new Toml(i);
+   if t == nil {
+     t = new Toml(i);
+   } else {
+     t.tag = fieldInt;
+     t.i = i;
+   }
  }
 
  pragma "no doc"
  proc =(ref t: Toml, b: bool) {
-   t = new Toml(b);
+   if t == nil {
+     t = new Toml(b);
+   } else {
+     t.tag = fieldBool;
+     t.boo = b;
+   }
  }
 
  pragma "no doc"
  proc =(ref t: Toml, r: real) {
-   t = new Toml(r);
+   if t == nil {
+     t = new Toml(r);
+   } else {
+     t.tag = fieldReal;
+     t.re = r;
+   }
  }
 
  pragma "no doc"
  proc =(ref t: Toml, dt: datetime) {
-   t = new Toml(dt);
+   if t == nil {
+     t = new Toml(dt);
+   } else {
+     t.tag = fieldDate;
+     t.dt = dt;
+   }
  }
 
  pragma "no doc"
  proc =(ref t: Toml, A: [?D] Toml) where isAssociativeDom(D) {
-   t = new Toml(A);
+   if t == nil {
+     t = new Toml(A);
+   } else {
+     t.tag = fieldToml;
+     t.D = D;
+     t.A = A;
+   }
  }
 
  pragma "no doc"
  proc =(ref t: Toml, arr: [?dom] Toml) where !isAssociativeDom(dom){
-   t = new Toml(arr);
+   if t == nil {
+     t = new Toml(arr);
+   } else {
+     t.tag = fieldArr;
+     t.dom = dom;
+     t.arr = arr;
+   }
  }
 
 

--- a/tools/mason/MasonUpdate.chpl
+++ b/tools/mason/MasonUpdate.chpl
@@ -286,9 +286,11 @@ proc createDepTrees(depTree: Toml, deps: [?d] Toml, name: string) : Toml {
 
     depList.push_back(new Toml(package));
 
-    var dt: domain(string);
-    var depTbl: [dt] Toml;
-    depTree[package] = depTbl;
+    if depTree.pathExists(package) == false {
+      var dt: domain(string);
+      var depTbl: [dt] Toml;
+      depTree[package] = depTbl;
+    }
     depTree[package]["name"] = package;
     depTree[package]["version"] = version;
     depTree[package]["chplVersion"] = chplVersion;
@@ -299,6 +301,7 @@ proc createDepTrees(depTree: Toml, deps: [?d] Toml, name: string) : Toml {
       var manifests = getManifests(subDeps);
       var dependency = createDepTrees(depTree, manifests, package);
     }
+    delete dep;
     deps.remove(deps.domain.first);
   }
   if depList.domain.size > 0 then


### PR DESCRIPTION
In the TOML package, do not needlessly create Toml instances when we can just change the tag.

In mason-update:
- delete dependencies as they are processed
- do not clear a dependency's children (therefore leaking them) by assigning an empty associative array to an existing Toml

Testing:
- [x] correctness + valgrind
  - [x] modules/packages/Toml
  - [x] mason/