### PR TITLE
Fix some initializer leaks

### DIFF
--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -261,4 +261,6 @@ SymExpr* findSourceOfYield(CallExpr* yield);
 
 void resolvePromotionType(AggregateType* at);
 
+void resolveDestructor(AggregateType* at);
+
 #endif

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -1969,6 +1969,18 @@ void resolvePromotionType(AggregateType* at) {
   }
 }
 
+void resolveDestructor(AggregateType* at) {
+  VarSymbol* tmp   = newTemp(at);
+  CallExpr*  call  = new CallExpr("deinit", gMethodToken, tmp);
+
+  FnSymbol* deinitFn = resolveUninsertedCall(at, call, false);
+
+  if (deinitFn != NULL) {
+    resolveFunction(deinitFn);
+    at->setDestructor(deinitFn);
+  }
+}
+
 /************************************* | **************************************
 *                                                                             *
 *                                                                             *
@@ -4977,6 +4989,9 @@ static void resolveInitField(CallExpr* call) {
     if (ct->scalarPromotionType == NULL) {
       resolvePromotionType(ct);
     }
+    if (ct->hasDestructor() == false) {
+      resolveDestructor(ct);
+    }
   }
 
   if (t != fs->type && t != dtNil && t != dtObject) {
@@ -6836,6 +6851,9 @@ static void resolveExprExpandGenerics(CallExpr* call) {
               if (wasGeneric == true && ct->symbol->hasFlag(FLAG_GENERIC) == false) {
                 if (ct->scalarPromotionType == NULL) {
                   resolvePromotionType(ct);
+                }
+                if (ct->hasDestructor() == false) {
+                  resolveDestructor(ct);
                 }
               }
             }

--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -366,9 +366,6 @@ void resolveFunction(FnSymbol* fn) {
           at->symbol->hasFlag(FLAG_GENERIC) == false) {
         resolvePromotionType(at);
       }
-      if (at->hasDestructor() == false) {
-        resolveDestructor(at);
-      }
     }
 
     if (fn->hasFlag(FLAG_EXTERN) == true) {

--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -366,6 +366,9 @@ void resolveFunction(FnSymbol* fn) {
           at->symbol->hasFlag(FLAG_GENERIC) == false) {
         resolvePromotionType(at);
       }
+      if (at->hasDestructor() == false) {
+        resolveDestructor(at);
+      }
     }
 
     if (fn->hasFlag(FLAG_EXTERN) == true) {

--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -1041,6 +1041,9 @@ static void formalIsDefaulted(FnSymbol*  fn,
         }
       }
     }
+  } else if (strcmp(fn->name, "_new") == 0 ||
+             fn->isInitializer()) {
+    temp->addFlag(FLAG_INSERT_AUTO_DESTROY);
   }
 }
 

--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -1043,7 +1043,10 @@ static void formalIsDefaulted(FnSymbol*  fn,
     }
   } else if (strcmp(fn->name, "_new") == 0 ||
              fn->isInitializer()) {
-    temp->addFlag(FLAG_INSERT_AUTO_DESTROY);
+    if (isSyncType(formal->getValType()) == false &&
+        isSingleType(formal->getValType()) == false) {
+      temp->addFlag(FLAG_INSERT_AUTO_DESTROY);
+    }
   }
 }
 

--- a/test/classes/initializers/memory/callParentDeinit.chpl
+++ b/test/classes/initializers/memory/callParentDeinit.chpl
@@ -1,0 +1,60 @@
+
+//
+// Simple case to ensure all deinits in a hierarchy are called
+//
+
+pragma "use default init"
+class Parent {
+  type idxType;
+
+  proc deinit() {
+    writeln("Parent.deinit");
+  }
+}
+
+class Child : Parent {
+  proc init(type t) {
+    super.init(t);
+  }
+  proc deinit() {
+    writeln("Child.deinit");
+  }
+}
+
+var ch = new Child(int);
+delete ch;
+
+writeln();
+
+//
+// More complex case that mimics some BaseDom hierarchy
+//
+
+pragma "use default init"
+class A {
+  param rank : int;
+  type idxType;
+  proc deinit() {
+    writeln("A.deinit");
+  }
+}
+
+pragma "use default init"
+class B : A {
+  var x : int;
+  proc deinit() {
+    writeln("B.deinit");
+  }
+}
+
+class C : B {
+  proc init(param rank : int, type idxType) {
+    super.init(rank, idxType);
+  }
+  proc deinit() {
+    writeln("C.deinit");
+  }
+}
+
+var c = new C(1, int);
+delete c;

--- a/test/classes/initializers/memory/callParentDeinit.good
+++ b/test/classes/initializers/memory/callParentDeinit.good
@@ -1,0 +1,6 @@
+Child.deinit
+Parent.deinit
+
+C.deinit
+B.deinit
+A.deinit

--- a/test/classes/initializers/memory/destroyDefaultArg.chpl
+++ b/test/classes/initializers/memory/destroyDefaultArg.chpl
@@ -1,0 +1,71 @@
+
+var resource = 0;
+
+record R {
+  var x : int;
+
+  proc init() {
+    resource += 1;
+    x = 0;
+    writeln("R.init()");
+  }
+
+  proc init(other:R) {
+    resource += 1;
+    this.x = 1;
+    writeln("R.init(R): ", x);
+  }
+
+  proc deinit() {
+    resource -= 1;
+    writeln("R.deinit(): ", x);
+  }
+}
+
+pragma "use default init"
+class CC {
+  var r : R;
+}
+
+{
+  writeln("----- Concrete Class -----");
+  var cc = new CC();
+  delete cc;
+}
+writeln("resource = ", resource);
+
+pragma "use default init"
+class GC {
+  type t;
+  var r : R;
+}
+
+{
+  writeln("----- Generic Class -----");
+  var gc = new GC(int);
+  delete gc;
+}
+writeln("resource = ", resource);
+
+pragma "use default init"
+record CR {
+  var r : R;
+}
+
+{
+  writeln("----- Concrete Record -----");
+  var cr = new CR();
+}
+writeln("resource = ", resource);
+
+pragma "use default init"
+record GR {
+  type t;
+  var r : R;
+}
+
+{
+  writeln("----- Generic Record -----");
+  var gr = new GR(int);
+}
+writeln("resource = ", resource);

--- a/test/classes/initializers/memory/destroyDefaultArg.good
+++ b/test/classes/initializers/memory/destroyDefaultArg.good
@@ -1,0 +1,24 @@
+----- Concrete Class -----
+R.init()
+R.init(R): 1
+R.deinit(): 0
+R.deinit(): 1
+resource = 0
+----- Generic Class -----
+R.init()
+R.init(R): 1
+R.deinit(): 0
+R.deinit(): 1
+resource = 0
+----- Concrete Record -----
+R.init()
+R.init(R): 1
+R.deinit(): 0
+R.deinit(): 1
+resource = 0
+----- Generic Record -----
+R.init()
+R.init(R): 1
+R.deinit(): 0
+R.deinit(): 1
+resource = 0


### PR DESCRIPTION
This PR resolves two kinds of initializer leaks:
1) Parent deinits were not always called. This leak is resolved by setting the destructor on the appropriate AggregateType once fully instantiated.
2) Some default initializer values were not destroyed. This is resolved by adding FLAG_INSERT_AUTO_DESTROY to certain default values.

Two tests are added to lock in this behavior.

Testing:
- [x] full local + futures
- [x] full valgrind
- [x] full memleaks

This PR also recovers the leaks introduced by #9075 