### PR TITLE
Fix the multi-locale no-op graph

### DIFF
--- a/test/performance/elliot/no-op.ml-time.graph
+++ b/test/performance/elliot/no-op.ml-time.graph
@@ -1,4 +1,5 @@
 perfkeys: real
 graphkeys: startup time
+files: no-op.dat
 graphtitle: no-op (non-user code startup time)
 ylabel: Time (seconds)


### PR DESCRIPTION
I forgot to add the .dat file name in #8123 (I just copied the single-locale
.graph file, but forgot that the inferred .dat file name wouldn't work.)