### PR TITLE
In intent repairs

### DIFF
--- a/compiler/optimizations/remoteValueForwarding.cpp
+++ b/compiler/optimizations/remoteValueForwarding.cpp
@@ -402,6 +402,7 @@ static void insertSerialization(FnSymbol*  fn,
                                 ArgSymbol* arg) {
   Type* oldArgType    = arg->type;
   IntentTag oldIntent = arg->intent;
+  bool newStyleInIntent = shouldAddFormalTempAtCallSite(arg, fn);
   ArgSymbol* oldArg   = NULL;
 
   Serializers ser = serializeMap[oldArgType->getValType()];
@@ -538,9 +539,11 @@ static void insertSerialization(FnSymbol*  fn,
     lastExpr->insertBefore(new CallExpr(dataDestroyFn, arg));
   }
 
-  FnSymbol* deserializeDestroyFn = getAutoDestroy(deserialized->getValType());
-  if (deserializeDestroyFn != NULL) {
-    lastExpr->insertBefore(new CallExpr(deserializeDestroyFn, deserialized));
+  if (!newStyleInIntent) {
+    FnSymbol* deserializeDestroyFn = getAutoDestroy(deserialized->getValType());
+    if (deserializeDestroyFn != NULL) {
+      lastExpr->insertBefore(new CallExpr(deserializeDestroyFn, deserialized));
+    }
   }
 }
 

--- a/compiler/passes/parallel.cpp
+++ b/compiler/passes/parallel.cpp
@@ -263,6 +263,10 @@ static bool needsAutoCopyAutoDestroyForArg(ArgSymbol* formal, Expr* arg,
   Symbol*  var      = s->symbol();
   Type*    baseType = arg->getValType();
 
+  // new-style in intents are handled elsewhere
+  if (shouldAddFormalTempAtCallSite(formal, fn))
+    return false;
+
   if (!formal->isRef() && isRecord(baseType))
     return true;
 

--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -1591,6 +1591,7 @@ static void handleInIntents(FnSymbol* fn,
         // "move" from call site to called function, so don't destroy
         // here. The called function will destroy.
         tmp->addFlag(FLAG_NO_AUTO_DESTROY);
+        tmp->addFlag(FLAG_EXPR_TEMP);
 
         // Does this need to be here?
         if (formal->hasFlag(FLAG_CONST_DUE_TO_TASK_FORALL_INTENT)) {

--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -1612,12 +1612,7 @@ static void handleInIntents(FnSymbol* fn,
         // Then "move" ownership to the called function
         // (don't destroy it here, it will be destroyed there).
         actualSym->addFlag(FLAG_NO_AUTO_DESTROY);
-        /*CallExpr* move = new CallExpr(PRIM_MOVE, tmp, actualSym);
-        anchor->insertBefore(new DefExpr(tmp));
-        anchor->insertBefore(move);
-        resolveCall(move);*/
       }
-
     }
 
     currActual = nextActual;


### PR DESCRIPTION
Fix memory leaks and a double-free in numa configurations after the in intent PR #8417.

* Resolves double-free
* fixes memory leak when 'in' intent function is resolved more than once
* fixes memory leak from parallel.cpp adding duplicate init copy calls

Verified that parallel/forall/in-intents/* passes in numa configuration (where some were core-dumping) and that none of these tests leak memory.

- [x] full local testing
- [x] full gasnet testing

Reviewed by @benharsh - thanks!