### PR TITLE
arithmetic operations on Series ADT

### DIFF
--- a/test/library/standard/Dataframes/Dataframes.chpl
+++ b/test/library/standard/Dataframes/Dataframes.chpl
@@ -117,7 +117,7 @@ module Dataframes {
 
     // TODO: verify |idx| = data.size
     // TODO: verify that data is rectangular domain(1)
-    proc init(rev_idx: [], data: [] ?T) {
+    proc init(data: [] ?T, rev_idx: []) {
       super.init();
       eltType = T;
 
@@ -208,10 +208,9 @@ module Dataframes {
         }
       }
 
-      return new TypedSeries(sum_rev_idx[1..curr_ord], sum_data[1..curr_ord]);
+      return new TypedSeries(sum_data[1..curr_ord], sum_rev_idx[1..curr_ord]);
     }
 
-    // TODO: unmatched items in other should be negative
     proc subtr(other: TypedSeries(eltType)): TypedSeries(eltType)
                                              where isNumericType(eltType) {
       // TODO: check if the index types are the same, throw if not
@@ -266,7 +265,7 @@ module Dataframes {
         }
       }
 
-      return new TypedSeries(diff_rev_idx[1..curr_ord], diff_data[1..curr_ord]);
+      return new TypedSeries(diff_data[1..curr_ord], diff_rev_idx[1..curr_ord]);
     }
 
     // TODO: unmatched items should be 0
@@ -324,7 +323,7 @@ module Dataframes {
         }
       }
 
-      return new TypedSeries(prod_rev_idx[1..curr_ord], prod_data[1..curr_ord]);
+      return new TypedSeries(prod_data[1..curr_ord], prod_rev_idx[1..curr_ord]);
     }
 
     proc writeThis(f) {

--- a/test/library/standard/Dataframes/Dataframes.chpl
+++ b/test/library/standard/Dataframes/Dataframes.chpl
@@ -242,6 +242,7 @@ module Dataframes {
     }
   }
 
+  // TODO: return tuple versions where first element is "None"
   class SeriesJoiner {
     type eltType;
 

--- a/test/library/standard/Dataframes/Dataframes.chpl
+++ b/test/library/standard/Dataframes/Dataframes.chpl
@@ -176,7 +176,7 @@ module Dataframes {
         for (i, d) in other.items() {
           var sum_d = d;
           if i <= this.ords.size then
-            sum_d += other.at(i);
+            sum_d += this.at(i);
           sum_data[i] = sum_d;
         }
         return new TypedSeries(sum_data);
@@ -211,61 +211,120 @@ module Dataframes {
       return new TypedSeries(sum_rev_idx[1..curr_ord], sum_data[1..curr_ord]);
     }
 
+    // TODO: unmatched items in other should be negative
     proc subtr(other: TypedSeries(eltType)): TypedSeries(eltType)
                                              where isNumericType(eltType) {
       // TODO: check if the index types are the same, throw if not
       if this.ords.size >= other.ords.size {
-        var sum_ords = 1..this.ords.size;
-        var sum_data: [sum_ords] eltType;
+        var diff_ords = 1..this.ords.size;
+        var diff_data: [diff_ords] eltType;
 
         for (i, d) in this.items() {
-          var sum_d = d;
+          var diff_d = d;
           if i <= other.ords.size then
-            sum_d -= other.at(i);
-          sum_data[i] = sum_d;
+            diff_d -= other.at(i);
+          diff_data[i] = diff_d;
         }
-        return new TypedSeries(sum_data);
+        return new TypedSeries(diff_data);
       } else {
-        var sum_ords = 1..other.ords.size;
-        var sum_data: [sum_ords] eltType;
+        var diff_ords = 1..other.ords.size;
+        var diff_data: [diff_ords] eltType;
 
         for (i, d) in other.items() {
-          var sum_d = d;
+          var diff_d = -d;
           if i <= this.ords.size then
-            sum_d -= other.at(i);
-          sum_data[i] = sum_d;
+            diff_d += this.at(i);
+          diff_data[i] = diff_d;
         }
-        return new TypedSeries(sum_data);
+        return new TypedSeries(diff_data);
       }
     }
 
     proc subtr(other: TypedSeries(eltType), type idxType): TypedSeries(eltType)
                                                            where isNumericType(eltType) {
       // TODO: check if the index types are the same, throw if not
-      var sum_ords = 1..(this.ords.size + other.ords.size);
-      var sum_rev_idx: [sum_ords] idxType;
-      var sum_data: [sum_ords] eltType;
+      var diff_ords = 1..(this.ords.size + other.ords.size);
+      var diff_rev_idx: [diff_ords] idxType;
+      var diff_data: [diff_ords] eltType;
 
       var curr_ord = 0;
       for (i, d) in this.items(idxType) {
-        var sum_d = d;
+        var diff_d = d;
         if other.indexContains(i) then
-          sum_d -= other[i];
+          diff_d -= other[i];
 
         curr_ord += 1;
-        sum_rev_idx[curr_ord] = i;
-        sum_data[curr_ord] = sum_d;
+        diff_rev_idx[curr_ord] = i;
+        diff_data[curr_ord] = diff_d;
       }
 
       for (other_i, other_d) in other.items(idxType) {
         if !this.indexContains(other_i) {
           curr_ord += 1;
-          sum_rev_idx[curr_ord] = other_i;
-          sum_data[curr_ord] = other_d;
+          diff_rev_idx[curr_ord] = other_i;
+          diff_data[curr_ord] = -other_d;
         }
       }
 
-      return new TypedSeries(sum_rev_idx[1..curr_ord], sum_data[1..curr_ord]);
+      return new TypedSeries(diff_rev_idx[1..curr_ord], diff_data[1..curr_ord]);
+    }
+
+    // TODO: unmatched items should be 0
+    proc mult(other: TypedSeries(eltType)): TypedSeries(eltType)
+                                            where isNumericType(eltType) {
+      // TODO: check if the index types are the same, throw if not
+      if this.ords.size >= other.ords.size {
+        var prod_ords = 1..this.ords.size;
+        var prod_data: [prod_ords] eltType;
+
+        for (i, d) in this.items() {
+          var prod_d = 0;
+          if i <= other.ords.size then
+            prod_d = d * other.at(i);
+          prod_data[i] = prod_d;
+        }
+        return new TypedSeries(prod_data);
+      } else {
+        var prod_ords = 1..other.ords.size;
+        var prod_data: [prod_ords] eltType;
+
+        for (i, d) in other.items() {
+          var prod_d = 0;
+          if i <= this.ords.size then
+            prod_d = d * this.at(i);
+          prod_data[i] = prod_d;
+        }
+        return new TypedSeries(prod_data);
+      }
+    }
+
+    proc mult(other: TypedSeries(eltType), type idxType): TypedSeries(eltType)
+                                                          where isNumericType(eltType) {
+      // TODO: check if the index types are the same, throw if not
+      var prod_ords = 1..(this.ords.size + other.ords.size);
+      var prod_rev_idx: [prod_ords] idxType;
+      var prod_data: [prod_ords] eltType;
+
+      var curr_ord = 0;
+      for (i, d) in this.items(idxType) {
+        var prod_d = 0;
+        if other.indexContains(i) then
+          prod_d = d * other[i];
+
+        curr_ord += 1;
+        prod_rev_idx[curr_ord] = i;
+        prod_data[curr_ord] = prod_d;
+      }
+
+      for (other_i, _) in other.items(idxType) {
+        if !this.indexContains(other_i) {
+          curr_ord += 1;
+          prod_rev_idx[curr_ord] = other_i;
+          prod_data[curr_ord] = 0;
+        }
+      }
+
+      return new TypedSeries(prod_rev_idx[1..curr_ord], prod_data[1..curr_ord]);
     }
 
     proc writeThis(f) {

--- a/test/library/standard/Dataframes/Dataframes.chpl
+++ b/test/library/standard/Dataframes/Dataframes.chpl
@@ -114,13 +114,12 @@ module Dataframes {
       this.data = data;
     }
 
-    // TODO: verify |idx| = data.size
     // TODO: verify that data is rectangular domain(1)
-    proc init(data: [] ?T, rev_idx: []) {
+    proc init(data: [] ?T, idx: Index) {
       super.init();
       eltType = T;
 
-      this.idx = new TypedIndex(rev_idx);
+      this.idx = idx;
       this.ords = 1..data.size;
       this.data = data;
     }
@@ -200,7 +199,7 @@ module Dataframes {
       }
 
       delete joiner;
-      return new TypedSeries(join_data[1..curr_ord], join_rev_idx[1..curr_ord]);
+      return new TypedSeries(join_data[1..curr_ord], new TypedIndex(join_rev_idx[1..curr_ord]));
     }
 
     proc add(other: TypedSeries(eltType)): TypedSeries(eltType) {

--- a/test/library/standard/Dataframes/Dataframes.chpl
+++ b/test/library/standard/Dataframes/Dataframes.chpl
@@ -21,6 +21,11 @@ module Dataframes {
   use Sort;
 
   class Index {
+    proc contains(lab) {
+      halt("generic Index contains no elements");
+      return false;
+    }
+
     proc writeThis(f, s: TypedSeries(?) = nil) {
       halt("cannot writeThis on generic Index");
     }
@@ -71,7 +76,7 @@ module Dataframes {
     }
 
     proc contains(lab: idxType) {
-      return {lab}.isSubset(labels);
+      return labels.member(lab);
     }
 
     proc writeThis(f, s: TypedSeries(?) = nil) {
@@ -90,12 +95,6 @@ module Dataframes {
   }
 
   class Series {
-    // TODO: overload + on a class for dynamic dispatch?
-    /*
-    proc +(ref lhs: Series, ref rhs: Series) {
-      return lhs.add(rhs);
-    }
-     */
   }
 
   class TypedSeries : Series {
@@ -151,10 +150,7 @@ module Dataframes {
       return data[(idx:TypedIndex(idxType))[lab]];
     }
 
-    // TODO: "in" operator
-    proc indexContains(lab: ?idxType) {
-      return (idx:TypedIndex(idxType)).contains(lab);
-    }
+    // TODO: "in" operator for idx.contains(lab)
 
     proc add(other: TypedSeries(eltType)): TypedSeries(eltType) {
       // TODO: check if the index types are the same, throw if not
@@ -192,7 +188,7 @@ module Dataframes {
       var curr_ord = 0;
       for (i, d) in this.items(idxType) {
         var sum_d = d;
-        if other.indexContains(i) then
+        if other.idx.contains(i) then
           sum_d += other[i];
 
         curr_ord += 1;
@@ -201,7 +197,7 @@ module Dataframes {
       }
 
       for (other_i, other_d) in other.items(idxType) {
-        if !this.indexContains(other_i) {
+        if !this.idx.contains(other_i) {
           curr_ord += 1;
           sum_rev_idx[curr_ord] = other_i;
           sum_data[curr_ord] = other_d;
@@ -249,7 +245,7 @@ module Dataframes {
       var curr_ord = 0;
       for (i, d) in this.items(idxType) {
         var diff_d = d;
-        if other.indexContains(i) then
+        if other.idx.contains(i) then
           diff_d -= other[i];
 
         curr_ord += 1;
@@ -258,7 +254,7 @@ module Dataframes {
       }
 
       for (other_i, other_d) in other.items(idxType) {
-        if !this.indexContains(other_i) {
+        if !this.idx.contains(other_i) {
           curr_ord += 1;
           diff_rev_idx[curr_ord] = other_i;
           diff_data[curr_ord] = -other_d;
@@ -307,7 +303,7 @@ module Dataframes {
       var curr_ord = 0;
       for (i, d) in this.items(idxType) {
         var prod_d = 0;
-        if other.indexContains(i) then
+        if other.idx.contains(i) then
           prod_d = d * other[i];
 
         curr_ord += 1;
@@ -316,7 +312,7 @@ module Dataframes {
       }
 
       for (other_i, _) in other.items(idxType) {
-        if !this.indexContains(other_i) {
+        if !this.idx.contains(other_i) {
           curr_ord += 1;
           prod_rev_idx[curr_ord] = other_i;
           prod_data[curr_ord] = 0;
@@ -336,4 +332,11 @@ module Dataframes {
       f <~> "dtype: " + eltType:string;
     }
   }
+
+  // TODO: overload + on a class for dynamic dispatch?
+  /*
+  proc +(ref lhs: TypedSeries(?T), ref rhs: TypedSeries(T)) {
+    return lhs.add(rhs);
+  }
+   */
 }

--- a/test/library/standard/Dataframes/psahabu/AccessSeries.chpl
+++ b/test/library/standard/Dataframes/psahabu/AccessSeries.chpl
@@ -1,9 +1,9 @@
 use Dataframes;
 
-var I = ["A", "B", "C", "D", "E"];
 var A = ["a", "b", "c", "d", "e"];
+var I = ["A", "B", "C", "D", "E"];
 
-var letters: TypedSeries(string) = new TypedSeries(I, A);
+var letters: TypedSeries(string) = new TypedSeries(A, I);
 
 writeln("A: " + letters["A"]);
 writeln("C: " + letters["C"]);

--- a/test/library/standard/Dataframes/psahabu/AccessSeries.chpl
+++ b/test/library/standard/Dataframes/psahabu/AccessSeries.chpl
@@ -3,7 +3,7 @@ use Dataframes;
 var A = ["a", "b", "c", "d", "e"];
 var I = ["A", "B", "C", "D", "E"];
 
-var letters: TypedSeries(string) = new TypedSeries(A, I);
+var letters: TypedSeries(string) = new TypedSeries(A, new TypedIndex(I));
 
 writeln("A: " + letters["A"]);
 writeln("C: " + letters["C"]);

--- a/test/library/standard/Dataframes/psahabu/AddSeries.chpl
+++ b/test/library/standard/Dataframes/psahabu/AddSeries.chpl
@@ -2,8 +2,8 @@ use Dataframes;
 
 var I = ["A", "B", "C", "D", "E"];
 
-var oneDigit: TypedSeries(int) = new TypedSeries(I, [1, 2, 3, 4, 5]);
-var twoDigit: TypedSeries(int) = new TypedSeries(I, [10, 20, 30, 40, 50]);
+var oneDigit: TypedSeries(int) = new TypedSeries([1, 2, 3, 4, 5], I);
+var twoDigit: TypedSeries(int) = new TypedSeries([10, 20, 30, 40, 50], I);
 var doubledDigit = oneDigit.add(twoDigit, string);
 
 writeln("addends:");
@@ -15,8 +15,8 @@ writeln(doubledDigit);
 
 var I2 = ["A", "B", "C"];
 var I3 = ["B", "C", "D", "E"];
-var X: TypedSeries(int) = new TypedSeries(I2, [0, 1, 2]);
-var Y: TypedSeries(int) = new TypedSeries(I3, [10, 20, 0, 0]);
+var X: TypedSeries(int) = new TypedSeries([0, 1, 2], I2);
+var Y: TypedSeries(int) = new TypedSeries([10, 20, 0, 0], I3);
 var XY = X.add(Y, string);
 
 writeln("\naddends:");

--- a/test/library/standard/Dataframes/psahabu/AddSeries.chpl
+++ b/test/library/standard/Dataframes/psahabu/AddSeries.chpl
@@ -2,37 +2,32 @@ use Dataframes;
 
 var I = new TypedIndex(["A", "B", "C", "D", "E"]);
 
-var oneDigit: TypedSeries(int) = new TypedSeries([1, 2, 3, 4, 5], I);
-var twoDigit: TypedSeries(int) = new TypedSeries([10, 20, 30, 40, 50], I);
-var doubledDigit = oneDigit.add(twoDigit, string);
+var oneDigit = new TypedSeries([1, 2, 3, 4, 5], I);
+var twoDigit = new TypedSeries([10, 20, 30, 40, 50], I);
 
 writeln("addends:");
 writeln(oneDigit);
 writeln(twoDigit);
 
 writeln("\nsum:");
-writeln(doubledDigit);
+writeln(oneDigit + twoDigit);
 
-var I2 = new TypedIndex(["A", "B", "C"]);
-var I3 = new TypedIndex(["B", "C", "D", "E"]);
-var X: TypedSeries(int) = new TypedSeries([0, 1, 2], I2);
-var Y: TypedSeries(int) = new TypedSeries([10, 20, 0, 0], I3);
-var XY = X.add(Y, string);
+var X = new TypedSeries([0, 1, 2], new TypedIndex(["A", "B", "C"]));
+var Y = new TypedSeries([10, 20, 0, 0], new TypedIndex(["B", "C", "D", "E"]));
 
 writeln("\naddends:");
 writeln(X);
 writeln(Y);
 
 writeln("\nsum:");
-writeln(XY);
+writeln(X + Y);
 
-var A: TypedSeries(string) = new TypedSeries(["hello ", "my ", "name", "is", "brad"]);
-var B: TypedSeries(string) = new TypedSeries(["world", "real"]);
-var AB = A.add(B);
+var A = new TypedSeries(["hello ", "my ", "name", "is", "brad"]);
+var B = new TypedSeries(["world", "real"]);
 
 writeln("\naddends:");
 writeln(A);
 writeln(B);
 
 writeln("\nsum:");
-writeln(AB);
+writeln(A + B);

--- a/test/library/standard/Dataframes/psahabu/AddSeries.chpl
+++ b/test/library/standard/Dataframes/psahabu/AddSeries.chpl
@@ -1,0 +1,38 @@
+use Dataframes;
+
+var I = ["A", "B", "C", "D", "E"];
+
+var oneDigit: TypedSeries(int) = new TypedSeries(I, [1, 2, 3, 4, 5]);
+var twoDigit: TypedSeries(int) = new TypedSeries(I, [10, 20, 30, 40, 50]);
+var doubledDigit = oneDigit.add(twoDigit, string);
+
+writeln("addends:");
+writeln(oneDigit);
+writeln(twoDigit);
+
+writeln("\nsum:");
+writeln(doubledDigit);
+
+var I2 = ["A", "B", "C"];
+var I3 = ["B", "C", "D", "E"];
+var X: TypedSeries(int) = new TypedSeries(I2, [0, 1, 2]);
+var Y: TypedSeries(int) = new TypedSeries(I3, [10, 20, 0, 0]);
+var XY = X.add(Y, string);
+
+writeln("\naddends:");
+writeln(X);
+writeln(Y);
+
+writeln("\nsum:");
+writeln(XY);
+
+var A: TypedSeries(string) = new TypedSeries(["hello ", "my ", "name", "is", "brad"]);
+var B: TypedSeries(string) = new TypedSeries(["world", "real"]);
+var AB = A.add(B);
+
+writeln("\naddends:");
+writeln(A);
+writeln(B);
+
+writeln("\nsum:");
+writeln(AB);

--- a/test/library/standard/Dataframes/psahabu/AddSeries.chpl
+++ b/test/library/standard/Dataframes/psahabu/AddSeries.chpl
@@ -1,6 +1,6 @@
 use Dataframes;
 
-var I = ["A", "B", "C", "D", "E"];
+var I = new TypedIndex(["A", "B", "C", "D", "E"]);
 
 var oneDigit: TypedSeries(int) = new TypedSeries([1, 2, 3, 4, 5], I);
 var twoDigit: TypedSeries(int) = new TypedSeries([10, 20, 30, 40, 50], I);
@@ -13,8 +13,8 @@ writeln(twoDigit);
 writeln("\nsum:");
 writeln(doubledDigit);
 
-var I2 = ["A", "B", "C"];
-var I3 = ["B", "C", "D", "E"];
+var I2 = new TypedIndex(["A", "B", "C"]);
+var I3 = new TypedIndex(["B", "C", "D", "E"]);
 var X: TypedSeries(int) = new TypedSeries([0, 1, 2], I2);
 var Y: TypedSeries(int) = new TypedSeries([10, 20, 0, 0], I3);
 var XY = X.add(Y, string);

--- a/test/library/standard/Dataframes/psahabu/AddSeries.good
+++ b/test/library/standard/Dataframes/psahabu/AddSeries.good
@@ -1,0 +1,59 @@
+addends:
+A	1
+B	2
+C	3
+D	4
+E	5
+dtype: int(64)
+A	10
+B	20
+C	30
+D	40
+E	50
+dtype: int(64)
+
+sum:
+A	11
+B	22
+C	33
+D	44
+E	55
+dtype: int(64)
+
+addends:
+A	0
+B	1
+C	2
+dtype: int(64)
+B	10
+C	20
+D	0
+E	0
+dtype: int(64)
+
+sum:
+A	0
+B	11
+C	22
+D	0
+E	0
+dtype: int(64)
+
+addends:
+1	hello 
+2	my 
+3	name
+4	is
+5	brad
+dtype: string
+1	world
+2	real
+dtype: string
+
+sum:
+1	hello world
+2	my real
+3	name
+4	is
+5	brad
+dtype: string

--- a/test/library/standard/Dataframes/psahabu/AddSeries.py
+++ b/test/library/standard/Dataframes/psahabu/AddSeries.py
@@ -1,0 +1,37 @@
+import pandas as pd
+
+I = ["A", "B", "C", "D", "E"]
+
+oneDigit = pd.Series([1, 2, 3, 4, 5], pd.Index(I))
+twoDigit = pd.Series([10, 20, 30, 40, 50], pd.Index(I))
+
+print "addends:"
+print oneDigit
+print twoDigit
+print
+print "sum:"
+print oneDigit + twoDigit
+print
+
+I2 = ["A", "B", "C"]
+I3 = ["B", "C", "D", "E"]
+X = pd.Series([0, 1, 2], pd.Index(I2))
+Y = pd.Series([10, 20, 0, 0], pd.Index(I3))
+
+print "addends:"
+print X
+print Y
+print
+print "sum:"
+print X + Y
+print
+
+A = pd.Series(["hello ", "my ", "name", "is", "brad"])
+B = pd.Series(["world", "real"])
+
+print "addends:"
+print A
+print B
+print 
+print "sum: "
+print A + B

--- a/test/library/standard/Dataframes/psahabu/ContainSeries.chpl
+++ b/test/library/standard/Dataframes/psahabu/ContainSeries.chpl
@@ -1,0 +1,9 @@
+use Dataframes;
+
+var I = ["A", "B", "C", "D", "E"];
+var A = ["a", "b", "c", "d", "e"];
+var letters: TypedSeries(string) = new TypedSeries(I, A);
+
+writeln("contains A: " + letters.indexContains("A"));
+writeln("contains F: " + letters.indexContains("F"));
+writeln(letters.idx.getType());

--- a/test/library/standard/Dataframes/psahabu/ContainSeries.chpl
+++ b/test/library/standard/Dataframes/psahabu/ContainSeries.chpl
@@ -6,5 +6,5 @@ var letters: TypedSeries(string) = new TypedSeries(A, I);
 
 writeln(letters);
 writeln();
-writeln("contains A: " + letters.indexContains("A"));
-writeln("contains F: " + letters.indexContains("F"));
+writeln("contains A: " + letters.idx.contains("A"));
+writeln("contains F: " + letters.idx.contains("F"));

--- a/test/library/standard/Dataframes/psahabu/ContainSeries.chpl
+++ b/test/library/standard/Dataframes/psahabu/ContainSeries.chpl
@@ -1,9 +1,10 @@
 use Dataframes;
 
-var I = ["A", "B", "C", "D", "E"];
 var A = ["a", "b", "c", "d", "e"];
-var letters: TypedSeries(string) = new TypedSeries(I, A);
+var I = ["A", "B", "C", "D", "E"];
+var letters: TypedSeries(string) = new TypedSeries(A, I);
 
+writeln(letters);
+writeln();
 writeln("contains A: " + letters.indexContains("A"));
 writeln("contains F: " + letters.indexContains("F"));
-writeln(letters.idx.getType());

--- a/test/library/standard/Dataframes/psahabu/ContainSeries.chpl
+++ b/test/library/standard/Dataframes/psahabu/ContainSeries.chpl
@@ -2,7 +2,7 @@ use Dataframes;
 
 var A = ["a", "b", "c", "d", "e"];
 var I = ["A", "B", "C", "D", "E"];
-var letters: TypedSeries(string) = new TypedSeries(A, I);
+var letters: TypedSeries(string) = new TypedSeries(A, new TypedIndex(I));
 
 writeln(letters);
 writeln();

--- a/test/library/standard/Dataframes/psahabu/ContainSeries.good
+++ b/test/library/standard/Dataframes/psahabu/ContainSeries.good
@@ -1,0 +1,9 @@
+A	a
+B	b
+C	c
+D	d
+E	e
+dtype: string
+
+contains A: true
+contains F: false

--- a/test/library/standard/Dataframes/psahabu/HelloSeries.chpl
+++ b/test/library/standard/Dataframes/psahabu/HelloSeries.chpl
@@ -4,7 +4,7 @@ var A = ["a", "b", "c", "d", "e"];
 var I = ["A", "B", "C", "D", "E"];
 
 var just_letters: TypedSeries(string) = new TypedSeries(A);
-var letters: TypedSeries(string) = new TypedSeries(A, I);
+var letters: TypedSeries(string) = new TypedSeries(A, new TypedIndex(I));
 
 writeln(just_letters);
 writeln(letters);

--- a/test/library/standard/Dataframes/psahabu/HelloSeries.chpl
+++ b/test/library/standard/Dataframes/psahabu/HelloSeries.chpl
@@ -1,10 +1,10 @@
 use Dataframes;
 
-var I = ["A", "B", "C", "D", "E"];
 var A = ["a", "b", "c", "d", "e"];
+var I = ["A", "B", "C", "D", "E"];
 
 var just_letters: TypedSeries(string) = new TypedSeries(A);
-var letters: TypedSeries(string) = new TypedSeries(I, A);
+var letters: TypedSeries(string) = new TypedSeries(A, I);
 
 writeln(just_letters);
 writeln(letters);

--- a/test/library/standard/Dataframes/psahabu/IterSeries.chpl
+++ b/test/library/standard/Dataframes/psahabu/IterSeries.chpl
@@ -3,7 +3,7 @@ use Dataframes;
 var A = ["a", "b", "c", "d", "e"];
 var I = ["A", "B", "C", "D", "E"];
 
-var letters: TypedSeries(string) = new TypedSeries(A, I);
+var letters: TypedSeries(string) = new TypedSeries(A, new TypedIndex(I));
 
 for i in letters.idx:TypedIndex(string) do
   writeln(i);

--- a/test/library/standard/Dataframes/psahabu/IterSeries.chpl
+++ b/test/library/standard/Dataframes/psahabu/IterSeries.chpl
@@ -1,9 +1,9 @@
 use Dataframes;
 
-var I = ["A", "B", "C", "D", "E"];
 var A = ["a", "b", "c", "d", "e"];
+var I = ["A", "B", "C", "D", "E"];
 
-var letters: TypedSeries(string) = new TypedSeries(I, A);
+var letters: TypedSeries(string) = new TypedSeries(A, I);
 
 for i in letters.idx:TypedIndex(string) do
   writeln(i);

--- a/test/library/standard/Dataframes/psahabu/MultiplySeries.chpl
+++ b/test/library/standard/Dataframes/psahabu/MultiplySeries.chpl
@@ -4,24 +4,24 @@ var I = ["A", "B", "C", "D", "E"];
 
 var oneDigit: TypedSeries(int) = new TypedSeries([1, 2, 3, 4, 5], I);
 var twoDigit: TypedSeries(int) = new TypedSeries([11, 22, 33, 44, 55], I);
-var doubledDigit = twoDigit.subtr(oneDigit, string);
+var doubledDigit = twoDigit.mult(oneDigit, string);
 
-writeln("terms:");
+writeln("factors:");
 writeln(oneDigit);
 writeln(twoDigit);
 
-writeln("\ndifference:");
+writeln("\nproduct:");
 writeln(doubledDigit);
 
 var I2 = ["A", "B", "C"];
 var I3 = ["B", "C", "D", "E"];
 var X: TypedSeries(int) = new TypedSeries([5, 1, 2], I2);
 var Y: TypedSeries(int) = new TypedSeries([10, 20, 6, 7], I3);
-var XY = Y.subtr(X, string);
+var XY = Y.mult(X, string);
 
-writeln("\nterms:");
+writeln("\nfactors:");
 writeln(Y);
 writeln(X);
 
-writeln("\ndifference:");
+writeln("\nproduct:");
 writeln(XY);

--- a/test/library/standard/Dataframes/psahabu/MultiplySeries.chpl
+++ b/test/library/standard/Dataframes/psahabu/MultiplySeries.chpl
@@ -1,6 +1,6 @@
 use Dataframes;
 
-var I = ["A", "B", "C", "D", "E"];
+var I = new TypedIndex(["A", "B", "C", "D", "E"]);
 
 var oneDigit: TypedSeries(int) = new TypedSeries([1, 2, 3, 4, 5], I);
 var twoDigit: TypedSeries(int) = new TypedSeries([11, 22, 33, 44, 55], I);
@@ -13,8 +13,8 @@ writeln(twoDigit);
 writeln("\nproduct:");
 writeln(doubledDigit);
 
-var I2 = ["A", "B", "C"];
-var I3 = ["B", "C", "D", "E"];
+var I2 = new TypedIndex(["A", "B", "C"]);
+var I3 = new TypedIndex(["B", "C", "D", "E"]);
 var X: TypedSeries(int) = new TypedSeries([5, 1, 2], I2);
 var Y: TypedSeries(int) = new TypedSeries([10, 20, 6, 7], I3);
 var XY = Y.mult(X, string);

--- a/test/library/standard/Dataframes/psahabu/MultiplySeries.chpl
+++ b/test/library/standard/Dataframes/psahabu/MultiplySeries.chpl
@@ -2,26 +2,22 @@ use Dataframes;
 
 var I = new TypedIndex(["A", "B", "C", "D", "E"]);
 
-var oneDigit: TypedSeries(int) = new TypedSeries([1, 2, 3, 4, 5], I);
-var twoDigit: TypedSeries(int) = new TypedSeries([11, 22, 33, 44, 55], I);
-var doubledDigit = twoDigit.mult(oneDigit, string);
+var oneDigit = new TypedSeries([1, 2, 3, 4, 5], I);
+var twoDigit = new TypedSeries([11, 22, 33, 44, 55], I);
 
 writeln("factors:");
 writeln(oneDigit);
 writeln(twoDigit);
 
 writeln("\nproduct:");
-writeln(doubledDigit);
+writeln(oneDigit * twoDigit);
 
-var I2 = new TypedIndex(["A", "B", "C"]);
-var I3 = new TypedIndex(["B", "C", "D", "E"]);
-var X: TypedSeries(int) = new TypedSeries([5, 1, 2], I2);
-var Y: TypedSeries(int) = new TypedSeries([10, 20, 6, 7], I3);
-var XY = Y.mult(X, string);
+var X = new TypedSeries([5, 1, 2], new TypedIndex(["A", "B", "C"]));
+var Y = new TypedSeries([10, 20, 6, 7], new TypedIndex(["B", "C", "D", "E"]));
 
 writeln("\nfactors:");
 writeln(Y);
 writeln(X);
 
 writeln("\nproduct:");
-writeln(XY);
+writeln(X * Y);

--- a/test/library/standard/Dataframes/psahabu/MultiplySeries.good
+++ b/test/library/standard/Dataframes/psahabu/MultiplySeries.good
@@ -1,0 +1,40 @@
+factors:
+A	1
+B	2
+C	3
+D	4
+E	5
+dtype: int(64)
+A	11
+B	22
+C	33
+D	44
+E	55
+dtype: int(64)
+
+product:
+A	11
+B	44
+C	99
+D	176
+E	275
+dtype: int(64)
+
+factors:
+B	10
+C	20
+D	6
+E	7
+dtype: int(64)
+A	5
+B	1
+C	2
+dtype: int(64)
+
+product:
+B	10
+C	40
+D	0
+E	0
+A	0
+dtype: int(64)

--- a/test/library/standard/Dataframes/psahabu/MultiplySeries.good
+++ b/test/library/standard/Dataframes/psahabu/MultiplySeries.good
@@ -32,9 +32,9 @@ C	2
 dtype: int(64)
 
 product:
+A	0
 B	10
 C	40
 D	0
 E	0
-A	0
 dtype: int(64)

--- a/test/library/standard/Dataframes/psahabu/MultiplySeries.py
+++ b/test/library/standard/Dataframes/psahabu/MultiplySeries.py
@@ -1,0 +1,26 @@
+import pandas as pd
+
+I = ["A", "B", "C", "D", "E"]
+
+oneDigit = pd.Series([1, 2, 3, 4, 5], pd.Index(I))
+twoDigit = pd.Series([11, 22, 33, 44, 55], pd.Index(I))
+
+print "factors:"
+print oneDigit
+print twoDigit
+print
+print "product:"
+print twoDigit * oneDigit
+print
+
+I2 = ["A", "B", "C"]
+I3 = ["B", "C", "D", "E"]
+X = pd.Series([5, 1, 2], pd.Index(I2))
+Y = pd.Series([10, 20, 6, 7], pd.Index(I3))
+
+print "factors:"
+print X
+print Y
+print
+print "product:"
+print Y * X 

--- a/test/library/standard/Dataframes/psahabu/MultiplySeries.py
+++ b/test/library/standard/Dataframes/psahabu/MultiplySeries.py
@@ -23,4 +23,4 @@ print X
 print Y
 print
 print "product:"
-print Y * X 
+print X * Y

--- a/test/library/standard/Dataframes/psahabu/ScalarPromSeries.chpl
+++ b/test/library/standard/Dataframes/psahabu/ScalarPromSeries.chpl
@@ -1,0 +1,18 @@
+use Dataframes;
+
+var oneDigit = new TypedSeries([1, 2, 3, 4, 5],
+                               new TypedIndex(["A", "B", "C", "D", "E"]));
+var n = 12;
+
+writeln("series:");
+writeln(oneDigit);
+writeln("scalar:");
+writeln(n);
+
+writeln();
+writeln("sum:");
+writeln(oneDigit + n);
+writeln("difference:");
+writeln(oneDigit - n);
+writeln("product:");
+writeln(oneDigit * n);

--- a/test/library/standard/Dataframes/psahabu/ScalarPromSeries.good
+++ b/test/library/standard/Dataframes/psahabu/ScalarPromSeries.good
@@ -1,0 +1,31 @@
+series:
+A	1
+B	2
+C	3
+D	4
+E	5
+dtype: int(64)
+scalar:
+12
+
+sum:
+A	13
+B	14
+C	15
+D	16
+E	17
+dtype: int(64)
+difference:
+A	-11
+B	-10
+C	-9
+D	-8
+E	-7
+dtype: int(64)
+product:
+A	12
+B	24
+C	36
+D	48
+E	60
+dtype: int(64)

--- a/test/library/standard/Dataframes/psahabu/ScalarPromSeries.py
+++ b/test/library/standard/Dataframes/psahabu/ScalarPromSeries.py
@@ -1,0 +1,17 @@
+import pandas as pd
+
+oneDigit = pd.Series([1, 2, 3, 4, 5], pd.Index(["A", "B", "C", "D", "E"]))
+n = 12
+
+print "series:"
+print oneDigit
+print "scalar:"
+print n
+
+print
+print "sum:"
+print oneDigit + n 
+print "difference:"
+print oneDigit - n 
+print "product:"
+print oneDigit * n 

--- a/test/library/standard/Dataframes/psahabu/SubtractSeries.chpl
+++ b/test/library/standard/Dataframes/psahabu/SubtractSeries.chpl
@@ -15,8 +15,8 @@ writeln(doubledDigit);
 
 var I2 = ["A", "B", "C"];
 var I3 = ["B", "C", "D", "E"];
-var X: TypedSeries(int) = new TypedSeries(I2, [0, 1, 2]);
-var Y: TypedSeries(int) = new TypedSeries(I3, [10, 20, 0, 0]);
+var X: TypedSeries(int) = new TypedSeries(I2, [5, 1, 2]);
+var Y: TypedSeries(int) = new TypedSeries(I3, [10, 20, 6, 7]);
 var XY = Y.subtr(X, string);
 
 writeln("\nterms:");

--- a/test/library/standard/Dataframes/psahabu/SubtractSeries.chpl
+++ b/test/library/standard/Dataframes/psahabu/SubtractSeries.chpl
@@ -2,26 +2,22 @@ use Dataframes;
 
 var I = new TypedIndex(["A", "B", "C", "D", "E"]);
 
-var oneDigit: TypedSeries(int) = new TypedSeries([1, 2, 3, 4, 5], I);
-var twoDigit: TypedSeries(int) = new TypedSeries([11, 22, 33, 44, 55], I);
-var doubledDigit = twoDigit.subtr(oneDigit, string);
+var oneDigit = new TypedSeries([1, 2, 3, 4, 5], I);
+var twoDigit = new TypedSeries([11, 22, 33, 44, 55], I);
 
 writeln("terms:");
 writeln(oneDigit);
 writeln(twoDigit);
 
 writeln("\ndifference:");
-writeln(doubledDigit);
+writeln(twoDigit - oneDigit);
 
-var I2 = new TypedIndex(["A", "B", "C"]);
-var I3 = new TypedIndex(["B", "C", "D", "E"]);
-var X: TypedSeries(int) = new TypedSeries([5, 1, 2], I2);
-var Y: TypedSeries(int) = new TypedSeries([10, 20, 6, 7], I3);
-var XY = Y.subtr(X, string);
+var X = new TypedSeries([5, 1, 2], new TypedIndex(["A", "B", "C"]));
+var Y = new TypedSeries([10, 20, 6, 7], new TypedIndex(["B", "C", "D", "E"]));
 
 writeln("\nterms:");
 writeln(Y);
 writeln(X);
 
 writeln("\ndifference:");
-writeln(XY);
+writeln(X - Y);

--- a/test/library/standard/Dataframes/psahabu/SubtractSeries.chpl
+++ b/test/library/standard/Dataframes/psahabu/SubtractSeries.chpl
@@ -1,0 +1,27 @@
+use Dataframes;
+
+var I = ["A", "B", "C", "D", "E"];
+
+var oneDigit: TypedSeries(int) = new TypedSeries(I, [1, 2, 3, 4, 5]);
+var twoDigit: TypedSeries(int) = new TypedSeries(I, [11, 22, 33, 44, 55]);
+var doubledDigit = twoDigit.subtr(oneDigit, string);
+
+writeln("terms:");
+writeln(oneDigit);
+writeln(twoDigit);
+
+writeln("\ndifference:");
+writeln(doubledDigit);
+
+var I2 = ["A", "B", "C"];
+var I3 = ["B", "C", "D", "E"];
+var X: TypedSeries(int) = new TypedSeries(I2, [0, 1, 2]);
+var Y: TypedSeries(int) = new TypedSeries(I3, [10, 20, 0, 0]);
+var XY = Y.subtr(X, string);
+
+writeln("\nterms:");
+writeln(X);
+writeln(Y);
+
+writeln("\ndifference:");
+writeln(XY);

--- a/test/library/standard/Dataframes/psahabu/SubtractSeries.chpl
+++ b/test/library/standard/Dataframes/psahabu/SubtractSeries.chpl
@@ -1,6 +1,6 @@
 use Dataframes;
 
-var I = ["A", "B", "C", "D", "E"];
+var I = new TypedIndex(["A", "B", "C", "D", "E"]);
 
 var oneDigit: TypedSeries(int) = new TypedSeries([1, 2, 3, 4, 5], I);
 var twoDigit: TypedSeries(int) = new TypedSeries([11, 22, 33, 44, 55], I);
@@ -13,8 +13,8 @@ writeln(twoDigit);
 writeln("\ndifference:");
 writeln(doubledDigit);
 
-var I2 = ["A", "B", "C"];
-var I3 = ["B", "C", "D", "E"];
+var I2 = new TypedIndex(["A", "B", "C"]);
+var I3 = new TypedIndex(["B", "C", "D", "E"]);
 var X: TypedSeries(int) = new TypedSeries([5, 1, 2], I2);
 var Y: TypedSeries(int) = new TypedSeries([10, 20, 6, 7], I3);
 var XY = Y.subtr(X, string);

--- a/test/library/standard/Dataframes/psahabu/SubtractSeries.good
+++ b/test/library/standard/Dataframes/psahabu/SubtractSeries.good
@@ -32,9 +32,9 @@ C	2
 dtype: int(64)
 
 difference:
-B	9
-C	18
-D	6
-E	7
-A	-5
+A	5
+B	-9
+C	-18
+D	-6
+E	-7
 dtype: int(64)

--- a/test/library/standard/Dataframes/psahabu/SubtractSeries.good
+++ b/test/library/standard/Dataframes/psahabu/SubtractSeries.good
@@ -1,0 +1,40 @@
+terms:
+A	1
+B	2
+C	3
+D	4
+E	5
+dtype: int(64)
+A	11
+B	22
+C	33
+D	44
+E	55
+dtype: int(64)
+
+difference:
+A	10
+B	20
+C	30
+D	40
+E	50
+dtype: int(64)
+
+terms:
+B	10
+C	20
+D	6
+E	7
+dtype: int(64)
+A	5
+B	1
+C	2
+dtype: int(64)
+
+difference:
+B	9
+C	18
+D	6
+E	7
+A	-5
+dtype: int(64)

--- a/test/library/standard/Dataframes/psahabu/SubtractSeries.py
+++ b/test/library/standard/Dataframes/psahabu/SubtractSeries.py
@@ -1,0 +1,26 @@
+import pandas as pd
+
+I = ["A", "B", "C", "D", "E"]
+
+oneDigit = pd.Series([1, 2, 3, 4, 5], pd.Index(I))
+twoDigit = pd.Series([11, 22, 33, 44, 55], pd.Index(I))
+
+print "terms:"
+print oneDigit
+print twoDigit
+print
+print "difference:"
+print twoDigit - oneDigit
+print
+
+I2 = ["A", "B", "C"]
+I3 = ["B", "C", "D", "E"]
+X = pd.Series([5, 1, 2], pd.Index(I2))
+Y = pd.Series([10, 20, 6, 7], pd.Index(I3))
+
+print "terms:"
+print X
+print Y
+print
+print "difference:"
+print Y - X 

--- a/test/library/standard/Dataframes/psahabu/SubtractSeries.py
+++ b/test/library/standard/Dataframes/psahabu/SubtractSeries.py
@@ -23,4 +23,4 @@ print X
 print Y
 print
 print "difference:"
-print Y - X 
+print X - Y


### PR DESCRIPTION
### Motivation
The motivation for the Series ADT arithmetic can be found in the connected issue.

### Implementation
The `uni()` method combines the indexes of both Series while taking a `SeriesUnifier` object, which contains three overridable functions: `f(lhs, rhs)`, `f_lhs(lhs)`, and `f_rhs(rhs)`. These three functions are used to fold the values of the `lhs` and `rhs` Series, respectively.

`add()`, `subtr()`, and `mult()` utilize `uni()`, and operators (`+`, `-`, and `*`) are built on top of those functions in turn. (The nested implementation of `uni()` and the other functions is necessary for dynamic dispatch to realize the types of the Series and the Index.)

### Notes
Included in this PR are pandas equivalents to our tests. Note that the only significant difference is that, if an index is not shared between two combined Series, Python emits `NaN`. This aspect will be tackled as part of #9037.