### PR TITLE
Warn only if compopts file is empty, not if executable compopts ouput empty

### DIFF
--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -1258,12 +1258,12 @@ for testname in testsrc:
     chpldoc_opts_filename = test_filename + chpldocsuffix
     if test_is_chpldoc and os.access(chpldoc_opts_filename, os.R_OK):
         compoptslist = ReadFileWithComments(chpldoc_opts_filename, False)
-        if not compoptslist:
+        if os.stat(chpldoc_opts_filename).st_size == 0:
             sys.stdout.write('[Warning: ignoring an empty chpldocopts file %s]\n' %
                              (test_filename+compoptssuffix))
     elif os.access(test_filename+compoptssuffix, os.R_OK):
         compoptslist = ReadFileWithComments(test_filename+compoptssuffix, False)
-        if not compoptslist:
+        if os.stat(test_filename+compoptssuffix).st_size == 0:
             # cf. for execoptslist no warning is issued
             sys.stdout.write('[Warning: ignoring an empty compopts file %s]\n'%(test_filename+compoptssuffix))
 


### PR DESCRIPTION
Long ago, an empty compopts list caused a test to be skipped.  The following commit added a warning message to alert people when this would happen.

https://github.com/chapel-lang/chapel/commit/581adb3888aeabc120bae160b7d324c70234afc7

Later, #4015 modified sub_test so that a test would run even with an empty compopts list.

There still may be some value in issuing the warning when a .compopts file is empty, but an executable .compopts file may legitimately emit an empty list in some circumstances, and that should not trigger a warning.  This change checks for an empty file, rather than an empty compopts list, before issuing the warning.

This change was made because #8747 created an executable compopts file that sometimes needs to emit an empty compopts list (on purpose).  This was triggering a warning in testing.

Tested with:
* nonempty nonexecutable compopts file
* nonempty executable compopts file
* empty nonexecutable compopts file
* empty executable compopts file (which triggers a different message elsewhere in the script)