### PR TITLE
Convert BaseArr and its derived classes to use initializers

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -1805,8 +1805,10 @@ void AggregateType::fieldToArg(FnSymbol*              fn,
 
           typeExpr->insertAtTail(new CallExpr(PRIM_TYPEOF, tmp));
 
-          arg->typeExpr    = typeExpr;
-          arg->type        = dtAny;
+          arg->typeExpr = typeExpr;
+          if (arg->hasFlag(FLAG_TYPE_VARIABLE)) {
+            arg->type = dtAny;
+          }
 
           // set up the ArgSymbol appropriately for the type
           // and initialization from the field declaration.

--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -561,7 +561,8 @@ AggregateType* AggregateType::generateType(SymbolMap& subs) {
     AggregateType* parent = dispatchParents.v[0];
 
     // Is the parent generic?
-    if (parent->typeConstructor->numFormals() > 0) {
+    if (parent->typeConstructor != NULL &&
+        parent->typeConstructor->numFormals() > 0) {
       AggregateType* instantiatedParent = parent->generateType(subs);
 
       retval = instantiationWithParent(instantiatedParent);

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -1128,7 +1128,8 @@ TypeSymbol::TypeSymbol(const char* init_name, Type* init_type) :
     llvmTbaaAggTypeDescriptor(NULL),
     llvmTbaaStructCopyNode(NULL), llvmConstTbaaStructCopyNode(NULL),
     llvmDIType(NULL),
-    doc(NULL)
+    doc(NULL),
+    instantiationPoint(NULL)
 {
   addFlag(FLAG_TYPE_VARIABLE);
   if (!type)
@@ -1155,6 +1156,7 @@ TypeSymbol::copyInner(SymbolMap* map) {
   new_type->addSymbol(new_type_symbol);
   new_type_symbol->copyFlags(this);
   new_type_symbol->cname = cname;
+  new_type_symbol->instantiationPoint = instantiationPoint;
   return new_type_symbol;
 }
 

--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -260,6 +260,8 @@ bool isAutoDestroyedVariable(Symbol* sym);
 
 SymExpr* findSourceOfYield(CallExpr* yield);
 
+void resolveTypeWithInitializer(AggregateType* at, FnSymbol* fn);
+
 void resolvePromotionType(AggregateType* at);
 
 void resolveDestructor(AggregateType* at);

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -505,6 +505,8 @@ class TypeSymbol : public Symbol {
 
   const char* doc;
 
+  BlockStmt* instantiationPoint;
+
  private:
   void renameInstantiatedStart();
   void renameInstantiatedIndividual(Symbol* sym);

--- a/compiler/resolution/ResolutionCandidate.cpp
+++ b/compiler/resolution/ResolutionCandidate.cpp
@@ -534,6 +534,21 @@ static bool isCandidateInit(ResolutionCandidate* res, CallInfo& info) {
   return retval;
 }
 
+static bool isCandidateNew(ResolutionCandidate* res, CallInfo& info) {
+  bool retval = false;
+
+  AggregateType* ft = toAggregateType(res->fn->getFormal(1)->getValType());
+  AggregateType* at = toAggregateType(info.call->get(1)->getValType());
+
+  if (ft == at) {
+    retval = true;
+  } else if (ft->getRootInstantiation() == at->getRootInstantiation()) {
+    retval = true;
+  }
+
+  return retval;
+}
+
 /************************************* | **************************************
 *                                                                             *
 *                                                                             *
@@ -548,6 +563,9 @@ bool ResolutionCandidate::checkResolveFormalsWhereClauses(CallInfo& info) {
   //
   // TODO: Expand this check for all methods
   if (fn->isInitializer() && isCandidateInit(this, info) == false) {
+    return false;
+  } else if (strcmp(fn->name, "_new") == 0 &&
+             isCandidateNew(this, info) == false) {
     return false;
   }
 

--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -362,12 +362,8 @@ void resolveFunction(FnSymbol* fn) {
 
     if (strcmp(fn->name, "init") == 0 && fn->isMethod()) {
       AggregateType* at = toAggregateType(fn->_this->getValType());
-      if (at->scalarPromotionType == NULL &&
-          at->symbol->hasFlag(FLAG_GENERIC) == false) {
-        resolvePromotionType(at);
-      }
-      if (developer == false) {
-        fixTypeNames(at);
+      if (at->symbol->hasFlag(FLAG_GENERIC) == false) {
+        resolveTypeWithInitializer(at, fn);
       }
     }
 

--- a/compiler/resolution/virtualDispatch.cpp
+++ b/compiler/resolution/virtualDispatch.cpp
@@ -227,6 +227,16 @@ static void addToVirtualMaps(FnSymbol*      pfn,
       }
 
       fn->instantiationPoint = instantiationPoint;
+    } else {
+      //
+      // BHARSH 2018-04-06:
+      //
+      // Essential for arrays to be able to use initializers.
+      //
+      // A smaller test case:
+      //   types/type_variables/deitz/test_point_of_instantiation3.chpl
+      //
+      fn->instantiationPoint = ct->symbol->instantiationPoint;
     }
 
     resolveOverride(pfn, fn);

--- a/modules/dists/BlockCycDist.chpl
+++ b/modules/dists/BlockCycDist.chpl
@@ -787,6 +787,7 @@ proc LocBlockCyclicDom._sizes {
 ////////////////////////////////////////////////////////////////////////////////
 // BlockCyclic Array Class
 //
+pragma "use default init"
 class BlockCyclicArr: BaseRectangularArr {
 
   //

--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -371,6 +371,7 @@ class LocBlockDom {
 // locArr: a non-distributed array of local array classes
 // myLocArr: optimized reference to here's local array class (or nil)
 //
+pragma "use default init"
 class BlockArr: BaseRectangularArr {
   type sparseLayoutType;
   var doRADOpt: bool = defaultDoRADOpt;

--- a/modules/dists/CyclicDist.chpl
+++ b/modules/dists/CyclicDist.chpl
@@ -654,6 +654,7 @@ class LocCyclicDom {
 proc LocCyclicDom.member(i) return myBlock.member(i);
 
 
+pragma "use default init"
 class CyclicArr: BaseRectangularArr {
   var doRADOpt: bool = defaultDoRADOpt;
   var dom: CyclicDom(rank, idxType, stridable);

--- a/modules/dists/DimensionalDist2D.chpl
+++ b/modules/dists/DimensionalDist2D.chpl
@@ -354,6 +354,7 @@ class LocDimensionalDom {
   }
 }
 
+pragma "use default init"
 class DimensionalArr : BaseRectangularArr {
   // required
   const dom; // must be a DimensionalDom

--- a/modules/dists/PrivateDist.chpl
+++ b/modules/dists/PrivateDist.chpl
@@ -139,6 +139,7 @@ class PrivateDom: BaseRectangularDom {
   proc dsiMyDist() return dist;
 }
 
+pragma "use default init"
 class PrivateArr: BaseRectangularArr {
   var dom: PrivateDom(rank, idxType, stridable);
   var data: eltType;

--- a/modules/dists/ReplicatedDist.chpl
+++ b/modules/dists/ReplicatedDist.chpl
@@ -462,8 +462,9 @@ class LocReplicatedArr {
 // 'eltType' and 'dom' as passed explicitly;
 // the fields in the parent class, BaseArr, are initialized to their defaults.
 //
-proc ReplicatedArr.ReplicatedArr(type eltType, dom: ReplicatedDom) {
-  // initializes the fields 'eltType', 'dom' by name
+proc ReplicatedArr.init(type eltType, dom: ReplicatedDom) {
+  this.eltType = eltType;
+  this.dom = dom;
 }
 
 proc ReplicatedArr.stridable param {

--- a/modules/dists/SparseBlockDist.chpl
+++ b/modules/dists/SparseBlockDist.chpl
@@ -342,7 +342,7 @@ class SparseBlockArr: BaseSparseArr {
 
   proc init(type eltType, param rank, type idxType, param stridable,
       type sparseLayoutType ,dom) {
-    super.init(eltType=eltType, rank=rank, idxType=idxType);
+    super.init(eltType=eltType, rank=rank, idxType=idxType, dom=dom);
     this.stridable = stridable;
     this.sparseLayoutType = sparseLayoutType;
     locArrDom = dom.dist.targetLocDom;

--- a/modules/dists/SparseBlockDist.chpl
+++ b/modules/dists/SparseBlockDist.chpl
@@ -340,8 +340,11 @@ class SparseBlockArr: BaseSparseArr {
   var myLocArr: LocSparseBlockArr(eltType, rank, idxType, stridable,
       sparseLayoutType);
 
-  proc SparseBlockArr(type eltType, param rank, type idxType, param stridable,
+  proc init(type eltType, param rank, type idxType, param stridable,
       type sparseLayoutType ,dom) {
+    super.init(eltType=eltType, rank=rank, idxType=idxType);
+    this.stridable = stridable;
+    this.sparseLayoutType = sparseLayoutType;
     locArrDom = dom.dist.targetLocDom;
   }
 

--- a/modules/dists/StencilDist.chpl
+++ b/modules/dists/StencilDist.chpl
@@ -324,6 +324,7 @@ class LocStencilDom {
 // locArr: a non-distributed array of local array classes
 // myLocArr: optimized reference to here's local array class (or nil)
 //
+pragma "use default init"
 class StencilArr: BaseRectangularArr {
   param ignoreFluff: bool;
   var doRADOpt: bool = defaultDoRADOpt;

--- a/modules/internal/ArrayViewReindex.chpl
+++ b/modules/internal/ArrayViewReindex.chpl
@@ -315,6 +315,24 @@ module ArrayViewReindex {
 
   } // end of class ArrayViewReindexDom
 
+  private proc buildIndexCacheHelper(arr, dom) {
+    if chpl__isDROrDRView(arr) {
+      if (chpl__isArrayView(arr)) {
+        if arr.isSliceArrayView() && !arr._containsRCRE() {
+          // Only slices below in the view stack, which won't have built up
+          // an indexCache.
+          return arr._getActualArray().dsiGetRAD().toSlice(arr.dom).toReindex(dom);
+        } else {
+          return arr.indexCache.toReindex(dom);
+        }
+      } else {
+        return arr.dsiGetRAD().toReindex(dom);
+      }
+    } else {
+      return false;
+    }
+  }
+
   //
   // The class representing a slice of an array.  Like other array
   // class implementations, it supports the standard dsi interface.
@@ -337,9 +355,21 @@ module ArrayViewReindex {
     // (eventually...), the indexCache provides a mean of directly
     // accessing the array's ddata to avoid indirection overheads
     // through the array field above.
-    const indexCache = buildIndexCache();
+    const indexCache;
 
-    const ownsArrInstance = false;
+    const ownsArrInstance;
+
+    proc init(type eltType, const _DomPid, const dom,
+              const _ArrPid, const _ArrInstance,
+              const ownsArrInstance : bool = false) {
+      this.eltType         = eltType;
+      this._DomPid         = _DomPid;
+      this.dom             = dom;
+      this._ArrPid         = _ArrPid;
+      this._ArrInstance    = _ArrInstance;
+      this.indexCache      = buildIndexCacheHelper(_ArrInstance, dom);
+      this.ownsArrInstance = ownsArrInstance;
+    }
 
     forwarding arr except these,
                       doiBulkTransferFromKnown, doiBulkTransferToKnown,

--- a/modules/internal/ArrayViewSlice.chpl
+++ b/modules/internal/ArrayViewSlice.chpl
@@ -25,6 +25,20 @@
 module ArrayViewSlice {
   use ChapelStandard;
 
+  private proc buildIndexCacheHelper(arr, dom) {
+    param isRankChangeReindex = arr.isRankChangeArrayView() ||
+                                arr.isReindexArrayView() ||
+                                (chpl__isArrayView(arr) && arr._containsRCRE());
+    if chpl__isDROrDRView(arr) && isRankChangeReindex {
+      if chpl__isArrayView(arr) then
+        return arr.indexCache.toSlice(dom);
+      else
+        return arr.dsiGetRAD().toSlice(dom);
+    } else {
+      return false;
+    }
+  }
+
   //
   // The class representing a slice of an array.  Like other array
   // class implementations, it supports the standard dsi interface.
@@ -47,7 +61,18 @@ module ArrayViewSlice {
     // (eventually...), the indexCache provides a mean of directly
     // accessing the array's ddata to avoid indirection overheads
     // through the array field above.
-    const indexCache = buildIndexCache();
+    //const indexCache = buildIndexCache();
+    const indexCache;
+
+    proc init(type eltType, const _DomPid, const dom, const _ArrPid, const _ArrInstance) {
+      this.eltType      = eltType;
+      this._DomPid      = _DomPid;
+      this.dom          = dom;
+      this._ArrPid      = _ArrPid;
+      this._ArrInstance = _ArrInstance;
+
+      this.indexCache = buildIndexCacheHelper(_ArrInstance, dom);
+    }
 
     forwarding arr except these,
                       doiBulkTransferFromKnown, doiBulkTransferToKnown,

--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -643,6 +643,7 @@ module ChapelDistribution {
   // Abstract array class
   //
   pragma "base array"
+  pragma "use default init"
   class BaseArr {
     // The common case seems to be local access to this class, so we
     // will use explicit processor atomics, even when network
@@ -771,6 +772,7 @@ module ChapelDistribution {
      another base class.
    */
   pragma "base array"
+  pragma "use default init"
   class BaseArrOverRectangularDom: BaseArr {
     param rank : int;
     type idxType;
@@ -795,6 +797,7 @@ module ChapelDistribution {
   }
 
   pragma "base array"
+  pragma "use default init"
   class BaseRectangularArr: BaseArrOverRectangularDom {
     /* rank, idxType, stridable are from BaseArrOverRectangularDom */
     type eltType;
@@ -809,6 +812,7 @@ module ChapelDistribution {
    * implementing sparse array classes.
    */
   pragma "base array"
+  pragma "use default init"
   class BaseSparseArr: BaseArr {
     type eltType;
     param rank : int;
@@ -833,6 +837,7 @@ module ChapelDistribution {
    * go here.
    */
   pragma "base array"
+  pragma "use default init"
   class BaseSparseArrImpl: BaseSparseArr {
 
     proc deinit() {

--- a/modules/internal/DefaultAssociative.chpl
+++ b/modules/internal/DefaultAssociative.chpl
@@ -559,6 +559,7 @@ module DefaultAssociative {
     }
   }
   
+  pragma "use default init"
   class DefaultAssociativeArr: BaseArr {
     type eltType;
     type idxType;

--- a/modules/internal/DefaultOpaque.chpl
+++ b/modules/internal/DefaultOpaque.chpl
@@ -154,6 +154,7 @@ module DefaultOpaque {
   }
   
   
+  pragma "use default init"
   class DefaultOpaqueArr: BaseArr {
     type eltType;
     type idxType;

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1051,7 +1051,7 @@ module DefaultRectangular {
 
     // change name to setup and call after constructor call sites
     // we want to get rid of all initialize functions everywhere
-    proc initialize() {
+    proc postinit() {
       if noinit_data == true then return;
       for param dim in 1..rank {
         off(dim) = dom.dsiDim(dim).alignedLow;

--- a/modules/internal/DefaultSparse.chpl
+++ b/modules/internal/DefaultSparse.chpl
@@ -346,6 +346,7 @@ module DefaultSparse {
   }
 
 
+  pragma "use default init"
   class DefaultSparseArr: BaseSparseArrImpl {
 
     /*proc DefaultSparseArr(type eltType, param rank, type idxType, dom) {*/

--- a/modules/layouts/LayoutCS.chpl
+++ b/modules/layouts/LayoutCS.chpl
@@ -576,6 +576,7 @@ class CSDom: BaseSparseDomImpl {
 } // CSDom
 
 
+pragma "use default init"
 class CSArr: BaseSparseArrImpl {
 
   proc dsiAccess(ind: rank*idxType) ref {

--- a/test/classes/initializers/compilerGenerated/generics/defaultTypeField.chpl
+++ b/test/classes/initializers/compilerGenerated/generics/defaultTypeField.chpl
@@ -1,0 +1,19 @@
+
+//
+// Test to ensure that we can resolve default initializers for types with a
+// type field that has a default value.
+//
+
+pragma "use default init"
+class Parent {
+  type idxType;
+}
+
+pragma "use default init"
+class Child : Parent {
+  type foo = 2*idxType;
+  var x : foo;
+}
+
+var c : Child(int);
+writeln("c.type = ", c.type:string);

--- a/test/classes/initializers/compilerGenerated/generics/defaultTypeField.good
+++ b/test/classes/initializers/compilerGenerated/generics/defaultTypeField.good
@@ -1,0 +1,1 @@
+c.type = Child(int(64),2*int(64))

--- a/test/distributions/bradc/assoc/UserMapAssoc.chpl
+++ b/test/distributions/bradc/assoc/UserMapAssoc.chpl
@@ -616,6 +616,7 @@ class LocUserMapAssocDom {
 //
 // the global array class
 //
+pragma "use default init"
 class UserMapAssocArr: BaseArr {
   // GENERICS:
 

--- a/test/distributions/dm/n.chpl
+++ b/test/distributions/dm/n.chpl
@@ -76,6 +76,7 @@ class WrapperRectDom : BaseRectangularDom {
   var pid: int = -1;
 }
 
+pragma "use default init"
 class WrapperArr: BaseArr {
   // required
   type eltType;

--- a/test/domains/vass/no-dom-field-error.chpl
+++ b/test/domains/vass/no-dom-field-error.chpl
@@ -14,6 +14,7 @@ class GlobalDomain : BaseDom {
   var ranges: rank * range(idxType);
 }
 
+pragma "use default init"
 class GlobalArray : BaseArr {}
 
 proc GlobalDistribution.init() {}

--- a/test/studies/comd/elegant/arrayOfStructs/util/AccumStencilDist.chpl
+++ b/test/studies/comd/elegant/arrayOfStructs/util/AccumStencilDist.chpl
@@ -121,6 +121,7 @@ class LocAccumStencilDom {
 // locArr: a non-distributed array of local array classes
 // myLocArr: optimized reference to here's local array class (or nil)
 //
+pragma "use default init"
 class AccumStencilArr: BaseRectangularArr {
   param ignoreFluff: bool;
   var doRADOpt: bool = defaultDoRADOpt;

--- a/test/studies/hpcc/common/bradc/Block1D.chpl
+++ b/test/studies/hpcc/common/bradc/Block1D.chpl
@@ -576,6 +576,7 @@ class LocBlock1DDom {
 //
 // the global array class
 //
+pragma "use default init"
 class Block1DArr: BaseArray {
   // GENERICS:
 

--- a/test/types/records/const-checking/scenario-3-assoc-dom-of-record-with-const-fld.bad
+++ b/test/types/records/const-checking/scenario-3-assoc-dom-of-record-with-const-fld.bad
@@ -1,3 +1,2 @@
 $CHPL_HOME/modules/internal/DefaultAssociative.chpl: error: cannot assign to a record of the type Node using the default assignment operator because it has 'const' field(s)
-$CHPL_HOME/modules/internal/ChapelArray.chpl: In function 'chpl__buildAssociativeArrayExpr':
 $CHPL_HOME/modules/internal/ChapelArray.chpl: error: cannot assign to a record of the type Coeff using the default assignment operator because it has 'const' field(s)

--- a/test/users/vass/crash1callDestructorsAddon.chpl
+++ b/test/users/vass/crash1callDestructorsAddon.chpl
@@ -131,6 +131,7 @@ class LocDimensionalDom {
   var myStorageDom: domain(myBlock.rank, stoSzT, false);
 }
 
+pragma "use default init"
 class DimensionalArr : BaseArr {
   // required
   type eltType;

--- a/test/users/vass/crash1callDestructorsMain.chpl
+++ b/test/users/vass/crash1callDestructorsMain.chpl
@@ -130,6 +130,7 @@ class LocDimensionalDom {
   var myStorageDom: domain(myBlock.rank, stoSzT, false);
 }
 
+pragma "use default init"
 class DimensionalArr : BaseArr {
   // required
   type eltType;


### PR DESCRIPTION
This PR converts BaseArr and its derived classes to use initializers. This is generally accomplished by either adding a 'use default init' pragma or converting an existing constructor to an initializer.

A number of bugs are resolved by this PR:
1) Point of instantiation issue for types with initializers is resolved by using the same 'fix' as constructors: set the point of instantiation for virtually dispatched methods to be the same as the initializer that instantiated the type.

2) Allow field default expressions to use previous fields that are generic. Solved by only setting ``dtAny`` on default formals that are type variables.

3) Fixes an issue with array runtime types as fields by using PRIM_GET_MEMBER_VALUE instead of PRIM_GET_MEMBER.

4) A minor segfault is avoided by checking if the type has a type constructor before attempting to use it.

5) Reproducing the recursive-resolution avoidance from #9004 for "_new" wrappers.

These bugs primarily impact complex hierarchies like those found in the array classes.

Resolves #9149 

Testing:
- [x] full local + futures
- [x] full gasnet
- [x] numa on arrays/, release/examples