### PR TITLE
Delete unmanaged pointers to close leak in new test

### DIFF
--- a/test/compflags/ferguson/unstable-new.chpl
+++ b/test/compflags/ferguson/unstable-new.chpl
@@ -23,6 +23,9 @@ proc errors() {
   writeln("in errors");
   writeln(x);
   writeln(y);
+
+  delete x;
+  delete y;
 }
 
 proc ok() {
@@ -44,6 +47,9 @@ proc ok() {
   writeln(f);
   writeln(g);
   writeln(h);
+
+  delete a;
+  delete b;
 }
 
 


### PR DESCRIPTION
Add deletes to leak less in this new test.

Trivial and not reviewed.