### PR TITLE
Use default-args wrapper fn for default init for now

### DIFF
--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -190,7 +190,8 @@ FnSymbol* wrapAndCleanUpActuals(FnSymbol*                fn,
 static bool fnIsDefaultInit(FnSymbol* fn) {
   return fn->hasFlag(FLAG_COMPILER_GENERATED) &&
          fn->hasFlag(FLAG_LAST_RESORT) &&
-         0 == strcmp(fn->name, "init");
+         (0 == strcmp(fn->name, "init") ||
+          0 == strcmp(fn->name, "_new"));
 }
 
 /************************************* | **************************************

--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -112,6 +112,8 @@ formalToDefaultExprEntryMap formalToDefaultExprEntry;
 *                                                                             *
 ************************************** | *************************************/
 
+static bool fnIsDefaultInit(FnSymbol* fn);
+
 FnSymbol* wrapAndCleanUpActuals(FnSymbol*                fn,
                                 CallInfo&                info,
                                 std::vector<ArgSymbol*>  actualIdxToFormal,
@@ -119,9 +121,13 @@ FnSymbol* wrapAndCleanUpActuals(FnSymbol*                fn,
   int       numActuals = static_cast<int>(actualIdxToFormal.size());
   FnSymbol* retval     = fn;
 
-  if (fn->hasFlag(FLAG_DEFAULT_CONSTRUCTOR)) {
-    // TODO - remove this branch of the conditional once
-    // initializers have replaced the default constructor
+  if (fn->hasFlag(FLAG_DEFAULT_CONSTRUCTOR) ||
+      fnIsDefaultInit(fn)) {
+    // TODO:
+    //  * remove fnIsDefaultInit component of the conditional
+    //    once default init uses 'in' intent to move args to fields.
+    //  * remove this branch of the conditional once
+    //    initializers have replaced the default constructor
 
     if (numActuals < fn->numFormals()) {
       retval = wrapDefaultedFormals(retval, info, actualIdxToFormal);
@@ -179,6 +185,12 @@ FnSymbol* wrapAndCleanUpActuals(FnSymbol*                fn,
   }
 
   return retval;
+}
+
+static bool fnIsDefaultInit(FnSymbol* fn) {
+  return fn->hasFlag(FLAG_COMPILER_GENERATED) &&
+         fn->hasFlag(FLAG_LAST_RESORT) &&
+         0 == strcmp(fn->name, "init");
 }
 
 /************************************* | **************************************


### PR DESCRIPTION
Without this, tests such as

  classes/initializers/compilerGenerated/syncFieldTypeOnly.chpl

that use sync variables and throw --force-initializers will fail in fifo
configurations because the allocated sync variable will be destroyed
twice.

I'd consider the plan to improve 'in' intent and use it for
default initializers to be the proper way to fix this problem.
Until then, this change just puts default initializers back to
using the old default argument wrappers (which have special
cases for this kind of thing).

- [x] full local fifo testing
- [x] full local qthreads testing

Reviewed by @lydia-duncan - thanks!