### PR TITLE
Keep track of the line number when handling multi-line strings

### DIFF
--- a/compiler/parser/chapel.lex
+++ b/compiler/parser/chapel.lex
@@ -304,7 +304,7 @@ static void  newString();
 static void  addString(const char* str);
 static void  addChar(char c);
 static void  addCharEscapeNonprint(char c);
-static void  addCharEscapingC(char c);
+static void  addCharEscapingC(yyscan_t scanner, char c);
 
 static int   getNextYYChar(yyscan_t scanner);
 
@@ -513,7 +513,7 @@ static const char* eatMultilineStringLiteral(yyscan_t scanner,
       startChCount = 0;
     }
 
-    addCharEscapingC(c);
+    addCharEscapingC(scanner, c);
   } /* eat up string */
 
   if (c == 0) {
@@ -949,7 +949,7 @@ static void addCharEscapeNonprint(char c) {
 }
 
 // Convert C escape characters into two characters: '\\' and the other character
-static void addCharEscapingC(char c) {
+static void addCharEscapingC(yyscan_t scanner, char c) {
   switch (c) {
     case '\"' :
       addChar('\\');
@@ -978,6 +978,8 @@ static void addCharEscapingC(char c) {
     case '\n' :
       addChar('\\');
       addChar('n');
+      // Keep track of line numbers when a newline is found in a string
+      processNewline(scanner);
       break;
     case '\r' :
       addChar('\\');

--- a/compiler/parser/flex-chapel.cpp
+++ b/compiler/parser/flex-chapel.cpp
@@ -3116,7 +3116,7 @@ static void  newString();
 static void  addString(const char* str);
 static void  addChar(char c);
 static void  addCharEscapeNonprint(char c);
-static void  addCharEscapingC(char c);
+static void  addCharEscapingC(yyscan_t scanner, char c);
 
 static int   getNextYYChar(yyscan_t scanner);
 
@@ -3325,7 +3325,7 @@ static const char* eatMultilineStringLiteral(yyscan_t scanner,
       startChCount = 0;
     }
 
-    addCharEscapingC(c);
+    addCharEscapingC(scanner, c);
   } /* eat up string */
 
   if (c == 0) {
@@ -3761,7 +3761,7 @@ static void addCharEscapeNonprint(char c) {
 }
 
 // Convert C escape characters into two characters: '\\' and the other character
-static void addCharEscapingC(char c) {
+static void addCharEscapingC(yyscan_t scanner, char c) {
   switch (c) {
     case '\"' :
       addChar('\\');
@@ -3790,6 +3790,8 @@ static void addCharEscapingC(char c) {
     case '\n' :
       addChar('\\');
       addChar('n');
+      // Keep track of line numbers when a newline is found in a string
+      processNewline(scanner);
       break;
     case '\r' :
       addChar('\\');

--- a/test/types/string/diten/multilineStringLineNumber.chpl
+++ b/test/types/string/diten/multilineStringLineNumber.chpl
@@ -1,0 +1,8 @@
+var q = """
+ Hi, I will error. 
+""";
+
+
+
+var x: int;
+x = 1.5;

--- a/test/types/string/diten/multilineStringLineNumber.good
+++ b/test/types/string/diten/multilineStringLineNumber.good
@@ -1,0 +1,1 @@
+multilineStringLineNumber.chpl:8: error: type mismatch in assignment from real(64) to int(64)


### PR DESCRIPTION
Multi-line strings weren't bumping the line number when a literal newline was
encountered.  This made the line numbers reported in error messages incorrect
when using multi-line strings.  Call `processNewline()` to handle newlines
inside of multi-line strings.

Add a test that got an incorrect line number in an error prior to this change.