### PR TITLE
Move code to determine the virtualenv dir into chpl_home_utils

### DIFF
--- a/util/chplenv/chpl_home_utils.py
+++ b/util/chplenv/chpl_home_utils.py
@@ -5,7 +5,7 @@ import sys
 chplenv_dir = os.path.dirname(__file__)
 sys.path.insert(0, os.path.abspath(chplenv_dir))
 
-import overrides
+import chpl_platform, chpl_python_version, overrides
 from utils import memoize
 
 
@@ -22,6 +22,24 @@ def get_chpl_third_party():
     default = os.path.join(get_chpl_home(), 'third-party')
     chpl_third_party = overrides.get('CHPL_THIRD_PARTY', default)
     return chpl_third_party
+
+# Get the chpl-venv install directory:
+# $CHPL_HOME/third-party/chpl-venv/install/$CHPL_HOST_PLATFORM/$py_version/chpl-virtualenv
+@memoize
+def get_chpl_venv():
+    chpl_venv = os.path.join(get_chpl_third_party(), 'chpl-venv')
+    host_platform = chpl_platform.get('host')
+    py_version = 'py{0}'.format(chpl_python_version.get())
+    uniq_path = os.path.join(host_platform, py_version)
+    venv_dir = os.path.join(chpl_venv, 'install', uniq_path, 'chpl-virtualenv')
+    return venv_dir
+
+# Get the test chpl-venv directory. Defaults to get_chpl_venv(), but can be
+# overridden with CHPL_TEST_VENV_DIR
+@memoize
+def get_chpl_test_venv():
+    venv_dir = os.getenv('CHPL_TEST_VENV_DIR', get_chpl_venv())
+    return venv_dir
 
 @memoize
 def using_chapel_module():

--- a/util/test/activate_chpl_test_venv.py
+++ b/util/test/activate_chpl_test_venv.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
-
 import os
 import sys
 
@@ -11,42 +9,28 @@ sys.path.insert(0, os.path.abspath(chplenv_dir))
 from chplenv import chpl_home_utils
 from chplenv import chpl_make
 
-# Activate a virtualenv that has testing infrastructure requirements installed
-#
-# By default, we will try to use
-#   $CHPL_HOME/third-party/chpl-venv/install/$CHPL_HOST_PLATFORM/$python_version_dir/chpl-virtualenv
-# as our virtualenv. We then check for a sentinel file that test-venv
-# creates when it's been successfully installed and finally activate
-# the virtualenv.
-#
-# A user can also set CHPL_TEST_VENV_DIR to specify the path to a custom
-# virtualenv that will be activated. "none" is a special value that means skip
-# activating a virtualenv. If CHPL_TEST_VENV_DIR is set, a user is asserting
-# that their virtualenv or local install has the requirements available.
-#
-# Note that this method does not allow us to specify python versions to use and
-# instead will use the system default. Long term we probably want to have a
-# wrapper script that activates the virtualenv and just calls start_test.
-
 def error(message):
-    print('[Error: {0}]'.format(message))
+    sys.stdout.write('[Error: {0}]\n'.format(message))
     exit(1)
 
-def activate_venv():
+def log(message):
+    sys.stdout.write('[{0}]\n'.format(message))
 
+# Activate a virtualenv that has testing infrastructure requirements installed
+def activate_venv():
     venv_dir = chpl_home_utils.get_chpl_test_venv()
     default_venv_dir = chpl_home_utils.get_chpl_venv()
 
     # user asserts that system already has the required dependencies installed:
     if venv_dir == 'none':
-        print('[Skipping virtualenv activation because venv_dir={0}. test-venv '
-              'requirements must be available.]'.format(venv_dir))
+        log('Skipping virtualenv activation because CHPL_TEST_VENV_DIR={0}. '
+            'test-venv requirements must be available.'.format(venv_dir))
 
     else:
         # using custom venv, does not check that our test requirements are met
         if venv_dir != default_venv_dir:
-            print('[Using custom virtualenv because venv_dir={1}. test-venv '
-                  'requirements must be available]'.format(venv_dir))
+            log('Using custom virtualenv because CHPL_TEST_VENV_DIR={0}. '
+                'test-venv requirements must be available'.format(venv_dir))
 
         # check Chapel test-venv for successful installation sentinel
         else:

--- a/util/test/activate_chpl_test_venv.py
+++ b/util/test/activate_chpl_test_venv.py
@@ -9,7 +9,6 @@ chplenv_dir = os.path.join(os.path.dirname(__file__), '..')
 sys.path.insert(0, os.path.abspath(chplenv_dir))
 
 from chplenv import chpl_home_utils
-from chplenv import chpl_platform
 from chplenv import chpl_make
 
 # Activate a virtualenv that has testing infrastructure requirements installed
@@ -35,38 +34,26 @@ def error(message):
 
 def activate_venv():
 
-    custom_venv_dir_var = 'CHPL_TEST_VENV_DIR'
-    custom_venv_dir = os.getenv(custom_venv_dir_var, '').strip()
+    venv_dir = chpl_home_utils.get_chpl_test_venv()
+    default_venv_dir = chpl_home_utils.get_chpl_venv()
 
     # user asserts that system already has the required dependencies installed:
-    if custom_venv_dir == 'none':
-        print('[Skipping virtualenv activation because {0}={1}. test-venv '
-              'requirements must be available.]'.format(custom_venv_dir_var,
-              custom_venv_dir))
+    if venv_dir == 'none':
+        print('[Skipping virtualenv activation because venv_dir={0}. test-venv '
+              'requirements must be available.]'.format(venv_dir))
 
     else:
-        venv_dir = None
-
         # using custom venv, does not check that our test requirements are met
-        if custom_venv_dir:
-            venv_dir = custom_venv_dir
-            print('[Using custom  virtualenv because {0}={1}. test-venv '
-                  'requirements must be available]'.format(custom_venv_dir_var,
-                  custom_venv_dir))
+        if venv_dir != default_venv_dir:
+            print('[Using custom virtualenv because venv_dir={1}. test-venv '
+                  'requirements must be available]'.format(venv_dir))
 
         # check Chapel test-venv for successful installation sentinel
         else:
-            chpl_home = os.path.join(chpl_home_utils.get_chpl_home(), '')
-            third_party = os.path.join(chpl_home, 'third-party')
-            host_platform = chpl_platform.get('host')
-            python_version_dir  = 'py{0}.{1}'.format(sys.version_info[0], sys.version_info[1])
-
-            venv_dir = os.path.join(third_party, 'chpl-venv', 'install',
-                                    host_platform, python_version_dir, 'chpl-virtualenv')
             sentinel_file = os.path.join(venv_dir, 'chpl-test-reqs')
             if not os.path.isfile(sentinel_file):
-                error('Chapel test virtualenv is not available, run `{0} '
-                      'test-venv` from {1}'.format(chpl_make.get(), chpl_home))
+                error('Chapel test virtualenv not available, run a top-level '
+                      '`{0} test-venv`'.format(chpl_make.get()))
 
         activation_file = os.path.join(venv_dir, 'bin', 'activate_this.py')
         if not os.path.isfile(activation_file):


### PR DESCRIPTION
Instead of hard-coding it in activate_chpl_test_venv.py, move it into a common
location so that we can use it in other scripts. This is motivated by wanting
to activate the venv in a script that will do start_test tab-completion.
