### PR TITLE
Add start_test tab completion support

### DIFF
--- a/third-party/chpl-venv/test-requirements.txt
+++ b/third-party/chpl-venv/test-requirements.txt
@@ -2,3 +2,4 @@ subprocess32==3.2.6
 argparse==1.3.0
 PyYAML==3.11
 filelock==2.0.13
+argcomplete==1.9.4

--- a/util/devel/chpl-scripts-completion.bash
+++ b/util/devel/chpl-scripts-completion.bash
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
+venv_path=$(python "$CWD/../chplenv/chpl_home_utils.py" --test-venv)
+
+register_argcomplete="register-python-argcomplete"
+if [[ "$venv_path" != "none" && -d "$venv_path" ]]; then
+  register_argcomplete="$venv_path/bin/$register_argcomplete"
+fi
+
+# Register any python scripts that use argparse/argcomplete
+if [ -x "$(command -v $register_argcomplete)" ]; then
+  eval "$($register_argcomplete start_test)"
+fi

--- a/util/start_test
+++ b/util/start_test
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# PYTHON_ARGCOMPLETE_OK
 #
 # CHAPEL TESTING
 
@@ -27,6 +28,10 @@ from chplenv import *
 
 from test import activate_chpl_test_venv
 import argparse
+try:
+    import argcomplete
+except ImportError:
+    argcomplete = None
 import subprocess32 as subprocess
 
 # PROGRAM ENTRY POINT
@@ -35,6 +40,8 @@ def main():
 
     # set up the parser and parse command-line arguments
     parser = parser_setup()
+    if argcomplete:
+        argcomplete.autocomplete(parser)
     global args
     preprocess_options()
     args = parser.parse_args()


### PR DESCRIPTION
Use argcomplete to provide tab completion for start_test. argcomplete hooks
into python scripts and dynamically executes them to determine a list a
completion hooks. This adds a little overhead to completions because the python
interpreter has to be spun up, but it avoids having to manually create/maintain
completions files like we do for the compiler.

To enable tab completion you should just be able to source:
$CHPL_HOME/util/devel/chpl-scripts-completion.bash

Related to https://github.com/chapel-lang/chapel/issues/5348