### PR TITLE
Remove unnecessary autoCopy for reductions state

### DIFF
--- a/compiler/resolution/implementForallIntents.cpp
+++ b/compiler/resolution/implementForallIntents.cpp
@@ -1440,13 +1440,9 @@ static void propagateThroughYield(CallExpr* rcall,
           // within a param conditional on a not-taken branch.
           svar = new VarSymbol(intentArgName(ix, "shadowVarReduc"));
           svar->addFlag(FLAG_INSERT_AUTO_DESTROY);
-          VarSymbol* stemp  = newTemp("svrTmp");
           redRef1->insertBefore(new DefExpr(svar));
-          redRef1->insertBefore(new DefExpr(stemp));
           redRef1->insertBefore("'move'(%S, identity(%S,%S))",
-                                stemp, gMethodToken, parentOp);
-          redRef1->insertBefore("'move'(%S, chpl__autoCopy(%S))",
-                                svar, stemp);
+                                svar, gMethodToken, parentOp);
           redRef2->insertBefore("accumulate(%S,%S,%S)",
                                 gMethodToken, parentOp, svar);
           shadowVars[ix] = svar;

--- a/compiler/resolution/implementForallIntents2.cpp
+++ b/compiler/resolution/implementForallIntents2.cpp
@@ -606,13 +606,9 @@ static Symbol* shadowVarForReduceIntent(FIcontext& ctx,
   VarSymbol* rsvar = new VarSymbol(intentArgName(ix, "reduceShadowVar"));
   rsvar->addFlag(FLAG_INSERT_AUTO_DESTROY);
 
-  VarSymbol* stemp = newTemp("rsvTemp");
   ctx.anchor1->insertBefore(new DefExpr(rsvar));
-  ctx.anchor1->insertBefore(new DefExpr(stemp));
   ctx.anchor1->insertBefore("'move'(%S, identity(%S,%S))",
-                            stemp, gMethodToken, currOp);
-  ctx.anchor1->insertBefore("'move'(%S, chpl__autoCopy(%S))",
-                            rsvar, stemp);
+                            rsvar, gMethodToken, currOp);
 
   // Wrap it up at the end.
   ctx.anchor2->insertBefore("accumulate(%S,%S,%S)",


### PR DESCRIPTION
Initialization of the shadow variable for a reduce intent
included an autoCopy of the value returned by reduceOp.identity.

Valgrind paratest run shows that this is unnecessary,
i.e. it passes with the autoCopy removed.
So, making this change on master.

Testing: paratest on valgrind+quickstart configuration