### PR TITLE
Fix an issue with returning a generic record created via a 'new' directly

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5570,7 +5570,13 @@ static void resolveNewHandleGenericInitializer(CallExpr*      call,
     call->insertBefore(def);
 
   } else {
-    call->parentExpr->insertBefore(def);
+    Expr* parent = call->parentExpr;
+    parent->insertBefore(def);
+
+    if (isClass(at) == false) {
+      call->replace(new SymExpr(new_temp));
+      parent->insertBefore(call);
+    }
   }
 
   // Invoking an instance method

--- a/test/classes/initializers/records/generics/returnNewGeneric.chpl
+++ b/test/classes/initializers/records/generics/returnNewGeneric.chpl
@@ -1,0 +1,18 @@
+record Option {
+  type eltType;
+  var state: bool;
+  var value: eltType;
+
+  proc init(value: ?eltType) {
+    this.eltType = eltType;
+    this.state   = true;
+    this.value   = value;
+    super.init();
+  }
+}
+
+proc Some(value: ?eltType) {
+  return new Option(value);
+}
+
+assert(Some(42) == Some(42));


### PR DESCRIPTION
Prior to this change, the following would fail with the error `illegal use of
function that does not return a value: 'init'` when the type defined an
initializer:

```chapel
proc Some(value: ?eltType) {
  return new Option(value);
}
```

This was due to an oversight in AST transformation.  I fixed a similar error for
concrete records with #6773 but didn't get back to the generic case until just
now.

Resolves #6688 

Passed classes/initializers with futures and a full paratest.