### PR TITLE
start_test to process files in a deterministic order

### DIFF
--- a/util/start_test
+++ b/util/start_test
@@ -207,6 +207,8 @@ def test_directory(test, test_type):
         # stop recursing if flag is set
         if not args.recurse:
             del dirs[:]
+        else:
+            dirs.sort()
 
         # ignore skipifs for --clean-only run
         if not args.clean_only:

--- a/util/test/sub_clean
+++ b/util/test/sub_clean
@@ -94,6 +94,7 @@ for f in clean:
     if os.path.isdir(f):
         print 'Cleaning directory: '+f
         dirlist = glob.glob(f+'/*.chpl')+glob.glob(f+'/*.test.c')
+        dirlist.sort()
         for file in dirlist:
             cleanChapelTest(file)
         cleanCleanfiles(f, 'CLEANFILES', True)

--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -972,6 +972,7 @@ if systemPrediff:
 
 # consistently look only at the files in the current directory
 dirlist=os.listdir(".")
+dirlist.sort()
 
 onetestsrc = os.getenv('CHPL_ONETEST')
 if onetestsrc==None:


### PR DESCRIPTION
To simplify comparison of results of different runs of `start_test`,
force it to process the files in a deterministic order.

For that, have `sub_test` and `sub_clean` sort their file lists.

The sorting order may differ between locales, OSes, etc.
Ex. capital vs. lower-case characters may be ordered differently.
I let it be, in favor of simplicity of the change in this PR.

UPDATE: also add sort() in `start_test` proper,
for deterministic order of recursion into sub-directories.
