### PR TITLE
Remove this.complete() calls from LCALS

### DIFF
--- a/test/release/examples/benchmarks/lcals/LCALSDataTypes.chpl
+++ b/test/release/examples/benchmarks/lcals/LCALSDataTypes.chpl
@@ -80,9 +80,7 @@ module LCALSDataTypes {
     var loop_chksum: [loop_length_dom] real;
 
     proc init() {
-      this.complete();
-      for i in loop_length_dom do
-        loop_run_time[i] = new vector(real);
+      loop_run_time = for i in loop_length_dom do new vector(real);
     }
 
     proc deinit() {
@@ -122,7 +120,6 @@ module LCALSDataTypes {
     var n_real_zones: int;
 
     proc init(ilen: LoopLength, ndims: int) {
-      this.complete();
       var rzmax: int;
       this.ndims = ndims;
       NPNL = 2;
@@ -181,7 +178,7 @@ module LCALSDataTypes {
       lpz = lrn;
 
       zoneDom = {0..#nnalls};
-      for i in 0..#nnalls do real_zones[i] = -1;
+      real_zones = -1;
 
       n_real_zones = 0;
 

--- a/test/release/examples/benchmarks/lcals/Timer.chpl
+++ b/test/release/examples/benchmarks/lcals/Timer.chpl
@@ -73,7 +73,6 @@ module Timer {
     var was_run: bool;
 
     proc init(timerType: TimerType = defaultTimerType) {
-      this.complete();
       if timerType == TimerType.Chapel {
         t = new ChapelTimer();
       } else if timerType == TimerType.Clock then {


### PR DESCRIPTION
While reviewing how our examples/ directory had changed between
releases, in general and w.r.t. gaterhing release-over-release
timings, it seemed like some cases of this.complete() would not be
necessary with minor adjustements to the initializers (with the goal
of making the initializers simpler, avoiding re-initialization, and
making the code backwards compatible with 1.16.  LCALS seems to
have been a pretty easy change.