### PR TITLE
Fix replaceRecordWrappedRefs()

### DIFF
--- a/compiler/passes/parallel.cpp
+++ b/compiler/passes/parallel.cpp
@@ -1694,6 +1694,10 @@ static void replaceRecordWrappedRefs() {
           fixLHS(call, todo);
         }
       }
+      else if (call->isPrimitive(PRIM_DEREF)) {
+        SET_LINENO(call);
+        call->replace(se->copy());
+      }
       else if (call->isPrimitive(PRIM_GET_MEMBER_VALUE)) {
         if (se == call->get(2)) {
           CallExpr* move = toCallExpr(call->parentExpr);


### PR DESCRIPTION
One case was missing there, triggering a regression
in test/trivial/sidelnik/reduction.chpl under --baseline.

It's somewhat surprising that we had not hit his without --baseline.
Probably that case had been handled by some optimization.

This changes adds this missing case and fixes the regression.

Passes linux64 --verify, baseline, gasnet testing.
Clarification: linux64 and gasnet failed for me in
mason/chplVersion/newTest/src, which I don't think is related.
baseline failed on two tests; I verified that the same failures
are presented on master as of 682deb5 without this change as well.

Produced by @benharsh.
