### PR TITLE
Add perf annotations for 2018-01-18

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -281,6 +281,11 @@ all:
       config: 16 node XC
   12/12/17:
     - (no-local) QualifiedType ref improvements (#7990)
+  01/16/18:
+    - rework iterator memory management (#8073)
+  01/17/18:
+    - text: support dynamically extendable heap w/ ugni (#7700)
+      config: 16 node XC
 
 
 AllCompTime:
@@ -553,6 +558,8 @@ isx.ml-time: &isx-ml-base
     - Switched to PCG random number generator (#3764)
   12/22/16:
     - Increased isx problem size (internal #279)
+  01/12/18:
+    - Avoid task yielding during ugni memory registration (#8162)
 isx-hand-optimized.ml-time:
   <<: *isx-ml-base
 isx-release.ml-time:


### PR DESCRIPTION
 - Minor [single-locale improvements/regressions](https://chapel-lang.org/perf/chapcs//?startdate=2018/01/04&enddate=2018/01/18&configs=default,removeinsertautocopytemps&graphs=knucleotideshootoutbenchmark,submittedmeteorshootoutbenchmark,memoryleaksforalltests,numberoftestswithleaks,hpcchpltime,allocatingstringoperations,searchesovernstrings) from iterator rework -- #8073
 - Decent [startup improvements for ugni](https://chapel-lang.org/perf/16-node-xc/?startdate=2018/01/06&enddate=2018/01/20&configs=gnuugniqthreads&graphs=noopnonusercodestartuptime) from full dynamic registration -- #7700
 - [ISx regression](https://chapel-lang.org/perf/16-node-xc/?startdate=2018/01/05&enddate=2018/01/18&configs=gnuugniqthreads&graphs=isxvariations) from preventing task-yielding in ugni memory registration -- #8162