### PR TITLE
Fix install llvm

### DIFF
--- a/configure
+++ b/configure
@@ -144,7 +144,7 @@ fi
 # and then move it.
 # Note that the resulting chplconfig is expected to cover the same
 # material as any existing chplconfig.
-./util/printchplenv --simple --overrides --anonymize > configured-chplconfig
+./util/printchplenv --all --simple --overrides --anonymize > configured-chplconfig
 mv configured-chplconfig chplconfig
 
 echo

--- a/util/buildRelease/install.sh
+++ b/util/buildRelease/install.sh
@@ -314,6 +314,9 @@ do
   fi
 done
 
+# copy filter-llvm-config.awk
+myinstallfile third-party/llvm/filter-llvm-config.awk "$DEST_THIRD_PARTY"/llvm
+
 # copy utf8-decoder header
 myinstallfile third-party/utf8-decoder/utf8-decoder.h "$DEST_THIRD_PARTY"/utf8-decoder/
 

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -7,7 +7,7 @@ chplenv_dir = os.path.dirname(__file__)
 sys.path.insert(0, os.path.abspath(chplenv_dir))
 
 import chpl_compiler, chpl_platform, overrides
-from chpl_home_utils import get_chpl_home
+from chpl_home_utils import get_chpl_third_party
 from utils import memoize
 
 
@@ -17,9 +17,9 @@ def get():
     if not llvm_val:
         host_platform = chpl_platform.get('host')
         host_compiler = chpl_compiler.get('host')
-        chpl_home = get_chpl_home()
+        chpl_third_party = get_chpl_third_party()
         llvm_target_dir = '{0}-{1}'.format(host_platform, host_compiler)
-        llvm_subdir = os.path.join(chpl_home, 'third-party', 'llvm', 'install',
+        llvm_subdir = os.path.join(chpl_third_party, 'llvm', 'install',
                                    llvm_target_dir)
         llvm_header = os.path.join(llvm_subdir, 'include', 'llvm',
                                    'PassSupport.h')


### PR DESCRIPTION
Fixes multiple issues with `make install` for LLVM configurations.

 * CHPL_LLVM was not being set in the chplconfig even if it was overridden
 * CHPL_LLVM was not being correctly computed if it was not set anywhere
 * the file filter-llvm-config.awk is used for C compiles with CHPL_LLVM=llvm and was missing from the installation directory.

Fixes #9144.

- [x] full local testing

Reviewed by @ben-albrecht - thanks!