### PR TITLE
Tidy up mason new package name checking

### DIFF
--- a/test/mason/existingdir/README
+++ b/test/mason/existingdir/README
@@ -1,0 +1,2 @@
+This file exists so the directory is not empty.
+The directory exists for use in tests. 

--- a/test/mason/masonNewBadName.0bad.good
+++ b/test/mason/masonNewBadName.0bad.good
@@ -1,0 +1,1 @@
+Bad package name '0bad' - only Chapel identifiers are legal package names

--- a/test/mason/masonNewBadName.bad-name.good
+++ b/test/mason/masonNewBadName.bad-name.good
@@ -1,0 +1,1 @@
+Bad package name 'bad-name' - only Chapel identifiers are legal package names

--- a/test/mason/masonNewBadName.bad.name.good
+++ b/test/mason/masonNewBadName.bad.name.good
@@ -1,0 +1,1 @@
+Bad package name 'bad.name' - only Chapel identifiers are legal package names

--- a/test/mason/masonNewBadName.badstuff.good
+++ b/test/mason/masonNewBadName.badstuff.good
@@ -1,0 +1,1 @@
+Bad package name 'bad$tuff' - $ is not allowed in package names

--- a/test/mason/masonNewBadName.chpl
+++ b/test/mason/masonNewBadName.chpl
@@ -1,0 +1,11 @@
+
+use MasonUtils;
+use FileSystem;
+use MasonNew;
+
+config const name="";
+
+proc main() {
+  const args = ['mason', 'new', name];
+  masonNew(args);
+}

--- a/test/mason/masonNewBadName.compopts
+++ b/test/mason/masonNewBadName.compopts
@@ -1,0 +1,1 @@
+-M ../../tools/mason/

--- a/test/mason/masonNewBadName.empty.good
+++ b/test/mason/masonNewBadName.empty.good
@@ -1,0 +1,1 @@
+<command-line arg>:1: error: Configuration variable 'name' is missing its initialization value

--- a/test/mason/masonNewBadName.execopts
+++ b/test/mason/masonNewBadName.execopts
@@ -1,0 +1,6 @@
+--name ''          # masonNewBadName.empty.good
+--name=0bad        # masonNewBadName.0bad.good
+--name='bad$tuff'  # masonNewBadName.badstuff.good
+--name=bad-name    # masonNewBadName.bad-name.good
+--name=bad.name    # masonNewBadName.bad.name.good
+--name=existingdir # masonNewBadName.existingdir.good

--- a/test/mason/masonNewBadName.existingdir.good
+++ b/test/mason/masonNewBadName.existingdir.good
@@ -1,0 +1,1 @@
+A directory named 'existingdir' already exists

--- a/tools/mason/MasonNew.chpl
+++ b/tools/mason/MasonNew.chpl
@@ -29,17 +29,13 @@ use MasonEnv;
 
 proc masonNew(args) {
   if args.size < 3 {
-      writeln('error: Invalid arguments.');
-      masonNewHelp();
-      exit();
-    }
-  else if isDir(args[2]) {
-    writeln('A directory with that name already exists');
-  }
-  else {
+    writeln('error: Invalid arguments.');
+    masonNewHelp();
+    exit();
+  } else {
     var vcs = true;
     var show = false;
-    var name = 'MyPackage';
+    var name = '';
     for arg in args[2..] {
       if arg == '-h' || arg == '--help' {
         masonNewHelp();
@@ -55,12 +51,48 @@ proc masonNew(args) {
         name = arg;
       }
     }
-    InitProject(name, vcs, show);
+
+    if name == '' {
+      writeln("No package name specified");
+    } else if !isIdentifier(name) {
+      writeln("Bad package name '", name,
+               "' - only Chapel identifiers are legal package names");
+    } else if name.count("$") > 0 {
+      writeln("Bad package name '", name,
+              "' - $ is not allowed in package names");
+    } else if isDir(name) {
+      writeln("A directory named '", name, "' already exists");
+    } else {
+      InitProject(name, vcs, show);
+    }
   }
 }
 
+proc isIdentifier(name:string) {
 
+  // Identifiers can't be empty
+  if name == "" then
+    return false;
 
+  // Identifiers can't start with a digit or a $
+  if name[1].isDigit() then
+    return false;
+  if name[1] == "$" then
+    return false;
+
+  // Check all characters are legal identifier characters
+  // - lower case alphabetic
+  // - upper case alphabetic
+  // - digits
+  // - _
+  // - $
+  var ok = true;
+  for ch in name {
+    if !(ch == "$" || ch == "_" || ch.isAlnum()) then
+      ok = false;
+  }
+  return ok;
+}
 
 proc InitProject(name, vcs, show) {
   if vcs {

--- a/tools/mason/MasonNew.chpl
+++ b/tools/mason/MasonNew.chpl
@@ -68,6 +68,8 @@ proc masonNew(args) {
   }
 }
 
+/* Return 'true' for valid identifiers according to Chapel parser/spec,
+   otherwise 'false' */
 proc isIdentifier(name:string) {
 
   // Identifiers can't be empty


### PR DESCRIPTION
See also issue #7961.

This PR adjusts `mason new` to better check the name of the package. While there, it removes the default package name of `MyPackage` and tightens up the check for an existing directory.

Package names that aren't Chapel identifiers aren't allowed and neither are package names that contain `$` (which is legal in Chapel identifiers). The rationale for disallowing `$` in package names is that it won't go well when used from a shell.

- [x] full local testing

Reviewed by @ben-albrecht - thanks!