### PR TITLE
Be sure to compute max comm domains before needing it (cp PR #9172)

### DIFF
--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -2088,10 +2088,10 @@ static void compute_comm_dom_cnt(void)
     }
 
     if (comm_dom_cnt == 0) {
-      uint32_t num_PUs;
+      uint32_t maxPar;
 
-      if ((num_PUs = chpl_task_getMaxPar()) > 0)
-        comm_dom_cnt = num_PUs;
+      if ((maxPar = chpl_task_getMaxPar()) > 0)
+        comm_dom_cnt = maxPar;
     }
 
     if (comm_dom_cnt == 0)

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -1865,11 +1865,16 @@ void chpl_comm_post_task_init(void)
     return;
 
   //
-  // Now that the memory layer has been set up, we can allocate the various
-  // data we need and fill it in.  Some of this need not be shared and so we
-  // could have allocated it earlier, but the logical flow is clearer if we
-  // do all this in one place.
+  // Now that the memory layer and tasking have been set up, we can
+  // allocate the various data we need and fill it in.  Some of this
+  // need not be shared and so we could have allocated it earlier, but
+  // the logical flow is clearer if we do all this in one place.
   //
+
+  //
+  // Figure out how many comm domains we need.
+  //
+  compute_comm_dom_cnt();
 
   //
   // Get our NIC address and share it around the job.
@@ -1880,7 +1885,8 @@ void chpl_comm_post_task_init(void)
   // do this by gathering (locale, nic_addr) pairs and then scattering
   // the nic_addr values into the map, which is indexed by locale.
   //
-  // While we're at it, also share the barrier info struct addresses
+  // While we're at it, also compute the maximum number of communication
+  // domains on any node and share the barrier info struct addresses
   // around the job.
   //
   {
@@ -1896,20 +1902,25 @@ void chpl_comm_post_task_init(void)
       typedef struct {
         c_nodeid_t nodeID;
         uint32_t nic_addr;
+        uint32_t comm_dom_cnt;
         barrier_info_t* bar_info;
       } gdata_t;
 
-      gdata_t  my_gdata = { chpl_nodeID, nic_addr, &bar_info };
+      gdata_t  my_gdata = { chpl_nodeID, nic_addr, comm_dom_cnt, &bar_info };
       gdata_t* gdata;
 
       gdata = (gdata_t*) chpl_mem_allocMany(chpl_numNodes, sizeof(gdata[0]),
                                             CHPL_RT_MD_COMM_PER_LOC_INFO,
                                             0, 0);
       if (PMI_Allgather(&my_gdata, gdata, sizeof(gdata[0])) != PMI_SUCCESS)
-        CHPL_INTERNAL_ERROR("PMI_Allgather(nic_addr_map) failed");
+        CHPL_INTERNAL_ERROR("PMI_Allgather(nic_addr_map etc.) failed");
+
+      comm_dom_cnt_max = gdata[0].comm_dom_cnt;  // redundant, but safe
 
       for (int i = 0; i < chpl_numNodes; i++) {
         nic_addr_map[gdata[i].nodeID] = gdata[i].nic_addr;
+        if (gdata[i].comm_dom_cnt > comm_dom_cnt_max)
+          comm_dom_cnt_max = gdata[i].comm_dom_cnt;
 
         if (gdata[i].nodeID >= bar_min_child
             && gdata[i].nodeID < bar_min_child + bar_num_children)
@@ -1921,8 +1932,6 @@ void chpl_comm_post_task_init(void)
       chpl_mem_free(gdata, 0, 0);
     }
   }
-
-  compute_comm_dom_cnt();
 
   //
   // We now have all the variable values (specifically: number of
@@ -2056,10 +2065,10 @@ static void compute_comm_dom_cnt(void)
   // If the user specified a communication concurrency value then make
   // that many comm domains.  Otherwise, if they specified the number
   // of hardware threads for tasking, make that many.  Otherwise, make
-  // at least enough that every processor PU we could be using can
-  // have one at the same time.  In the unlikely event that none of
-  // this was done or is known, make 16.  In any case, always add one
-  // for the polling task.
+  // as many as the tasking layer's expected maximum useful level of
+  // parallelism.  In the unlikely event that none of this was done or
+  // is known, make 16.  In any case, always add one for the polling
+  // task.
   //
   comm_dom_cnt = 0;
   if (commConcurrency == 0)
@@ -2081,7 +2090,7 @@ static void compute_comm_dom_cnt(void)
     if (comm_dom_cnt == 0) {
       uint32_t num_PUs;
 
-      if ((num_PUs = chpl_getNumLogicalCpus(true)) > 0)
+      if ((num_PUs = chpl_task_getMaxPar()) > 0)
         comm_dom_cnt = num_PUs;
     }
 
@@ -2638,34 +2647,6 @@ void set_up_for_polling(void)
   //
   acquire_comm_dom();
   cd->firmly_bound = true;
-
-  //
-  // Figure out the maximum number of communication domains on any
-  // locale.
-  //
-  {
-    typedef struct {
-      uint32_t comm_dom_cnt;
-    } gdata_t;
-
-    gdata_t  my_gdata = { comm_dom_cnt };
-    gdata_t* gdata;
-
-    gdata =
-      (gdata_t*) chpl_mem_allocMany(chpl_numNodes, sizeof(gdata[0]),
-                                    CHPL_RT_MD_COMM_PER_LOC_INFO,
-                                    0, 0);
-    if (PMI_Allgather(&my_gdata, gdata, sizeof(gdata[0])) != PMI_SUCCESS)
-      CHPL_INTERNAL_ERROR("PMI_Allgather(comm_dom_cnt) failed");
-
-    comm_dom_cnt_max = gdata[0].comm_dom_cnt;
-    for (i = 1; i < chpl_numNodes; i++) {
-      if (gdata[i].comm_dom_cnt > comm_dom_cnt_max)
-        comm_dom_cnt_max = gdata[i].comm_dom_cnt;
-    }
-
-    chpl_mem_free(gdata, 0, 0);
-  }
 
   //
   // Make the fork request and acknowledgement space, and communicate
@@ -4460,8 +4441,9 @@ void rf_done_init(void)
 {
   int i, j;
 
-  if (RF_DONE_NUM_PER_POOL < comm_dom_cnt_max * FORK_REQ_BUFS_PER_CD)
-    chpl_warning("(RF_DONE_NUM_PER_POOL "
+  if (RF_DONE_NUM_POOLS * RF_DONE_NUM_PER_POOL
+      < comm_dom_cnt_max * FORK_REQ_BUFS_PER_CD)
+    chpl_warning("(RF_DONE_NUM_POOLS * RF_DONE_NUM_PER_POOL "
                  "< comm_dom_cnt_max * FORK_REQ_BUFS_PER_CD) "
                  "may lead to hangs",
                  0, 0);

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -2040,6 +2040,10 @@ uint32_t gni_get_nic_address(int device_id)
 }
 
 
+//
+// This may call the tasking layer, so don't call it before that is
+// initialized.
+//
 static void compute_comm_dom_cnt(void)
 {
   int commConcurrency = -1;


### PR DESCRIPTION
Recent (last several months) code movement led to a situation in which,
for minimal-registered-memory mode, we used the job-wide maximum number
of comm domains per node before we had computed that.  Here, move the
computation and jobwide distribution of that value prior to the point at
which we need it.

Subsequent testing revealed an additional bug: we have been using the
number of logical processors when estimating how many comm domains we
will need.  Using the tasking layer's max level of parallelism is much
better.

That in turn pointed out yet one more bug, less serious but still noisy:
the check to make sure the pool of remote fork completion flags was big
enough was comparing the expected maximum demand for flags to the number
of flags per pool, not the total number of flags in all pools.  So here,
fix that as well.