### PR TITLE
Fix build issues for systems that have cuda installed

### DIFF
--- a/third-party/hwloc/Makefile
+++ b/third-party/hwloc/Makefile
@@ -27,6 +27,7 @@ CHPL_HWLOC_CFG_OPTIONS += --enable-static \
                           --disable-cairo \
                           --disable-libxml2 \
                           --disable-libudev \
+                          --disable-cuda \
                           --disable-opencl \
                           --disable-pci
 


### PR DESCRIPTION
Hwloc probes for cuda and if cuda is found, hwloc must be linked with
`-lcudart`. However, when qthreads is checking if hwloc works it only throws
`-lhwloc` or `-lhwloc -lnuma`, so the link step fails. Note that we build hwloc
and qthreads statically, for .so builds this wouldn't be an issue.

For now just throw `--disable-cuda` to hwloc to avoid the issue. The "right"
solution is probably for qthreads to use libtool or pkg-config to figure out
hwloc's link args: https://github.com/Qthreads/qthreads/issues/56