### PR TITLE
Update the checkCopyrights script

### DIFF
--- a/runtime/src/qio/regexp/re2/re2-interface.cc
+++ b/runtime/src/qio/regexp/re2/re2-interface.cc
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2004-2018 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 // Make sure that we get the RE2 extensions for Chapel
 #ifndef CHPL_RE2

--- a/tools/mason/MasonEnv.chpl
+++ b/tools/mason/MasonEnv.chpl
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2004-2018 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 use MasonUtils;
 use MasonHelp;

--- a/tools/mason/MasonSearch.chpl
+++ b/tools/mason/MasonSearch.chpl
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2004-2018 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 use MasonHelp;
 use MasonEnv;

--- a/util/test/checkCopyrights.bash
+++ b/util/test/checkCopyrights.bash
@@ -7,6 +7,7 @@
 # first few lines of the file, but that seems excessive.
 #
 #  *.c
+#  *.cc
 #  *.chpl
 #  *.cpp
 #  *.g
@@ -21,40 +22,67 @@ CWD=$(cd $(dirname $0) ; pwd)
 CHPL_HOME=${CHPL_HOME:-$CWD/../..}
 
 this_year=$(date '+%Y')
-copyright_pattern="copyright .*${this_year}.* Cray Inc"
+copyright_pattern="Copyright .*${this_year}[^0-9]* Cray Inc"
 source_dirs="compiler runtime make modules*"
 
 echo "[INFO] Moving to CHPL_HOME: ${CHPL_HOME}"
 cd $CHPL_HOME
 
-# COMP: c cpp h lex ypp y g RT: c h ALL: Make* MODULES: chpl
-
-
 echo "[INFO] Checking for copyrights in source files: ${copyright_pattern}"
-files_wo_copy=$(find $source_dirs \
+
+# Check the top-level "source" subdirs under CHPL_HOME ("$source_dirs")
+# Filename suffixes actually used, by subdir:
+#   compiler: c cpp h lex ypp
+#   runtime:  c cc h H
+#   modules:  chpl h
+#   ALL:      Make*
+
+files_wo_copy=$(find $source_dirs -type f \( \
     -name Make\* -o \
     -name \*.c -o \
+    -name \*.cc -o \
     -name \*.chpl -o \
     -name \*.cpp -o \
-    -name \*.g -o \
-    -name \*.h -o \
+    -name \*.cxx -o \
+    -name '*.[hH]' -o \
     -name \*.lex -o \
-    -name \*.y -o \
-    -name \*.ypp | \
+    -name \*.ypp \) -print | \
     grep -v compiler/codegen/reservedSymbolNames.h | \
     grep -v compiler/include/bison-chapel.h        | \
     grep -v compiler/include/flex-chapel.h         | \
     grep -v compiler/parser/bison-chapel.cpp       | \
-    grep -v modules/standard/gen/*/SysCTypes.chpl  | \
+    grep -v 'modules/standard/gen/.*/SysCTypes.chpl' | \
     xargs grep -i -L "${copyright_pattern}")
 
-# Now check the Make* files in CHPL_HOME.
+
+# Check the top-level Makefiles in CHPL_HOME
 root_files_wo_copy=$(find . -maxdepth 1 -name Make\* | xargs grep -i -L "${copyright_pattern}")
 
-if [ -n "${files_wo_copy}" -o -n "${root_files_wo_copy}" ] ; then
+
+# Check CHPL_HOME/tools. Filename suffixes actually used, by subdir:
+#   tools/c2chapel (excluding c2chapel/test/, c2chapel/utils/): py
+#   tools/chplvis: cxx fl h H
+#   tools/mason:   (excluding files named test*): chpl
+
+tools_wo_copy=$(find tools \( -type d \( -name test -o -name utils \) -prune \) -o \( -type f \( \
+    -name Make\* -o \
+    -name \*.c -o \
+    -name \*.cc -o \
+    -name \*.chpl -o \
+    -name \*.cpp -o \
+    -name \*.cxx -o \
+    -name '*.[hH]' -o \
+    -name \*.fl -o \
+    -name \*.py -o \
+    -name c2chapel \) \
+    ! -name 'test*' -print \) | \
+    xargs grep -i -L "${copyright_pattern}")
+
+if [ -n "${files_wo_copy}" -o -n "${root_files_wo_copy}" -o -n "${tools_wo_copy}" ] ; then
     echo "[ERROR] The following files have missing or incorrect copyrights:"
     echo "${files_wo_copy}"
     echo "${root_files_wo_copy}"
+    echo "${tools_wo_copy}"
     echo "Add the copyright with: \$CHPL_HOME/util/buildRelease/add_license_to_sources.py <files>"
     exit 1
 fi


### PR DESCRIPTION
This change updates the script used to check source files for Cray copyright notices (including the current year). 
    
The list of files in previously-scanned toplevel subdirs is adjusted to reflect the kinds of "source" files they now contain, or seem most likely to be added from now on.
    
Recently-added top-level subdir "tools" will now be scanned- before this change, "tools" was not scanned at all.

The regexp used to check for valid copyright year is slightly modified. Now, the LAST 4-digit year in the "Copyright ... Cray Inc" line must be the current year. For ex, "2018-2004" would no longer be accepted.

This change also adds the Cray copyright notice to some source files which had been missed for some reason.