### PR TITLE
Add barrier subtimings to isx-hand-optimized

### DIFF
--- a/test/studies/isx/isx-hand-optimized.graph
+++ b/test/studies/isx/isx-hand-optimized.graph
@@ -1,5 +1,5 @@
-perfkeys: total =, input =, bucket count =, bucket offset =, bucketize =, exchange =, count keys =
+perfkeys: total =, input =, bucket count =, bucket offset =, bucketize =, exchange =, exchange barrier =, count keys =
 repeat-files: isx-hand-optimized.dat
-graphkeys: total time, input time, bucket count time, bucket offset time, bucketize time, exchange time, count keys time
+graphkeys: total time, input time, bucket count time, bucket offset time, bucketize time, exchange time, exchange barrier time, count keys time
 ylabel: Time (seconds)
 graphtitle: ISx (Hand Optimized)

--- a/test/studies/isx/isx-hand-optimized.ml-keys
+++ b/test/studies/isx/isx-hand-optimized.ml-keys
@@ -11,5 +11,6 @@ bucket count =
 bucket offset =
 bucketize =
 exchange =
+exchange barrier =
 count keys =
 verify:Verification successful!

--- a/test/studies/isx/isx-hand-optimized.ml-time.graph
+++ b/test/studies/isx/isx-hand-optimized.ml-time.graph
@@ -1,5 +1,5 @@
-perfkeys: total =, input =, bucket count =, bucket offset =, bucketize =, exchange =, count keys =
+perfkeys: total =, input =, bucket count =, bucket offset =, bucketize =, exchange =, exchange barrier =, count keys =
 repeat-files: isx-hand-optimized.dat
-graphkeys: total time, input time, bucket count time, bucket offset time, bucketize time, exchange time, count keys time
+graphkeys: total time, input time, bucket count time, bucket offset time, bucketize time, exchange time, exchange barrier time, count keys time
 ylabel: Time (seconds)
 graphtitle: ISx (Hand Optimized)

--- a/test/studies/isx/isx-hand-optimized.perfkeys
+++ b/test/studies/isx/isx-hand-optimized.perfkeys
@@ -11,5 +11,6 @@ bucket count =
 bucket offset =
 bucketize =
 exchange =
+exchange barrier =
 count keys =
 verify:Verification successful!


### PR DESCRIPTION
Previously the exchange subtimer timed the exchange as well as the barrier.
Split the barrier out into a separate subtimer so we can better tell where time
is spent and maybe narrow down the noisy part of the computation.