### PR TITLE
Prevent candidate filtering from resolving signatures of incompatible initializers

### DIFF
--- a/compiler/include/ResolutionCandidate.h
+++ b/compiler/include/ResolutionCandidate.h
@@ -63,7 +63,7 @@ private:
 
   void                      resolveTypedefedArgTypes();
 
-  bool                      checkResolveFormalsWhereClauses();
+  bool                      checkResolveFormalsWhereClauses(CallInfo& info);
 
   bool                      checkGenericFormals();
 

--- a/compiler/resolution/ResolutionCandidate.cpp
+++ b/compiler/resolution/ResolutionCandidate.cpp
@@ -521,7 +521,9 @@ static bool isCandidateInit(ResolutionCandidate* res, CallInfo& info) {
   AggregateType* ft = toAggregateType(res->fn->_this->getValType());
   AggregateType* at = toAggregateType(info.call->get(2)->getValType());
 
-  if (ft == at || ft->isInstantiatedFrom(at) == true) {
+  if (ft == at) {
+    retval = true;
+  } else if (ft->getRootInstantiation() == at->getRootInstantiation()) {
     retval = true;
   }
 
@@ -539,6 +541,8 @@ bool ResolutionCandidate::checkResolveFormalsWhereClauses(CallInfo& info) {
 
   // Exclude initializers on other types before we attempt to resolve the
   // signature.
+  //
+  // TODO: Expand this check for all methods
   if (fn->isInitializer() && isCandidateInit(this, info) == false) {
     return false;
   }

--- a/compiler/resolution/ResolutionCandidate.cpp
+++ b/compiler/resolution/ResolutionCandidate.cpp
@@ -72,7 +72,7 @@ bool ResolutionCandidate::isApplicableConcrete(CallInfo& info) {
         resolveTypeConstructor(info);
       }
 
-      retval = checkResolveFormalsWhereClauses();
+      retval = checkResolveFormalsWhereClauses(info);
     }
   }
 
@@ -515,14 +515,33 @@ static bool looksLikeCopyInit(ResolutionCandidate* rc) {
   return retval;
 }
 
+static bool isCandidateInit(ResolutionCandidate* res, CallInfo& info) {
+  bool retval = false;
+
+  AggregateType* ft = toAggregateType(res->fn->_this->getValType());
+  AggregateType* at = toAggregateType(info.call->get(2)->getValType());
+
+  if (ft == at || ft->isInstantiatedFrom(at) == true) {
+    retval = true;
+  }
+
+  return retval;
+}
+
 /************************************* | **************************************
 *                                                                             *
 *                                                                             *
 *                                                                             *
 ************************************** | *************************************/
 
-bool ResolutionCandidate::checkResolveFormalsWhereClauses() {
+bool ResolutionCandidate::checkResolveFormalsWhereClauses(CallInfo& info) {
   int coindex = -1;
+
+  // Exclude initializers on other types before we attempt to resolve the
+  // signature.
+  if (fn->isInitializer() && isCandidateInit(this, info) == false) {
+    return false;
+  }
 
   /*
    * A derived generic type will use the type of its parent,

--- a/test/classes/initializers/compilerGenerated/arrayOfOtherRecs-allDefault.future
+++ b/test/classes/initializers/compilerGenerated/arrayOfOtherRecs-allDefault.future
@@ -1,2 +1,0 @@
-bug: default initializers and records that store arrays of other records
-#8761

--- a/test/classes/initializers/records/arrayOfOtherRecs-implicitType.future
+++ b/test/classes/initializers/records/arrayOfOtherRecs-implicitType.future
@@ -1,2 +1,0 @@
-bug: initializers with default value on array argument with implicit type
-#8763


### PR DESCRIPTION
Our existing resolution infrastructure finds many visible methods named
'init' that we the attempt to filter for 'good' candidates. The majority
of these initializers are not for the type that we're trying to
initialize.

We can get into trouble if we attempt to resolve the signature of a
candidate initializer because that candidate may be in the middle of
being initialized. For example, consider the default initializer for a
record storing an array of another record type:

```chpl
record R {
  var x : [1..3] OtherRec;
}
proc R.init(x = {var temp : [1..3] OtherRec; temp } ) { } // pseudocode
```

Resolution may look like this:
- resolve R.init()
- resolve R.init's formals
- resolve x's default value
- resolve [1..3] OtherRec
- resolve OtherRec.init
  - find visible 'init' methods
  - is 'R.init' a candidate?
    - resolve signature of R.init <---- Recursion!

Instead of attempting to resolve the signature of every candidate
initializer, this commit adds a check to return early if the
initializer's 'this' formal and the corresponding actual are not
instantiated from the same type.

Resolves #8761

Testing:
- [x] full local + futures
- [x] full gasnet