### PR TITLE
Fix typed sync variable initialization

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5151,9 +5151,12 @@ static void resolveInitVar(CallExpr* call) {
       targetType = useType;
     }
 
-    // Ignore the target type if it's the same & not a runtime type.
+    // Ignore the target type if it's the same & not a runtime type
+    // and not sync/single (since sync/single initCopy returns a different type)
     if (targetType == srcType &&
-        !targetType->symbol->hasFlag(FLAG_HAS_RUNTIME_TYPE)) {
+        !targetType->symbol->hasFlag(FLAG_HAS_RUNTIME_TYPE) &&
+        !isSyncType(srcType) &&
+        !isSingleType(srcType)) {
       targetType = srcType;
       targetTypeExpr = NULL;
     }

--- a/test/parallel/sync/diten/returnSync.bad
+++ b/test/parallel/sync/diten/returnSync.bad
@@ -1,1 +1,0 @@
-internal error: pthread_mutex_lock() failed


### PR DESCRIPTION
This is a follow-on to PR #9355.

It fixes a failure in fifo configurations for the test
```
 parallel/sync/diten/returnSync
```

Since sync/single have an initCopy that returns a different type,
they need to generate PRIM_COERCE rather than initCopy for the
case of typed variable initialization like

``` chapel
 var x: sync int = returnsSync();
```

- [x] full local testing
- [x] full local quickstart testing

Reviewed by @lydia-duncan - thanks!