### PR TITLE
Make --llvm-print-ir a developer flag

### DIFF
--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -855,8 +855,6 @@ static ArgumentDescription arg_desc[] = {
  {"", ' ', NULL, "LLVM Code Generation Options", NULL, NULL, NULL, NULL},
  {"llvm", ' ', NULL, "[Don't] use the LLVM code generator", "N", &llvmCodegen, "CHPL_LLVM_CODEGEN", NULL},
  {"llvm-wide-opt", ' ', NULL, "Enable [disable] LLVM wide pointer optimizations", "N", &fLLVMWideOpt, "CHPL_LLVM_WIDE_OPTS", NULL},
- {"llvm-print-ir", ' ', "<name>", "Dump LLVM Intermediate Representation of given function to stdout", "S256", llvmPrintIrName, "CHPL_LLVM_PRINT_IR", NULL},
- {"llvm-print-ir-stage", ' ', "<stage>", "Specifies from which LLVM optimization stage to print function: none, basic, full", "S256", llvmPrintIrStage, "CHPL_LLVM_PRINT_IR_STAGE", &verifyStageAndSetStageNum},
  {"mllvm", ' ', "<flags>", "LLVM flags (can be specified multiple times)", "S", NULL, "CHPL_MLLVM", setLLVMFlags},
 
  {"", ' ', NULL, "Compilation Trace Options", NULL, NULL, NULL, NULL},
@@ -930,6 +928,8 @@ static ArgumentDescription arg_desc[] = {
  {"log-pass", ' ', "<passname>", "Restrict IR dump to the named pass. Can be specified multiple times", "S", NULL, "CHPL_LOG_PASS", setLogPass},
  {"log-node", ' ', NULL, "Dump IR using AstDumpToNode", "F", &fLogNode, "CHPL_LOG_NODE", NULL},
 // {"log-symbol", ' ', "<symbol-name>", "Restrict IR dump to the named symbol(s)", "S256", log_symbol, "CHPL_LOG_SYMBOL", NULL}, // This doesn't work yet.
+ {"llvm-print-ir", ' ', "<name>", "Dump LLVM Intermediate Representation of given function to stdout", "S256", llvmPrintIrName, "CHPL_LLVM_PRINT_IR", NULL},
+ {"llvm-print-ir-stage", ' ', "<stage>", "Specifies from which LLVM optimization stage to print function: none, basic, full", "S256", llvmPrintIrStage, "CHPL_LLVM_PRINT_IR_STAGE", &verifyStageAndSetStageNum},
  {"verify", ' ', NULL, "Run consistency checks during compilation", "N", &fVerify, "CHPL_VERIFY", NULL},
  {"parse-only", ' ', NULL, "Stop compiling after 'parse' pass for syntax checking", "N", &fParseOnly, NULL, NULL},
  {"parser-debug", 'D', NULL, "Set parser debug level", "+", &debugParserLevel, "CHPL_PARSER_DEBUG", NULL},

--- a/man/chpl.rst
+++ b/man/chpl.rst
@@ -425,30 +425,8 @@ OPTIONS
     example, they might be able to hoist a 'get' out of a loop. See
     $CHPL\_HOME/doc/rst/technotes/llvm.rst for details.
 
-**--llvm-print-ir <name>**
-    Print intermediate representation (IR) of function named <name>. 
-    Need to specify stage using  **--llvm-print-ir-stage** in order 
-    to be printed.
-
-**--llvm-print-ir-stage <stage>**
-    Picks stage from which to print LLVM IR of function defined in 
-    **--llvm-print-ir**. 
-    The chapel compiler runs many different optimization passes each of which
-    can change IR of functions. This option allows one to pick IR of function
-    from some stages of optimization.
-
-    There are 3 optimization stages: none, basic, full:
-
-    1. 'none' is stage before any optimization has occurred
-    2. 'basic' is stage where basic optimizations occurs.
-    3. 'full' is stage where all kinds of optimization occurs, these consist
-        of very big optimizations executed by chapel compiler on LLVM IR.
-
-    Note that sometimes function might not be printed, for example when
-    one optimization pass notes that function is unused and decides to remove
-    it.
-
 **--mllvm <option>**
+
     Pass an option to the LLVM optimization and transformation passes.
     This option can be specified multiple times.
 

--- a/test/compflags/bradc/help/userhelp.good
+++ b/test/compflags/bradc/help/userhelp.good
@@ -99,11 +99,6 @@ LLVM Code Generation Options:
       --[no-]llvm                     [Don't] use the LLVM code generator
       --[no-]llvm-wide-opt            Enable [disable] LLVM wide pointer
                                       optimizations
-      --llvm-print-ir <name>          Dump LLVM Intermediate Representation of
-                                      given function to stdout
-      --llvm-print-ir-stage <stage>   Specifies from which LLVM optimization
-                                      stage to print function: none, basic,
-                                      full
       --mllvm <flags>                 LLVM flags (can be specified multiple
                                       times)
 


### PR DESCRIPTION
Suggested by @bradcray.

PR #6135 added --llvm-print-ir and documented it as a user feature... But this feature is really only useful to developers or expert users who might used developer flags anyway.

Passed full local testing.