### PR TITLE
Add 'top' information for compiler timeouts

### DIFF
--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -1453,6 +1453,8 @@ for testname in testsrc:
                                  (futuretest, localdir, test_filename))
                 printTestVariation(compoptsnum, compoptslist);
                 sys.stdout.write(']\n')
+                sys.stdout.write('[Compilation output was as follows:]\n')
+                sys.stdout.write(trim_output(output))
                 cleanup(execname)
                 cleanup(printpassesfile)
                 continue # on to next compopts


### PR DESCRIPTION
This simple change permits 'timedexec's output (which includes the top
processes running) to be printed in the event of a compilation timeout.
Previously we didn't print anything in this case beyond the fact that
the timeout had occurred.