### PR TITLE
Simplify getting yielded type for recursive standalone

### DIFF
--- a/compiler/include/foralls.h
+++ b/compiler/include/foralls.h
@@ -56,7 +56,6 @@ public:
 
 bool astUnderFI(const Expr* ast, ForallIntents* fi);
 void lowerForallStmts();
-Symbol* lookupForallIntentsOrigRetSym(FnSymbol* iterFn);
 
 #define for_riSpecs_vector(VAL, FI) \
   for_vector_allowing_0s(Expr, VAL, (FI)->riSpecs)

--- a/compiler/resolution/implementForallIntents2.cpp
+++ b/compiler/resolution/implementForallIntents2.cpp
@@ -1284,19 +1284,6 @@ void printIFI2cache() {
 }
 
 
-/////////// cache extended iterator -> its original return symbol ///////////
-
-static SymbolMap forallIntentsOrigRetSymMap;
-
-Symbol* lookupForallIntentsOrigRetSym(FnSymbol* iterFn) {
-  return forallIntentsOrigRetSymMap.get(iterFn);
-}
-
-static void addForallIntentsOrigRetSym(FnSymbol* iterFn, Symbol* origRetSym) {
-  forallIntentsOrigRetSymMap.put(iterFn, origRetSym);
-}
-
-
 /////////// extendLeaderNew ///////////
 
 static void extendLeaderNew(ForallStmt* fs, 
@@ -1331,7 +1318,6 @@ static void extendLeaderNew(ForallStmt* fs,
     origRetSym = iterFn->replaceReturnSymbol(retSym, /*newRetType*/NULL);
     origRetSym->defPoint->insertBefore(new DefExpr(retSym));
     origRetSym->name = "origRet";
-    addForallIntentsOrigRetSym(iterFn, origRetSym);
   }
 
   // Data for the call from the ForallStmt to the parallel iterator.


### PR DESCRIPTION
A variety of functions implementing forall intents end up calling buildIterYieldType in order to handle recursive parallel iterators. The previous implementation used a map to save the original yielded type but that map isn't really necessary. This PR uses a simpler solution that amounts to passing the resolved function to several pieces of the implementation.

- [x] passed full local testing
- [x] passed test/modules/standard/FileSystem/filerator/bradc/ with --baseline, --verify, --baseline --verify

Reviewed by @vasslitvinov - thanks!