### PR TITLE
Compiler changes supporting unmanaged in domain maps

### DIFF
--- a/compiler/AST/UnmanagedClassType.cpp
+++ b/compiler/AST/UnmanagedClassType.cpp
@@ -23,8 +23,8 @@
 #include "symbol.h"
 #include "expr.h"
 #include "iterator.h"
-                          
-UnmanagedClassType::UnmanagedClassType(AggregateType* cls) 
+
+UnmanagedClassType::UnmanagedClassType(AggregateType* cls)
   : Type(E_UnmanagedClassType, NULL) {
 
   canonicalClass = cls;
@@ -121,6 +121,16 @@ static void convertClassTypes(Type* (*convert)(Type*)) {
         se->setSymbol(newTS);
       }
     }
+
+    form_Map(SymbolMapElem, e, ts->type->substitutions) {
+      if (TypeSymbol* ets = toTypeSymbol(e->value)) {
+        Type* newT = convert(ets->type);
+        if (newT != ets->type) {
+          TypeSymbol* newTS = newT->symbol;
+          e->value = newTS;
+        }
+      }
+    }
   }
 
   forv_Vec(FnSymbol, fn, gFnSymbols) {
@@ -131,6 +141,16 @@ static void convertClassTypes(Type* (*convert)(Type*)) {
       Type* newYieldT = convert(fn->iteratorInfo->yieldedType);
       if (newYieldT != fn->iteratorInfo->yieldedType)
         fn->iteratorInfo->yieldedType = newYieldT;
+    }
+
+    form_Map(SymbolMapElem, e, fn->substitutions) {
+      if (TypeSymbol* ets = toTypeSymbol(e->value)) {
+        Type* newT = convert(ets->type);
+        if (newT != ets->type) {
+          TypeSymbol* newTS = newT->symbol;
+          e->value = newTS;
+        }
+      }
     }
   }
 }

--- a/compiler/AST/UnmanagedClassType.cpp
+++ b/compiler/AST/UnmanagedClassType.cpp
@@ -128,6 +128,11 @@ static void convertClassTypes(Type* (*convert)(Type*)) {
     if (newT != arg->type) arg->type = newT;
   }
 
+  forv_Vec(ShadowVarSymbol, sv, gShadowVarSymbols) {
+    Type* newT = convert(sv->type);
+    if (newT != sv->type) sv->type = newT;
+  }
+
   forv_Vec(TypeSymbol, ts, gTypeSymbols) {
     Type* newT = convert(ts->type);
     if (newT != ts->type) {

--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -1210,6 +1210,11 @@ bool isClassLike(Type* t) {
   return isClass(t) || isUnmanagedClassType(t);
 }
 
+bool isClassLikeOrNil(Type* t) {
+  if (t == dtNil) return true;
+  return isClassLike(t);
+}
+
 bool isRecord(Type* t) {
   if (AggregateType* ct = toAggregateType(t))
     return ct->isRecord();

--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -1470,7 +1470,7 @@ bool needsCapture(Type* t) {
       is_complex_type(t) ||
       is_enum_type(t) ||
       t == dtStringC ||
-      isClass(t) ||
+      isClassLike(t) ||
       isRecord(t) ||
       isUnion(t) ||
       t == dtTaskID || // false?

--- a/compiler/include/type.h
+++ b/compiler/include/type.h
@@ -448,6 +448,7 @@ int  get_exponent_width(Type*);
 bool isClass(Type* t);
 bool isClassOrNil(Type* t);
 bool isClassLike(Type* t); // includes UnmanagedClassType & ClassType
+bool isClassLikeOrNil(Type* t);
 bool isRecord(Type* t);
 bool isUnion(Type* t);
 

--- a/compiler/main/checks.cpp
+++ b/compiler/main/checks.cpp
@@ -757,7 +757,7 @@ checkFormalActualBaseTypesMatch()
             // Exact match, so OK.
             continue;
 
-          if (isClass(formal->type))
+          if (isClassLike(formal->type))
             // dtNil can be converted to any class type, so OK.
             continue;
 

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -881,9 +881,12 @@ static void processSyntacticDistributions(CallExpr* call) {
       if (SymExpr* distClass = toSymExpr(distCall->baseExpr)) {
         if (TypeSymbol* ts = expandTypeAlias(distClass)) {
           if (isDistClass(ts->type) == true) {
-            CallExpr* newExpr = new CallExpr(PRIM_NEW, distCall->remove());
+            CallExpr* newExpr = new CallExpr(PRIM_NEW,
+                new CallExpr("_to_unmanaged", distCall->remove()));
 
             call->insertAtHead(new CallExpr("chpl__buildDistValue", newExpr));
+
+            processManagedNew(newExpr);
           }
         }
       }

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -881,12 +881,15 @@ static void processSyntacticDistributions(CallExpr* call) {
       if (SymExpr* distClass = toSymExpr(distCall->baseExpr)) {
         if (TypeSymbol* ts = expandTypeAlias(distClass)) {
           if (isDistClass(ts->type) == true) {
-            CallExpr* newExpr = new CallExpr(PRIM_NEW,
-                new CallExpr("_to_unmanaged", distCall->remove()));
+            // TODO
+            //CallExpr* newExpr = new CallExpr(PRIM_NEW,
+            //    new CallExpr("_to_unmanaged", distCall->remove()));
+            CallExpr* newExpr = new CallExpr(PRIM_NEW, distCall->remove());
 
             call->insertAtHead(new CallExpr("chpl__buildDistValue", newExpr));
 
-            processManagedNew(newExpr);
+            // TODO
+            //processManagedNew(newExpr);
           }
         }
       }

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -6049,7 +6049,7 @@ static void handleUnstableNewError(CallExpr* newExpr) {
           } else {
             // TODO -- enable warning for internal/standard modules
             // along with updating them.
-            /*if (newExpr->getModule()->modTag == MOD_USER) */{
+            if (newExpr->getModule()->modTag == MOD_USER) {
               USR_WARN(newExpr, "new %s is unstable", newType->symbol->name);
               USR_PRINT(newExpr, "use 'new unmanaged %s' "
                                  "'new owned %s' or "

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -1154,9 +1154,9 @@ bool doCanDispatch(Type*     actualType,
   // autocopy(x) and the autocopy(x: atomic int) (represented as
   // autocopy(x: ref(atomic int)) internally).
   //
-  } else if (actualType                              == dtNil  &&
-             isClass(canonicalClassType(formalType)) == true   &&
-             formalType->symbol->hasFlag(FLAG_REF)   == false) {
+  } else if (actualType == dtNil &&
+             isClass(canonicalClassType(formalType)) &&
+             !formalType->symbol->hasFlag(FLAG_REF)) {
     retval = true;
 
   } else if (actualType->refType == formalType &&

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -1154,9 +1154,9 @@ bool doCanDispatch(Type*     actualType,
   // autocopy(x) and the autocopy(x: atomic int) (represented as
   // autocopy(x: ref(atomic int)) internally).
   //
-  } else if (actualType                            == dtNil  &&
-             isClass(formalType)                   == true   &&
-             formalType->symbol->hasFlag(FLAG_REF) == false) {
+  } else if (actualType                              == dtNil  &&
+             isClass(canonicalClassType(formalType)) == true   &&
+             formalType->symbol->hasFlag(FLAG_REF)   == false) {
     retval = true;
 
   } else if (actualType->refType == formalType &&

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -2937,7 +2937,7 @@ static bool populateForwardingMethods(CallInfo& info) {
   const char*    calledName = info.name;
   Type*          t          = forCall->get(2)->typeInfo()->getValType();
 
-  AggregateType* at         = toAggregateType(t);
+  AggregateType* at         = toAggregateType(canonicalClassType(t));
   bool           addedAny   = false;
 
   // Currently, only AggregateTypes can forward

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -2811,7 +2811,8 @@ static void findVisibleFunctionsAndCandidates(
   if (candidates.n             == 0 &&
       call->numActuals()       >= 1 &&
       call->get(1)->typeInfo() == dtMethodToken) {
-    Type* receiverType = call->get(2)->typeInfo()->getValType();
+    Type* receiverType =
+      canonicalClassType(call->get(2)->typeInfo()->getValType());
 
     if (typeUsesForwarding(receiverType) == true &&
         populateForwardingMethods(info)  == true) {
@@ -3083,7 +3084,7 @@ static bool populateForwardingMethods(CallInfo& info) {
 
     std::vector<FnSymbol*> methods;
 
-    collectVisibleMethodsNamed(delegate->type, methodName, methods);
+    collectVisibleMethodsNamed(canonicalClassType(delegate->type), methodName, methods);
 
     // Compute the type of `this` for use in the forwarding function.
     AggregateType* thisType = at;
@@ -6048,7 +6049,7 @@ static void handleUnstableNewError(CallExpr* newExpr) {
           } else {
             // TODO -- enable warning for internal/standard modules
             // along with updating them.
-            if (newExpr->getModule()->modTag == MOD_USER) {
+            /*if (newExpr->getModule()->modTag == MOD_USER) */{
               USR_WARN(newExpr, "new %s is unstable", newType->symbol->name);
               USR_PRINT(newExpr, "use 'new unmanaged %s' "
                                  "'new owned %s' or "

--- a/compiler/resolution/implementForallIntents.cpp
+++ b/compiler/resolution/implementForallIntents.cpp
@@ -20,6 +20,7 @@
 #include "implementForallIntents.h"
 
 #include "resolveFunction.h"
+#include "UnmanagedClassType.h"
 
 //
 //-----------------------------------------------------------------------------
@@ -1017,6 +1018,8 @@ void cleanupRedRefs(Expr*& redRef1, Expr*& redRef2) {
 // similar to isArrayClass()
 bool isReduceOp(Type* type) {
   bool retval = false;
+
+  type = canonicalClassType(type);
 
   if (type->symbol->hasFlag(FLAG_REDUCESCANOP) == true) {
     retval = true;

--- a/compiler/resolution/postFold.cpp
+++ b/compiler/resolution/postFold.cpp
@@ -267,7 +267,7 @@ static Expr* postFoldPrimop(CallExpr* call) {
       if (st->symbol->hasFlag(FLAG_DISTRIBUTION) && isDistClass(pt)) {
         AggregateType* ag = toAggregateType(st);
 
-        st = ag->getField("_instance")->type;
+        st = canonicalClassType(ag->getField("_instance")->type);
       } else {
         // Try to work around some resolution order issues
         st = resolveTypeAlias(subExpr);

--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -950,8 +950,7 @@ static Expr* preFoldPrimOp(CallExpr* call) {
     //
     SymExpr* se = toSymExpr(call->get(1));
 
-    if (se->symbol()->hasFlag(FLAG_EXPR_TEMP) == true &&
-        isClassLike(type)                     == false) {
+    if (se->symbol()->hasFlag(FLAG_EXPR_TEMP) && !isClassLike(type)) {
       USR_WARN(se, "accessing the locale of a local expression");
     }
 

--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -951,7 +951,7 @@ static Expr* preFoldPrimOp(CallExpr* call) {
     SymExpr* se = toSymExpr(call->get(1));
 
     if (se->symbol()->hasFlag(FLAG_EXPR_TEMP) == true &&
-        isClass(type)                         == false) {
+        isClassLike(type)                     == false) {
       USR_WARN(se, "accessing the locale of a local expression");
     }
 

--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -842,21 +842,21 @@ static void resolveTypeConstructor(FnSymbol* fn) {
 }
 
 void fixTypeNames(AggregateType* at) {
-  const char*    domName = "DefaultRectangularDom";
-  const int   domNameLen = strlen(domName);
+  const char* drDomName = "DefaultRectangularDom";
+  const int   drDomNameLen = strlen(drDomName);
 
   if (at->symbol->hasFlag(FLAG_BASE_ARRAY) == false &&
       isArrayClass(at)                     ==  true) {
-    const char* domainType = at->getField("dom")->type->symbol->name;
+    const char* domainType = canonicalClassType(at->getField("dom")->type)->symbol->name;
     const char* eltType    = at->getField("eltType")->type->symbol->name;
 
     at->symbol->name = astr("[", domainType, "] ", eltType);
 
-  } else if (strncmp(at->symbol->name, domName, domNameLen) == 0) {
-    at->symbol->name = astr("domain", at->symbol->name + domNameLen);
+  } else if (strncmp(at->symbol->name, drDomName, drDomNameLen) == 0) {
+    at->symbol->name = astr("domain", at->symbol->name + drDomNameLen);
 
   } else if (isRecordWrappedType(at) == true) {
-    at->symbol->name = at->getField("_instance")->type->symbol->name;
+    at->symbol->name = canonicalClassType(at->getField("_instance")->type)->symbol->name;
   }
 }
 

--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -1550,12 +1550,6 @@ static void addArgCoercion(FnSymbol*  fn,
 
     castCall   = new CallExpr("borrow", gMethodToken, prevActual);
 
-  } else if (isUnmanagedClass(ats->getValType()) &&
-             isBorrowClass(formal->getValType())) {
-    checkAgain = true;
-
-    castCall   = new CallExpr(PRIM_CAST, formal->getValType()->symbol, prevActual);
-
   } else if (ats->hasFlag(FLAG_REF) &&
              !(ats->getValType()->symbol->hasFlag(FLAG_TUPLE) &&
                formal->getValType()->symbol->hasFlag(FLAG_TUPLE)) ) {
@@ -1590,6 +1584,12 @@ static void addArgCoercion(FnSymbol*  fn,
         }
       }
     }
+
+  } else if (isUnmanagedClass(ats->typeInfo()) &&
+             isBorrowClass(formal->typeInfo())) {
+    checkAgain = true;
+
+    castCall   = new CallExpr(PRIM_CAST, formal->getValType()->symbol, prevActual);
 
   } else {
     // There was code to handle the case when the flag *is* present.

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1062,6 +1062,10 @@ module ChapelBase {
   inline proc _cast(type t, x) where x:object && t:x && (x.type != t)
     return if x != nil then __primitive("dynamic_cast", t, x) else __primitive("cast", t, nil);
 
+  pragma "unsafe"
+  inline proc _cast(type t, x) where x:_unmanaged && t:_unmanaged && t:x && (x.type != t)
+    return if x != nil then __primitive("dynamic_cast", t, x) else __primitive("cast", t, nil);
+
   inline proc _cast(type t, x:_nilType) where t == _nilType
     return nil;
 

--- a/test/classes/delete-free/unmanaged/unmanaged-forwarding.chpl
+++ b/test/classes/delete-free/unmanaged/unmanaged-forwarding.chpl
@@ -1,0 +1,15 @@
+class MyClass {
+  proc method() {
+    writeln("in method");
+  }
+}
+class Forwarder {
+  forwarding var x;
+}
+
+proc test() {
+  var ff = new unmanaged Forwarder(new unmanaged MyClass());
+
+  ff.method();
+}
+test();

--- a/test/classes/delete-free/unmanaged/unmanaged-forwarding.good
+++ b/test/classes/delete-free/unmanaged/unmanaged-forwarding.good
@@ -1,0 +1,1 @@
+in method


### PR DESCRIPTION
These compiler changes support the effort to use `unmanaged` more
in the domain map hierarchy (PR #9282). These portions can be applied
without changing the types in the domain map hierarchy. They are bug
fixes for `unmanaged`.

- [x] passed full local testing

Reviewed by @vasslitvinov - thanks!