### PR TITLE
basic reductions on Series

### DIFF
--- a/test/library/standard/DataFrames/DataFrames.chpl
+++ b/test/library/standard/DataFrames/DataFrames.chpl
@@ -265,6 +265,36 @@ module DataFrames {
       halt("generic Series cannot be compared");
       return this;
     }
+
+    pragma "no doc"
+    proc sum() {
+      halt("generic Series cannot be summed");
+      return 0;
+    }
+
+    pragma "no doc"
+    proc min() {
+      halt("generic Series does not have a min");
+      return 0;
+    }
+
+    pragma "no doc"
+    proc max() {
+      halt("generic Series does not have a max");
+      return 0;
+    }
+
+    pragma "no doc"
+    proc and() {
+      halt("generic Series cannot be 'and' together");
+      return 0;
+    }
+
+    pragma "no doc"
+    proc or() {
+      halt("generic Series cannot be 'or' together");
+      return 0;
+    }
   }
 
   class TypedSeries : Series {
@@ -513,6 +543,30 @@ module DataFrames {
 
     proc gteq_scalar(n): Series {
       return this.map(new SeriesGreaterThanEqualTo(n));
+    }
+
+    /*
+     * Reductions
+     */
+
+    proc sum(): eltType {
+      return + reduce this.these();
+    }
+
+    proc min(): eltType {
+      return min reduce this.these();
+    }
+
+    proc max(): eltType {
+      return max reduce this.these();
+    }
+
+    proc and() where eltType == bool {
+      return && reduce this.these();
+    }
+
+    proc or() where eltType == bool {
+      return || reduce this.these();
     }
 
     proc writeThis(f) {

--- a/test/library/standard/DataFrames/psahabu/AndOrSeries.chpl
+++ b/test/library/standard/DataFrames/psahabu/AndOrSeries.chpl
@@ -1,0 +1,28 @@
+use DataFrames;
+
+var noTrue = new TypedSeries([false, false, false]);
+var oneTrue = new TypedSeries([false, true, false]);
+var allTrue = new TypedSeries([true, true, true]);
+
+writeln("noTrue:");
+writeln(noTrue);
+writeln();
+writeln("oneTrue:");
+writeln(oneTrue);
+writeln();
+writeln("allTrue:");
+writeln(allTrue);
+
+writeln();
+writeln("noTrue.and(): " + noTrue.and());
+writeln();
+writeln("oneTrue.and(): " + oneTrue.and());
+writeln();
+writeln("allTrue.and(): " + allTrue.and());
+
+writeln();
+writeln("noTrue.or(): " + noTrue.or());
+writeln();
+writeln("oneTrue.or(): " + oneTrue.or());
+writeln();
+writeln("allTrue.or(): " + allTrue.or());

--- a/test/library/standard/DataFrames/psahabu/AndOrSeries.good
+++ b/test/library/standard/DataFrames/psahabu/AndOrSeries.good
@@ -1,0 +1,29 @@
+noTrue:
+1	false
+2	false
+3	false
+dtype: bool
+
+oneTrue:
+1	false
+2	true
+3	false
+dtype: bool
+
+allTrue:
+1	true
+2	true
+3	true
+dtype: bool
+
+noTrue.and(): false
+
+oneTrue.and(): false
+
+allTrue.and(): true
+
+noTrue.or(): false
+
+oneTrue.or(): true
+
+allTrue.or(): true

--- a/test/library/standard/DataFrames/psahabu/SumMinMaxSeries.chpl
+++ b/test/library/standard/DataFrames/psahabu/SumMinMaxSeries.chpl
@@ -1,0 +1,39 @@
+use DataFrames;
+
+var I = new TypedIndex(["A", "B", "C", "D", "E"]);
+var V1 = [true, false, true, false, true];
+var V2 = [false, true, false, true, false];
+
+var noNone = new TypedSeries([1, 2, 3, 4, 5], I);
+var someNone = new TypedSeries([1, 2, 3, 4, 5], I, V1);
+var moreNone = new TypedSeries([10, 20, 30, 40, 50], I, V2);
+
+writeln("noNone:");
+writeln(noNone);
+writeln();
+writeln("someNone:");
+writeln(someNone);
+writeln();
+writeln("moreNone:");
+writeln(moreNone);
+
+writeln();
+writeln("noNone.sum(): " + noNone.sum());
+writeln();
+writeln("someNone.sum(): " + someNone.sum());
+writeln();
+writeln("moreNone.sum(): " + moreNone.sum());
+
+writeln();
+writeln("noNone.min(): " + noNone.min());
+writeln();
+writeln("someNone.min(): " + someNone.min());
+writeln();
+writeln("moreNone.min(): " + moreNone.min());
+
+writeln();
+writeln("noNone.max(): " + noNone.max());
+writeln();
+writeln("someNone.max(): " + someNone.max());
+writeln();
+writeln("moreNone.max(): " + moreNone.max());

--- a/test/library/standard/DataFrames/psahabu/SumMinMaxSeries.good
+++ b/test/library/standard/DataFrames/psahabu/SumMinMaxSeries.good
@@ -1,0 +1,41 @@
+noNone:
+A	1
+B	2
+C	3
+D	4
+E	5
+dtype: int(64)
+
+someNone:
+A	1
+B	None
+C	3
+D	None
+E	5
+dtype: int(64)
+
+moreNone:
+A	None
+B	20
+C	None
+D	40
+E	None
+dtype: int(64)
+
+noNone.sum(): 15
+
+someNone.sum(): 9
+
+moreNone.sum(): 60
+
+noNone.min(): 1
+
+someNone.min(): 1
+
+moreNone.min(): 20
+
+noNone.max(): 5
+
+someNone.max(): 5
+
+moreNone.max(): 40

--- a/test/library/standard/DataFrames/psahabu/SumMinMaxSeries.py
+++ b/test/library/standard/DataFrames/psahabu/SumMinMaxSeries.py
@@ -1,0 +1,36 @@
+import pandas as pd
+
+I = ["A", "B", "C", "D", "E"]
+noNone = pd.Series([1, 2, 3, 4, 5], pd.Index(I))
+someNone = pd.Series([1, None, 3, None, 5], pd.Index(I))
+moreNone = pd.Series([None, 20, None, 40, None], pd.Index(I))
+
+print "noNone:"
+print noNone
+print
+print "someNone:"
+print someNone
+print
+print "moreNone:"
+print moreNone
+
+print
+print "noNone.sum():" + str(noNone.sum())
+print
+print "someNone.sum():" + str(someNone.sum())
+print
+print "moreNone.sum():" + str(moreNone.sum())
+
+print
+print "noNone.min():" + str(noNone.min())
+print
+print "someNone.min():" + str(someNone.min())
+print
+print "moreNone.min():" + str(moreNone.min())
+
+print
+print "noNone.max():" + str(noNone.max())
+print
+print "someNone.max():" + str(someNone.max())
+print
+print "moreNone.max():" + str(moreNone.max())


### PR DESCRIPTION
## Motivation
See the connected issue.

## Approach
Add methods on `TypedSeries` for `sum()`, `min()`, `max()`, `and() where eltType == bool` and `or() where eltType == bool`. Run a reduction on the `None`-excluding iterator.

### Notes
Included with this PR is a Pandas equivalent to the SumMinMaxSeries test. The most notable difference is that `None` causes the type of the Series to be `float` instead of `int`. A Pandas equivalent for AndOrSeries is not included because the approach is not immediately obvious.