### PR TITLE
allow if-expression functions to throw implicitly

### DIFF
--- a/compiler/passes/errorHandling.cpp
+++ b/compiler/passes/errorHandling.cpp
@@ -908,8 +908,8 @@ void ErrorCheckingVisitor::exitDeferStmt(DeferStmt* node) {
 
 static void markImplicitThrows(FnSymbol* fn, std::set<FnSymbol*>* visited, implicitThrowsReasons_t* reasons)
 {
-  // Currently, only task functions can be implicitly throws.
-  if (!isTaskFun(fn))
+  // Currently, only task functions and if-exprs can be implicitly throws.
+  if (!(isTaskFun(fn) || fn->hasFlag(FLAG_IF_EXPR_FN)))
     return;
 
   // If we already visited this function, don't visit it again.

--- a/test/errhandling/psahabu/cond-throwing.chpl
+++ b/test/errhandling/psahabu/cond-throwing.chpl
@@ -1,0 +1,16 @@
+module X {
+  proc giveFlag(i: int) throws {
+    if i == 1 then return true;
+    throw new IllegalArgumentError();
+    return false;
+  }
+
+  try {
+    var flag = true;
+    if (flag || giveFlag(1)) {
+      writeln("everything is ok");
+    }
+  } catch {
+    writeln("nothing is ok");
+  }
+}

--- a/test/errhandling/psahabu/cond-throwing.good
+++ b/test/errhandling/psahabu/cond-throwing.good
@@ -1,0 +1,1 @@
+everything is ok

--- a/test/errhandling/psahabu/if-expr-throwing.chpl
+++ b/test/errhandling/psahabu/if-expr-throwing.chpl
@@ -1,0 +1,14 @@
+module X {
+  proc giveFlag(i: int) throws {
+    if i == 1 then return true;
+    throw new IllegalArgumentError();
+    return false;
+  }
+
+  try {
+    var v = if giveFlag(1) then 100 else 1;
+    writeln("everything is ok: " + v);
+  } catch {
+    writeln("nothing is ok");
+  }
+}

--- a/test/errhandling/psahabu/if-expr-throwing.good
+++ b/test/errhandling/psahabu/if-expr-throwing.good
@@ -1,0 +1,1 @@
+everything is ok: 100


### PR DESCRIPTION
While converting `FileSystem.chpl` over to error handling, I ran into an issue where code in the following pattern would break:
```chapel
module X {
  try {
    if (someBool || throwingCall()) ...
  }
}
```

output:
```
error: call to throwing function throwingCall without throws, try, or try! (relaxed mode)
```

This is because infix `bool` operators containing function calls are transformed into if-expression inner functions, isolating the throwing call from the `try` context. This change allows the if-expression inner functions to throw implicitly, like task functions, thus permitting the pattern.

- [x] passes linux64+flat testing