### PR TITLE
fix START_DATE format in test-perf.chapcs.playground.bash

### DIFF
--- a/util/cron/test-perf.chapcs.playground.bash
+++ b/util/cron/test-perf.chapcs.playground.bash
@@ -22,14 +22,14 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.playground"
 # 1) Update GITHUB_USER to the GitHub username owning the branch
 # 2) Update GITHUB_BRANCH to the name of the GitHub branch under that user
 # 3) Update SHORT_NAME to be a short name that will be used in graph generation
-# 4) Update START_DATE to be today
+# 4) Update START_DATE to be today, using the format mm/dd/yy
 #
 
 # Test performance of lowering ForallStmt at lowerIterators
 GITHUB_USER=vasslitvinov
 GITHUB_BRANCH=li
 SHORT_NAME=lower-ForallStmt
-START_DATE=02/23
+START_DATE=02/24/18
 
 git branch -D $GITHUB_USER-$GITHUB_BRANCH
 git checkout -b $GITHUB_USER-$GITHUB_BRANCH


### PR DESCRIPTION
I mistakenly omitted the year in START_DATE in #8556 . Fixing that.

Again bumping START_DATE by 1 as the tests did not run last night.
(The build failed on the branch. That has been fixed.)

Thanks @ronawho for pointing this out.

While there, add the date format to the comment.
(Although that should not be necessary, really.)