### PR TITLE
Fix a typo in the ZMQ documentation

### DIFF
--- a/modules/packages/ZMQ.chpl
+++ b/modules/packages/ZMQ.chpl
@@ -205,7 +205,7 @@ and Chapel's ZMQ module intends on providing interfaces and serialization
 protocols suitable for exchanging data between Chapel and non-Chapel programs.
 
 As an example (and test) of Chapel-Python interoperability over ZeroMQ, the
-following sources demonstrate a :const:`PUSH`-:const:`PULL` socket pair between
+following sources demonstrate a :const:`REQ`-:const:`REP` socket pair between
 a Chapel server and a Python client using the
 `PyZMQ Python bindings for ZeroMQ <https://pyzmq.readthedocs.io/en/latest/>`_.
 


### PR DESCRIPTION
The interoperability example said the socket pair was PUSH-PULL, but the example
itself was REQ-REP.  Update the description to match the example.