### PR TITLE
Annotate regression from #7422

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -1075,6 +1075,8 @@ time_array_vs_ddata:
     - Optimize iteration over anonymous low-bounded counted ranges (#3154)
   03/01/16:
     - Extend early string-as-rec work to cover more sub-types of record (#3386)
+  10/05/17:
+    - Fix the anonymous range optimization for low-bounded counted ranges (#7422)
 
 time_array_vs_ref:
   09/13/16:


### PR DESCRIPTION
Documenting an older regression in `time_array_vs_ddata` that I pinpointed recently.

- [x] Passed `check_annotations.py`