### PR TITLE
Adjust program_constructs.chpl expected LLVM

### DIFF
--- a/test/llvm/llvm-invariant/program_constructs.chpl
+++ b/test/llvm/llvm-invariant/program_constructs.chpl
@@ -11,7 +11,7 @@ proc f(n)
   var sum = 0;
   for i in 1..10
   {
-// CHECK: @_construct_A_chpl
+// CHECK: call {{.*}} @_construct_A_chpl
 // CHECK-DAG: call {}* @llvm.invariant.start.p0i8(i64 8, i8* [[CAST1:%.*]])
 // CHECK-DAG: [[CAST1]] = bitcast %A_chpl* [[PTR1:%.*]] to i8*
 // CHECK_DAG: store %A_chpl {{%.*}}, %A_chpl* [[PTR1]]
@@ -22,7 +22,7 @@ proc f(n)
   }
 
   if n < 10 {
-// CHECK: @_construct_A_chpl
+// CHECK: call {{.*}} @_construct_A_chpl
 // CHECK-DAG: call {}* @llvm.invariant.start.p0i8(i64 8, i8* [[CAST2:%.*]])
 // CHECK-DAG: [[CAST2]] = bitcast %A_chpl* [[PTR2:%.*]] to i8*
 // CHECK_DAG: store %A_chpl {{%.*}}, %A_chpl* [[PTR2]]
@@ -32,7 +32,7 @@ proc f(n)
     return localConst.a;
   }
   else {
-// CHECK: @_construct_A_chpl
+// CHECK: call {{.*}} @_construct_A_chpl
 // CHECK-DAG: call {}* @llvm.invariant.start.p0i8(i64 8, i8* [[CAST3:%.*]])
 // CHECK-DAG: [[CAST3]] = bitcast %A_chpl* [[PTR3:%.*]] to i8*
 // CHECK_DAG: store %A_chpl {{%.*}}, %A_chpl* [[PTR3]]


### PR DESCRIPTION
Earlier changes made the @_construct_A_chpl match the
procedure declaration, instead of the call. Then, my recent
PR caused new variables to be marked const-value-will-not-change,
so we saw more llvm invariant start annotations.

This commit simply adjusts the FileCheck directives looking
for @_construct_A_chpl to look instead for a call to a function
with that name.