### PR TITLE
gmake clock skew warning filter is a global preexec, not a global prediff

### DIFF
--- a/util/test/preexec-for-gmake-clock-skew-warning
+++ b/util/test/preexec-for-gmake-clock-skew-warning
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# This script is for the use with 'start_test' as the system-wide prediff, when
+# This script is for the use with 'start_test' as the system-wide preexec, when
 # network time-sync problems (or similar) cause file modification times to look
 # wrong to gmake.
 
@@ -12,12 +12,12 @@
 # gmake: Warning: File `.../something' has modification time 0.01 s in the future
 # gmake: warning:  Clock skew detected.  Your build may be incomplete.
 
-# This prediff file removes such lines, so that they will not generate false test
+# This preexec file removes such lines, so that they will not generate false test
 # errors in start_test.
 
-# To use this prediff file with start_test (assuming bash):
+# To use this preexec file with start_test (assuming bash):
 #
-# export CHPL_SYSTEM_PREDIFF=$CHPL_HOME/util/test/prediff-for-gmake-clock-skew-warning
+# export CHPL_SYSTEM_PREEXEC=$CHPL_HOME/util/test/preexec-for-gmake-clock-skew-warning
 # start_test ...
 
 outfile=$2


### PR DESCRIPTION
Replaces PR #8148. 
This simply uses the gmake-clock-skew-warning filter as a preexec every time, without trying to make exceptions for binary test data. In PR #8128 and #8148, it was trying to be used as a prediff, where it caused trouble with binary test output data (mandelbrot) and any other test outputs that lack a trailing newline. 
Best of all, the CHPL_SYSTEM_PREEXEC handler was already implemented in start_test/sub_test. 