### PR TITLE
Experimental support for the Allinea compiler, ARM's commercial compiler

### DIFF
--- a/make/compiler/Makefile.allinea
+++ b/make/compiler/Makefile.allinea
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# The Allinea compiler is ARM's commercial compiler based on Clang.
+# The allinea compiler is ARM's commercial compiler based on clang.
 include $(CHPL_MAKE_HOME)/make/compiler/Makefile.clang
 
-# Any Allinea-specific settings can go here.
+# Any allinea-specific settings can go here.

--- a/make/compiler/Makefile.allinea
+++ b/make/compiler/Makefile.allinea
@@ -1,0 +1,21 @@
+# Copyright 2004-2018 Cray Inc.
+# Other additional copyright holders may be indicated within.
+# 
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# 
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The Allinea compiler is ARM's commercial compiler based on Clang.
+include $(CHPL_MAKE_HOME)/make/compiler/Makefile.clang
+
+# Any Allinea-specific settings can go here.

--- a/make/compiler/Makefile.allinea
+++ b/make/compiler/Makefile.allinea
@@ -1,14 +1,14 @@
 # Copyright 2004-2018 Cray Inc.
 # Other additional copyright holders may be indicated within.
-# 
+#
 # The entirety of this work is licensed under the Apache License,
 # Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License.
-# 
+#
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/make/compiler/Makefile.cray-prgenv-allinea
+++ b/make/compiler/Makefile.cray-prgenv-allinea
@@ -1,0 +1,24 @@
+# Copyright 2004-2018 Cray Inc.
+# Other additional copyright holders may be indicated within.
+# 
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# 
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# put Cray PE cross-compilation allinea-specific settings here
+
+CRAYPE_GEN_CFLAGS =
+CRAYPE_COMP_CXXFLAGS =
+
+include $(CHPL_MAKE_HOME)/make/compiler/Makefile.allinea
+include $(CHPL_MAKE_HOME)/make/compiler/Makefile.cray-prgenv

--- a/make/compiler/Makefile.cray-prgenv-allinea
+++ b/make/compiler/Makefile.cray-prgenv-allinea
@@ -1,14 +1,14 @@
 # Copyright 2004-2018 Cray Inc.
 # Other additional copyright holders may be indicated within.
-# 
+#
 # The entirety of this work is licensed under the Apache License,
 # Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License.
-# 
+#
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/util/chplenv/chpl_atomics.py
+++ b/util/chplenv/chpl_atomics.py
@@ -42,6 +42,8 @@ def get(flag='target'):
                 atomics_val = 'intrinsics'
             elif compiler_val == 'cray-prgenv-cray':
                 atomics_val = 'intrinsics'
+            elif compiler_val == 'cray-prgenv-allinea':
+                atomics_val = 'cstdlib'
             elif compiler_val == 'clang':
                 atomics_val = 'intrinsics'
             elif compiler_val == 'clang-included':


### PR DESCRIPTION
On Cray XC50-AC systems (64-bit ARM), the PrgEnv-intel compiler is replaced with PrgEnv-allinea, which is ARM's commercial compiler.

I added this experimental support to see if we should include PrgEnv-allinea in the XC50-AC version of the Chapel 1.17 module build.  As it turns out, configuration of that compiler on XC50-AC systems is not complete, so this Chapel support is not operational yet.  However, I would like to preserve what I have done so far, so we can use it when that compiler comes on-line.