### PR TITLE
The LCALS INNER_PROD kernel was using regular assignment instead of +=

### DIFF
--- a/test/release/examples/benchmarks/lcals/RunCRawLoops.chpl
+++ b/test/release/examples/benchmarks/lcals/RunCRawLoops.chpl
@@ -63,7 +63,7 @@ module RunCRawLoops {
             for isamp in 0..#num_samples {
               q = 0.0;
               for k in 0..#len {
-                q = z[k]*x[k];
+                q += z[k] * x[k];
               }
               val = q*isamp;
             }


### PR DESCRIPTION
This kernel should have been using += instead of just =.  This bug led to the
backend C compiler optimizing away the loop after PR #7422.

Verified that the reference version uses +=.