### PR TITLE
Fix support for arrays of barriers

### DIFF
--- a/modules/standard/Barriers.chpl
+++ b/modules/standard/Barriers.chpl
@@ -103,6 +103,11 @@ module Barriers {
       owned = true;
     }
 
+    pragma "no doc"
+    proc init() {
+      this.init(0);
+    }
+
     /* copy initializer */
     pragma "no doc"
     proc init(b: Barrier) {

--- a/test/parallel/taskPar/elliot/barrier/array-of-barriers.chpl
+++ b/test/parallel/taskPar/elliot/barrier/array-of-barriers.chpl
@@ -1,0 +1,12 @@
+use Barriers;
+
+var bar: Barrier;
+bar = new Barrier(1);
+bar.barrier();
+
+var barArr: [1..1] Barrier;
+barArr[1] = new Barrier(1);
+barArr[1].barrier();
+
+var barArr2: [1..10] Barrier = new Barrier(1);
+for bar2 in barArr2 do bar2.barrier();


### PR DESCRIPTION
Add a default 0-arg initializer for Barriers

Without this, an array of barriers fails to resolve because the default array
initialization is trying to call a default initializer.  An even simpler case
that failed is something like:

```chpl
var bar: Barrier; // resolution failure, no default init
bar = new Barrier(1);
```
