### PR TITLE
Switch revcomp-blc from readBytes() to read() of an array slice

### DIFF
--- a/test/studies/shootout/reverse-complement/bradc/revcomp-blc.chpl
+++ b/test/studies/shootout/reverse-complement/bradc/revcomp-blc.chpl
@@ -43,8 +43,7 @@ proc main(args: [] string) {
         input.revert();
 
         // Read until nextDescOffset into the data array.
-        input.readBytes(c_ptrTo(data[descOffset]),
-                        (nextDescOffset-descOffset):ssize_t);
+        input.read(data[descOffset..nextDescOffset-1]);
 
         // '2' to skip over '\n' + 1 to skip over '>' if not yet at eof
         begin process(data, seqOffset, nextDescOffset-(2+!eof));


### PR DESCRIPTION
In code reviewing my readBytes() clean-up with Michael, he pointed out
that binary I/O on an array slice felt like a much more natural way to
write this to him.  I think we must've shied away from it in the past
because our line-by-line reading options tanked performance wise due
to all the slicing.  But for this case, we're reading big enough
chunks that the slice performance seems to be in the noise.  This also
feels more Chapeltastic than readBytes() for this situation.