### PR TITLE
Dispatch foo

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -333,7 +333,7 @@ static int computeMaxSubclass(TypeSymbol* ts, std::vector<int>& n2) {
     int            myId  = at->classId;
     int            maxN1 = myId;
 
-    forv_Vec(Type, child, at->dispatchChildren) {
+    forv_Vec(AggregateType, child, at->dispatchChildren) {
       if (child != NULL) {
         int subMax = computeMaxSubclass(child->symbol, n2);
 

--- a/compiler/codegen/type.cpp
+++ b/compiler/codegen/type.cpp
@@ -269,7 +269,8 @@ void AggregateType::codegenDef() {
         /* Add a comment to class definitions listing super classes */
         bool first = true;
         fprintf(outfile, " /* : ");
-        forv_Vec(Type, parent, dispatchParents) {
+
+        forv_Vec(AggregateType, parent, dispatchParents) {
           if (parent) {
             if (!first) {
               fprintf(outfile, ", ");

--- a/compiler/passes/InitNormalize.cpp
+++ b/compiler/passes/InitNormalize.cpp
@@ -1136,11 +1136,9 @@ DefExpr* InitNormalize::toSuperField(SymExpr* expr) const {
 
 DefExpr* InitNormalize::toSuperField(AggregateType* at,
                                      const char*    name) const {
-  forv_Vec(Type, t, at->dispatchParents) {
-    if (AggregateType* pt = toAggregateType(t)) {
-      if (DefExpr* field = pt->toLocalField(name)) {
-        return field;
-      }
+  forv_Vec(AggregateType, pt, at->dispatchParents) {
+    if (DefExpr* field = pt->toLocalField(name)) {
+      return field;
     }
   }
 

--- a/compiler/passes/initializerRules.cpp
+++ b/compiler/passes/initializerRules.cpp
@@ -910,11 +910,9 @@ static DefExpr* toLocalField(AggregateType* at, CallExpr* expr);
 static DefExpr* fieldByName(AggregateType* at, const char* name);
 
 static DefExpr* toSuperFieldInit(AggregateType* at, CallExpr* callExpr) {
-  forv_Vec(Type, t, at->dispatchParents) {
-    if (AggregateType* pt = toAggregateType(t)) {
-      if (DefExpr* field = toLocalFieldInit(pt, callExpr)) {
-        return field;
-      }
+  forv_Vec(AggregateType, pt, at->dispatchParents) {
+    if (DefExpr* field = toLocalFieldInit(pt, callExpr)) {
+      return field;
     }
   }
 

--- a/compiler/resolution/callDestructors.cpp
+++ b/compiler/resolution/callDestructors.cpp
@@ -839,7 +839,7 @@ fixupDestructors() {
       INT_ASSERT(ct->dispatchParents.n <= 1);
 
       if (ct->dispatchParents.n == 1 && isClass(ct) == true) {
-        Type* parType = ct->dispatchParents.v[0];
+        AggregateType* parType = ct->dispatchParents.v[0];
 
         if (FnSymbol* parDestructor = parType->getDestructor()) {
           SET_LINENO(fn);

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -644,7 +644,7 @@ Type* getConcreteParentForGenericFormal(Type* actualType, Type* formalType) {
   Type* retval = NULL;
 
   if (AggregateType* at = toAggregateType(actualType)) {
-    forv_Vec(Type, parent, at->dispatchParents) {
+    forv_Vec(AggregateType, parent, at->dispatchParents) {
       if (isInstantiation(parent, formalType) == true) {
         retval = parent;
         break;
@@ -1833,15 +1833,18 @@ static void collectVisibleMethodsNamed(Type*                   t,
     }
 
     size_t maxChildMethods = methods.size();
+
     // Collect also methods from a parent class type
-    forv_Vec(Type, parent, at->dispatchParents) {
+    forv_Vec(AggregateType, parent, at->dispatchParents) {
       collectVisibleMethodsNamed(parent, nameAstr, methods);
     }
+
     // Filter out methods any of the parent methods
     // that have a signature match with the child's methods.
     // Such methods represent overrides with inheritance.
     for (size_t i = maxChildMethods; i < methods.size(); i++) {
       bool remove = false;
+
       for (size_t j = 0; j < maxChildMethods; j++) {
         if (methods[i] != NULL &&
             methods[j] != NULL &&
@@ -1850,8 +1853,10 @@ static void collectVisibleMethodsNamed(Type*                   t,
           break;
         }
       }
-      if (remove)
+
+      if (remove) {
         methods[i] = NULL;
+      }
     }
   }
 }

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -8618,11 +8618,7 @@ static bool isUnusedClass(AggregateType* ct) {
     retval = false;
 
   } else {
-    forv_Vec(Type, child, ct->dispatchChildren) {
-      AggregateType* childClass = toAggregateType(child);
-
-      INT_ASSERT(childClass);
-
+    forv_Vec(AggregateType, childClass, ct->dispatchChildren) {
       if (isUnusedClass(childClass) == false) {
         retval = false;
         break;

--- a/compiler/resolution/tuples.cpp
+++ b/compiler/resolution/tuples.cpp
@@ -381,7 +381,7 @@ TupleInfo getTupleInfo(std::vector<TypeSymbol*>& args,
 
     newType->instantiatedFrom = dtTuple;
 
-    forv_Vec(Type, t, dtTuple->dispatchParents) {
+    forv_Vec(AggregateType, t, dtTuple->dispatchParents) {
       AggregateType* at = toAggregateType(t);
 
       INT_ASSERT(at != NULL);


### PR DESCRIPTION
Minor tweaks for dispatchParents[] and dispatchChildren[]

Earlier in this release we migrated dispatchParents[] and dispatchParents[]
from Type to AggregateType and altered the element type from Type* to
AggregateType*.

This PR updates a handful of uses of these vectors to remove legacy
dynamic downcasts from Type* to AggregateType*.

Compiled in the conventional ways.  Tested in the conventional ways.
