### PR TITLE
Convert future to valgrind-only test

### DIFF
--- a/test/classes/initializers/phase1/domainMaps/init-dmap-dom-arr-local.bad
+++ b/test/classes/initializers/phase1/domainMaps/init-dmap-dom-arr-local.bad
@@ -1,1 +1,0 @@
-init-dmap-dom-arr-local.chpl:14: error: halt reached - array index out of bounds: (1)

--- a/test/classes/initializers/phase1/domainMaps/init-dmap-dom-arr-local.future
+++ b/test/classes/initializers/phase1/domainMaps/init-dmap-dom-arr-local.future
@@ -1,5 +1,11 @@
 bug: domain field doesn't get dmap set up correctly
 
+Update to original text below: It seems that there's a valgrind
+failure that makes the behavior of this test in --local mode
+nondeterministic.  As a result, my initial diagnosis below might be
+wrong.  Changing this to a valgrind-only future for the time being to
+ensure stability in testing.
+
 In this test, the 'D' field is declared in terms of dmap 'C' yet
 inspecting the code within the Cyclic distribution in the place where
 the failure occurs, it is clear that D's distribution is not referring

--- a/test/classes/initializers/phase1/domainMaps/init-dmap-dom-arr-local.skipif
+++ b/test/classes/initializers/phase1/domainMaps/init-dmap-dom-arr-local.skipif
@@ -1,1 +1,2 @@
 CHPL_COMM!=none
+CHPL_TEST_VGRND_EXE != on


### PR DESCRIPTION
It turns out that this future had a valgrind failure which caused its
output to be less predictable than I'd first realized.  Changing it
over to be tested under valgrind only for the time being.