### PR TITLE
Add future: class param field whose default value is a config var

### DIFF
--- a/test/classes/initializers/generics/param-field-default-value-non-param-config-var.chpl
+++ b/test/classes/initializers/generics/param-field-default-value-non-param-config-var.chpl
@@ -1,0 +1,9 @@
+config var notaparam = 42;
+class C {
+  param p = notaparam;
+  proc init() { }
+}
+
+var c = new C();
+writeln(c);
+delete c;

--- a/test/classes/initializers/generics/param-field-default-value-non-param-config-var.future
+++ b/test/classes/initializers/generics/param-field-default-value-non-param-config-var.future
@@ -1,0 +1,5 @@
+bug: class with initializer allows non-param default value for param field
+#8423
+
+Without the writeln() it compiles.
+With the writeln(), there's an error compiling the generated ChapelIO.c.

--- a/test/classes/initializers/generics/param-field-default-value-non-param-config-var.good
+++ b/test/classes/initializers/generics/param-field-default-value-non-param-config-var.good
@@ -1,0 +1,1 @@
+param-field-default-value-non-param-config-var.chpl:3: error: default value for param is not a param


### PR DESCRIPTION
Adds
test/classes/initializers/generics/
  param-field-default-value-non-param-config-var.chpl