### PR TITLE
Fix c2chapel: change source to . for ubuntu systems

### DIFF
--- a/tools/c2chapel/c2chapel
+++ b/tools/c2chapel/c2chapel
@@ -21,6 +21,6 @@
 
 PREFIX=$CHPL_HOME/tools/c2chapel
 
-source ${PREFIX}/install/venv/bin/activate
+. ${PREFIX}/install/venv/bin/activate
 
 exec ${PREFIX}/c2chapel.py "${@}"


### PR DESCRIPTION
On Ubuntu systems, /bin/sh points to dash, which does not have `source` (see https://wiki.ubuntu.com/DashAsBinSh). This pull request simply switches `source` to `.`.