### PR TITLE
Fix installed paths saved in CLANG_SETTINGS

### DIFF
--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -103,6 +103,16 @@ EXECS = $(CHPL) $(CHPLDOC) $(CHPLIPE)
 PRETARGETS = $(BUILD_VERSION_FILE) $(CONFIGURED_PREFIX_FILE) llvm $(CLANG_SETTINGS_FILE)
 TARGETS = $(CHPL)
 
+# Set up variables representing paths that will be installed
+# and how to fix them (for CLANG_SETTINGS).
+# So far, this only needs to fix CHPL_THIRD_PARTY/CHPL_HOME.
+ifndef CHPL_MAKE_THIRD_PARTY
+CHPL_MAKE_THIRD_PARTY = $(CHPL_MAKE_HOME)/third-party
+endif
+
+FIXPATH_CMD := $(CHPL_MAKE_HOME)/util/config/replace-paths.py \
+                  --fixpath '$$CHPL_THIRD_PARTY' $(CHPL_MAKE_THIRD_PARTY) \
+                  --fixpath '$$CHPL_HOME' $(CHPL_MAKE_HOME)
 
 #
 # main rules
@@ -133,7 +143,7 @@ $(CONFIGURED_PREFIX_FILE): $(CHPL_MAKE_HOME)/configured-prefix
 	echo '"'`cat $(CHPL_MAKE_HOME)/configured-prefix`'"' \ > $(CONFIGURED_PREFIX_FILE)
 
 $(CLANG_SETTINGS_FILE):
-	echo '{"'$(CLANG_CC)'","'$(CLANG_CXX)'","'`$(CHPL_MAKE_HOME)/util/config/gather-clang-sysroot-arguments $(CLANG_CC)`'"}' > $(CLANG_SETTINGS_FILE)
+	echo '{"'$(CLANG_CC)'","'$(CLANG_CXX)'","'`$(CHPL_MAKE_HOME)/util/config/gather-clang-sysroot-arguments $(CLANG_CC)`'"}' | $(FIXPATH_CMD) > $(CLANG_SETTINGS_FILE)
 
 $(CHPL_CONFIG_CHECK): | $(CHPL_BIN_DIR)
 	rm -rf $(CHPL_CONFIG_CHECK_PREFIX)

--- a/compiler/include/files.h
+++ b/compiler/include/files.h
@@ -94,6 +94,7 @@ const char* getIntermediateDirName();
 
 void readArgsFromCommand(std::string path, std::vector<std::string>& args);
 void readArgsFromFile(std::string path, std::vector<std::string>& cmds);
+void expandInstallationPaths(std::string& arg);
 void expandInstallationPaths(std::vector<std::string>& args);
 
 char*       dirHasFile(const char* dir, const char* file);

--- a/compiler/include/version.h
+++ b/compiler/include/version.h
@@ -20,12 +20,14 @@
 #ifndef _VERSION_H_
 #define _VERSION_H_
 
+#include <string>
+
 void get_version(char * buf);
 void get_major_minor_version(char * buf);
 const char* get_configured_prefix();
 
-const char* get_clang_cc();
-const char* get_clang_cxx();
-const char* get_clang_sysroot_args();
+std::string get_clang_cc();
+std::string get_clang_cxx();
+std::string get_clang_sysroot_args();
 
 #endif

--- a/compiler/main/version.cpp
+++ b/compiler/main/version.cpp
@@ -19,6 +19,7 @@
 
 #include <cstdio>
 #include "driver.h"
+#include "files.h"
 #include "version.h"
 
 // this include sets BUILD_VERSION
@@ -47,17 +48,23 @@ get_configured_prefix() {
   return CONFIGURED_PREFIX;
 }
 
-const char*
+std::string
 get_clang_cc() {
-  return CLANG_SETTINGS[0];
+  std::string ret = CLANG_SETTINGS[0];
+  expandInstallationPaths(ret);
+  return ret;
 }
 
-const char*
+std::string
 get_clang_cxx() {
-  return CLANG_SETTINGS[1];
+  std::string ret = CLANG_SETTINGS[1];
+  expandInstallationPaths(ret);
+  return ret;
 }
 
-const char*
+std::string
 get_clang_sysroot_args() {
-  return CLANG_SETTINGS[2];
+  std::string ret = CLANG_SETTINGS[2];
+  expandInstallationPaths(ret);
+  return ret;
 }

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -802,35 +802,38 @@ void readArgsFromFile(std::string path, std::vector<std::string>& args) {
   fclose(fd);
 }
 
-void expandInstallationPaths(std::vector<std::string>& args) {
-
+// Explands variables like $CHPL_HOME in the string
+void expandInstallationPaths(std::string& s) {
   const char* tofix[] = {"$CHPL_RUNTIME_LIB", CHPL_RUNTIME_LIB,
                          "$CHPL_RUNTIME_INCL", CHPL_RUNTIME_INCL,
                          "$CHPL_THIRD_PARTY", CHPL_THIRD_PARTY,
                          "$CHPL_HOME", CHPL_HOME,
                          NULL};
 
+  // For each of the patterns in tofix, find/replace all occurrences.
+  for (int j = 0; tofix[j] != NULL; j += 2) {
+
+    const char* key = tofix[j];
+    const char* val = tofix[j+1];
+    size_t key_len = strlen(key);
+    size_t val_len = strlen(val);
+
+    size_t off = 0;
+    while (true) {
+      off = s.find(key, off);
+      if (off == std::string::npos)
+        break; // no more occurrences to replace
+      s.replace(off, key_len, val);
+      off += val_len;
+    }
+  }
+}
+
+void expandInstallationPaths(std::vector<std::string>& args) {
+
   for (size_t i = 0; i < args.size(); i++) {
     std::string s = args[i];
-
-    // For each of the patterns in tofix, find/replace all occurrences.
-    for (int j = 0; tofix[j] != NULL; j += 2) {
-
-      const char* key = tofix[j];
-      const char* val = tofix[j+1];
-      size_t key_len = strlen(key);
-      size_t val_len = strlen(val);
-
-      size_t off = 0;
-      while (true) {
-        off = s.find(key, off);
-        if (off == std::string::npos)
-          break; // no more occurrences to replace
-        s.replace(off, key_len, val);
-        off += val_len;
-      }
-    }
-
+    expandInstallationPaths(s);
     args[i] = s;
   }
 }

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -802,7 +802,7 @@ void readArgsFromFile(std::string path, std::vector<std::string>& args) {
   fclose(fd);
 }
 
-// Explands variables like $CHPL_HOME in the string
+// Expands variables like $CHPL_HOME in the string
 void expandInstallationPaths(std::string& s) {
   const char* tofix[] = {"$CHPL_RUNTIME_LIB", CHPL_RUNTIME_LIB,
                          "$CHPL_RUNTIME_INCL", CHPL_RUNTIME_INCL,


### PR DESCRIPTION
Continuing PR #7801, this PR adjusts paths within CHPL_HOME saved in CLANG_SETTINGS to be stored relative to CHPL_HOME.

- [x]  full local testing
- [x] full local --llvm testing

Reviewed by @dmk42 - thanks!