### PR TITLE
Method 1

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -356,7 +356,7 @@ void AggregateType::addDeclaration(DefExpr* defExpr) {
                                                        "_mt",
                                                        dtMethodToken)));
 
-      fn->addFlag(FLAG_METHOD);
+      fn->setMethod(true);
       fn->addFlag(FLAG_METHOD_PRIMARY);
     }
   }
@@ -1495,7 +1495,7 @@ void AggregateType::buildDefaultInitializer() {
 
       symbol->defPoint->insertBefore(def);
 
-      fn->addFlag(FLAG_METHOD);
+      fn->setMethod(true);
       fn->addFlag(FLAG_METHOD_PRIMARY);
 
       preNormalizeInitMethod(fn);
@@ -1900,7 +1900,7 @@ ArgSymbol* AggregateType::moveConstructorToOuter(FnSymbol* fn) {
   fn->insertFormalAtHead(new DefExpr(retval));
   fn->insertFormalAtHead(new DefExpr(_mt));
 
-  fn->addFlag(FLAG_METHOD);
+  fn->setMethod(true);
   fn->addFlag(FLAG_METHOD_PRIMARY);
 
   while (isTypeSymbol(insertPoint->parentSymbol) == true) {

--- a/compiler/AST/AstToText.cpp
+++ b/compiler/AST/AstToText.cpp
@@ -67,12 +67,14 @@ void AstToText::appendName(FnSymbol* fn)
     mText += "top-level module statements for ";
     mText += (fn->name + 11);
   }
+
   else if (fn->hasFlag(FLAG_TYPE_CONSTRUCTOR))
   {
     INT_ASSERT(strncmp(fn->name, "_type_construct_", 16) == 0);
 
     mText += (fn->name + 16);
   }
+
   else if (fn->hasFlag(FLAG_CONSTRUCTOR))
   {
     INT_ASSERT(strncmp(fn->name, "_construct_",      11) == 0);
@@ -80,7 +82,8 @@ void AstToText::appendName(FnSymbol* fn)
     mText += (fn->name + 11);
     // todo: should this also include ".init" ?
   }
-  else if (fn->hasFlag(FLAG_METHOD))
+
+  else if (fn->isMethod() == true)
   {
     appendThisIntent(fn);
 
@@ -96,8 +99,11 @@ void AstToText::appendName(FnSymbol* fn)
 
     mText += fnName;
   }
+
   else
+  {
     mText += fn->name;
+  }
 }
 
 void AstToText::appendThisIntent(FnSymbol* fn)

--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -2488,7 +2488,7 @@ buildFunctionSymbol(FnSymbol*   fn,
 
     ArgSymbol* mt = new ArgSymbol(INTENT_BLANK, "_mt", dtMethodToken);
 
-    fn->addFlag(FLAG_METHOD);
+    fn->setMethod(true);
     fn->insertFormalAtHead(new DefExpr(mt));
   }
 

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -1964,9 +1964,16 @@ void FnSymbol::accept(AstVisitor* visitor) {
   }
 }
 
-// This function is a method on an aggregate type
 bool FnSymbol::isMethod() const {
   return hasFlag(FLAG_METHOD);
+}
+
+void FnSymbol::setMethod(bool value) {
+  if (value == true) {
+    addFlag(FLAG_METHOD);
+  } else {
+    removeFlag(FLAG_METHOD);
+  }
 }
 
 // This function is a method on an aggregate type, defined within its

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -1869,10 +1869,11 @@ bool FnSymbol::tagIfGeneric() {
 int FnSymbol::hasGenericFormals() const {
   bool hasGenericFormal   = false;
   bool hasGenericDefaults =  true;
+  bool resolveInit        = false;
   int  retval             =     0;
 
-  bool resolveInit = false;
-  if (this->hasFlag(FLAG_METHOD) && _this) {
+
+  if (isMethod() == true && _this != NULL) {
     if (AggregateType* at = toAggregateType(_this->type)) {
       if (at->initializerStyle != DEFINES_CONSTRUCTOR  &&
           strcmp(name, "init") == 0) {

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -600,8 +600,11 @@ public:
   bool                       isResolved()                                const;
 
   bool                       isMethod()                                  const;
+  void                       setMethod(bool value);
+
   bool                       isPrimaryMethod()                           const;
   bool                       isSecondaryMethod()                         const;
+
   bool                       isIterator()                                const;
   bool                       returnsRefOrConstRef()                      const;
 

--- a/compiler/passes/ResolveScope.cpp
+++ b/compiler/passes/ResolveScope.cpp
@@ -513,9 +513,15 @@ Symbol* ResolveScope::lookupWithUses(UnresolvedSymExpr* usymExpr) const {
 
           if (ResolveScope* next = getScopeFor(scopeToUse)) {
             if (Symbol* sym = next->lookupNameLocally(nameToUse)) {
-              if (sym->hasFlag(FLAG_METHOD) == false &&
-                  isRepeat(sym, symbols)    == false) {
-                symbols.push_back(sym);
+              if (isRepeat(sym, symbols) == false) {
+                if (FnSymbol* fn = toFnSymbol(sym)) {
+                  if (fn->isMethod() == false) {
+                    symbols.push_back(fn);
+                  }
+
+                } else {
+                  symbols.push_back(sym);
+                }
               }
             }
           }

--- a/compiler/passes/checkParsed.cpp
+++ b/compiler/passes/checkParsed.cpp
@@ -1,15 +1,15 @@
 /*
  * Copyright 2004-2017 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -171,27 +171,30 @@ static void checkExplicitDeinitCalls(CallExpr* call) {
   }
 }
 
-
 static void checkPrivateDecls(DefExpr* def) {
-  if (def->sym->hasFlag(FLAG_PRIVATE)) {
+  if (def->sym->hasFlag(FLAG_PRIVATE) == true) {
     // The symbol has been declared private.
-    if (def->parentSymbol) {
-      if (toFnSymbol(def->parentSymbol)) {
-        // The parent symbol of this definition is a FnSymbol.  Private
-        // symbols at the function scope are meaningless because there is no
-        // way for anything outside the function to access its locals, so warn
-        // the user.
+    if (def->parentSymbol != NULL) {
+      if (isFnSymbol(def->parentSymbol) == true) {
+        // The parent symbol of this definition is a FnSymbol.
+        // Private symbols at the function scope are meaningless
+        // because there is no way for anything outside the function
+        // to access ts locals, so warn the user.
         USR_WARN(def,
-                 "Private declarations within function bodies are meaningless");
-        // Don't want to waste time treating this symbol as if it could be
-        // accessed from an outer scope, so remove the flag.
+                 "Private declarations within function bodies "
+                 "are meaningless");
+
         def->sym->removeFlag(FLAG_PRIVATE);
-      } else if (ModuleSymbol *mod = toModuleSymbol(def->parentSymbol)) {
+
+      } else if (ModuleSymbol* mod = toModuleSymbol(def->parentSymbol)) {
+        FnSymbol* fn = toFnSymbol(def->sym);
+
         // The parent symbol is a module symbol.  Could still be invalid.
-        if (def->sym->hasFlag(FLAG_METHOD)) {
-          USR_FATAL_CONT(def, "Can't apply private to the fields or methods of a class or record yet");
-          // Private secondary methods require further discussion before they
-          // are implemented.
+        if (fn != NULL && fn->isMethod() == true) {
+          USR_FATAL_CONT(def,
+                         "Can't apply private to the fields or methods of "
+                         "a class or record yet");
+
         } else if (mod->block != def->parentExpr) {
           if (BlockStmt* block = toBlockStmt(def->parentExpr)) {
             // Scopeless blocks are used to define multiple symbols, for
@@ -201,23 +204,30 @@ static void checkPrivateDecls(DefExpr* def) {
               // block.  Private symbols at this scope are meaningless, so warn
               // the user.
               USR_WARN(def,
-                       "Private declarations within nested blocks are meaningless");
+                       "Private declarations within nested blocks "
+                       "are meaningless");
+
               def->sym->removeFlag(FLAG_PRIVATE);
             }
+
           } else {
             // There are many situations which could lead to this else branch.
             // Most of them will not reach here due to being banned at parse
             // time.  However, those that aren't excluded by syntax errors will
             // be caught here.
-            USR_WARN(def, "Private declarations are meaningless outside of module level declarations");
+            USR_WARN(def,
+                     "Private declarations are meaningless outside "
+                     "of module level declarations");
+
             def->sym->removeFlag(FLAG_PRIVATE);
           }
         }
-      } else if (TypeSymbol *t = toTypeSymbol(def->parentSymbol)) {
-        if (toAggregateType(t->type)) {
-          USR_FATAL_CONT(def, "Can't apply private to the fields or methods of a class or record yet");
-          // Private fields and methods require further discussion before they
-          // are implemented.
+
+      } else if (TypeSymbol* t = toTypeSymbol(def->parentSymbol)) {
+        if (isAggregateType(t->type) == true) {
+          USR_FATAL_CONT(def,
+                         "Can't apply private to the fields or methods "
+                         "of a class or record yet");
         }
       }
     }
@@ -267,7 +277,7 @@ checkFunction(FnSymbol* fn) {
   if (!strcmp(fn->name, "these") && fn->hasFlag(FLAG_NO_PARENS))
     USR_FATAL_CONT(fn, "method 'these' must have parentheses");
 
-  if (fn->thisTag != INTENT_BLANK && !fn->hasFlag(FLAG_METHOD)) {
+  if (fn->thisTag != INTENT_BLANK && fn->isMethod() == false) {
     USR_FATAL_CONT(fn, "'this' intents can only be applied to methods");
   }
 

--- a/compiler/passes/initializerRules.cpp
+++ b/compiler/passes/initializerRules.cpp
@@ -1006,7 +1006,8 @@ FnSymbol* buildClassAllocator(FnSymbol* initMethod) {
 
   type->addFlag(FLAG_TYPE_VARIABLE);
 
-  fn->addFlag(FLAG_METHOD);
+  fn->setMethod(true);
+
   fn->addFlag(FLAG_COMPILER_GENERATED);
   fn->addFlag(FLAG_LAST_RESORT);
 
@@ -1021,7 +1022,7 @@ FnSymbol* buildClassAllocator(FnSymbol* initMethod) {
   //   1) add a corresponding formal to the new type method
   //   2) add that formal to the call to "init"
   //
-  int count = 1;
+  int       count = 1;
   SymbolMap initArgToNewArgMap;
 
   for_formals(formal, initMethod) {

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -622,7 +622,7 @@ static void resolveUnresolvedSymExpr(UnresolvedSymExpr* usymExpr) {
       updateMethod(usymExpr, sym, symExpr);
 
     // sjd: stopgap to avoid shadowing variables or functions by methods
-    } else if (fn->hasFlag(FLAG_METHOD) == true) {
+    } else if (fn->isMethod() == true) {
       updateMethod(usymExpr);
 
     // handle function call without parentheses
@@ -1447,13 +1447,13 @@ static Symbol* inSymbolTable(const char* name, BaseAST* ast) {
 
   if (ResolveScope* scope = ResolveScope::getScopeFor(ast)) {
     if (Symbol* sym = scope->lookupNameLocally(name)) {
-      if (sym->hasFlag(FLAG_METHOD) == false) {
-        retval = sym;
-
-      } else if (FnSymbol* fn = toFnSymbol(sym)) {
-        if (methodMatched(ast, fn) == true) {
+      if (FnSymbol* fn = toFnSymbol(sym)) {
+        if (fn->isMethod() == false || methodMatched(ast, fn) == true) {
           retval = sym;
         }
+
+      } else {
+        retval = sym;
       }
     }
   }

--- a/compiler/resolution/ResolutionCandidate.cpp
+++ b/compiler/resolution/ResolutionCandidate.cpp
@@ -487,9 +487,9 @@ void ResolutionCandidate::computeSubstitutions() {
           USR_FATAL(formal,
                     "invalid generic type specification on class field");
 
-        } else if (fn->hasFlag(FLAG_METHOD) == true &&
-                   strcmp(fn->name, "init") == 0 &&
-                   fn->hasFlag(FLAG_COMPILER_GENERATED) &&
+        } else if (fn->isMethod()                       == true &&
+                   strcmp(fn->name, "init")             == 0    &&
+                   fn->hasFlag(FLAG_COMPILER_GENERATED) == true &&
                    !(formal->hasFlag(FLAG_ARG_THIS)                == true  &&
                      formal->hasFlag(FLAG_DELAY_GENERIC_EXPANSION) == true)) {
           // This is a compiler generated initializer, so the argument with

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -3020,7 +3020,8 @@ static bool populateForwardingMethods(CallInfo& info) {
       //  (e.g. proc these() return _value.these(); )
       fn->removeFlag(FLAG_ITERATOR_FN);
 
-      fn->addFlag(FLAG_METHOD);
+      fn->setMethod(true);
+
       fn->addFlag(FLAG_INLINE);
       fn->addFlag(FLAG_FORWARDING_FN);
       fn->addFlag(FLAG_COMPILER_GENERATED);

--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -343,7 +343,7 @@ void resolveFunction(FnSymbol* fn) {
           fn->getFormal(1)->type->symbol->addFlag(FLAG_PRIVATIZED_CLASS);
         }
 
-        if (fn->hasFlag(FLAG_METHOD) == true && fn->_this != NULL) {
+        if (fn->isMethod() == true && fn->_this != NULL) {
           ensureInMethodList(fn);
         }
 
@@ -668,7 +668,7 @@ static FnSymbol* makeIteratorMethod(IteratorInfo* ii,
     fn->addFlag(FLAG_INLINE);
   }
 
-  fn->addFlag(FLAG_METHOD);
+  fn->setMethod(true);
 
   fn->_this   = new ArgSymbol(INTENT_BLANK, "this", ii->iclass);
   fn->_this->addFlag(FLAG_ARG_THIS);
@@ -1526,7 +1526,7 @@ static void insertCasts(BaseAST* ast, FnSymbol* fn, Vec<CallExpr*>& casts) {
 ************************************** | *************************************/
 
 void ensureInMethodList(FnSymbol* fn) {
-  if (fn->hasFlag(FLAG_METHOD) == true && fn->_this != NULL) {
+  if (fn->isMethod() == true && fn->_this != NULL) {
     Type* thisType = fn->_this->type->getValType();
     bool  found    = false;
 

--- a/compiler/resolution/tuples.cpp
+++ b/compiler/resolution/tuples.cpp
@@ -289,11 +289,14 @@ FnSymbol* makeDestructTuple(TypeSymbol* newTypeSymbol,
 
   // Does "_this" even make sense in this situation?
   ArgSymbol* _this = new ArgSymbol(INTENT_BLANK, "this", newType);
+
   _this->addFlag(FLAG_ARG_THIS);
+
   dtor->_this = _this;
 
+  dtor->setMethod(true);
+
   dtor->insertFormalAtTail(new ArgSymbol(INTENT_BLANK, "_mt", dtMethodToken));
-  dtor->addFlag(FLAG_METHOD);
   dtor->insertFormalAtTail(dtor->_this);
 
   dtor->addFlag(FLAG_COMPILER_GENERATED);

--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -1706,7 +1706,7 @@ static FnSymbol* buildEmptyWrapper(FnSymbol* fn, CallInfo& info) {
   }
 
   if (fn->isMethod() == true) {
-    wrapper->addFlag(FLAG_METHOD);
+    wrapper->setMethod(true);
   }
 
   if (fn->hasFlag(FLAG_METHOD_PRIMARY)) {

--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -1705,7 +1705,7 @@ static FnSymbol* buildEmptyWrapper(FnSymbol* fn, CallInfo& info) {
     wrapper->retTag = fn->retTag;
   }
 
-  if (fn->hasFlag(FLAG_METHOD)) {
+  if (fn->isMethod() == true) {
     wrapper->addFlag(FLAG_METHOD);
   }
 


### PR DESCRIPTION
Start to clarify method

There is not currently a clear definition of "method" within
the compiler and there are a variety of ways that "methods"
are processed within the compiler.




There are currently two basic approaches 

1) Invoke FnSymbol::isMethod() const;
or (equivalently) test sym->hasFlag(FLAG_METHOD)
directly



2) Code that inspects the formals directly with some
variation of determining if formal(1) == gMethodToken.


These do not necessarily return the same result (for
reasons that are not entirely clear).  It is also worth
recalling the _mt is removed in later passes of the
compiler.



This PR starts an effort to standardize on the abstraction
isMethod() [perhaps with some variations in the future].

All existing uses of hasFlag(FLAG_METHOD) are converted
to the (currently identical) FnSymbol::isMethod().  Existing
uses of addFlag(FLAG_METHOD) are converted to the
new method FnSymbol::setMethod().

Compiled with standard variations, simple local testing, and
a standard  paratest.




