### PR TITLE
Adjust PRIM_COERCE to handle generic destination type

### DIFF
--- a/compiler/AST/primitive.cpp
+++ b/compiler/AST/primitive.cpp
@@ -399,8 +399,16 @@ returnInfoVirtualMethodCall(CallExpr* call) {
 }
 
 static QualifiedType
-returnInfoSecondType(CallExpr* call) {
+returnInfoCoerce(CallExpr* call) {
   QualifiedType t = call->get(2)->qualType();
+
+  if (t.type()->symbol->hasFlag(FLAG_GENERIC)) {
+    // Try to figure out what instantiation type we would use
+    // and return that type.
+    Type* iType = getInstantiationType(call->get(1)->typeInfo(),
+                                       t.type());
+    t = QualifiedType(iType, t.getQual());
+  }
   return t;
 }
 
@@ -784,7 +792,7 @@ initPrimitive() {
   // the declared return type is not really known until function
   // resolution.
   // It coerces its first argument to the type stored in the second argument.
-  prim_def(PRIM_COERCE, "coerce", returnInfoSecondType);
+  prim_def(PRIM_COERCE, "coerce", returnInfoCoerce);
 
   prim_def(PRIM_CALL_RESOLVES, "call resolves", returnInfoBool);
   prim_def(PRIM_METHOD_CALL_RESOLVES, "method call resolves", returnInfoBool);

--- a/compiler/resolution/ResolutionCandidate.cpp
+++ b/compiler/resolution/ResolutionCandidate.cpp
@@ -451,6 +451,12 @@ static Type* getBasicInstantiationType(Type* actualType, Type* formalType) {
       return actualC;
   }
 
+  if (isManagedPtrType(actualType)) {
+    Type* actualBaseType = actualType->getField("t")->type;
+    if (canInstantiate(actualBaseType, formalType))
+      return actualBaseType;
+  }
+
   if (isSyncType(actualType) || isSingleType(actualType)) {
     Type* baseType = actualType->getField("valType")->type;
     if (canInstantiate(baseType, formalType))

--- a/test/classes/delete-free/borrowed/coercions-to-init-borrowed.chpl
+++ b/test/classes/delete-free/borrowed/coercions-to-init-borrowed.chpl
@@ -1,0 +1,15 @@
+class MyClass {
+  var x:int;
+  var y:int;
+}
+
+var x: borrowed = new owned MyClass(1,2);
+writeln(x.type:string);
+writeln(x);
+
+var u = new unmanaged MyClass(3,4);
+var y: borrowed = u;
+writeln(y.type:string);
+writeln(y);
+
+delete u; 

--- a/test/classes/delete-free/borrowed/coercions-to-init-borrowed.good
+++ b/test/classes/delete-free/borrowed/coercions-to-init-borrowed.good
@@ -1,0 +1,4 @@
+MyClass
+{x = 1, y = 2}
+MyClass
+{x = 3, y = 4}


### PR DESCRIPTION
Enable generic instantiation for a borrow from an owned.

I noticed that an example such as the following wasn't working:
``` chapel
var x: borrowed = new owned MyClass(...);
```

This PR corrects that problem.

- [x] full local testing, baseline testing, verify testing, --no-local testing, GASNet testing

Reviewed by @lydia-duncan - thanks!