### PR TITLE
Forwarding on domains and distributions

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -897,6 +897,8 @@ module ChapelArray {
       }
     }
 
+    forwarding _value except these;
+
     inline proc _do_destroy() {
       if ! _unowned && ! _instance.singleton() {
         on _instance {
@@ -1039,6 +1041,8 @@ module ChapelArray {
         return _instance;
       }
     }
+
+    forwarding _value except these;
 
     pragma "no doc"
     proc chpl__serialize() where this._value.type : DefaultRectangularDom {

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -897,7 +897,7 @@ module ChapelArray {
       }
     }
 
-    forwarding _value except these;
+    forwarding _value except these, targetLocales;
 
     inline proc _do_destroy() {
       if ! _unowned && ! _instance.singleton() {

--- a/test/distributions/bharshbarg/forwardDomDist.chpl
+++ b/test/distributions/bharshbarg/forwardDomDist.chpl
@@ -1,0 +1,22 @@
+use BlockDist;
+
+proc Block.printBB() {
+  writeln("boundingBox = ", boundingBox);
+}
+
+proc DefaultAssociativeDom.printTableSize() {
+  writeln("tableSize = ", tableSize);
+}
+
+proc main() {
+  var DR = {1..20};
+  var BD = DR dmapped Block(DR);
+  writeln(BD.dist.type:string, ".printBB()");
+  BD.dist.printBB();
+  writeln();
+
+  var DA = {1, 3, 5, 6, 7, 42};
+  writeln(DA.type:string, ".printTableSize()");
+  DA.printTableSize();
+  writeln();
+}

--- a/test/distributions/bharshbarg/forwardDomDist.good
+++ b/test/distributions/bharshbarg/forwardDomDist.good
@@ -1,0 +1,6 @@
+Block(1,int(64),DefaultDist).printBB()
+boundingBox = {1..20}
+
+DefaultAssociativeDom(int(64),true).printTableSize()
+tableSize = 23
+

--- a/test/distributions/vass/changeBoundingBox.chpl
+++ b/test/distributions/vass/changeBoundingBox.chpl
@@ -48,11 +48,10 @@ For now, do this instead:
 
 const distTemp = new Block(dummyBB);
 const DM = new dmap(distTemp);
-const distInForce = DM._value;
 
-distInForce.changeBoundingBox(1..4);
+DM.changeBoundingBox(1..4);
 for idx in 0..6 do writeln("C:  ", idx, " maps to ",
-                           distInForce.dsiIndexToLocale(idx));
+                           DM.idxToLocale(idx));
 
 // Show this one in action, too.
 var Dbis: domain(1) dmapped DM;


### PR DESCRIPTION
This PR allows for forwarding on domains and distributions. This enables easy access to any method the domain map author implements.

'targetLocales' is except'd from distributions because some dists (like Block) have a field named 'targetLocales' that would conflict with the method of the same name.

Testing:
- [x] full local
- [x] full gasnet