### PR TITLE
Dispatch parents 1

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -396,37 +396,45 @@ void AggregateType::accept(AstVisitor* visitor) {
 // Returns true if the type has generic fields, false otherwise.
 // If the index of the first generic field has not previously been set, set it.
 bool AggregateType::setNextGenericField() {
-  // Don't redo work
-  if (genericField > 0)
-    return true;
+  bool retval = true;
 
-  int idx = 1;
-  for_fields(field, this) {
-    if (field->hasFlag(FLAG_TYPE_VARIABLE) || field->hasFlag(FLAG_PARAM) ||
-        (field->defPoint->init == NULL && field->defPoint->exprType == NULL
-         && field->type == dtUnknown)) {
-      // TODO: do something special if the type of the field is known but
-      // generic
-      genericField = idx;
-      break;
+  if (genericField == 0) {
+    int idx = 1;
+
+    for_fields(field, this) {
+      if (field->hasFlag(FLAG_TYPE_VARIABLE) == true ||
+          field->hasFlag(FLAG_PARAM)         == true ||
+          (field->defPoint->init     == NULL &&
+           field->defPoint->exprType == NULL &&
+           field->type == dtUnknown)) {
+        genericField = idx;
+        break;
+
+      } else {
+        idx++;
+      }
     }
-    idx++;
+
+    if (isClass() == true) {
+      if (dispatchParents.v[0]                                != NULL &&
+          dispatchParents.v[0]->symbol->hasFlag(FLAG_GENERIC) == true) {
+
+        if (AggregateType* parent = toAggregateType(dispatchParents.v[0])) {
+          if (parent->setNextGenericField() == false) {
+            INT_ASSERT(false);
+          }
+        }
+      }
+    }
+
+    if (genericField != 0) {
+      symbol->addFlag(FLAG_GENERIC);
+    } else {
+      retval = false;
+    }
   }
 
-  if (dispatchParents.v[0] != NULL &&
-      dispatchParents.v[0]->symbol->hasFlag(FLAG_GENERIC)) {
-    AggregateType* parent = toAggregateType(dispatchParents.v[0]);
-    if (parent) {
-      bool parentVal = parent->setNextGenericField();
-      INT_ASSERT(parentVal);
-    }
-  }
-
-  if (genericField != 0) {
-    symbol->addFlag(FLAG_GENERIC);
-    return true;
-  } else
-    return false;
+  return retval;
 }
 
 // Returns an instantiation of this AggregateType at the given index.  If the

--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -2098,20 +2098,10 @@ void AggregateType::setCreationStyle(TypeSymbol* t, FnSymbol* fn) {
 }
 
 void AggregateType::addRootType() {
-  // make root records inherit from value
-  // make root classes inherit from object
-  if (inherits.length == 0 && symbol->hasFlag(FLAG_NO_OBJECT) == false) {
-    SET_LINENO(this);
+  if (isClass() == true) {
+    if (inherits.length == 0 && symbol->hasFlag(FLAG_NO_OBJECT) == false) {
+      SET_LINENO(this);
 
-    if (isRecord() == true) {
-      dispatchParents.add(dtValue);
-
-      // Assume that this addition is unique; report if not.
-      if (dtValue->dispatchChildren.add_exclusive(this) == false) {
-        INT_ASSERT(false);
-      }
-
-    } else if (isClass() == true) {
       VarSymbol* super = new VarSymbol("super", dtObject);
 
       dispatchParents.add(dtObject);


### PR DESCRIPTION
Begin to update Type::dispatchParents[]


Within the current compiler every instance of
the class Type includes two dynamic vectors

Vec<Type*> Type::dispatchParents;
Vec<Type*> Type::dispatchChildren;

In the nearer term it would be more logical for these
to be

std::vector<AggregateType*> AggregateType::dispatchParents;
std::vector<AggregateType*> AggregateType::dispatchChildren;


As far as I am aware, the only case in which dispatchParents[]
contains a Type* rather than an AggregateType* is when
dtValue is inserted in to record types.


This PR updates AggregateType::addRootType() to stop
inserting dtValue in to dispatchParents[] and then makes
minor changes to two functions that assume that dispatchParents[]
has at least 1 value.  In practice the code in question is only meaningful
for Classes and so is easy to handle.

Compiled with/without CHPL_DEVELOPER on clang/darwin and
gcc/lnux64.  Passed a paratest with futures and --no-local.




