### PR TITLE
Rename postInit to "postinit"

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -422,7 +422,7 @@ bool AggregateType::hasInitializers() const {
 bool AggregateType::hasPostInitializer() const {
   bool retval = false;
 
-  // If there is postInit() it is defined on the defining type
+  // If there is postinit() it is defined on the defining type
   if (instantiatedFrom == NULL) {
     int size = methods.n;
 

--- a/compiler/AST/FnSymbol.cpp
+++ b/compiler/AST/FnSymbol.cpp
@@ -881,7 +881,7 @@ bool FnSymbol::isInitializer() const {
 }
 
 bool FnSymbol::isPostInitializer() const {
-  return isMethod() == true && strcmp(name, "postInit") == 0;
+  return isMethod() == true && strcmp(name, "postinit") == 0;
 }
 
 // This function or method is an iterator (as opposed to a procedure).

--- a/compiler/passes/initializerRules.cpp
+++ b/compiler/passes/initializerRules.cpp
@@ -1264,7 +1264,7 @@ static bool isSuperPostInit(CallExpr* stmt) {
   if (CallExpr* call = toCallExpr(stmt->baseExpr)) {
     if (call->numActuals()                        ==    2 &&
         call->isNamedAstr(astrSdot)               == true &&
-        isStringLiteral(call->get(2), "postInit") == true) {
+        isStringLiteral(call->get(2), "postinit") == true) {
       if (CallExpr* subExpr = toCallExpr(call->get(1))) {
         if (subExpr->numActuals()                     == 2    &&
             subExpr->isNamedAstr(astrSdot)            == true &&
@@ -1329,19 +1329,19 @@ static void insertSuperPostInit(FnSymbol* fn) {
     tmp->addFlag(FLAG_SUPER_TEMP);
 
     // Adding at head therefore add in reverse order
-    body->insertAtHead(new CallExpr("postInit", gMethodToken, tmp));
+    body->insertAtHead(new CallExpr("postinit", gMethodToken, tmp));
     body->insertAtHead(new CallExpr(PRIM_MOVE,  tmp,          superGet));
     body->insertAtHead(new DefExpr(tmp));
   }
 }
 
 //
-// Creates a method named "postInit" on 'at'. A call to "super.postInit" is
+// Creates a method named "postinit" on 'at'. A call to "super.postinit" is
 // added if 'at' is a class.
 //
 static void buildPostInit(AggregateType* at) {
   SET_LINENO(at);
-  FnSymbol* fn     = new FnSymbol("postInit");
+  FnSymbol* fn     = new FnSymbol("postinit");
   ArgSymbol* _mt   = new ArgSymbol(INTENT_BLANK, "_mt", dtMethodToken);
   ArgSymbol* _this = new ArgSymbol(INTENT_BLANK, "this", at);
 
@@ -1386,7 +1386,7 @@ static int insertPostInit(AggregateType* at, bool insertSuper) {
       if (method->formals.length > 2) {
         // Only accept method token and 'this'
         ret += 1;
-        USR_FATAL_CONT(method, "postInit must have zero arguments");
+        USR_FATAL_CONT(method, "postinit must have zero arguments");
       }
       if (at->isClass() == true && insertSuper == true) {
         insertSuperPostInit(method);

--- a/compiler/passes/initializerRules.cpp
+++ b/compiler/passes/initializerRules.cpp
@@ -1224,10 +1224,10 @@ static bool isSymbolThis(Expr* expr) {
 
 //
 // Builds the list of AggregateTypes in the hierarchy of `at` that have or
-// require a postInit.
+// require a postinit.
 //
 // Let's say we have a series of classes named from A through Z, where Z
-// inherits from Y and so on. If class Q has a postInit, this function will
+// inherits from Y and so on. If class Q has a postinit, this function will
 // add AggregateTypes to 'chain' from Q through Z with 'Q' at the head.
 //
 static bool buildPostInitChain(AggregateType* at,
@@ -1310,9 +1310,9 @@ static bool hasSuperPostInit(BlockStmt* block) {
 }
 
 //
-// Inserts a call to super.postInit if none exists anywhere in 'fn'
+// Inserts a call to super.postinit if none exists anywhere in 'fn'
 //
-// TODO: what should we do with super.postInits in conditionals?
+// TODO: what should we do with super.postinits in conditionals?
 // TODO: merge with addSuperInit
 //
 static void insertSuperPostInit(FnSymbol* fn) {
@@ -1368,8 +1368,8 @@ static void buildPostInit(AggregateType* at) {
 }
 
 //
-// Inserts a zero-arg where-less postInit for `at` unless one already exists.
-// Also inserts a super.postInit for any postInit if omitted.
+// Inserts a zero-arg where-less postinit for `at` unless one already exists.
+// Also inserts a super.postinit for any postinit if omitted.
 //
 // Returns number of errors found.
 //
@@ -1401,21 +1401,21 @@ static int insertPostInit(AggregateType* at, bool insertSuper) {
   return ret;
 }
 
-static std::set<AggregateType*> postInitCache;
+static std::set<AggregateType*> postinitCache;
 
 //
-// Inserts postInit methods and calls to super.postInit as needed.
+// Inserts postinit methods and calls to super.postinit as needed.
 //
-// If an ancestor of 'at' has a postInit, then every aggregate between 'at' and
-// that ancestor must have a postInit as well.
+// If an ancestor of 'at' has a postinit, then every aggregate between 'at' and
+// that ancestor must have a postinit as well.
 //
-// If postInits on a type have a where clause, insert a where-less postInit
+// If postinits on a type have a where clause, insert a where-less postinit
 // so the ancestors will always be called.
 //
 void preNormalizePostInit(AggregateType* at) {
   // Cache results to avoid extra work and to avoid looking for various forms
-  // of super.postInit.
-  if (postInitCache.find(at) != postInitCache.end()) {
+  // of super.postinit.
+  if (postinitCache.find(at) != postinitCache.end()) {
     return;
   }
 
@@ -1425,14 +1425,14 @@ void preNormalizePostInit(AggregateType* at) {
 
   int errors = 0;
   for_vector(AggregateType, cur, chain) {
-    if (postInitCache.find(cur) == postInitCache.end()) {
+    if (postinitCache.find(cur) == postinitCache.end()) {
       if (cur->hasInitializers() == false) {
         cur->symbol->addFlag(FLAG_USE_DEFAULT_INIT);
       }
       // Don't insert a super.init for the highest ancestor
       bool insertSuper = cur != chain.front();
       errors += insertPostInit(cur, insertSuper);
-      postInitCache.insert(cur);
+      postinitCache.insert(cur);
     }
   }
 

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -2282,7 +2282,7 @@ static void insertPostInit(Symbol* var, CallExpr* anchor) {
   AggregateType* at = toAggregateType(var->type);
 
   if (at->hasPostInitializer() == true) {
-    anchor->insertAfter(new CallExpr("postInit", gMethodToken, var));
+    anchor->insertAfter(new CallExpr("postinit", gMethodToken, var));
   }
 }
 

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -1975,7 +1975,7 @@ static void normVarTypeInference(DefExpr* defExpr) {
           argExpr->insertAtHead(modToken);
         }
 
-        // Add a call to postInit() if present
+        // Add a call to postinit() if present
         insertPostInit(var, argExpr);
 
       } else {
@@ -2046,7 +2046,7 @@ static void normVarTypeWoutInit(DefExpr* defExpr) {
 
     defExpr->insertAfter(init);
 
-    // Add a call to postInit() if present
+    // Add a call to postinit() if present
     insertPostInit(var, init);
 
   } else {
@@ -2104,7 +2104,7 @@ static void normVarTypeWithInit(DefExpr* defExpr) {
 
       defExpr->insertAfter(initCall);
 
-      // Add a call to postInit() if present
+      // Add a call to postinit() if present
       insertPostInit(var, initCall);
 
     } else if (isNewExpr(initExpr) == false) {
@@ -2124,7 +2124,7 @@ static void normVarTypeWithInit(DefExpr* defExpr) {
       argExpr->insertAtHead(var);
       argExpr->insertAtHead(gMethodToken);
 
-      // Add a call to postInit() if present
+      // Add a call to postinit() if present
       insertPostInit(var, argExpr);
     }
 
@@ -2161,7 +2161,7 @@ static void normVarTypeWithInit(DefExpr* defExpr) {
       argExpr->insertAtHead(new NamedExpr("this", new SymExpr(initExprTemp)));
       argExpr->insertAtHead(gMethodToken);
 
-      // Add a call to postInit() if present
+      // Add a call to postinit() if present
       insertPostInit(initExprTemp, argExpr);
 
       initExprTemp->addFlag(FLAG_DELAY_GENERIC_EXPANSION);

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -407,7 +407,7 @@ bool fixupDefaultInitCopy(FnSymbol* fn, FnSymbol* newFn, CallExpr* call) {
         def->insertAfter(initCall);
 
         if (ct->hasPostInitializer() == true) {
-          CallExpr* post = new CallExpr("postInit", gMethodToken, thisTmp);
+          CallExpr* post = new CallExpr("postinit", gMethodToken, thisTmp);
 
           initCall->insertAfter(post);
         }
@@ -5122,7 +5122,7 @@ static void resolveInitVar(CallExpr* call) {
       call->insertAtHead(gMethodToken);
 
       if (ct->hasPostInitializer() == true) {
-        call->insertAfter(new CallExpr("postInit", gMethodToken, dst));
+        call->insertAfter(new CallExpr("postinit", gMethodToken, dst));
       }
 
       resolveCall(call);
@@ -5823,7 +5823,7 @@ static void resolveNewAT(CallExpr* call) {
     INT_ASSERT(moveStmt                         != NULL);
     INT_ASSERT(moveStmt->isPrimitive(PRIM_MOVE) == true);
 
-    moveStmt->insertAfter(new CallExpr("postInit", gMethodToken, moveDest));
+    moveStmt->insertAfter(new CallExpr("postinit", gMethodToken, moveDest));
   }
 }
 
@@ -5950,7 +5950,7 @@ static void resolveNewHandleNonGenericInitializer(CallExpr* call) {
     call->insertAtHead(new SymExpr(gMethodToken));
 
     if (at->hasPostInitializer() == true) {
-      call->insertAfter(new CallExpr("postInit", gMethodToken, newTmp));
+      call->insertAfter(new CallExpr("postinit", gMethodToken, newTmp));
     }
   }
 
@@ -6008,7 +6008,7 @@ static void resolveNewHandleGenericInitializer(CallExpr* call) {
 
   if (at->isRecord()           == true &&
       at->hasPostInitializer() == true) {
-    call->insertAfter(new CallExpr("postInit", gMethodToken, initTmp));
+    call->insertAfter(new CallExpr("postinit", gMethodToken, initTmp));
   }
 
   initFn = resolveInitializer(call);

--- a/test/classes/initializers/postInit/args.chpl
+++ b/test/classes/initializers/postInit/args.chpl
@@ -1,7 +1,7 @@
 
 record R {
-  proc postInit(x:int) {
-    writeln("R.postInit");
+  proc postinit(x:int) {
+    writeln("R.postinit");
   }
 }
 

--- a/test/classes/initializers/postInit/args.good
+++ b/test/classes/initializers/postInit/args.good
@@ -1,1 +1,1 @@
-args.chpl:3: error: postInit must have zero arguments
+args.chpl:3: error: postinit must have zero arguments

--- a/test/classes/initializers/postInit/callPostInit.chpl
+++ b/test/classes/initializers/postInit/callPostInit.chpl
@@ -6,11 +6,11 @@ class C {
     writeln("C.init");
   }
 
-  proc postInit() {
-    writeln("C.postInit");
+  proc postinit() {
+    writeln("C.postinit");
   }
 }
 
 var c = new C();
-c.postInit();
+c.postinit();
 delete c;

--- a/test/classes/initializers/postInit/callPostInit.good
+++ b/test/classes/initializers/postInit/callPostInit.good
@@ -1,3 +1,3 @@
 C.init
-C.postInit
-C.postInit
+C.postinit
+C.postinit

--- a/test/classes/initializers/postInit/class-generic.chpl
+++ b/test/classes/initializers/postInit/class-generic.chpl
@@ -1,4 +1,4 @@
-// Verify that postInit() is called correctly when the new
+// Verify that postinit() is called correctly when the new
 // expression is a statement i.e. has a lock statement as
 // its parent.
 //
@@ -21,8 +21,8 @@ class MyCls {
     writeln('MyCls.init');
   }
 
-  proc postInit() {
-    writeln('MyCls.postInit');
+  proc postinit() {
+    writeln('MyCls.postinit');
   }
 }
 

--- a/test/classes/initializers/postInit/class-generic.good
+++ b/test/classes/initializers/postInit/class-generic.good
@@ -1,7 +1,7 @@
 MyCls.init
-MyCls.postInit
+MyCls.postinit
 
 MyCls.init
-MyCls.postInit
+MyCls.postinit
 {x = 20}
 

--- a/test/classes/initializers/postInit/class-nongeneric.chpl
+++ b/test/classes/initializers/postInit/class-nongeneric.chpl
@@ -1,4 +1,4 @@
-// Verify that postInit() is called correctly when the new
+// Verify that postinit() is called correctly when the new
 // expression is a statement i.e. has a lock statement as
 // its parent.
 //
@@ -19,8 +19,8 @@ class MyCls {
     writeln('MyCls.init');
   }
 
-  proc postInit() {
-    writeln('MyCls.postInit');
+  proc postinit() {
+    writeln('MyCls.postinit');
   }
 }
 

--- a/test/classes/initializers/postInit/class-nongeneric.good
+++ b/test/classes/initializers/postInit/class-nongeneric.good
@@ -1,7 +1,7 @@
 MyCls.init
-MyCls.postInit
+MyCls.postinit
 
 MyCls.init
-MyCls.postInit
+MyCls.postinit
 {x = 20}
 

--- a/test/classes/initializers/postInit/conditional.chpl
+++ b/test/classes/initializers/postInit/conditional.chpl
@@ -4,8 +4,8 @@ class A {
   proc init() {
     writeln("A.init");
   }
-  proc postInit() {
-    writeln("A.postInit");
+  proc postinit() {
+    writeln("A.postinit");
   }
 }
 
@@ -15,13 +15,13 @@ class B : A {
     writeln("B.init");
     this.b = b;
   }
-  proc postInit() {
+  proc postinit() {
     if b {
-      writeln("B.postInit");
-      super.postInit();
+      writeln("B.postinit");
+      super.postinit();
     } else {
-      super.postInit();
-      writeln("B.postInit");
+      super.postinit();
+      writeln("B.postinit");
     }
   }
 }

--- a/test/classes/initializers/postInit/conditional.good
+++ b/test/classes/initializers/postInit/conditional.good
@@ -1,9 +1,9 @@
 A.init
 B.init
-B.postInit
-A.postInit
+B.postinit
+A.postinit
 
 A.init
 B.init
-A.postInit
-B.postInit
+A.postinit
+B.postinit

--- a/test/classes/initializers/postInit/copy-init.chpl
+++ b/test/classes/initializers/postInit/copy-init.chpl
@@ -19,8 +19,8 @@ record MyRecord {
 
   }
 
-  proc postInit() {
-    writeln('    MyRecord.postInit()');
+  proc postinit() {
+    writeln('    MyRecord.postinit()');
   }
 
   proc deinit() {

--- a/test/classes/initializers/postInit/copy-init.good
+++ b/test/classes/initializers/postInit/copy-init.good
@@ -1,17 +1,17 @@
 main            DefaultInit  rec100
     MyRecord.init()
-    MyRecord.postInit()
+    MyRecord.postinit()
  
   fnCall        CopyInit     rec101 with (id = 100)
     MyRecord.init(other : MyRecord)
-    MyRecord.postInit()
+    MyRecord.postinit()
  
   fnCall        De-Init      rec101      (id = 101)
     MyRecord.deinit() (id = 101)
  
     returnRec   DefaultInit  rec200
     MyRecord.init()
-    MyRecord.postInit()
+    MyRecord.postinit()
     returnRec   No De-Init
  
   fnCall        De-Init      rec200      (id = 200)

--- a/test/classes/initializers/postInit/dispatch.chpl
+++ b/test/classes/initializers/postInit/dispatch.chpl
@@ -7,7 +7,7 @@ class C {
     writeln("In C.bar()");
   }
 
-  proc postInit() {
+  proc postinit() {
     foo();
     bar();
     //    baz();  // not possible since C doesn't define it
@@ -33,7 +33,7 @@ class E : C {
     writeln("In E.baz()");
   }
 
-  proc postInit() {
+  proc postinit() {
     foo();
     bar();
     baz();

--- a/test/classes/initializers/postInit/inherits.chpl
+++ b/test/classes/initializers/postInit/inherits.chpl
@@ -6,8 +6,8 @@ class A {
     writeln("A.init");
   }
 
-  proc postInit() {
-    writeln("A.postInit");
+  proc postinit() {
+    writeln("A.postinit");
   }
 }
 
@@ -18,8 +18,8 @@ class B : A {
     writeln("B.init");
   }
 
-  proc postInit() {
-    writeln("B.postInit");
+  proc postinit() {
+    writeln("B.postinit");
   }
 }
 
@@ -30,8 +30,8 @@ class C : B {
     writeln("C.init");
   }
 
-  proc postInit() {
-    writeln("C.postInit");
+  proc postinit() {
+    writeln("C.postinit");
   }
 }
 

--- a/test/classes/initializers/postInit/inherits.good
+++ b/test/classes/initializers/postInit/inherits.good
@@ -1,6 +1,6 @@
 A.init
 B.init
 C.init
-A.postInit
-B.postInit
-C.postInit
+A.postinit
+B.postinit
+C.postinit

--- a/test/classes/initializers/postInit/justPostInit.chpl
+++ b/test/classes/initializers/postInit/justPostInit.chpl
@@ -6,8 +6,8 @@ class C {
   var A : [1..4] int = 5;
   var s = "hello world";
 
-  proc postInit() {
-    writeln("C.postInit");
+  proc postinit() {
+    writeln("C.postinit");
   }
 }
 

--- a/test/classes/initializers/postInit/justPostInit.good
+++ b/test/classes/initializers/postInit/justPostInit.good
@@ -1,3 +1,3 @@
-C.postInit
+C.postinit
 has initializer: true
 c = {x = 10, A = 5 5 5 5, s = hello world}

--- a/test/classes/initializers/postInit/manual.chpl
+++ b/test/classes/initializers/postInit/manual.chpl
@@ -5,8 +5,8 @@ class A {
   proc init() {
     writeln("A.init");
   }
-  proc postInit() {
-    writeln("A.postInit");
+  proc postinit() {
+    writeln("A.postinit");
   }
 }
 
@@ -16,10 +16,10 @@ class B : A {
   proc init() {
     writeln("B.init");
   }
-  proc postInit() {
-    writeln("Start of B.postInit");
-    super.postInit();
-    writeln("End of B.postInit");
+  proc postinit() {
+    writeln("Start of B.postinit");
+    super.postinit();
+    writeln("End of B.postinit");
   }
 }
 

--- a/test/classes/initializers/postInit/manual.good
+++ b/test/classes/initializers/postInit/manual.good
@@ -1,5 +1,5 @@
 A.init
 B.init
-Start of B.postInit
-A.postInit
-End of B.postInit
+Start of B.postinit
+A.postinit
+End of B.postinit

--- a/test/classes/initializers/postInit/missing.chpl
+++ b/test/classes/initializers/postInit/missing.chpl
@@ -1,5 +1,5 @@
 
-// Parent does not have postInit, but child does
+// Parent does not have postinit, but child does
 
 class Y {
   var y : int;
@@ -16,8 +16,8 @@ class Z : Y {
     writeln("Z.init");
   }
 
-  proc postInit() {
-    writeln("Z.postInit");
+  proc postinit() {
+    writeln("Z.postinit");
   }
 }
 
@@ -25,7 +25,7 @@ var z = new Z();
 delete z;
 writeln();
 
-// Parent does not have postInit, but child and grandparent do
+// Parent does not have postinit, but child and grandparent do
 
 class A {
   var a : int;
@@ -34,8 +34,8 @@ class A {
     writeln("A.init");
   }
 
-  proc postInit() {
-    writeln("A.postInit");
+  proc postinit() {
+    writeln("A.postinit");
   }
 }
 
@@ -54,8 +54,8 @@ class C : B {
     writeln("C.init");
   }
 
-  proc postInit() {
-    writeln("C.postInit");
+  proc postinit() {
+    writeln("C.postinit");
   }
 }
 
@@ -63,7 +63,7 @@ var c = new C();
 delete c;
 writeln();
 
-// Parent has postInit, but child does not
+// Parent has postinit, but child does not
 
 class Parent {
   var p : int;
@@ -72,8 +72,8 @@ class Parent {
     writeln("Parent.init");
   }
 
-  proc postInit() {
-    writeln("Parent.postInit");
+  proc postinit() {
+    writeln("Parent.postinit");
   }
 }
 

--- a/test/classes/initializers/postInit/missing.good
+++ b/test/classes/initializers/postInit/missing.good
@@ -1,13 +1,13 @@
 Y.init
 Z.init
-Z.postInit
+Z.postinit
 
 A.init
 B.init
 C.init
-A.postInit
-C.postInit
+A.postinit
+C.postinit
 
 Parent.init
 Child.init
-Parent.postInit
+Parent.postinit

--- a/test/classes/initializers/postInit/record-generic.chpl
+++ b/test/classes/initializers/postInit/record-generic.chpl
@@ -1,4 +1,4 @@
-// Verify that postInit() is called correctly when the new
+// Verify that postinit() is called correctly when the new
 // expression is a statement i.e. has a lock statement as
 // its parent.
 //
@@ -34,8 +34,8 @@ record MyRec {
     writeln('MyRec.init value');
   }
 
-  proc postInit() {
-    writeln('MyRec.postInit');
+  proc postinit() {
+    writeln('MyRec.postinit');
     writeln();
   }
 }

--- a/test/classes/initializers/postInit/record-generic.good
+++ b/test/classes/initializers/postInit/record-generic.good
@@ -3,26 +3,26 @@ MyRec.init type
 
 MyRec.init type
 MyRec.init value
-MyRec.postInit
+MyRec.postinit
 
 (x = 20)
 
 MyRec.init value
-MyRec.postInit
+MyRec.postinit
 
 (x = 30)
 
 MyRec.init value
-MyRec.postInit
+MyRec.postinit
 
 (x = 40)
 
 MyRec.init value
-MyRec.postInit
+MyRec.postinit
 
 
 MyRec.init value
-MyRec.postInit
+MyRec.postinit
 
 foo (x = 20)
 

--- a/test/classes/initializers/postInit/record-nongeneric.chpl
+++ b/test/classes/initializers/postInit/record-nongeneric.chpl
@@ -1,4 +1,4 @@
-// Verify that postInit() is called correctly when the new
+// Verify that postinit() is called correctly when the new
 // expression is a statement i.e. has a lock statement as
 // its parent.
 //
@@ -25,8 +25,8 @@ record MyRec {
     writeln('MyRec.init value');
   }
 
-  proc postInit() {
-    writeln('MyRec.postInit');
+  proc postinit() {
+    writeln('MyRec.postinit');
     writeln();
   }
 }

--- a/test/classes/initializers/postInit/record-nongeneric.good
+++ b/test/classes/initializers/postInit/record-nongeneric.good
@@ -1,29 +1,29 @@
 MyRec.init default
-MyRec.postInit
+MyRec.postinit
 
 (x = 10)
 
 MyRec.init value
-MyRec.postInit
+MyRec.postinit
 
 (x = 20)
 
 MyRec.init value
-MyRec.postInit
+MyRec.postinit
 
 (x = 30)
 
 MyRec.init value
-MyRec.postInit
+MyRec.postinit
 
 (x = 40)
 
 MyRec.init value
-MyRec.postInit
+MyRec.postinit
 
 
 MyRec.init value
-MyRec.postInit
+MyRec.postinit
 
 foo (x = 20)
 

--- a/test/classes/initializers/postInit/simple.chpl
+++ b/test/classes/initializers/postInit/simple.chpl
@@ -9,8 +9,8 @@ class C {
     this.y = 1.0;
   }
 
-  proc postInit() {
-    writeln("C.postInit");
+  proc postinit() {
+    writeln("C.postinit");
     y *= x;
   }
 }
@@ -27,8 +27,8 @@ record R {
     writeln("R.init");
   }
 
-  proc postInit() {
-    writeln("R.postInit");
+  proc postinit() {
+    writeln("R.postinit");
   }
 }
 

--- a/test/classes/initializers/postInit/simple.good
+++ b/test/classes/initializers/postInit/simple.good
@@ -1,6 +1,6 @@
 C.init
-C.postInit
+C.postinit
 c = {x = 5, y = 5.0}
 
 R.init
-R.postInit
+R.postinit

--- a/test/classes/initializers/postInit/where.chpl
+++ b/test/classes/initializers/postInit/where.chpl
@@ -5,8 +5,8 @@ class Grandparent {
   proc init() {
     writeln("Grandparent.init");
   }
-  proc postInit() {
-    writeln("Grandparent.postInit");
+  proc postinit() {
+    writeln("Grandparent.postinit");
   }
 }
 
@@ -19,8 +19,8 @@ class Parent : Grandparent {
     writeln("Parent.init");
   }
 
-  proc postInit() where eltType == int {
-    writeln("Special Parent.postInit");
+  proc postinit() where eltType == int {
+    writeln("Special Parent.postinit");
   }
 }
 
@@ -31,8 +31,8 @@ class Child : Parent {
     super.init(t);
     writeln("Child.init");
   }
-  proc postInit() {
-    writeln("Child(",eltType:string,").postInit");
+  proc postinit() {
+    writeln("Child(",eltType:string,").postinit");
   }
 }
 

--- a/test/classes/initializers/postInit/where.good
+++ b/test/classes/initializers/postInit/where.good
@@ -1,12 +1,12 @@
 Grandparent.init
 Parent.init
 Child.init
-Grandparent.postInit
-Child(real(64)).postInit
+Grandparent.postinit
+Child(real(64)).postinit
 
 Grandparent.init
 Parent.init
 Child.init
-Grandparent.postInit
-Special Parent.postInit
-Child(int(64)).postInit
+Grandparent.postinit
+Special Parent.postinit
+Child(int(64)).postinit


### PR DESCRIPTION
We have decided to rename "postInit" to "postinit" in order to follow the all-lowercase precedent set by methods like 'init' and 'deinit'. This PR trivially changes the relevant strings in the compiler and the small number of tests that actually use postinit.

Testing:
- [x] full local