### PR TITLE
Init prop 5

### DIFF
--- a/compiler/passes/InitNormalize.cpp
+++ b/compiler/passes/InitNormalize.cpp
@@ -271,7 +271,7 @@ Expr* InitNormalize::completePhase1(CallExpr* initStmt) {
 }
 
 void InitNormalize::initializeFieldsAtTail(BlockStmt* block) {
-  if (mPhase == cPhase1 && mCurrField != NULL) {
+  if (mCurrField != NULL) {
     Expr* noop = new CallExpr(PRIM_NOOP);
 
     block->insertAtTail(noop);


### PR DESCRIPTION
Continue to integrate initializer branch to master

This PR extracts the body of preNormalizeInit() in to separate
functions for handling records vs. classes.

Compiled on the classic configurations with limited testing for
each.  Passed a full paratest.
