### PR TITLE
Add util/chpl-completion.bash to gen_release

### DIFF
--- a/util/buildRelease/gen_release
+++ b/util/buildRelease/gen_release
@@ -118,6 +118,7 @@ if (exists($ENV{"CHPL_GEN_RELEASE_NO_CLONE"})) {
        "util/README",
        "util/build_configs.py",
        "util/buildRelease/install.sh",
+       "util/chpl-completion.bash",
        "util/printchplenv",
        "util/setchplenv.bash",
        "util/setchplenv.csh",


### PR DESCRIPTION
Added util/chpl-completion.bash to the list of files gen_release should
include.  Tested by running gen_release and unpacking the result to verify that
it included util/chpl-completion.bash.