### PR TITLE
Do not flag "weakly"-recursive iterators

### DIFF
--- a/compiler/resolution/lowerIterators.cpp
+++ b/compiler/resolution/lowerIterators.cpp
@@ -247,6 +247,12 @@ static bool find_recursive_caller(FnSymbol* fn, FnSymbol* iter, Vec<FnSymbol*>& 
     if (caller == iter)
       return true;
 
+    // Ignore recursion through non-iterators.
+    if (!(caller->isIterator() ||
+          caller->retType->symbol->hasFlag(FLAG_ITERATOR_RECORD) ||
+          isTaskFun(caller)))
+      continue;
+
     // Otherwise, search recursively up the call chain.
     // If recursion was detected, no further searching is required.
     if (find_recursive_caller(caller, iter, fnSet))


### PR DESCRIPTION
find_recursive_caller() in lowerIterators.cpp used to cause FLAG_RECURSIVE_ITERATOR on iterators that are recursive through non-iterator calls. For example, i1() and i2() got this flag in the following example:

```chpl
  iter i1() {
    for i2() do ...;
  }

  iter i2 {
    foo();
    yield ...;
  }

  proc foo() {
    for i1() do ...;
  }
```

For the purposes of lowerIterators, however, this is not necessary. For example of the above example, i1() and i2() can be inlined into foo(). This will make foo() call itself recursively. However, it will not require us to resort to recursive-iterator implementation machinery.

As a real-life example, a BlockDist array leader iterator used to be considered "recursive", at least under gasnet.

This change eliminates FLAG_RECURSIVE_ITERATOR in cases like this, allowing us to use non-recursive-iterator implementation in more cases. Which hopefully simplifies the generated code.

Testing passes: linux64 --verify, gasnet, baseline.