### PR TITLE
Disallow dispatch on _new functions

### DIFF
--- a/compiler/resolution/ResolutionCandidate.cpp
+++ b/compiler/resolution/ResolutionCandidate.cpp
@@ -656,6 +656,10 @@ bool ResolutionCandidate::checkResolveFormalsWhereClauses() {
 
       bool formalIsParam     = formal->hasFlag(FLAG_INSTANTIATED_PARAM) ||
                                formal->intent == INTENT_PARAM;
+      bool isInitThis        = strcmp(fn->name,"init") == 0 &&
+                               formal->hasFlag(FLAG_ARG_THIS);
+      bool isNewTypeArg      = strcmp(fn->name,"_new") == 0 &&
+                               coindex == 0; // first formal/actual
 
       if (actualIsTypeAlias != formalIsTypeAlias) {
         return false;
@@ -675,8 +679,7 @@ bool ResolutionCandidate::checkResolveFormalsWhereClauses() {
                              NULL,
                              formalIsParam) == false) {
         return false;
-      } else if (strcmp(fn->name,"init") == 0 &&
-                 formal->hasFlag(FLAG_ARG_THIS)) {
+      } else if (isInitThis || isNewTypeArg) {
         AggregateType* ft = toAggregateType(formal->getValType());
         AggregateType* at = toAggregateType(actual->getValType());
 

--- a/test/classes/initializers/inheritance/inheritedInitWrongName.bad
+++ b/test/classes/initializers/inheritance/inheritedInitWrongName.bad
@@ -1,2 +1,0 @@
-inheritedInitWrongName.chpl:20: error: type mismatch in assignment from C to D
-deleted module lines

--- a/test/classes/initializers/inheritance/inheritedInitWrongName.future
+++ b/test/classes/initializers/inheritance/inheritedInitWrongName.future
@@ -1,6 +1,0 @@
-error message: accidental call to superclass initializer
-
-It seems to me that calls to 'new subclass(...)' (like 'new D' in this
-example) shouldn't resolve to superclass initializers, yet that's what
-seems to be happening here, resulting in a type mismatch, presumably
-in some internal code generated from new expressions.

--- a/test/classes/initializers/inheritance/parent-child-coerce-class.bad
+++ b/test/classes/initializers/inheritance/parent-child-coerce-class.bad
@@ -1,3 +1,0 @@
-parent-child-coerce-class.chpl:18: error: ambiguous call '_new(type Child, Derived)'
-parent-child-coerce-class.chpl:4: note: candidates are: _new(type chpl_t, x: Derived)
-parent-child-coerce-class.chpl:11: note:                 _new(type chpl_t, x: Base)

--- a/test/classes/initializers/inheritance/parent-child-coerce-class.future
+++ b/test/classes/initializers/inheritance/parent-child-coerce-class.future
@@ -1,2 +1,0 @@
-bug: initializer resolution confused by parent candidate
-#8176

--- a/test/classes/initializers/inheritance/parent-child-coerce.bad
+++ b/test/classes/initializers/inheritance/parent-child-coerce.bad
@@ -1,3 +1,0 @@
-parent-child-coerce.chpl:16: error: ambiguous call '_new(type Child, int(64))'
-parent-child-coerce.chpl:1: note: candidates are: _new(type chpl_t, x: int(64))
-parent-child-coerce.chpl:9: note:                 _new(type chpl_t, x: real(64))

--- a/test/classes/initializers/inheritance/parent-child-coerce.future
+++ b/test/classes/initializers/inheritance/parent-child-coerce.future
@@ -1,2 +1,0 @@
-bug: initializer resolution confused by parent candidate
-#8176


### PR DESCRIPTION
This PR re-uses the logic from #8259 in order to prevent _new functions from dispatching onto parent _new functions.

Closes #8176 

Testing:
- [x] full local