### PR TITLE
Moves + renames after #7738

### DIFF
--- a/compiler/AST/AstDumpToNode.cpp
+++ b/compiler/AST/AstDumpToNode.cpp
@@ -407,7 +407,7 @@ bool AstDumpToNode::enterForallStmt(ForallStmt* node)
 
   writeField("inductionVariables:  ", node->inductionVariables());
   writeField("iteratedExpressions: ", node->iteratedExpressions());
-  writeField("intentVariables:     ", node->intentVariables());
+  writeField("shadowVariables:     ", node->shadowVariables());
 
   newline();
   writeField("loopBody: ", 10, node->loopBody());

--- a/compiler/AST/flags.cpp
+++ b/compiler/AST/flags.cpp
@@ -108,6 +108,9 @@ static void viewSymbolFlags(Symbol* sym) {
           fprint_imm(stdout, *toVarSymbol(sym)->immediate, true);
           printf("\n");
         }
+        if (ShadowVarSymbol* svar = toShadowVarSymbol(vs)) {
+          printf("%s shadow var  ", svar->intentDescrString());
+        }
         printf("qual %s\n", qualifierToStr(vs->qual));
 
       } else if (ArgSymbol* as = toArgSymbol(sym)) {

--- a/compiler/AST/foralls.cpp
+++ b/compiler/AST/foralls.cpp
@@ -250,7 +250,7 @@ bool astUnderFI(const Expr* ast, ForallIntents* fi) {
 //                             //
 /////////////////////////////////
 
-// resolveParallelIteratorAndForallIntents() resolves key parts of ForallStmt:
+// resolveForallHeader() resolves key parts of ForallStmt:
 //
 //  * find the target parallel iterator (standalone or leader) and resolve it
 //  * issue an error, if neither is found
@@ -290,7 +290,7 @@ Ex. standalone iter walkdirs() in FileSystem module, as tested by:
 Therefore we compute this extended yield type manually.
 */
 static QualifiedType buildIterYieldType(ForallStmt* fs, FnSymbol* iterFn) {
-  if (fs->numIntentVars() == 0) {
+  if (fs->numShadowVars() == 0) {
     // The iterator has not undergone extendLeader().
     // It still yields whatever the user wrote.
     // Its return symbol is still in tact.
@@ -785,7 +785,7 @@ static void buildLeaderLoopBody(ForallStmt* pfs, Expr* iterExpr) {
 }
 
 // see also comments above
-CallExpr* resolveParallelIteratorAndForallIntents(ForallStmt* pfs, SymExpr* origSE)
+CallExpr* resolveForallHeader(ForallStmt* pfs, SymExpr* origSE)
 {
   CallExpr* retval = NULL;
 
@@ -898,8 +898,8 @@ void lowerForallStmts() {
     while (Expr* def = fs->inductionVariables().tail)
       userBody->insertAtHead(def->remove());
 
-    while (Expr* ivdef = fs->intentVariables().tail)
-      fs->loopBody()->insertAtHead(ivdef->remove());
+    while (Expr* svdef = fs->shadowVariables().tail)
+      fs->loopBody()->insertAtHead(svdef->remove());
 
     userBody->flattenAndRemove();          // into fs->loopBody()
     PARBody->insertAtTail(fs->loopBody()); // loopBody is already resolved

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -966,10 +966,10 @@ void ShadowVarSymbol::verify() {
     INT_FATAL(this, "ShadowVarSymbol::type is NULL");
   verifyNotOnList(specBlock);
   if (!resolved) {
-    // Verify that this symbol is on a ForallStmt::intentVariables() list.
+    // Verify that this symbol is on a ForallStmt::shadowVariables() list.
     ForallStmt* pfs = toForallStmt(defPoint->parentExpr);
     INT_ASSERT(pfs);
-    INT_ASSERT(defPoint->list == &(pfs->intentVariables()));
+    INT_ASSERT(defPoint->list == &(pfs->shadowVariables()));
   }
   INT_ASSERT(isReduce() == (intent == TFI_REDUCE));
   if (!iteratorsLowered && specBlock != NULL)

--- a/compiler/AST/view.cpp
+++ b/compiler/AST/view.cpp
@@ -135,7 +135,7 @@ list_ast(BaseAST* ast, BaseAST* parentAst = NULL, int indent = 0) {
       if (expr == pfs->loopBody()) {
         printf("\n%6c", ' ');
         for (int i = 0; i < indent; i++) printf(" ");
-        if (pfs->numIntentVars() == 0)
+        if (pfs->numShadowVars() == 0)
           printf("with() ");
         printf("do\n");
         indent -= 2;
@@ -272,7 +272,7 @@ list_ast(BaseAST* ast, BaseAST* parentAst = NULL, int indent = 0) {
         for (int i = 0; i < indent; i++) printf(" ");
         printf("in%s", pfs->zippered() ? " zip" : "");
       } else if (expr == pfs->iteratedExpressions().tail &&
-                 pfs->numIntentVars() > 0)
+                 pfs->numShadowVars() > 0)
       {
         printf("\n      ");
         for (int i = 0; i < indent; i++) printf(" ");

--- a/compiler/include/ForallStmt.h
+++ b/compiler/include/ForallStmt.h
@@ -33,7 +33,7 @@ public:
   bool       zippered()       const; // was 'zip' keyword used?
   AList&     inductionVariables();   // DefExprs, one per iterated expr
   AList&     iteratedExpressions();  // SymExprs, one per iterated expr
-  AList&     intentVariables();      // DefExprs of LoopIntentVars
+  AList&     shadowVariables();      // DefExprs of ShadowVarSymbols
   BlockStmt* loopBody()       const; // the body of the forall loop
 
   // when originating from a ForLoop
@@ -63,14 +63,14 @@ public:
   int   numIteratedExprs()         const;
   bool  isIteratedExpression(Expr* expr);
   int   reduceIntentIdx(Symbol* var);
-  int   numIntentVars()            const;
-  ShadowVarSymbol* getForallIntent(int index); //todo rename
+  int   numShadowVars()            const;
+  ShadowVarSymbol* getShadowVar(int index) const;
 
 private:
   bool           fZippered;
   AList          fIterVars;
   AList          fIterExprs;
-  AList          fIntentVars;  // may be empty
+  AList          fShadowVars;  // may be empty
   BlockStmt*     fLoopBody;    // always present
   bool           fFromForLoop; // see comment below
 
@@ -95,7 +95,7 @@ set membership is propagated through cloning, if applicable.
 inline bool   ForallStmt::zippered()       const { return fZippered;   }
 inline AList& ForallStmt::inductionVariables()   { return fIterVars;   }
 inline AList& ForallStmt::iteratedExpressions()  { return fIterExprs;  }
-inline AList& ForallStmt::intentVariables()      { return fIntentVars; }
+inline AList& ForallStmt::shadowVariables()      { return fShadowVars; }
 inline BlockStmt* ForallStmt::loopBody()   const { return fLoopBody;   }
 inline bool ForallStmt::iterCallAlreadyTagged() const { return fFromForLoop; }
 inline bool ForallStmt::needToHandleOuterVars() const { return !fFromForLoop; }
@@ -104,16 +104,16 @@ inline bool ForallStmt::createdFromForLoop()    const { return fFromForLoop; }
 // conveniences
 inline Expr* ForallStmt::firstIteratedExpr() const { return fIterExprs.head;  }
 inline int   ForallStmt::numIteratedExprs()  const { return fIterExprs.length;}
-inline int   ForallStmt::numIntentVars()     const { return fIntentVars.length;}
-inline ShadowVarSymbol* ForallStmt::getForallIntent(int index)
-  { return toShadowVarSymbol(toDefExpr(fIntentVars.get(index))->sym); }
+inline int   ForallStmt::numShadowVars()     const { return fShadowVars.length;}
+inline ShadowVarSymbol* ForallStmt::getShadowVar(int index) const
+  { return toShadowVarSymbol(toDefExpr(fShadowVars.get(index))->sym); }
 
 #define for_shadow_var_defs(SVD,TEMP,FS)    \
-  for_alist(TEMP,(FS)->intentVariables())   \
+  for_alist(TEMP,(FS)->shadowVariables())   \
     if (DefExpr* SVD = toDefExpr(TEMP))
 
 #define for_shadow_vars(SV,TEMP,FS)                    \
-  for_alist(TEMP,(FS)->intentVariables())              \
+  for_alist(TEMP,(FS)->shadowVariables())              \
     if (DefExpr* SVD = toDefExpr(TEMP))                \
       if (ShadowVarSymbol* SV = toShadowVarSymbol(SVD->sym))
 

--- a/compiler/include/baseAST.h
+++ b/compiler/include/baseAST.h
@@ -639,7 +639,7 @@ static inline const CallExpr* toConstCallExpr(const BaseAST* a)
   case E_ForallStmt:                                                          \
     AST_CALL_LIST (_a, ForallStmt, inductionVariables(),  call, __VA_ARGS__); \
     AST_CALL_LIST (_a, ForallStmt, iteratedExpressions(), call, __VA_ARGS__); \
-    AST_CALL_LIST (_a, ForallStmt, intentVariables(),     call, __VA_ARGS__); \
+    AST_CALL_LIST (_a, ForallStmt, shadowVariables(),     call, __VA_ARGS__); \
     AST_CALL_CHILD(_a, ForallStmt, loopBody(),            call, __VA_ARGS__); \
     break;                                                                    \
   case E_ModuleSymbol:                                                  \

--- a/compiler/include/foralls.h
+++ b/compiler/include/foralls.h
@@ -27,7 +27,7 @@
 
 //
 // ForallIntents: with clause/forall intents
-// TODO: replace with LoopIntentVars / ForallStmt::intentVariables
+// TODO: replace with ShadowVarSymbols / ForallStmt::shadowVariables
 //
 class ForallIntents {
 public:

--- a/compiler/include/implementForallIntents.h
+++ b/compiler/include/implementForallIntents.h
@@ -46,13 +46,9 @@ void      addArgsToToLeaderCallForPromotionWrapper(FnSymbol* fn,
 VarSymbol* localizeYieldForExtendLeader(Expr* origRetExpr, Expr* ref);
 void       checkAndRemoveOrigRetSym(Symbol* origRet, FnSymbol* parentFn);
 FnSymbol*  copyLeaderFn(FnSymbol* origFn, bool ignore_isResolved);
-void       printIFI2cache();
-void       IFI2cacheAdd(ForallStmt* fs, FnSymbol* origIter,
-                        FnSymbol* extdIter);
-bool       redirectedToIfi2Cache(ForallStmt* fs, FnSymbol* origIter,
-                                 CallExpr* iterCall);
 
-void extendLeaderNew(ForallStmt* fs, FnSymbol* origIterFn, CallExpr* iterCall);
+void implementForallIntents2New(ForallStmt* fs, CallExpr* parCall);
+void printIFI2cache();
 
 static const char* intentArgName(int ix, const char* base) {
   return astr("_x", istr(ix+1), "_", base);

--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -109,20 +109,12 @@ FnSymbol* getTheIteratorFn(CallExpr* call);
 FnSymbol* getTheIteratorFn(Type* icType);
 
 // forall intents
-CallExpr* resolveParallelIteratorAndForallIntents(ForallStmt* pfs,
-                                                  SymExpr*    origSE);
-
+CallExpr* resolveForallHeader(ForallStmt* pfs, SymExpr* origSE);
 void implementForallIntents1(DefExpr* defChplIter);
-
 void implementForallIntents2(CallExpr* call, CallExpr* origToLeaderCall);
-
-void implementForallIntents2wrapper(CallExpr* call,
-                                    CallExpr* origToLeaderCall);
-
+void implementForallIntents2wrapper(CallExpr* call, CallExpr* origToLeaderCall);
 void implementForallIntentsNew(ForallStmt* fs, CallExpr* parCall);
-
-void stashPristineCopyOfLeaderIter(FnSymbol* origLeader,
-                                   bool      ignoreIsResolved);
+void stashPristineCopyOfLeaderIter(FnSymbol* origLeader, bool ignoreIsResolved);
 
 // reduce intents
 void cleanupRedRefs(Expr*& redRef1, Expr*& redRef2);

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -557,8 +557,6 @@ public:
   void                       codegenPrototype();
   void                       codegenDef();
 
-  void                       printDef(FILE* outfile);
-
   void                       insertAtHead(Expr* ast);
   void                       insertAtHead(const char* format, ...);
 

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -6601,7 +6601,7 @@ static Expr* resolveExpr(Expr* expr) {
     makeRefType(se->symbol()->type);
 
     if (ForallStmt* pfs = toForallForIteratedExpr(se)) {
-      CallExpr* call = resolveParallelIteratorAndForallIntents(pfs, se);
+      CallExpr* call = resolveForallHeader(pfs, se);
 
       if (tryFailure == false) {
         retval = resolveExprPhase2(expr, fn, preFold(call));

--- a/compiler/resolution/implementForallIntents.cpp
+++ b/compiler/resolution/implementForallIntents.cpp
@@ -1187,7 +1187,7 @@ static Symbol* createShadowVarIfNeeded(ShadowVarSymbol *shadowvar,
   // The new shadow variable for 'svar' at 'efs'.
   ShadowVarSymbol* result = new ShadowVarSymbol(intent, svar->name, spec);
   result->outerVarRep = new SymExpr(svar);
-  efs->intentVariables().insertAtTail(new DefExpr(result));
+  efs->shadowVariables().insertAtTail(new DefExpr(result));
 
   return result;
 }
@@ -1952,12 +1952,12 @@ static bool isFsIndexVar(ForallStmt* fs, Symbol* sym)
   return sym->defPoint->list == &fs->inductionVariables();
 }
 
-static bool isFsIntentVar(ForallStmt* fs, Symbol* sym)
+static bool isFsShadowVar(ForallStmt* fs, Symbol* sym)
 {
   if (!isShadowVarSymbol(sym))
     return false;
 
-  return sym->defPoint->list == &fs->intentVariables();
+  return sym->defPoint->list == &fs->shadowVariables();
 }
 
 //
@@ -1981,7 +1981,7 @@ static void findOuterVarsNew(ForallStmt* fs, SymbolMap& outer2shadow,
         !sym->hasFlag(FLAG_TYPE_VARIABLE)      && // not a type alias or formal
         !sym->hasFlag(FLAG_TEMP)     && // not a temp
         !isFsIndexVar(fs, sym)       && // not fs's index var
-        !isFsIntentVar(fs, sym)      && // not fs's intent var
+        !isFsShadowVar(fs, sym)      && // not fs's intent var
         !sym->hasFlag(FLAG_ARG_THIS) && // todo: no special case for 'this'
         isOuterVarNew(sym, block)       // it must be an outer variable
     ) {
@@ -2164,10 +2164,10 @@ static void getOuterVarsNew(ForallStmt* fs, SymbolMap& outer2shadow,
       handleRISpec(fs, sv);
 }
 
-// Append the new ShadowVarSymbols we accumulated to fs->intentVariables().
+// Append the new ShadowVarSymbols we accumulated to fs->shadowVariables().
 static void appendNewShadowVars(ForallStmt* fs, SymbolMap& outer2shadow) {
   form_Map(SymbolMapElem, elem, outer2shadow)
-    fs->intentVariables().insertAtTail(new DefExpr(elem->value));
+    fs->shadowVariables().insertAtTail(new DefExpr(elem->value));
 }
 
 // Not to be invoked upon a reduce intent.
@@ -2246,7 +2246,7 @@ static void processShadowVarsNew(ForallStmt* fs, BlockStmt* body, int& numShadow
       }
 
       if (pruneit) {
-        // Todo: remove it from fs->intentVariables() right away.
+        // Todo: remove it from fs->shadowVariables() right away.
         svar->pruneit = true;
         continue; // for_shadow_vars
       }
@@ -2265,11 +2265,11 @@ static void processShadowVarsNew(ForallStmt* fs, BlockStmt* body, int& numShadow
 //
 // Ideally, we won't prune, so won't need to do this.
 //
-static void pruneIntentVars(ForallStmt* fs, BlockStmt* body,
+static void pruneShadowVars(ForallStmt* fs, BlockStmt* body,
                             SymbolMap& outer2shadow, int numInitialVars,
                             int numShadowVars, bool& needToReplace)
 {
-  INT_ASSERT(fs->numIntentVars() > numShadowVars); // can be ==; shouldn't be <
+  INT_ASSERT(fs->numShadowVars() > numShadowVars); // can be ==; shouldn't be <
 
   // There are two pieces to undo-ing a given shadow variable:
   //  (a) replace its references within the loop 'body' with its outer variable,
@@ -2278,14 +2278,14 @@ static void pruneIntentVars(ForallStmt* fs, BlockStmt* body,
   // For (a): given that we have not yet performed the outer-to-shadow
   // conversion within the loop body for the variables in 'outer2shadow',
   // no need to undo them there. So we look only at the initial variables
-  // in fs->intentVariables() before 'outer2shadow' kicked in.
+  // in fs->shadowVariables() before 'outer2shadow' kicked in.
   //
   // While there, we keep track of whether there is anything un-pruned left
   // in outer2shadow using numToReplace.
 
   int idx = 0;
   bool needToRevert = false;
-  int  numToReplace = fs->numIntentVars() - numInitialVars;
+  int  numToReplace = fs->numShadowVars() - numInitialVars;
 
   for_shadow_var_defs(svd, temp, fs) {
     ++idx;
@@ -2448,9 +2448,9 @@ static void implementForallIntents1New(ForallStmt* fs, CallExpr* parCall) {
 
   getOuterVarsNew(fs, outer2shadow, forallBody1);
 
-  // At this point, fs->intentVariables() and outer2shadow are disjoint sets.
+  // At this point, fs->shadowVariables() and outer2shadow are disjoint sets.
   //
-  // (A) fs->intentVariables() correspond to the explicit intents
+  // (A) fs->shadowVariables() correspond to the explicit intents
   // in the with-clause. The occurrences of those variables in the loop body
   // scopeResolve to the corresponding ShadowVarSymbols. getOuterVarsNew()
   // does not perceive them as "outer".
@@ -2461,34 +2461,33 @@ static void implementForallIntents1New(ForallStmt* fs, CallExpr* parCall) {
   // appendNewShadowVars() adds the (B) vars to the (A) set.
   // 'outer2shadow' stays unchanged.
   // Save the size of (A) before the addition.
-  int numInitialVars = (fs->intentVariables()).length;
+  int numInitialVars = (fs->shadowVariables()).length;
   appendNewShadowVars(fs, outer2shadow);
 
   processShadowVarsNew(fs, forallBody1, numShadowVars); // updates numShadowVars
 
-  if (fs->numIntentVars() == numShadowVars)
+  if (fs->numShadowVars() == numShadowVars)
     needToReplace = (outer2shadow.n > 0);
   else
-    pruneIntentVars(fs, forallBody1, outer2shadow, numInitialVars,
+    pruneShadowVars(fs, forallBody1, outer2shadow, numInitialVars,
                     numShadowVars, needToReplace); // updates needToReplace
 
-  if (fs->numIntentVars() == 0)
+  if (fs->numShadowVars() == 0)
   {
     addParIdxCopy(fs);
   }
   else
   {
     addActualsToParCallNew(fs, parCall);
-    detupleLeadIdxNew(fs, fs->numIntentVars());
+    detupleLeadIdxNew(fs, fs->numShadowVars());
     if (needToReplace)
       replaceVarUsesNew(forallBody1, outer2shadow);
   }
 }
 
 /////////////////////////////////////////////////////////////////////////////
-// top-level implementForallIntents2New
 
-static void implementForallIntents2New(ForallStmt* fs, CallExpr* parCall);
+// implementForallIntentsNew() -- based on "new" ForallStmt representation
 
 static void checkForNonIterator(CallExpr* parCall) {
   FnSymbol* dest = parCall->resolvedFunction();
@@ -2501,10 +2500,8 @@ static void checkForNonIterator(CallExpr* parCall) {
 }
 
 //
-// Performs both implementForallIntents1 and implementForallIntents2,
-// given the ForallStmt-based representation.
-//
-// parCall must have already been resolved.
+// Performs both implementForallIntents1 and implementForallIntents2.
+// 'parCall' must have already been resolved.
 //
 void implementForallIntentsNew(ForallStmt* fs, CallExpr* parCall)
 {
@@ -2514,149 +2511,6 @@ void implementForallIntentsNew(ForallStmt* fs, CallExpr* parCall)
 
   checkForNonIterator(parCall);
 
-  if (fs->numIntentVars() > 0)
+  if (fs->numShadowVars() > 0)
    implementForallIntents2New(fs, parCall);
-}
-
-/////////////////////////////////////////////////////////////////////////////
-// implementForallIntents2New and helpers
-//
-
-// extendLeaderNew() is in implementForallIntents2.cpp
-
-// todo move the rest of this file to that file, too
-
-static CallExpr* findForwardingCallAndUnresolve(FnSymbol* fDest) {
-  Symbol* retSym = fDest->getReturnSymbol();
-  retSym->type = dtUnknown;
-  SymExpr* retSE = retSym->getSingleDef();
-  // We need this. If we don't get it, is that a user error?
-  INT_ASSERT(retSE);
-
-  CallExpr* retMove = toCallExpr(retSE->parentExpr);
-  INT_ASSERT(retMove && retMove->isPrimitive(PRIM_MOVE));
-  Expr* retDef = retMove->get(2);
-
-  if (SymExpr* src = toSymExpr(retDef)) {
-    src->symbol()->type = dtUnknown;
-    SymExpr* srcSE = src->symbol()->getSingleDef();
-    INT_ASSERT(srcSE); // like retSE
-    CallExpr* srcMove = toCallExpr(srcSE->parentExpr);
-    INT_ASSERT(srcMove && srcMove->isPrimitive(PRIM_MOVE));
-    retDef = srcMove->get(2);
-  }
-
-  fDest->removeFlag(FLAG_RESOLVED);
-  CallExpr* fCall = toCallExpr(retDef);
-  // If we did not find it, is it user error or a new pattern?
-  INT_ASSERT(fCall);
-  return fCall;
-}
-
-static const char* newWrapperFormalName(int ix, Symbol* actual) {
-  if (!strcmp(actual->name, "chpl__reduceGlob"))
-    return intentArgName(ix, "reduceGlob");
-  else
-    return intentArgName(ix, actual->name);
-}
-    
-// "Wrap" throughout this function signifies either a wrapper,
-// ex. default wrapper, or an iterator forwarder.
-static void implementForallIntents2NewWrap(ForallStmt* fs, FnSymbol* dest,
-                                        CallExpr* parCall)
-{
-  int numExtraArgs = fs->numIntentVars();
-  if (numExtraArgs == 0)
-    // leave as-is
-    return;
-
-  FnSymbol* wDest = dest->copy();
-  wDest->addFlag(FLAG_INVISIBLE_FN);
-  wDest->instantiationPoint = getVisibilityBlock(parCall);
-  // Do we also need to update paramMap like in copyLeaderFn() ?
-  dest->defPoint->insertAfter(new DefExpr(wDest));
-  parCall->baseExpr->replace(new SymExpr(wDest));
-
-  // We cloned the wrapper 'dest' into 'wDest'.  wDest's call 'wCall'
-  // now invokes a clone of the iterator that 'dest' was invoking.
-  // The above code modifies both 'wCall' and the iterator that it invokes.
-  // Alas, 'wCall' inherits FLAG_RESOLVED and its return type from 'dest'
-  // and these are no longer appropriate due to these modifications.
-  //
-  // So 'wDest' will need to be resolved again.
-  // To make that happen, we un-resolve its relevant pieces.
-  //
-  CallExpr* wCall = findForwardingCallAndUnresolve(wDest);
-
-  // Extend wDest with formals to match parCall's actuals.
-  SymExpr* curArgSE = toSymExpr(
-    parCall->get(parCall->numActuals() - numExtraArgs + 1));
-  int ix = 0;
-
-  do {
-    Symbol*    curArg    = curArgSE->symbol();
-    IntentTag  fIntent   = concreteIntent(INTENT_BLANK, curArg->type);
-    const char* curName  = newWrapperFormalName(ix, curArg);
-    ArgSymbol* curFormal = new ArgSymbol(fIntent, curName, curArg->type);
-
-    curFormal->qual = curArg->qual;
-
-    if (curFormal->isRef() &&
-        curArg->isConstValWillNotChange())
-      curFormal->addFlag(FLAG_REF_TO_IMMUTABLE);
-
-    wCall->insertAtTail(curFormal);
-    wDest->insertFormalAtTail(curFormal);
-
-    curArgSE = toSymExpr(curArgSE->next);
-    ix++;
-  } while (curArgSE);
-
-  // Handle whatever wDest is wrapping or forwarding to.
-  implementForallIntents2New(fs, wCall);
-}
-  
-
-static void implementForallIntents2New(ForallStmt* fs, CallExpr* parCall)
-{
-  FnSymbol* dest = parCall->resolvedFunction();
-
-  if (redirectedToIfi2Cache(fs, dest, parCall))
-    // Cache hit. redirectedToIfi2Cache() adjusted AST as needed.
-    return;
-
-  // At the moment, 'dest' can be a wrapper and/or an iterator-forwarding
-  // procedure, ex. _array.these() or NPBRandomStream.iterate().
-
-  if (dest->hasFlag(FLAG_WRAPPER)) {
-    // a wrapper for either an iterator or an iterator forwarder
-    implementForallIntents2NewWrap(fs, dest, parCall);
-
-  } else if (!dest->isIterator()) {
-    // an "iterator forwarder" i.e. a 'proc' that returns an iterator
-
-    // The only way we know that it is an iterator forwarder is by checking
-    // its return type. For that, it needs to be resolved.
-    INT_ASSERT(dest->isResolved());
-
-    implementForallIntents2NewWrap(fs, dest, parCall);
-
-  } else {
-    // a call directly to an iterator
-
-    if (!(isLeaderIterator(dest) || isStandaloneIterator(dest))) {
-      // Todo: add our iterator calls to the call stack so the user
-      // can trace where this is coming from.
-      // (It would be useful in other cases as well.)
-      // Further, represent the forall statement itself on the stack, too.
-      USR_FATAL_CONT(fs, "iteration in the forall loop redirects to a non-parallel iterator");
-      USR_PRINT(dest, "the non-parallel iterator is defined here");
-      USR_STOP();
-    }
-
-    extendLeaderNew(fs, dest, parCall);
-  }
-
-  // Save the extended iterator for future lookups.
-  IFI2cacheAdd(fs, dest, parCall->resolvedFunction());
 }

--- a/compiler/resolution/implementForallIntents2.cpp
+++ b/compiler/resolution/implementForallIntents2.cpp
@@ -32,9 +32,6 @@ For a reduce intent, the global reduce op instance needs to be
 properly allocated, deallocated and connected to the corresponding
 user outer variable. This is the job of "Part 1".
 
-For now, implementForallIntents2New() and immediately-adjacent functions
-are in implementForallIntents.cpp, for historical reasons.
-
 Even though we don't have to, we keep "New" in function names for now, to
 distinguish them from the "old" implementation' in implementForallIntents.cpp.
 
@@ -198,7 +195,7 @@ public:
   bool inTaskFn()   const { return nested; }
 
   int  numShadowVars()   const {
-    int result = forall->numIntentVars();
+    int result = forall->numShadowVars();
     INT_ASSERT(result == (int)fiInfos.size());
     return result;
   }
@@ -214,7 +211,7 @@ public:
     anchorFn(curFn),
     anchor1(0), anchor2(0), anchor2orig(0), anchor2prev(0)
   {
-    fiInfos.resize(forall->numIntentVars());
+    fiInfos.resize(forall->numShadowVars());
   }
 
   // constructor for a nested context
@@ -227,7 +224,7 @@ public:
     anchorFn(curFn),
     anchor1(0), anchor2(0), anchor2orig(0), anchor2prev(0)
   {
-    int numSVars = forall->numIntentVars();
+    int numSVars = forall->numShadowVars();
     fiInfos.resize(numSVars);
     for (int ix = 0; ix < numSVars; ix++) {
       fiInfos[ix].svSymbol = parentCx.fiInfos[ix].svSymbol;
@@ -552,7 +549,7 @@ static void addArgsToToLeaderCallForPromotionWrapper(FIcontext& ctx) {
 // Exception 2: when the yield stmt is in a forall loop, we do not need
 // the shadow variable created from the current op (or parent op).
 // Instead the shadow variable we add to the yielded tuple is one
-// we add to the forall loop's intentVariables(). It will be handled
+// we add to the forall loop's shadowVariables(). It will be handled
 // according to the above scheme when this forall loop's parallel iterator
 // will be processed/extended.
 // The above scheme is still used for yields outside a forall loop, if any.
@@ -758,7 +755,7 @@ static Symbol* tupcomForYieldInForall(FIcontext& ctx, ForallStmt* efs, int ix)
 
   // Here is the new shadow variable.
   ShadowVarSymbol* esv = new ShadowVarSymbol(osv->intent, osv->name, NULL);
-  efs->intentVariables().insertAtTail(new DefExpr(esv));
+  efs->shadowVariables().insertAtTail(new DefExpr(esv));
 
   if (isReduce) {
     ensureCurrentReduceOpForReduceIntent(ctx, fii, ix);
@@ -1091,7 +1088,7 @@ typedef std::vector<IFI2cacheIntent> IFI2cacheAllIntents;
 
 static void IFI2cacheInitAI(IFI2cacheAllIntents& allIntents,
                             ForallStmt* fs) {
-    allIntents.resize(fs->numIntentVars());
+    allIntents.resize(fs->numShadowVars());
     INT_ASSERT(allIntents.size() > 0); // otherwise why extendLeader?
     int ix = 0;
     for_shadow_vars(svar, temp, fs) {
@@ -1159,7 +1156,8 @@ static int ifi2cacheNumAdds, ifi2cacheNumHits, ifi2cacheNumMisses;
 //
 // Add a mapping to the cache: (origIter, fs's intents) -> extdIter.
 //
-void IFI2cacheAdd(ForallStmt* fs, FnSymbol* origIter, FnSymbol* extdIter)
+static void IFI2cacheAdd(ForallStmt* fs, FnSymbol* origIter,
+                         FnSymbol* extdIter)
 {
   INT_ASSERT(fs && origIter && extdIter); // caller responsibility
   ifi2cacheNumAdds++;
@@ -1197,8 +1195,8 @@ static FnSymbol* IFI2cacheLookup(ForallStmt* fs, FnSymbol* origIter) {
   // If not for the counters, could return simply IFI2cacheFindEntry(...).
 }
 
-bool redirectedToIfi2Cache(ForallStmt* fs, FnSymbol* origIter,
-                           CallExpr* iterCall) {
+static bool redirectedToIfi2Cache(ForallStmt* fs, FnSymbol* origIter,
+                                  CallExpr* iterCall) {
   FnSymbol* lookupResult = IFI2cacheLookup(fs, origIter);
 
   if (lookupResult == NULL)
@@ -1206,7 +1204,7 @@ bool redirectedToIfi2Cache(ForallStmt* fs, FnSymbol* origIter,
 
   // Cache hit yay! Redirect iterCall to it.
 
-  int numSVars = fs->numIntentVars();
+  int numSVars = fs->numShadowVars();
   int numOrigArgs = origIter->numFormals();
 
   // The extended iterator has the original formals plus
@@ -1299,13 +1297,13 @@ static void addForallIntentsOrigRetSym(FnSymbol* iterFn, Symbol* origRetSym) {
 
 /////////// extendLeaderNew ///////////
 
-void extendLeaderNew(ForallStmt* fs, 
-                     FnSymbol* origIterFn, CallExpr* iterCall)
+static void extendLeaderNew(ForallStmt* fs, 
+                            FnSymbol* origIterFn, CallExpr* iterCall)
 {
   if (!pristineLeaderIterators.get(origIterFn))
     stashPristineCopyOfLeaderIter(origIterFn, false);
 
-  int numSVars = fs->numIntentVars();
+  int numSVars = fs->numShadowVars();
   if (numSVars == 0)
     // no outer variables in the loop body - nothing to do
     return;
@@ -1373,4 +1371,142 @@ void extendLeaderNew(ForallStmt* fs,
   if (origRetSym) {
     checkAndRemoveOrigRetSym(origRetSym, iterFn);
   }
+}
+
+
+/////////////////////////////////////////////////////////////////////////////
+// top-level implementForallIntents2New and helpers
+
+static CallExpr* findForwardingCallAndUnresolve(FnSymbol* fDest) {
+  Symbol* retSym = fDest->getReturnSymbol();
+  retSym->type = dtUnknown;
+  SymExpr* retSE = retSym->getSingleDef();
+  // We need this. If we don't get it, is that a user error?
+  INT_ASSERT(retSE);
+
+  CallExpr* retMove = toCallExpr(retSE->parentExpr);
+  INT_ASSERT(retMove && retMove->isPrimitive(PRIM_MOVE));
+  Expr* retDef = retMove->get(2);
+
+  if (SymExpr* src = toSymExpr(retDef)) {
+    src->symbol()->type = dtUnknown;
+    SymExpr* srcSE = src->symbol()->getSingleDef();
+    INT_ASSERT(srcSE); // like retSE
+    CallExpr* srcMove = toCallExpr(srcSE->parentExpr);
+    INT_ASSERT(srcMove && srcMove->isPrimitive(PRIM_MOVE));
+    retDef = srcMove->get(2);
+  }
+
+  fDest->removeFlag(FLAG_RESOLVED);
+  CallExpr* fCall = toCallExpr(retDef);
+  // If we did not find it, is it user error or a new pattern?
+  INT_ASSERT(fCall);
+  return fCall;
+}
+
+static const char* newWrapperFormalName(int ix, Symbol* actual) {
+  if (!strcmp(actual->name, "chpl__reduceGlob"))
+    return intentArgName(ix, "reduceGlob");
+  else
+    return intentArgName(ix, actual->name);
+}
+    
+// "Wrap" throughout this function signifies either a wrapper,
+// ex. default wrapper, or an iterator forwarder.
+static void implementForallIntents2NewWrap(ForallStmt* fs, FnSymbol* dest,
+                                        CallExpr* parCall)
+{
+  int numExtraArgs = fs->numShadowVars();
+  if (numExtraArgs == 0)
+    // leave as-is
+    return;
+
+  FnSymbol* wDest = dest->copy();
+  wDest->addFlag(FLAG_INVISIBLE_FN);
+  wDest->instantiationPoint = getVisibilityBlock(parCall);
+  // Do we also need to update paramMap like in copyLeaderFn() ?
+  dest->defPoint->insertAfter(new DefExpr(wDest));
+  parCall->baseExpr->replace(new SymExpr(wDest));
+
+  // We cloned the wrapper 'dest' into 'wDest'.  wDest's call 'wCall'
+  // now invokes a clone of the iterator that 'dest' was invoking.
+  // The above code modifies both 'wCall' and the iterator that it invokes.
+  // Alas, 'wCall' inherits FLAG_RESOLVED and its return type from 'dest'
+  // and these are no longer appropriate due to these modifications.
+  //
+  // So 'wDest' will need to be resolved again.
+  // To make that happen, we un-resolve its relevant pieces.
+  //
+  CallExpr* wCall = findForwardingCallAndUnresolve(wDest);
+
+  // Extend wDest with formals to match parCall's actuals.
+  SymExpr* curArgSE = toSymExpr(
+    parCall->get(parCall->numActuals() - numExtraArgs + 1));
+  int ix = 0;
+
+  do {
+    Symbol*    curArg    = curArgSE->symbol();
+    IntentTag  fIntent   = concreteIntent(INTENT_BLANK, curArg->type);
+    const char* curName  = newWrapperFormalName(ix, curArg);
+    ArgSymbol* curFormal = new ArgSymbol(fIntent, curName, curArg->type);
+
+    curFormal->qual = curArg->qual;
+
+    if (curFormal->isRef() &&
+        curArg->isConstValWillNotChange())
+      curFormal->addFlag(FLAG_REF_TO_IMMUTABLE);
+
+    wCall->insertAtTail(curFormal);
+    wDest->insertFormalAtTail(curFormal);
+
+    curArgSE = toSymExpr(curArgSE->next);
+    ix++;
+  } while (curArgSE);
+
+  // Handle whatever wDest is wrapping or forwarding to.
+  implementForallIntents2New(fs, wCall);
+}
+
+void implementForallIntents2New(ForallStmt* fs, CallExpr* parCall)
+{
+  FnSymbol* dest = parCall->resolvedFunction();
+
+  if (redirectedToIfi2Cache(fs, dest, parCall))
+    // Cache hit. redirectedToIfi2Cache() adjusted AST as needed.
+    return;
+
+  // At the moment, 'dest' can be a wrapper and/or an iterator-forwarding
+  // procedure, ex. _array.these() or NPBRandomStream.iterate().
+
+  if (dest->hasFlag(FLAG_WRAPPER)) {
+    // a wrapper for either an iterator or an iterator forwarder
+    implementForallIntents2NewWrap(fs, dest, parCall);
+
+  } else if (!dest->isIterator()) {
+    // an "iterator forwarder" i.e. a 'proc' that returns an iterator
+
+    // The only way we know that it is an iterator forwarder is by checking
+    // its return type. For that, it needs to be resolved.
+    INT_ASSERT(dest->isResolved());
+
+    implementForallIntents2NewWrap(fs, dest, parCall);
+
+  } else {
+    // a call directly to an iterator
+
+    if (!(isLeaderIterator(dest) || isStandaloneIterator(dest))) {
+      // Todo: add our iterator calls to the call stack so the user
+      // can trace where this is coming from.
+      // (It would be useful in other cases as well.)
+      // Further, represent the forall statement itself on the stack, too.
+      USR_FATAL_CONT(fs, "iteration in the forall loop redirects to a non-parallel iterator");
+      USR_PRINT(dest, "the non-parallel iterator is defined here");
+      USR_STOP();
+    }
+
+    extendLeaderNew(fs, dest, parCall);
+  }
+
+  // Save the extended iterator for future lookups.
+  IFI2cacheAdd(fs, dest, parCall->resolvedFunction());
 }

--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -890,7 +890,7 @@ static Expr* preFoldPrimOp(CallExpr* call) {
     Expr*         lhs       = call->get(2)->remove();
     ForallStmt*   fs        = enclosingForallStmt(call);
     // rOpIdx was computed by reduceIntentIdx()
-    ShadowVarSymbol*   svar = fs->getForallIntent(rOpIdx);
+    ShadowVarSymbol*   svar = fs->getShadowVar(rOpIdx);
     Symbol*       globalOp  = toSymExpr(svar->reduceOpExpr())->symbol();
 
     INT_ASSERT(!strcmp(toSymExpr(lhs)->symbol()->name, svar->name));

--- a/test/parallel/forall/vass/reciter/forall-reciter-todo.future
+++ b/test/parallel/forall/vass/reciter/forall-reciter-todo.future
@@ -1,3 +1,3 @@
 unimplemented feature: reduce intents in a for loop over a recursive iterator
 
-Issue t.b.d.
+Issue #7821


### PR DESCRIPTION
This PR makes no behavioral changes.
It contains only renamings and code moves.

Renames:
* resolveParallelIteratorAndForallIntents -> resolveForallHeader
* intentVariables -> shadowVariables
* ... and related terminology; "intent variables" is out now

Moves:
* implementForallIntents2New and helpers: ifi.cpp -> ifi2.cpp

While there:
* removed printDef in symbol.h - it is neither implemented nore used
* added printing of the shadow variable's intent in viewFlags()
* added an issue number to a .future