### PR TITLE
Fix plus reduce in csrmatvecMult

### DIFF
--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -1182,7 +1182,7 @@ module Sparse {
 
       forall i in Adom.dim(1) with (+ reduce Y) {
         for j in Adom.dimIter(2, i) {
-          Y[j] = A[i, j] * X2[i];
+          Y[j] += A[i, j] * X2[i];
         }
       }
     }


### PR DESCRIPTION
#8089 fixed a race condition but missed some accumulations of the reduction variable on certain architectures, in the numa and knl locale models.  This restores the accumulations but retains the fix to the prior race condition.