### PR TITLE
Print attributes and types with --llvm-print-ir

### DIFF
--- a/compiler/codegen/symbol.cpp
+++ b/compiler/codegen/symbol.cpp
@@ -39,6 +39,7 @@
 #include "iterator.h"
 #include "LayeredValueTable.h"
 #include "llvmDebug.h"
+#include "llvmExtractIR.h"
 #include "llvmUtil.h"
 #include "misc.h"
 #include "optimizations.h"
@@ -107,10 +108,11 @@ llvmStageNum_t llvmStageNumFromLlvmStageName(const char* stageName) {
 #ifdef HAVE_LLVM
 void printLlvmIr(llvm::Function *func, llvmStageNum_t numStage) {
   if(func) {
-    llvm::raw_os_ostream stdOut(std::cout);
+    //llvm::raw_os_ostream stdOut(std::cout);
     std::cout << "; " << "LLVM IR representation of " << llvmPrintIrName
-              << " function after " << llvmStageNameFromLlvmStageNum(numStage) << " optimization stage";
-    func->print(stdOut);
+              << " function after " << llvmStageNameFromLlvmStageNum(numStage)
+              << " optimization stage\n";
+    extractAndPrintFunctionLLVM(func);
   }
 }
 #endif

--- a/compiler/codegen/symbol.cpp
+++ b/compiler/codegen/symbol.cpp
@@ -108,7 +108,7 @@ void printLlvmIr(llvm::Function *func, llvmStageNum_t numStage) {
   if(func) {
     std::cout << "; " << "LLVM IR representation of " << llvmPrintIrName
               << " function after " << llvmStageNameFromLlvmStageNum(numStage)
-              << " optimization stage\n";
+              << " optimization stage\n" << std::flush;
     extractAndPrintFunctionLLVM(func);
   }
 }

--- a/compiler/codegen/symbol.cpp
+++ b/compiler/codegen/symbol.cpp
@@ -62,8 +62,6 @@
 #include "llvm/IR/LegacyPassManager.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Verifier.h"
-
-#include "llvm/Support/raw_os_ostream.h"
 #endif
 
 /******************************** | *********************************
@@ -108,7 +106,6 @@ llvmStageNum_t llvmStageNumFromLlvmStageName(const char* stageName) {
 #ifdef HAVE_LLVM
 void printLlvmIr(llvm::Function *func, llvmStageNum_t numStage) {
   if(func) {
-    //llvm::raw_os_ostream stdOut(std::cout);
     std::cout << "; " << "LLVM IR representation of " << llvmPrintIrName
               << " function after " << llvmStageNameFromLlvmStageNum(numStage)
               << " optimization stage\n";

--- a/compiler/include/llvmExtractIR.h
+++ b/compiler/include/llvmExtractIR.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2004-2017 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _LLVM_EXTRACT_IR_
+#define _LLVM_EXTRACT_IR_
+
+#ifdef HAVE_LLVM
+namespace llvm
+{
+  class Function;
+}
+
+void extractAndPrintFunctionLLVM(llvm::Function *func);
+#endif // end HAVE_LLVM
+
+#endif

--- a/compiler/util/Makefile.share
+++ b/compiler/util/Makefile.share
@@ -21,6 +21,7 @@ UTIL_SRCS = \
 	files.cpp \
 	llvmAggregateGlobalOps.cpp \
 	llvmDumpIR.cpp \
+        llvmExtractIR.cpp \
 	llvmGlobalToWide.cpp \
 	llvmUtil.cpp \
 	llvmDebug.cpp \

--- a/compiler/util/llvmExtractIR.cpp
+++ b/compiler/util/llvmExtractIR.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2004-2017 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "llvmExtractIR.h"
+
+#ifdef HAVE_LLVM
+#include "llvm/IR/LegacyPassManager.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/IRPrintingPasses.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/ToolOutputFile.h"
+#include "llvm/Transforms/IPO.h"
+#include "llvm/Transforms/Utils/Cloning.h"
+#include "llvm/Transforms/Utils/ValueMapper.h"
+#include "llvm/IR/Verifier.h"
+
+using namespace llvm;
+
+void extractAndPrintFunctionLLVM(Function *func) {
+
+  // Simple implementation:
+  //func->print(stdOut);
+
+  // Complex implementation:
+
+  Module* funcModule = func->getParent();
+  ValueToValueMapTy VMap;
+  // Create a new module containing only the definition of the function
+  auto ownedM = CloneModule(funcModule, VMap,
+                            [=](const GlobalValue *GV) { return GV == func; });
+  Module& M = *ownedM.get();
+
+  // Make sure the function in the module is externally visible
+  // (so the below cleanups don't remove it)
+  for (Function &F : M) {
+    if (F.getName() == func->getName()) {
+      F.setLinkage(GlobalValue::WeakAnyLinkage);
+    }
+  }
+
+  legacy::PassManager Passes;
+
+  Passes.add(createGlobalDCEPass());             // Delete unreachable globals
+  Passes.add(createStripDeadDebugInfoPass());    // Remove dead debug info
+  Passes.add(createStripDeadPrototypesPass());   // Remove dead func decls
+
+  std::error_code EC;
+  // could output to a file if we replace "-" with a filename
+  tool_output_file Out("-", EC, sys::fs::F_None);
+  if (EC) {    
+    errs() << EC.message() << '\n';
+    return;
+  }
+
+  Passes.add( createPrintModulePass(Out.os(), "", false));
+  // could add bit code this way:
+  //Passes.add(createBitcodeWriterPass(Out.os(), true));
+
+  Passes.run(M);
+
+  /*
+  std::vector<GlobalValue *> GVs;
+  GVs.push_back(func);
+
+  legacy::PassManager Extract;
+  Extract.add(createGVExtractionPass(GVs, DeleteFn));
+  Extract.run(*M); */
+}
+#endif // end HAVE_LLVM

--- a/test/llvm/parallel_loop_access/different_numbers.chpl
+++ b/test/llvm/parallel_loop_access/different_numbers.chpl
@@ -9,6 +9,7 @@ proc end_loop3() {}
 
 //Check whether we generate different metadata number for loops
 proc loop (A, B, n) {
+  //CHECK-LABEL: void @loop
   for i in vectorizeOnly(1..n) {
     //CHECK-LABEL: start_loop1
     start_loop1();

--- a/test/llvm/parallel_loop_access/generation_inside_loop.chpl
+++ b/test/llvm/parallel_loop_access/generation_inside_loop.chpl
@@ -11,6 +11,7 @@ proc end_block() {}
 // - basic block at the end of the loop
 
 proc loop (A, B, n) {
+  //CHECK-LABEL: void @loop
   for i in vectorizeOnly(1..n) {
     // CHECK-LABEL: start_block
     start_block();


### PR DESCRIPTION
Instead of just printing out a particular function, print out the type, metadata, and global declaration dependencies also. 

This makes --llvm-print-ir much more useful:
 * now we can verify appropriate metadata is created (e.g. loop metadata)
 * now we can import the IR into other LLVM-based tools

Resolves #7864.

- [x] full local --llvm testing

Reviewed by @dmk42 - thanks!