### PR TITLE
Store paths saved for --llvm relative to CHPL_HOME etc

### DIFF
--- a/compiler/include/files.h
+++ b/compiler/include/files.h
@@ -92,8 +92,9 @@ const char* filenameToModulename(const char* filename);
 
 const char* getIntermediateDirName();
 
-void readArgsFromFile(std::string path, std::vector<std::string>& cmds);
 void readArgsFromCommand(std::string path, std::vector<std::string>& args);
+void readArgsFromFile(std::string path, std::vector<std::string>& cmds);
+void expandInstallationPaths(std::vector<std::string>& args);
 
 char*       dirHasFile(const char* dir, const char* file);
 char*       findProgramPath(const char* argv0);

--- a/compiler/util/clangUtil.cpp
+++ b/compiler/util/clangUtil.cpp
@@ -1511,6 +1511,8 @@ void runClang(const char* just_parse_filename) {
   runtime_includes += "/list-includes-and-defines";
 
   readArgsFromFile(runtime_includes, args);
+  // Substitute $CHPL_HOME $CHPL_RUNTIME_LIB etc
+  expandInstallationPaths(args);
 
   if (compilingWithPrgEnv()) {
     std::string gather_prgenv(CHPL_HOME);
@@ -2584,6 +2586,8 @@ void makeBinaryLLVM(void) {
 
   std::vector<std::string> clangLDArgs;
   readArgsFromFile(runtime_libs, clangLDArgs);
+  // Substitute $CHPL_HOME $CHPL_RUNTIME_LIB etc
+  expandInstallationPaths(clangLDArgs);
 
   if (compilingWithPrgEnv()) {
     std::string gather_prgenv(CHPL_HOME);

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -823,7 +823,7 @@ void expandInstallationPaths(std::vector<std::string>& args) {
 
       size_t off = 0;
       while (true) {
-        off = s.find(tofix[j], off);
+        off = s.find(key, off);
         if (off == std::string::npos)
           break; // no more occurrences to replace
         s.replace(off, key_len, val);

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -802,6 +802,39 @@ void readArgsFromFile(std::string path, std::vector<std::string>& args) {
   fclose(fd);
 }
 
+void expandInstallationPaths(std::vector<std::string>& args) {
+
+  const char* tofix[] = {"$CHPL_RUNTIME_LIB", CHPL_RUNTIME_LIB,
+                         "$CHPL_RUNTIME_INCL", CHPL_RUNTIME_INCL,
+                         "$CHPL_THIRD_PARTY", CHPL_THIRD_PARTY,
+                         "$CHPL_HOME", CHPL_HOME,
+                         NULL};
+
+  for (size_t i = 0; i < args.size(); i++) {
+    std::string s = args[i];
+
+    // For each of the patterns in tofix, find/replace all occurrences.
+    for (int j = 0; tofix[j] != NULL; j += 2) {
+
+      const char* key = tofix[j];
+      const char* val = tofix[j+1];
+      size_t key_len = strlen(key);
+      size_t val_len = strlen(val);
+
+      size_t off = 0;
+      while (true) {
+        off = s.find(tofix[j], off);
+        if (off == std::string::npos)
+          break; // no more occurrences to replace
+        s.replace(off, key_len, val);
+        off += val_len;
+      }
+    }
+
+    args[i] = s;
+  }
+}
+
 // would just use realpath, but it is not supported on all platforms.
 static
 char* chplRealPath(const char* path)

--- a/runtime/Makefile.config
+++ b/runtime/Makefile.config
@@ -20,18 +20,37 @@
 #
 
 ifndef CHPL_MAKE_HOME
-export CHPL_MAKE_HOME=$(realpath $(shell pwd)/../..)
+export CHPL_MAKE_HOME=$(realpath $(shell pwd)/..)
 endif
 
 include $(CHPL_MAKE_HOME)/make/Makefile.base
 
 unexport CHPL_MAKE_SETTINGS_NO_NEWLINES
 
+# Set up variables representing paths that will be installed
+ifndef CHPL_MAKE_RUNTIME_LIB
+CHPL_MAKE_RUNTIME_LIB = $(CHPL_MAKE_HOME)/lib
+endif
+
+ifndef CHPL_MAKE_RUNTIME_INCL
+CHPL_MAKE_RUNTIME_INCL = $(CHPL_MAKE_HOME)/runtime/include
+endif
+
+ifndef CHPL_MAKE_THIRD_PARTY
+CHPL_MAKE_THIRD_PARTY = $(CHPL_MAKE_HOME)/third-party
+endif
+
+FIXPATH_CMD := $(CHPL_MAKE_HOME)/util/config/replace-paths.py \
+                  --fixpath '$$CHPL_RUNTIME_LIB' $(CHPL_MAKE_RUNTIME_LIB) \
+                  --fixpath '$$CHPL_RUNTIME_INCL' $(CHPL_MAKE_RUNTIME_INCL) \
+                  --fixpath '$$CHPL_THIRD_PARTY' $(CHPL_MAKE_THIRD_PARTY) \
+                  --fixpath '$$CHPL_HOME' $(CHPL_MAKE_HOME)
+
 printincludesanddefines: FORCE
-	@$(MAKE) --no-print-directory -f etc/Makefile.include printincludesanddefines
+	@$(MAKE) --no-print-directory -f etc/Makefile.include printincludesanddefines | $(FIXPATH_CMD)
 
 printlibraries: FORCE
-	@$(MAKE) --no-print-directory -f etc/Makefile.include printlibraries
+	@$(MAKE) --no-print-directory -f etc/Makefile.include printlibraries | $(FIXPATH_CMD)
 
 FORCE:
 

--- a/util/config/replace-paths.py
+++ b/util/config/replace-paths.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+
+import optparse
+import os
+import re
+import sys
+
+"""
+Normalizes path components to make them suitable for installation.
+For example, since $CHPL_HOME/lib will be installed to CHPL_RUNTIME_LIB,
+we replace references to that absolute path with $CHPL_RUNTIME_LIB.
+"""
+
+if __name__ == '__main__':
+
+  parser = optparse.OptionParser(usage='usage: %prog [--fixpath key path]')
+  parser.add_option('--fixpath', nargs=2, dest='fixpath', action='append');
+  
+  (options, args) = parser.parse_args()
+
+  if options.fixpath:
+
+    tofix=[]
+    for kv in options.fixpath:
+
+      key = kv[0]
+      val = kv[1];
+
+      val = os.path.realpath(val)
+      tofix.append([key, val])
+
+    #for kv in tofix:
+    #  key = kv[0]
+    #  val = kv[1];
+    #  sys.stdout.write("will replace {0} with {1}\n".format(val,key))
+
+    for line in sys.stdin.readlines():
+
+      # Find things that look like absolute paths
+      # Note that this needs to handle e.g. -I/some/directory
+      # (and not think it's a relative path starting with I)
+
+      pattern = r'/[^ ]+'
+
+      fixed = line
+
+      for m in re.findall(pattern, line):
+
+        origpath = m
+        path = os.path.realpath(origpath)
+        #sys.stdout.write("maybe found path {0} \n".format(path))
+
+        for kv in tofix:
+
+          key = kv[0]
+          val = kv[1];
+
+          #sys.stdout.write("does it start with {0}\n".format(val))
+          if path.startswith(val):
+            rel = os.path.relpath(path, val)
+            #sys.stdout.write("rel path to {0} is {1}\n".format(key, rel))
+            fixed = fixed.replace(origpath, key + "/" + rel)
+            break
+
+          #sys.stdout.write("replacing {0} {1}\n".format(val,key))
+          #sys.stdout.write(fixed)
+
+      sys.stdout.write(fixed)
+


### PR DESCRIPTION
PR #7757 started saving CC and LD flags in files to avoid a lot of
computation at chpl-time. But these flags contained some paths that
may not exist after installation. To fix, normalize these paths
to use e.g. $CHPL_HOME, and then expand them again in the compiler.

- [x] verified 'make install'd chpl works after source directory moved
- [x] full local --llvm testing

Reviewed by @dmk42 and @ronawho - thanks!