### PR TITLE
future: classes allow param record fields

### DIFF
--- a/test/classes/initializers/generics/param-record-field.chpl
+++ b/test/classes/initializers/generics/param-record-field.chpl
@@ -1,0 +1,11 @@
+record R { }
+
+class C {
+  param r:R;
+  proc init() { }
+}
+
+var c = new C();
+writeln(c);
+delete c;
+

--- a/test/classes/initializers/generics/param-record-field.future
+++ b/test/classes/initializers/generics/param-record-field.future
@@ -1,0 +1,6 @@
+bug: classes allow param record fields
+#8422
+
+Without the writeln(), this compiles.
+With the writeln(), there's a failure to build the generated source in
+ChapelIO.c

--- a/test/classes/initializers/generics/param-record-field.good
+++ b/test/classes/initializers/generics/param-record-field.good
@@ -1,0 +1,1 @@
+param-record-field.chpl:4: error: 'r' is not of a supported param type


### PR DESCRIPTION
Add the future test/classes/initializers/generics/param-record-field.chpl