### PR TITLE
Set PERF_CONFIG_NAME before sourcing common-perf in shootout script

### DIFF
--- a/util/cron/test-perf.chapel-shootout.bash
+++ b/util/cron/test-perf.chapel-shootout.bash
@@ -4,11 +4,12 @@
 # configuration.
 
 CWD=$(cd $(dirname $0) ; pwd)
+
+export CHPL_TEST_PERF_CONFIG_NAME="shootout"
+
 source $CWD/common-perf.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapel-shootout"
-
-export CHPL_TEST_PERF_CONFIG_NAME="shootout"
 
 export CHPL_NIGHTLY_TEST_DIRS="release/examples/benchmarks/shootout studies/shootout performance/elliot"
 $CWD/nightly -cron -performance -numtrials 5 -startdate 11/17/14


### PR DESCRIPTION
Whoops, PERF_CONFIG_NAME needs to be set before sourcing common-perf in order
for it to affect CHPL_TEST_PERF_DIR.