### PR TITLE
Fix sub_test filtering for Jira 287 (clock skew)

### DIFF
--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -2117,7 +2117,8 @@ for testname in testsrc:
 
                             err_strings = ['Clock skew detected']
                             for s in err_strings:
-                                if re.search(s, output, re.IGNORECASE) != None:
+                                # NOTE: checking pre_exec (compiler) output
+                                if re.search(s, pre_exec_output, re.IGNORECASE) != None:
                                     extra_msg = '(possible JIRA 287) '
                                     break
 


### PR DESCRIPTION
I added sub_test filtering for clock skew in #7731, but it never actually
triggered because we were only checking the execution output and the clock skew
text is part of the compiler output. Change sub_test to search the compiler
output instead.