### PR TITLE
Disallow field initialization before super.init

### DIFF
--- a/compiler/passes/initializerRules.cpp
+++ b/compiler/passes/initializerRules.cpp
@@ -30,13 +30,6 @@
 #include "type.h"
 #include "typeSpecifier.h"
 
-enum InitStyle {
-  STYLE_NONE          = 0,
-  STYLE_SUPER_INIT    = 1,
-  STYLE_THIS_INIT     = 2,
-  STYLE_THIS_INITDONE = 4
-};
-
 static bool     isInitStmt (CallExpr* stmt);
 
 static bool     isUnacceptableTry(Expr* stmt);

--- a/modules/internal/ChapelError.chpl
+++ b/modules/internal/ChapelError.chpl
@@ -54,7 +54,6 @@ module ChapelError {
     /* Construct an Error */
     proc init() {
       _next = nil;
-      super.init();
     }
 
     /* Override this method to provide an error message
@@ -91,18 +90,15 @@ module ChapelError {
     var info: string;
 
     proc init() {
-      super.init();
     }
 
     proc init(info: string) {
       this.info = info;
-      super.init();
     }
 
     proc init(formal: string, info: string) {
       this.formal = formal;
       this.info   = info;
-      super.init();
     }
 
     proc message() {
@@ -220,13 +216,11 @@ module ChapelError {
     /* Create a :class:`TaskErrors` containing only the passed error */
     proc init(err: Error) {
       _head = err;
-      super.init();
     }
 
     /* Create a :class:`TaskErrors` not containing any errors */
     proc init() {
       _head = nil;
-      super.init();
     }
 
     /* Iterate over the errors contained in this :class:`TaskErrors`.

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -864,7 +864,6 @@ module DefaultRectangular {
       this.stridable = stridable;
       // This should resize the arrays
       targetLocDom=newTargetLocDom;
-      super.init();
     }
 
     // These functions must always be called locally, because the lock

--- a/modules/packages/Crypto.chpl
+++ b/modules/packages/Crypto.chpl
@@ -573,7 +573,6 @@ module Crypto {
       }
       this.cipher = tmpCipher;
       this.byteLen = bits/8;
-      super.init();
     }
 
     /* This function returns the size in bytes of the key-length/variant of
@@ -763,7 +762,6 @@ proc bfEncrypt(plaintext: CryptoBuffer, key: CryptoBuffer, IV: CryptoBuffer, cip
         otherwise do halt("The desired variant of Blowfish cipher does not exist.");
       }
       this.cipher = tmpCipher;
-      super.init();
     }
 
     /* This is the 'Blowfish' encrypt routine that encrypts the user supplied message buffer
@@ -937,7 +935,6 @@ proc bfEncrypt(plaintext: CryptoBuffer, key: CryptoBuffer, IV: CryptoBuffer, cip
       this.byteLen = byteLen;
       this.iterCount = iterCount;
       this.hashName = digest.getDigestName();
-      super.init();
     }
 
     /* This function represents Password-Based KDF 2. It generates a secure-key

--- a/modules/packages/LinearAlgebraJama.chpl
+++ b/modules/packages/LinearAlgebraJama.chpl
@@ -1559,7 +1559,6 @@ class Matrix {
       this.m = m;
       this.n = n;
       aDom = {1..m, 1..n};
-      super.init();
    }
 
    /* Construct an m-by-n constant matrix.
@@ -1573,7 +1572,6 @@ class Matrix {
       this.n = n;
       aDom = {1..m, 1..n};
       A = s;
-      super.init();
    }
 
    /* Construct a matrix from a 2-D array.
@@ -1618,7 +1616,6 @@ class Matrix {
       this.n = n;
       this.aDom = {1..m, 1..n};
       this.A = A(this.aDom);
-      super.init();
    }
 
    /* Construct a matrix from a one-dimensional packed array

--- a/modules/packages/MatrixMarket.chpl
+++ b/modules/packages/MatrixMarket.chpl
@@ -97,7 +97,6 @@ module MatrixMarket {
          fd = open(fname, iomode.cw, iokind.native);
          fout = fd.writer(start=0);
          headers_written=false;
-         super.init();
       }
 
       proc write_headers(nrows, ncols, nnz=-1) {
@@ -199,7 +198,6 @@ class MMReader {
    proc init(const fname:string) {
       fd = open(fname, iomode.r, hints=IOHINT_SEQUENTIAL|IOHINT_CACHED);
       fin = fd.reader(start=0, hints=IOHINT_SEQUENTIAL|IOHINT_CACHED);
-      super.init();
    }
 
    proc read_header() {

--- a/modules/standard/Barriers.chpl
+++ b/modules/standard/Barriers.chpl
@@ -329,7 +329,6 @@ module Barriers {
      */
     proc init(n: int) {
       count = n;
-      super.init();
     }
 
     proc reset(nTasks: int) {

--- a/modules/standard/Regexp.chpl
+++ b/modules/standard/Regexp.chpl
@@ -400,7 +400,6 @@ class BadRegexpError : Error {
   var msg:string;
   proc init(msg: string) {
     this.msg = msg;
-    super.init();
   }
   proc message() {
     return msg;

--- a/modules/standard/SysError.chpl
+++ b/modules/standard/SysError.chpl
@@ -50,7 +50,6 @@ class SystemError : Error {
   proc init(err: syserr, details: string = "") {
     this.err     = err;
     this.details = details;
-    super.init();
   }
 
   /*

--- a/test/arrays/dinan/init_arraymember/test3.chpl
+++ b/test/arrays/dinan/init_arraymember/test3.chpl
@@ -9,7 +9,6 @@ class C {
   
   proc init() {
     x = f(d);
-    super.init();
   }
 }
 

--- a/test/classes/claridge/baseConstructorCall.chpl
+++ b/test/classes/claridge/baseConstructorCall.chpl
@@ -16,8 +16,8 @@ class DerivedClass: BaseClass {
   var c: int;
 
   proc init(b:int, c:int) {
-    this.c = c;
     super.init(b);
+    this.c = c;
   }
 }
 

--- a/test/classes/deitz/constructors/test_construct1.chpl
+++ b/test/classes/deitz/constructors/test_construct1.chpl
@@ -5,7 +5,6 @@ class C {
   proc init(xVal, yVal) {
     x = xVal;
     y = yVal;
-    super.init();
   }
 
   proc init(b: bool) {

--- a/test/classes/deitz/constructors/test_generic_construct1.chpl
+++ b/test/classes/deitz/constructors/test_generic_construct1.chpl
@@ -5,7 +5,6 @@ class C {
   proc init(type ctVal, y: ctVal) {
     ct = ctVal;
     x = y;
-    super.init();
   }
 }
 

--- a/test/classes/deitz/constructors/test_generic_construct2.chpl
+++ b/test/classes/deitz/constructors/test_generic_construct2.chpl
@@ -8,13 +8,11 @@ class C {
     this.ct = ct;
     this.bt = bt;
     x = y;
-    super.init();
   }
 
   proc init(type ct, y: ct) {
     this.ct = ct;
     x = y;
-    super.init();
   }
 }
 

--- a/test/classes/ferguson/const-override-bug.chpl
+++ b/test/classes/ferguson/const-override-bug.chpl
@@ -18,7 +18,6 @@ class myNumaDomain : myAbstractLocaleModel {
 
   proc init() {
     name = "test";
-    super.init();
   }
 }
 

--- a/test/classes/ferguson/delete-free/owned-shared-fields.chpl
+++ b/test/classes/ferguson/delete-free/owned-shared-fields.chpl
@@ -63,7 +63,6 @@ class C3 {
   proc init(a:MyClass, b:MyClass) {
     fo = new Owned(a);
     fs = new Shared(b);
-    super.init();
   }
 }
 

--- a/test/classes/initializers/assign-param-segfault.chpl
+++ b/test/classes/initializers/assign-param-segfault.chpl
@@ -18,7 +18,6 @@ class Bar {
       when Foo.Foo3 do this.baz = Baz.Baz3;
       otherwise this.baz = Baz.Baz0;
       }
-    super.init();
   }
 }
 var bar = new Bar(Foo.Foo1);

--- a/test/classes/initializers/base-class-generic-args.chpl
+++ b/test/classes/initializers/base-class-generic-args.chpl
@@ -11,7 +11,6 @@ class Circle {
   {
     this.rank = myRank;
     this.r=h;
-    super.init();
   }
 }
 
@@ -22,8 +21,8 @@ proc Circle.area() return 3.14159*2**2;
 class Oval: Circle{
   var r2: real;
   proc init(h1,h2,param myRank=h1.size) {
-    r2=h2;
     super.init(h1, myRank);
+    r2=h2;
   }
 }
 

--- a/test/classes/initializers/base-initializer.chpl
+++ b/test/classes/initializers/base-initializer.chpl
@@ -20,8 +20,8 @@ proc Circle.area() return 3.14159*r**2;
 class Oval: Circle{
   var r2: real;
   proc init(h1,h2) {
-    r2=h2;
     super.init(h1);
+    r2=h2;
   }
 }
 

--- a/test/classes/initializers/blockArray.chpl
+++ b/test/classes/initializers/blockArray.chpl
@@ -16,6 +16,5 @@ class Foo {
   proc init(n1 : int, n2 : int) {
     dom = { 1 .. n1, 1 .. n2 };
 
-    super.init();
   }
 }

--- a/test/classes/initializers/bothInitCalls.chpl
+++ b/test/classes/initializers/bothInitCalls.chpl
@@ -13,7 +13,6 @@ class EitherOr {
   proc init(useField: bool, otherVal: int) {
     fieldInit = useField;
     infer = otherVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/compilerGenerated/constructorChild.chpl
+++ b/test/classes/initializers/compilerGenerated/constructorChild.chpl
@@ -3,9 +3,9 @@ class Parent {
 
   proc init() {
     x = 10;
-    super.init();
   }
 }
+
 
 class Child: Parent {
   var y: int;

--- a/test/classes/initializers/compilerGenerated/inherits_constructor.chpl
+++ b/test/classes/initializers/compilerGenerated/inherits_constructor.chpl
@@ -7,9 +7,9 @@ class Parent {
   // child is invalid
   proc Parent() {
     a = 11;
-    super.init();
   }
 }
+
 
 class Child : Parent {
   var b: int;

--- a/test/classes/initializers/compilerGenerated/inherits_initializer.chpl
+++ b/test/classes/initializers/compilerGenerated/inherits_initializer.chpl
@@ -8,7 +8,6 @@ class Parent {
   // generated child initializer.
   proc init() {
     a = 11;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/compilerGenerated/inherits_initializer_bad.chpl
+++ b/test/classes/initializers/compilerGenerated/inherits_initializer_bad.chpl
@@ -9,7 +9,7 @@ class Parent {
   // call in the generated child initializer.
   proc init(x1: int, x2: int) {
     a = x1 + x2;
-    super.init();
+
   }
 }
 

--- a/test/classes/initializers/compilerGenerated/parent_inherits_initializer.chpl
+++ b/test/classes/initializers/compilerGenerated/parent_inherits_initializer.chpl
@@ -9,7 +9,6 @@ class Grandparent {
   // generated parent initializer.
   proc init() {
     a = 11;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/compilerGenerated/parent_inherits_initializer_bad.chpl
+++ b/test/classes/initializers/compilerGenerated/parent_inherits_initializer_bad.chpl
@@ -9,9 +9,9 @@ class GrandParent {
   // super.init() call in the generated parent initializer.
   proc init(x1: int, x2: int) {
     a = x1 + x2;
-    super.init();
   }
 }
+
 
 class Parent: GrandParent {
   var b: int;

--- a/test/classes/initializers/cond-only-else-2.chpl
+++ b/test/classes/initializers/cond-only-else-2.chpl
@@ -11,7 +11,7 @@ record MyRec {
     else
       writeln('Else does not initialize x');
 
-    super.init();
+    this.initDone();
   }
 }
 

--- a/test/classes/initializers/cond-only-then-2.chpl
+++ b/test/classes/initializers/cond-only-then-2.chpl
@@ -9,7 +9,7 @@ record MyRec {
     if a < 10 then
       x = 20;
 
-    super.init();
+    this.initDone();
   }
 }
 

--- a/test/classes/initializers/cond-only-then-3.chpl
+++ b/test/classes/initializers/cond-only-then-3.chpl
@@ -11,7 +11,7 @@ record MyRec {
     else
       writeln('Else does not initialize x');
 
-    super.init();
+    this.initDone();
   }
 }
 

--- a/test/classes/initializers/errors/bothGeneric-lhsConsRhsInit.chpl
+++ b/test/classes/initializers/errors/bothGeneric-lhsConsRhsInit.chpl
@@ -5,7 +5,6 @@ class hasInit {
 
   proc init(xVal) {
     x = xVal;
-    super.init();
   }
 }
 
@@ -16,6 +15,7 @@ class hasConstruct {
     this.x = x;
   }
 }
+
 
 var hi: hasConstruct(int) = new hasInit(10);
 writeln(hi);

--- a/test/classes/initializers/errors/bothGeneric-lhsInitRhsCons.chpl
+++ b/test/classes/initializers/errors/bothGeneric-lhsInitRhsCons.chpl
@@ -5,7 +5,6 @@ class hasInit {
 
   proc init(xVal) {
     x = xVal;
-    super.init();
   }
 }
 
@@ -16,6 +15,7 @@ class hasConstruct {
     this.x = x;
   }
 }
+
 
 var hi: hasInit(int) = new hasConstruct(10);
 writeln(hi);

--- a/test/classes/initializers/errors/errHandling/initThrows.chpl
+++ b/test/classes/initializers/errors/errHandling/initThrows.chpl
@@ -5,7 +5,6 @@ class Foo {
 
   proc init() throws {
     x = 10;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/errors/errHandling/initWithThrow.chpl
+++ b/test/classes/initializers/errors/errHandling/initWithThrow.chpl
@@ -7,7 +7,6 @@ class Foo {
   proc init() {
     x = 10;
     throw new Error();
-    super.init();
   }
 }
 

--- a/test/classes/initializers/errors/errHandling/initWithTry.chpl
+++ b/test/classes/initializers/errors/errHandling/initWithTry.chpl
@@ -7,7 +7,6 @@ class Foo {
   proc init() {
     x = 10;
     try outerFunc();
-    super.init();
   }
 }
 

--- a/test/classes/initializers/errors/errHandling/initWithTry2.chpl
+++ b/test/classes/initializers/errors/errHandling/initWithTry2.chpl
@@ -9,7 +9,6 @@ class Foo {
     try {
       outerFunc();
     }
-    super.init();
   }
 }
 

--- a/test/classes/initializers/errors/errHandling/initWithTryBang.chpl
+++ b/test/classes/initializers/errors/errHandling/initWithTryBang.chpl
@@ -8,7 +8,7 @@ class Foo {
     try! {
       outerFunc();
     }
-    super.init();
+
   }
 }
 

--- a/test/classes/initializers/errors/errHandling/initWithTryBang2.chpl
+++ b/test/classes/initializers/errors/errHandling/initWithTryBang2.chpl
@@ -6,7 +6,7 @@ class Foo {
   proc init() {
     x = 10;
     try! outerFunc();
-    super.init();
+
   }
 }
 

--- a/test/classes/initializers/errors/errHandling/initWithTryBangCatch.chpl
+++ b/test/classes/initializers/errors/errHandling/initWithTryBangCatch.chpl
@@ -11,7 +11,6 @@ class Foo {
     } catch {
       writeln("Look ma, I caught an error!");
     }
-    super.init();
   }
 }
 

--- a/test/classes/initializers/errors/errHandling/initWithTryCatch.chpl
+++ b/test/classes/initializers/errors/errHandling/initWithTryCatch.chpl
@@ -11,7 +11,6 @@ class Foo {
     } catch {
       writeln("Look ma, I caught an error!");
     }
-    super.init();
   }
 }
 

--- a/test/classes/initializers/errors/errHandling/tryDeeper.chpl
+++ b/test/classes/initializers/errors/errHandling/tryDeeper.chpl
@@ -9,7 +9,6 @@ class Foo {
     {
       try outerFunc();
     }
-    super.init();
   }
 }
 

--- a/test/classes/initializers/errors/fieldBeforeSuper.chpl
+++ b/test/classes/initializers/errors/fieldBeforeSuper.chpl
@@ -1,0 +1,12 @@
+
+class C {
+  var x : int;
+
+  proc init() {
+    this.x = 5;
+    super.init();
+  }
+}
+
+var c = new C();
+delete c;

--- a/test/classes/initializers/errors/fieldBeforeSuper.good
+++ b/test/classes/initializers/errors/fieldBeforeSuper.good
@@ -1,0 +1,2 @@
+fieldBeforeSuper.chpl:5: In initializer:
+fieldBeforeSuper.chpl:6: error: field initialization not allowed before super.init() or this.init()

--- a/test/classes/initializers/errors/fieldRecordTypeMismatch.chpl
+++ b/test/classes/initializers/errors/fieldRecordTypeMismatch.chpl
@@ -11,7 +11,6 @@ class C {
 
   proc init(y: real) {
     x = y;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/errors/generic-lhsConsRhsInit.chpl
+++ b/test/classes/initializers/errors/generic-lhsConsRhsInit.chpl
@@ -5,7 +5,6 @@ class hasInit {
 
   proc init(xVal) {
     x = xVal;
-    super.init();
   }
 }
 
@@ -16,6 +15,7 @@ class hasConstruct {
     this.x = x;
   }
 }
+
 
 var hi: hasConstruct(int) = new hasInit(10);
 writeln(hi);

--- a/test/classes/initializers/errors/generic-lhsConsRhsInit2.chpl
+++ b/test/classes/initializers/errors/generic-lhsConsRhsInit2.chpl
@@ -5,7 +5,6 @@ class hasInit {
 
   proc init(xVal) {
     x = xVal;
-    super.init();
   }
 }
 
@@ -16,6 +15,7 @@ class hasConstruct {
     x = xVal;
   }
 }
+
 
 var hi: hasConstruct = new hasInit(10);
 writeln(hi);

--- a/test/classes/initializers/errors/generic-lhsInitRhsCons.chpl
+++ b/test/classes/initializers/errors/generic-lhsInitRhsCons.chpl
@@ -5,7 +5,6 @@ class hasInit {
 
   proc init(xVal) {
     x = xVal;
-    super.init();
   }
 }
 
@@ -16,6 +15,7 @@ class hasConstruct {
     x = xVal;
   }
 }
+
 
 var hi: hasInit(int) = new hasConstruct(10);
 writeln(hi);

--- a/test/classes/initializers/errors/generic-lhsInitRhsCons2.chpl
+++ b/test/classes/initializers/errors/generic-lhsInitRhsCons2.chpl
@@ -5,7 +5,6 @@ class hasInit {
 
   proc init(xVal) {
     x = xVal;
-    super.init();
   }
 }
 
@@ -16,6 +15,7 @@ class hasConstruct {
     this.x = x;
   }
 }
+
 
 var hi: hasInit = new hasConstruct(10);
 writeln(hi);

--- a/test/classes/initializers/errors/lhsConsRhsInit.chpl
+++ b/test/classes/initializers/errors/lhsConsRhsInit.chpl
@@ -3,7 +3,6 @@ class hasInit {
 
   proc init(xVal) {
     x = xVal;
-    super.init();
   }
 }
 
@@ -14,6 +13,7 @@ class hasConstruct {
     x = xVal;
   }
 }
+
 
 var hi: hasConstruct = new hasInit(10);
 writeln(hi);

--- a/test/classes/initializers/errors/lhsInitRhsCons.chpl
+++ b/test/classes/initializers/errors/lhsInitRhsCons.chpl
@@ -3,7 +3,6 @@ class hasInit {
 
   proc init(xVal) {
     x = xVal;
-    super.init();
   }
 }
 
@@ -14,6 +13,7 @@ class hasConstruct {
     x = xVal;
   }
 }
+
 
 var hi: hasInit = new hasConstruct(10);
 writeln(hi);

--- a/test/classes/initializers/errors/name-bad-field.chpl
+++ b/test/classes/initializers/errors/name-bad-field.chpl
@@ -5,7 +5,6 @@ record R {
 
   proc init() {
     a = 1; writeln(b);
-    super.init();
   }
 }
 

--- a/test/classes/initializers/field-undefined.chpl
+++ b/test/classes/initializers/field-undefined.chpl
@@ -8,7 +8,6 @@ class Foo {
     b = _b;
     c = _c;
 
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generic-uninit-field-initializers.chpl
+++ b/test/classes/initializers/generic-uninit-field-initializers.chpl
@@ -14,7 +14,6 @@ class A {
   var x:t;
   proc init(type t) {
     this.t = t;
-    super.init();
   }
   // initializer for class 'A' requires a generic argument called 't'
 }
@@ -34,7 +33,6 @@ class B {
   param p;
   proc init(param p) {
     this.p = p;
-    super.init();
   }
   // initializer for class 'B' requires a generic argument called 'p'
 }
@@ -53,7 +51,6 @@ class C {
   const cst;
   proc init(cst) {
     this.cst = cst;
-    super.init();
   }
   // initializer for class 'C' requires a generic argument called 'cst'
 }
@@ -74,7 +71,6 @@ class D {
   var vbl;
   proc init(vbl) {
     this.vbl = vbl;
-    super.init();
   }
   // initializer for class 'D' requires a generic argument called 'vbl'
 }

--- a/test/classes/initializers/generic_initializer.chpl
+++ b/test/classes/initializers/generic_initializer.chpl
@@ -7,7 +7,6 @@ class Foo {
   proc init(type x_t, i:x_t, j:x_t) {
     this.x_t = x_t;
     x = i+j;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/argumentLess.chpl
+++ b/test/classes/initializers/generics/argumentLess.chpl
@@ -6,7 +6,6 @@ class Foo {
   proc init() {
     t = int;
     v = 10;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/build_new.chpl
+++ b/test/classes/initializers/generics/build_new.chpl
@@ -16,7 +16,6 @@ class MyClass0 {
     a0 = a;
     b0 = b;
 
-    super.init();
   }
 }
 
@@ -25,10 +24,10 @@ class MyClass1 : MyClass0 {
   var b1;
 
   proc init(a0, b0, a, b) {
+    super.init(a0, b0);
+
     a1 = a;
     b1 = b;
-
-    super.init(a0, b0);
   }
 }
 

--- a/test/classes/initializers/generics/declarations/argument_type.chpl
+++ b/test/classes/initializers/generics/declarations/argument_type.chpl
@@ -7,7 +7,6 @@ class Foo {
   proc init(xVal) {
     t = xVal.type;
     x = xVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/declarations/argument_type2.chpl
+++ b/test/classes/initializers/generics/declarations/argument_type2.chpl
@@ -6,7 +6,6 @@ class Foo {
   proc init(xVal) {
     t = xVal.type;
     x = xVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/declarations/concrete-inits-bad.chpl
+++ b/test/classes/initializers/generics/declarations/concrete-inits-bad.chpl
@@ -9,13 +9,11 @@ class Foo {
   proc init(xVal: int) {
     x = xVal;
     y = xVal + 2;
-    super.init();
   }
 
   proc init(xVal: real) {
     x = xVal;
     y = xVal + 2;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/declarations/concrete-inits-multiple-bad.chpl
+++ b/test/classes/initializers/generics/declarations/concrete-inits-multiple-bad.chpl
@@ -11,7 +11,6 @@ class Foo {
     x = xVal;
     y = yVal;
     z = xVal + 2;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/declarations/concrete-inits-multiple.chpl
+++ b/test/classes/initializers/generics/declarations/concrete-inits-multiple.chpl
@@ -10,7 +10,6 @@ class Foo {
     x = xVal;
     y = yVal;
     z = xVal + 2;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/declarations/concrete-inits.chpl
+++ b/test/classes/initializers/generics/declarations/concrete-inits.chpl
@@ -8,13 +8,11 @@ class Foo {
   proc init(xVal: int) {
     x = xVal;
     y = xVal + 2;
-    super.init();
   }
 
   proc init(xVal: real) {
     x = xVal;
     y = xVal + 2;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/declarations/default_value.chpl
+++ b/test/classes/initializers/generics/declarations/default_value.chpl
@@ -9,7 +9,6 @@ class Foo {
   proc init(xVal = 3) {
     x = xVal;
     y = xVal + 2;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/declarations/default_value_bad.chpl
+++ b/test/classes/initializers/generics/declarations/default_value_bad.chpl
@@ -8,7 +8,6 @@ class Foo {
   proc init(xVal = 3) {
     x = xVal;
     y = xVal + 2;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/declarations/matches-param.chpl
+++ b/test/classes/initializers/generics/declarations/matches-param.chpl
@@ -6,7 +6,6 @@ class Foo {
 
   proc init(param pVal) {
     p = pVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/declarations/matches-type.chpl
+++ b/test/classes/initializers/generics/declarations/matches-type.chpl
@@ -6,7 +6,6 @@ class Foo {
 
   proc init(type tVal) {
     t = tVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/declarations/matches-var.chpl
+++ b/test/classes/initializers/generics/declarations/matches-var.chpl
@@ -6,7 +6,6 @@ class Foo {
 
   proc init(vVal) {
     v = vVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/declarations/multiple_type_functions.chpl
+++ b/test/classes/initializers/generics/declarations/multiple_type_functions.chpl
@@ -11,14 +11,12 @@ class Foo {
     t = tVal;
     x = xVal;
     y = yVal;
-    super.init();
   }
 
   proc init(type tVal, xVal, yVal: bool) {
     t = tVal;
     x = xVal;
     y = yVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/declarations/no-arg-param.chpl
+++ b/test/classes/initializers/generics/declarations/no-arg-param.chpl
@@ -7,7 +7,6 @@ class Foo {
 
   proc init() {
     p = 4;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/declarations/no-arg-param2.chpl
+++ b/test/classes/initializers/generics/declarations/no-arg-param2.chpl
@@ -7,7 +7,6 @@ class Foo {
 
   proc init() {
     p = 4;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/declarations/no-arg-param3.chpl
+++ b/test/classes/initializers/generics/declarations/no-arg-param3.chpl
@@ -7,7 +7,6 @@ class Foo {
 
   proc init() {
     p = 4;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/declarations/no-arg-param4.chpl
+++ b/test/classes/initializers/generics/declarations/no-arg-param4.chpl
@@ -8,7 +8,6 @@ class Foo {
 
   proc init() {
     p = 4;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/declarations/no-arg-param5.chpl
+++ b/test/classes/initializers/generics/declarations/no-arg-param5.chpl
@@ -9,7 +9,6 @@ class Foo {
 
   proc init() {
     p = 4;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/declarations/no-arg-type.chpl
+++ b/test/classes/initializers/generics/declarations/no-arg-type.chpl
@@ -7,7 +7,6 @@ class Foo {
 
   proc init() {
     t = int;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/declarations/no-arg-type2.chpl
+++ b/test/classes/initializers/generics/declarations/no-arg-type2.chpl
@@ -7,7 +7,6 @@ class Foo {
 
   proc init() {
     t = int;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/declarations/no-arg-type3.chpl
+++ b/test/classes/initializers/generics/declarations/no-arg-type3.chpl
@@ -7,7 +7,6 @@ class Foo {
 
   proc init() {
     t = int;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/declarations/no-arg-type4.chpl
+++ b/test/classes/initializers/generics/declarations/no-arg-type4.chpl
@@ -8,7 +8,6 @@ class Foo {
 
   proc init() {
     t = int;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/declarations/no-arg-type5.chpl
+++ b/test/classes/initializers/generics/declarations/no-arg-type5.chpl
@@ -9,7 +9,6 @@ class Foo {
 
   proc init() {
     t = int;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/declarations/same_type_function.chpl
+++ b/test/classes/initializers/generics/declarations/same_type_function.chpl
@@ -6,12 +6,10 @@ class Foo {
   proc init(type t) {
     var xVal: t;
     x = xVal;
-    super.init();
   }
 
   proc init(xVal) {
     x = xVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/declarations/same_type_function_equally_good.chpl
+++ b/test/classes/initializers/generics/declarations/same_type_function_equally_good.chpl
@@ -11,7 +11,6 @@ class Foo {
     t = tVal;
     x = xVal;
     y = yVal;
-    super.init();
   }
 
   proc init(xVal, type yType) {
@@ -19,7 +18,6 @@ class Foo {
     x = xVal;
     var yVal: t;
     y = yVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/declarations/side-effects.chpl
+++ b/test/classes/initializers/generics/declarations/side-effects.chpl
@@ -9,7 +9,6 @@ class Foo {
   proc init(param pVal) {
     p = pVal;
     writeln(pVal);
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/declarations/side-effects2.chpl
+++ b/test/classes/initializers/generics/declarations/side-effects2.chpl
@@ -11,7 +11,6 @@ class Foo {
   proc init(param pVal) {
     p = pVal;
     writeln(pVal);
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/declarations/unusual-param-arg.chpl
+++ b/test/classes/initializers/generics/declarations/unusual-param-arg.chpl
@@ -7,12 +7,10 @@ class Foo {
 
   proc init(param pVal: int) where (pVal <= 10) {
     p = 10;
-    super.init();
   }
 
   proc init(param pVal: int) where (pVal > 10) {
     p = pVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/declarations/unusual-param-arg2.chpl
+++ b/test/classes/initializers/generics/declarations/unusual-param-arg2.chpl
@@ -11,12 +11,10 @@ class Foo {
 
   proc init(param pVal: int) where (pVal <= 10) {
     p = 10;
-    super.init();
   }
 
   proc init(param pVal: int) where (pVal > 10) {
     p = pVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/declarations/unusual-type-arg.chpl
+++ b/test/classes/initializers/generics/declarations/unusual-type-arg.chpl
@@ -7,12 +7,10 @@ class Foo {
 
   proc init(type tVal) where (isIntegralType(tVal)) { // true for int, uint
     t = int;
-    super.init();
   }
 
   proc init(type tVal) where (!isIntegralType(tVal)) { // everything else
     t = tVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/declarations/unusual-type-arg2.chpl
+++ b/test/classes/initializers/generics/declarations/unusual-type-arg2.chpl
@@ -11,12 +11,10 @@ class Foo {
 
   proc init(type tVal) where (isIntegralType(tVal)) { // true for int, uint
     t = int;
-    super.init();
   }
 
   proc init(type tVal) where (!isIntegralType(tVal)) { // everything else
     t = tVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/declarations/unusual-var-arg.chpl
+++ b/test/classes/initializers/generics/declarations/unusual-var-arg.chpl
@@ -7,12 +7,10 @@ class Foo {
 
   proc init(vVal) where (isIntegralType(vVal.type)) {
     v = 10;
-    super.init();
   }
 
   proc init(vVal) where (!isIntegralType(vVal.type)) {
     v = vVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/declarations/unusual-var-arg2.chpl
+++ b/test/classes/initializers/generics/declarations/unusual-var-arg2.chpl
@@ -11,12 +11,10 @@ class Foo {
 
   proc init(vVal) where (isIntegralType(vVal.type)) {
     v = 10;
-    super.init();
   }
 
   proc init(vVal) where (!isIntegralType(vVal.type)) {
     v = vVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/defaultValueClassArg-regularProc.chpl
+++ b/test/classes/initializers/generics/defaultValueClassArg-regularProc.chpl
@@ -3,7 +3,6 @@ class Foo {
 
   proc init(xVal) {
     x = xVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/defaultValueClassArg.chpl
+++ b/test/classes/initializers/generics/defaultValueClassArg.chpl
@@ -3,7 +3,6 @@ class Foo {
 
   proc init(xVal) {
     x = xVal;
-    super.init();
   }
 }
 
@@ -12,7 +11,6 @@ class DefaultArg {
 
   proc init(yVal = new Foo(3)) {
     y = yVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/explicitAssignment.chpl
+++ b/test/classes/initializers/generics/explicitAssignment.chpl
@@ -5,12 +5,12 @@ class Foo {
 
   proc init(xVal: int) {
     x = xVal;
-    super.init();
+
   }
 
   proc init(xVal: real) {
     x = xVal;
-    super.init();
+
   }
 }
 

--- a/test/classes/initializers/generics/explicitTNaming.chpl
+++ b/test/classes/initializers/generics/explicitTNaming.chpl
@@ -3,7 +3,6 @@ class Foo {
 
   proc init(type t) {
     this.t = t;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/genericArgUsesTypeQuery.chpl
+++ b/test/classes/initializers/generics/genericArgUsesTypeQuery.chpl
@@ -3,13 +3,11 @@ class C {
 
   proc init(type t, n) {
     this.t = t;
-    super.init();
   }
 
   proc init(other: C(?otherType),
             type classType = otherType) {
     this.t = other.t;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/inheritance/childFieldRefersToParentParam.chpl
+++ b/test/classes/initializers/generics/inheritance/childFieldRefersToParentParam.chpl
@@ -3,7 +3,6 @@ class BaseArr {
 
   proc init(param rank: int) {
     this.rank = rank;
-    super.init();
   }
 }
 
@@ -14,7 +13,6 @@ class ZeroBasedArr: BaseArr {
      from parent type during phase 1 of initialization:
   proc init(param rank: int) {
     this.rank = rank;
-    super.init();
   }
   */
 

--- a/test/classes/initializers/generics/inheritance/concrete-sub-inherits-param.chpl
+++ b/test/classes/initializers/generics/inheritance/concrete-sub-inherits-param.chpl
@@ -7,7 +7,6 @@ class Parent {
   proc init(param pVal: int) {
     p = pVal;
     x = pVal + 4;
-    super.init();
   }
 }
 
@@ -15,8 +14,8 @@ class Child : Parent {
   var y: int;
 
   proc init(yVal: int, param pVal: int) {
-    y = yVal;
     super.init(pVal);
+    y = yVal;
   }
 }
 

--- a/test/classes/initializers/generics/inheritance/concrete-sub-inherits-type.chpl
+++ b/test/classes/initializers/generics/inheritance/concrete-sub-inherits-type.chpl
@@ -8,7 +8,6 @@ class Parent {
   proc init(xVal) {
     t = xVal.type;
     x = xVal;
-    super.init();
   }
 }
 
@@ -16,8 +15,8 @@ class Child : Parent {
   var y: t;
 
   proc init(yVal, xVal) where yVal.type == xVal.type {
-    y = yVal;
     super.init(xVal);
+    y = yVal;
   }
 }
 

--- a/test/classes/initializers/generics/inheritance/concrete-sub-inherits-type.future
+++ b/test/classes/initializers/generics/inheritance/concrete-sub-inherits-type.future
@@ -1,7 +1,0 @@
-feature request: inheritance from generic classes with initializers
-
-Initializers on subclasses when the parent class is generic currently run into
-issues.  When the subclass is concrete, we get an assertion error during
-initializerResolution.  When the subclass is generic, we get an issue with an
-argument being generic when we don't expect it to be.  These are both
-resolvable issues, but I haven't taken the time to fix them yet.

--- a/test/classes/initializers/generics/inheritance/concrete-sub-inherits-type2.chpl
+++ b/test/classes/initializers/generics/inheritance/concrete-sub-inherits-type2.chpl
@@ -7,7 +7,6 @@ class Parent {
   proc init(xVal) {
     t = xVal.type;
     x = xVal;
-    super.init();
   }
 }
 
@@ -15,8 +14,8 @@ class Child : Parent {
   var y: int;
 
   proc init(yVal: int, xVal) {
-    y = yVal;
     super.init(xVal);
+    y = yVal;
   }
 }
 

--- a/test/classes/initializers/generics/inheritance/concrete-sub-inherits-var.chpl
+++ b/test/classes/initializers/generics/inheritance/concrete-sub-inherits-var.chpl
@@ -7,7 +7,6 @@ class Parent {
   proc init(xVal: int) {
     gen = -xVal;
     x = xVal;
-    super.init();
   }
 }
 
@@ -15,8 +14,8 @@ class Child : Parent {
   var y: int;
 
   proc init(yVal: int, xVal: int) {
-    y = yVal;
     super.init(xVal);
+    y = yVal;
   }
 }
 

--- a/test/classes/initializers/generics/inheritance/generic-sub-param-inherits-param.chpl
+++ b/test/classes/initializers/generics/inheritance/generic-sub-param-inherits-param.chpl
@@ -7,7 +7,6 @@ class Parent {
   proc init(param pVal: int) {
     p = pVal;
     x = pVal + 4;
-    super.init();
   }
 }
 
@@ -16,9 +15,9 @@ class Child : Parent {
   var y: int;
 
   proc init(yVal: int, param pVal: int) {
+    super.init(pVal);
     p2 = pVal > 10;
     y = yVal;
-    super.init(pVal);
   }
 }
 

--- a/test/classes/initializers/generics/inheritance/generic-sub-param-inherits-param.good
+++ b/test/classes/initializers/generics/inheritance/generic-sub-param-inherits-param.good
@@ -1,2 +1,2 @@
-Child(true,11)
+Child(11,true)
 {x = 15, y = 10}

--- a/test/classes/initializers/generics/inheritance/generic-sub-type-inherits-type.chpl
+++ b/test/classes/initializers/generics/inheritance/generic-sub-type-inherits-type.chpl
@@ -7,7 +7,6 @@ class Parent {
   proc init(xVal) {
     t = xVal.type;
     x = xVal;
-    super.init();
   }
 }
 
@@ -16,9 +15,9 @@ class Child : Parent {
   var y: t2;
 
   proc init(yVal, xVal) {
+    super.init(xVal);
     t2 = yVal.type;
     y = yVal;
-    super.init(xVal);
   }
 }
 

--- a/test/classes/initializers/generics/inheritance/generic-sub-var-inherits-var.chpl
+++ b/test/classes/initializers/generics/inheritance/generic-sub-var-inherits-var.chpl
@@ -7,7 +7,6 @@ class Parent {
   proc init(xVal: int) {
     gen = -xVal;
     x = xVal;
-    super.init();
   }
 }
 
@@ -16,9 +15,9 @@ class Child : Parent {
   var y: int;
 
   proc init(yVal: int, xVal: int) {
+    super.init(xVal);
     gen2 = -yVal;
     y = yVal;
-    super.init(xVal);
   }
 }
 

--- a/test/classes/initializers/generics/inheritance/setParentField-param.chpl
+++ b/test/classes/initializers/generics/inheritance/setParentField-param.chpl
@@ -3,7 +3,7 @@ class Foo {
 
   proc init() {
     p = 2;
-    super.init();
+
   }
 }
 
@@ -13,7 +13,7 @@ class Bar : Foo {
   proc init(xVal) {
     x = xVal;
     p = 6;
-    super.init();
+
   }
 }
 

--- a/test/classes/initializers/generics/inheritance/setParentField-type.chpl
+++ b/test/classes/initializers/generics/inheritance/setParentField-type.chpl
@@ -3,7 +3,7 @@ class Foo {
 
   proc init() {
     t = bool;
-    super.init();
+
   }
 }
 
@@ -13,7 +13,7 @@ class Bar : Foo {
   proc init(xVal) {
     x = xVal;
     t = real;
-    super.init();
+
   }
 }
 

--- a/test/classes/initializers/generics/inheritance/setParentField-var.chpl
+++ b/test/classes/initializers/generics/inheritance/setParentField-var.chpl
@@ -3,7 +3,7 @@ class Foo {
 
   proc init() {
     v = 2;
-    super.init();
+
   }
 }
 
@@ -13,7 +13,7 @@ class Bar : Foo {
   proc init(xVal) {
     x = xVal;
     v = x + 2;
-    super.init();
+
   }
 }
 

--- a/test/classes/initializers/generics/init-param-from-non-param.chpl
+++ b/test/classes/initializers/generics/init-param-from-non-param.chpl
@@ -3,7 +3,6 @@ class C {
   proc init() {
     var notaparam = 77;
     p = notaparam;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/init-type.chpl
+++ b/test/classes/initializers/generics/init-type.chpl
@@ -8,7 +8,6 @@ class A {
   var x:t;
   proc init(type t) {
     this.t = t;
-    super.init();
   }
   // initializer for class 'A' requires a generic argument called 't'
 }

--- a/test/classes/initializers/generics/init-type2.chpl
+++ b/test/classes/initializers/generics/init-type2.chpl
@@ -11,7 +11,6 @@ class A {
   proc init() {
     // I removed the argument and explicit setting of field t, to show that
     // omitted type fields work just fine.
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/init-type3.chpl
+++ b/test/classes/initializers/generics/init-type3.chpl
@@ -12,7 +12,6 @@ class A {
     // I removed the argument and explicit setting of field t, to show that
     // omitted type fields work just fine.
     this.x = xVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/init-type4.chpl
+++ b/test/classes/initializers/generics/init-type4.chpl
@@ -13,7 +13,6 @@ class A {
     // I removed the argument and explicit setting of field t, to show that
     // omitted type fields work just fine.
     this.x = xVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/initAtomicsViaWrite.chpl
+++ b/test/classes/initializers/generics/initAtomicsViaWrite.chpl
@@ -5,7 +5,6 @@ class C {
   proc init() {
     head.write(0);
     tail.write(0);
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/moreTypeFields.chpl
+++ b/test/classes/initializers/generics/moreTypeFields.chpl
@@ -10,7 +10,6 @@ class Foo {
   proc init(type t1Val, type t2Val) {
     t1 = t1Val;
     t2 = t2Val;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/nested.chpl
+++ b/test/classes/initializers/generics/nested.chpl
@@ -7,7 +7,7 @@ class C {
 
   proc init() {
     rank = 2;
-    super.init();
+    this.initDone();
     x = new D();
   }
 }

--- a/test/classes/initializers/generics/nested2.chpl
+++ b/test/classes/initializers/generics/nested2.chpl
@@ -8,7 +8,6 @@ class C {
   proc init() {
     rank = 2;
     x = new D();
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/omittedGenerics1.chpl
+++ b/test/classes/initializers/generics/omittedGenerics1.chpl
@@ -10,7 +10,6 @@ class SoManyParams {
     otherField = otherFieldVal;
     // the above is used to make the initializer actually do something.  The
     // other two fields should be given their appropriate default value.
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/omittedGenerics2.chpl
+++ b/test/classes/initializers/generics/omittedGenerics2.chpl
@@ -11,7 +11,6 @@ class Doomed {
     // the above is used to make the initializer actually do something.  It
     // should fail to resolve, though, because we have no idea what to do with
     // the param field.
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/onlyExplicit.chpl
+++ b/test/classes/initializers/generics/onlyExplicit.chpl
@@ -6,7 +6,6 @@ class Foo {
 
   proc init(param a) {
     this.a = a;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/ordinary_param.chpl
+++ b/test/classes/initializers/generics/ordinary_param.chpl
@@ -3,7 +3,6 @@ class Foo {
 
   proc init(param a) {
     this.a = a;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/paramArgDefaultValue.chpl
+++ b/test/classes/initializers/generics/paramArgDefaultValue.chpl
@@ -6,7 +6,6 @@ class Foo {
 
   proc init(param pVal = 3) {
     p = pVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/phase1/accessThisBad.chpl
+++ b/test/classes/initializers/generics/phase1/accessThisBad.chpl
@@ -6,7 +6,7 @@ class ThisTooEarly {
 
     r = rVal;
 
-    super.init();
+    this.initDone();
 
     foo(this); // OK!
   }

--- a/test/classes/initializers/generics/phase1/accessThisGood.chpl
+++ b/test/classes/initializers/generics/phase1/accessThisGood.chpl
@@ -3,7 +3,6 @@ class ThisEarly {
 
   proc init(param r: real) {
     this.r = r; // This is the only accepted use of this
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/phase1/badDependence.chpl
+++ b/test/classes/initializers/generics/phase1/badDependence.chpl
@@ -10,7 +10,6 @@ class ManyFields {
 
     f5 = val;
 
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/phase1/badDependence2.chpl
+++ b/test/classes/initializers/generics/phase1/badDependence2.chpl
@@ -6,7 +6,7 @@ class ManyFields {
     // f4's implicit reliance on f5 is bad, but the field declaration will tell
     // us this.
     f5 = val;
-    super.init();
+    this.initDone();
     // The proper way to write this is in Phase 2, or by relying on the val
     // argument.  You may also choose to initialize these fields with noinit
     // during Phase 1

--- a/test/classes/initializers/generics/phase1/enumField.chpl
+++ b/test/classes/initializers/generics/phase1/enumField.chpl
@@ -8,7 +8,6 @@ class Foo {
   proc init(val: Color) {
     a = val;
     b = green;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/phase1/enumFieldExplicitType.chpl
+++ b/test/classes/initializers/generics/phase1/enumFieldExplicitType.chpl
@@ -7,7 +7,6 @@ class Foo {
   proc init(val: Color) {
     a = val;
     b = Color.green;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/phase1/enumFieldNoUseBad.chpl
+++ b/test/classes/initializers/generics/phase1/enumFieldNoUseBad.chpl
@@ -7,7 +7,6 @@ class Foo {
 
   proc init() {
     a = blue;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/phase1/hasBlock.chpl
+++ b/test/classes/initializers/generics/phase1/hasBlock.chpl
@@ -7,7 +7,6 @@ class Scoping {
       a = aVal;
     }
     b = bVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/phase1/hasBlockNested.chpl
+++ b/test/classes/initializers/generics/phase1/hasBlockNested.chpl
@@ -15,7 +15,6 @@ class Scoping {
       c = cVal;
     }
     d = dVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/phase1/hasIf.chpl
+++ b/test/classes/initializers/generics/phase1/hasIf.chpl
@@ -10,7 +10,6 @@ class IfInit {
     } else {
       f2 = val;
     }
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/phase1/hasIfImplicit.chpl
+++ b/test/classes/initializers/generics/phase1/hasIfImplicit.chpl
@@ -11,7 +11,6 @@ class IfInit {
 
     // Error f2 is only initialized if f1 is false
 
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/phase1/hasLoopBad.chpl
+++ b/test/classes/initializers/generics/phase1/hasLoopBad.chpl
@@ -16,7 +16,6 @@ class InLoop {
     // in a loop could result in out of order initialization, or multiple
     // initialization, which would interfere with our ability to implicitly
     // initialize omitted fields.
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/phase1/hasLoopBad2.chpl
+++ b/test/classes/initializers/generics/phase1/hasLoopBad2.chpl
@@ -8,7 +8,6 @@ class InLoop {
     for i in arr.domain {
       highestNum = arr[i]; // uh oh!
     }
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/phase1/hasLoopBad3.chpl
+++ b/test/classes/initializers/generics/phase1/hasLoopBad3.chpl
@@ -12,7 +12,6 @@ class InLoop {
     for i in arr.domain {
       highestNum = arr[i];
     }
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/phase1/hasLoopBadDoWhile.chpl
+++ b/test/classes/initializers/generics/phase1/hasLoopBadDoWhile.chpl
@@ -10,7 +10,6 @@ class InLoop {
       highestNum = arr[i]; // uh oh!
       i += 1;
     } while (i < arr.domain.high);
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/phase1/hasLoopBadWhile.chpl
+++ b/test/classes/initializers/generics/phase1/hasLoopBadWhile.chpl
@@ -10,7 +10,6 @@ class InLoop {
       highestNum = arr[i]; // uh oh!
       i += 1;
     }
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/phase1/hasLoopGood.chpl
+++ b/test/classes/initializers/generics/phase1/hasLoopGood.chpl
@@ -14,7 +14,6 @@ class InLoop {
       }
     }
     highestNum = highest;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/phase1/hasParallelBad.chpl
+++ b/test/classes/initializers/generics/phase1/hasParallelBad.chpl
@@ -7,7 +7,6 @@ class InParallel {
       a = x;
       b = y;
     }
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/phase1/localHelpers.chpl
+++ b/test/classes/initializers/generics/phase1/localHelpers.chpl
@@ -10,7 +10,7 @@ class UsesHelpers {
     // value for it.
     f2 = helper;
     f3 = val;
-    super.init();
+    this.initDone();
     if (helper > 10) {
       writeln("double digits, woo!");
     }

--- a/test/classes/initializers/generics/phase1/methodCall.chpl
+++ b/test/classes/initializers/generics/phase1/methodCall.chpl
@@ -7,7 +7,6 @@ class MethodTooEarly {
 
     i = iVal;
 
-    super.init();
   }
 
   // This method demonstrates why it would be bad to access a method

--- a/test/classes/initializers/generics/phase1/multipleInits.chpl
+++ b/test/classes/initializers/generics/phase1/multipleInits.chpl
@@ -8,7 +8,6 @@ class LotsOFields {
     f2 = val2;
     f2 = val2*3; // uh oh!
     f3 = val3;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/phase1/multipleInits2.chpl
+++ b/test/classes/initializers/generics/phase1/multipleInits2.chpl
@@ -8,7 +8,6 @@ class LotsOFields {
     f2 = val2;
     f3 = val3;
     f2 = val2*3; // uh oh! Could error with "out of order" or "multiple init"
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/phase1/nested-function-defined-in-phase-2.chpl
+++ b/test/classes/initializers/generics/phase1/nested-function-defined-in-phase-2.chpl
@@ -6,7 +6,7 @@ class Foo {
   proc init(param val) {
     field = val;
     nested();
-    super.init();
+    this.initDone();
 
     // Where the function definition was placed shouldn't impact its viability
     proc nested() {

--- a/test/classes/initializers/generics/phase1/nested-function-mods-field1.chpl
+++ b/test/classes/initializers/generics/phase1/nested-function-mods-field1.chpl
@@ -9,7 +9,6 @@ class Foo {
     proc nested() {
       field = -field; // because this modifies a field
     }
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/phase1/nested-function-mods-field2.chpl
+++ b/test/classes/initializers/generics/phase1/nested-function-mods-field2.chpl
@@ -10,7 +10,6 @@ class Foo {
 
     field = val;
     nested(); // so this call shouldn't be allowed in Phase 1
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/phase1/nested-function-phase-2-mods-fields.chpl
+++ b/test/classes/initializers/generics/phase1/nested-function-phase-2-mods-fields.chpl
@@ -7,7 +7,7 @@ class Foo {
   proc init(param val) {
     field = val;
     nested();
-    super.init();
+    this.initDone();
 
     // Where the function definition was placed shouldn't impact its viability,
     // but where it is called should.  This function modifies a field, doesn't

--- a/test/classes/initializers/generics/phase1/nested-function-phase-2-returns.chpl
+++ b/test/classes/initializers/generics/phase1/nested-function-phase-2-returns.chpl
@@ -6,7 +6,7 @@ class Foo {
 
   proc init(param val) {
     field = nested(val);
-    super.init();
+    this.initDone();
 
     // Where the function definition was placed shouldn't impact its viability
     proc nested(param arg) param {

--- a/test/classes/initializers/generics/phase1/nested-function-returns.chpl
+++ b/test/classes/initializers/generics/phase1/nested-function-returns.chpl
@@ -8,7 +8,6 @@ class Foo {
       return arg+2;
     }
     field = nested(val);
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/phase1/nested-function.chpl
+++ b/test/classes/initializers/generics/phase1/nested-function.chpl
@@ -9,7 +9,6 @@ class Foo {
     }
     field = val;
     nested();
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/phase1/newInit-class-class.chpl
+++ b/test/classes/initializers/generics/phase1/newInit-class-class.chpl
@@ -7,7 +7,6 @@ class Container {
     y = new Stored(true);
     v = 10;
 
-    super.init();
   }
 
   proc deinit() {
@@ -21,7 +20,6 @@ class Stored {
   proc init(xVal) {
     x = xVal;
 
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/phase1/newInit-class-class2.chpl
+++ b/test/classes/initializers/generics/phase1/newInit-class-class2.chpl
@@ -5,7 +5,6 @@ class Container {
   proc init() {
     y = new Stored(true);
 
-    super.init();
   }
 
   proc deinit() {
@@ -19,7 +18,6 @@ class Stored {
   proc init(xVal) {
     x = xVal;
 
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/phase1/newInit-class-record.chpl
+++ b/test/classes/initializers/generics/phase1/newInit-class-record.chpl
@@ -7,7 +7,6 @@ class Container {
     y = new Stored(true);
     v = 10;
 
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/phase1/newInit-class-record2.chpl
+++ b/test/classes/initializers/generics/phase1/newInit-class-record2.chpl
@@ -5,7 +5,6 @@ class Container {
   proc init() {
     y = new Stored(true);
 
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/phase1/newInit-record-class.chpl
+++ b/test/classes/initializers/generics/phase1/newInit-record-class.chpl
@@ -19,7 +19,6 @@ class Stored {
   proc init(xVal) {
     x = xVal;
 
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/phase1/newInit-record-class2.chpl
+++ b/test/classes/initializers/generics/phase1/newInit-record-class2.chpl
@@ -17,7 +17,6 @@ class Stored {
   proc init(xVal) {
     x = xVal;
 
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/phase1/omittedCastEtc.chpl
+++ b/test/classes/initializers/generics/phase1/omittedCastEtc.chpl
@@ -9,7 +9,6 @@ class Foo {
 
   proc init(param zVal: int) {
     z = zVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/phase1/omittedDefaultOfField.chpl
+++ b/test/classes/initializers/generics/phase1/omittedDefaultOfField.chpl
@@ -9,7 +9,6 @@ class Foo {
 
   proc init(a) {
     y = a;
-    super.init();
   }
 
 }

--- a/test/classes/initializers/generics/phase1/omittedRecordField.chpl
+++ b/test/classes/initializers/generics/phase1/omittedRecordField.chpl
@@ -6,7 +6,6 @@ class Foo {
 
   proc init(param bVal: int) {
     b = bVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/phase1/orderedFields.chpl
+++ b/test/classes/initializers/generics/phase1/orderedFields.chpl
@@ -7,7 +7,6 @@ class LotsOFields {
     f1 = val1;
     f2 = val2;
     f3 = val3;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/phase1/unorderedFields-preferred.chpl
+++ b/test/classes/initializers/generics/phase1/unorderedFields-preferred.chpl
@@ -7,7 +7,6 @@ class LotsOFields {
     f1 = val1;
     f3 = val3;
     f2 = val2; // uh oh!
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/phase1/unorderedFields.chpl
+++ b/test/classes/initializers/generics/phase1/unorderedFields.chpl
@@ -7,7 +7,6 @@ class LotsOFields {
     f1 = val1;
     f3 = val3;
     f2 = val2; // uh oh!
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/reuse-class-instantiation.chpl
+++ b/test/classes/initializers/generics/reuse-class-instantiation.chpl
@@ -7,13 +7,11 @@ class Foo {
 
   proc init(type tVal) {
     t = tVal;
-    super.init();
   }
 
   proc init(xVal) {
     t = xVal.type;
     x = xVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/reuse-class-instantiation2.chpl
+++ b/test/classes/initializers/generics/reuse-class-instantiation2.chpl
@@ -8,7 +8,6 @@ class MyClass {
     x = _x;
     y = _y;
 
-    super.init();
   }
 
   proc init(_x, _y) {
@@ -17,7 +16,6 @@ class MyClass {
     x = _x;
     y = _y;
 
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/reuse-init-instantiation-param.chpl
+++ b/test/classes/initializers/generics/reuse-init-instantiation-param.chpl
@@ -7,7 +7,6 @@ class Foo {
 
   proc init(param pVal) {
     p = pVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/reuse-init-instantiation-var.chpl
+++ b/test/classes/initializers/generics/reuse-init-instantiation-var.chpl
@@ -6,7 +6,6 @@ class Foo {
 
   proc init(xVal) {
     x = xVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/reuse-init-instantiation-var2.chpl
+++ b/test/classes/initializers/generics/reuse-init-instantiation-var2.chpl
@@ -6,7 +6,6 @@ class Foo {
 
   proc init(xVal) {
     x = xVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/reuse-init-instantiation.chpl
+++ b/test/classes/initializers/generics/reuse-init-instantiation.chpl
@@ -7,7 +7,6 @@ class Foo {
 
   proc init(type tVal) {
     t = tVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/reuse-init-instantiation2.chpl
+++ b/test/classes/initializers/generics/reuse-init-instantiation2.chpl
@@ -8,7 +8,6 @@ class Foo {
   proc init(type tVal, xVal:tVal) {
     t = tVal;
     x = xVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/reuse-init-multiple-types.chpl
+++ b/test/classes/initializers/generics/reuse-init-multiple-types.chpl
@@ -13,7 +13,6 @@ class Foo {
     t1 = t1Val;
     t2 = t2Val;
 
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/reuse-init-new-instantiation-var.chpl
+++ b/test/classes/initializers/generics/reuse-init-new-instantiation-var.chpl
@@ -6,7 +6,6 @@ class Foo {
 
   proc init(xVal) {
     x = xVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/reuse-init-new-instantiation.chpl
+++ b/test/classes/initializers/generics/reuse-init-new-instantiation.chpl
@@ -7,7 +7,6 @@ class Foo {
 
   proc init(type tVal) {
     t = tVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/siblingCall-generic.chpl
+++ b/test/classes/initializers/generics/siblingCall-generic.chpl
@@ -9,7 +9,6 @@ class Foo {
   proc init(type tVal, xVal) {
     t = tVal;
     x = xVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/typeAlias.chpl
+++ b/test/classes/initializers/generics/typeAlias.chpl
@@ -5,7 +5,6 @@ class Generic {
   proc init(value: ?eltType) {
     this.eltType = eltType;
     this.value   = value;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/typeArgDefaultValue.chpl
+++ b/test/classes/initializers/generics/typeArgDefaultValue.chpl
@@ -7,7 +7,6 @@ class Foo {
 
   proc init(type tVal = bool) {
     t = tVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/typeArgDefaultValue2.chpl
+++ b/test/classes/initializers/generics/typeArgDefaultValue2.chpl
@@ -7,7 +7,6 @@ class Foo {
 
   proc init(type tVal = bool) {
     t = tVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/typeFunctions/fnReturnsConcrete.chpl
+++ b/test/classes/initializers/generics/typeFunctions/fnReturnsConcrete.chpl
@@ -3,7 +3,7 @@ class C {
   var x: t;
   proc init(type t) {
     this.t = t;
-    super.init();
+    this.initDone();
     writeln("In C.init()");
   }
 }

--- a/test/classes/initializers/generics/typeFunctions/fnReturnsConcrete2.chpl
+++ b/test/classes/initializers/generics/typeFunctions/fnReturnsConcrete2.chpl
@@ -3,7 +3,7 @@ class C {
   var x: t;
   proc init(type t) {
     this.t = t;
-    super.init();
+    this.initDone();
     writeln("In C.init()");
   }
 }

--- a/test/classes/initializers/generics/typeFunctions/fnReturnsGeneric.chpl
+++ b/test/classes/initializers/generics/typeFunctions/fnReturnsGeneric.chpl
@@ -3,7 +3,7 @@ class C {
   var x: t;
   proc init(type t) {
     this.t = t;
-    super.init();
+    this.initDone();
     writeln("In C.init()");
   }
 }

--- a/test/classes/initializers/generics/uninit-type.chpl
+++ b/test/classes/initializers/generics/uninit-type.chpl
@@ -8,7 +8,6 @@ class A {
   var x:t;
   proc init(type t) {
     this.t = t;
-    super.init();
   }
   // initializer for class 'A' requires a generic argument called 't'
 }

--- a/test/classes/initializers/generics/use-param-in-concrete-default.chpl
+++ b/test/classes/initializers/generics/use-param-in-concrete-default.chpl
@@ -8,7 +8,6 @@ class Foo {
 
   proc init(param pVal) {
     p = pVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/use-param-in-concrete-default2.chpl
+++ b/test/classes/initializers/generics/use-param-in-concrete-default2.chpl
@@ -9,7 +9,6 @@ class Foo {
   proc init(param pVal) {
     p = pVal;
     x = pVal + 2;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/use-param-in-concrete-default3.chpl
+++ b/test/classes/initializers/generics/use-param-in-concrete-default3.chpl
@@ -9,7 +9,6 @@ class Foo {
   proc init(param pVal) {
     p = pVal;
     x = p + 2;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/varArgDefaultValue.chpl
+++ b/test/classes/initializers/generics/varArgDefaultValue.chpl
@@ -6,7 +6,6 @@ class Foo {
 
   proc init(vVal = 3) {
     v = vVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/generics/varargs-init-generic.chpl
+++ b/test/classes/initializers/generics/varargs-init-generic.chpl
@@ -9,7 +9,6 @@ class Foo {
       total += i;
     }
     sum = total;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/inheritance/constructorChild.chpl
+++ b/test/classes/initializers/inheritance/constructorChild.chpl
@@ -3,7 +3,7 @@ class Parent {
 
   proc init() {
     x = 10;
-    super.init();
+
   }
 }
 

--- a/test/classes/initializers/inheritance/defaultForInheritedInit.chpl
+++ b/test/classes/initializers/inheritance/defaultForInheritedInit.chpl
@@ -7,7 +7,7 @@ class C {
     this.x = x;
     this.y = y;
     this.z = z;
-    super.init();
+
   }
 }
 

--- a/test/classes/initializers/inheritance/inheritedInitWrongName.chpl
+++ b/test/classes/initializers/inheritance/inheritedInitWrongName.chpl
@@ -7,7 +7,7 @@ class C {
     this.x = x;
     this.y = y;
     this.z = z;
-    super.init();
+
   }
 }
 

--- a/test/classes/initializers/inheritance/overloaded.chpl
+++ b/test/classes/initializers/inheritance/overloaded.chpl
@@ -3,7 +3,6 @@ class Parent {
 
   proc init() {
     covered = 4;
-    super.init();
   }
 }
 
@@ -12,7 +11,6 @@ class Child: Parent {
 
   proc init(val) {
     covered = val;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/inheritance/this-init-not-dynamic.chpl
+++ b/test/classes/initializers/inheritance/this-init-not-dynamic.chpl
@@ -20,7 +20,6 @@ class Base {
 
   proc init(x : int, y : int) {
     writeln('Base.init(x, y)');
-    super.init();
   }
 }
 

--- a/test/classes/initializers/inherits_initializer.chpl
+++ b/test/classes/initializers/inherits_initializer.chpl
@@ -7,7 +7,7 @@ class Parent {
 
   proc init() {
     a = 11;
-    super.init();
+
   }
 }
 

--- a/test/classes/initializers/initViaConditional.chpl
+++ b/test/classes/initializers/initViaConditional.chpl
@@ -5,7 +5,6 @@ class C {
 
   proc init(flag: bool) {
     x = if flag then 1.2 else 3.4;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/initializer-inheritance.chpl
+++ b/test/classes/initializers/initializer-inheritance.chpl
@@ -14,8 +14,8 @@ class base {
 class sub : base {
   var _j:int;
   proc init(i:int, j = -2) {
-    _j = j;
     super.init(i);
+    _j = j;
   }
 }
 

--- a/test/classes/initializers/named-argument-to-send-this-bad.chpl
+++ b/test/classes/initializers/named-argument-to-send-this-bad.chpl
@@ -3,7 +3,6 @@ class Foo {
 
   proc init(val) {
     badCall(arg=this, val);
-    super.init();
   }
 }
 

--- a/test/classes/initializers/noReturnInInit.chpl
+++ b/test/classes/initializers/noReturnInInit.chpl
@@ -80,7 +80,7 @@ class Tree {
     this.left  = left;
     this.right = right;
 
-    super.init();
+
   }
 
   proc init(item, depth) {

--- a/test/classes/initializers/parentCall/ifExplicitImplicit.chpl
+++ b/test/classes/initializers/parentCall/ifExplicitImplicit.chpl
@@ -4,7 +4,6 @@ class ParentCallInIf {
   proc init(param val: int) {
     if (val > 10) {
       f1 = val;
-      super.init();
     } else {
       this.initDone();
       f1 = -val;

--- a/test/classes/initializers/parentCall/inCobeginOn.chpl
+++ b/test/classes/initializers/parentCall/inCobeginOn.chpl
@@ -5,7 +5,7 @@ class Foo {
     x = xVal + yVal;
     cobegin {
       on xVal.locale {
-        super.init();
+        this.initDone();
       }
       writeln("in cobegin, whee!");
     }

--- a/test/classes/initializers/parentCall/inCobeginOn.comm-none.good
+++ b/test/classes/initializers/parentCall/inCobeginOn.comm-none.good
@@ -1,2 +1,2 @@
 inCobeginOn.chpl:4: In initializer:
-inCobeginOn.chpl:8: error: use of super.init() call in a parallel statement
+inCobeginOn.chpl:8: error: use of this.initDone() call in a parallel statement

--- a/test/classes/initializers/parentCall/inCobeginOn.comm-none.lm-numa.good
+++ b/test/classes/initializers/parentCall/inCobeginOn.comm-none.lm-numa.good
@@ -1,2 +1,2 @@
 inCobeginOn.chpl:4: In initializer:
-inCobeginOn.chpl:8: error: use of super.init() call in an on block
+inCobeginOn.chpl:8: error: use of this.initDone() call in an on block

--- a/test/classes/initializers/parentCall/inCobeginOn.good
+++ b/test/classes/initializers/parentCall/inCobeginOn.good
@@ -1,2 +1,2 @@
 inCobeginOn.chpl:4: In initializer:
-inCobeginOn.chpl:8: error: use of super.init() call in an on block
+inCobeginOn.chpl:8: error: use of this.initDone() call in an on block

--- a/test/classes/initializers/parentCall/inIf.chpl
+++ b/test/classes/initializers/parentCall/inIf.chpl
@@ -4,10 +4,8 @@ class ParentCallInIf {
   proc init(param val: int) {
     if (val > 10) {
       f1 = val;
-      super.init();
     } else {
       f1 = -val;
-      super.init();
       f1 += 3;
     }
   }

--- a/test/classes/initializers/parentCall/inOn.chpl
+++ b/test/classes/initializers/parentCall/inOn.chpl
@@ -4,7 +4,7 @@ class Foo {
   proc init(xVal) {
     x = xVal;
     on xVal {
-      super.init();
+      this.initDone();
     }
   }
 }

--- a/test/classes/initializers/parentCall/inOn.good
+++ b/test/classes/initializers/parentCall/inOn.good
@@ -1,2 +1,2 @@
 inOn.chpl:4: In initializer:
-inOn.chpl:7: error: use of super.init() call in an on block
+inOn.chpl:7: error: use of this.initDone() call in an on block

--- a/test/classes/initializers/parentCall/inOnCobegin.chpl
+++ b/test/classes/initializers/parentCall/inOnCobegin.chpl
@@ -5,7 +5,7 @@ class Foo {
     x = xVal + yVal;
     on xVal.locale {
       cobegin {
-        super.init();
+        this.initDone();
         writeln("in on+cobegin, whee!");
       }
     }

--- a/test/classes/initializers/parentCall/inOnCobegin.good
+++ b/test/classes/initializers/parentCall/inOnCobegin.good
@@ -1,2 +1,2 @@
 inOnCobegin.chpl:4: In initializer:
-inOnCobegin.chpl:8: error: use of super.init() call in a parallel statement
+inOnCobegin.chpl:8: error: use of this.initDone() call in a parallel statement

--- a/test/classes/initializers/parentCall/inOnLocal.chpl
+++ b/test/classes/initializers/parentCall/inOnLocal.chpl
@@ -4,7 +4,7 @@ class Foo {
   proc init(xVal) {
     x = xVal;
     on xVal {
-      super.init();
+      this.initDone();
     }
   }
 }

--- a/test/classes/initializers/parentCall/inOnLocal.good
+++ b/test/classes/initializers/parentCall/inOnLocal.good
@@ -1,2 +1,2 @@
-inOn.chpl:4: In initializer:
-inOn.chpl:7: error: use of super.init() call in an on block
+inOnLocal.chpl:4: In initializer:
+inOnLocal.chpl:7: error: use of this.initDone() call in an on block

--- a/test/classes/initializers/phase1/accessThisBad.chpl
+++ b/test/classes/initializers/phase1/accessThisBad.chpl
@@ -6,7 +6,7 @@ class ThisTooEarly {
 
     r = rVal;
 
-    super.init();
+    this.initDone();
 
     foo(this); // OK!
   }

--- a/test/classes/initializers/phase1/accessThisGood.chpl
+++ b/test/classes/initializers/phase1/accessThisGood.chpl
@@ -3,7 +3,6 @@ class ThisEarly {
 
   proc init(r: real) {
     this.r = r; // This is the only accepted use of this
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/arrayDependence.chpl
+++ b/test/classes/initializers/phase1/arrayDependence.chpl
@@ -5,7 +5,6 @@ class Foo {
   proc init(n : int) {
     D = { 1 .. n, 1 .. n };
 
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/badDependence.chpl
+++ b/test/classes/initializers/phase1/badDependence.chpl
@@ -10,7 +10,6 @@ class ManyFields {
 
     f5 = val;
 
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/badDependence2.chpl
+++ b/test/classes/initializers/phase1/badDependence2.chpl
@@ -6,7 +6,6 @@ class ManyFields {
     // f4's implicit reliance on f5 is bad, but the field declaration will tell
     // us this.
     f5 = val;
-    super.init();
     // The proper way to write this is in Phase 2, or by relying on the val
     // argument.  You may also choose to initialize these fields with noinit
     // during Phase 1

--- a/test/classes/initializers/phase1/complexOmittedField/omittedIfExpr.chpl
+++ b/test/classes/initializers/phase1/complexOmittedField/omittedIfExpr.chpl
@@ -4,7 +4,6 @@ class Foo {
 
   proc init(xVal: bool) {
     x = xVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/complexOmittedField/omittedLoopExpr.chpl
+++ b/test/classes/initializers/phase1/complexOmittedField/omittedLoopExpr.chpl
@@ -4,7 +4,6 @@ class Foo {
 
   proc init(dom) {
     D = dom;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/deeperOn.chpl
+++ b/test/classes/initializers/phase1/deeperOn.chpl
@@ -10,7 +10,6 @@ class Foo {
       }
       writeln("In a cobegin, whee!");
     }
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/dependence.chpl
+++ b/test/classes/initializers/phase1/dependence.chpl
@@ -11,7 +11,6 @@ class ManyFields {
     // though it isn't explicitly re-stated
     f3 = f2 - 2; // Depends on an omitted field
     f4 = f1 + 4; // Depends on an earlier field's explicit initialization
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/domainMaps/init-dmap-dom-arr-local.chpl
+++ b/test/classes/initializers/phase1/domainMaps/init-dmap-dom-arr-local.chpl
@@ -7,7 +7,6 @@ class VDistArray {
   proc init(val0: int, min: int, max: int) {
     this.C = new dmap(new Cyclic(min));
     this.D = {min..max};
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/domainMaps/init-dmap-dom-arr.chpl
+++ b/test/classes/initializers/phase1/domainMaps/init-dmap-dom-arr.chpl
@@ -7,7 +7,6 @@ class VDistArray {
   proc init(val0: int, min: int, max: int) {
     this.C = new dmap(new Cyclic(min));
     this.D = {min..max};
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/enumField.chpl
+++ b/test/classes/initializers/phase1/enumField.chpl
@@ -22,7 +22,6 @@ class Foo {
     g = blue;
     h = red;
     i = green;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/enumFieldExplicitType.chpl
+++ b/test/classes/initializers/phase1/enumFieldExplicitType.chpl
@@ -21,7 +21,6 @@ class Foo {
     g = Color.blue;
     h = Color.red;
     i = Color.green;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/enumFieldNoUseBad.chpl
+++ b/test/classes/initializers/phase1/enumFieldNoUseBad.chpl
@@ -7,7 +7,6 @@ class Foo {
 
   proc init() {
     a = blue;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/grandparentAccess.chpl
+++ b/test/classes/initializers/phase1/grandparentAccess.chpl
@@ -3,7 +3,6 @@ class A {
 
   proc init(aVal) {
     a = aVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/hasBeginOnFieldInit.chpl
+++ b/test/classes/initializers/phase1/hasBeginOnFieldInit.chpl
@@ -7,7 +7,6 @@ class Foo {
         x = xVal;
       }
     }
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/hasBeginOnNoFieldInit.chpl
+++ b/test/classes/initializers/phase1/hasBeginOnNoFieldInit.chpl
@@ -11,7 +11,6 @@ class Foo {
     }
 
     x = xVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/hasBlock.chpl
+++ b/test/classes/initializers/phase1/hasBlock.chpl
@@ -7,7 +7,6 @@ class Scoping {
       a = aVal;
     }
     b = bVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/hasBlockNested.chpl
+++ b/test/classes/initializers/phase1/hasBlockNested.chpl
@@ -15,7 +15,6 @@ class Scoping {
       c = cVal;
     }
     d = dVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/hasCobeginOnFieldInit.chpl
+++ b/test/classes/initializers/phase1/hasCobeginOnFieldInit.chpl
@@ -8,7 +8,6 @@ class Foo {
       }
       writeln("In a cobegin, whee!");
     }
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/hasCobeginOnNoFieldInit.chpl
+++ b/test/classes/initializers/phase1/hasCobeginOnNoFieldInit.chpl
@@ -12,7 +12,6 @@ class Foo {
     }
 
     x = xVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/hasDefer.chpl
+++ b/test/classes/initializers/phase1/hasDefer.chpl
@@ -7,7 +7,7 @@ class Foo {
       writeln("deferred!");
     }
     writeln("should be first");
-    super.init();
+    this.initDone();
     writeln("should be second");
   }
 }

--- a/test/classes/initializers/phase1/hasDeferBad.chpl
+++ b/test/classes/initializers/phase1/hasDeferBad.chpl
@@ -7,7 +7,7 @@ class Foo {
       writeln("deferred!");
     }
     writeln("should be first");
-    super.init();
+    this.initDone();
     writeln("should be second");
   }
 }

--- a/test/classes/initializers/phase1/hasIf.chpl
+++ b/test/classes/initializers/phase1/hasIf.chpl
@@ -10,7 +10,6 @@ class IfInit {
     } else {
       f2 = val;
     }
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/hasIfImplicit.chpl
+++ b/test/classes/initializers/phase1/hasIfImplicit.chpl
@@ -11,7 +11,6 @@ class IfInit {
 
     // Error f2 is only initialized if f1 is false
 
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/hasLoopBad.chpl
+++ b/test/classes/initializers/phase1/hasLoopBad.chpl
@@ -16,7 +16,6 @@ class InLoop {
     // in a loop could result in out of order initialization, or multiple
     // initialization, which would interfere with our ability to implicitly
     // initialize omitted fields.
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/hasLoopBad2.chpl
+++ b/test/classes/initializers/phase1/hasLoopBad2.chpl
@@ -8,7 +8,6 @@ class InLoop {
     for i in arr.domain {
       highestNum = arr[i]; // uh oh!
     }
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/hasLoopBad3.chpl
+++ b/test/classes/initializers/phase1/hasLoopBad3.chpl
@@ -8,7 +8,6 @@ class InLoop {
     for i in arr.domain {
       highestNum = arr[i]; // uh oh!
     }
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/hasLoopBadCoforall.chpl
+++ b/test/classes/initializers/phase1/hasLoopBadCoforall.chpl
@@ -8,7 +8,6 @@ class Foo {
     //   in Phase 1
     coforall val in a do
       x = val;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/hasLoopBadDoWhile.chpl
+++ b/test/classes/initializers/phase1/hasLoopBadDoWhile.chpl
@@ -10,7 +10,6 @@ class InLoop {
       highestNum = arr[i]; // uh oh!
       i += 1;
     } while (i < arr.domain.high);
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/hasLoopBadWhile.chpl
+++ b/test/classes/initializers/phase1/hasLoopBadWhile.chpl
@@ -10,7 +10,6 @@ class InLoop {
       highestNum = arr[i]; // uh oh!
       i += 1;
     }
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/hasLoopForallBad.chpl
+++ b/test/classes/initializers/phase1/hasLoopForallBad.chpl
@@ -8,7 +8,6 @@ class Foo {
     forall i in 1..numPrints {
       field = i;
     }
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/hasLoopForallGood.chpl
+++ b/test/classes/initializers/phase1/hasLoopForallGood.chpl
@@ -6,7 +6,6 @@ class Foo {
     forall i in 1..numPrints {
       writeln(numPrints);
     }
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/hasLoopGood.chpl
+++ b/test/classes/initializers/phase1/hasLoopGood.chpl
@@ -14,7 +14,6 @@ class InLoop {
       }
     }
     highestNum = highest;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/hasLoopGoodCoforall.chpl
+++ b/test/classes/initializers/phase1/hasLoopGoodCoforall.chpl
@@ -5,7 +5,6 @@ class Foo {
     coforall val in a do
       writeln(val);
     x = 10;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/hasOnCobeginFieldInit.chpl
+++ b/test/classes/initializers/phase1/hasOnCobeginFieldInit.chpl
@@ -8,7 +8,6 @@ class Foo {
         writeln("In a cobegin, whee!");
       }
     }
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/hasOnCobeginNoFieldInit.chpl
+++ b/test/classes/initializers/phase1/hasOnCobeginNoFieldInit.chpl
@@ -12,7 +12,6 @@ class Foo {
     }
 
     x = xVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/hasOnFieldInit.chpl
+++ b/test/classes/initializers/phase1/hasOnFieldInit.chpl
@@ -7,7 +7,6 @@ class Foo {
       // we may allow this later.  But it is better to go from more restrictive
       // to less than vice versa.
     }
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/hasOnNoFieldInit.chpl
+++ b/test/classes/initializers/phase1/hasOnNoFieldInit.chpl
@@ -7,7 +7,6 @@ class Foo {
       remoteVal = xVal;
     }
     x = remoteVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/hasParallelBad.chpl
+++ b/test/classes/initializers/phase1/hasParallelBad.chpl
@@ -7,7 +7,6 @@ class InParallel {
       a = x;
       b = y;
     }
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/localHelpers.chpl
+++ b/test/classes/initializers/phase1/localHelpers.chpl
@@ -10,7 +10,7 @@ class UsesHelpers {
     // value for it.
     f2 = helper;
     f3 = val;
-    super.init();
+    this.initDone();
     if (helper > 10) {
       writeln("double digits, woo!");
     }

--- a/test/classes/initializers/phase1/loopUpdate.chpl
+++ b/test/classes/initializers/phase1/loopUpdate.chpl
@@ -5,7 +5,6 @@ class Params {
   proc init() {
     numProbSizes = 3;
     for n in N do n = 10;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/methodCall.chpl
+++ b/test/classes/initializers/phase1/methodCall.chpl
@@ -7,7 +7,6 @@ class MethodTooEarly {
 
     i = iVal;
 
-    super.init();
   }
 
   // This method demonstrates why it would be bad to access a method

--- a/test/classes/initializers/phase1/methodCallIf.chpl
+++ b/test/classes/initializers/phase1/methodCallIf.chpl
@@ -3,7 +3,6 @@ class Foo {
 
   proc init(xVal) {
     x = if xVal > 5 then option1() else option2();
-    super.init();
   }
 
   proc option1() {

--- a/test/classes/initializers/phase1/methodCallInOmittedInit.chpl
+++ b/test/classes/initializers/phase1/methodCallInOmittedInit.chpl
@@ -4,7 +4,6 @@ class Foo {
 
   proc init(yVal) {
     y = yVal;
-    super.init();
   }
 
   proc xTimes3() {

--- a/test/classes/initializers/phase1/methodCallOverloaded.chpl
+++ b/test/classes/initializers/phase1/methodCallOverloaded.chpl
@@ -9,7 +9,6 @@ class Foo {
       xVal = true;
     }
     x = xVal;
-    super.init();
   }
 
   proc overloaded(val: int) {

--- a/test/classes/initializers/phase1/modifyDom-init-noType.chpl
+++ b/test/classes/initializers/phase1/modifyDom-init-noType.chpl
@@ -7,7 +7,6 @@ class C {
   proc init(arr: [] int) {
     D = arr.domain;
     A = arr;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/modifyDom-init-noType2.chpl
+++ b/test/classes/initializers/phase1/modifyDom-init-noType2.chpl
@@ -5,7 +5,6 @@ class C {
 
   proc init(dom) {
     D = dom;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/modifyDom.chpl
+++ b/test/classes/initializers/phase1/modifyDom.chpl
@@ -7,7 +7,6 @@ class C {
   proc init(arr: [] int) {
     D = arr.domain;
     A = arr;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/multipleInits.chpl
+++ b/test/classes/initializers/phase1/multipleInits.chpl
@@ -8,7 +8,6 @@ class LotsOFields {
     f2 = val2;
     f2 = val2*3;
     f3 = val3;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/multipleInits2.chpl
+++ b/test/classes/initializers/phase1/multipleInits2.chpl
@@ -8,7 +8,6 @@ class LotsOFields {
     f2 = val2;
     f3 = val3;
     f2 = val2*3;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/nested-function-defined-in-phase-2.chpl
+++ b/test/classes/initializers/phase1/nested-function-defined-in-phase-2.chpl
@@ -6,7 +6,7 @@ class Foo {
   proc init(val) {
     field = val;
     nested();
-    super.init();
+    this.initDone();
 
     // Where the function definition was placed shouldn't impact its viability
     proc nested() {

--- a/test/classes/initializers/phase1/nested-function-mods-field1.chpl
+++ b/test/classes/initializers/phase1/nested-function-mods-field1.chpl
@@ -9,7 +9,6 @@ class Foo {
     proc nested() {
       field = -field; // because this modifies a field
     }
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/nested-function-mods-field2.chpl
+++ b/test/classes/initializers/phase1/nested-function-mods-field2.chpl
@@ -10,7 +10,6 @@ class Foo {
 
     field = val;
     nested(); // so this call shouldn't be allowed in Phase 1
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/nested-function-phase-2-mods-fields.chpl
+++ b/test/classes/initializers/phase1/nested-function-phase-2-mods-fields.chpl
@@ -7,7 +7,7 @@ class Foo {
   proc init(val) {
     field = val;
     nested();
-    super.init();
+    this.initDone();
 
     // Where the function definition was placed shouldn't impact its viability,
     // but where it is called should.  This function modifies a field, doesn't

--- a/test/classes/initializers/phase1/nested-function-phase-2-returns.chpl
+++ b/test/classes/initializers/phase1/nested-function-phase-2-returns.chpl
@@ -6,7 +6,7 @@ class Foo {
 
   proc init(val) {
     field = nested(val);
-    super.init();
+    this.initDone();
 
     // Where the function definition was placed shouldn't impact its viability
     proc nested(arg) {

--- a/test/classes/initializers/phase1/nested-function-returns.chpl
+++ b/test/classes/initializers/phase1/nested-function-returns.chpl
@@ -8,7 +8,6 @@ class Foo {
       return arg+2;
     }
     field = nested(val);
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/nested-function.chpl
+++ b/test/classes/initializers/phase1/nested-function.chpl
@@ -9,7 +9,6 @@ class Foo {
     }
     field = val;
     nested();
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/newInit-class-class.chpl
+++ b/test/classes/initializers/phase1/newInit-class-class.chpl
@@ -5,7 +5,6 @@ class Container {
   proc init() {
     y = new Stored(true);
 
-    super.init();
   }
 
   proc deinit() {
@@ -19,7 +18,6 @@ class Stored {
   proc init(xVal) {
     x = xVal;
 
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/newInit-class-class2.chpl
+++ b/test/classes/initializers/phase1/newInit-class-class2.chpl
@@ -5,7 +5,6 @@ class Container {
   proc init() {
     y = new Stored(true);
 
-    super.init();
   }
 
   proc deinit() {
@@ -19,7 +18,6 @@ class Stored {
   proc init(xVal) {
     x = xVal;
 
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/newInit-class-record.chpl
+++ b/test/classes/initializers/phase1/newInit-class-record.chpl
@@ -5,7 +5,6 @@ class Container {
   proc init() {
     y = new Stored(true);
 
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/newInit-class-record2.chpl
+++ b/test/classes/initializers/phase1/newInit-class-record2.chpl
@@ -5,7 +5,6 @@ class Container {
   proc init() {
     y = new Stored(true);
 
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/newInit-record-class.chpl
+++ b/test/classes/initializers/phase1/newInit-record-class.chpl
@@ -17,7 +17,6 @@ class Stored {
   proc init(xVal) {
     x = xVal;
 
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/newInit-record-class2.chpl
+++ b/test/classes/initializers/phase1/newInit-record-class2.chpl
@@ -17,7 +17,6 @@ class Stored {
   proc init(xVal) {
     x = xVal;
 
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/nilDefaultVal.chpl
+++ b/test/classes/initializers/phase1/nilDefaultVal.chpl
@@ -3,7 +3,6 @@ class A {
 
   proc init(k=5) {
     this.k = k;
-    super.init();
   }
 }
 
@@ -12,7 +11,6 @@ class B {
 
   proc init(a = nil) {
     this.a = a;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/omit.chpl
+++ b/test/classes/initializers/phase1/omit.chpl
@@ -4,7 +4,6 @@ class OmitOne {
 
   proc init(bVal: real) {
     fieldB = bVal;
-    super.init();
   }
 }
 
@@ -15,7 +14,6 @@ class OmitMultiple {
 
   proc init(bVal: bool) {
     fieldB = bVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/omittedArrayExplicitInit.chpl
+++ b/test/classes/initializers/phase1/omittedArrayExplicitInit.chpl
@@ -5,7 +5,6 @@ class Foo {
   proc init(n : int) {
     D = { 1 .. n, 1 .. n };
 
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/omittedCastEtc.chpl
+++ b/test/classes/initializers/phase1/omittedCastEtc.chpl
@@ -9,7 +9,6 @@ class Foo {
 
   proc init(zVal: int) {
     z = zVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/omittedDefaultOfField.chpl
+++ b/test/classes/initializers/phase1/omittedDefaultOfField.chpl
@@ -9,7 +9,6 @@ class Foo {
 
   proc init(a) {
     y = a;
-    super.init();
   }
 
 }

--- a/test/classes/initializers/phase1/omittedRecordField.chpl
+++ b/test/classes/initializers/phase1/omittedRecordField.chpl
@@ -6,7 +6,6 @@ class Foo {
 
   proc init(bVal: int) {
     b = bVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/omittedSyncFieldWithInit.chpl
+++ b/test/classes/initializers/phase1/omittedSyncFieldWithInit.chpl
@@ -4,7 +4,6 @@ class Foo {
 
   proc init(otherVal) {
     other = otherVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/omittedSyncFieldWithoutInit.chpl
+++ b/test/classes/initializers/phase1/omittedSyncFieldWithoutInit.chpl
@@ -4,7 +4,6 @@ class Foo {
 
   proc init(otherVal) {
     other = otherVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/orderedFields.chpl
+++ b/test/classes/initializers/phase1/orderedFields.chpl
@@ -7,7 +7,6 @@ class LotsOFields {
     f1 = val1;
     f2 = val2;
     f3 = val3;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/sendFieldToFunc.chpl
+++ b/test/classes/initializers/phase1/sendFieldToFunc.chpl
@@ -4,7 +4,6 @@ class Foo {
   proc init(xVal) {
     x = xVal;
     bar(x); // This should be allowed
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/sendFieldToFuncModsField.chpl
+++ b/test/classes/initializers/phase1/sendFieldToFuncModsField.chpl
@@ -4,7 +4,6 @@ class Foo {
   proc init(xVal) {
     x = xVal;
     bar(x); // This should not be allowed
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/sendFieldToFuncUseRes.chpl
+++ b/test/classes/initializers/phase1/sendFieldToFuncUseRes.chpl
@@ -5,7 +5,6 @@ class Foo {
   proc init(xVal) {
     x = xVal;
     y = bar(x); // This should be allowed
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/setGrandparentField.chpl
+++ b/test/classes/initializers/phase1/setGrandparentField.chpl
@@ -3,7 +3,6 @@ class A {
 
   proc init(aVal) {
     a = aVal;
-    super.init();
   }
 }
 
@@ -11,8 +10,8 @@ class B : A {
   var b = false;
 
   proc init(bVal, aVal) {
-    b = bVal;
     super.init(aVal);
+    b = bVal;
   }
 }
 
@@ -20,9 +19,9 @@ class C : B {
   var c = 4.7;
 
   proc init(cVal, bVal, aVal) {
+    super.init(bVal, aVal);
     c = cVal;
     a = aVal;
-    super.init(bVal, aVal);
   }
 }
 

--- a/test/classes/initializers/phase1/syncFieldTypeAndInit.chpl
+++ b/test/classes/initializers/phase1/syncFieldTypeAndInit.chpl
@@ -3,7 +3,6 @@ class Foo {
 
   proc init(val) {
     s = val;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/syncFieldTypeAndInitSyncArg.chpl
+++ b/test/classes/initializers/phase1/syncFieldTypeAndInitSyncArg.chpl
@@ -4,7 +4,6 @@ class Foo {
   proc init(val: sync int) {
     writeln("inside the initializer");
     s = val;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/syncFieldTypeOnly.chpl
+++ b/test/classes/initializers/phase1/syncFieldTypeOnly.chpl
@@ -3,7 +3,6 @@ class Foo {
 
   proc init(val) {
     s = val;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/syncFieldTypeOnlySyncArg.chpl
+++ b/test/classes/initializers/phase1/syncFieldTypeOnlySyncArg.chpl
@@ -4,7 +4,6 @@ class Foo {
   proc init(val: sync int) {
     writeln("inside the initializer");
     s = val;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/syncStatements.chpl
+++ b/test/classes/initializers/phase1/syncStatements.chpl
@@ -8,7 +8,6 @@ class Foo {
     sync {
       x = xVal;
     }
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/typeAliasFieldTypeExplicit.chpl
+++ b/test/classes/initializers/phase1/typeAliasFieldTypeExplicit.chpl
@@ -7,7 +7,6 @@ class Foo {
 
   proc init(xVal: tAlias) {
     x = xVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/typeAliasFieldTypeOmitted.chpl
+++ b/test/classes/initializers/phase1/typeAliasFieldTypeOmitted.chpl
@@ -6,7 +6,6 @@ class Foo {
   var x: tAlias;
 
   proc init() {
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/unorderedFields-preferred.chpl
+++ b/test/classes/initializers/phase1/unorderedFields-preferred.chpl
@@ -7,7 +7,6 @@ class LotsOFields {
     f1 = val1;
     f3 = val3;
     f2 = val2; // uh oh!
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/unorderedFields.chpl
+++ b/test/classes/initializers/phase1/unorderedFields.chpl
@@ -7,7 +7,6 @@ class LotsOFields {
     f1 = val1;
     f3 = val3;
     f2 = val2; // uh oh!
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/writeFinishedField.chpl
+++ b/test/classes/initializers/phase1/writeFinishedField.chpl
@@ -4,7 +4,6 @@ class Foo {
   proc init(xVal) {
     x = xVal;
     writeln(x); // This should be allowed
-    super.init();
   }
 }
 

--- a/test/classes/initializers/phase2/modifyParentConst.chpl
+++ b/test/classes/initializers/phase2/modifyParentConst.chpl
@@ -3,7 +3,7 @@ class C {
 
   proc init(x) {
     this.x = x;
-    super.init();
+    this.initDone();
     //    this.x = 36;  can't do this
   }
 }

--- a/test/classes/initializers/phase2/modifyParentParam.chpl
+++ b/test/classes/initializers/phase2/modifyParentParam.chpl
@@ -3,7 +3,7 @@ class C {
 
   proc init(param x : int) {
     this.x = x;
-    super.init();
+
   }
 }
 

--- a/test/classes/initializers/phase2/modifyParentType.chpl
+++ b/test/classes/initializers/phase2/modifyParentType.chpl
@@ -3,7 +3,7 @@ class C {
 
   proc init(type t) {
     this.x = t;
-    super.init();
+
   }
 }
 

--- a/test/classes/initializers/phase2/selectStmt.chpl
+++ b/test/classes/initializers/phase2/selectStmt.chpl
@@ -3,7 +3,7 @@ class Foo {
 
   proc init(xVal) {
     x = xVal;
-    super.init();
+    this.initDone();
     select xVal.type {
       when int(16) do
         writeln("It was small");

--- a/test/classes/initializers/promotion/copyInitLookalike.chpl
+++ b/test/classes/initializers/promotion/copyInitLookalike.chpl
@@ -14,20 +14,20 @@ class C {
   proc init(x : int) {
     this.eltType = int;
     this.x = x;
-    super.init();
+
   }
 
   proc init(r : real) {
     this.eltType = real;
     this.x = r;
-    super.init();
+
   }
 
   proc init(other:C(int)) {
     writeln("copy init for 'int'");
     this.eltType = other.eltType;
     this.x = other.x;
-    super.init();
+
   }
 }
 

--- a/test/classes/initializers/promotion/initPromotion.chpl
+++ b/test/classes/initializers/promotion/initPromotion.chpl
@@ -8,7 +8,6 @@ class GenericClass {
   proc init(type i, param r : int) {
     this.idxType = i;
     this.rank = r;
-    super.init();
   }
 
   iter these() {

--- a/test/classes/initializers/records/defaultValueRecordArg.chpl
+++ b/test/classes/initializers/records/defaultValueRecordArg.chpl
@@ -11,7 +11,6 @@ class DefaultArg {
 
   proc init(yVal = new Foo(3)) {
     y = yVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/records/generics/defaultValueRecordArg.chpl
+++ b/test/classes/initializers/records/generics/defaultValueRecordArg.chpl
@@ -11,7 +11,6 @@ class DefaultArg {
 
   proc init(yVal = new Foo(3)) {
     y = yVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/recursiveCall.chpl
+++ b/test/classes/initializers/recursiveCall.chpl
@@ -78,7 +78,6 @@ class Tree {
     this.item = item;
     this.left = left;
     this.right = right;
-    super.init();
   }
 
   proc init(item, depth) {

--- a/test/classes/initializers/recursiveCall2.chpl
+++ b/test/classes/initializers/recursiveCall2.chpl
@@ -80,7 +80,6 @@ class Tree {
     this.item = item;
     this.left = left;
     this.right = right;
-    super.init();
   }
 
   proc init(item, depth) {

--- a/test/classes/initializers/secondary/bothSecondaryAndPrimary.chpl
+++ b/test/classes/initializers/secondary/bothSecondaryAndPrimary.chpl
@@ -9,7 +9,6 @@ class Foo {
     writeln("In primary initializer of class Foo");
     x = 3;
     y = yVal;
-    super.init();
   }
 }
 
@@ -17,7 +16,6 @@ proc Foo.init(xVal: int) {
   writeln("In secondary initializer of class Foo");
   x = xVal;
   y = xVal > 5;
-  super.init();
 }
 
 proc main() {

--- a/test/classes/initializers/secondary/inDiffModule.chpl
+++ b/test/classes/initializers/secondary/inDiffModule.chpl
@@ -23,6 +23,5 @@ module B {
     writeln("In secondary initializer of class Foo");
     x = xVal;
     y = xVal > 5;
-    super.init();
   }
 }

--- a/test/classes/initializers/secondary/inDiffModule2.chpl
+++ b/test/classes/initializers/secondary/inDiffModule2.chpl
@@ -15,7 +15,6 @@ module B {
     writeln("In secondary initializer of class Foo");
     x = xVal;
     y = xVal > 5;
-    super.init();
   }
 
   proc main() {

--- a/test/classes/initializers/secondary/inDiffModule3.chpl
+++ b/test/classes/initializers/secondary/inDiffModule3.chpl
@@ -11,7 +11,6 @@ module B {
     writeln("In secondary initializer of class Foo");
     x = xVal;
     y = xVal > 5;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/secondary/inDiffModuleBothSecondaryAndPrimary.chpl
+++ b/test/classes/initializers/secondary/inDiffModuleBothSecondaryAndPrimary.chpl
@@ -11,7 +11,6 @@ module B {
     writeln("In secondary initializer of class Foo");
     x = xVal;
     y = xVal > 5;
-    super.init();
   }
 }
 
@@ -24,7 +23,6 @@ module A {
       writeln("In primary initializer of class Foo");
       x = 3;
       y = yVal;
-      super.init();
     }
   }
 

--- a/test/classes/initializers/secondary/inDiffModuleBothSecondaryAndPrimary2.chpl
+++ b/test/classes/initializers/secondary/inDiffModuleBothSecondaryAndPrimary2.chpl
@@ -13,7 +13,7 @@ module A {
       writeln("In primary initializer of class Foo");
       x = 3;
       y = yVal;
-      super.init();
+
     }
   }
 
@@ -31,6 +31,5 @@ module B {
     writeln("In secondary initializer of class Foo");
     x = xVal;
     y = xVal > 5;
-    super.init();
   }
 }

--- a/test/classes/initializers/secondary/inSameModule.chpl
+++ b/test/classes/initializers/secondary/inSameModule.chpl
@@ -10,7 +10,6 @@ proc Foo.init(xVal) {
   writeln("In secondary initializer of class Foo");
   x = xVal;
   y = xVal > 5;
-  super.init();
 }
 
 proc main() {

--- a/test/classes/initializers/siblingCall/coforallSiblingCall.chpl
+++ b/test/classes/initializers/siblingCall/coforallSiblingCall.chpl
@@ -9,7 +9,6 @@ class Foo {
 
   proc init(xVal: int) {
     x = xVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/siblingCall/endsInitBad.chpl
+++ b/test/classes/initializers/siblingCall/endsInitBad.chpl
@@ -10,7 +10,6 @@ class Foo {
   proc init(f1Val: int, unmod: bool) {
     f1 = f1Val;
     f2 = unmod;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/siblingCall/endsInitBad.good
+++ b/test/classes/initializers/siblingCall/endsInitBad.good
@@ -1,2 +1,2 @@
 endsInitBad.chpl:5: In initializer:
-endsInitBad.chpl:6: error: field initialization not allowed before this.init()
+endsInitBad.chpl:6: error: field initialization not allowed before super.init() or this.init()

--- a/test/classes/initializers/siblingCall/endsInitGood.chpl
+++ b/test/classes/initializers/siblingCall/endsInitGood.chpl
@@ -10,7 +10,6 @@ class Foo {
   proc init(f1Val: int, unmod: bool) {
     f1 = f1Val;
     f2 = unmod;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/siblingCall/forallSiblingCall.chpl
+++ b/test/classes/initializers/siblingCall/forallSiblingCall.chpl
@@ -9,7 +9,6 @@ class Foo {
 
   proc init(xVal: int) {
     x = xVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/siblingCall/inBeginOn.chpl
+++ b/test/classes/initializers/siblingCall/inBeginOn.chpl
@@ -11,7 +11,6 @@ class Foo {
 
   proc init(xVal) {
     x = xVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/siblingCall/inCobeginOn.chpl
+++ b/test/classes/initializers/siblingCall/inCobeginOn.chpl
@@ -12,7 +12,6 @@ class Foo {
 
   proc init(xVal) {
     x = xVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/siblingCall/inDefer.chpl
+++ b/test/classes/initializers/siblingCall/inDefer.chpl
@@ -9,7 +9,6 @@ class Foo {
 
   proc init(xVal) {
     x = xVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/siblingCall/inOn.chpl
+++ b/test/classes/initializers/siblingCall/inOn.chpl
@@ -9,7 +9,6 @@ class Foo {
 
   proc init(a, b) {
     x = a + b;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/siblingCall/inOnCobegin.chpl
+++ b/test/classes/initializers/siblingCall/inOnCobegin.chpl
@@ -12,7 +12,6 @@ class Foo {
 
   proc init(xVal) {
     x = xVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/siblingCall/loopSiblingCall.chpl
+++ b/test/classes/initializers/siblingCall/loopSiblingCall.chpl
@@ -17,7 +17,6 @@ class Looper {
 
   proc init(best: int) {
     val = best;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/siblingCall/loopTopLevel.chpl
+++ b/test/classes/initializers/siblingCall/loopTopLevel.chpl
@@ -17,7 +17,6 @@ class Looper {
 
   proc init(best: int) {
     val = best;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/siblingCall/middleBad.chpl
+++ b/test/classes/initializers/siblingCall/middleBad.chpl
@@ -13,7 +13,6 @@ class Foo {
   proc init(f1Val: int, unmod: bool) {
     f1 = f1Val;
     f2 = unmod;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/siblingCall/middleBad.good
+++ b/test/classes/initializers/siblingCall/middleBad.good
@@ -1,2 +1,2 @@
 middleBad.chpl:5: In initializer:
-middleBad.chpl:6: error: field initialization not allowed before this.init()
+middleBad.chpl:6: error: field initialization not allowed before super.init() or this.init()

--- a/test/classes/initializers/siblingCall/middleGood.chpl
+++ b/test/classes/initializers/siblingCall/middleGood.chpl
@@ -13,7 +13,6 @@ class Foo {
   proc init(f1Val: int, unmod: bool) {
     f1 = f1Val;
     f2 = unmod;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/siblingCall/parallelSiblingCall.chpl
+++ b/test/classes/initializers/siblingCall/parallelSiblingCall.chpl
@@ -8,7 +8,6 @@ class ParaThis {
 
   proc init(start: int) {
     val = start;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/siblingCall/startsInit.chpl
+++ b/test/classes/initializers/siblingCall/startsInit.chpl
@@ -12,7 +12,6 @@ class Foo {
   proc init(f1Val: int, unmod: bool) {
     f1 = f1Val;
     f2 = unmod;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/siblingCall/syncStatements.chpl
+++ b/test/classes/initializers/siblingCall/syncStatements.chpl
@@ -14,7 +14,6 @@ class Foo {
 
   proc init(xVal) {
     x = xVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/user_def_default_initializer_const.chpl
+++ b/test/classes/initializers/user_def_default_initializer_const.chpl
@@ -5,7 +5,6 @@ class C {
 
   proc init() {
     x = 5;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/user_def_unique_initializer_const.chpl
+++ b/test/classes/initializers/user_def_unique_initializer_const.chpl
@@ -5,7 +5,6 @@ class C {
 
   proc init(y, z) {
     x = y+z;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/user_def_unique_initializer_const_multipleassign2.chpl
+++ b/test/classes/initializers/user_def_unique_initializer_const_multipleassign2.chpl
@@ -7,7 +7,6 @@ class C {
     x = y + z;
     x = 1;
 
-    super.init();
   }
 }
 

--- a/test/classes/initializers/varargs-init.chpl
+++ b/test/classes/initializers/varargs-init.chpl
@@ -7,7 +7,6 @@ class Foo {
       total += i;
     }
     sum = total;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/where-clause-other-args.chpl
+++ b/test/classes/initializers/where-clause-other-args.chpl
@@ -7,12 +7,10 @@ class Foo {
   proc init(param xVal, yVal) where (xVal > 10) {
     x = xVal;
     y = yVal;
-    super.init();
   }
 
   proc init(param xVal) where (xVal < 10) {
     x = xVal;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/where-clause.chpl
+++ b/test/classes/initializers/where-clause.chpl
@@ -4,12 +4,10 @@ class Foo {
 
   proc init(param xVal: int) where (xVal > 10) {
     x = xVal;
-    super.init();
   }
 
   proc init(param xVal: int) where (xVal <= 10) {
     x = abs(xVal) + 10;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/where-clause2.chpl
+++ b/test/classes/initializers/where-clause2.chpl
@@ -5,12 +5,10 @@ class Foo {
 
   proc init(xVal) where (isInt(xVal)) {
     x = xVal;
-    super.init();
   }
 
   proc init(realVal) where (isReal(realVal)) {
     x = floor(realVal):int;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/where-clause3.chpl
+++ b/test/classes/initializers/where-clause3.chpl
@@ -5,12 +5,10 @@ class Foo {
 
   proc init(xVal:int) where (isInt(xVal)) {
     x = xVal;
-    super.init();
   }
 
   proc init(realVal:real) where (isReal(realVal)) {
     x = floor(realVal):int;
-    super.init();
   }
 }
 

--- a/test/classes/initializers/where-clause4.chpl
+++ b/test/classes/initializers/where-clause4.chpl
@@ -4,7 +4,7 @@ class Foo {
 
   proc init(xVal) where (isInt(xVal)) {
     x = xVal;
-    super.init();
+
   }
 }
 

--- a/test/deprecated/constructorError/noConstructor1.chpl
+++ b/test/deprecated/constructorError/noConstructor1.chpl
@@ -4,7 +4,6 @@ class Foo {
 
   proc init(xVal) {
     x = xVal;
-    super.init();
   }
 }
 

--- a/test/domains/vass/assoc-idxtype-error-2.chpl
+++ b/test/domains/vass/assoc-idxtype-error-2.chpl
@@ -9,7 +9,6 @@ class C {
 proc C.init(d, a) where d: domain(?) {
   this.d = d;
   this.a = a;
-  super.init();
 }
 
 var c1 = new C(d1,a1);

--- a/test/errhandling/ExampleErrors.chpl
+++ b/test/errhandling/ExampleErrors.chpl
@@ -15,7 +15,6 @@ class StringError : Error {
 
   proc init(msg:string) {
     this.msg = msg;
-    super.init();
   }
 
   proc message() {

--- a/test/errhandling/ferguson/output-format.chpl
+++ b/test/errhandling/ferguson/output-format.chpl
@@ -2,7 +2,7 @@ class MyError : Error {
   var msg:string;
   proc init(msg:string) {
     this.msg = msg;
-    super.init();
+
   }
   proc message() {
     return "custom message";

--- a/test/errhandling/parallel/convenience.chpl
+++ b/test/errhandling/parallel/convenience.chpl
@@ -6,12 +6,10 @@ class MyError : Error {
   proc init(x:int) {
     this.msg = x:string;
     this.x = x;
-    super.init();
   }
   proc init(msg:string) {
     this.msg = msg;
     this.x = 1;
-    super.init();
   }
 }
 

--- a/test/library/standard/DateTime/testDatetimeTZ.chpl
+++ b/test/library/standard/DateTime/testDatetimeTZ.chpl
@@ -305,8 +305,8 @@ proc test_utctimetuple() {
   class UOFS: DST {
     var uofs: timedelta;
     proc init(uofs, dofs=0) {
-      this.uofs = new timedelta(minutes=uofs);
       super.init(dofs);
+      this.uofs = new timedelta(minutes=uofs);
     }
     proc utcoffset(dt) {
       return uofs;

--- a/test/library/standard/DateTime/testTimezoneConversions.chpl
+++ b/test/library/standard/DateTime/testTimezoneConversions.chpl
@@ -21,7 +21,6 @@ class USTimeZone: TZInfo {
     this.reprname = reprname;
     this.stdname = stdname;
     this.dstname = dstname;
-    super.init();
   }
 
   proc __repr__() {
@@ -83,7 +82,6 @@ class FixedOffset: TZInfo {
     this.offset = new timedelta(minutes=offset);
     this.name = name;
     this.dstoffset = new timedelta(minutes=dstoffset);
-    super.init();
   }
 
   proc utcoffset(dt: datetime) {

--- a/test/parallel/forall/vass/alist-error.chpl
+++ b/test/parallel/forall/vass/alist-error.chpl
@@ -9,7 +9,6 @@ class A {
     this.X = [x in 1..N] x;
     var Y = [x in this.X] R.getNext();
     delete R;
-    super.init();
   }
 }
 var a = new A(100);

--- a/test/parallel/sync/bradc/syncArrInit.chpl
+++ b/test/parallel/sync/bradc/syncArrInit.chpl
@@ -3,7 +3,6 @@ class C {
 
   proc init(v1: int) {
     irng = v1..v1;
-    super.init();
   }
 }
 

--- a/test/parallel/sync/bradc/syncArrInit2.chpl
+++ b/test/parallel/sync/bradc/syncArrInit2.chpl
@@ -3,7 +3,6 @@ class C {
 
   proc init(v1: int) {
     irng = v1;
-    super.init();
   }
 }
 

--- a/test/reductions/bradc/manual/threeclasstypes-construct.chpl
+++ b/test/reductions/bradc/manual/threeclasstypes-construct.chpl
@@ -19,7 +19,6 @@ class mysumreduce {
     intype = in_t;
     statetype = in_t;
     outtype = in_t;
-    super.init();
   }
 }
 

--- a/test/reductions/bradc/manual/threeclasstypes-construct2.chpl
+++ b/test/reductions/bradc/manual/threeclasstypes-construct2.chpl
@@ -19,7 +19,6 @@ class mysumreduce {
     this.intype = intype;
     this.statetype = statetype;
     this.outtype = outtype;
-    super.init();
   }
 }
 

--- a/test/release/examples/primers/learnChapelInYMinutes.chpl
+++ b/test/release/examples/primers/learnChapelInYMinutes.chpl
@@ -871,7 +871,6 @@ class GenericClass {
     this.classDomain = {1..elements};
     // all generic and const fields must be initialized in "phase 1" prior
     // to a call to the superclass initializer.
-    super.init(); 
   }
 
 // Copy-style initializer.

--- a/test/studies/amr/lib/grid/GridSolution_def.chpl
+++ b/test/studies/amr/lib/grid/GridSolution_def.chpl
@@ -32,7 +32,6 @@ class GridSolution {
     this.grid = grid;
     old_data =     new GridVariable(grid = grid);
     current_data = new GridVariable(grid = grid);
-    super.init();
   }
   // /|''''''''''''''''''''/|
   //< |    initializer    < |

--- a/test/studies/amr/lib/level/LevelSolution_def.chpl
+++ b/test/studies/amr/lib/level/LevelSolution_def.chpl
@@ -23,7 +23,6 @@ class LevelSolution {
     this.level  = level;
     old_data     = new LevelVariable(level = level);
     current_data = new LevelVariable(level = level);
-    super.init();
   }
   // /|''''''''''''''''''''/|
   //< |    initializer    < |

--- a/test/studies/amr/lib/level/Level_def.chpl
+++ b/test/studies/amr/lib/level/Level_def.chpl
@@ -91,7 +91,6 @@ class Level {
     //---------------------------------------------------------------
 
     possible_ghost_cells = possible_cells.expand(2*n_ghost_cells);
-    super.init();
 
   }
   // /|''''''''''''''''''''/|

--- a/test/studies/amr/lib/misc/MultiDomain_def.chpl
+++ b/test/studies/amr/lib/misc/MultiDomain_def.chpl
@@ -67,7 +67,6 @@ class MultiDomain
     this.rank = rank;
     this.stridable = stridable;
     root = new MDNode( rank, stridable );
-    super.init();
   }
 
 

--- a/test/studies/comd/elegant/arrayOfStructs/util/AccumStencilDist.chpl
+++ b/test/studies/comd/elegant/arrayOfStructs/util/AccumStencilDist.chpl
@@ -481,7 +481,6 @@ proc LocAccumStencil.init(param rank: int,
     }
     myChunk = {(...inds)};
   }
-  super.init();
 }
 
 proc AccumStencilDom.dsiMyDist() return dist;

--- a/test/studies/comd/llnl/utils/forcelj.chpl
+++ b/test/studies/comd/llnl/utils/forcelj.chpl
@@ -17,17 +17,10 @@ class ForceLJ : Force {
   var epsilon4 : real;
 
   proc init() {
-    sigma = 2.315;
-    epsilon  = 0.167;
-    var locCutoff = 2.5*sigma;
+    const sigma = 2.315;
+    const locCutoff = 2.5*sigma;
 
     var locCutoff2 = locCutoff * locCutoff;
-    sigma2 = sigma * sigma;
-    s6 = sigma2*sigma2*sigma2;
-    rCut6 = s6 / (locCutoff2*locCutoff2*locCutoff2);
-    eShift = POT_SHIFT * rCut6 * (rCut6 - 1.0);
-    epsilon2 = 2.0 * epsilon;
-    epsilon4 = 4.0 * epsilon;
     super.init(cutoff = locCutoff,
                mass = 63.55 * amuToInternalMass,
                lat = 3.615,
@@ -36,6 +29,14 @@ class ForceLJ : Force {
                atomicNumber = 29,
                potName = "Lennard-Jones",
                cutoff2 = locCutoff2);
+    this.sigma = sigma;
+    epsilon  = 0.167;
+    sigma2 = sigma * sigma;
+    s6 = sigma2*sigma2*sigma2;
+    rCut6 = s6 / (locCutoff2*locCutoff2*locCutoff2);
+    eShift = POT_SHIFT * rCut6 * (rCut6 - 1.0);
+    epsilon2 = 2.0 * epsilon;
+    epsilon4 = 4.0 * epsilon;
   }
 
   inline proc compute(a : real3, b : real3, inout fij, inout pij) {

--- a/test/types/records/const-checking/initArrOfRecConstField2.chpl
+++ b/test/types/records/const-checking/initArrOfRecConstField2.chpl
@@ -9,7 +9,6 @@ class C  {
   proc init() {
     var myR = new R(c=1, v=2);
     A = [myR, myR, myR];
-    super.init();
   }
 }
 

--- a/test/types/records/const-checking/initArrOfRecConstField2a.chpl
+++ b/test/types/records/const-checking/initArrOfRecConstField2a.chpl
@@ -9,7 +9,6 @@ class C  {
   proc init() {
     var myR = new R(c=1, v=2);
     A = myR;  // should use promoted initialization
-    super.init();
   }
 }
 

--- a/test/types/records/const-checking/initArrOfRecConstField2b.chpl
+++ b/test/types/records/const-checking/initArrOfRecConstField2b.chpl
@@ -9,7 +9,6 @@ class C  {
   proc init() {
     var myR = new R(c=1, v=2);
     A = [i in 1..3] myR;
-    super.init();
   }
 }
 

--- a/test/users/shetag/fock/blockindices-blc.chpl
+++ b/test/users/shetag/fock/blockindices-blc.chpl
@@ -9,7 +9,6 @@ class blockIndices {
     js = bas_info(jat);
     ks = bas_info(kat);
     ls = bas_info(lat);
-    super.init();
   }
 
   // BLC: TODO -- this should have a better name

--- a/test/users/shetag/fock/fock-1-begin-blc.chpl
+++ b/test/users/shetag/fock/fock-1-begin-blc.chpl
@@ -24,7 +24,6 @@ class blockIndices {
     this.khi = khi;
     this.llo = llo;
     this.lhi = lhi;
-    super.init();
   }
 }
 

--- a/test/users/shetag/fock/fock-orig.chpl
+++ b/test/users/shetag/fock/fock-orig.chpl
@@ -24,7 +24,6 @@ class blockIndices {
     this.khi = khi;
     this.llo = llo;
     this.lhi = lhi;
-    super.init();
   }
 }
 

--- a/test/users/thom/arrInClass-dommember.chpl
+++ b/test/users/thom/arrInClass-dommember.chpl
@@ -5,7 +5,6 @@ class StoreSomeInts {
   proc init(m_someints: [] int) {
     intsDom = m_someints.domain;
     this.m_someints = m_someints;
-    super.init();
   }
 }
 

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -37,7 +37,6 @@ class MasonError : Error {
   var msg:string;
   proc init(msg:string) {
     this.msg = msg;
-    super.init();
   }
   proc message() {
     return msg;


### PR DESCRIPTION
This PR updates the compiler to emit an error if local fields are initialized before a call to super.init.

The old initializer rules influenced many tests to initialize fields before super.init, which this PR undoes. The two main changes are:
1) Removal of super.init from the initializer
2) Replacement of super.init with an initDone

Testing:
- [x] full local + futures
- [x] full gasnet
- [x] full numa