### PR TITLE
Add an error when creating a ref to a type

### DIFF
--- a/compiler/passes/checkResolved.cpp
+++ b/compiler/passes/checkResolved.cpp
@@ -448,12 +448,8 @@ checkBadAddrOf(CallExpr* call)
           USR_FATAL_CONT(call, "Cannot set a reference to a param variable.");
         } else if (lhsRef && !lhsConst) {
           if (rhs->symbol()->hasFlag(FLAG_EXPR_TEMP) ||
-              rhs->symbol()->isConstant() || rhsParam) {
-            if (rhs->symbol()->isImmediate()) {
-              USR_FATAL_CONT(call, "Cannot set a non-const reference to a literal value.");
-            } else {
-              USR_FATAL_CONT(call, "Cannot set a non-const reference to a const variable.");
-            }
+              rhs->symbol()->isConstant()) {
+            USR_FATAL_CONT(call, "Cannot set a non-const reference to a const variable.");
           }
         }
       }

--- a/compiler/passes/checkResolved.cpp
+++ b/compiler/passes/checkResolved.cpp
@@ -436,7 +436,14 @@ checkBadAddrOf(CallExpr* call)
         bool lhsRef   = lhs && lhs->symbol()->hasFlag(FLAG_REF_VAR);
         bool lhsConst = lhs && lhs->symbol()->hasFlag(FLAG_CONST);
 
-        if (lhsRef && !lhsConst) {
+        bool rhsType = rhs->symbol()->hasFlag(FLAG_TYPE_VARIABLE);
+        // Also detect runtime type variables
+        if (rhs->symbol()->type->symbol->hasFlag(FLAG_RUNTIME_TYPE_VALUE))
+          rhsType = true;
+
+        if (lhsRef && rhsType) {
+          USR_FATAL_CONT(call, "Cannot set a reference to a type variable.");
+        } else if (lhsRef && !lhsConst) {
           if (rhs->symbol()->hasFlag(FLAG_EXPR_TEMP) ||
               rhs->symbol()->isConstant() || rhs->symbol()->isParameter()) {
             if (rhs->symbol()->isImmediate()) {

--- a/compiler/passes/checkResolved.cpp
+++ b/compiler/passes/checkResolved.cpp
@@ -437,15 +437,18 @@ checkBadAddrOf(CallExpr* call)
         bool lhsConst = lhs && lhs->symbol()->hasFlag(FLAG_CONST);
 
         bool rhsType = rhs->symbol()->hasFlag(FLAG_TYPE_VARIABLE);
+        bool rhsParam = rhs->symbol()->isParameter();
         // Also detect runtime type variables
         if (rhs->symbol()->type->symbol->hasFlag(FLAG_RUNTIME_TYPE_VALUE))
           rhsType = true;
 
         if (lhsRef && rhsType) {
           USR_FATAL_CONT(call, "Cannot set a reference to a type variable.");
+        } else if (lhsRef && rhsParam) {
+          USR_FATAL_CONT(call, "Cannot set a reference to a param variable.");
         } else if (lhsRef && !lhsConst) {
           if (rhs->symbol()->hasFlag(FLAG_EXPR_TEMP) ||
-              rhs->symbol()->isConstant() || rhs->symbol()->isParameter()) {
+              rhs->symbol()->isConstant() || rhsParam) {
             if (rhs->symbol()->isImmediate()) {
               USR_FATAL_CONT(call, "Cannot set a non-const reference to a literal value.");
             } else {

--- a/test/param/bharshbarg/refToGetFieldType.future
+++ b/test/param/bharshbarg/refToGetFieldType.future
@@ -1,1 +1,0 @@
-bug: Compiler allows const references to type/param fields

--- a/test/param/bharshbarg/refToGetFieldType.good
+++ b/test/param/bharshbarg/refToGetFieldType.good
@@ -1,1 +1,4 @@
-refToGetFieldType.chpl:14: illegal assignment of type to value
+refToGetFieldType.chpl:14: error: Cannot set a reference to a type variable.
+refToGetFieldType.chpl:19: error: Cannot set a reference to a type variable.
+refToGetFieldType.chpl:19: error: Cannot set a reference to a type variable.
+refToGetFieldType.chpl:19: error: Cannot set a reference to a param variable.

--- a/test/types/type_variables/ferguson/ref-type-error.chpl
+++ b/test/types/type_variables/ferguson/ref-type-error.chpl
@@ -1,0 +1,15 @@
+record R {
+  type A;
+}
+
+var r = new R(int);
+var A = [1,2,3];
+
+// each of these should be an error
+      ref a = r.A;
+const ref b = r.A;
+      ref e = A.type;
+const ref f = A.type;
+
+writeln(a);
+writeln(b);

--- a/test/types/type_variables/ferguson/ref-type-error.chpl
+++ b/test/types/type_variables/ferguson/ref-type-error.chpl
@@ -4,12 +4,15 @@ record R {
 
 var r = new R(int);
 var A = [1,2,3];
+param p = 1;
 
 // each of these should be an error
       ref a = r.A;
 const ref b = r.A;
       ref e = A.type;
 const ref f = A.type;
+      ref g = p;
+const ref h = p;
 
 writeln(a);
 writeln(b);

--- a/test/types/type_variables/ferguson/ref-type-error.good
+++ b/test/types/type_variables/ferguson/ref-type-error.good
@@ -1,0 +1,4 @@
+ref-type-error.chpl:9: error: Cannot set a reference to a type variable.
+ref-type-error.chpl:10: error: Cannot set a reference to a type variable.
+ref-type-error.chpl:11: error: Cannot set a reference to a type variable.
+ref-type-error.chpl:12: error: Cannot set a reference to a type variable.

--- a/test/types/type_variables/ferguson/ref-type-error.good
+++ b/test/types/type_variables/ferguson/ref-type-error.good
@@ -1,4 +1,6 @@
-ref-type-error.chpl:9: error: Cannot set a reference to a type variable.
 ref-type-error.chpl:10: error: Cannot set a reference to a type variable.
 ref-type-error.chpl:11: error: Cannot set a reference to a type variable.
 ref-type-error.chpl:12: error: Cannot set a reference to a type variable.
+ref-type-error.chpl:13: error: Cannot set a reference to a type variable.
+ref-type-error.chpl:14: error: Cannot set a reference to a param variable.
+ref-type-error.chpl:15: error: Cannot set a reference to a param variable.

--- a/test/variables/kbrady/ref-to-literal.good
+++ b/test/variables/kbrady/ref-to-literal.good
@@ -1,1 +1,1 @@
-ref-to-literal.chpl:1: error: Cannot set a non-const reference to a literal value.
+ref-to-literal.chpl:1: error: Cannot set a reference to a param variable.


### PR DESCRIPTION
Resolves #7635.
Adds an error for something like `const ref x = int`.

- [x] full local futures testing

Reviewed by @benharsh - thanks!