### PR TITLE
Enable type inference from 'new' within initializers

### DIFF
--- a/test/classes/initializers/generics/phase1/newInit-class-class2.future
+++ b/test/classes/initializers/generics/phase1/newInit-class-class2.future
@@ -1,5 +1,0 @@
-bug: internal error when field with only a declared initial value uses new
-
-We fixed the problem when a field has declared its type, but overlooked fixing
-it when the field has not declared its type and has declared an initial value
-(or is completely generic) using new.

--- a/test/classes/initializers/generics/phase1/newInit-class-record2.chpl
+++ b/test/classes/initializers/generics/phase1/newInit-class-record2.chpl
@@ -12,7 +12,7 @@ class Container {
 record Stored {
   var x: bool;
 
-  proc init(xVal) {
+  proc init(xVal:bool) {
     x = xVal;
 
     super.init();

--- a/test/classes/initializers/generics/phase1/newInit-class-record2.future
+++ b/test/classes/initializers/generics/phase1/newInit-class-record2.future
@@ -1,5 +1,0 @@
-bug: internal error when field with only a declared initial value uses new
-
-We fixed the problem when a field has declared its type, but overlooked fixing
-it when the field has not declared its type and has declared an initial value
-(or is completely generic) using new.

--- a/test/classes/initializers/generics/phase1/newInit-record-class2.future
+++ b/test/classes/initializers/generics/phase1/newInit-record-class2.future
@@ -1,5 +1,0 @@
-bug: internal error when field with only a declared initial value uses new
-
-We fixed the problem when a field has declared its type, but overlooked fixing
-it when the field has not declared its type and has declared an initial value
-(or is completely generic) using new.

--- a/test/classes/initializers/generics/phase1/newInit-record-record2.chpl
+++ b/test/classes/initializers/generics/phase1/newInit-record-record2.chpl
@@ -12,7 +12,7 @@ record Container {
 record Stored {
   var x: bool;
 
-  proc init(xVal) {
+  proc init(xVal:bool) {
     x = xVal;
 
     super.init();

--- a/test/classes/initializers/generics/phase1/newInit-record-record2.future
+++ b/test/classes/initializers/generics/phase1/newInit-record-record2.future
@@ -1,5 +1,0 @@
-bug: internal error when field with only a declared initial value uses new
-
-We fixed the problem when a field has declared its type, but overlooked fixing
-it when the field has not declared its type and has declared an initial value
-(or is completely generic) using new.

--- a/test/classes/initializers/generics/phase1/type-from-new.chpl
+++ b/test/classes/initializers/generics/phase1/type-from-new.chpl
@@ -1,0 +1,20 @@
+
+record R {
+  var x : int;
+}
+
+class C {
+  type t;
+  var v = new R();
+
+  proc init() {
+    t = new R();
+    super.init();
+    v = new R();
+  }
+}
+
+proc main() {
+  var c = new C();
+  delete c;
+}

--- a/test/classes/initializers/generics/phase1/type-from-new.good
+++ b/test/classes/initializers/generics/phase1/type-from-new.good
@@ -1,0 +1,1 @@
+type-from-new.chpl:11: error: Cannot initialize type field 't' with 'new' expression

--- a/test/classes/initializers/phase1/newInit-class-class2.future
+++ b/test/classes/initializers/phase1/newInit-class-class2.future
@@ -1,5 +1,0 @@
-bug: internal error when field with only a declared initial value uses new
-
-We fixed the problem when a field has declared its type, but overlooked fixing
-it when the field has not declared its type and has declared an initial value
-(or is completely generic) using new.

--- a/test/classes/initializers/phase1/newInit-class-record2.chpl
+++ b/test/classes/initializers/phase1/newInit-class-record2.chpl
@@ -12,7 +12,7 @@ class Container {
 record Stored {
   var x: bool;
 
-  proc init(xVal) {
+  proc init(xVal:bool) {
     x = xVal;
 
     super.init();

--- a/test/classes/initializers/phase1/newInit-class-record2.future
+++ b/test/classes/initializers/phase1/newInit-class-record2.future
@@ -1,5 +1,0 @@
-bug: internal error when field with only a declared initial value uses new
-
-We fixed the problem when a field has declared its type, but overlooked fixing
-it when the field has not declared its type and has declared an initial value
-(or is completely generic) using new.

--- a/test/classes/initializers/phase1/newInit-record-class2.future
+++ b/test/classes/initializers/phase1/newInit-record-class2.future
@@ -1,5 +1,0 @@
-bug: internal error when field with only a declared initial value uses new
-
-We fixed the problem when a field has declared its type, but overlooked fixing
-it when the field has not declared its type and has declared an initial value
-(or is completely generic) using new.

--- a/test/classes/initializers/phase1/newInit-record-record2.chpl
+++ b/test/classes/initializers/phase1/newInit-record-record2.chpl
@@ -12,7 +12,7 @@ record Container {
 record Stored {
   var x: bool;
 
-  proc init(xVal) {
+  proc init(xVal:bool) {
     x = xVal;
 
     super.init();

--- a/test/classes/initializers/phase1/newInit-record-record2.future
+++ b/test/classes/initializers/phase1/newInit-record-record2.future
@@ -1,5 +1,0 @@
-bug: internal error when field with only a declared initial value uses new
-
-We fixed the problem when a field has declared its type, but overlooked fixing
-it when the field has not declared its type and has declared an initial value
-(or is completely generic) using new.

--- a/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc-ideal.bad
+++ b/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc-ideal.bad
@@ -1,8 +1,0 @@
-chameneosredux-blc-ideal.chpl:56: internal error: INI0465 chpl version 1.16.0 pre-release (5007c1a)
-Note: This source location is a guess.
-
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
-and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
-please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
-

--- a/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc-ideal.chpl
+++ b/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc-ideal.chpl
@@ -52,7 +52,7 @@ record Population {
   //
   // construct the population in terms of an array of colors passed in
   //
-  proc init(colors) {
+  proc init(colors : [] Color) {
     chameneos = new Chameneos(1..colors.size, colors);
     super.init();
   }

--- a/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc-ideal.future
+++ b/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc-ideal.future
@@ -1,5 +1,0 @@
-bug: internal error for generic argument formed by promoted initializer call
-
-This test generates an internal error in spite of its similarity to
-../elliot/chameneosredux-ejr.chpl.  Seems like this should be legal,
-or even if not, should not be an internal error.


### PR DESCRIPTION
This PR leverages existing code to allow initializers to handle type inference from a 'new' expression. Previously we would see a PRIM_NEW and emit an internal error, presumably in order to make progress in other initializer tasks.

A new compiler error is added for the case where a type field is initialized from a 'new' expression.

Related futures have been updated to avoid copy initializer confusion by specifying the type of the generic argument to 'init'.

Closes #7341

Testing:
- [x] full local