### PR TITLE
Fix LLVM backend field access type and supertype TBAA handling

### DIFF
--- a/compiler/codegen/expr.cpp
+++ b/compiler/codegen/expr.cpp
@@ -440,7 +440,7 @@ void codegenInvariantStart(llvm::Value *val, llvm::Value *addr)
 }
 
 // Create an LLVM store instruction possibly adding
-// appropriate metadata based upon the Chapel type of val.
+// appropriate metadata based upon the Chapel type destType.
 //
 static
 llvm::StoreInst* codegenStoreLLVM(llvm::Value* val,
@@ -483,6 +483,8 @@ llvm::StoreInst* codegenStoreLLVM(llvm::Value* val,
 
 
 
+// The valType argument is a hint, in case we don't already know the
+// Chapel type of the memory into which we are storing.
 static
 llvm::StoreInst* codegenStoreLLVM(GenRet val,
                                   GenRet ptr,
@@ -550,6 +552,8 @@ llvm::LoadInst* codegenLoadLLVM(llvm::Value* ptr,
   return ret;
 }
 
+// The valType argument is a hint, in case we don't already know the
+// Chapel type of the memory from which we are loading.
 static
 llvm::LoadInst* codegenLoadLLVM(GenRet ptr,
                                 Type* valType = NULL,
@@ -2433,6 +2437,8 @@ GenRet codegenCallExpr(GenRet function,
     }
 
     if( sret ) {
+      // The second argument to codegenLoadLLVM() is a hint, in the
+      // case that we don't already know the Chapel type being loaded.
       ret.val = codegenLoadLLVM(sret, fSym?(fSym->retType):(NULL));
     }
 #endif
@@ -3160,6 +3166,8 @@ void codegenAssign(GenRet to_ptr, GenRet from)
         GenRet value = codegenValue(from);
         assert(value.val);
 
+	// The third argument to codegenStoreLLVM() is a hint, in the
+	// case that we don't already know the type of the destination.
         codegenStoreLLVM(value, to_ptr, type);
 #endif
       }

--- a/compiler/codegen/expr.cpp
+++ b/compiler/codegen/expr.cpp
@@ -3166,8 +3166,8 @@ void codegenAssign(GenRet to_ptr, GenRet from)
         GenRet value = codegenValue(from);
         assert(value.val);
 
-	// The third argument to codegenStoreLLVM() is a hint, in the
-	// case that we don't already know the type of the destination.
+        // The third argument to codegenStoreLLVM() is a hint, in the
+        // case that we don't already know the type of the destination.
         codegenStoreLLVM(value, to_ptr, type);
 #endif
       }

--- a/compiler/codegen/expr.cpp
+++ b/compiler/codegen/expr.cpp
@@ -445,24 +445,23 @@ void codegenInvariantStart(llvm::Value *val, llvm::Value *addr)
 static
 llvm::StoreInst* codegenStoreLLVM(llvm::Value* val,
                                   llvm::Value* ptr,
-                                  Type* valType = NULL,
+                                  Type* destType = NULL,
                                   Type* surroundingStruct = NULL,
                                   uint64_t fieldOffset = 0,
-                                  llvm::MDNode* fieldTbaaTypeDescriptor = NULL,
                                   bool addInvariantStart = false)
 {
   GenInfo *info = gGenInfo;
   llvm::StoreInst* ret = info->irBuilder->CreateStore(val, ptr);
   llvm::MDNode* tbaa = NULL;
-  if (USE_TBAA && valType &&
-      (isClass(valType) || !valType->symbol->llvmTbaaStructCopyNode)) {
+  if (USE_TBAA && destType &&
+      (isClass(destType) || !destType->symbol->llvmTbaaStructCopyNode)) {
     if (surroundingStruct) {
-      INT_ASSERT(fieldTbaaTypeDescriptor != info->tbaaRootNode);
+      INT_ASSERT(destType->symbol->llvmTbaaTypeDescriptor!=info->tbaaRootNode);
       tbaa = info->mdBuilder->createTBAAStructTagNode(
                surroundingStruct->symbol->llvmTbaaAggTypeDescriptor,
-               fieldTbaaTypeDescriptor, fieldOffset);
+               destType->symbol->llvmTbaaTypeDescriptor, fieldOffset);
     } else {
-      tbaa = valType->symbol->llvmTbaaAccessTag;
+      tbaa = destType->symbol->llvmTbaaAccessTag;
     }
   }
   if( tbaa ) ret->setMetadata(llvm::LLVMContext::MD_tbaa, tbaa);
@@ -490,9 +489,12 @@ llvm::StoreInst* codegenStoreLLVM(GenRet val,
                                   Type* valType = NULL)
 {
   if( val.chplType && !valType ) valType = val.chplType;
-  if( ptr.chplType && !valType ) {
-    if( ptr.isLVPtr ) valType = ptr.chplType;
-    else valType = ptr.chplType->getValType();
+  Type *destType;
+  if (ptr.chplType) {
+    if (ptr.isLVPtr) destType = ptr.chplType;
+    else destType = ptr.chplType->getValType();
+  } else {
+    destType = valType;
   }
 
   llvm::Type* ptrValType = llvm::cast<llvm::PointerType>(
@@ -510,33 +512,31 @@ llvm::StoreInst* codegenStoreLLVM(GenRet val,
 
   INT_ASSERT(!(ptr.alreadyStored && ptr.canBeMarkedAsConstAfterStore));
   ptr.alreadyStored = true;
-  return codegenStoreLLVM(val.val, ptr.val, valType, ptr.surroundingStruct,
-                          ptr.fieldOffset, ptr.fieldTbaaTypeDescriptor,
-                          ptr.canBeMarkedAsConstAfterStore);
+  return codegenStoreLLVM(val.val, ptr.val, destType, ptr.surroundingStruct,
+                          ptr.fieldOffset, ptr.canBeMarkedAsConstAfterStore);
 }
 // Create an LLVM load instruction possibly adding
 // appropriate metadata based upon the Chapel type of ptr.
 static
 llvm::LoadInst* codegenLoadLLVM(llvm::Value* ptr,
-                                Type* valType = NULL,
+                                Type* srcType = NULL,
                                 Type* surroundingStruct = NULL,
                                 uint64_t fieldOffset = 0,
-                                llvm::MDNode* fieldTbaaTypeDescriptor = NULL,
                                 bool isConst = false)
 {
   GenInfo* info = gGenInfo;
   llvm::LoadInst* ret = info->irBuilder->CreateLoad(ptr);
   llvm::MDNode* tbaa = NULL;
-  if (USE_TBAA && valType &&
-      (isClass(valType) || !valType->symbol->llvmTbaaStructCopyNode)) {
+  if (USE_TBAA && srcType &&
+      (isClass(srcType) || !srcType->symbol->llvmTbaaStructCopyNode)) {
     if (surroundingStruct) {
-      INT_ASSERT(fieldTbaaTypeDescriptor != info->tbaaRootNode);
+      INT_ASSERT(srcType->symbol->llvmTbaaTypeDescriptor!=info->tbaaRootNode);
       tbaa = info->mdBuilder->createTBAAStructTagNode(
                surroundingStruct->symbol->llvmTbaaAggTypeDescriptor,
-               fieldTbaaTypeDescriptor, fieldOffset, isConst);
+               srcType->symbol->llvmTbaaTypeDescriptor, fieldOffset, isConst);
     } else {
-      if( isConst ) tbaa = valType->symbol->llvmConstTbaaAccessTag;
-      else tbaa = valType->symbol->llvmTbaaAccessTag;
+      if (isConst) tbaa = srcType->symbol->llvmConstTbaaAccessTag;
+      else tbaa = srcType->symbol->llvmTbaaAccessTag;
     }
   }
 
@@ -555,13 +555,16 @@ llvm::LoadInst* codegenLoadLLVM(GenRet ptr,
                                 Type* valType = NULL,
                                 bool isConst = false)
 {
-  if( ptr.chplType && !valType ) {
-    if( ptr.isLVPtr ) valType = ptr.chplType;
-    else valType = ptr.chplType->getValType();
+  Type *srcType;
+  if (ptr.chplType) {
+    if (ptr.isLVPtr) srcType = ptr.chplType;
+    else srcType = ptr.chplType->getValType();
+  } else {
+    srcType = valType;
   }
 
-  return codegenLoadLLVM(ptr.val, valType, ptr.surroundingStruct,
-                         ptr.fieldOffset, ptr.fieldTbaaTypeDescriptor, isConst);
+  return codegenLoadLLVM(ptr.val, srcType, ptr.surroundingStruct,
+                         ptr.fieldOffset, isConst);
 }
 
 #endif
@@ -1074,8 +1077,6 @@ GenRet codegenFieldPtr(
         ret.surroundingStruct = cBaseType;
         ret.fieldOffset = info->module->getDataLayout().
           getStructLayout(structType)->getElementOffset(fieldno);
-        ret.fieldTbaaTypeDescriptor =
-          ret.chplType->symbol->llvmTbaaTypeDescriptor;
       }
     }
 #endif

--- a/compiler/codegen/symbol.cpp
+++ b/compiler/codegen/symbol.cpp
@@ -1136,7 +1136,9 @@ void TypeSymbol::codegenAggMetadata() {
 
       llvm::Type *fieldType = NULL;
       AggregateType *fct = toAggregateType(field->type);
+      bool is_super = false;
       if (fct && field->hasFlag(FLAG_SUPER_CLASS)) {
+        is_super = true;
         fieldType = info->lvt->getType(fct->classStructName(true));
       } else if (field->type->symbol->hasFlag(FLAG_EXTERN)) {
         fieldType = info->lvt->getType(field->type->symbol->cname);
@@ -1150,19 +1152,30 @@ void TypeSymbol::codegenAggMetadata() {
         uint64_t byte_offset =
           dl.getStructLayout(struct_type)->getElementOffset(fieldno);
         llvm::Constant *off = llvm::ConstantInt::get(int64Ty, byte_offset);
-        INT_ASSERT(field->type->symbol->llvmTbaaTypeDescriptor &&
-                   field->type->symbol->llvmTbaaTypeDescriptor !=
-                   info->tbaaRootNode);
-        TypeOps.push_back(field->type->symbol->llvmTbaaTypeDescriptor);
+        if (is_super) {
+          INT_ASSERT(field->type->symbol->llvmTbaaAggTypeDescriptor &&
+                     field->type->symbol->llvmTbaaAggTypeDescriptor !=
+                     info->tbaaRootNode);
+          TypeOps.push_back(field->type->symbol->llvmTbaaAggTypeDescriptor);
+        } else {
+          INT_ASSERT(field->type->symbol->llvmTbaaTypeDescriptor &&
+                     field->type->symbol->llvmTbaaTypeDescriptor !=
+                     info->tbaaRootNode);
+          TypeOps.push_back(field->type->symbol->llvmTbaaTypeDescriptor);
+        }
         TypeOps.push_back(llvm::ConstantAsMetadata::get(off));
 
         llvm::Constant *sz = llvm::ConstantInt::get(int64Ty, store_size);
         CopyOps.push_back(llvm::ConstantAsMetadata::get(off));
         CopyOps.push_back(llvm::ConstantAsMetadata::get(sz));
-        CopyOps.push_back(field->type->symbol->llvmTbaaAccessTag);
+        CopyOps.push_back(is_super ?
+                          field->type->symbol->llvmTbaaAggAccessTag :
+                          field->type->symbol->llvmTbaaAccessTag);
         ConstCopyOps.push_back(llvm::ConstantAsMetadata::get(off));
         ConstCopyOps.push_back(llvm::ConstantAsMetadata::get(sz));
-        ConstCopyOps.push_back(field->type->symbol->llvmConstTbaaAccessTag);
+        ConstCopyOps.push_back(is_super ?
+                               field->type->symbol->llvmConstTbaaAggAccessTag :
+                               field->type->symbol->llvmConstTbaaAccessTag);
       }
     }
   }
@@ -1170,6 +1183,19 @@ void TypeSymbol::codegenAggMetadata() {
     llvmTbaaAggTypeDescriptor = llvm::MDNode::get(ctx, TypeOps);
     llvmTbaaStructCopyNode = llvm::MDNode::get(ctx, CopyOps);
     llvmConstTbaaStructCopyNode = llvm::MDNode::get(ctx, ConstCopyOps);
+  }
+  if (llvmTbaaAggTypeDescriptor &&
+      llvmTbaaAggTypeDescriptor != info->tbaaRootNode) {
+    // Create tbaa access tags, one for const and one for not.
+    llvmTbaaAggAccessTag =
+      info->mdBuilder->createTBAAStructTagNode(llvmTbaaAggTypeDescriptor,
+                                               llvmTbaaAggTypeDescriptor,
+                                               /*Offset=*/0);
+    llvmConstTbaaAggAccessTag =
+      info->mdBuilder->createTBAAStructTagNode(llvmTbaaAggTypeDescriptor,
+                                               llvmTbaaAggTypeDescriptor,
+                                               /*Offset=*/0,
+                                               /*IsConstant=*/true);
   }
 #endif
 }

--- a/compiler/codegen/symbol.cpp
+++ b/compiler/codegen/symbol.cpp
@@ -1091,7 +1091,7 @@ void TypeSymbol::codegenAggMetadata() {
 
   GenInfo* info = gGenInfo;
 
-  // Set the llvmTbaaTypeDescriptor to non-NULL so that we can
+  // Set the llvmTbaaAggTypeDescriptor to non-NULL so that we can
   // avoid recursing.
   llvmTbaaAggTypeDescriptor = info->tbaaRootNode;
 

--- a/compiler/include/genret.h
+++ b/compiler/include/genret.h
@@ -99,14 +99,12 @@ public:
   llvm::Type *type; // set when generating a type only
   Type *surroundingStruct; // surrounding structure, if this is a field
   uint64_t fieldOffset; // byte offset of this field within struct
-  llvm::MDNode *fieldTbaaTypeDescriptor;
 #else
   // Keeping same layout for non-LLVM builds
   void* val;
   void* type;
   void* surroundingStruct;
   uint64_t fieldOffset;
-  void* fieldTbaaTypeDescriptor;
 #endif
 
   // Used to mark variables as const after they are stored
@@ -139,7 +137,7 @@ public:
                    // called type, since LLVM native integer types do not
                    // include signed-ness.
                    
-  GenRet() : c(), val(NULL), type(NULL), surroundingStruct(NULL), fieldOffset(0), fieldTbaaTypeDescriptor(NULL), canBeMarkedAsConstAfterStore(false), alreadyStored(false), chplType(NULL), isLVPtr(GEN_VAL), isUnsigned(false) { }
+  GenRet() : c(), val(NULL), type(NULL), surroundingStruct(NULL), fieldOffset(0), canBeMarkedAsConstAfterStore(false), alreadyStored(false), chplType(NULL), isLVPtr(GEN_VAL), isUnsigned(false) { }
   // Allow implicit conversion from AST elements.
   GenRet(BaseAST* ast) {
     *this = baseASTCodegen(ast);

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -435,6 +435,8 @@ class TypeSymbol : public Symbol {
   llvm::MDNode* llvmTbaaAccessTag;            // scalar access tag
   llvm::MDNode* llvmConstTbaaAccessTag;       // scalar const access tag
   llvm::MDNode* llvmTbaaAggTypeDescriptor;    // aggregate type descriptor
+  llvm::MDNode* llvmTbaaAggAccessTag;         // aggregate access tag
+  llvm::MDNode* llvmConstTbaaAggAccessTag;    // aggregate const access tag
   llvm::MDNode* llvmTbaaStructCopyNode;       // tbaa.struct for memcpy
   llvm::MDNode* llvmConstTbaaStructCopyNode;  // const tbaa.struct
   llvm::MDNode* llvmDIType;
@@ -446,6 +448,8 @@ class TypeSymbol : public Symbol {
   void* llvmTbaaAccessTag;
   void* llvmConstTbaaAccessTag;
   void* llvmTbaaAggTypeDescriptor;
+  void* llvmTbaaAggAccessTag;
+  void* llvmConstTbaaAggAccessTag;
   void* llvmTbaaStructCopyNode;
   void* llvmConstTbaaStructCopyNode;
   void* llvmDIType;

--- a/test/llvm/tbaa/tbaa_class.chpl
+++ b/test/llvm/tbaa/tbaa_class.chpl
@@ -32,17 +32,15 @@ writeln(myClass);
 //
 // Scalar TBAA type descriptors:  reference to parent type only
 // CHECK-DAG: ![[UNIONS:[0-9]+]] = !{!"all unions", ![[CHPLTYPES]], i64 0}
+// CHECK-DAG: ![[INT32:[0-9]+]] = !{!"int32_t", ![[UNIONS]], i64 0}
 // CHECK-DAG: ![[INT:[0-9]+]] = !{!"int64_t", ![[UNIONS]], i64 0}
 // CHECK-DAG: ![[REAL:[0-9]+]] = !{!"_real64", ![[UNIONS]], i64 0}
-// CHECK-DAG: ![[CVOIDPTR:[0-9]+]] = !{!"C void ptr", ![[UNIONS]], i64 0}
 //
-// Note that "object" is a scalar type descriptor because it is a pointer.
-// CHECK-DAG: ![[OBJECT:[0-9]+]] = !{!"object", ![[CVOIDPTR]], i64 0}
-//
-// Class object TBAA type descriptor:  reference to superclass and each field
-// CHECK-DAG: ![[CLS:[0-9]+]] = !{!"chpl_MyClass_chpl_object", ![[OBJECT]], i64 0, ![[INT]], i64 {{[0-9]+}}, ![[REAL]], i64 {{[0-9]+}}}
+// Class object TBAA type descriptors:  reference to superclass and each field
+// CHECK-DAG: ![[OBJOBJ:[0-9]+]] = !{!"chpl_object_object", ![[INT32]], i64 0}
+// CHECK-DAG: ![[CLSOBJ:[0-9]+]] = !{!"chpl_MyClass_chpl_object", ![[OBJOBJ]], i64 0, ![[INT]], i64 {{[0-9]+}}, ![[REAL]], i64 {{[0-9]+}}}
 //
 // Now validate those access tags.
 // The int is not at offset zero because the object superclass comes first.
-// CHECK-DAG: ![[INTVIACLS]] = !{![[CLS]], ![[INT]], i64 {{[0-9]+}}}
-// CHECK-DAG: ![[REALVIACLS]] = !{![[CLS]], ![[REAL]], i64 {{[0-9]+}}}
+// CHECK-DAG: ![[INTVIACLS]] = !{![[CLSOBJ]], ![[INT]], i64 {{[0-9]+}}}
+// CHECK-DAG: ![[REALVIACLS]] = !{![[CLSOBJ]], ![[REAL]], i64 {{[0-9]+}}}


### PR DESCRIPTION
In the translation to LLVM, we were sometimes passing an incorrect Chapel type to the low-level version of the `codegenLoadLLVM()` and `codegenStoreLLVM()` functions.  Nothing was wrong with the LLVM type, only the Chapel type, which is why it only became apparent while I was working on TBAA.  This change fixes that problem.  As a result, it is no longer necessary to carry around a `fieldTbaaTypeDescriptor` in a `GenRet`.

While there, I noticed that I was generating TBAA information the same for superclasses as for other classes, which meant that they were erroneously marked as pointers in the TBAA metadata.  This change fixes that.

Expected test results have been updated accordingly.

Test plan:
- [x] Mac on release/examples with `CHPL_LLVM=system`, `--llvm --fast`, and LLVM 5
- [x] Full local testing on linux64 with `CHPL_LLVM=llvm`, `--llvm --fast`, and LLVM 4, with `CHPL_DEVELOPER` and `CHPL_LLVM_DEVELOPER` set