### PR TITLE
Add experimental task-resetting to qthreads

### DIFF
--- a/f.chpl
+++ b/f.chpl
@@ -1,0 +1,29 @@
+use BlockDist;
+
+
+
+const m = 1000;
+const ProblemSpace: domain(1) dmapped Block(boundingBox={1..m}) = {1..m};
+writeln();
+writeln();
+
+var A: [ProblemSpace] int;
+var B: [ProblemSpace] int;
+var C: [ProblemSpace] int;
+
+A = B + C;
+writeln();
+writeln();
+allowTaskSpawnDebug = true;
+forall (a, b, c) in zip(A, B, C) do 
+  a = b + c;
+writeln();
+forall (a, b, c) in zip(A, B, C) do 
+  a = b + c;
+
+allowTaskSpawnDebug = false;
+
+writeln();
+writeln();
+
+

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -23,6 +23,13 @@
 module ChapelBase {
   use ChapelStandard;
 
+  proc resetTaskSpawn() {
+    if CHPL_TASKS == 'qthreads' {
+      extern proc qthread_reset_spawn_order();
+      qthread_reset_spawn_order();
+    }
+  }
+
   // These two are called by compiler-generated code.
   extern proc chpl_config_has_value(name:c_string, module_name:c_string): bool;
   extern proc chpl_config_get_value(name:c_string, module_name:c_string): c_string;

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -30,6 +30,26 @@ module ChapelBase {
     }
   }
 
+  proc chpl_setenv(name: string, val: string, overwrite: bool = false) {
+    extern proc setenv(name : c_string, envval : c_string, overwrite : c_int) : c_int;
+    setenv(name.c_str(), val.c_str(), overwrite:c_int);
+  }
+
+  proc chpl_unsetenv(name: string) {
+    extern proc unsetenv(name: c_string): void;
+    unsetenv(name.c_str());
+  }
+
+  var allowTaskSpawnDebug = false;
+  proc enableTaskSpawnDebug() {
+    if allowTaskSpawnDebug then 
+      chpl_setenv("QT_SHEP_DEBUG", "1");
+  }
+  proc disableTaskSpawnDebug() {
+    chpl_unsetenv("QT_SHEP_DEBUG");
+  }
+
+
   // These two are called by compiler-generated code.
   extern proc chpl_config_has_value(name:c_string, module_name:c_string): bool;
   extern proc chpl_config_get_value(name:c_string, module_name:c_string): c_string;

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -25,28 +25,23 @@ module ChapelBase {
 
   proc resetTaskSpawn() {
     if CHPL_TASKS == 'qthreads' {
-      extern proc qthread_reset_spawn_order();
-      qthread_reset_spawn_order();
+      extern proc qthread_chpl_reset_spawn_order();
+      qthread_chpl_reset_spawn_order();
     }
   }
 
-  proc chpl_setenv(name: string, val: string, overwrite: bool = false) {
-    extern proc setenv(name : c_string, envval : c_string, overwrite : c_int) : c_int;
-    setenv(name.c_str(), val.c_str(), overwrite:c_int);
+  proc setShepDebug(debug) {
+    extern proc qthread_chpl_set_shep_debug(debug: c_int);
+    qthread_chpl_set_shep_debug(debug:c_int);
   }
 
-  proc chpl_unsetenv(name: string) {
-    extern proc unsetenv(name: c_string): void;
-    unsetenv(name.c_str());
-  }
-
-  var allowTaskSpawnDebug = false;
+  var allowTaskSpawnDebug = false; 
   proc enableTaskSpawnDebug() {
     if allowTaskSpawnDebug then 
-      chpl_setenv("QT_SHEP_DEBUG", "1");
+      setShepDebug(here.id+1);
   }
   proc disableTaskSpawnDebug() {
-    chpl_unsetenv("QT_SHEP_DEBUG");
+    setShepDebug(0);
   }
 
 

--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -1779,6 +1779,7 @@ proc _cast(type t, r: range(?)) where isRangeType(t) {
         yield i;
       }
     } else {
+      resetTaskSpawn();
       coforall chunk in 0..#numChunks {
         if stridable {
           // TODO: find a way to avoid this densify/undensify for strided
@@ -1893,6 +1894,7 @@ proc _cast(type t, r: range(?)) where isRangeType(t) {
         yield (0..v-1,);
       else
       {
+        resetTaskSpawn();
         coforall chunk in 0..#numChunks
         {
           const (lo,hi) = _computeBlock(v, numChunks, chunk, v-1);

--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -1780,6 +1780,7 @@ proc _cast(type t, r: range(?)) where isRangeType(t) {
       }
     } else {
       resetTaskSpawn();
+      enableTaskSpawnDebug();
       coforall chunk in 0..#numChunks {
         if stridable {
           // TODO: find a way to avoid this densify/undensify for strided
@@ -1800,6 +1801,7 @@ proc _cast(type t, r: range(?)) where isRangeType(t) {
           }
         }
       }
+      disableTaskSpawnDebug();
     }
   }
 
@@ -1895,6 +1897,7 @@ proc _cast(type t, r: range(?)) where isRangeType(t) {
       else
       {
         resetTaskSpawn();
+        enableTaskSpawnDebug();
         coforall chunk in 0..#numChunks
         {
           const (lo,hi) = _computeBlock(v, numChunks, chunk, v-1);
@@ -1902,6 +1905,7 @@ proc _cast(type t, r: range(?)) where isRangeType(t) {
             chpl_debug_writeln("*** RI: tuple = ", (lo..hi,));
           yield (lo..hi,);
         }
+       disableTaskSpawnDebug();
       }
     }
   }

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -213,6 +213,7 @@ module DefaultRectangular {
         if debugDefaultDist {
           chpl_debug_writeln("*** DI: locBlock = ", locBlock);
         }
+        resetTaskSpawn();
         coforall chunk in 0..#numChunks {
           var followMe: rank*range(idxType) = locBlock;
           const (lo,hi) = _computeBlock(locBlock(parDim).length,
@@ -394,6 +395,7 @@ module DefaultRectangular {
             locBlock(i) = offset(i)..#(ranges(i).length);
           if debugDefaultDist then
             chpl_debug_writeln("*** DI: locBlock = ", locBlock);
+          resetTaskSpawn();
           coforall chunk in 0..#numChunks {
             var followMe: rank*range(idxType) = locBlock;
             const (lo,hi) = _computeBlock(locBlock(parDim).length,

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -214,6 +214,7 @@ module DefaultRectangular {
           chpl_debug_writeln("*** DI: locBlock = ", locBlock);
         }
         resetTaskSpawn();
+        enableTaskSpawnDebug();
         coforall chunk in 0..#numChunks {
           var followMe: rank*range(idxType) = locBlock;
           const (lo,hi) = _computeBlock(locBlock(parDim).length,
@@ -257,6 +258,7 @@ module DefaultRectangular {
             yield i;
           }
         }
+        disableTaskSpawnDebug();
       }
     }
 
@@ -396,6 +398,7 @@ module DefaultRectangular {
           if debugDefaultDist then
             chpl_debug_writeln("*** DI: locBlock = ", locBlock);
           resetTaskSpawn();
+          enableTaskSpawnDebug();
           coforall chunk in 0..#numChunks {
             var followMe: rank*range(idxType) = locBlock;
             const (lo,hi) = _computeBlock(locBlock(parDim).length,
@@ -408,6 +411,7 @@ module DefaultRectangular {
               chpl_debug_writeln("*** DI[", chunk, "]: followMe = ", followMe);
             yield followMe;
           }
+          disableTaskSpawnDebug();
         }
       }
     }

--- a/test/studies/prk/Stencil/optimized/stencil-opt.chpl
+++ b/test/studies/prk/Stencil/optimized/stencil-opt.chpl
@@ -43,6 +43,9 @@ const activePoints = (order-2*R)*(order-2*R),
 
 var timer: Timer;
 
+extern proc qthread_reset_spawn_order();
+//proc qthread_reset_spawn_order() { }
+
 /* Parallel Research Kernel - Stencil */
 proc main() {
 
@@ -81,8 +84,10 @@ proc main() {
   const outputDom = localDom dmapped outDist;
 
   /* Input and Output matrices represented as arrays over a 2D domain */
-  var input: [Dom] dtype = 0.0,
-      output: [outputDom] dtype = 0.0;
+  coforall loc in Locales do on loc do qthread_reset_spawn_order();
+  var input: [Dom] dtype = 0.0;
+  coforall loc in Locales do on loc do qthread_reset_spawn_order();
+  var output: [outputDom] dtype = 0.0;
 
   /* Weight matrix represented as tuple of tuples*/
   var weight: Wsize*(Wsize*(dtype));
@@ -133,12 +138,16 @@ proc main() {
 
   var stenTime, incTime, commTime : real;
   var subTimer : Timer;
+ 
+  //coforall loc in Locales do on loc do qthread_reset_spawn_order();
 
   //
   // Main loop of Stencil
   //
   if debug then startVdebug("stencil-fast-vis");
   for iteration in 0..iterations {
+
+  coforall loc in Locales do on loc do qthread_reset_spawn_order();
 
     /* Start timer after warmup iteration */
     if (iteration == 1) {

--- a/test/studies/prk/Stencil/optimized/stencil-opt.chpl
+++ b/test/studies/prk/Stencil/optimized/stencil-opt.chpl
@@ -43,8 +43,10 @@ const activePoints = (order-2*R)*(order-2*R),
 
 var timer: Timer;
 
-extern proc qthread_reset_spawn_order();
-//proc qthread_reset_spawn_order() { }
+proc resetTaskSpawn() {
+  extern proc qthread_reset_spawn_order();
+  coforall loc in Locales do on loc do qthread_reset_spawn_order();
+}
 
 /* Parallel Research Kernel - Stencil */
 proc main() {
@@ -84,10 +86,9 @@ proc main() {
   const outputDom = localDom dmapped outDist;
 
   /* Input and Output matrices represented as arrays over a 2D domain */
-  coforall loc in Locales do on loc do qthread_reset_spawn_order();
-  var input: [Dom] dtype = 0.0;
-  coforall loc in Locales do on loc do qthread_reset_spawn_order();
-  var output: [outputDom] dtype = 0.0;
+  resetTaskSpawn();
+  var input: [Dom] dtype = 0.0,
+      output: [outputDom] dtype = 0.0;
 
   /* Weight matrix represented as tuple of tuples*/
   var weight: Wsize*(Wsize*(dtype));
@@ -139,15 +140,13 @@ proc main() {
   var stenTime, incTime, commTime : real;
   var subTimer : Timer;
  
-  //coforall loc in Locales do on loc do qthread_reset_spawn_order();
+  resetTaskSpawn();
 
   //
   // Main loop of Stencil
   //
   if debug then startVdebug("stencil-fast-vis");
   for iteration in 0..iterations {
-
-  coforall loc in Locales do on loc do qthread_reset_spawn_order();
 
     /* Start timer after warmup iteration */
     if (iteration == 1) {

--- a/test/studies/prk/Stencil/optimized/stencil-opt.chpl
+++ b/test/studies/prk/Stencil/optimized/stencil-opt.chpl
@@ -43,11 +43,6 @@ const activePoints = (order-2*R)*(order-2*R),
 
 var timer: Timer;
 
-proc resetTaskSpawn() {
-  extern proc qthread_reset_spawn_order();
-  coforall loc in Locales do on loc do qthread_reset_spawn_order();
-}
-
 /* Parallel Research Kernel - Stencil */
 proc main() {
 
@@ -86,7 +81,6 @@ proc main() {
   const outputDom = localDom dmapped outDist;
 
   /* Input and Output matrices represented as arrays over a 2D domain */
-  resetTaskSpawn();
   var input: [Dom] dtype = 0.0,
       output: [outputDom] dtype = 0.0;
 
@@ -139,8 +133,6 @@ proc main() {
 
   var stenTime, incTime, commTime : real;
   var subTimer : Timer;
- 
-  resetTaskSpawn();
 
   //
   // Main loop of Stencil

--- a/third-party/qthread/qthread-src/include/qthread/qthread.h
+++ b/third-party/qthread/qthread-src/include/qthread/qthread.h
@@ -298,7 +298,8 @@ enum _qthread_features {
 #define QTHREAD_SPAWN_AGGREGABLE    (1 << SPAWN_AGGREGABLE)
 #define QTHREAD_SPAWN_LOCAL_PRIORITY (1 << SPAWN_LOCAL_PRIORITY)
 
-void qthread_reset_spawn_order(void);
+void qthread_chpl_reset_spawn_order(void);
+void qthread_chpl_set_shep_debug(int);
 
 int qthread_spawn(qthread_f             f,
                   const void           *arg,

--- a/third-party/qthread/qthread-src/include/qthread/qthread.h
+++ b/third-party/qthread/qthread-src/include/qthread/qthread.h
@@ -298,6 +298,8 @@ enum _qthread_features {
 #define QTHREAD_SPAWN_AGGREGABLE    (1 << SPAWN_AGGREGABLE)
 #define QTHREAD_SPAWN_LOCAL_PRIORITY (1 << SPAWN_LOCAL_PRIORITY)
 
+void qthread_reset_spawn_order(void);
+
 int qthread_spawn(qthread_f             f,
                   const void           *arg,
                   size_t                arg_size,

--- a/third-party/qthread/qthread-src/src/qthread.c
+++ b/third-party/qthread/qthread-src/src/qthread.c
@@ -2597,10 +2597,6 @@ int API_FUNC qthread_spawn(qthread_f             f,
         }
 #endif  /* ifdef QTHREAD_DEBUG */
     }
-    int shep_debug = qt_internal_get_env_bool("SHEP_DEBUG", 0);
-    if (shep_debug) {
-      printf("Spawning to shepherd %hu. myshep=%p\n", (unsigned short)dest_shep, myshep);
-    }
     qthread_debug(THREAD_BEHAVIOR, "target_shep(%i) => dest_shep(%i)\n", target_shep, dest_shep);
     /* Step 3: Allocate & init the structure */
 

--- a/third-party/qthread/qthread-src/src/qthread.c
+++ b/third-party/qthread/qthread-src/src/qthread.c
@@ -2520,6 +2520,13 @@ void API_FUNC qthread_flushsc(void)
  */
 #define QTHREAD_SPAWN_MASK_TEAMS (QTHREAD_SPAWN_NEW_TEAM | QTHREAD_SPAWN_NEW_SUBTEAM)
 
+void API_FUNC qthread_reset_spawn_order(void) {
+  for (unsigned int i=0; i<qlib->nshepherds; i++) {
+    qlib->shepherds[i].sched_shepherd =1;
+  }
+  qlib->sched_shepherd = 1;
+}
+
 int API_FUNC qthread_spawn(qthread_f             f,
                            const void           *arg,
                            size_t                arg_size,
@@ -2589,6 +2596,10 @@ int API_FUNC qthread_spawn(qthread_f             f,
             assert((feature_flag & QTHREAD_SPAWN_PC_SYNCVAR_T) == 0);
         }
 #endif  /* ifdef QTHREAD_DEBUG */
+    }
+    int shep_debug = qt_internal_get_env_bool("SHEP_DEBUG", 0);
+    if (shep_debug) {
+      printf("Spawning to shepherd %hu. myshep=%p\n", (unsigned short)dest_shep, myshep);
     }
     qthread_debug(THREAD_BEHAVIOR, "target_shep(%i) => dest_shep(%i)\n", target_shep, dest_shep);
     /* Step 3: Allocate & init the structure */

--- a/third-party/qthread/qthread-src/src/qthread.c
+++ b/third-party/qthread/qthread-src/src/qthread.c
@@ -2520,11 +2520,16 @@ void API_FUNC qthread_flushsc(void)
  */
 #define QTHREAD_SPAWN_MASK_TEAMS (QTHREAD_SPAWN_NEW_TEAM | QTHREAD_SPAWN_NEW_SUBTEAM)
 
-void API_FUNC qthread_reset_spawn_order(void) {
+void API_FUNC qthread_chpl_reset_spawn_order(void) {
   for (unsigned int i=0; i<qlib->nshepherds; i++) {
-    qlib->shepherds[i].sched_shepherd =1;
+    qlib->shepherds[i].sched_shepherd = 1;
   }
   qlib->sched_shepherd = 1;
+}
+
+static int shep_debug = 0;
+void API_FUNC qthread_chpl_set_shep_debug(int debug) {
+  shep_debug = debug;
 }
 
 int API_FUNC qthread_spawn(qthread_f             f,
@@ -2597,9 +2602,8 @@ int API_FUNC qthread_spawn(qthread_f             f,
         }
 #endif  /* ifdef QTHREAD_DEBUG */
     }
-    int shep_debug = qt_internal_get_env_bool("SHEP_DEBUG", 0);
     if (shep_debug) {
-      printf("Spawning to shepherd %hu. myshep=%p\n", (unsigned short)dest_shep, myshep);
+      printf("Node %d -- spawning to shepherd %d\n", (int)shep_debug, (int)dest_shep);
     }
     qthread_debug(THREAD_BEHAVIOR, "target_shep(%i) => dest_shep(%i)\n", target_shep, dest_shep);
     /* Step 3: Allocate & init the structure */

--- a/third-party/qthread/qthread-src/src/qthread.c
+++ b/third-party/qthread/qthread-src/src/qthread.c
@@ -2597,6 +2597,10 @@ int API_FUNC qthread_spawn(qthread_f             f,
         }
 #endif  /* ifdef QTHREAD_DEBUG */
     }
+    int shep_debug = qt_internal_get_env_bool("SHEP_DEBUG", 0);
+    if (shep_debug) {
+      printf("Spawning to shepherd %hu. myshep=%p\n", (unsigned short)dest_shep, myshep);
+    }
     qthread_debug(THREAD_BEHAVIOR, "target_shep(%i) => dest_shep(%i)\n", target_shep, dest_shep);
     /* Step 3: Allocate & init the structure */
 


### PR DESCRIPTION
This is experimental task-resetting code for qthreads. It's not complete or
cleaned up enough to be merged, but I wanted to open the PR for discussion.

Qthreads schedules tasks in a round-robin fashion, which works out well if
here.maxTaskPar tasks are used for each iteration, but not if more or less are
used because loops will have different affinity between iterations.

This adds an experimental ability to reset the task spawn order, which is
something we've wanted for years now. It's currently a gross hack in qthreads
and in our modules, but it works well enough to experiment with.

This was motivated by improving prk-stencil performance (which seems to get
particularly screwy affinity under ugni) but should help other benchmarks as
well.

This really naively resets the task spawn order for parallel range iteration
and parallel default rectangular domain iteration. Those are the building
blocks for most things, so this will effectively reset the task-spawn order for
most parallel iterators.

This is almost certainly wrong for things like:

```chpl
forall i in here.maxTaskPar/4 do
  forall j in here.maxTaskPar/4 do
    A[i,j] = i+j;
```

because it will not utilize all resources and will instead oversubscribe the
first here.maxTaskPar/4 cores, but for most codes the simple resetting policy
is what we want.
