### PR TITLE
Introduce SET_YYLINENO

### DIFF
--- a/compiler/AST/baseAST.cpp
+++ b/compiler/AST/baseAST.cpp
@@ -747,7 +747,7 @@ bool isCForLoop(const BaseAST* a)
 
 /************************************* | **************************************
 *                                                                             *
-* Definitions for astlocMarker                                                *
+* Definitions for astlocMarker and astlocYyMarker                             *
 *                                                                             *
 ************************************** | *************************************/
 
@@ -770,4 +770,28 @@ astlocMarker::astlocMarker(int lineno, const char* filename)
 // destructor, invoked upon leaving SET_LINENO's scope
 astlocMarker::~astlocMarker() {
   currentAstLoc = previousAstLoc;
+}
+
+// constructor, invoked upon SET_YYLINENO
+astlocYyMarker::astlocYyMarker(BaseAST* ast) :
+  prevYystartlineno (yystartlineno),
+  prevYyfilename    (yyfilename)
+{
+  yystartlineno = ast->linenum();
+  yyfilename    = ast->fname();
+}
+
+// constructor, for special occasions
+astlocYyMarker::astlocYyMarker(int lineno, const char* filename) :
+  prevYystartlineno (yystartlineno),
+  prevYyfilename    (yyfilename)
+{
+  yystartlineno = lineno;
+  yyfilename    = filename;
+}
+
+// destructor, invoked upon leaving SET_YYLINENO's scope
+astlocYyMarker::~astlocYyMarker() {
+  yystartlineno = prevYystartlineno;
+  yyfilename    = prevYyfilename;
 }

--- a/compiler/AST/foralls.cpp
+++ b/compiler/AST/foralls.cpp
@@ -215,15 +215,11 @@ void addForallIntent(ForallIntents* fi, Expr* var, IntentTag intent, Expr* ri) {
 }
 
 void addForallIntent(CallExpr* call, Expr* var, IntentTag intent, Expr* ri) {
+  SET_YYLINENO(var);
   ForallIntentTag tfi = ri ? TFI_REDUCE : argIntentToForallIntent(var, intent);
   const char* name = toUnresolvedSymExpr(var)->unresolved;
   ShadowVarSymbol* ss = new ShadowVarSymbol(tfi, name, ri);
   call->insertAtTail(new DefExpr(ss));
-  // SET_LINENO does not work while parsing, so adjust astloc manually.
-  ss->astloc = ss->defPoint->astloc = var->astloc;
-  // Turns out that 'new ShadowVarSymbol' also creates this node.
-  // It is important that it gets the correct astloc as well.
-  ss->outerVarRep->astloc = var->astloc;
 }
 
 //

--- a/compiler/include/baseAST.h
+++ b/compiler/include/baseAST.h
@@ -321,6 +321,25 @@ public:
 };
 
 //
+// Counterpart to SET_LINENO for use while parsing.
+//
+// Given that BaseAST constructor gives precedence to
+// (yystartlineno, yyfilename) over currentAstLoc,
+// we need to handle yy* separately.
+//
+#define SET_YYLINENO(ast) astlocYyMarker markYyAstLoc(ast)
+
+class astlocYyMarker {
+public:
+  astlocYyMarker(BaseAST* ast);
+  astlocYyMarker(int lineno, const char* filename);
+  ~astlocYyMarker();
+
+ int         prevYystartlineno;
+ const char* prevYyfilename;
+};
+
+//
 // class test inlines: determine the dynamic type of a BaseAST*
 //
 static inline bool isExpr(const BaseAST* a)


### PR DESCRIPTION
I need to do SET_LINENO during parsing to get a correct line number
for error reporting. SET_LINENO per se does not work during parsing
because BaseAST::BaseAST gives precedence to (yystartlineno, yyfilename)
over currentAstLoc.

To enable that, I added SET_YYLINENO macro.
It behaves just like SET_LINENO, except it works with
(yystartlineno, yyfilename) - so it is usable during parsing.

This allows me to remove some less-than-ideal code in foralls.cpp.

Replaces #7820.
