### PR TITLE
update ZMQ and Crypto to throw errors

### DIFF
--- a/modules/packages/Crypto.chpl
+++ b/modules/packages/Crypto.chpl
@@ -190,10 +190,10 @@ module Crypto {
        :rtype: `[] string`
 
     */
-    proc toHex() {
+    proc toHex() throws {
       var buffHex: [this.buffDomain] string;
       for i in this.buffDomain do {
-        try! buffHex[i] = "%02xu".format(this.buff[i]);
+        buffHex[i] = try "%02xu".format(this.buff[i]);
       }
       return buffHex;
     }
@@ -204,10 +204,10 @@ module Crypto {
        :rtype: `string`
 
     */
-    proc toHexString() {
+    proc toHexString() throws {
       var buffHexString: string;
       for i in this.buffDomain do {
-        try! buffHexString += "%02xu".format(this.buff[i]);
+        buffHexString += try "%02xu".format(this.buff[i]);
       }
       return buffHexString;
     }

--- a/modules/packages/ZMQ.chpl
+++ b/modules/packages/ZMQ.chpl
@@ -904,7 +904,7 @@ module ZMQ {
 
     // recv, enumerated types
     pragma "no doc"
-    proc recv(type T, flags: int = 0) throws  where isEnumType(T) {
+    proc recv(type T, flags: int = 0) throws where isEnumType(T) {
       return try recv(int, flags):T;
     }
 


### PR DESCRIPTION
To put more weight on the error handling system, this PR moves the ZMQ and Crypto modules from halts to throwing errors.

- [x] passes linux64+flat testing, with futures