### PR TITLE
Make INFINITY and NAN independent of bit patterns

### DIFF
--- a/modules/standard/Math.chpl
+++ b/modules/standard/Math.chpl
@@ -82,8 +82,8 @@ module Math {
   //////////////////////////////////////////////////////////////////////////
   // Helper constants and functions (not included in chpldocs).
   //
-  private extern proc chpl_macro_INFINITY():real(64);
-  private extern proc chpl_macro_NAN():real(64);
+  private extern proc chpl_macro_INFINITY64():real(64);
+  private extern proc chpl_macro_NAN64():real(64);
 
   private extern proc chpl_macro_double_isinf(x: real(64)): c_int;
   private extern proc chpl_macro_float_isinf(x: real(32)): c_int;
@@ -618,7 +618,7 @@ module Math {
 
 
   /* Returns a value for which :proc:`isinf` will return `true`. */
-  inline proc INFINITY: real(64) return chpl_macro_INFINITY();
+  inline proc INFINITY: real(64) return chpl_macro_INFINITY64();
 
 
   /* Returns `true` if the argument `x` is a representation of a finite value;
@@ -849,7 +849,7 @@ module Math {
 
 
   /* Returns a value for which :proc:`isnan` will return `true`. */
-  inline proc NAN : real(64) return chpl_macro_NAN();
+  inline proc NAN : real(64) return chpl_macro_NAN64();
 
 
   /* Returns the rounded integral value of the argument `x` determined by the

--- a/modules/standard/Math.chpl
+++ b/modules/standard/Math.chpl
@@ -82,8 +82,8 @@ module Math {
   //////////////////////////////////////////////////////////////////////////
   // Helper constants and functions (not included in chpldocs).
   //
-  private extern proc chpl_macro_INFINITY64():real(64);
-  private extern proc chpl_macro_NAN64():real(64);
+  private extern proc chpl_macro_INFINITY():real(32);
+  private extern proc chpl_macro_NAN():real(32);
 
   private extern proc chpl_macro_double_isinf(x: real(64)): c_int;
   private extern proc chpl_macro_float_isinf(x: real(32)): c_int;
@@ -618,7 +618,7 @@ module Math {
 
 
   /* Returns a value for which :proc:`isinf` will return `true`. */
-  inline proc INFINITY: real(64) return chpl_macro_INFINITY64();
+  inline proc INFINITY: real(64) return chpl_macro_INFINITY();
 
 
   /* Returns `true` if the argument `x` is a representation of a finite value;
@@ -849,7 +849,7 @@ module Math {
 
 
   /* Returns a value for which :proc:`isnan` will return `true`. */
-  inline proc NAN : real(64) return chpl_macro_NAN64();
+  inline proc NAN : real(64) return chpl_macro_NAN();
 
 
   /* Returns the rounded integral value of the argument `x` determined by the

--- a/runtime/include/chplmath.h
+++ b/runtime/include/chplmath.h
@@ -20,16 +20,12 @@
 #ifndef _CHPL_MATH_H_
 #define _CHPL_MATH_H_
 
-static inline double chpl_macro_INFINITY(void) {
-  double x;
-  *(unsigned long long int*) &x = 0x7ff0000000000000ULL;   // positive infinity
-  return x;
+static inline double chpl_macro_INFINITY64(void) {
+  return INFINITY;
 }
 
-static inline double chpl_macro_NAN(void) {
-  double x;
-  *(unsigned long long int*) &x = 0x7ff8000000000001ULL;   // quiet NaN
-  return x;
+static inline double chpl_macro_NAN64(void) {
+  return NAN;
 }
 
 static inline int chpl_macro_double_isinf(double x) { return isinf(x); }

--- a/runtime/include/chplmath.h
+++ b/runtime/include/chplmath.h
@@ -20,11 +20,11 @@
 #ifndef _CHPL_MATH_H_
 #define _CHPL_MATH_H_
 
-static inline double chpl_macro_INFINITY64(void) {
+static inline float chpl_macro_INFINITY(void) {
   return INFINITY;
 }
 
-static inline double chpl_macro_NAN64(void) {
+static inline float chpl_macro_NAN(void) {
   return NAN;
 }
 

--- a/test/modules/standard/math/infinity.chpl
+++ b/test/modules/standard/math/infinity.chpl
@@ -1,6 +1,9 @@
 var x = INFINITY;
 var y = -INFINITY;
 var z = NAN;
+var x32 = INFINITY: real(32);
+var y32 = -INFINITY: real(32);
+var z32 = NAN: real(32);
 
 if (isinf(x)) then writeln("INFINITY okay.");
 if (isfinite(x)) then writeln("INFINITY not okay.");
@@ -13,5 +16,17 @@ if (isnan(y)) then writeln("-INFINITY not okay.");
 if (isinf(z)) then writeln("NAN not okay.");
 if (isfinite(z)) then writeln("NAN not okay.");
 if (isnan(z)) then writeln("NAN okay.");
+
+if (isinf(x32)) then writeln("INFINITY32 okay.");
+if (isfinite(x32)) then writeln("INFINITY32 not okay.");
+if (isnan(x32)) then writeln("INFINITY32 not okay.");
+
+if (isinf(y32)) then writeln("-INFINITY32 okay.");
+if (isfinite(y32)) then writeln("-INFINITY32 not okay.");
+if (isnan(y32)) then writeln("-INFINITY32 not okay.");
+
+if (isinf(z32)) then writeln("NAN32 not okay.");
+if (isfinite(z32)) then writeln("NAN32 not okay.");
+if (isnan(z32)) then writeln("NAN32 okay.");
 
 if (isfinite(12345)) then writeln("Finite test passes.");

--- a/test/modules/standard/math/infinity.good
+++ b/test/modules/standard/math/infinity.good
@@ -1,4 +1,7 @@
 INFINITY okay.
 -INFINITY okay.
 NAN okay.
+INFINITY32 okay.
+-INFINITY32 okay.
+NAN32 okay.
 Finite test passes.


### PR DESCRIPTION
Leverage the predefined INFINITY and NAN macros to free Chapel of bit-pattern dependencies for those values.  Also, test 32-bit usage.

An example of something that uses a different bit pattern is a GPU that lacks 64-bit floating-point numbers and emulates them by concatenating two 32-bit values.  See [https://arxiv.org/pdf/cs/0603115.pdf](Implementation of float-float operators on graphics hardware).  Thanks to Damian McGuckin for the reference.

Passed full local testing on linux64.
Passed test/modules/standard/math/infinity.chpl with and without `--fast` on the following:
* Ubuntu with gcc and with LLVM
* Mac with Clang
* Cray XC with Cray, Intel, and gcc compilers