### PR TITLE
Retire future for internal error on (int)(real)

### DIFF
--- a/test/types/scalar/tmacd/fatal.future
+++ b/test/types/scalar/tmacd/fatal.future
@@ -1,1 +1,0 @@
-bug: (int)(real_variable) causes a fatal error rather than a compiler error.

--- a/test/types/scalar/tmacd/fatal.good
+++ b/test/types/scalar/tmacd/fatal.good
@@ -1,2 +1,1 @@
-chpl fatal.chpl
-internal error: FUN5596 chpl Version 1.9.0.620405d
+fatal.chpl:5: error: unresolved call 'int(64)(real(64))'


### PR DESCRIPTION
Retire future that for an internal error that no longer occurs.