### PR TITLE
Strengthen reduce intents in the spec

### DIFF
--- a/doc/rst/technotes/reduceIntents.rst
+++ b/doc/rst/technotes/reduceIntents.rst
@@ -11,7 +11,7 @@ Note: this is work in progress and is subject to change.
 Overview
 --------
 
-Reduce intents are a kind of forall intent - see Section 25.3
+Reduce intents are a kind of forall intent - see Section 26.3
 "Forall Intents" of the Chapel Language Specification.
 
 As with any forall intent, a reduce intent can be specified on any

--- a/spec/Data_Parallelism.tex
+++ b/spec/Data_Parallelism.tex
@@ -251,8 +251,8 @@ to the corresponding formal argument of the task function
 or the leader iterator.
 
 Each formal argument of a task function or iterator has the default
-intent by default.  For variables of primitive, enum, class, record
-and union types, this has the effect of capturing the value of the
+intent by default.  For variables of primitive, enum, and class
+types, this has the effect of capturing the value of the
 variable at task creation time.  Within the lexical scope of the
 forall statement or expression, the variable name references the
 captured value instead of the original value.
@@ -264,23 +264,20 @@ the body of the forall loop to modify the corresponding original
 variable or to read its updated value after concurrent modifications.
 The \chpl{in} intent is a way to obtain task-private variables
 in a forall loop.
+A \chpl{reduce} intent can be used to reduce values across iterations
+of a forall or coforall loop.
+Reduce intents are described in the \emph{Reduce Intents} technical note
+in the online documentation:
+\\ %formatting
+\mbox{$$ $$ $$} %indent
+\url{https://chapel-lang.org/docs/technotes/reduceIntents.html}
 
 \begin{rationale}
 A forall statement or expression may create tasks in its implementation.
 Forall intents affect those tasks in the same way that task intents
+\rsec{Task_Intents}
 affect the behavior of a task construct such as a \chpl{coforall} loop.
 \end{rationale}
-
-\begin{craychapel}
-To reduce values across iterations of a forall or coforall loop,
-"reduce" intents can be used.
-They are described in the \emph{Reduce Intents} page
-under \emph{Technical Notes}
-in Cray Chapel online documentation here:
-\\ %formatting
-\mbox{$$ $$ $$} %indent
-\url{https://chapel-lang.org/docs/technotes/reduceIntents.html}
-\end{craychapel}
 
 
 \section{Promotion}

--- a/spec/Task_Parallelism_and_Synchronization.tex
+++ b/spec/Task_Parallelism_and_Synchronization.tex
@@ -867,6 +867,13 @@ task-intent-list:
 
 where the following intents can be used as a \sntx{formal-intent}:
 \chpl{ref}, \chpl{in}, \chpl{const}, \chpl{const in}, \chpl{const ref}.
+In addition, \chpl{reduce} intents are allowed.
+They are similar to reduce forall intents \rsec{Forall_Intents}
+as described in the \emph{Reduce Intents} technical note
+in the online documentation:
+\\ %formatting
+\mbox{$$ $$ $$} %indent
+\url{https://chapel-lang.org/docs/technotes/reduceIntents.html}
 
 % TODO for task intents:
 % * Introduce a 'task-formal-intent' syntactic rule
@@ -888,8 +895,6 @@ subject to such treatment within nested task constructs, if any.
 
 
 \begin{rationale}
-% Ideally, replace "task intents" throughout the foregoing
-% with a more appropriate name for this feature.
 The primary motivation for task intents is to avoid some races on
 scalar/record variables, which are possible when one task modifies a
 variable and another task reads it. Without task intents,


### PR DESCRIPTION
* As forall intents, move from "craychapel" to may body of the spec.
* Add them as task intents, as well. For now, simply point to forall intents+tech note.
* Adjust the section number in the tech note.
* Remove records from capture-able values upon the default intent.

Reduce intents are close to being ready for first-class representation in the spec. A couple of things to finalize:

* The shadow variable represents the accumulation state in the loop body, right?
* How to allow a reduce op value to be specified for the intent, instead of the reduce class.
* How to handle the case where the input/output/state types are different. Ex. how the type inference should work; how to accumulate/account for the initial value of the outer variable, how much guiding input should the user provide.
* UDRI