### PR TITLE
Adapt prefetch.prediff for objdump output format change on Mac OS

### DIFF
--- a/test/modules/standard/Prefetch/prefetch.prediff
+++ b/test/modules/standard/Prefetch/prefetch.prediff
@@ -10,7 +10,7 @@ fi
 
 objdump -d "./$testname" > $disasm
 
-grep -A 20 -e "<_main>" -e "<main>" $disasm | grep "prefetch" > /dev/null
+grep -A 20 -e "<_main>" -e "<main>" -e "^_*main:" $disasm | grep "prefetch" > /dev/null
 if [ $? -eq 1 ]; then
   echo "Prefetch instruction not found" >> $outfile
 fi


### PR DESCRIPTION
test/modules/standard/Prefetch/prefetch threw an error on Mac,
after recent OS update. The error was:
    `> Prefetch instruction not found`
    `[Error matching program output for modules/standard/Prefetch/prefetch]`

The same test still passes everywhere else.

That "Prefetch instruction not found" message actually comes from the
prefetch.prediff script, which
- disassembles the prefetch.test.c binary with "objdump", then
- greps the objdump output for a string like "\<main\>", followed by
  another line containing string "prefetch".
To show if the low-level prefetch instruction was actually used.

It looks like the objdump output format changed on the Mac, from something
like
`    0000000000400430 <main>:`
to
`    _main:`

This change in the prefetch.prediff script lets the grep commands find the
desired string "prefetch", even with this different objdump output format.