### PR TITLE
Fix some failing futures caused by my introduction of new initializers

### DIFF
--- a/test/classes/initializers/compilerGenerated/arrayField-compInit.bad
+++ b/test/classes/initializers/compilerGenerated/arrayField-compInit.bad
@@ -1,11 +1,3 @@
 arrayField-compInit.chpl:14: error: unresolved call '_new(type C, [BlockDom(1,int(64),false,DefaultDist)] real(64))'
 arrayField-compInit.chpl:3: note: candidates are: _new(type chpl_t, X: [domain(1,int(64),false)] real(64))
-$CHPL_HOME/modules/internal/localeModels/flat/LocaleModel.chpl:58: note:                 _new(type chpl_t)
-$CHPL_HOME/modules/internal/localeModels/flat/LocaleModel.chpl:58: note:                 _new(type chpl_t, parent_loc: locale)
-$CHPL_HOME/modules/internal/localeModels/flat/LocaleModel.chpl:159: note:                 _new(type chpl_t)
-$CHPL_HOME/modules/internal/ChapelLocale.chpl:98: note:                 _new(type chpl_t)
-$CHPL_HOME/modules/internal/ChapelLocale.chpl:98: note:                 _new(type chpl_t, parent: locale)
-$CHPL_HOME/modules/internal/ChapelLocale.chpl:335: note:                 _new(type chpl_t)
-$CHPL_HOME/modules/internal/ChapelLocale.chpl:361: note:                 _new(type chpl_t, parent_loc: locale)
-$CHPL_HOME/modules/internal/ChapelLocale.chpl:361: note:                 _new(type chpl_t)
-$CHPL_HOME/modules/internal/ChapelLocale.chpl:403: note:                 _new(type chpl_t)
+(prediff deleted module lines)

--- a/test/classes/initializers/compilerGenerated/arrayField-compInit.prediff
+++ b/test/classes/initializers/compilerGenerated/arrayField-compInit.prediff
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+output=$2
+cat $output | sed '/^\$CHPL_HOME\/modules\// d' > $output.tmp
+echo "(prediff deleted module lines)" >> $output.tmp
+mv $output.tmp $output

--- a/test/classes/initializers/generics/typeAlias.bad
+++ b/test/classes/initializers/generics/typeAlias.bad
@@ -1,10 +1,2 @@
 typeAlias.chpl:14: error: unresolved call '_new(type Generic(string), "hello")'
-$CHPL_HOME/modules/internal/localeModels/flat/LocaleModel.chpl:58: note: candidates are: _new(type chpl_t)
-$CHPL_HOME/modules/internal/localeModels/flat/LocaleModel.chpl:58: note:                 _new(type chpl_t, parent_loc: locale)
-$CHPL_HOME/modules/internal/localeModels/flat/LocaleModel.chpl:159: note:                 _new(type chpl_t)
-$CHPL_HOME/modules/internal/ChapelLocale.chpl:98: note:                 _new(type chpl_t)
-$CHPL_HOME/modules/internal/ChapelLocale.chpl:98: note:                 _new(type chpl_t, parent: locale)
-$CHPL_HOME/modules/internal/ChapelLocale.chpl:335: note:                 _new(type chpl_t)
-$CHPL_HOME/modules/internal/ChapelLocale.chpl:361: note:                 _new(type chpl_t, parent_loc: locale)
-$CHPL_HOME/modules/internal/ChapelLocale.chpl:361: note:                 _new(type chpl_t)
-$CHPL_HOME/modules/internal/ChapelLocale.chpl:403: note:                 _new(type chpl_t)
+(prediff deleted module lines)

--- a/test/classes/initializers/generics/typeAlias.prediff
+++ b/test/classes/initializers/generics/typeAlias.prediff
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+output=$2
+cat $output | sed '/^\$CHPL_HOME\/modules\// d' > $output.tmp
+echo "(prediff deleted module lines)" >> $output.tmp
+mv $output.tmp $output

--- a/test/classes/initializers/generics/typeFunctions/fnReturnsConcrete.bad
+++ b/test/classes/initializers/generics/typeFunctions/fnReturnsConcrete.bad
@@ -1,10 +1,2 @@
 fnReturnsConcrete.chpl:15: error: unresolved call '_new(type C(int(64)))'
-$CHPL_HOME/modules/internal/localeModels/flat/LocaleModel.chpl:58: note: candidates are: _new(type chpl_t)
-$CHPL_HOME/modules/internal/localeModels/flat/LocaleModel.chpl:58: note:                 _new(type chpl_t, parent_loc: locale)
-$CHPL_HOME/modules/internal/localeModels/flat/LocaleModel.chpl:159: note:                 _new(type chpl_t)
-$CHPL_HOME/modules/internal/ChapelLocale.chpl:98: note:                 _new(type chpl_t)
-$CHPL_HOME/modules/internal/ChapelLocale.chpl:98: note:                 _new(type chpl_t, parent: locale)
-$CHPL_HOME/modules/internal/ChapelLocale.chpl:335: note:                 _new(type chpl_t)
-$CHPL_HOME/modules/internal/ChapelLocale.chpl:361: note:                 _new(type chpl_t, parent_loc: locale)
-$CHPL_HOME/modules/internal/ChapelLocale.chpl:361: note:                 _new(type chpl_t)
-$CHPL_HOME/modules/internal/ChapelLocale.chpl:403: note:                 _new(type chpl_t)
+(prediff deleted module lines)

--- a/test/classes/initializers/generics/typeFunctions/fnReturnsConcrete.prediff
+++ b/test/classes/initializers/generics/typeFunctions/fnReturnsConcrete.prediff
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+output=$2
+cat $output | sed '/^\$CHPL_HOME\/modules\// d' > $output.tmp
+echo "(prediff deleted module lines)" >> $output.tmp
+mv $output.tmp $output


### PR DESCRIPTION
The approach I took here was to apply the same prediff as I used to
quiet noise on the where-clause4.chpl test to these tests so that we
wouldn't have to keep updating the .bad files as new initializers were
added to the module code.