### PR TITLE
Fix locale model init phase violations

### DIFF
--- a/modules/internal/localeModels/apu/LocaleModel.chpl
+++ b/modules/internal/localeModels/apu/LocaleModel.chpl
@@ -136,9 +136,9 @@ module LocaleModel {
   //
   class LocaleModel : AbstractLocaleModel {
     const _node_id : int;
-    const local_name : string;
+    var local_name : string; // should never be modified after first assignment
 
-    const numSublocales: int;
+    var numSublocales: int; // should never be modified after first assignment
     var GPU: GPULocale;
     var CPU: CPULocale;
 
@@ -150,6 +150,10 @@ module LocaleModel {
       if doneCreatingLocales {
         halt("Cannot create additional LocaleModel instances");
       }
+      _node_id = chpl_nodeID: int;
+
+      super.init();
+
       setup();
     }
 
@@ -157,7 +161,10 @@ module LocaleModel {
       if doneCreatingLocales {
         halt("Cannot create additional LocaleModel instances");
       }
+      _node_id = chpl_nodeID: int;
+
       super.init(parent_loc);
+
       setup();
     }
 
@@ -214,8 +221,6 @@ module LocaleModel {
     //- Implementation (private)
     //-
     proc setup() {
-      _node_id = chpl_nodeID: int;
-
       helpSetupLocaleAPU(this, local_name, numSublocales);
     }
     //------------------------------------------------------------------------}

--- a/modules/internal/localeModels/flat/LocaleModel.chpl
+++ b/modules/internal/localeModels/flat/LocaleModel.chpl
@@ -57,7 +57,7 @@ module LocaleModel {
   //
   class LocaleModel : AbstractLocaleModel {
     const _node_id : int;
-    const local_name : string;
+    var local_name : string; // should never be modified after first assignment
 
     // This constructor must be invoked "on" the node
     // that it is intended to represent.  This trick is used
@@ -67,6 +67,10 @@ module LocaleModel {
       if doneCreatingLocales {
         halt("Cannot create additional LocaleModel instances");
       }
+      _node_id = chpl_nodeID: int;
+
+      super.init();
+
       setup();
     }
 
@@ -74,7 +78,10 @@ module LocaleModel {
       if doneCreatingLocales {
         halt("Cannot create additional LocaleModel instances");
       }
+      _node_id = chpl_nodeID: int;
+
       super.init(parent_loc);
+
       setup();
     }
 
@@ -142,8 +149,6 @@ module LocaleModel {
     //- Implementation (private)
     //-
     proc setup() {
-      _node_id = chpl_nodeID: int;
-
       helpSetupLocaleFlat(this, local_name);
     }
     //------------------------------------------------------------------------}

--- a/modules/internal/localeModels/knl/LocaleModel.chpl
+++ b/modules/internal/localeModels/knl/LocaleModel.chpl
@@ -233,8 +233,8 @@ module LocaleModel {
   class NumaDomain : AbstractLocaleModel {
     const sid : chpl_sublocID_t;
     const ndName : string; // note: locale provides `proc name`
-    const ddr : MemoryLocale;
-    const hbm : MemoryLocale;
+    var ddr : MemoryLocale; // should never be modified after first assignment
+    var hbm : MemoryLocale; // should never be modified after first assignment
 
     proc chpl_id() return parent.chpl_id(); // top-level node id
     proc chpl_localeid() {
@@ -271,6 +271,9 @@ module LocaleModel {
       sid = packSublocID(numSublocales, _sid, defaultMemoryKind())
               : chpl_sublocID_t;
       ndName = "ND"+_sid;
+
+      super.init(_parent);
+
       ddr = new MemoryLocale(sid, this);
 
       var hbm_available = (hbw_check_available() == 0);
@@ -287,8 +290,6 @@ module LocaleModel {
       hbm = new MemoryLocale(hbm_id, this);
 
       chpl_task_setSubloc(origSubloc);
-
-      super.init(_parent);
     }
 
     proc deinit() {
@@ -324,11 +325,11 @@ module LocaleModel {
   //
   class LocaleModel : AbstractLocaleModel {
     const _node_id : int;
-    const local_name : string;
-    const ddr : MemoryLocale;
-    const hbm : MemoryLocale;
+    var local_name : string; // should never be modified after first assignment
+    var ddr : MemoryLocale; // should never be modified after first assignment
+    var hbm : MemoryLocale; // should never be modified after first assignment
 
-    const numSublocales: int;
+    var numSublocales: int; // should never be modified after first assignment
     var childSpace: domain(1);
     var childLocales: [childSpace] NumaDomain;
 
@@ -340,6 +341,10 @@ module LocaleModel {
       if doneCreatingLocales {
         halt("Cannot create additional LocaleModel instances");
       }
+      _node_id = chpl_nodeID: int;
+
+      super.init();
+
       setup();
     }
 
@@ -347,7 +352,10 @@ module LocaleModel {
       if doneCreatingLocales {
         halt("Cannot create additional LocaleModel instances");
       }
+      _node_id = chpl_nodeID: int;
+
       super.init(parent_loc);
+
       setup();
     }
 
@@ -419,8 +427,6 @@ module LocaleModel {
     //- Implementation (private)
     //-
     proc setup() {
-      _node_id = chpl_nodeID: int;
-
       helpSetupLocaleNUMA(this, local_name, numSublocales);
 
       ddr = new MemoryLocale(c_sublocid_any, this);

--- a/modules/internal/localeModels/numa/LocaleModel.chpl
+++ b/modules/internal/localeModels/numa/LocaleModel.chpl
@@ -100,9 +100,9 @@ module LocaleModel {
   //
   class LocaleModel : AbstractLocaleModel {
     const _node_id : int;
-    const local_name : string;
+    var local_name : string; // should never be modified after first assignment
 
-    const numSublocales: int;
+    var numSublocales: int; // should never be modified after first assignment
     var childSpace: domain(1);
     var childLocales: [childSpace] NumaDomain;
 
@@ -114,6 +114,10 @@ module LocaleModel {
       if doneCreatingLocales {
         halt("Cannot create additional LocaleModel instances");
       }
+      _node_id = chpl_nodeID: int;
+
+      super.init();
+
       setup();
     }
 
@@ -121,7 +125,10 @@ module LocaleModel {
       if doneCreatingLocales {
         halt("Cannot create additional LocaleModel instances");
       }
+      _node_id = chpl_nodeID: int;
+
       super.init(parent_loc);
+
       setup();
     }
 
@@ -190,8 +197,6 @@ module LocaleModel {
     //- Implementation (private)
     //-
     proc setup() {
-      _node_id = chpl_nodeID: int;
-
       helpSetupLocaleNUMA(this, local_name, numSublocales);
     }
     //------------------------------------------------------------------------}


### PR DESCRIPTION
The locale models were updated to use initializers while the rules were new and in flux.  #8660 started enforcing some of the rules (in particular, not passing "this" to something during phase 1), so the locale models need to be updated to correct that problem.  While doing this, I noticed other violations of the rules that are not yet being enforced.  Currently, const members should not be initialized in phase 2, but they are.

This change gets testing back on track by fixing the enforced violations, and fixes violations anticipated to be enforced in the future.

In some places, a const field had to be changed to a var field to avoid a full refactoring of locale models.  In the long run, all locale models will need to be refactored to take new init rules into account.

- [x] Passed hellos on the knl locale model
- [x] Passed release/examples on the numa locale model
- [x] Passed full local testing on the flat locale model