### PR TITLE
Fix a typo/think-o in primers.

### DIFF
--- a/test/release/examples/primers/iterators.chpl
+++ b/test/release/examples/primers/iterators.chpl
@@ -169,7 +169,7 @@ proc Tree.writeThis(x)
 {
   var first = true;
 
-  for node in postorder(tree) {
+  for node in postorder(this) {
     if first then
       first = false;
     else


### PR DESCRIPTION
Replaced an unintended reference to a global variable with 'this'.

// This function with this glitch was introduced back in 0dcb0c3504f.