### PR TITLE
Rely on externally-set CHPL_AUXIO* Make variables to provide lustre api.

### DIFF
--- a/make/compiler/Makefile.cray-prgenv
+++ b/make/compiler/Makefile.cray-prgenv
@@ -76,12 +76,3 @@ ifneq (,$(filter $(CHPL_MAKE_COMM_SUBSTRATE),gemini aries))
 export PE_CHAPEL_PKGCONFIG_LIBS := cray-pmi:cray-udreg:cray-ugni:$(PE_CHAPEL_PKGCONFIG_LIBS)
 endif
 endif
-
-# on login/compute nodes, lustre requires the devel api to make
-# lustre/lustreapi.h available (it's implicitly available on esl nodes)
-ifneq (,$(findstring lustre,$(CHPL_MAKE_AUXFS)))
-HAVE_LUSTRE_API_DEVEL_STATUS=$(shell pkg-config --libs cray-lustre-api-devel &>/dev/null; echo $$?)
-ifeq ($(HAVE_LUSTRE_API_DEVEL_STATUS), 0)
-export PE_CHAPEL_PKGCONFIG_LIBS := cray-lustre-api-devel:$(PE_CHAPEL_PKGCONFIG_LIBS)
-endif
-endif


### PR DESCRIPTION
This change simply reverts PR #3550. PR #3550 was not entirely successful
because it only fixes the "missing file lustre/lustreapi.h" problem for
Cray-PrgEnv compilers- it does not help the clang-included compiler, which
does not interact with the Cray PrgEnv at all.

As we have recently decided to use the CHPL_AUXIO* Make variables to
provide lustre api paths and flags for clang-included, we may as well let
the the Cray-PrgEnv compilers get the same info the same way.