### PR TITLE
Fix Shared output format, add casts for coercions

### DIFF
--- a/modules/packages/SharedObject.chpl
+++ b/modules/packages/SharedObject.chpl
@@ -242,4 +242,27 @@ module SharedObject {
   proc chpl__autoDestroy(x: Shared) {
     __primitive("call destructor", x);
   }
+
+  // Don't print out 'p' when printing an Shared, just print class pointer
+  pragma "no doc"
+  proc Shared.readWriteThis(f) {
+    f <~> this.p;
+  }
+
+  // Note, coercion from Shared -> Shared.t is directly
+  // supported in the compiler via a call to borrow().
+
+  // This cast supports coercion from Shared(SubClass) to Shared(ParentClass)
+  // (i.e. when class SubClass : ParentClass ).
+  // It only works in a value context (i.e. when the result of the
+  // coercion is a value, not a reference).
+  pragma "no doc"
+  inline proc _cast(type t, x) where t:Shared && x:Shared && x.t:t.t {
+    var ret:t; // default-init the Shared type to return
+    ret.p = x.p:t.t; // cast the class type
+    ret.pn = x.pn;
+    if ret.pn != nil then
+      ret.pn.retain();
+    return ret;
+  }
 }

--- a/test/classes/delete-free/coercions-covariant-in-const-in-shared.chpl
+++ b/test/classes/delete-free/coercions-covariant-in-const-in-shared.chpl
@@ -1,0 +1,33 @@
+use SharedObject;
+
+class MyClass {
+  var x:int;
+}
+
+class SubClass : MyClass {
+  var y:int;
+}
+
+
+proc acceptSharedMyClass4(const in arg:Shared(MyClass)) {
+  writeln(arg);
+}
+proc acceptSharedMyClass5(in arg:Shared(MyClass)) {
+  writeln(arg);
+}
+
+proc test4() {
+  var instance = new Shared(new SubClass(4,4));
+  acceptSharedMyClass4(instance);
+  writeln("still have ", instance);
+}
+
+proc test5() {
+  var instance = new Shared(new SubClass(5,5));
+  acceptSharedMyClass5(instance);
+  writeln("still have ", instance);
+}
+
+test4();
+test5();
+

--- a/test/classes/delete-free/coercions-covariant-in-const-in-shared.good
+++ b/test/classes/delete-free/coercions-covariant-in-const-in-shared.good
@@ -1,0 +1,4 @@
+{x = 4, y = 4}
+still have {x = 4, y = 4}
+{x = 5, y = 5}
+still have {x = 5, y = 5}


### PR DESCRIPTION
Adjusts Shared to not print out its internal representation.
Allows Shared to work with subtype coercions similarly to Owned. Adds a test to that effect.

- [x] passed full local testing

Reviewed by @daviditen - thanks!