### PR TITLE
Fix phase one errors in BigInteger

### DIFF
--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -126,14 +126,14 @@ module BigInteger {
     var localeId : chpl_nodeID_t;      // The locale id for the GMP state
 
     proc init() {
-      super.init();
+      this.initDone();
       mpz_init(this.mpz);
 
       this.localeId = chpl_nodeID;
     }
 
     proc init(const ref num: bigint) {
-      super.init();
+      this.initDone();
       if _local || num.localeId == chpl_nodeID {
         mpz_init_set(this.mpz, num.mpz);
       } else {
@@ -148,21 +148,21 @@ module BigInteger {
     }
 
     proc init(num: int) {
-      super.init();
+      this.initDone();
       mpz_init_set_si(this.mpz, num.safeCast(c_long));
 
       this.localeId = chpl_nodeID;
     }
 
     proc init(num: uint) {
-      super.init();
+      this.initDone();
       mpz_init_set_ui(this.mpz, num.safeCast(c_ulong));
 
       this.localeId = chpl_nodeID;
     }
 
     proc init(str: string, base: int = 0) {
-      super.init();
+      this.initDone();
       const str_  = str.localize().c_str();
       const base_ = base.safeCast(c_int);
 
@@ -176,7 +176,7 @@ module BigInteger {
     }
 
     proc init(str: string, base: int = 0, out error: syserr) {
-      super.init();
+      this.initDone();
       const str_  = str.localize().c_str();
       const base_ = base.safeCast(c_int);
 


### PR DESCRIPTION
#8705 enforces phase one by default for records, which caused compilation failures for BigInteger. This is easily fixed by replacing super.init calls with initDone.

Testing:
- [x] subset of library/standard/GMP
- [x] release/examples/benchmarks/shootout/pidigits.chpl