### PR TITLE
dispatchChildren :- convert Vec<Type*> to Vec<AggregateType*>

### DIFF
--- a/compiler/include/type.h
+++ b/compiler/include/type.h
@@ -106,7 +106,7 @@ public:
   SymbolMap              substitutions;
 
   Vec<AggregateType*>    dispatchParents;    // dispatch hierarchy
-  Vec<Type*>             dispatchChildren;   // dispatch hierarchy
+  Vec<AggregateType*>    dispatchChildren;   // dispatch hierarchy
 
   // Only used for LLVM.
   std::map<std::string, int> GEPMap;

--- a/compiler/resolution/lowerIterators.cpp
+++ b/compiler/resolution/lowerIterators.cpp
@@ -140,8 +140,20 @@ static void nonLeaderParCheck()
 }
 
 static bool isVirtualIterator(Symbol* iterator) {
-  Vec<Type*> children = iterator->type->dispatchChildren;
-  return !((children.n == 0) || (children.n == 1 && children.v[0] == dtObject));
+  Vec<AggregateType*>* children = &(iterator->type->dispatchChildren);
+  bool                 retval   = false;
+
+  if (children->n == 0) {
+    retval = false;
+
+  } else if (children->n == 1 && children->v[0] == dtObject) {
+    retval = false;
+
+  } else {
+    retval = true;
+  }
+
+  return retval;
 }
 
 static void parallelIterVirtualCheck() {

--- a/compiler/resolution/virtualDispatch.cpp
+++ b/compiler/resolution/virtualDispatch.cpp
@@ -366,12 +366,13 @@ static void overrideIterator(FnSymbol* pfn, FnSymbol* cfn) {
     Type* pthisType = pfnInfo->iterator->_this->typeInfo();
     Type* cthisType = cfnInfo->iterator->_this->typeInfo();
 
-    pfn->retType->dispatchChildren.add_exclusive(cfn->retType);
-
     AggregateType* atPfnRetType = toAggregateType(pfn->retType);
+    AggregateType* atCfnRetType = toAggregateType(cfn->retType);
 
     INT_ASSERT(atPfnRetType != NULL);
+    INT_ASSERT(atCfnRetType != NULL);
 
+    pfn->retType->dispatchChildren.add_exclusive(atCfnRetType);
     cfn->retType->dispatchParents.add_exclusive(atPfnRetType);
 
     INT_ASSERT(cic->symbol->hasFlag(FLAG_ITERATOR_CLASS) == true);
@@ -383,19 +384,24 @@ static void overrideIterator(FnSymbol* pfn, FnSymbol* cfn) {
       INT_ASSERT(cic->dispatchParents.n == 1);
 
       if (parent == dtObject) {
-        int item = parent->dispatchChildren.index(cic);
+        AggregateType* atCic = toAggregateType(cic);
+
+        INT_ASSERT(atCic != NULL);
+
+        int            item  = parent->dispatchChildren.index(atCic);
 
         parent->dispatchChildren.remove(item);
 
         cic->dispatchParents.remove(0);
       }
 
-      pic->dispatchChildren.add_exclusive(cic);
-
+      AggregateType* atCic = toAggregateType(cic);
       AggregateType* atPic = toAggregateType(pic);
 
+      INT_ASSERT(atCic != NULL);
       INT_ASSERT(atPic != NULL);
 
+      pic->dispatchChildren.add_exclusive(atCic);
       cic->dispatchParents.add_exclusive(atPic);
     }
 


### PR DESCRIPTION
Also update Type::dispatchChildren[]
    
Convert Vec<Type*> dispatchChildren to Vec<AggregateType*> dispatchChildren
    
Fortunately there were only a few places that attempted to insert a value
with static type Type* and all of these were dynamically AggregateType*.
    
Passed conventional compilation/testing process
