### PR TITLE
Try to fix our "don't rerun autoconf" code in qthread/hwloc Makefiles

### DIFF
--- a/third-party/hwloc/Makefile
+++ b/third-party/hwloc/Makefile
@@ -62,6 +62,7 @@ hwloc-config: FORCE
 #
 	cd $(HWLOC_SUBDIR) && touch -c configure.ac
 	cd $(HWLOC_SUBDIR) && find . -name "*.m4" | xargs touch 
+	sleep 1
 	cd $(HWLOC_SUBDIR) && touch -c aclocal.m4
 	sleep 1
 	cd $(HWLOC_SUBDIR) && touch configure

--- a/third-party/hwloc/Makefile
+++ b/third-party/hwloc/Makefile
@@ -63,6 +63,7 @@ hwloc-config: FORCE
 	cd $(HWLOC_SUBDIR) && touch -c configure.ac
 	cd $(HWLOC_SUBDIR) && find . -name "*.m4" | xargs touch 
 	cd $(HWLOC_SUBDIR) && touch -c aclocal.m4
+	sleep 1
 	cd $(HWLOC_SUBDIR) && touch configure
 	cd $(HWLOC_SUBDIR) && find . -name "*.in" | xargs touch
 #

--- a/third-party/qthread/Makefile
+++ b/third-party/qthread/Makefile
@@ -113,6 +113,7 @@ qthread-config: FORCE
 #
 	cd $(QTHREAD_SUBDIR) && touch -c configure.ac
 	cd $(QTHREAD_SUBDIR) && find . -name "*.m4" | xargs touch
+	sleep 1
 	cd $(QTHREAD_SUBDIR) && touch -c aclocal.m4
 	sleep 1
 	cd $(QTHREAD_SUBDIR) && touch configure

--- a/third-party/qthread/Makefile
+++ b/third-party/qthread/Makefile
@@ -114,6 +114,7 @@ qthread-config: FORCE
 	cd $(QTHREAD_SUBDIR) && touch -c configure.ac
 	cd $(QTHREAD_SUBDIR) && find . -name "*.m4" | xargs touch
 	cd $(QTHREAD_SUBDIR) && touch -c aclocal.m4
+	sleep 1
 	cd $(QTHREAD_SUBDIR) && touch configure
 	cd $(QTHREAD_SUBDIR) && find . -name "*.in" | xargs touch
 


### PR DESCRIPTION
Since we store our our third-party libraries untarred they lose the timestamps
they had when they were tarballs. For packages that use autoconf/configure, we
try to touch some files in a certain order to prevent autoconf from rerunning,
but we never seem to get this quite right.

A user ran into another case where it seems like we're touching files too fast
for the filesystem's timestamp resolution. This just adds a sleep before we
touch configure to ensure it's newer than the m4 files. This partially reverts
some changes in #69 and #4504

This should (hopefully) fix https://github.com/chapel-lang/chapel/issues/7613

Adding sleeps isn't a satisfying solution, so I also opened https://github.com/chapel-lang/chapel/issues/7665