### PR TITLE
Enable tuples of generic records with initializers

### DIFF
--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -1714,3 +1714,26 @@ bool isRecordWithInitializers(Type* type) {
 
   return retval;
 }
+
+//
+// The simplest and most obvious case is that generic records need generic
+// initializers.
+//
+// Instantiated records also require generic initializers, because their
+// type or param fields need to be handled by an initializer.
+//
+bool needsGenericRecordInitializer(Type* type) {
+  bool retval = false;
+
+  if (AggregateType* at = toAggregateType(type)) {
+    if (isRecordWithInitializers(type)) {
+      if (at->isGeneric() == true ||
+          at->symbol->hasFlag(FLAG_GENERIC) == true ||
+          at->instantiatedFrom != NULL) {
+        retval = true;
+      }
+    }
+  }
+
+  return retval;
+}

--- a/compiler/include/type.h
+++ b/compiler/include/type.h
@@ -485,6 +485,8 @@ bool isGenericRecordWithInitializers(Type* type);
 bool isClassWithInitializers (Type* type);
 bool isRecordWithInitializers(Type* type);
 
+bool needsGenericRecordInitializer(Type* type);
+
 void registerTypeToStructurallyCodegen(TypeSymbol* type);
 GenRet genTypeStructureIndex(TypeSymbol* typesym);
 void codegenTypeStructures(FILE* hdrfile);

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -2102,7 +2102,8 @@ static void normVarTypeWoutInit(DefExpr* defExpr) {
 
     var->type = type;
 
-  } else if (isNonGenericRecordWithInitializers(type) == true) {
+  } else if (isNonGenericRecordWithInitializers(type) == true &&
+             needsGenericRecordInitializer(type) == false) {
     CallExpr* init = new CallExpr("init", gMethodToken, var);
 
     var->type = type;

--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -1242,7 +1242,10 @@ static void addLocalCopiesAndWritebacks(FnSymbol*  fn,
       } else {
         AggregateType* formalAt = toAggregateType(formal->getValType());
 
-        if (isNonGenericRecordWithInitializers(formalAt)) {
+        // BHARSH TODO: This pattern (is it concrete, otherwise use PRIM_INIT)
+        // is all over the place. Can we unify this stuff somewhere?
+        if (isNonGenericRecordWithInitializers(formalAt) &&
+            needsGenericRecordInitializer(formalAt) == false) {
           fn->insertAtHead(new CallExpr("init",
                                         gMethodToken,
                                         tmp));

--- a/test/classes/initializers/compilerGenerated/generics/tupleOfGeneric.chpl
+++ b/test/classes/initializers/compilerGenerated/generics/tupleOfGeneric.chpl
@@ -1,0 +1,32 @@
+
+record R {
+  type idxType;
+  param stridable : bool;
+  var low, high : idxType;
+
+  proc init(type idxType = int,
+            param stridable : bool = false) {
+    this.idxType   = idxType;
+    this.stridable = stridable;
+    super.init();
+  }
+}
+
+var r : R(int(32), false);
+writeln("r = ", r);
+
+//
+// The tricky part here is that _defaultOf is generated **and** normalized
+// in the middle of resolution. The type of the tuple field "x1" is known
+// at this point, which lead the compiler to think that the field was not a
+// generic record.
+//
+// Clearly the type is concrete, but the fact that it was instantiated from
+// a generic has consequences for the way 'init' is called.
+//
+// At this time this test was created, the compiler was inserting a zero-args
+// init call, which used the default 'int(64)' type for 'idxType'. This would
+// eventually lead to a type mismatch failure later in resolution.
+//
+var t : 1*R(int(32), false);
+writeln("t = ", t);

--- a/test/classes/initializers/compilerGenerated/generics/tupleOfGeneric.good
+++ b/test/classes/initializers/compilerGenerated/generics/tupleOfGeneric.good
@@ -1,0 +1,2 @@
+r = (low = 0, high = 0)
+t = ((low = 0, high = 0))


### PR DESCRIPTION
Before this change there would be compilation failures for tuples of generic records with initializers. The problem was that the compiler-generated ``_defaultOf`` for tuples would generate a init-less declaration of the _concrete_ record type, and then call normalize. Normalize would see this concrete type, and assume there would be a zero-argument initializer.

The problem with that sequence is that records instantiated from a generic still need to invoke the generic initializer in order to handle param/type fields.

This PR adds a new utility function, ``needsGenericRecordInitializer``, and uses it in a couple of key places.

I investigated the possibility of replacing ``isNonGenericRecordWithInitializers``, but was uncertain of the potential impact and so introduced a new function instead.

Testing:
- [x] full local + futures