### PR TITLE
Pull in an upstream fix for a gemini/aries multi-domain init bug

### DIFF
--- a/third-party/gasnet/README
+++ b/third-party/gasnet/README
@@ -28,6 +28,9 @@ as follows:
   third-party/gasnet/gasnet-src/other/contrib/cross-configure-aarch64-linux
   which is the only ARM change beneath gasnet-src in the tree.
 
+* Pulled in an upstream fix for a gemini/aries multi-domain initialization bug:
+   - https://bitbucket.org/berkeleylab/gasnet/commits/ed2fd98eb
+
 Upgrading GASNet versions
 =========================
 

--- a/third-party/gasnet/gasnet-src/gasnet_syncops.h
+++ b/third-party/gasnet/gasnet-src/gasnet_syncops.h
@@ -686,6 +686,9 @@ gasneti_atomic_val_t gasneti_semaphore_trydown_partial_SEQ(gasneti_semaphore_t_S
  * pointer, we prohibit any use of the LIFO in which a former element becomes unmapped
  * unless one can ensure that no partially-completed POP could be referencing the
  * object.
+ *
+ * NOTE: Because of the specifics of the representation, it is not permitted to copy
+ * a gasneti_lifo_head_t by value.
  */
 
 

--- a/third-party/gasnet/gasnet-src/gemini-conduit/gasnet_gemini.c
+++ b/third-party/gasnet/gasnet-src/gemini-conduit/gasnet_gemini.c
@@ -935,7 +935,6 @@ uintptr_t gasnetc_init_messaging(void)
   gni_nic_handle_t nic_handle;
   gni_cq_handle_t bound_cq_handle;
   peer_struct_t *peer_data;
-  gasneti_lifo_head_t post_descriptor_pool = GASNETI_LIFO_INITIALIZER;
   gasnetc_domain_count = gasneti_getenv_int_withdefault("GASNET_DOMAIN_COUNT",
                GASNETC_DOMAIN_COUNT_DEFAULT,0);
   gasnetc_poll_am_domain_mask = gasneti_getenv_int_withdefault("GASNET_AM_DOMAIN_POLL_MASK",
@@ -1200,14 +1199,13 @@ uintptr_t gasnetc_init_messaging(void)
   for (i=0; i < gasnetc_log2_remote; ++i) {
     /* allocate individually to ease later destruction of this pool. */
     gasnetc_post_descriptor_t *gpd = gasneti_calloc(1, sizeof(gasnetc_post_descriptor_t));
-    gasneti_lifo_push(&post_descriptor_pool, gpd);
+    gasneti_lifo_push(&DOMAIN_SPECIFIC_VAL(post_descriptor_pool), gpd);
   }
 
 #if GASNETC_USE_MULTI_DOMAIN 
   DOMAIN_SPECIFIC_VAL(cdm_handle) = cdm_handle;
   DOMAIN_SPECIFIC_VAL(nic_handle) = nic_handle;
   DOMAIN_SPECIFIC_VAL(bound_cq_handle) = bound_cq_handle;
-  DOMAIN_SPECIFIC_VAL(post_descriptor_pool) = post_descriptor_pool;
   DOMAIN_SPECIFIC_VAL(peer_data) = peer_data;
   DOMAIN_SPECIFIC_VAL(threads_per_domain) = 1;
   DOMAIN_SPECIFIC_VAL(initialized) = 1;


### PR DESCRIPTION
Pull in an upstream GASNet patch for a gemini/aries multi-domain initialization
bug. Pulls in https://bitbucket.org/berkeleylab/gasnet/commits/ed2fd98eb.

This closes https://github.com/chapel-lang/chapel/issues/7436