### PR TITLE
Do not lowerIterator() on dead parallel iterators

### DIFF
--- a/compiler/AST/iterator.cpp
+++ b/compiler/AST/iterator.cpp
@@ -1212,6 +1212,8 @@ rebuildIterator(IteratorInfo* ii,
       // If multiple calls to 'taskFn', we probably shouldn't remove it.
       INT_ASSERT(call == taskFn->singleInvocation());
 
+      // Note that this does not remove task functions that 'taskFn' invokes.
+      // Ex. test/parallel/forall/vass/binary-tree-spawn.no-recurse.chpl
       taskFn->defPoint->remove();
     }
   }


### PR DESCRIPTION
After we inline iterators, most iterators become unused.
So there is no reason to run lowerIterator(fn) on these iterators.

Instead, now we delete them from the tree.

The "unused" check is that the FnSymbol has no SymExprs referring to it.

This "unused" check does not work on serial iterators.
This is probably because of the _toLeader/_toFollower/_toStandalone
business, where a parallel iterator - that may still be used -
needs to go back to its serial counterpart at some point.
So limit the "unused" check to parallel iterators.

The task functions invoked by an unused iterator could also
be removed. However, this change is simpler and does not do that.
If we revert the task functions back to BlockStmts or dedicated
non-FnSymbol AST nodes, then such removal will happen automatically.

I needed to bump the depth argument to `maybeCalled` because
the test `binary-tree-spawn.no-recurse.chpl` now exposes dead-yet-inTree
task functions that are 5-deep call stack from the iterator invoking them.

Testing: linux64 --verify, gasnet, baseline.