### PR TITLE
Update SysError documentation

### DIFF
--- a/modules/standard/SysError.chpl
+++ b/modules/standard/SysError.chpl
@@ -27,9 +27,8 @@
 
    The IO module uses these routines in a way that supports error inspection
    and rapid prototyping. Most routines in the IO module have two forms.
-   In one form, an error (of type syserr) is returned in an out error argument.
-   In the second form, no error is returned, and instead the task will halt
-   with a fatal error if an error is encountered.
+   In one form, a :class:`SystemError` is thrown when an error occurs.
+   In the second form, a ``syserr`` is returned in an out error argument.
 
  */
 module SysError {
@@ -38,9 +37,9 @@ use SysBasic;
 
 /*
 
-   ``SystemError`` is a base class for ``Errors`` generated from ``syserr``.
-   It provides factory methods to create different subtypes based on the
-   ``syserr`` that is passed.
+   :class:`SystemError` is a base class for ``Errors`` generated from
+   ``syserr``. It provides factory methods to create different subtypes based
+   on the ``syserr`` that is passed.
 
 */
 class SystemError : Error {
@@ -53,7 +52,7 @@ class SystemError : Error {
   }
 
   /*
-     Provides a formatted string output for ``SystemError``, generated
+     Provides a formatted string output for :class:`SystemError`, generated
      from the internal ``err`` and the ``details`` string.
   */
   proc message() {
@@ -68,7 +67,7 @@ class SystemError : Error {
   }
 
   /*
-    Return the matching ``SystemError`` subtype for a given ``syserr``,
+    Return the matching :class:`SystemError` subtype for a given ``syserr``,
     with an optional string containing extra details.
 
     :arg err: the syserr to generate from
@@ -115,7 +114,7 @@ class SystemError : Error {
   }
 
   /*
-    Return the matching ``SystemError`` subtype for a given error number,
+    Return the matching :class:`SystemError` subtype for a given error number,
     with an optional string containing extra details.
 
     :arg err: the number to generate from
@@ -128,8 +127,8 @@ class SystemError : Error {
 
 /*
 
-   ``BlockingIOError`` is the subclass of ``SystemError`` corresponding to
-   :const:`SysBasic.EAGAIN`, :const:`SysBasic.EALREADY`,
+   :class:`BlockingIOError` is the subclass of :class:`SystemError`
+   corresponding to :const:`SysBasic.EAGAIN`, :const:`SysBasic.EALREADY`,
    :const:`SysBasic.EWOULDBLOCK`, and :const:`SysBasic.EINPROGRESS`.
 
 */
@@ -141,8 +140,8 @@ class BlockingIOError : SystemError {
 
 /*
 
-   ``ChildProcessError`` is the subclass of ``SystemError`` corresponding to
-   :const:`SysBasic.ECHILD`.
+   :class:`ChildProcessError` is the subclass of :class:`SystemError`
+   corresponding to :const:`SysBasic.ECHILD`.
 
 */
 class ChildProcessError : SystemError {
@@ -153,8 +152,8 @@ class ChildProcessError : SystemError {
 
 /*
 
-   ``ConnectionError`` is the subclass of ``SystemError`` that serves as the
-   base class for all system errors regarding connections.
+   :class:`ConnectionError` is the subclass of :class:`SystemError` that serves
+   as the base class for all system errors regarding connections.
 
 */
 class ConnectionError : SystemError {
@@ -165,8 +164,8 @@ class ConnectionError : SystemError {
 
 /*
 
-   ``BrokenPipeError`` is the subclass of ``ConnectionError`` corresponding
-   to :const:`SysBasic.EPIPE` and :const:`SysBasic.ESHUTDOWN`.
+   :class:`BrokenPipeError` is the subclass of :class:`ConnectionError`
+   corresponding to :const:`SysBasic.EPIPE` and :const:`SysBasic.ESHUTDOWN`.
 
 */
 class BrokenPipeError : ConnectionError {
@@ -177,7 +176,7 @@ class BrokenPipeError : ConnectionError {
 
 /*
 
-   ``ConnectionAbortedError`` is the subclass of ``ConnectionError``
+   :class:`ConnectionAbortedError` is the subclass of :class:`ConnectionError`
    corresponding to :const:`SysBasic.ECONNABORTED`.
 
 */
@@ -189,7 +188,7 @@ class ConnectionAbortedError : ConnectionError {
 
 /*
 
-   ``ConnectionRefusedError`` is the subclass of ``ConnectionError``
+   :class:`ConnectionRefusedError` is the subclass of :class:`ConnectionError`
    corresponding to :const:`SysBasic.ECONNREFUSED`.
 
 */
@@ -201,7 +200,7 @@ class ConnectionRefusedError : ConnectionError {
 
 /*
 
-   ``ConnectionResetError`` is the subclass of ``ConnectionError``
+   :class:`ConnectionResetError` is the subclass of :class:`ConnectionError`
    corresponding to :const:`SysBasic.ECONNRESET`.
 
 */
@@ -213,8 +212,8 @@ class ConnectionResetError : ConnectionError {
 
 /*
 
-   ``FileExistsError`` is the subclass of ``SystemError`` corresponding to
-   :const:`SysBasic.EEXIST`.
+   :class:`FileExistsError` is the subclass of :class:`SystemError`
+   corresponding to :const:`SysBasic.EEXIST`.
 
 */
 class FileExistsError : SystemError {
@@ -225,8 +224,8 @@ class FileExistsError : SystemError {
 
 /*
 
-   ``FileNotFoundError`` is the subclass of ``SystemError`` corresponding to
-   :const:`SysBasic.ENOENT`.
+   :class:`FileNotFoundError` is the subclass of :class:`SystemError`
+   corresponding to :const:`SysBasic.ENOENT`.
 
 */
 class FileNotFoundError : SystemError {
@@ -237,8 +236,8 @@ class FileNotFoundError : SystemError {
 
 /*
 
-   ``InterruptedError`` is the subclass of ``SystemError`` corresponding to
-   :const:`SysBasic.EINTR`.
+   :class:`InterruptedError` is the subclass of :class:`SystemError`
+   corresponding to :const:`SysBasic.EINTR`.
 
 */
 class InterruptedError : SystemError {
@@ -249,8 +248,8 @@ class InterruptedError : SystemError {
 
 /*
 
-   ``IsADirectoryError`` is the subclass of ``SystemError`` corresponding to
-   :const:`SysBasic.EISDIR`.
+   :class:`IsADirectoryError` is the subclass of :class:`SystemError`
+   corresponding to :const:`SysBasic.EISDIR`.
 
 */
 class IsADirectoryError : SystemError {
@@ -261,8 +260,8 @@ class IsADirectoryError : SystemError {
 
 /*
 
-   ``NotADirectoryError`` is the subclass of ``SystemError`` corresponding to
-   :const:`SysBasic.ENOTDIR`.
+   :class:`NotADirectoryError` is the subclass of :class:`SystemError`
+   corresponding to :const:`SysBasic.ENOTDIR`.
 
 */
 class NotADirectoryError : SystemError {
@@ -273,8 +272,8 @@ class NotADirectoryError : SystemError {
 
 /*
 
-   ``PermissionError`` is the subclass of ``SystemError`` corresponding to
-   :const:`SysBasic.EACCES` and :const:`SysBasic.EPERM`.
+   :class:`PermissionError` is the subclass of :class:`SystemError`
+   corresponding to :const:`SysBasic.EACCES` and :const:`SysBasic.EPERM`.
 
 */
 class PermissionError : SystemError {
@@ -285,8 +284,8 @@ class PermissionError : SystemError {
 
 /*
 
-   ``ProcessLookupError`` is the subclass of ``SystemError`` corresponding to
-   :const:`SysBasic.ESRCH`.
+   :class:`ProcessLookupError` is the subclass of :class:`SystemError`
+   corresponding to :const:`SysBasic.ESRCH`.
 
 */
 class ProcessLookupError : SystemError {
@@ -297,8 +296,8 @@ class ProcessLookupError : SystemError {
 
 /*
 
-   ``TimeoutError`` is the subclass of ``SystemError`` corresponding to
-   :const:`SysBasic.ETIMEDOUT`.
+   :class:`TimeoutError` is the subclass of :class:`SystemError` corresponding
+   to :const:`SysBasic.ETIMEDOUT`.
 
 */
 class TimeoutError : SystemError {
@@ -309,7 +308,7 @@ class TimeoutError : SystemError {
 
 /*
 
-   ``IOError`` is the subclass of ``SystemError`` that serves as the
+   :class:`IOError` is the subclass of :class:`SystemError` that serves as the
    base class for all errors regarding inputs and their formatting.
    They are typically not directly generated by the OS, but they are
    used and emitted by the IO module.
@@ -323,7 +322,7 @@ class IOError : SystemError {
 
 /*
 
-   ``EOFError`` is the subclass of ``SystemError`` corresponding to
+   :class:`EOFError` is the subclass of :class:`IOError` corresponding to
    :const:`SysBasic.EEOF`.
 
 */
@@ -335,8 +334,8 @@ class EOFError : IOError {
 
 /*
 
-   ``UnexpectedEOFError`` is the subclass of ``SystemError`` corresponding to
-   :const:`SysBasic.ESHORT`.
+   :class:`UnexpectedEOFError` is the subclass of :class:`IOError`
+   corresponding to :const:`SysBasic.ESHORT`.
 
 */
 class UnexpectedEOFError : IOError {
@@ -347,8 +346,8 @@ class UnexpectedEOFError : IOError {
 
 /*
 
-   ``BadFormatError`` is the subclass of ``SystemError`` corresponding to
-   :const:`SysBasic.EFORMAT`.
+   :class:`BadFormatError` is the subclass of :class:`IOError` corresponding
+   to :const:`SysBasic.EFORMAT`.
 
 */
 class BadFormatError : IOError {
@@ -384,28 +383,26 @@ private proc quote_string(s:string, len:ssize_t) {
   return new string(ret, owned=true, needToCopy=false);
 }
 
-/* Halt with a useful message if there was an error. Do nothing if the error
-   argument does not indicate an error occurred. The error message printed
-   when halting will describe the error passed and msg will be appended to it.
+/* Throw a :class:`SystemError` if an error occurred, formatting a useful
+   message based on the provided arguments. Do nothing if the error argument
+   does not indicate an error occurred.
 
-   :arg error: the error object
-   :arg msg: extra information to print after the error description
+   :arg error: the error code
+   :arg msg: extra information to include in the thrown error
+   :arg path: a path to include in the thrown error
+   :arg offset: an offset to include in the thrown error
  */
-proc ioerror(error:syserr, msg:string) throws
+proc ioerror(error:syserr, msg:string, path:string, offset:int(64)) throws
 {
-  if error then throw SystemError.fromSyserr(error, msg);
+  if error {
+    const quotedpath = quote_string(path, path.length:ssize_t);
+    var   details    = msg + " with path " + quotedpath +
+                       " offset " + offset:string;
+    throw SystemError.fromSyserr(error, details);
+  }
 }
 
-/* Halt with a useful message if there was an error. Do nothing if the error
-   argument does not indicate an error occurred. The error message printed
-   when halting will describe the error passed and msg will be appended to it,
-   along with the path related to the error (for example, the path to a file
-   which could not be opened).
-
-   :arg error: the error object
-   :arg msg: extra information to print after the error description
-   :arg path: a path to print out that is related to the error
- */
+// documented in the offset version
 proc ioerror(error:syserr, msg:string, path:string) throws
 {
   if error {
@@ -415,34 +412,14 @@ proc ioerror(error:syserr, msg:string, path:string) throws
   }
 }
 
-/* Halt with a useful message if there was an error. Do nothing if the error
-   argument does not indicate an error occurred. The error message printed
-   when halting will describe the error passed and msg will be appended to it,
-   along with the path and file offset related to the error. For example, this
-   routine might indicate a file format error at a particular location.
-
-   :arg error: the error object
-   :arg msg: extra information to print after the error description
-   :arg path: a path to print out that is related to the error
-   :arg offset: an offset to print out that is related to the error
- */
-proc ioerror(error:syserr, msg:string, path:string, offset:int(64)) throws
+// documented in the offset version
+proc ioerror(error:syserr, msg:string) throws
 {
-  if error {
-    const quotedpath = quote_string(path, path.length:ssize_t);
-    var   details    = msg + " with path " + quotedpath + " offset " + offset:string;
-    throw SystemError.fromSyserr(error, details);
-  }
+  if error then throw SystemError.fromSyserr(error, msg);
 }
 
-/* Halt with a useful message. Instead of an error argument, this routine takes
-   in an error string to report.
-   The error message printed when halting will describe the error passed and
-   msg will be appended to it, along with the path and file offset related to
-   the error. For example, this routine might indicate a file format error at a
-   particular location.
-
-   This routine .
+/* Throw an :class:`IOError` and include a formatted message based on the
+   provided arguments.
 
    :arg errstr: the error string
    :arg msg: extra information to print after the error description
@@ -452,12 +429,12 @@ proc ioerror(error:syserr, msg:string, path:string, offset:int(64)) throws
 proc ioerror(errstr:string, msg:string, path:string, offset:int(64)) throws
 {
   const quotedpath = quote_string(path, path.length:ssize_t);
-  const details    = errstr + " " + msg + " with path " + quotedpath + " offset " + offset:string;
+  const details    = errstr + " " + msg + " with path " + quotedpath +
+                     " offset " + offset:string;
   throw SystemError.fromSyserr(EIO:syserr, details);
 }
 
-/* Convert a syserr error code to a human-readable string describing that
-   error.
+/* Convert a syserr code to a human-readable string describing the error.
 
    :arg errstr: the error string
    :returns: a string describing the error

--- a/modules/standard/SysError.chpl
+++ b/modules/standard/SysError.chpl
@@ -436,7 +436,7 @@ proc ioerror(errstr:string, msg:string, path:string, offset:int(64)) throws
 
 /* Convert a syserr code to a human-readable string describing the error.
 
-   :arg errstr: the error string
+   :arg error: the error code
    :returns: a string describing the error
  */
 proc errorToString(error:syserr):string

--- a/modules/standard/SysError.chpl
+++ b/modules/standard/SysError.chpl
@@ -37,9 +37,9 @@ use SysBasic;
 
 /*
 
-   :class:`SystemError` is a base class for ``Errors`` generated from
-   ``syserr``. It provides factory methods to create different subtypes based
-   on the ``syserr`` that is passed.
+   :class:`SystemError` is a base class for :class:`ChapelError.Error` s
+   generated from ``syserr``. It provides factory methods to create different
+   subtypes based on the ``syserr`` that is passed.
 
 */
 class SystemError : Error {


### PR DESCRIPTION
- Replace all references to `halt` with `throws`.
- Combine `ioerror()` documentation into a single block.
- Update all `class` names to linked references.
- Correct a few superclass references.

- [x] passes linux64+flat testing