### PR TITLE
Add an OFI launcher

### DIFF
--- a/doc/rst/usingchapel/launcher.rst
+++ b/doc/rst/usingchapel/launcher.rst
@@ -50,8 +50,9 @@ Launcher Name        Description
 amudprun             GASNet launcher for programs running over UDP        
 aprun                Cray application launcher using aprun                
 gasnetrun_ibv        GASNet launcher for programs running over Infiniband 
-gasnetrun_psm        GASNet launcher for programs running over OmniPath
 gasnetrun_mpi        GASNet launcher for programs using the MPI conduit   
+gasnetrun_ofi        GASNet launcher for programs using the OFI conduit
+gasnetrun_psm        GASNet launcher for programs running over OmniPath
 lsf-gasnetrun_ibv    GASNet launcher using LSF (bsub) over Infiniband     
 pbs-aprun            Cray application launcher using PBS (qsub) + aprun   
 pbs-gasnetrun_ibv    GASNet launcher using PBS (qsub) over Infiniband     
@@ -85,6 +86,7 @@ follows:
   CHPL_COMM_SUBSTRATE=ibv  gasnetrun_ibv
   CHPL_COMM_SUBSTRATE=mpi  gasnetrun_mpi
   CHPL_COMM_SUBSTRATE=mxm  gasnetrun_ibv
+  CHPL_COMM_SUBSTRATE=ofi  gasnetrun_ofi
   CHPL_COMM_SUBSTRATE=psm  gasnetrun_psm
   CHPL_COMM_SUBSTRATE=smp  smp
   CHPL_COMM_SUBSTRATE=udp  amudprun

--- a/doc/rst/usingchapel/multilocale.rst
+++ b/doc/rst/usingchapel/multilocale.rst
@@ -183,6 +183,7 @@ aries                fast
 gemini               fast
 ibv                  large
 portals              fast
+smp                  fast
 other                everything
 ===================  ====================
 

--- a/runtime/src/launch/gasnetrun_ofi/Makefile
+++ b/runtime/src/launch/gasnetrun_ofi/Makefile
@@ -1,0 +1,41 @@
+# Copyright 2004-2017 Cray Inc.
+# Other additional copyright holders may be indicated within.
+# 
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# 
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+RUNTIME_ROOT = ../../..
+RUNTIME_SUBDIR = src/launch/gasnetrun_ofi
+
+ifndef CHPL_MAKE_HOME
+export CHPL_MAKE_HOME=$(shell pwd)/$(RUNTIME_ROOT)/..
+endif
+
+#
+# standard header
+#
+include $(RUNTIME_ROOT)/make/Makefile.runtime.head
+
+LAUNCH_OBJDIR = $(LAUNCHER_OBJDIR)
+include Makefile.share
+
+TARGETS = \
+	$(LAUNCHER_OBJS) \
+
+include $(RUNTIME_ROOT)/make/Makefile.runtime.subdirrules
+
+#
+# standard footer
+#
+include $(RUNTIME_ROOT)/make/Makefile.runtime.foot

--- a/runtime/src/launch/gasnetrun_ofi/Makefile.include
+++ b/runtime/src/launch/gasnetrun_ofi/Makefile.include
@@ -1,0 +1,24 @@
+# Copyright 2004-2017 Cray Inc.
+# Other additional copyright holders may be indicated within.
+# 
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# 
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+LAUNCH_SUBDIR = src/launch/gasnetrun_ofi
+
+LAUNCH_OBJDIR = $(LAUNCHER_BUILD)/$(LAUNCH_SUBDIR)
+
+ALL_SRCS += $(CURDIR)/$(LAUNCH_SUBDIR)/*.c
+
+include $(RUNTIME_ROOT)/$(LAUNCH_SUBDIR)/Makefile.share

--- a/runtime/src/launch/gasnetrun_ofi/Makefile.share
+++ b/runtime/src/launch/gasnetrun_ofi/Makefile.share
@@ -1,0 +1,31 @@
+# Copyright 2004-2017 Cray Inc.
+# Other additional copyright holders may be indicated within.
+# 
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# 
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+LAUNCHER_SRCS = \
+        launch-gasnetrun_ofi.c \
+
+#
+# is this the right time to set this variable?  Or is user code
+# compile time
+#
+RUNTIME_CFLAGS += -DLAUNCH_PATH="$(THIRD_PARTY_DIR)/gasnet/$(GASNET_INSTALL_SUBDIR)/bin/"
+
+SVN_SRCS = $(LAUNCHER_SRCS)
+SRCS = $(SVN_SRCS)
+
+LAUNCHER_OBJS = \
+	$(LAUNCHER_SRCS:%.c=$(LAUNCH_OBJDIR)/%.o)

--- a/runtime/src/launch/gasnetrun_ofi/launch-gasnetrun_ofi.c
+++ b/runtime/src/launch/gasnetrun_ofi/launch-gasnetrun_ofi.c
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2004-2017 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ * 
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * 
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include "chpllaunch.h"
+#include "chpl-mem.h"
+#include "error.h"
+
+#define LAUNCH_PATH_HELP WRAP_TO_STR(LAUNCH_PATH)
+#define WRAP_TO_STR(x) TO_STR(x)
+#define TO_STR(x) #x
+
+// TODO: Un-hard-code this stuff:
+
+static char _nlbuf[16];
+static char** chpl_launch_create_argv(const char *launch_cmd,
+                                      int argc, char* argv[],
+                                      int32_t numLocales) {
+  const int largc = 5;
+  char *largv[largc];
+
+  largv[0] = (char *) launch_cmd;
+  largv[1] = (char *) "-n";
+  sprintf(_nlbuf, "%d", numLocales);
+  largv[2] = _nlbuf;
+  largv[3] = (char*) "-E";
+  largv[4] = chpl_get_enviro_keys(',');
+
+  return chpl_bundle_exec_args(argc, argv, largc, largv);
+}
+
+
+int chpl_launch(int argc, char* argv[], int32_t numLocales) {
+  int len = strlen(WRAP_TO_STR(LAUNCH_PATH)) + strlen("gasnetrun_ofi") + 1;
+  char *cmd = chpl_mem_allocMany(len, sizeof(char), CHPL_RT_MD_COMMAND_BUFFER, -1, 0);
+  sprintf(cmd, "%sgasnetrun_ofi", WRAP_TO_STR(LAUNCH_PATH));
+
+  return chpl_launch_using_exec(cmd,
+                                chpl_launch_create_argv(cmd, argc, argv,
+                                                        numLocales),
+                                argv[0]);
+}
+
+
+int chpl_launch_handle_arg(int argc, char* argv[], int argNum,
+                           int32_t lineno, int32_t filename) {
+  return 0;
+}
+
+
+void chpl_launch_print_help(void) {
+}

--- a/util/chplenv/chpl_launcher.py
+++ b/util/chplenv/chpl_launcher.py
@@ -60,6 +60,10 @@ def get():
                     launcher_val = 'gasnetrun_ibv'
             elif substrate_val == 'mxm':
                 launcher_val = 'gasnetrun_ibv'
+            elif substrate_val == 'ofi':
+                launcher_val = 'gasnetrun_ofi'
+            elif substrate_val == 'psm':
+                launcher_val = 'gasnetrun_psm'
             elif substrate_val == 'lapi':
                 # our loadleveler launcher is not yet portable/stable/flexible
                 # enough to serve as a good default


### PR DESCRIPTION
Add a gasnetrun_ofi launcher that's a code clone of gasnetrun_{psm, mpi, ibv}
launchers.

We default to CHPL_LAUNCHER=gasnetrun_ofi for CHPL_COMM_SUBSTRATE=ofi. While I
was here I also made CHPL_LAUNCHER=gasnetrun_psm for CHPL_COMM_SUBSTRATE=psm

Tested the ofi launcher locally on my mac with the ofi sockets profider. Tested
psm on an omnipath system. We need regular testing for both of these configs,
but they work well enough to make them defaults.

This resolves https://github.com/chapel-lang/chapel/issues/7061