### PR TITLE
remove non-init halts from Crypto module

### DIFF
--- a/modules/internal/ChapelError.chpl
+++ b/modules/internal/ChapelError.chpl
@@ -106,8 +106,7 @@ module ChapelError {
     }
 
     proc message() {
-      var msg_fmt = "illegal argument '%s': %s";
-      return msg_fmt.format(arg_name, arg_info);
+      return "illegal argument '" + arg_name + ': ' + arg_info;
     }
   }
 

--- a/modules/internal/ChapelError.chpl
+++ b/modules/internal/ChapelError.chpl
@@ -106,7 +106,7 @@ module ChapelError {
     }
 
     proc message() {
-      return "illegal argument '" + arg_name + ': ' + arg_info;
+      return "illegal argument '" + arg_name + "': " + arg_info;
     }
   }
 

--- a/modules/internal/ChapelError.chpl
+++ b/modules/internal/ChapelError.chpl
@@ -86,6 +86,23 @@ module ChapelError {
     }
   }
 
+  class IllegalArgumentError : Error {
+    var msg: string;
+
+    proc init() {
+      super.init();
+    }
+
+    proc init(_msg: string) {
+      this.msg = _msg;
+      super.init();
+    }
+
+    proc message() {
+      return msg;
+    }
+  }
+
   // Used by the runtime to accumulate errors. This type
   // supports adding errors concurrently but need not support
   // iterating over the errors concurrently. Errors

--- a/modules/internal/ChapelError.chpl
+++ b/modules/internal/ChapelError.chpl
@@ -87,19 +87,27 @@ module ChapelError {
   }
 
   class IllegalArgumentError : Error {
-    var msg: string;
+    var arg_name: string;
+    var arg_info: string;
 
     proc init() {
       super.init();
     }
 
-    proc init(_msg: string) {
-      this.msg = _msg;
+    proc init(_arg_name: string) {
+      this.arg_name = _arg_name;
+      super.init();
+    }
+
+    proc init(_arg_name: string, _arg_info: string) {
+      this.arg_name = _arg_name;
+      this.arg_info = _arg_info;
       super.init();
     }
 
     proc message() {
-      return msg;
+      var msg_fmt = "illegal argument '%s': %s";
+      return msg_fmt.format(arg_name, arg_info);
     }
   }
 

--- a/modules/packages/Crypto.chpl
+++ b/modules/packages/Crypto.chpl
@@ -81,6 +81,7 @@
 module Crypto {
 
   use C_OpenSSL;
+  use SysError;
 
   pragma "no doc"
   proc generateKeys(bits: int) {
@@ -784,11 +785,11 @@ proc bfEncrypt(plaintext: CryptoBuffer, key: CryptoBuffer, IV: CryptoBuffer, cip
       var ivLen = IV.getBuffSize();
       var keyLen = key.getBuffSize();
       if (ivLen != 8) {
-        throw new IllegalArgumentError("Blowfish cipher expects an IV of size 8 bytes.");
+        throw new IllegalArgumentError("IV", "Blowfish cipher expects a size of 8 bytes.");
       }
 
       if (keyLen < 10) {
-        throw new IllegalArgumentError("Blowfish cipher expects a key of size greater than 10 bytes.");
+        throw new IllegalArgumentError("key", "Blowfish cipher expects a size greater than 10 bytes.");
       }
       var encryptedPlaintext = bfEncrypt(plaintext, key, IV, this.cipher);
       var encryptedPlaintextBuff = new CryptoBuffer(encryptedPlaintext);
@@ -829,7 +830,7 @@ proc bfEncrypt(plaintext: CryptoBuffer, key: CryptoBuffer, IV: CryptoBuffer, cip
     var retErrCode: c_int;
     retErrCode = RAND_bytes(c_ptrTo(buff): c_ptr(c_uchar), buffLen: c_int);
     if (!retErrCode) {
-      throw new IllegalArgumentError("The random buffer generator has failed to initialize a buffer.");
+      throw SystemError.fromSyserr(retErrCode);
     }
     return buff;
   }
@@ -862,7 +863,7 @@ proc bfEncrypt(plaintext: CryptoBuffer, key: CryptoBuffer, IV: CryptoBuffer, cip
     */
     proc createRandomBuffer(buffLen: int): CryptoBuffer throws {
       if (buffLen < 1) {
-        throw new IllegalArgumentError("Invalid random buffer length specified.");
+        throw new IllegalArgumentError("buffLen", "Invalid random buffer length specified.");
       }
       var randomizedBuff = try createRandomBuffer(buffLen);
       var randomizedCryptoBuff = new CryptoBuffer(randomizedBuff);
@@ -1026,7 +1027,7 @@ proc bfEncrypt(plaintext: CryptoBuffer, key: CryptoBuffer, IV: CryptoBuffer, cip
       }
 
       if (!openErrCode) {
-        throw new IllegalArgumentError("The RSAKey is an invalid match");
+        throw new IllegalArgumentError("key", "The RSAKey is an invalid match.");
       }
 
       var plaintextLen = ciphertext.size;

--- a/modules/packages/Crypto.chpl
+++ b/modules/packages/Crypto.chpl
@@ -864,7 +864,7 @@ proc bfEncrypt(plaintext: CryptoBuffer, key: CryptoBuffer, IV: CryptoBuffer, cip
       if (buffLen < 1) {
         throw new IllegalArgumentError("Invalid random buffer length specified.");
       }
-      var randomizedBuff = createRandomBuffer(buffLen);
+      var randomizedBuff = try createRandomBuffer(buffLen);
       var randomizedCryptoBuff = new CryptoBuffer(randomizedBuff);
       return randomizedCryptoBuff;
     }
@@ -1005,7 +1005,7 @@ proc bfEncrypt(plaintext: CryptoBuffer, key: CryptoBuffer, IV: CryptoBuffer, cip
     }
 
     pragma "no doc"
-    proc rsaDecrypt(key: RSAKey, iv: [] uint(8), ciphertext: [] uint(8), encKeys: [] CryptoBuffer) {
+    proc rsaDecrypt(key: RSAKey, iv: [] uint(8), ciphertext: [] uint(8), encKeys: [] CryptoBuffer) throws {
 
       var ctx: EVP_CIPHER_CTX;
       EVP_CIPHER_CTX_init(ctx);
@@ -1026,7 +1026,7 @@ proc bfEncrypt(plaintext: CryptoBuffer, key: CryptoBuffer, IV: CryptoBuffer, cip
       }
 
       if (!openErrCode) {
-        halt("The RSAKey is an invalid match");
+        throw new IllegalArgumentError("The RSAKey is an invalid match");
       }
 
       var plaintextLen = ciphertext.size;
@@ -1124,12 +1124,12 @@ proc bfEncrypt(plaintext: CryptoBuffer, key: CryptoBuffer, IV: CryptoBuffer, cip
        :rtype: `CryptoBuffer`
 
     */
-    proc decrypt(envp: Envelope, key: RSAKey): CryptoBuffer {
+    proc decrypt(envp: Envelope, key: RSAKey): CryptoBuffer throws {
       var iv = envp.getIV().getBuffData();
       var ciphertext = envp.getEncMessage().getBuffData();
       var encKeys = envp.getEncKeys();
 
-      var plaintext = rsaDecrypt(key, iv, ciphertext, encKeys);
+      var plaintext = try rsaDecrypt(key, iv, ciphertext, encKeys);
       var plaintextBuff = new CryptoBuffer(plaintext);
       return plaintextBuff;
     }

--- a/modules/packages/Crypto.chpl
+++ b/modules/packages/Crypto.chpl
@@ -780,15 +780,15 @@ proc bfEncrypt(plaintext: CryptoBuffer, key: CryptoBuffer, IV: CryptoBuffer, cip
        :rtype: `CryptoBuffer`
 
     */
-    proc encrypt(plaintext: CryptoBuffer, key: CryptoBuffer, IV: CryptoBuffer): CryptoBuffer {
+    proc encrypt(plaintext: CryptoBuffer, key: CryptoBuffer, IV: CryptoBuffer): CryptoBuffer throws {
       var ivLen = IV.getBuffSize();
       var keyLen = key.getBuffSize();
       if (ivLen != 8) {
-        halt("Blowfish cipher expects an IV of size 8 bytes.");
+        throw new IllegalArgumentError("Blowfish cipher expects an IV of size 8 bytes.");
       }
 
       if (keyLen < 10) {
-        halt("Blowfish cipher expects a key of size greater than 10 bytes.");
+        throw new IllegalArgumentError("Blowfish cipher expects a key of size greater than 10 bytes.");
       }
       var encryptedPlaintext = bfEncrypt(plaintext, key, IV, this.cipher);
       var encryptedPlaintextBuff = new CryptoBuffer(encryptedPlaintext);
@@ -824,12 +824,12 @@ proc bfEncrypt(plaintext: CryptoBuffer, key: CryptoBuffer, IV: CryptoBuffer, cip
   }
 
   pragma "no doc"
-  proc createRandomBuffer(buffLen: int) {
+  proc createRandomBuffer(buffLen: int) throws {
     var buff: [0..#buffLen] uint(8);
     var retErrCode: c_int;
     retErrCode = RAND_bytes(c_ptrTo(buff): c_ptr(c_uchar), buffLen: c_int);
     if (!retErrCode) {
-      halt("The random buffer generator has failed to initialize a buffer.");
+      throw new IllegalArgumentError("The random buffer generator has failed to initialize a buffer.");
     }
     return buff;
   }
@@ -860,9 +860,9 @@ proc bfEncrypt(plaintext: CryptoBuffer, key: CryptoBuffer, IV: CryptoBuffer, cip
        :rtype: `CryptoBuffer`
 
     */
-    proc createRandomBuffer(buffLen: int): CryptoBuffer {
+    proc createRandomBuffer(buffLen: int): CryptoBuffer throws {
       if (buffLen < 1) {
-        halt("Invalid random buffer length specified.");
+        throw new IllegalArgumentError("Invalid random buffer length specified.");
       }
       var randomizedBuff = createRandomBuffer(buffLen);
       var randomizedCryptoBuff = new CryptoBuffer(randomizedBuff);


### PR DESCRIPTION
Discussion after the merge of #8244 prompted a closer examination of the Crypto module. While it was not possible to remove halts from `init()` due to the present inability to throw from initializers, this PR locates all the other halts in the module and has them throw a new standard error type, `IllegalArgumentError`.

- [x] passes linux64+flat testing, with futures