### PR TITLE
Change default intent for range to const in

### DIFF
--- a/compiler/codegen/symbol.cpp
+++ b/compiler/codegen/symbol.cpp
@@ -754,6 +754,7 @@ bool argMustUseCPtr(Type* type) {
   if (isUnion(type))
     return true;
   if (isRecord(type) &&
+      !type->symbol->hasFlag(FLAG_RANGE) &&
       // TODO: why are ref types being created with AGGREGATE_RECORD?
       !type->symbol->hasFlag(FLAG_REF) &&
       !type->symbol->hasEitherFlag(FLAG_WIDE_REF, FLAG_WIDE_CLASS))

--- a/compiler/passes/resolveIntents.cpp
+++ b/compiler/passes/resolveIntents.cpp
@@ -43,7 +43,8 @@ static IntentTag constIntentForType(Type* t) {
       t == dtCFnPtr ||
       t == dtVoid ||
       t->symbol->hasFlag(FLAG_RANGE) ||
-      t->symbol->hasFlag(FLAG_EXTERN)) {
+      // MPF: This rule seems odd to me
+      (t->symbol->hasFlag(FLAG_EXTERN) && !isRecord(t))) {
     return INTENT_CONST_IN;
 
   } else if (isSyncType(t)          ||

--- a/compiler/passes/resolveIntents.cpp
+++ b/compiler/passes/resolveIntents.cpp
@@ -33,7 +33,6 @@ static IntentTag constIntentForType(Type* t) {
       is_enum_type(t) ||
       isClass(t) ||
       isUnion(t) ||
-      isAtomicType(t) ||
       t == dtOpaque ||
       t == dtTaskID ||
       t == dtFile ||
@@ -50,6 +49,7 @@ static IntentTag constIntentForType(Type* t) {
   } else if (isSyncType(t)          ||
              isSingleType(t)        ||
              isRecordWrappedType(t) ||  // domain, array, or distribution
+             isAtomicType(t) ||
              isRecord(t)) { // may eventually want to decide based on size
     return INTENT_CONST_REF;
 

--- a/compiler/passes/resolveIntents.cpp
+++ b/compiler/passes/resolveIntents.cpp
@@ -158,7 +158,9 @@ IntentTag concreteIntent(IntentTag existingIntent, Type* t) {
 }
 
 static IntentTag constIntentForThisArg(Type* t) {
-  if (isRecord(t) || isUnion(t) || t->symbol->hasFlag(FLAG_REF))
+  if (t->symbol->hasFlag(FLAG_RANGE))
+    return INTENT_CONST_IN;
+  else if (isRecord(t) || isUnion(t) || t->symbol->hasFlag(FLAG_REF))
     return INTENT_CONST_REF;
   else
     return INTENT_CONST_IN;
@@ -169,6 +171,9 @@ static IntentTag blankIntentForThisArg(Type* t) {
 
   Type* valType = t->getValType();
 
+  // Range default this intent is const-in
+  if (valType->symbol->hasFlag(FLAG_RANGE))
+    return INTENT_CONST_IN;
   // For user records or types with FLAG_DEFAULT_INTENT_IS_REF_MAYBE_CONST,
   // the intent for this is INTENT_REF_MAYBE_CONST
   //

--- a/compiler/passes/resolveIntents.cpp
+++ b/compiler/passes/resolveIntents.cpp
@@ -24,33 +24,36 @@
 bool intentsResolved = false;
 
 static IntentTag constIntentForType(Type* t) {
-  if (isSyncType(t)          ||
-      isSingleType(t)        ||
-      isRecordWrappedType(t) ||  // domain, array, or distribution
-      isRecord(t)) { // may eventually want to decide based on size
-    return INTENT_CONST_REF;
-  } else if (is_bool_type(t) ||
-             is_int_type(t) ||
-             is_uint_type(t) ||
-             is_real_type(t) ||
-             is_imag_type(t) ||
-             is_complex_type(t) ||
-             is_enum_type(t) ||
-             isClass(t) ||
-             isUnion(t) ||
-             isAtomicType(t) ||
-             t == dtOpaque ||
-             t == dtTaskID ||
-             t == dtFile ||
-             t == dtNil ||
-             t == dtStringC ||
-             t == dtCVoidPtr ||
-             t == dtCFnPtr ||
-             t == dtVoid ||
-             // TODO: t->symbol->hasFlag(FLAG_RANGE) ||
-             t->symbol->hasFlag(FLAG_EXTERN)) {
+  if (is_bool_type(t) ||
+      is_int_type(t) ||
+      is_uint_type(t) ||
+      is_real_type(t) ||
+      is_imag_type(t) ||
+      is_complex_type(t) ||
+      is_enum_type(t) ||
+      isClass(t) ||
+      isUnion(t) ||
+      isAtomicType(t) ||
+      t == dtOpaque ||
+      t == dtTaskID ||
+      t == dtFile ||
+      t == dtNil ||
+      t == dtStringC ||
+      t == dtCVoidPtr ||
+      t == dtCFnPtr ||
+      t == dtVoid ||
+      t->symbol->hasFlag(FLAG_RANGE) ||
+      t->symbol->hasFlag(FLAG_EXTERN)) {
     return INTENT_CONST_IN;
+
+  } else if (isSyncType(t)          ||
+             isSingleType(t)        ||
+             isRecordWrappedType(t) ||  // domain, array, or distribution
+             isRecord(t)) { // may eventually want to decide based on size
+    return INTENT_CONST_REF;
+
   }
+
   INT_FATAL(t, "Unhandled type in constIntentForType()");
   return INTENT_CONST;
 }
@@ -79,10 +82,7 @@ bool isTupleContainingRefMaybeConst(Type* t)
 IntentTag blankIntentForType(Type* t) {
   IntentTag retval = INTENT_BLANK;
 
-  if (/*isSyncType(t)                                  ||
-      isSingleType(t)                                ||
-        these should have FLAG_DEFAULT_INTENT_IS_REF) */
-      isAtomicType(t)                                ||
+  if (isAtomicType(t)                                ||
       t->symbol->hasFlag(FLAG_DEFAULT_INTENT_IS_REF)) {
     retval = INTENT_REF;
 
@@ -102,6 +102,7 @@ IntentTag blankIntentForType(Type* t) {
              t == dtCFnPtr                           ||
              isClass(t)                              ||
              isRecord(t)                             ||
+             // Note: isRecord(t) includes range (FLAG_RANGE)
              isUnion(t)                              ||
              t == dtTaskID                           ||
              t == dtFile                             ||

--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -125,6 +125,7 @@ static void resolveFormals(FnSymbol* fn) {
 // Fix up value types that need to be ref types.
 static void updateIfRefFormal(FnSymbol* fn, ArgSymbol* formal) {
   // For begin functions, copy ranges in if passed by blank intent.
+  // TODO: remove this code - it should no longer be necessary
   if (fn->hasFlag(FLAG_BEGIN)                   == true &&
       formal->type->symbol->hasFlag(FLAG_RANGE) == true) {
     if (formal->intent == INTENT_BLANK ||

--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -181,8 +181,9 @@ static bool needRefFormal(FnSymbol* fn, ArgSymbol* formal) {
 
   } else if (formal                              == fn->_this &&
              formal->hasFlag(FLAG_TYPE_VARIABLE) == false     &&
-             (isUnion(formal->type)  == true||
-              isRecord(formal->type) == true)) {
+             (isUnion(formal->type)  == true ||
+               (isRecord(formal->type) == true &&
+                !formal->type->symbol->hasFlag(FLAG_RANGE)))) {
     retval = true;
 
   } else {

--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -1114,6 +1114,7 @@ void insertFormalTemps(FnSymbol* fn) {
 }
 
 // Returns true if the formal needs an internal temporary, false otherwise.
+// See also ArgSymbol::requiresCPtr
 bool formalRequiresTemp(ArgSymbol* formal, FnSymbol* fn) {
   return
     //
@@ -1132,7 +1133,7 @@ bool formalRequiresTemp(ArgSymbol* formal, FnSymbol* fn) {
       (backendRequiresCopyForIn(formal->type) ||
        fn->hasFlag(FLAG_INLINE) ||
        fn->hasFlag(FLAG_ITERATOR_FN)))
-     );
+    );
 }
 
 //
@@ -1141,7 +1142,7 @@ bool formalRequiresTemp(ArgSymbol* formal, FnSymbol* fn) {
 // passing an argument of type 't'.
 //
 static bool backendRequiresCopyForIn(Type* t) {
-  return isRecord(t)                     == true ||
+  return (isRecord(t) == true && !t->symbol->hasFlag(FLAG_RANGE)) ||
          isUnion(t)                      == true ||
          t->symbol->hasFlag(FLAG_ARRAY)  == true ||
          t->symbol->hasFlag(FLAG_DOMAIN) == true;

--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -2064,7 +2064,7 @@ proc _cast(type t, r: range(?)) where isRangeType(t) {
 
   // Write implementation for ranges
   pragma "no doc"
-  proc range.readWriteThis(f)
+  proc range.writeThis(f)
   {
     // a range with a more normalized alignment
     // a separate variable so 'this' can be const
@@ -2083,29 +2083,39 @@ proc _cast(type t, r: range(?)) where isRangeType(t) {
 
     // Write out the alignment only if it differs from natural alignment.
     // We take alignment modulo the stride for consistency.
-    if f.writing {
-      if ! alignCheckRange.isNaturallyAligned() && aligned then
-        f <~> new ioLiteral(" align ") <~> chpl__mod(alignment, stride);
-    } else {
-      // try reading an 'align'
-      if !f.error() {
-        f <~> new ioLiteral(" align ");
-        if f.error() == EFORMAT then {
-          // naturally aligned.
-          f.clearError();
+    if ! alignCheckRange.isNaturallyAligned() && aligned then
+      f <~> new ioLiteral(" align ") <~> chpl__mod(alignment, stride);
+  }
+  pragma "no doc"
+  proc ref range.readThis(f)
+  {
+    if hasLowBound() then
+      f <~> _low;
+    f <~> new ioLiteral("..");
+    if hasHighBound() then
+      f <~> _high;
+    if stride != 1 then
+      f <~> new ioLiteral(" by ") <~> stride;
+
+    // try reading an 'align'
+    if !f.error() {
+      f <~> new ioLiteral(" align ");
+      if f.error() == EFORMAT then {
+        // naturally aligned.
+        f.clearError();
+      } else {
+        if stridable {
+          // un-naturally aligned - read the un-natural alignment
+          var a: idxType;
+          f <~> a;
+          _alignment = a;
         } else {
-          if stridable {
-            // un-naturally aligned - read the un-natural alignment
-            var a: idxType;
-            f <~> a;
-            _alignment = a;
-          } else {
-            halt("Trying to read an aligned range value into a non-stridable array");
-          }
+          halt("Trying to read an aligned range value into a non-stridable array");
         }
       }
     }
   }
+
 
   //################################################################################
   //# Internal helper functions.

--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -675,7 +675,7 @@ proc _cast(type t, r: range(?)) where isRangeType(t) {
 
   // Moves the low bound of the range up to the next alignment point.
   pragma "no doc"
-  /* private */ proc range.alignLow()
+  /* private */ proc ref range.alignLow()
   {
     if this.isAmbiguous() then
       __primitive("chpl_error", c"alignLow -- Cannot be applied to a range with ambiguous alignment.");
@@ -686,7 +686,7 @@ proc _cast(type t, r: range(?)) where isRangeType(t) {
 
   // Moves the high bound of the range down to the next alignment point.
   pragma "no doc"
-  /* private */ proc range.alignHigh()
+  /* private */ proc ref range.alignHigh()
   {
     if this.isAmbiguous() then
       __primitive("chpl_error", c"alignHigh -- Cannot be applied to a range with ambiguous alignment.");

--- a/test/studies/amr/advection/amr/AMR_AdvectionCTU_driver.prediff
+++ b/test/studies/amr/advection/amr/AMR_AdvectionCTU_driver.prediff
@@ -1,7 +1,11 @@
 #!/bin/bash --norc
 
-# could save the actual program output, e.g.: mv "$2" "$2".tmp
-mv "$2" "$2".save
+if [[ "$2" != *".comp.out.tmp" ]]
+then
 
-# the following overwrites "$2" with "ok" or error message(s)
-exec python ../../lib/python/regression_test.py "$2"
+  # could save the actual program output, e.g.: mv "$2" "$2".tmp
+  mv "$2" "$2".save
+
+  # the following overwrites "$2" with "ok" or error message(s)
+  exec python ../../lib/python/regression_test.py "$2"
+fi

--- a/test/studies/amr/lib/amr/BergerRigoutsosClustering.chpl
+++ b/test/studies/amr/lib/amr/BergerRigoutsosClustering.chpl
@@ -237,7 +237,8 @@ proc CandidateDomain.trim()
       //---- Approximately center the enlarged range ----
       
       var n_overflow_low = (min_width(d) - R.length) / 2;
-      R = ((trim_low - n_overflow_low*stride .. by stride) #min_width(d)).alignHigh();
+      var tmp = ((trim_low - n_overflow_low*stride .. by stride) #min_width(d));
+      R = tmp.alignHigh();
 
 
       //---- Enforce bounds of D ----

--- a/test/studies/amr/lib/grid/Grid_def.chpl
+++ b/test/studies/amr/lib/grid/Grid_def.chpl
@@ -112,14 +112,17 @@ class Grid {
     for loc in (loc1d.below:int .. loc1d.above by 2)**dimension {
       if loc != inner_location {
         for d in dimensions {
-          if loc(d) == loc1d.below then 
-            ranges(d) = ((extended_cells.low(d).. by 2) #n_ghost_cells(d)).alignHigh();
-          else if loc(d) == loc1d.inner then
+          if loc(d) == loc1d.below {
+            var tmp = ((extended_cells.low(d).. by 2) #n_ghost_cells(d));
+            ranges(d) = tmp.alignHigh();
+          } else if loc(d) == loc1d.inner {
             ranges(d) = cells.dim(d);
-          else
+          } else {
             // ((..extended_cells.high(d) by 2) #-n_ghost_cells(d)).alignLow();
             // hilde sez: Mathematical precision meets ease of use
-            ranges(d) = ((..extended_cells.high(d) by 2 align extended_cells.high(d)) #-n_ghost_cells(d)).alignLow();
+            var tmp = ((..extended_cells.high(d) by 2 align extended_cells.high(d)) #-n_ghost_cells(d));
+            ranges(d) = tmp.alignLow();
+          }
         }
         ghost_domain = ranges;
         ghost_domains.add(ghost_domain);

--- a/test/studies/amr/lib/python/regression_test.py
+++ b/test/studies/amr/lib/python/regression_test.py
@@ -87,8 +87,13 @@ def approximateDiff(file_name_1, file_name_2, tolerance):
 # The name of this script is sys.argv[0].  The name of the
 # output file should follow immediately.
 #----------------------------------------------------------
-output_file = open(sys.argv[1], 'w')
+output_file_name = sys.argv[1]
 
+output_file = open(output_file_name, 'w')
+if output_file_name.endswith(".comp.out.tmp"):
+    output_file.write("Compilation failed!\n");
+    output_file.close()
+    exit(0)
 
 #==== Tolerance for approximate diff-ing ====
 tolerance = 1e-4

--- a/test/types/range/elliot/anonymousRangeIter.chpl
+++ b/test/types/range/elliot/anonymousRangeIter.chpl
@@ -16,6 +16,5 @@ proc main() {
   for i in 2..#4 do write(i); writeln();
   for (i, j) in zip(1..10 by 3, 1..10 by -3) do write(i,j); writeln();
   var r = 1..10 by 2; for (i, j) in zip(1..10 by 2, r) do write(i, j); writeln();
-  coforall i in 5..5 do write(i); writeln();
   writeln();
 }

--- a/test/types/range/elliot/anonymousRangeIter.expectedGenCode
+++ b/test/types/range/elliot/anonymousRangeIter.expectedGenCode
@@ -13,7 +13,7 @@
 # loops to change.
 
 # for i in 1..2 do write(i); writeln();
-ic__F#_high_chpl = INT#(#);
+_ic__F#_high_chpl = INT#(#);
 for (i_chpl = INT#(#); ((i_chpl <= _ic__F#_high_chpl)); i_chpl += INT#(#)) {
 
 # for i in 2..2+1 do write(i); writeln();
@@ -29,16 +29,12 @@ _ic__F#_high_chpl# = INT#(#);
 for (i_chpl# = INT#(#); ((i_chpl# <= _ic__F#_high_chpl#)); i_chpl# += INT#(#)) {
 
 # for i in 2..#4 do write(i); writeln();
-_ic__F#_high_chpl# = INT#(#);
-for (i_chpl# = INT#(#); ((i_chpl# <= _ic__F#_high_chpl#)); i_chpl# += INT#(#)) {
+_ic__F#_high_chpl# = ret_x#_chpl;
+for (i_chpl# = ret_x#_chpl; ((i_chpl# <= _ic__F#_high_chpl#)); i_chpl# += INT#(#)) {
 
 # for (i, j) in zip(1..10 by 3, 1..10 by -3) do write(i,j); writeln();
-_ic__F#_high_chpl# = INT#(#);
+_ic__F#_i_chpl = INT#(#);
 for (_ic__F#_i_chpl = INT#(#),_ic__F#_i_chpl# = INT#(#); (tmp_chpl = (_ic__F#_i_chpl <= INT#(#)),tmp_chpl); tmp_chpl# = _ic__F#_i_chpl,tmp_chpl# += INT#(#),_ic__F#_i_chpl = tmp_chpl#,tmp_chpl# = _ic__F#_i_chpl#,tmp_chpl# += INT#(-#),_ic__F#_i_chpl# = tmp_chpl#) {
 
 # var r = 1..10 by 2; for (i, j) in zip(1..10 by 2, r) do write(i, j); writeln();
 for (_ic__F#_i_chpl# = INT#(#),_ic__value_chpl = ret_chpl; (tmp_chpl# = (_ic__F#_i_chpl# <= _ic__F#_high_chpl#),tmp_chpl#); tmp_chpl# = _ic__F#_i_chpl#,tmp_chpl# += INT#(#),_ic__F#_i_chpl# = tmp_chpl#,tmp_chpl# = _ic__value_chpl,tmp_chpl# += ret_chpl#,_ic__value_chpl = tmp_chpl#) {
-
-# coforall i in 5..5 do write(i); writeln();
-_ic__F#_high_chpl# = INT#(#);
-for (i_chpl# = INT#(#); ((i_chpl# <= _ic__F#_high_chpl#)); i_chpl# += INT#(#)) {

--- a/test/types/range/elliot/anonymousRangeIter.expectedGenCode
+++ b/test/types/range/elliot/anonymousRangeIter.expectedGenCode
@@ -37,7 +37,7 @@ _ic__F#_high_chpl# = INT#(#);
 for (_ic__F#_i_chpl = INT#(#),_ic__F#_i_chpl# = INT#(#); (tmp_chpl = (_ic__F#_i_chpl <= INT#(#)),tmp_chpl); tmp_chpl# = _ic__F#_i_chpl,tmp_chpl# += INT#(#),_ic__F#_i_chpl = tmp_chpl#,tmp_chpl# = _ic__F#_i_chpl#,tmp_chpl# += INT#(-#),_ic__F#_i_chpl# = tmp_chpl#) {
 
 # var r = 1..10 by 2; for (i, j) in zip(1..10 by 2, r) do write(i, j); writeln();
-for (_ic__F#_i_chpl# = INT64(1),_ic__value_chpl = ret_chpl; (tmp_chpl# = (_ic__F#_i_chpl# <= _ic__F#_high_chpl#),tmp_chpl#); tmp_chpl# = _ic__F#_i_chpl#,tmp_chpl# += INT64(2),_ic__F#_i_chpl# = tmp_chpl#,tmp_chpl# = _ic__value_chpl,tmp_chpl# += (&r_chpl)->_stride,_ic__value_chpl = tmp_chpl#) {
+for (_ic__F#_i_chpl# = INT#(#),_ic__value_chpl = ret_chpl; (tmp_chpl# = (_ic__F#_i_chpl# <= _ic__F#_high_chpl#),tmp_chpl#); tmp_chpl# = _ic__F#_i_chpl#,tmp_chpl# += INT#(#),_ic__F#_i_chpl# = tmp_chpl#,tmp_chpl# = _ic__value_chpl,tmp_chpl# += ret_chpl#,_ic__value_chpl = tmp_chpl#) {
 
 # coforall i in 5..5 do write(i); writeln();
 _ic__F#_high_chpl# = INT#(#);

--- a/test/types/range/elliot/anonymousRangeIter.good
+++ b/test/types/range/elliot/anonymousRangeIter.good
@@ -5,10 +5,7 @@
 2345
 1104774101
 1133557799
-5
 
-Found expected line
-Found expected line
 Found expected line
 Found expected line
 Found expected line

--- a/test/types/range/elliot/anonymousRangeIter.good
+++ b/test/types/range/elliot/anonymousRangeIter.good
@@ -18,4 +18,5 @@ Found expected line
 Found expected line
 Found expected line
 Found expected line
+Found build range
 Found expected line

--- a/test/types/range/elliot/anonymousRangeIter.prediff
+++ b/test/types/range/elliot/anonymousRangeIter.prediff
@@ -39,6 +39,10 @@ with open (testOutputFile, 'a') as f:
         while index < nActualLines:
             actualLine = actualLines[index]
             index += 1;
+
+            if re.search(r'build[a-zA-Z_]*range', actualLine):
+              f.write('Found build range\n')
+
             if expectedLine == actualLine:
               found = True
               break

--- a/test/types/range/elliot/anonymousRangeIter.prediff
+++ b/test/types/range/elliot/anonymousRangeIter.prediff
@@ -13,11 +13,15 @@ def normalize(ln):
 # open the expected generated code, and grab all the non-empty and non-comment
 # lines
 expectedGeneratedCodeLines = []
+fromLineNumbers = []
 with open(expectedGenCodeFile, 'r') as f:
+    linenum = 0;
     for line in f:
         line = line.rstrip()
+        linenum += 1
         if line != '' and line.startswith('#') == False:
            expectedGeneratedCodeLines.append(normalize(line))
+           fromLineNumbers.append(linenum)
 
 # grab the actual generated code
 with open (actualGenCodeFile) as f:
@@ -25,11 +29,11 @@ with open (actualGenCodeFile) as f:
 
 # add whether the line was found or not to test output
 with open (testOutputFile, 'a') as f:
-    for line in expectedGeneratedCodeLines:
+    for line,linenum in zip(expectedGeneratedCodeLines, fromLineNumbers):
         if line in actualGeneratedCode:
             f.write('Found expected line\n')
         else:
-            f.write('{0} is missing line: {1}\n'.format(actualGenCodeFile, line))
+            f.write('{0} is missing line {1}: {2}\n'.format(actualGenCodeFile, linenum, line))
 
 
 shutil.rmtree(genCodeDir)

--- a/test/types/range/elliot/anonymousRangeIter.prediff
+++ b/test/types/range/elliot/anonymousRangeIter.prediff
@@ -8,7 +8,8 @@ actualGenCodeFile = os.path.join(genCodeDir, sys.argv[1]+'.c')
 testOutputFile = sys.argv[2]
 
 def normalize(ln):
-  return re.sub(r'[0-9]+', '#', ln)
+  ret = re.sub(r'[0-9]+', '#', ln)
+  return ret.strip()
 
 # open the expected generated code, and grab all the non-empty and non-comment
 # lines
@@ -24,16 +25,30 @@ with open(expectedGenCodeFile, 'r') as f:
            fromLineNumbers.append(linenum)
 
 # grab the actual generated code
+actualLines = []
 with open (actualGenCodeFile) as f:
-    actualGeneratedCode = normalize(f.read())
+    actualLines = [normalize(i) for i in f.readlines()]
 
 # add whether the line was found or not to test output
 with open (testOutputFile, 'a') as f:
-    for line,linenum in zip(expectedGeneratedCodeLines, fromLineNumbers):
-        if line in actualGeneratedCode:
+    index = 0
+    nActualLines = len(actualLines)
+    for expectedLine,linenum in zip(expectedGeneratedCodeLines, fromLineNumbers):
+        found = False
+        startindex = index
+        while index < nActualLines:
+            actualLine = actualLines[index]
+            index += 1;
+            if expectedLine == actualLine:
+              found = True
+              break
+
+        if found:
             f.write('Found expected line\n')
         else:
-            f.write('{0} is missing line {1}: {2}\n'.format(actualGenCodeFile, linenum, line))
+            f.write('{0} is missing line {1}: {2}'.format(actualGenCodeFile, linenum, expectedLine))
+            f.write('(started searching on line {0} in the generated code)\n'.format(startindex+1))
+            break
 
 
 shutil.rmtree(genCodeDir)

--- a/test/types/range/ferguson/range-intents.chpl
+++ b/test/types/range/ferguson/range-intents.chpl
@@ -84,6 +84,9 @@ proc const int.test_const_this() {
 global = start;
 global.test_const_this();
 
+// We don't support 'in' or 'const in' as 'this' intents.
+// If we did, I'd want these functions uncommented to test it.
+
 /*proc in range.test_in_this() {
   global = change;
   writeln("in this ", upper(this));

--- a/test/types/range/ferguson/range-intents.chpl
+++ b/test/types/range/ferguson/range-intents.chpl
@@ -1,107 +1,184 @@
-var global = 1..10;
+// This test runs a series of test methods to verify
+// that range behaves similarly to int as far as
+// argument intents are concerned.
 
-writeln("1..10 means a copy was made; 1..20 means some sort of ref");
+config param testrange = true;
+
+proc make(x:int) {
+  if testrange then
+    return 1..x;
+  else
+    return x;
+}
+proc upper(x) { return x.high; }
+proc upper(x:int) { return x; }
+
+var start = make(10);
+var change = make(20);
+
+writeln(upper(start), " means a copy was made; ", upper(change), " means some sort of ref");
+
+var global = start;
 
 proc test_blank( arg ) {
-  global = 1..20;
-  writeln("default ", arg);
+  global = change;
+  writeln("default ", upper(arg));
 }
-global = 1..10;
+global = start;
 test_blank(global);
 
 proc test_const( const arg ) {
-  global = 1..20;
-  writeln("const ", arg);
+  global = change;
+  writeln("const ", upper(arg));
 }
-global = 1..10;
+global = start;
 test_const(global);
 
-proc test_const_in( const in arg ) {
-  global = 1..20;
-  writeln("const in ", arg);
+proc test_in( in arg ) {
+  global = change;
+  writeln("in ", upper(arg));
 }
-global = 1..10;
+global = start;
+test_in(global);
+
+proc test_const_in( const in arg ) {
+  global = change;
+  writeln("const in ", upper(arg));
+}
+global = start;
 test_const_in(global);
 
 proc test_const_ref( const ref arg ) {
-  global = 1..20;
-  writeln("const ref ", arg);
+  global = change;
+  writeln("const ref ", upper(arg));
 }
-global = 1..10;
+global = start;
 test_const_ref(global);
 
 proc test_ref( ref arg ) {
-  global = 1..20;
-  writeln("ref ", arg);
+  global = change;
+  writeln("ref ", upper(arg));
 }
-global = 1..10;
+global = start;
 test_ref(global);
 
 proc range.test_this() {
-  global = 1..20;
-  writeln("this ", this);
+  global = change;
+  writeln("this ", upper(this));
 }
-global = 1..10;
+proc int.test_this() {
+  global = change;
+  writeln("this ", upper(this));
+}
+global = start;
 global.test_this();
 
 proc const range.test_const_this() {
-  global = 1..20;
-  writeln("const this ", this);
+  global = change;
+  writeln("const this ", upper(this));
 }
-global = 1..10;
+proc const int.test_const_this() {
+  global = change;
+  writeln("const this ", upper(this));
+}
+global = start;
 global.test_const_this();
+
+/*proc in range.test_in_this() {
+  global = change;
+  writeln("in this ", upper(this));
+}
+proc in int.test_in_this() {
+  global = change;
+  writeln("in this ", upper(this));
+}
+global = start;
+global.test_in_this();
+*/
+/*proc const in range.test_const_in_this() {
+  global = change;
+  writeln("const in this ", upper(this));
+}
+proc const in int.test_const_in_this() {
+  global = change;
+  writeln("const in this ", upper(this));
+}
+global = start;
+global.test_const_in_this();
+*/
+proc const ref range.test_const_ref_this() {
+  global = change;
+  writeln("const ref this ", upper(this));
+}
+proc const ref int.test_const_ref_this() {
+  global = change;
+  writeln("const ref this ", upper(this));
+}
+global = start;
+global.test_const_ref_this();
+
+proc ref range.test_ref_this() {
+  global = change;
+  writeln("ref this ", upper(this));
+}
+proc ref int.test_ref_this() {
+  global = change;
+  writeln("ref this ", upper(this));
+}
+global = start;
+global.test_ref_this();
 
 proc test_begin(const ref loc) {
   sync {
     begin with (ref global) {
-      global = 1..20;
-      writeln("begin ", loc);
+      global = change;
+      writeln("begin ", upper(loc));
     }
   }
 }
-global = 1..10;
+global = start;
 test_begin(global);
 
 proc test_begin_in(const ref loc) {
   sync {
     begin with (ref global, in loc) {
-      global = 1..20;
-      writeln("begin in ", loc);
+      global = change;
+      writeln("begin in ", upper(loc));
     }
   }
 }
-global = 1..10;
+global = start;
 test_begin_in(global);
 
 proc test_begin_const_in(const ref loc) {
   sync {
     begin with (ref global, const in loc) {
-      global = 1..20;
-      writeln("begin const in ", loc);
+      global = change;
+      writeln("begin const in ", upper(loc));
     }
   }
 }
-global = 1..10;
+global = start;
 test_begin_const_in(global);
 
 proc test_begin_ref(const ref loc) {
   sync {
     begin with (ref global, ref loc) {
-      global = 1..20;
-      writeln("begin ref ", loc);
+      global = change;
+      writeln("begin ref ", upper(loc));
     }
   }
 }
-global = 1..10;
+global = start;
 test_begin_ref(global);
 
 proc test_begin_const_ref(const ref loc) {
   sync {
     begin with (ref global, const ref loc) {
-      global = 1..20;
-      writeln("begin const ref ", loc);
+      global = change;
+      writeln("begin const ref ", upper(loc));
     }
   }
 }
-global = 1..10;
+global = start;
 test_begin_const_ref(global);

--- a/test/types/range/ferguson/range-intents.chpl
+++ b/test/types/range/ferguson/range-intents.chpl
@@ -1,0 +1,93 @@
+var global = 1..10;
+
+writeln("1..10 means a copy was made; 1..20 means some sort of ref");
+
+proc test_blank( arg ) {
+  global = 1..20;
+  writeln("default ", arg);
+}
+global = 1..10;
+test_blank(global);
+
+proc test_const( const arg ) {
+  global = 1..20;
+  writeln("const ", arg);
+}
+global = 1..10;
+test_const(global);
+
+proc test_const_in( const in arg ) {
+  global = 1..20;
+  writeln("const in ", arg);
+}
+global = 1..10;
+test_const_in(global);
+
+proc test_const_ref( const ref arg ) {
+  global = 1..20;
+  writeln("const ref ", arg);
+}
+global = 1..10;
+test_const_ref(global);
+
+proc test_ref( ref arg ) {
+  global = 1..20;
+  writeln("ref ", arg);
+}
+global = 1..10;
+test_ref(global);
+
+proc test_begin(const ref loc) {
+  sync {
+    begin with (ref global) {
+      global = 1..20;
+      writeln("begin ", loc);
+    }
+  }
+}
+global = 1..10;
+test_begin(global);
+
+proc test_begin_in(const ref loc) {
+  sync {
+    begin with (ref global, in loc) {
+      global = 1..20;
+      writeln("begin in ", loc);
+    }
+  }
+}
+global = 1..10;
+test_begin_in(global);
+
+proc test_begin_const_in(const ref loc) {
+  sync {
+    begin with (ref global, const in loc) {
+      global = 1..20;
+      writeln("begin const in ", loc);
+    }
+  }
+}
+global = 1..10;
+test_begin_const_in(global);
+
+proc test_begin_ref(const ref loc) {
+  sync {
+    begin with (ref global, ref loc) {
+      global = 1..20;
+      writeln("begin ref ", loc);
+    }
+  }
+}
+global = 1..10;
+test_begin_ref(global);
+
+proc test_begin_const_ref(const ref loc) {
+  sync {
+    begin with (ref global, const ref loc) {
+      global = 1..20;
+      writeln("begin const ref ", loc);
+    }
+  }
+}
+global = 1..10;
+test_begin_const_ref(global);

--- a/test/types/range/ferguson/range-intents.chpl
+++ b/test/types/range/ferguson/range-intents.chpl
@@ -37,6 +37,20 @@ proc test_ref( ref arg ) {
 global = 1..10;
 test_ref(global);
 
+proc range.test_this() {
+  global = 1..20;
+  writeln("this ", this);
+}
+global = 1..10;
+global.test_this();
+
+proc const range.test_const_this() {
+  global = 1..20;
+  writeln("const this ", this);
+}
+global = 1..10;
+global.test_const_this();
+
 proc test_begin(const ref loc) {
   sync {
     begin with (ref global) {

--- a/test/types/range/ferguson/range-intents.compopts
+++ b/test/types/range/ferguson/range-intents.compopts
@@ -1,0 +1,2 @@
+-stestrange=false
+-stestrange=true

--- a/test/types/range/ferguson/range-intents.good
+++ b/test/types/range/ferguson/range-intents.good
@@ -1,13 +1,16 @@
-1..10 means a copy was made; 1..20 means some sort of ref
-default 1..10
-const 1..10
-const in 1..10
-const ref 1..20
-ref 1..20
-this 1..20
-const this 1..20
-begin 1..10
-begin in 1..10
-begin const in 1..10
-begin ref 1..20
-begin const ref 1..20
+10 means a copy was made; 20 means some sort of ref
+default 10
+const 10
+in 10
+const in 10
+const ref 20
+ref 20
+this 10
+const this 10
+const ref this 20
+ref this 20
+begin 10
+begin in 10
+begin const in 10
+begin ref 20
+begin const ref 20

--- a/test/types/range/ferguson/range-intents.good
+++ b/test/types/range/ferguson/range-intents.good
@@ -1,0 +1,11 @@
+1..10 means a copy was made; 1..20 means some sort of ref
+default 1..10
+const 1..10
+const in 1..10
+const ref 1..20
+ref 1..20
+begin 1..10
+begin in 1..10
+begin const in 1..10
+begin ref 1..20
+begin const ref 1..20

--- a/test/types/range/ferguson/range-intents.good
+++ b/test/types/range/ferguson/range-intents.good
@@ -4,6 +4,8 @@ const 1..10
 const in 1..10
 const ref 1..20
 ref 1..20
+this 1..20
+const this 1..20
 begin 1..10
 begin in 1..10
 begin const in 1..10


### PR DESCRIPTION
This PR adjusts the compiler to make range have similar intents to int. The main difference is `const in` vs `const ref` by default.

Resolves #5256.

Passed full local testing and full gasnet testing.

Reviewed by @benharsh - thanks!