### PR TITLE
Sparse layout fixes

### DIFF
--- a/modules/internal/DefaultSparse.chpl
+++ b/modules/internal/DefaultSparse.chpl
@@ -144,6 +144,9 @@ module DefaultSparse {
       // if the index already existed, then return
       if (found) then return 0;
 
+      if boundsChecking then
+        this.boundsCheck(ind);
+
       // increment number of nonzeroes
       nnz += 1;
 

--- a/test/arrays/sparse/OOBbaseDom.chpl
+++ b/test/arrays/sparse/OOBbaseDom.chpl
@@ -1,0 +1,21 @@
+use LayoutCS;
+
+config param useCS = false;
+
+const D = {1..10, 1..10};
+const D2 = D by 2;
+var SD: if useCS then sparse subdomain(D2) dmapped CS()
+                 else sparse subdomain(D2);
+
+SD += (1,1);
+SD += (5,3);
+
+var A: [SD] real;
+
+for ij in SD do
+  writeln("A[",ij,"] = ", A[ij]);
+
+SD += (0,0);
+
+for ij in SD do
+  writeln("A[",ij,"] = ", A[ij]);

--- a/test/arrays/sparse/OOBbaseDom.compopts
+++ b/test/arrays/sparse/OOBbaseDom.compopts
@@ -1,0 +1,2 @@
+-suseCS=false
+-suseCS=true

--- a/test/arrays/sparse/OOBbaseDom.good
+++ b/test/arrays/sparse/OOBbaseDom.good
@@ -1,0 +1,3 @@
+A[(1, 1)] = 0.0
+A[(5, 3)] = 0.0
+OOBbaseDom.chpl:18: error: halt reached - Sparse domain/array index out of bounds: (0, 0) (expected to be within {1..10 by 2, 1..10 by 2})

--- a/test/arrays/sparse/stridedBaseDom.chpl
+++ b/test/arrays/sparse/stridedBaseDom.chpl
@@ -1,0 +1,21 @@
+use LayoutCS;
+
+config param useCS = false;
+
+const D = {1..10, 1..10};
+const D2 = D by 2;
+var SD: if useCS then sparse subdomain(D2) dmapped CS()
+                 else sparse subdomain(D2);
+
+SD += (1,1);
+SD += (5,3);
+
+var A: [SD] real;
+
+for ij in SD do
+  writeln("A[",ij,"] = ", A[ij]);
+
+SD += (2,4);
+
+for ij in SD do
+  writeln("A[",ij,"] = ", A[ij]);

--- a/test/arrays/sparse/stridedBaseDom.compopts
+++ b/test/arrays/sparse/stridedBaseDom.compopts
@@ -1,0 +1,2 @@
+-suseCS=false
+-suseCS=true

--- a/test/arrays/sparse/stridedBaseDom.good
+++ b/test/arrays/sparse/stridedBaseDom.good
@@ -1,0 +1,3 @@
+A[(1, 1)] = 0.0
+A[(5, 3)] = 0.0
+stridedBaseDom.chpl:18: error: halt reached - Sparse domain/array index out of bounds: (2, 4) (expected to be within {1..10 by 2, 1..10 by 2})

--- a/test/domains/bradc/domEqualityPerf.chpl
+++ b/test/domains/bradc/domEqualityPerf.chpl
@@ -4,7 +4,7 @@ config var numTrials = 10,
            printTimings = false;
 
 
-const D = {1..10};
+const D = {1..50};
 var DS: sparse subdomain(D);
 var DA: domain(real);
 

--- a/test/domains/sungeun/sparse/index_not_in_domain_1.chpl
+++ b/test/domains/sungeun/sparse/index_not_in_domain_1.chpl
@@ -1,6 +1,6 @@
 config const n = 7;
 
-const D = {1..n*n};
+const D = {1..max(int)};
 
 var D1: sparse subdomain(D);
 D1 += max(int);

--- a/test/domains/sungeun/sparse/index_not_in_domain_2.chpl
+++ b/test/domains/sungeun/sparse/index_not_in_domain_2.chpl
@@ -1,6 +1,6 @@
 config const n = 7;
 
-const D = {1..n*n};
+const D = {1..max(int)};
 
 var D1: sparse subdomain(D);
 D1 += max(int);

--- a/test/domains/sungeun/sparse/plus_minus_equals.chpl
+++ b/test/domains/sungeun/sparse/plus_minus_equals.chpl
@@ -1,6 +1,6 @@
 config const n = 7;
 
-const D = {1..n*n};
+const D = {1..max(int)};
 
 var D1: sparse subdomain(D);
 D1 += max(int);


### PR DESCRIPTION
This fixes a few issues with sparse layouts:

* adds support for sparse parent domains to the CS layouts
* adds support for bounds checking indices as they're added to DefaultSparse domains

It also adds a pair of tests that ensure that things work as expected and updates a few tests whose parent domains' bounding boxes weren't big enough.  Removed one .notest file that didn't seem necessary.
