### PR TITLE
Extend checking of JIRA 329 (fatal MPP reservation) to handle more

### DIFF
--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -1901,6 +1901,8 @@ for testname in testsrc:
                             launcher_error = 'Jira 324 -- PBS job killed for'
                         elif re.search('Fatal MPP reservation error on confirm', output, re.IGNORECASE) != None:
                             launcher_error = 'Jira 329 -- Fatal MPP reservation error for'
+                        elif re.search('Fatal MPP reservation error on create', output, re.IGNORECASE) != None:
+                            launcher_error = 'Jira 329 -- Fatal MPP reservation error for'
                         elif (re.search('PBS: job killed: walltime', output, re.IGNORECASE) != None or
                               re.search('slurm.* CANCELLED .* DUE TO TIME LIMIT', output, re.IGNORECASE) != None):
                             exectimeout = True


### PR DESCRIPTION
The message it was checking for was "Fatal MPP reservation on
confirm" but we encountered another variant, "Fatal MPP reservation
on create".  Add that case to the list of those tracked since it
seems to be the same category of failures