### PR TITLE
Wrappers 1

### DIFF
--- a/compiler/include/wrappers.h
+++ b/compiler/include/wrappers.h
@@ -26,9 +26,9 @@ class ArgSymbol;
 class CallInfo;
 class FnSymbol;
 
-FnSymbol* wrapAndCleanUpActuals(FnSymbol*                fn,
-                                CallInfo&                info,
-                                std::vector<ArgSymbol*>* actualIdxToFormal,
-                                bool                     fastFollowerChecks);
+FnSymbol* wrapAndCleanUpActuals(FnSymbol*               fn,
+                                CallInfo&               info,
+                                std::vector<ArgSymbol*> actualIdxToFormal,
+                                bool                    fastFollowerChecks);
 
 #endif

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -2482,7 +2482,7 @@ static FnSymbol* wrapAndCleanUpActuals(ResolutionCandidate* best,
                                        bool                 followerChecks) {
   best->fn = wrapAndCleanUpActuals(best->fn,
                                    info,
-                                   &best->actualIdxToFormal,
+                                   best->actualIdxToFormal,
                                    followerChecks);
 
   return best->fn;

--- a/compiler/resolution/initializerResolution.cpp
+++ b/compiler/resolution/initializerResolution.cpp
@@ -331,7 +331,7 @@ static void makeRecordInitWrappers(CallExpr* call) {
 
   wrap = wrapAndCleanUpActuals(call->resolvedFunction(),
                                info,
-                               &actualIdxToFormal,
+                               actualIdxToFormal,
                                true);
 
   call->baseExpr->replace(new SymExpr(wrap));

--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -127,10 +127,10 @@ FnSymbol* wrapAndCleanUpActuals(FnSymbol*                fn,
 *                                                                             *
 ************************************** | *************************************/
 
-static FnSymbol* buildDefaultWrapper(FnSymbol*     fn,
-                                     CallInfo&     info,
-                                     Vec<Symbol*>* defaults,
-                                     SymbolMap*    paramMap);
+static FnSymbol* buildWrapperForDefaultedFormals(FnSymbol*     fn,
+                                                 CallInfo&     info,
+                                                 Vec<Symbol*>* defaults,
+                                                 SymbolMap*    paramMap);
 
 static void      insertWrappedCall(FnSymbol* fn,
                                    FnSymbol* wrapper,
@@ -141,7 +141,7 @@ static FnSymbol* wrapDefaultedFormals(FnSymbol*                fn,
                                       std::vector<ArgSymbol*>& actualFormals) {
   Vec<Symbol*> defaults;
   int          j      = 1;
-  FnSymbol*    retval = fn;
+  FnSymbol*    retval = NULL;
 
   for_formals(formal, fn) {
     bool used = false;
@@ -160,14 +160,14 @@ static FnSymbol* wrapDefaultedFormals(FnSymbol*                fn,
   retval = checkCache(defaultsCache, fn, &defaults);
 
   if (retval == NULL) {
-    retval = buildDefaultWrapper(fn, info, &defaults, &paramMap);
+    retval = buildWrapperForDefaultedFormals(fn, info, &defaults, &paramMap);
 
     resolveFormals(retval);
 
     addCache(defaultsCache, fn, retval, &defaults);
   }
 
-  // update actualFormals for use in reorderActuals
+  // update actualFormals[] for use in reorderActuals
   for_formals(formal, fn) {
     for (size_t i = 0; i < actualFormals.size(); i++) {
       if (actualFormals[i] == formal) {
@@ -179,10 +179,10 @@ static FnSymbol* wrapDefaultedFormals(FnSymbol*                fn,
   return retval;
 }
 
-static FnSymbol* buildDefaultWrapper(FnSymbol*     fn,
-                                     CallInfo&     info,
-                                     Vec<Symbol*>* defaults,
-                                     SymbolMap*    paramMap) {
+static FnSymbol* buildWrapperForDefaultedFormals(FnSymbol*     fn,
+                                                 CallInfo&     info,
+                                                 Vec<Symbol*>* defaults,
+                                                 SymbolMap*    paramMap) {
   SET_LINENO(fn);
 
   FnSymbol* wrapper = buildEmptyWrapper(fn, info);

--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -61,11 +61,11 @@
 static FnSymbol*  wrapDefaultedFormals(
                                FnSymbol*                fn,
                                CallInfo&                info,
-                               std::vector<ArgSymbol*>* actualToFormal);
+                               std::vector<ArgSymbol*>& actualToFormal);
 
 static void       reorderActuals(FnSymbol*                fn,
                                  CallInfo&                info,
-                                 std::vector<ArgSymbol*>* actualIdxToFormal);
+                                 std::vector<ArgSymbol*>& actualIdxToFormal);
 
 static void       coerceActuals(FnSymbol* fn,
                                 CallInfo& info);
@@ -89,9 +89,9 @@ static ArgSymbol* copyFormalForWrapper(ArgSymbol* formal);
 
 FnSymbol* wrapAndCleanUpActuals(FnSymbol*                fn,
                                 CallInfo&                info,
-                                std::vector<ArgSymbol*>* actualIdxToFormal,
+                                std::vector<ArgSymbol*>  actualIdxToFormal,
                                 bool                     fastFollowerChecks) {
-  int       numActuals = static_cast<int>(actualIdxToFormal->size());
+  int       numActuals = static_cast<int>(actualIdxToFormal.size());
   FnSymbol* retval     = fn;
 
   if (numActuals < fn->numFormals()) {
@@ -99,7 +99,7 @@ FnSymbol* wrapAndCleanUpActuals(FnSymbol*                fn,
   }
 
   // Map actuals to formals by position
-  if (actualIdxToFormal->size() > 1) {
+  if (actualIdxToFormal.size() > 1) {
     reorderActuals(retval, info, actualIdxToFormal);
   }
 
@@ -138,7 +138,7 @@ static void      insertWrappedCall(FnSymbol* fn,
 
 static FnSymbol* wrapDefaultedFormals(FnSymbol*                fn,
                                       CallInfo&                info,
-                                      std::vector<ArgSymbol*>* actualFormals) {
+                                      std::vector<ArgSymbol*>& actualFormals) {
   Vec<Symbol*> defaults;
   int          j      = 1;
   FnSymbol*    retval = fn;
@@ -146,7 +146,7 @@ static FnSymbol* wrapDefaultedFormals(FnSymbol*                fn,
   for_formals(formal, fn) {
     bool used = false;
 
-    for_vector(ArgSymbol, arg, *actualFormals) {
+    for_vector(ArgSymbol, arg, actualFormals) {
       if (arg == formal) {
         used = true;
       }
@@ -169,13 +169,9 @@ static FnSymbol* wrapDefaultedFormals(FnSymbol*                fn,
 
   // update actualFormals for use in reorderActuals
   for_formals(formal, fn) {
-    for (size_t i = 0; i < actualFormals->size(); i++) {
-      if ((*actualFormals)[i] == formal) {
-        ArgSymbol* newFormal = retval->getFormal(j);
-
-        (*actualFormals)[i] = newFormal;
-
-        j++;
+    for (size_t i = 0; i < actualFormals.size(); i++) {
+      if (actualFormals[i] == formal) {
+        actualFormals[i] = retval->getFormal(j++);
       }
     }
   }
@@ -584,8 +580,8 @@ static void insertWrappedCall(FnSymbol* fn,
 
 static void reorderActuals(FnSymbol*                fn,
                            CallInfo&                info,
-                           std::vector<ArgSymbol*>* actualFormals) {
-  int              numArgs       = actualFormals->size();
+                           std::vector<ArgSymbol*>& actualFormals) {
+  int              numArgs       = actualFormals.size();
   std::vector<int> formalsToFormals(numArgs);
   bool             needToReorder = false;
   int              i             = 0;
@@ -595,7 +591,7 @@ static void reorderActuals(FnSymbol*                fn,
 
     i++;
 
-    for_vector(ArgSymbol, af, *actualFormals ) {
+    for_vector(ArgSymbol, af, actualFormals) {
       j++;
 
       if (af == formal) {


### PR DESCRIPTION
wrap-1 :- Update wrappers.cpp to make it less impenetrable

I tripped over wrappers.cpp (again) in recent work and
finally took the time to figure out what it  is doing.  This
is another example of a block of functionality that is
dominated by a few functions that span several pages
each.

This is the first of a few PRs that will break these
large functions down to blocks that are more
manageable.

No changes in behavior.

Compiled with/without CHPL_DEVELOPER on clang/darwin
and gcc/linux64.  Ran a portion of release/ for each config.
Passed a full single-locale paratest on gcc/linux64.