### PR TITLE
Follow-up work to #9102

### DIFF
--- a/third-party/chpl-venv/Makefile
+++ b/third-party/chpl-venv/Makefile
@@ -43,7 +43,7 @@ $(PIP): $(CHPL_VENV_INSTALL_DIR)
 # Install virtualenv program.
 $(CHPL_VENV_VIRTUALENV): check-exes $(PIP)
 	export PYTHONPATH="$(PIPLIBS):$$PYTHONPATH" && \
-	python $(PIP) install -U --force-reinstall --ignore-installed \
+	python -S $(PIP) install -U --force-reinstall --ignore-installed \
 	 --prefix=$(CHPL_VENV_INSTALL_DIR) $(CHPL_PIP_INSTALL_PARAMS) $(shell cat virtualenv.txt)
 
 # Phony convenience target for installing virtualenv.

--- a/third-party/chpl-venv/Makefile
+++ b/third-party/chpl-venv/Makefile
@@ -30,16 +30,20 @@ $(CHPL_VENV_INSTALL_DIR):
 
 # Install pip via get-pip.py to ensure we have an updated version
 $(PIP): $(CHPL_VENV_INSTALL_DIR)
-	if [ -z "$$CHPL_PIP" ]; then \
-	  (cd install && curl -O $(GETPIP) && \
+	@echo "Installing local copy of pip with get-pip.py from $(GETPIP)"
+	@if [ -z "$$CHPL_PIP" ]; then \
+	  (cd install && curl -O $(GETPIP) || \
+	  { echo "Failed on command: curl -O $(GETPIP)."; \
+	    echo "Try setting CHPL_PIP to $$(which pip) and trying again"; \
+	    exit 1; } && \
 	  export PYTHONUSERBASE=$(CHPL_VENV_INSTALL_DIR) && \
-	  $(PYTHON) get-pip.py --user) \
+	  python get-pip.py --user) \
 	fi
 
 # Install virtualenv program.
 $(CHPL_VENV_VIRTUALENV): check-exes $(PIP)
 	export PYTHONPATH="$(PIPLIBS):$$PYTHONPATH" && \
-	$(PYTHON) $(PIP) install -U --force-reinstall --ignore-installed \
+	python $(PIP) install -U --force-reinstall --ignore-installed \
 	 --prefix=$(CHPL_VENV_INSTALL_DIR) $(CHPL_PIP_INSTALL_PARAMS) $(shell cat virtualenv.txt)
 
 # Phony convenience target for installing virtualenv.


### PR DESCRIPTION
Follow-up PR to #9102:

- Use `python -S` flag to avoid any `sys.path` prepending (looking at you Ubuntu)
- Add a helpful message that suggests setting `CHPL_PIP` if `curl` failed (likely due to an outdated openssl)
  - Maybe we should also suggest updating openssl?
- Stop using `$(PYTHON)` to call `python`. This variable was intended to check the python version, not pin the binary we should be using.