### PR TITLE
Convert locale models over to use init() rather than constructors

### DIFF
--- a/modules/internal/localeModels/apu/LocaleModel.chpl
+++ b/modules/internal/localeModels/apu/LocaleModel.chpl
@@ -59,13 +59,14 @@ module LocaleModel {
     }
     proc chpl_name() return name;
 
-    proc CPULocale() {
+    proc init() {
     }
 
-    proc CPULocale(_sid, _parent) {
+    proc init(_sid, _parent) {
       sid = _sid;
+      name = _parent.chpl_name() + "-CPU" + sid;
+      super.init();
       parent = _parent;
-      name = parent.chpl_name() + "-CPU" + sid;
     }
 
     proc writeThis(f) {
@@ -95,9 +96,9 @@ module LocaleModel {
     }
     proc chpl_name() return name;
 
-    proc GPULocale() {
+    proc init() {
     }
-    proc ~GPULocale() {
+    proc deinit() {
      extern proc hsa_shutdown(): void ;
 
      // Comment out this until runtime support for HSA is added
@@ -106,10 +107,11 @@ module LocaleModel {
     }
 
 
-    proc GPULocale(_sid, _parent) {
+    proc init(_sid, _parent) {
       sid = _sid;
+      name = _parent.chpl_name() + "-GPU" + sid;
+      super.init();
       parent = _parent;
-      name = parent.chpl_name() + "-GPU" + sid;
     }
 
     proc writeThis(f) {
@@ -146,14 +148,14 @@ module LocaleModel {
     // that it is intended to represent.  This trick is used
     // to establish the equivalence the "locale" field of the locale object
     // and the node ID portion of any wide pointer referring to it.
-    proc LocaleModel() {
+    proc init() {
       if doneCreatingLocales {
         halt("Cannot create additional LocaleModel instances");
       }
       setup();
     }
 
-    proc LocaleModel(parent_loc : locale) {
+    proc init(parent_loc : locale) {
       if doneCreatingLocales {
         halt("Cannot create additional LocaleModel instances");
       }
@@ -241,7 +243,7 @@ module LocaleModel {
     const myLocaleSpace: domain(1) = {0..numLocales-1};
     var myLocales: [myLocaleSpace] locale;
 
-    proc RootLocale() {
+    proc init() {
       parent = nil;
       nPUsPhysAcc = 0;
       nPUsPhysAll = 0;

--- a/modules/internal/localeModels/flat/LocaleModel.chpl
+++ b/modules/internal/localeModels/flat/LocaleModel.chpl
@@ -63,14 +63,14 @@ module LocaleModel {
     // that it is intended to represent.  This trick is used
     // to establish the equivalence the "locale" field of the locale object
     // and the node ID portion of any wide pointer referring to it.
-    proc LocaleModel() {
+    proc init() {
       if doneCreatingLocales {
         halt("Cannot create additional LocaleModel instances");
       }
       setup();
     }
 
-    proc LocaleModel(parent_loc : locale) {
+    proc init(parent_loc : locale) {
       if doneCreatingLocales {
         halt("Cannot create additional LocaleModel instances");
       }
@@ -161,7 +161,7 @@ module LocaleModel {
     const myLocaleSpace: domain(1) = {0..numLocales-1};
     var myLocales: [myLocaleSpace] locale;
 
-    proc RootLocale() {
+    proc init() {
       parent = nil;
       nPUsPhysAcc = 0;
       nPUsPhysAll = 0;

--- a/modules/internal/localeModels/knl/LocaleModel.chpl
+++ b/modules/internal/localeModels/knl/LocaleModel.chpl
@@ -201,10 +201,10 @@ module LocaleModel {
       return parent.highBandwidthMemory();
     }
 
-    proc MemoryLocale() {
+    proc init() {
     }
 
-    proc MemoryLocale(_sid, _parent) {
+    proc init(_sid, _parent) {
       sid = _sid: chpl_sublocID_t;
       extern proc chpl_task_getNumSublocales(): int(32);
       const (whichNuma, kind) =
@@ -215,6 +215,7 @@ module LocaleModel {
       else if kind == memoryKindMCDRAM() then
         kindstr = "MCDRAM";
       mlName = kindstr+whichNuma;
+      super.init();
       parent = _parent;
     }
 
@@ -262,17 +263,15 @@ module LocaleModel {
       return hbm;
     }
 
-    proc NumaDomain() {
+    proc init() {
     }
 
-    proc NumaDomain(_sid, _parent) {
+    proc init(_sid, _parent) {
       extern proc chpl_task_getNumSublocales(): int(32);
       var numSublocales = chpl_task_getNumSublocales();
       sid = packSublocID(numSublocales, _sid, defaultMemoryKind())
               : chpl_sublocID_t;
       ndName = "ND"+_sid;
-      parent = _parent;
-
       ddr = new MemoryLocale(sid, this);
 
       var hbm_available = (hbw_check_available() == 0);
@@ -287,6 +286,11 @@ module LocaleModel {
       const origSubloc = chpl_task_getRequestedSubloc();
       chpl_task_setSubloc(hbm_id);
       hbm = new MemoryLocale(hbm_id, this);
+
+      super.init();
+
+      parent = _parent;
+
       chpl_task_setSubloc(origSubloc);
     }
 
@@ -460,7 +464,7 @@ module LocaleModel {
     const myLocaleSpace: domain(1) = {0..numLocales-1};
     var myLocales: [myLocaleSpace] locale;
 
-    proc RootLocale() {
+    proc init() {
       parent = nil;
       nPUsPhysAcc = 0;
       nPUsPhysAll = 0;

--- a/modules/internal/localeModels/numa/LocaleModel.chpl
+++ b/modules/internal/localeModels/numa/LocaleModel.chpl
@@ -63,12 +63,13 @@ module LocaleModel {
     }
     proc chpl_name() return ndName;
 
-    proc NumaDomain() {
+    proc init() {
     }
 
-    proc NumaDomain(_sid, _parent) {
+    proc init(_sid, _parent) {
       sid = _sid;
       ndName = "ND"+sid;
+      super.init();
       parent = _parent;
     }
 
@@ -110,14 +111,14 @@ module LocaleModel {
     // that it is intended to represent.  This trick is used
     // to establish the equivalence the "locale" field of the locale object
     // and the node ID portion of any wide pointer referring to it.
-    proc LocaleModel() {
+    proc init() {
       if doneCreatingLocales {
         halt("Cannot create additional LocaleModel instances");
       }
       setup();
     }
 
-    proc LocaleModel(parent_loc : locale) {
+    proc init(parent_loc : locale) {
       if doneCreatingLocales {
         halt("Cannot create additional LocaleModel instances");
       }
@@ -214,7 +215,7 @@ module LocaleModel {
     const myLocaleSpace: domain(1) = {0..numLocales-1};
     var myLocales: [myLocaleSpace] locale;
 
-    proc RootLocale() {
+    proc init() {
       parent = nil;
       nPUsPhysAcc = 0;
       nPUsPhysAll = 0;

--- a/test/classes/initializers/where-clause4.good
+++ b/test/classes/initializers/where-clause4.good
@@ -1,2 +1,5 @@
 where-clause4.chpl:12: error: unresolved call '_new(type Foo, 3.4)'
 where-clause4.chpl:2: note: candidates are: _new(type chpl_t, xVal)
+$CHPL_HOME/modules/internal/localeModels/flat/LocaleModel.chpl:58: note:                 _new(type chpl_t)
+$CHPL_HOME/modules/internal/localeModels/flat/LocaleModel.chpl:58: note:                 _new(type chpl_t, parent_loc: locale)
+$CHPL_HOME/modules/internal/localeModels/flat/LocaleModel.chpl:159: note:                 _new(type chpl_t)

--- a/test/classes/initializers/where-clause4.suppressif
+++ b/test/classes/initializers/where-clause4.suppressif
@@ -1,0 +1,6 @@
+# locale model results in bad init() candidates
+#
+# currently, we're generating locale-model-specific candidates, so
+# here, I'm hard-coding the .good file to 'flat' and suppress the
+# errors for other locale models
+CHPL_LOCALE_MODEL!=flat


### PR DESCRIPTION
This change converts locale models over to use init() rather than
constructors.  For the most part this was straightforward, though for
the current compiler the 'parent' field seems to only be able to be
initialized in phase 2 (in spite of seemingly being 'const'?) and this
required using the `_parent` formal argument in a few cases that
wanted to use the field in phase 1 prior to its being initialized.