### PR TITLE
Switch the experimental VM over to testing --llvm --fast

### DIFF
--- a/util/cron/test-linux64-vm.bash
+++ b/util/cron/test-linux64-vm.bash
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 #
-# Test --fast configuration on full suite with compiler performance enabled on
-# linux64 on an experimental VM
+# Test llvm --fast configuration on full suite with compiler performance
+# enabled on linux64 on an experimental VM
 
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common.bash
 source $CWD/common-fast.bash
+source $CWD/common-llvm.bash
+unset CHPL_NIGHTLY_TEST_DIRS
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-vm"
 
@@ -13,5 +15,5 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-vm"
 export CHPL_TEST_NOMAIL=1
 export CHPL_NIGHTLY_DEBUG_EMAIL=eronagha@cray.com
 
-nightly_args="${nightly_args} -compperformance (--fast)"
+nightly_args="${nightly_args} -compperformance (--llvm --fast)"
 $CWD/nightly -cron ${nightly_args}


### PR DESCRIPTION
This will allow us to compare --fast compilation times between the C backend
and the llvm backend (and we have never done full --fast llvm testing, so this
will give us more llvm testing coverage.)