### PR TITLE
Revert "Adjust addVarsToActuals to handle Qualified-Ref fields"

### DIFF
--- a/compiler/passes/flattenFunctions.cpp
+++ b/compiler/passes/flattenFunctions.cpp
@@ -321,14 +321,10 @@ addVarsToActuals(CallExpr* call, SymbolMap* vars, bool outerCall) {
         // This is only a performance issue.
         INT_ASSERT(!sym->hasFlag(FLAG_SHOULD_NOT_PASS_BY_REF));
         /* NOTE: See note above in addVarsToFormals() */
-        if (sym->isRef())
-          call->insertAtTail(sym);
-        else {
-          VarSymbol* tmp = newTemp(sym->type->getValType()->refType);
-          call->getStmtExpr()->insertBefore(new DefExpr(tmp));
-          call->getStmtExpr()->insertBefore(new CallExpr(PRIM_MOVE, tmp, new CallExpr(PRIM_ADDR_OF, sym)));
-          call->insertAtTail(tmp);
-        }
+        VarSymbol* tmp = newTemp(sym->type->getValType()->refType);
+        call->getStmtExpr()->insertBefore(new DefExpr(tmp));
+        call->getStmtExpr()->insertBefore(new CallExpr(PRIM_MOVE, tmp, new CallExpr(PRIM_ADDR_OF, sym)));
+        call->insertAtTail(tmp);
       } else {
         call->insertAtTail(sym);
       }


### PR DESCRIPTION
This reverts commit d1ceac07d0be8897a01851f2be3ffff205250ed5.

That commit caused failures with --no-local or GASNet for test/studies/comd/llnl/CoMD (the symptom is that the energy is wrong at the start of the simulation). Additionally it caused a performance regression for the force part of the calculation. I'm reverting the change at least until there is a solution for the CoMD issue.

Passed full local testing.