### PR TITLE
Update preferred system version of LLVM to 4.0

### DIFF
--- a/third-party/llvm/Makefile.share-system
+++ b/third-party/llvm/Makefile.share-system
@@ -1,6 +1,6 @@
 include $(THIRD_PARTY_DIR)/llvm/Makefile.share
 
-PREFERRED_LLVM_VERS=3.7
+PREFERRED_LLVM_VERS=4.0
 
 ifndef LLVM_CONFIG
   export LLVM_CONFIG=$(shell $(THIRD_PARTY_DIR)/llvm/find-llvm-config.sh $(PREFERRED_LLVM_VERS))


### PR DESCRIPTION
In the combination of #6962 and #7643 , I missed updating the preferred LLVM version from 3.7 to 4.0 in one place.  This did not become apparent until we started testing CHPL_LLVM=system on more platforms.

This fixes the last remaining place where the version needs to be bumped.