### PR TITLE
Stop testing hpl.hpcc2012

### DIFF
--- a/test/studies/hpcc/HPL/vass/hpl.hpcc2012.notest
+++ b/test/studies/hpcc/HPL/vass/hpl.hpcc2012.notest
@@ -1,0 +1,5 @@
+This test has caused too many headaches without enough benefit, so I'm
+making it a notest until someone cares enough to look into it.  At the
+time of this writing, it's passing in all configurations other than
+CHPL_COMM=ugni where it segfaults in our 16-locale performance testing
+configuration.


### PR DESCRIPTION
This test has continued to cause headaches, the latest being a segfault when
doing 16-locale ugni testing.  Probably the right thing to do is to get valgrind
working cleanly under gasnet to see if that turns up anything, but I haven't
had time to dive into it.