### PR TITLE
Make aarch64 atomics the same as others

### DIFF
--- a/util/chplenv/chpl_atomics.py
+++ b/util/chplenv/chpl_atomics.py
@@ -32,14 +32,12 @@ def get(flag='target'):
             # support 64 bit atomics on 32 bit platforms and the cray compiler
             # will never run on a 32 bit machine. For pgi or 32 bit platforms
             # with an older gcc, we fall back to locks
-            if compiler_val in ['gnu', 'cray-prgenv-gnu', 'mpi-gnu']:
+            if compiler_val in ['gnu', 'cray-prgenv-gnu', 'mpi-gnu', 'aarch64-gnu']:
                 version = get_compiler_version('gnu')
                 if version >= CompVersion('4.8'):
                     atomics_val = 'intrinsics'
                 elif version >= CompVersion('4.1') and not platform_val.endswith('32'):
                     atomics_val = 'intrinsics'
-            elif compiler_val == 'aarch64-gnu':
-                atomics_val = 'cstdlib'
             elif compiler_val == 'intel' or compiler_val == 'cray-prgenv-intel':
                 atomics_val = 'intrinsics'
             elif compiler_val == 'cray-prgenv-cray':


### PR DESCRIPTION
This change gets rid of a special case and starts treating 64-bit ARM atomics the same as atomics in other environments.

In the early stages of the 64-bit ARM port, `CHPL_ATOMICS` was forced to `cstdlib` to accommodate a certain cross compiler.  However, that compiler ended up never being fully developed enough to compile Chapel.  The compilers that do work for 64-bit ARM are capable of the same atomics settings as everything else.
