### PR TITLE
Separate out the incorrect behavior from postInit/record-generic into own test

### DIFF
--- a/test/classes/initializers/postInit/record-generic-fails.bad
+++ b/test/classes/initializers/postInit/record-generic-fails.bad
@@ -1,0 +1,2 @@
+MyRec.init type
+(x = 0)

--- a/test/classes/initializers/postInit/record-generic-fails.chpl
+++ b/test/classes/initializers/postInit/record-generic-fails.chpl
@@ -1,0 +1,34 @@
+// Split out from record-generic.chpl to track the failure mode when
+// the instance is declared with only a type and no initial value
+
+// When postinit is no longer skipped for this case, it should be merged
+// back with record-generic.chpl
+
+record MyRec {
+  type t;
+  var  x : t;
+
+  proc init() {
+    this.t = int;
+    this.x = 10;
+
+    writeln('MyRec.init default');
+  }
+
+  proc init(type t) {
+    this.t = t;
+
+    writeln('MyRec.init type');
+  }
+
+  proc postinit() { // This gets skipped, but shouldn't
+    writeln('MyRec.postinit');
+    writeln();
+  }
+}
+
+proc main() {
+  var r1 : MyRec(int);
+
+  writeln(r1);
+}

--- a/test/classes/initializers/postInit/record-generic-fails.future
+++ b/test/classes/initializers/postInit/record-generic-fails.future
@@ -1,0 +1,2 @@
+bug: postinit skipped for generic records declared with only a type
+#9001

--- a/test/classes/initializers/postInit/record-generic-fails.good
+++ b/test/classes/initializers/postInit/record-generic-fails.good
@@ -1,0 +1,3 @@
+MyRec.init type
+MyRec.postinit
+(x = 0)

--- a/test/classes/initializers/postInit/record-generic.chpl
+++ b/test/classes/initializers/postInit/record-generic.chpl
@@ -44,13 +44,6 @@ record MyRec {
 
 
 proc main() {
-  var r1 : MyRec(int);
-
-  writeln(r1);
-  writeln();
-
-
-
   var r2 : MyRec(int) = new MyRec(20);
 
   writeln(r2);

--- a/test/classes/initializers/postInit/record-generic.good
+++ b/test/classes/initializers/postInit/record-generic.good
@@ -1,7 +1,4 @@
 MyRec.init type
-(x = 0)
-
-MyRec.init type
 MyRec.init value
 MyRec.postinit
 


### PR DESCRIPTION
Generic records are accidentally skipping the call to postinit when the instance
is declared with only its type (and no starting value).  Move the incorrect
behavior into a future file until it is fixed.