### PR TITLE
Update Barriers module to use initializers

### DIFF
--- a/modules/standard/Barriers.chpl
+++ b/modules/standard/Barriers.chpl
@@ -78,9 +78,9 @@ module Barriers {
        :arg reusable: Incur some extra overhead to allow reuse of this barrier?
 
     */
-    proc Barrier(numTasks: int,
-                 barrierType: BarrierType = BarrierType.Atomic,
-                 reusable: bool = (barrierType == BarrierType.Atomic)) {
+    proc init(numTasks: int,
+              barrierType: BarrierType = BarrierType.Atomic,
+              reusable: bool = (barrierType == BarrierType.Atomic)) {
       select barrierType {
         when BarrierType.Atomic {
           if reusable {
@@ -101,6 +101,13 @@ module Barriers {
         }
       }
       owned = true;
+    }
+
+    /* copy initializer */
+    pragma "no doc"
+    proc init(b: Barrier) {
+      this.bar = b.bar;
+      this.owned = false;
     }
 
     pragma "no doc"
@@ -208,7 +215,9 @@ module Barriers {
 
        :arg n: The number of tasks involved in this barrier
      */
-    proc aBarrier(n: int, param reusable: bool) {
+    proc init(n: int, param reusable: bool) {
+      this.reusable = reusable;
+      super.init();
       reset(n);
     }
 
@@ -293,8 +302,9 @@ module Barriers {
 
        :arg n: The number of tasks that will be involved in the barrier.
      */
-    proc sBarrier(n: int) {
+    proc init(n: int) {
       count = n;
+      super.init();
     }
 
     proc reset(nTasks: int) {
@@ -352,14 +362,5 @@ module Barriers {
     lhs.owned = false;
   }
 
-  pragma "init copy fn"
-  pragma "no doc"
-  proc chpl__initCopy(b: Barrier) {
-    pragma "no auto destroy"
-    var ret: Barrier;
-    ret.bar = b.bar;
-    ret.owned = false;
-    return ret;
-  }
 }
 

--- a/modules/standard/Barriers.chpl
+++ b/modules/standard/Barriers.chpl
@@ -108,6 +108,7 @@ module Barriers {
     proc init(b: Barrier) {
       this.bar = b.bar;
       this.owned = false;
+      super.init();
     }
 
     pragma "no doc"


### PR DESCRIPTION
This converts the Barriers module over from constructors to initializers.
This was fairly straightforward.  Most interesting part was probably
changing the chpl__initCopy() into a copy initializer.