### PR TITLE
Update TOML tests PREDIFF

### DIFF
--- a/test/library/packages/TOML/BurntSushi/PREDIFF
+++ b/test/library/packages/TOML/BurntSushi/PREDIFF
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Find the --f argument
 for arg in $*; do

--- a/test/library/packages/TOML/BurntSushi/PREDIFF
+++ b/test/library/packages/TOML/BurntSushi/PREDIFF
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Find the --f argument
 for arg in $*; do


### PR DESCRIPTION
Update TOML test `PREDIFF` to use `bash` instead of `sh` to support `[[ ]]` built-ins.