### PR TITLE
Fixup query formals 2

### DIFF
--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -2715,14 +2715,13 @@ static void addToWhereClause(ArgSymbol* formal,
 
 static void fixupQueryFormals(FnSymbol* fn) {
   for_formals(formal, fn) {
-    if (!formal->typeExpr)
-      continue;
+    if (BlockStmt* typeExpr = formal->typeExpr) {
+      Expr* tail = typeExpr->body.tail;
 
-    if (isDefExpr(formal->typeExpr->body.tail) == true) {
-      replaceUsesWithPrimTypeof(fn, formal);
+      if  (isDefExpr(tail) == true) {
+        replaceUsesWithPrimTypeof(fn, formal);
 
-    } else if (isCallExpr(formal->typeExpr->body.tail) == true) {
-      if (isQueryForGenericTypeSpecifier(formal) == true) {
+      } else if (isQueryForGenericTypeSpecifier(formal) == true) {
         expandQueryForGenericTypeSpecifier(fn, formal);
       }
     }

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -109,15 +109,6 @@ static bool moduleHonorsNoinit(Symbol* var, Expr* init);
 
 static void updateVariableAutoDestroy(DefExpr* defExpr);
 
-static void replace_query_uses(ArgSymbol*             formal,
-                               DefExpr*               defExpr,
-                               CallExpr*              query,
-                               std::vector<SymExpr*>& symExprs);
-
-static void add_to_where_clause(ArgSymbol* formal,
-                                Expr*      expr,
-                                CallExpr*  query);
-
 static TypeSymbol* expandTypeAlias(SymExpr* se);
 
 /************************************* | **************************************
@@ -2654,61 +2645,66 @@ static void cloneParameterizedPrimitive(FnSymbol* fn,
 
 /************************************* | **************************************
 *                                                                             *
+* Query formals appear in two/four forms                                      *
+*                                                                             *
+*   1)  proc chpl__autoDestroy(x: ?t) ...                                     *
+*       proc foo(x: ?t, y : t) ...                                            *
+*                                                                             *
+*       The identifier 't' may appear in the formals list, in a where clause, *
+*       or in the body of the function.                                       *
+*                                                                             *
+*       The parser represents the definition of the query variable as a       *
+*       DefExpr in the BlockStmt that is created for any formal type-expr.    *
+*                                                                             *
+*       This case is handled by replacing every use of 't' with x.type.       *
 *                                                                             *
 *                                                                             *
-************************************** | *************************************/
-
-static void
-replace_query_uses(ArgSymbol* formal, DefExpr* def, CallExpr* query,
-                   std::vector<SymExpr*>& symExprs) {
-  for_vector(SymExpr, se, symExprs) {
-    if (se->symbol() == def->sym) {
-      if (formal->variableExpr) {
-        CallExpr* parent = toCallExpr(se->parentExpr);
-        if (!parent || parent->numActuals() != 1)
-          USR_FATAL(se, "illegal access to query type or parameter");
-        se->replace(new SymExpr(formal));
-        parent->replace(se);
-        CallExpr* myQuery = query->copy();
-        myQuery->insertAtHead(parent);
-        se->replace(myQuery);
-      } else {
-        CallExpr* myQuery = query->copy();
-        myQuery->insertAtHead(formal);
-        se->replace(myQuery);
-      }
-    }
-  }
-}
-
-static void
-add_to_where_clause(ArgSymbol* formal, Expr* expr, CallExpr* query) {
-  FnSymbol* fn = formal->defPoint->getFunction();
-  if (!fn->where) {
-    fn->where = new BlockStmt(new SymExpr(gTrue));
-    insert_help(fn->where, NULL, fn);
-    fn->addFlag(FLAG_COMPILER_ADDED_WHERE);
-  }
-  formal->addFlag(FLAG_NOT_FULLY_GENERIC);
-  Expr* where = fn->where->body.tail;
-  CallExpr* clause;
-  query->insertAtHead(formal);
-  if (formal->variableExpr) {
-    clause = new CallExpr(PRIM_TUPLE_AND_EXPAND);
-    while (query->numActuals())
-      clause->insertAtTail(query->get(1)->remove());
-    clause->insertAtTail(expr->copy());
-  } else {
-    clause = new CallExpr("==", expr->copy(), query);
-  }
-  where->replace(new CallExpr("&", where->copy(), clause));
-}
-
-/************************************* | **************************************
 *                                                                             *
 *                                                                             *
+*   2)  proc =(ref a: _ddata(?t), b: _ddata(t)) ...                           *
+*                                                                             *
+*       The important difference is that 't' is a type field for a generic    *
+*       type; in this example the generic type _ddata.                        *
+*                                                                             *
+*       The BlockStmt for the type-expr of the formal will include a          *
+*       CallExpr with an actual that is a DefExpr.                            *
+*                                                                             *
+*                                                                             *
+*   2a) proc _getView(r:range(?))                                             *
+*                                                                             *
+*       This generic function handles any actual that is a specialization of  *
+*       the generic type range.  The compiler uses the same representation    *
+*       as for (2) and supplies a unique name for the query variable.         *
+*                                                                             *
+*       The current implementation does not attempt to distinguish this case  *
+*       from (2).                                                             *
+*                                                                             *
+*                                                                             *
+*   2b) proc +(a: int(?w), b: int(w)) return __primitive("+", a, b);          *
+*                                                                             *
+*       This appears to be another example of (2) but it is handled           *
+*       completely differently.  An earlier sub-phase notices these queries   *
+*       for a generic primitive type, instantiates new versions for all       *
+*       allowable values of 'w', and then deletes the original AST.           *
+*       Hence these functions are never observed by the following code.       *
+*                                                                             *
+*   NB: This code does not handle the count for varadic functions e.g.        *
+*                                                                             *
+*       proc min(x, y, z...?k) ...                                            *
+*                                                                             *
+*       The identifier 'k' is not part of the type of 'z'.  The current AST   *
+*       stores the DefExpr for 'k' in the variableExpr of 'z'.                *
 *                                                                             *
 ************************************** | *************************************/
+
+static void replaceQueryUses(ArgSymbol*             formal,
+                             DefExpr*               def,
+                             CallExpr*              query,
+                             std::vector<SymExpr*>& symExprs);
+
+static void addToWhereClause(ArgSymbol* formal,
+                             Expr*      expr,
+                             CallExpr*  query);
 
 static void fixupQueryFormals(FnSymbol* fn) {
   for_formals(formal, fn) {
@@ -2745,7 +2741,7 @@ static void fixupQueryFormals(FnSymbol* fn) {
         std::vector<SymExpr*> symExprs;
         collectSymExprs(fn, symExprs);
         if (call->isNamed("_build_tuple")) {
-          add_to_where_clause(formal, new SymExpr(new_IntSymbol(call->numActuals())), new CallExpr(PRIM_QUERY, new_CStringSymbol("size")));
+          addToWhereClause(formal, new SymExpr(new_IntSymbol(call->numActuals())), new CallExpr(PRIM_QUERY, new_CStringSymbol("size")));
           call->baseExpr->replace(new SymExpr(dtTuple->symbol));
           isTupleType = true;
         }
@@ -2755,9 +2751,9 @@ static void fixupQueryFormals(FnSymbol* fn) {
             positionQueryTemplate->insertAtTail(new_CStringSymbol(named->name));
             CallExpr* nameQuery = new CallExpr(PRIM_QUERY, new_CStringSymbol(named->name));
             if (DefExpr* def = toDefExpr(named->actual)) {
-              replace_query_uses(formal, def, nameQuery, symExprs);
+              replaceQueryUses(formal, def, nameQuery, symExprs);
             } else {
-              add_to_where_clause(formal, named->actual, nameQuery);
+              addToWhereClause(formal, named->actual, nameQuery);
             }
           }
         }
@@ -2767,9 +2763,9 @@ static void fixupQueryFormals(FnSymbol* fn) {
             CallExpr* positionQuery = positionQueryTemplate->copy();
             positionQuery->insertAtTail(new_IntSymbol(position));
             if (DefExpr* def = toDefExpr(actual)) {
-              replace_query_uses(formal, def, positionQuery, symExprs);
+              replaceQueryUses(formal, def, positionQuery, symExprs);
             } else {
-              add_to_where_clause(formal, actual, positionQuery);
+              addToWhereClause(formal, actual, positionQuery);
             }
             position++;
           }
@@ -2779,6 +2775,61 @@ static void fixupQueryFormals(FnSymbol* fn) {
       }
     }
   }
+}
+
+static void replaceQueryUses(ArgSymbol*             formal,
+                             DefExpr*               def,
+                             CallExpr*              query,
+                             std::vector<SymExpr*>& symExprs) {
+  for_vector(SymExpr, se, symExprs) {
+    if (se->symbol() == def->sym) {
+      if (formal->variableExpr) {
+        CallExpr* parent = toCallExpr(se->parentExpr);
+        if (!parent || parent->numActuals() != 1)
+          USR_FATAL(se, "illegal access to query type or parameter");
+        se->replace(new SymExpr(formal));
+        parent->replace(se);
+        CallExpr* myQuery = query->copy();
+        myQuery->insertAtHead(parent);
+        se->replace(myQuery);
+      } else {
+        CallExpr* myQuery = query->copy();
+        myQuery->insertAtHead(formal);
+        se->replace(myQuery);
+      }
+    }
+  }
+}
+
+static void addToWhereClause(ArgSymbol* formal, Expr* expr, CallExpr* query) {
+  FnSymbol* fn = formal->defPoint->getFunction();
+
+  if (!fn->where) {
+    fn->where = new BlockStmt(new SymExpr(gTrue));
+    insert_help(fn->where, NULL, fn);
+    fn->addFlag(FLAG_COMPILER_ADDED_WHERE);
+  }
+
+  formal->addFlag(FLAG_NOT_FULLY_GENERIC);
+
+  Expr* where = fn->where->body.tail;
+
+  CallExpr* clause;
+
+  query->insertAtHead(formal);
+
+  if (formal->variableExpr) {
+    clause = new CallExpr(PRIM_TUPLE_AND_EXPAND);
+    while (query->numActuals())
+      clause->insertAtTail(query->get(1)->remove());
+
+    clause->insertAtTail(expr->copy());
+
+  } else {
+    clause = new CallExpr("==", expr->copy(), query);
+  }
+
+  where->replace(new CallExpr("&", where->copy(), clause));
 }
 
 /************************************* | **************************************


### PR DESCRIPTION
Refactor normalize::fixupQueryFormals

This PR consists of a small sequence of trivial commits that
convert fixupQueryFormals() in to a handful of simple routines
that expose the operations that are being performed

Compiled with/without CHPL_DEVELOPER on clang/darwin
and gcc/linux64.  Tested each configuration on a small
portion of release/

Passed full paratest on linux64 for single locale and --no-local.
