### PR TITLE
Remove lcals suppression for cray-prgenv-gnu perf testing

### DIFF
--- a/test/release/examples/benchmarks/lcals/LCALSMain.suppressif
+++ b/test/release/examples/benchmarks/lcals/LCALSMain.suppressif
@@ -1,6 +1,0 @@
-#!/usr/bin/env python
-
-import os
-
-print(os.getenv('CHPL_TEST_PERF') == 'on' and
-      os.getenv('CHPL_TARGET_COMPILER') == 'cray-prgenv-gnu')


### PR DESCRIPTION
The PrgEnv-gnu driver appears to have been fixed, so remove the suppression.

This reverts https://github.com/chapel-lang/chapel/pull/8058