### PR TITLE
Document next idea for solving this bug and move on

### DIFF
--- a/test/classes/initializers/compilerGenerated/omittedIfExpr.future
+++ b/test/classes/initializers/compilerGenerated/omittedIfExpr.future
@@ -4,3 +4,9 @@ Currently, default initializers get generated improperly when one or more fields
 are given an initial value that is a conditional expression.  I thought I had a
 path that would solve this issue quickly, but it turns out to be more involved,
 so save this test as a future for the moment.
+
+Michael suggests that the right solution is probably to rewrite if expressions
+so that they are handled by their own AST node in place instead of creating
+a FnSymbol for them that is then moved out of the immediate scope.  However,
+this will be more work than is reasonable for this side bug at the moment, so
+put it off for now.


### PR DESCRIPTION
Michael suggested replacing the current handling of if expressions with a new
AST node that could handle them in place.

However, it seems like the general agreement (and I think Michael is included in
this to some extent) is that this is a lower priority fix.  So document the
idea to fix it and move on for now.