### PR TITLE
Add a .skipif for masonUpdateTest when SuSE version is 11 or lower

### DIFF
--- a/test/mason/masonUpdateTest.skipif
+++ b/test/mason/masonUpdateTest.skipif
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Skip this test for SuSE 11 and earlier. It requires an OpenSSL version that
+# is newer than is available on SuSe 11 due to github requirements.
+if [ -f /etc/SuSE-release ] ; then
+  slesVersion=`sed -n -e 's/VERSION = //p' /etc/SuSE-release`
+  if [ $slesVersion -le 11 ] ; then
+    echo true
+  else
+    echo false
+  fi
+else
+  echo false
+fi

--- a/test/mason/masonUpdateTest.skipif
+++ b/test/mason/masonUpdateTest.skipif
@@ -5,10 +5,10 @@
 if [ -f /etc/SuSE-release ] ; then
   slesVersion=`sed -n -e 's/VERSION = //p' /etc/SuSE-release`
   if [ $slesVersion -le 11 ] ; then
-    echo true
+    echo True
   else
-    echo false
+    echo False
   fi
 else
-  echo false
+  echo False
 fi


### PR DESCRIPTION
GitHub recently started requiring newer versions of OpenSSL than are available
on SLES-11 for https access. This test uses https to access GitHub, so can no
longer be run on SLES-11.