### PR TITLE
Wrappers 3

### DIFF
--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -998,16 +998,6 @@ static FnSymbol* promotionWrap(FnSymbol* fn,
 
   Vec<Symbol*>* actuals = &info.actuals;
 
-  if (fn->name == astrSequals) {
-    return fn;
-  }
-
-  // Don't try to promotion wrap _ref type constructor
-  if (fn->hasFlag(FLAG_TYPE_CONSTRUCTOR)) {
-    return fn;
-  }
-
-  bool      promotion_wrapper_required = false;
   int       j                          = -1;
   SymbolMap promoted_subs;
 
@@ -1028,35 +1018,29 @@ static FnSymbol* promotionWrap(FnSymbol* fn,
 
     if (canDispatch(actualType, actualSym, formal->type, fn, &promotes)) {
       if (promotes) {
-        promotion_wrapper_required = true;
         promoted_subs.put(formal, actualType->symbol);
       }
     }
   }
 
-  if (promotion_wrapper_required) {
-    if (fReportPromotion) {
-      USR_WARN(info.call, "promotion on %s", info.toString());
-    }
-
-    FnSymbol* wrapper = checkCache(promotionsCache, fn, &promoted_subs);
-
-    if (wrapper == NULL) {
-      wrapper = buildPromotionWrapper(fn,
-                                      info,
-                                      buildFastFollowerChecks,
-                                      &promoted_subs);
-
-      addCache(promotionsCache, fn, wrapper, &promoted_subs);
-    }
-
-    resolveFormals(wrapper);
-
-    return wrapper;
-
-  } else {
-    return fn;
+  if (fReportPromotion) {
+    USR_WARN(info.call, "promotion on %s", info.toString());
   }
+
+  FnSymbol* wrapper = checkCache(promotionsCache, fn, &promoted_subs);
+
+  if (wrapper == NULL) {
+    wrapper = buildPromotionWrapper(fn,
+                                    info,
+                                    buildFastFollowerChecks,
+                                    &promoted_subs);
+
+    addCache(promotionsCache, fn, wrapper, &promoted_subs);
+  }
+
+  resolveFormals(wrapper);
+
+  return wrapper;
 }
 
 static FnSymbol* buildPromotionWrapper(FnSymbol*  fn,

--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -1043,6 +1043,9 @@ static bool isPromotionRequired(FnSymbol* fn, CallInfo& info) {
   return retval;
 }
 
+// NB: This function is only invoked if isPromotionRequired() has
+// returned true.  This function is only required to perform the
+// desired transformations.
 static FnSymbol* promotionWrap(FnSymbol* fn,
                                CallInfo& info,
                                bool      fastFollowerChecks) {


### PR DESCRIPTION
wrap 3 :- continue to split wrappers in to manageable blocks of code

On master buildPromotionWrapper() is almost 300 lines
of somewhat tortuous code. This PR breaks this down to
a handful of more manageable functions.

This factoring was developed on a separate branch with extensive
testing. This PR applies that update in a relatively large number of
commits to help clarify the trivial transformations that are being
applied.

Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.
Ran a small portion of release/ for each config.

Passed single-locale paratest with futures on gcc/linux64
Passed paratest with futures and --no-local on gcc/linux64
