### PR TITLE
Don't print out Owned representation

### DIFF
--- a/modules/packages/OwnedObject.chpl
+++ b/modules/packages/OwnedObject.chpl
@@ -184,4 +184,10 @@ module OwnedObject {
     var ret = new Owned(src);
     return ret;
   }
+
+  // Don't print out 'p' when printing an Owned, just print class pointer
+  pragma "no doc"
+  proc Owned.readWriteThis(f) {
+    f <~> this.p;
+  }
 }


### PR DESCRIPTION
Don't print out 'p' when printing an Owned, just print class pointer.
This helps as tests are updated to use Owned in more places, since the
output does not need to change as much.

- [ ] full local testing