### PR TITLE
Add support for if/else branches ending with different field inits 

### DIFF
--- a/compiler/passes/initializerRules.cpp
+++ b/compiler/passes/initializerRules.cpp
@@ -641,6 +641,7 @@ static InitNormalize preNormalize(AggregateType* at,
 
           } else if (stateThen.currField() != stateElse.currField()) {
             unifyConditionalBranchLastField(at, cond, &stateThen, &stateElse);
+            stateThen.merge(stateElse);
             state.merge(stateThen);
 
           } else {

--- a/test/classes/initializers/cond-only-else-2.chpl
+++ b/test/classes/initializers/cond-only-else-2.chpl
@@ -1,4 +1,4 @@
-// Confirm that the compiler rejects a conditional with inconsistent
+// Confirm that the compiler allows a conditional with different
 // use of field initializers
 
 record MyRec {
@@ -9,7 +9,7 @@ record MyRec {
     if a < 10 then
       x = 20;
     else
-      writeln('Else does not initialize x');
+      writeln('Else does not explicitly initialize x');
 
     this.initDone();
   }

--- a/test/classes/initializers/cond-only-else-2.good
+++ b/test/classes/initializers/cond-only-else-2.good
@@ -1,2 +1,3 @@
-cond-only-else-2.chpl:8: In initializer:
-cond-only-else-2.chpl:9: error: Both arms of a conditional must initialize the same fields in phase 1
+Else does not explicitly initialize x
+r1: (x = 20, y = 20)
+r2: (x = 10, y = 20)

--- a/test/classes/initializers/cond-only-then-3.chpl
+++ b/test/classes/initializers/cond-only-then-3.chpl
@@ -1,4 +1,4 @@
-// Confirm that the compiler rejects a conditional with inconsistent
+// Confirm that the compiler allows a conditional with different
 // use of field initializers
 
 record MyRec {
@@ -9,7 +9,7 @@ record MyRec {
     if a < 10 then
       x = 20;
     else
-      writeln('Else does not initialize x');
+      writeln('Else does not explicitly initialize x');
 
     this.initDone();
   }

--- a/test/classes/initializers/cond-only-then-3.good
+++ b/test/classes/initializers/cond-only-then-3.good
@@ -1,2 +1,3 @@
-cond-only-then-3.chpl:8: In initializer:
-cond-only-then-3.chpl:9: error: Both arms of a conditional must initialize the same fields in phase 1
+Else does not explicitly initialize x
+r1: (x = 20, y = 20)
+r2: (x = 10, y = 20)

--- a/test/classes/initializers/phase1/hasIfDiffEndField-notLast.chpl
+++ b/test/classes/initializers/phase1/hasIfDiffEndField-notLast.chpl
@@ -1,0 +1,20 @@
+class Foo {
+  var x: int;
+  var y: bool;
+  var z: int;
+
+  proc init(xVal) {
+    if (xVal < 5) {
+      x = xVal;
+    } else {
+      x = xVal;
+      y = true;
+    }
+  }
+}
+
+var x = new Foo(4);
+var y = new Foo(6);
+writeln(x);
+writeln(y);
+delete x, y;

--- a/test/classes/initializers/phase1/hasIfDiffEndField-notLast.good
+++ b/test/classes/initializers/phase1/hasIfDiffEndField-notLast.good
@@ -1,0 +1,2 @@
+{x = 4, y = false, z = 0}
+{x = 6, y = true, z = 0}

--- a/test/classes/initializers/phase1/hasIfDiffEndField.chpl
+++ b/test/classes/initializers/phase1/hasIfDiffEndField.chpl
@@ -1,0 +1,19 @@
+class Foo {
+  var x: int;
+  var y: bool;
+
+  proc init(xVal) {
+    if (xVal < 5) {
+      x = xVal;
+    } else {
+      x = xVal;
+      y = true;
+    }
+  }
+}
+
+var x = new Foo(4);
+var y = new Foo(6);
+writeln(x);
+writeln(y);
+delete x, y;

--- a/test/classes/initializers/phase1/hasIfDiffEndField.good
+++ b/test/classes/initializers/phase1/hasIfDiffEndField.good
@@ -1,0 +1,2 @@
+{x = 4, y = false}
+{x = 6, y = true}

--- a/test/classes/initializers/phase1/hasIfDiffEndField2-notLast.chpl
+++ b/test/classes/initializers/phase1/hasIfDiffEndField2-notLast.chpl
@@ -1,0 +1,20 @@
+class Foo {
+  var x: int;
+  var y: bool;
+  var z: int;
+
+  proc init(xVal) {
+    if (xVal < 5) {
+      x = xVal;
+      y = true;
+    } else {
+      x = xVal;
+    }
+  }
+}
+
+var x = new Foo(4);
+var y = new Foo(6);
+writeln(x);
+writeln(y);
+delete x, y;

--- a/test/classes/initializers/phase1/hasIfDiffEndField2-notLast.good
+++ b/test/classes/initializers/phase1/hasIfDiffEndField2-notLast.good
@@ -1,0 +1,2 @@
+{x = 4, y = true, z = 0}
+{x = 6, y = false, z = 0}

--- a/test/classes/initializers/phase1/hasIfDiffEndField2.chpl
+++ b/test/classes/initializers/phase1/hasIfDiffEndField2.chpl
@@ -1,0 +1,19 @@
+class Foo {
+  var x: int;
+  var y: bool;
+
+  proc init(xVal) {
+    if (xVal < 5) {
+      x = xVal;
+      y = true;
+    } else {
+      x = xVal;
+    }
+  }
+}
+
+var x = new Foo(4);
+var y = new Foo(6);
+writeln(x);
+writeln(y);
+delete x, y;

--- a/test/classes/initializers/phase1/hasIfDiffEndField2.good
+++ b/test/classes/initializers/phase1/hasIfDiffEndField2.good
@@ -1,0 +1,2 @@
+{x = 4, y = true}
+{x = 6, y = false}

--- a/test/classes/initializers/phase1/hasIfSameFieldDiffPrior.chpl
+++ b/test/classes/initializers/phase1/hasIfSameFieldDiffPrior.chpl
@@ -1,0 +1,19 @@
+class Foo {
+  var x: int;
+  var y: bool;
+
+  proc init(xVal) {
+    if (xVal < 5) {
+      y = true;
+    } else {
+      x = xVal;
+      y = false;
+    }
+  }
+}
+
+var x = new Foo(4);
+var y = new Foo(6);
+writeln(x);
+writeln(y);
+delete x, y;

--- a/test/classes/initializers/phase1/hasIfSameFieldDiffPrior.good
+++ b/test/classes/initializers/phase1/hasIfSameFieldDiffPrior.good
@@ -1,0 +1,2 @@
+{x = 0, y = true}
+{x = 6, y = false}


### PR DESCRIPTION
Prior to this change, the following code would generate an error message.
With this change, it will now compile and run, inserting omitted initialization.
```chapel
proc init(xVal) {
  if (xVal > 5) {
    x = xVal;
    y = true;
  } else {
    x = xVal;
  }
}
```

This assumes that the intention is for omitted initialization to handle the
remaining fields in the branch that did not initialize as many.

Determines which branch is further ahead, and inserts omitted initialization for
all the remaining fields of the branch that is further behind.

Adds five tests.  One covers when both branches end on the same explicit
initialization, the others cover when the branches end on different fields,
whether fields remain or not.

Updates a few tests for new expected behavior.

Testing over:
- [x] classes/initializers with futures
- [x] full std/ with futures