### PR TITLE
Offset module-level CHPL_RT_MD constants

### DIFF
--- a/modules/internal/CPtr.chpl
+++ b/modules/internal/CPtr.chpl
@@ -306,7 +306,14 @@ module CPtr {
   }
 
 
-  private extern const CHPL_RT_MD_ARRAY_ELEMENTS:chpl_mem_descInt_t;
+  // Offset the CHPL_RT_MD constant in order to preserve the value through
+  // calls to chpl_here_alloc. See comments on offset_STR_* in String.chpl
+  // for more.
+  private proc offset_ARRAY_ELEMENTS {
+    extern const CHPL_RT_MD_ARRAY_ELEMENTS:chpl_mem_descInt_t;
+    extern proc chpl_memhook_md_num(): chpl_mem_descInt_t;
+    return CHPL_RT_MD_ARRAY_ELEMENTS - chpl_memhook_md_num();
+  }
 
   /*
     Return the size in bytes of a type, as with the C ``sizeof`` built-in.
@@ -338,7 +345,7 @@ module CPtr {
     */
   inline proc c_calloc(type eltType, size: integral) : c_ptr(eltType) {
     const alloc_size = size.safeCast(size_t) * c_sizeof(eltType);
-    return chpl_here_calloc(alloc_size, 1, CHPL_RT_MD_ARRAY_ELEMENTS):c_ptr(eltType);
+    return chpl_here_calloc(alloc_size, 1, offset_ARRAY_ELEMENTS):c_ptr(eltType);
   }
 
   /*
@@ -351,7 +358,7 @@ module CPtr {
     */
   inline proc c_malloc(type eltType, size: integral) : c_ptr(eltType) {
     const alloc_size = size.safeCast(size_t) * c_sizeof(eltType);
-    return chpl_here_alloc(alloc_size, CHPL_RT_MD_ARRAY_ELEMENTS):c_ptr(eltType);
+    return chpl_here_alloc(alloc_size, offset_ARRAY_ELEMENTS):c_ptr(eltType);
   }
 
   /* Free memory that was allocated with :proc:`c_calloc` or :proc:`c_malloc`.

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -77,9 +77,22 @@ module String {
   pragma "no doc"
   extern type chpl_mem_descInt_t = int(16);
 
-  // TODO: define my own mem descriptors?
-  private extern const CHPL_RT_MD_STR_COPY_REMOTE: chpl_mem_descInt_t;
-  private extern const CHPL_RT_MD_STR_COPY_DATA: chpl_mem_descInt_t;
+  private extern proc chpl_memhook_md_num(): chpl_mem_descInt_t;
+
+  // Calls to chpl_here_alloc increment the memory descriptor by
+  // `chpl_memhook_md_num`. For internal runtime descriptors like the ones
+  // below, this would result in selecting the incorrect descriptor string.
+  //
+  // Instead, decrement the CHPL_RT_MD* descriptor and use the result when
+  // calling chpl_here_alloc.
+  private proc offset_STR_COPY_DATA {
+    extern const CHPL_RT_MD_STR_COPY_DATA: chpl_mem_descInt_t;
+    return CHPL_RT_MD_STR_COPY_DATA - chpl_memhook_md_num();
+  }
+  private proc offset_STR_COPY_REMOTE {
+    extern const CHPL_RT_MD_STR_COPY_REMOTE: chpl_mem_descInt_t;
+    return CHPL_RT_MD_STR_COPY_REMOTE - chpl_memhook_md_num();
+  }
 
   pragma "no doc"
   type bufferType = c_ptr(uint(8));
@@ -99,7 +112,7 @@ module String {
   }
 
   private proc copyRemoteBuffer(src_loc_id: int(64), src_addr: bufferType, len: int): bufferType {
-      const dest = chpl_here_alloc(len+1, CHPL_RT_MD_STR_COPY_REMOTE): bufferType;
+      const dest = chpl_here_alloc(len+1, offset_STR_COPY_REMOTE): bufferType;
       chpl_string_comm_get(dest, src_loc_id, src_addr, len);
       dest[len] = 0;
       return dest;
@@ -162,7 +175,7 @@ module String {
           if this.owned {
             const allocSize = chpl_here_good_alloc_size(sLen+1);
             this.buff = chpl_here_alloc(allocSize,
-                                       CHPL_RT_MD_STR_COPY_DATA): bufferType;
+                                       offset_STR_COPY_DATA): bufferType;
             c_memcpy(this.buff, s.buff, s.len);
             this.buff[sLen] = 0;
             this._size = allocSize;
@@ -261,7 +274,7 @@ module String {
             // TODO: should I just allocate 'size' bytes?
             const allocSize = chpl_here_good_alloc_size(s_len+1);
             this.buff = chpl_here_alloc(allocSize,
-                                       CHPL_RT_MD_STR_COPY_DATA):bufferType;
+                                       offset_STR_COPY_DATA):bufferType;
             this._size = allocSize;
             // We just allocated a buffer, make sure to free it later
             this.owned = true;
@@ -391,7 +404,7 @@ module String {
       ret._size = max(chpl_string_min_alloc_size, newSize);
       ret.len = 1;
       ret.buff = chpl_here_alloc(ret._size,
-                                CHPL_RT_MD_STR_COPY_DATA): bufferType;
+                                offset_STR_COPY_DATA): bufferType;
       ret.owned = true;
 
       const remoteThis = this.locale_id != chpl_nodeID;
@@ -453,7 +466,7 @@ module String {
         // multi-locale and use that as the string buffer. No need to copy stuff
         // about after pulling it across.
         ret.buff = chpl_here_alloc(ret._size,
-                                  CHPL_RT_MD_STR_COPY_DATA): bufferType;
+                                  offset_STR_COPY_DATA): bufferType;
 
         var thisBuff: bufferType;
         const remoteThis = this.locale_id != chpl_nodeID;
@@ -899,7 +912,7 @@ module String {
         joined._size = allocSize;
         joined.buff = chpl_here_alloc(
           allocSize,
-          CHPL_RT_MD_STR_COPY_DATA): bufferType;
+          offset_STR_COPY_DATA): bufferType;
 
         var first = true;
         var offset = 0;
@@ -1308,7 +1321,7 @@ module String {
       if _local || s.locale_id == chpl_nodeID {
         if s.owned {
           ret.buff = chpl_here_alloc(s._size,
-                                    CHPL_RT_MD_STR_COPY_DATA): bufferType;
+                                    offset_STR_COPY_DATA): bufferType;
           c_memcpy(ret.buff, s.buff, s.len);
           ret.buff[s.len] = 0;
         } else {
@@ -1348,7 +1361,7 @@ module String {
       if _local || s.locale_id == chpl_nodeID {
         if s.owned {
           ret.buff = chpl_here_alloc(s._size,
-                                    CHPL_RT_MD_STR_COPY_DATA): bufferType;
+                                    offset_STR_COPY_DATA): bufferType;
           c_memcpy(ret.buff, s.buff, s.len);
           ret.buff[s.len] = 0;
         } else {
@@ -1428,7 +1441,7 @@ module String {
     const allocSize = chpl_here_good_alloc_size(ret.len+1);
     ret._size = allocSize;
     ret.buff = chpl_here_alloc(allocSize,
-                              CHPL_RT_MD_STR_COPY_DATA): bufferType;
+                              offset_STR_COPY_DATA): bufferType;
     ret.owned = true;
 
     const s0remote = s0.locale_id != chpl_nodeID;
@@ -1474,7 +1487,7 @@ module String {
     const allocSize = chpl_here_good_alloc_size(ret.len+1);
     ret._size = allocSize;
     ret.buff = chpl_here_alloc(allocSize,
-                              CHPL_RT_MD_STR_COPY_DATA): bufferType;
+                              offset_STR_COPY_DATA): bufferType;
     ret.owned = true;
 
     const sRemote = s.locale_id != chpl_nodeID;
@@ -1614,10 +1627,10 @@ module String {
 
         if lhs.owned {
           lhs.buff = chpl_here_realloc(lhs.buff, newSize,
-                                      CHPL_RT_MD_STR_COPY_DATA):bufferType;
+                                      offset_STR_COPY_DATA):bufferType;
         } else {
           var newBuff = chpl_here_alloc(newSize,
-                                       CHPL_RT_MD_STR_COPY_DATA):bufferType;
+                                       offset_STR_COPY_DATA):bufferType;
           c_memcpy(newBuff, lhs.buff, lhs.len);
           lhs.buff = newBuff;
           lhs.owned = true;
@@ -1794,7 +1807,7 @@ module String {
      :returns: A string with the single character with the ASCII value `i`.
   */
   inline proc asciiToString(i: uint(8)) {
-    var buffer = chpl_here_alloc(2, CHPL_RT_MD_STR_COPY_DATA): bufferType;
+    var buffer = chpl_here_alloc(2, offset_STR_COPY_DATA): bufferType;
     buffer[0] = i;
     buffer[1] = 0;
     var s = new string(buffer, 1, 2, owned=true, needToCopy=false);


### PR DESCRIPTION
The alloc functions in LocaleModelHelpMem were adding
`chpl_memhook_md_num` to the CHPL_RT_MD constants resulting in incorrect
memory descriptor strings in memory leaks output. Instead, pass
`CHPL_RT_MD* - chpl_memhook_md_num` to the alloc functions.

Testing:
- [x] full local
- [x] full gasnet
- [x] memleaks