### PR TITLE
Fix some c2chapel testing issues

### DIFF
--- a/tools/c2chapel/test/tester.sh
+++ b/tools/c2chapel/test/tester.sh
@@ -70,4 +70,5 @@ if [ "$numFailures" -eq "0" ]; then
   printf "${GREEN}SUCCESS${NORMAL}\n"
 else
   printf "${RED}$numFailures/$numTotal tests failed${NORMAL}\n"
+  exit 1;
 fi

--- a/util/cron/test-c2chapel.bash
+++ b/util/cron/test-c2chapel.bash
@@ -8,4 +8,13 @@ source $CWD/common.bash
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="c2chapel"
 
 export CHPL_NIGHTLY_TEST_DIRS="c2chapel/"
+
+# test/c2chapel/SKIPIF relies on 'c2chapel' being in $PATH.
+#
+# Depending on how this script is called, $PATH may have been reset (e.g. a
+# .bashrc was sourced).
+#
+# TODO: emit useful error if tests will be skipped
+export PATH="$CHPL_HOME/bin/$CHPL_HOST_PLATFORM:$PATH"
+
 $CWD/nightly -cron


### PR DESCRIPTION
This PR fixes two issues with our testing of c2chapel:
1) We need to update PATH in case something blew it away such that $CHPL_HOME/bin was lost
2) Added an ``exit 1`` to failing case in 'make check' script

Tested locally with a ``make check`` in tools/c2chapel. Tested cron script in an internal Jenkins sandbox.