### PR TITLE
Improve non-kernel scalability of isx-hand-optimized

### DIFF
--- a/test/studies/isx/isx-hand-optimized.chpl
+++ b/test/studies/isx/isx-hand-optimized.chpl
@@ -132,6 +132,12 @@ config const recvBuffFactor = 2.0,
 config const numBurnInRuns = 1,
              numTrials = 1;
 
+// Horrible hack to help https://github.com/chapel-lang/chapel/issues/9414
+record TimerArr {
+  var A: [1..numTrials] real;
+  proc this(i) ref { return A[i]; }
+  iter these() ref { for a in A do yield a; }
+}
 
 if printConfig then
   printConfiguration();
@@ -145,7 +151,7 @@ var allBucketKeys: [DistTaskSpace] [0..#recvBuffSize] keyType;
 var recvOffset: [DistTaskSpace] atomic int;
 var totalTime, inputTime, bucketCountTime, bucketOffsetTime, bucketizeTime,
     exchangeKeysTime, exchangeKeysOnlyTime, exchangeKeysBarrierTime,
-    countKeysTime: [DistTaskSpace] [1..numTrials] real;
+    countKeysTime: [DistTaskSpace] TimerArr;
 var verifyKeyCount: atomic int;
 
 allLocalesBarrier.reset(perBucketMultiply);


### PR DESCRIPTION
The timed kernel of ISx was scaling well, but the total running time was
scaling horrendously. The root cause of this was slow destruction of some
arrays. We have a bunch of block distributed arrays with inner [1..numTrials]
arrays for timer values. During deinit, all remote locales were going to locale
0 to remove themselves from the list of arrays declared over `1..numTrials`.
This led to a ton of on-stmts, each trying to acquire a shared atomic-lock
which killed scalability.

As a hacky workaround this adds a simple record wrapper so that we end up
creating unique `1..numTrials` domains instead of there being a single one.
This significantly improves scalability of ISx's total running time.

| nodes | kernel time | total before | total now |
| ----- | ----------- | ------------ | --------- |
|  64   |  9.6        |  24.6        |  19.6     |
| 128   | 10.4        |  40.1        |  22.1     |
| 256   | 11.6        |  95.5        |  25.5     |
| 512   | 12.8        | 218.1        |  28.1     |

Related to https://github.com/chapel-lang/chapel/issues/9414