### PR TITLE
Demote UtilReplicatedVar to package module

### DIFF
--- a/modules/Makefile
+++ b/modules/Makefile
@@ -110,6 +110,7 @@ PACKAGES_TO_DOCUMENT = \
 	packages/OwnedObject.chpl \
 	packages/RangeChunk.chpl \
 	packages/RecordParser.chpl \
+	packages/ReplicatedVar.chpl \
 	packages/Search.chpl \
 	packages/SharedObject.chpl \
 	packages/Sort.chpl \

--- a/modules/packages/HDFS.chpl
+++ b/modules/packages/HDFS.chpl
@@ -117,7 +117,7 @@ HDFS Support Types and Functions
  */
 module HDFS {
 
-use IO, SysBasic, SysError, UtilReplicatedVar;
+use IO, SysBasic, SysError, ReplicatedVar;
 
 pragma "no doc"
 extern type qio_locale_map_ptr_t;     // array of locale to byte range mappings

--- a/modules/packages/HDFSiterator.chpl
+++ b/modules/packages/HDFSiterator.chpl
@@ -25,7 +25,7 @@
  */
 module HDFSiterator {
 
-use HDFS, UtilReplicatedVar, RecordParser;
+use HDFS, ReplicatedVar, RecordParser;
 
 /* Iterate through an HDFS file (available in the default configured
    HDFS server) and yield records matching a regular expression.

--- a/modules/packages/MPI.chpl
+++ b/modules/packages/MPI.chpl
@@ -192,7 +192,7 @@ module MPI {
   use SysCTypes;
   require "mpi.h";
 
-  use UtilReplicatedVar;
+  use ReplicatedVar;
 
   /*
      Automatically initializes MPI (if not already initialized by the runtime), and

--- a/modules/packages/ReplicatedVar.chpl
+++ b/modules/packages/ReplicatedVar.chpl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2017 Cray Inc.
+ * Copyright 2004-2018 Cray Inc.
  * Other additional copyright holders may be indicated within.
  * 
  * The entirety of this work is licensed under the Apache License,

--- a/modules/packages/ReplicatedVar.chpl
+++ b/modules/packages/ReplicatedVar.chpl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2018 Cray Inc.
+ * Copyright 2004-2017 Cray Inc.
  * Other additional copyright holders may be indicated within.
  * 
  * The entirety of this work is licensed under the Apache License,
@@ -52,7 +52,7 @@ How to use replicated variables
 
 .. code-block:: chapel
 
-    use UtilReplicatedVar;
+    use ReplicatedVar;
 
     // declare a replicated variable of the type 'MyType'
     var myRepVar: [rcDomain] MyType;
@@ -96,13 +96,9 @@ and/or sparse), make that array's domain associative over int.
 Declarations
 ----------------------------------------------
 */
-module UtilReplicatedVar {
+module ReplicatedVar {
 
 use ReplicatedDist;
-
-compilerWarning(
-  "Module 'UtilReplicatedVar' has been deprecated and demoted to the package 'ReplicatedVar'"
-);
 
 private const rcDomainIx   = 1; // todo convert to param
 /* Use this domain when replicating over a subset of locales,
@@ -271,4 +267,4 @@ proc rcExampleOverLocales(initVal: ?MyType, newVal: MyType, newLocale: locale,
   writeln("\ncollected copies of myRepVar are:\n", collected);
 }
 
-} // module UtilReplicatedVar
+} // module ReplicatedVar

--- a/modules/packages/ReplicatedVar.chpl
+++ b/modules/packages/ReplicatedVar.chpl
@@ -22,7 +22,7 @@ Support for user-level replicated variables.
 
 A "replicated" variable is a variable for which there is a copy on each locale.
 Referencing a replicated variable
-(in a stylized way, see :ref:`below <basic-usage>`)
+(in a stylized way, see :ref:`below <ReplicatedVar_basic-usage>`)
 accesses its copy on the current locale.
 
 Features:
@@ -44,7 +44,7 @@ Limitations:
 
    var replArray: [MyDomain dmapped Replicated()] real;
 
-.. _basic-usage:
+.. _ReplicatedVar_basic-usage:
 
 -------------------------------
 How to use replicated variables
@@ -72,7 +72,7 @@ How to use replicated variables
     // access directly a remote copy on the locale 'remoteLoc' (read or write)
     ... rcRemote(myRepVar, remoteLoc) ...
 
-.. _subset-of-locales:
+.. _ReplicatedVar_subset-of-locales:
 
 ------------------------------------
 Replicating over a subset of locales
@@ -102,12 +102,12 @@ use ReplicatedDist;
 
 private const rcDomainIx   = 1; // todo convert to param
 /* Use this domain when replicating over a subset of locales,
-   as shown :ref:`above <subset-of-locales>`. */
+   as shown :ref:`above <ReplicatedVar_subset-of-locales>`. */
 const rcDomainBase = {rcDomainIx..rcDomainIx};
 private const rcLocales    = Locales;
 private const rcDomainMap  = new Replicated(rcLocales);
 /* Use this domain to declare a user-level replicated variable,
-   as shown :ref:`above <basic-usage>` . */
+   as shown :ref:`above <ReplicatedVar_basic-usage>` . */
 const rcDomain     = rcDomainBase dmapped new dmap(rcDomainMap);
 private param _rcErr1 = " must be 'rcDomain' or 'rcDomainBase dmapped Replicated(an array of locales)'";
 

--- a/test/deprecated/urv.chpl
+++ b/test/deprecated/urv.chpl
@@ -1,0 +1,1 @@
+use UtilReplicatedVar;

--- a/test/deprecated/urv.good
+++ b/test/deprecated/urv.good
@@ -1,0 +1,1 @@
+$CHPL_HOME/modules/standard/UtilReplicatedVar.chpl:103: warning: Module 'UtilReplicatedVar' has been deprecated and demoted to the package 'ReplicatedVar'

--- a/test/distributions/vass/testReplicatedVar1.chpl
+++ b/test/distributions/vass/testReplicatedVar1.chpl
@@ -1,4 +1,4 @@
-use ReplicatedDist, UtilReplicatedVar;
+use ReplicatedDist, ReplicatedVar;
 
 proc writeReplicands(x, locs) {
   for loc in locs {

--- a/test/distributions/vass/testReplicatedVar2.chpl
+++ b/test/distributions/vass/testReplicatedVar2.chpl
@@ -1,7 +1,7 @@
 // This test invokes the test examples provided with the implementation
 // of the replicated variables.
 
-use UtilReplicatedVar;
+use ReplicatedVar;
 
 rcExample(5.0, 33, Locales[0]);
 

--- a/test/studies/HDFS/tzakian/HDFSiterator.chpl
+++ b/test/studies/HDFS/tzakian/HDFSiterator.chpl
@@ -37,7 +37,7 @@
 use Sys, 
     HDFS,
     HDFStools, 
-    UtilReplicatedVar, 
+    ReplicatedVar,
     BlockDist;
 
 // ============== Serial iterator ========================

--- a/test/studies/graph500/kristyn/Graph500_1D_onV/Graph500_Modules/BFS_1D_onV.chpl
+++ b/test/studies/graph500/kristyn/Graph500_1D_onV/Graph500_Modules/BFS_1D_onV.chpl
@@ -18,7 +18,7 @@ proc BFS ( root : vertex_id, ParentTree, G )
   type Vertex_List = domain (index(vertex_domain) );
   var visited$ : [vertex_domain] sync int = -1;
 
-  use UtilReplicatedVar;
+  use ReplicatedVar;
   var Active_Level: [rcDomain] Level_Set (Vertex_List);
   var Next_Level: [rcDomain] Level_Set (Vertex_List);
   var Active_Remaining: [LocaleSpace] bool = true;

--- a/test/studies/graph500/v3/Graph500_Modules/BFS_1D_onV.chpl
+++ b/test/studies/graph500/v3/Graph500_Modules/BFS_1D_onV.chpl
@@ -18,7 +18,7 @@ proc BFS ( root : vertex_id, ParentTree, G )
   type Vertex_List = domain (index(vertex_domain) );
   var visited$ : [vertex_domain] sync int = -1;
 
-  use UtilReplicatedVar;
+  use ReplicatedVar;
   var Active_Level: [rcDomain] Level_Set (Vertex_List);
   var Next_Level: [rcDomain] Level_Set (Vertex_List);
   var Active_Remaining: [LocaleSpace] bool = true;

--- a/test/users/npadmana/bugs/replicated_invalid_ref_return/replicated_bug.chpl
+++ b/test/users/npadmana/bugs/replicated_invalid_ref_return/replicated_bug.chpl
@@ -1,4 +1,4 @@
-use UtilReplicatedVar;
+use ReplicatedVar;
 use Utils;
 
 module Utils {


### PR DESCRIPTION
Long-term we expect to have a more elegant way to represent replicated variables, at which point ``UtilReplicatedVar`` will no longer be useful or appropriate as a standard module. If we think we're going to deprecate something in the standard modules, we should do so sooner rather than later. This PR demotes ``UtilReplicatedVar`` to a package and renames it as ``ReplicatedVar``.

For now ``UtilReplicatedVar`` will still be usable, but will result in a compiler warning when used. All uses have been replaced with ``ReplicatedVar``.

Testing:
- [x] full local
- [x] full gasnet
- [x] library/packages/MPI