### PR TITLE
Fix gasnet smp support

### DIFF
--- a/doc/rst/usingchapel/launcher.rst
+++ b/doc/rst/usingchapel/launcher.rst
@@ -57,6 +57,7 @@ pbs-aprun            Cray application launcher using PBS (qsub) + aprun
 pbs-gasnetrun_ibv    GASNet launcher using PBS (qsub) over Infiniband     
 slurm-gasnetrun_ibv  GASNet launcher using SLURM over Infiniband          
 slurm-srun           native SLURM launcher                                
+smp                  GASNet launcher for programs running over shared-memory
 none                 do not use a launcher                                
 ===================  ====================================================
 
@@ -85,6 +86,7 @@ follows:
   CHPL_COMM_SUBSTRATE=mpi  gasnetrun_mpi
   CHPL_COMM_SUBSTRATE=mxm  gasnetrun_ibv
   CHPL_COMM_SUBSTRATE=psm  gasnetrun_psm
+  CHPL_COMM_SUBSTRATE=smp  smp
   CHPL_COMM_SUBSTRATE=udp  amudprun
   otherwise                none
   =======================  ==============================================

--- a/doc/rst/usingchapel/multilocale.rst
+++ b/doc/rst/usingchapel/multilocale.rst
@@ -125,6 +125,8 @@ psm
     PSM for Intel's OmniPath fabric
 shmem
     SHMEM for SGI Altix
+smp
+    Simulates multiple locales on a single shared-memory machine
 
 See the `GASNet website <http://gasnet.lbl.gov/>`_ for more
 information on each of these conduits.

--- a/runtime/src/launch/smp/Makefile
+++ b/runtime/src/launch/smp/Makefile
@@ -1,0 +1,41 @@
+# Copyright 2004-2017 Cray Inc.
+# Other additional copyright holders may be indicated within.
+#
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+RUNTIME_ROOT = ../../..
+RUNTIME_SUBDIR = src/launch/smp
+
+ifndef CHPL_MAKE_HOME
+export CHPL_MAKE_HOME=$(shell pwd)/$(RUNTIME_ROOT)/..
+endif
+
+#
+# standard header
+#
+include $(RUNTIME_ROOT)/make/Makefile.runtime.head
+
+LAUNCH_OBJDIR = $(LAUNCHER_OBJDIR)
+include Makefile.share
+
+TARGETS = \
+	$(LAUNCHER_OBJS) \
+
+include $(RUNTIME_ROOT)/make/Makefile.runtime.subdirrules
+
+#
+# standard footer
+#
+include $(RUNTIME_ROOT)/make/Makefile.runtime.foot

--- a/runtime/src/launch/smp/Makefile.include
+++ b/runtime/src/launch/smp/Makefile.include
@@ -1,0 +1,24 @@
+# Copyright 2004-2017 Cray Inc.
+# Other additional copyright holders may be indicated within.
+#
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+LAUNCH_SUBDIR = src/launch/smp
+
+LAUNCH_OBJDIR = $(LAUNCHER_BUILD)/$(LAUNCH_SUBDIR)
+
+ALL_SRCS += $(CURDIR)/$(LAUNCH_SUBDIR)/*.c
+
+include $(RUNTIME_ROOT)/$(LAUNCH_SUBDIR)/Makefile.share

--- a/runtime/src/launch/smp/Makefile.share
+++ b/runtime/src/launch/smp/Makefile.share
@@ -1,0 +1,25 @@
+# Copyright 2004-2017 Cray Inc.
+# Other additional copyright holders may be indicated within.
+#
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+LAUNCHER_SRCS = \
+        launch-smp.c \
+
+SVN_SRCS = $(LAUNCHER_SRCS)
+SRCS = $(SVN_SRCS)
+
+LAUNCHER_OBJS = \
+	$(LAUNCHER_SRCS:%.c=$(LAUNCH_OBJDIR)/%.o)

--- a/runtime/src/launch/smp/launch-smp.c
+++ b/runtime/src/launch/smp/launch-smp.c
@@ -23,17 +23,19 @@
 #include "error.h"
 
 
+// Simple launcher that just sets GASNET_PSHM_NODES and launchers the _real
+
 int chpl_launch(int argc, char* argv[], int32_t numLocales) {
+  char numlocalesval[12]; // big enough for int32_t
   char baseCommand[4096];
 
-  char numlocalesval[11]; // big enough for int32_t
   snprintf(numlocalesval, sizeof(numlocalesval), "%d", (int)numLocales);
   if (setenv("GASNET_PSHM_NODES", numlocalesval, 1) != 0) {
     chpl_error("Cannot setenv(\"GASNET_PSHM_NODES\")", 0, 0);
   }
 
   chpl_compute_real_binary_name(argv[0]);
-  sprintf(baseCommand, "%s", chpl_get_real_binary_name());
+  snprintf(baseCommand, sizeof(baseCommand), "%s", chpl_get_real_binary_name());
 
   return chpl_launch_using_exec(baseCommand,
                                 chpl_bundle_exec_args(argc, argv, 0, NULL),

--- a/runtime/src/launch/smp/launch-smp.c
+++ b/runtime/src/launch/smp/launch-smp.c
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2004-2017 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include "chpllaunch.h"
+#include "chpl-mem.h"
+#include "error.h"
+
+
+static char* chpl_launch_create_command(int argc, char* argv[],
+                                        int32_t numLocales) {
+  int i;
+  int size;
+  char baseCommand[256];
+  char* command;
+
+  chpl_compute_real_binary_name(argv[0]);
+
+  sprintf(baseCommand, "%s", chpl_get_real_binary_name());
+
+  size = strlen(baseCommand) + 1;
+
+  for (i=1; i<argc; i++) {
+    size += strlen(argv[i]) + 3;
+  }
+
+  command = chpl_mem_allocMany(size, sizeof(char), CHPL_RT_MD_COMMAND_BUFFER, -1, 0);
+
+  sprintf(command, "%s", baseCommand);
+  for (i=1; i<argc; i++) {
+    strcat(command, " '");
+    strcat(command, argv[i]);
+    strcat(command, "'");
+  }
+
+  if (strlen(command)+1 > size) {
+    chpl_internal_error("buffer overflow");
+  }
+
+  return command;
+}
+
+
+int chpl_launch(int argc, char* argv[], int32_t numLocales) {
+  char numlocalesval[11]; // big enough for int32_t
+  snprintf(numlocalesval, sizeof(numlocalesval), "%d", (int)numLocales);
+  if (setenv("GASNET_PSHM_NODES", numlocalesval, 1) != 0) {
+    chpl_error("Cannot setenv(\"GASNET_PSHM_NODES\")", 0, 0);
+  }
+
+  return chpl_launch_using_system(chpl_launch_create_command(argc, argv, numLocales),
+                                  argv[0]);
+}
+
+
+int chpl_launch_handle_arg(int argc, char* argv[], int argNum,
+                           int32_t lineno, int32_t filename) {
+  return 0;
+}
+
+
+void chpl_launch_print_help(void) {
+}

--- a/test/multilocale/numLocales/bradc/testVFlag.launcher-smp.goodstart
+++ b/test/multilocale/numLocales/bradc/testVFlag.launcher-smp.goodstart
@@ -1,0 +1,1 @@
+./testVFlag_real  -v -nl 1 EXECOPTS

--- a/test/multilocale/numLocales/bradc/testVerboseFlag.launcher-smp.goodstart
+++ b/test/multilocale/numLocales/bradc/testVerboseFlag.launcher-smp.goodstart
@@ -1,0 +1,1 @@
+./testVerboseFlag_real  --verbose -nl 1 EXECOPTS

--- a/third-party/gasnet/Makefile
+++ b/third-party/gasnet/Makefile
@@ -6,14 +6,18 @@ export CHPL_COMM=gasnet
 CHPL_MAKE_HOST_TARGET = --target
 include $(CHPL_MAKE_HOME)/make/Makefile.base
 
+ifneq ($(CHPL_MAKE_COMM_SUBSTRATE),none)
 CHPL_GASNET_CFG_OPTIONS += --enable-segment-$(CHPL_MAKE_COMM_SEGMENT)
+endif
 
-# pshm can only be used with CHPL_GASNET_SEGMENT={fast,large} and the
-# udp conduit, but there it lowers nightly testing time by 20% and the
-# reduced overhead helps expose races.  Enable it for that case and
-# disable it in all others.
+# PSHM (inter-Process SHared Memory) provide a mechanism for gasnet instances
+# on the same node to communicate through shared memory instead of the real
+# conduit. In "production" we only run a single gasnet client per node so this
+# doesn't help, but for smp it's required, and we've noticed faster testing
+# times since we do local spawning, which will result in multiple gasnet
+# clients on the same node.
 SUB_SEG = $(CHPL_MAKE_COMM_SUBSTRATE)-$(CHPL_MAKE_COMM_SEGMENT)
-ifneq (,$(findstring $(SUB_SEG), udp-fast udp-large))
+ifneq (,$(findstring $(SUB_SEG), udp-fast udp-large, smp-none))
 CHPL_GASNET_CFG_OPTIONS += --enable-pshm
 else
 CHPL_GASNET_CFG_OPTIONS += --disable-pshm

--- a/util/chplenv/chpl_comm_segment.py
+++ b/util/chplenv/chpl_comm_segment.py
@@ -16,10 +16,12 @@ def get():
         segment_val = overrides.get('CHPL_GASNET_SEGMENT')
         if not segment_val:
             substrate_val = chpl_comm_substrate.get()
-            if substrate_val == 'portals' or substrate_val == 'gemini' or substrate_val == 'aries':
+            if substrate_val in ('portals', 'gemini', 'aries'):
                 segment_val = 'fast'
             elif substrate_val == 'ibv':
                 segment_val = 'large'
+            elif substrate_val == 'smp':
+                segment_val = 'none'
             else:
                 segment_val = 'everything'
     else:

--- a/util/chplenv/chpl_launcher.py
+++ b/util/chplenv/chpl_launcher.py
@@ -44,7 +44,9 @@ def get():
             launcher_val = 'marenostrum'
         elif comm_val == 'gasnet':
             substrate_val = chpl_comm_substrate.get()
-            if substrate_val == 'udp':
+            if substrate_val == 'smp':
+                launcher_val = 'smp'
+            elif substrate_val == 'udp':
                 launcher_val = 'amudprun'
             elif substrate_val == 'mpi':
                 launcher_val = 'gasnetrun_mpi'


### PR DESCRIPTION
Fix smp support for gasnet. SMP is a "fake" conduit that uses shared-memory to
imitate a network. This allows users to try out gasnet and multi-locale
programs on a single node. It's similar to using amudp with local spawning, but
it doesn't require sockets and is simpler to setup.

The main change was ensuring that we don't disable pshm support for smp since
it's required. We also don't want to set a segment since there is no segment
for smp. Lastly we needed to add a simple launcher which effectively just sets
GASNET_PSHM_NODES. It would have been cleaner to do this in the runtime, but
unfortunately we don't parse `--numLocales/-nl` until after comm init is done.

This fixes https://github.com/chapel-lang/chapel/issues/7569
