### PR TITLE
Use initial value of outer variable upon reduce intent for coforalls

### DIFF
--- a/test/parallel/taskPar/vass/ri-3-stress-coforall.chpl
+++ b/test/parallel/taskPar/vass/ri-3-stress-coforall.chpl
@@ -30,7 +30,7 @@ proc onetest(ri: int) {
     red += idx;
   }
   const result = red;
-  check(result, sum(1..t), ri);
+  check(result, 5 + sum(1..t), ri);
 }
 
 proc sum(r) { const l = r.length; return l * (l+1) / 2; }


### PR DESCRIPTION
This is the counterpart of #7351 for coforall loops.

Implementation notes.
* Since here we are before resolution, we are not resolving
the initialAccumulate() call and branching in the compiler.
Instead we use a conditional on canResolveMethod.
* Since the Reflection module is not necessarily available,
we use the corresponding primitive directly.

Adjusted the test appropriately.