### PR TITLE
Make our execution limiter race-free

### DIFF
--- a/third-party/chpl-venv/test-requirements.txt
+++ b/third-party/chpl-venv/test-requirements.txt
@@ -1,3 +1,4 @@
 subprocess32==3.2.6
 argparse==1.3.0
 PyYAML==3.11
+filelock==2.0.13

--- a/util/test/execution_limiter.py
+++ b/util/test/execution_limiter.py
@@ -1,107 +1,49 @@
-from __future__ import with_statement
+""" Execution limiter implementations to help limit the number of concurrently
+running chpl executables """
 
 import getpass
 import os
-import sys
 import tempfile
-import time
+import filelock
 
-def log_info(msg):
-    if os.getenv('CHPL_TEST_DEBUG_RUNNING_EXECUTABLE_LOCK') is not None:
-        sys.stdout.write('[Exec-lock Info: {0}]\n'.format(msg))
-        sys.stdout.flush()
-
-# Empty class that can be used with a context manager. Does not
-# limit how many executables can run at once.
 class NoLock():
+    """ Empty class that can be used with a context manager. Does not limit how
+        many executables can run at once. """
     def __enter__(self):
         pass
-    def __exit__(self, type, value, traceback):
+    def __exit__(self, exc_type, exc_value, traceback):
         pass
 
-# Class that uses a file as a mutex so that only one executable can
-# run per user, per machine. This is useful when you want to
-# oversubscribe paratest, but don't want to cause too many
-# executables to run at once since some tests can consume the whole
-# machine which can starve other executables, causing timeouts.
-#
-# This works by using a file as a lock/mutex. It's race-y so it's
-# possible (though relatively unlikely) that two or more executables
-# could run at the same time. That's a little unfortunate, but not a
-# huge deal as it's pretty unlikely we'll get multiple resource
-# heavy tests running simultaneously
-#
-# The constructor takes the name of the executable and its timeout
-# value.
+
 class FileLock():
-    exec_name = ''
-    exec_timeout = ''
-    lock_file = ''
+    """ Simple wrapper over filelock that will only let one executable run per
+        user, per machine.
 
-    # simple backoff sleep, so that we have relatively fast latency for a bunch
-    # of quick running tests, but don't poll the machine continuously if a test
-    # is taking a while to run. see #3928 for why the times/backoff were chosen
-    sleep_time = .02
-    def _backoff_sleep(self, max_sleep=.5, backoff_factor=1.3):
-	time.sleep(self.sleep_time)
-	if self.sleep_time < max_sleep:
-	    self.sleep_time *= backoff_factor
-   
-    def __init__(self, exec_name, exec_timeout):
-	lock_name = '{0}-chpl_program_executing'.format(getpass.getuser())
+        filelock is a platform independent lock that uses 1 of 3 platform
+        dependent implementations. It will use `fcntl.flock` on unix systems
+        (including mac and cygwin) to create a hard lock, `msvcrt.locking` on
+        windows systems, and a soft file-based lock otherwise. fcntl and msvcrt
+        don't have issues with 'stale' locks because the lock is held on the
+        file descriptor and gets dropped by the OS even if the program crashes.
+        The soft file-based lock can cause stale locks, so if we ever run into
+        a platform where fcntl/msvcrt aren't supported we should re-add our own
+        implementation that can deal with stale lock files.
+
+        Also note that fcntl/msvcrt will leave the actual file used for locking
+        around. Removing the file would "unlock" the lock, so there'd be a race
+        between unlocking/removing and locking (we'd effectively have a double
+        unlock). This is a common problem for file-based locks including
+        "fasteners" (https://github.com/harlowja/fasteners/issues/26) """
+    lock_file = ''
+    lock = None
+
+    def __init__(self):
+        lock_name = '{0}-chpl_program_executing'.format(getpass.getuser())
         self.lock_file = os.path.join(tempfile.gettempdir(), lock_name)
-        self.exec_name = exec_name
-        self.exec_timeout = exec_timeout
+        self.lock = filelock.FileLock(self.lock_file)
 
     def __enter__(self):
-        self._lock()
+        self.lock.acquire()
 
-    def __exit__(self, type, value, traceback):
-        self._unlock()
-
-    # parse the lock_file and return how long ago the lock_file was
-    # modified, the name of the test that has the lock, and the
-    # test's timeout value. If there's issues opening or parsing the
-    # file, return a default of: (1, "corrupted_lock_file", 0), so
-    # that the waiting test can continue.
-    def _parse_lock_file(self):
-        default_lock_file = (1, "corrupted_lock_file", 0)
-        try:
-            with open(self.lock_file, 'r') as f:
-                lines = f.read().splitlines()
-                other_filename = lines[0]
-                other_timeout = int(lines[1])
-
-                modified = time.time() - os.path.getmtime(self.lock_file)
-                return (modified, other_filename, other_timeout)
-        except:
-            log_info('Failed to parse lock file, using default one')
-            return default_lock_file
-
-    # Grab the execution "lock", spin waiting while some other test
-    # has the lock. If for some reason the other test didn't clean
-    # up the locking file, we'll continue if the lock hasn't been
-    # modified in the other test's timeout value.
-    def _lock(self):
-	modified = 0
-	other_timeout = 1
-	while os.path.exists(self.lock_file) and modified < other_timeout:
-            modified, other_filename, other_timeout = self._parse_lock_file()
-            log_info('"{0}" is waiting at most {1}s for "{2}" (started {3:.1f}s '
-                     'ago) to finish executing'.format(
-                     self.exec_name, other_timeout, other_filename, modified))
-            self._backoff_sleep()
-
-	# actually grab the "lock" by creating the file
-        log_info('Grabbing exec-lock for "{0}"'.format(self.exec_name))
-	with open(self.lock_file, 'w') as f:
-	    f.write('{0}\n{1}\n'.format(self.exec_name, self.exec_timeout))
-
-
-    def _unlock(self):
-	try:
-	    # release the "lock" by removing the file
-            log_info('Releasing exec-lock for "{0}"'.format(self.exec_name))
-	    os.remove(self.lock_file)
-	except:
-	    pass
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.lock.release()

--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -1858,7 +1858,7 @@ for testname in testsrc:
                 exec_limiter = execution_limiter.NoLock()
                 if os.getenv("CHPL_TEST_LIMIT_RUNNING_EXECUTABLES") is not None:
                     exec_name = os.path.join(localdir, test_filename)
-                    exec_limiter = execution_limiter.FileLock(exec_name, timeout)
+                    exec_limiter = execution_limiter.FileLock()
 
                 with exec_limiter:
                     exectimeout = False  # 'exectimeout' is specific to one trial of one execopt setting


### PR DESCRIPTION
Use filelock (https://pypi.python.org/pypi/filelock) to make our execution
limiter race free in order to avoid timeouts under llvm/whitebox testing.

PR #3928 added an "execution_limiter" to try to prevent multiple executables
from running at the same time. It used a file as a lock in racey manner, but we
didn't think the race would be that big of a deal. However, recently we've seen
timeouts for some whitebox and llvm configurations that are using paratest in
heavily a oversubscribed manner and in all cases it seems to be because
multiple chpl executables are running, meaning the race is hurting us.

Our old implementation used a soft file-based lock, whereas filelock will use a
hard lock when available. filelock is a platform independent lock that uses 1
of 3 platform dependent implementations. It will use `fcntl.flock` on unix
systems (including mac and cygwin) to create a hard lock, `msvcrt.locking` on
windows systems, and a soft file-based lock otherwise. fcntl and msvcrt don't
have issues with 'stale' locks because the lock is held on the file descriptor
and gets dropped by the OS even if the program crashes. The soft file-based
lock can cause stale locks, so if we ever run into a platform where
fcntl/msvcrt aren't supported we should re-add our own implementation that can
deal with stale lock files.

Also note that fcntl/msvcrt will leave the actual file used for locking around.
Removing the file would "unlock" the lock, so there'd be a race between locking
and unlocking/removing (we'd effectively have a double unlock). This is a
common problem for file-based locks. Since we're only using a lockfile per
user, this shouldn't be a big deal, but if we start using the execution limiter
for more things we might need to find a different solution.

This should resolve https://github.com/chapel-lang/chapel/issues/7795