### PR TITLE
Make LinearAlgebra.Sparse.eye() concrete (cp PR #9112)

### DIFF
--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -1685,7 +1685,7 @@ module Sparse {
   }
 
   /* Return an identity matrix over sparse domain ``Dom`` */
-  proc eye(Dom, type eltType=real) where isCSDom(Dom) {
+  proc eye(Dom: domain, type eltType=real) where isCSDom(Dom) {
     const (m,n) = Dom.shape;
     var D = CSRDomain(Dom.parentDom);
     const idx = if m <= n then 1 else 2;

--- a/test/library/packages/LinearAlgebra/correctness/correctness.chpl
+++ b/test/library/packages/LinearAlgebra/correctness/correctness.chpl
@@ -659,6 +659,15 @@ use TestUtils;
     assertTrue(isIntType(M.eltType), "CSRMatrix(A, eltType=int)");
   }
 
+  /* CSR Identity */
+  {
+    var A = eye(IDom);
+    var B: [IDom] real = 1;
+
+    assertEqual(A.domain, B.domain, 'LinearAlgebra.Sparse.eye(IDom) // domain');
+    assertEqual(A, B, 'LinearAlgebra.Sparse.eye(IDom) // array');
+  }
+
   //
   // Simple Ops
   //


### PR DESCRIPTION
LinearAlgebra.Sparse.eye() (added in #8783) was generic, which resulted in unintentional promotion of the domain being passed. This PR specifies the domain argument type as : domain, to avoid promotion and get the desired behavior.
