### PR TITLE
Use string literal

### DIFF
--- a/compiler/AST/ModuleSymbol.cpp
+++ b/compiler/AST/ModuleSymbol.cpp
@@ -629,10 +629,6 @@ void ModuleSymbol::addDefaultUses() {
     SET_LINENO(this);
 
     block->useListAdd(rootModule);
-
-    UnresolvedSymExpr* modRef = new UnresolvedSymExpr("ChapelStringLiterals");
-
-    block->insertAtHead(new UseStmt(modRef));
   }
 }
 

--- a/test/modules/sungeun/init/printModuleInitOrder.good
+++ b/test/modules/sungeun/init/printModuleInitOrder.good
@@ -7,7 +7,6 @@ Initializing Modules:
      StringCasts
     ChapelDebugPrint
     ChapelBase
-     ChapelStringLiterals
     MemConsistency
     Atomics
     ChapelThreads


### PR DESCRIPTION
Stop the parser from adding "use ChapelStringLiterals;" to ChapelBase


I happened to notice that "the parser" was automagically inserting
"use ChapelStringLiterals;" in to ChapelBase.

This PR prevents this.  I was able to do this without adding it
manually to ChapelBase.chpl; presumably due to other changes
in the compiler.  I did not investigate.

Compiled in all the usual ways.

Paratested with single-locale, --no-local, and even --llvm.