### PR TITLE
Default to using CHPL_TASKS=fifo for freebsd

### DIFF
--- a/util/chplenv/chpl_tasks.py
+++ b/util/chplenv/chpl_tasks.py
@@ -28,6 +28,7 @@ def get():
 
         if (platform_val.startswith('cygwin') or
                 platform_val.startswith('netbsd') or
+                platform_val.startswith('freebsd') or
                 using_qthreads_incompatible_cce):
             tasks_val = 'fifo'
         else:


### PR DESCRIPTION
qthreads doesn't currently build on netbsd or freebsd. We defaulted to fifo for
netbsd with https://github.com/chapel-lang/chapel/pull/1244, this just does the same for freebsd.

With this, `vagrant/chapeldefaultcheck.sh` passes on my mac and an ubuntu 17.10
machine. Without it, the freebsd boxes would fail when building qthreads.

Related to https://github.com/chapel-lang/chapel/issues/8531