### PR TITLE
Fix gasnet.darwin test errors on chapelmac since 2017-10-11

### DIFF
--- a/util/cron/test-gasnet.darwin.bash
+++ b/util/cron/test-gasnet.darwin.bash
@@ -11,4 +11,9 @@ export CHPL_UTIL_SMTP_HOST=relaya
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gasnet.darwin"
 
+# 2017-11-03: needed on chapelmac since I.T. updates on 2017-10-10
+#             known to be needed on a Macbook when connected over VPN
+export GASNET_MASTERIP=127.0.0.1
+export GASNET_WORKERIP=127.0.0.0
+
 $CWD/nightly -cron

--- a/util/cron/test-gasnet.fast.darwin.bash
+++ b/util/cron/test-gasnet.fast.darwin.bash
@@ -12,4 +12,9 @@ export CHPL_UTIL_SMTP_HOST=relaya
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gasnet.fast.darwin"
 
+# 2017-11-03: needed on chapelmac since I.T. updates on 2017-10-10
+#             known to be needed on a Macbook when connected over VPN
+export GASNET_MASTERIP=127.0.0.1
+export GASNET_WORKERIP=127.0.0.0
+
 $CWD/nightly -cron -hellos


### PR DESCRIPTION
Cray I.T. updated chapelmac build slave on 2017-10-10, and since
then, gasnet.darwin fails "make test" unless the following are added:
    export GASNET_MASTERIP=127.0.0.1
    export GASNET_WORKERIP=127.0.0.0

The same setting is needed when running w gasnet from a Macbook
connected over a VPN.

See also https://chapel-lang.org/docs/1.15/platforms/udp.html#troubleshooting-the-udp-conduit