### PR TITLE
Fix typo in sub_test comment on chapel testing valgrind environment variables

### DIFF
--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -30,7 +30,7 @@
 # CHPL_HOME: Grabbed from the environment or deduced based on the path to
 #    the compiler.
 # CHPL_TEST_VGRND_COMP: Use valgrind on the compiler
-# CHPL_TEST_VBRND_EXE: Use valgrind on the test program
+# CHPL_TEST_VGRND_EXE: Use valgrind on the test program
 # CHPL_VALGRIND_OPTS: Options to valgrind
 # CHPL_TEST_FUTURES: 2 == test futures only
 #                    1 == test futures and non-futures


### PR DESCRIPTION
CHPL_TEST_VGRND_EXE was accidentally CHPL_TEST_VBRND_EXE (note: B instead of G)

Testing
- [x] paratest
- [x] valgrind exec run on one test
- [x] valgrind run on one test