### PR TITLE
Fix replace-paths to avoid normalizing file name

### DIFF
--- a/util/config/replace-paths.py
+++ b/util/config/replace-paths.py
@@ -48,6 +48,14 @@ if __name__ == '__main__':
 
         origpath = m
         path = os.path.realpath(origpath)
+
+        if os.path.isfile(path):
+          # Leave out the filename, since we're only trying to replace
+          # directories. This prevents clang++ from being replaced
+          # with e.g. clang-6.0 when clang++ is a symbolic link.
+          origpath = os.path.dirname(origpath)
+          path = os.path.dirname(path)
+
         #sys.stdout.write("maybe found path {0} \n".format(path))
 
         for kv in tofix:


### PR DESCRIPTION
This avoids a problem on Mac OS X where clang++ turns
into clang-6.0 for --llvm configurations.
(That happens because clang++ is a symbolic link pointing
 to clang-6.0).

This can be viewed as a follow-on to #7801 and #9103.

Reviewed by @dmk42 - thanks!

- [x] full local testing
- [x] verified prefix installation works with --llvm on Mac OS X including with a regexp test