### PR TITLE
Fix think-o in testArgMapping

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -3845,11 +3845,11 @@ static void testArgMapping(FnSymbol*                    fn1,
 
   } else if (formal1->instantiatedFrom != dtAny &&
              formal2->instantiatedFrom == dtAny) {
-    prefer1 = STRONG; reason = "generic any vs generic";
+    prefer1 = STRONG; reason = "generic any vs partially generic/concrete";
 
   } else if (formal1->instantiatedFrom == dtAny &&
              formal2->instantiatedFrom != dtAny) {
-    prefer2 = STRONG; reason = "generic any vs generic";
+    prefer2 = STRONG; reason = "generic any vs partially generic/concrete";
 
   } else if (formal1->instantiatedFrom &&
              formal2->instantiatedFrom &&

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -540,10 +540,12 @@ module ChapelBase {
   inline proc _cond_test(param x: bool) param return x;
   inline proc _cond_test(param x: integral) param return x != 0:x.type;
 
+  pragma "last resort"
   inline proc _cond_test(x) {
     compilerError("type '", x.type:string, "' used in if or while condition");
   }
 
+  pragma "last resort"
   inline proc _cond_test(x: _iteratorRecord) {
     compilerError("iterator or promoted expression ", x.type:string, " used in if or while condition");
   }

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -540,12 +540,10 @@ module ChapelBase {
   inline proc _cond_test(param x: bool) param return x;
   inline proc _cond_test(param x: integral) param return x != 0:x.type;
 
-  pragma "last resort"
   inline proc _cond_test(x) {
     compilerError("type '", x.type:string, "' used in if or while condition");
   }
 
-  pragma "last resort"
   inline proc _cond_test(x: _iteratorRecord) {
     compilerError("iterator or promoted expression ", x.type:string, " used in if or while condition");
   }


### PR DESCRIPTION
testArgMapping includes a mechanism to print out the reason one function in chosen over another in overload disambiguation. This included misleading wording: "generic any vs generic" is actually not what the spec says; the spec says "generic any vs not generic any". This PR adjusts the wording to resolve the thinko.

- [x] full local testing

Reviewed by @daviditen - thanks!