### PR TITLE
"make check" should printchplenv w debug output

### DIFF
--- a/util/test/checkChplInstall
+++ b/util/test/checkChplInstall
@@ -148,6 +148,11 @@ fi
 
 TEST_JOB=${TEST_JOB_BASENAME}
 
+if [ "${CHPL_CHECK_DEBUG}" == 1 ] ; then
+    log_debug "printchplenv, because \$CHPL_CHECK_DEBUG == 1"
+    $CHPL_HOME/util/printchplenv
+fi
+
 # Collect comm protocol environment variables (lowercase to avoid conflicts)
 chpl_comm="$($CHPL_HOME/util/chplenv/chpl_comm.py)"
 chpl_launcher="$($CHPL_HOME/util/chplenv/chpl_launcher.py)"


### PR DESCRIPTION
Export CHPL_CHECK_DEBUG=1 to see printchplenv immediately before test compile and execution.
This should help "make check" failures a little easier to diagnose. 
