### PR TITLE
Pre-release prep. Chapel 1.17.0: post-release version markings

### DIFF
--- a/compiler/main/version.cpp
+++ b/compiler/main/version.cpp
@@ -35,7 +35,7 @@ void
 get_version(char *v) {
   v += sprintf(v, "%d.%s.%s", MAJOR_VERSION, MINOR_VERSION, UPDATE_VERSION);
   if (strcmp(BUILD_VERSION, "0") != 0 || developer)
-    sprintf(v, ".%s", BUILD_VERSION);   // post-release
+    sprintf(v, " pre-release (%s)", BUILD_VERSION);
 }
 
 void

--- a/compiler/main/version_num.h
+++ b/compiler/main/version_num.h
@@ -21,7 +21,7 @@
 #define _version_num_H_
 
 #define MAJOR_VERSION 1
-#define MINOR_VERSION "17"
+#define MINOR_VERSION "18"
 #define UPDATE_VERSION "0"
 
 static const char* BUILD_VERSION =

--- a/doc/rst/conf.py
+++ b/doc/rst/conf.py
@@ -61,12 +61,12 @@ master_doc = 'index'
 # 'version' adds a redundant version number onto the top of the sidebar
 # automatically (rtd-theme). We also don't use |version| anywhere in rst
 
-chplversion = '1.17'                # post-release
+chplversion = '1.18 pre-release'    # TODO -- parse from `chpl --version`
 shortversion = chplversion.replace('-', '&#8209') # prevent line-break at hyphen
 html_context = {"chplversion":chplversion}
 
 # The full version, including alpha/beta/rc tags.
-release = '1.17.0'                  # post-release
+release = '1.18.0 pre-release'
 
 # General information about the project.
 project = u'Chapel Documentation'

--- a/doc/util/versionButton.php
+++ b/doc/util/versionButton.php
@@ -107,7 +107,7 @@ function dropSetup() {
   // Choose button color
   if (chplTitle.includes("pre-release")) {
     button.classList.add("preRelease");
-  } else if (chplTitle != chplVersions[1]) {
+  } else if (chplTitle != "1.16") {
     button.classList.add("oldVersion");
   } else {
     button.classList.add("currentVersion");

--- a/doc/util/versionButton.php
+++ b/doc/util/versionButton.php
@@ -84,7 +84,8 @@ var chplTitle = "<?php echo "$chplTitle";?>";
 
 // Note: assumes second element is most-recent release
 var chplVersions = [
-  "1.17",   // post-release
+  "1.18 pre-release",
+  "1.17",
   "1.16",
   "1.15",
   "1.14",
@@ -106,7 +107,7 @@ function dropSetup() {
   // Choose button color
   if (chplTitle.includes("pre-release")) {
     button.classList.add("preRelease");
-  } else if (chplTitle != "1.17") {
+  } else if (chplTitle != chplVersions[1]) {
     button.classList.add("oldVersion");
   } else {
     button.classList.add("currentVersion");

--- a/man/confchpl.rst
+++ b/man/confchpl.rst
@@ -1,5 +1,5 @@
 
-:Version: 1.17.0
+:Version: 1.18.0 pre-release
 :Manual section: 1
 :Title: \\fBchpl\\fP
 :Subtitle: Compiler for the Chapel Programming Language

--- a/man/confchpldoc.rst
+++ b/man/confchpldoc.rst
@@ -1,5 +1,5 @@
 
-:Version: 1.17.0
+:Version: 1.18.0 pre-release
 :Manual section: 1
 :Title: \\fBchpldoc\\fP
 :Subtitle: the Chapel Documentation Tool

--- a/test/compflags/bradc/printstuff/version.goodstart
+++ b/test/compflags/bradc/printstuff/version.goodstart
@@ -1,1 +1,1 @@
- version 1.17.0
+ version 1.18.0

--- a/test/compflags/bradc/printstuff/versionhelp.sh
+++ b/test/compflags/bradc/printstuff/versionhelp.sh
@@ -5,4 +5,4 @@ compiler=$3
 echo -n `basename $compiler`
 cat $CWD/version.goodstart
 diff $CWD/../../../../compiler/main/BUILD_VERSION $CWD/zero.txt > /dev/null 2>&1 && echo "" || \
-    { echo -n "." && cat $CWD/../../../../compiler/main/BUILD_VERSION | tr -d \" ; }    # post-release
+    { echo -n " pre-release (" && cat $CWD/../../../../compiler/main/BUILD_VERSION | tr -d \"\\n && echo ")" ; }


### PR DESCRIPTION
This change prepares the source on master branch for the upcoming
release, currently scheduled for 5 Apr 2018.

Now that the release branch for Chapel 1.17.0 has been created,
put the "pre-release" version markings back in the master branch,
and bump (most) version numbers on master branch from 1.17 to 1.18.
This includes reverting 841b8a7.

This prepares master branch for work on the next release, assumed to be 1.18.

See https://github.com/chapel-lang/chapel/issues/8979