### PR TITLE
Rename LAPACK test helper module

### DIFF
--- a/test/library/packages/LAPACK/LAPACK_Matrix_test.chpl
+++ b/test/library/packages/LAPACK/LAPACK_Matrix_test.chpl
@@ -1,4 +1,4 @@
-use Shared;
+use TestHelpers;
 
 config var verbose_test: bool;
 

--- a/test/library/packages/LAPACK/TestHelpers.chpl
+++ b/test/library/packages/LAPACK/TestHelpers.chpl
@@ -1,4 +1,4 @@
-module Shared {
+module TestHelpers {
   use LAPACK;
   param default_epsilon: real = 10.0e-14;  
 

--- a/test/library/packages/LAPACK/cgesv.chpl
+++ b/test/library/packages/LAPACK/cgesv.chpl
@@ -1,4 +1,4 @@
-use Shared, LAPACK, LAPACK.ClassicLAPACK;
+use TestHelpers, LAPACK, LAPACK.ClassicLAPACK;
 
 config var verbose_test: bool;
 

--- a/test/library/packages/LAPACK/dgees.chpl
+++ b/test/library/packages/LAPACK/dgees.chpl
@@ -1,4 +1,4 @@
-use Shared, LAPACK, LAPACK.ClassicLAPACK;
+use TestHelpers, LAPACK, LAPACK.ClassicLAPACK;
 
 config var verbose_test: bool;
 config const epsilon = 10e-6;

--- a/test/library/packages/LAPACK/dgesv.chpl
+++ b/test/library/packages/LAPACK/dgesv.chpl
@@ -1,4 +1,4 @@
-use Shared, LAPACK, LAPACK.ClassicLAPACK;
+use TestHelpers, LAPACK, LAPACK.ClassicLAPACK;
 
 config var verbose_test: bool;
 

--- a/test/library/packages/LAPACK/dgesvd.chpl
+++ b/test/library/packages/LAPACK/dgesvd.chpl
@@ -1,4 +1,4 @@
-use Shared, LAPACK, LAPACK.ClassicLAPACK;
+use TestHelpers, LAPACK, LAPACK.ClassicLAPACK;
 
 config var verbose_test: bool;
 

--- a/test/library/packages/LAPACK/sgesv.chpl
+++ b/test/library/packages/LAPACK/sgesv.chpl
@@ -1,4 +1,4 @@
-use Shared, LAPACK, LAPACK.ClassicLAPACK;
+use TestHelpers, LAPACK, LAPACK.ClassicLAPACK;
 
 config var verbose_test: bool;
 

--- a/test/library/packages/LAPACK/zgesv.chpl
+++ b/test/library/packages/LAPACK/zgesv.chpl
@@ -1,4 +1,4 @@
-use Shared, LAPACK, LAPACK.ClassicLAPACK;
+use TestHelpers, LAPACK, LAPACK.ClassicLAPACK;
 
 config var verbose_test: bool;
 


### PR DESCRIPTION
This module was named Shared, but Shared is now a type
exported by default from the internal modules (even though
it will be deprecated once we move to shared).

This PR just renames the test helper module to TestHelpers.

Test changes only, not reviewed.
Tested the relevant LAPACK directory on a Cray XC.