### PR TITLE
Fix prediff-for-gmake-clock-skew-warning causes false errors in mandelbrot* tests

### DIFF
--- a/test/release/examples/benchmarks/shootout/mandelbrot-fast.preexec
+++ b/test/release/examples/benchmarks/shootout/mandelbrot-fast.preexec
@@ -1,0 +1,1 @@
+../../../../../util/test/prediff-for-gmake-clock-skew-warning

--- a/test/release/examples/benchmarks/shootout/mandelbrot.preexec
+++ b/test/release/examples/benchmarks/shootout/mandelbrot.preexec
@@ -1,0 +1,1 @@
+../../../../../util/test/prediff-for-gmake-clock-skew-warning

--- a/util/test/prediff-for-gmake-clock-skew-warning
+++ b/util/test/prediff-for-gmake-clock-skew-warning
@@ -23,6 +23,21 @@
 outfile=$2
 temp=$outfile.temp
 
+# check the outfile for null characters
+# if found, then outfile is binary, the grep filter will not work, so DO NOT run the filter
+
+  # tr removes null chars, if any
+LC_ALL=C tr -d '\000' < $outfile > $temp
+  # did the outfile contain any null chars?
+LC_ALL=C diff -q $outfile $temp
+if [ $? != 0 ]; then
+    # yes: the outfile is binary, do not run the filter
+    rm -f $temp
+    exit 0
+fi
+
+# filter out gmake "clock skew detected" warnings (if any) from the outfile, with grep
+
 grep < $outfile > $temp -Ev '^g?make(\[[0-9]+\])?: *[Ww]arning: *(File .* has modification time .* in the future|Clock skew detected\. *Your build may be incomplete\.) *$'
 
 mv $temp $outfile


### PR DESCRIPTION
The grep filter in prediff-for-gmake-clock-skew-warning does not work with
"binary" test output files, like mandelbrot*, causing false test errors to
be reported.
    
This change checks if the test output is "binary" before filtering, and if
so, the prediff just skips the filtering and returns normally without
doing anything.

This change symlinks the prediff-for-gmake-clock-skew-warning file to appear
as new files mandelbrot.preexec and mandelbrot-fast.preexec. That way, the
clock-skew-warning filter will run BEFORE the mandelbrot tests add their
"binary" output to the test output file.

Note: other chpl tests create binary output, but these mandelbrot tests are 
the only ones under release/examples.  We could create symlinks to "preexec" for
those tests as well, but they wouldn't make any difference until someone ran the
full test suite AND set CHPL_SYSTEM_PREDIFF=prediff-for-gmake-clock-skew-warning. 

The worst that could happen from NOT setting all the other possible preexec symlinks, is that these tests might throw some false errors someday. 
```
./test/exercises/c-ray/c-ray.4samples.chpl
./test/exercises/c-ray/c-ray.chpl
./test/exercises/c-ray/c-ray.sphfract.chpl
./test/exercises/c-ray/forStudents/c-ray.chpl
./test/exercises/Mandelbrot/mandelbrot-bmptest.chpl
./test/io/ferguson/writefbinary.chpl
./test/release/examples/benchmarks/shootout/mandelbrot-fast-alt.chpl
./test/release/examples/benchmarks/shootout/mandelbrot-fast-clbg.chpl
./test/release/examples/benchmarks/shootout/mandelbrot.chpl
./test/studies/shootout/mandelbrot/bharshbarg/mandelbrot-unrolled.chpl
./test/studies/shootout/mandelbrot/bradc/mandelbrot-blc.chpl
./test/studies/shootout/mandelbrot/ferguson/mandelbrot-opt2.chpl
./test/studies/shootout/mandelbrot/ferguson/mandelbrot-stdout-putchar.chpl
./test/studies/shootout/mandelbrot/ferguson/mandelbrot-stdout.chpl
./test/studies/shootout/mandelbrot/ferguson/mandelbrot-tricks.chpl
./test/studies/shootout/mandelbrot/ferguson/mandelbrot2-opt.chpl
./test/studies/shootout/mandelbrot/jacobnelson/mandelbrot-complex.chpl
./test/studies/shootout/mandelbrot/jacobnelson/mandelbrot-dist.chpl
./test/studies/shootout/mandelbrot/jacobnelson/mandelbrot-fancy.chpl
./test/studies/shootout/mandelbrot/lydia/mandelbrot-no-dist.chpl
./test/studies/shootout/mandelbrot/lydia/mandelbrot-unzipped.chpl
./test/studies/shootout/mandelbrot/perfComp/mandelbrot-MAXLOGICAL.chpl
./test/studies/shootout/submitted/mandelbrot.chpl
./test/studies/shootout/submitted/mandelbrot2.chpl
```