### PR TITLE
Add prototype, err handling to highlighters

### DIFF
--- a/highlight/emacs/chpl-mode.el
+++ b/highlight/emacs/chpl-mode.el
@@ -180,7 +180,7 @@ or variable identifier (that's being defined)."
 
 (c-lang-defconst c-other-kwds
   "Keywords not accounted for by any other `*-kwds' language constant."
-  chpl '("align" "atomic" "begin" "by" "cobegin" "coforall" "dmapped" "for" "forall" "if" "in" "inout" "local" "noinit" "on" "out" "reduce" "ref" "scan" "serial" "single" "sparse" "sync" "where" "while" "with" "zip"))
+  chpl '("align" "atomic" "begin" "by" "catch" "cobegin" "coforall" "dmapped" "for" "forall" "if" "in" "inout" "local" "noinit" "on" "out" "prototype" "reduce" "ref" "scan" "serial" "single" "sparse" "sync" "throw" "throws" "try" "try!" "where" "while" "with" "zip"))
 
 ;;; Chpl.
 

--- a/highlight/emacs/chpl-mode.el
+++ b/highlight/emacs/chpl-mode.el
@@ -180,7 +180,7 @@ or variable identifier (that's being defined)."
 
 (c-lang-defconst c-other-kwds
   "Keywords not accounted for by any other `*-kwds' language constant."
-  chpl '("align" "atomic" "begin" "by" "catch" "cobegin" "coforall" "dmapped" "for" "forall" "if" "in" "inout" "local" "noinit" "on" "out" "prototype" "reduce" "ref" "scan" "serial" "single" "sparse" "sync" "throw" "throws" "try" "try!" "where" "while" "with" "zip"))
+  chpl '("align" "atomic" "begin" "by" "catch" "cobegin" "coforall" "dmapped" "for" "forall" "if" "in" "inout" "local" "noinit" "on" "out" "prototype" "reduce" "ref" "scan" "serial" "single" "sparse" "sync" "throw" "throws" "try" "where" "while" "with" "zip"))
 
 ;;; Chpl.
 

--- a/highlight/highlight/README
+++ b/highlight/highlight/README
@@ -7,7 +7,7 @@ which you can find at highlight http://www.andre-simon.de/
 This is the highlighter used by the Computer Languages Benchmark Game.
 
 For example, run from this directory:
-  highlight --config-file=./langDefs/chpl.lang your_file.chpl
+  highlight -O ansi --config-file=./langDefs/chpl.lang your_file.chpl
 
   (Note that you might need to install highlight for it to work
   correctly).

--- a/highlight/highlight/README
+++ b/highlight/highlight/README
@@ -9,6 +9,9 @@ This is the highlighter used by the Computer Languages Benchmark Game.
 For example, run from this directory:
   highlight --config-file=./langDefs/chpl.lang your_file.chpl
 
+  (Note that you might need to install highlight for it to work
+  correctly).
+
 For more options, try:
   highlight --help
 

--- a/highlight/highlight/langDefs/chpl.lang
+++ b/highlight/highlight/langDefs/chpl.lang
@@ -17,7 +17,8 @@ Keywords={
          "extern", "false", "for", "forall", "if", "in", "index", "inline",
          "inout", "iter", "label", "lambda", "let", "local", "module", "new",
          "nil", "noinit", "on", "only", "otherwise", "out", "param", "private",
-         "proc", "public", "record", "reduce", "ref", "require", "return",
+         "proc", "prototype",
+         "public", "record", "reduce", "ref", "require", "return",
          "scan", "select", "serial", "single", "sparse", "subdomain", "sync",
          "then", "throw", "throws", "true", "try", "type", "union", "use",
          "var", "when", "where", "while", "with", "yield", "zip"

--- a/highlight/source-highlight/chpl.lang
+++ b/highlight/source-highlight/chpl.lang
@@ -12,7 +12,7 @@ number =
 string delim "\"" "\"" escape "\\"
 
 # double-quotes mean that parens are interpreted literally
-keyword = "as|atomic|begin|break|by|class|cobegin|coforall|config|const|continue|proc|iter|delete|dmapped|do|domain|else|enum|except|export|extern|false|for|forall|if|in|index|inline|inout|label|lambda|let|local|module|new|nil|noinit|on|only|otherwise|out|param|private|public|record|reduce|ref|require|return|scan|select|serial|single|sparse|subdomain|sync|then|true|type|union|use|var|when|where|while|with|yield|zip"
+keyword = "as|atomic|begin|break|by|catch|class|cobegin|coforall|config|const|continue|iter|delete|dmapped|do|domain|else|enum|except|export|extern|false|for|forall|if|in|index|inline|inout|label|lambda|let|local|module|new|nil|noinit|on|only|otherwise|out|param|private|proc|prototype|public|record|reduce|ref|require|return|scan|select|serial|single|sparse|subdomain|sync|then|throw|throws|true|try|type|union|use|var|when|where|while|with|yield|zip"
 
 
 # double-quotes mean that parens are interpreted literally

--- a/highlight/vim/syntax/chpl.vim
+++ b/highlight/vim/syntax/chpl.vim
@@ -241,7 +241,7 @@ endif
 "  - Ranges need better support eg: [.., ..)
 
 " Chapel extentions
-syn keyword chplStatement	goto break return continue compilerWarning delete
+syn keyword chplStatement	break return continue compilerWarning delete
 syn keyword chplStatement	noinit new delete this these use except only require
 syn keyword chplStatement	as module yield compilerError zip
 syn keyword chplIntent		param type in out inout ref
@@ -253,6 +253,7 @@ syn keyword chplOperator	on reduce scan by align
 syn keyword chplStructure	class record union enum
 syn keyword chplStructure	proc iter cobegin begin local sync let select where
 syn keyword chplStructure	pragma inline with private public forwarding
+syn keyword chplStructure	prototype
 syn keyword chplBoolean		true false
 syn keyword chplConditional	if then else
 syn keyword chplConstant	nil


### PR DESCRIPTION
See also https://github.com/chapel-lang/chapel-tmbundle/commit/fe50e0bf1eaa3c0a53fcc3a22c43ede528ad3afa
See also https://bitbucket.org/birkenfeld/pygments-main/pull-requests/735/updating-chapel-highlighter/diff

It's debateable whether or not `try!` should work as its own keyword. I couldn't get highlight or GNU highlight or vim to do that with obvious/trivial changes. I could get the emacs one to do it, but I abandoned that in favor of consistency.

I tested with:
 * emacs24, emacs25 (my ubuntu won't let me install 22 or 23)
 * highlight version 3.39 (built from git)
 * GNU Source-highlight 3.1.8
 * vim 8.0

Reviewed by @psahabu - thanks!