### PR TITLE
Convert another 'chpl Version' to 'chpl version'

### DIFF
--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -997,7 +997,7 @@ static void printStuff(const char* argv0) {
   bool printedSomething = false;
 
   if (fPrintVersion) {
-    fprintf(stdout, "%s Version %s\n", sArgState.program_name, compileVersion);
+    fprintf(stdout, "%s version %s\n", sArgState.program_name, compileVersion);
 
     fPrintCopyright  = true;
     printedSomething = true;

--- a/test/compflags/bradc/printstuff/version.goodstart
+++ b/test/compflags/bradc/printstuff/version.goodstart
@@ -1,1 +1,1 @@
- Version 1.17.0
+ version 1.17.0


### PR DESCRIPTION
While capturing a compiler version number tonight, I noticed that
we still print out 'chpl Version' and was confused... didn't I
fix this a few weeks ago in PR #8108?!?  Well yes, but apparently
I missed the main place where we print out the compiler's version
number (who knew there were multiple places...?)  Sigh.

This fixes the more obvious, and maybe more important, place.
I did not take on the worthy but thankless task of trying to
unify the two places where we print the compiler version number
but would celebrate anyone else who did so.