### PR TITLE
Always append to nightly_args in nightly testing scripts

### DIFF
--- a/util/cron/common-slurm-gasnet-ibv.bash
+++ b/util/cron/common-slurm-gasnet-ibv.bash
@@ -16,7 +16,7 @@ export CHPL_LAUNCHER_USE_SBATCH=1
 export CHPL_APP_LAUNCH_CMD=$CHPL_HOME/util/test/chpl_launchcmd.py
 
 unset CHPL_START_TEST_ARGS
-nightly_args=-no-buildcheck
+nightly_args="${nightly_args} -no-buildcheck"
 
 # host-specific
 export CHPL_TARGET_ARCH=native

--- a/util/cron/test-linux64.bash
+++ b/util/cron/test-linux64.bash
@@ -8,5 +8,5 @@ source $CWD/common.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64"
 
-nightly_args="-compperformance (default)"
+nightly_args="${nightly_args} -compperformance (default)"
 $CWD/nightly -cron -futures ${nightly_args}

--- a/util/cron/test-no-local.bash
+++ b/util/cron/test-no-local.bash
@@ -8,5 +8,5 @@ source $CWD/common.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="no-local"
 
-nightly_args="-no-local -compperformance (--no-local)"
+nightly_args="${nightly_args} -no-local -compperformance (--no-local)"
 $CWD/nightly -cron ${nightly_args}

--- a/util/cron/test-perf.comm-counts.bash
+++ b/util/cron/test-perf.comm-counts.bash
@@ -19,6 +19,6 @@ perf_args="-performance -numtrials 1 -startdate $START_DATE -perflabel cc-"
 #  The warning message causes the good-output v. test-output comparison to fail.
 
 #  -no-buildcheck skips the "make check"
-nightly_args=-no-buildcheck
+nightly_args="${nightly_args} -no-buildcheck"
 
 $CWD/nightly -cron ${nightly_args} ${perf_args}

--- a/util/cron/test-xc-wb.bash
+++ b/util/cron/test-xc-wb.bash
@@ -19,7 +19,7 @@ if [ "${COMPILER}" != "pgi" ] ; then
 fi
 
 # Run the tests!
-nightly_args="-cron $(get_nightly_paratest_args)"
+nightly_args="${nightly_args} -cron $(get_nightly_paratest_args)"
 log_info "Calling nightly with args: ${nightly_args}"
 $CWD/nightly ${nightly_args}
 log_info "Finished running nightly."


### PR DESCRIPTION
Always append to nightly_args instead of overwriting for nightly test scripts.
None of the scripts I'm changing were sourcing scripts that set nightly_args so
this shouldn't have any impact on testing. This is just intended to prevent
issues like we saw in #7925 from happening in the future