### PR TITLE
Delay generic 1

### DIFF
--- a/compiler/resolution/callInfo.cpp
+++ b/compiler/resolution/callInfo.cpp
@@ -31,8 +31,8 @@ CallInfo::CallInfo() {
   name  = NULL;
 }
 
-bool CallInfo::isNotWellFormed(CallExpr* callExpr) {
-  bool retval = false;
+bool CallInfo::isWellFormed(CallExpr* callExpr) {
+  bool retval = true;
 
   call = callExpr;
 
@@ -61,7 +61,7 @@ bool CallInfo::isNotWellFormed(CallExpr* callExpr) {
     }
   }
 
-  for (int i = 1; i <= call->numActuals() && retval == false; i++) {
+  for (int i = 1; i <= call->numActuals() && retval == true; i++) {
     Expr* actual = call->get(i);
 
     if (NamedExpr* named = toNamedExpr(actual)) {
@@ -81,11 +81,11 @@ bool CallInfo::isNotWellFormed(CallExpr* callExpr) {
     Type*    t   = sym->type;
 
     if (t == dtUnknown && sym->hasFlag(FLAG_TYPE_VARIABLE) == false) {
-      retval = true;
+      retval = false;
 
     } else if (t->symbol->hasFlag(FLAG_GENERIC) == true &&
                sym->hasFlag(FLAG_DELAY_GENERIC_EXPANSION) == false) {
-      retval = true;
+      retval = false;
 
     } else {
       actuals.add(sym);

--- a/compiler/resolution/callInfo.cpp
+++ b/compiler/resolution/callInfo.cpp
@@ -83,9 +83,14 @@ bool CallInfo::isWellFormed(CallExpr* callExpr) {
     if (t == dtUnknown && sym->hasFlag(FLAG_TYPE_VARIABLE) == false) {
       retval = false;
 
-    } else if (t->symbol->hasFlag(FLAG_GENERIC) == true &&
-               sym->hasFlag(FLAG_DELAY_GENERIC_EXPANSION) == false) {
-      retval = false;
+    } else if (t->symbol->hasFlag(FLAG_GENERIC) == true) {
+      // The _this actual to an initializer may be generic
+      if (strcmp(name, "init") == 0 && i == 2) {
+        actuals.add(sym);
+
+      } else {
+        retval = false;
+      }
 
     } else {
       actuals.add(sym);
@@ -116,11 +121,9 @@ void CallInfo::haltNotWellFormed() const {
                 sym->name);
 
     } else if (t->symbol->hasFlag(FLAG_GENERIC) == true) {
-      if (sym->hasFlag(FLAG_DELAY_GENERIC_EXPANSION) == false) {
-        INT_FATAL(call,
-                  "the type of the actual argument '%s' is generic",
-                  sym->name);
-      }
+      INT_FATAL(call,
+                "the type of the actual argument '%s' is generic",
+                sym->name);
     }
   }
 }

--- a/compiler/resolution/callInfo.h
+++ b/compiler/resolution/callInfo.h
@@ -30,7 +30,7 @@ class CallInfo {
 public:
                    CallInfo();
 
-  bool             isNotWellFormed(CallExpr* call);
+  bool             isWellFormed(CallExpr* call);
 
   void             haltNotWellFormed()                                   const;
 

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -2026,15 +2026,14 @@ FnSymbol* resolveNormalCall(CallExpr* call, bool checkOnly) {
   if (isGenericRecordInit(call) == true) {
     retval = resolveInitializer(call);
 
-  } else if (info.isNotWellFormed(call) == true) {
-    if (checkOnly == false) {
-      info.haltNotWellFormed();
-
-    } else {
-      return NULL;
-    }
-  } else {
+  } else if (info.isWellFormed(call) == true) {
     retval = resolveNormalCall(info, checkOnly);
+
+  } else if (checkOnly == true) {
+    retval = NULL;
+
+  } else {
+    info.haltNotWellFormed();
   }
 
   return retval;
@@ -2228,26 +2227,26 @@ static FnSymbol* resolveNormalCall(CallInfo&            info,
     if (valueCall != NULL && valueCall != call) {
       CallInfo tmpInfo;
 
-      if (tmpInfo.isNotWellFormed(valueCall) == true) {
+      if (tmpInfo.isWellFormed(valueCall) == true) {
+        wrapAndCleanUpActuals(bestValue, tmpInfo, false);
+
+      } else {
         if (checkOnly == false) {
           tmpInfo.haltNotWellFormed();
         }
-
-      } else {
-        wrapAndCleanUpActuals(bestValue, tmpInfo, false);
       }
     }
 
     if (constRefCall != NULL) {
       CallInfo tmpInfo;
 
-      if (tmpInfo.isNotWellFormed(constRefCall) == true) {
+      if (tmpInfo.isWellFormed(constRefCall) == true) {
+        wrapAndCleanUpActuals(bestConstRef, tmpInfo, false);
+
+      } else {
         if (checkOnly == false) {
           tmpInfo.haltNotWellFormed();
         }
-
-      } else {
-        wrapAndCleanUpActuals(bestConstRef, tmpInfo, false);
       }
     }
 

--- a/test/classes/initializers/generics/initAtomicsViaWrite.bad
+++ b/test/classes/initializers/generics/initAtomicsViaWrite.bad
@@ -1,4 +1,5 @@
-initAtomicsViaWrite.chpl:3: internal error: GEN0433 chpl Version 1.16.0 pre-release (c0bf20b)
+initAtomicsViaWrite.chpl:5: In initializer:
+initAtomicsViaWrite.chpl:6: internal error: CAL0123 chpl Version 1.17.0 pre-release (5a84825)
 
 Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
 and we're sorry for the hassle.  We would appreciate your reporting this bug -- 


### PR DESCRIPTION
Begin to take weight off FLAG_DELAY_GENERIC_EXPANSION

One of the steps taken to advance initializers for generic
types was to introduce FLAG_DELAY_GENERIC_EXPANSION
to modify certain control/data flows within portions of resolution.

This PR makes a simple change to CallInfo so that it does
not rely on this flag for one of the checks that it happens
to implement.  The new version of the check is now clearly
an exception for the _this actual to an initializer.

Compiled with/without CHPL_DEVELOPER etc.
Passed a single-locale paratest with -futures.

