### PR TITLE
Add a test of a 'type' argument with a constraint and a query expression

### DIFF
--- a/test/functions/generic/genericTypeArgQuery.chpl
+++ b/test/functions/generic/genericTypeArgQuery.chpl
@@ -1,0 +1,12 @@
+proc foo(type t: C(?et)) {
+  writeln(" t is: ", t:string);
+  writeln("et is: ", et: string);
+}
+
+class C {
+  type eltType;
+  var x: eltType;
+}
+
+foo(C(int));
+foo(C(real));

--- a/test/functions/generic/genericTypeArgQuery.good
+++ b/test/functions/generic/genericTypeArgQuery.good
@@ -1,0 +1,4 @@
+ t is: C(int(64))
+et is: int(64)
+ t is: C(real(64))
+et is: real(64)


### PR DESCRIPTION
While answering a user question last week, I was excited to find that
the following case worked as I'd hoped: putting a generic type
constraint on a `type` argument supported the ability to do queries of
the generic elements of the type, as in value argument contexts:

```chapel
proc foo(type t: C(?t2)) ...
```

Doing some grepping I wasn't easily finding instances of other tests
that tried to exercise this pattern so thought I'd add this to lock
the behavior in or at least put epsilon more weight on it.