### PR TITLE
Add a vagrant script to check a "full" Chapel install

### DIFF
--- a/util/devel/test/vagrant/chapelfullcheck.sh
+++ b/util/devel/test/vagrant/chapelfullcheck.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Check if full (util/setchplenv + GMP/RE2) Chapel build passes make check
+# Prints summary at the end
+
+./tryit.sh 'bash -c '\''cd chapel && source util/setchplenv.bash && export CHPL_GMP=gmp && export CHPL_REGEXP=`./util/devel/test/vagrant/re2-supported.py` && export GMAKE=`which gmake` && export MAKE=${GMAKE:-make} && $MAKE && $MAKE check'\'

--- a/util/devel/test/vagrant/provision-scripts/apt-get-deps.sh
+++ b/util/devel/test/vagrant/provision-scripts/apt-get-deps.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 apt-get update
-apt-get install -y git gcc g++ perl python tcsh bash gcc g++ perl python python-dev python-setuptools bash make mawk pkg-config
+apt-get install -y git gcc g++ m4 perl python tcsh bash gcc g++ perl python python-dev python-setuptools bash make mawk pkg-config

--- a/util/devel/test/vagrant/provision-scripts/dnf-deps.sh
+++ b/util/devel/test/vagrant/provision-scripts/dnf-deps.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-dnf -y install git gcc gcc-c++ perl python tcsh bash gcc gcc-c++ perl python python-devel python-setuptools bash make gawk
+dnf -y install git gcc gcc-c++ m4 perl python tcsh bash gcc gcc-c++ perl python python-devel python-setuptools bash make gawk

--- a/util/devel/test/vagrant/provision-scripts/freebsd-pkg-deps.sh
+++ b/util/devel/test/vagrant/provision-scripts/freebsd-pkg-deps.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-pkg install --yes gcc perl5 python py27-setuptools bash gmake gawk git pkgconf
+pkg install --yes gcc m4 perl5 python py27-setuptools bash gmake gawk git pkgconf

--- a/util/devel/test/vagrant/provision-scripts/yum-deps.sh
+++ b/util/devel/test/vagrant/provision-scripts/yum-deps.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-yum -y install git gcc gcc-c++ perl python tcsh bash gcc gcc-c++ perl python python-devel python-setuptools bash make gawk
+yum -y install git gcc gcc-c++ m4 perl python tcsh bash gcc gcc-c++ perl python python-devel python-setuptools bash make gawk

--- a/util/devel/test/vagrant/provision-scripts/zypper-deps.sh
+++ b/util/devel/test/vagrant/provision-scripts/zypper-deps.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-zypper install -y gcc gcc-c++ perl python python-devel python-setuptools bash make gawk tcsh git
+zypper install -y gcc gcc-c++ m4 perl python python-devel python-setuptools bash make gawk tcsh git

--- a/util/devel/test/vagrant/re2-supported.py
+++ b/util/devel/test/vagrant/re2-supported.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+
+import os
+import sys
+
+chplenv_dir = os.path.join(os.path.dirname(__file__), '..', '..', '..', 'chplenv')
+sys.path.insert(0, os.path.abspath(chplenv_dir))
+
+import chpl_compiler
+import compiler_utils
+
+
+# re2 requires c++11 for std atomics (and possibly other features). Use whether
+# std atomics are supported as a rough proxy for whether re2 should build
+compiler_val = chpl_compiler.get('target')
+std_atomics = compiler_utils.has_std_atomics(compiler_val)
+
+sys.stdout.write('re2' if std_atomics else 'none')


### PR DESCRIPTION
This tests the default config, but with CHPL_REGEXP=re2 and CHPL_GMP=gmp
instead of silently ignoring failed speculative builds. Note that this requires
adding m4 to the provision lists. Also note that we only try to build re2 if
the target compiler supports C++11 atomics.

This was originally motivated by trying to test #8169, which added m4 as a
prereq for building GMP.

Related to https://github.com/chapel-lang/chapel/issues/8531