### PR TITLE
Be sure to compute max comm domains before needing it!

### DIFF
--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -2016,6 +2016,10 @@ uint32_t gni_get_nic_address(int device_id)
 }
 
 
+//
+// This may call the tasking layer, so don't call it before that is
+// initialized.
+//
 static void compute_comm_dom_cnt(void)
 {
   int commConcurrency = -1;

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -2064,10 +2064,10 @@ static void compute_comm_dom_cnt(void)
     }
 
     if (comm_dom_cnt == 0) {
-      uint32_t num_PUs;
+      uint32_t maxPar;
 
-      if ((num_PUs = chpl_task_getMaxPar()) > 0)
-        comm_dom_cnt = num_PUs;
+      if ((maxPar = chpl_task_getMaxPar()) > 0)
+        comm_dom_cnt = maxPar;
     }
 
     if (comm_dom_cnt == 0)


### PR DESCRIPTION
Recent (last several months) code movement led to a situation in which,
for minimal-registered-memory mode, we used the job-wide maximum number
of comm domains per node before we had computed that.  Here, move the
computation and jobwide distribution of that value prior to the point at
which we need it.

Subsequent testing revealed an additional bug: we have been using the
number of logical processors when estimating how many comm domains we
will need.  Using the tasking layer's max level of parallelism is much
better.

That in turn pointed out yet one more bug, less serious but still noisy:
the check to make sure the pool of remote fork completion flags was big
enough was comparing the expected maximum demand for flags to the number
of flags per pool, not the total number of flags in all pools.  So here,
fix that as well.

This fixes #9154.