### PR TITLE
Revert "Document valid/invalid PRIM_GET_MEMBER(_VALUE) / PRIM_SET_MEMBER"

### DIFF
--- a/compiler/AST/primitive.cpp
+++ b/compiler/AST/primitive.cpp
@@ -537,24 +537,10 @@ initPrimitive() {
   prim_def(PRIM_GETCID, "getcid", returnInfoInt32, false, true);
   prim_def(PRIM_SET_UNION_ID, "set_union_id", returnInfoVoid, true, true);
   prim_def(PRIM_GET_UNION_ID, "get_union_id", returnInfoDefaultInt, false, true);
-
-  // PRIM_GET_MEMBER(_VALUE): aggregate, field
-  // if the field is a ref:
-  //   GET_MEMBER is invalid AST
-  //   GET_MEMBER_VALUE returns the reference
-  // if the field is not a ref
-  //   GET_MEMBER returns a reference to the field
-  //   GET_MEMBER_VALUE returns the field value
   prim_def(PRIM_GET_MEMBER, ".", returnInfoGetMemberRef);
   prim_def(PRIM_GET_MEMBER_VALUE, ".v", returnInfoGetMember, false, true);
-
-  // PRIM_SET_MEMBER: base, field, value
-  // if the field is a ref, and the value is a ref, sets the ptr.
-  // if the field is a ref, and the value is a not ref, invalid AST
-  // if the field is not ref, and the value is a ref, derefs value first
-  // if neither are references, sets the field
+  // base, field, value
   prim_def(PRIM_SET_MEMBER, ".=", returnInfoVoid, true, true);
-
   prim_def(PRIM_CHECK_NIL, "_check_nil", returnInfoVoid, true, true);
   prim_def(PRIM_NEW, "new", returnInfoFirst);
   prim_def(PRIM_GET_REAL, "complex_get_real", returnInfoComplexField);

--- a/compiler/codegen/expr.cpp
+++ b/compiler/codegen/expr.cpp
@@ -4288,11 +4288,7 @@ GenRet CallExpr::codegenPrimitive() {
   }
 
   case PRIM_GET_MEMBER: {
-    // base=get(1), field symbol=get(2)
-
-    // Invalid AST to use PRIM_GET_MEMBER with a ref field
-    INT_ASSERT(!get(2)->isRef());
-
+    // base=get(1) field symbol=get(2)
     ret = codegenFieldPtr(get(1), get(2));
 
     // Used to only do addrOf if
@@ -4316,12 +4312,7 @@ GenRet CallExpr::codegenPrimitive() {
   }
 
   case PRIM_SET_MEMBER: {
-    // base=get(1), field=get(2), value=get(3)
-
-    // if the field is a ref, and the value is a not ref, invalid AST
-    if (get(2)->isRef() && !get(3)->isRef())
-      INT_FATAL("Invalid PRIM_SET_MEMBER ref field with value");
-
+    // base=get(1) field=get(2) value=get(3)
     GenRet ptr = codegenFieldPtr(get(1), get(2));
     GenRet val = get(3);
 
@@ -5310,9 +5301,6 @@ static bool codegenIsSpecialPrimitive(BaseAST* target, Expr* e, GenRet& ret) {
     case PRIM_GET_MEMBER: {
       /* Get a pointer to a member */
       SymExpr* se = toSymExpr(call->get(2));
-
-      // Invalid AST to use PRIM_GET_MEMBER with a ref field
-      INT_ASSERT(!call->get(2)->isRef());
 
       if (call->get(1)->typeInfo()->symbol->hasFlag(FLAG_WIDE_CLASS) ||
           call->get(1)->isWideRef()   ||


### PR DESCRIPTION
This reverts commit 8ede226609c3066acdea2f47e89c17d03bc0d6c5.

I'm reverting the commit to avoid baseline testing failures with:
library/packages/DistributedIters/checkDistributedIters.good
sparse/CS/multiplication/correctness
sparse/CS/multiplication/performance
studies/590o/alaska/graph

I will include these improvements in a PR for my upcoming work on iterator memory management.