### PR TITLE
Add test showing surprising ambiguity when adding enum to uint(8)

### DIFF
--- a/test/types/enum/addEnumUint8.bad
+++ b/test/types/enum/addEnumUint8.bad
@@ -1,0 +1,2 @@
+addEnumUint8.chpl:7: error: ambiguous call '+(E, 1)'
+(prediff deleted module lines)

--- a/test/types/enum/addEnumUint8.chpl
+++ b/test/types/enum/addEnumUint8.chpl
@@ -1,0 +1,7 @@
+enum E {a=1};
+param Ea = 1;
+param one8 = 1:uint(8);
+
+writeln((Ea+one8).type:string);
+writeln((E.a:int(64)+one8).type:string);
+writeln((E.a+one8).type:string);

--- a/test/types/enum/addEnumUint8.future
+++ b/test/types/enum/addEnumUint8.future
@@ -1,0 +1,5 @@
+adding enums to uint(8)s works in a surprising manner
+
+Generally, we treat enums like int(8)s and enum values as param
+int(8)s.  However, this test shows a case in which they are not
+treated equivalently which seems surprising.

--- a/test/types/enum/addEnumUint8.good
+++ b/test/types/enum/addEnumUint8.good
@@ -1,0 +1,3 @@
+uint(8)
+uint(8)
+uint(8)

--- a/test/types/enum/addEnumUint8.prediff
+++ b/test/types/enum/addEnumUint8.prediff
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+output=$2
+cat $output | sed '/^\$CHPL_HOME\/modules\// d' > $output.tmp
+echo "(prediff deleted module lines)" >> $output.tmp
+mv $output.tmp $output

--- a/test/types/enum/enumsLikeParams.chpl
+++ b/test/types/enum/enumsLikeParams.chpl
@@ -1,0 +1,17 @@
+enum color {red, green, blue};
+
+proc foo(x: int(64)) {
+  writeln("In normal version");
+}
+
+proc foo(param x: int(64)) {
+  writeln("In param version");
+}
+
+foo(color.red);   // calls param version
+
+var hue: color;
+foo(hue);         // calls normal version
+
+param shade: color = color.green;
+foo(shade);       // calls param version

--- a/test/types/enum/enumsLikeParams.good
+++ b/test/types/enum/enumsLikeParams.good
@@ -1,0 +1,3 @@
+In param version
+In normal version
+In param version


### PR DESCRIPTION
This test demonstrates that adding an enum and a uint(8) behaves
differently than adding a param int(64) and a uint(8) in spite
of the fact that we typically treat enums like param int(64)s.

While here, I also added a test that demonstrates that, by and large,
enums do act like int(64)s.

In filing these, I want to note that there's email discussion regarding
making enums not coerce to ints automatically for safety/sanity
reasons (which will hopefully soon move from email into an issue)
and that if we pursued that path, these tests would need to be
updated or potentially just retired.