### PR TITLE
Fix least common denominator CPU type for ARM-based Cray systems

### DIFF
--- a/util/chplenv/chpl_arch.py
+++ b/util/chplenv/chpl_arch.py
@@ -255,7 +255,10 @@ class InvalidLocationError(ValueError):
 # what we have in the module build script.
 def get_module_lcd_arch(platform_val, arch):
     if platform_val == "cray-xc":
-        return "sandybridge"
+        if arch.startswith("arm-"):
+            return "arm-thunderx2"
+        else:
+            return "sandybridge"
     elif platform_val == "cray-xe" or platform_val == "cray-xk":
         return "barcelona"
     elif platform_val == "aarch64":


### PR DESCRIPTION
For a Cray XC system, we were always setting the least common denominator CPU architecture to "sandybridge".  That is no longer always right, because of ARM systems.  This change sets the LCD to arm-thunderx2, which is currently the only ARM processor on Cray products.

This allows the ARM module to build without references to x86-64 architectures.