### PR TITLE
Accept comm count increase for cylic alloc/alloc_all tests

### DIFF
--- a/test/distributions/robust/arithmetic/performance/multilocale/alloc.cyclic.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/alloc.cyclic.good
@@ -1,10 +1,10 @@
 Dom1D
-(execute_on = 4, execute_on_nb = 6) (get = 38, put = 1, execute_on = 2, execute_on_fast = 2) (get = 38, put = 1, execute_on_fast = 2) (get = 38, put = 1, execute_on_fast = 2)
+(execute_on = 4, execute_on_nb = 6) (get = 39, put = 1, execute_on = 2, execute_on_fast = 2) (get = 39, put = 1, execute_on_fast = 2) (get = 39, put = 1, execute_on_fast = 2)
 Dom2D
-(execute_on = 4, execute_on_nb = 6) (get = 45, put = 1, execute_on = 2, execute_on_fast = 2) (get = 45, put = 1, execute_on_fast = 2) (get = 45, put = 1, execute_on_fast = 2)
+(execute_on = 4, execute_on_nb = 6) (get = 48, put = 1, execute_on = 2, execute_on_fast = 2) (get = 48, put = 1, execute_on_fast = 2) (get = 48, put = 1, execute_on_fast = 2)
 Dom3D
-(execute_on = 4, execute_on_nb = 6) (get = 60, put = 1, execute_on = 2, execute_on_fast = 2) (get = 60, put = 1, execute_on_fast = 2) (get = 60, put = 1, execute_on_fast = 2)
+(execute_on = 4, execute_on_nb = 6) (get = 67, put = 1, execute_on = 2, execute_on_fast = 2) (get = 67, put = 1, execute_on_fast = 2) (get = 67, put = 1, execute_on_fast = 2)
 Dom4D
-(execute_on = 4, execute_on_nb = 6) (get = 75, put = 1, execute_on = 2, execute_on_fast = 2) (get = 75, put = 1, execute_on_fast = 2) (get = 75, put = 1, execute_on_fast = 2)
+(execute_on = 4, execute_on_nb = 6) (get = 86, put = 1, execute_on = 2, execute_on_fast = 2) (get = 86, put = 1, execute_on_fast = 2) (get = 86, put = 1, execute_on_fast = 2)
 Dom2D32
-(execute_on = 4, execute_on_nb = 6) (get = 45, put = 1, execute_on = 2, execute_on_fast = 2) (get = 45, put = 1, execute_on_fast = 2) (get = 45, put = 1, execute_on_fast = 2)
+(execute_on = 4, execute_on_nb = 6) (get = 48, put = 1, execute_on = 2, execute_on_fast = 2) (get = 48, put = 1, execute_on_fast = 2) (get = 48, put = 1, execute_on_fast = 2)

--- a/test/distributions/robust/arithmetic/performance/multilocale/alloc_all.cyclic.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/alloc_all.cyclic.good
@@ -1,10 +1,10 @@
 Dom1D
-(get = 114, put = 6, execute_on = 16, execute_on_fast = 6, execute_on_nb = 9) (get = 114, put = 3, execute_on = 11, execute_on_fast = 7, execute_on_nb = 6) (get = 114, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6) (get = 114, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6)
+(get = 117, put = 6, execute_on = 16, execute_on_fast = 6, execute_on_nb = 9) (get = 117, put = 3, execute_on = 11, execute_on_fast = 7, execute_on_nb = 6) (get = 117, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6) (get = 117, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6)
 Dom2D
-(get = 135, put = 6, execute_on = 16, execute_on_fast = 6, execute_on_nb = 9) (get = 135, put = 3, execute_on = 11, execute_on_fast = 7, execute_on_nb = 6) (get = 135, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6) (get = 135, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6)
+(get = 144, put = 6, execute_on = 16, execute_on_fast = 6, execute_on_nb = 9) (get = 144, put = 3, execute_on = 11, execute_on_fast = 7, execute_on_nb = 6) (get = 144, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6) (get = 144, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6)
 Dom3D
-(get = 180, put = 6, execute_on = 16, execute_on_fast = 6, execute_on_nb = 9) (get = 180, put = 3, execute_on = 11, execute_on_fast = 7, execute_on_nb = 6) (get = 180, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6) (get = 180, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6)
+(get = 201, put = 6, execute_on = 16, execute_on_fast = 6, execute_on_nb = 9) (get = 201, put = 3, execute_on = 11, execute_on_fast = 7, execute_on_nb = 6) (get = 201, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6) (get = 201, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6)
 Dom4D
-(get = 225, put = 6, execute_on = 16, execute_on_fast = 6, execute_on_nb = 9) (get = 225, put = 3, execute_on = 11, execute_on_fast = 7, execute_on_nb = 6) (get = 225, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6) (get = 225, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6)
+(get = 258, put = 6, execute_on = 16, execute_on_fast = 6, execute_on_nb = 9) (get = 258, put = 3, execute_on = 11, execute_on_fast = 7, execute_on_nb = 6) (get = 258, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6) (get = 258, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6)
 Dom2D32
-(get = 135, put = 6, execute_on = 16, execute_on_fast = 6, execute_on_nb = 9) (get = 135, put = 3, execute_on = 11, execute_on_fast = 7, execute_on_nb = 6) (get = 135, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6) (get = 135, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6)
+(get = 144, put = 6, execute_on = 16, execute_on_fast = 6, execute_on_nb = 9) (get = 144, put = 3, execute_on = 11, execute_on_fast = 7, execute_on_nb = 6) (get = 144, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6) (get = 144, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6)


### PR DESCRIPTION
PR #8073 removed workaround-looking code from createICField
that made the iterator capture _this arguments by value.
This workaround had already been disabled for arrays and
seems unprincipled. However, disabling the workaround caused
a `this` argument for a range iterator to be passed by reference
instead of by value in these comms count tests, resulting in
an increase in communication (because now instead of GET'ing
the range, it GETs the lo and hi elements of the range individually).

Adjusting the default intent for ranges to be `const in` seems to
solve the issue, as would reinstating the workaround.

This commit accepts the comm counts increases so that we can
have testing pass while a more principled solution (possibly
including making range `const in` by default) is developed.

Discussed with @benharsh.