### PR TITLE
Add error on --warn-unstable for undecorated new

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -6017,7 +6017,7 @@ static void handleUnstableNewError(CallExpr* newExpr) {
         if (se == checkSe) {
           // OK
         } else if (CallExpr* parentCall = toCallExpr(se->parentExpr)) {
-          if (parentCall->isNamed("chpl__toraw") || // TODO -- remove case
+          if (parentCall->isNamed("chpl__tounmanaged") || // TODO -- remove case
               parentCall->isNamed("chpl__delete") || // TODO -- remove case
               parentCall->isNamed("chpl__buildDistValue") ||
               parentCall->isNamed("chpl_fix_thrown_error")) {
@@ -6031,8 +6031,13 @@ static void handleUnstableNewError(CallExpr* newExpr) {
             // TODO -- enable warning for internal/standard modules
             // along with updating them.
             if (newExpr->getModule()->modTag == MOD_USER) {
-              USR_WARN(newExpr, "new in is unstable - "
-                                "use 'new raw' or 'new owned'");
+              USR_WARN(newExpr, "new %s is unstable", newType->symbol->name);
+              USR_PRINT(newExpr, "use 'new unmanaged %s' "
+                                 "'new owned %s' or "
+                                 "'new shared %s'",
+                                 newType->symbol->name,
+                                 newType->symbol->name,
+                                 newType->symbol->name);
             }
           }
         }

--- a/test/compflags/ferguson/unstable-new.chpl
+++ b/test/compflags/ferguson/unstable-new.chpl
@@ -1,0 +1,51 @@
+use OwnedObject;
+
+class MyClass {
+  var x:int;
+}
+
+class MyGenericClass {
+  var y;
+}
+
+record MyRecord {
+  var x:int;
+}
+
+record MyGenericRecord {
+  var y;
+}
+
+proc errors() {
+  var x = new MyClass(1);
+  var y = new MyGenericClass(1);
+
+  writeln("in errors");
+  writeln(x);
+  writeln(y);
+}
+
+proc ok() {
+  var a = new unmanaged MyClass(1);
+  var b = new unmanaged MyGenericClass(1);
+  var c = new owned MyClass(1);
+  var d = new owned MyGenericClass(1);
+  var e = new Owned(new MyClass(1));
+  var f = new Owned(new MyGenericClass(1));
+  var g = new MyRecord(1);
+  var h = new MyGenericRecord(1);
+ 
+  writeln("in ok");
+  writeln(a);
+  writeln(b);
+  writeln(c);
+  writeln(d);
+  writeln(e);
+  writeln(f);
+  writeln(g);
+  writeln(h);
+}
+
+
+errors();
+ok();

--- a/test/compflags/ferguson/unstable-new.compopts
+++ b/test/compflags/ferguson/unstable-new.compopts
@@ -1,0 +1,1 @@
+--warn-unstable

--- a/test/compflags/ferguson/unstable-new.good
+++ b/test/compflags/ferguson/unstable-new.good
@@ -1,6 +1,8 @@
 unstable-new.chpl:19: In function 'errors':
-unstable-new.chpl:20: warning: new in is unstable - use 'new raw' or 'new owned'
-unstable-new.chpl:21: warning: new in is unstable - use 'new raw' or 'new owned'
+unstable-new.chpl:20: warning: new MyClass is unstable
+unstable-new.chpl:20: note: use 'new unmanaged MyClass' 'new owned MyClass' or 'new shared MyClass'
+unstable-new.chpl:21: warning: new MyGenericClass is unstable
+unstable-new.chpl:21: note: use 'new unmanaged MyGenericClass' 'new owned MyGenericClass' or 'new shared MyGenericClass'
 in errors
 {x = 1}
 {y = 1}

--- a/test/compflags/ferguson/unstable-new.good
+++ b/test/compflags/ferguson/unstable-new.good
@@ -1,0 +1,15 @@
+unstable-new.chpl:19: In function 'errors':
+unstable-new.chpl:20: warning: new in is unstable - use 'new raw' or 'new owned'
+unstable-new.chpl:21: warning: new in is unstable - use 'new raw' or 'new owned'
+in errors
+{x = 1}
+{y = 1}
+in ok
+{x = 1}
+{y = 1}
+{x = 1}
+{y = 1}
+{x = 1}
+{y = 1}
+(x = 1)
+(y = 1)


### PR DESCRIPTION
Compiler raises an error for a `new` that is not `new owned`/`new shared`/`new unmanaged` when the flag `--warn-unstable` is used.

Closes #9101.

Reviewed by @vasslitvinov - thanks!

- [x] full local testing
