### PR TITLE
Make TBAA tests more tolerant of slight differences in name mangling

### DIFF
--- a/test/llvm/tbaa/tbaa_class.chpl
+++ b/test/llvm/tbaa/tbaa_class.chpl
@@ -37,7 +37,7 @@ writeln(myClass);
 // CHECK-DAG: ![[REAL:[0-9]+]] = !{!"_real64", ![[UNIONS]], i64 0}
 //
 // Class object TBAA type descriptors:  reference to superclass and each field
-// CHECK-DAG: ![[OBJOBJ:[0-9]+]] = !{!"chpl_object_object", ![[INT32]], i64 0}
+// CHECK-DAG: ![[OBJOBJ:[0-9]+]] = !{!"chpl_object{{[0-9]*}}_object", ![[INT32]], i64 0}
 // CHECK-DAG: ![[CLSOBJ:[0-9]+]] = !{!"chpl_MyClass_chpl{{[0-9]*}}_object", ![[OBJOBJ]], i64 0, ![[INT]], i64 {{[0-9]+}}, ![[REAL]], i64 {{[0-9]+}}}
 //
 // Now validate those access tags.

--- a/test/llvm/tbaa/tbaa_scalar.chpl
+++ b/test/llvm/tbaa/tbaa_scalar.chpl
@@ -43,7 +43,7 @@ writeln(f(), ", ", ivar, ", ", rvar);
 // CHECK-DAG: ![[CVOIDPTR:[0-9]+]] = !{!"C void ptr", ![[UNIONS]], i64 0}
 //
 // Note that class pointers are scalars.
-// CHECK-DAG: ![[OBJECT:[0-9]+]] = !{!"object", ![[CVOIDPTR]], i64 0}
+// CHECK-DAG: ![[OBJECT:[0-9]+]] = !{!"object{{[0-9]*}}", ![[CVOIDPTR]], i64 0}
 // CHECK-DAG: ![[CLSPTR:[0-9]+]] = !{!"MyClass_chpl{{[0-9]*}}", ![[OBJECT]], i64 0}
 //
 // Now validate those access tags.


### PR DESCRIPTION
This is like #9207 but with a new case that arose with gasnet-numa.