### PR TITLE
Virtual dispatch 10

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -392,6 +392,19 @@ void AggregateType::accept(AstVisitor* visitor) {
   }
 }
 
+bool AggregateType::hasInitializers() const {
+  bool retval = false;
+
+  if (initializerStyle == DEFINES_INITIALIZER) {
+    retval = true;
+
+  } else {
+    retval = wantsDefaultInitializer();
+  }
+
+  return retval;
+}
+
 // For a record
 //     Return true if there are uses of new for this type
 //

--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -392,6 +392,25 @@ void AggregateType::accept(AstVisitor* visitor) {
   }
 }
 
+// For a record
+//     Return true if there are uses of new for this type
+//
+// For a class
+//     Return true if there are uses of new or if instances
+//     will be allocated via inheritance
+bool AggregateType::mayHaveInstances() const {
+  bool retval = false;
+
+  if (defaultTypeConstructor != NULL) {
+    retval = defaultTypeConstructor->isResolved();
+
+  } else {
+    retval = initializerResolved;
+  }
+
+  return retval;
+}
+
 // Determine the index for the first generic field (if present).
 // Return true if a generic field was found.
 bool AggregateType::setFirstGenericField() {

--- a/compiler/include/AggregateType.h
+++ b/compiler/include/AggregateType.h
@@ -84,6 +84,8 @@ public:
 
   void                        addDeclarations(Expr* expr);
 
+  bool                        mayHaveInstances()                         const;
+
   void                        codegenDef();
 
   void                        codegenPrototype();

--- a/compiler/include/AggregateType.h
+++ b/compiler/include/AggregateType.h
@@ -84,6 +84,8 @@ public:
 
   void                        addDeclarations(Expr* expr);
 
+  bool                        hasInitializers()                          const;
+
   bool                        mayHaveInstances()                         const;
 
   void                        codegenDef();

--- a/compiler/resolution/virtualDispatch.cpp
+++ b/compiler/resolution/virtualDispatch.cpp
@@ -116,9 +116,6 @@ static void addAllToVirtualMaps(FnSymbol*      pfn,
                                 AggregateType* pct);
 
 static void addToVirtualMaps(FnSymbol*      pfn,
-                             AggregateType* ct);
-
-static void addToVirtualMaps(FnSymbol*      pfn,
                              AggregateType* ct,
                              FnSymbol*      cfn,
                              AggregateType* type);
@@ -173,23 +170,17 @@ static void addAllToVirtualMaps(FnSymbol* pfn, AggregateType* pct) {
   forv_Vec(AggregateType, ct, pct->dispatchChildren) {
     if (ct->isGeneric() == false) {
       if (ct->mayHaveInstances() == true) {
-        addToVirtualMaps(pfn, ct);
+        std::vector<FnSymbol*> methods;
+
+        collectMethods(pfn, ct, methods);
+
+        for_vector(FnSymbol, cfn, methods) {
+          addToVirtualMaps(pfn, ct, cfn, ct);
+        }
       }
 
       // Recurse over this child's children
       addAllToVirtualMaps(pfn, ct);
-    }
-  }
-}
-
-static void addToVirtualMaps(FnSymbol* pfn, AggregateType* ct) {
-  if (ct->defaultTypeConstructor->isResolved() == true) {
-    std::vector<FnSymbol*> methods;
-
-    collectMethods(pfn, ct, methods);
-
-    for_vector(FnSymbol, cfn, methods) {
-      addToVirtualMaps(pfn, ct, cfn, ct);
     }
   }
 }

--- a/compiler/resolution/virtualDispatch.cpp
+++ b/compiler/resolution/virtualDispatch.cpp
@@ -117,8 +117,7 @@ static void addAllToVirtualMaps(FnSymbol*      pfn,
 
 static void addToVirtualMaps(FnSymbol*      pfn,
                              AggregateType* ct,
-                             FnSymbol*      cfn,
-                             AggregateType* type);
+                             FnSymbol*      cfn);
 
 static void collectMethods(FnSymbol*               pfn,
                            AggregateType*          ct,
@@ -175,7 +174,7 @@ static void addAllToVirtualMaps(FnSymbol* pfn, AggregateType* pct) {
         collectMethods(pfn, ct, methods);
 
         for_vector(FnSymbol, cfn, methods) {
-          addToVirtualMaps(pfn, ct, cfn, ct);
+          addToVirtualMaps(pfn, ct, cfn);
         }
       }
 
@@ -187,12 +186,11 @@ static void addAllToVirtualMaps(FnSymbol* pfn, AggregateType* pct) {
 
 static void addToVirtualMaps(FnSymbol*      pfn,
                              AggregateType* ct,
-                             FnSymbol*      cfn,
-                             AggregateType* type) {
+                             FnSymbol*      cfn) {
   SymbolMap subs;
 
   if (cfn->getFormal(2)->type->symbol->hasFlag(FLAG_GENERIC) == true) {
-    subs.put(cfn->getFormal(2), type->symbol);
+    subs.put(cfn->getFormal(2), ct->symbol);
   }
 
   for (int i = 3; i <= cfn->numFormals(); i++) {
@@ -211,7 +209,7 @@ static void addToVirtualMaps(FnSymbol*      pfn,
 
   } else {
     if (FnSymbol* fn = instantiate(cfn, subs)) {
-      FnSymbol*  typeConstr         = type->defaultTypeConstructor;
+      FnSymbol*  typeConstr         = ct->defaultTypeConstructor;
       BlockStmt* instantiationPoint = typeConstr->instantiationPoint;
 
       if (instantiationPoint == NULL) {

--- a/compiler/resolution/virtualDispatch.cpp
+++ b/compiler/resolution/virtualDispatch.cpp
@@ -171,7 +171,7 @@ static void addAllToVirtualMaps(FnSymbol* pfn, AggregateType* pct) {
   forv_Vec(Type, t, pct->dispatchChildren) {
     AggregateType* ct = toAggregateType(t);
 
-    if (ct->defaultTypeConstructor != NULL) {
+    if (ct->mayHaveInstances() == true) {
       addToVirtualMaps(pfn, ct);
     }
 

--- a/compiler/resolution/virtualDispatch.cpp
+++ b/compiler/resolution/virtualDispatch.cpp
@@ -213,14 +213,16 @@ static void addToVirtualMaps(FnSymbol*      pfn,
   } else {
     FnSymbol* fn = instantiate(cfn, subs);
 
-    FnSymbol*  typeConstr         = ct->defaultTypeConstructor;
-    BlockStmt* instantiationPoint = typeConstr->instantiationPoint;
+    if (ct->hasInitializers() == false) {
+      FnSymbol*  typeConstr         = ct->defaultTypeConstructor;
+      BlockStmt* instantiationPoint = typeConstr->instantiationPoint;
 
-    if (instantiationPoint == NULL) {
-      instantiationPoint = toBlockStmt(typeConstr->defPoint->parentExpr);
+      if (instantiationPoint == NULL) {
+        instantiationPoint = toBlockStmt(typeConstr->defPoint->parentExpr);
+      }
+
+      fn->instantiationPoint = instantiationPoint;
     }
-
-    fn->instantiationPoint = instantiationPoint;
 
     resolveOverride(pfn, fn);
   }

--- a/compiler/resolution/virtualDispatch.cpp
+++ b/compiler/resolution/virtualDispatch.cpp
@@ -149,15 +149,17 @@ static bool buildVirtualMaps() {
 
   forv_Vec(FnSymbol, fn, gFnSymbols) {
     if (AggregateType* at = fn->getReceiver()) {
-      if (isNonGenericClass(at) == true) {
-        if (fn->isResolved()            == true      &&
+      if (at->isClass() == true) {
+        if (at->isGeneric() == false) {
+          if (fn->isResolved()            == true      &&
 
-            fn->hasFlag(FLAG_WRAPPER)   == false     &&
-            fn->hasFlag(FLAG_NO_PARENS) == false     &&
+              fn->hasFlag(FLAG_WRAPPER)   == false     &&
+              fn->hasFlag(FLAG_NO_PARENS) == false     &&
 
-            fn->retTag                  != RET_PARAM &&
-            fn->retTag                  != RET_TYPE) {
-          addAllToVirtualMaps(fn, at);
+              fn->retTag                  != RET_PARAM &&
+              fn->retTag                  != RET_TYPE) {
+            addAllToVirtualMaps(fn, at);
+          }
         }
       }
     }
@@ -168,15 +170,15 @@ static bool buildVirtualMaps() {
 
 // Add overrides of pfn to virtual maps down the inheritance hierarchy
 static void addAllToVirtualMaps(FnSymbol* pfn, AggregateType* pct) {
-  forv_Vec(Type, t, pct->dispatchChildren) {
-    AggregateType* ct = toAggregateType(t);
+  forv_Vec(AggregateType, ct, pct->dispatchChildren) {
+    if (ct->isGeneric() == false) {
+      if (ct->mayHaveInstances() == true) {
+        addToVirtualMaps(pfn, ct);
+      }
 
-    if (ct->mayHaveInstances() == true) {
-      addToVirtualMaps(pfn, ct);
+      // Recurse over this child's children
+      addAllToVirtualMaps(pfn, ct);
     }
-
-    // Recurse over this child's children
-    addAllToVirtualMaps(pfn, ct);
   }
 }
 

--- a/compiler/resolution/virtualDispatch.cpp
+++ b/compiler/resolution/virtualDispatch.cpp
@@ -183,33 +183,13 @@ static void addAllToVirtualMaps(FnSymbol* pfn, AggregateType* pct) {
 }
 
 static void addToVirtualMaps(FnSymbol* pfn, AggregateType* ct) {
-  if (ct->symbol->hasFlag(FLAG_GENERIC) == false) {
-    if (ct->defaultTypeConstructor->isResolved() == true) {
-      std::vector<FnSymbol*> methods;
-
-      collectMethods(pfn, ct, methods);
-
-      for_vector(FnSymbol, cfn, methods) {
-        addToVirtualMaps(pfn, ct, cfn, ct);
-      }
-    }
-
-  } else {
-    FnSymbol*              typeConstr = ct->defaultTypeConstructor;
+  if (ct->defaultTypeConstructor->isResolved() == true) {
     std::vector<FnSymbol*> methods;
 
     collectMethods(pfn, ct, methods);
 
     for_vector(FnSymbol, cfn, methods) {
-      forv_Vec(AggregateType, at, gAggregateTypes) {
-        if (FnSymbol* typeConstrOther = at->defaultTypeConstructor) {
-          if (typeConstrOther->instantiatedFrom == typeConstr) {
-            if (at->symbol->hasFlag(FLAG_GENERIC) == false) {
-              addToVirtualMaps(pfn, ct, cfn, at);
-            }
-          }
-        }
-      }
+      addToVirtualMaps(pfn, ct, cfn, ct);
     }
   }
 }
@@ -220,8 +200,7 @@ static void addToVirtualMaps(FnSymbol*      pfn,
                              AggregateType* type) {
   SymbolMap subs;
 
-  if (ct->symbol->hasFlag(FLAG_GENERIC)                      == true ||
-      cfn->getFormal(2)->type->symbol->hasFlag(FLAG_GENERIC) == true) {
+  if (cfn->getFormal(2)->type->symbol->hasFlag(FLAG_GENERIC) == true) {
     subs.put(cfn->getFormal(2), type->symbol);
   }
 

--- a/test/classes/initializers/generics/overloading.bad
+++ b/test/classes/initializers/generics/overloading.bad
@@ -1,1 +1,0 @@
-overloading.chpl:3: error: halt reached - bbox() not implemented for this class

--- a/test/classes/initializers/generics/overloading.chpl
+++ b/test/classes/initializers/generics/overloading.chpl
@@ -5,13 +5,14 @@ class C {
 }
 
 class D : C {
-  param rank: int;
-  var ranges : rank*range(int, BoundedRangeType.bounded, false);
+  param rank   : int;
+  var   ranges : rank * range(int, BoundedRangeType.bounded, false);
 
-  // terrifyingly, making this an initializer mucks with virtual dispatch
   proc init(param rankVal: int) {
     rank = rankVal;
+
     super.init();
+
     for i in 1..rank do
       ranges(i) = 1..i;
   }

--- a/test/classes/initializers/generics/overloading.future
+++ b/test/classes/initializers/generics/overloading.future
@@ -1,5 +1,0 @@
-bug: initializer presence impacts virtual method dispatch
-
-If I change the initializer into a constructor, we find the correct version of
-the method being called.  I suspect our normalization is impacting it, but I am
-not certain.  Next step is to see if non-generic types are also impacted.


### PR DESCRIPTION
Enable virtual dispatch for generic classes with initializers

This PR finalizes changes to virtualDispatch.cpp to enable support
for virtual/dynamic dispatch of methods on generic classes that
also implement initializers.  In particular this PR


1. Removes some "legacy" paths that walk generic classes even
though virtual dispatch is only relevant to a subset of methods
on non-generic classes.


2. Abstracts a couple of places where explicit references to the
defaulTypeConstructor was a proxy for questions like "does this
program have the potential to make an instance of this class?".


3. Converts the future for this problem in to a passing test.


virtualDispatch.cpp continues to include a questionable use of
the FnSymbol::instantiationPoint for the defaultTypeConstructor.
This code is currently bypassed when the defaultTypeConstructor
does not exist.  This issue requires more attention at an appropriate
point.


This PR is presented as a handful of trivial commits that
highlight the simple transformations that were developed
and extensively tested on development branches.

Compiled with/without CHPL_DEVELOPER on clang/darwin
and gcc/linux64.  Limited testing on release/.

Also compiled with CHPL_LLVM=llvm on linux64 and tested
with a small portion of release/

Passed a full paratest with -futures.



