### PR TITLE
Add annotations for this week

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -623,6 +623,8 @@ jacobi:
     - refactoring of rectangular IO (#5157)
   08/02/17:
     - Remove handling of references from copyPropagation (#6779)
+  03/13/18:
+    - Enable phase one dynamic dispatch (#8790)
 
 knucleotide:
   10/17/15:
@@ -800,6 +802,8 @@ memleaksfull:
     - Rewrite default argument handling (#7858)
   01/23/18:
     - Fix memory leak introduced in PR #8073 (#8268)
+  03/14/15:
+    - Convert RecordParser over from constructors to initializers (#8810)
 
 meteor:
   12/18/13:
@@ -1006,6 +1010,8 @@ revcomp:
   03/10/17:
     - text: Re-enable binary IO optimization on NUMA (#5572)
       config: chapcs
+  03/15/17:
+    - Update to test (#8815)
 
 sad:
   05/03/16:


### PR DESCRIPTION
Mark revcomp update, memory leak reduction likely candidate, and jacobi
AST and generated code size due to initializer dynamic dispatch change.