### PR TITLE
Add a .compopts file for checkReturnedArray2

### DIFF
--- a/test/arrays/return/checkReturnedArray2.compopts
+++ b/test/arrays/return/checkReturnedArray2.compopts
@@ -1,0 +1,1 @@
+--bounds-checks


### PR DESCRIPTION
This test used to be a future but I made it a regular
test in PR #9355. But the expected output is failure
from array size mismatch detected at runtime - and those
checks only run with --bounds-checks on when we compile.
So add that to a .compopts file.

Trivial and not reviewed.