### PR TITLE
update ZMQ to throw errors

### DIFF
--- a/modules/packages/ZMQ.chpl
+++ b/modules/packages/ZMQ.chpl
@@ -904,7 +904,7 @@ module ZMQ {
 
     // recv, enumerated types
     pragma "no doc"
-    proc recv(type T, flags: int = 0) throws  where isEnumType(T) {
+    proc recv(type T, flags: int = 0) throws where isEnumType(T) {
       return try recv(int, flags):T;
     }
 


### PR DESCRIPTION
To put more weight on the error handling system, this PR moves the ZMQ module from halts to throwing errors.

- [x] passes linux64+flat testing, with futures