### PR TITLE
Handle CHPL_COMM_USE_GDB in Chapel runtime (vs. GASNet)

### DIFF
--- a/runtime/include/chpl-mem.h
+++ b/runtime/include/chpl-mem.h
@@ -265,6 +265,9 @@ void chpl_mem_layerFree(void*, int32_t lineno, int32_t filename);
 #define chpl_mem_allocMany(number, size, description, lineno, filename)        \
   sys_malloc((number)*(size))
 
+#define chpl_mem_alloc(size, description, lineno, filename)        \
+  sys_malloc(size)
+
 #define chpl_mem_free(ptr, lineno, filename)        \
   sys_free(ptr)
 

--- a/runtime/include/chpllaunch.h
+++ b/runtime/include/chpllaunch.h
@@ -27,6 +27,7 @@
 //
 int chpl_run_utility1K(const char *command, char *const argv[],
                        char *outbuf, int outbuflen);
+int chpl_run_cmdstr(const char *commandStr, char *outbuf, int outbuflen);
 char **chpl_bundle_exec_args(int argc, char *const argv[],
                              int largc, char *const largv[]);
 int chpl_launch_using_fork_exec(const char* command, char * const argv1[],

--- a/runtime/src/launch/amudprun/launch-amudprun.c
+++ b/runtime/src/launch/amudprun/launch-amudprun.c
@@ -102,8 +102,15 @@ static char** chpl_launch_create_argv(const char *launch_cmd,
       if (chpl_run_cmdstr("which xterm", xterm_path, sizeof(xterm_path)) > 0) {
         largv[largc++] = (char *) strdup(xterm_path);
         largv[largc++] = (char *) "-e";
-        largv[largc++] = (char *) "gdb";
-        largv[largc++] = (char *) "--args";
+        if (ev_use_gdb != NULL) {
+          largv[largc++] = (char *) "gdb";
+          largv[largc++] = (char *) "--args";
+        } else {
+          largv[largc++] = (char *) "lldb";
+          largv[largc++] = (char *) "--";
+        }
+      } else {
+        chpl_warning("CHPL_COMM_USE_(G|LL)DB ignored because no xterm", 0, 0);
       }
     }
   }

--- a/runtime/src/launch/amudprun/launch-amudprun.c
+++ b/runtime/src/launch/amudprun/launch-amudprun.c
@@ -97,10 +97,13 @@ static char** chpl_launch_create_argv(const char *launch_cmd,
     const char* ev_use_lldb = getenv("CHPL_COMM_USE_LLDB");
 
     if (ev_use_gdb != NULL || ev_use_lldb != NULL) {
-      char xterm_path[PATH_MAX];  // understood questionable; hopefully enough
+      // hopefully big enough; PATH_MAX is problematic, but what's better?  
+      const size_t xterm_path_size = PATH_MAX;
+      char *xterm_path = chpl_mem_alloc(xterm_path_size,
+                                        CHPL_RT_MD_COMMAND_BUFFER, -1, 0);
 
-      if (chpl_run_cmdstr("which xterm", xterm_path, sizeof(xterm_path)) > 0) {
-        largv[largc++] = (char *) strdup(xterm_path);
+      if (chpl_run_cmdstr("which xterm", xterm_path, xterm_path_size) > 0) {
+        largv[largc++] = xterm_path;
         largv[largc++] = (char *) "-e";
         if (ev_use_gdb != NULL) {
           largv[largc++] = (char *) "gdb";

--- a/runtime/src/main_launcher.c
+++ b/runtime/src/main_launcher.c
@@ -186,6 +186,40 @@ chpl_run_utility1K(const char *command, char *const argv[], char *outbuf, int ou
 }
 
 //
+// This is an even simpler run-a-command utility.  The command is just
+// a string to be run, by something like `/bin/sh -c "commandStr"`.  It
+// must not expect any input.  Its output to stdout is placed in outbuf,
+// truncated to fit if necessary.  Its output to stderr is discarded.
+// On success, the return value is the number of bytes in outbuf.  On
+// failure, it is -1; output may have been placed in outbuf in this
+// case, but if so it should be ignored.
+//
+int
+chpl_run_cmdstr(const char *commandStr, char *outbuf, int outbuflen) {
+  const char* commandStr_more = "2>/dev/null";
+  char my_cmd[strlen(commandStr) + 1 + strlen(commandStr_more) + 1];
+  FILE* f;
+  int retVal;
+
+  (void) snprintf(my_cmd, sizeof(my_cmd),
+                  "%s %s", commandStr, commandStr_more);
+
+  retVal = -1;
+  if ((f = popen(my_cmd, "r")) != NULL) {
+    if (fgets(outbuf, outbuflen, f) != NULL) {
+      // success; strip any final trailing newline
+      retVal = strlen(outbuf);
+      if (retVal > 0 && outbuf[retVal - 1] == '\n')
+        outbuf[--retVal] = '\0';
+    }
+
+    (void) pclose(f);
+  }
+
+  return retVal;
+}
+
+//
 // This function returns a NULL terminated argv list as required by
 // chpl_launch_using_exec(), i.e., execve(3).
 //

--- a/third-party/gasnet/README
+++ b/third-party/gasnet/README
@@ -17,13 +17,6 @@ Chapel modifications to GASNet
 The modifications that we have made to the official GASNet release are
 as follows:
 
-* Added support for launching an xterm window running a debugger in the
-  udp active messages layer if either of the environment variables
-  CHPL_COMM_USE_GDB or CHPL_COMM_USE_LLDB is set.  Our modification is
-  not particularly elegant, but it should be innocuous for non-Chapel
-  developers, and has been exceedingly useful for the Chapel development
-  team.
-
 * Added preliminary support for 64-bit ARM.  This adds the new file
   third-party/gasnet/gasnet-src/other/contrib/cross-configure-aarch64-linux
   which is the only ARM change beneath gasnet-src in the tree.


### PR DESCRIPTION
With `comm=gasnet` and the `amudprun` launcher, by setting `CHPL_COMM_USE_GDB`
or `CHPL_COMM_USE_LLDB` a user can cause the target program instances to
be run under the `gdb` or `lldb` debugger, respectively, with each instance
in its own `xterm` window.  In the past we've supported this through a mod
to the GASNet `amudprun` launcher, which we've had to re-apply each time
we upgraded GASNet.  Here we remove that patch and replace it with code
in our own Chapel `amudprun` launcher to achieve the same effect.

This resolves #5269.