### PR TITLE
 Remove runtime type from 'this' type argument of chpl__deserialize

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -7463,7 +7463,9 @@ static bool resolveSerializeDeserialize(AggregateType* at) {
       propagateNotPOD(at);
     }
 
-    if (isPrimitiveType(retType) == false && autoDestroyMap.get(retType) == NULL) {
+    if (isPrimitiveType(retType) == false &&
+        (autoDestroyMap.get(retType) == NULL ||
+         isClass(retType))) {
       USR_FATAL_CONT(serializeFn, "chpl__serialize must return a type that can be automatically memory managed (e.g. a record)");
       serializeFn = NULL;
     } else {

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -173,6 +173,7 @@ static void resolveNew(CallExpr* call);
 static void temporaryInitializerFixup(CallExpr* call);
 static void resolveCoerce(CallExpr* call);
 static void resolveGenericActuals(CallExpr* call);
+static void resolveAutoCopyEtc(AggregateType* at);
 
 static Expr* foldTryCond(Expr* expr);
 
@@ -7456,6 +7457,12 @@ static bool resolveSerializeDeserialize(AggregateType* at) {
       USR_FATAL(serializeFn, "chpl__serialize cannot return void");
     }
 
+    // Make sure we have resolved autocopy / autodestroy etc
+    if (AggregateType* at = toAggregateType(retType)) {
+      resolveAutoCopyEtc(at);
+      propagateNotPOD(at);
+    }
+
     if (isPrimitiveType(retType) == false && autoDestroyMap.get(retType) == NULL) {
       USR_FATAL_CONT(serializeFn, "chpl__serialize must return a type that can be automatically memory managed (e.g. a record)");
       serializeFn = NULL;
@@ -7561,7 +7568,6 @@ static void resolveSerializers() {
 *                                                                             *
 ************************************** | *************************************/
 
-static void        resolveAutoCopyEtc(AggregateType* at);
 static const char* autoCopyFnForType(AggregateType* at);
 static FnSymbol*   autoMemoryFunction(AggregateType* at, const char* fnName);
 


### PR DESCRIPTION
There are two problems with how serialize/deserialize in
remote value forwarding treated runtime types.

First, if the runtime type were actually used in the chpl__deserialize
method, it would cause GETs back to the data that was being serialized.
But in the case of a on+begin+in intent, that data might no longer
exist by the time the begin fires. Furthermore, these GETs would
probably be unexpected and surprising and they'd defeat the purpose
of serialize/deserialize.

Second, the treatment of runtime types within insertSerialization
significantly complicates the compiler code. In particular, it changes
when the argument is destroyed.

In order to avoid these problems, this commit replaces the runtime
type information with a dummy value that is never initialized.
If we add e.g. a PRIM_MEMSET, it could be 0-initialized. Alternatively,
insertSerialization could simply remove the `this` argument from
`chpl__deserialize` - since this happens after resolution that would
amount to removing the runtime component of the type. In any case
the point is that it should be an error to actually use a runtime
component of the `this` type argument to chpl__deserialize.

In order to work without using `this` at all, this commit also adjusts
domain serialization in ChapelArray to bundle up all of the relevant
pieces of information into a _serialized_domain record - including
param/type data. That allows a simple work-around for problems described
in issue #8543.  Additionally it allows the chpl__deserialize function to
be written without any mention whatsoever of the `this` type argument,
and so one can be more confident that the runtime type component of that
type argument is not being used.

To get the new pattern with _serialized_domain to work, additionally
it was important to resolve auto-copy/auto-destroy for types only
mentioned as the result of chpl__serialize.

- [x] passed full local testing, gasnet, future, no-local, baseline, verify

Reviewed by @benharsh - thanks!