### PR TITLE
Virtual dispatch 3

### DIFF
--- a/compiler/resolution/virtualDispatch.cpp
+++ b/compiler/resolution/virtualDispatch.cpp
@@ -344,22 +344,15 @@ static void addToVirtualMaps(FnSymbol* pfn, AggregateType* ct) {
 static void collectMethods(FnSymbol*               pfn,
                            AggregateType*          ct,
                            std::vector<FnSymbol*>& methods) {
-  Vec<FnSymbol*> tmp;
-
   for (AggregateType* fromType = ct;
        fromType != NULL;
        fromType = fromType->instantiatedFrom) {
-
     forv_Vec(FnSymbol, cfn, fromType->methods) {
-      if (cfn != NULL && possibleSignatureMatch(pfn, cfn) == true) {
-        tmp.add(cfn);
+      if (cfn->instantiatedFrom == NULL) {
+        if (possibleSignatureMatch(pfn, cfn) == true) {
+          methods.push_back(cfn);
+        }
       }
-    }
-  }
-
-  forv_Vec(FnSymbol, cfn, tmp) {
-    if (cfn->instantiatedFrom == NULL) {
-      methods.push_back(cfn);
     }
   }
 }

--- a/compiler/resolution/virtualDispatch.cpp
+++ b/compiler/resolution/virtualDispatch.cpp
@@ -373,8 +373,7 @@ static void collectMethods(FnSymbol*               pfn,
   // Then, add anything not instantiated from something in
   // the set.
   forv_Vec(FnSymbol, cfn, tmp) {
-    if (cfn->instantiatedFrom                 == NULL ||
-        generics.count(cfn->instantiatedFrom) ==    0) {
+    if (cfn->instantiatedFrom == NULL) {
       methods.push_back(cfn);
     }
   }

--- a/compiler/resolution/virtualDispatch.cpp
+++ b/compiler/resolution/virtualDispatch.cpp
@@ -344,10 +344,8 @@ static void addToVirtualMaps(FnSymbol* pfn, AggregateType* ct) {
 static void collectMethods(FnSymbol*               pfn,
                            AggregateType*          ct,
                            std::vector<FnSymbol*>& methods) {
-  Vec<FnSymbol*>      tmp;
-  std::set<FnSymbol*> generics;
+  Vec<FnSymbol*> tmp;
 
-  // Gather the generic, concrete, instantiated methods
   for (AggregateType* fromType = ct;
        fromType != NULL;
        fromType = fromType->instantiatedFrom) {
@@ -359,19 +357,6 @@ static void collectMethods(FnSymbol*               pfn,
     }
   }
 
-  // Don't add instantiations of generics if we were already
-  // going to add the generic version. addToVirtualMaps will
-  // re-instantiate.
-
-  // So, gather a set of generic versions.
-  forv_Vec(FnSymbol, cfn, tmp) {
-    if (cfn->hasFlag(FLAG_GENERIC) == true) {
-      generics.insert(cfn);
-    }
-  }
-
-  // Then, add anything not instantiated from something in
-  // the set.
   forv_Vec(FnSymbol, cfn, tmp) {
     if (cfn->instantiatedFrom == NULL) {
       methods.push_back(cfn);

--- a/compiler/resolution/virtualDispatch.cpp
+++ b/compiler/resolution/virtualDispatch.cpp
@@ -342,11 +342,11 @@ static void addToVirtualMaps(FnSymbol* pfn, AggregateType* ct) {
 }
 
 static void collectMethods(FnSymbol*               pfn,
-                           AggregateType*          ct,
+                           AggregateType*          pct,
                            std::vector<FnSymbol*>& methods) {
-  for (AggregateType* fromType = ct;
-       fromType != NULL;
-       fromType = fromType->instantiatedFrom) {
+  AggregateType* fromType = pct;
+
+  while (fromType != NULL) {
     forv_Vec(FnSymbol, cfn, fromType->methods) {
       if (cfn->instantiatedFrom == NULL) {
         if (possibleSignatureMatch(pfn, cfn) == true) {
@@ -354,6 +354,8 @@ static void collectMethods(FnSymbol*               pfn,
         }
       }
     }
+
+    fromType = fromType->instantiatedFrom;
   }
 }
 


### PR DESCRIPTION
Continue to make modest improvements to virtualDispatch.cpp
    
A short sequence of trivial commits to improve/simplify collectMethodsForVirtualMaps().

In particular this PR converts the output vector to be an instance of std::vector() instead
of a Vec, stops inserting objects in to this vector that won't be consumed at the call
site, and then leverages that update to simplify the implementation.
   
Standard compilation/testing protocol.

