### PR TITLE
Restore performance for substring test

### DIFF
--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -465,10 +465,11 @@ module String {
           thisBuff = this.buff;
         }
 
+        var buff = ret.buff; // Has perf impact and our LICM can't hoist :(
         for (r2_i, i) in zip(r2, 0..) {
-          ret.buff[i] = thisBuff[r2_i-1];
+          buff[i] = thisBuff[r2_i-1];
         }
-        ret.buff[ret.len] = 0;
+        buff[ret.len] = 0;
 
         if remoteThis then chpl_here_free(thisBuff);
       }


### PR DESCRIPTION
Restore performance for the "search within a string" test. #7371 fixed some
LICM reference bugs and as a result we're no longer hoisting some buffer temps
in String.this(r: range) (substring). Getting LICM to actually hoist these
temps again is a huge undertaking, so for now manually hoist a temp in the
String module. This is admittedly lame, but without this we pay a 250%
performance loss for the substring performance test.