### PR TITLE
Move global-to-wide later in LLVM pipeline

### DIFF
--- a/compiler/util/clangUtil.cpp
+++ b/compiler/util/clangUtil.cpp
@@ -2290,7 +2290,7 @@ void makeBinaryLLVM(void) {
       configurePMBuilder(PMBuilder2, /* opt level */ 1);
       // Should we disable vectorization since we did that?
       // Or run select few cleanup passes?
-      // Inlining is definately important here..
+      // Inlining is definitely important here..
 
       PMBuilder2.populateModulePassManager(mpm2);
 


### PR DESCRIPTION
This PR improves --llvm-wide-opt.

I noticed that we were running global-to-wide earlier than I intended;
EP_ScalarOptimizerLate seems too early since it happens before
vectorization. This commit changes it to run as the last stage in
optimization with EP_OptimizerLast (and then we'll run inlining etc again
in a 2nd set of opts).

Also switches to using two Module Pass Managers; one for optimization in
address-space-100 that concludes with global-to-wide, and then a second
to do clean-up optimization on that. These are currently two pass
managers so that it's easier to debug their output.

PR #7542 shows the start of another way to enable saving the LLVM module
for debugging purposes at key points.

Reviewed by @ronawho - thanks!

- [x] full local --llvm testing