### PR TITLE
Skip init methods when building virtual maps

### DIFF
--- a/compiler/resolution/virtualDispatch.cpp
+++ b/compiler/resolution/virtualDispatch.cpp
@@ -149,6 +149,8 @@ static bool buildVirtualMaps() {
         if (at->isGeneric() == false) {
           if (fn->isResolved()            == true      &&
 
+              strcmp(fn->name, "init")    != 0         &&
+
               fn->hasFlag(FLAG_WRAPPER)   == false     &&
               fn->hasFlag(FLAG_NO_PARENS) == false     &&
 

--- a/test/classes/initializers/compilerGenerated/shadow_with_different_type.chpl
+++ b/test/classes/initializers/compilerGenerated/shadow_with_different_type.chpl
@@ -1,0 +1,23 @@
+// Copied from test/classes/diten/shadow_with_different_type.chpl
+class Base {
+  var s = "Base";
+}
+
+class Sub: Base {
+  var s = 1;
+}
+
+proc main() {
+  var sub         = new Sub();
+  var base:Base() = sub;
+  var base2       = new Base();
+
+  base.s = "Base";
+
+  writeln(sub.s);
+  writeln(base.s);
+  writeln(base2.s);
+
+  delete base2;
+  delete sub;
+}

--- a/test/classes/initializers/compilerGenerated/shadow_with_different_type.good
+++ b/test/classes/initializers/compilerGenerated/shadow_with_different_type.good
@@ -1,0 +1,3 @@
+1
+Base
+Base


### PR DESCRIPTION
It is not appropriate to dynamically dispatch on initializers.  In the case of
actual calls, Ben's #8259 handles what is needed.  However, we then go on to
generate a bunch of virtual maps without following the same code path, and so
we add a version of these initializers to the hierarchy.  Default initializers
detected this when a derived class overwrote the field of a parent class.

Add a copy of the default initializers test that demonstrated this error clearly.

Fixes classes/diten/shadow_with_different_type and
classes/thomasvandoren/InheritGenericClass with --force-initializers.
Changes the failure mode of classes/deitz/nested/test_nested3

Passed classes/initializers with futures, a full paratest, no new failures for
a paratest with --force-initializers.