### PR TITLE
Remove CHPL_LOCALE_MODEL!=flat suppressif

### DIFF
--- a/test/classes/initializers/where-clause4.suppressif
+++ b/test/classes/initializers/where-clause4.suppressif
@@ -1,6 +1,0 @@
-# locale model results in bad init() candidates
-#
-# currently, we're generating locale-model-specific candidates, so
-# here, I'm hard-coding the .good file to 'flat' and suppress the
-# errors for other locale models
-CHPL_LOCALE_MODEL!=flat


### PR DESCRIPTION
On my advice, Brad added a prediff to this test so we wouldn't have to keep
updating it after every new module code initializer.  But the prediff made it
so that the output across locale models was reunified, so the suppressif is no
longer necessary.  Remove it.