### PR TITLE
Perf Triage Annotations for 4/12

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -315,6 +315,8 @@ all:
   04/03/18:
     - text: Reduce contention from ugni's polling thread (#9068)
       config: 16 node XC
+  04/11/18:
+    - Convert BaseDom and its derived classes to use initializers (#9113)
 
 
 AllCompTime:


### PR DESCRIPTION

- [chapcs](https://chapel-lang.org/perf/chapcs/?startdate=2018/03/29&enddate=2018/04/12&graphs=arrayviewcreation,minimdljsize10time,nbodyvariations,reversecomplementshootoutbenchmark)
  - Regressions on 4/11 due to #9113 
- [16 node XC](https://chapel-lang.org/perf/16-node-xc/?startdate=2018/03/29&enddate=2018/04/12&graphs=hpccraonperfgupsn233,prkstencilvariationsperf,prkoptimizedstenciltimesec)
  - Regressions on 4/11 due to #9113
  - RA regression is suspected noise
