### PR TITLE
Init parent 4

### DIFF
--- a/compiler/AST/astutil.cpp
+++ b/compiler/AST/astutil.cpp
@@ -682,15 +682,9 @@ bool isTypeExpr(Expr* expr) {
 
         } else if (var->immediate != NULL) {
           const char* name = var->immediate->v_string;
+          Symbol*     field = ct->getField(name);
 
-          for_fields(field, ct) {
-            if (strcmp(field->name, name) == 0) {
-              if (field->hasFlag(FLAG_TYPE_VARIABLE)) {
-                retval = true;
-                break;
-              }
-            }
-          }
+          retval = field->hasFlag(FLAG_TYPE_VARIABLE);
         }
       }
 

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -1463,9 +1463,6 @@ static bool shouldInsertCallTemps(CallExpr* call) {
   } else if (call->isPrimitive(PRIM_TUPLE_EXPAND)     == true) {
     retval = false;
 
-  } else if (call->isPrimitive(PRIM_GET_MEMBER_VALUE) == true) {
-    retval = false;
-
   } else if (parentCall && parentCall->isPrimitive(PRIM_MOVE)) {
     retval = false;
 

--- a/compiler/resolution/postFold.cpp
+++ b/compiler/resolution/postFold.cpp
@@ -615,11 +615,14 @@ static void updateFlagTypeVariable(CallExpr* call, Symbol* lhsSym) {
     if (FnSymbol* fn = rhs->resolvedFunction()) {
       isTypeVar = fn->retTag == RET_TYPE;
 
-    } else if (rhs->isPrimitive(PRIM_DEREF)  == true) {
+    } else if (rhs->isPrimitive(PRIM_DEREF)            == true) {
       isTypeVar = isTypeExpr(rhs->get(1));
 
-    } else if (rhs->isPrimitive(PRIM_TYPEOF) == true) {
+    } else if (rhs->isPrimitive(PRIM_TYPEOF)           == true) {
       isTypeVar = true;
+
+    } else if (rhs->isPrimitive(PRIM_GET_MEMBER_VALUE) == true) {
+      isTypeVar = isTypeExpr(rhs);
     }
 
   } else {

--- a/test/classes/initializers/inherited-type.chpl
+++ b/test/classes/initializers/inherited-type.chpl
@@ -4,17 +4,11 @@ class Derived : Base {
   proc init(_x : int, _y : int, _z : int) {
     super.init(_x, _y);
 
-    type t1 = int;
-    var  a  : t1;
-
     z = _z;
 
     initDone();
   }
 }
-
-
-
 
 
 class Base {
@@ -32,9 +26,6 @@ class Base {
     initDone();
   }
 }
-
-
-
 
 
 proc main() {


### PR DESCRIPTION
Minor updates to support accessing param fields from parent classes

The focus here is to handle PRIM_GET_MEMBER_VALUE more consistently with PRIM_GET_MEMBER.

Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.  Ran a modest subset
of release on each configuration.  Also compiled with CHPL_LLVM=llvm on linux64 and ran a modest
subset of release/

Passed a single-locale paratest with -futures and a second run that added --no-local.
