### PR TITLE
Skip ZMQ tests on gasnet configuration

### DIFF
--- a/test/library/packages/ZMQ.skipif
+++ b/test/library/packages/ZMQ.skipif
@@ -1,13 +1,28 @@
 #!/usr/bin/env python
 
-# The ZMQ package requires the zmq library.
-#
-# Installation of the ZMQ library is detected with the find_library function,
-# which looks for the appropriate dynamic library (e.g. libzmq.so).
-# Note that if the dynamic library is found, this test assumes that the
-# header and static library are available.
+"""
+ The ZMQ package requires the zmq library.
+
+ Installation of the ZMQ library is detected with the find_library function,
+ which looks for the appropriate dynamic library (e.g. libzmq.so).
+ Note that if the dynamic library is found, this test assumes that the
+ header and static library are available.
+
+ Skip CHPL_COMM != none until #9425 is resolved.
+"""
 
 from __future__ import print_function
 from ctypes.util import find_library
+import os
 
-print(find_library('zmq') is None)
+# Is ZMQ available?
+zmq_found = find_library('zmq') is not None
+
+# Are we configured for non-multilocale?
+is_local = os.getenv('CHPL_COMM', 'none') == 'none'
+
+# OK contains the conditions that must be met to run the test
+OK = is_local and zmq_found
+
+# Skip if not OK
+print(not OK)


### PR DESCRIPTION
Skip `CHPL_COMM != none` until #9425 is resolved.