### PR TITLE
Remove CHPL_NETWORK_ATOMICS from --path output

### DIFF
--- a/util/printchplenv
+++ b/util/printchplenv
@@ -237,9 +237,12 @@ def filter_tidy(chpl_env):
     return True
 
 
-"""Filter CHPL_MAKE for --path (special case)"""
+"""Filter CHPL_MAKE and CHPL_NETWORK_ATOMICS for --path (special cases)"""
 def filter_path(chpl_env):
-    return chpl_env.name != 'CHPL_MAKE'
+    name = chpl_env.name.strip()
+    if name == 'CHPL_MAKE' or name == 'CHPL_NETWORK_ATOMICS':
+        return False
+    return True
 
 
 """Filter variables that are not selected in contents

--- a/util/printchplenv
+++ b/util/printchplenv
@@ -239,10 +239,7 @@ def filter_tidy(chpl_env):
 
 """Filter CHPL_MAKE and CHPL_NETWORK_ATOMICS for --path (special cases)"""
 def filter_path(chpl_env):
-    name = chpl_env.name.strip()
-    if name == 'CHPL_MAKE' or name == 'CHPL_NETWORK_ATOMICS':
-        return False
-    return True
+    return chpl_env.name not in ['CHPL_MAKE', '  CHPL_NETWORK_ATOMICS']
 
 
 """Filter variables that are not selected in contents


### PR DESCRIPTION
`CHPL_NETWORK_ATOMICS` should not be part of the `--runtime --path` output, so it is removed as a special case check.

```
> printchplenv --runtime --path # (master)
darwin/clang/arch-unknown/loc-flat/comm-ugni/tasks-qthreads/tmr-generic/unwind-none/mem-jemalloc/atomics-intrinsics/ugni/gmp-none/hwloc/re2/fs-none

> printchplenv --runtime --path # (this PR)
darwin/clang/arch-unknown/loc-flat/comm-ugni/tasks-qthreads/tmr-generic/unwind-none/mem-jemalloc/atomics-intrinsics/gmp-none/hwloc/re2/fs-none
```

### Testing

- [x] ugni check (confirmed by @ronawho )
- [x] `linux64 paratest`
  - `[Summary: #Successes = 8056 | #Failures = 0 | #Futures = 0]`