### PR TITLE
Fix chip 20 application 8

### DIFF
--- a/doc/rst/developer/chips/20.rst
+++ b/doc/rst/developer/chips/20.rst
@@ -543,7 +543,7 @@ The application developer updates to the latest LibraryZ:
     }
 
     proc main() {
-      var instance = new Widget();
+      var instance:Base = new Widget();
       var x = 1;
       instance.run(x);
       delete instance;
@@ -554,10 +554,12 @@ It outputs
 
 ::
 
-  In Application.Widget.run
+  starting LibraryZ.Base.run!
 
-which is what we want! Not all languages would have that output for this
-example.
+which might be surprising. In particular, it might be confusing to the
+user whether or not they were overriding ``proc run``. The following
+sections cover potential solutions to this problem, including an
+``override`` keyword.
 
 New Method is Accidentally Overridden
 +++++++++++++++++++++++++++++++++++++

--- a/test/functions/ferguson/hijacking/Application8_cast.bad
+++ b/test/functions/ferguson/hijacking/Application8_cast.bad
@@ -1,0 +1,1 @@
+starting LibraryZ.Base.run!

--- a/test/functions/ferguson/hijacking/Application8_cast.chpl
+++ b/test/functions/ferguson/hijacking/Application8_cast.chpl
@@ -1,0 +1,23 @@
+  module LibraryZ2 {
+    class Base {
+      proc run(x:int) {
+        writeln("starting LibraryZ.Base.run!");
+      }
+    }
+  }
+  module Application8 {
+    use LibraryZ2;
+
+    class Widget : Base {
+      proc run(x:real) {
+        writeln("In Application.Widget.foo");
+      }
+    }
+
+    proc main() {
+      var instance:Base = new Widget();
+      var x = 1;
+      instance.run(x);
+      delete instance;
+    }
+  }

--- a/test/functions/ferguson/hijacking/Application8_cast.future
+++ b/test/functions/ferguson/hijacking/Application8_cast.future
@@ -1,0 +1,2 @@
+design: incomplete overriding and overloading should cause error
+#6252

--- a/test/functions/ferguson/hijacking/Application8_cast.good
+++ b/test/functions/ferguson/hijacking/Application8_cast.good
@@ -1,0 +1,1 @@
+compilation error


### PR DESCRIPTION
When discussing CHIP 20 with other developers, we noticed that Application8 wasn't testing what it was intended to.

This PR makes a quick adjustment to the document to solve this problem and adds the new version as a .future test (leaving the old version, that seemed to work correctly, as a regular test).

Test / documentation changes only, not reviewed.