### PR TITLE
init-proposal :- Insert a default call to super.init() for methods with initDone()

### DIFF
--- a/test/classes/initializers/initDone-2.chpl
+++ b/test/classes/initializers/initDone-2.chpl
@@ -1,0 +1,25 @@
+class MyClass0 {
+  proc init() {
+    writeln('MyClass0.init');
+  }
+}
+
+class MyClass1 : MyClass0 {
+  const x : int = 10;
+  const y : int = 20;
+
+  proc init(val : int) {
+    writeln('MyClass1.init');
+    y = val;
+
+    initDone();
+  }
+}
+
+proc main() {
+  var c : MyClass1 = new MyClass1(50);
+
+  writeln(c);
+
+  delete c;
+}

--- a/test/classes/initializers/initDone-2.good
+++ b/test/classes/initializers/initDone-2.good
@@ -1,0 +1,3 @@
+MyClass0.init
+MyClass1.init
+{x = 10, y = 50}


### PR DESCRIPTION
Continue to integrate initializer branch to master

This PR updates normalization of initializers for classes to insert
a call to super.init() when there is no existing call but there is a
use of initDone().

Compiled/limited testing on the standard configurations.

Passed a single-locale paratest
