### PR TITLE
Improve handling of initializers in 'inferConstRefs'

### DIFF
--- a/compiler/optimizations/inferConstRefs.cpp
+++ b/compiler/optimizations/inferConstRefs.cpp
@@ -493,6 +493,46 @@ static bool onlyUsedForRetarg(Symbol* ref, CallExpr* defCall) {
   return isRetArgOnly;
 }
 
+//
+// Returns true if 'ref' is only used in the following two cases:
+//   1) Used in 'defCall', usually a PRIM_ADDR_OF or PRIM_SET_REFERENCE
+//
+//   2) Passed to an initializer in the 'this' slot.
+//
+// An initializer can thwart detection of a 'const' thing because it takes the
+// "this" argument by ref. Normally such a pattern would cause us to assume
+// the variable was not const, but in this case we know it is a single def.
+//
+static bool onlyUsedForInitializer(Symbol* ref, CallExpr* defCall) {
+  bool isInitOnly = true;
+
+  INT_ASSERT(ref->isRef());
+  INT_ASSERT(defCall != NULL);
+
+  for_SymbolSymExprs(use, ref) {
+    if (use->parentExpr == defCall) {
+      continue;
+    }
+
+    CallExpr* call = toCallExpr(use->parentExpr);
+    if (call->isResolved()) {
+      FnSymbol*  fn         = call->resolvedFunction();
+      ArgSymbol* form       = actual_to_formal(use);
+      bool       isInitFn   = strcmp(fn->cname, "init") == 0 &&
+                              fn->isMethod() &&
+                              form->hasFlag(FLAG_ARG_THIS);
+
+      if (isInitFn == false) {
+        isInitOnly = false;
+      }
+    } else {
+      isInitOnly = false;
+    }
+  }
+
+  return isInitOnly;
+}
+
 // Note: This function is currently not recursive
 static bool inferConst(Symbol* sym) {
   INT_ASSERT(!sym->isRef());
@@ -548,8 +588,9 @@ static bool inferConst(Symbol* sym) {
 
         if (onlyUsedForRetarg(LHS, parent)) {
           numDefs += 1;
-        }
-        else if (!inferConstRef(LHS)) {
+        } else if (onlyUsedForInitializer(LHS, parent)) {
+          numDefs += 1;
+        } else if (!inferConstRef(LHS)) {
           isConstVal = false;
         }
       }


### PR DESCRIPTION
This commit updates the 'inferConstRefs' mini-pass to identify
initializers as a single 'def' of a variable, similar to the
pre-existing handling of retArgs. This allows more things to be inferred
to be const, which helps with RVF.

Testing:
- [x] local
- [x] no-local
- [x] gasnet