### PR TITLE
Don't depend on third-party source files to auto-rebuild a third-party lib

### DIFF
--- a/third-party/Makefile
+++ b/third-party/Makefile
@@ -59,29 +59,25 @@ clobber: FORCE
 
 depend:
 
-# Third-party dependencies. If any of these files (3rd party source dirs or our
+# Third-party dependencies. If any of these files (our 3rd party README or
 # Makefiles) change, then rebuild the 3rd party lib. This allows us to
 # automatically rebuild on 3rd party version upgrades or if we specify
-# different option in the Makefile.
+# different options in the Makefile. Note that this requires us to update the
+# version number and list patches in our README file. We used to use
+# third-party source files as dependencies too, but that introduced problems
+# with some files getting rebuilt because of built-in make rules.
 
-# Common C/C++ file extensions
-SRC_FILES_FILTER += -iname '*.c'   -o -iname '*.h'   -o -iname '*.cpp' -o
-SRC_FILES_FILTER += -iname '*.cc'  -o -iname '*.cxx' -o -iname '*.hpp' -o
-# Less common C++ extensions
-SRC_FILES_FILTER += -iname '*.c++' -o -iname '*.hp'  -o -iname '*.hxx' -o
-SRC_FILES_FILTER += -iname '*.h++' -o -iname '*.tcc' -o -iname '*.cp'
+# Find 3rd party dependencies -- arg 1 is the top-level dir with Makefiles/README
+find_3p_depend = $(1)/Makefile* $(1)/README
 
-# Find 3rd party dependencies -- arg 1 is src dir, arg 2 is top-level dir with Makefiles/README
-find_3p_depend = $(shell find $(1) $(SRC_FILES_FILTER) 2>/dev/null) $(2)/Makefile* $(2)/README
-
-GASNET_DEPEND         := $(call find_3p_depend, $(GASNET_SUBDIR),         $(GASNET_DIR))
-GMP_DEPEND            := $(call find_3p_depend, $(GMP_SUBDIR),            $(GMP_DIR))
-HWLOC_DEPEND          := $(call find_3p_depend, $(HWLOC_SUBDIR),          $(HWLOC_DIR))
-JEMALLOC_DEPEND       := $(call find_3p_depend, $(JEMALLOC_SUBDIR),       $(JEMALLOC_DIR))
-LIBUNWIND_DEPEND      := $(call find_3p_depend, $(LIBUNWIND_SUBDIR),      $(LIBUNWIND_DIR))
-MASSIVETHREADS_DEPEND := $(call find_3p_depend, $(MASSIVETHREADS_SUBDIR), $(MASSIVETHREADS_DIR))
-QTHREAD_DEPEND        := $(call find_3p_depend, $(QTHREAD_SUBDIR),        $(QTHREAD_DIR))
-RE2_DEPEND            := $(call find_3p_depend, $(RE2_SUBDIR),            $(RE2_DIR))
+GASNET_DEPEND         := $(call find_3p_depend, $(GASNET_DIR))
+GMP_DEPEND            := $(call find_3p_depend, $(GMP_DIR))
+HWLOC_DEPEND          := $(call find_3p_depend, $(HWLOC_DIR))
+JEMALLOC_DEPEND       := $(call find_3p_depend, $(JEMALLOC_DIR))
+LIBUNWIND_DEPEND      := $(call find_3p_depend, $(LIBUNWIND_DIR))
+MASSIVETHREADS_DEPEND := $(call find_3p_depend, $(MASSIVETHREADS_DIR))
+QTHREAD_DEPEND        := $(call find_3p_depend, $(QTHREAD_DIR))
+RE2_DEPEND            := $(call find_3p_depend, $(RE2_DIR))
 
 
 test-venv: $(CHPL_VENV_TEST_REQS)

--- a/third-party/gmp/Makefile
+++ b/third-party/gmp/Makefile
@@ -63,6 +63,7 @@ $(GMP_BUILD_SUBDIR):
 
 $(GMP_H_FILE): $(GMP_BUILD_SUBDIR)
 	touch $(GMP_SUBDIR)/doc/gmp.info*
+	touch $(GMP_SUBDIR)/demos/calc/calc*.c
 	cd $(GMP_BUILD_DIR) && $(GMP_SUBDIR)/configure CC='$(CC)' CFLAGS='$(CFLAGS) $(CHPL_GMP_CFLAGS)' CXX='$(CXX)' CXXFLAGS='$(CXXFLAGS) $(CHPL_GMP_CXXFLAGS)' $(CHPL_GMP_ABI_ARG) --prefix=$(GMP_INSTALL_DIR) $(CHPL_GMP_CFG_OPTIONS)
 	cd $(GMP_BUILD_DIR) && $(MAKE)
 ifeq ($(GMP_CROSS_COMPILED),no)


### PR DESCRIPTION
PR #7004 added code to automatically rebuild a third-party library if our
README/Makefiles changes or if any source file in the third-party dir changed.
Unfortunately depending on third-party sources had some unforeseen consequences
because of built-in make rules, so now only rebuild if our README/Makefiles
changes. We'll still auto-rebuild on version upgrades or if we bring in an
upstream patch or something so long as we're careful to update the README to
note version changes and mods.

The specific problem we ran into with depending on third-party sources was that
a built-in rule was causing us to auto-rebuild some gmp files that have a .y
file. Make will automatically rebuild a .c file if it has a .y file with a
newer timestamp than it. We could probably work around this, but it makes me
nervous about other built-in rules and I don't want to take any chances. For
gmp, this was effectively requiring a user to have yacc/bison installed in
order for `make check` to pass, which we do as part of the speculative build.

Also touch the specific .c files that were being rebuilt. They won't be rebuilt
by an implicit make rule anymore, but the gmp build might rebuild them, so make
sure that the generated .c has a newer timestamp than the source .y.

This resolves an issue where developers were seeing modifications to
`third-party/gmp/gmp-src/demos/calc/{calc.c, calclex.c}`. This also 
resolves https://github.com/chapel-lang/chapel/issues/7182