### PR TITLE
Convert to more tests to use initializers

### DIFF
--- a/test/studies/comd/elegant/arrayOfStructs/util/AccumStencilDist.chpl
+++ b/test/studies/comd/elegant/arrayOfStructs/util/AccumStencilDist.chpl
@@ -453,11 +453,13 @@ proc AccumStencil.dsiCreateReindexDist(newSpace, oldSpace) {
 }
 
 
-proc LocAccumStencil.LocAccumStencil(param rank: int,
-                      type idxType,
-                      locid, // the locale index from the target domain
-                      boundingBox: rank*range(idxType),
-                      targetLocBox: rank*range) {
+proc LocAccumStencil.init(param rank: int,
+                          type idxType,
+                          locid, // the locale index from the target domain
+                          boundingBox: rank*range(idxType),
+                          targetLocBox: rank*range) {
+  this.rank = rank;
+  this.idxType = idxType;
   if rank == 1 {
     const lo = boundingBox(1).low;
     const hi = boundingBox(1).high;
@@ -479,6 +481,7 @@ proc LocAccumStencil.LocAccumStencil(param rank: int,
     }
     myChunk = {(...inds)};
   }
+  super.init();
 }
 
 proc AccumStencilDom.dsiMyDist() return dist;

--- a/test/studies/comd/llnl/utils/forceeam.chpl
+++ b/test/studies/comd/llnl/utils/forceeam.chpl
@@ -14,12 +14,13 @@ class InterpolationObject {
   var nSpace : domain(1);
   var values : [nSpace] real;
 
-  proc InterpolationObject(n:int, x0:real, dx:real, values:[] real) {
+  proc init(n:int, x0:real, dx:real, values:[] real) {
     this.n = n;
+    this.x0 = x0;
     this.dx = dx;
     this.invDx = 1.0/dx;
-    this.x0 = x0;
     this.nSpace = -1..n+1;
+    super.init();
 
     var nSpaceInner : domain(1) = 0..n-1;
 

--- a/test/studies/comd/llnl/utils/forcelj.chpl
+++ b/test/studies/comd/llnl/utils/forcelj.chpl
@@ -16,7 +16,7 @@ class ForceLJ : Force {
   var epsilon2 : real;
   var epsilon4 : real;
 
-  proc ForceLJ() {
+  proc init() {
     sigma = 2.315;
     epsilon  = 0.167;
     var locCutoff = 2.5*sigma;

--- a/test/studies/comd/llnl/utils/forcelj.chpl
+++ b/test/studies/comd/llnl/utils/forcelj.chpl
@@ -19,21 +19,23 @@ class ForceLJ : Force {
   proc ForceLJ() {
     sigma = 2.315;
     epsilon  = 0.167;
-    mass = 63.55 * amuToInternalMass;
-    lat = 3.615;
-    latticeType = "FCC";  
-    cutoff = 2.5*sigma;
-    name = "Cu";
-    atomicNumber = 29;
-    potName = "Lennard-Jones";
+    var locCutoff = 2.5*sigma;
 
-    cutoff2 = cutoff * cutoff;
+    var locCutoff2 = locCutoff * locCutoff;
     sigma2 = sigma * sigma;
     s6 = sigma2*sigma2*sigma2;
-    rCut6 = s6 / (cutoff2*cutoff2*cutoff2);
+    rCut6 = s6 / (locCutoff2*locCutoff2*locCutoff2);
     eShift = POT_SHIFT * rCut6 * (rCut6 - 1.0);
     epsilon2 = 2.0 * epsilon;
     epsilon4 = 4.0 * epsilon;
+    super.init(cutoff = locCutoff,
+               mass = 63.55 * amuToInternalMass,
+               lat = 3.615,
+               latticeType = "FCC",
+               name = "Cu",
+               atomicNumber = 29,
+               potName = "Lennard-Jones",
+               cutoff2 = locCutoff2);
   }
 
   inline proc compute(a : real3, b : real3, inout fij, inout pij) {

--- a/test/studies/comd/llnl/utils/helpers.chpl
+++ b/test/studies/comd/llnl/utils/helpers.chpl
@@ -16,7 +16,7 @@ class Ticker {
   var duration : real;
   var times : int;
 
-  proc Ticker(const in tName : string) {
+  proc init(const in tName : string) {
     name = tName;
     tick = new Timer();
     tick.clear();

--- a/test/users/npadmana/bugs/replicated_invalid_ref_return/replicated_bug.chpl
+++ b/test/users/npadmana/bugs/replicated_invalid_ref_return/replicated_bug.chpl
@@ -12,8 +12,8 @@ module Utils {
     var D: domain(1);
     var x : int;
 
-    // Old-style constructor
-    proc R() {
+    // New style initializer
+    proc init() {
     }
 
     // No checks

--- a/test/users/shetag/fock/blockindices-blc.chpl
+++ b/test/users/shetag/fock/blockindices-blc.chpl
@@ -4,11 +4,12 @@ use fock;
 class blockIndices {
   const is, js, ks, ls: range(int);
 
-  proc blockIndices(iat, jat, kat, lat) {
+  proc init(iat, jat, kat, lat) {
     is = bas_info(iat);
     js = bas_info(jat);
     ks = bas_info(kat);
     ls = bas_info(lat);
+    super.init();
   }
 
   // BLC: TODO -- this should have a better name

--- a/test/users/shetag/fock/fock-1-begin-blc.chpl
+++ b/test/users/shetag/fock/fock-1-begin-blc.chpl
@@ -15,7 +15,7 @@ var jmat2, kmat2, jmat2T, kmat2T : [matD] elemType;
 class blockIndices {
   const ilo, ihi, jlo, jhi, klo, khi, llo, lhi : int;
   
-  proc blockIndices(ilo, ihi, jlo, jhi, klo, khi, llo, lhi) {
+  proc init(ilo, ihi, jlo, jhi, klo, khi, llo, lhi) {
     this.ilo = ilo;
     this.ihi = ihi;
     this.jlo = jlo;
@@ -23,7 +23,8 @@ class blockIndices {
     this.klo = klo;
     this.khi = khi;
     this.llo = llo;
-    this.lhi = lhi;	 
+    this.lhi = lhi;
+    super.init();
   }
 }
 

--- a/test/users/shetag/fock/fock-orig.chpl
+++ b/test/users/shetag/fock/fock-orig.chpl
@@ -15,7 +15,7 @@ var jmat2, kmat2, jmat2T, kmat2T : [matD] elemType;
 class blockIndices {
   const ilo, ihi, jlo, jhi, klo, khi, llo, lhi : int;
   
-  proc blockIndices(ilo, ihi, jlo, jhi, klo, khi, llo, lhi) {
+  proc init(ilo, ihi, jlo, jhi, klo, khi, llo, lhi) {
     this.ilo = ilo;
     this.ihi = ihi;
     this.jlo = jlo;
@@ -23,7 +23,8 @@ class blockIndices {
     this.klo = klo;
     this.khi = khi;
     this.llo = llo;
-    this.lhi = lhi;	 
+    this.lhi = lhi;
+    super.init();
   }
 }
 

--- a/test/users/thom/arrInClass-dommember.chpl
+++ b/test/users/thom/arrInClass-dommember.chpl
@@ -2,9 +2,10 @@ class StoreSomeInts {
   var intsDom: domain(1);
   var m_someints: [intsDom] int;
 
-  proc StoreSomeInts(m_someints: [] int) {
+  proc init(m_someints: [] int) {
     intsDom = m_someints.domain;
     this.m_someints = m_someints;
+    super.init();
   }
 }
 

--- a/test/users/thom/arrInClass-tuple.chpl
+++ b/test/users/thom/arrInClass-tuple.chpl
@@ -2,7 +2,7 @@ class StoreSomeInts {
   var intsDom: domain(1);
   var m_someints: [intsDom] int;
 
-  proc StoreSomeInts(intTuple:int...?k) {
+  proc init(intTuple:int...?k) {
     intsDom = {1..k};
     this.m_someints = intTuple;
   }

--- a/test/users/thom/returnGenericLineno/rosslyn.chpl
+++ b/test/users/thom/returnGenericLineno/rosslyn.chpl
@@ -78,7 +78,7 @@ module Rosslyn
            
 
         /** Explicit form of default constructor */
-        proc BenchmarkRunner(factory : BenchmarkFactory, repeats = 5 )
+        proc init(factory : BenchmarkFactory, repeats = 5 )
         {
             this.factory = factory;
             this.repeats = repeats;


### PR DESCRIPTION
These tests were accidentally overlooked in my initial conversion to
use initializers instead of constructors.  Some remain that still have
issues, but these were all capable of being converted.

In more detail:
test/studies/comd/elegant/arrayOfStructs/CoMD.chpl's helper file,
test/studies/comd/elegant/arrayOfStructs/util/AccumStencilDist.chpl,
saw the constructor for LocAccumStencil updated to an initializer.  The
other constructor in that file, for AccumStencil, could not yet be updated
because the type inherits from a library type.  This initializer would benefit
from Phase 1 being the default, and from the ability to define generic and
const fields in Phase 2.

test/studies/comd/llnl/CoMD.chpl's helper types InterpolationObject,
ForceLJ, and Ticker types have been updated to use initializers.  Ticker
would benefit from Phase 1 being the default.  I was unable to update
ForceEAM due to the presence of not yet supported error handling
statements in its body.

test/users/npadmana/bugs/replicated_invalid_ref_return/replicated_bug.chpl
was trivially updated to an initializer.

test/users/shetag/fock/fock-orig.chpl's blockIndices class was updated to
use an initializer.  This initializer would benefit from Phase 1 as the default
and the ability to set const fields during Phase 2.

test/users/shetag/fock/blockindices-blc.chpl, the helper file for
test/users/shetag/fock/fock-3-blc.chpl, test/users/shetag/fock/fock-stc-1.chpl,
test/users/shetag/fock/fock-stc.chpl,
test/users/shetag/fock/fock-dyn-prog-pool.chpl, and
test/users/shetag/fock/fock-dyn-prog-cntr.chpl, was updated.  It would also
benefit from Phase 1 as the default and the ability to set const fields during
Phase 2.

test/users/shetag/fock/fock-1-begin-blc.chpl would also benefit from Phase
1 as the default and the ability to set const fields during Phase 2.

test/users/thom/arrInClass-tuple.chpl would benefit from Phase 1 as the
default.

test/users/thom/arrInClass-dommember.chpl similarly would benefit from
Phase 1 as the default.

The helper file of test/users/thom/returnGenericLineno/strassen_main.chpl,
test/users/thom/returnGenericLineno/rosslyn.chpl, would also benefit from
Phase 1 as the default.

Passed a full std/ paratest