### PR TITLE
Fix an error in chplenv.rst

### DIFF
--- a/doc/rst/usingchapel/chplenv.rst
+++ b/doc/rst/usingchapel/chplenv.rst
@@ -490,8 +490,8 @@ CHPL_GMP
 CHPL_HWLOC
 ~~~~~~~~~~
    Optionally, the ``CHPL_HWLOC`` environment variable can select between
-   no hwloc support, using the hwloc package distributed with Chapel in
-   third-party, or using a system jemalloc.
+   no hwloc support or using the hwloc package distributed with Chapel in
+   third-party.
 
        ======== ==============================================================
        Value    Description


### PR DESCRIPTION
CHPL_HWLOC=system isn't supposed to be user facing but
at one point during development it was, and the leading
sentence was left in... as a copy of some text about jemalloc.

Reviewed by @ben-albrecht - thanks!