### PR TITLE
Fix CHPL_LLVM=system compilation flags

### DIFF
--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -142,7 +142,7 @@ $(CHPL_MAKE_HOME)/configured-prefix:
 $(CONFIGURED_PREFIX_FILE): $(CHPL_MAKE_HOME)/configured-prefix
 	echo '"'`cat $(CHPL_MAKE_HOME)/configured-prefix`'"' \ > $(CONFIGURED_PREFIX_FILE)
 
-$(CLANG_SETTINGS_FILE):
+$(CLANG_SETTINGS_FILE): FORCE
 	echo '{"'$(CLANG_CC)'","'$(CLANG_CXX)'","'`$(CHPL_MAKE_HOME)/util/config/gather-clang-sysroot-arguments $(CLANG_CC)`'"}' | $(FIXPATH_CMD) > $(CLANG_SETTINGS_FILE)
 
 $(CHPL_CONFIG_CHECK): | $(CHPL_BIN_DIR)

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -131,6 +131,8 @@ CHPL_CONFIG_CHECK = $(CHPL_CONFIG_CHECK_DIR)/built-for
 
 UPDATE_BUILD_VERSION = $(CHPL_MAKE_HOME)/util/devel/updateBuildVersion
 
+CLEAN_TARGS += $(CLANG_SETTINGS_FILE)
+
 $(BUILD_VERSION_FILE): FORCE
 	@({ test -x $(CHPL_MAKE_HOME)/.git ; } && \
 	test -x $(UPDATE_BUILD_VERSION) && $(UPDATE_BUILD_VERSION) $@) || \
@@ -142,7 +144,7 @@ $(CHPL_MAKE_HOME)/configured-prefix:
 $(CONFIGURED_PREFIX_FILE): $(CHPL_MAKE_HOME)/configured-prefix
 	echo '"'`cat $(CHPL_MAKE_HOME)/configured-prefix`'"' \ > $(CONFIGURED_PREFIX_FILE)
 
-$(CLANG_SETTINGS_FILE): FORCE
+$(CLANG_SETTINGS_FILE):
 	echo '{"'$(CLANG_CC)'","'$(CLANG_CXX)'","'`$(CHPL_MAKE_HOME)/util/config/gather-clang-sysroot-arguments $(CLANG_CC)`'"}' | $(FIXPATH_CMD) > $(CLANG_SETTINGS_FILE)
 
 $(CHPL_CONFIG_CHECK): | $(CHPL_BIN_DIR)

--- a/doc/rst/technotes/llvm.rst
+++ b/doc/rst/technotes/llvm.rst
@@ -51,6 +51,11 @@ Note:
 * You can set the environment variable ``CHPL_LLVM_DEVELOPER``
   to request a debug build of LLVM.
 
+* The pre-built LLVM that Apple distributes for Macs does not include
+  the header files needed for Chapel to use CHPL_LLVM=system.
+  However, you can install a Mac Homebrew version of LLVM with, for
+  example, ``brew install llvm@4`` and then set CHPL_LLVM=system.
+
 ---------------------------
 Activating the LLVM support
 ---------------------------

--- a/third-party/llvm/Makefile.share-included
+++ b/third-party/llvm/Makefile.share-included
@@ -4,10 +4,10 @@ LLVM_CONFIG=$(LLVM_INSTALL_DIR)/bin/llvm-config
 
 # LLVM preprocessor flags (ie -Dbla and -Ibla) 
 ifndef LLVM_CONFIG_CXXFLAGS
-  export LLVM_CONFIG_CXXFLAGS=$(shell test -x $(LLVM_CONFIG) && $(LLVM_CONFIG) --cxxflags | sed 's/ -O[0-4s] / /' | sed 's/ -DNDEBUG / /')
+  export LLVM_CONFIG_CXXFLAGS=$(shell test -x $(LLVM_CONFIG) && $(LLVM_CONFIG) --cxxflags | awk -f $(THIRD_PARTY_DIR)/llvm/filter-llvm-config.awk)
 endif
 
 ifndef LLVM_CONFIG_CFLAGS
-  export LLVM_CONFIG_CFLAGS=$(shell test -x $(LLVM_CONFIG) && $(LLVM_CONFIG) --cflags | sed 's/ -O[0-4s] / /' | sed 's/ -DNDEBUG / /')
+  export LLVM_CONFIG_CFLAGS=$(shell test -x $(LLVM_CONFIG) && $(LLVM_CONFIG) --cflags | awk -f $(THIRD_PARTY_DIR)/llvm/filter-llvm-config.awk)
 endif
 

--- a/third-party/llvm/Makefile.share-system
+++ b/third-party/llvm/Makefile.share-system
@@ -18,11 +18,11 @@ endif
 
 # LLVM preprocessor flags (ie -Dbla and -Ibla) 
 ifndef LLVM_CONFIG_CXXFLAGS
-  export LLVM_CONFIG_CXXFLAGS=$(shell test -x $(LLVM_CONFIG) && $(LLVM_CONFIG) --cxxflags | sed 's/ -O[0-4s] / /' | sed 's/ -DNDEBUG / /' | sed 's/ -pedantic / /' | sed 's/ -W / /')
+  export LLVM_CONFIG_CXXFLAGS=$(shell test -x $(LLVM_CONFIG) && $(LLVM_CONFIG) --cxxflags | sed 's/ -O[0-4s] / /' | sed 's/ -DNDEBUG / /' | sed 's/ -pedantic / /' | sed 's/ -W / /' | sed 's/ -Wall / /')
 endif
 
 ifndef LLVM_CONFIG_CFLAGS
-  export LLVM_CONFIG_CFLAGS=$(shell test -x $(LLVM_CONFIG) && $(LLVM_CONFIG) --cflags | sed 's/ -O[0-4s] / /' | sed 's/ -DNDEBUG / /' | sed 's/ -pedantic/ /' | sed 's/ -W / /' )
+  export LLVM_CONFIG_CFLAGS=$(shell test -x $(LLVM_CONFIG) && $(LLVM_CONFIG) --cflags | sed 's/ -O[0-4s] / /' | sed 's/ -DNDEBUG / /' | sed 's/ -pedantic/ /' | sed 's/ -W / /' | sed 's/ -Wall / /')
 endif
 
 # Figure out which clang we are using

--- a/third-party/llvm/Makefile.share-system
+++ b/third-party/llvm/Makefile.share-system
@@ -18,11 +18,11 @@ endif
 
 # LLVM preprocessor flags (ie -Dbla and -Ibla) 
 ifndef LLVM_CONFIG_CXXFLAGS
-  export LLVM_CONFIG_CXXFLAGS=$(shell test -x $(LLVM_CONFIG) && $(LLVM_CONFIG) --cxxflags | sed 's/ -O[0-4s] / /' | sed 's/ -DNDEBUG / /' | sed 's/ -pedantic / /' | sed 's/ -W / /' | sed 's/ -Wall / /')
+  export LLVM_CONFIG_CXXFLAGS=$(shell test -x $(LLVM_CONFIG) && $(LLVM_CONFIG) --cxxflags | xargs -n 1 | awk -f $(THIRD_PARTY_DIR)/llvm/filter-llvm-config.awk | xargs)
 endif
 
 ifndef LLVM_CONFIG_CFLAGS
-  export LLVM_CONFIG_CFLAGS=$(shell test -x $(LLVM_CONFIG) && $(LLVM_CONFIG) --cflags | sed 's/ -O[0-4s] / /' | sed 's/ -DNDEBUG / /' | sed 's/ -pedantic/ /' | sed 's/ -W / /' | sed 's/ -Wall / /')
+  export LLVM_CONFIG_CFLAGS=$(shell test -x $(LLVM_CONFIG) && $(LLVM_CONFIG) --cflags | xargs -n 1 | awk -f $(THIRD_PARTY_DIR)/llvm/filter-llvm-config.awk | xargs)
 endif
 
 # Figure out which clang we are using

--- a/third-party/llvm/Makefile.share-system
+++ b/third-party/llvm/Makefile.share-system
@@ -27,7 +27,5 @@ endif
 
 # Figure out which clang we are using
 # if LLVM_CONFIG is e.g. llvm-config-3.7, we should use clang-3.7
-LLVM_CONFIG_NAME=$(notdir $(LLVM_CONFIG))
-CLANG_CC=$(subst llvm-config,clang,$(LLVM_CONFIG_NAME))
-CLANG_CXX=$(subst llvm-config,clang++,$(LLVM_CONFIG_NAME))
-
+CLANG_CC=$(subst llvm-config,clang,$(LLVM_CONFIG))
+CLANG_CXX=$(subst llvm-config,clang++,$(LLVM_CONFIG))

--- a/third-party/llvm/Makefile.share-system
+++ b/third-party/llvm/Makefile.share-system
@@ -18,11 +18,11 @@ endif
 
 # LLVM preprocessor flags (ie -Dbla and -Ibla) 
 ifndef LLVM_CONFIG_CXXFLAGS
-  export LLVM_CONFIG_CXXFLAGS=$(shell test -x $(LLVM_CONFIG) && $(LLVM_CONFIG) --cxxflags | xargs -n 1 | awk -f $(THIRD_PARTY_DIR)/llvm/filter-llvm-config.awk | xargs)
+  export LLVM_CONFIG_CXXFLAGS=$(shell test -x $(LLVM_CONFIG) && $(LLVM_CONFIG) --cxxflags | awk -f $(THIRD_PARTY_DIR)/llvm/filter-llvm-config.awk)
 endif
 
 ifndef LLVM_CONFIG_CFLAGS
-  export LLVM_CONFIG_CFLAGS=$(shell test -x $(LLVM_CONFIG) && $(LLVM_CONFIG) --cflags | xargs -n 1 | awk -f $(THIRD_PARTY_DIR)/llvm/filter-llvm-config.awk | xargs)
+  export LLVM_CONFIG_CFLAGS=$(shell test -x $(LLVM_CONFIG) && $(LLVM_CONFIG) --cflags | awk -f $(THIRD_PARTY_DIR)/llvm/filter-llvm-config.awk)
 endif
 
 # Figure out which clang we are using

--- a/third-party/llvm/filter-llvm-config.awk
+++ b/third-party/llvm/filter-llvm-config.awk
@@ -1,7 +1,9 @@
+BEGIN { RS=" " }
 /^-DNDEBUG$/ { next }
 /^-O[0-4s]?$/ { next }
 /^-pedantic$/ { next }
-/^-W.,/ { print }
-/^-Wno-/ { print }
+/^-W.,/ { printf " %s",$0 }
+/^-Wno-/ { printf " %s",$0 }
 /^-W/ { next }
-{ print }
+{ printf " %s",$0 }
+END { printf "\n" }

--- a/third-party/llvm/filter-llvm-config.awk
+++ b/third-party/llvm/filter-llvm-config.awk
@@ -1,0 +1,7 @@
+/^-DNDEBUG$/ { next }
+/^-O[0-4s]?$/ { next }
+/^-pedantic$/ { next }
+/^-W.,/ { print }
+/^-Wno-/ { print }
+/^-W/ { next }
+{ print }

--- a/third-party/llvm/find-llvm-config.sh
+++ b/third-party/llvm/find-llvm-config.sh
@@ -15,6 +15,7 @@ then
 elif command_exists llvm-config
 then
   command -v llvm-config
+# If llvm-config is not found by now, search the Mac Homebrew directories.
 elif command_exists /usr/local/opt/llvm@$PREFERRED_VERSION/bin/llvm-config
 then
   command -v /usr/local/opt/llvm@$PREFERRED_VERSION/bin/llvm-config

--- a/third-party/llvm/find-llvm-config.sh
+++ b/third-party/llvm/find-llvm-config.sh
@@ -2,6 +2,7 @@
 
 # takes in a single argument: the preferred version, e.g. 3.7
 PREFERRED_VERSION=$1
+PREFERRED_VERSION_MAJOR=`echo $1 | cut -d. -f1`
 
 command_exists()
 {
@@ -14,6 +15,15 @@ then
 elif command_exists llvm-config
 then
   command -v llvm-config
+elif command_exists /usr/local/opt/llvm@$PREFERRED_VERSION/bin/llvm-config
+then
+  command -v /usr/local/opt/llvm@$PREFERRED_VERSION/bin/llvm-config
+elif command_exists /usr/local/opt/llvm@$PREFERRED_VERSION_MAJOR/bin/llvm-config
+then
+  command -v /usr/local/opt/llvm@$PREFERRED_VERSION_MAJOR/bin/llvm-config
+elif command_exists /usr/local/opt/llvm/bin/llvm-config
+then
+  command -v /usr/local/opt/llvm/bin/llvm-config
 else
   echo missing-llvm-config
 fi


### PR DESCRIPTION
The command-line flags for compiling LLVM come from the tool `llvm-config`.  When using the system LLVM, `llvm-config` often reports flags that cause us problems, such as a `-Wall` flag in the wrong sequence for our purposes.

Makefile.share-system already filters out several undesired flags.  This change filters out all added warnings to prevent compilation errors when either CHPL_DEVELOPER or WARNINGS is set.

Also, cause a `make clean` to remove CLANG_SETTINGS so it gets reinitialized properly.

Support is added for Mac Homebrew compilations with CHPL_LLVM=system.