### PR TITLE
Remove .suppressif files for tests now passing with --llvm

### DIFF
--- a/test/compflags/library/withMain/lib2.suppressif
+++ b/test/compflags/library/withMain/lib2.suppressif
@@ -1,7 +1,0 @@
-# Known LLVM issue with --library
-#
-# This is a known issue where we are not yet able to handle compiling
-# with --library when using the LLVM back end.  See github issue
-# #6336.  Suppress this for now.
-
-CHPL_LLVM!=none

--- a/test/compflags/lydia/library/errorMessage/hasMain.suppressif
+++ b/test/compflags/lydia/library/errorMessage/hasMain.suppressif
@@ -1,7 +1,0 @@
-# Known LLVM issue with --library
-#
-# This is a known issue where we are not yet able to handle compiling
-# with --library when using the LLVM back end.  See github issue
-# #6336.  Suppress this for now.
-
-CHPL_LLVM!=none


### PR DESCRIPTION
These tests appear to be working with LLVM now.

Closes #6336.