### PR TITLE
Remove dead newAlias code and compiler support

### DIFF
--- a/compiler/include/flags_list.h
+++ b/compiler/include/flags_list.h
@@ -194,7 +194,6 @@ symbolFlag( FLAG_MODULE_INIT , npr, "module init" , "a module init function" )
 // This flag marks the result of an autoCopy as necessary.
 // Necessary autoCopies are not removed by the removeUnnecessaryAutoCopyCalls optimization.
 symbolFlag( FLAG_NECESSARY_AUTO_COPY, npr, "necessary auto copy", "a variable containing a necessary autoCopy" )
-symbolFlag( FLAG_NEW_ALIAS_FN, ypr, "new alias fn", "newAlias function" )
 symbolFlag( FLAG_IGNORE_NOINIT, ypr, "ignore noinit", "this type must be initialized" )
 symbolFlag( FLAG_NON_BLOCKING , npr, "non blocking" , "with FLAG_ON/FLAG_ON_BLOCK, non-blocking on functions" )
 symbolFlag( FLAG_NO_AUTO_DESTROY , ypr, "no auto destroy" , ncm )

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1428,16 +1428,6 @@ module ChapelArray {
       return member(i);
     }
 
-    pragma "no doc"
-    pragma "reference to const when const this"
-    pragma "new alias fn"
-    proc newAlias() {
-      var x = _value;
-      pragma "no copy"
-      var ret = _getDomain(x);
-      return ret;
-    }
-
     /* Return true if this domain is a subset of ``super``. Otherwise
        returns false. */
     proc isSubset(super : domain) {
@@ -2328,17 +2318,6 @@ module ChapelArray {
     proc numElements return _value.dom.dsiNumIndices;
     /* Return the number of elements in the array */
     proc size return numElements;
-
-    pragma "no doc"
-    pragma "reference to const when const this"
-    pragma "new alias fn"
-    pragma "fn returns aliasing array"
-    proc newAlias() {
-      var x = _value;
-      pragma "no copy"
-      var ret = _getArray(x);
-      return ret;
-    }
 
     //
     // This routine determines whether an actual array argument


### PR DESCRIPTION
This PR removes some dead newAlias code and compiler support for it.

Trivial and not reviewed.
Passed full local testing.