### PR TITLE
Locale model cleanup

### DIFF
--- a/modules/internal/localeModels/knl/LocaleModel.chpl
+++ b/modules/internal/localeModels/knl/LocaleModel.chpl
@@ -315,14 +315,10 @@ module LocaleModel {
     proc addChild(loc:locale) { halt("Cannot add children to this locale type."); }
     proc getChild(idx:int) : locale { return nil; }
 
-    // This is commented out b/c it leads to an internal error during
-    // the resolveIntents pass.  See
-    // test/functions/iterators/sungeun/iterInClass.future
-    //
-    // iter getChildren() : locale {
-    //  halt("No children to iterate over.");
-    //  yield nil;
-    // }
+    iter getChildren() : locale {
+      halt("No children to iterate over.");
+      yield nil;
+    }
   }
 
   //

--- a/modules/internal/localeModels/numa/LocaleModel.chpl
+++ b/modules/internal/localeModels/numa/LocaleModel.chpl
@@ -85,14 +85,10 @@ module LocaleModel {
     proc addChild(loc:locale) { halt("Cannot add children to this locale type."); }
     proc getChild(idx:int) : locale { return nil; }
 
-    // This is commented out b/c it leads to an internal error during
-    // the resolveIntents pass.  See
-    // test/functions/iterators/sungeun/iterInClass.future
-    //
-    // iter getChildren() : locale {
-    //  halt("No children to iterate over.");
-    //  yield nil;
-    // }
+    iter getChildren() : locale {
+      halt("No children to iterate over.");
+      yield nil;
+    }
   }
 
   //

--- a/test/localeModels/numa/basics/bad_children.chpl
+++ b/test/localeModels/numa/basics/bad_children.chpl
@@ -1,0 +1,3 @@
+var myNumaDomain = (here:LocaleModel).getChild(0):NumaDomain;
+for child in myNumaDomain.getChildren() do
+  writeln(child);

--- a/test/localeModels/numa/basics/bad_children.good
+++ b/test/localeModels/numa/basics/bad_children.good
@@ -1,0 +1,1 @@
+bad_children.chpl:2: error: halt reached - No children to iterate over.


### PR DESCRIPTION
In the numa and knl locale models, `NumaDomain`'s `getChildren()` method was commented out while waiting on a future, `test/functions/iterators/sungeun/iterInClass`.  That test now passes, so this change uncomments the code and provides a test to verify it.

This closes issue #8508 .

Tested on the numa locale model on Mac, Linux, and Cray systems, with C and LLVM back ends.
Tested on the knl locale model on a KNL Cray system with the C back end.
(The LLVM back end has an unrelated problem on a KNL Cray system; see issue #8901 .)