### PR TITLE
Improved performance of LinearAlgebra.Sparse _array.plus()

### DIFF
--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -396,11 +396,17 @@ proc _array.T where isDefaultRectangularArr(this) && this.domain.rank == 2
   return transpose(this);
 }
 
-/* Add matrices, maintaining dimensions, deprecated for ``_array.plus`` */
+/*Add matrices, maintaining dimensions. Preferred method at scale */
 proc matPlus(A: [?Adom] ?eltType, B: [?Bdom] eltType) where isDefaultRectangularArr(A) && isDefaultRectangularArr(B) {
-  compilerWarning('matPlus has been deprecated for _array.plus, ' +
-                  'try: A.plus(B)');
-  return A.plus(B);
+  var dom = {A.domain.dim(1),B.domain.dim(2)};
+  var sps = CSRDomain(dom);
+  sps += A.domain;
+  sps += B.domain;
+  var S: [sps] real;
+  for (i,j) in sps {
+    S(i,j) = A(i,j) + B(i,j);
+  }
+  return S;
 }
 
 /* Add matrices, maintaining dimensions */

--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -398,23 +398,22 @@ proc _array.T where isDefaultRectangularArr(this) && this.domain.rank == 2
 
 /*Add matrices, maintaining dimensions. Preferred method at scale */
 proc matPlus(A: [?Adom] ?eltType, B: [?Bdom] eltType) where isDefaultRectangularArr(A) && isDefaultRectangularArr(B) {
-  var dom = {A.domain.dim(1),B.domain.dim(2)};
-  var sps = CSRDomain(dom);
-  sps += A.domain;
-  sps += B.domain;
-  var S: [sps] real;
-  for (i,j) in sps {
-    S(i,j) = A(i,j) + B(i,j);
-  }
-  return S;
+  compilerWarning('matMinus has been deprecated for _array.plus, ' +
+                  'try: A.minus(B)');
+  return A.plus(B);
 }
 
 /* Add matrices, maintaining dimensions */
-proc _array.plus(A: [?Adom]) where isDefaultRectangularArr(A) && isDefaultRectangularArr(this) {
-  if Adom.rank != this.domain.rank then compilerError("Unmatched ranks");
-  if Adom.shape != this.domain.shape then halt("Unmatched shapes");
-  var C: [Adom] eltType = this + A;
-  return C;
+proc _array.plus(A: [?Adom]) where isCSArr(A) && isCSArr(this) {
+  if this.domain.parentDom != Adom.parentDom then halt("Unmatched Shapes");
+  var sps = CSRDomain(Adom.parentDom);
+  sps += this.domain;
+  sps += Adom;
+  var S: [sps] real;
+  forall (i,j) in sps {
+    S(i,j) = this(i,j) + A(i,j);
+  }
+  return S;
 }
 
 /* Subtract matrices, maintaining dimensions, deprecated for ``_array.minus``*/

--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -398,23 +398,17 @@ proc _array.T where isDefaultRectangularArr(this) && this.domain.rank == 2
 
 /* Add matrices, maintaining dimensions, deprecated for ``_array.plus`` */
 proc matPlus(A: [?Adom] ?eltType, B: [?Bdom] eltType) where isDefaultRectangularArr(A) && isDefaultRectangularArr(B) {
-  compilerWarning('matMinus has been deprecated for _array.plus, ' +
-                  'try: A.minus(B)');
+  compilerWarning('matPlus has been deprecated for _array.plus, ' +
+                  'try: A.plus(B)');
   return A.plus(B);
 }
 
 /* Add matrices, maintaining dimensions */
-proc _array.plus(A: [?Adom] eltType) where isCSArr(A) && isCSArr(this) {
+proc _array.plus(A: [?Adom] ?eltType) where isDefaultRectangularArr(A) && isDefaultRectangularArr(this) {
   if Adom.rank != this.domain.rank then compilerError("Unmatched ranks");
-  if this.domain.shape != Adom.shape then halt("Unmatched shapes");
-  var sps = CSRDomain(Adom.parentDom);
-  sps += this.domain;
-  sps += Adom;
-  var S: [sps] eltType;
-  forall (i,j) in sps {
-    S[i,j] = this[i,j] + A[i,j];
-  }
-  return S;
+  if Adom.shape != this.domain.shape then halt("Unmatched shapes");
+  var C: [Adom] eltType = this + A;
+  return C;
 }
 
 /* Subtract matrices, maintaining dimensions, deprecated for ``_array.minus``*/
@@ -425,17 +419,11 @@ proc matMinus(A: [?Adom] ?eltType, B: [?Bdom] eltType) where isDefaultRectangula
 }
 
 /* Subtract matrices, maintaining dimensions */
-proc _array.minus(A: [?Adom]) where isCSArr(A) && isCSArr(this) {
+proc _array.minus(A: [?Adom] ?eltType) where isDefaultRectangularArr(A) && isDefaultRectangularArr(this) {
   if Adom.rank != this.domain.rank then compilerError("Unmatched ranks");
   if Adom.shape != this.domain.shape then halt("Unmatched shapes");
-  var sps = CSRDomain(Adom.parentDom);
-  sps += this.domain;
-  sps += Adom;
-  var S: [sps] eltType;
-  forall (i,j) in sps {
-    S[i,j] = this[i,j] - A[i,j];
-  }
-  return S;
+  var C: [Adom] eltType = this - A;
+  return C;
 }
 
 /* Element-wise multiplication, maintaining dimensions */
@@ -1607,45 +1595,31 @@ module Sparse {
   proc _array.T where isCSArr(this) { return transpose(this); }
 
   /* Element-wise addition */
-  proc _array.plus(A) where isCSArr(this) && isCSArr(A) {
-    if this.domain._value.parentDom != A.domain._value.parentDom then
-      halt('Cannot add sparse arrays with non-matching parent domains');
-
-    // Create copy of 'this'
-    var BDom = this.domain;
-    var B: [BDom] this.eltType;
-    forall (i,j) in B.domain do B[i,j] = this[i,j];
-
-    // If domain indices do not match, bulk add A's indices to B
-    if this.domain != A.domain {
-      BDom += A.domain;
+  proc _array.plus(A: [?Adom] ?eltType) where isCSArr(this) && isCSArr(A) {
+    if Adom.rank != this.domain.rank then compilerError("Unmatched ranks");
+    if this.domain.shape != Adom.shape then halt("Unmatched shapes");
+    var sps = CSRDomain(Adom.parentDom);
+    sps += this.domain;
+    sps += Adom;
+    var S: [sps] eltType;
+    forall (i,j) in sps {
+      S[i,j] = this[i,j] + A[i,j];
     }
-
-    // Do in-place addition of A into B
-    forall (i,j) in A.domain do B[i,j] += A[i,j];
-
-    return B;
+    return S;
   }
 
   /* Element-wise subtraction */
-  proc _array.minus(A) where isCSArr(this) && isCSArr(A) {
-    if this.domain._value.parentDom != A.domain._value.parentDom then
-      halt('Cannot add sparse arrays with non-matching parent domains');
-
-    // Create copy of 'this'
-    var BDom = this.domain;
-    var B: [BDom] this.eltType;
-    forall (i,j) in B.domain do B[i,j] = this[i,j];
-
-    // If domain indices do not match, bulk add A's indices to B
-    if this.domain != A.domain {
-      BDom += A.domain;
+  proc _array.minus(A: [?Adom] ?eltType) where isCSArr(this) && isCSArr(A) {
+    if Adom.rank != this.domain.rank then compilerError("Unmatched ranks");
+    if this.domain.shape != Adom.shape then halt("Unmatched shapes");
+    var sps = CSRDomain(Adom.parentDom);
+    sps += this.domain;
+    sps += Adom;
+    var S: [sps] eltType;
+    forall (i,j) in sps {
+      S[i,j] = this[i,j] - A[i,j];
     }
-
-    // Do in-place addition of A into B
-    forall (i,j) in A.domain do B[i,j] -= A[i,j];
-
-    return B;
+    return S;
   }
 
   /* Element-wise multiplication */


### PR DESCRIPTION
The matrix methods  `_array.plus()` and `_array.minus()` don't seem to scale well on large matrices. This implementation does. This PR is a work around for #9364 but not a solution, as I believe that issue points to an important underlying language issue related to recent ticket #9344 