### PR TITLE
Promotion Wrapper :- Stop discriminating wrappers based on '(' vs '['

### DIFF
--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -979,8 +979,6 @@ static FnSymbol* promotionWrap(FnSymbol* fn,
       USR_WARN(info->call, "promotion on %s", info->toString());
     }
 
-    promoted_subs.put(fn, (Symbol*)info->call->square);
-
     FnSymbol* wrapper = checkCache(promotionsCache, fn, &promoted_subs);
 
     if (wrapper == NULL) {


### PR DESCRIPTION
Promotion Wrapper :- remove legacy code that discriminated calls with '(' vs calls '['


I tripped over a syntactically poor static cast in wrappers.cpp.  My first
impulse was to convert it to a more appropriate cast but then I began to
wonder if the operation made any sense at all.

This caused me to look more closely at wrappers.cpp and this firmed
up my sense that the operation did not make sense.  Testing, a scan
of really old branches, and discussion with Brad confirmed that the
correct step is to remove the statement rather than modify it.



Consider the two calls to foo() in the following contrived
fragment (based on an existing trivial test)

var s : [1..5] int = ( 1, 2, 3, 4, 5 );

proc foo(i : int)
  return 3.14;

proc main() {
  writeln(foo(s));
  writeln(foo[s]);   // Not present in actual test
}


The calls to foo() require array promotion.  At one time
the details of this promotion depended on the syntax
at each call site and it was necessary to generate two
different promotions using the "bool" property that
records the syntax used for the call as a discriminator.
This has not been true for a long time.

Before this PR, the compiler continued to generate two
different promotions for this program although both
promotions were identical.

This PR simply removes the line that included the
call->square property in the key used for the
promotionsCache.

Compiled with CHPL_DEVELOPER on clang/darwin and
ran a small portion release/  Compiled with CHPL_DEVELOPER
on gcc/linux64 and passed a full paratest with futures.

Also confirmed that this was the last place in the compiler
that relied on call->square other than for debug printing.



