### PR TITLE
Skip this test on 32-bit platforms

### DIFF
--- a/test/studies/shootout/mandelbrot/ferguson/mandelbrot-tricks.skipif
+++ b/test/studies/shootout/mandelbrot/ferguson/mandelbrot-tricks.skipif
@@ -1,0 +1,2 @@
+# Image is slightly different on a 32-bit platform.
+CHPL_TARGET_PLATFORM <= 32


### PR DESCRIPTION
The image output is slightly different on a 32-bit platform. I believe this is due to the fewer number of iterations used.
  