### PR TITLE
Follow type aliases to work around resolution order issues

### DIFF
--- a/compiler/resolution/postFold.cpp
+++ b/compiler/resolution/postFold.cpp
@@ -251,11 +251,11 @@ static Expr* postFoldPrimop(CallExpr* call) {
       if (st->symbol->hasFlag(FLAG_DISTRIBUTION) && isDistClass(pt)) {
         AggregateType* ag = toAggregateType(st);
         st = ag->getField("_instance")->type;
+      } else {
+        // Try to work around some resolution order issues
+        st = resolveTypeAlias(subExpr);
+        pt = resolveTypeAlias(parentExpr);
       }
-
-      // Try to work around some resolution order issues
-      st = resolveTypeAlias(subExpr);
-      pt = resolveTypeAlias(parentExpr);
 
       if (st                                != dtUnknown &&
           pt                                != dtUnknown &&

--- a/compiler/resolution/postFold.cpp
+++ b/compiler/resolution/postFold.cpp
@@ -273,7 +273,11 @@ static Expr* postFoldPrimop(CallExpr* call) {
         }
 
         call->replace(retval);
+      } else {
+        USR_FATAL(call, "Unable to perform subtype query: %s:%s", st->symbol->name, pt->symbol->name);
       }
+    } else {
+      USR_FATAL(call, "Subtype query requires a type");
     }
 
   } else if (call->isPrimitive(PRIM_CAST) == true) {


### PR DESCRIPTION
The removal of c_string_copy (#8014) resulted in a failure for the
following test:

extern/jjueckstock/basic.chpl

That PR adjusted the _defaultOf for c_string to return a cast from
'c_nil' to 'c_string'. This requires the resolution of a '_cast'
function in CPtr.chpl with a where-clause of:

```chpl
(t:c_intptr || t:c_uintptr || t:int(64) || t:uint(64)) &&
(x.type:c_void_ptr || x.type:c_ptr)
```

The compiler hadn't yet resolved the 'c_intptr' type, and so the
resolution of the where-clause failed. This commit updates postFold's
handling of PRIM_IS_SUBTYPE to follow type aliases, which correctly
finds the type of c_intptr and allows the where-clause to resolve.

Also adds errors if we are unable to evaluate the call.

Testing:
- [x] full local
- [x] full gasnet
- [x] test/extern/ , CHPL_LLVM=system