### PR TITLE
Proposed specification changes for type t:someType arguments

### DIFF
--- a/spec/Generics.tex
+++ b/spec/Generics.tex
@@ -74,10 +74,7 @@ accepting type arguments that only apply to a specific group of types.
 Suppose that we'd like to define a function that accepts a type argument
 and returns 1 represented in that type.
 \begin{chapel}
-proc getOne(type t:real) {
-  return 1.0;
-}
-proc getOne(type t:integral) {
+proc getOne(type t:numeric) {
   return 1:t;
 }
 \end{chapel}

--- a/spec/Generics.tex
+++ b/spec/Generics.tex
@@ -38,8 +38,7 @@ If a formal argument is specified with intent \chpl{type}, then a type
 must be passed to the function at the call site.  A copy of the
 function is instantiated for each unique type that is passed to this
 function at a call site.  The formal argument has the semantics of a
-type alias. Note that type arguments can specify a type that they should
-match.
+type alias.
 
 \begin{chapelexample}{build2tuple.chpl}
 The following code defines a function that takes two types at the call
@@ -66,6 +65,10 @@ writeln(t2);
 (1, hello)
 \end{chapeloutput}
 \end{chapelexample}
+
+A formal type argument can include a formal type (a colon followed by a
+type). This pattern is sometimes useful to create generic functions
+accepting type arguments that only apply to a specific group of types.
 
 \begin{chapelexample}{typeColonArgument.chpl}
 Suppose that we'd like to define a function that accepts a type argument

--- a/spec/Generics.tex
+++ b/spec/Generics.tex
@@ -38,7 +38,9 @@ If a formal argument is specified with intent \chpl{type}, then a type
 must be passed to the function at the call site.  A copy of the
 function is instantiated for each unique type that is passed to this
 function at a call site.  The formal argument has the semantics of a
-type alias.
+type alias. Note that type arguments can specify a type that they should
+match.
+
 \begin{chapelexample}{build2tuple.chpl}
 The following code defines a function that takes two types at the call
 site and returns a 2-tuple where the types of the components of the
@@ -64,6 +66,34 @@ writeln(t2);
 (1, hello)
 \end{chapeloutput}
 \end{chapelexample}
+
+\begin{chapelexample}{typeColonArgument.chpl}
+Suppose that we'd like to define a function that accepts a type argument
+and returns 1 represented in that type.
+\begin{chapel}
+proc getOne(type t:real) {
+  return 1.0;
+}
+proc getOne(type t:integral) {
+  return 1:t;
+}
+\end{chapel}
+Now calls to this function will resolve to the appropriate version based
+upon the argument type supplied.
+\begin{chapel}
+var anInt8 = getOne(int(8));
+var aReal = getOne(real);
+\end{chapel}
+\begin{chapelpost}
+writeln(anInt8.type:string, " ", anInt8);
+writeln(aReal.type:string, " ", aReal);
+\end{chapelpost}
+\begin{chapeloutput}
+int(8) 1
+real(64) 1.0
+\end{chapeloutput}
+\end{chapelexample}
+
 
 \subsection{Formal Parameter Arguments}
 \label{Formal_Parameter_Arguments}

--- a/spec/Generics.tex
+++ b/spec/Generics.tex
@@ -138,11 +138,12 @@ each unique actual type.
 \begin{chapelexample}{fillTuple2.chpl}
 The example from the previous section can be extended to be generic on
 a parameter as well as the actual argument that is passed to it by
-omitting the type of the formal argument \chpl{x}.  The following code
+omitting the type of the formal argument \chpl{x}.  Additionally
+the parameter argument can allow any type be passed. The following code
 defines a function that returns a homogeneous tuple of size \chpl{p}
 where each component in the tuple is initialized to \chpl{x}:
 \begin{chapel}
-proc fillTuple(param p: int, x) {
+proc fillTuple(param p, x) {
   var result: p*x.type;
   for param i in 1..p do
     result(i) = x;


### PR DESCRIPTION
PR  #7776 adjusts the compiler to allow arguments like `type t:object`. Many other cases were already working.

However the specification does not explicitly say whether or not this is legal. This PR modifies the specification to assert that `type t:someType` arguments are legal and to show an example of them. Additionally it adjusts one of the `param` examples to show that the type for a `param` argument can be omitted.

Reviewed by @daviditen - thanks!