### PR TITLE
Consolidate helper functions

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -806,6 +806,16 @@ bool AggregateType::isInstantiatedFrom(const AggregateType* base) const {
   return retval;
 }
 
+AggregateType* AggregateType::getRootInstantiation() {
+  AggregateType* retval = this;
+
+  while (retval->instantiatedFrom != NULL) {
+    retval = retval->instantiatedFrom;
+  }
+
+  return retval;
+}
+
 int AggregateType::getFieldPosition(const char* name, bool fatal) {
   Vec<Type*> next, current;
   Vec<Type*>* next_p = &next, *current_p = &current;

--- a/compiler/include/AggregateType.h
+++ b/compiler/include/AggregateType.h
@@ -113,6 +113,8 @@ public:
   bool                        isInstantiatedFrom(const AggregateType* base)
                                                                          const;
 
+  AggregateType*              getRootInstantiation();
+
   DefExpr*                    toLocalField(const char* name)             const;
   DefExpr*                    toLocalField(SymExpr*    expr)             const;
   DefExpr*                    toLocalField(CallExpr*   expr)             const;


### PR DESCRIPTION
Simple consolidation of two helper functions

@benharsh noted that a new helper function for functionResolution.cpp in #8826 had a clone in
ResolutionCandidate.cpp.

This trivial PR introduces a single method on AggregateType and drops the two functions.

Compiled on the standard configurations, limited testing of each, and then a single-locale
paratest with futures.

Discussed with @benharsh 