### PR TITLE
change perf playground branch name

### DIFF
--- a/util/cron/test-perf.chapcs.playground.bash
+++ b/util/cron/test-perf.chapcs.playground.bash
@@ -27,7 +27,7 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.playground"
 
 # Test performance of lowering ForallStmt at lowerIterators
 GITHUB_USER=vasslitvinov
-GITHUB_BRANCH=li
+GITHUB_BRANCH=lower-ForallStmt
 SHORT_NAME=lower-ForallStmt
 START_DATE=03/07/18
 


### PR DESCRIPTION
I renamed my lower-ForallStmt branch for #8785.
Updating the perf playground script appropriately.