### PR TITLE
Convert docs/latest URLs to docs for simplicity

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2684,7 +2684,7 @@ Fourteenth public release of Chapel, April 2, 2015
 Highlights
 ----------
 * revamped 'chpldoc' and used it to create web docs for all standard modules
-  (see https://chapel-lang.org/docs/latest/)
+  (see https://chapel-lang.org/docs/)
 * added a new FileSystem standard module supporting operations on files/dirs
   (see https://chapel-lang.org/docs/1.11/modules/standard/FileSystem.html)
 * added a new FFTW standard module supporting key FFTW routines
@@ -2878,7 +2878,7 @@ Third-Party Software Changes
 Documentation
 -------------
 * added web-based docs for all standard modules and removed from spec/READMEs
-  (see https://chapel-lang.org/docs/latest/)
+  (see https://chapel-lang.org/docs/)
 * made some minor improvements to the Quick Reference document
 * added documentation for class and record destructors to the spec
 * removed an outdated distinction between function calls using () vs. [] in spec

--- a/LICENSE
+++ b/LICENSE
@@ -85,7 +85,7 @@ The Chapel implementation is composed of two categories of code:
    For packages that are used based on a CHPL_* setting, note that this
    setting may either be explicitly or implicitly set. Additionally,
    some packages are only used if a speculative build was successful.
-   See https://chapel-lang.org/docs/latest/usingchapel/chplenv.html to
+   See https://chapel-lang.org/docs/usingchapel/chplenv.html to
    see which packages are used by default and which ones are built
    speculatively. You can also check your CHPL_* settings by running
    $CHPL_HOME/util/printchplenv after Chapel has been built

--- a/README.rst
+++ b/README.rst
@@ -28,17 +28,17 @@ For more information about Chapel, please refer to the following resources:
    If you are viewing this file locally, we recommend referring to
    doc/README.rst for local references to documentation and resources.
 
-=====================  ==================================================================================
+=====================  ========================================================
 Project homepage:      https://chapel-lang.org
 Installing Chapel:     https://chapel-lang.org/download.html
-Building from source:  https://chapel-lang.org/docs/latest/usingchapel/QUICKSTART.html
+Building from source:  https://chapel-lang.org/docs/usingchapel/QUICKSTART.html
 Sample computations:   https://chapel-lang.org/hellos.html
 Learning Chapel:       https://chapel-lang.org/learning.html
 Reporting bugs:        https://chapel-lang.org/bugs.html
-Online documentation:  https://chapel-lang.org/docs/latest/
+Online documentation:  https://chapel-lang.org/docs/
 GitHub:                https://github.com/chapel-lang/chapel
 Mailing lists:         https://sourceforge.net/p/chapel/mailman
 Facebook:              https://www.facebook.com/ChapelLanguage
 Twitter:               https://twitter.com/ChapelLanguage
-=====================  ==================================================================================
+=====================  ========================================================
 

--- a/doc/rst/developer/chips/13.rst
+++ b/doc/rst/developer/chips/13.rst
@@ -20,7 +20,7 @@ several versions.
 
 Note that Chapel 1.14 and earlier uses array reference counting but that
 is no longer necessary because of changes in the language (see
-https://chapel-lang.org/docs/latest/language/evolution.html#lexical-scoping
+https://chapel-lang.org/docs/language/evolution.html#lexical-scoping
 ).
 
 Function Return Behavior

--- a/doc/rst/language/archivedSpecs.rst
+++ b/doc/rst/language/archivedSpecs.rst
@@ -44,7 +44,7 @@ Spec *<version>* (Chapel *<release in which specification was made available>*)
 
 
 
-.. _Language Specification:     https://chapel-lang.org/docs/latest/language/spec.html
+.. _Language Specification:     https://chapel-lang.org/docs/language/spec.html
 .. _Spec 0.981 (Chapel 1.13.0): https://chapel-lang.org/docs/1.13/language/spec.html
 .. _Spec 0.98  (Chapel 1.12.0): https://chapel-lang.org/spec/spec-0.98.pdf
 .. _Spec 0.97  (Chapel 1.11.0): https://chapel-lang.org/spec/spec-0.97.pdf

--- a/doc/rst/technotes/initializers.rst
+++ b/doc/rst/technotes/initializers.rst
@@ -740,7 +740,7 @@ types use initializers when possible.  Please report any bugs
 encountered using the guidance described at the `bugs`_ page.
 
 .. _bugs:
-   https://chapel-lang.org/docs/latest/usingchapel/bugs.html
+   https://chapel-lang.org/docs/usingchapel/bugs.html
 
 
 

--- a/doc/rst/technotes/local.rst
+++ b/doc/rst/technotes/local.rst
@@ -36,10 +36,8 @@ the performance of a program, as communication usually slows down
 execution.
 
 The ``local`` construct does not necessarily indicate the cause of
-communication when present. See the `Module\: CommDiagnostics`_ for ways to
+communication when present. See the :chpl:mod:`CommDiagnostics` module for ways to
 diagnose communication.
-
-.. _Module\: CommDiagnostics:    https://chapel-lang.org/docs/modules/standard/CommDiagnostics.html
 
 
 

--- a/doc/rst/technotes/local.rst
+++ b/doc/rst/technotes/local.rst
@@ -39,7 +39,7 @@ The ``local`` construct does not necessarily indicate the cause of
 communication when present. See the `Module\: CommDiagnostics`_ for ways to
 diagnose communication.
 
-.. _Module\: CommDiagnostics:    https://chapel-lang.org/docs/latest/modules/standard/CommDiagnostics.html
+.. _Module\: CommDiagnostics:    https://chapel-lang.org/docs/modules/standard/CommDiagnostics.html
 
 
 

--- a/runtime/include/chpl-comm-compiler-macros.h
+++ b/runtime/include/chpl-comm-compiler-macros.h
@@ -43,25 +43,22 @@
 
 
 static inline
-int chpl_gen_comm_get(void *addr, c_nodeid_t node, void* raddr,
+void chpl_gen_comm_get(void *addr, c_nodeid_t node, void* raddr,
                        size_t size, int32_t typeIndex,
                        int32_t commID, int ln, int32_t fn)
 {
   if (chpl_nodeID == node) {
     chpl_memcpy(addr, raddr, size);
-    return 0;
 #ifdef HAS_CHPL_CACHE_FNS
   } else if( chpl_cache_enabled() ) {
     chpl_cache_comm_get(addr, node, raddr, size, typeIndex, commID, ln, fn);
 #endif
-    return 2;
   } else {
 #ifdef CHPL_TASK_COMM_GET
     chpl_task_comm_get(addr, node, raddr, size, typeIndex, commID, ln, fn);
 #else
     chpl_comm_get(addr, node, raddr, size, typeIndex, commID, ln, fn);
 #endif
-    return 1;
   }
 }
 

--- a/runtime/include/chpl-comm-compiler-macros.h
+++ b/runtime/include/chpl-comm-compiler-macros.h
@@ -43,22 +43,25 @@
 
 
 static inline
-void chpl_gen_comm_get(void *addr, c_nodeid_t node, void* raddr,
+int chpl_gen_comm_get(void *addr, c_nodeid_t node, void* raddr,
                        size_t size, int32_t typeIndex,
                        int32_t commID, int ln, int32_t fn)
 {
   if (chpl_nodeID == node) {
     chpl_memcpy(addr, raddr, size);
+    return 0;
 #ifdef HAS_CHPL_CACHE_FNS
   } else if( chpl_cache_enabled() ) {
     chpl_cache_comm_get(addr, node, raddr, size, typeIndex, commID, ln, fn);
 #endif
+    return 2;
   } else {
 #ifdef CHPL_TASK_COMM_GET
     chpl_task_comm_get(addr, node, raddr, size, typeIndex, commID, ln, fn);
 #else
     chpl_comm_get(addr, node, raddr, size, typeIndex, commID, ln, fn);
 #endif
+    return 1;
   }
 }
 

--- a/test/exercises/boundedBuffer/boundedBuffer.chpl
+++ b/test/exercises/boundedBuffer/boundedBuffer.chpl
@@ -187,7 +187,7 @@ proc consumer(b: BoundedBuffer, cid: int) {
 // with atomics before, refer to the online documentation or ask one
 // of the helpers for a hint:
 //
-//   https://chapel-lang.org/docs/latest/builtins/internal/Atomics.html
+//   https://chapel-lang.org/docs/builtins/internal/Atomics.html
 //
 // STEP 5 (optional): Compare the performance of your two versions
 // (note: you may want to turn off the --noisy and/or --verbose

--- a/test/exercises/c-ray/forStudents/c-ray.chpl
+++ b/test/exercises/c-ray/forStudents/c-ray.chpl
@@ -182,7 +182,7 @@ proc main() {
   // balanced since some pixels result in far more pixel bounces than
   // others.  Can you achieve a speed improvement by applying the
   // dynamic() iterator from the DynamicIters module:
-  // https://chapel-lang.org/docs/latest/modules/standard/DynamicIters.html
+  // https://chapel-lang.org/docs/modules/standard/DynamicIters.html
   // Do you need to create a more load-imbalanced scene (or increase
   // the value of 'maxRayDepth') in order to see a noticeable
   // difference?

--- a/test/release/examples/benchmarks/shootout/Makefile
+++ b/test/release/examples/benchmarks/shootout/Makefile
@@ -75,7 +75,7 @@ pidigits: pidigits.chpl
 	else \
 	echo "";\
 	echo "Can't build pidigits without CHPL_GMP being enabled. See for details:"; \
-	echo "https://chapel-lang.org/docs/latest/usingchapel/chplenv.html#chpl-gmp"; \
+	echo "https://chapel-lang.org/docs/usingchapel/chplenv.html#chpl-gmp"; \
 	echo ""; \
 	fi
 
@@ -85,7 +85,7 @@ pidigits-fast: pidigits-fast.chpl
 	else \
 	echo "";\
 	echo "Can't build pidigits-fast without CHPL_GMP being enabled. See for details:"; \
-	echo "https://chapel-lang.org/docs/latest/usingchapel/chplenv.html#chpl-gmp"; \
+	echo "https://chapel-lang.org/docs/usingchapel/chplenv.html#chpl-gmp"; \
 	echo ""; \
 	fi
 
@@ -95,7 +95,7 @@ regexdna: regexdna.chpl
 	else \
 	echo "";\
 	echo "Can't build regexdna without CHPL_REGEXP being enabled. See for details:"; \
-	echo "https://chapel-lang.org/docs/latest/usingchapel/chplenv.html#chpl-regexp"; \
+	echo "https://chapel-lang.org/docs/usingchapel/chplenv.html#chpl-regexp"; \
 	echo ""; \
 	fi
 
@@ -105,7 +105,7 @@ regexdna-redux: regexdna-redux.chpl
 	else \
 	echo "";\
 	echo "Can't build regexdna-redux without CHPL_REGEXP being enabled. See for details:"; \
-	echo "https://chapel-lang.org/docs/latest/usingchapel/chplenv.html#chpl-regexp"; \
+	echo "https://chapel-lang.org/docs/usingchapel/chplenv.html#chpl-regexp"; \
 	echo ""; \
 	fi
 

--- a/test/studies/dedup/dedup-externblock.chpl
+++ b/test/studies/dedup/dedup-externblock.chpl
@@ -14,7 +14,7 @@ require "-lcrypto", "-lssl";
 // scope. Functions, variables, and types are supported - including
 // inline functions. Macros have limited support.
 // See
-//   https://chapel-lang.org/docs/latest/technotes/extern.html
+//   https://chapel-lang.org/docs/technotes/extern.html
 extern {
   #include <openssl/sha.h>
 }

--- a/tools/c2chapel/README.rst
+++ b/tools/c2chapel/README.rst
@@ -16,5 +16,5 @@ function declaration in a header file:
 
   extern proc foo(str: c_string, n : c_int) : void;
 
-See the `online documentation <https://chapel-lang.org/docs/latest/tools/c2chapel/c2chapel.html>`_ for more
+See the `online documentation <https://chapel-lang.org/docs/tools/c2chapel/c2chapel.html>`_ for more
 information.

--- a/util/dockerfiles/README.md
+++ b/util/dockerfiles/README.md
@@ -25,7 +25,7 @@ This is the core image for Chapel. It provides the complete Chapel compiler and 
 
 The Chapel core image (above), rebuilt with `CHPL_COMM=gasnet` and `GASNET_SPAWNFN=L`. Simulates a multilocale Chapel platform within the Docker container.
 
-Multilocale Chapel brings additional requirements, unrelated to Docker. The `chpl` compilation produces two binary files (e.g. `hello_real` as well as `hello`). When you run the binary, you need another command line parameter, `-nl #`, to specify the number of locales. Please see [Multilocale Chapel Execution](https://chapel-lang.org/docs/latest/usingchapel/multilocale.html) for details.
+Multilocale Chapel brings additional requirements, unrelated to Docker. The `chpl` compilation produces two binary files (e.g. `hello_real` as well as `hello`). When you run the binary, you need another command line parameter, `-nl #`, to specify the number of locales. Please see [Multilocale Chapel Execution](https://chapel-lang.org/docs/usingchapel/multilocale.html) for details.
 
 # How to use the image
 
@@ -67,7 +67,7 @@ Hello, world!
 
 # Documentation
 
-Chapel's documentation is [available online](https://chapel-lang.org/docs/latest/).
+Chapel's documentation is [available online](https://chapel-lang.org/docs/).
 Documentation for a specific release is also available: [1.16](https://chapel-lang.org/docs/1.16/), [1.15](https://chapel-lang.org/docs/1.15/).
 
 # License


### PR DESCRIPTION
This is mostly cosmetic, reflecting that we made chapel-lang.org/docs/ equivalent to .../docs/latest but may allow us to retire the docs/latest/ link eventually.  In one case, I also fixed an absolute URL to use a Chapel module cross-reference instead.