### PR TITLE
Add checks for trailing spaces to smokeTest

### DIFF
--- a/util/buildRelease/smokeTest
+++ b/util/buildRelease/smokeTest
@@ -45,6 +45,15 @@ if (( $num_tabs > 0 )) ; then
     exit 1
 fi
 
+# Need to clean up all of the trailing spaces before adding this
+# Check for trailing spaces
+#num_trailing_space_lines=$($CHPL_HOME/util/devel/lookForTrailingSpaces | wc -l)
+#if (( $num_trailing_space_lines > 0 )) ; then
+#    echo "Found $num_trailing_space_lines lines with trailing spaces :-("
+#    echo $($CHPL_HOME/util/devel/lookForTrailingSpaces)
+#    exit 1
+#fi
+
 # Check for standard C headers.
 standard_c_headers=$($CHPL_HOME/util/devel/grepstdchdrs || :)
 if [ -n "${standard_c_headers}" ] ; then

--- a/util/devel/lookForTrailingSpaces
+++ b/util/devel/lookForTrailingSpaces
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+#
+# either CHPL_HOME must be set or this must be run from the root chapel
+# directory
+#
+
+cd $CHPL_HOME >& /dev/null
+
+# Look for trailing spaces in files in compiler/runtime/modules.
+# Exclude the generated files bison-chapel.cpp and flex-chapel.cpp.
+git grep ' $' -- compiler ':!*bison-chapel.cpp' ':!*flex-chapel.cpp'
+git grep ' $' -- runtime
+git grep ' $' -- modules


### PR DESCRIPTION
Add checks for trailing spaces in compiler/runtime/modules to the smokeTest
script.  These checks are currently commented out because a lot of files
have lines with trailing spaces. Once those are cleaned up we can uncomment
the new code in smokeTest.

I verified that the new test is working by cleaning up the trailing spaces
across compiler/runtime/modules and running smokeTest with the new code
uncommented.

The trailing spaces can be cleaned up with the command:

```
for f in `util/devel/lookForTrailingSpaces | sed -e 's/:.*$//' | sort | uniq` ; do
  sed -i -e 's/  *$//' $f
  rm ${f}-e
  git add $f
done
```