### PR TITLE
Updated "make install" with mason support

### DIFF
--- a/util/buildRelease/install.sh
+++ b/util/buildRelease/install.sh
@@ -317,6 +317,19 @@ done
 # copy utf8-decoder header
 myinstallfile third-party/utf8-decoder/utf8-decoder.h "$DEST_THIRD_PARTY"/utf8-decoder/
 
+# copy mason
+if [ -f tools/mason/mason ]
+then
+  if [ ! -z "$PREFIX" ]
+  then
+    myinstallfile tools/mason/mason "$PREFIX/share/chapel/$VERS/tools/mason"
+    ln -s "$PREFIX/share/chapel/$VERS/tools/mason/mason" "$PREFIX/bin/mason"
+  else
+    myinstallfile tools/mason/mason "$DEST_CHPL_HOME/tools/mason"
+    ln -s "$DEST_CHPL_HOME/tools/mason/mason" "$DEST_DIR/bin/$CHPL_HOST_PLATFORM"/mason
+  fi
+fi
+
 # copy chplconfig
 if [ -f chplconfig ]
 then

--- a/util/buildRelease/install.sh
+++ b/util/buildRelease/install.sh
@@ -322,8 +322,7 @@ if [ -f tools/mason/mason ]
 then
   if [ ! -z "$PREFIX" ]
   then
-    myinstallfile tools/mason/mason "$PREFIX/share/chapel/$VERS/tools/mason"
-    ln -s "$PREFIX/share/chapel/$VERS/tools/mason/mason" "$PREFIX/bin/mason"
+    myinstallfile tools/mason/mason "$PREFIX/bin"
   else
     myinstallfile tools/mason/mason "$DEST_CHPL_HOME/tools/mason"
     ln -s "$DEST_CHPL_HOME/tools/mason/mason" "$DEST_DIR/bin/$CHPL_HOST_PLATFORM"/mason


### PR DESCRIPTION
This PR solves one of the points of issue #7574, adding support to make install for mason.

I've only made mason to be sure that I wasn't missing anything in how the script/make install works on chapel. After this is considered OK I will expand it (or makes new PRs) to cover the entire issue.