### PR TITLE
Remove qio_free_string

### DIFF
--- a/modules/internal/CString.chpl
+++ b/modules/internal/CString.chpl
@@ -277,7 +277,7 @@ module CString {
   inline proc chpl_free_c_string(ref cs: c_string) {
     pragma "insert line file info"
     extern proc chpl_rt_free_c_string(ref cs: c_string);
-    if (cs != c_nil) then chpl_rt_free_c_string(cs);
+    if (cs != c_nil:c_string) then chpl_rt_free_c_string(cs);
     // cs = c_nil;
   }
 

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -962,7 +962,6 @@ private extern proc qio_locales_for_region(fl:qio_file_ptr_t,
                                    ref num_locs_out:c_int):syserr;
 private extern proc qio_get_chunk(fl:qio_file_ptr_t, ref len:int(64)):syserr;
 private extern proc qio_get_fs_type(fl:qio_file_ptr_t, ref tp:c_int):syserr;
-private extern proc qio_free_string(arg:c_string);
 
 pragma "no prototype" // FIXME
 private extern proc qio_file_path_for_fd(fd:fd_t, ref path:c_string):syserr;
@@ -1460,7 +1459,7 @@ proc file.getPath(out error:syserr) : string {
       if !error {
         error = qio_shortest_path(_file_internal, tmp2, tmp);
       }
-      qio_free_string(tmp);
+      chpl_free_c_string(tmp);
       if !error {
         ret = new string(tmp2, needToCopy=false);
       }
@@ -4477,7 +4476,7 @@ proc file.localesForRegion(start:int(64), end:int(64)) {
     // We allocated memory in the runtime for this, so free it now
     if num_hosts != 0 {
       for i in 0..num_hosts-1 do
-        qio_free_string(locs[i]);
+        chpl_free_c_string(locs[i]);
       c_free(locs);
     }
 

--- a/runtime/include/qio/qio.h
+++ b/runtime/include/qio/qio.h
@@ -73,11 +73,6 @@ typedef uint32_t qio_hint_t;
 #define FTYPE_CURL 3
 #endif
 
-// So that we can free c_strings from Chapel
-// This is temporary for now, one Sung's 'string_free' function goes in, this
-// and the use of it in IO.chpl can go away.
-#define qio_free_string(str) qio_free((char*)str)
-
 // The qio lock must be re-entrant in order to handle
 // e.g. qio_printf, which has will lock the lock, then
 // call printf, which will call cookie write, and lock the lock again.

--- a/test/modules/sungeun/init/printModuleInitOrder.good
+++ b/test/modules/sungeun/init/printModuleInitOrder.good
@@ -1,6 +1,7 @@
 Initializing Modules:
    ChapelStandard
     CPtr
+    CString
     String
      SysCTypes
      StringCasts

--- a/test/optimizations/deadCodeElimination/elliot/countDeadModules.good
+++ b/test/optimizations/deadCodeElimination/elliot/countDeadModules.good
@@ -1,1 +1,1 @@
-Removed 25 dead modules.
+Removed 24 dead modules.


### PR DESCRIPTION
The qio_free_string macro does not work with LLVM builds, and we can easily use chpl_free_c_string in its place.

Testing:
- [x] full local