### PR TITLE
Add skipif for time-write performance test with launcher

### DIFF
--- a/test/io/vass/time-write.skipif
+++ b/test/io/vass/time-write.skipif
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+
+import os
+
+print(os.getenv('CHPL_TEST_PERF') == 'on' and
+      os.getenv('CHPL_LAUNCHER') != 'none')

--- a/test/io/vass/time-write.skipif
+++ b/test/io/vass/time-write.skipif
@@ -2,5 +2,7 @@
 
 import os
 
+# test is long running, but no need to validate it outside of normal
+# perf testing.
 print(os.getenv('CHPL_TEST_PERF') == 'on' and
       os.getenv('CHPL_LAUNCHER') != 'none')

--- a/test/io/vass/time-write.skipif
+++ b/test/io/vass/time-write.skipif
@@ -2,7 +2,10 @@
 
 import os
 
-# test is long running, but no need to validate it outside of normal
-# perf testing.
+"""
+This test measures performance writes, where we only care about on-node
+performance, so we skip performance testing when launching onto another
+node
+"""
 print(os.getenv('CHPL_TEST_PERF') == 'on' and
       os.getenv('CHPL_LAUNCHER') != 'none')


### PR DESCRIPTION
This test was on the verge of timing out before, but with some machine updates
starting doing so.  We could adjust the problem size for this new behavior, but
I'm not too worried about the difference between launcher writelns and local
ones so at Elliot's suggestion skip the performance test version when the
launcher is on

Validated a fresh checkout that this doesn't prevent a correctness run or
an ordinary perf run for the test, and does prevent a perf run with a launcher
(but not a correctness launcher run)