### PR TITLE
Update docs for string casts and error handling

### DIFF
--- a/doc/rst/technotes/errorHandling.rst
+++ b/doc/rst/technotes/errorHandling.rst
@@ -286,6 +286,14 @@ scope is exited, regardless of how it is exited.
     }
   }
 
+.. note::
+
+  It is not possible to throw errors out of a ``defer`` statement because the
+  atomicity of all ``defer`` statements must be guaranteed, and the handling
+  context would be unclear.
+
+  Errors also cannot be thrown by ``deinit()`` for similar reasons.
+
 .. _technote-errorHandling-methods:
 
 Methods
@@ -611,7 +619,6 @@ Current Limitations
 * Error handling does not work yet with initializers.
 * It is not yet decided whether or not it will be possible to
   throw from a `deinit` function.
-* In the future, there will be a better way to select strict mode.
 * Errors can't currently be thrown from iterators that are not inlined by the
   compiler
 

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -46,6 +46,19 @@
   The :mod:`Regexp` module also provides some routines for searching
   within strings.
 
+  Casts from ``string`` to the following types will throw an error if they
+  are invalid:
+
+    - ``int``
+    - ``uint``
+    - ``real``
+    - ``imag``
+    - ``complex``
+    - ``enum``
+
+  To learn more about handling this error, see the
+  :ref:`Error Handling technical note <readme-errorHandling>`.
+
   .. warning::
 
     While :record:`string` is intended to be a Unicode string, there is much

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -48,8 +48,8 @@
 
   .. warning::
 
-    Casts from ``string`` to the following types will throw an error if they
-    are invalid:
+    Casts from :record:`string` to the following types will throw an error
+    if they are invalid:
 
       - ``int``
       - ``uint``

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -46,23 +46,25 @@
   The :mod:`Regexp` module also provides some routines for searching
   within strings.
 
-  Casts from ``string`` to the following types will throw an error if they
-  are invalid:
-
-    - ``int``
-    - ``uint``
-    - ``real``
-    - ``imag``
-    - ``complex``
-    - ``enum``
-
-  To learn more about handling this error, see the
-  :ref:`Error Handling technical note <readme-errorHandling>`.
-
   .. warning::
 
+    Casts from ``string`` to the following types will throw an error if they
+    are invalid:
+
+      - ``int``
+      - ``uint``
+      - ``real``
+      - ``imag``
+      - ``complex``
+      - ``enum``
+
+    To learn more about handling these errors, see the
+    :ref:`Error Handling technical note <readme-errorHandling>`.
+
+  .. note::
+
     While :record:`string` is intended to be a Unicode string, there is much
-    left to do. As of Chapel 1.13, only ASCII strings can be expected to work
+    left to do. As of Chapel 1.17, only ASCII strings can be expected to work
     correctly with all functions.
 
     Future work involves support for both ASCII and unicode strings, and


### PR DESCRIPTION
- `String.chpl`: warn users of throwing casts
- Error handling technote: ban on throwing from `defer` and `deinit()`