### PR TITLE
Improved support for postInit

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -2021,6 +2021,10 @@ bool AggregateType::needsConstructor() {
   if (symbol->hasFlag(FLAG_USE_DEFAULT_INIT))
     return false;
 
+  if (hasPostInitializer() == true) {
+    return false;
+  }
+
   ModuleSymbol* mod = getModule();
 
   // For now, always generate a default constructor for types in the internal

--- a/compiler/include/initializerRules.h
+++ b/compiler/include/initializerRules.h
@@ -35,6 +35,7 @@ void      errorOnFieldsInArgList(FnSymbol* fn);
 
 void      preNormalizeFields(AggregateType* at);
 void      preNormalizeInitMethod(FnSymbol* fn);
+void      preNormalizePostInit(AggregateType* at);
 FnSymbol* buildClassAllocator(FnSymbol* initMethod);
 
 #endif

--- a/compiler/passes/initializerRules.cpp
+++ b/compiler/passes/initializerRules.cpp
@@ -1372,6 +1372,9 @@ void preNormalizePostInit(AggregateType* at) {
   int errors = 0;
   for_vector(AggregateType, cur, chain) {
     if (postInitCache.find(cur) == postInitCache.end()) {
+      if (cur->hasInitializers() == false) {
+        cur->symbol->addFlag(FLAG_USE_DEFAULT_INIT);
+      }
       // Don't insert a super.init for the highest ancestor
       bool insertSuper = cur != chain.front();
       errors += insertPostInit(cur, insertSuper);

--- a/compiler/passes/initializerRules.cpp
+++ b/compiler/passes/initializerRules.cpp
@@ -1326,7 +1326,9 @@ static int insertPostInit(AggregateType* at, bool insertSuper) {
 
   forv_Vec(FnSymbol, method, at->methods) {
     if (method->isPostInitializer()) {
-      found = true;
+      if (method->where == NULL) {
+        found = true;
+      }
       if (method->formals.length > 2) {
         // Only accept method token and 'this'
         ret += 1;

--- a/compiler/passes/initializerRules.cpp
+++ b/compiler/passes/initializerRules.cpp
@@ -1167,3 +1167,212 @@ static bool isSymbolThis(Expr* expr) {
 
   return retval;
 }
+
+//
+// Builds the list of AggregateTypes in the hierarchy of `at` that have or
+// require a postInit.
+//
+// Let's say we have a series of classes named from A through Z, where Z
+// inherits from Y and so on. If class Q has a postInit, this function will
+// add AggregateTypes to 'chain' from Q through Z with 'Q' at the head.
+//
+static bool buildPostInitChain(AggregateType* at,
+                              std::vector<AggregateType*>& chain) {
+  bool ret = false;
+
+  // Works around odd case with _ddata
+  AggregateType* parent = NULL;
+  if (at->isClass() == true && at->dispatchParents.size() > 0) {
+    parent = at->dispatchParents.v[0];
+  }
+
+  if (at == dtObject) {
+    ret = false;
+  } else if (at->isRecord()) {
+    if (at->hasPostInitializer()) {
+      chain.push_back(at);
+      ret = true;
+    }
+  } else if (parent != NULL && buildPostInitChain(parent, chain) == true) {
+    ret = true;
+    chain.push_back(at);
+  } else if (at->hasPostInitializer()) {
+    ret = true;
+    chain.push_back(at);
+  }
+
+  return ret;
+}
+
+static bool isSuperPostInit(CallExpr* stmt) {
+  bool retval = false;
+
+  if (CallExpr* call = toCallExpr(stmt->baseExpr)) {
+    if (call->numActuals()                        ==    2 &&
+        call->isNamedAstr(astrSdot)               == true &&
+        isStringLiteral(call->get(2), "postInit") == true) {
+      if (CallExpr* subExpr = toCallExpr(call->get(1))) {
+        if (subExpr->numActuals()                     == 2    &&
+            subExpr->isNamedAstr(astrSdot)            == true &&
+            isSymbolThis(subExpr->get(1))             == true &&
+            isStringLiteral(subExpr->get(2), "super") == true) {
+          retval = true;
+        }
+      }
+    }
+  }
+
+  return retval;
+}
+
+static bool hasSuperPostInit(BlockStmt* block) {
+  Expr* stmt   = block->body.head;
+  bool  retval = false;
+
+  while (stmt != NULL && retval == false) {
+    if (CallExpr* callExpr = toCallExpr(stmt)) {
+      retval = isSuperPostInit(callExpr);
+
+    } else if (CondStmt* cond = toCondStmt(stmt)) {
+      if (cond->elseStmt == NULL) {
+        retval = hasSuperPostInit(cond->thenStmt);
+
+      } else {
+        retval = hasSuperPostInit(cond->thenStmt) ||
+                 hasSuperPostInit(cond->elseStmt);
+      }
+
+    } else if (BlockStmt* block = toBlockStmt(stmt)) {
+      retval = hasSuperPostInit(block);
+
+    } else if (ForallStmt* block = toForallStmt(stmt)) {
+      retval = hasSuperPostInit(block->loopBody());
+    }
+
+    stmt = stmt->next;
+  }
+
+  return retval;
+}
+
+//
+// Inserts a call to super.postInit if none exists anywhere in 'fn'
+//
+// TODO: what should we do with super.postInits in conditionals?
+// TODO: merge with addSuperInit
+//
+static void insertSuperPostInit(FnSymbol* fn) {
+  if (hasSuperPostInit(fn->body) == false) {
+    SET_LINENO(fn);
+    BlockStmt* body     = fn->body;
+
+    VarSymbol* tmp      = newTemp("super_tmp");
+
+    Symbol*    _this    = fn->_this;
+    Symbol*    superSym = new_CStringSymbol("super");
+    CallExpr*  superGet = new CallExpr(PRIM_GET_MEMBER_VALUE, _this, superSym);
+
+    tmp->addFlag(FLAG_SUPER_TEMP);
+
+    // Adding at head therefore add in reverse order
+    body->insertAtHead(new CallExpr("postInit", gMethodToken, tmp));
+    body->insertAtHead(new CallExpr(PRIM_MOVE,  tmp,          superGet));
+    body->insertAtHead(new DefExpr(tmp));
+  }
+}
+
+//
+// Creates a method named "postInit" on 'at'. A call to "super.postInit" is
+// added if 'at' is a class.
+//
+static void buildPostInit(AggregateType* at) {
+  SET_LINENO(at);
+  FnSymbol* fn     = new FnSymbol("postInit");
+  ArgSymbol* _mt   = new ArgSymbol(INTENT_BLANK, "_mt", dtMethodToken);
+  ArgSymbol* _this = new ArgSymbol(INTENT_BLANK, "this", at);
+
+  fn->cname = fn->name;
+  fn->_this = _this;
+
+  _this->addFlag(FLAG_ARG_THIS);
+
+  fn->insertFormalAtTail(_mt);
+  fn->insertFormalAtTail(_this);
+
+  DefExpr* def = new DefExpr(fn);
+
+  at->symbol->defPoint->insertBefore(def);
+
+  fn->setMethod(true);
+  fn->addFlag(FLAG_METHOD_PRIMARY);
+
+  if (at->isClass()) {
+    insertSuperPostInit(fn);
+  }
+
+  at->methods.add(fn);
+}
+
+//
+// Inserts a zero-arg where-less postInit for `at` unless one already exists.
+// Also inserts a super.postInit for any postInit if omitted.
+//
+// Returns number of errors found.
+//
+static int insertPostInit(AggregateType* at, bool insertSuper) {
+  int ret = 0;
+
+  bool found = false;
+
+  forv_Vec(FnSymbol, method, at->methods) {
+    if (method->isPostInitializer()) {
+      found = true;
+      if (at->isClass() == true && insertSuper == true) {
+        insertSuperPostInit(method);
+      }
+    }
+  }
+
+  if (found == false) {
+    buildPostInit(at);
+  }
+
+  return ret;
+}
+
+static std::set<AggregateType*> postInitCache;
+
+//
+// Inserts postInit methods and calls to super.postInit as needed.
+//
+// If an ancestor of 'at' has a postInit, then every aggregate between 'at' and
+// that ancestor must have a postInit as well.
+//
+// If postInits on a type have a where clause, insert a where-less postInit
+// so the ancestors will always be called.
+//
+void preNormalizePostInit(AggregateType* at) {
+  // Cache results to avoid extra work and to avoid looking for various forms
+  // of super.postInit.
+  if (postInitCache.find(at) != postInitCache.end()) {
+    return;
+  }
+
+  // First element of 'chain' is the highest ancestor
+  std::vector<AggregateType*> chain;
+  buildPostInitChain(at, chain);
+
+  int errors = 0;
+  for_vector(AggregateType, cur, chain) {
+    if (postInitCache.find(cur) == postInitCache.end()) {
+      // Don't insert a super.init for the highest ancestor
+      bool insertSuper = cur != chain.front();
+      errors += insertPostInit(cur, insertSuper);
+      postInitCache.insert(cur);
+    }
+  }
+
+  if (errors > 0) {
+    USR_STOP();
+  }
+}

--- a/compiler/passes/initializerRules.cpp
+++ b/compiler/passes/initializerRules.cpp
@@ -1327,6 +1327,11 @@ static int insertPostInit(AggregateType* at, bool insertSuper) {
   forv_Vec(FnSymbol, method, at->methods) {
     if (method->isPostInitializer()) {
       found = true;
+      if (method->formals.length > 2) {
+        // Only accept method token and 'this'
+        ret += 1;
+        USR_FATAL_CONT(method, "postInit must have zero arguments");
+      }
       if (at->isClass() == true && insertSuper == true) {
         insertSuperPostInit(method);
       }

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -136,6 +136,7 @@ void normalize() {
         isRecordWithInitializers(at) == true) {
       preNormalizeFields(at);
     }
+    preNormalizePostInit(at);
   }
 
   forv_Vec(FnSymbol, fn, gFnSymbols) {

--- a/test/classes/initializers/postInit/args.chpl
+++ b/test/classes/initializers/postInit/args.chpl
@@ -1,0 +1,8 @@
+
+record R {
+  proc postInit(x:int) {
+    writeln("R.postInit");
+  }
+}
+
+var r = new R();

--- a/test/classes/initializers/postInit/args.good
+++ b/test/classes/initializers/postInit/args.good
@@ -1,0 +1,1 @@
+args.chpl:3: error: postInit must have zero arguments

--- a/test/classes/initializers/postInit/callPostInit.chpl
+++ b/test/classes/initializers/postInit/callPostInit.chpl
@@ -1,0 +1,16 @@
+
+class C {
+  var c : int;
+
+  proc init() {
+    writeln("C.init");
+  }
+
+  proc postInit() {
+    writeln("C.postInit");
+  }
+}
+
+var c = new C();
+c.postInit();
+delete c;

--- a/test/classes/initializers/postInit/callPostInit.good
+++ b/test/classes/initializers/postInit/callPostInit.good
@@ -1,0 +1,3 @@
+C.init
+C.postInit
+C.postInit

--- a/test/classes/initializers/postInit/conditional.chpl
+++ b/test/classes/initializers/postInit/conditional.chpl
@@ -1,6 +1,4 @@
 
-config const flag = true;
-
 class A {
   var a : int;
   proc init() {
@@ -28,5 +26,10 @@ class B : A {
   }
 }
 
-var b = new B(flag);
-delete b;
+var t = new B(true);
+delete t;
+
+writeln();
+
+var f = new B(false);
+delete f;

--- a/test/classes/initializers/postInit/conditional.chpl
+++ b/test/classes/initializers/postInit/conditional.chpl
@@ -1,0 +1,32 @@
+
+config const flag = true;
+
+class A {
+  var a : int;
+  proc init() {
+    writeln("A.init");
+  }
+  proc postInit() {
+    writeln("A.postInit");
+  }
+}
+
+class B : A {
+  var b : bool;
+  proc init(b:bool) {
+    writeln("B.init");
+    this.b = b;
+  }
+  proc postInit() {
+    if b {
+      writeln("B.postInit");
+      super.postInit();
+    } else {
+      super.postInit();
+      writeln("B.postInit");
+    }
+  }
+}
+
+var b = new B(flag);
+delete b;

--- a/test/classes/initializers/postInit/conditional.good
+++ b/test/classes/initializers/postInit/conditional.good
@@ -2,3 +2,8 @@ A.init
 B.init
 B.postInit
 A.postInit
+
+A.init
+B.init
+A.postInit
+B.postInit

--- a/test/classes/initializers/postInit/conditional.good
+++ b/test/classes/initializers/postInit/conditional.good
@@ -1,0 +1,4 @@
+A.init
+B.init
+B.postInit
+A.postInit

--- a/test/classes/initializers/postInit/dispatch.chpl
+++ b/test/classes/initializers/postInit/dispatch.chpl
@@ -1,0 +1,52 @@
+class C {
+  proc foo() {
+    writeln("In C.foo()");
+  }
+
+  proc bar() {
+    writeln("In C.bar()");
+  }
+
+  proc postInit() {
+    foo();
+    bar();
+    //    baz();  // not possible since C doesn't define it
+  }
+}
+
+class D : C {
+  proc foo() {
+    writeln("In D.foo()");
+  }
+
+  proc baz() {
+    writeln("In D.baz()");
+  }
+}
+
+class E : C {
+  proc foo() {
+    writeln("In E.foo()");
+  }
+
+  proc baz() {
+    writeln("In E.baz()");
+  }
+
+  proc postInit() {
+    foo();
+    bar();
+    baz();
+  }
+}
+
+writeln("C:");
+var myC = new C();
+writeln("D:");
+var myD = new D();
+writeln("E:");
+var myE = new E();
+
+delete myE;
+delete myD;
+delete myC;

--- a/test/classes/initializers/postInit/dispatch.good
+++ b/test/classes/initializers/postInit/dispatch.good
@@ -1,0 +1,12 @@
+C:
+In C.foo()
+In C.bar()
+D:
+In D.foo()
+In C.bar()
+E:
+In E.foo()
+In C.bar()
+In E.foo()
+In C.bar()
+In E.baz()

--- a/test/classes/initializers/postInit/inherits.chpl
+++ b/test/classes/initializers/postInit/inherits.chpl
@@ -1,0 +1,39 @@
+
+class A {
+  var a : int;
+
+  proc init() {
+    writeln("A.init");
+  }
+
+  proc postInit() {
+    writeln("A.postInit");
+  }
+}
+
+class B : A {
+  var b : int;
+
+  proc init() {
+    writeln("B.init");
+  }
+
+  proc postInit() {
+    writeln("B.postInit");
+  }
+}
+
+class C : B {
+  var c : int;
+
+  proc init() {
+    writeln("C.init");
+  }
+
+  proc postInit() {
+    writeln("C.postInit");
+  }
+}
+
+var c = new C();
+delete c;

--- a/test/classes/initializers/postInit/inherits.good
+++ b/test/classes/initializers/postInit/inherits.good
@@ -1,0 +1,6 @@
+A.init
+B.init
+C.init
+A.postInit
+B.postInit
+C.postInit

--- a/test/classes/initializers/postInit/justPostInit.chpl
+++ b/test/classes/initializers/postInit/justPostInit.chpl
@@ -1,0 +1,17 @@
+
+use Reflection;
+
+class C {
+  var x = 10;
+  var A : [1..4] int = 5;
+  var s = "hello world";
+
+  proc postInit() {
+    writeln("C.postInit");
+  }
+}
+
+var c = new C();
+writeln("has initializer: ", canResolveMethod(c, "init"));
+writeln("c = ", c);
+delete c;

--- a/test/classes/initializers/postInit/justPostInit.good
+++ b/test/classes/initializers/postInit/justPostInit.good
@@ -1,0 +1,3 @@
+C.postInit
+has initializer: true
+c = {x = 10, A = 5 5 5 5, s = hello world}

--- a/test/classes/initializers/postInit/manual.chpl
+++ b/test/classes/initializers/postInit/manual.chpl
@@ -1,0 +1,27 @@
+
+class A { 
+  var a : int;
+
+  proc init() {
+    writeln("A.init");
+  }
+  proc postInit() {
+    writeln("A.postInit");
+  }
+}
+
+class B : A {
+  var b : int;
+
+  proc init() {
+    writeln("B.init");
+  }
+  proc postInit() {
+    writeln("Start of B.postInit");
+    super.postInit();
+    writeln("End of B.postInit");
+  }
+}
+
+var b = new B();
+delete b;

--- a/test/classes/initializers/postInit/manual.good
+++ b/test/classes/initializers/postInit/manual.good
@@ -1,0 +1,5 @@
+A.init
+B.init
+Start of B.postInit
+A.postInit
+End of B.postInit

--- a/test/classes/initializers/postInit/missing.chpl
+++ b/test/classes/initializers/postInit/missing.chpl
@@ -1,0 +1,89 @@
+
+// Parent does not have postInit, but child does
+
+class Y {
+  var y : int;
+
+  proc init() {
+    writeln("Y.init");
+  }
+}
+
+class Z : Y {
+  var z : int;
+
+  proc init() {
+    writeln("Z.init");
+  }
+
+  proc postInit() {
+    writeln("Z.postInit");
+  }
+}
+
+var z = new Z();
+delete z;
+writeln();
+
+// Parent does not have postInit, but child and grandparent do
+
+class A {
+  var a : int;
+
+  proc init() {
+    writeln("A.init");
+  }
+
+  proc postInit() {
+    writeln("A.postInit");
+  }
+}
+
+class B : A {
+  var b : int;
+
+  proc init() {
+    writeln("B.init");
+  }
+}
+
+class C : B {
+  var c : int;
+
+  proc init() {
+    writeln("C.init");
+  }
+
+  proc postInit() {
+    writeln("C.postInit");
+  }
+}
+
+var c = new C();
+delete c;
+writeln();
+
+// Parent has postInit, but child does not
+
+class Parent {
+  var p : int;
+
+  proc init() {
+    writeln("Parent.init");
+  }
+
+  proc postInit() {
+    writeln("Parent.postInit");
+  }
+}
+
+class Child : Parent {
+  var c : int;
+
+  proc init() {
+    writeln("Child.init");
+  }
+}
+
+var child = new Child();
+delete child;

--- a/test/classes/initializers/postInit/missing.good
+++ b/test/classes/initializers/postInit/missing.good
@@ -1,0 +1,13 @@
+Y.init
+Z.init
+Z.postInit
+
+A.init
+B.init
+C.init
+A.postInit
+C.postInit
+
+Parent.init
+Child.init
+Parent.postInit

--- a/test/classes/initializers/postInit/simple.chpl
+++ b/test/classes/initializers/postInit/simple.chpl
@@ -1,0 +1,35 @@
+
+class C {
+  var x : int;
+  var y : real;
+
+  proc init() {
+    writeln("C.init");
+    this.x = 5;
+    this.y = 1.0;
+  }
+
+  proc postInit() {
+    writeln("C.postInit");
+    y *= x;
+  }
+}
+
+var c = new C();
+writeln("c = ", c);
+writeln();
+delete c;
+
+record R {
+  var x : int;
+
+  proc init() {
+    writeln("R.init");
+  }
+
+  proc postInit() {
+    writeln("R.postInit");
+  }
+}
+
+var r = new R();

--- a/test/classes/initializers/postInit/simple.good
+++ b/test/classes/initializers/postInit/simple.good
@@ -1,0 +1,6 @@
+C.init
+C.postInit
+c = {x = 5, y = 5.0}
+
+R.init
+R.postInit

--- a/test/classes/initializers/postInit/where.chpl
+++ b/test/classes/initializers/postInit/where.chpl
@@ -1,0 +1,44 @@
+
+class Grandparent {
+  var g : int;
+
+  proc init() {
+    writeln("Grandparent.init");
+  }
+  proc postInit() {
+    writeln("Grandparent.postInit");
+  }
+}
+
+class Parent : Grandparent {
+  type eltType;
+  var x : eltType;
+
+  proc init(type t) {
+    this.eltType = t;
+    writeln("Parent.init");
+  }
+
+  proc postInit() where eltType == int {
+    writeln("Special Parent.postInit");
+  }
+}
+
+class Child : Parent {
+  var y : 2*eltType;
+
+  proc init(type t) {
+    super.init(t);
+    writeln("Child.init");
+  }
+  proc postInit() {
+    writeln("Child(",eltType:string,").postInit");
+  }
+}
+
+var c = new Child(real);
+delete c;
+writeln();
+
+var i = new Child(int);
+delete i;

--- a/test/classes/initializers/postInit/where.good
+++ b/test/classes/initializers/postInit/where.good
@@ -1,0 +1,12 @@
+Grandparent.init
+Parent.init
+Child.init
+Grandparent.postInit
+Child(real(64)).postInit
+
+Grandparent.init
+Parent.init
+Child.init
+Grandparent.postInit
+Special Parent.postInit
+Child(int(64)).postInit


### PR DESCRIPTION
This PR improves support for postInit and enables the following:
- Compiler insertion of super.postInit
- handling absence of postInit between child and ancestor with postInit
- postInit implies default init
- postInit with where clause
- error for postInit with arguments

At the start of normalization we will look at each type and determine if a postInit needs to be inserted. If a type inherits from a type that implements a postInit, then the inheriting type must also have a postInit. If a postInit does not exist, one will be created.

A special case is if all postInits on a type have a where clause. In this case we need to generate a where-less postInit so that ancestor postInits will still be invoked.

Open questions:
- Should we do anything special for ``super.postInit`` calls in conditionals?
- Should users be allowed to call postInit manually?

Testing:
- [x] full local + futures
- [x] full gasnet
- [x] partial baseline