### PR TITLE
Repair the runtime unit-testing side of error.h after #8836.

### DIFF
--- a/runtime/include/error.h
+++ b/runtime/include/error.h
@@ -67,19 +67,23 @@ void chpl_internal_error(const char* message);
   } while (0)
 
 static inline
+void chpl_error_vs(char *restrict, size_t, int32_t, int32_t,
+                   const char *restrict, ...)
+    __attribute__((format(printf, 5, 6)));
+
+static inline
 void chpl_error_vs(char *restrict str, size_t size,
                    int32_t lineno, int32_t filenameIdx,
-                   const char *restrict format, ...)
-       __attribute__((format(printf, 5, 6))) {
+                   const char *restrict format, ...) {
   fflush(stdout);
   fprintf(stderr, "%" PRId32 ":%" PRId32 ": error: ", filenameIdx, lineno);
 
   va_list ap;
-  va_start(ap, filenameIdx);
-  vfprintf(stderr, format, message);
+  va_start(ap, format);
+  vfprintf(stderr, format, ap);
   va_end(ap);
 
-  fprintf("\n", stderr);
+  fprintf(stderr, "\n");
   exit(1);
 }
 


### PR DESCRIPTION
There is limited support for a "standalone" build of the runtime to
support certain kinds of unit testing.  When I did the work in #8836 I
threw together a standalone version of `chpl_error_vs()`, intending to
come back and correct it later before merging, but I never returned to
finish up.  I also never tested it, which would have demonstrated that I
hadn't done so.  Complete and test it now.