### PR TITLE
Process /proc/cpuinfo for CPU counts in a better way. (cp PR #9188)

### DIFF
--- a/runtime/src/chplsys.c
+++ b/runtime/src/chplsys.c
@@ -504,7 +504,7 @@ uint64_t chpl_sys_availMemoryBytes(void) {
 //
 static struct {
   int physId, coreId;
-} cpuTab[1024];
+} cpuTab[8192];
 static const int cpuTabSize = sizeof(cpuTab) / sizeof(cpuTab[0]);
 static int cpuTabLen = 0;
 
@@ -583,7 +583,7 @@ static void getCpuInfo_once(void) {
   fclose(f);
 
   if ((numPUs = procs) <= 0)
-    numPUs = 1;
+    numPUs = cpuTabLen;
 
   if (cpuTabLen > 0) {
     numCores = cpuTabLen;


### PR DESCRIPTION
We've been computing node core counts by dividing the number of
'processor' entries in `/proc/cpuinfo` by the number of hardware threads
per core.  We've been getting the latter two values by looking at the
'siblings' and 'cpu cores' entries, and to avoid being confused we've
insisted that all the 'siblings' entries have the same value and all the
'cpu cores' entries have the same value.  But we've begun to encounter
situations where that doesn't hold, which leads to an internal error and
we cannot continue.

Here, switch to just counting the number of distinct pairs of 'physical
id' and 'core id' values to give us a core count.  For at least the one
internal error situation for which we have a copy of the `/proc/cpuinfo`
file, this gives the correct result.

I believe this will resolve #9170 and the problem reported [here](https://github.com/buddha314/Charcoal/issues/6).  It will also close
#9187.