### PR TITLE
Remove .bad file for non-future test

### DIFF
--- a/test/types/enum/compare.bad
+++ b/test/types/enum/compare.bad
@@ -1,1 +1,0 @@
-$CHPL_HOME/modules/internal/ChapelBase.chpl:137: error: 'param' functions cannot return non-'param' values


### PR DESCRIPTION
The .future was changed to a regular test in PR #7659.

Test change only, not reviewed.