### PR TITLE
Pre-release prep. Chapel 1.16.0: "pre-release" tags back in master and bump to 1.17.0

### DIFF
--- a/compiler/main/version.cpp
+++ b/compiler/main/version.cpp
@@ -31,7 +31,7 @@ void
 get_version(char *v) {
   v += sprintf(v, "%d.%s.%s", MAJOR_VERSION, MINOR_VERSION, UPDATE_VERSION);
   if (strcmp(BUILD_VERSION, "0") != 0 || developer)
-    sprintf(v, ".%s", BUILD_VERSION);   // post-release
+    sprintf(v, " pre-release (%s)", BUILD_VERSION);
 }
 
 void

--- a/compiler/main/version_num.h
+++ b/compiler/main/version_num.h
@@ -21,7 +21,7 @@
 #define _version_num_H_
 
 #define MAJOR_VERSION 1
-#define MINOR_VERSION "16"
+#define MINOR_VERSION "17"
 #define UPDATE_VERSION "0"
 
 static const char* BUILD_VERSION =

--- a/doc/rst/conf.py
+++ b/doc/rst/conf.py
@@ -61,11 +61,11 @@ master_doc = 'index'
 # 'version' adds a redundant version number onto the top of the sidebar
 # automatically (rtd-theme). We also don't use |version| anywhere in rst
 
-chplversion = '1.16'                # post-release
+chplversion = '1.16 pre-release'    # TODO -- parse from `chpl --version`
 shortversion = chplversion.replace('-', '&#8209') # prevent line-break at hyphen
 
 # The full version, including alpha/beta/rc tags.
-release = '1.16.0'                  # post-release
+release = '1.16.0 pre-release'
 
 # General information about the project.
 project = u'Chapel Documentation {0}'.format(shortversion)

--- a/doc/rst/conf.py
+++ b/doc/rst/conf.py
@@ -55,17 +55,17 @@ master_doc = 'index'
 # built documents.
 #
 # The short X.Y version.
-# version = '1.16'
+# version = '1.17'
 
 # We use a custom version variable (shortversion) instead, because setting
 # 'version' adds a redundant version number onto the top of the sidebar
 # automatically (rtd-theme). We also don't use |version| anywhere in rst
 
-chplversion = '1.16 pre-release'    # TODO -- parse from `chpl --version`
+chplversion = '1.17 pre-release'    # TODO -- parse from `chpl --version`
 shortversion = chplversion.replace('-', '&#8209') # prevent line-break at hyphen
 
 # The full version, including alpha/beta/rc tags.
-release = '1.16.0 pre-release'
+release = '1.17.0 pre-release'
 
 # General information about the project.
 project = u'Chapel Documentation {0}'.format(shortversion)

--- a/man/confchpl.rst
+++ b/man/confchpl.rst
@@ -1,5 +1,5 @@
 
-:Version: 1.16.0 pre-release
+:Version: 1.17.0 pre-release
 :Manual section: 1
 :Title: \\fBchpl\\fP
 :Subtitle: Compiler for the Chapel Programming Language

--- a/man/confchpl.rst
+++ b/man/confchpl.rst
@@ -1,5 +1,5 @@
 
-:Version: 1.16.0
+:Version: 1.16.0 pre-release
 :Manual section: 1
 :Title: \\fBchpl\\fP
 :Subtitle: Compiler for the Chapel Programming Language

--- a/man/confchpldoc.rst
+++ b/man/confchpldoc.rst
@@ -1,5 +1,5 @@
 
-:Version: 1.16.0 pre-release
+:Version: 1.17.0 pre-release
 :Manual section: 1
 :Title: \\fBchpldoc\\fP
 :Subtitle: the Chapel Documentation Tool

--- a/man/confchpldoc.rst
+++ b/man/confchpldoc.rst
@@ -1,5 +1,5 @@
 
-:Version: 1.16.0
+:Version: 1.16.0 pre-release
 :Manual section: 1
 :Title: \\fBchpldoc\\fP
 :Subtitle: the Chapel Documentation Tool

--- a/test/compflags/bradc/printstuff/version.goodstart
+++ b/test/compflags/bradc/printstuff/version.goodstart
@@ -1,1 +1,1 @@
- Version 1.16.0
+ Version 1.17.0

--- a/test/compflags/bradc/printstuff/versionhelp.sh
+++ b/test/compflags/bradc/printstuff/versionhelp.sh
@@ -5,4 +5,4 @@ compiler=$3
 echo -n `basename $compiler`
 cat $CWD/version.goodstart
 diff $CWD/../../../../compiler/main/BUILD_VERSION $CWD/zero.txt > /dev/null 2>&1 && echo "" || \
-    { echo -n "." && cat $CWD/../../../../compiler/main/BUILD_VERSION | tr -d \" ; }    # post-release
+    { echo -n " pre-release (" && cat $CWD/../../../../compiler/main/BUILD_VERSION | tr -d \"\\n && echo ")" ; }


### PR DESCRIPTION
THIS IS NOT CHAPEL RELEASE 1.17.0
    
Now that the release branch for Chapel 1.16.0 has been created,
change (most) version numbers on master branch from 1.16 to 1.17
and put the "pre-release" version tags back in.

This prepares master branch for work on the next release after 1.16.0