### PR TITLE
Emphasize parens for deinit

### DIFF
--- a/doc/rst/developer/chips/10.rst
+++ b/doc/rst/developer/chips/10.rst
@@ -679,7 +679,8 @@ Deinitialization
 ++++++++++++++++
 
 To specify actions that occur upon deinitialization, specify a ``proc
-deinit()`` method. This method must have zero arguments and cannot be called
+deinit()`` method. This method must have zero arguments and be declared
+with parentheses. It cannot be called
 directly. If a type does not specify a ``proc deinit()`` method, the compiler
 will generate one.
 It will be equivalent to a user-written ``deinit`` with an empty body.

--- a/spec/Classes.tex
+++ b/spec/Classes.tex
@@ -790,7 +790,7 @@ features become supported.
 
 A class author may specify additional actions to be performed before a class object is
 reclaimed, by defining a class deinitializer.  A class deinitializer is a method
-named \chpl{deinit}.  A class deinitializer takes no arguments (aside from
+named \chpl{deinit()}.  A class deinitializer takes no arguments (aside from
 the implicit \chpl{this} argument).  If defined, the deinitializer is called each time
 a \chpl{delete} statement is invoked with a valid instance of that class type.  The
 deinitializer is not called if the argument of \chpl{delete} evaluates to \chpl{nil}.

--- a/spec/Data_Parallelism.tex
+++ b/spec/Data_Parallelism.tex
@@ -264,8 +264,8 @@ affect the behavior of a task construct such as a \chpl{coforall} loop.
 \end{rationale}
 
 \begin{craychapel}
-An initial implementation of "reduce" intents is also available,
-which permits users to reduce values across iterations of a forall loop.
+To reduce values across iterations of a forall or coforall loop,
+"reduce" intents can be used.
 They are described in the \emph{Reduce Intents} page
 under \emph{Technical Notes}
 in Cray Chapel online documentation here:

--- a/spec/Modules.tex
+++ b/spec/Modules.tex
@@ -371,7 +371,7 @@ During module deinitialization:
 \begin{itemize}
 
 \item If the module contains a deinitializer, which is a function
-named \chpl{deinit} that is declared at the module level,
+named \chpl{deinit()} that is declared at the module level,
 it is executed first.
 
 \item If the module declares global variables, they are deinitialized

--- a/spec/Records.tex
+++ b/spec/Records.tex
@@ -251,7 +251,7 @@ supplied, the default initializer cannot be called directly.
 
 A record author may specify additional actions to be performed before record storage is
 reclaimed by defining a record deinitializer.  A record deinitializer is a method named
-\chpl{deinit}.  A record deinitializer takes no arguments
+\chpl{deinit()}.  A record deinitializer takes no arguments
 (aside from the implicit \chpl{this} argument).  If defined, the deinitializer is called
 on a record object after it goes out of scope and before its memory is reclaimed.
 


### PR DESCRIPTION
With #7375, we require deinit functions to be declared with parens,
both as class/record deinitializers and module deinit functions.

Emphasize that in the spec by writing parens next to "deinit"
where they are discussed.
Emphasize that in CHIP 10 explicitly.

While there, promote reduce intents from "initial implementation"
and indicate that they are available for coforalls too.