### PR TITLE
Add four tests of sending initialized fields to functions in Phase 1

### DIFF
--- a/test/classes/initializers/phase1/sendFieldToFunc.bad
+++ b/test/classes/initializers/phase1/sendFieldToFunc.bad
@@ -1,0 +1,2 @@
+sendFieldToFunc.chpl:4: In initializer:
+sendFieldToFunc.chpl:6: error: can't pass "this" as an actual to a function during phase 1 of initialization

--- a/test/classes/initializers/phase1/sendFieldToFunc.chpl
+++ b/test/classes/initializers/phase1/sendFieldToFunc.chpl
@@ -1,0 +1,18 @@
+class Foo {
+  var x: bool;
+
+  proc init(xVal) {
+    x = xVal;
+    bar(x); // This should be allowed
+    super.init();
+  }
+}
+
+proc bar(val) {
+  writeln(val);
+  return !val;
+}
+
+var foo = new Foo(true);
+writeln(foo);
+delete foo;

--- a/test/classes/initializers/phase1/sendFieldToFunc.future
+++ b/test/classes/initializers/phase1/sendFieldToFunc.future
@@ -1,0 +1,6 @@
+bug: should allow initialized fields to be sent to functions
+
+We currently only allow initialized fields to be sent to functions when the
+function is used in creating the initial value of another field.  We should
+allow it generally, but verify that the intent used is good (no ref, no out, no
+inout, etc).

--- a/test/classes/initializers/phase1/sendFieldToFunc.good
+++ b/test/classes/initializers/phase1/sendFieldToFunc.good
@@ -1,0 +1,2 @@
+true
+{x = true}

--- a/test/classes/initializers/phase1/sendFieldToFuncModsField.bad
+++ b/test/classes/initializers/phase1/sendFieldToFuncModsField.bad
@@ -1,0 +1,2 @@
+sendFieldToFuncModsField.chpl:4: In initializer:
+sendFieldToFuncModsField.chpl:6: error: can't pass "this" as an actual to a function during phase 1 of initialization

--- a/test/classes/initializers/phase1/sendFieldToFuncModsField.chpl
+++ b/test/classes/initializers/phase1/sendFieldToFuncModsField.chpl
@@ -1,0 +1,17 @@
+class Foo {
+  var x: bool;
+
+  proc init(xVal) {
+    x = xVal;
+    bar(x); // This should not be allowed
+    super.init();
+  }
+}
+
+proc bar(ref val) {
+  val = !val;
+}
+
+var foo = new Foo(true);
+writeln(foo);
+delete foo;

--- a/test/classes/initializers/phase1/sendFieldToFuncModsField.future
+++ b/test/classes/initializers/phase1/sendFieldToFuncModsField.future
@@ -1,0 +1,6 @@
+bug: should not allow initialized fields to be sent to functions via ref intent
+
+We currently only allow initialized fields to be sent to functions when the
+function is used in creating the initial value of another field.  We should
+allow it generally, but verify that the intent used is good (no ref, no out, no
+inout, etc).

--- a/test/classes/initializers/phase1/sendFieldToFuncModsField.good
+++ b/test/classes/initializers/phase1/sendFieldToFuncModsField.good
@@ -1,0 +1,2 @@
+sendFieldToFuncModsField.chpl:4: In initializer:
+sendFieldToFuncModsField.chpl:6: error: can't pass field "x" as an actual to a function that modifies it during phase 1 of initialization

--- a/test/classes/initializers/phase1/sendFieldToFuncUseRes.chpl
+++ b/test/classes/initializers/phase1/sendFieldToFuncUseRes.chpl
@@ -1,0 +1,19 @@
+class Foo {
+  var x: bool;
+  var y: bool;
+
+  proc init(xVal) {
+    x = xVal;
+    y = bar(x); // This should be allowed
+    super.init();
+  }
+}
+
+proc bar(val) {
+  writeln(val);
+  return !val;
+}
+
+var foo = new Foo(true);
+writeln(foo);
+delete foo;

--- a/test/classes/initializers/phase1/sendFieldToFuncUseRes.good
+++ b/test/classes/initializers/phase1/sendFieldToFuncUseRes.good
@@ -1,0 +1,2 @@
+true
+{x = true, y = false}

--- a/test/classes/initializers/phase1/writeFinishedField.bad
+++ b/test/classes/initializers/phase1/writeFinishedField.bad
@@ -1,0 +1,2 @@
+writeFinishedField.chpl:4: In initializer:
+writeFinishedField.chpl:6: error: can't pass "this" as an actual to a function during phase 1 of initialization

--- a/test/classes/initializers/phase1/writeFinishedField.chpl
+++ b/test/classes/initializers/phase1/writeFinishedField.chpl
@@ -1,0 +1,13 @@
+class Foo {
+  var x: bool;
+
+  proc init(xVal) {
+    x = xVal;
+    writeln(x); // This should be allowed
+    super.init();
+  }
+}
+
+var foo = new Foo(true);
+writeln(foo);
+delete foo;

--- a/test/classes/initializers/phase1/writeFinishedField.future
+++ b/test/classes/initializers/phase1/writeFinishedField.future
@@ -1,0 +1,6 @@
+bug: should allow initialized fields to be sent to functions
+
+We currently only allow initialized fields to be sent to functions when the
+function is used in creating the initial value of another field.  We should
+allow it generally, but verify that the intent used is good (no ref, no out, no
+inout, etc).

--- a/test/classes/initializers/phase1/writeFinishedField.good
+++ b/test/classes/initializers/phase1/writeFinishedField.good
@@ -1,0 +1,2 @@
+true
+{x = true}


### PR DESCRIPTION
The behavior today is inconsistent - if the return value of the function being
called is used as the initial value of a field, we allow the call to contain a
prior field.  However, that same call is not allowed in other circumstances in
Phase 1.  We would like to be able to send fields that have already been
initialized as arguments to functions during Phase 1 (assuming the intent for
the field does not allow it to be modified, as this would be a double
initialization).