### PR TITLE
AstDumpToNode :- print the raw type-qualifier rather than the filtered one

### DIFF
--- a/compiler/AST/AstDumpToNode.cpp
+++ b/compiler/AST/AstDumpToNode.cpp
@@ -1941,7 +1941,7 @@ void AstDumpToNode::ast_symbol(Symbol* sym, bool def)
 
 int AstDumpToNode::writeQual(QualifiedType qual) const
 {
-  const char* name = qual.qualStr();
+  const char* name = qualifierToStr(qual.getQual());
 
   if (compact)
     fprintf(mFP, " qual: %s", name);


### PR DESCRIPTION
While looking at cullOverReferences.cpp I noticed that AstDumpToNode wasn't printing
the type-qualifier in the way I expected/preferred.  Update that to show the "raw"
value rather than the "processed" value.

Compiled on clang/darwin and gcc/linux64 with/without CHPL_DEVELOPER.
Abbreviated testing using start_test.

