### PR TITLE
Remove -O from ra-dist.compopts to work around GCC 6.3 issue

### DIFF
--- a/test/studies/hpcc/RA/bradc/parallel/ra-dist.compopts
+++ b/test/studies/hpcc/RA/bradc/parallel/ra-dist.compopts
@@ -1,1 +1,1 @@
-../../../common/probSize.chpl -M ../../../../../release/examples/benchmarks/hpcc/ --no-warnings -O --no-local
+../../../common/probSize.chpl -M ../../../../../release/examples/benchmarks/hpcc/ --no-warnings --no-local


### PR DESCRIPTION
The program was seg-faulting when compiled with --baseline.

The error goes away with GCC 7.2 or with lower levels of C compiler
optimization (-O1, -O2 work; -O3 triggers the bug).

This commit makes the simple adjustment to remove -O from ra-dist.compopts
as a workaround.

Digging in to the error, it seems that GCC emitted a

  movdqa 0x28(%r13), %xmm0

where %r13 is the base address for some heap allocation (namely an iterator
class in this case).

Note that movdqa requires the address loaded to be 16-byte aligned.  %r13 is a
heap allocation and is 16-byte aligned. Adding 0x28 to it gives a pointer that
is not a multiple of 16. 0x28 is just the offset of a particular field in the
allocated class instance and I don't see any reason that the generated C code
indicates it should be 16-byte aligned.

See also PRs #7602 #7792.