### PR TITLE
Add comparison operators for astloc

### DIFF
--- a/compiler/include/baseAST.h
+++ b/compiler/include/baseAST.h
@@ -148,6 +148,15 @@ public:
   int         lineno;    // line number of location
 };
 
+static inline
+bool operator==(const astlocT lhs, const astlocT rhs) {
+  return lhs.filename == rhs.filename && lhs.lineno == rhs.lineno;
+}
+static inline
+bool operator!=(const astlocT lhs, const astlocT rhs) {
+  return lhs.filename != rhs.filename || lhs.lineno != rhs.lineno;
+}
+
 //
 // enumerated type of all AST node types
 //

--- a/compiler/include/baseAST.h
+++ b/compiler/include/baseAST.h
@@ -146,16 +146,14 @@ public:
 
   const char* filename;  // filename of location
   int         lineno;    // line number of location
-};
 
-static inline
-bool operator==(const astlocT lhs, const astlocT rhs) {
-  return lhs.filename == rhs.filename && lhs.lineno == rhs.lineno;
-}
-static inline
-bool operator!=(const astlocT lhs, const astlocT rhs) {
-  return lhs.filename != rhs.filename || lhs.lineno != rhs.lineno;
-}
+  inline bool operator==(const astlocT other) const {
+    return this->filename == other.filename && this->lineno == other.lineno;
+  }
+  inline bool operator!=(const astlocT other) const {
+    return this->filename != other.filename || this->lineno != other.lineno;
+  }
+};
 
 //
 // enumerated type of all AST node types


### PR DESCRIPTION
These comparison operators for AST locations are useful for simplifying error messages and I used them in my upcoming work on lifetime checking (PR #8338).

- [x] full local testing

Reviewed by @daviditen - thanks!