### PR TITLE
Reduce contention from ugni's polling thread (cp PR #9068)

### DIFF
--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -1383,7 +1383,7 @@ static volatile chpl_bool polling_task_running     = false;
 static volatile chpl_bool polling_task_please_exit = false;
 static volatile chpl_bool polling_task_done        = false;
 
-static chpl_bool polling_task_blocking_cq = false;
+static chpl_bool polling_task_blocking_cq = true;
 
 
 //
@@ -2731,7 +2731,7 @@ void set_up_for_polling(void)
     uint32_t cq_mode = GNI_CQ_NOBLOCK;
 
     polling_task_blocking_cq = chpl_env_rt_get_bool("COMM_UGNI_BLOCKING_CQ",
-                                                    false);
+                                                    polling_task_blocking_cq);
 
     if (polling_task_blocking_cq)
       cq_mode = GNI_CQ_BLOCKING;

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -1383,7 +1383,7 @@ static volatile chpl_bool polling_task_running     = false;
 static volatile chpl_bool polling_task_please_exit = false;
 static volatile chpl_bool polling_task_done        = false;
 
-static chpl_bool polling_task_blocking_cq = true;
+static chpl_bool polling_task_blocking_cq;
 
 
 //
@@ -2731,7 +2731,7 @@ void set_up_for_polling(void)
     uint32_t cq_mode = GNI_CQ_NOBLOCK;
 
     polling_task_blocking_cq = chpl_env_rt_get_bool("COMM_UGNI_BLOCKING_CQ",
-                                                    polling_task_blocking_cq);
+                                                    true);
 
     if (polling_task_blocking_cq)
       cq_mode = GNI_CQ_BLOCKING;


### PR DESCRIPTION
This updates ugni to use a blocking CQ by default for the progress thread.
Instead of actively polling for new events in a loop we do a CqWaitEvent to
block and wait for a completion event to be generated. Really, this just
enables the feature added in #8562 by default.

Spectre/meltdown patches have increased the cost of context switches (#8969),
which exacerbates the contention between the progress thread and a worker/task
that's running on the same core.

This will resolve the performance regressions we saw after the spectre/meltdown
patches were applied, and in some cases performance will be better than before.
We saw performance improvements when we originally added this as an opt-in
feature but there are some regression for coforall+on microbenchmarks, so we
weren't quite ready to enable it before. However, given how much more
interference/contention there is now, it seems worth enabling.

In short, this will reduce contention from the polling thread, but it does
slightly increase the latency for active messages. This means that tests that
create a lot of of AMs without doing much work (coforall+on mirco-benchmark)
will slow down slightly, but most benchmarks will improve. Here's a brief-ish
summary:

| Benchmark              | Perf gain       |
| ---------------------- | --------------- |
| CoMD elegant           | 10% improvement |
| CoMD llnl              | 30% improvement |
| NPB EP                 | 90% improvement |
| RA-rmo                 | 20% improvement |
| PRK stencil block      | 70% improvement |
| PRK stencil stencil    | 70% improvement |
| stream-ep              |  2% improvement |
| stream-global/prom     | 10% improvement |
| single large reduction | 20% improvement |

| Benchmark              | Perf loss       |
| ---------------------- | --------------- |
| coforall+on microbench | 90% regression  |
| coforall+on net AMO    | 15% regression  |
| many small reductions  | 25% regression  |
| lulesh                 | 10% regression  |
| hpl                    |  5% regression  |

This partially resolves #9067 (resolves for ugni, but not gasnet)