### PR TITLE
Convert Random to use initializers

### DIFF
--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -556,7 +556,7 @@ module Random {
 
 
       /*
-        Constructs a new stream of random numbers using the specified seed
+        Creates a new stream of random numbers using the specified seed
         and parallel safety.
 
         :arg eltType: The element type to be generated.
@@ -571,10 +571,14 @@ module Random {
         :type parSafe: `bool`
 
       */
-      proc RandomStream(type eltType,
-                        seed: int(64) = SeedGenerator.currentTime,
-                        param parSafe: bool = true) {
+      proc init(type eltType,
+                seed: int(64) = SeedGenerator.currentTime,
+                param parSafe: bool = true) {
+        this.eltType = eltType;
         this.seed = seed;
+        // TODO: This can't be right:
+        //        this.parSafe = parSafe;
+        super.init();
         for param i in 1..numGenerators(eltType) {
           param inc = pcg_getvalid_inc(i);
           PCGRandomStreamPrivate_rngs[i].srandom(seed:uint(64), inc);
@@ -2032,7 +2036,7 @@ module Random {
 
 
       /*
-        Constructs a new stream of random numbers using the specified seed
+        Creates a new stream of random numbers using the specified seed
         and parallel safety.
 
         .. note::
@@ -2052,9 +2056,10 @@ module Random {
         :type parSafe: `bool`
 
       */
-      proc NPBRandomStream(type eltType,
-                           seed: int(64) = SeedGenerator.oddCurrentTime,
-                           param parSafe: bool = true) {
+      proc init(type eltType,
+                seed: int(64) = SeedGenerator.oddCurrentTime,
+                param parSafe: bool = true) {
+        this.eltType = eltType;
 
         // The mod operation is written in these steps in order
         // to work around an apparent PGI compiler bug.
@@ -2069,6 +2074,9 @@ module Random {
         // Adjust seed to be between 0 and 2**46.
         mod = useed & two_46_mask;
         this.seed = mod:int(64);
+        // TODO: This can't be right:
+        //        this.parSafe = parSafe;
+        super.init();
 
         if this.seed % 2 == 0 || this.seed < 1 || this.seed > two_46:int(64) then
           halt("NPBRandomStream seed must be an odd integer between 0 and 2**46");

--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -540,6 +540,11 @@ module Random {
       type eltType;
 
       /*
+        The seed value for the PRNG.
+      */
+      const seed: int(64);
+
+      /*
         Indicates whether or not the PCGRandomStream needs to be
         parallel-safe by default.  If multiple tasks interact with it in
         an uncoordinated fashion, this must be set to `true`.  If it will
@@ -548,12 +553,6 @@ module Random {
         to ensuring mutual exclusion.
       */
       param parSafe: bool = true;
-
-      /*
-        The seed value for the PRNG.
-      */
-      const seed: int(64);
-
 
       /*
         Creates a new stream of random numbers using the specified seed
@@ -576,8 +575,7 @@ module Random {
                 param parSafe: bool = true) {
         this.eltType = eltType;
         this.seed = seed;
-        // TODO: This can't be right:
-        //        this.parSafe = parSafe;
+        this.parSafe = parSafe;
         super.init();
         for param i in 1..numGenerators(eltType) {
           param inc = pcg_getvalid_inc(i);
@@ -2019,6 +2017,12 @@ module Random {
       type eltType = real(64);
 
       /*
+        The seed value for the PRNG.  It must be an odd integer in the
+        interval [1, 2**46).
+      */
+      const seed: int(64);
+
+      /*
         Indicates whether or not the NPBRandomStream needs to be
         parallel-safe by default.  If multiple tasks interact with it in
         an uncoordinated fashion, this must be set to `true`.  If it will
@@ -2027,12 +2031,6 @@ module Random {
         to ensuring mutual exclusion.
       */
       param parSafe: bool = true;
-
-      /*
-        The seed value for the PRNG.  It must be an odd integer in the
-        interval [1, 2**46).
-      */
-      const seed: int(64);
 
 
       /*
@@ -2056,7 +2054,7 @@ module Random {
         :type parSafe: `bool`
 
       */
-      proc init(type eltType,
+      proc init(type eltType = real(64),
                 seed: int(64) = SeedGenerator.oddCurrentTime,
                 param parSafe: bool = true) {
         this.eltType = eltType;
@@ -2074,8 +2072,7 @@ module Random {
         // Adjust seed to be between 0 and 2**46.
         mod = useed & two_46_mask;
         this.seed = mod:int(64);
-        // TODO: This can't be right:
-        //        this.parSafe = parSafe;
+        this.parSafe = parSafe;
         super.init();
 
         if this.seed % 2 == 0 || this.seed < 1 || this.seed > two_46:int(64) then


### PR DESCRIPTION
This converts the Random module to use initializers.  In doing this, I reordered the fields
to match the initializer argument order because I initially ran into problems by trying to
initialize fields in argument order rather than field order which the compiler doesn't like
(and I think the field order isn't terribly important and reflects the old / deprecated
constructor argument ordering).

Other than that, this was a fairly trivial translation.