### PR TITLE
Fix a leak in coforall-plus-on.chpl

### DIFF
--- a/compiler/optimizations/remoteValueForwarding.cpp
+++ b/compiler/optimizations/remoteValueForwarding.cpp
@@ -196,6 +196,8 @@ static bool canForwardValue(Map<Symbol*, Vec<SymExpr*>*>& defMap,
 
 static bool isSufficientlyConst(ArgSymbol* arg);
 
+static CallExpr* findDestroyCallForArg(ArgSymbol* arg);
+
 static void defaultForwarding(Map<Symbol*, Vec<SymExpr*>*>& useMap,
                               FnSymbol*                     fn,
                               ArgSymbol*                    arg);
@@ -377,80 +379,11 @@ static void adjustArgIntentForDeref(ArgSymbol* arg) {
   arg->removeFlag(FLAG_SCOPE);
 }
 
-//
-// BHARSH 2017-08-21:
-//
-// This function inserts calls to chpl__serialize and chpl__deserialize.
-// For example, AST like this:
-//
-//   call on_fn tmp myRecord;
-//
-//   function on_fn(const in dummy_locale_arg, const ref myRecord : Foo) {
-//     call writeln myRecord;
-//   }
-//
-// Will be transformed to AST like this:
-//
-//   var myRecord_data : 3*int;
-//   call chpl__serialize myRecord myRecord_data;
-//   call on_fn tmp myRecord_data
-//
-//   function on_fn(const in dummy_locale_arg, const myRecord_data : 3*int) {
-//     var myRecord : Foo;
-//     call chpl__deserialize myRecord_data myRecord;
-//     call writeln myRecord;
-//     call chpl__autoDestroy myRecord_data;
-//     call chpl__autoDestroy myRecord;
-//   }
-//
-// If we're RVF-ing something with a runtime type, this function copies the
-// original formal and uses it to construct a runtime type within the
-// on-statement. This will change the number of formals for this on-statement
-// unlike traditional RVF.
-//
-// BHARSH TODO: Split this function into more easily-digestible pieces
-// BHARSH TODO: capture the assumptions made here in documentation
-//
-static CallExpr* findDestroyCallForArg(ArgSymbol* arg);
-static void insertSerialization(FnSymbol*  fn,
-                                ArgSymbol* arg) {
-  Type* oldArgType    = arg->type;
-  bool newStyleInIntent = shouldAddFormalTempAtCallSite(arg, fn);
-
-  Serializers ser = serializeMap[oldArgType->getValType()];
-
-  FnSymbol* serializeFn   = ser.serializer;
-  FnSymbol* deserializeFn = ser.deserializer;
-  INT_ASSERT(serializeFn != NULL && deserializeFn != NULL);
-
-  bool needsRuntimeType = oldArgType->getValType()->symbol->hasFlag(FLAG_HAS_RUNTIME_TYPE);
-
-  Type* dataType = NULL;
-  if (serializeFn->hasFlag(FLAG_FN_RETARG)) {
-    ArgSymbol* retArg = toArgSymbol(toDefExpr(serializeFn->formals.tail)->sym);
-    INT_ASSERT(retArg && retArg->hasFlag(FLAG_RETARG));
-
-    dataType = retArg->getValType();
-  } else {
-    dataType = serializeFn->retType;
-  }
-  arg->type = dataType;
-  adjustArgIntentForDeref(arg);
-
-  // If argDestroyCall is set, we'll move the destroy
-  // call from the task function to the call sites.
-  CallExpr* argDestroyCall = findDestroyCallForArg(arg);
-
-  // Current compiler always moves the auto-destroy
-  // for a coforall index variable into the task function
-  // These asserts just remind us to check this code if that changes.
-  if (arg->hasFlag(FLAG_COFORALL_INDEX_VAR) &&
-      getAutoDestroy(arg->getValType()))
-    INT_ASSERT(argDestroyCall);
-  else
-    INT_ASSERT(!argDestroyCall);
-
-  // Update each callsite to invoke the serializer
+// Update each callsite to invoke the serializer.
+static void serializeAtCallSites(FnSymbol* fn,  ArgSymbol* arg,
+                       Type* dataType,          CallExpr* argDestroyCall,
+                       FnSymbol* serializeFn,   bool newStyleInIntent)
+{
   forv_Vec(CallExpr, call, *fn->calledBy) {
     SymExpr* actual = toSymExpr(formal_to_actual(call, arg));
     SET_LINENO(actual);
@@ -509,15 +442,16 @@ static void insertSerialization(FnSymbol*  fn,
 
     actual->replace(new SymExpr(data));
   }
+}
 
-  // Remove the old auto-destroy call from the task fn.
-  if (argDestroyCall) {
-    argDestroyCall->remove();
-  }
-
-  // Replace all uses of 'arg' with a local reference to a deserialized
-  // instance of 'arg'
-  SET_LINENO(fn);
+// Insert and return the temp that will hold the deserialized
+// instace of 'arg'.
+// Replace all references to 'arg' within the task function
+// with local references to that temp.
+static VarSymbol* replaceArgWithDeserialized(FnSymbol* fn, ArgSymbol* arg,
+                                Type* oldArgType, FnSymbol* deserializeFn,
+                                bool needsRuntimeType)
+{
   VarSymbol* deserialized = newTemp(arg->cname, oldArgType->getValType());
   VarSymbol* dsRef = newTemp(arg->cname, QualifiedType(QUAL_REF, oldArgType->getValType()));
   for_SymbolSymExprs(se, arg) {
@@ -553,6 +487,13 @@ static void insertSerialization(FnSymbol*  fn,
   anchor->insertBefore(callToAdd);
   anchor->insertBefore(new CallExpr(PRIM_MOVE, dsRef, new CallExpr(PRIM_SET_REFERENCE, deserialized)));
 
+  return deserialized;
+}
+
+// Destroy 'arg' and 'deserialized' before returning from the task function.
+static void destroyArgAndDeserialized(FnSymbol* fn, ArgSymbol* arg,
+                             bool newStyleInIntent, VarSymbol* deserialized)
+{
   CallExpr* lastExpr = toCallExpr(fn->body->body.tail);
   INT_ASSERT(lastExpr && lastExpr->isPrimitive(PRIM_RETURN));
 
@@ -567,6 +508,95 @@ static void insertSerialization(FnSymbol*  fn,
       lastExpr->insertBefore(new CallExpr(deserializeDestroyFn, deserialized));
     }
   }
+}
+
+//
+// BHARSH 2017-08-21:
+//
+// This function inserts calls to chpl__serialize and chpl__deserialize.
+// For example, AST like this:
+//
+//   call on_fn tmp myRecord;
+//
+//   function on_fn(const in dummy_locale_arg, const ref myRecord : Foo) {
+//     call writeln myRecord;
+//   }
+//
+// Will be transformed to AST like this:
+//
+//   var myRecord_data : 3*int;
+//   call chpl__serialize myRecord myRecord_data;
+//   call on_fn tmp myRecord_data
+//
+//   function on_fn(const in dummy_locale_arg, const myRecord_data : 3*int) {
+//     var myRecord : Foo;
+//     call chpl__deserialize myRecord_data myRecord;
+//     call writeln myRecord;
+//     call chpl__autoDestroy myRecord_data;
+//     call chpl__autoDestroy myRecord;
+//   }
+//
+// If we're RVF-ing something with a runtime type, this function copies the
+// original formal and uses it to construct a runtime type within the
+// on-statement. This will change the number of formals for this on-statement
+// unlike traditional RVF.
+//
+// BHARSH TODO: Split this function into better easily-digestible pieces
+// BHARSH TODO: capture the assumptions made here in documentation
+//
+static void insertSerialization(FnSymbol*  fn,
+                                ArgSymbol* arg) {
+  Type* oldArgType    = arg->type;
+  bool newStyleInIntent = shouldAddFormalTempAtCallSite(arg, fn);
+
+  Serializers ser = serializeMap[oldArgType->getValType()];
+
+  FnSymbol* serializeFn   = ser.serializer;
+  FnSymbol* deserializeFn = ser.deserializer;
+  INT_ASSERT(serializeFn != NULL && deserializeFn != NULL);
+
+  bool needsRuntimeType = oldArgType->getValType()->symbol->hasFlag(FLAG_HAS_RUNTIME_TYPE);
+
+  Type* dataType = NULL;
+  if (serializeFn->hasFlag(FLAG_FN_RETARG)) {
+    ArgSymbol* retArg = toArgSymbol(toDefExpr(serializeFn->formals.tail)->sym);
+    INT_ASSERT(retArg && retArg->hasFlag(FLAG_RETARG));
+
+    dataType = retArg->getValType();
+  } else {
+    dataType = serializeFn->retType;
+  }
+  arg->type = dataType;
+  adjustArgIntentForDeref(arg);
+
+  // If argDestroyCall is set, we'll move the destroy
+  // call from the task function to the call sites.
+  CallExpr* argDestroyCall = findDestroyCallForArg(arg);
+
+  // Current compiler always moves the auto-destroy
+  // for a coforall index variable into the task function
+  // These asserts just remind us to check this code if that changes.
+  if (arg->hasFlag(FLAG_COFORALL_INDEX_VAR) &&
+      getAutoDestroy(arg->getValType()))
+    INT_ASSERT(argDestroyCall);
+  else
+    INT_ASSERT(!argDestroyCall);
+
+  serializeAtCallSites(fn, arg, dataType, argDestroyCall, serializeFn,
+                       newStyleInIntent);
+
+  // Remove the old auto-destroy call from the task fn.
+  if (argDestroyCall) {
+    argDestroyCall->remove();
+  }
+
+  SET_LINENO(fn);
+
+  // The deserialized instance.
+  VarSymbol* deserialized = replaceArgWithDeserialized(fn, arg, oldArgType,
+                                             deserializeFn, needsRuntimeType);
+
+  destroyArgAndDeserialized(fn, arg, newStyleInIntent, deserialized);
 }
 
 static CallExpr* findDestroyCallForArg(ArgSymbol* arg) {

--- a/compiler/optimizations/remoteValueForwarding.cpp
+++ b/compiler/optimizations/remoteValueForwarding.cpp
@@ -457,15 +457,6 @@ static void insertSerialization(FnSymbol*  fn,
 
     Symbol* actualInput = actual->symbol();
 
-/*
-///////////
-2018-04-11 Vass: I am commenting out the following fragment as a temporary
-fix for a read-after-delete bug exposed in these tests:
-    parallel/forall/in-intents/coforall-plus-on
-    # under numa
-    parallel/forall/in-intents/both-arr-dom-const-const
-    parallel/forall/in-intents/both-arr-dom-var-const
-///////////
     // If we're working with a copy added to support an 'in' intent,
     // we don't need that copy anymore since the serialize/deserialize
     // calls will have the same effect. So remove the copy call
@@ -495,7 +486,6 @@ fix for a read-after-delete bug exposed in these tests:
         initExpr->replace(new CallExpr(PRIM_MOVE, actual->symbol(), actualInput));
       }
     }
-*/
 
     VarSymbol* data = newTemp(astr(arg->cname, "_data"), dataType);
     if (arg->hasFlag(FLAG_COFORALL_INDEX_VAR)) {

--- a/compiler/resolution/lowerForalls.cpp
+++ b/compiler/resolution/lowerForalls.cpp
@@ -627,8 +627,16 @@ static void addFormalTempSIifNeeded(FnSymbol* cloneTaskFn, Expr* aInit,
   e->value = currSI;
   map.put(SI->OutervarForIN(), eFormal);
 
-  eFormal->intent = INTENT_CONST_REF;
+  eFormal->intent         = INTENT_CONST_REF;
+  eFormal->originalIntent = INTENT_CONST_REF;  // (*)
   // non-ref type is ok for eFormal
+
+  // (*) We need this adjustment, otherwise shouldAddFormalTempAtCallSite()
+  // in insertSerialization() / remoteValueForwarding will get confused.
+  // Check these tests for valgrind and memLeaks under --no-local and numa:
+  //   parallel/forall/in-intents/coforall-plus-on
+  //   parallel/forall/in-intents/both-arr-dom-const-const
+  //   parallel/forall/in-intents/both-arr-dom-var-const
 
   addCloneOfInitBlock(aInit, map, SI);
 }


### PR DESCRIPTION
This fixes the memory leaks in

    parallel/forall/in-intents/coforall-plus-on.chpl

and under NUMA in

    parallel/forall/in-intents/both-arr-dom-const-const.chpl
    parallel/forall/in-intents/both-arr-dom-var-const.chpl

The leaks were due to #8785 + #9180.

#9180 commented out the removal of initCopy that was added
to support in-intents in foralls in some cases where it was
not needed.

This PR instead adjusts the AST so that shouldAddFormalTempAtCallSite()
produces the desired results in the above tests. In detail,
addFormalTempSIifNeeded(), a part of addFormalTempSIifNeeded(),
converts an in-intent formal of a task function to a ref formal
plus initCopy. Because this is what is expected at this point
during compilation. With this PR, when this happens,
'originalIntent' of such a formal is also adjusted to be 'ref'.
That way shouldAddFormalTempAtCallSite() handles this situation
properly. So the initCopy removal code is enabled again.

This PR consists of two commits.

* a3706f1e89 implements the above.

* 44ba7a7a4d - "while there", start refactoring insertSerialization()
as that function was too long. No behavioral changes should result.
This refactoring should definitely be improved further.
