### PR TITLE
Tim Sort

### DIFF
--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -512,7 +512,7 @@ proc insertionSort(Data: [?Dom] ?eltType, comparator:?rec=defaultComparator)
 
 /*
    Sort the 1D array `Data` in-place using a sequential, stable binary insertion sort algorithm.
-   Should be used when there is a high cost of comparision.
+   Should be used when there is a high cost of comparison.
 
    :arg Data: The array to be sorted
    :type Data: [] `eltType`
@@ -520,7 +520,6 @@ proc insertionSort(Data: [?Dom] ?eltType, comparator:?rec=defaultComparator)
       data is sorted.
 
  */
-
 proc binaryInsertionSort(Data: [?Dom] ?eltType, comparator:?rec=defaultComparator) {
   chpl_check_comparator(comparator, eltType);
   const low = Dom.low,
@@ -528,37 +527,49 @@ proc binaryInsertionSort(Data: [?Dom] ?eltType, comparator:?rec=defaultComparato
         stride = abs(Dom.stride);
 
   for i in low..high by stride {
-    var ithVal = Data[i];
+    var valToInsert = Data[i],
+        lo = low,
+        hi = i - stride; 
 
-    var lo: int = low,
-        hi: int = i - stride,
-        loc: int = -1;              // index that ithVal should be inserted at
+    var (found, loc) = _binarySearchForLastOccurrence(Data, valToInsert, comparator, lo, hi);
+    loc = if found then loc + stride else loc;              // insert after last occurrence if exists; else insert after expected location
 
-    while (lo <= hi) {
-      const size = (hi - lo) / stride,
-            mid = if hi == lo then hi
-                  else if size % 2 then lo + ((size - 1)/2) * stride
-                  else lo + (size/2 - 1) * stride;
-
-      if chpl_compare(ithVal, Data[mid], comparator) == 0 {
-          loc = mid;              // index of last occurence of ithVal in 1..mid
-          lo = loc + stride;
-      }
-      else if chpl_compare(ithVal, Data[mid], comparator) > 0 then
-        lo = mid + stride;
-      else
-        hi = mid - stride;
-    }
-    
-    loc = if loc == -1 then lo else loc + stride;
     for j in loc..i-stride by -stride {
       // backward swap until loc
-      Data[j+stride] = Data[j];
+      Data[j + stride] = Data[j];
     }
-    Data[loc] = ithVal;
+
+    Data[loc] = valToInsert;
   }
 }
 
+/*
+  Binary searches for the index of the last occurrence of `val` in the 1D array `Data` based on a comparator.
+  If `val` is not in `Data`, the index that it should be inserted at is returned.
+  Does not check for a valid comparator.
+*/
+private proc _binarySearchForLastOccurrence(Data: [?Dom], val, comparator:?rec=defaultComparator, in lo=Dom.low, in hi=Dom.high) {
+  const stride = if Dom.stridable then abs(Dom.stride) else 1;
+
+  var loc = -1;                                        // index of the last occurrence of val in Data
+
+  while (lo <= hi) {
+    const size = (hi - lo) / stride,
+          mid = lo + (size/2) * stride;
+
+    if chpl_compare(val, Data[mid], comparator) == 0 {
+        loc = mid;                                    // index of last occurrence of val in 1..mid
+        lo = loc + stride;
+    }
+    else if chpl_compare(val, Data[mid], comparator) > 0 then
+      lo = mid + stride;
+    else
+      hi = mid - stride;
+  }
+
+  if loc == -1 then return (false, lo);              // returns index where val should be
+  return (true, loc);                                // returns index of the last occurrence of val
+}
 
 pragma "no doc"
 /* Error message for multi-dimension arrays */

--- a/test/modules/packages/Sort/correctness/correctness.chpl
+++ b/test/modules/packages/Sort/correctness/correctness.chpl
@@ -98,6 +98,14 @@ proc main() {
     for param i in 1..tests.size {
       var (arr, cmp) = tests(i);
       resetArray(arr, cmp);
+      binaryInsertionSort(arr, comparator=cmp);
+      if !checkSort(arr, cmp) then
+        writeln('  for binaryInsertionSort() function.\n');
+    }
+
+    for param i in 1..tests.size {
+      var (arr, cmp) = tests(i);
+      resetArray(arr, cmp);
       quickSort(arr, comparator=cmp);
       if !checkSort(arr, cmp) then
         writeln('  for quickSort() function.\n');

--- a/test/modules/packages/Sort/performance/performance.chpl
+++ b/test/modules/packages/Sort/performance/performance.chpl
@@ -11,7 +11,7 @@ use Time;
 
 config const M: int = 6,                    // 2**M bytes
              correctness: bool = true,      // Disables output
-             sorts: string = 'qhims';       // Sorts to use (first letter)
+             sorts: string = 'qhimsr';      // Sorts to use (first letter)
 
 // Array properties
 config type T = int;                // Type of array
@@ -81,6 +81,18 @@ proc gatherTimings(const ref A) {
       writeln('insertionSort failed to sort data');
     else
       print('insertionSort (seconds): ', t.elapsed());
+    t.clear();
+  }
+  if sorts.find('r')
+  {
+    var B = A;
+    t.start();
+    binaryInsertionSort(B);
+    t.stop();
+    if !isSorted(B) then
+      writeln('binaryInsertionSort failed to sort data');
+    else
+      print('binaryInsertionSort (seconds): ', t.elapsed());
     t.clear();
   }
   if sorts.find('m')

--- a/test/modules/packages/Sort/performance/performance.perfexecopts
+++ b/test/modules/packages/Sort/performance/performance.perfexecopts
@@ -3,3 +3,4 @@
 --sorts='i' --M=12 --correctness=false            # insertionSort
 --sorts='s' --M=12 --correctness=false            # selectionSort
 --sorts='b' --M=12 --correctness=false            # bubbleSort
+--sorts='r' --M=12 --correctness=false            # binary insertion sort

--- a/test/modules/packages/Sort/performance/sorts-quadratic.graph
+++ b/test/modules/packages/Sort/performance/sorts-quadratic.graph
@@ -1,6 +1,6 @@
 perfkeys: (seconds):, (seconds):, (seconds):
-files: insertionSort.dat, selectionSort.dat, bubbleSort.dat
-graphkeys: insertionSort, selectionSort, bubbleSort
+files: insertionSort.dat, selectionSort.dat, bubbleSort.dat, binaryInsertionSort.dat
+graphkeys: insertionSort, selectionSort, bubbleSort, binaryInsertionSort
 graphtitle: Quadratic sorts on 2^12 bytes of shuffled data
 ylabel: Time (seconds)
 


### PR DESCRIPTION
Implementation of Tim Sort for the Sort module - WIP

Currently implemented:
- Binary insertion sort (including correctness and performance)

Next steps:
- Tim sort without galloping

Benchmarking:

```
Time taken to sort 65536 bytes (8192 int(64)s)
quickSort (seconds): 0.022325
heapSort (seconds): 0.027805
insertionSort (seconds): 1.78996
binaryInsertionSort (seconds): 0.89685
mergeSort (seconds): 0.097196
selectionSort (seconds): 1.97712
```