### PR TITLE
Resolve new 4

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5857,11 +5857,7 @@ static void resolveNewHandleNonGenericInitializer(CallExpr* call) {
   }
 
   if (at->isClass() == true) {
-    // Convert the PRIM_NEW to a normal call
-    call->primitive = NULL;
-    call->baseExpr  = new UnresolvedSymExpr("_new");
-
-    parent_insert_help(call, call->baseExpr);
+    call->setUnresolvedFunction("_new");
 
     if (isBlockStmt(call->parentExpr) == true) {
       call->insertBefore(def);
@@ -5871,11 +5867,7 @@ static void resolveNewHandleNonGenericInitializer(CallExpr* call) {
     }
 
   } else {
-    // Convert the PRIM_NEW to a normal call
-    call->primitive = NULL;
-    call->baseExpr  = new UnresolvedSymExpr("init");
-
-    parent_insert_help(call, call->baseExpr);
+    call->setUnresolvedFunction("init");
 
     if (isBlockStmt(call->parentExpr) == true) {
       call->insertBefore(def);
@@ -5918,13 +5910,9 @@ static void resolveNewHandleGenericInitializer(CallExpr* call) {
 
   newTmp->addFlag(FLAG_DELAY_GENERIC_EXPANSION);
 
-  typeExpr->replace(new UnresolvedSymExpr("init"));
+  call->setUnresolvedFunction("init");
 
-  // Convert the PRIM_NEW to a normal call
-  call->primitive = NULL;
-  call->baseExpr  = call->get(1)->remove();
-
-  parent_insert_help(call, call->baseExpr);
+  call->get(1)->remove();
 
   if (at->isClass() == true) {
     if (isBlockStmt(call->parentExpr) == true) {

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5926,23 +5926,31 @@ static void resolveNewHandleGenericInitializer(CallExpr* call) {
 
   parent_insert_help(call, call->baseExpr);
 
-  if (isBlockStmt(call->parentExpr) == true) {
-    call->insertBefore(def);
+  if (at->isClass() == true) {
+    if (isBlockStmt(call->parentExpr) == true) {
+      call->insertBefore(def);
 
-    if (at->isClass() == false) {
+    } else {
+      call->parentExpr->insertBefore(def);
+    }
+
+
+  } else {
+    if (isBlockStmt(call->parentExpr) == true) {
+      call->insertBefore(def);
+
       if (isArgSymbol(call->parentSymbol)          == true  &&
           toBlockStmt(call->parentExpr)->body.tail == call) {
         call->insertAfter(new SymExpr(newTmp));
       }
-    }
 
-  } else {
-    Expr* parent = call->parentExpr;
+    } else {
+      Expr* parent = call->parentExpr;
 
-    parent->insertBefore(def);
+      call->parentExpr->insertBefore(def);
 
-    if (at->isClass() == false) {
       call->replace(new SymExpr(newTmp));
+
       parent->insertBefore(call);
     }
   }

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5877,17 +5877,13 @@ static void resolveNewHandleNonGenericInitializer(CallExpr* call) {
 
     parent_insert_help(call, call->baseExpr);
 
-    if (at->isClass() == false) {
-      if (isBlockStmt(call->parentExpr) == true) {
-        if (isArgSymbol(call->parentSymbol)          == true  &&
-            toBlockStmt(call->parentExpr)->body.tail == call) {
-          call->insertAfter(new SymExpr(newTmp));
-        }
-      }
-    }
-
     if (isBlockStmt(call->parentExpr) == true) {
       call->insertBefore(def);
+
+      if (isArgSymbol(call->parentSymbol)          == true  &&
+          toBlockStmt(call->parentExpr)->body.tail == call) {
+        call->insertAfter(new SymExpr(newTmp));
+      }
 
     } else {
       Expr* parent = call->parentExpr;
@@ -5930,17 +5926,15 @@ static void resolveNewHandleGenericInitializer(CallExpr* call) {
 
   parent_insert_help(call, call->baseExpr);
 
-  if (at->isClass() == false) {
-    if (isBlockStmt(call->parentExpr) == true) {
+  if (isBlockStmt(call->parentExpr) == true) {
+    call->insertBefore(def);
+
+    if (at->isClass() == false) {
       if (isArgSymbol(call->parentSymbol)          == true  &&
           toBlockStmt(call->parentExpr)->body.tail == call) {
         call->insertAfter(new SymExpr(newTmp));
       }
     }
-  }
-
-  if (isBlockStmt(call->parentExpr) == true) {
-    call->insertBefore(def);
 
   } else {
     Expr* parent = call->parentExpr;


### PR DESCRIPTION
Begin to address issues with PRIM_NEW at top level of a block statement

A new expression (PRIM_NEW) can appear at the top level of a block stmt;

  1) the application may define a statement that is a new expression
  2) the new expression may be the default value for a procedure formal

This is not currently being handled correctly and can lead to internal errors.
This PR begins to simplify the handling for this situation.

Compiled in standard configurations.  Limited testing for each configuration.
Passed a single-locale paratest with -futures
