### PR TITLE
Stop throwing --enable-allow-gcc4 for the GASNet build

### DIFF
--- a/third-party/gasnet/Makefile
+++ b/third-party/gasnet/Makefile
@@ -6,7 +6,7 @@ export CHPL_COMM=gasnet
 CHPL_MAKE_HOST_TARGET = --target
 include $(CHPL_MAKE_HOME)/make/Makefile.base
 
-CHPL_GASNET_CFG_OPTIONS += --enable-segment-$(CHPL_MAKE_COMM_SEGMENT) --enable-allow-gcc4
+CHPL_GASNET_CFG_OPTIONS += --enable-segment-$(CHPL_MAKE_COMM_SEGMENT)
 
 # pshm can only be used with CHPL_GASNET_SEGMENT={fast,large} and the
 # udp conduit, but there it lowers nightly testing time by 20% and the


### PR DESCRIPTION
`--enable-allow-gcc4` allows "the use of a broken gcc/g++ 4.0-4.2 compiler". It
doesn't actually do anything other than quiet a warning/error that gasnet will
throw if it detects you're using a broken compiler.

gcc 4.2 is almost 10 years old at this point, so I think we can stop throwing
it and just prefer that people upgrade gcc versions or quiet the warning
themselves.

This was originally added in e7f7577d40 in 2008, when gcc 4 was new.