### PR TITLE
Distributed Bag/Deque :- update constructors to be new style initializers

### DIFF
--- a/modules/packages/Collection.chpl
+++ b/modules/packages/Collection.chpl
@@ -63,6 +63,12 @@ module Collection {
     */
     type eltType;
 
+    proc init(type eltType) {
+      this.eltType = eltType;
+
+      initDone();
+    }
+
     /*
       Adds an element to this data structure.
     */

--- a/modules/packages/DistributedBag.chpl
+++ b/modules/packages/DistributedBag.chpl
@@ -284,19 +284,29 @@ module DistributedBag {
     pragma "no doc"
     var bag : Bag(eltType);
 
-    proc DistributedBagImpl(type eltType, targetLocales : [?targetLocDom] locale = Locales) {
-      bag = new Bag(eltType, this);
-      this.targetLocDom = targetLocDom;
+    proc init(type eltType, targetLocales : [?targetLocDom] locale = Locales) {
+      super.init(eltType);
+
+      this.targetLocDom  = targetLocDom;
       this.targetLocales = targetLocales;
-      pid = _newPrivatizedClass(this);
+
+      initDone();
+
+      this.pid           = _newPrivatizedClass(this);
+      this.bag           = new Bag(eltType, this);
     }
 
     pragma "no doc"
-    proc DistributedBagImpl(other, pid, type eltType = other.eltType) {
-      bag = new Bag(eltType, this);
-      this.targetLocDom = other.targetLocDom;
+    proc init(other, pid, type eltType = other.eltType) {
+      super.init(eltType);
+
+      this.targetLocDom  = other.targetLocDom;
       this.targetLocales = other.targetLocales;
-      this.pid = pid;
+      this.pid           = pid;
+
+      initDone();
+
+      this.bag           = new Bag(eltType, this);
     }
 
     pragma "no doc"

--- a/modules/packages/DistributedDeque.chpl
+++ b/modules/packages/DistributedDeque.chpl
@@ -268,8 +268,10 @@ module DistributedDeque {
       considered unbounded.
     */
     var cap : int;
+
     pragma "no doc"
     var targetLocDom : domain(1);
+
     /*
       Locales to distribute the `Deque` across.
     */
@@ -282,8 +284,10 @@ module DistributedDeque {
     // Keeps track of which slot we are on...
     pragma "no doc"
     var globalHead : DistributedDequeCounter;
+
     pragma "no doc"
     var globalTail : DistributedDequeCounter;
+
     pragma "no doc"
     var queueSize : DistributedDequeCounter;
 
@@ -292,17 +296,25 @@ module DistributedDeque {
     // to reduce the amount of contention.
     pragma "no doc"
     var nSlots : int;
+
     pragma "no doc"
     var slotSpace = {0..-1};
+
     pragma "no doc"
     var slots : [slotSpace] LocalDeque(eltType);
 
-    proc DistributedDequeImpl(type eltType, cap : int = -1, targetLocales : [?locDom] locale =Locales) {
-      this.cap = cap;
-      this.nSlots = here.maxTaskPar * targetLocales.size;
-      this.slotSpace = {0..#this.nSlots};
-      this.targetLocDom = locDom;
+    proc init(type eltType,
+              cap : int = -1,
+              targetLocales : [?locDom] locale = Locales) {
+      super.init(eltType);
+
+      this.cap           = cap;
+      this.targetLocDom  = locDom;
       this.targetLocales = targetLocales;
+      this.nSlots        = here.maxTaskPar * targetLocales.size;
+      this.slotSpace     = {0..#this.nSlots};
+
+      initDone();
 
       // Initialize each slot. We use a round-robin algorithm.
       var idx : atomic int;
@@ -332,7 +344,9 @@ module DistributedDeque {
     }
 
     pragma "no doc"
-    proc DistributedDequeImpl(other, privData, type eltType = other.eltType) {
+    proc init(other, privData, type eltType = other.eltType) {
+      super.init(eltType);
+
       this.cap = other.cap;
       this.targetLocDom = other.targetLocDom;
       this.targetLocales = other.targetLocales;
@@ -342,6 +356,8 @@ module DistributedDeque {
       this.nSlots = other.nSlots;
       this.slotSpace = {0..#this.nSlots};
       slots = other.slots;
+
+      initDone();
     }
 
     pragma "no doc"


### PR DESCRIPTION
Convert Distributed Deque/Bag from constructors to new style initializers.


Minor changes to convert 4 constructors.  Added an explicit, trivial, initializer to
the base class CollectionImpl.

Passed single-locale paratest with -futures and configured for gasnet

