### PR TITLE
Filter out LLVM compile options that inhibit debugging

### DIFF
--- a/third-party/llvm/filter-llvm-config.awk
+++ b/third-party/llvm/filter-llvm-config.awk
@@ -1,5 +1,8 @@
 BEGIN { RS=" " }
+/^$/ { next }
 /^-DNDEBUG$/ { next }
+/^-fPIC$/ { next }
+/^-gsplit-dwarf$/ { next }
 /^-O[0-4s]?$/ { next }
 /^-pedantic$/ { next }
 /^-W.,/ { printf " %s",$0 }


### PR DESCRIPTION
The `-gsplit-dwarf` option prevents gdb from being able to see the source files used to build chpl.  This change filters it out from the `llvm-config` output.

While there, also filter out `-fPIC` which can increase code size and/or execution time, and is not needed except in shared libraries.  Empty options are also filtered out, to remove unnecessary blanks.

Tested on linux64 and Mac, with CHPL_LLVM=llvm and CHPL_LLVM=system.