### PR TITLE
write functions  convert record to JSON incorrect when enum is involved

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -2809,10 +2809,8 @@ private proc _write_text_internal(_channel_internal:qio_channel_ptr_t,
   } else if isEnumType(t) {
     var st = qio_channel_style_element(_channel_internal, QIO_STYLE_ELEMENT_AGGREGATE);
     var s = x:string;
-    if st == QIO_AGGREGATE_FORMAT_JSON then
-      return qio_channel_print_string(false, _channel_internal, s.c_str(), s.length:ssize_t);
-    else
-      return qio_channel_print_literal(false, _channel_internal, s.c_str(), s.length:ssize_t);
+    if st == QIO_AGGREGATE_FORMAT_JSON then s = '"'+s+'"';
+    return qio_channel_print_literal(false, _channel_internal, s.c_str(), s.length:ssize_t);
   } else {
     compilerError("Unknown primitive type in _write_text_internal ", t:string);
   }
@@ -2975,7 +2973,6 @@ private inline proc _read_one_internal(_channel_internal:qio_channel_ptr_t,
                                        ref x:?t,
                                        loc:locale):syserr where _isIoPrimitiveTypeOrNewline(t) {
   var e:syserr = ENOERR;
-
   if t == ioNewline {
     return qio_channel_skip_past_newline(false, _channel_internal, x.skipWhitespaceOnly);
   } else if t == ioChar {
@@ -3014,7 +3011,6 @@ private inline proc _write_one_internal(_channel_internal:qio_channel_ptr_t,
                                         x:?t,
                                         loc:locale):syserr where _isIoPrimitiveTypeOrNewline(t) {
   var e:syserr = ENOERR;
-
   if t == ioNewline {
     return qio_channel_write_newline(false, _channel_internal);
   } else if t == ioChar {

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -2761,7 +2761,7 @@ private proc _read_text_internal(_channel_internal:qio_channel_ptr_t, out x:?t):
   } else if isEnumType(t) {
     var err:syserr = ENOERR;
     for i in chpl_enumerate(t) {
-      var str = i:string;
+      var str = '"' + i:string + '"';
       var slen:ssize_t = str.length.safeCast(ssize_t);
       err = qio_channel_scan_literal(false, _channel_internal, str.c_str(), slen, 1);
       // Do not free str, because enum literals are C string literals
@@ -2804,7 +2804,7 @@ private proc _write_text_internal(_channel_internal:qio_channel_ptr_t, x:?t):sys
     return qio_channel_print_string(false, _channel_internal, local_x.c_str(), local_x.length:ssize_t);
   } else if isEnumType(t) {
     var s = x:string;
-    return qio_channel_print_literal(false, _channel_internal, s.c_str(), s.length:ssize_t);
+    return qio_channel_print_string(false, _channel_internal, s.c_str(), s.length:ssize_t);
   } else {
     compilerError("Unknown primitive type in _write_text_internal ", t:string);
   }

--- a/test/io/ferguson/json-enum.chpl
+++ b/test/io/ferguson/json-enum.chpl
@@ -1,0 +1,27 @@
+
+enum MyEnum { Type1, Type2, Type3 };
+
+record MyRecord {
+  var a: string;
+  var b: MyEnum;
+}
+
+var f = opentmp();
+
+{
+  var writer = f.writer();
+  var r:MyRecord = new MyRecord("Hello", MyEnum.Type3);
+  writef("Writting JSON: %jt\n", r);
+  writer.writef("%jt", r);
+  writer.close();
+}
+
+{
+  var reader = f.reader();
+  var r:MyRecord;
+  reader.readf("%jt", r);
+  writeln("Read: ", r);
+  reader.close();
+}
+
+f.close();

--- a/test/io/ferguson/json-enum.good
+++ b/test/io/ferguson/json-enum.good
@@ -1,0 +1,2 @@
+Writting JSON: {"a":"Hello", "b":"Type3"}
+Read: (a = Hello, b = Type3)


### PR DESCRIPTION
When write a record using `writef("%jt", obj);`, then the object is not written correctly if enum is
involved in the record.

closes #8252 

- [x] full local testing
