### PR TITLE
Better errors for param initialization

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -4902,6 +4902,15 @@ static void resolveInitField(CallExpr* call) {
   if (t == dtUnknown)
     INT_FATAL(call, "Unable to resolve field type");
 
+  if (fs->hasFlag(FLAG_PARAM)) {
+    if (isLegalParamType(t) == false) {
+      USR_FATAL_CONT(fs, "'%s' is not of a supported param type", fs->name);
+    }
+    if (rhs->symbol()->isParameter() == false) {
+      USR_FATAL_CONT(call, "Initializing parameter '%s' to value not known at compile time", fs->name);
+    }
+  }
+
   if (t == dtNil && fs->type == dtUnknown)
     USR_FATAL(call->parentSymbol, "unable to determine type of field from nil");
   if (fs->type == dtUnknown) {

--- a/test/classes/initializers/generics/init-param-from-non-param.future
+++ b/test/classes/initializers/generics/init-param-from-non-param.future
@@ -1,3 +1,0 @@
-bug: initializers allow assignment of non-params to param fields
-#8406
-

--- a/test/classes/initializers/generics/init-param-from-non-param.good
+++ b/test/classes/initializers/generics/init-param-from-non-param.good
@@ -1,1 +1,2 @@
+init-param-from-non-param.chpl:3: In initializer:
 init-param-from-non-param.chpl:5: error: Initializing parameter 'p' to value not known at compile time

--- a/test/classes/initializers/generics/param-record-field.future
+++ b/test/classes/initializers/generics/param-record-field.future
@@ -1,6 +1,0 @@
-bug: classes allow param record fields
-#8422
-
-Without the writeln(), this compiles.
-With the writeln(), there's a failure to build the generated source in
-ChapelIO.c

--- a/test/types/records/init/record-with-record-param.future
+++ b/test/types/records/init/record-with-record-param.future
@@ -1,2 +1,0 @@
-error message: Confusing error message
-#8438


### PR DESCRIPTION
Param field initialization is handled in a different path than other primitives, meaning that it couldn't rely on pre-existing error checking for params. This PR  updates ``resolveInitField`` to check two cases:
1) Verify that the field's type is valid for params
2) Verify that the value is known at compile-time

Closes #8406 
Closes #8422 
Closes #8438

Testing:
- [x] full local + futures