### PR TITLE
Virtual dispatch 7

### DIFF
--- a/compiler/resolution/virtualDispatch.cpp
+++ b/compiler/resolution/virtualDispatch.cpp
@@ -185,10 +185,7 @@ static void addAllToVirtualMaps(FnSymbol* pfn, AggregateType* pct) {
 
 static void addToVirtualMaps(FnSymbol* pfn, AggregateType* ct) {
   if (ct->symbol->hasFlag(FLAG_GENERIC) == false) {
-    FnSymbol* typeConstr = ct->defaultTypeConstructor;
-
-    if (typeConstr->isResolved()          == true ||
-        typeConstr->hasFlag(FLAG_GENERIC) == true) {
+    if (ct->defaultTypeConstructor->isResolved() == true) {
       std::vector<FnSymbol*> methods;
 
       collectMethods(pfn, ct, methods);
@@ -199,21 +196,17 @@ static void addToVirtualMaps(FnSymbol* pfn, AggregateType* ct) {
     }
 
   } else {
-    FnSymbol* typeConstr = ct->defaultTypeConstructor;
+    FnSymbol*              typeConstr = ct->defaultTypeConstructor;
+    std::vector<FnSymbol*> methods;
 
-    if (typeConstr->isResolved()          == true ||
-        typeConstr->hasFlag(FLAG_GENERIC) == true) {
-      std::vector<FnSymbol*> methods;
+    collectMethods(pfn, ct, methods);
 
-      collectMethods(pfn, ct, methods);
-
-      for_vector(FnSymbol, cfn, methods) {
-        forv_Vec(AggregateType, at, gAggregateTypes) {
-          if (FnSymbol* typeConstrOther = at->defaultTypeConstructor) {
-            if (typeConstrOther->instantiatedFrom == typeConstr) {
-              if (at->symbol->hasFlag(FLAG_GENERIC) == false) {
-                addToVirtualMaps(pfn, ct, cfn, at);
-              }
+    for_vector(FnSymbol, cfn, methods) {
+      forv_Vec(AggregateType, at, gAggregateTypes) {
+        if (FnSymbol* typeConstrOther = at->defaultTypeConstructor) {
+          if (typeConstrOther->instantiatedFrom == typeConstr) {
+            if (at->symbol->hasFlag(FLAG_GENERIC) == false) {
+              addToVirtualMaps(pfn, ct, cfn, at);
             }
           }
         }

--- a/compiler/resolution/virtualDispatch.cpp
+++ b/compiler/resolution/virtualDispatch.cpp
@@ -184,19 +184,30 @@ static void addAllToVirtualMaps(FnSymbol* pfn, AggregateType* pct) {
 }
 
 static void addToVirtualMaps(FnSymbol* pfn, AggregateType* ct) {
-  FnSymbol* typeConstr = ct->defaultTypeConstructor;
+  if (ct->symbol->hasFlag(FLAG_GENERIC) == false) {
+    FnSymbol* typeConstr = ct->defaultTypeConstructor;
 
-  if (typeConstr->isResolved()          == true ||
-      typeConstr->hasFlag(FLAG_GENERIC) == true) {
-    std::vector<FnSymbol*> methods;
+    if (typeConstr->isResolved()          == true ||
+        typeConstr->hasFlag(FLAG_GENERIC) == true) {
+      std::vector<FnSymbol*> methods;
 
-    collectMethods(pfn, ct, methods);
+      collectMethods(pfn, ct, methods);
 
-    for_vector(FnSymbol, cfn, methods) {
-      if (ct->symbol->hasFlag(FLAG_GENERIC) == false) {
+      for_vector(FnSymbol, cfn, methods) {
         addToVirtualMaps(pfn, ct, cfn, ct);
+      }
+    }
 
-      } else {
+  } else {
+    FnSymbol* typeConstr = ct->defaultTypeConstructor;
+
+    if (typeConstr->isResolved()          == true ||
+        typeConstr->hasFlag(FLAG_GENERIC) == true) {
+      std::vector<FnSymbol*> methods;
+
+      collectMethods(pfn, ct, methods);
+
+      for_vector(FnSymbol, cfn, methods) {
         forv_Vec(AggregateType, at, gAggregateTypes) {
           if (FnSymbol* typeConstrOther = at->defaultTypeConstructor) {
             if (typeConstrOther->instantiatedFrom == typeConstr) {


### PR DESCRIPTION
Continue to make modest improvements to virtualDispatch.cpp



This PR makes a simple revision to
    
void addToVirtualMaps(FnSymbol* pfn, AggregateType* ct);

to eliminate a dependency on at->defaultTypeConstructor and
to separate the handling of virtual-dispatch for generic vs.
non-generic classes.



Before this PR the body consisted of  an if-statement where the
consequent is a loop, such that the loop consisted of a simple
if-else.

The outer if-statement included a use of 

ct->defaultTypeConstructor->hasFlag(FLAG_GENERIC)

while the inner conditional tested

ct->symbol->hasFlag(FLAG_GENERIC);

In practice, these two tests always yield the same result.


After this PR, the body consists of an if-else with a simpler
loop in each arm i.e. a nominal use of "loop unswitching".

While loop-unswitching can be used for performance gains
the goal here is only clarity.


Standard compilation/testing protocol.
