### PR TITLE
Fix mason testing sed issue

### DIFF
--- a/test/mason/filterCurrentVersion
+++ b/test/mason/filterCurrentVersion
@@ -3,7 +3,7 @@
 outputfile=$2
 compiler=$3
 
-curver=`$compiler --version | head -1 | sed -E 's/chpl version ([0-9]\.[0-9][0-9]*\.[0-9][0-9]*).*/\1/'`
+curver=`$compiler --version | head -1 | sed 's/chpl version \([0-9]\.[0-9][0-9]*\.[0-9][0-9]*\).*/\1/'`
 curver=`echo $curver | sed 's/\./\\\./g'`
 
 sed "s/$curver/CHPL_CUR_FULL/g" $outputfile > $outputfile.tmp


### PR DESCRIPTION
This pattern is simple enough that we can rely on basic sed regex, and avoid dealing with "-E" support.

Testing ``test/mason/``:

| | 1.17 | 1.18 |
|--|--|--|
| OS X | ✅  |  ✅ |
| SLES 12 | ✅  | ✅  |
| SLES 11(?) | ✅ | ✅  |