### PR TITLE
Fix locale_name.prediff

### DIFF
--- a/test/localeModels/dmk/locale_name.prediff
+++ b/test/localeModels/dmk/locale_name.prediff
@@ -1,5 +1,7 @@
 #! /usr/bin/env bash
-COMM_SUB="$CHPL_COMM-$CHPL_COMM_SUBSTRATE"
+COMM=`$CHPL_HOME/util/chplenv/chpl_comm.py`
+SUB=`$CHPL_HOME/util/chplenv/chpl_comm_substrate.py`
+COMM_SUB="$COMM-$SUB"
 if [ "$COMM_SUB" = "gasnet-udp" -a "$GASNET_SPAWNFN" = "L" ]; then
     echo "matches nodeName-nodeID" >$1.good
 elif [ "$COMM_SUB" = "gasnet-smp" ]; then


### PR DESCRIPTION
I was getting comm and substrate values from the env vars, but we don't stuff
the chplenv into prediffs/precomps/preexecs like we do for other files, so
CHPL_COMM_SUBSTRATE wasn't set on gasnet-darwin testing. Other configs use
paratest, and paratest.server ends up propagating and setting the chplenv so
this failure mode was masked in other configurations (and my testing)

This just updates the prediff to explicitly run the chplenv scripts instead of
relying on the env vars.