### PR TITLE
Fix sporadic chpldoc failure from #8672

### DIFF
--- a/compiler/passes/docs.cpp
+++ b/compiler/passes/docs.cpp
@@ -305,7 +305,7 @@ void generateSphinxOutput(std::string sphinxDir, std::string outputDir) {
   // Set the PATH and VIRTUAL_ENV variables in the environment. The values are
   // based on the install path in the third-party/chpl-venv/ dir.
 
-  const char * venvDir = getVenvDir().c_str();
+  const char * venvDir = astr(getVenvDir().c_str());
   const char * venvBinDir = astr(venvDir, "/bin");
   const char * sphinxBuild = astr("sphinx-build");
 


### PR DESCRIPTION
Re-add an `astr()` call that I mistakenly removed in #8672. This was causing
sporadic chpldoc failures for some developers. I haven't been able to reproduce
the failure myself, but Mike has confirmed that this resolves it for him.