### PR TITLE
Fix bug in LinearAlgebra.Sparse.dot()

### DIFF
--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -1148,11 +1148,11 @@ module Sparse {
     if !trans {
       if Adom.shape(2) != Xdom.shape(1) then
         halt("Mismatched shape in matrix-vector multiplication");
-      forall (i, x) in zip(Adom.dim(1), X) {
-        for j in Adom.dimIter(2, i) {
-          Y[i] += A[i, j] * x;
+        forall i in Adom.dim(1) {
+          for j in Adom.dimIter(2, i) {
+            Y[i] += A[i, j] * X[j];
+          }
         }
-      }
     } else {
       if Adom.shape(1) != Xdom.shape(1) then
         halt("Mismatched shape in matrix-vector multiplication");

--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -1148,6 +1148,7 @@ module Sparse {
     if !trans {
       if Adom.shape(2) != Xdom.shape(1) then
         halt("Mismatched shape in matrix-vector multiplication");
+        // TODO: Loop over non-zero rows only
         forall i in Adom.dim(1) {
           for j in Adom.dimIter(2, i) {
             Y[i] += A[i, j] * X[j];

--- a/test/library/packages/LinearAlgebra/correctness/correctness.chpl
+++ b/test/library/packages/LinearAlgebra/correctness/correctness.chpl
@@ -689,6 +689,15 @@ config const correctness = true;
   }
 
   {
+    var A = Matrix([1,1,0],
+                   [0,1,1]);
+    var Asps = CSRMatrix(A);
+    var v = Vector(1,2,3);
+    const Av = Vector(3, 5);
+    assertEqual(Asps.dot(v), Av);
+  }
+
+  {
     var A = eye(3,5);
     // Identity matrix (3x5)
     test_CSRdot(A);
@@ -744,6 +753,16 @@ config const correctness = true;
     var A2 = 2*A;
     assertEqual(Av, A2);
   }
+
+  {
+    var A = Matrix([1,1,0],
+                   [0,1,1]);
+    var Asps = CSRMatrix(A);
+    var v = Vector(2,3);
+    const Av = Vector(2, 5, 3);
+    assertEqual(v.dot(Asps), Av);
+  }
+
 
   /* dot - matrix-scalar */
   {


### PR DESCRIPTION
- Fixed a bug in `LinearAlgebra.Sparse._csrmatvecMult()` (called from `dot(CSRMatrix, Vector)`
- Added test that demonstrated the bug
- Added TODO for a potential optimization in the future

**Testing**

- [x] Tested `test/libraries/packages/LinearAlgebra/`