### PR TITLE
Update issue pointer in futures to Github version

### DIFF
--- a/test/modules/cassella/ambigmodmain.future
+++ b/test/modules/cassella/ambigmodmain.future
@@ -10,5 +10,5 @@ main function and potentially a bug in scope resolve's resolution of module
 names - ideally, we would like to see an error because M is ambiguous instead
 of arbitrarily choosing one or the other.
 
-When this is resolved, please update Jira issue 176
-(https://chapel.atlassian.net/projects/CHAPEL/issues/CHAPEL-176)
+When this is resolved, please update issue #7511
+(https://github.com/chapel-lang/chapel/issues/7511)

--- a/test/modules/cassella/ambigmodmain.mainModule.future
+++ b/test/modules/cassella/ambigmodmain.mainModule.future
@@ -12,5 +12,5 @@ module works, so the .compopts should be expanded to:
 --main-module X.M # ambigmodmain.X.good
 --main-module Y.M # ambigmodmain.Y.good
 
-and please update Jira issue 177
-(https://chapel.atlassian.net/projects/CHAPEL/issues/CHAPEL-177)
+and please update issue #7510
+(https://github.com/chapel-lang/chapel/issues/7510)

--- a/test/modules/cassella/ambigmodmain.unnested.future
+++ b/test/modules/cassella/ambigmodmain.unnested.future
@@ -6,5 +6,5 @@ and both define a main, if the ambiguous name is specified with the
 as the desired module.  Ideally, we would like to see an error because M is
 ambiguous instead of arbitrarily choosing one or the other.
 
-When this is resolved, please update Jira issue 176
-(https://chapel.atlassian.net/projects/CHAPEL/issues/CHAPEL-176)
+When this is resolved, please update issue #7511
+(https://github.com/chapel-lang/chapel/issues/7511)

--- a/test/modules/cassella/ambigmodmain.unnested2.future
+++ b/test/modules/cassella/ambigmodmain.unnested2.future
@@ -6,5 +6,5 @@ and both define a main, if the ambiguous name is specified with the
 as the desired module.  Ideally, we would like to see an error because M is
 ambiguous instead of arbitrarily choosing one or the other.
 
-When this is resolved, please update Jira issue 176
-(https://chapel.atlassian.net/projects/CHAPEL/issues/CHAPEL-176)
+When this is resolved, please update issue #7511
+(https://github.com/chapel-lang/chapel/issues/7511)


### PR DESCRIPTION
We're no longer using JIRA to track these issues, use the new #7510 and
#7511.