### PR TITLE
BUILD_VERSION_FILE runs updateBuildVersion if it exists

### DIFF
--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -134,7 +134,7 @@ UPDATE_BUILD_VERSION = $(CHPL_MAKE_HOME)/util/devel/updateBuildVersion
 CLEAN_TARGS += $(CLANG_SETTINGS_FILE)
 
 $(BUILD_VERSION_FILE): FORCE
-	@({ test -x $(CHPL_MAKE_HOME)/.git ; } && \
+	@({ test -x $(UPDATE_BUILD_VERSION) ; } && \
 	test -x $(UPDATE_BUILD_VERSION) && $(UPDATE_BUILD_VERSION) $@) || \
 	test -r $(BUILD_VERSION_FILE) || (echo '"0"' > $@);
 

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -134,7 +134,7 @@ UPDATE_BUILD_VERSION = $(CHPL_MAKE_HOME)/util/devel/updateBuildVersion
 CLEAN_TARGS += $(CLANG_SETTINGS_FILE)
 
 $(BUILD_VERSION_FILE): FORCE
-	@({ test -x $(UPDATE_BUILD_VERSION) ; } && \
+	@({ test -e $(CHPL_MAKE_HOME)/.git ; } && \
 	test -x $(UPDATE_BUILD_VERSION) && $(UPDATE_BUILD_VERSION) $@) || \
 	test -r $(BUILD_VERSION_FILE) || (echo '"0"' > $@);
 


### PR DESCRIPTION
This can be viewed as a follow-on to PR #7498.

The old command (looking for .git directory) does not work for me since I
use git worktree. In a git worktree setup, $CHPL_HOME will be a git
checkout and respond to git commands like 'git log', but it contains
a .git file rather than a .git directory. That causes failures with
test/compflags/bradc/printstuff/version.chpl (among others) because the
BUILD_VERSION file contains "0" instead of a git hash.

So, this commit changes the relevant Makefile snippet to check for
the $CHPL_HOME/.git in file or directory form. That solves
the problem in my git worktree configuration.

- [x] full local testing

Reviewed by @bradcray - thanks!