### PR TITLE
Revert portion of #8293 relating to field access type

### DIFF
--- a/compiler/include/genret.h
+++ b/compiler/include/genret.h
@@ -99,12 +99,14 @@ public:
   llvm::Type *type; // set when generating a type only
   Type *surroundingStruct; // surrounding structure, if this is a field
   uint64_t fieldOffset; // byte offset of this field within struct
+  llvm::MDNode *fieldTbaaTypeDescriptor;
 #else
   // Keeping same layout for non-LLVM builds
   void* val;
   void* type;
   void* surroundingStruct;
   uint64_t fieldOffset;
+  void* fieldTbaaTypeDescriptor;
 #endif
 
   // Used to mark variables as const after they are stored
@@ -137,7 +139,7 @@ public:
                    // called type, since LLVM native integer types do not
                    // include signed-ness.
                    
-  GenRet() : c(), val(NULL), type(NULL), surroundingStruct(NULL), fieldOffset(0), canBeMarkedAsConstAfterStore(false), alreadyStored(false), chplType(NULL), isLVPtr(GEN_VAL), isUnsigned(false) { }
+  GenRet() : c(), val(NULL), type(NULL), surroundingStruct(NULL), fieldOffset(0), fieldTbaaTypeDescriptor(NULL), canBeMarkedAsConstAfterStore(false), alreadyStored(false), chplType(NULL), isLVPtr(GEN_VAL), isUnsigned(false) { }
   // Allow implicit conversion from AST elements.
   GenRet(BaseAST* ast) {
     *this = baseASTCodegen(ast);


### PR DESCRIPTION
Testing of #8293 was incomplete because I forgot that `start_test` unsets `CHPL_DEVELOPER`.  When a Chapel program is compiled with `CHPL_DEVELOPER` and `CHPL_LLVM_DEVELOPER` set and `--llvm` (outside of the test harness), the LLVM verifier fails due to invalid metadata.  Testing only succeeds because `start_test` turns off the verifier.

This change is an exact reversion of expr.cpp and genret.h from #8293 , which is the portion related to field access types.  The other files, related to the handling of superclasses, are not reverted.  In hindsight, I would have done better to split the two purposes into two separate PRs.