### PR TITLE
Quiet test_record_of_array_type future under valgrind

### DIFF
--- a/test/arrays/deitz/part3/test_record_of_array_type.bad
+++ b/test/arrays/deitz/part3/test_record_of_array_type.bad
@@ -1,4 +1,3 @@
-1.0 2.0 3.0
 (x = 0.0 0.0 0.0)
 Thread
 Conditional jump or move depends on uninitialised value(s)

--- a/test/arrays/deitz/part3/test_record_of_array_type.prediff
+++ b/test/arrays/deitz/part3/test_record_of_array_type.prediff
@@ -9,9 +9,9 @@ if grep -q '^==[0-9]*== ' $outfile; then
   # Preserve the original output.
   mv $outfile $temp
 
-  # Grab the first two lines of the program output
-  # because they should be deterministic.
-  grep -v ^= $temp | head -2 > $outfile
+  # Grab the second line of the program output
+  # because it should be deterministic.
+  grep -v ^= $temp | head -2 | tail -n1 > $outfile
 
   # Add the first two lines of valgrind output, cleaned up.
   grep ^= $temp | sed 's@^=[^ ]*= @@;s@Thread.*@Thread@' | head -2 >> $outfile


### PR DESCRIPTION
Similar to #7266, for some reason the first line of output for this test is occasionally missing the first character. This happens to the 3rd line as well, which the prediff already filters out. Instead of investigating this further, just update the prediff to only grab the second line of output.