### PR TITLE
Fix copyright range-end years.

### DIFF
--- a/runtime/include/comm/gasnet/chpl-comm-impl.h
+++ b/runtime/include/comm/gasnet/chpl-comm-impl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2017 Cray Inc.
+ * Copyright 2004-2018 Cray Inc.
  * Other additional copyright holders may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,

--- a/runtime/include/comm/ugni/comm-ugni-heap-pages.h
+++ b/runtime/include/comm/ugni/comm-ugni-heap-pages.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2017 Cray Inc.
+ * Copyright 2004-2018 Cray Inc.
  * Other additional copyright holders may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,

--- a/runtime/include/mem/jemalloc/chpl-mem-jemalloc-prefix.h
+++ b/runtime/include/mem/jemalloc/chpl-mem-jemalloc-prefix.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2017 Cray Inc.
+ * Copyright 2004-2018 Cray Inc.
  * Other additional copyright holders may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,

--- a/runtime/src/comm/ugni/comm-ugni-heap-pages.c
+++ b/runtime/src/comm/ugni/comm-ugni-heap-pages.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2017 Cray Inc.
+ * Copyright 2004-2018 Cray Inc.
  * Other additional copyright holders may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,


### PR DESCRIPTION
The dynamic heap registration branch began in 2017 and these files were
new then; I didn't notice that the range-end years were wrong before
merging the branch because the travis smoke test was working today.