### PR TITLE
Fix a typo in an error message in IO.open()

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1663,7 +1663,7 @@ proc open(out error:syserr, path:string="", mode:iomode, hints:iohints=IOHINT_NO
     }
   } else {
     if (path == "") then
-      try! ioerror(ENOENT:syserr, "in open: Both path and url were path");
+      try! ioerror(ENOENT:syserr, "in open: Both path and url were blank");
     /* TODO: The above two lines breaks the function's original invariant of not
        generating errors within itself.  It is better style to remove these
        lines.  Doing so should still work, but we can't be certain until we


### PR DESCRIPTION
The error was:
"in open: Both path and url were path"

Updated it to:
"in open: Both path and url were blank"