### PR TITLE
Free c_strings allocated by IO runtime

### DIFF
--- a/runtime/src/chpl-file-utils.c
+++ b/runtime/src/chpl-file-utils.c
@@ -361,6 +361,7 @@ qioerr chpl_fs_realpath_file(qio_file_t* path, const char **shortened) {
     return err;
   }
   err = chpl_fs_realpath(unshortened, shortened);
+  qio_free(unshortened);
   // Since what is returned from qio_file_path is not necessarily the realpath,
   // call realpath on it before returning.
   return err;

--- a/runtime/src/qio/qio.c
+++ b/runtime/src/qio/qio.c
@@ -1352,8 +1352,7 @@ qioerr qio_file_path_for_fd(fd_t fd, const char** string_out)
   const char* result;
   sprintf(pathbuf, "/proc/self/fd/%i", fd);
   err = qio_int_to_err(sys_readlink(pathbuf, &result));
-  // result is owned by sys_readlink, so has to be copied.
-  *string_out = qio_strdup(result);
+  *string_out = result;
   return err;
 #else
 #ifdef __APPLE__


### PR DESCRIPTION
The first leak is resolved by updating SysErr.chpl to correctly take ownership of c_strings by calling string initializers instead of casting to `string`.

The second leak is resolved by manually freeing a couple of c_strings allocated by QIO within the runtime.

Testing:
- [x] full local
- [x] full gasnet
- [x] memleaks (~8 tests no longer leak)