### PR TITLE
QualifiedType ref improvements supporting iterator memory management changes

### DIFF
--- a/compiler/AST/primitive.cpp
+++ b/compiler/AST/primitive.cpp
@@ -537,10 +537,24 @@ initPrimitive() {
   prim_def(PRIM_GETCID, "getcid", returnInfoInt32, false, true);
   prim_def(PRIM_SET_UNION_ID, "set_union_id", returnInfoVoid, true, true);
   prim_def(PRIM_GET_UNION_ID, "get_union_id", returnInfoDefaultInt, false, true);
+
+  // PRIM_GET_MEMBER(_VALUE): aggregate, field
+  // if the field is a ref:
+  //   GET_MEMBER is invalid AST
+  //   GET_MEMBER_VALUE returns the reference
+  // if the field is not a ref
+  //   GET_MEMBER returns a reference to the field
+  //   GET_MEMBER_VALUE returns the field value
   prim_def(PRIM_GET_MEMBER, ".", returnInfoGetMemberRef);
   prim_def(PRIM_GET_MEMBER_VALUE, ".v", returnInfoGetMember, false, true);
-  // base, field, value
+
+  // PRIM_SET_MEMBER: base, field, value
+  // if the field is a ref, and the value is a ref, sets the ptr.
+  // if the field is a ref, and the value is a not ref, invalid AST
+  // if the field is not ref, and the value is a ref, derefs value first
+  // if neither are references, sets the field
   prim_def(PRIM_SET_MEMBER, ".=", returnInfoVoid, true, true);
+
   prim_def(PRIM_CHECK_NIL, "_check_nil", returnInfoVoid, true, true);
   prim_def(PRIM_NEW, "new", returnInfoFirst);
   prim_def(PRIM_GET_REAL, "complex_get_real", returnInfoComplexField);

--- a/compiler/codegen/expr.cpp
+++ b/compiler/codegen/expr.cpp
@@ -4258,7 +4258,11 @@ GenRet CallExpr::codegenPrimitive() {
   }
 
   case PRIM_GET_MEMBER: {
-    // base=get(1) field symbol=get(2)
+    // base=get(1), field symbol=get(2)
+
+    // Invalid AST to use PRIM_GET_MEMBER with a ref field
+    INT_ASSERT(!get(2)->isRef());
+
     ret = codegenFieldPtr(get(1), get(2));
 
     // Used to only do addrOf if
@@ -4282,7 +4286,12 @@ GenRet CallExpr::codegenPrimitive() {
   }
 
   case PRIM_SET_MEMBER: {
-    // base=get(1) field=get(2) value=get(3)
+    // base=get(1), field=get(2), value=get(3)
+
+    // if the field is a ref, and the value is a not ref, invalid AST
+    if (get(2)->isRef() && !get(3)->isRef())
+      INT_FATAL("Invalid PRIM_SET_MEMBER ref field with value");
+
     GenRet ptr = codegenFieldPtr(get(1), get(2));
     GenRet val = get(3);
 
@@ -5271,6 +5280,9 @@ static bool codegenIsSpecialPrimitive(BaseAST* target, Expr* e, GenRet& ret) {
     case PRIM_GET_MEMBER: {
       /* Get a pointer to a member */
       SymExpr* se = toSymExpr(call->get(2));
+
+      // Invalid AST to use PRIM_GET_MEMBER with a ref field
+      INT_ASSERT(!call->get(2)->isRef());
 
       if (call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS) ||
           call->get(1)->isWideRef()   ||

--- a/compiler/passes/flattenFunctions.cpp
+++ b/compiler/passes/flattenFunctions.cpp
@@ -321,10 +321,14 @@ addVarsToActuals(CallExpr* call, SymbolMap* vars, bool outerCall) {
         // This is only a performance issue.
         INT_ASSERT(!sym->hasFlag(FLAG_SHOULD_NOT_PASS_BY_REF));
         /* NOTE: See note above in addVarsToFormals() */
-        VarSymbol* tmp = newTemp(sym->type->getValType()->refType);
-        call->getStmtExpr()->insertBefore(new DefExpr(tmp));
-        call->getStmtExpr()->insertBefore(new CallExpr(PRIM_MOVE, tmp, new CallExpr(PRIM_ADDR_OF, sym)));
-        call->insertAtTail(tmp);
+        if (sym->isRef())
+          call->insertAtTail(sym);
+        else {
+          VarSymbol* tmp = newTemp(sym->type->getValType()->refType);
+          call->getStmtExpr()->insertBefore(new DefExpr(tmp));
+          call->getStmtExpr()->insertBefore(new CallExpr(PRIM_MOVE, tmp, new CallExpr(PRIM_ADDR_OF, sym)));
+          call->insertAtTail(tmp);
+        }
       } else {
         call->insertAtTail(sym);
       }


### PR DESCRIPTION
This PR consists of several commits that support my work on improving iterator memory management:
 * document valid usage of PRIM_GET_MEMBER, PRIM_GET_MEMBER_VALUE, PRIM_SET_MEMBER with ref fields. As far as I know, the patterns this PR documents as invalid would have previously led to miscompiles or errors from the backend C compiler.
 * Adjust inlineFunctions to handle value actuals passed to formal arguments that are Qualified ref but not of reference type. This is particularly important given the above restriction.
 * Adjust addVarsToActuals to avoid adding a PRIM_ADDR_OF in the event an inner function refers to a QualifiedType ref variable or actual.

The individual commits contain more explanation.

Passed full local testing.
Passed hellos with --baseline --verify, --verify, GASNet.

Reviewed by @benharsh - thanks!