### PR TITLE
Support CHPL_TARGET_ARCH=unknown in LLVM codegen

### DIFF
--- a/compiler/util/clangUtil.cpp
+++ b/compiler/util/clangUtil.cpp
@@ -1578,7 +1578,8 @@ void runClang(const char* just_parse_filename) {
   if (specializeCCode &&
       CHPL_TARGET_BACKEND_ARCH != NULL &&
       CHPL_TARGET_BACKEND_ARCH[0] != '\0' &&
-      0 != strcmp(CHPL_TARGET_BACKEND_ARCH, "none")) {
+      0 != strcmp(CHPL_TARGET_BACKEND_ARCH, "none") &&
+      0 != strcmp(CHPL_TARGET_BACKEND_ARCH, "unknown")) {
     std::string march = "-march=";
     const char *backend_arch = CHPL_TARGET_BACKEND_ARCH;
     if (strncmp(backend_arch, "arm-", 4) == 0) {


### PR DESCRIPTION
Since -march=unknown doesn't mean anything to clang,
we need to treat it like CHPL_TARGET_ARCH=none and just
not provide a -march flag at all if CHPL_TARGET_ARCH=unknown.

Passed full local testing with CHPL_LLVM=llvm and with --llvm.

Fixes #9079.

Reviewed by @dmk42 - thanks!