### PR TITLE
'None' entries in Series ADT

### DIFF
--- a/test/library/standard/Dataframes/psahabu/ArithNoneSeries.chpl
+++ b/test/library/standard/Dataframes/psahabu/ArithNoneSeries.chpl
@@ -1,0 +1,28 @@
+use Dataframes;
+
+var I = new TypedIndex(["A", "B", "C", "D", "E"]);
+var V1 = [true, false, true, false, true];
+var V2 = [false, true, false, true, false];
+
+var oneDigit = new TypedSeries([1, 2, 3, 4, 5], I, V1);
+var twoDigit = new TypedSeries([10, 20, 30, 40, 50], I, V1);
+var twoDigitInv = new TypedSeries([10, 20, 30, 40, 50], I, V2);
+
+writeln("oneDigit:");
+writeln(oneDigit);
+writeln("\ntwoDigit:");
+writeln(twoDigit);
+writeln("\ntwoDigitInv:");
+writeln(twoDigitInv);
+
+writeln("\noneDigit + twoDigit:");
+writeln(oneDigit + twoDigit);
+
+writeln("\noneDigit - twoDigit:");
+writeln(oneDigit - twoDigit);
+
+writeln("\noneDigit + twoDigitInv:");
+writeln(oneDigit + twoDigitInv);
+
+writeln("\noneDigit - twoDigitInv:");
+writeln(oneDigit - twoDigitInv);

--- a/test/library/standard/Dataframes/psahabu/ArithNoneSeries.chpl
+++ b/test/library/standard/Dataframes/psahabu/ArithNoneSeries.chpl
@@ -10,8 +10,10 @@ var twoDigitInv = new TypedSeries([10, 20, 30, 40, 50], I, V2);
 
 writeln("oneDigit:");
 writeln(oneDigit);
+
 writeln("\ntwoDigit:");
 writeln(twoDigit);
+
 writeln("\ntwoDigitInv:");
 writeln(twoDigitInv);
 

--- a/test/library/standard/Dataframes/psahabu/ArithNoneSeries.good
+++ b/test/library/standard/Dataframes/psahabu/ArithNoneSeries.good
@@ -1,0 +1,55 @@
+oneDigit:
+A	1
+B	None
+C	3
+D	None
+E	5
+dtype: int(64)
+
+twoDigit:
+A	10
+B	None
+C	30
+D	None
+E	50
+dtype: int(64)
+
+twoDigitInv:
+A	None
+B	20
+C	None
+D	40
+E	None
+dtype: int(64)
+
+oneDigit + twoDigit:
+A	11
+B	None
+C	33
+D	None
+E	55
+dtype: int(64)
+
+oneDigit - twoDigit:
+A	-9
+B	None
+C	-27
+D	None
+E	-45
+dtype: int(64)
+
+oneDigit + twoDigitInv:
+A	None
+B	None
+C	None
+D	None
+E	None
+dtype: int(64)
+
+oneDigit - twoDigitInv:
+A	None
+B	None
+C	None
+D	None
+E	None
+dtype: int(64)

--- a/test/library/standard/Dataframes/psahabu/ArithNoneSeries.py
+++ b/test/library/standard/Dataframes/psahabu/ArithNoneSeries.py
@@ -1,0 +1,27 @@
+import pandas as pd
+
+I = ["A", "B", "C", "D", "E"]
+oneDigit = pd.Series([1, None, 3, None, 5], pd.Index(I))
+twoDigit = pd.Series([10, None, 30, None, 50], pd.Index(I))
+twoDigitInv = pd.Series([None, 20, None, 40, None], pd.Index(I))
+
+print "oneDigit:"
+print oneDigit
+print
+print "twoDigit:"
+print twoDigit
+print
+print "twoDigitInv:"
+print twoDigitInv
+print
+print "oneDigit + twoDigit:"
+print oneDigit + twoDigit
+print
+print "oneDigit - twoDigit:"
+print oneDigit - twoDigit
+print
+print "oneDigit + twoDigitInv:"
+print oneDigit + twoDigitInv
+print
+print "oneDigit - twoDigitInv:"
+print oneDigit - twoDigitInv

--- a/test/library/standard/Dataframes/psahabu/ContainSeries.py
+++ b/test/library/standard/Dataframes/psahabu/ContainSeries.py
@@ -1,0 +1,10 @@
+import pandas as pd
+
+I = ["A", "B", "C", "D", "E"]
+A = ["a", "b", "c", "d", "e"]
+letters = pd.Series(A, pd.Index(I))
+
+print letters
+print
+print "contains A: " + str(letters.index.contains("A"))
+print "contains F: " + str(letters.index.contains("F"))

--- a/test/library/standard/Dataframes/psahabu/FilterNoneSeries.chpl
+++ b/test/library/standard/Dataframes/psahabu/FilterNoneSeries.chpl
@@ -1,0 +1,22 @@
+use Dataframes;
+
+var I = new TypedIndex(["A", "B", "C", "D", "E"]);
+var V1 = [true, false, true, false, true];
+var V2 = [false, true, false, true, false];
+
+var oneDigit = new TypedSeries([1, 2, 3, 4, 5], I, V1);
+var twoDigit = new TypedSeries([10, 20, 30, 40, 50], I, V1);
+var twoDigitInv = new TypedSeries([10, 20, 30, 40, 50], I, V2);
+
+writeln("oneDigit:");
+writeln(oneDigit);
+writeln("\ntwoDigit:");
+writeln(twoDigit);
+writeln("\ntwoDigitInv:");
+writeln(twoDigitInv);
+
+writeln("\noneDigit < 3");
+writeln(oneDigit < 3);
+
+writeln("\ntwoDigit > 30");
+writeln(twoDigit > 30);

--- a/test/library/standard/Dataframes/psahabu/FilterNoneSeries.chpl
+++ b/test/library/standard/Dataframes/psahabu/FilterNoneSeries.chpl
@@ -10,13 +10,15 @@ var twoDigitInv = new TypedSeries([10, 20, 30, 40, 50], I, V2);
 
 writeln("oneDigit:");
 writeln(oneDigit);
+
 writeln("\ntwoDigit:");
 writeln(twoDigit);
+
 writeln("\ntwoDigitInv:");
 writeln(twoDigitInv);
 
 writeln("\noneDigit < 3");
-writeln(oneDigit < 3);
+writeln(oneDigit[oneDigit < 3]);
 
 writeln("\ntwoDigit > 30");
-writeln(twoDigit > 30);
+writeln(twoDigit[twoDigit > 30]);

--- a/test/library/standard/Dataframes/psahabu/FilterNoneSeries.chpl
+++ b/test/library/standard/Dataframes/psahabu/FilterNoneSeries.chpl
@@ -2,20 +2,15 @@ use Dataframes;
 
 var I = new TypedIndex(["A", "B", "C", "D", "E"]);
 var V1 = [true, false, true, false, true];
-var V2 = [false, true, false, true, false];
 
 var oneDigit = new TypedSeries([1, 2, 3, 4, 5], I, V1);
 var twoDigit = new TypedSeries([10, 20, 30, 40, 50], I, V1);
-var twoDigitInv = new TypedSeries([10, 20, 30, 40, 50], I, V2);
 
 writeln("oneDigit:");
 writeln(oneDigit);
 
 writeln("\ntwoDigit:");
 writeln(twoDigit);
-
-writeln("\ntwoDigitInv:");
-writeln(twoDigitInv);
 
 writeln("\noneDigit < 3");
 writeln(oneDigit[oneDigit < 3]);

--- a/test/library/standard/Dataframes/psahabu/FilterNoneSeries.good
+++ b/test/library/standard/Dataframes/psahabu/FilterNoneSeries.good
@@ -1,0 +1,31 @@
+oneDigit:
+A	1
+B	None
+C	3
+D	None
+E	5
+dtype: int(64)
+
+twoDigit:
+A	10
+B	None
+C	30
+D	None
+E	50
+dtype: int(64)
+
+twoDigitInv:
+A	None
+B	20
+C	None
+D	40
+E	None
+dtype: int(64)
+
+oneDigit < 3
+A	1
+dtype: int(64)
+
+twoDigit > 30
+E	50
+dtype: int(64)

--- a/test/library/standard/Dataframes/psahabu/FilterNoneSeries.good
+++ b/test/library/standard/Dataframes/psahabu/FilterNoneSeries.good
@@ -14,14 +14,6 @@ D	None
 E	50
 dtype: int(64)
 
-twoDigitInv:
-A	None
-B	20
-C	None
-D	40
-E	None
-dtype: int(64)
-
 oneDigit < 3
 A	1
 dtype: int(64)

--- a/test/library/standard/Dataframes/psahabu/FilterNoneSeries.py
+++ b/test/library/standard/Dataframes/psahabu/FilterNoneSeries.py
@@ -1,0 +1,17 @@
+import pandas as pd
+
+I = ["A", "B", "C", "D", "E"]
+oneDigit = pd.Series([1, None, 3, None, 5], pd.Index(I))
+twoDigit = pd.Series([10, None, 30, None, 50], pd.Index(I))
+
+print "oneDigit:"
+print oneDigit
+print
+print "twoDigit:"
+print twoDigit
+print
+print "oneDigit < 3:"
+print oneDigit[oneDigit < 3]
+print
+print "twoDigit > 30:"
+print twoDigit[twoDigit > 30]

--- a/test/library/standard/Dataframes/psahabu/IterNoneSeries.chpl
+++ b/test/library/standard/Dataframes/psahabu/IterNoneSeries.chpl
@@ -6,26 +6,31 @@ var V = [true, false, true, false, true];
 
 var letters = new TypedSeries(A, new TypedIndex(I), V);
 
-writeln();
+writeln("these():");
 for t in letters do
   writeln(t);
 
 writeln();
+writeln("items():");
 for t in letters.items(string) do
   writeln(t);
 
 writeln();
+writeln("fast():");
 for t in letters.fast() do
   writeln(t);
 
 writeln();
+writeln("items_fast():");
 for t in letters.items_fast(string) do
   writeln(t);
 
 writeln();
+writeln("_these():");
 for t in letters._these() do
   writeln(t);
 
 writeln();
+writeln("_items():");
 for t in letters._items(string) do
   writeln(t);

--- a/test/library/standard/Dataframes/psahabu/IterNoneSeries.chpl
+++ b/test/library/standard/Dataframes/psahabu/IterNoneSeries.chpl
@@ -5,15 +5,6 @@ var I = ["A", "B", "C", "D", "E"];
 var V = [true, false, true, false, true];
 
 var letters = new TypedSeries(A, new TypedIndex(I), V);
-writeln(letters);
-
-/*
-for i in letters.idx:TypedIndex(string) do
-  writeln(i);
-
-writeln();
-for i in (letters.idx:TypedIndex(string)).items() do
-  writeln(i);
 
 writeln();
 for t in letters do
@@ -22,4 +13,19 @@ for t in letters do
 writeln();
 for t in letters.items(string) do
   writeln(t);
- */
+
+writeln();
+for t in letters.fast() do
+  writeln(t);
+
+writeln();
+for t in letters.items_fast(string) do
+  writeln(t);
+
+writeln();
+for t in letters._these() do
+  writeln(t);
+
+writeln();
+for t in letters._items(string) do
+  writeln(t);

--- a/test/library/standard/Dataframes/psahabu/IterNoneSeries.chpl
+++ b/test/library/standard/Dataframes/psahabu/IterNoneSeries.chpl
@@ -1,0 +1,25 @@
+use Dataframes;
+
+var A = ["a", "b", "c", "d", "e"];
+var I = ["A", "B", "C", "D", "E"];
+var V = [true, false, true, false, true];
+
+var letters = new TypedSeries(A, new TypedIndex(I), V);
+writeln(letters);
+
+/*
+for i in letters.idx:TypedIndex(string) do
+  writeln(i);
+
+writeln();
+for i in (letters.idx:TypedIndex(string)).items() do
+  writeln(i);
+
+writeln();
+for t in letters do
+  writeln(t);
+
+writeln();
+for t in letters.items(string) do
+  writeln(t);
+ */

--- a/test/library/standard/Dataframes/psahabu/IterNoneSeries.good
+++ b/test/library/standard/Dataframes/psahabu/IterNoneSeries.good
@@ -1,0 +1,37 @@
+these():
+a
+c
+e
+
+items():
+(A, a)
+(C, c)
+(E, e)
+
+fast():
+a
+b
+c
+d
+e
+
+items_fast():
+(A, a)
+(B, b)
+(C, c)
+(D, d)
+(E, e)
+
+_these():
+(true, a)
+(false, b)
+(true, c)
+(false, d)
+(true, e)
+
+_items():
+(true, (A, a))
+(false, (B, b))
+(true, (C, c))
+(false, (D, d))
+(true, (E, e))

--- a/test/library/standard/Dataframes/psahabu/IterNoneSeries.py
+++ b/test/library/standard/Dataframes/psahabu/IterNoneSeries.py
@@ -1,0 +1,24 @@
+import pandas as pd
+
+I = ["A", "B", "C", "D", "E"]
+A = ["a", None, "c", None, "e"]
+
+letters = pd.Series(A, pd.Index(I))
+
+for i in letters.index:
+    print i
+
+print
+for i in zip(letters.index, range(0, 5)):
+    print i 
+
+print
+for i in letters:
+    print i
+
+print
+for i in letters.items():
+    print i
+
+print
+print letters


### PR DESCRIPTION
### Motivation
The motivation for `None` entires in Series ADT can be found in the connected issue.

### Implementation
A `valid_bits` array has been added to the `TypedSeries` class, along with internal iterators emitting those bits. These iterators were then utilized by the `union`, `map`, and `filter` operations to properly process the underlying data. These operations are still carried out on the underlying data as if it were valid, however it is masked with the `valid_bits` array in the final result.

* For `union`, both datum have to be valid for the output to be valid.
* For `map` and `filter`, the original datum has to be valid for the output to be valid.

### Pandas
Included in this PR are pandas equivalents to our tests. Note that the only significant difference is that pandas also makes use of `NaN`, whereas we simply use `None` for all empty cases. There are minor differences in the indenting of None when printing a Series.