### PR TITLE
Disallow super.init calls inside record initializers

### DIFF
--- a/compiler/passes/initializerRules.cpp
+++ b/compiler/passes/initializerRules.cpp
@@ -468,9 +468,7 @@ static InitNormalize preNormalize(AggregateType* at,
           state.completePhase0(callExpr);
 
           if (at->isRecord() == true) {
-            // INIT TODO: disallow super.init in records
-            // gdbShouldBreakHere();
-            // USR_FATAL_CONT(stmt, "super.init not allowed in records");
+            USR_FATAL_CONT(stmt, "super.init() not allowed in records");
             callExpr->remove();
 
           } else if (at->symbol->hasFlag(FLAG_EXTERN) == true) {

--- a/modules/internal/ChapelSyncvar.chpl
+++ b/modules/internal/ChapelSyncvar.chpl
@@ -115,7 +115,6 @@ module ChapelSyncvar {
       ensureFEType(valType);
       this.valType = valType;
       this.wrapped = new (getSyncClassType(valType))(valType);
-      super.init();
     }
 
     //
@@ -133,7 +132,6 @@ module ChapelSyncvar {
       this.valType = other.valType;
       this.wrapped = other.wrapped;
       this.isOwned = false;
-      super.init();
     }
 
     proc deinit() {
@@ -632,7 +630,6 @@ module ChapelSyncvar {
       ensureFEType(valType);
       this.valType = valType;
       wrapped = new _singlecls(valType);
-      super.init();
     }
 
     //
@@ -650,7 +647,6 @@ module ChapelSyncvar {
       this.valType = other.valType;
       wrapped = other.wrapped;
       isOwned = false;
-      super.init();
     }
 
     proc deinit() {

--- a/modules/packages/Buffers.chpl
+++ b/modules/packages/Buffers.chpl
@@ -129,7 +129,6 @@ module Buffers {
   proc bytes.init() {
     this.home = here;
     this._bytes_internal = QBYTES_PTR_NULL;
-    super.init();
   }
   /*
 
@@ -171,11 +170,9 @@ module Buffers {
     if x.home == here {
       qbytes_retain(x._bytes_internal);
       this._bytes_internal = x._bytes_internal;
-      super.init();
     } else {
       // The initial ref count is 1, so no need to call qbytes_retain here.
       this._bytes_internal = bulk_get_bytes(x.home.id, x._bytes_internal);
-      super.init();
     }
   }
 
@@ -271,7 +268,6 @@ module Buffers {
   proc buffer_iterator.init() {
     this.home = here;
     this._bufit_internal = qbuffer_iter_null();
-    super.init();
   }
 
   /* A region within a buffer (indicated by two :record:`buffer_iterator` s ) */

--- a/modules/packages/OwnedObject.chpl
+++ b/modules/packages/OwnedObject.chpl
@@ -90,7 +90,6 @@ module OwnedObject {
         compilerError("Owned only works with classes");
 
       this.p = p;
-      //super.init();
     }
 
     /*

--- a/modules/packages/SharedObject.chpl
+++ b/modules/packages/SharedObject.chpl
@@ -104,7 +104,6 @@ module SharedObject {
       this.t = t;
       this.p = nil;
       this.pn = nil;
-      super.init();
     }
 
     /*
@@ -132,7 +131,7 @@ module SharedObject {
       this.p = p;
       this.pn = rc;
 
-      super.init();
+      this.initDone();
 
       // Boost includes a mechanism for classes inheriting from
       // enable_shared_from_this to record a weak pointer back to the

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -842,7 +842,6 @@ record ReverseComparator {
    */
   proc init() {
     this.comparator = defaultComparator;
-    super.init();
   }
 
   /*
@@ -855,7 +854,6 @@ record ReverseComparator {
    */
   proc init(comparator) {
     this.comparator = comparator;
-    super.init();
   }
 
   /*
@@ -867,7 +865,6 @@ record ReverseComparator {
   pragma "no doc"
   proc init(revcomp: ReverseComparator(?)) {
     this.comparator = revcomp.comparator;
-    super.init();
   }
 
   /*

--- a/modules/standard/Barriers.chpl
+++ b/modules/standard/Barriers.chpl
@@ -116,7 +116,6 @@ module Barriers {
     proc init(b: Barrier) {
       this.bar = b.bar;
       this.owned = false;
-      super.init();
     }
 
     pragma "no doc"

--- a/modules/standard/DateTime.chpl
+++ b/modules/standard/DateTime.chpl
@@ -273,7 +273,6 @@ module DateTime {
     this.chpl_year = year;
     this.chpl_month = month;
     this.chpl_day = day;
-    super.init();
   }
 
   /* A `date` object representing the current day */
@@ -546,7 +545,6 @@ module DateTime {
     this.chpl_second = second;
     this.chpl_microsecond = microsecond;
     this.chpl_tzinfo = tzinfo;
-    super.init();
   }
 
   pragma "no doc"
@@ -870,7 +868,6 @@ module DateTime {
     // Testcase: test/library/standard/DateTime/testTimezone.chpl
     chpl_date = new date(year, month, day);
     chpl_time = new time(hour, minute, second, microsecond, tzinfo);
-    super.init();
   }
 
   /* Return a `datetime` value representing the current time and date */
@@ -1458,7 +1455,6 @@ module DateTime {
 
     if this.days > 999999999 then
       halt("Overflow: days > 999999999");
-    super.init();
   }
 
   /* Create a `timedelta` from a given number of seconds */

--- a/test/arrays/vass/const-checking.fields.chpl
+++ b/test/arrays/vass/const-checking.fields.chpl
@@ -9,7 +9,7 @@ record REC {
   proc init() {
     arvar = ARR;
     arcst = ARR;
-    super.init();
+    this.initDone();
     arvar[1] = 1111;
     arcst[2] = 1111;
   }
@@ -22,7 +22,7 @@ class CLSS {
   proc init() {
     cvar = ARR;
     ccst = ARR;
-    super.init();
+    this.initDone();
     cvar[1] = 1111;
     ccst[2] = 1111;
   }

--- a/test/classes/ferguson/delete-free/owned-shared-fields.chpl
+++ b/test/classes/ferguson/delete-free/owned-shared-fields.chpl
@@ -30,7 +30,6 @@ record R3 {
   proc init(a:MyClass, b:MyClass) {
     fo = new Owned(a);
     fs = new Shared(b);
-    super.init();
   }
 }
 
@@ -38,7 +37,7 @@ record R4 {
   var fo:Owned(MyClass);
   var fs:Shared(MyClass);
   proc init(a:MyClass, b:MyClass) {
-    super.init();
+    this.initDone();
     fo = new Owned(a);
     fs = new Shared(b);
   }

--- a/test/classes/initializers/compilerGenerated/generics/tupleOfGeneric.chpl
+++ b/test/classes/initializers/compilerGenerated/generics/tupleOfGeneric.chpl
@@ -8,7 +8,6 @@ record R {
             param stridable : bool = false) {
     this.idxType   = idxType;
     this.stridable = stridable;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/cond-both-3.chpl
+++ b/test/classes/initializers/cond-both-3.chpl
@@ -11,7 +11,6 @@ record MyRec {
     else
       x = 12;
 
-    super.init();
   }
 }
 

--- a/test/classes/initializers/cond-both-4.chpl
+++ b/test/classes/initializers/cond-both-4.chpl
@@ -11,7 +11,6 @@ record MyRec {
     else
       y = 22;
 
-    super.init();
   }
 }
 

--- a/test/classes/initializers/copy-init-1.chpl
+++ b/test/classes/initializers/copy-init-1.chpl
@@ -10,7 +10,6 @@ record MyRecord {
 
     id       = globalId;
 
-    super.init();
   }
 
   proc init(other : MyRecord) {
@@ -18,7 +17,6 @@ record MyRecord {
 
     id       = other.id + 1;
 
-    super.init();
   }
 
   proc deinit() {

--- a/test/classes/initializers/copy-init-2.chpl
+++ b/test/classes/initializers/copy-init-2.chpl
@@ -10,7 +10,6 @@ record MyRecord {
 
     id       = globalId;
 
-    super.init();
   }
 
   proc deinit() {

--- a/test/classes/initializers/copy-init-3.chpl
+++ b/test/classes/initializers/copy-init-3.chpl
@@ -10,7 +10,6 @@ record MyRecord {
 
     id       = globalId;
 
-    super.init();
   }
 
   proc init(other : MyRecord) {
@@ -18,7 +17,6 @@ record MyRecord {
 
     id       = other.id + 1;
 
-    super.init();
   }
 
   proc deinit() {

--- a/test/classes/initializers/generics/phase1/newInit-class-record.chpl
+++ b/test/classes/initializers/generics/phase1/newInit-class-record.chpl
@@ -16,8 +16,6 @@ record Stored {
 
   proc init(xVal) where !xVal: Stored {
     x = xVal;
-
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/phase1/newInit-class-record2.chpl
+++ b/test/classes/initializers/generics/phase1/newInit-class-record2.chpl
@@ -14,8 +14,6 @@ record Stored {
 
   proc init(xVal:bool) {
     x = xVal;
-
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/phase1/newInit-record-class.chpl
+++ b/test/classes/initializers/generics/phase1/newInit-record-class.chpl
@@ -6,8 +6,6 @@ record Container {
   proc init() {
     y = new Stored(true);
     v = 10;
-
-    super.init();
   }
 
   proc deinit() {

--- a/test/classes/initializers/generics/phase1/newInit-record-class2.chpl
+++ b/test/classes/initializers/generics/phase1/newInit-record-class2.chpl
@@ -4,8 +4,6 @@ record Container {
 
   proc init() {
     y = new Stored(true);
-
-    super.init();
   }
 
   proc deinit() {

--- a/test/classes/initializers/generics/phase1/newInit-record-record.chpl
+++ b/test/classes/initializers/generics/phase1/newInit-record-record.chpl
@@ -7,7 +7,6 @@ record Container {
     y = new Stored(true);
 
     v = 10;
-    super.init();
   }
 }
 
@@ -17,7 +16,6 @@ record Stored {
   proc init(xVal) where !xVal: Stored {
     x = xVal;
 
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/phase1/newInit-record-record2.chpl
+++ b/test/classes/initializers/generics/phase1/newInit-record-record2.chpl
@@ -5,7 +5,6 @@ record Container {
   proc init() {
     y = new Stored(true);
 
-    super.init();
   }
 }
 
@@ -15,7 +14,6 @@ record Stored {
   proc init(xVal:bool) {
     x = xVal;
 
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/phase1/simpleThis.chpl
+++ b/test/classes/initializers/generics/phase1/simpleThis.chpl
@@ -7,7 +7,6 @@ record MyRecord {
     x = xVal;
     y = 1 + this.x;
 
-    super.init();
   }
 }
 

--- a/test/classes/initializers/nested-destructor.chpl
+++ b/test/classes/initializers/nested-destructor.chpl
@@ -38,8 +38,6 @@ record R
     // a compiler generated copy initializer?
     this.id = other.id + 1;
     this.c  = other.c;
-
-    super.init();
   }
 
   proc deinit()

--- a/test/classes/initializers/not-a-copy-initializer-where-clause.chpl
+++ b/test/classes/initializers/not-a-copy-initializer-where-clause.chpl
@@ -19,7 +19,6 @@ record Foo {
   proc init(genericArg) where genericArg.type != Foo {
     genericArg.someMethod();
     a = true;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/not-a-copy-initializer.chpl
+++ b/test/classes/initializers/not-a-copy-initializer.chpl
@@ -18,7 +18,6 @@ record Foo {
   proc init(genericArg) where (!genericArg: Foo) {
     genericArg.someMethod();
     a = true;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/newInit-class-record.chpl
+++ b/test/classes/initializers/phase1/newInit-class-record.chpl
@@ -14,8 +14,6 @@ record Stored {
 
   proc init(xVal) where !xVal: Stored {
     x = xVal;
-
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/newInit-class-record2.chpl
+++ b/test/classes/initializers/phase1/newInit-class-record2.chpl
@@ -14,8 +14,6 @@ record Stored {
 
   proc init(xVal:bool) {
     x = xVal;
-
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/newInit-record-class.chpl
+++ b/test/classes/initializers/phase1/newInit-record-class.chpl
@@ -4,8 +4,6 @@ record Container {
 
   proc init() {
     y = new Stored(true);
-
-    super.init();
   }
 
   proc deinit() {

--- a/test/classes/initializers/phase1/newInit-record-class2.chpl
+++ b/test/classes/initializers/phase1/newInit-record-class2.chpl
@@ -4,8 +4,6 @@ record Container {
 
   proc init() {
     y = new Stored(true);
-
-    super.init();
   }
 
   proc deinit() {

--- a/test/classes/initializers/phase1/newInit-record-record.chpl
+++ b/test/classes/initializers/phase1/newInit-record-record.chpl
@@ -5,7 +5,6 @@ record Container {
   proc init() {
     y = new Stored(true);
 
-    super.init();
   }
 }
 
@@ -15,7 +14,6 @@ record Stored {
   proc init(xVal) where !xVal: Stored {
     x = xVal;
 
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/newInit-record-record2.chpl
+++ b/test/classes/initializers/phase1/newInit-record-record2.chpl
@@ -5,7 +5,6 @@ record Container {
   proc init() {
     y = new Stored(true);
 
-    super.init();
   }
 }
 
@@ -15,7 +14,6 @@ record Stored {
   proc init(xVal:bool) {
     x = xVal;
 
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/simpleThis.chpl
+++ b/test/classes/initializers/phase1/simpleThis.chpl
@@ -7,7 +7,6 @@ record MyRecord {
     x = xVal;
     y = 1 + this.x;
 
-    super.init();
   }
 }
 

--- a/test/classes/initializers/promotion/initPromotion.chpl
+++ b/test/classes/initializers/promotion/initPromotion.chpl
@@ -47,7 +47,6 @@ record GenericRecord {
 
   proc init(type t) {
     this.eltType = t;
-    super.init();
   }
 
   proc chpl__promotionType() type {

--- a/test/classes/initializers/qualified/qualifiedNew.chpl
+++ b/test/classes/initializers/qualified/qualifiedNew.chpl
@@ -4,7 +4,6 @@ module A {
 
     proc init(a: int) {
       this.a = a + 1;
-      super.init();
     }
   }
 }

--- a/test/classes/initializers/qualified/qualifiedTypeAndNew.bad
+++ b/test/classes/initializers/qualified/qualifiedTypeAndNew.bad
@@ -1,4 +1,4 @@
-qualifiedTypeAndNew.chpl:13: internal error: NOR0825 chpl version 1.17.0 pre-release (e050000)
+qualifiedTypeAndNew.chpl:12: internal error: NOR0825 chpl version 1.17.0 pre-release (e050000)
 Note: This source location is a guess.
 
 Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),

--- a/test/classes/initializers/qualified/qualifiedTypeAndNew.chpl
+++ b/test/classes/initializers/qualified/qualifiedTypeAndNew.chpl
@@ -4,7 +4,6 @@ module A {
 
     proc init(a: int) {
       this.a = a + 1;
-      super.init();
     }
   }
 }

--- a/test/classes/initializers/record-with-record-field-3.chpl
+++ b/test/classes/initializers/record-with-record-field-3.chpl
@@ -29,7 +29,6 @@ record SubRec {
     a = other.a;
     b = other.b;
 
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/checking-copies2.chpl
+++ b/test/classes/initializers/records/checking-copies2.chpl
@@ -14,7 +14,6 @@ record R {
   proc init(other:R) {
     this.x = other.x;
     this.y = other.y;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/copyInitWhereClause.chpl
+++ b/test/classes/initializers/records/copyInitWhereClause.chpl
@@ -3,7 +3,6 @@ record Foo {
 
   proc init(xVal) where (xVal.type != Foo) {
     x = xVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/declaration.chpl
+++ b/test/classes/initializers/records/declaration.chpl
@@ -5,7 +5,6 @@ record Foo {
 
   proc init(xVal) {
     x = xVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/declaration.good
+++ b/test/classes/initializers/records/declaration.good
@@ -1,4 +1,4 @@
-declaration.chpl:12: error: unresolved call 'Foo.init()'
+declaration.chpl:11: error: unresolved call 'Foo.init()'
 declaration.chpl:6: note: candidates are: Foo.init(xVal)
 declaration.chpl:3: note:                 Foo.init(other: Foo)
 deleted module lines

--- a/test/classes/initializers/records/declaration2.chpl
+++ b/test/classes/initializers/records/declaration2.chpl
@@ -5,7 +5,6 @@ record Foo {
 
   proc init(xVal: int) {
     x = xVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/declaration2.good
+++ b/test/classes/initializers/records/declaration2.good
@@ -1,4 +1,4 @@
-declaration2.chpl:12: error: unresolved call 'Foo.init()'
+declaration2.chpl:11: error: unresolved call 'Foo.init()'
 declaration2.chpl:6: note: candidates are: Foo.init(xVal: int)
 declaration2.chpl:3: note:                 Foo.init(other: Foo)
 deleted module lines

--- a/test/classes/initializers/records/defaultValueRecordArg-regularProc.chpl
+++ b/test/classes/initializers/records/defaultValueRecordArg-regularProc.chpl
@@ -3,7 +3,6 @@ record Foo {
 
   proc init(xVal) where xVal.type != Foo {
     x = xVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/defaultValueRecordArg.chpl
+++ b/test/classes/initializers/records/defaultValueRecordArg.chpl
@@ -3,7 +3,6 @@ record Foo {
 
   proc init(xVal) where xVal.type != Foo {
     x = xVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/generics/argument_type.chpl
+++ b/test/classes/initializers/records/generics/argument_type.chpl
@@ -6,7 +6,6 @@ record Foo {
   proc init(xVal) where !xVal: Foo {
     t = xVal.type;
     x = xVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/generics/assignment/init-type.chpl
+++ b/test/classes/initializers/records/generics/assignment/init-type.chpl
@@ -8,7 +8,6 @@ record A {
   var x:t;
   proc init(type t) {
     this.t = t;
-    super.init();
   }
   // initializer for record 'A' requires a generic argument called 't'
 }

--- a/test/classes/initializers/records/generics/assignment/init-type2.chpl
+++ b/test/classes/initializers/records/generics/assignment/init-type2.chpl
@@ -11,7 +11,6 @@ record A {
   proc init() {
     // I removed the argument and explicit setting of field t, to show that
     // omitted type fields work just fine.
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/generics/assignment/init-type3.chpl
+++ b/test/classes/initializers/records/generics/assignment/init-type3.chpl
@@ -12,7 +12,6 @@ record A {
     // I removed the argument and explicit setting of field t, to show that
     // omitted type fields work just fine.
     this.x = xVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/generics/assignment/init-type4.chpl
+++ b/test/classes/initializers/records/generics/assignment/init-type4.chpl
@@ -13,7 +13,6 @@ record A {
     // I removed the argument and explicit setting of field t, to show that
     // omitted type fields work just fine.
     this.x = xVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/generics/assignment/moreTypeFields.chpl
+++ b/test/classes/initializers/records/generics/assignment/moreTypeFields.chpl
@@ -10,7 +10,6 @@ record Foo {
   proc init(type t1Val, type t2Val) {
     t1 = t1Val;
     t2 = t2Val;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/generics/assignment/omittedGenerics1.chpl
+++ b/test/classes/initializers/records/generics/assignment/omittedGenerics1.chpl
@@ -10,7 +10,6 @@ record SoManyParams {
     otherField = otherFieldVal;
     // the above is used to make the initializer actually do something.  The
     // other two fields should be given their appropriate default value.
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/generics/assignment/paramArgDefaultValue.chpl
+++ b/test/classes/initializers/records/generics/assignment/paramArgDefaultValue.chpl
@@ -6,7 +6,6 @@ record Foo {
 
   proc init(param pVal = 3) {
     p = pVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/generics/assignment/reuse-init-instantiation-param.chpl
+++ b/test/classes/initializers/records/generics/assignment/reuse-init-instantiation-param.chpl
@@ -7,7 +7,6 @@ record Foo {
 
   proc init(param pVal) {
     p = pVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/generics/assignment/reuse-init-instantiation.chpl
+++ b/test/classes/initializers/records/generics/assignment/reuse-init-instantiation.chpl
@@ -7,7 +7,6 @@ record Foo {
 
   proc init(type tVal) {
     t = tVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/generics/assignment/reuse-init-instantiation2.chpl
+++ b/test/classes/initializers/records/generics/assignment/reuse-init-instantiation2.chpl
@@ -8,7 +8,6 @@ record Foo {
   proc init(type tVal, xVal:tVal) {
     t = tVal;
     x = xVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/generics/assignment/reuse-init-new-instantiation-var.chpl
+++ b/test/classes/initializers/records/generics/assignment/reuse-init-new-instantiation-var.chpl
@@ -6,7 +6,6 @@ record Foo {
 
   proc init(xVal) where !xVal: Foo {
     x = xVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/generics/assignment/reuse-init-new-instantiation.chpl
+++ b/test/classes/initializers/records/generics/assignment/reuse-init-new-instantiation.chpl
@@ -7,7 +7,6 @@ record Foo {
 
   proc init(type tVal) {
     t = tVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/generics/assignment/typeAlias.chpl
+++ b/test/classes/initializers/records/generics/assignment/typeAlias.chpl
@@ -5,7 +5,6 @@ record Generic {
   proc init(value: ?eltType) where !value: Generic {
     this.eltType = eltType;
     this.value   = value;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/generics/assignment/typeAliasError.chpl
+++ b/test/classes/initializers/records/generics/assignment/typeAliasError.chpl
@@ -5,7 +5,6 @@ record Generic {
   proc init(value: ?eltType) {
     this.eltType = eltType;
     this.value   = value;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/generics/assignment/typeAliasError.good
+++ b/test/classes/initializers/records/generics/assignment/typeAliasError.good
@@ -1,2 +1,2 @@
-typeAliasError.chpl:14: error: Best initializer match doesn't work for generic instantiation Generic(int(64))
+typeAliasError.chpl:13: error: Best initializer match doesn't work for generic instantiation Generic(int(64))
 typeAliasError.chpl:5: note: Best initializer match was defined here, and generated instantiation Generic(string)

--- a/test/classes/initializers/records/generics/assignment/typeArgDefaultValue.chpl
+++ b/test/classes/initializers/records/generics/assignment/typeArgDefaultValue.chpl
@@ -7,7 +7,6 @@ record Foo {
 
   proc init(type tVal = bool) {
     t = tVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/generics/assignment/uninit-type.chpl
+++ b/test/classes/initializers/records/generics/assignment/uninit-type.chpl
@@ -8,7 +8,6 @@ record A {
   var x:t;
   proc init(type t) {
     this.t = t;
-    super.init();
   }
   // initializer for record 'A' requires a generic argument called 't'
 }

--- a/test/classes/initializers/records/generics/assignment/use-param-in-concrete-default.chpl
+++ b/test/classes/initializers/records/generics/assignment/use-param-in-concrete-default.chpl
@@ -8,7 +8,6 @@ record Foo {
 
   proc init(param pVal) {
     p = pVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/generics/assignment/use-param-in-concrete-default2.chpl
+++ b/test/classes/initializers/records/generics/assignment/use-param-in-concrete-default2.chpl
@@ -9,7 +9,6 @@ record Foo {
   proc init(param pVal) {
     p = pVal;
     x = pVal + 2;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/generics/assignment/use-param-in-concrete-default3.chpl
+++ b/test/classes/initializers/records/generics/assignment/use-param-in-concrete-default3.chpl
@@ -9,7 +9,6 @@ record Foo {
   proc init(param pVal) {
     p = pVal;
     x = p + 2;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/generics/assignment/varArgDefaultValue.chpl
+++ b/test/classes/initializers/records/generics/assignment/varArgDefaultValue.chpl
@@ -6,7 +6,6 @@ record Foo {
 
   proc init(vVal = 3) {
     v = vVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/generics/defaultValueRecordArg-explicitInstance.chpl
+++ b/test/classes/initializers/records/generics/defaultValueRecordArg-explicitInstance.chpl
@@ -3,7 +3,6 @@ record Foo {
 
   proc init(xVal) where !xVal: Foo {
     x = xVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/generics/defaultValueRecordArg-regularProc.chpl
+++ b/test/classes/initializers/records/generics/defaultValueRecordArg-regularProc.chpl
@@ -3,7 +3,6 @@ record Foo {
 
   proc init(xVal) where !xVal: Foo {
     x = xVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/generics/defaultValueRecordArg.chpl
+++ b/test/classes/initializers/records/generics/defaultValueRecordArg.chpl
@@ -3,7 +3,6 @@ record Foo {
 
   proc init(xVal) where !xVal: Foo {
     x = xVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/generics/explicitAssignment.chpl
+++ b/test/classes/initializers/records/generics/explicitAssignment.chpl
@@ -5,12 +5,10 @@ record Foo {
 
   proc init(xVal: int) {
     x = xVal;
-    super.init();
   }
 
   proc init(xVal: real) {
     x = xVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/generics/fullySpecifiedAssignment/defaultInitGivesDifferentResult.chpl
+++ b/test/classes/initializers/records/generics/fullySpecifiedAssignment/defaultInitGivesDifferentResult.chpl
@@ -3,7 +3,6 @@ record MyRec {
 
   proc init(param p) {
     field = p + 2;
-    super.init();
   }
 }
 var rec: MyRec(5) = new MyRec(3);

--- a/test/classes/initializers/records/generics/fullySpecifiedAssignment/init-type.chpl
+++ b/test/classes/initializers/records/generics/fullySpecifiedAssignment/init-type.chpl
@@ -8,7 +8,6 @@ record A {
   var x:t;
   proc init(type t) {
     this.t = t;
-    super.init();
   }
   // initializer for record 'A' requires a generic argument called 't'
 }

--- a/test/classes/initializers/records/generics/fullySpecifiedAssignment/moreTypeFields.chpl
+++ b/test/classes/initializers/records/generics/fullySpecifiedAssignment/moreTypeFields.chpl
@@ -10,7 +10,6 @@ record Foo {
   proc init(type t1Val, type t2Val) {
     t1 = t1Val;
     t2 = t2Val;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/generics/fullySpecifiedAssignment/paramArgDefaultValue.chpl
+++ b/test/classes/initializers/records/generics/fullySpecifiedAssignment/paramArgDefaultValue.chpl
@@ -6,7 +6,6 @@ record Foo {
 
   proc init(param pVal = 3) {
     p = pVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/generics/fullySpecifiedAssignment/reuse-init-instantiation-param.chpl
+++ b/test/classes/initializers/records/generics/fullySpecifiedAssignment/reuse-init-instantiation-param.chpl
@@ -7,7 +7,6 @@ record Foo {
 
   proc init(param pVal) {
     p = pVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/generics/fullySpecifiedAssignment/reuse-init-instantiation.chpl
+++ b/test/classes/initializers/records/generics/fullySpecifiedAssignment/reuse-init-instantiation.chpl
@@ -7,7 +7,6 @@ record Foo {
 
   proc init(type tVal) {
     t = tVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/generics/fullySpecifiedAssignment/reuse-init-new-instantiation-var.chpl
+++ b/test/classes/initializers/records/generics/fullySpecifiedAssignment/reuse-init-new-instantiation-var.chpl
@@ -6,7 +6,6 @@ record Foo {
 
   proc init(xVal) where !xVal: Foo {
     x = xVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/generics/fullySpecifiedAssignment/reuse-init-new-instantiation.chpl
+++ b/test/classes/initializers/records/generics/fullySpecifiedAssignment/reuse-init-new-instantiation.chpl
@@ -7,7 +7,6 @@ record Foo {
 
   proc init(type tVal) {
     t = tVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/generics/fullySpecifiedAssignment/typeArgDefaultValue.chpl
+++ b/test/classes/initializers/records/generics/fullySpecifiedAssignment/typeArgDefaultValue.chpl
@@ -7,7 +7,6 @@ record Foo {
 
   proc init(type tVal = bool) {
     t = tVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/generics/fullySpecifiedAssignment/uninit-type.chpl
+++ b/test/classes/initializers/records/generics/fullySpecifiedAssignment/uninit-type.chpl
@@ -8,7 +8,6 @@ record A {
   var x:t;
   proc init(type t) {
     this.t = t;
-    super.init();
   }
   // initializer for record 'A' requires a generic argument called 't'
 }

--- a/test/classes/initializers/records/generics/fullySpecifiedAssignment/use-param-in-concrete-default.chpl
+++ b/test/classes/initializers/records/generics/fullySpecifiedAssignment/use-param-in-concrete-default.chpl
@@ -8,7 +8,6 @@ record Foo {
 
   proc init(param pVal) {
     p = pVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/generics/fullySpecifiedAssignment/use-param-in-concrete-default2.chpl
+++ b/test/classes/initializers/records/generics/fullySpecifiedAssignment/use-param-in-concrete-default2.chpl
@@ -9,7 +9,6 @@ record Foo {
   proc init(param pVal) {
     p = pVal;
     x = pVal + 2;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/generics/fullySpecifiedAssignment/use-param-in-concrete-default3.chpl
+++ b/test/classes/initializers/records/generics/fullySpecifiedAssignment/use-param-in-concrete-default3.chpl
@@ -9,7 +9,6 @@ record Foo {
   proc init(param pVal) {
     p = pVal;
     x = p + 2;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/generics/fullySpecifiedAssignment/varArgDefaultValue.chpl
+++ b/test/classes/initializers/records/generics/fullySpecifiedAssignment/varArgDefaultValue.chpl
@@ -6,7 +6,6 @@ record Foo {
 
   proc init(vVal = 3) {
     v = vVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/generics/init-type.chpl
+++ b/test/classes/initializers/records/generics/init-type.chpl
@@ -8,7 +8,6 @@ record A {
   var x:t;
   proc init(type t) {
     this.t = t;
-    super.init();
   }
   // initializer for record 'A' requires a generic argument called 't'
 }

--- a/test/classes/initializers/records/generics/moreTypeFields.chpl
+++ b/test/classes/initializers/records/generics/moreTypeFields.chpl
@@ -10,7 +10,6 @@ record Foo {
   proc init(type t1Val, type t2Val) {
     t1 = t1Val;
     t2 = t2Val;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/generics/omittedGenerics2.chpl
+++ b/test/classes/initializers/records/generics/omittedGenerics2.chpl
@@ -11,7 +11,6 @@ record Doomed {
     // the above is used to make the initializer actually do something.  It
     // should fail to resolve, though, because we have no idea what to do with
     // the param field.
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/generics/ordinary_param.chpl
+++ b/test/classes/initializers/records/generics/ordinary_param.chpl
@@ -3,7 +3,6 @@ record Foo {
 
   proc init(param a) {
     this.a = a;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/generics/paramArgDefaultValue.chpl
+++ b/test/classes/initializers/records/generics/paramArgDefaultValue.chpl
@@ -6,7 +6,6 @@ record Foo {
 
   proc init(param pVal = 3) {
     p = pVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/generics/returnNewGeneric.chpl
+++ b/test/classes/initializers/records/generics/returnNewGeneric.chpl
@@ -7,7 +7,6 @@ record Option {
     this.eltType = eltType;
     this.state   = true;
     this.value   = value;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/generics/reuse-class-instantiation.chpl
+++ b/test/classes/initializers/records/generics/reuse-class-instantiation.chpl
@@ -7,13 +7,11 @@ record Foo {
 
   proc init(type tVal) {
     t = tVal;
-    super.init();
   }
 
   proc init(xVal) where !xVal: Foo {
     t = xVal.type;
     x = xVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/generics/reuse-init-instantiation-param.chpl
+++ b/test/classes/initializers/records/generics/reuse-init-instantiation-param.chpl
@@ -7,7 +7,6 @@ record Foo {
 
   proc init(param pVal) {
     p = pVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/generics/reuse-init-instantiation-var.chpl
+++ b/test/classes/initializers/records/generics/reuse-init-instantiation-var.chpl
@@ -6,7 +6,6 @@ record Foo {
 
   proc init(xVal) where !xVal: Foo {
     x = xVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/generics/reuse-init-instantiation-var2.chpl
+++ b/test/classes/initializers/records/generics/reuse-init-instantiation-var2.chpl
@@ -6,7 +6,6 @@ record Foo {
 
   proc init(xVal) where !xVal: Foo {
     x = xVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/generics/reuse-init-instantiation.chpl
+++ b/test/classes/initializers/records/generics/reuse-init-instantiation.chpl
@@ -7,7 +7,6 @@ record Foo {
 
   proc init(type tVal) {
     t = tVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/generics/reuse-init-new-instantiation-var.chpl
+++ b/test/classes/initializers/records/generics/reuse-init-new-instantiation-var.chpl
@@ -6,7 +6,6 @@ record Foo {
 
   proc init(xVal) where (!xVal: Foo) {
     x = xVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/generics/reuse-init-new-instantiation.chpl
+++ b/test/classes/initializers/records/generics/reuse-init-new-instantiation.chpl
@@ -7,7 +7,6 @@ record Foo {
 
   proc init(type tVal) {
     t = tVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/generics/siblingCall-generic.chpl
+++ b/test/classes/initializers/records/generics/siblingCall-generic.chpl
@@ -9,7 +9,6 @@ record Foo {
   proc init(type tVal, xVal) {
     t = tVal;
     x = xVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/generics/siblingCall-moreComplex.chpl
+++ b/test/classes/initializers/records/generics/siblingCall-moreComplex.chpl
@@ -4,7 +4,6 @@ record Foo {
   proc init(type idxType, space: range) {
     this.idxType = idxType;
     this.D = space;
-    super.init();
   }
   proc init(type idxType, size: idxType) {
     this.init(idxType, 0..#size);

--- a/test/classes/initializers/records/generics/typeArgDefaultValue.chpl
+++ b/test/classes/initializers/records/generics/typeArgDefaultValue.chpl
@@ -7,7 +7,6 @@ record Foo {
 
   proc init(type tVal = bool) {
     t = tVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/generics/uninit-type.chpl
+++ b/test/classes/initializers/records/generics/uninit-type.chpl
@@ -8,7 +8,6 @@ record A {
   var x:t;
   proc init(type t) {
     this.t = t;
-    super.init();
   }
   // initializer for record 'A' requires a generic argument called 't'
 }

--- a/test/classes/initializers/records/generics/use-param-in-concrete-default.chpl
+++ b/test/classes/initializers/records/generics/use-param-in-concrete-default.chpl
@@ -8,7 +8,6 @@ record Foo {
 
   proc init(param pVal) {
     p = pVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/generics/use-param-in-concrete-default2.chpl
+++ b/test/classes/initializers/records/generics/use-param-in-concrete-default2.chpl
@@ -9,7 +9,6 @@ record Foo {
   proc init(param pVal) {
     p = pVal;
     x = pVal + 2;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/generics/use-param-in-concrete-default3.chpl
+++ b/test/classes/initializers/records/generics/use-param-in-concrete-default3.chpl
@@ -9,7 +9,6 @@ record Foo {
   proc init(param pVal) {
     p = pVal;
     x = p + 2;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/generics/varArgDefaultValue.chpl
+++ b/test/classes/initializers/records/generics/varArgDefaultValue.chpl
@@ -6,7 +6,6 @@ record Foo {
 
   proc init(vVal = 3) {
     v = vVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/out_arg.chpl
+++ b/test/classes/initializers/records/out_arg.chpl
@@ -3,7 +3,6 @@ record Foo {
 
   proc init() {
     x = 12;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/reductionOverCreatedArray-generalType.chpl
+++ b/test/classes/initializers/records/reductionOverCreatedArray-generalType.chpl
@@ -5,19 +5,16 @@ record Foo {
   proc init(x: int) {
     this.x = x;
     this.y = true;
-    super.init();
   }
 
   proc init() {
     x = 0;
     y = true;
-    super.init();
   }
 
   proc init(other: Foo) {
     x = other.x;
     y = false;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/returnArg.chpl
+++ b/test/classes/initializers/records/returnArg.chpl
@@ -1,6 +1,5 @@
 record Foo {
   proc init() {
-    super.init();
   }
 }
 proc quux(x: Foo) return x;

--- a/test/classes/initializers/records/returnArg2.chpl
+++ b/test/classes/initializers/records/returnArg2.chpl
@@ -1,10 +1,8 @@
 record Foo {
   proc init() {
-    super.init();
   }
 
   proc init(other: Foo) {
-    super.init();
   }
 }
 proc quux(x: Foo) return x;

--- a/test/classes/initializers/records/returnArg3.chpl
+++ b/test/classes/initializers/records/returnArg3.chpl
@@ -3,7 +3,6 @@ record Foo {
 
   proc init(xVal) {
     x = xVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/where-clause-other-args.chpl
+++ b/test/classes/initializers/records/where-clause-other-args.chpl
@@ -7,12 +7,10 @@ record Foo {
   proc init(param xVal, yVal) where (xVal > 10) {
     x = xVal;
     y = yVal;
-    super.init();
   }
 
   proc init(param xVal) where (xVal < 10) {
     x = xVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/where-clause.chpl
+++ b/test/classes/initializers/records/where-clause.chpl
@@ -4,12 +4,10 @@ record Foo {
 
   proc init(param xVal: int) where (xVal > 10) {
     x = xVal;
-    super.init();
   }
 
   proc init(param xVal: int) where (xVal <= 10) {
     x = abs(xVal) + 10;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/where-clause2.chpl
+++ b/test/classes/initializers/records/where-clause2.chpl
@@ -5,12 +5,10 @@ record Foo {
 
   proc init(xVal) where (isInt(xVal)) {
     x = xVal;
-    super.init();
   }
 
   proc init(realVal) where (isReal(realVal)) {
     x = floor(realVal):int;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/where-clause3.chpl
+++ b/test/classes/initializers/records/where-clause3.chpl
@@ -5,12 +5,10 @@ record Foo {
 
   proc init(xVal:int) where (isInt(xVal)) {
     x = xVal;
-    super.init();
   }
 
   proc init(realVal:real) where (isReal(realVal)) {
     x = floor(realVal):int;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/where-clause4.chpl
+++ b/test/classes/initializers/records/where-clause4.chpl
@@ -4,7 +4,6 @@ record Foo {
 
   proc init(xVal) where (isInt(xVal)) {
     x = xVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/where-clause4.good
+++ b/test/classes/initializers/records/where-clause4.good
@@ -1,4 +1,4 @@
-where-clause4.chpl:12: error: unresolved call 'Foo.init(3.4)'
+where-clause4.chpl:11: error: unresolved call 'Foo.init(3.4)'
 where-clause4.chpl:5: note: candidates are: Foo.init(xVal)
 where-clause4.chpl:2: note:                 Foo.init(other: Foo)
 deleted module lines

--- a/test/classes/initializers/siblingCall/record-0.chpl
+++ b/test/classes/initializers/siblingCall/record-0.chpl
@@ -18,7 +18,6 @@ record MyRec {
 
     z = _z;
 
-    super.init();
 
     writeln('init(_z)   Phase 2');
   }

--- a/test/errhandling/ferguson/err-return.chpl
+++ b/test/errhandling/ferguson/err-return.chpl
@@ -10,7 +10,6 @@ record MyRecord {
   var y:my_struct;
   proc init(x:int) {
     y = new my_struct(x:c_int);
-    super.init();
   }
   proc deinit() {
     writeln("deinit ", y.x);

--- a/test/functions/ferguson/in-intent.chpl
+++ b/test/functions/ferguson/in-intent.chpl
@@ -2,12 +2,10 @@ record R {
   var x:int;
   proc init(x:int) {
     this.x = x;
-    super.init();
     writeln("init ", x);
   }
   proc init(r:R) {
     this.x = r.x;
-    super.init();
     writeln("copy init ", x);
   }
   proc deinit() {

--- a/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc-ideal.chpl
+++ b/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc-ideal.chpl
@@ -54,7 +54,6 @@ record Population {
   //
   proc init(colors : [] Color) {
     chameneos = new Chameneos(1..colors.size, colors);
-    super.init();
   }
 
   //

--- a/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc.chpl
+++ b/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc.chpl
@@ -54,7 +54,6 @@ record Population {
   //
   proc init(colors: [] Color) {
     chameneos = [i in colors.domain] new Chameneos(i, colors[i]);
-    super.init();
   }
 
   //

--- a/test/studies/shootout/chameneos-redux/elliot/chameneosredux-ejr.chpl
+++ b/test/studies/shootout/chameneos-redux/elliot/chameneosredux-ejr.chpl
@@ -59,7 +59,6 @@ record Population {
   proc init(colors: [] Color) {
     chamSpace = colors.domain;
     chameneos = new Chameneos(1..colors.size, colors);
-    super.init();
   }
 
   //

--- a/test/types/records/const-checking/initRecFieldWithConstField.chpl
+++ b/test/types/records/const-checking/initRecFieldWithConstField.chpl
@@ -8,7 +8,6 @@ record R2 {
 
   proc init(initR) {
     r = initR;
-    super.init();
   }
 }
 

--- a/test/types/records/ferguson/copy-init/copy-init-issue.chpl
+++ b/test/types/records/ferguson/copy-init/copy-init-issue.chpl
@@ -2,7 +2,6 @@ record MyRecord {
   var y:int;
   proc init(x:int) {
     y = x;
-    super.init();
   }
   proc init(from:MyRecord) {
     y = from.y;

--- a/test/types/records/ferguson/copy-init/new-init-generic.chpl
+++ b/test/types/records/ferguson/copy-init/new-init-generic.chpl
@@ -6,14 +6,12 @@ record R {
 proc R.init(x)
 {
   this.x = x;
-  super.init();
 }
 
 proc R.init(from: R)
 {
   writeln("In R.init");
   this.x = from.x;
-  super.init();
 }
 
 proc run() {

--- a/test/types/records/ferguson/deinit/break-in-for-iter1.chpl
+++ b/test/types/records/ferguson/deinit/break-in-for-iter1.chpl
@@ -2,7 +2,6 @@ record R {
   var x: int;
   proc init(x:int) {
     this.x = x;
-    super.init();
     writeln("Creating ", x);
   }
   proc deinit() {

--- a/test/types/records/ferguson/deinit/break-in-for-iter2.chpl
+++ b/test/types/records/ferguson/deinit/break-in-for-iter2.chpl
@@ -2,7 +2,6 @@ record R {
   var x: int;
   proc init(x:int) {
     this.x = x;
-    super.init();
     writeln("Creating ", x);
   }
   proc deinit() {

--- a/test/types/records/ferguson/deinit/for-iter.chpl
+++ b/test/types/records/ferguson/deinit/for-iter.chpl
@@ -2,7 +2,6 @@ record R {
   var x: int;
   proc init(x:int) {
     this.x = x;
-    super.init();
     writeln("Creating ", x);
   }
   proc deinit() {

--- a/test/types/records/hilde/callConstructorThruTypeFn.chpl
+++ b/test/types/records/hilde/callConstructorThruTypeFn.chpl
@@ -11,7 +11,7 @@ record R {
 record S {
   var _i : int;
   var _r : real;
-  proc init(i : int) { _i = i; _r = 3.1416; super.init(); }
+  proc init(i : int) { _i = i; _r = 3.1416; }
 }
 
 proc chooseARecordType(param derived = false) type {

--- a/test/types/records/init/condFieldInit.chpl
+++ b/test/types/records/init/condFieldInit.chpl
@@ -4,7 +4,6 @@ record R {
 
   proc init(param stridable) {
     this.stridable = stridable;
-    super.init();
   }
 }
 

--- a/test/types/records/init/copy/copyWithRefOther.chpl
+++ b/test/types/records/init/copy/copyWithRefOther.chpl
@@ -3,12 +3,11 @@ record R {
   
   proc init(x: int) {
     this.x = x;
-    super.init();
   }
 
   proc init(ref src: R) {
     this.x = src.x;
-    super.init();
+    this.initDone();
     src.x = 0;
   }
 }

--- a/test/types/records/init/copy/localUseNoCopyGeneric.chpl
+++ b/test/types/records/init/copy/localUseNoCopyGeneric.chpl
@@ -8,13 +8,11 @@ module Bar {
     x = other.x;
     y = other.y;
     z = other.z;
-    super.init();
   }
   proc R.init(a,b,c) {
     x = a;
     y = b;
     z = c;
-    super.init();
   }
 
   proc getter() {

--- a/test/types/records/init/copy/localUseNoCopyGenericD.chpl
+++ b/test/types/records/init/copy/localUseNoCopyGenericD.chpl
@@ -8,13 +8,11 @@ module Bar {
     x = other.x;
     y = other.y;
     z = other.z;
-    super.init();
   }
   proc R.init(a,b,c) {
     x = a;
     y = b;
     z = c;
-    super.init();
   }
   proc R.deinit() {
   }

--- a/test/types/records/noakes/return.chpl
+++ b/test/types/records/noakes/return.chpl
@@ -22,7 +22,7 @@ record Rec
     copy         = false;
     freed        = false;
 
-    super.init();
+    this.initDone();
 
     if (sDebug == true) then
       writeln("Constructing Rec       id:  ", id);
@@ -37,7 +37,7 @@ record Rec
     copy   = true;
     freed  = false;
 
-    super.init();
+    this.initDone();
 
     if (sDebug == true) then
       writeln("copying Rec other: ", other.id);

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -111,7 +111,6 @@ record VersionInfo {
   }
 
   proc init(str:string) {
-    super.init();
     const s : [1..3] string = str.split(".");
     assert(s.size == 3);
 


### PR DESCRIPTION
This PR updates the compiler to emit an error if a super.init call is found inside a record initializer. A super.init call does not make sense inside of a record because records do not support inheritance.

Various tests have had their super.init calls removed, and a subset of those tests have had their super.init calls replaced with initDone() calls.

Testing:
- [x] full local + futures
- [x] full gasnet