### PR TITLE
Update the comments of replace function in string file

### DIFF
--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -698,7 +698,7 @@ module String {
       :arg count: an optional integer specifying the number of replacements to
                   make, values less than zero will replace all occurrences
 
-      :returns: a copy of the string where `needle` replaces `replacement` up
+      :returns: a copy of the string where `replacement` replaces `needle` up
                 to `count` times
      */
     // TODO: not ideal - count and single allocation probably faster


### PR DESCRIPTION
The comments of **replace function** of the string should be updated:  _here a copy of the string where `needle` replaces `replacement` up_ this should be actually replaced with _a copy of the string where `replacement` replaces `needle` up ._ .

