### PR TITLE
skipif for lineno-memLeaks on baseline

### DIFF
--- a/test/memory/psahabu/lineno-memLeaks.skipif
+++ b/test/memory/psahabu/lineno-memLeaks.skipif
@@ -1,0 +1,1 @@
+COMPOPTS <= --baseline


### PR DESCRIPTION
#8548 introduced a test that fails under baseline, likely due to improper inlining. This PR introduces a `.skipif` when running `start_test` and compiling with `--baseline`.