### PR TITLE
Skip llvm-incremental under --llvm --fast

### DIFF
--- a/test/compflags/kushal/llvm-incremental.skipif
+++ b/test/compflags/kushal/llvm-incremental.skipif
@@ -1,1 +1,2 @@
 CHPL_LLVM==none
+COMPOPTS <= --fast


### PR DESCRIPTION
This is a future intended to capture that --incremental doesn't work with
--llvm. It fails to match the .bad under --fast, because we also get a
"--incremental may hurt execution perf" warning. That warning message is already
being tested with fastAndIncremental, so just skip this test for --fast