### PR TITLE
Convert Sort module from constructors to initializers

### DIFF
--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -130,6 +130,8 @@ implemented with a compare method:
   // This will output: -1, 2, 3, -4
   writeln(Array);
 
+.. _reverse-comparator:
+
 Reverse Comparator
 ~~~~~~~~~~~~~~~~~~
 
@@ -860,7 +862,7 @@ record ReverseComparator {
    Copy Initializer - builds a comparator that's a copy of
    its argument.
 
-   :arg revcomp: :ref:`ReverseComparator <comparators>` to copy.
+   :arg revcomp: :ref:`ReverseComparator <reverse-comparator>` to copy.
    */
   proc init(revcomp: ReverseComparator(?)) {
     this.comparator = revcomp.comparator;

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -835,14 +835,37 @@ record ReverseComparator {
   var comparator;
 
   /*
-   Constructor - builds a comparator with a compare method that reverses the sort order of
-   the argument-provided comparator.
+   Initializer - builds a comparator with a compare method that
+   reverses the sort order of the default comparator.
+   */
+  proc init() {
+    this.comparator = defaultComparator;
+    super.init();
+  }
+
+  /*
+   Initializer - builds a comparator with a compare method that
+   reverses the sort order of the argument-provided comparator.
 
    :arg comparator: :ref:`Comparator <comparators>` record that defines how the
       data is sorted.
 
    */
-  proc ReverseComparator(comparator:?rec=defaultComparator) {}
+  proc init(comparator) {
+    this.comparator = comparator;
+    super.init();
+  }
+
+  /*
+   Copy Initializer - builds a comparator that's a copy of
+   its argument.
+
+   :arg revcomp: :ref:`ReverseComparator <comparators>` to copy.
+   */
+  proc init(revcomp: ReverseComparator(?)) {
+    this.comparator = revcomp.comparator;
+    super.init();
+  }
 
   /*
    Reversed compare method defined based on ``comparator.key`` if defined,

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -864,6 +864,7 @@ record ReverseComparator {
 
    :arg revcomp: :ref:`ReverseComparator <reverse-comparator>` to copy.
    */
+  pragma "no doc"
   proc init(revcomp: ReverseComparator(?)) {
     this.comparator = revcomp.comparator;
     super.init();


### PR DESCRIPTION
This change makes the Sort module (specifically, the ReverseComparator
record) from a constructor-based approach to an initializer-based one.
There were a few surprises here that are worth noting:

1) The ReverseComparator record is completely generic and in a constructor-
   based world had a signature like:

```chapel
     proc ReverseComparator(comparator=defaultComparator) { ... }
```

   which permitted 'comparator' to be of type 'defaultComparator' or
   whatever other type was passed in.  However, changing this to
   an initializer with the signature:

```chapel
     proc init(comparator=defaultComparator) {
       this.comparator = comparator;
       ...
       super.init();
       ...
     }
```

   puts a type constraint on the argument, requiring it to be of the same
   type as 'defaultComparator'.  This is consistent with what we do for
   normal arguments, so seems appropriate, but requires creating two
   initializers to get the same behavior as the old constructor:

```chapel
     proc init() {
       this.comparator = defaultComparator;
       ...
       super.init();
       ...
     }

     proc init(comparator) {
       this.comparator = comparator;
       ...
       super.init();
       ...
     }
```

2) After doing the above translation, the problem is that the second
   initializer matches the expected signature for a copy initializer,
   but doesn't implement the copy initializer semantics (and I think,
   conceptually, results in something like an infinite recursion?).
   So a third initializer has to be inserted in order to handle the
   case where the argument is of type ReverseComparator to handle the
   copy initialization case.