### PR TITLE
Make the autocomplete test work even if chpl is not in PATH

### DIFF
--- a/test/chplenv/autocomplete/autocomplete.chpl
+++ b/test/chplenv/autocomplete/autocomplete.chpl
@@ -10,6 +10,12 @@ use Spawn;
 
 var home = CHPL_HOME;
 
+extern proc getenv(name: c_string): c_string;
+extern proc setenv(name: c_string, val: c_string, overwrite: c_int): c_int;
+
+var path = getenv("PATH"):string;
+setenv("PATH", (path + ":" + home + "/bin/" + CHPL_HOST_PLATFORM).c_str(), 1);
+
 var genScript = home + "/util/devel/gen-chpl-bash-completion";
 var completeScript = home + "/util/chpl-completion.bash";
 
@@ -22,3 +28,9 @@ for line in runScript.stdout.lines() {
 
 runScript.wait();
 diff.wait();
+
+if diff.exit_status != 0 {
+  writeln();
+  writeln("diff failed. You may need to run ", genScript,
+          " to regenerate ", completeScript);
+}


### PR DESCRIPTION
Some of our testing appears to run with chpl not in PATH. Make this test set
PATH to include "CHPL_HOME/bin/CHPL_HOST_PLATFORM" before it tries to use chpl.

Tested with PATH including chpl on Cygwin64, Linux64, OSX, Valgrind.
Tested with PATH not including chpl on Cygwin64, Linux64, OSX, Valgrind.