### PR TITLE
Avoid --baseline "leaks" for parallel/forall/vass/memleaks*

### DIFF
--- a/test/parallel/forall/vass/memleaks1-minimal.chpl
+++ b/test/parallel/forall/vass/memleaks1-minimal.chpl
@@ -7,8 +7,10 @@ proc main() {
   var MY_VAR = 1;
   const m1 = memoryUsed();
 
-  forall idx in MYITER() do
-    useMe(MY_VAR);
+  {
+    forall idx in MYITER() do
+      useMe(MY_VAR);
+  }
 
   const m2 = memoryUsed();
   writeln("leaked: ", m2-m1);

--- a/test/parallel/forall/vass/memleaks2-BlockDist.chpl
+++ b/test/parallel/forall/vass/memleaks2-BlockDist.chpl
@@ -11,8 +11,10 @@ proc main() {
   var myvar = initval;
   const m1 = memoryUsed();
 
-  forall da in DARRAY do
-    da = myvar;
+  {
+    forall da in DARRAY do
+      da = myvar;
+  }
 
   const m2 = memoryUsed();
 


### PR DESCRIPTION
In #8287 I removed a "serial do" around the foralls, but rather confusingly
this seemed to result in a leak under --baseline. It turns out that we aren't
actually leaking, it's just that as of #6942 we put `freeIterator()` calls
inside a defer statement, so we were checking the memory used before
`freeIterator()` was called.

Just wrap the foralls in a new block to ensure `freeIterator()` is called
before we check the memory leaks. Note that this was only a problem under
--baseline. If the iterators are inlined the `freeIterator()` call is removed.