### PR TITLE
Fix arguments like type t:object

### DIFF
--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -780,6 +780,11 @@ static bool needToAddCoercion(Type*      actualType,
              (getIntent(formal) & INTENT_FLAG_REF) != 0) {
     retval = false;
 
+  // If actual and formal are type symbols, no coercion is necessary
+  } else if (actualSym->hasFlag(FLAG_TYPE_VARIABLE) &&
+             formal->hasFlag(FLAG_TYPE_VARIABLE)) {
+    retval = false;
+
   } else if (canCoerce(actualType, actualSym, formalType, fn) == true) {
     retval =  true;
 

--- a/test/functions/ferguson/type-colon-dispatch.chpl
+++ b/test/functions/ferguson/type-colon-dispatch.chpl
@@ -1,0 +1,43 @@
+record R {
+  var x;
+}
+
+class Parent {
+  var a:int;
+}
+
+class Child : Parent {
+  var b:int;
+}
+
+class MyClass {
+  var c:int;
+}
+
+proc foo(type t:int) {
+  writeln("int");
+}
+proc foo(type t:integral) {
+  writeln("integral");
+}
+proc foo(type t) {
+  writeln("any type");
+}
+proc foo(type t:R) {
+  writeln("R");
+}
+proc foo(type t:Parent) {
+  writeln("Parent");
+}
+proc foo(type t:object) {
+  writeln("object");
+}
+
+
+foo(int);
+foo(int(8));
+foo(real);
+foo(R(complex));
+foo(Parent);
+foo(Child);
+foo(MyClass);

--- a/test/functions/ferguson/type-colon-dispatch.good
+++ b/test/functions/ferguson/type-colon-dispatch.good
@@ -1,0 +1,7 @@
+int
+integral
+any type
+R
+Parent
+Parent
+object


### PR DESCRIPTION
After working with function resolution, I've realized that it's
significantly more work for the compiler to resolve a 'where' clause than
a type constraint expressed with a : on the argument. Additionally, I
know that many _cast overrides are created and resolved in the process of
normal program compilation, and these typically use where clauses. For
this reason, I was wondering if declaring arguments like 'type t:object'
or 'type t:integral' would work.

So, I tried a few cases and to my surprise most of them were working
already! I only needed to make a minor modification to allow it in the
remaining cases. (In particular, only the type t:someclasstype were not
working).

For example, this PR enables functions like this:
``` chapel
proc foo(type t:object) {
  writeln("object");
}
```
The fix amounts to adjusting needToAddCoercion to ignore coercing between type variables.

This pattern does not seem to be used much (if at all) in our code base
currently, so I added a test to exercise it.

Passed full local testing.

Future work: Replace some where clauses with the `type t:sometype`
argument declarations to reduce the work the compiler must do.

Reviewed by @vasslitvinov - thanks!