### PR TITLE
Clean up Path documentation

### DIFF
--- a/modules/standard/Path.chpl
+++ b/modules/standard/Path.chpl
@@ -50,139 +50,149 @@ use SysError;
    return splitPath(name)[2];
  }
 
-  /* Determines and returns the longest common path prefix of
-   all the string pathnames provided.
+ /* Determines and returns the longest common path prefix of
+    all the string pathnames provided.
 
-   :arg paths: Any number of paths
-   :type paths: `string`
+    :arg paths: Any number of paths
+    :type paths: `string`
 
-   :return: The longest common path prefix
-   :rtype: `string`
-   */
+    :return: The longest common path prefix
+    :rtype: `string`
+ */
 
-  proc commonPath(paths: string ...?n): string {
+ proc commonPath(paths: string ...?n): string {
 
-  var result: string = "";    // result string
-  var inputLength = n;   // size of input array
-  var firstPath = paths(1);
-  var flag: int = 0;
+   var result: string = "";    // result string
+   var inputLength = n;   // size of input array
+   var firstPath = paths(1);
+   var flag: int = 0;
 
-  // if input is empty, return empty string.
-  // if input is just one string, return that string as longest common prefix path.
+   // if input is empty, return empty string.
+   // if input is just one string, return that string as longest common prefix
+   // path.
 
-  if inputLength == 0 then {
-    return result;
-  } else if inputLength == 1 then{
-    return firstPath;
-  }
+   if inputLength == 0 then {
+     return result;
+   } else if inputLength == 1 then{
+     return firstPath;
+   }
 
-  var prefixArray = firstPath.split(pathSep, -1, false);    // array of resultant prefix string
+   var prefixArray = firstPath.split(pathSep, -1, false);
+   // array of resultant prefix string
 
-  var pos = prefixArray.size;   // rightmost index of common prefix
-  var minPathLength = prefixArray.size;
+   var pos = prefixArray.size;   // rightmost index of common prefix
+   var minPathLength = prefixArray.size;
 
-  for i in 2..n do {
+   for i in 2..n do {
 
-    var tempArray = paths(i).split(pathSep, -1, false);   // temporary array storing the current path under consideration
+     var tempArray = paths(i).split(pathSep, -1, false);
+     // temporary array storing the current path under consideration
 
-    var minimum = min(prefixArray.size, tempArray.size);
+     var minimum = min(prefixArray.size, tempArray.size);
 
-    if minimum < minPathLength then {
-      minPathLength = minimum;
-    }
+     if minimum < minPathLength then {
+       minPathLength = minimum;
+     }
 
-    for itr in 1..minimum do {
-      if (tempArray[itr]!=prefixArray[itr] && itr<=pos) {
-        pos = itr;
-        flag=1;   // indicating that pos was changed
-        break;
-      }
-    }
-  }
+     for itr in 1..minimum do {
+       if (tempArray[itr]!=prefixArray[itr] && itr<=pos) {
+         pos = itr;
+         flag=1;   // indicating that pos was changed
+         break;
+       }
+     }
+   }
 
-  if (flag == 1) {
-    prefixArray.remove(pos..prefixArray.size);
-  }   else {
-    prefixArray.remove(minPathLength+1..prefixArray.size);    // in case all paths are subsets of the longest path thus pos was never updated
-  }
+   if (flag == 1) {
+     prefixArray.remove(pos..prefixArray.size);
+   } else {
+     prefixArray.remove(minPathLength+1..prefixArray.size);
+     // in case all paths are subsets of the longest path thus pos was never
+     // updated
+   }
 
-  result = pathSep.join(prefixArray);
+   result = pathSep.join(prefixArray);
 
-  return result;
-  }
+   return result;
+ }
 
-  /* Determines and returns the longest common path prefix of
-   all the string pathnames provided.
+ /* Determines and returns the longest common path prefix of
+    all the string pathnames provided.
 
-   :arg paths: Any number of paths as an array
-   :type paths: `array`
+    :arg paths: Any number of paths as an array
+    :type paths: `array`
 
-   :return: The longest common path prefix
-   :rtype: `string`
-   */
+    :return: The longest common path prefix
+    :rtype: `string`
+ */
 
-  proc commonPath(paths: []): string {
+ proc commonPath(paths: []): string {
 
-  var result: string = "";    // result string
-  var inputLength = paths.size;   // size of input array
-  if inputLength == 0 then {     // if input is empty, return empty string.
-    return result;
-  } 
+   var result: string = "";    // result string
+   var inputLength = paths.size;   // size of input array
+   if inputLength == 0 then {     // if input is empty, return empty string.
+     return result;
+   }
   
-  var start: int = paths.domain.first;
-  var end: int = paths.domain.last;
-  var firstPath = paths[start];
-  var delimiter: string;
-  var flag: int = 0;
+   var start: int = paths.domain.first;
+   var end: int = paths.domain.last;
+   var firstPath = paths[start];
+   var delimiter: string;
+   var flag: int = 0;
 
-  // if input is just one string, return that string as longest common prefix path.
+   // if input is just one string, return that string as longest common prefix
+   // path.
 
-  if inputLength == 1 then{
-    return firstPath;
-  }
+   if inputLength == 1 then{
+     return firstPath;
+   }
 
-  // finding delimiter to split the paths.
+   // finding delimiter to split the paths.
 
-  if firstPath.find("\\", 1..firstPath.length) == 0 then {
-    delimiter = "/";
-  } else {
-    delimiter = "\\";
-  }
+   if firstPath.find("\\", 1..firstPath.length) == 0 then {
+     delimiter = "/";
+   } else {
+     delimiter = "\\";
+   }
 
-  var prefixArray = firstPath.split(delimiter, -1, false);    // array of resultant prefix string
+   var prefixArray = firstPath.split(delimiter, -1, false);
+   // array of resultant prefix string
 
-  var pos = prefixArray.size;   // rightmost index of common prefix
-  var minPathLength = prefixArray.size;
+   var pos = prefixArray.size;   // rightmost index of common prefix
+   var minPathLength = prefixArray.size;
 
-  for i in (start+1)..end do {
+   for i in (start+1)..end do {
 
-    var tempArray = paths[i].split(delimiter, -1, false);   // temporary array storing the current path under consideration
+     var tempArray = paths[i].split(delimiter, -1, false);
+     // temporary array storing the current path under consideration
 
-    var minimum = min(prefixArray.size, tempArray.size);
+     var minimum = min(prefixArray.size, tempArray.size);
 
-    if minimum < minPathLength then {
-      minPathLength = minimum;
-    }
+     if minimum < minPathLength then {
+       minPathLength = minimum;
+     }
 
-    for itr in 1..minimum do {
-      if (tempArray[itr]!=prefixArray[itr] && itr<=pos) {
-        pos = itr;
-        flag = 1;   // indicating that pos was changed
-        break;
-      }
-    }
-  }
+     for itr in 1..minimum do {
+       if (tempArray[itr]!=prefixArray[itr] && itr<=pos) {
+         pos = itr;
+         flag = 1;   // indicating that pos was changed
+         break;
+       }
+     }
+   }
 
-  if (flag == 1) {
-    prefixArray.remove(pos..prefixArray.size);
-  }   else {
-      prefixArray.remove(minPathLength+1..prefixArray.size);    // in case all paths are subsets of the longest path thus pos was never updated
-  }
+   if (flag == 1) {
+     prefixArray.remove(pos..prefixArray.size);
+   } else {
+     prefixArray.remove(minPathLength+1..prefixArray.size);
+     // in case all paths are subsets of the longest path thus pos was never
+     // updated
+   }
 
-  result = delimiter.join(prefixArray);
+   result = delimiter.join(prefixArray);
 
-  return result;
-  }
+   return result;
+ }
 
 /* Represents generally the current directory */
 const curDir = ".";
@@ -201,11 +211,11 @@ const curDir = ".";
 
  /*
 
- Returns the parent directory of the :type:`~IO.file` record.  For instance,
- a file with path `/foo/bar/baz` would return `/foo/bar`
+   Returns the parent directory of the :type:`~IO.file` record.  For instance,
+   a file with path `/foo/bar/baz` would return `/foo/bar`
 
-  :return: The parent directory of the file
-  :rtype: `string`
+   :return: The parent directory of the file
+   :rtype: `string`
 
  */
  pragma "no doc"
@@ -223,13 +233,13 @@ const curDir = ".";
  }
 
  /*
- Returns the parent directory of the :type:`~IO.file` record.  For instance,
- a file with path `/foo/bar/baz` would return `/foo/bar`
+   Returns the parent directory of the :type:`~IO.file` record.  For instance,
+   a file with path `/foo/bar/baz` would return `/foo/bar`
 
- Will throw an error if one occurs.
+   Will throw an error if one occurs.
 
-  :return: The parent directory of the file
-  :rtype: `string`
+   :return: The parent directory of the file
+   :rtype: `string`
  */
  proc file.getParentName(): string throws {
    var err: syserr = ENOERR;
@@ -283,7 +293,7 @@ const curDir = ".";
 */
   proc joinPath(paths: string ...?n): string {
     var result : string = paths(1); // result variable stores final answer
-   // loop to iterate over all the paths
+    // loop to iterate over all the paths
     for i in 2..n {
       var temp : string = paths(i);
       if temp.startsWith('/') {

--- a/modules/standard/Path.chpl
+++ b/modules/standard/Path.chpl
@@ -83,7 +83,7 @@ proc realPath(out error: syserr, name: string): string {
    This resolves and removes any :data:`curDir` and :data:`parentDir` uses
    present, as well as any symbolic links.  Returns the result
 
-   Will halt with an error message if one is detected.
+   Will throw an error if one occurs.
 
    :arg name: A path to resolve.  If the path does not refer to a valid file
               or directory, an error will occur.
@@ -120,7 +120,7 @@ proc file.realPath(out error: syserr): string {
    :data:`parentDir` uses present, as well as any symbolic links.  Returns the
    result
 
-   Will halt with an error message if one is detected.
+   Will throw an error if one occurs.
 
    :return: A canonical path to the file referenced by this :type:`~IO.file`
             record.  If the :type:`~IO.file` record is not valid, an error will
@@ -214,7 +214,7 @@ proc file.realPath(): string throws {
  Returns the parent directory of the :type:`~IO.file` record.  For instance,
  a file with path `/foo/bar/baz` would return `/foo/bar`
 
- Will halt with an error message if one is detected.
+ Will throw an error if one occurs.
 
   :return: The parent directory of the file
   :rtype: `string`

--- a/modules/standard/Path.chpl
+++ b/modules/standard/Path.chpl
@@ -32,10 +32,39 @@
    Operations which occur on the files or directories referred to by these paths
    may be found in :mod:`FileSystem` (for operations *on* the file) or :mod:`IO`
    (for operations *within* the file).
+
+   Path Computations
+   -----------------
+   :proc:`commonPath`
+   :proc:`realPath`
+   :proc:`file.realPath`
+
+   Path Manipulations
+   ------------------
+   :proc:`joinPath`
+   :proc:`splitPath`
+
+   Path Properties
+   ---------------
+   :proc:`basename`
+   :proc:`dirname`
+   :proc:`file.getParentName`
+   :proc:`isAbsPath`
+
+   Constant and Function Definitions
+   ---------------------------------
 */
 module Path {
 
 use SysError;
+
+/* Represents generally the current directory */
+const curDir = ".";
+
+/* Represents generally the parent directory */
+const parentDir = "..";
+/* Denotes the separator between a directory and its child. */
+const pathSep = "/";
 
 /* Returns the basename of the file name provided.  For instance, in the
    name `/foo/bar/baz`, this function would return `baz`, while `/foo/bar/`
@@ -194,9 +223,6 @@ use SysError;
    return result;
  }
 
-/* Represents generally the current directory */
-const curDir = ".";
-
 /* Returns the parent directory of the file name provided.  For instance,
    in the name `/foo/bar/baz`, this function would return `/foo/bar`, as
    would a call with `/foo/bar/` as the argument.
@@ -308,11 +334,6 @@ const curDir = ".";
     }
    return result;
  }
-
-/* Represents generally the parent directory */
-const parentDir = "..";
-/* Denotes the separator between a directory and its child. */
-const pathSep = "/";
 
 pragma "no doc"
 proc realPath(out error: syserr, name: string): string {

--- a/modules/standard/Path.chpl
+++ b/modules/standard/Path.chpl
@@ -276,8 +276,10 @@ const pathSep = "/";
 
 /* Determines whether the path specified is an absolute path.
 
-   Note: this is currently only implemented in a Unix environment.  It will not
-   behave correctly in a non-Unix environment.
+   .. note::
+
+      This is currently only implemented in a Unix environment.  It will not
+      behave correctly in a non-Unix environment.
 
    :arg name: the path to be checked.
    :type name: `string`
@@ -415,9 +417,13 @@ proc file.realPath(): string throws {
 
    With the exception of a path of the empty string or just "/", the original
    path can be recreated from this function's returned parts by joining them
-   with the path separator character:
+   with the path separator character, either explicitly:
 
    `dirname` + "/" + `basename`
+
+   or by calling :proc:`joinPath`:
+
+   `joinPath(dirname, basename)`
 
    :arg name: path to be split
    :type name: `string`


### PR DESCRIPTION
Various updates to the documentation of the Path module now that it is slightly
more populated.

Updates include:
- Replacing "will halt with an error" documentation with "will throw an error",
   since those functions throw errors now.
- Alphabetizing the contents of the Path module, which had some functions
  out of order since 1.16 (whoops)
- Moving the constants in the module to the top so that the functions can
   all use them, regardless of relative alphabetization.
- Adding categorizations and links to the beginning of the documentation,
  similar to how the FileSystem module is organized
- Changing a "note:" into a documentation Note.
- Adding a reference to joinPath from the splitPath documentation. The
   splitPath documentation was only missing the reference because joinPath
   hadn't been implemented prior to this release cycle.

Passed a full paratest.  Read through and double checked the links in a build of
the module documentation.