### PR TITLE
Use Chapel-installed virtualenv for ZMQ interop testing

### DIFF
--- a/test/library/packages/ZMQ/interop-py/CLEANFILES
+++ b/test/library/packages/ZMQ/interop-py/CLEANFILES
@@ -1,0 +1,1 @@
+pyzmq-venv

--- a/test/library/packages/ZMQ/interop-py/PREEXEC
+++ b/test/library/packages/ZMQ/interop-py/PREEXEC
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+clean_venv() {
+    echo "Aborted virtualenv build due to errors"
+    rm -rf pyzmq-venv
+    exit 1
+}
+
 if [[ ! -f pyzmq-venv/bin/activate ]] ; then
     # Path to Chapel-installed virtualenv
     CHPL_VIRTUALENV=$(python $CHPL_HOME/util/chplenv/chpl_home_utils.py --venv)/../virtualenv
@@ -15,8 +21,8 @@ if [[ ! -f pyzmq-venv/bin/activate ]] ; then
         fi
     fi
 
-    # Exit if anything goes wrong
-    set -e
+    # Set the trap to abort and clean up virtualenv if anything goes wrong
+    trap clean_venv ERR
 
     # Create virtualenv
     ${CHPL_VIRTUALENV} pyzmq-venv
@@ -24,3 +30,5 @@ if [[ ! -f pyzmq-venv/bin/activate ]] ; then
     python -m pip install ${CHPL_PIP_INSTALL_PARAMS} -r requirements.txt
     deactivate
 fi
+
+

--- a/test/library/packages/ZMQ/interop-py/PREEXEC
+++ b/test/library/packages/ZMQ/interop-py/PREEXEC
@@ -9,6 +9,9 @@ if [[ ! -f pyzmq-venv/bin/activate ]] ; then
         which virtualenv 2> /dev/null
         if [[ $? -eq 0 ]]; then
             CHPL_VIRTUALENV=virtualenv
+        else
+            # Abort mission if virtualenv not available
+            exit 1
         fi
     fi
 

--- a/test/library/packages/ZMQ/interop-py/PREEXEC
+++ b/test/library/packages/ZMQ/interop-py/PREEXEC
@@ -1,8 +1,23 @@
 #!/usr/bin/env bash
 
 if [[ ! -f pyzmq-venv/bin/activate ]] ; then
-    virtualenv pyzmq-venv
+    # Path to Chapel-installed virtualenv
+    CHPL_VIRTUALENV=$(python $CHPL_HOME/util/chplenv/chpl_home_utils.py --venv)/../virtualenv
+
+    # If Chapel virtualenv DNE, check for system-installed virtualenv
+    if [[ ! -f ${CHPL_VIRTUALENV} ]]; then
+        which virtualenv 2> /dev/null
+        if [[ $? -eq 0 ]]; then
+            CHPL_VIRTUALENV=virtualenv
+        fi
+    fi
+
+    # Exit if anything goes wrong
+    set -e
+
+    # Create virtualenv
+    ${CHPL_VIRTUALENV} pyzmq-venv
     source pyzmq-venv/bin/activate
-    python -m pip install -r requirements.txt
+    python -m pip install ${CHPL_PIP_INSTALL_PARAMS} -r requirements.txt
     deactivate
 fi

--- a/test/library/packages/ZMQ/interop-py/server.chpl
+++ b/test/library/packages/ZMQ/interop-py/server.chpl
@@ -1,6 +1,11 @@
 use Spawn;
+use FileSystem;
 
 config const spawnClient = true;
+
+// Confirm virtualenv is built
+if !exists('pyzmq-venv') then halt('virtualenv failed to build');
+
 if spawnClient then
   begin {
     var client = spawn(["./wrapper.sh", "client.py"]);

--- a/test/library/packages/ZMQ/interop-py/wrapper.sh
+++ b/test/library/packages/ZMQ/interop-py/wrapper.sh
@@ -7,5 +7,5 @@ if [[ -f pyzmq-venv/bin/activate ]] ; then
     python $pyscript
     deactivate
 else
-    python $pyscript
+    echo "virtualenv failed to build"
 fi

--- a/test/library/packages/ZMQ/interop-py/wrapper.sh
+++ b/test/library/packages/ZMQ/interop-py/wrapper.sh
@@ -8,4 +8,5 @@ if [[ -f pyzmq-venv/bin/activate ]] ; then
     deactivate
 else
     echo "virtualenv failed to build"
+    exit 1
 fi


### PR DESCRIPTION
Previously, ZMQ interop testing required a system-installed `virtualenv` to work, which is not necessarily a requirement for Chapel. This PR modifies the `PREEXEC` to use the Chapel-installed `virtualenv` if it can be found, otherwise it tries to find a system-installed version. If that is not found, the test will fail.

Note the Chapel-installed `virtualenv` may not exist if `CHPL_TEST_VENV_DIR` is set to `none`, for example.

Other changes:

- Clean up virtualenv
- Print an error message if the virtualenv is not built, which should trigger a clear failure instead of a timeout or success
- Use the `CHPL_PIP_INSTALL_PARAMS` to stay consistent with how `test-venv` packages are installed.
