### PR TITLE
Remove dont_use_exit_use_chpl_exit_instead

### DIFF
--- a/runtime/include/chplrt.h
+++ b/runtime/include/chplrt.h
@@ -38,8 +38,6 @@
 
 #define _noop(x)
 
-#define exit    dont_use_exit_use_chpl_exit_instead
-
 #endif // LAUNCHER
 
 #endif

--- a/runtime/src/chplexit.c
+++ b/runtime/src/chplexit.c
@@ -30,8 +30,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#undef exit
-
 static void chpl_exit_common(int status, int all) {
   fflush(stdout);
   fflush(stderr);


### PR DESCRIPTION
The macro `define exit dont_use_exit_use_chpl_exit_instead` was used to prevent
accidental calls to exit instead of chpl_exit. Unfortunately this sort of macro
definition is error-prone because it replaces every `exit` token, not just
function calls. This is causing compilation failures with new versions of clang
on OSX with an error along the lines of:

```
 no member named 'dont_use_exit_use_chpl_exit_instead' in the global namespace
 using ::exit;
       ~~^
 ../../../../include/chplrt.h:41:17: note: expanded from macro 'exit'
 #define exit    dont_use_exit_use_chpl_exit_instead
```

This just removes the macro, because we don't believe it's very useful anymore.
We could add a lookForBadExit script (similar to ./util/devel/lookForBadAlloc
that replaced the similar macros for the system allocator) but that seems like
overkill. Calling the wrong allocator can result in undefined behavior and
result in all sorts of nasty bugs, while calling exit has no such problems.
There's also no cases where we've accidentally added exit() or cases where we
needed to call the real exit, so it doesn't seem worthwhile to check for calls.