### PR TITLE
Extract resolveFunction() :- Phase 1

### DIFF
--- a/compiler/AST/foralls.cpp
+++ b/compiler/AST/foralls.cpp
@@ -17,20 +17,20 @@
  * limitations under the License.
  */
 
-// foralls.h, foralls.cpp - support for forall loops
+#include "foralls.h"
 
+#include "astutil.h"
+#include "AstVisitor.h"
 #include "DeferStmt.h"
 #include "driver.h"
-#include "foralls.h"
+#include "ForLoop.h"
 #include "ForallStmt.h"
-#include "astutil.h"
+#include "iterator.h"
+#include "passes.h"
+#include "resolution.h"
+#include "resolveFunction.h"
 #include "stlUtil.h"
 #include "stringutil.h"
-#include "passes.h" // for normalized, resolved
-#include "AstVisitor.h"
-#include "ForLoop.h"
-#include "resolution.h"
-#include "iterator.h"
 
 const char* forallIntentTagDescription(ForallIntentTag tfiTag) {
   switch (tfiTag) {
@@ -648,7 +648,7 @@ static void resolveParallelIteratorAndIdxVar(ForallStmt* pfs,
   FnSymbol* parIter = iterCall->resolvedFunction();
   bool alreadyResolved = parIter->isResolved();
 
-  resolveFns(parIter);
+  resolveFunction(parIter);
 
   // Set QualifiedType of the index variable.
   QualifiedType iType = fsIterYieldType(pfs, parIter, alreadyResolved);

--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -168,7 +168,6 @@ void      resolveFormals(FnSymbol* fn);
 void      resolveBlockStmt(BlockStmt* blockStmt);
 void      resolveCall(CallExpr* call);
 void      resolveCallAndCallee(CallExpr* call, bool allowUnresolved = false);
-void      resolveFns(FnSymbol* fn);
 void      resolveDefaultGenericType(CallExpr* call);
 void      resolveReturnType(FnSymbol* fn);
 Type*     resolveTypeAlias(SymExpr* se);

--- a/compiler/include/resolveFunction.h
+++ b/compiler/include/resolveFunction.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2004-2017 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _RESOLVE_FUNCTION_H_
+#define _RESOLVE_FUNCTION_H_
+
+class FnSymbol;
+
+void resolveFunction(FnSymbol* fn);
+
+#endif

--- a/compiler/resolution/ResolutionCandidate.cpp
+++ b/compiler/resolution/ResolutionCandidate.cpp
@@ -25,6 +25,7 @@
 #include "expandVarArgs.h"
 #include "expr.h"
 #include "resolution.h"
+#include "resolveFunction.h"
 #include "stmt.h"
 #include "stringutil.h"
 #include "symbol.h"
@@ -126,7 +127,7 @@ void ResolutionCandidate::resolveTypeConstructor(CallInfo& info) {
 
     INT_ASSERT(typeConstructorCall->isResolved());
 
-    resolveFns(typeConstructorCall->resolvedFunction());
+    resolveFunction(typeConstructorCall->resolvedFunction());
 
     fn->_this->type = typeConstructorCall->resolvedFunction()->retType;
 

--- a/compiler/resolution/callDestructors.cpp
+++ b/compiler/resolution/callDestructors.cpp
@@ -25,6 +25,7 @@
 #include "expr.h"
 #include "postFold.h"
 #include "resolution.h"
+#include "resolveFunction.h"
 #include "resolveIntents.h"
 #include "stlUtil.h"
 #include "stmt.h"
@@ -1070,12 +1071,17 @@ static void ensureModuleDeinitFnAnchor(ModuleSymbol* mod, Expr*& anchor) {
     return;
 
   SET_LINENO(mod);
+
   FnSymbol* deinitFn = mod->deinitFn;
+
   if (!deinitFn) {
     deinitFn = new FnSymbol(astr("chpl__deinit_", mod->name));
+
     mod->block->insertAtTail(new DefExpr(deinitFn));
+
     normalize(deinitFn);
-    resolveFns(deinitFn);
+    resolveFunction(deinitFn);
+
     mod->deinitFn = deinitFn;
   }
 

--- a/compiler/resolution/initializerResolution.cpp
+++ b/compiler/resolution/initializerResolution.cpp
@@ -29,6 +29,7 @@
 #include "passes.h"
 #include "resolution.h"
 #include "ResolutionCandidate.h"
+#include "resolveFunction.h"
 #include "stmt.h"
 #include "stringutil.h"
 #include "symbol.h"
@@ -237,7 +238,7 @@ static void filterInitCandidate(CallInfo&                  info,
 
 /************************************* | **************************************
 *                                                                             *
-* Copied from resolveFns(FnSymbol* fn) in functionResolution.                 *
+* Copied from resolveFunction(FnSymbol* fn) in functionResolution.            *
 *                                                                             *
 * Removed code for extern functions (since I don't think it will apply),      *
 * iterators, type constructors, and FLAG_PRIVATIZED_CLASS.                    *
@@ -336,7 +337,7 @@ static void makeRecordInitWrappers(CallExpr* call) {
 
   call->baseExpr->replace(new SymExpr(wrap));
 
-  resolveFns(wrap);
+  resolveFunction(wrap);
 }
 
 // Modified version of computeActualFormalAlignment to only populate the

--- a/compiler/resolution/tuples.cpp
+++ b/compiler/resolution/tuples.cpp
@@ -29,6 +29,7 @@
 #include "driver.h"
 #include "expr.h"
 #include "passes.h"
+#include "resolveFunction.h"
 #include "resolveIntents.h"
 #include "stmt.h"
 #include "stringutil.h"
@@ -453,7 +454,7 @@ TupleInfo getTupleInfo(std::vector<TypeSymbol*>& args,
     newType->methods.add(dtor);
 
     // Resolve it so it stays in AST
-    resolveFns(dtor);
+    resolveFunction(dtor);
 
   }
 

--- a/compiler/resolution/virtualDispatch.cpp
+++ b/compiler/resolution/virtualDispatch.cpp
@@ -50,6 +50,7 @@ static child type could end up calling something in the parent.
 #include "expr.h"
 #include "iterator.h"
 #include "resolution.h"
+#include "resolveFunction.h"
 #include "stmt.h"
 #include "symbol.h"
 
@@ -346,7 +347,7 @@ static void addToVirtualMaps(FnSymbol* pfn, AggregateType* ct) {
           resolveFormals(fn);
 
           if (signatureMatch(pfn, fn) && evaluateWhereClause(fn)) {
-            resolveFns(fn);
+            resolveFunction(fn);
 
             if (fn->retType->symbol->hasFlag(FLAG_ITERATOR_RECORD) &&
                 pfn->retType->symbol->hasFlag(FLAG_ITERATOR_RECORD)) {


### PR DESCRIPTION
Begin to extract resolveFns() et al from functionResolution.cpp

This trivial PR lays a foundation for extracting resolveFns() from
functionResolution.cpp.

1) Rename resolveFns() to be resolveFunction()

2) Introduce resolveFunction.h.  Remove resolveFns()
from resolution.h and add resolveFunction() to
resolveFunction.h

3) Perform multiple trivial touches to support 1/2.

Compiled with/without CHPL_DEVELOPER on
clang/darwin and gcc/linux64.  Ran a portion of
release/ with all four configs.

Also compiled with CHPL_LLVM=llvm and ran a
small portion of release/
