### PR TITLE
Fix a race in pbs-gasnetrun_ibv launcher while determining the pbs version

### DIFF
--- a/runtime/src/launch/pbs-gasnetrun_ibv/launch-pbs-gasnetrun_ibv.c
+++ b/runtime/src/launch/pbs-gasnetrun_ibv/launch-pbs-gasnetrun_ibv.c
@@ -69,7 +69,7 @@ static qsubVersion determineQsubVersion(void) {
     return nccs;
   } else if (strstr(version, "PBSPro")) {
     return pbspro;
-  } else if (strstr(version, "version: ")) {
+  } else if (strstr(version, "version:") || strstr(version, "Version:")) {
     return torque;
   } else {
     return unknown;

--- a/runtime/src/launch/pbs-gasnetrun_ibv/launch-pbs-gasnetrun_ibv.c
+++ b/runtime/src/launch/pbs-gasnetrun_ibv/launch-pbs-gasnetrun_ibv.c
@@ -42,7 +42,6 @@ char sysFilename[FILENAME_MAX];
 
 /* copies of binary to run per node */
 #define procsPerNode 1  
-#define versionBuffLen 80
 
 #define launcherAccountEnvvar "CHPL_LAUNCHER_ACCOUNT"
 
@@ -54,26 +53,18 @@ typedef enum {
 } qsubVersion;
 
 static qsubVersion determineQsubVersion(void) {
-  char version[versionBuffLen+1] = "";
-  char* versionPtr = version;
-  FILE* sysFile;
-  int i;
+  const int buflen = 256;
+  char version[buflen];
+  char *argv[3];
+  argv[0] = (char *) "qsub";
+  argv[1] = (char *) "--version";
+  argv[2] = NULL;
 
-  char* command = chpl_glom_strings(3, "qsub --version > ", sysFilename, " 2>&1");
-  system(command);
-  sysFile = fopen(sysFilename, "r");
-  for (i=0; i<versionBuffLen; i++) {
-    char tmp;
-    fscanf(sysFile, "%c", &tmp);
-    if (tmp == '\n') {
-      *versionPtr++ = '\0';
-      break;
-    } else {
-      *versionPtr++ = tmp;
-    }
+  memset(version, 0, buflen);
+  if (chpl_run_utility1K("qsub", argv, version, buflen) <= 0) {
+    chpl_error("Error trying to determine qsub version", 0, 0);
   }
 
-  fclose(sysFile);
   if (strstr(version, "NCCS")) {
     return nccs;
   } else if (strstr(version, "PBSPro")) {


### PR DESCRIPTION
Similar to #7441/#7450, but for pbs-gasnetrun_ibv. I partially copied the code
from pbs-aprun, but note that this launcher checks for torque instead of moab.
torque/moab are one in the same, so I probably could have updated this launcher
to use the pbs-aprun check, but we don't have a machine to fully test this
launcher on, so I didn't want to change too much.

Since we don't have a machine to test this on, I just made sure the launcher
compiles and that determineQsubVersion works correctly on PBSPro and
moab/torque machines.
