### PR TITLE
Avoid false positive errors from gcc 8.1

### DIFF
--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -174,10 +174,12 @@ SQUASH_WARN_GEN_CFLAGS += -Wno-stringop-overflow
 endif
 
 #
-# Avoid false positive warnings about class member accesses
+# Avoid false positive warnings about class member access and string overflows.
+# The string overflow false positives occur in runtime code unlike gcc 7.
 #
 ifeq ($(shell test $(GNU_GPP_MAJOR_VERSION) -eq 8; echo "$$?"),0)
 WARN_CXXFLAGS += -Wno-class-memaccess
+RUNTIME_CFLAGS += -Wno-stringop-overflow
 endif
 
 #


### PR DESCRIPTION
In the normal course of Chapel development while gcc 8.1 was the target compiler, I tripped over a false positive warning not prevented by the Makefile change in #9454 .  We turned the warning into an error with `-Werror`, so this change prevents it.

Passes full local testing.
