### PR TITLE
Get instantiation

### DIFF
--- a/compiler/include/AggregateType.h
+++ b/compiler/include/AggregateType.h
@@ -105,6 +105,7 @@ public:
   bool                        setFirstGenericField();
 
   AggregateType*              getInstantiation(Symbol* sym, int index);
+
   AggregateType*              getInstantiationParent(AggregateType* pt);
 
   AggregateType*              getInstantiationMulti(SymbolMap& subs,
@@ -182,9 +183,9 @@ public:
 
 private:
   static ArgSymbol*           createGenericArg(VarSymbol* field);
-  static void                 insertImplicitThis(
-                                            FnSymbol*         fn,
-                                            Vec<const char*>& fieldNamesSet);
+
+  static void                 insertImplicitThis(FnSymbol*         fn,
+                                                 Vec<const char*>& names);
 
 private:
   virtual std::string         docsDirective();
@@ -206,6 +207,8 @@ private:
 
   void                        typeConstrSetFields(FnSymbol* fn,
                                                   CallExpr* superCall)   const;
+
+  bool                        setNextGenericField();
 
   void                        typeConstrSetField(FnSymbol*  fn,
                                                  VarSymbol* field,

--- a/compiler/include/AggregateType.h
+++ b/compiler/include/AggregateType.h
@@ -108,6 +108,8 @@ public:
 
   AggregateType*              getCurInstantiation(Symbol* sym);
 
+  AggregateType*              getNewInstantiation(Symbol* sym);
+
   AggregateType*              getInstantiationParent(AggregateType* pt);
 
   AggregateType*              getInstantiationMulti(SymbolMap& subs,

--- a/compiler/include/AggregateType.h
+++ b/compiler/include/AggregateType.h
@@ -106,6 +106,8 @@ public:
 
   AggregateType*              getInstantiation(Symbol* sym, int index);
 
+  AggregateType*              getCurInstantiation(Symbol* sym);
+
   AggregateType*              getInstantiationParent(AggregateType* pt);
 
   AggregateType*              getInstantiationMulti(SymbolMap& subs,


### PR DESCRIPTION
Integrate updates to logic for AggregateType::getInstantiation

This PR merges components of work being done to improve support for generic types.
No expected changes in behavior

Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.  Passed
a portion of release for each config.  Passed a single-locale paratest with -futures
