### PR TITLE
Allow multiple config type declarations in one statement

### DIFF
--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -3064,8 +3064,11 @@ BlockStmt* handleConfigTypes(BlockStmt* blk) {
           }
         }
       }
+    } else if (BlockStmt* innerBlk = toBlockStmt(node)) {
+      // recursively handle multiple defs in a single statement
+      handleConfigTypes(innerBlk);
     } else {
-      INT_FATAL("Got non-DefExpr in type_alias_decl_stmt");
+      INT_FATAL("Got non-DefExpr/BlockStmt in type_alias_decl_stmt");
     }
   }
   return blk;

--- a/test/types/config/twoConfigsOneDecl.bad
+++ b/test/types/config/twoConfigsOneDecl.bad
@@ -1,7 +1,0 @@
-internal error: BUI2784 chpl Version 1.14.0.7f81ddd
-
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
-and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
-please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
-

--- a/test/types/config/twoConfigsOneDecl.future
+++ b/test/types/config/twoConfigsOneDecl.future
@@ -1,6 +1,0 @@
-bug: declaration lists break 'config type'
-
-This program seems to show that the compiler can't handle multiple
-declarations in a single 'config type' statement.  If the list of
-config types is broken into separate statements, things work fine, but
-this seems unfortunate/inconsistent.


### PR DESCRIPTION
In the function handleConfigTypes allow multiple declarations in one statement
by accepting a BlockStmt containing config type DefExprs, and handle that block
recursively.

Fixes the future test/types/config/twoConfigsOneDecl.chpl, issue #5039.