### PR TITLE
Add support for -futures-only to paratest.server

### DIFF
--- a/util/test/paratest.server
+++ b/util/test/paratest.server
@@ -491,7 +491,7 @@ sub find_files {
 
 
 sub print_help {
-    print "Usage: paratest.server [-compopts s] [-dirfile d] [-dirs d] [-env s] [-execopts s] [-filedist] [-futures] [-logfile l] [-memleaks f] [-nodefile n] [-nodepara m] [-valgrind[exe]] [-help|-h] [-timeout t]\n";
+    print "Usage: paratest.server [-compopts s] [-dirfile d] [-dirs d] [-env s] [-execopts s] [-filedist] [-futures] [-futures-only] [-logfile l] [-memleaks f] [-nodefile n] [-nodepara m] [-valgrind[exe]] [-help|-h] [-timeout t]\n";
     print "    -compopts s: s is a string that is passed with -compopts to start_test.\n";
     print "    -dirfile  d: d is a file listing directories to test. Default is the current diretory.\n";
     print "    -dirs     d: d is a space separated list of directories to recursively search for directories to test\n";
@@ -499,6 +499,7 @@ sub print_help {
     print "    -execopts s: s is a string that is passed with -execopts to start_test.\n";
     print "    -filedist  : distribute work at the granularity of files (directory granurality is the default).\n";
     print "    -futures   : include .future tests (default is none).\n";
+    print "    -futures-only : only run .future tests, not regular ones.\n";
     print "    -logfile  l: l is the output log file. Default is \"user\".\"platform\".log. in the Logs subdirectory.\n";
     print "    -memleaks f: pass -memleaks to start_test; aggregate all output.\n";
     print "    -nodefile n: n is a file listing nodes to run on. Default is current node.\n";

--- a/util/test/paratest.server
+++ b/util/test/paratest.server
@@ -575,6 +575,8 @@ sub main {
                 print "missing -futures-mode arg\n";
                 exit (8);
             }
+        } elsif (/^-futures-only/) {
+            $futures_mode = 2;
         } elsif (/^-futures/) {
             $futures_mode = 1;
         } elsif (/^-logfile/) {


### PR DESCRIPTION
start_test has long supported a -futures-only flag that tested the
future tests but no others.  paratest.server (and by extension,
paratest.chapcs) has _seemed_ to support such a flag, in that it
accepted it; but in practice, it ran all tests and futures because
the flag parsing for paratest.server is weak and checks for prefix
strings rather than complete strings.  So it fell into the -futures
case silently and ran everything.

Being able to run paratest in this mode has long seemed attractive
to me because I commonly run paratest.chapcs, get clean output,
and then think "Oh shoot, I should've checked futures as well"
so re-run the whole thing, wasting time and cycles.

Here, I added support for a -futures-only flag, building on
pre-existing support in subsequent scripts for this being supported
via futures mode "2".  Thanks to Elliot for doing the detective
work to determine that it would be this easy to implement.

Note that my futures-only flag is as lame as the other paratest
flags in that you could also say -futures-only-stupid-script
and it would accept the flag and run the futures only.