### PR TITLE
Directly create aBarrier classes in the AllLocalesBarrier

### DIFF
--- a/modules/packages/AllLocalesBarriers.chpl
+++ b/modules/packages/AllLocalesBarriers.chpl
@@ -70,10 +70,14 @@ module AllLocalesBarriers {
   class AllLocalesBarrier: BarrierBaseType {
 
     const BarrierSpace = LocaleSpace dmapped Block(LocaleSpace);
-    var globalBarrier: [BarrierSpace] Barrier;
+    var globalBarrier: [BarrierSpace] aBarrier(reusable=true, hackIntoCommBarrier=true);
 
     proc init(numTasksPerLocale: int) {
-      globalBarrier = [b in BarrierSpace] new Barrier(numTasksPerLocale, hackIntoCommBarrier=true);
+      globalBarrier = [b in BarrierSpace] new aBarrier(numTasksPerLocale, reusable=true, hackIntoCommBarrier=true);
+    }
+
+    proc deinit() {
+      [b in globalBarrier] delete b;
     }
 
     proc barrier() {

--- a/modules/standard/Barriers.chpl
+++ b/modules/standard/Barriers.chpl
@@ -110,13 +110,6 @@ module Barriers {
       this.init(0);
     }
 
-    // Hack for AllLocalesBarrier
-    pragma "no doc"
-    proc init(numTasks: int, param hackIntoCommBarrier: bool) {
-      bar = new aBarrier(numTasks, reusable=true, hackIntoCommBarrier=true);
-      owned = true;
-    }
-
     /* copy initializer */
     pragma "no doc"
     proc init(b: Barrier) {
@@ -226,6 +219,7 @@ module Barriers {
     pragma "no doc"
     var done: chpl__processorAtomicType(bool);
 
+    // Hack for AllLocalesBarrier
     pragma "no doc"
     param hackIntoCommBarrier = false;
 
@@ -239,6 +233,7 @@ module Barriers {
       reset(n);
     }
 
+    // Hack for AllLocalesBarrier
     pragma "no doc"
     proc init(n: int, param reusable: bool, param hackIntoCommBarrier: bool) {
       this.reusable = reusable;


### PR DESCRIPTION
Instead of using the record wrapper, directly create the atomic barrier class.
This should avoid any potential dynamic dispatch, which was causing an issue
for --baseline testing.

Avoiding dynamic dispatch also slightly improves the performance of this
barrier, though not significantly since a majority of the time is spent
communicating. For the 16-node micro-benchmark that does 100,000 barriers this
this shaves a 1/3 of a second off (6.5s -> 6.2s)