### PR TITLE
Add an --llvm shootout performance configuration

### DIFF
--- a/util/cron/test-perf.chapel-shootout-llvm.bash
+++ b/util/cron/test-perf.chapel-shootout-llvm.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Run shootout performance benchmark tests on chapel-shootout with default
+# Run shootout performance benchmark tests on chapel-shootout with llvm
 # configuration.
 
 CWD=$(cd $(dirname $0) ; pwd)
@@ -8,11 +8,13 @@ CWD=$(cd $(dirname $0) ; pwd)
 export CHPL_TEST_PERF_CONFIG_NAME="shootout"
 
 source $CWD/common-perf.bash
+source $CWD/common-llvm.bash
 
-export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapel-shootout"
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapel-shootout-llvm"
 
 export CHPL_NIGHTLY_TEST_DIRS="release/examples/benchmarks/shootout studies/shootout performance/elliot"
 
+perf_args="${perf_args} -performance-description llvm -performance-configs default:v,llvm:v -sync-dir-suffix llvm"
 perf_args="${perf_args} -performance -numtrials 5 -startdate 11/17/14"
 
 $CWD/nightly -cron ${nighly_args} ${perf_args}


### PR DESCRIPTION
See how --llvm compares to the C backend for the shootout competition