### PR TITLE
Remove getFirstChild()

### DIFF
--- a/compiler/AST/CallExpr.cpp
+++ b/compiler/AST/CallExpr.cpp
@@ -163,19 +163,6 @@ bool CallExpr::isPrimitive(const char* primitiveName) const {
   return primitive && !strcmp(primitive->name, primitiveName);
 }
 
-Expr* CallExpr::getFirstChild() {
-  Expr* retval = NULL;
-
-  if (baseExpr != NULL) {
-    retval = baseExpr;
-
-  } else if (argList.head != NULL) {
-    retval = argList.head;
-  }
-
-  return retval;
-}
-
 Expr* CallExpr::getFirstExpr() {
   Expr* retval = NULL;
 

--- a/compiler/AST/CatchStmt.cpp
+++ b/compiler/AST/CatchStmt.cpp
@@ -74,10 +74,6 @@ void CatchStmt::replaceChild(Expr* old_ast, Expr* new_ast) {
   }
 }
 
-Expr* CatchStmt::getFirstChild() {
-  return _body;
-}
-
 Expr* CatchStmt::getFirstExpr() {
   if (_body) {
     return _body->getFirstExpr();

--- a/compiler/AST/DeferStmt.cpp
+++ b/compiler/AST/DeferStmt.cpp
@@ -75,10 +75,6 @@ void DeferStmt::replaceChild(Expr* oldAst, Expr* newAst) {
   }
 }
 
-Expr* DeferStmt::getFirstChild() {
-  return _body;
-}
-
 Expr* DeferStmt::getFirstExpr() {
   if (_body) {
     return _body->getFirstExpr();

--- a/compiler/AST/ForallStmt.cpp
+++ b/compiler/AST/ForallStmt.cpp
@@ -137,10 +137,6 @@ GenRet ForallStmt::codegen() {
   return ret;
 }
 
-Expr* ForallStmt::getFirstChild() {
-  return fIterVars.head;
-}
-
 Expr* ForallStmt::getFirstExpr() {
   if (Expr* iv = fIterVars.head->getFirstExpr())
     return iv;

--- a/compiler/AST/TryStmt.cpp
+++ b/compiler/AST/TryStmt.cpp
@@ -97,10 +97,6 @@ void TryStmt::replaceChild(Expr* old_ast, Expr* new_ast) {
   // catches are handled automatically (AList)
 }
 
-Expr* TryStmt::getFirstChild() {
-  return _body;
-}
-
 Expr* TryStmt::getFirstExpr() {
   if (_body) {
     return _body->getFirstExpr();

--- a/compiler/AST/UseStmt.cpp
+++ b/compiler/AST/UseStmt.cpp
@@ -104,10 +104,6 @@ Expr* UseStmt::getFirstExpr() {
   return this;
 }
 
-Expr* UseStmt::getFirstChild() {
-  return NULL;
-}
-
 void UseStmt::replaceChild(Expr* oldAst, Expr* newAst) {
   if (oldAst == src) {
     src = newAst;

--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -524,10 +524,6 @@ void SymExpr::replaceChild(Expr* old_ast, Expr* new_ast) {
   INT_FATAL(this, "Unexpected case in SymExpr::replaceChild");
 }
 
-Expr* SymExpr::getFirstChild() {
-  return NULL;
-}
-
 Expr* SymExpr::getFirstExpr() {
   return this;
 }
@@ -645,10 +641,6 @@ UnresolvedSymExpr::replaceChild(Expr* old_ast, Expr* new_ast) {
 }
 
 
-Expr* UnresolvedSymExpr::getFirstChild() {
-  return NULL;
-}
-
 Expr* UnresolvedSymExpr::getFirstExpr() {
   return this;
 }
@@ -718,10 +710,6 @@ DefExpr::DefExpr(Symbol* initSym, BaseAST* initInit, BaseAST* initExprType) :
     INT_FATAL(this, "DefExpr of ArgSymbol cannot have either exprType or init");
 
   gDefExprs.add(this);
-}
-
-Expr* DefExpr::getFirstChild() {
-  return NULL;
 }
 
 Expr* DefExpr::getFirstExpr() {
@@ -882,10 +870,6 @@ void ContextCallExpr::prettyPrint(std::ostream* o) {
   *o << " )";
 }
 
-Expr* ContextCallExpr::getFirstChild() {
-  return options.head;
-}
-
 Expr* ContextCallExpr::getFirstExpr() {
   return options.head->getFirstExpr();
 }
@@ -1042,11 +1026,6 @@ void ForallExpr::accept(AstVisitor* visitor) {
   INT_FATAL(this, "ForallExpr::accept() is not implemented");
 }
 
-Expr* ForallExpr::getFirstChild() {
-  INT_FATAL(this, "ForallExpr::getFirstChild() is not implemented");
-  return NULL;
-}
-
 Expr* ForallExpr::getFirstExpr() {
   INT_FATAL(this, "ForallExpr::getFirstExpr() is not implemented");
   return NULL;
@@ -1065,10 +1044,6 @@ NamedExpr::NamedExpr(const char* init_name, Expr* init_actual) :
   gNamedExprs.add(this);
 }
 
-
-Expr* NamedExpr::getFirstChild() {
-  return (actual != NULL) ? actual : NULL ;
-}
 
 Expr* NamedExpr::getFirstExpr() {
   return (actual != NULL) ? actual->getFirstExpr() : this;

--- a/compiler/AST/stmt.cpp
+++ b/compiler/AST/stmt.cpp
@@ -292,19 +292,6 @@ void BlockStmt::flattenAndRemove() {
 }
 
 Expr*
-BlockStmt::getFirstChild() {
-  Expr* retval = NULL;
-
-  if (blockInfo)
-    retval = blockInfo;
-
-  else if (body.head)
-    retval = body.head;
-
-  return retval;
-}
-
-Expr*
 BlockStmt::getFirstExpr() {
   Expr* retval = 0;
 
@@ -743,10 +730,6 @@ void CondStmt::accept(AstVisitor* visitor) {
   }
 }
 
-Expr* CondStmt::getFirstChild() {
-  return (condExpr != 0) ? condExpr : NULL ;
-}
-
 Expr* CondStmt::getFirstExpr() {
   return (condExpr != 0) ? condExpr->getFirstExpr() : this;
 }
@@ -935,10 +918,6 @@ void GotoStmt::accept(AstVisitor* visitor) {
   }
 }
 
-Expr* GotoStmt::getFirstChild() {
-  return (label != 0) ? label : NULL;
-}
-
 Expr* GotoStmt::getFirstExpr() {
   return (label != 0) ? label->getFirstExpr() : this;
 }
@@ -999,10 +978,6 @@ ExternBlockStmt* ExternBlockStmt::copyInner(SymbolMap* map) {
 
 void ExternBlockStmt::accept(AstVisitor* visitor) {
   visitor->visitEblockStmt(this);
-}
-
-Expr* ExternBlockStmt::getFirstChild() {
-  return NULL;
 }
 
 Expr* ExternBlockStmt::getFirstExpr() {
@@ -1108,10 +1083,6 @@ void ForwardingStmt::accept(AstVisitor* visitor) {
 
     visitor->exitForwardingStmt(this);
   }
-}
-
-Expr* ForwardingStmt::getFirstChild() {
-  return toFnDef;
 }
 
 Expr* ForwardingStmt::getFirstExpr() {

--- a/compiler/include/CallExpr.h
+++ b/compiler/include/CallExpr.h
@@ -77,14 +77,11 @@ public:
 
   virtual void    accept(AstVisitor* visitor);
 
-  virtual void    replaceChild(Expr* old_ast, Expr* new_ast);
-
   virtual GenRet  codegen();
   virtual void    prettyPrint(std::ostream* o);
   virtual QualifiedType qualType();
 
-  virtual Expr*   getFirstChild();
-
+  virtual void    replaceChild(Expr* old_ast, Expr* new_ast);
   virtual Expr*   getFirstExpr();
   virtual Expr*   getNextExpr(Expr* expr);
 

--- a/compiler/include/CatchStmt.h
+++ b/compiler/include/CatchStmt.h
@@ -57,7 +57,6 @@ public:
 
   void                accept(AstVisitor* visitor);
   void                replaceChild(Expr* old_ast, Expr* new_ast);
-  Expr*               getFirstChild();
   Expr*               getFirstExpr();
   void                verify();
   GenRet              codegen();

--- a/compiler/include/DeferStmt.h
+++ b/compiler/include/DeferStmt.h
@@ -39,7 +39,6 @@ public:
 
   void                accept(AstVisitor* visitor);
   void                replaceChild(Expr* old_ast, Expr* new_ast);
-  Expr*               getFirstChild();
   Expr*               getFirstExpr();
   Expr*               getNextExpr(Expr* expr);
   void                verify();

--- a/compiler/include/ForallStmt.h
+++ b/compiler/include/ForallStmt.h
@@ -44,12 +44,11 @@ public:
 
   DECLARE_COPY(ForallStmt);
 
-  virtual void        replaceChild(Expr* oldAst, Expr* newAst);
   virtual void        verify();
   virtual void        accept(AstVisitor* visitor);
   virtual GenRet      codegen();
 
-  virtual Expr*       getFirstChild();
+  virtual void        replaceChild(Expr* oldAst, Expr* newAst);
   virtual Expr*       getFirstExpr();
   virtual Expr*       getNextExpr(Expr* expr);
 

--- a/compiler/include/TryStmt.h
+++ b/compiler/include/TryStmt.h
@@ -39,7 +39,6 @@ public:
 
   void                accept(AstVisitor* visitor);
   void                replaceChild(Expr* old_ast, Expr* new_ast);
-  Expr*               getFirstChild();
   Expr*               getFirstExpr();
   Expr*               getNextExpr(Expr* expr);
   void                verify();

--- a/compiler/include/UseStmt.h
+++ b/compiler/include/UseStmt.h
@@ -37,8 +37,6 @@ public:
 
   virtual Expr*   getFirstExpr();
 
-  virtual Expr*   getFirstChild();
-
   virtual void    replaceChild(Expr* oldAst, Expr* newAst);
 
   virtual void    accept(AstVisitor* visitor);

--- a/compiler/include/expr.h
+++ b/compiler/include/expr.h
@@ -48,8 +48,6 @@ public:
   virtual Expr*   copy(SymbolMap* map = NULL, bool internal = false)   = 0;
   virtual void    replaceChild(Expr* old_ast, Expr* new_ast)           = 0;
 
-  virtual Expr*   getFirstChild()                                      = 0;
-
   virtual Expr*   getFirstExpr()                                       = 0;
   virtual Expr*   getNextExpr(Expr* expr);
 
@@ -115,8 +113,6 @@ public:
 
   virtual GenRet  codegen();
 
-  virtual Expr*   getFirstChild();
-
   virtual Expr*   getFirstExpr();
 
   const char*     name()                               const;
@@ -152,8 +148,6 @@ class SymExpr : public Expr {
   virtual GenRet  codegen();
   virtual void    prettyPrint(std::ostream* o);
 
-  virtual Expr*   getFirstChild();
-
   virtual Expr*   getFirstExpr();
 
   Symbol* symbol() {
@@ -178,8 +172,6 @@ class UnresolvedSymExpr : public Expr {
   virtual QualifiedType qualType();
   virtual GenRet  codegen();
   virtual void    prettyPrint(std::ostream *o);
-
-  virtual Expr*   getFirstChild();
 
   virtual Expr*   getFirstExpr();
 };
@@ -228,7 +220,6 @@ public:
   virtual GenRet         codegen();
   virtual void           prettyPrint(std::ostream* o);
 
-  virtual Expr*          getFirstChild();
   virtual Expr*          getFirstExpr();
 
   void                   setRefValueConstRefOptions(CallExpr* refCall,
@@ -279,7 +270,6 @@ public:
   virtual void    accept(AstVisitor* visitor);
   virtual GenRet  codegen();
 
-  virtual Expr*   getFirstChild();
   virtual Expr*   getFirstExpr();
 };
 
@@ -300,8 +290,6 @@ class NamedExpr : public Expr {
   virtual QualifiedType qualType();
   virtual GenRet  codegen();
   virtual void    prettyPrint(std::ostream* o);
-
-  virtual Expr*   getFirstChild();
 
   virtual Expr*   getFirstExpr();
 };

--- a/compiler/include/stmt.h
+++ b/compiler/include/stmt.h
@@ -91,7 +91,6 @@ public:
 
   // Interface to Expr
   virtual void        replaceChild(Expr* oldAst, Expr* newAst);
-  virtual Expr*       getFirstChild();
   virtual Expr*       getFirstExpr();
   virtual Expr*       getNextExpr(Expr* expr);
 
@@ -172,7 +171,6 @@ public:
   virtual void        verify();
   virtual void        accept(AstVisitor* visitor);
 
-  virtual Expr*       getFirstChild();
   virtual Expr*       getFirstExpr();
   virtual Expr*       getNextExpr(Expr* expr);
 
@@ -218,7 +216,6 @@ class GotoStmt : public Stmt {
   virtual void        verify();
   virtual void        accept(AstVisitor* visitor);
 
-  virtual Expr*       getFirstChild();
   virtual Expr*       getFirstExpr();
 
   const char*         getName();
@@ -246,8 +243,6 @@ public:
 
   // Interface to Expr
   virtual void        replaceChild(Expr* oldAst, Expr* newAst);
-
-  virtual Expr*       getFirstChild();
   virtual Expr*       getFirstExpr();
 
   // Local interface
@@ -277,8 +272,6 @@ public:
 
   // Interface to Expr
   virtual void        replaceChild(Expr* oldAst, Expr* newAst);
-
-  virtual Expr*       getFirstChild();
   virtual Expr*       getFirstExpr();
 
   // forwarding function - contains forwarding expression; used during parsing


### PR DESCRIPTION
This member function is currently unused
and not well understood.

Removing it completely.