### PR TITLE
Add a .future about bounds checking for array.insert method.

### DIFF
--- a/test/arrays/diten/arrayInsertPastEnd.bad
+++ b/test/arrays/diten/arrayInsertPastEnd.bad
@@ -1,0 +1,1 @@
+arrayInsertPastEnd.chpl:4: error: halt reached - array slice out of bounds in dimension 1: 5..7

--- a/test/arrays/diten/arrayInsertPastEnd.chpl
+++ b/test/arrays/diten/arrayInsertPastEnd.chpl
@@ -1,0 +1,5 @@
+var A = [1,2,3];
+var B = [-1, -2, -3];
+
+A.insert(5, B);
+writeln(A);

--- a/test/arrays/diten/arrayInsertPastEnd.future
+++ b/test/arrays/diten/arrayInsertPastEnd.future
@@ -1,0 +1,3 @@
+bug: Bounds check in array.insert(a: []) misses out of bounds insert
+
+Issue #7575

--- a/test/arrays/diten/arrayInsertPastEnd.good
+++ b/test/arrays/diten/arrayInsertPastEnd.good
@@ -1,0 +1,1 @@
+arrayInsertPastEnd.chpl:4: error: halt reached - insert at position 5 out of bounds


### PR DESCRIPTION
The bounds checking for array.insert doesn't catch some out of bounds
inserts, though they are still caught by another method it uses.

Issue #7575.