### PR TITLE
Add an llvm --no-local performance configuration

### DIFF
--- a/util/cron/test-perf.chapcs.clang.bash
+++ b/util/cron/test-perf.chapcs.clang.bash
@@ -16,6 +16,6 @@ SHORT_NAME=clang
 START_DATE=09/10/16
 
 perf_args="-performance-description $SHORT_NAME -performance-configs default:v,$SHORT_NAME:v -sync-dir-suffix $SHORT_NAME"
-perf_args="${perf_args} -performance -numtrials 5 -startdate $START_DATE"
+perf_args="${perf_args} -performance -numtrials 1 -startdate $START_DATE"
 
 $CWD/nightly -cron ${nightly_args} ${perf_args}

--- a/util/cron/test-perf.chapcs.llvm.no-local.bash
+++ b/util/cron/test-perf.chapcs.llvm.no-local.bash
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#
+
+CWD=$(cd $(dirname $0) ; pwd)
+
+export CHPL_TEST_PERF_CONFIG_NAME='chapcs'
+
+source $CWD/common-perf.bash
+source $CWD/common-llvm.bash
+
+# common-llvm restricts us to extern/fergeson, we want all the perf tests
+unset CHPL_NIGHTLY_TEST_DIRS
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.llvm.no-local"
+
+perf_args="-performance-description llvm-no-local -performance-configs no-local:v,llvm-no-local:v -sync-dir-suffix llvm-no-local"
+perf_args="${perf_args} -performance -numtrials 3 -startdate 12/15/17"
+
+nightly_args="${nightly_args} -no-local"
+
+$CWD/nightly -cron ${nightly_args} ${perf_args}

--- a/util/cron/test-perf.chapcs.no-local.bash
+++ b/util/cron/test-perf.chapcs.no-local.bash
@@ -10,7 +10,7 @@ source $CWD/common-perf.bash
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.no-local"
 
 perf_args="-performance-description no-local -performance-configs default:v,no-local:v -sync-dir-suffix no-local"
-perf_args="${perf_args} -performance -numtrials 5 -startdate 09/13/17"
+perf_args="${perf_args} -performance -numtrials 3 -startdate 09/13/17"
 
 nightly_args="${nightly_args} -no-local"
 


### PR DESCRIPTION
--no-local prk-stencil performs much worse with the llvm backend, so I want to
see if there's other regressions as well.

This will run on the same machine as regular --no-local perf testing, which
required moving clang to a different machine, so drop clang to 1 trial (it's
not a configuration we care deeply about) and only do 3 trials for --no-local
perf configs since they're a little slower.