### PR TITLE
Error handling primer good file, 'defer'

### DIFF
--- a/doc/rst/technotes/errorHandling.rst
+++ b/doc/rst/technotes/errorHandling.rst
@@ -260,6 +260,32 @@ propagating the error out of the function as described above.
     }
   }
 
+.. _technote-errorHandling-defer:
+
+``defer``
+---------
+
+When an error is thrown, it is sometimes necessary to clean up state and
+allocated memory. ``defer`` statements facilitate that by running when a
+scope is exited, regardless of how it is exited.
+
+.. code-block:: chapel
+
+  proc deferredDelete(i: int) {
+    try {
+      var huge = allocateLargeObject();
+      defer {
+        delete huge;
+        writeln("huge has been deleted");
+      }
+
+      canThrow(i);
+      processObject(huge);
+    } catch {
+      writeln("no memory leaks");
+    }
+  }
+
 .. _technote-errorHandling-methods:
 
 Methods

--- a/test/release/examples/primers/errorHandling.good
+++ b/test/release/examples/primers/errorHandling.good
@@ -1,0 +1,3 @@
+an error occurred
+fake.txt does not exist
+still_fake.txt does not exist


### PR DESCRIPTION
Thanks to @cassella for catching the lack of a good file.

Thanks to @mppf for the reminder about `defer`.