### PR TITLE
Put the main process to sleep while waiting to shutdown

### DIFF
--- a/runtime/include/chpl-comm.h
+++ b/runtime/include/chpl-comm.h
@@ -354,7 +354,8 @@ void chpl_comm_broadcast_private(int id, size_t size, int32_t tid);
 // function may be called from a Chapel task.  As such, if the barrier
 // cannot be immediately satisfied, while it waits chpl_comm_barrier()
 // must call chpl_task_yield() in order not to monopolize the execution
-// resources and prevent making progress.
+// resources and prevent making progress. This barrier must be available
+// for use in module code, so it cannot be tied up in the runtime 
 //
 void chpl_comm_barrier(const char *msg);
 


### PR DESCRIPTION
This PR frees up `chpl_comm_barrier()` for use in module code, and prevents the
main process from interfering with tasks running on the same CPU.

Previously, the main process on non-0 locales would spin-wait on a barrier in
`chpl_comm_pre_task_exit()`, waiting for locale-0 to tell them to do an orderly
shutdown. This barrier prevented chpl_comm_barrier from being used in user
applications, and the spin-waiting hurts performance for tasks running on the
same CPU. This alleviates both issues by putting the main process to sleep with
a condition variable, and having locale-0 wake everybody up with a AM that
signals the cond var when it's time to shutdown.

This is motivated by an upcoming scalable barrier PR that wants to use
`chpl_comm_barrier()` in module code. The scalable barrier will significantly
improve ISx performance and scalability. Putting the main process to sleep
reduces interference, but we probably won't notice this in any tests yet
because the progress-thread currently causes more interference. i.e. tasks
sharing a core with the progress-thread are already the slowest tasks, so the
benefit of parking the main process will only be visible once that issue is
resolved.