### PR TITLE
Switch from these(tag) to foralls for some standalone iters

### DIFF
--- a/modules/dists/SparseBlockDist.chpl
+++ b/modules/dists/SparseBlockDist.chpl
@@ -245,7 +245,7 @@ class SparseBlockDom: BaseSparseDomImpl {
   {
     coforall locDom in locDoms {
       on locDom {
-        for i in locDom.mySparseBlock._value.these(tag) {
+        forall i in locDom.mySparseBlock {
           yield i;
         }
       }
@@ -401,7 +401,7 @@ class SparseBlockArr: BaseSparseArr {
    {
     coforall locA in locArr do on locA {
       // forward to sparse standalone iterator
-      for i in locA.myElems._value.these(tag) {
+      forall i in locA.myElems {
         yield i;
       }
     }

--- a/modules/internal/ArrayViewRankChange.chpl
+++ b/modules/internal/ArrayViewRankChange.chpl
@@ -270,7 +270,7 @@ module ArrayViewRankChange {
       && chpl__isDROrDRView(downDom)
       && __primitive("method call resolves", upDom, "these", tag)
     {
-      for i in upDom.these(tag) do
+      forall i in upDom do
         yield i;
     }
 
@@ -279,7 +279,7 @@ module ArrayViewRankChange {
       && !chpl__isDROrDRView(downDom)
       && __primitive("method call resolves", downDom, "these", tag)
     {
-      for i in downDom.these(tag) do
+      forall i in downDom do
         yield downIdxToUpIdx(i);
     }
 
@@ -549,7 +549,7 @@ module ArrayViewRankChange {
     iter these(param tag: iterKind) ref
       where tag == iterKind.standalone && !localeModelHasSublocales &&
            __primitive("method call resolves", privDom, "these", tag) {
-      for i in privDom.these(tag) {
+      forall i in privDom {
         yield if shouldUseIndexCache()
                 then indexCache.getDataElem(indexCache.getDataIndex(i))
                 else arr.dsiAccess(chpl_rankChangeConvertIdx(i, collapsedDim, idx));

--- a/modules/internal/ArrayViewReindex.chpl
+++ b/modules/internal/ArrayViewReindex.chpl
@@ -242,7 +242,7 @@ module ArrayViewReindex {
       && chpl__isDROrDRView(downdom)
       && __primitive("method call resolves", updom, "these", tag)
     {
-      for i in updom.these(tag) do
+      forall i in updom do
           yield i;
     }
 
@@ -250,7 +250,7 @@ module ArrayViewReindex {
       && !chpl__isDROrDRView(downdom)
       && __primitive("method call resolves", downdom, "these", tag)
     {
-      for i in downdom.these(tag) do
+      forall i in downdom do
         yield downIdxToUpIdx(i);
     }
 
@@ -449,7 +449,7 @@ module ArrayViewReindex {
     iter these(param tag: iterKind) ref
       where tag == iterKind.standalone && !localeModelHasSublocales &&
            __primitive("method call resolves", privDom, "these", tag) {
-      for i in privDom.these(tag) {
+      forall i in privDom {
         if shouldUseIndexCache() {
           const dataIdx = indexCache.getDataIndex(i);
           yield indexCache.getDataElem(dataIdx);

--- a/modules/internal/ArrayViewSlice.chpl
+++ b/modules/internal/ArrayViewSlice.chpl
@@ -92,7 +92,7 @@ module ArrayViewSlice {
     iter these(param tag: iterKind) ref
       where tag == iterKind.standalone && !localeModelHasSublocales &&
            __primitive("method call resolves", privDom, "these", tag) {
-      for i in privDom.these(tag) do yield arr.dsiAccess(i);
+      forall i in privDom do yield arr.dsiAccess(i);
     }
 
     iter these(param tag: iterKind) where tag == iterKind.leader {


### PR DESCRIPTION
Back when we were working on the rank-change array view, we ran into some bugs with standalone iterators and reductions:

https://github.com/chapel-lang/chapel/pull/5694#issuecomment-287206496

We went with the workaround of invoking "foo.these(tag)" directly, and the bug was tracked in #5223. This bug was recently fixed, so we should now be able to use the more elegant ``forall`` approach.

The primitives that verify a resolvable standalone iterator exists have not been changed. Until we know more about how we want to express this pattern, I'm hesitant to remove those primitives.

Testing:
- [x] full local
- [x] full gasnet
- [x] full numa