### PR TITLE
Fix tests using 'this' in phase zero.

### DIFF
--- a/test/classes/initializers/generics/phase1/accessThisBad.chpl
+++ b/test/classes/initializers/generics/phase1/accessThisBad.chpl
@@ -6,7 +6,7 @@ class ThisTooEarly {
 
     r = rVal;
 
-    this.initDone();
+    super.init();
 
     foo(this); // OK!
   }

--- a/test/classes/initializers/generics/phase1/methodCall.chpl
+++ b/test/classes/initializers/generics/phase1/methodCall.chpl
@@ -5,6 +5,8 @@ class MethodTooEarly {
     myMethod();   // *** Invalid.  Still in phase1
     myMethod(20); // *** Invalid.  Still in phase1
 
+    super.init();
+
     i = iVal;
 
   }

--- a/test/classes/initializers/named-argument-to-send-this-bad.chpl
+++ b/test/classes/initializers/named-argument-to-send-this-bad.chpl
@@ -3,6 +3,7 @@ class Foo {
 
   proc init(val) {
     badCall(arg=this, val);
+    super.init();
   }
 }
 

--- a/test/classes/initializers/phase1/accessThisBad.chpl
+++ b/test/classes/initializers/phase1/accessThisBad.chpl
@@ -6,7 +6,7 @@ class ThisTooEarly {
 
     r = rVal;
 
-    this.initDone();
+    super.init();
 
     foo(this); // OK!
   }

--- a/test/classes/initializers/phase1/methodCall.chpl
+++ b/test/classes/initializers/phase1/methodCall.chpl
@@ -5,6 +5,8 @@ class MethodTooEarly {
     myMethod();   // *** Invalid.  Still in phase1
     myMethod(20); // *** Invalid.  Still in phase1
 
+    super.init();
+
     i = iVal;
 
   }


### PR DESCRIPTION
Restores super.init calls to test usage of 'this' in phase zero. PRs #8790 and #8768 were tested separately, but impacted some of the same tests leading to failures on master.