### PR TITLE
Fix filelock import on cle6 machines

### DIFF
--- a/util/test/execution_limiter.py
+++ b/util/test/execution_limiter.py
@@ -5,8 +5,11 @@ import getpass
 import os
 import tempfile
 
-import activate_chpl_test_venv
-import filelock
+try:
+    import activate_chpl_test_venv
+    import filelock
+except ImportError:
+    pass
 
 class NoLock():
     """ Empty class that can be used with a context manager. Does not limit how

--- a/util/test/execution_limiter.py
+++ b/util/test/execution_limiter.py
@@ -4,6 +4,8 @@ running chpl executables """
 import getpass
 import os
 import tempfile
+
+import activate_chpl_test_venv
 import filelock
 
 class NoLock():


### PR DESCRIPTION
sub_test/execution_limiter are run as a subprocess of start_test. Depending on
the level of support subprocess32 was built with, subprocesses may or may not
inherit the venv activated in start_test, so to be safe re-activate it in the
execution_limiter before importing filelock.

Our module gets built on a cle5 machine and builds a python 2.6 venv with the
system python and a python 2.7 venv with a custom installed python. Something
about this causes the 2.7 subprocesses32 to not have its full functionality and
as a result spawned processes don't inherit the venv (at least that's my best
guess as to what's going on.)
