### PR TITLE
Allow FileCheck to be used when CHPL_LLVM=system

### DIFF
--- a/doc/rst/usingchapel/chplenv.rst
+++ b/doc/rst/usingchapel/chplenv.rst
@@ -633,7 +633,7 @@ CHPL_LLVM
         .. code-block:: sh
 
             # Ubuntu 16.04
-            apt-get install llvm-4.0-dev llvm-4.0 clang-4.0 libclang-4.0-dev libedit-dev
+            apt-get install llvm-4.0-dev llvm-4.0 llvm-4.0-tools clang-4.0 libclang-4.0-dev libedit-dev
 
 .. _readme-chplenv.CHPL_UNWIND:
 

--- a/test/llvm/PREDIFF
+++ b/test/llvm/PREDIFF
@@ -8,6 +8,12 @@ PLATFORM=`$CHPL_HOME/util/chplenv/chpl_platform.py --host`
 COMPILER=`$CHPL_HOME/util/chplenv/chpl_compiler.py --host`
 FILECHECK=${CHPL_HOME}/third-party/llvm/install/${PLATFORM}-${COMPILER}/bin/FileCheck
 
+if [ ! -x $FILECHECK ]; then
+    PREFERRED_LLVM_VERS=`cat ${CHPL_HOME}/third-party/llvm/LLVM_VERSION`
+    LLVM_CONFIG=`${CHPL_HOME}/third-party/llvm/find-llvm-config.sh $PREFERRED_LLVM_VERS`
+    FILECHECK=${LLVM_CONFIG//llvm-config/FileCheck}
+fi
+
 mv $OUTFILE $TMPFILE
 $FILECHECK --input-file $TMPFILE $TESTNAME.chpl 2> $OUTFILE
 rm $TMPFILE

--- a/test/llvm/check-against-const/SKIPIF
+++ b/test/llvm/check-against-const/SKIPIF
@@ -1,1 +1,1 @@
-CHPL_LLVM!=llvm
+CHPL_LLVM==none

--- a/test/llvm/fast-flags/SKIPIF
+++ b/test/llvm/fast-flags/SKIPIF
@@ -1,1 +1,1 @@
-CHPL_LLVM!=llvm
+CHPL_LLVM==none

--- a/test/llvm/function-args/SKIPIF
+++ b/test/llvm/function-args/SKIPIF
@@ -1,1 +1,1 @@
-CHPL_LLVM!=llvm
+CHPL_LLVM==none

--- a/test/llvm/generate-nsw-for-signed/SKIPIF
+++ b/test/llvm/generate-nsw-for-signed/SKIPIF
@@ -1,1 +1,1 @@
-CHPL_LLVM!=llvm
+CHPL_LLVM==none

--- a/test/llvm/llvm-invariant/SKIPIF
+++ b/test/llvm/llvm-invariant/SKIPIF
@@ -1,1 +1,1 @@
-CHPL_LLVM!=llvm
+CHPL_LLVM==none

--- a/test/llvm/parallel_loop_access/SKIPIF
+++ b/test/llvm/parallel_loop_access/SKIPIF
@@ -1,1 +1,1 @@
-CHPL_LLVM!=llvm
+CHPL_LLVM==none

--- a/test/llvm/vectorization/SKIPIF
+++ b/test/llvm/vectorization/SKIPIF
@@ -1,1 +1,1 @@
-CHPL_LLVM!=llvm
+CHPL_LLVM==none


### PR DESCRIPTION
Previously, the LLVM tests requiring FileCheck were only run when CHPL_LLVM=llvm.  This change adds a search for the location of FileCheck, which is needed when CHPL_LLVM=system, so that the tests can run in that environment.

Tested on Ubuntu and Mac with CHPL_LLVM=system.
Tested on linux64 with CHPL_LLVM=llvm to make sure that still works.
Tested on Mac with CHPL_LLVM unset to make sure the tests are still properly skipped in that case.