### PR TITLE
no-doc auto destroy workaround in Owned

### DIFF
--- a/modules/packages/OwnedObject.chpl
+++ b/modules/packages/OwnedObject.chpl
@@ -230,6 +230,7 @@ module OwnedObject {
   }
   // This is a workaround - compiler was resolving
   // chpl__autoDestroy(x:object) from internal coercions.
+  pragma "no doc"
   proc chpl__autoDestroy(x: Owned) {
     __primitive("call destructor", x);
   }


### PR DESCRIPTION
Just removes the chpl__autoDestroy proc in Owned from the docs.

Trivial and not reviewed.

- [x] full local testing