### PR TITLE
Temporary fix for read-after-delete in coforall-plus-on

### DIFF
--- a/compiler/optimizations/remoteValueForwarding.cpp
+++ b/compiler/optimizations/remoteValueForwarding.cpp
@@ -457,6 +457,15 @@ static void insertSerialization(FnSymbol*  fn,
 
     Symbol* actualInput = actual->symbol();
 
+/*
+///////////
+2018-04-11 Vass: I am commenting out the following fragment as a temporary
+fix for a read-after-delete bug exposed in these tests:
+    parallel/forall/in-intents/coforall-plus-on
+    # under numa
+    parallel/forall/in-intents/both-arr-dom-const-const
+    parallel/forall/in-intents/both-arr-dom-var-const
+///////////
     // If we're working with a copy added to support an 'in' intent,
     // we don't need that copy anymore since the serialize/deserialize
     // calls will have the same effect. So remove the copy call
@@ -486,6 +495,7 @@ static void insertSerialization(FnSymbol*  fn,
         initExpr->replace(new CallExpr(PRIM_MOVE, actual->symbol(), actualInput));
       }
     }
+*/
 
     VarSymbol* data = newTemp(astr(arg->cname, "_data"), dataType);
     if (arg->hasFlag(FLAG_COFORALL_INDEX_VAR)) {


### PR DESCRIPTION
This change fixes the read-after-delete accesses introduced
by #8785 in

    parallel/forall/in-intents/coforall-plus-on.chpl

and under NUMA in

    parallel/forall/in-intents/both-arr-dom-const-const.chpl
    parallel/forall/in-intents/both-arr-dom-var-const.chpl

This change comments out a transformation that replaces chpl__initCopy
with just a PRIM_MOVE. I am not	deleting the code because I consider
this change temporary.

It is temporary	in part	because	we are still discussing	whether	we
actually want the initCopy to be present there or not.

I am merging this PR right now to reduce noise in nightly testing.

This change does not introduce known valgrind	failures or extra memory
leaks. The test coforall-plus-on.chpl now leaks	one domain, which
it did not leak	prior to #8785.

Discussed with BenH and Michael.
