### PR TITLE
LinearAlgebra square checks

### DIFF
--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -832,6 +832,8 @@ proc isDiag(A: [?D] ?eltType) {
     compilerError("Rank size is not 2");
 
   const zero = 0: eltType;
+
+  // Check if any element not along the diagonal is nonzero
   for (i, j) in D {
     if i != j && A[i, j] != zero then return false;
   }
@@ -843,6 +845,9 @@ proc isDiag(A: [?D] ?eltType) {
 proc isHermitian(A: [?D]) {
   if D.rank != 2 then
     compilerError("Rank size is not 2");
+  if !isSquare(A) then
+    return false;
+
   for (i, j) in D {
     if i > j {
       if A[i, j] != conjg(A[j, i]) then return false;
@@ -856,6 +861,9 @@ proc isHermitian(A: [?D]) {
 proc isSymmetric(A: [?D]) : bool {
   if D.rank != 2 then
     compilerError("Rank size is not 2");
+  if !isSquare(A) then
+    return false;
+
   for (i, j) in D {
     if i > j {
       if A[i, j] != A[j, i] then return false;
@@ -905,15 +913,18 @@ proc isSquare(A: [?D]) {
 }
 
 
-/* Return the trace of square matrix ``A`` */
+/* Return the trace (sum of diagonal elements) of ``A`` */
 proc trace(A: [?D] ?eltType) {
   if D.rank != 2 then compilerError("Rank size not 2");
-  else
-    if !isSquare(A) then halt("Trace only supports square matrices");
-    var trace = 0: eltType;
-    forall (i, j) in zip(D.dim(1), D.dim(2)) with (+ reduce trace) do
-      trace += A[i, j];
-    return trace;
+
+  const (m, n) = A.shape;
+  const d = if m < n then 1 else 2;
+
+  var trace = 0: eltType;
+  forall i in D.dim(d) with (+ reduce trace) {
+    trace += A[i, i];
+  }
+  return trace;
 }
 
 //

--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -73,6 +73,14 @@ row vector, vector-vector multiplication is always treated as an inner-product,
 as the function name implies.
 An outer product can be computed with the :proc:`outer` function.
 
+**Domain maps**
+
+All of the functions in this module only support
+``DefaultRectangular`` arrays (the default domain map), unless explicitly
+specified in the function's documentation. Other domain maps
+are supported through submodules, such ``LinearAlgebra.Sparse`` for the
+``CS`` layout.
+
 **Promotion flattening**
 
 Promotion flattening is an unintended consequence of Chapel's

--- a/test/library/packages/LinearAlgebra/correctness/correctness.chpl
+++ b/test/library/packages/LinearAlgebra/correctness/correctness.chpl
@@ -393,6 +393,18 @@ config const correctness = true;
   assertEqual(Mtrace, t);
 }
 
+/* Rectangular trace */
+{
+  var Mrect = Matrix([1,2,3,4],
+                 [4,5,6,7],
+                 [7,8,9,8],
+                 eltType=real);
+  var Mtrace = 15.0;
+  var t = trace(Mrect);
+  assertEqual(Mtrace, t, 'trace(Mrect)');
+}
+
+
 /* diag */
 {
   var M = Matrix([1,2,3],
@@ -477,6 +489,10 @@ config const correctness = true;
   var I = eye(3,3);
   assertTrue(isDiag(I), "isDiag(I)");
 
+  // rectangular
+  var Irect = eye(3,5);
+  assertTrue(isDiag(I), "isDiag(Irect)");
+
   var M = I;
   M[0,2] = 1;
   assertFalse(isDiag(M), "isDiag(M)");
@@ -491,6 +507,11 @@ config const correctness = true;
   assertTrue(isHermitian(H), "isHermitian(H)");
   H[0,1] += -2i;
   assertFalse(isHermitian(H), "isHermitian(H')");
+
+  // rectangular
+  var Hrect = Matrix(3, 4, eltType=complex);
+  assertFalse(isHermitian(Hrect), "isHermitian(Hrect)");
+
 }
 
 /* isSymmetric */
@@ -502,6 +523,9 @@ config const correctness = true;
   assertTrue(isSymmetric(S), "isSymmetric(S)");
   S[0, 1] += 2;
   assertFalse(isSymmetric(S), "isSymmetric(S')");
+  S[0, 1] -= 2;
+  S[1, 0] += 2;
+  assertFalse(isSymmetric(S), "isSymmetric(S'')");
 }
 
 


### PR DESCRIPTION
- Update documentation to be more clear about what domain maps are supported in `LinearAlgebra`
- Remove `isSquare` check from `trace()`
- Add `isSquare`check to return `false` for `isHermitian()` and `isSymmetric()`
- New tests for this behavior

### Testing
- [x] OS X with MKL
- [x] Confirmed docs render well

### Next Steps

- Implement matrix property functions for sparse matrices
- Add `DefaultRectangular` check to all `LinearAlgebra` functions
  - Users will get a compiler error instead of a potentially wrong answer