### PR TITLE
Continue to advance virtual dispatch for generics with initializers

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -266,7 +266,7 @@ void Symbol::addFlag(Flag flag) {
 
 void Symbol::copyFlags(const Symbol* other) {
   flags |= other->flags;
-  qual = other->qual;
+  qual   = other->qual;
 }
 
 
@@ -1838,7 +1838,11 @@ bool FnSymbol::tagIfGeneric() {
     if (result > 0) {
       addFlag(FLAG_GENERIC);
 
-      if (retType != dtUnknown && hasFlag(FLAG_TYPE_CONSTRUCTOR)) {
+      if (retType != dtUnknown && hasFlag(FLAG_TYPE_CONSTRUCTOR) == true) {
+        if (AggregateType* at = toAggregateType(retType)) {
+          at->markAsGeneric();
+        }
+
         retType->symbol->addFlag(FLAG_GENERIC);
 
         if (result == 2) {
@@ -2819,11 +2823,14 @@ immediate_type(Immediate *imm) {
   return NULL;
 }
 
-VarSymbol *new_ImmediateSymbol(Immediate *imm) {
-  VarSymbol *s = uniqueConstantsHash.get(imm);
+VarSymbol* new_ImmediateSymbol(Immediate *imm) {
+  VarSymbol* s = uniqueConstantsHash.get(imm);
+
   if (s)
     return s;
-  Type *t = immediate_type(imm);
+
+  Type* t = immediate_type(imm);
+
   s = new VarSymbol(astr("_literal_", istr(literal_id++)), t);
   rootModule->block->insertAtTail(new DefExpr(s));
   s->immediate = new Immediate;
@@ -2840,15 +2847,14 @@ VarSymbol *new_ImmediateSymbol(Immediate *imm) {
   return s;
 }
 
-Immediate *getSymbolImmediate(Symbol* sym) {
+Immediate* getSymbolImmediate(Symbol* sym) {
   Immediate* imm = NULL;
 
   if (VarSymbol* var = toVarSymbol(sym)) {
     imm = var->immediate;
   }
+
   if (EnumSymbol* enumsym = toEnumSymbol(sym)) {
-    // We used to assert et->getIntegerType() here,
-    // but that assert fires when printing out AST during debugging
     imm = enumsym->getImmediate();
   }
 

--- a/compiler/include/AggregateType.h
+++ b/compiler/include/AggregateType.h
@@ -60,6 +60,28 @@ public:
 
   virtual void                printDocs(std::ostream* file, unsigned int tabs);
 
+  bool                        isClass()                                  const;
+  bool                        isRecord()                                 const;
+  bool                        isUnion()                                  const;
+
+  bool                        isGeneric()                                const;
+  void                        markAsGeneric();
+
+  const char*                 classStructName(bool standalone);
+
+  int                         numFields()                                const;
+
+  Symbol*                     getField(int i)                            const;
+
+  Symbol*                     getField(const char* name,
+                                       bool        fatal = true)         const;
+
+  int                         getFieldPosition(const char* name,
+                                               bool        fatal = true);
+
+  // e is as used in PRIM_GET_MEMBER/PRIM_GET_SVEC_MEMBER
+  QualifiedType               getFieldType(Expr* e);
+
   void                        addDeclarations(Expr* expr);
 
   void                        codegenDef();
@@ -75,33 +97,16 @@ public:
                                                     bool        nested,
                                                     const char* baseOffset);
 
-  // The following two methods are used for types which define initializers
   bool                        setFirstGenericField();
 
   AggregateType*              getInstantiation(Symbol* sym, int index);
-  AggregateType*              getInstantiationParent(AggregateType* parentType);
+  AggregateType*              getInstantiationParent(AggregateType* pt);
 
   AggregateType*              getInstantiationMulti(SymbolMap& subs,
-                                                    FnSymbol* fn);
+                                                    FnSymbol*  fn);
 
   bool                        isInstantiatedFrom(const AggregateType* base)
                                                                          const;
-
-  const char*                 classStructName(bool standalone);
-
-  int                         getMemberGEP(const char* name);
-
-  int                         getFieldPosition(const char* name,
-                                               bool        fatal = true);
-
-  Symbol*                     getField(const char* name, bool fatal = true) const;
-  Symbol*                     getField(int i)                            const;
-
-  // e is as used in PRIM_GET_MEMBER/PRIM_GET_SVEC_MEMBER
-  QualifiedType               getFieldType(Expr* e);
-
-  int                         numFields()                                const;
-
 
   DefExpr*                    toLocalField(const char* name)             const;
   DefExpr*                    toLocalField(SymExpr*    expr)             const;
@@ -110,32 +115,32 @@ public:
   DefExpr*                    toSuperField(SymExpr*  expr);
   DefExpr*                    toSuperField(CallExpr* expr);
 
-  bool                        isClass()                                  const;
-  bool                        isRecord()                                 const;
-  bool                        isUnion()                                  const;
-
-  bool                        isGeneric()                                const;
-  void                        markAsGeneric();
+  int                         getMemberGEP(const char* name);
 
   void                        createOuterWhenRelevant();
+
   void                        buildConstructors();
 
   void                        addRootType();
 
   void                        addClassToHierarchy();
 
+  bool                        parentDefinesInitializer();
+
+  bool                        wantsDefaultInitializer();
+
+  void                        buildDefaultInitializer();
+
+
+  //
+  // Public fields
+  //
+
   AggregateTag                aggregateTag;
 
   FnSymbol*                   defaultTypeConstructor;
-  FnSymbol*                   defaultInitializer;
-                              // This is the compiler-supplied
-                              // default-initializer.
-                              // It provides initial values for the
-                              // fields in an aggregate type.
 
-  bool                        parentDefinesInitializer();
-  bool                        wantsDefaultInitializer();
-  void                        buildDefaultInitializer();
+  FnSymbol*                   defaultInitializer;
 
   AggregateType*              instantiatedFrom;
 
@@ -201,14 +206,18 @@ private:
                                                VarSymbol* field)         const;
 
   void                        buildConstructor();
+
   bool                        needsConstructor();
+
   ArgSymbol*                  moveConstructorToOuter(FnSymbol* fn);
 
   void                        fieldToArg(FnSymbol*              fn,
                                          std::set<const char*>& names,
                                          SymbolMap&             fieldArgMap);
-  void                        fieldToArgType(DefExpr* fieldDef,
+
+  void                        fieldToArgType(DefExpr*   fieldDef,
                                              ArgSymbol* arg);
+
   bool                        addSuperArgs(FnSymbol*                    fn,
                                            const std::set<const char*>& names);
 

--- a/compiler/include/AggregateType.h
+++ b/compiler/include/AggregateType.h
@@ -125,9 +125,9 @@ public:
 
   void                        addClassToHierarchy();
 
-  bool                        parentDefinesInitializer();
+  bool                        parentDefinesInitializer()                 const;
 
-  bool                        wantsDefaultInitializer();
+  bool                        wantsDefaultInitializer()                  const;
 
   void                        buildDefaultInitializer();
 

--- a/compiler/include/AggregateType.h
+++ b/compiler/include/AggregateType.h
@@ -76,7 +76,7 @@ public:
                                                     const char* baseOffset);
 
   // The following two methods are used for types which define initializers
-  bool                        setNextGenericField();
+  bool                        setFirstGenericField();
 
   AggregateType*              getInstantiation(Symbol* sym, int index);
   AggregateType*              getInstantiationParent(AggregateType* parentType);

--- a/compiler/passes/initializerRules.cpp
+++ b/compiler/passes/initializerRules.cpp
@@ -334,8 +334,7 @@ static void preNormalizeInit(FnSymbol* fn) {
   // If this is a non-generic class then create a type method
   // to wrap this initializer
   if (isClass(at) == true && at->isGeneric() == false) {
-    FnSymbol* _newFn = buildClassAllocator(fn);
-    normalize(_newFn);
+    buildClassAllocator(fn);
 
     fn->addFlag(FLAG_INLINE);
   }
@@ -1072,9 +1071,10 @@ FnSymbol* buildClassAllocator(FnSymbol* initMethod) {
 
   body->insertAtTail(new CallExpr(PRIM_RETURN, newInstance));
 
-
   // Insert the definition in to the tree
   at->symbol->defPoint->insertBefore(new DefExpr(fn));
+
+  normalize(fn);
 
   return fn;
 }

--- a/compiler/resolution/initializerResolution.cpp
+++ b/compiler/resolution/initializerResolution.cpp
@@ -281,9 +281,7 @@ static void resolveInitializerMatch(FnSymbol* fn) {
 
         resolveInitializerBody(fn);
 
-        FnSymbol* classAlloc = buildClassAllocator(fn);
-
-        normalize(classAlloc);
+        buildClassAllocator(fn);
 
       } else {
         INT_ASSERT(false);

--- a/compiler/resolution/initializerResolution.cpp
+++ b/compiler/resolution/initializerResolution.cpp
@@ -261,7 +261,7 @@ static void resolveMatch(FnSymbol* fn) {
 
     if (wasGeneric == true) {
       AggregateType* at  = toAggregateType(fn->_this->type);
-      bool           res = at->setNextGenericField();
+      bool           res = at->setFirstGenericField();
 
       if (at->isClass() == true) {
         if (at->dispatchParents.v[0]                                == NULL ||

--- a/compiler/resolution/initializerResolution.cpp
+++ b/compiler/resolution/initializerResolution.cpp
@@ -262,22 +262,31 @@ static void resolveInitializerMatch(FnSymbol* fn) {
       resolveInitializerBody(fn);
 
     } else {
-      bool res = at->setFirstGenericField();
+      if (at->isRecord() == true) {
+        at->setFirstGenericField();
 
-      if (at->isClass() == true) {
+        resolveInitializerBody(fn);
+
+      } else if (at->isClass() == true) {
         AggregateType* parent = at->dispatchParents.v[0];
 
         if (parent->isGeneric() == false) {
-          INT_ASSERT(res);
+          if (at->setFirstGenericField() == false) {
+            INT_ASSERT(false);
+          }
+
+        } else {
+          at->setFirstGenericField();
         }
-      }
 
-      resolveInitializerBody(fn);
+        resolveInitializerBody(fn);
 
-      if (at->isClass() == true) {
         FnSymbol* classAlloc = buildClassAllocator(fn);
 
         normalize(classAlloc);
+
+      } else {
+        INT_ASSERT(false);
       }
     }
   }

--- a/compiler/resolution/initializerResolution.cpp
+++ b/compiler/resolution/initializerResolution.cpp
@@ -43,7 +43,7 @@ static void gatherInitCandidates(CallInfo&                  info,
                                  Vec<FnSymbol*>&            visibleFns,
                                  Vec<ResolutionCandidate*>& candidates);
 
-static void resolveMatch(FnSymbol* fn);
+static void resolveInitializerMatch(FnSymbol* fn);
 
 static void makeRecordInitWrappers(CallExpr* call);
 
@@ -60,7 +60,7 @@ FnSymbol* resolveInitializer(CallExpr* call) {
 
   INT_ASSERT(call->isResolved());
 
-  resolveMatch(call->resolvedFunction());
+  resolveInitializerMatch(call->resolvedFunction());
 
   if (isGenericRecord(call->get(2)->typeInfo())) {
     NamedExpr* named   = toNamedExpr(call->get(2));
@@ -154,15 +154,14 @@ static void resolveInitCall(CallExpr* call) {
 *                                                                             *
 ************************************** | *************************************/
 
-static void      doGatherInitCandidates(CallInfo&                  info,
-                                        Vec<FnSymbol*>&            visibleFns,
-                                        bool                       generated,
-                                        Vec<ResolutionCandidate*>& candidates);
+static void doGatherInitCandidates(CallInfo&                  info,
+                                   Vec<FnSymbol*>&            visibleFns,
+                                   bool                       generated,
+                                   Vec<ResolutionCandidate*>& candidates);
 
-static void      filterInitCandidate(CallInfo&                  info,
-                                     FnSymbol*                  fn,
-                                     Vec<ResolutionCandidate*>& candidates);
-
+static void filterInitCandidate(CallInfo&                  info,
+                                FnSymbol*                  fn,
+                                Vec<ResolutionCandidate*>& candidates);
 
 static void gatherInitCandidates(CallInfo&                  info,
                                  Vec<FnSymbol*>&            visibleFns,
@@ -245,35 +244,39 @@ static void filterInitCandidate(CallInfo&                  info,
 *                                                                             *
 ************************************** | *************************************/
 
-static void resolveMatch(FnSymbol* fn) {
+static void resolveInitializerMatch(FnSymbol* fn) {
   if (fn->isResolved() == false) {
+    AggregateType* at = toAggregateType(fn->_this->type);
+
     if (fn->id == breakOnResolveID) {
       printf("breaking on resolve fn:\n");
       print_view(fn);
       gdbShouldBreakHere();
     }
 
-    fn->addFlag(FLAG_RESOLVED);
-
     insertFormalTemps(fn);
 
-    bool wasGeneric = fn->_this->type->symbol->hasFlag(FLAG_GENERIC);
+    bool wasGeneric = at->symbol->hasFlag(FLAG_GENERIC);
 
     if (wasGeneric == true) {
-      AggregateType* at  = toAggregateType(fn->_this->type);
-      bool           res = at->setFirstGenericField();
+      INT_ASSERT(at);
+
+      bool res = at->setFirstGenericField();
 
       if (at->isClass() == true) {
-        if (at->dispatchParents.v[0]                                == NULL ||
-            at->dispatchParents.v[0]->symbol->hasFlag(FLAG_GENERIC) == false) {
+        AggregateType* parent = at->dispatchParents.v[0];
+
+        if (parent->symbol->hasFlag(FLAG_GENERIC) == false) {
           INT_ASSERT(res);
         }
       }
     }
 
+    fn->addFlag(FLAG_RESOLVED);
+
     resolveBlockStmt(fn->body);
 
-    if (wasGeneric == true && isClass(fn->_this->type) == true) {
+    if (wasGeneric == true && isClass(at) == true) {
       FnSymbol* classAlloc = buildClassAllocator(fn);
 
       normalize(classAlloc);
@@ -282,12 +285,10 @@ static void resolveMatch(FnSymbol* fn) {
     if (tryFailure == false) {
       resolveReturnType(fn);
 
-      toAggregateType(fn->_this->type)->initializerResolved = true;
+      at->initializerResolved = true;
 
-      // insert casts as necessary
       insertAndResolveCasts(fn);
 
-      // make sure methods are in the methods list
       ensureInMethodList(fn);
 
     } else {

--- a/compiler/resolution/initializerResolution.cpp
+++ b/compiler/resolution/initializerResolution.cpp
@@ -258,28 +258,27 @@ static void resolveInitializerMatch(FnSymbol* fn) {
 
     insertFormalTemps(fn);
 
-    bool wasGeneric = at->symbol->hasFlag(FLAG_GENERIC);
+    if (at->isGeneric() == false) {
+      resolveInitializerBody(fn);
 
-    if (wasGeneric == true) {
-      INT_ASSERT(at);
-
+    } else {
       bool res = at->setFirstGenericField();
 
       if (at->isClass() == true) {
         AggregateType* parent = at->dispatchParents.v[0];
 
-        if (parent->symbol->hasFlag(FLAG_GENERIC) == false) {
+        if (parent->isGeneric() == false) {
           INT_ASSERT(res);
         }
       }
-    }
 
-    resolveInitializerBody(fn);
+      resolveInitializerBody(fn);
 
-    if (wasGeneric == true && isClass(at) == true) {
-      FnSymbol* classAlloc = buildClassAllocator(fn);
+      if (at->isClass() == true) {
+        FnSymbol* classAlloc = buildClassAllocator(fn);
 
-      normalize(classAlloc);
+        normalize(classAlloc);
+      }
     }
   }
 }


### PR DESCRIPTION
Continue to advance virtual dispatch for generics with initializers

While working on virtualDispatch.cpp I

1) Made some innocuous changes to AggregateType (e.g. made a couple of methods const)

2) Resolved an issue in setNextGenericField() for hierarchies that mix generic
and non-generic classes.


This PR merges a handful of simple commits that integrate those changes.

Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64 as
well as CHPL_LLVM=llvm on linux64.  Passed a portion of release/ for each
configuration.

Multiple paratests in several modes during development.
This PR passed a single-locale paratest with -futures
