### PR TITLE
Fix updateBuildVersion to work with git worktree

### DIFF
--- a/util/devel/updateBuildVersion
+++ b/util/devel/updateBuildVersion
@@ -23,7 +23,7 @@ if (-r "$build_version_file") {
 }
 
 if (defined $ENV{'CHPL_HOME'} &&
-    -d "$chplhome/.git") {
+    -e "$chplhome/.git") {
 
     $git_rev = `cd $ENV{'CHPL_HOME'} && git rev-parse --short HEAD`;
     chomp($git_rev);


### PR DESCRIPTION
I've started using git worktree to save space while having multiple git
working directories (usually for different branches).  In a git worktree
environment, $CHPL_HOME/.git is a file (not a directory). That causes
updateBuildVersion to fail and some of the tests like
compflags/bradc/printstuff/version to fail too. This commit simply
adjusts updateBuildVersion to allow .git to be a file or a directory.

Verified this change works in a non-worktree checkout as well as with worktrees.
(version number is right, printstuff/version passes).

Trivial and not reviewed.

FYI I used these commands to set up several checkouts that share the
same git history:

``` bash
  # Create a "bare" git repository (less confusing this way)
  # This directory will store the git history only and not have
  # files checkout out.
  git clone https://github.com/mppf/chapel.git chapel.git --bare
  git remote add upstream https://github.com/chapel-lang/chapel.git
  git branch --set-upstream-to=upstream/master master

  # Make a directory to store checkouts
  mkdir ../w

  # use git worktree to add new checkouts
  git worktree add ../w/master master
  git worktree add ../w/1
  git worktree add ../w/2

  # when using one of these checkouts, start a new branch
  # based on master like this:
  cd ../w/1
  git fetch upstream
  git checkout upstream/master
  git checkout -b some-feature-branch
```