### PR TITLE
Replace several 'proc these()' in ChapelArray with iterators

### DIFF
--- a/compiler/resolution/cullOverReferences.cpp
+++ b/compiler/resolution/cullOverReferences.cpp
@@ -1347,7 +1347,6 @@ void cullOverReferences() {
                        node.variable->id, node.fieldIndex);
                 
                 printf("for iterator %i\n", iterator->id);
-
                 */
 
                 gatherLoopDetails(forLoop, isForall, leaderDetails,
@@ -1387,7 +1386,8 @@ void cullOverReferences() {
                   // and modifying the index variable should make us
                   // consider the array to be "set".
                   if (iteratorFn->isMethod() &&
-                      isArrayClass(iteratorFn->getFormal(1)->type))
+                      (isArrayClass(iteratorFn->getFormal(1)->type) ||
+                       iteratorFn->hasFlag(FLAG_REF_TO_CONST_WHEN_CONST_THIS)))
                       iteratorYieldsConstWhenConstThis = true;
 
                   // Note, if we wanted to use the return intent

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5456,7 +5456,7 @@ static void moveSetFlagsAndCheckForConstAccess(Symbol*   lhsSym,
 
     moveSetFlagsForConstAccess(lhsSym, rhs, baseSym, false);
 
-  } else if (refConstWCT == true) {
+  } else if (refConstWCT == true && !resolvedFn->isIterator()) {
     Symbol* baseSym = getBaseSymForConstCheck(rhs);
 
     if (baseSym->isConstant()               == true ||

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1108,16 +1108,32 @@ module ChapelArray {
       compilerError("associative domains do not support .stridable");
     }
 
-    pragma "no doc"
-    inline proc these() {
-      return _value.these();
+    iter these() ref {
+      for i in _value.these() {
+        yield i;
+      }
+    }
+    iter these(param tag: iterKind) ref
+      where tag == iterKind.standalone &&
+            __primitive("method call resolves", _value, "these", tag=tag) {
+      for i in _value.these(tag) do
+        yield i;
+    }
+    iter these(param tag: iterKind)
+      where tag == iterKind.leader {
+      // If I use forall here, it says
+      //   error: user invocation of a parallel iterator should not supply tag
+      //   arguments -- they are added implicitly by the compiler
+      for followThis in _value.these(tag) do
+        yield followThis;
+    }
+    iter these(param tag: iterKind, followThis) ref
+      where tag == iterKind.follower {
+      for i in _value.these(tag, followThis) do
+        yield i;
     }
 
-    pragma "no doc"
-    inline proc these(param tag) where
-        (tag == iterKind.leader || tag == iterKind.standalone) &&
-        __primitive("method call resolves", _value, "these", tag=tag)
-      return _value.these(tag=tag);
+
 
     // see comments for the same method in _array
     //

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -2310,11 +2310,14 @@ module ChapelArray {
       return localSlice((...d.getIndices()));
     }
 
+    pragma "reference to const when const this"
     iter these() ref {
       for i in _value.these() {
         yield i;
       }
     }
+
+    pragma "reference to const when const this"
     iter these(param tag: iterKind) ref
       where tag == iterKind.standalone &&
             __primitive("method call resolves", _value, "these", tag=tag) {
@@ -2326,6 +2329,7 @@ module ChapelArray {
       for followThis in _value.these(tag) do
         yield followThis;
     }
+    pragma "reference to const when const this"
     iter these(param tag: iterKind, followThis, param fast: bool = false) ref
       where tag == iterKind.follower {
 

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1108,12 +1108,14 @@ module ChapelArray {
       compilerError("associative domains do not support .stridable");
     }
 
-    iter these() ref {
+    // if this is ref, a coforall over these doesn't copy the
+    // index variable appropriately (iterations are sharing the value)
+    iter these() /*ref*/ {
       for i in _value.these() {
         yield i;
       }
     }
-    iter these(param tag: iterKind) ref
+    iter these(param tag: iterKind) /*ref*/
       where tag == iterKind.standalone &&
             __primitive("method call resolves", _value, "these", tag=tag) {
       for i in _value.these(tag) do
@@ -1127,7 +1129,7 @@ module ChapelArray {
       for followThis in _value.these(tag) do
         yield followThis;
     }
-    iter these(param tag: iterKind, followThis) ref
+    iter these(param tag: iterKind, followThis) /*ref*/
       where tag == iterKind.follower {
       for i in _value.these(tag, followThis) do
         yield i;

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1108,14 +1108,12 @@ module ChapelArray {
       compilerError("associative domains do not support .stridable");
     }
 
-    // if this is ref, a coforall over these doesn't copy the
-    // index variable appropriately (iterations are sharing the value)
-    iter these() /*ref*/ {
+    iter these() {
       for i in _value.these() {
         yield i;
       }
     }
-    iter these(param tag: iterKind) /*ref*/
+    iter these(param tag: iterKind)
       where tag == iterKind.standalone &&
             __primitive("method call resolves", _value, "these", tag=tag) {
       for i in _value.these(tag) do
@@ -1129,12 +1127,11 @@ module ChapelArray {
       for followThis in _value.these(tag) do
         yield followThis;
     }
-    iter these(param tag: iterKind, followThis) /*ref*/
+    iter these(param tag: iterKind, followThis)
       where tag == iterKind.follower {
       for i in _value.these(tag, followThis) do
         yield i;
     }
-
 
 
     // see comments for the same method in _array

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1127,10 +1127,17 @@ module ChapelArray {
       for followThis in _value.these(tag) do
         yield followThis;
     }
-    iter these(param tag: iterKind, followThis)
+    iter these(param tag: iterKind, followThis, param fast: bool = false)
       where tag == iterKind.follower {
-      for i in _value.these(tag, followThis) do
-        yield i;
+
+      if __primitive("method call resolves", _value, "these",
+                     tag=tag, followThis, fast=fast) {
+        for i in _value.these(tag=tag, followThis, fast=fast) do
+          yield i;
+      } else {
+        for i in _value.these(tag, followThis) do
+          yield i;
+      }
     }
 
 
@@ -2319,10 +2326,17 @@ module ChapelArray {
       for followThis in _value.these(tag) do
         yield followThis;
     }
-    iter these(param tag: iterKind, followThis) ref
+    iter these(param tag: iterKind, followThis, param fast: bool = false) ref
       where tag == iterKind.follower {
-      for i in _value.these(tag, followThis) do
-        yield i;
+
+      if __primitive("method call resolves", _value, "these",
+                     tag=tag, followThis, fast=fast) {
+        for i in _value.these(tag=tag, followThis, fast=fast) do
+          yield i;
+      } else {
+        for i in _value.these(tag, followThis) do
+          yield i;
+      }
     }
 
     // 1/5/10: do we need this since it always returns domain.numIndices?

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -2303,16 +2303,27 @@ module ChapelArray {
       return localSlice((...d.getIndices()));
     }
 
-    pragma "no doc"
-    inline proc these() {
-      return _value.these();
+    iter these() ref {
+      for i in _value.these() {
+        yield i;
+      }
     }
-
-    pragma "no doc"
-    inline proc these(param tag) where
-        (tag == iterKind.leader || tag == iterKind.standalone) &&
-        __primitive("method call resolves", _value, "these", tag=tag)
-      return _value.these(tag=tag);
+    iter these(param tag: iterKind) ref
+      where tag == iterKind.standalone &&
+            __primitive("method call resolves", _value, "these", tag=tag) {
+      for i in _value.these(tag) do
+        yield i;
+    }
+    iter these(param tag: iterKind)
+      where tag == iterKind.leader {
+      for followThis in _value.these(tag) do
+        yield followThis;
+    }
+    iter these(param tag: iterKind, followThis) ref
+      where tag == iterKind.follower {
+      for i in _value.these(tag, followThis) do
+        yield i;
+    }
 
     // 1/5/10: do we need this since it always returns domain.numIndices?
     /* Return the number of elements in the array */


### PR DESCRIPTION
The 'proc these' that returns an iterator record causes problems for iterators that include default arguments, because these default arguments will be (after 7858) allocated at the call site (before
that PR it is worse). In the problematic situation, the call site is 'proc these', which will return before the iterator runs. That's a problem if the iterator captures these default arguments by reference. It seems clear to me that whether or not an iterator has a default argument should have no bearing on whether or not the iterator captures that argument by value or by reference.  The default argument I was running in to is `offset` in DefaultRectangularDom's `iter these`.

Passed full local testing.
Passed hellos with --baseline --verify, --verify, GASNet.

Reviewed by @benharsh - thanks!