### PR TITLE
Mark regressions for JIRA issue 324

### DIFF
--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -1894,10 +1894,12 @@ for testname in testsrc:
                             launcher_error = 'Jira 193 -- Unexpected close of apsys for'
                         elif re.search('Transient MPP reservation error on create', output, re.IGNORECASE) != None:
                             launcher_error = 'Jira 203 -- Transient MPP reservation error for'
-                        elif re.search('Fatal MPP reservation error on confirm', output, re.IGNORECASE) != None:
-                            launcher_error = 'Jira 329 -- Fatal MPP reservation error for'
                         elif re.search('Failed to recv data from background qsub', output, re.IGNORECASE) != None:
                             launcher_error = 'Jira 260 -- Failed to recv data from background qsub for'
+                        elif (re.search(r'\d+ Killed', output) and re.search('/var/spool/PBS/mom_priv/jobs', output)):
+                            launcher_error = 'Jira 324 -- PBS job killed for'
+                        elif re.search('Fatal MPP reservation error on confirm', output, re.IGNORECASE) != None:
+                            launcher_error = 'Jira 329 -- Fatal MPP reservation error for'
                         elif (re.search('PBS: job killed: walltime', output, re.IGNORECASE) != None or
                               re.search('slurm.* CANCELLED .* DUE TO TIME LIMIT', output, re.IGNORECASE) != None):
                             exectimeout = True


### PR DESCRIPTION
Detect regressions with messages like the below in the test output:
```
    -bash: line 1: 35989 Killed                  /var/spool/PBS/mom_priv/jobs/274019.sdb.SC
    /var/spool/PBS/mom_priv/jobs/274613.sdb.SC: line 1:  5203 Killed                  ./here-id -nl 4
```
and mark them with a recognizable error msg,
    `Jira 324 -- PBS job killed`
for easier triage.