### PR TITLE
Fix high precision timer launcher issue

### DIFF
--- a/util/test/computePerfStats
+++ b/util/test/computePerfStats
@@ -267,11 +267,13 @@ def cleanup():
     print("output was: ")
     # if test output was too long, only print first and last 1000 characters
     if len(test_output_raw) > 2000: 
+        print("(first 1000 followed by last 1000)")
         head = test_output_raw[:1000].strip()
         tail = test_output_raw[-1000:].strip()
         head = ''.join(x if x in string.printable else "~" for x in head)
         tail = ''.join(x if x in string.printable else "~" for x in tail)
         print(head)
+        print(" <truncated> ")
         print(tail)
     else:
         out = test_output_raw.strip()

--- a/util/test/timers/defaultTimer
+++ b/util/test/timers/defaultTimer
@@ -3,4 +3,4 @@
 # simple low precision timer that is just a wrapper for calling time -p on a
 # program. Precision is limited to the precision of time -p
 
-time -p $@
+{ time -p $@ ; } 2>&1

--- a/util/test/timers/highPrecisionTimer
+++ b/util/test/timers/highPrecisionTimer
@@ -13,5 +13,5 @@ if __name__ == '__main__':
     except KeyboardInterrupt:
         pass
     end_time = timer()
-    sys.stderr.write("real {0:0.4}\n\n\n".format(end_time - start_time))
+    sys.stdout.write("real {0:0.4}\n\n\n".format(end_time - start_time))
     sys.exit(return_code)


### PR DESCRIPTION
### util/test/timers/highPrecisionTimer

Output time information to stdout not stderr

Otherwise we see sporadic failures with
  studies/shootout/fasta/kbrady/fasta-printf
in a configuration with a launcher.

Adding a sys.stdout.flush() beforehand didn't solve the problem either.
I suspect that there's a launcher or other multi-node software in the way
of the flush strategy working.

I think it's reasonable to always output the time on stdout because if a
perf test is outputting anything to stderr it's probably failing.

### util/test/computePerfStats

Make it clearer in the failure message that output is truncated 



### Review & Testing:

Reviewed by @daviditen and @ronawho - thanks!

- [x] 10 trials with highPrecisionTimer in the test/configuration that failed last night
- [x] 10 trials with defaultTimer in the test/configuration that failed last night
- [x] 100 trials with highPrecisionTimer in the test/configuration that failed last night
- [x] checked performance testing on test/studies/shootout