### PR TITLE
Fix two misspellings of "parentheses" in the spec

### DIFF
--- a/spec/Arrays.tex
+++ b/spec/Arrays.tex
@@ -251,7 +251,7 @@ and control the runtime representation of an array's elements.  See
 
 Arrays can be indexed using index values from the domain over which
 they are declared.  Array indexing is expressed using either
-parenthesis or square brackets.  This results in a reference to the
+parentheses or square brackets.  This results in a reference to the
 element that corresponds to the index value.
 
 % NEED SYNTAX DIAGRAM HERE?

--- a/spec/Expressions.tex
+++ b/spec/Expressions.tex
@@ -461,7 +461,7 @@ This choice also has the (arguably positive) effect of making the
 unparenthesized version of this statement result in an aggregate value
 if A and B are both aggregates---the reduction of A results in a
 scalar which promotes when being multiplied by B, resulting in an
-aggregate.  Our intuition is that users who forget the parenthesis
+aggregate.  Our intuition is that users who forget the parentheses
 will learn of their error at compilation time because the resulting
 expression is not a scalar as expected.
 


### PR DESCRIPTION
The word "parentheses" was spelled "parenthesis" at two locations where the
'e' spelling was really correct.  Fix them.