### PR TITLE
Replaced an autoCopy with PRIM_INIT_VAR

### DIFF
--- a/compiler/resolution/implementForallIntents2.cpp
+++ b/compiler/resolution/implementForallIntents2.cpp
@@ -611,7 +611,7 @@ static Symbol* shadowVarForReduceIntent(FIcontext& ctx,
   ctx.anchor1->insertBefore(new DefExpr(stemp));
   ctx.anchor1->insertBefore("'move'(%S, identity(%S,%S))",
                             stemp, gMethodToken, currOp);
-  ctx.anchor1->insertBefore("'move'(%S, chpl__autoCopy(%S))",
+  ctx.anchor1->insertBefore("'init var'(%S,%S)",
                             rsvar, stemp);
 
   // Wrap it up at the end.


### PR DESCRIPTION
Looks like the right way to initialize a variable is via PRIM_INIT_VAR, rather than with an autoCopy.
Making this change for the new implementForallIntents2.

There are two autocopies still in the old implementForallIntents. That code needs to go away altogether, so I am leaving those autocopies alone.

Testing: valgrind in quickstart configuration, with --verify.