### PR TITLE
Skipif begin-in-init-copy.chpl for pgi

### DIFF
--- a/test/parallel/begin/ferguson/begin-in-init-copy.skipif
+++ b/test/parallel/begin/ferguson/begin-in-init-copy.skipif
@@ -1,0 +1,3 @@
+# Test was intermittently failing with PGI
+CHPL_TARGET_COMPILER==pgi
+CHPL_TARGET_COMPILER==cray-prgenv-pgi


### PR DESCRIPTION
begin-in-init-copy.chpl was apparently intermittently failing in PGI configurations.
This PR simply skips this test in those configurations.

Testing change only, not reviewed.