### PR TITLE
Pull in an upstream GASNet patch for faster uncoordinated smp shutdown times

### DIFF
--- a/third-party/gasnet/README
+++ b/third-party/gasnet/README
@@ -26,6 +26,8 @@ as follows:
 * Pulled in an upstream performance improvement for InfiniBand:
    - https://bitbucket.org/berkeleylab/gasnet/commits/79315e5fe
    - https://bitbucket.org/berkeleylab/gasnet/commits/5cb86a7e0
+* Pulled in an upstream fix for slow uncoordinated shutdowns with segment smp:
+   - https://bitbucket.org/berkeleylab/gasnet/commits/a636c641d
 
 Upgrading GASNet versions
 =========================

--- a/third-party/gasnet/gasnet-src/smp-conduit/gasnet_core.c
+++ b/third-party/gasnet/gasnet-src/smp-conduit/gasnet_core.c
@@ -90,9 +90,9 @@ static void gasnetc_bootstrapBarrier(void) {
 
 static int *gasnetc_fds = NULL;
 
-#define GASNETC_DEFAULT_EXITTIMEOUT_MAX       20.
-#define GASNETC_DEFAULT_EXITTIMEOUT_MIN       10.
-#define GASNETC_DEFAULT_EXITTIMEOUT_FACTOR     0.25
+#define GASNETC_DEFAULT_EXITTIMEOUT_MAX       5.
+#define GASNETC_DEFAULT_EXITTIMEOUT_MIN       1.
+#define GASNETC_DEFAULT_EXITTIMEOUT_FACTOR    0.1
 static double gasnetc_exittimeout = GASNETC_DEFAULT_EXITTIMEOUT_MAX;
 
 static struct gasnetc_exit_data {


### PR DESCRIPTION
Pull in an upstream GASNet patch for faster uncoordinated smp shutdown times.
This pulls in:
 - https://bitbucket.org/berkeleylab/gasnet/commits/a636c641d

Closes https://github.com/chapel-lang/chapel/issues/9163
