### PR TITLE
Update initializer+cobegin test error message

### DIFF
--- a/test/classes/initializers/parentCall/inCobeginOn.no-local.good
+++ b/test/classes/initializers/parentCall/inCobeginOn.no-local.good
@@ -1,2 +1,2 @@
 inCobeginOn.chpl:4: In initializer:
-inCobeginOn.chpl:8: error: use of super.init() call in an on block
+inCobeginOn.chpl:8: error: use of this.initDone() call in an on block


### PR DESCRIPTION
PR #8768 changed this test without updating the output for the no-local .good file.