### PR TITLE
Add skipif for StencilDist future

### DIFF
--- a/test/distributions/bharshbarg/stencil/writeSlice.skipif
+++ b/test/distributions/bharshbarg/stencil/writeSlice.skipif
@@ -1,0 +1,1 @@
+CHPL_COMM == none


### PR DESCRIPTION
I neglected to ensure that this test would only run with multiple locales, which made this test appear to pass on single-locale configs.