### PR TITLE
remove 'try!' from IO.chpl

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1629,7 +1629,7 @@ proc open(path:string="", mode:iomode, hints:iohints=IOHINT_NONE, style:iostyle 
 
     error = qio_file_open_access(ret._file_internal, path.localize().c_str(), _modestring(mode).c_str(), hints, local_style);
     if error then
-      try ioerror(error, "Unable to open file in HDFS", url);
+      try ioerror(error, "in open", path);
   }
 
   return ret;

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1549,8 +1549,8 @@ to create a channel to actually perform I/O operations
 
 */
 
-proc open(path:string="", mode:iomode, hints:iohints=IOHINT_NONE, style:iostyle =
-    defaultIOStyle(), url:string=""):file throws {
+proc open(path:string="", mode:iomode, hints:iohints=IOHINT_NONE,
+          style:iostyle = defaultIOStyle(), url:string=""): file throws {
 
   proc parse_hdfs_path(path:string) throws {
     // hdfs://<host>:<port>/<path>
@@ -1638,7 +1638,7 @@ proc open(path:string="", mode:iomode, hints:iohints=IOHINT_NONE, style:iostyle 
 // documented in open() throws version
 pragma "no doc"
 proc open(out error:syserr, path:string="", mode:iomode, hints:iohints=IOHINT_NONE,
-    style:iostyle = defaultIOStyle(), url:string=""):file {
+          style:iostyle = defaultIOStyle(), url:string=""):file {
   var err: syserr = ENOERR;
   var ret: file;
   try {

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -3460,10 +3460,10 @@ proc stringify(const args ...?k):string {
     try! {
       // Open a memory buffer to store the result
       var f = openmem();
-      defer f.close();
+      defer try! f.close();
 
       var w = f.writer(locking=false);
-      defer w.close();
+      defer try! w.close();
 
       w.write((...args));
 
@@ -3472,7 +3472,7 @@ proc stringify(const args ...?k):string {
       var buf = c_malloc(uint(8), offset+1);
 
       var r = f.reader(locking=false);
-      defer r.close();
+      defer try! r.close();
 
       r.readBytes(buf, offset:ssize_t);
       // Add the terminating NULL byte to make C string conversion easy.

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1584,7 +1584,7 @@ proc open(path:string="", mode:iomode, hints:iohints=IOHINT_NONE, style:iostyle 
     try {
       port = port_str: int;
     } catch {
-      error = EINVAL;
+      throw SystemError.fromSyserr(EINVAL, "invalid port");
     }
 
     var file_path = "";
@@ -1594,7 +1594,7 @@ proc open(path:string="", mode:iomode, hints:iohints=IOHINT_NONE, style:iostyle 
 
   var local_style = style;
   var error: syserr = ENOERR;
-  var ret:   file;
+  var ret: file;
   ret.home = here;
   if (url != "") {
     if (url.startsWith("hdfs://")) { // HDFS

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1551,7 +1551,8 @@ to create a channel to actually perform I/O operations
 
 proc open(path:string="", mode:iomode, hints:iohints=IOHINT_NONE, style:iostyle =
     defaultIOStyle(), url:string=""):file throws {
-  proc parse_hdfs_path(path:string) {
+
+  proc parse_hdfs_path(path:string) throws {
     // hdfs://<host>:<port>/<path>
     var host_start = path.find("//") + 2;
     var colon = path.find(":", host_start..);
@@ -1598,7 +1599,7 @@ proc open(path:string="", mode:iomode, hints:iohints=IOHINT_NONE, style:iostyle 
   ret.home = here;
   if (url != "") {
     if (url.startsWith("hdfs://")) { // HDFS
-      var (host, port, file_path) = parse_hdfs_path(url);
+      var (host, port, file_path) = try parse_hdfs_path(url);
       var fs:c_void_ptr;
 
       // Since we don't have an auto-destructor for this, we actually need to make


### PR DESCRIPTION
#8452 contains a list of `try!` uses in the modules, with the most egregious offender being `IO.chpl`. This PR removes some of those uses:

- `file.check`
  - output the error code `EINVAL` instead of halting
- `openreader` / `openwriter`
    - output the error code `EINVAL` instead of halting
- `open`
  - wrap the `ioerror` calls with `try` instead of `try!`
  - have the `out error` version wrap the `throws` version instead
- `try! this.unlock()`
  - remove `try!`, since `unlock` doesn't throw
- while there, update `stringify` to use `defer` constructs
  - still using `try!` due to difficulty in recovery

- [x] passes linux64+flat testing