### PR TITLE
Minor touch-ups to primer examples w.r.t. initializers

### DIFF
--- a/test/release/examples/primers/errorHandling.chpl
+++ b/test/release/examples/primers/errorHandling.chpl
@@ -60,8 +60,10 @@ try {
   types, developers can also create their own hierarchies.
  */
 
-pragma "use default init"
-class EmptyFilenameError : Error { }
+class EmptyFilenameError : Error {
+  proc init() {
+  }
+}
 
 proc checkFilename(f_name: string) throws {
   if f_name.isEmptyString() then

--- a/test/release/examples/primers/learnChapelInYMinutes.chpl
+++ b/test/release/examples/primers/learnChapelInYMinutes.chpl
@@ -881,9 +881,7 @@ class GenericClass {
             type classType = other.classType) {
     this.classType = classType;
     this.classDomain = other.classDomain;
-    this.complete();
-    // Copy and cast
-    for idx in this.classDomain do this[idx] = other[idx] : classType;
+    this.classArray = for o in other do o: classType;  // copy and cast
   }
 
 // Define bracket notation on a GenericClass


### PR DESCRIPTION
* added explicit initializer to errorHandling.chpl primer to avoid
  use of pragma "use default init" (when adding it, I'd hoped that
  it would no longer be necessary by now)

* Rewrote copy initializer in learnChapelInYMinutes to make it
  phase 1 only (arguably unnecessary, but seemed "simpler"?)