### PR TITLE
Fix bounds checking in array.insert

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -2887,9 +2887,10 @@ module ChapelArray {
 
       const shift = vals.size,
             shiftRange = pos..this.domain.high,
-            newRange = this.domain.low..(this.domain.high + vals.size);
+            newRange = this.domain.low..(this.domain.high + vals.size),
+            validInsertRange = this.domain.low..(this.domain.high + 1);
 
-      if boundsChecking && !newRange.member(pos) then
+      if boundsChecking && !validInsertRange.member(pos) then
         halt("insert at position " + pos + " out of bounds");
 
       reallocateArray(newRange, debugMsg="insert reallocate");

--- a/test/arrays/diten/arrayInsertPastEnd.bad
+++ b/test/arrays/diten/arrayInsertPastEnd.bad
@@ -1,1 +1,0 @@
-arrayInsertPastEnd.chpl:4: error: halt reached - array slice out of bounds in dimension 1: 5..7

--- a/test/arrays/diten/arrayInsertPastEnd.future
+++ b/test/arrays/diten/arrayInsertPastEnd.future
@@ -1,3 +1,0 @@
-bug: Bounds check in array.insert(a: []) misses out of bounds insert
-
-Issue #7575


### PR DESCRIPTION
Bounds checking in array.insert was allowing the insert position to be
anywhere in the newly resized array, but the position should be somewhere in
the non-resized array (or 1 past the end).

Fixes issue #7575.