### PR TITLE
Update atomics to use initializers

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -4311,6 +4311,9 @@ void lvalueCheck(CallExpr* call) {
 
       INT_ASSERT(calleeFn == formal->defPoint->parentSymbol); // sanity
 
+      Symbol* actSym = isSymExpr(actual) ? toSymExpr(actual)->symbol() : NULL;
+      bool isInitParam = actSym->hasFlag(FLAG_PARAM) && calleeFn->isInitializer();
+
       if (calleeFn->hasFlag(FLAG_ASSIGNOP)) {
         // This assert is FYI. Perhaps can remove it if it fails.
         INT_ASSERT(callStack.n > 0 && callStack.v[callStack.n - 1] == call);
@@ -4329,7 +4332,7 @@ void lvalueCheck(CallExpr* call) {
           USR_FATAL_CONT(actual, "illegal lvalue in assignment");
         }
 
-      } else {
+      } else if (isInitParam == false) {
         ModuleSymbol* mod          = calleeFn->getModule();
         char          cn1          = calleeFn->name[0];
         const char*   calleeParens = (isalpha(cn1) || cn1 == '_') ? "()" : "";

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5553,7 +5553,7 @@ static void resolveMoveForRhsCallExpr(CallExpr* call) {
     moveFinalize(call);
 
     if (SymExpr* se = toSymExpr(rhs->get(1))) {
-      Type* seType = se->symbol()->type;
+      Type* seType = se->symbol()->getValType();
 
       if (isNonGenericRecordWithInitializers(seType) == true) {
         Expr*     callLhs  = call->get(1)->remove();

--- a/modules/internal/Atomics.chpl
+++ b/modules/internal/Atomics.chpl
@@ -316,6 +316,7 @@ module Atomics {
   /*
      The boolean atomic type.
   */
+  pragma "use default init"
   record atomicbool {
     pragma "no doc"
     var _v:atomic_bool = create_atomic_bool();
@@ -439,6 +440,7 @@ module Atomics {
   pragma "atomic type"
   pragma "ignore noinit" 
   pragma "no doc"
+  pragma "use default init"
   record atomic_uint8 {
     var _v:atomic_uint_least8_t = create_atomic_uint_least8();
     inline proc deinit() {
@@ -542,6 +544,7 @@ module Atomics {
   pragma "atomic type"
   pragma "ignore noinit"
   pragma "no doc"
+  pragma "use default init"
   record atomic_uint16 {
     var _v:atomic_uint_least16_t = create_atomic_uint_least16();
     inline proc deinit() {
@@ -645,6 +648,7 @@ module Atomics {
   pragma "atomic type"
   pragma "ignore noinit"
   pragma "no doc"
+  pragma "use default init"
   record atomic_uint32 {
     var _v:atomic_uint_least32_t = create_atomic_uint_least32();
     inline proc deinit() {
@@ -748,6 +752,7 @@ module Atomics {
   pragma "atomic type"
   pragma "ignore noinit"
   pragma "no doc"
+  pragma "use default init"
   record atomic_uint64 {
     var _v:atomic_uint_least64_t = create_atomic_uint_least64();
     inline proc deinit() {
@@ -851,6 +856,7 @@ module Atomics {
   pragma "atomic type"
   pragma "ignore noinit"
   pragma "no doc"
+  pragma "use default init"
   record atomic_int8 {
     var _v:atomic_int_least8_t = create_atomic_int_least8();
     inline proc deinit() {
@@ -954,6 +960,7 @@ module Atomics {
   pragma "atomic type"
   pragma "ignore noinit"
   pragma "no doc"
+  pragma "use default init"
   record atomic_int16 {
     var _v:atomic_int_least16_t = create_atomic_int_least16();
     inline proc deinit() {
@@ -1057,6 +1064,7 @@ module Atomics {
   pragma "atomic type"
   pragma "ignore noinit"
   pragma "no doc"
+  pragma "use default init"
   record atomic_int32 {
     var _v:atomic_int_least32_t = create_atomic_int_least32();
     inline proc deinit() {
@@ -1158,6 +1166,7 @@ module Atomics {
 
   pragma "atomic type"
   pragma "ignore noinit"
+  pragma "use default init"
   record atomic_int64 {
     pragma "no doc"
     var _v:atomic_int_least64_t = create_atomic_int_least64();
@@ -1374,6 +1383,7 @@ module Atomics {
   pragma "atomic type"
   pragma "ignore noinit"
   pragma "no doc"
+  pragma "use default init"
   record atomic_real64 {
     var _v:atomic__real64 = create_atomic__real64();
     inline proc deinit() {
@@ -1454,6 +1464,7 @@ module Atomics {
   pragma "atomic type"
   pragma "ignore noinit"
   pragma "no doc"
+  pragma "use default init"
   record atomic_real32 {
     var _v:atomic__real32 = create_atomic__real32();
     inline proc deinit() {

--- a/modules/internal/AtomicsCommon.chpl
+++ b/modules/internal/AtomicsCommon.chpl
@@ -20,6 +20,7 @@
 module AtomicsCommon {
   use ChapelStandard;
 
+  pragma "use default init"
   record atomic_refcnt {
     // The common case seems to be local access to this class, so we
     // will use explicit processor atomics, even when network

--- a/modules/internal/NetworkAtomics.chpl
+++ b/modules/internal/NetworkAtomics.chpl
@@ -75,6 +75,7 @@ module NetworkAtomics {
 
   // int(64)
   pragma "atomic type"
+  pragma "use default init"
   record ratomic_int64 {
     var _v: int(64);
     inline proc const read(order:memory_order = memory_order_seq_cst):int(64) {
@@ -269,6 +270,7 @@ module NetworkAtomics {
 
   // int32
   pragma "atomic type"
+  pragma "use default init"
   record ratomic_int32 {
     var _v: int(32);
     inline proc const read(order:memory_order = memory_order_seq_cst):int(32) {
@@ -460,6 +462,7 @@ module NetworkAtomics {
 
   // uint(64)
   pragma "atomic type"
+  pragma "use default init"
   record ratomic_uint64 {
     var _v: uint(64);
     inline proc const read(order:memory_order = memory_order_seq_cst):uint(64) {
@@ -651,6 +654,7 @@ module NetworkAtomics {
 
   // uint(32)
   pragma "atomic type"
+  pragma "use default init"
   record ratomic_uint32 {
     var _v: uint(32);
     inline proc const read(order:memory_order = memory_order_seq_cst):uint(32) {
@@ -790,6 +794,7 @@ module NetworkAtomics {
 
   // bool, implemented with int(64)
   pragma "atomic type"
+  pragma "use default init"
   record ratomicbool {
     var _v: int(64);
     inline proc const read(order:memory_order = memory_order_seq_cst):bool {
@@ -911,6 +916,7 @@ inline proc compareExchangeWeak(expected:bool, desired:bool,
                                               ref result:bool(32));
   
   pragma "atomic type"
+  pragma "use default init"
   record ratomic_real64 {
     var _v: real(64);
     inline proc const read(order:memory_order = memory_order_seq_cst):real(64) {

--- a/test/param/errors/checkParamTypes-error.good
+++ b/test/param/errors/checkParamTypes-error.good
@@ -1,2 +1,2 @@
-checkParamTypes.chpl:16: error: 'p' is not of a supported param type
-checkParamTypes.chpl:18: error: Passed!
+checkParamTypes.chpl:18: error: 'p' is not of a supported param type
+checkParamTypes.chpl:20: error: Passed!

--- a/test/param/errors/checkParamTypes-nofloat32.good
+++ b/test/param/errors/checkParamTypes-nofloat32.good
@@ -1,2 +1,2 @@
-checkParamTypes.chpl:16: error: Initializing parameter 'p' to value not known at compile time
-checkParamTypes.chpl:18: error: Passed!
+checkParamTypes.chpl:18: error: Initializing parameter 'p' to value not known at compile time
+checkParamTypes.chpl:20: error: Passed!

--- a/test/param/errors/checkParamTypes.chpl
+++ b/test/param/errors/checkParamTypes.chpl
@@ -1,8 +1,10 @@
 enum color { red, green, blue};
 
+pragma "use default init"
 record R {
   var x: int;
 }
+pragma "use default init"
 class C {
   var x: int;
 }

--- a/test/param/errors/checkParamTypes.good
+++ b/test/param/errors/checkParamTypes.good
@@ -1,1 +1,1 @@
-checkParamTypes.chpl:18: error: Passed!
+checkParamTypes.chpl:20: error: Passed!


### PR DESCRIPTION
This PR updates processor and network atomic types to use initializers instead of constructors. A small compiler change is needed in order to avoid an unhelpful compiler message for param atomics (which are unsupported).

Testing:
- [x] local + futures
- [ ] gasnet
- [ ] 16-node-xc
  - [ ] HPCC RA-atomics
  - [ ] HPCC Streams
  - [ ] PRK Stencil
  - [ ] miniMD
  - [ ] ISx
  - [ ] Remote task spawning