### PR TITLE
Improve error messages for openfd failures

### DIFF
--- a/runtime/src/qio/qio.c
+++ b/runtime/src/qio/qio.c
@@ -769,12 +769,22 @@ qioerr qio_file_init(qio_file_t** file_out, FILE* fp, fd_t fd, qio_hint_t iohint
              ftype == S_IFBLK ) {
     // regular file or block device can seek
     seekable = 1;
+  } else if( ftype == S_IFDIR ) {
+    if( fd == 0 ) {
+      QIO_RETURN_CONSTANT_ERROR(EINVAL, "fd 0 (stdin) is a directory");
+    } else if( fd == 1 ) {
+      QIO_RETURN_CONSTANT_ERROR(EINVAL, "fd 1 (stdout) is a directory");
+    } else if( fd == 2 ) {
+      QIO_RETURN_CONSTANT_ERROR(EINVAL, "fd 2 (stderr) is a directory");
+    } else {
+      QIO_RETURN_CONSTANT_ERROR(EINVAL, "cannot openfd a directory");
+    }
+  } else if( ftype == S_IFLNK ) {
+    QIO_RETURN_CONSTANT_ERROR(EINVAL, "cannot openfd a symbolic link");
   } else {
-    // ftype == S_IFDIR
-    // ftype == S_IFLNK
     // ftype == S_IFWHT on Mac OS X
-    // can't open symlink/dir/whiteout
-    QIO_RETURN_CONSTANT_ERROR(EINVAL, "file type not openable");
+    // can't open a whiteout
+    QIO_RETURN_CONSTANT_ERROR(EINVAL, "unhandled file type in openfd");
   }
 
   if( seekable ) {

--- a/test/io/ferguson/stdin-is-directory/hello.chpl
+++ b/test/io/ferguson/stdin-is-directory/hello.chpl
@@ -1,0 +1,1 @@
+writeln("Hello");

--- a/test/io/ferguson/stdin-is-directory/stdin-is-directory.chpl
+++ b/test/io/ferguson/stdin-is-directory/stdin-is-directory.chpl
@@ -1,0 +1,19 @@
+const filename = "hello.chpl";
+
+proc mysystem(cmd: string): int {
+  use Spawn;
+  var sub = spawnshell(cmd);
+  sub.wait();
+  return sub.exit_status;
+}
+
+var ret = mysystem(CHPL_HOME + "/bin/" + CHPL_HOST_PLATFORM + "/" +
+                   "chpl -o a.out " + filename);
+if ret != 0 then
+  halt("Error compiling Chapel code");
+
+ret = mysystem("./a.out < test-dir");
+
+ret = mysystem("rm a.out*");
+if ret != 0 then
+  halt("Error removing a.out executable(s)");

--- a/test/io/ferguson/stdin-is-directory/stdin-is-directory.good
+++ b/test/io/ferguson/stdin-is-directory/stdin-is-directory.good
@@ -1,3 +1,3 @@
-uncaught SystemError: Invalid argument: fd 0 (stdin) is a directory (in openfd with path "/home/mppf/w/1/test/io/ferguson/stdin-is-directory/test-dir")
+uncaught SystemError: Invalid argument: fd 0 (stdin) is a directory (in openfd with path "/<snip>/test-dir")
   <internal>:0: thrown here
   <internal>:0: uncaught here

--- a/test/io/ferguson/stdin-is-directory/stdin-is-directory.good
+++ b/test/io/ferguson/stdin-is-directory/stdin-is-directory.good
@@ -1,0 +1,3 @@
+uncaught SystemError: Invalid argument: fd 0 (stdin) is a directory (in openfd with path "/home/mppf/w/1/test/io/ferguson/stdin-is-directory/test-dir")
+  <internal>:0: thrown here
+  <internal>:0: uncaught here

--- a/test/io/ferguson/stdin-is-directory/stdin-is-directory.prediff
+++ b/test/io/ferguson/stdin-is-directory/stdin-is-directory.prediff
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+
+# This prediff exists to change absolute
+# paths into relative paths.
+ 
+import sys, re
+
+execout=sys.argv[2]
+
+fh = open(execout, 'r')
+myLines = fh.readlines()
+fh.close()
+
+fh = open(execout, 'w')
+for line in myLines:
+    fixed = re.sub(r'".*test-dir"', '"/<snip>/test-dir"', line)
+    fh.write(fixed)
+fh.close()

--- a/test/io/ferguson/stdin-is-directory/stdin-is-directory.prediff
+++ b/test/io/ferguson/stdin-is-directory/stdin-is-directory.prediff
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-# This prediff exists to change absolute
-# paths into relative paths.
+# This prediff exists to change an absolute
+# paths like /home/user/chapel/test/io/ferguson/test-dir
+# into /<snip>/test-dir
  
 import sys, re
 

--- a/test/io/ferguson/stdin-is-directory/test-dir/README
+++ b/test/io/ferguson/stdin-is-directory/test-dir/README
@@ -1,0 +1,1 @@
+This file exists to make sure the directory is checked out by git.


### PR DESCRIPTION
In nightly testing, we've seen several errors of this form:
```
uncaught SystemError: 'file type not openable (in openfd with path "/")
```

This is probably coming from some sort of system / launcher issue, but the error message leaves a few open questions. This PR simply improves the error message to add more detail so we can better understand what is going wrong if it happens again. Additionally, it adds a test to make sure we get a reasonable error in this case.

- [x] full local testing

Reviewed by @psahabu - thanks!