### PR TITLE
Revert #9205 "Workaround for c_sublocid_any ..."

### DIFF
--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -448,12 +448,10 @@ module ChapelLocale {
       // Simple locales barrier, see implementation below for notes
       var b: localesBarrier;
       var flags: [1..#numLocales-1] localesSignal;
-      // A workaround for not munging identifiers in modules.
-      const chpl_my_sublocid_any = c_sublocid_any;
       coforall locIdx in 0..#numLocales /*ref(b)*/ {
         on __primitive("chpl_on_locale_num",
                        chpl_buildLocaleID(locIdx:chpl_nodeID_t,
-                                          chpl_my_sublocid_any)) {
+                                          c_sublocid_any)) {
           chpl_defaultDistInitPrivate();
           yield locIdx;
           b.wait(locIdx, flags);

--- a/modules/internal/LocaleModelHelpSetup.chpl
+++ b/modules/internal/LocaleModelHelpSetup.chpl
@@ -78,11 +78,9 @@ module LocaleModelHelpSetup {
 
   proc helpSetupRootLocaleNUMA(dst:RootLocale) {
     var root_accum:chpl_root_locale_accum;
-    // A workaround for not munging identifiers in modules.
-    const chpl_my_sublocid_any = c_sublocid_any;
 
     forall locIdx in dst.chpl_initOnLocales() with (ref root_accum) {
-      chpl_task_setSubloc(chpl_my_sublocid_any);
+      chpl_task_setSubloc(c_sublocid_any);
       const node = new LocaleModel(dst);
       dst.myLocales[locIdx] = node;
       root_accum.accum(node);
@@ -93,11 +91,9 @@ module LocaleModelHelpSetup {
 
   proc helpSetupRootLocaleAPU(dst:RootLocale) {
     var root_accum:chpl_root_locale_accum;
-    // A workaround for not munging identifiers in modules.
-    const chpl_my_sublocid_any = c_sublocid_any;
 
     forall locIdx in dst.chpl_initOnLocales() with (ref root_accum) {
-      chpl_task_setSubloc(chpl_my_sublocid_any);
+      chpl_task_setSubloc(c_sublocid_any);
       const node = new LocaleModel(dst);
       dst.myLocales[locIdx] = node;
       root_accum.accum(node);


### PR DESCRIPTION
Reverts #9205 "Workaround for c_sublocid_any -related failures"

The workaround was to avoid the following issue.

An internal module contained a local variable whose name was the same
as the name of a global 'extern' variable. The compiler failed to
uniquifyName() of the local variable because it did not realize that
it was necessary. The latter happened because the extern variable
was !isRenameable() so its name was not recorded. The local variable's
name, then, was not deemed to be in conflict with the extern.

#9300 fixed this behavior, so the workaround from #9205 is no longer
necessary.