### PR TITLE
Add perf annotations for 2017-12-14

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -276,6 +276,9 @@ all:
     - Reduce wide pointer overhead for sparse domains/arrays (#7627)
   11/21/17:
     - New bulk transfer interface (#7775)
+  12/08/17:
+    - text: Machine upgraded to CLE6
+      config: 16 node XC
 
 
 AllCompTime:


### PR DESCRIPTION
The only notable change is that the jupiter CLE6 upgrade has slightly improved
performance for some tests, and seems to have stabilized performance for ra-rmo
and ra-atomics. Since the machine was down when it was upgraded, I also
verified that we get the better performance even with an older compiler (to
ensure the changes are from the upgrade, and not from any commits that went in
while the machine was down.)

Here's the [graphs](https://chapel-lang.org/perf/16-node-xc/?startdate=2017/10/09&enddate=2017/12/14&graphs=npbepperfmopssized,hpccptransperfgbsecn2000nb100,hpccraatomicsperfgupsn233,hpccraonperfgupsn233,hpccrarmoperfgupsn233,doeluleshdensetimesecsedov15oct,emptyremotetaskspawntime)

 - EP and ptrans are a little faster
 - lulesh and the empty-task-spawn are a little faster for gasnet-aries
 - ra-rmo and ra-atomics are faster and seem to be more consistent for ugni
 - ra-on had an off day 2017/12/14, but I think we just got a few bad runs (I get good perf numbers, and we've ra-on has had a few sporadically bad days in the past)