### PR TITLE
Fix a mis-typed variable.

### DIFF
--- a/runtime/src/chpl-env.c
+++ b/runtime/src/chpl-env.c
@@ -75,7 +75,7 @@ int64_t chpl_env_str_to_int(const char* evVal, int64_t dflt) {
 
 
 size_t chpl_env_str_to_size(const char* evVal, size_t dflt) {
-  int64_t val;
+  size_t val;
   int scnCnt;
   char units;
 


### PR DESCRIPTION
Jenkins linux32 smoke testing demonstrated another flaw in #7700 -- a
variable typed as int64_t that should have been size_t.  Fix this.