### PR TITLE
Limit darwin gnu testing to just release/examples

### DIFF
--- a/util/cron/test-gnu.darwin.bash
+++ b/util/cron/test-gnu.darwin.bash
@@ -9,4 +9,4 @@ source $CWD/common-darwin.bash
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gnu.darwin"
 
 export CHPL_HOST_COMPILER=gnu
-$CWD/nightly -cron
+$CWD/nightly -cron -examples


### PR DESCRIPTION
gnu on darwin isn't a configuration we care deeply about and with #8214 our
testing times have increased by several hours, so limit this config to only
release/examples.