### PR TITLE
Quiet --verify failure

### DIFF
--- a/test/users/thom/itoverride.chpl
+++ b/test/users/thom/itoverride.chpl
@@ -49,9 +49,7 @@ proc main()
   delete t1;
 
 
-  var m = o.manyC();
-  writeln("Many: ", m);
-  for obj in m do delete obj;
+  writeln("Many: ", o.manyC());
 
   delete o;
 }


### PR DESCRIPTION
Storing the result of 'manyC' in this way caused --verify to fail, so undo the change and leak again. I was unable to create a smaller reproducer, so reverting the change is easiest for now.