### PR TITLE
Spec and documentation updates

### DIFF
--- a/doc/rst/technotes/extern.rst
+++ b/doc/rst/technotes/extern.rst
@@ -683,15 +683,18 @@ it in inline assembly.
 --------
 
 The extern block functionality allows simple #defines to be used from Chapel
-code. Simple defines take no arguments and define an integer value or use
-another #define. For example:
+code. Simple defines take no arguments and define an integer, string, or
+real value or use another #define that does so. Simple casts are also
+supported, as are macros that are simply an alternative name for another
+C variable. For example:
 
 .. code-block:: chapel
 
   extern {
    #define NEG_ONE (-1)
-   #define MY_NUMBER (NEG_ONE)
+   #define MY_NUMBER ((unsigned int)NEG_ONE)
   }
+  writeln(NEG_ONE);
   writeln(MY_NUMBER);
 
 However, it is easy to create #defines that are not supported because the

--- a/doc/rst/technotes/extern.rst
+++ b/doc/rst/technotes/extern.rst
@@ -682,11 +682,11 @@ it in inline assembly.
 #defines
 --------
 
-The extern block functionality allows simple #defines to be used from Chapel
-code. Simple defines take no arguments and define an integer, string, or
-real value or use another #define that does so. Simple casts are also
-supported, as are macros that are simply an alternative name for another
-C variable. For example:
+The extern block functionality allows simple #defines to be used from
+Chapel code. Simple defines take no arguments and define an integer,
+string, or real value or use another #define that does so. Casts to
+built-in numeric types are also supported, as are macros that are simply
+an alternative name for another C variable. For example:
 
 .. code-block:: chapel
 

--- a/modules/packages/OwnedObject.chpl
+++ b/modules/packages/OwnedObject.chpl
@@ -20,34 +20,75 @@
 
 /*
 
-   :record:`Owned` (along with :record:`~SharedObject.Shared`) manage the deallocation
-   of a class instance. :record:`Owned` is meant to be used when only
-   one reference to an object needs to manage that object's storage.
+   :record:`Owned` (along with :record:`~SharedObject.Shared`) manage the
+   deallocation of a class instance. :record:`Owned` is meant to be used when
+   only one reference to an object needs to manage that object's storage.
 
-   To use :record:`Owned`, allocate a class instance following this
-   pattern:
+   To use :record:`Owned`, store a new class instance in a new Owned
+   record as is shown in this example:
 
    .. code-block:: chapel
 
-     var myOwnedObject = new Owned(new MyClass(...));
+     use OwnedObject;
+     class MyClass { }
+
+     var myOwnedObject = new Owned(new MyClass());
 
    When myOwnedObject goes out of scope, the class instance
    it refers to will be deleted.
 
-   It is an error to copy initialize from myOwnedObject or to assign
-   it to another :record:`Owned`.
+   Copy initializing from ``myOwnedObject`` or assigning it to another
+   :record:`Owned` will leave ``myOwnedObject`` storing a nil value
+   and transfer the owned class instance to the other value.
+
+   .. code-block:: chapel
+
+     var otherOwnedObject = myOwnedObject;
+     // now myOwnedObject stores nil
+     // the value it stored earlier has moved to otherOwnedObject
+
+     myOwnedObject = otherOwnedObject;
+     // this assignment moves the value from the right-hand-side
+     // to the left-hand-side, leaving the right-hand-side empty.
+     // after the assignment, otherOwnedObject stores nil
+     // and myOwnedObject stores a value that will be deleted
+     // when myOwnedObject goes out of scope.
+
+   The compiler includes support for introducing automatic coercions
+   from :record:`Owned` to the contained class type. For example:
+
+   .. code-block:: chapel
+
+
+     proc f(arg:MyClass) {
+       writeln(arg);
+     }
+
+     var myOwned = new Owned(new MyClass());
+     f(myOwned); // compiler coerces to MyClass via borrow()
+
+   Additionally, the compiler includes support for coercing a value
+   of type ``Owned(T)`` to ``Owned(U)`` when ``T`` is a subclass of ``U``.
+   For example:
+
+   .. code-block:: chapel
+
+     class Person { }
+     class Student : Person { }
+
+     var myStudent = new Owned(new Student());
+     var myPerson:Owned(Person) = myStudent;
+     // relies on coercion from Owned(Student) to Owned(Person)
+     // moves the instance from myStudent to myPerson, leaving
+     // myStudent containing nil.
 
    .. note::
 
      The ways in which :record:`Owned` may be used are currently limited.
      Copy-initialization, assignment, and `in` intent are expected to work.
-     However, it is an error to use a :record:`Owned` in a way that causes the
-     compiler to add an implicitly copy, such as by returning a :record:`Owned`
-     that was passed by reference.
-
-   .. note::
-
-     :record:`Owned` arguments with `const in` intent do not work yet.
+     However, it is currently an error to use a :record:`Owned` in a way that
+     causes the compiler to add an implicitly copy, such as by returning a
+     :record:`Owned` that was passed by reference.
 
  */
 module OwnedObject {
@@ -130,7 +171,7 @@ module OwnedObject {
        Change the instance managed by this class to `newPtr`.
        If this record was already managing a non-nil instance,
        that instance will be deleted.
-     */ 
+     */
     proc ref retain(newPtr:p.type) {
       var oldPtr = p;
       p = newPtr;

--- a/modules/packages/SharedObject.chpl
+++ b/modules/packages/SharedObject.chpl
@@ -19,10 +19,10 @@
 
 /*
 
-   :record:`Shared` (along with :record:`~OwnedObject.Owned`) manage the deallocation
-   of a class instance. :record:`Shared` is meant to be used when many
-   different references will exist to the object and these references
-   need to keep the object alive.
+   :record:`Shared` (along with :record:`~OwnedObject.Owned`) manage the
+   deallocation of a class instance. :record:`Shared` is meant to be used when
+   many different references will exist to the object and these references need
+   to keep the object alive.
 
    To use :record:`Shared`, allocate a class instance following this
    pattern:
@@ -48,6 +48,11 @@
        // now mySharedObject is deinitialized, but the MyClass
        // instance is not deleted until globalSharedObject is deinitialized.
      }
+
+   :record:`Shared` supports coercions to the class type as well as
+   coercions from a ``Shared(T)`` to ``Shared(U)`` where ``T`` is a
+   subclass of ``U``. See :record:`~OwnedObject.Owned` for examples
+   of these coercions.
 
  */
 module SharedObject {

--- a/spec/Conversions.tex
+++ b/spec/Conversions.tex
@@ -42,11 +42,11 @@ An implicit conversion occurs at each of the following program locations:
       occur for param arguments~(\rsec{Formal_Parameter_Arguments})
       with a specified type.
 
-% MPF: I don't see how this rule can be type correct
-%      and it also doesn't seem to be implemented right now
-%\item The formal argument of a function call is converted
-%      to the type of the corresponding actual argument, if the formal's
-%      intent is \chpl{out}.
+% MPF: This rule doesn't seem to be implemented right now,
+%      but rather reflects ideal language design.
+\item The formal argument of a function call is converted
+      to the type of the corresponding actual argument, if the formal's
+      intent is \chpl{out}.
 
 \item The return or yield expression within a function without a \chpl{ref}
       return intent is converted to the return type of that function.

--- a/spec/Conversions.tex
+++ b/spec/Conversions.tex
@@ -23,6 +23,10 @@ Each location determines the target type.
 The source and target types of an implicit conversion must be allowed.
 They determine whether and how the expression's value changes.
 
+Implicit conversions are not applied when initializing \chpl{ref} or
+\chpl{type} values or for actual arguments passed to \chpl{ref} or
+\chpl{type} formal arguments.
+
 \index{conversions!implicit!occurs at}
 An implicit conversion occurs at each of the following program locations:
 
@@ -33,20 +37,15 @@ An implicit conversion occurs at each of the following program locations:
 
 \item The actual argument of a function call or an operator is converted
       to the type of the corresponding formal argument, if the formal's
-      intent is \chpl{in} or \chpl{const in} or an abstract intent
+      intent is \chpl{param}, \chpl{in}, \chpl{const in}, or an abstract intent
       (\rsec{Abstract_Intents}) with the semantics of
-      \chpl{in} or \chpl{const in}. This conversion does not occur
-      for \chpl{type} arguments~(\rsec{Formal_Type_Arguments} even
-      if they specify a concrete type. It does not occur for generic
-      arguments~(\rsec{Generic_Functions}). It does
-      occur for param arguments~(\rsec{Formal_Parameter_Arguments})
-      with a specified type.
+      \chpl{in} or \chpl{const in}.
 
 % MPF: This rule doesn't seem to be implemented right now,
 %      but rather reflects ideal language design.
-\item The formal argument of a function call is converted
-      to the type of the corresponding actual argument, if the formal's
-      intent is \chpl{out}.
+\item If the formal argument's intent is \chpl{out}, the formal argument
+      is converted to the type of the corresponding actual argument
+      upon function return.
 
 \item The return or yield expression within a function without a \chpl{ref}
       return intent is converted to the return type of that function.

--- a/spec/Conversions.tex
+++ b/spec/Conversions.tex
@@ -35,11 +35,18 @@ An implicit conversion occurs at each of the following program locations:
       to the type of the corresponding formal argument, if the formal's
       intent is \chpl{in} or \chpl{const in} or an abstract intent
       (\rsec{Abstract Intents}) with the semantics of
-      \chpl{in} or \chpl{const in}.
+      \chpl{in} or \chpl{const in}. This conversion does not occur
+      for \chpl{type} arguments~(\rsec{Formal_Type_Arguments} even
+      if they specify a concrete type. It does not occur for generic
+      arguments~(\rsec{Generic_Functions}). It does
+      occur for param arguments~(\rsec{Formal_Parameter_Arguments})
+      with a specified type.
 
-\item The formal argument of a function call is converted
-      to the type of the corresponding actual argument, if the formal's
-      intent is \chpl{out}.
+% MPF: I don't see how this rule can be type correct
+%      and it also doesn't seem to be implemented right now
+%\item The formal argument of a function call is converted
+%      to the type of the corresponding actual argument, if the formal's
+%      intent is \chpl{out}.
 
 \item The return or yield expression within a function without a \chpl{ref}
       return intent is converted to the return type of that function.

--- a/spec/Conversions.tex
+++ b/spec/Conversions.tex
@@ -34,7 +34,7 @@ An implicit conversion occurs at each of the following program locations:
 \item The actual argument of a function call or an operator is converted
       to the type of the corresponding formal argument, if the formal's
       intent is \chpl{in} or \chpl{const in} or an abstract intent
-      (\rsec{Abstract Intents}) with the semantics of
+      (\rsec{Abstract_Intents}) with the semantics of
       \chpl{in} or \chpl{const in}. This conversion does not occur
       for \chpl{type} arguments~(\rsec{Formal_Type_Arguments} even
       if they specify a concrete type. It does not occur for generic

--- a/spec/Procedures.tex
+++ b/spec/Procedures.tex
@@ -509,7 +509,41 @@ local changes affect the actual? & no  & on return & on return & immediately & N
 \index{intents!abstract}
 
 The abstract intents are \chpl{const} and the \emph{default intent}
-(when no intent is specified).
+(when no intent is specified). The following table summarizes what
+these abstract intents mean for each type:
+
+\begin{center}
+\begin{tabular}[c]{|l|l|l|l|}
+\hline
+               & meaning of     &  maning of        & \\
+  type           & const intent &  default intent   &  notes \\
+\hline
+\hline
+  \chpl{bool}    & \chpl{const in}  & \chpl{const in}  & \\
+  \chpl{int}     & \chpl{const in}  & \chpl{const in}  & \\
+  \chpl{uint}    & \chpl{const in}  & \chpl{const in}  & \\
+  \chpl{real}    & \chpl{const in}  & \chpl{const in}  & \\
+  \chpl{imag}    & \chpl{const in}  & \chpl{const in}  & \\
+  \chpl{complex} & \chpl{const in}  & \chpl{const in}  & \\
+  \chpl{range}   & \chpl{const in}  & \chpl{const in}  & \\
+  \chpl{class}   & \chpl{const in}  & \chpl{const in} & \\
+\hline
+  \chpl{atomic}  & \chpl{const ref} & \chpl{ref} & \\
+  \chpl{single}  & \chpl{const ref} & \chpl{ref} & \\
+  \chpl{sync}    & \chpl{const ref} & \chpl{ref} & \\
+\hline
+  \chpl{string}  & \chpl{const ref} & \chpl{const ref} & \\
+  \chpl{record}  & \chpl{const ref} & \chpl{const ref}
+  & for \chpl{this}, see \rsec{The_Default_Intent} \\
+  \chpl{union}   & \chpl{const ref} & \chpl{const ref} & \\
+  \chpl{dmap}    & \chpl{const ref} & \chpl{const ref} & \\
+  \chpl{domain}  & \chpl{const ref} & \chpl{const ref} & \\
+array          & \chpl{const ref} & \chpl{ref} / \chpl{const ref}
+  & see \rsec{The_Default_Intent} \\
+\hline
+\end{tabular}
+\end{center}
+
 
 \subsubsection{The Const Intent}
 \label{The_Const_Intent}
@@ -521,36 +555,9 @@ yet leaves unspecified whether the actual argument will be passed
 by \chpl{const in} or \chpl{const ref} intent.  In general, small
 values, such as scalar types, will be passed by \chpl{const in}; while
 larger values, such as domains and arrays, will be passed
-by \chpl{const ref} intent. Each type has a default \chpl{const} intent,
-according to the following table:
+by \chpl{const ref} intent.  The table in \rsec{Abstract_Intents} lists
+the meaning of the const intent for each type.
 
-\begin{center}
-\begin{tabular}[c]{|l|c|}
-\hline
-     & meaning \\
-type & of \chpl{const} \\
-\hline
-\hline
-\chpl{bool}    & \chpl{const in}  \\
-\chpl{int}     & \chpl{const in}  \\
-\chpl{uint}    & \chpl{const in}  \\
-\chpl{real}    & \chpl{const in}  \\
-\chpl{imag}    & \chpl{const in}  \\
-\chpl{complex} & \chpl{const in}  \\
-\chpl{range}   & \chpl{const in}  \\
-\chpl{string}  & \chpl{const ref} \\
-\chpl{sync}    & \chpl{const ref} \\
-\chpl{single}  & \chpl{const ref} \\
-\chpl{atomic}  & \chpl{const in}  \\
-\chpl{record}  & \chpl{const ref} \\
-\chpl{class}   & \chpl{const in}  \\
-\chpl{union}   & \chpl{const in}  \\
-\chpl{dmap}    & \chpl{const ref} \\
-\chpl{domain}  & \chpl{const ref} \\
-array          & \chpl{const ref} \\
-\hline
-\end{tabular}
-\end{center}
 
 \subsubsection{The Default Intent}
 \label{The_Default_Intent}
@@ -558,44 +565,20 @@ array          & \chpl{const ref} \\
 
 When no intent is specified for a formal argument, the \emph{default
 intent} is applied.  It is designed to take the most natural/least
-surprising action for the argument, based on its type.  The following
-table shows how default intents are interpreted based on the argument's
-type:
+surprising action for the argument, based on its type.  The table
+in \rsec{Abstract_Intents} lists the meaning of the default intent
+for each type.
 
-\begin{center}
-\begin{tabular}[c]{|l|c|}
-\hline
-     & meaning of \\
-type & default intent \\
-\hline
-\hline
-\chpl{bool}    & \chpl{const} \\
-\chpl{int}     & \chpl{const} \\
-\chpl{uint}    & \chpl{const} \\
-\chpl{real}    & \chpl{const} \\
-\chpl{imag}    & \chpl{const} \\
-\chpl{complex} & \chpl{const} \\
-\chpl{range}   & \chpl{const} \\
-\chpl{string}  & \chpl{const} \\
-\chpl{sync}    & \chpl{ref}   \\
-\chpl{single}  & \chpl{ref}   \\
-\chpl{atomic}  & \chpl{ref}   \\
-\chpl{record}  & \chpl{const} (but see below) \\
-\chpl{class}   & \chpl{const} \\
-\chpl{union}   & \chpl{const} \\
-\chpl{dmap}    & \chpl{const} \\
-\chpl{domain}  & \chpl{const} \\
-array          & \chpl{ref} / \chpl{const ref} \\
-\hline
-\end{tabular}
-\end{center}
+The default intent for arrays and for a \chpl{this} argument of record
+type~(see \rsec{Method_receiver_and_this}) is \chpl{ref} or \chpl{const
+ref}. Note that neither of these cause an array or record to be copied by
+default.
 
-The default intent for arrays is \chpl{ref} or \chpl{const ref} - meaning
-that the array is not copied by default. The compiler will choose
-\chpl{ref} or \chpl{const ref} based upon whether or not the formal
-argument is modified inside of the function. The choice between
-\chpl{ref} and \chpl{const ref} is similar to and interacts with
-return intent overloads (see \rsec{Return_Intent_Overloads}).
+In these cases, the compiler will choose \chpl{ref} or \chpl{const ref}
+based upon whether or not the formal argument is modified inside of the
+function.  The choice between \chpl{ref} and \chpl{const ref} is similar
+to and interacts with return intent overloads (see
+\rsec{Return_Intent_Overloads}).
 
 \begin{openissue}
 How tuples should be handled under default intents is an open issue;

--- a/spec/Procedures.tex
+++ b/spec/Procedures.tex
@@ -505,7 +505,7 @@ local changes affect the actual? & no  & on return & on return & immediately & N
 
 
 \subsection{Abstract Intents}
-\label{Abstract Intents}
+\label{Abstract_Intents}
 \index{intents!abstract}
 
 The abstract intents are \chpl{const} and the \emph{default intent}

--- a/spec/Procedures.tex
+++ b/spec/Procedures.tex
@@ -509,37 +509,42 @@ local changes affect the actual? & no  & on return & on return & immediately & N
 \index{intents!abstract}
 
 The abstract intents are \chpl{const} and the \emph{default intent}
-(when no intent is specified). The following table summarizes what
-these abstract intents mean for each type:
+(when no intent is specified).
+
+
+\subsubsection{Abstract Intents Table}
+\label{Abstract_Intents_Table}
+
+The following table summarizes what these abstract intents mean for each type:
 
 \begin{center}
 \begin{tabular}[c]{|l|l|l|l|}
 \hline
-               & meaning of     &  maning of        & \\
-  type           & const intent &  default intent   &  notes \\
+                 & meaning of          &  meaning of        & \\
+  type           & \chpl{const} intent &  default intent    &  notes \\
 \hline
 \hline
-  \chpl{bool}    & \chpl{const in}  & \chpl{const in}  & \\
-  \chpl{int}     & \chpl{const in}  & \chpl{const in}  & \\
-  \chpl{uint}    & \chpl{const in}  & \chpl{const in}  & \\
-  \chpl{real}    & \chpl{const in}  & \chpl{const in}  & \\
-  \chpl{imag}    & \chpl{const in}  & \chpl{const in}  & \\
-  \chpl{complex} & \chpl{const in}  & \chpl{const in}  & \\
-  \chpl{range}   & \chpl{const in}  & \chpl{const in}  & \\
-  \chpl{class}   & \chpl{const in}  & \chpl{const in} & \\
+  \chpl{bool}    & \chpl{const in}     & \chpl{const in}  & \\
+  \chpl{int}     & \chpl{const in}     & \chpl{const in}  & \\
+  \chpl{uint}    & \chpl{const in}     & \chpl{const in}  & \\
+  \chpl{real}    & \chpl{const in}     & \chpl{const in}  & \\
+  \chpl{imag}    & \chpl{const in}     & \chpl{const in}  & \\
+  \chpl{complex} & \chpl{const in}     & \chpl{const in}  & \\
+  \chpl{range}   & \chpl{const in}     & \chpl{const in}  & \\
+  \chpl{class}   & \chpl{const in}     & \chpl{const in} & \\
 \hline
-  \chpl{atomic}  & \chpl{const ref} & \chpl{ref} & \\
-  \chpl{single}  & \chpl{const ref} & \chpl{ref} & \\
-  \chpl{sync}    & \chpl{const ref} & \chpl{ref} & \\
+  \chpl{atomic}  & \chpl{const ref}    & \chpl{ref} & \\
+  \chpl{single}  & \chpl{const ref}    & \chpl{ref} & \\
+  \chpl{sync}    & \chpl{const ref}    & \chpl{ref} & \\
 \hline
-  \chpl{string}  & \chpl{const ref} & \chpl{const ref} & \\
-  \chpl{record}  & \chpl{const ref} & \chpl{const ref}
-  & for \chpl{this}, see \rsec{The_Default_Intent} \\
-  \chpl{union}   & \chpl{const ref} & \chpl{const ref} & \\
-  \chpl{dmap}    & \chpl{const ref} & \chpl{const ref} & \\
-  \chpl{domain}  & \chpl{const ref} & \chpl{const ref} & \\
-array          & \chpl{const ref} & \chpl{ref} / \chpl{const ref}
-  & see \rsec{The_Default_Intent} \\
+  \chpl{string}  & \chpl{const ref}    & \chpl{const ref} & \\
+  \chpl{record}  & \chpl{const ref}    & \chpl{const ref}
+   & for \chpl{this}, see \hyperref[The_Default_Intent]{"The Default Intent"} \\
+  \chpl{union}   & \chpl{const ref}    & \chpl{const ref} & \\
+  \chpl{dmap}    & \chpl{const ref}    & \chpl{const ref} & \\
+  \chpl{domain}  & \chpl{const ref}    & \chpl{const ref} & \\
+  array          & \chpl{const ref}    & \chpl{ref} / \chpl{const ref}
+   & see \hyperref[The_Default_Intent]{"The Default Intent"} \\
 \hline
 \end{tabular}
 \end{center}
@@ -550,13 +555,13 @@ array          & \chpl{const ref} & \chpl{ref} / \chpl{const ref}
 \index{intents!const@\chpl{const}}
 
 The \chpl{const} intent specifies the intention that the function will
-not and cannot modify the formal argument within its dynamic scope,
-yet leaves unspecified whether the actual argument will be passed
-by \chpl{const in} or \chpl{const ref} intent.  In general, small
-values, such as scalar types, will be passed by \chpl{const in}; while
-larger values, such as domains and arrays, will be passed
-by \chpl{const ref} intent.  The table in \rsec{Abstract_Intents} lists
-the meaning of the const intent for each type.
+not and cannot modify the formal argument within its dynamic scope.
+Whether the actual argument will be passed by \chpl{const in} or
+\chpl{const ref} intent depends on its type.  In general, small values,
+such as scalar types, will be passed by \chpl{const in}; while larger
+values, such as domains and arrays, will be passed by \chpl{const ref}
+intent.  The \hyperref[Abstract_Intents_Table]{table} earlier in this
+sub-section lists the meaning of the const intent for each type.
 
 
 \subsubsection{The Default Intent}
@@ -565,20 +570,18 @@ the meaning of the const intent for each type.
 
 When no intent is specified for a formal argument, the \emph{default
 intent} is applied.  It is designed to take the most natural/least
-surprising action for the argument, based on its type.  The table
-in \rsec{Abstract_Intents} lists the meaning of the default intent
-for each type.
+surprising action for the argument, based on its type. The
+\hyperref[Abstract_Intents_Table]{table}
+earlier in this sub-section lists the meaning of the default
+intent for each type.
 
 The default intent for arrays and for a \chpl{this} argument of record
 type~(see \rsec{Method_receiver_and_this}) is \chpl{ref} or \chpl{const
-ref}. Note that neither of these cause an array or record to be copied by
-default.
-
-In these cases, the compiler will choose \chpl{ref} or \chpl{const ref}
-based upon whether or not the formal argument is modified inside of the
-function.  The choice between \chpl{ref} and \chpl{const ref} is similar
-to and interacts with return intent overloads (see
-\rsec{Return_Intent_Overloads}).
+ref}. It is \chpl{ref} if the formal argument is modified inside the
+function, otherwise it is \chpl{const ref}.  Note that neither of these
+cause an array or record to be copied by default.  The choice between
+\chpl{ref} and \chpl{const ref} is similar to and interacts with return
+intent overloads (see \rsec{Return_Intent_Overloads}).
 
 \begin{openissue}
 How tuples should be handled under default intents is an open issue;

--- a/spec/Procedures.tex
+++ b/spec/Procedures.tex
@@ -521,24 +521,9 @@ yet leaves unspecified whether the actual argument will be passed
 by \chpl{const in} or \chpl{const ref} intent.  In general, small
 values, such as scalar types, will be passed by \chpl{const in}; while
 larger values, such as domains and arrays, will be passed
-by \chpl{const ref} intent.  At present, the decision between the two
-mechanisms is implementation-defined.  If a user's function is
-sensitive to which mechanism is used, they should use the desired
-concrete intent to guarantee portability.
+by \chpl{const ref} intent. Each type has a default \chpl{const} intent,
+according to the following table:
 
-\begin{openissue}
-It remains an open issue whether the choice between \chpl{const in}
-and \chpl{const ref} should be defined by the language, either for
-certain types or for all of them.  One area of active debate is
-whether the implementation can choose between \chpl{const in}
-and \chpl{const ref} for records based on size.  Another open issue is
-how tuples should be handled with respect to \chpl{const} intents.
-\end{openissue}
-
-\begin{craychapel}
-The current implementation uses the following mapping:
-% TODO: does this really need to be about the "current implementation"?
-% Couldn't it just be about "the current language"?
 \begin{center}
 \begin{tabular}[c]{|l|c|}
 \hline
@@ -566,10 +551,6 @@ array          & \chpl{const ref} \\
 \hline
 \end{tabular}
 \end{center}
-
-\end{craychapel}
-
-
 
 \subsubsection{The Default Intent}
 \label{The_Default_Intent}
@@ -621,11 +602,6 @@ How tuples should be handled under default intents is an open issue;
 particularly for heterogeneous tuples whose components would fall into
 separate categories in the table above.  One proposed approach is to
 apply the default intent to each component of the tuple independently.
-
-Another open issue arises if the meaning of the \chpl{const} intent is
-not defined by the language completely. If so, should the meaning of
-the default intent have that same flexibility? In particular, should the
-default intent for records mean \chpl{const} or \chpl{const in}?
 \end{openissue}
 
 

--- a/spec/Procedures.tex
+++ b/spec/Procedures.tex
@@ -537,7 +537,8 @@ how tuples should be handled with respect to \chpl{const} intents.
 
 \begin{craychapel}
 The current implementation uses the following mapping:
-
+% TODO: does this really need to be about the "current implementation"?
+% Couldn't it just be about "the current language"?
 \begin{center}
 \begin{tabular}[c]{|l|c|}
 \hline
@@ -551,6 +552,7 @@ type & of \chpl{const} \\
 \chpl{real}    & \chpl{const in}  \\
 \chpl{imag}    & \chpl{const in}  \\
 \chpl{complex} & \chpl{const in}  \\
+\chpl{range}   & \chpl{const in}  \\
 \chpl{string}  & \chpl{const ref} \\
 \chpl{sync}    & \chpl{const ref} \\
 \chpl{single}  & \chpl{const ref} \\
@@ -592,6 +594,7 @@ type & default intent \\
 \chpl{real}    & \chpl{const} \\
 \chpl{imag}    & \chpl{const} \\
 \chpl{complex} & \chpl{const} \\
+\chpl{range}   & \chpl{const} \\
 \chpl{string}  & \chpl{const} \\
 \chpl{sync}    & \chpl{ref}   \\
 \chpl{single}  & \chpl{ref}   \\


### PR DESCRIPTION
See individual commits, but this PR combines documentation improvements.

* describe #define improvements for extern blocks
* describe coercion for Owned/Shared
* improve spec description of coercions for argument passing
* significantly rework and improve spec description of default, const intents

- [x] full local testing

Reviewed by @vasslitvinov and @daviditen - thanks!