### PR TITLE
Fix mutex destruction check during jemalloc exit

### DIFF
--- a/runtime/src/mem/jemalloc/mem-jemalloc.c
+++ b/runtime/src/mem/jemalloc/mem-jemalloc.c
@@ -397,7 +397,7 @@ void chpl_mem_layerInit(void) {
 
 
 void chpl_mem_layerExit(void) {
-  if (heap.base != NULL) {
+  if (have_fixed_comm_layer_heap) {
     // ignore errors, we're exiting anyways
     (void) pthread_mutex_destroy(&heap.alloc_lock);
   }


### PR DESCRIPTION
The mutex is only initialized when we have a fixed heap, but we attempted to
destroy it for fixed and dynamically extended heaps. Only destroy it when a
fixed heap is used.