### PR TITLE
Add barrier subtimings to isx-hand-optimized

### DIFF
--- a/test/studies/isx/isx-hand-optimized.chpl
+++ b/test/studies/isx/isx-hand-optimized.chpl
@@ -144,7 +144,8 @@ const DistTaskSpace = LocTaskSpace dmapped Block(LocTaskSpace);
 var allBucketKeys: [DistTaskSpace] [0..#recvBuffSize] keyType;
 var recvOffset: [DistTaskSpace] atomic int;
 var totalTime, inputTime, bucketCountTime, bucketOffsetTime, bucketizeTime,
-    exchangeKeysTime, countKeysTime: [DistTaskSpace] [1..numTrials] real;
+    exchangeKeysTime, exchangeKeysBarrierTime,
+    countKeysTime: [DistTaskSpace] [1..numTrials] real;
 var verifyKeyCount: atomic int;
 
 allLocalesBarrier.reset(perBucketMultiply);
@@ -223,10 +224,16 @@ proc bucketSort(taskID : int, trial: int, time = false, verify = false) {
   }
   
   exchangeKeys(taskID, sendOffsets, bucketSizes, myBucketedKeys);
-  allLocalesBarrier.barrier();
 
   if subtime {
     exchangeKeysTime.localAccess[taskID][trial] = subTimer.elapsed();
+    subTimer.clear();
+  }
+
+  allLocalesBarrier.barrier();
+
+  if subtime {
+    exchangeKeysBarrierTime.localAccess[taskID][trial] = subTimer.elapsed();
     subTimer.clear();
   }
 
@@ -404,6 +411,7 @@ proc printTimingData(units) {
       printTimeTable(bucketOffsetTime, units, "bucket offset");
       printTimeTable(bucketizeTime, units, "bucketize");
       printTimeTable(exchangeKeysTime, units, "exchange");
+      printTimeTable(exchangeKeysBarrierTime, units, "exchange barrier");
       printTimeTable(countKeysTime, units, "count keys");
     }
     printTimeTable(totalTime, units, "total");
@@ -417,6 +425,7 @@ proc printTimingData(units) {
     printTimingStats(bucketOffsetTime, "bucket offset");
     printTimingStats(bucketizeTime, "bucketize");
     printTimingStats(exchangeKeysTime, "exchange");
+    printTimingStats(exchangeKeysBarrierTime, "exchange barrier");
     printTimingStats(countKeysTime, "count keys");
   }
   printTimingStats(totalTime, "total");

--- a/test/studies/isx/isx-hand-optimized.chpl
+++ b/test/studies/isx/isx-hand-optimized.chpl
@@ -144,7 +144,7 @@ const DistTaskSpace = LocTaskSpace dmapped Block(LocTaskSpace);
 var allBucketKeys: [DistTaskSpace] [0..#recvBuffSize] keyType;
 var recvOffset: [DistTaskSpace] atomic int;
 var totalTime, inputTime, bucketCountTime, bucketOffsetTime, bucketizeTime,
-    exchangeKeysTime, exchangeKeysBarrierTime,
+    exchangeKeysTime, exchangeKeysOnlyTime, exchangeKeysBarrierTime,
     countKeysTime: [DistTaskSpace] [1..numTrials] real;
 var verifyKeyCount: atomic int;
 
@@ -226,6 +226,7 @@ proc bucketSort(taskID : int, trial: int, time = false, verify = false) {
   exchangeKeys(taskID, sendOffsets, bucketSizes, myBucketedKeys);
 
   if subtime {
+    exchangeKeysOnlyTime.localAccess[taskID][trial] = subTimer.elapsed();
     exchangeKeysTime.localAccess[taskID][trial] = subTimer.elapsed();
     subTimer.clear();
   }
@@ -234,6 +235,7 @@ proc bucketSort(taskID : int, trial: int, time = false, verify = false) {
 
   if subtime {
     exchangeKeysBarrierTime.localAccess[taskID][trial] = subTimer.elapsed();
+    exchangeKeysTime.localAccess[taskID][trial] += subTimer.elapsed();
     subTimer.clear();
   }
 
@@ -411,6 +413,7 @@ proc printTimingData(units) {
       printTimeTable(bucketOffsetTime, units, "bucket offset");
       printTimeTable(bucketizeTime, units, "bucketize");
       printTimeTable(exchangeKeysTime, units, "exchange");
+      printTimeTable(exchangeKeysOnlyTime, units, "exchange only");
       printTimeTable(exchangeKeysBarrierTime, units, "exchange barrier");
       printTimeTable(countKeysTime, units, "count keys");
     }
@@ -425,6 +428,7 @@ proc printTimingData(units) {
     printTimingStats(bucketOffsetTime, "bucket offset");
     printTimingStats(bucketizeTime, "bucketize");
     printTimingStats(exchangeKeysTime, "exchange");
+    printTimingStats(exchangeKeysOnlyTime, "exchange only");
     printTimingStats(exchangeKeysBarrierTime, "exchange barrier");
     printTimingStats(countKeysTime, "count keys");
   }

--- a/test/studies/isx/isx-hand-optimized.graph
+++ b/test/studies/isx/isx-hand-optimized.graph
@@ -1,5 +1,5 @@
-perfkeys: total =, input =, bucket count =, bucket offset =, bucketize =, exchange =, count keys =
+perfkeys: total =, input =, bucket count =, bucket offset =, bucketize =, exchange =, exchange barrier =, count keys =
 repeat-files: isx-hand-optimized.dat
-graphkeys: total time, input time, bucket count time, bucket offset time, bucketize time, exchange time, count keys time
+graphkeys: total time, input time, bucket count time, bucket offset time, bucketize time, exchange time, exchange barrier time, count keys time
 ylabel: Time (seconds)
 graphtitle: ISx (Hand Optimized)

--- a/test/studies/isx/isx-hand-optimized.graph
+++ b/test/studies/isx/isx-hand-optimized.graph
@@ -1,5 +1,5 @@
-perfkeys: total =, input =, bucket count =, bucket offset =, bucketize =, exchange =, exchange barrier =, count keys =
+perfkeys: total =, input =, bucket count =, bucket offset =, bucketize =, exchange =, exchange only =, exchange barrier =, count keys =
 repeat-files: isx-hand-optimized.dat
-graphkeys: total time, input time, bucket count time, bucket offset time, bucketize time, exchange time, exchange barrier time, count keys time
+graphkeys: total time, input time, bucket count time, bucket offset time, bucketize time, exchange time, exchange only =, exchange barrier time, count keys time
 ylabel: Time (seconds)
 graphtitle: ISx (Hand Optimized)

--- a/test/studies/isx/isx-hand-optimized.ml-keys
+++ b/test/studies/isx/isx-hand-optimized.ml-keys
@@ -11,5 +11,6 @@ bucket count =
 bucket offset =
 bucketize =
 exchange =
+exchange barrier =
 count keys =
 verify:Verification successful!

--- a/test/studies/isx/isx-hand-optimized.ml-keys
+++ b/test/studies/isx/isx-hand-optimized.ml-keys
@@ -11,6 +11,7 @@ bucket count =
 bucket offset =
 bucketize =
 exchange =
+exchange only =
 exchange barrier =
 count keys =
 verify:Verification successful!

--- a/test/studies/isx/isx-hand-optimized.ml-time.graph
+++ b/test/studies/isx/isx-hand-optimized.ml-time.graph
@@ -1,5 +1,5 @@
-perfkeys: total =, input =, bucket count =, bucket offset =, bucketize =, exchange =, count keys =
+perfkeys: total =, input =, bucket count =, bucket offset =, bucketize =, exchange =, exchange barrier =, count keys =
 repeat-files: isx-hand-optimized.dat
-graphkeys: total time, input time, bucket count time, bucket offset time, bucketize time, exchange time, count keys time
+graphkeys: total time, input time, bucket count time, bucket offset time, bucketize time, exchange time, exchange barrier time, count keys time
 ylabel: Time (seconds)
 graphtitle: ISx (Hand Optimized)

--- a/test/studies/isx/isx-hand-optimized.ml-time.graph
+++ b/test/studies/isx/isx-hand-optimized.ml-time.graph
@@ -1,5 +1,5 @@
-perfkeys: total =, input =, bucket count =, bucket offset =, bucketize =, exchange =, exchange barrier =, count keys =
+perfkeys: total =, input =, bucket count =, bucket offset =, bucketize =, exchange =, exchange only =, exchange barrier =, count keys =
 repeat-files: isx-hand-optimized.dat
-graphkeys: total time, input time, bucket count time, bucket offset time, bucketize time, exchange time, exchange barrier time, count keys time
+graphkeys: total time, input time, bucket count time, bucket offset time, bucketize time, exchange time, exchange only time, exchange barrier time, count keys time
 ylabel: Time (seconds)
 graphtitle: ISx (Hand Optimized)

--- a/test/studies/isx/isx-hand-optimized.perfkeys
+++ b/test/studies/isx/isx-hand-optimized.perfkeys
@@ -11,5 +11,6 @@ bucket count =
 bucket offset =
 bucketize =
 exchange =
+exchange barrier =
 count keys =
 verify:Verification successful!

--- a/test/studies/isx/isx-hand-optimized.perfkeys
+++ b/test/studies/isx/isx-hand-optimized.perfkeys
@@ -11,6 +11,7 @@ bucket count =
 bucket offset =
 bucketize =
 exchange =
+exchange only =
 exchange barrier =
 count keys =
 verify:Verification successful!


### PR DESCRIPTION
Previously the exchange subtimer timed the exchange as well as the barrier.
This adds an extra subtimer to the barrier step, to hopefully allow us to see
if the exchange step is completely in roughly the same amount of time, or if
some tasks are spending more time just waiting for the barrier.