### PR TITLE
Adjust LLVM test skipifs

### DIFF
--- a/test/compflags/kushal/llvm-incremental.compopts
+++ b/test/compflags/kushal/llvm-incremental.compopts
@@ -1,1 +1,1 @@
---incremental
+--llvm --incremental

--- a/test/extern/ferguson/externblock/struct-fn.skipif
+++ b/test/extern/ferguson/externblock/struct-fn.skipif
@@ -1,2 +1,1 @@
-CHPL_LLVM==none
 COMPOPTS <= --baseline

--- a/test/llvm/function-args/SKIPIF
+++ b/test/llvm/function-args/SKIPIF
@@ -1,1 +1,2 @@
 CHPL_LLVM==none
+COMPOPTS <= --no-local

--- a/test/llvm/generate-nsw-for-signed/SKIPIF
+++ b/test/llvm/generate-nsw-for-signed/SKIPIF
@@ -1,1 +1,2 @@
 CHPL_LLVM==none
+COMPOPTS <= --baseline

--- a/test/llvm/tbaa/SKIPIF
+++ b/test/llvm/tbaa/SKIPIF
@@ -1,1 +1,3 @@
 CHPL_LLVM==none
+COMPOPTS <= --baseline
+COMPOPTS <= --no-local

--- a/test/users/npadmana/bugs/extern_struct_function_pointer/test_extern_struct_function_pointer.skipif
+++ b/test/users/npadmana/bugs/extern_struct_function_pointer/test_extern_struct_function_pointer.skipif
@@ -1,2 +1,1 @@
-CHPL_LLVM==none
 COMPOPTS <= --baseline

--- a/test/users/npadmana/gsl_demonstration/SKIPIF
+++ b/test/users/npadmana/gsl_demonstration/SKIPIF
@@ -16,6 +16,8 @@ from os import environ
 
 if environ['CHPL_LLVM'] == 'none':
   print (True) # Skip if we don't have extern block support
+elif '--baseline' in environ['COMPOPTS']:
+  print (True) # Skip for --baseline
 else:
   # OK, we have extern block support.
   if 'GSL_DIR' in environ:


### PR DESCRIPTION
To get clean testing with CHPL_LLVM=llvm
without --llvm and possibly with --no-local or --baseline.

Test changes only, not reviewed.