### PR TITLE
coforall/try! bug

### DIFF
--- a/compiler/passes/errorHandling.cpp
+++ b/compiler/passes/errorHandling.cpp
@@ -837,9 +837,6 @@ void ErrorCheckingVisitor::checkCatches(TryStmt* tryStmt) {
 }
 
 bool ErrorCheckingVisitor::enterCallExpr(CallExpr* node) {
-  if (node->id == 637145) {
-    gdbShouldBreakHere();
-  }
   bool insideTry = (tryDepth > 0);
 
   if (FnSymbol* calledFn = node->resolvedFunction()) {
@@ -923,8 +920,6 @@ static void markImplicitThrows(FnSymbol* fn, std::set<FnSymbol*>* visited, impli
   // Currently, only task functions can be implicitly throws.
   if (!isTaskFun(fn))
     return;
-
-  gdbShouldBreakHere();
 
   // If we already visited this function, don't visit it again.
   if (visited->count(fn) > 0)

--- a/compiler/passes/errorHandling.cpp
+++ b/compiler/passes/errorHandling.cpp
@@ -588,6 +588,8 @@ static void printReason(BaseAST* node, implicitThrowsReasons_t* reasons)
 
 // Returns true if the catches don't cover all of the cases.
 static bool catchesNotExhaustive(TryStmt* tryStmt) {
+  if (tryStmt->tryBang())
+    return false;
 
   bool hasCatchAll = false;
 
@@ -692,18 +694,15 @@ bool ImplicitThrowsVisitor::enterTryStmt(TryStmt* node) {
 void ImplicitThrowsVisitor::exitTryStmt(TryStmt* node) {
   tryDepth--;
 
-  // is it an exhaustive catch?
-
+  // is it a non-exhaustive catch?
   bool nonExhaustive = catchesNotExhaustive(node);
 
-  if (!node->tryBang()) {
-    canThrow = nonExhaustive;
-    if (nonExhaustive)
-      onlyUnchecked = false;
-    if (reasonThrows == NULL)
-      reasonThrows = node;
-  }
-  // try! does not change the throwing status of a block
+  if (tryDepth == 0)
+    canThrow = canThrow || nonExhaustive;
+  if (nonExhaustive)
+    onlyUnchecked = false;
+  if (reasonThrows == NULL)
+    reasonThrows = node;
 }
 
 bool ImplicitThrowsVisitor::enterCallExpr(CallExpr* node) {
@@ -801,12 +800,8 @@ void ErrorCheckingVisitor::exitTryStmt(TryStmt* node) {
   // is it an exhaustive catch?
   bool nonExhaustive = catchesNotExhaustive(node);
 
-  if (node->tryBang()) {
-    // OK
-  } else {
-    if (tryDepth==0 && nonExhaustive && !fnCanThrow) {
-      USR_FATAL_CONT(node, "try without a catchall in a non-throwing function");
-    }
+  if (tryDepth==0 && nonExhaustive && !fnCanThrow) {
+    USR_FATAL_CONT(node, "try without a catchall in a non-throwing function");
   }
 }
 

--- a/test/errhandling/psahabu/coforall-try-bang-2.chpl
+++ b/test/errhandling/psahabu/coforall-try-bang-2.chpl
@@ -1,0 +1,15 @@
+module Test {
+  proc throwme() throws {
+    throw new Error();
+  }
+
+  proc test() {
+    coforall i in 1..10 {
+      try! {
+        throwme();
+      }
+    }
+  }
+
+  test();
+}

--- a/test/errhandling/psahabu/coforall-try-bang-2.good
+++ b/test/errhandling/psahabu/coforall-try-bang-2.good
@@ -1,0 +1,3 @@
+uncaught Error: 
+  coforall-try-bang-2.chpl:3: thrown here
+  coforall-try-bang-2.chpl:8: uncaught here

--- a/test/errhandling/psahabu/coforall-try-bang-nested.chpl
+++ b/test/errhandling/psahabu/coforall-try-bang-nested.chpl
@@ -1,0 +1,17 @@
+module Test {
+  proc throwme() throws {
+    throw new Error();
+  }
+
+  proc test() {
+    coforall i in 1..10 {
+      try! {
+        try {
+          throwme();
+        }
+      }
+    }
+  }
+
+  test();
+}

--- a/test/errhandling/psahabu/coforall-try-bang-nested.good
+++ b/test/errhandling/psahabu/coforall-try-bang-nested.good
@@ -1,0 +1,3 @@
+uncaught Error: 
+  coforall-try-bang-nested.chpl:3: thrown here
+  coforall-try-bang-nested.chpl:8: uncaught here

--- a/test/errhandling/psahabu/coforall-try-bang.chpl
+++ b/test/errhandling/psahabu/coforall-try-bang.chpl
@@ -1,0 +1,15 @@
+module Test {
+  proc throwme() throws {
+    throw new IllegalArgumentError("Bozos", "Sing");
+  }
+
+  proc test() {
+    coforall i in 1..10 {
+      writeln(i);
+      throwme();
+      try! { }
+    }
+  }
+
+  test();
+}

--- a/test/errhandling/psahabu/coforall-try-bang.good
+++ b/test/errhandling/psahabu/coforall-try-bang.good
@@ -1,0 +1,4 @@
+coforall-try-bang.chpl:6: In function 'test':
+coforall-try-bang.chpl:7: error: call to throwing function coforall_fn without throws, try, or try! (relaxed mode)
+coforall-try-bang.chpl:7: note: throwing function coforall_fn defined here
+note: call to throwing function here

--- a/test/errhandling/psahabu/coforall-try-bang.good
+++ b/test/errhandling/psahabu/coforall-try-bang.good
@@ -1,4 +1,4 @@
 coforall-try-bang.chpl:6: In function 'test':
 coforall-try-bang.chpl:7: error: call to throwing function coforall_fn without throws, try, or try! (relaxed mode)
 coforall-try-bang.chpl:7: note: throwing function coforall_fn defined here
-note: call to throwing function here
+coforall-try-bang.chpl:10: note: call to throwing function here


### PR DESCRIPTION
@benharsh discovered a bug in error handling where a `try!` at the end of a `coforall` block allows unhandled throwing calls to escape within the `coforall`. For example:

``` chapel
// throwme() is unhandled, but this passes checking
proc test() {
  coforall i in 1..10 {
    writeln(i);
    throwme();
    try! { }
  }
}
```

The error ended up being in `ImplicitThrowsVisitor`, where `exitTryStmt()` would mark an entire function block as non-throwing if `try!` was the last statement. This was triggered by a `coforall` because they are lowered into a `coforall_fn()` during compilation.

This change required additional checking on `throw` statements in order to maintain correctness.

- [x] linux64+flat testing