### PR TITLE
Convert BaseDist-inheriting classes to use initializers

### DIFF
--- a/modules/dists/CyclicDist.chpl
+++ b/modules/dists/CyclicDist.chpl
@@ -177,20 +177,25 @@ class Cyclic: BaseDist {
   var dataParIgnoreRunningTasks: bool;
   var dataParMinGranularity: int;
 
-  proc Cyclic(startIdx,
-             targetLocales: [] locale = Locales,
-             dataParTasksPerLocale=getDataParTasksPerLocale(),
-             dataParIgnoreRunningTasks=getDataParIgnoreRunningTasks(),
-             dataParMinGranularity=getDataParMinGranularity(),
-             param rank: int = _determineRankFromStartIdx(startIdx),
-             type idxType = _determineIdxTypeFromStartIdx(startIdx))
+  proc init(startIdx,
+            targetLocales: [] locale = Locales,
+            dataParTasksPerLocale=getDataParTasksPerLocale(),
+            dataParIgnoreRunningTasks=getDataParIgnoreRunningTasks(),
+            dataParMinGranularity=getDataParMinGranularity(),
+            param rank: int = _determineRankFromStartIdx(startIdx),
+            type idxType = _determineIdxTypeFromStartIdx(startIdx))
     where isTuple(startIdx) || isIntegralType(startIdx.type) {
     var tupleStartIdx: rank*idxType;
     if isTuple(startIdx) then tupleStartIdx = startIdx;
                          else tupleStartIdx(1) = startIdx;
 
+    this.rank = rank;
+    this.idxType = idxType;
+
     // MPF - why isn't it:
     //setupTargetLocalesArray(targetLocDom, targetLocs, targetLocales);
+
+    this.complete();
 
     if rank == 1  {
       targetLocDom = {0..#targetLocales.numElements};

--- a/modules/dists/DimensionalDist2D.chpl
+++ b/modules/dists/DimensionalDist2D.chpl
@@ -369,7 +369,7 @@ class LocDimensionalArr {
 
 // constructor
 // gotta list all the things we let the user set
-proc DimensionalDist2D.DimensionalDist2D(
+proc DimensionalDist2D.init(
   targetLocales: [] locale,
   di1,
   di2,
@@ -379,12 +379,19 @@ proc DimensionalDist2D.DimensionalDist2D(
   dataParIgnoreRunningTasks: bool = getDataParIgnoreRunningTasks(),
   dataParMinGranularity: int      = getDataParMinGranularity()
 ) {
+  this.targetLocales = targetLocales;
+  this.di1 = di1;
+  this.di2 = di2;
   this.name = name;
+  this.idxType = idxType;
   this.dataParTasksPerLocale = if dataParTasksPerLocale==0
                                then here.maxTaskPar
                                else dataParTasksPerLocale;
   this.dataParIgnoreRunningTasks = dataParIgnoreRunningTasks;
   this.dataParMinGranularity = dataParMinGranularity;
+
+  this.complete();
+
   checkInvariants();
 
   _passLocalLocIDsDist(di1, true, di2, true,
@@ -503,7 +510,7 @@ proc DimensionalDist2D.dsiPrivatize(privatizeData) {
 
 // constructor of a privatized copy
 // ('dummy' distinguishes it from the user constructor)
-proc DimensionalDist2D.DimensionalDist2D(param dummy: int,
+proc DimensionalDist2D.init(param dummy: int,
   targetLocales: [] locale,
   name,
   type idxType,
@@ -513,10 +520,17 @@ proc DimensionalDist2D.DimensionalDist2D(param dummy: int,
   dataParIgnoreRunningTasks,
   dataParMinGranularity
 ) {
+  this.targetLocales = targetLocales;
+  this.di1 = di1;
+  this.di2 = di2;
   this.name = name;
+  this.idxType = idxType;
   this.dataParTasksPerLocale     = dataParTasksPerLocale;
   this.dataParIgnoreRunningTasks = dataParIgnoreRunningTasks;
   this.dataParMinGranularity     = dataParMinGranularity;
+
+  this.complete();
+
   // should not need it, but run it for now just in case
   checkInvariants();
 }

--- a/modules/dists/PrivateDist.chpl
+++ b/modules/dists/PrivateDist.chpl
@@ -66,6 +66,7 @@ do not provide some standard domain/array functionality.
 This distribution may perform unnecessary communication
 between locales.
 */
+pragma "use default init"
 class Private: BaseDist {
   proc dsiNewRectangularDom(param rank: int, type idxType, param stridable: bool, inds) {
     for i in inds do

--- a/modules/dists/ReplicatedDist.chpl
+++ b/modules/dists/ReplicatedDist.chpl
@@ -117,9 +117,11 @@ class Replicated : BaseDist {
 
 // constructor: replicate over the given locales
 // (by default, over all locales)
-proc Replicated.Replicated(targetLocales: [] locale = Locales,
-                 purposeMessage: string = "used to create a Replicated")
+proc Replicated.init(targetLocales: [] locale = Locales,
+                     purposeMessage: string = "used to create a Replicated")
 {
+  this.complete();
+
   for loc in targetLocales {
     this.targetLocDom.add(loc.id);
     this.targetLocales[loc.id] = loc;

--- a/modules/internal/ArrayViewRankChange.chpl
+++ b/modules/internal/ArrayViewRankChange.chpl
@@ -47,6 +47,7 @@ module ArrayViewRankChange {
   // rank-change domains and arrays similar to the one that caused
   // it to be created.
   //
+  pragma "use default init"
   class ArrayViewRankChangeDist: BaseDist {
     // a pointer down to the distribution that this class is creating
     // lower-dimensional views of

--- a/modules/internal/ArrayViewReindex.chpl
+++ b/modules/internal/ArrayViewReindex.chpl
@@ -32,6 +32,7 @@ module ArrayViewReindex {
   // that it creates reindexed views of, and a down-facing and up-facing
   // domain indicating the old and new index sets, respectively.
   //
+  pragma "use default init"
   class ArrayViewReindexDist: BaseDist {
     // a pointer down to the distribution that this class is creating
     // reindexed views of

--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -27,6 +27,7 @@ module ChapelDistribution {
   // Abstract distribution class
   //
   pragma "base dist"
+  pragma "use default init"
   class BaseDist {
     // The common case seems to be local access to this class, so we
     // will use explicit processor atomics, even when network

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -37,6 +37,7 @@ module DefaultRectangular {
   config param defaultDisableLazyRADOpt = false;
   config param earlyShiftData = true;
 
+  pragma "use default init"
   class DefaultDist: BaseDist {
     proc dsiNewRectangularDom(param rank: int, type idxType, param stridable: bool, inds) {
       const dom = new DefaultRectangularDom(rank, idxType, stridable, this);

--- a/modules/layouts/LayoutCS.chpl
+++ b/modules/layouts/LayoutCS.chpl
@@ -69,6 +69,7 @@ This domain map is a layout, i.e. it maps all indices to the current locale.
 All elements of a CS-distributed array are stored
 on the locale where the array variable is declared.
 */
+pragma "use default init"
 class CS: BaseDist {
   param compressRows: bool = true;
 

--- a/test/distributions/bradc/assoc/UserMapAssoc.chpl
+++ b/test/distributions/bradc/assoc/UserMapAssoc.chpl
@@ -80,9 +80,11 @@ class UserMapAssoc : BaseDist {
 
   // CONSTRUCTORS:
 
-  proc UserMapAssoc(type idxType = int(64),
-                    mapper:?t = new DefaultMapper(),
-                    targetLocales: [] locale = Locales) {
+  proc init(type idxType = int(64),
+            mapper:?t = new DefaultMapper(),
+            targetLocales: [] locale = Locales) {
+    this.idxType = idxType;
+    this.mapper = mapper;
     //
     // 0-base the local capture of the targetLocDom for simplicity
     // later on
@@ -102,9 +104,10 @@ class UserMapAssoc : BaseDist {
   //
   // builds up a privatized (replicated copy)
   //
-  proc UserMapAssoc(type idxType = int(64),
-                    mapper,
-                    other: UserMapAssoc(idxType, mapper.type)) {
+  proc init(type idxType = int(64),
+            mapper,
+            other: UserMapAssoc(idxType, mapper.type)) {
+    this.idxType = idxType;
     this.mapper = mapper; // normally == other.mapper;
     targetLocDom = other.targetLocDom;
     this.targetLocales = other.targetLocales;

--- a/test/distributions/bradc/wrongDomForDist/DummyArithDist.chpl
+++ b/test/distributions/bradc/wrongDomForDist/DummyArithDist.chpl
@@ -1,4 +1,7 @@
 class MyDist : BaseDist {
+
+  proc init() { }
+
   proc dsiNewRectangularDom(param rank: int, type idxType, param stridable: bool, inds) {
     const dom = new MyDom(rank=rank, idxType=idxType, stridable=stridable);
     dom.dsiSetIndices(inds);

--- a/test/distributions/bradc/wrongDomForDist/DummyAssocDist.chpl
+++ b/test/distributions/bradc/wrongDomForDist/DummyAssocDist.chpl
@@ -1,4 +1,6 @@
 class MyDist : BaseDist {
+  proc init() { }
+
   proc dsiNewAssociativeDom(type idxType, param parSafe:bool) {
     return new MyDom();
   }

--- a/test/domains/vass/no-dom-field-error.chpl
+++ b/test/domains/vass/no-dom-field-error.chpl
@@ -16,7 +16,7 @@ class GlobalDomain : BaseDom {
 
 class GlobalArray : BaseArr {}
 
-proc GlobalDistribution.GlobalDistribution() {}
+proc GlobalDistribution.init() {}
 
 proc GlobalDistribution.dsiClone(): GlobalDistribution {
   return new GlobalDistribution();

--- a/test/studies/comd/elegant/arrayOfStructs/CoMD.prediff
+++ b/test/studies/comd/elegant/arrayOfStructs/CoMD.prediff
@@ -1,10 +1,15 @@
 #!/usr/bin/env python
 
-import sys, os, shutil
+import sys, os, shutil, re
 
 test_name = sys.argv[1]
 out_file  = sys.argv[2]
 tmp_file  = out_file + ".prediff.tmp"
+
+with open(out_file) as outf:
+    for line in outf:
+        if re.search(r"\.chpl:\d+: error:", line) != None:
+            sys.exit(0);
 
 EPSILON = 1e-6
 vals = {}

--- a/test/studies/comd/elegant/arrayOfStructs/util/AccumStencilDist.chpl
+++ b/test/studies/comd/elegant/arrayOfStructs/util/AccumStencilDist.chpl
@@ -174,7 +174,7 @@ private proc makeZero(param rank : int, type idxType) {
 //
 // AccumStencil constructor for clients of the AccumStencil distribution
 //
-proc AccumStencil.AccumStencil(boundingBox: domain,
+proc AccumStencil.init(boundingBox: domain,
                 targetLocales: [] locale = Locales,
                 dataParTasksPerLocale=getDataParTasksPerLocale(),
                 dataParIgnoreRunningTasks=getDataParIgnoreRunningTasks(),
@@ -189,11 +189,17 @@ proc AccumStencil.AccumStencil(boundingBox: domain,
   if idxType != boundingBox.idxType then
     compilerError("specified AccumStencil index type != index type of specified bounding box");
 
+  this.rank = rank;
+  this.idxType = idxType;
+  this.ignoreFluff = ignoreFluff;
+
   this.boundingBox = boundingBox : domain(rank, idxType, stridable=false);
   this.fluff = fluff;
 
   // can't have periodic if there's no fluff
   this.periodic = periodic && !isZeroTuple(fluff);
+
+  this.complete();
 
   setupTargetLocalesArray(targetLocDom, this.targetLocales, targetLocales);
 
@@ -1427,10 +1433,13 @@ inline proc LocAccumStencilArr.this(i) ref {
 //
 // Privatization
 //
-proc AccumStencil.AccumStencil(other: AccumStencil, privateData,
+proc AccumStencil.init(other: AccumStencil, privateData,
                 param rank = other.rank,
                 type idxType = other.idxType,
                 param ignoreFluff = other.ignoreFluff) {
+  this.rank = rank;
+  this.idxType = idxType;
+  this.ignoreFluff = ignoreFluff;
   boundingBox = {(...privateData(1))};
   targetLocDom = {(...privateData(2))};
   dataParTasksPerLocale = privateData(3);
@@ -1438,6 +1447,8 @@ proc AccumStencil.AccumStencil(other: AccumStencil, privateData,
   dataParMinGranularity = privateData(5);
   fluff = privateData(6);
   periodic = privateData(7);
+
+  this.complete();
 
   for i in targetLocDom {
     targetLocales(i) = other.targetLocales(i);

--- a/test/users/vass/crash1callDestructorsAddon.chpl
+++ b/test/users/vass/crash1callDestructorsAddon.chpl
@@ -155,7 +155,7 @@ class LocDimensionalArr {
 
 // constructor
 // gotta list all the things we let the user set
-proc DimensionalDist.DimensionalDist(
+proc DimensionalDist.init(
   targetLocales,
   di1,
   di2,
@@ -165,11 +165,18 @@ proc DimensionalDist.DimensionalDist(
   dataParIgnoreRunningTasks: bool = getDataParIgnoreRunningTasks(),
   dataParMinGranularity: int      = getDataParMinGranularity()
 ) {
+  this.targetLocales = targetLocales;
+  this.di1 = di1;
+  this.di2 = di2;
   this.name = name;
+  this.idxType = idxType;
   this.dataParTasksPerLocale = if dataParTasksPerLocale==0 then here.maxTaskPar
                                else dataParTasksPerLocale;
   this.dataParIgnoreRunningTasks = dataParIgnoreRunningTasks;
   this.dataParMinGranularity = dataParMinGranularity;
+
+  this.complete();
+
   checkInvariants();
 
   _passLocalLocIDsDist(di1, di2, this.targetLocales,
@@ -255,7 +262,7 @@ proc DimensionalDist.dsiPrivatize(privatizeData) {
 
 // constructor of a privatized copy
 // (currently almost same the user constructor; 'dummy' is to distinguish)
-proc DimensionalDist.DimensionalDist(param dummy: int,
+proc DimensionalDist.init(param dummy: int,
   targetLocales,
   di1,
   di2,
@@ -265,10 +272,17 @@ proc DimensionalDist.DimensionalDist(param dummy: int,
   dataParIgnoreRunningTasks,
   dataParMinGranularity
 ) {
+  this.targetLocales = targetLocales;
+  this.di1 = di1;
+  this.di2 = di2;
   this.name = name;
+  this.idxType = idxType;
   this.dataParTasksPerLocale     = dataParTasksPerLocale;
   this.dataParIgnoreRunningTasks = dataParIgnoreRunningTasks;
   this.dataParMinGranularity     = dataParMinGranularity;
+
+  this.complete();
+
   // should not need it, but run it for now just in case
   checkInvariants();
 }

--- a/test/users/vass/crash1callDestructorsMain.chpl
+++ b/test/users/vass/crash1callDestructorsMain.chpl
@@ -155,7 +155,7 @@ class LocDimensionalArr {
 
 // constructor
 // gotta list all the things we let the user set
-proc DimensionalDist.DimensionalDist(
+proc DimensionalDist.init(
   targetLocales,
   di1,
   di2,
@@ -165,11 +165,18 @@ proc DimensionalDist.DimensionalDist(
   dataParIgnoreRunningTasks: bool = getDataParIgnoreRunningTasks(),
   dataParMinGranularity: int      = getDataParMinGranularity()
 ) {
+  this.targetLocales = targetLocales;
+  this.di1 = di1;
+  this.di2 = di2;
   this.name = name;
+  this.idxType = idxType;
   this.dataParTasksPerLocale = if dataParTasksPerLocale==0 then here.maxTaskPar
                                else dataParTasksPerLocale;
   this.dataParIgnoreRunningTasks = dataParIgnoreRunningTasks;
   this.dataParMinGranularity = dataParMinGranularity;
+
+  this.complete();
+
   checkInvariants();
 
   _passLocalLocIDsDist(di1, di2, this.targetLocales,
@@ -255,7 +262,7 @@ proc DimensionalDist.dsiPrivatize(privatizeData) {
 
 // constructor of a privatized copy
 // (currently almost same the user constructor; 'dummy' is to distinguish)
-proc DimensionalDist.DimensionalDist(param dummy: int,
+proc DimensionalDist.init(param dummy: int,
   targetLocales,
   di1,
   di2,
@@ -265,10 +272,17 @@ proc DimensionalDist.DimensionalDist(param dummy: int,
   dataParIgnoreRunningTasks,
   dataParMinGranularity
 ) {
+  this.targetLocales = targetLocales;
+  this.di1 = di1;
+  this.di2 = di2;
   this.name = name;
+  this.idxType = idxType;
   this.dataParTasksPerLocale     = dataParTasksPerLocale;
   this.dataParIgnoreRunningTasks = dataParIgnoreRunningTasks;
   this.dataParMinGranularity     = dataParMinGranularity;
+
+  this.complete();
+
   // should not need it, but run it for now just in case
   checkInvariants();
 }


### PR DESCRIPTION
This PR updates BaseDist and its derived classes to either:
- use default initializers instead of default constructors
- convert a user-defined constructor to a user-defined initializer

These transformations were generally accomplished by:
- explicitly initializing param/type fields
- inserting a "this.complete()" statement.
- adding a "use default init" pragma

A handful of tests with custom distributions have been updated in a similar manner.

Testing:
- [x] full local + futures
- [x] full gasnet