### PR TITLE
Fix linear algebra sparse matpow

### DIFF
--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -611,18 +611,10 @@ proc _matmatMult(A: [?Adom] ?eltType, B: [?Bdom] eltType)
   return C;
 }
 
-// D is a domain to copy
-pragma "no doc"
-proc _makeMatrix(D, type eltType) {
-  var A:[D] eltType;
-  return A;
-}
 
 /* Return the matrix ``A`` to the ``bth`` power, where ``b`` is a positive
    integral type. */
 proc matPow(A: [], b) where isNumeric(b) {
-  use BitOps;
-
   // TODO -- flatten recursion into while-loop
   if !isIntegral(b) then
     // TODO -- support all reals with Sylvester's formula
@@ -630,78 +622,26 @@ proc matPow(A: [], b) where isNumeric(b) {
   if !isSquare(A) then
     halt("Array not square");
 
-  // Handle simple base cases
-  if b < 0 {
-    halt("Negative powers not yet supported");
-  } else if b == 0 {
-    return eye(A.domain, A.eltType);
-  } else if b == 1 {
-    return A;
-  }
-
-  // topbit is the bit position of the top bit set
-  // 2**topbit is the largest power of 2 in b
-  var topbit = numBits(b.type) - clz(b) - 1;
-
-  var toPowerTwoD:[1..topbit] A.domain.type;
-
-  // This makes a skyline array of arrays
-  // each array has its own unique domain
-  var toPowerTwoA = for i in 1..topbit do
-                        _makeMatrix(toPowerTwoD[i], A.eltType);
-
-  // Set the base case of the array (A**(2**1) == A**2 == A*A)
-  {
-    // do the multiply
-    var tmp = dot(A,A);
-    // copy domain and array
-    toPowerTwoD[1] = tmp.domain;
-    toPowerTwoA[1] = tmp;
-  }
-
-  // Compute each of the A**(2**i)
-  for i in 2..topbit {
-    // do the multiply
-    var tmp = dot(toPowerTwoA[i-1], toPowerTwoA[i-1]);
-    // copy domain and array
-    toPowerTwoD[i] = tmp.domain;
-    toPowerTwoA[i] = tmp;
-  }
-
-  var resultD: A.domain.type;
-  var resultA: [resultD] A.eltType;
-
-  // Set up resultA based upon the last bit
-  if (b & 1) == 0 {
-    // b is even, so start with identity
-    var tmp = eye(A.domain, A.eltType);
-    // copy domain and array
-    resultD = tmp.domain;
-    resultA = tmp;
-  } else {
-    // b is odd, so start with A
-    // copy domain and array
-    resultD = A.domain;
-    resultA = A;
-  }
-
-  // Now compute the result based on the squares
-  // This does not consider the last bit (handled above)
-  for i in 1..topbit {
-    // toPowerTwoA[i] stores A**(2**i)
-    // does b include 2**i ?
-    if (b >> i) & 1 == 1 {
-      // do the multiply
-      var tmp = dot(resultA, toPowerTwoA[i]);
-      // copy domain and array
-      resultD = tmp.domain;
-      resultA = tmp;
-    }
-  }
-
-  return resultA;
+  return _expBySquaring(A, b).value;
 }
 
+// This is a workaround for undesired use
+// of runtime-type of the input array x below
+// in the return type. See also issue #9438.
+record _wrap {
+  var value;
+}
+
+pragma "no doc"
+/* Exponentiate by squaring recursively */
+private proc _expBySquaring(x: ?t, n): _wrap(t) {
+  // TODO -- _expBySquaring(pinv(x), -n);
+  if n < 0  then halt("Negative powers not yet supported");
+  else if n == 0  then return new _wrap(eye(x.domain, x.eltType));
+  else if n == 1  then return new _wrap(x);
+  else if n%2 == 0  then return _expBySquaring(dot(x, x), n / 2);
+  else return new _wrap(dot(x, _expBySquaring(dot(x, x), (n - 1) / 2).value));
+}
 
 /* Return cross-product of 3-element vectors ``A`` and ``B`` with domain of
   ``A`` */

--- a/test/library/packages/LinearAlgebra/correctness/correctness.chpl
+++ b/test/library/packages/LinearAlgebra/correctness/correctness.chpl
@@ -375,6 +375,13 @@ use TestUtils;
 
   assertEqual(A2, B2, "matPow(A, 2)");
   assertEqual(A3, B3, "matPow(A, 3)");
+
+  var A0 = matPow(A, 0);
+  var A1 = matPow(A, 1);
+  var I3 = eye(3, eltType=real);
+
+  assertEqual(A0, I3, "matPow(A, 0)");
+  assertEqual(A1, A,  "matPow(A, 1)");
 }
 
 


### PR DESCRIPTION
Introduce a workaround in LinearAlgebra.chpl for issue #9438,
which was causing failures in 
`library/packages/LinearAlgebra/correctness/correctness.chpl`
after PR #9355.

The workaround is to make the recursive function return
a type that doesn't (currently) have a runtime type component.

I initially tried to write a non-recursive version of the function
but ran into other issues.

- [x] passed test/library/packages/LinearAlgebra on a Cray XC

Reviewed by @ben-albrecht - thanks!