### PR TITLE
Delete stmt

### DIFF
--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1263,16 +1263,20 @@ module ChapelBase {
 
   // implements 'delete' statement
   inline proc chpl__delete(arg)
-    where isClassType(arg.type) || isExternClassType(arg.type)
-  {
+    where isClassType(arg.type) || isExternClassType(arg.type) {
+
     if chpl_isDdata(arg.type) then
       compilerError("cannot delete data class");
+
     if arg.type == _nilType then
       compilerError("should not delete 'nil'");
 
-    arg.deinit();
-    on arg do
-      chpl_here_free(__primitive("_wide_get_addr", arg));
+    if (arg != nil) {
+      arg.deinit();
+
+      on arg do
+        chpl_here_free(__primitive("_wide_get_addr", arg));
+    }
   }
 
   proc chpl__delete(arr: []) {

--- a/spec/Classes.tex
+++ b/spec/Classes.tex
@@ -809,11 +809,10 @@ var c : C = nil;
 delete c;        // Does nothing: c is nil.
 
 c = new C();     // Creates a new object.
-delete c;        // Deletes that object: Writes out "Bye, bye." 
+delete c;        // Deletes that object: Writes out "Bye, bye."
                  // and reclaims the memory that was held by c.
 \end{chapel}
 \begin{chapeloutput}
-Bye, bye.
 Bye, bye.
 \end{chapeloutput}
 \end{chapelexample}

--- a/test/classes/constructors/nested-destructor.bad
+++ b/test/classes/constructors/nested-destructor.bad
@@ -2,5 +2,3 @@ in R()
 in ~R
 in ~C
 in ~R
-in ~C
-nested-destructor.chpl:3: error: attempt to dereference nil

--- a/test/classes/constructors/nested-destructor.future
+++ b/test/classes/constructors/nested-destructor.future
@@ -1,7 +1,12 @@
-bug: multiple destructor calls for nested class in record
+bug: A nested class captures outer record by value rather than ref
 
-When defining a class within a record to use as one of its fields, we have a
-bug where the destructor for the record is getting executed multiple times when
-the record leaves scope.  This doesn't occur when the class is declared outside
-the record, or when the record is made into a class and the destructor is called
-manually.
+When defining a class within a record, the class should have
+a reference to the enclosing record so that it can access
+the outer fields.
+
+There is a bug in the compiler that causes instances of
+the class to get a copy of the outer record at the time
+the class is constructed.
+
+In this test we can see two uses of R.deinit(); one for
+the R defined in doit() and the other for the copy.

--- a/test/classes/deleting/deinitOnNil.bad
+++ b/test/classes/deleting/deinitOnNil.bad
@@ -1,1 +1,0 @@
-In C's deinit()

--- a/test/classes/deleting/deinitOnNil.future
+++ b/test/classes/deleting/deinitOnNil.future
@@ -1,5 +1,0 @@
-bug: deinit() called on nil class references
-
-This test shows that we're currently calling deinit() on nil class
-references even though the spec says we don't (and its example shows
-that we do... :(

--- a/test/classes/deleting/deleteArrays.chpl
+++ b/test/classes/deleting/deleteArrays.chpl
@@ -12,7 +12,7 @@ class C {
 writeln("---");
 {
   var A: [1..3] C;
-  
+
   delete A;
 }
 writeln("---");

--- a/test/classes/deleting/deleteArrays.good
+++ b/test/classes/deleting/deleteArrays.good
@@ -2,9 +2,6 @@ Deleting a C
 Deleting a C
 Deleting a C
 ---
-Deleting a C
-Deleting a C
-Deleting a C
 ---
 Deleting a C
 Deleting a C

--- a/test/classes/initializers/nested-destructor.bad
+++ b/test/classes/initializers/nested-destructor.bad
@@ -1,0 +1,14 @@
+doit entered
+  in init of R
+    in init of C 1
+
+  (id = 1, c = {})
+
+  (id = 2, c = {})
+
+doit exiting
+  entered deinit of R 2
+    in deinit of C 1
+      entered deinit of R 1
+      exiting deinit of R 1
+  exiting deinit of R 2

--- a/test/classes/initializers/nested-destructor.chpl
+++ b/test/classes/initializers/nested-destructor.chpl
@@ -4,35 +4,72 @@ record R
 {
   class C
   {
+    proc init()
+    {
+      writeln("    in init of C ", outer.id);
+    }
+
     proc deinit()
     {
-      writeln("in deinit of C");
+      writeln("    in deinit of C ", outer.id);
     }
   }
-  var c : C;
+
+  var id : int;
+  var c  : C;
 
   proc init()
   {
-    writeln("in init of R");
-    c = new C();
+    writeln("  in init of R");
+
+    id = 1;
+    c  = new C();
   }
 
-  proc init(other:R) {
-    // TODO: maybe have way to allow the user to use a compiler generated copy
-    // initializer?
-    this.c = other.c;
+  proc init(other:R)
+  {
+    writeln("  in copy initializer of R ", other.id);
+
+    // TODO: maybe have way to allow the user to use
+    // a compiler generated copy initializer?
+    this.id = other.id + 1;
+    this.c  = other.c;
+
     super.init();
   }
 
   proc deinit()
   {
-    writeln("in deinit of R");
+    if id == 2 then
+      writeln("  entered deinit of R ", id);
+    else
+      writeln("      entered deinit of R ", id);
+
     delete c;
+
+    if id == 2 then
+      writeln("  exiting deinit of R ", id);
+    else
+      writeln("      exiting deinit of R ", id);
   }
 }
 
-proc doit() {
-  var x: R;
+proc doit()
+{
+  writeln("doit entered");
+
+  var x : R;
+
+  writeln();
+  writeln("  ", x);
+
+  x.id = 2;
+
+  writeln();
+  writeln("  ", x);
+
+  writeln();
+  writeln("doit exiting");
 }
 
 doit();

--- a/test/classes/initializers/nested-destructor.future
+++ b/test/classes/initializers/nested-destructor.future
@@ -1,7 +1,12 @@
-bug: multiple destructor calls for nested class in record
+bug: A nested class captures outer record by value rather than ref
 
-When defining a class within a record to use as one of its fields, we have a
-bug where the destructor for the record is getting executed multiple times when
-the record leaves scope.  This doesn't occur when the class is declared outside
-the record, or when the record is made into a class and the destructor is called
-manually.
+When defining a class within a record, the class should have
+a reference to the enclosing record so that it can access
+the outer fields.
+
+There is a bug in the compiler that causes instances of
+the class to get a copy of the outer record at the time
+the class is constructed.
+
+In this test we can see two uses of R.deinit(); one for
+the R defined in doit() and the other for the copy.


### PR DESCRIPTION
Do not invoke deinit() if a class variable is nil

Prior to this PR the user-defined method deinit() would be invoked for a class
variable with value 'nil'.  This PR fixes that error and also avoids calling chpl_here_free()
for these variables.

Two passing tests were updated to reflect the fix in behavior and a passing future was
converted to a passing test.

Two futures were impacted by this change.  This impact revealed that the futures had
been mischaracterized.  One future is for constructors and the other is for the converted
version with initializers and so will be a priority for this release.

All updates are in Chapel code.

paratested for single-locale and gasnet. 

