### PR TITLE
Added a .skipif

### DIFF
--- a/test/types/coerce/ferguson/coercion-dispatch-minimal-modules.skipif
+++ b/test/types/coerce/ferguson/coercion-dispatch-minimal-modules.skipif
@@ -1,0 +1,2 @@
+CHPL_COMM != none
+COMPOPTS <= --no-local


### PR DESCRIPTION
The test `coercion-dispatch-minimal-modules` crashes the compiler in --no-local mode.

This is a shortcoming of the --minimal-modules mode (which this test uses), rather than of the test of the compiler. See below for details.

Therefore, skipif this test for --no-local.

Details: the test reaches the pass insertWideReferences in the compiler. There, it references `dtLocaleID`, which is not set in --minimal-modules mode. So IMO we simply should not be running this test under --no-local.
