### PR TITLE
Skip Jama testing for memory leaks

### DIFF
--- a/test/modules/packages/LinearAlgebraJama/SKIPIF
+++ b/test/modules/packages/LinearAlgebraJama/SKIPIF
@@ -1,0 +1,1 @@
+CHPL_MEM_LEAK_TESTING == true


### PR DESCRIPTION
Matrices are classes in this LinearAlgebraJama module, and this test
doesn't do a good job of cleaning up after itself as it creates and
destroys matrices.  I started an effort to have it do so in PR #7366,
but underanticipated just how often the library routines themselves
create temporary matrices which are then dropped on the floor back at
the callsite.  I then continued the effort by storing the results of
any library routines into separate variables and freeing them after
they were printed out / checked, but quickly reached the point where
it was obviously not a good use of my time (or anyone's on the core
team).  Given that this is a package module that we anticipate ending
up in Mason-land, it seems reasonable to skip it for our memory leak
testing while we continue to strive to drive leaks down to zero to
focus on ones that are in the core language and modules.

I think the right way to solve this problem would be to have this
module's matrices either be Owned classes or similar record-wrapped
classes that automatically manage lifetimes for the user and intend to
file a future against the package's repository for that purpose.