### PR TITLE
Resolve new 1

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5762,6 +5762,18 @@ static void resolveNewAT(CallExpr* call) {
   } else {
     resolveNewHandleGenericInitializer(call);
   }
+
+  if (at->isClass()            == true &&
+      at->hasPostInitializer() == true) {
+    CallExpr* moveStmt = toCallExpr(call->parentExpr);
+    SymExpr*  moveLHS  = toSymExpr(moveStmt->get(1));
+    Symbol*   moveDest = moveLHS->symbol();
+
+    INT_ASSERT(moveStmt                         != NULL);
+    INT_ASSERT(moveStmt->isPrimitive(PRIM_MOVE) == true);
+
+    moveStmt->insertAfter(new CallExpr("postInit", gMethodToken, moveDest));
+  }
 }
 
 static bool resolveNewHasInitializer(AggregateType* at) {

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5719,12 +5719,12 @@ static void     fixupArgDefaultWhenRecordInit(AggregateType* at,
                                               CallExpr*      call,
                                               VarSymbol*     newTmp);
 
-static SymExpr* resolveNewTypeExpr(CallExpr* call);
+static SymExpr* resolveNewFindTypeExpr(CallExpr* call);
 
 static void     resolveNewHalt(CallExpr* call);
 
 static void resolveNew(CallExpr* call) {
-  if (SymExpr* typeExpr = resolveNewTypeExpr(call)) {
+  if (SymExpr* typeExpr = resolveNewFindTypeExpr(call)) {
     if (Type* type = resolveTypeAlias(typeExpr)) {
       if (AggregateType* at = toAggregateType(type)) {
         if (resolveNewHasInitializer(at) == false) {
@@ -5796,7 +5796,7 @@ static bool resolveNewHasInitializer(AggregateType* at) {
 static void resolveNewHandleConstructor(CallExpr* call) {
   SET_LINENO(call);
 
-  SymExpr*       typeExpr = resolveNewTypeExpr(call);
+  SymExpr*       typeExpr = resolveNewFindTypeExpr(call);
   AggregateType* at       = toAggregateType(resolveTypeAlias(typeExpr));
 
   if (FnSymbol* atInit = at->defaultInitializer) {
@@ -6083,7 +6083,7 @@ static void fixupArgDefaultWhenRecordInit(AggregateType* at,
 }
 
 // Find the SymExpr that captures the type
-static SymExpr* resolveNewTypeExpr(CallExpr* call) {
+static SymExpr* resolveNewFindTypeExpr(CallExpr* call) {
   Expr*    arg1   = call->get(1);
   SymExpr* retval = NULL;
 

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5709,9 +5709,9 @@ static void     resolveNewHandleNonGenericInitializer(CallExpr*      call,
                                                       AggregateType* at,
                                                       SymExpr*       typeExpr);
 
-static void resolveNewHandleInstantiatedGenericInit(CallExpr*      call,
-                                                    AggregateType* at,
-                                                    SymExpr*       typeExpr);
+static void     resolveNewHandleInstantiatedInit(CallExpr*      call,
+                                                 AggregateType* at,
+                                                 SymExpr*       typeExpr);
 
 static void     resolveNewHandleGenericInitializer(CallExpr*      call,
                                                    AggregateType* at,
@@ -5763,7 +5763,7 @@ static void resolveNewAT(CallExpr* call) {
     resolveNewHandleNonGenericInitializer(call, at, typeExpr);
 
   } else if (at->instantiatedFrom              != NULL) {
-    resolveNewHandleInstantiatedGenericInit(call, at, typeExpr);
+    resolveNewHandleInstantiatedInit(call, at, typeExpr);
 
   } else {
     resolveNewHandleGenericInitializer(call, at, typeExpr);
@@ -5911,14 +5911,15 @@ static void resolveNewHandleNonGenericInitializer(CallExpr*      call,
 // provided an instantiation instead of the generic version.  We should
 // ensure that we can resolve the call as if it were generic, and then
 // double check that the type we were given matches the provided type.
-static void resolveNewHandleInstantiatedGenericInit(CallExpr*      call,
-                                                    AggregateType* at,
-                                                    SymExpr*       typeExpr) {
+static void resolveNewHandleInstantiatedInit(CallExpr*      call,
+                                             AggregateType* at,
+                                             SymExpr*       typeExpr) {
   SET_LINENO(call);
 
   AggregateType* genericSrc = at->instantiatedFrom;
+
+  // Go back until we are at the base generic type.
   while (genericSrc->instantiatedFrom != NULL) {
-    // Go back until we are at the base generic type.
     genericSrc = genericSrc->instantiatedFrom;
   }
 


### PR DESCRIPTION
Minor updates to resolveNew() et al.

This PR integrates the first batch of a handful of superficial
changes to the functions that support the resolution of PRIM_NEW.
These were developed while working the resolution bug that was
exposed by working on the module code for BaseDist et al.

Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux.
Limited testing for each configuration.  Passed a full paratest with -futures.


