### PR TITLE
Remove initialize method from the LocSparseBlockDom class (which was empty)

### DIFF
--- a/modules/dists/SparseBlockDist.chpl
+++ b/modules/dists/SparseBlockDist.chpl
@@ -286,10 +286,6 @@ class LocSparseBlockDom {
   var sparseDist = new sparseLayoutType; //unresolved call workaround
   var mySparseBlock: sparse subdomain(parentDom) dmapped new dmap(sparseDist);
 
-  proc initialize() {
-    //    writeln("On locale ", here.id, " LocSparseBlockDom = ", this);
-  }
-
   proc dsiAdd(ind: rank*idxType) {
     return mySparseBlock.add(ind);
   }


### PR DESCRIPTION
Since it has no contents, I see no reason why this should cause issues (though
I'm going to do a sanity check anyways)

- [x] standard paratest
- [x] gasnet paratest