### PR TITLE
cleanup inTree()

### DIFF
--- a/compiler/AST/ModuleSymbol.cpp
+++ b/compiler/AST/ModuleSymbol.cpp
@@ -35,7 +35,7 @@ ModuleSymbol*                      standardModule        = NULL;
 ModuleSymbol*                      printModuleInitModule = NULL;
 
 Vec<ModuleSymbol*>                 userModules; // Contains user + main modules
-Vec<ModuleSymbol*>                 allModules;  // Contains all modules
+Vec<ModuleSymbol*>                 allModules;  // Contains all modules except rootModule
 
 static ModuleSymbol*               sMainModule           = NULL;
 static std::string                 sMainModuleName;
@@ -213,8 +213,6 @@ ModuleSymbol::ModuleSymbol(const char* iName,
   doc                 = NULL;
   extern_info         = NULL;
   llvmDINameSpace     = NULL;
-
-  block->parentSymbol = this;
 
   registerModule(this);
 
@@ -695,6 +693,7 @@ void initRootModule() {
                                           new BlockStmt());
 
   rootModule->filename = astr("<internal>");
+  rootModule->block->parentSymbol = rootModule;
 }
 
 void initStringLiteralModule() {

--- a/compiler/AST/astutil.cpp
+++ b/compiler/AST/astutil.cpp
@@ -453,7 +453,7 @@ void buildDefUseMaps(Vec<Symbol*>& symSet,
     if (sym == NULL) continue;
 
     for_SymbolSymExprs(se, sym) {
-      if (se->parentSymbol && sym == se->symbol()) {
+      if (se->inTree() && sym == se->symbol()) {
         int result = isDefAndOrUse(se);
 
         if (result & 1)
@@ -488,7 +488,7 @@ buildDefUseSetsInternal(BaseAST* ast,
                         Vec<SymExpr*>& defSet,
                         Vec<SymExpr*>& useSet) {
   if (SymExpr* se = toSymExpr(ast)) {
-    if (se->parentSymbol && se->symbol() && symSet.set_in(se->symbol())) {
+    if (se->inTree() && se->symbol() && symSet.set_in(se->symbol())) {
       int result = isDefAndOrUse(se);
       if (result & 1)
         defSet.set_add(se);
@@ -902,7 +902,7 @@ static void changeDeadTypesToVoid(Vec<TypeSymbol*>& types)
   // change symbols with dead types to void (important for baseline)
   //
   forv_Vec(DefExpr, def, gDefExprs) {
-    if (def->parentSymbol                != NULL  &&
+    if (def->inTree()                             &&
         def->sym->type                   != NULL  &&
         isAggregateType(def->sym->type)  ==  true &&
         isTypeSymbol(def->sym)           == false &&

--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -293,7 +293,7 @@ void Expr::verifyParent(const Expr* child) {
 
 bool Expr::inTree() {
   if (parentSymbol)
-    return parentSymbol->inTree();
+    return true;
   else
     return false;
 }
@@ -535,7 +535,7 @@ void SymExpr::verify() {
     INT_FATAL(this, "SymExpr::verify %12d: var is NULL", id);
 
   if (var->defPoint) {
-    if (var->defPoint->parentSymbol == NULL)
+    if (!var->defPoint->inTree())
       INT_FATAL(this, "SymExpr::verify %12d:  var->defPoint is not in AST", id);
   } else {
     if (var != rootModule)

--- a/compiler/AST/iterator.cpp
+++ b/compiler/AST/iterator.cpp
@@ -1409,7 +1409,7 @@ static void addLocalsToClassAndRecord(Vec<Symbol*>& locals, FnSymbol* fn,
   // calls for PRIM_ITERATOR_RECORD_FIELD_VALUE_BY_FORMAL
   std::map<Symbol*, std::vector<CallExpr*> > formalToPrimMap;
   forv_Vec(CallExpr, call, gCallExprs) {
-    if (call->parentSymbol && call->isPrimitive(PRIM_ITERATOR_RECORD_FIELD_VALUE_BY_FORMAL)) {
+    if (call->inTree() && call->isPrimitive(PRIM_ITERATOR_RECORD_FIELD_VALUE_BY_FORMAL)) {
       AggregateType* ir = toAggregateType(toArgSymbol((toSymExpr(call->get(1))->symbol()))->type);
       if (ii->irecord == ir) {
         Symbol* formal = toSymExpr(call->get(2))->symbol();

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -136,10 +136,11 @@ void Symbol::verify() {
 
 
 bool Symbol::inTree() {
-  if (this == rootModule)
-    return true;
   if (defPoint)
     return defPoint->inTree();
+  // rootModule->defPoint is always NULL
+  if (this == rootModule)
+    return true;
   else
     return false;
 }

--- a/compiler/codegen/stmt.cpp
+++ b/compiler/codegen/stmt.cpp
@@ -58,7 +58,7 @@ void codegenStmt(Expr* stmt) {
       // Adjust the current line number, but leave the scope alone.
       llvm::MDNode* scope;
 
-      if(stmt->parentSymbol && stmt->parentSymbol->astTag == E_FnSymbol) {
+      if(stmt->inTree() && stmt->parentSymbol->astTag == E_FnSymbol) {
         scope = debug_info->get_function((FnSymbol *)stmt->parentSymbol);
       } else {
         scope = info->irBuilder->getCurrentDebugLocation().getScope();

--- a/compiler/include/expr.h
+++ b/compiler/include/expr.h
@@ -36,7 +36,7 @@ public:
   virtual        ~Expr();
 
   // Interface for BaseAST
-  virtual bool    inTree();
+          bool    inTree();
   virtual bool    isStmt()                                           const;
   virtual QualifiedType qualType();
   virtual void    verify();
@@ -297,8 +297,17 @@ class NamedExpr : public Expr {
 
 // Determines whether a node is in the AST (vs. has been removed
 // from the AST). Used e.g. by cleanAst().
-// Exception: 'n' is also live if isRootModule(n).
-
+//
+// We may want to replace isAlive() with {Expr,Symbol,Type}::inTree().
+// Right now they are different:
+//  - Symbol::inTree() performs an additional check for rootModule
+//    whereas isAlive(Symbol) does not.
+//  - isAlive(Symbol) is false vs. Symbol::inTree() is true on rootModule.
+//    'rootModule' is the only module that is always alive/in tree
+//    yet does not have a defPoint.
+//  - Type::inTree() performs an additional check for Type::symbol != NULL,
+//    whereas isAlive(Type) does not.
+//
 static inline bool isAlive(Expr* expr) {
   return expr->parentSymbol;
 }

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -104,7 +104,7 @@ class Symbol : public BaseAST {
 public:
   // Interface for BaseAST
   virtual GenRet     codegen();
-  virtual bool       inTree();
+          bool       inTree();
   virtual QualifiedType qualType();
   virtual void       verify();
 

--- a/compiler/include/type.h
+++ b/compiler/include/type.h
@@ -62,7 +62,7 @@ public:
 
   // Interface for BaseAST
   virtual GenRet         codegen();
-  virtual bool           inTree();
+          bool           inTree();
   virtual QualifiedType  qualType();
   virtual void           verify();
 

--- a/compiler/main/checks.cpp
+++ b/compiler/main/checks.cpp
@@ -556,7 +556,7 @@ static void check_afterInlineFunctions() {
     forv_Vec(DefExpr, def, gDefExprs) {
       Symbol* sym = def->sym;
       if (isLcnSymbol(sym) &&
-          def->parentSymbol != NULL && // symbol is in the tree
+          def->inTree() && // symbol is in the tree
           def->parentSymbol->hasFlag(FLAG_WIDE_REF) == false) {
         if (sym->type->symbol->hasFlag(FLAG_REF) ||
             sym->type->symbol->hasFlag(FLAG_WIDE_REF)) {

--- a/compiler/optimizations/removeEmptyRecords.cpp
+++ b/compiler/optimizations/removeEmptyRecords.cpp
@@ -46,8 +46,7 @@ removeEmptyRecords() {
   while (change) {
     change = false;
     forv_Vec(AggregateType, ct, gAggregateTypes) {
-      if (isRecord(ct) && ct->symbol->defPoint->parentSymbol &&
-          !ct->symbol->hasFlag(FLAG_EXTERN)) {
+      if (isRecord(ct) && ct->inTree() && !ct->symbol->hasFlag(FLAG_EXTERN)) {
         bool empty = true;
         for_fields(field, ct) {
           if (emptyRecordTypeSet.count(field->type) == 0) {

--- a/compiler/optimizations/scalarReplace.cpp
+++ b/compiler/optimizations/scalarReplace.cpp
@@ -393,7 +393,7 @@ scalarReplaceRecord(AggregateType* ct, Symbol* sym) {
   bool memberAccessed = false;
   for_uses(se, useMap, sym) {
     CallExpr* parent = toCallExpr(se->parentExpr);
-    if (se->parentSymbol && parent != NULL) {
+    if (se->inTree() && parent != NULL) {
       if (isHandledRecordUse(se) == false) {
         return false;
       }

--- a/compiler/passes/checkNormalized.cpp
+++ b/compiler/passes/checkNormalized.cpp
@@ -64,8 +64,7 @@ static void checkFunctionSignatures() {
 
 static void checkPrimNew() {
   forv_Vec(CallExpr, call, gCallExprs) {
-    if (call->parentSymbol          != NULL &&
-        call->isPrimitive(PRIM_NEW) == true) {
+    if (call->inTree() &&  call->isPrimitive(PRIM_NEW)) {
 
       if (call->numActuals() >= 1) {
         Expr*    arg1     = call->get(1);

--- a/compiler/passes/checkParsed.cpp
+++ b/compiler/passes/checkParsed.cpp
@@ -174,7 +174,7 @@ static void checkExplicitDeinitCalls(CallExpr* call) {
 static void checkPrivateDecls(DefExpr* def) {
   if (def->sym->hasFlag(FLAG_PRIVATE) == true) {
     // The symbol has been declared private.
-    if (def->parentSymbol != NULL) {
+    if (def->inTree()) {
       if (isFnSymbol(def->parentSymbol) == true) {
         // The parent symbol of this definition is a FnSymbol.
         // Private symbols at the function scope are meaningless

--- a/compiler/passes/insertWideReferences.cpp
+++ b/compiler/passes/insertWideReferences.cpp
@@ -269,7 +269,7 @@ static void handleIsWidePointer();
 static bool isLocalBlock(Expr* stmt) {
   BlockStmt* block = toBlockStmt(stmt);
   return block &&
-         block->parentSymbol &&
+         block->inTree() &&
          block->isLoopStmt() == false &&
          block->blockInfoGet() &&
          block->blockInfoGet()->isPrimitive(PRIM_BLOCK_LOCAL);

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -813,7 +813,7 @@ static void moveGlobalDeclarationsToModuleScope() {
 
 static void insertUseForExplicitModuleCalls() {
   forv_Vec(SymExpr, se, gSymExprs) {
-    if (se->parentSymbol && se->symbol() == gModuleToken) {
+    if (se->inTree() && se->symbol() == gModuleToken) {
       SET_LINENO(se);
 
       CallExpr*     call  = toCallExpr(se->parentExpr);

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -637,7 +637,7 @@ static void resolveUnresolvedSymExpr(UnresolvedSymExpr* usymExpr) {
 
   const char* name = usymExpr->unresolved;
 
-  if (name == astrSdot || usymExpr->parentSymbol == NULL) {
+  if (name == astrSdot || !usymExpr->inTree()) {
 
   } else if (Symbol* sym = lookup(name, usymExpr)) {
     FnSymbol* fn = toFnSymbol(sym);

--- a/compiler/resolution/callDestructors.cpp
+++ b/compiler/resolution/callDestructors.cpp
@@ -145,7 +145,7 @@ void ReturnByRef::returnByRefCollectCalls(RefMap& calls)
     // Only transform calls that are still in the AST tree
     // (defer statement bodies have been removed at this point
     //  in this pass)
-    if (call->parentSymbol != NULL) {
+    if (call->inTree()) {
 
       // Only transform calls to transformable functions
       if (FnSymbol* fn = theTransformableFunction(call))
@@ -946,7 +946,7 @@ static void insertYieldTemps()
 static void insertReferenceTemps() {
   forv_Vec(CallExpr, call, gCallExprs) {
     // Is call in the tree?
-    if (call->parentSymbol != NULL) {
+    if (call->inTree()) {
       if (call->isResolved() || call->isPrimitive(PRIM_VIRTUAL_METHOD_CALL)) {
         insertReferenceTemps(call);
       }

--- a/compiler/resolution/lowerIterators.cpp
+++ b/compiler/resolution/lowerIterators.cpp
@@ -416,7 +416,7 @@ fragmentLocalBlocks() {
     // NOAKES 2014/11/25 Transitional.  Avoid calling blockInfoGet() on loops
     if (block->isLoopStmt() == true) {
 
-    } else if (block->parentSymbol &&
+    } else if (block->inTree()       &&
                block->blockInfoGet() &&
                block->blockInfoGet()->isPrimitive(PRIM_BLOCK_LOCAL) &&
                !leaveLocalBlockUnfragmented(block)) {
@@ -579,7 +579,7 @@ replaceIteratorFormals(FnSymbol* iterator, Symbol* ic,
     if (throws)
       replaceErrorFormalWithEnclosingError(se);
     // if se was not replaced by the above call...
-    if (se->parentSymbol != NULL)
+    if (se->inTree())
       replaceIteratorFormalsWithIteratorFields(iterator, ic, se);
   }
 }
@@ -2121,7 +2121,7 @@ static void
 inlineIterators() {
   forv_Vec(BlockStmt, block, gBlockStmts) {
     // Skip blocks that are no longer in the tree.
-    if (block->parentSymbol == NULL)
+    if (!block->inTree())
       continue;
 
     if (ForLoop* forLoop = toForLoop(block)) {
@@ -2145,7 +2145,7 @@ static void fixNumericalGetMemberPrims()
   // fix GET_MEMBER primitives that access fields of an iterator class
   // via a number
   forv_Vec(CallExpr, call, gCallExprs) {
-    if (call->parentSymbol && call->isPrimitive(PRIM_GET_MEMBER)) {
+    if (call->inTree() && call->isPrimitive(PRIM_GET_MEMBER)) {
       AggregateType* ct = toAggregateType(call->get(1)->getValType());
       int64_t num;
       if (get_int(call->get(2), &num)) {
@@ -2220,7 +2220,7 @@ static void handlePolymorphicIterators()
 {
   forv_Vec(FnSymbol, fn, gFnSymbols) {
     // Find iterator functions that are not in the AST tree.
-    if (fn->defPoint->parentSymbol &&
+    if (fn->inTree()     &&
         fn->iteratorInfo &&
         !fn->hasFlag(FLAG_TASK_FN_FROM_ITERATOR_FN)) {
       // Assert that the getIterator() function *is* in the tree.

--- a/compiler/resolution/postFold.cpp
+++ b/compiler/resolution/postFold.cpp
@@ -90,7 +90,7 @@ Expr* postFold(Expr* expr) {
 
   Expr* retval = expr;
 
-  INT_ASSERT(expr->parentSymbol != NULL);
+  INT_ASSERT(expr->inTree());
 
   if (CallExpr* call = toCallExpr(expr)) {
     if (call->isResolved() == true) {

--- a/compiler/resolution/virtualDispatch.cpp
+++ b/compiler/resolution/virtualDispatch.cpp
@@ -736,7 +736,7 @@ static bool wasSuperDot(CallExpr* call);
 
 void insertDynamicDispatchCalls() {
   forv_Vec(CallExpr, call, gCallExprs) {
-    if (call->parentSymbol != NULL) {
+    if (call->inTree()) {
       if (FnSymbol* fn = call->resolvedFunction()) {
 
         if (virtualChildrenMap.get(fn) != NULL  &&   // There are overrides

--- a/compiler/resolution/visibleFunctions.cpp
+++ b/compiler/resolution/visibleFunctions.cpp
@@ -126,7 +126,7 @@ void findVisibleFunctions(CallInfo&       info,
 static void buildVisibleFunctionMap() {
   for (int i = nVisibleFunctions; i < gFnSymbols.n; i++) {
     FnSymbol* fn = gFnSymbols.v[i];
-    if (!fn->hasFlag(FLAG_INVISIBLE_FN) && fn->defPoint->parentSymbol && !isArgSymbol(fn->defPoint->parentSymbol)) {
+    if (!fn->hasFlag(FLAG_INVISIBLE_FN) && fn->inTree() && !isArgSymbol(fn->defPoint->parentSymbol)) {
       BlockStmt* block = NULL;
       if (fn->hasFlag(FLAG_AUTO_II)) {
         block = theProgram->block;


### PR DESCRIPTION
It used to be the case that the presence (non-NULL-ness)
of parentSymbol was not enough to decide Expr::inTree().

#### This PR

* establishes Expr::inTree() === (Expr::parentSymbol != NULL)

* adjusts Expr::inTree() correspondingly,

* replaces a few explicit checks for "parentSymbol != NULL"
  with calls to inTree(), for clarity.

The only case where this discipline did not hold was for ModuleSymbol::block.
I adjusted that, almost trivially.

While there, I made "this == rootModule" the second check in Symbol::inTree().
Because we expect the now-first check to succeed in most cases and
the "this == rootModule" check to fail almost always.

While there, I made {Expr,Type,Symbol}::inTree() non-virtual,
as we do not override them in subclasses.

#### Other potential improvements

* There may be other cases where we could replace "parentSymbol != NULL"
with inTree().

* Add INT_ASSERT(symbol != NULL) in Type::verify().

* Replace isAlive() with inTree().

The only reason not to do that that I see is that isAlive() executes
slightly fewer conditionals than inTree(). This could be mitigated:

  - To avoid the check for rootModule, we can add another version of
    Symbol::inTree(). We could apply that version whenever we do not need the
    precise answer for rootModule, ex. when the Symbol is not a ModuleSymbol.
    Maybe Symbol::inTree() could be virtual, overriden for ModuleSymbol.

  - To avoid the check for Type::symbol!=NULL, we could ensure that
    it is always the case. Add INT_ASSERT(symbol!=NULL) to Type::verify().


Testing: linux64 --verify, gasnet, baseline.