### PR TITLE
Pre-release prep. Chapel 1.17.0: post-release version markings

### DIFF
--- a/compiler/main/version.cpp
+++ b/compiler/main/version.cpp
@@ -35,7 +35,7 @@ void
 get_version(char *v) {
   v += sprintf(v, "%d.%s.%s", MAJOR_VERSION, MINOR_VERSION, UPDATE_VERSION);
   if (strcmp(BUILD_VERSION, "0") != 0 || developer)
-    sprintf(v, " pre-release (%s)", BUILD_VERSION);
+    sprintf(v, ".%s", BUILD_VERSION);   // post-release
 }
 
 void

--- a/doc/rst/conf.py
+++ b/doc/rst/conf.py
@@ -61,12 +61,12 @@ master_doc = 'index'
 # 'version' adds a redundant version number onto the top of the sidebar
 # automatically (rtd-theme). We also don't use |version| anywhere in rst
 
-chplversion = '1.17 pre-release'    # TODO -- parse from `chpl --version`
+chplversion = '1.17'                # post-release
 shortversion = chplversion.replace('-', '&#8209') # prevent line-break at hyphen
 html_context = {"chplversion":chplversion}
 
 # The full version, including alpha/beta/rc tags.
-release = '1.17.0 pre-release'
+release = '1.17.0'                  # post-release
 
 # General information about the project.
 project = u'Chapel Documentation'

--- a/doc/rst/usingchapel/QUICKSTART.rst
+++ b/doc/rst/usingchapel/QUICKSTART.rst
@@ -16,7 +16,7 @@ enable more features, such as distributed memory execution.
 0) See :ref:`prereqs.rst <readme-prereqs>` for more information about system
    tools and packages you may need to have installed to build and run Chapel.
 
-1) If you don't already have Chapel 1.16, see
+1) If you don't already have Chapel 1.17, see
    https://chapel-lang.org/download.html .
 
 2) If you are using a source release, build Chapel in a *quickstart*
@@ -28,14 +28,14 @@ enable more features, such as distributed memory execution.
 
       .. code-block:: bash
 
-         tar xzf chapel-1.16.0.tar.gz
+         tar xzf chapel-1.17.0.tar.gz
 
    b. Make sure that your shell is in the directory containing
       QUICKSTART.rst, for example:
 
       .. code-block:: bash
 
-         cd chapel-1.16.0
+         cd chapel-1.17.0
 
    c. Set up your environment for Chapel's Quickstart mode.
       If you are using a shell other than bash,

--- a/doc/rst/usingchapel/chplenv.rst
+++ b/doc/rst/usingchapel/chplenv.rst
@@ -33,7 +33,7 @@ CHPL_HOME
 
     .. code-block:: sh
 
-        export CHPL_HOME=~/chapel-1.16.0
+        export CHPL_HOME=~/chapel-1.17.0
 
    .. note::
      This, and all other examples in the Chapel documentation, assumes you're

--- a/doc/util/versionButton.php
+++ b/doc/util/versionButton.php
@@ -106,7 +106,7 @@ function dropSetup() {
   // Choose button color
   if (chplTitle.includes("pre-release")) {
     button.classList.add("preRelease");
-  } else if (chplTitle != chplVersions[1]) {
+  } else if (chplTitle != "1.17") {
     button.classList.add("oldVersion");
   } else {
     button.classList.add("currentVersion");

--- a/doc/util/versionButton.php
+++ b/doc/util/versionButton.php
@@ -84,7 +84,7 @@ var chplTitle = "<?php echo "$chplTitle";?>";
 
 // Note: assumes second element is most-recent release
 var chplVersions = [
-  "1.17 pre-release",
+  "1.17",   // post-release
   "1.16",
   "1.15",
   "1.14",

--- a/man/confchpl.rst
+++ b/man/confchpl.rst
@@ -1,5 +1,5 @@
 
-:Version: 1.17.0 pre-release
+:Version: 1.17.0
 :Manual section: 1
 :Title: \\fBchpl\\fP
 :Subtitle: Compiler for the Chapel Programming Language

--- a/man/confchpldoc.rst
+++ b/man/confchpldoc.rst
@@ -1,5 +1,5 @@
 
-:Version: 1.17.0 pre-release
+:Version: 1.17.0
 :Manual section: 1
 :Title: \\fBchpldoc\\fP
 :Subtitle: the Chapel Documentation Tool

--- a/test/compflags/bradc/printstuff/versionhelp.sh
+++ b/test/compflags/bradc/printstuff/versionhelp.sh
@@ -5,4 +5,4 @@ compiler=$3
 echo -n `basename $compiler`
 cat $CWD/version.goodstart
 diff $CWD/../../../../compiler/main/BUILD_VERSION $CWD/zero.txt > /dev/null 2>&1 && echo "" || \
-    { echo -n " pre-release (" && cat $CWD/../../../../compiler/main/BUILD_VERSION | tr -d \"\\n && echo ")" ; }
+    { echo -n "." && cat $CWD/../../../../compiler/main/BUILD_VERSION | tr -d \" ; }    # post-release


### PR DESCRIPTION
THIS IS NOT CHAPEL RELEASE 1.17.0

This change prepares the source on master branch for the upcoming
release, currently scheduled for 5 Apr 2018.

* remove all the "pre-release version" strings and labels on master branch
* bump any remaining 1.16 version numbers on master to 1.17.0

See #8979 

