### PR TITLE
Add 'help' and 'version' as Mason commands

### DIFF
--- a/tools/mason/mason.chpl
+++ b/tools/mason/mason.chpl
@@ -78,6 +78,8 @@ proc main(args: [] string) {
     when 'env' do masonEnv(args);
     when 'doc' do masonDoc(args);
     when 'clean' do masonClean();
+    when 'help' do masonHelp();
+    when 'version' do printVersion();
     when '--list' do masonList();
     when '-h' do masonHelp();
     when '--help' do masonHelp();


### PR DESCRIPTION
'mason --list' says that 'help' and 'version' are Mason commands, but both were
unrecognized.  Add them and make them print the obvious things.