### PR TITLE
Improve extern shadow test

### DIFF
--- a/test/extern/tzakian/shadow.chpl
+++ b/test/extern/tzakian/shadow.chpl
@@ -1,10 +1,23 @@
-extern {
-#include "shadow.h"
+module ExternFoo {
+  extern {
+    #include "shadow.h"
+  }
+
+  writeln("In ExternFoo, foo(1) returns ", foo(1));
 }
 
-writeln(foo(1));
-proc foo(x) {
-  return x + 2;
+module LocalFoo {
+  proc foo(x:int):string {
+    return (x + 2):string;
+  }
+
+  writeln("In LocalFoo, foo(1) returns ", foo(1));
 }
 
-writeln(foo(1));
+module shadow {
+  use ExternFoo;
+  use LocalFoo;
+  proc main() {
+    writeln("With both visible, foo(1) returns ", foo(1));
+  }
+}

--- a/test/extern/tzakian/shadow.future
+++ b/test/extern/tzakian/shadow.future
@@ -1,9 +1,0 @@
-bug: Shadowed functions from extern #include causes error in generated header
-
-Right now this generates a compile time error by gcc. 
-We would like Chapel to check to see if there is any shadowing and 
-error out before it goes through all the work of compiling it to C.
-The errors are: 
-error: conflicting types for 'foo'
-error: previous declaration of 'foo' was here
-

--- a/test/extern/tzakian/shadow.good
+++ b/test/extern/tzakian/shadow.good
@@ -1,2 +1,3 @@
-error: ambiguous call 'foo(1)' [functionResolution.cpp:1815]
-
+In ExternFoo, foo(1) returns 2
+In LocalFoo, foo(1) returns 3
+With both visible, foo(1) returns 3


### PR DESCRIPTION
This future was not failing in the manner it used to.  This commit adds
to the test to make it clearer what is going on and make it no longer a
future.