### PR TITLE
Fix perf graphs screenshot button

### DIFF
--- a/util/test/perf/perfgraph.js
+++ b/util/test/perf/perfgraph.js
@@ -563,7 +563,12 @@ function captureScreenshot(g, graphInfo) {
           ctx.fillText(label, 0, fontSize);
 
           // open the screenshot in a new window
-          window.open(captureCanvas.toDataURL());
+          //
+          // BHARSH 2017-10-09: recent browser versions no longer allow 'window.open'
+          // with a data URL due to security concerns.
+          //
+          var screenWin = window.open();
+          screenWin.document.write("<img src='" + captureCanvas.toDataURL() + "'/>");
 
           // restore the roll box and ylabel
           g.updateOptions(restoreOpts);


### PR DESCRIPTION
Create an 'img' element for the screenshot now that browser security disallows window.open with data URLs.