### PR TITLE
Fix gasnet build by removing GASNETI_FALLTHROUGH

### DIFF
--- a/third-party/gasnet/README
+++ b/third-party/gasnet/README
@@ -24,7 +24,6 @@ as follows:
 * Pulled in an upstream fix for a gemini/aries multi-domain initialization bug:
    - https://bitbucket.org/berkeleylab/gasnet/commits/ed2fd98eb
 * Pulled in an upstream performance improvement for InfiniBand:
-   - https://bitbucket.org/berkeleylab/gasnet/commits/79315e5fe
    - https://bitbucket.org/berkeleylab/gasnet/commits/5cb86a7e0
 * Pulled in an upstream fix for slow uncoordinated shutdowns with segment smp:
    - https://bitbucket.org/berkeleylab/gasnet/commits/a636c641d

--- a/third-party/gasnet/gasnet-src/ibv-conduit/gasnet_core.c
+++ b/third-party/gasnet/gasnet-src/ibv-conduit/gasnet_core.c
@@ -1002,7 +1002,7 @@ static int gasnetc_load_settings(void) {
     default: fprintf(stderr,
                      "WARNING: ignoring invalid GASNET_MAX_MTU value %d.\n",
                      i);
-             /* fall through to "auto" case: */ GASNETI_FALLTHROUGH
+             /* fall through to "auto" case: */
   case    0: /* TODO: "automatic" might be more sophisticated than using the maximum */
   case   -1: gasnetc_max_mtu = 0; /* Use port's active_mtu */
              break;


### PR DESCRIPTION
In 6eebb6215a I mistakenly brought in an upstream patch that I thought was just
a comment update so that I could cleanly bring in bc9313d389. Turns out
GASNETI_FALLTHROUGH isn't defined in the release of gasnet that we're using
only upstream. Remove GASNETI_FALLTHROUGH to avoid build issues.

Related to #9210 and #9255