### PR TITLE
The gmake clock-skew-warning filters regex need another adjustment

### DIFF
--- a/util/test/checkChplInstall
+++ b/util/test/checkChplInstall
@@ -181,8 +181,8 @@ fi
 if [ -n "${TEST_COMP_OUT}" ]; then
     # apply "prediff"-like filter to remove gmake "clock skew detected" warnings, if any
     TEST_COMP_OUT=$( grep <<<"${TEST_COMP_OUT}" -v \
-        -e '^g*make: Warning: File .* has modification time .* in the future *$' \
-        -e '^g*make: warning:  Clock skew detected\.  Your build may be incomplete\. *$' )
+        -e '^g*make\(\[[0-9]*\]\)*: Warning: File .* has modification time .* in the future *$' \
+        -e '^g*make\(\[[0-9]*\]\)*: warning:  Clock skew detected\.  Your build may be incomplete\. *$' )
 fi
 
 if [ -n "${TEST_COMP_OUT}" ]; then

--- a/util/test/preexec-for-gmake-clock-skew-warning
+++ b/util/test/preexec-for-gmake-clock-skew-warning
@@ -25,7 +25,7 @@ temp=$outfile.temp
 
 if [ -s "$outfile" ]; then
     grep < $outfile > $temp -v \
-        -e '^g*make: Warning: File .* has modification time .* in the future *$' \
-        -e '^g*make: warning:  Clock skew detected\.  Your build may be incomplete\. *$'
+        -e '^g*make\(\[[0-9]*\]\)*: Warning: File .* has modification time .* in the future *$' \
+        -e '^g*make\(\[[0-9]*\]\)*: warning:  Clock skew detected\.  Your build may be incomplete\. *$'
     mv $temp $outfile
 fi


### PR DESCRIPTION
PR #8151 added filters to silently remove "clock skew detected" warning messages
from gmake (if any), because those messages (when they occur) caused false test
failures- both in Chapel's test harness, and in the shell script used to
implement "make check". PR #8273 changed the regex to a form that I thought
would cover all forms of the gmake warning message we could ever see, yet be
more compatible with older/different versions of grep. However, we now know
that change did NOT cover all forms of the warning message. If the message has
a make level number added (ie, "gmake[1]: Warning", not "gmake: Warning"), the
regex will miss.

This change changes the regex yet again. It tries to cover that
"gmake[1]: Warning" case, and still be portable.