### PR TITLE
Remove this.complete() calls from binary trees

### DIFF
--- a/test/release/examples/benchmarks/shootout/binarytrees.chpl
+++ b/test/release/examples/benchmarks/shootout/binarytrees.chpl
@@ -71,7 +71,6 @@ class Tree {
   // A Tree-building initializer
   //
   proc init(depth) {
-    this.complete();
     if depth > 0 {
       left  = new Tree(depth-1);
       right = new Tree(depth-1);

--- a/test/studies/shootout/binary-trees/binarytrees-blc.chpl
+++ b/test/studies/shootout/binary-trees/binarytrees-blc.chpl
@@ -77,7 +77,6 @@ class Tree {
   // A Tree-building initializer
   //
   proc init(depth) {
-    this.complete();
     if depth > 0 {
       left  = new Tree(depth-1);
       right = new Tree(depth-1);


### PR DESCRIPTION
With Lydia's improvement to support for control flow in initializers,
these binary trees versions no longer require this.complete() calls,
so removing them for efficiency and cleanliness.