### PR TITLE
Fix autocomplete test when system chapel is installed

### DIFF
--- a/test/chplenv/autocomplete/autocomplete.chpl
+++ b/test/chplenv/autocomplete/autocomplete.chpl
@@ -14,7 +14,7 @@ extern proc getenv(name: c_string): c_string;
 extern proc setenv(name: c_string, val: c_string, overwrite: c_int): c_int;
 
 var path = getenv("PATH"):string;
-setenv("PATH", (path + ":" + home + "/bin/" + CHPL_HOST_PLATFORM).c_str(), 1);
+setenv("PATH", (home + "/bin/" + CHPL_HOST_PLATFORM + ":" + path).c_str(), 1);
 
 var genScript = home + "/util/devel/gen-chpl-bash-completion";
 var completeScript = home + "/util/chpl-completion.bash";


### PR DESCRIPTION
Prepends compiler bin to avoid conflicting with system-installed chapel release.