### PR TITLE
Switch the experimental VM over to testing --fast

### DIFF
--- a/util/cron/test-linux64-vm.bash
+++ b/util/cron/test-linux64-vm.bash
@@ -1,12 +1,11 @@
 #!/usr/bin/env bash
 #
-# Test llvm configuration on full suite with compiler performance enabled on
+# Test --fast configuration on full suite with compiler performance enabled on
 # linux64 on an experimental VM
 
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common.bash
-source $CWD/common-llvm.bash
-unset CHPL_NIGHTLY_TEST_DIRS
+source $CWD/common-fast.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-vm"
 
@@ -14,5 +13,5 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-vm"
 export CHPL_TEST_NOMAIL=1
 export CHPL_NIGHTLY_DEBUG_EMAIL=eronagha@cray.com
 
-nightly_args="${nightly_args} -compperformance (default)"
-$CWD/nightly -cron -futures ${nightly_args}
+nightly_args="${nightly_args} -compperformance (--fast)"
+$CWD/nightly -cron ${nightly_args}


### PR DESCRIPTION
I want to start doing compiler performance testing for --llvm --fast, but to
start, let's get a baseline for the C backend's --fast compilation times.