### PR TITLE
Update isAbsPath test so that it will fail on platforms we don't support

### DIFF
--- a/test/library/standard/Path/victor-ludorum/testcases_isAbsPath.chpl
+++ b/test/library/standard/Path/victor-ludorum/testcases_isAbsPath.chpl
@@ -1,4 +1,5 @@
    use Path;
+   use Spawn;
 
    writeln(isAbsPath("/foo/bar"));
 
@@ -13,3 +14,19 @@
    writeln(isAbsPath("\\server"));
 	 	 	 
    writeln(isAbsPath("."));
+
+   // Check to see if we correctly detect Pythons's abspath to the $CWD as an
+   // absolute path (This is to help identify platforms we don't support.)
+   writeln(isAbsPath(getPythonsAbspath()));
+
+   proc getPythonsAbspath() {
+     var command = "python -c 'import os; print(os.path.abspath(\"\"))'";
+     var sub = spawnshell(command, stdout=PIPE);
+
+     var absPath:string;
+     sub.stdout.readline(absPath);
+     absPath = absPath.strip();
+     sub.wait();
+     return absPath;
+     sub.wait();
+   }

--- a/test/library/standard/Path/victor-ludorum/testcases_isAbsPath.good
+++ b/test/library/standard/Path/victor-ludorum/testcases_isAbsPath.good
@@ -5,3 +5,4 @@ false
 true
 false
 false
+true


### PR DESCRIPTION
Previously the isAbsPath test just checked fixed string literals. Update the
test to check if Python's abspath for the CWD is detected as an absolute path.
This will let us know if our abspath implementation is wrong on other platforms
that we may test on in the future. e.g. this test would (correctly) fail on
windows since we don't support windows style paths yet.

Related to https://github.com/chapel-lang/chapel/pull/8239