### PR TITLE
Type constr 2

### DIFF
--- a/compiler/include/AggregateType.h
+++ b/compiler/include/AggregateType.h
@@ -198,6 +198,8 @@ private:
   void                        addClassToHierarchy(
                                           std::set<AggregateType*>& seen);
 
+  AggregateType*              instantiationWithParent(AggregateType* parent);
+
   Symbol*                     substitutionForField(Symbol*    field,
                                                    SymbolMap& subs)      const;
 

--- a/test/classes/initializers/generics/inheritance/inherited.chpl
+++ b/test/classes/initializers/generics/inheritance/inherited.chpl
@@ -1,0 +1,81 @@
+class Base {
+  proc init() {
+    initDone();
+  }
+}
+
+class Child1 {
+  type  t1;
+  param p1;
+
+  proc init(type _t1, param _p1) {
+    t1 = _t1;
+    p1 = _p1;
+
+    initDone();
+  }
+}
+
+class Child2 : Child1 {
+  type  t2;
+
+  proc init(type _t1, param _p1, type _t2) {
+    super.init(_t1, _p1);
+
+    t2 = _t2;
+
+    initDone();
+  }
+}
+
+
+
+
+
+proc main() {
+  testLevel1();
+  writeln();
+
+  testLevel2();
+}
+
+
+proc testLevel1() {
+  var c11 : Child1(int, 10);
+  var c12 : Child1(p1 = 10, t1 = real);
+
+  writeln('c11.type ', c11.type : string);
+  writeln('c12.type ', c12.type : string);
+  writeln();
+
+  writeln('Are the types the same? ', c11.type == c12.type);
+  writeln();
+
+  c11 = new Child1(int, 10);
+
+  writeln(c11);
+
+  delete c11;
+}
+
+
+proc testLevel2() {
+  var c21 : Child2(real, 20, int);
+  var c22 : Child2(t2 = int, t1 = real, p1 = 20);
+
+  writeln('c21.type ', c21.type : string);
+  writeln('c22.type ', c22.type : string);
+  writeln();
+
+  writeln('Are the types the same? ', c21.type == c22.type);
+  writeln();
+
+  c21 = new Child2(real, 20, int);
+
+  writeln(c21);
+
+  delete c21;
+}
+
+
+

--- a/test/classes/initializers/generics/inheritance/inherited.good
+++ b/test/classes/initializers/generics/inheritance/inherited.good
@@ -1,0 +1,13 @@
+c11.type Child1(int(64),10)
+c12.type Child1(real(64),10)
+
+Are the types the same? false
+
+{}
+
+c21.type Child2(real(64),20,int(64))
+c22.type Child2(real(64),20,int(64))
+
+Are the types the same? true
+
+{}


### PR DESCRIPTION
This PR continues the effort to support Distributed Deque/Bag

Adds support for instantiating class hierarchies with generic fields at different levels

Compiled on clang/linux64 with multiple configurations and limited testing of each
Passed a single-locale paratest with futures
