### PR TITLE
Document cmake prerequisite and LLVM version

### DIFF
--- a/doc/rst/usingchapel/chplenv.rst
+++ b/doc/rst/usingchapel/chplenv.rst
@@ -624,7 +624,7 @@ CHPL_LLVM
    If unset, ``CHPL_LLVM`` defaults to ``llvm`` if you've already installed
    llvm in third-party and ``none`` otherwise.
 
-   Chapel currently supports LLVM 3.7.
+   Chapel currently supports LLVM 3.7 through 4.0.
 
    .. note::
 

--- a/doc/rst/usingchapel/prereqs.rst
+++ b/doc/rst/usingchapel/prereqs.rst
@@ -33,6 +33,8 @@ about your environment for using Chapel:
       expression support (i.e.  CHPL_LLVM=llvm or CHPL_REGEXP=re2). If
       GCC is used, we recommend GCC version 5 or newer for this purpose.
 
+  * Building LLVM requires cmake version 3.4.3 or later.
+
   * If you wish to use Chapel's test system, python-setuptools and
     python-devel (or equivalent packages for your platform) are required.
 


### PR DESCRIPTION
Update the documentation to show cmake as a prerequisite for LLVM.  While we are there, update the documentation of which LLVM versions are supported.
