### PR TITLE
Use different code for makeRawNew in resolve

### DIFF
--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -1406,9 +1406,3 @@ new_Expr(const char* format, va_list vl) {
   INT_ASSERT(stack.size() == 1);
   return stack.top();
 }
-
-CallExpr* makeRawNew(Expr* typeArg, Expr* arg) {
-  return new CallExpr(PRIM_NEW, typeArg, arg,
-                      new NamedExpr("_chpl_manager",
-                                    new SymExpr(dtUnmanaged->symbol)));
-}

--- a/compiler/include/expr.h
+++ b/compiler/include/expr.h
@@ -384,8 +384,6 @@ Expr* getNextExpr(Expr* expr);
 Expr* new_Expr(const char* format, ...);
 Expr* new_Expr(const char* format, va_list vl);
 
-CallExpr* makeRawNew(Expr* typeArg, Expr* arg);
-
 #ifdef HAVE_LLVM
 llvm::Value* createTempVarLLVM(llvm::Type* type, const char* name);
 llvm::Value* createTempVarLLVM(llvm::Type* type);

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -912,6 +912,8 @@ static void processSyntacticDistributions(CallExpr* call) {
  */
 static void processManagedNew(CallExpr* newCall) {
   SET_LINENO(newCall);
+  /*if (newCall->id == 190325 || newCall->id == 190284)
+    gdbShouldBreakHere();*/
   if (newCall->inTree() && newCall->isPrimitive(PRIM_NEW)) {
     if (CallExpr* callManager = toCallExpr(newCall->get(1))) {
       if (callManager->numActuals() == 1) {

--- a/compiler/resolution/implementForallIntents.cpp
+++ b/compiler/resolution/implementForallIntents.cpp
@@ -2086,7 +2086,9 @@ static Symbol* setupRiGlobalOp(ForallStmt* fs, Symbol* fiVarSym,
 
   {
     NamedExpr* newArg = new NamedExpr("eltType", eltTypeArg);
-    CallExpr* newCall = makeRawNew(new SymExpr(riTypeSym), newArg);
+    CallExpr* newCall = new CallExpr(PRIM_NEW, new SymExpr(riTypeSym), newArg,
+			  new NamedExpr("_chpl_manager",
+					new SymExpr(dtUnmanaged->symbol)));
     hld->insertAtTail(new CallExpr(PRIM_MOVE, globalOp, newCall));
   }
 

--- a/test/users/ren/mink-blc-arg.future
+++ b/test/users/ren/mink-blc-arg.future
@@ -1,0 +1,11 @@
+feature request: arguments to user-defined reductions
+
+In our early plans for user-defined reductions, we'd talked about
+supporting the ability to pass arguments to the implementing class'
+constructor.  This test captures that concept.  I think the concept is
+important -- the syntax proposed here seems intuitive but is not
+crucial.  Note that there's a bit of a similarity here with our desire
+to turn reductions into more of a value type and/or removing the
+explicit call to new and making it look like a class constructor call
+to the user.
+


### PR DESCRIPTION
The makeRawNew function was called both from build and
from implementForallIntents during resolution. The problem
with that is that the AST for new is slightly different before
and after normalize. So, solve the problem by moving the function
to build.cpp and getting it to generate the pre-normalize pattern
and then using the body the function in implementForallIntents with
the post-normalize pattern.