### PR TITLE
Workaround for c_sublocid_any -related failures

### DIFF
--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -448,10 +448,12 @@ module ChapelLocale {
       // Simple locales barrier, see implementation below for notes
       var b: localesBarrier;
       var flags: [1..#numLocales-1] localesSignal;
+      // A workaround for not munging identifiers in modules.
+      const chpl_my_sublocid_any = c_sublocid_any;
       coforall locIdx in 0..#numLocales /*ref(b)*/ {
         on __primitive("chpl_on_locale_num",
                        chpl_buildLocaleID(locIdx:chpl_nodeID_t,
-                                          c_sublocid_any)) {
+                                          chpl_my_sublocid_any)) {
           chpl_defaultDistInitPrivate();
           yield locIdx;
           b.wait(locIdx, flags);

--- a/modules/internal/LocaleModelHelpSetup.chpl
+++ b/modules/internal/LocaleModelHelpSetup.chpl
@@ -77,9 +77,11 @@ module LocaleModelHelpSetup {
 
   proc helpSetupRootLocaleNUMA(dst:RootLocale) {
     var root_accum:chpl_root_locale_accum;
+    // A workaround for not munging identifiers in modules.
+    const chpl_my_sublocid_any = c_sublocid_any;
 
     forall locIdx in dst.chpl_initOnLocales() with (ref root_accum) {
-      chpl_task_setSubloc(c_sublocid_any);
+      chpl_task_setSubloc(chpl_my_sublocid_any);
       const node = new LocaleModel(dst);
       dst.myLocales[locIdx] = node;
       root_accum.accum(node);
@@ -90,9 +92,11 @@ module LocaleModelHelpSetup {
 
   proc helpSetupRootLocaleAPU(dst:RootLocale) {
     var root_accum:chpl_root_locale_accum;
+    // A workaround for not munging identifiers in modules.
+    const chpl_my_sublocid_any = c_sublocid_any;
 
     forall locIdx in dst.chpl_initOnLocales() with (ref root_accum) {
-      chpl_task_setSubloc(c_sublocid_any);
+      chpl_task_setSubloc(chpl_my_sublocid_any);
       const node = new LocaleModel(dst);
       dst.myLocales[locIdx] = node;
       root_accum.accum(node);


### PR DESCRIPTION
#8785 led to numerous failures with NUMA and APU locale models.
Many of them were due to incorect generated code involving
forall intent for c_sublocid_any.

This PR avoids the issue by introducing a differently-named
variable. This may be a temporary measure, depending on
deeper investigation.

#### Analysis

Before this PR, the generated C code contained this code:

```C
/* LocaleModelHelpSetup.chpl:84 */
static void helpSetupRootLocaleNUMA(...) {
  int32_t local_c_sublocid_any;
  ...
  int32_t c_sublocid_any;
  ...
  local_c_sublocid_any = c_sublocid_any;
  ...
  c_sublocid_any = local_c_sublocid_any;

  ... uses of c_sublocid_any ...
}
```

where the local variable c_sublocid_any is read prior to initialization.
This lead to execution-time troubles.
Curiously, valgrind did not pick up on this.

Why do we generate this code?

`local_c_sublocid_any`-related code is created during localizeGlobals.
The local `c_sublocid_any` variable is created during lowerIterators.
The Chapel code for helpSetupRootLocaleNUMA() has a forall loop,
whose body accesses c_sublocid_any, which is passed by in intent.
During lowerIterators, the parallel iterator is inlined and
a local variable for c_sublocid_any is created to implement
the forall intent.

So, to our compiler, `local_c_sublocid_any = c_sublocid_any`
references the global c_sublocid_any Symbol, while
`c_sublocid_any = local_c_sublocid_any` references the local one.

Normally the latter would be munged to c_sublocid_any_chpl.
Alas, we do not munge the code generated for intenal modules.
So the two symbols looks the same to the C compiler.

The workaround in this PR introduces a differently-named local
variable, which undergoes forall intents instead of c_sublocid_any.

Joint investigation with @dmk42 .
Thanks to @bradcray for a discussion.