### PR TITLE
Virtual dispatch 8

### DIFF
--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -586,7 +586,7 @@ public:
                                                  Type*   newRetType);
 
   int                        numFormals()                                const;
-  ArgSymbol*                 getFormal(int i);
+  ArgSymbol*                 getFormal(int i)                            const;
 
   void                       collapseBlocks();
 
@@ -600,10 +600,15 @@ public:
   bool                       isResolved()                                const;
 
   bool                       isMethod()                                  const;
+  bool                       isMethodOnClass()                           const;
+  bool                       isMethodOnRecord()                          const;
+
   void                       setMethod(bool value);
 
   bool                       isPrimaryMethod()                           const;
   bool                       isSecondaryMethod()                         const;
+
+  AggregateType*             getReceiver()                               const;
 
   bool                       isIterator()                                const;
   bool                       returnsRefOrConstRef()                      const;

--- a/compiler/resolution/virtualDispatch.cpp
+++ b/compiler/resolution/virtualDispatch.cpp
@@ -148,25 +148,17 @@ static bool buildVirtualMaps() {
   int numTypes = gTypeSymbols.n;
 
   forv_Vec(FnSymbol, fn, gFnSymbols) {
-    if (fn->isResolved()            == true      &&
-        fn->numFormals()            >  1         &&
+    if (AggregateType* at = fn->getReceiver()) {
+      if (isNonGenericClass(at) == true) {
+        if (fn->isResolved()            == true      &&
 
-        fn->hasFlag(FLAG_WRAPPER)   == false     &&
-        fn->hasFlag(FLAG_NO_PARENS) == false     &&
+            fn->hasFlag(FLAG_WRAPPER)   == false     &&
+            fn->hasFlag(FLAG_NO_PARENS) == false     &&
 
-        fn->retTag                  != RET_PARAM &&
-        fn->retTag                  != RET_TYPE) {
-      ArgSymbol*     _mt   = fn->getFormal(1);
-      ArgSymbol*     _this = fn->getFormal(2);
-      AggregateType* at    = toAggregateType(_this->type);
-
-      AggregateType* at2   = fn->getReceiver();
-
-      if (_mt->type == dtMethodToken && isNonGenericClass(at) == true) {
-        INT_ASSERT(at                    == at2);
-        INT_ASSERT(fn->isMethodOnClass() == true);
-
-        addAllToVirtualMaps(fn, at);
+            fn->retTag                  != RET_PARAM &&
+            fn->retTag                  != RET_TYPE) {
+          addAllToVirtualMaps(fn, at);
+        }
       }
     }
   }

--- a/compiler/resolution/virtualDispatch.cpp
+++ b/compiler/resolution/virtualDispatch.cpp
@@ -160,7 +160,12 @@ static bool buildVirtualMaps() {
       ArgSymbol*     _this = fn->getFormal(2);
       AggregateType* at    = toAggregateType(_this->type);
 
+      AggregateType* at2   = fn->getReceiver();
+
       if (_mt->type == dtMethodToken && isNonGenericClass(at) == true) {
+        INT_ASSERT(at                    == at2);
+        INT_ASSERT(fn->isMethodOnClass() == true);
+
         addAllToVirtualMaps(fn, at);
       }
     }


### PR DESCRIPTION
Introduce FnSymbol::getReceiver()

This PR introduces a function returns the "receiver" for an FnSymbol
that implements a method or NULL otherwise.  Uses this function to
trivially implement isMethodForClass() and isMethodForRecord().

Applies getReceiver() to simplify an entry point in virtualDispatch.cpp

Compiled with common configurations.  Multiple testing passes and
then a final paratest with -futures.