### PR TITLE
Add versions of channel.mark, commit, revert for locking=false channels

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -2251,22 +2251,6 @@ proc channel.advancePastByte(byte:uint(8)) throws {
 }
 
 
-// These begin with an _ to indicated that
-// you should have a lock before you use these... there is probably
-// a better name for them...
-
-/*
-   For a channel locked with :proc:`channel.lock`, return the offset
-   of that channel.
- */
-inline proc channel._offset():int(64) {
-  var ret:int(64);
-  on this.home {
-    ret = qio_channel_offset_unlocked(_channel_internal);
-  }
-  return ret;
-}
-
 /*
    *mark* a channel - that is, save the current offset of the channel
    on its *mark stack*. This function can only be called on a channel
@@ -2302,6 +2286,43 @@ inline proc channel.mark():syserr where this.locking == false {
 }
 
 /*
+   Abort an *I/O transaction*. See :proc:`channel.mark`. This function
+   will pop the last element from the *mark stack* and then leave the
+   previous channel offset unchanged.  This function can only be
+   called on a channel with ``locking==false``.
+*/
+inline proc channel.revert() where this.locking == false {
+  qio_channel_revert_unlocked(_channel_internal);
+}
+
+/*
+   Commit an *I/O transaction*. See :proc:`channel.mark`.  This
+   function will pop the last element from the *mark stack* and then
+   set the channel offset to the popped offset.  This function can
+   only be called on a channel with ``locking==false``.
+
+*/
+inline proc channel.commit() where this.locking == false {
+  qio_channel_commit_unlocked(_channel_internal);
+}
+
+// These begin with an _ to indicated that
+// you should have a lock before you use these... there is probably
+// a better name for them...
+
+/*
+   For a channel locked with :proc:`channel.lock`, return the offset
+   of that channel.
+ */
+inline proc channel._offset():int(64) {
+  var ret:int(64);
+  on this.home {
+    ret = qio_channel_offset_unlocked(_channel_internal);
+  }
+  return ret;
+}
+
+/*
    This routine is identical to :proc:`channel.mark` except that it
    can be called on channels with ``locking==true`` and should be
    called only once the channel has been locked with
@@ -2321,16 +2342,6 @@ inline proc channel._mark():syserr {
 }
 
 /*
-   Abort an *I/O transaction*. See :proc:`channel.mark`. This function
-   will pop the last element from the *mark stack* and then leave the
-   previous channel offset unchanged.  This function can only be
-   called on a channel with ``locking==false``.
-*/
-inline proc channel.revert() where this.locking == false {
-  qio_channel_revert_unlocked(_channel_internal);
-}
-
-/*
    Abort an *I/O transaction*. See :proc:`channel._mark`.  This
    function will pop the last element from the *mark stack* and then
    leave the previous channel offset unchanged.  This function should
@@ -2339,17 +2350,6 @@ inline proc channel.revert() where this.locking == false {
 */
 inline proc channel._revert() {
   qio_channel_revert_unlocked(_channel_internal);
-}
-
-/*
-   Commit an *I/O transaction*. See :proc:`channel.mark`.  This
-   function will pop the last element from the *mark stack* and then
-   set the channel offset to the popped offset.  This function can
-   only be called on a channel with ``locking==false``.
-
-*/
-inline proc channel.commit() where this.locking == false {
-  qio_channel_commit_unlocked(_channel_internal);
 }
 
 /*

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -197,7 +197,8 @@ multiple tasks. When creating a channel, it is possible to disable the lock
 Some channel methods - in particular those beginning with the underscore -
 should only be called on locked channels.  With these methods, it is possible
 to get or set the channel style, or perform I/O "transactions" (see
-:proc:`channel._mark`). To use these methods, first lock the channel with
+:proc:`channel.mark` and :proc:`channel._mark`). To use these methods, 
+first lock the channel with
 channel.lock(), call the methods you need, and then unlock the channel with
 channel.unlock(). Note that in the future, we may move to alternative ways of
 calling these functions that guarantee that they are not called on a channel
@@ -2323,7 +2324,7 @@ inline proc channel._mark():syserr {
    Abort an *I/O transaction*. See :proc:`channel.mark`. This function
    will pop the last element from the *mark stack* and then leave the
    previous channel offset unchanged.  This function can only be
-   called on a channel with ``locking==false`.
+   called on a channel with ``locking==false``.
 */
 inline proc channel.revert() where this.locking == false {
   qio_channel_revert_unlocked(_channel_internal);
@@ -2344,7 +2345,7 @@ inline proc channel._revert() {
    Commit an *I/O transaction*. See :proc:`channel.mark`.  This
    function will pop the last element from the *mark stack* and then
    set the channel offset to the popped offset.  This function can
-   only be called on a channel with ``locking==false`.
+   only be called on a channel with ``locking==false``.
 
 */
 inline proc channel.commit() where this.locking == false {

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -2266,11 +2266,10 @@ inline proc channel._offset():int(64) {
   return ret;
 }
 
-
 /*
-   *mark* a channel - that is, save the current offset of the channel on its
-   *mark stack*. This function should only be called on a channel that is
-   already locked with with :proc:`channel.lock`.
+   *mark* a channel - that is, save the current offset of the channel
+   on its *mark stack*. This function can only be called on a channel
+   with ``locking==false``.
 
    The *mark stack* stores several channel offsets. For any channel offset that
    is between the minimum and maximum value in the *mark stack*, I/O operations
@@ -2278,17 +2277,14 @@ inline proc channel._offset():int(64) {
    those operations can be un-done. As a result, it is possible to perform *I/O
    transactions* on a channel. The basic steps for an *I/O transaction* are:
 
-    * lock the channel with :proc:`channel.lock`
-      (or work on an already-locked channel)
-    * *mark* the current position with :proc:`channel._mark`
+    * *mark* the current position with :proc:`channel.mark`
     * do something speculative (e.g. try to read 200 bytes of anything followed
       by a 'B')
     * if the speculative operation was successful,  commit the changes by
-      calling :proc:`channel._commit`
+      calling :proc:`channel.commit`
     * if the speculative operation was not successful, go back to the *mark* by
-      calling :proc:`channel._revert`. Subsequent I/O operations will work
+      calling :proc:`channel.revert`. Subsequent I/O operations will work
       as though nothing happened.
-    * unlock the channel with :proc:`channel.unlock` if necessary
 
   .. note::
 
@@ -2300,31 +2296,68 @@ inline proc channel._offset():int(64) {
   :returns: an error code, if an error was encountered.
 
  */
+inline proc channel.mark():syserr where this.locking == false {
+  return qio_channel_mark(false, _channel_internal);
+}
+
+/*
+   This routine is identical to :proc:`channel.mark` except that it
+   can be called on channels with ``locking==true`` and should be
+   called only once the channel has been locked with
+   :proc:`channel.lock`.  The channel should not be unlocked with
+   :proc:`channel.unlock` until after the mark has been committed with
+   :proc:`channel._commit` or reverted with :proc:`channel._revert`.
+
+   See :proc:`channel.mark` for details other than the locking
+   discipline.
+
+  :returns: an error code, if an error was encountered.
+
+ */
 // TODO - use the out error= style and otherwise halt on error, for consistency
 inline proc channel._mark():syserr {
   return qio_channel_mark(false, _channel_internal);
 }
 
 /*
+   Abort an *I/O transaction*. See :proc:`channel.mark`. This function
+   will pop the last element from the *mark stack* and then leave the
+   previous channel offset unchanged.  This function can only be
+   called on a channel with ``locking==false`.
+*/
+inline proc channel.revert() where this.locking == false {
+  qio_channel_revert_unlocked(_channel_internal);
+}
 
-   Abort an *I/O transaction*. See :proc:`channel._mark`. This function should
-   only be called on a channel that has already been locked and marked.  This
-   function will pop the last element from the *mark stack* and then leave the
-   previous channel offset unchanged.
-
- */
+/*
+   Abort an *I/O transaction*. See :proc:`channel._mark`.  This
+   function will pop the last element from the *mark stack* and then
+   leave the previous channel offset unchanged.  This function should
+   only be called on a channel that has already been locked and
+   marked.
+*/
 inline proc channel._revert() {
   qio_channel_revert_unlocked(_channel_internal);
 }
 
 /*
+   Commit an *I/O transaction*. See :proc:`channel.mark`.  This
+   function will pop the last element from the *mark stack* and then
+   set the channel offset to the popped offset.  This function can
+   only be called on a channel with ``locking==false`.
 
-   Commit an *I/O transaction*. See :proc:`channel._mark`. This function should
-   only be called on a channel that has already been locked and marked.  This
-   function will pop the last element from the *mark stack* and then set the
-   channel offset to the popped offset.
+*/
+inline proc channel.commit() where this.locking == false {
+  qio_channel_commit_unlocked(_channel_internal);
+}
 
- */
+/*
+   Commit an *I/O transaction*. See :proc:`channel._mark`.  This
+   function will pop the last element from the *mark stack* and then
+   set the channel offset to the popped offset.  This function should
+   only be called on a channel that has already been locked and
+   marked.
+*/
 inline proc channel._commit() {
   qio_channel_commit_unlocked(_channel_internal);
 }

--- a/test/studies/shootout/reverse-complement/bharshbarg/revcomp-mark-skip-read-begin.chpl
+++ b/test/studies/shootout/reverse-complement/bharshbarg/revcomp-mark-skip-read-begin.chpl
@@ -17,29 +17,29 @@ proc main(args: [] string) {
   sync { // wait for all process() tasks to complete before continuing
 
     while true {
-      const descOffset = input._offset();
+      const descOffset = input.offset();
       var nextDescOffset = descOffset;
       var seqOffset = descOffset;
       var eof = false;
 
       // Mark where we start scanning (keep bytes in I/O buffer in input)
-      input._mark();
+      input.mark();
 
       // Scan forward until we get to the \n (end of description)
       input.advancePastByte(ascii("\n"));
-      seqOffset = input._offset();
+      seqOffset = input.offset();
 
       try {
         // Scan forward until we get to the > (end of sequence)
         input.advancePastByte(ascii(">"));
-        nextDescOffset = input._offset();
+        nextDescOffset = input.offset();
       } catch e:EOFError {
         eof = true;
         nextDescOffset = len;
       }
 
       // Go back to the point we marked
-      input._revert();
+      input.revert();
 
       // Read until nextDescOffset into the data array.
       input.readBytes(c_ptrTo(data[descOffset]),

--- a/test/studies/shootout/reverse-complement/bradc/revcomp-blc.chpl
+++ b/test/studies/shootout/reverse-complement/bradc/revcomp-blc.chpl
@@ -17,14 +17,14 @@ proc main(args: [] string) {
   sync { // wait for all process() tasks to complete before continuing
     if len {  // make sure the file is not empty
       do {
-        const descOffset = input._offset();
+        const descOffset = input.offset();
 
         // Mark where we start scanning (keep bytes in I/O buffer in input)
-        input._mark();
+        input.mark();
 
         // Scan forward until we get to '\n' (end of description)
         input.advancePastByte(ascii("\n"));
-        const seqOffset = input._offset();
+        const seqOffset = input.offset();
 
         // Scan forward until we get to '>' (end of sequence) or EOF
         const (eof, nextDescOffset) = findNextDesc();
@@ -36,11 +36,11 @@ proc main(args: [] string) {
           } catch (e:EOFError) {
             return (true, len);
           }
-          return (false, input._offset());
+          return (false, input.offset());
         }
 
         // Go back to the point we marked
-        input._revert();
+        input.revert();
 
         // Read until nextDescOffset into the data array.
         input.readBytes(c_ptrTo(data[descOffset]),


### PR DESCRIPTION
For channels for which locking==false, this PR adds versions of the existing
_mark(), _commit(), and _revert() methods, yet without underscores for
clarity.  In the long-run, we should probably add no-underscore versions for
the case with manual locking as well, but that felt like too big of a change to
take on for this release.