### PR TITLE
Update LLVM alias analysis metadata part 2

### DIFF
--- a/compiler/codegen/expr.cpp
+++ b/compiler/codegen/expr.cpp
@@ -448,13 +448,23 @@ static
 llvm::StoreInst* codegenStoreLLVM(llvm::Value* val,
                                   llvm::Value* ptr,
                                   Type* valType = NULL,
+                                  Type* baseType = NULL,
+                                  uint64_t offset = 0,
                                   bool addInvariantStart = false)
 {
   GenInfo *info = gGenInfo;
   llvm::StoreInst* ret = info->irBuilder->CreateStore(val, ptr);
   llvm::MDNode* tbaa = NULL;
-  if( USE_TBAA && valType && !valType->symbol->llvmTbaaStructCopyNode )
-    tbaa = valType->symbol->llvmTbaaAccessTag;
+  if( USE_TBAA && valType && !valType->symbol->llvmTbaaStructCopyNode ) {
+    if (baseType) {
+      tbaa = info->mdBuilder->createTBAAStructTagNode(
+               baseType->symbol->llvmTbaaTypeDescriptor,
+               valType->symbol->llvmTbaaTypeDescriptor,
+               offset);
+    } else {
+      tbaa = valType->symbol->llvmTbaaAccessTag;
+    }
+  }
   if( tbaa ) ret->setMetadata(llvm::LLVMContext::MD_tbaa, tbaa);
 
   if(!info->loopStack.empty()) {
@@ -500,21 +510,31 @@ llvm::StoreInst* codegenStoreLLVM(GenRet val,
 
   INT_ASSERT(!(ptr.alreadyStored && ptr.canBeMarkedAsConstAfterStore));
   ptr.alreadyStored = true;
-  return codegenStoreLLVM(val.val, ptr.val, valType, ptr.canBeMarkedAsConstAfterStore);
+  return codegenStoreLLVM(val.val, ptr.val, valType, ptr.baseType, ptr.offset,
+                          ptr.canBeMarkedAsConstAfterStore);
 }
 // Create an LLVM load instruction possibly adding
 // appropriate metadata based upon the Chapel type of ptr.
 static
 llvm::LoadInst* codegenLoadLLVM(llvm::Value* ptr,
                                 Type* valType = NULL,
+                                Type* baseType = NULL,
+                                uint64_t offset = 0,
                                 bool isConst = false)
 {
   GenInfo* info = gGenInfo;
   llvm::LoadInst* ret = info->irBuilder->CreateLoad(ptr);
   llvm::MDNode* tbaa = NULL;
   if( USE_TBAA && valType && !valType->symbol->llvmTbaaStructCopyNode ) {
-    if( isConst ) tbaa = valType->symbol->llvmConstTbaaAccessTag;
-    else tbaa = valType->symbol->llvmTbaaAccessTag;
+    if (baseType) {
+      tbaa = info->mdBuilder->createTBAAStructTagNode(
+               baseType->symbol->llvmTbaaTypeDescriptor,
+               valType->symbol->llvmTbaaTypeDescriptor,
+               offset, isConst);
+    } else {
+      if( isConst ) tbaa = valType->symbol->llvmConstTbaaAccessTag;
+      else tbaa = valType->symbol->llvmTbaaAccessTag;
+    }
   }
 
   if(!info->loopStack.empty()) {
@@ -537,7 +557,7 @@ llvm::LoadInst* codegenLoadLLVM(GenRet ptr,
     else valType = ptr.chplType->getValType();
   }
 
-  return codegenLoadLLVM(ptr.val, valType);
+  return codegenLoadLLVM(ptr.val, valType, ptr.baseType, ptr.offset, isConst);
 }
 
 #endif
@@ -1039,8 +1059,18 @@ GenRet codegenFieldPtr(
       INT_ASSERT(ret.val);
     } else {
       // Normally, we just use a GEP.
+      int fieldno = cBaseType->getMemberGEP(c_field_name);
       ret.val = info->irBuilder->CreateConstInBoundsGEP2_32(
-          NULL, baseValue, 0, cBaseType->getMemberGEP(c_field_name));
+          NULL, baseValue, 0, fieldno);
+      if (!isUnion(ct)) {
+        llvm::StructType *structBaseType =
+          llvm::dyn_cast<llvm::StructType>(baseValue->getType());
+        if (structBaseType) {
+          ret.baseType = castType ? castType : baseType;
+          ret.offset = info->module->getDataLayout().
+            getStructLayout(structBaseType)->getElementOffset(fieldno);
+        }
+      }
     }
 #endif
   }

--- a/compiler/include/genret.h
+++ b/compiler/include/genret.h
@@ -96,10 +96,14 @@ public:
   // one of the following is set when generating LLVM
   llvm::Value *val; // use val->getType() to obtain LLVM type
   llvm::Type *type; // set when generating a type only
+  Type *baseType; // surrounding structure, if this is a field
+  uint64_t offset; // byte offset of this field
 #else
   // Keeping same layout for non-LLVM builds
   void* val;
   void* type;
+  void* baseType;
+  uint64_t offset;
 #endif
 
   // Used to mark variables as const after they are stored
@@ -132,7 +136,7 @@ public:
                    // called type, since LLVM native integer types do not
                    // include signed-ness.
                    
-  GenRet() : c(), val(NULL), type(NULL), canBeMarkedAsConstAfterStore(false), alreadyStored(false), chplType(NULL), isLVPtr(GEN_VAL), isUnsigned(false) { }
+  GenRet() : c(), val(NULL), type(NULL), baseType(NULL), offset(0), canBeMarkedAsConstAfterStore(false), alreadyStored(false), chplType(NULL), isLVPtr(GEN_VAL), isUnsigned(false) { }
   // Allow implicit conversion from AST elements.
   GenRet(BaseAST* ast) {
     *this = baseASTCodegen(ast);


### PR DESCRIPTION
Update LLVM TBAA metadata to take struct members into account.  Member access is now reported as part of the struct as well as the member type itself, adding to the information available for the alias analysis passes.

Another PR will recursively handle members of members as well as performing some cleanup and adding some tests.

Passes full local LLVM testing.