### PR TITLE
Restore gcd() future about lack of return from a function that always does

### DIFF
--- a/test/trivial/preston/gcd.bad
+++ b/test/trivial/preston/gcd.bad
@@ -1,2 +1,2 @@
-gcd.chpl:3: In function 'gcd':
+gcd.chpl:3: In function 'mygcd':
 gcd.chpl:3: error: control reaches end of function that returns a value

--- a/test/trivial/preston/gcd.chpl
+++ b/test/trivial/preston/gcd.chpl
@@ -1,6 +1,6 @@
 // a beginning
 
-proc gcd(in x, in y) {
+proc mygcd(in x, in y) {
   if x < 0 then x = -x;
   if y < 0 then y = -y;
 
@@ -13,4 +13,4 @@ proc gcd(in x, in y) {
 }
 
 
-writeln(gcd(125,1005));
+writeln(mygcd(125,1005));


### PR DESCRIPTION
This future started passing inadvertantly last night because it
uses a very generic function, gcd(), which was considered a
worse match than the new gcd() library function.  The future
is still relevant, though, so I just renamed the function to
keep it working as it was.