### PR TITLE
Update skipif for minimal modules test

### DIFF
--- a/test/types/coerce/ferguson/coercion-dispatch-minimal-modules.skipif
+++ b/test/types/coerce/ferguson/coercion-dispatch-minimal-modules.skipif
@@ -1,2 +1,6 @@
+# Several configurations aren't working with minimal modules...
+COMPOPTS <= --baseline
 CHPL_COMM != none
 COMPOPTS <= --no-local
+CHPL_LOCALE_MODEL != flat
+EXECOPTS <= memLeaksLog


### PR DESCRIPTION
Continuing #7812, skipif for more configurations for this minimal modules test. I made the skipif skip the same configurations as test/compflags/bradc/minimalModules. Minimal modules just doesn't work in all of these configurations.

A reasonable alternative would be to change this test to no longer use minimal modules.