### PR TITLE
Default generic type

### DIFF
--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -165,7 +165,6 @@ void      resolveBlockStmt(BlockStmt* blockStmt);
 void      resolveCall(CallExpr* call);
 void      resolveCallAndCallee(CallExpr* call, bool allowUnresolved = false);
 
-void      resolveDefaultGenericType(CallExpr* call);
 Type*     resolveDefaultGenericTypeSymExpr(SymExpr* se);
 Type*     resolveTypeAlias(SymExpr* se);
 


### PR DESCRIPTION
Minor updates to resolveDefaultGenericType()

Make this function file static and rename it to be resolveGenericActuals()

Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64
Tested each configuration on a portion of release/

Passed  a single locale paratest with -futures

