### PR TITLE
Norm new expr 2

### DIFF
--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -1093,6 +1093,13 @@ static void callConstructor(CallExpr* call) {
       if (isSymExpr(arg1->baseExpr) == true &&
           arg1->partialTag          == false) {
         fixPrimNew(call);
+
+      } else if (CallExpr* subCall = toCallExpr(arg1->baseExpr)) {
+        if (isSymExpr(subCall->baseExpr) == true) {
+          if (subCall->partialTag == true) {
+            fixPrimNew(call);
+          }
+        }
       }
     }
 
@@ -1115,8 +1122,7 @@ static void callConstructor(CallExpr* call) {
                parentParent->isPrimitive(PRIM_NEW) == true) {
       if (call->partialTag == true) {
         INT_ASSERT(parentParent->get(1) == parent);
-
-        fixPrimNew(parentParent);
+        //        fixPrimNew(parentParent);
 
       } else {
         INT_ASSERT(false);


### PR DESCRIPTION
Continue to refactor the normalization of calls to Constructors and to TypeConstructors

Before this PR, the function callConstructor() was used to normalize calls to
constructors (i.e. new expressions) and calls to type constructors.  The logic
for both cases was inter-twined in a confusing/obtuse way.

This PR consists of 4 trivial commits that converts this single function in to 2 predicates
and 2 procedures that separate the handling of new expressions from the invocation of
type constructors for class/records.

Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.
Limited testing for each configuration.

Full single-locale paratest with -futures on linux64
