### PR TITLE
Limit the amount of oversubscription we do for darwin testing

### DIFF
--- a/util/cron/common-darwin.bash
+++ b/util/cron/common-darwin.bash
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+
+# Use relay SMTP server, since postfix does not reliably start when test
+# machine is rebooted.
+export CHPL_UTIL_SMTP_HOST=relaya
+
+# 2017-11-03: needed on chapelmac since I.T. updates on 2017-10-10
+#             known to be needed on a Macbook when connected over VPN
+export GASNET_MASTERIP=127.0.0.1
+export GASNET_WORKERIP=127.0.0.0

--- a/util/cron/common-darwin.bash
+++ b/util/cron/common-darwin.bash
@@ -9,3 +9,7 @@ export CHPL_UTIL_SMTP_HOST=relaya
 #             known to be needed on a Macbook when connected over VPN
 export GASNET_MASTERIP=127.0.0.1
 export GASNET_WORKERIP=127.0.0.0
+
+# We run darwin testing heavily oversubscribed, so limit the number of Chapel
+# executables that run concurrently to avoid timeouts.
+export CHPL_TEST_LIMIT_RUNNING_EXECUTABLES=yes

--- a/util/cron/test-darwin.bash
+++ b/util/cron/test-darwin.bash
@@ -4,10 +4,7 @@
 
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common.bash
-
-# Use relay SMTP server, since postfix does not reliably start when test
-# machine is rebooted.
-export CHPL_UTIL_SMTP_HOST=relaya
+source $CWD/common-darwin.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="darwin"
 

--- a/util/cron/test-gasnet.darwin.bash
+++ b/util/cron/test-gasnet.darwin.bash
@@ -4,16 +4,8 @@
 
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common-gasnet.bash
-
-# Use relay SMTP server, since postfix does not reliably start when test
-# machine is rebooted.
-export CHPL_UTIL_SMTP_HOST=relaya
+source $CWD/common-darwin.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gasnet.darwin"
-
-# 2017-11-03: needed on chapelmac since I.T. updates on 2017-10-10
-#             known to be needed on a Macbook when connected over VPN
-export GASNET_MASTERIP=127.0.0.1
-export GASNET_WORKERIP=127.0.0.0
 
 $CWD/nightly -cron

--- a/util/cron/test-gasnet.fast.darwin.bash
+++ b/util/cron/test-gasnet.fast.darwin.bash
@@ -5,16 +5,8 @@
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common-gasnet.bash
 export CHPL_GASNET_SEGMENT=fast
-
-# Use relay SMTP server, since postfix does not reliably start when test
-# machine is rebooted.
-export CHPL_UTIL_SMTP_HOST=relaya
+source $CWD/common-darwin.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gasnet.fast.darwin"
-
-# 2017-11-03: needed on chapelmac since I.T. updates on 2017-10-10
-#             known to be needed on a Macbook when connected over VPN
-export GASNET_MASTERIP=127.0.0.1
-export GASNET_WORKERIP=127.0.0.0
 
 $CWD/nightly -cron -hellos

--- a/util/cron/test-gnu.darwin.bash
+++ b/util/cron/test-gnu.darwin.bash
@@ -4,10 +4,7 @@
 
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common.bash
-
-# Use relay SMTP server, since postfix does not reliably start when test
-# machine is rebooted.
-export CHPL_UTIL_SMTP_HOST=relaya
+source $CWD/common-darwin.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gnu.darwin"
 


### PR DESCRIPTION
On darwin we run up to 4 concurrent testing configurations (3 of which are long
running.) Historically, this oversubscription hasn't been a problem, but some
new software periodically bogs down the machine and is causing timeouts. Try to
alleviate these timeouts by limiting the number of chapel executables that can
run at once. Note that I expect this to increase total testing time. If the
increase is too much, we can limit the amount of gnu and maybe
gasnet-everything testing that we do.
