### PR TITLE
 Catch more use-before-init phase 1 errors

### DIFF
--- a/test/classes/initializers/generics/initAtomicsViaWrite.bad
+++ b/test/classes/initializers/generics/initAtomicsViaWrite.bad
@@ -1,8 +1,2 @@
 initAtomicsViaWrite.chpl:5: In initializer:
-initAtomicsViaWrite.chpl:6: internal error: CAL0123 chpl version 1.17.0 pre-release (5a84825)
-
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
-and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
-please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
-
+initAtomicsViaWrite.chpl:6: error: Field used before it is initialized

--- a/test/classes/initializers/phase1/use-before-field.chpl
+++ b/test/classes/initializers/phase1/use-before-field.chpl
@@ -1,0 +1,15 @@
+
+record B {
+  var foo : int;
+}
+
+record A {
+  var b : B;
+
+  proc init() {
+    b.foo = 5;
+    super.init();
+  }
+}
+
+var a = new A();

--- a/test/classes/initializers/phase1/use-before-field.good
+++ b/test/classes/initializers/phase1/use-before-field.good
@@ -1,0 +1,2 @@
+use-before-field.chpl:9: In initializer:
+use-before-field.chpl:10: error: Field used before it is initialized

--- a/test/classes/initializers/phase1/use-before-method.chpl
+++ b/test/classes/initializers/phase1/use-before-method.chpl
@@ -1,0 +1,19 @@
+
+record B {
+  var foo : int;
+
+  proc set(i:int) {
+    foo = i;
+  }
+}
+
+record A {
+  var b : B;
+
+  proc init() {
+    b.set(1);
+    super.init();
+  }
+}
+
+var a = new A();

--- a/test/classes/initializers/phase1/use-before-method.good
+++ b/test/classes/initializers/phase1/use-before-method.good
@@ -1,0 +1,2 @@
+use-before-method.chpl:13: In initializer:
+use-before-method.chpl:14: error: Field used before it is initialized

--- a/test/classes/initializers/phase1/use-before-square.chpl
+++ b/test/classes/initializers/phase1/use-before-square.chpl
@@ -1,0 +1,19 @@
+
+record B {
+  var foo : int;
+
+  proc this(i:int) ref {
+    return foo;
+  }
+}
+
+record A {
+  var b : B;
+
+  proc init() {
+    b[1] = 1;
+    super.init();
+  }
+}
+
+var a = new A();

--- a/test/classes/initializers/phase1/use-before-square.good
+++ b/test/classes/initializers/phase1/use-before-square.good
@@ -1,0 +1,2 @@
+use-before-square.chpl:13: In initializer:
+use-before-square.chpl:14: error: Field used before it is initialized


### PR DESCRIPTION
Before this PR users could call methods on fields during phase 1, and the
compiler would fail to complain. For example:

```chpl
// 'x' is a field
proc init() {
  x[1] = 1;
  x.foo = 1;
  x.m();
  super.init();
}
```

The three statements preceeding the 'super.init' should be flagged as
'use before init' errors at compile-time. The second statement was in
fact identified as an error, but the message was confusing (can't pass
"this" as an actual to a function...).

Three changes are made to InitNormalize::fieldUsedBeforeInitialized:

1) "x[1] = 1": If the LHS of an assignment looks like a field access and the
   call is flagged with the 'square' tag, then we are dealing with a field use.

2) "x.foo = 1": If the LHS of an assignment is not a simple field access, then
   we need to walk through it to determine if it contains field uses.

3) "x.m()": When examining an arbitrary CallExpr that is not an assignment
   or field access, we need to examine its baseExpr as well as its actuals.
   In this case, the baseExpr is a field access like "this.x".

These cases now result in an error message like:
  Field used before it is initialized

Testing:
- [x] full local + futures