### PR TITLE
Print where clauses

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -2213,7 +2213,7 @@ const char* toString(FnSymbol* fn) {
     }
   }
 
-  if (fn->where) {
+  if (fn->where && fn->where->body.length == 1) {
     AstToText info;
     info.appendExpr(fn->where->body.only(), false);
     retval = astr(retval, " where ", info.text().c_str());

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -2085,12 +2085,7 @@ const char* toString(FnSymbol* fn) {
   const char* retval = NULL;
 
   if (fn->userString != NULL) {
-    if (developer == true) {
-      retval = astr(fn->userString, " [", istr(fn->id), "]");
-    } else {
-      retval = fn->userString;
-    }
-
+    retval = fn->userString;
   } else {
     int  start      =     1;
     bool first      =  true;
@@ -2216,10 +2211,16 @@ const char* toString(FnSymbol* fn) {
     if (skipParens == false) {
       retval = astr(retval, ")");
     }
+  }
 
-    if (developer  == true) {
-      retval = astr(retval, " [", istr(fn->id), "]");
-    }
+  if (fn->where) {
+    AstToText info;
+    info.appendExpr(fn->where->body.only(), false);
+    retval = astr(retval, " where ", info.text().c_str());
+  }
+
+  if (developer) {
+    retval = astr(retval, " [", istr(fn->id), "]");
   }
 
   return retval;

--- a/test/classes/initializers/records/where-clause4.good
+++ b/test/classes/initializers/records/where-clause4.good
@@ -1,3 +1,3 @@
 where-clause4.chpl:12: error: unresolved call 'Foo.init(3.4)'
-where-clause4.chpl:5: note: candidates are: Foo.init(xVal)
+where-clause4.chpl:5: note: candidates are: Foo.init(xVal) where isInt(xVal)
 deleted module lines

--- a/test/classes/initializers/where-clause4.good
+++ b/test/classes/initializers/where-clause4.good
@@ -1,2 +1,2 @@
 where-clause4.chpl:12: error: unresolved call '_new(type Foo, 3.4)'
-where-clause4.chpl:2: note: candidates are: _new(type chpl_t, xVal)
+where-clause4.chpl:2: note: candidates are: _new(type chpl_t, xVal) where isInt(xVal)

--- a/test/functions/diten/unresolvedWhere.chpl
+++ b/test/functions/diten/unresolvedWhere.chpl
@@ -1,0 +1,3 @@
+proc foo(x) where isIntegral(x) { }
+proc foo(x) where isReal(x) { }
+foo("bar");

--- a/test/functions/diten/unresolvedWhere.good
+++ b/test/functions/diten/unresolvedWhere.good
@@ -1,0 +1,3 @@
+unresolvedWhere.chpl:3: error: unresolved call 'foo("bar")'
+unresolvedWhere.chpl:1: note: candidates are: foo(x) where isIntegral(x)
+unresolvedWhere.chpl:2: note:                 foo(x) where isReal(x)

--- a/test/functions/diten/whereClauseIgnored.good
+++ b/test/functions/diten/whereClauseIgnored.good
@@ -1,2 +1,2 @@
 whereClauseIgnored.chpl:8: error: unresolved call 'f(3)'
-whereClauseIgnored.chpl:1: note: candidates are: f(x: int)
+whereClauseIgnored.chpl:1: note: candidates are: f(x: int) where false

--- a/test/functions/iterators/thomasvandoren/ParallelOnly.bad
+++ b/test/functions/iterators/thomasvandoren/ParallelOnly.bad
@@ -1,2 +1,2 @@
 ParallelOnly.chpl:13: error: unresolved call 'myIter()'
-ParallelOnly.chpl:3: note: candidates are: myIter(param tag: iterKind)
+ParallelOnly.chpl:3: note: candidates are: myIter(param tag: iterKind) where tag==iterKind.standalone

--- a/test/functions/whereClauses/whereClauseArgMismatch.good
+++ b/test/functions/whereClauses/whereClauseArgMismatch.good
@@ -1,2 +1,2 @@
 whereClauseArgMismatch.chpl:9: error: unresolved call 'foo(1.2)'
-whereClauseArgMismatch.chpl:1: note: candidates are: foo(x: uint)
+whereClauseArgMismatch.chpl:1: note: candidates are: foo(x: uint) where bar()

--- a/test/functions/whereClauses/whereClauseCantFold.good
+++ b/test/functions/whereClauses/whereClauseCantFold.good
@@ -1,2 +1,2 @@
 whereClauseCantFold.chpl:5: error: unresolved call 'foo(1.2)'
-whereClauseCantFold.chpl:1: note: candidates are: foo(param x: uint(8))
+whereClauseCantFold.chpl:1: note: candidates are: foo(param x: uint(8)) where x==0

--- a/test/functions/whereClauses/whereClauseParamArgMismatch.good
+++ b/test/functions/whereClauses/whereClauseParamArgMismatch.good
@@ -1,2 +1,2 @@
 whereClauseParamArgMismatch.chpl:10: error: unresolved call 'foo(1.2)'
-whereClauseParamArgMismatch.chpl:1: note: candidates are: foo(param x: uint)
+whereClauseParamArgMismatch.chpl:1: note: candidates are: foo(param x: uint) where bar()

--- a/test/functions/whereClauses/whereClauseParamArgMismatch2.good
+++ b/test/functions/whereClauses/whereClauseParamArgMismatch2.good
@@ -1,2 +1,2 @@
 whereClauseParamArgMismatch2.chpl:10: error: unresolved call 'foo(1.2)'
-whereClauseParamArgMismatch2.chpl:1: note: candidates are: foo(param x: uint(8))
+whereClauseParamArgMismatch2.chpl:1: note: candidates are: foo(param x: uint(8)) where bar()

--- a/test/functions/whereClauses/whereClauseParamArgMismatch3.good
+++ b/test/functions/whereClauses/whereClauseParamArgMismatch3.good
@@ -1,2 +1,2 @@
 whereClauseParamArgMismatch3.chpl:10: error: unresolved call 'foo(1.2)'
-whereClauseParamArgMismatch3.chpl:1: note: candidates are: foo(param x: uint(64))
+whereClauseParamArgMismatch3.chpl:1: note: candidates are: foo(param x: uint(64)) where bar()


### PR DESCRIPTION
Update toString(FnSymbol*) to include the where clause if it exists

This will cause the where clause to be included in messages such as the
candidate list in an unresolved call error.

Updated a handful of test .good and .bad files to include where clauses.

This is requested in issue #5690.