### PR TITLE
Don't force GASNet segment sizes smaller than 2 GiB.

### DIFF
--- a/runtime/src/comm/gasnet/comm-gasnet.c
+++ b/runtime/src/comm/gasnet/comm-gasnet.c
@@ -754,7 +754,7 @@ static void set_max_segsize_env_var(size_t size) {
 static void set_max_segsize() {
   size_t size;
 
-  if ((size = chpl_comm_getenvMaxHeapSize()) != 0) {
+  if ((size = (size_t) chpl_comm_getenvMaxHeapSize()) != 0) {
     set_max_segsize_env_var(size);
     return;
   }
@@ -767,16 +767,16 @@ static void set_max_segsize() {
   }
 
   // Use 90% of the available memory as the maximum segment size,
-  // heuristically
-  if ((size = chpl_sys_availMemoryBytes()) != 0) {
+  // heuristically.  But if that's less than the 2g GASNet default
+  // segment size, just let GASNet choose the segment size.
+  if ((size = (size_t) chpl_sys_availMemoryBytes()) != 0) {
     size_t dst_size = 0.9 * size;
-    if (dst_size < 1000 || dst_size > chpl_sys_physicalMemoryBytes())
-      chpl_internal_error("Overflow/underflow determining max segment size");
-    set_max_segsize_env_var(dst_size);
-    return;
+    if (dst_size >= (1UL << 31)) {
+      if (dst_size > (size_t) chpl_sys_physicalMemoryBytes())
+        chpl_internal_error("Overflow/underflow determining max segment size");
+      set_max_segsize_env_var(dst_size);
+    }
   }
-
-  chpl_internal_error("Could not determine maximum segment size");
 #endif
 }
 


### PR DESCRIPTION
GASNet has a "very conservative" (according to their top-level README)
default segment size of 2 GiB.  The new chpl_sys_availMemoryBytes()
implementation can easily return numbers less than this on a loaded Mac.
(Today I've seen as few as 8000 4k pages or 32m on the system that runs
our nightly Mac testing.)  So here, adjust such that we don't enforce a
segment size smaller than the 2 GiB GASNet default.  As part of this,
remove the internal error we used to print if we didn't set a segment
size, since doing so now is purposeful.

While here, I made some type conversions explicit for clarity.  It is
appropriate that system memory sizes are uint64_t, but also appropriate
that intra-program memory sizes, including the GASNet segment size, are
size_t.