### PR TITLE
Stop serializing foralls in parallel/forall/vass/memleaks*

### DIFF
--- a/test/parallel/forall/vass/memleaks1-minimal.chpl
+++ b/test/parallel/forall/vass/memleaks1-minimal.chpl
@@ -7,10 +7,8 @@ proc main() {
   var MY_VAR = 1;
   const m1 = memoryUsed();
 
-  // serial to quiet a sporadic (1 in 1000) regression (see JIRA issue 112)
-  serial do
-    forall idx in MYITER() do
-      useMe(MY_VAR);
+  forall idx in MYITER() do
+    useMe(MY_VAR);
 
   const m2 = memoryUsed();
   writeln("leaked: ", m2-m1);

--- a/test/parallel/forall/vass/memleaks2-BlockDist.chpl
+++ b/test/parallel/forall/vass/memleaks2-BlockDist.chpl
@@ -11,10 +11,8 @@ proc main() {
   var myvar = initval;
   const m1 = memoryUsed();
 
-  // serial to quiet a sporadic (1 in 1000) regression (see JIRA issue 112)
-  serial do
-    forall da in DARRAY do
-      da = myvar;
+  forall da in DARRAY do
+    da = myvar;
 
   const m2 = memoryUsed();
 


### PR DESCRIPTION
This reverts #2537. That PR quieted some memleaks by wrapping a forall with a
serial stmt. The root cause was never understood, but the sporadic leaks seem
to be gone now, so remove the serial stmts and references to the JIRA issue.

Passes 100,000 trials for test/parallel/forall/vass/memleaks*.chpl with the
quickstart configuration for --local and --no-local.