### PR TITLE
Fixed a 32-bit compiler build issue due to #8331

### DIFF
--- a/compiler/AST/view.cpp
+++ b/compiler/AST/view.cpp
@@ -868,13 +868,13 @@ void vec_view(std::vector<Symbol*>* vec) {
 }
 
 void vec_view(std::vector<Symbol*>& vec) {
-  printf("vector<Symbol> %ld elm(s)\n", vec.size());
-  for (size_t i = 0; i < vec.size(); i++) {
+  printf("vector<Symbol> %d elm(s)\n", (int)vec.size());
+  for (int i = 0; i < (int)vec.size(); i++) {
     Symbol* elm = vec[i];
     if (elm)
-      printf("%3ld %8d  %s\n", i, elm->id, elm->name);
+      printf("%3d %8d  %s\n", i, elm->id, elm->name);
     else
-      printf("%3ld <null>\n", i);
+      printf("%3d <null>\n", i);
   }
 }
 


### PR DESCRIPTION
An issue was caused by a different interpretation of the type of std::vector::size()
on 64-bit vs. 32-bit systems, affecting printf %d format.

I am resolving it by casting size() to 'int'.
This should be safe because the vectors in question should be shorter than 32 bits.