### PR TITLE
Fix LLVM tests for gasnet-fast

### DIFF
--- a/test/llvm/function-args/ref_nonnull.skipif
+++ b/test/llvm/function-args/ref_nonnull.skipif
@@ -1,0 +1,1 @@
+CHPL_COMM!=none

--- a/test/llvm/llvm-invariant/function_local_const.chpl
+++ b/test/llvm/llvm-invariant/function_local_const.chpl
@@ -7,7 +7,9 @@ record A
   var a : int;
 }
 
-// CHECK: @_construct_A_chpl
+// CHECK: call {{.*}} @_construct_A_chpl
+// CHECK: store
+// CHECK: load
 // CHECK-DAG: call {}* @llvm.invariant.start.p0i8(i64 8, i8* [[CAST:%.*]])
 // CHECK-DAG: [[CAST]] = bitcast %A_chpl* [[PTR:%.*]] to i8*
 // CHECK_DAG: store %A_chpl {{%.*}}, %A_chpl* [[PTR]]

--- a/test/llvm/llvm-invariant/program_constructs.chpl
+++ b/test/llvm/llvm-invariant/program_constructs.chpl
@@ -12,6 +12,8 @@ proc f(n)
   for i in 1..10
   {
 // CHECK: call {{.*}} @_construct_A_chpl
+// CHECK: store
+// CHECK: load
 // CHECK-DAG: call {}* @llvm.invariant.start.p0i8(i64 8, i8* [[CAST1:%.*]])
 // CHECK-DAG: [[CAST1]] = bitcast %A_chpl* [[PTR1:%.*]] to i8*
 // CHECK_DAG: store %A_chpl {{%.*}}, %A_chpl* [[PTR1]]
@@ -23,6 +25,8 @@ proc f(n)
 
   if n < 10 {
 // CHECK: call {{.*}} @_construct_A_chpl
+// CHECK: store
+// CHECK: load
 // CHECK-DAG: call {}* @llvm.invariant.start.p0i8(i64 8, i8* [[CAST2:%.*]])
 // CHECK-DAG: [[CAST2]] = bitcast %A_chpl* [[PTR2:%.*]] to i8*
 // CHECK_DAG: store %A_chpl {{%.*}}, %A_chpl* [[PTR2]]
@@ -33,6 +37,8 @@ proc f(n)
   }
   else {
 // CHECK: call {{.*}} @_construct_A_chpl
+// CHECK: store
+// CHECK: load
 // CHECK-DAG: call {}* @llvm.invariant.start.p0i8(i64 8, i8* [[CAST3:%.*]])
 // CHECK-DAG: [[CAST3]] = bitcast %A_chpl* [[PTR3:%.*]] to i8*
 // CHECK_DAG: store %A_chpl {{%.*}}, %A_chpl* [[PTR3]]

--- a/test/llvm/tbaa/tbaa_class.skipif
+++ b/test/llvm/tbaa/tbaa_class.skipif
@@ -1,0 +1,1 @@
+CHPL_COMM!=none

--- a/test/llvmDebug/llvmDebug_test.py
+++ b/test/llvmDebug/llvmDebug_test.py
@@ -51,10 +51,8 @@ else:
 #    print 'checking functions --FAIL'
 
 # Verify the struct types
-if 'My_Actor' in output:
-    if 'My_name' in output:
-        if 'My_age' in output:
-            print 'checking types --PASS'
+if ('My_Actor' in output) and ('My_name' in output) and ('My_age' in output):
+    print 'checking types --PASS'
 else:
     print 'checking types --FAIL'
 

--- a/test/llvmDebug/sub_test
+++ b/test/llvmDebug/sub_test
@@ -4,6 +4,7 @@ LLVM=`$CHPL_HOME/util/chplenv/chpl_llvm.py`
 PLAT=`$CHPL_HOME/util/chplenv/chpl_platform.py --target`
 HOST=`$CHPL_HOME/util/chplenv/chpl_platform.py --host`
 COMP=`$CHPL_HOME/util/chplenv/chpl_compiler.py --host`
+COMM=`$CHPL_HOME/util/chplenv/chpl_comm.py`
 
 # We test it only if we're on linux64 with LLVM
 if [ "$LLVM" != "llvm" ]; then
@@ -16,10 +17,15 @@ echo "[Skipping test based on environment settings]";
 exit 0;
 fi
 
+if [ "$COMM" != "none" ]; then
+echo "[Skipping test based on environment settings]";
+exit 0;
+fi
+
 
 rm llvmDebug_test.out.tmp
 python llvmDebug_test.py "$CHPL_HOME" "$HOST" "$COMP" > llvmDebug_test.out.tmp 2>&1
-if ! diff llvmDebug_test.out.tmp llvmDebug_test.good; then
+if ! diff llvmDebug_test.good llvmDebug_test.out.tmp; then
 echo "[Error matching debug info for llvmDebug_test]";
 else
 echo "[Success matching debug info for llvmDebug_test]";


### PR DESCRIPTION
This change fixes some LLVM-specific tests to either work or skip when CHPL_COMM!=none, as appropriate.
