### PR TITLE
Unify AggregateType::getFieldPosition behavior with the getField method

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -662,7 +662,7 @@ int AggregateType::getFieldPosition(const char* name, bool fatal) {
 
   current_p->set_add(this);
 
-  int fieldPos = 0;
+  int fieldPos = 1;
 
   while (current_p->n != 0) {
     forv_Vec(Type, t, *current_p) {


### PR DESCRIPTION
getFieldPosition returns the field of an AggregateType using 0-based indexing.
However, the getField method relies on 1-based indexing.  We don't use the
former at all in the compiler, but I wanted to use it for my initializers
implementation and it would be useful to have those methods use the same
indexing, even though the functionality of
`getField(getFieldPosition("foo", false)` is already handled by
`getField("foo", false)` (my use involves getting a starting index for a field,
and then traversing from there)