### PR TITLE
Fix bad reference to `multilocale.rst` in runtime

### DIFF
--- a/runtime/src/comm/none/comm-none-locales.c
+++ b/runtime/src/comm/none/comm-none-locales.c
@@ -28,7 +28,7 @@ int64_t chpl_comm_default_num_locales(void) {
 void chpl_comm_verify_num_locales(int64_t proposedNumLocales) {
   if (proposedNumLocales != 1) {
     chpl_error("Only 1 locale may be used for CHPL_COMM layer 'none'\n"
-               "To use multiple locales, see $CHPL_HOME/doc/rst/multilocale.rst",
+               "To use multiple locales, see $CHPL_HOME/doc/rst/usingchapel/multilocale.rst",
                0, 0);
   }
 }


### PR DESCRIPTION
Update path to `multilocale.rst` in runtime error message.

Closes #8385