### PR TITLE
Minor cleanup of uses of breakOnResolveID:

### DIFF
--- a/compiler/AST/foralls.cpp
+++ b/compiler/AST/foralls.cpp
@@ -670,8 +670,7 @@ static void resolveParallelIteratorAndIdxVar(ForallStmt* pfs,
                                         origIterator, alreadyResolved);
   VarSymbol* idxVar = parIdxVar(pfs);
 
-  if (idxVar->id == breakOnResolveID)
-    gdbShouldBreakHere();
+  if (idxVar->id == breakOnResolveID) gdbShouldBreakHere();
   idxVar->type = iType.type();
   idxVar->qual = iType.getQual();
 }

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -2040,6 +2040,8 @@ FnSymbol* resolveNormalCall(CallExpr* call, bool checkOnly) {
   FnSymbol* retval = NULL;
 
   if (call->id == breakOnResolveID) {
+    printf("breaking on resolve call %d:\n", call->id);
+    print_view(call);
     gdbShouldBreakHere();
   }
 

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -2040,8 +2040,6 @@ FnSymbol* resolveNormalCall(CallExpr* call, bool checkOnly) {
   FnSymbol* retval = NULL;
 
   if (call->id == breakOnResolveID) {
-    printf("breaking on resolve call:\n");
-    print_view(call);
     gdbShouldBreakHere();
   }
 

--- a/compiler/resolution/initializerResolution.cpp
+++ b/compiler/resolution/initializerResolution.cpp
@@ -111,6 +111,8 @@ static void resolveInitCall(CallExpr* call) {
   CallInfo info;
 
   if (call->id == breakOnResolveID) {
+    printf("breaking on resolve call %d:\n", call->id);
+    print_view(call);
     gdbShouldBreakHere();
   }
 

--- a/compiler/resolution/initializerResolution.cpp
+++ b/compiler/resolution/initializerResolution.cpp
@@ -111,8 +111,6 @@ static void resolveInitCall(CallExpr* call) {
   CallInfo info;
 
   if (call->id == breakOnResolveID) {
-    printf("breaking on resolve call:\n");
-    print_view(call);
     gdbShouldBreakHere();
   }
 
@@ -268,8 +266,8 @@ static void resolveInitializerMatch(FnSymbol* fn) {
     AggregateType* at = toAggregateType(fn->_this->type);
 
     if (fn->id == breakOnResolveID) {
-      printf("breaking on resolve fn:\n");
-      print_view(fn);
+      printf("breaking on resolve fn %s[%d] (%d args)\n",
+             fn->name, fn->id, fn->numFormals());
       gdbShouldBreakHere();
     }
 

--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -305,8 +305,8 @@ static void resolveSpecifiedReturnType(FnSymbol* fn) {
 void resolveFunction(FnSymbol* fn) {
   if (fn->isResolved() == false) {
     if (fn->id == breakOnResolveID) {
-      printf("breaking on resolve fn:\n");
-      print_view(fn);
+      printf("breaking on resolve fn %s[%d] (%d args)\n",
+             fn->name, fn->id, fn->numFormals());
       gdbShouldBreakHere();
     }
 


### PR DESCRIPTION
* Do not print_view the FnSymbol for which the breakpoint hits.
  These printouts can be too lengthy.
  Instead, print a couple of pieces of information about the FnSymbol.

* Print CallExpr id before print_view on it upon breakOnResolveID.

* Uniformize code formatting in foralls.cpp w.r.t. breakOnResolveID.