### PR TITLE
Update ZMQ interop-py PREEXEC to use new virtualenv.py path

### DIFF
--- a/test/library/packages/ZMQ/interop-py/PREEXEC
+++ b/test/library/packages/ZMQ/interop-py/PREEXEC
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+#Note: This is a temporary solution to supporting additional python dependencies
+#      Something integrated with start_test would be preferred in the long term,
+#      such that a test author only needs to specify a requirements.txt file
+
 clean_venv() {
     echo "Aborted virtualenv build due to errors"
     rm -rf pyzmq-venv
@@ -8,7 +12,9 @@ clean_venv() {
 
 if [[ ! -f pyzmq-venv/bin/activate ]] ; then
     # Path to Chapel-installed virtualenv
-    CHPL_VIRTUALENV=$(python $CHPL_HOME/util/chplenv/chpl_home_utils.py --venv)/../virtualenv
+    PYTHON_VERSION=$(python $CHPL_HOME/util/chplenv/chpl_python_version.py)
+    CHPL_VIRTUALENV=$(python $CHPL_HOME/util/chplenv/chpl_home_utils.py --venv)/../lib/python${PYTHON_VERSION}/site-packages/virtualenv.py
+
 
     # If Chapel virtualenv DNE, check for system-installed virtualenv
     if [[ ! -f ${CHPL_VIRTUALENV} ]]; then
@@ -25,7 +31,7 @@ if [[ ! -f pyzmq-venv/bin/activate ]] ; then
     trap clean_venv ERR
 
     # Create virtualenv
-    ${CHPL_VIRTUALENV} pyzmq-venv
+    python ${CHPL_VIRTUALENV} pyzmq-venv
     source pyzmq-venv/bin/activate
     python -m pip install ${CHPL_PIP_INSTALL_PARAMS} -r requirements.txt
     deactivate


### PR DESCRIPTION
#9102 and friends fixed the heart of the issue that was causing this test to fail nightly on OS X. However, the virtualenv path in the `PREEXEC` became stale, so the test continued to fail.  This PR updates the path.

Also added a comment about my desire to have this functionality built into the test framework, rather than have test authors write `PREEXEC`s like this.

- [x] Test locally (OS X)
- [x] Test on failing machine (OS X)