### PR TITLE
Use processor atomics for Barrier variables

### DIFF
--- a/modules/standard/Barriers.chpl
+++ b/modules/standard/Barriers.chpl
@@ -208,9 +208,9 @@ module Barriers {
     pragma "no doc"
     var n: int;
     pragma "no doc"
-    var count: atomic int;
+    var count: chpl__processorAtomicType(int);
     pragma "no doc"
-    var done: atomic bool;
+    var done: chpl__processorAtomicType(bool);
 
     /* Construct a new Barrier object.
 


### PR DESCRIPTION
The atomics are always manipulated inside an on-stmt back to the locale where
the barrier lives, so using processor atomics will be faster.

This shaves about a second off the empty barrier test under ugni (10s to 9s),
and slightly helps ISx, but ISx is currently so noisy it's hard to see the
difference.