### PR TITLE
Remove non-alphanumeric characters from start of chip 22

### DIFF
--- a/doc/rst/developer/chips/22.rst
+++ b/doc/rst/developer/chips/22.rst
@@ -1,4 +1,4 @@
-﻿Chapel GPU Language Support
+Chapel GPU Language Support
 ===========================
 
 Status

--- a/doc/rst/developer/chips/README.md
+++ b/doc/rst/developer/chips/README.md
@@ -23,6 +23,6 @@ See the first CHIP for an overview.
 * [19 Dynamically Loading Chapel Code](19.rst)
 * [20 Function Hijacking](20.rst)
 * [21 Chapel's Cryptography Library](21.rst)
-* [22 GPU Language Extensions](22.rst)
+* [22 Chapel GPU Language Support](22.rst)
 * [23 Initializers :- Experiences, Concerns, Proposals](23.rst)
 


### PR DESCRIPTION
Not sure how they got there or why I had to start the file fresh and copy
everything but the first character over to remove them, but it was messing with
the make update step for the README file, as reported by #8506.

Resolves #8506 