### PR TITLE
Forwarding wrappers should propagate errors

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -3127,6 +3127,10 @@ static bool populateForwardingMethods(CallInfo& info) {
 
       fn->addFlag(FLAG_LAST_RESORT);
 
+      if (method->throwsError()) {
+        fn->throwsErrorInit();
+      }
+
       fn->retTag = method->retTag;
 
       ArgSymbol* mt    = new ArgSymbol(INTENT_BLANK, "_mt", dtMethodToken);

--- a/test/classes/delete-free/owned-error-handling.chpl
+++ b/test/classes/delete-free/owned-error-handling.chpl
@@ -1,0 +1,17 @@
+
+use OwnedObject;
+
+class Foo {
+  proc foobar() throws {
+    throw new Error();
+  }
+}
+
+proc main() {
+  var f = new Owned(new Foo());
+  try {
+    f.foobar();
+  } catch e : Error {
+    writeln("SUCCESS");
+  }
+}

--- a/test/classes/delete-free/owned-error-handling.good
+++ b/test/classes/delete-free/owned-error-handling.good
@@ -1,0 +1,1 @@
+SUCCESS

--- a/test/classes/forwarding/forwardErrors.chpl
+++ b/test/classes/forwarding/forwardErrors.chpl
@@ -1,0 +1,20 @@
+
+record B {
+  proc foo() throws {
+    throw new Error();
+  }
+}
+
+record A {
+  var down : B;
+  forwarding down;
+}
+
+proc main() {
+  try {
+    var a = new A();
+    a.foo();
+  } catch e : Error {
+    writeln("Got error from proc.");
+  }
+}

--- a/test/classes/forwarding/forwardErrors.good
+++ b/test/classes/forwarding/forwardErrors.good
@@ -1,0 +1,1 @@
+Got error from proc.


### PR DESCRIPTION
Wrapper methods for forwarded fields should propagate errors, otherwise try-catch blocks will not work and the program will halt due to uncaught errors.

Testing:
- [x] full local