### PR TITLE
Fix typos

### DIFF
--- a/compiler/AST/foralls.cpp
+++ b/compiler/AST/foralls.cpp
@@ -280,7 +280,7 @@ bool astUnderFI(const Expr* ast, ForallIntents* fi) {
 /*
 When we are dealing with a recursive parallel iterator, we call
 fsIterYieldType() while resolving it. At that time, IteratorInfo
-has not been created yet. Also the yield type is not yet avaiable
+has not been created yet. Also the yield type is not yet available
 anywhere, because it is the type of a tuple of the original return type
 plus one component per shadow variable.
 

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -74,7 +74,7 @@ static void normalize(BaseAST* base);
 static void normalizeReturns(FnSymbol* fn);
 
 static bool isCallToConstructor(CallExpr* call);
-static void normalizeCallToConstructor(CallExpr* calll);
+static void normalizeCallToConstructor(CallExpr* call);
 
 static bool isCallToTypeConstructor(CallExpr* call);
 static void normalizeCallToTypeConstructor(CallExpr* call);
@@ -2727,7 +2727,7 @@ static void cloneParameterizedPrimitive(FnSymbol* fn,
 *       allowable values of 'w', and then deletes the original AST.           *
 *       Hence these functions are never observed by the following code.       *
 *                                                                             *
-*   NB: This code does not handle the count for varadic functions e.g.        *
+*   NB: This code does not handle the count for variadic functions e.g.       *
 *                                                                             *
 *       proc min(x, y, z...?k) ...                                            *
 *                                                                             *

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -1114,7 +1114,7 @@ static bool canParamCoerce(Type*   actualType,
     if (EnumType* etype = toEnumType(actualType)) {
       ensureEnumTypeResolved(etype);
 
-      // TODO: aren't these redundand with the last check?
+      // TODO: aren't these redundant with the last check?
       Type* enumIntType = etype->getIntegerType();
 
       if (enumIntType == formalType)
@@ -1239,7 +1239,7 @@ static bool canParamCoerce(Type*   actualType,
   if (is_real_type(formalType)) {
     int mantissa_width = get_mantissa_width(formalType);
 
-    // don't coerce bools to reals (per spec: "uninteded by programmer")
+    // don't coerce bools to reals (per spec: "unintended by programmer")
 
     // coerce any integer type to maximum width real
     if ((is_int_type(actualType) || is_uint_type(actualType))
@@ -1283,7 +1283,7 @@ static bool canParamCoerce(Type*   actualType,
   if (is_complex_type(formalType)) {
     int mantissa_width = get_mantissa_width(formalType);
 
-    // don't coerce bools to reals (per spec: "uninteded by programmer")
+    // don't coerce bools to complexes (per spec: "unintended by programmer")
 
     // coerce any integer type to maximum width complex
     if ((is_int_type(actualType) || is_uint_type(actualType)) &&

--- a/compiler/resolution/implementForallIntents2.cpp
+++ b/compiler/resolution/implementForallIntents2.cpp
@@ -203,7 +203,7 @@ public:
     return result;
   }
 
-  // constructor for the outermodst context
+  // constructor for the outermost context
   FIcontext(ForallStmt* fs, CallExpr* iterCall,
             FnSymbol* iterFn, VarSymbol* retSymbol) :
     forall(fs),
@@ -527,7 +527,7 @@ static void addArgsToToLeaderCallForPromotionWrapper(FIcontext& ctx) {
 }
 
 
-/////////// seting up for a reduce intent ///////////
+/////////// setting up for a reduce intent ///////////
 
 // As we extend the yield expression into a tuple with shadow variables,
 // we need to handle a reduce-intent variable specially by setting up

--- a/compiler/util/clangUtil.cpp
+++ b/compiler/util/clangUtil.cpp
@@ -1490,7 +1490,7 @@ void runClang(const char* just_parse_filename) {
     clangCC = llvm_install + "clang";
     clangCXX = llvm_install + "clang++";
   } else {
-    USR_FATAL("Unspported CHPL_LLVM setting %s", CHPL_LLVM);
+    USR_FATAL("Unsupported CHPL_LLVM setting %s", CHPL_LLVM);
   }
 
   // read clang-sysroot-arguments


### PR DESCRIPTION
Fix typos in clangUtil.cpp, implementForallIntents2.cpp, functionResolution.cpp, normalize.cpp, and foralls.cpp.