### PR TITLE
Work around a gcc bug by ensuring that the last line in a file is not #include

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -2275,6 +2275,7 @@ void codegen(void) {
     codegen_header_addons();
 
     closeCFile(&hdrfile);
+    fprintf(mainfile.fptr, "/* last line not #include to avoid gcc bug */\n");
     closeCFile(&mainfile);
     closeCFile(&defnfile);
     closeCFile(&strconfig);


### PR DESCRIPTION
I tripped over this gcc bug on a cluster of SLES12 machines (but not on some machines with a different flavor of SLES12).  In our case, it only occurred with the numa locale model and only on certain tests, but it had nothing to do with the locale model or those tests.

https://gcc.gnu.org/ml/gcc-bugs/2017-11/msg02753.html

It turns out that because our generated `_main.c` has a `#include` as its last line, we will occasionally hit this bug, somewhat randomly from our point of view.  This change adds a comment at the end of `_main.c` to ensure that the last line is not a `#include`, which works around the bug.