### PR TITLE
add printInitCommCounts.lm-numa.good

### DIFF
--- a/test/modules/sungeun/init/printInitCommCounts.lm-numa.good
+++ b/test/modules/sungeun/init/printInitCommCounts.lm-numa.good
@@ -1,0 +1,1 @@
+(execute_on = 4, execute_on_fast = 4, execute_on_nb = 4) (get = 25, put = 3, execute_on_fast = 6) (get = 25, put = 3, execute_on_fast = 6) (get = 25, put = 3, execute_on_fast = 6) (get = 25, put = 3, execute_on_fast = 6)


### PR DESCRIPTION
The only failure in a full paratest under numa and comm=gasnet,
as of this writing, is in this test:

  modules/sungeun/init/printInitCommCounts.chpl

because of higher comm counts compared to printInitCommCounts.good.
The increase is that #gets on non-0 locales is 25, vs. 14 for flat.

We do not track this test in the nightly testing and do not have plans
to address this increase at the moment.

Therefore I am "locking in" these higher comm counts for numa
by adding a numa-specific .good. That way a full paratest over numa
is back to clean.