### PR TITLE
Make TBAA tests tolerant of slight differences in name mangling

### DIFF
--- a/test/llvm/tbaa/tbaa_class.chpl
+++ b/test/llvm/tbaa/tbaa_class.chpl
@@ -38,7 +38,7 @@ writeln(myClass);
 //
 // Class object TBAA type descriptors:  reference to superclass and each field
 // CHECK-DAG: ![[OBJOBJ:[0-9]+]] = !{!"chpl_object_object", ![[INT32]], i64 0}
-// CHECK-DAG: ![[CLSOBJ:[0-9]+]] = !{!"chpl_MyClass_chpl_object", ![[OBJOBJ]], i64 0, ![[INT]], i64 {{[0-9]+}}, ![[REAL]], i64 {{[0-9]+}}}
+// CHECK-DAG: ![[CLSOBJ:[0-9]+]] = !{!"chpl_MyClass_chpl{{[0-9]*}}_object", ![[OBJOBJ]], i64 0, ![[INT]], i64 {{[0-9]+}}, ![[REAL]], i64 {{[0-9]+}}}
 //
 // Now validate those access tags.
 // The int is not at offset zero because the object superclass comes first.

--- a/test/llvm/tbaa/tbaa_scalar.chpl
+++ b/test/llvm/tbaa/tbaa_scalar.chpl
@@ -24,7 +24,7 @@ proc f() {
   cvar = new MyClass;
   return cvar;
   // Look for an access of the class pointer, and remember its TBAA access tag.
-  // CHECK: store %chpl_MyClass_chpl_object*
+  // CHECK: store %chpl_MyClass_chpl{{[0-9]*}}_object*
   // CHECK-SAME: !tbaa ![[CLSPTRACC:[0-9]+]]
 }
 
@@ -44,7 +44,7 @@ writeln(f(), ", ", ivar, ", ", rvar);
 //
 // Note that class pointers are scalars.
 // CHECK-DAG: ![[OBJECT:[0-9]+]] = !{!"object", ![[CVOIDPTR]], i64 0}
-// CHECK-DAG: ![[CLSPTR:[0-9]+]] = !{!"MyClass_chpl", ![[OBJECT]], i64 0}
+// CHECK-DAG: ![[CLSPTR:[0-9]+]] = !{!"MyClass_chpl{{[0-9]*}}", ![[OBJECT]], i64 0}
 //
 // Now validate those access tags.
 // Scalar accesses are always at offset zero.


### PR DESCRIPTION
This change makes the LLVM TBAA tests tolerant of slight changes in name mangling.  In the tests, the search for `MyClass_chpl` now has an optional integer after it.