### PR TITLE
Prevent signed/unsigned comparison errors

### DIFF
--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -396,7 +396,7 @@ void EnumType::sizeAndNormalize() {
         if( v >= 0 ) uv = v;
         else uv = 1;
       } else if( get_uint( constant->init, &uv ) ) {
-        if (uv <= INT64_MAX) v = uv;
+        if (uv <= (uint64_t)INT64_MAX) v = uv;
         else v = 1;
       }
     } else {
@@ -436,7 +436,7 @@ void EnumType::sizeAndNormalize() {
 
   // User error if the enum contains both negative values and
   // something needing a uint64.
-  if (min_v < 0 && max_uv > INT64_MAX)
+  if (min_v < 0 && max_uv > (uint64_t)INT64_MAX)
     USR_FATAL(this,
               "this enum cannot be represented with a single integer type");
 
@@ -560,7 +560,7 @@ void EnumType::sizeAndNormalize() {
         if( v >= 0 ) uv = v;
         else have_uv = false;
       } else if( get_uint( constant->init, &uv ) ) {
-        if (uv <= INT64_MAX) v = uv;
+        if (uv <= (uint64_t)INT64_MAX) v = uv;
         else have_v = false;
       }
 


### PR DESCRIPTION
Some compilers will generate a warning for comparing signed and unsigned values, which we turn into an error with \-Werror.  In particular, we have seen this happen with gcc 4.7.  This change adds explicit casts to quiet the warnings introduced by #7659 .

Verified not to introduce any new errors into a full local test.