### PR TITLE
Skip tryCResolve in scopeResolve if there are no extern C blocks

### DIFF
--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -659,7 +659,8 @@ static void resolveUnresolvedSymExpr(UnresolvedSymExpr* usymExpr) {
     updateMethod(usymExpr);
 
 #ifdef HAVE_LLVM
-    if (tryCResolve(usymExpr->getModule(), name) == true) {
+    if (gExternBlockStmts.size() > 0 &&
+        tryCResolve(usymExpr->getModule(), name) == true) {
       // Try resolution again since the symbol should exist now
       resolveUnresolvedSymExpr(usymExpr);
     }


### PR DESCRIPTION
This addresses a slowdown in scopeResolve for CHPL_LLVM=llvm compiles
relative to CHPL_LLVM=none compiles, when extern blocks are not used.
It would be better to further improve scopeResolve for the case in which
an extern block is used in one module, or to generally improve the performance
of this feature. However this is a quick and easy performance fix.

- [x] full local --llvm testing
- [x] full local CHPL_LLVM=llvm testing

Reviewed by @ronawho - thanks!