### PR TITLE
Accept reduction in comm counts from PR #8958

### DIFF
--- a/test/distributions/robust/arithmetic/performance/multilocale/assignReindex.replicated.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/assignReindex.replicated.good
@@ -1,2 +1,2 @@
-(put = 12, execute_on = 10, execute_on_nb = 9) (get = 66, put = 1, execute_on = 9, execute_on_fast = 3) (get = 66, put = 1, execute_on = 4, execute_on_fast = 3) (get = 66, put = 1, execute_on = 4, execute_on_fast = 3)
+(put = 12, execute_on = 10, execute_on_nb = 9) (get = 62, put = 1, execute_on = 9, execute_on_fast = 3) (get = 62, put = 1, execute_on = 4, execute_on_fast = 3) (get = 62, put = 1, execute_on = 4, execute_on_fast = 3)
 (<no communication>) (<no communication>) (<no communication>) (<no communication>)

--- a/test/distributions/robust/arithmetic/performance/multilocale/assignSlice.replicated.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/assignSlice.replicated.good
@@ -1,1 +1,1 @@
-(put = 12, execute_on = 4, execute_on_nb = 6) (get = 63, put = 1, execute_on = 6, execute_on_fast = 2) (get = 63, put = 1, execute_on = 4, execute_on_fast = 2) (get = 63, put = 1, execute_on = 4, execute_on_fast = 2)
+(put = 12, execute_on = 4, execute_on_nb = 6) (get = 61, put = 1, execute_on = 6, execute_on_fast = 2) (get = 61, put = 1, execute_on = 4, execute_on_fast = 2) (get = 61, put = 1, execute_on = 4, execute_on_fast = 2)

--- a/test/distributions/robust/arithmetic/performance/multilocale/reduceSlice.replicated.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/reduceSlice.replicated.good
@@ -1,1 +1,1 @@
-(put = 12, execute_on = 4, execute_on_nb = 6) (get = 63, put = 1, execute_on = 6, execute_on_fast = 2) (get = 63, put = 1, execute_on = 4, execute_on_fast = 2) (get = 63, put = 1, execute_on = 4, execute_on_fast = 2)
+(put = 12, execute_on = 4, execute_on_nb = 6) (get = 61, put = 1, execute_on = 6, execute_on_fast = 2) (get = 61, put = 1, execute_on = 4, execute_on_fast = 2) (get = 61, put = 1, execute_on = 4, execute_on_fast = 2)


### PR DESCRIPTION
PR #8958 had the potential to reduce communication and it appears it did for a few replicated comm-counting tests.

Test change only, not reviewed.