### PR TITLE
Add a .future about dynamic dispatch on iterators

### DIFF
--- a/test/functions/iterators/diten/dynamicDispatchIterator3Levels.bad
+++ b/test/functions/iterators/diten/dynamicDispatchIterator3Levels.bad
@@ -1,0 +1,7 @@
+internal error: VIR0377 chpl Version 1.16.0 pre-release (d9b1d3d)
+
+Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
+please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
+the filename + line number above may be useful in working around the issue.
+

--- a/test/functions/iterators/diten/dynamicDispatchIterator3Levels.chpl
+++ b/test/functions/iterators/diten/dynamicDispatchIterator3Levels.chpl
@@ -1,0 +1,46 @@
+class Parent {
+  iter myit() {
+    var low = 1;
+    var high = 4;
+    writeln("Parent");
+    for i in low..high {
+      yield i;
+    }
+  }
+}
+
+class Child: Parent {
+  iter myit() {
+    var low = 1;
+    var high = 8;
+    var stride = 2;
+    writeln("Child");
+    for i in low..high by stride {
+      yield i;
+    }
+  }
+}
+
+class Grandchild: Child {
+  iter myit() {
+    var low = 2;
+    var high = 8;
+    var stride = 2;
+
+    writeln("Grandchild");
+    for i in low..high by stride {
+      yield i;
+    }
+  }
+}
+
+var p1: Parent = new Child();
+var p2: Parent = new Grandchild();
+
+for i in p1.myit() {
+  writeln(i);
+}
+
+for i in p2.myit() {
+  writeln(i);
+}

--- a/test/functions/iterators/diten/dynamicDispatchIterator3Levels.future
+++ b/test/functions/iterators/diten/dynamicDispatchIterator3Levels.future
@@ -1,0 +1,3 @@
+bug: Iterator inheriting 3 or more levels deep causes assertion failure
+
+Issue #7429

--- a/test/functions/iterators/diten/dynamicDispatchIterator3Levels.good
+++ b/test/functions/iterators/diten/dynamicDispatchIterator3Levels.good
@@ -1,0 +1,10 @@
+Child
+1
+3
+5
+7
+Grandchild
+2
+4
+6
+8


### PR DESCRIPTION
A dynamic dispatch on a serial iterator causes an internal
compiler error if the inheritance chain is at least 3 levels
deep (e.g. Parent, Child, Grandchild).

Issue #7429.