### PR TITLE
Remove uses of _value in SSCA2

### DIFF
--- a/test/release/examples/benchmarks/ssca2/SSCA2_Modules/analyze_torus_graphs_stencil_rep_v1.chpl
+++ b/test/release/examples/benchmarks/ssca2/SSCA2_Modules/analyze_torus_graphs_stencil_rep_v1.chpl
@@ -47,18 +47,11 @@ module analyze_torus_graphs {
           yield neighbors(n);
     }
 
-    // Simply forward the domain's parallel iterator
     iter FilteredNeighbors( v : index (vertices), param tag: iterKind)
-    where tag == iterKind.leader {
-      for block in torus_stencil._value.these(tag) do
-        yield block;
-    }
-
-    iter FilteredNeighbors( v : index (vertices), param tag: iterKind, followThis)
-    where tag == iterKind.follower {
+    where tag == iterKind.standalone {
       const ref neighbors = Neighbors[v];
       const ref weights = edge_weight[v];
-      for n in torus_stencil._value.these(tag, followThis) do
+      forall n in torus_stencil do
         if (FILTERING && weights(n)%8 != 0) || !FILTERING then
           yield neighbors(n);
     }
@@ -72,18 +65,11 @@ module analyze_torus_graphs {
         yield (neighbors(n), weights(n));
     }
 
-    // Simply forward the domain's parallel iterator
     iter NeighborPairs( v : index (vertices), param tag: iterKind)
-    where tag == iterKind.leader {
-      for block in torus_stencil._value.these(tag) do
-        yield block;
-    }
-
-    iter NeighborPairs( v : index (vertices), param tag: iterKind, followThis)
-    where tag == iterKind.follower {
+    where tag == iterKind.standalone {
       const ref neighbors = Neighbors[v];
       const ref weights = edge_weight[v];
-      for n in torus_stencil._value.these(tag, followThis) do
+      forall n in torus_stencil do
         yield (neighbors(n), weights(n));
     }
 

--- a/test/release/examples/benchmarks/ssca2/SSCA2_Modules/io_RMAT_graph.chpl
+++ b/test/release/examples/benchmarks/ssca2/SSCA2_Modules/io_RMAT_graph.chpl
@@ -212,8 +212,8 @@ repfiles[repfileST2] = createGraphFile(snapshot_prefix, START_FILENAME, rea);
     }
 
    if DISTRIBUTION_TYPE == "BLOCK" && IOsingleTaskPerLocale {
-      coforall locDom in GRow._value.dom.locDoms do on locDom {
-        const myIDs = locDom.myBlock.dim(1);
+      coforall loc in GRow.targetLocales() do on loc {
+        const myIDs = GRow.localSubdomain().dim(1);
 
         // All work is done in graphReaderReal() iterator.
         for graphReaderReal(GRow, uxIDs, VType, vCount, eCount, repfiles,

--- a/test/studies/ssca2/graphio/analyze_RMAT_graph_associative_array.chpl
+++ b/test/studies/ssca2/graphio/analyze_RMAT_graph_associative_array.chpl
@@ -91,16 +91,9 @@ proc  generate_and_analyze_associative_array_RMAT_graph_representation {
         yield w;}  // var iterator to avoid a copy
 
     // Simply forward the domain's parallel iterator
-    // FYI: no fast follower opt
     iter   edge_weight(v : index (vertices), param tag: iterKind)
-    where tag == iterKind.leader {
-      for block in Row(v).Weight._value.these(tag) do
-        yield block;
-    }
-
-    iter   edge_weight(v : index (vertices), param tag: iterKind, followThis)
-    where tag == iterKind.follower {
-      for elem in Row(v).Weight._value.these(tag, followThis) do
+    where tag == iterKind.standalone {
+      forall elem in Row(v).Weight do
         yield elem;
     }
 


### PR DESCRIPTION
Most uses of _value were used to forward iterators. These were
leader/follower iterators that were never zipped, and so could be more
elegantly expressed as standalone iterators with a natural forall-loop
instead of '_value.these(tag)'.

Also replaced a couple of _value uses with ``targetLocales`` and
``localSubdomain``.

Testing:
- [x] full local
- [x] full gasnet
- [x] 16-node-xc performance