### PR TITLE
Resolve destructor/deinit in resolveAutoCopyEtc

### DIFF
--- a/test/studies/parboil/BFS/bfs.chpl
+++ b/test/studies/parboil/BFS/bfs.chpl
@@ -12,8 +12,9 @@ enum Color {
   white, gray, black
 }
 
+use Deque;
+
 proc bfs(nodes: [] Node, edges: [] Edge, colors: [] Color, costs: [] int(32), source: int(32)) {
-  use Deque;
   var wavefront = new deque(int(32));
   wavefront.pushBack(source);
   colors[source] = Color.gray;


### PR DESCRIPTION
Previously, the Type::destructor field was only set in
resolveTypeConstructor, but this code path is not used for initializers.

I tried replacing the __primitive("call destructor") in ChapelBase with a
simple call to "deinit" but that causes errors (we don't want users to
call "deinit" directly).

I tried to replace PRIM_CALL_DESTRUCTOR with deinit within preFold, I get
errors that I believe have to do with point-of-instantiation rules and
'use Sort' within functions.

This commit adds the resolution of 'deinit' and setting of
Type::destructor to resolveAutoCopies - it is resolved just before
resolving chpl__autoDestroy. It leaves the old code in place since both
will only resolve and set the Type::destructor field if it's NULL.

This resolves a problem Brad was seeing where a version of Owned using
initializers would never call the deinit function. The chpl__autoDestroy
was being called, but the PRIM_CALL_DESTRUCTOR within it was just being
removed in callDestructors, since the Type::destructor field was NULL.

Note, this PR adds a workaround to  test/studies/parboil/BFS/bfs.chpl
for a similar issue to the localUseNoCopy.chpl future added in PR #8141.

- [x] full local testing

Reviewed by @noakesmichael - thanks!