### PR TITLE
Limit qthread stack size for this test

### DIFF
--- a/test/parallel/begin/ferguson/begin-in-init-copy.execenv
+++ b/test/parallel/begin/ferguson/begin-in-init-copy.execenv
@@ -1,0 +1,4 @@
+CHPL_RT_CALL_STACK_SIZE=256K
+#Could also consider the following:
+#CHPL_RT_NUM_THREADS_PER_LOCALE=255
+#QT_GUARD_PAGES=false


### PR DESCRIPTION
Similarly to PR #309 to avoid failures on smaller machines.

Test change only, not reviewed.