### PR TITLE
Prevent path splitting when fixing path on fish (#9049)

### DIFF
--- a/util/config/fixpath.py
+++ b/util/config/fixpath.py
@@ -6,6 +6,11 @@ from os import getenv
 from sys import argv
 import re
 
+def escape_path(p):
+    if len(argv) >=3 and argv[2] == 'fish':
+        # Suppress splitting of fish so that the path will be treated as a whole
+        return '"{}"'.format(p)
+    return p
 
 def main(env='PATH', delim=':'):
     """
@@ -25,7 +30,7 @@ def main(env='PATH', delim=':'):
     pattern = r'(?<!\\)\:'
 
     # Split path into list separated by non-escaped ':'s, and sieve chpl_home
-    newpath = [p for p in re.split(pattern, path) if chpl_home not in p]
+    newpath = [escape_path(p) for p in re.split(pattern, path) if chpl_home not in p]
 
     # Return path delimited by shell-type (':' vs. ' ')
     return delim.join(newpath)


### PR DESCRIPTION
Say, my `PATH` looks like `"/foo bar/42" "/usr/bin"` on fish. Fish will export `/foo bar/42:/usr/bin` to subcommands. The result of splitting in`fixpath.py` will be `["/foo bar/42", "/usr/bin"]`, and the result of join by delim is `/foo bar/42 /usr/bin`, which will be consumed by, for example `setchplenv.fish`. Fish will then treat this as `"/foo" "bar/42" "/usr/bin"`

The solution I proposed is to double quote each entry of `PATH`, so that `setchplenv.fish` can directly pass them to fish shell

Closes #9049