### PR TITLE
Add bug for forwarding a virtual method

### DIFF
--- a/test/classes/forwarding/forwardGenericVirtual.bad
+++ b/test/classes/forwarding/forwardGenericVirtual.bad
@@ -1,0 +1,4 @@
+forwardGenericVirtual.chpl:22: In function 'action':
+forwardGenericVirtual.chpl:24: warning: Rank mismatch between Rect(3) and Rect(1)
+forwardGenericVirtual.chpl:26: error: unresolved call 'Rect(1).inner(Rect(3))'
+forwardGenericVirtual.chpl:18: note: candidates are: Rect.inner(x)

--- a/test/classes/forwarding/forwardGenericVirtual.chpl
+++ b/test/classes/forwarding/forwardGenericVirtual.chpl
@@ -1,0 +1,35 @@
+
+class Base {
+  // Removing this somehow avoids the bug...
+  proc action(a) {
+    halt("Should not see this!");
+  }
+}
+
+class View : Base {
+  var arr;
+
+  forwarding arr;
+}
+
+class Rect : Base {
+  param rank : int;
+
+  proc inner(x) where x.rank == this.rank {
+    writeln("Inner called on ", this.type:string, " with ", x.type:string);
+  }
+
+  proc action(a) {
+    if a.rank != this.rank {
+      compilerWarning("Rank mismatch between ", a.type:string, " and ", this.type:string);
+    }
+    inner(a);
+  }
+}
+
+var one = new Rect(1);
+var three = new Rect(3);
+var v = new View(three);
+
+one.action(one);
+v.action(three);

--- a/test/classes/forwarding/forwardGenericVirtual.future
+++ b/test/classes/forwarding/forwardGenericVirtual.future
@@ -1,0 +1,4 @@
+bug: forwarding generic virtual method causes resolution errors
+
+The 'action' method on 'Rect' should only be called with rank-compatible Rects,
+yet we try to call Rect(1).action(Rect(3)). Why?

--- a/test/classes/forwarding/forwardGenericVirtual.future
+++ b/test/classes/forwarding/forwardGenericVirtual.future
@@ -2,3 +2,11 @@ bug: forwarding generic virtual method causes resolution errors
 
 The 'action' method on 'Rect' should only be called with rank-compatible Rects,
 yet we try to call Rect(1).action(Rect(3)). Why?
+
+I ran into this bug while working on array forwarding. The 'doiBulkTransfer'
+method in BaseArr was causing bizarre resolution errors in the following test:
+
+test/optimizations/sungeun/bulk_transfer/assign.chpl
+
+Somehow the compiler was attempting to call doiBulkTransfer between a 1D
+DefaultRectangular array of locales and a 3D DR array of reals.

--- a/test/classes/forwarding/forwardGenericVirtual.good
+++ b/test/classes/forwarding/forwardGenericVirtual.good
@@ -1,0 +1,2 @@
+Inner called on Rect(1) with Rect(1)
+Inner called on Rect(3) with Rect(3)


### PR DESCRIPTION
I ran into this bug while working on array forwarding. The 'doiBulkTransfer'
method in BaseArr was causing bizarre resolution errors in the following test:

test/optimizations/sungeun/bulk_transfer/assign.chpl

Somehow the compiler was attempting to call doiBulkTransfer between a 1D
DefaultRectangular array of locales and a 3D DR array of reals.