### PR TITLE
tidy URLs in spec

### DIFF
--- a/spec/Data_Parallelism.tex
+++ b/spec/Data_Parallelism.tex
@@ -82,9 +82,13 @@ is \emph{leading} the execution of the loop, as is the mapping of
 iterations to tasks.
 
 This concept will be formalized in future drafts of the Chapel
-specification; for now, please refer
-to \chpl{CHPL_HOME/examples/primers/parIters.chpl} for a brief
-introduction or to \emph{User-Defined Parallel Zippered Iterators in
+specification. For now, the primer on parallel iterators
+in the online documentation provides a brief introduction:
+\\ %formatting
+\mbox{$$ $$ $$ $$ $$} %indent
+\url{https://chapel-lang.org/docs/primers/parIters.html}
+\\
+Please also refer to \emph{User-Defined Parallel Zippered Iterators in
 Chapel}, published in the PGAS 2011 workshop.
 
 Control continues with the statement following the forall loop only
@@ -272,7 +276,7 @@ under \emph{Technical Notes}
 in Cray Chapel online documentation here:
 \\ %formatting
 \mbox{$$ $$ $$} %indent
-\url{https://chapel-lang.org/docs/latest/}
+\url{https://chapel-lang.org/docs/technotes/reduceIntents.html}
 \end{craychapel}
 
 

--- a/spec/Domain_Maps.tex
+++ b/spec/Domain_Maps.tex
@@ -39,7 +39,7 @@ in Cray Chapel online documentation here:
 \\ %formatting
 \mbox{$$ $$ $$} %indent
 % Should this be "craychapel"?
-\url{https://chapel-lang.org/docs/latest/}
+\url{https://chapel-lang.org/docs/modules/layoutdist.html}
 
 \item specification of user-defined domain maps is forthcoming;
 please refer to the \emph{Domain Map Standard Interface} page
@@ -48,7 +48,7 @@ in Cray Chapel online documentation here:
 \\ %formatting
 \mbox{$$ $$ $$} %indent
 % Should this be "craychapel"?
-\url{https://chapel-lang.org/docs/latest/}
+\url{https://chapel-lang.org/docs/technotes/dsi.html}
 
 \end{itemize}
 
@@ -113,11 +113,12 @@ var MyBlockDist: dmap(Block(rank=2));
 \end{chapel}
 declares a variable capable of storing dmap values
 for a two-dimensional Block distribution.
-The Block distribution is described in more detail here:
+The Block distribution is described in more detail
+in the standard library documentation. See:
 \\ %formatting
 \mbox{$$ $$ $$} %indent
 % Should this be "craychapel"?
-\url{https://chapel-lang.org/docs/latest/}
+\url{https://chapel-lang.org/docs/modules/dists/BlockDist.html}
 \end{example}
 
 \begin{example}

--- a/spec/Input_and_Output.tex
+++ b/spec/Input_and_Output.tex
@@ -7,7 +7,12 @@
 
 Chapel includes an extensive library for input and output that is
 documented in the standard library documentation. See
-\url{https://chapel-lang.org/docs/latest/modules/standard/IO.html}
+\\ %formatting
+\mbox{$$ $$ $$ $$ $$} %indent
+\url{https://chapel-lang.org/docs/modules/standard/IO.html}
+\\
 and
-\url{https://chapel-lang.org/docs/latest/builtins/internal/ChapelIO.html}.
+\\ %formatting
+\mbox{$$ $$ $$ $$ $$} %indent
+\url{https://chapel-lang.org/docs/builtins/internal/ChapelIO.html}.
 

--- a/spec/Types.tex
+++ b/spec/Types.tex
@@ -195,7 +195,7 @@ The standard \chpl{Math} module provides some functions on
 complex types. See
 \\ %formatting
 \mbox{$$ $$ $$ $$ $$} %indent
-\url{https://chapel-lang.org/docs/latest/modules/standard/Math.html}
+\url{https://chapel-lang.org/docs/modules/standard/Math.html}
 
 \begin{example}
 Given a complex number \chpl{c} with the value \chpl{3.14+2.72i}, the


### PR DESCRIPTION
* remove `latest` from paths
* point to specific pages instead of to the doc root
* uniform formatting
* click on each link in the document to verify that it works