### PR TITLE
Name module when cannot find it

### DIFF
--- a/compiler/AST/UseStmt.cpp
+++ b/compiler/AST/UseStmt.cpp
@@ -215,7 +215,11 @@ void UseStmt::scopeResolve(ResolveScope* scope) {
       }
 
     } else {
-      USR_FATAL(this, "Cannot find module or enum");
+      if (UnresolvedSymExpr* use = toUnresolvedSymExpr(src)) {
+        USR_FATAL(this, "Cannot find module or enum '%s'", use->unresolved);
+      } else {
+        USR_FATAL(this, "Cannot find module or enum");
+      }
     }
 
   } else {

--- a/test/modules/errors/useMissingModule.chpl
+++ b/test/modules/errors/useMissingModule.chpl
@@ -1,0 +1,1 @@
+use GooberPeas;

--- a/test/modules/errors/useMissingModule.good
+++ b/test/modules/errors/useMissingModule.good
@@ -1,0 +1,1 @@
+useMissingModule.chpl:1: error: Cannot find module or enum 'GooberPeas'

--- a/test/modules/errors/useMissingModule2.chpl
+++ b/test/modules/errors/useMissingModule2.chpl
@@ -1,0 +1,2 @@
+use Goober.Peas;
+

--- a/test/modules/errors/useMissingModule2.good
+++ b/test/modules/errors/useMissingModule2.good
@@ -1,0 +1,1 @@
+useMissingModule2.chpl:1: error: Cannot find object 'Goober'

--- a/test/modules/errors/useMissingModule3.chpl
+++ b/test/modules/errors/useMissingModule3.chpl
@@ -1,0 +1,4 @@
+use Goober.Peas;
+
+module Goober {
+}

--- a/test/modules/errors/useMissingModule3.compopts
+++ b/test/modules/errors/useMissingModule3.compopts
@@ -1,0 +1,1 @@
+--no-warnings

--- a/test/modules/errors/useMissingModule3.good
+++ b/test/modules/errors/useMissingModule3.good
@@ -1,0 +1,1 @@
+useMissingModule3.chpl:1: error: Cannot find field 'Peas'


### PR DESCRIPTION
This improves the error message we generate when a `use`d module or enum
name can't be found by naming the module to help the user track down the
error.  It also adds some tests to lock in the behavior and test other related
existing error messages.