### PR TITLE
Increase the gasnet exit timeout under gasnet-{aries,gemini} again

### DIFF
--- a/runtime/src/comm/gasnet/comm-gasnet.c
+++ b/runtime/src/comm/gasnet/comm-gasnet.c
@@ -793,11 +793,13 @@ static void set_num_comm_domains() {
     chpl_error("Cannot setenv(\"GASNET_AM_DOMAIN_POLL_MASK\")", 0, 0);
   }
 
-  // for some reason a higher GASNET_DOMAIN_COUNT increases the exit time
+  // GASNET_DOMAIN_COUNT increases the shutdown time. Work around this for now.
+  // See https://github.com/chapel-lang/chapel/issues/7251 and
+  // https://upc-bugs.lbl.gov/bugzilla/show_bug.cgi?id=3621
   if (setenv("GASNET_EXITTIMEOUT_FACTOR", "0.5", 0) != 0) {
     chpl_error("Cannot setenv(\"GASNET_EXITTIMEOUT_FACTOR\")", 0, 0);
   }
-  if (setenv("GASNET_EXITTIMEOUT_MIN", "5.0", 0) != 0) {
+  if (setenv("GASNET_EXITTIMEOUT_MIN", "10.0", 0) != 0) {
     chpl_error("Cannot setenv(\"GASNET_EXITTIMEOUT_MIN\")", 0, 0);
   }
 #endif


### PR DESCRIPTION
Bump the default timeout again (first done in #7241). GASNet 1.30.0 added an
additional shutdown watchdog, which has caused us to see some sigalarms. We use
the multi-domain feature, which increases the shutdowm times so for now just
raise the default timeout. Note that there was no actual regression in the
shutdown times in 1.30.0, it's just that there is an extra watchdog whose limit
is too low when the multi-domain feature is being used.

For more info see https://github.com/chapel-lang/chapel/issues/7251 and
https://upc-bugs.lbl.gov/bugzilla/show_bug.cgi?id=3621