### PR TITLE
retire future: record-deinit-throws

### DIFF
--- a/test/errhandling/nspark/record-deinit-throws.bad
+++ b/test/errhandling/nspark/record-deinit-throws.bad
@@ -1,7 +1,0 @@
-$CHPL_HOME/modules/internal/ChapelBase.chpl:1184: internal error: CAL1302 chpl version 1.16.0 pre-release (1ff89ab)
-
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
-and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
-please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
-

--- a/test/errhandling/nspark/record-deinit-throws.future
+++ b/test/errhandling/nspark/record-deinit-throws.future
@@ -1,2 +1,0 @@
-Error-handling WIP: This future should close when error handling supports
-throwing from the deinit() method of a generic function.

--- a/test/errhandling/nspark/record-deinit-throws.good
+++ b/test/errhandling/nspark/record-deinit-throws.good
@@ -1,1 +1,1 @@
-called oops()
+record-deinit-throws.chpl:12: error: deinit is not permitted to throw


### PR DESCRIPTION
@nspark provided a future where a record deinitializer was marked throws. Given the decision to ban deinit from throwing as of #8161, this future has been retired and modified.