### PR TITLE
Skip arrayInsertPastEnd under --fast

### DIFF
--- a/test/arrays/diten/arrayInsertPastEnd.skipif
+++ b/test/arrays/diten/arrayInsertPastEnd.skipif
@@ -1,0 +1,1 @@
+COMPOPTS <= --fast


### PR DESCRIPTION
This test relies on bounds checking, so skip under --fast