### PR TITLE
Pull in an upstream GASNet patch for an InfiniBand performance improvement

### DIFF
--- a/third-party/gasnet/README
+++ b/third-party/gasnet/README
@@ -23,6 +23,9 @@ as follows:
 
 * Pulled in an upstream fix for a gemini/aries multi-domain initialization bug:
    - https://bitbucket.org/berkeleylab/gasnet/commits/ed2fd98eb
+* Pulled in an upstream performance improvement for InfiniBand:
+   - https://bitbucket.org/berkeleylab/gasnet/commits/79315e5fe
+   - https://bitbucket.org/berkeleylab/gasnet/commits/5cb86a7e0
 
 Upgrading GASNet versions
 =========================
@@ -32,9 +35,9 @@ un-tarballed GASNet package contents.  Version updates should be done as
 follows, assuming the CWD is $CHPL_HOME/third-party/gasnet/:
 
 1. un-tarball the new package version into the directory it specifies,
-   for example GASNet-1.28.2
+   for example GASNet-1.30.0
 2. git rm -r gasnet-src
-3. mv GASNet-1.28.2 gasnet-src
+3. mv GASNet-1.30.0 gasnet-src
 4. git add --force gasnet-src
    ('--force' is needed so that the 'git add' ignores our .gitignore)
 5. commit

--- a/third-party/gasnet/gasnet-src/ibv-conduit/gasnet_core.c
+++ b/third-party/gasnet/gasnet-src/ibv-conduit/gasnet_core.c
@@ -1002,7 +1002,7 @@ static int gasnetc_load_settings(void) {
     default: fprintf(stderr,
                      "WARNING: ignoring invalid GASNET_MAX_MTU value %d.\n",
                      i);
-             /* fall through to "auto" case: */
+             /* fall through to "auto" case: */ GASNETI_FALLTHROUGH
   case    0: /* TODO: "automatic" might be more sophisticated */
              /* Our historic default is 1k, which is a good latency-vs-bandwidth compromise */
              gasnetc_max_mtu = IBV_MTU_1024;

--- a/third-party/gasnet/gasnet-src/ibv-conduit/gasnet_core.c
+++ b/third-party/gasnet/gasnet-src/ibv-conduit/gasnet_core.c
@@ -1003,9 +1003,8 @@ static int gasnetc_load_settings(void) {
                      "WARNING: ignoring invalid GASNET_MAX_MTU value %d.\n",
                      i);
              /* fall through to "auto" case: */ GASNETI_FALLTHROUGH
-  case    0: /* TODO: "automatic" might be more sophisticated */
-             /* Our historic default is 1k, which is a good latency-vs-bandwidth compromise */
-             gasnetc_max_mtu = IBV_MTU_1024;
+  case    0: /* TODO: "automatic" might be more sophisticated than using the maximum */
+  case   -1: gasnetc_max_mtu = 0; /* Use port's active_mtu */
              break;
   case  256: gasnetc_max_mtu = IBV_MTU_256;
              break;
@@ -1016,8 +1015,6 @@ static int gasnetc_load_settings(void) {
   case 2048: gasnetc_max_mtu = IBV_MTU_2048;
              break;
   case 4096: gasnetc_max_mtu = IBV_MTU_4096;
-             break;
-  case   -1: gasnetc_max_mtu = 0; /* Use port's active_mtu */
              break;
   }
 


### PR DESCRIPTION
Pull in an upstream GASNet patch for an InfiniBand performance improvement.
This pulls in:
 - https://bitbucket.org/berkeleylab/gasnet/commits/79315e5fe
 - https://bitbucket.org/berkeleylab/gasnet/commits/5cb86a7e0

Note that the first commit is just a comment change, but without it the real
patch doesn't apply cleanly.

Closes https://github.com/chapel-lang/chapel/issues/9210