### PR TITLE
Close leaks due to LocRadCache objects

### DIFF
--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -412,6 +412,11 @@ class LocBlockArr {
   inline proc unlockLocRAD() {
     locRADLock.clear();
   }
+
+  proc deinit() {
+    if locRAD != nil then
+      delete locRAD;
+  }
 }
 
 //

--- a/modules/dists/CyclicDist.chpl
+++ b/modules/dists/CyclicDist.chpl
@@ -956,6 +956,11 @@ class LocCyclicArr {
   inline proc unlockLocRAD() {
     locRADLock.clear();
   }
+
+  proc deinit() {
+    if locRAD != nil then
+      delete locRAD;
+  }
 }
 
 proc LocCyclicArr.this(i) ref {

--- a/modules/dists/StencilDist.chpl
+++ b/modules/dists/StencilDist.chpl
@@ -369,6 +369,11 @@ class LocStencilArr {
   inline proc unlockLocRAD() {
     locRADLock.clear();
   }
+
+  proc deinit() {
+    if locRAD != nil then
+      delete locRAD;
+  }
 }
 
 private proc makeZero(param rank : int, type idxType) {
@@ -964,6 +969,11 @@ proc StencilArr.dsiDisplayRepresentation() {
 }
 
 proc StencilArr.dsiGetBaseDom() return dom;
+
+proc StencilArr.initialize() {
+  dists/StencilDist.chpl:  var sendRecvFlag : [locDom.NeighDom] atomic bool;
+  writeln("In StencilArr's initialize() routine");
+}
 
 //
 // NOTE: Each locale's myElems array must be initialized prior to setting up

--- a/modules/dists/StencilDist.chpl
+++ b/modules/dists/StencilDist.chpl
@@ -970,11 +970,6 @@ proc StencilArr.dsiDisplayRepresentation() {
 
 proc StencilArr.dsiGetBaseDom() return dom;
 
-proc StencilArr.initialize() {
-  dists/StencilDist.chpl:  var sendRecvFlag : [locDom.NeighDom] atomic bool;
-  writeln("In StencilArr's initialize() routine");
-}
-
 //
 // NOTE: Each locale's myElems array must be initialized prior to setting up
 // the RAD cache.


### PR DESCRIPTION
It appears that we have not been cleaning up LocRadCache objects
in our Block, Cyclic, Stencil distributions.  Doing so seems to
be as easy as creating a deinit() routine that frees them if
they're non-`nil` on the local array descriptors.  This takes
MultiBlockDist2DLocales.chpl down to zero leaks.

TODO:
- [x] testing
