### PR TITLE
Add an error message for constructor when any parent type defines an init()

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -1182,6 +1182,17 @@ void AggregateType::buildConstructor() {
 
           // If it doesn't yet have an initializer, make one.
           at->buildConstructors();
+
+          // Error out if the parent type or one that it inherits from
+          // defines an initializer - we should not be creating a default
+          // constructor in that case, it won't know what to do with it.
+          if (at->initializerStyle == DEFINES_INITIALIZER ||
+              at->parentDefinesInitializer() == true) {
+            // at->defaultInitializer will still be NULL
+            USR_FATAL(this, "Cannot create default constructor on type '%s',"
+                      " which inherits from a type that defines an initializer",
+                      symbol->name);
+          }
         }
 
         // Get the parent constructor.
@@ -1743,6 +1754,19 @@ bool AggregateType::needsConstructor() {
     }
   }
   // Otherwise, we don't need a default constructor.
+  return false;
+}
+
+bool AggregateType::parentDefinesInitializer() {
+  if (dispatchParents.n > 0) {
+    if (AggregateType* pt = toAggregateType(dispatchParents.v[0])) {
+      if (pt->initializerStyle == DEFINES_INITIALIZER) {
+        return true;
+      } else {
+        return pt->parentDefinesInitializer();
+      }
+    }
+  }
   return false;
 }
 

--- a/compiler/include/AggregateType.h
+++ b/compiler/include/AggregateType.h
@@ -132,6 +132,8 @@ public:
                               // default-initializer.
                               // It provides initial values for the
                               // fields in an aggregate type.
+
+  bool                        parentDefinesInitializer();
   bool                        wantsDefaultInitializer();
   void                        buildDefaultInitializer();
 

--- a/test/classes/initializers/compilerGenerated/constructorChild.chpl
+++ b/test/classes/initializers/compilerGenerated/constructorChild.chpl
@@ -1,0 +1,21 @@
+class Parent {
+  var x: int;
+
+  proc init() {
+    x = 10;
+    super.init();
+  }
+}
+
+class Child: Parent {
+  var y: int;
+
+  proc Child(yVal) {
+    y = yVal;
+    x = 13;
+  }
+}
+
+var child = new Child(4);
+writeln(child);
+delete child;

--- a/test/classes/initializers/compilerGenerated/constructorChild.good
+++ b/test/classes/initializers/compilerGenerated/constructorChild.good
@@ -1,0 +1,1 @@
+constructorChild.chpl:10: error: Cannot create default constructor on type 'Child', which inherits from a type that defines an initializer

--- a/test/classes/initializers/inheritance/constructorChild.chpl
+++ b/test/classes/initializers/inheritance/constructorChild.chpl
@@ -1,0 +1,21 @@
+class Parent {
+  var x: int;
+
+  proc init() {
+    x = 10;
+    super.init();
+  }
+}
+
+class Child: Parent {
+  var y: int;
+
+  proc Child(yVal) {
+    y = yVal;
+    x = 13;
+  }
+}
+
+var child = new Child(4);
+writeln(child);
+delete child;

--- a/test/classes/initializers/inheritance/constructorChild.good
+++ b/test/classes/initializers/inheritance/constructorChild.good
@@ -1,0 +1,1 @@
+constructorChild.chpl:10: error: Cannot create default constructor on type 'Child', which inherits from a type that defines an initializer


### PR DESCRIPTION
The default constructor relies on calling the parent type's default constructor.
If any type we are inheriting from defines an initializer, we will run into
problems.  It isn't worth extending constructors to support inheriting from such
types, so just generate a friendly compiler error.

Also adds two tests to cover the new error message for inheritance, covering
both the default constructor world and the default initializer world.

Passed classes/initializers with futures, and a full std/ paratest