### PR TITLE
Change LLVM dump() to print()

### DIFF
--- a/compiler/util/llvmAggregateGlobalOps.cpp
+++ b/compiler/util/llvmAggregateGlobalOps.cpp
@@ -49,6 +49,7 @@
 
 #include "llvm/Pass.h"
 #include "llvm/Support/raw_ostream.h"
+#include "llvm/Support/Debug.h"
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/Statistic.h"
 
@@ -223,11 +224,15 @@ Instruction* reorderAddressingMemopsUses(Instruction *FirstLoadOrStore,
     // Leave loads/stores where they are (they will be removed)
     if( isa<StoreInst>(insn) || isa<LoadInst>(insn) ) {
       if( DebugThis ) {
-        errs() << "found load/store: "; insn->dump();
+        dbgs() << "found load/store: ";
+        insn->print(dbgs(), true);
+	dbgs() << '\n';
       }
     } else if( memopsUses.count(insn) ) {
       if( DebugThis ) {
-        errs() << "found memop use: "; insn->dump();
+        dbgs() << "found memop use: ";
+        insn->print(dbgs(), true);
+	dbgs() << '\n';
       }
       // Move uses of memops to after the final memop.
       insn->removeFromParent();
@@ -235,7 +240,9 @@ Instruction* reorderAddressingMemopsUses(Instruction *FirstLoadOrStore,
       LastMemopUse = insn;
     } else {
       if( DebugThis ) {
-        errs() << "found other: "; insn->dump();
+        dbgs() << "found other: ";
+        insn->print(dbgs(), true);
+        dbgs() << '\n';
       }
       // Move addressing instructions to before the first memop.
       insn->removeFromParent();
@@ -626,8 +633,9 @@ Instruction *AggregateGlobalOpsOpt::tryAggregating(Instruction *StartInst, Value
     StartPtr = Range.StartPtr;
 
     if( DebugThis ) {
-      errs() << "base is:";
-      StartPtr->dump();
+      dbgs() << "base is:";
+      StartPtr->print(dbgs(), true);
+      dbgs() << '\n';
     }
 
     // Determine alignment
@@ -662,8 +670,9 @@ Instruction *AggregateGlobalOpsOpt::tryAggregating(Instruction *StartInst, Value
         StoreInst* oldStore = cast<StoreInst>(*SI);
 
         if( DebugThis ) {
-          errs() << "have store in range:";
-          oldStore->dump();
+          dbgs() << "have store in range:";
+          oldStore->print(dbgs(), true);
+          dbgs() << '\n';
         }
 
         Value* ptrToAlloc = rebasePointer(oldStore->getPointerOperand(),
@@ -739,8 +748,9 @@ Instruction *AggregateGlobalOpsOpt::tryAggregating(Instruction *StartInst, Value
            SE = Range.TheStores.end(); SI != SE; ++SI) {
         LoadInst* oldLoad = cast<LoadInst>(*SI);
         if( DebugThis ) {
-          errs() << "have load in range:";
-          oldLoad->dump();
+          dbgs() << "have load in range:";
+          oldLoad->print(dbgs(), true);
+          dbgs() << '\n';
         }
 
         Value* ptrToAlloc = rebasePointer(oldLoad->getPointerOperand(),
@@ -800,8 +810,9 @@ bool AggregateGlobalOpsOpt::runOnFunction(Function &F) {
   // Walk all instruction in the function.
   for (Function::iterator BB = F.begin(), BBE = F.end(); BB != BBE; ++BB) {
     if( DebugThis ) {
-      errs() << "Working on BB ";
-      BB->dump();
+      dbgs() << "Working on BB ";
+      BB->print(dbgs(), true);
+      dbgs() << '\n';
     }
 
     for (BasicBlock::iterator BI = BB->begin(), BE = BB->end(); BI != BE;) {
@@ -824,8 +835,9 @@ bool AggregateGlobalOpsOpt::runOnFunction(Function &F) {
     }
 
     if( DebugThis && MadeChange ) {
-      errs() << "After transform BB is ";
-      BB->dump();
+      dbgs() << "After transform BB is ";
+      BB->print(dbgs(), true);
+      dbgs() << '\n';
     }
 
   }

--- a/compiler/util/llvmAggregateGlobalOps.cpp
+++ b/compiler/util/llvmAggregateGlobalOps.cpp
@@ -226,13 +226,13 @@ Instruction* reorderAddressingMemopsUses(Instruction *FirstLoadOrStore,
       if( DebugThis ) {
         dbgs() << "found load/store: ";
         insn->print(dbgs(), true);
-	dbgs() << '\n';
+        dbgs() << '\n';
       }
     } else if( memopsUses.count(insn) ) {
       if( DebugThis ) {
         dbgs() << "found memop use: ";
         insn->print(dbgs(), true);
-	dbgs() << '\n';
+        dbgs() << '\n';
       }
       // Move uses of memops to after the final memop.
       insn->removeFromParent();

--- a/compiler/util/llvmGlobalToWide.cpp
+++ b/compiler/util/llvmGlobalToWide.cpp
@@ -1484,7 +1484,7 @@ namespace {
             dbgs() << "verifying new function after pass one: ";
             dbgs().write_escaped(NF->getName()) << '\n';
             NF->print(dbgs(), nullptr, false, true);
-	    dbgs() << '\n';
+            dbgs() << '\n';
           }
           if( extraChecks ) {
 #if HAVE_LLVM_VER >= 35

--- a/compiler/util/llvmGlobalToWide.cpp
+++ b/compiler/util/llvmGlobalToWide.cpp
@@ -43,6 +43,7 @@
 
 #include "llvm/Pass.h"
 #include "llvm/Support/raw_ostream.h"
+#include "llvm/Support/Debug.h"
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/Statistic.h"
 
@@ -454,7 +455,7 @@ namespace {
     void fixInstruction(Instruction* insn)
     {
       if( debugPassTwo ) {
-        errs() << " atf|" << *insn << "|" << "\n";
+        dbgs() << " atf|" << *insn << "|" << "\n";
       }
 
       // First, check to see if the instruction operates on
@@ -473,7 +474,7 @@ namespace {
       if( isaGlobalPointer(info, insn->getType()) ) needsWork = true;
 
       if( ! needsWork ) {
-        if( debugPassTwo ) errs() << " okf|" << *insn << "|" << "\n";
+        if( debugPassTwo ) dbgs() << " okf|" << *insn << "|" << "\n";
         return;
       }
 
@@ -1120,9 +1121,9 @@ namespace {
       bool madeInfo = false;
 
       if( debugThisFn[0] || debugAllPassOne || debugAllPassTwo ) {
-        errs() << "GlobalToWide: ";
-        errs().write_escaped(M.getModuleIdentifier()) << '\n';
-        errs().write_escaped(M.getTargetTriple()) << '\n';
+        dbgs() << "GlobalToWide: ";
+        dbgs().write_escaped(M.getModuleIdentifier()) << '\n';
+        dbgs().write_escaped(M.getTargetTriple()) << '\n';
       }
 
       // Normally we expect a user of this optimization to have
@@ -1251,9 +1252,9 @@ namespace {
         }
 
         if( debugPassOne ) {
-          errs() << "==================================== start pass one\n";
-          errs() << "starting pass one with function ";
-          errs().write_escaped(F->getName()) << '\n';
+          dbgs() << "==================================== start pass one\n";
+          dbgs() << "starting pass one with function ";
+          dbgs().write_escaped(F->getName()) << '\n';
         }
 
         // skip the special functions like wideToGlobal
@@ -1294,8 +1295,8 @@ namespace {
         if( debugPassOne ) {
           // Wait until we have converted the argument types since
           // we might rename them... before dumping the fn.
-          F->dump();
-          errs() << "-----------------------------\n";
+          F->print(dbgs(), nullptr, false, true);
+          dbgs() << "\n-----------------------------\n";
         }
 
         // if we don't need to update the function's return value or at least
@@ -1480,9 +1481,10 @@ namespace {
     
           // DEBUG: verify function
           if( debugPassOne ) {
-            errs() << "verifying new function after pass one: ";
-            errs().write_escaped(NF->getName()) << '\n';
-            NF->dump();
+            dbgs() << "verifying new function after pass one: ";
+            dbgs().write_escaped(NF->getName()) << '\n';
+            NF->print(dbgs(), nullptr, false, true);
+	    dbgs() << '\n';
           }
           if( extraChecks ) {
 #if HAVE_LLVM_VER >= 35
@@ -1496,7 +1498,7 @@ namespace {
         F->eraseFromParent();
 
         if( debugPassOne ) {
-          errs() << "==================================== end pass one fn\n";
+          dbgs() << "==================================== end pass one fn\n";
         }
       }
 
@@ -1609,10 +1611,13 @@ namespace {
         if( F->begin() == F->end() ) continue;
 
         if( debugPassTwo ) {
-          errs() << "Pass 2.1 to function ---------- ";
-          errs().write_escaped(F->getName()) << '\n';
-          if( debugPassTwo ) F->dump();
-          errs() << "-----------------------------\n";
+          dbgs() << "Pass 2.1 to function ---------- ";
+          dbgs().write_escaped(F->getName()) << '\n';
+          if( debugPassTwo ) {
+            F->print(dbgs(), nullptr, false, true);
+            dbgs() << '\n';
+          }
+          dbgs() << "-----------------------------\n";
         }
  
         /*
@@ -1678,11 +1683,11 @@ namespace {
         }
 
         if( debugPassTwo ) {
-          errs() << "After rewriting global ops, function is: ";
-          errs().write_escaped(F->getName()) << '\n';
-          F->dump();
-          errs() << "-----------------------------\n";
-          errs() << "Now pass 2.2 mapping w2g and g2w: \n";
+          dbgs() << "After rewriting global ops, function is: ";
+          dbgs().write_escaped(F->getName()) << '\n';
+          F->print(dbgs(), nullptr, false, true);
+          dbgs() << "\n-----------------------------\n";
+          dbgs() << "Now pass 2.2 mapping w2g and g2w: \n";
         }
 
         for (Function::iterator BI = F->begin(), BE = F->end(); BI != BE; ) {
@@ -1715,7 +1720,7 @@ namespace {
         }
 
         if( debugPassTwo ) {
-          errs() << "Now pass 2.3 remapping instructions\n";
+          dbgs() << "Now pass 2.3 remapping instructions\n";
         }
 
         for (Function::iterator BI = F->begin(), BE = F->end(); BI != BE; ) {
@@ -1747,7 +1752,7 @@ namespace {
         Junk.clear();
 
         if( debugPassTwo ) {
-          errs() << "AFTER PASS 2 the function is:\n";
+          dbgs() << "AFTER PASS 2 the function is:\n";
 
           for (Function::iterator BI = F->begin(), BE = F->end(); BI != BE; ) {
             BasicBlock& BBRef = *BI;
@@ -1755,13 +1760,13 @@ namespace {
             ++BI;
   
             if( debugPassTwo ) {
-              errs() << BB->getName() << ":\n";
+              dbgs() << BB->getName() << ":\n";
             }
    
             for (BasicBlock::iterator I = BB->begin(), E = BB->end(); I != E; ) {
               Instruction *insn = &*I;
               ++I;
-              errs() << "    |" << *insn << "|" << "\n";
+              dbgs() << "    |" << *insn << "|" << "\n";
             }
           }
         }

--- a/compiler/util/llvmUtil.cpp
+++ b/compiler/util/llvmUtil.cpp
@@ -502,7 +502,7 @@ uint64_t doGetTypeFieldNext(LLVM_TARGET_DATA * layout, llvm::Type* ty, uint64_t 
   unsigned i, n;
   uint64_t local_offset, next_offset_here, offset_here;
 
-  //ty->dump();
+  //ty->print(dbgs(), true);
   //printf("offset %i parent %i,%i\n", (int) offset, (int) parent_this_offset, (int) parent_next_offset);
 
   assert(parent_this_offset <= offset && offset <= parent_next_offset);


### PR DESCRIPTION
Beginning with LLVM 5, the dump() methods are no longer exposed for non-debug builds.  This change switches to using print() instead.

A lot of the LLVM community didn't know this (myself included) but dump() was only intended as something that could be run from inside gdb.  That is why it is now stripped from non-debug builds.

The print() methods take varying numbers of arguments depending on what is being printed.  The last argument is `isForDebug` which needs to be set to `true` to duplicate what we used to get from the dump() methods.

This change is sufficient to get LLVM 5 to work without setting CHPL_LLVM_DEVELOPER.  However, it will conflict with some of the files that @mppf is changing with the llvm-wide-opt PR.  Therefore, I will submit this PR as a record of what needs to be done, and then close it to get out of the way.

Passes full local testing with and without `--fast`, except for known errors in fft optimization that will need to be investigated (documented in #7246 ).