### PR TITLE
Fix locale model init phase violations part deux

### DIFF
--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -103,7 +103,6 @@ module ChapelLocale {
     pragma "no doc"
     proc init(parent: locale) {
       this.parent = parent;
-      super.init();
     }
 
     //------------------------------------------------------------------------{

--- a/modules/internal/localeModels/apu/LocaleModel.chpl
+++ b/modules/internal/localeModels/apu/LocaleModel.chpl
@@ -63,9 +63,9 @@ module LocaleModel {
     }
 
     proc init(_sid, _parent) {
+      super.init(_parent);
       sid = _sid;
       name = _parent.chpl_name() + "-CPU" + sid;
-      super.init(_parent);
     }
 
     proc writeThis(f) {
@@ -107,9 +107,9 @@ module LocaleModel {
 
 
     proc init(_sid, _parent) {
+      super.init(_parent);
       sid = _sid;
       name = _parent.chpl_name() + "-GPU" + sid;
-      super.init(_parent);
     }
 
     proc writeThis(f) {
@@ -152,7 +152,7 @@ module LocaleModel {
       }
       _node_id = chpl_nodeID: int;
 
-      super.init();
+      this.initDone();
 
       setup();
     }
@@ -161,9 +161,11 @@ module LocaleModel {
       if doneCreatingLocales {
         halt("Cannot create additional LocaleModel instances");
       }
+      super.init(parent_loc);
+
       _node_id = chpl_nodeID: int;
 
-      super.init(parent_loc);
+      this.initDone();
 
       setup();
     }

--- a/modules/internal/localeModels/flat/LocaleModel.chpl
+++ b/modules/internal/localeModels/flat/LocaleModel.chpl
@@ -78,9 +78,11 @@ module LocaleModel {
       if doneCreatingLocales {
         halt("Cannot create additional LocaleModel instances");
       }
-      _node_id = chpl_nodeID: int;
 
       super.init(parent_loc);
+
+      _node_id = chpl_nodeID: int;
+
       this.initDone();
 
       setup();

--- a/modules/internal/localeModels/knl/LocaleModel.chpl
+++ b/modules/internal/localeModels/knl/LocaleModel.chpl
@@ -205,7 +205,6 @@ module LocaleModel {
     }
 
     proc init(_sid, _parent) {
-      sid = _sid: chpl_sublocID_t;
       extern proc chpl_task_getNumSublocales(): int(32);
       const (whichNuma, kind) =
         unpackSublocID(chpl_task_getNumSublocales(), sid);
@@ -214,8 +213,11 @@ module LocaleModel {
         kindstr = "DDR";
       else if kind == memoryKindMCDRAM() then
         kindstr = "MCDRAM";
-      mlName = kindstr+whichNuma;
+
       super.init(_parent);
+
+      sid = _sid: chpl_sublocID_t;
+      mlName = kindstr+whichNuma;
     }
 
     proc writeThis(f) {
@@ -268,11 +270,14 @@ module LocaleModel {
     proc init(_sid, _parent) {
       extern proc chpl_task_getNumSublocales(): int(32);
       var numSublocales = chpl_task_getNumSublocales();
+
+      super.init(_parent);
+
       sid = packSublocID(numSublocales, _sid, defaultMemoryKind())
               : chpl_sublocID_t;
       ndName = "ND"+_sid;
 
-      super.init(_parent);
+      this.initDone();
 
       ddr = new MemoryLocale(sid, this);
 
@@ -343,7 +348,7 @@ module LocaleModel {
       }
       _node_id = chpl_nodeID: int;
 
-      super.init();
+      this.initDone();
 
       setup();
     }
@@ -352,9 +357,11 @@ module LocaleModel {
       if doneCreatingLocales {
         halt("Cannot create additional LocaleModel instances");
       }
+      super.init(parent_loc);
+
       _node_id = chpl_nodeID: int;
 
-      super.init(parent_loc);
+      this.initDone();
 
       setup();
     }

--- a/modules/internal/localeModels/knl/LocaleModel.chpl
+++ b/modules/internal/localeModels/knl/LocaleModel.chpl
@@ -206,6 +206,10 @@ module LocaleModel {
 
     proc init(_sid, _parent) {
       extern proc chpl_task_getNumSublocales(): int(32);
+
+      super.init(_parent);
+
+      sid = _sid: chpl_sublocID_t;
       const (whichNuma, kind) =
         unpackSublocID(chpl_task_getNumSublocales(), sid);
       var kindstr:string;
@@ -213,10 +217,6 @@ module LocaleModel {
         kindstr = "DDR";
       else if kind == memoryKindMCDRAM() then
         kindstr = "MCDRAM";
-
-      super.init(_parent);
-
-      sid = _sid: chpl_sublocID_t;
       mlName = kindstr+whichNuma;
     }
 

--- a/modules/internal/localeModels/numa/LocaleModel.chpl
+++ b/modules/internal/localeModels/numa/LocaleModel.chpl
@@ -67,9 +67,9 @@ module LocaleModel {
     }
 
     proc init(_sid, _parent) {
+      super.init(_parent);
       sid = _sid;
       ndName = "ND"+sid;
-      super.init(_parent);
     }
 
     proc writeThis(f) {
@@ -116,7 +116,7 @@ module LocaleModel {
       }
       _node_id = chpl_nodeID: int;
 
-      super.init();
+      this.initDone();
 
       setup();
     }
@@ -125,9 +125,11 @@ module LocaleModel {
       if doneCreatingLocales {
         halt("Cannot create additional LocaleModel instances");
       }
+      super.init(parent_loc);
+
       _node_id = chpl_nodeID: int;
 
-      super.init(parent_loc);
+      this.initDone();
 
       setup();
     }


### PR DESCRIPTION
The newest initializer rules are now being enforced.  This PR updates all locale models to the following understanding.
```
old:

  class C : D {
    proc init() {
      // phase 1        // not an anything
      super.init(...);  // make me a C, B, A, ...
      // phase 2        // I'm a 'Z' here
    }
  }

new:

  class C : D {
    proc init() {
      // miscellaneous side computation   // not an anything
      super.init(...);                    // now I'm a 'D'
      // phase 1                          // init C's fields
      this.initDone();                    // make me a 'C'
      // phase 2                          // can call 'C.' or 'D.' methods, access their fields, etc.
    }
  }
```
This completes (and corrects) the process begun in #8690 .

- [x] Passed release/examples with flat on Mac
- [x] Passed release/examples with numa on Mac
- [x] Passed full local testing with flat on linux64
- [x] Passed full local testing with numa on linux64 (with some failures that existed prior to this change, being investigated)
- [x] Passed release/examples with knl on Cray XC knl compute nodes
