### PR TITLE
Adjusted .bad files for #7785

### DIFF
--- a/test/arrays/deitz/part1/test_array_arg7_auto.bad
+++ b/test/arrays/deitz/part1/test_array_arg7_auto.bad
@@ -1,1 +1,2 @@
 test_array_arg7_auto.chpl:16: syntax error: near '=>'
+test_array_arg7_auto.chpl:18: syntax error: near '=>'

--- a/test/arrays/deitz/part1/test_array_arg8_auto.bad
+++ b/test/arrays/deitz/part1/test_array_arg8_auto.bad
@@ -1,1 +1,4 @@
 test_array_arg8_auto.chpl:9: syntax error: near '=>'
+test_array_arg8_auto.chpl:10: syntax error: near '=>'
+test_array_arg8_auto.chpl:11: syntax error: near '=>'
+test_array_arg8_auto.chpl:12: syntax error: near '=>'

--- a/test/arrays/deitz/part1/test_array_arg9_auto.bad
+++ b/test/arrays/deitz/part1/test_array_arg9_auto.bad
@@ -1,1 +1,3 @@
 test_array_arg9_auto.chpl:14: syntax error: near '=>'
+test_array_arg9_auto.chpl:16: syntax error: near '=>'
+test_array_arg9_auto.chpl:18: syntax error: near '=>'

--- a/test/arrays/deitz/part3/test_slice_stride2_auto.bad
+++ b/test/arrays/deitz/part3/test_slice_stride2_auto.bad
@@ -1,1 +1,5 @@
 test_slice_stride2_auto.chpl:12: syntax error: near '=>'
+test_slice_stride2_auto.chpl:14: syntax error: near '=>'
+test_slice_stride2_auto.chpl:16: syntax error: near '=>'
+test_slice_stride2_auto.chpl:18: syntax error: near '=>'
+test_slice_stride2_auto.chpl:20: syntax error: near '=>'

--- a/test/arrays/deitz/part3/test_slice_stride3_auto.bad
+++ b/test/arrays/deitz/part3/test_slice_stride3_auto.bad
@@ -1,1 +1,5 @@
 test_slice_stride3_auto.chpl:15: syntax error: near '=>'
+test_slice_stride3_auto.chpl:17: syntax error: near '=>'
+test_slice_stride3_auto.chpl:19: syntax error: near '=>'
+test_slice_stride3_auto.chpl:21: syntax error: near '=>'
+test_slice_stride3_auto.chpl:23: syntax error: near '=>'

--- a/test/arrays/deitz/part3/test_slice_stride4_auto.bad
+++ b/test/arrays/deitz/part3/test_slice_stride4_auto.bad
@@ -1,1 +1,2 @@
 test_slice_stride4_auto.chpl:3: syntax error: near '=>'
+test_slice_stride4_auto.chpl:7: syntax error: near '=>'

--- a/test/chpldoc/nodoc/privateClasses.doc.bad
+++ b/test/chpldoc/nodoc/privateClasses.doc.bad
@@ -1,2 +1,5 @@
 privateClasses.doc.chpl:1: syntax error: near 'class'
+privateClasses.doc.chpl:4: syntax error: near '}'
+privateClasses.doc.chpl:10: syntax error: near '}'
+privateClasses.doc.chpl:22: syntax error: near '}'
 cat: docs/source/modules/privateClasses.rst: No such file or directory

--- a/test/chpldoc/nodoc/privateTypeAlias.doc.bad
+++ b/test/chpldoc/nodoc/privateTypeAlias.doc.bad
@@ -1,2 +1,4 @@
 privateTypeAlias.doc.chpl:2: syntax error: near 'type'
+privateTypeAlias.doc.chpl:5: syntax error: near 'type'
+privateTypeAlias.doc.chpl:8: syntax error: near 'type'
 cat: docs/source/modules/privateTypeAlias.rst: No such file or directory

--- a/test/domains/sungeun/rect/at_operator.bad
+++ b/test/domains/sungeun/rect/at_operator.bad
@@ -1,1 +1,4 @@
 at_operator.chpl:6: Invalid token: near '@'
+at_operator.chpl:6: syntax error: near 'n'
+at_operator.chpl:8: Invalid token: near '@'
+at_operator.chpl:8: syntax error: near 'n'

--- a/test/expressions/vass/tuple-from-param-loop.bad
+++ b/test/expressions/vass/tuple-from-param-loop.bad
@@ -1,1 +1,6 @@
 tuple-from-param-loop.chpl:3: syntax error: near 'param'
+tuple-from-param-loop.chpl:4: syntax error: near 'param'
+tuple-from-param-loop.chpl:6: syntax error: near 'param'
+tuple-from-param-loop.chpl:7: syntax error: near 'param'
+tuple-from-param-loop.chpl:9: syntax error: near 'param'
+tuple-from-param-loop.chpl:10: syntax error: near 'param'

--- a/test/statements/vass/index-variable-var.bad
+++ b/test/statements/vass/index-variable-var.bad
@@ -1,1 +1,2 @@
 index-variable-var.chpl:9: syntax error: near 'var'
+index-variable-var.chpl:14: syntax error: near '}'

--- a/test/studies/shootout/fannkuch-redux/bradc/fannkuch-redux-blc-unbounded.bad
+++ b/test/studies/shootout/fannkuch-redux/bradc/fannkuch-redux-blc-unbounded.bad
@@ -1,1 +1,2 @@
 fannkuch-redux-blc-unbounded.chpl:67: syntax error: near 'var'
+fannkuch-redux-blc-unbounded.chpl:78: syntax error: near '}'

--- a/test/studies/shootout/spectral-norm/bradc/spectralnorm-partred.bad
+++ b/test/studies/shootout/spectral-norm/bradc/spectralnorm-partred.bad
@@ -1,1 +1,2 @@
 spectralnorm-partred.chpl:37: syntax error: near '='
+spectralnorm-partred.chpl:45: syntax error: near '='


### PR DESCRIPTION
With #7785, the compiler is now capable of reporting multiple syntax errors in a single run.

This PR adjusts the .bad files that are affected by this change because they contain multiple syntax errors according to the currently-implemented syntax.
