### PR TITLE
Chapel 1.17.1 point release: incr version numbers on release branch

### DIFF
--- a/compiler/main/version_num.h
+++ b/compiler/main/version_num.h
@@ -22,7 +22,7 @@
 
 #define MAJOR_VERSION 1
 #define MINOR_VERSION "17"
-#define UPDATE_VERSION "0"
+#define UPDATE_VERSION "1"
 
 static const char* BUILD_VERSION =
 #include "BUILD_VERSION"

--- a/doc/rst/conf.py
+++ b/doc/rst/conf.py
@@ -66,7 +66,7 @@ shortversion = chplversion.replace('-', '&#8209') # prevent line-break at hyphen
 html_context = {"chplversion":chplversion}
 
 # The full version, including alpha/beta/rc tags.
-release = '1.17.0'                  # post-release
+release = '1.17.1'                  # post-release
 
 # General information about the project.
 project = u'Chapel Documentation'

--- a/doc/rst/usingchapel/QUICKSTART.rst
+++ b/doc/rst/usingchapel/QUICKSTART.rst
@@ -28,14 +28,14 @@ enable more features, such as distributed memory execution.
 
       .. code-block:: bash
 
-         tar xzf chapel-1.17.0.tar.gz
+         tar xzf chapel-1.17.1.tar.gz
 
    b. Make sure that your shell is in the directory containing
       QUICKSTART.rst, for example:
 
       .. code-block:: bash
 
-         cd chapel-1.17.0
+         cd chapel-1.17.1
 
    c. Set up your environment for Chapel's Quickstart mode.
       If you are using a shell other than bash,

--- a/doc/rst/usingchapel/chplenv.rst
+++ b/doc/rst/usingchapel/chplenv.rst
@@ -33,7 +33,7 @@ CHPL_HOME
 
     .. code-block:: sh
 
-        export CHPL_HOME=~/chapel-1.17.0
+        export CHPL_HOME=~/chapel-1.17.1
 
    .. note::
      This, and all other examples in the Chapel documentation, assumes you're

--- a/man/confchpl.rst
+++ b/man/confchpl.rst
@@ -1,5 +1,5 @@
 
-:Version: 1.17.0
+:Version: 1.17.1
 :Manual section: 1
 :Title: \\fBchpl\\fP
 :Subtitle: Compiler for the Chapel Programming Language

--- a/man/confchpldoc.rst
+++ b/man/confchpldoc.rst
@@ -1,5 +1,5 @@
 
-:Version: 1.17.0
+:Version: 1.17.1
 :Manual section: 1
 :Title: \\fBchpldoc\\fP
 :Subtitle: the Chapel Documentation Tool

--- a/test/compflags/bradc/printstuff/version.goodstart
+++ b/test/compflags/bradc/printstuff/version.goodstart
@@ -1,1 +1,1 @@
- version 1.17.0
+ version 1.17.1

--- a/util/dockerfiles/Dockerfile
+++ b/util/dockerfiles/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     pkg-config \
     && rm -rf /var/lib/apt/lists/*
 
-ENV CHPL_VERSION 1.17.0
+ENV CHPL_VERSION 1.17.1
 ENV CHPL_HOME    /opt/chapel/$CHPL_VERSION
 ENV CHPL_GMP     system
 

--- a/util/dockerfiles/README.md
+++ b/util/dockerfiles/README.md
@@ -11,7 +11,7 @@
 
 ## `chapel/chapel:<version>`
 Supported Chapel versions:
-* [`1.17.0`, `latest` (_1.17.0/Dockerfile_)](https://github.com/chapel-lang/chapel/blob/release/1.17/util/dockerfiles/Dockerfile/)
+* [`1.17.1`, `latest` (_1.17.1/Dockerfile_)](https://github.com/chapel-lang/chapel/blob/release/1.17/util/dockerfiles/Dockerfile/)
 * [`1.16.0` (_1.16.0/Dockerfile_)](https://github.com/chapel-lang/chapel/blob/master/util/dockerfiles/1.16.0/Dockerfile/)
 * [`1.15.0` (_1.15.0/Dockerfile_)](https://github.com/chapel-lang/chapel/blob/master/util/dockerfiles/1.15.0/Dockerfile/)
 
@@ -19,7 +19,7 @@ This is the core image for Chapel. It provides the complete Chapel compiler and 
 
 ## [`chapel/chapel-gasnet:<version>`](https://hub.docker.com/r/chapel/chapel-gasnet/)
 
-* [`1.17.0`, `latest` (_1.17.0/gasnet/Dockerfile_)](https://github.com/chapel-lang/chapel/blob/release/1.17/util/dockerfiles/gasnet/Dockerfile/)
+* [`1.17.1`, `latest` (_1.17.1/gasnet/Dockerfile_)](https://github.com/chapel-lang/chapel/blob/release/1.17/util/dockerfiles/gasnet/Dockerfile/)
 * [`1.16.0` (_1.16.0/gasnet/Dockerfile_)](https://github.com/chapel-lang/chapel/blob/master/util/dockerfiles/1.16.0/gasnet/Dockerfile/)
 * [`1.15.0` (_1.15.0/gasnet/Dockerfile_)](https://github.com/chapel-lang/chapel/blob/master/util/dockerfiles/1.15.0/gasnet/Dockerfile/)
 


### PR DESCRIPTION
Preparing for a Chapel 1.17.1 point release on release/1.17 branch.
Final release date and content still TBD.