### PR TITLE
More robust cmdline parsing in paratest.server

### DIFF
--- a/util/test/paratest.server
+++ b/util/test/paratest.server
@@ -11,8 +11,8 @@
 #  - paratest.server is run from $CHPL_HOME/test.
 #  - Chapel compiler bin as $CHPL_HOME/bin/"platform"/chpl.
 #  - Scripts start_test in $CHPL_HOME/util and paratest.client in the same 
-#  	   directory as paratest.server. It will create a temporary directory 
-#  	   .synch to synchronize the distribution of work to the client processes.
+#      directory as paratest.server. It will create a temporary directory 
+#     .synch to synchronize the distribution of work to the client processes.
 #  - Be able to run start_test remotely. This may include the following:
 #    - Chapel built without node-specific local temporary directories.
 #        Nodes must be able to execute start_test. For example, the
@@ -42,7 +42,7 @@ $sleep_time = 1;                       # polling time (sec) to distribute work
 $futures_mode = 0;
 $filedist = 0;
 $dirs = "";
-$node_para = 1;				                 # the number of tasks to run on each node
+$node_para = 1;                        # the number of tasks to run on each node
 $valgrind = 0;
 $memleaks = "/dev/null";
 $memleaksflag = 0;
@@ -527,7 +527,7 @@ sub main {
 
     while ($#ARGV >= 0) {
         $_ = $ARGV[0];
-        if (/^-compopts/) {
+        if (/^-compopts$/) {
             shift @ARGV;
             if ($#ARGV >= 0) {
                 $compopts = "$compopts $ARGV[0]";
@@ -535,7 +535,7 @@ sub main {
                 print "missing -compopts arg\n";
                 exit (8);
             }
-        } elsif (/^-execopts/) {
+        } elsif (/^-execopts$/) {
             shift @ARGV;
             if ($#ARGV >= 0) {
                 $execopts = "$execopts $ARGV[0]";
@@ -543,7 +543,7 @@ sub main {
                 print "missing -execopts arg\n";
                 exit (8);
             }
-        } elsif (/^-env/) {
+        } elsif (/^-env$/) {
             shift @ARGV;
             if ($#ARGV >= 0) {
                 $extra_env = "$extra_env $ARGV[0]";
@@ -551,9 +551,9 @@ sub main {
                 print "missing -env arg\n";
                 exit (8);
             }
-        } elsif (/^-filedist/) {
+        } elsif (/^-filedist$/) {
             $filedist = 1;
-        } elsif (/^-dirfile/) {
+        } elsif (/^-dirfile$/) {
             shift @ARGV;
             if ($#ARGV >= 0) {
                 $dirfile = $ARGV[0];
@@ -561,7 +561,7 @@ sub main {
                 print "missing -dirfile arg\n";
                 exit (8);
             }
-        } elsif (/^-dirs/) {
+        } elsif (/^-dirs$/) {
             shift @ARGV;
             if ($#ARGV >= 0) {
                 $dirs = trim("$dirs $ARGV[0]");
@@ -570,7 +570,7 @@ sub main {
                 exit (8);
             }
          # "undocumented" option, only meant to be used by other scripts
-        } elsif (/^-futures-mode/) {
+        } elsif (/^-futures-mode$/) {
             shift @ARGV;
             if ($#ARGV >= 0) {
                 $futures_mode = $ARGV[0];
@@ -578,11 +578,11 @@ sub main {
                 print "missing -futures-mode arg\n";
                 exit (8);
             }
-        } elsif (/^-futures-only/) {
+        } elsif (/^-futures-only$/) {
             $futures_mode = 2;
-        } elsif (/^-futures/) {
+        } elsif (/^-futures$/) {
             $futures_mode = 1;
-        } elsif (/^-logfile/) {
+        } elsif (/^-logfile$/) {
             shift @ARGV;
             if ($#ARGV >= 0) {
                 $fin_logfile = $ARGV[0];
@@ -590,7 +590,7 @@ sub main {
                 print "missing -logfile arg\n";
                 exit (8);
             }
-        } elsif (/^-nodefile/) {
+        } elsif (/^-nodefile$/) {
             shift @ARGV;
             if ($#ARGV >= 0) {
                 $nodefile = $ARGV[0];
@@ -598,7 +598,7 @@ sub main {
                 print "missing -nodefile arg\n";
                 exit (8);
             }
-        } elsif (/^-nodepara/) {
+        } elsif (/^-nodepara$/) {
             shift @ARGV;
             if ($#ARGV >= 0) {
                 $node_para = $ARGV[0];
@@ -606,7 +606,7 @@ sub main {
                 print "missing -nodepara arg\n";
                 exit(8);
             }
-        } elsif (/^-timeout/) {
+        } elsif (/^-timeout$/) {
             shift @ARGV;
             if ($#ARGV >= 0) {
                 $timeout = $ARGV[0];
@@ -614,7 +614,7 @@ sub main {
                 print "missing -timeout arg\n";
                 exit(8);
             }
-        } elsif (/^-memleaks/) {
+        } elsif (/^-memleaks$/) {
             shift @ARGV;
             if ($#ARGV >= 0) {
                 $memleaks = $ARGV[0];
@@ -623,20 +623,18 @@ sub main {
                 print "missing -memleaks arg\n";
                 exit (8);
             }
-        } elsif (/^-valgrind/) {
-            if (/^-valgrindexe/) {
-                $valgrind = 2;
-                $ENV{'CHPL_TEST_VGRND_EXE'} = "on";
-            } else {
-                $valgrind = 1;
-                $ENV{'CHPL_TEST_VGRND_COMP'} = "on";
-                $ENV{'CHPL_TEST_VGRND_EXE'} = "on";
-            }
-        } elsif (/^-show-all-errors/) {
+        } elsif (/^-valgrind$/) {
+            $valgrind = 1;
+            $ENV{'CHPL_TEST_VGRND_COMP'} = "on";
+            $ENV{'CHPL_TEST_VGRND_EXE'} = "on";
+        } elsif (/^-valgrindexe$/) {
+            $valgrind = 2;
+            $ENV{'CHPL_TEST_VGRND_EXE'} = "on";
+        } elsif (/^-show-all-errors$/) {
             $show_all_errors = 1;
         } elsif (/^-junit-xml$/) {
             $junit_xml = 1;
-        } elsif (/^-junit-xml-file/) {
+        } elsif (/^-junit-xml-file$/) {
             shift @ARGV;
             if ($#ARGV >= 0) {
                 $junit_xml_file = $ARGV[0];
@@ -645,7 +643,7 @@ sub main {
                 print "missing -junit-xml-file arg\n";
                 exit (8);
             }
-        } elsif (/^-junit-remove-prefix/) {
+        } elsif (/^-junit-remove-prefix$/) {
             shift @ARGV;
             if ($#ARGV >= 0) {
                 $junit_remove_prefix = $ARGV[0];
@@ -653,7 +651,7 @@ sub main {
                 print "missing -junit-remove-prefix arg\n";
                 exit (8);
             }
-        } elsif (/^-help|^-h/) {
+        } elsif (/^-help$|^-h$/) {
             print_help;
             exit (9);
         } else {
@@ -749,10 +747,10 @@ sub main {
         die "Error generating Spec tests in $ENV{CHPL_HOME}/spec\n" unless $? == 0;
         chdir $cwd;
         if ($filedist) {
-	    print "[Collecting test files in $cwd]\n";
+            print "[Collecting test files in $cwd]\n";
             @testdir_list = find_files (".", 0, !$futures_mode, 1);
         } else {
-	    print "[Collecting test directories in $cwd]\n";
+            print "[Collecting test directories in $cwd]\n";
             @testdir_list = find_subdirs (".", 0);
         }
     }


### PR DESCRIPTION
Addressed the lame-ness mentioned in #8529, where passing
-futures-only-stupid-script to paratest.server had the same effect
as passing -futures-only. With this change, a legitimate option
with trailing garbage results in an error message.

While there, replaced tabs with spaces in a couple of spots.