### PR TITLE
Extract resolveFunction() :- Phase 3

### DIFF
--- a/compiler/AST/ParamForLoop.cpp
+++ b/compiler/AST/ParamForLoop.cpp
@@ -22,6 +22,7 @@
 #include "AstVisitor.h"
 #include "build.h"
 #include "resolution.h"
+#include "resolveFunction.h"
 #include "stringutil.h"
 
 /************************************ | *************************************

--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -84,8 +84,6 @@ bool explainCallMatch(CallExpr* call);
 
 bool isDispatchParent(Type* t, Type* pt);
 
-void protoIteratorClass(FnSymbol* fn);
-
 bool canCoerce(Type*     actualType,
                Symbol*   actualSym,
                Type*     formalType,
@@ -165,11 +163,12 @@ disambiguateForInit(CallInfo&                    info,
                     Vec<ResolutionCandidate*>&   candidates);
 
 // Regular resolve functions
-void      resolveFormals(FnSymbol* fn);
 void      resolveBlockStmt(BlockStmt* blockStmt);
 void      resolveCall(CallExpr* call);
 void      resolveCallAndCallee(CallExpr* call, bool allowUnresolved = false);
+
 void      resolveDefaultGenericType(CallExpr* call);
+Type*     resolveDefaultGenericTypeSymExpr(SymExpr* se);
 Type*     resolveTypeAlias(SymExpr* se);
 
 FnSymbol* tryResolveCall(CallExpr* call);
@@ -223,7 +222,6 @@ AggregateType* computeTupleWithIntent(IntentTag intent, AggregateType* t);
 bool evaluateWhereClause(FnSymbol* fn);
 
 bool isAutoDestroyedVariable(Symbol* sym);
-
 
 extern Map<Type*,FnSymbol*> valueToRuntimeTypeMap; // convertValueToRuntimeType
 

--- a/compiler/include/resolveFunction.h
+++ b/compiler/include/resolveFunction.h
@@ -24,6 +24,10 @@ class AggregateType;
 class FnSymbol;
 class Type;
 
+void  resolveFormalsAndFunction(FnSymbol* fn);
+
+void  resolveFormals(FnSymbol* fn);
+
 void  resolveFunction(FnSymbol* fn);
 
 bool  isLeaderIterator(FnSymbol* fn);

--- a/compiler/resolution/generics.cpp
+++ b/compiler/resolution/generics.cpp
@@ -25,6 +25,7 @@
 #include "driver.h"
 #include "expr.h"
 #include "PartialCopyData.h"
+#include "resolveFunction.h"
 #include "resolveIntents.h"
 #include "stmt.h"
 #include "stringutil.h"

--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -25,6 +25,7 @@
 #include "ParamForLoop.h"
 #include "passes.h"
 #include "resolution.h"
+#include "resolveFunction.h"
 #include "resolveIntents.h"
 #include "scopeResolve.h"
 #include "stlUtil.h"

--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -51,6 +51,7 @@
 #include "ForLoop.h"
 #include "passes.h"
 #include "resolution.h"
+#include "resolveFunction.h"
 #include "resolveIntents.h"
 #include "stlUtil.h"
 #include "stmt.h"


### PR DESCRIPTION
Additional work to extract resolveFns() et al from functionResolution.cpp

I realized that I had overlooked the opportunity to pull resolveFormals() et al
in to resolveFunction.cpp.  This simple PR makes that transition.

Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.
Also compiled with CHPL_LLVM=llvm on gcc/linux64.  Ran a portion of release
for each configuration.

Passed a single-locale paratest with --no-locale
