### PR TITLE
Fix how CHPL_LAUNCHER_REAL_WRAPPER is set in sub_test

### DIFF
--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -1791,7 +1791,7 @@ for testname in testsrc:
             args=list()
             if timer and timereal:
                 cmd='./'+execname
-                os.environ['CHPL_LAUNCHER_REAL_WRAPPER'] = timer
+                testenv['CHPL_LAUNCHER_REAL_WRAPPER'] = timer
             elif timer:
                 cmd=timer
                 args+=['./'+execname]


### PR DESCRIPTION
Previously, we were setting `CHPL_LAUNCHER_REAL_WRAPPER` in sub_test's
environment, which meant that any other commands running as a child of
sub_test would also have it set. This meant that things like the
regexdna.preexec or the other "run fasta to produce an input file" prexecs
could have `CHPL_LAUNCHER_REAL_WRAPPER` set in their environment, which would
add the timer output to the file, which screwed up the input for tests that
relied on it (at least as of #8165, which redirected the timer output to stdout
instead of stderr.)

To avoid this, just set `CHPL_LAUNCHER_REAL_WRAPPER` in the testenv, which is
only used when we're actually executing a test (and not a preexec or anything)

I don't understand how this didn't bite us when #8165 was merged, but it has
been causing regressions in nightly testing the last week.