### PR TITLE
Added FnSymbol::singleInvocation()

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -1792,6 +1792,31 @@ FnSymbol::collapseBlocks() {
   body->accept(&visitor);
 }
 
+//
+// If 'this' has a single use as the callee of a CallExpr,
+// return that CallExpr. Otherwise return NULL.
+//
+CallExpr* FnSymbol::singleInvocation() const {
+  SymExpr* se = firstSymExpr();
+
+  if (se == NULL)
+    // no uses at all
+    return NULL;
+
+  if (se != lastSymExpr())
+    // more than one use
+    return NULL;
+
+  // Got exactly one use. Check how it is used.
+  if (CallExpr* parent = toCallExpr(se->parentExpr))
+    if (se == parent->baseExpr)
+      // yes, it is the callee
+      return parent;
+
+  // The use is not as the callee, ex. as a FCF.
+  return NULL;
+}
+
 
 //
 // If the function is not currently marked as generic

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -584,6 +584,8 @@ public:
 
   void                       collapseBlocks();
 
+  CallExpr*                  singleInvocation()                          const;
+
   bool                       tagIfGeneric();
 
   bool                       isResolved()                                const;

--- a/compiler/resolution/implementForallIntents2.cpp
+++ b/compiler/resolution/implementForallIntents2.cpp
@@ -254,13 +254,10 @@ class EflopiInfo {
 public:
   ForallStmt* eflopiForall;
   ForLoop*    eflopiLoop;
+  // more details if eflopiLoop
   CallExpr*   eflopiCall;
-  // more details
-  // todo soon: remove all except asgnToIter?
-  Symbol*    iterSym;
-  CallExpr*  asgnToIter;
-  Symbol*    iterCallTemp;
-  CallExpr*  asgnToCallTemp;
+  CallExpr*   asgnToIter;
+  Symbol*     iterCallTemp;
 };
 
 //
@@ -321,10 +318,8 @@ static bool findCallToParallelIterator(ForLoop* forLoop, EflopiInfo& eInfo)
     eInfo.eflopiForall   = NULL;
     eInfo.eflopiLoop     = forLoop;
     eInfo.eflopiCall     = iterCall;
-    eInfo.iterSym        = iterSym;
     eInfo.asgnToIter     = asgnToIter;
     eInfo.iterCallTemp   = calltemp;
-    eInfo.asgnToCallTemp = asgnToCallTemp;
     return true;
   }
 
@@ -1019,7 +1014,7 @@ static void propagateRecursivelyNew(FIcontext& ctx)
 
       // We will be extending 'tfn' specifically to this situation.
       // So there better be no other users of it.
-      // todo soon: INT_ASSERT(rcall == tfn->singleInvocation());
+      INT_ASSERT(rcall == tfn->singleInvocation());
 
       if (needsCapture(tfn)) {
 


### PR DESCRIPTION
singleInvocation() returns the CallExpr that is the single call
to 'this' FnSymbol. If there is no such call, return NULL.

There are a couple of places in the compiler where I would like
to assert that the call I am looking at is a single invocation.
singleInvocation() allows me to do that cheaply,
thanks to firstSymExpr() and lastSymExpr().

This PR also uses singleInvocation() to add an assertion in
implementForallIntents2.cpp and to replace an expensive check
in iterator.cpp.

While there, removed unused fields of eflopiInfo.

Testing: linux64 --verify -futures