### PR TITLE
Minor cleanups to "running on a cray" doc 

### DIFF
--- a/doc/rst/platforms/cray.rst
+++ b/doc/rst/platforms/cray.rst
@@ -177,7 +177,7 @@ Using Chapel on a Cray System
         source util/setchplenv.bash
 
 
-4) Compile your Chapel program.  For example:
+2) Compile your Chapel program.  For example:
 
    .. code-block:: sh
 
@@ -186,7 +186,7 @@ Using Chapel on a Cray System
    See :ref:`readme-compiling` or  ``man chpl`` for further details.
 
 
-5) If ``CHPL_LAUNCHER`` is set to anything other than ``none``, when you
+3) If ``CHPL_LAUNCHER`` is set to anything other than ``none``, when you
    compile a Chapel program for your Cray system, you will see two
    binaries (e.g., ``hello6-taskpar-dist`` and ``hello6-taskpar-dist_real``).
    The first binary contains code to launch the Chapel program onto
@@ -234,7 +234,7 @@ Using Chapel on a Cray System
    :ref:`readme-launcher`.
 
 
-6) Execute your Chapel program.  Multi-locale executions require the
+4) Execute your Chapel program.  Multi-locale executions require the
    number of locales (compute nodes) to be specified on the command
    line.  For example::
 
@@ -243,7 +243,7 @@ Using Chapel on a Cray System
    Requests the program to be executed using two locales.
 
 
-7) If your Cray system has compute nodes with varying numbers of
+5) If your Cray system has compute nodes with varying numbers of
    cores, you can request nodes with at least a certain number of
    cores using the variable ``CHPL_LAUNCHER_CORES_PER_LOCALE``.  For
    example, on a Cray system in which some compute nodes have 24 or
@@ -272,7 +272,7 @@ Using Chapel on a Cray System
    between Chapel launchers and workload managers.
 
 
-8) If your Cray system has compute nodes with varying numbers of CPUs
+6) If your Cray system has compute nodes with varying numbers of CPUs
    per compute unit, you can request nodes with a certain number of
    CPUs per compute unit using the variable ``CHPL_LAUNCHER_CPUS_PER_CU``.
    For example, on a Cray XC series system with some nodes having at

--- a/doc/rst/platforms/cray.rst
+++ b/doc/rst/platforms/cray.rst
@@ -480,9 +480,9 @@ Network Atomics
 ---------------
 
 The Gemini(TM) and Aries(TM) networks support remote atomic memory
-operations (AMOs) on XC, XE, and XK series systems.  When the ``CHPL_COMM``
-environment variable is set to ``ugni``, the following operations on
-remote atomics are done using the network::
+operations (AMOs) on XC, XE, and XK series systems.  When the
+``CHPL_NETWORK_ATOMICS`` environment variable is set to ``ugni``, the
+following operations on remote atomics are done using the network::
 
     32- and 64-bit signed and unsigned integer types:
     32- and 64-bit real types:

--- a/doc/rst/platforms/cray.rst
+++ b/doc/rst/platforms/cray.rst
@@ -139,10 +139,6 @@ Building Chapel for a Cray System from Source
        PrgEnv-gnu
        PrgEnv-intel
 
-   For PrgEnv-cray we recommend using CCE 8.4 or newer for best performance.
-   This allows us to build our recommended third-party packages (i.e. allows
-   us to default to CHPL_TASKS=qthreads instead of CHPL_TASKS=fifo)
-
 
 4) Optionally, set one or more of the following environment variables to
    configure the Chapel build.  These are described in greater detail in

--- a/doc/rst/platforms/cray.rst
+++ b/doc/rst/platforms/cray.rst
@@ -140,19 +140,7 @@ Building Chapel for a Cray System from Source
        PrgEnv-intel
 
 
-4) Optionally, set one or more of the following environment variables to
-   configure the Chapel build.  These are described in greater detail in
-   :ref:`readme-chplenv`.
-
-     :``CHPL_TASKS``: tasking implementation, default ``qthreads``
-     :``CHPL_COMM``: communication implementation, default ``ugni`` on
-                     XC/XE systems, ``gasnet`` on CS systems
-
-   For CS\ |trade| series systems, see :ref:`readme-infiniband` for
-   information about using Chapel with InfiniBand.
-
-
-5) Make sure you're in the top-level chapel/ directory and make/re-make the
+4) Make sure you're in the top-level chapel/ directory and make/re-make the
    compiler and runtime::
 
      gmake
@@ -189,27 +177,7 @@ Using Chapel on a Cray System
         source util/setchplenv.bash
 
 
-2) Optionally, set one or more of the following environment variables to
-   select a Chapel configuration.  These are described in greater detail
-   in :ref:`readme-chplenv`.
-
-     :``CHPL_TASKS``: tasking implementation, default ``qthreads``
-     :``CHPL_COMM``: communication implementation, default ``ugni`` on Cray
-                     XC/XE, ``gasnet`` on Cray CS
-
-   For CS\ |trade| series systems, see :ref:`readme-infiniband` for
-   information about using Chapel with InfiniBand.
-
-   The configuration selected must be one that is present in the Chapel
-   installation being used, whether that is a source distribution or the
-   pre-built module.  If it is not, the Chapel compiler will produce an
-   error message saying so when you try to compile anything.  If you get
-   this error, you will need to build the desired configuration (if you
-   are working from source) or modify your configuration so that it is
-   one of those supplied (if you are working with the pre-built module).
-
-
-3) Compile your Chapel program.  For example:
+4) Compile your Chapel program.  For example:
 
    .. code-block:: sh
 
@@ -218,7 +186,7 @@ Using Chapel on a Cray System
    See :ref:`readme-compiling` or  ``man chpl`` for further details.
 
 
-4) If ``CHPL_LAUNCHER`` is set to anything other than ``none``, when you
+5) If ``CHPL_LAUNCHER`` is set to anything other than ``none``, when you
    compile a Chapel program for your Cray system, you will see two
    binaries (e.g., ``hello6-taskpar-dist`` and ``hello6-taskpar-dist_real``).
    The first binary contains code to launch the Chapel program onto
@@ -266,7 +234,7 @@ Using Chapel on a Cray System
    :ref:`readme-launcher`.
 
 
-5) Execute your Chapel program.  Multi-locale executions require the
+6) Execute your Chapel program.  Multi-locale executions require the
    number of locales (compute nodes) to be specified on the command
    line.  For example::
 
@@ -275,7 +243,7 @@ Using Chapel on a Cray System
    Requests the program to be executed using two locales.
 
 
-6) If your Cray system has compute nodes with varying numbers of
+7) If your Cray system has compute nodes with varying numbers of
    cores, you can request nodes with at least a certain number of
    cores using the variable ``CHPL_LAUNCHER_CORES_PER_LOCALE``.  For
    example, on a Cray system in which some compute nodes have 24 or
@@ -304,7 +272,7 @@ Using Chapel on a Cray System
    between Chapel launchers and workload managers.
 
 
-7) If your Cray system has compute nodes with varying numbers of CPUs
+8) If your Cray system has compute nodes with varying numbers of CPUs
    per compute unit, you can request nodes with a certain number of
    CPUs per compute unit using the variable ``CHPL_LAUNCHER_CPUS_PER_CU``.
    For example, on a Cray XC series system with some nodes having at
@@ -439,27 +407,7 @@ To use ugni communications:
    layer.
 
 
-2) Set your CHPL_TASKS environment variable to ``qthreads`` (the
-   default) or ``fifo``:
-
-   .. code-block:: sh
-
-     export CHPL_TASKS=qthreads
-
-   or:
-
-   .. code-block:: sh
-
-     export CHPL_TASKS=fifo
-
-   Either of these tasking layers work with ugni communications.  Other
-   Chapel environment variables having to do with runtime layers can
-   be left unset.  Setting ``CHPL_COMM`` and ``CHPL_TASKS`` like this
-   will cause the correct combination of other runtime layers that work
-   with those to be selected automatically.
-
-
-3) *(Optional)* Load an appropriate ``craype-hugepages`` module.  For example::
+2) *(Optional)* Load an appropriate ``craype-hugepages`` module.  For example::
 
      module load craype-hugepages16M
 

--- a/doc/rst/platforms/cray.rst
+++ b/doc/rst/platforms/cray.rst
@@ -130,7 +130,6 @@ Building Chapel for a Cray System from Source
       ===========================  ==============================
       ...the GNU compiler (gcc)    gnu    (default)
       ...the Intel compiler (icc)  intel
-      ...the PGI compiler (pgcc)   pgi
       ===========================  ==============================
 
    On a Cray X-series system, ensure that you have one of the following
@@ -139,23 +138,13 @@ Building Chapel for a Cray System from Source
        PrgEnv-cray
        PrgEnv-gnu
        PrgEnv-intel
-       PrgEnv-pgi
 
    For PrgEnv-cray we recommend using CCE 8.4 or newer for best performance.
    This allows us to build our recommended third-party packages (i.e. allows
    us to default to CHPL_TASKS=qthreads instead of CHPL_TASKS=fifo)
 
-4) By default, ``g++`` will be used to compile code that runs on the login
-   node, such as the Chapel compiler and launcher code.  Optionally, you can
-   override this default by setting ``CHPL_HOST_COMPILER`` to one of the
-   following values:
 
-     :``gnu``: the GNU compiler suite -- ``gcc`` and ``g++``
-     :``intel``: the Intel compiler suite -- ``icc`` and ``icpc``
-     :``pgi``: the PGI compiler suite -- ``pgcc`` and ``pgc++``
-
-
-5) Optionally, set one or more of the following environment variables to
+4) Optionally, set one or more of the following environment variables to
    configure the Chapel build.  These are described in greater detail in
    :ref:`readme-chplenv`.
 
@@ -167,7 +156,7 @@ Building Chapel for a Cray System from Source
    information about using Chapel with InfiniBand.
 
 
-6) Make sure you're in the top-level chapel/ directory and make/re-make the
+5) Make sure you're in the top-level chapel/ directory and make/re-make the
    compiler and runtime::
 
      gmake


### PR DESCRIPTION
Remove references to pgi. We don't build the module with support for pgi as a
target compiler anymore, and we don't trust pgi that much anyways, so don't
list it as a backend compiler.

Remove the "change your host compiler section". We really recommend using gnu,
so don't list alternatives.

Remove note about recommending cce 8.4.0 or newer. 8.4 is pretty old at this
point. Any site using Chapel will certainly have at least 8.4.

Remove note about setting CHPL_TASKS. We really want people to just default to
qthreads. This might have been more relevant when muxed was around, but now we
really don't want fifo to be used.

Remove note about setting the comm layer. ugni provides the best performance,
so we want users to use it if they're on a xe/xc. If they're on a cs, gasnet is
there only option so there's no reason for them to change it.

Fix a reference from CHPL_COMM to CHPL_NETWORK_ATOMICS in the AMO section
