### PR TITLE
Improve hasCopyConstructor

### DIFF
--- a/test/types/records/ferguson/copy-init/new-init-generic.future
+++ b/test/types/records/ferguson/copy-init/new-init-generic.future
@@ -1,4 +1,0 @@
-feature request: copy initializer for generic record
-
-The compiler is not recognizing that the second initializer in this test is a
-copy initializer.


### PR DESCRIPTION
PR #5642 added hasCopyConstructor to detect the presence of a
copy-initializer. However the apprach used in that PR (namely to loop
over all of the FnSymbols) doesn't work in the event that the type in
question is a generic type and the specific copy initializer hasn't been
resolved yet.

To resolve that issue (and at the same time to remove the loop over all
FnSymbols), change hasCopyConstructor to try resolving an appropriate
copy init call.

While there, renamed hasCopyConstructor to hasCopyInit since it's
detecting a copy initializer (vs an old-style copy constructor).

This PR is intended to resolve an issue that came up when
converting SharedObject to use initializers (see PR #8170).

Passed full local futures testing.
Reviewed by @noakesmichael - thanks!