### PR TITLE
new future: init() initializing a param field with a non-param value

### DIFF
--- a/test/classes/initializers/generics/init-param-from-non-param.chpl
+++ b/test/classes/initializers/generics/init-param-from-non-param.chpl
@@ -1,8 +1,7 @@
-config var notaparam = 77;
-
 class C {
   param p:int;
   proc init() {
+    var notaparam = 77;
     p = notaparam;
     super.init();
   }

--- a/test/classes/initializers/generics/init-param-from-non-param.chpl
+++ b/test/classes/initializers/generics/init-param-from-non-param.chpl
@@ -1,0 +1,13 @@
+config var notaparam = 77;
+
+class C {
+  param p:int;
+  proc init() {
+    p = notaparam;
+    super.init();
+  }
+}
+
+var c = new C();
+writeln(c);
+delete c;

--- a/test/classes/initializers/generics/init-param-from-non-param.future
+++ b/test/classes/initializers/generics/init-param-from-non-param.future
@@ -1,0 +1,3 @@
+bug: initializers allow assignment of non-params to param fields
+#8406
+

--- a/test/classes/initializers/generics/init-param-from-non-param.good
+++ b/test/classes/initializers/generics/init-param-from-non-param.good
@@ -1,0 +1,1 @@
+init-param-from-non-param.chpl:6: error: Initializing parameter 'p' to value not known at compile time

--- a/test/classes/initializers/generics/init-param-from-non-param.good
+++ b/test/classes/initializers/generics/init-param-from-non-param.good
@@ -1,1 +1,1 @@
-init-param-from-non-param.chpl:6: error: Initializing parameter 'p' to value not known at compile time
+init-param-from-non-param.chpl:5: error: Initializing parameter 'p' to value not known at compile time


### PR DESCRIPTION
This should fail to compile.

This is the future for issue #8406