### PR TITLE
Generate error rather than segfault when casting empty string to real

### DIFF
--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -898,7 +898,7 @@ static void build_enum_cast_function(EnumType* et) {
   fn->insertFormalAtTail(arg1);
   fn->insertFormalAtTail(arg2);
 
-  // Handle error case of trying to convert an empty string
+  // First, handle error case of trying to convert an empty string
   fn->insertAtTail(new CondStmt(new CallExpr(buildDotExpr(arg2,
                                                           "isEmptyString"),
                                              new CallExpr(PRIM_ACTUALS_LIST)),
@@ -907,7 +907,6 @@ static void build_enum_cast_function(EnumType* et) {
                                                                     et->symbol->name)))));
 
   CondStmt* cond = NULL;
-
   for_enums(constant, et) {
     cond = new CondStmt(
              new CallExpr("==", arg2, new_StringSymbol(constant->sym->name)),

--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -898,7 +898,16 @@ static void build_enum_cast_function(EnumType* et) {
   fn->insertFormalAtTail(arg1);
   fn->insertFormalAtTail(arg2);
 
+  // Handle error case of trying to convert an empty string
+  fn->insertAtTail(new CondStmt(new CallExpr(buildDotExpr(arg2,
+                                                          "isEmptyString"),
+                                             new CallExpr(PRIM_ACTUALS_LIST)),
+                                new CallExpr(PRIM_RT_ERROR,
+                                             new_CStringSymbol(astr("Empty string when converting from string to ",
+                                                                    et->symbol->name)))));
+
   CondStmt* cond = NULL;
+
   for_enums(constant, et) {
     cond = new CondStmt(
              new CallExpr("==", arg2, new_StringSymbol(constant->sym->name)),

--- a/modules/internal/StringCasts.chpl
+++ b/modules/internal/StringCasts.chpl
@@ -45,7 +45,10 @@ module StringCasts {
 
   proc _cast(type t, x: string) where isBoolType(t) {
     var str = x.strip();
-    if (str == "true") {
+    if str.isEmptyString() {
+      __primitive("chpl_error", c"Empty string when converting from string to bool");
+      return false;
+    } else if (str == "true") {
       return true;
     } else if (str == "false") {
       return false;

--- a/runtime/src/chplcast.c
+++ b/runtime/src/chplcast.c
@@ -356,7 +356,7 @@ _define_string_to_int_type(uint, 64)
                                            int32_t filename) {         \
     int invalid;                                                        \
     char invalidStr[2] = "\0\0";                                        \
-    _##base##width val;                                                 \
+    _##base##width val = 0.0;                                           \
     if (!str) {                                                         \
       invalid = 1;                                                      \
     } else {                                                            \

--- a/runtime/src/chplcast.c
+++ b/runtime/src/chplcast.c
@@ -356,9 +356,14 @@ _define_string_to_type(uint, 64)
                                            int32_t filename) {         \
     int invalid;                                                        \
     char invalidStr[2] = "\0\0";                                        \
-    _##base##width val = c_string_to_##base##width##_precise(str,       \
-                                                             &invalid, \
-                                                             invalidStr); \
+    _##base##width val;                                                 \
+    if (!str) {                                                         \
+      invalid = 1;                                                      \
+    } else {                                                            \
+      val = c_string_to_##base##width##_precise(str,                    \
+                                                &invalid,               \
+                                                invalidStr);            \
+    }                                                                   \
     if (invalid) {                                                      \
       const char* message;                                              \
       if (invalid == 2) {                                               \

--- a/runtime/src/chplcast.c
+++ b/runtime/src/chplcast.c
@@ -310,7 +310,7 @@ _define_string_to_complex_precise(complex, 128, "%lf", 64)
 
 
 
-#define _define_string_to_type(base, width)                             \
+#define _define_string_to_int_type(base, width)                             \
   _type(base, width) c_string_to_##base##width##_t(c_string str, int lineno, \
                                                    int32_t filename) {   \
     int invalid;                                                        \
@@ -342,14 +342,14 @@ _define_string_to_complex_precise(complex, 128, "%lf", 64)
     return val;                                                         \
   }
 
-_define_string_to_type(int, 8)
-_define_string_to_type(int, 16)
-_define_string_to_type(int, 32)
-_define_string_to_type(int, 64)
-_define_string_to_type(uint, 8)
-_define_string_to_type(uint, 16)
-_define_string_to_type(uint, 32)
-_define_string_to_type(uint, 64)
+_define_string_to_int_type(int, 8)
+_define_string_to_int_type(int, 16)
+_define_string_to_int_type(int, 32)
+_define_string_to_int_type(int, 64)
+_define_string_to_int_type(uint, 8)
+_define_string_to_int_type(uint, 16)
+_define_string_to_int_type(uint, 32)
+_define_string_to_int_type(uint, 64)
 
 #define _define_string_to_real_type(base, width)                        \
   _##base##width c_string_to_##base##width(c_string str, int lineno,    \

--- a/test/types/string/cast/emptyStringToBool.good
+++ b/test/types/string/cast/emptyStringToBool.good
@@ -1,1 +1,1 @@
-emptyStringToType.chpl:4: error: halt reached - Unexpected value when converting from string to bool: ''
+emptyStringToType.chpl:6: error: halt reached - Unexpected value when converting from string to bool: ''

--- a/test/types/string/cast/emptyStringToBool.good
+++ b/test/types/string/cast/emptyStringToBool.good
@@ -1,1 +1,1 @@
-emptyStringToType.chpl:6: error: halt reached - Unexpected value when converting from string to bool: ''
+emptyStringToType.chpl:6: error: Empty string when converting from string to bool

--- a/test/types/string/cast/emptyStringToBool.good
+++ b/test/types/string/cast/emptyStringToBool.good
@@ -1,0 +1,1 @@
+emptyStringToType.chpl:4: error: halt reached - Unexpected value when converting from string to bool: ''

--- a/test/types/string/cast/emptyStringToComplex.good
+++ b/test/types/string/cast/emptyStringToComplex.good
@@ -1,1 +1,1 @@
-emptyStringToType.chpl:4: error: Empty string when converting from string to complex(128)
+emptyStringToType.chpl:6: error: Empty string when converting from string to complex(128)

--- a/test/types/string/cast/emptyStringToComplex.good
+++ b/test/types/string/cast/emptyStringToComplex.good
@@ -1,0 +1,1 @@
+emptyStringToType.chpl:4: error: Empty string when converting from string to complex(128)

--- a/test/types/string/cast/emptyStringToEnum.good
+++ b/test/types/string/cast/emptyStringToEnum.good
@@ -1,0 +1,1 @@
+emptyStringToType.chpl:6: error: halt reached - illegal conversion of string "" to color

--- a/test/types/string/cast/emptyStringToEnum.good
+++ b/test/types/string/cast/emptyStringToEnum.good
@@ -1,1 +1,1 @@
-emptyStringToType.chpl:6: error: halt reached - illegal conversion of string "" to color
+emptyStringToType.chpl:6: error: Empty string when converting from string to color

--- a/test/types/string/cast/emptyStringToImag.good
+++ b/test/types/string/cast/emptyStringToImag.good
@@ -1,0 +1,1 @@
+emptyStringToType.chpl:6: error: Empty string when converting from string to imag(64)

--- a/test/types/string/cast/emptyStringToInt.good
+++ b/test/types/string/cast/emptyStringToInt.good
@@ -1,0 +1,1 @@
+emptyStringToType.chpl:4: error: Empty string when converting from string to int(64)

--- a/test/types/string/cast/emptyStringToInt.good
+++ b/test/types/string/cast/emptyStringToInt.good
@@ -1,1 +1,1 @@
-emptyStringToType.chpl:4: error: Empty string when converting from string to int(64)
+emptyStringToType.chpl:6: error: Empty string when converting from string to int(64)

--- a/test/types/string/cast/emptyStringToReal.good
+++ b/test/types/string/cast/emptyStringToReal.good
@@ -1,1 +1,1 @@
-emptyStringToType.chpl:4: error: Empty string when converting from string to real(64)
+emptyStringToType.chpl:6: error: Empty string when converting from string to real(64)

--- a/test/types/string/cast/emptyStringToReal.good
+++ b/test/types/string/cast/emptyStringToReal.good
@@ -1,0 +1,1 @@
+emptyStringToType.chpl:4: error: Empty string when converting from string to real(64)

--- a/test/types/string/cast/emptyStringToType.chpl
+++ b/test/types/string/cast/emptyStringToType.chpl
@@ -1,0 +1,7 @@
+config type t = real;
+config var s: string;
+
+var x = s: t;
+
+writeln( "s = ", s );
+writeln( "x = ", x );

--- a/test/types/string/cast/emptyStringToType.chpl
+++ b/test/types/string/cast/emptyStringToType.chpl
@@ -1,3 +1,5 @@
+enum color {red, green, blue};
+
 config type t = real;
 config var s: string;
 

--- a/test/types/string/cast/emptyStringToType.compopts
+++ b/test/types/string/cast/emptyStringToType.compopts
@@ -2,4 +2,6 @@
 -st=int      # emptyStringToInt.good
 -st=uint     # emptyStringToUint.good
 -st=bool     # emptyStringToBool.good
+-st=imag     # emptyStringToImag.good
 -st=complex  # emptyStringToComplex.good
+-st=color    # emptyStringToEnum.good

--- a/test/types/string/cast/emptyStringToType.compopts
+++ b/test/types/string/cast/emptyStringToType.compopts
@@ -1,0 +1,5 @@
+-st=real     # emptyStringToReal.good
+-st=int      # emptyStringToInt.good
+-st=uint     # emptyStringToUint.good
+-st=bool     # emptyStringToBool.good
+-st=complex  # emptyStringToComplex.good

--- a/test/types/string/cast/emptyStringToUint.good
+++ b/test/types/string/cast/emptyStringToUint.good
@@ -1,1 +1,1 @@
-emptyStringToType.chpl:4: error: Empty string when converting from string to uint(64)
+emptyStringToType.chpl:6: error: Empty string when converting from string to uint(64)

--- a/test/types/string/cast/emptyStringToUint.good
+++ b/test/types/string/cast/emptyStringToUint.good
@@ -1,0 +1,1 @@
+emptyStringToType.chpl:4: error: Empty string when converting from string to uint(64)


### PR DESCRIPTION
This patch generates an error message when converting empty strings to floating point types rather than the segfault we were getting before, as reported in issue #7989.  It also adds a test that ensures that error messages are generated when casting empty strings to several basic types.

While here, I put in a minor cleanup effort to unify the error messages for bools and enums to more closely match what we do for integers and (now) floating point values.

I also renamed the `_define_string_to_type` macro used to perform string->int conversions to `_define_string_to_int_type` since it only handles the integer cases and this improved orthogonality with the floating point cases.

This PR fixes #7989.