### PR TITLE
Make it easier to run valgrind testing

### DIFF
--- a/util/start_test
+++ b/util/start_test
@@ -787,6 +787,28 @@ def set_up_general():
             logger.write("[valgrind: OFF]")
             os.environ["CHPL_TEST_VGRND_EXE"] = "off"
 
+    if args.valgrind or args.valgrind_exe:
+      # Set a maximum number of threads per locale for valgrind testing.
+      # Without this, several task-heavy tests will fail.
+      if not "CHPL_RT_NUM_THREADS_PER_LOCALE" in os.environ:
+        os.environ["CHPL_RT_NUM_THREADS_PER_LOCALE"] = "100";
+
+      # Additionally, fail with an error if valgrind testing
+      # is running with qthreads or jemalloc.
+      tasks = chpl_tasks.get();
+      mem = chpl_mem.get();
+      if tasks != "fifo":
+        print("Cannot run valgrind testing unless CHPL_TASKS=fifo - "
+              "try the quickstart config?")
+        print("Note, CHPL_TASKS was {0}".format(tasks));
+        sys.exit(-1)
+      if mem != "cstdlib":
+        print("Cannot run valgrind testing unless CHPL_MEM=cstdlib - "
+              "try the quickstart config?")
+        print ("Note, CHPL_MEM was {0}".format(mem));
+        sys.exit(-1)
+
+
     # compiler
     global compiler
     if not args.compiler:

--- a/util/test/paratest.server
+++ b/util/test/paratest.server
@@ -662,8 +662,8 @@ sub main {
 
     # Check for a compatible valgrind configuration
     if ($valgrind > 0) {
-      $tasks = `../util/chplenv/chpl_tasks.py`; chomp $tasks;
-      $mem = `../util/chplenv/chpl_mem.py`; chomp $mem;
+      $tasks = `$ENV{CHPL_HOME}/util/chplenv/chpl_tasks.py`; chomp $tasks;
+      $mem = `$ENV{CHPL_HOME}/util/chplenv/chpl_mem.py`; chomp $mem;
 
       if ($tasks ne "fifo") {
         die "Error: valgrind requires tasks=fifo - try quickstart";

--- a/util/test/paratest.server
+++ b/util/test/paratest.server
@@ -660,6 +660,19 @@ sub main {
 
     die "Error: CHPL_HOME must be set\n" unless defined $ENV{CHPL_HOME};
 
+    # Check for a compatible valgrind configuration
+    if ($valgrind > 0) {
+      $tasks = `../util/chplenv/chpl_tasks.py`; chomp $tasks;
+      $mem = `../util/chplenv/chpl_mem.py`; chomp $mem;
+
+      if ($tasks ne "fifo") {
+        die "Error: valgrind requires tasks=fifo - try quickstart";
+      }
+      if ($mem ne "cstdlib") {
+        die "Error: valgrind requires mem=cstdlib - try quickstart";
+      }
+    }
+
 # Set some more environment variables so they can be tested by skipif
     $ENV{'COMPOPTS'} = $compopts;
     $ENV{'EXECOPTS'} = $execopts;


### PR DESCRIPTION
This PR makes paratest.server and start_test check for a common misconfiguration of valgrind (running it not in quickstart mode) and error out.

Additionally, it adjust start_test to set CHPL_RT_NUM_THREADS_PER_LOCALE=100 as nightly valgrind testing does if that environment variable is not already set.

Resolves #5492.

- [x] verified that studies/comd/llnl/CoMD can now pass with -valgrind
- [x] verified error on paratest in misconfiguration
- [x] verified error on start_test in misconfiguration
- [x] full local paratest

Reviewed by @ronawho - thanks!