### PR TITLE
Convert sys_sockaddr_t from using constructors to initializers

### DIFF
--- a/modules/standard/Sys.chpl
+++ b/modules/standard/Sys.chpl
@@ -215,7 +215,7 @@ module Sys {
   extern record sys_sockaddr_t {
     var addr:sys_sockaddr_storage_t;
     var len:socklen_t;
-    proc sys_sockaddr_t() {
+    proc init() {
       sys_init_sys_sockaddr_t(this);
     }
   }


### PR DESCRIPTION
This is a trivial 1-minute fix (TM).  I originally went on and
converted a few other cases as well, but started seeing errors
in testing, so am taking one case at a time this time around.