### PR TITLE
Improve core counting for ARM systems

### DIFF
--- a/runtime/src/chplsys.c
+++ b/runtime/src/chplsys.c
@@ -558,16 +558,16 @@ static void getCpuInfo(int* p_numPhysCpus, int* p_numLogCpus) {
     // See if the /sys filesystem has any more information for us.
     int threads_per_core = 0;
     if ((f = fopen("/sys/devices/system/cpu/cpu0/topology/thread_siblings",
-		   "r")) != NULL) {
+                   "r")) != NULL) {
       int c;
       while ((c = getc(f)) != EOF) {
-	if (c == '1') {
-	  ++threads_per_core;
-	} else if (c != '0' && c != ',' && c != '\n') {
-	  // unknown file format -- don't use
-	  threads_per_core = 1;
-	  break;
-	}
+        if (c == '1') {
+          ++threads_per_core;
+        } else if (c != '0' && c != ',' && c != '\n') {
+          // unknown file format -- don't use
+          threads_per_core = 1;
+          break;
+        }
       }
       fclose(f);
     }

--- a/runtime/src/chplsys.c
+++ b/runtime/src/chplsys.c
@@ -52,6 +52,7 @@
 #include <sched.h>
 #endif
 
+#include <ctype.h>
 #include <signal.h>
 #include <stdint.h>
 #include <string.h>

--- a/runtime/src/chplsys.c
+++ b/runtime/src/chplsys.c
@@ -561,9 +561,37 @@ static void getCpuInfo(int* p_numPhysCpus, int* p_numLogCpus) {
                    "r")) != NULL) {
       int c;
       while ((c = getc(f)) != EOF) {
-        if (c == '1') {
-          ++threads_per_core;
-        } else if (c != '0' && c != ',' && c != '\n') {
+        // The number of threads per core is the total number of bits
+        // set in the hex digits of the thread_siblings map.
+        if (isxdigit(c)) {
+          switch (tolower(c)) {
+          case '0':
+            break;
+          case '1':
+          case '2':
+          case '4':
+          case '8':
+            threads_per_core += 1;
+            break;
+          case '3':
+          case '5':
+          case '6':
+          case '9':
+          case 'a':
+          case 'c':
+            threads_per_core += 2;
+            break;
+          case '7':
+          case 'b':
+          case 'd':
+          case 'e':
+            threads_per_core += 3;
+            break;
+          case 'f':
+            threads_per_core += 4;
+            break;
+          }
+        } else if (c != ',' && c != '\n' && tolower(c) != 'x') {
           // unknown file format -- don't use
           threads_per_core = 1;
           break;

--- a/util/chplenv/chpl_platform.py
+++ b/util/chplenv/chpl_platform.py
@@ -57,6 +57,8 @@ def get(flag='host'):
                     platform_val = "linux64_32"
                 else:
                     platform_val = "linux64"
+            elif machine == 'aarch64':
+                platform_val = "linux64"
             else:
                 platform_val = "linux32"
         elif platform_val.startswith("cygwin"):


### PR DESCRIPTION
64-bit ARM Linux systems have an abbreviated version of /proc/cpuinfo that lacks some of the information we need. As a result, Chapel was unable to count the number of cores properly on those systems.  This change gathers additional information from the /sys filesystem when /proc/cpuinfo is insufficient.

After this change, we no longer need to set QTHREAD_WORKER_UNIT=pu to run on ARM.

The `/sys/devices/system/cpu/cpuX/topology/thread_siblings` file provides a hex map of thread affinity, with the number of bits set indicating the number of threads on a core.  Here is an example of four different thread sibling maps (three from aarch64 systems and one from an x86-64 system).

```
00000000,00000000,00000001
00000000,00000000,00000000,00000000,00000000,00000000,0000000f
00000000,00000100,00000000,00010000,00000000,01000000,00000001
0000,01000001
```

Some programs that parse these files seem to expect that there is also a possibility of the hex numbers being preceded by a 0x prefix.

- [x] Tested on three 64-bit ARM systems with different thread sibling maps (one was a Cray system)
- [x] Passed full local testing on x86-64 linux64