### PR TITLE
Fix typos

### DIFF
--- a/compiler/resolution/implementForallIntents.cpp
+++ b/compiler/resolution/implementForallIntents.cpp
@@ -1071,13 +1071,13 @@ General Context
 Let's say we are extending the parallel iterator with a variable
 that corresponds to a reduce intent. For example, from this:
 
-  iter myIter(param tag == standlone) {
+  iter myIter(param tag == standalone) {
     ... yield 555; ...
   }
 
 to this:
 
-  iter myIter(param tag == standlone, x1_reduceParent:SumReduceScanOp) {
+  iter myIter(param tag == standalone, x1_reduceParent:SumReduceScanOp) {
     var x1_shadowVarReduc = x1_reduceParent.identity;
     ... yield (555, addr-of(x1_shadowVarReduc)); ...
     x1_reduceParent.accumulate(x1_shadowVarReduc);
@@ -1107,7 +1107,7 @@ Need to handle these cases:
 
 * The yield is in >1 nested foralls --> create a new shadow var for each:
 
-  iter myIter(param tag == standlone, x1_reduceParent:SumReduceScanOp) {
+  iter myIter(param tag == standalone, x1_reduceParent:SumReduceScanOp) {
     var x1_shadowVarReduc = x1_reduceParent.identity;
 
     forall ... with (x1_reduceParent reduce x1_shadowVarReduc) {

--- a/compiler/util/clangUtil.cpp
+++ b/compiler/util/clangUtil.cpp
@@ -1165,7 +1165,7 @@ void configurePMBuilder(PassManagerBuilder &PMBuilder, int optLevel=-1) {
     PMBuilder.Inliner = createFunctionInliningPass(optLevel,
                                                    opts.OptimizeSize
 #if HAVE_LLVM_VER >= 50
-                                                   , /*DisableInlineHotCalsite*/
+                                                   ,/*DisableInlineHotCallsite*/
                                                    false
 #endif
                                                   );

--- a/doc/rst/developer/bestPractices/ContributorInfo.rst
+++ b/doc/rst/developer/bestPractices/ContributorInfo.rst
@@ -741,7 +741,7 @@ rely on should be committed to the chapel repository:
     - Is there an alternate package with a more permissive license that can
       accomplish the same purpose?
 
-      - If so, we recommend relying on that package instead
+      - If so, we recommend relying on that package instead.
 
       - If not, it would be better to add directions on how to install this
         dependency.
@@ -757,9 +757,9 @@ rely on should be committed to the chapel repository:
   - The compiler for ordinary Chapel?  A commonly used runtime configuration?
 
     - In these cases, we will probably want to include the code in our
-      distribution
+      distribution.
 
-  - A standard or package module that is not include by default?
+  - A standard or package module that is not included by default?
 
     - Depending on the circumstances, it might be better to just include
       directions on how to install this code.

--- a/doc/rst/technotes/errorHandling.rst
+++ b/doc/rst/technotes/errorHandling.rst
@@ -292,7 +292,7 @@ Methods
 -------
 
 Errors can be thrown by methods, just as with any other function.
-An overriding method must throw if the overriden method throws,
+An overriding method must throw if the overridden method throws,
 or not throw if the overridden method does not throw.
 
 .. code-block:: chapel


### PR DESCRIPTION
Fix typos in ContributorInfo.rst, errorHandling.rst, implementForallIntents.cpp, and clangUtil.cpp.