### PR TITLE
Fix memory leak caused by "".join(("",""))

### DIFF
--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -890,6 +890,9 @@ module String {
         var joinedSize: int = this.len * (S.size - 1);
         for s in S do joinedSize += s.length;
 
+        if joinedSize == 0 then
+          return '';
+
         var joined: string;
         joined.len = joinedSize;
         const allocSize = chpl_here_good_alloc_size(joined.len + 1);


### PR DESCRIPTION
This currently results in returning a string with len 0 but buf[]
allocated and _size > 0.  The len being 0 results in isEmptyString()
returning true, so deinit() doesn't free the buf[].

Avoid this by handing a resulting joinedSize 0 as a special case, and
return a real empty string.

This fixes the leak in test/types/string/psahabu/join-tuples.chpl