### PR TITLE
Keep deprecated LayoutCSR documented

### DIFF
--- a/doc/rst/developer/bestPractices/Deprecation.rst
+++ b/doc/rst/developer/bestPractices/Deprecation.rst
@@ -1,0 +1,9 @@
+Chapel's Deprecation Policy
+===========================
+
+Chapel's general policy for deprecation is to:
+
+- Provide a compiler warning (or error) when a deprecated feature is used
+- Continue to document and support the deprecated feature for 1 release cycle
+  - The documentation should contain a pointer to the preferred feature
+  - This holds true for modules as well

--- a/modules/Makefile
+++ b/modules/Makefile
@@ -132,6 +132,7 @@ DISTS_TO_DOCUMENT = \
 	dists/dims/BlockDim.chpl \
 	dists/dims/ReplicatedDim.chpl \
 	layouts/LayoutCS.chpl \
+	layouts/LayoutCSR.chpl \
 
 INTERNAL_MODULES_TO_DOCUMENT =                \
 	internal/Atomics.chpl                 \

--- a/modules/layouts/LayoutCSR.chpl
+++ b/modules/layouts/LayoutCSR.chpl
@@ -1,15 +1,15 @@
 /*
  * Copyright 2004-2017 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,19 +17,22 @@
  * limitations under the License.
  */
 
-config param debugCSR = false;
-use LayoutCS;
+/* Deprecated. Use the module :mod:`LayoutCS` instead. */
+module LayoutCSR {
+  use LayoutCS;
 
-pragma "no doc"
+  pragma "no doc"
+  config param debugCSR = false;
 
-// TODO: It would be nice to support CSR & CSC type-aliases in LayoutCS
-/* For backwards-compatibility with LayoutCSR */
-type CSR = CS;
+  // TODO: It would be nice to support CSR & CSC type-aliases in LayoutCS
+  /* CSR type-alias provided for backwards-compatibility*/
+  type CSR = CS;
 
-compilerWarning(
-  "Module 'LayoutCSR' has been deprecated in favor of 'LayoutCS'"
-);
+  compilerWarning(
+    "Module 'LayoutCSR' has been deprecated in favor of 'LayoutCS'"
+  );
 
-if debugCSR {
-  compilerError("'debugCSR' has been deprecated in favor of 'debugCS'");
+  if debugCSR {
+    compilerError("'debugCSR' has been deprecated in favor of 'debugCS'");
+  }
 }


### PR DESCRIPTION
LayoutCSR was deprecated for LayoutCS (#6936), and its documentation was removed. It was later decided that we should keep the deprecated module documentation up for 1 release cycle.

I did not add `LayoutCSR` back to the list of modules for the docs post-processing script because I want the `type CSR` documentation shown.

Also, added a note about deprecation policies for future chapel devs.