### PR TITLE
Update README.md for CHIP 23

### DIFF
--- a/doc/rst/developer/chips/README.md
+++ b/doc/rst/developer/chips/README.md
@@ -24,4 +24,5 @@ See the first CHIP for an overview.
 * [20 Function Hijacking](20.rst)
 * [21 Chapel's Cryptography Library](21.rst)
 * [22 GPU Language Extensions](22.rst)
+* [23 Initializers :- Experiences, Concerns, Proposals](23.rst)
 


### PR DESCRIPTION
CHIP 23 was missing from the README, so didn't appear on the nice list of links
at the bottom of the chips page on github.