### PR TITLE
Default to segment fast for gasnet's smp conduit

### DIFF
--- a/third-party/gasnet/Makefile
+++ b/third-party/gasnet/Makefile
@@ -15,9 +15,9 @@ endif
 # conduit. In "production" we only run a single gasnet client per node so this
 # doesn't help, but for smp it's required, and we've noticed faster testing
 # times since we do local spawning, which will result in multiple gasnet
-# clients on the same node.
+# clients on the same node. Note that pshm only works with segment fast/large.
 SUB_SEG = $(CHPL_MAKE_COMM_SUBSTRATE)-$(CHPL_MAKE_COMM_SEGMENT)
-ifneq (,$(findstring $(SUB_SEG), udp-fast udp-large, smp-none))
+ifneq (,$(findstring $(SUB_SEG), udp-fast udp-large smp-fast smp-large))
 CHPL_GASNET_CFG_OPTIONS += --enable-pshm
 else
 CHPL_GASNET_CFG_OPTIONS += --disable-pshm

--- a/util/chplenv/chpl_comm_segment.py
+++ b/util/chplenv/chpl_comm_segment.py
@@ -16,12 +16,10 @@ def get():
         segment_val = overrides.get('CHPL_GASNET_SEGMENT')
         if not segment_val:
             substrate_val = chpl_comm_substrate.get()
-            if substrate_val in ('portals', 'gemini', 'aries'):
+            if substrate_val in ('portals', 'gemini', 'aries', 'smp'):
                 segment_val = 'fast'
             elif substrate_val == 'ibv':
                 segment_val = 'large'
-            elif substrate_val == 'smp':
-                segment_val = 'none'
             else:
                 segment_val = 'everything'
     else:


### PR DESCRIPTION
I had been mistakenly thinking you couldn't set a segment for gasnet, but it
turns out that you just can't use segment-everything with pshm. Gasnet defaults
to segment-fast, so that's what we were getting by not enabling a specific
segment.

Default to segment-fast to reflect this understanding. See Dan's explanation in
https://github.com/chapel-lang/chapel/commit/57726dc84c#commitcomment-24973648