### PR TITLE
Update virtualenv version to 15.1.0

### DIFF
--- a/third-party/chpl-venv/virtualenv.txt
+++ b/third-party/chpl-venv/virtualenv.txt
@@ -1,1 +1,1 @@
-virtualenv==12.0.5
+virtualenv==15.1.0


### PR DESCRIPTION
This change results in an updated version of `pip` within the virtualenv, which avoids the [out of date TLS issue](http://pyfound.blogspot.com/2017/01/time-to-upgrade-your-python-tls-v12.html) on OS X systems.

- [x] `make test-venv && make chpldoc` locally
- [x] `paratest: [Summary: #Successes = 8452 | #Failures = 0 | #Futures = 0]`