### PR TITLE
Add two tests of applying .type to a generic arg, one a future

### DIFF
--- a/test/functions/generic/genericArgDotType.bad
+++ b/test/functions/generic/genericArgDotType.bad
@@ -1,0 +1,2 @@
+In foo()
+In bar()

--- a/test/functions/generic/genericArgDotType.chpl
+++ b/test/functions/generic/genericArgDotType.chpl
@@ -1,0 +1,17 @@
+enum color {red, green, blue};
+enum size {small, medium, large};
+
+proc foo(x: enumerated, y: x.type) {
+  writeln("In foo()");
+}
+
+foo(color.red, size.small);
+
+proc bar(x: integral, y: x.type) {
+  writeln("In bar()");
+}
+
+var i8 = 1: int(8);
+var i64 = max(int);
+
+bar(i8, i64);

--- a/test/functions/generic/genericArgDotType.compopts
+++ b/test/functions/generic/genericArgDotType.compopts
@@ -1,0 +1,1 @@
+--ignore-errors-for-pass

--- a/test/functions/generic/genericArgDotType.future
+++ b/test/functions/generic/genericArgDotType.future
@@ -1,0 +1,9 @@
+bug: .type on generic argument
+
+It seems as though applying .type to an argument with a specified, but
+generic, formal type should refer to the type of the actual with which
+the function was instantiated, not be a copy of the generic formal
+type.  This test suggests that we're taking the latter interpretation
+at present.  The test genericArgDotType2.chpl, in which the first
+argument's type is completely specified, demonstrates how I think it
+should work.

--- a/test/functions/generic/genericArgDotType.good
+++ b/test/functions/generic/genericArgDotType.good
@@ -1,0 +1,4 @@
+test/functions/generic/genericArgDotType.chpl:8: error: unresolved call 'foo(color, size)'
+test/functions/generic/genericArgDotType.chpl:4: note: candidates are: foo(x: enumerated, y: x.type)
+test/functions/generic/genericArgDotType.chpl:17: error: unresolved call 'bar(int(8), int(64))'
+test/functions/generic/genericArgDotType.chpl:10: note: candidates are: bar(x: integral, y: x.type)

--- a/test/functions/generic/genericArgDotType2.chpl
+++ b/test/functions/generic/genericArgDotType2.chpl
@@ -1,0 +1,17 @@
+enum color {red, green, blue};
+enum size {small, medium, large};
+
+proc foo(x, y: x.type) {
+  writeln("In foo()");
+}
+
+foo(color.red, size.small);
+
+proc bar(x, y: x.type) {
+  writeln("In bar()");
+}
+
+var i8 = 1: int(8);
+var i64 = max(int);
+
+bar(i8, i64);

--- a/test/functions/generic/genericArgDotType2.compopts
+++ b/test/functions/generic/genericArgDotType2.compopts
@@ -1,0 +1,1 @@
+--ignore-errors-for-pass

--- a/test/functions/generic/genericArgDotType2.good
+++ b/test/functions/generic/genericArgDotType2.good
@@ -1,0 +1,4 @@
+genericArgDotType2.chpl:8: error: unresolved call 'foo(color, size)'
+genericArgDotType2.chpl:4: note: candidates are: foo(x, y: x.type )
+genericArgDotType2.chpl:17: error: unresolved call 'bar(int(8), int(64))'
+genericArgDotType2.chpl:10: note: candidates are: bar(x, y: x.type )


### PR DESCRIPTION
genericArgDotType.chpl shows that when an argument's type is based on
that of an argument with a specified, but formal, generic type, the
compiler only inherits the loose generic type of the argument, not the
more specific actual type with which it was instantiated.  This seems
surprising and wrong.

In contrast, genericArgDotType2.chpl shows that when the generic
argument simply has no type specified, the type constraint is taken
based on the actual type.  I believe that the first case should work
like this as well.