### PR TITLE
Fix defaultOf with default initializer and fully generic field

### DIFF
--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -1387,7 +1387,7 @@ static void buildInitializerCall(AggregateType* ct,
     } else if (field->defPoint->exprType == NULL &&
                field->defPoint->init     == NULL) {
 
-      buildRecordQueryVarField(fn, arg, call, field, false);
+      buildRecordQueryVarField(fn, arg, call, field, true);
 
     }
   }

--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -1387,7 +1387,12 @@ static void buildInitializerCall(AggregateType* ct,
     } else if (field->defPoint->exprType == NULL &&
                field->defPoint->init     == NULL) {
 
-      buildRecordQueryVarField(fn, arg, call, field, true);
+      // Can only use a NamedExpr if using a default initializer. Otherwise the
+      // user can use an arbitrary identifier.
+      //
+      // BHARSH INIT TODO: Try to write a test that fails because we cannot
+      // correctly generate a _defaultOf for something with an explicit init.
+      buildRecordQueryVarField(fn, arg, call, field, ct->wantsDefaultInitializer());
 
     }
   }

--- a/test/classes/initializers/phase1/domainMaps/init-dmap-dom-arr.bad
+++ b/test/classes/initializers/phase1/domainMaps/init-dmap-dom-arr.bad
@@ -7,4 +7,4 @@
 2 0
 3 1
 4 2
-$CHPL_HOME/modules/internal/ChapelArray.chpl:907: error: attempt to dereference nil
+$CHPL_HOME/modules/internal/ChapelArray.chpl:909: error: attempt to dereference nil


### PR DESCRIPTION
A defaultOf can be generated for a type with a default initializer. Prior to this PR, we could incorrectly generate a defaultOf if there was a fully generic field. In such cases, we need to pass something to the default initializer. Before this PR the compiler inserted the temporary into the ``init`` call without considering its position related to the formals. This can be problematic if the fully generic field is not first:

```
class C {
  var pid : int;
  var instance;
  var owned : bool;
}
var tempInstance = "hello";
C.init(tempInstance); // no matching initializer!
```

To fix this issue, the compiler should use a named expression for defaultOfs generated over default initializers.

Testing:
- [x] local + futures
- [x] gasnet + futures