### PR TITLE
Archive nightly xc-wb.prgenv-cray test logs in NightlyHistory

### DIFF
--- a/util/cron/historify-logs
+++ b/util/cron/historify-logs
@@ -24,12 +24,16 @@ NightlyPerformance/chap04 \
 NightlyPerformance/chap08 \
 NightlyPerformance/chap12 \
 NightlyPerformance/chapcs \
+NightlyPerformance/chapcs.comm-counts \
 NightlyPerformance/shootout \
 "
 
 # logs for "Cray hardware" configurations
 loghomeCrayHW=/cray/css/users/chapelu
-logsourcesCrayHW=Nightly
+logsourcesCrayHW="\
+Nightly \
+NightlyWbOnCray \
+"
 
 verbose=false
 numerrors=


### PR DESCRIPTION
This adds two new locations for util/cron/historify-logs to search
(... for test logs to archive in /data/sea/chapel/NightlyHistory),
every time Jenkins job "archive-test-logs" runs.

The locations added are
/cray/css/users/chapelu/NightlyWbOnCray
and
/data/sea/chapel/NightlyPerformance/chapcs.comm-counts