### PR TITLE
Launchers should run "sbatch --version" without a temp. "command" file.

### DIFF
--- a/runtime/src/launch/pbs-gasnetrun_ibv/launch-pbs-gasnetrun_ibv.c
+++ b/runtime/src/launch/pbs-gasnetrun_ibv/launch-pbs-gasnetrun_ibv.c
@@ -59,12 +59,13 @@ static qsubVersion determineQsubVersion(void) {
   FILE* sysFile;
   int i;
 
-  char* command = chpl_glom_strings(3, "qsub --version > ", sysFilename, " 2>&1");
-  system(command);
-  sysFile = fopen(sysFilename, "r");
+  sysFile = popen("qsub --version", "r");
+  if (sysFile == NULL) {
+    return unknown;
+  }
   for (i=0; i<versionBuffLen; i++) {
     char tmp;
-    fscanf(sysFile, "%c", &tmp);
+    tmp = fgetc(sysFile);
     if (tmp == '\n') {
       *versionPtr++ = '\0';
       break;
@@ -73,7 +74,7 @@ static qsubVersion determineQsubVersion(void) {
     }
   }
 
-  fclose(sysFile);
+  pclose(sysFile);
   if (strstr(version, "NCCS")) {
     return nccs;
   } else if (strstr(version, "PBSPro")) {

--- a/runtime/src/launch/slurm-gasnetrun_ibv/launch-slurm-gasnetrun_ibv.c
+++ b/runtime/src/launch/slurm-gasnetrun_ibv/launch-slurm-gasnetrun_ibv.c
@@ -70,12 +70,13 @@ static sbatchVersion determineQsubVersion(void) {
   FILE* sysFile;
   int i;
 
-  char* command = chpl_glom_strings(3, "sbatch --version > ", sysFilename, " 2>&1");
-  system(command);
-  sysFile = fopen(sysFilename, "r");
+  sysFile = popen("sbatch --version", "r");
+  if (sysFile == NULL) {
+    return unknown;
+  }
   for (i=0; i<versionBuffLen; i++) {
     char tmp;
-    fscanf(sysFile, "%c", &tmp);
+    tmp = fgetc(sysFile);
     if (tmp == '\n') {
       *versionPtr++ = '\0';
       break;
@@ -84,7 +85,7 @@ static sbatchVersion determineQsubVersion(void) {
     }
   }
 
-  fclose(sysFile);
+  pclose(sysFile);
   if (strstr(version, "NCCS")) {
     return nccs;
   } else if (strstr(version, "SBATCHPro")) {

--- a/runtime/src/launch/slurm-gasnetrun_ibv/launch-slurm-gasnetrun_ibv.c
+++ b/runtime/src/launch/slurm-gasnetrun_ibv/launch-slurm-gasnetrun_ibv.c
@@ -51,7 +51,6 @@ char sysFilename[FILENAME_MAX];
 
 /* copies of binary to run per node */
 #define procsPerNode 1  
-#define versionBuffLen 80
 
 #define launcherAccountEnvvar "CHPL_LAUNCHER_ACCOUNT"
 
@@ -64,28 +63,19 @@ typedef enum {
   unknown
 } sbatchVersion;
 
-static sbatchVersion determineQsubVersion(void) {
-  char version[versionBuffLen+1] = "";
-  char* versionPtr = version;
-  FILE* sysFile;
-  int i;
+static sbatchVersion determineSlurmVersion(void) {
+  const int buflen = 256;
+  char version[buflen];
+  char *argv[3];
+  argv[0] = (char *) "sbatch";
+  argv[1] = (char *) "--version";
+  argv[2] = NULL;
 
-  sysFile = popen("sbatch --version", "r");
-  if (sysFile == NULL) {
-    return unknown;
-  }
-  for (i=0; i<versionBuffLen; i++) {
-    char tmp;
-    tmp = fgetc(sysFile);
-    if (tmp == '\n') {
-      *versionPtr++ = '\0';
-      break;
-    } else {
-      *versionPtr++ = tmp;
-    }
+  memset(version, 0, buflen);
+  if (chpl_run_utility1K("sbatch", argv, version, buflen) <= 0) {
+    chpl_error("Error trying to determine sbatch version", 0, 0);
   }
 
-  pclose(sysFile);
   if (strstr(version, "NCCS")) {
     return nccs;
   } else if (strstr(version, "SBATCHPro")) {
@@ -222,7 +212,7 @@ static char* chpl_launch_create_command(int argc, char* argv[],
     slurmFile = fopen(slurmFilename, "w");
     fprintf(slurmFile, "#!/bin/sh\n\n");
     fprintf(slurmFile, "#SBATCH -J Chpl-%.10s\n", basenamePtr);
-    genNumLocalesOptions(slurmFile, determineQsubVersion(), numLocales, getNumCoresPerLocale());
+    genNumLocalesOptions(slurmFile, determineSlurmVersion(), numLocales, getNumCoresPerLocale());
     if (projectString && strlen(projectString) > 0)
       fprintf(slurmFile, "#SBATCH -A %s\n", projectString);
     if (getenv("CHPL_LAUNCHER_USE_SBATCH") != NULL) {


### PR DESCRIPTION
Using a temporary "command" file to execute "sbatch --version" was
unnecessary, and vulnerable to a variety of problems.

This changes the three launchers which did that to now run
"sbatch --version" directly, using popen().

   runtime/src/launch/pbs-gasnetrun_ibv/launch-pbs-gasnetrun_ibv.c
   runtime/src/launch/slurm-gasnetrun_ibv/launch-slurm-gasnetrun_ibv.c
   runtime/src/launch/slurm-srun/launch-slurm-srun.c