### PR TITLE
Pre-release prep. Chapel 1.16.0: update dockerfiles

### DIFF
--- a/util/dockerfiles/1.16.0/Dockerfile
+++ b/util/dockerfiles/1.16.0/Dockerfile
@@ -1,0 +1,30 @@
+FROM debian:stretch
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    wget \
+    ca-certificates \
+    gcc \
+    g++ \
+    perl \
+    python \
+    python-dev \
+    python-setuptools \
+    libgmp10 \
+    libgmp-dev \
+    bash \
+    make \
+    mawk \
+    file \
+    pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV CHPL_VERSION 1.16.0
+ENV CHPL_HOME    /opt/chapel/$CHPL_VERSION
+ENV CHPL_GMP     system
+
+RUN mkdir -p /opt/chapel \
+    && wget -q -O - https://github.com/chapel-lang/chapel/releases/download/$CHPL_VERSION/chapel-$CHPL_VERSION.tar.gz | tar -xzC /opt/chapel --transform 's/chapel-//' \
+    && make -C $CHPL_HOME \
+    && make -C $CHPL_HOME chpldoc
+
+ENV PATH $PATH:$CHPL_HOME/bin/linux64:$CHPL_HOME/util

--- a/util/dockerfiles/1.16.0/gasnet/Dockerfile
+++ b/util/dockerfiles/1.16.0/gasnet/Dockerfile
@@ -1,0 +1,8 @@
+FROM chapel/chapel:latest
+
+ENV CHPL_COMM gasnet
+
+RUN make -C $CHPL_HOME \
+    && make -C $CHPL_HOME chpldoc
+
+ENV GASNET_SPAWNFN L


### PR DESCRIPTION
THIS IS NOT CHAPEL RELEASE 1.16.0

This creates the usual advisory copies of Chapel Dockerfiles in the
master branch source, in preparation for the upcoming Chapel
release, currently scheduled for 5 Oct 2017.

- copies Chapel 1.15.0's Dockerfiles,
- changes release version,
- changes base SuSE release from jessie to stretch.

This passed preliminary tests with a pre-release Chapel.