### PR TITLE
Add ability to append options to qsub

### DIFF
--- a/test/release/examples/benchmarks/ssca2/SSCA2_main.lm-knl.timeout
+++ b/test/release/examples/benchmarks/ssca2/SSCA2_main.lm-knl.timeout
@@ -1,0 +1,4 @@
+# This timeout is currently required because the cray compiler takes roughly 7
+# minutes to compile the generated code for this test, and we have to add
+# extra time in case the node needs to be rebooted in to the desired mode.
+1600

--- a/test/release/examples/benchmarks/ssca2/SSCA2_main.lm-knl.timeout
+++ b/test/release/examples/benchmarks/ssca2/SSCA2_main.lm-knl.timeout
@@ -1,4 +1,0 @@
-# This timeout is currently required because the cray compiler takes roughly 7
-# minutes to compile the generated code for this test, and we have to add
-# extra time in case the node needs to be rebooted in to the desired mode.
-1600

--- a/util/test/chpl_launchcmd.py
+++ b/util/test/chpl_launchcmd.py
@@ -254,6 +254,9 @@ class AbstractJob(object):
             submit_command.append('-l')
             submit_command.append('{0}={1}'.format(
                 self.processing_elems_per_node_resource, 1))
+        more_l = os.environ.get('CHPL_LAUNCHCMD_QSUB_MORE_L')
+        if more_l:
+            submit_command.append('{0}'.format(more_l))
 
 
         logging.debug('qsub command: {0}'.format(submit_command))


### PR DESCRIPTION
This change adds the ability to append resource options to qsub to handle unusual configurations, such as specifying a particular KNL mode.

Code by @ronawho , tested by @dmk42 .
