### PR TITLE
Stop using point-of-instantiation in isMoreVisible

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -1231,10 +1231,7 @@ getParentBlock(Expr* expr) {
       return block;
   }
   if (expr->parentSymbol) {
-    FnSymbol* parentFn = toFnSymbol(expr->parentSymbol);
-    if (parentFn && parentFn->instantiationPoint)
-      return parentFn->instantiationPoint;
-    else if (expr->parentSymbol->defPoint)
+    if (expr->parentSymbol->defPoint)
       return getParentBlock(expr->parentSymbol->defPoint);
   }
   return NULL;

--- a/test/functions/ferguson/hijacking/Application2.bad
+++ b/test/functions/ferguson/hijacking/Application2.bad
@@ -1,2 +1,0 @@
-in Application2.setup
-Global is 0

--- a/test/functions/ferguson/hijacking/Application2.future
+++ b/test/functions/ferguson/hijacking/Application2.future
@@ -1,2 +1,0 @@
-bug: point-of-instantiation preferred over point-of-definition
-#8077

--- a/test/types/type_variables/bradc/test_point_of_instantiation2-blc.good
+++ b/test/types/type_variables/bradc/test_point_of_instantiation2-blc.good
@@ -1,8 +1,8 @@
 foo
 bar
-M1's goo
+M2's goo
 bar
-M1's goo
+M2's goo
 bar
 M2's goo
 M2's goo


### PR DESCRIPTION
Function disambiguation rules use a function, isMoreVisible, to tell when one
function is more visible than another. This function has historically treated
the point of instantiation of a generic as the "parent block" for that
function. However that leads to confusing program behavior in some cases,
as described in CHIP 20 and its connected issue #8077.

This behavior originated in commit 1da623b5f50906858891056584d5187d1bb478a0.

- [x] passed full local testing

Reviewed by @benharsh - thanks!