### PR TITLE
Change `pip` to `python -m pip` in ZMQ PREEXEC

### DIFF
--- a/test/library/packages/ZMQ/interop-py/PREEXEC
+++ b/test/library/packages/ZMQ/interop-py/PREEXEC
@@ -3,6 +3,6 @@
 if [[ ! -f pyzmq-venv/bin/activate ]] ; then
     virtualenv pyzmq-venv
     source pyzmq-venv/bin/activate
-    pip install -r requirements.txt
+    python -m pip install -r requirements.txt
     deactivate
 fi


### PR DESCRIPTION
`pip` executable was failing to execute if the shebang string was longer
than 128 characters on linux. Switching to the pip library call via `python -m pip` circumvents this issue.

Closes #8668

- [x] Tested on linux64