### PR TITLE
Fix string parsing bug in TOML module

### DIFF
--- a/modules/packages/TOML.chpl
+++ b/modules/packages/TOML.chpl
@@ -75,7 +75,7 @@ module TomlParser {
 
 
   /* Prints a line by line output of parsing process */
-  config const debugTomlParser: bool = false;
+  config const debugTomlParser = false;
 
   pragma "no doc"
   class Parser {
@@ -101,6 +101,7 @@ module TomlParser {
       comment = compile("(\\#)"),
       comma = compile("(\\,)");
 
+    var debugCounter = 1;
 
     proc parseLoop() : Toml {
 
@@ -123,6 +124,7 @@ module TomlParser {
           halt("Unexpected token ->", getToken(source));
         }
         if debugTomlParser {
+          debugCounter += 1;
           debugPrint();
         }
       }
@@ -323,13 +325,12 @@ module TomlParser {
     }
 
     proc debugPrint() {
-      writeln();
-      writeln("========================= Debug Info  ==========================");
+      writeln(debugCounter, ':');
+      writeln(rootTable);
+      // Pointer to the line we are currently on
+      write('->');
       source.debug();
       writeln();
-      writeln(rootTable);
-      writeln();
-      writeln("================================================================");
     }
 
   }
@@ -678,11 +679,13 @@ Used to recursively hold tables and respective values
 
 pragma "no doc"
  /*
- Reader module for use in the Parser Class.
+ Reader (Lexer) module for use in the Parser Class.
  */
 module TomlReader {
 
  use Regexp;
+
+ config const debugTomlReader = false;
 
   /* Returns the next token in the current line without removing it */
   proc top(source) {
@@ -747,27 +750,30 @@ module TomlReader {
 
     proc splitLine(line) {
       var linetokens: [1..0] string;
-      const doubleQuotes = '".*?\\[^\\]?"',
-         singleQuotes = "'.*?\\[^\\]?'",
-         bracketContents = "(\\[\\w+\\])",
-         brackets = "(\\[)|(\\])",
-         comments = "(\\#)",
-         commas = "(\\,)",
-         equals = "(\\=)",
-         curly = "(\\{)|(\\})";
+      const doubleQuotes = '(".*?")',           // ""
+            singleQuotes = "('.*?')",           // ''
+            bracketContents = "(\\[\\w+\\])",   // [_]
+            brackets = "(\\[)|(\\])",           // []
+            comments = "(\\#)",                 // #
+            commas = "(\\,)",                   // ,
+            equals = "(\\=)",                   // =
+            curly = "(\\{)|(\\})";              // {}
 
       const pattern = compile('|'.join(doubleQuotes,
-                                    singleQuotes,
-                                    bracketContents,
-                                    brackets,
-                                    comments,
-                                    commas,
-                                    curly,
-                                    equals));
+                                       singleQuotes,
+                                       bracketContents,
+                                       brackets,
+                                       comments,
+                                       commas,
+                                       curly,
+                                       equals));
 
       for token in pattern.split(line) {
         var strippedToken = token.strip();
         if strippedToken.length != 0  {
+          if debugTomlReader {
+            writeln('Tokenized: ', '(', strippedToken, ')');
+          }
           linetokens.push_back(strippedToken);}
       }
       if !linetokens.isEmpty() {
@@ -806,14 +812,15 @@ module TomlReader {
 
 
     proc debug() {
-      var lineCounter: int = 1;
       for line in tokenlist {
-        write("line: ",lineCounter);
-        for token in line {
-          write(" token: " + token);
+        if line.A.size != 0 {
+          for token in line {
+            if token.length != 0 {
+              write("(", token, ")");
+            }
+          }
+          writeln();
         }
-        lineCounter += 1;
-        writeln();
       }
     }
 

--- a/modules/packages/TOML.chpl
+++ b/modules/packages/TOML.chpl
@@ -679,7 +679,7 @@ Used to recursively hold tables and respective values
 
 pragma "no doc"
  /*
- Reader (Lexer) module for use in the Parser Class.
+ Reader module for use in the Parser Class.
  */
 module TomlReader {
 

--- a/test/mason/chplVersion/mason-chpl-version-build.chpl
+++ b/test/mason/chplVersion/mason-chpl-version-build.chpl
@@ -16,5 +16,5 @@ proc main() {
   lock.close();
 
   var compopts = ["",];
-  BuildProgram(false, false, compopts);
+  buildProgram(false, false, compopts);
 }

--- a/test/modules/packages/Toml/test/TomlTest.execopts
+++ b/test/modules/packages/Toml/test/TomlTest.execopts
@@ -10,3 +10,4 @@
 --f childInitParent.good # childInitParent
 --f arrayCorner.good # arrayCorner
 --f actual.good # actual
+--f mason-1.good # mason-1

--- a/test/modules/packages/Toml/test/mason-1.good
+++ b/test/modules/packages/Toml/test/mason-1.good
@@ -1,0 +1,10 @@
+
+[brick]
+name = "MapReduce"
+compopts = "--set configParam=2 -sverbose=true"
+version = "0.1.0"
+chplVersion = "1.17.0"
+
+[dependencies]
+
+

--- a/tools/mason/MasonBuild.chpl
+++ b/tools/mason/MasonBuild.chpl
@@ -30,7 +30,6 @@ use MasonUpdate;
 proc masonBuild(args) {
   var show = false;
   var release = false;
-  var debug = false;
   var compopts: [1..0] string;
   if args.size > 2 {
     for arg in args[2..] {
@@ -44,16 +43,13 @@ proc masonBuild(args) {
       else if arg == '--show' {
         show = true;
       }
-      else if arg == '--debug' {
-        debug = true;
-      }
       else {
         compopts.push_back(arg);
       }
     }
   }
   UpdateLock(args);
-  buildProgram(release, show, compopts, debug);
+  buildProgram(release, show, compopts);
 }
 
 private proc checkChplVersion(lockFile : Toml) {

--- a/tools/mason/MasonBuild.chpl
+++ b/tools/mason/MasonBuild.chpl
@@ -30,6 +30,7 @@ use MasonUpdate;
 proc masonBuild(args) {
   var show = false;
   var release = false;
+  var debug = false;
   var compopts: [1..0] string;
   if args.size > 2 {
     for arg in args[2..] {
@@ -43,13 +44,16 @@ proc masonBuild(args) {
       else if arg == '--show' {
         show = true;
       }
+      else if arg == '--debug' {
+        debug = true;
+      }
       else {
         compopts.push_back(arg);
       }
     }
   }
   UpdateLock(args);
-  BuildProgram(release, show, compopts);
+  buildProgram(release, show, debug, compopts);
 }
 
 private proc checkChplVersion(lockFile : Toml) {
@@ -62,7 +66,7 @@ private proc checkChplVersion(lockFile : Toml) {
   }
 }
 
-proc BuildProgram(release: bool, show: bool, compopts: [?d] string) {
+proc buildProgram(release: bool, show: bool, debug: bool, compopts: [?d] string) {
   if isFile("Mason.lock") {
 
     // --fast
@@ -91,8 +95,12 @@ proc BuildProgram(release: bool, show: bool, compopts: [?d] string) {
       compopts.push_back(cmpFlags);
     }
 
+    if debug {
+      writeln('compopts: ', compopts);
+    }
+
     // Compile Program
-    if compileSrc(lockFile, binLoc, show, release, compopts) {
+    if compileSrc(lockFile, binLoc, show, release, compopts, debug) {
       writeln("Build Successful\n");
     }
     else {
@@ -128,7 +136,7 @@ proc makeTargetFiles(binLoc: string) {
    named after the project folder in which it is
    contained */
 proc compileSrc(lockFile: Toml, binLoc: string, show: bool,
-                release: bool, compopts: [?dom] string) : bool {
+                release: bool, compopts: [?dom] string, debug: bool) : bool {
   var sourceList = genSourceList(lockFile);
   var depPath = MASON_HOME + '/src/';
   var project = lockFile["root"]["name"].s;

--- a/tools/mason/MasonBuild.chpl
+++ b/tools/mason/MasonBuild.chpl
@@ -53,7 +53,7 @@ proc masonBuild(args) {
     }
   }
   UpdateLock(args);
-  buildProgram(release, show, debug, compopts);
+  buildProgram(release, show, compopts, debug);
 }
 
 private proc checkChplVersion(lockFile : Toml) {
@@ -66,7 +66,7 @@ private proc checkChplVersion(lockFile : Toml) {
   }
 }
 
-proc buildProgram(release: bool, show: bool, debug: bool, compopts: [?d] string) {
+proc buildProgram(release: bool, show: bool, compopts: [?d] string) {
   if isFile("Mason.lock") {
 
     // --fast
@@ -95,12 +95,8 @@ proc buildProgram(release: bool, show: bool, debug: bool, compopts: [?d] string)
       compopts.push_back(cmpFlags);
     }
 
-    if debug {
-      writeln('compopts: ', compopts);
-    }
-
     // Compile Program
-    if compileSrc(lockFile, binLoc, show, release, compopts, debug) {
+    if compileSrc(lockFile, binLoc, show, release, compopts) {
       writeln("Build Successful\n");
     }
     else {
@@ -136,7 +132,7 @@ proc makeTargetFiles(binLoc: string) {
    named after the project folder in which it is
    contained */
 proc compileSrc(lockFile: Toml, binLoc: string, show: bool,
-                release: bool, compopts: [?dom] string, debug: bool) : bool {
+                release: bool, compopts: [?dom] string) : bool {
   var sourceList = genSourceList(lockFile);
   var depPath = MASON_HOME + '/src/';
   var project = lockFile["root"]["name"].s;

--- a/tools/mason/MasonBuild.chpl
+++ b/tools/mason/MasonBuild.chpl
@@ -73,7 +73,7 @@ proc BuildProgram(release: bool, show: bool, compopts: [?d] string) {
     // Make Binary Directory
     makeTargetFiles(binLoc);
 
-    //Install dependencies into $MASON_HOME/src
+    // Install dependencies into $MASON_HOME/src
     var toParse = open("Mason.lock", iomode.r);
     var lockFile = parseToml(toParse);
     checkChplVersion(lockFile);

--- a/tools/mason/MasonHelp.chpl
+++ b/tools/mason/MasonHelp.chpl
@@ -89,9 +89,6 @@ proc masonBuildHelp() {
   writeln('    -h, --help                   Display this message');
   writeln('        --show                   Increase verbosity');
   writeln('        --release                Compile to target/release with optimizations (--fast)');
-  if developerMode {
-    writeln('        --debug                  Print debug information');
-  }
   writeln();
   writeln('When no options are provided, the following will take place:');
   writeln('   - Build from mason project if Mason.lock present');

--- a/tools/mason/MasonHelp.chpl
+++ b/tools/mason/MasonHelp.chpl
@@ -21,6 +21,7 @@
 /* A help module for the mason package manager */
 
 use Help;
+use MasonUtils;
 
 
 proc masonHelp() {
@@ -88,6 +89,9 @@ proc masonBuildHelp() {
   writeln('    -h, --help                   Display this message');
   writeln('        --show                   Increase verbosity');
   writeln('        --release                Compile to target/release with optimizations (--fast)');
+  if developerMode {
+    writeln('        --debug                  Print debug information');
+  }
   writeln();
   writeln('When no options are provided, the following will take place:');
   writeln('   - Build from mason project if Mason.lock present');
@@ -116,6 +120,9 @@ proc masonSearchHelp() {
   writeln();
   writeln("Usage:");
   writeln("    mason search [options] <query>");
+  if developerMode {
+    writeln('        --debug                 Print debug information');
+  }
   writeln();
   writeln("Options:");
   writeln("    -h, --help                  Display this message");

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -221,6 +221,3 @@ proc developerMode: bool {
   const env = getEnv("CHPL_DEVELOPER");
   return env != "";
 }
-
-
-

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -217,3 +217,10 @@ proc gitC(newDir, command, quiet=false) {
   return ret;
 }
 
+proc developerMode: bool {
+  const env = getEnv("CHPL_DEVELOPER");
+  return env != "";
+}
+
+
+


### PR DESCRIPTION
This PR fixes a bug where whitespace-separated strings were failing to parse when using the `TOML` module, e.g.

```toml
[foo]
key = "value with spaces"
```

This was observed for users utilizing the `[compopts]` field in the manifest file.

The fix involved updating the regular expressions for lexing single and double quotes in `TomlReader`.

Other changes include:

- Added an example `mason.toml` for `TOML` testing
- Added a `--debugTomlReader` flag for debugging `TomlReader` submodule
- Modified debug format for `TOML` module
- A few minor code cleanups

Testing passed for:

- [x] `test/mason/`
- [x] `test/module/packages/Toml/`