### PR TITLE
Don't set argument type to dtAny for type variables with type exprs

### DIFF
--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -2351,7 +2351,8 @@ DefExpr* buildClassDefExpr(const char*  name,
 void setupTypeIntentArg(ArgSymbol* arg) {
   arg->intent = INTENT_BLANK;
   arg->addFlag(FLAG_TYPE_VARIABLE);
-  arg->type = dtAny;
+  if (arg->typeExpr == NULL)
+    arg->type = dtAny;
 }
 
 

--- a/test/functions/ferguson/type-colon-generic-record.chpl
+++ b/test/functions/ferguson/type-colon-generic-record.chpl
@@ -1,0 +1,20 @@
+record R {
+  
+  var x;
+}
+
+proc foo(type t:R) {
+  writeln("generic ", t:string);
+}
+proc foo(type t:R(real)) {
+  writeln("real ", t:string);
+}
+
+
+var r1=new R(1);
+var rs=new R("test");
+var rr=new R(1.0);
+
+foo(r1.type);
+foo(rs.type);
+foo(rr.type);

--- a/test/functions/ferguson/type-colon-generic-record.good
+++ b/test/functions/ferguson/type-colon-generic-record.good
@@ -1,0 +1,3 @@
+generic R(int(64))
+generic R(string)
+real R(real(64))

--- a/test/functions/ferguson/type-colon-int-int8.chpl
+++ b/test/functions/ferguson/type-colon-int-int8.chpl
@@ -1,0 +1,12 @@
+proc foo(type t:int) {
+  writeln("int version");
+}
+proc foo(type t:int(8)) {
+  writeln("int(8) version");
+}
+
+proc bar(x:int(8)) {
+}
+
+foo(int(8));
+bar(1);

--- a/test/functions/ferguson/type-colon-int-int8.good
+++ b/test/functions/ferguson/type-colon-int-int8.good
@@ -1,0 +1,1 @@
+int(8) version


### PR DESCRIPTION
e.g. proc foo(type t:int(8)) should not have type dtAny but rather type dtUnknown that is resolved later. This allows the determination about whether or not that type is generic to be made later in compilation and enables more 'type t:someType' argument patterns to work.

- [x] full local testing
- [x] test/functions/ferguson with --baseline, --verify, --baseline --verify

Reviewed by @vasslitvinov - thanks!