### PR TITLE
Add tests of duplicate function / variable / type

### DIFF
--- a/test/functions/ferguson/hijacking/DuplicateFunction.chpl
+++ b/test/functions/ferguson/hijacking/DuplicateFunction.chpl
@@ -1,0 +1,27 @@
+module LibraryX1 {
+  proc setup() {
+    writeln("In LibraryX1.setup");
+  }
+  proc run() {
+    setup();
+  }
+}
+
+module LibraryY1 {
+  proc setup() {
+    writeln("In LibraryY1.setup");
+  }
+  proc run() {
+    setup();
+  }
+}
+
+module Main {
+  use LibraryX1;
+  use LibraryY1;
+
+  proc main() {
+    LibraryX1.run();
+    LibraryY1.run();
+  }
+}

--- a/test/functions/ferguson/hijacking/DuplicateFunction.good
+++ b/test/functions/ferguson/hijacking/DuplicateFunction.good
@@ -1,0 +1,2 @@
+In LibraryX1.setup
+In LibraryY1.setup

--- a/test/functions/ferguson/hijacking/DuplicateType.chpl
+++ b/test/functions/ferguson/hijacking/DuplicateType.chpl
@@ -1,0 +1,45 @@
+module LibraryX1 {
+
+  class MyClass {
+    var x:int;
+  }
+
+  var global:MyClass;
+  proc setup() {
+    writeln("In LibraryX1.setup");
+    global = new MyClass(10);
+  }
+  proc run() {
+    setup();
+    writeln("In LibraryX1.run global is ", global);
+  }
+}
+
+module LibraryY1 {
+  
+  class MyClass {
+    var x:int;
+    var y:int;
+  }
+
+
+  var global:MyClass;
+  proc setup() {
+    writeln("In LibraryY1.setup");
+    global = new MyClass(1,2);
+  }
+  proc run() {
+    setup();
+    writeln("In LibraryY1.run global is ", global);
+  }
+}
+
+module Main {
+  use LibraryX1;
+  use LibraryY1;
+
+  proc main() {
+    LibraryX1.run();
+    LibraryY1.run();
+  }
+}

--- a/test/functions/ferguson/hijacking/DuplicateType.good
+++ b/test/functions/ferguson/hijacking/DuplicateType.good
@@ -1,0 +1,4 @@
+In LibraryX1.setup
+In LibraryX1.run global is {x = 10}
+In LibraryY1.setup
+In LibraryY1.run global is {x = 1, y = 2}


### PR DESCRIPTION
In thinking about CHIP 20, I realized the set of tests would be more
complete if they included tests for two simpler cases. This PR just
adds two simple tests.

I view issue #7847 as related in that a "library" might include multiple modules,
and adding a module to a library might break programs that were working
with a previous version of that library, simply due to naming conflict with
another library.

Test change only, not reviewed.