### PR TITLE
Make --print-callgraph print calls to functions in standard modules

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -8373,9 +8373,20 @@ static void printCallGraph(FnSymbol* startPoint, int indent, std::set<FnSymbol*>
   for_vector(BaseAST, ast, asts) {
     if (CallExpr* call = toCallExpr(ast)) {
       if (FnSymbol* fn = call->resolvedFunction()) {
-        if (fn->getModule()->modTag == MOD_USER &&
+        if ((fn->getModule()->modTag == MOD_USER ||
+             call->getModule()->modTag == MOD_USER) &&
+            fn->getModule()->modTag != MOD_INTERNAL &&
             !fn->hasFlag(FLAG_COMPILER_GENERATED) &&
             !fn->hasFlag(FLAG_COMPILER_NESTED_FUNCTION)) {
+
+          if (strncmp("chpl_", fn->name, 5) == 0 &&
+              !fn->hasFlag(FLAG_MODULE_INIT)) {
+            // skip any functions that are internal (start with "chpl_")
+            // except for the init function for the module, which needs
+            // to be traversed to find top-level calls in the module
+            continue;
+          }
+
           FnSymbol* instFn = fn;
           if (fn->instantiatedFrom) {
             instFn = fn->instantiatedFrom;

--- a/test/compflags/diten/printCallGraph.good
+++ b/test/compflags/diten/printCallGraph.good
@@ -2,12 +2,16 @@ e
   f
     e (Recursive)
     h
+      writeln
   g
     f
       e (Recursive)
       h
+        writeln
     h
+      writeln
   h
+    writeln
 main
 H
 H


### PR DESCRIPTION
The --print-callgraph option only printed calls to user functions, but we'd
like to also see calls to functions in the standard modules.  Make it print
calls to standard modules, but not go any further down.

Update a test for printCallGraph to expect this.