### PR TITLE
Fix 32-bit revcomp failures

### DIFF
--- a/test/studies/shootout/reverse-complement/bharshbarg/revcomp-buf.chpl
+++ b/test/studies/shootout/reverse-complement/bharshbarg/revcomp-buf.chpl
@@ -40,7 +40,7 @@ record buf {
     if cur >= cap {
       if numLeft > 0 {
         cap = min(bufSize, numLeft);
-        chan.readBytes(c_ptrTo(buf), cap);
+        chan.readBytes(c_ptrTo(buf), cap:ssize_t);
         numLeft -= cap;
 
         // ensure we return an empty slice if we run out of bytes
@@ -63,7 +63,7 @@ record buf {
     const ptr = c_ptrTo(arr);
     const ret = memchr(ptr, c:c_int, arr.size:size_t);
     if ret != c_nil {
-      const idx = arr.domain.first + ret:int - ptr:int;
+      const idx = arr.domain.first + ret:c_intptr - ptr:c_intptr;
       return idx;
     }
     return -1;

--- a/test/studies/shootout/reverse-complement/bharshbarg/revcomp-line.chpl
+++ b/test/studies/shootout/reverse-complement/bharshbarg/revcomp-line.chpl
@@ -39,7 +39,7 @@ record buf {
     if cur >= cap {
       if numLeft > 0 {
         cap = min(bufSize, numLeft);
-        chan.readBytes(c_ptrTo(buf), cap);
+        chan.readBytes(c_ptrTo(buf), cap:ssize_t);
         numLeft -= cap;
 
         // ensure we return an empty slice if we run out of bytes
@@ -62,7 +62,7 @@ record buf {
     const ptr = c_ptrTo(arr);
     const ret = memchr(ptr, c:c_int, arr.size:size_t);
     if ret != c_nil {
-      const idx = arr.domain.first + ret:int - ptr:int;
+      const idx = arr.domain.first + ret:c_intptr - ptr:c_intptr;
       return idx;
     }
     return -1;


### PR DESCRIPTION
Fix 32-bit failures by casting to ssize_t and c_intptr.

Tested on linux64, linux32, and OS X.