### PR TITLE
Call postinit on declared generic record (cp PR #9044)

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -9346,6 +9346,13 @@ static Expr* resolvePrimInit(CallExpr* call, Type* type) {
     resolveCallAndCallee(defOfCall);
 
     retval = foldTryCond(postFold(defOfCall));
+
+    if (at && at->isRecord() && at->hasPostInitializer()) {
+      CallExpr* move = toCallExpr(defOfCall->parentExpr);
+      INT_ASSERT(move->isPrimitive(PRIM_MOVE));
+      SymExpr*  var  = toSymExpr(move->get(1));
+      move->insertAfter(new CallExpr("postinit", gMethodToken, var->copy()));
+    }
   }
 
   return retval;

--- a/test/classes/initializers/postInit/record-generic.good
+++ b/test/classes/initializers/postInit/record-generic.good
@@ -1,7 +1,11 @@
 MyRec.init type
+MyRec.postinit
+
 (x = 0)
 
 MyRec.init type
+MyRec.postinit
+
 MyRec.init value
 MyRec.postinit
 

--- a/test/types/typedefs/nelson/typedefFixingParameter.chpl
+++ b/test/types/typedefs/nelson/typedefFixingParameter.chpl
@@ -1,7 +1,7 @@
 
 record X {
   param p = 0;
-  proc initialize() { 
+  proc postinit() {
     writeln("X has p=", p); 
   }
 }


### PR DESCRIPTION
Issue #9001 exposed a bug where postinit would not be called on a declared generic record, like:
```chpl
var x : R(int);
```

This commit:
- adds the postinit call where appropriate
- updates a .good file with correct output
- converts a test using initialize() to use postinit, a task blocked by this bug