### PR TITLE
Fix some comments in chpldoc tests

### DIFF
--- a/test/chpldoc/basics/disconnectedComment.doc.chpl
+++ b/test/chpldoc/basics/disconnectedComment.doc.chpl
@@ -6,7 +6,7 @@ module unattached {
 
   }
 
-  /* This comment should be attached to the method */
+  /* This comment should be attached to the function */
 
   proc commentLess() {
 
@@ -20,7 +20,7 @@ module unattached {
   }
 
   /* This comment also should be attached, even though
-     it is further away from the method */
+     it is further away from the function */
 
 
 
@@ -50,7 +50,7 @@ module unattached {
     writeln(val);
   }
 
-  /* This comment should not be attached, even after all methods are defined */
+  /* This comment should not be attached, even after all functions are defined */
 
 }
 

--- a/test/chpldoc/basics/disconnectedComment.doc.good
+++ b/test/chpldoc/basics/disconnectedComment.doc.good
@@ -18,7 +18,7 @@ even when before the defined module
 
 .. function:: proc commentLess()
 
-   This comment should be attached to the method 
+   This comment should be attached to the function 
 
 .. function:: proc commentLess2()
 
@@ -28,7 +28,7 @@ even when before the defined module
 .. function:: proc commentLess3()
 
    This comment also should be attached, even though
-   it is further away from the method 
+   it is further away from the function 
 
 .. function:: proc hasArg(val: int)
 

--- a/test/chpldoc/basics/fullyCommented.doc.chpl
+++ b/test/chpldoc/basics/fullyCommented.doc.chpl
@@ -1,18 +1,18 @@
 module Other {
-  /* Comment for method inside module */
+  /* Comment for a function inside module */
   proc inside { }
 
-  /* Comment for method with a body inside module */
+  /* Comment for a function with a body inside module */
   proc body() {
     writeln("I have a body");
   }
   
-  /* Comment for method with an argument inside module */
+  /* Comment for a function with an argument inside module */
   proc hasArg(val: int) {
     
   }
   
-  /* Comment for method with argument and body inside module */
+  /* Comment for a function with argument and body inside module */
   proc argAndBody(val: int) {
     writeln(val);
   }
@@ -23,17 +23,17 @@ proc method1() {
 
 }
 
-/* Comment for method with a body */
+/* Comment for a function with a body */
 proc body() {
   writeln("I have a body");
 }
 
-/* Comment for method with an argument */
+/* Comment for a function with an argument */
 proc hasArg(val: int) {
 
 }
 
-/* Comment for method with argument and body */
+/* Comment for a function with argument and body */
 proc argAndBody(val: int) {
   writeln(val);
 }

--- a/test/chpldoc/basics/fullyCommented.doc.good
+++ b/test/chpldoc/basics/fullyCommented.doc.good
@@ -24,15 +24,15 @@ fullyCommented.doc
 
 .. function:: proc body()
 
-   Comment for method with a body 
+   Comment for a function with a body 
 
 .. function:: proc hasArg(val: int)
 
-   Comment for method with an argument 
+   Comment for a function with an argument 
 
 .. function:: proc argAndBody(val: int)
 
-   Comment for method with argument and body 
+   Comment for a function with argument and body 
 
 .. default-domain:: chpl
 
@@ -48,17 +48,17 @@ Other
 
 .. function:: proc inside
 
-   Comment for method inside module 
+   Comment for a function inside module 
 
 .. function:: proc body()
 
-   Comment for method with a body inside module 
+   Comment for a function with a body inside module 
 
 .. function:: proc hasArg(val: int)
 
-   Comment for method with an argument inside module 
+   Comment for a function with an argument inside module 
 
 .. function:: proc argAndBody(val: int)
 
-   Comment for method with argument and body inside module 
+   Comment for a function with argument and body inside module 
 

--- a/test/chpldoc/basics/hello.doc.chpl
+++ b/test/chpldoc/basics/hello.doc.chpl
@@ -1,4 +1,4 @@
-/* This method prints out a greeting.*/
+/* This function prints out a greeting.*/
 proc hello() {
   writeln("Hello, world!"); /* This comment should not be included */
 }

--- a/test/chpldoc/basics/hello.doc.good
+++ b/test/chpldoc/basics/hello.doc.good
@@ -12,5 +12,5 @@ hello.doc
 
 .. function:: proc hello()
 
-   This method prints out a greeting.
+   This function prints out a greeting.
 

--- a/test/chpldoc/basics/longerComments.doc.chpl
+++ b/test/chpldoc/basics/longerComments.doc.chpl
@@ -1,21 +1,21 @@
 module Other {
-  /* This is a comment for a method inside of
+  /* This is a comment for a function inside of
      a module */
   proc inside { }
 
-  /* This is a comment for a method with a body 
+  /* This is a comment for a function with a body 
      inside of a module */
   proc body() {
     writeln("I have a body");
   }
   
-  /* This is a comment for a method with an 
+  /* This is a comment for a function with an 
      argument inside of a module */
   proc hasArg(val: int) {
     
   }
   
-  /* This is a comment for a method with an 
+  /* This is a comment for a function with an 
      argument and body inside of a module */
   proc argAndBody(val: int) {
     writeln(val);
@@ -28,20 +28,20 @@ proc method1() {
 
 }
 
-/* This is a comment for method with a body 
+/* This is a comment for a function with a body 
    which lies outside of a defined module */
 proc body() {
   writeln("I have a body");
 }
 
-/* This is a comment for method with an 
+/* This is a comment for a function with an 
    argument which lies outside of a defined
    module */
 proc hasArg(val: int) {
 
 }
 
-/* This is a comment for method with an
+/* This is a comment for a function with an
    argument and body which lies outside of a
    defined module */
 proc argAndBody(val: int) {

--- a/test/chpldoc/basics/longerComments.doc.good
+++ b/test/chpldoc/basics/longerComments.doc.good
@@ -25,18 +25,18 @@ longerComments.doc
 
 .. function:: proc body()
 
-   This is a comment for method with a body 
+   This is a comment for a function with a body 
    which lies outside of a defined module 
 
 .. function:: proc hasArg(val: int)
 
-   This is a comment for method with an 
+   This is a comment for a function with an 
    argument which lies outside of a defined
    module 
 
 .. function:: proc argAndBody(val: int)
 
-   This is a comment for method with an
+   This is a comment for a function with an
    argument and body which lies outside of a
    defined module 
 
@@ -54,21 +54,21 @@ Other
 
 .. function:: proc inside
 
-   This is a comment for a method inside of
+   This is a comment for a function inside of
    a module 
 
 .. function:: proc body()
 
-   This is a comment for a method with a body 
+   This is a comment for a function with a body 
    inside of a module 
 
 .. function:: proc hasArg(val: int)
 
-   This is a comment for a method with an 
+   This is a comment for a function with an 
    argument inside of a module 
 
 .. function:: proc argAndBody(val: int)
 
-   This is a comment for a method with an 
+   This is a comment for a function with an 
    argument and body inside of a module 
 

--- a/test/chpldoc/basics/main.doc.chpl
+++ b/test/chpldoc/basics/main.doc.chpl
@@ -1,4 +1,4 @@
-/* This is the only valid doc string in this modules. */
+/* This is the only valid doc string in this module. */
 module main {
 
   begin {

--- a/test/chpldoc/basics/main.doc.good
+++ b/test/chpldoc/basics/main.doc.good
@@ -1,7 +1,7 @@
 .. default-domain:: chpl
 
 .. module:: main
-   :synopsis: This is the only valid doc string in this modules. 
+   :synopsis: This is the only valid doc string in this module. 
 
 main
 ====
@@ -11,7 +11,7 @@ main
 
    use main;
 
-This is the only valid doc string in this modules. 
+This is the only valid doc string in this module. 
 
 .. function:: proc foo()
 

--- a/test/chpldoc/basics/sparselyCommented.doc.chpl
+++ b/test/chpldoc/basics/sparselyCommented.doc.chpl
@@ -1,10 +1,10 @@
 module Other {
-  /* Comment for method inside module */
+  /* Comment for a function inside module */
   proc inside () { }
 
   proc insideCommentless () { }
 
-  /* Comment for method with a body inside module */
+  /* Comment for a function with a body inside module */
   proc body() {
     writeln("I have a body");
   }
@@ -13,7 +13,7 @@ module Other {
     writeln("I have a body");
   }
 
-  /* Comment for method with an argument inside module */
+  /* Comment for a function with an argument inside module */
   proc hasArg(val: int) {
     
   }
@@ -22,7 +22,7 @@ module Other {
     
   }
 
-  /* Comment for method with argument and body inside module */
+  /* Comment for a function with argument and body inside module */
   proc argAndBody(val: int) {
     writeln(val);
   }
@@ -41,7 +41,7 @@ proc method1Commentless() {
 
 }
 
-/* Comment for method with a body */
+/* Comment for a function with a body */
 proc body() {
   writeln("I have a body");
 }
@@ -50,7 +50,7 @@ proc bodyCommentless() {
   writeln("I have a body");
 }
 
-/* Comment for method with an argument */
+/* Comment for a function with an argument */
 proc hasArg(val: int) {
 
 }
@@ -59,7 +59,7 @@ proc hasArgCommentless(val: int) {
 
 }
 
-/* Comment for method with argument and body */
+/* Comment for a function with argument and body */
 proc argAndBody(val: int) {
   writeln(val);
 }

--- a/test/chpldoc/basics/sparselyCommented.doc.good
+++ b/test/chpldoc/basics/sparselyCommented.doc.good
@@ -26,19 +26,19 @@ sparselyCommented.doc
 
 .. function:: proc body()
 
-   Comment for method with a body 
+   Comment for a function with a body 
 
 .. function:: proc bodyCommentless()
 
 .. function:: proc hasArg(val: int)
 
-   Comment for method with an argument 
+   Comment for a function with an argument 
 
 .. function:: proc hasArgCommentless(val: int)
 
 .. function:: proc argAndBody(val: int)
 
-   Comment for method with argument and body 
+   Comment for a function with argument and body 
 
 .. function:: proc argAndBodyCommentless(val: int)
 
@@ -56,25 +56,25 @@ Other
 
 .. function:: proc inside()
 
-   Comment for method inside module 
+   Comment for a function inside module 
 
 .. function:: proc insideCommentless()
 
 .. function:: proc body()
 
-   Comment for method with a body inside module 
+   Comment for a function with a body inside module 
 
 .. function:: proc bodyCommentless()
 
 .. function:: proc hasArg(val: int)
 
-   Comment for method with an argument inside module 
+   Comment for a function with an argument inside module 
 
 .. function:: proc hasArgCommentless(val: int)
 
 .. function:: proc argAndBody(val: int)
 
-   Comment for method with argument and body inside module 
+   Comment for a function with argument and body inside module 
 
 .. function:: proc argAndBodyCommentless(val: int)
 

--- a/test/chpldoc/classes/basic.doc.chpl
+++ b/test/chpldoc/classes/basic.doc.chpl
@@ -24,7 +24,7 @@ module basic {
        Lydia built */
     module classesAreGrown {
       
-      /* This is the classes all aged and stiff, aware of the proc
+      /* This is the class all aged and stiff, aware of the proc
 	 that is thoroughly miffed, raised in the module whose 
 	 classes are grown, sister of the class with nary a tone,
 	 declared in the module all sad and alone, listed behind 

--- a/test/chpldoc/classes/basic.doc.good
+++ b/test/chpldoc/classes/basic.doc.good
@@ -76,7 +76,7 @@ Lydia built
 
 .. class:: agedAndStiff
 
-   This is the classes all aged and stiff, aware of the proc
+   This is the class all aged and stiff, aware of the proc
    that is thoroughly miffed, raised in the module whose 
    classes are grown, sister of the class with nary a tone,
    declared in the module all sad and alone, listed behind 

--- a/test/chpldoc/module/module.doc.chpl
+++ b/test/chpldoc/module/module.doc.chpl
@@ -36,14 +36,14 @@ module P {
 }
 
 module Q {
-  /* Sadly, this method's module does not */
+  /* Sadly, this function's module does not */
   proc main() {
     writeln("Oh no! Something printed!");
   }
 }
 
 module R {
-  /* Nor this method's module */
+  /* Nor this function's module */
   proc furthermore() {
 
   }

--- a/test/chpldoc/module/module.doc.good
+++ b/test/chpldoc/module/module.doc.good
@@ -82,7 +82,7 @@ Q
 
 .. function:: proc main()
 
-   Sadly, this method's module does not 
+   Sadly, this function's module does not 
 
 .. default-domain:: chpl
 
@@ -98,5 +98,5 @@ R
 
 .. function:: proc furthermore()
 
-   Nor this method's module 
+   Nor this function's module 
 

--- a/test/chpldoc/module/nestWithFns.doc.chpl
+++ b/test/chpldoc/module/nestWithFns.doc.chpl
@@ -1,11 +1,11 @@
-/* This module has a comment, but uncommented first method */
+/* This module has a comment, but uncommented first function */
 module OuterMod {
 
   proc outerFn() {
 
   }
 
-  /* The second method is commented */
+  /* The second function is commented */
   proc outerCommented() {
 
   }

--- a/test/chpldoc/module/nestWithFns.doc.good
+++ b/test/chpldoc/module/nestWithFns.doc.good
@@ -1,7 +1,7 @@
 .. default-domain:: chpl
 
 .. module:: OuterMod
-   :synopsis: This module has a comment, but uncommented first method 
+   :synopsis: This module has a comment, but uncommented first function 
 
 OuterMod
 ========
@@ -19,13 +19,13 @@ OuterMod
 
    OuterMod/*
 
-This module has a comment, but uncommented first method 
+This module has a comment, but uncommented first function 
 
 .. function:: proc outerFn()
 
 .. function:: proc outerCommented()
 
-   The second method is commented 
+   The second function is commented 
 
 .. default-domain:: chpl
 

--- a/test/chpldoc/types/arguments/methodCall.doc.chpl
+++ b/test/chpldoc/types/arguments/methodCall.doc.chpl
@@ -1,10 +1,10 @@
-/* This proc specifies the type of the next method's argument */
+/* This proc specifies the type of the next function's argument */
 proc nada() type {
 
 }
 
 /* This proc takes an argument whose type is determined by
-   another method */
+   another function */
 proc needsAType(val: nada()) {
 
 }

--- a/test/chpldoc/types/arguments/methodCall.doc.good
+++ b/test/chpldoc/types/arguments/methodCall.doc.good
@@ -12,10 +12,10 @@ methodCall.doc
 
 .. function:: proc nada() type
 
-   This proc specifies the type of the next method's argument 
+   This proc specifies the type of the next function's argument 
 
 .. function:: proc needsAType(val: nada())
 
    This proc takes an argument whose type is determined by
-   another method 
+   another function 
 

--- a/test/chpldoc/types/arguments/recordsAndClasses.doc.chpl
+++ b/test/chpldoc/types/arguments/recordsAndClasses.doc.chpl
@@ -2,7 +2,7 @@ record thingy {
 
 }
 
-/* This method takes a record as its argument */
+/* This function takes a record as its argument */
 proc takesAThingy(val: thingy) {
 
 }
@@ -11,7 +11,7 @@ class whatchamacallit {
 
 }
 
-/* This method takes a whatchamacallit as its argument */
+/* This function takes a whatchamacallit as its argument */
 proc takesAWhatchamacallit(val: whatchamacallit) {
 
 }

--- a/test/chpldoc/types/arguments/recordsAndClasses.doc.good
+++ b/test/chpldoc/types/arguments/recordsAndClasses.doc.good
@@ -14,11 +14,11 @@ recordsAndClasses.doc
 
 .. function:: proc takesAThingy(val: thingy)
 
-   This method takes a record as its argument 
+   This function takes a record as its argument 
 
 .. class:: whatchamacallit
 
 .. function:: proc takesAWhatchamacallit(val: whatchamacallit)
 
-   This method takes a whatchamacallit as its argument 
+   This function takes a whatchamacallit as its argument 
 

--- a/test/chpldoc/types/arguments/tuples.doc.chpl
+++ b/test/chpldoc/types/arguments/tuples.doc.chpl
@@ -1,24 +1,24 @@
-/* This method takes a tuple of bools as an argument */
+/* This function takes a tuple of bools as an argument */
 proc smallTuple(val: (bool, bool)) {
 
 }
 
-/* This method takes a heterogeneous tuple as an argument */
+/* This function takes a heterogeneous tuple as an argument */
 proc difTypes(val: (real, int, imag)) {
 
 }
 
-/* This method takes a tuple of strings as an argument */
+/* This function takes a tuple of strings as an argument */
 proc difDecl(val: 3*string) {
 
 }
 
-/* This method takes a tuple of tuples of complex numbers */
+/* This function takes a tuple of tuples of complex numbers */
 proc multiDimension(val: 3*(4*complex)) {
 
 }
 
-/* This method takes a one dimensional tuple */
+/* This function takes a one dimensional tuple */
 proc singleDimension(val: (uint,)) {
 
 }

--- a/test/chpldoc/types/arguments/tuples.doc.good
+++ b/test/chpldoc/types/arguments/tuples.doc.good
@@ -12,21 +12,21 @@ tuples.doc
 
 .. function:: proc smallTuple(val: (bool, bool))
 
-   This method takes a tuple of bools as an argument 
+   This function takes a tuple of bools as an argument 
 
 .. function:: proc difTypes(val: (real, int, imag))
 
-   This method takes a heterogeneous tuple as an argument 
+   This function takes a heterogeneous tuple as an argument 
 
 .. function:: proc difDecl(val: 3*(string))
 
-   This method takes a tuple of strings as an argument 
+   This function takes a tuple of strings as an argument 
 
 .. function:: proc multiDimension(val: 3*(4*(complex)))
 
-   This method takes a tuple of tuples of complex numbers 
+   This function takes a tuple of tuples of complex numbers 
 
 .. function:: proc singleDimension(val: (uint))
 
-   This method takes a one dimensional tuple 
+   This function takes a one dimensional tuple 
 


### PR DESCRIPTION
I got back around to an old chpldoc todo, and while there noticed a
bunch of tests had either typos in their comments or incorrectly
labeled functions as methods.  This updates those tests.