### PR TITLE
Move PRIM_SIZEOF fixup from resolveMoveForRhsCallExpr to preFoldPrimOp

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5078,13 +5078,6 @@ static void resolveMoveForRhsCallExpr(CallExpr* call) {
     call->insertBefore(new CallExpr(PRIM_MOVE, tmp,     rhs->remove()));
     call->insertAtTail(new CallExpr(PRIM_CAST, lhsType, tmp));
 
-  } else if (rhs->isPrimitive(PRIM_SIZEOF) == true) {
-    // Fix up arg to sizeof(), as we may not have known the type earlier
-    SymExpr* sizeSym  = toSymExpr(rhs->get(1));
-    Type*    sizeType = sizeSym->symbol()->typeInfo();
-
-    rhs->replace(new CallExpr(PRIM_SIZEOF, sizeType->symbol));
-
   } else if (rhs->isPrimitive(PRIM_CAST_TO_VOID_STAR) == true) {
     if (isReferenceType(rhs->get(1)->typeInfo())) {
       // Add a dereference as needed, as we did not have complete

--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -933,6 +933,14 @@ static Expr* preFoldPrimOp(CallExpr* call) {
 
       call->insertAtTail(tmp);
     }
+  } else if (call->isPrimitive(PRIM_SIZEOF) == true) {
+    // Fix up arg to sizeof(), as we may not have known the type earlier
+    SymExpr* sizeSym  = toSymExpr(call->get(1));
+    Type*    sizeType = sizeSym->symbol()->typeInfo();
+
+    retval = new CallExpr(PRIM_SIZEOF, sizeType->symbol);
+    call->replace(retval);
+
   }
 
   return retval;


### PR DESCRIPTION
Since this fixup doesn't actually do anything with the PRIM_MOVE in which it is contained (it only modifies the RHS), it makes more sense in preFold than as a special case for resolveMove.

- [x] full local testing
- [x] hellos with CHPL_LOCALE_MODEL=numa

Reviewed by @noakesmichael - thanks!