### PR TITLE
Include on functions in markTaskFunctionsInIterators

### DIFF
--- a/compiler/passes/flattenFunctions.cpp
+++ b/compiler/passes/flattenFunctions.cpp
@@ -57,8 +57,7 @@ static void markTaskFunctionsInIterators(Vec<FnSymbol*>& nestedFunctions) {
 
   forv_Vec(FnSymbol, fn, nestedFunctions) {
     FnSymbol* curFn = fn;
-    while (curFn &&
-           curFn->hasEitherFlag(FLAG_BEGIN, FLAG_COBEGIN_OR_COFORALL)) {
+    while (curFn && isTaskFun(curFn)) {
       curFn = toFnSymbol(curFn->defPoint->parentSymbol);
     }
     // Now curFn is NULL or the first not-a-task function
@@ -66,8 +65,7 @@ static void markTaskFunctionsInIterators(Vec<FnSymbol*>& nestedFunctions) {
       // Mark all of the inner task functions
       IteratorInfo* ii = curFn->iteratorInfo;
       curFn = fn;
-      while (curFn &&
-             curFn->hasEitherFlag(FLAG_BEGIN, FLAG_COBEGIN_OR_COFORALL)) {
+      while (curFn && isTaskFun(curFn)) {
         curFn->addFlag(FLAG_TASK_FN_FROM_ITERATOR_FN);
         curFn->iteratorInfo = ii;
         curFn = toFnSymbol(curFn->defPoint->parentSymbol);


### PR DESCRIPTION
markTaskFunctionsInIterators marks task functions with
FLAG_TASK_FN_FROM_ITERATOR_FN but this did not previously
include on statements. The compiler's sense of a task function
does include on statements (see that isTaskFun returns true
for on statements) and so it is reasonable to apply the same
treatment to on statements.

Resolves numa failures with

    test/parallel/taskPar/vass/yield-arrays-in-task-funs

after PR #8073.

Passed full local testing.
Passed gasnet testing of hellos and primers.

Reviewed by @vasslitvinov - thanks!