### PR TITLE
Include MasonEnv.chpl in the list of sources in the Mason Makefile

### DIFF
--- a/tools/mason/Makefile
+++ b/tools/mason/Makefile
@@ -29,7 +29,7 @@ bdir=$(CHPL_BIN_DIR)
 link=../../tools/mason/mason
 linkFile=$(bdir)/mason
 
-MASON_SOURCES=MasonBuild.chpl MasonHelp.chpl MasonNew.chpl MasonUpdate.chpl MasonSearch.chpl MasonUtils.chpl mason.chpl
+MASON_SOURCES=MasonBuild.chpl MasonEnv.chpl MasonHelp.chpl MasonNew.chpl MasonSearch.chpl MasonUpdate.chpl MasonUtils.chpl mason.chpl
 
 all: mason
 


### PR DESCRIPTION
In the Makefile for building Mason, MasonEnv.chpl wasn't included in the list
of source files, so changes to MasonEnv didn't cause Mason to be rebuilt.  Add
it and alphabetize the Mason*.chpl files.