### PR TITLE
Make gsl_demo compopts conditional on GSL_DIR

### DIFF
--- a/test/users/npadmana/gsl_demonstration/gsl_demo.compopts
+++ b/test/users/npadmana/gsl_demonstration/gsl_demo.compopts
@@ -1,1 +1,5 @@
--I$GSL_DIR/include -L$GSL_DIR/lib
+#! /bin/sh
+
+if [ x$GSL_DIR != x ]; then
+  echo -I$GSL_DIR/include -L$GSL_DIR/lib
+fi


### PR DESCRIPTION
This fixes an LLVM-only test that suddenly began reporting failure when we upgraded to a SLES12 installation, where the Gnu Scientific Library (libgsl) is installed.  The original .compopts file had
```
-I$GSL_DIR/include -L$GSL_DIR/lib
```
and when GSL_DIR was unset (the usual case) it was searching /include and /lib.  In /lib was an incompatible set of 32-bit libraries on the 64-bit machine, which caused a warning message that made the testing harness report failure even though the test succeeded.

The .compopts file is now executable, and only emits the options above if GSL_DIR is set.
