### PR TITLE
dispatchParents :- dispatchParents[] from Vec<Type*> to Vec<AggregateType*>

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -511,8 +511,12 @@ AggregateType* AggregateType::getInstantiation(Symbol* sym, int index) {
   // been done outside of the AggregateType by
   // instantiateTypeForTypeConstructor.  Totally)
   forv_Vec(Type, pt, this->dispatchParents) {
-    newInstance->dispatchParents.add(pt);
-    bool inserted = pt->dispatchChildren.add_exclusive(newInstance);
+    AggregateType* at = toAggregateType(pt);
+    INT_ASSERT(at != NULL);
+
+    newInstance->dispatchParents.add(at);
+
+    bool inserted = at->dispatchChildren.add_exclusive(newInstance);
     INT_ASSERT(inserted);
   }
 

--- a/compiler/include/type.h
+++ b/compiler/include/type.h
@@ -105,8 +105,8 @@ public:
 
   SymbolMap              substitutions;
 
+  Vec<AggregateType*>    dispatchParents;    // dispatch hierarchy
   Vec<Type*>             dispatchChildren;   // dispatch hierarchy
-  Vec<Type*>             dispatchParents;    // dispatch hierarchy
 
   // Only used for LLVM.
   std::map<std::string, int> GEPMap;

--- a/compiler/resolution/generics.cpp
+++ b/compiler/resolution/generics.cpp
@@ -347,7 +347,11 @@ static AggregateType* instantiateTypeForTypeConstructor(FnSymbol*      fn,
       useT = newParentTy;
     }
 
-    newCt->dispatchParents.add(useT);
+    AggregateType* at = toAggregateType(useT);
+
+    INT_ASSERT(at != NULL);
+
+    newCt->dispatchParents.add(at);
   }
 
   forv_Vec(Type, t, fn->retType->dispatchParents) {

--- a/compiler/resolution/tuples.cpp
+++ b/compiler/resolution/tuples.cpp
@@ -379,8 +379,13 @@ TupleInfo getTupleInfo(std::vector<TypeSymbol*>& args,
     newType->instantiatedFrom = dtTuple;
 
     forv_Vec(Type, t, dtTuple->dispatchParents) {
-      newType->dispatchParents.add(t);
-      t->dispatchChildren.add_exclusive(newType);
+      AggregateType* at = toAggregateType(t);
+
+      INT_ASSERT(at != NULL);
+
+      newType->dispatchParents.add(at);
+
+      at->dispatchChildren.add_exclusive(newType);
     }
 
     // Decide whether or not we have a homogeneous/star tuple

--- a/compiler/resolution/virtualDispatch.cpp
+++ b/compiler/resolution/virtualDispatch.cpp
@@ -363,11 +363,16 @@ static void overrideIterator(FnSymbol* pfn, FnSymbol* cfn) {
     Type* pic       = pfnInfo->iclass;
     Type* cic       = cfnInfo->iclass;
 
-    Type* pthisType  = pfnInfo->iterator->_this->typeInfo();
-    Type* cthisType  = cfnInfo->iterator->_this->typeInfo();
+    Type* pthisType = pfnInfo->iterator->_this->typeInfo();
+    Type* cthisType = cfnInfo->iterator->_this->typeInfo();
 
     pfn->retType->dispatchChildren.add_exclusive(cfn->retType);
-    cfn->retType->dispatchParents.add_exclusive(pfn->retType);
+
+    AggregateType* atPfnRetType = toAggregateType(pfn->retType);
+
+    INT_ASSERT(atPfnRetType != NULL);
+
+    cfn->retType->dispatchParents.add_exclusive(atPfnRetType);
 
     INT_ASSERT(cic->symbol->hasFlag(FLAG_ITERATOR_CLASS) == true);
     INT_ASSERT(cthisType->dispatchParents.n              == 1);
@@ -386,7 +391,12 @@ static void overrideIterator(FnSymbol* pfn, FnSymbol* cfn) {
       }
 
       pic->dispatchChildren.add_exclusive(cic);
-      cic->dispatchParents.add_exclusive(pic);
+
+      AggregateType* atPic = toAggregateType(pic);
+
+      INT_ASSERT(atPic != NULL);
+
+      cic->dispatchParents.add_exclusive(atPic);
     }
 
   } else {


### PR DESCRIPTION
Continue to update Type::dispatchParents[]

First step to convert Vec<Type*> dispatchParents to Vec<AggregateType*> dispatchParents.

Fortunately there were only a few places that attempted to insert a value with static
type Type* and all of these were dynamically AggregateType*.

Passed conventional compilation/testing process

