### PR TITLE
Fix default binary name for foo/bar/baz.chpl

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -2085,12 +2085,13 @@ void codegen(void) {
       lastSlash++;
     }
 
-    if (strlen(lastSlash) > FILENAME_MAX) {
+    // copy from that slash onwards into the executableFilename,
+    // saving space for a `\0` terminator
+    if (strlen(lastSlash) >= sizeof(executableFilename)) {
       INT_FATAL("input filename exceeds executable filename buffer size");
     }
+    strncpy(executableFilename, lastSlash, sizeof(executableFilename)-1);
 
-    // copy from that slash onwards into the executableFilename
-    strncpy(executableFilename, lastSlash, sizeof(executableFilename));
     // remove the filename extension
     char* lastDot = strrchr(executableFilename, '.');
     if (lastDot == NULL) {

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -2071,11 +2071,22 @@ void codegen(void) {
   }
 
   // Set the executable name to the name of the file containing the
-  // main module (minus its extension) if it isn't set already.
+  // main module (minus its path and extension) if it isn't set
+  // already.
   if (executableFilename[0] == '\0') {
     ModuleSymbol* mainMod = ModuleSymbol::mainModule();
-    strncpy(executableFilename, mainMod->astloc.filename,
-            sizeof(executableFilename));
+    const char* mainModFilename = mainMod->astloc.filename;
+
+    // find the last slash in the filename's path, if there is one
+    const char* lastSlash = strrchr(mainModFilename, '/');
+    if (lastSlash == NULL) {
+      lastSlash = mainModFilename;
+    } else {
+      lastSlash++;
+    }
+
+    // copy from that slash onwards into the executableFilename
+    strncpy(executableFilename, lastSlash, sizeof(executableFilename));
     // remove the filename extension
     char* lastDot = strrchr(executableFilename, '.');
     if (lastDot == NULL) {

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -2085,6 +2085,10 @@ void codegen(void) {
       lastSlash++;
     }
 
+    if (strlen(lastSlash) > FILENAME_MAX) {
+      INT_FATAL("input filename exceeds executable filename buffer size");
+    }
+
     // copy from that slash onwards into the executableFilename
     strncpy(executableFilename, lastSlash, sizeof(executableFilename));
     // remove the filename extension

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -2091,6 +2091,7 @@ void codegen(void) {
       INT_FATAL("input filename exceeds executable filename buffer size");
     }
     strncpy(executableFilename, lastSlash, sizeof(executableFilename)-1);
+    executableFilename[sizeof(executableFilename)-1] = '\0';
 
     // remove the filename extension
     char* lastDot = strrchr(executableFilename, '.');

--- a/test/compflags/ferguson/default-binary-name/sub_test
+++ b/test/compflags/ferguson/default-binary-name/sub_test
@@ -85,6 +85,7 @@ run("test-default-binary-name-main-module.chpl", "test-default-binary-name-main-
 run("test-default-binary-name2.chpl", "test-default-binary-name2", [], "Hi\nHello")
 run("test-default-binary-name3.chpl", "test-default-binary-name3", [], "Hi")
 run("test-default-binary-name3.chpl", "M3", ["M3.chpl"], "Hi\nHello")
+run("subdir/testSubDirFile.chpl", "testSubDirFile", [], "Hello")
 
 # finally, test with setting the binary name with the enivronment variable.
 # this is last so we don't have to worry about restoring the environment

--- a/test/compflags/ferguson/default-binary-name/subdir/NOTEST
+++ b/test/compflags/ferguson/default-binary-name/subdir/NOTEST
@@ -1,0 +1,1 @@
+This directory is just here for the parent directory's purposes.

--- a/test/compflags/ferguson/default-binary-name/subdir/testSubDirFile.chpl
+++ b/test/compflags/ferguson/default-binary-name/subdir/testSubDirFile.chpl
@@ -1,0 +1,1 @@
+writeln("Hello");


### PR DESCRIPTION
Paul @cassella pointed out that with my recent change to the default
executable names in PR #8587, I accidentally made it so that `foo/bar/baz.chpl`
would default to `foo/bar/baz` rather than simply `./baz`.  This fixes
that by searching backwards for the last slash and starting the
executable name from the character following, if it exists.  It also adds a test
for this case to head off problems in the future.