### PR TITLE
Also copy 'qual' upon VarSymbol::copyInner()

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -535,6 +535,7 @@ VarSymbol*
 VarSymbol::copyInner(SymbolMap* map) {
   VarSymbol* newVarSymbol = new VarSymbol(name, type);
   newVarSymbol->copyFlags(this);
+  newVarSymbol->qual = qual;
   newVarSymbol->cname = cname;
   INT_ASSERT(!newVarSymbol->immediate);
   return newVarSymbol;


### PR DESCRIPTION
Somehow copyInner() was not copying `qual` from the source
to the destination. This PR fixes that omission.

Passes linux64 -verify and gasnet paratest.