### PR TITLE
Limit the amount of memory used for oversubscribedArrayAlloc under valgrind

### DIFF
--- a/test/runtime/configMatters/comm/oversubscribedArrayAlloc.execopts
+++ b/test/runtime/configMatters/comm/oversubscribedArrayAlloc.execopts
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+
+import os
+
+# Valgrind causes a program to "use a lot more memory", so limit mem fraction
+if os.getenv('CHPL_TEST_VGRND_EXE') == 'on':
+    print('--memFraction=100')


### PR DESCRIPTION
Valgrind can significantly increase the amount of memory used. This test
defaults to using 1/3 of available memory, which with valgrind's overhead
exhausts available mem. Using 1/5 seemed to work, but took a long time so I'm
dropping down to 1/100