### PR TITLE
Avoid premature primitive type errors in normalize

### DIFF
--- a/compiler/include/typeSpecifier.h
+++ b/compiler/include/typeSpecifier.h
@@ -30,8 +30,9 @@ class Type;
 // fatalOK: This argument indicates whether it is reasonable for the
 // routine to issue a fatal error when the type expression is found
 // to be illegal (e.g., 'int(3)').  Calls early in the compiler
-// working on code that may later be folded out or unreachable should
-// set this to 'false' to avoid issuing errors prematurely.
+// working on code that may later be folded out or found to be
+// unreachable should set this to 'false' to avoid issuing errors
+// prematurely.
 //
 Type* typeForTypeSpecifier(Expr* expr, bool fatalOK = true);
 

--- a/compiler/include/typeSpecifier.h
+++ b/compiler/include/typeSpecifier.h
@@ -23,6 +23,16 @@
 class Expr;
 class Type;
 
-Type* typeForTypeSpecifier(Expr* expr);
+//
+// Convert a type specifier expression, 'expr' into a Type* if
+// possible; return NULL otherwise.
+//
+// fatalOK: This argument indicates whether it is reasonable for the
+// routine to issue a fatal error when the type expression is found
+// to be illegal (e.g., 'int(3)').  Calls early in the compiler
+// working on code that may later be folded out or unreachable should
+// set this to 'false' to avoid issuing errors prematurely.
+//
+Type* typeForTypeSpecifier(Expr* expr, bool fatalOK = true);
 
 #endif

--- a/compiler/passes/initializerRules.cpp
+++ b/compiler/passes/initializerRules.cpp
@@ -78,7 +78,7 @@ void preNormalizeFields(AggregateType* at) {
       Type* type = NULL;
 
       if (Expr* typeExpr = defExpr->exprType) {
-        type = typeForTypeSpecifier(typeExpr);
+        type = typeForTypeSpecifier(typeExpr, false);
 
         // var x, y : Foo
         //   =>

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -2036,7 +2036,7 @@ static void normVarTypeInference(DefExpr* defExpr) {
 static void normVarTypeWoutInit(DefExpr* defExpr) {
   Symbol* var      = defExpr->sym;
   Expr*   typeExpr = defExpr->exprType->remove();
-  Type*   type     = typeForTypeSpecifier(typeExpr);
+  Type*   type     = typeForTypeSpecifier(typeExpr, false);
 
   // Noakes 2016/02/02
   // The code for resolving the type of an extern variable
@@ -2097,7 +2097,7 @@ static void normVarTypeWithInit(DefExpr* defExpr) {
   Symbol* var      = defExpr->sym;
   Expr*   typeExpr = defExpr->exprType->remove();
   Expr*   initExpr = defExpr->init->remove();
-  Type*   type     = typeForTypeSpecifier(typeExpr);
+  Type*   type     = typeForTypeSpecifier(typeExpr, false);
 
   // Note: the above line will not obtain a type if the typeExpr is a CallExpr
   // for a generic record or class, as that is a more complicated set of AST.

--- a/compiler/resolution/typeSpecifier.cpp
+++ b/compiler/resolution/typeSpecifier.cpp
@@ -24,7 +24,7 @@
 
 static int typeSize(VarSymbol* var);
 
-Type* typeForTypeSpecifier(Expr* expr) {
+Type* typeForTypeSpecifier(Expr* expr, bool fatalOK) {
   Type* retval = NULL;
 
   if (SymExpr* symExpr = toSymExpr(expr)) {
@@ -62,7 +62,8 @@ Type* typeForTypeSpecifier(Expr* expr) {
                       break;
 
                     default:
-                      USR_FATAL_CONT(call, "illegal size %d for bool", size);
+                      if (fatalOK)
+                        USR_FATAL_CONT(call, "illegal size %d for bool", size);
                       break;
                     }
 
@@ -88,7 +89,8 @@ Type* typeForTypeSpecifier(Expr* expr) {
                       break;
 
                     default:
-                      USR_FATAL_CONT(call, "illegal size %d for int", size);
+                      if (fatalOK)
+                        USR_FATAL_CONT(call, "illegal size %d for int", size);
                       break;
                     }
 
@@ -114,7 +116,8 @@ Type* typeForTypeSpecifier(Expr* expr) {
                       break;
 
                     default:
-                      USR_FATAL_CONT(call, "illegal size %d for uint", size);
+                      if (fatalOK)
+                        USR_FATAL_CONT(call, "illegal size %d for uint", size);
                       break;
                     }
 
@@ -132,7 +135,8 @@ Type* typeForTypeSpecifier(Expr* expr) {
                       break;
 
                     default:
-                      USR_FATAL_CONT(call, "illegal size %d for real", size);
+                      if (fatalOK)
+                        USR_FATAL_CONT(call, "illegal size %d for real", size);
                       break;
                     }
 
@@ -150,7 +154,8 @@ Type* typeForTypeSpecifier(Expr* expr) {
                       break;
 
                     default:
-                      USR_FATAL_CONT(call, "illegal size %d for imag", size);
+                      if (fatalOK)
+                        USR_FATAL_CONT(call, "illegal size %d for imag", size);
                       break;
                     }
 
@@ -168,7 +173,8 @@ Type* typeForTypeSpecifier(Expr* expr) {
                       break;
 
                     default:
-                      USR_FATAL_CONT(call, "illegal size %d for complex", size);
+                      if (fatalOK)
+                        USR_FATAL_CONT(call, "illegal size %d for complex", size);
                       break;
                     }
                   }

--- a/test/statements/conditionals/param/foldOutIllegalReal.chpl
+++ b/test/statements/conditionals/param/foldOutIllegalReal.chpl
@@ -1,0 +1,12 @@
+proc intToRealSimpler(x:int(?w)) {
+  if w == 64 || w == 32 {
+    writeln("OK");
+    var r:real(w);
+    writeln(r);
+  } else {
+    writeln("Not good");
+  }
+}
+
+intToRealSimpler(0:int(32));
+intToRealSimpler(0:int(8));

--- a/test/statements/conditionals/param/foldOutIllegalReal.good
+++ b/test/statements/conditionals/param/foldOutIllegalReal.good
@@ -1,0 +1,3 @@
+OK
+0.0
+Not good

--- a/test/statements/conditionals/param/foldOutIllegalReal2.chpl
+++ b/test/statements/conditionals/param/foldOutIllegalReal2.chpl
@@ -1,0 +1,7 @@
+proc intToRealSimpler(x : int(?w)) {
+  if w == 64 || w == 32 {
+    var r : real(w);
+
+    writeln(r);
+  }
+}


### PR DESCRIPTION
This change adds an argument to typeForTypeSpecifier() that indicates whether or not it is legal for the routine to throw fatal errors.  Early in the compiler (e.g., normalize) when code is being processed that may be folded out or never executed, generating such errors may be incorrect since the code may never be reached.  For this reason, made all early calls to the routine pass in `false` for this argument.

Added some tests indicating such cases which did not work prior to this change.