### PR TITLE
Block sparseLayoutType -> unmanaged, fix .bad files

### DIFF
--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -431,7 +431,7 @@ proc Block.init(boundingBox: domain,
                 dataParMinGranularity=getDataParMinGranularity(),
                 param rank = boundingBox.rank,
                 type idxType = boundingBox.idxType,
-                type sparseLayoutType = DefaultDist) {
+                type sparseLayoutType = unmanaged DefaultDist) {
   this.rank = rank;
   this.idxType = idxType;
   if rank != boundingBox.rank then

--- a/test/arrays/diten/privatizedArrayErrorMessage.good
+++ b/test/arrays/diten/privatizedArrayErrorMessage.good
@@ -1,2 +1,2 @@
-privatizedArrayErrorMessage.chpl:12: error: unresolved call 'foo([BlockDom(1,int(64),false,DefaultDist)] int(64))'
+privatizedArrayErrorMessage.chpl:12: error: unresolved call 'foo([BlockDom(1,int(64),false,unmanaged DefaultDist)] int(64))'
 privatizedArrayErrorMessage.chpl:3: note: candidates are: foo(A: C)

--- a/test/arrays/diten/privatizedDomainErrorMessage.good
+++ b/test/arrays/diten/privatizedDomainErrorMessage.good
@@ -1,2 +1,2 @@
-privatizedDomainErrorMessage.chpl:12: error: unresolved call 'foo(BlockDom(1,int(64),false,DefaultDist))'
+privatizedDomainErrorMessage.chpl:12: error: unresolved call 'foo(BlockDom(1,int(64),false,unmanaged DefaultDist))'
 privatizedDomainErrorMessage.chpl:3: note: candidates are: foo(A: C)

--- a/test/arrays/vass/initialization-mapped-1.bad
+++ b/test/arrays/vass/initialization-mapped-1.bad
@@ -1,3 +1,3 @@
-initialization-mapped-1.chpl:8: warning: _domain(unmanaged BlockDom(1,int(64),false,DefaultDist))
+initialization-mapped-1.chpl:8: warning: _domain(unmanaged BlockDom(1,int(64),false,unmanaged DefaultDist))
 initialization-mapped-1.chpl:9: warning: _domain(unmanaged DefaultRectangularDom(1,int(64),false))
 initialization-mapped-1.chpl:10: error: assert failed

--- a/test/classes/initializers/compilerGenerated/arrayField-compInit.bad
+++ b/test/classes/initializers/compilerGenerated/arrayField-compInit.bad
@@ -1,3 +1,3 @@
-arrayField-compInit.chpl:14: error: unresolved call '_new(type C, [BlockDom(1,int(64),false,DefaultDist)] real(64))'
+arrayField-compInit.chpl:14: error: unresolved call '_new(type C, [BlockDom(1,int(64),false,unmanaged DefaultDist)] real(64))'
 arrayField-compInit.chpl:3: note: candidates are: _new(type chpl_t, X: [domain(1,int(64),false)] real(64))
 (prediff deleted module lines)

--- a/test/classes/initializers/phase1/domainMaps/init-dmap-dom-arr.bad
+++ b/test/classes/initializers/phase1/domainMaps/init-dmap-dom-arr.bad
@@ -7,4 +7,4 @@
 2 0
 3 1
 4 2
-$CHPL_HOME/modules/internal/ChapelArray.chpl:897: error: attempt to dereference nil
+$CHPL_HOME/modules/internal/ChapelArray.chpl:907: error: attempt to dereference nil

--- a/test/distributions/bharshbarg/forwardDomDist.good
+++ b/test/distributions/bharshbarg/forwardDomDist.good
@@ -1,4 +1,4 @@
-Block(1,int(64),DefaultDist).printBB()
+Block(1,int(64),unmanaged DefaultDist).printBB()
 boundingBox = {1..20}
 
 DefaultAssociativeDom(int(64),true).printTableSize()

--- a/test/distributions/deitz/test_distribution_syntax2.chpl
+++ b/test/distributions/deitz/test_distribution_syntax2.chpl
@@ -3,7 +3,7 @@ config const n: int = 4;
 {
   use BlockDist;
 
-  var Dist: dmap(Block(rank=2)) = new dmap(new Block(boundingBox={1..n,1..n}));
+  var Dist: dmap(unmanaged Block(rank=2)) = new dmap(new unmanaged Block(boundingBox={1..n,1..n}));
   var Dom: domain(2) dmapped Dist = {1..n,1..n} dmapped Dist;
   var Arr: [Dom] 2*int;
 
@@ -18,7 +18,7 @@ config const n: int = 4;
 {
   use CyclicDist;
 
-  var Dist: dmap(Cyclic(rank=2)) = new dmap(new Cyclic(startIdx=(1,1)));
+  var Dist: dmap(unmanaged Cyclic(rank=2)) = new dmap(new unmanaged Cyclic(startIdx=(1,1)));
   var Dom: domain(2) dmapped Dist = {1..n,1..n} dmapped Dist;
   var Arr: [Dom] 2*int;
 


### PR DESCRIPTION
Addresses .bad file mismatches after PR #9282.

 * Make the sparseLayoutType unmanaged in BlockDist.
 * update .bad files as appropriate

Trivial and not reviewed.

- [x] full local testing
- [x] full local gasnet testing