### PR TITLE
Split against all instances of = in overrides.py

### DIFF
--- a/util/chplenv/overrides.py
+++ b/util/chplenv/overrides.py
@@ -133,7 +133,7 @@ class ChapelConfig(object):
                 if self.skip_line(line, linenum):
                     continue
 
-                var, val = [f.strip() for f in line.split('=', 1)]
+                var, val = [f.strip() for f in line.split('=')]
                 self.chplconfig[var] = val
 
     def skip_line(self, line, linenum):
@@ -147,7 +147,7 @@ class ChapelConfig(object):
 
         # Check for syntax errors
         try:
-            var, val = [f.strip() for f in line.split('=', 1)]
+            var, val = [f.strip() for f in line.split('=')]
         except ValueError:
             self.warnings.append(
             (


### PR DESCRIPTION
#9013 tried to protect against environment variables that contained equals signs, but may have gone too far.  This reverts a portion of that change by having overrides.py split on all occurrences of the equals sign, not just the first one.