### PR TITLE
Convert channel type from constructors to initializers

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1945,16 +1945,6 @@ record channel {
   var _readWriteThisFromLocale:locale;
 }
 
-// TODO -- shouldn't have to write this this way!
-pragma "no doc"
-pragma "init copy fn"
-proc chpl__initCopy(x: channel) {
-  on x.home {
-    qio_channel_retain(x._channel_internal);
-  }
-  return x;
-}
-
 pragma "no doc"
 proc =(ref ret:channel, x:channel) {
   // retain -- release
@@ -1971,7 +1961,19 @@ proc =(ref ret:channel, x:channel) {
 }
 
 pragma "no doc"
-proc channel.channel(param writing:bool, param kind:iokind, param locking:bool, f:file, out error:syserr, hints:c_int, start:int(64), end:int(64), in local_style:iostyle) {
+proc channel.init(param writing:bool, param kind:iokind, param locking:bool) {
+  this.writing = writing;
+  this.kind = kind;
+  this.locking = locking;
+  super.init();
+}
+
+pragma "no doc"
+proc channel.init(param writing:bool, param kind:iokind, param locking:bool, f:file, out error:syserr, hints:c_int, start:int(64), end:int(64), in local_style:iostyle) {
+  this.writing = writing;
+  this.kind = kind;
+  this.locking = locking;
+  super.init();
   on f.home {
     this.home = f.home;
     if kind != iokind.dynamic {

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1968,8 +1968,29 @@ proc channel.init(param writing:bool, param kind:iokind, param locking:bool) {
   super.init();
 }
 
+//
+// Note that this is effectively the initializer that the compiler
+// would typically provide and that, by providing the next initializer
+// below, we have to write it out manually...  A good case for having
+// a means to "opt-in" to including the compiler-provided initializer?
+//
+pragma "no doc"
+proc channel.init(param writing:bool, param kind:iokind, param locking:bool,
+                  home: locale, _channel_internal:qio_channel_ptr_t,
+                  _readWriteThisFromLocale: locale) {
+  this.writing = writing;
+  this.kind = kind;
+  this.locking = locking;
+  this.home = home;
+  this._channel_internal = _channel_internal;
+  this._readWriteThisFromLocale = _readWriteThisFromLocale;
+  super.init();
+}
+
 pragma "no doc"
 proc channel.init(param writing:bool, param kind:iokind, param locking:bool, f:file, out error:syserr, hints:c_int, start:int(64), end:int(64), in local_style:iostyle) {
+  // Note that once issue #7960 is resolved, the following could become a
+  // call to this.init(writing, kind, locking)...
   this.writing = writing;
   this.kind = kind;
   this.locking = locking;

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1968,6 +1968,20 @@ proc channel.init(param writing:bool, param kind:iokind, param locking:bool) {
   super.init();
 }
 
+pragma "no doc"
+proc channel.init(x: channel) {
+  this.writing = x.writing;
+  this.kind = x.kind;
+  this.locking = x.locking;
+  this.home = x.home;
+  this._channel_internal = x._channel_internal;
+  _readWriteThisFromLocale = x._readWriteThisFromLocale;
+  super.init();
+  on x.home {
+    qio_channel_retain(x._channel_internal);
+  }
+}
+
 //
 // Note that this is effectively the initializer that the compiler
 // would typically provide and that, by providing the next initializer


### PR DESCRIPTION
Converting the channel type to use initializers was a bit tricky in that they required:

* a translation of the old constructor to an initializer
* a types/params-only overload due to the way we declare channels in type signatures
* a copy initializer, where the implicit one created by the compiler caused segfaults and so could not be used
* a manual transcription of the default initializer that the compiler would normally make since the other initializers overrode it (a good motivator for the "opt-in to exposing the compiler initializer" feature that's been discussed)
  
In the code review, @mppf pointed out that some of the initializers are not intended to be end-user facing such that, if/when we had private methods (in the sense of "private to this module"), they could be tagged as such.  He also pointed out that even if we had a way of opting into making the compiler-provided initializer available, he may not want to make use of it stylistically, in order to make it abundantly clear that that initializer does nothing w.r.t. ownership.  I mentioned this in issue #8136.