### PR TITLE
Convert MatrixMarket package from constructors to initializers

### DIFF
--- a/modules/packages/MatrixMarket.chpl
+++ b/modules/packages/MatrixMarket.chpl
@@ -92,10 +92,12 @@ module MatrixMarket {
       var headers_written:bool;
       var last_rowno:int;
 
-      proc MMWriter(type eltype, const fname:string) {
+      proc init(type eltype, const fname:string) {
+         this.eltype = eltype;
          fd = open(fname, iomode.cw, iokind.native);
          fout = fd.writer(start=0);
          headers_written=false;
+         super.init();
       }
 
       proc write_headers(nrows, ncols, nnz=-1) {
@@ -194,9 +196,10 @@ class MMReader {
    var fin:channel(false, iokind.dynamic, true);
    var finfo:MMInfo;
 
-   proc MMReader(const fname:string) {
+   proc init(const fname:string) {
       fd = open(fname, iomode.r, hints=IOHINT_SEQUENTIAL|IOHINT_CACHED);
       fin = fd.reader(start=0, hints=IOHINT_SEQUENTIAL|IOHINT_CACHED);
+      super.init();
    }
 
    proc read_header() {


### PR DESCRIPTION
This was a completely straightforward case of making constructors into initializers.
