### PR TITLE
With mem=jemalloc, comm=ugni, and hugepages, support dynamically extendable heap.

### DIFF
--- a/runtime/include/chpl-comm.h
+++ b/runtime/include/chpl-comm.h
@@ -23,6 +23,7 @@
 #ifndef LAUNCHER
 
 #include <stdint.h>
+#include "chplsys.h"
 #include "chpltypes.h"
 #include "chpl-comm-impl.h"
 #include "chpl-comm-heap-macros.h"
@@ -221,6 +222,10 @@ void chpl_comm_rollcall(void);
 // chpl_comm_regMemHeapInfo():
 //   This provides the address and size of the initial registered heap.
 //
+// chpl_comm_regMemHeapPageSize():
+//   This returns the page size for the comm layer registered heap,
+//   either the size of a system page or some hugepage size.
+//
 // chpl_comm_regMemAllocThreshold():
 //   Allocations smaller than this should be done normally, by the
 //   memory layer.  Those at least this size may be done through this
@@ -252,6 +257,14 @@ void chpl_comm_rollcall(void);
 static inline
 void chpl_comm_regMemHeapInfo(void** start_p, size_t* size_p) {
   CHPL_COMM_IMPL_REG_MEM_HEAP_INFO(start_p, size_p);
+}
+
+#ifndef CHPL_COMM_IMPL_REG_MEM_HEAP_PAGE_SIZE
+  #define CHPL_COMM_IMPL_REG_MEM_HEAP_PAGE_SIZE() chpl_getSysPageSize()
+#endif
+static inline
+size_t chpl_comm_regMemHeapPageSize(void) {
+  return CHPL_COMM_IMPL_REG_MEM_HEAP_PAGE_SIZE();
 }
 
 #ifndef CHPL_COMM_IMPL_REG_MEM_ALLOC_THRESHOLD

--- a/runtime/include/chpl-comm.h
+++ b/runtime/include/chpl-comm.h
@@ -229,7 +229,8 @@ void chpl_comm_rollcall(void);
 // chpl_comm_regMemAllocThreshold():
 //   Allocations smaller than this should be done normally, by the
 //   memory layer.  Those at least this size may be done through this
-//   comm layer sub-interface.
+//   comm layer sub-interface.  SIZE_MAX is returned if the comm layer
+//   cannot or will not do allocations at all.
 //
 // chpl_comm_regMemAlloc()
 //   Allocate memory, returning either a non-NULL pointer or NULL when

--- a/runtime/include/chpl-comm.h
+++ b/runtime/include/chpl-comm.h
@@ -214,23 +214,17 @@ void chpl_comm_post_task_init(void);
 void chpl_comm_rollcall(void);
 
 //
-// Communication layers that need or want to register memory with the
-// network interface may have to provide the space for the Chapel heap
-// themselves.  If so, this provides that heap's address and length.
+// This is the comm layer sub-interface for heap management and dynamic
+// memory allocation, when memory has to be registered with the network
+// for best performance.
 //
-// This function may be called multiple times during program
-// initialization.
-//
-void chpl_comm_get_registered_heap(void** start_p, size_t* size_p);
-
-//
-// This is the comm layer sub-interface for dynamic allocation and
-// registration of memory. The functions are as follows:
+// chpl_comm_regMemHeapInfo():
+//   This provides the address and size of the initial registered heap.
 //
 // chpl_comm_regMemAllocThreshold():
 //   Allocations smaller than this should be done normally, by the
-//   memory layer.  Others should be done through this comm layer
-//   sub-interface.
+//   memory layer.  Those at least this size may be done through this
+//   comm layer sub-interface.
 //
 // chpl_comm_regMemAlloc()
 //   Allocate memory, returning either a non-NULL pointer or NULL when
@@ -251,6 +245,15 @@ void chpl_comm_get_registered_heap(void** start_p, size_t* size_p);
 //   perhaps not performance-optimal, to first try to free it here, and 
 //   only free it elsewhere if this function returns false.
 //
+#ifndef CHPL_COMM_IMPL_REG_MEM_HEAP_INFO
+#define CHPL_COMM_IMPL_REG_MEM_HEAP_INFO(start_p, size_p)   \
+        do { *(start_p) = NULL ; *(size_p) = 0; } while (0)
+#endif
+static inline
+void chpl_comm_regMemHeapInfo(void** start_p, size_t* size_p) {
+  CHPL_COMM_IMPL_REG_MEM_HEAP_INFO(start_p, size_p);
+}
+
 #ifndef CHPL_COMM_IMPL_REG_MEM_ALLOC_THRESHOLD
   #define CHPL_COMM_IMPL_REG_MEM_ALLOC_THRESHOLD() SIZE_MAX
 #endif

--- a/runtime/include/chpl-env.h
+++ b/runtime/include/chpl-env.h
@@ -22,15 +22,39 @@
 
 #include "chpltypes.h"
 
-//
-// Returns the value of a CHPL_RT_* environment variable, with default.
-//
-const char* chpl_get_rt_env(const char*, const char*);
+#include <inttypes.h>
 
 //
-// Returns the value of a boolean CHPL_RT_* environment variable, with
-// default.
+// Returns the string value of a CHPL_RT_* environment variable, with
+// a default.
 //
-chpl_bool chpl_get_rt_env_bool(const char*, chpl_bool);
+const char* chpl_env_rt_get(const char*, const char*);
+
+//
+// These convert string values, presumably from environment variables,
+// to typed values (boolean, int, or size), with a default.
+//
+chpl_bool chpl_env_str_to_bool(const char*, chpl_bool);
+int64_t chpl_env_str_to_int(const char*, int64_t);
+size_t chpl_env_str_to_size(const char*, size_t);
+
+//
+// These combine getting the environment variable and converting to a
+// typed value.
+//
+static inline
+chpl_bool chpl_env_rt_get_bool(const char* ev, chpl_bool dflt) {
+  return chpl_env_str_to_bool(chpl_env_rt_get(ev, NULL), dflt);
+}
+
+static inline
+int64_t chpl_env_rt_get_int(const char* ev, int64_t dflt) {
+  return chpl_env_str_to_int(chpl_env_rt_get(ev, NULL), dflt);
+}
+
+static inline
+size_t chpl_env_rt_get_size(const char* ev, size_t dflt) {
+  return chpl_env_str_to_size(chpl_env_rt_get(ev, NULL), dflt);
+}
 
 #endif

--- a/runtime/include/comm/gasnet/chpl-comm-impl.h
+++ b/runtime/include/comm/gasnet/chpl-comm-impl.h
@@ -1,15 +1,15 @@
 /*
- * Copyright 2004-2018 Cray Inc.
+ * Copyright 2004-2017 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,30 +17,15 @@
  * limitations under the License.
  */
 
-#include "chplrt.h"
+#ifndef _chpl_comm_impl_h_
+#define _chpl_comm_impl_h_
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <stdint.h>
-#include <string.h>
+//
+// This is the comm layer sub-interface for dynamic allocation and
+// registration of memory.
+//
+#define CHPL_COMM_IMPL_REG_MEM_HEAP_INFO(start_p, size_p) \
+    chpl_comm_impl_regMemHeapInfo(start_p, size_p)
+void chpl_comm_impl_regMemHeapInfo(void** start_p, size_t* size_p);
 
-#include "chpl-comm.h"
-#include "chpl-mem.h"
-#include "chplmemtrack.h"
-#include "chpltypes.h"
-#include "error.h"
-
-void chpl_mem_layerInit(void) {
-  void* start;
-  size_t size;
-
-  chpl_comm_regMemHeapInfo(&start, &size);
-  if (start || size) {
-    chpl_error("Your CHPL_MEM setting doesn't support the registered heap "
-               "required by your CHPL_COMM setting. You'll need to change one "
-               "of these configurations.", 0, 0);
-  }
-}
-
-
-void chpl_mem_layerExit(void) { }
+#endif // _chpl_comm_impl_h_

--- a/runtime/include/comm/ugni/chpl-comm-impl.h
+++ b/runtime/include/comm/ugni/chpl-comm-impl.h
@@ -28,6 +28,10 @@
     chpl_comm_impl_regMemHeapInfo(start_p, size_p)
 void chpl_comm_impl_regMemHeapInfo(void** start_p, size_t* size_p);
 
+#define CHPL_COMM_IMPL_REG_MEM_HEAP_PAGE_SIZE() \
+        chpl_comm_impl_regMemHeapPageSize()
+size_t chpl_comm_impl_regMemHeapPageSize(void);
+
 #define CHPL_COMM_IMPL_REG_MEM_ALLOC_THRESHOLD() \
         chpl_comm_impl_regMemAllocThreshold()
 size_t chpl_comm_impl_regMemAllocThreshold(void);

--- a/runtime/include/comm/ugni/chpl-comm-impl.h
+++ b/runtime/include/comm/ugni/chpl-comm-impl.h
@@ -24,6 +24,10 @@
 // This is the comm layer sub-interface for dynamic allocation and
 // registration of memory.
 //
+#define CHPL_COMM_IMPL_REG_MEM_HEAP_INFO(start_p, size_p) \
+    chpl_comm_impl_regMemHeapInfo(start_p, size_p)
+void chpl_comm_impl_regMemHeapInfo(void** start_p, size_t* size_p);
+
 #define CHPL_COMM_IMPL_REG_MEM_ALLOC_THRESHOLD() \
         chpl_comm_impl_regMemAllocThreshold()
 size_t chpl_comm_impl_regMemAllocThreshold(void);

--- a/runtime/include/comm/ugni/chpl-comm-task-decls.h
+++ b/runtime/include/comm/ugni/chpl-comm-task-decls.h
@@ -43,7 +43,7 @@ typedef struct {
 typedef struct {
   chpl_fn_int_t fid;
   int caller;
-  void* done; // where to indicate completion on caller
+  void* rf_done; // where to indicate completion on caller
 } chpl_comm_bundleData_t;
 
 //

--- a/runtime/include/comm/ugni/comm-ugni-heap-pages.h
+++ b/runtime/include/comm/ugni/comm-ugni-heap-pages.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2004-2017 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _comm_ugni_heap_pages_h_
+#define _comm_ugni_heap_pages_h_
+
+//
+// System and heap page sizes, for the uGNI communication interface.
+//
+
+#include <stdint.h>
+
+size_t chpl_comm_ugni_getSysPageSize(void);
+size_t chpl_comm_ugni_getHeapPageSize(void);
+
+#endif // _comm_ugni_heap_pages_h_

--- a/runtime/include/mem/jemalloc/chpl-mem-impl.h
+++ b/runtime/include/mem/jemalloc/chpl-mem-impl.h
@@ -21,14 +21,7 @@
 #ifndef _chpl_mem_impl_H_
 #define _chpl_mem_impl_H_
 
-// Set up a #define to control jemalloc.h
-#ifndef CHPL_JEMALLOC_PREFIX
-// Use the je_ prefix
-#define CHPL_JEMALLOC_PREFIX je_
-// Ask jemalloc.h to provide the je_ functions
-// (i.e. je_malloc rather than just malloc)
-#define JEMALLOC_NO_DEMANGLE
-#endif
+#include "chpl-mem-jemalloc-prefix.h"
 
 #include "jemalloc/jemalloc.h"
 

--- a/runtime/include/mem/jemalloc/chpl-mem-jemalloc-prefix.h
+++ b/runtime/include/mem/jemalloc/chpl-mem-jemalloc-prefix.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2004-2017 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* jemalloc memory function implementation */
+#ifndef _chpl_mem_jemalloc_prefix_H_
+#define _chpl_mem_jemalloc_prefix_H_
+
+// If the build environment doesn't supply a jemalloc symbol prefix
+// then just use "je_"
+#ifndef CHPL_JEMALLOC_PREFIX
+#define CHPL_JEMALLOC_PREFIX je_
+// Ask jemalloc.h to provide the je_ functions
+// (i.e. je_malloc rather than just malloc)
+#define JEMALLOC_NO_DEMANGLE
+#endif
+
+#endif

--- a/runtime/make/Makefile.runtime.head
+++ b/runtime/make/Makefile.runtime.head
@@ -46,6 +46,13 @@ LAUNCHER_INCLS = \
         -I$(RUNTIME_ROOT)/include/comm \
         -I$(RUNTIME_ROOT)/include
 
+ifneq ($(MAKE_LAUNCHER),1)
+  ifeq ($(CHPL_MAKE_TARGET_MEM),jemalloc)
+    LAUNCHER_CFLAGS += -DCHPL_TARGET_MEM_JEMALLOC
+    LAUNCHER_INCLS += -I$(RUNTIME_ROOT)/include/mem/$(CHPL_MAKE_TARGET_MEM)
+  endif
+endif
+
 # Get runtime headers and required -D flags.
 # sets RUNTIME_INCLUDE_ROOT RUNTIME_CFLAGS RUNTIME_INCLS
 include $(RUNTIME_ROOT)/make/Makefile.runtime.include

--- a/runtime/make/Makefile.runtime.include
+++ b/runtime/make/Makefile.runtime.include
@@ -90,10 +90,19 @@ ifeq ($(RUNTIME_CYGWIN),1)
   RUNTIME_INCLS += -I/usr/include/w32api
 endif
 
-# Add any further includes for memory
+# Add any further includes for memory including jemalloc target memory,
+# when making the launcher.
 MEM_INCLUDE=$(RUNTIME_ROOT)/make/Makefile.runtime.mem-$(CHPL_MAKE_MEM)
 ifneq ($(strip $(wildcard $(MEM_INCLUDE))),)
   include $(MEM_INCLUDE)
+endif
+
+ifeq ($(MAKE_LAUNCHER),1)
+  ifeq ($(CHPL_MAKE_TARGET_MEM),jemalloc)
+    TARGET_MEM_INCLUDE=\
+      $(RUNTIME_ROOT)/make/Makefile.runtime.mem-$(CHPL_MAKE_TARGET_MEM)
+    -include $(TARGET_MEM_INCLUDE)
+  endif
 endif
 
 # Add any further includes for GMP.
@@ -107,8 +116,6 @@ UNWIND_INCLUDE=$(RUNTIME_ROOT)/make/Makefile.runtime.unwind-$(CHPL_MAKE_UNWIND)
 # Add any further includes for HWLOC.
 HWLOC_INCLUDE=$(RUNTIME_ROOT)/make/Makefile.runtime.hwloc-$(CHPL_MAKE_HWLOC)
 -include $(HWLOC_INCLUDE)
-
-# Further includes for JEMALLOC are in Makefile.runtime.mem-jemalloc
 
 #
 # For use with pyChapel / library-mode.

--- a/runtime/src/Makefile.share
+++ b/runtime/src/Makefile.share
@@ -17,6 +17,7 @@
 
 COMMON_LAUNCHER_SRCS = \
 	arg.c \
+	chpl-env.c \
 	chpl-linefile-support.c \
 	chpl-string-support.c \
 	chplcast.c \
@@ -31,7 +32,6 @@ COMMON_NOGEN_SRCS = \
 	chpl-cache.c \
 	chpl-comm.c \
         chpl-comm-callbacks.c \
-	chpl-env.c \
 	chpl-init.c \
 	chplexit.c \
 	chpl-file-utils.c \

--- a/runtime/src/chpl-comm.c
+++ b/runtime/src/chpl-comm.c
@@ -23,9 +23,11 @@
 //
 #include "chplrt.h"
 #include "chpl-comm.h"
+#include "chpl-env.h"
 #include "chpl-mem.h"
 #include "chpl-mem-consistency.h"
 
+#include <pthread.h>
 #include <stdint.h>
 #include <string.h>
 #include <unistd.h>
@@ -77,42 +79,26 @@ void chpl_gen_stopCommDiagnosticsHere(void) {
 }
 
 
+static int maxHeapSize_set;
+static pthread_once_t maxHeapSize_once = PTHREAD_ONCE_INIT;
+static size_t maxHeapSize;
+
+static
+void set_maxHeapSize(void)
+{
+  maxHeapSize = chpl_env_rt_get_size("MAX_HEAP_SIZE", 0);
+}
+
 size_t chpl_comm_getenvMaxHeapSize(void)
 {
-  char*  p;
-  static int    env_checked = 0;
-  static size_t size = 0;
-
-  if (env_checked)
-    return size;
-
-  if ((p = getenv("CHPL_RT_MAX_HEAP_SIZE")) != NULL) {
-    //
-    // The user specified a maximum size, so start with that.
-    //
-    int  num_scanned;
-    char units;
-
-    if ((num_scanned = sscanf(p, "%zi%c", &size, &units)) != 1) {
-      if (num_scanned == 2 && strchr("kKmMgG", units) != NULL) {
-        switch (units) {
-        case 'k' : case 'K': size <<= 10; break;
-        case 'm' : case 'M': size <<= 20; break;
-        case 'g' : case 'G': size <<= 30; break;
-        }
-      }
-      else {
-        chpl_warning("Cannot parse CHPL_RT_MAX_HEAP_SIZE environment "
-                     "variable; assuming 1g", 0, 0);
-        size = ((size_t) 1) << 30;
-      }
-    }
+  if (!maxHeapSize_set
+      && pthread_once(&maxHeapSize_once, set_maxHeapSize) != 0) {
+    chpl_internal_error("pthread_once(&maxHeapSize_once) failed");
   }
 
-  env_checked = 1;
-
-  return size;
+  return maxHeapSize;
 }
+
 
 void* chpl_get_global_serialize_table(int64_t idx) {
   return chpl_global_serialize_table[idx];

--- a/runtime/src/chpl-env.c
+++ b/runtime/src/chpl-env.c
@@ -23,11 +23,13 @@
 #include "chpltypes.h"
 #include "error.h"
 
+#include <inttypes.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
 
-const char* chpl_get_rt_env(const char* evs, const char* dflt) {
+const char* chpl_env_rt_get(const char* evs, const char* dflt) {
   char evName[100];
   const char* evVal;
 
@@ -41,9 +43,7 @@ const char* chpl_get_rt_env(const char* evs, const char* dflt) {
 }
 
 
-chpl_bool chpl_get_rt_env_bool(const char* evs, chpl_bool dflt) {
-  const char* evVal = chpl_get_rt_env(evs, NULL);
-
+chpl_bool chpl_env_str_to_bool(const char* evVal, chpl_bool dflt) {
   if (evVal == NULL)
     return dflt;
   if (strchr("0fFnN", evVal[0]) != NULL)
@@ -52,7 +52,50 @@ chpl_bool chpl_get_rt_env_bool(const char* evs, chpl_bool dflt) {
     return true;
 
   chpl_msg(1,
-           "warning: unknown CHPL_RT_%s value; should be T or F, assuming %c\n",
-           evs, (dflt ? 'T' : 'F'));
+           "warning: env var unknown bool value \"%s\", assuming %c\n",
+           evVal, (dflt ? 'T' : 'F'));
   return dflt;
+}
+
+
+int64_t chpl_env_str_to_int(const char* evVal, int64_t dflt) {
+  int64_t val;
+
+  if (evVal == NULL)
+    return dflt;
+
+  if (sscanf(evVal, "%" SCNi64, &val) == 1)
+    return val;
+
+  chpl_msg(1,
+           "warning: unknown env var int value \"%s\", assuming %" PRId64 "\n",
+           evVal, dflt);
+  return dflt;
+}
+
+
+size_t chpl_env_str_to_size(const char* evVal, size_t dflt) {
+  int64_t val;
+  int scnCnt;
+  char units;
+
+  if (evVal == NULL)
+    return dflt;
+
+  if ((scnCnt = sscanf(evVal, "%zi%c", &val, &units)) != 1) {
+    if (scnCnt == 2 && strchr("kKmMgG", units) != NULL) {
+      switch (units) {
+      case 'k' : case 'K': val <<= 10; break;
+      case 'm' : case 'M': val <<= 20; break;
+      case 'g' : case 'G': val <<= 30; break;
+      }
+    } else {
+      chpl_msg(1,
+               "warning: unknown env var size value \"%s\", assuming %zd\n",
+               evVal, dflt);
+      return dflt;
+    }
+  }
+
+  return val;
 }

--- a/runtime/src/chpl-mem-desc.c
+++ b/runtime/src/chpl-mem-desc.c
@@ -75,7 +75,7 @@ chpl_bool chpl_mem_descTrack(chpl_mem_descInt_t mdi) {
     // Init is parallel-safe because all stores are of the same values.
     //
     if (!track_all_mds_set) {
-      track_all_mds = chpl_get_rt_env_bool("MEMTRACK_ALL_MDS", false);
+      track_all_mds = chpl_env_rt_get_bool("MEMTRACK_ALL_MDS", false);
       track_all_mds_set = true;
     }
 

--- a/runtime/src/chplsys.c
+++ b/runtime/src/chplsys.c
@@ -244,7 +244,7 @@ static void computeHeapPageSizeByGuessing(size_t page_size_in)
   // in the heap.
   heapPageSize = page_size_in;
 
-  chpl_comm_get_registered_heap(&heap_start, &heap_size);
+  chpl_comm_regMemHeapInfo(&heap_start, &heap_size);
 
   if (heap_start != NULL && heap_size != 0) {
 

--- a/runtime/src/comm/gasnet/comm-gasnet.c
+++ b/runtime/src/comm/gasnet/comm-gasnet.c
@@ -926,7 +926,7 @@ void chpl_comm_rollcall(void) {
            chpl_numNodes, chpl_nodeName());
 }
 
-void chpl_comm_get_registered_heap(void** start_p, size_t* size_p) {
+void chpl_comm_impl_regMemHeapInfo(void** start_p, size_t* size_p) {
 #if defined(GASNET_SEGMENT_FAST) || defined(GASNET_SEGMENT_LARGE)
   *start_p = chpl_numGlobalsOnHeap * sizeof(wide_ptr_t) 
              + (char*)seginfo_table[chpl_nodeID].addr;

--- a/runtime/src/comm/none/comm-none.c
+++ b/runtime/src/comm/none/comm-none.c
@@ -131,11 +131,6 @@ void chpl_comm_rollcall(void) {
   chpl_msg(2, "executing on a single node\n");
 }
 
-void chpl_comm_get_registered_heap(void** start_p, size_t* size_p) {
-  *start_p = NULL;
-  *size_p  = 0;
-}
-
 void chpl_comm_broadcast_global_vars(int numGlobals) { }
 
 void chpl_comm_broadcast_private(int id, size_t size, int32_t tid) { }

--- a/runtime/src/comm/ugni/Makefile.share
+++ b/runtime/src/comm/ugni/Makefile.share
@@ -18,16 +18,19 @@
 COMM_LAUNCHER_SRCS = \
         comm-ugni-launch.c \
         comm-ugni-locales.c \
+        comm-ugni-heap-pages.c \
 
 COMM_SRCS = \
         comm-ugni.c \
         comm-ugni-mem.c \
         comm-ugni-locales.c \
+        comm-ugni-heap-pages.c \
 
 SVN_SRCS = \
         comm-ugni.c \
         comm-ugni-launch.c \
         comm-ugni-locales.c \
+        comm-ugni-heap-pages.c \
 
 SRCS = $(SVN_SRCS)
 

--- a/runtime/src/comm/ugni/comm-ugni-heap-pages.c
+++ b/runtime/src/comm/ugni/comm-ugni-heap-pages.c
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2004-2017 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//
+// System and heap page sizes, for the uGNI communication interface.
+//
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "chplrt.h"
+#include "chplcgfns.h"
+#include "comm-ugni-heap-pages.h"
+#include "error.h"
+
+
+//
+// This is really just a utility function, but exposing it makes things
+// easier for chpl_comm_ugni_getHeapPageSize() callers in the launcher,
+// where the regular chplsys.c support isn't available.
+//
+size_t chpl_comm_ugni_getSysPageSize(void) {
+  static size_t sps = 0;
+
+  if (sps != 0)
+    return sps;
+
+#if defined _SC_PAGESIZE
+  sps = (size_t) sysconf(_SC_PAGESIZE);
+#elif defined _SC_PAGE_SIZE
+  sps = (size_t) sysconf(_SC_PAGE_SIZE);
+#endif
+
+  if (sps == 0)
+    chpl_internal_error("can't get system page size");
+
+  return sps;
+}
+
+
+//
+// Figure out what the heap page size will be.
+//
+size_t chpl_comm_ugni_getHeapPageSize(void) {
+  static size_t hps = 0;
+
+  if (hps != 0)
+    return hps;
+
+  //
+  // Do we have mem=jemalloc and a dynamically extensible heap?
+  //
+  if (strcmp(CHPL_MEM, "jemalloc") != 0
+      || getenv("CHPL_RT_MAX_HEAP_SIZE") != NULL) {
+    return (hps = chpl_comm_ugni_getSysPageSize());
+  }
+
+  //
+  // Do we have hugepages?
+  //
+  const char* ev = getenv("HUGETLB_DEFAULT_PAGE_SIZE");
+
+  if (ev == NULL) {
+    return (hps = chpl_comm_ugni_getSysPageSize());
+  }
+
+  //
+  // Figure out the heap page size.
+  //
+  int num_scanned;
+  char units;
+
+  if ((num_scanned = sscanf(ev, "%zi%c", &hps, &units)) != 1) {
+    if (num_scanned == 2 && strchr("kKmMgG", units) != NULL) {
+      switch (units) {
+      case 'k' : case 'K': hps <<= 10; break;
+      case 'm' : case 'M': hps <<= 20; break;
+      case 'g' : case 'G': hps <<= 30; break;
+      }
+    }
+    else {
+      chpl_error("Cannot parse HUGETLB_DEFAULT_PAGE_SIZE environment variable",
+                 0, 0);
+    }
+  }
+
+  return hps;
+}

--- a/runtime/src/comm/ugni/comm-ugni-launch.c
+++ b/runtime/src/comm/ugni/comm-ugni-launch.c
@@ -23,11 +23,66 @@
 
 #define _POSIX_C_SOURCE 200112L  // for setenv(3) in <stdlib.h>
 
+#include <assert.h>
+#include <math.h>
 #include <stdlib.h>
 
 #include "chplrt.h"
+#include "comm-ugni-heap-pages.h"
 #include "chpl-comm-launch.h"
 #include "error.h"
+
+
+//
+// With mem=jemalloc and comm=ugni with hugepages and a dynamically
+// extensible heap, we have to configure jemalloc's large chunk size.
+// It would be preferable to deal with this entirely within the target
+// program, but we need it before jemalloc does its constructor-based
+// initialization and we don't have a dependable way to arrange that
+// in the target program.
+//
+static
+void maybe_set_jemalloc_lg_chunk(void) {
+  size_t hps;
+
+  hps = chpl_comm_ugni_getHeapPageSize();
+  if (hps == chpl_comm_ugni_getSysPageSize())
+    return;
+
+  //
+  // We're using the jemalloc memory layer, the heap is dynamically
+  // extensible, and we've got hugepages, so we'll be registering
+  // memory.  (chpl_comm_ugni_getHeapPageSize()) checks all this.)
+  //
+  // Arrange for jemalloc's chunk size (and alignment) to be the same
+  // as what the comm layer recommends, which is the heap page size.
+  // Make sure this is a power of 2, because jemalloc needs that.
+  //
+  int hps_log2;
+  char* ev;
+  char buf[1000];
+
+  // sanity check: power of 2 and >= sys page size
+  assert((hps & (hps - 1)) == 0
+         && hps >= chpl_comm_ugni_getSysPageSize());
+
+  // lg_chunk is specified as the base-2 log of the expansion chunk size
+  hps_log2 = lrint(log2((double) hps));
+
+  if ((ev = getenv("CHPL_JE_MALLOC_CONF")) == NULL) {
+    snprintf(buf, sizeof(buf), "lg_chunk:%d", hps_log2);
+  } else {
+    // Override any user-specified lg_chunk.  Smaller or larger, it
+    // would break our logic either way.
+    if (snprintf(buf, sizeof(buf), "%s,lg_chunk:%d", ev, hps_log2)
+        >= sizeof(buf)) {
+      chpl_internal_error("setting CHPL_JE_MALLOC_CONF would truncate");
+    }
+  }
+
+  if (setenv("CHPL_JE_MALLOC_CONF", buf, 1) != 0)
+    chpl_internal_error("cannot setenv(CHPL_JE_MALLOC_CONF)");
+}
 
 
 void chpl_comm_preLaunch(void) {
@@ -35,4 +90,5 @@ void chpl_comm_preLaunch(void) {
     chpl_error("cannot setenv HUGETLB_VERBOSE=0", 0, 0);
   if (setenv("HUGETLB_NO_RESERVE", "yes", 0) != 0)
     chpl_error("cannot setenv HUGETLB_NO_RESERVE=yes", 0, 0);
+  maybe_set_jemalloc_lg_chunk();
 }

--- a/runtime/src/error.c
+++ b/runtime/src/error.c
@@ -99,7 +99,7 @@ static void chpl_stack_unwind(void){
 #endif
 
   // Check if we need to print the stack trace (default = yes)
-  if(! chpl_get_rt_env_bool("UNWIND", true)) {
+  if(! chpl_env_rt_get_bool("UNWIND", true)) {
     return;
   }
 

--- a/runtime/src/mem/jemalloc/mem-jemalloc.c
+++ b/runtime/src/mem/jemalloc/mem-jemalloc.c
@@ -326,7 +326,7 @@ void chpl_mem_layerInit(void) {
   void* heap_base;
   size_t heap_size;
 
-  chpl_comm_get_registered_heap(&heap_base, &heap_size);
+  chpl_comm_regMemHeapInfo(&heap_base, &heap_size);
   if (heap_base != NULL && heap_size == 0) {
     chpl_internal_error("if heap address is specified, size must be also");
   }

--- a/third-party/jemalloc/README
+++ b/third-party/jemalloc/README
@@ -33,3 +33,8 @@ Note that these instructions are for a simple API compatible updates. If the
 jemalloc API changes, or the references to the man page in the runtime shim are
 no longer accurate, more care should be taken to see what changes have been
 made and if we need to change anything on our end.
+
+In particular, if the base name of the jemalloc configuration environment
+variable changes from "MALLOC_CONF" to something else, please update the
+reference to that variable in runtime/src/comm/ugni/comm-ugni-launch.c to
+the new name.


### PR DESCRIPTION
In the past we have only provided a fixed-size registered heap when
CHPL_COMM=ugni.  Here, build on the dynamic registration capability
recently added for array allocations, to support dynamic extension of
the main heap also, even when it is composed of registered memory.