### PR TITLE
Allow Chapel to compile on an ARM-based Cray system

### DIFF
--- a/third-party/gmp/Makefile
+++ b/third-party/gmp/Makefile
@@ -10,7 +10,7 @@ include $(CHPL_MAKE_HOME)/make/Makefile.base
 #
 GMP_CROSS_COMPILED=no
 ifneq (, $(filter cray-x%,$(CHPL_MAKE_TARGET_PLATFORM)))
-CHPL_GMP_CFG_OPTIONS += --host=$(HOSTTYPE)-cle-linux-gnu
+CHPL_GMP_CFG_OPTIONS += --host=$(shell uname -m)-cle-linux-gnu
 GMP_CROSS_COMPILED=yes
 else ifneq ($(CHPL_MAKE_HOST_PLATFORM),$(CHPL_MAKE_TARGET_PLATFORM))
 CHPL_GMP_CFG_OPTIONS += --host=$(CHPL_MAKE_TARGET_PLATFORM)-unknown-linux-gnu

--- a/third-party/gmp/Makefile
+++ b/third-party/gmp/Makefile
@@ -10,7 +10,7 @@ include $(CHPL_MAKE_HOME)/make/Makefile.base
 #
 GMP_CROSS_COMPILED=no
 ifneq (, $(filter cray-x%,$(CHPL_MAKE_TARGET_PLATFORM)))
-CHPL_GMP_CFG_OPTIONS += --host=x86_64-cle-linux-gnu
+CHPL_GMP_CFG_OPTIONS += --host=$(HOSTTYPE)-cle-linux-gnu
 GMP_CROSS_COMPILED=yes
 else ifneq ($(CHPL_MAKE_HOST_PLATFORM),$(CHPL_MAKE_TARGET_PLATFORM))
 CHPL_GMP_CFG_OPTIONS += --host=$(CHPL_MAKE_TARGET_PLATFORM)-unknown-linux-gnu

--- a/third-party/hwloc/Makefile
+++ b/third-party/hwloc/Makefile
@@ -9,7 +9,7 @@ include $(CHPL_MAKE_HOME)/make/Makefile.base
 # Cray X* builds are cross-compilations.
 #
 ifneq (, $(filter cray-x%,$(CHPL_MAKE_TARGET_PLATFORM)))
-CHPL_HWLOC_CFG_OPTIONS += --host=$(HOSTTYPE)-cle-linux-gnu
+CHPL_HWLOC_CFG_OPTIONS += --host=$(shell uname -m)-cle-linux-gnu
 else ifneq ($(CHPL_MAKE_HOST_PLATFORM),$(CHPL_MAKE_TARGET_PLATFORM))
 CHPL_HWLOC_CFG_OPTIONS += --host=$(CHPL_MAKE_TARGET_PLATFORM)-unknown-linux-gnu
 endif

--- a/third-party/hwloc/Makefile
+++ b/third-party/hwloc/Makefile
@@ -9,7 +9,7 @@ include $(CHPL_MAKE_HOME)/make/Makefile.base
 # Cray X* builds are cross-compilations.
 #
 ifneq (, $(filter cray-x%,$(CHPL_MAKE_TARGET_PLATFORM)))
-CHPL_HWLOC_CFG_OPTIONS += --host=x86_64-cle-linux-gnu
+CHPL_HWLOC_CFG_OPTIONS += --host=$(HOSTTYPE)-cle-linux-gnu
 else ifneq ($(CHPL_MAKE_HOST_PLATFORM),$(CHPL_MAKE_TARGET_PLATFORM))
 CHPL_HWLOC_CFG_OPTIONS += --host=$(CHPL_MAKE_TARGET_PLATFORM)-unknown-linux-gnu
 endif

--- a/third-party/jemalloc/Makefile
+++ b/third-party/jemalloc/Makefile
@@ -9,7 +9,7 @@ include $(CHPL_MAKE_HOME)/make/Makefile.base
 # Cray X* builds are cross-compilations.
 #
 ifneq (, $(filter cray-x%,$(CHPL_MAKE_TARGET_PLATFORM)))
-CHPL_JEMALLOC_CFG_OPTIONS += --host=x86_64-cle-linux-gnu
+CHPL_JEMALLOC_CFG_OPTIONS += --host=$(HOSTTYPE)-cle-linux-gnu
 else ifneq ($(CHPL_MAKE_HOST_PLATFORM),$(CHPL_MAKE_TARGET_PLATFORM))
 CHPL_JEMALLOC_CFG_OPTIONS += --host=$(CHPL_MAKE_TARGET_PLATFORM)-unknown-linux-gnu
 endif

--- a/third-party/jemalloc/Makefile
+++ b/third-party/jemalloc/Makefile
@@ -9,7 +9,7 @@ include $(CHPL_MAKE_HOME)/make/Makefile.base
 # Cray X* builds are cross-compilations.
 #
 ifneq (, $(filter cray-x%,$(CHPL_MAKE_TARGET_PLATFORM)))
-CHPL_JEMALLOC_CFG_OPTIONS += --host=$(HOSTTYPE)-cle-linux-gnu
+CHPL_JEMALLOC_CFG_OPTIONS += --host=$(shell uname -m)-cle-linux-gnu
 else ifneq ($(CHPL_MAKE_HOST_PLATFORM),$(CHPL_MAKE_TARGET_PLATFORM))
 CHPL_JEMALLOC_CFG_OPTIONS += --host=$(CHPL_MAKE_TARGET_PLATFORM)-unknown-linux-gnu
 endif

--- a/third-party/massivethreads/Makefile
+++ b/third-party/massivethreads/Makefile
@@ -9,7 +9,7 @@ include $(CHPL_MAKE_HOME)/make/Makefile.base
 # Cray X* builds are cross-compilations.
 #
 ifneq (, $(filter cray-x%,$(CHPL_MAKE_TARGET_PLATFORM)))
-CHPL_MASSIVETHREADS_CFG_OPTIONS += --host=x86_64-cle-linux-gnu
+CHPL_MASSIVETHREADS_CFG_OPTIONS += --host=$(HOSTTYPE)-cle-linux-gnu
 else ifneq ($(CHPL_MAKE_HOST_PLATFORM),$(CHPL_MAKE_TARGET_PLATFORM))
 CHPL_MASSIVETHREADS_CFG_OPTIONS += --host=$(CHPL_MAKE_TARGET_PLATFORM)-unknown-linux-gnu
 endif

--- a/third-party/massivethreads/Makefile
+++ b/third-party/massivethreads/Makefile
@@ -9,7 +9,7 @@ include $(CHPL_MAKE_HOME)/make/Makefile.base
 # Cray X* builds are cross-compilations.
 #
 ifneq (, $(filter cray-x%,$(CHPL_MAKE_TARGET_PLATFORM)))
-CHPL_MASSIVETHREADS_CFG_OPTIONS += --host=$(HOSTTYPE)-cle-linux-gnu
+CHPL_MASSIVETHREADS_CFG_OPTIONS += --host=$(shell uname -m)-cle-linux-gnu
 else ifneq ($(CHPL_MAKE_HOST_PLATFORM),$(CHPL_MAKE_TARGET_PLATFORM))
 CHPL_MASSIVETHREADS_CFG_OPTIONS += --host=$(CHPL_MAKE_TARGET_PLATFORM)-unknown-linux-gnu
 endif

--- a/third-party/qthread/Makefile
+++ b/third-party/qthread/Makefile
@@ -19,7 +19,7 @@ QTHREAD_DIR = $(QTHREAD_ABS_DIR)
 # Cray X* builds are cross-compilations
 #
 ifneq (, $(filter cray-x%,$(CHPL_MAKE_TARGET_PLATFORM)))
-CHPL_QTHREAD_CFG_OPTIONS += --host=x86_64-cle-linux-gnu
+CHPL_QTHREAD_CFG_OPTIONS += --host=$(HOSTTYPE)-cle-linux-gnu
 else ifneq ($(CHPL_MAKE_HOST_PLATFORM),$(CHPL_MAKE_TARGET_PLATFORM))
 CHPL_QTHREAD_CFG_OPTIONS += --host=$(CHPL_MAKE_TARGET_PLATFORM)-unknown-linux-gnu
 endif

--- a/third-party/qthread/Makefile
+++ b/third-party/qthread/Makefile
@@ -19,7 +19,7 @@ QTHREAD_DIR = $(QTHREAD_ABS_DIR)
 # Cray X* builds are cross-compilations
 #
 ifneq (, $(filter cray-x%,$(CHPL_MAKE_TARGET_PLATFORM)))
-CHPL_QTHREAD_CFG_OPTIONS += --host=$(HOSTTYPE)-cle-linux-gnu
+CHPL_QTHREAD_CFG_OPTIONS += --host=$(shell uname -m)-cle-linux-gnu
 else ifneq ($(CHPL_MAKE_HOST_PLATFORM),$(CHPL_MAKE_TARGET_PLATFORM))
 CHPL_QTHREAD_CFG_OPTIONS += --host=$(CHPL_MAKE_TARGET_PLATFORM)-unknown-linux-gnu
 endif


### PR DESCRIPTION
Right now, third-party Cray builds are hard coded to x86_64.  This change lets them compile on whichever architecture is being used.

Note that `$HOSTTYPE` only provides the machine type in bash, and `/bin/arch` reports some x86_64 systems as i386.  `uname -m` works for Cray Intel, AMD, and ARM systems.

This change only affects systems that report as `cray-x`-something.

Test plan - hellos and studies/shootout/pidigits/pidigits-gmp.chpl on:
- [x] Intel-based Cray systems
- [x] ARM-based Cray systems
- [x] AMD-based Cray systems

Note that MassiveThreads gets far enough to complain about missing architectural features, but has not yet been ported to 64-bit ARM.