### PR TITLE
Update the version of flex used to generate the lexer

### DIFF
--- a/compiler/include/bison-chapel.h
+++ b/compiler/include/bison-chapel.h
@@ -1,19 +1,19 @@
-/* A Bison parser, made by GNU Bison 2.5.  */
+/* A Bison parser, made by GNU Bison 3.0.4.  */
 
 /* Bison interface for Yacc-like parsers in C
-   
-      Copyright (C) 1984, 1989-1990, 2000-2011 Free Software Foundation, Inc.
-   
+
+   Copyright (C) 1984, 1989-1990, 2000-2015 Free Software Foundation, Inc.
+
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
    (at your option) any later version.
-   
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
-   
+
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
@@ -26,22 +26,26 @@
    special exception, which will cause the skeleton and the resulting
    Bison output files to be licensed under the GNU General Public
    License without this special exception.
-   
+
    This special exception was added by the Free Software Foundation in
    version 2.2 of Bison.  */
 
+#ifndef YY_YY_INCLUDE_BISON_CHAPEL_H_INCLUDED
+# define YY_YY_INCLUDE_BISON_CHAPEL_H_INCLUDED
+/* Debug traces.  */
+#ifndef YYDEBUG
+# define YYDEBUG 1
+#endif
+#if YYDEBUG
+extern int yydebug;
+#endif
 /* "%code requires" blocks.  */
-
-/* Line 2068 of yacc.c  */
-#line 32 "chapel.ypp"
+#line 32 "chapel.ypp" /* yacc.c:1915  */
 
   #include <string>
   extern int         captureTokens;
   extern std::string captureString;
-
-
-/* Line 2068 of yacc.c  */
-#line 45 "chapel.ypp"
+#line 45 "chapel.ypp" /* yacc.c:1915  */
 
   #ifndef _BISON_CHAPEL_DEFINES_0_
   #define _BISON_CHAPEL_DEFINES_0_
@@ -56,10 +60,7 @@
   void stringBufferInit();
 
   #endif
-
-
-/* Line 2068 of yacc.c  */
-#line 65 "chapel.ypp"
+#line 65 "chapel.ypp" /* yacc.c:1915  */
 
   #ifndef _BISON_CHAPEL_DEFINES_1_
   #define _BISON_CHAPEL_DEFINES_1_
@@ -119,10 +120,7 @@
   };
 
   #endif
-
-
-/* Line 2068 of yacc.c  */
-#line 130 "chapel.ypp"
+#line 130 "chapel.ypp" /* yacc.c:1915  */
 
   #ifndef _BISON_CHAPEL_DEFINES_2_
   #define _BISON_CHAPEL_DEFINES_2_
@@ -139,10 +137,7 @@
   #define YYLTYPE_IS_TRIVIAL  1
 
   #endif
-
-
-/* Line 2068 of yacc.c  */
-#line 152 "chapel.ypp"
+#line 152 "chapel.ypp" /* yacc.c:1915  */
 
   #ifndef _BISON_CHAPEL_DEFINES_3_
   #define _BISON_CHAPEL_DEFINES_3_
@@ -170,216 +165,191 @@
 
   #endif
 
+#line 169 "../include/bison-chapel.h" /* yacc.c:1915  */
 
-
-/* Line 2068 of yacc.c  */
-#line 177 "../include/bison-chapel.h"
-
-/* Tokens.  */
+/* Token type.  */
 #ifndef YYTOKENTYPE
 # define YYTOKENTYPE
-   /* Put the tokens into the symbol table, so that GDB and other debuggers
-      know about them.  */
-   enum yytokentype {
-     TIDENT = 258,
-     INTLITERAL = 259,
-     REALLITERAL = 260,
-     IMAGLITERAL = 261,
-     STRINGLITERAL = 262,
-     CSTRINGLITERAL = 263,
-     EXTERNCODE = 264,
-     TALIGN = 265,
-     TAS = 266,
-     TATOMIC = 267,
-     TBEGIN = 268,
-     TBREAK = 269,
-     TBY = 270,
-     TCATCH = 271,
-     TCLASS = 272,
-     TCOBEGIN = 273,
-     TCOFORALL = 274,
-     TCONFIG = 275,
-     TCONST = 276,
-     TCONTINUE = 277,
-     TDEFER = 278,
-     TDELETE = 279,
-     TDMAPPED = 280,
-     TDO = 281,
-     TDOMAIN = 282,
-     TELSE = 283,
-     TENUM = 284,
-     TEXCEPT = 285,
-     TEXPORT = 286,
-     TEXTERN = 287,
-     TFOR = 288,
-     TFORALL = 289,
-     TFORWARDING = 290,
-     TIF = 291,
-     TIN = 292,
-     TINDEX = 293,
-     TINLINE = 294,
-     TINOUT = 295,
-     TITER = 296,
-     TLABEL = 297,
-     TLAMBDA = 298,
-     TLET = 299,
-     TLOCAL = 300,
-     TMINUSMINUS = 301,
-     TMODULE = 302,
-     TNEW = 303,
-     TNIL = 304,
-     TNOINIT = 305,
-     TON = 306,
-     TONLY = 307,
-     TOTHERWISE = 308,
-     TOUT = 309,
-     TPARAM = 310,
-     TPLUSPLUS = 311,
-     TPRAGMA = 312,
-     TPRIMITIVE = 313,
-     TPRIVATE = 314,
-     TPROC = 315,
-     TPROTOTYPE = 316,
-     TPUBLIC = 317,
-     TRECORD = 318,
-     TREDUCE = 319,
-     TREF = 320,
-     TREQUIRE = 321,
-     TRETURN = 322,
-     TSCAN = 323,
-     TSELECT = 324,
-     TSERIAL = 325,
-     TSINGLE = 326,
-     TSPARSE = 327,
-     TSUBDOMAIN = 328,
-     TSYNC = 329,
-     TTHEN = 330,
-     TTHROW = 331,
-     TTHROWS = 332,
-     TTRY = 333,
-     TTRYBANG = 334,
-     TTYPE = 335,
-     TUNDERSCORE = 336,
-     TUNION = 337,
-     TUSE = 338,
-     TVAR = 339,
-     TWHEN = 340,
-     TWHERE = 341,
-     TWHILE = 342,
-     TWITH = 343,
-     TYIELD = 344,
-     TZIP = 345,
-     TALIAS = 346,
-     TAND = 347,
-     TASSIGN = 348,
-     TASSIGNBAND = 349,
-     TASSIGNBOR = 350,
-     TASSIGNBXOR = 351,
-     TASSIGNDIVIDE = 352,
-     TASSIGNEXP = 353,
-     TASSIGNLAND = 354,
-     TASSIGNLOR = 355,
-     TASSIGNMINUS = 356,
-     TASSIGNMOD = 357,
-     TASSIGNMULTIPLY = 358,
-     TASSIGNPLUS = 359,
-     TASSIGNSL = 360,
-     TASSIGNSR = 361,
-     TBAND = 362,
-     TBNOT = 363,
-     TBOR = 364,
-     TBXOR = 365,
-     TCOLON = 366,
-     TCOMMA = 367,
-     TDIVIDE = 368,
-     TDOT = 369,
-     TDOTDOT = 370,
-     TDOTDOTDOT = 371,
-     TEQUAL = 372,
-     TEXP = 373,
-     TGREATER = 374,
-     TGREATEREQUAL = 375,
-     THASH = 376,
-     TLESS = 377,
-     TLESSEQUAL = 378,
-     TMINUS = 379,
-     TMOD = 380,
-     TNOT = 381,
-     TNOTEQUAL = 382,
-     TOR = 383,
-     TPLUS = 384,
-     TQUESTION = 385,
-     TSEMI = 386,
-     TSHIFTLEFT = 387,
-     TSHIFTRIGHT = 388,
-     TSTAR = 389,
-     TSWAP = 390,
-     TASSIGNREDUCE = 391,
-     TIO = 392,
-     TLCBR = 393,
-     TRCBR = 394,
-     TLP = 395,
-     TRP = 396,
-     TLSBR = 397,
-     TRSBR = 398,
-     TNOELSE = 399,
-     TUMINUS = 400,
-     TUPLUS = 401
-   };
+  enum yytokentype
+  {
+    TIDENT = 258,
+    INTLITERAL = 259,
+    REALLITERAL = 260,
+    IMAGLITERAL = 261,
+    STRINGLITERAL = 262,
+    CSTRINGLITERAL = 263,
+    EXTERNCODE = 264,
+    TALIGN = 265,
+    TAS = 266,
+    TATOMIC = 267,
+    TBEGIN = 268,
+    TBREAK = 269,
+    TBY = 270,
+    TCATCH = 271,
+    TCLASS = 272,
+    TCOBEGIN = 273,
+    TCOFORALL = 274,
+    TCONFIG = 275,
+    TCONST = 276,
+    TCONTINUE = 277,
+    TDEFER = 278,
+    TDELETE = 279,
+    TDMAPPED = 280,
+    TDO = 281,
+    TDOMAIN = 282,
+    TELSE = 283,
+    TENUM = 284,
+    TEXCEPT = 285,
+    TEXPORT = 286,
+    TEXTERN = 287,
+    TFOR = 288,
+    TFORALL = 289,
+    TFORWARDING = 290,
+    TIF = 291,
+    TIN = 292,
+    TINDEX = 293,
+    TINLINE = 294,
+    TINOUT = 295,
+    TITER = 296,
+    TLABEL = 297,
+    TLAMBDA = 298,
+    TLET = 299,
+    TLOCAL = 300,
+    TMINUSMINUS = 301,
+    TMODULE = 302,
+    TNEW = 303,
+    TNIL = 304,
+    TNOINIT = 305,
+    TON = 306,
+    TONLY = 307,
+    TOTHERWISE = 308,
+    TOUT = 309,
+    TPARAM = 310,
+    TPLUSPLUS = 311,
+    TPRAGMA = 312,
+    TPRIMITIVE = 313,
+    TPRIVATE = 314,
+    TPROC = 315,
+    TPROTOTYPE = 316,
+    TPUBLIC = 317,
+    TRECORD = 318,
+    TREDUCE = 319,
+    TREF = 320,
+    TREQUIRE = 321,
+    TRETURN = 322,
+    TSCAN = 323,
+    TSELECT = 324,
+    TSERIAL = 325,
+    TSINGLE = 326,
+    TSPARSE = 327,
+    TSUBDOMAIN = 328,
+    TSYNC = 329,
+    TTHEN = 330,
+    TTHROW = 331,
+    TTHROWS = 332,
+    TTRY = 333,
+    TTRYBANG = 334,
+    TTYPE = 335,
+    TUNDERSCORE = 336,
+    TUNION = 337,
+    TUSE = 338,
+    TVAR = 339,
+    TWHEN = 340,
+    TWHERE = 341,
+    TWHILE = 342,
+    TWITH = 343,
+    TYIELD = 344,
+    TZIP = 345,
+    TALIAS = 346,
+    TAND = 347,
+    TASSIGN = 348,
+    TASSIGNBAND = 349,
+    TASSIGNBOR = 350,
+    TASSIGNBXOR = 351,
+    TASSIGNDIVIDE = 352,
+    TASSIGNEXP = 353,
+    TASSIGNLAND = 354,
+    TASSIGNLOR = 355,
+    TASSIGNMINUS = 356,
+    TASSIGNMOD = 357,
+    TASSIGNMULTIPLY = 358,
+    TASSIGNPLUS = 359,
+    TASSIGNSL = 360,
+    TASSIGNSR = 361,
+    TBAND = 362,
+    TBNOT = 363,
+    TBOR = 364,
+    TBXOR = 365,
+    TCOLON = 366,
+    TCOMMA = 367,
+    TDIVIDE = 368,
+    TDOT = 369,
+    TDOTDOT = 370,
+    TDOTDOTDOT = 371,
+    TEQUAL = 372,
+    TEXP = 373,
+    TGREATER = 374,
+    TGREATEREQUAL = 375,
+    THASH = 376,
+    TLESS = 377,
+    TLESSEQUAL = 378,
+    TMINUS = 379,
+    TMOD = 380,
+    TNOT = 381,
+    TNOTEQUAL = 382,
+    TOR = 383,
+    TPLUS = 384,
+    TQUESTION = 385,
+    TSEMI = 386,
+    TSHIFTLEFT = 387,
+    TSHIFTRIGHT = 388,
+    TSTAR = 389,
+    TSWAP = 390,
+    TASSIGNREDUCE = 391,
+    TIO = 392,
+    TLCBR = 393,
+    TRCBR = 394,
+    TLP = 395,
+    TRP = 396,
+    TLSBR = 397,
+    TRSBR = 398,
+    TNOELSE = 399,
+    TUPLUS = 400,
+    TUMINUS = 401
+  };
 #endif
 
+/* Value type.  */
 
-
-#if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
-
-# define yystype YYSTYPE /* obsolescent; will be withdrawn */
-# define YYSTYPE_IS_DECLARED 1
-#endif
-
-
-
+/* Location type.  */
 #if ! defined YYLTYPE && ! defined YYLTYPE_IS_DECLARED
-typedef struct YYLTYPE
+typedef struct YYLTYPE YYLTYPE;
+struct YYLTYPE
 {
   int first_line;
   int first_column;
   int last_line;
   int last_column;
-} YYLTYPE;
-# define yyltype YYLTYPE /* obsolescent; will be withdrawn */
+};
 # define YYLTYPE_IS_DECLARED 1
 # define YYLTYPE_IS_TRIVIAL 1
 #endif
 
 
 
-#ifndef YYPUSH_DECLS
-#  define YYPUSH_DECLS
-struct yypstate;
-typedef struct yypstate yypstate;
+#ifndef YYPUSH_MORE_DEFINED
+# define YYPUSH_MORE_DEFINED
 enum { YYPUSH_MORE = 4 };
-#if defined __STDC__ || defined __cplusplus
-int yypush_parse (yypstate *yyps, int yypushed_char, YYSTYPE const *yypushed_val, YYLTYPE const *yypushed_loc, ParserContext* context);
-#else
-int yypush_parse ();
 #endif
 
-#if defined __STDC__ || defined __cplusplus
+typedef struct yypstate yypstate;
+
+int yypush_parse (yypstate *ps, int pushed_char, YYSTYPE const *pushed_val, YYLTYPE *pushed_loc, ParserContext* context);
+
 yypstate * yypstate_new (void);
-#else
-yypstate * yypstate_new ();
-#endif
-#if defined __STDC__ || defined __cplusplus
-void yypstate_delete (yypstate *yyps);
-#else
-void yypstate_delete ();
-#endif
-#endif
-
+void yypstate_delete (yypstate *ps);
 /* "%code provides" blocks.  */
-
-/* Line 2068 of yacc.c  */
-#line 183 "chapel.ypp"
+#line 183 "chapel.ypp" /* yacc.c:1915  */
 
   extern int yydebug;
 
@@ -387,7 +357,6 @@ void yypstate_delete ();
                ParserContext* context,
                const char*    str);
 
+#line 361 "../include/bison-chapel.h" /* yacc.c:1915  */
 
-
-/* Line 2068 of yacc.c  */
-#line 394 "../include/bison-chapel.h"
+#endif /* !YY_YY_INCLUDE_BISON_CHAPEL_H_INCLUDED  */

--- a/compiler/include/flex-chapel.h
+++ b/compiler/include/flex-chapel.h
@@ -2,9 +2,9 @@
 #define yyHEADER_H 1
 #define yyIN_HEADER 1
 
-#line 6 "../include/flex-chapel.h"
+#line 5 "../include/flex-chapel.h"
 
-#line 8 "../include/flex-chapel.h"
+#line 7 "../include/flex-chapel.h"
 
 #define  YY_INT_ALIGNED short int
 
@@ -12,10 +12,34 @@
 
 #define FLEX_SCANNER
 #define YY_FLEX_MAJOR_VERSION 2
-#define YY_FLEX_MINOR_VERSION 5
-#define YY_FLEX_SUBMINOR_VERSION 35
+#define YY_FLEX_MINOR_VERSION 6
+#define YY_FLEX_SUBMINOR_VERSION 4
 #if YY_FLEX_SUBMINOR_VERSION > 0
 #define FLEX_BETA
+#endif
+
+#ifdef yyget_lval
+#define yyget_lval_ALREADY_DEFINED
+#else
+#define yyget_lval yyget_lval
+#endif
+
+#ifdef yyset_lval
+#define yyset_lval_ALREADY_DEFINED
+#else
+#define yyset_lval yyset_lval
+#endif
+
+#ifdef yyget_lloc
+#define yyget_lloc_ALREADY_DEFINED
+#else
+#define yyget_lloc yyget_lloc
+#endif
+
+#ifdef yyset_lloc
+#define yyset_lloc_ALREADY_DEFINED
+#else
+#define yyset_lloc yyset_lloc
 #endif
 
 /* First, we deal with  platform-specific or compiler-specific issues. */
@@ -58,7 +82,6 @@ typedef int flex_int32_t;
 typedef unsigned char flex_uint8_t; 
 typedef unsigned short int flex_uint16_t;
 typedef unsigned int flex_uint32_t;
-#endif /* ! C99 */
 
 /* Limits of integral types. */
 #ifndef INT8_MIN
@@ -89,27 +112,23 @@ typedef unsigned int flex_uint32_t;
 #define UINT32_MAX             (4294967295U)
 #endif
 
+#ifndef SIZE_MAX
+#define SIZE_MAX               (~(size_t)0)
+#endif
+
+#endif /* ! C99 */
+
 #endif /* ! FLEXINT_H */
 
-#ifdef __cplusplus
+/* begin standard C++ headers. */
 
-/* The "const" storage-class-modifier is valid. */
-#define YY_USE_CONST
-
-#else	/* ! __cplusplus */
-
-/* C99 requires __STDC__ to be defined as 1. */
-#if defined (__STDC__)
-
-#define YY_USE_CONST
-
-#endif	/* defined (__STDC__) */
-#endif	/* ! __cplusplus */
-
-#ifdef YY_USE_CONST
+/* TODO: this is always defined, so inline it */
 #define yyconst const
+
+#if defined(__GNUC__) && __GNUC__ >= 3
+#define yynoreturn __attribute__((__noreturn__))
 #else
-#define yyconst
+#define yynoreturn
 #endif
 
 /* An opaque pointer. */
@@ -131,7 +150,15 @@ typedef void* yyscan_t;
 
 /* Size of default input buffer. */
 #ifndef YY_BUF_SIZE
+#ifdef __ia64__
+/* On IA-64, the buffer size is 16k, not 8k.
+ * Moreover, YY_BUF_SIZE is 2*YY_READ_BUF_SIZE in the general case.
+ * Ditto for the __ia64__ case accordingly.
+ */
+#define YY_BUF_SIZE 32768
+#else
 #define YY_BUF_SIZE 16384
+#endif /* __ia64__ */
 #endif
 
 #ifndef YY_TYPEDEF_YY_BUFFER_STATE
@@ -156,7 +183,7 @@ struct yy_buffer_state
 	/* Size of input buffer in bytes, not including room for EOB
 	 * characters.
 	 */
-	yy_size_t yy_buf_size;
+	int yy_buf_size;
 
 	/* Number of characters read into yy_ch_buf, not including EOB
 	 * characters.
@@ -184,7 +211,7 @@ struct yy_buffer_state
 
     int yy_bs_lineno; /**< The line count. */
     int yy_bs_column; /**< The column count. */
-    
+
 	/* Whether to try to fill the input buffer when we reach the
 	 * end of it.
 	 */
@@ -195,25 +222,25 @@ struct yy_buffer_state
 	};
 #endif /* !YY_STRUCT_YY_BUFFER_STATE */
 
-void yyrestart (FILE *input_file ,yyscan_t yyscanner );
-void yy_switch_to_buffer (YY_BUFFER_STATE new_buffer ,yyscan_t yyscanner );
-YY_BUFFER_STATE yy_create_buffer (FILE *file,int size ,yyscan_t yyscanner );
-void yy_delete_buffer (YY_BUFFER_STATE b ,yyscan_t yyscanner );
-void yy_flush_buffer (YY_BUFFER_STATE b ,yyscan_t yyscanner );
-void yypush_buffer_state (YY_BUFFER_STATE new_buffer ,yyscan_t yyscanner );
-void yypop_buffer_state (yyscan_t yyscanner );
+void yyrestart ( FILE *input_file , yyscan_t yyscanner );
+void yy_switch_to_buffer ( YY_BUFFER_STATE new_buffer , yyscan_t yyscanner );
+YY_BUFFER_STATE yy_create_buffer ( FILE *file, int size , yyscan_t yyscanner );
+void yy_delete_buffer ( YY_BUFFER_STATE b , yyscan_t yyscanner );
+void yy_flush_buffer ( YY_BUFFER_STATE b , yyscan_t yyscanner );
+void yypush_buffer_state ( YY_BUFFER_STATE new_buffer , yyscan_t yyscanner );
+void yypop_buffer_state ( yyscan_t yyscanner );
 
-YY_BUFFER_STATE yy_scan_buffer (char *base,yy_size_t size ,yyscan_t yyscanner );
-YY_BUFFER_STATE yy_scan_string (yyconst char *yy_str ,yyscan_t yyscanner );
-YY_BUFFER_STATE yy_scan_bytes (yyconst char *bytes,int len ,yyscan_t yyscanner );
+YY_BUFFER_STATE yy_scan_buffer ( char *base, yy_size_t size , yyscan_t yyscanner );
+YY_BUFFER_STATE yy_scan_string ( const char *yy_str , yyscan_t yyscanner );
+YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, int len , yyscan_t yyscanner );
 
-void *yyalloc (yy_size_t ,yyscan_t yyscanner );
-void *yyrealloc (void *,yy_size_t ,yyscan_t yyscanner );
-void yyfree (void * ,yyscan_t yyscanner );
+void *yyalloc ( yy_size_t , yyscan_t yyscanner );
+void *yyrealloc ( void *, yy_size_t , yyscan_t yyscanner );
+void yyfree ( void * , yyscan_t yyscanner );
 
 /* Begin user sect3 */
 
-#define yywrap(n) 1
+#define yywrap(yyscanner) (/*CONSTCOND*/1)
 #define YY_SKIP_YYWRAP
 
 #define yytext_ptr yytext_r
@@ -238,44 +265,48 @@ void yyfree (void * ,yyscan_t yyscanner );
 
 int yylex_init (yyscan_t* scanner);
 
-int yylex_init_extra (YY_EXTRA_TYPE user_defined,yyscan_t* scanner);
+int yylex_init_extra ( YY_EXTRA_TYPE user_defined, yyscan_t* scanner);
 
 /* Accessor methods to globals.
    These are made visible to non-reentrant scanners for convenience. */
 
-int yylex_destroy (yyscan_t yyscanner );
+int yylex_destroy ( yyscan_t yyscanner );
 
-int yyget_debug (yyscan_t yyscanner );
+int yyget_debug ( yyscan_t yyscanner );
 
-void yyset_debug (int debug_flag ,yyscan_t yyscanner );
+void yyset_debug ( int debug_flag , yyscan_t yyscanner );
 
-YY_EXTRA_TYPE yyget_extra (yyscan_t yyscanner );
+YY_EXTRA_TYPE yyget_extra ( yyscan_t yyscanner );
 
-void yyset_extra (YY_EXTRA_TYPE user_defined ,yyscan_t yyscanner );
+void yyset_extra ( YY_EXTRA_TYPE user_defined , yyscan_t yyscanner );
 
-FILE *yyget_in (yyscan_t yyscanner );
+FILE *yyget_in ( yyscan_t yyscanner );
 
-void yyset_in  (FILE * in_str ,yyscan_t yyscanner );
+void yyset_in  ( FILE * _in_str , yyscan_t yyscanner );
 
-FILE *yyget_out (yyscan_t yyscanner );
+FILE *yyget_out ( yyscan_t yyscanner );
 
-void yyset_out  (FILE * out_str ,yyscan_t yyscanner );
+void yyset_out  ( FILE * _out_str , yyscan_t yyscanner );
 
-int yyget_leng (yyscan_t yyscanner );
+			int yyget_leng ( yyscan_t yyscanner );
 
-char *yyget_text (yyscan_t yyscanner );
+char *yyget_text ( yyscan_t yyscanner );
 
-int yyget_lineno (yyscan_t yyscanner );
+int yyget_lineno ( yyscan_t yyscanner );
 
-void yyset_lineno (int line_number ,yyscan_t yyscanner );
+void yyset_lineno ( int _line_number , yyscan_t yyscanner );
 
-YYSTYPE * yyget_lval (yyscan_t yyscanner );
+int yyget_column  ( yyscan_t yyscanner );
 
-void yyset_lval (YYSTYPE * yylval_param ,yyscan_t yyscanner );
+void yyset_column ( int _column_no , yyscan_t yyscanner );
 
-       YYLTYPE *yyget_lloc (yyscan_t yyscanner );
+YYSTYPE * yyget_lval ( yyscan_t yyscanner );
+
+void yyset_lval ( YYSTYPE * yylval_param , yyscan_t yyscanner );
+
+       YYLTYPE *yyget_lloc ( yyscan_t yyscanner );
     
-        void yyset_lloc (YYLTYPE * yylloc_param ,yyscan_t yyscanner );
+        void yyset_lloc ( YYLTYPE * yylloc_param , yyscan_t yyscanner );
     
 /* Macros after this point can all be overridden by user definitions in
  * section 1.
@@ -283,18 +314,18 @@ void yyset_lval (YYSTYPE * yylval_param ,yyscan_t yyscanner );
 
 #ifndef YY_SKIP_YYWRAP
 #ifdef __cplusplus
-extern "C" int yywrap (yyscan_t yyscanner );
+extern "C" int yywrap ( yyscan_t yyscanner );
 #else
-extern int yywrap (yyscan_t yyscanner );
+extern int yywrap ( yyscan_t yyscanner );
 #endif
 #endif
 
 #ifndef yytext_ptr
-static void yy_flex_strncpy (char *,yyconst char *,int ,yyscan_t yyscanner);
+static void yy_flex_strncpy ( char *, const char *, int , yyscan_t yyscanner);
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen (yyconst char * ,yyscan_t yyscanner);
+static int yy_flex_strlen ( const char * , yyscan_t yyscanner);
 #endif
 
 #ifndef YY_NO_INPUT
@@ -303,7 +334,12 @@ static int yy_flex_strlen (yyconst char * ,yyscan_t yyscanner);
 
 /* Amount of stuff to slurp up with each read. */
 #ifndef YY_READ_BUF_SIZE
+#ifdef __ia64__
+/* On IA-64, the buffer size is 16k, not 8k */
+#define YY_READ_BUF_SIZE 16384
+#else
 #define YY_READ_BUF_SIZE 8192
+#endif /* __ia64__ */
 #endif
 
 /* Number of entries by which start-condition stack grows. */
@@ -318,7 +354,7 @@ static int yy_flex_strlen (yyconst char * ,yyscan_t yyscanner);
 #define YY_DECL_IS_OURS 1
 
 extern int yylex \
-               (YYSTYPE * yylval_param,YYLTYPE * yylloc_param ,yyscan_t yyscanner);
+               (YYSTYPE * yylval_param, YYLTYPE * yylloc_param , yyscan_t yyscanner);
 
 #define YY_DECL int yylex \
                (YYSTYPE * yylval_param, YYLTYPE * yylloc_param , yyscan_t yyscanner)
@@ -338,9 +374,154 @@ extern int yylex \
 #undef YY_DECL
 #endif
 
+#ifndef yy_create_buffer_ALREADY_DEFINED
+#undef yy_create_buffer
+#endif
+#ifndef yy_delete_buffer_ALREADY_DEFINED
+#undef yy_delete_buffer
+#endif
+#ifndef yy_scan_buffer_ALREADY_DEFINED
+#undef yy_scan_buffer
+#endif
+#ifndef yy_scan_string_ALREADY_DEFINED
+#undef yy_scan_string
+#endif
+#ifndef yy_scan_bytes_ALREADY_DEFINED
+#undef yy_scan_bytes
+#endif
+#ifndef yy_init_buffer_ALREADY_DEFINED
+#undef yy_init_buffer
+#endif
+#ifndef yy_flush_buffer_ALREADY_DEFINED
+#undef yy_flush_buffer
+#endif
+#ifndef yy_load_buffer_state_ALREADY_DEFINED
+#undef yy_load_buffer_state
+#endif
+#ifndef yy_switch_to_buffer_ALREADY_DEFINED
+#undef yy_switch_to_buffer
+#endif
+#ifndef yypush_buffer_state_ALREADY_DEFINED
+#undef yypush_buffer_state
+#endif
+#ifndef yypop_buffer_state_ALREADY_DEFINED
+#undef yypop_buffer_state
+#endif
+#ifndef yyensure_buffer_stack_ALREADY_DEFINED
+#undef yyensure_buffer_stack
+#endif
+#ifndef yylex_ALREADY_DEFINED
+#undef yylex
+#endif
+#ifndef yyrestart_ALREADY_DEFINED
+#undef yyrestart
+#endif
+#ifndef yylex_init_ALREADY_DEFINED
+#undef yylex_init
+#endif
+#ifndef yylex_init_extra_ALREADY_DEFINED
+#undef yylex_init_extra
+#endif
+#ifndef yylex_destroy_ALREADY_DEFINED
+#undef yylex_destroy
+#endif
+#ifndef yyget_debug_ALREADY_DEFINED
+#undef yyget_debug
+#endif
+#ifndef yyset_debug_ALREADY_DEFINED
+#undef yyset_debug
+#endif
+#ifndef yyget_extra_ALREADY_DEFINED
+#undef yyget_extra
+#endif
+#ifndef yyset_extra_ALREADY_DEFINED
+#undef yyset_extra
+#endif
+#ifndef yyget_in_ALREADY_DEFINED
+#undef yyget_in
+#endif
+#ifndef yyset_in_ALREADY_DEFINED
+#undef yyset_in
+#endif
+#ifndef yyget_out_ALREADY_DEFINED
+#undef yyget_out
+#endif
+#ifndef yyset_out_ALREADY_DEFINED
+#undef yyset_out
+#endif
+#ifndef yyget_leng_ALREADY_DEFINED
+#undef yyget_leng
+#endif
+#ifndef yyget_text_ALREADY_DEFINED
+#undef yyget_text
+#endif
+#ifndef yyget_lineno_ALREADY_DEFINED
+#undef yyget_lineno
+#endif
+#ifndef yyset_lineno_ALREADY_DEFINED
+#undef yyset_lineno
+#endif
+#ifndef yyget_column_ALREADY_DEFINED
+#undef yyget_column
+#endif
+#ifndef yyset_column_ALREADY_DEFINED
+#undef yyset_column
+#endif
+#ifndef yywrap_ALREADY_DEFINED
+#undef yywrap
+#endif
+#ifndef yyget_lval_ALREADY_DEFINED
+#undef yyget_lval
+#endif
+#ifndef yyset_lval_ALREADY_DEFINED
+#undef yyset_lval
+#endif
+#ifndef yyget_lloc_ALREADY_DEFINED
+#undef yyget_lloc
+#endif
+#ifndef yyset_lloc_ALREADY_DEFINED
+#undef yyset_lloc
+#endif
+#ifndef yyalloc_ALREADY_DEFINED
+#undef yyalloc
+#endif
+#ifndef yyrealloc_ALREADY_DEFINED
+#undef yyrealloc
+#endif
+#ifndef yyfree_ALREADY_DEFINED
+#undef yyfree
+#endif
+#ifndef yytext_ALREADY_DEFINED
+#undef yytext
+#endif
+#ifndef yyleng_ALREADY_DEFINED
+#undef yyleng
+#endif
+#ifndef yyin_ALREADY_DEFINED
+#undef yyin
+#endif
+#ifndef yyout_ALREADY_DEFINED
+#undef yyout
+#endif
+#ifndef yy_flex_debug_ALREADY_DEFINED
+#undef yy_flex_debug
+#endif
+#ifndef yylineno_ALREADY_DEFINED
+#undef yylineno
+#endif
+#ifndef yytables_fload_ALREADY_DEFINED
+#undef yytables_fload
+#endif
+#ifndef yytables_destroy_ALREADY_DEFINED
+#undef yytables_destroy
+#endif
+#ifndef yyTABLES_NAME_ALREADY_DEFINED
+#undef yyTABLES_NAME
+#endif
+
 #line 284 "chapel.lex"
 
 
-#line 345 "../include/flex-chapel.h"
+#line 525 "../include/flex-chapel.h"
 #undef yyIN_HEADER
 #endif /* yyHEADER_H */

--- a/compiler/include/misc.h
+++ b/compiler/include/misc.h
@@ -25,6 +25,12 @@
 
 #define exit(x) dont_use_exit_use_clean_exit_instead
 
+#if defined(__GNUC__) && __GNUC__ >= 3
+#define chpl_noreturn __attribute__((__noreturn__))
+#else
+#define chpl_noreturn
+#endif
+
 // INT_FATAL(ast, format, ...)
 //   where ast         == BaseAST* or NULL
 //         format, ... == normal printf stuff
@@ -79,7 +85,7 @@ void        printCallStack(bool force, bool shortModule, FILE* out);
 void        startCatchingSignals();
 void        stopCatchingSignals();
 
-void        clean_exit(int status);
+void        clean_exit(int status) chpl_noreturn;
 
 void        printCallStack();
 void        printCallStackCalls();

--- a/compiler/parser/Makefile
+++ b/compiler/parser/Makefile
@@ -43,7 +43,7 @@ endif
 # Don't create rules for bison-chapel.cpp or flex-chapel.cpp since we don't
 # want them to be rebuilt automatically. (This is because of the bison version
 # 2.5 requirement)
-parser: FORCE
+parser: FORCE flex_version_check
 	@rm -f bison-chapel.output bison-chapel.cpp flex-chapel.cpp
 	@rm -f ../include/bison-chapel.h ../include/flex-chapel.h
 	bison chapel.ypp
@@ -54,6 +54,16 @@ parser: FORCE
 	fi;
 	flex chapel.lex
 
+# Require that the flex version is at least 2.6.0
+flex_version_check:
+	@if python -c "import sys;                                        \
+                       from distutils.version import LooseVersion as LV;  \
+                       sys.exit(LV(sys.argv[1]) >= LV(sys.argv[2]))"      \
+                   `flex --version | sed -e 's/flex //' -e 's/ .*//'`     \
+                   "2.6.0";                                               \
+		then echo "PROBLEM: flex version must be at least 2.6.0"; \
+		exit 1;                                                   \
+	fi
 
 #
 # standard footer

--- a/compiler/parser/bison-chapel.cpp
+++ b/compiler/parser/bison-chapel.cpp
@@ -1,19 +1,19 @@
-/* A Bison parser, made by GNU Bison 2.5.  */
+/* A Bison parser, made by GNU Bison 3.0.4.  */
 
 /* Bison implementation for Yacc-like parsers in C
-   
-      Copyright (C) 1984, 1989-1990, 2000-2011 Free Software Foundation, Inc.
-   
+
+   Copyright (C) 1984, 1989-1990, 2000-2015 Free Software Foundation, Inc.
+
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
    (at your option) any later version.
-   
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
-   
+
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
@@ -26,7 +26,7 @@
    special exception, which will cause the skeleton and the resulting
    Bison output files to be licensed under the GNU General Public
    License without this special exception.
-   
+
    This special exception was added by the Free Software Foundation in
    version 2.2 of Bison.  */
 
@@ -44,7 +44,7 @@
 #define YYBISON 1
 
 /* Bison version.  */
-#define YYBISON_VERSION "2.5"
+#define YYBISON_VERSION "3.0.4"
 
 /* Skeleton name.  */
 #define YYSKELETON_NAME "yacc.c"
@@ -58,21 +58,20 @@
 /* Pull parsers.  */
 #define YYPULL 0
 
-/* Using locations.  */
-#define YYLSP_NEEDED 1
 
 
 
 /* Copy the first part of user declarations.  */
 
+#line 67 "bison-chapel.cpp" /* yacc.c:339  */
 
-/* Line 268 of yacc.c  */
-#line 71 "bison-chapel.cpp"
-
-/* Enabling traces.  */
-#ifndef YYDEBUG
-# define YYDEBUG 1
-#endif
+# ifndef YY_NULLPTR
+#  if defined __cplusplus && 201103L <= __cplusplus
+#   define YY_NULLPTR nullptr
+#  else
+#   define YY_NULLPTR 0
+#  endif
+# endif
 
 /* Enabling verbose error messages.  */
 #ifdef YYERROR_VERBOSE
@@ -82,23 +81,24 @@
 # define YYERROR_VERBOSE 0
 #endif
 
-/* Enabling the token table.  */
-#ifndef YYTOKEN_TABLE
-# define YYTOKEN_TABLE 0
+/* In a future release of Bison, this section will be replaced
+   by #include "bison-chapel.h".  */
+#ifndef YY_YY_INCLUDE_BISON_CHAPEL_H_INCLUDED
+# define YY_YY_INCLUDE_BISON_CHAPEL_H_INCLUDED
+/* Debug traces.  */
+#ifndef YYDEBUG
+# define YYDEBUG 1
 #endif
-
+#if YYDEBUG
+extern int yydebug;
+#endif
 /* "%code requires" blocks.  */
-
-/* Line 288 of yacc.c  */
-#line 32 "chapel.ypp"
+#line 32 "chapel.ypp" /* yacc.c:355  */
 
   #include <string>
   extern int         captureTokens;
   extern std::string captureString;
-
-
-/* Line 288 of yacc.c  */
-#line 45 "chapel.ypp"
+#line 45 "chapel.ypp" /* yacc.c:355  */
 
   #ifndef _BISON_CHAPEL_DEFINES_0_
   #define _BISON_CHAPEL_DEFINES_0_
@@ -113,10 +113,7 @@
   void stringBufferInit();
 
   #endif
-
-
-/* Line 288 of yacc.c  */
-#line 65 "chapel.ypp"
+#line 65 "chapel.ypp" /* yacc.c:355  */
 
   #ifndef _BISON_CHAPEL_DEFINES_1_
   #define _BISON_CHAPEL_DEFINES_1_
@@ -176,10 +173,7 @@
   };
 
   #endif
-
-
-/* Line 288 of yacc.c  */
-#line 130 "chapel.ypp"
+#line 130 "chapel.ypp" /* yacc.c:355  */
 
   #ifndef _BISON_CHAPEL_DEFINES_2_
   #define _BISON_CHAPEL_DEFINES_2_
@@ -196,10 +190,7 @@
   #define YYLTYPE_IS_TRIVIAL  1
 
   #endif
-
-
-/* Line 288 of yacc.c  */
-#line 152 "chapel.ypp"
+#line 152 "chapel.ypp" /* yacc.c:355  */
 
   #ifndef _BISON_CHAPEL_DEFINES_3_
   #define _BISON_CHAPEL_DEFINES_3_
@@ -227,213 +218,191 @@
 
   #endif
 
+#line 222 "bison-chapel.cpp" /* yacc.c:355  */
 
-
-/* Line 288 of yacc.c  */
-#line 234 "bison-chapel.cpp"
-
-/* Tokens.  */
+/* Token type.  */
 #ifndef YYTOKENTYPE
 # define YYTOKENTYPE
-   /* Put the tokens into the symbol table, so that GDB and other debuggers
-      know about them.  */
-   enum yytokentype {
-     TIDENT = 258,
-     INTLITERAL = 259,
-     REALLITERAL = 260,
-     IMAGLITERAL = 261,
-     STRINGLITERAL = 262,
-     CSTRINGLITERAL = 263,
-     EXTERNCODE = 264,
-     TALIGN = 265,
-     TAS = 266,
-     TATOMIC = 267,
-     TBEGIN = 268,
-     TBREAK = 269,
-     TBY = 270,
-     TCATCH = 271,
-     TCLASS = 272,
-     TCOBEGIN = 273,
-     TCOFORALL = 274,
-     TCONFIG = 275,
-     TCONST = 276,
-     TCONTINUE = 277,
-     TDEFER = 278,
-     TDELETE = 279,
-     TDMAPPED = 280,
-     TDO = 281,
-     TDOMAIN = 282,
-     TELSE = 283,
-     TENUM = 284,
-     TEXCEPT = 285,
-     TEXPORT = 286,
-     TEXTERN = 287,
-     TFOR = 288,
-     TFORALL = 289,
-     TFORWARDING = 290,
-     TIF = 291,
-     TIN = 292,
-     TINDEX = 293,
-     TINLINE = 294,
-     TINOUT = 295,
-     TITER = 296,
-     TLABEL = 297,
-     TLAMBDA = 298,
-     TLET = 299,
-     TLOCAL = 300,
-     TMINUSMINUS = 301,
-     TMODULE = 302,
-     TNEW = 303,
-     TNIL = 304,
-     TNOINIT = 305,
-     TON = 306,
-     TONLY = 307,
-     TOTHERWISE = 308,
-     TOUT = 309,
-     TPARAM = 310,
-     TPLUSPLUS = 311,
-     TPRAGMA = 312,
-     TPRIMITIVE = 313,
-     TPRIVATE = 314,
-     TPROC = 315,
-     TPROTOTYPE = 316,
-     TPUBLIC = 317,
-     TRECORD = 318,
-     TREDUCE = 319,
-     TREF = 320,
-     TREQUIRE = 321,
-     TRETURN = 322,
-     TSCAN = 323,
-     TSELECT = 324,
-     TSERIAL = 325,
-     TSINGLE = 326,
-     TSPARSE = 327,
-     TSUBDOMAIN = 328,
-     TSYNC = 329,
-     TTHEN = 330,
-     TTHROW = 331,
-     TTHROWS = 332,
-     TTRY = 333,
-     TTRYBANG = 334,
-     TTYPE = 335,
-     TUNDERSCORE = 336,
-     TUNION = 337,
-     TUSE = 338,
-     TVAR = 339,
-     TWHEN = 340,
-     TWHERE = 341,
-     TWHILE = 342,
-     TWITH = 343,
-     TYIELD = 344,
-     TZIP = 345,
-     TALIAS = 346,
-     TAND = 347,
-     TASSIGN = 348,
-     TASSIGNBAND = 349,
-     TASSIGNBOR = 350,
-     TASSIGNBXOR = 351,
-     TASSIGNDIVIDE = 352,
-     TASSIGNEXP = 353,
-     TASSIGNLAND = 354,
-     TASSIGNLOR = 355,
-     TASSIGNMINUS = 356,
-     TASSIGNMOD = 357,
-     TASSIGNMULTIPLY = 358,
-     TASSIGNPLUS = 359,
-     TASSIGNSL = 360,
-     TASSIGNSR = 361,
-     TBAND = 362,
-     TBNOT = 363,
-     TBOR = 364,
-     TBXOR = 365,
-     TCOLON = 366,
-     TCOMMA = 367,
-     TDIVIDE = 368,
-     TDOT = 369,
-     TDOTDOT = 370,
-     TDOTDOTDOT = 371,
-     TEQUAL = 372,
-     TEXP = 373,
-     TGREATER = 374,
-     TGREATEREQUAL = 375,
-     THASH = 376,
-     TLESS = 377,
-     TLESSEQUAL = 378,
-     TMINUS = 379,
-     TMOD = 380,
-     TNOT = 381,
-     TNOTEQUAL = 382,
-     TOR = 383,
-     TPLUS = 384,
-     TQUESTION = 385,
-     TSEMI = 386,
-     TSHIFTLEFT = 387,
-     TSHIFTRIGHT = 388,
-     TSTAR = 389,
-     TSWAP = 390,
-     TASSIGNREDUCE = 391,
-     TIO = 392,
-     TLCBR = 393,
-     TRCBR = 394,
-     TLP = 395,
-     TRP = 396,
-     TLSBR = 397,
-     TRSBR = 398,
-     TNOELSE = 399,
-     TUMINUS = 400,
-     TUPLUS = 401
-   };
+  enum yytokentype
+  {
+    TIDENT = 258,
+    INTLITERAL = 259,
+    REALLITERAL = 260,
+    IMAGLITERAL = 261,
+    STRINGLITERAL = 262,
+    CSTRINGLITERAL = 263,
+    EXTERNCODE = 264,
+    TALIGN = 265,
+    TAS = 266,
+    TATOMIC = 267,
+    TBEGIN = 268,
+    TBREAK = 269,
+    TBY = 270,
+    TCATCH = 271,
+    TCLASS = 272,
+    TCOBEGIN = 273,
+    TCOFORALL = 274,
+    TCONFIG = 275,
+    TCONST = 276,
+    TCONTINUE = 277,
+    TDEFER = 278,
+    TDELETE = 279,
+    TDMAPPED = 280,
+    TDO = 281,
+    TDOMAIN = 282,
+    TELSE = 283,
+    TENUM = 284,
+    TEXCEPT = 285,
+    TEXPORT = 286,
+    TEXTERN = 287,
+    TFOR = 288,
+    TFORALL = 289,
+    TFORWARDING = 290,
+    TIF = 291,
+    TIN = 292,
+    TINDEX = 293,
+    TINLINE = 294,
+    TINOUT = 295,
+    TITER = 296,
+    TLABEL = 297,
+    TLAMBDA = 298,
+    TLET = 299,
+    TLOCAL = 300,
+    TMINUSMINUS = 301,
+    TMODULE = 302,
+    TNEW = 303,
+    TNIL = 304,
+    TNOINIT = 305,
+    TON = 306,
+    TONLY = 307,
+    TOTHERWISE = 308,
+    TOUT = 309,
+    TPARAM = 310,
+    TPLUSPLUS = 311,
+    TPRAGMA = 312,
+    TPRIMITIVE = 313,
+    TPRIVATE = 314,
+    TPROC = 315,
+    TPROTOTYPE = 316,
+    TPUBLIC = 317,
+    TRECORD = 318,
+    TREDUCE = 319,
+    TREF = 320,
+    TREQUIRE = 321,
+    TRETURN = 322,
+    TSCAN = 323,
+    TSELECT = 324,
+    TSERIAL = 325,
+    TSINGLE = 326,
+    TSPARSE = 327,
+    TSUBDOMAIN = 328,
+    TSYNC = 329,
+    TTHEN = 330,
+    TTHROW = 331,
+    TTHROWS = 332,
+    TTRY = 333,
+    TTRYBANG = 334,
+    TTYPE = 335,
+    TUNDERSCORE = 336,
+    TUNION = 337,
+    TUSE = 338,
+    TVAR = 339,
+    TWHEN = 340,
+    TWHERE = 341,
+    TWHILE = 342,
+    TWITH = 343,
+    TYIELD = 344,
+    TZIP = 345,
+    TALIAS = 346,
+    TAND = 347,
+    TASSIGN = 348,
+    TASSIGNBAND = 349,
+    TASSIGNBOR = 350,
+    TASSIGNBXOR = 351,
+    TASSIGNDIVIDE = 352,
+    TASSIGNEXP = 353,
+    TASSIGNLAND = 354,
+    TASSIGNLOR = 355,
+    TASSIGNMINUS = 356,
+    TASSIGNMOD = 357,
+    TASSIGNMULTIPLY = 358,
+    TASSIGNPLUS = 359,
+    TASSIGNSL = 360,
+    TASSIGNSR = 361,
+    TBAND = 362,
+    TBNOT = 363,
+    TBOR = 364,
+    TBXOR = 365,
+    TCOLON = 366,
+    TCOMMA = 367,
+    TDIVIDE = 368,
+    TDOT = 369,
+    TDOTDOT = 370,
+    TDOTDOTDOT = 371,
+    TEQUAL = 372,
+    TEXP = 373,
+    TGREATER = 374,
+    TGREATEREQUAL = 375,
+    THASH = 376,
+    TLESS = 377,
+    TLESSEQUAL = 378,
+    TMINUS = 379,
+    TMOD = 380,
+    TNOT = 381,
+    TNOTEQUAL = 382,
+    TOR = 383,
+    TPLUS = 384,
+    TQUESTION = 385,
+    TSEMI = 386,
+    TSHIFTLEFT = 387,
+    TSHIFTRIGHT = 388,
+    TSTAR = 389,
+    TSWAP = 390,
+    TASSIGNREDUCE = 391,
+    TIO = 392,
+    TLCBR = 393,
+    TRCBR = 394,
+    TLP = 395,
+    TRP = 396,
+    TLSBR = 397,
+    TRSBR = 398,
+    TNOELSE = 399,
+    TUPLUS = 400,
+    TUMINUS = 401
+  };
 #endif
 
+/* Value type.  */
 
-
-#if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
-
-# define yystype YYSTYPE /* obsolescent; will be withdrawn */
-# define YYSTYPE_IS_DECLARED 1
-#endif
-
+/* Location type.  */
 #if ! defined YYLTYPE && ! defined YYLTYPE_IS_DECLARED
-typedef struct YYLTYPE
+typedef struct YYLTYPE YYLTYPE;
+struct YYLTYPE
 {
   int first_line;
   int first_column;
   int last_line;
   int last_column;
-} YYLTYPE;
-# define yyltype YYLTYPE /* obsolescent; will be withdrawn */
+};
 # define YYLTYPE_IS_DECLARED 1
 # define YYLTYPE_IS_TRIVIAL 1
 #endif
 
-#ifndef YYPUSH_DECLS
-#  define YYPUSH_DECLS
-struct yypstate;
-typedef struct yypstate yypstate;
+
+
+#ifndef YYPUSH_MORE_DEFINED
+# define YYPUSH_MORE_DEFINED
 enum { YYPUSH_MORE = 4 };
-
-#if defined __STDC__ || defined __cplusplus
-int yypush_parse (yypstate *yyps, int yypushed_char, YYSTYPE const *yypushed_val, YYLTYPE const *yypushed_loc, ParserContext* context);
-#else
-int yypush_parse ();
 #endif
 
-#if defined __STDC__ || defined __cplusplus
+typedef struct yypstate yypstate;
+
+int yypush_parse (yypstate *ps, int pushed_char, YYSTYPE const *pushed_val, YYLTYPE *pushed_loc, ParserContext* context);
+
 yypstate * yypstate_new (void);
-#else
-yypstate * yypstate_new ();
-#endif
-#if defined __STDC__ || defined __cplusplus
-void yypstate_delete (yypstate *yyps);
-#else
-void yypstate_delete ();
-#endif
-#endif
-
+void yypstate_delete (yypstate *ps);
 /* "%code provides" blocks.  */
-
-/* Line 340 of yacc.c  */
-#line 183 "chapel.ypp"
+#line 183 "chapel.ypp" /* yacc.c:355  */
 
   extern int yydebug;
 
@@ -441,28 +410,20 @@ void yypstate_delete ();
                ParserContext* context,
                const char*    str);
 
+#line 414 "bison-chapel.cpp" /* yacc.c:355  */
 
-
-/* Line 340 of yacc.c  */
-#line 448 "bison-chapel.cpp"
+#endif /* !YY_YY_INCLUDE_BISON_CHAPEL_H_INCLUDED  */
 
 /* Copy the second part of user declarations.  */
 
-
-/* Line 343 of yacc.c  */
-#line 454 "bison-chapel.cpp"
+#line 420 "bison-chapel.cpp" /* yacc.c:358  */
 /* Unqualified %code blocks.  */
-
-/* Line 344 of yacc.c  */
-#line 38 "chapel.ypp"
+#line 38 "chapel.ypp" /* yacc.c:359  */
 
   #include <string>
   int         captureTokens;
   std::string captureString;
-
-
-/* Line 344 of yacc.c  */
-#line 191 "chapel.ypp"
+#line 191 "chapel.ypp" /* yacc.c:359  */
 
   #include "build.h"
   #include "CatchStmt.h"
@@ -528,10 +489,7 @@ void yypstate_delete ();
     fprintf(stderr, "\n");
   }
 
-
-
-/* Line 344 of yacc.c  */
-#line 535 "bison-chapel.cpp"
+#line 493 "bison-chapel.cpp" /* yacc.c:359  */
 
 #ifdef short
 # undef short
@@ -545,11 +503,8 @@ typedef unsigned char yytype_uint8;
 
 #ifdef YYTYPE_INT8
 typedef YYTYPE_INT8 yytype_int8;
-#elif (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
-typedef signed char yytype_int8;
 #else
-typedef short int yytype_int8;
+typedef signed char yytype_int8;
 #endif
 
 #ifdef YYTYPE_UINT16
@@ -569,8 +524,7 @@ typedef short int yytype_int16;
 #  define YYSIZE_T __SIZE_TYPE__
 # elif defined size_t
 #  define YYSIZE_T size_t
-# elif ! defined YYSIZE_T && (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
+# elif ! defined YYSIZE_T
 #  include <stddef.h> /* INFRINGES ON USER NAME SPACE */
 #  define YYSIZE_T size_t
 # else
@@ -584,46 +538,75 @@ typedef short int yytype_int16;
 # if defined YYENABLE_NLS && YYENABLE_NLS
 #  if ENABLE_NLS
 #   include <libintl.h> /* INFRINGES ON USER NAME SPACE */
-#   define YY_(msgid) dgettext ("bison-runtime", msgid)
+#   define YY_(Msgid) dgettext ("bison-runtime", Msgid)
 #  endif
 # endif
 # ifndef YY_
-#  define YY_(msgid) msgid
+#  define YY_(Msgid) Msgid
+# endif
+#endif
+
+#ifndef YY_ATTRIBUTE
+# if (defined __GNUC__                                               \
+      && (2 < __GNUC__ || (__GNUC__ == 2 && 96 <= __GNUC_MINOR__)))  \
+     || defined __SUNPRO_C && 0x5110 <= __SUNPRO_C
+#  define YY_ATTRIBUTE(Spec) __attribute__(Spec)
+# else
+#  define YY_ATTRIBUTE(Spec) /* empty */
+# endif
+#endif
+
+#ifndef YY_ATTRIBUTE_PURE
+# define YY_ATTRIBUTE_PURE   YY_ATTRIBUTE ((__pure__))
+#endif
+
+#ifndef YY_ATTRIBUTE_UNUSED
+# define YY_ATTRIBUTE_UNUSED YY_ATTRIBUTE ((__unused__))
+#endif
+
+#if !defined _Noreturn \
+     && (!defined __STDC_VERSION__ || __STDC_VERSION__ < 201112)
+# if defined _MSC_VER && 1200 <= _MSC_VER
+#  define _Noreturn __declspec (noreturn)
+# else
+#  define _Noreturn YY_ATTRIBUTE ((__noreturn__))
 # endif
 #endif
 
 /* Suppress unused-variable warnings by "using" E.  */
 #if ! defined lint || defined __GNUC__
-# define YYUSE(e) ((void) (e))
+# define YYUSE(E) ((void) (E))
 #else
-# define YYUSE(e) /* empty */
+# define YYUSE(E) /* empty */
 #endif
 
-/* Identity function, used to suppress warnings about constant conditions.  */
-#ifndef lint
-# define YYID(n) (n)
+#if defined __GNUC__ && 407 <= __GNUC__ * 100 + __GNUC_MINOR__
+/* Suppress an incorrect diagnostic about yylval being uninitialized.  */
+# define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN \
+    _Pragma ("GCC diagnostic push") \
+    _Pragma ("GCC diagnostic ignored \"-Wuninitialized\"")\
+    _Pragma ("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")
+# define YY_IGNORE_MAYBE_UNINITIALIZED_END \
+    _Pragma ("GCC diagnostic pop")
 #else
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
-static int
-YYID (int yyi)
-#else
-static int
-YYID (yyi)
-    int yyi;
+# define YY_INITIAL_VALUE(Value) Value
 #endif
-{
-  return yyi;
-}
+#ifndef YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+# define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+# define YY_IGNORE_MAYBE_UNINITIALIZED_END
 #endif
+#ifndef YY_INITIAL_VALUE
+# define YY_INITIAL_VALUE(Value) /* Nothing. */
+#endif
+
 
 #if ! defined yyoverflow || YYERROR_VERBOSE
 
 /* The parser invokes alloca or malloc; define the necessary symbols.  */
 
 # ifdef YYSTACK_ALLOC
-   /* Pacify GCC's `empty if-body' warning.  */
-#  define YYSTACK_FREE(Ptr) do { /* empty */; } while (YYID (0))
+   /* Pacify GCC's 'empty if-body' warning.  */
+#  define YYSTACK_FREE(Ptr) do { /* empty */; } while (0)
 #  ifndef YYSTACK_ALLOC_MAXIMUM
     /* The OS might guarantee only one guard page at the bottom of the stack,
        and a page size can be as small as 4096 bytes.  So we cannot safely
@@ -639,7 +622,7 @@ YYID (yyi)
 #  endif
 #  if (defined __cplusplus && ! defined EXIT_SUCCESS \
        && ! ((defined YYMALLOC || defined malloc) \
-	     && (defined YYFREE || defined free)))
+             && (defined YYFREE || defined free)))
 #   include <stdlib.h> /* INFRINGES ON USER NAME SPACE */
 #   ifndef EXIT_SUCCESS
 #    define EXIT_SUCCESS 0
@@ -647,15 +630,13 @@ YYID (yyi)
 #  endif
 #  ifndef YYMALLOC
 #   define YYMALLOC malloc
-#   if ! defined malloc && ! defined EXIT_SUCCESS && (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
+#   if ! defined malloc && ! defined EXIT_SUCCESS
 void *malloc (YYSIZE_T); /* INFRINGES ON USER NAME SPACE */
 #   endif
 #  endif
 #  ifndef YYFREE
 #   define YYFREE free
-#   if ! defined free && ! defined EXIT_SUCCESS && (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
+#   if ! defined free && ! defined EXIT_SUCCESS
 void free (void *); /* INFRINGES ON USER NAME SPACE */
 #   endif
 #  endif
@@ -665,8 +646,8 @@ void free (void *); /* INFRINGES ON USER NAME SPACE */
 
 #if (! defined yyoverflow \
      && (! defined __cplusplus \
-	 || (defined YYLTYPE_IS_TRIVIAL && YYLTYPE_IS_TRIVIAL \
-	     && defined YYSTYPE_IS_TRIVIAL && YYSTYPE_IS_TRIVIAL)))
+         || (defined YYLTYPE_IS_TRIVIAL && YYLTYPE_IS_TRIVIAL \
+             && defined YYSTYPE_IS_TRIVIAL && YYSTYPE_IS_TRIVIAL)))
 
 /* A type that is properly aligned for any stack member.  */
 union yyalloc
@@ -692,35 +673,35 @@ union yyalloc
    elements in the stack, and YYPTR gives the new location of the
    stack.  Advance YYPTR to a properly aligned location for the next
    stack.  */
-# define YYSTACK_RELOCATE(Stack_alloc, Stack)				\
-    do									\
-      {									\
-	YYSIZE_T yynewbytes;						\
-	YYCOPY (&yyptr->Stack_alloc, Stack, yysize);			\
-	Stack = &yyptr->Stack_alloc;					\
-	yynewbytes = yystacksize * sizeof (*Stack) + YYSTACK_GAP_MAXIMUM; \
-	yyptr += yynewbytes / sizeof (*yyptr);				\
-      }									\
-    while (YYID (0))
+# define YYSTACK_RELOCATE(Stack_alloc, Stack)                           \
+    do                                                                  \
+      {                                                                 \
+        YYSIZE_T yynewbytes;                                            \
+        YYCOPY (&yyptr->Stack_alloc, Stack, yysize);                    \
+        Stack = &yyptr->Stack_alloc;                                    \
+        yynewbytes = yystacksize * sizeof (*Stack) + YYSTACK_GAP_MAXIMUM; \
+        yyptr += yynewbytes / sizeof (*yyptr);                          \
+      }                                                                 \
+    while (0)
 
 #endif
 
 #if defined YYCOPY_NEEDED && YYCOPY_NEEDED
-/* Copy COUNT objects from FROM to TO.  The source and destination do
+/* Copy COUNT objects from SRC to DST.  The source and destination do
    not overlap.  */
 # ifndef YYCOPY
 #  if defined __GNUC__ && 1 < __GNUC__
-#   define YYCOPY(To, From, Count) \
-      __builtin_memcpy (To, From, (Count) * sizeof (*(From)))
+#   define YYCOPY(Dst, Src, Count) \
+      __builtin_memcpy (Dst, Src, (Count) * sizeof (*(Src)))
 #  else
-#   define YYCOPY(To, From, Count)		\
-      do					\
-	{					\
-	  YYSIZE_T yyi;				\
-	  for (yyi = 0; yyi < (Count); yyi++)	\
-	    (To)[yyi] = (From)[yyi];		\
-	}					\
-      while (YYID (0))
+#   define YYCOPY(Dst, Src, Count)              \
+      do                                        \
+        {                                       \
+          YYSIZE_T yyi;                         \
+          for (yyi = 0; yyi < (Count); yyi++)   \
+            (Dst)[yyi] = (Src)[yyi];            \
+        }                                       \
+      while (0)
 #  endif
 # endif
 #endif /* !YYCOPY_NEEDED */
@@ -736,17 +717,19 @@ union yyalloc
 #define YYNNTS  124
 /* YYNRULES -- Number of rules.  */
 #define YYNRULES  495
-/* YYNRULES -- Number of states.  */
+/* YYNSTATES -- Number of states.  */
 #define YYNSTATES  938
 
-/* YYTRANSLATE(YYLEX) -- Bison symbol number corresponding to YYLEX.  */
+/* YYTRANSLATE[YYX] -- Symbol number corresponding to YYX as returned
+   by yylex, with out-of-bounds checking.  */
 #define YYUNDEFTOK  2
 #define YYMAXUTOK   401
 
-#define YYTRANSLATE(YYX)						\
+#define YYTRANSLATE(YYX)                                                \
   ((unsigned int) (YYX) <= YYMAXUTOK ? yytranslate[YYX] : YYUNDEFTOK)
 
-/* YYTRANSLATE[YYLEX] -- Bison symbol number corresponding to YYLEX.  */
+/* YYTRANSLATE[TOKEN-NUM] -- Symbol number corresponding to TOKEN-NUM
+   as returned by yylex, without out-of-bounds checking.  */
 static const yytype_uint8 yytranslate[] =
 {
        0,     2,     2,     2,     2,     2,     2,     2,     2,     2,
@@ -793,242 +776,7 @@ static const yytype_uint8 yytranslate[] =
 };
 
 #if YYDEBUG
-/* YYPRHS[YYN] -- Index of the first RHS symbol of rule number YYN in
-   YYRHS.  */
-static const yytype_uint16 yyprhs[] =
-{
-       0,     0,     3,     5,     6,     9,    11,    14,    17,    21,
-      23,    25,    27,    29,    31,    33,    35,    37,    39,    41,
-      43,    45,    47,    49,    52,    55,    59,    63,    67,    71,
-      75,    79,    83,    86,    90,    94,    97,   100,   104,   107,
-     114,   122,   130,   131,   133,   135,   136,   138,   141,   145,
-     149,   151,   154,   156,   160,   164,   170,   171,   173,   175,
-     177,   181,   187,   193,   197,   202,   207,   212,   217,   222,
-     227,   232,   237,   242,   247,   252,   257,   262,   267,   272,
-     277,   278,   280,   282,   284,   286,   289,   291,   294,   298,
-     300,   302,   305,   308,   310,   312,   314,   316,   318,   320,
-     324,   330,   336,   339,   342,   348,   352,   359,   366,   371,
-     377,   383,   387,   391,   398,   404,   411,   417,   424,   428,
-     433,   440,   448,   455,   463,   468,   474,   479,   484,   488,
-     495,   501,   508,   514,   523,   531,   534,   538,   542,   545,
-     548,   552,   556,   557,   560,   563,   567,   573,   575,   579,
-     583,   589,   595,   596,   599,   603,   606,   610,   617,   626,
-     633,   642,   644,   646,   648,   649,   652,   653,   656,   660,
-     666,   672,   674,   676,   679,   683,   685,   689,   690,   691,
-     700,   701,   703,   706,   709,   710,   711,   722,   726,   730,
-     736,   742,   744,   748,   750,   753,   755,   757,   759,   761,
-     763,   765,   767,   769,   771,   773,   775,   777,   779,   781,
-     783,   785,   787,   789,   791,   793,   795,   797,   799,   801,
-     803,   805,   807,   809,   811,   813,   815,   817,   819,   821,
-     823,   825,   826,   830,   834,   835,   837,   841,   846,   851,
-     858,   865,   866,   868,   870,   872,   874,   876,   879,   882,
-     884,   886,   888,   889,   891,   893,   896,   898,   900,   902,
-     904,   905,   907,   910,   912,   914,   916,   917,   919,   921,
-     923,   925,   927,   930,   932,   933,   935,   938,   941,   942,
-     945,   949,   954,   959,   962,   967,   968,   971,   974,   979,
-     984,   989,   995,  1000,  1001,  1003,  1005,  1007,  1011,  1015,
-    1021,  1023,  1025,  1029,  1031,  1034,  1038,  1039,  1042,  1045,
-    1046,  1049,  1052,  1054,  1059,  1064,  1071,  1075,  1076,  1078,
-    1080,  1084,  1089,  1093,  1098,  1105,  1106,  1109,  1112,  1115,
-    1118,  1121,  1124,  1126,  1128,  1132,  1136,  1138,  1142,  1144,
-    1146,  1148,  1152,  1156,  1157,  1159,  1161,  1165,  1169,  1173,
-    1175,  1177,  1179,  1181,  1183,  1185,  1187,  1189,  1192,  1197,
-    1202,  1207,  1213,  1216,  1219,  1226,  1233,  1238,  1248,  1258,
-    1266,  1273,  1280,  1285,  1295,  1305,  1313,  1318,  1325,  1332,
-    1342,  1352,  1359,  1361,  1363,  1365,  1367,  1369,  1371,  1373,
-    1375,  1379,  1380,  1382,  1387,  1389,  1393,  1398,  1400,  1404,
-    1407,  1411,  1415,  1417,  1421,  1424,  1429,  1431,  1433,  1435,
-    1437,  1439,  1441,  1443,  1445,  1450,  1454,  1458,  1461,  1464,
-    1466,  1469,  1472,  1474,  1476,  1478,  1480,  1482,  1484,  1486,
-    1491,  1496,  1501,  1505,  1509,  1513,  1517,  1522,  1526,  1531,
-    1533,  1535,  1537,  1539,  1541,  1545,  1550,  1554,  1559,  1563,
-    1568,  1572,  1578,  1582,  1586,  1590,  1594,  1598,  1602,  1606,
-    1610,  1614,  1618,  1622,  1626,  1630,  1634,  1638,  1642,  1646,
-    1650,  1654,  1658,  1662,  1666,  1670,  1673,  1676,  1679,  1682,
-    1685,  1688,  1692,  1696,  1700,  1704,  1708,  1712,  1716,  1720,
-    1722,  1724,  1726,  1728,  1730,  1732
-};
-
-/* YYRHS -- A `-1'-separated list of the rules' RHS.  */
-static const yytype_int16 yyrhs[] =
-{
-     148,     0,    -1,   149,    -1,    -1,   149,   150,    -1,   152,
-      -1,   151,   152,    -1,    57,     7,    -1,   151,    57,     7,
-      -1,   153,    -1,   156,    -1,   161,    -1,   162,    -1,   169,
-      -1,   163,    -1,   172,    -1,   175,    -1,   173,    -1,   182,
-      -1,   176,    -1,   177,    -1,   181,    -1,   168,    -1,   247,
-     131,    -1,    12,   152,    -1,    13,   248,   152,    -1,    14,
-     164,   131,    -1,    18,   248,   156,    -1,    22,   164,   131,
-      -1,    24,   236,   131,    -1,    42,   165,   152,    -1,    45,
-     257,   167,    -1,    45,   167,    -1,    51,   257,   167,    -1,
-      70,   257,   167,    -1,    70,   167,    -1,    74,   152,    -1,
-      89,   257,   131,    -1,     1,   131,    -1,   154,   155,    47,
-     165,   138,   139,    -1,   154,   155,    47,   165,   138,   157,
-     139,    -1,   154,   155,    47,   165,   138,     1,   139,    -1,
-      -1,    62,    -1,    59,    -1,    -1,    61,    -1,   138,   139,
-      -1,   138,   157,   139,    -1,   138,     1,   139,    -1,   150,
-      -1,   157,   150,    -1,   257,    -1,   257,    11,   257,    -1,
-     158,   112,   257,    -1,   158,   112,   257,    11,   257,    -1,
-      -1,   158,    -1,   134,    -1,   158,    -1,    83,   235,   131,
-      -1,    83,   257,    30,   160,   131,    -1,    83,   257,    52,
-     159,   131,    -1,    66,   235,   131,    -1,   259,    93,   258,
-     131,    -1,   259,   104,   258,   131,    -1,   259,   101,   258,
-     131,    -1,   259,   103,   258,   131,    -1,   259,    97,   258,
-     131,    -1,   259,   102,   258,   131,    -1,   259,    98,   258,
-     131,    -1,   259,    94,   258,   131,    -1,   259,    95,   258,
-     131,    -1,   259,    96,   258,   131,    -1,   259,   106,   258,
-     131,    -1,   259,   105,   258,   131,    -1,   259,   135,   258,
-     131,    -1,   259,   136,   258,   131,    -1,   259,    99,   258,
-     131,    -1,   259,   100,   258,   131,    -1,    -1,   165,    -1,
-       3,    -1,   164,    -1,     7,    -1,    26,   152,    -1,   156,
-      -1,    67,   131,    -1,    67,   258,   131,    -1,   131,    -1,
-     170,    -1,    62,   170,    -1,    59,   170,    -1,   189,    -1,
-     220,    -1,   185,    -1,   171,    -1,   197,    -1,   223,    -1,
-      35,   257,   131,    -1,    35,   257,    30,   160,   131,    -1,
-      35,   257,    52,   159,   131,    -1,    35,   223,    -1,    32,
-       9,    -1,    26,   152,    87,   257,   131,    -1,    87,   257,
-     167,    -1,    19,   257,    37,   257,   248,   167,    -1,    19,
-     257,    37,   174,   248,   167,    -1,    19,   257,   248,   167,
-      -1,    33,   257,    37,   257,   167,    -1,    33,   257,    37,
-     174,   167,    -1,    33,   257,   167,    -1,    33,   174,   167,
-      -1,    33,    55,   165,    37,   257,   167,    -1,    34,   257,
-      37,   257,   167,    -1,    34,   257,    37,   257,   251,   167,
-      -1,    34,   257,    37,   174,   167,    -1,    34,   257,    37,
-     174,   251,   167,    -1,    34,   257,   167,    -1,    34,   257,
-     251,   167,    -1,   142,   235,    37,   257,   143,   152,    -1,
-     142,   235,    37,   257,   251,   143,   152,    -1,   142,   235,
-      37,   174,   143,   152,    -1,   142,   235,    37,   174,   251,
-     143,   152,    -1,   142,   235,   143,   152,    -1,   142,   235,
-     251,   143,   152,    -1,    90,   140,   235,   141,    -1,    36,
-     257,    75,   152,    -1,    36,   257,   156,    -1,    36,   257,
-      75,   152,    28,   152,    -1,    36,   257,   156,    28,   152,
-      -1,    36,   257,   203,   257,    75,   152,    -1,    36,   257,
-     203,   257,   156,    -1,    36,   257,   203,   257,    75,   152,
-      28,   152,    -1,    36,   257,   203,   257,   156,    28,   152,
-      -1,    23,   152,    -1,    78,   257,   131,    -1,    79,   257,
-     131,    -1,    78,   163,    -1,    79,   163,    -1,    78,   156,
-     178,    -1,    79,   156,   178,    -1,    -1,   178,   179,    -1,
-      16,   156,    -1,    16,   180,   156,    -1,    16,   140,   180,
-     141,   156,    -1,   165,    -1,   165,   111,   257,    -1,    76,
-     257,   131,    -1,    69,   257,   138,   183,   139,    -1,    69,
-     257,   138,     1,   139,    -1,    -1,   183,   184,    -1,    85,
-     235,   167,    -1,    53,   152,    -1,    53,    26,   152,    -1,
-     186,   165,   187,   138,   188,   139,    -1,    32,   166,   186,
-     165,   187,   138,   188,   139,    -1,   186,   165,   187,   138,
-       1,   139,    -1,    32,   166,   186,   165,   187,   138,     1,
-     139,    -1,    17,    -1,    63,    -1,    82,    -1,    -1,   111,
-     235,    -1,    -1,   188,   169,    -1,   188,   151,   169,    -1,
-     190,   165,   138,   191,   139,    -1,   190,   165,   138,     1,
-     139,    -1,    29,    -1,   192,    -1,   191,   112,    -1,   191,
-     112,   192,    -1,   165,    -1,   165,    93,   257,    -1,    -1,
-      -1,    43,   194,   205,   195,   212,   230,   219,   215,    -1,
-      -1,    39,    -1,    31,   166,    -1,    32,   166,    -1,    -1,
-      -1,   196,   211,   198,   200,   199,   212,   230,   213,   219,
-     214,    -1,   210,   202,   204,    -1,   210,   203,   204,    -1,
-     210,   201,   114,   202,   204,    -1,   210,   201,   114,   203,
-     204,    -1,   242,    -1,   140,   257,   141,    -1,   165,    -1,
-     108,   165,    -1,   107,    -1,   109,    -1,   110,    -1,   108,
-      -1,   117,    -1,   127,    -1,   123,    -1,   120,    -1,   122,
-      -1,   119,    -1,   129,    -1,   124,    -1,   134,    -1,   113,
-      -1,   132,    -1,   133,    -1,   125,    -1,   118,    -1,   126,
-      -1,    15,    -1,   121,    -1,    10,    -1,   135,    -1,   137,
-      -1,    93,    -1,   104,    -1,   101,    -1,   103,    -1,    97,
-      -1,   102,    -1,    98,    -1,    94,    -1,    95,    -1,    96,
-      -1,   106,    -1,   105,    -1,    -1,   140,   206,   141,    -1,
-     140,   206,   141,    -1,    -1,   207,    -1,   206,   112,   207,
-      -1,   208,   165,   234,   229,    -1,   208,   165,   234,   218,
-      -1,   208,   140,   228,   141,   234,   229,    -1,   208,   140,
-     228,   141,   234,   218,    -1,    -1,   209,    -1,    37,    -1,
-      40,    -1,    54,    -1,    21,    -1,    21,    37,    -1,    21,
-      65,    -1,    55,    -1,    65,    -1,    80,    -1,    -1,    55,
-      -1,    65,    -1,    21,    65,    -1,    21,    -1,    80,    -1,
-      60,    -1,    41,    -1,    -1,    21,    -1,    21,    65,    -1,
-      65,    -1,    55,    -1,    80,    -1,    -1,    77,    -1,   131,
-      -1,   215,    -1,   156,    -1,   168,    -1,   130,   165,    -1,
-     130,    -1,    -1,   216,    -1,   116,   257,    -1,   116,   217,
-      -1,    -1,    86,   257,    -1,    80,   221,   131,    -1,    20,
-      80,   221,   131,    -1,    32,    80,   221,   131,    -1,   165,
-     222,    -1,   165,   222,   112,   221,    -1,    -1,    93,   243,
-      -1,    93,   231,    -1,   224,    55,   225,   131,    -1,   224,
-      21,   225,   131,    -1,   224,    65,   225,   131,    -1,   224,
-      21,    65,   225,   131,    -1,   224,    84,   225,   131,    -1,
-      -1,    20,    -1,    32,    -1,   226,    -1,   225,   112,   226,
-      -1,   165,   230,   229,    -1,   140,   228,   141,   230,   229,
-      -1,    81,    -1,   165,    -1,   140,   228,   141,    -1,   227,
-      -1,   227,   112,    -1,   227,   112,   228,    -1,    -1,    93,
-      50,    -1,    93,   258,    -1,    -1,   111,   243,    -1,   111,
-     231,    -1,     1,    -1,   142,   235,   143,   243,    -1,   142,
-     235,   143,   231,    -1,   142,   235,    37,   257,   143,   243,
-      -1,   142,     1,   143,    -1,    -1,   243,    -1,   216,    -1,
-     142,   143,   232,    -1,   142,   235,   143,   232,    -1,   142,
-     143,   233,    -1,   142,   235,   143,   233,    -1,   142,   235,
-      37,   257,   143,   232,    -1,    -1,   111,   243,    -1,   111,
-     216,    -1,   111,    27,    -1,   111,    71,    -1,   111,    74,
-      -1,   111,   233,    -1,   257,    -1,   216,    -1,   235,   112,
-     257,    -1,   235,   112,   216,    -1,   257,    -1,   236,   112,
-     257,    -1,    81,    -1,   258,    -1,   216,    -1,   237,   112,
-     237,    -1,   238,   112,   237,    -1,    -1,   240,    -1,   241,
-      -1,   240,   112,   241,    -1,   165,    93,   216,    -1,   165,
-      93,   258,    -1,   216,    -1,   258,    -1,   165,    -1,   246,
-      -1,   259,    -1,   245,    -1,   267,    -1,   266,    -1,    71,
-     257,    -1,    38,   140,   239,   141,    -1,    27,   140,   239,
-     141,    -1,    73,   140,   239,   141,    -1,    72,    73,   140,
-     239,   141,    -1,    12,   257,    -1,    74,   257,    -1,    33,
-     257,    37,   257,    26,   257,    -1,    33,   257,    37,   174,
-      26,   257,    -1,    33,   257,    26,   257,    -1,    33,   257,
-      37,   257,    26,    36,   257,    75,   257,    -1,    33,   257,
-      37,   174,    26,    36,   257,    75,   257,    -1,    33,   257,
-      26,    36,   257,    75,   257,    -1,    34,   257,    37,   257,
-      26,   257,    -1,    34,   257,    37,   174,    26,   257,    -1,
-      34,   257,    26,   257,    -1,    34,   257,    37,   257,    26,
-      36,   257,    75,   257,    -1,    34,   257,    37,   174,    26,
-      36,   257,    75,   257,    -1,    34,   257,    26,    36,   257,
-      75,   257,    -1,   142,   235,   143,   257,    -1,   142,   235,
-      37,   257,   143,   257,    -1,   142,   235,    37,   174,   143,
-     257,    -1,   142,   235,    37,   257,   143,    36,   257,    75,
-     257,    -1,   142,   235,    37,   174,   143,    36,   257,    75,
-     257,    -1,    36,   257,    75,   257,    28,   257,    -1,    49,
-      -1,   246,    -1,   242,    -1,   262,    -1,   261,    -1,   193,
-      -1,   255,    -1,   256,    -1,   254,   137,   257,    -1,    -1,
-     249,    -1,    88,   140,   250,   141,    -1,   253,    -1,   250,
-     112,   253,    -1,    88,   140,   252,   141,    -1,   253,    -1,
-     252,   112,   253,    -1,   209,   242,    -1,   257,    64,   242,
-      -1,   270,    64,   242,    -1,   259,    -1,   254,   137,   257,
-      -1,    48,   257,    -1,    44,   225,    37,   257,    -1,   264,
-      -1,   243,    -1,   244,    -1,   268,    -1,   269,    -1,   193,
-      -1,   255,    -1,   256,    -1,   140,   116,   257,   141,    -1,
-     257,   111,   257,    -1,   257,   115,   257,    -1,   257,   115,
-      -1,   115,   257,    -1,   115,    -1,    78,   257,    -1,    79,
-     257,    -1,   257,    -1,   242,    -1,   261,    -1,   262,    -1,
-     263,    -1,   259,    -1,   193,    -1,   260,   140,   239,   141,
-      -1,   260,   142,   239,   143,    -1,    58,   140,   239,   141,
-      -1,   257,   114,   165,    -1,   257,   114,    80,    -1,   257,
-     114,    27,    -1,   140,   237,   141,    -1,   140,   237,   112,
-     141,    -1,   140,   238,   141,    -1,   140,   238,   112,   141,
-      -1,     4,    -1,     5,    -1,     6,    -1,     7,    -1,     8,
-      -1,   138,   235,   139,    -1,   138,   235,   112,   139,    -1,
-     142,   235,   143,    -1,   142,   235,   112,   143,    -1,   142,
-     265,   143,    -1,   142,   265,   112,   143,    -1,   257,    91,
-     257,    -1,   265,   112,   257,    91,   257,    -1,   257,   129,
-     257,    -1,   257,   124,   257,    -1,   257,   134,   257,    -1,
-     257,   113,   257,    -1,   257,   132,   257,    -1,   257,   133,
-     257,    -1,   257,   125,   257,    -1,   257,   117,   257,    -1,
-     257,   127,   257,    -1,   257,   123,   257,    -1,   257,   120,
-     257,    -1,   257,   122,   257,    -1,   257,   119,   257,    -1,
-     257,   107,   257,    -1,   257,   109,   257,    -1,   257,   110,
-     257,    -1,   257,    92,   257,    -1,   257,   128,   257,    -1,
-     257,   118,   257,    -1,   257,    15,   257,    -1,   257,    10,
-     257,    -1,   257,   121,   257,    -1,   257,    25,   257,    -1,
-     129,   257,    -1,   124,   257,    -1,    46,   257,    -1,    56,
-     257,    -1,   126,   257,    -1,   108,   257,    -1,   257,    64,
-     257,    -1,   257,    64,   174,    -1,   270,    64,   257,    -1,
-     270,    64,   174,    -1,   257,    68,   257,    -1,   257,    68,
-     174,    -1,   270,    68,   257,    -1,   270,    68,   174,    -1,
-     129,    -1,   134,    -1,    92,    -1,   128,    -1,   107,    -1,
-     109,    -1,   110,    -1
-};
-
-/* YYRLINE[YYN] -- source line where rule number YYN was defined.  */
+  /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint16 yyrline[] =
 {
        0,   441,   441,   446,   447,   453,   454,   459,   460,   465,
@@ -1084,7 +832,7 @@ static const yytype_uint16 yyrline[] =
 };
 #endif
 
-#if YYDEBUG || YYERROR_VERBOSE || YYTOKEN_TABLE
+#if YYDEBUG || YYERROR_VERBOSE || 0
 /* YYTNAME[SYMBOL-NUM] -- String name of the symbol SYMBOL-NUM.
    First, the terminals, then, starting at YYNTOKENS, nonterminals.  */
 static const char *const yytname[] =
@@ -1111,8 +859,8 @@ static const char *const yytname[] =
   "TGREATER", "TGREATEREQUAL", "THASH", "TLESS", "TLESSEQUAL", "TMINUS",
   "TMOD", "TNOT", "TNOTEQUAL", "TOR", "TPLUS", "TQUESTION", "TSEMI",
   "TSHIFTLEFT", "TSHIFTRIGHT", "TSTAR", "TSWAP", "TASSIGNREDUCE", "TIO",
-  "TLCBR", "TRCBR", "TLP", "TRP", "TLSBR", "TRSBR", "TNOELSE", "TUMINUS",
-  "TUPLUS", "$accept", "program", "toplevel_stmt_ls", "toplevel_stmt",
+  "TLCBR", "TRCBR", "TLP", "TRP", "TLSBR", "TRSBR", "TNOELSE", "TUPLUS",
+  "TUMINUS", "$accept", "program", "toplevel_stmt_ls", "toplevel_stmt",
   "pragma_ls", "stmt", "module_decl_stmt", "access_control",
   "opt_prototype", "block_stmt", "stmt_ls", "only_ls", "opt_only_ls",
   "except_ls", "use_stmt", "require_stmt", "assignment_stmt", "opt_ident",
@@ -1143,13 +891,13 @@ static const char *const yytname[] =
   "intent_expr", "io_expr", "new_expr", "let_expr", "expr", "opt_try_expr",
   "lhs_expr", "fun_expr", "call_expr", "dot_expr", "parenthesized_expr",
   "literal_expr", "assoc_expr_ls", "binary_op_expr", "unary_op_expr",
-  "reduce_expr", "scan_expr", "reduce_scan_op_expr", 0
+  "reduce_expr", "scan_expr", "reduce_scan_op_expr", YY_NULLPTR
 };
 #endif
 
 # ifdef YYPRINT
-/* YYTOKNUM[YYLEX-NUM] -- Internal token number corresponding to
-   token YYLEX-NUM.  */
+/* YYTOKNUM[NUM] -- (External) token number corresponding to the
+   (internal) symbol number NUM (which must be that of a token).  */
 static const yytype_uint16 yytoknum[] =
 {
        0,   256,   257,   258,   259,   260,   261,   262,   263,   264,
@@ -1170,238 +918,18 @@ static const yytype_uint16 yytoknum[] =
 };
 # endif
 
-/* YYR1[YYN] -- Symbol number of symbol that rule YYN derives.  */
-static const yytype_uint16 yyr1[] =
-{
-       0,   147,   148,   149,   149,   150,   150,   151,   151,   152,
-     152,   152,   152,   152,   152,   152,   152,   152,   152,   152,
-     152,   152,   152,   152,   152,   152,   152,   152,   152,   152,
-     152,   152,   152,   152,   152,   152,   152,   152,   152,   153,
-     153,   153,   154,   154,   154,   155,   155,   156,   156,   156,
-     157,   157,   158,   158,   158,   158,   159,   159,   160,   160,
-     161,   161,   161,   162,   163,   163,   163,   163,   163,   163,
-     163,   163,   163,   163,   163,   163,   163,   163,   163,   163,
-     164,   164,   165,   166,   166,   167,   167,   168,   168,   169,
-     169,   169,   169,   169,   169,   169,   169,   170,   170,   171,
-     171,   171,   171,   172,   173,   173,   173,   173,   173,   173,
-     173,   173,   173,   173,   173,   173,   173,   173,   173,   173,
-     173,   173,   173,   173,   173,   173,   174,   175,   175,   175,
-     175,   175,   175,   175,   175,   176,   177,   177,   177,   177,
-     177,   177,   178,   178,   179,   179,   179,   180,   180,   181,
-     182,   182,   183,   183,   184,   184,   184,   185,   185,   185,
-     185,   186,   186,   186,   187,   187,   188,   188,   188,   189,
-     189,   190,   191,   191,   191,   192,   192,   194,   195,   193,
-     196,   196,   196,   196,   198,   199,   197,   200,   200,   200,
-     200,   201,   201,   202,   202,   202,   202,   202,   202,   202,
-     202,   202,   202,   202,   202,   202,   202,   202,   202,   202,
-     202,   202,   202,   202,   202,   202,   202,   202,   202,   203,
-     203,   203,   203,   203,   203,   203,   203,   203,   203,   203,
-     203,   204,   204,   205,   206,   206,   206,   207,   207,   207,
-     207,   208,   208,   209,   209,   209,   209,   209,   209,   209,
-     209,   209,   210,   210,   210,   210,   210,   210,   211,   211,
-     212,   212,   212,   212,   212,   212,   213,   213,   214,   214,
-     215,   215,   216,   216,   217,   217,   218,   218,   219,   219,
-     220,   220,   220,   221,   221,   222,   222,   222,   223,   223,
-     223,   223,   223,   224,   224,   224,   225,   225,   226,   226,
-     227,   227,   227,   228,   228,   228,   229,   229,   229,   230,
-     230,   230,   230,   231,   231,   231,   231,   232,   232,   232,
-     233,   233,   233,   233,   233,   234,   234,   234,   234,   234,
-     234,   234,   235,   235,   235,   235,   236,   236,   237,   237,
-     237,   238,   238,   239,   239,   240,   240,   241,   241,   241,
-     241,   242,   243,   243,   243,   243,   243,   243,   243,   243,
-     243,   243,   243,   243,   244,   244,   244,   244,   244,   244,
-     244,   244,   244,   244,   244,   244,   244,   244,   244,   244,
-     244,   245,   246,   247,   247,   247,   247,   247,   247,   247,
-     247,   248,   248,   249,   250,   250,   251,   252,   252,   253,
-     253,   253,   254,   254,   255,   256,   257,   257,   257,   257,
-     257,   257,   257,   257,   257,   257,   257,   257,   257,   257,
-     258,   258,   258,   259,   259,   259,   259,   260,   260,   261,
-     261,   261,   262,   262,   262,   263,   263,   263,   263,   264,
-     264,   264,   264,   264,   264,   264,   264,   264,   264,   264,
-     265,   265,   266,   266,   266,   266,   266,   266,   266,   266,
-     266,   266,   266,   266,   266,   266,   266,   266,   266,   266,
-     266,   266,   266,   266,   266,   267,   267,   267,   267,   267,
-     267,   268,   268,   268,   268,   269,   269,   269,   269,   270,
-     270,   270,   270,   270,   270,   270
-};
-
-/* YYR2[YYN] -- Number of symbols composing right hand side of rule YYN.  */
-static const yytype_uint8 yyr2[] =
-{
-       0,     2,     1,     0,     2,     1,     2,     2,     3,     1,
-       1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
-       1,     1,     1,     2,     2,     3,     3,     3,     3,     3,
-       3,     3,     2,     3,     3,     2,     2,     3,     2,     6,
-       7,     7,     0,     1,     1,     0,     1,     2,     3,     3,
-       1,     2,     1,     3,     3,     5,     0,     1,     1,     1,
-       3,     5,     5,     3,     4,     4,     4,     4,     4,     4,
-       4,     4,     4,     4,     4,     4,     4,     4,     4,     4,
-       0,     1,     1,     1,     1,     2,     1,     2,     3,     1,
-       1,     2,     2,     1,     1,     1,     1,     1,     1,     3,
-       5,     5,     2,     2,     5,     3,     6,     6,     4,     5,
-       5,     3,     3,     6,     5,     6,     5,     6,     3,     4,
-       6,     7,     6,     7,     4,     5,     4,     4,     3,     6,
-       5,     6,     5,     8,     7,     2,     3,     3,     2,     2,
-       3,     3,     0,     2,     2,     3,     5,     1,     3,     3,
-       5,     5,     0,     2,     3,     2,     3,     6,     8,     6,
-       8,     1,     1,     1,     0,     2,     0,     2,     3,     5,
-       5,     1,     1,     2,     3,     1,     3,     0,     0,     8,
-       0,     1,     2,     2,     0,     0,    10,     3,     3,     5,
-       5,     1,     3,     1,     2,     1,     1,     1,     1,     1,
-       1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
-       1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
-       1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
-       1,     0,     3,     3,     0,     1,     3,     4,     4,     6,
-       6,     0,     1,     1,     1,     1,     1,     2,     2,     1,
-       1,     1,     0,     1,     1,     2,     1,     1,     1,     1,
-       0,     1,     2,     1,     1,     1,     0,     1,     1,     1,
-       1,     1,     2,     1,     0,     1,     2,     2,     0,     2,
-       3,     4,     4,     2,     4,     0,     2,     2,     4,     4,
-       4,     5,     4,     0,     1,     1,     1,     3,     3,     5,
-       1,     1,     3,     1,     2,     3,     0,     2,     2,     0,
-       2,     2,     1,     4,     4,     6,     3,     0,     1,     1,
-       3,     4,     3,     4,     6,     0,     2,     2,     2,     2,
-       2,     2,     1,     1,     3,     3,     1,     3,     1,     1,
-       1,     3,     3,     0,     1,     1,     3,     3,     3,     1,
-       1,     1,     1,     1,     1,     1,     1,     2,     4,     4,
-       4,     5,     2,     2,     6,     6,     4,     9,     9,     7,
-       6,     6,     4,     9,     9,     7,     4,     6,     6,     9,
-       9,     6,     1,     1,     1,     1,     1,     1,     1,     1,
-       3,     0,     1,     4,     1,     3,     4,     1,     3,     2,
-       3,     3,     1,     3,     2,     4,     1,     1,     1,     1,
-       1,     1,     1,     1,     4,     3,     3,     2,     2,     1,
-       2,     2,     1,     1,     1,     1,     1,     1,     1,     4,
-       4,     4,     3,     3,     3,     3,     4,     3,     4,     1,
-       1,     1,     1,     1,     3,     4,     3,     4,     3,     4,
-       3,     5,     3,     3,     3,     3,     3,     3,     3,     3,
-       3,     3,     3,     3,     3,     3,     3,     3,     3,     3,
-       3,     3,     3,     3,     3,     2,     2,     2,     2,     2,
-       2,     3,     3,     3,     3,     3,     3,     3,     3,     1,
-       1,     1,     1,     1,     1,     1
-};
-
-/* YYDEFACT[STATE-NAME] -- Default reduction number in state STATE-NUM.
-   Performed when YYTABLE doesn't specify something else to do.  Zero
-   means the default is an error.  */
-static const yytype_uint16 yydefact[] =
-{
-       3,     0,     0,     1,     0,    82,   439,   440,   441,   442,
-     443,     0,   391,    80,   161,   391,     0,   294,    80,     0,
-       0,     0,     0,   171,    80,    80,     0,     0,   293,     0,
-       0,   181,     0,   177,     0,     0,     0,     0,   382,     0,
-       0,     0,     0,   293,   293,   162,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,   163,     0,
-       0,     0,   491,   493,     0,   494,   495,   419,     0,     0,
-     492,   489,    89,   490,     0,     0,     0,     4,     0,     5,
-       9,    45,    10,    11,    12,    14,   351,    22,    13,    90,
-      96,    15,    17,    16,    19,    20,    21,    18,    95,     0,
-      93,     0,   411,     0,    97,    94,    98,     0,   423,   407,
-     408,   354,   352,     0,     0,   412,   413,     0,   353,     0,
-     424,   425,   426,   406,   356,   355,   409,   410,     0,    38,
-      24,   362,     0,     0,   392,     0,    81,     0,     0,     0,
-       0,     0,     0,     0,     0,   411,   423,   352,   412,   413,
-     391,   353,   424,   425,     0,     0,   135,     0,   336,     0,
-     343,    84,    83,   182,   103,     0,   183,     0,     0,     0,
-       0,     0,   294,   295,   102,     0,     0,   343,     0,     0,
-       0,     0,     0,   296,     0,    86,    32,     0,   477,   404,
-       0,   478,     7,   343,   295,    92,    91,   273,   333,     0,
-     332,     0,     0,    87,   422,     0,     0,    35,     0,   357,
-       0,   343,    36,   363,     0,   142,   138,     0,   353,   142,
-     139,     0,   285,     0,     0,   332,     0,     0,   480,   418,
-     476,   479,   475,     0,    47,    50,     0,     0,   338,     0,
-     340,     0,     0,   339,     0,   332,     0,     0,     6,    46,
-       0,   164,     0,   259,   258,   184,     0,     0,     0,     0,
-      23,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,   417,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,   343,   343,     0,     0,
-       0,    25,    26,     0,    27,     0,     0,     0,     0,     0,
-       0,     0,    28,     0,    29,     0,   351,   349,     0,   344,
-     345,   350,     0,     0,     0,     0,   112,     0,     0,   111,
-       0,     0,     0,   118,     0,     0,    56,    99,     0,   219,
-     226,   227,   228,   223,   225,   221,   224,   222,   220,   230,
-     229,   128,     0,     0,    30,   234,   178,   300,     0,   301,
-     303,     0,   312,     0,   306,     0,     0,    85,    31,    33,
-       0,   183,   272,     0,    63,   420,   421,    88,     0,    34,
-     343,     0,   149,   140,   136,   141,   137,     0,   283,   280,
-      60,     0,    56,   105,    37,    49,    48,    51,     0,   444,
-       0,     0,   435,     0,   437,     0,     0,     0,     0,     0,
-       0,   448,     8,     0,     0,     0,     0,   252,     0,     0,
-       0,     0,     0,   390,   472,   471,   474,   482,   481,   486,
-     485,   468,   465,   466,   467,   415,   455,   434,   433,   432,
-     416,   459,   470,   464,   462,   473,   463,   461,   453,   458,
-     460,   469,   452,   456,   457,   454,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,   484,   483,   488,   487,   246,   243,
-     244,   245,   249,   250,   251,     0,     0,   394,     0,     0,
-       0,     0,     0,     0,     0,     0,   446,   391,   391,   108,
-     281,   337,     0,     0,   359,     0,   282,   164,     0,     0,
-       0,   366,     0,     0,     0,   372,     0,     0,     0,   119,
-     490,    59,     0,    52,    57,     0,   127,     0,     0,     0,
-     358,     0,   235,     0,   242,   260,     0,   304,     0,     0,
-     311,   407,     0,   298,   405,   297,   431,   335,   334,     0,
-       0,     0,   360,     0,   143,   287,   407,     0,     0,     0,
-     445,   414,   436,   341,   438,   342,     0,     0,   447,   124,
-     376,     0,   450,   449,     0,     0,   165,     0,     0,   175,
-       0,   172,   256,   253,   254,   257,   185,     0,     0,   289,
-     288,   290,   292,    64,    71,    72,    73,    68,    70,    78,
-      79,    66,    69,    67,    65,    75,    74,    76,    77,   429,
-     430,   247,   248,   399,     0,   393,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,   104,   347,
-     348,   346,     0,     0,   126,     0,     0,   110,     0,   109,
-       0,     0,   116,     0,     0,   114,     0,     0,   397,     0,
-     100,     0,   101,     0,     0,   130,     0,   132,   241,   233,
-       0,   325,   261,   264,   263,   265,     0,   302,   305,   306,
-       0,     0,   307,   308,   151,     0,     0,   150,   153,   361,
-       0,   144,   147,     0,   284,    61,    62,     0,     0,     0,
-       0,   125,     0,     0,     0,   293,   170,     0,   173,   169,
-     255,   260,   216,   214,   195,   198,   196,   197,   208,   199,
-     212,   204,   202,   215,   203,   201,   206,   211,   213,   200,
-     205,   209,   210,   207,   217,   218,     0,   193,     0,   231,
-     231,   191,   291,   395,   423,   423,     0,     0,     0,     0,
-       0,     0,     0,     0,   107,   106,     0,   113,     0,     0,
-     365,     0,   364,     0,     0,   371,   117,     0,   370,   115,
-       0,   396,    54,    53,   129,   381,   131,     0,   236,     0,
-       0,   306,   262,   278,   299,   316,     0,   446,     0,   155,
-       0,     0,     0,   145,     0,   122,   378,     0,     0,   120,
-     377,     0,   451,     0,    39,     0,   159,    80,   293,   293,
-     157,   293,   167,   176,   174,     0,   194,     0,     0,   234,
-     187,   188,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,   293,   369,     0,     0,   375,     0,     0,   398,     0,
-       0,   134,   325,   328,   329,   330,     0,   327,   331,   407,
-     274,   238,   237,     0,     0,     0,   314,   407,   156,   154,
-       0,   148,     0,   123,     0,   121,    41,    40,   168,   266,
-     192,   193,   231,   231,     0,     0,     0,     0,     0,     0,
-       0,   160,   158,     0,     0,     0,     0,    55,   133,   306,
-     317,     0,   275,   277,   276,   279,   270,   271,   179,     0,
-     146,     0,     0,   267,   278,   189,   190,   232,     0,     0,
-       0,     0,     0,     0,   368,   367,   374,   373,   240,   239,
-     319,   320,   322,   407,     0,   446,   407,   380,   379,     0,
-       0,   321,   323,   268,   186,   269,   317,   324
-};
-
-/* YYDEFGOTO[NTERM-NUM].  */
-static const yytype_int16 yydefgoto[] =
-{
-      -1,     1,     2,   235,    78,   536,    80,    81,   250,    82,
-     236,   531,   535,   532,    83,    84,    85,   162,    86,   166,
-     186,    87,    88,    89,    90,    91,    92,   634,    93,    94,
-      95,   393,   564,   693,    96,    97,   560,   688,    98,    99,
-     425,   705,   100,   101,   590,   591,   145,   179,   545,   103,
-     104,   427,   711,   596,   738,   739,   362,   820,   366,   541,
-     542,   543,   495,   597,   255,   676,   904,   934,   898,   198,
-     893,   851,   854,   105,   223,   398,   106,   107,   182,   183,
-     370,   371,   553,   374,   550,   921,   848,   781,   237,   157,
-     241,   242,   328,   329,   330,   146,   109,   110,   111,   147,
-     113,   133,   134,   496,   344,   657,   497,   114,   148,   149,
-     204,   331,   151,   119,   152,   153,   122,   123,   246,   124,
-     125,   126,   127,   128
-};
-
-/* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
-   STATE-NUM.  */
 #define YYPACT_NINF -775
+
+#define yypact_value_is_default(Yystate) \
+  (!!((Yystate) == (-775)))
+
+#define YYTABLE_NINF -447
+
+#define yytable_value_is_error(Yytable_value) \
+  0
+
+  /* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
+     STATE-NUM.  */
 static const yytype_int16 yypact[] =
 {
     -775,   100,  2520,  -775,   -37,  -775,  -775,  -775,  -775,  -775,
@@ -1500,7 +1028,108 @@ static const yytype_int16 yypact[] =
    10297,  -775,  -775,  -775,  -775,  -775,  7908,  -775
 };
 
-/* YYPGOTO[NTERM-NUM].  */
+  /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
+     Performed when YYTABLE does not specify something else to do.  Zero
+     means the default is an error.  */
+static const yytype_uint16 yydefact[] =
+{
+       3,     0,     0,     1,     0,    82,   439,   440,   441,   442,
+     443,     0,   391,    80,   161,   391,     0,   294,    80,     0,
+       0,     0,     0,   171,    80,    80,     0,     0,   293,     0,
+       0,   181,     0,   177,     0,     0,     0,     0,   382,     0,
+       0,     0,     0,   293,   293,   162,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,   163,     0,
+       0,     0,   491,   493,     0,   494,   495,   419,     0,     0,
+     492,   489,    89,   490,     0,     0,     0,     4,     0,     5,
+       9,    45,    10,    11,    12,    14,   351,    22,    13,    90,
+      96,    15,    17,    16,    19,    20,    21,    18,    95,     0,
+      93,     0,   411,     0,    97,    94,    98,     0,   423,   407,
+     408,   354,   352,     0,     0,   412,   413,     0,   353,     0,
+     424,   425,   426,   406,   356,   355,   409,   410,     0,    38,
+      24,   362,     0,     0,   392,     0,    81,     0,     0,     0,
+       0,     0,     0,     0,     0,   411,   423,   352,   412,   413,
+     391,   353,   424,   425,     0,     0,   135,     0,   336,     0,
+     343,    84,    83,   182,   103,     0,   183,     0,     0,     0,
+       0,     0,   294,   295,   102,     0,     0,   343,     0,     0,
+       0,     0,     0,   296,     0,    86,    32,     0,   477,   404,
+       0,   478,     7,   343,   295,    92,    91,   273,   333,     0,
+     332,     0,     0,    87,   422,     0,     0,    35,     0,   357,
+       0,   343,    36,   363,     0,   142,   138,     0,   353,   142,
+     139,     0,   285,     0,     0,   332,     0,     0,   480,   418,
+     476,   479,   475,     0,    47,    50,     0,     0,   338,     0,
+     340,     0,     0,   339,     0,   332,     0,     0,     6,    46,
+       0,   164,     0,   259,   258,   184,     0,     0,     0,     0,
+      23,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   417,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,   343,   343,     0,     0,
+       0,    25,    26,     0,    27,     0,     0,     0,     0,     0,
+       0,     0,    28,     0,    29,     0,   351,   349,     0,   344,
+     345,   350,     0,     0,     0,     0,   112,     0,     0,   111,
+       0,     0,     0,   118,     0,     0,    56,    99,     0,   219,
+     226,   227,   228,   223,   225,   221,   224,   222,   220,   230,
+     229,   128,     0,     0,    30,   234,   178,   300,     0,   301,
+     303,     0,   312,     0,   306,     0,     0,    85,    31,    33,
+       0,   183,   272,     0,    63,   420,   421,    88,     0,    34,
+     343,     0,   149,   140,   136,   141,   137,     0,   283,   280,
+      60,     0,    56,   105,    37,    49,    48,    51,     0,   444,
+       0,     0,   435,     0,   437,     0,     0,     0,     0,     0,
+       0,   448,     8,     0,     0,     0,     0,   252,     0,     0,
+       0,     0,     0,   390,   472,   471,   474,   482,   481,   486,
+     485,   468,   465,   466,   467,   415,   455,   434,   433,   432,
+     416,   459,   470,   464,   462,   473,   463,   461,   453,   458,
+     460,   469,   452,   456,   457,   454,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   484,   483,   488,   487,   246,   243,
+     244,   245,   249,   250,   251,     0,     0,   394,     0,     0,
+       0,     0,     0,     0,     0,     0,   446,   391,   391,   108,
+     281,   337,     0,     0,   359,     0,   282,   164,     0,     0,
+       0,   366,     0,     0,     0,   372,     0,     0,     0,   119,
+     490,    59,     0,    52,    57,     0,   127,     0,     0,     0,
+     358,     0,   235,     0,   242,   260,     0,   304,     0,     0,
+     311,   407,     0,   298,   405,   297,   431,   335,   334,     0,
+       0,     0,   360,     0,   143,   287,   407,     0,     0,     0,
+     445,   414,   436,   341,   438,   342,     0,     0,   447,   124,
+     376,     0,   450,   449,     0,     0,   165,     0,     0,   175,
+       0,   172,   256,   253,   254,   257,   185,     0,     0,   289,
+     288,   290,   292,    64,    71,    72,    73,    68,    70,    78,
+      79,    66,    69,    67,    65,    75,    74,    76,    77,   429,
+     430,   247,   248,   399,     0,   393,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,   104,   347,
+     348,   346,     0,     0,   126,     0,     0,   110,     0,   109,
+       0,     0,   116,     0,     0,   114,     0,     0,   397,     0,
+     100,     0,   101,     0,     0,   130,     0,   132,   241,   233,
+       0,   325,   261,   264,   263,   265,     0,   302,   305,   306,
+       0,     0,   307,   308,   151,     0,     0,   150,   153,   361,
+       0,   144,   147,     0,   284,    61,    62,     0,     0,     0,
+       0,   125,     0,     0,     0,   293,   170,     0,   173,   169,
+     255,   260,   216,   214,   195,   198,   196,   197,   208,   199,
+     212,   204,   202,   215,   203,   201,   206,   211,   213,   200,
+     205,   209,   210,   207,   217,   218,     0,   193,     0,   231,
+     231,   191,   291,   395,   423,   423,     0,     0,     0,     0,
+       0,     0,     0,     0,   107,   106,     0,   113,     0,     0,
+     365,     0,   364,     0,     0,   371,   117,     0,   370,   115,
+       0,   396,    54,    53,   129,   381,   131,     0,   236,     0,
+       0,   306,   262,   278,   299,   316,     0,   446,     0,   155,
+       0,     0,     0,   145,     0,   122,   378,     0,     0,   120,
+     377,     0,   451,     0,    39,     0,   159,    80,   293,   293,
+     157,   293,   167,   176,   174,     0,   194,     0,     0,   234,
+     187,   188,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,   293,   369,     0,     0,   375,     0,     0,   398,     0,
+       0,   134,   325,   328,   329,   330,     0,   327,   331,   407,
+     274,   238,   237,     0,     0,     0,   314,   407,   156,   154,
+       0,   148,     0,   123,     0,   121,    41,    40,   168,   266,
+     192,   193,   231,   231,     0,     0,     0,     0,     0,     0,
+       0,   160,   158,     0,     0,     0,     0,    55,   133,   306,
+     317,     0,   275,   277,   276,   279,   270,   271,   179,     0,
+     146,     0,     0,   267,   278,   189,   190,   232,     0,     0,
+       0,     0,     0,     0,   368,   367,   374,   373,   240,   239,
+     319,   320,   322,   407,     0,   446,   407,   380,   379,     0,
+       0,   321,   323,   268,   186,   269,   317,   324
+};
+
+  /* YYPGOTO[NTERM-NUM].  */
 static const yytype_int16 yypgoto[] =
 {
     -775,  -775,  -775,    -1,  -660,  1705,  -775,  -775,  -775,  1444,
@@ -1518,10 +1147,27 @@ static const yytype_int16 yypgoto[] =
     -775,  -775,  -775,  -308
 };
 
-/* YYTABLE[YYPACT[STATE-NUM]].  What to do in state STATE-NUM.  If
-   positive, shift that token.  If negative, reduce the rule which
-   number is the opposite.  If YYTABLE_NINF, syntax error.  */
-#define YYTABLE_NINF -447
+  /* YYDEFGOTO[NTERM-NUM].  */
+static const yytype_int16 yydefgoto[] =
+{
+      -1,     1,     2,   235,    78,   536,    80,    81,   250,    82,
+     236,   531,   535,   532,    83,    84,    85,   162,    86,   166,
+     186,    87,    88,    89,    90,    91,    92,   634,    93,    94,
+      95,   393,   564,   693,    96,    97,   560,   688,    98,    99,
+     425,   705,   100,   101,   590,   591,   145,   179,   545,   103,
+     104,   427,   711,   596,   738,   739,   362,   820,   366,   541,
+     542,   543,   495,   597,   255,   676,   904,   934,   898,   198,
+     893,   851,   854,   105,   223,   398,   106,   107,   182,   183,
+     370,   371,   553,   374,   550,   921,   848,   781,   237,   157,
+     241,   242,   328,   329,   330,   146,   109,   110,   111,   147,
+     113,   133,   134,   496,   344,   657,   497,   114,   148,   149,
+     204,   331,   151,   119,   152,   153,   122,   123,   246,   124,
+     125,   126,   127,   128
+};
+
+  /* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
+     positive, shift that token.  If negative, reduce the rule whose
+     number is the opposite.  If YYTABLE_NINF, syntax error.  */
 static const yytype_int16 yytable[] =
 {
      117,    77,   499,   565,   195,   196,   740,   544,   418,   131,
@@ -2886,12 +2532,6 @@ static const yytype_int16 yytable[] =
      274,     0,   275,   276,   277,   278,   279,   280,   281,   282,
      283,     0,   284,   285,   286,     0,     0,   287,   288,   289
 };
-
-#define yypact_value_is_default(yystate) \
-  ((yystate) == (-775))
-
-#define yytable_value_is_error(yytable_value) \
-  YYID (0)
 
 static const yytype_int16 yycheck[] =
 {
@@ -4258,8 +3898,8 @@ static const yytype_int16 yycheck[] =
      125,    -1,   127,   128,   129,    -1,    -1,   132,   133,   134
 };
 
-/* YYSTOS[STATE-NUM] -- The (internal number of the) accessing
-   symbol of state STATE-NUM.  */
+  /* YYSTOS[STATE-NUM] -- The (internal number of the) accessing
+     symbol of state STATE-NUM.  */
 static const yytype_uint16 yystos[] =
 {
        0,   148,   149,     0,     1,     3,     4,     5,     6,     7,
@@ -4358,103 +3998,177 @@ static const yytype_uint16 yystos[] =
      257,   232,   233,   131,   214,   215,   143,   232
 };
 
-#define yyerrok		(yyerrstatus = 0)
-#define yyclearin	(yychar = YYEMPTY)
-#define YYEMPTY		(-2)
-#define YYEOF		0
+  /* YYR1[YYN] -- Symbol number of symbol that rule YYN derives.  */
+static const yytype_uint16 yyr1[] =
+{
+       0,   147,   148,   149,   149,   150,   150,   151,   151,   152,
+     152,   152,   152,   152,   152,   152,   152,   152,   152,   152,
+     152,   152,   152,   152,   152,   152,   152,   152,   152,   152,
+     152,   152,   152,   152,   152,   152,   152,   152,   152,   153,
+     153,   153,   154,   154,   154,   155,   155,   156,   156,   156,
+     157,   157,   158,   158,   158,   158,   159,   159,   160,   160,
+     161,   161,   161,   162,   163,   163,   163,   163,   163,   163,
+     163,   163,   163,   163,   163,   163,   163,   163,   163,   163,
+     164,   164,   165,   166,   166,   167,   167,   168,   168,   169,
+     169,   169,   169,   169,   169,   169,   169,   170,   170,   171,
+     171,   171,   171,   172,   173,   173,   173,   173,   173,   173,
+     173,   173,   173,   173,   173,   173,   173,   173,   173,   173,
+     173,   173,   173,   173,   173,   173,   174,   175,   175,   175,
+     175,   175,   175,   175,   175,   176,   177,   177,   177,   177,
+     177,   177,   178,   178,   179,   179,   179,   180,   180,   181,
+     182,   182,   183,   183,   184,   184,   184,   185,   185,   185,
+     185,   186,   186,   186,   187,   187,   188,   188,   188,   189,
+     189,   190,   191,   191,   191,   192,   192,   194,   195,   193,
+     196,   196,   196,   196,   198,   199,   197,   200,   200,   200,
+     200,   201,   201,   202,   202,   202,   202,   202,   202,   202,
+     202,   202,   202,   202,   202,   202,   202,   202,   202,   202,
+     202,   202,   202,   202,   202,   202,   202,   202,   202,   203,
+     203,   203,   203,   203,   203,   203,   203,   203,   203,   203,
+     203,   204,   204,   205,   206,   206,   206,   207,   207,   207,
+     207,   208,   208,   209,   209,   209,   209,   209,   209,   209,
+     209,   209,   210,   210,   210,   210,   210,   210,   211,   211,
+     212,   212,   212,   212,   212,   212,   213,   213,   214,   214,
+     215,   215,   216,   216,   217,   217,   218,   218,   219,   219,
+     220,   220,   220,   221,   221,   222,   222,   222,   223,   223,
+     223,   223,   223,   224,   224,   224,   225,   225,   226,   226,
+     227,   227,   227,   228,   228,   228,   229,   229,   229,   230,
+     230,   230,   230,   231,   231,   231,   231,   232,   232,   232,
+     233,   233,   233,   233,   233,   234,   234,   234,   234,   234,
+     234,   234,   235,   235,   235,   235,   236,   236,   237,   237,
+     237,   238,   238,   239,   239,   240,   240,   241,   241,   241,
+     241,   242,   243,   243,   243,   243,   243,   243,   243,   243,
+     243,   243,   243,   243,   244,   244,   244,   244,   244,   244,
+     244,   244,   244,   244,   244,   244,   244,   244,   244,   244,
+     244,   245,   246,   247,   247,   247,   247,   247,   247,   247,
+     247,   248,   248,   249,   250,   250,   251,   252,   252,   253,
+     253,   253,   254,   254,   255,   256,   257,   257,   257,   257,
+     257,   257,   257,   257,   257,   257,   257,   257,   257,   257,
+     258,   258,   258,   259,   259,   259,   259,   260,   260,   261,
+     261,   261,   262,   262,   262,   263,   263,   263,   263,   264,
+     264,   264,   264,   264,   264,   264,   264,   264,   264,   264,
+     265,   265,   266,   266,   266,   266,   266,   266,   266,   266,
+     266,   266,   266,   266,   266,   266,   266,   266,   266,   266,
+     266,   266,   266,   266,   266,   267,   267,   267,   267,   267,
+     267,   268,   268,   268,   268,   269,   269,   269,   269,   270,
+     270,   270,   270,   270,   270,   270
+};
 
-#define YYACCEPT	goto yyacceptlab
-#define YYABORT		goto yyabortlab
-#define YYERROR		goto yyerrorlab
+  /* YYR2[YYN] -- Number of symbols on the right hand side of rule YYN.  */
+static const yytype_uint8 yyr2[] =
+{
+       0,     2,     1,     0,     2,     1,     2,     2,     3,     1,
+       1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
+       1,     1,     1,     2,     2,     3,     3,     3,     3,     3,
+       3,     3,     2,     3,     3,     2,     2,     3,     2,     6,
+       7,     7,     0,     1,     1,     0,     1,     2,     3,     3,
+       1,     2,     1,     3,     3,     5,     0,     1,     1,     1,
+       3,     5,     5,     3,     4,     4,     4,     4,     4,     4,
+       4,     4,     4,     4,     4,     4,     4,     4,     4,     4,
+       0,     1,     1,     1,     1,     2,     1,     2,     3,     1,
+       1,     2,     2,     1,     1,     1,     1,     1,     1,     3,
+       5,     5,     2,     2,     5,     3,     6,     6,     4,     5,
+       5,     3,     3,     6,     5,     6,     5,     6,     3,     4,
+       6,     7,     6,     7,     4,     5,     4,     4,     3,     6,
+       5,     6,     5,     8,     7,     2,     3,     3,     2,     2,
+       3,     3,     0,     2,     2,     3,     5,     1,     3,     3,
+       5,     5,     0,     2,     3,     2,     3,     6,     8,     6,
+       8,     1,     1,     1,     0,     2,     0,     2,     3,     5,
+       5,     1,     1,     2,     3,     1,     3,     0,     0,     8,
+       0,     1,     2,     2,     0,     0,    10,     3,     3,     5,
+       5,     1,     3,     1,     2,     1,     1,     1,     1,     1,
+       1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
+       1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
+       1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
+       1,     0,     3,     3,     0,     1,     3,     4,     4,     6,
+       6,     0,     1,     1,     1,     1,     1,     2,     2,     1,
+       1,     1,     0,     1,     1,     2,     1,     1,     1,     1,
+       0,     1,     2,     1,     1,     1,     0,     1,     1,     1,
+       1,     1,     2,     1,     0,     1,     2,     2,     0,     2,
+       3,     4,     4,     2,     4,     0,     2,     2,     4,     4,
+       4,     5,     4,     0,     1,     1,     1,     3,     3,     5,
+       1,     1,     3,     1,     2,     3,     0,     2,     2,     0,
+       2,     2,     1,     4,     4,     6,     3,     0,     1,     1,
+       3,     4,     3,     4,     6,     0,     2,     2,     2,     2,
+       2,     2,     1,     1,     3,     3,     1,     3,     1,     1,
+       1,     3,     3,     0,     1,     1,     3,     3,     3,     1,
+       1,     1,     1,     1,     1,     1,     1,     2,     4,     4,
+       4,     5,     2,     2,     6,     6,     4,     9,     9,     7,
+       6,     6,     4,     9,     9,     7,     4,     6,     6,     9,
+       9,     6,     1,     1,     1,     1,     1,     1,     1,     1,
+       3,     0,     1,     4,     1,     3,     4,     1,     3,     2,
+       3,     3,     1,     3,     2,     4,     1,     1,     1,     1,
+       1,     1,     1,     1,     4,     3,     3,     2,     2,     1,
+       2,     2,     1,     1,     1,     1,     1,     1,     1,     4,
+       4,     4,     3,     3,     3,     3,     4,     3,     4,     1,
+       1,     1,     1,     1,     3,     4,     3,     4,     3,     4,
+       3,     5,     3,     3,     3,     3,     3,     3,     3,     3,
+       3,     3,     3,     3,     3,     3,     3,     3,     3,     3,
+       3,     3,     3,     3,     3,     2,     2,     2,     2,     2,
+       2,     3,     3,     3,     3,     3,     3,     3,     3,     1,
+       1,     1,     1,     1,     1,     1
+};
 
 
-/* Like YYERROR except do call yyerror.  This remains here temporarily
-   to ease the transition to the new meaning of YYERROR, for GCC.
-   Once GCC version 2 has supplanted version 1, this can go.  However,
-   YYFAIL appears to be in use.  Nevertheless, it is formally deprecated
-   in Bison 2.4.2's NEWS entry, where a plan to phase it out is
-   discussed.  */
+#define yyerrok         (yyerrstatus = 0)
+#define yyclearin       (yychar = YYEMPTY)
+#define YYEMPTY         (-2)
+#define YYEOF           0
 
-#define YYFAIL		goto yyerrlab
-#if defined YYFAIL
-  /* This is here to suppress warnings from the GCC cpp's
-     -Wunused-macros.  Normally we don't worry about that warning, but
-     some users do, and we want to make it easy for users to remove
-     YYFAIL uses, which will produce warnings from Bison 2.5.  */
-#endif
+#define YYACCEPT        goto yyacceptlab
+#define YYABORT         goto yyabortlab
+#define YYERROR         goto yyerrorlab
+
 
 #define YYRECOVERING()  (!!yyerrstatus)
 
-#define YYBACKUP(Token, Value)					\
-do								\
-  if (yychar == YYEMPTY && yylen == 1)				\
-    {								\
-      yychar = (Token);						\
-      yylval = (Value);						\
-      YYPOPSTACK (1);						\
-      goto yybackup;						\
-    }								\
-  else								\
-    {								\
+#define YYBACKUP(Token, Value)                                  \
+do                                                              \
+  if (yychar == YYEMPTY)                                        \
+    {                                                           \
+      yychar = (Token);                                         \
+      yylval = (Value);                                         \
+      YYPOPSTACK (yylen);                                       \
+      yystate = *yyssp;                                         \
+      goto yybackup;                                            \
+    }                                                           \
+  else                                                          \
+    {                                                           \
       yyerror (&yylloc, context, YY_("syntax error: cannot back up")); \
-      YYERROR;							\
-    }								\
-while (YYID (0))
+      YYERROR;                                                  \
+    }                                                           \
+while (0)
 
-
-#define YYTERROR	1
-#define YYERRCODE	256
+/* Error token number */
+#define YYTERROR        1
+#define YYERRCODE       256
 
 
 /* YYLLOC_DEFAULT -- Set CURRENT to span from RHS[1] to RHS[N].
    If N is 0, then set CURRENT to the empty location which ends
    the previous symbol: RHS[0] (always defined).  */
 
-#define YYRHSLOC(Rhs, K) ((Rhs)[K])
 #ifndef YYLLOC_DEFAULT
-# define YYLLOC_DEFAULT(Current, Rhs, N)				\
-    do									\
-      if (YYID (N))                                                    \
-	{								\
-	  (Current).first_line   = YYRHSLOC (Rhs, 1).first_line;	\
-	  (Current).first_column = YYRHSLOC (Rhs, 1).first_column;	\
-	  (Current).last_line    = YYRHSLOC (Rhs, N).last_line;		\
-	  (Current).last_column  = YYRHSLOC (Rhs, N).last_column;	\
-	}								\
-      else								\
-	{								\
-	  (Current).first_line   = (Current).last_line   =		\
-	    YYRHSLOC (Rhs, 0).last_line;				\
-	  (Current).first_column = (Current).last_column =		\
-	    YYRHSLOC (Rhs, 0).last_column;				\
-	}								\
-    while (YYID (0))
+# define YYLLOC_DEFAULT(Current, Rhs, N)                                \
+    do                                                                  \
+      if (N)                                                            \
+        {                                                               \
+          (Current).first_line   = YYRHSLOC (Rhs, 1).first_line;        \
+          (Current).first_column = YYRHSLOC (Rhs, 1).first_column;      \
+          (Current).last_line    = YYRHSLOC (Rhs, N).last_line;         \
+          (Current).last_column  = YYRHSLOC (Rhs, N).last_column;       \
+        }                                                               \
+      else                                                              \
+        {                                                               \
+          (Current).first_line   = (Current).last_line   =              \
+            YYRHSLOC (Rhs, 0).last_line;                                \
+          (Current).first_column = (Current).last_column =              \
+            YYRHSLOC (Rhs, 0).last_column;                              \
+        }                                                               \
+    while (0)
 #endif
 
+#define YYRHSLOC(Rhs, K) ((Rhs)[K])
 
-/* YY_LOCATION_PRINT -- Print the location on the stream.
-   This macro was not mandated originally: define only if we know
-   we won't break user code: when these are the locations we know.  */
-
-#ifndef YY_LOCATION_PRINT
-# if defined YYLTYPE_IS_TRIVIAL && YYLTYPE_IS_TRIVIAL
-#  define YY_LOCATION_PRINT(File, Loc)			\
-     fprintf (File, "%d.%d-%d.%d",			\
-	      (Loc).first_line, (Loc).first_column,	\
-	      (Loc).last_line,  (Loc).last_column)
-# else
-#  define YY_LOCATION_PRINT(File, Loc) ((void) 0)
-# endif
-#endif
-
-
-/* YYLEX -- calling `yylex' with the right arguments.  */
-
-#ifdef YYLEX_PARAM
-# define YYLEX yylex (&yylval, &yylloc, YYLEX_PARAM)
-#else
-# define YYLEX yylex (&yylval, &yylloc)
-#endif
 
 /* Enable debugging if requested.  */
 #if YYDEBUG
@@ -4464,58 +4178,87 @@ while (YYID (0))
 #  define YYFPRINTF fprintf
 # endif
 
-# define YYDPRINTF(Args)			\
-do {						\
-  if (yydebug)					\
-    YYFPRINTF Args;				\
-} while (YYID (0))
-
-# define YY_SYMBOL_PRINT(Title, Type, Value, Location)			  \
-do {									  \
-  if (yydebug)								  \
-    {									  \
-      YYFPRINTF (stderr, "%s ", Title);					  \
-      yy_symbol_print (stderr,						  \
-		  Type, Value, Location, context); \
-      YYFPRINTF (stderr, "\n");						  \
-    }									  \
-} while (YYID (0))
+# define YYDPRINTF(Args)                        \
+do {                                            \
+  if (yydebug)                                  \
+    YYFPRINTF Args;                             \
+} while (0)
 
 
-/*--------------------------------.
-| Print this symbol on YYOUTPUT.  |
-`--------------------------------*/
+/* YY_LOCATION_PRINT -- Print the location on the stream.
+   This macro was not mandated originally: define only if we know
+   we won't break user code: when these are the locations we know.  */
 
-/*ARGSUSED*/
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
+#ifndef YY_LOCATION_PRINT
+# if defined YYLTYPE_IS_TRIVIAL && YYLTYPE_IS_TRIVIAL
+
+/* Print *YYLOCP on YYO.  Private, do not rely on its existence. */
+
+YY_ATTRIBUTE_UNUSED
+static unsigned
+yy_location_print_ (FILE *yyo, YYLTYPE const * const yylocp)
+{
+  unsigned res = 0;
+  int end_col = 0 != yylocp->last_column ? yylocp->last_column - 1 : 0;
+  if (0 <= yylocp->first_line)
+    {
+      res += YYFPRINTF (yyo, "%d", yylocp->first_line);
+      if (0 <= yylocp->first_column)
+        res += YYFPRINTF (yyo, ".%d", yylocp->first_column);
+    }
+  if (0 <= yylocp->last_line)
+    {
+      if (yylocp->first_line < yylocp->last_line)
+        {
+          res += YYFPRINTF (yyo, "-%d", yylocp->last_line);
+          if (0 <= end_col)
+            res += YYFPRINTF (yyo, ".%d", end_col);
+        }
+      else if (0 <= end_col && yylocp->first_column < end_col)
+        res += YYFPRINTF (yyo, "-%d", end_col);
+    }
+  return res;
+ }
+
+#  define YY_LOCATION_PRINT(File, Loc)          \
+  yy_location_print_ (File, &(Loc))
+
+# else
+#  define YY_LOCATION_PRINT(File, Loc) ((void) 0)
+# endif
+#endif
+
+
+# define YY_SYMBOL_PRINT(Title, Type, Value, Location)                    \
+do {                                                                      \
+  if (yydebug)                                                            \
+    {                                                                     \
+      YYFPRINTF (stderr, "%s ", Title);                                   \
+      yy_symbol_print (stderr,                                            \
+                  Type, Value, Location, context); \
+      YYFPRINTF (stderr, "\n");                                           \
+    }                                                                     \
+} while (0)
+
+
+/*----------------------------------------.
+| Print this symbol's value on YYOUTPUT.  |
+`----------------------------------------*/
+
 static void
 yy_symbol_value_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep, YYLTYPE const * const yylocationp, ParserContext* context)
-#else
-static void
-yy_symbol_value_print (yyoutput, yytype, yyvaluep, yylocationp, context)
-    FILE *yyoutput;
-    int yytype;
-    YYSTYPE const * const yyvaluep;
-    YYLTYPE const * const yylocationp;
-    ParserContext* context;
-#endif
 {
-  if (!yyvaluep)
-    return;
+  FILE *yyo = yyoutput;
+  YYUSE (yyo);
   YYUSE (yylocationp);
   YYUSE (context);
+  if (!yyvaluep)
+    return;
 # ifdef YYPRINT
   if (yytype < YYNTOKENS)
     YYPRINT (yyoutput, yytoknum[yytype], *yyvaluep);
-# else
-  YYUSE (yyoutput);
 # endif
-  switch (yytype)
-    {
-      default:
-	break;
-    }
+  YYUSE (yytype);
 }
 
 
@@ -4523,24 +4266,11 @@ yy_symbol_value_print (yyoutput, yytype, yyvaluep, yylocationp, context)
 | Print this symbol on YYOUTPUT.  |
 `--------------------------------*/
 
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 static void
 yy_symbol_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep, YYLTYPE const * const yylocationp, ParserContext* context)
-#else
-static void
-yy_symbol_print (yyoutput, yytype, yyvaluep, yylocationp, context)
-    FILE *yyoutput;
-    int yytype;
-    YYSTYPE const * const yyvaluep;
-    YYLTYPE const * const yylocationp;
-    ParserContext* context;
-#endif
 {
-  if (yytype < YYNTOKENS)
-    YYFPRINTF (yyoutput, "token %s (", yytname[yytype]);
-  else
-    YYFPRINTF (yyoutput, "nterm %s (", yytname[yytype]);
+  YYFPRINTF (yyoutput, "%s %s (",
+             yytype < YYNTOKENS ? "token" : "nterm", yytname[yytype]);
 
   YY_LOCATION_PRINT (yyoutput, *yylocationp);
   YYFPRINTF (yyoutput, ": ");
@@ -4553,16 +4283,8 @@ yy_symbol_print (yyoutput, yytype, yyvaluep, yylocationp, context)
 | TOP (included).                                                   |
 `------------------------------------------------------------------*/
 
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 static void
 yy_stack_print (yytype_int16 *yybottom, yytype_int16 *yytop)
-#else
-static void
-yy_stack_print (yybottom, yytop)
-    yytype_int16 *yybottom;
-    yytype_int16 *yytop;
-#endif
 {
   YYFPRINTF (stderr, "Stack now");
   for (; yybottom <= yytop; yybottom++)
@@ -4573,51 +4295,42 @@ yy_stack_print (yybottom, yytop)
   YYFPRINTF (stderr, "\n");
 }
 
-# define YY_STACK_PRINT(Bottom, Top)				\
-do {								\
-  if (yydebug)							\
-    yy_stack_print ((Bottom), (Top));				\
-} while (YYID (0))
+# define YY_STACK_PRINT(Bottom, Top)                            \
+do {                                                            \
+  if (yydebug)                                                  \
+    yy_stack_print ((Bottom), (Top));                           \
+} while (0)
 
 
 /*------------------------------------------------.
 | Report that the YYRULE is going to be reduced.  |
 `------------------------------------------------*/
 
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 static void
-yy_reduce_print (YYSTYPE *yyvsp, YYLTYPE *yylsp, int yyrule, ParserContext* context)
-#else
-static void
-yy_reduce_print (yyvsp, yylsp, yyrule, context)
-    YYSTYPE *yyvsp;
-    YYLTYPE *yylsp;
-    int yyrule;
-    ParserContext* context;
-#endif
+yy_reduce_print (yytype_int16 *yyssp, YYSTYPE *yyvsp, YYLTYPE *yylsp, int yyrule, ParserContext* context)
 {
+  unsigned long int yylno = yyrline[yyrule];
   int yynrhs = yyr2[yyrule];
   int yyi;
-  unsigned long int yylno = yyrline[yyrule];
   YYFPRINTF (stderr, "Reducing stack by rule %d (line %lu):\n",
-	     yyrule - 1, yylno);
+             yyrule - 1, yylno);
   /* The symbols being reduced.  */
   for (yyi = 0; yyi < yynrhs; yyi++)
     {
       YYFPRINTF (stderr, "   $%d = ", yyi + 1);
-      yy_symbol_print (stderr, yyrhs[yyprhs[yyrule] + yyi],
-		       &(yyvsp[(yyi + 1) - (yynrhs)])
-		       , &(yylsp[(yyi + 1) - (yynrhs)])		       , context);
+      yy_symbol_print (stderr,
+                       yystos[yyssp[yyi + 1 - yynrhs]],
+                       &(yyvsp[(yyi + 1) - (yynrhs)])
+                       , &(yylsp[(yyi + 1) - (yynrhs)])                       , context);
       YYFPRINTF (stderr, "\n");
     }
 }
 
-# define YY_REDUCE_PRINT(Rule)		\
-do {					\
-  if (yydebug)				\
-    yy_reduce_print (yyvsp, yylsp, Rule, context); \
-} while (YYID (0))
+# define YY_REDUCE_PRINT(Rule)          \
+do {                                    \
+  if (yydebug)                          \
+    yy_reduce_print (yyssp, yyvsp, yylsp, Rule, context); \
+} while (0)
 
 /* Nonzero means print parse trace.  It is left uninitialized so that
    multiple parsers can coexist.  */
@@ -4631,7 +4344,7 @@ int yydebug;
 
 
 /* YYINITDEPTH -- initial size of the parser's stacks.  */
-#ifndef	YYINITDEPTH
+#ifndef YYINITDEPTH
 # define YYINITDEPTH 200
 #endif
 
@@ -4654,15 +4367,8 @@ int yydebug;
 #   define yystrlen strlen
 #  else
 /* Return the length of YYSTR.  */
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 static YYSIZE_T
 yystrlen (const char *yystr)
-#else
-static YYSIZE_T
-yystrlen (yystr)
-    const char *yystr;
-#endif
 {
   YYSIZE_T yylen;
   for (yylen = 0; yystr[yylen]; yylen++)
@@ -4678,16 +4384,8 @@ yystrlen (yystr)
 #  else
 /* Copy YYSRC to YYDEST, returning the address of the terminating '\0' in
    YYDEST.  */
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 static char *
 yystpcpy (char *yydest, const char *yysrc)
-#else
-static char *
-yystpcpy (yydest, yysrc)
-    char *yydest;
-    const char *yysrc;
-#endif
 {
   char *yyd = yydest;
   const char *yys = yysrc;
@@ -4717,27 +4415,27 @@ yytnamerr (char *yyres, const char *yystr)
       char const *yyp = yystr;
 
       for (;;)
-	switch (*++yyp)
-	  {
-	  case '\'':
-	  case ',':
-	    goto do_not_strip_quotes;
+        switch (*++yyp)
+          {
+          case '\'':
+          case ',':
+            goto do_not_strip_quotes;
 
-	  case '\\':
-	    if (*++yyp != '\\')
-	      goto do_not_strip_quotes;
-	    /* Fall through.  */
-	  default:
-	    if (yyres)
-	      yyres[yyn] = *yyp;
-	    yyn++;
-	    break;
+          case '\\':
+            if (*++yyp != '\\')
+              goto do_not_strip_quotes;
+            /* Fall through.  */
+          default:
+            if (yyres)
+              yyres[yyn] = *yyp;
+            yyn++;
+            break;
 
-	  case '"':
-	    if (yyres)
-	      yyres[yyn] = '\0';
-	    return yyn;
-	  }
+          case '"':
+            if (yyres)
+              yyres[yyn] = '\0';
+            return yyn;
+          }
     do_not_strip_quotes: ;
     }
 
@@ -4760,12 +4458,11 @@ static int
 yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
                 yytype_int16 *yyssp, int yytoken)
 {
-  YYSIZE_T yysize0 = yytnamerr (0, yytname[yytoken]);
+  YYSIZE_T yysize0 = yytnamerr (YY_NULLPTR, yytname[yytoken]);
   YYSIZE_T yysize = yysize0;
-  YYSIZE_T yysize1;
   enum { YYERROR_VERBOSE_ARGS_MAXIMUM = 5 };
   /* Internationalized format string. */
-  const char *yyformat = 0;
+  const char *yyformat = YY_NULLPTR;
   /* Arguments of yyformat. */
   char const *yyarg[YYERROR_VERBOSE_ARGS_MAXIMUM];
   /* Number of reported tokens (one for the "unexpected", one per
@@ -4773,10 +4470,6 @@ yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
   int yycount = 0;
 
   /* There are many possibilities here to consider:
-     - Assume YYFAIL is not used.  It's too flawed to consider.  See
-       <http://lists.gnu.org/archive/html/bison-patches/2009-12/msg00024.html>
-       for details.  YYERROR is fine as it does not invoke this
-       function.
      - If this state is a consistent state with a default action, then
        the only way this function was invoked is if the default action
        is an error action.  In that case, don't check for expected
@@ -4825,11 +4518,13 @@ yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
                     break;
                   }
                 yyarg[yycount++] = yytname[yyx];
-                yysize1 = yysize + yytnamerr (0, yytname[yyx]);
-                if (! (yysize <= yysize1
-                       && yysize1 <= YYSTACK_ALLOC_MAXIMUM))
-                  return 2;
-                yysize = yysize1;
+                {
+                  YYSIZE_T yysize1 = yysize + yytnamerr (YY_NULLPTR, yytname[yyx]);
+                  if (! (yysize <= yysize1
+                         && yysize1 <= YYSTACK_ALLOC_MAXIMUM))
+                    return 2;
+                  yysize = yysize1;
+                }
               }
         }
     }
@@ -4849,10 +4544,12 @@ yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
 # undef YYCASE_
     }
 
-  yysize1 = yysize + yystrlen (yyformat);
-  if (! (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM))
-    return 2;
-  yysize = yysize1;
+  {
+    YYSIZE_T yysize1 = yysize + yystrlen (yyformat);
+    if (! (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM))
+      return 2;
+    yysize = yysize1;
+  }
 
   if (*yymsg_alloc < yysize)
     {
@@ -4889,36 +4586,21 @@ yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
 | Release the memory associated to this symbol.  |
 `-----------------------------------------------*/
 
-/*ARGSUSED*/
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 static void
 yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocationp, ParserContext* context)
-#else
-static void
-yydestruct (yymsg, yytype, yyvaluep, yylocationp, context)
-    const char *yymsg;
-    int yytype;
-    YYSTYPE *yyvaluep;
-    YYLTYPE *yylocationp;
-    ParserContext* context;
-#endif
 {
   YYUSE (yyvaluep);
   YYUSE (yylocationp);
   YYUSE (context);
-
   if (!yymsg)
     yymsg = "Deleting";
   YY_SYMBOL_PRINT (yymsg, yytype, yyvaluep, yylocationp);
 
-  switch (yytype)
-    {
-
-      default:
-	break;
-    }
+  YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+  YYUSE (yytype);
+  YY_IGNORE_MAYBE_UNINITIALIZED_END
 }
+
 
 
 struct yypstate
@@ -4931,11 +4613,11 @@ struct yypstate
     int yyerrstatus;
 
     /* The stacks and their tools:
-       `yyss': related to states.
-       `yyvs': related to semantic values.
-       `yyls': related to locations.
+       'yyss': related to states.
+       'yyvs': related to semantic values.
+       'yyls': related to locations.
 
-       Refer to the stacks thru separate pointers, to allow yyoverflow
+       Refer to the stacks through separate pointers, to allow yyoverflow
        to reallocate them elsewhere.  */
 
     /* The state stack.  */
@@ -4963,33 +4645,19 @@ struct yypstate
   };
 
 /* Initialize the parser data structure.  */
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 yypstate *
 yypstate_new (void)
-#else
-yypstate *
-yypstate_new ()
-
-#endif
 {
   yypstate *yyps;
   yyps = (yypstate *) malloc (sizeof *yyps);
   if (!yyps)
-    return 0;
+    return YY_NULLPTR;
   yyps->yynew = 1;
   return yyps;
 }
 
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 void
 yypstate_delete (yypstate *yyps)
-#else
-void
-yypstate_delete (yyps)
-    yypstate *yyps;
-#endif
 {
 #ifndef yyoverflow
   /* If the stack was reallocated but the parse did not complete, then the
@@ -5020,33 +4688,31 @@ yypstate_delete (yyps)
 | yypush_parse.  |
 `---------------*/
 
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 int
-yypush_parse (yypstate *yyps, int yypushed_char, YYSTYPE const *yypushed_val, YYLTYPE const *yypushed_loc, ParserContext* context)
-#else
-int
-yypush_parse (yyps, yypushed_char, yypushed_val, yypushed_loc, context)
-    yypstate *yyps;
-    int yypushed_char;
-    YYSTYPE const *yypushed_val;
-    YYLTYPE const *yypushed_loc;
-    ParserContext* context;
-#endif
+yypush_parse (yypstate *yyps, int yypushed_char, YYSTYPE const *yypushed_val, YYLTYPE *yypushed_loc, ParserContext* context)
 {
 /* The lookahead symbol.  */
 int yychar;
 
+
 /* The semantic value of the lookahead symbol.  */
-YYSTYPE yylval;
+/* Default value used for initialization, for pacifying older GCCs
+   or non-GCC compilers.  */
+YY_INITIAL_VALUE (static YYSTYPE yyval_default;)
+YYSTYPE yylval YY_INITIAL_VALUE (= yyval_default);
 
 /* Location data for the lookahead symbol.  */
-YYLTYPE yylloc;
+static YYLTYPE yyloc_default
+# if defined YYLTYPE_IS_TRIVIAL && YYLTYPE_IS_TRIVIAL
+  = { 1, 1, 1, 1 }
+# endif
+;
+YYLTYPE yylloc = yyloc_default;
 
   int yyn;
   int yyresult;
   /* Lookahead token as an internal (translated) token number.  */
-  int yytoken;
+  int yytoken = 0;
   /* The variables used to return semantic value and location from the
      action routines.  */
   YYSTYPE yyval;
@@ -5071,10 +4737,9 @@ YYLTYPE yylloc;
       goto yyread_pushed_token;
     }
 
-  yytoken = 0;
-  yyss = yyssa;
-  yyvs = yyvsa;
-  yyls = yylsa;
+  yyssp = yyss = yyssa;
+  yyvsp = yyvs = yyvsa;
+  yylsp = yyls = yylsa;
   yystacksize = YYINITDEPTH;
 
   YYDPRINTF ((stderr, "Starting parse\n"));
@@ -5083,21 +4748,7 @@ YYLTYPE yylloc;
   yyerrstatus = 0;
   yynerrs = 0;
   yychar = YYEMPTY; /* Cause a token to be read.  */
-
-  /* Initialize stack pointers.
-     Waste one element of value and location stack
-     so that they stay on the same level as the state stack.
-     The wasted elements are never initialized.  */
-  yyssp = yyss;
-  yyvsp = yyvs;
-  yylsp = yyls;
-
-#if defined YYLTYPE_IS_TRIVIAL && YYLTYPE_IS_TRIVIAL
-  /* Initialize the default location before parsing starts.  */
-  yylloc.first_line   = yylloc.last_line   = 1;
-  yylloc.first_column = yylloc.last_column = 1;
-#endif
-
+  yylsp[0] = *yypushed_loc;
   goto yysetstate;
 
 /*------------------------------------------------------------.
@@ -5118,26 +4769,26 @@ YYLTYPE yylloc;
 
 #ifdef yyoverflow
       {
-	/* Give user a chance to reallocate the stack.  Use copies of
-	   these so that the &'s don't force the real ones into
-	   memory.  */
-	YYSTYPE *yyvs1 = yyvs;
-	yytype_int16 *yyss1 = yyss;
-	YYLTYPE *yyls1 = yyls;
+        /* Give user a chance to reallocate the stack.  Use copies of
+           these so that the &'s don't force the real ones into
+           memory.  */
+        YYSTYPE *yyvs1 = yyvs;
+        yytype_int16 *yyss1 = yyss;
+        YYLTYPE *yyls1 = yyls;
 
-	/* Each stack pointer address is followed by the size of the
-	   data in use in that stack, in bytes.  This used to be a
-	   conditional around just the two extra args, but that might
-	   be undefined if yyoverflow is a macro.  */
-	yyoverflow (YY_("memory exhausted"),
-		    &yyss1, yysize * sizeof (*yyssp),
-		    &yyvs1, yysize * sizeof (*yyvsp),
-		    &yyls1, yysize * sizeof (*yylsp),
-		    &yystacksize);
+        /* Each stack pointer address is followed by the size of the
+           data in use in that stack, in bytes.  This used to be a
+           conditional around just the two extra args, but that might
+           be undefined if yyoverflow is a macro.  */
+        yyoverflow (YY_("memory exhausted"),
+                    &yyss1, yysize * sizeof (*yyssp),
+                    &yyvs1, yysize * sizeof (*yyvsp),
+                    &yyls1, yysize * sizeof (*yylsp),
+                    &yystacksize);
 
-	yyls = yyls1;
-	yyss = yyss1;
-	yyvs = yyvs1;
+        yyls = yyls1;
+        yyss = yyss1;
+        yyvs = yyvs1;
       }
 #else /* no yyoverflow */
 # ifndef YYSTACK_RELOCATE
@@ -5145,23 +4796,23 @@ YYLTYPE yylloc;
 # else
       /* Extend the stack our own way.  */
       if (YYMAXDEPTH <= yystacksize)
-	goto yyexhaustedlab;
+        goto yyexhaustedlab;
       yystacksize *= 2;
       if (YYMAXDEPTH < yystacksize)
-	yystacksize = YYMAXDEPTH;
+        yystacksize = YYMAXDEPTH;
 
       {
-	yytype_int16 *yyss1 = yyss;
-	union yyalloc *yyptr =
-	  (union yyalloc *) YYSTACK_ALLOC (YYSTACK_BYTES (yystacksize));
-	if (! yyptr)
-	  goto yyexhaustedlab;
-	YYSTACK_RELOCATE (yyss_alloc, yyss);
-	YYSTACK_RELOCATE (yyvs_alloc, yyvs);
-	YYSTACK_RELOCATE (yyls_alloc, yyls);
+        yytype_int16 *yyss1 = yyss;
+        union yyalloc *yyptr =
+          (union yyalloc *) YYSTACK_ALLOC (YYSTACK_BYTES (yystacksize));
+        if (! yyptr)
+          goto yyexhaustedlab;
+        YYSTACK_RELOCATE (yyss_alloc, yyss);
+        YYSTACK_RELOCATE (yyvs_alloc, yyvs);
+        YYSTACK_RELOCATE (yyls_alloc, yyls);
 #  undef YYSTACK_RELOCATE
-	if (yyss1 != yyssa)
-	  YYSTACK_FREE (yyss1);
+        if (yyss1 != yyssa)
+          YYSTACK_FREE (yyss1);
       }
 # endif
 #endif /* no yyoverflow */
@@ -5171,10 +4822,10 @@ YYLTYPE yylloc;
       yylsp = yyls + yysize - 1;
 
       YYDPRINTF ((stderr, "Stack size increased to %lu\n",
-		  (unsigned long int) yystacksize));
+                  (unsigned long int) yystacksize));
 
       if (yyss + yystacksize - 1 <= yyssp)
-	YYABORT;
+        YYABORT;
     }
 
   YYDPRINTF ((stderr, "Entering state %d\n", yystate));
@@ -5255,7 +4906,9 @@ yyread_pushed_token:
   yychar = YYEMPTY;
 
   yystate = yyn;
+  YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
   *++yyvsp = yylval;
+  YY_IGNORE_MAYBE_UNINITIALIZED_END
   *++yylsp = yylloc;
   goto yynewstate;
 
@@ -5278,7 +4931,7 @@ yyreduce:
   yylen = yyr2[yyn];
 
   /* If YYLEN is nonzero, implement the default value of the action:
-     `$$ = $1'.
+     '$$ = $1'.
 
      Otherwise, the following line sets YYVAL to garbage.
      This behavior is undocumented and Bison
@@ -5293,569 +4946,491 @@ yyreduce:
   switch (yyn)
     {
         case 2:
-
-/* Line 1806 of yacc.c  */
-#line 441 "chapel.ypp"
+#line 441 "chapel.ypp" /* yacc.c:1661  */
     { yyblock = (yyval.pblockstmt); }
+#line 4952 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 3:
-
-/* Line 1806 of yacc.c  */
-#line 446 "chapel.ypp"
+#line 446 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pblockstmt) = new BlockStmt();                                  resetTempID(); }
+#line 4958 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 4:
-
-/* Line 1806 of yacc.c  */
-#line 447 "chapel.ypp"
-    { (yyvsp[(1) - (2)].pblockstmt)->appendChapelStmt((yyvsp[(2) - (2)].pblockstmt)); context->generatedStmt = (yyvsp[(1) - (2)].pblockstmt); resetTempID(); }
+#line 447 "chapel.ypp" /* yacc.c:1661  */
+    { (yyvsp[-1].pblockstmt)->appendChapelStmt((yyvsp[0].pblockstmt)); context->generatedStmt = (yyvsp[-1].pblockstmt); resetTempID(); }
+#line 4964 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 6:
-
-/* Line 1806 of yacc.c  */
-#line 454 "chapel.ypp"
-    { (yyval.pblockstmt) = buildPragmaStmt( (yyvsp[(1) - (2)].vpch), (yyvsp[(2) - (2)].pblockstmt) ); }
+#line 454 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildPragmaStmt( (yyvsp[-1].vpch), (yyvsp[0].pblockstmt) ); }
+#line 4970 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 7:
-
-/* Line 1806 of yacc.c  */
-#line 459 "chapel.ypp"
-    { (yyval.vpch) = new Vec<const char*>(); (yyval.vpch)->add(astr((yyvsp[(2) - (2)].pch))); }
+#line 459 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.vpch) = new Vec<const char*>(); (yyval.vpch)->add(astr((yyvsp[0].pch))); }
+#line 4976 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 8:
-
-/* Line 1806 of yacc.c  */
-#line 460 "chapel.ypp"
-    { (yyvsp[(1) - (3)].vpch)->add(astr((yyvsp[(3) - (3)].pch))); }
+#line 460 "chapel.ypp" /* yacc.c:1661  */
+    { (yyvsp[-2].vpch)->add(astr((yyvsp[0].pch))); }
+#line 4982 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 23:
-
-/* Line 1806 of yacc.c  */
-#line 479 "chapel.ypp"
-    { (yyval.pblockstmt) = buildChapelStmt((yyvsp[(1) - (2)].pexpr)); }
+#line 479 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildChapelStmt((yyvsp[-1].pexpr)); }
+#line 4988 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 24:
-
-/* Line 1806 of yacc.c  */
-#line 480 "chapel.ypp"
-    { (yyval.pblockstmt) = buildAtomicStmt((yyvsp[(2) - (2)].pblockstmt)); }
+#line 480 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildAtomicStmt((yyvsp[0].pblockstmt)); }
+#line 4994 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 25:
-
-/* Line 1806 of yacc.c  */
-#line 481 "chapel.ypp"
-    { (yyval.pblockstmt) = buildBeginStmt((yyvsp[(2) - (3)].pcallexpr), (yyvsp[(3) - (3)].pblockstmt)); }
+#line 481 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildBeginStmt((yyvsp[-1].pcallexpr), (yyvsp[0].pblockstmt)); }
+#line 5000 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 26:
-
-/* Line 1806 of yacc.c  */
-#line 482 "chapel.ypp"
-    { (yyval.pblockstmt) = buildGotoStmt(GOTO_BREAK, (yyvsp[(2) - (3)].pch)); }
+#line 482 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildGotoStmt(GOTO_BREAK, (yyvsp[-1].pch)); }
+#line 5006 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 27:
-
-/* Line 1806 of yacc.c  */
-#line 483 "chapel.ypp"
-    { (yyval.pblockstmt) = buildCobeginStmt((yyvsp[(2) - (3)].pcallexpr), (yyvsp[(3) - (3)].pblockstmt));  }
+#line 483 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildCobeginStmt((yyvsp[-1].pcallexpr), (yyvsp[0].pblockstmt));  }
+#line 5012 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 28:
-
-/* Line 1806 of yacc.c  */
-#line 484 "chapel.ypp"
-    { (yyval.pblockstmt) = buildGotoStmt(GOTO_CONTINUE, (yyvsp[(2) - (3)].pch)); }
+#line 484 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildGotoStmt(GOTO_CONTINUE, (yyvsp[-1].pch)); }
+#line 5018 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 29:
-
-/* Line 1806 of yacc.c  */
-#line 485 "chapel.ypp"
-    { (yyval.pblockstmt) = buildDeleteStmt((yyvsp[(2) - (3)].pcallexpr)); }
+#line 485 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildDeleteStmt((yyvsp[-1].pcallexpr)); }
+#line 5024 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 30:
-
-/* Line 1806 of yacc.c  */
-#line 486 "chapel.ypp"
-    { (yyval.pblockstmt) = buildLabelStmt((yyvsp[(2) - (3)].pch), (yyvsp[(3) - (3)].pblockstmt)); }
+#line 486 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildLabelStmt((yyvsp[-1].pch), (yyvsp[0].pblockstmt)); }
+#line 5030 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 31:
-
-/* Line 1806 of yacc.c  */
-#line 487 "chapel.ypp"
-    { (yyval.pblockstmt) = buildLocalStmt((yyvsp[(2) - (3)].pexpr), (yyvsp[(3) - (3)].pblockstmt)); }
+#line 487 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildLocalStmt((yyvsp[-1].pexpr), (yyvsp[0].pblockstmt)); }
+#line 5036 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 32:
-
-/* Line 1806 of yacc.c  */
-#line 488 "chapel.ypp"
-    { (yyval.pblockstmt) = buildLocalStmt((yyvsp[(2) - (2)].pblockstmt)); }
+#line 488 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildLocalStmt((yyvsp[0].pblockstmt)); }
+#line 5042 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 33:
-
-/* Line 1806 of yacc.c  */
-#line 489 "chapel.ypp"
-    { (yyval.pblockstmt) = buildOnStmt((yyvsp[(2) - (3)].pexpr), (yyvsp[(3) - (3)].pblockstmt)); }
+#line 489 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildOnStmt((yyvsp[-1].pexpr), (yyvsp[0].pblockstmt)); }
+#line 5048 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 34:
-
-/* Line 1806 of yacc.c  */
-#line 490 "chapel.ypp"
-    { (yyval.pblockstmt) = buildSerialStmt((yyvsp[(2) - (3)].pexpr), (yyvsp[(3) - (3)].pblockstmt)); }
+#line 490 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildSerialStmt((yyvsp[-1].pexpr), (yyvsp[0].pblockstmt)); }
+#line 5054 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 35:
-
-/* Line 1806 of yacc.c  */
-#line 491 "chapel.ypp"
-    { (yyval.pblockstmt) = buildSerialStmt(new SymExpr(gTrue), (yyvsp[(2) - (2)].pblockstmt)); }
+#line 491 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildSerialStmt(new SymExpr(gTrue), (yyvsp[0].pblockstmt)); }
+#line 5060 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 36:
-
-/* Line 1806 of yacc.c  */
-#line 492 "chapel.ypp"
-    { (yyval.pblockstmt) = buildSyncStmt((yyvsp[(2) - (2)].pblockstmt)); }
+#line 492 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildSyncStmt((yyvsp[0].pblockstmt)); }
+#line 5066 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 37:
-
-/* Line 1806 of yacc.c  */
-#line 493 "chapel.ypp"
-    { (yyval.pblockstmt) = buildPrimitiveStmt(PRIM_YIELD, (yyvsp[(2) - (3)].pexpr)); }
+#line 493 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildPrimitiveStmt(PRIM_YIELD, (yyvsp[-1].pexpr)); }
+#line 5072 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 38:
-
-/* Line 1806 of yacc.c  */
-#line 494 "chapel.ypp"
+#line 494 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pblockstmt) = buildErrorStandin(); }
+#line 5078 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 39:
-
-/* Line 1806 of yacc.c  */
-#line 499 "chapel.ypp"
-    { (yyval.pblockstmt) = buildChapelStmt(new DefExpr(buildModule((yyvsp[(4) - (6)].pch), currentModuleType,
-    new BlockStmt(), yyfilename, (yyvsp[(1) - (6)].b), (yyvsp[(2) - (6)].b), (yylsp[(1) - (6)]).comment))); }
+#line 499 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildChapelStmt(new DefExpr(buildModule((yyvsp[-2].pch), currentModuleType,
+    new BlockStmt(), yyfilename, (yyvsp[-5].b), (yyvsp[-4].b), (yylsp[-5]).comment))); }
+#line 5085 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 40:
-
-/* Line 1806 of yacc.c  */
-#line 502 "chapel.ypp"
-    { (yyval.pblockstmt) = buildChapelStmt(new DefExpr(buildModule((yyvsp[(4) - (7)].pch), currentModuleType, (yyvsp[(6) - (7)].pblockstmt), yyfilename, (yyvsp[(1) - (7)].b), (yyvsp[(2) - (7)].b), (yylsp[(1) - (7)]).comment))); }
+#line 502 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildChapelStmt(new DefExpr(buildModule((yyvsp[-3].pch), currentModuleType, (yyvsp[-1].pblockstmt), yyfilename, (yyvsp[-6].b), (yyvsp[-5].b), (yylsp[-6]).comment))); }
+#line 5091 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 41:
-
-/* Line 1806 of yacc.c  */
-#line 504 "chapel.ypp"
-    {(yyval.pblockstmt) = buildChapelStmt(new DefExpr(buildModule((yyvsp[(4) - (7)].pch), currentModuleType,
-        buildErrorStandin(), yyfilename, (yyvsp[(1) - (7)].b), (yyvsp[(2) - (7)].b), (yylsp[(1) - (7)]).comment))); }
+#line 504 "chapel.ypp" /* yacc.c:1661  */
+    {(yyval.pblockstmt) = buildChapelStmt(new DefExpr(buildModule((yyvsp[-3].pch), currentModuleType,
+        buildErrorStandin(), yyfilename, (yyvsp[-6].b), (yyvsp[-5].b), (yylsp[-6]).comment))); }
+#line 5098 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 42:
-
-/* Line 1806 of yacc.c  */
-#line 509 "chapel.ypp"
+#line 509 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.b) = false; (yyloc).comment = context->latestComment; context->latestComment = NULL; }
+#line 5104 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 43:
-
-/* Line 1806 of yacc.c  */
-#line 510 "chapel.ypp"
+#line 510 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.b) = false; (yyloc).comment = context->latestComment; context->latestComment = NULL; }
+#line 5110 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 44:
-
-/* Line 1806 of yacc.c  */
-#line 511 "chapel.ypp"
+#line 511 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.b) = true; (yyloc).comment = context->latestComment; context->latestComment = NULL; }
+#line 5116 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 45:
-
-/* Line 1806 of yacc.c  */
-#line 515 "chapel.ypp"
+#line 515 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.b) = false; }
+#line 5122 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 46:
-
-/* Line 1806 of yacc.c  */
-#line 516 "chapel.ypp"
+#line 516 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.b) = true;  }
+#line 5128 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 47:
-
-/* Line 1806 of yacc.c  */
-#line 529 "chapel.ypp"
+#line 529 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pblockstmt) = new BlockStmt(); }
+#line 5134 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 48:
-
-/* Line 1806 of yacc.c  */
-#line 530 "chapel.ypp"
-    { (yyval.pblockstmt) = (yyvsp[(2) - (3)].pblockstmt);              }
+#line 530 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = (yyvsp[-1].pblockstmt);              }
+#line 5140 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 49:
-
-/* Line 1806 of yacc.c  */
-#line 531 "chapel.ypp"
+#line 531 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pblockstmt) = buildErrorStandin(); }
+#line 5146 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 50:
-
-/* Line 1806 of yacc.c  */
-#line 536 "chapel.ypp"
-    { (yyval.pblockstmt) = new BlockStmt(); (yyval.pblockstmt)->appendChapelStmt((yyvsp[(1) - (1)].pblockstmt)); }
+#line 536 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = new BlockStmt(); (yyval.pblockstmt)->appendChapelStmt((yyvsp[0].pblockstmt)); }
+#line 5152 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 51:
-
-/* Line 1806 of yacc.c  */
-#line 537 "chapel.ypp"
-    { (yyvsp[(1) - (2)].pblockstmt)->appendChapelStmt((yyvsp[(2) - (2)].pblockstmt)); }
+#line 537 "chapel.ypp" /* yacc.c:1661  */
+    { (yyvsp[-1].pblockstmt)->appendChapelStmt((yyvsp[0].pblockstmt)); }
+#line 5158 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 52:
-
-/* Line 1806 of yacc.c  */
-#line 542 "chapel.ypp"
+#line 542 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.ponlylist) = new std::vector<OnlyRename*>();
                                          OnlyRename* cur = new OnlyRename();
                                          cur->tag = OnlyRename::SINGLE;
-                                         cur->elem = (yyvsp[(1) - (1)].pexpr);
+                                         cur->elem = (yyvsp[0].pexpr);
                                          (yyval.ponlylist)->push_back(cur); }
+#line 5168 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 53:
-
-/* Line 1806 of yacc.c  */
-#line 547 "chapel.ypp"
+#line 547 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.ponlylist) = new std::vector<OnlyRename*>();
                                          OnlyRename* cur = new OnlyRename();
                                          cur->tag = OnlyRename::DOUBLE;
-                                         cur->renamed = new std::pair<Expr*, Expr*>((yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr));
+                                         cur->renamed = new std::pair<Expr*, Expr*>((yyvsp[-2].pexpr), (yyvsp[0].pexpr));
                                          (yyval.ponlylist)->push_back(cur); }
+#line 5178 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 54:
-
-/* Line 1806 of yacc.c  */
-#line 552 "chapel.ypp"
+#line 552 "chapel.ypp" /* yacc.c:1661  */
     { OnlyRename* cur = new OnlyRename();
                                          cur->tag = OnlyRename::SINGLE;
-                                         cur->elem = (yyvsp[(3) - (3)].pexpr);
-                                         (yyvsp[(1) - (3)].ponlylist)->push_back(cur); }
+                                         cur->elem = (yyvsp[0].pexpr);
+                                         (yyvsp[-2].ponlylist)->push_back(cur); }
+#line 5187 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 55:
-
-/* Line 1806 of yacc.c  */
-#line 556 "chapel.ypp"
+#line 556 "chapel.ypp" /* yacc.c:1661  */
     { OnlyRename* cur = new OnlyRename();
                                          cur->tag = OnlyRename::DOUBLE;
-                                         cur->renamed = new std::pair<Expr*, Expr*>((yyvsp[(3) - (5)].pexpr), (yyvsp[(5) - (5)].pexpr));
-                                         (yyvsp[(1) - (5)].ponlylist)->push_back(cur); }
+                                         cur->renamed = new std::pair<Expr*, Expr*>((yyvsp[-2].pexpr), (yyvsp[0].pexpr));
+                                         (yyvsp[-4].ponlylist)->push_back(cur); }
+#line 5196 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 56:
-
-/* Line 1806 of yacc.c  */
-#line 563 "chapel.ypp"
+#line 563 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.ponlylist) = new std::vector<OnlyRename*>();
                                          OnlyRename* cur = new OnlyRename();
                                          cur->tag = OnlyRename::SINGLE;
                                          cur->elem = new UnresolvedSymExpr("");
                                          (yyval.ponlylist)->push_back(cur); }
+#line 5206 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 58:
-
-/* Line 1806 of yacc.c  */
-#line 572 "chapel.ypp"
+#line 572 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.ponlylist) = new std::vector<OnlyRename*>();
                                          OnlyRename* cur = new OnlyRename();
                                          cur->tag = OnlyRename::SINGLE;
                                          cur->elem = new UnresolvedSymExpr("");
                                          (yyval.ponlylist)->push_back(cur); }
+#line 5216 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 60:
-
-/* Line 1806 of yacc.c  */
-#line 581 "chapel.ypp"
-    { (yyval.pblockstmt) = buildUseStmt((yyvsp[(2) - (3)].pcallexpr)); }
+#line 581 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildUseStmt((yyvsp[-1].pcallexpr)); }
+#line 5222 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 61:
-
-/* Line 1806 of yacc.c  */
-#line 582 "chapel.ypp"
-    { (yyval.pblockstmt) = buildUseStmt((yyvsp[(2) - (5)].pexpr), (yyvsp[(4) - (5)].ponlylist), true); }
+#line 582 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildUseStmt((yyvsp[-3].pexpr), (yyvsp[-1].ponlylist), true); }
+#line 5228 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 62:
-
-/* Line 1806 of yacc.c  */
-#line 583 "chapel.ypp"
-    { (yyval.pblockstmt) = buildUseStmt((yyvsp[(2) - (5)].pexpr), (yyvsp[(4) - (5)].ponlylist), false); }
+#line 583 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildUseStmt((yyvsp[-3].pexpr), (yyvsp[-1].ponlylist), false); }
+#line 5234 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 63:
-
-/* Line 1806 of yacc.c  */
-#line 587 "chapel.ypp"
-    { (yyval.pblockstmt) = buildRequireStmt((yyvsp[(2) - (3)].pcallexpr)); }
+#line 587 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildRequireStmt((yyvsp[-1].pcallexpr)); }
+#line 5240 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 64:
-
-/* Line 1806 of yacc.c  */
-#line 592 "chapel.ypp"
-    { (yyval.pblockstmt) = buildAssignment((yyvsp[(1) - (4)].pexpr), (yyvsp[(3) - (4)].pexpr), "=");   }
+#line 592 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildAssignment((yyvsp[-3].pexpr), (yyvsp[-1].pexpr), "=");   }
+#line 5246 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 65:
-
-/* Line 1806 of yacc.c  */
-#line 594 "chapel.ypp"
-    { (yyval.pblockstmt) = buildAssignment((yyvsp[(1) - (4)].pexpr), (yyvsp[(3) - (4)].pexpr), "+=");  }
+#line 594 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildAssignment((yyvsp[-3].pexpr), (yyvsp[-1].pexpr), "+=");  }
+#line 5252 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 66:
-
-/* Line 1806 of yacc.c  */
-#line 596 "chapel.ypp"
-    { (yyval.pblockstmt) = buildAssignment((yyvsp[(1) - (4)].pexpr), (yyvsp[(3) - (4)].pexpr), "-=");  }
+#line 596 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildAssignment((yyvsp[-3].pexpr), (yyvsp[-1].pexpr), "-=");  }
+#line 5258 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 67:
-
-/* Line 1806 of yacc.c  */
-#line 598 "chapel.ypp"
-    { (yyval.pblockstmt) = buildAssignment((yyvsp[(1) - (4)].pexpr), (yyvsp[(3) - (4)].pexpr), "*=");  }
+#line 598 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildAssignment((yyvsp[-3].pexpr), (yyvsp[-1].pexpr), "*=");  }
+#line 5264 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 68:
-
-/* Line 1806 of yacc.c  */
-#line 600 "chapel.ypp"
-    { (yyval.pblockstmt) = buildAssignment((yyvsp[(1) - (4)].pexpr), (yyvsp[(3) - (4)].pexpr), "/=");  }
+#line 600 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildAssignment((yyvsp[-3].pexpr), (yyvsp[-1].pexpr), "/=");  }
+#line 5270 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 69:
-
-/* Line 1806 of yacc.c  */
-#line 602 "chapel.ypp"
-    { (yyval.pblockstmt) = buildAssignment((yyvsp[(1) - (4)].pexpr), (yyvsp[(3) - (4)].pexpr), "%=");  }
+#line 602 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildAssignment((yyvsp[-3].pexpr), (yyvsp[-1].pexpr), "%=");  }
+#line 5276 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 70:
-
-/* Line 1806 of yacc.c  */
-#line 604 "chapel.ypp"
-    { (yyval.pblockstmt) = buildAssignment((yyvsp[(1) - (4)].pexpr), (yyvsp[(3) - (4)].pexpr), "**="); }
+#line 604 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildAssignment((yyvsp[-3].pexpr), (yyvsp[-1].pexpr), "**="); }
+#line 5282 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 71:
-
-/* Line 1806 of yacc.c  */
-#line 606 "chapel.ypp"
-    { (yyval.pblockstmt) = buildAssignment((yyvsp[(1) - (4)].pexpr), (yyvsp[(3) - (4)].pexpr), "&=");  }
+#line 606 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildAssignment((yyvsp[-3].pexpr), (yyvsp[-1].pexpr), "&=");  }
+#line 5288 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 72:
-
-/* Line 1806 of yacc.c  */
-#line 608 "chapel.ypp"
-    { (yyval.pblockstmt) = buildAssignment((yyvsp[(1) - (4)].pexpr), (yyvsp[(3) - (4)].pexpr), "|=");  }
+#line 608 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildAssignment((yyvsp[-3].pexpr), (yyvsp[-1].pexpr), "|=");  }
+#line 5294 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 73:
-
-/* Line 1806 of yacc.c  */
-#line 610 "chapel.ypp"
-    { (yyval.pblockstmt) = buildAssignment((yyvsp[(1) - (4)].pexpr), (yyvsp[(3) - (4)].pexpr), "^=");  }
+#line 610 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildAssignment((yyvsp[-3].pexpr), (yyvsp[-1].pexpr), "^=");  }
+#line 5300 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 74:
-
-/* Line 1806 of yacc.c  */
-#line 612 "chapel.ypp"
-    { (yyval.pblockstmt) = buildAssignment((yyvsp[(1) - (4)].pexpr), (yyvsp[(3) - (4)].pexpr), ">>="); }
+#line 612 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildAssignment((yyvsp[-3].pexpr), (yyvsp[-1].pexpr), ">>="); }
+#line 5306 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 75:
-
-/* Line 1806 of yacc.c  */
-#line 614 "chapel.ypp"
-    { (yyval.pblockstmt) = buildAssignment((yyvsp[(1) - (4)].pexpr), (yyvsp[(3) - (4)].pexpr), "<<="); }
+#line 614 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildAssignment((yyvsp[-3].pexpr), (yyvsp[-1].pexpr), "<<="); }
+#line 5312 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 76:
-
-/* Line 1806 of yacc.c  */
-#line 616 "chapel.ypp"
-    { (yyval.pblockstmt) = buildAssignment((yyvsp[(1) - (4)].pexpr), (yyvsp[(3) - (4)].pexpr), "<=>"); }
+#line 616 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildAssignment((yyvsp[-3].pexpr), (yyvsp[-1].pexpr), "<=>"); }
+#line 5318 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 77:
-
-/* Line 1806 of yacc.c  */
-#line 618 "chapel.ypp"
-    { (yyval.pblockstmt) = buildAssignment((yyvsp[(1) - (4)].pexpr), (yyvsp[(3) - (4)].pexpr), PRIM_REDUCE_ASSIGN); }
+#line 618 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildAssignment((yyvsp[-3].pexpr), (yyvsp[-1].pexpr), PRIM_REDUCE_ASSIGN); }
+#line 5324 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 78:
-
-/* Line 1806 of yacc.c  */
-#line 620 "chapel.ypp"
-    { (yyval.pblockstmt) = buildLAndAssignment((yyvsp[(1) - (4)].pexpr), (yyvsp[(3) - (4)].pexpr));    }
+#line 620 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildLAndAssignment((yyvsp[-3].pexpr), (yyvsp[-1].pexpr));    }
+#line 5330 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 79:
-
-/* Line 1806 of yacc.c  */
-#line 622 "chapel.ypp"
-    { (yyval.pblockstmt) = buildLOrAssignment((yyvsp[(1) - (4)].pexpr), (yyvsp[(3) - (4)].pexpr));     }
+#line 622 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildLOrAssignment((yyvsp[-3].pexpr), (yyvsp[-1].pexpr));     }
+#line 5336 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 80:
-
-/* Line 1806 of yacc.c  */
-#line 626 "chapel.ypp"
+#line 626 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pch) = NULL; }
+#line 5342 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 82:
-
-/* Line 1806 of yacc.c  */
-#line 631 "chapel.ypp"
-    { (yyval.pch) = (yyvsp[(1) - (1)].pch); }
+#line 631 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pch) = (yyvsp[0].pch); }
+#line 5348 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 83:
-
-/* Line 1806 of yacc.c  */
-#line 635 "chapel.ypp"
-    { (yyval.pch) = (yyvsp[(1) - (1)].pch); }
+#line 635 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pch) = (yyvsp[0].pch); }
+#line 5354 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 84:
-
-/* Line 1806 of yacc.c  */
-#line 636 "chapel.ypp"
-    { (yyval.pch) = (yyvsp[(1) - (1)].pch); }
+#line 636 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pch) = (yyvsp[0].pch); }
+#line 5360 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 85:
-
-/* Line 1806 of yacc.c  */
-#line 640 "chapel.ypp"
-    { (yyval.pblockstmt) = (yyvsp[(2) - (2)].pblockstmt); }
+#line 640 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = (yyvsp[0].pblockstmt); }
+#line 5366 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 86:
-
-/* Line 1806 of yacc.c  */
-#line 641 "chapel.ypp"
-    { (yyval.pblockstmt) = (yyvsp[(1) - (1)].pblockstmt); }
+#line 641 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = (yyvsp[0].pblockstmt); }
+#line 5372 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 87:
-
-/* Line 1806 of yacc.c  */
-#line 645 "chapel.ypp"
+#line 645 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pblockstmt) = buildPrimitiveStmt(PRIM_RETURN); }
+#line 5378 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 88:
-
-/* Line 1806 of yacc.c  */
-#line 646 "chapel.ypp"
-    { (yyval.pblockstmt) = buildPrimitiveStmt(PRIM_RETURN, (yyvsp[(2) - (3)].pexpr)); }
+#line 646 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildPrimitiveStmt(PRIM_RETURN, (yyvsp[-1].pexpr)); }
+#line 5384 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 89:
-
-/* Line 1806 of yacc.c  */
-#line 650 "chapel.ypp"
+#line 650 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pblockstmt) = buildChapelStmt(new BlockStmt()); }
+#line 5390 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 91:
-
-/* Line 1806 of yacc.c  */
-#line 652 "chapel.ypp"
-    { (yyval.pblockstmt) = (yyvsp[(2) - (2)].pblockstmt); }
+#line 652 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = (yyvsp[0].pblockstmt); }
+#line 5396 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 92:
-
-/* Line 1806 of yacc.c  */
-#line 653 "chapel.ypp"
-    { applyPrivateToBlock((yyvsp[(2) - (2)].pblockstmt)); (yyval.pblockstmt) = (yyvsp[(2) - (2)].pblockstmt); }
+#line 653 "chapel.ypp" /* yacc.c:1661  */
+    { applyPrivateToBlock((yyvsp[0].pblockstmt)); (yyval.pblockstmt) = (yyvsp[0].pblockstmt); }
+#line 5402 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 99:
-
-/* Line 1806 of yacc.c  */
-#line 666 "chapel.ypp"
-    { (yyval.pblockstmt) = buildForwardingStmt((yyvsp[(2) - (3)].pexpr)); }
+#line 666 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildForwardingStmt((yyvsp[-1].pexpr)); }
+#line 5408 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 100:
-
-/* Line 1806 of yacc.c  */
-#line 667 "chapel.ypp"
-    { (yyval.pblockstmt) = buildForwardingStmt((yyvsp[(2) - (5)].pexpr), (yyvsp[(4) - (5)].ponlylist), true); }
+#line 667 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildForwardingStmt((yyvsp[-3].pexpr), (yyvsp[-1].ponlylist), true); }
+#line 5414 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 101:
-
-/* Line 1806 of yacc.c  */
-#line 668 "chapel.ypp"
-    { (yyval.pblockstmt) = buildForwardingStmt((yyvsp[(2) - (5)].pexpr), (yyvsp[(4) - (5)].ponlylist), false); }
+#line 668 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildForwardingStmt((yyvsp[-3].pexpr), (yyvsp[-1].ponlylist), false); }
+#line 5420 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 102:
-
-/* Line 1806 of yacc.c  */
-#line 669 "chapel.ypp"
-    { (yyval.pblockstmt) = buildForwardingDeclStmt((yyvsp[(2) - (2)].pblockstmt)); }
+#line 669 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildForwardingDeclStmt((yyvsp[0].pblockstmt)); }
+#line 5426 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 103:
-
-/* Line 1806 of yacc.c  */
-#line 674 "chapel.ypp"
+#line 674 "chapel.ypp" /* yacc.c:1661  */
     {
 #ifdef HAVE_LLVM
       if (externC) {
-        (yyval.pblockstmt) = buildExternBlockStmt(astr((yyvsp[(2) - (2)].pch)));
+        (yyval.pblockstmt) = buildExternBlockStmt(astr((yyvsp[0].pch)));
       } else {
         USR_FATAL(new BlockStmt(), "extern block syntax is turned off. Use --extern-c flag to turn on.");
       }
@@ -5863,680 +5438,602 @@ yyreduce:
       USR_FATAL(new BlockStmt(), "Chapel must be built with llvm in order to use the extern block syntax");
 #endif
     }
+#line 5442 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 104:
-
-/* Line 1806 of yacc.c  */
-#line 688 "chapel.ypp"
-    { (yyval.pblockstmt) = DoWhileStmt::build((yyvsp[(4) - (5)].pexpr), (yyvsp[(2) - (5)].pblockstmt)); }
+#line 688 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = DoWhileStmt::build((yyvsp[-1].pexpr), (yyvsp[-3].pblockstmt)); }
+#line 5448 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 105:
-
-/* Line 1806 of yacc.c  */
-#line 689 "chapel.ypp"
-    { (yyval.pblockstmt) = WhileDoStmt::build((yyvsp[(2) - (3)].pexpr), (yyvsp[(3) - (3)].pblockstmt)); }
+#line 689 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = WhileDoStmt::build((yyvsp[-1].pexpr), (yyvsp[0].pblockstmt)); }
+#line 5454 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 106:
-
-/* Line 1806 of yacc.c  */
-#line 690 "chapel.ypp"
-    { (yyval.pblockstmt) = buildCoforallLoopStmt((yyvsp[(2) - (6)].pexpr), (yyvsp[(4) - (6)].pexpr), (yyvsp[(5) - (6)].pcallexpr), (yyvsp[(6) - (6)].pblockstmt)); }
+#line 690 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildCoforallLoopStmt((yyvsp[-4].pexpr), (yyvsp[-2].pexpr), (yyvsp[-1].pcallexpr), (yyvsp[0].pblockstmt)); }
+#line 5460 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 107:
-
-/* Line 1806 of yacc.c  */
-#line 691 "chapel.ypp"
-    { (yyval.pblockstmt) = buildCoforallLoopStmt((yyvsp[(2) - (6)].pexpr), zipToTuple((yyvsp[(4) - (6)].pcallexpr)), (yyvsp[(5) - (6)].pcallexpr), (yyvsp[(6) - (6)].pblockstmt), true); }
+#line 691 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildCoforallLoopStmt((yyvsp[-4].pexpr), zipToTuple((yyvsp[-2].pcallexpr)), (yyvsp[-1].pcallexpr), (yyvsp[0].pblockstmt), true); }
+#line 5466 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 108:
-
-/* Line 1806 of yacc.c  */
-#line 692 "chapel.ypp"
-    { (yyval.pblockstmt) = buildCoforallLoopStmt(NULL, (yyvsp[(2) - (4)].pexpr), (yyvsp[(3) - (4)].pcallexpr), (yyvsp[(4) - (4)].pblockstmt)); }
+#line 692 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildCoforallLoopStmt(NULL, (yyvsp[-2].pexpr), (yyvsp[-1].pcallexpr), (yyvsp[0].pblockstmt)); }
+#line 5472 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 109:
-
-/* Line 1806 of yacc.c  */
-#line 693 "chapel.ypp"
-    { (yyval.pblockstmt) = ForLoop::buildForLoop(  (yyvsp[(2) - (5)].pexpr), (yyvsp[(4) - (5)].pexpr), (yyvsp[(5) - (5)].pblockstmt), false, false); }
+#line 693 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = ForLoop::buildForLoop(  (yyvsp[-3].pexpr), (yyvsp[-1].pexpr), (yyvsp[0].pblockstmt), false, false); }
+#line 5478 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 110:
-
-/* Line 1806 of yacc.c  */
-#line 694 "chapel.ypp"
-    { (yyval.pblockstmt) = ForLoop::buildForLoop(  (yyvsp[(2) - (5)].pexpr), (yyvsp[(4) - (5)].pcallexpr), (yyvsp[(5) - (5)].pblockstmt), false,  true); }
+#line 694 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = ForLoop::buildForLoop(  (yyvsp[-3].pexpr), (yyvsp[-1].pcallexpr), (yyvsp[0].pblockstmt), false,  true); }
+#line 5484 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 111:
-
-/* Line 1806 of yacc.c  */
-#line 695 "chapel.ypp"
-    { (yyval.pblockstmt) = ForLoop::buildForLoop(NULL, (yyvsp[(2) - (3)].pexpr), (yyvsp[(3) - (3)].pblockstmt), false, false); }
+#line 695 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = ForLoop::buildForLoop(NULL, (yyvsp[-1].pexpr), (yyvsp[0].pblockstmt), false, false); }
+#line 5490 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 112:
-
-/* Line 1806 of yacc.c  */
-#line 696 "chapel.ypp"
-    { (yyval.pblockstmt) = ForLoop::buildForLoop(NULL, (yyvsp[(2) - (3)].pcallexpr), (yyvsp[(3) - (3)].pblockstmt), false,  true); }
+#line 696 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = ForLoop::buildForLoop(NULL, (yyvsp[-1].pcallexpr), (yyvsp[0].pblockstmt), false,  true); }
+#line 5496 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 113:
-
-/* Line 1806 of yacc.c  */
-#line 697 "chapel.ypp"
-    { (yyval.pblockstmt) = buildParamForLoopStmt((yyvsp[(3) - (6)].pch), (yyvsp[(5) - (6)].pexpr), (yyvsp[(6) - (6)].pblockstmt)); }
+#line 697 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildParamForLoopStmt((yyvsp[-3].pch), (yyvsp[-1].pexpr), (yyvsp[0].pblockstmt)); }
+#line 5502 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 114:
-
-/* Line 1806 of yacc.c  */
-#line 698 "chapel.ypp"
-    { (yyval.pblockstmt) = ForallStmt::build((yyvsp[(2) - (5)].pexpr), (yyvsp[(4) - (5)].pexpr), NULL, (yyvsp[(5) - (5)].pblockstmt)); }
+#line 698 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = ForallStmt::build((yyvsp[-3].pexpr), (yyvsp[-1].pexpr), NULL, (yyvsp[0].pblockstmt)); }
+#line 5508 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 115:
-
-/* Line 1806 of yacc.c  */
-#line 699 "chapel.ypp"
-    { (yyval.pblockstmt) = ForallStmt::build((yyvsp[(2) - (6)].pexpr), (yyvsp[(4) - (6)].pexpr), (yyvsp[(5) - (6)].pcallexpr),   (yyvsp[(6) - (6)].pblockstmt)); }
+#line 699 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = ForallStmt::build((yyvsp[-4].pexpr), (yyvsp[-2].pexpr), (yyvsp[-1].pcallexpr),   (yyvsp[0].pblockstmt)); }
+#line 5514 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 116:
-
-/* Line 1806 of yacc.c  */
-#line 700 "chapel.ypp"
-    { (yyval.pblockstmt) = ForallStmt::build((yyvsp[(2) - (5)].pexpr), (yyvsp[(4) - (5)].pcallexpr), NULL, (yyvsp[(5) - (5)].pblockstmt), true); }
+#line 700 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = ForallStmt::build((yyvsp[-3].pexpr), (yyvsp[-1].pcallexpr), NULL, (yyvsp[0].pblockstmt), true); }
+#line 5520 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 117:
-
-/* Line 1806 of yacc.c  */
-#line 701 "chapel.ypp"
-    { (yyval.pblockstmt) = ForallStmt::build((yyvsp[(2) - (6)].pexpr), (yyvsp[(4) - (6)].pcallexpr), (yyvsp[(5) - (6)].pcallexpr),   (yyvsp[(6) - (6)].pblockstmt), true); }
+#line 701 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = ForallStmt::build((yyvsp[-4].pexpr), (yyvsp[-2].pcallexpr), (yyvsp[-1].pcallexpr),   (yyvsp[0].pblockstmt), true); }
+#line 5526 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 118:
-
-/* Line 1806 of yacc.c  */
-#line 702 "chapel.ypp"
-    { (yyval.pblockstmt) = ForallStmt::build(NULL, (yyvsp[(2) - (3)].pexpr), NULL, (yyvsp[(3) - (3)].pblockstmt)); }
+#line 702 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = ForallStmt::build(NULL, (yyvsp[-1].pexpr), NULL, (yyvsp[0].pblockstmt)); }
+#line 5532 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 119:
-
-/* Line 1806 of yacc.c  */
-#line 703 "chapel.ypp"
-    { (yyval.pblockstmt) = ForallStmt::build(NULL, (yyvsp[(2) - (4)].pexpr), (yyvsp[(3) - (4)].pcallexpr),   (yyvsp[(4) - (4)].pblockstmt)); }
+#line 703 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = ForallStmt::build(NULL, (yyvsp[-2].pexpr), (yyvsp[-1].pcallexpr),   (yyvsp[0].pblockstmt)); }
+#line 5538 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 120:
-
-/* Line 1806 of yacc.c  */
-#line 705 "chapel.ypp"
+#line 705 "chapel.ypp" /* yacc.c:1661  */
     {
-      if ((yyvsp[(2) - (6)].pcallexpr)->argList.length != 1)
-        USR_FATAL((yyvsp[(4) - (6)].pexpr), "invalid index expression");
-      (yyval.pblockstmt) = ForallStmt::build((yyvsp[(2) - (6)].pcallexpr)->get(1)->remove(), (yyvsp[(4) - (6)].pexpr), NULL, new BlockStmt((yyvsp[(6) - (6)].pblockstmt)));
+      if ((yyvsp[-4].pcallexpr)->argList.length != 1)
+        USR_FATAL((yyvsp[-2].pexpr), "invalid index expression");
+      (yyval.pblockstmt) = ForallStmt::build((yyvsp[-4].pcallexpr)->get(1)->remove(), (yyvsp[-2].pexpr), NULL, new BlockStmt((yyvsp[0].pblockstmt)));
     }
+#line 5548 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 121:
-
-/* Line 1806 of yacc.c  */
-#line 711 "chapel.ypp"
+#line 711 "chapel.ypp" /* yacc.c:1661  */
     {
-      if ((yyvsp[(2) - (7)].pcallexpr)->argList.length != 1)
-        USR_FATAL((yyvsp[(4) - (7)].pexpr), "invalid index expression");
-      (yyval.pblockstmt) = ForallStmt::build((yyvsp[(2) - (7)].pcallexpr)->get(1)->remove(), (yyvsp[(4) - (7)].pexpr), (yyvsp[(5) - (7)].pcallexpr),   new BlockStmt((yyvsp[(7) - (7)].pblockstmt)));
+      if ((yyvsp[-5].pcallexpr)->argList.length != 1)
+        USR_FATAL((yyvsp[-3].pexpr), "invalid index expression");
+      (yyval.pblockstmt) = ForallStmt::build((yyvsp[-5].pcallexpr)->get(1)->remove(), (yyvsp[-3].pexpr), (yyvsp[-2].pcallexpr),   new BlockStmt((yyvsp[0].pblockstmt)));
     }
+#line 5558 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 122:
-
-/* Line 1806 of yacc.c  */
-#line 717 "chapel.ypp"
+#line 717 "chapel.ypp" /* yacc.c:1661  */
     {
-      if ((yyvsp[(2) - (6)].pcallexpr)->argList.length != 1)
-        USR_FATAL((yyvsp[(4) - (6)].pcallexpr), "invalid index expression");
-      (yyval.pblockstmt) = ForallStmt::build((yyvsp[(2) - (6)].pcallexpr)->get(1)->remove(), (yyvsp[(4) - (6)].pcallexpr), NULL, new BlockStmt((yyvsp[(6) - (6)].pblockstmt)), true);
+      if ((yyvsp[-4].pcallexpr)->argList.length != 1)
+        USR_FATAL((yyvsp[-2].pcallexpr), "invalid index expression");
+      (yyval.pblockstmt) = ForallStmt::build((yyvsp[-4].pcallexpr)->get(1)->remove(), (yyvsp[-2].pcallexpr), NULL, new BlockStmt((yyvsp[0].pblockstmt)), true);
     }
+#line 5568 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 123:
-
-/* Line 1806 of yacc.c  */
-#line 723 "chapel.ypp"
+#line 723 "chapel.ypp" /* yacc.c:1661  */
     {
-      if ((yyvsp[(2) - (7)].pcallexpr)->argList.length != 1)
-        USR_FATAL((yyvsp[(4) - (7)].pcallexpr), "invalid index expression");
-      (yyval.pblockstmt) = ForallStmt::build((yyvsp[(2) - (7)].pcallexpr)->get(1)->remove(), (yyvsp[(4) - (7)].pcallexpr), (yyvsp[(5) - (7)].pcallexpr),   new BlockStmt((yyvsp[(7) - (7)].pblockstmt)), true);
+      if ((yyvsp[-5].pcallexpr)->argList.length != 1)
+        USR_FATAL((yyvsp[-3].pcallexpr), "invalid index expression");
+      (yyval.pblockstmt) = ForallStmt::build((yyvsp[-5].pcallexpr)->get(1)->remove(), (yyvsp[-3].pcallexpr), (yyvsp[-2].pcallexpr),   new BlockStmt((yyvsp[0].pblockstmt)), true);
     }
+#line 5578 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 124:
-
-/* Line 1806 of yacc.c  */
-#line 729 "chapel.ypp"
+#line 729 "chapel.ypp" /* yacc.c:1661  */
     {
-      if ((yyvsp[(2) - (4)].pcallexpr)->argList.length > 1)
-        (yyval.pblockstmt) = ForallStmt::build(NULL, new CallExpr("chpl__ensureDomainExpr", (yyvsp[(2) - (4)].pcallexpr)), NULL, new BlockStmt((yyvsp[(4) - (4)].pblockstmt)));
+      if ((yyvsp[-2].pcallexpr)->argList.length > 1)
+        (yyval.pblockstmt) = ForallStmt::build(NULL, new CallExpr("chpl__ensureDomainExpr", (yyvsp[-2].pcallexpr)), NULL, new BlockStmt((yyvsp[0].pblockstmt)));
       else
-        (yyval.pblockstmt) = ForallStmt::build(NULL, (yyvsp[(2) - (4)].pcallexpr)->get(1)->remove(), NULL, new BlockStmt((yyvsp[(4) - (4)].pblockstmt)));
+        (yyval.pblockstmt) = ForallStmt::build(NULL, (yyvsp[-2].pcallexpr)->get(1)->remove(), NULL, new BlockStmt((yyvsp[0].pblockstmt)));
     }
+#line 5589 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 125:
-
-/* Line 1806 of yacc.c  */
-#line 736 "chapel.ypp"
+#line 736 "chapel.ypp" /* yacc.c:1661  */
     {
-      if ((yyvsp[(2) - (5)].pcallexpr)->argList.length > 1)
-        (yyval.pblockstmt) = ForallStmt::build(NULL, new CallExpr("chpl__ensureDomainExpr", (yyvsp[(2) - (5)].pcallexpr)), (yyvsp[(3) - (5)].pcallexpr),   new BlockStmt((yyvsp[(5) - (5)].pblockstmt)));
+      if ((yyvsp[-3].pcallexpr)->argList.length > 1)
+        (yyval.pblockstmt) = ForallStmt::build(NULL, new CallExpr("chpl__ensureDomainExpr", (yyvsp[-3].pcallexpr)), (yyvsp[-2].pcallexpr),   new BlockStmt((yyvsp[0].pblockstmt)));
       else
-        (yyval.pblockstmt) = ForallStmt::build(NULL, (yyvsp[(2) - (5)].pcallexpr)->get(1)->remove(), (yyvsp[(3) - (5)].pcallexpr),   new BlockStmt((yyvsp[(5) - (5)].pblockstmt)));
+        (yyval.pblockstmt) = ForallStmt::build(NULL, (yyvsp[-3].pcallexpr)->get(1)->remove(), (yyvsp[-2].pcallexpr),   new BlockStmt((yyvsp[0].pblockstmt)));
     }
+#line 5600 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 126:
-
-/* Line 1806 of yacc.c  */
-#line 745 "chapel.ypp"
-    { (yyval.pcallexpr) = new CallExpr(PRIM_ZIP, (yyvsp[(3) - (4)].pcallexpr)); }
+#line 745 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pcallexpr) = new CallExpr(PRIM_ZIP, (yyvsp[-1].pcallexpr)); }
+#line 5606 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 127:
-
-/* Line 1806 of yacc.c  */
-#line 749 "chapel.ypp"
-    { (yyval.pblockstmt) = buildIfStmt((yyvsp[(2) - (4)].pexpr), (yyvsp[(4) - (4)].pblockstmt)); }
+#line 749 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildIfStmt((yyvsp[-2].pexpr), (yyvsp[0].pblockstmt)); }
+#line 5612 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 128:
-
-/* Line 1806 of yacc.c  */
-#line 750 "chapel.ypp"
-    { (yyval.pblockstmt) = buildIfStmt((yyvsp[(2) - (3)].pexpr), (yyvsp[(3) - (3)].pblockstmt)); }
+#line 750 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildIfStmt((yyvsp[-1].pexpr), (yyvsp[0].pblockstmt)); }
+#line 5618 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 129:
-
-/* Line 1806 of yacc.c  */
-#line 751 "chapel.ypp"
-    { (yyval.pblockstmt) = buildIfStmt((yyvsp[(2) - (6)].pexpr), (yyvsp[(4) - (6)].pblockstmt), (yyvsp[(6) - (6)].pblockstmt)); }
+#line 751 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildIfStmt((yyvsp[-4].pexpr), (yyvsp[-2].pblockstmt), (yyvsp[0].pblockstmt)); }
+#line 5624 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 130:
-
-/* Line 1806 of yacc.c  */
-#line 752 "chapel.ypp"
-    { (yyval.pblockstmt) = buildIfStmt((yyvsp[(2) - (5)].pexpr), (yyvsp[(3) - (5)].pblockstmt), (yyvsp[(5) - (5)].pblockstmt)); }
+#line 752 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildIfStmt((yyvsp[-3].pexpr), (yyvsp[-2].pblockstmt), (yyvsp[0].pblockstmt)); }
+#line 5630 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 131:
-
-/* Line 1806 of yacc.c  */
-#line 753 "chapel.ypp"
+#line 753 "chapel.ypp" /* yacc.c:1661  */
     {
-(yyval.pblockstmt) = buildIfStmt(convertAssignmentAndWarn((yyvsp[(2) - (6)].pexpr),(yyvsp[(3) - (6)].pch),(yyvsp[(4) - (6)].pexpr)), (yyvsp[(6) - (6)].pblockstmt)); }
+(yyval.pblockstmt) = buildIfStmt(convertAssignmentAndWarn((yyvsp[-4].pexpr),(yyvsp[-3].pch),(yyvsp[-2].pexpr)), (yyvsp[0].pblockstmt)); }
+#line 5637 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 132:
-
-/* Line 1806 of yacc.c  */
-#line 755 "chapel.ypp"
+#line 755 "chapel.ypp" /* yacc.c:1661  */
     {
-(yyval.pblockstmt) = buildIfStmt(convertAssignmentAndWarn((yyvsp[(2) - (5)].pexpr),(yyvsp[(3) - (5)].pch),(yyvsp[(4) - (5)].pexpr)), (yyvsp[(5) - (5)].pblockstmt)); }
+(yyval.pblockstmt) = buildIfStmt(convertAssignmentAndWarn((yyvsp[-3].pexpr),(yyvsp[-2].pch),(yyvsp[-1].pexpr)), (yyvsp[0].pblockstmt)); }
+#line 5644 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 133:
-
-/* Line 1806 of yacc.c  */
-#line 757 "chapel.ypp"
+#line 757 "chapel.ypp" /* yacc.c:1661  */
     {
-(yyval.pblockstmt) = buildIfStmt(convertAssignmentAndWarn((yyvsp[(2) - (8)].pexpr),(yyvsp[(3) - (8)].pch),(yyvsp[(4) - (8)].pexpr)), (yyvsp[(6) - (8)].pblockstmt), (yyvsp[(8) - (8)].pblockstmt)); }
+(yyval.pblockstmt) = buildIfStmt(convertAssignmentAndWarn((yyvsp[-6].pexpr),(yyvsp[-5].pch),(yyvsp[-4].pexpr)), (yyvsp[-2].pblockstmt), (yyvsp[0].pblockstmt)); }
+#line 5651 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 134:
-
-/* Line 1806 of yacc.c  */
-#line 759 "chapel.ypp"
+#line 759 "chapel.ypp" /* yacc.c:1661  */
     {
-(yyval.pblockstmt) = buildIfStmt(convertAssignmentAndWarn((yyvsp[(2) - (7)].pexpr),(yyvsp[(3) - (7)].pch),(yyvsp[(4) - (7)].pexpr)), (yyvsp[(5) - (7)].pblockstmt), (yyvsp[(7) - (7)].pblockstmt)); }
+(yyval.pblockstmt) = buildIfStmt(convertAssignmentAndWarn((yyvsp[-5].pexpr),(yyvsp[-4].pch),(yyvsp[-3].pexpr)), (yyvsp[-2].pblockstmt), (yyvsp[0].pblockstmt)); }
+#line 5658 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 135:
-
-/* Line 1806 of yacc.c  */
-#line 764 "chapel.ypp"
-    { (yyval.pblockstmt) = DeferStmt::build((yyvsp[(2) - (2)].pblockstmt)); }
+#line 764 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = DeferStmt::build((yyvsp[0].pblockstmt)); }
+#line 5664 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 136:
-
-/* Line 1806 of yacc.c  */
-#line 767 "chapel.ypp"
-    { (yyval.pblockstmt) = TryStmt::build(false, (yyvsp[(2) - (3)].pexpr)); }
+#line 767 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = TryStmt::build(false, (yyvsp[-1].pexpr)); }
+#line 5670 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 137:
-
-/* Line 1806 of yacc.c  */
-#line 768 "chapel.ypp"
-    { (yyval.pblockstmt) = TryStmt::build(true,  (yyvsp[(2) - (3)].pexpr)); }
+#line 768 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = TryStmt::build(true,  (yyvsp[-1].pexpr)); }
+#line 5676 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 138:
-
-/* Line 1806 of yacc.c  */
-#line 769 "chapel.ypp"
-    { (yyval.pblockstmt) = TryStmt::build(false, (yyvsp[(2) - (2)].pblockstmt)); }
+#line 769 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = TryStmt::build(false, (yyvsp[0].pblockstmt)); }
+#line 5682 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 139:
-
-/* Line 1806 of yacc.c  */
-#line 770 "chapel.ypp"
-    { (yyval.pblockstmt) = TryStmt::build(true,  (yyvsp[(2) - (2)].pblockstmt)); }
+#line 770 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = TryStmt::build(true,  (yyvsp[0].pblockstmt)); }
+#line 5688 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 140:
-
-/* Line 1806 of yacc.c  */
-#line 771 "chapel.ypp"
-    { (yyval.pblockstmt) = TryStmt::build(false, (yyvsp[(2) - (3)].pblockstmt), (yyvsp[(3) - (3)].pblockstmt)); }
+#line 771 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = TryStmt::build(false, (yyvsp[-1].pblockstmt), (yyvsp[0].pblockstmt)); }
+#line 5694 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 141:
-
-/* Line 1806 of yacc.c  */
-#line 772 "chapel.ypp"
-    { (yyval.pblockstmt) = TryStmt::build(true,  (yyvsp[(2) - (3)].pblockstmt), (yyvsp[(3) - (3)].pblockstmt)); }
+#line 772 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = TryStmt::build(true,  (yyvsp[-1].pblockstmt), (yyvsp[0].pblockstmt)); }
+#line 5700 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 142:
-
-/* Line 1806 of yacc.c  */
-#line 776 "chapel.ypp"
+#line 776 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pblockstmt) = buildChapelStmt(); }
+#line 5706 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 143:
-
-/* Line 1806 of yacc.c  */
-#line 777 "chapel.ypp"
-    { (yyvsp[(1) - (2)].pblockstmt)->insertAtTail((yyvsp[(2) - (2)].pexpr)); }
+#line 777 "chapel.ypp" /* yacc.c:1661  */
+    { (yyvsp[-1].pblockstmt)->insertAtTail((yyvsp[0].pexpr)); }
+#line 5712 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 144:
-
-/* Line 1806 of yacc.c  */
-#line 781 "chapel.ypp"
-    { (yyval.pexpr) = CatchStmt::build((yyvsp[(2) - (2)].pblockstmt)); }
+#line 781 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = CatchStmt::build((yyvsp[0].pblockstmt)); }
+#line 5718 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 145:
-
-/* Line 1806 of yacc.c  */
-#line 782 "chapel.ypp"
-    { (yyval.pexpr) = CatchStmt::build((yyvsp[(2) - (3)].pexpr), (yyvsp[(3) - (3)].pblockstmt)); }
+#line 782 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = CatchStmt::build((yyvsp[-1].pexpr), (yyvsp[0].pblockstmt)); }
+#line 5724 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 146:
-
-/* Line 1806 of yacc.c  */
-#line 783 "chapel.ypp"
-    { (yyval.pexpr) = CatchStmt::build((yyvsp[(3) - (5)].pexpr), (yyvsp[(5) - (5)].pblockstmt)); }
+#line 783 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = CatchStmt::build((yyvsp[-2].pexpr), (yyvsp[0].pblockstmt)); }
+#line 5730 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 147:
-
-/* Line 1806 of yacc.c  */
-#line 787 "chapel.ypp"
-    { (yyval.pexpr) = new DefExpr(new VarSymbol((yyvsp[(1) - (1)].pch)), NULL, new UnresolvedSymExpr("Error")); }
+#line 787 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new DefExpr(new VarSymbol((yyvsp[0].pch)), NULL, new UnresolvedSymExpr("Error")); }
+#line 5736 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 148:
-
-/* Line 1806 of yacc.c  */
-#line 788 "chapel.ypp"
-    { (yyval.pexpr) = new DefExpr(new VarSymbol((yyvsp[(1) - (3)].pch)), NULL, (yyvsp[(3) - (3)].pexpr));   }
+#line 788 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new DefExpr(new VarSymbol((yyvsp[-2].pch)), NULL, (yyvsp[0].pexpr));   }
+#line 5742 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 149:
-
-/* Line 1806 of yacc.c  */
-#line 792 "chapel.ypp"
-    { (yyval.pblockstmt) = buildPrimitiveStmt(PRIM_THROW, (yyvsp[(2) - (3)].pexpr)); }
+#line 792 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildPrimitiveStmt(PRIM_THROW, (yyvsp[-1].pexpr)); }
+#line 5748 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 150:
-
-/* Line 1806 of yacc.c  */
-#line 796 "chapel.ypp"
-    { (yyval.pblockstmt) = buildChapelStmt(buildSelectStmt((yyvsp[(2) - (5)].pexpr), (yyvsp[(4) - (5)].pblockstmt))); }
+#line 796 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildChapelStmt(buildSelectStmt((yyvsp[-3].pexpr), (yyvsp[-1].pblockstmt))); }
+#line 5754 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 151:
-
-/* Line 1806 of yacc.c  */
-#line 798 "chapel.ypp"
+#line 798 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pblockstmt) = buildErrorStandin(); }
+#line 5760 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 152:
-
-/* Line 1806 of yacc.c  */
-#line 802 "chapel.ypp"
+#line 802 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pblockstmt) = buildChapelStmt(); }
+#line 5766 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 153:
-
-/* Line 1806 of yacc.c  */
-#line 803 "chapel.ypp"
-    { (yyvsp[(1) - (2)].pblockstmt)->insertAtTail((yyvsp[(2) - (2)].pexpr)); }
+#line 803 "chapel.ypp" /* yacc.c:1661  */
+    { (yyvsp[-1].pblockstmt)->insertAtTail((yyvsp[0].pexpr)); }
+#line 5772 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 154:
-
-/* Line 1806 of yacc.c  */
-#line 808 "chapel.ypp"
-    { (yyval.pexpr) = new CondStmt(new CallExpr(PRIM_WHEN, (yyvsp[(2) - (3)].pcallexpr)), (yyvsp[(3) - (3)].pblockstmt)); }
+#line 808 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new CondStmt(new CallExpr(PRIM_WHEN, (yyvsp[-1].pcallexpr)), (yyvsp[0].pblockstmt)); }
+#line 5778 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 155:
-
-/* Line 1806 of yacc.c  */
-#line 810 "chapel.ypp"
-    { (yyval.pexpr) = new CondStmt(new CallExpr(PRIM_WHEN), (yyvsp[(2) - (2)].pblockstmt)); }
+#line 810 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new CondStmt(new CallExpr(PRIM_WHEN), (yyvsp[0].pblockstmt)); }
+#line 5784 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 156:
-
-/* Line 1806 of yacc.c  */
-#line 812 "chapel.ypp"
-    { (yyval.pexpr) = new CondStmt(new CallExpr(PRIM_WHEN), (yyvsp[(3) - (3)].pblockstmt)); }
+#line 812 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new CondStmt(new CallExpr(PRIM_WHEN), (yyvsp[0].pblockstmt)); }
+#line 5790 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 157:
-
-/* Line 1806 of yacc.c  */
-#line 819 "chapel.ypp"
+#line 819 "chapel.ypp" /* yacc.c:1661  */
     {
-      (yyval.pblockstmt) = buildChapelStmt(buildClassDefExpr((yyvsp[(2) - (6)].pch),
+      (yyval.pblockstmt) = buildChapelStmt(buildClassDefExpr((yyvsp[-4].pch),
                                              NULL,
-                                             (yyvsp[(1) - (6)].aggrTag),
-                                             (yyvsp[(3) - (6)].pcallexpr),
-                                             (yyvsp[(5) - (6)].pblockstmt),
+                                             (yyvsp[-5].aggrTag),
+                                             (yyvsp[-3].pcallexpr),
+                                             (yyvsp[-1].pblockstmt),
                                              FLAG_UNKNOWN,
-                                             (yylsp[(1) - (6)]).comment));
+                                             (yylsp[-5]).comment));
     }
+#line 5804 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 158:
-
-/* Line 1806 of yacc.c  */
-#line 829 "chapel.ypp"
+#line 829 "chapel.ypp" /* yacc.c:1661  */
     {
-      (yyval.pblockstmt) = buildChapelStmt(buildClassDefExpr((yyvsp[(4) - (8)].pch),
-                                             (yyvsp[(2) - (8)].pch),
-                                             (yyvsp[(3) - (8)].aggrTag),
-                                             (yyvsp[(5) - (8)].pcallexpr),
-                                             (yyvsp[(7) - (8)].pblockstmt),
+      (yyval.pblockstmt) = buildChapelStmt(buildClassDefExpr((yyvsp[-4].pch),
+                                             (yyvsp[-6].pch),
+                                             (yyvsp[-5].aggrTag),
+                                             (yyvsp[-3].pcallexpr),
+                                             (yyvsp[-1].pblockstmt),
                                              FLAG_EXTERN,
-                                             (yylsp[(3) - (8)]).comment));
+                                             (yylsp[-5]).comment));
     }
+#line 5818 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 159:
-
-/* Line 1806 of yacc.c  */
-#line 839 "chapel.ypp"
+#line 839 "chapel.ypp" /* yacc.c:1661  */
     {
-      (yyval.pblockstmt) = buildChapelStmt(buildClassDefExpr((yyvsp[(2) - (6)].pch),
+      (yyval.pblockstmt) = buildChapelStmt(buildClassDefExpr((yyvsp[-4].pch),
                                              NULL,
-                                             (yyvsp[(1) - (6)].aggrTag),
-                                             (yyvsp[(3) - (6)].pcallexpr),
+                                             (yyvsp[-5].aggrTag),
+                                             (yyvsp[-3].pcallexpr),
                                              new BlockStmt(),
                                              FLAG_UNKNOWN,
-                                             (yylsp[(1) - (6)]).comment));
+                                             (yylsp[-5]).comment));
     }
+#line 5832 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 160:
-
-/* Line 1806 of yacc.c  */
-#line 849 "chapel.ypp"
+#line 849 "chapel.ypp" /* yacc.c:1661  */
     {
-      (yyval.pblockstmt) = buildChapelStmt(buildClassDefExpr((yyvsp[(4) - (8)].pch),
-                                             (yyvsp[(2) - (8)].pch),
-                                             (yyvsp[(3) - (8)].aggrTag),
-                                             (yyvsp[(5) - (8)].pcallexpr),
+      (yyval.pblockstmt) = buildChapelStmt(buildClassDefExpr((yyvsp[-4].pch),
+                                             (yyvsp[-6].pch),
+                                             (yyvsp[-5].aggrTag),
+                                             (yyvsp[-3].pcallexpr),
                                              new BlockStmt(),
                                              FLAG_EXTERN,
-                                             (yylsp[(3) - (8)]).comment));
+                                             (yylsp[-5]).comment));
     }
+#line 5846 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 161:
-
-/* Line 1806 of yacc.c  */
-#line 861 "chapel.ypp"
+#line 861 "chapel.ypp" /* yacc.c:1661  */
     {
              (yyval.aggrTag)                     = AGGREGATE_CLASS;
              (yyloc).comment             = context->latestComment;
              context->latestComment = NULL;
            }
+#line 5856 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 162:
-
-/* Line 1806 of yacc.c  */
-#line 866 "chapel.ypp"
+#line 866 "chapel.ypp" /* yacc.c:1661  */
     {
              (yyval.aggrTag)                     = AGGREGATE_RECORD;
              (yyloc).comment             = context->latestComment;
              context->latestComment = NULL;
            }
+#line 5866 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 163:
-
-/* Line 1806 of yacc.c  */
-#line 871 "chapel.ypp"
+#line 871 "chapel.ypp" /* yacc.c:1661  */
     {
              (yyval.aggrTag)                     = AGGREGATE_UNION;
              (yyloc).comment             = context->latestComment;
              context->latestComment = NULL;
            }
+#line 5876 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 164:
-
-/* Line 1806 of yacc.c  */
-#line 879 "chapel.ypp"
+#line 879 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pcallexpr) = NULL; }
+#line 5882 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 165:
-
-/* Line 1806 of yacc.c  */
-#line 880 "chapel.ypp"
-    { (yyval.pcallexpr) = (yyvsp[(2) - (2)].pcallexpr); }
+#line 880 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pcallexpr) = (yyvsp[0].pcallexpr); }
+#line 5888 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 166:
-
-/* Line 1806 of yacc.c  */
-#line 885 "chapel.ypp"
+#line 885 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pblockstmt) = new BlockStmt(); }
+#line 5894 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 167:
-
-/* Line 1806 of yacc.c  */
-#line 887 "chapel.ypp"
-    { (yyvsp[(1) - (2)].pblockstmt)->insertAtTail((yyvsp[(2) - (2)].pblockstmt)); }
+#line 887 "chapel.ypp" /* yacc.c:1661  */
+    { (yyvsp[-1].pblockstmt)->insertAtTail((yyvsp[0].pblockstmt)); }
+#line 5900 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 168:
-
-/* Line 1806 of yacc.c  */
-#line 889 "chapel.ypp"
-    { (yyvsp[(1) - (3)].pblockstmt)->insertAtTail(buildPragmaStmt((yyvsp[(2) - (3)].vpch), (yyvsp[(3) - (3)].pblockstmt))); }
+#line 889 "chapel.ypp" /* yacc.c:1661  */
+    { (yyvsp[-2].pblockstmt)->insertAtTail(buildPragmaStmt((yyvsp[-1].vpch), (yyvsp[0].pblockstmt))); }
+#line 5906 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 169:
-
-/* Line 1806 of yacc.c  */
-#line 894 "chapel.ypp"
+#line 894 "chapel.ypp" /* yacc.c:1661  */
     {
-      EnumType* pdt = (yyvsp[(1) - (5)].penumtype);
-      for_vector(DefExpr, ec, *(yyvsp[(4) - (5)].pvecOfDefs)) {
+      EnumType* pdt = (yyvsp[-4].penumtype);
+      for_vector(DefExpr, ec, *(yyvsp[-1].pvecOfDefs)) {
         ec->sym->type = pdt;
         pdt->constants.insertAtTail(ec);
         if (pdt->defaultValue == NULL) {
           pdt->defaultValue = ec->sym;
         }
       }
-      delete (yyvsp[(4) - (5)].pvecOfDefs);
-      pdt->doc = (yylsp[(1) - (5)]).comment;
-      TypeSymbol* pst = new TypeSymbol((yyvsp[(2) - (5)].pch), pdt);
-      (yyvsp[(1) - (5)].penumtype)->symbol = pst;
+      delete (yyvsp[-1].pvecOfDefs);
+      pdt->doc = (yylsp[-4]).comment;
+      TypeSymbol* pst = new TypeSymbol((yyvsp[-3].pch), pdt);
+      (yyvsp[-4].penumtype)->symbol = pst;
       (yyval.pblockstmt) = buildChapelStmt(new DefExpr(pst));
     }
+#line 5926 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 170:
-
-/* Line 1806 of yacc.c  */
-#line 910 "chapel.ypp"
+#line 910 "chapel.ypp" /* yacc.c:1661  */
     {
       (yyval.pblockstmt) = buildErrorStandin();
     }
+#line 5934 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 171:
-
-/* Line 1806 of yacc.c  */
-#line 917 "chapel.ypp"
+#line 917 "chapel.ypp" /* yacc.c:1661  */
     {
       (yyval.penumtype) = new EnumType();
       (yyloc).comment = context->latestComment;
       context->latestComment = NULL;
     }
+#line 5944 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 172:
-
-/* Line 1806 of yacc.c  */
-#line 926 "chapel.ypp"
+#line 926 "chapel.ypp" /* yacc.c:1661  */
     {
       (yyval.pvecOfDefs) = new std::vector<DefExpr*>();
-      (yyval.pvecOfDefs)->push_back((yyvsp[(1) - (1)].pdefexpr));
+      (yyval.pvecOfDefs)->push_back((yyvsp[0].pdefexpr));
       //$$->doc = context->latestComment;
       // start here for enabling documentation of enum constants
       //context->latestComment = NULL;
     }
+#line 5956 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 173:
-
-/* Line 1806 of yacc.c  */
-#line 934 "chapel.ypp"
+#line 934 "chapel.ypp" /* yacc.c:1661  */
     {
-      (yyval.pvecOfDefs) = (yyvsp[(1) - (2)].pvecOfDefs);
+      (yyval.pvecOfDefs) = (yyvsp[-1].pvecOfDefs);
     }
+#line 5964 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 174:
-
-/* Line 1806 of yacc.c  */
-#line 938 "chapel.ypp"
+#line 938 "chapel.ypp" /* yacc.c:1661  */
     {
-      (yyvsp[(1) - (3)].pvecOfDefs)->push_back((yyvsp[(3) - (3)].pdefexpr));
+      (yyvsp[-2].pvecOfDefs)->push_back((yyvsp[0].pdefexpr));
     }
+#line 5972 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 175:
-
-/* Line 1806 of yacc.c  */
-#line 944 "chapel.ypp"
-    { (yyval.pdefexpr) = new DefExpr(new EnumSymbol((yyvsp[(1) - (1)].pch))); }
+#line 944 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pdefexpr) = new DefExpr(new EnumSymbol((yyvsp[0].pch))); }
+#line 5978 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 176:
-
-/* Line 1806 of yacc.c  */
-#line 945 "chapel.ypp"
-    { (yyval.pdefexpr) = new DefExpr(new EnumSymbol((yyvsp[(1) - (3)].pch)), (yyvsp[(3) - (3)].pexpr)); }
+#line 945 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pdefexpr) = new DefExpr(new EnumSymbol((yyvsp[-2].pch)), (yyvsp[0].pexpr)); }
+#line 5984 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 177:
-
-/* Line 1806 of yacc.c  */
-#line 950 "chapel.ypp"
+#line 950 "chapel.ypp" /* yacc.c:1661  */
     {
       captureTokens = 1;
       captureString.clear();
     }
+#line 5993 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 178:
-
-/* Line 1806 of yacc.c  */
-#line 955 "chapel.ypp"
+#line 955 "chapel.ypp" /* yacc.c:1661  */
     {
       captureTokens = 0;
-      (yyvsp[(3) - (3)].pfnsymbol)->userString = astr(captureString);
+      (yyvsp[0].pfnsymbol)->userString = astr(captureString);
     }
+#line 6002 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 179:
-
-/* Line 1806 of yacc.c  */
-#line 960 "chapel.ypp"
+#line 960 "chapel.ypp" /* yacc.c:1661  */
     {
-      (yyvsp[(3) - (8)].pfnsymbol)->retTag = (yyvsp[(5) - (8)].retTag);
-      if ((yyvsp[(5) - (8)].retTag) == RET_REF || (yyvsp[(5) - (8)].retTag) == RET_CONST_REF)
+      (yyvsp[-5].pfnsymbol)->retTag = (yyvsp[-3].retTag);
+      if ((yyvsp[-3].retTag) == RET_REF || (yyvsp[-3].retTag) == RET_CONST_REF)
         USR_FATAL("'ref' return types are not allowed in lambdas");
-      if ((yyvsp[(5) - (8)].retTag) == RET_PARAM)
+      if ((yyvsp[-3].retTag) == RET_PARAM)
         USR_FATAL("'param' return types are not allowed in lambdas");
-      if ((yyvsp[(5) - (8)].retTag) == RET_TYPE)
+      if ((yyvsp[-3].retTag) == RET_TYPE)
         USR_FATAL("'type' return types are not allowed in lambdas");
-      if ((yyvsp[(6) - (8)].pexpr))
-        (yyvsp[(3) - (8)].pfnsymbol)->retExprType = new BlockStmt((yyvsp[(6) - (8)].pexpr), BLOCK_SCOPELESS);
-      if ((yyvsp[(7) - (8)].pexpr))
-        (yyvsp[(3) - (8)].pfnsymbol)->where = new BlockStmt((yyvsp[(7) - (8)].pexpr));
-      (yyvsp[(3) - (8)].pfnsymbol)->insertAtTail((yyvsp[(8) - (8)].pblockstmt));
-      (yyval.pexpr) = new DefExpr(buildLambda((yyvsp[(3) - (8)].pfnsymbol)));
+      if ((yyvsp[-2].pexpr))
+        (yyvsp[-5].pfnsymbol)->retExprType = new BlockStmt((yyvsp[-2].pexpr), BLOCK_SCOPELESS);
+      if ((yyvsp[-1].pexpr))
+        (yyvsp[-5].pfnsymbol)->where = new BlockStmt((yyvsp[-1].pexpr));
+      (yyvsp[-5].pfnsymbol)->insertAtTail((yyvsp[0].pblockstmt));
+      (yyval.pexpr) = new DefExpr(buildLambda((yyvsp[-5].pfnsymbol)));
     }
+#line 6022 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 180:
-
-/* Line 1806 of yacc.c  */
-#line 980 "chapel.ypp"
+#line 980 "chapel.ypp" /* yacc.c:1661  */
     {
                   (yyval.pfnsymbol) = new FnSymbol("");
 
                   (yyloc).comment             = context->latestComment;
                   context->latestComment = NULL;
                 }
+#line 6033 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 181:
-
-/* Line 1806 of yacc.c  */
-#line 986 "chapel.ypp"
+#line 986 "chapel.ypp" /* yacc.c:1661  */
     {
                   (yyval.pfnsymbol) = new FnSymbol("");
                   (yyval.pfnsymbol)->addFlag(FLAG_INLINE);
@@ -6544,2116 +6041,1836 @@ yyreduce:
                   (yyloc).comment             = context->latestComment;
                   context->latestComment = NULL;
                 }
+#line 6045 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 182:
-
-/* Line 1806 of yacc.c  */
-#line 993 "chapel.ypp"
+#line 993 "chapel.ypp" /* yacc.c:1661  */
     {
-                  (yyval.pfnsymbol) = new FnSymbol((yyvsp[(2) - (2)].pch));
+                  (yyval.pfnsymbol) = new FnSymbol((yyvsp[0].pch));
                   (yyval.pfnsymbol)->addFlag(FLAG_EXPORT);
                   (yyval.pfnsymbol)->addFlag(FLAG_LOCAL_ARGS);
 
                   (yyloc).comment             = context->latestComment;
                   context->latestComment = NULL;
                 }
+#line 6058 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 183:
-
-/* Line 1806 of yacc.c  */
-#line 1001 "chapel.ypp"
+#line 1001 "chapel.ypp" /* yacc.c:1661  */
     {
-                  (yyval.pfnsymbol) = new FnSymbol((yyvsp[(2) - (2)].pch));
+                  (yyval.pfnsymbol) = new FnSymbol((yyvsp[0].pch));
                   (yyval.pfnsymbol)->addFlag(FLAG_EXTERN);
                   (yyval.pfnsymbol)->addFlag(FLAG_LOCAL_ARGS);
 
                   (yyloc).comment             = context->latestComment;
                   context->latestComment = NULL;
                 }
+#line 6071 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 184:
-
-/* Line 1806 of yacc.c  */
-#line 1013 "chapel.ypp"
+#line 1013 "chapel.ypp" /* yacc.c:1661  */
     {
       // Sets up to capture tokens while parsing the next grammar nonterminal.
       captureTokens = 1;
       captureString.clear();
     }
+#line 6081 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 185:
-
-/* Line 1806 of yacc.c  */
-#line 1019 "chapel.ypp"
+#line 1019 "chapel.ypp" /* yacc.c:1661  */
     {
       // Stop capturing and save the result.
       captureTokens = 0;
 
-      (yyvsp[(4) - (4)].pfnsymbol)->userString = astr(captureString);
+      (yyvsp[0].pfnsymbol)->userString = astr(captureString);
     }
+#line 6092 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 186:
-
-/* Line 1806 of yacc.c  */
-#line 1026 "chapel.ypp"
+#line 1026 "chapel.ypp" /* yacc.c:1661  */
     {
-      FnSymbol* fn = (yyvsp[(4) - (10)].pfnsymbol);
+      FnSymbol* fn = (yyvsp[-6].pfnsymbol);
 
-      fn->copyFlags((yyvsp[(1) - (10)].pfnsymbol));
+      fn->copyFlags((yyvsp[-9].pfnsymbol));
       // The user explicitly named this function (controls mangling).
-      if (*(yyvsp[(1) - (10)].pfnsymbol)->name)
-        fn->cname = (yyvsp[(1) - (10)].pfnsymbol)->name;
+      if (*(yyvsp[-9].pfnsymbol)->name)
+        fn->cname = (yyvsp[-9].pfnsymbol)->name;
 
-      if ((yyvsp[(2) - (10)].procIter) == ProcIter_ITER)
+      if ((yyvsp[-8].procIter) == ProcIter_ITER)
       {
         if (fn->hasFlag(FLAG_EXTERN))
           USR_FATAL_CONT(fn, "'iter' is not legal with 'extern'");
         fn->addFlag(FLAG_ITERATOR_FN);
       }
 
-      (yyval.pblockstmt) = buildFunctionDecl((yyvsp[(4) - (10)].pfnsymbol), (yyvsp[(6) - (10)].retTag), (yyvsp[(7) - (10)].pexpr), (yyvsp[(8) - (10)].b), (yyvsp[(9) - (10)].pexpr), (yyvsp[(10) - (10)].pblockstmt), (yylsp[(1) - (10)]).comment);
+      (yyval.pblockstmt) = buildFunctionDecl((yyvsp[-6].pfnsymbol), (yyvsp[-4].retTag), (yyvsp[-3].pexpr), (yyvsp[-2].b), (yyvsp[-1].pexpr), (yyvsp[0].pblockstmt), (yylsp[-9]).comment);
       context->latestComment = NULL;
     }
+#line 6115 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 187:
-
-/* Line 1806 of yacc.c  */
-#line 1048 "chapel.ypp"
+#line 1048 "chapel.ypp" /* yacc.c:1661  */
     {
-      (yyval.pfnsymbol) = buildFunctionSymbol((yyvsp[(3) - (3)].pfnsymbol), (yyvsp[(2) - (3)].pch), (yyvsp[(1) - (3)].pt), NULL);
+      (yyval.pfnsymbol) = buildFunctionSymbol((yyvsp[0].pfnsymbol), (yyvsp[-1].pch), (yyvsp[-2].pt), NULL);
     }
+#line 6123 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 188:
-
-/* Line 1806 of yacc.c  */
-#line 1052 "chapel.ypp"
+#line 1052 "chapel.ypp" /* yacc.c:1661  */
     {
-      (yyval.pfnsymbol) = buildFunctionSymbol((yyvsp[(3) - (3)].pfnsymbol), (yyvsp[(2) - (3)].pch), (yyvsp[(1) - (3)].pt), NULL);
+      (yyval.pfnsymbol) = buildFunctionSymbol((yyvsp[0].pfnsymbol), (yyvsp[-1].pch), (yyvsp[-2].pt), NULL);
       (yyval.pfnsymbol)->addFlag(FLAG_ASSIGNOP);
     }
+#line 6132 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 189:
-
-/* Line 1806 of yacc.c  */
-#line 1057 "chapel.ypp"
+#line 1057 "chapel.ypp" /* yacc.c:1661  */
     {
-      (yyval.pfnsymbol) = buildFunctionSymbol((yyvsp[(5) - (5)].pfnsymbol), (yyvsp[(4) - (5)].pch), (yyvsp[(1) - (5)].pt), (yyvsp[(2) - (5)].pexpr));
+      (yyval.pfnsymbol) = buildFunctionSymbol((yyvsp[0].pfnsymbol), (yyvsp[-1].pch), (yyvsp[-4].pt), (yyvsp[-3].pexpr));
     }
+#line 6140 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 190:
-
-/* Line 1806 of yacc.c  */
-#line 1061 "chapel.ypp"
+#line 1061 "chapel.ypp" /* yacc.c:1661  */
     {
-      (yyval.pfnsymbol) = buildFunctionSymbol((yyvsp[(5) - (5)].pfnsymbol), (yyvsp[(4) - (5)].pch), (yyvsp[(1) - (5)].pt), (yyvsp[(2) - (5)].pexpr));
+      (yyval.pfnsymbol) = buildFunctionSymbol((yyvsp[0].pfnsymbol), (yyvsp[-1].pch), (yyvsp[-4].pt), (yyvsp[-3].pexpr));
       (yyval.pfnsymbol)->addFlag(FLAG_ASSIGNOP);
     }
+#line 6149 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 192:
-
-/* Line 1806 of yacc.c  */
-#line 1069 "chapel.ypp"
-    { (yyval.pexpr) = (yyvsp[(2) - (3)].pexpr); }
+#line 1069 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = (yyvsp[-1].pexpr); }
+#line 6155 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 194:
-
-/* Line 1806 of yacc.c  */
-#line 1074 "chapel.ypp"
-    { (yyval.pch) = astr("~", (yyvsp[(2) - (2)].pch)); }
+#line 1074 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pch) = astr("~", (yyvsp[0].pch)); }
+#line 6161 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 195:
-
-/* Line 1806 of yacc.c  */
-#line 1075 "chapel.ypp"
+#line 1075 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pch) = "&"; }
+#line 6167 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 196:
-
-/* Line 1806 of yacc.c  */
-#line 1076 "chapel.ypp"
+#line 1076 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pch) = "|"; }
+#line 6173 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 197:
-
-/* Line 1806 of yacc.c  */
-#line 1077 "chapel.ypp"
+#line 1077 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pch) = "^"; }
+#line 6179 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 198:
-
-/* Line 1806 of yacc.c  */
-#line 1078 "chapel.ypp"
+#line 1078 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pch) = "~"; }
+#line 6185 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 199:
-
-/* Line 1806 of yacc.c  */
-#line 1079 "chapel.ypp"
+#line 1079 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pch) = "=="; }
+#line 6191 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 200:
-
-/* Line 1806 of yacc.c  */
-#line 1080 "chapel.ypp"
+#line 1080 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pch) = "!="; }
+#line 6197 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 201:
-
-/* Line 1806 of yacc.c  */
-#line 1081 "chapel.ypp"
+#line 1081 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pch) = "<="; }
+#line 6203 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 202:
-
-/* Line 1806 of yacc.c  */
-#line 1082 "chapel.ypp"
+#line 1082 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pch) = ">="; }
+#line 6209 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 203:
-
-/* Line 1806 of yacc.c  */
-#line 1083 "chapel.ypp"
+#line 1083 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pch) = "<"; }
+#line 6215 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 204:
-
-/* Line 1806 of yacc.c  */
-#line 1084 "chapel.ypp"
+#line 1084 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pch) = ">"; }
+#line 6221 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 205:
-
-/* Line 1806 of yacc.c  */
-#line 1085 "chapel.ypp"
+#line 1085 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pch) = "+"; }
+#line 6227 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 206:
-
-/* Line 1806 of yacc.c  */
-#line 1086 "chapel.ypp"
+#line 1086 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pch) = "-"; }
+#line 6233 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 207:
-
-/* Line 1806 of yacc.c  */
-#line 1087 "chapel.ypp"
+#line 1087 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pch) = "*"; }
+#line 6239 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 208:
-
-/* Line 1806 of yacc.c  */
-#line 1088 "chapel.ypp"
+#line 1088 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pch) = "/"; }
+#line 6245 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 209:
-
-/* Line 1806 of yacc.c  */
-#line 1089 "chapel.ypp"
+#line 1089 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pch) = "<<"; }
+#line 6251 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 210:
-
-/* Line 1806 of yacc.c  */
-#line 1090 "chapel.ypp"
+#line 1090 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pch) = ">>"; }
+#line 6257 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 211:
-
-/* Line 1806 of yacc.c  */
-#line 1091 "chapel.ypp"
+#line 1091 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pch) = "%"; }
+#line 6263 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 212:
-
-/* Line 1806 of yacc.c  */
-#line 1092 "chapel.ypp"
+#line 1092 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pch) = "**"; }
+#line 6269 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 213:
-
-/* Line 1806 of yacc.c  */
-#line 1093 "chapel.ypp"
+#line 1093 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pch) = "!"; }
+#line 6275 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 214:
-
-/* Line 1806 of yacc.c  */
-#line 1094 "chapel.ypp"
+#line 1094 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pch) = "chpl_by"; }
+#line 6281 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 215:
-
-/* Line 1806 of yacc.c  */
-#line 1095 "chapel.ypp"
+#line 1095 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pch) = "#"; }
+#line 6287 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 216:
-
-/* Line 1806 of yacc.c  */
-#line 1096 "chapel.ypp"
+#line 1096 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pch) = "chpl_align"; }
+#line 6293 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 217:
-
-/* Line 1806 of yacc.c  */
-#line 1097 "chapel.ypp"
+#line 1097 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pch) = "<=>"; }
+#line 6299 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 218:
-
-/* Line 1806 of yacc.c  */
-#line 1098 "chapel.ypp"
+#line 1098 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pch) = "<~>"; }
+#line 6305 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 219:
-
-/* Line 1806 of yacc.c  */
-#line 1102 "chapel.ypp"
+#line 1102 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pch) = "="; }
+#line 6311 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 220:
-
-/* Line 1806 of yacc.c  */
-#line 1103 "chapel.ypp"
+#line 1103 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pch) = "+="; }
+#line 6317 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 221:
-
-/* Line 1806 of yacc.c  */
-#line 1104 "chapel.ypp"
+#line 1104 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pch) = "-="; }
+#line 6323 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 222:
-
-/* Line 1806 of yacc.c  */
-#line 1105 "chapel.ypp"
+#line 1105 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pch) = "*="; }
+#line 6329 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 223:
-
-/* Line 1806 of yacc.c  */
-#line 1106 "chapel.ypp"
+#line 1106 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pch) = "/="; }
+#line 6335 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 224:
-
-/* Line 1806 of yacc.c  */
-#line 1107 "chapel.ypp"
+#line 1107 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pch) = "%="; }
+#line 6341 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 225:
-
-/* Line 1806 of yacc.c  */
-#line 1108 "chapel.ypp"
+#line 1108 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pch) = "**="; }
+#line 6347 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 226:
-
-/* Line 1806 of yacc.c  */
-#line 1109 "chapel.ypp"
+#line 1109 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pch) = "&="; }
+#line 6353 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 227:
-
-/* Line 1806 of yacc.c  */
-#line 1110 "chapel.ypp"
+#line 1110 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pch) = "|="; }
+#line 6359 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 228:
-
-/* Line 1806 of yacc.c  */
-#line 1111 "chapel.ypp"
+#line 1111 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pch) = "^="; }
+#line 6365 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 229:
-
-/* Line 1806 of yacc.c  */
-#line 1112 "chapel.ypp"
+#line 1112 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pch) = ">>="; }
+#line 6371 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 230:
-
-/* Line 1806 of yacc.c  */
-#line 1113 "chapel.ypp"
+#line 1113 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pch) = "<<="; }
+#line 6377 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 231:
-
-/* Line 1806 of yacc.c  */
-#line 1117 "chapel.ypp"
+#line 1117 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pfnsymbol) = new FnSymbol("_"); (yyval.pfnsymbol)->addFlag(FLAG_NO_PARENS); }
+#line 6383 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 232:
-
-/* Line 1806 of yacc.c  */
-#line 1118 "chapel.ypp"
-    { (yyval.pfnsymbol) = (yyvsp[(2) - (3)].pfnsymbol); }
+#line 1118 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pfnsymbol) = (yyvsp[-1].pfnsymbol); }
+#line 6389 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 233:
-
-/* Line 1806 of yacc.c  */
-#line 1122 "chapel.ypp"
-    { (yyval.pfnsymbol) = (yyvsp[(2) - (3)].pfnsymbol); }
+#line 1122 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pfnsymbol) = (yyvsp[-1].pfnsymbol); }
+#line 6395 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 234:
-
-/* Line 1806 of yacc.c  */
-#line 1126 "chapel.ypp"
+#line 1126 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pfnsymbol) = buildFunctionFormal(NULL, NULL); }
+#line 6401 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 235:
-
-/* Line 1806 of yacc.c  */
-#line 1127 "chapel.ypp"
-    { (yyval.pfnsymbol) = buildFunctionFormal(NULL, (yyvsp[(1) - (1)].pdefexpr)); }
+#line 1127 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pfnsymbol) = buildFunctionFormal(NULL, (yyvsp[0].pdefexpr)); }
+#line 6407 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 236:
-
-/* Line 1806 of yacc.c  */
-#line 1128 "chapel.ypp"
-    { (yyval.pfnsymbol) = buildFunctionFormal((yyvsp[(1) - (3)].pfnsymbol), (yyvsp[(3) - (3)].pdefexpr)); }
+#line 1128 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pfnsymbol) = buildFunctionFormal((yyvsp[-2].pfnsymbol), (yyvsp[0].pdefexpr)); }
+#line 6413 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 237:
-
-/* Line 1806 of yacc.c  */
-#line 1133 "chapel.ypp"
-    { (yyval.pdefexpr) = buildArgDefExpr((yyvsp[(1) - (4)].pt), (yyvsp[(2) - (4)].pch), (yyvsp[(3) - (4)].pexpr), (yyvsp[(4) - (4)].pexpr), NULL); }
+#line 1133 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pdefexpr) = buildArgDefExpr((yyvsp[-3].pt), (yyvsp[-2].pch), (yyvsp[-1].pexpr), (yyvsp[0].pexpr), NULL); }
+#line 6419 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 238:
-
-/* Line 1806 of yacc.c  */
-#line 1135 "chapel.ypp"
-    { (yyval.pdefexpr) = buildArgDefExpr((yyvsp[(1) - (4)].pt), (yyvsp[(2) - (4)].pch), (yyvsp[(3) - (4)].pexpr), NULL, (yyvsp[(4) - (4)].pexpr)); }
+#line 1135 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pdefexpr) = buildArgDefExpr((yyvsp[-3].pt), (yyvsp[-2].pch), (yyvsp[-1].pexpr), NULL, (yyvsp[0].pexpr)); }
+#line 6425 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 239:
-
-/* Line 1806 of yacc.c  */
-#line 1137 "chapel.ypp"
-    { (yyval.pdefexpr) = buildTupleArgDefExpr((yyvsp[(1) - (6)].pt), (yyvsp[(3) - (6)].pblockstmt), (yyvsp[(5) - (6)].pexpr), (yyvsp[(6) - (6)].pexpr)); }
+#line 1137 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pdefexpr) = buildTupleArgDefExpr((yyvsp[-5].pt), (yyvsp[-3].pblockstmt), (yyvsp[-1].pexpr), (yyvsp[0].pexpr)); }
+#line 6431 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 240:
-
-/* Line 1806 of yacc.c  */
-#line 1139 "chapel.ypp"
+#line 1139 "chapel.ypp" /* yacc.c:1661  */
     { USR_FATAL("variable-length argument may not be grouped in a tuple"); }
+#line 6437 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 241:
-
-/* Line 1806 of yacc.c  */
-#line 1143 "chapel.ypp"
+#line 1143 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pt) = INTENT_BLANK; }
+#line 6443 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 242:
-
-/* Line 1806 of yacc.c  */
-#line 1144 "chapel.ypp"
-    { (yyval.pt) = (yyvsp[(1) - (1)].pt); }
+#line 1144 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pt) = (yyvsp[0].pt); }
+#line 6449 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 243:
-
-/* Line 1806 of yacc.c  */
-#line 1148 "chapel.ypp"
+#line 1148 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pt) = INTENT_IN; }
+#line 6455 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 244:
-
-/* Line 1806 of yacc.c  */
-#line 1149 "chapel.ypp"
+#line 1149 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pt) = INTENT_INOUT; }
+#line 6461 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 245:
-
-/* Line 1806 of yacc.c  */
-#line 1150 "chapel.ypp"
+#line 1150 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pt) = INTENT_OUT; }
+#line 6467 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 246:
-
-/* Line 1806 of yacc.c  */
-#line 1151 "chapel.ypp"
+#line 1151 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pt) = INTENT_CONST; }
+#line 6473 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 247:
-
-/* Line 1806 of yacc.c  */
-#line 1152 "chapel.ypp"
+#line 1152 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pt) = INTENT_CONST_IN; }
+#line 6479 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 248:
-
-/* Line 1806 of yacc.c  */
-#line 1153 "chapel.ypp"
+#line 1153 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pt) = INTENT_CONST_REF; }
+#line 6485 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 249:
-
-/* Line 1806 of yacc.c  */
-#line 1154 "chapel.ypp"
+#line 1154 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pt) = INTENT_PARAM; }
+#line 6491 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 250:
-
-/* Line 1806 of yacc.c  */
-#line 1155 "chapel.ypp"
+#line 1155 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pt) = INTENT_REF; }
+#line 6497 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 251:
-
-/* Line 1806 of yacc.c  */
-#line 1156 "chapel.ypp"
+#line 1156 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pt) = INTENT_TYPE; }
+#line 6503 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 252:
-
-/* Line 1806 of yacc.c  */
-#line 1160 "chapel.ypp"
+#line 1160 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pt) = INTENT_BLANK; }
+#line 6509 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 253:
-
-/* Line 1806 of yacc.c  */
-#line 1161 "chapel.ypp"
+#line 1161 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pt) = INTENT_PARAM; }
+#line 6515 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 254:
-
-/* Line 1806 of yacc.c  */
-#line 1162 "chapel.ypp"
+#line 1162 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pt) = INTENT_REF;   }
+#line 6521 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 255:
-
-/* Line 1806 of yacc.c  */
-#line 1163 "chapel.ypp"
+#line 1163 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pt) = INTENT_CONST_REF;   }
+#line 6527 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 256:
-
-/* Line 1806 of yacc.c  */
-#line 1164 "chapel.ypp"
+#line 1164 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pt) = INTENT_CONST;   }
+#line 6533 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 257:
-
-/* Line 1806 of yacc.c  */
-#line 1165 "chapel.ypp"
+#line 1165 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pt) = INTENT_TYPE;  }
+#line 6539 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 258:
-
-/* Line 1806 of yacc.c  */
-#line 1169 "chapel.ypp"
+#line 1169 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.procIter) = ProcIter_PROC; }
+#line 6545 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 259:
-
-/* Line 1806 of yacc.c  */
-#line 1170 "chapel.ypp"
+#line 1170 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.procIter) = ProcIter_ITER; }
+#line 6551 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 260:
-
-/* Line 1806 of yacc.c  */
-#line 1174 "chapel.ypp"
+#line 1174 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.retTag) = RET_VALUE; }
+#line 6557 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 261:
-
-/* Line 1806 of yacc.c  */
-#line 1175 "chapel.ypp"
+#line 1175 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.retTag) = RET_VALUE; }
+#line 6563 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 262:
-
-/* Line 1806 of yacc.c  */
-#line 1176 "chapel.ypp"
+#line 1176 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.retTag) = RET_CONST_REF; }
+#line 6569 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 263:
-
-/* Line 1806 of yacc.c  */
-#line 1177 "chapel.ypp"
+#line 1177 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.retTag) = RET_REF; }
+#line 6575 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 264:
-
-/* Line 1806 of yacc.c  */
-#line 1178 "chapel.ypp"
+#line 1178 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.retTag) = RET_PARAM; }
+#line 6581 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 265:
-
-/* Line 1806 of yacc.c  */
-#line 1179 "chapel.ypp"
+#line 1179 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.retTag) = RET_TYPE; }
+#line 6587 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 266:
-
-/* Line 1806 of yacc.c  */
-#line 1183 "chapel.ypp"
+#line 1183 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.b) = false; }
+#line 6593 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 267:
-
-/* Line 1806 of yacc.c  */
-#line 1184 "chapel.ypp"
+#line 1184 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.b) = true;  }
+#line 6599 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 268:
-
-/* Line 1806 of yacc.c  */
-#line 1187 "chapel.ypp"
+#line 1187 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pblockstmt) = NULL; }
+#line 6605 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 271:
-
-/* Line 1806 of yacc.c  */
-#line 1193 "chapel.ypp"
-    { (yyval.pblockstmt) = new BlockStmt((yyvsp[(1) - (1)].pblockstmt)); }
+#line 1193 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = new BlockStmt((yyvsp[0].pblockstmt)); }
+#line 6611 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 272:
-
-/* Line 1806 of yacc.c  */
-#line 1198 "chapel.ypp"
-    { (yyval.pdefexpr) = new DefExpr(new VarSymbol((yyvsp[(2) - (2)].pch))); }
+#line 1198 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pdefexpr) = new DefExpr(new VarSymbol((yyvsp[0].pch))); }
+#line 6617 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 273:
-
-/* Line 1806 of yacc.c  */
-#line 1200 "chapel.ypp"
+#line 1200 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pdefexpr) = new DefExpr(new VarSymbol(astr("chpl__query", istr(query_uid++)))); }
+#line 6623 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 274:
-
-/* Line 1806 of yacc.c  */
-#line 1204 "chapel.ypp"
+#line 1204 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pdefexpr) = new DefExpr(new VarSymbol(astr("chpl__query", istr(query_uid++)))); }
+#line 6629 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 276:
-
-/* Line 1806 of yacc.c  */
-#line 1209 "chapel.ypp"
-    { (yyval.pexpr) = (yyvsp[(2) - (2)].pexpr); }
+#line 1209 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = (yyvsp[0].pexpr); }
+#line 6635 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 277:
-
-/* Line 1806 of yacc.c  */
-#line 1210 "chapel.ypp"
-    { (yyvsp[(2) - (2)].pdefexpr)->sym->addFlag(FLAG_PARAM); (yyval.pexpr) = (yyvsp[(2) - (2)].pdefexpr); }
+#line 1210 "chapel.ypp" /* yacc.c:1661  */
+    { (yyvsp[0].pdefexpr)->sym->addFlag(FLAG_PARAM); (yyval.pexpr) = (yyvsp[0].pdefexpr); }
+#line 6641 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 278:
-
-/* Line 1806 of yacc.c  */
-#line 1214 "chapel.ypp"
+#line 1214 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pexpr) = NULL; }
+#line 6647 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 279:
-
-/* Line 1806 of yacc.c  */
-#line 1215 "chapel.ypp"
-    { (yyval.pexpr) = (yyvsp[(2) - (2)].pexpr); }
+#line 1215 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = (yyvsp[0].pexpr); }
+#line 6653 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 280:
-
-/* Line 1806 of yacc.c  */
-#line 1220 "chapel.ypp"
-    { (yyval.pblockstmt) = (yyvsp[(2) - (3)].pblockstmt); }
+#line 1220 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = (yyvsp[-1].pblockstmt); }
+#line 6659 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 281:
-
-/* Line 1806 of yacc.c  */
-#line 1222 "chapel.ypp"
-    { (yyval.pblockstmt) = handleConfigTypes((yyvsp[(3) - (4)].pblockstmt)); }
+#line 1222 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = handleConfigTypes((yyvsp[-1].pblockstmt)); }
+#line 6665 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 282:
-
-/* Line 1806 of yacc.c  */
-#line 1224 "chapel.ypp"
-    { (yyval.pblockstmt) = convertTypesToExtern((yyvsp[(3) - (4)].pblockstmt)); }
+#line 1224 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = convertTypesToExtern((yyvsp[-1].pblockstmt)); }
+#line 6671 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 283:
-
-/* Line 1806 of yacc.c  */
-#line 1229 "chapel.ypp"
+#line 1229 "chapel.ypp" /* yacc.c:1661  */
     {
-      VarSymbol* var = new VarSymbol((yyvsp[(1) - (2)].pch));
+      VarSymbol* var = new VarSymbol((yyvsp[-1].pch));
 
       var->addFlag(FLAG_TYPE_VARIABLE);
 
       var->doc               = context->latestComment;
       context->latestComment = NULL;
 
-      DefExpr* def = new DefExpr(var, (yyvsp[(2) - (2)].pexpr));
+      DefExpr* def = new DefExpr(var, (yyvsp[0].pexpr));
 
       (yyval.pblockstmt) = buildChapelStmt(def);
     }
+#line 6688 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 284:
-
-/* Line 1806 of yacc.c  */
-#line 1242 "chapel.ypp"
+#line 1242 "chapel.ypp" /* yacc.c:1661  */
     {
-      VarSymbol* var = new VarSymbol((yyvsp[(1) - (4)].pch));
+      VarSymbol* var = new VarSymbol((yyvsp[-3].pch));
 
       var->addFlag(FLAG_TYPE_VARIABLE);
 
       var->doc               = context->latestComment;
       context->latestComment = NULL;
 
-      DefExpr* def = new DefExpr(var, (yyvsp[(2) - (4)].pexpr));
+      DefExpr* def = new DefExpr(var, (yyvsp[-2].pexpr));
 
-      (yyvsp[(4) - (4)].pblockstmt)->insertAtHead(def);
-      (yyval.pblockstmt) = buildChapelStmt((yyvsp[(4) - (4)].pblockstmt));
+      (yyvsp[0].pblockstmt)->insertAtHead(def);
+      (yyval.pblockstmt) = buildChapelStmt((yyvsp[0].pblockstmt));
     }
+#line 6706 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 285:
-
-/* Line 1806 of yacc.c  */
-#line 1258 "chapel.ypp"
+#line 1258 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pexpr) = NULL; }
+#line 6712 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 286:
-
-/* Line 1806 of yacc.c  */
-#line 1260 "chapel.ypp"
-    { (yyval.pexpr) = (yyvsp[(2) - (2)].pexpr); }
+#line 1260 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = (yyvsp[0].pexpr); }
+#line 6718 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 287:
-
-/* Line 1806 of yacc.c  */
-#line 1262 "chapel.ypp"
-    { (yyval.pexpr) = buildForallLoopExprFromArrayType((yyvsp[(2) - (2)].pcallexpr)); }
+#line 1262 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = buildForallLoopExprFromArrayType((yyvsp[0].pcallexpr)); }
+#line 6724 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 288:
-
-/* Line 1806 of yacc.c  */
-#line 1267 "chapel.ypp"
+#line 1267 "chapel.ypp" /* yacc.c:1661  */
     {
       std::set<Flag> flags;
-      flags.insert((yyvsp[(1) - (4)].flag));
+      flags.insert((yyvsp[-3].flag));
       flags.insert(FLAG_PARAM);
-      (yyval.pblockstmt) = buildVarDecls((yyvsp[(3) - (4)].pblockstmt), flags, (yylsp[(1) - (4)]).comment);
+      (yyval.pblockstmt) = buildVarDecls((yyvsp[-1].pblockstmt), flags, (yylsp[-3]).comment);
       context->latestComment = NULL;
     }
+#line 6736 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 289:
-
-/* Line 1806 of yacc.c  */
-#line 1275 "chapel.ypp"
+#line 1275 "chapel.ypp" /* yacc.c:1661  */
     {
       std::set<Flag> flags;
-      flags.insert((yyvsp[(1) - (4)].flag));
+      flags.insert((yyvsp[-3].flag));
       flags.insert(FLAG_CONST);
-      (yyval.pblockstmt) = buildVarDecls((yyvsp[(3) - (4)].pblockstmt), flags, (yylsp[(1) - (4)]).comment);
+      (yyval.pblockstmt) = buildVarDecls((yyvsp[-1].pblockstmt), flags, (yylsp[-3]).comment);
       context->latestComment = NULL;
     }
+#line 6748 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 290:
-
-/* Line 1806 of yacc.c  */
-#line 1283 "chapel.ypp"
+#line 1283 "chapel.ypp" /* yacc.c:1661  */
     {
       std::set<Flag> flags;
-      flags.insert((yyvsp[(1) - (4)].flag));
+      flags.insert((yyvsp[-3].flag));
       flags.insert(FLAG_REF_VAR);
-      (yyval.pblockstmt) = buildVarDecls((yyvsp[(3) - (4)].pblockstmt), flags, (yylsp[(1) - (4)]).comment);
+      (yyval.pblockstmt) = buildVarDecls((yyvsp[-1].pblockstmt), flags, (yylsp[-3]).comment);
       context->latestComment = NULL;
     }
+#line 6760 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 291:
-
-/* Line 1806 of yacc.c  */
-#line 1291 "chapel.ypp"
+#line 1291 "chapel.ypp" /* yacc.c:1661  */
     {
       std::set<Flag> flags;
-      flags.insert((yyvsp[(1) - (5)].flag));
+      flags.insert((yyvsp[-4].flag));
       flags.insert(FLAG_CONST);
       flags.insert(FLAG_REF_VAR);
-      (yyval.pblockstmt) = buildVarDecls((yyvsp[(4) - (5)].pblockstmt), flags, (yylsp[(1) - (5)]).comment);
+      (yyval.pblockstmt) = buildVarDecls((yyvsp[-1].pblockstmt), flags, (yylsp[-4]).comment);
       context->latestComment = NULL;
     }
+#line 6773 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 292:
-
-/* Line 1806 of yacc.c  */
-#line 1300 "chapel.ypp"
+#line 1300 "chapel.ypp" /* yacc.c:1661  */
     {
       std::set<Flag> flags;
-      flags.insert((yyvsp[(1) - (4)].flag));
-      (yyval.pblockstmt) = buildVarDecls((yyvsp[(3) - (4)].pblockstmt), flags, (yylsp[(1) - (4)]).comment);
+      flags.insert((yyvsp[-3].flag));
+      (yyval.pblockstmt) = buildVarDecls((yyvsp[-1].pblockstmt), flags, (yylsp[-3]).comment);
       context->latestComment = NULL;
     }
+#line 6784 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 293:
-
-/* Line 1806 of yacc.c  */
-#line 1309 "chapel.ypp"
+#line 1309 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.flag) = FLAG_UNKNOWN; (yyloc).comment = context->latestComment; context->latestComment = NULL; }
+#line 6790 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 294:
-
-/* Line 1806 of yacc.c  */
-#line 1310 "chapel.ypp"
+#line 1310 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.flag) = FLAG_CONFIG;  (yyloc).comment = context->latestComment; context->latestComment = NULL; }
+#line 6796 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 295:
-
-/* Line 1806 of yacc.c  */
-#line 1311 "chapel.ypp"
+#line 1311 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.flag) = FLAG_EXTERN;  (yyloc).comment = context->latestComment; context->latestComment = NULL; }
+#line 6802 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 297:
-
-/* Line 1806 of yacc.c  */
-#line 1317 "chapel.ypp"
+#line 1317 "chapel.ypp" /* yacc.c:1661  */
     {
-      for_alist(expr, (yyvsp[(3) - (3)].pblockstmt)->body)
-        (yyvsp[(1) - (3)].pblockstmt)->insertAtTail(expr->remove());
+      for_alist(expr, (yyvsp[0].pblockstmt)->body)
+        (yyvsp[-2].pblockstmt)->insertAtTail(expr->remove());
     }
+#line 6811 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 298:
-
-/* Line 1806 of yacc.c  */
-#line 1325 "chapel.ypp"
-    { (yyval.pblockstmt) = buildChapelStmt(new DefExpr(new VarSymbol((yyvsp[(1) - (3)].pch)), (yyvsp[(3) - (3)].pexpr), (yyvsp[(2) - (3)].pexpr))); }
+#line 1325 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildChapelStmt(new DefExpr(new VarSymbol((yyvsp[-2].pch)), (yyvsp[0].pexpr), (yyvsp[-1].pexpr))); }
+#line 6817 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 299:
-
-/* Line 1806 of yacc.c  */
-#line 1327 "chapel.ypp"
-    { (yyval.pblockstmt) = buildTupleVarDeclStmt((yyvsp[(2) - (5)].pblockstmt), (yyvsp[(4) - (5)].pexpr), (yyvsp[(5) - (5)].pexpr)); }
+#line 1327 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildTupleVarDeclStmt((yyvsp[-3].pblockstmt), (yyvsp[-1].pexpr), (yyvsp[0].pexpr)); }
+#line 6823 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 300:
-
-/* Line 1806 of yacc.c  */
-#line 1332 "chapel.ypp"
+#line 1332 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pexpr) = new DefExpr(new VarSymbol("chpl__tuple_blank")); }
+#line 6829 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 301:
-
-/* Line 1806 of yacc.c  */
-#line 1334 "chapel.ypp"
-    { (yyval.pexpr) = new DefExpr(new VarSymbol((yyvsp[(1) - (1)].pch))); }
+#line 1334 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new DefExpr(new VarSymbol((yyvsp[0].pch))); }
+#line 6835 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 302:
-
-/* Line 1806 of yacc.c  */
-#line 1336 "chapel.ypp"
-    { (yyval.pexpr) = (yyvsp[(2) - (3)].pblockstmt); }
+#line 1336 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = (yyvsp[-1].pblockstmt); }
+#line 6841 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 303:
-
-/* Line 1806 of yacc.c  */
-#line 1341 "chapel.ypp"
-    { (yyval.pblockstmt) = buildChapelStmt((yyvsp[(1) - (1)].pexpr)); }
+#line 1341 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildChapelStmt((yyvsp[0].pexpr)); }
+#line 6847 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 304:
-
-/* Line 1806 of yacc.c  */
-#line 1343 "chapel.ypp"
-    { (yyval.pblockstmt) = buildChapelStmt((yyvsp[(1) - (2)].pexpr)); }
+#line 1343 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = buildChapelStmt((yyvsp[-1].pexpr)); }
+#line 6853 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 305:
-
-/* Line 1806 of yacc.c  */
-#line 1345 "chapel.ypp"
-    { (yyval.pblockstmt) = ((yyvsp[(3) - (3)].pblockstmt)->insertAtHead((yyvsp[(1) - (3)].pexpr)), (yyvsp[(3) - (3)].pblockstmt)); }
+#line 1345 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pblockstmt) = ((yyvsp[0].pblockstmt)->insertAtHead((yyvsp[-2].pexpr)), (yyvsp[0].pblockstmt)); }
+#line 6859 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 306:
-
-/* Line 1806 of yacc.c  */
-#line 1351 "chapel.ypp"
+#line 1351 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pexpr) = NULL; }
+#line 6865 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 307:
-
-/* Line 1806 of yacc.c  */
-#line 1352 "chapel.ypp"
+#line 1352 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pexpr) = new SymExpr(gNoInit); }
+#line 6871 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 308:
-
-/* Line 1806 of yacc.c  */
-#line 1353 "chapel.ypp"
-    { (yyval.pexpr) = (yyvsp[(2) - (2)].pexpr); }
+#line 1353 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = (yyvsp[0].pexpr); }
+#line 6877 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 309:
-
-/* Line 1806 of yacc.c  */
-#line 1357 "chapel.ypp"
+#line 1357 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pexpr) = NULL; }
+#line 6883 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 310:
-
-/* Line 1806 of yacc.c  */
-#line 1358 "chapel.ypp"
-    { (yyval.pexpr) = (yyvsp[(2) - (2)].pexpr); }
+#line 1358 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = (yyvsp[0].pexpr); }
+#line 6889 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 311:
-
-/* Line 1806 of yacc.c  */
-#line 1359 "chapel.ypp"
-    { (yyval.pexpr) = (yyvsp[(2) - (2)].pcallexpr); }
+#line 1359 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = (yyvsp[0].pcallexpr); }
+#line 6895 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 312:
-
-/* Line 1806 of yacc.c  */
-#line 1360 "chapel.ypp"
+#line 1360 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pexpr) = NULL; }
+#line 6901 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 313:
-
-/* Line 1806 of yacc.c  */
-#line 1381 "chapel.ypp"
+#line 1381 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pcallexpr) = new CallExpr("chpl__buildArrayRuntimeType",
-             new CallExpr("chpl__ensureDomainExpr", (yyvsp[(2) - (4)].pcallexpr)), (yyvsp[(4) - (4)].pexpr));
+             new CallExpr("chpl__ensureDomainExpr", (yyvsp[-2].pcallexpr)), (yyvsp[0].pexpr));
     }
+#line 6909 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 314:
-
-/* Line 1806 of yacc.c  */
-#line 1385 "chapel.ypp"
+#line 1385 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pcallexpr) = new CallExpr("chpl__buildArrayRuntimeType",
-             new CallExpr("chpl__ensureDomainExpr", (yyvsp[(2) - (4)].pcallexpr)), (yyvsp[(4) - (4)].pcallexpr));
+             new CallExpr("chpl__ensureDomainExpr", (yyvsp[-2].pcallexpr)), (yyvsp[0].pcallexpr));
     }
+#line 6917 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 315:
-
-/* Line 1806 of yacc.c  */
-#line 1389 "chapel.ypp"
+#line 1389 "chapel.ypp" /* yacc.c:1661  */
     {
-      if ((yyvsp[(2) - (6)].pcallexpr)->argList.length != 1)
-        USR_FATAL((yyvsp[(4) - (6)].pexpr), "invalid index expression");
+      if ((yyvsp[-4].pcallexpr)->argList.length != 1)
+        USR_FATAL((yyvsp[-2].pexpr), "invalid index expression");
       (yyval.pcallexpr) = new CallExpr("chpl__buildArrayRuntimeType",
-             new CallExpr("chpl__ensureDomainExpr", (yyvsp[(4) - (6)].pexpr)), (yyvsp[(6) - (6)].pexpr), (yyvsp[(2) - (6)].pcallexpr)->get(1)->remove(),
-             new CallExpr("chpl__ensureDomainExpr", (yyvsp[(4) - (6)].pexpr)->copy()));
+             new CallExpr("chpl__ensureDomainExpr", (yyvsp[-2].pexpr)), (yyvsp[0].pexpr), (yyvsp[-4].pcallexpr)->get(1)->remove(),
+             new CallExpr("chpl__ensureDomainExpr", (yyvsp[-2].pexpr)->copy()));
     }
+#line 6929 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 316:
-
-/* Line 1806 of yacc.c  */
-#line 1397 "chapel.ypp"
+#line 1397 "chapel.ypp" /* yacc.c:1661  */
     {
       (yyval.pcallexpr) = new CallExpr(PRIM_ERROR);
     }
+#line 6937 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 317:
-
-/* Line 1806 of yacc.c  */
-#line 1403 "chapel.ypp"
+#line 1403 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pexpr) = NULL; }
+#line 6943 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 318:
-
-/* Line 1806 of yacc.c  */
-#line 1404 "chapel.ypp"
-    { (yyval.pexpr) = (yyvsp[(1) - (1)].pexpr); }
+#line 1404 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = (yyvsp[0].pexpr); }
+#line 6949 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 319:
-
-/* Line 1806 of yacc.c  */
-#line 1405 "chapel.ypp"
-    { (yyval.pexpr) = (yyvsp[(1) - (1)].pdefexpr); }
+#line 1405 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = (yyvsp[0].pdefexpr); }
+#line 6955 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 320:
-
-/* Line 1806 of yacc.c  */
-#line 1410 "chapel.ypp"
-    { (yyval.pexpr) = new CallExpr("chpl__buildArrayRuntimeType", gNil, (yyvsp[(3) - (3)].pexpr)); }
+#line 1410 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new CallExpr("chpl__buildArrayRuntimeType", gNil, (yyvsp[0].pexpr)); }
+#line 6961 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 321:
-
-/* Line 1806 of yacc.c  */
-#line 1412 "chapel.ypp"
-    { (yyval.pexpr) = buildFormalArrayType((yyvsp[(2) - (4)].pcallexpr), (yyvsp[(4) - (4)].pexpr)); }
+#line 1412 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = buildFormalArrayType((yyvsp[-2].pcallexpr), (yyvsp[0].pexpr)); }
+#line 6967 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 322:
-
-/* Line 1806 of yacc.c  */
-#line 1418 "chapel.ypp"
-    { (yyval.pexpr) = new CallExpr("chpl__buildArrayRuntimeType", gNil, (yyvsp[(3) - (3)].pexpr)); }
+#line 1418 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new CallExpr("chpl__buildArrayRuntimeType", gNil, (yyvsp[0].pexpr)); }
+#line 6973 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 323:
-
-/* Line 1806 of yacc.c  */
-#line 1420 "chapel.ypp"
-    { (yyval.pexpr) = buildFormalArrayType((yyvsp[(2) - (4)].pcallexpr), (yyvsp[(4) - (4)].pexpr)); }
+#line 1420 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = buildFormalArrayType((yyvsp[-2].pcallexpr), (yyvsp[0].pexpr)); }
+#line 6979 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 324:
-
-/* Line 1806 of yacc.c  */
-#line 1422 "chapel.ypp"
-    { (yyval.pexpr) = buildFormalArrayType((yyvsp[(4) - (6)].pexpr), (yyvsp[(6) - (6)].pexpr), (yyvsp[(2) - (6)].pcallexpr)); }
+#line 1422 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = buildFormalArrayType((yyvsp[-2].pexpr), (yyvsp[0].pexpr), (yyvsp[-4].pcallexpr)); }
+#line 6985 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 325:
-
-/* Line 1806 of yacc.c  */
-#line 1426 "chapel.ypp"
+#line 1426 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pexpr) = NULL; }
+#line 6991 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 326:
-
-/* Line 1806 of yacc.c  */
-#line 1427 "chapel.ypp"
-    { (yyval.pexpr) = (yyvsp[(2) - (2)].pexpr); }
+#line 1427 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = (yyvsp[0].pexpr); }
+#line 6997 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 327:
-
-/* Line 1806 of yacc.c  */
-#line 1428 "chapel.ypp"
-    { (yyval.pexpr) = (yyvsp[(2) - (2)].pdefexpr); }
+#line 1428 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = (yyvsp[0].pdefexpr); }
+#line 7003 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 328:
-
-/* Line 1806 of yacc.c  */
-#line 1429 "chapel.ypp"
+#line 1429 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pexpr) = new UnresolvedSymExpr("_domain"); }
+#line 7009 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 329:
-
-/* Line 1806 of yacc.c  */
-#line 1430 "chapel.ypp"
+#line 1430 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pexpr) = new UnresolvedSymExpr( "_singlevar"); }
+#line 7015 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 330:
-
-/* Line 1806 of yacc.c  */
-#line 1431 "chapel.ypp"
+#line 1431 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pexpr) = new UnresolvedSymExpr( "_syncvar"); }
+#line 7021 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 331:
-
-/* Line 1806 of yacc.c  */
-#line 1432 "chapel.ypp"
-    { (yyval.pexpr) = (yyvsp[(2) - (2)].pexpr); }
+#line 1432 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = (yyvsp[0].pexpr); }
+#line 7027 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 332:
-
-/* Line 1806 of yacc.c  */
-#line 1438 "chapel.ypp"
-    { (yyval.pcallexpr) = new CallExpr(PRIM_ACTUALS_LIST, (yyvsp[(1) - (1)].pexpr)); }
+#line 1438 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pcallexpr) = new CallExpr(PRIM_ACTUALS_LIST, (yyvsp[0].pexpr)); }
+#line 7033 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 333:
-
-/* Line 1806 of yacc.c  */
-#line 1439 "chapel.ypp"
-    { (yyval.pcallexpr) = new CallExpr(PRIM_ACTUALS_LIST, (yyvsp[(1) - (1)].pdefexpr)); }
+#line 1439 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pcallexpr) = new CallExpr(PRIM_ACTUALS_LIST, (yyvsp[0].pdefexpr)); }
+#line 7039 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 334:
-
-/* Line 1806 of yacc.c  */
-#line 1440 "chapel.ypp"
-    { (yyvsp[(1) - (3)].pcallexpr)->insertAtTail((yyvsp[(3) - (3)].pexpr)); }
+#line 1440 "chapel.ypp" /* yacc.c:1661  */
+    { (yyvsp[-2].pcallexpr)->insertAtTail((yyvsp[0].pexpr)); }
+#line 7045 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 335:
-
-/* Line 1806 of yacc.c  */
-#line 1441 "chapel.ypp"
-    { (yyvsp[(1) - (3)].pcallexpr)->insertAtTail((yyvsp[(3) - (3)].pdefexpr)); }
+#line 1441 "chapel.ypp" /* yacc.c:1661  */
+    { (yyvsp[-2].pcallexpr)->insertAtTail((yyvsp[0].pdefexpr)); }
+#line 7051 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 336:
-
-/* Line 1806 of yacc.c  */
-#line 1445 "chapel.ypp"
-    { (yyval.pcallexpr) = new CallExpr(PRIM_ACTUALS_LIST, (yyvsp[(1) - (1)].pexpr));}
+#line 1445 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pcallexpr) = new CallExpr(PRIM_ACTUALS_LIST, (yyvsp[0].pexpr));}
+#line 7057 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 337:
-
-/* Line 1806 of yacc.c  */
-#line 1446 "chapel.ypp"
-    { (yyvsp[(1) - (3)].pcallexpr)->insertAtTail((yyvsp[(3) - (3)].pexpr)); }
+#line 1446 "chapel.ypp" /* yacc.c:1661  */
+    { (yyvsp[-2].pcallexpr)->insertAtTail((yyvsp[0].pexpr)); }
+#line 7063 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 338:
-
-/* Line 1806 of yacc.c  */
-#line 1450 "chapel.ypp"
+#line 1450 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pexpr) = new UnresolvedSymExpr("chpl__tuple_blank"); }
+#line 7069 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 339:
-
-/* Line 1806 of yacc.c  */
-#line 1451 "chapel.ypp"
-    { (yyval.pexpr) = (yyvsp[(1) - (1)].pexpr); }
+#line 1451 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = (yyvsp[0].pexpr); }
+#line 7075 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 340:
-
-/* Line 1806 of yacc.c  */
-#line 1452 "chapel.ypp"
-    { (yyval.pexpr) = (yyvsp[(1) - (1)].pdefexpr); }
+#line 1452 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = (yyvsp[0].pdefexpr); }
+#line 7081 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 341:
-
-/* Line 1806 of yacc.c  */
-#line 1456 "chapel.ypp"
-    { (yyval.pcallexpr) = new CallExpr(PRIM_ACTUALS_LIST, (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
+#line 1456 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pcallexpr) = new CallExpr(PRIM_ACTUALS_LIST, (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
+#line 7087 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 342:
-
-/* Line 1806 of yacc.c  */
-#line 1457 "chapel.ypp"
-    { (yyvsp[(1) - (3)].pcallexpr)->insertAtTail((yyvsp[(3) - (3)].pexpr)); }
+#line 1457 "chapel.ypp" /* yacc.c:1661  */
+    { (yyvsp[-2].pcallexpr)->insertAtTail((yyvsp[0].pexpr)); }
+#line 7093 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 343:
-
-/* Line 1806 of yacc.c  */
-#line 1461 "chapel.ypp"
+#line 1461 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pcallexpr) = new CallExpr(PRIM_ACTUALS_LIST); }
+#line 7099 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 345:
-
-/* Line 1806 of yacc.c  */
-#line 1466 "chapel.ypp"
-    { (yyval.pcallexpr) = new CallExpr(PRIM_ACTUALS_LIST, (yyvsp[(1) - (1)].pexpr)); }
+#line 1466 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pcallexpr) = new CallExpr(PRIM_ACTUALS_LIST, (yyvsp[0].pexpr)); }
+#line 7105 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 346:
-
-/* Line 1806 of yacc.c  */
-#line 1467 "chapel.ypp"
-    { (yyvsp[(1) - (3)].pcallexpr)->insertAtTail((yyvsp[(3) - (3)].pexpr)); }
+#line 1467 "chapel.ypp" /* yacc.c:1661  */
+    { (yyvsp[-2].pcallexpr)->insertAtTail((yyvsp[0].pexpr)); }
+#line 7111 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 347:
-
-/* Line 1806 of yacc.c  */
-#line 1471 "chapel.ypp"
-    { (yyval.pexpr) = buildNamedActual((yyvsp[(1) - (3)].pch), (yyvsp[(3) - (3)].pdefexpr)); }
+#line 1471 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = buildNamedActual((yyvsp[-2].pch), (yyvsp[0].pdefexpr)); }
+#line 7117 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 348:
-
-/* Line 1806 of yacc.c  */
-#line 1472 "chapel.ypp"
-    { (yyval.pexpr) = buildNamedActual((yyvsp[(1) - (3)].pch), (yyvsp[(3) - (3)].pexpr)); }
+#line 1472 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = buildNamedActual((yyvsp[-2].pch), (yyvsp[0].pexpr)); }
+#line 7123 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 349:
-
-/* Line 1806 of yacc.c  */
-#line 1473 "chapel.ypp"
-    { (yyval.pexpr) = (yyvsp[(1) - (1)].pdefexpr); }
+#line 1473 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = (yyvsp[0].pdefexpr); }
+#line 7129 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 350:
-
-/* Line 1806 of yacc.c  */
-#line 1474 "chapel.ypp"
-    { (yyval.pexpr) = (yyvsp[(1) - (1)].pexpr); }
+#line 1474 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = (yyvsp[0].pexpr); }
+#line 7135 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 351:
-
-/* Line 1806 of yacc.c  */
-#line 1478 "chapel.ypp"
-    { (yyval.pexpr) = new UnresolvedSymExpr((yyvsp[(1) - (1)].pch)); }
+#line 1478 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new UnresolvedSymExpr((yyvsp[0].pch)); }
+#line 7141 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 357:
-
-/* Line 1806 of yacc.c  */
-#line 1495 "chapel.ypp"
-    { (yyval.pexpr) = new CallExpr( "_singlevar", (yyvsp[(2) - (2)].pexpr)); }
+#line 1495 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new CallExpr( "_singlevar", (yyvsp[0].pexpr)); }
+#line 7147 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 358:
-
-/* Line 1806 of yacc.c  */
-#line 1497 "chapel.ypp"
-    { (yyval.pexpr) = new CallExpr("chpl__buildIndexType", (yyvsp[(3) - (4)].pcallexpr)); }
+#line 1497 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new CallExpr("chpl__buildIndexType", (yyvsp[-1].pcallexpr)); }
+#line 7153 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 359:
-
-/* Line 1806 of yacc.c  */
-#line 1499 "chapel.ypp"
-    { (yyval.pexpr) = new CallExpr("chpl__buildDomainRuntimeType", new UnresolvedSymExpr("defaultDist"), (yyvsp[(3) - (4)].pcallexpr)); }
+#line 1499 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new CallExpr("chpl__buildDomainRuntimeType", new UnresolvedSymExpr("defaultDist"), (yyvsp[-1].pcallexpr)); }
+#line 7159 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 360:
-
-/* Line 1806 of yacc.c  */
-#line 1501 "chapel.ypp"
-    { (yyval.pexpr) = new CallExpr("chpl__buildSubDomainType", (yyvsp[(3) - (4)].pcallexpr)); }
+#line 1501 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new CallExpr("chpl__buildSubDomainType", (yyvsp[-1].pcallexpr)); }
+#line 7165 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 361:
-
-/* Line 1806 of yacc.c  */
-#line 1503 "chapel.ypp"
-    { (yyval.pexpr) = new CallExpr("chpl__buildSparseDomainRuntimeType", buildDotExpr((yyvsp[(4) - (5)].pcallexpr)->copy(), "defaultSparseDist"), (yyvsp[(4) - (5)].pcallexpr)); }
+#line 1503 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new CallExpr("chpl__buildSparseDomainRuntimeType", buildDotExpr((yyvsp[-1].pcallexpr)->copy(), "defaultSparseDist"), (yyvsp[-1].pcallexpr)); }
+#line 7171 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 362:
-
-/* Line 1806 of yacc.c  */
-#line 1505 "chapel.ypp"
-    { (yyval.pexpr) = new CallExpr("chpl__atomicType", (yyvsp[(2) - (2)].pexpr)); }
+#line 1505 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new CallExpr("chpl__atomicType", (yyvsp[0].pexpr)); }
+#line 7177 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 363:
-
-/* Line 1806 of yacc.c  */
-#line 1507 "chapel.ypp"
-    { (yyval.pexpr) = new CallExpr( "_syncvar", (yyvsp[(2) - (2)].pexpr)); }
+#line 1507 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new CallExpr( "_syncvar", (yyvsp[0].pexpr)); }
+#line 7183 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 364:
-
-/* Line 1806 of yacc.c  */
-#line 1512 "chapel.ypp"
-    { (yyval.pexpr) = buildForLoopExpr((yyvsp[(2) - (6)].pexpr), (yyvsp[(4) - (6)].pexpr), (yyvsp[(6) - (6)].pexpr)); }
+#line 1512 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = buildForLoopExpr((yyvsp[-4].pexpr), (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
+#line 7189 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 365:
-
-/* Line 1806 of yacc.c  */
-#line 1514 "chapel.ypp"
-    { (yyval.pexpr) = buildForLoopExpr((yyvsp[(2) - (6)].pexpr), zipToTuple((yyvsp[(4) - (6)].pcallexpr)), (yyvsp[(6) - (6)].pexpr), NULL, false, true); }
+#line 1514 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = buildForLoopExpr((yyvsp[-4].pexpr), zipToTuple((yyvsp[-2].pcallexpr)), (yyvsp[0].pexpr), NULL, false, true); }
+#line 7195 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 366:
-
-/* Line 1806 of yacc.c  */
-#line 1516 "chapel.ypp"
-    { (yyval.pexpr) = buildForLoopExpr(NULL, (yyvsp[(2) - (4)].pexpr), (yyvsp[(4) - (4)].pexpr)); }
+#line 1516 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = buildForLoopExpr(NULL, (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
+#line 7201 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 367:
-
-/* Line 1806 of yacc.c  */
-#line 1518 "chapel.ypp"
-    { (yyval.pexpr) = buildForLoopExpr((yyvsp[(2) - (9)].pexpr), (yyvsp[(4) - (9)].pexpr), (yyvsp[(9) - (9)].pexpr), (yyvsp[(7) - (9)].pexpr)); }
+#line 1518 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = buildForLoopExpr((yyvsp[-7].pexpr), (yyvsp[-5].pexpr), (yyvsp[0].pexpr), (yyvsp[-2].pexpr)); }
+#line 7207 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 368:
-
-/* Line 1806 of yacc.c  */
-#line 1520 "chapel.ypp"
-    { (yyval.pexpr) = buildForLoopExpr((yyvsp[(2) - (9)].pexpr), zipToTuple((yyvsp[(4) - (9)].pcallexpr)), (yyvsp[(9) - (9)].pexpr), (yyvsp[(7) - (9)].pexpr), false, true); }
+#line 1520 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = buildForLoopExpr((yyvsp[-7].pexpr), zipToTuple((yyvsp[-5].pcallexpr)), (yyvsp[0].pexpr), (yyvsp[-2].pexpr), false, true); }
+#line 7213 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 369:
-
-/* Line 1806 of yacc.c  */
-#line 1522 "chapel.ypp"
-    { (yyval.pexpr) = buildForLoopExpr(NULL, (yyvsp[(2) - (7)].pexpr), (yyvsp[(7) - (7)].pexpr), (yyvsp[(5) - (7)].pexpr)); }
+#line 1522 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = buildForLoopExpr(NULL, (yyvsp[-5].pexpr), (yyvsp[0].pexpr), (yyvsp[-2].pexpr)); }
+#line 7219 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 370:
-
-/* Line 1806 of yacc.c  */
-#line 1524 "chapel.ypp"
-    { (yyval.pexpr) = buildForallLoopExpr((yyvsp[(2) - (6)].pexpr), (yyvsp[(4) - (6)].pexpr), (yyvsp[(6) - (6)].pexpr)); }
+#line 1524 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = buildForallLoopExpr((yyvsp[-4].pexpr), (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
+#line 7225 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 371:
-
-/* Line 1806 of yacc.c  */
-#line 1526 "chapel.ypp"
-    { (yyval.pexpr) = buildForallLoopExpr((yyvsp[(2) - (6)].pexpr), zipToTuple((yyvsp[(4) - (6)].pcallexpr)), (yyvsp[(6) - (6)].pexpr), NULL, false, true); }
+#line 1526 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = buildForallLoopExpr((yyvsp[-4].pexpr), zipToTuple((yyvsp[-2].pcallexpr)), (yyvsp[0].pexpr), NULL, false, true); }
+#line 7231 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 372:
-
-/* Line 1806 of yacc.c  */
-#line 1528 "chapel.ypp"
-    { (yyval.pexpr) = buildForallLoopExpr(NULL, (yyvsp[(2) - (4)].pexpr), (yyvsp[(4) - (4)].pexpr)); }
+#line 1528 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = buildForallLoopExpr(NULL, (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
+#line 7237 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 373:
-
-/* Line 1806 of yacc.c  */
-#line 1530 "chapel.ypp"
-    { (yyval.pexpr) = buildForallLoopExpr((yyvsp[(2) - (9)].pexpr), (yyvsp[(4) - (9)].pexpr), (yyvsp[(9) - (9)].pexpr), (yyvsp[(7) - (9)].pexpr)); }
+#line 1530 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = buildForallLoopExpr((yyvsp[-7].pexpr), (yyvsp[-5].pexpr), (yyvsp[0].pexpr), (yyvsp[-2].pexpr)); }
+#line 7243 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 374:
-
-/* Line 1806 of yacc.c  */
-#line 1532 "chapel.ypp"
-    { (yyval.pexpr) = buildForallLoopExpr((yyvsp[(2) - (9)].pexpr), zipToTuple((yyvsp[(4) - (9)].pcallexpr)), (yyvsp[(9) - (9)].pexpr), (yyvsp[(7) - (9)].pexpr), false, true); }
+#line 1532 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = buildForallLoopExpr((yyvsp[-7].pexpr), zipToTuple((yyvsp[-5].pcallexpr)), (yyvsp[0].pexpr), (yyvsp[-2].pexpr), false, true); }
+#line 7249 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 375:
-
-/* Line 1806 of yacc.c  */
-#line 1534 "chapel.ypp"
-    { (yyval.pexpr) = buildForallLoopExpr(NULL, (yyvsp[(2) - (7)].pexpr), (yyvsp[(7) - (7)].pexpr), (yyvsp[(5) - (7)].pexpr)); }
+#line 1534 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = buildForallLoopExpr(NULL, (yyvsp[-5].pexpr), (yyvsp[0].pexpr), (yyvsp[-2].pexpr)); }
+#line 7255 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 376:
-
-/* Line 1806 of yacc.c  */
-#line 1536 "chapel.ypp"
+#line 1536 "chapel.ypp" /* yacc.c:1661  */
     {
-      if ((yyvsp[(2) - (4)].pcallexpr)->argList.length > 1)
-        (yyval.pexpr) = buildForallLoopExpr(NULL, new CallExpr("chpl__ensureDomainExpr", (yyvsp[(2) - (4)].pcallexpr)), (yyvsp[(4) - (4)].pexpr), NULL, true);
+      if ((yyvsp[-2].pcallexpr)->argList.length > 1)
+        (yyval.pexpr) = buildForallLoopExpr(NULL, new CallExpr("chpl__ensureDomainExpr", (yyvsp[-2].pcallexpr)), (yyvsp[0].pexpr), NULL, true);
       else
-        (yyval.pexpr) = buildForallLoopExpr(NULL, (yyvsp[(2) - (4)].pcallexpr)->get(1)->remove(), (yyvsp[(4) - (4)].pexpr), NULL, true);
+        (yyval.pexpr) = buildForallLoopExpr(NULL, (yyvsp[-2].pcallexpr)->get(1)->remove(), (yyvsp[0].pexpr), NULL, true);
     }
+#line 7266 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 377:
-
-/* Line 1806 of yacc.c  */
-#line 1543 "chapel.ypp"
+#line 1543 "chapel.ypp" /* yacc.c:1661  */
     {
-      if ((yyvsp[(2) - (6)].pcallexpr)->argList.length != 1)
-        USR_FATAL((yyvsp[(4) - (6)].pexpr), "invalid index expression");
-      (yyval.pexpr) = buildForallLoopExpr((yyvsp[(2) - (6)].pcallexpr)->get(1)->remove(), (yyvsp[(4) - (6)].pexpr), (yyvsp[(6) - (6)].pexpr), NULL, true);
+      if ((yyvsp[-4].pcallexpr)->argList.length != 1)
+        USR_FATAL((yyvsp[-2].pexpr), "invalid index expression");
+      (yyval.pexpr) = buildForallLoopExpr((yyvsp[-4].pcallexpr)->get(1)->remove(), (yyvsp[-2].pexpr), (yyvsp[0].pexpr), NULL, true);
     }
+#line 7276 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 378:
-
-/* Line 1806 of yacc.c  */
-#line 1549 "chapel.ypp"
+#line 1549 "chapel.ypp" /* yacc.c:1661  */
     {
-      if ((yyvsp[(2) - (6)].pcallexpr)->argList.length != 1)
-        USR_FATAL((yyvsp[(4) - (6)].pcallexpr), "invalid index expression");
-      (yyval.pexpr) = buildForallLoopExpr((yyvsp[(2) - (6)].pcallexpr)->get(1)->remove(), zipToTuple((yyvsp[(4) - (6)].pcallexpr)), (yyvsp[(6) - (6)].pexpr), NULL, false, true);
+      if ((yyvsp[-4].pcallexpr)->argList.length != 1)
+        USR_FATAL((yyvsp[-2].pcallexpr), "invalid index expression");
+      (yyval.pexpr) = buildForallLoopExpr((yyvsp[-4].pcallexpr)->get(1)->remove(), zipToTuple((yyvsp[-2].pcallexpr)), (yyvsp[0].pexpr), NULL, false, true);
     }
+#line 7286 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 379:
-
-/* Line 1806 of yacc.c  */
-#line 1555 "chapel.ypp"
+#line 1555 "chapel.ypp" /* yacc.c:1661  */
     {
-      if ((yyvsp[(2) - (9)].pcallexpr)->argList.length != 1)
-        USR_FATAL((yyvsp[(4) - (9)].pexpr), "invalid index expression");
-      (yyval.pexpr) = buildForallLoopExpr((yyvsp[(2) - (9)].pcallexpr)->get(1)->remove(), (yyvsp[(4) - (9)].pexpr), (yyvsp[(9) - (9)].pexpr), (yyvsp[(7) - (9)].pexpr));
+      if ((yyvsp[-7].pcallexpr)->argList.length != 1)
+        USR_FATAL((yyvsp[-5].pexpr), "invalid index expression");
+      (yyval.pexpr) = buildForallLoopExpr((yyvsp[-7].pcallexpr)->get(1)->remove(), (yyvsp[-5].pexpr), (yyvsp[0].pexpr), (yyvsp[-2].pexpr));
     }
+#line 7296 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 380:
-
-/* Line 1806 of yacc.c  */
-#line 1561 "chapel.ypp"
+#line 1561 "chapel.ypp" /* yacc.c:1661  */
     {
-      if ((yyvsp[(2) - (9)].pcallexpr)->argList.length != 1)
-        USR_FATAL((yyvsp[(4) - (9)].pcallexpr), "invalid index expression");
-      (yyval.pexpr) = buildForallLoopExpr((yyvsp[(2) - (9)].pcallexpr)->get(1)->remove(), zipToTuple((yyvsp[(4) - (9)].pcallexpr)), (yyvsp[(9) - (9)].pexpr), (yyvsp[(7) - (9)].pexpr), false, true);
+      if ((yyvsp[-7].pcallexpr)->argList.length != 1)
+        USR_FATAL((yyvsp[-5].pcallexpr), "invalid index expression");
+      (yyval.pexpr) = buildForallLoopExpr((yyvsp[-7].pcallexpr)->get(1)->remove(), zipToTuple((yyvsp[-5].pcallexpr)), (yyvsp[0].pexpr), (yyvsp[-2].pexpr), false, true);
     }
+#line 7306 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 381:
-
-/* Line 1806 of yacc.c  */
-#line 1570 "chapel.ypp"
-    { (yyval.pexpr) = new CallExpr(new DefExpr(buildIfExpr((yyvsp[(2) - (6)].pexpr), (yyvsp[(4) - (6)].pexpr), (yyvsp[(6) - (6)].pexpr)))); }
+#line 1570 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new CallExpr(new DefExpr(buildIfExpr((yyvsp[-4].pexpr), (yyvsp[-2].pexpr), (yyvsp[0].pexpr)))); }
+#line 7312 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 382:
-
-/* Line 1806 of yacc.c  */
-#line 1579 "chapel.ypp"
+#line 1579 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pexpr) = new SymExpr(gNil); }
+#line 7318 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 390:
-
-/* Line 1806 of yacc.c  */
-#line 1595 "chapel.ypp"
-    { (yyval.pexpr) = new CallExpr("<~>", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
+#line 1595 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new CallExpr("<~>", (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
+#line 7324 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 391:
-
-/* Line 1806 of yacc.c  */
-#line 1599 "chapel.ypp"
+#line 1599 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pcallexpr) = NULL; }
+#line 7330 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 393:
-
-/* Line 1806 of yacc.c  */
-#line 1604 "chapel.ypp"
-    { (yyval.pcallexpr) = (yyvsp[(3) - (4)].pcallexpr); }
+#line 1604 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pcallexpr) = (yyvsp[-1].pcallexpr); }
+#line 7336 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 394:
-
-/* Line 1806 of yacc.c  */
-#line 1609 "chapel.ypp"
+#line 1609 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pcallexpr) = new CallExpr(PRIM_ACTUALS_LIST);
-      addTaskIntent((yyval.pcallexpr), (yyvsp[(1) - (1)].pShadowVar)); }
+      addTaskIntent((yyval.pcallexpr), (yyvsp[0].pShadowVar)); }
+#line 7343 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 395:
-
-/* Line 1806 of yacc.c  */
-#line 1612 "chapel.ypp"
-    { addTaskIntent((yyvsp[(1) - (3)].pcallexpr), (yyvsp[(3) - (3)].pShadowVar)); }
+#line 1612 "chapel.ypp" /* yacc.c:1661  */
+    { addTaskIntent((yyvsp[-2].pcallexpr), (yyvsp[0].pShadowVar)); }
+#line 7349 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 396:
-
-/* Line 1806 of yacc.c  */
-#line 1616 "chapel.ypp"
-    { (yyval.pcallexpr) = (yyvsp[(3) - (4)].pcallexpr); }
+#line 1616 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pcallexpr) = (yyvsp[-1].pcallexpr); }
+#line 7355 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 397:
-
-/* Line 1806 of yacc.c  */
-#line 1621 "chapel.ypp"
+#line 1621 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pcallexpr) = new CallExpr(PRIM_ACTUALS_LIST);
-      addForallIntent((yyval.pcallexpr), (yyvsp[(1) - (1)].pShadowVar)); }
+      addForallIntent((yyval.pcallexpr), (yyvsp[0].pShadowVar)); }
+#line 7362 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 398:
-
-/* Line 1806 of yacc.c  */
-#line 1624 "chapel.ypp"
-    { addForallIntent((yyvsp[(1) - (3)].pcallexpr), (yyvsp[(3) - (3)].pShadowVar)); }
+#line 1624 "chapel.ypp" /* yacc.c:1661  */
+    { addForallIntent((yyvsp[-2].pcallexpr), (yyvsp[0].pShadowVar)); }
+#line 7368 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 399:
-
-/* Line 1806 of yacc.c  */
-#line 1628 "chapel.ypp"
+#line 1628 "chapel.ypp" /* yacc.c:1661  */
     {
-      (yyval.pShadowVar) = ShadowVarSymbol::buildFromArgIntent((yyvsp[(1) - (2)].pt), (yyvsp[(2) - (2)].pexpr));
+      (yyval.pShadowVar) = ShadowVarSymbol::buildFromArgIntent((yyvsp[-1].pt), (yyvsp[0].pexpr));
     }
+#line 7376 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 400:
-
-/* Line 1806 of yacc.c  */
-#line 1631 "chapel.ypp"
+#line 1631 "chapel.ypp" /* yacc.c:1661  */
     {
-      (yyval.pShadowVar) = ShadowVarSymbol::buildFromReduceIntent((yyvsp[(3) - (3)].pexpr), (yyvsp[(1) - (3)].pexpr));
+      (yyval.pShadowVar) = ShadowVarSymbol::buildFromReduceIntent((yyvsp[0].pexpr), (yyvsp[-2].pexpr));
     }
+#line 7384 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 401:
-
-/* Line 1806 of yacc.c  */
-#line 1634 "chapel.ypp"
+#line 1634 "chapel.ypp" /* yacc.c:1661  */
     {
-      (yyval.pShadowVar) = ShadowVarSymbol::buildFromReduceIntent((yyvsp[(3) - (3)].pexpr), (yyvsp[(1) - (3)].pexpr));
+      (yyval.pShadowVar) = ShadowVarSymbol::buildFromReduceIntent((yyvsp[0].pexpr), (yyvsp[-2].pexpr));
     }
+#line 7392 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 403:
-
-/* Line 1806 of yacc.c  */
-#line 1642 "chapel.ypp"
-    { (yyval.pexpr) = new CallExpr("<~>", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
+#line 1642 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new CallExpr("<~>", (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
+#line 7398 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 404:
-
-/* Line 1806 of yacc.c  */
-#line 1647 "chapel.ypp"
-    { (yyval.pexpr) = new CallExpr(PRIM_NEW, (yyvsp[(2) - (2)].pexpr)); }
+#line 1647 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new CallExpr(PRIM_NEW, (yyvsp[0].pexpr)); }
+#line 7404 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 405:
-
-/* Line 1806 of yacc.c  */
-#line 1652 "chapel.ypp"
-    { (yyval.pexpr) = buildLetExpr((yyvsp[(2) - (4)].pblockstmt), (yyvsp[(4) - (4)].pexpr)); }
+#line 1652 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = buildLetExpr((yyvsp[-2].pblockstmt), (yyvsp[0].pexpr)); }
+#line 7410 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 414:
-
-/* Line 1806 of yacc.c  */
-#line 1668 "chapel.ypp"
-    { (yyval.pexpr) = new CallExpr(PRIM_TUPLE_EXPAND, (yyvsp[(3) - (4)].pexpr)); }
+#line 1668 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new CallExpr(PRIM_TUPLE_EXPAND, (yyvsp[-1].pexpr)); }
+#line 7416 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 415:
-
-/* Line 1806 of yacc.c  */
-#line 1670 "chapel.ypp"
-    { (yyval.pexpr) = createCast((yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
+#line 1670 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = createCast((yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
+#line 7422 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 416:
-
-/* Line 1806 of yacc.c  */
-#line 1672 "chapel.ypp"
-    { (yyval.pexpr) = new CallExpr("chpl_build_bounded_range", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
+#line 1672 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new CallExpr("chpl_build_bounded_range", (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
+#line 7428 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 417:
-
-/* Line 1806 of yacc.c  */
-#line 1674 "chapel.ypp"
-    { (yyval.pexpr) = new CallExpr("chpl_build_low_bounded_range", (yyvsp[(1) - (2)].pexpr)); }
+#line 1674 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new CallExpr("chpl_build_low_bounded_range", (yyvsp[-1].pexpr)); }
+#line 7434 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 418:
-
-/* Line 1806 of yacc.c  */
-#line 1676 "chapel.ypp"
-    { (yyval.pexpr) = new CallExpr("chpl_build_high_bounded_range", (yyvsp[(2) - (2)].pexpr)); }
+#line 1676 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new CallExpr("chpl_build_high_bounded_range", (yyvsp[0].pexpr)); }
+#line 7440 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 419:
-
-/* Line 1806 of yacc.c  */
-#line 1678 "chapel.ypp"
+#line 1678 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pexpr) = new CallExpr("chpl_build_unbounded_range"); }
+#line 7446 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 420:
-
-/* Line 1806 of yacc.c  */
-#line 1682 "chapel.ypp"
-    { (yyval.pexpr) = tryExpr((yyvsp[(2) - (2)].pexpr)); }
+#line 1682 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = tryExpr((yyvsp[0].pexpr)); }
+#line 7452 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 421:
-
-/* Line 1806 of yacc.c  */
-#line 1683 "chapel.ypp"
-    { (yyval.pexpr) = tryBangExpr((yyvsp[(2) - (2)].pexpr)); }
+#line 1683 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = tryBangExpr((yyvsp[0].pexpr)); }
+#line 7458 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 422:
-
-/* Line 1806 of yacc.c  */
-#line 1684 "chapel.ypp"
-    { (yyval.pexpr) = (yyvsp[(1) - (1)].pexpr); }
+#line 1684 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = (yyvsp[0].pexpr); }
+#line 7464 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 429:
-
-/* Line 1806 of yacc.c  */
-#line 1706 "chapel.ypp"
-    { (yyval.pexpr) = new CallExpr((yyvsp[(1) - (4)].pexpr), (yyvsp[(3) - (4)].pcallexpr)); }
+#line 1706 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new CallExpr((yyvsp[-3].pexpr), (yyvsp[-1].pcallexpr)); }
+#line 7470 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 430:
-
-/* Line 1806 of yacc.c  */
-#line 1707 "chapel.ypp"
-    { (yyval.pexpr) = buildSquareCallExpr((yyvsp[(1) - (4)].pexpr), (yyvsp[(3) - (4)].pcallexpr)); }
+#line 1707 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = buildSquareCallExpr((yyvsp[-3].pexpr), (yyvsp[-1].pcallexpr)); }
+#line 7476 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 431:
-
-/* Line 1806 of yacc.c  */
-#line 1708 "chapel.ypp"
-    { (yyval.pexpr) = buildPrimitiveExpr((yyvsp[(3) - (4)].pcallexpr)); }
+#line 1708 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = buildPrimitiveExpr((yyvsp[-1].pcallexpr)); }
+#line 7482 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 432:
-
-/* Line 1806 of yacc.c  */
-#line 1712 "chapel.ypp"
-    { (yyval.pexpr) = buildDotExpr((yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pch)); }
+#line 1712 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = buildDotExpr((yyvsp[-2].pexpr), (yyvsp[0].pch)); }
+#line 7488 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 433:
-
-/* Line 1806 of yacc.c  */
-#line 1713 "chapel.ypp"
-    { (yyval.pexpr) = new CallExpr(PRIM_TYPEOF, (yyvsp[(1) - (3)].pexpr)); }
+#line 1713 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new CallExpr(PRIM_TYPEOF, (yyvsp[-2].pexpr)); }
+#line 7494 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 434:
-
-/* Line 1806 of yacc.c  */
-#line 1714 "chapel.ypp"
-    { (yyval.pexpr) = buildDotExpr((yyvsp[(1) - (3)].pexpr), "_dom"); }
+#line 1714 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = buildDotExpr((yyvsp[-2].pexpr), "_dom"); }
+#line 7500 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 435:
-
-/* Line 1806 of yacc.c  */
-#line 1722 "chapel.ypp"
-    { (yyval.pexpr) = (yyvsp[(2) - (3)].pexpr); }
+#line 1722 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = (yyvsp[-1].pexpr); }
+#line 7506 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 436:
-
-/* Line 1806 of yacc.c  */
-#line 1723 "chapel.ypp"
-    { (yyval.pexpr) = buildOneTuple((yyvsp[(2) - (4)].pexpr)); }
+#line 1723 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = buildOneTuple((yyvsp[-2].pexpr)); }
+#line 7512 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 437:
-
-/* Line 1806 of yacc.c  */
-#line 1724 "chapel.ypp"
-    { (yyval.pexpr) = buildTuple((yyvsp[(2) - (3)].pcallexpr)); }
+#line 1724 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = buildTuple((yyvsp[-1].pcallexpr)); }
+#line 7518 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 438:
-
-/* Line 1806 of yacc.c  */
-#line 1725 "chapel.ypp"
-    { (yyval.pexpr) = buildTuple((yyvsp[(2) - (4)].pcallexpr)); }
+#line 1725 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = buildTuple((yyvsp[-2].pcallexpr)); }
+#line 7524 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 439:
-
-/* Line 1806 of yacc.c  */
-#line 1729 "chapel.ypp"
-    { (yyval.pexpr) = buildIntLiteral((yyvsp[(1) - (1)].pch));    }
+#line 1729 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = buildIntLiteral((yyvsp[0].pch));    }
+#line 7530 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 440:
-
-/* Line 1806 of yacc.c  */
-#line 1730 "chapel.ypp"
-    { (yyval.pexpr) = buildRealLiteral((yyvsp[(1) - (1)].pch));   }
+#line 1730 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = buildRealLiteral((yyvsp[0].pch));   }
+#line 7536 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 441:
-
-/* Line 1806 of yacc.c  */
-#line 1731 "chapel.ypp"
-    { (yyval.pexpr) = buildImagLiteral((yyvsp[(1) - (1)].pch));   }
+#line 1731 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = buildImagLiteral((yyvsp[0].pch));   }
+#line 7542 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 442:
-
-/* Line 1806 of yacc.c  */
-#line 1732 "chapel.ypp"
-    { (yyval.pexpr) = buildStringLiteral((yyvsp[(1) - (1)].pch)); }
+#line 1732 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = buildStringLiteral((yyvsp[0].pch)); }
+#line 7548 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 443:
-
-/* Line 1806 of yacc.c  */
-#line 1733 "chapel.ypp"
-    { (yyval.pexpr) = buildCStringLiteral((yyvsp[(1) - (1)].pch)); }
+#line 1733 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = buildCStringLiteral((yyvsp[0].pch)); }
+#line 7554 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 444:
-
-/* Line 1806 of yacc.c  */
-#line 1734 "chapel.ypp"
-    { (yyval.pexpr) = new CallExpr("chpl__buildDomainExpr", (yyvsp[(2) - (3)].pcallexpr)); }
+#line 1734 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new CallExpr("chpl__buildDomainExpr", (yyvsp[-1].pcallexpr)); }
+#line 7560 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 445:
-
-/* Line 1806 of yacc.c  */
-#line 1735 "chapel.ypp"
-    { (yyval.pexpr) = new CallExpr("chpl__buildDomainExpr", (yyvsp[(2) - (4)].pcallexpr)); }
+#line 1735 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new CallExpr("chpl__buildDomainExpr", (yyvsp[-2].pcallexpr)); }
+#line 7566 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 446:
-
-/* Line 1806 of yacc.c  */
-#line 1736 "chapel.ypp"
-    { (yyval.pexpr) = new CallExpr("chpl__buildArrayExpr",  (yyvsp[(2) - (3)].pcallexpr)); }
+#line 1736 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new CallExpr("chpl__buildArrayExpr",  (yyvsp[-1].pcallexpr)); }
+#line 7572 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 447:
-
-/* Line 1806 of yacc.c  */
-#line 1737 "chapel.ypp"
-    { (yyval.pexpr) = new CallExpr("chpl__buildArrayExpr",  (yyvsp[(2) - (4)].pcallexpr)); }
+#line 1737 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new CallExpr("chpl__buildArrayExpr",  (yyvsp[-2].pcallexpr)); }
+#line 7578 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 448:
-
-/* Line 1806 of yacc.c  */
-#line 1739 "chapel.ypp"
+#line 1739 "chapel.ypp" /* yacc.c:1661  */
     {
-      (yyval.pexpr) = new CallExpr("chpl__buildAssociativeArrayExpr", (yyvsp[(2) - (3)].pcallexpr));
+      (yyval.pexpr) = new CallExpr("chpl__buildAssociativeArrayExpr", (yyvsp[-1].pcallexpr));
     }
+#line 7586 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 449:
-
-/* Line 1806 of yacc.c  */
-#line 1743 "chapel.ypp"
+#line 1743 "chapel.ypp" /* yacc.c:1661  */
     {
-      (yyval.pexpr) = new CallExpr("chpl__buildAssociativeArrayExpr", (yyvsp[(2) - (4)].pcallexpr));
+      (yyval.pexpr) = new CallExpr("chpl__buildAssociativeArrayExpr", (yyvsp[-2].pcallexpr));
     }
+#line 7594 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 450:
-
-/* Line 1806 of yacc.c  */
-#line 1750 "chapel.ypp"
-    { (yyval.pcallexpr) = new CallExpr(PRIM_ACTUALS_LIST, (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
+#line 1750 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pcallexpr) = new CallExpr(PRIM_ACTUALS_LIST, (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
+#line 7600 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 451:
-
-/* Line 1806 of yacc.c  */
-#line 1751 "chapel.ypp"
-    { (yyvsp[(1) - (5)].pcallexpr)->insertAtTail((yyvsp[(3) - (5)].pexpr)); (yyvsp[(1) - (5)].pcallexpr)->insertAtTail((yyvsp[(5) - (5)].pexpr)); }
+#line 1751 "chapel.ypp" /* yacc.c:1661  */
+    { (yyvsp[-4].pcallexpr)->insertAtTail((yyvsp[-2].pexpr)); (yyvsp[-4].pcallexpr)->insertAtTail((yyvsp[0].pexpr)); }
+#line 7606 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 452:
-
-/* Line 1806 of yacc.c  */
-#line 1755 "chapel.ypp"
-    { (yyval.pexpr) = new CallExpr("+", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
+#line 1755 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new CallExpr("+", (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
+#line 7612 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 453:
-
-/* Line 1806 of yacc.c  */
-#line 1756 "chapel.ypp"
-    { (yyval.pexpr) = new CallExpr("-", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
+#line 1756 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new CallExpr("-", (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
+#line 7618 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 454:
-
-/* Line 1806 of yacc.c  */
-#line 1757 "chapel.ypp"
-    { (yyval.pexpr) = new CallExpr("*", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
+#line 1757 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new CallExpr("*", (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
+#line 7624 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 455:
-
-/* Line 1806 of yacc.c  */
-#line 1758 "chapel.ypp"
-    { (yyval.pexpr) = new CallExpr("/", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
+#line 1758 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new CallExpr("/", (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
+#line 7630 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 456:
-
-/* Line 1806 of yacc.c  */
-#line 1759 "chapel.ypp"
-    { (yyval.pexpr) = new CallExpr("<<", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
+#line 1759 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new CallExpr("<<", (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
+#line 7636 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 457:
-
-/* Line 1806 of yacc.c  */
-#line 1760 "chapel.ypp"
-    { (yyval.pexpr) = new CallExpr(">>", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
+#line 1760 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new CallExpr(">>", (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
+#line 7642 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 458:
-
-/* Line 1806 of yacc.c  */
-#line 1761 "chapel.ypp"
-    { (yyval.pexpr) = new CallExpr("%", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
+#line 1761 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new CallExpr("%", (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
+#line 7648 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 459:
-
-/* Line 1806 of yacc.c  */
-#line 1762 "chapel.ypp"
-    { (yyval.pexpr) = new CallExpr("==", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
+#line 1762 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new CallExpr("==", (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
+#line 7654 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 460:
-
-/* Line 1806 of yacc.c  */
-#line 1763 "chapel.ypp"
-    { (yyval.pexpr) = new CallExpr("!=", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
+#line 1763 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new CallExpr("!=", (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
+#line 7660 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 461:
-
-/* Line 1806 of yacc.c  */
-#line 1764 "chapel.ypp"
-    { (yyval.pexpr) = new CallExpr("<=", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
+#line 1764 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new CallExpr("<=", (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
+#line 7666 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 462:
-
-/* Line 1806 of yacc.c  */
-#line 1765 "chapel.ypp"
-    { (yyval.pexpr) = new CallExpr(">=", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
+#line 1765 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new CallExpr(">=", (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
+#line 7672 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 463:
-
-/* Line 1806 of yacc.c  */
-#line 1766 "chapel.ypp"
-    { (yyval.pexpr) = new CallExpr("<", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
+#line 1766 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new CallExpr("<", (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
+#line 7678 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 464:
-
-/* Line 1806 of yacc.c  */
-#line 1767 "chapel.ypp"
-    { (yyval.pexpr) = new CallExpr(">", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
+#line 1767 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new CallExpr(">", (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
+#line 7684 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 465:
-
-/* Line 1806 of yacc.c  */
-#line 1768 "chapel.ypp"
-    { (yyval.pexpr) = new CallExpr("&", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
+#line 1768 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new CallExpr("&", (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
+#line 7690 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 466:
-
-/* Line 1806 of yacc.c  */
-#line 1769 "chapel.ypp"
-    { (yyval.pexpr) = new CallExpr("|", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
+#line 1769 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new CallExpr("|", (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
+#line 7696 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 467:
-
-/* Line 1806 of yacc.c  */
-#line 1770 "chapel.ypp"
-    { (yyval.pexpr) = new CallExpr("^", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
+#line 1770 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new CallExpr("^", (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
+#line 7702 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 468:
-
-/* Line 1806 of yacc.c  */
-#line 1771 "chapel.ypp"
-    { (yyval.pexpr) = new CallExpr("&&", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
+#line 1771 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new CallExpr("&&", (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
+#line 7708 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 469:
-
-/* Line 1806 of yacc.c  */
-#line 1772 "chapel.ypp"
-    { (yyval.pexpr) = new CallExpr("||", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
+#line 1772 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new CallExpr("||", (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
+#line 7714 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 470:
-
-/* Line 1806 of yacc.c  */
-#line 1773 "chapel.ypp"
-    { (yyval.pexpr) = new CallExpr("**", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
+#line 1773 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new CallExpr("**", (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
+#line 7720 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 471:
-
-/* Line 1806 of yacc.c  */
-#line 1774 "chapel.ypp"
-    { (yyval.pexpr) = new CallExpr("chpl_by", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
+#line 1774 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new CallExpr("chpl_by", (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
+#line 7726 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 472:
-
-/* Line 1806 of yacc.c  */
-#line 1775 "chapel.ypp"
-    { (yyval.pexpr) = new CallExpr("chpl_align", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
+#line 1775 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new CallExpr("chpl_align", (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
+#line 7732 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 473:
-
-/* Line 1806 of yacc.c  */
-#line 1776 "chapel.ypp"
-    { (yyval.pexpr) = new CallExpr("#", (yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
+#line 1776 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new CallExpr("#", (yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
+#line 7738 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 474:
-
-/* Line 1806 of yacc.c  */
-#line 1777 "chapel.ypp"
-    { (yyval.pexpr) = new CallExpr("chpl__distributed", (yyvsp[(3) - (3)].pexpr), (yyvsp[(1) - (3)].pexpr)); }
+#line 1777 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new CallExpr("chpl__distributed", (yyvsp[0].pexpr), (yyvsp[-2].pexpr)); }
+#line 7744 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 475:
-
-/* Line 1806 of yacc.c  */
-#line 1781 "chapel.ypp"
-    { (yyval.pexpr) = new CallExpr("+", (yyvsp[(2) - (2)].pexpr)); }
+#line 1781 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new CallExpr("+", (yyvsp[0].pexpr)); }
+#line 7750 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 476:
-
-/* Line 1806 of yacc.c  */
-#line 1782 "chapel.ypp"
-    { (yyval.pexpr) = new CallExpr("-", (yyvsp[(2) - (2)].pexpr)); }
+#line 1782 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new CallExpr("-", (yyvsp[0].pexpr)); }
+#line 7756 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 477:
-
-/* Line 1806 of yacc.c  */
-#line 1783 "chapel.ypp"
-    { (yyval.pexpr) = buildPreDecIncWarning((yyvsp[(2) - (2)].pexpr), '-'); }
+#line 1783 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = buildPreDecIncWarning((yyvsp[0].pexpr), '-'); }
+#line 7762 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 478:
-
-/* Line 1806 of yacc.c  */
-#line 1784 "chapel.ypp"
-    { (yyval.pexpr) = buildPreDecIncWarning((yyvsp[(2) - (2)].pexpr), '+'); }
+#line 1784 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = buildPreDecIncWarning((yyvsp[0].pexpr), '+'); }
+#line 7768 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 479:
-
-/* Line 1806 of yacc.c  */
-#line 1785 "chapel.ypp"
-    { (yyval.pexpr) = new CallExpr("!", (yyvsp[(2) - (2)].pexpr)); }
+#line 1785 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new CallExpr("!", (yyvsp[0].pexpr)); }
+#line 7774 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 480:
-
-/* Line 1806 of yacc.c  */
-#line 1786 "chapel.ypp"
-    { (yyval.pexpr) = new CallExpr("~", (yyvsp[(2) - (2)].pexpr)); }
+#line 1786 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = new CallExpr("~", (yyvsp[0].pexpr)); }
+#line 7780 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 481:
-
-/* Line 1806 of yacc.c  */
-#line 1790 "chapel.ypp"
-    { (yyval.pexpr) = buildReduceExpr((yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
+#line 1790 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = buildReduceExpr((yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
+#line 7786 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 482:
-
-/* Line 1806 of yacc.c  */
-#line 1791 "chapel.ypp"
-    { (yyval.pexpr) = buildReduceExpr((yyvsp[(1) - (3)].pexpr), zipToTuple((yyvsp[(3) - (3)].pcallexpr)), true); }
+#line 1791 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = buildReduceExpr((yyvsp[-2].pexpr), zipToTuple((yyvsp[0].pcallexpr)), true); }
+#line 7792 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 483:
-
-/* Line 1806 of yacc.c  */
-#line 1792 "chapel.ypp"
-    { (yyval.pexpr) = buildReduceExpr((yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
+#line 1792 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = buildReduceExpr((yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
+#line 7798 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 484:
-
-/* Line 1806 of yacc.c  */
-#line 1793 "chapel.ypp"
-    { (yyval.pexpr) = buildReduceExpr((yyvsp[(1) - (3)].pexpr), zipToTuple((yyvsp[(3) - (3)].pcallexpr)), true); }
+#line 1793 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = buildReduceExpr((yyvsp[-2].pexpr), zipToTuple((yyvsp[0].pcallexpr)), true); }
+#line 7804 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 485:
-
-/* Line 1806 of yacc.c  */
-#line 1797 "chapel.ypp"
-    { (yyval.pexpr) = buildScanExpr((yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
+#line 1797 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = buildScanExpr((yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
+#line 7810 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 486:
-
-/* Line 1806 of yacc.c  */
-#line 1798 "chapel.ypp"
-    { (yyval.pexpr) = buildScanExpr((yyvsp[(1) - (3)].pexpr), zipToTuple((yyvsp[(3) - (3)].pcallexpr)), true); }
+#line 1798 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = buildScanExpr((yyvsp[-2].pexpr), zipToTuple((yyvsp[0].pcallexpr)), true); }
+#line 7816 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 487:
-
-/* Line 1806 of yacc.c  */
-#line 1799 "chapel.ypp"
-    { (yyval.pexpr) = buildScanExpr((yyvsp[(1) - (3)].pexpr), (yyvsp[(3) - (3)].pexpr)); }
+#line 1799 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = buildScanExpr((yyvsp[-2].pexpr), (yyvsp[0].pexpr)); }
+#line 7822 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 488:
-
-/* Line 1806 of yacc.c  */
-#line 1800 "chapel.ypp"
-    { (yyval.pexpr) = buildScanExpr((yyvsp[(1) - (3)].pexpr), zipToTuple((yyvsp[(3) - (3)].pcallexpr)), true); }
+#line 1800 "chapel.ypp" /* yacc.c:1661  */
+    { (yyval.pexpr) = buildScanExpr((yyvsp[-2].pexpr), zipToTuple((yyvsp[0].pcallexpr)), true); }
+#line 7828 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 489:
-
-/* Line 1806 of yacc.c  */
-#line 1805 "chapel.ypp"
+#line 1805 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pexpr) = new UnresolvedSymExpr("SumReduceScanOp"); }
+#line 7834 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 490:
-
-/* Line 1806 of yacc.c  */
-#line 1806 "chapel.ypp"
+#line 1806 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pexpr) = new UnresolvedSymExpr("ProductReduceScanOp"); }
+#line 7840 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 491:
-
-/* Line 1806 of yacc.c  */
-#line 1807 "chapel.ypp"
+#line 1807 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pexpr) = new UnresolvedSymExpr("LogicalAndReduceScanOp"); }
+#line 7846 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 492:
-
-/* Line 1806 of yacc.c  */
-#line 1808 "chapel.ypp"
+#line 1808 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pexpr) = new UnresolvedSymExpr("LogicalOrReduceScanOp"); }
+#line 7852 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 493:
-
-/* Line 1806 of yacc.c  */
-#line 1809 "chapel.ypp"
+#line 1809 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pexpr) = new UnresolvedSymExpr("BitwiseAndReduceScanOp"); }
+#line 7858 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 494:
-
-/* Line 1806 of yacc.c  */
-#line 1810 "chapel.ypp"
+#line 1810 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pexpr) = new UnresolvedSymExpr("BitwiseOrReduceScanOp"); }
+#line 7864 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
   case 495:
-
-/* Line 1806 of yacc.c  */
-#line 1811 "chapel.ypp"
+#line 1811 "chapel.ypp" /* yacc.c:1661  */
     { (yyval.pexpr) = new UnresolvedSymExpr("BitwiseXorReduceScanOp"); }
+#line 7870 "bison-chapel.cpp" /* yacc.c:1661  */
     break;
 
 
-
-/* Line 1806 of yacc.c  */
-#line 8657 "bison-chapel.cpp"
+#line 7874 "bison-chapel.cpp" /* yacc.c:1661  */
       default: break;
     }
   /* User semantic actions sometimes alter yychar, and that requires
@@ -8676,7 +7893,7 @@ yyreduce:
   *++yyvsp = yyval;
   *++yylsp = yyloc;
 
-  /* Now `shift' the result of the reduction.  Determine what state
+  /* Now 'shift' the result of the reduction.  Determine what state
      that goes to, based on the state we popped back to and the rule
      number reduced by.  */
 
@@ -8691,9 +7908,9 @@ yyreduce:
   goto yynewstate;
 
 
-/*------------------------------------.
-| yyerrlab -- here on detecting error |
-`------------------------------------*/
+/*--------------------------------------.
+| yyerrlab -- here on detecting error.  |
+`--------------------------------------*/
 yyerrlab:
   /* Make sure we have latest lookahead translation.  See comments at
      user semantic actions for why this is necessary.  */
@@ -8744,20 +7961,20 @@ yyerrlab:
   if (yyerrstatus == 3)
     {
       /* If just tried and failed to reuse lookahead token after an
-	 error, discard it.  */
+         error, discard it.  */
 
       if (yychar <= YYEOF)
-	{
-	  /* Return failure if at end of input.  */
-	  if (yychar == YYEOF)
-	    YYABORT;
-	}
+        {
+          /* Return failure if at end of input.  */
+          if (yychar == YYEOF)
+            YYABORT;
+        }
       else
-	{
-	  yydestruct ("Error: discarding",
-		      yytoken, &yylval, &yylloc, context);
-	  yychar = YYEMPTY;
-	}
+        {
+          yydestruct ("Error: discarding",
+                      yytoken, &yylval, &yylloc, context);
+          yychar = YYEMPTY;
+        }
     }
 
   /* Else will try to reuse lookahead token after shifting the error
@@ -8777,7 +7994,7 @@ yyerrorlab:
      goto yyerrorlab;
 
   yyerror_range[1] = yylsp[1-yylen];
-  /* Do not reclaim the symbols of the rule which action triggered
+  /* Do not reclaim the symbols of the rule whose action triggered
      this YYERROR.  */
   YYPOPSTACK (yylen);
   yylen = 0;
@@ -8790,35 +8007,37 @@ yyerrorlab:
 | yyerrlab1 -- common code for both syntax error and YYERROR.  |
 `-------------------------------------------------------------*/
 yyerrlab1:
-  yyerrstatus = 3;	/* Each real token shifted decrements this.  */
+  yyerrstatus = 3;      /* Each real token shifted decrements this.  */
 
   for (;;)
     {
       yyn = yypact[yystate];
       if (!yypact_value_is_default (yyn))
-	{
-	  yyn += YYTERROR;
-	  if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYTERROR)
-	    {
-	      yyn = yytable[yyn];
-	      if (0 < yyn)
-		break;
-	    }
-	}
+        {
+          yyn += YYTERROR;
+          if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYTERROR)
+            {
+              yyn = yytable[yyn];
+              if (0 < yyn)
+                break;
+            }
+        }
 
       /* Pop the current state because it cannot handle the error token.  */
       if (yyssp == yyss)
-	YYABORT;
+        YYABORT;
 
       yyerror_range[1] = *yylsp;
       yydestruct ("Error: popping",
-		  yystos[yystate], yyvsp, yylsp, context);
+                  yystos[yystate], yyvsp, yylsp, context);
       YYPOPSTACK (1);
       yystate = *yyssp;
       YY_STACK_PRINT (yyss, yyssp);
     }
 
+  YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
   *++yyvsp = yylval;
+  YY_IGNORE_MAYBE_UNINITIALIZED_END
 
   yyerror_range[2] = yylloc;
   /* Using YYLLOC is tempting, but would change the location of
@@ -8847,7 +8066,7 @@ yyabortlab:
   yyresult = 1;
   goto yyreturn;
 
-#if !defined(yyoverflow) || YYERROR_VERBOSE
+#if !defined yyoverflow || YYERROR_VERBOSE
 /*-------------------------------------------------.
 | yyexhaustedlab -- memory exhaustion comes here.  |
 `-------------------------------------------------*/
@@ -8866,14 +8085,14 @@ yyreturn:
       yydestruct ("Cleanup: discarding lookahead",
                   yytoken, &yylval, &yylloc, context);
     }
-  /* Do not reclaim the symbols of the rule which action triggered
+  /* Do not reclaim the symbols of the rule whose action triggered
      this YYABORT or YYACCEPT.  */
   YYPOPSTACK (yylen);
   YY_STACK_PRINT (yyss, yyssp);
   while (yyssp != yyss)
     {
       yydestruct ("Cleanup: popping",
-		  yystos[*yyssp], yyvsp, yylsp, context);
+                  yystos[*yyssp], yyvsp, yylsp, context);
       YYPOPSTACK (1);
     }
 #ifndef yyoverflow
@@ -8887,9 +8106,5 @@ yypushreturn:
   if (yymsg != yymsgbuf)
     YYSTACK_FREE (yymsg);
 #endif
-  /* Make sure YYID is used.  */
-  return YYID (yyresult);
+  return yyresult;
 }
-
-
-

--- a/compiler/parser/flex-chapel.cpp
+++ b/compiler/parser/flex-chapel.cpp
@@ -1,6 +1,6 @@
-#line 2 "flex-chapel.cpp"
+#line 1 "flex-chapel.cpp"
 
-#line 4 "flex-chapel.cpp"
+#line 3 "flex-chapel.cpp"
 
 #define  YY_INT_ALIGNED short int
 
@@ -8,10 +8,34 @@
 
 #define FLEX_SCANNER
 #define YY_FLEX_MAJOR_VERSION 2
-#define YY_FLEX_MINOR_VERSION 5
-#define YY_FLEX_SUBMINOR_VERSION 35
+#define YY_FLEX_MINOR_VERSION 6
+#define YY_FLEX_SUBMINOR_VERSION 4
 #if YY_FLEX_SUBMINOR_VERSION > 0
 #define FLEX_BETA
+#endif
+
+#ifdef yyget_lval
+#define yyget_lval_ALREADY_DEFINED
+#else
+#define yyget_lval yyget_lval
+#endif
+
+#ifdef yyset_lval
+#define yyset_lval_ALREADY_DEFINED
+#else
+#define yyset_lval yyset_lval
+#endif
+
+#ifdef yyget_lloc
+#define yyget_lloc_ALREADY_DEFINED
+#else
+#define yyget_lloc yyget_lloc
+#endif
+
+#ifdef yyset_lloc
+#define yyset_lloc_ALREADY_DEFINED
+#else
+#define yyset_lloc yyset_lloc
 #endif
 
 /* First, we deal with  platform-specific or compiler-specific issues. */
@@ -54,7 +78,6 @@ typedef int flex_int32_t;
 typedef unsigned char flex_uint8_t; 
 typedef unsigned short int flex_uint16_t;
 typedef unsigned int flex_uint32_t;
-#endif /* ! C99 */
 
 /* Limits of integral types. */
 #ifndef INT8_MIN
@@ -85,38 +108,32 @@ typedef unsigned int flex_uint32_t;
 #define UINT32_MAX             (4294967295U)
 #endif
 
+#ifndef SIZE_MAX
+#define SIZE_MAX               (~(size_t)0)
+#endif
+
+#endif /* ! C99 */
+
 #endif /* ! FLEXINT_H */
 
-#ifdef __cplusplus
+/* begin standard C++ headers. */
 
-/* The "const" storage-class-modifier is valid. */
-#define YY_USE_CONST
-
-#else	/* ! __cplusplus */
-
-/* C99 requires __STDC__ to be defined as 1. */
-#if defined (__STDC__)
-
-#define YY_USE_CONST
-
-#endif	/* defined (__STDC__) */
-#endif	/* ! __cplusplus */
-
-#ifdef YY_USE_CONST
+/* TODO: this is always defined, so inline it */
 #define yyconst const
+
+#if defined(__GNUC__) && __GNUC__ >= 3
+#define yynoreturn __attribute__((__noreturn__))
 #else
-#define yyconst
+#define yynoreturn
 #endif
 
 /* Returned upon end-of-file. */
 #define YY_NULL 0
 
-/* Promotes a possibly negative, possibly signed char to an unsigned
- * integer for use as an array index.  If the signed char is negative,
- * we want to instead treat it as an 8-bit unsigned char, hence the
- * double cast.
+/* Promotes a possibly negative, possibly signed char to an
+ *   integer in range [0..255] for use as an array index.
  */
-#define YY_SC_TO_UI(c) ((unsigned int) (unsigned char) c)
+#define YY_SC_TO_UI(c) ((YY_CHAR) (c))
 
 /* An opaque pointer. */
 #ifndef YY_TYPEDEF_YY_SCANNER_T
@@ -140,25 +157,29 @@ typedef void* yyscan_t;
  * definition of BEGIN.
  */
 #define BEGIN yyg->yy_start = 1 + 2 *
-
 /* Translate the current start state into a value that can be later handed
  * to BEGIN to return to the state.  The YYSTATE alias is for lex
  * compatibility.
  */
 #define YY_START ((yyg->yy_start - 1) / 2)
 #define YYSTATE YY_START
-
 /* Action number for EOF rule of a given start state. */
 #define YY_STATE_EOF(state) (YY_END_OF_BUFFER + state + 1)
-
 /* Special action meaning "start processing a new file". */
-#define YY_NEW_FILE yyrestart(yyin ,yyscanner )
-
+#define YY_NEW_FILE yyrestart( yyin , yyscanner )
 #define YY_END_OF_BUFFER_CHAR 0
 
 /* Size of default input buffer. */
 #ifndef YY_BUF_SIZE
+#ifdef __ia64__
+/* On IA-64, the buffer size is 16k, not 8k.
+ * Moreover, YY_BUF_SIZE is 2*YY_READ_BUF_SIZE in the general case.
+ * Ditto for the __ia64__ case accordingly.
+ */
+#define YY_BUF_SIZE 32768
+#else
 #define YY_BUF_SIZE 16384
+#endif /* __ia64__ */
 #endif
 
 /* The state buf must be large enough to hold one state per character in the main buffer.
@@ -170,11 +191,17 @@ typedef void* yyscan_t;
 typedef struct yy_buffer_state *YY_BUFFER_STATE;
 #endif
 
+#ifndef YY_TYPEDEF_YY_SIZE_T
+#define YY_TYPEDEF_YY_SIZE_T
+typedef size_t yy_size_t;
+#endif
+
 #define EOB_ACT_CONTINUE_SCAN 0
 #define EOB_ACT_END_OF_FILE 1
 #define EOB_ACT_LAST_MATCH 2
-
+    
     #define YY_LESS_LINENO(n)
+    #define YY_LINENO_REWIND_TO(ptr)
     
 /* Return all but the first "n" matched characters back to the input stream. */
 #define yyless(n) \
@@ -189,13 +216,7 @@ typedef struct yy_buffer_state *YY_BUFFER_STATE;
 		YY_DO_BEFORE_ACTION; /* set up yytext again */ \
 		} \
 	while ( 0 )
-
 #define unput(c) yyunput( c, yyg->yytext_ptr , yyscanner )
-
-#ifndef YY_TYPEDEF_YY_SIZE_T
-#define YY_TYPEDEF_YY_SIZE_T
-typedef size_t yy_size_t;
-#endif
 
 #ifndef YY_STRUCT_YY_BUFFER_STATE
 #define YY_STRUCT_YY_BUFFER_STATE
@@ -209,7 +230,7 @@ struct yy_buffer_state
 	/* Size of input buffer in bytes, not including room for EOB
 	 * characters.
 	 */
-	yy_size_t yy_buf_size;
+	int yy_buf_size;
 
 	/* Number of characters read into yy_ch_buf, not including EOB
 	 * characters.
@@ -237,7 +258,7 @@ struct yy_buffer_state
 
     int yy_bs_lineno; /**< The line count. */
     int yy_bs_column; /**< The column count. */
-    
+
 	/* Whether to try to fill the input buffer when we reach the
 	 * end of it.
 	 */
@@ -271,84 +292,77 @@ struct yy_buffer_state
 #define YY_CURRENT_BUFFER ( yyg->yy_buffer_stack \
                           ? yyg->yy_buffer_stack[yyg->yy_buffer_stack_top] \
                           : NULL)
-
 /* Same as previous macro, but useful when we know that the buffer stack is not
  * NULL or when we need an lvalue. For internal use only.
  */
 #define YY_CURRENT_BUFFER_LVALUE yyg->yy_buffer_stack[yyg->yy_buffer_stack_top]
 
-void yyrestart (FILE *input_file ,yyscan_t yyscanner );
-void yy_switch_to_buffer (YY_BUFFER_STATE new_buffer ,yyscan_t yyscanner );
-YY_BUFFER_STATE yy_create_buffer (FILE *file,int size ,yyscan_t yyscanner );
-void yy_delete_buffer (YY_BUFFER_STATE b ,yyscan_t yyscanner );
-void yy_flush_buffer (YY_BUFFER_STATE b ,yyscan_t yyscanner );
-void yypush_buffer_state (YY_BUFFER_STATE new_buffer ,yyscan_t yyscanner );
-void yypop_buffer_state (yyscan_t yyscanner );
+void yyrestart ( FILE *input_file , yyscan_t yyscanner );
+void yy_switch_to_buffer ( YY_BUFFER_STATE new_buffer , yyscan_t yyscanner );
+YY_BUFFER_STATE yy_create_buffer ( FILE *file, int size , yyscan_t yyscanner );
+void yy_delete_buffer ( YY_BUFFER_STATE b , yyscan_t yyscanner );
+void yy_flush_buffer ( YY_BUFFER_STATE b , yyscan_t yyscanner );
+void yypush_buffer_state ( YY_BUFFER_STATE new_buffer , yyscan_t yyscanner );
+void yypop_buffer_state ( yyscan_t yyscanner );
 
-static void yyensure_buffer_stack (yyscan_t yyscanner );
-static void yy_load_buffer_state (yyscan_t yyscanner );
-static void yy_init_buffer (YY_BUFFER_STATE b,FILE *file ,yyscan_t yyscanner );
+static void yyensure_buffer_stack ( yyscan_t yyscanner );
+static void yy_load_buffer_state ( yyscan_t yyscanner );
+static void yy_init_buffer ( YY_BUFFER_STATE b, FILE *file , yyscan_t yyscanner );
+#define YY_FLUSH_BUFFER yy_flush_buffer( YY_CURRENT_BUFFER , yyscanner)
 
-#define YY_FLUSH_BUFFER yy_flush_buffer(YY_CURRENT_BUFFER ,yyscanner)
+YY_BUFFER_STATE yy_scan_buffer ( char *base, yy_size_t size , yyscan_t yyscanner );
+YY_BUFFER_STATE yy_scan_string ( const char *yy_str , yyscan_t yyscanner );
+YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, int len , yyscan_t yyscanner );
 
-YY_BUFFER_STATE yy_scan_buffer (char *base,yy_size_t size ,yyscan_t yyscanner );
-YY_BUFFER_STATE yy_scan_string (yyconst char *yy_str ,yyscan_t yyscanner );
-YY_BUFFER_STATE yy_scan_bytes (yyconst char *bytes,int len ,yyscan_t yyscanner );
-
-void *yyalloc (yy_size_t ,yyscan_t yyscanner );
-void *yyrealloc (void *,yy_size_t ,yyscan_t yyscanner );
-void yyfree (void * ,yyscan_t yyscanner );
+void *yyalloc ( yy_size_t , yyscan_t yyscanner );
+void *yyrealloc ( void *, yy_size_t , yyscan_t yyscanner );
+void yyfree ( void * , yyscan_t yyscanner );
 
 #define yy_new_buffer yy_create_buffer
-
 #define yy_set_interactive(is_interactive) \
 	{ \
 	if ( ! YY_CURRENT_BUFFER ){ \
         yyensure_buffer_stack (yyscanner); \
 		YY_CURRENT_BUFFER_LVALUE =    \
-            yy_create_buffer(yyin,YY_BUF_SIZE ,yyscanner); \
+            yy_create_buffer( yyin, YY_BUF_SIZE , yyscanner); \
 	} \
 	YY_CURRENT_BUFFER_LVALUE->yy_is_interactive = is_interactive; \
 	}
-
 #define yy_set_bol(at_bol) \
 	{ \
 	if ( ! YY_CURRENT_BUFFER ){\
         yyensure_buffer_stack (yyscanner); \
 		YY_CURRENT_BUFFER_LVALUE =    \
-            yy_create_buffer(yyin,YY_BUF_SIZE ,yyscanner); \
+            yy_create_buffer( yyin, YY_BUF_SIZE , yyscanner); \
 	} \
 	YY_CURRENT_BUFFER_LVALUE->yy_at_bol = at_bol; \
 	}
-
 #define YY_AT_BOL() (YY_CURRENT_BUFFER_LVALUE->yy_at_bol)
 
 /* Begin user sect3 */
 
-#define yywrap(n) 1
+#define yywrap(yyscanner) (/*CONSTCOND*/1)
 #define YY_SKIP_YYWRAP
-
-typedef unsigned char YY_CHAR;
+typedef flex_uint8_t YY_CHAR;
 
 typedef int yy_state_type;
 
 #define yytext_ptr yytext_r
 
-static yy_state_type yy_get_previous_state (yyscan_t yyscanner );
-static yy_state_type yy_try_NUL_trans (yy_state_type current_state  ,yyscan_t yyscanner);
-static int yy_get_next_buffer (yyscan_t yyscanner );
-static void yy_fatal_error (yyconst char msg[] ,yyscan_t yyscanner );
+static yy_state_type yy_get_previous_state ( yyscan_t yyscanner );
+static yy_state_type yy_try_NUL_trans ( yy_state_type current_state  , yyscan_t yyscanner);
+static int yy_get_next_buffer ( yyscan_t yyscanner );
+static void yynoreturn yy_fatal_error ( const char* msg , yyscan_t yyscanner );
 
 /* Done after the current pattern has been matched and before the
  * corresponding action - sets up yytext.
  */
 #define YY_DO_BEFORE_ACTION \
 	yyg->yytext_ptr = yy_bp; \
-	yyleng = (size_t) (yy_cp - yy_bp); \
+	yyleng = (int) (yy_cp - yy_bp); \
 	yyg->yy_hold_char = *yy_cp; \
 	*yy_cp = '\0'; \
 	yyg->yy_c_buf_p = yy_cp;
-
 #define YY_NUM_RULES 150
 #define YY_END_OF_BUFFER 151
 /* This struct is not used in this scanner,
@@ -358,7 +372,7 @@ struct yy_trans_info
 	flex_int32_t yy_verify;
 	flex_int32_t yy_nxt;
 	};
-static yyconst flex_int16_t yy_accept[413] =
+static const flex_int16_t yy_accept[413] =
     {   0,
         0,    0,    0,    0,  151,  149,  148,  147,  102,  141,
        97,  119,  103,  142,  127,  128,  117,  115,  125,  116,
@@ -408,7 +422,7 @@ static yyconst flex_int16_t yy_accept[413] =
        47,    0
     } ;
 
-static yyconst flex_int32_t yy_ec[256] =
+static const YY_CHAR yy_ec[256] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    2,    3,
         1,    2,    2,    1,    1,    1,    1,    1,    1,    1,
@@ -440,7 +454,7 @@ static yyconst flex_int32_t yy_ec[256] =
         1,    1,    1,    1,    1
     } ;
 
-static yyconst flex_int32_t yy_meta[69] =
+static const YY_CHAR yy_meta[69] =
     {   0,
         1,    1,    1,    1,    1,    1,    2,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    3,    1,    4,    4,
@@ -451,7 +465,7 @@ static yyconst flex_int32_t yy_meta[69] =
         2,    2,    2,    2,    1,    1,    1,    1
     } ;
 
-static yyconst flex_int16_t yy_base[416] =
+static const flex_int16_t yy_base[416] =
     {   0,
         0,    0,  488,  487,  551,  554,  554,  554,  524,  554,
       554,  523,   60,  554,  554,  554,   57,   58,  554,   55,
@@ -501,7 +515,7 @@ static yyconst flex_int16_t yy_base[416] =
         0,  554,  369,  371,  160
     } ;
 
-static yyconst flex_int16_t yy_def[416] =
+static const flex_int16_t yy_def[416] =
     {   0,
       412,    1,    1,    1,  412,  412,  412,  412,  412,  412,
       412,  412,  412,  412,  412,  412,  412,  412,  412,  412,
@@ -551,7 +565,7 @@ static yyconst flex_int16_t yy_def[416] =
       413,    0,  412,  412,  412
     } ;
 
-static yyconst flex_int16_t yy_nxt[623] =
+static const flex_int16_t yy_nxt[623] =
     {   0,
         6,    7,    8,    9,   10,   11,    6,   12,   13,   14,
        15,   16,   17,   18,   19,   20,   21,   22,   23,   24,
@@ -624,7 +638,7 @@ static yyconst flex_int16_t yy_nxt[623] =
       412,  412
     } ;
 
-static yyconst flex_int16_t yy_chk[623] =
+static const flex_int16_t yy_chk[623] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
@@ -728,7 +742,7 @@ static yyconst flex_int16_t yy_chk[623] =
      a  bison-style YYSTYPE by reference. The value will always be in yylval->pch.
      a  bison-style YYLTYPE by reference.
 
-     i.e. int yylex(YYSTYPE*,YYLTYPE*,yyscan_t yyscanner);
+     i.e. int yylex(YYSTYPE*, YYLTYPE*, yyscan_t yyscanner);
 */
 /*
    Provide a condition stack
@@ -769,9 +783,10 @@ static void processInvalidToken(yyscan_t scanner);
 
 static bool yy_has_state(yyscan_t scanner);
 
+#line 786 "flex-chapel.cpp"
 /* hex float literals, have decimal exponents indicating the power of 2 */
 
-#line 775 "flex-chapel.cpp"
+#line 789 "flex-chapel.cpp"
 
 #define INITIAL 0
 #define externmode 1
@@ -826,7 +841,7 @@ struct yyguts_t
 
     }; /* end struct yyguts_t */
 
-static int yy_init_globals (yyscan_t yyscanner );
+static int yy_init_globals ( yyscan_t yyscanner );
 
     /* This must go here because YYSTYPE and YYLTYPE are included
      * from bison output in section 1.*/
@@ -836,44 +851,48 @@ static int yy_init_globals (yyscan_t yyscanner );
     
 int yylex_init (yyscan_t* scanner);
 
-int yylex_init_extra (YY_EXTRA_TYPE user_defined,yyscan_t* scanner);
+int yylex_init_extra ( YY_EXTRA_TYPE user_defined, yyscan_t* scanner);
 
 /* Accessor methods to globals.
    These are made visible to non-reentrant scanners for convenience. */
 
-int yylex_destroy (yyscan_t yyscanner );
+int yylex_destroy ( yyscan_t yyscanner );
 
-int yyget_debug (yyscan_t yyscanner );
+int yyget_debug ( yyscan_t yyscanner );
 
-void yyset_debug (int debug_flag ,yyscan_t yyscanner );
+void yyset_debug ( int debug_flag , yyscan_t yyscanner );
 
-YY_EXTRA_TYPE yyget_extra (yyscan_t yyscanner );
+YY_EXTRA_TYPE yyget_extra ( yyscan_t yyscanner );
 
-void yyset_extra (YY_EXTRA_TYPE user_defined ,yyscan_t yyscanner );
+void yyset_extra ( YY_EXTRA_TYPE user_defined , yyscan_t yyscanner );
 
-FILE *yyget_in (yyscan_t yyscanner );
+FILE *yyget_in ( yyscan_t yyscanner );
 
-void yyset_in  (FILE * in_str ,yyscan_t yyscanner );
+void yyset_in  ( FILE * _in_str , yyscan_t yyscanner );
 
-FILE *yyget_out (yyscan_t yyscanner );
+FILE *yyget_out ( yyscan_t yyscanner );
 
-void yyset_out  (FILE * out_str ,yyscan_t yyscanner );
+void yyset_out  ( FILE * _out_str , yyscan_t yyscanner );
 
-int yyget_leng (yyscan_t yyscanner );
+			int yyget_leng ( yyscan_t yyscanner );
 
-char *yyget_text (yyscan_t yyscanner );
+char *yyget_text ( yyscan_t yyscanner );
 
-int yyget_lineno (yyscan_t yyscanner );
+int yyget_lineno ( yyscan_t yyscanner );
 
-void yyset_lineno (int line_number ,yyscan_t yyscanner );
+void yyset_lineno ( int _line_number , yyscan_t yyscanner );
 
-YYSTYPE * yyget_lval (yyscan_t yyscanner );
+int yyget_column  ( yyscan_t yyscanner );
 
-void yyset_lval (YYSTYPE * yylval_param ,yyscan_t yyscanner );
+void yyset_column ( int _column_no , yyscan_t yyscanner );
 
-       YYLTYPE *yyget_lloc (yyscan_t yyscanner );
+YYSTYPE * yyget_lval ( yyscan_t yyscanner );
+
+void yyset_lval ( YYSTYPE * yylval_param , yyscan_t yyscanner );
+
+       YYLTYPE *yyget_lloc ( yyscan_t yyscanner );
     
-        void yyset_lloc (YYLTYPE * yylloc_param ,yyscan_t yyscanner );
+        void yyset_lloc ( YYLTYPE * yylloc_param , yyscan_t yyscanner );
     
 /* Macros after this point can all be overridden by user definitions in
  * section 1.
@@ -881,39 +900,47 @@ void yyset_lval (YYSTYPE * yylval_param ,yyscan_t yyscanner );
 
 #ifndef YY_SKIP_YYWRAP
 #ifdef __cplusplus
-extern "C" int yywrap (yyscan_t yyscanner );
+extern "C" int yywrap ( yyscan_t yyscanner );
 #else
-extern int yywrap (yyscan_t yyscanner );
+extern int yywrap ( yyscan_t yyscanner );
 #endif
+#endif
+
+#ifndef YY_NO_UNPUT
+    
 #endif
 
 #ifndef yytext_ptr
-static void yy_flex_strncpy (char *,yyconst char *,int ,yyscan_t yyscanner);
+static void yy_flex_strncpy ( char *, const char *, int , yyscan_t yyscanner);
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen (yyconst char * ,yyscan_t yyscanner);
+static int yy_flex_strlen ( const char * , yyscan_t yyscanner);
 #endif
 
 #ifndef YY_NO_INPUT
-
 #ifdef __cplusplus
-static int yyinput (yyscan_t yyscanner );
+static int yyinput ( yyscan_t yyscanner );
 #else
-static int input (yyscan_t yyscanner );
+static int input ( yyscan_t yyscanner );
 #endif
 
 #endif
 
-    static void yy_push_state (int new_state ,yyscan_t yyscanner);
+    static void yy_push_state ( int _new_state , yyscan_t yyscanner);
     
-    static void yy_pop_state (yyscan_t yyscanner );
+    static void yy_pop_state ( yyscan_t yyscanner );
     
-    static int yy_top_state (yyscan_t yyscanner );
+    static int yy_top_state ( yyscan_t yyscanner );
     
 /* Amount of stuff to slurp up with each read. */
 #ifndef YY_READ_BUF_SIZE
+#ifdef __ia64__
+/* On IA-64, the buffer size is 16k, not 8k */
+#define YY_READ_BUF_SIZE 16384
+#else
 #define YY_READ_BUF_SIZE 8192
+#endif /* __ia64__ */
 #endif
 
 /* Copy whatever the last rule matched to the standard output. */
@@ -921,7 +948,7 @@ static int input (yyscan_t yyscanner );
 /* This used to be an fputs(), but since the string might contain NUL's,
  * we now use fwrite().
  */
-#define ECHO fwrite( yytext, yyleng, 1, yyout )
+#define ECHO do { if (fwrite( yytext, (size_t) yyleng, 1, yyout )) {} } while (0)
 #endif
 
 /* Gets input and stuffs it into "buf".  number of characters read, or YY_NULL,
@@ -945,7 +972,7 @@ static int input (yyscan_t yyscanner );
 	else \
 		{ \
 		errno=0; \
-		while ( (result = fread(buf, 1, max_size, yyin))==0 && ferror(yyin)) \
+		while ( (result = (int) fread(buf, 1, (yy_size_t) max_size, yyin)) == 0 && ferror(yyin)) \
 			{ \
 			if( errno != EINTR) \
 				{ \
@@ -987,7 +1014,7 @@ static int input (yyscan_t yyscanner );
 #define YY_DECL_IS_OURS 1
 
 extern int yylex \
-               (YYSTYPE * yylval_param,YYLTYPE * yylloc_param ,yyscan_t yyscanner);
+               (YYSTYPE * yylval_param, YYLTYPE * yylloc_param , yyscan_t yyscanner);
 
 #define YY_DECL int yylex \
                (YYSTYPE * yylval_param, YYLTYPE * yylloc_param , yyscan_t yyscanner)
@@ -1002,7 +1029,7 @@ extern int yylex \
 
 /* Code executed at the end of each rule. */
 #ifndef YY_BREAK
-#define YY_BREAK break;
+#define YY_BREAK /*LINTED*/break;
 #endif
 
 #define YY_RULE_SETUP \
@@ -1012,15 +1039,10 @@ extern int yylex \
  */
 YY_DECL
 {
-	register yy_state_type yy_current_state;
-	register char *yy_cp, *yy_bp;
-	register int yy_act;
+	yy_state_type yy_current_state;
+	char *yy_cp, *yy_bp;
+	int yy_act;
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
-
-#line 114 "chapel.lex"
-
-
-#line 1024 "flex-chapel.cpp"
 
     yylval = yylval_param;
 
@@ -1046,13 +1068,19 @@ YY_DECL
 		if ( ! YY_CURRENT_BUFFER ) {
 			yyensure_buffer_stack (yyscanner);
 			YY_CURRENT_BUFFER_LVALUE =
-				yy_create_buffer(yyin,YY_BUF_SIZE ,yyscanner);
+				yy_create_buffer( yyin, YY_BUF_SIZE , yyscanner);
 		}
 
-		yy_load_buffer_state(yyscanner );
+		yy_load_buffer_state( yyscanner );
 		}
 
-	while ( 1 )		/* loops until end-of-file is reached */
+	{
+#line 114 "chapel.lex"
+
+
+#line 1081 "flex-chapel.cpp"
+
+	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
 		yy_cp = yyg->yy_c_buf_p;
 
@@ -1068,7 +1096,7 @@ YY_DECL
 yy_match:
 		do
 			{
-			register YY_CHAR yy_c = yy_ec[YY_SC_TO_UI(*yy_cp)];
+			YY_CHAR yy_c = yy_ec[YY_SC_TO_UI(*yy_cp)] ;
 			if ( yy_accept[yy_current_state] )
 				{
 				yyg->yy_last_accepting_state = yy_current_state;
@@ -1078,9 +1106,9 @@ yy_match:
 				{
 				yy_current_state = (int) yy_def[yy_current_state];
 				if ( yy_current_state >= 413 )
-					yy_c = yy_meta[(unsigned int) yy_c];
+					yy_c = yy_meta[yy_c];
 				}
-			yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+			yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 			++yy_cp;
 			}
 		while ( yy_base[yy_current_state] != 554 );
@@ -1858,7 +1886,7 @@ YY_RULE_SETUP
 #line 284 "chapel.lex"
 ECHO;
 	YY_BREAK
-#line 1862 "flex-chapel.cpp"
+#line 1889 "flex-chapel.cpp"
 case YY_STATE_EOF(INITIAL):
 case YY_STATE_EOF(externmode):
 	yyterminate();
@@ -1937,7 +1965,7 @@ case YY_STATE_EOF(externmode):
 				{
 				yyg->yy_did_buffer_switch_on_eof = 0;
 
-				if ( yywrap(yyscanner ) )
+				if ( yywrap( yyscanner ) )
 					{
 					/* Note: because we've taken care in
 					 * yy_get_next_buffer() to have set up
@@ -1990,6 +2018,7 @@ case YY_STATE_EOF(externmode):
 			"fatal flex scanner internal error--no action found" );
 	} /* end of action switch */
 		} /* end of scanning one token */
+	} /* end of user's declarations */
 } /* end of yylex */
 
 /* yy_get_next_buffer - try to read in a new buffer
@@ -2002,9 +2031,9 @@ case YY_STATE_EOF(externmode):
 static int yy_get_next_buffer (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
-	register char *dest = YY_CURRENT_BUFFER_LVALUE->yy_ch_buf;
-	register char *source = yyg->yytext_ptr;
-	register int number_to_move, i;
+	char *dest = YY_CURRENT_BUFFER_LVALUE->yy_ch_buf;
+	char *source = yyg->yytext_ptr;
+	int number_to_move, i;
 	int ret_val;
 
 	if ( yyg->yy_c_buf_p > &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[yyg->yy_n_chars + 1] )
@@ -2033,7 +2062,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 	/* Try to read more data. */
 
 	/* First move last chars to start of buffer. */
-	number_to_move = (int) (yyg->yy_c_buf_p - yyg->yytext_ptr) - 1;
+	number_to_move = (int) (yyg->yy_c_buf_p - yyg->yytext_ptr - 1);
 
 	for ( i = 0; i < number_to_move; ++i )
 		*(dest++) = *(source++);
@@ -2053,7 +2082,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 			{ /* Not enough room in the buffer - grow it. */
 
 			/* just a shorter name for the current buffer */
-			YY_BUFFER_STATE b = YY_CURRENT_BUFFER;
+			YY_BUFFER_STATE b = YY_CURRENT_BUFFER_LVALUE;
 
 			int yy_c_buf_p_offset =
 				(int) (yyg->yy_c_buf_p - b->yy_ch_buf);
@@ -2069,11 +2098,12 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 				b->yy_ch_buf = (char *)
 					/* Include room in for 2 EOB chars. */
-					yyrealloc((void *) b->yy_ch_buf,b->yy_buf_size + 2 ,yyscanner );
+					yyrealloc( (void *) b->yy_ch_buf,
+							 (yy_size_t) (b->yy_buf_size + 2) , yyscanner );
 				}
 			else
 				/* Can't grow it, we don't own it. */
-				b->yy_ch_buf = 0;
+				b->yy_ch_buf = NULL;
 
 			if ( ! b->yy_ch_buf )
 				YY_FATAL_ERROR(
@@ -2091,7 +2121,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 		/* Read in more data. */
 		YY_INPUT( (&YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[number_to_move]),
-			yyg->yy_n_chars, (size_t) num_to_read );
+			yyg->yy_n_chars, num_to_read );
 
 		YY_CURRENT_BUFFER_LVALUE->yy_n_chars = yyg->yy_n_chars;
 		}
@@ -2101,7 +2131,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 		if ( number_to_move == YY_MORE_ADJ )
 			{
 			ret_val = EOB_ACT_END_OF_FILE;
-			yyrestart(yyin  ,yyscanner);
+			yyrestart( yyin  , yyscanner);
 			}
 
 		else
@@ -2115,12 +2145,15 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 	else
 		ret_val = EOB_ACT_CONTINUE_SCAN;
 
-	if ((yy_size_t) (yyg->yy_n_chars + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
+	if ((yyg->yy_n_chars + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
 		/* Extend the array by 50%, plus the number we really need. */
-		yy_size_t new_size = yyg->yy_n_chars + number_to_move + (yyg->yy_n_chars >> 1);
-		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) yyrealloc((void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf,new_size ,yyscanner );
+		int new_size = yyg->yy_n_chars + number_to_move + (yyg->yy_n_chars >> 1);
+		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) yyrealloc(
+			(void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf, (yy_size_t) new_size , yyscanner );
 		if ( ! YY_CURRENT_BUFFER_LVALUE->yy_ch_buf )
 			YY_FATAL_ERROR( "out of dynamic memory in yy_get_next_buffer()" );
+		/* "- 2" to take care of EOB's */
+		YY_CURRENT_BUFFER_LVALUE->yy_buf_size = (int) (new_size - 2);
 	}
 
 	yyg->yy_n_chars += number_to_move;
@@ -2136,15 +2169,15 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
     static yy_state_type yy_get_previous_state (yyscan_t yyscanner)
 {
-	register yy_state_type yy_current_state;
-	register char *yy_cp;
+	yy_state_type yy_current_state;
+	char *yy_cp;
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
 	yy_current_state = yyg->yy_start;
 
 	for ( yy_cp = yyg->yytext_ptr + YY_MORE_ADJ; yy_cp < yyg->yy_c_buf_p; ++yy_cp )
 		{
-		register YY_CHAR yy_c = (*yy_cp ? yy_ec[YY_SC_TO_UI(*yy_cp)] : 1);
+		YY_CHAR yy_c = (*yy_cp ? yy_ec[YY_SC_TO_UI(*yy_cp)] : 1);
 		if ( yy_accept[yy_current_state] )
 			{
 			yyg->yy_last_accepting_state = yy_current_state;
@@ -2154,9 +2187,9 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 			{
 			yy_current_state = (int) yy_def[yy_current_state];
 			if ( yy_current_state >= 413 )
-				yy_c = yy_meta[(unsigned int) yy_c];
+				yy_c = yy_meta[yy_c];
 			}
-		yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+		yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 		}
 
 	return yy_current_state;
@@ -2169,11 +2202,11 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
  */
     static yy_state_type yy_try_NUL_trans  (yy_state_type yy_current_state , yyscan_t yyscanner)
 {
-	register int yy_is_jam;
+	int yy_is_jam;
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner; /* This var may be unused depending upon options. */
-	register char *yy_cp = yyg->yy_c_buf_p;
+	char *yy_cp = yyg->yy_c_buf_p;
 
-	register YY_CHAR yy_c = 1;
+	YY_CHAR yy_c = 1;
 	if ( yy_accept[yy_current_state] )
 		{
 		yyg->yy_last_accepting_state = yy_current_state;
@@ -2183,13 +2216,18 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 		{
 		yy_current_state = (int) yy_def[yy_current_state];
 		if ( yy_current_state >= 413 )
-			yy_c = yy_meta[(unsigned int) yy_c];
+			yy_c = yy_meta[yy_c];
 		}
-	yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+	yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 	yy_is_jam = (yy_current_state == 412);
 
+	(void)yyg;
 	return yy_is_jam ? 0 : yy_current_state;
 }
+
+#ifndef YY_NO_UNPUT
+
+#endif
 
 #ifndef YY_NO_INPUT
 #ifdef __cplusplus
@@ -2216,7 +2254,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 		else
 			{ /* need more input */
-			int offset = yyg->yy_c_buf_p - yyg->yytext_ptr;
+			int offset = (int) (yyg->yy_c_buf_p - yyg->yytext_ptr);
 			++yyg->yy_c_buf_p;
 
 			switch ( yy_get_next_buffer( yyscanner ) )
@@ -2233,14 +2271,14 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 					 */
 
 					/* Reset buffer status. */
-					yyrestart(yyin ,yyscanner);
+					yyrestart( yyin , yyscanner);
 
 					/*FALLTHROUGH*/
 
 				case EOB_ACT_END_OF_FILE:
 					{
-					if ( yywrap(yyscanner ) )
-						return EOF;
+					if ( yywrap( yyscanner ) )
+						return 0;
 
 					if ( ! yyg->yy_did_buffer_switch_on_eof )
 						YY_NEW_FILE;
@@ -2278,11 +2316,11 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 	if ( ! YY_CURRENT_BUFFER ){
         yyensure_buffer_stack (yyscanner);
 		YY_CURRENT_BUFFER_LVALUE =
-            yy_create_buffer(yyin,YY_BUF_SIZE ,yyscanner);
+            yy_create_buffer( yyin, YY_BUF_SIZE , yyscanner);
 	}
 
-	yy_init_buffer(YY_CURRENT_BUFFER,input_file ,yyscanner);
-	yy_load_buffer_state(yyscanner );
+	yy_init_buffer( YY_CURRENT_BUFFER, input_file , yyscanner);
+	yy_load_buffer_state( yyscanner );
 }
 
 /** Switch to a different input buffer.
@@ -2311,7 +2349,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 		}
 
 	YY_CURRENT_BUFFER_LVALUE = new_buffer;
-	yy_load_buffer_state(yyscanner );
+	yy_load_buffer_state( yyscanner );
 
 	/* We don't actually know whether we did this switch during
 	 * EOF (yywrap()) processing, but the only time this flag
@@ -2340,7 +2378,7 @@ static void yy_load_buffer_state  (yyscan_t yyscanner)
 {
 	YY_BUFFER_STATE b;
     
-	b = (YY_BUFFER_STATE) yyalloc(sizeof( struct yy_buffer_state ) ,yyscanner );
+	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state ) , yyscanner );
 	if ( ! b )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_create_buffer()" );
 
@@ -2349,13 +2387,13 @@ static void yy_load_buffer_state  (yyscan_t yyscanner)
 	/* yy_ch_buf has to be 2 characters longer than the size given because
 	 * we need to put in 2 end-of-buffer characters.
 	 */
-	b->yy_ch_buf = (char *) yyalloc(b->yy_buf_size + 2 ,yyscanner );
+	b->yy_ch_buf = (char *) yyalloc( (yy_size_t) (b->yy_buf_size + 2) , yyscanner );
 	if ( ! b->yy_ch_buf )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_create_buffer()" );
 
 	b->yy_is_our_buffer = 1;
 
-	yy_init_buffer(b,file ,yyscanner);
+	yy_init_buffer( b, file , yyscanner);
 
 	return b;
 }
@@ -2375,15 +2413,11 @@ static void yy_load_buffer_state  (yyscan_t yyscanner)
 		YY_CURRENT_BUFFER_LVALUE = (YY_BUFFER_STATE) 0;
 
 	if ( b->yy_is_our_buffer )
-		yyfree((void *) b->yy_ch_buf ,yyscanner );
+		yyfree( (void *) b->yy_ch_buf , yyscanner );
 
-	yyfree((void *) b ,yyscanner );
+	yyfree( (void *) b , yyscanner );
 }
 
-#ifndef __cplusplus
-extern int isatty (int );
-#endif /* __cplusplus */
-    
 /* Initializes or reinitializes a buffer.
  * This function is sometimes called more than once on the same buffer,
  * such as during a yyrestart() or at EOF.
@@ -2394,7 +2428,7 @@ extern int isatty (int );
 	int oerrno = errno;
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
-	yy_flush_buffer(b ,yyscanner);
+	yy_flush_buffer( b , yyscanner);
 
 	b->yy_input_file = file;
 	b->yy_fill_buffer = 1;
@@ -2438,7 +2472,7 @@ extern int isatty (int );
 	b->yy_buffer_status = YY_BUFFER_NEW;
 
 	if ( b == YY_CURRENT_BUFFER )
-		yy_load_buffer_state(yyscanner );
+		yy_load_buffer_state( yyscanner );
 }
 
 /** Pushes the new state onto the stack. The new state becomes
@@ -2470,7 +2504,7 @@ void yypush_buffer_state (YY_BUFFER_STATE new_buffer , yyscan_t yyscanner)
 	YY_CURRENT_BUFFER_LVALUE = new_buffer;
 
 	/* copied from yy_switch_to_buffer. */
-	yy_load_buffer_state(yyscanner );
+	yy_load_buffer_state( yyscanner );
 	yyg->yy_did_buffer_switch_on_eof = 1;
 }
 
@@ -2484,13 +2518,13 @@ void yypop_buffer_state (yyscan_t yyscanner)
 	if (!YY_CURRENT_BUFFER)
 		return;
 
-	yy_delete_buffer(YY_CURRENT_BUFFER ,yyscanner);
+	yy_delete_buffer(YY_CURRENT_BUFFER , yyscanner);
 	YY_CURRENT_BUFFER_LVALUE = NULL;
 	if (yyg->yy_buffer_stack_top > 0)
 		--yyg->yy_buffer_stack_top;
 
 	if (YY_CURRENT_BUFFER) {
-		yy_load_buffer_state(yyscanner );
+		yy_load_buffer_state( yyscanner );
 		yyg->yy_did_buffer_switch_on_eof = 1;
 	}
 }
@@ -2500,7 +2534,7 @@ void yypop_buffer_state (yyscan_t yyscanner)
  */
 static void yyensure_buffer_stack (yyscan_t yyscanner)
 {
-	int num_to_alloc;
+	yy_size_t num_to_alloc;
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
 	if (!yyg->yy_buffer_stack) {
@@ -2509,15 +2543,15 @@ static void yyensure_buffer_stack (yyscan_t yyscanner)
 		 * scanner will even need a stack. We use 2 instead of 1 to avoid an
 		 * immediate realloc on the next call.
          */
-		num_to_alloc = 1;
+      num_to_alloc = 1; /* After all that talk, this was set to 1 anyways... */
 		yyg->yy_buffer_stack = (struct yy_buffer_state**)yyalloc
 								(num_to_alloc * sizeof(struct yy_buffer_state*)
 								, yyscanner);
 		if ( ! yyg->yy_buffer_stack )
 			YY_FATAL_ERROR( "out of dynamic memory in yyensure_buffer_stack()" );
-								  
+
 		memset(yyg->yy_buffer_stack, 0, num_to_alloc * sizeof(struct yy_buffer_state*));
-				
+
 		yyg->yy_buffer_stack_max = num_to_alloc;
 		yyg->yy_buffer_stack_top = 0;
 		return;
@@ -2526,7 +2560,7 @@ static void yyensure_buffer_stack (yyscan_t yyscanner)
 	if (yyg->yy_buffer_stack_top >= (yyg->yy_buffer_stack_max) - 1){
 
 		/* Increase the buffer to prepare for a possible push. */
-		int grow_size = 8 /* arbitrary grow size */;
+		yy_size_t grow_size = 8 /* arbitrary grow size */;
 
 		num_to_alloc = yyg->yy_buffer_stack_max + grow_size;
 		yyg->yy_buffer_stack = (struct yy_buffer_state**)yyrealloc
@@ -2546,7 +2580,7 @@ static void yyensure_buffer_stack (yyscan_t yyscanner)
  * @param base the character buffer
  * @param size the size in bytes of the character buffer
  * @param yyscanner The scanner object.
- * @return the newly allocated buffer state object. 
+ * @return the newly allocated buffer state object.
  */
 YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size , yyscan_t yyscanner)
 {
@@ -2556,23 +2590,23 @@ YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size , yyscan_t yyscann
 	     base[size-2] != YY_END_OF_BUFFER_CHAR ||
 	     base[size-1] != YY_END_OF_BUFFER_CHAR )
 		/* They forgot to leave room for the EOB's. */
-		return 0;
+		return NULL;
 
-	b = (YY_BUFFER_STATE) yyalloc(sizeof( struct yy_buffer_state ) ,yyscanner );
+	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state ) , yyscanner );
 	if ( ! b )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_scan_buffer()" );
 
-	b->yy_buf_size = size - 2;	/* "- 2" to take care of EOB's */
+	b->yy_buf_size = (int) (size - 2);	/* "- 2" to take care of EOB's */
 	b->yy_buf_pos = b->yy_ch_buf = base;
 	b->yy_is_our_buffer = 0;
-	b->yy_input_file = 0;
+	b->yy_input_file = NULL;
 	b->yy_n_chars = b->yy_buf_size;
 	b->yy_is_interactive = 0;
 	b->yy_at_bol = 1;
 	b->yy_fill_buffer = 0;
 	b->yy_buffer_status = YY_BUFFER_NEW;
 
-	yy_switch_to_buffer(b ,yyscanner );
+	yy_switch_to_buffer( b , yyscanner );
 
 	return b;
 }
@@ -2585,20 +2619,20 @@ YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size , yyscan_t yyscann
  * @note If you want to scan bytes that may contain NUL values, then use
  *       yy_scan_bytes() instead.
  */
-YY_BUFFER_STATE yy_scan_string (yyconst char * yystr , yyscan_t yyscanner)
+YY_BUFFER_STATE yy_scan_string (const char * yystr , yyscan_t yyscanner)
 {
     
-	return yy_scan_bytes(yystr,strlen(yystr) ,yyscanner);
+	return yy_scan_bytes( yystr, (int) strlen(yystr) , yyscanner);
 }
 
 /** Setup the input buffer state to scan the given bytes. The next call to yylex() will
  * scan from a @e copy of @a bytes.
- * @param bytes the byte buffer to scan
- * @param len the number of bytes in the buffer pointed to by @a bytes.
+ * @param yybytes the byte buffer to scan
+ * @param _yybytes_len the number of bytes in the buffer pointed to by @a bytes.
  * @param yyscanner The scanner object.
  * @return the newly allocated buffer state object.
  */
-YY_BUFFER_STATE yy_scan_bytes  (yyconst char * yybytes, int  _yybytes_len , yyscan_t yyscanner)
+YY_BUFFER_STATE yy_scan_bytes  (const char * yybytes, int  _yybytes_len , yyscan_t yyscanner)
 {
 	YY_BUFFER_STATE b;
 	char *buf;
@@ -2606,8 +2640,8 @@ YY_BUFFER_STATE yy_scan_bytes  (yyconst char * yybytes, int  _yybytes_len , yysc
 	int i;
     
 	/* Get memory for full buffer, including space for trailing EOB's. */
-	n = _yybytes_len + 2;
-	buf = (char *) yyalloc(n ,yyscanner );
+	n = (yy_size_t) (_yybytes_len + 2);
+	buf = (char *) yyalloc( n , yyscanner );
 	if ( ! buf )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_scan_bytes()" );
 
@@ -2616,7 +2650,7 @@ YY_BUFFER_STATE yy_scan_bytes  (yyconst char * yybytes, int  _yybytes_len , yysc
 
 	buf[_yybytes_len] = buf[_yybytes_len+1] = YY_END_OF_BUFFER_CHAR;
 
-	b = yy_scan_buffer(buf,n ,yyscanner);
+	b = yy_scan_buffer( buf, n , yyscanner);
 	if ( ! b )
 		YY_FATAL_ERROR( "bad buffer in yy_scan_bytes()" );
 
@@ -2628,7 +2662,7 @@ YY_BUFFER_STATE yy_scan_bytes  (yyconst char * yybytes, int  _yybytes_len , yysc
 	return b;
 }
 
-    static void yy_push_state (int  new_state , yyscan_t yyscanner)
+    static void yy_push_state (int  _new_state , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 	if ( yyg->yy_start_stack_ptr >= yyg->yy_start_stack_depth )
@@ -2636,13 +2670,14 @@ YY_BUFFER_STATE yy_scan_bytes  (yyconst char * yybytes, int  _yybytes_len , yysc
 		yy_size_t new_size;
 
 		yyg->yy_start_stack_depth += YY_START_STACK_INCR;
-		new_size = yyg->yy_start_stack_depth * sizeof( int );
+		new_size = (yy_size_t) yyg->yy_start_stack_depth * sizeof( int );
 
 		if ( ! yyg->yy_start_stack )
-			yyg->yy_start_stack = (int *) yyalloc(new_size ,yyscanner );
+			yyg->yy_start_stack = (int *) yyalloc( new_size , yyscanner );
 
 		else
-			yyg->yy_start_stack = (int *) yyrealloc((void *) yyg->yy_start_stack,new_size ,yyscanner );
+			yyg->yy_start_stack = (int *) yyrealloc(
+					(void *) yyg->yy_start_stack, new_size , yyscanner );
 
 		if ( ! yyg->yy_start_stack )
 			YY_FATAL_ERROR( "out of memory expanding start-condition stack" );
@@ -2650,7 +2685,7 @@ YY_BUFFER_STATE yy_scan_bytes  (yyconst char * yybytes, int  _yybytes_len , yysc
 
 	yyg->yy_start_stack[yyg->yy_start_stack_ptr++] = YY_START;
 
-	BEGIN(new_state);
+	BEGIN(_new_state);
 }
 
     static void yy_pop_state  (yyscan_t yyscanner)
@@ -2672,9 +2707,11 @@ YY_BUFFER_STATE yy_scan_bytes  (yyconst char * yybytes, int  _yybytes_len , yysc
 #define YY_EXIT_FAILURE 2
 #endif
 
-static void yy_fatal_error (yyconst char* msg , yyscan_t yyscanner)
+static void yynoreturn yy_fatal_error (const char* msg , yyscan_t yyscanner)
 {
-    	(void) fprintf( stderr, "%s\n", msg );
+	struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+	(void)yyg;
+	fprintf( stderr, "%s\n", msg );
 	exit( YY_EXIT_FAILURE );
 }
 
@@ -2712,7 +2749,7 @@ YY_EXTRA_TYPE yyget_extra  (yyscan_t yyscanner)
 int yyget_lineno  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
-    
+
         if (! YY_CURRENT_BUFFER)
             return 0;
     
@@ -2725,7 +2762,7 @@ int yyget_lineno  (yyscan_t yyscanner)
 int yyget_column  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
-    
+
         if (! YY_CURRENT_BUFFER)
             return 0;
     
@@ -2780,51 +2817,51 @@ void yyset_extra (YY_EXTRA_TYPE  user_defined , yyscan_t yyscanner)
 }
 
 /** Set the current line number.
- * @param line_number
+ * @param _line_number line number
  * @param yyscanner The scanner object.
  */
-void yyset_lineno (int  line_number , yyscan_t yyscanner)
+void yyset_lineno (int  _line_number , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
         /* lineno is only valid if an input buffer exists. */
         if (! YY_CURRENT_BUFFER )
-           yy_fatal_error( "yyset_lineno called with no buffer" , yyscanner); 
+           YY_FATAL_ERROR( "yyset_lineno called with no buffer" );
     
-    yylineno = line_number;
+    yylineno = _line_number;
 }
 
 /** Set the current column.
- * @param line_number
+ * @param _column_no column number
  * @param yyscanner The scanner object.
  */
-void yyset_column (int  column_no , yyscan_t yyscanner)
+void yyset_column (int  _column_no , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
         /* column is only valid if an input buffer exists. */
         if (! YY_CURRENT_BUFFER )
-           yy_fatal_error( "yyset_column called with no buffer" , yyscanner); 
+           YY_FATAL_ERROR( "yyset_column called with no buffer" );
     
-    yycolumn = column_no;
+    yycolumn = _column_no;
 }
 
 /** Set the input stream. This does not discard the current
  * input buffer.
- * @param in_str A readable stream.
+ * @param _in_str A readable stream.
  * @param yyscanner The scanner object.
  * @see yy_switch_to_buffer
  */
-void yyset_in (FILE *  in_str , yyscan_t yyscanner)
+void yyset_in (FILE *  _in_str , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
-    yyin = in_str ;
+    yyin = _in_str ;
 }
 
-void yyset_out (FILE *  out_str , yyscan_t yyscanner)
+void yyset_out (FILE *  _out_str , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
-    yyout = out_str ;
+    yyout = _out_str ;
 }
 
 int yyget_debug  (yyscan_t yyscanner)
@@ -2833,10 +2870,10 @@ int yyget_debug  (yyscan_t yyscanner)
     return yy_flex_debug;
 }
 
-void yyset_debug (int  bdebug , yyscan_t yyscanner)
+void yyset_debug (int  _bdebug , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
-    yy_flex_debug = bdebug ;
+    yy_flex_debug = _bdebug ;
 }
 
 /* Accessor methods for yylval and yylloc */
@@ -2871,9 +2908,7 @@ void yyset_lloc (YYLTYPE *  yylloc_param , yyscan_t yyscanner)
  * the ONLY reentrant function that doesn't take the scanner as the last argument.
  * That's why we explicitly handle the declaration, instead of using our macros.
  */
-
 int yylex_init(yyscan_t* ptr_yy_globals)
-
 {
     if (ptr_yy_globals == NULL){
         errno = EINVAL;
@@ -2900,9 +2935,7 @@ int yylex_init(yyscan_t* ptr_yy_globals)
  * The user defined value in the first argument will be available to yyalloc in
  * the yyextra field.
  */
-
-int yylex_init_extra(YY_EXTRA_TYPE yy_user_defined,yyscan_t* ptr_yy_globals )
-
+int yylex_init_extra( YY_EXTRA_TYPE yy_user_defined, yyscan_t* ptr_yy_globals )
 {
     struct yyguts_t dummy_yyguts;
 
@@ -2912,20 +2945,20 @@ int yylex_init_extra(YY_EXTRA_TYPE yy_user_defined,yyscan_t* ptr_yy_globals )
         errno = EINVAL;
         return 1;
     }
-	
+
     *ptr_yy_globals = (yyscan_t) yyalloc ( sizeof( struct yyguts_t ), &dummy_yyguts );
-	
+
     if (*ptr_yy_globals == NULL){
         errno = ENOMEM;
         return 1;
     }
-    
+
     /* By setting to 0xAA, we expose bugs in
     yy_init_globals. Leave at 0x00 for releases. */
     memset(*ptr_yy_globals,0x00,sizeof(struct yyguts_t));
-    
+
     yyset_extra (yy_user_defined, *ptr_yy_globals);
-    
+
     return yy_init_globals ( *ptr_yy_globals );
 }
 
@@ -2936,10 +2969,10 @@ static int yy_init_globals (yyscan_t yyscanner)
      * This function is called from yylex_destroy(), so don't allocate here.
      */
 
-    yyg->yy_buffer_stack = 0;
+    yyg->yy_buffer_stack = NULL;
     yyg->yy_buffer_stack_top = 0;
     yyg->yy_buffer_stack_max = 0;
-    yyg->yy_c_buf_p = (char *) 0;
+    yyg->yy_c_buf_p = NULL;
     yyg->yy_init = 0;
     yyg->yy_start = 0;
 
@@ -2952,8 +2985,8 @@ static int yy_init_globals (yyscan_t yyscanner)
     yyin = stdin;
     yyout = stdout;
 #else
-    yyin = (FILE *) 0;
-    yyout = (FILE *) 0;
+    yyin = NULL;
+    yyout = NULL;
 #endif
 
     /* For future reference: Set errno on error, since we are called by
@@ -2969,17 +3002,17 @@ int yylex_destroy  (yyscan_t yyscanner)
 
     /* Pop the buffer stack, destroying each element. */
 	while(YY_CURRENT_BUFFER){
-		yy_delete_buffer(YY_CURRENT_BUFFER ,yyscanner );
+		yy_delete_buffer( YY_CURRENT_BUFFER , yyscanner );
 		YY_CURRENT_BUFFER_LVALUE = NULL;
 		yypop_buffer_state(yyscanner);
 	}
 
 	/* Destroy the stack itself. */
-	yyfree(yyg->yy_buffer_stack ,yyscanner);
+	yyfree(yyg->yy_buffer_stack , yyscanner);
 	yyg->yy_buffer_stack = NULL;
 
     /* Destroy the start condition stack. */
-        yyfree(yyg->yy_start_stack ,yyscanner );
+        yyfree( yyg->yy_start_stack , yyscanner );
         yyg->yy_start_stack = NULL;
 
     /* Reset the globals. This is important in a non-reentrant scanner so the next time
@@ -2997,18 +3030,21 @@ int yylex_destroy  (yyscan_t yyscanner)
  */
 
 #ifndef yytext_ptr
-static void yy_flex_strncpy (char* s1, yyconst char * s2, int n , yyscan_t yyscanner)
+static void yy_flex_strncpy (char* s1, const char * s2, int n , yyscan_t yyscanner)
 {
-	register int i;
+	struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+	(void)yyg;
+
+	int i;
 	for ( i = 0; i < n; ++i )
 		s1[i] = s2[i];
 }
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen (yyconst char * s , yyscan_t yyscanner)
+static int yy_flex_strlen (const char * s , yyscan_t yyscanner)
 {
-	register int n;
+	int n;
 	for ( n = 0; s[n]; ++n )
 		;
 
@@ -3018,11 +3054,16 @@ static int yy_flex_strlen (yyconst char * s , yyscan_t yyscanner)
 
 void *yyalloc (yy_size_t  size , yyscan_t yyscanner)
 {
-	return (void *) malloc( size );
+	struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+	(void)yyg;
+	return malloc(size);
 }
 
 void *yyrealloc  (void * ptr, yy_size_t  size , yyscan_t yyscanner)
 {
+	struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+	(void)yyg;
+
 	/* The cast to (char *) in the following accommodates both
 	 * implementations that use char* generic pointers, and those
 	 * that use void* generic pointers.  It works with the latter
@@ -3030,18 +3071,19 @@ void *yyrealloc  (void * ptr, yy_size_t  size , yyscan_t yyscanner)
 	 * any pointer type to void*, and deal with argument conversions
 	 * as though doing an assignment.
 	 */
-	return (void *) realloc( (char *) ptr, size );
+	return realloc(ptr, size);
 }
 
 void yyfree (void * ptr , yyscan_t yyscanner)
 {
+	struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+	(void)yyg;
 	free( (char *) ptr );	/* see yyrealloc() for (char *) cast */
 }
 
 #define YYTABLES_NAME "yytables"
 
 #line 284 "chapel.lex"
-
 
 
 /************************************ | *************************************


### PR DESCRIPTION
The version we have used up to now was flex 2.5.35.  It generated variables
with 'register' storage class specifiers, which modern C++ compilers warn
about being deprecated.

The version I updated to is flex 2.6.4.  This version does not use the
'register' storage class specifier.  It does use the `noreturn` attribute on
a function that calls `exit()` on all paths, which is fine except that we've
replaced `exit` with `clean_exit()` and `clean_exit()` wasn't marked with the
`noreturn` attribute, so generated a new warning.  I added the attribute to
`clean_exit()` and the parser directory now builds without warnings.

To make sure we don't fall back to an old version of flex, I added a check to
the "parser" rule in compiler/parser/Makefile to check the flex version and
require at least 2.6.0. This shouldn't cause problems for end-users because we
build the generated files ourselves and keep them checked in to the repository.