### PR TITLE
Add a + to command for make check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ depend:
 	@echo "make depend has been deprecated for the time being"
 
 check:
-	@CHPL_HOME=$(CHPL_MAKE_HOME) bash $(CHPL_MAKE_HOME)/util/test/checkChplInstall
+	@+CHPL_HOME=$(CHPL_MAKE_HOME) bash $(CHPL_MAKE_HOME)/util/test/checkChplInstall
 
 check-chpldoc: chpldoc third-party-test-venv
 	@bash $(CHPL_MAKE_HOME)/util/test/checkChplDoc


### PR DESCRIPTION
Otherwise make -j 8 check fails.
This comes up in situations where make check is run
within another Makefile.

Passed full local testing.

Reviewed by @ben-albrecht - thanks!