### PR TITLE
Filter out gmake "clock skew detected" warnings from chpl tests and "make check"

### DIFF
--- a/util/test/checkChplInstall
+++ b/util/test/checkChplInstall
@@ -179,7 +179,7 @@ fi
 
     # no errors on stdout/stderr?
     # first, apply "prediff"-like filter to remove gmake "clock skew detected" warnings, if any
-TEST_COMP_OUT=$( grep < ${TMP_TEST_DIR}/chpl.out -Ev '^g?make(|\[[0-9]+\]): *[Ww]arning: *(File .* has modification time .* in the future|Clock skew detected\. *Your build may be incomplete\.) *$' 2>&1 )
+TEST_COMP_OUT=$( grep < ${TMP_TEST_DIR}/chpl.out -Ev '^g?make(\[[0-9]+\])?: *[Ww]arning: *(File .* has modification time .* in the future|Clock skew detected\. *Your build may be incomplete\.) *$' 2>&1 )
 
 if [ -n "${TEST_COMP_OUT}" ]; then
     log_error "Test job compiled with output - Chapel is not installed correctly"

--- a/util/test/checkChplInstall
+++ b/util/test/checkChplInstall
@@ -162,19 +162,26 @@ COMP_FLAGS="--cc-warnings"
 
 # Compile test job into temporary directory
 log_info "Compiling \$CHPL_HOME/${REL_TEST_DIR}/${TEST_JOB}.chpl"
-TEST_COMP_OUT=$( ${CHPL_BIN} ${TEST_DIR}/${TEST_JOB}.chpl ${COMP_FLAGS} -o ${TMP_TEST_DIR}/${TEST_JOB} 2>&1 )
+${CHPL_BIN} ${TEST_DIR}/${TEST_JOB}.chpl ${COMP_FLAGS} -o ${TMP_TEST_DIR}/${TEST_JOB} > ${TMP_TEST_DIR}/chpl.out 2>&1
 COMPILE_STATUS=$?
 
-# Check that compile was successful
+# Check that chpl compile was successful
 log_debug "Compilation exit status was ${COMPILE_STATUS}"
 
+    # exit status 0?
 if [ ${COMPILE_STATUS} -ne 0 ]; then
     log_error "Test job failed to compile - Chapel is not installed correctly"
     log_error "Compilation output:"
-    echo "${TEST_COMP_OUT}"
+    cat ${TMP_TEST_DIR}/chpl.out
     log_debug "Exit \"make check\" script with status code 1"
     exit 1
-elif [ -n "${TEST_COMP_OUT}" ]; then
+fi
+
+    # no errors on stdout/stderr?
+    # first, apply "prediff"-like filter to remove gmake "clock skew detected" warnings, if any
+TEST_COMP_OUT=$( grep < ${TMP_TEST_DIR}/chpl.out -Ev '^g?make(|\[[0-9]+\]): *[Ww]arning: *(File .* has modification time .* in the future|Clock skew detected\. *Your build may be incomplete\.) *$' 2>&1 )
+
+if [ -n "${TEST_COMP_OUT}" ]; then
     log_error "Test job compiled with output - Chapel is not installed correctly"
     log_error "Compilation output:"
     echo "${TEST_COMP_OUT}"

--- a/util/test/prediff-for-gmake-clock-skew-warning
+++ b/util/test/prediff-for-gmake-clock-skew-warning
@@ -1,12 +1,24 @@
 #!/bin/sh
 
-# When remote-mounted NFS file system is used as a workspace for chapel testing,
-# it is not unusual to see lines like these in the chpl compiler output:
+# This script is for the use with 'start_test' as the system-wide prediff, when
+# network time-sync problems (or similar) cause file modification times to look
+# wrong to gmake.
+
+# This typically occurs when a remote-mounted NFS file system is used as a workspace.
+# It has also been observed less frequently on VMs, even when using a local vdisk.
+
+# In either case, it is not unusual to see lines like these in chpl compiler output:
 #
 # gmake: Warning: File `.../something' has modification time 0.01 s in the future
 # gmake: warning:  Clock skew detected.  Your build may be incomplete.
 
-# This removes such lines.
+# This prediff file removes such lines, so that they will not generate false test
+# errors in start_test.
+
+# To use this prediff file with start_test (assuming bash):
+#
+# export CHPL_SYSTEM_PREDIFF=$CHPL_HOME/util/test/prediff-for-gmake-clock-skew-warning
+# start_test ...
 
 outfile=$2
 temp=$outfile.temp

--- a/util/test/prediff-for-gmake-clock-skew-warning
+++ b/util/test/prediff-for-gmake-clock-skew-warning
@@ -23,6 +23,6 @@
 outfile=$2
 temp=$outfile.temp
 
-grep < $outfile > $temp -Ev '^g?make(|\[[0-9]+\]): *[Ww]arning: *(File .* has modification time .* in the future|Clock skew detected\. *Your build may be incomplete\.) *$'
+grep < $outfile > $temp -Ev '^g?make(\[[0-9]+\])?: *[Ww]arning: *(File .* has modification time .* in the future|Clock skew detected\. *Your build may be incomplete\.) *$'
 
 mv $temp $outfile

--- a/util/test/prediff-for-gmake-clock-skew-warning
+++ b/util/test/prediff-for-gmake-clock-skew-warning
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# When remote-mounted NFS file system is used as a workspace for chapel testing,
+# it is not unusual to see lines like these in the chpl compiler output:
+#
+# gmake: Warning: File `.../something' has modification time 0.01 s in the future
+# gmake: warning:  Clock skew detected.  Your build may be incomplete.
+
+# This removes such lines.
+
+outfile=$2
+temp=$outfile.temp
+
+grep < $outfile > $temp -Ev '^g?make(|\[[0-9]+\]): *[Ww]arning: *(File .* has modification time .* in the future|Clock skew detected\. *Your build may be incomplete\.) *$'
+
+mv $temp $outfile


### PR DESCRIPTION
This is to quiet Chapel test errors caused by gmake warnings like this
in the Chapel test output (the chpl compile output, actually):
    
      gmake: Warning: File `foo/bar.o' has modification time 0.01 s in the future
      gmake: warning:  Clock skew detected.  Your build may be incomplete.
    
These warning msgs typically happen when CHPL_HOME or TMPDIR is located on
a remote-mounted NFS file system. They are nothing to worry about- at least,
not from the chpl compiler. However, they will cause the test output to
differ from the "good"- unless filtered out