### PR TITLE
Fix handling of compopts/execopts in start_test

### DIFF
--- a/util/start_test
+++ b/util/start_test
@@ -632,6 +632,13 @@ def check_environment_with_args():
             .format(getpass.getuser(), tgt_platform))
 
 
+# Strip quotes that might have been added by preprocess_options()
+def strip_preprocessing(arg):
+    if arg.startswith("'") and arg.endswith("'"):
+        return arg[1:-1]
+    else:
+        return arg
+
 def set_up_environment():
     # pre-
     if args.preexec:
@@ -640,16 +647,16 @@ def set_up_environment():
     if args.prediff:
         os.environ["CHPL_SYSTEM_PREDIFF"] = args.prediff
 
-    # compopts
+    # compopts (note that we have to strip out our preprocessing)
     if args.compopts:
-        args.compopts = [x[1:-1] for x in args.compopts]
+        args.compopts = [strip_preprocessing(x) for x in args.compopts]
         args.compopts = "--cc-warnings " + " ".join(args.compopts)
     else:
         args.compopts = "--cc-warnings"
 
-    # execopts
+    # execopts (note that we have to strip out our preprocessing)
     if args.execopts:
-        args.execopts = [x[1:-1] for x in args.execopts]
+        args.execopts = [strip_preprocessing(x) for x in args.execopts]
         args.execopts = " ".join(args.execopts)
     else:
         args.execopts = ""
@@ -1416,6 +1423,10 @@ def parser_setup():
     return parser
 
 
+# argparse interprets anything that starts with a `--` as an option, so
+# something like `--compopts --fast` would get interpreted as two options. Here
+# we preprocess to turn that into `--compopts '--fast'` (note that we'll have
+# to remove the quotes later)
 def preprocess_options():
     index = 0
     for arg in sys.argv:
@@ -1423,7 +1434,6 @@ def preprocess_options():
         if arg in ["-compopts", "--compopts", "-execopts", "--execopts"]:
             escape_next_argument(sys.argv, index)
         index += 1
-
 
 def escape_next_argument(args, index):
     next = args[index + 1].strip()

--- a/util/start_test
+++ b/util/start_test
@@ -1276,6 +1276,10 @@ def parser_setup():
     # executing options
     parser.add_argument("-execopts", "--execopts", action="append", 
             dest="execopts", help="set options for executing tests")
+    # lame hack to prevent abbreviations from not getting preprocessed in
+    # preprocess_options() (makes things like --execop ambiguous)
+    parser.add_argument("-execopts ", "--execopts ", action="append",
+            dest="execopts", help=argparse.SUPPRESS)
     # compiler
     parser.add_argument("-compiler", "--compiler", action="store",
             dest="compiler", help=help_all("set alternate compiler"))
@@ -1286,6 +1290,10 @@ def parser_setup():
     # compiler options
     parser.add_argument("-compopts", "--compopts", action="append",
             dest="compopts", help="set options for the compiler")
+    # lame hack to prevent abbreviations from not getting preprocessed in
+    # preprocess_options() (makes things like --compop ambiguous)
+    parser.add_argument("-compopts ", "--compopts ", action="append",
+            dest="compopts", help=argparse.SUPPRESS)
     # log_file
     parser.add_argument("-logfile", "--logfile", action="store",
             dest="log_file", help="set alternate log file")

--- a/util/start_test
+++ b/util/start_test
@@ -1444,10 +1444,11 @@ def preprocess_options():
         index += 1
 
 def escape_next_argument(args, index):
-    next = args[index + 1].strip()
-    if next and next[0] == "-": # single argument, not escaped
-        args[index + 1] = "'{0}'".format(next)
-    print(args)
+    if index + 1 < len(args):
+        next = args[index + 1].strip()
+        if next and next[0] == "-": # single argument, not escaped
+            args[index + 1] = "'{0}'".format(next)
+        print(args)
 
 
 # UTILITY ROUTINES AND CLASSES


### PR DESCRIPTION
Fix how we preprocess and fixup --compopts= and --execopts= arguments to
start_test. We convert things like `--compopts --fast` to `--compopts '--fast'`
so that argparse doesn't interpret `--fast` as an option to start_test and we
later strip the leading and trailing characters to remove the quotes. However,
we were removing the leading and trailing characters even when we didn't add
quotes for things like `--compopts=fast`. Correct that by only stripping the
leading and trailing characters if they were quotes.

Also prevent abbreviations for `--compopts` and `--execopts`. argparse allows
abbreviations for non-ambiguous options, but abbreviations for `--compopts` and
`--execopts` breaks the preprocessing that we do. Instead of trying to handle
abbreviations, just prevent them for compopts/execopts

This resolves https://github.com/chapel-lang/chapel/issues/4949