### PR TITLE
Add a scalable AllLocalesBarrier

### DIFF
--- a/modules/packages/AllLocalesBarriers.chpl
+++ b/modules/packages/AllLocalesBarriers.chpl
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2004-2018 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+/* Support for a Barrier between a number of tasks across all Locales. */
+
+module AllLocalesBarriers {
+  use BlockDist, Barriers;
+
+  private var allLocalesBarrierCreated: atomic bool;
+  record AllLocalesBarrier {
+    // TODO use PrivateDist?
+    const BarrierSpace = LocaleSpace dmapped Block(LocaleSpace);
+    var globalBarrier: [BarrierSpace] Barrier;
+
+    proc init(numTasksPerLocale: int) {
+      if allLocalesBarrierCreated.testAndSet() then
+        halt("Sorry, only one all locales barrier can be created at this time");
+      globalBarrier = [b in BarrierSpace] new Barrier(numTasksPerLocale, hackIntoCommBarrier=true);
+    }
+
+    proc barrier() {
+      globalBarrier.localAccess[here.id].barrier();
+    }
+  }
+}

--- a/modules/standard/Barriers.chpl
+++ b/modules/standard/Barriers.chpl
@@ -103,6 +103,19 @@ module Barriers {
       owned = true;
     }
 
+    // needed for default init of an array
+    pragma "no doc"
+    proc init() {
+      this.init(0);
+    }
+
+    // Hack for AllTasksBarrier
+    pragma "no doc"
+    proc init(numTasks: int, param hackIntoCommBarrier: bool) {
+      bar = new aBarrier(numTasks, reusable=true, hackIntoCommBarrier=true);
+      owned = true;
+    }
+
     /* copy initializer */
     pragma "no doc"
     proc init(b: Barrier) {
@@ -212,12 +225,23 @@ module Barriers {
     pragma "no doc"
     var done: atomic bool;
 
+    pragma "no doc"
+    param hackIntoCommBarrier = false;
+
     /* Construct a new Barrier object.
 
        :arg n: The number of tasks involved in this barrier
      */
     proc init(n: int, param reusable: bool) {
       this.reusable = reusable;
+      super.init();
+      reset(n);
+    }
+
+    pragma "no doc"
+    proc init(n: int, param reusable: bool, param hackIntoCommBarrier: bool) {
+      this.reusable = reusable;
+      this.hackIntoCommBarrier = hackIntoCommBarrier;
       super.init();
       reset(n);
     }
@@ -238,6 +262,10 @@ module Barriers {
       on this {
         const myc = count.fetchSub(1);
         if myc<=1 {
+          if hackIntoCommBarrier {
+            extern proc chpl_comm_user_barrier(msg: c_string);
+            chpl_comm_user_barrier("local barrier call".localize().c_str());
+          }
           if done.testAndSet() then
             halt("Too many callers to barrier()");
           if reusable {

--- a/runtime/include/chpl-comm.h
+++ b/runtime/include/chpl-comm.h
@@ -354,9 +354,12 @@ void chpl_comm_broadcast_private(int id, size_t size, int32_t tid);
 // function may be called from a Chapel task.  As such, if the barrier
 // cannot be immediately satisfied, while it waits chpl_comm_barrier()
 // must call chpl_task_yield() in order not to monopolize the execution
-// resources and prevent making progress.
+// resources and prevent making progress. chpl_comm_user_barrier is
+// intended to be available for module code usage, chpl_comm_barrier is
+// meant for the runtime
 //
 void chpl_comm_barrier(const char *msg);
+void chpl_comm_user_barrier(const char *msg);
 
 //
 // Do exit processing that has to occur before the tasking layer is

--- a/runtime/src/comm/gasnet/comm-gasnet.c
+++ b/runtime/src/comm/gasnet/comm-gasnet.c
@@ -1033,6 +1033,21 @@ void chpl_comm_barrier(const char *msg) {
   GASNET_Safe_Retval(gasnet_barrier_try(id, 0), retval);
 }
 
+void chpl_comm_user_barrier(const char *msg) {
+  int id = (int) msg[0] + 255; // offset from other barrier
+  int retval;
+
+#ifdef CHPL_COMM_DEBUG
+  chpl_msg(2, "%d: enter barrier for '%s'\n", chpl_nodeID, msg);
+#endif
+
+  gasnet_barrier_notify(id, 0);
+  while ((retval = gasnet_barrier_try(id, 0)) == GASNET_ERR_NOT_READY) {
+    chpl_task_yield();
+  }
+  GASNET_Safe_Retval(gasnet_barrier_try(id, 0), retval);
+}
+
 void chpl_comm_pre_task_exit(int all) {
   if (all) {
     chpl_comm_barrier("stop polling");

--- a/runtime/src/comm/none/comm-none.c
+++ b/runtime/src/comm/none/comm-none.c
@@ -137,6 +137,8 @@ void chpl_comm_broadcast_private(int id, size_t size, int32_t tid) { }
 
 void chpl_comm_barrier(const char *msg) { }
 
+void chpl_comm_user_barrier(const char *msg) { }
+
 void chpl_comm_pre_task_exit(int all) { }
 
 void chpl_comm_exit(int all, int status) { }

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -512,6 +512,10 @@ void chpl_comm_barrier(const char *msg) {
 
 }
 
+void chpl_comm_user_barrier(const char *msg) {
+  chpl_internal_error("chpl_comm_user_barrier not implemented for ofi");
+}
+
 void chpl_comm_pre_task_exit(int all) {
   // Tear down the progress thread
 }

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -1244,6 +1244,10 @@ static barrier_info_t  rt_bar_info;
 static barrier_info_t* rt_child_bar_info[BAR_TREE_NUM_CHILDREN];
 static barrier_info_t* rt_parent_bar_info;
 
+static barrier_info_t  user_bar_info;
+static barrier_info_t* user_child_bar_info[BAR_TREE_NUM_CHILDREN];
+static barrier_info_t* user_parent_bar_info;
+
 
 static void chpl_comm_barrier_init(uint32_t nic_addr,
                                    barrier_info_t*  bar_info,
@@ -1782,6 +1786,7 @@ void chpl_comm_post_task_init(void)
                                        0, 0);
 
     chpl_comm_barrier_init(nic_addr, &rt_bar_info, rt_child_bar_info, &rt_parent_bar_info);
+    chpl_comm_barrier_init(nic_addr, &user_bar_info, user_child_bar_info, &user_parent_bar_info);
 
   }
 
@@ -3290,6 +3295,11 @@ static void chpl_comm_barrier_internal(const char *msg,
 void chpl_comm_barrier(const char *msg)
 {
     chpl_comm_barrier_internal(msg, &rt_bar_info, rt_child_bar_info, rt_parent_bar_info);
+}
+
+void chpl_comm_user_barrier(const char *msg)
+{
+    chpl_comm_barrier_internal(msg, &user_bar_info, user_child_bar_info, user_parent_bar_info);
 }
 
 

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -1240,10 +1240,44 @@ static uint32_t bar_min_child;
 static uint32_t bar_num_children;
 static uint32_t bar_parent;
 
-static barrier_info_t  bar_info;
-static barrier_info_t* child_bar_info[BAR_TREE_NUM_CHILDREN];
-static barrier_info_t* parent_bar_info;
+static barrier_info_t  rt_bar_info;
+static barrier_info_t* rt_child_bar_info[BAR_TREE_NUM_CHILDREN];
+static barrier_info_t* rt_parent_bar_info;
 
+
+static void chpl_comm_barrier_init(uint32_t nic_addr,
+                                   barrier_info_t*  bar_info,
+                                   barrier_info_t** child_bar_info,
+                                   barrier_info_t** parent_bar_info)
+{
+
+  typedef struct {
+    c_nodeid_t nodeID;
+    uint32_t nic_addr;
+    barrier_info_t* bar_info;
+  } gdata_t;
+
+  gdata_t  my_gdata = { chpl_nodeID, nic_addr, bar_info };
+  gdata_t* gdata;
+
+  gdata = (gdata_t*) chpl_mem_allocMany(chpl_numNodes, sizeof(gdata[0]),
+                                        CHPL_RT_MD_COMM_PER_LOC_INFO,
+                                        0, 0);
+  if (PMI_Allgather(&my_gdata, gdata, sizeof(gdata[0])) != PMI_SUCCESS)
+    CHPL_INTERNAL_ERROR("PMI_Allgather(nic_addr_map) failed");
+
+  for (int i = 0; i < chpl_numNodes; i++) {
+    nic_addr_map[gdata[i].nodeID] = gdata[i].nic_addr;
+
+    if (gdata[i].nodeID >= bar_min_child
+        && gdata[i].nodeID < bar_min_child + bar_num_children)
+      child_bar_info[gdata[i].nodeID - bar_min_child] = gdata[i].bar_info;
+    else if (chpl_nodeID != 0 && gdata[i].nodeID == bar_parent)
+      *parent_bar_info = gdata[i].bar_info;
+  }
+
+  chpl_mem_free(gdata, 0, 0);
+}
 
 //
 // These flags tell tell the state of, or give direction to, the polling
@@ -1747,34 +1781,8 @@ void chpl_comm_post_task_init(void)
                                        CHPL_RT_MD_COMM_PER_LOC_INFO,
                                        0, 0);
 
-    {
-      typedef struct {
-        c_nodeid_t nodeID;
-        uint32_t nic_addr;
-        barrier_info_t* bar_info;
-      } gdata_t;
+    chpl_comm_barrier_init(nic_addr, &rt_bar_info, rt_child_bar_info, &rt_parent_bar_info);
 
-      gdata_t  my_gdata = { chpl_nodeID, nic_addr, &bar_info };
-      gdata_t* gdata;
-
-      gdata = (gdata_t*) chpl_mem_allocMany(chpl_numNodes, sizeof(gdata[0]),
-                                            CHPL_RT_MD_COMM_PER_LOC_INFO,
-                                            0, 0);
-      if (PMI_Allgather(&my_gdata, gdata, sizeof(gdata[0])) != PMI_SUCCESS)
-        CHPL_INTERNAL_ERROR("PMI_Allgather(nic_addr_map) failed");
-
-      for (int i = 0; i < chpl_numNodes; i++) {
-        nic_addr_map[gdata[i].nodeID] = gdata[i].nic_addr;
-
-        if (gdata[i].nodeID >= bar_min_child
-            && gdata[i].nodeID < bar_min_child + bar_num_children)
-          child_bar_info[gdata[i].nodeID - bar_min_child] = gdata[i].bar_info;
-        else if (chpl_nodeID != 0 && gdata[i].nodeID == bar_parent)
-          parent_bar_info = gdata[i].bar_info;
-      }
-
-      chpl_mem_free(gdata, 0, 0);
-    }
   }
 
   compute_comm_dom_cnt();
@@ -3203,7 +3211,11 @@ void chpl_comm_broadcast_private(int id, size_t size, int32_t tid)
 }
 
 
-void chpl_comm_barrier(const char *msg)
+
+static void chpl_comm_barrier_internal(const char *msg,
+                                       barrier_info_t*  bar_info,
+                                       barrier_info_t** child_bar_info,
+                                       barrier_info_t* parent_bar_info)
 {
   DBG_P_L(DBGF_IFACE, "IFACE chpl_comm_barrier(\"%s\")", msg);
 
@@ -3228,7 +3240,7 @@ void chpl_comm_barrier(const char *msg)
   //
   DBG_P_LP(DBGF_BARRIER, "BAR wait for %d children", (int) bar_num_children);
   for (uint32_t i = 0; i < bar_num_children; i++) {
-    while (bar_info.child_notify[i] == 0) {
+    while (bar_info->child_notify[i] == 0) {
       PERFSTATS_INC(lyield_in_bar_1_cnt);
       local_yield();
     }
@@ -3250,7 +3262,7 @@ void chpl_comm_barrier(const char *msg)
     // Wait for our parent locale to release us from the barrier.
     //
     DBG_P_LP(DBGF_BARRIER, "BAR wait for parental release");
-    while (bar_info.parent_release == 0) {
+    while (bar_info->parent_release == 0) {
       PERFSTATS_INC(lyield_in_bar_2_cnt);
       local_yield();
     }
@@ -3260,8 +3272,8 @@ void chpl_comm_barrier(const char *msg)
   // Clear all our barrier flags.
   //
   for (uint32_t i = 0; i < bar_num_children; i++)
-    bar_info.child_notify[i] = 0;
-  bar_info.parent_release = 0;
+    bar_info->child_notify[i] = 0;
+  bar_info->parent_release = 0;
 
   //
   // Release our children.
@@ -3273,6 +3285,11 @@ void chpl_comm_barrier(const char *msg)
                   (void*) &child_bar_info[i]->parent_release,
                   sizeof(release_flag), NULL, may_proxy_true);
   }
+}
+
+void chpl_comm_barrier(const char *msg)
+{
+    chpl_comm_barrier_internal(msg, &rt_bar_info, rt_child_bar_info, rt_parent_bar_info);
 }
 
 

--- a/test/release/examples/benchmarks/isx/isx.chpl
+++ b/test/release/examples/benchmarks/isx/isx.chpl
@@ -17,7 +17,7 @@
 // We want to use block-distributed arrays (BlockDist), barrier
 // synchronization (Barriers), and timers (Time).
 //
-use BlockDist, Barriers, Time;
+use BlockDist, AllLocalesBarriers, Time;
 
 //
 // The type of key to use when sorting.
@@ -147,7 +147,7 @@ var totalTime, inputTime, bucketCountTime, bucketOffsetTime, bucketizeTime,
     exchangeKeysTime, countKeysTime: [DistTaskSpace] [1..numTrials] real;
 var verifyKeyCount: atomic int;
 
-var barrier = new Barrier(numTasks);
+var barrier = new AllLocalesBarrier(perBucketMultiply);
 
 // should result in one loop iteration per task
 proc main() {


### PR DESCRIPTION
Add a scalable AllLocalesBarrier and use it in ISX. 

The main scalability issue for ISx is that we use a barrier that lives on locale 0, and every other locale must do an on-stmt back to that locale to barrier locally. This is a huge bottleneck and significantly overloads locale 0 (at 256 nodes, we're creating ~10,000 tasks on locale 0, which will trigger an OOM with default call stack sizes.)

With this barrier, there are no execute-on's in ISx. There's only numLocales-1 execute-on-nb's for the initial `coforall loc in Locales do on loc ` , and everything else is just gets/puts.

The basic way it works is we do a local barrier (reusing our centralized busy-wait atomic barrier) on each locale, and the last task to enter the barrier will do a chpl_comm_barrier before releasing the barrier. This is much more scalable than the current approach, since chpl_comm_barrier is optimized/scalable (tree-based for ugni, and probably a tree or something for gasnet)

The scalability for this is good, and the overall performance is pretty high. The centralized busy-wait atomic barrier doesn't perform very well with high core-counts, but that's a fixed cost and doesn't impact locale-count scalability. 

Note, this PR is for discussion only. The individual commits will be broken out and merged separately (assuming the overall approach is ok'd)
