### PR TITLE
Suppress lcals performance testing under cray-prgenv-gnu

### DIFF
--- a/test/release/examples/benchmarks/lcals/LCALSMain.suppressif
+++ b/test/release/examples/benchmarks/lcals/LCALSMain.suppressif
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+
+import os
+
+print(os.getenv('CHPL_TEST_PERF') == 'on' and
+      os.getenv('CHPL_TARGET_COMPILER') == 'cray-prgenv-gnu')


### PR DESCRIPTION
This test is failing with an undefined reference to "_ZGVcN4v___exp_finite",
because the driver isn't throwing -lmvec. Suppress it until the driver is fixed