### PR TITLE
Fix link from LinearAlgebra.Sparse docs -> Sparse primer

### DIFF
--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -929,7 +929,7 @@ Sparse matrices are represented as 2D arrays domain-mapped to a sparse *layout*.
 Only the ``CS(compressRows=true)`` (CSR) layout of the
 :mod:`LayoutCS` layout module is currently supported.
 
-See the `Sparse Primer <primers-sparse>`_ for more information about working
+See the :ref:`Sparse Primer <primers-sparse>` for more information about working
 with sparse domains and arrays in Chapel.
 
 Sparse Linear Algebra Interface


### PR DESCRIPTION
Uses the inter-document referencing role,`` :ref:`foo` `` , instead of the intra-document referencing syntax,`` `foo`_``.

I'll never get restructured text syntax right the first time.

## Testing

- [x] `make docs`