### PR TITLE
Adjust partial-reduction tests

### DIFF
--- a/test/npb/cg/bradc/cg-sparse-partred.skipif
+++ b/test/npb/cg/bradc/cg-sparse-partred.skipif
@@ -1,0 +1,5 @@
+# This test currently takes much longer under cygwin and valgrind,
+# so do not test it there.
+# TODO: bring performance on par with linux.
+CHPL_TARGET_PLATFORM <= cygwin
+CHPL_TEST_VGRND_EXE == on

--- a/test/reductions/partial/CSimpl.chpl
+++ b/test/reductions/partial/CSimpl.chpl
@@ -32,5 +32,6 @@ proc CS.dsiPartialReduce(const reduceOp, const resDimSpec,
     reduceOp.accumulateOntoState(resArr[resIdx], srcElm);
   }
 
+  delete resReduceOp;
   return  resArr;
 }

--- a/test/reductions/partial/DRimpl.chpl
+++ b/test/reductions/partial/DRimpl.chpl
@@ -29,5 +29,6 @@ proc DefaultDist.dsiPartialReduce(const reduceOp, const resDimSpec,
     reduceOp.accumulateOntoState(resArr[resIdx], srcElm);
   }
 
+  delete resReduceOp;
   return  resArr;
 }


### PR DESCRIPTION
* cg-sparse-partred.chpl runs too long under cygwin and valgrind,
  so skip them there.

* dsiPartialReduce() in DRimpl.chpl and CSimpl.chpl leak
  a lot of reduce ops. Add a missing 'delete' to reduce
  the leaks in half.