### PR TITLE
Add perf annotations for 2018-02-22

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -294,6 +294,9 @@ all:
       config: chapcs
   02/13/18:
     - Change default intent for range to const in (#8368)
+  02/22/18:
+    - text: Put the main process to sleep while waiting to shutdown (#8533)
+      config: 16 node XC
 
 AllCompTime:
   11/09/14:


### PR DESCRIPTION
Decent [gn-aries](https://chapel-lang.org/perf/16-node-xc/?startdate=2018/02/16&enddate=2018/02/24&graphs=hpccptransperfgbsecn2000nb100,hpccrarmoperfgupsn233,doeminimdtimesecsize20) improvements from putting the main process to sleep -- #8533