### PR TITLE
Fix write cptr baseline

### DIFF
--- a/modules/internal/CPtr.chpl
+++ b/modules/internal/CPtr.chpl
@@ -55,6 +55,13 @@ module CPtr {
       if x then do writeln("x is not nil");
       if !x then do writeln("x is nil");
 
+    Additionally, a ``c_ptr`` can be output like so:
+
+    .. code-block:: chapel
+
+      var x: c_ptr = c_ptrTo(...);
+      writeln(x); // outputs nil or e.g. 0xabc123000000
+
   */
 
   //   Similar to _ddata from ChapelBase, but differs

--- a/modules/internal/CPtr.chpl
+++ b/modules/internal/CPtr.chpl
@@ -87,14 +87,10 @@ module CPtr {
 
   pragma "no doc"
   inline proc c_void_ptr.writeThis(ch) {
-    if this == c_nil {
-      ch <~> "(nil)";
-    } else {
-      var err:syserr = ENOERR;
-      ch.writef(error=err, "0x%xu", this:c_uintptr);
-      if err then
-        ch.setError(err);
-    }
+    var err:syserr = ENOERR;
+    ch.writef(error=err, "0x%xu", this:c_uintptr);
+    if err then
+      ch.setError(err);
   }
 
   pragma "no doc"

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -3024,7 +3024,7 @@ private inline proc _write_one_internal(_channel_internal:qio_channel_ptr_t,
   // to stop writing if there was an error.
   qio_channel_clear_error(_channel_internal);
 
-  if (isClassType(t) || chpl_isDdata(t)) && x == nil {
+  if (isClassType(t) || chpl_isDdata(t) || isAnyCPtr(t)) && x == nil {
     // future - write class IDs, have serialization format
     var st = writer.styleElement(QIO_STYLE_ELEMENT_AGGREGATE);
     var iolit:ioLiteral;

--- a/test/io/nspark/print-cptr.good
+++ b/test/io/nspark/print-cptr.good
@@ -1,5 +1,5 @@
-c_nil = (nil)
-foo = (mem = (nil))
+c_nil = nil
+foo = (mem = nil)
 foo = (mem = 0x???)
-bar = (mem = (nil))
+bar = (mem = nil)
 bar = (mem = 0x???)


### PR DESCRIPTION
Follow-on to PR #7254.

This PR adds some documentation and moves the nil-check to _write_one_internal.

Checking for nil in the writeThis method on c_ptr causes
runtime failures in --baseline (from checking that the `this`
for the called method is not `nil`, but it is).

Passed full local testing and --baseline testing for the test that failed.

Reviewed by @lydia-duncan - thanks!