### PR TITLE
Convert BaseDom and its derived classes to use initializers

### DIFF
--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -263,4 +263,6 @@ void resolvePromotionType(AggregateType* at);
 
 void resolveDestructor(AggregateType* at);
 
+void fixTypeNames(AggregateType* at);
+
 #endif

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -4994,6 +4994,9 @@ static void resolveInitField(CallExpr* call) {
     if (ct->scalarPromotionType == NULL) {
       resolvePromotionType(ct);
     }
+    if (developer == false) {
+      fixTypeNames(ct);
+    }
     // BHARSH INIT TODO: Would like to resolve destructor here, but field
     // types are not fully resolved. E.g., "var foo : t"
   }
@@ -6855,6 +6858,9 @@ static void resolveExprExpandGenerics(CallExpr* call) {
               if (wasGeneric == true && ct->symbol->hasFlag(FLAG_GENERIC) == false) {
                 if (ct->scalarPromotionType == NULL) {
                   resolvePromotionType(ct);
+                }
+                if (developer == false) {
+                  fixTypeNames(ct);
                 }
               }
             }

--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -856,7 +856,7 @@ void fixTypeNames(AggregateType* at) {
     at->symbol->name = astr("[", domainType, "] ", eltType);
 
   } else if (strncmp(at->symbol->name, domName, domNameLen) == 0) {
-    at->symbol->name = astr("domain", at->symbol->name + strlen(domName));
+    at->symbol->name = astr("domain", at->symbol->name + domNameLen);
 
   } else if (isRecordWrappedType(at) == true) {
     at->symbol->name = at->getField("_instance")->type->symbol->name;

--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -366,6 +366,9 @@ void resolveFunction(FnSymbol* fn) {
           at->symbol->hasFlag(FLAG_GENERIC) == false) {
         resolvePromotionType(at);
       }
+      if (developer == false) {
+        fixTypeNames(at);
+      }
     }
 
     if (fn->hasFlag(FLAG_EXTERN) == true) {
@@ -780,7 +783,6 @@ static FnSymbol* makeIteratorMethod(IteratorInfo* ii,
 *                                                                             *
 ************************************** | *************************************/
 
-static void      fixTypeNames(AggregateType* at);
 static void      resolveDefaultTypeConstructor(AggregateType* at);
 static void      instantiateDefaultConstructor(FnSymbol* fn);
 static FnSymbol* instantiateBase(FnSymbol* fn);
@@ -842,9 +844,9 @@ static void resolveTypeConstructor(FnSymbol* fn) {
   }
 }
 
-static void fixTypeNames(AggregateType* at) {
+void fixTypeNames(AggregateType* at) {
   const char*    domName = "DefaultRectangularDom";
-  AggregateType* from    = at->instantiatedFrom;
+  const int   domNameLen = 21;
 
   if (at->symbol->hasFlag(FLAG_BASE_ARRAY) == false &&
       isArrayClass(at)                     ==  true) {
@@ -853,7 +855,7 @@ static void fixTypeNames(AggregateType* at) {
 
     at->symbol->name = astr("[", domainType, "] ", eltType);
 
-  } else if (from != NULL && strcmp(from->symbol->name, domName) == 0) {
+  } else if (strncmp(at->symbol->name, domName, domNameLen) == 0) {
     at->symbol->name = astr("domain", at->symbol->name + strlen(domName));
 
   } else if (isRecordWrappedType(at) == true) {

--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -846,7 +846,7 @@ static void resolveTypeConstructor(FnSymbol* fn) {
 
 void fixTypeNames(AggregateType* at) {
   const char*    domName = "DefaultRectangularDom";
-  const int   domNameLen = 21;
+  const int   domNameLen = strlen(domName);
 
   if (at->symbol->hasFlag(FLAG_BASE_ARRAY) == false &&
       isArrayClass(at)                     ==  true) {

--- a/modules/dists/BlockCycDist.chpl
+++ b/modules/dists/BlockCycDist.chpl
@@ -477,6 +477,7 @@ proc LocBlockCyclic.writeThis(x) {
 ////////////////////////////////////////////////////////////////////////////////
 // BlockCyclic Domain Class
 //
+pragma "use default init"
 class BlockCyclicDom: BaseRectangularDom {
   //
   // LEFT LINK: a pointer to the parent distribution
@@ -698,7 +699,11 @@ class LocBlockCyclicDom {
   // indices back to the local index type.
   //
   var myStarts: domain(rank, idxType, stridable=true);
-  var myFlatInds: domain(1) = {0..#computeFlatInds()};
+  var myFlatInds: domain(1);
+}
+
+proc LocBlockCyclicDom.postinit() {
+  myFlatInds = {0..#computeFlatInds()};
 }
 
 //

--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -337,6 +337,7 @@ class LocBlock {
 // locDoms:   a non-distributed array of local domain classes
 // whole:     a non-distributed domain that defines the domain's indices
 //
+pragma "use default init"
 class BlockDom: BaseRectangularDom {
   type sparseLayoutType;
   const dist: Block(rank, idxType, sparseLayoutType);

--- a/modules/dists/CyclicDist.chpl
+++ b/modules/dists/CyclicDist.chpl
@@ -442,6 +442,7 @@ class LocCyclic {
 }
 
 
+pragma "use default init"
 class CyclicDom : BaseRectangularDom {
   const dist: Cyclic(rank, idxType);
 

--- a/modules/dists/DimensionalDist2D.chpl
+++ b/modules/dists/DimensionalDist2D.chpl
@@ -270,6 +270,21 @@ class DimensionalDist2D : BaseDist {
 
 // class LocDimensionalDist - no local distribution descriptor - for now
 
+private proc locDescTypeHelper(param rank : int, type idxType, dom1, dom2) type {
+  type d1type = dom1.dsiNewLocalDom1d(idxType, 0).type;
+  type d2type = dom2.dsiNewLocalDom1d(idxType, 0).type;
+
+  proc strideHelper(dom1d) param {
+    const dummy = dom1d.dsiNewLocalDom1d(idxType, 0).dsiSetLocalIndices1d(dom1d, 0);
+    return dummy.stridable;
+  }
+
+  param str = strideHelper(dom1) || strideHelper(dom2);
+
+  return LocDimensionalDom(domain(rank, idxType, str), d1type, d2type);
+}
+
+pragma "use default init"
 class DimensionalDom : BaseRectangularDom {
   // required
   const dist; // not reprivatized
@@ -285,7 +300,7 @@ class DimensionalDom : BaseRectangularDom {
 
   // This is our index set; we store it here so we can get to it easily.
   // Although strictly speaking it is not necessary.
-  var whole: domainT;
+  var whole: domain(rank, idxType, stridable);
 
   // This is the idxType of the "storage index ranges" to be produced
   // by dsiSetLocalIndices1d(). It needs to be uniform across dimensions,
@@ -311,8 +326,10 @@ class DimensionalDom : BaseRectangularDom {
                                          dom1.dsiNewLocalDom1d(stoIndexT, 0:locIdT).type,
                                          dom2.dsiNewLocalDom1d(stoIndexT, 0:locIdT).type);
 
-  // local domain descriptors
-  var localDdescs: [dist.targetIds] locDdescType; // not reprivatized
+  // local domain descriptors, not reprivatized
+  // INIT TODO: Used to use 'locDdescType' instead of 'locDescTypeHelper'. Can
+  // we clean this up?
+  var localDdescs: [dist.targetIds] locDescTypeHelper(rank, idxType, dom1, dom2); // locDdescType
 }
 
 class LocDimensionalDom {

--- a/modules/dists/PrivateDist.chpl
+++ b/modules/dists/PrivateDist.chpl
@@ -87,6 +87,7 @@ class Private: BaseDist {
   proc singleton() param return true;
 }
 
+pragma "use default init"
 class PrivateDom: BaseRectangularDom {
   var dist: Private;
 

--- a/modules/dists/ReplicatedDist.chpl
+++ b/modules/dists/ReplicatedDist.chpl
@@ -175,6 +175,7 @@ proc Replicated.dsiPrivatize(privatizeData)
 //
 // global domain class
 //
+pragma "use default init"
 class ReplicatedDom : BaseRectangularDom {
   // we need to be able to provide the domain map for our domain - to build its
   // runtime type (because the domain map is part of the type - for any domain)

--- a/modules/dists/SparseBlockDist.chpl
+++ b/modules/dists/SparseBlockDist.chpl
@@ -64,7 +64,7 @@ class SparseBlockDom: BaseSparseDomImpl {
   var locDoms: [dist.targetLocDom] LocSparseBlockDom(rank, idxType, stridable,
       sparseLayoutType);
 
-  proc initialize() {
+  proc postinit() {
     setup();
     //    writeln("Exiting initialize");
   }

--- a/modules/dists/StencilDist.chpl
+++ b/modules/dists/StencilDist.chpl
@@ -279,6 +279,7 @@ class LocStencil {
 // locDoms:   a non-distributed array of local domain classes
 // whole:     a non-distributed domain that defines the domain's indices
 //
+pragma "use default init"
 class StencilDom: BaseRectangularDom {
   param ignoreFluff : bool;
   const dist: Stencil(rank, idxType, ignoreFluff);

--- a/modules/internal/ArrayViewRankChange.chpl
+++ b/modules/internal/ArrayViewRankChange.chpl
@@ -116,6 +116,7 @@ module ArrayViewRankChange {
   // for rectangular domains (because they're the only ones with
   // rank>1), so this is a subclass of BaseRectangularDom.
   //
+ pragma "use default init"
  class ArrayViewRankChangeDom: BaseRectangularDom {
     // the lower-dimensional index set that we represent upwards
     var upDom: DefaultRectangularDom(rank, idxType, stridable);
@@ -139,8 +140,11 @@ module ArrayViewRankChange {
     }
 
     // the higher-dimensional domain that we're equivalent to
+    //
+    // BHARSH INIT TODO: use 'downrank' instead of 'collapsedDim.rank'
+    //
     var downDomPid:int;
-    var downDomInst: downDomType(downrank, idxType, stridable);
+    var downDomInst: downDomType(collapsedDim.rank, idxType, stridable);
 
     //
     // TODO: If we put this expression into the variable declaration

--- a/modules/internal/ArrayViewRankChange.chpl
+++ b/modules/internal/ArrayViewRankChange.chpl
@@ -109,6 +109,16 @@ module ArrayViewRankChange {
     }
   }
 
+  private proc downDomType(param rank : int,
+                           type idxType,
+                           param stridable : bool,
+                           dist) type {
+      var ranges: rank*range(idxType, BoundedRangeType.bounded, stridable);
+      var a = dist.downDist.dsiNewRectangularDom(rank=rank, idxType,
+                                                 stridable=stridable, ranges);
+      return a.type;
+  }
+
   //
   // This class represents the domain of a rank-change slice of an
   // array.  Like other domain class implementations, it supports the
@@ -141,21 +151,10 @@ module ArrayViewRankChange {
 
     // the higher-dimensional domain that we're equivalent to
     //
-    // BHARSH INIT TODO: use 'downrank' instead of 'collapsedDim.rank'
+    // BHARSH INIT TODO: use 'downrank' instead of 'collapsedDim.size'
     //
     var downDomPid:int;
-    var downDomInst: downDomType(collapsedDim.rank, idxType, stridable);
-
-    //
-    // TODO: If we put this expression into the variable declaration
-    // above, we get a memory leak.  File a future against this?
-    //
-    proc downDomType(param rank: int, type idxType, param stridable: bool) type {
-      var ranges: rank*range(idxType, BoundedRangeType.bounded, stridable);
-      var a = dist.downDist.dsiNewRectangularDom(rank=rank, idxType,
-                                                 stridable=stridable, ranges);
-      return a.type;
-    }
+    var downDomInst: downDomType(collapsedDim.size, idxType, stridable, distInst);
 
     proc downrank param {
       return collapsedDim.size;

--- a/modules/internal/ArrayViewReindex.chpl
+++ b/modules/internal/ArrayViewReindex.chpl
@@ -98,6 +98,7 @@ module ArrayViewReindex {
   // for rectangular domains so this is a subclass of
   // BaseRectangularDom.
   //
+ pragma "use default init"
  class ArrayViewReindexDom: BaseRectangularDom {
     // the new reindexed index set that we represent upwards
     var updom: DefaultRectangularDom(rank, idxType, stridable);

--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -168,6 +168,7 @@ module ChapelDistribution {
   // Abstract domain classes
   //
   pragma "base domain"
+  pragma "use default init"
   class BaseDom {
     // The common case seems to be local access to this class, so we
     // will use explicit processor atomics, even when network
@@ -363,6 +364,7 @@ module ChapelDistribution {
     //   }
   }
 
+  pragma "use default init"
   class BaseRectangularDom : BaseDom {
     param rank : int;
     type idxType;
@@ -388,6 +390,7 @@ module ChapelDistribution {
     }
   }
 
+  pragma "use default init"
   class BaseSparseDomImpl : BaseSparseDom {
 
     var nnzDom = {1..nnz};
@@ -548,6 +551,7 @@ module ChapelDistribution {
 
   }
 
+  pragma "use default init"
   class BaseSparseDom : BaseDom {
     // rank and idxType will be moved to BaseDom
     param rank: int;
@@ -606,6 +610,7 @@ module ChapelDistribution {
   } // end BaseSparseDom
 
 
+  pragma "use default init"
   class BaseAssociativeDom : BaseDom {
     proc deinit() {
       // this is a bug workaround
@@ -622,6 +627,7 @@ module ChapelDistribution {
 
   }
 
+  pragma "use default init"
   class BaseOpaqueDom : BaseDom {
     proc deinit() {
       // this is a bug workaround

--- a/modules/internal/DefaultAssociative.chpl
+++ b/modules/internal/DefaultAssociative.chpl
@@ -64,7 +64,7 @@ module DefaultAssociative {
     var numEntries: atomic_int64;
     var tableLock: atomicbool; // do not access directly, use function below
     var tableSizeNum = 1;
-    var tableSize:int = chpl__primes(tableSizeNum);
+    var tableSize : int;
     var tableDom = {0..tableSize-1};
     var table: [tableDom] chpl_TableEntry(idxType);
   
@@ -83,13 +83,16 @@ module DefaultAssociative {
     proc linksDistribution() param return false;
     proc dsiLinksDistribution()     return false;
   
-    proc DefaultAssociativeDom(type idxType,
-                               param parSafe: bool,
-                               dist: DefaultDist) {
+    proc init(type idxType,
+              param parSafe: bool,
+              dist: DefaultDist) {
       if !chpl__validDefaultAssocDomIdxType(idxType) then
         compilerError("Default Associative domains with idxType=",
                       idxType:string, " are not allowed", 2);
+      this.idxType = idxType;
+      this.parSafe = parSafe;
       this.dist = dist;
+      this.tableSize = chpl__primes(tableSizeNum);
     }
   
     //

--- a/modules/internal/DefaultOpaque.chpl
+++ b/modules/internal/DefaultOpaque.chpl
@@ -69,7 +69,8 @@ module DefaultOpaque {
     proc linksDistribution() param return false;
     proc dsiLinksDistribution()     return false;
   
-    proc DefaultOpaqueDom(dist: DefaultDist, param parSafe: bool) {
+    proc init(dist: DefaultDist, param parSafe: bool) {
+      this.parSafe = parSafe;
       this.dist = dist;
       adomain = new DefaultAssociativeDom(_OpaqueIndex, dist, parSafe=parSafe);
     }

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -101,7 +101,8 @@ module DefaultRectangular {
 
     proc isDefaultRectangular() param return true;
 
-    proc DefaultRectangularDom(param rank, type idxType, param stridable, dist) {
+    proc init(param rank, type idxType, param stridable, dist) {
+      super.init(rank=rank, idxType=idxType, stridable=stridable);
       this.dist = dist;
     }
 

--- a/modules/internal/DefaultSparse.chpl
+++ b/modules/internal/DefaultSparse.chpl
@@ -34,11 +34,11 @@ module DefaultSparse {
     proc linksDistribution() param return false;
     proc dsiLinksDistribution()     return false;
 
-    proc DefaultSparseDom(param rank, type idxType, dist: DefaultDist,
+    proc init(param rank, type idxType, dist: DefaultDist,
         parentDom: domain) {
+      super.init(rank=rank, idxType=idxType, parentDom=parentDom);
 
       this.dist = dist;
-      this.parentDom = parentDom;
     }
 
     proc dsiBuildArray(type eltType)

--- a/modules/layouts/LayoutCS.chpl
+++ b/modules/layouts/LayoutCS.chpl
@@ -108,17 +108,24 @@ class CSDom: BaseSparseDomImpl {
   var idx: [nnzDom] idxType;        // would like index(parentDom.dim(1))
 
   /* Initializer */
-  proc CSDom(param rank, type idxType, param compressRows, param stridable, dist: CS(compressRows), parentDom: domain) {
+  proc init(param rank, type idxType, param compressRows, param stridable, dist: CS(compressRows), parentDom: domain) {
     if (rank != 2 || parentDom.rank != 2) then
       compilerError("Only 2D sparse domains are supported by the CS distribution");
     if parentDom.idxType != idxType then
       compilerError("idxType mismatch in CSDom.init(): " + idxType:string + " != " + parentDom.idxType:string);
 
+    super.init(rank, idxType, parentDom);
+
+    this.compressRows = compressRows;
+    this.stridable = stridable;
+
     this.dist = dist;
-    this.parentDom = parentDom;
     rowRange = parentDom.dim(1);
     colRange = parentDom.dim(2);
     startIdxDom = if compressRows then {rowRange.low..rowRange.high+1} else {colRange.low..colRange.high+1};
+
+    this.complete();
+
     nnzDom = {1..nnz};
     dsiClear();
   }

--- a/modules/layouts/LayoutCS.chpl
+++ b/modules/layouts/LayoutCS.chpl
@@ -114,7 +114,7 @@ class CSDom: BaseSparseDomImpl {
     if parentDom.idxType != idxType then
       compilerError("idxType mismatch in CSDom.init(): " + idxType:string + " != " + parentDom.idxType:string);
 
-    super.init(rank, idxType, parentDom);
+    super.init(rank=rank, idxType=idxType, parentDom=parentDom);
 
     this.compressRows = compressRows;
     this.stridable = stridable;

--- a/test/distributions/bradc/assoc/UserMapAssoc.chpl
+++ b/test/distributions/bradc/assoc/UserMapAssoc.chpl
@@ -254,6 +254,7 @@ class UserMapAssoc : BaseDist {
 //
 // The global domain class
 //
+pragma "use default init"
 class UserMapAssocDom: BaseAssociativeDom {
   param parSafe: bool=true; // we need this because of the wrapper interface
 

--- a/test/distributions/bradc/wrongDomForDist/DummyArithDist.chpl
+++ b/test/distributions/bradc/wrongDomForDist/DummyArithDist.chpl
@@ -11,6 +11,7 @@ class MyDist : BaseDist {
   proc dsiClone() return new MyDist();
 }
 
+pragma "use default init"
 class MyDom : BaseRectangularDom {
   const dist: MyDist;
 

--- a/test/distributions/bradc/wrongDomForDist/DummyAssocDist.chpl
+++ b/test/distributions/bradc/wrongDomForDist/DummyAssocDist.chpl
@@ -8,6 +8,7 @@ class MyDist : BaseDist {
   proc dsiClone() return new MyDist();
 }
 
+pragma "use default init"
 class MyDom : BaseAssociativeDom {
   type idxType = int(32);
   const dist: MyDist;

--- a/test/domains/vass/no-dom-field-error.chpl
+++ b/test/domains/vass/no-dom-field-error.chpl
@@ -30,10 +30,13 @@ proc GlobalDistribution.dsiNewArithmeticDom(param rank: int,
   return new GlobalDomain(rank, idxType, stridable);
 }
 
-proc GlobalDomain.GlobalDomain(param rank: int,
+proc GlobalDomain.init(param rank: int,
                                type idxType,
-                               param stridable: bool)
-{}
+                               param stridable: bool) {
+  this.rank = rank;
+  this.idxType = idxType;
+  this.stridable = stridable;
+}
 
 proc GlobalDomain.dsiSetIndices(arg_ranges: rank * range(idxType)): void {
   ranges = arg_ranges;

--- a/test/functions/vass/arg-is-tuple-with-generic-class.chpl
+++ b/test/functions/vass/arg-is-tuple-with-generic-class.chpl
@@ -3,8 +3,10 @@ class TestDom: BaseSparseDom {
   type idxType;
   var parentDom;
 
-  proc TestDom(param rank, type idxType, 
+  proc init(param rank, type idxType,
                                parentDom: domain) {
+    this.rank = rank;
+    this.idxType = idxType;
     this.parentDom = parentDom;
   }
 

--- a/test/studies/comd/elegant/arrayOfStructs/util/AccumStencilDist.chpl
+++ b/test/studies/comd/elegant/arrayOfStructs/util/AccumStencilDist.chpl
@@ -80,6 +80,7 @@ class LocAccumStencil {
 // locDoms:   a non-distributed array of local domain classes
 // whole:     a non-distributed domain that defines the domain's indices
 //
+pragma "use default init"
 class AccumStencilDom: BaseRectangularDom {
   param ignoreFluff : bool;
   const dist: AccumStencil(rank, idxType, ignoreFluff);

--- a/test/users/vass/crash1callDestructorsAddon.chpl
+++ b/test/users/vass/crash1callDestructorsAddon.chpl
@@ -76,6 +76,11 @@ class DimensionalDist : BaseDist {
 
 // class LocDimensionalDist - no local distribution descriptor - for now
 
+private proc locDescTypeHelper(dom1, dom2) type {
+  return (dom1.dsiNewLocalDom1d(0).type, dom2.dsiNewLocalDom1d(0).type);
+}
+
+pragma "use default init"
 class DimensionalDom : BaseRectangularDom {
   // required
   param rank: int;
@@ -93,7 +98,7 @@ class DimensionalDom : BaseRectangularDom {
 
   // this is our index set; we store it here so we can get to it easily
   // although it is not necessary, strictly speaking
-  var whole: domainT;
+  var whole: domain(rank, idxType, stridable);
 
   // convenience - our instantiation of LocDimensionalDom
   proc lddTypeArg1 type  return domainT;
@@ -102,7 +107,8 @@ class DimensionalDom : BaseRectangularDom {
   proc locDdescType type  return LocDimensionalDom(lddTypeArg1, lddTypeArg2);
 
   // local domain descriptors
-  var localDdescs: [dist.targetIds] locDdescType; // not reprivatized
+  var localDdescs : [dist.targetIdx] LocDimensionalDom(domain(rank, idxType, stridable),
+                                                       locDescTypeHelper(dom1, dom2));
 
   // for privatization
   var pid: int = -1;

--- a/test/users/vass/crash1callDestructorsMain.chpl
+++ b/test/users/vass/crash1callDestructorsMain.chpl
@@ -76,6 +76,10 @@ class DimensionalDist : BaseDist {
 
 // class LocDimensionalDist - no local distribution descriptor - for now
 
+private proc locDescTypeHelper(dom1, dom2) type {
+  return (dom1.dsiNewLocalDom1d(0).type, dom2.dsiNewLocalDom1d(0).type);
+}
+
 class DimensionalDom : BaseRectangularDom {
   // required
   param rank: int;
@@ -93,7 +97,7 @@ class DimensionalDom : BaseRectangularDom {
 
   // this is our index set; we store it here so we can get to it easily
   // although it is not necessary, strictly speaking
-  var whole: domainT;
+  var whole: domain(rank, idxType, stridable);
 
   // convenience - our instantiation of LocDimensionalDom
   proc lddTypeArg1 type  return domainT;
@@ -102,7 +106,8 @@ class DimensionalDom : BaseRectangularDom {
   proc locDdescType type  return LocDimensionalDom(lddTypeArg1, lddTypeArg2);
 
   // local domain descriptors
-  var localDdescs: [dist.targetIds] locDdescType; // not reprivatized
+  var localDdescs : [dist.targetIdx] LocDimensionalDom(domain(rank, idxType, stridable),
+                                                       locDescTypeHelper(dom1, dom2));
 
   // for privatization
   var pid: int = -1;


### PR DESCRIPTION
This PR converts BaseDom and all of its derived classes to use initializers instead of constructors. This is accomplished by either adding a "use default init" pragma or by converting an existing constructor to an initializer.

A small compiler change is made to fix the name of DefaultRectangularDom so that users just see "domain". This functionality existed before, but only for constructors.

Future work:
- Allow field default value to be call on the result of another call (DefaultAssociativeDom)
- Rework BaseDom* classes in ChapelDistribution to use explicit initializers, and stop using named args in derived class' super.init.

Testing:
- [x] full local + futures
- [x] full gasnet