### PR TITLE
Print out suggestion upon --flag vs -flag confusion

### DIFF
--- a/compiler/main/arg.cpp
+++ b/compiler/main/arg.cpp
@@ -723,9 +723,27 @@ static void print_suggestions(const char* flag, const ArgumentDescription* desc)
       usearg[i] = '\0';
   }
 
+  // Find the first developer only flag
+  // (Code in this function assumes developer flags are after other flags)
+  int firstDeveloperOnly = 0;
+  for (int i = 0; desc[i].name != 0; i++) {
+    const char* devFlags = "Developer Flags";
+    if (desc[i].description &&
+        // Does the description start with devFlags?
+        strlen(desc[i].description) > strlen(devFlags) &&
+        0 == memcmp(desc[i].description, devFlags, strlen(devFlags))) {
+      firstDeveloperOnly = i;
+      break;
+    }
+  }
+
   bool helped = false;
   // Find some common confusions and print a suggestion
   for (int i = 0; desc[i].name != 0; i++) {
+    // Skip developer-only options for non-developer compile
+    if (!developer && i >= firstDeveloperOnly)
+      break;
+
     if (usearg[0] == desc[i].key && usearg[1] == '\0') {
       // e.g. --s was used instead of -s
       fprintf(stderr, "       Did you mean -%c ?\n", desc[i].key);
@@ -746,6 +764,10 @@ static void print_suggestions(const char* flag, const ArgumentDescription* desc)
   // e.g. --helpme
   if (!helped) {
     for (int i = 0; desc[i].name != 0; i++) {
+      // Skip developer-only options for non-developer compile
+      if (!developer && i >= firstDeveloperOnly)
+        break;
+
       if (desc[i].name[0] != '\0' &&
           strlen(usearg) > strlen(desc[i].name) &&
           0 == memcmp(usearg, desc[i].name, strlen(desc[i].name))) {
@@ -758,6 +780,10 @@ static void print_suggestions(const char* flag, const ArgumentDescription* desc)
   // Did the user type a portion of a flag?
   if (!helped) {
     for (int i = 0; desc[i].name != 0; i++) {
+      // Skip developer-only options for non-developer compile
+      if (!developer && i >= firstDeveloperOnly)
+        break;
+
       if (desc[i].name[0] != '\0' &&
           strlen(usearg) < strlen(desc[i].name) &&
           0 == memcmp(usearg, desc[i].name, strlen(usearg))) {

--- a/compiler/main/arg.cpp
+++ b/compiler/main/arg.cpp
@@ -499,7 +499,7 @@ static void process_arg(const ArgumentState*       state,
                         char***                    argv,
                         const char*                currentFlag);
 
-static void print_perhaps(const char* flag, const ArgumentDescription* desc);
+static void print_suggestions(const char* flag, const ArgumentDescription* desc);
 static void bad_flag(const char* flag, const char* arg, const ArgumentDescription* desc);
 static void extraneous_arg(const char* flag, const char* extras, const ArgumentDescription* desc);
 
@@ -711,7 +711,7 @@ static void process_arg(const ArgumentState*       state,
     desc->pfn(desc, arg);
 }
 
-static void print_perhaps(const char* flag, const ArgumentDescription* desc)
+static void print_suggestions(const char* flag, const ArgumentDescription* desc)
 {
   const char* nodashes = flag;
   // skip past any '-' characters at the start of flag
@@ -728,16 +728,16 @@ static void print_perhaps(const char* flag, const ArgumentDescription* desc)
   for (int i = 0; desc[i].name != 0; i++) {
     if (usearg[0] == desc[i].key && usearg[1] == '\0') {
       // e.g. --s was used instead of -s
-      fprintf(stderr, " Perhaps you meant -%c ?\n", desc[i].key);
+      fprintf(stderr, "       Did you mean -%c ?\n", desc[i].key);
       helped = true;
     } if (0 == strcmp(usearg, desc[i].name)) {
-      fprintf(stderr, " Perhaps you meant --%s ?\n", desc[i].name);
+      fprintf(stderr, "       Did you mean --%s ?\n", desc[i].name);
       helped = true;
     } else if (desc[i].env &&
                (0 == strcmp(usearg, desc[i].env) ||
                 (desc[i].env[0] == '_' &&
                  0 == strcmp(usearg, desc[i].env+1)))) {
-      fprintf(stderr, " Perhaps you meant --%s ?\n", desc[i].name);
+      fprintf(stderr, "       Did you mean --%s ?\n", desc[i].name);
       helped = true;
     }
   }
@@ -749,7 +749,7 @@ static void print_perhaps(const char* flag, const ArgumentDescription* desc)
       if (desc[i].name[0] != '\0' &&
           strlen(usearg) > strlen(desc[i].name) &&
           0 == memcmp(usearg, desc[i].name, strlen(desc[i].name))) {
-        fprintf(stderr, " Perhaps you meant --%s ?\n", desc[i].name);
+        fprintf(stderr, "       Did you mean --%s ?\n", desc[i].name);
         helped = true;
       }
     }
@@ -761,7 +761,7 @@ static void print_perhaps(const char* flag, const ArgumentDescription* desc)
       if (desc[i].name[0] != '\0' &&
           strlen(usearg) < strlen(desc[i].name) &&
           0 == memcmp(usearg, desc[i].name, strlen(usearg))) {
-        fprintf(stderr, " Perhaps you meant --%s ?\n", desc[i].name);
+        fprintf(stderr, "       Did you mean --%s ?\n", desc[i].name);
       }
     }
   }
@@ -772,7 +772,7 @@ static void print_perhaps(const char* flag, const ArgumentDescription* desc)
 static void bad_flag(const char* flag, const char* arg, const ArgumentDescription* desc)
 {
   fprintf(stderr, "Unrecognized flag: '%s' (use '-h' for help)\n", flag);
-  print_perhaps(arg, desc);
+  print_suggestions(arg, desc);
   clean_exit(1);
 }
 
@@ -782,7 +782,7 @@ static void extraneous_arg(const char* flag, const char* extras, const ArgumentD
           "Extra characters after flag '%s': '%s' (use 'h' for help)\n",
           flag,
           extras);
-  print_perhaps(flag, desc);
+  print_suggestions(flag, desc);
   clean_exit(1);
 }
 

--- a/compiler/main/arg.cpp
+++ b/compiler/main/arg.cpp
@@ -499,8 +499,9 @@ static void process_arg(const ArgumentState*       state,
                         char***                    argv,
                         const char*                currentFlag);
 
-static void bad_flag(const char* flag);
-static void extraneous_arg(const char* flag, const char* extras);
+static void print_perhaps(const char* flag, const ArgumentDescription* desc);
+static void bad_flag(const char* flag, const char* arg, const ArgumentDescription* desc);
+static void extraneous_arg(const char* flag, const char* extras, const ArgumentDescription* desc);
 
 static void missing_arg(const char* currentFlag);
 
@@ -572,7 +573,7 @@ static void ProcessCommandLine(ArgumentState* state, int argc, char* aargv[])
         if (found == false)
         {
           // This does not return
-          bad_flag(*argv);
+          bad_flag(*argv, *argv, desc);
         }
       }
       else
@@ -593,7 +594,7 @@ static void ProcessCommandLine(ArgumentState* state, int argc, char* aargv[])
               process_arg(state, &(state->desc[i]), &argv, (*argv)-2);
 
               if (**argv != '\0')
-                extraneous_arg(errFlag, *argv);
+                extraneous_arg(errFlag, *argv, desc);
 
               found = true;
             }
@@ -603,7 +604,7 @@ static void ProcessCommandLine(ArgumentState* state, int argc, char* aargv[])
         if (found == false)
         {
           // This does not return
-          bad_flag(errFlag);
+          bad_flag(errFlag, *argv, desc);
         }
 
       }
@@ -710,18 +711,78 @@ static void process_arg(const ArgumentState*       state,
     desc->pfn(desc, arg);
 }
 
-static void bad_flag(const char* flag)
+static void print_perhaps(const char* flag, const ArgumentDescription* desc)
+{
+  const char* nodashes = flag;
+  // skip past any '-' characters at the start of flag
+  while (*nodashes == '-') nodashes++;
+  char* usearg = strdup(nodashes);
+  // Chop off the string after '='
+  for (int i = 0; usearg[i]; i++) {
+    if (usearg[i] == '=')
+      usearg[i] = '\0';
+  }
+
+  bool helped = false;
+  // Find some common confusions and print a suggestion
+  for (int i = 0; desc[i].name != 0; i++) {
+    if (usearg[0] == desc[i].key && usearg[1] == '\0') {
+      // e.g. --s was used instead of -s
+      fprintf(stderr, " Perhaps you meant -%c ?\n", desc[i].key);
+      helped = true;
+    } if (0 == strcmp(usearg, desc[i].name)) {
+      fprintf(stderr, " Perhaps you meant --%s ?\n", desc[i].name);
+      helped = true;
+    } else if (desc[i].env &&
+               (0 == strcmp(usearg, desc[i].env) ||
+                (desc[i].env[0] == '_' &&
+                 0 == strcmp(usearg, desc[i].env+1)))) {
+      fprintf(stderr, " Perhaps you meant --%s ?\n", desc[i].name);
+      helped = true;
+    }
+  }
+
+  // Did the user elaborate on a flag that was abbreviated?
+  // e.g. --helpme
+  if (!helped) {
+    for (int i = 0; desc[i].name != 0; i++) {
+      if (desc[i].name[0] != '\0' &&
+          strlen(usearg) > strlen(desc[i].name) &&
+          0 == memcmp(usearg, desc[i].name, strlen(desc[i].name))) {
+        fprintf(stderr, " Perhaps you meant --%s ?\n", desc[i].name);
+        helped = true;
+      }
+    }
+  }
+
+  // Did the user type a portion of a flag?
+  if (!helped) {
+    for (int i = 0; desc[i].name != 0; i++) {
+      if (desc[i].name[0] != '\0' &&
+          strlen(usearg) < strlen(desc[i].name) &&
+          0 == memcmp(usearg, desc[i].name, strlen(usearg))) {
+        fprintf(stderr, " Perhaps you meant --%s ?\n", desc[i].name);
+      }
+    }
+  }
+
+  free(usearg);
+}
+
+static void bad_flag(const char* flag, const char* arg, const ArgumentDescription* desc)
 {
   fprintf(stderr, "Unrecognized flag: '%s' (use '-h' for help)\n", flag);
+  print_perhaps(arg, desc);
   clean_exit(1);
 }
 
-static void extraneous_arg(const char* flag, const char* extras)
+static void extraneous_arg(const char* flag, const char* extras, const ArgumentDescription* desc)
 {
   fprintf(stderr,
           "Extra characters after flag '%s': '%s' (use 'h' for help)\n",
           flag,
           extras);
+  print_perhaps(flag, desc);
   clean_exit(1);
 }
 

--- a/test/compflags/bradc/oneDash/badFlag.good
+++ b/test/compflags/bradc/oneDash/badFlag.good
@@ -1,1 +1,4 @@
 Unrecognized flag: '-e' (use '-h' for help)
+       Did you mean --explain-call ?
+       Did you mean --explain-instantiation ?
+       Did you mean --explain-verbose ?

--- a/test/compflags/bradc/oneDash/dashDevel.good
+++ b/test/compflags/bradc/oneDash/dashDevel.good
@@ -1,6 +1,2 @@
 Unrecognized flag: '-d' (use '-h' for help)
-       Did you mean --dead-code-elimination ?
-       Did you mean --div-by-zero-checks ?
-       Did you mean --debug ?
-       Did you mean --dynamic ?
        Did you mean --devel ?

--- a/test/compflags/bradc/oneDash/dashDevel.good
+++ b/test/compflags/bradc/oneDash/dashDevel.good
@@ -1,1 +1,6 @@
 Unrecognized flag: '-d' (use '-h' for help)
+       Did you mean --dead-code-elimination ?
+       Did you mean --div-by-zero-checks ?
+       Did you mean --debug ?
+       Did you mean --dynamic ?
+       Did you mean --devel ?

--- a/test/compflags/bradc/oneDash/goodBad.good
+++ b/test/compflags/bradc/oneDash/goodBad.good
@@ -1,1 +1,2 @@
 Extra characters after flag '-g': 'e' (use 'h' for help)
+       Did you mean -g ?

--- a/test/compflags/bradc/oneDash/goodGood.good
+++ b/test/compflags/bradc/oneDash/goodGood.good
@@ -1,1 +1,2 @@
 Extra characters after flag '-g': 'O' (use 'h' for help)
+       Did you mean -g ?

--- a/test/compflags/ferguson/suggestions.1.good
+++ b/test/compflags/ferguson/suggestions.1.good
@@ -1,0 +1,2 @@
+Unrecognized flag: '--h' (use '-h' for help)
+       Did you mean -h ?

--- a/test/compflags/ferguson/suggestions.2.good
+++ b/test/compflags/ferguson/suggestions.2.good
@@ -1,0 +1,2 @@
+Unrecognized flag: '-i' (use '-h' for help)
+       Did you mean --inline ?

--- a/test/compflags/ferguson/suggestions.3.good
+++ b/test/compflags/ferguson/suggestions.3.good
@@ -1,0 +1,2 @@
+Unrecognized flag: '--inline-functions' (use '-h' for help)
+       Did you mean --inline ?

--- a/test/compflags/ferguson/suggestions.4.good
+++ b/test/compflags/ferguson/suggestions.4.good
@@ -1,0 +1,2 @@
+Unrecognized flag: '-i' (use '-h' for help)
+       Did you mean --ieee-float ?

--- a/test/compflags/ferguson/suggestions.5.good
+++ b/test/compflags/ferguson/suggestions.5.good
@@ -1,0 +1,2 @@
+Unrecognized flag: '--CHPL_REGEXP=re2' (use '-h' for help)
+       Did you mean --regexp ?

--- a/test/compflags/ferguson/suggestions.chpl
+++ b/test/compflags/ferguson/suggestions.chpl
@@ -1,0 +1,1 @@
+writeln("Hello");

--- a/test/compflags/ferguson/suggestions.compopts
+++ b/test/compflags/ferguson/suggestions.compopts
@@ -1,0 +1,5 @@
+--h                 # suggestions.1.good
+-inline             # suggestions.2.good
+--inline-functions  # suggestions.3.good
+-ieee               # suggestions.4.good
+--CHPL_REGEXP=re2   # suggestions.5.good


### PR DESCRIPTION
I'm frequently confused by what I consider to be the arbitrary distinction 
between `-flag` flags and `--flag` flags. While I personally would advocate
simply removing these distinction in our compiler, this PR does not go that
far. Instead, it just prints out a suggestion after the usual "Unrecognized 
flag" error. While there, I made this suggestion also work for several other
common flag confusion scenarios.

For example:
```
$ chpl --h
Unrecognized flag: '--h' (use '-h' for help)
       Did you mean -h ?
$ chpl hello.chpl -inline
Unrecognized flag: '-i' (use '-h' for help)
       Did you mean --inline ?
$ chpl hello.chpl --inline-functions
Unrecognized flag: '--inline-functions' (use '-h' for help)
       Did you mean --inline ?
$ chpl hello.chpl -ieee
Unrecognized flag: '-i' (use '-h' for help)
       Did you mean --ieee-float ?
$ chpl hello.chpl --CHPL_REGEXP=re2
Unrecognized flag: '--CHPL_REGEXP=re2' (use '-h' for help)
       Did you mean --regexp ?
```

- [x] full local testing

Reviewed by @ben-albrecht - thanks!
