### PR TITLE
Update TestSystem.rst

### DIFF
--- a/doc/rst/developer/bestPractices/TestSystem.rst
+++ b/doc/rst/developer/bestPractices/TestSystem.rst
@@ -110,7 +110,7 @@ The test system can be exercised by invoking:
 This is assuming ``$CHPL_HOME/util/`` is in the user's `$PATH`, which is
 taken care of when sourcing ``$CHPL_HOME/util/setchplenv.bash``.
 
-This will cause the compiler to compile hi.chpl then execute the
+This will cause the compiler to compile hi.chpl then start_test execute the
 resulting binary.  The concatenation of the compiler and executable
 output will then be compared against the ``.good`` file.  A transcript of
 the test system's actions is printed to the console and also stored in


### PR DESCRIPTION
In the documentation [Create a simple test](https://github.com/chapel-lang/chapel/blob/master/doc/rst/developer/bestPractices/TestSystem.rst#creating-a-simple-test) , there is a line **This will cause the compiler to compile hi.chpl then execute the resulting binary** which indicates that **compiler** execute the binary but actually **start_does** execute that . So , in this PR it has been updated .
@lydia-duncan Kindly review this and suggest the modification needed