### PR TITLE
Initializers for sync/single

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5031,6 +5031,10 @@ static void resolveInitVar(CallExpr* call) {
   Symbol*  src     = srcExpr->symbol();
   Type*    srcType = src->type;
 
+  if (call->id == breakOnResolveID) {
+    gdbShouldBreakHere();
+  }
+
   if (dst->hasFlag(FLAG_NO_COPY)               == true)  {
     call->primitive = primitives[PRIM_MOVE];
     resolveMove(call);
@@ -5039,7 +5043,9 @@ static void resolveInitVar(CallExpr* call) {
     call->primitive = primitives[PRIM_MOVE];
     resolveMove(call);
 
-  } else if (isRecordWithInitializers(srcType) == true)  {
+  } else if (isRecordWithInitializers(srcType) == true &&
+             isSyncType(srcType) == false &&
+             isSingleType(srcType) == false)  {
     AggregateType* ct  = toAggregateType(srcType);
     SymExpr*       rhs = toSymExpr(call->get(2));
 

--- a/modules/internal/ChapelSyncvar.chpl
+++ b/modules/internal/ChapelSyncvar.chpl
@@ -115,7 +115,6 @@ module ChapelSyncvar {
       ensureFEType(valType);
       this.valType = valType;
       this.wrapped = new (getSyncClassType(valType))(valType);
-      this.isOwned = true;
       super.init();
     }
 
@@ -633,7 +632,6 @@ module ChapelSyncvar {
       ensureFEType(valType);
       this.valType = valType;
       wrapped = new _singlecls(valType);
-      isOwned = true;
       super.init();
     }
 

--- a/test/expressions/lydia/noinit/usedWithSingle.bad
+++ b/test/expressions/lydia/noinit/usedWithSingle.bad
@@ -1,6 +1,0 @@
-usedWithSingle.chpl:1: warning: type _singlevar(int(64)) does not currently support noinit, using default initialization
-usedWithSingle.chpl:2: warning: type _singlevar(bool) does not currently support noinit, using default initialization
-Task 1 finishing
-Task 2 done!
-4
-true

--- a/test/expressions/lydia/noinit/usedWithSync.bad
+++ b/test/expressions/lydia/noinit/usedWithSync.bad
@@ -1,4 +1,0 @@
-usedWithSync.chpl:1: warning: type _syncvar(int(64)) does not currently support noinit, using default initialization
-usedWithSync.chpl:2: warning: type _syncvar(bool) does not currently support noinit, using default initialization
-4
-true


### PR DESCRIPTION
This PR updates sync and single types to use initializers. Note that these types rely on ``chpl__initCopy`` returning a different type, so this isn't a total conversion to pure initializers.

Two .bad files are removed in order to reduce overhead of updating them as the initializer work progresses.

A breakpoint has been added for ``resolveInitVar`` to aid debugging.

Testing:
- [x] full local