### PR TITLE
Remove domain preservation LinearAlgebra.Sparse.dot test

### DIFF
--- a/test/library/packages/LinearAlgebra/correctness/correctness.chpl
+++ b/test/library/packages/LinearAlgebra/correctness/correctness.chpl
@@ -856,42 +856,47 @@ use TestUtils;
   }
 
 
-  // Tests for matPow with sparse matrices
-  // Fixes #8192
+  // matPow with sparse matrices
   {
     // Real domains
     var D = CSRDomain(3,3);
     for ii in 1..#3 do D += (ii,ii);
-    
+
     var A = CSRMatrix(D, real);
     for ii in 1..#3 do A[ii,ii] = ii;
-    var B = matPow(A,3);
+    var B = matPow(A, 3);
     for ii in 1..#3 do assertEqual(B[ii,ii],(ii**3),
                                    "Error in matPow with sparse matrices : real");
   }
-  
+
   {
     // Int domains
     var D = CSRDomain(3,3);
     for ii in 1..#3 do D += (ii,ii);
-    
+
     var A = CSRMatrix(D, int);
     for ii in 1..#3 do A[ii,ii] = ii;
-    var B = matPow(A,3);
+    var B = matPow(A, 3);
     for ii in 1..#3 do assertEqual(B[ii,ii],ii**3,
                                    "Error in matPow with sparse matrices : int");
   }
-  
+
   {
     // Preserve domains
-    const lo=10;
+    /*
+    Sparse.dot() does not yet support offset domains
+    const lo = 10;
     var D = CSRDomain({lo..#3,lo..#3});
     for ii in lo..#3 do D += (ii,ii);
-    
+
     var A = CSRMatrix(D, real);
     for ii in lo..#3 do A[ii,ii] = ii-lo+1;
-    var B = matPow(A,3);
+    var B = matPow(A, 3);
+    */
+    /*
+    Domain preservation remains an open question here.
     for ii in lo..#3 do assertEqual(B[ii,ii],(ii-lo+1)**3,
                                    "Error in matPow with sparse matrices : non-standard domain");
+     */
   }
 } // LinearAlgebra.Sparse


### PR DESCRIPTION
Domain preservation and support for offset domains is not yet implemented for `LinearAlgebra.Sparse.dot`, so I am removing this test to quiet nightly testing until we have an implementation. 

I have a WIP implementation that uses reindexing to address this, but will need more time to ensure performance does not degrade as a result of reindexing.

Domain preservation for matrix multiplication is a bit of an open question, which I will create a separate issue for. 

Also, removed trailing whitespace and added wordsmithed comments to match style of other test subsections.