### PR TITLE
makeRandomStream returns an Owned random stream 

### DIFF
--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -136,7 +136,6 @@ module Random {
     where isSupportedNumericType(arr.eltType) {
     var randNums = makeRandomStream(seed, eltType=arr.eltType, parSafe=false, algorithm=algorithm);
     randNums.fillRandom(arr);
-    delete randNums;
   }
 
   pragma "no doc"
@@ -156,7 +155,6 @@ module Random {
   proc shuffle(arr: [], seed: int(64) = SeedGenerator.oddCurrentTime, param algorithm=RNG.PCG) {
     var randNums = makeRandomStream(seed, eltType=arr.domain.idxType, parSafe=false, algorithm=algorithm);
     randNums.shuffle(arr);
-    delete randNums;
   }
 
   /* Produce a random permutation, storing it in a 1-D array.
@@ -172,7 +170,6 @@ module Random {
   proc permutation(arr: [], seed: int(64) = SeedGenerator.oddCurrentTime, param algorithm=RNG.PCG) {
     var randNums = makeRandomStream(seed, eltType=arr.eltType, parSafe=false, algorithm=algorithm);
     randNums.permutation(arr);
-    delete randNums;
   }
 
   /*

--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -197,15 +197,17 @@ module Random {
 
     :arg algorithm: A param indicating which algorithm to use. Defaults to PCG.
     :type algorithm: :type:`RNG`
+
+    :returns: an owned RandomStream
   */
   proc makeRandomStream(type eltType,
                         seed: int(64) = SeedGenerator.oddCurrentTime,
                         param parSafe: bool = true,
                         param algorithm = defaultRNG) {
     if algorithm == RNG.PCG then
-      return new unmanaged RandomStream(seed=seed, parSafe=parSafe, eltType=eltType);
+      return new owned RandomStream(seed=seed, parSafe=parSafe, eltType=eltType);
     else if algorithm == RNG.NPB then
-      return new unmanaged NPBRandomStream(seed=seed, parSafe=parSafe, eltType=eltType);
+      return new owned NPBRandomStream(seed=seed, parSafe=parSafe, eltType=eltType);
     else
       compilerError("Unknown random number generator");
   }

--- a/test/distributions/robust/arithmetic/modules/test_module_Norm.chpl
+++ b/test/distributions/robust/arithmetic/modules/test_module_Norm.chpl
@@ -132,5 +132,3 @@ writeln("\trcR1D:");
 doNorm(rcR1D, 1);
 writeln("\trcR2D:");
 doNorm(rcR2D, 2);
-
-delete rng;

--- a/test/distributions/robust/arithmetic/modules/test_module_Random.chpl
+++ b/test/distributions/robust/arithmetic/modules/test_module_Random.chpl
@@ -123,6 +123,3 @@ writeln("\trcR3D: ", checkRNG(rcR3D, rcT3D), " errors");
 
 if printRefArrays then
   outputRealArrays();
-
-delete trng;
-delete rng;

--- a/test/domains/diten/assocDomIntersect.chpl
+++ b/test/domains/diten/assocDomIntersect.chpl
@@ -16,7 +16,6 @@ proc setupDoms(ref D1, ref D2) {
     if !D2.member(rnd2) then
       D2 += rnd2;
   }
-  delete rs;
 }
 
 for i in 1..nTrials {

--- a/test/domains/ferguson/build-associative.chpl
+++ b/test/domains/ferguson/build-associative.chpl
@@ -83,5 +83,3 @@ if timing {
 if perf || correctness {
   writeln("SUCCESS");
 }
-
-delete rng;

--- a/test/exercises/life.chpl
+++ b/test/exercises/life.chpl
@@ -58,8 +58,6 @@ for i in 1..k {
   printGrid();
 }
 
-delete rs;
-
 // print a generation
 proc printGrid() {
   write("+"); for i in 1..n do write("-"); writeln("+");

--- a/test/functions/deitz/iterators/leader_follower/test_strided_leader2.chpl
+++ b/test/functions/deitz/iterators/leader_follower/test_strided_leader2.chpl
@@ -35,8 +35,6 @@ use Random;
     B(i) = r;
 
   writeln(B);
-
-  delete rs;
 }
 
 {
@@ -48,6 +46,4 @@ use Random;
     B(f) = r;
 
   writeln(B);
-
-  delete rs;
 }

--- a/test/library/packages/LinearAlgebra/performance/MatrixUtils.chpl
+++ b/test/library/packages/LinearAlgebra/performance/MatrixUtils.chpl
@@ -34,7 +34,5 @@ proc populate(ref A, ref ADom, nnz: int, seed: int) where isCSArr(A) {
   for idx in ADom {
     A[idx] = 2.0; //randomReals.getNext();
   }
-  delete randomIndices;
-  delete randomReals;
 }
 

--- a/test/library/standard/DateTime/testDatetimeTZ.chpl
+++ b/test/library/standard/DateTime/testDatetimeTZ.chpl
@@ -184,7 +184,6 @@ proc test_tz_aware_arithmetic() {
   var maxdiff = max - min;
   assert(maxdiff == datetime.max - datetime.min +
                     new timedelta(minutes=2*1439));
-  delete rng;
 }
 
 proc test_tzinfo_now() {

--- a/test/library/standard/Random/bradc/randomAcrossTypes.chpl
+++ b/test/library/standard/Random/bradc/randomAcrossTypes.chpl
@@ -95,13 +95,3 @@ for i in 1..4 {
 writeln(A);
 writeln(B);
 writeln(C);
-
-delete rs1;
-delete rs2;
-delete rs3;
-delete rs4;
-delete rs5;
-delete rs6;
-delete rs7;
-delete rs8;
-delete rs9;

--- a/test/library/standard/Random/bradc/test-Random-evenseed.1-0.good
+++ b/test/library/standard/Random/bradc/test-Random-evenseed.1-0.good
@@ -1,1 +1,1 @@
-test-Random-evenseed.chpl:20: error: halt reached - NPBRandomStream seed must be an odd integer
+test-Random-evenseed.chpl:17: error: halt reached - NPBRandomStream seed must be an odd integer

--- a/test/library/standard/Random/bradc/test-Random-evenseed.chpl
+++ b/test/library/standard/Random/bradc/test-Random-evenseed.chpl
@@ -9,26 +9,21 @@ config param useNPB = true;
 config param rtype = if useNPB then RNG.NPB else RNG.PCG;
 
 proc main() {
+  var Vector1 = {1..20};
+  var Vec1 : [Vector1] real;
+  var Vec2 : [Vector1] real;
+  var Vec3 : [Vector1] real;
 
+  var rng = makeRandomStream(real, 314159264, algorithm=rtype);
 
+  rng.fillRandom(Vec1);
 
-var Vector1 = {1..20};
-var Vec1 : [Vector1] real;
-var Vec2 : [Vector1] real;
-var Vec3 : [Vector1] real;
+  fillRandom(Vec2,314159264, algorithm=rtype);
+  fillRandom(Vec3,314159264, algorithm=rtype);
 
-var rng = makeRandomStream(real, 314159264, algorithm=rtype);
-
-rng.fillRandom(Vec1);
-
-fillRandom(Vec2,314159264, algorithm=rtype);
-fillRandom(Vec3,314159264, algorithm=rtype);
-
-for (a,b,c) in zip(Vec1, Vec2, Vec3) {
-  assert( a == b );
-  assert( b == c );
-}
-
-delete rng;
+  for (a,b,c) in zip(Vec1, Vec2, Vec3) {
+    assert( a == b );
+    assert( b == c );
+  }
 }
 

--- a/test/library/standard/Random/bradc/testGetNth.chpl
+++ b/test/library/standard/Random/bradc/testGetNth.chpl
@@ -20,7 +20,3 @@ for i in 1..n {
     //writeln("#", i, " = ", r2);
   }
 }
-
-delete randStr1;
-delete randStr2;
-delete randStr3;

--- a/test/library/standard/Random/bradc/testGetNth2.chpl
+++ b/test/library/standard/Random/bradc/testGetNth2.chpl
@@ -74,7 +74,3 @@ proc checkArrays(str) {
     }
   }
 }
-
-delete randStr1;
-delete randStr2;
-delete randStr3;

--- a/test/library/standard/Random/bradc/writeRandomStream.chpl
+++ b/test/library/standard/Random/bradc/writeRandomStream.chpl
@@ -8,7 +8,5 @@ module A2 {
     var rnd  = makeRandomStream(real, seed=314159265, algorithm=rtype);
 
     writeln(rnd);
-
-    delete rnd;
   }
 }

--- a/test/library/standard/Random/deitz/test1D2D.chpl
+++ b/test/library/standard/Random/deitz/test1D2D.chpl
@@ -10,8 +10,6 @@ config param algo = RNG.NPB;
 
   writeln(for i in 1..n do "%{#.#####}".format(rs.getNext()));
   writeln(rs.getNext());
-
-  delete rs;
 }
 
 {
@@ -19,8 +17,6 @@ config param algo = RNG.NPB;
 
   writeln(for i in 1..n do "%{#.#####}".format(rs.getNth(i)));
   writeln(rs.getNext());
-
-  delete rs;
 }
 
 {
@@ -30,8 +26,6 @@ config param algo = RNG.NPB;
   rs.fillRandom(A);
   writeln(for e in A do "%{#.#####}".format(e));
   writeln(rs.getNext());
-
-  delete rs;
 }
 
 {
@@ -41,8 +35,6 @@ config param algo = RNG.NPB;
   rs.fillRandom(A);
   writeln(for e in A do "%{#.#####}".format(e));
   writeln(rs.getNext());
-
-  delete rs;
 }
 
 {
@@ -53,8 +45,6 @@ config param algo = RNG.NPB;
   writeln(for e in A do "%{#######}".format(e.locale.id));
   writeln(for e in A do "%{#.#####}".format(e));
   writeln(rs.getNext());
-
-  delete rs;
 }
 
 {
@@ -65,8 +55,6 @@ config param algo = RNG.NPB;
   writeln(for e in A do "%{#######}".format(e.locale.id));
   writeln(for e in A do "%{#.#####}".format(e));
   writeln(rs.getNext());
-
-  delete rs;
 }
 
 {
@@ -78,8 +66,6 @@ config param algo = RNG.NPB;
   writeln(for e in A do "%{#######}".format(e.locale.id));
   writeln(for e in A do "%{#.#####}".format(e));
   writeln(rs.getNext());
-
-  delete rs;
 }
 
 {
@@ -91,8 +77,6 @@ config param algo = RNG.NPB;
   writeln(for e in A do "%{#######}".format(e.locale.id));
   writeln(for e in A do "%{#.#####}".format(e));
   writeln(rs.getNext());
-
-  delete rs;
 }
 
 {
@@ -104,8 +88,6 @@ config param algo = RNG.NPB;
   writeln(for e in A do "%{#######}".format(e.locale.id));
   writeln(for e in A do "%{#.#####}".format(e));
   writeln(rs.getNext());
-
-  delete rs;
 }
 
 {
@@ -117,6 +99,4 @@ config param algo = RNG.NPB;
   writeln(for e in A do "%{#######}".format(e.locale.id));
   writeln(for e in A do "%{#.#####}".format(e));
   writeln(rs.getNext());
-
-  delete rs;
 }

--- a/test/library/standard/Random/elliot/testBadNth.chpl
+++ b/test/library/standard/Random/elliot/testBadNth.chpl
@@ -19,6 +19,3 @@ if useNPB {
     pcgRand.skipToNth(-1);
   }
 }
-
-delete npbRand;
-delete pcgRand;

--- a/test/library/standard/Random/elliot/testCaughtNth.chpl
+++ b/test/library/standard/Random/elliot/testCaughtNth.chpl
@@ -23,6 +23,3 @@ try! {
 } catch (e: IllegalArgumentError) {
   writeln("Successfully caught IllegalArgumentError");
 }
-
-delete npbRand;
-delete pcgRand;

--- a/test/library/standard/Random/ferguson/chapel-testu01/chplu01.chpl
+++ b/test/library/standard/Random/ferguson/chapel-testu01/chplu01.chpl
@@ -179,7 +179,7 @@ if testReal {
   for i in 1..10 {
     writeln(test_rand_double());
   }
-  delete rs; // start over, don't count above as run-up
+  // start over, don't count above as run-up
   rs = getRNG();
   if crush then
     run_crush_testu01_double(name.localize().c_str());
@@ -190,7 +190,7 @@ if testReal {
   for i in 1..10 {
     writef("%xu\n", test_rand_uint32());
   }
-  delete rs; // start over, don't count above as run-up
+  // start over, don't count above as run-up
   rs = getRNG();
   if crush then
     run_crush_testu01_uint(name.localize().c_str());

--- a/test/library/standard/Random/ferguson/check-time-seed.chpl
+++ b/test/library/standard/Random/ferguson/check-time-seed.chpl
@@ -56,8 +56,6 @@ proc getRealRandoms(method:int) {
 
     for a in A do
       a = R.getNext();
-
-    delete R;
   }
 
   return A;

--- a/test/library/standard/Random/ferguson/pcg-rand-check.chpl
+++ b/test/library/standard/Random/ferguson/pcg-rand-check.chpl
@@ -38,8 +38,6 @@ writeln("Checking 32-bit RNG seq 1");
     if verbose then writef("%xu\n", got);
     assert( got == expect32_1[i] );
   }
-
-  delete rs;
 }
 
 {
@@ -66,8 +64,6 @@ writeln("Checking 32-bit RNG seq 1");
     if verbose then writef("%xu\n", got);
     assert( got:uint(32) == expect32_1[i] );
   }
-
-  delete rs;
 }
 
 
@@ -99,8 +95,6 @@ writeln("Checking 32-bit RNG seq 1");
     if verbose then writef("%xu\n", got);
     assert( got == expect32_1[i] >> 24 );
   }
-
-  delete rs;
 }
 
 // check 16 bit version
@@ -132,8 +126,6 @@ writeln("Checking 32-bit RNG seq 1");
     if verbose then writef("%xu\n", got);
     assert( got == expect32_1[i] >> 16 );
   }
-
-  delete rs;
 }
 
 writeln("Checking 2x 32-bit RNG seq 1 seq 2");
@@ -166,8 +158,6 @@ writeln("Checking 2x 32-bit RNG seq 1 seq 2");
     if verbose then writef("%xu\n", got);
     assert( got == (expect32_1[i]:uint(64) << 32) | expect32_2[i]:uint(64) );
   }
-
-  delete rs;
 }
 
 //writeln("Checking real(32)");
@@ -204,8 +194,6 @@ writeln("Checking 2x 32-bit RNG seq 1 seq 2");
     if verbose then writef("%n\n", got);
     assert( got == expect[i] );
   }
-
-  delete rs;
 }*/
 
 writeln("Checking real(64)");

--- a/test/library/standard/Random/ferguson/pcg-rand-range-check.chpl
+++ b/test/library/standard/Random/ferguson/pcg-rand-range-check.chpl
@@ -71,8 +71,6 @@ var histo:[0..255] int;
 
     if verbose then writef("% 3i: %i\n", i, h);
   }
-
-  delete rs;
 }
 
 
@@ -94,8 +92,6 @@ histo = 0;
 
     if verbose then writef("% 3i: %i\n", i, h);
   }
-
-  delete rs;
 }
 
 histo = 0;
@@ -117,8 +113,6 @@ histo = 0;
 
     if verbose then writef("% 3i: %i\n", i, h);
   }
-
-  delete rs;
 }
 
 

--- a/test/library/standard/Random/ferguson/pcg-rand-range-check2.chpl
+++ b/test/library/standard/Random/ferguson/pcg-rand-range-check2.chpl
@@ -54,8 +54,6 @@ for i in 0..#n {
   assert(got[i] == num);
 }
 
-delete rs;
-
 var rs2 = makeRandomStream(seed=seed, parSafe=false, eltType=uint(64), algorithm=RNG.PCG);
 
 var max2:uint = (2**32 + max):uint;
@@ -92,5 +90,3 @@ assert(got2[n+1] == num);
 rs2.skipToNth(n + 3);
 num = rs2.getNext();
 assert(got2[n+2] == num);
-
-delete rs2;

--- a/test/library/standard/Random/ferguson/pcg-real32-bug.chpl
+++ b/test/library/standard/Random/ferguson/pcg-real32-bug.chpl
@@ -9,7 +9,3 @@ var displace = (rng.getNext(), rng.getNext(), rng.getNext());
 
 if verbose then
   writeln(displace);
-
-
-delete rng;
-

--- a/test/library/standard/Random/ferguson/rmixed.chpl
+++ b/test/library/standard/Random/ferguson/rmixed.chpl
@@ -12,8 +12,6 @@ use Random;
 
   var v3 = rng.getNext(uint(64));
   writeln(v3.type:string);
-
-  delete rng;
 }
 
 // Test stepping for uint
@@ -27,8 +25,6 @@ use Random;
     var v1  = rng.getNext();
 
     v2 = rng.getNext();
-
-    delete rng;
   }
 
   {
@@ -39,8 +35,6 @@ use Random;
     var got_v2 = rng.getNext();
 
     assert(v2 == got_v2);
-
-    delete rng;
   }
 }
 
@@ -55,8 +49,6 @@ use Random;
     var v1 = rng.getNext();
 
     v2 = rng.getNext();
-
-    delete rng;
   }
 
   {
@@ -67,8 +59,6 @@ use Random;
     var got_v2 = rng.getNext();
 
     assert(v2 == got_v2);
-
-    delete rng;
   }
 }
 
@@ -84,8 +74,6 @@ use Random;
     var v1 = rng.getNext();
 
     v2 = rng.getNext();
-
-    delete rng;
   }
 
   {
@@ -96,8 +84,6 @@ use Random;
     var got_v2 = rng.getNext();
 
     assert(v2 == got_v2);
-
-    delete rng;
   }
 }
 

--- a/test/library/standard/Random/marybeth/test-Random.chpl
+++ b/test/library/standard/Random/marybeth/test-Random.chpl
@@ -1,20 +1,17 @@
 proc main() {
+  use Random;
 
-use Random;
+  var Vector1 = {1..20};
+  var Vec1 : [Vector1] real;
 
-var Vector1 = {1..20};
-var Vec1 : [Vector1] real;
+  var rng = makeRandomStream(real, 314159265, algorithm=RNG.NPB);
 
-var rng = makeRandomStream(real, 314159265, algorithm=RNG.NPB);
+  rng.fillRandom(Vec1);
+  writeln(Vec1);
 
-rng.fillRandom(Vec1);
-writeln(Vec1);
-
-fillRandom(Vec1,314159265, algorithm=RNG.NPB);
-writeln(Vec1);
-fillRandom(Vec1,314159265, algorithm=RNG.NPB);
-writeln(Vec1);
-
-delete rng;
+  fillRandom(Vec1,314159265, algorithm=RNG.NPB);
+  writeln(Vec1);
+  fillRandom(Vec1,314159265, algorithm=RNG.NPB);
+  writeln(Vec1);
 }
 

--- a/test/release/examples/primers/opaque-domains.chpl
+++ b/test/release/examples/primers/opaque-domains.chpl
@@ -284,6 +284,4 @@ proc createRandomGraph() {
       }
     }
   }
-
-  delete myRandNums;
 }

--- a/test/sparse/CS/multiplication/performance.chpl
+++ b/test/sparse/CS/multiplication/performance.chpl
@@ -72,8 +72,6 @@ proc populate(ref A, ref ADom, sparsity: real, seed: int) where isSparseArr(A) {
   for idx in ADom {
     A[idx] = randomReals.getNext();
   }
-  delete randomIndices;
-  delete randomReals;
 }
 
 /* Populate dense matrix with random elements according to "sparsity" */
@@ -94,6 +92,4 @@ proc populate(ref A: [?ADom], sparsity: real, seed: int) where !isSparseArr(A) {
   for idx in indices {
     A[idx] = randomReals.getNext();
   }
-  delete randomReals;
-  delete randomIndices;
 }

--- a/test/studies/labelprop/labelprop-tweets.chpl
+++ b/test/studies/labelprop/labelprop-tweets.chpl
@@ -502,7 +502,6 @@ proc create_and_analyze_graph(Pairs)
           maxlabel = lab;
         }
       }
-      delete tiebreaker;
 
       // TODO:
       // Did the existing label correspond to a maximal label?


### PR DESCRIPTION
Since makeRandomStream allocates a new object,
it can communicate to the caller that it should be
freed by the caller by returning an owned object. 

This PR does not attempt to deprecate makeRandomStream
for two reasons:
 1. Can't add a warning overload for return type changes like this
 2. Owned coerces to borrowed so code using the older
      makeRandomStream has a chance of continuing to work.

Relates to issue #6493 and #9087.

- [x] full local testing

Reviewed by @bradcray - thanks!