### PR TITLE
Avoid errors when using system LLVM 5

### DIFF
--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -182,11 +182,13 @@ static void ensureTmpDirExists() {
 }
 
 
+#if !defined(HAVE_LLVM) || HAVE_LLVM_VER < 50
 static
 void deleteDirSystem(const char* dirname) {
   const char* cmd = astr("rm -rf ", dirname);
   mysystem(cmd, astr("removing directory: ", dirname));
 }
+#endif
 
 #ifdef HAVE_LLVM
 static

--- a/compiler/util/llvmDebug.cpp
+++ b/compiler/util/llvmDebug.cpp
@@ -507,7 +507,9 @@ llvm::DIFile* debug_data::get_file(const char *fpath)
 llvm::DINamespace* debug_data::construct_module_scope(ModuleSymbol* modSym)
 {
   const char* fname = modSym->fname();
+#if HAVE_LLVM_VER < 50
   int line = modSym->linenum();
+#endif
   llvm::DIFile* file = get_file(fname);
   return this->dibuilder.createNameSpace(file, /* Scope */
                                          modSym->name, /* Name */


### PR DESCRIPTION
When compiling with CHPL_LLVM=system and LLVM version 5, and either WARNINGS or CHPL_DEVELOPER set, compiler/util/files.cpp gets an error for an unused function, and compiler/util/llvmDebug.cpp gets an error for an unused variable.

These errors were masked with CHPL_LLVM=llvm because we compile LLVM without LLVM_ENABLE_WARNINGS set, so llvm-config adds the `-w` flag to disable all warnings.  The system LLVM typically has LLVM_ENABLE_WARNINGS turned on, and only disables specific warnings that it needs to disable.  Hence these errors become visible when CHPL_LLVM=system.

This change conditionally compiles the offending function and variable declarations, so that they are only available when they are needed.

Tested with LLVM 4 and LLVM 5, with both CHPL_LLVM=llvm and CHPL_LLVM=system.
Also tested with CHPL_LLVM=none.