### PR TITLE
Resolve new 5

### DIFF
--- a/test/classes/initializers/postInit/nongeneric-class.chpl
+++ b/test/classes/initializers/postInit/nongeneric-class.chpl
@@ -1,0 +1,49 @@
+// Verify that postInit() is called correctly when the new
+// expression is a statement i.e. has a lock statement as
+// its parent.
+//
+// This can occur in two situations
+//
+//   1) A new expression at top level.
+//      Note that the instance will leak
+//
+//   2) A type/init  expr for a procedure formal
+//
+
+class MyCls {
+  var x : int;
+
+  proc init(x : int) {
+    this.x = x;
+
+    writeln('MyCls.init');
+  }
+
+  proc postInit() {
+    writeln('MyCls.postInit');
+  }
+}
+
+
+
+
+proc main() {
+  // 1) A new expression at top level
+  new MyCls(10);
+
+  writeln();
+
+  foo();
+}
+
+
+
+
+
+// The initExpr is a block statement with the new expr.
+proc foo(x = new MyCls(20)) {
+  writeln(x);
+  writeln();
+}
+
+

--- a/test/classes/initializers/postInit/nongeneric-class.good
+++ b/test/classes/initializers/postInit/nongeneric-class.good
@@ -1,0 +1,7 @@
+MyCls.init
+MyCls.postInit
+
+MyCls.init
+MyCls.postInit
+{x = 20}
+


### PR DESCRIPTION
Continue to address issues with PRIM_NEW at top level of a block statement

This simple PR updates resolveNewHandleNonGenericInitializer() so that
a PRIM_NEW at statement level, i.e. the parentExpr is a BlockStmt, is handled
correctly.

Adds a test to lock in this behavior.

Compiled with the standard configurations.  Limited testing for each config.
Passed a single-locale paratest with -futures (modulo existing errors on master)

