### PR TITLE
Allow :integral to work in where clauses

### DIFF
--- a/compiler/resolution/postFold.cpp
+++ b/compiler/resolution/postFold.cpp
@@ -464,6 +464,11 @@ static bool isSubTypeOrInstantiation(Type* sub, Type* super) {
   if (sub == super) {
     retval = true;
 
+  } else if (canInstantiate(sub, super)) {
+    // handles special cases like dtIntegral, which aren't covered
+    // by at->instantiatedFrom
+    retval = true;
+
   } else if (AggregateType* at = toAggregateType(sub)) {
     for (int i = 0; i < at->dispatchParents.n && retval == false; i++) {
       retval = isSubTypeOrInstantiation(at->dispatchParents.v[i], super);

--- a/test/functions/ferguson/where-subtype-dispatch.chpl
+++ b/test/functions/ferguson/where-subtype-dispatch.chpl
@@ -1,0 +1,102 @@
+
+
+proc foo(x) where x:integral {
+  writeln("integral");
+}
+proc foo(x) {
+  writeln("any type");
+}
+
+writeln("foo");
+var i8:int(8) = 1;
+foo(i8);
+writeln();
+
+record R {
+  var x;
+}
+
+class Parent {
+  var a:int;
+}
+
+class Child : Parent {
+  var b:int;
+}
+
+class MyClass {
+  var c:int;
+}
+
+class GenericParent {
+  var y;
+}
+
+class GenericChild : GenericParent {
+  var z:int;
+}
+
+proc bar(type t) where t:int {
+  writeln("int");
+}
+proc bar(type t) where (t:integral && !t:int) {
+  writeln("integral");
+}
+proc bar(type t) where !(t:int || t:integral || t:R || t:Parent ||
+                         t:GenericParent || t:object) {
+  writeln("any type");
+}
+proc bar(type t) where t:R {
+  writeln("R");
+}
+proc bar(type t) where t:Parent {
+  writeln("Parent");
+}
+proc bar(type t) where t:GenericParent {
+  writeln("GenericParent");
+}
+proc bar(type t) where (t:object && !t:Parent && !t:GenericParent) {
+  writeln("object");
+}
+
+writeln("bar");
+bar(int);
+bar(int(8));
+bar(real);
+bar(R(complex));
+bar(Parent);
+bar(Child);
+bar(MyClass);
+bar(GenericParent(int));
+bar(GenericChild(int));
+writeln();
+
+proc test1() where GenericParent(int):GenericChild { writeln("BAD"); }
+proc test1() { writeln("test1"); }
+proc test2() where GenericChild(real):GenericParent { writeln("test2"); }
+proc test2() { writeln("BAD"); }
+proc test3() where GenericChild(int):GenericParent { writeln("test3"); }
+proc test3() { writeln("BAD"); }
+proc test4() where GenericChild(int):GenericParent(int) { writeln("test4"); }
+proc test4() { writeln("BAD"); }
+proc test5() where GenericChild(real):GenericParent(int) { writeln("BAD"); }
+proc test5() { writeln("test5"); }
+proc test6() where GenericChild(int(8)):GenericParent(int) { writeln("BAD"); }
+proc test6() { writeln("test6"); }
+
+proc test7() where int:integral { writeln("test7"); }
+proc test7() { writeln("BAD"); }
+proc test8() where real:integral { writeln("BAD"); }
+proc test8() { writeln("test8"); }
+proc test9() where real:numeric { writeln("test9"); }
+proc test9() { writeln("BAD"); }
+
+test1();
+test2();
+test3();
+test4();
+test5();
+test6();
+test7();
+test8();
+test9();

--- a/test/functions/ferguson/where-subtype-dispatch.chpl
+++ b/test/functions/ferguson/where-subtype-dispatch.chpl
@@ -52,8 +52,11 @@ proc bar(type t) where t:R {
 proc bar(type t) where t:Parent {
   writeln("Parent");
 }
-proc bar(type t) where t:GenericParent {
+proc bar(type t) where (t:GenericParent && !t:GenericChild(int)) {
   writeln("GenericParent");
+}
+proc bar(type t) where t:GenericChild(int) {
+  writeln("GenericChild(int)");
 }
 proc bar(type t) where (t:object && !t:Parent && !t:GenericParent) {
   writeln("object");
@@ -69,6 +72,7 @@ bar(Child);
 bar(MyClass);
 bar(GenericParent(int));
 bar(GenericChild(int));
+bar(GenericChild(real));
 writeln();
 
 proc test1() where GenericParent(int):GenericChild { writeln("BAD"); }

--- a/test/functions/ferguson/where-subtype-dispatch.good
+++ b/test/functions/ferguson/where-subtype-dispatch.good
@@ -1,0 +1,23 @@
+foo
+integral
+
+bar
+int
+integral
+any type
+R
+Parent
+Parent
+object
+GenericParent
+GenericParent
+
+test1
+test2
+test3
+test4
+test5
+test6
+test7
+test8
+test9

--- a/test/functions/ferguson/where-subtype-dispatch.good
+++ b/test/functions/ferguson/where-subtype-dispatch.good
@@ -10,6 +10,7 @@ Parent
 Parent
 object
 GenericParent
+GenericChild(int)
 GenericParent
 
 test1

--- a/test/functions/lydia/userDefinedDefaultFunction/redefine-string.future
+++ b/test/functions/lydia/userDefinedDefaultFunction/redefine-string.future
@@ -1,0 +1,4 @@
+bug: redefining _defaultOf for string causes compilation errors
+
+It seems likely that the root cause here is the current point-of-instantiation
+behavior.


### PR DESCRIPTION
I would expect the following program to print out "integral" but it does not before this PR:

``` chapel
proc foo(x) where x:integral {
  writeln("integral");
}
proc foo(x) {
  writeln("any type");
}

writeln("foo");
var i8:int(8) = 1;
bar(i8);
```

The compiler has special treatment for several numeric types in canInstantiate that needs to be used in the handling for a:b in a where clause, which is computed by the function
isSubTypeOrInstantiation. (For history, note that PR #3242 introduced isSubTypeOrInstantiation)

This PR simply adjusts isSubTypeOrInstantiation to call canInstantiate to handle these special cases.

Fixes #8172.

- [x] full local testing

Reviewed by @lydia-duncan - thanks!