### PR TITLE
Prevent certain data races upon 'in' forall intents

### DIFF
--- a/test/release/examples/benchmarks/miniMD/helpers/forces.chpl
+++ b/test/release/examples/benchmarks/miniMD/helpers/forces.chpl
@@ -340,7 +340,7 @@ class ForceLJ : Force {
     const cfsq = cutforcesq;
 
     var t_eng, t_vir : real;
-    forall (b,p,c,r) in zip(Bins, RealPos, RealCount, binSpace) with (in cfsq, + reduce t_eng, + reduce t_vir) {
+    forall (b,p,c,r) in zip(Bins, RealPos, RealCount, binSpace) with (const in cfsq, + reduce t_eng, + reduce t_vir) {
       for (a, x, j) in zip(b[1..c],p[1..c],1..c) {
         for(n,i) in a.neighs[1..a.ncount] {
           const del = x - Pos[n][i];

--- a/test/studies/prk/Stencil/optimized/stencil-opt.chpl
+++ b/test/studies/prk/Stencil/optimized/stencil-opt.chpl
@@ -148,7 +148,7 @@ proc main() {
     if iteration >= 1 then subTimer.start();
 
     if debug then diagnostics('stencil');
-    forall (i,j) in innerDom with (in weight) {
+    forall (i,j) in innerDom with (const in weight) {
       var tmpout: dtype = 0.0;
       if (!compact) {
         for param jj in -R..-1 do tmpout += weight[R1][R1+jj] * input.localAccess[i, j+jj];

--- a/test/studies/prk/Stencil/stencil.chpl
+++ b/test/studies/prk/Stencil/stencil.chpl
@@ -186,7 +186,7 @@ proc main() {
 
     if debug then diagnostics('stencil');
     if (!tiling) {
-      forall (i,j) in innerDom with (in weight) {
+      forall (i,j) in innerDom with (const in weight) {
         var tmpout: dtype = 0.0;
         if (!compact) {
           for param jj in -R..-1 do tmpout += weight[R1][R1+jj] * input[i, j+jj];


### PR DESCRIPTION
Before this change, the compiler would generate racy code
for a forall loop with an 'in'-intented shadow variable, ex.:

    forall ... with (in somevar) ...;

when the corresponding parallel iterator has a for loop over
another parallel iterator, ex.:

    iter myParallelIter(param tag: iterKind) {
      ...
      for anotherIter(iterKind.standalone) {
        yield ...;
      }
      ...
    }

The reason is that all iterations of the for-loop over anotherIter
would use the same shadow variable for 'somevar', allowing for
unintended data races.

The compiler changes to handle this situation properly would be too invasive
so I did not want to put them in so close to code freeze.
Leaving this as future work.

Instead, this change detects this situation and changes the 'in' intent
to 'const in' intent. So if 'somevar' is modified within the loop,
const-checking flags that as an error. If it is not modified
within the loop, there will be no data races. The user is warned
about the change from 'in' to 'const in'.

A couple of miniMD and stencil variants pass a tuple by 'in' intent.
Changing those to 'const in' intent.

This originally exhibited itself as a performance issue with miniMD.
Thanks to BenH for narrowing down this issue to a small reproducer
and finding a workaround.

Testing: linux64 --verify, gasnet.
