### PR TITLE
IFA :- Drop a few unused enum values for Float/Complex

### DIFF
--- a/compiler/ifa/num.h
+++ b/compiler/ifa/num.h
@@ -1,15 +1,15 @@
 /*
  * Copyright 2004-2017 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -51,24 +51,20 @@ enum IF1_string_kind {
 };
 
 enum IF1_bool_type {
-  BOOL_SIZE_1, BOOL_SIZE_SYS, BOOL_SIZE_8, BOOL_SIZE_16, BOOL_SIZE_32, 
+  BOOL_SIZE_1, BOOL_SIZE_SYS, BOOL_SIZE_8, BOOL_SIZE_16, BOOL_SIZE_32,
   BOOL_SIZE_64, BOOL_SIZE_NUM
 };
 
-enum IF1_int_type { 
+enum IF1_int_type {
   INT_SIZE_8, INT_SIZE_16, INT_SIZE_32, INT_SIZE_64, INT_SIZE_NUM
 };
 
-enum IF1_float_type { 
-  FLOAT_SIZE_16, FLOAT_SIZE_32, FLOAT_SIZE_48, FLOAT_SIZE_64, 
-  FLOAT_SIZE_80, FLOAT_SIZE_96, FLOAT_SIZE_112, FLOAT_SIZE_128, 
-  FLOAT_SIZE_NUM
+enum IF1_float_type {
+  FLOAT_SIZE_32, FLOAT_SIZE_64, FLOAT_SIZE_NUM
 };
 
-enum IF1_complex_type { 
-  COMPLEX_SIZE_32, COMPLEX_SIZE_64, COMPLEX_SIZE_96, COMPLEX_SIZE_128, 
-  COMPLEX_SIZE_160, COMPLEX_SIZE_192, COMPLEX_SIZE_224, COMPLEX_SIZE_256, 
-  COMPLEX_SIZE_NUM
+enum IF1_complex_type {
+  COMPLEX_SIZE_64, COMPLEX_SIZE_128, COMPLEX_SIZE_NUM
 };
 
 //

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -2602,38 +2602,50 @@ static void fixupQueryFormals(FnSymbol* fn) {
     } else if (CallExpr* call = toCallExpr(formal->typeExpr->body.tail)) {
       // clone query primitive types
       SymExpr* callFnSymExpr = toSymExpr(call->baseExpr);
+
       if (callFnSymExpr && call->numActuals() == 1) {
         Symbol* callFnSym = callFnSymExpr->symbol();
+
         if (DefExpr* def = toDefExpr(call->get(1))) {
           if (callFnSym == dtBools[BOOL_SIZE_DEFAULT]->symbol) {
-            for (int i=BOOL_SIZE_8; i<BOOL_SIZE_NUM; i++)
-              if (dtBools[i]) {
-                clone_for_parameterized_primitive_formals(fn, def,
-                                                          get_width(dtBools[i]));
-              }
+            for (int i = BOOL_SIZE_8; i < BOOL_SIZE_NUM; i++) {
+              clone_for_parameterized_primitive_formals(fn,
+                                                        def,
+                                                        get_width(dtBools[i]));
+            }
+
             fn->defPoint->remove();
             return;
+
           } else if (callFnSym == dtInt[INT_SIZE_DEFAULT]->symbol ||
                      callFnSym == dtUInt[INT_SIZE_DEFAULT]->symbol) {
-            for( int i=INT_SIZE_8; i<INT_SIZE_NUM; i++)
-              if (dtInt[i])
-                clone_for_parameterized_primitive_formals(fn, def,
+            for (int i = INT_SIZE_8; i < INT_SIZE_NUM; i++) {
+                clone_for_parameterized_primitive_formals(fn,
+                                                          def,
                                                           get_width(dtInt[i]));
+            }
+
             fn->defPoint->remove();
             return;
+
           } else if (callFnSym == dtReal[FLOAT_SIZE_DEFAULT]->symbol ||
                      callFnSym == dtImag[FLOAT_SIZE_DEFAULT]->symbol) {
-            for( int i=FLOAT_SIZE_16; i<FLOAT_SIZE_NUM; i++)
-              if (dtReal[i])
-                clone_for_parameterized_primitive_formals(fn, def,
+            for (int i = FLOAT_SIZE_32; i < FLOAT_SIZE_NUM; i++) {
+                clone_for_parameterized_primitive_formals(fn,
+                                                          def,
                                                           get_width(dtReal[i]));
+            }
+
             fn->defPoint->remove();
             return;
+
           } else if (callFnSym == dtComplex[COMPLEX_SIZE_DEFAULT]->symbol) {
-            for( int i=COMPLEX_SIZE_32; i<COMPLEX_SIZE_NUM; i++)
-              if (dtComplex[i])
-                clone_for_parameterized_primitive_formals(fn, def,
-                                                          get_width(dtComplex[i]));
+            for (int i = COMPLEX_SIZE_64; i < COMPLEX_SIZE_NUM; i++) {
+              clone_for_parameterized_primitive_formals(fn,
+                                                        def,
+                                                        get_width(dtComplex[i]));
+            }
+
             fn->defPoint->remove();
             return;
           }


### PR DESCRIPTION
Retire a few unused enum values in compiler/ifa/num.h


I was looking at some code in normalize.cpp and wondered why
the code was checking against NULL when indexing in to the
various prim_type arrays.

It turned out that ifa/num.h defined several enum values for FLOAT
and COMPLEX that we don't use in a functional way, but that do
have trivial effects on code.

1) The compiler allocates a few arrays based on these enums but
then leaves the missing slots NULL

2) The compiler loops over all the enum values in normalize.cpp
but then needs to skip the NULLs.

This PR eliminates the extraneous enums and then updates the
two loops that were skipping the NULLs.

Compiled with/without CHPL_DEVELOPER on clang/darwin and
gcc/linux64.  Ran a small portion of release/ in each configuration.

Also compiled with CHPL_LLVM=llvm on gcc/linux64 and ran a
small portion of release/


Passed a single-locale paratest
