### PR TITLE
Update paratest.chapcs for slurm 17

### DIFF
--- a/util/test/paratest.chapcs
+++ b/util/test/paratest.chapcs
@@ -53,11 +53,11 @@ def get_exclusive_nodes():
     Get the nodes reserved exclusively on the chapel partition. Returns tuple
     of (num_exclusive_nodes, exclusive_hostnames)
     """
-    # Grab the "SHARED;NODES;NODELIST;REQ_NODES" info for all jobs. For each
-    # exclusive (SHARED=no) job, track the nodes allocated/requested or the
-    # number of nodes requested if no specific nodes were allocated/requested.
-    # Also consider "draining" nodes as exclusively reserved since no other
-    # jobs will be able to run on them
+    # Grab "OVER_SUBSCRIBE;NODES;NODELIST;REQ_NODES" info for all jobs. For
+    # each non-shared (OVER_SUBSCRIBE!=YES) job, track the allocated/requested
+    # nodes or the number of nodes requested if no specific nodes were
+    # allocated/requested. Also consider "draining" nodes as exclusively
+    # reserved since no other jobs will be able to run on them
     squeue_cmd = ['squeue',
                   '--partition=chapel',
                   '--noheader',
@@ -68,15 +68,15 @@ def get_exclusive_nodes():
                  '--partition=chapel',
                  '--noheader',
                  '--responding',
-                 '--format="no;%D;%N;%N"',
+                 '--format="NO;%D;%N;%N"',
                  '--states=DRAINING']
     sinfo_out = run_command_wrapper(sinfo_cmd)
 
     num_exclusive_nodes = 0
     exclusive_hostnames = set()
     for line in squeue_out + sinfo_out:
-        shared, num_nodes, nodelist, req_nodes = line.split(';')
-        if shared == 'no':
+        oversub, num_nodes, nodelist, req_nodes = line.split(';')
+        if oversub.upper() != 'YES':
             nodes = nodelist or req_nodes
             if nodes:
                 exclusive_hostnames.update(expand_hostnames(nodes))
@@ -104,16 +104,16 @@ def get_num_non_exclusive_nodes():
     return num_non_exclusive_nodes
 
 
-def get_num_shared_jobs_running():
+def get_num_oversub_jobs():
     """
-    Get the number of shared jobs running on the chapel partition
+    Get the number of jobs that allow oversubscription (permit node sharing)
     """
     squeue_cmd = ['squeue',
                   '--partition=chapel',
                   '--noheader',
                   '--format="%h"']
-    squeue_out = run_command_wrapper(squeue_cmd)
-    return squeue_out.count('yes')
+    squeue_out = [s.upper() for s in run_command_wrapper(squeue_cmd)]
+    return squeue_out.count('YES')
 
 
 def get_good_nodepara():
@@ -126,7 +126,7 @@ def get_good_nodepara():
     nodepara = 3
     if chpl_comm.get() != 'none':
         nodepara = 2
-    if get_num_shared_jobs_running() == 0:
+    if get_num_oversub_jobs() == 0:
         nodepara += 1
     return nodepara
 
@@ -134,9 +134,9 @@ def get_good_nodepara():
 def run_paratest(args):
     """
     Run paratest inside an salloc using all nodes that are not reserved
-    exclusively on the chapel partition. Throw `--share --nice` and turn off
-    affinity and limit how many executables can run at once so we play nice
-    with other testing going on.
+    exclusively on the chapel partition. Throw `--oversubscribe --nice` and
+    turn off affinity and limit how many executables can run at once so we play
+    nice with other testing going on.
     """
     nodepara = get_good_nodepara()
     num_free_nodes = get_num_non_exclusive_nodes()
@@ -147,7 +147,7 @@ def run_paratest(args):
                   '--nodes={0}'.format(num_free_nodes),
                   '--immediate=60',
                   '--partition=chapel',
-                  '--share',
+                  '--oversubscribe',
                   '--nice']
 
     exclude_set = get_exclusive_nodes()[1]

--- a/util/test/paratest.chapcs
+++ b/util/test/paratest.chapcs
@@ -3,19 +3,20 @@
 """
 Simple slurm-aware paratest wrapper for testing on the chapcs cluster. This
 script aims to run parallel testing as quickly as possible without interfering
-with nightly testing or other exclusive reservations (e.g.  developers running
+with nightly testing or other exclusive reservations (e.g. developers running
 performance experiments.) It also tries to interfere as little as possible with
 other paratests in order to avoid timeouts.
 
 To use this script:
 
   cd test
-  ../util/test/paratest.chapcs
+  $CHPL_HOME/util/test/paratest.chapcs
 
-start_test options can be passed as additional command-line arguments
+paratest.server options can be passed as additional command-line arguments
 (e.g. -compopts --llvm).
-
 """
+
+from __future__ import print_function
 
 import os.path
 import sys
@@ -171,6 +172,7 @@ def run_paratest(args):
 
 
 def main(paratest_args):
+    """ Just run paratest with the user's args """
     run_paratest(paratest_args)
 
 


### PR DESCRIPTION
Slurm 17 changed the notion of "share" to "over subscribe". Update our wrapper
to throw `--oversubscribe` instead of `--share` and change the code that checks
`%h` (formally SHARE, now OVER_SUBSCRIBE) to look for the new formatting.

Previously SHARE could either be "no" or "yes", but now OVER_SUBSCRIBE can have
a bunch of different states (NO, YES, USER, MCS, and some others). Instead of
checking for SHARE==no, check for OVER_SUBSCRIBE!=YES, since that's roughly
equivalent for our purposes. Also make some of our string equality checks
case-insensitive.