### PR TITLE
Explicitly skip some tests with custom sub_tests for perf testing

### DIFF
--- a/test/compflags/ferguson/default-binary-name/SKIPIF
+++ b/test/compflags/ferguson/default-binary-name/SKIPIF
@@ -1,2 +1,1 @@
-CHPL_COMM!=none
 CHPL_TEST_PERF == on

--- a/test/setchplenv/SKIPIF
+++ b/test/setchplenv/SKIPIF
@@ -1,2 +1,1 @@
-CHPL_COMM!=none
 CHPL_TEST_PERF == on


### PR DESCRIPTION
The real sub_test knows which tests to skip while running performance testing,
but most custom sub_tests don't. This results in tests running when they
shouldn't be, so add explicit SKIPIFs for them. This is similar to #5948

I noticed this while running release-over-release performance testing because
the default-binary-name test fails for older releases.