### PR TITLE
Type constr 1

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -1741,24 +1741,21 @@ void AggregateType::insertImplicitThis(FnSymbol*         fn,
   }
 }
 
-void AggregateType:: moveConstructorToOuter(FnSymbol* fn) {
-  Expr* insertPoint = symbol->defPoint;
+ArgSymbol* AggregateType::moveConstructorToOuter(FnSymbol* fn) {
+  Expr*      insertPoint = symbol->defPoint;
+  ArgSymbol* _mt         = new ArgSymbol(INTENT_BLANK, "_mt",   dtMethodToken);
+  ArgSymbol* retval      = new ArgSymbol(INTENT_BLANK, "outer", this);
 
-  // Remove the DefPoint for this constructor, add it to the outer
-  // class's method list.
   methods.add(fn);
 
-  fn->_outer = new ArgSymbol(INTENT_BLANK, "outer", this);
+  retval->addFlag(FLAG_GENERIC);
 
-  fn->_outer->addFlag(FLAG_GENERIC); // Arg expects a real object :-P.
+  fn->_outer = retval;
 
-  fn->insertFormalAtHead(new DefExpr(fn->_outer));
+  fn->insertFormalAtHead(new DefExpr(retval));
+  fn->insertFormalAtHead(new DefExpr(_mt));
 
-  fn->insertFormalAtHead(new DefExpr(new ArgSymbol(INTENT_BLANK,
-                                                   "_mt",
-                                                   dtMethodToken)));
   fn->addFlag(FLAG_METHOD);
-
   fn->addFlag(FLAG_METHOD_PRIMARY);
 
   while (isTypeSymbol(insertPoint->parentSymbol) == true) {
@@ -1766,6 +1763,8 @@ void AggregateType:: moveConstructorToOuter(FnSymbol* fn) {
   }
 
   insertPoint->insertBefore(fn->defPoint->remove());
+
+  return retval;
 }
 
 /************************************* | **************************************

--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -954,22 +954,28 @@ CallExpr* AggregateType::typeConstrSuperCall(FnSymbol* fn) const {
     retval = new CallExpr(parent->symbol->name);
 
     for_formals(formal, superTypeCtor) {
-      ArgSymbol* arg              = toArgSymbol(formal->copy());
-      bool       fieldInThisClass = false;
+      ArgSymbol* arg = toArgSymbol(formal->copy());
 
-      for_fields(sym, this) {
-        if (strcmp(sym->name, arg->name) == 0) {
-          fieldInThisClass = true;
-        }
-      }
-
-      if (fieldInThisClass == false) {
+      if (isFieldInThisClass(arg->name) == false) {
         arg->addFlag(FLAG_PARENT_FIELD);
 
         fn->insertFormalAtTail(arg);
 
         retval->insertAtTail(new SymExpr(arg));
       }
+    }
+  }
+
+  return retval;
+}
+
+bool AggregateType::isFieldInThisClass(const char* name) const {
+  bool retval = false;
+
+  for_fields(sym, this) {
+    if (strcmp(sym->name, name) == 0) {
+      retval = true;
+      break;
     }
   }
 

--- a/compiler/include/AggregateType.h
+++ b/compiler/include/AggregateType.h
@@ -173,6 +173,7 @@ private:
 
   FnSymbol*                   buildTypeConstructor();
   CallExpr*                   typeConstrSuperCall(FnSymbol* fn)          const;
+  bool                        isFieldInThisClass(const char* name)       const;
 
   void                        buildConstructor();
   bool                        needsConstructor();

--- a/compiler/include/AggregateType.h
+++ b/compiler/include/AggregateType.h
@@ -180,6 +180,10 @@ private:
   void                        typeConstrSetFields(FnSymbol* fn,
                                                   CallExpr* superCall)   const;
 
+  void                        typeConstrSetField(FnSymbol*  fn,
+                                                 VarSymbol* field,
+                                                 Expr*      expr)        const;
+
   void                        buildConstructor();
   bool                        needsConstructor();
   void                        moveConstructorToOuter(FnSymbol* fn);

--- a/compiler/include/AggregateType.h
+++ b/compiler/include/AggregateType.h
@@ -189,7 +189,7 @@ private:
 
   void                        buildConstructor();
   bool                        needsConstructor();
-  void                        moveConstructorToOuter(FnSymbol* fn);
+  ArgSymbol*                  moveConstructorToOuter(FnSymbol* fn);
 
   void                        fieldToArg(FnSymbol*              fn,
                                          std::set<const char*>& names,

--- a/compiler/include/AggregateType.h
+++ b/compiler/include/AggregateType.h
@@ -170,7 +170,10 @@ private:
                                           std::set<AggregateType*>& seen);
 
   AggregateType*              discoverParentAndCheck(Expr* storesName);
-  void                        buildTypeConstructor();
+
+  FnSymbol*                   buildTypeConstructor();
+  CallExpr*                   typeConstrSuperCall(FnSymbol* fn)          const;
+
   void                        buildConstructor();
   bool                        needsConstructor();
   void                        moveConstructorToOuter(FnSymbol* fn);

--- a/compiler/include/AggregateType.h
+++ b/compiler/include/AggregateType.h
@@ -184,6 +184,9 @@ private:
                                                  VarSymbol* field,
                                                  Expr*      expr)        const;
 
+  ArgSymbol*                  insertGenericArg(FnSymbol*  fn,
+                                               VarSymbol* field)         const;
+
   void                        buildConstructor();
   bool                        needsConstructor();
   void                        moveConstructorToOuter(FnSymbol* fn);

--- a/compiler/include/AggregateType.h
+++ b/compiler/include/AggregateType.h
@@ -172,8 +172,13 @@ private:
   AggregateType*              discoverParentAndCheck(Expr* storesName);
 
   FnSymbol*                   buildTypeConstructor();
+
   CallExpr*                   typeConstrSuperCall(FnSymbol* fn)          const;
+
   bool                        isFieldInThisClass(const char* name)       const;
+
+  void                        typeConstrSetFields(FnSymbol* fn,
+                                                  CallExpr* superCall)   const;
 
   void                        buildConstructor();
   bool                        needsConstructor();


### PR DESCRIPTION
Clarify business logic in AggregateType::buildTypeConstructor()

Before this PR the method AggregateType::buildTypeConstructor() was
several pages of convoluted code that obfuscated the steps being taken.

This PR consists of a handful of simple commits that implement simple
transformations that introduce several "helper" methods that partition
the logic.  However there is no change in business logic or behavior.

Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.
Tested with a portion of test/release for each configuration.

The individual commits were subjected to multiple paratests
during development and, of course, the final PR has passed a
single-locale paratest with -futures.  These help to confirm
that there is no impact on business logic.


