### PR TITLE
Switch the experimental VM over to testing llvm

### DIFF
--- a/util/cron/test-linux64-vm.bash
+++ b/util/cron/test-linux64-vm.bash
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 #
-# Test default configuration on full suite with compiler performance enabled on
+# Test llvm configuration on full suite with compiler performance enabled on
 # linux64 on an experimental VM
 
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common.bash
+source $CWD/common-llvm.bash
+unset CHPL_NIGHTLY_TEST_DIRS
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-vm"
 


### PR DESCRIPTION
The VM is currently testing default compilation time. By switching to test
llvm, this will give us a more comprehensive comparison of compilation
performance differences between the C backend and the llvm backend.