### PR TITLE
Skip enum tests using enum constants > int on some compilers

### DIFF
--- a/test/types/enum/ferguson/dependent-uint.skipif
+++ b/test/types/enum/ferguson/dependent-uint.skipif
@@ -1,0 +1,5 @@
+# Only some compilers support enums with values larger than int.
+# Technically, such enums are not legal according to the C standard,
+# but it is a common C extension.
+CHPL_TARGET_COMPILER<=pgi
+CHPL_TARGET_COMPILER<=cray

--- a/test/types/enum/ferguson/enum-overflow.skipif
+++ b/test/types/enum/ferguson/enum-overflow.skipif
@@ -1,0 +1,5 @@
+# Only some compilers support enums with values larger than int.
+# Technically, such enums are not legal according to the C standard,
+# but it is a common C extension.
+CHPL_TARGET_COMPILER<=pgi
+CHPL_TARGET_COMPILER<=cray


### PR DESCRIPTION
Only some compilers support enums with values larger than int.
Technically, such enums are not legal according to the C standard,
but it is a common C extension.

I'm .skipif'ing the failing tests since this will not be an issue with the LLVM backend.