### PR TITLE
Use zero-arg initializer in BaseDom

### DIFF
--- a/modules/dists/StencilDist.chpl
+++ b/modules/dists/StencilDist.chpl
@@ -621,7 +621,7 @@ proc StencilDom.init(param rank : int,
                      dist : Stencil(rank, idxType, ignoreFluff),
                      fluff : rank*idxType,
                      periodic : bool = false) {
-  super.init(rank=rank, idxType=idxType, stridable=stridable);
+  super.init(rank, idxType, stridable);
   this.ignoreFluff = ignoreFluff;
   this.dist = dist;
   this.fluff = fluff;

--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -168,7 +168,6 @@ module ChapelDistribution {
   // Abstract domain classes
   //
   pragma "base domain"
-  pragma "use default init"
   class BaseDom {
     // The common case seems to be local access to this class, so we
     // will use explicit processor atomics, even when network
@@ -180,6 +179,9 @@ module ChapelDistribution {
     var _arrsLock: atomicbool; //   and lock for concurrent access
     var _free_when_no_arrs: bool;
     var pid:int = nullPid; // privatized ID, if privatization is supported
+
+    proc init() {
+    }
 
     proc deinit() {
     }

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -102,7 +102,7 @@ module DefaultRectangular {
     proc isDefaultRectangular() param return true;
 
     proc init(param rank, type idxType, param stridable, dist) {
-      super.init(rank=rank, idxType=idxType, stridable=stridable);
+      super.init(rank, idxType, stridable);
       this.dist = dist;
     }
 

--- a/modules/internal/DefaultSparse.chpl
+++ b/modules/internal/DefaultSparse.chpl
@@ -36,7 +36,7 @@ module DefaultSparse {
 
     proc init(param rank, type idxType, dist: DefaultDist,
         parentDom: domain) {
-      super.init(rank=rank, idxType=idxType, parentDom=parentDom);
+      super.init(rank, idxType, parentDom);
 
       this.dist = dist;
     }

--- a/modules/layouts/LayoutCS.chpl
+++ b/modules/layouts/LayoutCS.chpl
@@ -114,7 +114,7 @@ class CSDom: BaseSparseDomImpl {
     if parentDom.idxType != idxType then
       compilerError("idxType mismatch in CSDom.init(): " + idxType:string + " != " + parentDom.idxType:string);
 
-    super.init(rank=rank, idxType=idxType, parentDom=parentDom);
+    super.init(rank, idxType, parentDom);
 
     this.compressRows = compressRows;
     this.stridable = stridable;


### PR DESCRIPTION
By using an explicit zero-arg initializer we avoid unnecessary allocation/initialization of temporaries for default args. These temporaries resulted in performance regressions for a handful of tests.

Resolves #9211

Testing:
- [x] local + futures
- [x] gasnet