### PR TITLE
Fix capitalization of 'Version' in this test of the release

### DIFF
--- a/util/buildRelease/testReleaseHelp
+++ b/util/buildRelease/testReleaseHelp
@@ -84,7 +84,7 @@ set patch=`cat compiler/main/version_num.h | grep UPDATE_VERSION | cut -f3 -d' '
 set expected_version_string="$major.$minor.$patch"
 
 # Test chpl --version for expected string version.
-set version_string = `chpl --version | grep 'Version' | cut -d' ' -f 3`
+set version_string = `chpl --version | grep 'version' | cut -d' ' -f 3`
 set versionstatus = $status
 if ($versionstatus != 0) then
     echo "ERROR: execution of chpl --version failed"


### PR DESCRIPTION
This fixes the testReleaseHelp smoke test that PR #8235 broke.  I didn't grep hard enough for lingering "Version" strings and was hoping Travis passing was indicative that I hadn't missed anything.  Sorry for the noise.
