### PR TITLE
Avoid baseline error for chpl__defaultHash(range)

### DIFF
--- a/modules/internal/DefaultAssociative.chpl
+++ b/modules/internal/DefaultAssociative.chpl
@@ -859,11 +859,11 @@ module DefaultAssociative {
     use Reflection;
     var ret : uint;
     for param i in 1..numFields(r.type) {
-      const ref field = getField(r, i);
-      if isVoidType(field.type) == false &&
-         getFieldName(r.type, i) != "_promotionType" &&
+      if isParam(getField(r, i)) == false &&
          isType(getField(r, i)) == false &&
-         isParam(getField(r, i)) == false {
+         isVoidType(getField(r, i).type) == false &&
+         getFieldName(r.type, i) != "_promotionType" {
+        const ref field = getField(r, i);
         const fieldHash = chpl__defaultHash(field);
         if i == 1 then
           ret = fieldHash;


### PR DESCRIPTION
This PR changes the order of conditionals to work around baseline error for getField and enums. The original code could incorrectly attempt to acquire a const-reference to a param/type field, which could result in odd errors under baseline. Overall this change results in a more principled implementation.

Testing:
 - [x] full local