### PR TITLE
Make the chpl-autocompletion test more explicit about what to do if it fails

### DIFF
--- a/test/chplenv/autocomplete/autocomplete.chpl
+++ b/test/chplenv/autocomplete/autocomplete.chpl
@@ -32,5 +32,6 @@ diff.wait();
 if diff.exit_status != 0 {
   writeln();
   writeln("diff failed. You may need to run ", genScript,
-          " to regenerate ", completeScript);
+          " to regenerate ", completeScript, ". Try:");
+  writeln(genScript, " > ", completeScript);
 }


### PR DESCRIPTION

Make test/chplenv/autocomplete/autocomplete.chpl print the command to run
to regenerate chpl-completion.bash.  It requires an output redirect which
wasn't obvious.  This is just a small change to the output when the test fails.