### PR TITLE
Fix point of instantiation for generated copy initializers

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5169,7 +5169,15 @@ FnSymbol* findCopyInit(AggregateType* at) {
   VarSymbol* tmpAt = newTemp(at);
   CallExpr*  call  = new CallExpr("init", gMethodToken, tmpAt, tmpAt);
 
-  return resolveUninsertedCall(at, call, false);
+  FnSymbol* ret = resolveUninsertedCall(at, call, false);
+
+  // ret's instantiationPoint points to the dummy BlockStmt created by
+  // resolveUninsertedCall, so it needs to be updated.
+  if (ret != NULL) {
+    ret->instantiationPoint = at->symbol->instantiationPoint;
+  }
+
+  return ret;
 }
 
 /************************************* | **************************************

--- a/test/classes/initializers/records/generics/copyInitInstantiation.chpl
+++ b/test/classes/initializers/records/generics/copyInitInstantiation.chpl
@@ -1,0 +1,40 @@
+module SomeRecord {
+  record SomeR {
+    type t;
+    var x : t;
+
+    proc init(type t) {
+      this.t = t;
+    }
+  }
+}
+
+module MockStandard {
+  use SomeRecord;
+
+  proc helper(type t) {
+    var r = new SomeR(t);
+
+    // Compiler-generated copy initializer needs to know about R.
+    //
+    // Program would fail to compile if SomeR's copy initializer had an
+    // incorrect point-of-instantiation.
+    var x = r;
+
+    writeln("x = ", x);
+  }
+}
+
+module MockMain {
+  use MockStandard;
+  record R {
+    var x : int;
+    proc init() {
+      writeln("R.init");
+    }
+  }
+  proc main() {
+    helper(R);
+  }
+}
+

--- a/test/classes/initializers/records/generics/copyInitInstantiation.good
+++ b/test/classes/initializers/records/generics/copyInitInstantiation.good
@@ -1,0 +1,3 @@
+R.init
+R.init
+x = (x = (x = 0))


### PR DESCRIPTION
A program could run into surprising errors with unhelpful messages for copy initializers due to a point of instantiation issue. The problem was that the generic copy initializer was instantiated in a temporary block, which was later removed.

#9160 introduced tracking of an AggregateType's instantiation point, which we can easily re-use here to correctly set the instantiation point of the copy initializer.

A new test is added to check this behavior.

Resolves #9215 .

Testing:
- [x] full local + futures