### PR TITLE
Set rootLocaleInitialized in RootLocale.deinit

### DIFF
--- a/modules/internal/localeModels/apu/LocaleModel.chpl
+++ b/modules/internal/localeModels/apu/LocaleModel.chpl
@@ -301,8 +301,12 @@ module LocaleModel {
     }
 
     proc deinit() {
-      for loc in myLocales do
-        delete loc;
+      for loc in myLocales {
+        on loc {
+          rootLocaleInitialized = false;
+          delete loc;
+        }
+      }
     }
   }
 }

--- a/modules/internal/localeModels/flat/LocaleModel.chpl
+++ b/modules/internal/localeModels/flat/LocaleModel.chpl
@@ -220,8 +220,12 @@ module LocaleModel {
     }
 
     proc deinit() {
-      for loc in myLocales do
-        delete loc;
+      for loc in myLocales {
+        on loc {
+          rootLocaleInitialized = false;
+          delete loc;
+        }
+      }
     }
   }
 

--- a/modules/internal/localeModels/knl/LocaleModel.chpl
+++ b/modules/internal/localeModels/knl/LocaleModel.chpl
@@ -524,8 +524,12 @@ module LocaleModel {
     }
 
     proc deinit() {
-      for loc in myLocales do
-        delete loc;
+      for loc in myLocales {
+        on loc {
+          rootLocaleInitialized = false;
+          delete loc;
+        }
+      }
     }
   }
 

--- a/modules/internal/localeModels/numa/LocaleModel.chpl
+++ b/modules/internal/localeModels/numa/LocaleModel.chpl
@@ -274,8 +274,12 @@ module LocaleModel {
     }
 
     proc deinit() {
-      for loc in myLocales do
-        delete loc;
+      for loc in myLocales {
+        on loc {
+          rootLocaleInitialized = false;
+          delete loc;
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Before this commit, RootLocale deinit consisted of a
for loop over the locales, where it would delete each
locale in turn. Note though that deleteing an object
runs an 'on' statement to go where the object is stored.
After PR #7193, these 'on' statements had the effect
of changing the running task count field of the locale
object - which in some cases was already deleted.

This commit sets rootLocaleInitialized=false in this
loop in order to disable the modifications to the
running task count. It wraps both this change and the
delete in an on statement.

Reviewed by @ronawho - thanks!

 - [x] full std correctness testing 
 - [x] full numa correctness testing (passed expect for 2 known  in-intent failures)
 - [x] full gasnet correctness testing 