### PR TITLE
Fix typos

### DIFF
--- a/compiler/include/type.h
+++ b/compiler/include/type.h
@@ -287,7 +287,7 @@ public:
 
   // If isRef() is true, returns a QualifiedType with
   // a ref type (i.e. with FLAG_REF). This is useful for
-  // working with parts of the compiler that havn't fully
+  // working with parts of the compiler that haven't fully
   // transferred to QualifiedType.
   QualifiedType refToRefType() const;
 

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -4071,7 +4071,7 @@ module ChapelArray {
 
         // Now copy the data over
         for i in 0..#oldSize {
-          // this is a move, transfering ownership
+          // this is a move, transferring ownership
           __primitive("=", data[i], oldData[i]);
         }
 

--- a/runtime/src/chplsys.c
+++ b/runtime/src/chplsys.c
@@ -414,7 +414,7 @@ uint64_t chpl_sys_physicalMemoryBytes(void) {
 // Should return in some sense "currently available user memory"
 // This should return one of:
 //  * the amount of memory that can be allocated without causing swapping
-//  * the amount of memory that is currently unnused (i.e. free)
+//  * the amount of memory that is currently unused (i.e. free)
 uint64_t chpl_sys_availMemoryBytes(void) {
 #if defined(__APPLE__)
 

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -3060,7 +3060,7 @@ chpl_bool chpl_comm_impl_regMemFree(void* p, size_t size)
   // Note that this may leave remnant (and misleading) non-0 values in
   // table entries past the new end of the active area in remote nodes'
   // copies of our region table.  This is okay as long as these entries
-  // always get overwitten if the table grows past them again, as is
+  // always get overwritten if the table grows past them again, as is
   // the case now.  If removing the entry didn't change the length of
   // the table then we can just send the now-empty entry.
   //


### PR DESCRIPTION
Fix typos in include/type.h, chplsys.c, comm-ugni.c, and ChapelArray.chpl.