### PR TITLE
Fix Chapel buffer overflows that trigger gcc 8.1 errors

### DIFF
--- a/compiler/AST/AstDump.cpp
+++ b/compiler/AST/AstDump.cpp
@@ -249,7 +249,7 @@ void AstDump::visitSymExpr(SymExpr* node) {
   if (var != 0 && var->immediate != 0) {
     const size_t bufSize = 128;
     char         imm[bufSize];
-    char         buff[bufSize];
+    char         buff[bufSize + 1];
 
     snprint_imm(imm, bufSize, *var->immediate);
     sprintf(buff, "%s%s", imm, is_imag_type(var->type) ? "i" : "");

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -1991,7 +1991,14 @@ static const char* generateFileName(ChainHashMap<char*, StringHashFns, int>& fil
   int version = 1;
   while (filenames.get(filename)) {
     version++;
-    sprintf(filename, "%s%d", lowerFilename, version);
+    int wanted_to_write = snprintf(filename, sizeof(filename), "%s%d",
+                                   lowerFilename, version);
+    if (wanted_to_write < 0) {
+      USR_FATAL("character encoding error while generating file name");
+    } else if ((size_t)wanted_to_write >= sizeof(filename)) {
+      USR_FATAL("module name '%s' is too long to be the basis for a file name",
+                currentModuleName);
+    }
   }
   filenames.put(filename, 1);
 

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -1053,7 +1053,13 @@ static void printStuff(const char* argv0) {
     printf("CHPL_RUNTIME_INCL: %s\n", CHPL_RUNTIME_INCL);
     printf("CHPL_THIRD_PARTY: %s\n", CHPL_THIRD_PARTY);
     printf("\n");
-    snprintf(buf, FILENAME_MAX, "%s/util/printchplenv --all", CHPL_HOME);
+    int wanted_to_write = snprintf(buf, sizeof(buf),
+                                   "%s/util/printchplenv --all", CHPL_HOME);
+    if (wanted_to_write < 0) {
+      USR_FATAL("character encoding error in CHPL_HOME path name");
+    } else if ((size_t)wanted_to_write >= sizeof(buf)) {
+      USR_FATAL("CHPL_HOME path name is too long");
+    }
     int status = mysystem(buf, "running printchplenv", false);
     clean_exit(status);
   }

--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -146,8 +146,9 @@ GEN_CFLAGS += $(C_STD)
 #
 # Flags for turning on warnings for C++/C code
 #
-WARN_CXXFLAGS = -Wall -Werror -Wpointer-arith -Wwrite-strings -Wno-strict-aliasing
-WARN_CFLAGS = $(WARN_CXXFLAGS) -Wmissing-prototypes -Wstrict-prototypes -Wmissing-format-attribute
+WARN_COMMONFLAGS = -Wall -Werror -Wpointer-arith -Wwrite-strings -Wno-strict-aliasing
+WARN_CXXFLAGS = $(WARN_COMMONFLAGS)
+WARN_CFLAGS = $(WARN_COMMONFLAGS) -Wmissing-prototypes -Wstrict-prototypes -Wmissing-format-attribute
 WARN_GEN_CFLAGS = $(WARN_CFLAGS)
 SQUASH_WARN_GEN_CFLAGS = -Wno-unused -Wno-uninitialized
 
@@ -170,6 +171,13 @@ endif
 #
 ifeq ($(shell test $(GNU_GPP_MAJOR_VERSION) -eq 7; echo "$$?"),0)
 SQUASH_WARN_GEN_CFLAGS += -Wno-stringop-overflow
+endif
+
+#
+# Avoid false positive warnings about class member accesses
+#
+ifeq ($(shell test $(GNU_GPP_MAJOR_VERSION) -eq 8; echo "$$?"),0)
+WARN_CXXFLAGS += -Wno-class-memaccess
 endif
 
 #

--- a/runtime/src/main_launcher.c
+++ b/runtime/src/main_launcher.c
@@ -53,7 +53,16 @@ static void chpl_launch_sanity_checks(const char* argv0) {
   // chpl_compute_real_binary_name() )
   if (stat(chpl_get_real_binary_name(), &statBuf) != 0) {
     char errorMsg[256];
-    sprintf(errorMsg, "unable to locate file: %s", chpl_get_real_binary_name());
+    int wanted_to_write = snprintf(errorMsg, sizeof(errorMsg),
+                                   "unable to locate file: %s",
+                                   chpl_get_real_binary_name());
+    if (wanted_to_write < 0) {
+      const char fallbackMsg[] =
+        "character encoding error in name of executable to be launched";
+      strcpy(errorMsg, fallbackMsg);
+    } else if ((size_t)wanted_to_write >= sizeof(errorMsg)) {
+      strcpy(&errorMsg[sizeof(errorMsg) - 4], "...");
+    }
     chpl_error(errorMsg, 0, 0);
   }
 }


### PR DESCRIPTION
Some of our users are early adopters of new gcc versions.  Because we use `-Werror`, Chapel will not compile in nightly testing mode (`WARNINGS` set) or with `CHPL_DEVELOPER` set, when gcc 8.1 is the back end C compiler.  This change fixes the buffer overflows that prevent compilation.

There is also a gcc 8.1 complaint about class member access that does not apply.  This change updates the gnu Makefile to turn that off.

Passes full local testing and full GASNet testing.