### PR TITLE
Fix the post-parse check for yields and returns from module scope

### DIFF
--- a/compiler/passes/checkParsed.cpp
+++ b/compiler/passes/checkParsed.cpp
@@ -352,11 +352,12 @@ static void nestedName(ModuleSymbol* mod) {
 
 static void
 checkModule(ModuleSymbol* mod) {
-  for_alist(stmt, mod->block->body) {
-    if (CallExpr* call = toCallExpr(stmt)) {
+  std::vector<CallExpr*> calls;
+  collectCallExprs(mod->block, calls);
+  for_vector(CallExpr, call, calls) {
+    if (call->parentSymbol == mod) {
       if (call->isPrimitive(PRIM_RETURN)) {
         USR_FATAL_CONT(call, "return statement is not in a function or iterator");
-
       } else if (call->isPrimitive(PRIM_YIELD)) {
         USR_FATAL_CONT(call, "yield statement is outside an iterator");
       }

--- a/test/functions/iterators/bharshbarg/moduleYield.future
+++ b/test/functions/iterators/bharshbarg/moduleYield.future
@@ -1,1 +1,0 @@
-bug: compiler fails to warn about a yield outside a loop and runs into an internal error


### PR DESCRIPTION
The checkModule function was walking the statements in the module's body
looking for yields and returns to issue errors about.  However, it didn't
dive into any statements, so skipped over whole BlockStmts without looking
inside of them.

Update it to look at all of the CallExprs in the module body that have the
module itself as a parentSymbol.

Remove a .future that yielded from the module level.  This will close #7617.