### PR TITLE
Add smp to the list of compatible launchers for `make check`

### DIFF
--- a/util/test/checkChplInstall
+++ b/util/test/checkChplInstall
@@ -189,7 +189,7 @@ else
 fi
 
 # Check for valid launchers
-if [ ${chpl_launcher} == "slurm-srun" -o ${chpl_launcher} == "amudprun" -o ${chpl_launcher} == "none" ]; then
+if [ ${chpl_launcher} == "slurm-srun" -o ${chpl_launcher} == "amudprun" -o ${chpl_launcher} == "smp" -o ${chpl_launcher} == "none" ]; then
     log_info "\$CHPL_LAUNCHER=${chpl_launcher} is compatible with test script."
 else
     log_warning "\$CHPL_LAUNCHER=${chpl_launcher} is not compatible with test script."


### PR DESCRIPTION
Not all launchers are compatible with `make check` so we have to explicitly
list the supported ones. CHPL_LAUNCHER=smp works, so add it to the approved
list.