### PR TITLE
Fix nightly gasnet-{everything,fast} testing

### DIFF
--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -618,14 +618,6 @@ if (!($dist eq "")) {
     $testdirs .= " distributions/robust/arithmetic";
     $testflags = "$testflags distributions/robust/arithmetic";
 }
-if ($parnodefile eq "") {
-} else {
-    if ($gasnet == 1) {
-        $testflags = "$testflags -comm gasnet";
-    } elsif ($mpi == 1) {
-        $testflags = "$testflags -comm mpi";
-    }
-}
 
 if ($hello == 1) {
     if ($parnodefile eq "") {

--- a/util/cron/test-gasnet-everything.bash
+++ b/util/cron/test-gasnet-everything.bash
@@ -13,4 +13,4 @@ export GASNET_QUIET=Y
 # Test a GASNet compile using the default segment (everything for linux64)
 export CHPL_GASNET_SEGMENT=everything
 
-$CWD/nightly -cron -futures $(get_nightly_paratest_args 3)"
+$CWD/nightly -cron -futures $(get_nightly_paratest_args 3)


### PR DESCRIPTION
We started using paratest for nightly gasnet testing with #7501, but nightly
hasn't used paratest for gasnet testing in a long time. It was still trying to
call paratest with `-comm gasnet`, which was removed years ago with c79342b81b.

Stop throwing `-comm` in nightly to fix this.