### PR TITLE
compiling.rst: s/tab autocomplete/tab complete/

### DIFF
--- a/doc/rst/usingchapel/compiling.rst
+++ b/doc/rst/usingchapel/compiling.rst
@@ -84,13 +84,13 @@ Flags                   Description
 =====================   ======================================================
 
 
-----------------------------
-Tab Autocompletion for Flags
-----------------------------
+------------------------
+Tab Completion for Flags
+------------------------
 
 Bash users can source the script ``$CHPL_HOME/util/chpl-completion.bash`` to
-enable tab-autocompletion for chpl options.  After sourcing the
-chpl-completion.bash script tab autocompletion can be used:
+enable tab-completion for chpl options.  After sourcing the
+chpl-completion.bash script tab completion can be used:
 
   .. code-block:: sh
 
@@ -103,7 +103,7 @@ Will print the options that start with "--ca".
      --cache-remote --cast-checks
 
 Adding one more letter to differentiate and pressing tab again will
-autocomplete the option and add a space, ready for the next option.
+auto-complete the option and add a space, ready for the next option.
 
   .. code-block:: sh
 


### PR DESCRIPTION
The bash man page refers to "completion" and "programmable completion", not "autocompletion".  A few quick google searches greatly favor "completion".  The use of "autocompletion" to describe the feature seems mostly to be in stackoverflow questions.

(The LDP page on the subject uses "auto-complete" in one case to refer to the action taken by the shell in response to the user pressing tab, so I've left the corresponding use in compiling.rst like that.)