### PR TITLE
Fix code generation bug for wide-ref tuples passed to const-in tuples

### DIFF
--- a/compiler/passes/resolveIntents.cpp
+++ b/compiler/passes/resolveIntents.cpp
@@ -238,6 +238,10 @@ void resolveArgIntent(ArgSymbol* arg) {
     } else if (intent == INTENT_IN) {
       // MPF note: check types/range/ferguson/range-begin.chpl
       // if you try to add INTENT_CONST_IN here.
+      //
+      // BHARSH: Update insertWideReferences.fixTupleFormal and the following
+      // test if INTENT_CONST_IN is added here:
+      //   multilocale/bharshbarg/constInTuple.chpl
 
       // Resolution already handled copying for INTENT_IN for
       // records/unions.

--- a/test/multilocale/bharshbarg/constInTuple.future
+++ b/test/multilocale/bharshbarg/constInTuple.future
@@ -1,1 +1,0 @@
-bug: failure to compile generated code with inline wrapper around function with 'const in' tuple formal


### PR DESCRIPTION
A tuple formal with the 'const in' intent was left with an 'in' intent
by resolveIntents. A program can be written such that the actual
corresponding to the formal was a wide reference. For a normal record
this would not be a problem, as codegen would transform this pattern
such that the actual was dereferenced before the function call.

Tuples are different because codegen transforms tuple formals into
references (as decided by the 'argMustUseCPtr' function). This means
that we'll end up passing a wide-reference to a narrow reference, which
is currently unhandled by codegen.

The more principled solution would be to adjust resolveIntents to treat
'in' and 'const in' more similarly, but that seems challenging to me at
this time. The easiest fix, implemented by this commit, is to modify
'insertWideReferences' to insert a PRIM_DEREF when it sees this pattern.

Resolves #7619.

Testing:
- [x] full no-local
- [x] full gasnet