### PR TITLE
Improve diagnostics for bogus shadow variables

### DIFF
--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -646,6 +646,7 @@ static void checkUseBeforeDefs() {
       }
     }
   }
+  USR_STOP();
 }
 
 // If the AST node defines a symbol, then extract that symbol

--- a/test/classes/vass/nested-class-with-user-defined-constructor-1.bad
+++ b/test/classes/vass/nested-class-with-user-defined-constructor-1.bad
@@ -1,9 +1,1 @@
 nested-class-with-user-defined-constructor-1.chpl:4: error: constructor for class 'inner' requires a generic argument called 'outer'
-nested-class-with-user-defined-constructor-1.chpl:4: In initializer 'inner':
-nested-class-with-user-defined-constructor-1.chpl:4: internal error: EXPnnnn chpl Version mmmm
-
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
-and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
-please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
-

--- a/test/parallel/forall/vass/bogusShadowVar.chpl
+++ b/test/parallel/forall/vass/bogusShadowVar.chpl
@@ -1,0 +1,7 @@
+
+forall loc in Locales with
+  (in numLocales,
+   in bogusVar1,
+   + reduce bogusVar2)
+do
+  writeln();

--- a/test/parallel/forall/vass/bogusShadowVar.good
+++ b/test/parallel/forall/vass/bogusShadowVar.good
@@ -1,0 +1,2 @@
+bogusShadowVar.chpl:4: error: 'bogusVar1' undeclared (first use this function)
+bogusShadowVar.chpl:5: error: 'bogusVar2' undeclared (first use this function)


### PR DESCRIPTION
First, add USR_STOP() at the end of checkUseBeforeDefs().
This prevents invalid ShadowVarSymbol nodes
from reaching verify().

As a side effect, one future no longer crashes
the compiler. I updated .bad.

Second, when creating shadow variables, give them correct astloc.
That way the error messages referring to shadow variables
point to correct lines. And anyway it is good to get that right.

Added a test.