### PR TITLE
Convert Futures module over to using initializers

### DIFF
--- a/modules/packages/ExplicitRefCount.chpl
+++ b/modules/packages/ExplicitRefCount.chpl
@@ -20,6 +20,7 @@
 module ExplicitRefCount {
 
   pragma "no doc"
+  pragma "use default init"
   class RefCountBase {
 
     var refcnt: atomic int;

--- a/modules/packages/Futures.chpl
+++ b/modules/packages/Futures.chpl
@@ -116,7 +116,9 @@ module Futures {
     var value: retType;
     var state: atomic bool;
 
-    proc FutureClass(type retType) {
+    proc init(type retType) {
+      this.retType = retType;
+      super.init();
       refcnt.write(0);
       state.clear();
     }
@@ -142,7 +144,9 @@ module Futures {
     var classRef: FutureClass(retType) = nil;
 
     pragma "no doc"
-    proc Future(type retType) {
+    proc init(type retType) {
+      this.retType = retType;
+      super.init();
       acquire(new FutureClass(retType));
     }
 


### PR DESCRIPTION
This converts the Futures module from using constructors to using initializers.  This
was a very straightforward case.