### PR TITLE
Skip the new bigint tests from #8163 unless GMP is built

### DIFF
--- a/test/classes/initializers/records/reductionOverCreatedArray-arrayTemp.skipif
+++ b/test/classes/initializers/records/reductionOverCreatedArray-arrayTemp.skipif
@@ -1,0 +1,1 @@
+CHPL_GMP==none

--- a/test/classes/initializers/records/reductionOverCreatedArray-reductionTemp.skipif
+++ b/test/classes/initializers/records/reductionOverCreatedArray-reductionTemp.skipif
@@ -1,1 +1,2 @@
 CHPL_TEST_VGRND_EXE!=on
+CHPL_GMP == none

--- a/test/classes/initializers/records/reductionOverCreatedArray-reductionTemp2.skipif
+++ b/test/classes/initializers/records/reductionOverCreatedArray-reductionTemp2.skipif
@@ -1,1 +1,2 @@
 CHPL_TEST_VGRND_EXE!=on
+CHPL_GMP == none

--- a/test/classes/initializers/records/reductionOverCreatedArray-zero.skipif
+++ b/test/classes/initializers/records/reductionOverCreatedArray-zero.skipif
@@ -1,1 +1,2 @@
 CHPL_TEST_VGRND_EXE!=on
+CHPL_GMP == none


### PR DESCRIPTION
I limited the futures from #8163 to only run under valgrind, but
forgot that BigInteger relied on GMP.  This caused a failure in
pgi testing (where we can't/don't build GMP).  So, skip the case
that works and the futures when GMP == none.