### PR TITLE
Fix MPI for CHPL_COMM=ugni

### DIFF
--- a/modules/packages/MPI.chpl
+++ b/modules/packages/MPI.chpl
@@ -290,7 +290,8 @@ module MPI {
             var cookieJar = pmiGniCookie.split(":");
             const lastcookie = cookieJar.domain.last;
             cookieJar[lastcookie] = ((cookieJar[lastcookie]):int + 1):string;
-            C_Env.setenv("PMI_GNI_COOKIE",("%s".format(":".join(cookieJar))).c_str(),1);
+            const newVal = ":".join(cookieJar);
+            C_Env.setenv("PMI_GNI_COOKIE",newVal.c_str(),1);
           }
         }
     }


### PR DESCRIPTION
The MPI package started to fail to compile under CHPL_COMM=ugni sometime this release cycle. It failed because ``string.format`` started to ``throw``, and was uncaught. We didn't catch it because we don't yet have nightly testing for this configuration.

The ``format`` call turned out to be unnecessary, and removing it resolves the failure.

Testing:
- [x] library/packages/MPI with CHPL_COMM=ugni