### PR TITLE
Fix memory leaks in Crypto tests

### DIFF
--- a/test/modules/packages/Crypto/saru/aes/aesTest1.chpl
+++ b/test/modules/packages/Crypto/saru/aes/aesTest1.chpl
@@ -27,4 +27,15 @@ proc main(){
   /* Decrypt the message using the key and IV */
   var orig = a.decrypt(ct, key, iv);
   writeln("Obtained Plaintext: ", orig.toHex());
+
+  /* Clean up allocated classes */
+  delete orig;
+  delete ct;
+  delete msg;
+  delete iv;
+  delete key;
+  delete k;
+  delete hash;
+  delete salt;
+  delete a;
 }

--- a/test/modules/packages/Crypto/saru/hashing/hash1.chpl
+++ b/test/modules/packages/Crypto/saru/hashing/hash1.chpl
@@ -6,8 +6,19 @@ proc main(){
   var s = "The quick brown fox jumps over the lazy dog";
   writeln(s);
 
-  var digest = SHA.getDigest(new CryptoBuffer(s));
+  var buf = new CryptoBuffer(s);
+  var digest = SHA.getDigest(buf);
   writeln(SHA.getDigestName() , " = " , digest.toHex());
-  digest = SHA2.getDigest(new CryptoBuffer(s));
+
+  delete digest;
+  delete buf;
+
+  buf = new CryptoBuffer(s);
+  digest = SHA2.getDigest(buf);
   writeln(SHA2.getDigestName() , " = " , digest.toHex());
+
+  delete digest;
+  delete buf;
+  delete SHA2;
+  delete SHA;
 }

--- a/test/modules/packages/Crypto/saru/hashing/hash2.chpl
+++ b/test/modules/packages/Crypto/saru/hashing/hash2.chpl
@@ -5,6 +5,11 @@ proc main(){
   var s = "The quick brown fox jumps over the lazy dog";
   writeln(s);
 
-  var digest = SHA.getDigest(new CryptoBuffer(s));
+  var buf = new CryptoBuffer(s);
+  var digest = SHA.getDigest(buf);
   writeln(SHA.getDigestName() + " = " + digest.toHexString());
+
+  delete digest;
+  delete buf;
+  delete SHA;
 }

--- a/test/modules/packages/Crypto/saru/kdf/pbkdf2-1.chpl
+++ b/test/modules/packages/Crypto/saru/kdf/pbkdf2-1.chpl
@@ -1,7 +1,13 @@
 proc main(){
   use Crypto;
 
-  var k = new KDF(32, 1000, new Hash("SHA256"));
-  var key = k.passKDF("random_key", new CryptoBuffer("random_salt"));
+  var hash = new Hash("SHA256");
+  var k = new KDF(32, 1000, hash);
+  var buf = new CryptoBuffer("random_salt");
+  var key = k.passKDF("random_key", buf);
   writeln("Generated Key: ", key.toHex());
+  delete key;
+  delete buf;
+  delete k;
+  delete hash;
 }

--- a/test/modules/packages/Crypto/saru/kdf/pbkdf2-2.chpl
+++ b/test/modules/packages/Crypto/saru/kdf/pbkdf2-2.chpl
@@ -1,7 +1,14 @@
 proc main() {
   use Crypto;
 
-  var k = new KDF(0, 1000, new Hash("SHA256")); // should halt
-  var key = k.passKDF("random_key", new CryptoBuffer("random_salt"));
+  var hash = new Hash("SHA256");
+  var k = new KDF(0, 1000, hash); // should halt
+  var buf = new CryptoBuffer("random_salt");
+  var key = k.passKDF("random_key", buf);
   writeln("Generated Key: ", key.toHex());
+
+  delete key;
+  delete buf;
+  delete k;
+  delete hash;
 }

--- a/test/modules/packages/Crypto/saru/utils/buffer.chpl
+++ b/test/modules/packages/Crypto/saru/utils/buffer.chpl
@@ -8,6 +8,8 @@ proc main(){
   writeln(b.getBuffData());
   writeln(b.getBuffSize());
 
+  delete b;
+
   /* Array to buffer */
   var arr: [0..4] uint(8) = [1: uint(8), 2: uint(8), 3: uint(8), 4: uint(8), 5: uint(8)];
   var c = new CryptoBuffer(arr);
@@ -15,4 +17,6 @@ proc main(){
   writeln(c.toHexString());
   writeln(c.getBuffData());
   writeln(c.getBuffSize());
+
+  delete c;
 }

--- a/test/modules/packages/Crypto/saru/utils/buffer2.chpl
+++ b/test/modules/packages/Crypto/saru/utils/buffer2.chpl
@@ -8,4 +8,5 @@ proc main(){
   writeln(c.toHexString());
   writeln(c.getBuffData());
   writeln(c.getBuffSize());
+  delete c;
 }

--- a/test/modules/packages/Crypto/saru/utils/buffer3.chpl
+++ b/test/modules/packages/Crypto/saru/utils/buffer3.chpl
@@ -2,4 +2,5 @@ proc main() {
   use Crypto;
   var a = new CryptoBuffer(""); // doesn't do anything
   writeln(a.toHex());
+  delete a;
 }

--- a/test/modules/packages/Crypto/saru/utils/buffer4.chpl
+++ b/test/modules/packages/Crypto/saru/utils/buffer4.chpl
@@ -3,4 +3,5 @@ proc main() {
   var x: [0..10] uint(8);
   var a = new CryptoBuffer(x);
   writeln(a.toHex()); // prints 0 due to uninitialized values
+  delete a;
 }


### PR DESCRIPTION
The tests for the Crypto module create, but don't delete classes, so they
leak memory. Add delete statements so they don't leak.