### PR TITLE
Disable nil checks for LCALS correctness testing

### DIFF
--- a/test/release/examples/benchmarks/lcals/LCALSMain.compopts
+++ b/test/release/examples/benchmarks/lcals/LCALSMain.compopts
@@ -1,3 +1,3 @@
-# This code takes too much time with bounds checks enabled. Don't print timing
-# or checksum output, or else we'd have to filter it out in testing
---no-bounds-checks -soutputFormat=OutputStyle.MINIMAL
+# This code takes too much time with bounds/nil checks enabled. Don't print
+# timing or checksum output, or else we'd have to filter it out in testing
+--no-bounds-checks --no-nil-checks -soutputFormat=OutputStyle.MINIMAL


### PR DESCRIPTION
Disable nil checks for LCALS. #7371 fixed some LICM reference bugs and as a
result some references in LCALS are no longer being hoisted. These references
are being nil checked, and lcals does a lot of trials so the cost of nil checks
really adds up.

Disabling nil checks takes the execution time from 15 minutes to 7 minutes on
chapcs.