### PR TITLE
[W.I.P] Atomic Object using CMPXCHG16B

### DIFF
--- a/test/expressions/AtomicObject/atomicObjectTest.chpl
+++ b/test/expressions/AtomicObject/atomicObjectTest.chpl
@@ -1,0 +1,5 @@
+class O {
+	var x : int;
+}
+var o : atomic O;
+writeln(o.read());

--- a/test/expressions/AtomicObject/atomicObjectTest.chpl
+++ b/test/expressions/AtomicObject/atomicObjectTest.chpl
@@ -2,4 +2,6 @@ class O {
 	var x : int;
 }
 var o : atomic O;
+o.write(new O(1));
 writeln(o.read());
+


### PR DESCRIPTION
Beginning of PR for support for `atomic` types on objects using Intel's `CMPXCHG16B`. I have added three functions to the runtime, `Write128`, `Read128` and `CAS128`, as well as the beginning of a new type `atomic_object` which is generic. @mppf 

- [ ] Implement `atomic_object` type
   - [x] Atomic Load
      - [x] Implement `Read128` in runtime
      - [x] Implement `read` for `atomic_object`
   - [x] Atomic Store
      - [x] Implement `Write128` in runtime
      - [x] Implement `write` for `atomic_object`
   - [ ] Atomic CompareExchange
      - [x] Implement `CAS128` in runtime
      - [ ] Implement `compareExchange` for `atomic_object`
   - [ ] Atomic Exchange
      - [ ] Implement `Exchange128` in runtime
      - [ ] Implement `exchange` for `atomic_object`