### PR TITLE
Stop hard-coding the keyType in ISx makeInput

### DIFF
--- a/test/release/examples/benchmarks/isx/isx.chpl
+++ b/test/release/examples/benchmarks/isx/isx.chpl
@@ -355,7 +355,7 @@ proc makeInput(taskID, myKeys) {
   // Fill local array
   //
 
-  for key in myKeys do key = pcg.bounded_random(inc, maxKeyVal:uint(32)):int(32);
+  for key in myKeys do key = pcg.bounded_random(inc, maxKeyVal:uint(32)):keyType;
     
   if (debug) then
     writeln(taskID, ": myKeys: ", myKeys);

--- a/test/studies/isx/isx-bucket-spmd.chpl
+++ b/test/studies/isx/isx-bucket-spmd.chpl
@@ -358,7 +358,7 @@ proc makeInput(bucketID) {
   // Fill local array
   //
 
-  for key in myKeys do key = pcg.bounded_random(inc, maxKeyVal:uint(32)):int(32);
+  for key in myKeys do key = pcg.bounded_random(inc, maxKeyVal:uint(32)):keyType;
 
   if (debug) then
     writeln(bucketID, ": myKeys: ", myKeys);

--- a/test/studies/isx/isx-hand-optimized.chpl
+++ b/test/studies/isx/isx-hand-optimized.chpl
@@ -365,7 +365,7 @@ proc makeInput(taskID, myKeys) {
   //
 
   local {
-    for key in myKeys do key = pcg.bounded_random(inc, maxKeyVal:uint(32)):int(32);
+    for key in myKeys do key = pcg.bounded_random(inc, maxKeyVal:uint(32)):keyType;
   }
     
   if (debug) then

--- a/test/studies/isx/isx-no-return.chpl
+++ b/test/studies/isx/isx-no-return.chpl
@@ -348,7 +348,7 @@ proc makeInput(myKeys, bucketID) {
   // Fill local array
   //
 
-  for key in myKeys do key = pcg.bounded_random(inc, maxKeyVal:uint(32)):int(32);
+  for key in myKeys do key = pcg.bounded_random(inc, maxKeyVal:uint(32)):keyType;
 
   if (debug) then
     writeln(bucketID, ": myKeys: ", myKeys);

--- a/test/studies/isx/isx-per-task.chpl
+++ b/test/studies/isx/isx-per-task.chpl
@@ -364,7 +364,7 @@ proc makeInput(taskID) {
   // Fill local array
   //
 
-  for key in myKeys do key = pcg.bounded_random(inc, maxKeyVal:uint(32)):int(32);
+  for key in myKeys do key = pcg.bounded_random(inc, maxKeyVal:uint(32)):keyType;
 
   if (debug) then
     writeln(taskID, ": myKeys: ", myKeys);


### PR DESCRIPTION
Cast the results of pcg.bounded_random() back to `keyType` instead of
explicitly casting to `int(32)`, which happens to be the default keyType.

Related to https://github.com/chapel-lang/chapel/issues/8497