### PR TITLE
Add a future covering the bad error message for recursion and arguments

### DIFF
--- a/test/functions/lydia/infinite-recursion-arg.bad
+++ b/test/functions/lydia/infinite-recursion-arg.bad
@@ -1,0 +1,8 @@
+infinite-recursion-arg.chpl:1: internal error: RES0120 chpl version 1.17.0 pre-release (06f19a352b)
+Note: This source location is a guess.
+
+Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
+please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
+the filename + line number above may be useful in working around the issue.
+

--- a/test/functions/lydia/infinite-recursion-arg.chpl
+++ b/test/functions/lydia/infinite-recursion-arg.chpl
@@ -1,0 +1,9 @@
+proc infinite1(x: int, y = infinite2(x)) {
+  return y;
+}
+
+proc infinite2(x: int) {
+  return infinite1(x);
+}
+
+writeln(infinite1(2));

--- a/test/functions/lydia/infinite-recursion-arg.future
+++ b/test/functions/lydia/infinite-recursion-arg.future
@@ -1,0 +1,2 @@
+Unclear error message with infinite recursion due to arguments
+#8730

--- a/test/functions/lydia/infinite-recursion-arg.good
+++ b/test/functions/lydia/infinite-recursion-arg.good
@@ -1,0 +1,3 @@
+infinite-recursion-arg.chpl:1: error: unable to resolve return type of function 'infinite1'
+infinite-recursion-arg.chpl:5: In function 'infinite2':
+infinite-recursion-arg.chpl:6: error: called recursively at this point


### PR DESCRIPTION
When an argument's default value causes infinite recursion, instead of getting a
helpful error message we get an internal error complaining about making the
intent for the type.  Tracks progress on #8730