### PR TITLE
Fix issue with isAbsPath on crays

### DIFF
--- a/modules/standard/Path.chpl
+++ b/modules/standard/Path.chpl
@@ -273,7 +273,8 @@ proc file.realPath(): string throws {
 */
 
   proc isAbsPath(name: string): bool {
-    if (isUnixEnv()) {
+    if (CHPL_TARGET_PLATFORM != "cygwin64" &&
+        CHPL_TARGET_PLATFORM != "cygwin32") {
         if name.isEmptyString() {
            return false;
         }
@@ -286,25 +287,6 @@ proc file.realPath(): string throws {
           return false;
     } else {
       compilerError("Target platform should have Unix like environment");
-    }
-  }
-
-  /* Helper to determine if we are in a Unix environment.  Not sure yet how
-     useful this will be to other functions, but I didn't want to write that
-     big conditional in the function itself */
-  private proc isUnixEnv() param {
-    if (CHPL_TARGET_PLATFORM == "linux64" ||
-        CHPL_TARGET_PLATFORM == "linux32" ||
-        CHPL_TARGET_PLATFORM == "darwin" ||
-        CHPL_TARGET_PLATFORM == "netbsd64" ||
-        CHPL_TARGET_PLATFORM == "netbsd32" ||
-        CHPL_TARGET_PLATFORM == "cray-xk" ||
-        CHPL_TARGET_PLATFORM == "cray-xe" ||
-        CHPL_TARGET_PLATFORM == "cray-xc" ||
-        CHPL_TARGET_PLATFORM == "cray-cs") {
-      return true;
-    } else {
-      return false;
     }
   }
 }

--- a/modules/standard/Path.chpl
+++ b/modules/standard/Path.chpl
@@ -273,9 +273,7 @@ proc file.realPath(): string throws {
 */
 
   proc isAbsPath(name: string): bool {
-     if (CHPL_TARGET_PLATFORM == 'linux64' ||
-         CHPL_TARGET_PLATFORM == 'linux32' || 
-         CHPL_TARGET_PLATFORM == 'darwin') {
+    if (isUnixEnv()) {
         if name.isEmptyString() {
            return false;
         }
@@ -286,8 +284,27 @@ proc file.realPath(): string throws {
         }
         else 
           return false;
-     }
-     else
-       compilerError("Target platform should have Unix like environment");
-  } 
+    } else {
+      compilerError("Target platform should have Unix like environment");
+    }
+  }
+
+  /* Helper to determine if we are in a Unix environment.  Not sure yet how
+     useful this will be to other functions, but I didn't want to write that
+     big conditional in the function itself */
+  private proc isUnixEnv() param {
+    if (CHPL_TARGET_PLATFORM == "linux64" ||
+        CHPL_TARGET_PLATFORM == "linux32" ||
+        CHPL_TARGET_PLATFORM == "darwin" ||
+        CHPL_TARGET_PLATFORM == "netbsd64" ||
+        CHPL_TARGET_PLATFORM == "netbsd32" ||
+        CHPL_TARGET_PLATFORM == "cray-xk" ||
+        CHPL_TARGET_PLATFORM == "cray-xe" ||
+        CHPL_TARGET_PLATFORM == "cray-xc" ||
+        CHPL_TARGET_PLATFORM == "cray-cs") {
+      return true;
+    } else {
+      return false;
+    }
+  }
 }


### PR DESCRIPTION
cray wasn't included in the list of Unix-like environments for isAbsPath.
This just changes the check so that it only errors for cygwin.  We think this
is okay because most systems are Unix-like and so even if we don't know about
them or test against them now, they will probably be accurate.

Testing:
- [x] full paratest over std with futures
- [x] test/library/standard/Path, test/library/standard/FileSystem with futures on cygwin64
- [x] double check test on cray