### PR TITLE
Reduce the impact of clock skew in compiler performance tracking

### DIFF
--- a/compiler/main/PhaseTracker.cpp
+++ b/compiler/main/PhaseTracker.cpp
@@ -301,9 +301,10 @@ bool Phase::IsStartOfPass() const
 
 void Phase::ReportPass(unsigned long now) const
 {
-  unsigned long phaseTime = now - mStartTime;
-  if (now < mStartTime)
-    phaseTime = 0;
+  // clock-skew can cause now < startTime, just report 0 in that case
+  unsigned long phaseTime = 0;
+  if (now > mStartTime)
+    phaseTime = now - mStartTime;
 
   ReportTime(mName, phaseTime / 1e6);
 

--- a/compiler/main/PhaseTracker.cpp
+++ b/compiler/main/PhaseTracker.cpp
@@ -302,6 +302,8 @@ bool Phase::IsStartOfPass() const
 void Phase::ReportPass(unsigned long now) const
 {
   unsigned long phaseTime = now - mStartTime;
+  if (now < mStartTime)
+    phaseTime = 0;
 
   ReportTime(mName, phaseTime / 1e6);
 


### PR DESCRIPTION
This prevents the compiler from reporting 90 year compilation times. Our
compiler is slow, but not quite that slow.

For compiler performance test configurations, we collect per-pass timings for
all ~8,000 tests in the test suite and then report the average times. Over the
last couple of months, we've had a few days where times of 2.9e^10s (90 years!)
are reported for some passes. I think this is from a clock-skew correction
causing our startTime to be after the stopTime. i.e. startTime - stopTime ends
up being a near-max ulong because we're using a non-monotonic timer that's
affected by clock-skew

This just adjusts our phaseTracker to report 0 time if stopTime < startTime.
This doesn't happen often (1/8000 tests every once in a while), so the
incorrect time won't significantly affect the average time we report.

Note that this is a lame workaround. The real fix is to use a monotonic timer
like `std::chrono::steady_clock`. Note that steady_clock requires C++11, so
we'll still have to fallback to our old timer if C++11 isn't available.