### PR TITLE
Manually hoist loop-invariant array access in miniMD

### DIFF
--- a/test/release/examples/benchmarks/miniMD/helpers/neighbor.chpl
+++ b/test/release/examples/benchmarks/miniMD/helpers/neighbor.chpl
@@ -12,7 +12,8 @@ proc updateFluff() {
     // boundaries() yields a periodic array element, and the 
     // neighbor panel value
     forall (pos, N) in Pos.boundaries() {
-      for p in pos do p += PosOffset[N];
+      const PO = PosOffset[N];
+      for p in pos do p += PO;
     }
   } else {
     forall (P, D, S) in zip(PosOffset, Dest, Src) {


### PR DESCRIPTION
This change recovers performance lost due to #7371 , and improves performance by 30% on 16-node-xc.