### PR TITLE
Fix meteor.perfkeys for 4 less warning lines

### DIFF
--- a/test/studies/shootout/submitted/meteor.perfkeys
+++ b/test/studies/shootout/submitted/meteor.perfkeys
@@ -1,4 +1,4 @@
 # file: meteor-submited.dat
 real
-verify:5: 2098 solutions found
-verify:27: 1 1 3 3 3
+verify:1: 2098 solutions found
+verify:23: 1 1 3 3 3


### PR DESCRIPTION
PR #8859 added a warning and then PR #8859 turned it off by default.
This PR just updates meteor.perfkeys appropriately for the latest change.

Test change only, not reviewed.