### PR TITLE
Initializers: Enable fields with conditional types

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -4790,7 +4790,7 @@ static void updateFieldsMember(Expr* expr, FnSymbol* fn, DefExpr* currField) {
   if (SymExpr* symExpr = toSymExpr(expr)) {
     Symbol* sym = symExpr->symbol();
     SymExpr* _this = new SymExpr(fn->_this);
-    AggregateType* _thisType = toAggregateType(_this->symbol()->type);
+    AggregateType* _thisType = toAggregateType(_this->symbol()->getValType());
     INT_ASSERT(_thisType);
 
     if (DefExpr* fieldDef = _thisType->toLocalField(symExpr)) {

--- a/test/classes/initializers/generics/typeFunctions/conditionalFieldType.chpl
+++ b/test/classes/initializers/generics/typeFunctions/conditionalFieldType.chpl
@@ -1,0 +1,59 @@
+
+proc helper(param cond : bool, type t) type {
+  if cond {
+    return t;
+  } else {
+    return void;
+  }
+}
+
+record R {
+  type idxType;
+  param stridable : bool;
+
+  var stride : helper(stridable, idxType);
+
+  proc init(type idxType,
+            param stridable : bool,
+            stride : int = 1) {
+    this.idxType = idxType;
+    this.stridable = stridable;
+    super.init();
+    if stridable then this.stride = stride;
+  }
+}
+
+class C {
+  type idxType;
+  param stridable : bool;
+
+  var stride : helper(stridable, idxType);
+
+  proc init(type idxType,
+            param stridable : bool,
+            stride : int = 1) {
+    this.idxType = idxType;
+    this.stridable = stridable;
+    super.init();
+    if stridable then this.stride = stride;
+  }
+}
+
+writeln("----- Records -----");
+var rX = new R(int, false);
+writeln("rX = ", rX);
+writeln("rX.stride.type = ", rX.stride.type:string);
+
+var rY = new R(int, true, 5);
+writeln("rY = ", rY);
+writeln("rY.stride.type = ", rY.stride.type:string);
+
+writeln();
+writeln("----- Classes -----");
+var cX = new R(int, false);
+writeln("cX = ", cX);
+writeln("cX.stride.type = ", cX.stride.type:string);
+
+var cY = new R(int, true, 5);
+writeln("cY = ", cY);
+writeln("cY.stride.type = ", cY.stride.type:string);

--- a/test/classes/initializers/generics/typeFunctions/conditionalFieldType.good
+++ b/test/classes/initializers/generics/typeFunctions/conditionalFieldType.good
@@ -1,0 +1,11 @@
+----- Records -----
+rX = ()
+rX.stride.type = void
+rY = (stride = 5)
+rY.stride.type = int(64)
+
+----- Classes -----
+cX = ()
+cX.stride.type = void
+cY = (stride = 5)
+cY.stride.type = int(64)


### PR DESCRIPTION
This PR allows for fields to have a type chosen by a condition dependent on another field. For example:
```chpl
proc helper(param cond : bool, type t) type {
  if cond then return t;
  else return void;
}
record R {
  param stridable : bool;
  var stride : helper(stridable, int);
}
```

The compiler was failing to account for the case where the type of ``this`` was a reference, and we only looked at the ``_val`` field.

Testing:
- [x] full local + futures
  