### PR TITLE
Fix support for multiple '-l' flags

### DIFF
--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -94,7 +94,8 @@ void addLibPath(const char* libString) {
 }
 
 void addLibFile(const char* libFile) {
-  libFiles.add(libFile);
+  // use astr() to get a copy of the string that this vector can own
+  libFiles.add(astr(libFile));
 }
 
 void addIncInfo(const char* incDir) {

--- a/test/compflags/library/libpath/allLs2.chpl
+++ b/test/compflags/library/libpath/allLs2.chpl
@@ -1,0 +1,12 @@
+require "foo.h";
+require "bar.h", "-lbar";;
+require "baz.h";
+
+extern proc foo();
+extern proc bar();
+extern proc baz();
+
+writeln("In main");
+foo();
+bar();
+baz();

--- a/test/compflags/library/libpath/allLs2.compopts
+++ b/test/compflags/library/libpath/allLs2.compopts
@@ -1,0 +1,1 @@
+-Ifoo -Ibar -Ibaz -Lfoo -Lbar -Lbaz -lfoo -lbaz

--- a/test/compflags/library/libpath/allLs2.good
+++ b/test/compflags/library/libpath/allLs2.good
@@ -1,0 +1,4 @@
+In main
+In foo()
+In bar()
+In baz()


### PR DESCRIPTION
@daviditen pointed out that as a result of PR #9030, I inadvertently broke support for specifying multiple '-l' flags.  The reason:  Previously, we'd added `atr('-l', libName))` to add library strings to a vector, but my new approach removed the need for the `-l` to be concatenated in, so I also removed the `astr()` call.  This resulted in the same buffer being pointed to over and over again in my vector, effectively causing each `-l` flag to "overwrite" the previous.  The fix is simple: re-introduce the `astr()` call.

I added a test of using multiple `-l` flags to prevent against this backslide in the future.