### PR TITLE
Restructure extendLeaderNew() and its helpers

### DIFF
--- a/compiler/AST/ForallStmt.cpp
+++ b/compiler/AST/ForallStmt.cpp
@@ -21,6 +21,7 @@
 #include "AstVisitor.h"
 #include "build.h"
 #include "foralls.h"
+#include "ForLoop.h"
 #include "passes.h"
 #include "stringutil.h"
 
@@ -33,7 +34,8 @@
 ForallStmt::ForallStmt(bool zippered, BlockStmt* body):
   Stmt(E_ForallStmt),
   fZippered(zippered),
-  fLoopBody(body)
+  fLoopBody(body),
+  fFromForLoop(false)
 {
   fIterVars.parent = this;
   fIterExprs.parent = this;
@@ -399,4 +401,20 @@ BlockStmt* ForallStmt::build(Expr* indices, Expr* iterator, CallExpr* intents,
   body->blockTag = BLOCK_NORMAL; // do not flatten it in cleanup(), please
 
   return buildChapelStmt(fs);
+}
+
+/////////////////////////////////////////////////////////////////////////////
+// support for converting from a for loop
+/////////////////////////////////////////////////////////////////////////////
+
+ForallStmt* ForallStmt::fromForLoop(ForLoop* forLoop) {
+  // intended only for for-loops
+  INT_ASSERT(forLoop->isForLoop());
+  // conversion from zippered is not implemented
+  INT_ASSERT(forLoop->zipperedGet() == false);
+
+  ForallStmt* result = new ForallStmt(false, new BlockStmt());
+  result->fFromForLoop = true;
+
+  return result;
 }

--- a/compiler/AST/foralls.cpp
+++ b/compiler/AST/foralls.cpp
@@ -275,24 +275,106 @@ bool astUnderFI(const Expr* ast, ForallIntents* fi) {
 //  * follower iterator(s), if needed, are invoked from within the leader loop
 //  * all inductionVariables()' DefExprs are moved to the original loop body
 
+/////////// fsIterYieldType ///////////
+
+/*
+When we are dealing with a recursive parallel iterator, we call
+fsIterYieldType() while resolving it. At that time, IteratorInfo
+has not been created yet. Also the yield type is not yet avaiable
+anywhere, because it is the type of a tuple of the original return type
+plus one component per shadow variable.
+
+Ex. standalone iter walkdirs() in FileSystem module, as tested by:
+  test/modules/standard/FileSystem/filerator/bradc/findfiles-par.chpl
+
+Therefore we compute this extended yield type manually.
+*/
+static QualifiedType buildIterYieldType(ForallStmt* fs, FnSymbol* iterFn) {
+  if (fs->numIntentVars() == 0) {
+    // The iterator has not undergone extendLeader().
+    // It still yields whatever the user wrote.
+    // Its return symbol is still in tact.
+
+    QualifiedType result(iterFn->getReturnSymbol()->type);
+    // What is the right qualifier?
+    return result;
+  }
+
+  // Otherwise, build the tuple mocking what iterFn yields, supposedly.
+  CallExpr* constup = new CallExpr("_type_construct__tuple");
+
+  // The original return type is available: it must have been declared
+  // by the user, since the iterator is recursive.
+  Symbol* origRetSym = lookupForallIntentsOrigRetSym(iterFn);
+  INT_ASSERT(origRetSym != NULL);
+  INT_ASSERT(origRetSym->type != dtUnknown);
+  constup->insertAtTail(origRetSym->type->symbol);
+
+  // The other tuple components are refs to shadow variables,
+  // so their types come from respective outer variables.
+  for_shadow_vars(svar, temp, fs) {
+    Symbol* ovar = NULL;
+    switch (svar->intent) {
+      case TFI_DEFAULT:
+      case TFI_CONST:
+      case TFI_IN:
+      case TFI_CONST_IN:
+      case TFI_REF:
+      case TFI_CONST_REF:
+        ovar = svar->outerVarSym();
+        break;
+
+      case TFI_REDUCE:
+        // ... except for reduce intents - they are TODO.
+        USR_FATAL_CONT(svar, "Reduce intents are currently not implemented"
+          " for forall- or for-loops over recursive parallel iterators");
+        USR_PRINT(iterFn, "the parallel iterator is here");
+        USR_STOP();
+        break;
+    }
+    INT_ASSERT(ovar != NULL);
+    INT_ASSERT(ovar->type != dtUnknown);
+
+    constup->insertAtTail(ovar->type->getRefType()->symbol);
+  }
+
+  int numComponents = constup->numActuals();
+  constup->insertAtHead(new_IntSymbol(numComponents));
+
+  // Resolve it now.
+  fs->insertBefore(constup);
+  resolveCall(constup);
+  constup->remove();
+
+  // What is the right qualifier?
+  QualifiedType result(constup->qualType().type());
+  return result;
+}
+
+
 //
 // Given an iterator function, find the type that it yields.
 // It would be fn->retType, alas protoIteratorClass() messes with that.
-// This helper is ForallStmt-specific because of the error message it issues.
+// This helper is ForallStmt-specific because of the assumptions it makes.
 //
-static QualifiedType fsIterYieldType(FnSymbol* iterFn, CallExpr* iterCall)
+static QualifiedType fsIterYieldType(ForallStmt* fs, FnSymbol* iterFn,
+                                     bool alreadyResolved)
 {
   if (iterFn->isIterator()) {
-    IteratorInfo* ii = iterFn->iteratorInfo;
-    INT_ASSERT(ii);
-    return ii->getValue->getReturnQualType();
+    if (IteratorInfo* ii = iterFn->iteratorInfo) {
+      return ii->getValue->getReturnQualType();
+    } else {
+      // We are in the midst of resolving a recursive iterator.
+      INT_ASSERT(alreadyResolved);
+      return buildIterYieldType(fs, iterFn);
+    }
   } else {
     // e.g. "proc these() return _value.these();"
     AggregateType* retType = toAggregateType(iterFn->retType);
     INT_ASSERT(retType && retType->symbol->hasFlag(FLAG_ITERATOR_RECORD));
     FnSymbol* iterator = retType->iteratorInfo->iterator;
     INT_ASSERT(iterator->isIterator()); // no more recursion?
-    return fsIterYieldType(iterator, iterCall);
+    return fsIterYieldType(fs, iterator, alreadyResolved);
   }
 }
 
@@ -559,10 +641,12 @@ static void resolveParallelIteratorAndIdxVar(ForallStmt* pfs,
 {
   // The par iterator probably has been extendLeader()-ed for forall intents.
   FnSymbol* parIter = iterCall->resolvedFunction();
+  bool alreadyResolved = parIter->isResolved();
+
   resolveFns(parIter);
 
   // Set QualifiedType of the index variable.
-  QualifiedType iType = fsIterYieldType(parIter, iterCall);
+  QualifiedType iType = fsIterYieldType(pfs, parIter, alreadyResolved);
   VarSymbol* idxVar = parIdxVar(pfs);
 
   if (idxVar->id == breakOnResolveID)

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -950,7 +950,7 @@ void ShadowVarSymbol::verify() {
   Symbol::verify();
   if (astTag != E_ShadowVarSymbol)
     INT_FATAL(this, "Bad ShadowVarSymbol::astTag");
-  if (!iteratorsLowered)
+  if (!iteratorsLowered && !isReduce())
     INT_ASSERT(outerVarRep);
   if (outerVarRep && outerVarRep->parentSymbol != this)
     INT_FATAL(this, "Bad ShadowVarSymbol::outerVarRep::parentSymbol");
@@ -958,7 +958,7 @@ void ShadowVarSymbol::verify() {
     INT_FATAL(this, "Bad ShadowVarSymbol::specBlock::parentSymbol");
   if (outerVarRep) {
     verifyNotOnList(outerVarRep);
-    // this assert hold already after scopeResolve
+    // this assert holds already after scopeResolve
     INT_ASSERT(!normalized || isSymExpr(outerVarRep));
   }
   // for VarSymbol
@@ -971,10 +971,9 @@ void ShadowVarSymbol::verify() {
     INT_ASSERT(pfs);
     INT_ASSERT(defPoint->list == &(pfs->intentVariables()));
   }
-  bool reduce = isReduce();
-  INT_ASSERT(reduce == (intent == TFI_REDUCE));
-  if (!iteratorsLowered)
-    INT_ASSERT(reduce == (specBlock != NULL));
+  INT_ASSERT(isReduce() == (intent == TFI_REDUCE));
+  if (!iteratorsLowered && specBlock != NULL)
+    INT_ASSERT(isReduce());
 }
 
 void ShadowVarSymbol::accept(AstVisitor* visitor) {

--- a/compiler/include/ForallStmt.h
+++ b/compiler/include/ForallStmt.h
@@ -32,9 +32,13 @@ class ForallStmt : public Stmt
 public:
   bool       zippered()       const; // was 'zip' keyword used?
   AList&     inductionVariables();   // DefExprs, one per iterated expr
-  AList&     iteratedExpressions();  // SymExprs, CallExprs
+  AList&     iteratedExpressions();  // SymExprs, one per iterated expr
   AList&     intentVariables();      // DefExprs of LoopIntentVars
   BlockStmt* loopBody()       const; // the body of the forall loop
+
+  // when originating from a ForLoop
+  bool       iterCallAlreadyTagged() const;  // already has 'tag' actual
+  bool       noFindOuterVars()       const;  // no add'l shadow variables
 
   DECLARE_COPY(ForallStmt);
 
@@ -50,6 +54,9 @@ public:
   // for the parser
   static BlockStmt* build(Expr* indices, Expr* iterator, CallExpr* intents,
                           BlockStmt* body, bool zippered = false);
+
+  static ForallStmt* fromForLoop(ForLoop* forLoop);
+
   // helpers
   Expr* firstIteratedExpr()        const;
   int   numIteratedExprs()         const;
@@ -64,6 +71,7 @@ private:
   AList          fIterExprs;
   AList          fIntentVars;  // may be empty
   BlockStmt*     fLoopBody;    // always present
+  bool           fFromForLoop;
 
   ForallStmt(bool zippered, BlockStmt* body);
 };
@@ -74,6 +82,8 @@ inline AList& ForallStmt::inductionVariables()   { return fIterVars;   }
 inline AList& ForallStmt::iteratedExpressions()  { return fIterExprs;  }
 inline AList& ForallStmt::intentVariables()      { return fIntentVars; }
 inline BlockStmt* ForallStmt::loopBody()   const { return fLoopBody;   }
+inline bool ForallStmt::iterCallAlreadyTagged() const { return fFromForLoop; }
+inline bool ForallStmt::noFindOuterVars()       const { return fFromForLoop; }
 
 // conveniences
 inline Expr* ForallStmt::firstIteratedExpr() const { return fIterExprs.head;  }

--- a/compiler/include/ForallStmt.h
+++ b/compiler/include/ForallStmt.h
@@ -37,6 +37,7 @@ public:
   BlockStmt* loopBody()       const; // the body of the forall loop
 
   // when originating from a ForLoop
+  bool       createdFromForLoop()    const;  // is converted from a for-loop
   bool       iterCallAlreadyTagged() const;  // already has 'tag' actual
   bool       needToHandleOuterVars() const;  // yes, convert to shadow vars
 
@@ -76,14 +77,14 @@ private:
   ForallStmt(bool zippered, BlockStmt* body);
 };
 
-/* fFromForLoop / iterCallAlreadyTagged / needToHandleOuterVars
+/* fFromForLoop and its accessors
 
 These support handling of some ForLoops by converting them to ForallStmts.
 They cause skipping certain actions for these "conversion" ForallStmt nodes.
 
 Why not just have a single accessor to fFromForLoop? This is to emphasize
-that the two accessors check different properties. These two properties could
-potentially be independent of each other and of fFromForLoop.
+that the three accessors check different properties. These properties could
+potentially be independent of each other.
 
 As fFromForLoop is currently local to implementForallIntents, we may be able
 to replace fFromForLoop with a HashSet. If so, we need to ensure that the
@@ -98,6 +99,7 @@ inline AList& ForallStmt::intentVariables()      { return fIntentVars; }
 inline BlockStmt* ForallStmt::loopBody()   const { return fLoopBody;   }
 inline bool ForallStmt::iterCallAlreadyTagged() const { return fFromForLoop; }
 inline bool ForallStmt::needToHandleOuterVars() const { return !fFromForLoop; }
+inline bool ForallStmt::createdFromForLoop()    const { return fFromForLoop; }
 
 // conveniences
 inline Expr* ForallStmt::firstIteratedExpr() const { return fIterExprs.head;  }

--- a/compiler/include/ForallStmt.h
+++ b/compiler/include/ForallStmt.h
@@ -38,7 +38,7 @@ public:
 
   // when originating from a ForLoop
   bool       iterCallAlreadyTagged() const;  // already has 'tag' actual
-  bool       noFindOuterVars()       const;  // no add'l shadow variables
+  bool       needToHandleOuterVars() const;  // yes, convert to shadow vars
 
   DECLARE_COPY(ForallStmt);
 
@@ -71,10 +71,24 @@ private:
   AList          fIterExprs;
   AList          fIntentVars;  // may be empty
   BlockStmt*     fLoopBody;    // always present
-  bool           fFromForLoop;
+  bool           fFromForLoop; // see comment below
 
   ForallStmt(bool zippered, BlockStmt* body);
 };
+
+/* fFromForLoop / iterCallAlreadyTagged / needToHandleOuterVars
+
+These support handling of some ForLoops by converting them to ForallStmts.
+They cause skipping certain actions for these "conversion" ForallStmt nodes.
+
+Why not just have a single accessor to fFromForLoop? This is to emphasize
+that the two accessors check different properties. These two properties could
+potentially be independent of each other and of fFromForLoop.
+
+As fFromForLoop is currently local to implementForallIntents, we may be able
+to replace fFromForLoop with a HashSet. If so, we need to ensure that the
+set membership is propagated through cloning, if applicable.
+*/
 
 // accessor implementations
 inline bool   ForallStmt::zippered()       const { return fZippered;   }
@@ -83,7 +97,7 @@ inline AList& ForallStmt::iteratedExpressions()  { return fIterExprs;  }
 inline AList& ForallStmt::intentVariables()      { return fIntentVars; }
 inline BlockStmt* ForallStmt::loopBody()   const { return fLoopBody;   }
 inline bool ForallStmt::iterCallAlreadyTagged() const { return fFromForLoop; }
-inline bool ForallStmt::noFindOuterVars()       const { return fFromForLoop; }
+inline bool ForallStmt::needToHandleOuterVars() const { return !fFromForLoop; }
 
 // conveniences
 inline Expr* ForallStmt::firstIteratedExpr() const { return fIterExprs.head;  }

--- a/compiler/include/expr.h
+++ b/compiler/include/expr.h
@@ -474,7 +474,10 @@ static inline bool needsCapture(FnSymbol* taskFn) {
 }
 
 inline Symbol* ShadowVarSymbol::outerVarSym() const {
-  return this->outerVarSE()->symbol();
+  if (SymExpr* ovse = this->outerVarSE())
+    return ovse->symbol();
+  else
+    return NULL;
 }
 
 // E.g. NamedExpr::actual, DefExpr::init.

--- a/compiler/include/foralls.h
+++ b/compiler/include/foralls.h
@@ -56,6 +56,7 @@ public:
 
 bool astUnderFI(const Expr* ast, ForallIntents* fi);
 void lowerForallStmts();
+Symbol* lookupForallIntentsOrigRetSym(FnSymbol* iterFn);
 
 #define for_riSpecs_vector(VAL, FI) \
   for_vector_allowing_0s(Expr, VAL, (FI)->riSpecs)

--- a/compiler/include/implementForallIntents.h
+++ b/compiler/include/implementForallIntents.h
@@ -49,8 +49,8 @@ FnSymbol*  copyLeaderFn(FnSymbol* origFn, bool ignore_isResolved);
 
 void extendLeaderNew(ForallStmt* fs, FnSymbol* origIterFn, CallExpr* iterCall);
 
-static const char* astrArg(int ix, const char* base) {
-  return astr("x", istr(ix+1), "_", base);
+static const char* intentArgName(int ix, const char* base) {
+  return astr("chpl_", istr(ix+1), "_", base);
 }
 
 #endif

--- a/compiler/include/implementForallIntents.h
+++ b/compiler/include/implementForallIntents.h
@@ -46,11 +46,16 @@ void      addArgsToToLeaderCallForPromotionWrapper(FnSymbol* fn,
 VarSymbol* localizeYieldForExtendLeader(Expr* origRetExpr, Expr* ref);
 void       checkAndRemoveOrigRetSym(Symbol* origRet, FnSymbol* parentFn);
 FnSymbol*  copyLeaderFn(FnSymbol* origFn, bool ignore_isResolved);
+void       printIFI2cache();
+void       IFI2cacheAdd(ForallStmt* fs, FnSymbol* origIter,
+                        FnSymbol* extdIter);
+bool       redirectedToIfi2Cache(ForallStmt* fs, FnSymbol* origIter,
+                                 CallExpr* iterCall);
 
 void extendLeaderNew(ForallStmt* fs, FnSymbol* origIterFn, CallExpr* iterCall);
 
 static const char* intentArgName(int ix, const char* base) {
-  return astr("chpl_", istr(ix+1), "_", base);
+  return astr("_x", istr(ix+1), "_", base);
 }
 
 #endif

--- a/compiler/include/implementForallIntents.h
+++ b/compiler/include/implementForallIntents.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2004-2017 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _implementForallIntents_H_
+#define _implementForallIntents_H_
+
+#include "resolution.h"
+
+#include "astutil.h"
+#include "DeferStmt.h"
+#include "driver.h"
+#include "ForallStmt.h"
+#include "ForLoop.h"
+#include "passes.h"
+#include "resolveIntents.h"
+#include "stlUtil.h"
+#include "stringutil.h"
+#include "visibleFunctions.h"
+#include <utility>
+
+// functions currently defined/used across implementForallIntents*.cpp
+
+extern Map<FnSymbol*,FnSymbol*> pristineLeaderIterators;
+
+IntentTag argIntentForForallIntent(ForallIntentTag tfi);
+bool      callingParallelIterator(CallExpr* call);
+void      addArgsToToLeaderCallForPromotionWrapper(FnSymbol* fn,
+                                                   int numExtraArgs,
+                                                   Symbol* extraFormals[]);
+VarSymbol* localizeYieldForExtendLeader(Expr* origRetExpr, Expr* ref);
+void       checkAndRemoveOrigRetSym(Symbol* origRet, FnSymbol* parentFn);
+FnSymbol*  copyLeaderFn(FnSymbol* origFn, bool ignore_isResolved);
+
+void extendLeaderNew(ForallStmt* fs, FnSymbol* origIterFn, CallExpr* iterCall);
+
+static const char* astrArg(int ix, const char* base) {
+  return astr("x", istr(ix+1), "_", base);
+}
+
+#endif

--- a/compiler/resolution/Makefile.share
+++ b/compiler/resolution/Makefile.share
@@ -24,6 +24,7 @@ RESOLUTION_SRCS =                                              \
                   cullOverReferences.cpp                       \
                   expandVarArgs.cpp                            \
                   implementForallIntents.cpp                   \
+                  implementForallIntents2.cpp                  \
                   generics.cpp                                 \
                   functionResolution.cpp                       \
                   initializerResolution.cpp                    \

--- a/compiler/resolution/implementForallIntents.cpp
+++ b/compiler/resolution/implementForallIntents.cpp
@@ -17,18 +17,7 @@
  * limitations under the License.
  */
 
-#include "resolution.h"
-
-#include "astutil.h"
-#include "driver.h"
-#include "ForallStmt.h"
-#include "ForLoop.h"
-#include "passes.h"
-#include "resolveIntents.h"
-#include "stlUtil.h"
-#include "stringutil.h"
-#include "visibleFunctions.h"
-#include <utility>
+#include "implementForallIntents.h"
 
 //
 //-----------------------------------------------------------------------------
@@ -822,10 +811,10 @@ void implementForallIntents1(DefExpr* defChplIter)
 // Todo: for a given leader, we could also cache specializations
 // for each set of outer variables that we have seen.
 // Like SymbolMapCache?
-static Map<FnSymbol*,FnSymbol*> pristineLeaderIterators;
+Map<FnSymbol*,FnSymbol*> pristineLeaderIterators;
 
 
-static FnSymbol* copyLeaderFn(FnSymbol* origFn, bool ignore_isResolved) {
+FnSymbol* copyLeaderFn(FnSymbol* origFn, bool ignore_isResolved) {
   SET_LINENO(origFn->defPoint);
   FnSymbol* copyFn = origFn->copy();
   copyFn->addFlag(FLAG_INVISIBLE_FN);
@@ -950,7 +939,7 @@ static void propagateExtraArgsForLoopIter(CallExpr* call,
 //
 // Return this new symbol.
 //
-static VarSymbol* localizeYieldForExtendLeader(Expr* origRetExpr, Expr* ref) {
+VarSymbol* localizeYieldForExtendLeader(Expr* origRetExpr, Expr* ref) {
   SymExpr* orse = toSymExpr(origRetExpr);
   INT_ASSERT(orse);
   Symbol* origRetSym = orse->symbol();
@@ -982,7 +971,7 @@ static VarSymbol* localizeYieldForExtendLeader(Expr* origRetExpr, Expr* ref) {
 //
 // Verify that 'origRet' is not used, and remove it from the tree.
 //
-static void checkAndRemoveOrigRetSym(Symbol* origRet, FnSymbol* parentFn) {
+void checkAndRemoveOrigRetSym(Symbol* origRet, FnSymbol* parentFn) {
   // parentFn and this assert are just sanity checking for the caller
   INT_ASSERT(origRet->defPoint->parentSymbol == parentFn);
 
@@ -1055,10 +1044,6 @@ bool isReduceOp(Type* type) {
     if (isReduceOp(t))
       return true;
   return false;
-}
-
-static const char* astrArg(int ix, const char* add1) {
-  return astr("x", istr(ix+1), "_", add1);
 }
 
 //
@@ -1214,7 +1199,7 @@ static Symbol* createShadowVarIfNeeded(ShadowVarSymbol *shadowvar,
 // within PWL.  We *need* to bypass the machinery related to handling the
 // loop index - otherwise an extraneous new x1_svarRef will be generated.
 //
-static void addArgsToToLeaderCallForPromotionWrapper(FnSymbol* fn,
+void addArgsToToLeaderCallForPromotionWrapper(FnSymbol* fn,
                                                      int numExtraArgs,
                                                      Symbol* extraFormals[])
 {
@@ -1233,7 +1218,7 @@ static void addArgsToToLeaderCallForPromotionWrapper(FnSymbol* fn,
 // Is 'call' invoking a parallel iterator?
 // Since the call is not resolved, we can't use isLeaderIterator(),
 // and this implementation is a heuristic.
-static bool callingParallelIterator(CallExpr* call) {
+bool callingParallelIterator(CallExpr* call) {
   // Check 'call' for an actual argument that's a parallel tag.
   // Todo: handle the case where the actual's value is not known yet.
   for_actuals(actual, call) {
@@ -1877,7 +1862,7 @@ void implementForallIntents2wrapper(CallExpr* call, CallExpr* eflopiHelper)
 /////////////////////////////////////////////////////////////////////////////
 // ForallIntentTag <-> IntentTag
 
-static IntentTag argIntentForForallIntent(ForallIntentTag tfi) {
+IntentTag argIntentForForallIntent(ForallIntentTag tfi) {
   switch (tfi) {
     case TFI_DEFAULT:   return INTENT_BLANK;
     case TFI_CONST:     return INTENT_CONST;
@@ -2012,7 +1997,7 @@ static void findOuterVarsNew(ForallStmt* fs, SymbolMap& outer2shadow,
 }
 
 /////////////////////////////////////////////////////////////////////////////
-// markOuterVarsWithIntentsNew() and helpers
+// setup for a reduce intent
 //
 
 //
@@ -2116,9 +2101,13 @@ static Symbol* setupRiGlobalOp(ForallStmt* fs, Symbol* fiVarSym,
   return globalOp;
 }
 
-static Symbol* handleRISpec(ForallStmt* fs, ShadowVarSymbol* svar)
+static void handleRISpec(ForallStmt* fs, ShadowVarSymbol* svar)
 {
-  Symbol* result = NULL;
+  if (svar->reduceGlobalOp != NULL)
+    // Already handled, ex. in tupcomForYieldInForall().
+    return;
+
+  Symbol* globalOp = NULL;
   Symbol* fiVarSym = svar->outerVarSym();
   Expr*   riSpec   = svar->reduceOpExpr();
   SET_LINENO(riSpec);
@@ -2127,7 +2116,7 @@ static Symbol* handleRISpec(ForallStmt* fs, ShadowVarSymbol* svar)
     Symbol* riSym = riSE->symbol();
 
     if (TypeSymbol* riTypeSym = toTypeSymbol(riSym)) {
-      result = setupRiGlobalOp(fs, fiVarSym, riSpec, riTypeSym, NULL);
+      globalOp = setupRiGlobalOp(fs, fiVarSym, riSpec, riTypeSym, NULL);
 
     } else {
       INT_ASSERT(isLcnSymbol(riSym)); // what else can a globalOp be??
@@ -2137,7 +2126,7 @@ static Symbol* handleRISpec(ForallStmt* fs, ShadowVarSymbol* svar)
       // The user will manage allocation and deallocation of 'riSym'.
       // So we only need to add a call generate().
       insertFinalGenerate(fs, fiVarSym, riSym);
-      result = riSym;
+      globalOp = riSym;
     }
 
   } else if (CallExpr* riSpecCall = toCallExpr(riSpec)) {
@@ -2151,24 +2140,14 @@ static Symbol* handleRISpec(ForallStmt* fs, ShadowVarSymbol* svar)
 
     riTypeSE->remove();
     Expr* eltTypeArg = riSpecCall->get(1)->remove();
-    result = setupRiGlobalOp(fs, fiVarSym, riSpec, riTypeSym, eltTypeArg);
+    globalOp = setupRiGlobalOp(fs, fiVarSym, riSpec, riTypeSym, eltTypeArg);
 
   } else {
     // What else can this be?
     INT_FATAL(fs, "not implemented");
   }
 
-  return result;
-}
-
-// Mark the variables listed in 'with' clauses, if any, with tiMark markers.
-// Same as markOuterVarsWithIntents() in createTaskFunctions.cpp,
-// except different representation.
-static void markOuterVarsWithIntentsNew(ForallStmt* fs)
-{
-  for_shadow_vars(sv, temp, fs)
-    if (sv->isReduce())
-      sv->reduceGlobalOp = handleRISpec(fs, sv);
+  svar->reduceGlobalOp = globalOp;
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -2176,9 +2155,13 @@ static void markOuterVarsWithIntentsNew(ForallStmt* fs)
 static void getOuterVarsNew(ForallStmt* fs, SymbolMap& outer2shadow,
                             BlockStmt* body)
 {
-  // do the same as in 'if (needsCapture(fn))' in createTaskFunctions()
-  findOuterVarsNew(fs, outer2shadow, body);
-  markOuterVarsWithIntentsNew(fs);
+  if (!fs->noFindOuterVars())
+    // do the same as in 'if (needsCapture(fn))' in createTaskFunctions()
+    findOuterVarsNew(fs, outer2shadow, body);
+
+  for_shadow_vars(sv, temp, fs)
+    if (sv->isReduce())
+      handleRISpec(fs, sv);
 }
 
 // Append the new ShadowVarSymbols we accumulated to fs->intentVariables().
@@ -2186,8 +2169,6 @@ static void appendNewShadowVars(ForallStmt* fs, SymbolMap& outer2shadow) {
   form_Map(SymbolMapElem, elem, outer2shadow)
     fs->intentVariables().insertAtTail(new DefExpr(elem->value));
 }
-
-/////////////////////////////////////////////////////////////////////////////
 
 // Not to be invoked upon a reduce intent.
 // All our shadow variables are expected to be refs.
@@ -2213,32 +2194,38 @@ static void setShadowVarFlagsNew(Symbol* ovar, ShadowVarSymbol* svar, IntentTag 
   }
 }
 
-//
-// This does some processing of the shadow vars.
-// Todo: give it a better name.
-//
-static void createShadowVarsNew(ForallStmt* fs, BlockStmt* body, int& numShadowVars)
+static void processShadowVarsNew(ForallStmt* fs, BlockStmt* body, int& numShadowVars)
 {
   // todo: prune right away, get rid of 'numShadowVars'
 
-  for_shadow_vars(svar, temp, fs)
-  {
-    Symbol* ovar = svar->outerVarSym();
-    svar->type = ovar->type->getRefType();
-    resolveSVarIntent(svar);
+  for_shadow_vars(svar, temp, fs) {
+    if (svar->isReduce())
+    {
+      Symbol* ovar = svar->outerVarSym();
+      if (ovar && ovar->hasFlag(FLAG_CONST))
+        USR_FATAL_CONT(fs,
+          "reduce intent is applied to a 'const' variable %s", ovar->name);
 
-    // If ovar is a reference, e.g. an index variable of
-    // a 'var' iterator, we do not want to force
-    // that ref type onto 'svar'. Otherwise the generated
-    // code will store into *svar without initializing svar
-    // first. Todo: what if ovar is a domain?
-    Type* valtype = ovar->type->getValType();
+      // The shadow variable will assume the reference from the leadIdx tuple.
+      svar->addFlag(FLAG_REF_VAR);
+      svar->qual = QUAL_REF;
+      svar->type = dtUnknown;
+    }
+    else
+    {
+      Symbol* ovar = svar->outerVarSym();
+      svar->type = ovar->type->getRefType();
+      resolveSVarIntent(svar);
 
-    bool       isReduce = svar->isReduce();
-    IntentTag  tiIntent = INTENT_BLANK; // not used for reduce intents
+      // If ovar is a reference, e.g. an index variable of
+      // a 'var' iterator, we do not want to force
+      // that ref type onto 'svar'. Otherwise the generated
+      // code will store into *svar without initializing svar
+      // first. Todo: what if ovar is a domain?
+      Type* valtype = ovar->type->getValType();
 
-    if (!isReduce) {
-      tiIntent = concreteIntent(argIntentForForallIntent(svar->intent), valtype);
+      IntentTag  tiIntent =
+        concreteIntent(argIntentForForallIntent(svar->intent), valtype);
 
       // See if we want to prune it.
       bool pruneit = false;
@@ -2263,19 +2250,9 @@ static void createShadowVarsNew(ForallStmt* fs, BlockStmt* body, int& numShadowV
         svar->pruneit = true;
         continue; // for_shadow_vars
       }
-    }  // if !isReduce
 
-    if (isReduce) {
-      if (ovar->hasFlag(FLAG_CONST))
-        USR_FATAL_CONT(fs,
-          "reduce intent is applied to a 'const' variable %s", ovar->name);
-      // The shadow variable will assume the reference from the leadIdx tuple.
-      svar->addFlag(FLAG_REF_VAR);
-      svar->type = dtUnknown;
-    } else {
       setShadowVarFlagsNew(ovar, svar, tiIntent);
     }
-
     numShadowVars++;
   }
 }
@@ -2487,7 +2464,7 @@ static void implementForallIntents1New(ForallStmt* fs, CallExpr* parCall) {
   int numInitialVars = (fs->intentVariables()).length;
   appendNewShadowVars(fs, outer2shadow);
 
-  createShadowVarsNew(fs, forallBody1, numShadowVars); // updates numShadowVars
+  processShadowVarsNew(fs, forallBody1, numShadowVars); // updates numShadowVars
 
   if (fs->numIntentVars() == numShadowVars)
     needToReplace = (outer2shadow.n > 0);
@@ -2527,416 +2504,9 @@ void implementForallIntentsNew(ForallStmt* fs, CallExpr* parCall)
 // implementForallIntents2New and helpers
 //
 
-// Handle a yield within propagateExtraLeaderArgs().
-static void propagateThroughYieldNew(ForallStmt* fs,
-                                  CallExpr* rcall,
-                                  FnSymbol* parentFn,
-                                  VarSymbol* retSym,
-                                  Symbol* extraActuals[],
-                                  Symbol* extraFormals[],
-                                  Symbol* shadowVarsRI[],
-                                  bool nested,
-                                  Expr*& redRef1,
-                                  Expr*& redRef2)
-{
-  // Make a tuple that includes the extra args.
-  Expr* origRetArg = rcall->get(1)->remove();
-  VarSymbol* newOrigRet = localizeYieldForExtendLeader(origRetArg, rcall);
-  CallExpr* buildTuple = new CallExpr("_build_tuple_always_allow_ref",
-                                      newOrigRet);
+// extendLeaderNew() is in implementForallIntents2.cpp
 
-  // Check for an "eflopi" (Enclosing For-Loop Over a Parallel Iterator).
-  // This is specific to a given yield.
-  // Todo: handle multiple yields in a single eflopi.
-  ForLoop*  eflopiLoop    = NULL;
-  CallExpr* eflopiCall    = NULL;
-  int       eflopiIdx     = 1;
-  CallExpr* eflopiHelper  = NULL;
-  int       ix            = -1;
-
-  // sets eflopiLoop and eflopiCall if appropriate:
-  eflopiFind(rcall, eflopiLoop, eflopiCall);
-
-  // add tuple components
-  for_shadow_vars(shadowvar, temp, fs) {
-    ++ix;
-    bool isReduce = shadowvar->isReduce();
-    Symbol* svar = shadowVarsRI[ix];
-    Symbol* tupleComponent;
-    if (isReduce) {
-
-      Symbol* parentOp = extraFormals[ix];
-      // not resolved yet: INT_ASSERT(isReduceOp(extraActuals[ix]->type));
-
-      // Todo: handle eflopi case when !isReduce.
-      if (eflopiCall) {
-        //
-        // Convert the eflopiLoop loop similarly to how a forall is handled:
-        //
-        // * pass parentOp/currOp to its eflopi's iterator
-        //    --> done earlier in propagateExtraLeaderArgs()
-        //        the same way as for non-eflopi reduce-intent args
-        //
-        // * propagate that parentOp/currOp within eflopi's iterator
-        //   and have it yield a tuple containing
-        //   the corresponding shadow var by reference
-        //    --> this is done by calling implementForallIntents2()
-        //        as caused by eflopiHelper, eflopiMap
-        //
-        // * detuple the value yielded by eflopi's iterator
-        //   into the original yielded value plus shadow variable(s)
-        //   for reduce intents
-        //    --> done below
-        //
-        // * yield the shadow variable as part of rcall's tuple
-        //    --> this is done via 'tupleComponent' as in non-eflopi case
-        //
-
-        // Detuple the value yielded by eflopi's parallel iterator
-        //
-        if (eflopiIdx == 1) {
-          // do only once for this yield
-          redirectToNewIOI(eflopiLoop);
-        }
-        Symbol* origIOI = eflopiLoop->indexGet()->symbol();
-        // If it fails, replace newOrigRet with newIOI in buildTuple.
-        INT_ASSERT(newOrigRet != origIOI);
-
-        // Extract and yield the shadow variable reference.
-        Symbol* rvar = new VarSymbol(astrArg(ix, "eflopiRvar"));
-        rvar->addFlag(FLAG_REF_VAR);
-        eflopiIdx++;
-        insertExtractFromYieldAtHead(eflopiLoop, eflopiIdx, rvar, origIOI);
-        eflopiLoop->insertAtHead(new DefExpr(rvar));
-        tupleComponent = rvar;
-
-        // Cause implementForallIntents2() over eflopi's parallel iterator.
-        if (!eflopiHelper)
-          eflopiHelper = new CallExpr(PRIM_ACTUALS_LIST, gVoid); // dummy arg
-        eflopiHelper->insertAtTail(parentOp);
-
-      } else {
-        if (!svar) {
-          INT_ASSERT(!nested); // nested case is handled above
-          setupRedRefs(parentFn, nested, redRef1, redRef2);
-          // Todo: skip these additions if the current 'rcall' yield
-          // is going to be compiled away, e.g. if it is
-          // within a param conditional on a not-taken branch.
-          svar = new VarSymbol(astrArg(ix, "shadowVarReduc"));
-          svar->addFlag(FLAG_INSERT_AUTO_DESTROY);
-          VarSymbol* stemp  = newTemp("svrTmp");
-          redRef1->insertBefore(new DefExpr(svar));
-          redRef1->insertBefore(new DefExpr(stemp));
-          redRef1->insertBefore("'move'(%S, identity(%S,%S))",
-                                stemp, gMethodToken, parentOp);
-          redRef1->insertBefore("'move'(%S, chpl__autoCopy(%S))",
-                                svar, stemp);
-          redRef2->insertBefore("accumulate(%S,%S,%S)",
-                                gMethodToken, parentOp, svar);
-          shadowVarsRI[ix] = svar;
-        }
-        // pass 'svar' by reference
-        // If the yield is inside a forall, (create and) pass
-        // the corresponding shadow variable instead.
-        Symbol* ssvar = createShadowVarIfNeeded(shadowvar, parentOp, svar, rcall);
-        // todo: have a single 'sref' per 'svar', not one for each yield
-        VarSymbol* sref = new VarSymbol(astrArg(ix, "svarRef"));
-        rcall->insertBefore(new DefExpr(sref));
-        rcall->insertBefore("'move'(%S, 'addr of'(%S))", sref, ssvar);
-        tupleComponent = sref;
-      }
-    } else {
-      if (eflopiLoop != NULL && shadowvar->intent == TFI_IN) {
-        USR_WARN(shadowvar, "switching from 'in' to 'const in' intent for the shadow variable %s", shadowvar->name);
-        USR_PRINT(shadowvar, "'in' intent is currently not implemented");
-        USR_PRINT(eflopiLoop, "due to a loop over a parallel iterator here");
-        shadowvar->intent = TFI_CONST_IN;
-      }
-
-      Symbol* toPass = extraFormals[ix];
-      INT_ASSERT(toPass->type != dtUnknown && // see 'else' below
-                 toPass->type != dtAny);
-      // Note: all shadow variables are yielded by ref.
-      if (toPass->isRef()) {
-        tupleComponent = extraFormals[ix];
-      } else {
-        // If the yield is inside a forall, (create and) pass
-        // the corresponding shadow variable instead.
-        Symbol* ssvar = createShadowVarIfNeeded(shadowvar, NULL, toPass, rcall);
-        // If toPass->type can be dtUnknown, we should do this always,
-        // using PRIM_SET_REFERENCE.
-        VarSymbol* ytemp = newTemp("svarAddrTmp", toPass->getRefType());
-        ytemp->qual = QUAL_REF;
-        rcall->insertBefore(new DefExpr(ytemp));
-        rcall->insertBefore("'move'(%S, 'addr of'(%S))", ytemp, ssvar);
-        tupleComponent = ytemp;                           
-      }
-    }
-    buildTuple->insertAtTail(new SymExpr(tupleComponent));
-  }
-
-  rcall->insertBefore("'move'(%S,%E)", retSym, buildTuple);
-  rcall->insertAtTail(new SymExpr(retSym));
-  if (eflopiHelper)
-    eflopiMap[eflopiCall] = eflopiHelper;
-}
-
-static void propagateRecursivelyNew(ForallStmt* fs,
-                                 FnSymbol* parentFn,
-                                 FnSymbol* currentFn,
-                                 VarSymbol* retSym,
-                                 Symbol* extraActuals[],
-                                 Symbol* extraFormals[],
-                                 Symbol* shadowVarsRI[],
-                                 bool nested,
-                                 Expr*& redRef1,
-                                 Expr*& redRef2);
-
-//
-// Propagate 'extraActuals' through the task constructs, implementing
-// task intents. See the header comment for extendLeader().
-//
-// * 'call' gets each of extraActuals[ix] added as an actual
-// * callee 'fn' gets a newly-created corresponding formal: extraFormals[ix]
-//
-// Within 'fn' :
-// * for each call to a task function: do the above recursively
-// * for each yield: convert to yielding (prev yield value, extraFormals[*])
-//
-// For a reduce-intent position -- when fivec[ix].isReduce():
-// * extraFormals[ix] is a parentOp - passed to task functions, extra treatment
-// * shadowVarsRI[ix] is created - passed to yields, extra treatment
-//
-static void propagateExtraLeaderArgsNew(ForallStmt* fs, CallExpr* call,
-                                     VarSymbol* retSym,
-                                     Symbol* extraActuals[],
-                                     bool nested)
-{
-  FnSymbol* fn = call->resolvedFunction();
-  INT_ASSERT(fn); // callee's responsibility
-
-  if (fn->hasFlag(FLAG_WRAPPER)) {
-    // We are not handling void-returning wrappers at the moment.
-    INT_ASSERT(!(fn->getReturnSymbol() == gVoid || fn->retType == dtVoid));
-  }
-
-  int     numExtraArgs = fs->numIntentVars();
-  Symbol* extraFormals[numExtraArgs];
-  Symbol* shadowVarsRI[numExtraArgs];
-  Expr    *redRef1 = NULL, *redRef2 = NULL;
-  int     ix = -1;
-
-  for_shadow_vars(svar, temp, fs) {
-    ++ix;
-    Symbol* eActual  = extraActuals[ix];
-    bool    isReduce = svar->isReduce();
-
-    // Use named args to disambiguate from the already-existing iterator args,
-    // just in case. This necessitates toNamedExpr() in handleCaptureArgs().
-    const char* eName   =
-      isReduce ? astrArg(ix, "reduceParent") :
-        nested ? eActual->name :
-          strcmp(eActual->name, "_tuple_expand_tmp_") ?
-            astrArg(ix, eActual->name) // uniquify arg name
-            : astrArg(ix, "tet");
-
-    IntentTag efInt = isReduce ? INTENT_BLANK :
-      concreteIntent(argIntentForForallIntent(svar->intent), eActual->type);
-    Type* efType = eActual->type;
-    bool  addFlagImm  = false;
-
-    if (efInt & INTENT_FLAG_REF) {
-      INT_ASSERT(!isReduce); // otherwise efType may be unknown
-      INT_ASSERT(efType != dtUnknown && efType != dtAny);
-
-      //
-      // For ref intents, we need to make it a ref type.
-      // Because eFormal will be passed to _build_tuple_always_allow_ref()
-      // - the call is created in propagateThroughYieldNew.
-      // If _build_tuple_always_allow_ref's actual has a non-ref type,
-      // even if it is an ArgSymbol with a ref intent, the corresponding
-      // component of the resulting tuple will be non-ref, which will break
-      // SSCA2 and test/parallel/forall/vass/intents-all-int.chpl.
-      // Todo: fix resolution of _build_tuple_always_allow_ref.
-      //
-      efType = efType->getRefType();
-
-      if (eActual->isConstValWillNotChange())
-        addFlagImm = true;
-    }
-    
-    ArgSymbol*  eFormal = new ArgSymbol(efInt, eName, efType);
-    if (addFlagImm || eActual->hasFlag(FLAG_REF_TO_IMMUTABLE))
-      eFormal->addFlag(FLAG_REF_TO_IMMUTABLE);
-
-    call->insertAtTail(new NamedExpr(eName, new SymExpr(eActual)));
-    fn->insertFormalAtTail(eFormal);
-    extraFormals[ix] = eFormal;
-
-    // In leader outside any taskFn just use reduceParent.
-    // Todo: also skip if there are no other taskFns or yields in 'fn'.
-    if (isReduce && nested) {
-      // We shouldn't bother with all this when it is not a task function.
-      INT_ASSERT(isTaskFun(fn));
-      setupRedRefs(fn, nested, redRef1, redRef2);
-      ArgSymbol* parentOp = eFormal; // the reduceParent arg
-      VarSymbol* currOp   = new VarSymbol(astrArg(ix, "reduceCurr"));
-      VarSymbol* svar     = new VarSymbol(astrArg(ix, "shadowVar"));
-      svar->addFlag(FLAG_INSERT_AUTO_DESTROY);
-      VarSymbol* stemp    = newTemp("svTmp");
-      redRef1->insertBefore(new DefExpr(currOp));
-      redRef1->insertBefore("'move'(%S, clone(%S,%S))", // init
-                            currOp, gMethodToken, parentOp);
-      redRef1->insertBefore(new DefExpr(svar));
-      redRef1->insertBefore(new DefExpr(stemp));
-      redRef1->insertBefore("'move'(%S, identity(%S,%S))",
-                            stemp, gMethodToken, currOp);
-      redRef1->insertBefore("'move'(%S, chpl__autoCopy(%S))",
-                            svar, stemp);
-      redRef2->insertBefore("accumulate(%S,%S,%S)",
-                            gMethodToken, currOp, svar);
-      redRef2->insertBefore("chpl__reduceCombine(%S,%S)", parentOp, currOp);
-      redRef2->insertBefore("chpl__cleanupLocalOp(%S,%S)", parentOp, currOp);
-      // use currOp instead of parentOp for yielding and passing to taskFns
-      extraFormals[ix] = currOp;
-      shadowVarsRI[ix]   = svar;
-    } else {
-      shadowVarsRI[ix] = NULL;
-    }
-  }
-
-  if (!nested && fn->hasFlag(FLAG_PROMOTION_WRAPPER)) {
-    INT_ASSERT(!redRef1); // no need to clean them up
-    addArgsToToLeaderCallForPromotionWrapper(fn, numExtraArgs, extraFormals);
-  } else {
-    propagateRecursivelyNew(fs, fn, fn, retSym,
-                         extraActuals, extraFormals, shadowVarsRI,
-                         nested, redRef1, redRef2);
-    cleanupRedRefs(redRef1, redRef2);
-  }
-}
-
-// Propagate the additions of shadow variables to yield statements
-// recursively into task functions.
-static void propagateRecursivelyNew(ForallStmt* fs,
-                                 FnSymbol* parentFn,
-                                 FnSymbol* currentFn,
-                                 VarSymbol* retSym,
-                                 Symbol* extraActuals[],
-                                 Symbol* extraFormals[],
-                                 Symbol* shadowVarsRI[],
-                                 bool nested,
-                                 Expr*& redRef1,
-                                 Expr*& redRef2)
-{
-  std::vector<CallExpr*> rCalls;
-  collectMyCallExprs(currentFn, rCalls, currentFn);
-
-  for_vector(CallExpr, rcall, rCalls) {
-    if (rcall->isPrimitive(PRIM_YIELD)) {
-
-      propagateThroughYieldNew(fs, rcall, parentFn, retSym,
-                            extraActuals, extraFormals,
-                            shadowVarsRI,
-                            nested, redRef1, redRef2);
-
-    } else if (FnSymbol* tfn = resolvedToTaskFun(rcall)) {
-     if (needsCapture(tfn)) {
-      // 'rcall' better be the only call to 'tfn'.
-      // The following assert is a weak assurance of that.
-      // For a strong assurance, we could additionally build a set of task
-      // functions, calls to which we have seen.
-      // OTOH our normal call verification should suffice: it will fail
-      // the first propagated call if a second call propagates to same tfn.
-      INT_ASSERT(tfn->defPoint->parentSymbol == currentFn);
-
-      if (tfn->hasFlag(FLAG_BEGIN)) {
-        // (A) Reduce intents do not make sense when a 'begin' outlives
-        //     the iterator. There used to be a check for that here.
-        // (B) However, currently there can be no yields in a 'begin'
-        //     - see checkControlFlow().
-        //     Without a yield, the above is not a concern.
-        // (C) Generally, if a task function does not have a yield,
-        //     there is nothing to be done w.r.t. forall intents.
-        //     We could check the entire tfn for yields. Instead,
-        //     we just do a fast check for FLAG_BEGIN
-        //     as a conservative approximation.
-        //     We verify the absence of yields, however.
-        if (fVerify) {  // for assertions only
-          std::vector<CallExpr*> bCalls;
-          collectMyCallExprs(tfn, bCalls, tfn);
-          for_vector(CallExpr, bcall, bCalls)
-            INT_ASSERT(!bcall->isPrimitive(PRIM_YIELD));
-        }
-      } else {
-        // Propagate the extra args recursively into 'tfn'.
-        propagateExtraLeaderArgsNew(fs, rcall, retSym, extraFormals, true);
-      }
-     } else {
-      // !needsCapture(tfn) => descend into 'tfn' without argument intents.
-      propagateRecursivelyNew(fs, parentFn, tfn, retSym,
-                           extraActuals, extraFormals, shadowVarsRI,
-                           nested, redRef1, redRef2);
-     }
-    }
-  }
-}
-
-// 'origIterFn' should be either not yet resolved or
-// have been stashed into pristineLeaderIterators before being resolved
-static void extendLeaderNew(ForallStmt* fs,
-                            FnSymbol* origIterFn, CallExpr* call)
-{
-  if (!pristineLeaderIterators.get(origIterFn))
-    stashPristineCopyOfLeaderIter(origIterFn, false);
-
-  int numExtraArgs = fs->numIntentVars();
-  if (numExtraArgs == 0)
-    // no outer variables in the loop body - nothing to do
-    return;
-
-  // Replace the callee with a clone.
-  if (origIterFn->isResolved()) {
-    // ... using a pristine copy if the callee is already resolved.
-    // See the comment on an assert in copyLeaderFn().
-    origIterFn = pristineLeaderIterators.get(origIterFn);
-    INT_ASSERT(origIterFn);
-  }
-
-  FnSymbol* iterFn = copyLeaderFn(origIterFn, /*ignore_isResolved:*/false);
-  iterFn->instantiationPoint = getVisibilityBlock(call);
-  call->baseExpr->replace(new SymExpr(iterFn));
-
-  // Setup the new return/yield symbol.
-  VarSymbol* retSym  = NULL;
-  Symbol* origRetSym = NULL;
-
-  if (!iterFn->hasFlag(FLAG_PROMOTION_WRAPPER)) {
-    retSym  = newTemp("ret"); // its type is to be inferred
-    origRetSym = iterFn->replaceReturnSymbol(retSym, /*newRetType*/NULL);
-    origRetSym->defPoint->insertBefore(new DefExpr(retSym));
-    origRetSym->name = "origRet";
-  }
-
-  INT_ASSERT(numExtraArgs > 0); // we shouldn't be doing all this otherwise
-  Expr* origArg = call->get(call->numActuals() - numExtraArgs + 1);
-
-  Symbol* extraActuals[numExtraArgs];
-  for (int ix = 0; ix < numExtraArgs; ix++) {
-    Expr* nextArg = origArg->next;
-    SymExpr* origSE = toSymExpr(origArg->remove());
-    INT_ASSERT(origSE); // if it is not a symbol, still need to make it happen
-    extraActuals[ix] = origSE->symbol();
-    origArg = nextArg;
-  }
-  INT_ASSERT(!origArg); // we should have processed all args
-
-  propagateExtraLeaderArgsNew(fs, call, retSym, extraActuals, false);
-
-  if (origRetSym) {
-    checkAndRemoveOrigRetSym(origRetSym, iterFn);
-  }
-}
+// todo move the rest of this file to that file, too
 
 static CallExpr* findForwardingCallAndUnresolve(FnSymbol* fDest) {
   Symbol* retSym = fDest->getReturnSymbol();

--- a/compiler/resolution/implementForallIntents.cpp
+++ b/compiler/resolution/implementForallIntents.cpp
@@ -1417,7 +1417,7 @@ static void propagateThroughYield(CallExpr* rcall,
         INT_ASSERT(newOrigRet != origIOI);
 
         // Extract and yield the shadow variable reference.
-        Symbol* rvar = new VarSymbol(astrArg(ix, "eflopiRvar"));
+        Symbol* rvar = new VarSymbol(intentArgName(ix, "eflopiRvar"));
         rvar->addFlag(FLAG_REF_VAR);
         eflopiIdx++;
         insertExtractFromYieldAtHead(eflopiLoop, eflopiIdx, rvar, origIOI);
@@ -1436,7 +1436,7 @@ static void propagateThroughYield(CallExpr* rcall,
           // Todo: skip these additions if the current 'rcall' yield
           // is going to be compiled away, e.g. if it is
           // within a param conditional on a not-taken branch.
-          svar = new VarSymbol(astrArg(ix, "shadowVarReduc"));
+          svar = new VarSymbol(intentArgName(ix, "shadowVarReduc"));
           svar->addFlag(FLAG_INSERT_AUTO_DESTROY);
           VarSymbol* stemp  = newTemp("svrTmp");
           redRef1->insertBefore(new DefExpr(svar));
@@ -1454,7 +1454,7 @@ static void propagateThroughYield(CallExpr* rcall,
         // the corresponding shadow variable instead.
         Symbol* ssvar = createShadowVarIfNeeded(NULL, parentOp, svar, rcall);
         // todo: have a single 'sref' per 'svar', not one for each yield
-        VarSymbol* sref = new VarSymbol(astrArg(ix, "svarRef"));
+        VarSymbol* sref = new VarSymbol(intentArgName(ix, "svarRef"));
         rcall->insertBefore(new DefExpr(sref));
         rcall->insertBefore("'move'(%S, 'addr of'(%S))", sref, ssvar);
         tupleComponent = sref;
@@ -1526,11 +1526,11 @@ static void propagateExtraLeaderArgs(CallExpr* call, VarSymbol* retSym,
     // Use named args to disambiguate from the already-existing iterator args,
     // just in case. This necessitates toNamedExpr() in handleCaptureArgs().
     const char* eName   =
-      isReduce ? astrArg(ix, "reduceParent") :
+      isReduce ? intentArgName(ix, "reduceParent") :
         nested ? eActual->name :
           strcmp(eActual->name, "_tuple_expand_tmp_") ?
-            astrArg(ix, eActual->name) // uniquify arg name
-            : astrArg(ix, "tet");
+            intentArgName(ix, eActual->name) // uniquify arg name
+            : intentArgName(ix, "tet");
 
     ArgSymbol*  eFormal = new ArgSymbol(INTENT_BLANK, eName, eActual->type);
 
@@ -1547,8 +1547,8 @@ static void propagateExtraLeaderArgs(CallExpr* call, VarSymbol* retSym,
       INT_ASSERT(isTaskFun(fn));
       setupRedRefs(fn, nested, redRef1, redRef2);
       ArgSymbol* parentOp = eFormal; // the reduceParent arg
-      VarSymbol* currOp   = new VarSymbol(astrArg(ix, "reduceCurr"));
-      VarSymbol* svar     = new VarSymbol(astrArg(ix, "shadowVar"));
+      VarSymbol* currOp   = new VarSymbol(intentArgName(ix, "reduceCurr"));
+      VarSymbol* svar     = new VarSymbol(intentArgName(ix, "shadowVar"));
       svar->addFlag(FLAG_INSERT_AUTO_DESTROY);
       VarSymbol* stemp    = newTemp("svTmp");
       redRef1->insertBefore(new DefExpr(currOp));
@@ -2155,7 +2155,7 @@ static void handleRISpec(ForallStmt* fs, ShadowVarSymbol* svar)
 static void getOuterVarsNew(ForallStmt* fs, SymbolMap& outer2shadow,
                             BlockStmt* body)
 {
-  if (!fs->noFindOuterVars())
+  if (fs->needToHandleOuterVars())
     // do the same as in 'if (needsCapture(fn))' in createTaskFunctions()
     findOuterVarsNew(fs, outer2shadow, body);
 

--- a/compiler/resolution/implementForallIntents2.cpp
+++ b/compiler/resolution/implementForallIntents2.cpp
@@ -1,0 +1,1097 @@
+/*
+ * Copyright 2004-2017 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "implementForallIntents.h"
+
+/*
+This file contains Part 2 of the new implementation of forall intents.
+"Part 2" is mostly about extending a copy of the parallel iterator in question
+with arguments and yield values corresponding to forall intents.
+
+For a reduce intent, the global reduce op instance needs to be
+properly allocated, deallocated and connected to the corresponding
+user outer variable. This is the job of "Part 1".
+
+For now, implementForallIntents2New() and immediately-adjacent functions
+are in implementForallIntents.cpp, for historical reasons.
+
+Even though we don't have to, we keep "New" in function names for now, to
+distinguish them from the "old" implementation' in implementForallIntents.cpp.
+
+OUTLINE
+
+extendLeaderNew() extends a copy of the parallel iterator
+of the given forall loop to:
+
+* accept additional arguments for outer/shadow variables,
+* additionally yield shadow variables,
+* propagate these additional formals down to the yields,
+  properly handling whatever parallel constructs are on the way.
+
+TOP LEVEL
+
+The extension process starts "at the top level"
+by processing the call to the parallel iterator:
+
+  * clone the parallel iterator
+
+  * add actuals to the call to the parallel iterator
+
+  * create + add formals to the parallel iterator
+     - they become shadow variables
+
+  * traverse the body of the parallel iterator
+
+For a reduce intent (RI), the actual/formal is the reduce op class;
+the corresponding thing to yield is a task-private accumulation state.
+
+During the traversal, act as following.
+
+WHEN ENCOUNTERING A TASK FUNCTION
+
+  * add actuals + formals to the task function and CallExpr
+    like we did at the top level to the parallel iterator
+
+  * traverse the body of the task function
+
+WHEN ENCOUNTERING A YIELD
+
+  * augment the yield with the current shadow variables
+
+  * Also, do the following at most once per the parallel iterator
+    ("at the top level") and per a task function:
+
+    - for a RI, initialize a task-private reduce op at task
+      startup, combine() then delete it at task teardown
+      (do not do this "at the top level")
+
+    - for a RI, set up + tear down the shadow variable to yield
+      based on the current reduce op
+
+    - for a TPV (task-private variable), set up + tear down the shadow
+      variable to yield (no corresponding actual+formal in above steps)
+
+IF THE YIELD IS INSIDE A FORALL
+
+  * augment the ForallStmt with forall intents
+
+  * for a RI, skip certain steps
+
+IF THE YIELD IS INSIDE A FOR OVER A PARALLEL ITERATOR
+
+  * convert to forall loop
+    (preserving the semantics)
+
+  * process the forall as above
+
+*/
+
+/////////// helper data structures ///////////
+
+//
+// FIinfo aka Forall Intent info
+//
+// Contains all things pertinent to a single forall intent
+// across the call described by the enclosing FIcontext.
+//
+// RI = Reduce Intent  TPV = Task-Private Variable (upcoming)
+//
+class FIinfo {
+public:
+  // The shadow var in the ForallStmt being processed.
+  // In most cases it can be used only for info ex. the intent.
+  ShadowVarSymbol* svSymbol;
+
+  // The variable to be passed as an actual
+  // to the parallel iterator, task function,
+  // or ForallStmt within the parallel iterator.
+  // NULL for a TPV (todo soon: always NULL in this case?)
+  Symbol* fiActual;
+
+  // The corresponding formal or (for a TPV) local variable.
+  // For a RI, this is "parentOp"; otherwise the shadow variable.
+  // For a TPV, this is a local variable, once created;
+  // otherwise the formal of the parallel iterator or task fn.
+  // Todo: better name for it?
+  Symbol* fiFormal;
+
+  // For a reduce intent - non-NULL once created:
+  Symbol* riCurrentOp;
+  Symbol* riShadowVar;
+
+  // constructor
+  // invoked implicitly upon FIcontext::fiInfos.resize()
+  FIinfo() : svSymbol(0), fiActual(0), fiFormal(0),
+             riCurrentOp(0), riShadowVar(0) { }
+};
+
+typedef std::vector<FIinfo> FIvec;
+
+//
+// FIcontext aka Forall Intents contest
+//
+// Contains things pertinent to the 'call' being traversed
+// during extendLeaderNew(). The 'call' can be either:
+//
+//   when inIterator(): to the parallel iterator, from the ForallStmt,
+//
+//   when inTaskFn(): to a task function,
+//     from within the parallel iterator or its task function.
+//
+// Multiple yield statements may be handled/extended
+// under the same FIcontext.
+//
+class FIcontext {
+public:
+  // The forall stmt being processed.
+  ForallStmt*  forall;
+
+  // The call in being looked at.
+  CallExpr*    call;
+
+  // The iterator or task function being called.
+  FnSymbol*    curFn;
+
+  // Calling a function nested in the iterator?
+  bool         nested;
+
+  // The iterator's return symbol.
+  VarSymbol*   retSym;
+
+  // The FnSymbol for task startup/teardown code, usually 'curFn'.
+  // It is an enclosing function when descending into a task function
+  // that does not create a user-level task. Such a task function
+  // does not affect the intents.
+  FnSymbol*    anchorFn;
+
+  // Where in 'anchorFn' to insert startup/teardown code.
+  Expr*        anchor1;
+  Expr*        anchor2;
+  Expr*        anchor2orig;
+  Expr*        anchor2prev;
+
+  // Information on each forall intent across this call.
+  FIvec        fiInfos;
+
+  bool inIterator() const { return !nested; }
+  bool inTaskFn()   const { return nested; }
+
+  int  numShadowVars()   const {
+    int result = forall->numIntentVars();
+    INT_ASSERT(result == (int)fiInfos.size());
+    return result;
+  }
+
+  // constructor for the outermodst context
+  FIcontext(ForallStmt* fs, CallExpr* iterCall,
+            FnSymbol* iterFn, VarSymbol* retSymbol) :
+    forall(fs),
+    call(iterCall),
+    curFn(iterFn),
+    nested(false),
+    retSym(retSymbol),
+    anchorFn(curFn),
+    anchor1(0), anchor2(0), anchor2orig(0), anchor2prev(0)
+  {
+    fiInfos.resize(forall->numIntentVars());
+  }
+
+  // constructor for a nested context
+  FIcontext(FIcontext& parentCx, CallExpr* taskCall, FnSymbol* taskFn) :
+    forall(parentCx.forall),
+    call(taskCall),
+    curFn(taskFn),
+    nested(true),
+    retSym(parentCx.retSym),
+    anchorFn(curFn),
+    anchor1(0), anchor2(0), anchor2orig(0), anchor2prev(0)
+  {
+    int numSVars = forall->numIntentVars();
+    fiInfos.resize(numSVars);
+    for (int ix = 0; ix < numSVars; ix++) {
+      fiInfos[ix].svSymbol = parentCx.fiInfos[ix].svSymbol;
+      fiInfos[ix].fiActual = parentCx.fiInfos[ix].fiFormal;
+    }
+  }
+};
+
+
+/////////// EFLOPI: Enclosing For Loop Over Parallel Iterator ///////////
+
+// 
+// Info we gather while looking for an eflopi or an enclosing forall loop
+//
+// The contents are valid only after a call to findEnclosingParallelLoop()
+// as follows:
+//
+//  * 'eflopiForall' and 'eflopiLoop' are always set up
+//   -  to the corresponding ForallStmt or ForLoop node if one is found,
+//   -  to NULL if neither is found.
+//
+//  * the other fields are set up only if eflopiLoop != NULL.
+//
+class EflopiInfo {
+public:
+  ForallStmt* eflopiForall;
+  ForLoop*    eflopiLoop;
+  CallExpr*   eflopiCall;
+  // more details
+  // todo soon: remove all except asgnToIter?
+  Symbol*    iterSym;
+  CallExpr*  asgnToIter;
+  Symbol*    iterCallTemp;
+  CallExpr*  asgnToCallTemp;
+};
+
+//
+// Is 'forLoop' a loop over a parallel iterator?
+// If so, fill in 'eInfo' with details.
+//
+static bool findCallToParallelIterator(ForLoop* forLoop, EflopiInfo& eInfo)
+{
+  Symbol* iterSym = forLoop->iteratorGet()->symbol();
+
+  // Find an assignment to 'iterSym'.
+  CallExpr* asgnToIter = NULL;
+  for (Expr* curr = forLoop->prev; curr; curr = curr->prev)
+    if (CallExpr* call = toCallExpr(curr))
+      if (call->isPrimitive(PRIM_MOVE))
+        if (SymExpr* lhs1 = toSymExpr(call->get(1)))
+          if (lhs1->symbol() == iterSym) {
+            asgnToIter = call;
+            break;
+          }
+  INT_ASSERT(asgnToIter);
+
+  // We have:
+  //   move( call_tmp call( ITERATOR args... ) )
+  //   move( _iterator call( _getIterator call_tmp ) )
+  // We need to see if args... contain a leader or standalone tag.
+  // 'asgnToIter' is the second of the above moves. Find the first one.
+  CallExpr* rhs1 = toCallExpr(asgnToIter->get(2));
+  INT_ASSERT(rhs1 && rhs1->isNamed("_getIterator"));
+  Symbol* calltemp = toSymExpr(rhs1->get(1))->symbol();
+  CallExpr* asgnToCallTemp = NULL;
+  for (Expr* curr = asgnToIter->prev; curr; curr = curr->prev)
+    if (CallExpr* call = toCallExpr(curr))
+      if (call->isPrimitive(PRIM_MOVE))
+        if (SymExpr* lhs2 = toSymExpr(call->get(1)))
+          if (lhs2->symbol() == calltemp) {
+            asgnToCallTemp = call;
+            break;
+          }
+
+  // Sometimes, e.g. forall over a range - ri-5-c.chpl, _getIterator is invoked
+  // on a non-temp. We notice this by the absence of asgnToCallTemp.
+  // In such a case, the iterator will be nontemp.these(),
+  // which is not a parallel iterator.
+  if (!asgnToCallTemp)
+    return false;
+
+  CallExpr* iterCall = toCallExpr(asgnToCallTemp->get(2));
+  INT_ASSERT(iterCall);
+
+  if (callingParallelIterator(iterCall)) {
+    // Found it. Fill in the information before returning.
+    eInfo.eflopiForall   = NULL;
+    eInfo.eflopiLoop     = forLoop;
+    eInfo.eflopiCall     = iterCall;
+    eInfo.iterSym        = iterSym;
+    eInfo.asgnToIter     = asgnToIter;
+    eInfo.iterCallTemp   = calltemp;
+    eInfo.asgnToCallTemp = asgnToCallTemp;
+    return true;
+  }
+
+  // no signs of a parallel iterator
+  return false;
+}
+
+// Starting with 'curr', look for an enclosing parallel loop, i.e.
+// either a forall loop or a for loop over a parallel iterator.
+// Set up 'eflopiInfo' as appropriate.
+static void findEnclosingParallelLoop(Expr* curr, EflopiInfo& eflopiInfo) {
+  while ((curr = curr->parentExpr)) {
+    if (ForallStmt* fs = toForallStmt(curr)) {
+      eflopiInfo.eflopiForall = fs;
+      eflopiInfo.eflopiLoop   = NULL;
+      return;
+    }
+    else if (ForLoop* forLoop = toForLoop(curr)) {
+      if (findCallToParallelIterator(forLoop, eflopiInfo))
+        // findCallToParallelIterator() filled out eflopiInfo.
+        return;
+    }
+  }
+
+  // Nothing of interest.
+  eflopiInfo.eflopiForall = NULL;
+  eflopiInfo.eflopiLoop   = NULL;
+  return;
+}
+
+// We need expr->remove().
+// If it is the only thing in its enclosing block, yank the block.
+// Ditto the defer statement.
+static void removeWithEnclosing(Expr* expr) {
+  if (BlockStmt* block = toBlockStmt(expr->parentExpr))
+    if (expr == block->body.head && expr == block->body.tail)
+      {
+        // Remove the entire block. Check for an enclosing defer first.
+        if (DeferStmt* defer = toDeferStmt(block->parentExpr)) {
+          defer->remove();
+          return;
+        }
+        INT_ASSERT(block->parentExpr != NULL);
+        block->remove();
+        return;
+      }
+  expr->remove();
+  return;
+}
+
+static ForallStmt* replaceEflopiWithForall(EflopiInfo& eInfo)
+{
+  // the loop to be replaced
+  ForLoop* src  = eInfo.eflopiLoop;
+
+  // Otherwise currentAstLoc points to the forall loop
+  // that invokes the iterator src->parentSymbol.
+  SET_LINENO(src);
+
+  // the replacement loop
+  ForallStmt* dest = ForallStmt::fromForLoop(src);
+
+  // convert src index variable to dest index variable
+  // todo instead use the corresponding user variable
+  Symbol* srcIndex = src->indexGet()->symbol();
+  src->indexGet()->remove(); // get it out of the way
+  dest->inductionVariables().insertAtHead(srcIndex->defPoint->remove());
+  // remove its uses outside the loop
+  for_SymbolSymExprs(idxSE, srcIndex) {
+    if (Expr* idxStmt = idxSE->getStmtExpr()) {
+      // heuristic, instead of checking the full chain of parentExpr
+      // todo soon: instead of heuristic, leverage getSingleDef()
+      if (idxStmt->parentExpr != src) {
+        INT_ASSERT(idxSE == srcIndex->getSingleDef());
+        // todo soon: given that the above always holds, use it
+        // and simplify the body of this for_SymbolSymExprs
+        INT_ASSERT(isBlockStmt(idxStmt->parentExpr));
+        INT_ASSERT(toBlockStmt(idxStmt->parentExpr)->body.length == 1);
+        removeWithEnclosing(idxStmt);
+      } else {
+        INT_ASSERT(idxSE == srcIndex->getSingleUse());
+      }
+    }
+  }
+
+  // set the iterator call
+  dest->iteratedExpressions().insertAtHead(new SymExpr(eInfo.iterCallTemp));
+
+  // remove _iterator that keeps the iterator class
+  Symbol* IC = src->iteratorGet()->symbol();
+  src->iteratorGet()->remove(); // get it out of the way
+  for_SymbolSymExprs(icSE, IC)
+    removeWithEnclosing(icSE->getStmtExpr());
+  IC->defPoint->remove();
+
+  // no more uses
+  INT_ASSERT(IC->firstSymExpr() == NULL);
+
+  // no with-clause adjustments - the for loop does not have one
+
+  // transfer the loop body
+  AList& sourceBody = src->body;
+  AList& resultBody = dest->loopBody()->body;
+  while (Expr* forStmt = sourceBody.head)
+    resultBody.insertAtTail(forStmt->remove());
+
+  // replace the loop statement itself
+  src->replace(dest);
+
+  return dest;
+}
+
+
+/////////// assorted helpers ///////////
+
+static void checkNoYieldsIn(FnSymbol* fn) {
+  std::vector<CallExpr*> calls;
+  collectCallExprs(fn, calls);
+  for_vector(CallExpr, call, calls)
+    INT_ASSERT(!call->isPrimitive(PRIM_YIELD));
+}
+
+static Symbol* makeAddrOfIfNeeded(Symbol* origSym, Expr* ref) {
+  if (origSym->isRef()) {
+    return origSym;
+  }
+  else {
+    // If origSym->type==dtUnknown, should we use PRIM_SET_REFERENCE ?
+    Type* tempType = origSym->getRefType();
+    if (tempType == NULL) tempType = dtUnknown; // ex. for a reduce intent
+
+    VarSymbol* atemp = newTemp("svarAddrTemp", tempType);
+    atemp->qual = QUAL_REF;
+
+    ref->insertBefore(new DefExpr(atemp));
+    ref->insertBefore("'move'(%S, 'addr of'(%S))", atemp, origSym);
+
+    return atemp;
+  }
+}
+
+static void propagateRecursivelyNew(FIcontext& ctx);
+
+
+/////////// misc / interface to the "old world" implementation ///////////
+
+// A helper for inserting teardown code in reverse order of intents
+// and tear down riShadowVar before riCurrentOp.
+static void adjustInsertAnchor2(FIcontext& ctx) {
+  ctx.anchor2 = ctx.anchor2prev->next;
+}
+
+//
+// Set up anchor references, so we can add intent-related code
+// into ctx.curFn via ref->insertBefore().
+//
+// ctx.anchor1 is for startup code at the beginning of a task.
+// ctx.anchor2 is for teardown code at the end of a task.
+//
+// If anchors have been set up previously, move anchor2 *above*
+// previously-inserted nodes.
+//
+static void setupAnchors(FIcontext& ctx) {
+  if (ctx.anchor2prev != NULL) {
+    // We have set this up already. Just update.
+    adjustInsertAnchor2(ctx);
+    return;
+  }
+  setupRedRefs(ctx.anchorFn, ctx.inTaskFn(), ctx.anchor1, ctx.anchor2);
+  // When the old world goes away, we can switch to better names.
+  ctx.anchor2orig = ctx.anchor2;
+  ctx.anchor2prev = new CallExpr("redRef2prev");
+  ctx.anchor2->insertBefore(ctx.anchor2prev);
+}
+
+static void cleanupAnchors(FIcontext& ctx) {
+  // Like cleanupRedRefs(ctx.anchor1, ctx.anchor2), plus ctx.anchor2prev.
+
+  if (ctx.anchor1 == NULL)
+    // nothing to do
+    return;
+
+  ctx.anchor1->remove();      ctx.anchor1 = NULL;
+  ctx.anchor2orig->remove();  ctx.anchor2orig = NULL;
+  ctx.anchor2prev->remove();  ctx.anchor2prev = NULL;
+
+  // Do not remove() anchor2 - it may result from adjustInsertAnchor2(),
+  // not the one we allocated originally.
+  ctx.anchor2 = NULL;
+}
+
+static void addArgsToToLeaderCallForPromotionWrapper(FIcontext& ctx) {
+  // When the old world goes away, todo: eliminate this temporary array.
+  int numSVars = ctx.numShadowVars();
+  Symbol* fiFormalsTemp[numSVars];
+  for (int ix = 0; ix < numSVars; ix++)
+    fiFormalsTemp[ix] = ctx.fiInfos[ix].fiFormal;
+  addArgsToToLeaderCallForPromotionWrapper(ctx.curFn, numSVars, fiFormalsTemp);
+}
+
+
+/////////// seting up for a reduce intent ///////////
+
+// As we extend the yield expression into a tuple with shadow variables,
+// we need to handle a reduce-intent variable specially by setting up
+// the current reduction op and initializing the shadow variable from it.
+//
+// Setup at start of the task function:
+//
+//   def currentOp = parentOp.clone();
+//   def shadowVar = currentOp.identity;
+//
+// Accumulate and tear down at the end.
+//
+//   currentOp.accumulate(shadowVar);
+//   chpl__reduceCombine(parentOp, currentOp);
+//   chpl__cleanupLocalOp(parentOp, currentOp);
+//   // rely on later compiler passes to destruct shadowVar
+//
+// Exception 1: when the yield stmt is in the iterator itself, outside any
+// parallel constructs, do not create/tear down the current op.
+// Instead use the parent op directly, as there is no concurrent access to it.
+//
+// Exception 2: when the yield stmt is in a forall loop, we do not need
+// the shadow variable created from the current op (or parent op).
+// Instead the shadow variable we add to the yielded tuple is one
+// we add to the forall loop's intentVariables(). It will be handled
+// according to the above scheme when this forall loop's parallel iterator
+// will be processed/extended.
+// The above scheme is still used for yields outside a forall loop, if any.
+
+//
+// Set up fiInfo.riCurrentOp, if not already.
+//
+static void ensureCurrentReduceOpForReduceIntent(FIcontext& ctx,
+                                                 FIinfo& fiInfo, int ix)
+{
+  if (fiInfo.riCurrentOp != NULL)
+    return;
+
+  INT_ASSERT(fiInfo.riShadowVar == NULL); // Can't have it without current op.
+
+  Symbol* parentOp = fiInfo.fiFormal;
+
+  if (ctx.inIterator()) {
+    // We are in the parallel iterator outside any parallel constructs.
+    // Use the parent op directly, as there is no concurrent access to it.
+    fiInfo.riCurrentOp = parentOp;
+    return;
+  }
+
+  Symbol* currOp = new VarSymbol(astrArg(ix, "reduceCurrOp"));
+  // 'currOp' always points to the same reduction op class instance.
+  currOp->addFlag(FLAG_CONST);
+  currOp->qual = QUAL_CONST_VAL;
+
+  setupAnchors(ctx);
+
+  ctx.anchor1->insertBefore(new DefExpr(currOp));
+  ctx.anchor1->insertBefore("'move'(%S, clone(%S,%S))", // initialization
+                            currOp, gMethodToken, parentOp);
+
+  ctx.anchor2->insertBefore("chpl__reduceCombine(%S,%S)", parentOp, currOp);
+  ctx.anchor2->insertBefore("chpl__cleanupLocalOp(%S,%S)", parentOp, currOp);
+
+  fiInfo.riCurrentOp = currOp;
+}
+
+//
+// Set up (if not already) and return fiInfo.riShadowVar.
+//
+static Symbol* shadowVarForReduceIntent(FIcontext& ctx,
+                                        FIinfo& fiInfo, int ix)
+{
+  if (fiInfo.riShadowVar != NULL)
+    return fiInfo.riShadowVar;
+
+  Symbol* currOp = fiInfo.riCurrentOp;
+  INT_ASSERT(currOp != NULL); // caller responsibility
+
+  setupAnchors(ctx);
+
+  // Create the shadow variable and set it up.
+  VarSymbol* rsvar = new VarSymbol(astrArg(ix, "reduceShadowVar"));
+  rsvar->addFlag(FLAG_INSERT_AUTO_DESTROY);
+
+  VarSymbol* stemp = newTemp("rsvTemp");
+  ctx.anchor1->insertBefore(new DefExpr(rsvar));
+  ctx.anchor1->insertBefore(new DefExpr(stemp));
+  ctx.anchor1->insertBefore("'move'(%S, identity(%S,%S))",
+                            stemp, gMethodToken, currOp);
+  ctx.anchor1->insertBefore("'move'(%S, chpl__autoCopy(%S))",
+                            rsvar, stemp);
+
+  // Wrap it up at the end.
+  ctx.anchor2->insertBefore("accumulate(%S,%S,%S)",
+                            gMethodToken, currOp, rsvar);
+
+  fiInfo.riShadowVar = rsvar;
+  return rsvar;
+}
+
+
+/////////// when yield is inside a forall loop ///////////
+
+/*
+General Context
+---------------
+
+Let's say we are extending the parallel iterator with variables
+that corresponds to forall intents. For example, from this:
+
+  iter myIter(param tag == standalone)
+  {
+    ...
+    yield 555;
+    ...
+  }
+
+to this:
+
+  iter myIter(param tag == standalone,
+              x1_reduceParent:SumReduceScanOp, // reduce intent
+              x2_foo:int)                      // in intent
+
+ {
+    var x1_reduceShadowVar = x1_reduceParent.identity;
+    ...
+    yield (555, addr-of(x1_reduceShadowVar), addr-of(x2_foo));
+    ...
+    x1_reduceParent.accumulate(x1_reduceShadowVar);
+  }
+
+Particular Concern
+------------------
+
+If the above yield is actually within a forall:
+
+  iter myIter(param tag == standalone)
+  {
+    forall ...
+    { ...
+      yield 555;
+      ... }
+  }
+
+then we need to create a new set of shadow variables under this forall
+and yield those instead:
+
+  iter myIter(param tag == standalone,
+              x1_reduceParent:SumReduceScanOp, // reduce intent
+              x2_foo:int)                      // in intent
+
+ {
+    forall ... with (reduce x1_reduceParent, in x2_foo)
+    { ...
+      yield (555, addr-of(x1_reduceShadowVar), addr-of(x2_foo));
+      ... }
+  }
+
+
+Notice that 'x1_reduceShadowVar' is not needed in this case.
+It is still needed if there are yields outside foralls and task constructs.
+
+If the forall is inside a task function
+---------------------------------------
+
+The above approach applies, except instead of x1_reduceParent
+we need to create and use a current reduce op.
+The difference is the same as in the case
+where the yield is not in any forall loops.
+
+Look Out For...
+---------------
+
+Need to handle these cases:
+
+* The yield is in >1 nested foralls --> create a new shadow var for each:
+
+  iter myIter(param tag == standalone, x1_reduceParent:SumReduceScanOp) {
+    var x1_reduceShadowVar = x1_reduceParent.identity;
+
+    forall ... with (x1_reduceParent reduce x1_reduceShadowVar) {
+      // shadow var: x1_reduceShadowVar'
+
+      forall ... with (x1_reduceParent reduce x1_reduceShadowVar') {
+        // shadow var: x1_reduceShadowVar''
+
+        ... yield (555, addr-of(x1_reduceShadowVar'')); ...
+      }
+    }
+
+    x1_reduceParent.accumulate(x1_reduceShadowVar);
+  }
+
+* Multiple yields within the same forall(s) --> use the same shadow var:
+
+    forall ... with (x1_reduceParent reduce x1_reduceShadowVar) {
+      // shadow var: x1_reduceShadowVar'
+
+      ... yield (555, addr-of(x1_reduceShadowVar'')); ...
+      ... yield (666, addr-of(x1_reduceShadowVar'')); ...
+    }
+*/
+
+static Symbol* tupcomForYieldInForall(FIcontext& ctx, ForallStmt* efs, int ix)
+{
+  FIinfo&          fii = ctx.fiInfos[ix];
+  ShadowVarSymbol* osv = fii.svSymbol;
+  bool        isReduce = osv->isReduce();
+
+  // Check whether we have already created a shadow variable
+  // because we have processed another yield within this forall.
+  // If so, reuse it.
+  //
+  // TODO need to look up in outer enclosing forall statements, if applicable.
+  // If it is a parallel for, should convert that to a forall first, perhaps.
+  // Without that lookup, in intent and reduce intent may result in races.
+  // See also checkFor2ndEnclosingParallelLoop().
+  //
+  for_shadow_vars(efsShadVar, temp, efs) // linear search, for simplicity
+    if (isReduce ?
+        (efsShadVar->reduceGlobalOp != NULL &&
+         efsShadVar->reduceGlobalOp == fii.riCurrentOp) :
+        efsShadVar->outerVarSym()  == fii.fiFormal)
+      return efsShadVar;
+
+  // Here is the new shadow variable.
+  ShadowVarSymbol* esv = new ShadowVarSymbol(osv->intent, osv->name, NULL);
+  efs->intentVariables().insertAtTail(new DefExpr(esv));
+
+  if (isReduce) {
+    ensureCurrentReduceOpForReduceIntent(ctx, fii, ix);
+    esv->reduceGlobalOp = fii.riCurrentOp;
+    esv->outerVarRep    = NULL;  // no user-level outer var
+  } else {
+    esv->outerVarRep    = new SymExpr(fii.fiFormal);
+  }
+
+  return esv;
+}
+
+// Currently doubly-nested parallel loops around a yield
+// in a parallel iterator do not work smoothly.
+// So instead we issue a nice, albeit fatal, error.
+//
+// One need is for tupcomForYieldInForall() to look up the shadow variables
+// in the second enclosing forall loop when applicable - see a todo item there.
+//
+static void checkFor2ndEnclosingParallelLoop(FIcontext& ctx,
+                                      CallExpr* yieldCall, ForallStmt* efs) {
+  EflopiInfo eInfo;
+  findEnclosingParallelLoop(efs, eInfo);
+  Expr* enclPar = eInfo.eflopiForall ? (Expr*)eInfo.eflopiForall
+                                     : (Expr*)eInfo.eflopiLoop;
+  if (enclPar == NULL)
+    // No concern.
+    return;
+
+  USR_FATAL_CONT(yieldCall,
+     "this yield is nested in two or more enclosing parallel loops");
+  USR_PRINT(yieldCall,
+     "(a parallel loop is a for-loop over parallel iterator or a forall-loop)");
+  USR_PRINT(yieldCall,
+     "this is currently not implemented within parallel iterators");
+
+  USR_PRINT(efs, "the immediately enclosing parallel loop is here");
+  USR_PRINT(enclPar, "the second enclosing parallel loop is here");
+  USR_PRINT(ctx.forall, "the forall loop that invokes the iterator is here");
+
+  // If we continue, we may get a const violation on x*_reduceShadowVar.
+  USR_STOP();
+}
+
+
+/////////// extendYieldNew, simple case ///////////
+
+static Symbol* tupcomForSerialYield(FIcontext& ctx, int ix)
+{
+  FIinfo& fii = ctx.fiInfos[ix];
+
+  switch (fii.svSymbol->intent) {
+    case  TFI_DEFAULT:
+    {
+      INT_ASSERT(false); // it is better to have a concrete intent here
+      return NULL;
+    }
+
+    case TFI_CONST:
+    case TFI_IN:
+    case TFI_CONST_IN:
+    case TFI_REF:
+    case TFI_CONST_REF:
+    {
+      Symbol* component = fii.fiFormal;
+      // When the type is dtUnknown, we still need to ensure yield by ref.
+      // Ex. have makeAddrOfIfNeeded() insert a PRIM_SET_REFERENCE.
+      INT_ASSERT(component->type != dtUnknown &&
+                 component->type != dtAny);
+      return component;
+    }
+
+    case TFI_REDUCE:
+    {
+      ensureCurrentReduceOpForReduceIntent(ctx, fii, ix);
+      return shadowVarForReduceIntent(ctx, fii, ix);
+    }
+  }
+
+  INT_ASSERT(false); // garbage intent
+  return NULL;
+}
+
+//
+// Switch from yielding a user value to yielding the tuple
+//   (user value, shadow variable1, shadow variable2...)
+//
+// 'efs' is the enclosing ForallStmt if any, otherwise NULL.
+//
+static void extendYieldNew(FIcontext& ctx, CallExpr* yieldCall,
+                           ForallStmt* efs)
+{
+  // Make a tuple that includes the extra args.
+  Expr*      origRetArg = yieldCall->get(1)->remove();
+  VarSymbol* newOrigRet = localizeYieldForExtendLeader(origRetArg, yieldCall);
+  CallExpr*  buildTuple = new CallExpr("_build_tuple_always_allow_ref",
+                                       newOrigRet);
+  int numSVars   = ctx.numShadowVars();
+
+  if (efs != NULL)
+    checkFor2ndEnclosingParallelLoop(ctx, yieldCall, efs);
+
+  for (int ix = 0; ix < numSVars; ix++) {
+    Symbol* tupComponent = (efs == NULL) ?
+      tupcomForSerialYield(ctx, ix) :
+      tupcomForYieldInForall(ctx, efs, ix);
+
+    // shadow variables are always yielded by reference
+    tupComponent = makeAddrOfIfNeeded(tupComponent, yieldCall);
+    buildTuple->insertAtTail(new SymExpr(tupComponent));
+  }
+
+  yieldCall->insertBefore("'move'(%S,%E)", ctx.retSym, buildTuple);
+  yieldCall->insertAtTail(new SymExpr(ctx.retSym));
+}
+
+
+/////////// propagateExtraLeaderArgsNew ///////////
+
+static ArgSymbol* newExtraFormal(FIcontext& ctx, FIinfo& fii, int ix,
+                                 Symbol* eActual)
+{
+    bool     isReduce   = fii.svSymbol->isReduce();
+    const char* eName   =
+      isReduce ? astrArg(ix, "reduceParent") :
+        ctx.nested ? eActual->name :
+          !strcmp(eActual->name, "_tuple_expand_tmp_") ?
+            astrArg(ix, "tet") :
+              astrArg(ix, eActual->name); // uniquify user arg name
+
+    Type* efType    = eActual->type;
+    IntentTag efInt = isReduce ? INTENT_CONST_IN :
+      concreteIntent(argIntentForForallIntent(fii.svSymbol->intent), efType);
+    bool addFlagImm = false;
+
+    if (efInt & INTENT_FLAG_REF) {
+      INT_ASSERT(!isReduce); // otherwise efType may be unknown
+      INT_ASSERT(efType != dtUnknown && efType != dtAny);
+
+      //
+      // For ref intents, we need to make it a ref type.
+      // Because eFormal will be passed to _build_tuple_always_allow_ref()
+      // call that's created in extendYieldNew().
+      // If _build_tuple_always_allow_ref's actual has a non-ref type,
+      // even if it is an ArgSymbol with a ref intent, the corresponding
+      // component of the resulting tuple will be non-ref, which will break
+      // SSCA2 and test/parallel/forall/vass/intents-all-int.chpl.
+      // Todo: fix resolution of _build_tuple_always_allow_ref.
+      //
+      efType = efType->getRefType();
+
+      if (eActual->isConstValWillNotChange())
+        addFlagImm = true;
+    }
+    
+    ArgSymbol*  eFormal = new ArgSymbol(efInt, eName, efType);
+
+    if (addFlagImm || eActual->hasFlag(FLAG_REF_TO_IMMUTABLE))
+      eFormal->addFlag(FLAG_REF_TO_IMMUTABLE);
+
+    return eFormal;
+}
+
+static void propagateExtraLeaderArgsNew(FIcontext& ctx)
+{
+  if (ctx.curFn->hasFlag(FLAG_WRAPPER))
+  {
+    // We are not handling void-returning wrappers at the moment.
+    INT_ASSERT(!(ctx.curFn->getReturnSymbol() == gVoid ||
+                 ctx.curFn->retType == dtVoid));
+  }
+
+  const int numSVars = ctx.numShadowVars();
+
+  for (int ix = 0; ix < numSVars; ix++)
+  {
+    FIinfo&    fii     = ctx.fiInfos[ix];
+    Symbol*    eActual = fii.fiActual; // 'e' for "Extra"
+    ArgSymbol* eFormal = newExtraFormal(ctx, fii, ix, eActual);
+    fii.fiFormal       = eFormal;
+
+    // Use named args to disambiguate from user's iterator formals, if any.
+    ctx.call->insertAtTail(new NamedExpr(eFormal->name,
+                                         new SymExpr(eActual)));
+    ctx.curFn->insertFormalAtTail(eFormal);
+  }
+
+  if (ctx.inIterator() && ctx.curFn->hasFlag(FLAG_PROMOTION_WRAPPER))
+  {
+    INT_ASSERT(!ctx.anchor1); // no need to clean them up
+    addArgsToToLeaderCallForPromotionWrapper(ctx);
+  }
+  else
+  {
+    propagateRecursivelyNew(ctx);
+    cleanupAnchors(ctx);
+  }
+}
+
+
+/////////// propagateRecursivelyNew ///////////
+
+static void propagateRecursivelyNew(FIcontext& ctx)
+{
+  std::vector<CallExpr*> rCalls;
+  collectMyCallExprs(ctx.curFn, rCalls, ctx.curFn);
+
+  for_vector(CallExpr, rcall, rCalls) {
+    if (rcall->isPrimitive(PRIM_YIELD)) {
+
+      EflopiInfo eflopiInfo;
+      findEnclosingParallelLoop(rcall, eflopiInfo);
+
+      if (ForallStmt* efs = eflopiInfo.eflopiForall)
+      {
+        // There is an enclosing forall loop.
+        extendYieldNew(ctx, rcall, efs);
+      }
+      else if (eflopiInfo.eflopiLoop != NULL)
+      {
+        // There is an enclosing parallel for loop.
+        // See also "if (eflopiCall) {" and "USR_WARN(shadowvar,"
+        // in former propagateThroughYieldNew().
+
+        ForallStmt* efs = replaceEflopiWithForall(eflopiInfo);
+        extendYieldNew(ctx, rcall, efs);
+      }
+      else
+      {
+        // No enclosing forall or parallel for.
+        extendYieldNew(ctx, rcall, NULL);
+      }
+
+    } else if (FnSymbol* tfn = resolvedToTaskFun(rcall)) {
+
+      // We will be extending 'tfn' specifically to this situation.
+      // So there better be no other users of it.
+      // todo soon: INT_ASSERT(rcall == tfn->singleInvocation());
+
+      if (needsCapture(tfn)) {
+
+        if (tfn->hasFlag(FLAG_BEGIN)) {
+          // A 'begin' block should not have yields,
+          // so nothing to do here. Just check it.
+          if (fVerify) checkNoYieldsIn(tfn);
+        }
+        else {
+          // Ideally, skip this if 'tfn' has no yields.
+          // However, that is rare, and checking for that is expensive.
+          // So for now we do not check and always process the tfn.
+
+          // Propagate the extra args recursively into 'tfn'.
+          FIcontext taskCntx(ctx, rcall, tfn);
+          propagateExtraLeaderArgsNew(taskCntx);
+        }
+
+      } else {
+        // !needsCapture(tfn) => descend into 'tfn' without argument intents.
+
+        // FIcontext remains the same except for curFn.
+        FnSymbol* saveCurFn = ctx.curFn;
+        ctx.curFn = tfn;
+
+        propagateRecursivelyNew(ctx);
+
+        // Restore curFn. anchorFn can stay the same.
+        ctx.curFn = saveCurFn;
+      }
+    }
+  }
+}
+
+
+/////////// extendLeaderNew ///////////
+
+void extendLeaderNew(ForallStmt* fs, 
+                     FnSymbol* origIterFn, CallExpr* iterCall)
+{
+  if (!pristineLeaderIterators.get(origIterFn))
+    stashPristineCopyOfLeaderIter(origIterFn, false);
+
+  int numSVars = fs->numIntentVars();
+  if (numSVars == 0)
+    // no outer variables in the loop body - nothing to do
+    return;
+
+  // Replace the callee with a clone.
+  if (origIterFn->isResolved()) {
+    // ... using a pristine copy if the callee is already resolved.
+    // See the comment on an assert in copyLeaderFn().
+    origIterFn = pristineLeaderIterators.get(origIterFn);
+    INT_ASSERT(origIterFn);
+  }
+
+  FnSymbol* iterFn = copyLeaderFn(origIterFn, /*ignore_isResolved:*/false);
+  iterFn->instantiationPoint = getVisibilityBlock(iterCall);
+  iterCall->baseExpr->replace(new SymExpr(iterFn));
+
+  // Setup the new return/yield symbol.
+  VarSymbol* retSym  = NULL;
+  Symbol* origRetSym = NULL;
+
+  if (!iterFn->hasFlag(FLAG_PROMOTION_WRAPPER)) {
+    retSym  = newTemp("ret"); // its type is to be inferred
+    origRetSym = iterFn->replaceReturnSymbol(retSym, /*newRetType*/NULL);
+    origRetSym->defPoint->insertBefore(new DefExpr(retSym));
+    origRetSym->name = "origRet";
+  }
+
+  // Data for the call from the ForallStmt to the parallel iterator.
+  FIcontext ctx(fs, iterCall, iterFn, retSym);
+
+  // Initialize it corresponding to the shadow vars from 'fs'.
+  // Remove the corresponding actuals from 'iterCall'
+  // so that propagateExtraLeaderArgsNew() can uniformly add them in
+  // wrapping in NamedExprs.
+  // They are added in addActualsToParCallNew().
+  //
+  // Note that here we may have already disconnected from ForallStmt
+  // and its shadow variables' outerVarRep. Because 'iterCall' may be
+  // inside a wrapper or iterator forwarder, so iterCall's actuals
+  // are not necessarily the same as outerVarReps.
+
+  Expr* origArg = iterCall->get(iterCall->numActuals() - numSVars + 1);
+  int ix = 0;
+
+  for_shadow_vars(svar, temp, fs) {
+    FIinfo& fii = ctx.fiInfos[ix];
+    fii.svSymbol = svar;
+
+    Expr*   nextArg = origArg->next;
+    SymExpr* origSE = toSymExpr(origArg->remove());
+    INT_ASSERT(origSE);
+    fii.fiActual = origSE->symbol();
+    // as noted above, fiActual may differ from svar->outerVarSym()
+
+    origArg = nextArg;
+    ix++;
+  }
+
+  INT_ASSERT(!origArg);        // we should have processed all args
+  INT_ASSERT(ix == numSVars);  // ... and all SVars
+
+  propagateExtraLeaderArgsNew(ctx);
+
+  if (origRetSym) {
+    checkAndRemoveOrigRetSym(origRetSym, iterFn);
+  }
+}

--- a/test/parallel/forall/vass/par-loops/2-enclosing-par-loops-error-1.chpl
+++ b/test/parallel/forall/vass/par-loops/2-enclosing-par-loops-error-1.chpl
@@ -1,0 +1,41 @@
+/*
+This tests the situation where a reduce intent and/or in intent
+occurs in a forall loop, whose the parallel iterator contains a yield
+that is in 2 parallel loops.
+
+Specifically, in a forall loop that's in another forall loop.
+
+When this is no longer an error, test for absence of data races, like
+  parallel/forall/vass/reduce-with-forall-in-par-iter
+  parallel/forall/vass/reduce-fatter-with-forall-in-par-iter
+*/
+
+iter myiter() {
+  yield 555;
+}
+
+iter myiter(param tag) {
+  coforall ooo in 1..3 {
+    yield 666;
+  }
+}
+
+iter pariter() {
+  yield 333;
+}
+
+iter pariter(param tag) {
+  forall loc in Locales do
+    forall kkk in myiter() do
+      yield kkk + loc.id;
+}
+
+proc main {
+  var result1 = 20000, result2 = 9;
+  forall iii in pariter() with (
+                                in result1,
+                                + reduce result2
+                                ) {
+    writeln(result1, result2);
+  }
+}

--- a/test/parallel/forall/vass/par-loops/2-enclosing-par-loops-error-1.chpl
+++ b/test/parallel/forall/vass/par-loops/2-enclosing-par-loops-error-1.chpl
@@ -14,7 +14,7 @@ iter myiter() {
   yield 555;
 }
 
-iter myiter(param tag) {
+iter myiter(param tag) where tag == iterKind.standalone {
   coforall ooo in 1..3 {
     yield 666;
   }
@@ -24,7 +24,7 @@ iter pariter() {
   yield 333;
 }
 
-iter pariter(param tag) {
+iter pariter(param tag) where tag == iterKind.standalone {
   forall loc in Locales do
     forall kkk in myiter() do
       yield kkk + loc.id;

--- a/test/parallel/forall/vass/par-loops/2-enclosing-par-loops-error-1.good
+++ b/test/parallel/forall/vass/par-loops/2-enclosing-par-loops-error-1.good
@@ -1,0 +1,7 @@
+2-enclosing-par-loops-error-1.chpl:27: In iterator 'pariter':
+2-enclosing-par-loops-error-1.chpl:30: error: this yield is nested in two or more enclosing parallel loops
+2-enclosing-par-loops-error-1.chpl:30: note: (a parallel loop is a for-loop over parallel iterator or a forall-loop)
+2-enclosing-par-loops-error-1.chpl:30: note: this is currently not implemented within parallel iterators
+2-enclosing-par-loops-error-1.chpl:29: note: the immediately enclosing parallel loop is here
+2-enclosing-par-loops-error-1.chpl:28: note: the second enclosing parallel loop is here
+2-enclosing-par-loops-error-1.chpl:35: note: the forall loop that invokes the iterator is here

--- a/test/parallel/forall/vass/par-loops/2-enclosing-par-loops-error-2.chpl
+++ b/test/parallel/forall/vass/par-loops/2-enclosing-par-loops-error-2.chpl
@@ -14,7 +14,7 @@ iter myiter() {
   yield 555;
 }
 
-iter myiter(param tag) {
+iter myiter(param tag) where tag == iterKind.standalone {
   coforall ooo in 1..3 {
     yield 666;
   }
@@ -24,7 +24,7 @@ iter pariter() {
   yield 333;
 }
 
-iter pariter(param tag) {
+iter pariter(param tag) where tag == iterKind.standalone {
   for loc in Locales.these(iterKind.standalone) do
     forall kkk in myiter() do
       yield kkk + loc.id;

--- a/test/parallel/forall/vass/par-loops/2-enclosing-par-loops-error-2.chpl
+++ b/test/parallel/forall/vass/par-loops/2-enclosing-par-loops-error-2.chpl
@@ -1,0 +1,41 @@
+/*
+This tests the situation where a reduce intent and/or in intent
+occurs in a forall loop, whose the parallel iterator contains a yield
+that is in 2 parallel loops.
+
+Specifically, in a forall loop that's in a parallel for loop.
+
+When this is no longer an error, test for absence of data races, like
+  parallel/forall/vass/reduce-with-forall-in-par-iter
+  parallel/forall/vass/reduce-fatter-with-forall-in-par-iter
+*/
+
+iter myiter() {
+  yield 555;
+}
+
+iter myiter(param tag) {
+  coforall ooo in 1..3 {
+    yield 666;
+  }
+}
+
+iter pariter() {
+  yield 333;
+}
+
+iter pariter(param tag) {
+  for loc in Locales.these(iterKind.standalone) do
+    forall kkk in myiter() do
+      yield kkk + loc.id;
+}
+
+proc main {
+  var result1 = 20000, result2 = 9;
+  forall iii in pariter() with (
+                                in result1,
+                                + reduce result2
+                                ) {
+    writeln(result1, result2);
+  }
+}

--- a/test/parallel/forall/vass/par-loops/2-enclosing-par-loops-error-2.good
+++ b/test/parallel/forall/vass/par-loops/2-enclosing-par-loops-error-2.good
@@ -1,0 +1,7 @@
+2-enclosing-par-loops-error-2.chpl:27: In iterator 'pariter':
+2-enclosing-par-loops-error-2.chpl:30: error: this yield is nested in two or more enclosing parallel loops
+2-enclosing-par-loops-error-2.chpl:30: note: (a parallel loop is a for-loop over parallel iterator or a forall-loop)
+2-enclosing-par-loops-error-2.chpl:30: note: this is currently not implemented within parallel iterators
+2-enclosing-par-loops-error-2.chpl:29: note: the immediately enclosing parallel loop is here
+2-enclosing-par-loops-error-2.chpl:28: note: the second enclosing parallel loop is here
+2-enclosing-par-loops-error-2.chpl:35: note: the forall loop that invokes the iterator is here

--- a/test/parallel/forall/vass/par-loops/2-enclosing-par-loops-error-3.chpl
+++ b/test/parallel/forall/vass/par-loops/2-enclosing-par-loops-error-3.chpl
@@ -1,0 +1,41 @@
+/*
+This tests the situation where a reduce intent and/or in intent
+occurs in a forall loop, whose the parallel iterator contains a yield
+that is in 2 parallel loops.
+
+Specifically, in a parallel for loop that's in a forall loop.
+
+When this is no longer an error, test for absence of data races, like
+  parallel/forall/vass/reduce-with-forall-in-par-iter
+  parallel/forall/vass/reduce-fatter-with-forall-in-par-iter
+*/
+
+iter myiter() {
+  yield 555;
+}
+
+iter myiter(param tag) {
+  coforall ooo in 1..3 {
+    yield 666;
+  }
+}
+
+iter pariter() {
+  yield 333;
+}
+
+iter pariter(param tag) {
+  forall loc in Locales do
+    for kkk in myiter(iterKind.standalone) do
+      yield kkk + loc.id;
+}
+
+proc main {
+  var result1 = 20000, result2 = 9;
+  forall iii in pariter() with (
+                                in result1,
+                                + reduce result2
+                                ) {
+    writeln(result1, result2);
+  }
+}

--- a/test/parallel/forall/vass/par-loops/2-enclosing-par-loops-error-3.chpl
+++ b/test/parallel/forall/vass/par-loops/2-enclosing-par-loops-error-3.chpl
@@ -14,7 +14,7 @@ iter myiter() {
   yield 555;
 }
 
-iter myiter(param tag) {
+iter myiter(param tag) where tag == iterKind.standalone {
   coforall ooo in 1..3 {
     yield 666;
   }
@@ -24,7 +24,7 @@ iter pariter() {
   yield 333;
 }
 
-iter pariter(param tag) {
+iter pariter(param tag) where tag == iterKind.standalone {
   forall loc in Locales do
     for kkk in myiter(iterKind.standalone) do
       yield kkk + loc.id;

--- a/test/parallel/forall/vass/par-loops/2-enclosing-par-loops-error-3.good
+++ b/test/parallel/forall/vass/par-loops/2-enclosing-par-loops-error-3.good
@@ -1,0 +1,7 @@
+2-enclosing-par-loops-error-3.chpl:27: In iterator 'pariter':
+2-enclosing-par-loops-error-3.chpl:30: error: this yield is nested in two or more enclosing parallel loops
+2-enclosing-par-loops-error-3.chpl:30: note: (a parallel loop is a for-loop over parallel iterator or a forall-loop)
+2-enclosing-par-loops-error-3.chpl:30: note: this is currently not implemented within parallel iterators
+2-enclosing-par-loops-error-3.chpl:29: note: the immediately enclosing parallel loop is here
+2-enclosing-par-loops-error-3.chpl:28: note: the second enclosing parallel loop is here
+2-enclosing-par-loops-error-3.chpl:35: note: the forall loop that invokes the iterator is here

--- a/test/parallel/forall/vass/par-loops/2-enclosing-par-loops-error-4.chpl
+++ b/test/parallel/forall/vass/par-loops/2-enclosing-par-loops-error-4.chpl
@@ -14,7 +14,7 @@ iter myiter() {
   yield 555;
 }
 
-iter myiter(param tag) {
+iter myiter(param tag) where tag == iterKind.standalone {
   coforall ooo in 1..3 {
     yield 666;
   }
@@ -24,7 +24,7 @@ iter pariter() {
   yield 333;
 }
 
-iter pariter(param tag) {
+iter pariter(param tag) where tag == iterKind.standalone {
   for loc in Locales.these(iterKind.standalone) do
     for kkk in myiter(iterKind.standalone) do
       yield kkk + loc.id;

--- a/test/parallel/forall/vass/par-loops/2-enclosing-par-loops-error-4.chpl
+++ b/test/parallel/forall/vass/par-loops/2-enclosing-par-loops-error-4.chpl
@@ -1,0 +1,41 @@
+/*
+This tests the situation where a reduce intent and/or in intent
+occurs in a forall loop, whose the parallel iterator contains a yield
+that is in 2 parallel loops.
+
+Specifically, in a parallel for loop that's in another parallel for loop.
+
+When this is no longer an error, test for absence of data races, like
+  parallel/forall/vass/reduce-with-forall-in-par-iter
+  parallel/forall/vass/reduce-fatter-with-forall-in-par-iter
+*/
+
+iter myiter() {
+  yield 555;
+}
+
+iter myiter(param tag) {
+  coforall ooo in 1..3 {
+    yield 666;
+  }
+}
+
+iter pariter() {
+  yield 333;
+}
+
+iter pariter(param tag) {
+  for loc in Locales.these(iterKind.standalone) do
+    for kkk in myiter(iterKind.standalone) do
+      yield kkk + loc.id;
+}
+
+proc main {
+  var result1 = 20000, result2 = 9;
+  forall iii in pariter() with (
+                                in result1,
+                                + reduce result2
+                                ) {
+    writeln(result1, result2);
+  }
+}

--- a/test/parallel/forall/vass/par-loops/2-enclosing-par-loops-error-4.good
+++ b/test/parallel/forall/vass/par-loops/2-enclosing-par-loops-error-4.good
@@ -1,0 +1,7 @@
+2-enclosing-par-loops-error-4.chpl:27: In iterator 'pariter':
+2-enclosing-par-loops-error-4.chpl:30: error: this yield is nested in two or more enclosing parallel loops
+2-enclosing-par-loops-error-4.chpl:30: note: (a parallel loop is a for-loop over parallel iterator or a forall-loop)
+2-enclosing-par-loops-error-4.chpl:30: note: this is currently not implemented within parallel iterators
+2-enclosing-par-loops-error-4.chpl:29: note: the immediately enclosing parallel loop is here
+2-enclosing-par-loops-error-4.chpl:28: note: the second enclosing parallel loop is here
+2-enclosing-par-loops-error-4.chpl:35: note: the forall loop that invokes the iterator is here

--- a/test/parallel/forall/vass/reciter/forall-reciter-todo.bad
+++ b/test/parallel/forall/vass/reciter/forall-reciter-todo.bad
@@ -1,0 +1,2 @@
+forall-reciter-todo.chpl:50: error: Reduce intents are currently not implemented for forall- or for-loops over recursive parallel iterators
+forall-reciter-todo.chpl:19: note: the parallel iterator is here

--- a/test/parallel/forall/vass/reciter/forall-reciter-todo.chpl
+++ b/test/parallel/forall/vass/reciter/forall-reciter-todo.chpl
@@ -1,0 +1,55 @@
+/*
+See ./forall-reciter-works.chpl
+
+This test is for reduce intents, which are TODO.
+*/
+
+config const nn = 3;
+config const mm = 3;
+
+//
+// myiter() iterator ensures deterministic execution (using cnt$)
+// while still creating bona fide parallel tasks
+//
+
+iter myiter(depth: int): int {
+  yield 555;
+}
+
+iter myiter(depth: int, param tag: iterKind): int
+   where tag == iterKind.standalone
+{
+  if depth <= 0 {
+    //
+    // this piece ensures deterministic execution (using cnt$)
+    // while still creating bona fide parallel tasks
+    //
+    var cnt$: sync int = 1;
+    coforall ooo in 1..nn {
+      const current = cnt$;
+      writef("myiter start %t\n", current);
+      for jjj in 1..mm {
+        yield current * 100 + jjj;
+      }
+      writef("myiter done  %t\n", current);
+      cnt$ = current + 1;
+    }
+  } else {
+    writeln("recursing for depth ", depth);
+    // the recursive piece
+    forall kkk in myiter(depth-1) do
+      yield kkk;
+  }
+}
+
+proc main {
+  writeln("starting");
+
+  // testing reduce intents
+  var ovarPR = 1;
+  forall iii2 in myiter(2) with (+ reduce ovarPR) {
+    writef("%5i  %5i\n", iii2, ovarPR);
+    ovarPR += iii2;
+  }
+  writef("done iii2  %i\n", ovarPR);
+}

--- a/test/parallel/forall/vass/reciter/forall-reciter-todo.future
+++ b/test/parallel/forall/vass/reciter/forall-reciter-todo.future
@@ -1,0 +1,3 @@
+unimplemented feature: reduce intents in a for loop over a recursive iterator
+
+Issue t.b.d.

--- a/test/parallel/forall/vass/reciter/forall-reciter-todo.good
+++ b/test/parallel/forall/vass/reciter/forall-reciter-todo.good
@@ -1,0 +1,19 @@
+starting
+recursing for depth 2
+recursing for depth 1
+myiter start 1
+  101      0
+  102    101
+  103    203
+myiter done  1
+myiter start 2
+  201      0
+  202    201
+  203    403
+myiter done  2
+myiter start 3
+  301      0
+  302    301
+  303    603
+myiter done  3
+done iii2  1819

--- a/test/parallel/forall/vass/reciter/forall-reciter-works.chpl
+++ b/test/parallel/forall/vass/reciter/forall-reciter-works.chpl
@@ -1,0 +1,68 @@
+/*
+A forall loop that invokes a recursive parallel iterator.
+
+As of this writing (#7738), this works except for the case
+where there are reduce intents.
+Once those are implemented, extend this test to exercise
+those as well, by incorporating ./forall-reciter-works.chpl
+
+This situation is inspired by this test:
+  modules/standard/FileSystem/filerator/bradc/findfiles-par.chpl
+*/
+
+config const nn = 3;
+config const mm = 3;
+
+//
+// myiter() iterator ensures deterministic execution (using cnt$)
+// while still creating bona fide parallel tasks
+//
+
+iter myiter(depth: int): int {
+  yield 555;
+}
+
+iter myiter(depth: int, param tag: iterKind): int
+   where tag == iterKind.standalone
+{
+  if depth <= 0 {
+    //
+    // this piece ensures deterministic execution (using cnt$)
+    // while still creating bona fide parallel tasks
+    //
+    var cnt$: sync int = 1;
+    coforall ooo in 1..nn {
+      const current = cnt$;
+      writef("myiter start %t\n", current);
+      for jjj in 1..mm {
+        yield current * 100 + jjj;
+      }
+      writef("myiter done  %t\n", current);
+      cnt$ = current + 1;
+    }
+  } else {
+    writeln("recursing for depth ", depth);
+    // the recursive piece
+    forall kkk in myiter(depth-1) do
+      yield kkk;
+  }
+}
+
+proc main {
+  writeln("starting");
+
+  // no shadow variables at all
+  forall iii0 in myiter(2) {
+    writeln(iii0);
+  }
+  writeln("done iii0");
+
+  // testing in and ref intents
+  var ovarIn = 1, ovarRef = 2;
+  forall iii2 in myiter(2) with (in ovarIn, ref ovarRef) {
+    writef("%5i  %5i  %5i\n", iii2, ovarIn, ovarRef);
+    ovarIn += iii2;
+    ovarRef += iii2;
+  }
+  writef("done iii2  %i  %i\n", ovarIn, ovarRef);
+}

--- a/test/parallel/forall/vass/reciter/forall-reciter-works.good
+++ b/test/parallel/forall/vass/reciter/forall-reciter-works.good
@@ -1,0 +1,37 @@
+starting
+recursing for depth 2
+recursing for depth 1
+myiter start 1
+101
+102
+103
+myiter done  1
+myiter start 2
+201
+202
+203
+myiter done  2
+myiter start 3
+301
+302
+303
+myiter done  3
+done iii0
+recursing for depth 2
+recursing for depth 1
+myiter start 1
+  101      1      2
+  102    102    103
+  103    204    205
+myiter done  1
+myiter start 2
+  201      1    308
+  202    202    509
+  203    404    711
+myiter done  2
+myiter start 3
+  301      1    914
+  302    302   1215
+  303    604   1517
+myiter done  3
+done iii2  1  1820


### PR DESCRIPTION
* Restructure most of the "new" "Part 2" part of the implementation
of forall intents, specifically extendLeaderNew() and its helpers.
It still handles a variety of cases as before, now hopefully in
a more comprehensible manner.

* The following case is now handled nicely and uniformly
for all forall intents. The case is when the parallel iterator
(the one that is invoked by the forall loop)
itself contains a parallel loop (i.e. a forall or a for-loop
that invokes a leader or standalone iterator explicitly).

* The case from the previous bullet where the parallel loop is
a for-loop is handled by converting it to a forall loop first.
Handling a forall loop in this context is much simpler than
handling a for-loop, partly due to a better AST representation.
As a result, `eflopiMap` is no longer needed for the "new" implementation.

* The case when a yield in the parallel iterator is nested
inside 2 (or more) levels of parallel iterators has been causing INT_ASSERT.
Now it generates a "currently not implemented" error instead.

* ... except for the standalone iterator `walkdirs` in `FileSystem` module,
as tested by `modules/standard/FileSystem/filerator/bradc/findfiles-par`.

* To handle walkdirs and findfiles-par, recursive iterators are now supported
when the recursive invocation is made in a forall loop. (Previously it worked
only when such invocation was in a for-loop.) This works as long as there
are no reduce intents involved.

This PR's commits before squashing are 7278920..15b6a7e.

Testing:
- [x] linux64 --verify
- [x] gasnet multilocale tests
- [x] baseline
