### PR TITLE
Fix typos

### DIFF
--- a/compiler/include/UnmanagedClassType.h
+++ b/compiler/include/UnmanagedClassType.h
@@ -28,7 +28,7 @@
 * In particular this type is important for unmanaged.                         *
 * Each refers to the AggregateType for the actual class. Because we want      *
 * the AggregateType for each class to store the dispatch parents and other    *
-* important fields, and since each can have multple UnmanagedClassType variants,*
+* important fields, and since each can have multiple UnmanagedClassType variants,*
 * the UnmanagedClassType is not an AggregateType but rather a Type that         *
 * points to the canonical class type (i.e. the AggregateType).                *
 *                                                                             *

--- a/compiler/optimizations/remoteValueForwarding.cpp
+++ b/compiler/optimizations/remoteValueForwarding.cpp
@@ -445,7 +445,7 @@ static void serializeAtCallSites(FnSymbol* fn,  ArgSymbol* arg,
 }
 
 // Insert and return the temp that will hold the deserialized
-// instace of 'arg'.
+// instance of 'arg'.
 // Replace all references to 'arg' within the task function
 // with local references to that temp.
 static VarSymbol* replaceArgWithDeserialized(FnSymbol* fn, ArgSymbol* arg,

--- a/compiler/resolution/loopDetails.cpp
+++ b/compiler/resolution/loopDetails.cpp
@@ -104,7 +104,7 @@ ForLoop* findFollowerForLoop(BlockStmt* block) {
    declared in the same block that is marked with FLAG_CHPL__ITER,
    or NULL if no such variable exists.
  */
-static Symbol* findPreceedingChplIter(Expr* ref)
+static Symbol* findPrecedingChplIter(Expr* ref)
 {
   Symbol* chpl_iter = NULL;
   Expr* e = ref;
@@ -135,7 +135,7 @@ static Symbol* findNewIterLF(Symbol* chpl_iter) {
 }
 
 static Symbol* findNewIterLF(Expr* ref) {
-  Symbol* chpl_iter = findPreceedingChplIter(ref);
+  Symbol* chpl_iter = findPrecedingChplIter(ref);
 
   if (chpl_iter) {
     INT_ASSERT(!strcmp(chpl_iter->name, "chpl__iterLF"));
@@ -326,7 +326,7 @@ void gatherLoopDetails(ForLoop*  forLoop,
 
   // find the variable marked with "chpl__iter" variable
   // in the loop header.
-  Symbol* chpl_iter = findPreceedingChplIter(forLoop);
+  Symbol* chpl_iter = findPrecedingChplIter(forLoop);
 
   bool forall = (chpl_iter != NULL);
   // MPF: should be the same as isLoweredForallLoop but it isn't yet

--- a/compiler/resolution/lowerForalls.cpp
+++ b/compiler/resolution/lowerForalls.cpp
@@ -71,7 +71,7 @@ To lower a forall statement:
   the current variables to be used when a yield statement
   or a ForallStmt is encountered.
 
-* The key places during the tranversal are:
+* The key places during the traversal are:
 
  - The start and end of the iterator body.
  - A task-parallel construct i.e. a call to a task function.
@@ -605,9 +605,9 @@ static void expandYield(ExpandVisitor* EV, CallExpr* yieldCall)
 // At this point in compilation, in certain cases an in-intent formal is
 // represented as a ref-intent formal + copy construction into a "formal temp".
 // See insertFormalTemps(). As a result, in-intent formals are treated
-// as PODs, with argument passing implemented as memcopy,
+// as PODs, with argument passing implemented as memcpy,
 //
-// So, we need to mimick that here. Otherwise we miss copy-construction
+// So, we need to mimic that here. Otherwise we miss copy-construction
 // from the actual into the formal.
 //
 static void addFormalTempSIifNeeded(FnSymbol* cloneTaskFn, Expr* aInit,


### PR DESCRIPTION
Fix typos in UnmanagedClassType.h, lowerForalls.cpp, remoteValueForwarding.cpp, and loopDetails.cpp.

Spot-tested the test added by the PR that introduced the typo in loopDetails.cpp, as the typo was in code.  (test/classes/delete-free/lifetimes/hello-lifetime-checking.chpl)