### PR TITLE
Convert an internal error about param formal default value into two user errors

### DIFF
--- a/compiler/resolution/ResolutionCandidate.cpp
+++ b/compiler/resolution/ResolutionCandidate.cpp
@@ -464,13 +464,17 @@ void ResolutionCandidate::computeSubstitutions() {
 
         SymExpr* se = toSymExpr(formal->defaultExpr->body.tail);
 
-        if (se                          != NULL                              &&
-            se->symbol()->isParameter() == true                              &&
-            (formal->type->symbol->hasFlag(FLAG_GENERIC)      == false ||
-             canInstantiate(se->symbol()->type, formal->type) ==  true)) {
+        if (se && se->symbol()->isParameter() &&
+            (!formal->type->symbol->hasFlag(FLAG_GENERIC) ||
+             canInstantiate(se->symbol()->type, formal->type))) {
           subs.put(formal, se->symbol());
         } else {
-          INT_FATAL(fn, "unable to handle default parameter");
+          if (!se || !se->symbol()->isParameter()) {
+            USR_FATAL(formal, "default value for param formal is not a param");
+          } else {
+            USR_FATAL(formal, "type mismatch between declared formal type "
+                              "and default value type");
+          }
         }
       }
 

--- a/test/functions/diten/paramFormalDefaultNotParamError.chpl
+++ b/test/functions/diten/paramFormalDefaultNotParamError.chpl
@@ -1,0 +1,4 @@
+proc notParam(x) return x;
+proc f(param p = notParam(1)) { }
+
+f();

--- a/test/functions/diten/paramFormalDefaultNotParamError.good
+++ b/test/functions/diten/paramFormalDefaultNotParamError.good
@@ -1,0 +1,1 @@
+paramFormalDefaultNotParamError.chpl:2: error: default value for param formal is not a param

--- a/test/functions/diten/paramFormalGenericDefaultMismatchError.chpl
+++ b/test/functions/diten/paramFormalGenericDefaultMismatchError.chpl
@@ -1,0 +1,3 @@
+proc foo(param r: integral = 2.718) { }
+
+foo();

--- a/test/functions/diten/paramFormalGenericDefaultMismatchError.good
+++ b/test/functions/diten/paramFormalGenericDefaultMismatchError.good
@@ -1,0 +1,1 @@
+paramFormalGenericDefaultMismatchError.chpl:1: error: type mismatch between declared formal type and default value type


### PR DESCRIPTION
A param formal with a non-param default value or a type-mismatched default
value resulted in an internal error, as reported in issue #8240. Change the
internal error into two user errors:

`error: default value for param formal is not a param`
or
`error: type mismatch between declared formal type and default value type`

Added tests to trigger each of these errors.