### PR TITLE
Fix for memory leak on Blowfish tests

### DIFF
--- a/modules/packages/Crypto.chpl
+++ b/modules/packages/Crypto.chpl
@@ -713,6 +713,13 @@ proc bfEncrypt(plaintext: CryptoBuffer, key: CryptoBuffer, IV: CryptoBuffer, cip
      Standard(AES) cipher is used more in practice. Since, Blowfish is unpatented and placed
      in the public domain, it receives a decent amount of attention from the community.
 
+     .. note::
+
+       Since the key in Blowfish can be of various sizes, use a :chpl:class:`KDF` routine
+       to generate a secure-key with the recommended byte-size as 16 bytes. Also, the
+       initialization vector in Blowfish cipher should strictly be 8 bytes long.
+
+
      The `Blowfish` class supports 4 `chaining modes <https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation>`_:
 
      - ``cbc`` or `Cipher Block Chaining`

--- a/modules/packages/Crypto.chpl
+++ b/modules/packages/Crypto.chpl
@@ -650,25 +650,27 @@ proc bfEncrypt(plaintext: CryptoBuffer, key: CryptoBuffer, IV: CryptoBuffer, cip
     var plaintextData = plaintext.getBuffData();
     var plaintextLen = plaintext.getBuffSize();
 
-    var ciphertextLen = plaintextLen + 8; // block size length for blowfish
+    var ciphertextLen = plaintextLen + 8;
     var cipherDomain: domain(1) = {0..#ciphertextLen};
+    var updatedCipherLen: c_int = 0;
     var ciphertext: [cipherDomain] uint(8);
-    var updateCipherLen: c_int;
 
     EVP_EncryptInit_ex(ctx,
                        cipher,
                        c_nil: ENGINE_PTR,
                        c_ptrTo(keyData): c_ptr(c_uchar),
                        c_ptrTo(ivData): c_ptr(c_uchar));
+
     EVP_EncryptUpdate(ctx,
                       c_ptrTo(ciphertext): c_ptr(c_uchar),
                       c_ptrTo(ciphertextLen): c_ptr(c_int),
                       c_ptrTo(plaintextData): c_ptr(c_uchar),
                       plaintextLen: c_int);
+
     EVP_EncryptFinal_ex(ctx,
                         c_ptrTo(ciphertext[ciphertextLen..]): c_ptr(c_uchar),
-                        c_ptrTo(updateCipherLen): c_ptr(c_int));
-    cipherDomain = {0..#(ciphertextLen + updateCipherLen)};
+                        c_ptrTo(updatedCipherLen): c_ptr(c_int));
+    cipherDomain = {0..#(ciphertextLen + updatedCipherLen)};
     return ciphertext;
   }
 
@@ -745,22 +747,10 @@ proc bfEncrypt(plaintext: CryptoBuffer, key: CryptoBuffer, IV: CryptoBuffer, cip
         when "ecb"  do tmpCipher = EVP_bf_ecb();
         when "cfb"  do tmpCipher = EVP_bf_cfb();
         when "ofb"  do tmpCipher = EVP_bf_ofb();
-        otherwise do halt("The desired variant of Blowfish does not exist.");
+        otherwise do halt("The desired variant of Blowfish cipher does not exist.");
       }
       this.cipher = tmpCipher;
-      this.byteLen = 8;
       super.init();
-    }
-
-    /* This function returns the size in bytes of the key of the
-       Blowfish encryption algorithm. Returns the value `8`.
-
-       :return: Key length of Blowfish in bytes.
-       :rtype: `int`
-
-    */
-    proc getByteSize(): int {
-        return this.byteLen;
     }
 
     /* This is the 'Blowfish' encrypt routine that encrypts the user supplied message buffer
@@ -784,6 +774,15 @@ proc bfEncrypt(plaintext: CryptoBuffer, key: CryptoBuffer, IV: CryptoBuffer, cip
 
     */
     proc encrypt(plaintext: CryptoBuffer, key: CryptoBuffer, IV: CryptoBuffer): CryptoBuffer {
+      var ivLen = IV.getBuffSize();
+      var keyLen = key.getBuffSize();
+      if (ivLen != 8) {
+        halt("Blowfish cipher expects an IV of size 8 bytes.");
+      }
+
+      if (keyLen < 10) {
+        halt("Blowfish cipher expects a key of size greater than 10 bytes.");
+      }
       var encryptedPlaintext = bfEncrypt(plaintext, key, IV, this.cipher);
       var encryptedPlaintextBuff = new CryptoBuffer(encryptedPlaintext);
       return encryptedPlaintextBuff;

--- a/test/library/packages/Crypto/saru/blowfish/bfTest1.chpl
+++ b/test/library/packages/Crypto/saru/blowfish/bfTest1.chpl
@@ -6,8 +6,8 @@ proc main() {
   var msg = new CryptoBuffer("hello world");
 
   // static values assumed for testing purposes
-  var iv = new CryptoBuffer("iv");
-  var key = new CryptoBuffer("key");
+  var iv = new CryptoBuffer("12345678"); // should be exactly 8 bytes
+  var key = new CryptoBuffer("long keys are the best");
 
   writeln("MSG: ", msg.toHex());
 

--- a/test/library/packages/Crypto/saru/blowfish/bfTest1.good
+++ b/test/library/packages/Crypto/saru/blowfish/bfTest1.good
@@ -1,3 +1,3 @@
 MSG: 68 65 6c 6c 6f 20 77 6f 72 6c 64
-CT: d1 a1 ef 46 89 5a f8 cb 19 37 41 36 94 d7 ed 5c
+CT: 64 16 02 e7 e5 fd 4c b4 8b 46 bb e2 69 16 55 2b
 PT: 68 65 6c 6c 6f 20 77 6f 72 6c 64

--- a/test/library/packages/Crypto/saru/blowfish/bfTest2.chpl
+++ b/test/library/packages/Crypto/saru/blowfish/bfTest2.chpl
@@ -8,13 +8,13 @@ proc main(){
   /* Key Generation phase starts */
   var salt = new CryptoBuffer("random_salt");
   var hash = new Hash("SHA256");
-  var k = new KDF(a.getByteSize(), 1000, hash);
+  var k = new KDF(16, 1000, hash);
   var key = k.passKDF("random_key", salt);
   writeln("Generated Key: ", key.toHex());
   /* Key Generation phase ends */
 
   /* IV is manipulated to return the same encryption on every run (for testing purposes) */
-  var iv = new CryptoBuffer("iv");
+  var iv = new CryptoBuffer("iv123456");
   writeln("Generated IV: ", iv.toHex());
 
   /* The message to be encrypted */

--- a/test/library/packages/Crypto/saru/blowfish/bfTest2.good
+++ b/test/library/packages/Crypto/saru/blowfish/bfTest2.good
@@ -1,5 +1,5 @@
-Generated Key: c1 75 99 d8 24 84 cd a5
-Generated IV: 69 76
+Generated Key: c1 75 99 d8 24 84 cd a5 3f 23 a1 9a ba 6c 05 0f
+Generated IV: 69 76 31 32 33 34 35 36
 Original Message: 74 65 73 74 20 73 74 72 69 6e 67
-Obtained Ciphertext: c2 00 20 35 d0 bb 5d b9 a9 29 3a 5e c1 58 c4 fd
+Obtained Ciphertext: 97 fd a4 18 ad 0c 40 e5 43 fd eb aa 1a 7b e2 f6
 Obtained Plaintext: 74 65 73 74 20 73 74 72 69 6e 67


### PR DESCRIPTION
Apparently, Blowfish has certain restrictions on its key and IV sizes. Since the key size in blowfish is variable (recommended is 16 bytes), it is advised to use a key-derivation function with size 16 (as done in `bfTest2.chpl`). I'm also adding a note to the docs for the same. We can also strictly enforce a 16-byte key, just in case.

P.S: Sorry, for the huge delay. Was (and still am) stuck with a major release at work.