### PR TITLE
Adjust line numbers for meteor performance test

### DIFF
--- a/test/studies/shootout/submitted/meteor.perfkeys
+++ b/test/studies/shootout/submitted/meteor.perfkeys
@@ -1,4 +1,4 @@
 # file: meteor-submited.dat
 real
-verify:1: 2098 solutions found
-verify:23: 1 1 3 3 3
+verify:5: 2098 solutions found
+verify:27: 1 1 3 3 3


### PR DESCRIPTION
Fix nightly testing failures for performance test
  test/studies/shootout/submitted/meteor

Added 4 to the line numbers to accommodate the two
warnings currently emitted by the compiler (returning
an iterator will convert it to an array).