### PR TITLE
normalize :- Avoid normalizing an FnSymbol multiple times

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -1256,6 +1256,7 @@ FnSymbol::FnSymbol(const char* initName) : Symbol(E_FnSymbol, initName) {
   doc                = NULL;
   retSymbol          = NULL;
   llvmDISubprogram   = NULL;
+  mIsNormalized      = false;
   _throwsError       = false;
 
   substitutions.clear();
@@ -1928,6 +1929,14 @@ int FnSymbol::hasGenericFormals() const {
   }
 
   return retval;
+}
+
+bool FnSymbol::isNormalized() const {
+  return mIsNormalized;
+}
+
+void FnSymbol::setNormalized(bool value) {
+  mIsNormalized = value;
 }
 
 bool FnSymbol::isResolved() const {

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -594,7 +594,11 @@ public:
 
   bool                       tagIfGeneric();
 
+  bool                       isNormalized()                              const;
+  void                       setNormalized(bool value);
+
   bool                       isResolved()                                const;
+
   bool                       isMethod()                                  const;
   bool                       isPrimaryMethod()                           const;
   bool                       isSecondaryMethod()                         const;
@@ -616,6 +620,7 @@ private:
 
   int                        hasGenericFormals()                         const;
 
+  bool                       mIsNormalized;
   bool                       _throwsError;
 };
 

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -42,78 +42,77 @@
 
 bool normalized = false;
 
-static void insertModuleInit();
-static FnSymbol* toModuleDeinitFn(ModuleSymbol* mod, Expr* stmt);
-static void handleModuleDeinitFn(ModuleSymbol* mod);
-static void transformLogicalShortCircuit();
-static void handleReduceAssign();
+static void        insertModuleInit();
+static FnSymbol*   toModuleDeinitFn(ModuleSymbol* mod, Expr* stmt);
+static void        handleModuleDeinitFn(ModuleSymbol* mod);
+static void        transformLogicalShortCircuit();
+static void        handleReduceAssign();
 
-static void fixupArrayFormals(FnSymbol* fn);
+static void        fixupArrayFormals(FnSymbol* fn);
 
-static bool includesParameterizedPrimitive(FnSymbol* fn);
-static void replaceFunctionWithInstantiationsOfPrimitive(FnSymbol* fn);
-static void fixupQueryFormals(FnSymbol* fn);
+static bool        includesParameterizedPrimitive(FnSymbol* fn);
+static void        replaceFunctionWithInstantiationsOfPrimitive(FnSymbol* fn);
+static void        fixupQueryFormals(FnSymbol* fn);
 
-static bool isConstructor(FnSymbol* fn);
-static bool isInitMethod (FnSymbol* fn);
+static bool        isConstructor(FnSymbol* fn);
+static bool        isInitMethod (FnSymbol* fn);
 
-static void updateConstructor(FnSymbol* fn);
-static void updateInitMethod (FnSymbol* fn);
+static void        updateConstructor(FnSymbol* fn);
+static void        updateInitMethod (FnSymbol* fn);
 
-static void normalizeTheProgram();
-static void checkUseBeforeDefs();
-static void moveGlobalDeclarationsToModuleScope();
-static void insertUseForExplicitModuleCalls(void);
+static void        checkUseBeforeDefs();
+static void        moveGlobalDeclarationsToModuleScope();
+static void        insertUseForExplicitModuleCalls(void);
 
-static void hack_resolve_types(ArgSymbol* arg);
+static void        hack_resolve_types(ArgSymbol* arg);
 
-static void find_printModuleInit_stuff();
+static void        find_printModuleInit_stuff();
 
-static void processSyntacticDistributions(CallExpr* call);
-static void normalize(BaseAST* base);
-static void normalizeReturns(FnSymbol* fn);
+static void        normalizeBase(BaseAST* base);
+static void        processSyntacticDistributions(CallExpr* call);
+static void        normalizeReturns(FnSymbol* fn);
 
-static bool isCallToConstructor(CallExpr* call);
-static void normalizeCallToConstructor(CallExpr* call);
+static bool        isCallToConstructor(CallExpr* call);
+static void        normalizeCallToConstructor(CallExpr* call);
 
-static bool isCallToTypeConstructor(CallExpr* call);
-static void normalizeCallToTypeConstructor(CallExpr* call);
+static bool        isCallToTypeConstructor(CallExpr* call);
+static void        normalizeCallToTypeConstructor(CallExpr* call);
 
-static void applyGetterTransform(CallExpr* call);
-static void insertCallTemps(CallExpr* call);
-static void insertCallTempsWithStmt(CallExpr* call, Expr* stmt);
+static void        applyGetterTransform(CallExpr* call);
+static void        insertCallTemps(CallExpr* call);
+static void        insertCallTempsWithStmt(CallExpr* call, Expr* stmt);
 
-static void normalizeTypeAlias(DefExpr* defExpr);
-static void normalizeConfigVariableDefinition(DefExpr* defExpr);
-static void normalizeVariableDefinition(DefExpr* defExpr);
+static void        normalizeTypeAlias(DefExpr* defExpr);
+static void        normalizeConfigVariableDefinition(DefExpr* defExpr);
+static void        normalizeVariableDefinition(DefExpr* defExpr);
 
-static void normRefVar(DefExpr* defExpr);
+static void        normRefVar(DefExpr* defExpr);
 
-static void init_untyped_var(VarSymbol* var,
-                             Expr*      init,
-                             Expr*      insert,
-                             VarSymbol* constTemp);
+static void        init_untyped_var(VarSymbol* var,
+                                    Expr*      init,
+                                    Expr*      insert,
+                                    VarSymbol* constTemp);
 
-static void init_typed_var(VarSymbol* var,
-                           Expr*      type,
-                           Expr*      insert,
-                           VarSymbol* constTemp);
+static void        init_typed_var(VarSymbol* var,
+                                  Expr*      type,
+                                  Expr*      insert,
+                                  VarSymbol* constTemp);
 
-static void init_typed_var(VarSymbol* var,
-                           Expr*      type,
-                           Expr*      init,
-                           Expr*      insert,
-                           VarSymbol* constTemp);
+static void        init_typed_var(VarSymbol* var,
+                                  Expr*      type,
+                                  Expr*      init,
+                                  Expr*      insert,
+                                  VarSymbol* constTemp);
 
-static void init_noinit_var(VarSymbol* var,
-                            Expr*      type,
-                            Expr*      init,
-                            Expr*      insert,
-                            VarSymbol* constTemp);
+static void        init_noinit_var(VarSymbol* var,
+                                   Expr*      type,
+                                   Expr*      init,
+                                   Expr*      insert,
+                                   VarSymbol* constTemp);
 
-static bool moduleHonorsNoinit(Symbol* var, Expr* init);
+static bool        moduleHonorsNoinit(Symbol* var, Expr* init);
 
-static void updateVariableAutoDestroy(DefExpr* defExpr);
+static void        updateVariableAutoDestroy(DefExpr* defExpr);
 
 static TypeSymbol* expandTypeAlias(SymExpr* se);
 
@@ -160,7 +159,7 @@ void normalize() {
     }
   }
 
-  normalizeTheProgram();
+  normalizeBase(theProgram);
 
   normalized = true;
 
@@ -257,11 +256,14 @@ void normalize() {
 ************************************** | *************************************/
 
 void normalize(FnSymbol* fn) {
-  normalize((BaseAST*) fn);
+  if (fn->isNormalized() == false) {
+    normalizeBase(fn);
+    fn->setNormalized(true);
+  }
 }
 
 void normalize(Expr* expr) {
-  normalize((BaseAST*) expr);
+  normalizeBase(expr);
 }
 
 /************************************* | **************************************
@@ -455,13 +457,9 @@ static void insertCallTempsForRiSpecs(BaseAST* base) {
 *                                                                             *
 ************************************** | *************************************/
 
-static void normalizeTheProgram() {
-  normalize(theProgram);
-}
-
 // the following function is called from multiple places,
 // e.g., after generating default or wrapper functions
-static void normalize(BaseAST* base) {
+static void normalizeBase(BaseAST* base) {
 
   //
   // Phase 0
@@ -490,7 +488,9 @@ static void normalize(BaseAST* base) {
 
   for_vector(Symbol, symbol, symbols) {
     if (FnSymbol* fn = toFnSymbol(symbol)) {
-      normalizeReturns(fn);
+      if (fn->isNormalized() == false) {
+        normalizeReturns(fn);
+      }
     }
   }
 
@@ -503,7 +503,8 @@ static void normalize(BaseAST* base) {
       DefExpr* defExpr = var->defPoint;
 
       if (FnSymbol* fn = toFnSymbol(defExpr->parentSymbol)) {
-        if (fn != stringLiteralModule->initFn) {
+        if (fn                 != stringLiteralModule->initFn &&
+            fn->isNormalized() == false) {
           Expr* type = defExpr->exprType;
           Expr* init = defExpr->init;
 


### PR DESCRIPTION
Only normalize FnSymbol once

While debugging on a development branch I happened to notice a small number of
functions that had multiple RVVs (return variable values).  This turned out to be a
side-effect of flows in which certain functions can pass through normalization more
than once.

This simple PR adds a "flag" to FnSymbol and then tweaks the few paths
through normalization to test/set this flag as required.

Compiled for the expected configurations and passed a single-locale paratest
