### PR TITLE
Fix this one weird assignment bug

### DIFF
--- a/test/classes/initializers/records/weirdAssignmentBug.chpl
+++ b/test/classes/initializers/records/weirdAssignmentBug.chpl
@@ -5,11 +5,9 @@ const vertex_domain = {1..N_VERTICES} ;
 
 record vertex_struct {
 
-  // constructor
   proc init(nd: domain(1)) {
     this.nd = nd;
     vlock$ = true;
-    super.init();
   }
 
   var nd: domain(1);


### PR DESCRIPTION
This test's inititializer still had super.init() after the field
initialization.  Removing the superfluous super.init() restores the
failure described in the future.