### PR TITLE
caches: Drop the unused caches ordersCache and coercionsCache

### DIFF
--- a/compiler/resolution/caches.cpp
+++ b/compiler/resolution/caches.cpp
@@ -1,15 +1,15 @@
 /*
  * Copyright 2004-2017 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,39 +17,44 @@
  * limitations under the License.
  */
 
-#include "astutil.h"
 #include "caches.h"
+
+#include "astutil.h"
 #include "stmt.h"
 #include "stringutil.h"
 
+
+/************************************* | **************************************
+*                                                                             *
+*                                                                             *
+*                                                                             *
+************************************** | *************************************/
+
+SymbolMapCache genericsCache;
+SymbolMapCache promotionsCache;
+
+static bool isCacheEntryMatch(SymbolMap* s1, SymbolMap* s2);
 
 SymbolMapCacheEntry::SymbolMapCacheEntry(FnSymbol* ifn, SymbolMap* imap) :
   fn(ifn), map(*imap) { }
 
 
 void
-addCache(SymbolMapCache& cache, FnSymbol* oldFn, FnSymbol* fn, SymbolMap* map) {
+addCache(SymbolMapCache& cache,
+         FnSymbol*       oldFn,
+         FnSymbol*       fn,
+         SymbolMap*      map) {
   Vec<SymbolMapCacheEntry*>* entries = cache.get(oldFn);
-  SymbolMapCacheEntry* entry = new SymbolMapCacheEntry(fn, map);
+  SymbolMapCacheEntry*       entry   = new SymbolMapCacheEntry(fn, map);
+
   if (entries) {
     entries->add(entry);
+
   } else {
     entries = new Vec<SymbolMapCacheEntry*>();
     entries->add(entry);
     cache.put(oldFn, entries);
   }
-}
-
-
-static bool
-isCacheEntryMatch(SymbolMap* s1, SymbolMap* s2) {
-  form_Map(SymbolMapElem, e, *s1)
-    if (s2->get(e->key) != e->value)
-      return false;
-  form_Map(SymbolMapElem, e, *s2)
-    if (s1->get(e->key) != e->value)
-      return false;
-  return true;
 }
 
 
@@ -66,7 +71,10 @@ checkCache(SymbolMapCache& cache, FnSymbol* oldFn, SymbolMap* map) {
 
 
 void
-replaceCache(SymbolMapCache& cache, FnSymbol* oldFn, FnSymbol* fn, SymbolMap* map) {
+replaceCache(SymbolMapCache& cache,
+             FnSymbol*       oldFn,
+             FnSymbol*       fn,
+             SymbolMap*      map) {
   if (Vec<SymbolMapCacheEntry*>* entries = cache.get(oldFn)) {
     forv_Vec(SymbolMapCacheEntry, entry, *entries) {
       if (isCacheEntryMatch(map, &entry->map)) {
@@ -75,6 +83,7 @@ replaceCache(SymbolMapCache& cache, FnSymbol* oldFn, FnSymbol* fn, SymbolMap* ma
       }
     }
   }
+
   INT_FATAL(oldFn, "unable to replace cache entry; entry does not exist");
 }
 
@@ -90,35 +99,57 @@ freeCache(SymbolMapCache& cache) {
   cache.clear();
 }
 
+static bool isCacheEntryMatch(SymbolMap* s1, SymbolMap* s2) {
+  form_Map(SymbolMapElem, e, *s1) {
+    if (s2->get(e->key) != e->value) {
+      return false;
+    }
+  }
+
+  form_Map(SymbolMapElem, e, *s2) {
+    if (s1->get(e->key) != e->value) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+
+
+/************************************* | **************************************
+*                                                                             *
+*                                                                             *
+*                                                                             *
+************************************** | *************************************/
+
+static bool isCacheEntryMatch(Vec<Symbol*>* vec1, Vec<Symbol*>* vec2);
+
+SymbolVecCache defaultsCache;
 
 SymbolVecCacheEntry::SymbolVecCacheEntry(FnSymbol* ifn, Vec<Symbol*>* ivec) :
   fn(ifn), vec(*ivec) { }
 
 
 void
-addCache(SymbolVecCache& cache, FnSymbol* oldFn, FnSymbol* fn, Vec<Symbol*>* vec) {
+addCache(SymbolVecCache& cache,
+         FnSymbol*       oldFn,
+         FnSymbol*       fn,
+         Vec<Symbol*>* vec) {
   Vec<SymbolVecCacheEntry*>* entries = cache.get(oldFn);
+  SymbolVecCacheEntry*       entry   = new SymbolVecCacheEntry(fn, vec);
+
   if (entries) {
-    entries->add(new SymbolVecCacheEntry(fn, vec));
+    entries->add(entry);
+
   } else {
     entries = new Vec<SymbolVecCacheEntry*>();
-    entries->add(new SymbolVecCacheEntry(fn, vec));
+
+    entries->add(entry);
+
     cache.put(oldFn, entries);
   }
 }
-
-
-static bool 
-isCacheEntryMatch(Vec<Symbol*>* vec1, Vec<Symbol*>* vec2) {
-  forv_Vec(Symbol, d, *vec1)
-    if (!vec2->in(d))
-      return false;
-  forv_Vec(Symbol, d, *vec2)
-    if (!vec1->in(d))
-      return false;
-  return true;
-}
-
 
 FnSymbol*
 checkCache(SymbolVecCache& cache, FnSymbol* fn, Vec<Symbol*>* vec) {
@@ -129,6 +160,7 @@ checkCache(SymbolVecCache& cache, FnSymbol* fn, Vec<Symbol*>* vec) {
       }
     }
   }
+
   return NULL;
 }
 
@@ -139,14 +171,28 @@ freeCache(SymbolVecCache& cache) {
     forv_Vec(SymbolVecCacheEntry, entry, *elem->value) {
       delete entry;
     }
+
     delete elem->value;
   }
+
   cache.clear();
 }
 
 
-SymbolMapCache ordersCache;
-SymbolMapCache genericsCache;
-SymbolMapCache coercionsCache;
-SymbolMapCache promotionsCache;
-SymbolVecCache defaultsCache;
+static bool isCacheEntryMatch(Vec<Symbol*>* vec1, Vec<Symbol*>* vec2) {
+  forv_Vec(Symbol, d, *vec1) {
+    if (!vec2->in(d)) {
+      return false;
+    }
+  }
+
+  forv_Vec(Symbol, d, *vec2) {
+    if (!vec1->in(d)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+

--- a/compiler/resolution/caches.h
+++ b/compiler/resolution/caches.h
@@ -1,15 +1,15 @@
 /*
  * Copyright 2004-2017 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -36,40 +36,32 @@
 //   freeCache(cache): frees memory associated with cache
 //
 class SymbolMapCacheEntry {
- public:
+public:
   SymbolMapCacheEntry(FnSymbol* ifn, SymbolMap* imap);
+
   FnSymbol* fn;
   SymbolMap map;
 };
-typedef Map<FnSymbol*,Vec<SymbolMapCacheEntry*>*> SymbolMapCache;
-typedef MapElem<FnSymbol*,Vec<SymbolMapCacheEntry*>*> SymbolMapCacheElem;
+
+typedef Map<FnSymbol*,     Vec<SymbolMapCacheEntry*>*> SymbolMapCache;
+typedef MapElem<FnSymbol*, Vec<SymbolMapCacheEntry*>*> SymbolMapCacheElem;
 
 
-void addCache(SymbolMapCache& cache, FnSymbol* old, FnSymbol* fn, SymbolMap* map);
-FnSymbol* checkCache(SymbolMapCache& cache, FnSymbol* oldFn, SymbolMap* map);
-void replaceCache(SymbolMapCache& cache, FnSymbol* old, FnSymbol* fn, SymbolMap* map);
-void freeCache(SymbolMapCache& cache);
+void      addCache(SymbolMapCache& cache,
+                   FnSymbol*       oldFn,
+                   FnSymbol*       newFn,
+                   SymbolMap*      map);
 
-//
-// SymbolVecCache: FnSymbol -> FnSymbol cache based on a Vec<Symbol*>
-//
-//   This cache works similarly to the SymbolMapCache above except
-//   instead of a map, the cache is based on a vector.  The cache
-//   entries match if the functions are the same and the vectors
-//   contain the same elements (in any order).
-//
-class SymbolVecCacheEntry {
- public:
-  SymbolVecCacheEntry(FnSymbol* fn, Vec<Symbol*>* ivec);
-  FnSymbol* fn;
-  Vec<Symbol*> vec;
-};
-typedef Map<FnSymbol*,Vec<SymbolVecCacheEntry*>*> SymbolVecCache;
-typedef MapElem<FnSymbol*,Vec<SymbolVecCacheEntry*>*> SymbolVecCacheElem;
+FnSymbol* checkCache(SymbolMapCache& cache,
+                     FnSymbol*       oldFn,
+                     SymbolMap*      map);
 
-void addCache(SymbolVecCache& cache, FnSymbol* newFn, FnSymbol* oldFn, Vec<Symbol*>* vec);
-FnSymbol* checkCache(SymbolVecCache& cache, FnSymbol* fn, Vec<Symbol*>* vec);
-void freeCache(SymbolVecCache& cache);
+void      replaceCache(SymbolMapCache& cache,
+                       FnSymbol*       oldFn,
+                       FnSymbol*       newFn,
+                       SymbolMap*      map);
+
+void      freeCache(SymbolMapCache& cache);
 
 //
 // Caches to avoid creating multiple identical wrappers and
@@ -80,10 +72,56 @@ void freeCache(SymbolVecCache& cache);
 // when instantiating constructors and building up the default
 // wrappers for constructors.
 //
-extern SymbolMapCache ordersCache;
+
 extern SymbolMapCache genericsCache;
-extern SymbolMapCache coercionsCache;
 extern SymbolMapCache promotionsCache;
+
+
+
+
+
+
+
+//
+// SymbolVecCache: FnSymbol -> FnSymbol cache based on a Vec<Symbol*>
+//
+//   This cache works similarly to the SymbolMapCache above except
+//   instead of a map, the cache is based on a vector.  The cache
+//   entries match if the functions are the same and the vectors
+//   contain the same elements (in any order).
+//
+class SymbolVecCacheEntry {
+public:
+  SymbolVecCacheEntry(FnSymbol* fn, Vec<Symbol*>* ivec);
+
+  FnSymbol*    fn;
+  Vec<Symbol*> vec;
+};
+
+typedef Map<FnSymbol*,     Vec<SymbolVecCacheEntry*>*> SymbolVecCache;
+typedef MapElem<FnSymbol*, Vec<SymbolVecCacheEntry*>*> SymbolVecCacheElem;
+
+
+void      addCache(SymbolVecCache& cache,
+                   FnSymbol*       newFn,
+                   FnSymbol*       oldFn,
+                   Vec<Symbol*>* vec);
+
+FnSymbol* checkCache(SymbolVecCache& cache,
+                     FnSymbol*       fn,
+                     Vec<Symbol*>*   vec);
+
+void      freeCache(SymbolVecCache& cache);
+
+//
+// Caches to avoid creating multiple identical wrappers and
+// instantiating the same functions in the same ways
+//
+// Note that these caches are necessary for correctness, not just
+// performance, because they can impact the types that are created
+// when instantiating constructors and building up the default
+// wrappers for constructors.
+//
 extern SymbolVecCache defaultsCache;
 
 #endif

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -7466,10 +7466,9 @@ void resolve() {
 
   pruneResolvedTree();
 
-  freeCache(ordersCache);
   freeCache(defaultsCache);
+
   freeCache(genericsCache);
-  freeCache(coercionsCache);
   freeCache(promotionsCache);
 
   visibleFunctionsClear();


### PR DESCRIPTION
Remove two unused "caches" :- ordersCache and coercionsCache

I was looking at the use of "caches" in wrappers.cpp and noticed that the
code base defines two caches that are no longer referenced other than
to "clean them up" at the end of function resolution.

This PR removes all references to these two caches.  While there
update caches.{h,cpp} to fit in 80 columns etc.

Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.
Also compiler with CHPL_LLVM=llvm on gcc/linux64.  Ran a small portion of
release for each configuration and a paratest to confirm that no functional
changes occurred.



