### PR TITLE
Correct ISx reported times

### DIFF
--- a/test/release/examples/benchmarks/isx/isx.chpl
+++ b/test/release/examples/benchmarks/isx/isx.chpl
@@ -429,26 +429,23 @@ proc printTimeTable(timeTable, units, timerName) {
 }
 
 //
-// print timing statistics (avg/min/max across tasks of min across
-// trials)
+// print timing statistics (avg/min/max across tasks and trials)
 //
 proc printTimingStats(timeTable, timerName) {
-  var minMinTime = max(real),
-      maxMinTime = min(real),
-      totMinTime: real;
+  var minTime = max(real),
+      maxTime = min(real),
+      totTime: real;
 
   //
-  // iterate over the buckets, computing the min/max/total of the
-  // min times across trials.
+  // iterate over the buckets, computing the min/max/total
   //
-  forall timings in timeTable with (min reduce minMinTime,
-                                    max reduce maxMinTime,
-                                    + reduce totMinTime) {
-    const minTime = min reduce timings;
-    totMinTime += minTime;
-    minMinTime = min(minMinTime, minTime);
-    maxMinTime = max(maxMinTime, minTime);
+  forall timings in timeTable with (min reduce minTime,
+                                    max reduce maxTime,
+                                    + reduce totTime) {
+    totTime += + reduce timings;
+    minTime = min(minTime, min reduce timings);
+    maxTime = max(maxTime, max reduce timings);
   }
-  var avgTime = totMinTime / numTasks;
-  writeln(timerName, " = ", avgTime, " (", minMinTime, "..", maxMinTime, ")");
+  var avgTime = totTime / (numTasks * numTrials) ;
+  writeln(timerName, " = ", avgTime, " (", minTime, "..", maxTime, ")");
 }

--- a/test/studies/isx/isx-bucket-spmd.chpl
+++ b/test/studies/isx/isx-bucket-spmd.chpl
@@ -433,26 +433,23 @@ proc printTimeTable(timeTable, units, timerName) {
 }
 
 //
-// print timing statistics (avg/min/max across buckets of min across
-// trials)
+// print timing statistics (avg/min/max across tasks and trials)
 //
 proc printTimingStats(timeTable, timerName) {
-  var minMinTime = max(real),
-      maxMinTime = min(real),
-      totMinTime: real;
+  var minTime = max(real),
+      maxTime = min(real),
+      totTime: real;
 
   //
-  // iterate over the buckets, computing the min/max/total of the
-  // min times across trials.
+  // iterate over the buckets, computing the min/max/total
   //
-  forall timings in timeTable with (min reduce minMinTime,
-                                    max reduce maxMinTime,
-                                    + reduce totMinTime) {
-    const minTime = min reduce timings;
-    totMinTime += minTime;
-    minMinTime = min(minMinTime, minTime);
-    maxMinTime = max(maxMinTime, minTime);
+  forall timings in timeTable with (min reduce minTime,
+                                    max reduce maxTime,
+                                    + reduce totTime) {
+    totTime += + reduce timings;
+    minTime = min(minTime, min reduce timings);
+    maxTime = max(maxTime, max reduce timings);
   }
-  var avgTime = totMinTime / numLocales;
-  writeln(timerName, " = ", avgTime, " (", minMinTime, "..", maxMinTime, ")");
+  var avgTime = totTime / (numBuckets * numTrials) ;
+  writeln(timerName, " = ", avgTime, " (", minTime, "..", maxTime, ")");
 }

--- a/test/studies/isx/isx-hand-optimized.chpl
+++ b/test/studies/isx/isx-hand-optimized.chpl
@@ -440,26 +440,23 @@ proc printTimeTable(timeTable, units, timerName) {
 }
 
 //
-// print timing statistics (avg/min/max across tasks of min across
-// trials)
+// print timing statistics (avg/min/max across tasks and trials)
 //
 proc printTimingStats(timeTable, timerName) {
-  var minMinTime = max(real),
-      maxMinTime = min(real),
-      totMinTime: real;
+  var minTime = max(real),
+      maxTime = min(real),
+      totTime: real;
 
   //
-  // iterate over the buckets, computing the min/max/total of the
-  // min times across trials.
+  // iterate over the buckets, computing the min/max/total
   //
-  forall timings in timeTable with (min reduce minMinTime,
-                                    max reduce maxMinTime,
-                                    + reduce totMinTime) {
-    const minTime = min reduce timings;
-    totMinTime += minTime;
-    minMinTime = min(minMinTime, minTime);
-    maxMinTime = max(maxMinTime, minTime);
+  forall timings in timeTable with (min reduce minTime,
+                                    max reduce maxTime,
+                                    + reduce totTime) {
+    totTime += + reduce timings;
+    minTime = min(minTime, min reduce timings);
+    maxTime = max(maxTime, max reduce timings);
   }
-  var avgTime = totMinTime / numTasks;
-  writeln(timerName, " = ", avgTime, " (", minMinTime, "..", maxMinTime, ")");
+  var avgTime = totTime / (numTasks * numTrials) ;
+  writeln(timerName, " = ", avgTime, " (", minTime, "..", maxTime, ")");
 }

--- a/test/studies/isx/isx-no-return.chpl
+++ b/test/studies/isx/isx-no-return.chpl
@@ -422,26 +422,23 @@ proc printTimeTable(timeTable, units, timerName) {
 }
 
 //
-// print timing statistics (avg/min/max across buckets of min across
-// trials)
+// print timing statistics (avg/min/max across tasks and trials)
 //
 proc printTimingStats(timeTable, timerName) {
-  var minMinTime = max(real),
-      maxMinTime = min(real),
-      totMinTime: real;
+  var minTime = max(real),
+      maxTime = min(real),
+      totTime: real;
 
   //
-  // iterate over the buckets, computing the min/max/total of the
-  // min times across trials.
+  // iterate over the buckets, computing the min/max/total
   //
-  forall timings in timeTable with (min reduce minMinTime,
-                                    max reduce maxMinTime,
-                                    + reduce totMinTime) {
-    const minTime = min reduce timings;
-    totMinTime += minTime;
-    minMinTime = min(minMinTime, minTime);
-    maxMinTime = max(maxMinTime, minTime);
+  forall timings in timeTable with (min reduce minTime,
+                                    max reduce maxTime,
+                                    + reduce totTime) {
+    totTime += + reduce timings;
+    minTime = min(minTime, min reduce timings);
+    maxTime = max(maxTime, max reduce timings);
   }
-  var avgTime = totMinTime / numLocales;
-  writeln(timerName, " = ", avgTime, " (", minMinTime, "..", maxMinTime, ")");
+  var avgTime = totTime / (numBuckets * numTrials) ;
+  writeln(timerName, " = ", avgTime, " (", minTime, "..", maxTime, ")");
 }

--- a/test/studies/isx/isx-per-task.chpl
+++ b/test/studies/isx/isx-per-task.chpl
@@ -439,26 +439,23 @@ proc printTimeTable(timeTable, units, timerName) {
 }
 
 //
-// print timing statistics (avg/min/max across tasks of min across
-// trials)
+// print timing statistics (avg/min/max across tasks and trials)
 //
 proc printTimingStats(timeTable, timerName) {
-  var minMinTime = max(real),
-      maxMinTime = min(real),
-      totMinTime: real;
+  var minTime = max(real),
+      maxTime = min(real),
+      totTime: real;
 
   //
-  // iterate over the buckets, computing the min/max/total of the
-  // min times across trials.
+  // iterate over the buckets, computing the min/max/total
   //
-  forall timings in timeTable with (min reduce minMinTime,
-                                    max reduce maxMinTime,
-                                    + reduce totMinTime) {
-    const minTime = min reduce timings;
-    totMinTime += minTime;
-    minMinTime = min(minMinTime, minTime);
-    maxMinTime = max(maxMinTime, minTime);
+  forall timings in timeTable with (min reduce minTime,
+                                    max reduce maxTime,
+                                    + reduce totTime) {
+    totTime += + reduce timings;
+    minTime = min(minTime, min reduce timings);
+    maxTime = max(maxTime, max reduce timings);
   }
-  var avgTime = totMinTime / numTasks;
-  writeln(timerName, " = ", avgTime, " (", minMinTime, "..", maxMinTime, ")");
+  var avgTime = totTime / (numTasks * numTrials) ;
+  writeln(timerName, " = ", avgTime, " (", minTime, "..", maxTime, ")");
 }


### PR DESCRIPTION
Previously, if numTrials was greater than 1 our timing values weren't correct.
Instead of computing the average across all trials and tasks, we took the min
for each task from any trial. e.g. if we had timings like:

|         | task 1 | task 2 |
| ------- | ------ | ------ |
| trial 1 |   5s   |     1s |
| trial 2 |   1s   |     5s |

We'd report an average time of 1 second per task, which looks great but isn't
accurate. We will now correctly report the average for each task as 3 seconds,
which matches the reference version. Note that this isn't an issue for nightly
testing where we only do 1 trial, but this was giving misleading results for
scalability numbers where we tend to run 5 trials.