### PR TITLE
Privatize the ofi comm layer internal interface.

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi-am.c
+++ b/runtime/src/comm/ofi/comm-ofi-am.c
@@ -42,7 +42,7 @@
 #include "comm-ofi-internal.h"
 
 static struct ofi_stuff* ofi = NULL;
-void ofi_am_init(struct ofi_stuff* _ofi) {
+void chpl_comm_ofi_am_init(struct ofi_stuff* _ofi) {
   if (ofi == NULL) {
     ofi = _ofi;
   } else {
@@ -127,6 +127,6 @@ static void execute_on_common(c_nodeid_t node, c_sublocid_t subloc,
 //
 //
 
-void ofi_am_handler(struct fi_cq_data_entry* cqe) {
+void chpl_comm_ofi_am_handler(struct fi_cq_data_entry* cqe) {
 
 }

--- a/runtime/src/comm/ofi/comm-ofi-diagnostics.c
+++ b/runtime/src/comm/ofi/comm-ofi-diagnostics.c
@@ -21,14 +21,14 @@
 #include "chpl-gen-includes.h"
 #include "comm-ofi-internal.h"
 
-static struct commDiagnostics_atomic comm_diagnostics;
+static struct commDiags_atomic comm_diagnostics;
 static int chpl_comm_diags_enabled = 1; // for masking diags
 
-struct commDiagnostics_atomic *chpl_getCommDiagnostics() {
+struct commDiags_atomic *chpl_comm_ofi_getCommDiags() {
   return &comm_diagnostics;
 }
 
-void chpl_commDiagnosticsInc(atomic_uint_least64_t *val) {
+void chpl_comm_ofi_commDiagsInc(atomic_uint_least64_t *val) {
   if (chpl_comm_diagnostics && chpl_comm_diags_enabled) {
      atomic_fetch_add_uint_least64_t(val, 1);
   }

--- a/runtime/src/comm/ofi/comm-ofi-internal.h
+++ b/runtime/src/comm/ofi/comm-ofi-internal.h
@@ -61,14 +61,14 @@ struct ofi_stuff {
 
 };
 
-void ofi_put_get_init(struct ofi_stuff*);
-void ofi_am_init(struct ofi_stuff*);
+void chpl_comm_ofi_put_get_init(struct ofi_stuff*);
+void chpl_comm_ofi_am_init(struct ofi_stuff*);
 
-void ofi_am_handler(struct fi_cq_data_entry*);
+void chpl_comm_ofi_am_handler(struct fi_cq_data_entry*);
 
 /* Comm diagnostics stuff */
 /* Dupe of the version in chpl-comm.h except with atomics */
-struct commDiagnostics_atomic {
+struct commDiags_atomic {
   atomic_uint_least64_t get;
   atomic_uint_least64_t get_nb;
   atomic_uint_least64_t put;
@@ -81,11 +81,11 @@ struct commDiagnostics_atomic {
   atomic_uint_least64_t execute_on_nb;
 };
 
-struct commDiagnostics_atomic *chpl_getCommDiagnostics(void);
-void chpl_commDiagnosticsInc(atomic_uint_least64_t *val);
+struct commDiags_atomic *chpl_comm_ofi_getCommDiags(void);
+void chpl_comm_ofi_commDiagsInc(atomic_uint_least64_t *val);
 
 #define CHPL_COMM_DIAGS_INC(comm_type)                                  \
-    chpl_commDiagnosticsInc(&(chpl_getCommDiagnostics()->comm_type))
+    chpl_comm_ofi_commDiagsInc(&(chpl_comm_ofi_getCommDiags()->comm_type))
 
 #define OFICHKRET(fncall, err) do {              \
     int retval;                                  \

--- a/runtime/src/comm/ofi/comm-ofi-put-get.c
+++ b/runtime/src/comm/ofi/comm-ofi-put-get.c
@@ -42,7 +42,7 @@
 #include "comm-ofi-internal.h"
 
 static struct ofi_stuff* ofi = NULL;
-void ofi_put_get_init(struct ofi_stuff* _ofi) {
+void chpl_comm_ofi_put_get_init(struct ofi_stuff* _ofi) {
   if (ofi == NULL) {
     ofi = _ofi;
   } else {

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -156,8 +156,8 @@ void chpl_comm_post_task_init(void) {
   }
 
   libfabric_init();
-  ofi_put_get_init(&ofi);
-  ofi_am_init(&ofi);
+  chpl_comm_ofi_put_get_init(&ofi);
+  chpl_comm_ofi_am_init(&ofi);
 
   // Start progress thread(s)
   for (i = 0; i < num_progress_threads; i++) {
@@ -601,7 +601,7 @@ int chpl_comm_numPollingTasks(void) { return 1; }
 void chpl_comm_make_progress(void) { }
 
 // In comm-ofi-am.c
-void am_handler(struct fi_cq_data_entry* cqe);
+void chpl_comm_ofi_am_handler(struct fi_cq_data_entry* cqe);
 
 /*
  * Set up the progress thread
@@ -642,7 +642,7 @@ static void progress_thread(void *args) {
     num_read = fi_cq_read(ofi.rx_cq[id], cqes, num_cqes);
     if (num_read > 0) {
       for (i = 0; i < num_read; i++) {
-        ofi_am_handler(&cqes[i]);
+        chpl_comm_ofi_am_handler(&cqes[i]);
         // send ack
       }
     } else {


### PR DESCRIPTION
This renames global symbols that are private to the ofi comm layer
(i.e., those not in the public interface) so that they all start with
"chpl_comm_ofi_".  This will help prevent collisions with user symbols.
