### PR TITLE
file.check throws

### DIFF
--- a/compiler/passes/errorHandling.cpp
+++ b/compiler/passes/errorHandling.cpp
@@ -622,8 +622,6 @@ static AList castToError(Symbol* error, SymExpr* &castedError) {
 
   if (error->type == dtError) {
     castedError = new SymExpr(error);
-
-    ret.insertAtTail(castedError);
   } else {
     VarSymbol* castedErrorVar = newTemp("castedError", dtError);
     castedError = new SymExpr(castedErrorVar);

--- a/compiler/passes/errorHandling.cpp
+++ b/compiler/passes/errorHandling.cpp
@@ -154,7 +154,7 @@ namespace {
 // Static class helper functions
 static bool catchesNotExhaustive(TryStmt* tryStmt);
 static bool shouldEnforceStrict(CallExpr* node);
-static Expr* castToError(Symbol* errorExpr);
+static AList castToError(Symbol* error, SymExpr* &castedError);
 
 class ErrorHandlingVisitor : public AstVisitorTraverse {
 
@@ -299,12 +299,15 @@ void ErrorHandlingVisitor::lowerCatches(const TryInfo& info) {
 
     BlockStmt* deferDeleteBody = new BlockStmt();
     DeferStmt* deferDelete     = new DeferStmt(deferDeleteBody);
-    CallExpr*  deleteError     = new CallExpr(gChplDeleteError,
-                                              castToError(toDelete));
+
+    SymExpr*   castedError     = NULL;
+    AList      castError       = castToError(toDelete, castedError);
+    CallExpr*  deleteError     = new CallExpr(gChplDeleteError, castedError);
     AList      deleteCond      = errorCond(toDelete,
                                            new BlockStmt(deleteError));
 
-    deferDeleteBody->insertAtHead(deleteCond);
+    deferDeleteBody->insertAtHead(castError);
+    deferDeleteBody->insertAtTail(deleteCond);
     catchBody->insertAtHead(deferDelete);
   }
 
@@ -384,9 +387,11 @@ bool ErrorHandlingVisitor::enterCallExpr(CallExpr* node) {
     VarSymbol* thrownError = toVarSymbol(thrownExpr->symbol());
 
     VarSymbol* fixedError  = newTemp("fixed_error", dtError);
-    CallExpr*  fixError    = new CallExpr(gChplFixThrownError,
-                                          castToError(thrownError));
+    SymExpr*   castedError = NULL;
+    AList      castError   = castToError(thrownError, castedError);
+    CallExpr*  fixError    = new CallExpr(gChplFixThrownError, castedError);
 
+    throwBlock->insertAtTail(castError);
     throwBlock->insertAtTail(new DefExpr(fixedError));
     throwBlock->insertAtTail(new CallExpr(PRIM_MOVE, fixedError, fixError));
 
@@ -489,12 +494,11 @@ void ErrorHandlingVisitor::exitForLoop(ForLoop* node) {
 // Sets the fn out variable with the given error, then goes to the fn epilogue.
 AList ErrorHandlingVisitor::setOutGotoEpilogue(VarSymbol* error) {
 
-  Expr* castError = castToError(error);
-
-  AList ret;
+  SymExpr* castedError = NULL;
+  AList    ret         = castToError(error, castedError);
   // Using PRIM_ASSIGN instead of PRIM_MOVE here to work around
   // errors that come up in C compilation.
-  ret.insertAtTail(new CallExpr(PRIM_ASSIGN, outError, castError));
+  ret.insertAtTail(new CallExpr(PRIM_ASSIGN, outError, castedError));
   ret.insertAtTail(new GotoStmt(GOTO_RETURN, epilogue));
 
   return ret;
@@ -515,10 +519,10 @@ GotoStmt* ErrorHandlingVisitor::gotoHandler() {
 AList ErrorHandlingVisitor::setOuterErrorAndGotoHandler(VarSymbol* error) {
 
   INT_ASSERT(!tryStack.empty());
-  Expr* castError = castToError(error);
-  TryInfo& outerTry = tryStack.top();
-  AList ret;
-  ret.insertAtTail(new CallExpr(PRIM_MOVE, outerTry.errorVar, castError));
+  TryInfo& outerTry    = tryStack.top();
+  SymExpr* castedError = NULL;
+  AList    ret         = castToError(error, castedError);
+  ret.insertAtTail(new CallExpr(PRIM_MOVE, outerTry.errorVar, castedError));
   ret.insertAtTail(gotoHandler());
 
   return ret;
@@ -613,15 +617,23 @@ static bool shouldEnforceStrict(CallExpr* node) {
 }
 
 
-static Expr* castToError(Symbol* error) {
-  Expr* castError = NULL;
+static AList castToError(Symbol* error, SymExpr* &castedError) {
+  AList ret;
 
-  if (error->type == dtError)
-    castError = new SymExpr(error);
-  else
-    castError = new CallExpr(PRIM_CAST, dtError->symbol, error);
+  if (error->type == dtError) {
+    castedError = new SymExpr(error);
 
-  return castError;
+    ret.insertAtTail(castedError);
+  } else {
+    VarSymbol* castedErrorVar = newTemp("castedError", dtError);
+    castedError = new SymExpr(castedErrorVar);
+
+    CallExpr* castError = new CallExpr(PRIM_CAST, dtError->symbol, error);
+    ret.insertAtTail(new DefExpr(castedErrorVar));
+    ret.insertAtTail(new CallExpr(PRIM_MOVE, castedErrorVar, castError));
+  }
+
+  return ret;
 }
 
 class ImplicitThrowsVisitor : public AstVisitorTraverse {

--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -1353,6 +1353,7 @@ proc sameFile(out error: syserr, file1: file, file2: file): bool {
 
   // If one of the files references a null file, exit early to avoid segfault.
   file1.check(error);
+  if error then return false;
   file2.check(error);
   if error then return false;
 

--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -1351,25 +1351,12 @@ proc sameFile(out error: syserr, file1: file, file2: file): bool {
   extern proc chpl_fs_samefile(ref ret: c_int, file1: qio_file_ptr_t,
                                file2: qio_file_ptr_t): syserr;
 
+  // If one of the files references a null file, exit early to avoid segfault.
+  file1.check(error);
+  file2.check(error);
+  if error then return false;
+
   var ret:c_int;
-  if (is_c_nil(file1._file_internal) || is_c_nil(file2._file_internal)) {
-    // Implementation note on program design tradeoffs:
-    // I could use file.check() here.  That would not rely on the understanding
-    // of file's internals.  However, it would cause this method to either
-    // return error messages or halt, depending on the error encountered.
-    // This check could be moved to the version w/o the err argument, but if
-    // someone called this function w/o going through that, we'd lose the
-    // check.  Also, we already must make use of the record internals to do the
-    // inner comparison (since the record is a chapel construct), so there's no
-    // additional harm.
-
-    // The file is referencing a null file.  We'll get a segfault if we
-    // continue.
-    error = EBADF;
-    return false; // This part isn't as important as the error.
-  }
-
-
   error = chpl_fs_samefile(ret, file1._file_internal, file2._file_internal);
   return ret != 0;
 }

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1307,7 +1307,7 @@ proc file.check() throws {
     throw SystemError.fromSyserr(EBADF, "Operation attempted on an invalid file");
 }
 
-/* Emit a syserr if a file is invalid */
+/* Return a syserr through out error if a file is invalid */
 proc file.check(out error:syserr) {
   try! {
     check();

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -2670,8 +2670,8 @@ proc file.lines(param locking:bool = true, start:int(64) = 0, end:int(64) = max(
 proc file.writer(out error:syserr, param kind=iokind.dynamic, param locking=true, start:int(64) = 0, end:int(64) = max(int(64)), hints:iohints = IOHINT_NONE, style:iostyle = this._style): channel(true,kind,locking) {
   check(error);
 
+  var ret:channel(true, kind, locking);
   if !error {
-    var ret:channel(true, kind, locking);
     on this.home {
       ret = new channel(true, kind, locking, this, error, hints, start, end, style);
     }

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1302,10 +1302,9 @@ proc =(ref ret:file, x:file) {
 }
 
 /* Halt if a file is invalid */
-proc file.check() {
-  if(is_c_nil(_file_internal)) {
-    halt("Operation attempted on an invalid file");
-  }
+proc file.check() throws {
+  if is_c_nil(_file_internal) then
+    throw new FileNotFoundError("Operation attempted on an invalid file");
 }
 
 pragma "no doc"
@@ -1337,7 +1336,7 @@ proc file.unlock() {
 // channel style is protected by channel lock, can be modified.
 pragma "no doc"
 proc file._style:iostyle {
-  check();
+  try! check();
 
   var ret:iostyle;
   on this.home {
@@ -1375,7 +1374,7 @@ proc file._style:iostyle {
                will halt with an error message.
  */
 proc file.close(out error:syserr) {
-  check();
+  try! check();
   on this.home {
     error = qio_file_close(_file_internal);
   }
@@ -1405,7 +1404,7 @@ This function will typically call the ``fsync`` system call.
 
  */
 proc file.fsync(out error:syserr) {
-  check();
+  try! check();
   on this.home {
     error = qio_file_sync(_file_internal);
   }
@@ -1436,7 +1435,7 @@ to get the path to a file.
 
  */
 proc file.getPath(out error:syserr) : string {
-  check();
+  try! check();
   var ret:string;
   on this.home {
     var tmp:c_string_copy;
@@ -2531,7 +2530,7 @@ proc openwriter(path:string="", param kind=iokind.dynamic, param locking=true,
 // if the error code is nonzero.
 // The return error code should be checked to avoid double-deletion errors.
 proc file.reader(out error:syserr, param kind=iokind.dynamic, param locking=true, start:int(64) = 0, end:int(64) = max(int(64)), hints:iohints = IOHINT_NONE, style:iostyle = this._style): channel(false, kind, locking) {
-  check();
+  try! check();
 
   var ret:channel(false, kind, locking);
   on this.home {
@@ -2557,7 +2556,7 @@ proc file.reader(param kind=iokind.dynamic, param locking=true, start:int(64) = 
    :returns: an object which yields strings read from the file
  */
 proc file.lines(out error:syserr, param locking:bool = true, start:int(64) = 0, end:int(64) = max(int(64)), hints:iohints = IOHINT_NONE, in local_style:iostyle = this._style) {
-  check();
+  try! check();
 
   local_style.string_format = QIO_STRING_FORMAT_TOEND;
   local_style.string_end = 0x0a; // '\n'
@@ -2631,7 +2630,7 @@ proc file.lines(param locking:bool = true, start:int(64) = 0, end:int(64) = max(
 // If the return error code is nonzero, the ref count will be 0 not 1.
 // The error code should be checked to avoid double-deletion errors.
 proc file.writer(out error:syserr, param kind=iokind.dynamic, param locking=true, start:int(64) = 0, end:int(64) = max(int(64)), hints:iohints = IOHINT_NONE, style:iostyle = this._style): channel(true,kind,locking) {
-  check();
+  try! check();
 
   var ret:channel(true, kind, locking);
   on this.home {

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1335,8 +1335,8 @@ proc file.unlock() {
 // this prevents race conditions;
 // channel style is protected by channel lock, can be modified.
 pragma "no doc"
-proc file._style:iostyle {
-  try! check();
+proc file._style:iostyle throws {
+  try check();
 
   var ret:iostyle;
   on this.home {
@@ -1373,8 +1373,8 @@ proc file._style:iostyle {
                is not provided and an error is encountered, this function
                will halt with an error message.
  */
-proc file.close(out error:syserr) {
-  try! check();
+proc file.close(out error:syserr) throws {
+  try check();
   on this.home {
     error = qio_file_close(_file_internal);
   }
@@ -1403,8 +1403,8 @@ This function will typically call the ``fsync`` system call.
             will halt with an error message.
 
  */
-proc file.fsync(out error:syserr) {
-  try! check();
+proc file.fsync(out error:syserr) throws {
+  try check();
   on this.home {
     error = qio_file_sync(_file_internal);
   }
@@ -1434,8 +1434,8 @@ to get the path to a file.
             will halt with an error message.
 
  */
-proc file.getPath(out error:syserr) : string {
-  try! check();
+proc file.getPath(out error:syserr) : string throws {
+  try check();
   var ret:string;
   on this.home {
     var tmp:c_string_copy;
@@ -2529,8 +2529,8 @@ proc openwriter(path:string="", param kind=iokind.dynamic, param locking=true,
 // It is the responsibility of the caller to release the returned channel
 // if the error code is nonzero.
 // The return error code should be checked to avoid double-deletion errors.
-proc file.reader(out error:syserr, param kind=iokind.dynamic, param locking=true, start:int(64) = 0, end:int(64) = max(int(64)), hints:iohints = IOHINT_NONE, style:iostyle = this._style): channel(false, kind, locking) {
-  try! check();
+proc file.reader(out error:syserr, param kind=iokind.dynamic, param locking=true, start:int(64) = 0, end:int(64) = max(int(64)), hints:iohints = IOHINT_NONE, style:iostyle = this._style): channel(false, kind, locking) throws {
+  try check();
 
   var ret:channel(false, kind, locking);
   on this.home {
@@ -2555,8 +2555,8 @@ proc file.reader(param kind=iokind.dynamic, param locking=true, start:int(64) = 
                will halt with an error message.
    :returns: an object which yields strings read from the file
  */
-proc file.lines(out error:syserr, param locking:bool = true, start:int(64) = 0, end:int(64) = max(int(64)), hints:iohints = IOHINT_NONE, in local_style:iostyle = this._style) {
-  try! check();
+proc file.lines(out error:syserr, param locking:bool = true, start:int(64) = 0, end:int(64) = max(int(64)), hints:iohints = IOHINT_NONE, in local_style:iostyle = this._style) throws {
+  try check();
 
   local_style.string_format = QIO_STRING_FORMAT_TOEND;
   local_style.string_end = 0x0a; // '\n'
@@ -2629,8 +2629,8 @@ proc file.lines(param locking:bool = true, start:int(64) = 0, end:int(64) = max(
 // channel.
 // If the return error code is nonzero, the ref count will be 0 not 1.
 // The error code should be checked to avoid double-deletion errors.
-proc file.writer(out error:syserr, param kind=iokind.dynamic, param locking=true, start:int(64) = 0, end:int(64) = max(int(64)), hints:iohints = IOHINT_NONE, style:iostyle = this._style): channel(true,kind,locking) {
-  try! check();
+proc file.writer(out error:syserr, param kind=iokind.dynamic, param locking=true, start:int(64) = 0, end:int(64) = max(int(64)), hints:iohints = IOHINT_NONE, style:iostyle = this._style): channel(true,kind,locking) throws {
+  try check();
 
   var ret:channel(true, kind, locking);
   on this.home {

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1309,11 +1309,13 @@ proc file.check() throws {
 
 /* Return a syserr through out error if a file is invalid */
 proc file.check(out error:syserr) {
+  var err: syserr = ENOERR;
   try! {
     check();
   } catch e: SystemError {
-    error = e.err;
+    err = e.err;
   }
+  error = err;
 }
 
 pragma "no doc"

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -2567,8 +2567,10 @@ proc file.reader(out error:syserr, param kind=iokind.dynamic, param locking=true
   check(error);
 
   var ret:channel(false, kind, locking);
-  on this.home {
-    ret = new channel(false, kind, locking, this, error, hints, start, end, style);
+  if !error {
+    on this.home {
+      ret = new channel(false, kind, locking, this, error, hints, start, end, style);
+    }
   }
   return ret;
 }
@@ -2597,9 +2599,11 @@ proc file.lines(out error:syserr, param locking:bool = true, start:int(64) = 0, 
   param kind = iokind.dynamic;
   var ret:ItemReader(string, kind, locking);
 
-  on this.home {
-    var ch = new channel(false, kind, locking, this, error, hints, start, end, local_style);
-    ret = new ItemReader(string, kind, locking, ch);
+  if !error {
+    on this.home {
+      var ch = new channel(false, kind, locking, this, error, hints, start, end, local_style);
+      ret = new ItemReader(string, kind, locking, ch);
+    }
   }
   return ret;
 }
@@ -2666,9 +2670,11 @@ proc file.lines(param locking:bool = true, start:int(64) = 0, end:int(64) = max(
 proc file.writer(out error:syserr, param kind=iokind.dynamic, param locking=true, start:int(64) = 0, end:int(64) = max(int(64)), hints:iohints = IOHINT_NONE, style:iostyle = this._style): channel(true,kind,locking) {
   check(error);
 
-  var ret:channel(true, kind, locking);
-  on this.home {
-    ret = new channel(true, kind, locking, this, error, hints, start, end, style);
+  if !error {
+    var ret:channel(true, kind, locking);
+    on this.home {
+      ret = new channel(true, kind, locking, this, error, hints, start, end, style);
+    }
   }
   return ret;
 }

--- a/modules/standard/Path.chpl
+++ b/modules/standard/Path.chpl
@@ -204,14 +204,10 @@ proc file.realPath(): string throws {
 
    var ret: string = "unknown";
    if !error {
-     writeln("passed check");
      var tmp: string;
      tmp = this.realPath(error);
-     //if !error then
-     if !error {
-       writeln("passed realPath");
+     if !error then
        ret = dirname(new string(tmp));
-     }
    }
    return ret;
  }

--- a/modules/standard/Path.chpl
+++ b/modules/standard/Path.chpl
@@ -200,12 +200,19 @@ proc file.realPath(): string throws {
  */
  pragma "no doc"
  proc file.getParentName(out error:syserr): string {
-   check();
-   var ret: string;
-   var tmp: string;
-   tmp = this.realPath(error);
-   ret = if error then "unknown"
-                  else dirname(new string(tmp));
+   check(error);
+
+   var ret: string = "unknown";
+   if !error {
+     writeln("passed check");
+     var tmp: string;
+     tmp = this.realPath(error);
+     //if !error then
+     if !error {
+       writeln("passed realPath");
+       ret = dirname(new string(tmp));
+     }
+   }
    return ret;
  }
 

--- a/modules/standard/SysError.chpl
+++ b/modules/standard/SysError.chpl
@@ -135,7 +135,7 @@ class SystemError : Error {
 
 */
 class BlockingIOError : SystemError {
-  proc init(details: string = "", err: syserr = EWOULDBLOCK) {
+  proc init(details: string = "", err: syserr = EWOULDBLOCK:syserr) {
     super.init(err, details);
   }
 }
@@ -147,7 +147,7 @@ class BlockingIOError : SystemError {
 
 */
 class ChildProcessError : SystemError {
-  proc init(details: string = "", err: syserr = ECHILD) {
+  proc init(details: string = "", err: syserr = ECHILD:syserr) {
     super.init(err, details);
   }
 }
@@ -168,7 +168,7 @@ class ConnectionError : SystemError { }
 
 */
 class BrokenPipeError : ConnectionError {
-  proc init(details: string = "", err: syserr = EPIPE) {
+  proc init(details: string = "", err: syserr = EPIPE:syserr) {
     super.init(err, details);
   }
 }
@@ -180,7 +180,7 @@ class BrokenPipeError : ConnectionError {
 
 */
 class ConnectionAbortedError : ConnectionError {
-  proc init(details: string = "", err: syserr = ECONNABORTED) {
+  proc init(details: string = "", err: syserr = ECONNABORTED:syserr) {
     super.init(err, details);
   }
 }
@@ -192,7 +192,7 @@ class ConnectionAbortedError : ConnectionError {
 
 */
 class ConnectionRefusedError : ConnectionError {
-  proc init(details: string = "", err: syserr = ECONNREFUSED) {
+  proc init(details: string = "", err: syserr = ECONNREFUSED:syserr) {
     super.init(err, details);
   }
 }
@@ -204,7 +204,7 @@ class ConnectionRefusedError : ConnectionError {
 
 */
 class ConnectionResetError : ConnectionError {
-  proc init(details: string = "", err: syserr = ECONNRESET) {
+  proc init(details: string = "", err: syserr = ECONNRESET:syserr) {
     super.init(err, details);
   }
 }
@@ -216,7 +216,7 @@ class ConnectionResetError : ConnectionError {
 
 */
 class FileExistsError : SystemError {
-  proc init(details: string = "", err: syserr = EEXIST) {
+  proc init(details: string = "", err: syserr = EEXIST:syserr) {
     super.init(err, details);
   }
 }
@@ -228,7 +228,7 @@ class FileExistsError : SystemError {
 
 */
 class FileNotFoundError : SystemError {
-  proc init(details: string = "", err: syserr = ENOENT) {
+  proc init(details: string = "", err: syserr = ENOENT:syserr) {
     super.init(err, details);
   }
 }
@@ -240,7 +240,7 @@ class FileNotFoundError : SystemError {
 
 */
 class InterruptedError : SystemError {
-  proc init(details: string = "", err: syserr = EINTR) {
+  proc init(details: string = "", err: syserr = EINTR:syserr) {
     super.init(err, details);
   }
 }
@@ -252,7 +252,7 @@ class InterruptedError : SystemError {
 
 */
 class IsADirectoryError : SystemError {
-  proc init(details: string = "", err: syserr = EISDIR) {
+  proc init(details: string = "", err: syserr = EISDIR:syserr) {
     super.init(err, details);
   }
 }
@@ -264,7 +264,7 @@ class IsADirectoryError : SystemError {
 
 */
 class NotADirectoryError : SystemError {
-  proc init(details: string = "", err: syserr = ENOTDIR) {
+  proc init(details: string = "", err: syserr = ENOTDIR:syserr) {
     super.init(err, details);
   }
 }
@@ -276,7 +276,7 @@ class NotADirectoryError : SystemError {
 
 */
 class PermissionError : SystemError {
-  proc init(details: string = "", err: syserr = EPERM) {
+  proc init(details: string = "", err: syserr = EPERM:syserr) {
     super.init(err, details);
   }
 }
@@ -288,7 +288,7 @@ class PermissionError : SystemError {
 
 */
 class ProcessLookupError : SystemError {
-  proc init(details: string = "", err: syserr = ESRCH) {
+  proc init(details: string = "", err: syserr = ESRCH:syserr) {
     super.init(err, details);
   }
 }
@@ -300,7 +300,7 @@ class ProcessLookupError : SystemError {
 
 */
 class TimeoutError : SystemError {
-  proc init(details: string = "", err: syserr = ETIMEDOUT) {
+  proc init(details: string = "", err: syserr = ETIMEDOUT:syserr) {
     super.init(err, details);
   }
 }
@@ -323,7 +323,7 @@ class IOError : SystemError { }
 
 */
 class EOFError : IOError {
-  proc init(details: string = "", err: syserr = EEOF) {
+  proc init(details: string = "", err: syserr = EEOF:syserr) {
     super.init(err, details);
   }
 }
@@ -335,7 +335,7 @@ class EOFError : IOError {
 
 */
 class UnexpectedEOFError : IOError {
-  proc init(details: string = "", err: syserr = ESHORT) {
+  proc init(details: string = "", err: syserr = ESHORT:syserr) {
     super.init(err, details);
   }
 }
@@ -347,7 +347,7 @@ class UnexpectedEOFError : IOError {
 
 */
 class BadFormatError : IOError {
-  proc init(details: string = "", err: syserr = EFORMAT) {
+  proc init(details: string = "", err: syserr = EFORMAT:syserr) {
     super.init(err, details);
   }
 }

--- a/test/io/marybeth/testreadln5.good
+++ b/test/io/marybeth/testreadln5.good
@@ -1,1 +1,3 @@
-testreadln5.chpl:3: error: halt reached - Operation attempted on an invalid file
+uncaught SystemError: Bad file descriptor (Operation attempted on an invalid file)
+  testreadln5.chpl:3: thrown here
+  testreadln5.chpl:3: uncaught here

--- a/test/library/standard/FileSystem/lydia/sameFile/givenNull.good
+++ b/test/library/standard/FileSystem/lydia/sameFile/givenNull.good
@@ -1,1 +1,3 @@
-givenNull.chpl:7: error: halt reached - Operation attempted on an invalid file
+uncaught SystemError: Bad file descriptor (in file.path)
+  givenNull.chpl:7: thrown here
+  givenNull.chpl:7: uncaught here

--- a/test/library/standard/FileSystem/lydia/sameFile/givenNull2.good
+++ b/test/library/standard/FileSystem/lydia/sameFile/givenNull2.good
@@ -1,1 +1,3 @@
-givenNull2.chpl:7: error: halt reached - Operation attempted on an invalid file
+uncaught SystemError: Bad file descriptor (in file.path)
+  givenNull2.chpl:7: thrown here
+  givenNull2.chpl:7: uncaught here

--- a/test/library/standard/FileSystem/lydia/sameFile/givenNull3.good
+++ b/test/library/standard/FileSystem/lydia/sameFile/givenNull3.good
@@ -1,1 +1,3 @@
-givenNull3.chpl:6: error: halt reached - Operation attempted on an invalid file
+uncaught SystemError: Bad file descriptor (in file.path)
+  givenNull3.chpl:6: thrown here
+  givenNull3.chpl:6: uncaught here

--- a/test/types/file/closedWithoutOpen.good
+++ b/test/types/file/closedWithoutOpen.good
@@ -1,1 +1,3 @@
-closedWithoutOpen.chpl:3: error: halt reached - Operation attempted on an invalid file
+uncaught SystemError: Bad file descriptor (in file.close with path "unknown")
+  closedWithoutOpen.chpl:3: thrown here
+  closedWithoutOpen.chpl:3: uncaught here

--- a/test/types/file/freadIntUnopenedFile.good
+++ b/test/types/file/freadIntUnopenedFile.good
@@ -1,1 +1,3 @@
-freadIntUnopenedFile.chpl:4: error: halt reached - Operation attempted on an invalid file
+uncaught SystemError: Bad file descriptor (Operation attempted on an invalid file)
+  freadIntUnopenedFile.chpl:4: thrown here
+  freadIntUnopenedFile.chpl:4: uncaught here


### PR DESCRIPTION
@mppf pointed out that `file.check()` was halting when it should throw. It has been updated to throw a `FileNotFoundError`.

In order to build a `FileNotFoundError` with just a string, it was necessary to add a cast to its constructor's default `syserr` argument. This was repeated across all `SystemError` subtypes. (There may be a better way to achieve this coercion.)

- [x] passes linux64+flat testing