### PR TITLE
Minor improvements to paratest.server

### DIFF
--- a/util/test/paratest.server
+++ b/util/test/paratest.server
@@ -103,8 +103,8 @@ sub collect_logs {
     }
 
     systemd ("echo \\[Parallel testing started at $starttime\\] > $fin_log");
-    print "Collecting logs to $fin_log\n" if $verbose;
-    foreach $log (@logs) {
+    print "Collecting logs to $fin_log\n";
+    foreach $log (sort @logs) {
         if (-e $log) {
             print "Merging $log\n" if $verbose;
             open GLOG, $log or die "Cannot open log '$log'\n";
@@ -350,7 +350,9 @@ sub feed_nodes {
       }
 
       $endtime = `date`; chomp $endtime;
+      print "\n";
       if ($memleaksflag) {
+          print "Collecting memleaks logs to $memleaks\n";
           systemd("cat $logdir/tmp.*.memleaks > $memleaks");
           systemd("rm -f $logdir/tmp.*.memleaks");
       }


### PR DESCRIPTION
* When aggregating individual log files, do so in a sorted order.

This is to make the order of tests in the combined log consistent
among multiple runs. In the spirit of #8572, this order will not
necessarily be consistent across systems, users, etc.

Note that the memleaks logs are already aggregated in a sorted order.

* At the end of a paratest run, print information messages that
the logs are being aggregated ("collected").

This reminds the user where the final log(s) will be.