### PR TITLE
Fix apparent typo in runtime/etc/Makefile.auxFilesys

### DIFF
--- a/doc/rst/technotes/auxIO.rst
+++ b/doc/rst/technotes/auxIO.rst
@@ -348,7 +348,7 @@ Chapel with (and use). For example if we wanted to enable :mod:`Curl` and
 
     ``CHPL_AUX_FILESYS="hdfs curl"``
 
-Assuming that you have correctly defined ``CHPL_AUXIO_INCLUDES`` and
+Assuming that you have correctly defined ``CHPL_AUXIO_INCLUDE`` and
 ``CHPL_AUXIO_LIBS`` as detailed above, and have the correct libraries
 installed.
 

--- a/runtime/etc/Makefile.auxFilesys
+++ b/runtime/etc/Makefile.auxFilesys
@@ -38,7 +38,7 @@ endif
 
 ifneq (,$(findstring lustre,$(CHPL_MAKE_AUXFS)))
 	GEN_LFLAGS += \
-		$(CHPL_AUXIO_INCLUDES) \
+		$(CHPL_AUXIO_INCLUDE) \
 		$(CHPL_AUXIO_LIBS)
 	LIBS += -DSYS_HAS_LLAPI -llustreapi
 endif 


### PR DESCRIPTION
Environment variable
    CHPL_AUXIO_INCLUDES
is changed to
    CHPL_AUXIO_INCLUDE (no "S"),

There are other, existing occurrences of CHPL_AUXIO_INCLUDE.

It is not likely that two separate env variables named
CHPL_AUXIO_INCLUDE and _INCLUDES were both intended to exist.
Much more likely that the slightly-less-frequently-occurring
"_INCLUDES" was a typo.