### PR TITLE
HOST, not TARGET for printchplenv --launcher

### DIFF
--- a/util/printchplenv
+++ b/util/printchplenv
@@ -6,7 +6,7 @@ Print the current Chapel configuration. Arguments allow selection of
 what gets printed [content], how it gets printed [format], and what gets
 filtered [filter].
 
-The default [content] arguments are: --runtime --launcher
+The default [content] provides user-facing variables.
 
 Options:
   -h, --help    Show this help message and exit
@@ -55,44 +55,43 @@ ChapelEnv = namedtuple('ChapelEnv', ['name', 'content', 'shortname'])
 # Set default argument of 'shortname' to None
 ChapelEnv.__new__.__defaults__ = (None,)
 
-# Define common sets
+# Define base sets
 COMPILER = set(['compiler'])
 LAUNCHER = set(['launcher'])
 RUNTIME = set(['runtime'])
 INTERNAL = set(['internal'])
-RUNTIME_LAUNCHER = set(['runtime', 'launcher'])
-COMPILER_LAUNCHER = set(['compiler', 'launcher'])
+DEFAULT = set(['default'])
 
 # Global ordered list that stores names, content-categories, and shortnames
 CHPL_ENVS = [
-    ChapelEnv('CHPL_HOST_PLATFORM', COMPILER_LAUNCHER),
-    ChapelEnv('CHPL_HOST_COMPILER', COMPILER_LAUNCHER),
-    ChapelEnv('CHPL_TARGET_PLATFORM', RUNTIME),
-    ChapelEnv('CHPL_TARGET_COMPILER', RUNTIME),
+    ChapelEnv('CHPL_HOST_PLATFORM', COMPILER | LAUNCHER),
+    ChapelEnv('CHPL_HOST_COMPILER', COMPILER | LAUNCHER),
+    ChapelEnv('CHPL_TARGET_PLATFORM', RUNTIME | DEFAULT),
+    ChapelEnv('CHPL_TARGET_COMPILER', RUNTIME | DEFAULT),
     ChapelEnv('CHPL_ORIG_TARGET_COMPILER', INTERNAL),
-    ChapelEnv('CHPL_TARGET_ARCH', RUNTIME, 'arch'),
+    ChapelEnv('CHPL_TARGET_ARCH', RUNTIME | DEFAULT, 'arch'),
     ChapelEnv('CHPL_RUNTIME_ARCH', INTERNAL),
     ChapelEnv('CHPL_TARGET_BACKEND_ARCH', INTERNAL),
-    ChapelEnv('CHPL_LOCALE_MODEL', RUNTIME_LAUNCHER, 'loc'),
-    ChapelEnv('CHPL_COMM', RUNTIME_LAUNCHER, 'comm'),
-    ChapelEnv('  CHPL_COMM_SUBSTRATE', RUNTIME_LAUNCHER),
-    ChapelEnv('  CHPL_GASNET_SEGMENT', RUNTIME_LAUNCHER),
-    ChapelEnv('CHPL_TASKS', RUNTIME_LAUNCHER, 'tasks'),
-    ChapelEnv('CHPL_LAUNCHER', LAUNCHER, 'launch'),
-    ChapelEnv('CHPL_TIMERS', RUNTIME_LAUNCHER, 'tmr'),
-    ChapelEnv('CHPL_UNWIND', RUNTIME_LAUNCHER, 'unwind'),
+    ChapelEnv('CHPL_LOCALE_MODEL', RUNTIME | LAUNCHER | DEFAULT, 'loc'),
+    ChapelEnv('CHPL_COMM', RUNTIME | LAUNCHER | DEFAULT, 'comm'),
+    ChapelEnv('  CHPL_COMM_SUBSTRATE', RUNTIME | LAUNCHER | DEFAULT),
+    ChapelEnv('  CHPL_GASNET_SEGMENT', RUNTIME | LAUNCHER | DEFAULT),
+    ChapelEnv('CHPL_TASKS', RUNTIME | LAUNCHER | DEFAULT, 'tasks'),
+    ChapelEnv('CHPL_LAUNCHER', LAUNCHER | DEFAULT, 'launch'),
+    ChapelEnv('CHPL_TIMERS', RUNTIME | LAUNCHER | DEFAULT, 'tmr'),
+    ChapelEnv('CHPL_UNWIND', RUNTIME | LAUNCHER | DEFAULT, 'unwind'),
     ChapelEnv('CHPL_HOST_MEM', INTERNAL, 'hostmem'),
     ChapelEnv('CHPL_TARGET_MEM', INTERNAL, 'tgtmem'),
-    ChapelEnv('CHPL_MEM', RUNTIME_LAUNCHER, 'mem'),
+    ChapelEnv('CHPL_MEM', RUNTIME | LAUNCHER | DEFAULT, 'mem'),
     ChapelEnv('  CHPL_JEMALLOC', INTERNAL, 'jemalloc'),
-    ChapelEnv('CHPL_MAKE', RUNTIME, 'make'),
-    ChapelEnv('CHPL_ATOMICS', RUNTIME_LAUNCHER, 'atomics'),
-    ChapelEnv('  CHPL_NETWORK_ATOMICS', RUNTIME),
-    ChapelEnv('CHPL_GMP', RUNTIME, 'gmp'),
-    ChapelEnv('CHPL_HWLOC', RUNTIME),
-    ChapelEnv('CHPL_REGEXP', RUNTIME),
+    ChapelEnv('CHPL_MAKE', RUNTIME | DEFAULT, 'make'),
+    ChapelEnv('CHPL_ATOMICS', RUNTIME | LAUNCHER | DEFAULT, 'atomics'),
+    ChapelEnv('  CHPL_NETWORK_ATOMICS', RUNTIME | DEFAULT),
+    ChapelEnv('CHPL_GMP', RUNTIME | DEFAULT, 'gmp'),
+    ChapelEnv('CHPL_HWLOC', RUNTIME | DEFAULT),
+    ChapelEnv('CHPL_REGEXP', RUNTIME | DEFAULT),
     ChapelEnv('CHPL_LLVM', COMPILER, 'llvm'),
-    ChapelEnv('CHPL_AUX_FILESYS', RUNTIME, 'fs'),
+    ChapelEnv('CHPL_AUX_FILESYS', RUNTIME | DEFAULT, 'fs'),
     ChapelEnv('CHPL_RUNTIME_SUBDIR', INTERNAL),
     ChapelEnv('CHPL_LAUNCHER_SUBDIR', INTERNAL),
     ChapelEnv('CHPL_COMPILER_SUBDIR', INTERNAL),
@@ -387,9 +386,9 @@ def main():
     if options.tidy:
         options.filter.append('tidy')
 
-    # Set default [content] to --runtime --launcher
+    # Set default [content]
     if not options.content:
-        options.content.extend(['runtime', 'launcher'])
+        options.content = ['default']
 
     # Convert lists to sets to pass to printchplenv
     contents = set(options.content)

--- a/util/printchplenv
+++ b/util/printchplenv
@@ -61,13 +61,14 @@ LAUNCHER = set(['launcher'])
 RUNTIME = set(['runtime'])
 INTERNAL = set(['internal'])
 RUNTIME_LAUNCHER = set(['runtime', 'launcher'])
+COMPILER_LAUNCHER = set(['compiler', 'launcher'])
 
 # Global ordered list that stores names, content-categories, and shortnames
 CHPL_ENVS = [
-    ChapelEnv('CHPL_HOST_PLATFORM', COMPILER),
-    ChapelEnv('CHPL_HOST_COMPILER', COMPILER),
-    ChapelEnv('CHPL_TARGET_PLATFORM', RUNTIME_LAUNCHER),
-    ChapelEnv('CHPL_TARGET_COMPILER', RUNTIME_LAUNCHER),
+    ChapelEnv('CHPL_HOST_PLATFORM', COMPILER_LAUNCHER),
+    ChapelEnv('CHPL_HOST_COMPILER', COMPILER_LAUNCHER),
+    ChapelEnv('CHPL_TARGET_PLATFORM', RUNTIME),
+    ChapelEnv('CHPL_TARGET_COMPILER', RUNTIME),
     ChapelEnv('CHPL_ORIG_TARGET_COMPILER', INTERNAL),
     ChapelEnv('CHPL_TARGET_ARCH', RUNTIME, 'arch'),
     ChapelEnv('CHPL_RUNTIME_ARCH', INTERNAL),


### PR DESCRIPTION
`printchplenv --launcher` was unintentionally changed to  printe `TARGET` values instead of `HOST` values. Surprisingly, this did not cause catastrophic failure. It did, however, modify the module build paths on Cray e.g. `PrgEnv-gnu` vs. `gnu`.

In making this change, the default output logic was changed to no longer depend on existing flags. Instead, the variables that are printed by default are specified by a `content` element of `'default'`. The help output was updated to reflect this, referring to the default variables as "user-facing variables".

Before this PR:

```
> printchplenv --simple --launcher --anonymize

CHPL_TARGET_PLATFORM=darwin
CHPL_TARGET_COMPILER=clang
CHPL_LOCALE_MODEL=flat
CHPL_COMM=none
CHPL_TASKS=qthreads
CHPL_LAUNCHER=none
CHPL_TIMERS=generic
CHPL_UNWIND=none
CHPL_MEM=jemalloc
CHPL_ATOMICS=intrinsics

> printchplenv --path --launcher

darwin/clang/loc-flat/comm-none/tasks-qthreads/launch-none/tmr-generic/unwind-none/mem-jemalloc/atomics-intrinsics
```

After this PR:

```
> printchplenv --simple --launcher --anonymize

CHPL_HOST_PLATFORM=darwin   <--- replaced TARGET
CHPL_HOST_COMPILER=clang    <--- replaced TARGET
CHPL_LOCALE_MODEL=flat
CHPL_COMM=none
CHPL_TASKS=qthreads
CHPL_LAUNCHER=none
CHPL_TIMERS=generic
CHPL_UNWIND=none
CHPL_MEM=jemalloc
CHPL_ATOMICS=intrinsics

> printchplenv --path --launcher

darwin/clang/loc-flat/comm-none/tasks-qthreads/launch-none/tmr-generic/unwind-none/mem-jemalloc/atomics-intrinsics
```

Default output remains unchanged.

## Testing

- [x] `linux64 paratest`
  - `[Summary: #Successes = 8075 | #Failures = 0 | #Futures = 0]`