### PR TITLE
Silence GCC bug exposed by --baseline -O

### DIFF
--- a/test/studies/sudoku/dinan/sudoku-simpler.compopts
+++ b/test/studies/sudoku/dinan/sudoku-simpler.compopts
@@ -1,0 +1,1 @@
+--ccflags -O2


### PR DESCRIPTION
This test began to fail after an unrelated PR (#7578) was merged. We
observed that GCC was generating an unaligned vector instruction in
deeply-nested inlined functions. Since chapel inlines many functions by
default under normal conditions (disabled by baseline), we think it's
unlikely that we would encounter this behavior in normal testing.

Throwing -O defaults to O3 under gcc, and this test will pass under baseline
with O2 enabled.