### PR TITLE
Eliminate memory leaks in reductionex_record_class.chpl

### DIFF
--- a/test/users/ferguson/histogram/reductionex_record_class.chpl
+++ b/test/users/ferguson/histogram/reductionex_record_class.chpl
@@ -30,7 +30,13 @@ record Test {
     }
 
     proc generate() {
-      return h;
+      const result = h;
+      h = nil; // giving up ownership - do not delete in deinit()
+      return result;
+    }
+
+    proc deinit() {
+      delete h;
     }
   }
 
@@ -50,3 +56,4 @@ var test   = new Test(16, 16000:uint(64), 0:uint(64));
 var counts = test.reduceit(array);
 
 writeln(counts);
+delete counts;


### PR DESCRIPTION
Each instance of `myhisto` allocates an instance of `histo` and so
should delete it. Add a deinitializer to do so.

The one exception is when generate() is invoked. Which happens
for the top-level reduction op object that produces the value
of the reduction for consumption by the user.
In that scenario, pass ownership to the user and do not
delete it in the deinitializer.

Passes valgrind. -memLeaks reports no leaks.