### PR TITLE
Add annotations for the week preceding Oct 26th, 2017

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -272,7 +272,7 @@ all:
       config: 16 node XC
   09/19/17:
     - Fix LICM bug (#7371)
-  10/20/17:
+  10/21/17:
     - Reduce wide pointer overhead for sparse domains/arrays (#7627)
 
 
@@ -616,12 +616,12 @@ LCALS-raw-short: &lcals-base
     - Stop throwing --dataParMinGranularity=1000 (#4917)
   12/10/16:
     - Throw --no-ieee-float for LCALS (#5001)
+  10/24/17:
+    - Fix LCALS inner_prod kernel (#7632)
 LCALS-raw-medium:
   <<: *lcals-base
 LCALS-raw-long:
   <<: *lcals-base
-  10/23/17:
-    - Fix LCALS inner_prod kernel (#7632)
 LCALS-parallel-short:
   <<: *lcals-base
 LCALS-parallel-medium:

--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -272,6 +272,8 @@ all:
       config: 16 node XC
   09/19/17:
     - Fix LICM bug (#7371)
+  10/20/17:
+    - Reduce wide pointer overhead for sparse domains/arrays (#7627)
 
 
 AllCompTime:
@@ -618,6 +620,8 @@ LCALS-raw-medium:
   <<: *lcals-base
 LCALS-raw-long:
   <<: *lcals-base
+  10/23/17:
+    - Fix LCALS inner_prod kernel (#7632)
 LCALS-parallel-short:
   <<: *lcals-base
 LCALS-parallel-medium:


### PR DESCRIPTION
Covers the restoration of the LCALS inner_prod performance with the bugfix, and
the improvement to no-local testing due to BHarsh's reduction of wide pointer
overhead.