### PR TITLE
Fix dynamic dispatch of serial iterators with nesting deeper than 2

### DIFF
--- a/test/functions/iterators/diten/dynamicDispatchIterator3Levels.bad
+++ b/test/functions/iterators/diten/dynamicDispatchIterator3Levels.bad
@@ -1,7 +1,0 @@
-internal error: VIR0377 chpl Version 1.16.0 pre-release (d9b1d3d)
-
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
-and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
-please see http://chapel.cray.com/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
-

--- a/test/functions/iterators/diten/dynamicDispatchIterator3Levels.future
+++ b/test/functions/iterators/diten/dynamicDispatchIterator3Levels.future
@@ -1,3 +1,0 @@
-bug: Iterator inheriting 3 or more levels deep causes assertion failure
-
-Issue #7429


### PR DESCRIPTION
When the class hierarchy is at least three levels deep with an iterator
overloaded at each level, the compiler was tripping an assert. This was
because the iterator classes for both the parent and grandparent iterators
were getting added to the child iterator class's dispatchParents list.

Check that the classes the iterators are defined in have a direct subclass
relationship before linking the iterator classes.