### PR TITLE
Add a prediff to handle uninitialized mason installation

### DIFF
--- a/test/mason/run/PREDIFF
+++ b/test/mason/run/PREDIFF
@@ -3,6 +3,6 @@
 outfile=$2
 temp=$outfile.temp
 
-cat $outfile | sed "s@${PWD}@\$PWD@" > $temp
+cat $outfile | sed "s@${PWD}@\$PWD@" | sed 's/Initializing mason-registry for mason-registry/Updating mason-registry for mason-registry/' > $temp
 
 mv $temp $outfile


### PR DESCRIPTION
If mason was not initialized, message would print `initializing` instead of `updating` resulting in a failure. 

- Modified `PREDIFF` to filter that out