### PR TITLE
Organize test/modules follow-up

### DIFF
--- a/test/library/packages/LinearAlgebra/correctness/SKIPIF
+++ b/test/library/packages/LinearAlgebra/correctness/SKIPIF
@@ -1,1 +1,1 @@
-../../linearalgebra.skipif
+../../LinearAlgebra.skipif

--- a/test/library/packages/LinearAlgebra/performance/SKIPIF
+++ b/test/library/packages/LinearAlgebra/performance/SKIPIF
@@ -1,1 +1,1 @@
-../../linearalgebra.skipif
+../../LinearAlgebra.skipif

--- a/test/studies/hpcc/common/testProbSize.prediff
+++ b/test/studies/hpcc/common/testProbSize.prediff
@@ -2,7 +2,7 @@
 
 $hostname = `hostname -s`; chomp($hostname);
 
-$countMemoryDir="../../../modules/standard/memory/countMemory";
+$countMemoryDir="../../../library/standard/memory/countMemory";
 $countMemoryFile="$countMemoryDir/countMemory.$hostname.good";
 
 system("cd $countMemoryDir && ./countMemory.prediff");


### PR DESCRIPTION
- Fix `SKIPIF` reference path
- Fix cross-reference in `prediff`