### PR TITLE
Address problems with GMP after moving out of runtime

### DIFF
--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -246,30 +246,27 @@ module BigInteger {
     }
 
     proc numLimbs : uint {
-      var mpz_struct = this.mpz[1];
-
-      return chpl_gmp_mpz_nlimbs(mpz_struct).safeCast(uint);
+      return chpl_gmp_mpz_nlimbs(this.mpz);
     }
 
-    proc get_limbn(n: uint) : uint {
-      const n_ = n.safeCast(mp_size_t);
-      var   ret: mp_limb_t;
+    proc get_limbn(n: integral) : uint {
+      var   ret: uint;
 
       if _local {
-        ret = mpz_getlimbn(this.mpz, n_);
+        ret = chpl_gmp_mpz_getlimbn(this.mpz, n);
 
       } else if this.localeId == chpl_nodeID {
-        ret = mpz_getlimbn(this.mpz, n_);
+        ret = chpl_gmp_mpz_getlimbn(this.mpz, n);
 
       } else {
         const thisLoc = chpl_buildLocaleID(this.localeId, c_sublocid_any);
 
         on __primitive("chpl_on_locale_num", thisLoc) {
-          ret = mpz_getlimbn(this.mpz, n_);
+          ret = chpl_gmp_mpz_getlimbn(this.mpz, n);
         }
       }
 
-      return ret.safeCast(uint);
+      return ret;
     }
 
     proc mpzStruct() : __mpz_struct {

--- a/modules/standard/GMP.chpl
+++ b/modules/standard/GMP.chpl
@@ -158,7 +158,8 @@ module GMP {
   extern type mp_size_t       = c_long;
 
   /* The GMP ``mp_limb_t``   type. */
-  extern type mp_limb_t       = uint(64);
+  /* This is normally uint(64) but can depend on configuration. */
+  extern type mp_limb_t;
 
   /* The GMP `mp_bits_per_limb`` constant */
   extern const mp_bits_per_limb: c_int;
@@ -806,8 +807,11 @@ module GMP {
   // 5.16 Special Functions
   //
 
-  extern proc mpz_getlimbn(const ref op: mpz_t,
-                           n: mp_size_t) : mp_limb_t;
+  // This is private because you'd have to use a cast
+  // primitive to actually use the result.
+  // chpl_gmp_mpz_getlimbn might do better.
+  private extern proc mpz_getlimbn(const ref op: mpz_t,
+                                   n: mp_size_t) : mp_limb_t;
 
   extern proc mpz_size(const ref x: mpz_t): size_t;
 
@@ -1138,12 +1142,32 @@ module GMP {
     // get a pointer to the limbs
     var dst_limbs_ptr = chpl_gmp_mpz_struct_limbs(ret[1]);
 
-    __primitive("chpl_comm_array_get", dst_limbs_ptr[0],
-                                       src_locale, src_limbs_ptr[0],
-                                       new_size);
+    __primitive("chpl_comm_get", dst_limbs_ptr[0],
+                                 src_locale, src_limbs_ptr[0],
+                                 (new_size:size_t)*c_sizeof(mp_limb_t));
 
     // Update the sign and size of the number
     chpl_gmp_mpz_set_sign_size(ret, src_sign_size);
+  }
+
+  /* Return the number of limbs used in the number */
+  proc chpl_gmp_mpz_nlimbs(const ref from: mpz_t) : uint(64) {
+    var x = chpl_gmp_mpz_struct_sign_size(from[1]);
+    return (abs(x)):uint(64);
+  }
+
+  /* Return the i'th limb used in the number (counting from 0) */
+  proc chpl_gmp_mpz_getlimbn(const ref from: mpz_t, n:integral) : uint(64) {
+    var i = n.safeCast(mp_size_t);
+    // OK to cast result to maximal uint for two reasons:
+    //  1. GMP always uses unsigned limbs
+    //  2. This function is really "getting the bits" so it would be
+    //     OK to lose the sign
+    // This uses __primitive cast because mp_limb_t is opaque to the Chapel
+    // compiler (because it might vary depending on GMP configuration/platform)
+    var limb = mpz_getlimbn(from, i);
+    var ret = __primitive("cast", uint(64), limb);
+    return ret;
   }
 
   /* Return the number of limbs allocated in an __mpz_struct */

--- a/modules/standard/GMP.chpl
+++ b/modules/standard/GMP.chpl
@@ -136,10 +136,12 @@ module GMP {
   // Initialize GMP to use Chapel's allocator
   //
   proc chpl_gmp_init() {
-    extern proc mp_set_memory_functions(alloc:c_fn_ptr, realloc:c_fn_ptr, free:c_fn_ptr);
-    mp_set_memory_functions(c_ptrTo(chpl_gmp_alloc),
-                            c_ptrTo(chpl_gmp_realloc),
-                            c_ptrTo(chpl_gmp_free));
+    extern proc chpl_gmp_mp_set_memory_functions(alloc:c_fn_ptr,
+                                                 realloc:c_fn_ptr,
+                                                 free:c_fn_ptr);
+    chpl_gmp_mp_set_memory_functions(c_ptrTo(chpl_gmp_alloc),
+                                     c_ptrTo(chpl_gmp_realloc),
+                                     c_ptrTo(chpl_gmp_free));
   }
 
   // Initialize GMP library on all locales

--- a/modules/standard/GMPHelper/chplgmp.h
+++ b/modules/standard/GMPHelper/chplgmp.h
@@ -28,6 +28,17 @@
 #include "chpl-comm-compiler-macros.h"
 #include "chpl-comm.h"
 
+// Need this workaround for some compilers until the Chapel
+// compiler moves away from representing all C fn pointers as void*
+static inline
+void chpl_gmp_mp_set_memory_functions(c_fn_ptr alloc,
+                                      c_fn_ptr realloc,
+                                      c_fn_ptr free) {
+  mp_set_memory_functions((void *(*) (size_t)) alloc,
+                          (void *(*) (void *, size_t, size_t)) realloc,
+                          (void (*) (void *, size_t)) free);
+}
+
 static inline
 mp_size_t chpl_gmp_mpz_struct_nalloc(__mpz_struct from) {
   return from._mp_alloc;

--- a/test/library/standard/GMP/ferguson/bigint_getlimbs.chpl
+++ b/test/library/standard/GMP/ferguson/bigint_getlimbs.chpl
@@ -1,0 +1,63 @@
+use BigInteger;
+
+// The default is to not output the limbs,
+// but to go through the motions of accessing them.
+// The reason is that the limb size / configuration
+// can vary between platforms.
+config const debug = false;
+
+var x:bigint;
+x.fac(100);
+
+const n = x.numLimbs;
+if debug then writeln("numLimbs is ", n);
+
+var checkn = mpz_size(x.mpz);
+assert(n == checkn);
+
+var A:[0..#n] uint;
+for i in 0..#n {
+  var limb = x.get_limbn(i:uint);
+  if debug then writeln("limb ", i, " is ", limb);
+  A[i] = limb;
+}
+
+// We'll access the limbs in different ways and
+// make sure they match.
+var B:[0..#n] uint;
+var C:[0..#n] uint;
+
+on Locales[numLocales-1] {
+  // Check getting size from other locale
+  var checkn = x.numLimbs;
+  assert(n == checkn);
+
+  // Read each limb from the other locale
+  for i in 0..#n {
+    var limb = x.get_limbn(i:uint);
+    if debug then writeln("limb ", i, " is ", limb);
+    B[i] = limb;
+  }
+}
+
+on Locales[numLocales-1] {
+  // Copy the entire number to the current locale.
+  var local_x = x;
+  
+  // Check getting size from copy
+  var checkn = local_x.numLimbs;
+  assert(n == checkn);
+
+  // Read each limb from the local copy
+  for i in 0..#n {
+    var limb = local_x.get_limbn(i:uint);
+    if debug then writeln("limb ", i, " is ", limb);
+    C[i] = limb;
+  }
+}
+
+// Now make sure that A, B, C match
+for i in 0..#n {
+  assert(A[i] == B[i]);
+  assert(B[i] == C[i]);
+}


### PR DESCRIPTION
This PR resolves testing failures after PR #8944.

### Addressing problems with void* vs C function pointer types

Some C compilers in nightly testing caused failures because they cared
that void* wasn't the matching argument type for mp_set_memory_functions.
To overcome that, I've wrapped mp_set_memory_functions with a C function
that simply casts the c_fn_ptr (void*) to the appropriate function
pointer type.

Issue #9411 describes why this workaround is necessary and what the
real solution would be.


### Addressing problems with pointer type mismatch for mp_limb_t*

Because GMP can be configured to create a different mp_limb_t
on different systems (and in fact it does so on Cygwin), the
GMP module should not assume anything about the size of mp_limb_t.
(Previous to this PR it assumed it matched `uint(64)`).
This PR makes that type opaque. Some related code needed
to be adjusted based on that change:
    
* chpl_gmp_get_mpz now uses chpl_comm_get and sizeof
   instead of chpl_comm_array_get
* added chpl_gmp_mpz_nlimbs and chpl_gmp_mpz_getlimbn. These are
   callable from user code & used in the BigInteger module to
   get the number of limbs / the i'th limb. These both return uint(64)
   always, so that the issue with mp_size_t varying is less problematic.
 * BigInteger functions numLimbs and get_limbn now use the uint(64)
   versions above.
 * mpz_getlimbn is now private to GMP.chpl since it can't be
   used right now without internal compiler knowledge, since the
   Chapel compiler won't understand its return type.
    
While adjusting bigint's numLimbs and get_limbn I noticed that these do not
appear to be tested, so I added a (multilocale even!) test that
they work correctly.


### Testing & Review

- [x] verified that it resolves the problem with pidigits and PrgEnv-Cray on a Cray XC
- [x] cygwin GMP failures resolved
- [x] test/library/standard/GMP passes with GASNet
- [x] full local testing

Reviewed by @ronawho - thanks!