### PR TITLE
Correct how we set the locale name with gasnet local spawning

### DIFF
--- a/modules/internal/LocaleModelHelpSetup.chpl
+++ b/modules/internal/LocaleModelHelpSetup.chpl
@@ -111,10 +111,10 @@ module LocaleModelHelpSetup {
     // current node.  For this reason (as well), the constructor (or
     // at least this setup method) must be run on the node it is
     // intended to describe.
-    var comm, spawnfn : c_string;
+    var spawnfn: c_string;
     extern proc chpl_nodeName() : c_string;
     // sys_getenv returns one on success.
-    if sys_getenv(c"CHPL_COMM", comm) == 1 && comm == c"gasnet" &&
+    if CHPL_COMM == "gasnet" && CHPL_COMM_SUBSTRATE == "udp" &&
       sys_getenv(c"GASNET_SPAWNFN", spawnfn) == 1 && spawnfn == c"L"
     then local_name = chpl_nodeName():string + "-" + _node_id:string;
     else local_name = chpl_nodeName():string;

--- a/modules/internal/LocaleModelHelpSetup.chpl
+++ b/modules/internal/LocaleModelHelpSetup.chpl
@@ -32,6 +32,7 @@ module LocaleModelHelpSetup {
   use ChapelLocale;
   use DefaultRectangular;
   use ChapelNumLocales;
+  use ChapelEnv;
   use Sys;
 
   config param debugLocaleModel = false;
@@ -103,21 +104,35 @@ module LocaleModelHelpSetup {
     here.runningTaskCntSet(0);  // locale init parallelism mis-sets this
   }
 
-  proc helpSetupLocaleFlat(dst:LocaleModel, out local_name:string) {
-    const _node_id = chpl_nodeID: int;
+  // gasnet-smp and gasnet-udp w/ GASNET_SPAWNFN=L are local spawns
+  private inline proc localSpawn() {
+    if CHPL_COMM == "gasnet" {
+      var spawnfn: c_string;
+      if (CHPL_COMM_SUBSTRATE == "udp" &&
+         sys_getenv(c"GASNET_SPAWNFN", spawnfn) == 1 && spawnfn == c"L") {
+        return true;
+      } else if (CHPL_COMM_SUBSTRATE == "smp") {
+        return true;
+      }
+    }
+    return false;
+  }
 
+  private inline proc getNodeName() {
     // chpl_nodeName is defined in chplsys.c.
     // It supplies a node name obtained by running uname(3) on the
     // current node.  For this reason (as well), the constructor (or
     // at least this setup method) must be run on the node it is
     // intended to describe.
-    var spawnfn: c_string;
-    extern proc chpl_nodeName() : c_string;
-    // sys_getenv returns one on success.
-    if CHPL_COMM == "gasnet" && CHPL_COMM_SUBSTRATE == "udp" &&
-      sys_getenv(c"GASNET_SPAWNFN", spawnfn) == 1 && spawnfn == c"L"
-    then local_name = chpl_nodeName():string + "-" + _node_id:string;
-    else local_name = chpl_nodeName():string;
+    extern proc chpl_nodeName(): c_string;
+    const _node_name = chpl_nodeName(): string;
+    const _node_id = (chpl_nodeID: int): string;
+
+    return if localSpawn() then _node_name + "-" + _node_id else _node_name;
+  }
+
+  proc helpSetupLocaleFlat(dst:LocaleModel, out local_name:string) {
+    local_name = getNodeName();
 
     extern proc chpl_task_getCallStackSize(): size_t;
     dst.callStackSize = chpl_task_getCallStackSize();

--- a/test/localeModels/dmk/locale_name.prediff
+++ b/test/localeModels/dmk/locale_name.prediff
@@ -1,5 +1,5 @@
 #! /usr/bin/env bash
-if [ "$CHPL_COMM" = "gasnet" -a "$GASNET_SPAWNFN" = "L" ]; then
+if [ "$CHPL_COMM" = "gasnet" -a "$CHPL_COMM_SUBSTRATE" = 'udp' -a "$GASNET_SPAWNFN" = "L" ]; then
     echo "matches nodeName-nodeID" >$1.good
 else
     echo "matches nodeName" >$1.good

--- a/test/localeModels/dmk/locale_name.prediff
+++ b/test/localeModels/dmk/locale_name.prediff
@@ -1,5 +1,8 @@
 #! /usr/bin/env bash
-if [ "$CHPL_COMM" = "gasnet" -a "$CHPL_COMM_SUBSTRATE" = 'udp' -a "$GASNET_SPAWNFN" = "L" ]; then
+COMM_SUB="$CHPL_COMM-$CHPL_COMM_SUBSTRATE"
+if [ "$COMM_SUB" = "gasnet-udp" -a "$GASNET_SPAWNFN" = "L" ]; then
+    echo "matches nodeName-nodeID" >$1.good
+elif [ "$COMM_SUB" = "gasnet-smp" ]; then
     echo "matches nodeName-nodeID" >$1.good
 else
     echo "matches nodeName" >$1.good


### PR DESCRIPTION
Correct how we set the locale name. While testing #9148 I noticed that we were
using `<node_name>-<node_id>` instead of just `<node_name>` for configs like
gasnet_ibv.

Previously we only checked for comm=gasnet and spawnfn=L, but this got a few
cases wrong. Specifically, spawnfn only means anything for the udp substrate,
so we don't want to add a node_id for something like ibv. We also weren't
adding the node_id to the gasnet-smp case.

The node/locale name is now `<node_name>-<node_id>` for gasnet-smp or
gasnet-udp w/ GASNET_SPAWNFN=L. Otherwise it is just `<node_name>`

This is a logical followup on #9176. Before that PR we never detected
local-spawning because of an incorrect sys_getenv. Fixing that bug exposed this
bug in the implementation of locale name detection.
