### PR TITLE
Remove the empty initialize method from this test, and a related comment

### DIFF
--- a/test/users/shetag/classWithArray/initArrWithFn.chpl
+++ b/test/users/shetag/classWithArray/initArrWithFn.chpl
@@ -3,11 +3,6 @@ class C {
 
   //error: internal failure SYM1167 chpl Version 0.5.271
   var arr : [1..n] int = initArr(n);
-  //  var arr : [1..n] int;
-
-  proc initialize() {
-    //    [i in 1..n] arr(i) = i;
-  }
 
   proc initArr(n) {
     const a : [1..n] int = [i in 1..n] i;


### PR DESCRIPTION
Based on the context, I believe the comment within the initialize method was
related to the commented out alternate declaration for the array field.  I
could add an alternative commented out initializer to replace the initialize()
method, but I don't think that is necessary.

The test still passes with this change.  Need to check a fresh checkout