### PR TITLE
Fix chplsys mem functions

### DIFF
--- a/modules/standard/Memory.chpl
+++ b/modules/standard/Memory.chpl
@@ -112,11 +112,11 @@ enum MemUnits {Bytes, KB, MB, GB};
   :rtype: `retType`
  */
 proc locale.physicalMemory(unit: MemUnits=MemUnits.Bytes, type retType=int(64)) {
-  extern proc chpl_bytesPerLocale(): uint(64);
+  extern proc chpl_sys_physicalMemoryBytes(): uint(64);
 
   var bytesInLocale: uint(64);
 
-  on this do bytesInLocale = chpl_bytesPerLocale();
+  on this do bytesInLocale = chpl_sys_physicalMemoryBytes();
 
   var retVal: retType;
   select (unit) {

--- a/runtime/include/chplsys.h
+++ b/runtime/include/chplsys.h
@@ -26,8 +26,8 @@
 
 size_t chpl_getSysPageSize(void);
 size_t chpl_getHeapPageSize(void); // note: only works after mem layer inited
-uint64_t chpl_bytesPerLocale(void);
-size_t chpl_bytesAvailOnThisLocale(void);
+uint64_t chpl_sys_physicalMemoryBytes(void);
+uint64_t chpl_sys_availMemoryBytes(void);
 int chpl_getNumPhysicalCpus(chpl_bool accessible_only);
 int chpl_getNumLogicalCpus(chpl_bool accessible_only);
 

--- a/runtime/src/chplsys.c
+++ b/runtime/src/chplsys.c
@@ -358,22 +358,32 @@ size_t chpl_getHeapPageSize(void) {
 }
 
 
-uint64_t chpl_bytesPerLocale(void) {
+// This function returns the amount of physical memory the
+// system reports there is. This amount of memory is not generally
+// allocatable, since there has to be space for the kernel. This routine
+// makes no attempt to account for kernel space.
+uint64_t chpl_sys_physicalMemoryBytes(void) {
 #ifdef NO_BYTES_PER_LOCALE
   chpl_internal_error("sorry- bytesPerLocale not supported on this platform");
   return 0;
 #elif defined __APPLE__
   uint64_t membytes;
   size_t len = sizeof(membytes);
-  if (sysctlbyname("hw.memsize", &membytes, &len, NULL, 0)) 
+  if (sysctlbyname("hw.memsize", &membytes, &len, NULL, 0))
     chpl_internal_error("query of physical memory failed");
   return membytes;
 #elif defined _AIX
   return _system_configuration.physmem;
+#elif defined __FreeBSD__
+  uint64_t membytes;
+  size_t len = sizeof(membytes);
+  if (sysctlbyname("hw.physmem", &membytes, &len, NULL, 0))
+    chpl_internal_error("query of physical memory failed");
+  return membytes;
 #elif defined __NetBSD__
   uint64_t membytes;
   size_t len = sizeof(membytes);
-  if (sysctlbyname("hw.usermem", &membytes, &len, NULL, 0))
+  if (sysctlbyname("hw.physmem64", &membytes, &len, NULL, 0))
     chpl_internal_error("query of physical memory failed");
   return membytes;
 #elif defined __CYGWIN__
@@ -389,6 +399,8 @@ uint64_t chpl_bytesPerLocale(void) {
   //
 #else
   long int numPages, pageSize;
+  // This code runs for linux, but probably works for FreeBSD/NetBSD.
+  //
   numPages = sysconf(_SC_PHYS_PAGES);
   if (numPages < 0)
     chpl_internal_error("query of physical memory failed");
@@ -399,23 +411,82 @@ uint64_t chpl_bytesPerLocale(void) {
 #endif
 }
 
+// Should return in some sense "currently available user memory"
+// This should return one of:
+//  * the amount of memory that can be allocated without causing swapping
+//  * the amount of memory that is currently unnused (i.e. free)
+uint64_t chpl_sys_availMemoryBytes(void) {
+#if defined(__APPLE__)
 
-size_t chpl_bytesAvailOnThisLocale(void) {
-#if defined __APPLE__
-  int membytes;
-  size_t len = sizeof(membytes);
-  if (sysctlbyname("hw.usermem", &membytes, &len, NULL, 0)) 
-    chpl_internal_error("query of physical memory failed");
-  return (size_t) membytes;
-#elif defined __NetBSD__
-  int64_t membytes;
-  size_t len = sizeof(membytes);
-  if (sysctlbyname("hw.usermem64", &membytes, &len, NULL, 0))
-    chpl_internal_error("query of hw.usermem64 failed");
-  return (size_t) membytes;
+  // On Mac OS X, we could get this value by calling host_statistics64
+  // but that's not really documented.
+  //
+  // So, we run vm_stat, which calls host_statistics, but
+  // which hopefully has a more stable interface.
+  //
+  // We used to use sysctlbyname("hw.usermem", &membytes, &len, NULL, 0)
+  // but that led to nonsense values being returned on some systems, anyway.
+
+  uint64_t pageSize = chpl_getSysPageSize();
+  FILE* f = popen("vm_stat", "r");
+  char buffer[256];
+  unsigned long pagesFree = 0;
+  int foundPagesFree = 0;
+
+  if (!f)
+    chpl_internal_error("could not run vm_stat in chpl_sys_availMemoryBytes");
+
+  while( fgets(buffer, sizeof(buffer), f) ) {
+    if (1 == sscanf(buffer, "Pages free: %lu", &pagesFree)) {
+      foundPagesFree = 1;
+    }
+  }
+
+  pclose(f);
+
+  if (!foundPagesFree)
+    chpl_internal_error("could not find Pages free vm_stat output "
+                        "in chpl_sys_availMemoryBytes");
+
+  return pageSize * pagesFree;
+
+#elif defined(__NetBSD__) || defined(__FreeBSD__)
+  // This used to run
+  //   sysctlbyname("hw.usermem64", &membytes, &len, NULL, 0)
+  // which returns the amount of non-kernel memory.
+  // It now gathers the amount of free memory to be more consistent
+  // with the Linux version.
+
+  uint64_t pageSize = chpl_getSysPageSize();
+  FILE* f = popen("vmstat -s", "r");
+  char buffer[256];
+  unsigned long pagesFree = 0;
+  int foundPagesFree = 0;
+
+  if (!f)
+    chpl_internal_error("could not run vm_stat in chpl_sys_availMemoryBytes");
+
+  while( fgets(buffer, sizeof(buffer), f) ) {
+    if (strstr(buffer, "pages free" /* or pages freed */)) {
+      if (1 == sscanf(buffer, "%lu", &pagesFree))
+        foundPagesFree = 1;
+    }
+  }
+
+  pclose(f);
+
+  if (!foundPagesFree)
+    chpl_internal_error("could not find pages free vm_stat output "
+                        "in chpl_sys_availMemoryBytes");
+
+  return pageSize * pagesFree;
+
 #elif defined(__linux__)
   struct sysinfo s;
 
+  // MPF: I think this should return MemAvailable not MemFree
+  // on linux, because the page cache might be full of memory we can
+  // discard.
   if (sysinfo(&s) != 0)
     chpl_internal_error("sysinfo() failed");
   return (size_t) s.freeram;

--- a/runtime/src/chplsys.c
+++ b/runtime/src/chplsys.c
@@ -467,7 +467,7 @@ uint64_t chpl_sys_availMemoryBytes(void) {
     chpl_internal_error("could not run vm_stat in chpl_sys_availMemoryBytes");
 
   while( fgets(buffer, sizeof(buffer), f) ) {
-    if (strstr(buffer, "pages free" /* or pages freed */)) {
+    if (strstr(buffer, "pages free\n")) {
       if (1 == sscanf(buffer, "%lu", &pagesFree))
         foundPagesFree = 1;
     }

--- a/runtime/src/comm/gasnet/comm-gasnet.c
+++ b/runtime/src/comm/gasnet/comm-gasnet.c
@@ -768,8 +768,11 @@ static void set_max_segsize() {
 
   // Use 90% of the available memory as the maximum segment size,
   // heuristically
-  if ((size = chpl_bytesAvailOnThisLocale()) != 0) {
-    set_max_segsize_env_var((size_t) (0.9 * size));
+  if ((size = chpl_sys_availMemoryBytes()) != 0) {
+    size_t dst_size = 0.9 * size;
+    if (dst_size < 1000 || dst_size > chpl_sys_physicalMemoryBytes())
+      chpl_internal_error("Overflow/underflow determining max segment size");
+    set_max_segsize_env_var(dst_size);
     return;
   }
 


### PR DESCRIPTION
This PR resolves multiple problems with chpl_bytesPerLocale and
chpl_bytesAvailOnThisLocale.

First, it renames them to better reflect that they come from the runtime
and to accurately state what they do.

  * chpl_bytesPerLocale renamed to to chpl_sys_physicalMemoryBytes
  * chpl_bytesAvailOnThisLocale renamed to chpl_sys_availMemoryBytes

Second, updated FreeBSD/NetBSD in chpl_sys_physicalMemoryBytes to get the
hw.physmem/hw.physmem64 system property. As far as I know, these could
actually use _SC_PHYS_PAGES the way linux does, but we don't test on them
regularly and apparently _SC_PHYS_PAGES was not sufficient for NetBSD at
some point (see commit cab70c9).

Third, update chpl_sys_availMemoryBytes() implementation for Mac OS X,
FreeBSD, and NetBSD. Before this commit, on my Mac OS X system, this call
returned a value that I could not explain.  Note, I think it'd be more
reasonable to use MemAvailable (from /proc/meminfo) on linux for this -
because there might be quite a bit of freeable memory in the page cache,
but I didn't try to do that in this commit. Instead, this commit just
makes the other platforms also return the amount of free memory (which is
at least a reasonable guess at the amount of available memory).

chpl_sys_physicalMemoryBytes supports the locale.physicalMemory function.
It's debateable whether or not we should have a function returning the
amount of user memory a program could allocate with dedicated scheduling -
i.e. total physical memory - kernel memory.  If we decided to add such
  a thing, it would need a different Chapel-level interface.

- [x] full local testing
- [x] memory functions return sane values on various platforms:
    - [x] netbsd
    - [x] freebsd
    - [x] mac os x
    - [x] linux

Reviewed by @gbtitus - thanks!