### PR TITLE
Add a skipif to avoid a test in --baseline

### DIFF
--- a/test/extern/ferguson/return-int-pretend-void.skipif
+++ b/test/extern/ferguson/return-int-pretend-void.skipif
@@ -1,0 +1,2 @@
+COMPOPTS <= --baseline
+# This test doesn't work in --baseline configuration


### PR DESCRIPTION
This test in effect lies to the compiler about the return type in an `extern proc` declaration. In some cases such confusion can be useful to paper over trivial implementation differences. Nonetheless, the compiler will generate erroneous C code in this case with `--baseline` so skip the test in that configuration. The intent of the test is not that we must always support this in all configurations; more that if it's easy for us to support it we should.