### PR TITLE
User programs can build with CHPL_COMM=ofi

### DIFF
--- a/make/compiler/Makefile.cray-prgenv
+++ b/make/compiler/Makefile.cray-prgenv
@@ -47,8 +47,8 @@ LIB_STATIC_FLAG =
 LIB_DYNAMIC_FLAG = -shared
 
 #
-# Circumstances may push us to choose dynamic linking instead of the
-# PrgEnv default static linking.
+# Normally we let the PrgEnv compilers choose the linking mode, but in
+# some circumstances we push dynamic linking as the default.
 #
 ifneq ($(CHPL_MAKE_LOCALE_MODEL), flat)
 # With locale models other than 'flat' we will need libnuma.  That is
@@ -57,8 +57,8 @@ RUNTIME_LFLAGS += -dynamic
 else ifeq ($(CHPL_MAKE_COMM), ofi)
 # libfabric calls dlopen() and getaddrinfo().  With static linking, the
 # references to these cause link-time warnings that the corresponding
-# dynamic libraries will be required at execution time.  With dynamic
-# linking we avoid these warnings.
+# dynamic libraries will be required at execution time, so default to
+# dynamic linking to avoid these warnings.
 RUNTIME_LFLAGS += -dynamic
 endif
 

--- a/make/compiler/Makefile.cray-prgenv
+++ b/make/compiler/Makefile.cray-prgenv
@@ -46,10 +46,19 @@ GEN_DYNAMIC_FLAG = -dynamic
 LIB_STATIC_FLAG =
 LIB_DYNAMIC_FLAG = -shared
 
-# With locale models other than 'flat' we will need libnuma.  That is
-# so far available only in .so form, but the PrgEnv compilers default
-# to forcing static linking.  So, override them in this case.
+#
+# Circumstances may push us to choose dynamic linking instead of the
+# PrgEnv default static linking.
+#
 ifneq ($(CHPL_MAKE_LOCALE_MODEL), flat)
+# With locale models other than 'flat' we will need libnuma.  That is
+# so far available only in .so form, so override them in this case.
+RUNTIME_LFLAGS += -dynamic
+else ifeq ($(CHPL_MAKE_COMM), ofi)
+# libfabric calls dlopen() and getaddrinfo().  With static linking, the
+# references to these cause link-time warnings that the corresponding
+# dynamic libraries will be required at execution time.  With dynamic
+# linking we avoid these warnings.
 RUNTIME_LFLAGS += -dynamic
 endif
 

--- a/runtime/include/chpl-mem-desc.h
+++ b/runtime/include/chpl-mem-desc.h
@@ -48,6 +48,7 @@
   m(SET_WIDE_STRING,      "set wide string",                          true ), \
   m(GET_WIDE_STRING,      "get wide string",                          true ), \
   m(COMMAND_BUFFER,       "command buffer",                           true ), \
+  m(COMM_UTIL,            "comm layer utility space",                 false), \
   m(COMM_XMIT_RCV_BUF,    "comm layer transmit/receive buffer",       false), \
   m(COMM_FRK_SND_INFO,    "comm layer sent remote fork info",         false), \
   m(COMM_FRK_SND_ARG,     "comm layer sent remote fork arg",          false), \

--- a/runtime/src/comm/ofi/comm-ofi-am.c
+++ b/runtime/src/comm/ofi/comm-ofi-am.c
@@ -42,7 +42,7 @@
 #include "comm-ofi-internal.h"
 
 static struct ofi_stuff* ofi = NULL;
-void ofi_put_get_init(struct ofi_stuff* _ofi) {
+void ofi_am_init(struct ofi_stuff* _ofi) {
   if (ofi == NULL) {
     ofi = _ofi;
   } else {

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -237,18 +237,20 @@ static void libfabric_init() {
 
   hints->addr_format = FI_FORMAT_UNSPEC;
 
-  // memory layer hasn't been initialized, need to use the system allocator
-#include "chpl-mem-no-warning-macros.h"
-#ifdef CHPL_COMM_SUBSTRATE_SOCKETS
-  hints->fabric_attr->prov_name = "sockets";
-#else
-#ifdef CHPL_COMM_SUBSTRATE_GNI
+#if defined(CHPL_COMM_SUBSTRATE_SOCKETS)
+  {
+    const char s[] = "sockets";
+    char* sDup = chpl_mem_alloc(sizeof(s),
+                                CHPL_RT_MD_COMM_UTIL,
+                                0, 0);
+    strcpy(sDup, s);
+    hints->fabric_attr->prov_name = sDup;
+  }
+#elif defined(CHPL_COMM_SUBSTRATE_GNI)
 #error "Substrate GNI not supported"
 #else
 #error "Substrate type not supported"
 #endif
-#endif
-#include "chpl-mem-warning-macros.h"
 
   /* connectionless reliable */
   hints->ep_attr->type = FI_EP_RDM;

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -454,13 +454,6 @@ void chpl_comm_rollcall(void) {
            chpl_numNodes, chpl_nodeName());
 }
 
-void chpl_comm_desired_shared_heap(void** start_p, size_t* size_p) {
-  // Use of FI_MR_SCALABLE could cover entire address space
-
-  *start_p = NULL;
-  *size_p  = 0;
-}
-
 void chpl_comm_broadcast_global_vars(int numGlobals) {
 #ifdef CHPL_TARGET_PLATFORM_CRAY_XC
   // Use PMI_AllGather


### PR DESCRIPTION
Make some relatively minor changes to allow the runtime and user programs to build with CHPL_COMM=ofi:
- Remove includes of the now-nonexistent memory warning macros include files, and recode where those were needed.
- For now, use the default of no registered shared heap.
- Fix a misnamed function definition.
- With Cray PrgEnv target compilers, default to dynamic linking to avoid a couple of link-time warnings.
