### PR TITLE
Added Prabhanjan Mannari to CONTRIBUTORS -- oops

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -24,6 +24,7 @@ Contributors to the current release
 * Przemysław Leśniak, individual contributor / [GSoC 2017]
 * Vassily Litvinov, [Cray Inc.]
 * Tom MacDonald, [Cray Inc.]
+* Prabhanjan Mannari, individual contributor
 * Barry Moore, [University of Pittsburgh]
 * Sarthak Munshi, individual contributor / [GSoC 2017]
 * Michael Noakes, [Cray Inc.]


### PR DESCRIPTION
For some reason, the GitHub graph view of the project doesn't list
Prabhanjan Mannari, so I missed him on my first draft of the
contributors file.  Happily, Ben Albrecht caught this in time.