### PR TITLE
Fix codegen failure for assignment between voids

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -8342,12 +8342,9 @@ static void cleanupVoidVarsAndFields() {
   // be left in the tree if optimizations are disabled, and can cause codegen
   // failures later on (at least under LLVM).
   //
-  // Solution: only keep '_void' SymExprs if the parent is a PRIM_RETURN
+  // Solution: Remove SymExprs to _void if the expr is at the statement level.
   for_SymbolSymExprs(se, gVoid) {
-    CallExpr*  parent       = toCallExpr(se->parentExpr);
-    const bool isPrimReturn = parent != NULL &&
-                              parent->isPrimitive(PRIM_RETURN);
-    if (isPrimReturn == false) {
+    if (se == se->getStmtExpr()) {
       se->remove();
     }
   }

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -8336,6 +8336,21 @@ static void cleanupVoidVarsAndFields() {
       }
     }
   }
+
+  // Problem case introduced by postFoldNormal where a statement-level call
+  // returning void can be replaced by a '_void' SymExpr. Such SymExprs will
+  // be left in the tree if optimizations are disabled, and can cause codegen
+  // failures later on (at least under LLVM).
+  //
+  // Solution: only keep '_void' SymExprs if the parent is a PRIM_RETURN
+  for_SymbolSymExprs(se, gVoid) {
+    CallExpr*  parent       = toCallExpr(se->parentExpr);
+    const bool isPrimReturn = parent != NULL &&
+                              parent->isPrimitive(PRIM_RETURN);
+    if (isPrimReturn == false) {
+      se->remove();
+    }
+  }
 }
 
 /************************************* | **************************************

--- a/test/types/void/void-assign.chpl
+++ b/test/types/void/void-assign.chpl
@@ -1,0 +1,6 @@
+
+proc main() {
+  var tmp : void;
+  var other : void;
+  tmp = other;
+}

--- a/test/types/void/void-assign.compopts
+++ b/test/types/void/void-assign.compopts
@@ -1,0 +1,1 @@
+--baseline


### PR DESCRIPTION
The compiler was leaving a stray statement-level SymExpr to ``_void`` in the tree, which caused codegen failures for ``--llvm`` testing.

This PR removes any ``_void`` SymExprs that are at the statement level. Also adds a test to more easily catch this case in the future.

Testing:
- [x] full local
- [x] full llvm