### PR TITLE
Enable phase one dynamic dispatch

### DIFF
--- a/compiler/include/InitNormalize.h
+++ b/compiler/include/InitNormalize.h
@@ -83,8 +83,8 @@ public:
 
   void            describe(int offset = 0)                               const;
 
-  void            checkAndEmitErrors(Expr* expr);
-  void            checkAndEmitErrors(CallExpr* call);
+  void            processThisUses(Expr* expr);
+  void            processThisUses(CallExpr* call);
 
   void            makeThisAsParent(CallExpr* initCall);
 

--- a/compiler/include/InitNormalize.h
+++ b/compiler/include/InitNormalize.h
@@ -86,6 +86,8 @@ public:
   void            checkAndEmitErrors(Expr* expr);
   void            checkAndEmitErrors(CallExpr* call);
 
+  void            makeThisAsParent(CallExpr* initCall);
+
 private:
   enum BlockType {
     cBlockNormal,
@@ -156,6 +158,7 @@ private:
   InitPhase       mPhase;
   BlockType       mBlockType;
   BlockType       mPrevBlockType;
+  VarSymbol*      mThisAsParent;
 
   std::set<DefExpr*> mImplicitFields;
 };

--- a/compiler/passes/InitNormalize.cpp
+++ b/compiler/passes/InitNormalize.cpp
@@ -251,7 +251,9 @@ void InitNormalize::completePhase1(CallExpr* initStmt) {
   }
 
   // Allow users to treat 'this' as the initialized type
-  initStmt->insertAfter(new CallExpr(PRIM_SETCID, new SymExpr(mFn->_this)));
+  if (type()->isClass()) {
+    initStmt->insertAfter(new CallExpr(PRIM_SETCID, new SymExpr(mFn->_this)));
+  }
 
   mPhase = cPhase2;
 }

--- a/compiler/passes/InitNormalize.cpp
+++ b/compiler/passes/InitNormalize.cpp
@@ -41,12 +41,14 @@ InitNormalize::InitNormalize(FnSymbol* fn) {
   mPhase         = startPhase(fn);
   mBlockType     = cBlockNormal;
   mPrevBlockType = cBlockNormal;
+  mThisAsParent  = NULL;
 }
 
 InitNormalize::InitNormalize(BlockStmt* block, const InitNormalize& curr) {
   mFn            = curr.mFn;
   mCurrField     = curr.mCurrField;
   mPhase         = curr.mPhase;
+  mThisAsParent  = curr.mThisAsParent;
 
   if (CallExpr* blockInfo = block->blockInfoGet()) {
     if        (blockInfo->isPrimitive(PRIM_BLOCK_BEGIN)       == true ||
@@ -85,6 +87,7 @@ InitNormalize::InitNormalize(CondStmt* cond, const InitNormalize& curr) {
   mCurrField     = curr.mCurrField;
   mPhase         = curr.mPhase;
   mBlockType     = cBlockCond;
+  mThisAsParent  = curr.mThisAsParent;
 
   if (mBlockType != curr.mBlockType) {
     mPrevBlockType = curr.mBlockType;
@@ -98,6 +101,7 @@ InitNormalize::InitNormalize(LoopStmt* loop, const InitNormalize& curr) {
   mCurrField     = curr.mCurrField;
   mPhase         = curr.mPhase;
   mBlockType     = cBlockLoop;
+  mThisAsParent  = curr.mThisAsParent;
 
   if (mBlockType != curr.mBlockType) {
     mPrevBlockType = curr.mBlockType;
@@ -112,6 +116,7 @@ InitNormalize::InitNormalize(ForallStmt* loop, const InitNormalize& curr) {
   mCurrField     = curr.mCurrField;
   mPhase         = curr.mPhase;
   mBlockType     = cBlockForall;
+  mThisAsParent  = curr.mThisAsParent;
 
   if (mBlockType != curr.mBlockType) {
     mPrevBlockType = curr.mBlockType;
@@ -127,6 +132,10 @@ void InitNormalize::merge(const InitNormalize& fork) {
 
   mImplicitFields.insert(fork.mImplicitFields.begin(),
                          fork.mImplicitFields.end());
+
+  if (this->mThisAsParent == NULL) {
+    this->mThisAsParent = fork.mThisAsParent;
+  }
 }
 
 AggregateType* InitNormalize::type() const {
@@ -240,6 +249,9 @@ void InitNormalize::completePhase1(CallExpr* initStmt) {
   } else {
     INT_ASSERT(false);
   }
+
+  // Allow users to treat 'this' as the initialized type
+  initStmt->insertAfter(new CallExpr(PRIM_SETCID, new SymExpr(mFn->_this)));
 
   mPhase = cPhase2;
 }
@@ -1353,6 +1365,47 @@ void InitNormalize::makeOuterArg() {
                                  mFn->_outer));
 }
 
+//
+// Initialize the 'mThisAsParent' field
+//
+// mThisAsParent points to the same data as 'this', but has the parent type
+// of 'this'. This method also inserts a call to set the class ID of
+// mThisAsParent (and 'this') so that we only dynamically dispatch methods to
+// the parent.
+//
+void InitNormalize::makeThisAsParent(CallExpr* call) {
+  // type parentType = this.super.type;
+  // var thisAsParent : parentType = (_cast parentType this);
+
+  INT_ASSERT(this->mThisAsParent == NULL);
+
+  VarSymbol* parentType = newTemp();
+  DefExpr*   parentDef  = new DefExpr(parentType);
+  parentType->addFlag(FLAG_TYPE_VARIABLE);
+
+  // Let resolution figure out the type for us
+  // (move parentType (typeof (.v this super)))
+  CallExpr* getSuper = new CallExpr(PRIM_GET_MEMBER_VALUE, mFn->_this, new_CStringSymbol("super"));
+  CallExpr* typeInit = new CallExpr(PRIM_MOVE, parentType,
+                                    new CallExpr(PRIM_TYPEOF, getSuper));
+
+  // Important to use PRIM_CAST here, otherwise resolution will complain about
+  // 'this' having an unknown type if the class is generic.
+  VarSymbol* thisAsParent = newTemp("chpl__thisAsParent");
+  SymExpr*   tapType      = new SymExpr(parentType);
+  CallExpr*  tapInit      = new CallExpr(PRIM_CAST, parentType, new SymExpr(mFn->_this));
+  DefExpr*   tapDef       = new DefExpr(thisAsParent, tapInit, tapType);
+
+  CallExpr* setCID = new CallExpr(PRIM_SETCID, thisAsParent);
+
+  call->insertAfter(setCID);
+  call->insertAfter(tapDef);
+  call->insertAfter(typeInit);
+  call->insertAfter(parentDef);
+
+  this->mThisAsParent = thisAsParent;
+}
+
 static bool isThisDot(CallExpr* call) {
   bool retval = false;
 
@@ -1433,6 +1486,31 @@ static bool isMethodCall(CallExpr* call) {
   return retval;
 }
 
+//
+// Returns true if 'type' or its parents have a method named 'methodName'
+//
+// Note: Assumes only one entry in dispatchParents.
+//
+static bool typeHasMethod(AggregateType* type, const char* methodName) {
+  bool retval = false;
+
+  forv_Vec(FnSymbol, method, type->methods) {
+    if (strcmp(method->name, methodName) == 0) {
+      retval = true;
+      break;
+    }
+  }
+
+  if (retval == false) {
+    AggregateType* parent = type->dispatchParents.v[0];
+    if (parent != NULL && parent != dtObject) {
+      retval = typeHasMethod(parent, methodName);
+    }
+  }
+
+  return retval;
+}
+
 void InitNormalize::checkAndEmitErrors(Expr* expr) {
   if (isPhase2() != true) {
     if (CallExpr* call = toCallExpr(expr)) {
@@ -1443,10 +1521,16 @@ void InitNormalize::checkAndEmitErrors(Expr* expr) {
   }
 }
 
-// Catch a handful of errors:
+//
+// This method processes uses of 'this' and either:
+// 1) Checks for semantic errors
+// 2) Updates 'this' to be mThisAsParent
+//
+// The errors caught are:
 // 1) use-before-init
-// 2) method call in phase 1
-// 3) pass 'this' to function in phase 1
+// 2) cast 'this'
+// 3) call child-only method in phase one
+//
 void InitNormalize::checkAndEmitErrors(CallExpr* call) {
   std::vector<CallExpr*> uses;
   collectThisUses(call, uses);
@@ -1465,12 +1549,44 @@ void InitNormalize::checkAndEmitErrors(CallExpr* call) {
         numErrors += 1;
       }
     } else if (isMethodCall(use)) {
-      USR_FATAL_CONT(call, "cannot call a method during phase 1 of initialization");
-      numErrors += 1;
+      if (isPhase0() == true) {
+        USR_FATAL_CONT(call, "cannot call a method before super.init() or this.init()");
+        numErrors += 1;
+      } else {
+        // Check if the called method can be dynamically dispatched, otherwise
+        // it's an error.
+        Immediate* imm = getSymbolImmediate(toSymExpr(use->get(2))->symbol());
+        const char* methodName = imm->string_value();
+        AggregateType* parentType = type()->dispatchParents.v[0];
+        if (typeHasMethod(parentType, methodName) == false) {
+          USR_FATAL_CONT(call, "cannot call method \"%s\" on type \"%s\" in phase one", methodName, type()->symbol->name);
+          USR_PRINT(call, "\"this\" in phase one treated as parent type \"%s\" for method calls", parentType->symbol->name);
+          numErrors += 1;
+        }
+
+        SymExpr* thisSE = toSymExpr(use->get(1));
+        if (thisSE != NULL && thisSE->symbol()->hasFlag(FLAG_ARG_THIS)) {
+          thisSE->replace(new SymExpr(mThisAsParent));
+        }
+      }
     } else {
-      USR_FATAL_CONT(call, "cannot pass \"this\" to a function in phase 1 of initialization");
-      numErrors += 1;
-      // TODO: Ensure 'this' in 'use'
+      if (use->isPrimitive(PRIM_CAST) || use->isNamed("_cast")) {
+        USR_FATAL_CONT(call, "cannot cast \"this\" in phase one");
+        numErrors += 1;
+      } else {
+        // Find 'this' usage(s) in call and replace them with mThisAsParent
+        for_actuals(actual, use) {
+          SymExpr* actSe = NULL;
+          if (SymExpr* se = toSymExpr(actual)) {
+            actSe = se;
+          } else if (NamedExpr* named = toNamedExpr(actual)) {
+            actSe = toSymExpr(named->actual);
+          }
+          if (actSe != NULL && actSe->symbol()->hasFlag(FLAG_ARG_THIS)) {
+            actSe->replace(new SymExpr(mThisAsParent));
+          }
+        }
+      }
     }
   }
 

--- a/compiler/passes/InitNormalize.cpp
+++ b/compiler/passes/InitNormalize.cpp
@@ -1552,6 +1552,9 @@ void InitNormalize::processThisUses(CallExpr* call) {
       if (isPhase0() == true) {
         USR_FATAL_CONT(call, "cannot call a method before super.init() or this.init()");
         numErrors += 1;
+      } else if (type()->isRecord()) {
+        USR_FATAL_CONT(call, "cannot call a method on a record during phase 1 of initialization");
+        numErrors += 1;
       } else {
         // Check if the called method can be dynamically dispatched, otherwise
         // it's an error.
@@ -1570,7 +1573,10 @@ void InitNormalize::processThisUses(CallExpr* call) {
         }
       }
     } else {
-      if (use->isPrimitive(PRIM_CAST) || use->isNamed("_cast")) {
+      if (type()->isRecord()) {
+        USR_FATAL_CONT(call, "cannot pass \"this\" to a function in phase 1 of initialization");
+        numErrors += 1;
+      } else if (use->isPrimitive(PRIM_CAST) || use->isNamed("_cast")) {
         USR_FATAL_CONT(call, "cannot cast \"this\" in phase one");
         numErrors += 1;
       } else {

--- a/compiler/passes/InitNormalize.cpp
+++ b/compiler/passes/InitNormalize.cpp
@@ -1511,12 +1511,12 @@ static bool typeHasMethod(AggregateType* type, const char* methodName) {
   return retval;
 }
 
-void InitNormalize::checkAndEmitErrors(Expr* expr) {
+void InitNormalize::processThisUses(Expr* expr) {
   if (isPhase2() != true) {
     if (CallExpr* call = toCallExpr(expr)) {
-      checkAndEmitErrors(call);
+      processThisUses(call);
     } else if (DefExpr* def = toDefExpr(expr)) {
-      checkAndEmitErrors(def->init);
+      processThisUses(def->init);
     }
   }
 }
@@ -1531,7 +1531,7 @@ void InitNormalize::checkAndEmitErrors(Expr* expr) {
 // 2) cast 'this'
 // 3) call child-only method in phase one
 //
-void InitNormalize::checkAndEmitErrors(CallExpr* call) {
+void InitNormalize::processThisUses(CallExpr* call) {
   std::vector<CallExpr*> uses;
   collectThisUses(call, uses);
 
@@ -1610,7 +1610,7 @@ Expr* InitNormalize::fieldInitFromInitStmt(DefExpr*  field,
     }
   }
 
-  checkAndEmitErrors(initStmt);
+  processThisUses(initStmt);
 
   retval     = fieldInitFromStmt(initStmt, field);
   mCurrField = toDefExpr(mCurrField->next);

--- a/compiler/passes/initializerRules.cpp
+++ b/compiler/passes/initializerRules.cpp
@@ -463,7 +463,7 @@ static InitNormalize preNormalize(AggregateType* at,
                 "initializers for now");
 
     } else if (isDefExpr(stmt) == true) {
-      state.checkAndEmitErrors(stmt);
+      state.processThisUses(stmt);
 
       stmt = stmt->next;
 
@@ -598,7 +598,7 @@ static InitNormalize preNormalize(AggregateType* at,
 
       // No action required
       } else {
-        state.checkAndEmitErrors(stmt);
+        state.processThisUses(stmt);
 
         stmt = stmt->next;
       }

--- a/test/classes/initializers/errors/multipleErrors.chpl
+++ b/test/classes/initializers/errors/multipleErrors.chpl
@@ -3,7 +3,7 @@ proc printer(args...) {
   for a in args do writeln(a);
 }
 
-class C {
+record C {
   var x : int;
   var y : real;
 

--- a/test/classes/initializers/errors/multipleErrors.good
+++ b/test/classes/initializers/errors/multipleErrors.good
@@ -1,5 +1,5 @@
 multipleErrors.chpl:10: In initializer:
 multipleErrors.chpl:11: error: Field "x" used before it is initialized
 multipleErrors.chpl:11: error: Field "y" used before it is initialized
-multipleErrors.chpl:11: error: cannot call a method during phase 1 of initialization
+multipleErrors.chpl:11: error: cannot call a method on a record during phase 1 of initialization
 multipleErrors.chpl:11: error: cannot pass "this" to a function in phase 1 of initialization

--- a/test/classes/initializers/generics/phase1/accessThisBad.good
+++ b/test/classes/initializers/generics/phase1/accessThisBad.good
@@ -1,2 +1,2 @@
 accessThisBad.chpl:4: In initializer:
-accessThisBad.chpl:5: error: cannot pass "this" to a function in phase 1 of initialization
+accessThisBad.chpl:5: error: cannot pass "this" to a function before calling super.init() or this.init()

--- a/test/classes/initializers/generics/phase1/methodCall.good
+++ b/test/classes/initializers/generics/phase1/methodCall.good
@@ -1,2 +1,2 @@
 methodCall.chpl:4: In initializer:
-methodCall.chpl:5: error: cannot call a method during phase 1 of initialization
+methodCall.chpl:5: error: cannot call a method before super.init() or this.init()

--- a/test/classes/initializers/named-argument-to-send-this-bad.good
+++ b/test/classes/initializers/named-argument-to-send-this-bad.good
@@ -1,2 +1,2 @@
 named-argument-to-send-this-bad.chpl:4: In initializer:
-named-argument-to-send-this-bad.chpl:5: error: cannot pass "this" to a function in phase 1 of initialization
+named-argument-to-send-this-bad.chpl:5: error: cannot pass "this" to a function before calling super.init() or this.init()

--- a/test/classes/initializers/phase1/accessThisBad.good
+++ b/test/classes/initializers/phase1/accessThisBad.good
@@ -1,2 +1,2 @@
 accessThisBad.chpl:4: In initializer:
-accessThisBad.chpl:5: error: cannot pass "this" to a function in phase 1 of initialization
+accessThisBad.chpl:5: error: cannot pass "this" to a function before calling super.init() or this.init()

--- a/test/classes/initializers/phase1/dynamicThis/callMethod.chpl
+++ b/test/classes/initializers/phase1/dynamicThis/callMethod.chpl
@@ -1,0 +1,91 @@
+
+class Parent {
+  var a : int;
+  var b : real;
+
+  proc init() {
+    writeln("Parent.init()");
+    this.a = 1;
+    this.b = 5.0;
+  }
+
+  proc init(a, b) {
+    writeln("Parent.init(a, b)");
+    this.a = a;
+    this.b = b;
+  }
+
+  proc parentOnly() {
+    writeln("Parent.parentOnly()");
+  }
+
+  proc inheritedMethod() {
+    writeln("Parent.inheritedMethod()");
+  }
+}
+
+class Child : Parent {
+  var x : int;
+  var y : real;
+
+  proc init() {
+    writeln("phase one");
+
+    this.x = a * 5;
+    this.y = b * -1.0;
+    parentOnly();
+    inheritedMethod();
+
+    this.initDone();
+
+    writeln("phase two");
+    inheritedMethod();
+  }
+
+  proc init(a, b, x, y) {
+    super.init(a, b);
+    writeln("phase one");
+
+    this.x = x;
+    this.y = y;
+    parentOnly();
+    inheritedMethod();
+
+    this.initDone();
+
+    writeln("phase two");
+    inheritedMethod();
+  }
+
+  proc init(q) {
+    writeln("Child this.init()");
+    this.init(q, q, q, q);
+    writeln("phase two");
+    inheritedMethod();
+  }
+
+  proc inheritedMethod() {
+    writeln("Child.inheritedMethod()");
+  }
+}
+
+proc main() {
+  writeln("----- implicit super.init -----");
+  var implicit = new Child();
+  writeln("implicit = ", implicit);
+  delete implicit;
+
+  writeln();
+
+  writeln("----- explicit super.init -----");
+  var explicit = new Child(1, 10.0, 100, 1000.0);
+  writeln("explicit = ", explicit);
+  delete explicit;
+
+  writeln();
+
+  writeln("----- this.init -----");
+  var thisInit = new Child(1);
+  writeln("thisInit = ", thisInit);
+  delete thisInit;
+}

--- a/test/classes/initializers/phase1/dynamicThis/callMethod.good
+++ b/test/classes/initializers/phase1/dynamicThis/callMethod.good
@@ -1,0 +1,29 @@
+----- implicit super.init -----
+Parent.init()
+phase one
+Parent.parentOnly()
+Parent.inheritedMethod()
+phase two
+Child.inheritedMethod()
+implicit = {a = 1, b = 5.0, x = 5, y = -5.0}
+
+----- explicit super.init -----
+Parent.init(a, b)
+phase one
+Parent.parentOnly()
+Parent.inheritedMethod()
+phase two
+Child.inheritedMethod()
+explicit = {a = 1, b = 10.0, x = 100, y = 1000.0}
+
+----- this.init -----
+Child this.init()
+Parent.init(a, b)
+phase one
+Parent.parentOnly()
+Parent.inheritedMethod()
+phase two
+Child.inheritedMethod()
+phase two
+Child.inheritedMethod()
+thisInit = {a = 1, b = 1.0, x = 1, y = 1.0}

--- a/test/classes/initializers/phase1/dynamicThis/castThis.chpl
+++ b/test/classes/initializers/phase1/dynamicThis/castThis.chpl
@@ -1,0 +1,26 @@
+
+class Parent {
+  var x : int;
+
+  proc init() {
+    this.x = 5;
+  }
+
+  proc inheritedMethod() {
+    writeln("Parent.inheritedMethod()");
+  }
+}
+
+class Child : Parent {
+  var y : real;
+
+  proc init() {
+    this.y = x ** 2;
+    inheritedMethod();
+    (this:Child).inheritedMethod();
+  }
+
+  proc inheritedMethod() {
+    writeln("Child.inheritedMethod()");
+  }
+}

--- a/test/classes/initializers/phase1/dynamicThis/castThis.good
+++ b/test/classes/initializers/phase1/dynamicThis/castThis.good
@@ -1,0 +1,2 @@
+castThis.chpl:17: In initializer:
+castThis.chpl:20: error: cannot cast "this" in phase one

--- a/test/classes/initializers/phase1/dynamicThis/childMethod.chpl
+++ b/test/classes/initializers/phase1/dynamicThis/childMethod.chpl
@@ -1,0 +1,34 @@
+
+class Parent {
+  var p : int;
+
+  proc init() {
+    this.p = 5;
+  }
+
+  proc inheritedMethod() {
+    writeln("Parent.inheritedMethod()");
+  }
+}
+
+class Child : Parent {
+  var c : real;
+
+  proc init() {
+    this.c = p ** 2;
+    inheritedMethod();
+    childMethod();
+  }
+
+  proc inheritedMethod() {
+    writeln("Child.inheritedMethod()");
+  }
+
+  proc childMethod() {
+    writeln("Child.childMethod()");
+  }
+}
+
+var c = new Child();
+delete c;
+

--- a/test/classes/initializers/phase1/dynamicThis/childMethod.good
+++ b/test/classes/initializers/phase1/dynamicThis/childMethod.good
@@ -1,0 +1,3 @@
+childMethod.chpl:17: In initializer:
+childMethod.chpl:20: error: cannot call method "childMethod" on type "Child" in phase one
+childMethod.chpl:20: note: "this" in phase one treated as parent type "Parent" for method calls

--- a/test/classes/initializers/phase1/dynamicThis/conditional.chpl
+++ b/test/classes/initializers/phase1/dynamicThis/conditional.chpl
@@ -1,0 +1,31 @@
+
+class Parent {
+  var x : int;
+
+  proc init() {
+    this.x = 5;
+  }
+
+  proc inheritedMethod() {
+    writeln("Parent.inheritedMethod()");
+  }
+}
+
+class Child : Parent {
+  var y : real;
+
+  proc init(cond:bool) {
+    if cond {
+      this.y = -1.0;
+      inheritedMethod();
+    } else {
+      this.y = 1.0;
+      inheritedMethod();
+    }
+    inheritedMethod();
+  }
+}
+
+var c = new Child(true);
+writeln("c = ", c);
+delete c;

--- a/test/classes/initializers/phase1/dynamicThis/conditional.good
+++ b/test/classes/initializers/phase1/dynamicThis/conditional.good
@@ -1,0 +1,3 @@
+Parent.inheritedMethod()
+Parent.inheritedMethod()
+c = {x = 5, y = -1.0}

--- a/test/classes/initializers/phase1/dynamicThis/genericParent.chpl
+++ b/test/classes/initializers/phase1/dynamicThis/genericParent.chpl
@@ -1,0 +1,49 @@
+
+// This test exists to ensure that the compiler doesn't screw up when fiddling
+// with the type and class ID of 'this' in phase one.
+
+class Parent {
+  type eltType;
+  var x : eltType;
+
+  proc init(type t) {
+    this.eltType = t;
+  }
+
+  proc inheritedMethod() {
+    writeln(this.type:string, ".inheritedMethod()");
+  }
+}
+
+proc foobar(p : Parent(int)) {
+  writeln("foobar(Parent(int))");
+}
+proc foobar(p : Parent) {
+  writeln("foobar(Parent(other))");
+}
+
+class Child : Parent {
+  var y : real;
+
+  proc init(type t) {
+    super.init(t);
+    inheritedMethod();
+    foobar(this);
+    initDone();
+    inheritedMethod();
+  }
+
+  proc inheritedMethod() {
+    writeln(this.type:string, ".inheritedMethod()");
+  }
+}
+
+writeln("----- integer -----");
+var childInt = new Child(int);
+delete childInt;
+
+writeln();
+
+writeln("----- real -----");
+var childReal = new Child(real);
+delete childReal;

--- a/test/classes/initializers/phase1/dynamicThis/genericParent.good
+++ b/test/classes/initializers/phase1/dynamicThis/genericParent.good
@@ -1,0 +1,9 @@
+----- integer -----
+Parent(int(64)).inheritedMethod()
+foobar(Parent(int))
+Child(int(64)).inheritedMethod()
+
+----- real -----
+Parent(real(64)).inheritedMethod()
+foobar(Parent(other))
+Child(real(64)).inheritedMethod()

--- a/test/classes/initializers/phase1/dynamicThis/grandparentMethod.chpl
+++ b/test/classes/initializers/phase1/dynamicThis/grandparentMethod.chpl
@@ -1,0 +1,38 @@
+
+//
+// This test exists to ensure that the compiler does not emit an error for the
+// call to 'grandMethod'. This could happen if the compiler only checked the
+// methods in 'Parent'.
+//
+
+class Grandparent {
+  var g : int;
+
+  proc init() {
+    this.g = 1;
+  }
+
+  proc grandMethod() {
+    writeln("Grandparent.grandMethod()");
+  }
+}
+
+class Parent : Grandparent {
+  var p : real;
+
+  proc init() {
+    this.p = 2.0;
+  }
+}
+
+class Child : Parent {
+  var c : string;
+
+  proc init() {
+    this.c = "foo";
+    grandMethod();
+  }
+}
+
+var c = new Child();
+delete c;

--- a/test/classes/initializers/phase1/dynamicThis/grandparentMethod.good
+++ b/test/classes/initializers/phase1/dynamicThis/grandparentMethod.good
@@ -1,0 +1,1 @@
+Grandparent.grandMethod()

--- a/test/classes/initializers/phase1/dynamicThis/passToChildType.chpl
+++ b/test/classes/initializers/phase1/dynamicThis/passToChildType.chpl
@@ -1,0 +1,28 @@
+
+class Parent {
+  var x : int;
+
+  proc init() {
+    this.x = 5;
+  }
+
+  proc inheritedMethod() {
+    writeln("Parent.inheritedMethod");
+  }
+}
+
+class Child : Parent {
+  var y : real;
+
+  proc init() {
+    this.y = x**2;
+    foobar(this);
+  }
+}
+
+proc foobar(c : Child) {
+  writeln("foobar(Child)");
+}
+
+var c = new Child();
+delete c;

--- a/test/classes/initializers/phase1/dynamicThis/passToChildType.good
+++ b/test/classes/initializers/phase1/dynamicThis/passToChildType.good
@@ -1,0 +1,3 @@
+passToChildType.chpl:17: In initializer:
+passToChildType.chpl:19: error: unresolved call 'foobar(Parent)'
+passToChildType.chpl:23: note: candidates are: foobar(c: Child)

--- a/test/classes/initializers/phase1/dynamicThis/thisToFunction.chpl
+++ b/test/classes/initializers/phase1/dynamicThis/thisToFunction.chpl
@@ -1,0 +1,50 @@
+
+class Parent {
+  var x : int;
+
+  proc init() {
+    this.x = 5;
+  }
+
+  proc inheritedMethod() {
+    writeln("Parent.inheritedMethod()");
+  }
+}
+
+proc foobar(thing) {
+  writeln("thing.type = ", thing.type:string);
+  thing.x += 1;
+  thing.inheritedMethod();
+  writeln();
+}
+
+proc multi(a,b) {
+  writeln("a.type = ", a.type:string);
+  writeln("b.type = ", b.type:string);
+  a.inheritedMethod();
+  b.inheritedMethod();
+  writeln();
+}
+
+class Child : Parent {
+  var y : real;
+
+  proc init() {
+    writeln("----- phase one -----");
+    this.y = x ** 2;
+    inheritedMethod();
+    foobar(this);
+    multi(this, this);
+    this.initDone();
+    writeln("----- phase two -----");
+    foobar(this);
+  }
+
+  proc inheritedMethod() {
+    writeln("Child.inheritedMethod()");
+  }
+}
+
+var c = new Child();
+writeln("c = ", c);
+delete c;

--- a/test/classes/initializers/phase1/dynamicThis/thisToFunction.good
+++ b/test/classes/initializers/phase1/dynamicThis/thisToFunction.good
@@ -1,0 +1,15 @@
+----- phase one -----
+Parent.inheritedMethod()
+thing.type = Parent
+Parent.inheritedMethod()
+
+a.type = Parent
+b.type = Parent
+Parent.inheritedMethod()
+Parent.inheritedMethod()
+
+----- phase two -----
+thing.type = Child
+Child.inheritedMethod()
+
+c = {x = 7, y = 25.0}

--- a/test/classes/initializers/phase1/methodCall.good
+++ b/test/classes/initializers/phase1/methodCall.good
@@ -1,2 +1,2 @@
 methodCall.chpl:4: In initializer:
-methodCall.chpl:5: error: cannot call a method during phase 1 of initialization
+methodCall.chpl:5: error: cannot call a method before super.init() or this.init()

--- a/test/classes/initializers/phase1/useAfterInit/passMissingFn.bad
+++ b/test/classes/initializers/phase1/useAfterInit/passMissingFn.bad
@@ -1,2 +1,2 @@
 passMissingFn.chpl:9: In initializer:
-passMissingFn.chpl:11: error: cannot call a method during phase 1 of initialization
+passMissingFn.chpl:11: error: cannot call a method on a record during phase 1 of initialization

--- a/test/classes/initializers/phase1/useAfterInit/passThisFn.good
+++ b/test/classes/initializers/phase1/useAfterInit/passThisFn.good
@@ -1,2 +1,2 @@
 passThisFn.chpl:10: In initializer:
-passThisFn.chpl:15: error: cannot call a method during phase 1 of initialization
+passThisFn.chpl:15: error: cannot call a method on a record during phase 1 of initialization


### PR DESCRIPTION
This PR updates the compiler to transform ``this`` in phase one to have the type and class ID of the class it inherits. The class ID is reset upon a call to initDone or at the end of the initializer.

Users can now call methods in phase one, provided that the parent implements the invoked method. Users can also now pass ``this`` to functions in phase one. Passing ``this`` before super.init or this.init is an error.

Testing:
- [x] full local + futures
- [x] full gasnet
- [x] partial numa
- [x] partial LLVM