### PR TITLE
Improve an error message about a param initialized with a non-param

### DIFF
--- a/compiler/resolution/ResolutionCandidate.cpp
+++ b/compiler/resolution/ResolutionCandidate.cpp
@@ -470,7 +470,7 @@ void ResolutionCandidate::computeSubstitutions() {
           subs.put(formal, se->symbol());
         } else {
           if (!se || !se->symbol()->isParameter()) {
-            USR_FATAL(formal, "default value for param formal is not a param");
+            USR_FATAL(formal, "default value for param is not a param");
           } else {
             USR_FATAL(formal, "type mismatch between declared formal type "
                               "and default value type");

--- a/test/classes/diten/paramFieldNonParamInit.chpl
+++ b/test/classes/diten/paramFieldNonParamInit.chpl
@@ -1,0 +1,10 @@
+proc notParam(i: int) {
+  return i;
+}
+
+class Foo {
+  param field = notParam(1);
+}
+
+var f = new Foo();
+delete f;

--- a/test/classes/diten/paramFieldNonParamInit.good
+++ b/test/classes/diten/paramFieldNonParamInit.good
@@ -1,0 +1,1 @@
+paramFieldNonParamInit.chpl:6: error: default value for param is not a param

--- a/test/functions/diten/paramFormalDefaultNotParamError.good
+++ b/test/functions/diten/paramFormalDefaultNotParamError.good
@@ -1,1 +1,1 @@
-paramFormalDefaultNotParamError.chpl:2: error: default value for param formal is not a param
+paramFormalDefaultNotParamError.chpl:2: error: default value for param is not a param


### PR DESCRIPTION
This new error message was about a param formal, but also applies to param
fields.  Remove the word 'formal' so the wording works in either case.

Added a simplified version of the param field test case from issue #8240.