### PR TITLE
Virtual dispatch 1

### DIFF
--- a/compiler/AST/AstDumpToNode.cpp
+++ b/compiler/AST/AstDumpToNode.cpp
@@ -895,7 +895,7 @@ bool AstDumpToNode::enterFnSym(FnSymbol* node)
     newline();
     fprintf(mFP, "RetType:  ");
     mOffset = mOffset + 10;
-    node->retType->symbol->accept(this);
+    writeType(node->retType, false);
     mOffset = mOffset - 10;
   }
 

--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -29,26 +29,41 @@
 class CallInfo;
 class ResolutionCandidate;
 
-extern bool                           beforeLoweringForallStmts;
-extern int                            explainCallLine;
+struct Serializers {
+  FnSymbol* serializer;
+  FnSymbol* deserializer;
+  FnSymbol* broadcaster;
+  FnSymbol* destroyer;
+};
 
-extern SymbolMap                      paramMap;
 
-extern Vec<CallExpr*>                 callStack;
+extern bool                             beforeLoweringForallStmts;
 
-extern bool                           tryFailure;
+extern int                              explainCallLine;
 
-extern Vec<CallExpr*>                 inits;
+extern SymbolMap                        paramMap;
 
-extern Vec<BlockStmt*>                standardModuleSet;
+extern Vec<CallExpr*>                   callStack;
 
-extern char                           arrayUnrefName[];
+extern bool                             tryFailure;
 
-extern Map<Type*,     FnSymbol*>      autoDestroyMap;
-extern Map<FnSymbol*, FnSymbol*>      iteratorLeaderMap;
-extern Map<FnSymbol*, FnSymbol*>      iteratorFollowerMap;
+extern Vec<CallExpr*>                   inits;
 
-extern std::map<CallExpr*, CallExpr*> eflopiMap;
+extern Vec<BlockStmt*>                  standardModuleSet;
+
+extern char                             arrayUnrefName[];
+
+extern Map<Type*,     FnSymbol*>        autoDestroyMap;
+
+extern Map<FnSymbol*, FnSymbol*>        iteratorLeaderMap;
+
+extern Map<FnSymbol*, FnSymbol*>        iteratorFollowerMap;
+
+extern Map<Type*,     FnSymbol*>        valueToRuntimeTypeMap;
+
+extern std::map<Type*,     Serializers> serializeMap;
+
+extern std::map<CallExpr*, CallExpr*>   eflopiMap;
 
 
 
@@ -204,6 +219,8 @@ void lvalueCheck(CallExpr* call);
 
 void checkForStoringIntoTuple(CallExpr* call, FnSymbol* resolvedFn);
 
+bool signatureMatch(FnSymbol* fn, FnSymbol* gn);
+
 void printTaskOrForallConstErrorNote(Symbol* aVar);
 
 // tuples
@@ -219,16 +236,5 @@ AggregateType* computeTupleWithIntent(IntentTag intent, AggregateType* t);
 bool evaluateWhereClause(FnSymbol* fn);
 
 bool isAutoDestroyedVariable(Symbol* sym);
-
-extern Map<Type*,FnSymbol*> valueToRuntimeTypeMap; // convertValueToRuntimeType
-
-struct Serializers {
-  FnSymbol* serializer;
-  FnSymbol* deserializer;
-  FnSymbol* broadcaster;
-  FnSymbol* destroyer;
-};
-
-extern std::map<Type*, Serializers> serializeMap;
 
 #endif

--- a/compiler/include/virtualDispatch.h
+++ b/compiler/include/virtualDispatch.h
@@ -26,27 +26,22 @@
 class FnSymbol;
 class Type;
 
-//
-// The virtualMethodTable maps types to their arrays of methods.  The
-// virtualMethodMap maps methods to their indexes into these arrays.
-// The virtualChildrenMap maps methods to all of the methods that
-// could be called when they are called.  The virtualRootsMap maps
-// methods to the root methods that it overrides.  Note that multiple
-// inheritance will require more virtual method tables, one for each
-// path up the class hierarchy to each class root.
-//
-
-extern Map<FnSymbol*, int>             virtualMethodMap;
-extern Map<Type*,     Vec<FnSymbol*>*> virtualMethodTable;
-extern Map<FnSymbol*, Vec<FnSymbol*>*> virtualChildrenMap;
+// Map a method to the set of methods being overridden
 extern Map<FnSymbol*, Vec<FnSymbol*>*> virtualRootsMap;
+
+// Map a method to the set of methods that might be invoked
+extern Map<FnSymbol*, Vec<FnSymbol*>*> virtualChildrenMap;
+
+// Map types to arrays of virtual methods
+extern Map<Type*,     Vec<FnSymbol*>*> virtualMethodTable;
+
+// Map a method to its index within the array of methods
+extern Map<FnSymbol*, int>             virtualMethodMap;
 
 extern bool                            inDynamicDispatchResolution;
 
 void resolveDynamicDispatches();
 
 void insertDynamicDispatchCalls();
-
-bool signatureMatch(FnSymbol* fn, FnSymbol* gn);
 
 #endif

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -1814,6 +1814,36 @@ static void collectVisibleMethodsNamed(Type*                   t,
 
 /************************************* | **************************************
 *                                                                             *
+* Checks that types match.                                                    *
+* Note - does not currently check that instantiated params match.             *
+*                                                                             *
+************************************** | *************************************/
+
+bool signatureMatch(FnSymbol* fn, FnSymbol* gn) {
+  bool retval = true;
+
+  if (fn->name != gn->name) {
+    retval = false;
+
+  } else if (fn->numFormals() != gn->numFormals()) {
+    retval = false;
+
+  } else {
+    for (int i = 3; i <= fn->numFormals() && retval == true; i++) {
+      ArgSymbol* fa = fn->getFormal(i);
+      ArgSymbol* ga = gn->getFormal(i);
+
+      if (fa->type != ga->type || strcmp(fa->name, ga->name) != 0) {
+        retval = false;
+      }
+    }
+  }
+
+  return retval;
+}
+
+/************************************* | **************************************
+*                                                                             *
 *                                                                             *
 *                                                                             *
 ************************************** | *************************************/

--- a/compiler/resolution/virtualDispatch.cpp
+++ b/compiler/resolution/virtualDispatch.cpp
@@ -605,33 +605,6 @@ static bool isVirtualChild(FnSymbol* child, FnSymbol* parent) {
   return false;
 }
 
-// Checks that types match.
-// Note - does not currently check that instantiated params match.
-bool signatureMatch(FnSymbol* fn, FnSymbol* gn) {
-  if (fn->name != gn->name) {
-    return false;
-  }
-
-  if (fn->numFormals() != gn->numFormals()) {
-    return false;
-  }
-
-  for (int i = 3; i <= fn->numFormals(); i++) {
-    ArgSymbol* fa = fn->getFormal(i);
-    ArgSymbol* ga = gn->getFormal(i);
-
-    if (strcmp(fa->name, ga->name)) {
-      return false;
-    }
-
-    if (fa->type != ga->type) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
 static bool possibleSignatureMatch(FnSymbol* fn, FnSymbol* gn) {
   if (fn->name != gn->name) {
     return false;


### PR DESCRIPTION
Begin to straighten out resolution/virtualDispatch.cpp

1. Move signatureMatch() from virtualDispatch to functionResolution.

2. Also tweak AstDumpToNode to update display of retType for FnSymbol.

Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64
Ran a small portion of release/ on each configuration
Passed a single-locale paratest
