### PR TITLE
Fix testing after range default intent

### DIFF
--- a/test/distributions/robust/arithmetic/performance/multilocale/alloc.cyclic.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/alloc.cyclic.good
@@ -1,10 +1,10 @@
 Dom1D
-(execute_on = 4, execute_on_nb = 6) (get = 39, put = 1, execute_on = 2, execute_on_fast = 2) (get = 39, put = 1, execute_on_fast = 2) (get = 39, put = 1, execute_on_fast = 2)
+(execute_on = 4, execute_on_nb = 6) (get = 38, put = 1, execute_on = 2, execute_on_fast = 2) (get = 38, put = 1, execute_on_fast = 2) (get = 38, put = 1, execute_on_fast = 2)
 Dom2D
-(execute_on = 4, execute_on_nb = 6) (get = 48, put = 1, execute_on = 2, execute_on_fast = 2) (get = 48, put = 1, execute_on_fast = 2) (get = 48, put = 1, execute_on_fast = 2)
+(execute_on = 4, execute_on_nb = 6) (get = 45, put = 1, execute_on = 2, execute_on_fast = 2) (get = 45, put = 1, execute_on_fast = 2) (get = 45, put = 1, execute_on_fast = 2)
 Dom3D
-(execute_on = 4, execute_on_nb = 6) (get = 67, put = 1, execute_on = 2, execute_on_fast = 2) (get = 67, put = 1, execute_on_fast = 2) (get = 67, put = 1, execute_on_fast = 2)
+(execute_on = 4, execute_on_nb = 6) (get = 60, put = 1, execute_on = 2, execute_on_fast = 2) (get = 60, put = 1, execute_on_fast = 2) (get = 60, put = 1, execute_on_fast = 2)
 Dom4D
-(execute_on = 4, execute_on_nb = 6) (get = 86, put = 1, execute_on = 2, execute_on_fast = 2) (get = 86, put = 1, execute_on_fast = 2) (get = 86, put = 1, execute_on_fast = 2)
+(execute_on = 4, execute_on_nb = 6) (get = 75, put = 1, execute_on = 2, execute_on_fast = 2) (get = 75, put = 1, execute_on_fast = 2) (get = 75, put = 1, execute_on_fast = 2)
 Dom2D32
-(execute_on = 4, execute_on_nb = 6) (get = 48, put = 1, execute_on = 2, execute_on_fast = 2) (get = 48, put = 1, execute_on_fast = 2) (get = 48, put = 1, execute_on_fast = 2)
+(execute_on = 4, execute_on_nb = 6) (get = 45, put = 1, execute_on = 2, execute_on_fast = 2) (get = 45, put = 1, execute_on_fast = 2) (get = 45, put = 1, execute_on_fast = 2)

--- a/test/distributions/robust/arithmetic/performance/multilocale/alloc_all.cyclic.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/alloc_all.cyclic.good
@@ -1,10 +1,10 @@
 Dom1D
-(get = 117, put = 6, execute_on = 16, execute_on_fast = 6, execute_on_nb = 9) (get = 117, put = 3, execute_on = 11, execute_on_fast = 7, execute_on_nb = 6) (get = 117, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6) (get = 117, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6)
+(get = 114, put = 6, execute_on = 16, execute_on_fast = 6, execute_on_nb = 9) (get = 114, put = 3, execute_on = 11, execute_on_fast = 7, execute_on_nb = 6) (get = 114, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6) (get = 114, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6)
 Dom2D
-(get = 144, put = 6, execute_on = 16, execute_on_fast = 6, execute_on_nb = 9) (get = 144, put = 3, execute_on = 11, execute_on_fast = 7, execute_on_nb = 6) (get = 144, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6) (get = 144, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6)
+(get = 135, put = 6, execute_on = 16, execute_on_fast = 6, execute_on_nb = 9) (get = 135, put = 3, execute_on = 11, execute_on_fast = 7, execute_on_nb = 6) (get = 135, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6) (get = 135, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6)
 Dom3D
-(get = 201, put = 6, execute_on = 16, execute_on_fast = 6, execute_on_nb = 9) (get = 201, put = 3, execute_on = 11, execute_on_fast = 7, execute_on_nb = 6) (get = 201, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6) (get = 201, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6)
+(get = 180, put = 6, execute_on = 16, execute_on_fast = 6, execute_on_nb = 9) (get = 180, put = 3, execute_on = 11, execute_on_fast = 7, execute_on_nb = 6) (get = 180, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6) (get = 180, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6)
 Dom4D
-(get = 258, put = 6, execute_on = 16, execute_on_fast = 6, execute_on_nb = 9) (get = 258, put = 3, execute_on = 11, execute_on_fast = 7, execute_on_nb = 6) (get = 258, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6) (get = 258, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6)
+(get = 225, put = 6, execute_on = 16, execute_on_fast = 6, execute_on_nb = 9) (get = 225, put = 3, execute_on = 11, execute_on_fast = 7, execute_on_nb = 6) (get = 225, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6) (get = 225, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6)
 Dom2D32
-(get = 144, put = 6, execute_on = 16, execute_on_fast = 6, execute_on_nb = 9) (get = 144, put = 3, execute_on = 11, execute_on_fast = 7, execute_on_nb = 6) (get = 144, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6) (get = 144, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6)
+(get = 135, put = 6, execute_on = 16, execute_on_fast = 6, execute_on_nb = 9) (get = 135, put = 3, execute_on = 11, execute_on_fast = 7, execute_on_nb = 6) (get = 135, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6) (get = 135, put = 3, execute_on = 3, execute_on_fast = 7, execute_on_nb = 6)

--- a/test/io/ferguson/stdin-is-directory/stdin-is-directory.chpl
+++ b/test/io/ferguson/stdin-is-directory/stdin-is-directory.chpl
@@ -12,7 +12,7 @@ var ret = mysystem(CHPL_HOME + "/bin/" + CHPL_HOST_PLATFORM + "/" +
 if ret != 0 then
   halt("Error compiling Chapel code");
 
-ret = mysystem("./a.out < test-dir");
+ret = mysystem("./a.out -nl 1 < test-dir");
 
 ret = mysystem("rm a.out*");
 if ret != 0 then

--- a/test/modules/sungeun/init/printInitCommCounts.good
+++ b/test/modules/sungeun/init/printInitCommCounts.good
@@ -1,1 +1,1 @@
-(execute_on = 4, execute_on_fast = 4, execute_on_nb = 4) (get = 16, put = 3, execute_on_fast = 6) (get = 16, put = 3, execute_on_fast = 6) (get = 16, put = 3, execute_on_fast = 6) (get = 16, put = 3, execute_on_fast = 6)
+(execute_on = 4, execute_on_fast = 4, execute_on_nb = 4) (get = 14, put = 3, execute_on_fast = 6) (get = 14, put = 3, execute_on_fast = 6) (get = 14, put = 3, execute_on_fast = 6) (get = 14, put = 3, execute_on_fast = 6)

--- a/test/optimizations/remoteValueForwarding/serialization/domains.good
+++ b/test/optimizations/remoteValueForwarding/serialization/domains.good
@@ -1,7 +1,7 @@
 ===== on-stmt (variable domain) =====
 {1..10}
 LOCALE0: (<no communication>)
-LOCALE1: (get = 15, put = 1, execute_on = 1)
+LOCALE1: (get = 9, put = 1, execute_on = 1)
 ===== on-stmt (const domain) =====
 LOCALE0: (<no communication>)
 LOCALE1: (<no communication>)

--- a/test/performance/ferguson/remote-array-write.chpl
+++ b/test/performance/ferguson/remote-array-write.chpl
@@ -17,4 +17,4 @@ stop();
 writeln(A[1]);
 writeln(A[n]);
 
-report(maxGets=8, maxOns=1);
+report(maxGets=5, maxOns=1);

--- a/test/performance/ferguson/remote-record-write-copy.chpl
+++ b/test/performance/ferguson/remote-record-write-copy.chpl
@@ -26,4 +26,4 @@ stop();
 writeln(A[1]);
 writeln(A[n]);
 
-report(maxGets=8, maxOns=1);
+report(maxGets=5, maxOns=1);

--- a/test/performance/ferguson/remote-record-write.chpl
+++ b/test/performance/ferguson/remote-record-write.chpl
@@ -27,4 +27,4 @@ stop();
 writeln(A[1]);
 writeln(A[n]);
 
-report(maxGets=8, maxOns=1);
+report(maxGets=5, maxOns=1);

--- a/test/performance/ferguson/remote-tuple-write-copy.chpl
+++ b/test/performance/ferguson/remote-tuple-write-copy.chpl
@@ -22,4 +22,4 @@ stop();
 writeln(A[1]);
 writeln(A[n]);
 
-report(maxGets=8, maxOns=1);
+report(maxGets=5, maxOns=1);

--- a/test/performance/ferguson/remote-tuple-write-small-copy.chpl
+++ b/test/performance/ferguson/remote-tuple-write-small-copy.chpl
@@ -22,4 +22,4 @@ stop();
 writeln(A[1]);
 writeln(A[n]);
 
-report(maxGets=8, maxOns=1);
+report(maxGets=5, maxOns=1);

--- a/test/performance/ferguson/remote-tuple-write-small.chpl
+++ b/test/performance/ferguson/remote-tuple-write-small.chpl
@@ -20,4 +20,4 @@ stop();
 writeln(A[1]);
 writeln(A[n]);
 
-report(maxGets=8, maxOns=1);
+report(maxGets=5, maxOns=1);

--- a/test/performance/ferguson/remote-tuple-write.chpl
+++ b/test/performance/ferguson/remote-tuple-write.chpl
@@ -20,4 +20,4 @@ stop();
 writeln(A[1]);
 writeln(A[n]);
 
-report(maxGets=8, maxOns=1);
+report(maxGets=5, maxOns=1);

--- a/test/performance/hilde/coforallOnByRef.good
+++ b/test/performance/hilde/coforallOnByRef.good
@@ -1,1 +1,1 @@
-(execute_on_nb = 1) (get = 4, put = 1, execute_on_fast = 1)
+(execute_on_nb = 1) (get = 3, put = 1, execute_on_fast = 1)

--- a/test/performance/hilde/userSync.good
+++ b/test/performance/hilde/userSync.good
@@ -3,4 +3,4 @@ Called visitLocales().
 Called visitLocales().
 Called visitLocales().
 Called visitLocales().
-(get = 36, put = 8, execute_on = 4, execute_on_nb = 4) (get = 4, put = 2, execute_on = 1, execute_on_fast = 1) (get = 4, put = 2, execute_on = 1, execute_on_fast = 1) (get = 4, put = 2, execute_on = 1, execute_on_fast = 1) (get = 4, put = 2, execute_on = 1, execute_on_fast = 1)
+(get = 36, put = 8, execute_on = 4, execute_on_nb = 4) (get = 3, put = 2, execute_on = 1, execute_on_fast = 1) (get = 3, put = 2, execute_on = 1, execute_on_fast = 1) (get = 3, put = 2, execute_on = 1, execute_on_fast = 1) (get = 3, put = 2, execute_on = 1, execute_on_fast = 1)

--- a/test/studies/hpcc/CommDiags/stream-ep_commDiags.good
+++ b/test/studies/hpcc/CommDiags/stream-ep_commDiags.good
@@ -3,5 +3,5 @@ Bytes per array = 256
 Total memory required (GB) = 7.15256e-07
 Number of trials = 10
 
-(execute_on_nb = 3) (get = 8, put = 2, execute_on_fast = 1) (get = 8, put = 2, execute_on_fast = 1) (get = 8, put = 2, execute_on_fast = 1)
+(execute_on_nb = 3) (get = 6, put = 2, execute_on_fast = 1) (get = 6, put = 2, execute_on_fast = 1) (get = 6, put = 2, execute_on_fast = 1)
 Validation: SUCCESS


### PR DESCRIPTION
This PR addresses testing failures from PR #8368 and PR #8448.

Several tests are showing comm count improvements from PR #8368 - this
PR just accepts the improvement.

The new test stdin-is-directory  added in PR #8448 needed to pass `-nl 1` to
the compiled program to work in a multilocale setting.

Testing changes only - not reviewed.