### PR TITLE
Un-futurize extern/diten/callSystem.future

### DIFF
--- a/test/extern/diten/callSystem.future
+++ b/test/extern/diten/callSystem.future
@@ -1,4 +1,0 @@
-bug: extern function 'system' crashes with CHPL_GASNET_SEGMENT=fast
-
-On our Linux test systems with CHPL_COMM=gasnet and CHPL_GASNET_SEGMENT=fast
-the extern function 'system' crashes.

--- a/test/extern/diten/callSystem.skipif
+++ b/test/extern/diten/callSystem.skipif
@@ -1,1 +1,0 @@
-CHPL_GASNET_SEGMENT != fast


### PR DESCRIPTION
After our testing machines had an OS upgrade this test started passing.  I
confirmed that it passes going back several days with the updated OS.