### PR TITLE
Stop forcing serial initialization for isx-hand-optimized

### DIFF
--- a/test/studies/isx/isx-hand-optimized.compopts
+++ b/test/studies/isx/isx-hand-optimized.compopts
@@ -1,1 +1,1 @@
---no-warnings -schpl_defaultArrayInitMethod=ArrayInit.serialInit --no-bounds-checks
+--no-warnings --no-bounds-checks

--- a/test/studies/isx/isx-hand-optimized.ml-compopts
+++ b/test/studies/isx/isx-hand-optimized.ml-compopts
@@ -1,1 +1,1 @@
---no-warnings -schpl_defaultArrayInitMethod=ArrayInit.serialInit -sdisableBlockLazyRAD
+--no-warnings -sdisableBlockLazyRAD

--- a/test/studies/isx/isx-hand-optimized.perfcompopts
+++ b/test/studies/isx/isx-hand-optimized.perfcompopts
@@ -1,1 +1,1 @@
---no-warnings -schpl_defaultArrayInitMethod=ArrayInit.serialInit -sdisableBlockLazyRAD
+--no-warnings -sdisableBlockLazyRAD


### PR DESCRIPTION
We originally forced serial array initialization for isx-hand-optimized because
we were miscounting running tasks and mistakenly initializing some arrays in
parallel (leading to over-subscription and potentially wrong affinity.)

Task counting was fixed a while back in #7193 and array initialization is now
correctly done serially for ISx, so remove the lame workaround.