### PR TITLE
Optional command line parameters for easy_install and pip install, in Makefiles

### DIFF
--- a/third-party/chpl-venv/Makefile
+++ b/third-party/chpl-venv/Makefile
@@ -46,7 +46,7 @@ $(CHPL_VENV_INSTALL_DIR):
 # Install virtualenv program.
 $(CHPL_VENV_VIRTUALENV): $(CHPL_VENV_INSTALL_DIR) check-exes
 	export PYTHONPATH=$(CHPL_VENV_INSTALL_DIR):$$PYTHONPATH && \
-	$(EASY_INSTALL) --install-dir=$(CHPL_VENV_INSTALL_DIR) $(shell cat virtualenv.txt)
+	$(EASY_INSTALL) --install-dir=$(CHPL_VENV_INSTALL_DIR) $(CHPL_EASY_INSTALL_PARAMS) $(shell cat virtualenv.txt)
 
 # Phony convenience target for installing virtualenv.
 virtualenv: $(CHPL_VENV_VIRTUALENV)
@@ -74,7 +74,7 @@ $(CHPL_VENV_TEST_REQS): $(CHPL_VENV_VIRTUALENV_DIR)
 	export PATH=$(CHPL_VENV_VIRTUALENV_BIN):$$PATH && \
 	export VIRTUAL_ENV=$(CHPL_VENV_VIRTUALENV_DIR) && \
 	python $(CHPL_VENV_VIRTUALENV_BIN)/pip install \
-	-U --force-reinstall -r test-requirements.txt && \
+	-U --force-reinstall $(CHPL_PIP_INSTALL_PARAMS) -r test-requirements.txt && \
 	$(CHPL_VENV_VIRTUALENV) --relocatable $(CHPL_VENV_VIRTUALENV_DIR) && \
 	touch $(CHPL_VENV_TEST_REQS)
 
@@ -82,14 +82,14 @@ $(CHPL_VENV_SPHINX_BUILD): $(CHPL_VENV_VIRTUALENV_DIR)
 	export PATH=$(CHPL_VENV_VIRTUALENV_BIN):$$PATH && \
 	export VIRTUAL_ENV=$(CHPL_VENV_VIRTUALENV_DIR) && \
 	python $(CHPL_VENV_VIRTUALENV_BIN)/pip install \
-	-U --force-reinstall -r chpldoc-requirements.txt && \
+	-U --force-reinstall $(CHPL_PIP_INSTALL_PARAMS) -r chpldoc-requirements.txt && \
 	$(CHPL_VENV_VIRTUALENV) --relocatable $(CHPL_VENV_VIRTUALENV_DIR)
 
 $(CHPL_VENV_CHPLSPELL_REQS): $(CHPL_VENV_VIRTUALENV_DIR)
 	export PATH=$(CHPL_VENV_VIRTUALENV_BIN):$$PATH && \
 	export VIRTUAL_ENV=$(CHPL_VENV_VIRTUALENV_DIR) && \
 	python $(CHPL_VENV_VIRTUALENV_BIN)/pip install \
-	-U --force-reinstall -r chplspell-requirements.txt && \
+	-U --force-reinstall $(CHPL_PIP_INSTALL_PARAMS) -r chplspell-requirements.txt && \
 	$(CHPL_VENV_VIRTUALENV) --relocatable $(CHPL_VENV_VIRTUALENV_DIR) && \
 	touch $(CHPL_VENV_CHPLSPELL_REQS)
 

--- a/tools/c2chapel/Makefile
+++ b/tools/c2chapel/Makefile
@@ -74,8 +74,8 @@ c2chapel: venv
 
 	$(VIRTUAL_ENV) $(VENV_DIR)
 	. $(VENV_DIR)/bin/activate && \
-	  pip install $(INSTALL)/$(TAR) && \
-	  pip install argparse
+	  python $(VENV_DIR)/bin/pip install $(INSTALL)/$(TAR) && \
+	  python $(VENV_DIR)/bin/pip install $(CHPL_PIP_INSTALL_PARAMS) argparse
 
 check:
 	cd test && ./tester.sh


### PR DESCRIPTION
Optional env variables CHPL_EASY_INSTALL_PARAMS and CHPL_PIP_INSTALL_PARAMS
are added to easy_install and pip install command lines in the Make
rules for "make test-venv" and similar.
    
This facilitates using a local PyPI mirror or cache, as workaround
for PyPI's rejecting https connections from clients built with older
versions of OpenSSL. On our SLES-11 machines, for example.
    
From PyPI website:
    In preparation for our CDN provider deprecating TLSv1.0 and TLSv1.1
    protocols, we have begun rolling brownouts for these protocols for
    the first ten (10) minutes of each hour.
