### PR TITLE
Fix ISx min timings

### DIFF
--- a/test/release/examples/benchmarks/isx/isx.chpl
+++ b/test/release/examples/benchmarks/isx/isx.chpl
@@ -433,7 +433,9 @@ proc printTimeTable(timeTable, units, timerName) {
 // trials)
 //
 proc printTimingStats(timeTable, timerName) {
-  var minMinTime, maxMinTime, totMinTime: real;
+  var minMinTime = max(real),
+      maxMinTime = min(real),
+      totMinTime: real;
 
   //
   // iterate over the buckets, computing the min/max/total of the

--- a/test/studies/isx/isx-bucket-spmd.chpl
+++ b/test/studies/isx/isx-bucket-spmd.chpl
@@ -437,7 +437,9 @@ proc printTimeTable(timeTable, units, timerName) {
 // trials)
 //
 proc printTimingStats(timeTable, timerName) {
-  var minMinTime, maxMinTime, totMinTime: real;
+  var minMinTime = max(real),
+      maxMinTime = min(real),
+      totMinTime: real;
 
   //
   // iterate over the buckets, computing the min/max/total of the

--- a/test/studies/isx/isx-hand-optimized.chpl
+++ b/test/studies/isx/isx-hand-optimized.chpl
@@ -444,7 +444,9 @@ proc printTimeTable(timeTable, units, timerName) {
 // trials)
 //
 proc printTimingStats(timeTable, timerName) {
-  var minMinTime, maxMinTime, totMinTime: real;
+  var minMinTime = max(real),
+      maxMinTime = min(real),
+      totMinTime: real;
 
   //
   // iterate over the buckets, computing the min/max/total of the

--- a/test/studies/isx/isx-no-return.chpl
+++ b/test/studies/isx/isx-no-return.chpl
@@ -426,7 +426,9 @@ proc printTimeTable(timeTable, units, timerName) {
 // trials)
 //
 proc printTimingStats(timeTable, timerName) {
-  var minMinTime, maxMinTime, totMinTime: real;
+  var minMinTime = max(real),
+      maxMinTime = min(real),
+      totMinTime: real;
 
   //
   // iterate over the buckets, computing the min/max/total of the

--- a/test/studies/isx/isx-per-task.chpl
+++ b/test/studies/isx/isx-per-task.chpl
@@ -443,7 +443,9 @@ proc printTimeTable(timeTable, units, timerName) {
 // trials)
 //
 proc printTimingStats(timeTable, timerName) {
-  var minMinTime, maxMinTime, totMinTime: real;
+  var minMinTime = max(real),
+      maxMinTime = min(real),
+      totMinTime: real;
 
   //
   // iterate over the buckets, computing the min/max/total of the


### PR DESCRIPTION
We were computing the min timings with a min reduce intent on a forall, but
since we now maintain the initial value of reduce intents (#7351), this meant
we were always reporting 0. Update the initial value to be max(real) to avoid
this.