### PR TITLE
Update various internal types to use initializers

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1008,6 +1008,7 @@ module ChapelArray {
   }
 
 
+  pragma "use default init"
   record _serialized_domain {
     param rank;
     type idxType;
@@ -3903,6 +3904,7 @@ module ChapelArray {
   // index for all opaque domains
   //
   pragma "no doc"
+  pragma "use default init"
   record _OpaqueIndex {
     var node:int = 0;
     var i:uint = 0;

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -846,12 +846,15 @@ module ChapelBase {
 
   pragma "end count"
   pragma "no default functions"
-  pragma "use default init"
   class _EndCount : _EndCountBase {
     type iType;
     type taskType;
     var i: iType;
     var taskCnt: taskType;
+    proc init(type iType, type taskType) {
+      this.iType = iType;
+      this.taskType = taskType;
+    }
   }
 
   // This function is called once by the initiating task.  No on

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -838,6 +838,7 @@ module ChapelBase {
   // to add non-generic fields here.
   // And to get 'errors' field from any generic instantiation.
   pragma "no default functions"
+  pragma "use default init"
   class _EndCountBase {
     var errors: chpl_TaskErrors;
     var taskList: c_void_ptr = _defaultOf(c_void_ptr);
@@ -845,6 +846,7 @@ module ChapelBase {
 
   pragma "end count"
   pragma "no default functions"
+  pragma "use default init"
   class _EndCount : _EndCountBase {
     type iType;
     type taskType;
@@ -1825,6 +1827,7 @@ module ChapelBase {
   extern const QIO_TUPLE_FORMAT_JSON:int;
 
   // Support for module deinit functions.
+  pragma "use default init"
   class chpl_ModuleDeinit {
     const moduleName: c_string;          // for debugging; non-null, not owned
     const deinitFun:  c_fn_ptr;          // module deinit function

--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -480,10 +480,12 @@ module ChapelLocale {
   // too complicated this early on, so we are using a for loop to
   // broadcast that we are done.
   pragma "no doc"
+  pragma "use default init"
   class localesSignal {
     var s: atomic bool;
   }
   pragma "no doc"
+  pragma "use default init"
   record localesBarrier {
     proc wait(locIdx, flags) {
       if locIdx==0 {

--- a/modules/internal/LocaleModelHelpSetup.chpl
+++ b/modules/internal/LocaleModelHelpSetup.chpl
@@ -40,6 +40,7 @@ module LocaleModelHelpSetup {
 
   extern var chpl_nodeID: chpl_nodeID_t;
 
+  pragma "use default init"
   record chpl_root_locale_accum {
     var nPUsPhysAcc: atomic int;
     var nPUsPhysAll: atomic int;

--- a/modules/internal/LocaleTree.chpl
+++ b/modules/internal/LocaleTree.chpl
@@ -26,6 +26,7 @@ module LocaleTree {
 
   use ChapelLocale; // For declaration of rootLocale.
 
+  pragma "use default init"
   record chpl_localeTreeRecord {
     var left, right: locale;
   }

--- a/modules/internal/tasktable/on/ChapelTaskTable.chpl
+++ b/modules/internal/tasktable/on/ChapelTaskTable.chpl
@@ -51,6 +51,11 @@ module ChapelTaskTable {
   // sort the tasks and indent to show the parent/child relationships, which
   // might be very nice.
   //
+  // This 'plain old data' pragma appears to be necessary for the following
+  // test to work: parallel/begin/stonea/reports.chpl
+  //
+  pragma "plain old data"
+  pragma "use default init"
   record chpldev_Task {
     var state     : taskState;
     var lineno    : uint(32);
@@ -58,6 +63,7 @@ module ChapelTaskTable {
     var tl_info   : uint(64);
   }
   
+  pragma "use default init"
   class chpldev_taskTable_t {
     var dom : domain(chpl_taskID_t, parSafe=false);
     var map : [dom] chpldev_Task;


### PR DESCRIPTION
These various internal types are fairly simple and not 'special' like tuples or arrays, and so are easy to convert to initializers.

Testing:
- [x] local + futures
- [x] gasnet
- [x] multilocale task-spawn perf
- [x] single-locale task-spawn perf