### PR TITLE
Allow specifying /proc/cpuinfo system file name via the environment

### DIFF
--- a/runtime/src/chplsys.c
+++ b/runtime/src/chplsys.c
@@ -539,7 +539,7 @@ static void getCpuInfo_once(void) {
 
   const char* fname = chpl_env_rt_get("PROC_CPUINFO_FNAME", "/proc/cpuinfo");
   if ((f = fopen(fname, "r")) == NULL)
-    chpl_internal_error("Cannot open /proc/cpuinfo");
+    chpl_internal_error_v("Cannot open %s", fname);
 
   //
   // If f is NULL, we should have exited by now, but Coverity doesn't

--- a/runtime/src/chplsys.c
+++ b/runtime/src/chplsys.c
@@ -29,6 +29,7 @@
 // Other Chapel Header
 #include "chpl-align.h"
 #include "chpl-comm.h"
+#include "chpl-env.h"
 #include "chpl-mem.h"
 #include "chpl-tasks.h"
 #include "chpltypes.h"
@@ -536,7 +537,8 @@ static void getCpuInfo_once(void) {
   int physId;
   int coreId;
 
-  if ((f = fopen("/proc/cpuinfo", "r")) == NULL)
+  const char* fname = chpl_env_rt_get("PROC_CPUINFO_FNAME", "/proc/cpuinfo");
+  if ((f = fopen(fname, "r")) == NULL)
     chpl_internal_error("Cannot open /proc/cpuinfo");
 
   //


### PR DESCRIPTION
On Linux-based systems the runtime looks at `/proc/cpuinfo` to help figure
out how many processors and hardware threads are present.  Here, allow
the name of this file to be specified via the environment.  This is a
maintenance aid, so that we can feed outside users' `/proc/cpuinfo` files
into the runtime when debugging problems.

While here I also added support for a varargs version of the internal error
function, called `chpl_internal_error_v()`.  I've wanted this for a long time
and this was a good excuse to add it.