### PR TITLE
Resolve function 4

### DIFF
--- a/compiler/AST/ParamForLoop.cpp
+++ b/compiler/AST/ParamForLoop.cpp
@@ -491,7 +491,7 @@ Type* ParamForLoop::indexType()
 
   if (FnSymbol* sym = range->resolvedFunction())
   {
-    resolveFormals(sym);
+    resolveSignature(sym);
 
     DefExpr* formal = toDefExpr(sym->formals.get(1));
 

--- a/compiler/include/resolveFunction.h
+++ b/compiler/include/resolveFunction.h
@@ -24,9 +24,9 @@ class AggregateType;
 class FnSymbol;
 class Type;
 
-void  resolveFormalsAndFunction(FnSymbol* fn);
+void  resolveSignatureAndFunction(FnSymbol* fn);
 
-void  resolveFormals(FnSymbol* fn);
+void  resolveSignature(FnSymbol* fn);
 
 void  resolveFunction(FnSymbol* fn);
 

--- a/compiler/resolution/ResolutionCandidate.cpp
+++ b/compiler/resolution/ResolutionCandidate.cpp
@@ -629,7 +629,7 @@ bool ResolutionCandidate::checkResolveFormalsWhereClauses() {
    * A derived generic type will use the type of its parent,
    * and expects this to be instantiated before it is.
    */
-  resolveFormals(fn);
+  resolveSignature(fn);
 
   for_formals(formal, fn) {
     if (Symbol* actual = formalIdxToActual[++coindex]) {

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5855,13 +5855,13 @@ static Expr* resolveTypeOrParamExpr(Expr* expr) {
 
 
               if (fn->retTag  == RET_PARAM || fn->retTag  == RET_TYPE) {
-                resolveFormalsAndFunction(fn);
+                resolveSignatureAndFunction(fn);
 
               } else if (fn->retType == dtUnknown) {
-                resolveFormalsAndFunction(fn);
+                resolveSignatureAndFunction(fn);
 
               } else {
-                resolveFormals(fn);
+                resolveSignature(fn);
 
               }
             }
@@ -6277,7 +6277,7 @@ static void resolveExprTypeConstructor(SymExpr* symExpr) {
         if (ct != dtString ||
             (sym->isParameter()                    == false   &&
              sym->hasFlag(FLAG_INSTANTIATED_PARAM) == false))  {
-          resolveFormals(ct->defaultTypeConstructor);
+          resolveSignature(ct->defaultTypeConstructor);
 
           if (resolvedFormals.set_in(ct->defaultTypeConstructor)) {
             if (hasPartialCopyData(ct->defaultTypeConstructor) == true) {
@@ -6721,10 +6721,10 @@ static void resolveUses(ModuleSymbol* mod)
             module_resolution_depth, mod->name);
   }
 
-  resolveFormalsAndFunction(mod->initFn);
+  resolveSignatureAndFunction(mod->initFn);
 
   if (FnSymbol* defn = mod->deinitFn) {
-    resolveFormalsAndFunction(defn);
+    resolveSignatureAndFunction(defn);
   }
 
   if (fPrintModuleResolution) {
@@ -6763,7 +6763,7 @@ static void resolveExports() {
     if (fn->hasFlag(FLAG_EXPORT) == true) {
       SET_LINENO(fn);
 
-      resolveFormalsAndFunction(fn);
+      resolveSignatureAndFunction(fn);
     }
   }
 }
@@ -7247,7 +7247,7 @@ static void resolveOther() {
 
   for_vector(FnSymbol, fn, fns) {
     if (fn->hasFlag(FLAG_GENERIC) == false) {
-      resolveFormalsAndFunction(fn);
+      resolveSignatureAndFunction(fn);
     }
   }
 }

--- a/compiler/resolution/generics.cpp
+++ b/compiler/resolution/generics.cpp
@@ -705,7 +705,7 @@ bool evaluateWhereClause(FnSymbol* fn) {
   if (fn->where) {
     whereStack.add(fn);
 
-    resolveFormals(fn);
+    resolveSignature(fn);
 
     resolveBlockStmt(fn->where);
 

--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -1466,7 +1466,8 @@ static Expr* createFunctionAsValue(CallExpr *call) {
     }
   }
 
-  resolveFormals(captured_fn);
+  resolveSignature(captured_fn);
+
   resolveFnForCall(captured_fn, call);
 
   //
@@ -1476,12 +1477,13 @@ static Expr* createFunctionAsValue(CallExpr *call) {
   if (call->isPrimitive(PRIM_CAPTURE_FN_FOR_C)) {
     return new SymExpr(captured_fn);
   }
+
   //
   // Otherwise, we need to create a Chapel first-class function (fcf)...
   //
 
-  AggregateType *parent;
-  FnSymbol *thisParentMethod;
+  AggregateType* parent;
+  FnSymbol*      thisParentMethod;
 
   std::string parent_name = buildParentName(captured_fn->formals, true, captured_fn->retType);
 

--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -40,6 +40,12 @@
 #include "view.h"
 #include "WhileStmt.h"
 
+#include <set>
+
+static void resolveFormals(FnSymbol* fn);
+
+static void resolveSpecifiedReturnType(FnSymbol* fn);
+
 static bool isFollowerIterator(FnSymbol* fn);
 static bool isVecIterator(FnSymbol* fn);
 
@@ -67,125 +73,126 @@ void resolveSignatureAndFunction(FnSymbol* fn) {
 *                                                                             *
 ************************************** | *************************************/
 
-static bool      convertAtomicFormalTypeToRef(ArgSymbol* formal,
-                                              FnSymbol*  fn);
-
-static void      resolveSpecifiedReturnType(FnSymbol* fn);
-
-static void      protoIteratorClass(FnSymbol* fn);
-
-static FnSymbol* protoIteratorMethod(IteratorInfo* ii,
-                                     const char*   name,
-                                     Type*         retType);
-
 void resolveSignature(FnSymbol* fn) {
-  static Vec<FnSymbol*> done;
+  if (fn->hasFlag(FLAG_GENERIC) == false) {
+    static std::set<FnSymbol*> done;
 
-  if (!fn->hasFlag(FLAG_GENERIC)) {
-    if (done.set_in(fn))
-      return;
+    if (done.find(fn) == done.end()) {
+      done.insert(fn);
 
-    done.set_add(fn);
+      resolveFormals(fn);
 
-    for_formals(formal, fn) {
-      if (formal->type == dtUnknown) {
-        if (!formal->typeExpr) {
-          formal->type = dtObject;
-
-        } else {
-          resolveBlockStmt(formal->typeExpr);
-
-          formal->type = formal->typeExpr->body.tail->getValType();
-        }
+      if (fn->retExprType != NULL) {
+        resolveSpecifiedReturnType(fn);
       }
 
-      //
-      // Fix up value types that need to be ref types.
-      //
-      if (formal->type->symbol->hasFlag(FLAG_REF))
-        // Already a ref type, so done.
-        continue;
-
-      // Don't pass dtString params in by reference
-      if(formal->type == dtString && formal->hasFlag(FLAG_INSTANTIATED_PARAM))
-        continue;
-
-      if (formal->type->symbol->hasFlag(FLAG_RANGE) &&
-          (formal->intent == INTENT_BLANK || formal->intent == INTENT_IN) &&
-          fn->hasFlag(FLAG_BEGIN)) {
-        // For begin functions, copy ranges in if passed by blank intent.
-        // This is a temporary workaround.
-        // * arguably blank intent for ranges should be 'const ref',
-        //   but the current compiler uses a mix of 'const in' and 'const ref'.
-        // * resolveIntents is changing INTENT_IN to INTENT_REF
-        //   which interferes with the logic in parallel.cpp
-        //   (another approach to that problem might be to separately
-        //    store the 'requested intent' and the 'concrete intent').
-        formal->intent = INTENT_CONST_IN;
-      }
-
-      if (formal->intent == INTENT_INOUT ||
-          formal->intent == INTENT_OUT ||
-          formal->intent == INTENT_REF ||
-          formal->intent == INTENT_CONST_REF ||
-          convertAtomicFormalTypeToRef(formal, fn) ||
-          formal->hasFlag(FLAG_WRAP_WRITTEN_FORMAL) ||
-          (formal == fn->_this &&
-           !formal->hasFlag(FLAG_TYPE_VARIABLE) &&
-           (isUnion(formal->type) ||
-            isRecord(formal->type)))) {
-        makeRefType(formal->type);
-
-        if (formal->type->refType) {
-          formal->type = formal->type->refType;
-          // The type of the formal is its own ref type!
-
-        } else {
-          formal->qual = QUAL_REF;
-        }
-      }
-
-      if (isRecordWrappedType(formal->type) &&
-          fn->hasFlag(FLAG_ITERATOR_FN)) {
-        // Pass domains, arrays into iterators by ref.
-        // This is a temporary workaround for issues with
-        // iterator lowering.
-        // It is temporary because we expect more of the
-        // compiler to handle 'refness' of an ArgSymbol
-        // in the future.
-        makeRefType(formal->type);
-
-        formal->type = formal->type->refType;
-      }
-
-      // Adjust tuples for intent.
-      // This should not apply to 'ref' , 'out', or 'inout' formals,
-      // but these are currently turned into reference types above.
-      // It probably should not apply to 'const ref' either but
-      // that is more debatable.
-      if (formal->type->symbol->hasFlag(FLAG_TUPLE) &&
-          !formal->hasFlag(FLAG_TYPE_VARIABLE) &&
-          !(formal == fn->_this) &&
-          !doNotChangeTupleTypeRefLevel(fn, false)) {
-
-        // Let 'in' intent work similarly to the blank intent.
-        IntentTag intent = formal->intent;
-        if (intent == INTENT_IN) intent = INTENT_BLANK;
-        AggregateType* tupleType = toAggregateType(formal->type);
-        INT_ASSERT(tupleType);
-        Type* newType = computeTupleWithIntent(intent, tupleType);
-        formal->type = newType;
-      }
-
+      resolvedFormals.set_add(fn);
     }
-
-    if (fn->retExprType) {
-      resolveSpecifiedReturnType(fn);
-    }
-
-    resolvedFormals.set_add(fn);
   }
 }
+
+/************************************* | **************************************
+*                                                                             *
+*                                                                             *
+*                                                                             *
+************************************** | *************************************/
+
+static bool convertAtomicFormalTypeToRef(ArgSymbol* formal,
+                                         FnSymbol*  fn);
+
+static void resolveFormals(FnSymbol* fn) {
+  for_formals(formal, fn) {
+    if (formal->type == dtUnknown) {
+      if (formal->typeExpr == NULL) {
+        formal->type = dtObject;
+
+      } else {
+        resolveBlockStmt(formal->typeExpr);
+
+        formal->type = formal->typeExpr->body.tail->getValType();
+      }
+    }
+
+    //
+    // Fix up value types that need to be ref types.
+    //
+    if (formal->type->symbol->hasFlag(FLAG_REF))
+      // Already a ref type, so done.
+      continue;
+
+    // Don't pass dtString params in by reference
+    if(formal->type == dtString && formal->hasFlag(FLAG_INSTANTIATED_PARAM))
+      continue;
+
+    if (formal->type->symbol->hasFlag(FLAG_RANGE) &&
+        (formal->intent == INTENT_BLANK || formal->intent == INTENT_IN) &&
+        fn->hasFlag(FLAG_BEGIN)) {
+      // For begin functions, copy ranges in if passed by blank intent.
+      // This is a temporary workaround.
+      // * arguably blank intent for ranges should be 'const ref',
+      //   but the current compiler uses a mix of 'const in' and 'const ref'.
+      // * resolveIntents is changing INTENT_IN to INTENT_REF
+      //   which interferes with the logic in parallel.cpp
+      //   (another approach to that problem might be to separately
+      //    store the 'requested intent' and the 'concrete intent').
+      formal->intent = INTENT_CONST_IN;
+    }
+
+    if (formal->intent == INTENT_INOUT ||
+        formal->intent == INTENT_OUT ||
+        formal->intent == INTENT_REF ||
+        formal->intent == INTENT_CONST_REF ||
+        convertAtomicFormalTypeToRef(formal, fn) ||
+        formal->hasFlag(FLAG_WRAP_WRITTEN_FORMAL) ||
+        (formal == fn->_this &&
+         !formal->hasFlag(FLAG_TYPE_VARIABLE) &&
+         (isUnion(formal->type) ||
+          isRecord(formal->type)))) {
+      makeRefType(formal->type);
+
+      if (formal->type->refType) {
+        formal->type = formal->type->refType;
+        // The type of the formal is its own ref type!
+
+      } else {
+        formal->qual = QUAL_REF;
+      }
+    }
+
+    if (isRecordWrappedType(formal->type) &&
+        fn->hasFlag(FLAG_ITERATOR_FN)) {
+      // Pass domains, arrays into iterators by ref.
+      // This is a temporary workaround for issues with
+      // iterator lowering.
+      // It is temporary because we expect more of the
+      // compiler to handle 'refness' of an ArgSymbol
+      // in the future.
+      makeRefType(formal->type);
+
+      formal->type = formal->type->refType;
+    }
+
+    // Adjust tuples for intent.
+    // This should not apply to 'ref' , 'out', or 'inout' formals,
+    // but these are currently turned into reference types above.
+    // It probably should not apply to 'const ref' either but
+    // that is more debatable.
+    if (formal->type->symbol->hasFlag(FLAG_TUPLE) &&
+        !formal->hasFlag(FLAG_TYPE_VARIABLE) &&
+        !(formal == fn->_this) &&
+        !doNotChangeTupleTypeRefLevel(fn, false)) {
+
+      // Let 'in' intent work similarly to the blank intent.
+      IntentTag intent = formal->intent;
+      if (intent == INTENT_IN) intent = INTENT_BLANK;
+      AggregateType* tupleType = toAggregateType(formal->type);
+      INT_ASSERT(tupleType);
+      Type* newType = computeTupleWithIntent(intent, tupleType);
+      formal->type = newType;
+    }
+  }
+}
+
 
 //
 // Generally, atomics must also be passed by reference when
@@ -225,6 +232,17 @@ static bool convertAtomicFormalTypeToRef(ArgSymbol* formal, FnSymbol* fn) {
     && !fn->hasFlag(FLAG_BUILD_TUPLE);
 }
 
+/************************************* | **************************************
+*                                                                             *
+*                                                                             *
+*                                                                             *
+************************************** | *************************************/
+
+static void      protoIteratorClass(FnSymbol* fn);
+
+static FnSymbol* protoIteratorMethod(IteratorInfo* ii,
+                                     const char*   name,
+                                     Type*         retType);
 
 static void resolveSpecifiedReturnType(FnSymbol* fn) {
   Type* retType;

--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -56,8 +56,8 @@ static void instantiateDefaultConstructor(FnSymbol* fn);
 *                                                                             *
 ************************************** | *************************************/
 
-void resolveFormalsAndFunction(FnSymbol* fn) {
-  resolveFormals(fn);
+void resolveSignatureAndFunction(FnSymbol* fn) {
+  resolveSignature(fn);
   resolveFunction(fn);
 }
 
@@ -78,7 +78,7 @@ static FnSymbol* protoIteratorMethod(IteratorInfo* ii,
                                      const char*   name,
                                      Type*         retType);
 
-void resolveFormals(FnSymbol* fn) {
+void resolveSignature(FnSymbol* fn) {
   static Vec<FnSymbol*> done;
 
   if (!fn->hasFlag(FLAG_GENERIC)) {
@@ -520,7 +520,7 @@ void resolveFunction(FnSymbol* fn) {
       if (pt                         != NULL     &&
           pt                         != dtObject &&
           pt->defaultTypeConstructor != NULL) {
-        resolveFormals(pt->defaultTypeConstructor);
+        resolveSignature(pt->defaultTypeConstructor);
 
         if (resolvedFormals.set_in(pt->defaultTypeConstructor)) {
           resolveFunction(pt->defaultTypeConstructor);
@@ -534,7 +534,7 @@ void resolveFunction(FnSymbol* fn) {
       for_fields(field, ct) {
         if (AggregateType* fct = toAggregateType(field->type)) {
           if (fct->defaultTypeConstructor) {
-            resolveFormals(fct->defaultTypeConstructor);
+            resolveSignature(fct->defaultTypeConstructor);
 
             if (resolvedFormals.set_in(fct->defaultTypeConstructor)) {
               resolveFunction(fct->defaultTypeConstructor);

--- a/compiler/resolution/tuples.cpp
+++ b/compiler/resolution/tuples.cpp
@@ -466,7 +466,7 @@ static void
 getTupleArgAndType(FnSymbol* fn, ArgSymbol*& arg, AggregateType*& ct) {
 
   // Adjust any formals for blank-intent tuple behavior now
-  resolveFormals(fn);
+  resolveSignature(fn);
 
   INT_ASSERT(fn->numFormals() == 1); // expected of the original function
   arg = fn->getFormal(1);
@@ -574,7 +574,7 @@ static void
 instantiate_tuple_cast(FnSymbol* fn, CallExpr* context)
 {
   // Adjust any formals for blank-intent tuple behavior now
-  resolveFormals(fn);
+  resolveSignature(fn);
 
   AggregateType* toT   = toAggregateType(fn->getFormal(1)->type);
   ArgSymbol*     arg   = fn->getFormal(2);
@@ -586,8 +586,10 @@ instantiate_tuple_cast(FnSymbol* fn, CallExpr* context)
   block->insertAtTail(new DefExpr(retv));
 
   if (fromT->numFields() != toT->numFields()) {
-    USR_FATAL_CONT(context, "tuple size mismatch (expected %d, got %d)", 
-                   toT->numFields()-1, fromT->numFields()-1);
+    USR_FATAL_CONT(context,
+                   "tuple size mismatch (expected %d, got %d)",
+                   toT->numFields()   - 1,
+                   fromT->numFields() - 1);
     return;
   }
 

--- a/compiler/resolution/virtualDispatch.cpp
+++ b/compiler/resolution/virtualDispatch.cpp
@@ -344,7 +344,7 @@ static void addToVirtualMaps(FnSymbol* pfn, AggregateType* ct) {
         }
 
         if (fn) {
-          resolveFormals(fn);
+          resolveSignature(fn);
 
           if (signatureMatch(pfn, fn) && evaluateWhereClause(fn)) {
             resolveFunction(fn);

--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -196,7 +196,7 @@ static FnSymbol* wrapDefaultedFormals(FnSymbol*                fn,
   if (retval == NULL) {
     retval = buildWrapperForDefaultedFormals(fn, info, &defaults, &paramMap);
 
-    resolveFormals(retval);
+    resolveSignature(retval);
 
     addCache(defaultsCache, fn, retval, &defaults);
   }
@@ -1069,7 +1069,7 @@ static FnSymbol* promotionWrap(FnSymbol* fn,
   if (retval == NULL) {
     retval = buildPromotionWrapper(fn, info, fastFollowerChecks, subs);
 
-    resolveFormals(retval);
+    resolveSignature(retval);
 
     addCache(promotionsCache, fn, retval, &subs);
   }


### PR DESCRIPTION
Trivial changes for resolveFormals()

I noticed that resolveFormals() is really a packaging of
resolveFormals() and resolveSpecifiedReturnType().

The first commit converts current uses of resolveFormals()
to be resolveSignature().

The second commit extracts the actual resolveFormals() from
the new resolveSignature().

Compiled with/without CHPL_DEVELOPER on clang/darwin
and gcc/linux64 and passed a portion of release/ for each
config.  Also compiled with CHPL_LLVM=llvm and tested
on a portion of release/

Passed a single-locale paratest on linux64.
