### PR TITLE
Fix control-C hangs in compiler on Mac OS X

### DIFF
--- a/compiler/util/misc.cpp
+++ b/compiler/util/misc.cpp
@@ -550,11 +550,17 @@ void considerExitingEndOfPass() {
 
 
 static void handleInterrupt(int sig) {
-  USR_FATAL("received interrupt");
+  stopCatchingSignals();
+  fprintf(stderr, "error: received interrupt\n");
+  fflush(stdout);
+  fflush(stderr);
+
+  clean_exit(1);
 }
 
 
 static void handleSegFault(int sig) {
+  stopCatchingSignals();
   INT_FATAL("seg fault");
 }
 
@@ -569,6 +575,8 @@ void startCatchingSignals() {
 
 void stopCatchingSignals() {
   signal(SIGINT,  SIG_DFL);
+  signal(SIGTERM, SIG_DFL);
+  signal(SIGHUP,  SIG_DFL);
   signal(SIGSEGV, SIG_DFL);
 }
 


### PR DESCRIPTION
We were seeing behavior where control-C would cause the Chapel compiler to
hang. I've only been able to reproduce this on Mac OS X (and not on Linux). I
had a theory that in the process of handling the control-c we ran into a core
dump and that caused the hang, somehow. In fact, on Mac OS X, adding a core
dump to setupError or clean_exit makes the issue easy to reproduce, and the
change below prevents it from hanging in these cases.

One reason why it only reproduced on OS X is that the `signal` C library call,
while simple, is not portable. For portability, we should be using `sigaction`
instead, but this PR doesn't try to do that.

This PR makes the following changes to improve upon the situation:

 * changes handleInterrupt to call fprintf to print out "error: received
   interrupt" instead of calling USR_FATAL. This limits the amount of code we
   run in the signal handler in that case.

 * calls stopCatchingSignals() as the first thing in each of the signal
   handlers. This prevents a core-dump encountered during signal handling from
   causing some kind of blocking situation.

 * adjusts stopCatchingSignals to restore default handlers for all 4 signals
   the compiler catches instead of just 2 of them.

- [x] full local testing

Reviewed by @benharsh - thanks!