### PR TITLE
Remove processIteratorYields and supporting functions

### DIFF
--- a/compiler/include/checks.h
+++ b/compiler/include/checks.h
@@ -38,7 +38,6 @@ void check_resolve();
 void check_resolveIntents();
 void check_checkResolved();
 void check_replaceArrayAccessesWithRefTemps();
-void check_processIteratorYields();
 void check_flattenFunctions();
 void check_cullOverReferences();
 void check_lowerErrorHandling();

--- a/compiler/include/passes.h
+++ b/compiler/include/passes.h
@@ -61,7 +61,6 @@ void makeBinary();
 void normalize();
 void optimizeOnClauses();
 void parallel();
-void processIteratorYields();
 void prune();
 void prune2();
 void readExternC();

--- a/compiler/main/checks.cpp
+++ b/compiler/main/checks.cpp
@@ -175,13 +175,6 @@ void check_replaceArrayAccessesWithRefTemps()
   check_afterResolveIntents();
 }
 
-void check_processIteratorYields() {
-  check_afterEveryPass();
-  check_afterNormalization();
-  check_afterResolution();
-  check_afterResolveIntents();
-}
-
 void check_flattenFunctions()
 {
   check_afterEveryPass();

--- a/compiler/main/runpasses.cpp
+++ b/compiler/main/runpasses.cpp
@@ -55,7 +55,6 @@ struct PassInfo {
 #define LOG_resolveIntents                     LOG_NO_SHORT
 #define LOG_checkResolved                      LOG_NEVER
 #define LOG_replaceArrayAccessesWithRefTemps   LOG_NO_SHORT
-#define LOG_processIteratorYields              LOG_NO_SHORT
 #define LOG_flattenFunctions                   LOG_NO_SHORT
 #define LOG_cullOverReferences                 LOG_NO_SHORT
 #define LOG_lowerErrorHandling                 LOG_NO_SHORT
@@ -122,7 +121,6 @@ static PassInfo sPassList[] = {
   RUN(replaceArrayAccessesWithRefTemps), // replace multiple array access calls with reference temps
 
   // Post-resolution cleanup
-  RUN(processIteratorYields),   // adjustments to iterators
   RUN(flattenFunctions),        // denest nested functions
   RUN(cullOverReferences),      // remove excess references
   RUN(lowerErrorHandling),      // lower error handling constructs

--- a/compiler/resolution/implementForallIntents.cpp
+++ b/compiler/resolution/implementForallIntents.cpp
@@ -941,6 +941,8 @@ static void propagateExtraArgsForLoopIter(CallExpr* call,
 //
 // Return this new symbol.
 //
+// TODO: this code may no longer be necessary now that localizeReturnSymbols
+// has been removed.
 VarSymbol* localizeYieldForExtendLeader(Expr* origRetExpr, Expr* ref) {
   SymExpr* orse = toSymExpr(origRetExpr);
   INT_ASSERT(orse);

--- a/compiler/resolution/lowerIterators.cpp
+++ b/compiler/resolution/lowerIterators.cpp
@@ -938,73 +938,6 @@ countEnclosingLocalBlocks(Expr* expr, BlockStmt* outer = NULL) {
 }
 
 
-static void localizeReturnSymbols(FnSymbol* iteratorFn, std::vector<SymExpr*> symExprs)
-{
-  /*
-  //
-  // localize return symbols
-  //
-  Symbol* ret = iteratorFn->getReturnSymbol();
-  Map<BlockStmt*,Symbol*> retReplacementMap;
-  for_vector(SymExpr, se, symExprs) {
-    if (se->symbol() == ret) {
-      BlockStmt* block = NULL;
-      for (Expr* parent = se->parentExpr; parent; parent = parent->parentExpr) {
-        block = toBlockStmt(parent);
-        if (block)
-          break;
-      }
-      INT_ASSERT(block);
-      if (block != ret->defPoint->parentExpr) {
-        if (Symbol* repl = retReplacementMap.get(block)) {
-          se->setSymbol(repl);
-        } else {
-          SET_LINENO(se);
-          Symbol* newRet = newTemp("newRet", ret->type);
-          newRet->addFlag(FLAG_SHOULD_NOT_PASS_BY_REF);
-          //newRet->addFlag(FLAG_YVV);
-          block->insertAtHead(new DefExpr(newRet));
-          se->setSymbol(newRet);
-          retReplacementMap.put(block, newRet);
-        }
-      }
-    }
-  }*/
-}
-
-
-//
-// Invokes localizeReturnSymbols() on all iterators.
-//
-// Q: What about yields in task functions?
-// A: Since this is done before flattenFunctions, task functions
-// are still nested in their respective iterators. So their yields
-// will be included in 'asts' and handled when 'fn' is the enclosing
-// iterator.
-//
-// see commit 8d3b2c4065d6466dbaadab0ae0c8444e6645dae6
-// Now we're using a return temp per yield, but this change is still
-// apparently necessary. I think that lowerIterators isn't copying some
-// variables when it should be.
-//
-// TODO: revisit and remove this
-static void localizeIteratorReturnSymbols() {
-/*  forv_Vec(FnSymbol, iterFn, gFnSymbols) {
-    if (iterFn->inTree() && iterFn->isIterator()) {
-      std::vector<SymExpr*> symExprs;
-      collectSymExprs(iterFn, symExprs);
-      localizeReturnSymbols(iterFn, symExprs);
-    }
-  }*/
-}
-
-// processIteratorYields is a separate pass, called before flattenFunctions.
-// TODO: Move this and supporting functions into their own source file.
-void processIteratorYields() {
-  localizeIteratorReturnSymbols();
-}
-
-
 static Map<FnSymbol*,FnSymbol*> loopBodyFnArgsSuppliedMap;
 
 //
@@ -1172,8 +1105,6 @@ createIteratorFn(FnSymbol* iterator, CallExpr* iteratorFnCall, Symbol* index,
   iteratorFn->insertFormalAtTail(loopBodyFnIDArg);
   ArgSymbol* loopBodyFnArgArgs = new ArgSymbol(INTENT_CONST_IN, "_loopBodyFnArgs", argsBundleType);
   iteratorFn->insertFormalAtTail(loopBodyFnArgArgs);
-
-  localizeReturnSymbols(iteratorFn, symExprs);
 
   convertYieldsAndReturns(calls, index, loopBodyFnIDArg, loopBodyFnArgArgs);
 

--- a/compiler/resolution/lowerIterators.cpp
+++ b/compiler/resolution/lowerIterators.cpp
@@ -940,6 +940,7 @@ countEnclosingLocalBlocks(Expr* expr, BlockStmt* outer = NULL) {
 
 static void localizeReturnSymbols(FnSymbol* iteratorFn, std::vector<SymExpr*> symExprs)
 {
+  /*
   //
   // localize return symbols
   //
@@ -968,7 +969,7 @@ static void localizeReturnSymbols(FnSymbol* iteratorFn, std::vector<SymExpr*> sy
         }
       }
     }
-  }
+  }*/
 }
 
 
@@ -988,13 +989,13 @@ static void localizeReturnSymbols(FnSymbol* iteratorFn, std::vector<SymExpr*> sy
 //
 // TODO: revisit and remove this
 static void localizeIteratorReturnSymbols() {
-  forv_Vec(FnSymbol, iterFn, gFnSymbols) {
+/*  forv_Vec(FnSymbol, iterFn, gFnSymbols) {
     if (iterFn->inTree() && iterFn->isIterator()) {
       std::vector<SymExpr*> symExprs;
       collectSymExprs(iterFn, symExprs);
       localizeReturnSymbols(iterFn, symExprs);
     }
-  }
+  }*/
 }
 
 // processIteratorYields is a separate pass, called before flattenFunctions.


### PR DESCRIPTION
This is a follow-on to #8073. It removes the processIteratorYields pass and the supporting functions localizeReturnSymbols and localizeIteratorReturnSymbols. These should no longer be necessary.

- [x] full local testing

Reviewed by @vasslitvinov - thanks!