### PR TITLE
Fix library-related flags for LLVM back-end

### DIFF
--- a/compiler/include/files.h
+++ b/compiler/include/files.h
@@ -32,8 +32,8 @@ extern std::string ccflags;
 extern std::string ldflags;
 extern bool ccwarnings;
 extern Vec<const char*> incDirs;
-extern int numLibFlags;
-extern const char** libFlag;
+extern Vec<const char*> libDirs;
+extern Vec<const char*> libFiles;
 
 struct fileinfo {
   FILE* fptr;

--- a/compiler/util/clangUtil.cpp
+++ b/compiler/util/clangUtil.cpp
@@ -1620,7 +1620,7 @@ void runClang(const char* just_parse_filename) {
 
   clangCCArgs.push_back("-pthread");
 
-  // libFlag and ldflags are handled during linking later.
+  // library directories/files and ldflags are handled during linking later.
 
   clangCCArgs.push_back("-DCHPL_GEN_CODE");
 
@@ -2798,9 +2798,13 @@ void makeBinaryLLVM(void) {
   // Put user-requested libraries at the end of the compile line,
   // they should at least be after the .o files and should be in
   // order where libraries depend on libraries to their right.
-  for (int i=0; i<numLibFlags; i++) {
-    command += " ";
-    command += libFlag[i];
+  forv_Vec(const char*, dirName, libDirs) {
+    command += " -L";
+    command += dirName;
+  }
+  forv_Vec(const char*, libName, libFiles) {
+    command += " -l";
+    command += libName;
   }
 
   if( printSystemCommands ) {

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -59,9 +59,9 @@ char               saveCDir[FILENAME_MAX + 1]           = "";
 std::string ccflags;
 std::string ldflags;
 
-Vec<const char*>   libFiles;
-Vec<const char*>   libDirs;
 Vec<const char*>   incDirs;
+Vec<const char*>   libDirs;
+Vec<const char*>   libFiles;
 
 // directory for intermediates; tmpdir or saveCDir
 static const char* intDirName        = NULL;


### PR DESCRIPTION
In working on PR #9030, I didn't test the LLVM back-end and failed
to notice that my changes would break it.  This replaces the old
array of library flags generation for LLVM with the new STL Vector-based
approach.