### PR TITLE
Quiet timeouts for privatization test

### DIFF
--- a/test/distributions/privatization/runtime/addAndGetPrivatizedInParallel.chpl
+++ b/test/distributions/privatization/runtime/addAndGetPrivatizedInParallel.chpl
@@ -10,6 +10,7 @@ forall i in classSizes[1]..classSizes[2]-1 {
 
 // concurrently add some additional values, while reading all the old ones
 for classNum in 2..classSizes.size-1 {
+  var arr: [classSizes[1]..classSizes[classNum]-1] int;
   cobegin {
 
     {
@@ -22,12 +23,13 @@ for classNum in 2..classSizes.size-1 {
     {
       coforall 1..#here.maxTaskPar-1 {
         for i in classSizes[1]..classSizes[classNum]-1 {
-          writeln(getPrivatized(i).i);
+          arr[i] = getPrivatized(i).i;
         }
       }
     }
 
   }
+  for i in arr do writeln(i);
 }
 
 // Report no leaks


### PR DESCRIPTION
addAndGetPrivatizedInParallel has been sporadically timing out for cce whitebox
testing ever since that configuration was moved onto a busier machine. It turns
out that concurrent parallel-safe I/O uses a spinlock under qthreads, and this
test was doing a writeln on all cores, which led to timeouts when the machine
was busy. In order to quiet this test in the meantime, this just stores the
results in an array and writes out the array at the end to avoid concurrent IO

For more info see https://github.com/chapel-lang/chapel/issues/7748