### PR TITLE
Shutdown the memory layer after the comm layer

### DIFF
--- a/runtime/src/chplexit.c
+++ b/runtime/src/chplexit.c
@@ -41,9 +41,11 @@ static void chpl_exit_common(int status, int all) {
     chpl_task_exit();
     chpl_reportMemInfo();
   }
-  chpl_mem_exit();
   chpl_comm_exit(all, status);
-  chpl_topo_exit();
+  if (all) {
+    chpl_mem_exit();
+    chpl_topo_exit();
+  }
   exit(status);
 }
 


### PR DESCRIPTION
Previously we were shutting down the memory layer before the comm layer, but
the comm layer should be allowed to allocate/deallocate during exit, so this
was the wrong order. Move mem exit after comm exit, and only run mem exit if
we're doing an orderly "all" exit.

We don't shutdown the tasking layer for an abnormal "any" exit because anything
could still be going on and we just want to shutdown without cleaning up much.
Similarly we don't want to try to shutdown the memory layer, because other
things (like the tasking or comm layer) could still be trying to allocate and
deallocate memory and if the memory layer is shutdown this could just lead to
other confusing errors instead of just exiting.

This resolves https://github.com/chapel-lang/chapel/issues/7718 and https://chapel.atlassian.net/browse/CHAPEL-274