### PR TITLE
Housekeeping for Cray-specific tests

### DIFF
--- a/test/execflags/bradc/gdbddash/gdbSetConfig.skipif
+++ b/test/execflags/bradc/gdbddash/gdbSetConfig.skipif
@@ -9,7 +9,7 @@ import os, os.path
 # installation and thus nothing to worry about.  To squash the noise, we will
 # avoid running it there.
 if os.getenv('CHPL_TARGET_PLATFORM') == 'cray-xc':
-    if not os.path.exists('/etc/opt/cray/release') or not os.path.exists('/etc/opt/cray/release/CLEinfo'):
+    if not (os.path.exists('/etc/opt/cray/release/CLEinfo') or os.path.exists('/etc/opt/cray/release/cle-release')):
         print(True)
     else:
         print(False)

--- a/test/library/packages/LAPACK/COMPOPTS
+++ b/test/library/packages/LAPACK/COMPOPTS
@@ -1,1 +1,1 @@
--g -I$CRAY_LIBSCI_PREFIX_DIR/include -lgfortran -lsci_gnu -L$CRAY_LIBSCI_PREFIX_DIR/lib
+-g -lgfortran -lsci_gnu

--- a/test/library/packages/LinearAlgebra.skipif
+++ b/test/library/packages/LinearAlgebra.skipif
@@ -18,7 +18,7 @@ and non-llvm configurations.
 from os import getenv, path
 
 # Make sure we're not on a whitebox
-isRealCray = path.exists('/etc/opt/cray/release') or path.exists('/etc/opt/cray/release/CLEinfo')
+isRealCray = path.exists('/etc/opt/cray/release/CLEinfo') or path.exists('/etc/opt/cray/release/cle-release')
 
 # Make sure we're on an XC
 isRealXC = isRealCray and getenv('CHPL_TARGET_PLATFORM') == 'cray-xc'

--- a/test/release/examples/primers/LAPACKlib.compopts
+++ b/test/release/examples/primers/LAPACKlib.compopts
@@ -1,1 +1,1 @@
--I$CRAY_LIBSCI_PREFIX_DIR/include -lgfortran -lsci_gnu -L$CRAY_LIBSCI_PREFIX_DIR/lib
+-lgfortran -lsci_gnu

--- a/test/release/examples/primers/LAPACKlib.skipif
+++ b/test/release/examples/primers/LAPACKlib.skipif
@@ -4,7 +4,7 @@ import os, os.path
 
 isXC = os.getenv('CHPL_TARGET_PLATFORM') == 'cray-xc'
 isGNU = 'gnu' in str(os.getenv('CHPL_TARGET_COMPILER'))
-isWB = not os.path.exists('/etc/opt/cray/release') or not os.path.exists('/etc/opt/cray/release/CLEinfo')
+isWB = not (os.path.exists('/etc/opt/cray/release/CLEinfo') or os.path.exists('/etc/opt/cray/release/cle-release'))
 isLLVM = '--llvm' in str(os.getenv('COMPOPTS'))
 
 if isXC and isGNU and not isWB and not isLLVM:

--- a/test/release/examples/primers/LinearAlgebralib.skipif
+++ b/test/release/examples/primers/LinearAlgebralib.skipif
@@ -4,7 +4,7 @@ import os, os.path
 
 isXC = os.getenv('CHPL_TARGET_PLATFORM') == 'cray-xc'
 isGNU = 'gnu' in str(os.getenv('CHPL_TARGET_COMPILER'))
-isWB = not os.path.exists('/etc/opt/cray/release') or not os.path.exists('/etc/opt/cray/release/CLEinfo')
+isWB = not (os.path.exists('/etc/opt/cray/release/CLEinfo') or os.path.exists('/etc/opt/cray/release/cle-release'))
 isLLVM = '--llvm' in str(os.getenv('COMPOPTS'))
 
 if isXC and isGNU and not isWB and not isLLVM:

--- a/test/release/examples/primers/Makefile
+++ b/test/release/examples/primers/Makefile
@@ -44,7 +44,7 @@ endif
 
 ifdef CRAY_LIBSCI_PREFIX_DIR
 	TARGETS += LAPACKlib LinearAlgebralib
-	LAPACK_OPTS = -I$(CRAY_LIBSCI_PREFIX_DIR)/include -lgfortran -lsci_gnu -L$(CRAY_LIBSCI_PREFIX_DIR)/lib
+	LAPACK_OPTS = -lgfortran -lsci_gnu
 endif
 
 REALS = $(TARGETS:%=%_real)


### PR DESCRIPTION
This cleans up some items found in testing for Cray XC50 with ARM compute nodes.

The environment variable `CRAY_LIBSCI_PREFIX_DIR` was being used explicitly in compopts files to find the cray-libsci headers and libraries, but these are found automatically by the PrgEnv modules when cray-libsci is loaded.  The environment variable is not always kept up to date by cray-libsci when other modules are loaded, so sometimes we were pointing to the wrong place when the compiler would have otherwise found the right place.  I removed our uses of this environment variable to let the PrgEnv and cray-libsci modules cooperate to do the work for us.  (We can depend on the environment variable's existence, but not its contents.)

Some tests were being skipped on Cray XC systems running CLE 6 because the file that reports the operating system version has moved.  Also, the tests for this checked the directory above first.  They only needed to check whether the file itself existed.  I've simplified the tests and added a search for the CLE 6 version of the file so these tests will now begin running again on Cray XC systems.

Tested on both Cray XC systems, where these tests should run, and whitebox systems, where they should not run.