### PR TITLE
When running gasnet testing with valgrind, use its suppression file

### DIFF
--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -798,6 +798,8 @@ if (os.getenv('CHPL_TEST_VGRND_EXE')=='on' and vgrbin):
     valgrindbinopts = chpl_valgrind_opts.split()+['-q']
     if (chplcomm!='none'):
         valgrindbinopts+=['--trace-children=yes']
+        if (chplcomm=='gasnet'):
+            valgrindbinopts+=['--suppressions=%s/third-party/gasnet/gasnet-src/other/contrib/gasnet.supp'%(chpl_home)]
 else:
     valgrindbin = None
     valgrindbinopts = None


### PR DESCRIPTION
Unfortunately, this does not result in clean execution for simple
hello world programs, but it's better than nothing.  As a background
task, I'm trying to determine what we can do to tighten this up (with
some help from the GASNet team as well).