### PR TITLE
Retire initAtomicsViaWrite future

### DIFF
--- a/test/classes/initializers/generics/initAtomicsViaWrite.bad
+++ b/test/classes/initializers/generics/initAtomicsViaWrite.bad
@@ -1,2 +1,0 @@
-initAtomicsViaWrite.chpl:5: In initializer:
-initAtomicsViaWrite.chpl:6: error: Field used before it is initialized

--- a/test/classes/initializers/generics/initAtomicsViaWrite.future
+++ b/test/classes/initializers/generics/initAtomicsViaWrite.future
@@ -1,9 +1,0 @@
-bug: internal error attempting to write atomics in generic class initializer
-
-Something about this test results in an internal error.  I don't think
-this test should work (*), but I stumbled across it while looking for a
-correct solution.
-
-(*) = Because the compiler presumably shouldn't view a .write() as an
-initialization of the atomic?  Yet interestingly, if I remove the
-generic field, it does work, so maybe I'm wrong in that assumption?

--- a/test/classes/initializers/generics/initAtomicsViaWrite.good
+++ b/test/classes/initializers/generics/initAtomicsViaWrite.good
@@ -1,1 +1,2 @@
-{head = 0, tail = 0}
+initAtomicsViaWrite.chpl:5: In initializer:
+initAtomicsViaWrite.chpl:6: error: Field used before it is initialized


### PR DESCRIPTION
Thanks to BHarsh's PR #8292, I believe this future can now be retired.
Though the .good file suggested that maybe this should "just work",
with more reflection, I don't think that's the case and believe that
if we want to initialize atomics in phase 1, we should do so by
adding support for initialize-time assignment of atomics by their
base type (if not normal assignments as well).  The .future here
suggests that even when filing it, I wasn't convinced it should work
(just shouldn't internal error), so in any case I think the original
problem is now resolved.