### PR TITLE
Resolve new 7

### DIFF
--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -136,6 +136,7 @@ void normalize() {
         isRecordWithInitializers(at) == true) {
       preNormalizeFields(at);
     }
+
     preNormalizePostInit(at);
   }
 
@@ -1354,10 +1355,9 @@ static void applyGetterTransform(CallExpr* call) {
 *                                                                             *
 ************************************** | *************************************/
 
-static bool  shouldInsertCallTemps(CallExpr* call);
-static void  evaluateAutoDestroy(CallExpr* call, VarSymbol* tmp);
-static bool  moveMakesTypeAlias(CallExpr* call);
-static Type* typeForNewNonGenericRecord(CallExpr* call);
+static bool shouldInsertCallTemps(CallExpr* call);
+static void evaluateAutoDestroy(CallExpr* call, VarSymbol* tmp);
+static bool moveMakesTypeAlias(CallExpr* call);
 
 static void insertCallTemps(CallExpr* call) {
   if (shouldInsertCallTemps(call) == true) {
@@ -1373,7 +1373,7 @@ static void insertCallTempsWithStmt(CallExpr* call, Expr* stmt) {
 
   stmt->insertBefore(new DefExpr(tmp));
 
-  if (call->isPrimitive(PRIM_NEW)    == true) {
+  if (call->isPrimitive(PRIM_NEW) == true) {
     tmp->addFlag(FLAG_INSERT_AUTO_DESTROY_FOR_EXPLICIT_NEW);
 
   } else {
@@ -1406,37 +1406,9 @@ static void insertCallTempsWithStmt(CallExpr* call, Expr* stmt) {
     tmp->addFlag(FLAG_SUPER_TEMP);
   }
 
-  // Is this a new-expression for a record with an initializer?
-  if (Type* type = typeForNewNonGenericRecord(call)) {
-    // Define the type for the tmp
-    tmp->type = type;
+  call->replace(new SymExpr(tmp));
 
-    // 2017/03/14: call has the form prim_new(MyRec(a, b, c))
-    // Extract the argument to the new expression
-    CallExpr* newArg = toCallExpr(call->get(1));
-
-    // Convert the argument for the new-expression into an init call
-    newArg->setUnresolvedFunction("init");
-
-    // Add _mt and _this (insert at head in reverse order)
-    newArg->insertAtHead(tmp);
-    newArg->insertAtHead(gMethodToken);
-
-    // Add a call to postInit() if present
-    insertPostInit(tmp, newArg);
-
-    // Move the tmp.init(args) expression to before the call
-    stmt->insertBefore(newArg->remove());
-
-    // Replace the degenerate new-expression with a use of the tmp variable
-    call->replace(new SymExpr(tmp));
-
-  // No.  The simple case
-  } else {
-    call->replace(new SymExpr(tmp));
-
-    stmt->insertBefore(new CallExpr(PRIM_MOVE, tmp, call));
-  }
+  stmt->insertBefore(new CallExpr(PRIM_MOVE, tmp, call));
 }
 
 static bool shouldInsertCallTemps(CallExpr* call) {
@@ -1540,42 +1512,6 @@ static bool moveMakesTypeAlias(CallExpr* call) {
     if (SymExpr* se = toSymExpr(call->get(1))) {
       if (VarSymbol* var = toVarSymbol(se->symbol())) {
         retval = var->isType();
-      }
-    }
-  }
-
-  return retval;
-}
-
-//
-// If this is a new-expression for a non-generic record with an initializer
-// then return the type for the initializer
-//
-// 2017/03/14 This currently runs before new expressions have been
-// normalized.
-//
-// Before normalization, a new expression is usually
-//
-//    prim_new(MyRec(a, b, c))
-//
-// and this is the form that is currently recognized
-//
-//
-// After normalization, it will generally be
-//
-//    prim_new(MyRec, a, b, c);
-
-static Type* typeForNewNonGenericRecord(CallExpr* call) {
-  Type* retval = NULL;
-
-  if (call->isPrimitive(PRIM_NEW) == true && call->numActuals() == 1) {
-    if (CallExpr* arg1 = toCallExpr(call->get(1))) {
-      if (SymExpr* base = toSymExpr(arg1->baseExpr)) {
-        if (TypeSymbol* sym = toTypeSymbol(base->symbol())) {
-          if (isNonGenericRecordWithInitializers(sym->type) == true) {
-            retval = sym->type;
-          }
-        }
       }
     }
   }
@@ -2103,7 +2039,7 @@ static void normVarTypeWoutInit(DefExpr* defExpr) {
     var->type = type;
 
   } else if (isNonGenericRecordWithInitializers(type) == true &&
-             needsGenericRecordInitializer(type) == false) {
+             needsGenericRecordInitializer(type)      == false) {
     CallExpr* init = new CallExpr("init", gMethodToken, var);
 
     var->type = type;

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -406,6 +406,12 @@ bool fixupDefaultInitCopy(FnSymbol* fn, FnSymbol* newFn, CallExpr* call) {
 
         def->insertAfter(initCall);
 
+        if (ct->hasPostInitializer() == true) {
+          CallExpr* post = new CallExpr("postInit", gMethodToken, thisTmp);
+
+          initCall->insertAfter(post);
+        }
+
         // Replace the other setting of the return-value-variable
         // with what we have now...
 
@@ -415,7 +421,7 @@ bool fixupDefaultInitCopy(FnSymbol* fn, FnSymbol* newFn, CallExpr* call) {
         // Remove other PRIM_MOVEs to the RVV
         for_alist(stmt, newFn->body->body) {
           if (CallExpr* callStmt = toCallExpr(stmt)) {
-            if (callStmt->isPrimitive(PRIM_MOVE)) {
+            if (callStmt->isPrimitive(PRIM_MOVE) == true) {
               SymExpr* se = toSymExpr(callStmt->get(1));
 
               INT_ASSERT(se);
@@ -5073,7 +5079,6 @@ static void resolveInitField(CallExpr* call) {
 * and then resolves the PRIM_MOVE.                                            *
 *                                                                             *
 ************************************** | *************************************/
-
 
 static void resolveInitVar(CallExpr* call) {
   SymExpr* dstExpr = toSymExpr(call->get(1));

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -397,13 +397,7 @@ bool fixupDefaultInitCopy(FnSymbol* fn, FnSymbol* newFn, CallExpr* call) {
       // it up completely...
       instantiateBody(newFn);
 
-      FnSymbol* initFn = findCopyInit(ct);
-
-      if (initFn == NULL) {
-        // No copy-initializer could be found
-        newFn->addFlag(FLAG_ERRONEOUS_INITCOPY);
-
-      } else {
+      if (FnSymbol* initFn = findCopyInit(ct)) {
         Symbol*   thisTmp  = newTemp(ct);
         DefExpr*  def      = new DefExpr(thisTmp);
         CallExpr* initCall = new CallExpr(initFn, gMethodToken, thisTmp, arg);
@@ -435,6 +429,10 @@ bool fixupDefaultInitCopy(FnSymbol* fn, FnSymbol* newFn, CallExpr* call) {
 
         // Set the RVV to the copy
         newFn->insertBeforeEpilogue(new CallExpr(PRIM_MOVE, retSym, thisTmp));
+
+      } else {
+        // No copy-initializer could be found
+        newFn->addFlag(FLAG_ERRONEOUS_INITCOPY);
       }
 
       retval = true;

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5948,6 +5948,10 @@ static void resolveNewHandleNonGenericInitializer(CallExpr* call) {
     // Invoking an instance method
     call->insertAtHead(new SymExpr(newTmp));
     call->insertAtHead(new SymExpr(gMethodToken));
+
+    if (at->hasPostInitializer() == true) {
+      call->insertAfter(new CallExpr("postInit", gMethodToken, newTmp));
+    }
   }
 
   resolveCall(call);
@@ -6001,6 +6005,11 @@ static void resolveNewHandleGenericInitializer(CallExpr* call) {
   temporaryInitializerFixup(call);
 
   resolveGenericActuals(call);
+
+  if (at->isRecord()           == true &&
+      at->hasPostInitializer() == true) {
+    call->insertAfter(new CallExpr("postInit", gMethodToken, initTmp));
+  }
 
   initFn = resolveInitializer(call);
 
@@ -7191,6 +7200,7 @@ void resolve() {
   insertDynamicDispatchCalls();
 
   beforeLoweringForallStmts = false;
+
   lowerForallStmts();
 
   insertReturnTemps();

--- a/test/classes/initializers/postInit/copy-init.chpl
+++ b/test/classes/initializers/postInit/copy-init.chpl
@@ -1,0 +1,88 @@
+var globalId = 0;
+
+record MyRecord {
+  var id : int;
+
+  proc init() {
+    writeln('    MyRecord.init()');
+
+    globalId = globalId + 100;
+
+    id       = globalId;
+
+  }
+
+  proc init(other : MyRecord) {
+    writeln('    MyRecord.init(other : MyRecord)');
+
+    id       = other.id + 1;
+
+  }
+
+  proc postInit() {
+    writeln('    MyRecord.postInit()');
+  }
+
+  proc deinit() {
+    writeln('    MyRecord.deinit() ', this);
+  }
+}
+
+
+
+
+proc main() {
+  writeln('main            DefaultInit  rec100');
+
+  var rec100 : MyRecord;
+
+  fnCall(rec100);
+
+  writeln();
+  writeln();
+
+  writeln('main            De-Init      rec100      ', rec100);
+}
+
+
+
+
+proc fnCall(arg100) {
+  {
+    writeln(' ');
+    writeln('  fnCall        CopyInit     rec101 with ', arg100);
+
+    var rec101 = arg100;
+
+    writeln(' ');
+    writeln('  fnCall        De-Init      rec101      ', rec101);
+  }
+
+  writeln(' ');
+
+  {
+    var rec200 = returnRec();
+
+    writeln(' ');
+    writeln('  fnCall        De-Init      rec200      ', rec200);
+  }
+
+  writeln(' ');
+}
+
+
+
+
+proc returnRec() {
+  writeln('    returnRec   DefaultInit  rec200');
+
+  var rec200 : MyRecord;
+
+  writeln('    returnRec   No De-Init');
+
+  return rec200;
+}
+
+
+
+

--- a/test/classes/initializers/postInit/copy-init.good
+++ b/test/classes/initializers/postInit/copy-init.good
@@ -1,0 +1,23 @@
+main            DefaultInit  rec100
+    MyRecord.init()
+    MyRecord.postInit()
+ 
+  fnCall        CopyInit     rec101 with (id = 100)
+    MyRecord.init(other : MyRecord)
+    MyRecord.postInit()
+ 
+  fnCall        De-Init      rec101      (id = 101)
+    MyRecord.deinit() (id = 101)
+ 
+    returnRec   DefaultInit  rec200
+    MyRecord.init()
+    MyRecord.postInit()
+    returnRec   No De-Init
+ 
+  fnCall        De-Init      rec200      (id = 200)
+    MyRecord.deinit() (id = 200)
+ 
+
+
+main            De-Init      rec100      (id = 100)
+    MyRecord.deinit() (id = 100)

--- a/test/classes/initializers/postInit/record-generic.chpl
+++ b/test/classes/initializers/postInit/record-generic.chpl
@@ -1,0 +1,90 @@
+// Verify that postInit() is called correctly when the new
+// expression is a statement i.e. has a lock statement as
+// its parent.
+//
+// This can occur in two situations
+//
+//   1) A new expression at top level.
+//      Note that the instance will leak
+//
+//   2) A type/init  expr for a procedure formal
+//
+
+record MyRec {
+  type t;
+  var  x : t;
+
+  proc init() {
+    this.t = int;
+    this.x = 10;
+
+    writeln('MyRec.init default');
+  }
+
+  proc init(type t) {
+    this.t = t;
+
+    writeln('MyRec.init type');
+  }
+
+  proc init(x : int) {
+    this.t = int;
+    this.x = x;
+
+    writeln('MyRec.init value');
+  }
+
+  proc postInit() {
+    writeln('MyRec.postInit');
+    writeln();
+  }
+}
+
+
+
+
+proc main() {
+  var r1 : MyRec(int);
+
+  writeln(r1);
+  writeln();
+
+
+
+  var r2 : MyRec(int) = new MyRec(20);
+
+  writeln(r2);
+  writeln();
+
+
+
+  var r3         = new MyRec(30);
+
+  writeln(r3);
+  writeln();
+
+
+
+  r3 = new MyRec(40);
+  writeln(r3);
+  writeln();
+
+  // 1) A new expression at top level
+  new MyRec(50);
+
+  writeln();
+
+  foo();
+}
+
+
+
+
+
+// The initExpr is a block statement with the new expr.
+proc foo(x = new MyRec(20)) {
+  writeln('foo ', x);
+  writeln();
+}
+
+

--- a/test/classes/initializers/postInit/record-generic.good
+++ b/test/classes/initializers/postInit/record-generic.good
@@ -1,0 +1,28 @@
+MyRec.init type
+(x = 0)
+
+MyRec.init type
+MyRec.init value
+MyRec.postInit
+
+(x = 20)
+
+MyRec.init value
+MyRec.postInit
+
+(x = 30)
+
+MyRec.init value
+MyRec.postInit
+
+(x = 40)
+
+MyRec.init value
+MyRec.postInit
+
+
+MyRec.init value
+MyRec.postInit
+
+foo (x = 20)
+

--- a/test/classes/initializers/postInit/record-nongeneric.chpl
+++ b/test/classes/initializers/postInit/record-nongeneric.chpl
@@ -1,0 +1,81 @@
+// Verify that postInit() is called correctly when the new
+// expression is a statement i.e. has a lock statement as
+// its parent.
+//
+// This can occur in two situations
+//
+//   1) A new expression at top level.
+//      Note that the instance will leak
+//
+//   2) A type/init  expr for a procedure formal
+//
+
+record MyRec {
+  var x : int;
+
+  proc init() {
+    this.x = 10;
+
+    writeln('MyRec.init default');
+  }
+
+  proc init(x : int) {
+    this.x = x;
+
+    writeln('MyRec.init value');
+  }
+
+  proc postInit() {
+    writeln('MyRec.postInit');
+    writeln();
+  }
+}
+
+
+
+
+proc main() {
+  var r1 : MyRec;
+
+  writeln(r1);
+  writeln();
+
+
+
+  var r2 : MyRec = new MyRec(20);
+
+  writeln(r2);
+  writeln();
+
+
+
+  var r3         = new MyRec(30);
+
+  writeln(r3);
+  writeln();
+
+
+
+  r3 = new MyRec(40);
+  writeln(r3);
+  writeln();
+
+  // 1) A new expression at top level
+  new MyRec(50);
+
+  writeln();
+
+  foo();
+}
+
+
+
+
+
+// The initExpr is a block statement with the new expr.
+proc foo(x = new MyRec(20)) {
+  writeln('foo ', x);
+  writeln();
+}
+
+

--- a/test/classes/initializers/postInit/record-nongeneric.good
+++ b/test/classes/initializers/postInit/record-nongeneric.good
@@ -1,0 +1,29 @@
+MyRec.init default
+MyRec.postInit
+
+(x = 10)
+
+MyRec.init value
+MyRec.postInit
+
+(x = 20)
+
+MyRec.init value
+MyRec.postInit
+
+(x = 30)
+
+MyRec.init value
+MyRec.postInit
+
+(x = 40)
+
+MyRec.init value
+MyRec.postInit
+
+
+MyRec.init value
+MyRec.postInit
+
+foo (x = 20)
+


### PR DESCRIPTION
Address several failures to invoke postInit() on records

I noticed several situations in which postinit() (nee postInit()) was
not being invoked for records.


1) Eliminate some code from normalize that attempted to add
insert postInit for non-generic records in a naive way in a complex
situation.

2) Update two locations in functionResolution that insert calls to
init() but that failed to add the corresponding postinit()

3) Update the two handlers for PRIM_NEW to insert calls to postinit()

4) Add 3 tests to lock in these updates

Compiled with/without CHPL_DEVELOPER on clang/darwin and gcc/linux64.
Limited testing for each configuration.  Passed a single-locale paratest with
-futures
