### PR TITLE
Dispatch parents 3

### DIFF
--- a/compiler/AST/baseAST.cpp
+++ b/compiler/AST/baseAST.cpp
@@ -227,11 +227,13 @@ void cleanAst() {
       }
     }
 
-    for(int i = 0; i < ts->type->dispatchChildren.n; i++) {
-      Type* type = ts->type->dispatchChildren.v[i];
-
-      if (type && !isAlive(type)) {
-        ts->type->dispatchChildren.v[i] = NULL;
+    if (AggregateType* at = toAggregateType(ts->type)) {
+      for (int i = 0; i < at->dispatchChildren.n; i++) {
+        if (AggregateType* type = at->dispatchChildren.v[i]) {
+          if (isAlive(type) == false) {
+            at->dispatchChildren.v[i] = NULL;
+          }
+        }
       }
     }
   }

--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -1292,56 +1292,84 @@ bool isRefIterType(Type* t) {
   return false;
 }
 
-bool isSubClass(Type* type, Type* baseType)
-{
-  if (type == baseType)
-    return true;
+bool isSubClass(Type* type, Type* baseType) {
+  bool retval = false;
 
-  forv_Vec(Type, pt, type->dispatchParents)
-    if (isSubClass(pt, baseType))
-      return true;
+  if (type == baseType) {
+    retval = true;
 
-  return false;
+  } else if (AggregateType* at = toAggregateType(type)) {
+    forv_Vec(AggregateType, pt, at->dispatchParents) {
+      if (isSubClass(pt, baseType) == true) {
+        retval = true;
+        break;
+      }
+    }
+  }
+
+  return retval;
 }
 
 bool isDistClass(Type* type) {
-  if (type->symbol->hasFlag(FLAG_BASE_DIST))
-    return true;
+  bool retval = false;
 
-  forv_Vec(Type, pt, type->dispatchParents)
-    if (isDistClass(pt))
-      return true;
+  if (type->symbol->hasFlag(FLAG_BASE_DIST) == true) {
+    retval = true;
 
-  return false;
+  } else if (AggregateType* at = toAggregateType(type)) {
+    forv_Vec(AggregateType, pt, at->dispatchParents) {
+      if (isDistClass(pt) == true) {
+        retval = true;
+        break;
+      }
+    }
+  }
+
+  return retval;
 }
 
 bool isDomainClass(Type* type) {
-  if (type->symbol->hasFlag(FLAG_BASE_DOMAIN))
-    return true;
+  bool retval = false;
 
-  forv_Vec(Type, pt, type->dispatchParents)
-    if (isDomainClass(pt))
-      return true;
+  if (type->symbol->hasFlag(FLAG_BASE_DOMAIN) == true) {
+    retval = true;
 
-  return false;
+  } else if (AggregateType* at = toAggregateType(type)) {
+    forv_Vec(AggregateType, pt, at->dispatchParents) {
+      if (isDomainClass(pt) == true) {
+        retval = true;
+        break;
+      }
+    }
+  }
+
+  return retval;
 }
 
 bool isArrayClass(Type* type) {
-  if (type->symbol->hasFlag(FLAG_BASE_ARRAY))
-    return true;
+  bool retval = false;
 
-  forv_Vec(Type, t, type->dispatchParents)
-    if (isArrayClass(t))
-      return true;
+  if (type->symbol->hasFlag(FLAG_BASE_ARRAY) == true) {
+    retval = true;
 
-  return false;
+  } else if (AggregateType* at = toAggregateType(type)) {
+    forv_Vec(AggregateType, t, at->dispatchParents) {
+      if (isArrayClass(t) == true) {
+        retval = true;
+        break;
+      }
+    }
+  }
+
+  return retval;
 }
 
 bool isString(Type* type) {
   bool retval = false;
 
-  if (AggregateType* aggr = toAggregateType(type))
+  if (AggregateType* aggr = toAggregateType(type)) {
     retval = strcmp(aggr->symbol->name, "string") == 0;
+  }
 
   return retval;
 }

--- a/compiler/codegen/type.cpp
+++ b/compiler/codegen/type.cpp
@@ -592,21 +592,28 @@ int AggregateType::getMemberGEP(const char *name) {
           return GEPIdx->second;
         }
 
-        forv_Vec(Type, parent, t->dispatchParents) {
-          if (parent)
-            next_p->set_add(parent);
+        if (AggregateType* at = toAggregateType(t)) {
+          forv_Vec(AggregateType, parent, at->dispatchParents) {
+            if (parent)
+              next_p->set_add(parent);
+          }
         }
       }
+
       Vec<Type*>* temp = next_p;
-      next_p = current_p;
+
+      next_p    = current_p;
       current_p = temp;
+
       next_p->clear();
     }
 
     const char *className = "<no name>";
+
     if (this->symbol) {
       className = this->symbol->name;
     }
+
     INT_FATAL(this, "no field '%s' in class '%s' in getField()",
               name, className);
   }

--- a/compiler/include/AggregateType.h
+++ b/compiler/include/AggregateType.h
@@ -164,6 +164,7 @@ public:
   int                         classId;
 
   Vec<AggregateType*>         dispatchParents;    // dispatch hierarchy
+  Vec<AggregateType*>         dispatchChildren;   // dispatch hierarchy
 
 private:
   static ArgSymbol*           createGenericArg(VarSymbol* field);

--- a/compiler/include/AggregateType.h
+++ b/compiler/include/AggregateType.h
@@ -163,6 +163,8 @@ public:
   // isa checking. This is the value we store in chpl__cid_XYZ.
   int                         classId;
 
+  Vec<AggregateType*>         dispatchParents;    // dispatch hierarchy
+
 private:
   static ArgSymbol*           createGenericArg(VarSymbol* field);
   static void                 insertImplicitThis(

--- a/compiler/include/type.h
+++ b/compiler/include/type.h
@@ -105,8 +105,6 @@ public:
 
   SymbolMap              substitutions;
 
-  Vec<AggregateType*>    dispatchChildren;   // dispatch hierarchy
-
   // Only used for LLVM.
   std::map<std::string, int> GEPMap;
 

--- a/compiler/include/type.h
+++ b/compiler/include/type.h
@@ -105,7 +105,6 @@ public:
 
   SymbolMap              substitutions;
 
-  Vec<AggregateType*>    dispatchParents;    // dispatch hierarchy
   Vec<AggregateType*>    dispatchChildren;   // dispatch hierarchy
 
   // Only used for LLVM.

--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -1541,16 +1541,21 @@ static void buildRecordQueryVarField(FnSymbol*  fn,
 ************************************** | *************************************/
 
 static bool inheritsFromError(Type* t) {
-  if (t == dtError)
-    return true;
+  bool retval = false;
 
-  bool ret = false;
+  if (t == dtError) {
+    retval = true;
 
-  forv_Vec(Type, parent, t->dispatchParents) {
-    ret = ret || inheritsFromError(parent);
+  } else if (AggregateType* at = toAggregateType(t)) {
+    forv_Vec(AggregateType, parent, at->dispatchParents) {
+      if (inheritsFromError(parent) == true) {
+        retval = true;
+        break;
+      }
+    }
   }
 
-  return ret;
+  return retval;
 }
 
 static void buildDefaultReadWriteFunctions(AggregateType* ct) {

--- a/compiler/resolution/implementForallIntents.cpp
+++ b/compiler/resolution/implementForallIntents.cpp
@@ -1040,12 +1040,21 @@ void cleanupRedRefs(Expr*& redRef1, Expr*& redRef2) {
 // Is 'type' a Reduce/Scan Op?
 // similar to isArrayClass()
 bool isReduceOp(Type* type) {
-  if (type->symbol->hasFlag(FLAG_REDUCESCANOP))
-    return true;
-  forv_Vec(Type, t, type->dispatchParents)
-    if (isReduceOp(t))
-      return true;
-  return false;
+  bool retval = false;
+
+  if (type->symbol->hasFlag(FLAG_REDUCESCANOP) == true) {
+    retval = true;
+
+  } else if (AggregateType* at = toAggregateType(type)) {
+    forv_Vec(AggregateType, t, at->dispatchParents) {
+      if (isReduceOp(t) == true) {
+        retval = true;
+        break;
+      }
+    }
+  }
+
+  return retval;
 }
 
 //

--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -710,11 +710,9 @@ static void resolveTypeConstructor(FnSymbol* fn) {
     fixTypeNames(at);
   }
 
-  forv_Vec(Type, parent, fn->retType->dispatchParents) {
-    if (AggregateType* pt = toAggregateType(parent)) {
-      if (pt != dtObject) {
-        resolveDefaultTypeConstructor(pt);
-      }
+  forv_Vec(AggregateType, pt, at->dispatchParents) {
+    if (pt != dtObject) {
+      resolveDefaultTypeConstructor(pt);
     }
   }
 

--- a/compiler/resolution/virtualDispatch.cpp
+++ b/compiler/resolution/virtualDispatch.cpp
@@ -382,7 +382,7 @@ static void overrideIterator(FnSymbol* pfn, FnSymbol* cfn) {
     INT_ASSERT(atCthisType->dispatchParents.n              == 1);
 
     if (atCthisType->dispatchParents.only() == pthisType) {
-      Type* parent = cic->dispatchParents.only();
+      AggregateType* parent = cic->dispatchParents.only();
 
       INT_ASSERT(cic->dispatchParents.n == 1);
 
@@ -552,8 +552,8 @@ static void buildVirtualMethodTable() {
     }
   }
 
-  forv_Vec(Type, ct, ctq) {
-    if (Vec<FnSymbol*>* parentFns = virtualMethodTable.get(ct)) {
+  forv_Vec(Type, t, ctq) {
+    if (Vec<FnSymbol*>* parentFns = virtualMethodTable.get(t)) {
       forv_Vec(FnSymbol, pfn, *parentFns) {
         Vec<Type*> childSet;
 
@@ -561,7 +561,7 @@ static void buildVirtualMethodTable() {
           forv_Vec(FnSymbol, cfn, *childFns) {
             if (AggregateType* at = toAggregateType(cfn->_this->type)) {
               forv_Vec(AggregateType, pt, at->dispatchParents) {
-                if (pt == ct) {
+                if (pt == t) {
                   if (childSet.set_in(at) == NULL) {
                     addVirtualMethodTableEntry(at, cfn, false);
 
@@ -575,16 +575,20 @@ static void buildVirtualMethodTable() {
           }
         }
 
-        forv_Vec(Type, childType, ct->dispatchChildren) {
-          if (childSet.set_in(childType) == NULL) {
-            addVirtualMethodTableEntry(childType, pfn, false);
+        if (AggregateType* at = toAggregateType(t)) {
+          forv_Vec(AggregateType, childType, at->dispatchChildren) {
+            if (childSet.set_in(childType) == NULL) {
+              addVirtualMethodTableEntry(childType, pfn, false);
+            }
           }
         }
       }
     }
 
-    forv_Vec(Type, child, ct->dispatchChildren) {
-      ctq.add(child);
+    if (AggregateType* at = toAggregateType(t)) {
+      forv_Vec(AggregateType, child, at->dispatchChildren) {
+        ctq.add(child);
+      }
     }
   }
 

--- a/compiler/util/llvmDebug.cpp
+++ b/compiler/util/llvmDebug.cpp
@@ -232,10 +232,12 @@ llvm::DIType* debug_data::construct_type(Type *type)
       else if(type->astTag == E_AggregateType) {
         // dealing with classes
         AggregateType *this_class = (AggregateType *)type;
+
         llvm::SmallVector<llvm::Metadata *, 8> EltTys;
         llvm::DIType* derivedFrom = nullptr;
-        if( type->dispatchParents.length() > 0 )
-          derivedFrom = get_type(type->dispatchParents.first());
+
+        if( this_class->dispatchParents.length() > 0 )
+          derivedFrom = get_type(this_class->dispatchParents.first());
 
         // solve the data class: _ddata
         if(this_class->symbol->hasFlag(FLAG_DATA_CLASS)) {
@@ -328,10 +330,12 @@ llvm::DIType* debug_data::construct_type(Type *type)
 
   else if(ty->isStructTy() && type->astTag == E_AggregateType) {
     AggregateType *this_class = (AggregateType *)type;
+
     llvm::SmallVector<llvm::Metadata *, 8> EltTys;
     llvm::DIType* derivedFrom = nullptr;
-    if( type->dispatchParents.length() > 0 )
-      derivedFrom = get_type(type->dispatchParents.first());
+
+    if( this_class->dispatchParents.length() > 0 )
+      derivedFrom = get_type(this_class->dispatchParents.first());
 
     const llvm::StructLayout* slayout = NULL;
     llvm::StructType* struct_type = llvm::cast<llvm::StructType>(ty);


### PR DESCRIPTION
Migrate dispatchParents/dispatchChildren from Type to AggregateType

Update the relevant header files and then make a few updates for cases
in which the static type Type* needed to be guarded with a dynamic
type check for AggregateType* before attempting to access these vectors.

Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.
Passed a small portion of release/ with each configuration.

Passed a single-locale paratest with -futures

Also compiled with CHPL_LLVM=llvm and then passed a single-locale paratest.

