### PR TITLE
Forward array method calls

### DIFF
--- a/modules/dists/StencilDist.chpl
+++ b/modules/dists/StencilDist.chpl
@@ -1387,12 +1387,7 @@ iter StencilArr.dsiBoundaries(param tag : iterKind) where tag == iterKind.standa
 // array
 //
 pragma "no copy return"
-proc _array.noFluffView() {
-  var a = _value.dsiNoFluffView();
-  return _newArray(a);
-}
-
-proc StencilArr.dsiNoFluffView() {
+proc StencilArr.noFluffView() {
   var tempDist = new Stencil(dom.dist.boundingBox, dom.dist.targetLocales,
                              dom.dist.dataParTasksPerLocale, dom.dist.dataParIgnoreRunningTasks,
                              dom.dist.dataParMinGranularity, ignoreFluff=true);
@@ -1408,12 +1403,7 @@ proc StencilArr.dsiNoFluffView() {
   alias.myLocArr = this.myLocArr;
 
   newDom.add_arr(alias, locking=false);
-  return alias;
-}
-
-// wrapper
-proc _array.updateFluff() {
-  _value.dsiUpdateFluff();
+  return _newArray(alias);
 }
 
 //
@@ -1559,7 +1549,7 @@ proc StencilArr.shouldDoPackedUpdate() param : bool {
 // approach. What we really want is to do a naive transfer if the periodic
 // neighbor is the current locale.
 //
-proc StencilArr.dsiUpdateFluff() {
+proc StencilArr.updateFluff() {
   if isZeroTuple(dom.fluff) then return;
 
   if shouldDoPackedUpdate() && dom.dist.targetLocales.size > 1 {

--- a/modules/internal/ArrayViewRankChange.chpl
+++ b/modules/internal/ArrayViewRankChange.chpl
@@ -117,7 +117,7 @@ module ArrayViewRankChange {
   //
  class ArrayViewRankChangeDom: BaseRectangularDom {
     // the lower-dimensional index set that we represent upwards
-    var upDom: DefaultRectangularDom(rank, idxType, stridable);
+    forwarding var upDom: DefaultRectangularDom(rank, idxType, stridable);
 
     // the collapsed dimensions and indices in those dimensions
     //
@@ -175,57 +175,6 @@ module ArrayViewRankChange {
                                         ownsArrInstance=true);
     }
 
-    // TODO: Use delegation feature for these?
-    // TODO: Can't all these be implemented in ChapelArray given dsiDim()?
-
-    proc dsiNumIndices {
-      return upDom.dsiNumIndices;
-    }
-
-    proc dsiLow {
-      return upDom.dsiLow;
-    }
-
-    proc dsiHigh {
-      return upDom.dsiHigh;
-    }
-
-    proc dsiAlignedLow {
-      return upDom.dsiAlignedLow;
-    }
-
-    proc dsiAlignedHigh {
-      return upDom.dsiAlignedHigh;
-    }
-
-    proc dsiStride {
-      return upDom.dsiStride;
-    }
-
-    proc dsiAlignment {
-      return upDom.dsiAlignment;
-    }
-
-    proc dsiFirst {
-      return upDom.dsiFirst;
-    }
-
-    proc dsiLast {
-      return upDom.dsiLast;
-    }
-
-    proc dsiDim(upDim: int) {
-      return upDom.dsiDim(upDim);
-    }
-
-    proc dsiDims() {
-      return upDom.dsiDims();
-    }
-
-    proc dsiGetIndices() {
-      return upDom.dsiGetIndices();
-    }
-
     proc dsiSetIndices(inds) {
       // Free underlying domains if necessary
       this.dsiDestroyDom();
@@ -249,10 +198,6 @@ module ArrayViewRankChange {
 
     proc dsiAssignDomain(rhs: domain, lhsPrivate: bool) {
       chpl_assignDomainWithGetSetIndices(this, rhs);
-    }
-
-    proc dsiMember(i) {
-      return upDom.dsiMember(i);
     }
 
     iter these() {
@@ -496,6 +441,9 @@ module ArrayViewRankChange {
 
     const ownsArrInstance = false;
 
+    // Forward all unhandled methods to underlying privatized array
+    forwarding arr;
+
 
     //
     // standard generic aspects of arrays
@@ -673,28 +621,11 @@ module ArrayViewRankChange {
     // locality-oriented queries
     //
 
-    proc dsiTargetLocales() {
-      //
-      // See commentary on ArrayViewRankChangeDom.dsiTargetLocales() above.
-      //
-      return arr.dsiTargetLocales();
-    }
-
     proc dsiHasSingleLocalSubdomain() param
       return privDom.dsiHasSingleLocalSubdomain();
 
     proc dsiLocalSubdomain() {
       return privDom.dsiLocalSubdomain();
-    }
-
-    proc dsiNoFluffView() {
-      // For now avoid implementing 'noFluffView' on each class and use
-      // 'canResolve' to print a better error message.
-      if canResolveMethod(arr, "dsiNoFluffView") {
-        return arr.dsiNoFluffView();
-      } else {
-        compilerError("noFluffView is not supported on this array type.");
-      }
     }
 
     //
@@ -724,7 +655,9 @@ module ArrayViewRankChange {
     //
     // bulk-transfer
     //
-
+    // If these methods were nonexistant, calls to these methods would use
+    // BaseArr's implementation instead of arr's.
+    //
     proc dsiSupportsBulkTransfer() param {
       return arr.dsiSupportsBulkTransfer();
     }
@@ -753,46 +686,6 @@ module ArrayViewRankChange {
     proc _getViewDom() {
       return _viewHelper(dom.dsiDims());
     }
-
-    // contiguous transfer support
-    proc doiUseBulkTransfer(B) {
-      return arr.doiUseBulkTransfer(B);
-    }
-
-    proc doiCanBulkTransfer(viewDom) {
-      return arr.doiCanBulkTransfer(viewDom);
-    }
-
-    proc doiBulkTransfer(B, viewDom) {
-      arr.doiBulkTransfer(B, viewDom);
-    }
-
-    // strided transfer support
-    proc doiUseBulkTransferStride(B) {
-      return arr.doiUseBulkTransferStride(B);
-    }
-
-    proc doiCanBulkTransferStride(viewDom) {
-      return arr.doiCanBulkTransferStride(viewDom);
-    }
-
-    proc doiBulkTransferStride(B, viewDom) {
-      arr.doiBulkTransferStride(B, viewDom);
-    }
-
-    // distributed transfer support
-    proc doiBulkTransferToDR(B, viewDom) {
-      arr.doiBulkTransferToDR(B, viewDom);
-    }
-
-    proc doiBulkTransferFromDR(B, viewDom) {
-      arr.doiBulkTransferFromDR(B, viewDom);
-    }
-
-    proc doiBulkTransferFrom(B, viewDom) {
-      arr.doiBulkTransferFrom(B, viewDom);
-    }
-
 
     //
     // utility functions used to set up the index cache

--- a/modules/internal/ArrayViewRankChange.chpl
+++ b/modules/internal/ArrayViewRankChange.chpl
@@ -117,7 +117,8 @@ module ArrayViewRankChange {
   //
  class ArrayViewRankChangeDom: BaseRectangularDom {
     // the lower-dimensional index set that we represent upwards
-    forwarding var upDom: DefaultRectangularDom(rank, idxType, stridable);
+    var upDom: DefaultRectangularDom(rank, idxType, stridable);
+    forwarding upDom except these;
 
     // the collapsed dimensions and indices in those dimensions
     //
@@ -442,7 +443,7 @@ module ArrayViewRankChange {
     const ownsArrInstance = false;
 
     // Forward all unhandled methods to underlying privatized array
-    forwarding arr;
+    forwarding arr except these;
 
 
     //
@@ -661,9 +662,10 @@ module ArrayViewRankChange {
     proc dsiSupportsBulkTransfer() param {
       return arr.dsiSupportsBulkTransfer();
     }
-
     proc dsiSupportsBulkTransferInterface() param
       return arr.dsiSupportsBulkTransferInterface();
+    proc doiCanBulkTransfer() param return arr.doiCanBulkTransfer();
+    proc doiCanBulkTransferStride(viewDom) param return arr.doiCanBulkTransferStride(viewDom);
 
     // Recursively builds up the view-domain given an initial tuple of
     // dimensions. Handles nested rank-changes.

--- a/modules/internal/ArrayViewRankChange.chpl
+++ b/modules/internal/ArrayViewRankChange.chpl
@@ -656,7 +656,7 @@ module ArrayViewRankChange {
     //
     // bulk-transfer
     //
-    // If these methods were nonexistant, calls to these methods would use
+    // If these methods were nonexistent, calls to these methods would use
     // BaseArr's implementation instead of arr's.
     //
     proc dsiSupportsBulkTransfer() param {

--- a/modules/internal/ArrayViewReindex.chpl
+++ b/modules/internal/ArrayViewReindex.chpl
@@ -99,7 +99,8 @@ module ArrayViewReindex {
   //
  class ArrayViewReindexDom: BaseRectangularDom {
     // the new reindexed index set that we represent upwards
-    forwarding var updom: DefaultRectangularDom(rank, idxType, stridable);
+    var updom: DefaultRectangularDom(rank, idxType, stridable);
+    forwarding updom except these;
 
     // the old original index set that we're equivalent to
     var downdomPid;
@@ -338,7 +339,7 @@ module ArrayViewReindex {
 
     const ownsArrInstance = false;
 
-    forwarding arr;
+    forwarding arr except these;
 
     proc downdom {
       // TODO: This routine may get a remote domain if this is a view
@@ -557,6 +558,8 @@ module ArrayViewReindex {
     proc dsiSupportsBulkTransferInterface() param {
       return arr.dsiSupportsBulkTransferInterface();
     }
+    proc doiCanBulkTransfer() param return arr.doiCanBulkTransfer();
+    proc doiCanBulkTransferStride(viewDom) param return arr.doiCanBulkTransferStride(viewDom);
 
     proc _viewHelper(dims) {
       if dims.size != dom.rank {

--- a/modules/internal/ArrayViewReindex.chpl
+++ b/modules/internal/ArrayViewReindex.chpl
@@ -549,7 +549,7 @@ module ArrayViewReindex {
     // bulk-transfer
     //
     //
-    // If these methods were nonexistant, calls to these methods would use
+    // If these methods were nonexistent, calls to these methods would use
     // BaseArr's implementation instead of arr's.
     //
     proc dsiSupportsBulkTransfer() param {

--- a/modules/internal/ArrayViewSlice.chpl
+++ b/modules/internal/ArrayViewSlice.chpl
@@ -228,7 +228,7 @@ module ArrayViewSlice {
     //
     // bulk-transfer
     //
-    // If these methods were nonexistant, calls to these methods would use
+    // If these methods were nonexistent, calls to these methods would use
     // BaseArr's implementation instead of arr's.
     //
     proc dsiSupportsBulkTransfer() param {

--- a/modules/internal/ArrayViewSlice.chpl
+++ b/modules/internal/ArrayViewSlice.chpl
@@ -49,7 +49,7 @@ module ArrayViewSlice {
     // through the array field above.
     const indexCache = buildIndexCache();
 
-    forwarding arr;
+    forwarding arr except these;
 
 
     //
@@ -234,9 +234,10 @@ module ArrayViewSlice {
     proc dsiSupportsBulkTransfer() param {
       return arr.dsiSupportsBulkTransfer();
     }
-
     proc dsiSupportsBulkTransferInterface() param
       return arr.dsiSupportsBulkTransferInterface();
+    proc doiCanBulkTransfer() param return arr.doiCanBulkTransfer();
+    proc doiCanBulkTransferStride(viewDom) param return arr.doiCanBulkTransferStride(viewDom);
 
     proc _viewHelper(dims) {
       compilerError("viewHelper not supported on ArrayViewSlice.");

--- a/modules/internal/ArrayViewSlice.chpl
+++ b/modules/internal/ArrayViewSlice.chpl
@@ -49,6 +49,8 @@ module ArrayViewSlice {
     // through the array field above.
     const indexCache = buildIndexCache();
 
+    forwarding arr;
+
 
     //
     // standard generic aspects of arrays
@@ -182,17 +184,6 @@ module ArrayViewSlice {
       }
     }
 
-    inline proc dsiLocalAccess(i) ref
-      return arr.dsiLocalAccess(i);
-
-    inline proc dsiLocalAccess(i)
-      where shouldReturnRvalueByValue(eltType)
-      return arr.dsiLocalAccess(i);
-
-    inline proc dsiLocalAccess(i) const ref
-      where shouldReturnRvalueByConstRef(eltType)
-      return arr.dsiLocalAccess(i);
-
     inline proc checkBounds(i) {
       if boundsChecking then
         if !privDom.dsiMember(i) then
@@ -204,25 +195,11 @@ module ArrayViewSlice {
     // locality-oriented queries
     //
 
-    proc dsiTargetLocales() {
-      return arr.dsiTargetLocales();
-    }
-
     proc dsiHasSingleLocalSubdomain() param
       return privDom.dsiHasSingleLocalSubdomain();
 
     proc dsiLocalSubdomain() {
       return privDom.dsiLocalSubdomain();
-    }
-
-    proc dsiNoFluffView() {
-      // For now avoid implementing 'noFluffView' on each class and use
-      // 'canResolve' to print a better error message.
-      if canResolveMethod(arr, "dsiNoFluffView") {
-        return arr.dsiNoFluffView();
-      } else {
-        compilerError("noFluffView is not supported on this array type.");
-      }
     }
 
 
@@ -251,7 +228,9 @@ module ArrayViewSlice {
     //
     // bulk-transfer
     //
-
+    // If these methods were nonexistant, calls to these methods would use
+    // BaseArr's implementation instead of arr's.
+    //
     proc dsiSupportsBulkTransfer() param {
       return arr.dsiSupportsBulkTransfer();
     }
@@ -273,46 +252,6 @@ module ArrayViewSlice {
         return {(...dom.dsiDims())};
       }
     }
-
-    // contiguous transfer support
-    proc doiUseBulkTransfer(B) {
-      return arr.doiUseBulkTransfer(B);
-    }
-
-    proc doiCanBulkTransfer(viewDom) {
-      return arr.doiCanBulkTransfer(viewDom);
-    }
-
-    proc doiBulkTransfer(B, viewDom) {
-      arr.doiBulkTransfer(B, viewDom);
-    }
-
-    // strided transfer support
-    proc doiUseBulkTransferStride(B) {
-      return arr.doiUseBulkTransferStride(B);
-    }
-
-    proc doiCanBulkTransferStride(viewDom) {
-      return arr.doiCanBulkTransferStride(viewDom);
-    }
-
-    proc doiBulkTransferStride(B, viewDom) {
-      arr.doiBulkTransferStride(B, viewDom);
-    }
-
-    // distributed transfer support
-    proc doiBulkTransferToDR(B, viewDom) {
-      arr.doiBulkTransferToDR(B, viewDom);
-    }
-
-    proc doiBulkTransferFromDR(B, viewDom) {
-      arr.doiBulkTransferFromDR(B, viewDom);
-    }
-
-    proc doiBulkTransferFrom(B, viewDom) {
-      arr.doiBulkTransferFrom(B, viewDom);
-    }
-
 
     //
     // utility functions used to set up the index cache

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -2030,6 +2030,8 @@ module ChapelArray {
       }
     }
 
+    forwarding _value;
+
     inline proc _do_destroy() {
       if ! _unowned {
         on _instance {

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -2030,7 +2030,7 @@ module ChapelArray {
       }
     }
 
-    forwarding _value;
+    forwarding _value except these;
 
     inline proc _do_destroy() {
       if ! _unowned {

--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -750,9 +750,6 @@ module ChapelDistribution {
 
     proc dsiSupportsBulkTransfer() param return false;
     proc doiCanBulkTransfer() param return false;
-    proc doiBulkTransfer(B, viewDom) {
-      halt("This array type does not support bulk transfer.");
-    }
 
     proc dsiDisplayRepresentation() { writeln("<no way to display representation>"); }
     proc isDefaultRectangular() param return false;


### PR DESCRIPTION
This PR allows domain map authors to more easily implement custom methods for their array types. Prior to this PR, they would have to implement a secondary method on the ``_array`` type in order to forward the call to the actual method.

This PR applies ``forwarding`` to the ``_value`` field of the ``_array`` record, and to the downward-pointing fields in array views. As a result, we could eliminate many dsi* routines from the array view implementations and more elegantly implement StencilDist's ``noFluffView`` and ``updateFluff`` methods.

Testing:
- [x] linux64
- [x] gasnet
- [x] numa
- [x] valgrind
- [x] baseline