### PR TITLE
Clean up code by removing support for LLVM older than 4

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -1856,11 +1856,7 @@ codegen_config() {
     info->builder->SetInsertPoint(createConfigBlock);
 
     llvm::Function *initConfigFunc = getFunctionLLVM("initConfigVarTable");
-#if HAVE_LLVM_VER >= 37
     info->builder->CreateCall(initConfigFunc, {} );
-#else
-    info->builder->CreateCall(initConfigFunc);
-#endif
 
     llvm::Function *installConfigFunc = getFunctionLLVM("installConfigVar");
 

--- a/compiler/codegen/expr.cpp
+++ b/compiler/codegen/expr.cpp
@@ -2316,7 +2316,8 @@ GenRet codegenCallExpr(GenRet function,
       // argument
       if( llArgs.size() < fnType->getNumParams() &&
           func &&
-          llvm_fn_param_has_attr(func,llArgs.size()+1,LLVM_ATTRIBUTE::ByVal) ){
+          func->getAttributes().hasAttribute(llArgs.size()+1,
+                                             llvm::Attribute::ByVal) ){
         args[i] = codegenAddrOf(codegenValuePtr(args[i]));
         // TODO -- this is not working!
       }

--- a/compiler/codegen/expr.cpp
+++ b/compiler/codegen/expr.cpp
@@ -303,15 +303,9 @@ GenRet codegenWideAddr(GenRet locale, GenRet raddr, Type* wideType = NULL)
     } else {
 #ifdef HAVE_LLVM
       llvm::Value* adr = info->builder->CreateStructGEP(
-#if HAVE_LLVM_VER >= 37
-          NULL,
-#endif
-          ret.val, WIDE_GEP_ADDR);
+          NULL, ret.val, WIDE_GEP_ADDR);
       llvm::Value* loc = info->builder->CreateStructGEP(
-#if HAVE_LLVM_VER >= 37
-          NULL,
-#endif
-          ret.val, WIDE_GEP_LOC);
+          NULL, ret.val, WIDE_GEP_LOC);
 
       // cast address if needed. This is necessary for building a wide
       // NULL pointer since NULL is actually an i8*.
@@ -343,11 +337,7 @@ GenRet codegenWideAddr(GenRet locale, GenRet raddr, Type* wideType = NULL)
     // we are supposed to have since null has type void*.
     llvm::Value* locAddr = raddr.val;
     locAddr = info->builder->CreatePointerCast(locAddr, locAddrType);
-#if HAVE_LLVM_VER >= 37
     ret.val = info->builder->CreateCall(fn, {locale.val, locAddr});
-#else
-    ret.val = info->builder->CreateCall2(fn, locale.val, locAddr);
-#endif
 
 #endif
   }
@@ -388,14 +378,9 @@ void codegenInvariantStart(llvm::Value *val, llvm::Value *addr)
   llvm::Type *int8PtrTy =
     llvm::Type::getInt8Ty(info->llvmContext)->getPointerTo(0);
 
-  #if HAVE_LLVM_VER >= 40
   llvm::Type *objectPtr = { int8PtrTy };
   llvm::Function *invariantStart =
     llvm::Intrinsic::getDeclaration(info->module, llvm::Intrinsic::invariant_start, objectPtr);
-  #else
-  llvm::Function *invariantStart =
-    llvm::Intrinsic::getDeclaration(info->module, llvm::Intrinsic::invariant_start);
-  #endif
 
   const llvm::DataLayout& dataLayout = info->module->getDataLayout();
 
@@ -723,10 +708,7 @@ static GenRet codegenWideThingField(GenRet ws, WideThingField field)
       if (ws.val->getType()->isPointerTy()){
         ret.isLVPtr = GEN_PTR;
         ret.val = info->builder->CreateConstInBoundsGEP2_32(
-#if HAVE_LLVM_VER >= 37
-                                            NULL,
-#endif
-                                            ws.val, 0, field);
+                                            NULL, ws.val, 0, field);
       } else {
         ret.isLVPtr = GEN_VAL;
         ret.val = info->builder->CreateExtractValue(ws.val, field);
@@ -1005,10 +987,7 @@ GenRet codegenFieldPtr(
     if( isUnion(ct) && !special ) {
       // Get a pointer to the union data then cast it to the right type
       ret.val = info->builder->CreateConstInBoundsGEP2_32(
-#if HAVE_LLVM_VER >= 37
-          NULL,
-#endif
-          baseValue, 0, cBaseType->getMemberGEP("_u"));
+          NULL, baseValue, 0, cBaseType->getMemberGEP("_u"));
       llvm::PointerType* ty =
         llvm::PointerType::get(retType.type,
                                baseValue->getType()->getPointerAddressSpace());
@@ -1018,10 +997,7 @@ GenRet codegenFieldPtr(
     } else {
       // Normally, we just use a GEP.
       ret.val = info->builder->CreateConstInBoundsGEP2_32(
-#if HAVE_LLVM_VER >= 37
-          NULL,
-#endif
-          baseValue, 0, cBaseType->getMemberGEP(c_field_name));
+          NULL, baseValue, 0, cBaseType->getMemberGEP(c_field_name));
     }
 #endif
   }

--- a/compiler/codegen/stmt.cpp
+++ b/compiler/codegen/stmt.cpp
@@ -56,11 +56,7 @@ void codegenStmt(Expr* stmt) {
       if(stmt->parentSymbol && stmt->parentSymbol->astTag == E_FnSymbol) {
         scope = debug_info->get_function((FnSymbol *)stmt->parentSymbol);
       } else {
-        scope = info->builder->getCurrentDebugLocation().getScope(
-#if HAVE_LLVM_VER < 37
-                                                      info->llvmContext
-#endif
-                                                      );
+        scope = info->builder->getCurrentDebugLocation().getScope();
       }
 
       info->builder->SetCurrentDebugLocation(

--- a/compiler/codegen/symbol.cpp
+++ b/compiler/codegen/symbol.cpp
@@ -496,10 +496,7 @@ GenRet VarSymbol::codegenVarSymbol(bool lhsInSetReference) {
         globalValue->setConstant(true);
         globalValue->setInitializer(llvm::cast<llvm::Constant>(
               info->builder->CreateConstInBoundsGEP2_32(
-#if HAVE_LLVM_VER >= 37
-                NULL,
-#endif
-                constString, 0, 0)));
+                NULL, constString, 0, 0)));
         ret.val = globalValue;
         ret.isLVPtr = GEN_PTR;
       } else {
@@ -690,10 +687,7 @@ void VarSymbol::codegenDef() {
             llvm::cast<llvm::GlobalVariable>(constString);
           globalValue->setInitializer(llvm::cast<llvm::Constant>(
                 info->builder->CreateConstInBoundsGEP2_32(
-#if HAVE_LLVM_VER >= 37
-                  NULL,
-#endif
-                  globalString, 0, 0)));
+                  NULL, globalString, 0, 0)));
         } else {
           llvm::GlobalVariable *globalString =
             new llvm::GlobalVariable(
@@ -707,10 +701,7 @@ void VarSymbol::codegenDef() {
                 llvm::IntegerType::getInt8Ty(info->module->getContext())));
           globalValue->setInitializer(llvm::cast<llvm::Constant>(
                 info->builder->CreateConstInBoundsGEP1_32(
-#if HAVE_LLVM_VER >= 37
-                  NULL,
-#endif
-                  globalString, 0)));
+                  NULL, globalString, 0)));
         }
       } else {
         globalValue->setInitializer(llvm::cast<llvm::Constant>(
@@ -1353,15 +1344,11 @@ void FnSymbol::codegenDef() {
     info->lvt->removeLayer();
     if( developer ) {
       bool problems = false;
-#if HAVE_LLVM_VER >= 35
       // Debug info generation creates metadata nodes that won't be
       // finished until the whole codegen is complete and finalize
       // is called.
       if( ! debug_info )
         problems = llvm::verifyFunction(*func, &llvm::errs());
-#else
-      problems = llvm::verifyFunction(*func, llvm::PrintMessageAction);
-#endif
       if( problems ) {
         INT_FATAL("LLVM function verification failed");
       }

--- a/compiler/codegen/symbol.cpp
+++ b/compiler/codegen/symbol.cpp
@@ -890,7 +890,7 @@ void TypeSymbol::codegenMetadata() {
   llvm::LLVMContext& ctx = info->module->getContext();
   // Create the TBAA root node if necessary.
   if( ! info->tbaaRootNode ) {
-    LLVM_METADATA_OPERAND_TYPE* Ops[1];
+    llvm::Metadata* Ops[1];
     Ops[0] = llvm::MDString::get(ctx, "Chapel types");
     info->tbaaRootNode = llvm::MDNode::get(ctx, Ops);
   }
@@ -942,26 +942,26 @@ void TypeSymbol::codegenMetadata() {
       hasEitherFlag(FLAG_DATA_CLASS,FLAG_WIDE_CLASS) ) {
     // Now create tbaa metadata, one for const and one for not.
     {
-      LLVM_METADATA_OPERAND_TYPE* Ops[2];
+      llvm::Metadata* Ops[2];
       Ops[0] = llvm::MDString::get(ctx, cname);
       Ops[1] = parent;
       llvmTbaaTypeDescriptor = llvm::MDNode::get(ctx, Ops);
     }
     {
-      LLVM_METADATA_OPERAND_TYPE* Ops[3];
+      llvm::Metadata* Ops[3];
       Ops[0] = llvmTbaaTypeDescriptor;
       Ops[1] = llvmTbaaTypeDescriptor;
-      Ops[2] = llvm_constant_as_metadata(
+      Ops[2] = llvm::ConstantAsMetadata::get(
                    llvm::ConstantInt::get(llvm::Type::getInt64Ty(ctx), 0));
       llvmTbaaAccessTag = llvm::MDNode::get(ctx, Ops);
     }
     {
-      LLVM_METADATA_OPERAND_TYPE* Ops[4];
+      llvm::Metadata* Ops[4];
       Ops[0] = llvmTbaaTypeDescriptor;
       Ops[1] = llvmTbaaTypeDescriptor;
-      Ops[2] = llvm_constant_as_metadata(
+      Ops[2] = llvm::ConstantAsMetadata::get(
                    llvm::ConstantInt::get(llvm::Type::getInt64Ty(ctx), 0));
-      Ops[3] = llvm_constant_as_metadata(
+      Ops[3] = llvm::ConstantAsMetadata::get(
                    llvm::ConstantInt::get(llvm::Type::getInt64Ty(ctx), 1));
       llvmConstTbaaAccessTag = llvm::MDNode::get(ctx, Ops);
     }
@@ -978,8 +978,8 @@ void TypeSymbol::codegenMetadata() {
 
   if( ct ) {
     // Now create the tbaa.struct metadata nodes.
-    llvm::SmallVector<LLVM_METADATA_OPERAND_TYPE*, 16> Ops;
-    llvm::SmallVector<LLVM_METADATA_OPERAND_TYPE*, 16> ConstOps;
+    llvm::SmallVector<llvm::Metadata*, 16> Ops;
+    llvm::SmallVector<llvm::Metadata*, 16> ConstOps;
 
     const char* struct_name = ct->classStructName(true);
     llvm::Type* struct_type_ty = info->lvt->getType(struct_name);
@@ -998,11 +998,11 @@ void TypeSymbol::codegenMetadata() {
       unsigned gep = ct->getMemberGEP(field->cname);
       llvm::Constant* off = llvm::ConstantExpr::getOffsetOf(struct_type, gep);
       llvm::Constant* sz = llvm::ConstantExpr::getSizeOf(fieldType);
-      Ops.push_back(llvm_constant_as_metadata(off));
-      Ops.push_back(llvm_constant_as_metadata(sz));
+      Ops.push_back(llvm::ConstantAsMetadata::get(off));
+      Ops.push_back(llvm::ConstantAsMetadata::get(sz));
       Ops.push_back(field->type->symbol->llvmTbaaAccessTag);
-      ConstOps.push_back(llvm_constant_as_metadata(off));
-      ConstOps.push_back(llvm_constant_as_metadata(sz));
+      ConstOps.push_back(llvm::ConstantAsMetadata::get(off));
+      ConstOps.push_back(llvm::ConstantAsMetadata::get(sz));
       ConstOps.push_back(field->type->symbol->llvmConstTbaaAccessTag);
     }
     llvmTbaaStructCopyNode = llvm::MDNode::get(ctx, Ops);
@@ -1286,7 +1286,7 @@ void FnSymbol::codegenDef() {
     info->lvt->addLayer();
 
     if(debug_info) {
-      LLVM_DISUBPROGRAM dbgScope = debug_info->get_function(this);
+      llvm::DISubprogram* dbgScope = debug_info->get_function(this);
       info->builder->SetCurrentDebugLocation(
         llvm::DebugLoc::get(linenum(),0,dbgScope));
     }

--- a/compiler/include/clangSupport.h
+++ b/compiler/include/clangSupport.h
@@ -34,21 +34,9 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/SmallString.h"
 
-#if HAVE_LLVM_VER >= 32
-// workaround for oddities with clang 3.2
-namespace clang {
-  using namespace llvm;
-//  typedef llvm::StringRef StringRef;
-//  typedef llvm::SmallVector StringRef;
-};
 #include "clang/Basic/DiagnosticOptions.h"
 #include "clang/Lex/HeaderSearchOptions.h"
 #include "clang/Lex/PreprocessorOptions.h"
-#else
-#include "clang/Frontend/DiagnosticOptions.h"
-#include "clang/Frontend/HeaderSearchOptions.h"
-#include "clang/Frontend/PreprocessorOptions.h"
-#endif
 
 #include "clang/Frontend/TextDiagnosticPrinter.h"
 #include "clang/AST/ASTContext.h"
@@ -96,18 +84,10 @@ namespace clang {
 #include "llvm/Support/Path.h"
 #include "llvm/Support/ToolOutputFile.h"
 
-#if HAVE_LLVM_VER >= 40
 #include "llvm/Bitcode/BitcodeReader.h"
 #include "llvm/Bitcode/BitcodeWriter.h"
-#else
-#include "llvm/Bitcode/ReaderWriter.h"
-#endif
 
-#if HAVE_LLVM_VER >= 35
 #include "llvm/IR/Verifier.h"
-#else
-#include "llvm/Analysis/Verifier.h"
-#endif
 
 
 #include "llvm/ADT/DenseMap.h"

--- a/compiler/include/codegen.h
+++ b/compiler/include/codegen.h
@@ -37,7 +37,7 @@
 #ifdef HAVE_LLVM
 
 // forward declare.
-class ClangInfo;
+struct ClangInfo;
 
 #endif
 

--- a/compiler/include/llvmDebug.h
+++ b/compiler/include/llvmDebug.h
@@ -33,20 +33,14 @@
 #include "llvm/Support/Dwarf.h"
 #endif
 
-#if HAVE_LLVM_VER >= 35
 #include "llvm/IR/DebugInfo.h"
 #include "llvm/IR/DIBuilder.h"
-#else
-#include "llvm/DebugInfo.h"
-#include "llvm/DIBuilder.h"
-#endif
 
 #include <vector>
 
 //#define DW_LANG_chapel (llvm::dwarf::DW_LANG_lo_user+37)
 #define DW_LANG_chapel llvm::dwarf::DW_LANG_lo_user
 
-#if HAVE_LLVM_VER >= 37
 // This should be renamed to DI versions
 #define LLVM_DITYPE llvm::DIType*
 #define LLVM_DIFILE llvm::DIFile*
@@ -85,62 +79,9 @@ static inline LLVM_DIVARIABLE toDIVARIABLE(llvm::MDNode* N)
 }
 
 
-
-
-#else
-#define LLVM_DITYPE llvm::DIType
-#define LLVM_DIFILE llvm::DIFile
-#define LLVM_DINAMESPACE llvm::DINameSpace
-#define LLVM_DISUBPROGRAM llvm::DISubprogram
-#define LLVM_DIGLOBALVARIABLE llvm::DIGlobalVariable
-#define LLVM_DIVARIABLE llvm::DIVariable
-#define LLVM_DITYPEARRAY llvm::DITypeArray
-#define LLVM_DIARRAY llvm::DIArray
-
-#if HAVE_LLVM_VER >= 36
-#define LLVM_DI_SUBROUTINE_TYPE llvm::DISubroutineType
-#else
-#define LLVM_DI_SUBROUTINE_TYPE llvm::DICompositeType
-#endif
-
-static inline LLVM_DITYPE toDITYPE(llvm::MDNode* N)
-{
-  return llvm::DIType(N);
-}
-
-static inline LLVM_DINAMESPACE toDINAMESPACE(llvm::MDNode* N)
-{
-  return llvm::DINameSpace(N);
-}
-
-static inline LLVM_DISUBPROGRAM toDISUBPROGRAM(llvm::MDNode* N)
-{
-  return llvm::DISubprogram(N);
-}
-
-static inline LLVM_DIGLOBALVARIABLE toDIGLOBALVARIABLE(llvm::MDNode* N)
-{
-  return llvm::DIGlobalVariable(N);
-}
-
-static inline LLVM_DIVARIABLE toDIVARIABLE(llvm::MDNode* N)
-{
-  return llvm::DIVariable(N);
-}
-
-
-
-#endif
-
-
-
 // LLVM 4.0 added DIGlobalVariableExpression but previously
 // it was basically stored in DIGlobalVariable
-#if HAVE_LLVM_VER >= 40
 #define LLVM_DIGLOBALVARIABLEEXPRESSION llvm::DIGlobalVariableExpression*
-#else
-#define LLVM_DIGLOBALVARIABLEEXPRESSION llvm::DIGlobalVariable*
-#endif
 
 
 

--- a/compiler/include/llvmDebug.h
+++ b/compiler/include/llvmDebug.h
@@ -38,54 +38,6 @@
 
 #include <vector>
 
-//#define DW_LANG_chapel (llvm::dwarf::DW_LANG_lo_user+37)
-#define DW_LANG_chapel llvm::dwarf::DW_LANG_lo_user
-
-// This should be renamed to DI versions
-#define LLVM_DITYPE llvm::DIType*
-#define LLVM_DIFILE llvm::DIFile*
-#define LLVM_DINAMESPACE llvm::DINamespace*
-#define LLVM_DISUBPROGRAM llvm::DISubprogram*
-#define LLVM_DIGLOBALVARIABLE llvm::DIGlobalVariable*
-#define LLVM_DIVARIABLE llvm::DIVariable*
-#define LLVM_DITYPEARRAY llvm::DITypeRefArray
-#define LLVM_DIARRAY llvm::DebugNodeArray
-
-#define LLVM_DI_SUBROUTINE_TYPE llvm::DISubroutineType*
-
-static inline LLVM_DITYPE toDITYPE(llvm::MDNode* N)
-{
-  return llvm::cast_or_null<llvm::DIType>(N);
-}
-
-static inline LLVM_DINAMESPACE toDINAMESPACE(llvm::MDNode* N)
-{
-  return llvm::cast_or_null<llvm::DINamespace>(N);
-}
-
-static inline LLVM_DISUBPROGRAM toDISUBPROGRAM(llvm::MDNode* N)
-{
-  return llvm::cast_or_null<llvm::DISubprogram>(N);
-}
-
-static inline LLVM_DIGLOBALVARIABLE toDIGLOBALVARIABLE(llvm::MDNode* N)
-{
-  return llvm::cast_or_null<llvm::DIGlobalVariable>(N);
-}
-
-static inline LLVM_DIVARIABLE toDIVARIABLE(llvm::MDNode* N)
-{
-  return llvm::cast_or_null<llvm::DIVariable>(N);
-}
-
-
-// LLVM 4.0 added DIGlobalVariableExpression but previously
-// it was basically stored in DIGlobalVariable
-#define LLVM_DIGLOBALVARIABLEEXPRESSION llvm::DIGlobalVariableExpression*
-
-
-
-
 #endif
 
 struct lessAstr {
@@ -103,31 +55,31 @@ class debug_data
   void finalize();
   void create_compile_unit(const char *file, const char *directory, bool is_optimized, const char *flags);
 
-  LLVM_DITYPE construct_type(Type *type);
-  LLVM_DITYPE get_type(Type *type);
+  llvm::DIType* construct_type(Type *type);
+  llvm::DIType* get_type(Type *type);
 
-  LLVM_DIFILE construct_file(const char *file);
-  LLVM_DIFILE get_file(const char *file);
+  llvm::DIFile* construct_file(const char *file);
+  llvm::DIFile* get_file(const char *file);
 
-  LLVM_DINAMESPACE construct_module_scope(ModuleSymbol* modSym);
-  LLVM_DINAMESPACE get_module_scope(ModuleSymbol* modSym);
+  llvm::DINamespace* construct_module_scope(ModuleSymbol* modSym);
+  llvm::DINamespace* get_module_scope(ModuleSymbol* modSym);
 
-  LLVM_DI_SUBROUTINE_TYPE get_function_type(FnSymbol *function);
-  LLVM_DISUBPROGRAM construct_function(FnSymbol *function);
-  LLVM_DISUBPROGRAM get_function(FnSymbol *function);
+  llvm::DISubroutineType* get_function_type(FnSymbol *function);
+  llvm::DISubprogram* construct_function(FnSymbol *function);
+  llvm::DISubprogram* get_function(FnSymbol *function);
 
-  LLVM_DIGLOBALVARIABLEEXPRESSION construct_global_variable(VarSymbol *gVarSym);
-  LLVM_DIGLOBALVARIABLEEXPRESSION get_global_variable(VarSymbol *gVarSym);
-  LLVM_DIVARIABLE construct_variable(VarSymbol *varSym);
-  LLVM_DIVARIABLE get_variable(VarSymbol *varSym);
-  LLVM_DIVARIABLE construct_formal_arg(ArgSymbol *argSym, unsigned int ArgNo);
-  LLVM_DIVARIABLE get_formal_arg(ArgSymbol *argSym, unsigned int ArgNo);
+  llvm::DIGlobalVariableExpression* construct_global_variable(VarSymbol *gVarSym);
+  llvm::DIGlobalVariableExpression* get_global_variable(VarSymbol *gVarSym);
+  llvm::DIVariable* construct_variable(VarSymbol *varSym);
+  llvm::DIVariable* get_variable(VarSymbol *varSym);
+  llvm::DIVariable* construct_formal_arg(ArgSymbol *argSym, unsigned int ArgNo);
+  llvm::DIVariable* get_formal_arg(ArgSymbol *argSym, unsigned int ArgNo);
 
  private:
   llvm::DIBuilder dibuilder;
   bool optimized;
   //std::vector<llvm::DIFile>files;
-  std::map<const char*,LLVM_DIFILE,lessAstr> filesByName;
+  std::map<const char*,llvm::DIFile*,lessAstr> filesByName;
   //std::vector<llvm::DIType>types;
   //std::map<const char*,llvm::DIType,lessAstr> typesByName;
   //std::vector<llvm::DINameSpace>name_spaces;

--- a/compiler/include/llvmGlobalToWide.h
+++ b/compiler/include/llvmGlobalToWide.h
@@ -27,11 +27,7 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallPtrSet.h"
 
-#if HAVE_LLVM_VER >= 35
 #include "llvm/IR/ValueHandle.h"
-#else
-#include "llvm/Support/ValueHandle.h"
-#endif
 
 /* The LLVM Global to Wide transformation allows the Chapel code generator
  * to emit multi-locale global pointer code that can be optimized by existing

--- a/compiler/include/llvmUtil.h
+++ b/compiler/include/llvmUtil.h
@@ -31,7 +31,9 @@
 // So we can declare our small set insert fixup
 #include "llvm/ADT/SmallSet.h"
 
-#if HAVE_LLVM_VER >= 40
+#if HAVE_LLVM_VER < 40
+#error LLVM version is too old for this version of Chapel
+#endif
 
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Value.h"
@@ -40,22 +42,7 @@
 #include "llvm/IR/Attributes.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/DataLayout.h"
-#define LLVM_ATTRIBUTE llvm::Attribute
-static inline bool llvm_fn_param_has_attr(llvm::Function* f, unsigned idx, llvm::Attribute::AttrKind v)
-{
-  return f->getAttributes().hasAttribute(idx, v);
-}
-
-#else
-
-#error LLVM version is too old for this version of Chapel
-
-#endif
-
 #include "llvm/IR/LegacyPassManager.h"
-#define LEGACY_FUNCTION_PASS_MANAGER llvm::legacy::FunctionPassManager
-#define LEGACY_PASS_MANAGER llvm::legacy::PassManagerBase
-#define LEGACY_MODULE_PASS_MANAGER llvm::legacy::PassManager
 
 struct PromotedPair {
   llvm::Value* a;
@@ -77,28 +64,6 @@ PromotedPair convertValuesToLarger(llvm::IRBuilder<> *builder, llvm::Value *valu
 int64_t getTypeSizeInBytes(const llvm::DataLayout& layout, llvm::Type* ty);
 bool isTypeSizeSmallerThan(const llvm::DataLayout& layout, llvm::Type* ty, uint64_t max_size_bytes);
 uint64_t getTypeFieldNext(const llvm::DataLayout& layout, llvm::Type* ty, uint64_t offset);
-
-
-// And create a type for a metadata operand 
-#define LLVM_METADATA_OPERAND_TYPE llvm::Metadata
-static inline llvm::ConstantAsMetadata* llvm_constant_as_metadata(llvm::Constant* C)
-{
-  return llvm::ConstantAsMetadata::get(C);
-}
-template<typename T, unsigned N>
-static inline
-bool llvm_small_set_insert(llvm::SmallSet<T,N> & smallset, const T &V) {
-  return smallset.insert(V).second;
-}
-
-// LLVMs after 3.5 require C++11 support
-#define HAVE_LLVM_CXX11 1
-
-#ifdef HAVE_LLVM_CXX11
-#define LLVM_CXX_OVERRIDE override
-#else
-#define LLVM_CXX_OVERRIDE
-#endif
 
 #endif //HAVE_LLVM
 

--- a/compiler/include/llvmUtil.h
+++ b/compiler/include/llvmUtil.h
@@ -31,7 +31,7 @@
 // So we can declare our small set insert fixup
 #include "llvm/ADT/SmallSet.h"
 
-#if HAVE_LLVM_VER >= 33
+#if HAVE_LLVM_VER >= 40
 
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Value.h"
@@ -46,39 +46,16 @@ static inline bool llvm_fn_param_has_attr(llvm::Function* f, unsigned idx, llvm:
   return f->getAttributes().hasAttribute(idx, v);
 }
 
-#elif HAVE_LLVM_VER >= 32
-
-#include "llvm/Module.h"
-#include "llvm/Value.h"
-#include "llvm/IRBuilder.h"
-#include "llvm/DataLayout.h"
-#include "llvm/Intrinsics.h"
-#include "llvm/IntrinsicInst.h"
-#include "llvm/Attributes.h"
-#define LLVM_ATTRIBUTE llvm::Attributes
-static inline bool llvm_fn_param_has_attr(llvm::Function* f, unsigned idx, llvm::Attributes::AttrVal v)
-{
-  //return f->getAttributes().getParamAttributes(idx).hasAttribute(v);
-  return f->getParamAttributes(idx).hasAttribute(v);
-}
-
 #else
 
 #error LLVM version is too old for this version of Chapel
 
 #endif
 
-// PassManager also changed names..
-#if HAVE_LLVM_VER >= 37
 #include "llvm/IR/LegacyPassManager.h"
 #define LEGACY_FUNCTION_PASS_MANAGER llvm::legacy::FunctionPassManager
 #define LEGACY_PASS_MANAGER llvm::legacy::PassManagerBase
 #define LEGACY_MODULE_PASS_MANAGER llvm::legacy::PassManager
-#else
-#include "llvm/PassManager.h"
-#define LEGACY_FUNCTION_PASS_MANAGER llvm::FunctionPassManager
-#define LEGACY_PASS_MANAGER llvm::PassManagerBase
-#endif
 
 struct PromotedPair {
   llvm::Value* a;
@@ -103,7 +80,6 @@ uint64_t getTypeFieldNext(const llvm::DataLayout& layout, llvm::Type* ty, uint64
 
 
 // And create a type for a metadata operand 
-#if HAVE_LLVM_VER >= 36
 #define LLVM_METADATA_OPERAND_TYPE llvm::Metadata
 static inline llvm::ConstantAsMetadata* llvm_constant_as_metadata(llvm::Constant* C)
 {
@@ -114,24 +90,9 @@ static inline
 bool llvm_small_set_insert(llvm::SmallSet<T,N> & smallset, const T &V) {
   return smallset.insert(V).second;
 }
-#else
-#define LLVM_METADATA_OPERAND_TYPE llvm::Value
-static inline llvm::Constant* llvm_constant_as_metadata(llvm::Constant* C)
-{
-  return C;
-}
-template<typename T, unsigned N>
-static inline
-bool llvm_small_set_insert(llvm::SmallSet<T,N> & smallset, const T &V) {
-  return smallset.insert(V);
-}
-
-#endif
 
 // LLVMs after 3.5 require C++11 support
-#if HAVE_LLVM_VER >= 35
 #define HAVE_LLVM_CXX11 1
-#endif
 
 #ifdef HAVE_LLVM_CXX11
 #define LLVM_CXX_OVERRIDE override

--- a/compiler/passes/externCResolve.cpp
+++ b/compiler/passes/externCResolve.cpp
@@ -343,11 +343,7 @@ void convertDeclToChpl(ModuleSymbol* module,
   //functions
   if (clang::FunctionDecl *fd =
       llvm::dyn_cast_or_null<clang::FunctionDecl>(cValue)) {
-#if HAVE_LLVM_VER >= 35
     clang::QualType resultType = fd->getReturnType();
-#else
-    clang::QualType resultType = fd->getResultType();
-#endif
     FnSymbol* f = new FnSymbol(name);
     f->addFlag(FLAG_EXTERN);
     f->addFlag(FLAG_LOCAL_ARGS);

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -1018,7 +1018,7 @@ static bool tryCResolve(ModuleSymbol*                     module,
   if (module == NULL) {
     return false;
 
-  } else if (llvm_small_set_insert(visited, module)) {
+  } else if (visited.insert(module).second) {
     // visited.insert(module)) {
     // we added it to the set, so continue.
 

--- a/compiler/util/clangUtil.cpp
+++ b/compiler/util/clangUtil.cpp
@@ -585,7 +585,7 @@ class CCodeGenConsumer : public ASTConsumer {
     ~CCodeGenConsumer() { }
 
     // Start ASTVisitor Overrides
-    void Initialize(ASTContext &Context) LLVM_CXX_OVERRIDE {
+    void Initialize(ASTContext &Context) override {
 
       setupClangContext(info, &Context);
 
@@ -603,7 +603,7 @@ class CCodeGenConsumer : public ASTConsumer {
     // This is called by the parser to process every top-level Decl*.
     //
     // \returns true to continue parsing, or false to abort parsing.
-    bool HandleTopLevelDecl(DeclGroupRef DG) LLVM_CXX_OVERRIDE {
+    bool HandleTopLevelDecl(DeclGroupRef DG) override {
 
       if (Diags->hasErrorOccurred()) return true;
 
@@ -638,20 +638,20 @@ class CCodeGenConsumer : public ASTConsumer {
       Builder->HandleInlineFunctionDefinition(D);
     }
 
-   void HandleInterestingDecl(DeclGroupRef D) LLVM_CXX_OVERRIDE {
+   void HandleInterestingDecl(DeclGroupRef D) override {
      if (Diags->hasErrorOccurred()) return;
      if (parseOnly) return;
      Builder->HandleInterestingDecl(D);
    }
 
-   void HandleTranslationUnit(ASTContext &Context) LLVM_CXX_OVERRIDE {
+   void HandleTranslationUnit(ASTContext &Context) override {
      // Don't call Builder->HandleTranslationUnit yet, so that we
      // can keep it open to codegen more later.
      savedCtx = &Context;
      INT_ASSERT(savedCtx == info->clangInfo->Ctx);
    }
 
-   void HandleTagDeclDefinition(TagDecl *D) LLVM_CXX_OVERRIDE {
+   void HandleTagDeclDefinition(TagDecl *D) override {
       if (Diags->hasErrorOccurred()) return;
 
       // make a note of C globals
@@ -675,69 +675,69 @@ class CCodeGenConsumer : public ASTConsumer {
       Builder->HandleTagDeclDefinition(D);
     }
 
-    void HandleTagDeclRequiredDefinition(const TagDecl *D) LLVM_CXX_OVERRIDE {
+    void HandleTagDeclRequiredDefinition(const TagDecl *D) override {
       if (Diags->hasErrorOccurred()) return;
       if (parseOnly) return;
       Builder->HandleTagDeclRequiredDefinition(D);
     }
 
-    void HandleCXXImplicitFunctionInstantiation(FunctionDecl *D) LLVM_CXX_OVERRIDE {
+    void HandleCXXImplicitFunctionInstantiation(FunctionDecl *D) override {
       if (Diags->hasErrorOccurred()) return;
       if (parseOnly) return;
       Builder->HandleCXXImplicitFunctionInstantiation(D);
     }
 
-    void HandleTopLevelDeclInObjCContainer(DeclGroupRef D) LLVM_CXX_OVERRIDE {
+    void HandleTopLevelDeclInObjCContainer(DeclGroupRef D) override {
       if (Diags->hasErrorOccurred()) return;
       if (parseOnly) return;
       Builder->HandleTopLevelDeclInObjCContainer(D);
     }
 
-    void HandleImplicitImportDecl(ImportDecl *D) LLVM_CXX_OVERRIDE {
+    void HandleImplicitImportDecl(ImportDecl *D) override {
       if (Diags->hasErrorOccurred()) return;
       if (parseOnly) return;
       Builder->HandleImplicitImportDecl(D);
     }
 
-    void CompleteTentativeDefinition(VarDecl *D) LLVM_CXX_OVERRIDE {
+    void CompleteTentativeDefinition(VarDecl *D) override {
       if (Diags->hasErrorOccurred()) return;
       if (parseOnly) return;
       Builder->CompleteTentativeDefinition(D);
     }
 
-    void AssignInheritanceModel(CXXRecordDecl *RD) LLVM_CXX_OVERRIDE {
+    void AssignInheritanceModel(CXXRecordDecl *RD) override {
       if (Diags->hasErrorOccurred()) return;
       if (parseOnly) return;
       Builder->AssignInheritanceModel(RD);
     }
 
-    void HandleCXXStaticMemberVarInstantiation(VarDecl *VD) LLVM_CXX_OVERRIDE {
+    void HandleCXXStaticMemberVarInstantiation(VarDecl *VD) override {
       if (Diags->hasErrorOccurred()) return;
       if (parseOnly) return;
        Builder->HandleCXXStaticMemberVarInstantiation(VD);
     }
 
-    void HandleVTable(CXXRecordDecl *RD) LLVM_CXX_OVERRIDE {
+    void HandleVTable(CXXRecordDecl *RD) override {
        if (Diags->hasErrorOccurred()) return;
        if (parseOnly) return;
        Builder->HandleVTable(RD);
      }
 
-    ASTMutationListener *GetASTMutationListener() LLVM_CXX_OVERRIDE {
+    ASTMutationListener *GetASTMutationListener() override {
       if (Builder) return Builder->GetASTMutationListener();
       return nullptr;
     }
 
-    ASTDeserializationListener *GetASTDeserializationListener() LLVM_CXX_OVERRIDE {
+    ASTDeserializationListener *GetASTDeserializationListener() override {
       if (Builder) return Builder->GetASTDeserializationListener();
       return nullptr;
     }
 
-    void PrintStats() LLVM_CXX_OVERRIDE {
+    void PrintStats() override {
       if (Builder) Builder->PrintStats();
     }
 
-    bool shouldSkipFunctionBody(Decl *D) LLVM_CXX_OVERRIDE {
+    bool shouldSkipFunctionBody(Decl *D) override {
       if (Builder) return Builder->shouldSkipFunctionBody(D);
       return true;
     }
@@ -1057,7 +1057,7 @@ static void setupModule()
   llvm::LLVMContext& cx = info->module->getContext();
   // Create the TBAA root node
   {
-    LLVM_METADATA_OPERAND_TYPE* Ops[1];
+    llvm::Metadata* Ops[1];
     Ops[0] = llvm::MDString::get(cx, "Chapel types");
     info->tbaaRootNode = llvm::MDNode::get(cx, Ops);
   }
@@ -1890,7 +1890,7 @@ bool isBuiltinExternCFunction(const char* cname)
 
 static
 void addAggregateGlobalOps(const PassManagerBuilder &Builder,
-    LEGACY_PASS_MANAGER &PM) {
+    llvm::legacy::PassManagerBase &PM) {
   GenInfo* info = gGenInfo;
   if( fLLVMWideOpt ) {
     PM.add(createAggregateGlobalOpsOptPass(info->globalToWideInfo.globalSpace));
@@ -1899,7 +1899,7 @@ void addAggregateGlobalOps(const PassManagerBuilder &Builder,
 
 static
 void addGlobalToWide(const PassManagerBuilder &Builder,
-    LEGACY_PASS_MANAGER &PM) {
+    llvm::legacy::PassManagerBase &PM) {
   GenInfo* info = gGenInfo;
   if( fLLVMWideOpt ) {
     PM.add(createGlobalToWide(&info->globalToWideInfo, info->clangInfo->asmTargetLayoutStr));
@@ -1949,7 +1949,7 @@ bool getIrDumpExtensionPoint(llvmStageNum_t s,
 
 static
 void addDumpIrPass(const PassManagerBuilder &Builder,
-    LEGACY_PASS_MANAGER &PM) {
+    llvm::legacy::PassManagerBase &PM) {
   PM.add(createDumpIrPass(llvmPrintIrStageNum));
 }
 
@@ -2137,7 +2137,7 @@ void makeBinaryLLVM(void) {
           PassManagerBuilder::addGlobalExtension(
               point,
               [stage] (const PassManagerBuilder &Builder,
-                       LEGACY_PASS_MANAGER &PM) -> void {
+                       llvm::legacy::PassManagerBase &PM) -> void {
                 PM.add(createDumpIrPass(stage));
               });
       }

--- a/compiler/util/llvmDebug.cpp
+++ b/compiler/util/llvmDebug.cpp
@@ -60,9 +60,6 @@ http://llvm.org/docs/SourceLevelDebugging.html
 for more information on LLVM debug information.
 */
 
-// smooth changes in zero DIFlags
-#define FLAG_ZERO llvm::DINode::FlagZero
-
 // Note: All char strings must be the same size
 // Very hacky, but completely legal and functional. Only issue is that file_name 
 // will have garbage from beyond full_path.
@@ -209,7 +206,7 @@ llvm::DIType* debug_data::construct_type(Type *type)
             (PointeeTy->isSized()?
             8*layout.getABITypeAlignment(PointeeTy):
             8), /* AlignInBits */
-            FLAG_ZERO, /* Flags */
+            llvm::DINode::FlagZero, /* Flags */
             NULL, /* DerivedFrom */
             NULL /* Elements */
             );
@@ -298,7 +295,7 @@ llvm::DIType* debug_data::construct_type(Type *type)
                 layout.getTypeSizeInBits(fty),
                 8*layout.getABITypeAlignment(fty),
                 slayout->getElementOffsetInBits(this_class->getMemberGEP(field->cname)),
-                FLAG_ZERO,
+                llvm::DINode::FlagZero,
                 fditype);
 
               EltTys.push_back(mty);
@@ -312,7 +309,7 @@ llvm::DIType* debug_data::construct_type(Type *type)
               defLine, /* LineNumber */
               layout.getTypeSizeInBits(ty), /* SizeInBits */
               8*layout.getABITypeAlignment(ty), /* AlignInBits */
-              FLAG_ZERO, /* Flags */
+              llvm::DINode::FlagZero, /* Flags */
               derivedFrom, /* DerivedFrom */
               this->dibuilder.getOrCreateArray(EltTys) /* Elements */
               );
@@ -373,7 +370,7 @@ llvm::DIType* debug_data::construct_type(Type *type)
         layout.getTypeSizeInBits(fty),
         8*layout.getABITypeAlignment(fty),
         slayout->getElementOffsetInBits(this_class->getMemberGEP(field->cname)),
-        FLAG_ZERO,
+        llvm::DINode::FlagZero,
         fditype);
 
       EltTys.push_back(mty);
@@ -387,7 +384,7 @@ llvm::DIType* debug_data::construct_type(Type *type)
         defLine,
         layout.getTypeSizeInBits(ty),
         8*layout.getABITypeAlignment(ty),
-        FLAG_ZERO,
+        llvm::DINode::FlagZero,
         derivedFrom,
         this->dibuilder.getOrCreateArray(EltTys));
     
@@ -402,7 +399,7 @@ llvm::DIType* debug_data::construct_type(Type *type)
         defLine,
         layout.getTypeSizeInBits(ty),
         8*layout.getABITypeAlignment(ty),
-        FLAG_ZERO,
+        llvm::DINode::FlagZero,
         derivedFrom,
         this->dibuilder.getOrCreateArray(EltTys));
     
@@ -417,7 +414,7 @@ llvm::DIType* debug_data::construct_type(Type *type)
         defLine,
         layout.getTypeSizeInBits(ty),
         8*layout.getABITypeAlignment(ty),
-        FLAG_ZERO,
+        llvm::DINode::FlagZero,
         this->dibuilder.getOrCreateArray(EltTys));
         
       myTypeDescriptors[type] = N;
@@ -561,7 +558,7 @@ llvm::DISubprogram* debug_data::construct_function(FnSymbol *function)
     !function->hasFlag(FLAG_EXPORT), /* is local to unit */
     true, /* is definition */
     line_number, /* beginning of scope we start */
-    FLAG_ZERO, /* flags */
+    llvm::DINode::FlagZero, /* flags */
     optimized /* isOptimized */
     // TODO - in 3.8, do we need to pass Decl?
     );
@@ -677,7 +674,7 @@ llvm::DIVariable* debug_data::construct_formal_arg(ArgSymbol *argSym, unsigned A
       line_number, /*Lineno*/
       argSym_type, /*Type*/
       true,/*AlwaysPreserve, won't be removed when optimized*/
-      FLAG_ZERO /*Flags*/
+      llvm::DINode::FlagZero /*Flags*/
       );
   else {
     //Empty dbg node if the symbol type is unresolved

--- a/compiler/util/llvmGlobalToWide.cpp
+++ b/compiler/util/llvmGlobalToWide.cpp
@@ -1958,7 +1958,7 @@ bool containsGlobalPointers(unsigned gSpace, SmallSet<Type*, 10> & set, Type* t)
 
   // If it's something we've already enumerated,
   // it doesn't get to say yes.
-  if( llvm_small_set_insert(set, t) ) {
+  if( set.insert(t).second ) {
     // We added it to the set, we can continue.
   } else {
     // It was already in the set, don't bother


### PR DESCRIPTION
Supporting old versions of LLVM caused considerable clutter (over 500 lines worth).  This change removes the old `#ifdef`s.  Where reasonable, it also further consolidates the code once the conditionals are removed.

This implements part of #6993 .

While testing this, I ran up against `ClangInfo` being declared as a struct in one place and a class in another.  To get it to compile with the latest Mac Clang, I had to make it consistently a struct.

The following tests were run with both LLVM 4 and LLVM 5:
Passed full local testing with `--llvm` on linux64.
Passed the hellos with `--llvm`, with and without `--fast`, plus test/llvm on a Mac building LLVM with clang.