### PR TITLE
fix errant resolution in Series

### DIFF
--- a/test/library/standard/DataFrames/DataFrames.chpl
+++ b/test/library/standard/DataFrames/DataFrames.chpl
@@ -532,7 +532,6 @@ module DataFrames {
    * FIRST CLASS FUNCTION SERENITY NOW.
    */
 
-  // TODO: return tuple versions where first element is "None"
   class SeriesUnifier {
     type eltType;
 
@@ -550,32 +549,35 @@ module DataFrames {
     }
   }
 
+  // TODO: isNumericType prevents instantiation with bools
+  // would prefer "is summable" type here
   class SeriesAdd : SeriesUnifier {
-    proc f(lhs: eltType, rhs: eltType): eltType {
+    proc f(lhs: eltType, rhs: eltType): eltType where isNumericType(eltType) ||
+                                                      isStringType(eltType) {
       return lhs + rhs;
     }
   }
 
   class SeriesSubtr : SeriesUnifier {
-    proc f(lhs: eltType, rhs: eltType): eltType {
+    proc f(lhs: eltType, rhs: eltType): eltType where isNumericType(eltType) {
       return lhs - rhs;
     }
 
-    proc f_rhs(rhs: eltType): eltType {
+    proc f_rhs(rhs: eltType): eltType where isNumericType(eltType) {
       return -rhs;
     }
   }
 
   class SeriesMult : SeriesUnifier {
-    proc f(lhs: eltType, rhs: eltType): eltType {
+    proc f(lhs: eltType, rhs: eltType): eltType where isNumericType(eltType) {
       return lhs * rhs;
     }
 
-    proc f_lhs(lhs: eltType): eltType {
+    proc f_lhs(lhs: eltType): eltType where isNumericType(eltType) {
       return 0;
     }
 
-    proc f_rhs(rhs: eltType): eltType {
+    proc f_rhs(rhs: eltType): eltType where isNumericType(eltType) {
       return 0;
     }
   }

--- a/test/library/standard/DataFrames/psahabu/MixedOperateSeries.good
+++ b/test/library/standard/DataFrames/psahabu/MixedOperateSeries.good
@@ -1,0 +1,28 @@
+oneDigit:
+A	1
+B	2
+C	3
+D	4
+E	5
+dtype: int(64)
+
+twoDigit:
+A	10
+B	20
+C	30
+D	40
+E	50
+dtype: int(64)
+
+oneDigit + twoDigit:
+A	11
+B	22
+C	33
+D	44
+E	55
+dtype: int(64)
+
+oneDigit < 3
+A	1
+B	2
+dtype: int(64)

--- a/test/library/standard/Dataframes/psahabu/MixedOperateSeries.chpl
+++ b/test/library/standard/Dataframes/psahabu/MixedOperateSeries.chpl
@@ -1,4 +1,4 @@
-use Dataframes;
+use DataFrames;
 
 var I = new TypedIndex(["A", "B", "C", "D", "E"]);
 
@@ -14,4 +14,9 @@ writeln("\noneDigit + twoDigit:");
 writeln(oneDigit + twoDigit);
 
 writeln("\noneDigit < 3");
-writeln(oneDigit < 3);
+writeln(oneDigit[oneDigit < 3]);
+
+/*
+var bools = new TypedSeries([true, false, true, false, true], I);
+writeln(bools);
+ */

--- a/test/library/standard/Dataframes/psahabu/MixedOperateSeries.chpl
+++ b/test/library/standard/Dataframes/psahabu/MixedOperateSeries.chpl
@@ -1,0 +1,17 @@
+use Dataframes;
+
+var I = new TypedIndex(["A", "B", "C", "D", "E"]);
+
+var oneDigit = new TypedSeries([1, 2, 3, 4, 5], I);
+var twoDigit = new TypedSeries([10, 20, 30, 40, 50], I);
+
+writeln("oneDigit:");
+writeln(oneDigit);
+writeln("\ntwoDigit:");
+writeln(twoDigit);
+
+writeln("\noneDigit + twoDigit:");
+writeln(oneDigit + twoDigit);
+
+writeln("\noneDigit < 3");
+writeln(oneDigit < 3);


### PR DESCRIPTION
## Motivation
A bug was preventing Series from being used productively by preventing two operations from being used in the same program. More information can be found in the connected issue.

### Probable Cause
Investigation by @cassella showed that a `SeriesAdd(bool)` was being instantiated, which was confusing because such an operation doesn't appear in the reproducer. However, filtering operations have `TypedSeries(bool)` as their return type (i.e. `mySeries < 3`). Creating a separate `TypedSeries(bool)` while commenting out the filter operation reproduced the original error, suggesting that `SeriesAdd(bool)` is being instantiated because `TypedSeries(bool)` exists.

## Fix
@cassella discovered this workaround: Gating `f()`, `f_lhs()`, and `f_rhs()` of `SeriesUnifier` subclasses with `where isNumeric(eltType)`.

Ultimately, a concept like `Summable` (for example) would be preferable so that all types with a `+` operator could be put into a Series, but this works for now.