### PR TITLE
Actually test --llvm compiler performance on chapvm01

### DIFF
--- a/util/cron/test-linux64-vm.bash
+++ b/util/cron/test-linux64-vm.bash
@@ -14,5 +14,5 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-vm"
 export CHPL_TEST_NOMAIL=1
 export CHPL_NIGHTLY_DEBUG_EMAIL=eronagha@cray.com
 
-nightly_args="-compperformance (default)"
+nightly_args="${nightly_args} -compperformance (default)"
 $CWD/nightly -cron -futures ${nightly_args}


### PR DESCRIPTION
The script was accidentally overriding instead of appending to nightly_args, so
the `-llvm` was being lost, meaning we weren't actually testing with `--llvm`