### PR TITLE
Improve start_test tab completion suggestions

### DIFF
--- a/util/start_test
+++ b/util/start_test
@@ -1262,7 +1262,10 @@ def help_all(help_msg):
 def parser_setup():
     parser = argparse.ArgumentParser(description="Test Chapel code.")
     # main args
-    parser.add_argument("tests", nargs="*", help="test files or directories")
+    p = parser.add_argument("tests", nargs="*", help="test files or directories")
+    if argcomplete:
+        p.completer = argcomplete.completers.FilesCompleter([".chpl", ".test.c"])
+
     # executing options
     parser.add_argument("-execopts", "--execopts", action="append", 
             dest="execopts", help="set options for executing tests")
@@ -1318,9 +1321,12 @@ def parser_setup():
     # performance
     parser.add_argument("-performance", "--performance", action="store_true",
             dest="performance", help="run performance tests")
-    parser.add_argument("-perflabel", "--perflabel", action="store",
-            default="perf", dest="perflabel",
-            help="set alternate performance test label")
+    p = parser.add_argument("-perflabel", "--perflabel", action="store",
+               default="perf", dest="perflabel",
+               help="set alternate performance test label")
+    if argcomplete:
+        p.completer = argcomplete.completers.ChoicesCompleter(('ml-', ))
+
     parser.add_argument("-performance-description",
             "--performance-description", action="store", default="",
             dest="performance_description", help=help_all(""))

--- a/util/start_test
+++ b/util/start_test
@@ -1251,6 +1251,14 @@ def jUnit():
 
 # PARSER
 
+
+def help_all(help_msg):
+    if any("help-all" in s for s in sys.argv):
+        return help_msg
+    else:
+        return argparse.SUPPRESS
+
+
 def parser_setup():
     parser = argparse.ArgumentParser(description="Test Chapel code.")
     # main args
@@ -1260,7 +1268,7 @@ def parser_setup():
             dest="execopts", help="set options for executing tests")
     # compiler
     parser.add_argument("-compiler", "--compiler", action="store",
-            dest="compiler", help="set alternate compiler")
+            dest="compiler", help=help_all("set alternate compiler"))
     # program launch utility
     parser.add_argument("-launchcmd", "--launchcmd", action="store",
             dest="launch_cmd", default=os.getenv("CHPL_TEST_LAUNCHCMD", ""),
@@ -1315,17 +1323,17 @@ def parser_setup():
             help="set alternate performance test label")
     parser.add_argument("-performance-description",
             "--performance-description", action="store", default="",
-            dest="performance_description")
+            dest="performance_description", help=help_all(""))
     parser.add_argument("-performance-configs", "--performance-configs",
             "-performance-configurations", "--performance-configurations",
             action="store", dest="performance_configs",
-            help="set performance configurations")
+            help=help_all("set performance configurations"))
     parser.add_argument("-compperformance", "--compperformance",
             action="store_true", dest="comp_performance",
-            help="test compiler performance")
+            help=help_all("test compiler performance"))
     parser.add_argument("-compperformance-description",
             "--compperformance-description", action="store", default="",
-            dest="comp_performance_description")
+            dest="comp_performance_description", help=help_all(""))
     parser.add_argument("-numtrials", "--numtrials", "-num-trials",
         "--num-trials", action="store", dest="num_trials",
         default=os.getenv("CHPL_TEST_NUM_TRIALS", "1"),
@@ -1333,22 +1341,22 @@ def parser_setup():
     # graphing
     parser.add_argument("-gen-graphs", "--gen-graphs", "-generate-graphs",
             "--generate-graphs", action="store_true", dest="gen_graphs",
-            help="only generate graphs, don't run tests")
+            help=help_all("only generate graphs, don't run tests"))
     parser.add_argument("-nodisplaygraphrange", "--nodisplaygraphrange",
             "-no-display-graph-range", "--no-display-graph-range",
             action="store_false", dest="graphs_disp_range",
-            help="don't display trial range envelopes on the graphs")
+            help=help_all("don't display trial range envelopes ongraphs"))
     parser.add_argument("-graphsgendefault", "--graphsgendefault",
             "-graphs-gen-default", "--graphs-gen-default", action="store",
             choices=["avg", "min", "max", "med"], default="avg",
             dest="graphs_gen_default",
-            help="set default method to reduce multiple trials")
+            help=help_all("set default method to reduce multiple trials"))
     parser.add_argument("-startdate", "--startdate", action="store",
             dest="start_date", metavar="<MM/DD/YY>", 
             help="set graph start date")
     parser.add_argument("-gengraphopts", "--gengraphopts", "-genGraphOpts",
             "--genGraphOpts", action="store", dest="gen_graph_opts",
-            default="", help="set additional graph generation options")
+            default="", help=help_all("set additional graph gen options"))
     # only compile
     parser.add_argument("-comp-only", "--comp-only", action="store_true",
             dest="comp_only", help="only compile the tests, don't run")
@@ -1367,35 +1375,37 @@ def parser_setup():
     # stdin redirect
     parser.add_argument("-nostdinredirect", "--nostdinredirect",
             action="store_true", dest="no_stdin_redirect",
-            help="run the tests without redirecting stdin from /dev/null")
+            help=help_all("don't redirect stdin from /dev/null"))
     parser.add_argument("-stdinredirect", "--stdinredirect",
             action="store_true", dest="stdin_redirect",
-            help="force stdin redirection from /dev/null")
+            help=help_all("force stdin redirection from /dev/null"))
     # launcher timeout
     parser.add_argument("-launchertimeout", "--launchertimeout", 
             action="store", dest="launcher_timeout",
-            help="rely on the launcher to enforce the timeout, not timedexec")
+            help=help_all("rely on the launcher to enforce the timeout"))
     # no chpl home warning
     parser.add_argument("-no-chpl-home-warn", "--no-chpl-home-warn",
             action="store_false", dest="chpl_home_warn",
-            help="don't warn about not starting in CHPL_HOME")
+            help=help_all("don't warn about not starting in CHPL_HOME"))
     # progress
     parser.add_argument("-progress", "--progress", action="store_true",
-            dest="progress", help="Log pass/fail for each test to stderr")
+            dest="progress", help=help_all("Log pass/fail for each test"))
     # test root
     parser.add_argument("-test-root", "--test-root", action="store",
-        dest="test_root_dir", help="set absolute path to test directory")
+        dest="test_root_dir", help=help_all("set abs path to test directory"))
     # jUnit
     parser.add_argument("-junit-xml", "--junit-xml", action="store_true",
-            dest="junit_xml", help="create jUnit XML report")
+            dest="junit_xml", help=help_all("create jUnit XML report"))
     parser.add_argument("-junit-xml-file", "--junit-xml-file", action="store",
             dest="junit_xml_file", metavar="<file>",
-            help="set the path to store the jUnit XML report")
+            help=help_all("set the path to store the jUnit XML report"))
     parser.add_argument("-junit-remove-prefix", "--junit-remove-prefix",
             action="store", dest="junit_remove_prefix", metavar="<prefix>",
-            help="set the <prefix> to remove from tests in the jUnit report")
+            help=help_all("<prefix> to remove from tests in jUnit report"))
     # extra help
     parser.add_argument("-help", action="help", help=argparse.SUPPRESS)
+    parser.add_argument("--help-all", action="help",
+            help="show all options, including ones meant for other scripts")
 
     return parser
 


### PR DESCRIPTION
Only show useful "developer" oriented flags, and only suggest .chpl and .test.c
files. This hides the following flags from start_test completion:

 --compiler
 --performance-description
 --performance-configurations
 --compperformance
 --gen-graphs
 --nodisplaygraphrange
 --graphsgendefault
 --gengraphopts
 --nostdinredirect
 --stdinredirect
 --launchertimeout
 --no-chpl-home-warn
 --progress
 --test-root
 --junit-xml
 --junit-xml-file
 --junit-remove-prefix
