### PR TITLE
Clean up tabs & whitespace in Mason source code

### DIFF
--- a/tools/mason/MasonBuild.chpl
+++ b/tools/mason/MasonBuild.chpl
@@ -34,18 +34,18 @@ proc masonBuild(args) {
   if args.size > 2 {
     for arg in args[2..] {
       if arg == '-h' || arg == '--help' {
-	masonBuildHelp();
-	exit();
+        masonBuildHelp();
+        exit();
       }
       else if arg == '--release' {
-	release = true;
+        release = true;
       }
       else if arg == '--show' {
-	show = true;
+        show = true;
       }
       else {
-	compopts.push_back(arg);
-      } 
+        compopts.push_back(arg);
+      }
     }
   }
   UpdateLock(args);
@@ -104,17 +104,17 @@ proc BuildProgram(release: bool, show: bool, compopts: [?d] string) {
      toParse.close();
   }
   else writeln("Cannot build: no Mason.lock found");
-} 
+}
 
 
 /* Creates the rest of the project structure */
 proc makeTargetFiles(binLoc: string) {
   if !isDir('target') {
-    mkdir('target'); 
+    mkdir('target');
   }
   if !isDir('target/' + binLoc) {
     mkdir('target/' + binLoc);
-    
+
     // TODO:
     //mkdir('target/' + binLoc + '/tests');
     //mkdir('target/'+ binLoc + '/examples');
@@ -125,16 +125,16 @@ proc makeTargetFiles(binLoc: string) {
 
 /* Compiles the program into the main project src
    folder. Requires that the main library file be
-   named after the project folder in which it is 
+   named after the project folder in which it is
    contained */
-proc compileSrc(lockFile: Toml, binLoc: string, show: bool, 
-		release: bool, compopts: [?dom] string) : bool {
+proc compileSrc(lockFile: Toml, binLoc: string, show: bool,
+                release: bool, compopts: [?dom] string) : bool {
   var sourceList = genSourceList(lockFile);
   var depPath = MASON_HOME + '/src/';
   var project = lockFile["root"]["name"].s;
   var pathToProj = 'src/'+ project + '.chpl';
   var moveTo = ' -o target/'+ binLoc +'/'+ project;
- 
+
   if isFile(pathToProj) {
     var command: string = 'chpl ' + pathToProj + moveTo + ' ' + ' '.join(compopts);
     if release then command += " --fast";
@@ -154,7 +154,7 @@ proc compileSrc(lockFile: Toml, binLoc: string, show: bool,
     if compilation != 0 {
       return false;
     }
-    
+
     // Confirming File Structure
     if isFile('target/' + binLoc + '/' + project) then
       return true;
@@ -208,8 +208,8 @@ proc getSrcCode(sourceList: [?d] 3*string, show) {
       var getDependency = "git clone -qn "+ srcURL + ' ' + destination +'/';
       var checkout = "git checkout -q v" + version;
       if show {
-	getDependency = "git clone -n " + srcURL + ' ' + destination + '/';
-	checkout = "git checkout v" + version;
+        getDependency = "git clone -n " + srcURL + ' ' + destination + '/';
+        checkout = "git checkout v" + version;
       }
       runCommand(getDependency);
       gitC(destination, checkout);

--- a/tools/mason/MasonHelp.chpl
+++ b/tools/mason/MasonHelp.chpl
@@ -101,7 +101,7 @@ proc masonNewHelp() {
   writeln('    -h, --help                   Display this message');
   writeln('        --show                   Increase verbosity');
   writeln('        --no-vcs                 Do not initialize a git repository');
-  
+
 }
 
 proc masonSearchHelp() {

--- a/tools/mason/MasonNew.chpl
+++ b/tools/mason/MasonNew.chpl
@@ -42,17 +42,17 @@ proc masonNew(args) {
     var name = 'MyPackage';
     for arg in args[2..] {
       if arg == '-h' || arg == '--help' {
-	masonNewHelp();
-	exit();
+        masonNewHelp();
+        exit();
       }
       else if arg == '--no-vcs' {
-	vcs = false;
+        vcs = false;
       }
       else if arg == '--show' {
-	show = true;
+        show = true;
       }
       else {
-	name = arg;
+        name = arg;
       }
     }
     InitProject(name, vcs, show);
@@ -60,8 +60,8 @@ proc masonNew(args) {
 }
 
 
-  
-  
+
+
 proc InitProject(name, vcs, show) {
   if vcs {
     gitInit(name, show);
@@ -109,7 +109,7 @@ proc makeBasicToml(name: string) {
   tomlWriter.write(baseToml);
   tomlWriter.close();
 }
-  
+
 
 proc makeProjectFiles(name: string) {
   mkdir(name + "/src");

--- a/tools/mason/MasonUpdate.chpl
+++ b/tools/mason/MasonUpdate.chpl
@@ -415,7 +415,7 @@ proc getDependencies(tomlTbl: Toml) {
   for k in tomlTbl.D {
     if k == "dependencies" {
       for (a,d) in allFields(tomlTbl[k]) {
-	deps.push_back((a, d));
+        deps.push_back((a, d));
       }
     }
   }

--- a/tools/mason/mason.chpl
+++ b/tools/mason/mason.chpl
@@ -102,20 +102,20 @@ proc masonRun(args) {
     for arg in args[2..] {
       if arg == '-h' || arg == '--help' {
         masonRunHelp();
-	exit();
+        exit();
       }
       else if arg == '--build' {
-	masonBuild(['mason', 'build']);
+        masonBuild(['mason', 'build']);
       }
       else if arg == '--show' {
-	show = true;
+        show = true;
       }
       else {
-	execopts.push_back(arg);
+        execopts.push_back(arg);
       }
-    }  
+    }
   }
-  // Find the Binary and execute 
+  // Find the Binary and execute
   if isDir('target') {
     var execs = ' '.join(execopts);
     var command = "target/debug/" + toRun + ' ' + execs;
@@ -144,7 +144,7 @@ proc masonClean() {
   runCommand('rm -rf target');
 }
 
- 
+
 proc masonDoc(args) {
   var toDoc = basename(getEnv('PWD'));
   var project = toDoc + '.chpl';


### PR DESCRIPTION
I don't want these changes to pollute more meaningful commits in upcoming changes.