### PR TITLE
Only consider "online" nodes in paratest.chapcs when making a reservation

### DIFF
--- a/util/test/paratest.chapcs
+++ b/util/test/paratest.chapcs
@@ -78,13 +78,15 @@ def get_exclusive_nodes():
 def get_num_non_exclusive_nodes():
     """
     Get the number of nodes available for testing on the chapel partition
-    (total - exclusive)
+    (online - exclusive)
     """
+    online_states = 'ALLOC,ALLOCATED,COMP,COMPLETING,IDLE,MIX,MIXED'
     sinfo_cmd = ['sinfo',
                  '--partition=chapel',
                  '--noheader',
                  '--responding',
-                 '--format="%D"']
+                 '--format="%D"',
+                 '--states={0}'.format(online_states)]
     sinfo_out = run_command_wrapper(sinfo_cmd)
     num_online_nodes = int(sinfo_out[0])
     num_non_exclusive_nodes = num_online_nodes - get_exclusive_nodes()[0]


### PR DESCRIPTION
Previously we just computed the total number of "responding" nodes, but this
didn't work correctly if a node was actually online but marked as "drain" (or
a handful of other states.)

Fix this to only check for nodes that are "online" (allocated, completing,
idle, or mixed -- see https://slurm.schedmd.com/sinfo.html "Node State Codes"
for more info)