### PR TITLE
Support stridable queries on sparse domains

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1084,13 +1084,8 @@ module ChapelArray {
     }
 
     /* Return true if this is a stridable domain */
-    proc stridable param where isRectangularDom(this) {
+    proc stridable param where isRectangularDom(this) || isSparseDom(this) {
       return _value.stridable;
-    }
-
-    pragma "no doc"
-    proc stridable param where isSparseDom(this) {
-      compilerError("sparse domains do not currently support .stridable");
     }
 
     pragma "no doc"

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1084,8 +1084,13 @@ module ChapelArray {
     }
 
     /* Return true if this is a stridable domain */
-    proc stridable param where isRectangularDom(this) || isSparseDom(this) {
+    proc stridable param where isRectangularDom(this) {
       return _value.stridable;
+    }
+
+    /* Return true if this sparse domain's parent is stridable */
+    proc stridable param where isSparseDom(this) {
+      return _value.parentDom.stridable;
     }
 
     pragma "no doc"

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1088,7 +1088,7 @@ module ChapelArray {
       return _value.stridable;
     }
 
-    /* Return true if this sparse domain's parent is stridable */
+    pragma "no doc"
     proc stridable param where isSparseDom(this) {
       return _value.parentDom.stridable;
     }

--- a/modules/internal/DefaultSparse.chpl
+++ b/modules/internal/DefaultSparse.chpl
@@ -41,6 +41,10 @@ module DefaultSparse {
       this.parentDom = parentDom;
     }
 
+    proc stridable param {
+      return this.parentDom.stridable;
+    }
+
     proc dsiBuildArray(type eltType)
       return new DefaultSparseArr(eltType=eltType, rank=rank, idxType=idxType,
                                   dom=this);

--- a/modules/internal/DefaultSparse.chpl
+++ b/modules/internal/DefaultSparse.chpl
@@ -41,10 +41,6 @@ module DefaultSparse {
       this.parentDom = parentDom;
     }
 
-    proc stridable param {
-      return this.parentDom.stridable;
-    }
-
     proc dsiBuildArray(type eltType)
       return new DefaultSparseArr(eltType=eltType, rank=rank, idxType=idxType,
                                   dom=this);

--- a/test/domains/claridge/sparseStridableQuery.chpl
+++ b/test/domains/claridge/sparseStridableQuery.chpl
@@ -1,3 +1,0 @@
-var D = {1..10};
-var D_sparse: sparse subdomain(D);
-writeln(D_sparse.stridable);

--- a/test/domains/claridge/sparseStridableQuery.good
+++ b/test/domains/claridge/sparseStridableQuery.good
@@ -1,1 +1,0 @@
-sparseStridableQuery.chpl:3: error: sparse domains do not currently support .stridable

--- a/test/sparse/domains/stridable.chpl
+++ b/test/sparse/domains/stridable.chpl
@@ -1,0 +1,15 @@
+config const n = 10;
+
+const D = {1..n};
+const D2 = D by 2;
+
+const SD: sparse subdomain(D);
+const SD2: sparse subdomain(D2);
+
+if SD.stridable then
+  compilerError("SD should not be stridable");
+
+if !SD2.stridable then
+  compilerError("SD2 should be stridable");
+
+writeln((SD.stridable, SD2.stridable));

--- a/test/sparse/domains/stridable.chpl
+++ b/test/sparse/domains/stridable.chpl
@@ -1,3 +1,5 @@
+use BlockDist, LayoutCS;
+
 config const n = 10;
 
 const D = {1..n};
@@ -6,10 +8,21 @@ const D2 = D by 2;
 const SD: sparse subdomain(D);
 const SD2: sparse subdomain(D2);
 
+const BD = D dmapped Block({1..n});
+const BSD: sparse subdomain(BD);
+
+const SDCS: sparse subdomain({1..n, 1..n by 2}) dmapped CS();
+
 if SD.stridable then
   compilerError("SD should not be stridable");
 
 if !SD2.stridable then
   compilerError("SD2 should be stridable");
 
-writeln((SD.stridable, SD2.stridable));
+if !SDCS.stridable then
+  compilerError("SD2CS should be stridable");
+
+if BSD.stridable then
+  compilerError("BSD should not be stridable");
+
+writeln((SD.stridable, SD2.stridable, SDCS.stridable, BSD.stridable));

--- a/test/sparse/domains/stridable.good
+++ b/test/sparse/domains/stridable.good
@@ -1,0 +1,1 @@
+(false, true)

--- a/test/sparse/domains/stridable.good
+++ b/test/sparse/domains/stridable.good
@@ -1,1 +1,1 @@
-(false, true)
+(false, true, true, false)

--- a/test/sparse/domains/stridableOfStridable.chpl
+++ b/test/sparse/domains/stridableOfStridable.chpl
@@ -1,0 +1,27 @@
+use BlockDist, LayoutCS;
+
+config const n = 10;
+
+const D = {1..n};
+const D2 = D by 2;
+
+const SD2: sparse subdomain(D2);
+const SD22: sparse subdomain(SD2);
+
+const BD = D2 dmapped Block({1..n});
+const BSD: sparse subdomain(BD);
+const BSD2: sparse subdomain(BSD);
+
+if !SD2.stridable then
+  compilerError("SD2 should be stridable");
+
+if !SD22.stridable then
+  compilerError("SD22 should be stridable");
+
+if !BSD.stridable then
+  compilerError("BSD should be stridable");
+
+if !BSD2.stridable then
+  compilerError("BSD2 should be stridable");
+
+writeln((SD2.stridable, SD22.stridable, BSD.stridable, BSD2.stridable));

--- a/test/sparse/domains/stridableOfStridable.good
+++ b/test/sparse/domains/stridableOfStridable.good
@@ -1,0 +1,1 @@
+(true, true, true, true)


### PR DESCRIPTION
While investigating support for slicing of sparse domains/arrays in support of issue #8023, the first thing I ran into was the lack of support for querying the stridability of sparse domains.  This change adds the ability for sparse domains to support a `stridable` query that is implemented by forwarding the query on to their parent domains.  It also adds tests to make sure this works with our three main sparse domain maps today, and that it works when creating sparse domains of other sparse domains.