### PR TITLE
Fix default arguments for init

### DIFF
--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -476,10 +476,13 @@ static DefaultExprFnEntry buildDefaultedActualFn(FnSymbol*  fn,
 
   SymbolMap copyMap;
 
+  bool isConstructorOrInit = fn->hasFlag(FLAG_CONSTRUCTOR) ||
+                             0 == strcmp(fn->name, "init");
+
   // Set up the arguments
   if (fn->hasFlag(FLAG_METHOD) &&
       fn->_this != NULL &&
-      !fn->hasFlag(FLAG_CONSTRUCTOR)) {
+      !isConstructorOrInit) {
     // Set up mt and this arguments
     Symbol* thisArg = fn->_this;
     ArgSymbol* mt = new ArgSymbol(INTENT_BLANK, "_mt", dtMethodToken);
@@ -707,10 +710,13 @@ static Symbol* createDefaultedActual(FnSymbol*  fn,
   // appropriate actual values.
   CallExpr* newCall = new CallExpr(entry->defaultExprFn);
 
+  bool isConstructorOrInit = fn->hasFlag(FLAG_CONSTRUCTOR) ||
+                             0 == strcmp(fn->name, "init");
+
   // Add method token, this if needed
   if (fn->hasFlag(FLAG_METHOD) &&
       fn->_this != NULL &&
-      !fn->hasFlag(FLAG_CONSTRUCTOR)) {
+      !isConstructorOrInit) {
     // Set up mt and _this arguments
     newCall->insertAtTail(gMethodToken);
     Symbol* usedFormal = fn->_this;


### PR DESCRIPTION
After PR #8141, we were seeing failures in getInitialization
(which, as called in parallel.cpp, looks for the initialization
point for global const variables). The AST looked something like this:

```
 DefExpr unixEpoch
 DefExpr def_tmp
 init_default_tzinfo( &unixEpoch, /*ret*/ &def_tmp)
 init( &unixEpoch, /*ret*/ &def_tmp )
```

(Note that PR #7858 rewrote default argument handling to use
 functions returning the default value - instead of a wrapper
 function calling the entire original function).

In other words, the function producing the default value for
an argument to an init function was consuming the 'this' argument.
But that doesn't make sense because 'this' won't be initialized yet
(it's initialized in the initializer). Therefore, I extended logic
in buildDefaultedActualFn and createDefaultedActual that avoids
passing 'this' to the default-argument function to apply to init
functions in addition to constructors.

- [x] full local testing

Reviewed by @lydia-duncan - thanks!