### PR TITLE
These tests rely on bounds checking, so skip under --fast

### DIFF
--- a/test/arrays/sparse/OOBbaseDom.skipif
+++ b/test/arrays/sparse/OOBbaseDom.skipif
@@ -1,0 +1,1 @@
+COMPOPTS <= --fast

--- a/test/arrays/sparse/stridedBaseDom.skipif
+++ b/test/arrays/sparse/stridedBaseDom.skipif
@@ -1,0 +1,1 @@
+COMPOPTS <= --fast


### PR DESCRIPTION
These tests rely on bounds checking.  Add .skipif for --fast
