### PR TITLE
Stop hard-coding path to virtualenv dir in the man Makefile

### DIFF
--- a/man/Makefile
+++ b/man/Makefile
@@ -9,9 +9,9 @@ MANPAGE = man1/$(PROGRAM).1
 CHPLDOC_MANPAGE = man1/$(CHPLDOC).1
 TARGETS = $(MANPAGE) $(PROGRAM).pdf $(CHPLDOC).pdf
 
-PYTHON_VERSION_DIR = py$(shell $(CHPL_MAKE_HOME)/util/chplenv/chpl_python_version.py)
+VENV_DIR = $(shell python $(CHPL_MAKE_HOME)/util/chplenv/chpl_home_utils.py --venv)
 
-RST2MAN = $(shell which rst2man.py || echo $(CHPL_MAKE_HOME)/third-party/chpl-venv/install/*/$(PYTHON_VERSION_DIR)/chpl-virtualenv/bin/rst2man.py)
+RST2MAN = $(shell which rst2man.py || echo $(VENV_DIR)/bin/rst2man.py)
 
 STARS = \*\*\*\*\*
 


### PR DESCRIPTION
Use the new common helper routines.