### PR TITLE
Improve view.cpp debugging facilities

### DIFF
--- a/compiler/AST/ForallStmt.cpp
+++ b/compiler/AST/ForallStmt.cpp
@@ -173,11 +173,6 @@ Expr* ForallStmt::getNextExpr(Expr* expr) {
 // helpers
 /////////////////////////////////////////////////////////////////////////////
 
-// Is 'expr' an iterable-expression for 'this' ?
-bool ForallStmt::isIteratedExpression(Expr* expr) {
-  return expr->list && expr->list == &fIterExprs;
-}
-
 // If 'var' is listed in this's with-clause with a reduce intent,
 // return its position in the with-clause, otherwise return -1.
 // Used in preFold for PRIM_REDUCE_ASSIGN, set up in normalize.
@@ -200,6 +195,23 @@ ForallStmt* enclosingForallStmt(Expr* expr) {
     if (ForallStmt* fs = toForallStmt(curr))
       return fs;
   return NULL;
+}
+
+// Is 'expr' an iterable-expression for some ForallStmt?
+bool isForallIterExpr(Expr* expr) {
+  if (expr->list != NULL)
+    if (ForallStmt* pfs = toForallStmt(expr->parentExpr))
+      if (expr->list == &pfs->iteratedExpressions())
+        return true;
+  return false;
+}
+
+// Is 'expr' the fs->loopBody() for some 'fs' ?
+bool isForallLoopBody(Expr* expr) {
+  if (ForallStmt* pfs = toForallStmt(expr->parentExpr))
+    if (expr == pfs->loopBody())
+      return true;
+  return false;
 }
 
 // valid after addParIdxVarsAndRestruct()

--- a/compiler/AST/view.cpp
+++ b/compiler/AST/view.cpp
@@ -28,7 +28,6 @@
 #include "CForLoop.h"
 #include "CatchStmt.h"
 #include "DeferStmt.h"
-#include "expr.h"
 #include "ForallStmt.h"
 #include "ForLoop.h"
 #include "iterator.h"
@@ -37,7 +36,6 @@
 #include "stlUtil.h"
 #include "stmt.h"
 #include "stringutil.h"
-#include "symbol.h"
 #include "TryStmt.h"
 #include "virtualDispatch.h"
 #include "WhileStmt.h"
@@ -106,6 +104,9 @@ forall_explanation_start(BaseAST* ast, BaseAST* parentAst) {
     if (ast == fe->cond)
       return "} if( ";
   }
+  if (isDeferStmt(ast)) {
+    return "defer\n";
+  }
   return NULL;
 }
 
@@ -125,6 +126,17 @@ list_line(Expr* expr, BaseAST* parentAst) {
   return false;
 }
 
+static void print_indent(int indent) {
+  for (int i = 0; i < indent; i++) printf(" ");
+}
+static void print_on_its_own_line(int indent, const char* msg,
+                                  bool newline = true) {
+  if (newline) printf("\n");
+  printf("%6c", ' ');
+  print_indent(indent);
+  printf("%s", msg);
+}
+
 static void
 list_ast(BaseAST* ast, BaseAST* parentAst = NULL, int indent = 0) {
   bool do_list_line = false;
@@ -133,21 +145,17 @@ list_ast(BaseAST* ast, BaseAST* parentAst = NULL, int indent = 0) {
   if (Expr* expr = toExpr(ast)) {
     if (ForallStmt* pfs = toForallStmt(parentAst)) {
       if (expr == pfs->loopBody()) {
-        printf("\n%6c", ' ');
-        for (int i = 0; i < indent; i++) printf(" ");
         if (pfs->numShadowVars() == 0)
-          printf("with() ");
-        printf("do\n");
-        indent -= 2;
-      } else if (expr->list) {
+          print_on_its_own_line(indent, "with()");
+        print_on_its_own_line(indent, "do\n", false);
         printf("\n");
+        indent -= 2;
       }
     }
     do_list_line = !parentAst || list_line(expr, parentAst);
     if (do_list_line) {
       printf("%-7d ", expr->id);
-      for (int i = 0; i < indent; i++)
-        printf(" ");
+      print_indent(indent);
     }
     if (const char* expl = forall_explanation_start(ast, parentAst))
       printf("%s", expl);
@@ -168,7 +176,7 @@ list_ast(BaseAST* ast, BaseAST* parentAst = NULL, int indent = 0) {
     } else if (toCondStmt(ast)) {
       printf("if ");
     } else if (toForallStmt(ast)) {
-      printf("forall");
+      printf("forall\n");
     } else if (CallExpr* e = toCallExpr(expr)) {
       if (e->isPrimitive(PRIM_BLOCK_C_FOR_LOOP))
           is_C_loop = true;
@@ -224,12 +232,17 @@ list_ast(BaseAST* ast, BaseAST* parentAst = NULL, int indent = 0) {
       printf("%-7d ", expr->id);
       if (*block_explain)
         indent -= 2;
-      for (int i = 0; i < indent; i++)
-        printf(" ");
+      print_indent(indent);
       if ((parent_C_loop && parent_C_loop->get(3) == expr) || *block_explain)
         printf("} ");
+      else if (isDeferStmt(parentAst))
+        printf("}"); // newline is coming
       else
         printf("}\n");
+      if (isForallLoopBody(expr)) {
+        print_indent(indent);
+        printf("        end forall %d", parentAst->id);
+      }
     } else if (ForallExpr* e = toForallExpr(expr)) {
       if (e->cond) printf(") ");
       else         printf("} ");
@@ -265,18 +278,15 @@ list_ast(BaseAST* ast, BaseAST* parentAst = NULL, int indent = 0) {
       if (cond->condExpr == expr)
         printf("\n");
     } else if (ForallStmt* pfs = toForallStmt(parentAst)) {
-      if (expr == pfs->loopBody()) {
-        indent += 2;
-      } else if (expr == pfs->inductionVariables().tail) {
-        printf("\n%6c", ' ');
-        for (int i = 0; i < indent; i++) printf(" ");
-        printf("in%s", pfs->zippered() ? " zip" : "");
+      if (AList* list = expr->list)
+        if (list->parent == pfs)
+          if (expr != list->tail)
+            printf("\n");
+      if (expr == pfs->inductionVariables().tail) {
+        print_on_its_own_line(indent, pfs->zippered() ? "in zip\n" : "in\n");
       } else if (expr == pfs->iteratedExpressions().tail &&
-                 pfs->numShadowVars() > 0)
-      {
-        printf("\n      ");
-        for (int i = 0; i < indent; i++) printf(" ");
-        printf("with (...)\n");
+                 pfs->numShadowVars() > 0) {
+        print_on_its_own_line(indent, "with\n");
       }
     } else if (!toCondStmt(expr) && do_list_line) {
       DefExpr* def = toDefExpr(expr);
@@ -337,6 +347,25 @@ BaseAST* aid(int id) {
   return aidWithError(id, "aid");
 }
 
+BaseAST* aid(BaseAST* ast) {
+  return ast;
+}
+
+Expr* aidExpr(int id) {
+  if (BaseAST* ast = aidWithError(id, "aidExpr"))
+    return aidExpr(ast);
+  else
+    return NULL;
+}
+
+Expr* aidExpr(BaseAST* ast) {
+  if (Expr* expr = toExpr(ast))
+    return expr;
+  if (ast != NULL)
+    printf("<aidExpr: node %d is a %s, not an Expr>\n",
+           ast->id, ast->astTagAsString());
+  return NULL;
+}
 
 void viewFlags(int id) {
   if (BaseAST* ast = aidWithError(id, "viewFlags"))
@@ -714,7 +743,7 @@ void debugSummary(BaseAST* ast) {
 }
 
 // find the Parent Symbol
-BaseAST* debugParentSym(int id) {
+Symbol* debugParentSym(int id) {
   if (BaseAST* ast = aid09(id))
     return debugParentSym(ast);
   else {
@@ -722,7 +751,7 @@ BaseAST* debugParentSym(int id) {
     return NULL;
   }
 }
-BaseAST* debugParentSym(BaseAST* ast) {
+Symbol* debugParentSym(BaseAST* ast) {
   if (!ast)
     return NULL;
   else if (Expr* expr = toExpr(ast))
@@ -731,6 +760,28 @@ BaseAST* debugParentSym(BaseAST* ast) {
     return sym->defPoint->parentSymbol;
   else {
     printf("<debugParentSym: node %d is neither Expr nor Symbol>\n", ast->id);
+    return NULL;
+  }
+}
+
+// find the Parent Expression
+Expr* debugParentExpr(int id) {
+  if (BaseAST* ast = aid09(id))
+    return debugParentExpr(ast);
+  else {
+    printf("%s\n", aidNotFoundError("debugParentExpr", id));
+    return NULL;
+  }
+}
+Expr* debugParentExpr(BaseAST* ast) {
+  if (!ast)
+    return NULL;
+  else if (Expr* expr = toExpr(ast))
+    return expr->parentExpr;
+  else if (Symbol* sym = toSymbol(ast))
+    return sym->defPoint->parentExpr;
+  else {
+    printf("<debugParentExpr: node %d is neither Expr nor Symbol>\n", ast->id);
     return NULL;
   }
 }
@@ -812,6 +863,21 @@ void vec_view(Vec<FnSymbol*,VEC_INTEGRAL_SIZE>& v)
   }
 }
 
+void vec_view(std::vector<Symbol*>* vec) {
+  vec_view(*vec);
+}
+
+void vec_view(std::vector<Symbol*>& vec) {
+  printf("vector<Symbol> %ld elm(s)\n", vec.size());
+  for (size_t i = 0; i < vec.size(); i++) {
+    Symbol* elm = vec[i];
+    if (elm)
+      printf("%3ld %8d  %s\n", i, elm->id, elm->name);
+    else
+      printf("%3ld <null>\n", i);
+  }
+}
+
 //
 // fnsWithName: print all FnSymbols with the given name
 //
@@ -880,6 +946,7 @@ void whocalls(int id) {
 
   int forAll = 0, forMatch = 0, forNonTreeMatch = 0;
   forv_Vec(CallExpr, call, gCallExprs) {
+    // todo: does this really happen?
     if (call->isPrimitive(PRIM_BLOCK_FOR_LOOP) && call->numActuals() >= 2) {
       forAll++;
       // check each step, just in case

--- a/compiler/include/ForallStmt.h
+++ b/compiler/include/ForallStmt.h
@@ -62,7 +62,6 @@ public:
   // helpers
   Expr* firstIteratedExpr()        const;
   int   numIteratedExprs()         const;
-  bool  isIteratedExpression(Expr* expr);
   int   reduceIntentIdx(Symbol* var);
   int   numShadowVars()            const;
   ShadowVarSymbol* getShadowVar(int index) const;
@@ -122,6 +121,8 @@ inline ShadowVarSymbol* ForallStmt::getShadowVar(int index) const
       if (ShadowVarSymbol* SV = toShadowVarSymbol(SVD->sym))
 
 // helpers
+bool isForallIterExpr(Expr* expr);
+bool isForallLoopBody(Expr* expr);
 ForallStmt* enclosingForallStmt(Expr* expr);
 
 // used for lowering ForallStmt and forall intents

--- a/compiler/include/view.h
+++ b/compiler/include/view.h
@@ -20,11 +20,17 @@
 #ifndef _VIEW_H_
 #define _VIEW_H_
 
-#include "baseAST.h"
+#include "expr.h"
 #include "vec.h"
+#include <vector>
 
-BaseAST*    aid(int id);
-BaseAST*    aid09(int id);
+BaseAST* aid(int id);
+BaseAST* aid09(int id);
+Expr*    aidExpr(int id);
+
+// counterparts of the above for convenient shortcuts
+BaseAST* aid(BaseAST* ast);
+Expr*    aidExpr(BaseAST* ast);
 
 void        list_view_noline(BaseAST* ast);
 void        nprint_view(BaseAST* ast);
@@ -69,6 +75,9 @@ void        vec_view(Vec<Symbol*,   VEC_INTEGRAL_SIZE>* v);
 void        vec_view(Vec<Symbol*,   VEC_INTEGRAL_SIZE>& v);
 void        vec_view(Vec<FnSymbol*, VEC_INTEGRAL_SIZE>* v);
 void        vec_view(Vec<FnSymbol*, VEC_INTEGRAL_SIZE>& v);
+void        vec_view(std::vector<Symbol*>* vec);
+void        vec_view(std::vector<Symbol*>& vec);
+
 
 void        fnsWithName(const char* name);
 void        fnsWithName(const char* name, Vec<FnSymbol*>& fnVec);
@@ -96,7 +105,9 @@ int debugID(int id);
 int debugID(BaseAST* ast);
 void debugSummary(int id);
 void debugSummary(BaseAST* ast);
-BaseAST* debugParentSym(int id);
-BaseAST* debugParentSym(BaseAST* ast);
+Symbol* debugParentSym(int id);
+Symbol* debugParentSym(BaseAST* ast);
+Expr* debugParentExpr(int id);
+Expr* debugParentExpr(BaseAST* ast);
 
 #endif

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -6539,15 +6539,10 @@ static bool isParamResolved(FnSymbol* fn, Expr* expr) {
 }
 
 static ForallStmt* toForallForIteratedExpr(SymExpr* expr) {
-  ForallStmt* retval = NULL;
-
-  if (ForallStmt* pfs = toForallStmt(expr->parentExpr)) {
-    if (pfs->isIteratedExpression(expr) == true) {
-      retval = pfs;
-    }
-  }
-
-  return retval;
+  if (isForallIterExpr(expr))
+    return toForallStmt(expr->parentExpr);
+  else
+    return NULL;
 }
 
 static Expr* resolveExprPhase2(Expr* origExpr, FnSymbol* fn, Expr* expr) {


### PR DESCRIPTION
* Improved list_view() for ForallStmt and DeferStmt.

* Added a couple of variants on aid(), for convenience while debugging.

* Added debugParentExpr to return an Expr*.
  Changed debugParentSym to return a Symbol*.

* Added vec_view on std::vector<Symbol*>,
  following its counterpart on 'Vec'.

* While there, added and used ForallStmt::isForallIterExpr(),isForallLoopBody(),
which replaced ForallStmt::isIteratedExpression().