### PR TITLE
Specify a type in DefaultAssociative as a workaround

### DIFF
--- a/modules/internal/DefaultAssociative.chpl
+++ b/modules/internal/DefaultAssociative.chpl
@@ -64,7 +64,7 @@ module DefaultAssociative {
     var numEntries: atomic_int64;
     var tableLock: atomicbool; // do not access directly, use function below
     var tableSizeNum = 1;
-    var tableSize = chpl__primes(tableSizeNum);
+    var tableSize:int = chpl__primes(tableSizeNum);
     var tableDom = {0..tableSize-1};
     var table: [tableDom] chpl_TableEntry(idxType);
   


### PR DESCRIPTION
Issue #8131 describes a problem with function resolution.
This change is a simple workaround for that particular issue
and takes the form of specifying DefaultAssociative's
field tableSize as :int rather than letting the compiler infer it.

- [x] full local testing
- [x] baseline testing
- [x] --no-local testing
- [x] --verify testing
- [x] GASNet testing

Reviewed by @benharsh - thanks!