### PR TITLE
Add prediff for Jira 203

### DIFF
--- a/util/test/prediff-for-Jira-203
+++ b/util/test/prediff-for-Jira-203
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# This script is for the use with 'start_test' as the system-wide prediff, to
+# suppress sporadic false test errors observed on both kaibab and kay-elogin,
+# caused by "Transient MPP reservation error on create" appearing in the test
+# output.
+
+# This is thought to be a system issue, caused by a miscommunication between
+# ALPS and PBS. Not a Chapel issue.
+
+# Note: start_test's error handler also recognizes the same string,
+#   "Transient MPP reservation error on create",
+# and, if found, generates a more-recognizable error msg,
+#   "Error: Jira 203 -- Transient MPP reservation error",
+# instead of the generic
+#   "Error matching program output".
+
+# See Jira #203 (https://chapel.atlassian.net/browse/CHAPEL-203) for more info.
+
+# To use this prediff file with start_test (assuming bash):
+#
+# export CHPL_SYSTEM_PREEXEC=$CHPL_HOME/util/test/prediff-for-Jira-203
+# start_test ...
+
+outfile=$2
+sed < $outfile > $outfile.tmp -e '/Transient MPP reservation error on create/d'
+mv -f $outfile.tmp $outfile


### PR DESCRIPTION
This system-prediff script has been used on kaibab since Aug 2017, except it was generated
in the Jenkins job config, not stored as a file in Chapel.git. 

This change moves the prediff script to Chapel.git, since we now want to use it on kay-elogin as well.  