### PR TITLE
Make some late-breaking CHANGES.md edits (cp PR #9360)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@ Bug Fixes
 * fixed a bug in which postinit() was not called for generic records
 * fixed a bug in which most launchers would not work with 'make install'
 * fixed a portability problem w.r.t. our processing of /proc/cpuinfo
-* fixed a bug in which LinearAlgebra.sparse.eye() would unintentionally promote
+* fixed a bug in which LinearAlgebra.Sparse.eye() would unintentionally promote
 
 Cray-specific Changes
 ---------------------
@@ -29,7 +29,7 @@ Documentation
 
 Packaging Changes
 -----------------
-* converted our use of easy_install for Python packages to pip
+* converted our use of easy_install to pip when installing virtualenv
 
 Third-Party Software Changes
 ----------------------------


### PR DESCRIPTION
This minor correction to the CHANGES.md file will not make it into the Chapel 1.17.1 release tarball or other release products, so this commit will not be included the corresponding release tag.  

At least the online copy of [CHANGES.md](https://github.com/chapel-lang/chapel/blob/release/1.17/CHANGES.md) will be improved. 