### PR TITLE
Add sub_test filtering for Jira 287

### DIFF
--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -2106,6 +2106,12 @@ for testname in testsrc:
                                     extra_msg = '(possible JIRA 274) '
                                     break
 
+                            err_strings = ['Clock skew detected']
+                            for s in err_strings:
+                                if re.search(s, output, re.IGNORECASE) != None:
+                                    extra_msg = '(possible JIRA 287) '
+                                    break
+
                             sys.stdout.write('%s[Error %s'%(futuretest, extra_msg))
 
                         sys.stdout.write('matching program output for %s/%s'%


### PR DESCRIPTION
Jira 287 (Clock skew) is a sporadic failure we see mostly on VMs though
occasionally on real hardware too.

This adds sub_test filtering so it's easier to pick out when this error occurs.
It happens once in a while in nightly testing (I count 10 occurrences this
year), and this should make it much easier to pick out. Long term we may want
to squash theses errors if they keep occurring since they don't affect
correctness and there's nothing we can do about it, but this at least makes it
easier to identify for now.