### PR TITLE
Add some quality-of-life features to perf graphs

### DIFF
--- a/util/test/perf/index.html
+++ b/util/test/perf/index.html
@@ -53,6 +53,7 @@
 
         <button class="grayButton" onclick="selectAllGraphs()">Select All</button>
         <button class="grayButton" onclick="unselectAllGraphs()">Unselect All</button>
+        <button class="grayButton" onclick="invertSelection()">Invert Selection</button>
       </div>
 
       <p>Filter: <input type="text" name="filterBox">&nbsp;

--- a/util/test/perf/index.html
+++ b/util/test/perf/index.html
@@ -49,12 +49,15 @@
       <div id="buttonMenu">
         <button class="grayButton" onclick="displaySelectedGraphs()">Display</button>
         <button class="grayButton" onclick="clearDates()">Clear Dates</button>
+        <button class="grayButton" onclick="lastTwoWeeks()">Last Two Weeks</button>
 
         <button class="grayButton" onclick="selectAllGraphs()">Select All</button>
         <button class="grayButton" onclick="unselectAllGraphs()">Unselect All</button>
       </div>
 
-      <p>Filter: <input type="text" name="filterBox"></p>
+      <p>Filter: <input type="text" name="filterBox">&nbsp;
+        <button class="grayButton" onclick="clearFilter()" style="padding: 0px 3px 0px 3px">&#x2715;</button>
+      </p>
 
       <div id="graphlist">
         <!-- populated with checkboxes by javascript -->

--- a/util/test/perf/perfgraph.css
+++ b/util/test/perf/perfgraph.css
@@ -86,6 +86,15 @@ span.highlight {
   border-color: black !important;
 }
 
+.annotationInfo {
+  position: absolute;
+  background-color: white;
+  border: 1px solid black;
+  padding: 4px;
+  font-size: 14px;
+  z-index: 1000;
+}
+
 .grayButton {
   background-color: #d8d8d8;
   border: 1px solid black;

--- a/util/test/perf/perfgraph.css
+++ b/util/test/perf/perfgraph.css
@@ -35,7 +35,7 @@ body {
   width: 300px;
 }
 #buttonMenu .grayButton {
-  min-width: 80px;
+  min-width: 85px;
 }
 
 .graph {

--- a/util/test/perf/perfgraph.js
+++ b/util/test/perf/perfgraph.js
@@ -232,7 +232,7 @@ function getNextDivs(afterDiv) {
   var annToggle        = addButtonHelper('annotations');
   var screenshotToggle = addButtonHelper('screenshot');
   var closeGraphToggle = addButtonHelper('close');
-  var resetY           = addButtonHelper('reset Y zoom');
+  var resetY           = addButtonHelper('reset y zoom');
 
   return {
     div: div,
@@ -427,6 +427,13 @@ function setupLogToggle(g, graphInfo, logToggle) {
   }
 }
 
+// Compute x-axis position of the left side of the annotation text box.
+// Attempts to find a value such that the box will fit within the span of the
+// graph.
+//
+// Prefers to align the left of the annotation text box with the left of the
+// annotation number box. If the box would extend past the right side of the
+// graph, we shift the box to the left.
 function computeInfoLeft(info, box, parentDiv) {
   var ret  = 0;
 
@@ -453,9 +460,9 @@ function computeInfoLeft(info, box, parentDiv) {
   return ret;
 }
 
+// Find snippets that look like PRs (e..g (#1234)) and replace them
+// with links to the corresponding GitHub PR.
 function computeGitHubLinks(text) {
-  // Find snippets that look like PRs (e..g (#1234)) and replace them
-  // with links to the corresponding GitHub PR.
   var re = /\(#([0-9]+)\)/gi;
   text = text.replace(re, function(m, num) {
     var url = "https://github.com/chapel-lang/chapel/pull/" + num;
@@ -466,6 +473,9 @@ function computeGitHubLinks(text) {
   return text;
 }
 
+// Generate divs containing annotation text and links to PRs. They replace the
+// tooltip and will only be visible when hovering over the annotation number
+// box.
 function buildAnnotationHovers(container) {
   $(container).find('.blackAnnotation').each(function(i, box) {
     var text = box.title;
@@ -562,6 +572,8 @@ function setupCloseGraphToggle(g, graphInfo, closeGraphToggle) {
   }
 }
 
+// Setting `valueRange` to null will reset the y-axis zoom to the default. Note
+// that the default is different depending on the x-axis slice.
 function setupResetYZoom(g, graphInfo, resetY) {
   resetY.style.visibility = 'visible';
 
@@ -1318,9 +1330,7 @@ function unselectAllGraphs() {
 function invertSelection() {
   for (var i = 0; i < allGraphs.length; i++) {
     var elem = document.getElementById('graph' + i);
-    // Only tick the checkboxes that are visible. This allows users to
-    // filter for a string, hit 'select all', and only have that subset
-    // selected.
+    // Only tick the checkboxes that are visible in case others are filtered.
     if ($(elem.parentElement).is(":visible")) {
       elem.checked = !elem.checked;
     }
@@ -1663,6 +1673,8 @@ function parseDate(date) {
   }
 }
 
+// Compute the date from two weeks ago and set the x-axis slice to:
+//   (today - 2 weeks) .. today
 function lastTwoWeeks() {
   var end = getTodaysDate('-');
 

--- a/util/test/perf/perfgraph.js
+++ b/util/test/perf/perfgraph.js
@@ -1017,6 +1017,10 @@ function perfGraphInit() {
             g.setAnnotations(g.graphInfo.annotations, true);
           }
           setConfigurationVisibility(g);
+
+          // The previous call doesn't trigger the usual callback for some
+          // reason, so rebuild annotation hovers for this graph.
+          buildAnnotationHovers(g.divs.container);
         });
       };
     }

--- a/util/test/perf/perfgraph.js
+++ b/util/test/perf/perfgraph.js
@@ -459,7 +459,7 @@ function computeGitHubLinks(text) {
   var re = /\(#([0-9]+)\)/gi;
   text = text.replace(re, function(m, num) {
     var url = "https://github.com/chapel-lang/chapel/pull/" + num;
-    return "<a href='" + url + "'>" + m + "</a>";
+    return "<a target='_blank' href='" + url + "'>" + m + "</a>";
   });
   text = text.replace("\n", "\n<hr/>");
 

--- a/util/test/perf/perfgraph.js
+++ b/util/test/perf/perfgraph.js
@@ -1315,6 +1315,18 @@ function unselectAllGraphs() {
   checkAll(false);
 }
 
+function invertSelection() {
+  for (var i = 0; i < allGraphs.length; i++) {
+    var elem = document.getElementById('graph' + i);
+    // Only tick the checkboxes that are visible. This allows users to
+    // filter for a string, hit 'select all', and only have that subset
+    // selected.
+    if ($(elem.parentElement).is(":visible")) {
+      elem.checked = !elem.checked;
+    }
+  }
+}
+
 
 function checkAll(val) {
   for (var i = 0; i < allGraphs.length; i++) {


### PR DESCRIPTION
0) "Invert Selection" button

1) Add "Last Two Weeks" button as shortcut to common-case date slicing.

2) Add button to clear filter box.

3) Redirect ctrl+f and meta+f to filter box.

4) Add button to each graph that resets the Y-axis zoom.

5) Preserve Y-axis zoom when annotations are enabled

6) Instead of using a tooltip to see annotation text, a box will appear
below the annotation when hovered over. This box will contain the annotation
text with strings like "(#NNN)" linked to GitHub PRs.