### PR TITLE
Hardcode CHPL_GMP to 'system' when using cray-prgenv-cray

### DIFF
--- a/util/chplenv/chpl_gmp.py
+++ b/util/chplenv/chpl_gmp.py
@@ -14,22 +14,26 @@ from utils import memoize
 def get():
     gmp_val = overrides.get('CHPL_GMP')
     if not gmp_val:
-        target_platform = chpl_platform.get('target')
-
-        # Detect if gmp has been built for this configuration.
-        third_party = get_chpl_third_party()
-        uniq_cfg_path = chpl_3p_gmp_configs.get_uniq_cfg_path()
-        gmp_subdir = os.path.join(third_party, 'gmp', 'install', uniq_cfg_path)
-
-        if os.path.exists(os.path.join(gmp_subdir, 'include', 'gmp.h')):
-            gmp_val = 'gmp'
-        elif target_platform.startswith('cray-x'):
-            gmp_val = 'system'
-        elif target_platform == 'aarch64':
+        target_compiler = chpl_compiler.get('target')
+        if target_compiler == 'cray-prgenv-cray':
             gmp_val = 'system'
         else:
-            gmp_val = 'none'
-    return gmp_val
+            target_platform = chpl_platform.get('target')
+
+            # Detect if gmp has been built for this configuration.
+            third_party = get_chpl_third_party()
+            uniq_cfg_path = chpl_3p_gmp_configs.get_uniq_cfg_path()
+            gmp_subdir = os.path.join(third_party, 'gmp', 'install', uniq_cfg_path)
+
+            if os.path.exists(os.path.join(gmp_subdir, 'include', 'gmp.h')):
+                gmp_val = 'gmp'
+            elif target_platform.startswith('cray-x'):
+                gmp_val = 'system'
+            elif target_platform == 'aarch64':
+                gmp_val = 'system'
+            else:
+                gmp_val = 'none'
+        return gmp_val
 
 
 def _main():

--- a/util/chplenv/chpl_gmp.py
+++ b/util/chplenv/chpl_gmp.py
@@ -33,7 +33,7 @@ def get():
                 gmp_val = 'system'
             else:
                 gmp_val = 'none'
-        return gmp_val
+    return gmp_val
 
 
 def _main():


### PR DESCRIPTION
Rationale: We're getting silent test failures when building our
bundled copy of GMP in that mode.