### PR TITLE
Fix some sparse matrix-matrix mult bugs

### DIFF
--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -1225,7 +1225,7 @@ module Sparse {
   pragma "no doc"
   /* Sparse-accumulator */
   record _SPA {
-    var cols: range;
+    var cols; // range(?)
     type eltType = int;
     var b: [cols] bool,      // occupation
         w: [cols] eltType,   // values

--- a/test/modules/packages/linearalgebra/correctness/sparse-sorted.chpl
+++ b/test/modules/packages/linearalgebra/correctness/sparse-sorted.chpl
@@ -11,6 +11,11 @@ config const debug = false;
 // result in a sparse array with unsorted 'idx' values. This would fail
 // in different ways, most obviously when checking for domain membership.
 //
+// I'm not sure what it is about this particular set of indices that triggers
+// the failure. Simple patterns like this don't trigger the failure:
+// - identity matrix
+// - matrix with the same indices in each row
+//
 
 proc main() {
   const R = 1..n;

--- a/test/modules/packages/linearalgebra/correctness/sparse-sorted.chpl
+++ b/test/modules/packages/linearalgebra/correctness/sparse-sorted.chpl
@@ -1,0 +1,39 @@
+
+use LayoutCS;
+use LinearAlgebra;
+use LinearAlgebra.Sparse;
+
+config const n = 1000;
+config const debug = false;
+
+//
+// BHARSH: Leading up to the 1.16 release, 'dot' with sparse arrays would
+// result in a sparse array with unsorted 'idx' values. This would fail
+// in different ways, most obviously when checking for domain membership.
+//
+
+proc main() {
+  const R = 1..n;
+  const parent = {R,R};
+  var D : sparse subdomain(parent) dmapped CS();
+
+  for i in R {
+    const s = 1 + i % 10;
+    for j in 1..n by s # 5 do D += (i,j);
+  }
+
+  var A : [D] int;
+
+  var B = A.dot(A);
+
+  var fails = 0;
+  forall bb in B.domain with (+ reduce fails) {
+    if B.domain.member(bb) == false {
+      fails += 1;
+      if debug then writeln("NOT FOUND: ", bb);
+    }
+  }
+
+  if fails == 0 then writeln("SUCCESS");
+  else writeln("Found ", fails, " failures out of ", D.size, " indices.");
+}

--- a/test/modules/packages/linearalgebra/correctness/sparse-sorted.good
+++ b/test/modules/packages/linearalgebra/correctness/sparse-sorted.good
@@ -1,0 +1,1 @@
+SUCCESS


### PR DESCRIPTION
1) SPA used the range '0..#cols', when it should use the first dimension
of A's domain. Otherwise there would be OOB errors if the array wasn't
zero-based.

2) The resulting sparse array did not sort its indices internally. This
would result in various failures. For example, domain membership checks
would fail despite those indices being yielded from the domain's
iterator. The fix is to sort SPA.ls before inserting into 'C'.

Testing:
- [x] LA primer
- [x] modules/packages/linearAgebra/correctness