### PR TITLE
Remove remaining destructors from modules code

### DIFF
--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -780,7 +780,7 @@ module ChapelDistribution {
     proc dsiPostReallocate() {
     }
 
-    proc ~BaseArrOverRectangularDom() {
+    proc deinit() {
       // this is a bug workaround
     }
 
@@ -792,7 +792,7 @@ module ChapelDistribution {
     /* rank, idxType, stridable are from BaseArrOverRectangularDom */
     type eltType;
 
-    proc ~BaseRectangularArr() {
+    proc deinit() {
       // this is a bug workaround
     }
   }

--- a/modules/packages/ZMQ.chpl
+++ b/modules/packages/ZMQ.chpl
@@ -475,7 +475,7 @@ module ZMQ {
       this.initDone();
       if this.ctx == nil {
         var errmsg = zmq_strerror(errno):string;
-        halt("Error in ContextClass(): %s\n", errmsg);
+        halt("Error in ContextClass.init(): %s\n", errmsg);
       }
     }
 
@@ -484,7 +484,7 @@ module ZMQ {
         var ret = zmq_ctx_term(this.ctx):int;
         if ret == -1 {
           var errmsg = zmq_strerror(errno):string;
-          halt("Error in ~ContextClass(): %s\n", errmsg);
+          halt("Error in ContextClass.deinit(): %s\n", errmsg);
         }
       }
     }
@@ -570,7 +570,7 @@ module ZMQ {
       this.initDone();
       if this.socket == nil {
         var errmsg = zmq_strerror(errno):string;
-        halt("Error in SocketClass(): %s\n", errmsg);
+        halt("Error in SocketClass.init(): %s\n", errmsg);
       }
     }
 
@@ -579,7 +579,7 @@ module ZMQ {
         var ret = zmq_close(socket):int;
         if ret == -1 {
           var errmsg = zmq_strerror(errno):string;
-          halt("Error in ~SocketClass(): %s\n", errmsg);
+          halt("Error in SocketClass.deinit(): %s\n", errmsg);
         }
         socket = c_nil;
       }


### PR DESCRIPTION
A quick sanity check to see whether we still had destructors in
the modules turned up only two instances as well as some error
messages that were still written from the constructor/destructor
perspective.  Removing these primarily as housecleaning.