### PR TITLE
Remove initialize method from Timer record (which was empty)

### DIFF
--- a/modules/standard/Time.chpl
+++ b/modules/standard/Time.chpl
@@ -147,11 +147,6 @@ record Timer {
   pragma "no doc"
   var running:     bool       = false;
 
-  pragma "no doc"
-  proc initialize() {
-    // does nothing.
-  }
-
   /*
      Clears the elapsed time. If the timer is running then it is restarted
      otherwise it remains in the stopped state.


### PR DESCRIPTION
We've decided that we would like to remove as many uses of the old
"initialize()" method (which was used to do some operations after the completion
of the default constructor, without having to redefine the default constructor
to get its functionality) as possible.

This initialize method should be trivial to remove - it had no contents and the
type is not one that has special compiler support, so we should not see an
impact after its removal.

Passed a full standard paratest run, and a small sample of performance runs
showed no difference in behavior