### PR TITLE
Improve scopeResolve for ShadowVarSymbol

### DIFF
--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -1529,7 +1529,7 @@ buildForallLoopStmt(Expr*      indices,
 
 // Todo: replace with ForallIntents or similar.
 void addTaskIntent(CallExpr* ti, ShadowVarSymbol* svar) {
-  Expr* ovar = svar->outerVarRep;
+  Expr* ovar = new UnresolvedSymExpr(svar->name);
   if (Expr* ri = svar->reduceOpExpr()) {
     // This is a reduce intent. NB 'intent' is undefined.
     ti->insertAtTail(ri);

--- a/compiler/AST/foralls.cpp
+++ b/compiler/AST/foralls.cpp
@@ -215,7 +215,7 @@ ShadowVarSymbol* ShadowVarSymbol::buildFromArgIntent(IntentTag intent,
 {
   ForallIntentTag  fi = argIntentToForallIntent(ovar, intent);
   const char*    name = toUnresolvedSymExpr(ovar)->unresolved;
-  return new ShadowVarSymbol(fi, name, ovar);
+  return new ShadowVarSymbol(fi, name, NULL);
 }
 
 ShadowVarSymbol* ShadowVarSymbol::buildFromReduceIntent(Expr* ovar,
@@ -223,7 +223,7 @@ ShadowVarSymbol* ShadowVarSymbol::buildFromReduceIntent(Expr* ovar,
 {
   INT_ASSERT(riExpr != NULL);
   const char* name = toUnresolvedSymExpr(ovar)->unresolved;
-  return new ShadowVarSymbol(TFI_REDUCE, name, ovar, riExpr);
+  return new ShadowVarSymbol(TFI_REDUCE, name, NULL, riExpr);
 }
 
 void addForallIntent(ForallIntents* fi, Expr* var, IntentTag intent, Expr* ri) {

--- a/compiler/include/baseAST.h
+++ b/compiler/include/baseAST.h
@@ -667,7 +667,7 @@ static inline const CallExpr* toConstCallExpr(const BaseAST* a)
     AST_CALL_CHILD(_a, ArgSymbol, variableExpr, call, __VA_ARGS__);     \
     break;                                                              \
   case E_ShadowVarSymbol:                                                   \
-    AST_CALL_CHILD(_a, ShadowVarSymbol, outerVarRep,   call, __VA_ARGS__);  \
+    AST_CALL_CHILD(_a, ShadowVarSymbol, outerVarSE,    call, __VA_ARGS__);  \
     AST_CALL_CHILD(_a, ShadowVarSymbol, specBlock,     call, __VA_ARGS__);  \
     AST_CALL_CHILD(_a, ShadowVarSymbol, svInitBlock,   call, __VA_ARGS__);  \
     AST_CALL_CHILD(_a, ShadowVarSymbol, svDeinitBlock, call, __VA_ARGS__);  \

--- a/compiler/include/expr.h
+++ b/compiler/include/expr.h
@@ -350,15 +350,8 @@ static inline bool needsCapture(FnSymbol* taskFn) {
          taskFn->hasFlag(FLAG_NON_BLOCKING);
 }
 
-inline SymExpr* ShadowVarSymbol::outerVarSE() const {
-  if (SymExpr* ovse = toSymExpr(this->outerVarRep))
-    return ovse;
-  else
-    return NULL;
-}
-
 inline Symbol* ShadowVarSymbol::outerVarSym() const {
-  if (SymExpr* ovse = this->outerVarSE())
+  if (SymExpr* ovse = this->outerVarSE)
     return ovse->symbol();
   else
     return NULL;

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -387,7 +387,7 @@ class ShadowVarSymbol : public VarSymbol {
 public:
   ShadowVarSymbol(ForallIntentTag iIntent,
                   const char* iName,
-                  Expr* outerVar,
+                  SymExpr* outerVar,
                   Expr* iSpec = NULL);
 
   virtual void    verify();
@@ -404,11 +404,11 @@ public:
   static ShadowVarSymbol* buildFromArgIntent(IntentTag intent, Expr* ovar);
   static ShadowVarSymbol* buildFromReduceIntent(Expr* ovar, Expr* riExpr);
 
-  // The corresponding outer var or NULL if not applicable.
-  SymExpr* outerVarSE()   const;
-  Symbol*  outerVarSym()  const;
+  // The outer variable or NULL if not applicable.
+  Symbol* outerVarSym()    const;
+
   // Returns the EXPR in "with (EXPR reduce x)".
-  Expr*    reduceOpExpr() const;
+  Expr*  reduceOpExpr()    const;
 
   BlockStmt* initBlock()   const { return svInitBlock; }
   BlockStmt* deinitBlock() const { return svDeinitBlock; }
@@ -426,10 +426,8 @@ public:
   // The intent for this variable.
   ForallIntentTag intent;
 
-  // Either a SymExpr* (after scopeResolve) or a UnresolvedSymExpr*.
-  // This would be just a SymExpr*, if not for checkIdInsideWithClause().
-  // See also: sv->outerVarSE() and sv->outerVarSym().
-  Expr* outerVarRep;
+  // Reference to the outer variable. NULL for task-private variables.
+  SymExpr* outerVarSE;
 
   // For a reduce intent, the reduce expression, wrapped in a block.
   // Otherwise NULL.

--- a/test/parallel/forall/vass/bogusShadowVar.good
+++ b/test/parallel/forall/vass/bogusShadowVar.good
@@ -1,2 +1,2 @@
-bogusShadowVar.chpl:4: error: 'bogusVar1' undeclared (first use this function)
-bogusShadowVar.chpl:5: error: 'bogusVar2' undeclared (first use this function)
+bogusShadowVar.chpl:4: error: could not find the outer variable for 'bogusVar1'
+bogusShadowVar.chpl:5: error: could not find the outer variable for 'bogusVar2'

--- a/test/parallel/forall/vass/errorFieldMethodInWithClause.chpl
+++ b/test/parallel/forall/vass/errorFieldMethodInWithClause.chpl
@@ -1,0 +1,42 @@
+// see also parallel/taskPar/vass/errorFieldMethodInWithClause.chpl
+const ITER = 1..3;
+
+proc ourProc { return 7; }
+iter ourIter { yield 8; }
+
+proc something {}
+
+class myClass {
+  var myField = 5;
+  proc myProcc return 6;
+}
+
+proc myClass.test {
+  forall ITER with (in myField) do
+    something();
+  forall ITER with (in myProcc) do
+    something;
+  forall ITER with (ref ourProc, ref ourIter) do
+    something;
+}
+
+class myRecord {
+  var myFild = 5;
+  proc myProc return 6;
+}
+
+proc myRecord.test {
+  forall ITER with (in myFild) do
+    something();
+  forall ITER with (in myProc) do
+    something;
+  forall ITER with (ref ourProc, ref ourIter) do
+    something;
+}
+
+proc main {
+  const mc = new myClass();
+  mc.test;
+  const mr = new myRecord();
+  mr.test;
+}

--- a/test/parallel/forall/vass/errorFieldMethodInWithClause.good
+++ b/test/parallel/forall/vass/errorFieldMethodInWithClause.good
@@ -1,0 +1,8 @@
+errorFieldMethodInWithClause.chpl:15: error: cannot reference a field or function 'myField' in a with-clause of this forall loop
+errorFieldMethodInWithClause.chpl:17: error: cannot reference a field or function 'myProcc' in a with-clause of this forall loop
+errorFieldMethodInWithClause.chpl:19: error: cannot reference a field or function 'ourProc' in a with-clause of this forall loop
+errorFieldMethodInWithClause.chpl:19: error: cannot reference a field or function 'ourIter' in a with-clause of this forall loop
+errorFieldMethodInWithClause.chpl:29: error: cannot reference a field or function 'myFild' in a with-clause of this forall loop
+errorFieldMethodInWithClause.chpl:31: error: cannot reference a field or function 'myProc' in a with-clause of this forall loop
+errorFieldMethodInWithClause.chpl:33: error: cannot reference a field or function 'ourProc' in a with-clause of this forall loop
+errorFieldMethodInWithClause.chpl:33: error: cannot reference a field or function 'ourIter' in a with-clause of this forall loop

--- a/test/parallel/taskPar/vass/errorFieldMethodInWithClause.chpl
+++ b/test/parallel/taskPar/vass/errorFieldMethodInWithClause.chpl
@@ -1,4 +1,6 @@
 // see also field-in-task-ref-clause.chpl
+// see also parallel/forall/vass/errorFieldMethodInWithClause.chpl
+
 const ITER = 1..3;
 
 class myClass {
@@ -12,12 +14,10 @@ iter ourIter { yield 8; }
 proc something {}
 
 proc myClass.test {
-  forall ITER with (in myField) do
-    something();
-  forall ITER with (in myProcc) do
-    something;
-  forall ITER with (ref ourProc, ref ourIter) do
-    something;
+
+
+  // forall testing moved to parallel/forall/vass
+
 
   cobegin with (in myField) {
     something;

--- a/test/parallel/taskPar/vass/errorFieldMethodInWithClause.good
+++ b/test/parallel/taskPar/vass/errorFieldMethodInWithClause.good
@@ -1,9 +1,5 @@
-errorFieldMethodInWithClause.chpl:15: error: cannot reference a field or function 'myField' in a with-clause of this forall loop
-errorFieldMethodInWithClause.chpl:17: error: cannot reference a field or function 'myProcc' in a with-clause of this forall loop
-errorFieldMethodInWithClause.chpl:19: error: cannot reference a field or function 'ourProc' in a with-clause of this forall loop
-errorFieldMethodInWithClause.chpl:19: error: cannot reference a field or function 'ourIter' in a with-clause of this forall loop
 errorFieldMethodInWithClause.chpl:22: error: cannot reference a field or function 'myField' in a with-clause of this cobegin block
-errorFieldMethodInWithClause.chpl:14: In function 'test':
+errorFieldMethodInWithClause.chpl:16: In function 'test':
 errorFieldMethodInWithClause.chpl:26: error: cannot reference a field or function 'myProcc' in a with-clause of this cobegin block
 errorFieldMethodInWithClause.chpl:30: error: cannot reference a field or function 'ourProc' in a with-clause of this cobegin block
 errorFieldMethodInWithClause.chpl:30: error: cannot reference a field or function 'ourIter' in a with-clause of this cobegin block

--- a/test/parallel/taskPar/vass/field-in-task-ref-clause.chpl
+++ b/test/parallel/taskPar/vass/field-in-task-ref-clause.chpl
@@ -1,4 +1,7 @@
 // see also errorFieldMethodInWithClause.chpl
+//
+// with-clauses of forall loops are tested in
+//  parallel/forall/vass/errorFieldMethodInWithClause.chpl
 
 class MyClass {
   var myField:int = 111;
@@ -20,11 +23,6 @@ class MyClass {
         writeln(myField);
       }
   }
-  proc myForall() {
-      forall 1..1 with (ref myField) {
-        writeln(myField);
-      }
-  }
 }  // class MyClass
 
 var c = new MyClass();
@@ -34,8 +32,6 @@ writeln(c);
 c.myCobegin();
 writeln(c);
 c.myCoforall();
-writeln(c);
-c.myForall();
 writeln(c);
 
 record MyRecord {
@@ -58,11 +54,6 @@ record MyRecord {
         writeln(myField);
       }
   }
-  proc myForall() {
-      forall 1..1 with (ref myField) {
-        writeln(myField);
-      }
-  }
 }  // record MyRecord
 
 var r = new MyRerord();
@@ -72,6 +63,4 @@ writeln(r);
 r.myCobegin();
 writeln(r);
 r.myCoforall();
-writeln(r);
-r.myForall();
 writeln(r);

--- a/test/parallel/taskPar/vass/field-in-task-ref-clause.good
+++ b/test/parallel/taskPar/vass/field-in-task-ref-clause.good
@@ -1,8 +1,6 @@
-field-in-task-ref-clause.chpl:7: error: cannot reference a field or function 'myField' in a with-clause of this begin block
-field-in-task-ref-clause.chpl:13: error: cannot reference a field or function 'myField' in a with-clause of this cobegin block
-field-in-task-ref-clause.chpl:19: error: cannot reference a field or function 'myField' in a with-clause of this coforall loop
-field-in-task-ref-clause.chpl:24: error: cannot reference a field or function 'myField' in a with-clause of this forall loop
-field-in-task-ref-clause.chpl:45: error: cannot reference a field or function 'myField' in a with-clause of this begin block
-field-in-task-ref-clause.chpl:51: error: cannot reference a field or function 'myField' in a with-clause of this cobegin block
-field-in-task-ref-clause.chpl:57: error: cannot reference a field or function 'myField' in a with-clause of this coforall loop
-field-in-task-ref-clause.chpl:62: error: cannot reference a field or function 'myField' in a with-clause of this forall loop
+field-in-task-ref-clause.chpl:10: error: cannot reference a field or function 'myField' in a with-clause of this begin block
+field-in-task-ref-clause.chpl:16: error: cannot reference a field or function 'myField' in a with-clause of this cobegin block
+field-in-task-ref-clause.chpl:22: error: cannot reference a field or function 'myField' in a with-clause of this coforall loop
+field-in-task-ref-clause.chpl:41: error: cannot reference a field or function 'myField' in a with-clause of this begin block
+field-in-task-ref-clause.chpl:47: error: cannot reference a field or function 'myField' in a with-clause of this cobegin block
+field-in-task-ref-clause.chpl:53: error: cannot reference a field or function 'myField' in a with-clause of this coforall loop


### PR DESCRIPTION
Before this change, scope resolution for the outer variable "ovar"
of a shadow variable "svar" was done so:

* the parser reprsented the ovar as UnresolvedSymExpr
* scopeResolve handled that UnresolvedSymExpr just like any other
* ... and converted it to SymExpr

One outcome of this was that ShadowVarSymbol::outerVarRep could
not have the type SymExpr*. This was not ideal because it was
actually a SymExpr* for most of the compiler.

Now, scope resolution works like this:

* the parser does not represent the ovar
* scopeResolve creates the ovar SymExpr for each svar
  using the same steps as if it were an UnresolvedSymExpr,
  except it uses the svar's name instead of
  UnresolvedSymExpr::unresolved

As a result, there is no UnresolvedSymExpr for the ovar
and ShadowVarSymbol::outerVarSE has the type SymExpr* .
outerVarSE replaces outerVarRep.

Also, when there is no outer variable for a given name,
we give a specific error message, rather than a generic one.
Detecting the case of the shadow variable referring to
a field or a function (for error reporting) is also easier now.

The tests for the error messages still do the same as before.
The changes are:

* update the error message text
* split a test into two and otherwise separate the checking
  of with-clauses for foralls from those for task constructs (*)

(*) I had to introduce an earlier USR_STOP(). Because there is
another (existing) check for err_user (or somesuch) that is
interpreted as "the immediately-preceeding operation failed
and we can recover". So some errors that used to be reported
in a single compiler run no longer are - we need to test them
separately.

Tested: linux64 --verify.
