### PR TITLE
Add note about GMP's requirement of m4 to prereq.rst

### DIFF
--- a/doc/rst/usingchapel/prereqs.rst
+++ b/doc/rst/usingchapel/prereqs.rst
@@ -35,6 +35,9 @@ about your environment for using Chapel:
 
   * Building LLVM requires cmake version 3.4.3 or later.
 
+  * Building GMP requires the m4 macro processing package, which may
+    not be installed by default in all systems.
+
   * If you wish to use Chapel's test system, python-setuptools and
     python-devel (or equivalent packages for your platform) are required.
 


### PR DESCRIPTION
This recently tripped up a user, so call it out explicitly.  The
GMP installation information notes the package dependency and some
situations where the version in use on a particular system may be
incompatible.