### PR TITLE
Fix segfault with inheritance and initializers/constructors, attempt 2

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -1415,6 +1415,7 @@ void AggregateType::buildConstructor() {
           // defines an initializer - we should not be creating a default
           // constructor in that case, it won't know what to do with it.
           if (at->initializerStyle == DEFINES_INITIALIZER ||
+              at->wantsDefaultInitializer() ||
               at->parentDefinesInitializer() == true) {
             // at->defaultInitializer will still be NULL
             USR_FATAL(this,
@@ -2091,7 +2092,8 @@ bool AggregateType::parentDefinesInitializer() const {
 
   if (dispatchParents.n > 0) {
     if (AggregateType* pt = dispatchParents.v[0]) {
-      if (pt->initializerStyle == DEFINES_INITIALIZER) {
+      if (pt->initializerStyle == DEFINES_INITIALIZER ||
+          pt->wantsDefaultInitializer()) {
         retval = true;
 
       } else {

--- a/test/classes/initializers/compilerGenerated/constructor_inherits_default.chpl
+++ b/test/classes/initializers/compilerGenerated/constructor_inherits_default.chpl
@@ -1,0 +1,15 @@
+class Parent {
+  var x: int;
+}
+
+class Child: Parent {
+  var y: int;
+
+  proc Child(yVal) {
+    y = yVal;
+  }
+}
+
+var c = new Child(3);
+writeln(c);
+delete c;

--- a/test/classes/initializers/compilerGenerated/constructor_inherits_default.good
+++ b/test/classes/initializers/compilerGenerated/constructor_inherits_default.good
@@ -1,0 +1,1 @@
+constructor_inherits_default.chpl:5: error: Cannot create default constructor on type 'Child', which inherits from a type that defines an initializer

--- a/test/classes/initializers/compilerGenerated/pragmaOnly/constructor_inherits_default.chpl
+++ b/test/classes/initializers/compilerGenerated/pragmaOnly/constructor_inherits_default.chpl
@@ -1,0 +1,16 @@
+pragma "use default init"
+class Parent {
+  var x: int;
+}
+
+class Child: Parent {
+  var y: int;
+
+  proc Child(yVal) {
+    y = yVal;
+  }
+}
+
+var c = new Child(3);
+writeln(c);
+delete c;

--- a/test/classes/initializers/compilerGenerated/pragmaOnly/constructor_inherits_default.good
+++ b/test/classes/initializers/compilerGenerated/pragmaOnly/constructor_inherits_default.good
@@ -1,0 +1,1 @@
+constructor_inherits_default.chpl:6: error: Cannot create default constructor on type 'Child', which inherits from a type that defines an initializer

--- a/test/classes/initializers/compilerGenerated/pragmaOnly/constructor_inherits_default_parent.chpl
+++ b/test/classes/initializers/compilerGenerated/pragmaOnly/constructor_inherits_default_parent.chpl
@@ -1,0 +1,20 @@
+pragma "use default init"
+class Grandparent {
+  var w: int;
+}
+
+class Parent: Grandparent {
+  var x: int;
+}
+
+class Child: Parent {
+  var y: int;
+
+  proc Child(yVal) {
+    y = yVal;
+  }
+}
+
+var c = new Child(3);
+writeln(c);
+delete c;

--- a/test/classes/initializers/compilerGenerated/pragmaOnly/constructor_inherits_default_parent.good
+++ b/test/classes/initializers/compilerGenerated/pragmaOnly/constructor_inherits_default_parent.good
@@ -1,0 +1,1 @@
+constructor_inherits_default_parent.chpl:10: error: Cannot create default constructor on type 'Child', which inherits from a type that defines an initializer


### PR DESCRIPTION
Prior to this change, if a parent class relied on the default initializer and a child
of that parent defined an explicit constructor, we would encounter a segfault
during compilation instead of the nice error message about mixing your object
initialization styles. This change resolves that error.

It turns out the check for if the parent utilizes an initializer (either that it
defines or the compiler generated one) was only looking for if an explicit
initializer was in the hierarchy.  Expand the check to also error when a default
initializer is present above the class with a constructor.

Add three tests validating this behavior.  One has the parent type get a default
initializer via `--force-initializers`, one has the parent type obtain it via the
pragma, and the third examines a three class hierarchy where the child defines
an explicit constructor and the grandparent uses the pragma (and the parent
relies on the default constructor).

Testing:
- [x] classes/initializers with futures
- [x] full std/ paratest