### PR TITLE
Update prereq.rst for #9102 changes

### DIFF
--- a/doc/rst/usingchapel/prereqs.rst
+++ b/doc/rst/usingchapel/prereqs.rst
@@ -33,11 +33,11 @@ about your environment for using Chapel:
       expression support (i.e.  CHPL_LLVM=llvm or CHPL_REGEXP=re2). If
       GCC is used, we recommend GCC version 5 or newer for this purpose.
 
-  * Building GMP requires an M4 macro processor
+  * Building GMP requires an M4 macro processor.
 
   * Building LLVM requires cmake version 3.4.3 or later.
 
-  * If you wish to use Chapel's test system, python-setuptools and
+  * If you wish to use chpldoc or Chapel's test system, ``curl`` and
     python-devel (or equivalent packages for your platform) are required.
 
 .. _readme-prereqs-installation:


### PR DESCRIPTION
`chpldoc` and `test-venv` no longer require `easy_install`, so python-setuptools has been removed as a dependency. These features now require `curl` to install a local pip, so `curl` has been added as a dependency.

Note: I opted to not describe the caveat of requiring an openssl that support TLS 1.2+ on non-OS X systems, but could be convinced to do so if the reviewer(s) had a strong opinion on it.