### PR TITLE
The gmake clock-skew-warning filters should use a more portable regex

### DIFF
--- a/util/test/checkChplInstall
+++ b/util/test/checkChplInstall
@@ -162,24 +162,28 @@ COMP_FLAGS="--cc-warnings"
 
 # Compile test job into temporary directory
 log_info "Compiling \$CHPL_HOME/${REL_TEST_DIR}/${TEST_JOB}.chpl"
-${CHPL_BIN} ${TEST_DIR}/${TEST_JOB}.chpl ${COMP_FLAGS} -o ${TMP_TEST_DIR}/${TEST_JOB} > ${TMP_TEST_DIR}/chpl.out 2>&1
+TEST_COMP_OUT=$( ${CHPL_BIN} ${TEST_DIR}/${TEST_JOB}.chpl ${COMP_FLAGS} -o ${TMP_TEST_DIR}/${TEST_JOB} 2>&1 )
 COMPILE_STATUS=$?
 
-# Check that chpl compile was successful
+# Check that compile was successful
 log_debug "Compilation exit status was ${COMPILE_STATUS}"
 
     # exit status 0?
 if [ ${COMPILE_STATUS} -ne 0 ]; then
     log_error "Test job failed to compile - Chapel is not installed correctly"
     log_error "Compilation output:"
-    cat ${TMP_TEST_DIR}/chpl.out
+    echo "${TEST_COMP_OUT}"
     log_debug "Exit \"make check\" script with status code 1"
     exit 1
 fi
 
     # no errors on stdout/stderr?
-    # first, apply "prediff"-like filter to remove gmake "clock skew detected" warnings, if any
-TEST_COMP_OUT=$( grep < ${TMP_TEST_DIR}/chpl.out -Ev '^g?make(\[[0-9]+\])?: *[Ww]arning: *(File .* has modification time .* in the future|Clock skew detected\. *Your build may be incomplete\.) *$' 2>&1 )
+if [ -n "${TEST_COMP_OUT}" ]; then
+    # apply "prediff"-like filter to remove gmake "clock skew detected" warnings, if any
+    TEST_COMP_OUT=$( grep <<<"${TEST_COMP_OUT}" -v \
+        -e '^g*make: Warning: File .* has modification time .* in the future *$' \
+        -e '^g*make: warning:  Clock skew detected\.  Your build may be incomplete\. *$' )
+fi
 
 if [ -n "${TEST_COMP_OUT}" ]; then
     log_error "Test job compiled with output - Chapel is not installed correctly"

--- a/util/test/preexec-for-gmake-clock-skew-warning
+++ b/util/test/preexec-for-gmake-clock-skew-warning
@@ -23,6 +23,9 @@
 outfile=$2
 temp=$outfile.temp
 
-grep < $outfile > $temp -Ev '^g?make(\[[0-9]+\])?: *[Ww]arning: *(File .* has modification time .* in the future|Clock skew detected\. *Your build may be incomplete\.) *$'
-
-mv $temp $outfile
+if [ -s "$outfile" ]; then
+    grep < $outfile > $temp -v \
+        -e '^g*make: Warning: File .* has modification time .* in the future *$' \
+        -e '^g*make: warning:  Clock skew detected\.  Your build may be incomplete\. *$'
+    mv $temp $outfile
+fi


### PR DESCRIPTION
PR #8151 added filters to silently remove "clock skew detected" warning messages from gmake (if any), because those messages (when they occur) caused false test failures- both in Chapel's test harness, and in the shell script used to implement "make check". When the modified "make check" was run on omnios, the grep command failed because it did not accept "-E".

This change introduces a grep/regex that solves the omnios compatibility problem.

In the "make check" script (checkChplInstall) only, it also reverts some unnecessary complexity in PR #8151.  To understand this PR, it may be helpful to
>    git diff 7926fcce -- util/test/checkChplInstall

(ie, diff the version BEFORE PR #8151)
