### PR TITLE
Update tuples to use special function instead of constructors

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -1354,6 +1354,11 @@ void AggregateType::buildConstructor() {
     }
   }
 
+  // Don't use initializers or constructors for tuples.
+  if (symbol->hasFlag(FLAG_TUPLE)) {
+    return;
+  }
+
   // Create the default constructor function symbol,
   FnSymbol* fn = new FnSymbol(astr("_construct_", symbol->name));
 
@@ -1367,13 +1372,6 @@ void AggregateType::buildConstructor() {
 
   if (symbol->hasFlag(FLAG_REF) == true) {
     fn->addFlag(FLAG_REF);
-  }
-
-  if (symbol->hasFlag(FLAG_TUPLE) == true) {
-    fn->addFlag(FLAG_TUPLE);
-    fn->addFlag(FLAG_INLINE);
-
-    gGenericTupleInit = fn;
   }
 
   // And insert it into the class type.

--- a/compiler/AST/FnSymbol.cpp
+++ b/compiler/AST/FnSymbol.cpp
@@ -37,7 +37,6 @@ FnSymbol*                 initStringLiterals    = NULL;
 
 FnSymbol*                 gAddModuleFn          = NULL;
 FnSymbol*                 gGenericTupleTypeCtor = NULL;
-FnSymbol*                 gGenericTupleInit     = NULL;
 FnSymbol*                 gGenericTupleDestroy  = NULL;
 
 std::map<FnSymbol*, int>  ftableMap;

--- a/compiler/AST/astutil.cpp
+++ b/compiler/AST/astutil.cpp
@@ -1081,3 +1081,7 @@ void convertToQualifiedRefs() {
   }
 #undef fixRefSymbols
 }
+
+bool isTupleTypeConstructor(FnSymbol* fn) {
+  return fn->hasFlag(FLAG_TYPE_CONSTRUCTOR) && fn->hasFlag(FLAG_TUPLE);
+}

--- a/compiler/AST/checkAST.cpp
+++ b/compiler/AST/checkAST.cpp
@@ -78,6 +78,8 @@ void checkArgsAndLocals()
 // resolution).
 void checkNoUnresolveds()
 {
+  // BHARSH INIT TODO: Can this be '0' now that the tuple constructor is gone?
+  //
   // TODO: This value should really be cranked down to 0.
   // But in some cases _construct__tuple remains unresolved after
   // resolution ... .

--- a/compiler/include/FnSymbol.h
+++ b/compiler/include/FnSymbol.h
@@ -185,7 +185,6 @@ extern FnSymbol*                chpl_gen_main;
 extern FnSymbol*                gAddModuleFn;
 
 extern FnSymbol*                gGenericTupleTypeCtor;
-extern FnSymbol*                gGenericTupleInit;
 extern FnSymbol*                gGenericTupleDestroy;
 
 extern std::map<FnSymbol*, int> ftableMap;

--- a/compiler/include/astutil.h
+++ b/compiler/include/astutil.h
@@ -189,4 +189,6 @@ void collectUsedFnSymbols(BaseAST* ast, std::set<FnSymbol*>& fnSymbols);
 
 void convertToQualifiedRefs();
 
+bool isTupleTypeConstructor(FnSymbol* fn);
+
 #endif

--- a/compiler/include/flags_list.h
+++ b/compiler/include/flags_list.h
@@ -150,6 +150,7 @@ symbolFlag( FLAG_INDEX_VAR , npr, "index var" , ncm )
 // into loop index variables.
 symbolFlag( FLAG_INDEX_OF_INTEREST , npr, "an _indexOfInterest or chpl__followIdx variable" , ncm )
 symbolFlag( FLAG_INIT_COPY_FN,  ypr, "init copy fn" , "init copy function" )
+symbolFlag( FLAG_INIT_TUPLE, ypr, "tuple init fn", ncm)
 symbolFlag( FLAG_INLINE , npr, "inline" , ncm )
 symbolFlag( FLAG_INLINE_ITERATOR , npr, "inline iterator" , "iterators that are always inlined, e.g., leaders" )
 symbolFlag( FLAG_INSERT_AUTO_DESTROY , ypr, "insert auto destroy" , ncm )

--- a/compiler/include/misc.h
+++ b/compiler/include/misc.h
@@ -66,6 +66,8 @@
 #define iterKindStandaloneTagname "standalone"
 #define iterFollowthisArgname     "followThis"
 
+#define tupleInitName "chpl__init_tuple"
+
 class BaseAST;
 
 bool        forceWidePtrsForLocal();

--- a/compiler/optimizations/copyPropagation.cpp
+++ b/compiler/optimizations/copyPropagation.cpp
@@ -946,8 +946,11 @@ void copyPropagation(void) {
   if (!fNoCopyPropagation) {
     forv_Vec(FnSymbol, fn, gFnSymbols)
     {
+      // BHARSH INIT TODO: Can this be eliminated now that tuples no longer use
+      // constructors?
+      //
       // This test is necessary because extern function stubs may contain
-      // _construct_tuple calls that are unresolved.
+      // _construct__tuple calls that are unresolved.
       if (fn->hasFlag(FLAG_EXTERN))
         continue;
 

--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -832,11 +832,10 @@ static void build_enum_enumerate_function(EnumType* et) {
   et->symbol->defPoint->insertAfter(new DefExpr(fn));
 
   // Generate the tuple of enum values for the given enum type
-  CallExpr* call = new CallExpr("_construct__tuple");
+  CallExpr* call = new CallExpr("_build_tuple");
   for_enums(constant, et) {
     call->insertAtTail(constant->sym);
   }
-  call->insertAtHead(new_IntSymbol(call->numActuals()));
 
   fn->insertAtTail(new CallExpr(PRIM_RETURN, call));
 

--- a/compiler/passes/checkResolved.cpp
+++ b/compiler/passes/checkResolved.cpp
@@ -396,7 +396,7 @@ checkReturnPaths(FnSymbol* fn) {
       fn->retTag == RET_TYPE ||
       fn->hasFlag(FLAG_EXTERN) ||
       fn->hasFlag(FLAG_DEFAULT_CONSTRUCTOR) ||
-      fn->hasFlag(FLAG_TUPLE) ||
+      fn->hasFlag(FLAG_INIT_TUPLE) ||
       fn->hasFlag(FLAG_TYPE_CONSTRUCTOR) ||
       fn->hasFlag(FLAG_AUTO_II))
     return; // No.

--- a/compiler/passes/checkResolved.cpp
+++ b/compiler/passes/checkResolved.cpp
@@ -396,6 +396,7 @@ checkReturnPaths(FnSymbol* fn) {
       fn->retTag == RET_TYPE ||
       fn->hasFlag(FLAG_EXTERN) ||
       fn->hasFlag(FLAG_DEFAULT_CONSTRUCTOR) ||
+      fn->hasFlag(FLAG_TUPLE) ||
       fn->hasFlag(FLAG_TYPE_CONSTRUCTOR) ||
       fn->hasFlag(FLAG_AUTO_II))
     return; // No.

--- a/compiler/resolution/ResolutionCandidate.cpp
+++ b/compiler/resolution/ResolutionCandidate.cpp
@@ -239,7 +239,7 @@ bool ResolutionCandidate::computeAlignment(CallInfo& info) {
       // Fail if there are too many unnamed actuals.
       if (match == false &&
           (fn->hasFlag(FLAG_GENERIC) == false ||
-           fn->hasFlag(FLAG_TUPLE)   == false)) {
+           fn->hasFlag(FLAG_INIT_TUPLE)   == false)) {
         return false;
       }
     }

--- a/compiler/resolution/ResolutionCandidate.cpp
+++ b/compiler/resolution/ResolutionCandidate.cpp
@@ -19,6 +19,7 @@
 
 #include "ResolutionCandidate.h"
 
+#include "astutil.h"
 #include "caches.h"
 #include "callInfo.h"
 #include "driver.h"
@@ -237,10 +238,13 @@ bool ResolutionCandidate::computeAlignment(CallInfo& info) {
       }
 
       // Fail if there are too many unnamed actuals.
-      if (match == false &&
-          (fn->hasFlag(FLAG_GENERIC) == false ||
-           fn->hasFlag(FLAG_INIT_TUPLE)   == false)) {
-        return false;
+      if (match == false) {
+        if (fn->hasFlag(FLAG_GENERIC) == false) {
+          return false;
+        } else if (fn->hasFlag(FLAG_INIT_TUPLE) == false &&
+                   isTupleTypeConstructor(fn)   == false) {
+          return false;
+        }
       }
     }
   }

--- a/compiler/resolution/cullOverReferences.cpp
+++ b/compiler/resolution/cullOverReferences.cpp
@@ -1639,8 +1639,7 @@ static void lateConstCheck(std::map<BaseAST*, BaseAST*> & reasonNotConst)
 
         // For now, ignore errors with tuple construction/build_tuple
         if (calledFn->hasFlag(FLAG_BUILD_TUPLE) ||
-            (calledFn->hasFlag(FLAG_CONSTRUCTOR) &&
-             calledFn->retType->symbol->hasFlag(FLAG_TUPLE))) {
+            calledFn->hasFlag(FLAG_TUPLE)) {
           error = false;
         }
 

--- a/compiler/resolution/cullOverReferences.cpp
+++ b/compiler/resolution/cullOverReferences.cpp
@@ -1639,7 +1639,7 @@ static void lateConstCheck(std::map<BaseAST*, BaseAST*> & reasonNotConst)
 
         // For now, ignore errors with tuple construction/build_tuple
         if (calledFn->hasFlag(FLAG_BUILD_TUPLE) ||
-            calledFn->hasFlag(FLAG_TUPLE)) {
+            calledFn->hasFlag(FLAG_INIT_TUPLE)) {
           error = false;
         }
 

--- a/compiler/resolution/expandVarArgs.cpp
+++ b/compiler/resolution/expandVarArgs.cpp
@@ -499,11 +499,11 @@ static CallExpr* expandVarArgString(FnSymbol*      fn,
 
   if (formal->hasFlag(FLAG_TYPE_VARIABLE) == true) {
     retval = new CallExpr("_type_construct__tuple");
-  } else {
-    retval = new CallExpr("_construct__tuple");
-  }
 
-  retval->insertAtTail(new_IntSymbol(n));
+    retval->insertAtTail(new_IntSymbol(n));
+  } else {
+    retval = new CallExpr("_build_tuple");
+  }
 
   // Create a local for every blank string
   for (int i = 0; i < n; i++) {
@@ -552,7 +552,7 @@ static CallExpr* buildTupleCall(ArgSymbol* formal, const Formals& formals) {
   if (formal->hasFlag(FLAG_TYPE_VARIABLE) == true) {
     retval = new CallExpr("_type_construct__tuple");
   } else {
-    retval = new CallExpr("_construct__tuple");
+    retval = new CallExpr(tupleInitName);
   }
 
   retval->insertAtTail(new_IntSymbol(n));

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -390,7 +390,7 @@ FnSymbol* getUnalias(Type* t) {
 bool doNotChangeTupleTypeRefLevel(FnSymbol* fn, bool forRet) {
   if (fn->hasFlag(FLAG_TYPE_CONSTRUCTOR)         || // _type_construct__tuple
       fn->hasFlag(FLAG_CONSTRUCTOR)              || // any constructor
-      fn->hasFlag(FLAG_TUPLE)                    || // chpl__init_tuple
+      fn->hasFlag(FLAG_INIT_TUPLE)               || // chpl__init_tuple
       fn->hasFlag(FLAG_BUILD_TUPLE)              || // _build_tuple(_allow_ref)
       fn->hasFlag(FLAG_BUILD_TUPLE_TYPE)         || // _build_tuple_type
       fn->hasFlag(FLAG_TUPLE_CAST_FN)            || // _cast for tuples

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -384,7 +384,7 @@ FnSymbol* getUnalias(Type* t) {
 // where tuples containing refs can be returned.
 bool doNotChangeTupleTypeRefLevel(FnSymbol* fn, bool forRet) {
   if (fn->hasFlag(FLAG_TYPE_CONSTRUCTOR)         || // _type_construct__tuple
-      fn->hasFlag(FLAG_CONSTRUCTOR)              || // _construct__tuple
+      fn->hasFlag(FLAG_TUPLE)                    || // chpl__init_tuple
       fn->hasFlag(FLAG_BUILD_TUPLE)              || // _build_tuple(_allow_ref)
       fn->hasFlag(FLAG_BUILD_TUPLE_TYPE)         || // _build_tuple_type
       fn->hasFlag(FLAG_TUPLE_CAST_FN)            || // _cast for tuples

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -382,8 +382,14 @@ FnSymbol* getUnalias(Type* t) {
 // to tuples without refs before returning.
 // This function returns true for exceptional FnSymbols
 // where tuples containing refs can be returned.
+//
+// The 'FLAG_CONSTRUCTOR' case can prevent additional copies/leaks in the case
+// that a class/field has a tuple field. See the following test:
+//     types/records/ferguson/tuples/class-tuple-record
+//
 bool doNotChangeTupleTypeRefLevel(FnSymbol* fn, bool forRet) {
   if (fn->hasFlag(FLAG_TYPE_CONSTRUCTOR)         || // _type_construct__tuple
+      fn->hasFlag(FLAG_CONSTRUCTOR)              || // any constructor
       fn->hasFlag(FLAG_TUPLE)                    || // chpl__init_tuple
       fn->hasFlag(FLAG_BUILD_TUPLE)              || // _build_tuple(_allow_ref)
       fn->hasFlag(FLAG_BUILD_TUPLE_TYPE)         || // _build_tuple_type

--- a/compiler/resolution/generics.cpp
+++ b/compiler/resolution/generics.cpp
@@ -77,7 +77,7 @@ explainInstantiation(FnSymbol* fn) {
         else
           len += sprintf(msg+len, ", ");
         INT_ASSERT(arg);
-        if (strcmp(fn->name, "_construct__tuple"))
+        if (strcmp(fn->name, tupleInitName))
           len += sprintf(msg+len, "%s = ", arg->name);
         if (VarSymbol* vs = toVarSymbol(e->value)) {
           if (vs->immediate && vs->immediate->const_kind == NUM_KIND_INT)

--- a/compiler/resolution/generics.cpp
+++ b/compiler/resolution/generics.cpp
@@ -438,7 +438,8 @@ FnSymbol* instantiateSignature(FnSymbol*  fn,
   // (_build_tuple, tuple type constructor, tuple default constructor)
   //
 
-  if (fn->hasFlag(FLAG_INIT_TUPLE)            == true ||
+  if (fn->hasFlag(FLAG_INIT_TUPLE)       == true ||
+      isTupleTypeConstructor(fn)         == true ||
       fn->hasFlag(FLAG_BUILD_TUPLE_TYPE) == true) {
     retval = createTupleSignature(fn, subs, call);
 

--- a/compiler/resolution/generics.cpp
+++ b/compiler/resolution/generics.cpp
@@ -438,7 +438,7 @@ FnSymbol* instantiateSignature(FnSymbol*  fn,
   // (_build_tuple, tuple type constructor, tuple default constructor)
   //
 
-  if (fn->hasFlag(FLAG_TUPLE)            == true ||
+  if (fn->hasFlag(FLAG_INIT_TUPLE)            == true ||
       fn->hasFlag(FLAG_BUILD_TUPLE_TYPE) == true) {
     retval = createTupleSignature(fn, subs, call);
 

--- a/compiler/resolution/initializerResolution.cpp
+++ b/compiler/resolution/initializerResolution.cpp
@@ -442,7 +442,7 @@ static void makeActualsVector(const CallInfo&          info,
       }
 
       // Fail if there are too many unnamed actuals.
-      if (!match && !(fn->hasFlag(FLAG_GENERIC) && fn->hasFlag(FLAG_TUPLE))) {
+      if (!match && !(fn->hasFlag(FLAG_GENERIC) && fn->hasFlag(FLAG_INIT_TUPLE))) {
         INT_FATAL(call,
                   "Compilation should have verified this action was valid");
       }

--- a/compiler/resolution/lowerIterators.cpp
+++ b/compiler/resolution/lowerIterators.cpp
@@ -65,10 +65,8 @@ FnSymbol* getTheIteratorFn(Type* icType)
   INT_ASSERT(icTypeAgg);
 
   if (icType->symbol->hasFlag(FLAG_TUPLE)) {
-    FnSymbol* getIterFn = icTypeAgg->defaultInitializer;
-    // A tuple of iterator classes -> first argument to
-    // tuple constructor is the iterator class type.
-    Type* firstIcType = getIterFn->getFormal(1)->type;
+    // A tuple of iterator classes -> first field is the iterator class
+    Type* firstIcType = icTypeAgg->getField(1)->type;
     INT_ASSERT(firstIcType->symbol->hasFlag(FLAG_ITERATOR_CLASS));
     AggregateType* firstIcTypeAgg = toAggregateType(firstIcType);
     FnSymbol* result = firstIcTypeAgg->iteratorInfo->getIterator;

--- a/compiler/resolution/tuples.cpp
+++ b/compiler/resolution/tuples.cpp
@@ -958,7 +958,8 @@ FnSymbol* createTupleSignature(FnSymbol* fn, SymbolMap& subs, CallExpr* call) {
   bool      noChangeTypes  = fn->hasFlag(FLAG_BUILD_TUPLE_TYPE) == true ||
                              fn->retTag                         == RET_TYPE;
 
-  bool      firstArgIsSize = fn->hasFlag(FLAG_INIT_TUPLE)            == true ||
+  bool      firstArgIsSize = fn->hasFlag(FLAG_INIT_TUPLE)       == true ||
+                             isTupleTypeConstructor(fn)         == true ||
                              fn->hasFlag(FLAG_STAR_TUPLE)       == true;
 
 

--- a/compiler/resolution/tuples.cpp
+++ b/compiler/resolution/tuples.cpp
@@ -259,7 +259,7 @@ FnSymbol* makeConstructTuple(std::vector<TypeSymbol*>& args,
   ctor->addFlag(FLAG_LAST_RESORT);
   ctor->addFlag(FLAG_INLINE);
   ctor->addFlag(FLAG_INVISIBLE_FN);
-  ctor->addFlag(FLAG_TUPLE);
+  ctor->addFlag(FLAG_INIT_TUPLE);
 
   ctor->addFlag(FLAG_PARTIAL_TUPLE);
 
@@ -958,7 +958,7 @@ FnSymbol* createTupleSignature(FnSymbol* fn, SymbolMap& subs, CallExpr* call) {
   bool      noChangeTypes  = fn->hasFlag(FLAG_BUILD_TUPLE_TYPE) == true ||
                              fn->retTag                         == RET_TYPE;
 
-  bool      firstArgIsSize = fn->hasFlag(FLAG_TUPLE)            == true ||
+  bool      firstArgIsSize = fn->hasFlag(FLAG_INIT_TUPLE)            == true ||
                              fn->hasFlag(FLAG_STAR_TUPLE)       == true;
 
 
@@ -1039,7 +1039,7 @@ FnSymbol* createTupleSignature(FnSymbol* fn, SymbolMap& subs, CallExpr* call) {
 
     retval = at->typeConstructor;
 
-  } else if (fn->hasFlag(FLAG_TUPLE) == true) {
+  } else if (fn->hasFlag(FLAG_INIT_TUPLE) == true) {
     retval = info.init;
 
   } else if (fn->hasFlag(FLAG_BUILD_TUPLE_TYPE)    == true) {

--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -947,7 +947,6 @@ static void updateWrapCall(FnSymbol*  fn,
 
   if (fn->hasFlag(FLAG_DEFAULT_CONSTRUCTOR)      == true  &&
       fn->_this->type->symbol->hasFlag(FLAG_REF) == false &&
-      strcmp(fn->name, "_construct__tuple")      != 0     &&
       formal->hasFlag(FLAG_TYPE_VARIABLE)        == false &&
       paramMap->get(formal)                      == NULL  &&
       formal->type                               != dtMethodToken) {
@@ -1026,8 +1025,7 @@ static void formalIsDefaulted(FnSymbol*  fn,
   // In the future, it would probably be better to initialize the
   // fields in order in favor of calling the default constructor.
   if (fn->hasFlag(FLAG_DEFAULT_CONSTRUCTOR)      == true  &&
-      fn->_this->type->symbol->hasFlag(FLAG_REF) == false &&
-      strcmp(fn->name, "_construct__tuple")      != 0) {
+      fn->_this->type->symbol->hasFlag(FLAG_REF) == false) {
     if (formal->hasFlag(FLAG_TYPE_VARIABLE) == false) {
       AggregateType* type = toAggregateType(wrapFn->_this->type);
 

--- a/modules/internal/ChapelTuple.chpl
+++ b/modules/internal/ChapelTuple.chpl
@@ -44,6 +44,11 @@ module ChapelTuple {
     param size : int;
   }
 
+  pragma "tuple"
+  inline proc chpl__init_tuple(param size : int) {
+    // body inserted during generic instantiation
+  }
+
   //
   // syntactic support for tuples
   //

--- a/modules/internal/ChapelTuple.chpl
+++ b/modules/internal/ChapelTuple.chpl
@@ -44,7 +44,7 @@ module ChapelTuple {
     param size : int;
   }
 
-  pragma "tuple"
+  pragma "tuple init fn"
   inline proc chpl__init_tuple(param size : int) {
     // body inserted during generic instantiation
   }


### PR DESCRIPTION
We aim to eventually deprecate constructors, so this commit updates
tuples to use a special function instead of a constructor. Tuples are
sufficiently special that I don't think it makes sense to use an
initializer just yet.

This special function is named 'chpl__init_tuple', and is generated by
the compiler in the same way the old constructor was generated. Various
conditionals in the compiler have been updated to look for FLAG_TUPLE
instead of a function name.

Testing:
- [x] local + futures
- [x] gasnet
- [x] --verify on release/examples/ and types/tuples/
- [x] --baseline on release/examples/ and types/tuples/
- [x] 16-node-xc miniMD performance (uses tuples)