### PR TITLE
add error handling to casts from string

### DIFF
--- a/compiler/resolution/lowerIterators.cpp
+++ b/compiler/resolution/lowerIterators.cpp
@@ -1474,6 +1474,8 @@ findFollowingCheckErrorBlock(SymExpr* se, LabelSymbol*& outHandlerLabel,
   Expr* stmt = se->getStmtExpr(); // aka last scope
   Expr* scope = stmt->parentExpr;
 
+  gdbShouldBreakHere();
+
   while (scope) {
     if (isBlockStmt(scope)) {
       // Consider statements that appear before stmt

--- a/compiler/resolution/lowerIterators.cpp
+++ b/compiler/resolution/lowerIterators.cpp
@@ -1474,8 +1474,6 @@ findFollowingCheckErrorBlock(SymExpr* se, LabelSymbol*& outHandlerLabel,
   Expr* stmt = se->getStmtExpr(); // aka last scope
   Expr* scope = stmt->parentExpr;
 
-  gdbShouldBreakHere();
-
   while (scope) {
     if (isBlockStmt(scope)) {
       // Consider statements that appear before stmt

--- a/modules/internal/CString.chpl
+++ b/modules/internal/CString.chpl
@@ -117,89 +117,29 @@ module CString {
   // casts from c_string to bool types
   //
   inline proc _cast(type t, x:c_string) throws where isBoolType(t)
-  {
-    pragma "insert line file info"
-    extern proc c_string_to_chpl_bool(x:c_string, ref err: bool) : bool;
-
-    var isErr: bool;
-    var retVal = c_string_to_chpl_bool((x:string).strip().c_str(), isErr): t;
-
-    if isErr then
-      throw new IllegalArgumentError(x:string, "Unexpected value when converting from string to bool");
-
-    return retVal;
-  }
+    return try ((x:string).strip()): t;
 
   //
   // casts from c_string to integer types
   //
-  pragma "insert line file info"
-  extern proc c_string_to_int8_t  (x:c_string) : int(8);
-  pragma "insert line file info"
-  extern proc c_string_to_int16_t (x:c_string) : int(16);
-  pragma "insert line file info"
-  extern proc c_string_to_int32_t (x:c_string) : int(32);
-  pragma "insert line file info"
-  extern proc c_string_to_int64_t (x:c_string) : int(64);
-  pragma "insert line file info"
-  extern proc c_string_to_uint8_t (x:c_string) : uint(8);
-  pragma "insert line file info"
-  extern proc c_string_to_uint16_t(x:c_string) : uint(16);
-  pragma "insert line file info"
-  extern proc c_string_to_uint32_t(x:c_string) : uint(32);
-  pragma "insert line file info"
-  extern proc c_string_to_uint64_t(x:c_string) : uint(64);
-
-  inline proc _cast(type t, x:c_string) where t == int(8)
-    return c_string_to_int8_t((x:string).strip().c_str());
-  inline proc _cast(type t, x:c_string) where t == int(16)
-    return c_string_to_int16_t((x:string).strip().c_str());
-  inline proc _cast(type t, x:c_string) where t == int(32)
-    return c_string_to_int32_t((x:string).strip().c_str());
-  inline proc _cast(type t, x:c_string) where t == int(64)
-    return c_string_to_int64_t((x:string).strip().c_str());
-  inline proc _cast(type t, x:c_string) where t == uint(8)
-    return c_string_to_uint8_t((x:string).strip().c_str());
-  inline proc _cast(type t, x:c_string) where t == uint(16)
-    return c_string_to_uint16_t((x:string).strip().c_str());
-  inline proc _cast(type t, x:c_string) where t == uint(32)
-    return c_string_to_uint32_t((x:string).strip().c_str());
-  inline proc _cast(type t, x:c_string) where t == uint(64)
-    return c_string_to_uint64_t((x:string).strip().c_str());
+  inline proc _cast(type t, x:c_string) throws where t == int(8) || t == int(16) || t == int(32) || t == int(64)
+    return try ((x:string).strip()): t;
+  inline proc _cast(type t, x:c_string) throws where t == uint(8) || t == uint(16) || t == uint(32) || t == uint(64)
+    return try ((x:string).strip()): t;
 
   //
   // casts from c_string to real/imag types
   //
-  pragma "insert line file info"
-  extern proc c_string_to_real32(x:c_string) : real(32);
-  pragma "insert line file info"
-  extern proc c_string_to_real64(x:c_string) : real(64);
-  pragma "insert line file info"
-  extern proc c_string_to_imag32(x:c_string) : imag(32);
-  pragma "insert line file info"
-  extern proc c_string_to_imag64(x:c_string) : imag(64);
-
-  inline proc _cast(type t, x:c_string) where t == real(32)
-    return c_string_to_real32((x:string).strip().c_str());
-  inline proc _cast(type t, x:c_string) where t == real(64)
-    return c_string_to_real64((x:string).strip().c_str());
-  inline proc _cast(type t, x:c_string) where t == imag(32)
-    return c_string_to_imag32((x:string).strip().c_str());
-  inline proc _cast(type t, x:c_string) where t == imag(64)
-    return c_string_to_imag64((x:string).strip().c_str());
+  inline proc _cast(type t, x:c_string) throws where t == real(32) || t == real(64)
+    return try ((x:string).strip()): t;
+  inline proc _cast(type t, x:c_string) throws where t == imag(32) || t == imag(64)
+    return try ((x:string).strip()): t;
 
   //
   // casts from c_string to complex types
   //
-  pragma "insert line file info"
-  extern proc c_string_to_complex64(x:c_string) : complex(64);
-  pragma "insert line file info"
-  extern proc c_string_to_complex128(x:c_string) : complex(128);
-
-  inline proc _cast(type t, x:c_string) where t == complex(64)
-    return c_string_to_complex64((x:string).strip().c_str());
-  inline proc _cast(type t, x:c_string) where t == complex(128)
-    return c_string_to_complex128((x:string).strip().c_str());
+  inline proc _cast(type t, x:c_string) throws where t == complex(64) || t == complex(128)
+    return try ((x:string).strip()): t;
 
   //
   // casts from complex

--- a/modules/internal/CString.chpl
+++ b/modules/internal/CString.chpl
@@ -116,7 +116,7 @@ module CString {
   //
   // casts from c_string to bool types
   //
-  inline proc _cast(type t, x:c_string) where isBoolType(t)
+  inline proc _cast(type t, x:c_string) throws where isBoolType(t)
   {
     pragma "insert line file info"
     extern proc c_string_to_chpl_bool(x:c_string, ref err: c_string) : bool;

--- a/modules/internal/CString.chpl
+++ b/modules/internal/CString.chpl
@@ -119,8 +119,16 @@ module CString {
   inline proc _cast(type t, x:c_string) where isBoolType(t)
   {
     pragma "insert line file info"
-    extern proc c_string_to_chpl_bool(x:c_string) : bool;
-    return c_string_to_chpl_bool((x:string).strip().c_str()) : t;
+    extern proc c_string_to_chpl_bool(x:c_string, ref err: c_string) : bool;
+
+    var err_str: c_string;
+    var retVal = c_string_to_chpl_bool((x:string).strip().c_str(), err_str) : t;
+
+    var err_str_cast = err_str:string;
+    if !err_str_cast.isEmptyString() then
+      throw new IllegalArgumentError("string", err_str_cast);
+
+    return retVal;
   }
 
   //

--- a/modules/internal/CString.chpl
+++ b/modules/internal/CString.chpl
@@ -119,14 +119,13 @@ module CString {
   inline proc _cast(type t, x:c_string) throws where isBoolType(t)
   {
     pragma "insert line file info"
-    extern proc c_string_to_chpl_bool(x:c_string, ref err: c_string) : bool;
+    extern proc c_string_to_chpl_bool(x:c_string, ref err: bool) : bool;
 
-    var err_str: c_string;
-    var retVal = c_string_to_chpl_bool((x:string).strip().c_str(), err_str) : t;
+    var isErr: bool;
+    var retVal = c_string_to_chpl_bool((x:string).strip().c_str(), isErr): t;
 
-    var err_str_cast = err_str:string;
-    if !err_str_cast.isEmptyString() then
-      throw new IllegalArgumentError("string", err_str_cast);
+    if isErr then
+      throw new IllegalArgumentError(x:string, "Unexpected value when converting from string to bool");
 
     return retVal;
   }

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1010,9 +1010,7 @@ module ChapelBase {
 
   pragma "command line setting"
   proc _command_line_cast(param s: c_string, type t, x) {
-    try! {
-      return _cast(t, x:string);
-    }
+    return _cast(t, x:string);
   }
 
 

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1010,7 +1010,9 @@ module ChapelBase {
 
   pragma "command line setting"
   proc _command_line_cast(param s: c_string, type t, x) {
-    return _cast(t, x:string);
+    try! {
+      return _cast(t, x:string);
+    }
   }
 
 

--- a/modules/internal/ChapelError.chpl
+++ b/modules/internal/ChapelError.chpl
@@ -94,8 +94,8 @@ module ChapelError {
       super.init();
     }
 
-    proc init(_info: string) {
-      this.info = _info;
+    proc init(info: string) {
+      this.info = info;
       super.init();
     }
 

--- a/modules/internal/ChapelError.chpl
+++ b/modules/internal/ChapelError.chpl
@@ -106,10 +106,7 @@ module ChapelError {
     }
 
     proc message() {
-      if arg_name.isEmptyString() then
-        return "'" + arg_info + "'";
-      else
-        return "illegal argument '" + arg_name + "': " + arg_info;
+      return "illegal argument '" + arg_name + "': " + arg_info;
     }
   }
 

--- a/modules/internal/ChapelError.chpl
+++ b/modules/internal/ChapelError.chpl
@@ -99,9 +99,9 @@ module ChapelError {
       super.init();
     }
 
-    proc init(_formal: string, _info: string) {
-      this.formal = _formal;
-      this.info = _info;
+    proc init(formal: string, info: string) {
+      this.formal = formal;
+      this.info   = info;
       super.init();
     }
 

--- a/modules/internal/ChapelError.chpl
+++ b/modules/internal/ChapelError.chpl
@@ -106,7 +106,10 @@ module ChapelError {
     }
 
     proc message() {
-      return "illegal argument '" + arg_name + "': " + arg_info;
+      if arg_name.isEmptyString() then
+        return "'" + arg_info + "'";
+      else
+        return "illegal argument '" + arg_name + "': " + arg_info;
     }
   }
 

--- a/modules/internal/ChapelError.chpl
+++ b/modules/internal/ChapelError.chpl
@@ -87,26 +87,29 @@ module ChapelError {
   }
 
   class IllegalArgumentError : Error {
-    var arg_name: string;
-    var arg_info: string;
+    var formal: string;
+    var info: string;
 
     proc init() {
       super.init();
     }
 
-    proc init(_arg_name: string) {
-      this.arg_name = _arg_name;
+    proc init(_info: string) {
+      this.info = _info;
       super.init();
     }
 
-    proc init(_arg_name: string, _arg_info: string) {
-      this.arg_name = _arg_name;
-      this.arg_info = _arg_info;
+    proc init(_formal: string, _info: string) {
+      this.formal = _formal;
+      this.info = _info;
       super.init();
     }
 
     proc message() {
-      return "illegal argument '" + arg_name + "': " + arg_info;
+      if formal.isEmptyString() then
+        return info;
+      else
+        return "illegal argument '" + formal + "': " + info;
     }
   }
 
@@ -405,5 +408,17 @@ module ChapelError {
       return err;
     // If err wasn't a taskError, wrap it in one
     return new TaskErrors(err);
+  }
+
+  // The compiler generates functions to cast from strings to enums. This
+  // function helps the compiler throw errors from those generated casts.
+  pragma "no doc"
+  pragma "insert line file info"
+  pragma "always propagate line file info"
+  proc chpl_enum_cast_error(casted: string, enumName: string) throws {
+    if casted.isEmptyString() then
+      throw new IllegalArgumentError("bad cast from empty string to " + enumName);
+    else
+      throw new IllegalArgumentError("bad cast from string '" + casted + "' to " + enumName);
   }
 }

--- a/modules/internal/LocaleModelHelpSetup.chpl
+++ b/modules/internal/LocaleModelHelpSetup.chpl
@@ -115,8 +115,8 @@ module LocaleModelHelpSetup {
     // sys_getenv returns zero on success.
     if sys_getenv(c"CHPL_COMM", comm) == 0 && comm == c"gasnet" &&
       sys_getenv(c"GASNET_SPAWNFN", spawnfn) == 0 && spawnfn == c"L"
-    then local_name = try! chpl_nodeName():string + "-" + _node_id:string;
-    else local_name = try! chpl_nodeName():string;
+    then local_name = chpl_nodeName():string + "-" + _node_id:string;
+    else local_name = chpl_nodeName():string;
 
     extern proc chpl_task_getCallStackSize(): size_t;
     dst.callStackSize = chpl_task_getCallStackSize();

--- a/modules/internal/LocaleModelHelpSetup.chpl
+++ b/modules/internal/LocaleModelHelpSetup.chpl
@@ -115,8 +115,8 @@ module LocaleModelHelpSetup {
     // sys_getenv returns zero on success.
     if sys_getenv(c"CHPL_COMM", comm) == 0 && comm == c"gasnet" &&
       sys_getenv(c"GASNET_SPAWNFN", spawnfn) == 0 && spawnfn == c"L"
-    then local_name = chpl_nodeName():string + "-" + _node_id:string;
-    else local_name = chpl_nodeName():string;
+    then local_name = try! chpl_nodeName():string + "-" + _node_id:string;
+    else local_name = try! chpl_nodeName():string;
 
     extern proc chpl_task_getCallStackSize(): size_t;
     dst.callStackSize = chpl_task_getCallStackSize();

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -1519,13 +1519,13 @@ module String {
 
   // Concatenation with other types is done by casting to string
   private inline proc concatHelp(s: string, x:?t) where t != string {
-    var cs = x:string;
+    var cs = try! x:string;
     const ret = s + cs;
     return ret;
   }
 
   private inline proc concatHelp(x:?t, s: string) where t != string  {
-    var cs = x:string;
+    var cs = try! x:string;
     const ret = cs + s;
     return ret;
   }

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -1519,13 +1519,13 @@ module String {
 
   // Concatenation with other types is done by casting to string
   private inline proc concatHelp(s: string, x:?t) where t != string {
-    var cs = try! x:string;
+    var cs = x:string;
     const ret = s + cs;
     return ret;
   }
 
   private inline proc concatHelp(x:?t, s: string) where t != string  {
-    var cs = try! x:string;
+    var cs = x:string;
     const ret = cs + s;
     return ret;
   }

--- a/modules/internal/StringCasts.chpl
+++ b/modules/internal/StringCasts.chpl
@@ -46,13 +46,13 @@ module StringCasts {
   proc _cast(type t, x: string) throws where isBoolType(t) {
     var str = x.strip();
     if str.isEmptyString() {
-      throw new IllegalArgumentError(x, "Empty string when converting from string to bool");
+      throw new IllegalArgumentError("bad cast from empty string to bool");
     } else if (str == "true") {
       return true;
     } else if (str == "false") {
       return false;
     } else {
-      throw new IllegalArgumentError(x, "Unexpected value when converting from string to bool");
+      throw new IllegalArgumentError("bad cast from string '" + x + "' to bool");
     }
     return false;
   }
@@ -71,7 +71,7 @@ module StringCasts {
     // this should only happen if the runtime is broken
     if isErr {
       try! {
-        throw new IllegalArgumentError("integral", "Unexpected case in integral_to_c_string");
+        throw new IllegalArgumentError("Unexpected case in integral_to_c_string");
       }
     }
 
@@ -108,7 +108,7 @@ module StringCasts {
 
     if isIntType(t) {
       if localX.isEmptyString() then
-        throw new IllegalArgumentError(x, "Empty string when converting from string to int(" + numBits(t) + ")");
+        throw new IllegalArgumentError("bad cast from empty string to int(" + numBits(t) + ")");
 
       select numBits(t) {
         when 8  do retVal = c_string_to_int8_t(localX.c_str(), isErr);
@@ -119,10 +119,10 @@ module StringCasts {
       }
 
       if isErr then
-        throw new IllegalArgumentError(x, "Unexpected character when converting from string to int(" + numBits(t) + ")");
+        throw new IllegalArgumentError("bad cast from string '" + x + "' to int(" + numBits(t) + ")");
     } else {
       if localX.isEmptyString() then
-        throw new IllegalArgumentError(x, "Empty string when converting from string to uint(" + numBits(t) + ")");
+        throw new IllegalArgumentError("bad cast from empty string to uint(" + numBits(t) + ")");
 
       select numBits(t) {
         when 8  do retVal = c_string_to_uint8_t(localX.c_str(), isErr);
@@ -133,7 +133,7 @@ module StringCasts {
       }
 
       if isErr then
-        throw new IllegalArgumentError(x, "Unexpected character when converting from string to uint(" + numBits(t) + ")");
+        throw new IllegalArgumentError("bad cast from string '" + x + "' to uint(" + numBits(t) + ")");
     }
 
     return retVal;
@@ -180,7 +180,7 @@ module StringCasts {
     const localX = x.localize();
 
     if localX.isEmptyString() then
-      throw new IllegalArgumentError(x, "Empty string when converting from string to real(" + numBits(t) + ")");
+      throw new IllegalArgumentError("bad cast from empty string to real(" + numBits(t) + ")");
 
     select numBits(t) {
       when 32 do retVal = c_string_to_real32(localX.c_str(), isErr);
@@ -189,7 +189,7 @@ module StringCasts {
     }
 
     if isErr then
-      throw new IllegalArgumentError(x, "Unexpected character when converting from string to real(" + numBits(t) + ")");
+      throw new IllegalArgumentError("bad cast from string '" + x + "' to real(" + numBits(t) + ")");
 
     return retVal;
   }
@@ -205,7 +205,7 @@ module StringCasts {
     const localX = x.localize();
 
     if localX.isEmptyString() then
-      throw new IllegalArgumentError(x, "Empty string when converting from string to imag(" + numBits(t) + ")");
+      throw new IllegalArgumentError("bad cast from empty string to imag(" + numBits(t) + ")");
 
     select numBits(t) {
       when 32 do retVal = c_string_to_imag32(localX.c_str(), isErr);
@@ -214,7 +214,7 @@ module StringCasts {
     }
 
     if isErr then
-      throw new IllegalArgumentError(x, "Unexpected character when converting from string to imag(" + numBits(t) + ")");
+      throw new IllegalArgumentError("bad cast from string '" + x + "' to imag(" + numBits(t) + ")");
 
     return retVal;
   }
@@ -257,7 +257,7 @@ module StringCasts {
     const localX = x.localize();
 
     if localX.isEmptyString() then
-      throw new IllegalArgumentError(x, "Empty string when converting from string to complex(" + numBits(t) + ")");
+      throw new IllegalArgumentError("bad cast from empty string to complex(" + numBits(t) + ")");
 
     select numBits(t) {
       when 64 do retVal = c_string_to_complex64(localX.c_str(), isErr);
@@ -266,7 +266,7 @@ module StringCasts {
     }
 
     if isErr then
-      throw new IllegalArgumentError(x, "Unexpected character when converting from string to complex(" + numBits(t) + ")");
+      throw new IllegalArgumentError("bad cast from string '" + x + "' to complex(" + numBits(t) + ")");
 
     return retVal;
   }

--- a/modules/internal/StringCasts.chpl
+++ b/modules/internal/StringCasts.chpl
@@ -68,6 +68,7 @@ module StringCasts {
     var isErr: bool;
     var csc = integral_to_c_string(x:int(64), numBytes(x.type), isIntType(x.type), isErr);
 
+    // this should only happen if the runtime is broken
     if isErr {
       try! {
         throw new IllegalArgumentError("integral", "Unexpected case in integral_to_c_string");

--- a/modules/internal/StringCasts.chpl
+++ b/modules/internal/StringCasts.chpl
@@ -60,7 +60,7 @@ module StringCasts {
   //
   // int
   //
-  proc _cast(type t, x: integral) throws where t == string {
+  proc _cast(type t, x: integral) where t == string {
     //TODO: switch to using qio's writef somehow
     extern proc integral_to_c_string(x:int(64), size:uint(32), isSigned: bool, ref err: bool) : c_string;
     extern proc strlen(const str: c_string) : size_t;
@@ -68,8 +68,11 @@ module StringCasts {
     var isErr: bool;
     var csc = integral_to_c_string(x:int(64), numBytes(x.type), isIntType(x.type), isErr);
 
-    if isErr then
-      throw new IllegalArgumentError("integral", "Unexpected case in integral_to_c_string");
+    if isErr {
+      try! {
+        throw new IllegalArgumentError("integral", "Unexpected case in integral_to_c_string");
+      }
+    }
 
     var ret: string;
     ret.buff = csc:c_ptr(uint(8));

--- a/modules/internal/StringCasts.chpl
+++ b/modules/internal/StringCasts.chpl
@@ -46,13 +46,13 @@ module StringCasts {
   proc _cast(type t, x: string) throws where isBoolType(t) {
     var str = x.strip();
     if str.isEmptyString() {
-      throw new IllegalArgumentError("string", "Empty string when converting from string to bool");
+      throw new IllegalArgumentError(x, "Empty string when converting from string to bool");
     } else if (str == "true") {
       return true;
     } else if (str == "false") {
       return false;
     } else {
-      throw new IllegalArgumentError("string", "Unexpected value when converting from string to bool: '"+x+"'");
+      throw new IllegalArgumentError(x, "Unexpected value when converting from string to bool");
     }
     return false;
   }

--- a/modules/internal/StringCasts.chpl
+++ b/modules/internal/StringCasts.chpl
@@ -43,17 +43,17 @@ module StringCasts {
     }
   }
 
-  proc _cast(type t, x: string) where isBoolType(t) {
+  proc _cast(type t, x: string) where isBoolType(t) throws {
     var str = x.strip();
     if str.isEmptyString() {
-      __primitive("chpl_error", c"Empty string when converting from string to bool");
+      throw new IllegalArgumentError("Empty string when converting from string to bool");
       return false;
     } else if (str == "true") {
       return true;
     } else if (str == "false") {
       return false;
     } else {
-      halt("Unexpected value when converting from string to bool: '"+x+"'");
+      throw new IllegalArgumentError("Unexpected value when converting from string to bool: '"+x+"'");
     }
   }
 
@@ -212,7 +212,7 @@ module StringCasts {
       otherwise compilerError("Unsupported bit width ", numBits(t), " in cast to string");
     }
   }
- 
+
   // Catch all cast anything -> string is in ChapelIO
 
 }

--- a/modules/internal/StringCasts.chpl
+++ b/modules/internal/StringCasts.chpl
@@ -111,7 +111,7 @@ module StringCasts {
         when 16 do retVal = c_string_to_int16_t(localX.c_str(), isErr);
         when 32 do retVal = c_string_to_int32_t(localX.c_str(), isErr);
         when 64 do retVal = c_string_to_int64_t(localX.c_str(), isErr);
-        otherwise compilerError("Unsupported bit width ", numBits(t): string, " in cast to string");
+        otherwise compilerError("Unsupported bit width ", numBits(t), " in cast to string");
       }
 
       if isErr then
@@ -125,7 +125,7 @@ module StringCasts {
         when 16 do retVal = c_string_to_uint16_t(localX.c_str(), isErr);
         when 32 do retVal = c_string_to_uint32_t(localX.c_str(), isErr);
         when 64 do retVal = c_string_to_uint64_t(localX.c_str(), isErr);
-        otherwise compilerError("Unsupported bit width ", numBits(t): string, " in cast to string");
+        otherwise compilerError("Unsupported bit width ", numBits(t), " in cast to string");
       }
 
       if isErr then

--- a/modules/standard/DateTime.chpl
+++ b/modules/standard/DateTime.chpl
@@ -327,7 +327,7 @@ module DateTime {
     timeStruct.tm_wday = weekday(): int(32);
     timeStruct.tm_yday = (toordinal() - (new date(year, 1, 1)).toordinal() + 1): int(32);
     timeStruct.tm_isdst = (-1): int(32);
-    return timeStruct; 
+    return timeStruct;
   }
 
   /* Return the number of days since 1-1-0001 this `date` represents */
@@ -1105,7 +1105,7 @@ module DateTime {
 
     // on our Linux64 systems, the "%Y" format doesn't zero-pad to 4
     // characters on its own, so do it manually.
-    var year = zeroPad(4, strftime("%Y"):int);
+    var year = zeroPad(4, try! strftime("%Y"):int);
     return strftime(year + "-%m-%d" + sep + "%H:%M:%S" + micro + offset);
   }
 

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1583,10 +1583,10 @@ proc open(out error:syserr, path:string="", mode:iomode, hints:iohints=IOHINT_NO
     if port_start > 0 then port_str = path[port_start..port_end];
 
     var port: int;
-    try! {
+    try {
       port = port_str: int;
-    } catch e: IllegalArgumentError {
-      error = ENOENT;
+    } catch {
+      error = EINVAL;
     }
 
     var file_path = "";
@@ -5605,7 +5605,7 @@ proc _setIfPrimitive(ref lhs:?t, rhs:?t2, argi:int):syserr where t!=bool&&_isIoP
   try {
     lhs = rhs:t;
   } catch {
-    return EFORMAT;
+    return ERANGE;
   }
   return ENOERR;
 }

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -5333,7 +5333,13 @@ proc _toIntegral(x:?t) where isIntegralType(t)
 private inline
 proc _toIntegral(x:?t) where _isIoPrimitiveType(t) && !isIntegralType(t)
 {
-  return (x:int, true);
+  var ret: (int, bool);
+  try {
+    ret = (x:int, true);
+  } catch {
+    ret = (0, false);
+  }
+  return ret;
 }
 private inline
 proc _toIntegral(x:?t) where !_isIoPrimitiveType(t)
@@ -5370,7 +5376,13 @@ proc _toSigned(x:uint(64))
 private inline
 proc _toSigned(x:?t) where _isIoPrimitiveType(t) && !isIntegralType(t)
 {
-  return (x:int, true);
+  var ret: (int, bool);
+  try {
+    ret = (x:int, true);
+  } catch {
+    ret = (0, false);
+  }
+  return ret;
 }
 private inline
 proc _toSigned(x:?t) where !_isIoPrimitiveType(t)
@@ -5408,7 +5420,13 @@ proc _toUnsigned(x:int(64))
 private inline
 proc _toUnsigned(x:?t) where _isIoPrimitiveType(t) && !isIntegralType(t)
 {
-  return (x:uint, true);
+  var ret: (uint, bool);
+  try {
+    ret = (x:uint, true);
+  } catch {
+    ret = (0:uint, false);
+  }
+  return ret;
 }
 private inline
 proc _toUnsigned(x:?t) where !_isIoPrimitiveType(t)
@@ -5425,7 +5443,13 @@ proc _toReal(x:?t) where isRealType(t)
 private inline
 proc _toReal(x:?t) where _isIoPrimitiveType(t) && !isRealType(t)
 {
-  return (x:real, true);
+  var ret: (real, bool);
+  try {
+    ret = (x:real, true);
+  } catch {
+    ret = (0.0, false);
+  }
+  return ret;
 }
 private inline
 proc _toReal(x:?t) where !_isIoPrimitiveType(t)
@@ -5441,7 +5465,13 @@ proc _toImag(x:?t) where isImagType(t)
 private inline
 proc _toImag(x:?t) where _isIoPrimitiveType(t) && !isImagType(t)
 {
-  return (x:imag, true);
+  var ret: (imag, bool);
+  try {
+    ret = (x:imag, true);
+  } catch {
+    ret = (0.0i, false);
+  }
+  return ret;
 }
 private inline
 proc _toImag(x:?t) where !_isIoPrimitiveType(t)
@@ -5458,7 +5488,13 @@ proc _toComplex(x:?t) where isComplexType(t)
 private inline
 proc _toComplex(x:?t) where _isIoPrimitiveType(t) && !isComplexType(t)
 {
-  return (x:complex, true);
+  var ret: (complex, bool);
+  try {
+    ret = (x:complex, true);
+  } catch {
+    ret = (0.0+0.0i, false);
+  }
+  return ret;
 }
 private inline
 proc _toComplex(x:?t) where !_isIoPrimitiveType(t)
@@ -5496,7 +5532,14 @@ private inline
 proc _toNumeric(x:?t) where _isIoPrimitiveType(t) && !isNumericType(t)
 {
   // enums, bools get cast to int.
-  return (x:int, true);
+  var ret: (int, bool);
+  try {
+    ret = (x:int, true);
+  } catch {
+    ret = (0, false);
+  }
+  return ret;
+
 }
 private inline
 proc _toNumeric(x:?t) where !_isIoPrimitiveType(t)
@@ -5559,7 +5602,11 @@ proc _setIfPrimitive(ref lhs:?t, rhs:?t2, argi:int):syserr where t==bool&&_isIoP
 private inline
 proc _setIfPrimitive(ref lhs:?t, rhs:?t2, argi:int):syserr where t!=bool&&_isIoPrimitiveType(t)
 {
-  lhs = rhs:t;
+  try {
+    lhs = rhs:t;
+  } catch {
+    return EFORMAT;
+  }
   return ENOERR;
 }
 private inline
@@ -6506,7 +6553,11 @@ proc channel.readf(fmtStr:string, ref args ...?k, out error:syserr):bool {
                   if _isIoPrimitiveType(args(i).type) {
                     // but only if it's a primitive type
                     // (so that we can avoid problems with string-to-record).
-                    args(i) = r.capArr[r.capturei]:args(i).type;
+                    try {
+                      args(i) = r.capArr[r.capturei]:args(i).type;
+                    } catch {
+                      error = qio_format_error_bad_regexp();
+                    }
                   }
                   r.capturei += 1;
                 }

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1579,11 +1579,19 @@ proc open(out error:syserr, path:string="", mode:iomode, hints:iohints=IOHINT_NO
     }
 
     var host = path[host_start..host_end];
-    var port = "";
-    if port_start > 0 then port = path[port_start..port_end];
+    var port_str = "";
+    if port_start > 0 then port_str = path[port_start..port_end];
+
+    var port: int;
+    try! {
+      port = port_str: int;
+    } catch e: IllegalArgumentError {
+      error = ENOENT;
+    }
+
     var file_path = "";
     if path_start > 0 then file_path = path[path_start..];
-    return (host, port:int, file_path);
+    return (host, port, file_path);
   }
 
   var local_style = style;

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -3437,7 +3437,7 @@ proc _stringify_tuple(tup:?t) where isTuple(t)
 
   for param i in 1..tup.size {
     if i != 1 then str += ", ";
-    str += tup[i]:string;
+    str += try! tup[i]:string;
   }
 
  str += ")";
@@ -3469,7 +3469,7 @@ proc stringify(const args ...?k):string {
         str += args[i]:string;
       } else if isRangeType(args[i].type) ||
                 isPrimitiveType(args[i].type) {
-        str += args[i]:string;
+        str += try! args[i]:string;
       } else if isTupleType(args[i].type) {
         str += _stringify_tuple(args[i]);
       }

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -3437,7 +3437,7 @@ proc _stringify_tuple(tup:?t) where isTuple(t)
 
   for param i in 1..tup.size {
     if i != 1 then str += ", ";
-    str += try! tup[i]:string;
+    str += tup[i]:string;
   }
 
  str += ")";
@@ -3469,7 +3469,7 @@ proc stringify(const args ...?k):string {
         str += args[i]:string;
       } else if isRangeType(args[i].type) ||
                 isPrimitiveType(args[i].type) {
-        str += try! args[i]:string;
+        str += args[i]:string;
       } else if isTupleType(args[i].type) {
         str += _stringify_tuple(args[i]);
       }

--- a/modules/standard/Regexp.chpl
+++ b/modules/standard/Regexp.chpl
@@ -609,7 +609,12 @@ record regexp {
         captures[i] = m;
       } else {
         if m.matched {
-          captures[i] = text[m]:captures[i].type;
+          try {
+            captures[i] = text[m]:captures[i].type;
+          } catch {
+            var empty:captures[i].type;
+            captures[i] = empty;
+          }
         } else {
           var empty:captures[i].type;
           captures[i] = empty;

--- a/runtime/include/chplcast.h
+++ b/runtime/include/chplcast.h
@@ -45,7 +45,7 @@ uint16_t c_string_to_uint16_t(c_string str, chpl_bool* err, int lineno, int32_t 
 uint32_t c_string_to_uint32_t(c_string str, chpl_bool* err, int lineno, int32_t filename);
 uint64_t c_string_to_uint64_t(c_string str, chpl_bool* err, int lineno, int32_t filename);
 
-chpl_bool c_string_to_chpl_bool(c_string str, c_string* err, int lineno, int32_t filename);
+chpl_bool c_string_to_chpl_bool(c_string str, chpl_bool* err, int lineno, int32_t filename);
 
 _real32 c_string_to_real32_precise(c_string str, int* invalid, char* invalidCh);
 _real64 c_string_to_real64_precise(c_string str, int* invalid, char* invalidCh);

--- a/runtime/include/chplcast.h
+++ b/runtime/include/chplcast.h
@@ -36,14 +36,14 @@ uint32_t c_string_to_uint32_t_precise(c_string str, int* invalid, char* invalidC
 uint64_t c_string_to_uint64_t_precise(c_string str, int* invalid, char* invalidChar);
 
 /* string to every other primitive type */
-int8_t c_string_to_int8_t(c_string str, c_string* err, int lineno, int32_t filename);
-int16_t c_string_to_int16_t(c_string str, c_string* err, int lineno, int32_t filename);
-int32_t c_string_to_int32_t(c_string str, c_string* err, int lineno, int32_t filename);
-int64_t c_string_to_int64_t(c_string str, c_string* err, int lineno, int32_t filename);
-uint8_t c_string_to_uint8_t(c_string str, c_string* err, int lineno, int32_t filename);
-uint16_t c_string_to_uint16_t(c_string str, c_string* err, int lineno, int32_t filename);
-uint32_t c_string_to_uint32_t(c_string str, c_string* err, int lineno, int32_t filename);
-uint64_t c_string_to_uint64_t(c_string str, c_string* err, int lineno, int32_t filename);
+int8_t c_string_to_int8_t(c_string str, chpl_bool* err, int lineno, int32_t filename);
+int16_t c_string_to_int16_t(c_string str, chpl_bool* err, int lineno, int32_t filename);
+int32_t c_string_to_int32_t(c_string str, chpl_bool* err, int lineno, int32_t filename);
+int64_t c_string_to_int64_t(c_string str, chpl_bool* err, int lineno, int32_t filename);
+uint8_t c_string_to_uint8_t(c_string str, chpl_bool* err, int lineno, int32_t filename);
+uint16_t c_string_to_uint16_t(c_string str, chpl_bool* err, int lineno, int32_t filename);
+uint32_t c_string_to_uint32_t(c_string str, chpl_bool* err, int lineno, int32_t filename);
+uint64_t c_string_to_uint64_t(c_string str, chpl_bool* err, int lineno, int32_t filename);
 
 chpl_bool c_string_to_chpl_bool(c_string str, c_string* err, int lineno, int32_t filename);
 
@@ -56,18 +56,18 @@ _complex64 c_string_to_complex64_precise(c_string str, int* invalid, char* inval
 _complex128 c_string_to_complex128_precise(c_string str, int* invalid, char* invalidCh);
 #endif
 
-_real32 c_string_to_real32(c_string str, c_string* err, int lineno, int32_t filename);
-_real64 c_string_to_real64(c_string str, c_string* err, int lineno, int32_t filename);
-_imag32 c_string_to_imag32(c_string str, c_string* err, int lineno, int32_t filename);
-_imag64 c_string_to_imag64(c_string str, c_string* err, int lineno, int32_t filename);
+_real32 c_string_to_real32(c_string str, chpl_bool* err, int lineno, int32_t filename);
+_real64 c_string_to_real64(c_string str, chpl_bool* err, int lineno, int32_t filename);
+_imag32 c_string_to_imag32(c_string str, chpl_bool* err, int lineno, int32_t filename);
+_imag64 c_string_to_imag64(c_string str, chpl_bool* err, int lineno, int32_t filename);
 #ifndef __cplusplus
-_complex64 c_string_to_complex64(c_string str, c_string* err, int lineno, int32_t filename);
-_complex128 c_string_to_complex128(c_string str, c_string* err, int lineno, int32_t filename);
+_complex64 c_string_to_complex64(c_string str, chpl_bool* err, int lineno, int32_t filename);
+_complex128 c_string_to_complex128(c_string str, chpl_bool* err, int lineno, int32_t filename);
 #endif
 
 
 /* every other primitive type to string */
-c_string integral_to_c_string(int64_t x, uint32_t size, chpl_bool isSigned, c_string* err);
+c_string integral_to_c_string(int64_t x, uint32_t size, chpl_bool isSigned, chpl_bool* err);
 c_string real_to_c_string(_real64 x, chpl_bool isImag);
 
 // TODO: Can we use the pattern above, to reduce the number of interfaces required?

--- a/runtime/include/chplcast.h
+++ b/runtime/include/chplcast.h
@@ -1,15 +1,15 @@
 /*
  * Copyright 2004-2018 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -36,16 +36,16 @@ uint32_t c_string_to_uint32_t_precise(c_string str, int* invalid, char* invalidC
 uint64_t c_string_to_uint64_t_precise(c_string str, int* invalid, char* invalidChar);
 
 /* string to every other primitive type */
-int8_t c_string_to_int8_t(c_string str, int lineno, int32_t filename);
-int16_t c_string_to_int16_t(c_string str, int lineno, int32_t filename);
-int32_t c_string_to_int32_t(c_string str, int lineno, int32_t filename);
-int64_t c_string_to_int64_t(c_string str, int lineno, int32_t filename);
-uint8_t c_string_to_uint8_t(c_string str, int lineno, int32_t filename);
-uint16_t c_string_to_uint16_t(c_string str, int lineno, int32_t filename);
-uint32_t c_string_to_uint32_t(c_string str, int lineno, int32_t filename);
-uint64_t c_string_to_uint64_t(c_string str, int lineno, int32_t filename);
+int8_t c_string_to_int8_t(c_string str, c_string* err, int lineno, int32_t filename);
+int16_t c_string_to_int16_t(c_string str, c_string* err, int lineno, int32_t filename);
+int32_t c_string_to_int32_t(c_string str, c_string* err, int lineno, int32_t filename);
+int64_t c_string_to_int64_t(c_string str, c_string* err, int lineno, int32_t filename);
+uint8_t c_string_to_uint8_t(c_string str, c_string* err, int lineno, int32_t filename);
+uint16_t c_string_to_uint16_t(c_string str, c_string* err, int lineno, int32_t filename);
+uint32_t c_string_to_uint32_t(c_string str, c_string* err, int lineno, int32_t filename);
+uint64_t c_string_to_uint64_t(c_string str, c_string* err, int lineno, int32_t filename);
 
-chpl_bool c_string_to_chpl_bool(c_string str, int lineno, int32_t filename);
+chpl_bool c_string_to_chpl_bool(c_string str, c_string* err, int lineno, int32_t filename);
 
 _real32 c_string_to_real32_precise(c_string str, int* invalid, char* invalidCh);
 _real64 c_string_to_real64_precise(c_string str, int* invalid, char* invalidCh);
@@ -56,18 +56,18 @@ _complex64 c_string_to_complex64_precise(c_string str, int* invalid, char* inval
 _complex128 c_string_to_complex128_precise(c_string str, int* invalid, char* invalidCh);
 #endif
 
-_real32 c_string_to_real32(c_string str, int lineno, int32_t filename);
-_real64 c_string_to_real64(c_string str, int lineno, int32_t filename);
-_imag32 c_string_to_imag32(c_string str, int lineno, int32_t filename);
-_imag64 c_string_to_imag64(c_string str, int lineno, int32_t filename);
+_real32 c_string_to_real32(c_string str, c_string* err, int lineno, int32_t filename);
+_real64 c_string_to_real64(c_string str, c_string* err, int lineno, int32_t filename);
+_imag32 c_string_to_imag32(c_string str, c_string* err, int lineno, int32_t filename);
+_imag64 c_string_to_imag64(c_string str, c_string* err, int lineno, int32_t filename);
 #ifndef __cplusplus
-_complex64 c_string_to_complex64(c_string str, int lineno, int32_t filename);
-_complex128 c_string_to_complex128(c_string str, int lineno, int32_t filename);
+_complex64 c_string_to_complex64(c_string str, c_string* err, int lineno, int32_t filename);
+_complex128 c_string_to_complex128(c_string str, c_string* err, int lineno, int32_t filename);
 #endif
 
 
 /* every other primitive type to string */
-c_string integral_to_c_string(int64_t x, uint32_t size, chpl_bool isSigned);
+c_string integral_to_c_string(int64_t x, uint32_t size, chpl_bool isSigned, c_string* err);
 c_string real_to_c_string(_real64 x, chpl_bool isImag);
 
 // TODO: Can we use the pattern above, to reduce the number of interfaces required?

--- a/runtime/src/chplcast.c
+++ b/runtime/src/chplcast.c
@@ -132,14 +132,13 @@ _define_string_to_int_precise(uint, 32, 1)
 _define_string_to_bigint_precise(uint, 64, 1, "%" SCNu64)
 
 
-chpl_bool c_string_to_chpl_bool(c_string str, c_string* err, int lineno, int32_t filename) {
+chpl_bool c_string_to_chpl_bool(c_string str, chpl_bool* err, int lineno, int32_t filename) {
   if (string_compare(str, "true") == 0) {
     return true;
   } else if (string_compare(str, "false") == 0) {
     return false;
   } else {
-    *err = chpl_glom_strings(3, "Unexpected value when converting from string to bool: '",
-                             str, "'");
+    *err = true;
     return false;
   }
 }

--- a/runtime/src/chplcast.c
+++ b/runtime/src/chplcast.c
@@ -309,7 +309,7 @@ _define_string_to_complex_precise(complex, 128, "%lf", 64)
 
 
 #define _define_string_to_int_type(base, width)                             \
-  _type(base, width) c_string_to_##base##width##_t(c_string str, c_string* err,\
+  _type(base, width) c_string_to_##base##width##_t(c_string str, chpl_bool* err,\
                                                    int lineno, int32_t filename) { \
     int invalid;                                                        \
     char invalidStr[2] = "\0\0";                                        \
@@ -322,19 +322,9 @@ _define_string_to_complex_precise(complex, 128, "%lf", 64)
                                                   invalidStr);          \
     }                                                                   \
                                                                         \
-    if (invalid) {                                                      \
-      if (invalid == 2) {                                               \
-        if (invalidStr[0] == '\0') {                                    \
-          *err = "Missing terminating 'i' character when converting from string to " #base "(" #width ")"; \
-        } else {                                                        \
-          *err = chpl_glom_strings(3, "Missing terminating 'i' character when converting from string to " #base "(" #width "); got '", invalidStr, "' instead"); \
-        }                                                               \
-      } else if (invalidStr[0]) {                                       \
-        *err = chpl_glom_strings(3, "Unexpected character when converting from string to " #base "(" #width "): '", invalidStr, "'"); \
-      } else {                                                          \
-        *err = "Empty string when converting from string to " #base "(" #width ")"; \
-      }                                                                 \
-    }                                                                   \
+    if (invalid)                                                        \
+      *err = true;                                                      \
+                                                                        \
     return val;                                                         \
   }
 
@@ -348,7 +338,7 @@ _define_string_to_int_type(uint, 32)
 _define_string_to_int_type(uint, 64)
 
 #define _define_string_to_real_type(base, width)                        \
-  _##base##width c_string_to_##base##width(c_string str, c_string* err, \
+  _##base##width c_string_to_##base##width(c_string str, chpl_bool* err, \
                                            int lineno, int32_t filename) { \
     int invalid;                                                        \
     char invalidStr[2] = "\0\0";                                        \
@@ -360,20 +350,11 @@ _define_string_to_int_type(uint, 64)
                                                 &invalid,               \
                                                 invalidStr);            \
     }                                                                   \
-    if (invalid) {                                                      \
-      if (invalid == 2) {                                               \
-        if (invalidStr[0] == '\0') {                                    \
-          *err = "Missing terminating 'i' character when converting from string to " #base "(" #width ")"; \
-        } else {                                                        \
-          *err = chpl_glom_strings(3, "Missing terminating 'i' character when converting from string to " #base "(" #width "); got '", invalidStr, "' instead"); \
-        }                                                               \
-      } else if (invalidStr[0]) {                                       \
-        *err = chpl_glom_strings(3, "Unexpected character when converting from string to " #base "(" #width "): '", invalidStr, "'"); \
-      } else {                                                          \
-        *err = "Empty string when converting from string to " #base "(" #width ")"; \
-      }                                                                 \
-    }                                                                   \
-    return val;                                                         \
+                                                                        \
+    if (invalid)                                                        \
+      *err = true;                                                      \
+                                                                        \
+   return val;                                                          \
   }
 
 _define_string_to_real_type(real, 32)
@@ -385,7 +366,7 @@ _define_string_to_real_type(complex, 128)
 
 
 c_string
-integral_to_c_string(int64_t x, uint32_t size, chpl_bool isSigned, c_string* err)
+integral_to_c_string(int64_t x, uint32_t size, chpl_bool isSigned, chpl_bool* err)
 {
   char buffer[256];
   const char* format = "";
@@ -393,7 +374,7 @@ integral_to_c_string(int64_t x, uint32_t size, chpl_bool isSigned, c_string* err
   switch (SIGNED * isSigned + size)
   {
    default:
-    *err = "Unexpected case in integral_to_c_string";
+    *err = true;
     break;
 
    case UNSIGNED + 1: format = "%" PRIu8;  break;

--- a/test/errhandling/psahabu/str-to-bool.chpl
+++ b/test/errhandling/psahabu/str-to-bool.chpl
@@ -1,0 +1,13 @@
+var x = "true";
+var s = "brad";
+
+var x_b = x: bool;
+var tmp_b: bool;
+
+try! {
+  var s_b = s: bool;
+  tmp_b = x_b && s_b;
+} catch e: IllegalArgumentError {
+  writeln("caught cast error");
+  writeln(e.message());
+}

--- a/test/errhandling/psahabu/str-to-bool.chpl
+++ b/test/errhandling/psahabu/str-to-bool.chpl
@@ -2,6 +2,8 @@ var x = "true";
 var s = "brad";
 
 var x_b = x: bool;
+writeln("successful cast");
+
 var tmp_b: bool;
 
 try! {

--- a/test/errhandling/psahabu/str-to-bool.good
+++ b/test/errhandling/psahabu/str-to-bool.good
@@ -1,0 +1,2 @@
+caught cast error
+illegal argument 'brad': Unexpected value when converting from string to bool

--- a/test/errhandling/psahabu/str-to-bool.good
+++ b/test/errhandling/psahabu/str-to-bool.good
@@ -1,3 +1,3 @@
 successful cast
 caught cast error
-illegal argument 'brad': Unexpected value when converting from string to bool
+bad cast from string 'brad' to bool

--- a/test/errhandling/psahabu/str-to-bool.good
+++ b/test/errhandling/psahabu/str-to-bool.good
@@ -1,2 +1,3 @@
+successful cast
 caught cast error
 illegal argument 'brad': Unexpected value when converting from string to bool

--- a/test/errhandling/psahabu/str-to-complex.chpl
+++ b/test/errhandling/psahabu/str-to-complex.chpl
@@ -2,6 +2,7 @@ var x: string = "1 + 9i";
 var s: string = "brad";
 
 var x_c = x: complex;
+writeln("successful cast");
 
 try! {
   var s_c = s: complex;

--- a/test/errhandling/psahabu/str-to-complex.chpl
+++ b/test/errhandling/psahabu/str-to-complex.chpl
@@ -1,0 +1,12 @@
+var x: string = "1 + 9i";
+var s: string = "brad";
+
+var x_c = x: complex;
+
+try! {
+  var s_c = s: complex;
+  x_c += s_c;
+} catch e: IllegalArgumentError {
+  writeln("caught cast error");
+  writeln(e.message());
+}

--- a/test/errhandling/psahabu/str-to-complex.good
+++ b/test/errhandling/psahabu/str-to-complex.good
@@ -1,0 +1,2 @@
+caught cast error
+illegal argument 'brad': Unexpected character when converting from string to complex(128)

--- a/test/errhandling/psahabu/str-to-complex.good
+++ b/test/errhandling/psahabu/str-to-complex.good
@@ -1,3 +1,3 @@
 successful cast
 caught cast error
-illegal argument 'brad': Unexpected character when converting from string to complex(128)
+bad cast from string 'brad' to complex(128)

--- a/test/errhandling/psahabu/str-to-complex.good
+++ b/test/errhandling/psahabu/str-to-complex.good
@@ -1,2 +1,3 @@
+successful cast
 caught cast error
 illegal argument 'brad': Unexpected character when converting from string to complex(128)

--- a/test/errhandling/psahabu/str-to-enum.chpl
+++ b/test/errhandling/psahabu/str-to-enum.chpl
@@ -1,0 +1,17 @@
+enum Goal { peace, land, bread }
+var x = "peace";
+var s = "brad";
+
+var x_g = x: Goal;
+writeln("successful cast");
+
+var tmp_g: Goal;
+
+try {
+  var s_g = s: Goal;
+  tmp_g = s_g;
+} catch e {
+  writeln("caught cast error");
+  writeln(e.message());
+}
+

--- a/test/errhandling/psahabu/str-to-enum.good
+++ b/test/errhandling/psahabu/str-to-enum.good
@@ -1,0 +1,3 @@
+successful cast
+caught cast error
+bad cast from string 'brad' to Goal

--- a/test/errhandling/psahabu/str-to-imag.chpl
+++ b/test/errhandling/psahabu/str-to-imag.chpl
@@ -1,0 +1,12 @@
+var x: string = "9i";
+var s: string = "brad";
+
+var x_im = x: imag;
+
+try! {
+  var s_im = s: imag;
+  x_im += s_im;
+} catch e: IllegalArgumentError {
+  writeln("caught cast error");
+  writeln(e.message());
+}

--- a/test/errhandling/psahabu/str-to-imag.chpl
+++ b/test/errhandling/psahabu/str-to-imag.chpl
@@ -2,6 +2,7 @@ var x: string = "9i";
 var s: string = "brad";
 
 var x_im = x: imag;
+writeln("successful cast");
 
 try! {
   var s_im = s: imag;

--- a/test/errhandling/psahabu/str-to-imag.good
+++ b/test/errhandling/psahabu/str-to-imag.good
@@ -1,2 +1,3 @@
+successful cast
 caught cast error
 illegal argument 'brad': Unexpected character when converting from string to imag(64)

--- a/test/errhandling/psahabu/str-to-imag.good
+++ b/test/errhandling/psahabu/str-to-imag.good
@@ -1,3 +1,3 @@
 successful cast
 caught cast error
-illegal argument 'brad': Unexpected character when converting from string to imag(64)
+bad cast from string 'brad' to imag(64)

--- a/test/errhandling/psahabu/str-to-imag.good
+++ b/test/errhandling/psahabu/str-to-imag.good
@@ -1,0 +1,2 @@
+caught cast error
+illegal argument 'brad': Unexpected character when converting from string to imag(64)

--- a/test/errhandling/psahabu/str-to-int.chpl
+++ b/test/errhandling/psahabu/str-to-int.chpl
@@ -1,0 +1,12 @@
+var x: string = "5";
+var s: string = "brad";
+
+var x_i = x: int;
+
+try! {
+  var s_i = s: int;
+  x_i += s_i;
+} catch e: IllegalArgumentError {
+  writeln("caught cast error");
+  writeln(e.message());
+}

--- a/test/errhandling/psahabu/str-to-int.chpl
+++ b/test/errhandling/psahabu/str-to-int.chpl
@@ -2,6 +2,7 @@ var x: string = "5";
 var s: string = "brad";
 
 var x_i = x: int;
+writeln("successful cast");
 
 try! {
   var s_i = s: int;

--- a/test/errhandling/psahabu/str-to-int.good
+++ b/test/errhandling/psahabu/str-to-int.good
@@ -1,2 +1,3 @@
+successful cast
 caught cast error
 illegal argument 'brad': Unexpected character when converting from string to int(64)

--- a/test/errhandling/psahabu/str-to-int.good
+++ b/test/errhandling/psahabu/str-to-int.good
@@ -1,3 +1,3 @@
 successful cast
 caught cast error
-illegal argument 'brad': Unexpected character when converting from string to int(64)
+bad cast from string 'brad' to int(64)

--- a/test/errhandling/psahabu/str-to-int.good
+++ b/test/errhandling/psahabu/str-to-int.good
@@ -1,0 +1,2 @@
+caught cast error
+illegal argument 'brad': Unexpected character when converting from string to int(64)

--- a/test/errhandling/psahabu/str-to-real.chpl
+++ b/test/errhandling/psahabu/str-to-real.chpl
@@ -1,0 +1,12 @@
+var x: string = "3.1415";
+var s: string = "brad";
+
+var x_r = x: real;
+
+try! {
+  var s_r = s: real;
+  x_r += s_r;
+} catch e: IllegalArgumentError {
+  writeln("caught cast error");
+  writeln(e.message());
+}

--- a/test/errhandling/psahabu/str-to-real.chpl
+++ b/test/errhandling/psahabu/str-to-real.chpl
@@ -2,6 +2,7 @@ var x: string = "3.1415";
 var s: string = "brad";
 
 var x_r = x: real;
+writeln("successful cast");
 
 try! {
   var s_r = s: real;

--- a/test/errhandling/psahabu/str-to-real.good
+++ b/test/errhandling/psahabu/str-to-real.good
@@ -1,3 +1,3 @@
 successful cast
 caught cast error
-illegal argument 'brad': Unexpected character when converting from string to real(64)
+bad cast from string 'brad' to real(64)

--- a/test/errhandling/psahabu/str-to-real.good
+++ b/test/errhandling/psahabu/str-to-real.good
@@ -1,2 +1,3 @@
+successful cast
 caught cast error
 illegal argument 'brad': Unexpected character when converting from string to real(64)

--- a/test/errhandling/psahabu/str-to-real.good
+++ b/test/errhandling/psahabu/str-to-real.good
@@ -1,0 +1,2 @@
+caught cast error
+illegal argument 'brad': Unexpected character when converting from string to real(64)

--- a/test/execflags/configFile/configFileBadEnum.good
+++ b/test/execflags/configFile/configFileBadEnum.good
@@ -1,1 +1,3 @@
-<command line setting of 'gingerbread'>: error: halt reached - illegal conversion of string "garlic" to ingredients
+uncaught IllegalArgumentError: bad cast from string 'garlic' to ingredients
+  <command line setting of 'gingerbread'>:0: thrown here
+  <command line setting of 'gingerbread'>:0: uncaught here

--- a/test/execflags/diten/configComplex.good
+++ b/test/execflags/diten/configComplex.good
@@ -1,3 +1,3 @@
-uncaught IllegalArgumentError: illegal argument '3.1i + 1.1': Unexpected character when converting from string to complex(128)
+uncaught IllegalArgumentError: bad cast from string '3.1i + 1.1' to complex(128)
   <command line setting of 'z'>:0: thrown here
   <command line setting of 'z'>:0: uncaught here

--- a/test/execflags/diten/configComplex.good
+++ b/test/execflags/diten/configComplex.good
@@ -1,1 +1,3 @@
-<command line setting of 'z'>: error: Unexpected character when converting from string to complex(128): '+'
+uncaught IllegalArgumentError: illegal argument '3.1i + 1.1': Unexpected character when converting from string to complex(128)
+  <command line setting of 'z'>:0: thrown here
+  <command line setting of 'z'>:0: uncaught here

--- a/test/execflags/shannon/configs/configVarBadEnum.good
+++ b/test/execflags/shannon/configs/configVarBadEnum.good
@@ -1,1 +1,3 @@
-<command line setting of 'gingerbread'>: error: halt reached - illegal conversion of string "meatloaf" to ingredients
+uncaught IllegalArgumentError: bad cast from string 'meatloaf' to ingredients
+  <command line setting of 'gingerbread'>:0: thrown here
+  <command line setting of 'gingerbread'>:0: uncaught here

--- a/test/execflags/shannon/configs/configVarInvalidBoolean.good
+++ b/test/execflags/shannon/configs/configVarInvalidBoolean.good
@@ -1,3 +1,3 @@
-uncaught IllegalArgumentError: illegal argument 'maybe': Unexpected value when converting from string to bool
+uncaught IllegalArgumentError: bad cast from string 'maybe' to bool
   <command line setting of 'x'>:0: thrown here
   <command line setting of 'x'>:0: uncaught here

--- a/test/execflags/shannon/configs/configVarInvalidBoolean.good
+++ b/test/execflags/shannon/configs/configVarInvalidBoolean.good
@@ -1,1 +1,3 @@
-<command line setting of 'x'>: error: halt reached - Unexpected value when converting from string to bool: 'maybe'
+uncaught IllegalArgumentError: illegal argument 'maybe': Unexpected value when converting from string to bool
+  <command line setting of 'x'>:0: thrown here
+  <command line setting of 'x'>:0: uncaught here

--- a/test/execflags/shannon/configs/configVarInvalidComplex.good
+++ b/test/execflags/shannon/configs/configVarInvalidComplex.good
@@ -1,1 +1,3 @@
-<command line setting of 'x'>: error: Unexpected character when converting from string to complex(128): 'j'
+uncaught IllegalArgumentError: illegal argument '5.6+7.8j': Unexpected character when converting from string to complex(128)
+  <command line setting of 'x'>:0: thrown here
+  <command line setting of 'x'>:0: uncaught here

--- a/test/execflags/shannon/configs/configVarInvalidComplex.good
+++ b/test/execflags/shannon/configs/configVarInvalidComplex.good
@@ -1,3 +1,3 @@
-uncaught IllegalArgumentError: illegal argument '5.6+7.8j': Unexpected character when converting from string to complex(128)
+uncaught IllegalArgumentError: bad cast from string '5.6+7.8j' to complex(128)
   <command line setting of 'x'>:0: thrown here
   <command line setting of 'x'>:0: uncaught here

--- a/test/execflags/shannon/configs/configVarInvalidFloat.good
+++ b/test/execflags/shannon/configs/configVarInvalidFloat.good
@@ -1,3 +1,3 @@
-uncaught IllegalArgumentError: illegal argument 'true': Unexpected character when converting from string to real(64)
+uncaught IllegalArgumentError: bad cast from string 'true' to real(64)
   <command line setting of 'x'>:0: thrown here
   <command line setting of 'x'>:0: uncaught here

--- a/test/execflags/shannon/configs/configVarInvalidFloat.good
+++ b/test/execflags/shannon/configs/configVarInvalidFloat.good
@@ -1,1 +1,3 @@
-<command line setting of 'x'>: error: Unexpected character when converting from string to real(64): 't'
+uncaught IllegalArgumentError: illegal argument 'true': Unexpected character when converting from string to real(64)
+  <command line setting of 'x'>:0: thrown here
+  <command line setting of 'x'>:0: uncaught here

--- a/test/execflags/shannon/configs/configVarInvalidInteger.good
+++ b/test/execflags/shannon/configs/configVarInvalidInteger.good
@@ -1,3 +1,3 @@
-uncaught IllegalArgumentError: illegal argument '56.78': Unexpected character when converting from string to int(64)
+uncaught IllegalArgumentError: bad cast from string '56.78' to int(64)
   <command line setting of 'x'>:0: thrown here
   <command line setting of 'x'>:0: uncaught here

--- a/test/execflags/shannon/configs/configVarInvalidInteger.good
+++ b/test/execflags/shannon/configs/configVarInvalidInteger.good
@@ -1,1 +1,3 @@
-<command line setting of 'x'>: error: Unexpected character when converting from string to int(64): '.'
+uncaught IllegalArgumentError: illegal argument '56.78': Unexpected character when converting from string to int(64)
+  <command line setting of 'x'>:0: thrown here
+  <command line setting of 'x'>:0: uncaught here

--- a/test/execflags/tmacd/config_num.bad
+++ b/test/execflags/tmacd/config_num.bad
@@ -1,3 +1,3 @@
-uncaught IllegalArgumentError: illegal argument '0xFF': Unexpected character when converting from string to int(64)
+uncaught IllegalArgumentError: bad cast from string '0xFF' to int(64)
   <command line setting of 'i'>:0: thrown here
   <command line setting of 'i'>:0: uncaught here

--- a/test/execflags/tmacd/config_num.bad
+++ b/test/execflags/tmacd/config_num.bad
@@ -1,1 +1,3 @@
-<command line setting of 'i'>: error: Unexpected character when converting from string to int(64): 'x'
+uncaught IllegalArgumentError: illegal argument '0xFF': Unexpected character when converting from string to int(64)
+  <command line setting of 'i'>:0: thrown here
+  <command line setting of 'i'>:0: uncaught here

--- a/test/functions/ferguson/hijacking/Application3.chpl
+++ b/test/functions/ferguson/hijacking/Application3.chpl
@@ -2,7 +2,7 @@
     var global:int;
     proc setup(x) {
       writeln("in LibraryX.setup()");
-      global = x:int;
+      global = try! x:int;
     }
     proc run(x) {
       setup(x);

--- a/test/memory/shannon/memmaxIntOnly.good
+++ b/test/memory/shannon/memmaxIntOnly.good
@@ -1,1 +1,3 @@
-<internal>: error: Unexpected character when converting from string to uint(64): '.'
+uncaught IllegalArgumentError: illegal argument '1.1': Unexpected character when converting from string to uint(64)
+  <internal>:0: thrown here
+  <internal>:0: uncaught here

--- a/test/memory/shannon/memmaxIntOnly.good
+++ b/test/memory/shannon/memmaxIntOnly.good
@@ -1,3 +1,3 @@
-uncaught IllegalArgumentError: illegal argument '1.1': Unexpected character when converting from string to uint(64)
+uncaught IllegalArgumentError: bad cast from string '1.1' to uint(64)
   <internal>:0: thrown here
   <internal>:0: uncaught here

--- a/test/multilocale/bradc/configBadValue.good
+++ b/test/multilocale/bradc/configBadValue.good
@@ -1,3 +1,3 @@
-uncaught IllegalArgumentError: illegal argument '3.2i': Unexpected character when converting from string to int(64)
+uncaught IllegalArgumentError: bad cast from string '3.2i' to int(64)
   <command line setting of 'intVal'>:0: thrown here
   <command line setting of 'intVal'>:0: uncaught here

--- a/test/multilocale/bradc/configBadValue.good
+++ b/test/multilocale/bradc/configBadValue.good
@@ -1,1 +1,3 @@
-<command line setting of 'intVal'>: error: Unexpected character when converting from string to int(64): '.'
+uncaught IllegalArgumentError: illegal argument '3.2i': Unexpected character when converting from string to int(64)
+  <command line setting of 'intVal'>:0: thrown here
+  <command line setting of 'intVal'>:0: uncaught here

--- a/test/studies/shootout/meteor/kbrady/meteor-implicit-domain.chpl
+++ b/test/studies/shootout/meteor/kbrady/meteor-implicit-domain.chpl
@@ -56,7 +56,7 @@ module meteor {
   }
 
   use direction;  // make direction's symbols directly available to this scope
-  
+
   var pieceDef: [0..9][0..3] direction = [
     [  E,  E,   E, SE],
     [ SE,  E,  NE,  E],
@@ -584,7 +584,7 @@ module meteor {
 
   proc main(args: [] string) {
     if args.domain.size > 1 then
-        maxSolutions = args[1]:int;
+        maxSolutions = try! args[1]:int;
     calcPieces();
     calcRows();
     solve(0, 0);

--- a/test/studies/shootout/meteor/kbrady/meteor.chpl
+++ b/test/studies/shootout/meteor/kbrady/meteor.chpl
@@ -56,7 +56,7 @@ module meteor {
   }
 
   use direction;  // make direction's symbols directly available to this scope
-  
+
   var pieceDef: [0..9][0..3] direction = [
     [  E,  E,   E, SE],
     [ SE,  E,  NE,  E],
@@ -584,7 +584,7 @@ module meteor {
 
   proc main(args: [] string) {
     if args.domain.size > 1 then
-        maxSolutions = args[1]:int;
+        maxSolutions = try! args[1]:int;
     calcPieces();
     calcRows();
     solve(0, 0);

--- a/test/trivial/deitz/other/string2prims.good
+++ b/test/trivial/deitz/other/string2prims.good
@@ -20,6 +20,6 @@
 3.14 + 2.1i
 true
 false
-uncaught IllegalArgumentError: illegal argument 'maybe': Unexpected value when converting from string to bool
+uncaught IllegalArgumentError: bad cast from string 'maybe' to bool
   string2prims.chpl:42: thrown here
   string2prims.chpl:42: uncaught here

--- a/test/trivial/deitz/other/string2prims.good
+++ b/test/trivial/deitz/other/string2prims.good
@@ -20,4 +20,6 @@
 3.14 + 2.1i
 true
 false
-string2prims.chpl:42: error: halt reached - Unexpected value when converting from string to bool: 'maybe'
+uncaught IllegalArgumentError: illegal argument 'maybe': Unexpected value when converting from string to bool
+  string2prims.chpl:42: thrown here
+  string2prims.chpl:42: uncaught here

--- a/test/types/string/bradc/string2complex/badStringToComplex.good
+++ b/test/types/string/bradc/string2complex/badStringToComplex.good
@@ -1,3 +1,3 @@
-uncaught IllegalArgumentError: illegal argument '1.2+': Unexpected character when converting from string to complex(64)
+uncaught IllegalArgumentError: bad cast from string '1.2+' to complex(64)
   badStringToComplex.chpl:3: thrown here
   badStringToComplex.chpl:3: uncaught here

--- a/test/types/string/bradc/string2complex/badStringToComplex.good
+++ b/test/types/string/bradc/string2complex/badStringToComplex.good
@@ -1,1 +1,3 @@
-badStringToComplex.chpl:3: error: Unexpected character when converting from string to complex(64): '+'
+uncaught IllegalArgumentError: illegal argument '1.2+': Unexpected character when converting from string to complex(64)
+  badStringToComplex.chpl:3: thrown here
+  badStringToComplex.chpl:3: uncaught here

--- a/test/types/string/bradc/string2complex/badStringToComplex2.good
+++ b/test/types/string/bradc/string2complex/badStringToComplex2.good
@@ -1,1 +1,3 @@
-badStringToComplex2.chpl:3: error: Missing terminating 'i' character when converting from string to complex(64)
+uncaught IllegalArgumentError: illegal argument '1.2+3.4': Unexpected character when converting from string to complex(64)
+  badStringToComplex2.chpl:3: thrown here
+  badStringToComplex2.chpl:3: uncaught here

--- a/test/types/string/bradc/string2complex/badStringToComplex2.good
+++ b/test/types/string/bradc/string2complex/badStringToComplex2.good
@@ -1,3 +1,3 @@
-uncaught IllegalArgumentError: illegal argument '1.2+3.4': Unexpected character when converting from string to complex(64)
+uncaught IllegalArgumentError: bad cast from string '1.2+3.4' to complex(64)
   badStringToComplex2.chpl:3: thrown here
   badStringToComplex2.chpl:3: uncaught here

--- a/test/types/string/bradc/string2complex/badStringToComplex3.good
+++ b/test/types/string/bradc/string2complex/badStringToComplex3.good
@@ -1,3 +1,3 @@
-uncaught IllegalArgumentError: illegal argument '1.2 + + +3.4': Unexpected character when converting from string to complex(64)
+uncaught IllegalArgumentError: bad cast from string '1.2 + + +3.4' to complex(64)
   badStringToComplex3.chpl:3: thrown here
   badStringToComplex3.chpl:3: uncaught here

--- a/test/types/string/bradc/string2complex/badStringToComplex3.good
+++ b/test/types/string/bradc/string2complex/badStringToComplex3.good
@@ -1,1 +1,3 @@
-badStringToComplex3.chpl:3: error: Unexpected character when converting from string to complex(64): '+'
+uncaught IllegalArgumentError: illegal argument '1.2 + + +3.4': Unexpected character when converting from string to complex(64)
+  badStringToComplex3.chpl:3: thrown here
+  badStringToComplex3.chpl:3: uncaught here

--- a/test/types/string/bradc/string2complex/badStringToComplex4.good
+++ b/test/types/string/bradc/string2complex/badStringToComplex4.good
@@ -1,1 +1,3 @@
-badStringToComplex4.chpl:3: error: Unexpected character when converting from string to complex(64): 'c'
+uncaught IllegalArgumentError: illegal argument '1.2 c 3.4i': Unexpected character when converting from string to complex(64)
+  badStringToComplex4.chpl:3: thrown here
+  badStringToComplex4.chpl:3: uncaught here

--- a/test/types/string/bradc/string2complex/badStringToComplex4.good
+++ b/test/types/string/bradc/string2complex/badStringToComplex4.good
@@ -1,3 +1,3 @@
-uncaught IllegalArgumentError: illegal argument '1.2 c 3.4i': Unexpected character when converting from string to complex(64)
+uncaught IllegalArgumentError: bad cast from string '1.2 c 3.4i' to complex(64)
   badStringToComplex4.chpl:3: thrown here
   badStringToComplex4.chpl:3: uncaught here

--- a/test/types/string/bradc/string2complex/badStringToComplex5.good
+++ b/test/types/string/bradc/string2complex/badStringToComplex5.good
@@ -1,1 +1,3 @@
-badStringToComplex5.chpl:3: error: Unexpected character when converting from string to complex(64): '3'
+uncaught IllegalArgumentError: illegal argument '1.2 3.4i': Unexpected character when converting from string to complex(64)
+  badStringToComplex5.chpl:3: thrown here
+  badStringToComplex5.chpl:3: uncaught here

--- a/test/types/string/bradc/string2complex/badStringToComplex5.good
+++ b/test/types/string/bradc/string2complex/badStringToComplex5.good
@@ -1,3 +1,3 @@
-uncaught IllegalArgumentError: illegal argument '1.2 3.4i': Unexpected character when converting from string to complex(64)
+uncaught IllegalArgumentError: bad cast from string '1.2 3.4i' to complex(64)
   badStringToComplex5.chpl:3: thrown here
   badStringToComplex5.chpl:3: uncaught here

--- a/test/types/string/bradc/string2complex/badStringToComplex6.good
+++ b/test/types/string/bradc/string2complex/badStringToComplex6.good
@@ -1,3 +1,3 @@
-uncaught IllegalArgumentError: illegal argument '1.2 + 3.4j': Unexpected character when converting from string to complex(64)
+uncaught IllegalArgumentError: bad cast from string '1.2 + 3.4j' to complex(64)
   badStringToComplex6.chpl:3: thrown here
   badStringToComplex6.chpl:3: uncaught here

--- a/test/types/string/bradc/string2complex/badStringToComplex6.good
+++ b/test/types/string/bradc/string2complex/badStringToComplex6.good
@@ -1,1 +1,3 @@
-badStringToComplex6.chpl:3: error: Unexpected character when converting from string to complex(64): 'j'
+uncaught IllegalArgumentError: illegal argument '1.2 + 3.4j': Unexpected character when converting from string to complex(64)
+  badStringToComplex6.chpl:3: thrown here
+  badStringToComplex6.chpl:3: uncaught here

--- a/test/types/string/bradc/string2complex/badStringToComplex7.good
+++ b/test/types/string/bradc/string2complex/badStringToComplex7.good
@@ -1,1 +1,3 @@
-badStringToComplex7.chpl:3: error: Unexpected character when converting from string to complex(64): ' '
+uncaught IllegalArgumentError: illegal argument '1.2 + 3.4 i': Unexpected character when converting from string to complex(64)
+  badStringToComplex7.chpl:3: thrown here
+  badStringToComplex7.chpl:3: uncaught here

--- a/test/types/string/bradc/string2complex/badStringToComplex7.good
+++ b/test/types/string/bradc/string2complex/badStringToComplex7.good
@@ -1,3 +1,3 @@
-uncaught IllegalArgumentError: illegal argument '1.2 + 3.4 i': Unexpected character when converting from string to complex(64)
+uncaught IllegalArgumentError: bad cast from string '1.2 + 3.4 i' to complex(64)
   badStringToComplex7.chpl:3: thrown here
   badStringToComplex7.chpl:3: uncaught here

--- a/test/types/string/bradc/string2complex/badStringToComplex8.good
+++ b/test/types/string/bradc/string2complex/badStringToComplex8.good
@@ -1,1 +1,3 @@
-badStringToComplex8.chpl:3: error: Unexpected character when converting from string to complex(64): 'j'
+uncaught IllegalArgumentError: illegal argument '1.2 + 3.4ij': Unexpected character when converting from string to complex(64)
+  badStringToComplex8.chpl:3: thrown here
+  badStringToComplex8.chpl:3: uncaught here

--- a/test/types/string/bradc/string2complex/badStringToComplex8.good
+++ b/test/types/string/bradc/string2complex/badStringToComplex8.good
@@ -1,3 +1,3 @@
-uncaught IllegalArgumentError: illegal argument '1.2 + 3.4ij': Unexpected character when converting from string to complex(64)
+uncaught IllegalArgumentError: bad cast from string '1.2 + 3.4ij' to complex(64)
   badStringToComplex8.chpl:3: thrown here
   badStringToComplex8.chpl:3: uncaught here

--- a/test/types/string/bradc/string2complex/badStringToComplex9.good
+++ b/test/types/string/bradc/string2complex/badStringToComplex9.good
@@ -1,3 +1,3 @@
-uncaught IllegalArgumentError: illegal argument '1.2 i': Unexpected character when converting from string to complex(64)
+uncaught IllegalArgumentError: bad cast from string '1.2 i' to complex(64)
   badStringToComplex9.chpl:3: thrown here
   badStringToComplex9.chpl:3: uncaught here

--- a/test/types/string/bradc/string2complex/badStringToComplex9.good
+++ b/test/types/string/bradc/string2complex/badStringToComplex9.good
@@ -1,1 +1,3 @@
-badStringToComplex9.chpl:3: error: Unexpected character when converting from string to complex(64): 'i'
+uncaught IllegalArgumentError: illegal argument '1.2 i': Unexpected character when converting from string to complex(64)
+  badStringToComplex9.chpl:3: thrown here
+  badStringToComplex9.chpl:3: uncaught here

--- a/test/types/string/bradc/string2complex/badStringToImag.good
+++ b/test/types/string/bradc/string2complex/badStringToImag.good
@@ -1,3 +1,3 @@
-uncaught IllegalArgumentError: illegal argument '1.2': Unexpected character when converting from string to imag(64)
+uncaught IllegalArgumentError: bad cast from string '1.2' to imag(64)
   badStringToImag.chpl:3: thrown here
   badStringToImag.chpl:3: uncaught here

--- a/test/types/string/bradc/string2complex/badStringToImag.good
+++ b/test/types/string/bradc/string2complex/badStringToImag.good
@@ -1,1 +1,3 @@
-badStringToImag.chpl:3: error: Missing terminating 'i' character when converting from string to imag(64)
+uncaught IllegalArgumentError: illegal argument '1.2': Unexpected character when converting from string to imag(64)
+  badStringToImag.chpl:3: thrown here
+  badStringToImag.chpl:3: uncaught here

--- a/test/types/string/bradc/string2complex/badStringToImag2.good
+++ b/test/types/string/bradc/string2complex/badStringToImag2.good
@@ -1,1 +1,3 @@
-badStringToImag2.chpl:3: error: Missing terminating 'i' character when converting from string to imag(64); got 'j' instead
+uncaught IllegalArgumentError: illegal argument '1.2j': Unexpected character when converting from string to imag(64)
+  badStringToImag2.chpl:3: thrown here
+  badStringToImag2.chpl:3: uncaught here

--- a/test/types/string/bradc/string2complex/badStringToImag2.good
+++ b/test/types/string/bradc/string2complex/badStringToImag2.good
@@ -1,3 +1,3 @@
-uncaught IllegalArgumentError: illegal argument '1.2j': Unexpected character when converting from string to imag(64)
+uncaught IllegalArgumentError: bad cast from string '1.2j' to imag(64)
   badStringToImag2.chpl:3: thrown here
   badStringToImag2.chpl:3: uncaught here

--- a/test/types/string/bradc/string2complex/badStringToImag3.good
+++ b/test/types/string/bradc/string2complex/badStringToImag3.good
@@ -1,3 +1,3 @@
-uncaught IllegalArgumentError: illegal argument '1.2 i': Unexpected character when converting from string to imag(64)
+uncaught IllegalArgumentError: bad cast from string '1.2 i' to imag(64)
   badStringToImag3.chpl:3: thrown here
   badStringToImag3.chpl:3: uncaught here

--- a/test/types/string/bradc/string2complex/badStringToImag3.good
+++ b/test/types/string/bradc/string2complex/badStringToImag3.good
@@ -1,1 +1,3 @@
-badStringToImag3.chpl:3: error: Missing terminating 'i' character when converting from string to imag(64); got ' ' instead
+uncaught IllegalArgumentError: illegal argument '1.2 i': Unexpected character when converting from string to imag(64)
+  badStringToImag3.chpl:3: thrown here
+  badStringToImag3.chpl:3: uncaught here

--- a/test/types/string/bradc/string2ints/badstring2int.good
+++ b/test/types/string/bradc/string2ints/badstring2int.good
@@ -1,1 +1,3 @@
-badstring2int.chpl:3: error: Unexpected character when converting from string to int(64): 'e'
+uncaught IllegalArgumentError: illegal argument '1e': Unexpected character when converting from string to int(64)
+  badstring2int.chpl:3: thrown here
+  badstring2int.chpl:3: uncaught here

--- a/test/types/string/bradc/string2ints/badstring2int.good
+++ b/test/types/string/bradc/string2ints/badstring2int.good
@@ -1,3 +1,3 @@
-uncaught IllegalArgumentError: illegal argument '1e': Unexpected character when converting from string to int(64)
+uncaught IllegalArgumentError: bad cast from string '1e' to int(64)
   badstring2int.chpl:3: thrown here
   badstring2int.chpl:3: uncaught here

--- a/test/types/string/bradc/string2ints/badstring2int2.good
+++ b/test/types/string/bradc/string2ints/badstring2int2.good
@@ -1,3 +1,3 @@
-uncaught IllegalArgumentError: illegal argument 'a1': Unexpected character when converting from string to int(64)
+uncaught IllegalArgumentError: bad cast from string 'a1' to int(64)
   badstring2int2.chpl:3: thrown here
   badstring2int2.chpl:3: uncaught here

--- a/test/types/string/bradc/string2ints/badstring2int2.good
+++ b/test/types/string/bradc/string2ints/badstring2int2.good
@@ -1,1 +1,3 @@
-badstring2int2.chpl:3: error: Unexpected character when converting from string to int(64): 'a'
+uncaught IllegalArgumentError: illegal argument 'a1': Unexpected character when converting from string to int(64)
+  badstring2int2.chpl:3: thrown here
+  badstring2int2.chpl:3: uncaught here

--- a/test/types/string/bradc/string2ints/badstring2int64.good
+++ b/test/types/string/bradc/string2ints/badstring2int64.good
@@ -1,3 +1,3 @@
-uncaught IllegalArgumentError: illegal argument '1e': Unexpected character when converting from string to int(64)
+uncaught IllegalArgumentError: bad cast from string '1e' to int(64)
   badstring2int64.chpl:3: thrown here
   badstring2int64.chpl:3: uncaught here

--- a/test/types/string/bradc/string2ints/badstring2int64.good
+++ b/test/types/string/bradc/string2ints/badstring2int64.good
@@ -1,1 +1,3 @@
-badstring2int64.chpl:3: error: Unexpected character when converting from string to int(64): 'e'
+uncaught IllegalArgumentError: illegal argument '1e': Unexpected character when converting from string to int(64)
+  badstring2int64.chpl:3: thrown here
+  badstring2int64.chpl:3: uncaught here

--- a/test/types/string/bradc/string2ints/badstring2uint64-2.good
+++ b/test/types/string/bradc/string2ints/badstring2uint64-2.good
@@ -1,3 +1,3 @@
-uncaught IllegalArgumentError: illegal argument '-1': Unexpected character when converting from string to uint(64)
+uncaught IllegalArgumentError: bad cast from string '-1' to uint(64)
   badstring2uint64-2.chpl:3: thrown here
   badstring2uint64-2.chpl:3: uncaught here

--- a/test/types/string/bradc/string2ints/badstring2uint64-2.good
+++ b/test/types/string/bradc/string2ints/badstring2uint64-2.good
@@ -1,1 +1,3 @@
-badstring2uint64-2.chpl:3: error: Unexpected character when converting from string to uint(64): '-'
+uncaught IllegalArgumentError: illegal argument '-1': Unexpected character when converting from string to uint(64)
+  badstring2uint64-2.chpl:3: thrown here
+  badstring2uint64-2.chpl:3: uncaught here

--- a/test/types/string/bradc/string2ints/badstring2uint64-3.good
+++ b/test/types/string/bradc/string2ints/badstring2uint64-3.good
@@ -1,1 +1,3 @@
-badstring2uint64-3.chpl:3: error: Unexpected character when converting from string to uint(64): 'a'
+uncaught IllegalArgumentError: illegal argument 'a1': Unexpected character when converting from string to uint(64)
+  badstring2uint64-3.chpl:3: thrown here
+  badstring2uint64-3.chpl:3: uncaught here

--- a/test/types/string/bradc/string2ints/badstring2uint64-3.good
+++ b/test/types/string/bradc/string2ints/badstring2uint64-3.good
@@ -1,3 +1,3 @@
-uncaught IllegalArgumentError: illegal argument 'a1': Unexpected character when converting from string to uint(64)
+uncaught IllegalArgumentError: bad cast from string 'a1' to uint(64)
   badstring2uint64-3.chpl:3: thrown here
   badstring2uint64-3.chpl:3: uncaught here

--- a/test/types/string/bradc/string2ints/badstring2uint64.good
+++ b/test/types/string/bradc/string2ints/badstring2uint64.good
@@ -1,3 +1,3 @@
-uncaught IllegalArgumentError: illegal argument '1e': Unexpected character when converting from string to uint(64)
+uncaught IllegalArgumentError: bad cast from string '1e' to uint(64)
   badstring2uint64.chpl:3: thrown here
   badstring2uint64.chpl:3: uncaught here

--- a/test/types/string/bradc/string2ints/badstring2uint64.good
+++ b/test/types/string/bradc/string2ints/badstring2uint64.good
@@ -1,1 +1,3 @@
-badstring2uint64.chpl:3: error: Unexpected character when converting from string to uint(64): 'e'
+uncaught IllegalArgumentError: illegal argument '1e': Unexpected character when converting from string to uint(64)
+  badstring2uint64.chpl:3: thrown here
+  badstring2uint64.chpl:3: uncaught here

--- a/test/types/string/bradc/string2ints/badstring2val.good
+++ b/test/types/string/bradc/string2ints/badstring2val.good
@@ -1,3 +1,3 @@
-uncaught IllegalArgumentError: illegal argument '1e': Unexpected character when converting from string to int(64)
+uncaught IllegalArgumentError: bad cast from string '1e' to int(64)
   badstring2val.chpl:3: thrown here
   badstring2val.chpl:3: uncaught here

--- a/test/types/string/bradc/string2ints/badstring2val.good
+++ b/test/types/string/bradc/string2ints/badstring2val.good
@@ -1,1 +1,3 @@
-badstring2val.chpl:3: error: Unexpected character when converting from string to int(64): 'e'
+uncaught IllegalArgumentError: illegal argument '1e': Unexpected character when converting from string to int(64)
+  badstring2val.chpl:3: thrown here
+  badstring2val.chpl:3: uncaught here

--- a/test/types/string/bradc/string2ints/emptyToInt.good
+++ b/test/types/string/bradc/string2ints/emptyToInt.good
@@ -1,1 +1,3 @@
-emptyToInt.chpl:2: error: Empty string when converting from string to int(32)
+uncaught IllegalArgumentError: illegal argument '': Empty string when converting from string to int(32)
+  emptyToInt.chpl:2: thrown here
+  emptyToInt.chpl:2: uncaught here

--- a/test/types/string/bradc/string2ints/emptyToInt.good
+++ b/test/types/string/bradc/string2ints/emptyToInt.good
@@ -1,3 +1,3 @@
-uncaught IllegalArgumentError: illegal argument '': Empty string when converting from string to int(32)
+uncaught IllegalArgumentError: bad cast from empty string to int(32)
   emptyToInt.chpl:2: thrown here
   emptyToInt.chpl:2: uncaught here

--- a/test/types/string/bradc/string2ints/emptyToInt64.good
+++ b/test/types/string/bradc/string2ints/emptyToInt64.good
@@ -1,3 +1,3 @@
-uncaught IllegalArgumentError: illegal argument '': Empty string when converting from string to int(64)
+uncaught IllegalArgumentError: bad cast from empty string to int(64)
   emptyToInt64.chpl:2: thrown here
   emptyToInt64.chpl:2: uncaught here

--- a/test/types/string/bradc/string2ints/emptyToInt64.good
+++ b/test/types/string/bradc/string2ints/emptyToInt64.good
@@ -1,1 +1,3 @@
-emptyToInt64.chpl:2: error: Empty string when converting from string to int(64)
+uncaught IllegalArgumentError: illegal argument '': Empty string when converting from string to int(64)
+  emptyToInt64.chpl:2: thrown here
+  emptyToInt64.chpl:2: uncaught here

--- a/test/types/string/bradc/string2ints/emptyToUint64.good
+++ b/test/types/string/bradc/string2ints/emptyToUint64.good
@@ -1,1 +1,3 @@
-emptyToUint64.chpl:2: error: Empty string when converting from string to uint(64)
+uncaught IllegalArgumentError: illegal argument '': Empty string when converting from string to uint(64)
+  emptyToUint64.chpl:2: thrown here
+  emptyToUint64.chpl:2: uncaught here

--- a/test/types/string/bradc/string2ints/emptyToUint64.good
+++ b/test/types/string/bradc/string2ints/emptyToUint64.good
@@ -1,3 +1,3 @@
-uncaught IllegalArgumentError: illegal argument '': Empty string when converting from string to uint(64)
+uncaught IllegalArgumentError: bad cast from empty string to uint(64)
   emptyToUint64.chpl:2: thrown here
   emptyToUint64.chpl:2: uncaught here

--- a/test/types/string/bradc/string2ints/string2negval.good
+++ b/test/types/string/bradc/string2ints/string2negval.good
@@ -2,6 +2,6 @@ x8 is: -1
 x16 is: -1
 x32 is: -1
 x64 is: -1
-uncaught IllegalArgumentError: illegal argument '-1': Unexpected character when converting from string to uint(8)
+uncaught IllegalArgumentError: bad cast from string '-1' to uint(8)
   string2negval.chpl:15: thrown here
   string2negval.chpl:15: uncaught here

--- a/test/types/string/bradc/string2ints/string2negval.good
+++ b/test/types/string/bradc/string2ints/string2negval.good
@@ -2,4 +2,6 @@ x8 is: -1
 x16 is: -1
 x32 is: -1
 x64 is: -1
-string2negval.chpl:15: error: Unexpected character when converting from string to uint(8): '-'
+uncaught IllegalArgumentError: illegal argument '-1': Unexpected character when converting from string to uint(8)
+  string2negval.chpl:15: thrown here
+  string2negval.chpl:15: uncaught here

--- a/test/types/string/cast/emptyStringToBool.good
+++ b/test/types/string/cast/emptyStringToBool.good
@@ -1,3 +1,3 @@
-uncaught IllegalArgumentError: illegal argument '': Empty string when converting from string to bool
+uncaught IllegalArgumentError: bad cast from empty string to bool
   emptyStringToType.chpl:6: thrown here
   emptyStringToType.chpl:6: uncaught here

--- a/test/types/string/cast/emptyStringToBool.good
+++ b/test/types/string/cast/emptyStringToBool.good
@@ -1,1 +1,3 @@
-emptyStringToType.chpl:6: error: Empty string when converting from string to bool
+uncaught IllegalArgumentError: illegal argument '': Empty string when converting from string to bool
+  emptyStringToType.chpl:6: thrown here
+  emptyStringToType.chpl:6: uncaught here

--- a/test/types/string/cast/emptyStringToComplex.good
+++ b/test/types/string/cast/emptyStringToComplex.good
@@ -1,3 +1,3 @@
-uncaught IllegalArgumentError: illegal argument '': Empty string when converting from string to complex(128)
+uncaught IllegalArgumentError: bad cast from empty string to complex(128)
   emptyStringToType.chpl:6: thrown here
   emptyStringToType.chpl:6: uncaught here

--- a/test/types/string/cast/emptyStringToComplex.good
+++ b/test/types/string/cast/emptyStringToComplex.good
@@ -1,1 +1,3 @@
-emptyStringToType.chpl:6: error: Empty string when converting from string to complex(128)
+uncaught IllegalArgumentError: illegal argument '': Empty string when converting from string to complex(128)
+  emptyStringToType.chpl:6: thrown here
+  emptyStringToType.chpl:6: uncaught here

--- a/test/types/string/cast/emptyStringToEnum.good
+++ b/test/types/string/cast/emptyStringToEnum.good
@@ -1,1 +1,3 @@
-emptyStringToType.chpl:6: error: Empty string when converting from string to color
+uncaught IllegalArgumentError: bad cast from empty string to color
+  emptyStringToType.chpl:6: thrown here
+  emptyStringToType.chpl:6: uncaught here

--- a/test/types/string/cast/emptyStringToImag.good
+++ b/test/types/string/cast/emptyStringToImag.good
@@ -1,3 +1,3 @@
-uncaught IllegalArgumentError: illegal argument '': Empty string when converting from string to imag(64)
+uncaught IllegalArgumentError: bad cast from empty string to imag(64)
   emptyStringToType.chpl:6: thrown here
   emptyStringToType.chpl:6: uncaught here

--- a/test/types/string/cast/emptyStringToImag.good
+++ b/test/types/string/cast/emptyStringToImag.good
@@ -1,1 +1,3 @@
-emptyStringToType.chpl:6: error: Empty string when converting from string to imag(64)
+uncaught IllegalArgumentError: illegal argument '': Empty string when converting from string to imag(64)
+  emptyStringToType.chpl:6: thrown here
+  emptyStringToType.chpl:6: uncaught here

--- a/test/types/string/cast/emptyStringToInt.good
+++ b/test/types/string/cast/emptyStringToInt.good
@@ -1,1 +1,3 @@
-emptyStringToType.chpl:6: error: Empty string when converting from string to int(64)
+uncaught IllegalArgumentError: illegal argument '': Empty string when converting from string to int(64)
+  emptyStringToType.chpl:6: thrown here
+  emptyStringToType.chpl:6: uncaught here

--- a/test/types/string/cast/emptyStringToInt.good
+++ b/test/types/string/cast/emptyStringToInt.good
@@ -1,3 +1,3 @@
-uncaught IllegalArgumentError: illegal argument '': Empty string when converting from string to int(64)
+uncaught IllegalArgumentError: bad cast from empty string to int(64)
   emptyStringToType.chpl:6: thrown here
   emptyStringToType.chpl:6: uncaught here

--- a/test/types/string/cast/emptyStringToReal.good
+++ b/test/types/string/cast/emptyStringToReal.good
@@ -1,3 +1,3 @@
-uncaught IllegalArgumentError: illegal argument '': Empty string when converting from string to real(64)
+uncaught IllegalArgumentError: bad cast from empty string to real(64)
   emptyStringToType.chpl:6: thrown here
   emptyStringToType.chpl:6: uncaught here

--- a/test/types/string/cast/emptyStringToReal.good
+++ b/test/types/string/cast/emptyStringToReal.good
@@ -1,1 +1,3 @@
-emptyStringToType.chpl:6: error: Empty string when converting from string to real(64)
+uncaught IllegalArgumentError: illegal argument '': Empty string when converting from string to real(64)
+  emptyStringToType.chpl:6: thrown here
+  emptyStringToType.chpl:6: uncaught here

--- a/test/types/string/cast/emptyStringToUint.good
+++ b/test/types/string/cast/emptyStringToUint.good
@@ -1,1 +1,3 @@
-emptyStringToType.chpl:6: error: Empty string when converting from string to uint(64)
+uncaught IllegalArgumentError: illegal argument '': Empty string when converting from string to uint(64)
+  emptyStringToType.chpl:6: thrown here
+  emptyStringToType.chpl:6: uncaught here

--- a/test/types/string/cast/emptyStringToUint.good
+++ b/test/types/string/cast/emptyStringToUint.good
@@ -1,3 +1,3 @@
-uncaught IllegalArgumentError: illegal argument '': Empty string when converting from string to uint(64)
+uncaught IllegalArgumentError: bad cast from empty string to uint(64)
   emptyStringToType.chpl:6: thrown here
   emptyStringToType.chpl:6: uncaught here


### PR DESCRIPTION
 ### motivation
Failed casts of strings to primitive data types (`bool`, `int`, `real`, `imag`, `complex`) and `enum` types used to halt.

``` chapel
var s = "brad";
var i = s: int;  // this will halt!
```

To help users write resilient programs and put more weight on error handling, this PR allows such casts to throw errors.

``` chapel
var s = "brad";
try! {
  var i = s: int;
} catch e: IllegalArgumentError {
  writeln("caught cast error");
}
```

### approach
- Change the runtime to return an error flag if a cast is not possible.
- Have the matching `extern` declarations and calls pass an error flag variable by ref.
- Check and translate the error flag into an `IllegalArgumentError` in Chapel `_cast(...)` functions.
- Do the same for the generated `enum` casts in `buildDefaultFunctions`.

### misc
`integral_to_c_string()` is a special case where a failure would indicate a truly fatal error in the runtime. As such, its matching Chapel module function `_cast(type t, x: integral) where t == string` has been set to halt on such an error. This has been noted in #8452.

- [x] update tests with improperly handled casts
- [x] passes linux64+flat testing