### PR TITLE
Fix LLVM performance regression for class pointers

### DIFF
--- a/compiler/codegen/expr.cpp
+++ b/compiler/codegen/expr.cpp
@@ -454,13 +454,14 @@ llvm::StoreInst* codegenStoreLLVM(llvm::Value* val,
   GenInfo *info = gGenInfo;
   llvm::StoreInst* ret = info->irBuilder->CreateStore(val, ptr);
   llvm::MDNode* tbaa = NULL;
-  if( USE_TBAA && valType ) {
+  if (USE_TBAA && valType &&
+      (isClass(valType) || !valType->symbol->llvmTbaaStructCopyNode)) {
     if (surroundingStruct) {
       INT_ASSERT(fieldTbaaTypeDescriptor != info->tbaaRootNode);
       tbaa = info->mdBuilder->createTBAAStructTagNode(
                surroundingStruct->symbol->llvmTbaaAggTypeDescriptor,
                fieldTbaaTypeDescriptor, fieldOffset);
-    } else if (!valType->symbol->llvmTbaaStructCopyNode) {
+    } else {
       tbaa = valType->symbol->llvmTbaaAccessTag;
     }
   }
@@ -526,13 +527,14 @@ llvm::LoadInst* codegenLoadLLVM(llvm::Value* ptr,
   GenInfo* info = gGenInfo;
   llvm::LoadInst* ret = info->irBuilder->CreateLoad(ptr);
   llvm::MDNode* tbaa = NULL;
-  if( USE_TBAA && valType ) {
+  if (USE_TBAA && valType &&
+      (isClass(valType) || !valType->symbol->llvmTbaaStructCopyNode)) {
     if (surroundingStruct) {
       INT_ASSERT(fieldTbaaTypeDescriptor != info->tbaaRootNode);
       tbaa = info->mdBuilder->createTBAAStructTagNode(
                surroundingStruct->symbol->llvmTbaaAggTypeDescriptor,
                fieldTbaaTypeDescriptor, fieldOffset, isConst);
-    } else if (!valType->symbol->llvmTbaaStructCopyNode) {
+    } else {
       if( isConst ) tbaa = valType->symbol->llvmConstTbaaAccessTag;
       else tbaa = valType->symbol->llvmTbaaAccessTag;
     }

--- a/compiler/codegen/expr.cpp
+++ b/compiler/codegen/expr.cpp
@@ -454,13 +454,13 @@ llvm::StoreInst* codegenStoreLLVM(llvm::Value* val,
   GenInfo *info = gGenInfo;
   llvm::StoreInst* ret = info->irBuilder->CreateStore(val, ptr);
   llvm::MDNode* tbaa = NULL;
-  if( USE_TBAA && valType && !valType->symbol->llvmTbaaStructCopyNode ) {
+  if( USE_TBAA && valType ) {
     if (surroundingStruct) {
       INT_ASSERT(fieldTbaaTypeDescriptor != info->tbaaRootNode);
       tbaa = info->mdBuilder->createTBAAStructTagNode(
                surroundingStruct->symbol->llvmTbaaAggTypeDescriptor,
                fieldTbaaTypeDescriptor, fieldOffset);
-    } else {
+    } else if (!valType->symbol->llvmTbaaStructCopyNode) {
       tbaa = valType->symbol->llvmTbaaAccessTag;
     }
   }
@@ -526,13 +526,13 @@ llvm::LoadInst* codegenLoadLLVM(llvm::Value* ptr,
   GenInfo* info = gGenInfo;
   llvm::LoadInst* ret = info->irBuilder->CreateLoad(ptr);
   llvm::MDNode* tbaa = NULL;
-  if( USE_TBAA && valType && !valType->symbol->llvmTbaaStructCopyNode ) {
+  if( USE_TBAA && valType ) {
     if (surroundingStruct) {
       INT_ASSERT(fieldTbaaTypeDescriptor != info->tbaaRootNode);
       tbaa = info->mdBuilder->createTBAAStructTagNode(
                surroundingStruct->symbol->llvmTbaaAggTypeDescriptor,
                fieldTbaaTypeDescriptor, fieldOffset, isConst);
-    } else {
+    } else if (!valType->symbol->llvmTbaaStructCopyNode) {
       if( isConst ) tbaa = valType->symbol->llvmConstTbaaAccessTag;
       else tbaa = valType->symbol->llvmTbaaAccessTag;
     }


### PR DESCRIPTION
Loads and stores cannot correctly handle `tbaa` access tags whose access type is a struct.  In #7873 , as additional metadata were added, I added a check to prevent struct `tbaa` access tags from being attached to loads and stores.

In #8194 , I began generating `tbaa.struct` nodes for class objects, which triggered this check and then prevented the metadata for class pointers from being attached to loads and stores.  This slowed down the stencil PRK by a factor of 3.

This change qualifies the check so that class pointers can get through, while still protecting against aggregate objects having their metadata attached to loads and stores.

The lesson here is that we were deriving tremendous benefit from scalar TBAA metadata on class pointers.

Passed full local testing with `CHPL_DEVELOPER` and `CHPL_LLVM_DEVELOPER` set, and `--llvm --fast`