### PR TITLE
Ignore default initializers for iterator records and classes

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -1994,6 +1994,12 @@ bool AggregateType::wantsDefaultInitializer() const {
   } else if (symbol->hasFlag(FLAG_REF) == true) {
     retval = false;
 
+  // Iterator classes and records want neither default constructors nor
+  // initializers, and never will
+  } else if (symbol->hasFlag(FLAG_ITERATOR_CLASS) ||
+             symbol->hasFlag(FLAG_ITERATOR_RECORD)) {
+    retval = false;
+
   } else {
     // No default initializer for types that have an initialize() method
     forv_Vec(FnSymbol, method, nonConstHole->methods) {


### PR DESCRIPTION
Iterator records and classes do not create a default constructor today, so there
isn't any reason to try and use default initializers.  Once the implementation
for constructors is removed, this check should no longer be necessary.

Testing:
- [x] classes/initializers with futures
- [x] full paratest
- [x] full paratest with --force-initializers: no new failures and removes 54