### PR TITLE
Init prop 4

### DIFF
--- a/compiler/include/InitNormalize.h
+++ b/compiler/include/InitNormalize.h
@@ -66,7 +66,9 @@ public:
   void            checkPhase(BlockStmt* block);
 
   Expr*           completePhase1(CallExpr* insertBefore);
-  void            initializeFieldsBefore(Expr* insertBefore);
+
+  void            initializeFieldsAtTail(BlockStmt* block);
+  void            initializeFieldsBefore(Expr*      insertBefore);
 
   bool            isFieldReinitialized(DefExpr* field)                   const;
   bool            inLoopBody()                                           const;

--- a/compiler/include/InitNormalize.h
+++ b/compiler/include/InitNormalize.h
@@ -158,8 +158,6 @@ private:
 
   DefExpr*        toSuperField(AggregateType* at, const char* name)      const;
 
-  void            transformSuperInit(Expr* initStmt);
-
   const char*     phaseToString(InitPhase phase)                         const;
 
   FnSymbol*       mFn;

--- a/compiler/include/initializerRules.h
+++ b/compiler/include/initializerRules.h
@@ -34,4 +34,6 @@ void      preNormalizeFields(AggregateType* at);
 void      preNormalizeInitMethod(FnSymbol* fn);
 FnSymbol* buildClassAllocator(FnSymbol* initMethod);
 
+void      transformSuperInit(CallExpr* initCall);
+
 #endif


### PR DESCRIPTION
Continue to integrate initializer development branch to master

Convert a couple of private methods on InitNormalize to be functions
in initializerRules.cpp.  Do a little cleanup.

Compiled with standard configurations.  Limited testing for each
configuration.  Passed a full paratest for single-locale
