### PR TITLE
Be conservative about IPA

### DIFF
--- a/make/compiler/Makefile.cray-prgenv-cray
+++ b/make/compiler/Makefile.cray-prgenv-cray
@@ -51,3 +51,8 @@ CHPL_GASNET_MORE_CFLAGS += -O0 -UNDEBUG
 endif
 
 include $(CHPL_MAKE_HOME)/make/compiler/Makefile.cray-prgenv
+
+# Certain versions of CCE have had difficulty with high levels of
+# interprocedural analysis.  We conservatively back off slightly in
+# case someone happens to be using one of those versions.
+OPT_CFLAGS += -hipa2


### PR DESCRIPTION
We don't always control which version of CCE is being used.  This change conservatively backs off interprocedural analysis (IPA) optimizations slightly in case someone is using a version that has had difficulty with high levels of IPA.

Verified to work and to avoid under- or over-optimizing on x86-64 and ARM Cray systems.