### PR TITLE
Fix issue #7783 for forwarding

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -3121,9 +3121,7 @@ static bool populateForwardingMethods(CallInfo& info) {
       fn->addFlag(FLAG_FORWARDING_FN);
       fn->addFlag(FLAG_COMPILER_GENERATED);
 
-      // Mark it as generic if `this` argument is generic
-      if (thisType->symbol->hasFlag(FLAG_GENERIC))
-        fn->addFlag(FLAG_GENERIC);
+      // see below, after arguments added, for adjustment to FLAG_GENERIC
 
       fn->addFlag(FLAG_LAST_RESORT);
 
@@ -3185,6 +3183,13 @@ static bool populateForwardingMethods(CallInfo& info) {
 
         i++;
       }
+
+      // Adjust whether or not fn is generic:
+      //  - it should be marked it as generic if `this` argument is generic
+      //  - it should not be marked generic if all arguments are concrete
+      //    (including if the arguments represent generic types with defaults)
+      fn->removeFlag(FLAG_GENERIC);
+      fn->tagIfGeneric();
 
       // copy the where clause
       if (method->where != NULL) {

--- a/test/classes/forwarding/forwarding-generic-default.chpl
+++ b/test/classes/forwarding/forwarding-generic-default.chpl
@@ -1,0 +1,45 @@
+// This test case represents a bug originally reported in issue #7783
+
+class A{
+  forwarding var driver: B;
+}
+
+class B{
+  type MyType = 3*string; //This makes the compiler not find the overridden methods.
+
+  var bfield:MyType; 
+
+  proc foo1(){
+     return this;
+  }
+
+  proc foo2(args2:string){
+      return this;
+  }
+
+  proc foo3(args3, args4:string){
+      return this;
+  }
+  proc foo4(arg){
+     return this;
+  }
+
+}
+
+class C:B{
+
+  var cfield:int;
+}
+
+
+var c1 = new A(new C());
+writeln(c1.foo1());
+
+var c2 = new A(new C());
+writeln(c2.foo2("Test"));
+
+var c3 = new A(new C());
+writeln(c3.foo3("Test", "Test"));
+
+var c4 = new A(new C());
+writeln(c4.foo4("Test"));

--- a/test/classes/forwarding/forwarding-generic-default.good
+++ b/test/classes/forwarding/forwarding-generic-default.good
@@ -1,0 +1,4 @@
+{bfield = (, , ), cfield = 0}
+{bfield = (, , ), cfield = 0}
+{bfield = (, , ), cfield = 0}
+{bfield = (, , ), cfield = 0}


### PR DESCRIPTION
The forwarding method was computing FLAG_GENERIC incorrectly; this PR
fixes issue #7783 by adjusting it to use FnSymbol::tagIfGeneric.
Additionally, it adds a version of the test from issue #7783, which now
passes, to the testing system.

Fixes #7783.

- [x] full local testing

Reviewed by @vasslitvinov - thanks!