### PR TITLE
Fix LLVM version test

### DIFF
--- a/compiler/util/clangUtil.cpp
+++ b/compiler/util/clangUtil.cpp
@@ -1439,7 +1439,7 @@ void prepareCodegenLLVM()
     FM.setNoInfs();
     FM.setNoSignedZeros();
     FM.setAllowReciprocal();
-#if HAVE_LLVM_VER < 6
+#if HAVE_LLVM_VER < 60
     FM.setUnsafeAlgebra();
 #else
     FM.setAllowContract(true);


### PR DESCRIPTION
Fix a truncated LLVM version test in #8696 .  A character got truncated in between testing and checking in.