### PR TITLE
Use the scalable allLocalesBarrier in isx-hand-optimized

### DIFF
--- a/test/studies/isx/isx-hand-optimized.chpl
+++ b/test/studies/isx/isx-hand-optimized.chpl
@@ -17,7 +17,7 @@
 // We want to use block-distributed arrays (BlockDist), barrier
 // synchronization (Barriers), and timers (Time).
 //
-use BlockDist, Barriers, Time;
+use BlockDist, AllLocalesBarriers, Time;
 
 //
 // The type of key to use when sorting.
@@ -147,7 +147,7 @@ var totalTime, inputTime, bucketCountTime, bucketOffsetTime, bucketizeTime,
     exchangeKeysTime, countKeysTime: [DistTaskSpace] [1..numTrials] real;
 var verifyKeyCount: atomic int;
 
-var barrier = new Barrier(numTasks);
+allLocalesBarrier.reset(perBucketMultiply);
 
 // should result in one loop iteration per task
 proc main() {
@@ -223,7 +223,7 @@ proc bucketSort(taskID : int, trial: int, time = false, verify = false) {
   }
   
   exchangeKeys(taskID, sendOffsets, bucketSizes, myBucketedKeys);
-  barrier.barrier();
+  allLocalesBarrier.barrier();
 
   if subtime {
     exchangeKeysTime.localAccess[taskID][trial] = subTimer.elapsed();
@@ -248,7 +248,7 @@ proc bucketSort(taskID : int, trial: int, time = false, verify = false) {
   // reset the receive offsets for the next iteration
   //
   recvOffset[taskID].write(0);
-  barrier.barrier();
+  allLocalesBarrier.barrier();
 }
 
 
@@ -338,7 +338,7 @@ proc verifyResults(taskID, myBucketSize, myLocalKeyCounts) {
   //
   //
   verifyKeyCount.add(myBucketSize);
-  barrier.barrier();
+  allLocalesBarrier.barrier();
   if verifyKeyCount.read() != totalKeys then
     halt("total key count mismatch: " + verifyKeyCount.read() + " != " + totalKeys);
 


### PR DESCRIPTION
Switch isx-hand-optimized over to the new allLocalesBarrier. This significantly
improves scalability and performance of ISx.

At 16 node, this shaves 2s off the avg time (10s -> 8s), but more importantly
it really stabilizes the timings (min and max are much closer to average):

Previously we would see timings like:

| step     | avg   | min  | max   |
| -------- | ----- | ---- | ----- |
| input    |  0.99 | 0.68 |  2.87 |
| exchange |  5.85 | 0.20 |  8.16 |
| total    | 10.10 | 6.35 | 11.86 |

and now we see much more consistent timings:

| step     | avg   | min  | max   |
| -------- | ----- | ---- | ----- |
| input    |  1.07 | 0.98 | 1.52  |
| exchange |  3.39 | 2.01 | 3.56  |
| total    |  7.71 | 7.56 | 7.81  |

Note that the remaining difference between the min and max times is mostly from
interference/contention from the progress thread, which is being worked on
separately.

We see similarly good numbers at higher scales. At 256 nodes we're within ~15%
of the reference SHMEM version, whereas before we'd run out of memory because
10,000 tasks were being created on locale 0 as part of the barrier. With a
lowered stack size we were still between 50% and 2X off.