### PR TITLE
Enforce qualified refs after inlining

### DIFF
--- a/compiler/AST/astutil.cpp
+++ b/compiler/AST/astutil.cpp
@@ -1038,7 +1038,9 @@ static void setQualRef(Symbol* sym) {
       }
       sym->qual = q;
       if (ArgSymbol* arg = toArgSymbol(sym)) {
-        arg->intent = INTENT_REF;
+        if (arg->intent != INTENT_CONST_REF) {
+          arg->intent = INTENT_REF;
+        }
       }
     }
     sym->type = sym->getValType();

--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -1300,7 +1300,6 @@ CallExpr* createCast(BaseAST* src, BaseAST* toType)
   return expr;
 }
 
-
 QualifiedType CallExpr::qualType(void) {
   QualifiedType retval(NULL);
 
@@ -1310,12 +1309,14 @@ QualifiedType CallExpr::qualType(void) {
   } else if (isResolved()) {
     FnSymbol* fn = resolvedFunction();
     Qualifier q = QUAL_UNKNOWN;
-    if (fn->retTag == RET_VALUE) {
-      q = QUAL_VAL;
-    } else if (fn->retTag == RET_REF) {
+    if (fn->retType->isRef()) {
       q = QUAL_REF;
-    } else if (fn->retTag == RET_CONST_REF) {
-      q = QUAL_CONST_REF;
+    } else if (fn->retType->isWideRef()) {
+      q = QUAL_WIDE_REF;
+    } else if (fn->retTag == RET_VALUE) {
+      q = QUAL_VAL;
+    } else {
+      q = QUAL_UNKNOWN;
     }
     retval = QualifiedType(q, fn->retType);
 

--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -1308,7 +1308,16 @@ QualifiedType CallExpr::qualType(void) {
     retval = primitive->returnInfo(this);
 
   } else if (isResolved()) {
-    retval = QualifiedType(resolvedFunction()->retType);
+    FnSymbol* fn = resolvedFunction();
+    Qualifier q = QUAL_UNKNOWN;
+    if (fn->retTag == RET_VALUE) {
+      q = QUAL_VAL;
+    } else if (fn->retTag == RET_REF) {
+      q = QUAL_REF;
+    } else if (fn->retTag == RET_CONST_REF) {
+      q = QUAL_CONST_REF;
+    }
+    retval = QualifiedType(q, fn->retType);
 
   } else {
     retval = QualifiedType(dtUnknown);

--- a/compiler/AST/primitive.cpp
+++ b/compiler/AST/primitive.cpp
@@ -293,8 +293,7 @@ static QualifiedType
 returnInfoGetTupleMember(CallExpr* call) {
   AggregateType* ct = toAggregateType(call->get(1)->getValType());
   INT_ASSERT(ct && ct->symbol->hasFlag(FLAG_STAR_TUPLE));
-  // TODO: shouldn't we just return getField->qualType?
-  return QualifiedType(ct->getField("x1")->type, QUAL_VAL);
+  return ct->getField("x1")->qualType();
 }
 
 static QualifiedType

--- a/compiler/AST/primitive.cpp
+++ b/compiler/AST/primitive.cpp
@@ -331,7 +331,15 @@ returnInfoGetMemberRef(CallExpr* call) {
     if (imm->const_kind == NUM_KIND_INT)
     {
       int64_t i = imm->int_value();
-      field = ct->getField(i);
+      if (ct->symbol->hasFlag(FLAG_ITERATOR_CLASS)) {
+        // Handle a peculiar intra-pass state where we attempt to get the
+        // type of an iterator class field when what we really want is the
+        // type of the corresponding formal of the iterator function.
+        FnSymbol* fn = getTheIteratorFn(ct);
+        field = fn->getFormal(i);
+      } else {
+        field = ct->getField(i);
+      }
     }
     INT_ASSERT(field);
     retType = field->type->refType ? field->type->refType : field->type;

--- a/compiler/AST/primitive.cpp
+++ b/compiler/AST/primitive.cpp
@@ -293,6 +293,7 @@ static QualifiedType
 returnInfoGetTupleMember(CallExpr* call) {
   AggregateType* ct = toAggregateType(call->get(1)->getValType());
   INT_ASSERT(ct && ct->symbol->hasFlag(FLAG_STAR_TUPLE));
+  // TODO: shouldn't we just return getField->qualType?
   return QualifiedType(ct->getField("x1")->type, QUAL_VAL);
 }
 

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -1968,6 +1968,38 @@ adjustArgSymbolTypesForIntent(void)
   }
 }
 
+static void convertToRefTypes() {
+#define updateSymbols(SymType) \
+  forv_Vec(SymType, sym, g##SymType##s) { \
+    QualifiedType q = sym->qualType(); \
+    Type* type      = q.type(); \
+    if (q.isRef() && !q.isRefType()) { \
+      type = getOrMakeRefTypeDuringCodegen(type); \
+    } else if (q.isWideRef() && !q.isWideRefType()) { \
+      type = getOrMakeRefTypeDuringCodegen(type); \
+      type = getOrMakeWideTypeDuringCodegen(type); \
+    } \
+    sym->type = type; \
+    if (type->symbol->hasFlag(FLAG_REF)) { \
+      sym->qual = QUAL_REF; \
+    } else if (type->symbol->hasFlag(FLAG_WIDE_REF)) { \
+      sym->qual = QUAL_WIDE_REF; \
+    } \
+  }
+
+  updateSymbols(VarSymbol);
+  updateSymbols(ArgSymbol);
+  updateSymbols(ShadowVarSymbol);
+
+  forv_Vec(FnSymbol, fn, gFnSymbols) {
+    if (fn->getReturnSymbol()) {
+      fn->retType = fn->getReturnSymbol()->type;
+    }
+  }
+
+#undef updateSymbols
+}
+
 extern bool printCppLineno;
 debug_data *debug_info=NULL;
 
@@ -2035,47 +2067,7 @@ void codegen(void) {
 
   adjustArgSymbolTypesForIntent();
 
-  forv_Vec(VarSymbol, sym, gVarSymbols) {
-    QualifiedType q = sym->qualType();
-    Type* type      = q.type();
-
-    if (q.isRef() && !q.isRefType()) {
-      type = getOrMakeRefTypeDuringCodegen(type);
-    } else if (q.isWideRef() && !q.isWideRefType()) {
-      type = getOrMakeRefTypeDuringCodegen(type);
-      type = getOrMakeWideTypeDuringCodegen(type);
-    }
-
-    sym->type = type;
-    if (type->symbol->hasFlag(FLAG_REF)) {
-      sym->qual = QUAL_REF;
-    } else if (type->symbol->hasFlag(FLAG_WIDE_REF)) {
-      sym->qual = QUAL_WIDE_REF;
-    }
-  }
-  forv_Vec(ArgSymbol, sym, gArgSymbols) {
-    QualifiedType q = sym->qualType();
-    Type* type      = q.type();
-
-    if (q.isRef() && !q.isRefType()) {
-      type = getOrMakeRefTypeDuringCodegen(type);
-    } else if (q.isWideRef() && !q.isWideRefType()) {
-      type = getOrMakeRefTypeDuringCodegen(type);
-      type = getOrMakeWideTypeDuringCodegen(type);
-    }
-
-    sym->type = type;
-    if (type->symbol->hasFlag(FLAG_REF)) {
-      sym->qual = QUAL_REF;
-    } else if (type->symbol->hasFlag(FLAG_WIDE_REF)) {
-      sym->qual = QUAL_WIDE_REF;
-    }
-  }
-  forv_Vec(FnSymbol, fn, gFnSymbols) {
-    if (fn->getReturnSymbol()) {
-      fn->retType = fn->getReturnSymbol()->type;
-    }
-  }
+  convertToRefTypes();
 
   // Wrap calls to chosen functions from c library
   if( llvmCodegen ) {

--- a/compiler/include/astutil.h
+++ b/compiler/include/astutil.h
@@ -186,4 +186,6 @@ bool givesType(Symbol* sym);
 Symbol* getSvecSymbol(CallExpr* call);
 void collectUsedFnSymbols(BaseAST* ast, std::set<FnSymbol*>& fnSymbols);
 
+void convertToQualifiedRefs();
+
 #endif

--- a/compiler/main/checks.cpp
+++ b/compiler/main/checks.cpp
@@ -52,6 +52,7 @@ static void checkIsIterator(); // Ensure each iterator is flagged so.
 static void checkAggregateTypes(); // Checks that class and record types have
                                    // default initializers and default type
                                    // constructors.
+static void check_afterInlineFunctions();
 static void checkResolveRemovedPrims(void); // Checks that certain primitives
                                             // are removed after resolution
 static void checkNoRecordDeletes();  // No 'delete' on records.
@@ -279,6 +280,7 @@ void check_inlineFunctions()
   check_afterCallDestructors();
   check_afterLowerIterators();
   check_afterResolveIntents();
+  check_afterInlineFunctions();
 }
 
 void check_scalarReplace()
@@ -288,6 +290,7 @@ void check_scalarReplace()
   check_afterCallDestructors();
   check_afterLowerIterators();
   check_afterResolveIntents();
+  check_afterInlineFunctions();
   // Suggestion: Ensure no constant expressions.
 }
 
@@ -298,6 +301,7 @@ void check_refPropagation()
   check_afterCallDestructors();
   check_afterLowerIterators();
   check_afterResolveIntents();
+  check_afterInlineFunctions();
 }
 
 void check_copyPropagation()
@@ -307,6 +311,7 @@ void check_copyPropagation()
   check_afterCallDestructors();
   check_afterLowerIterators();
   check_afterResolveIntents();
+  check_afterInlineFunctions();
 }
 
 
@@ -317,6 +322,7 @@ void check_deadCodeElimination()
   check_afterCallDestructors();
   check_afterLowerIterators();
   check_afterResolveIntents();
+  check_afterInlineFunctions();
   // Suggestion: Ensure no dead code.
 }
 
@@ -327,6 +333,7 @@ void check_removeWrapRecords()
   check_afterCallDestructors();
   check_afterLowerIterators();
   check_afterResolveIntents();
+  check_afterInlineFunctions();
   // Suggestion: Ensure no more wrap records.
 }
 
@@ -337,6 +344,7 @@ void check_removeEmptyRecords()
   check_afterCallDestructors();
   check_afterLowerIterators();
   check_afterResolveIntents();
+  check_afterInlineFunctions();
   // Suggestion: Ensure no empty records.
 }
 
@@ -347,6 +355,7 @@ void check_localizeGlobals()
   check_afterCallDestructors();
   check_afterLowerIterators();
   check_afterResolveIntents();
+  check_afterInlineFunctions();
 }
 
 void check_loopInvariantCodeMotion()
@@ -356,6 +365,7 @@ void check_loopInvariantCodeMotion()
   check_afterCallDestructors();
   check_afterLowerIterators();
   check_afterResolveIntents();
+  check_afterInlineFunctions();
 }
 
 void check_prune2()
@@ -365,6 +375,7 @@ void check_prune2()
   check_afterCallDestructors();
   check_afterLowerIterators();
   check_afterResolveIntents();
+  check_afterInlineFunctions();
   // Suggestion: Ensure no dead classes or functions.
 }
 
@@ -375,6 +386,7 @@ void check_returnStarTuplesByRefArgs()
   check_afterCallDestructors();
   check_afterLowerIterators();
   check_afterResolveIntents();
+  check_afterInlineFunctions();
 }
 
 void check_insertWideReferences()
@@ -384,6 +396,7 @@ void check_insertWideReferences()
   check_afterCallDestructors();
   check_afterLowerIterators();
   check_afterResolveIntents();
+  check_afterInlineFunctions();
 }
 
 void check_optimizeOnClauses()
@@ -393,6 +406,7 @@ void check_optimizeOnClauses()
   check_afterCallDestructors();
   check_afterLowerIterators();
   check_afterResolveIntents();
+  check_afterInlineFunctions();
 }
 
 void check_addInitCalls()
@@ -402,6 +416,7 @@ void check_addInitCalls()
   check_afterCallDestructors();
   check_afterLowerIterators();
   check_afterResolveIntents();
+  check_afterInlineFunctions();
 }
 
 void check_insertLineNumbers()
@@ -410,6 +425,7 @@ void check_insertLineNumbers()
   check_afterNormalization();
   check_afterCallDestructors();
   check_afterLowerIterators();
+  check_afterInlineFunctions();
 }
 
 void check_denormalize() {
@@ -551,6 +567,20 @@ static void check_afterLowerIterators()
   checkLowerIteratorsRemovedPrims();
   if (fVerify)
     checkArgsAndLocals();
+}
+
+static void check_afterInlineFunctions() {
+  if (fVerify) {
+    forv_Vec(DefExpr, def, gDefExprs) {
+      Symbol* sym = def->sym;
+      if (isLcnSymbol(sym)) {
+        if (sym->type->symbol->hasFlag(FLAG_REF) ||
+            sym->type->symbol->hasFlag(FLAG_WIDE_REF)) {
+          INT_FATAL("Found reference type: %s[%d]\n", sym->cname, sym->id);
+        }
+      }
+    }
+  }
 }
 
 static void checkIsIterator() {

--- a/compiler/main/checks.cpp
+++ b/compiler/main/checks.cpp
@@ -573,7 +573,9 @@ static void check_afterInlineFunctions() {
   if (fVerify) {
     forv_Vec(DefExpr, def, gDefExprs) {
       Symbol* sym = def->sym;
-      if (isLcnSymbol(sym)) {
+      if (isLcnSymbol(sym) &&
+          def->parentSymbol != NULL && // symbol is in the tree
+          def->parentSymbol->hasFlag(FLAG_WIDE_REF) == false) {
         if (sym->type->symbol->hasFlag(FLAG_REF) ||
             sym->type->symbol->hasFlag(FLAG_WIDE_REF)) {
           INT_FATAL("Found reference type: %s[%d]\n", sym->cname, sym->id);

--- a/compiler/optimizations/inlineFunctions.cpp
+++ b/compiler/optimizations/inlineFunctions.cpp
@@ -45,6 +45,8 @@ static void inlineCleanup();
 ************************************** | *************************************/
 
 void inlineFunctions() {
+  convertToQualifiedRefs();
+
   compute_call_sites();
 
   updateRefCalls();

--- a/compiler/optimizations/localizeGlobals.cpp
+++ b/compiler/optimizations/localizeGlobals.cpp
@@ -68,8 +68,7 @@ void localizeGlobals() {
           SET_LINENO(se); // Set the se line number for output
           if (!local_global) {
             const char * newname = astr("local_", var->cname);
-            local_global = newTemp(newname, var->getValType());
-            local_global->qual = var->qualType().getQual();
+            local_global = newTemp(newname, var->qualType());
             fn->insertAtHead(new CallExpr(PRIM_MOVE, local_global, var));
             fn->insertAtHead(new DefExpr(local_global));
 

--- a/compiler/optimizations/localizeGlobals.cpp
+++ b/compiler/optimizations/localizeGlobals.cpp
@@ -68,7 +68,8 @@ void localizeGlobals() {
           SET_LINENO(se); // Set the se line number for output
           if (!local_global) {
             const char * newname = astr("local_", var->cname);
-            local_global = newTemp(newname, var->type);
+            local_global = newTemp(newname, var->getValType());
+            local_global->qual = var->qualType().getQual();
             fn->insertAtHead(new CallExpr(PRIM_MOVE, local_global, var));
             fn->insertAtHead(new DefExpr(local_global));
 

--- a/compiler/optimizations/refPropagation.cpp
+++ b/compiler/optimizations/refPropagation.cpp
@@ -199,7 +199,9 @@ eliminateSingleAssignmentReference(Map<Symbol*,Vec<SymExpr*>*>& defMap,
               ++s_ref_repl_count;
               addUse(useMap, se);
             } else {
-              VarSymbol* tmp = newTemp(parent->get(2)->qualType().toRef());
+              QualifiedType qt = parent->get(2)->qualType();
+              VarSymbol* tmp = newTemp(qt);
+              if (qt.isRef()) tmp->qual = QUAL_REF;
               parent->getStmtExpr()->insertBefore(new DefExpr(tmp));
               parent->getStmtExpr()->insertBefore(new CallExpr(PRIM_MOVE, tmp, parent->get(2)->remove()));
               SymExpr* se = toSymExpr(rhs->get(1)->copy());

--- a/compiler/optimizations/refPropagation.cpp
+++ b/compiler/optimizations/refPropagation.cpp
@@ -201,7 +201,6 @@ eliminateSingleAssignmentReference(Map<Symbol*,Vec<SymExpr*>*>& defMap,
             } else {
               QualifiedType qt = parent->get(2)->qualType();
               VarSymbol* tmp = newTemp(qt);
-              if (qt.isRef()) tmp->qual = QUAL_REF;
               parent->getStmtExpr()->insertBefore(new DefExpr(tmp));
               parent->getStmtExpr()->insertBefore(new CallExpr(PRIM_MOVE, tmp, parent->get(2)->remove()));
               SymExpr* se = toSymExpr(rhs->get(1)->copy());

--- a/compiler/optimizations/scalarReplace.cpp
+++ b/compiler/optimizations/scalarReplace.cpp
@@ -398,6 +398,7 @@ scalarReplaceRecord(AggregateType* ct, Symbol* sym) {
         return false;
       }
       if (parent->isPrimitive(PRIM_GET_MEMBER) ||
+          parent->isPrimitive(PRIM_SET_MEMBER) ||
           parent->isPrimitive(PRIM_GET_MEMBER_VALUE)) {
         // TODO: svec primitives?
         memberAccessed = true;

--- a/compiler/optimizations/scalarReplace.cpp
+++ b/compiler/optimizations/scalarReplace.cpp
@@ -351,12 +351,14 @@ static bool isHandledRecordUse(SymExpr* se) {
   } else if (call->isPrimitive(PRIM_SET_MEMBER) && call->get(1) == se) {
     ret = true;
   } else if (call->isPrimitive(PRIM_MOVE)) {
-    if (call->get(1) == se) {
-      ret = true;
-    } else if (call->get(1)->isRef() && se->isRef() == false) {
-      // If both sides of the move are refs, then the references alias. Ref
-      // aliases are not handled at this time.
-      ret = true;
+    INT_ASSERT(call->get(2) == se);
+    if (call->get(1)->isRef()) {
+      if (se->isRef() == false) {
+        // like a PRIM_ASSIGN: *(ref) = se;
+        ret = true;
+      }
+    } else {
+      ret = true; // var = se;
     }
   }
 

--- a/compiler/optimizations/scalarReplace.cpp
+++ b/compiler/optimizations/scalarReplace.cpp
@@ -388,7 +388,7 @@ scalarReplaceRecord(AggregateType* ct, Symbol* sym) {
   //
   // only scalar replace sym if:
   // - all of the uses are handled primitives
-  // - we access at least one member of 'sym. Otherwise there's no point
+  // - we access at least one member of sym. Otherwise there's no point
   //
   bool memberAccessed = false;
   for_uses(se, useMap, sym) {

--- a/compiler/passes/denormalize.cpp
+++ b/compiler/passes/denormalize.cpp
@@ -264,6 +264,8 @@ static bool isBadMove(CallExpr* ce) {
                (lhs->isRef() && rhs->isWideRef())) {
       // another wide-temporary convenience pattern
       ret = true;
+    } else if (isDerefMove(ce)) {
+      ret = true;
     }
   }
 
@@ -361,7 +363,6 @@ bool isDenormalizable(Symbol* sym,
                   ce->isPrimitive(PRIM_ARRAY_GET) ||
                   ce->isPrimitive(PRIM_GET_MEMBER) ||
                   ce->isPrimitive(PRIM_DEREF) ||
-                  isDerefMove(ce) ||
                   ce->isPrimitive(PRIM_GET_MEMBER_VALUE) ||
                   ce->isPrimitive(PRIM_RETURN) ||
                   (ce->isPrimitive(PRIM_ARRAY_SHIFT_BASE_POINTER) && ce->get(1) == se) ||

--- a/compiler/passes/denormalize.cpp
+++ b/compiler/passes/denormalize.cpp
@@ -338,6 +338,7 @@ bool isDenormalizable(Symbol* sym,
                   ce->isPrimitive(PRIM_ARRAY_GET) ||
                   ce->isPrimitive(PRIM_GET_MEMBER) ||
                   ce->isPrimitive(PRIM_DEREF) ||
+                  isDerefMove(ce) ||
                   ce->isPrimitive(PRIM_GET_MEMBER_VALUE) ||
                   ce->isPrimitive(PRIM_RETURN) ||
                   (ce->isPrimitive(PRIM_ARRAY_SHIFT_BASE_POINTER) && ce->get(1) == se) ||

--- a/compiler/passes/denormalize.cpp
+++ b/compiler/passes/denormalize.cpp
@@ -315,6 +315,7 @@ bool isDenormalizable(Symbol* sym,
           usePar = se->parentExpr;
           if(CallExpr* ce = toCallExpr(usePar)) {
             if( !(ce->isPrimitive(PRIM_ADDR_OF) ||
+                  ce->isPrimitive(PRIM_SET_REFERENCE) ||
                   // TODO: PRIM_SET_REFERENCE?
                   //
                   // TODO: BHARSH: I added PRIM_RETURN here after seeing a case

--- a/compiler/passes/denormalize.cpp
+++ b/compiler/passes/denormalize.cpp
@@ -247,6 +247,29 @@ void findCandidatesInFunc(FnSymbol *fn, UseDefCastMap& udcMap,
   findCandidatesInFuncOnlySym(fn, symSet, udcMap, analysisData);
 }
 
+static bool isBadMove(CallExpr* ce) {
+  bool ret = false;
+
+  if (ce->isPrimitive(PRIM_MOVE)) {
+    Expr* lhs = ce->get(1);
+    Expr* rhs = ce->get(2);
+    if (lhs->typeInfo() != rhs->typeInfo()) {
+      // Possible for shorthand/convenience moves where codegen will transform
+      // it into something else. For example:
+      //   (move myWideClass myNarrowClass)
+      // will create a wide temporary for 'myNarrowClass' and assign it to
+      // 'myWideClass'.
+      ret = true;
+    } else if ((lhs->isWideRef() && rhs->isRef()) ||
+               (lhs->isRef() && rhs->isWideRef())) {
+      // another wide-temporary convenience pattern
+      ret = true;
+    }
+  }
+
+  return ret;
+}
+
 bool isDenormalizable(Symbol* sym,
     SymExpr** useOut, Expr** defOut, Type** castTo,
     SafeExprAnalysis& analysisData) {
@@ -342,10 +365,8 @@ bool isDenormalizable(Symbol* sym,
                   ce->isPrimitive(PRIM_GET_MEMBER_VALUE) ||
                   ce->isPrimitive(PRIM_RETURN) ||
                   (ce->isPrimitive(PRIM_ARRAY_SHIFT_BASE_POINTER) && ce->get(1) == se) ||
-                  (ce->isPrimitive(PRIM_MOVE) &&
-                   ce->get(1)->typeInfo() !=
-                   ce->get(2)->typeInfo()) ||
-                   isFloatComparisonPrimitive(ce))) {
+                  isBadMove(ce) ||
+                  isFloatComparisonPrimitive(ce))) {
               use = se;
             }
           }

--- a/compiler/passes/insertWideReferences.cpp
+++ b/compiler/passes/insertWideReferences.cpp
@@ -2179,7 +2179,7 @@ static void fixAST() {
             if (!isFullyWide(lhs) && (hasSomeWideness(rhs->typeInfo()) || rhs->isWideRef())) {
               SET_LINENO(lhs);
 
-              VarSymbol* tmp = newTemp(getTupleField(rhs)->type);
+              VarSymbol* tmp = newTemp(getTupleField(rhs)->qualType());
               DEBUG_PRINTF("Temp %d for get_svec_member_value\n", tmp->id);
               call->insertBefore(new DefExpr(tmp));
               call->insertAfter(new CallExpr(PRIM_MOVE, lhs->copy(), tmp));

--- a/compiler/passes/insertWideReferences.cpp
+++ b/compiler/passes/insertWideReferences.cpp
@@ -851,7 +851,9 @@ static bool fieldCanBeWide(Symbol* field) {
 //
 static void widenSubAggregateTypes(BaseAST* cause, Type* parent) {
   for_fields(fi, toAggregateType(parent)) {
-    if (isRecord(fi->type) && canWidenRecord(fi) == false) {
+    if (fi->isRefOrWideRef() == false &&
+        isRecord(fi->type) &&
+        canWidenRecord(fi) == false) {
       widenSubAggregateTypes(cause, fi->type);
     } else {
       if (fieldCanBeWide(fi)) {
@@ -1493,7 +1495,8 @@ static void narrowWideClassesThroughCalls()
           SET_LINENO(call);
           stmt->insertBefore(new DefExpr(var));
 
-          if (narrowType.type()->symbol->hasFlag(FLAG_EXTERN)) {
+          if (narrowType.isRefOrWideRef() == false &&
+              narrowType.type()->symbol->hasFlag(FLAG_EXTERN)) {
 
             // Insert a local check because we cannot reflect any changes
             // made to the class back to another locale


### PR DESCRIPTION
### Summary

This PR adds functionality to --verify that enforces the use of qualified references after inlineFunctions. This PR also implements various changes to obey this new requirement.

At the start of inlineFunctions, regardless of whether inlining is enabled, all symbols with a _ref type are modified to use QUAL_REF and the symbol's type will be set to the corresponding 'val' type. This modification takes place in `convertToQualifiedRefs`. The same function also changes uses of PRIM_ADDR_OF to PRIM_SET_REFERENCE. After inlining, --verify will fail if any Symbols have a _ref type.

### Changes to Def/Use Analysis

As part of this change, the `isDefOrUse` helper function was updated with slightly different rules and was made easier to follow. The main change in behavior involves the following pattern:
```
(move someRefVar otherRefVar)
```
Previously this was considered both a `def` and a `use`. This PR alters the behavior of this function to recognize this pattern as a `def` of the LHS. PRIM_ASSIGN behaves the same as it did before.

### Changes to Optimization Passes

The `refPropagation` pass has been updated to handle the slightly-changed def-use rules by changing when a SymExpr is passed to `addUse` or `addDef`. Much of this could probably be avoided by using for_SymbolSymExprs.

The `scalarReplace` pass will no longer scalar replace something if its fields are never accessed directly. For example, assignment between two tuples of integers will no longer scalar-replace (assuming it was made to bulk-copy). Otherwise in multilocale we might perform a GET per element instead of a single bulk GET. Performance playground testing and a subset of 16-node-xc testing suggests that this has not hurt performance. Otherwise, minor changes were made to handle new def-use rules.

### Miscellaneous Minor Changes
- Codegen updated to improve readability of transition back to _ref types
- CallExpr::qualType() will not return QUAL_UNKNOWN for resolved functions
- Minor quirks in primitive.cpp ironed out to handle new patterns
- Various `newTemp` calls now use `qualType` instead of a `Type*`.
- Denormalize updated to better handle complicated PRIM_MOVE patterns
- IWR needed to use 'isRef' and 'isWideRef' instead of checking `Type*`.

### Testing
- [x] local --verify
- [x] gasnet --verify
- [x] baseline
- [x] --local performance
- [x] subset of 16-node-xc performance (ugni)