### PR TITLE
Update reduction implementation to use initializers

### DIFF
--- a/compiler/passes/createTaskFunctions.cpp
+++ b/compiler/passes/createTaskFunctions.cpp
@@ -338,7 +338,8 @@ static void addReduceIntentSupport(FnSymbol* fn, CallExpr* call,
   AggregateType* reduceAt = toAggregateType(reduceType->type);
   INT_ASSERT(reduceAt);
 
-  CallExpr* newOp = new CallExpr(reduceAt->defaultInitializer->name,
+  CallExpr* newOp = new CallExpr(PRIM_NEW,
+                                 reduceAt->symbol,
                                  new NamedExpr("eltType", new SymExpr(eltType)));
   headAnchor->insertBefore(new CallExpr(PRIM_MOVE, globalOp, newOp));
 

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -1858,11 +1858,13 @@ static Expr*     getInsertPointForTypeFunction(Type* type) {
   AggregateType* at     = toAggregateType(type);
   Expr*          retval = NULL;
 
+  // BHARSH TODO: Why not use at->symbol->instantiationPoint ?
+  // Some tests failed at the time:
+  //   - library/standard/DateTime/*
+  //   - mason/*
   if (at == NULL) {
     // Not an AggregateType
     retval = chpl_gen_main->body;
-  } else if (at->symbol->instantiationPoint != NULL) {
-    retval = at->symbol->instantiationPoint;
 
   } else if (at->defaultInitializer &&
              at->defaultInitializer->instantiationPoint) {

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -1931,11 +1931,7 @@ static FnSymbol* resolveUninsertedCall(Expr* insert, CallExpr* call, bool errorO
 void resolveTypeWithInitializer(AggregateType* at, FnSymbol* fn) {
   if (at->symbol->instantiationPoint == NULL &&
       fn->instantiationPoint != NULL) {
-    if (FnSymbol* parentFn = toFnSymbol(fn->instantiationPoint->parentSymbol)) {
-      at->symbol->instantiationPoint = parentFn->body;
-    } else {
-      at->symbol->instantiationPoint = fn->instantiationPoint;
-    }
+    at->symbol->instantiationPoint = fn->instantiationPoint;
   }
   if (at->scalarPromotionType == NULL) {
     resolvePromotionType(at);

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -1861,6 +1861,8 @@ static Expr*     getInsertPointForTypeFunction(Type* type) {
   if (at == NULL) {
     // Not an AggregateType
     retval = chpl_gen_main->body;
+  } else if (at->symbol->instantiationPoint != NULL) {
+    retval = at->symbol->instantiationPoint;
 
   } else if (at->defaultInitializer &&
              at->defaultInitializer->instantiationPoint) {
@@ -1927,8 +1929,13 @@ static FnSymbol* resolveUninsertedCall(Expr* insert, CallExpr* call, bool errorO
 }
 
 void resolveTypeWithInitializer(AggregateType* at, FnSymbol* fn) {
-  if (at->symbol->instantiationPoint == NULL) {
-    at->symbol->instantiationPoint = fn->instantiationPoint;
+  if (at->symbol->instantiationPoint == NULL &&
+      fn->instantiationPoint != NULL) {
+    if (FnSymbol* parentFn = toFnSymbol(fn->instantiationPoint->parentSymbol)) {
+      at->symbol->instantiationPoint = parentFn->body;
+    } else {
+      at->symbol->instantiationPoint = fn->instantiationPoint;
+    }
   }
   if (at->scalarPromotionType == NULL) {
     resolvePromotionType(at);

--- a/compiler/resolution/implementForallIntents.cpp
+++ b/compiler/resolution/implementForallIntents.cpp
@@ -2097,7 +2097,17 @@ static Symbol* setupRiGlobalOp(ForallStmt* fs, Symbol* fiVarSym,
 
   resolveBlockStmt(hld);
   insertAndResolveInitialAccumulate(fs, hld, globalOp, fiVarSym);
+
+  AggregateType* reductionClass = toAggregateType(canonicalClassType(globalOp->type));
+  if (reductionClass->symbol->instantiationPoint == hld) {
+    BlockStmt* parentBlock = toBlockStmt(hld->parentExpr);
+    INT_ASSERT(parentBlock != NULL);
+    reductionClass->symbol->instantiationPoint = parentBlock;
+  }
+
   hld->flattenAndRemove();
+
+
 
   // Todo: this replace() is somewhat expensive.
   // Can instead we update fs->riSpecs[i] aka 'riSpec' in-place?

--- a/modules/internal/ChapelReduce.chpl
+++ b/modules/internal/ChapelReduce.chpl
@@ -188,7 +188,7 @@ module ChapelReduce {
   pragma "use default init"
   class LogicalOrReduceScanOp: ReduceScanOp {
     type eltType;
-    var value = _land_id(eltType);
+    var value = _lor_id(eltType);
 
     proc identity return _lor_id(eltType);
     proc accumulate(x) {

--- a/modules/internal/ChapelReduce.chpl
+++ b/modules/internal/ChapelReduce.chpl
@@ -66,6 +66,7 @@ module ChapelReduce {
   }
 
   pragma "ReduceScanOp"
+  pragma "use default init"
   class ReduceScanOp {
     var l: atomicbool; // only accessed locally
 
@@ -85,6 +86,7 @@ module ChapelReduce {
     }
   }
 
+  pragma "use default init"
   class SumReduceScanOp: ReduceScanOp {
     type eltType;
     var value: chpl__sumType(eltType);
@@ -107,6 +109,7 @@ module ChapelReduce {
     proc clone() return new unmanaged SumReduceScanOp(eltType=eltType);
   }
 
+  pragma "use default init"
   class ProductReduceScanOp: ReduceScanOp {
     type eltType;
     var value = _prod_id(eltType);
@@ -125,6 +128,7 @@ module ChapelReduce {
     proc clone() return new unmanaged ProductReduceScanOp(eltType=eltType);
   }
 
+  pragma "use default init"
   class MaxReduceScanOp: ReduceScanOp {
     type eltType;
     var value = min(eltType);
@@ -143,6 +147,7 @@ module ChapelReduce {
     proc clone() return new unmanaged MaxReduceScanOp(eltType=eltType);
   }
 
+  pragma "use default init"
   class MinReduceScanOp: ReduceScanOp {
     type eltType;
     var value = max(eltType);
@@ -161,9 +166,10 @@ module ChapelReduce {
     proc clone() return new unmanaged MinReduceScanOp(eltType=eltType);
   }
 
+  pragma "use default init"
   class LogicalAndReduceScanOp: ReduceScanOp {
     type eltType;
-    var value = identity;
+    var value = _land_id(eltType);
 
     proc identity return _land_id(eltType);
     proc accumulate(x) {
@@ -179,9 +185,10 @@ module ChapelReduce {
     proc clone() return new unmanaged LogicalAndReduceScanOp(eltType=eltType);
   }
 
+  pragma "use default init"
   class LogicalOrReduceScanOp: ReduceScanOp {
     type eltType;
-    var value = identity;
+    var value = _land_id(eltType);
 
     proc identity return _lor_id(eltType);
     proc accumulate(x) {
@@ -197,6 +204,7 @@ module ChapelReduce {
     proc clone() return new unmanaged LogicalOrReduceScanOp(eltType=eltType);
   }
 
+  pragma "use default init"
   class BitwiseAndReduceScanOp: ReduceScanOp {
     type eltType;
     var value = _band_id(eltType);
@@ -215,6 +223,7 @@ module ChapelReduce {
     proc clone() return new unmanaged BitwiseAndReduceScanOp(eltType=eltType);
   }
 
+  pragma "use default init"
   class BitwiseOrReduceScanOp: ReduceScanOp {
     type eltType;
     var value = _bor_id(eltType);
@@ -233,6 +242,7 @@ module ChapelReduce {
     proc clone() return new unmanaged BitwiseOrReduceScanOp(eltType=eltType);
   }
 
+  pragma "use default init"
   class BitwiseXorReduceScanOp: ReduceScanOp {
     type eltType;
     var value = _bxor_id(eltType);
@@ -251,6 +261,7 @@ module ChapelReduce {
     proc clone() return new unmanaged BitwiseXorReduceScanOp(eltType=eltType);
   }
 
+  pragma "use default init"
   class maxloc: ReduceScanOp {
     type eltType;
     var value = min(eltType);
@@ -276,6 +287,7 @@ module ChapelReduce {
     proc clone() return new unmanaged maxloc(eltType=eltType);
   }
 
+  pragma "use default init"
   class minloc: ReduceScanOp {
     type eltType;
     var value = max(eltType);

--- a/test/parallel/forall/reduce-intents/ri-6-named.chpl
+++ b/test/parallel/forall/reduce-intents/ri-6-named.chpl
@@ -4,6 +4,7 @@ var ARR: [1..n] int = 1..n;
 var numErrors = 0;
 
 // A (simplified) copy of the predefined SumReduceScanOp.
+pragma "use default init"
 class UserReduceOp: ReduceScanOp {
   type eltType;
   var value: eltType;

--- a/test/parallel/forall/reduce-intents/ri-6-user-instance.chpl
+++ b/test/parallel/forall/reduce-intents/ri-6-user-instance.chpl
@@ -6,6 +6,7 @@ var ARR: [1..n] int = 1..n;
 var numErrors = 0;
 
 // A (simplified) copy of the predefined SumReduceScanOp.
+pragma "use default init"
 class UserReduceOp: ReduceScanOp {
   type eltType;
   var value: eltType;

--- a/test/parallel/forall/reduce-intents/ri-7-initAccum.chpl
+++ b/test/parallel/forall/reduce-intents/ri-7-initAccum.chpl
@@ -27,6 +27,7 @@ writeln("user op:     ", xOp);
 
 delete plusOp;
 
+pragma "use default init"
 class PlusReduceOp: ReduceScanOp {
   type eltType;
   var  value: eltType;

--- a/test/parallel/forall/reduce-intents/ri-a1-ident-ref-ret.chpl
+++ b/test/parallel/forall/reduce-intents/ri-a1-ident-ref-ret.chpl
@@ -58,6 +58,7 @@ writeln("globalArrIdVar ", globalArrIdVar);
 writeln("globalIntIdVar ", globalIntIdVar);
 
 // uses *Const identity values
+pragma "use default init"
 class PlusReduceOpConst: ReduceScanOp {
   type eltType;
   var  value: eltType;
@@ -71,6 +72,7 @@ class PlusReduceOpConst: ReduceScanOp {
 }
 
 // uses *Var identity values
+pragma "use default init"
 class PlusReduceOpVar: ReduceScanOp {
   type eltType;
   var  value: eltType;

--- a/test/parallel/forall/vass/3types-1-wrapped-plus.chpl
+++ b/test/parallel/forall/vass/3types-1-wrapped-plus.chpl
@@ -19,6 +19,7 @@ record Routput {
   var outField: chpl__sumType(eltType);
 }
 
+pragma "use default init"
 class MyOp: ReduceScanOp {
   type eltType;
 

--- a/test/parallel/forall/vass/3types-1-wrapped-plus.good
+++ b/test/parallel/forall/vass/3types-1-wrapped-plus.good
@@ -1,3 +1,3 @@
-3types-1-wrapped-plus.chpl:44: In function 'main':
-3types-1-wrapped-plus.chpl:49: warning: Rstate(int(64))
+3types-1-wrapped-plus.chpl:45: In function 'main':
+3types-1-wrapped-plus.chpl:50: warning: Rstate(int(64))
 result = 4950

--- a/test/parallel/forall/vass/3types-2-arg-error.chpl
+++ b/test/parallel/forall/vass/3types-2-arg-error.chpl
@@ -19,6 +19,7 @@ record Routput {
   var outField: chpl__sumType(eltType);
 }
 
+pragma "use default init"
 class MyOp: ReduceScanOp {
   type eltType;
 

--- a/test/parallel/forall/vass/3types-2-arg-error.good
+++ b/test/parallel/forall/vass/3types-2-arg-error.good
@@ -1,1 +1,1 @@
-3types-2-arg-error.chpl:46: error: for a reduce intent, the 'reduce' keyword must be preceded by the reduction operator or the name of the reduction class with the single optional argument indicating the type of the reduction input
+3types-2-arg-error.chpl:47: error: for a reduce intent, the 'reduce' keyword must be preceded by the reduction operator or the name of the reduction class with the single optional argument indicating the type of the reduction input

--- a/test/parallel/forall/vass/3types-3-sum-of-booleans.chpl
+++ b/test/parallel/forall/vass/3types-3-sum-of-booleans.chpl
@@ -8,6 +8,7 @@
   writeln(sum);        // result: real
 
   /* Implements + reduction over numeric data. */
+pragma "use default init"
   class PlusReduceOp: ReduceScanOp {
 
     /* the type of the elements to be reduced */

--- a/test/parallel/forall/vass/array-reduce-intents.chpl
+++ b/test/parallel/forall/vass/array-reduce-intents.chpl
@@ -56,6 +56,7 @@ proc main {
 
 }
 
+pragma "use default init"
 class PlusReduceOp: ReduceScanOp {
   type eltType;
   var  value: eltType;

--- a/test/parallel/forall/vass/array-reduce-intents2.chpl
+++ b/test/parallel/forall/vass/array-reduce-intents2.chpl
@@ -28,6 +28,7 @@ proc main {
   writeln("histoP = ", histoP);
 }
 
+pragma "use default init"
 class PlusReduceOp: ReduceScanOp {
   type eltType;
   var  value: eltType;

--- a/test/parallel/forall/vass/reduce-assign-1.chpl
+++ b/test/parallel/forall/vass/reduce-assign-1.chpl
@@ -56,6 +56,7 @@ proc main {
 
 }
 
+pragma "use default init"
 class PlusReduceOp: ReduceScanOp {
   type eltType;
   var  value: eltType;

--- a/test/reductions/diten/deleteReductionClass.chpl
+++ b/test/reductions/diten/deleteReductionClass.chpl
@@ -3,7 +3,8 @@ class LastOp: ReduceScanOp {
   type eltType;
   var last: eltType;
 
-  proc LastOp(type eltType) {
+  proc init(type eltType) {
+    this.eltType = eltType;
     count$ += 1;
   }
   proc deinit() {

--- a/test/reductions/sungeun/count.chpl
+++ b/test/reductions/sungeun/count.chpl
@@ -3,7 +3,7 @@ class countVal: ReduceScanOp {
   const val: eltType;
   var count: atomic int;
 
-  proc countVal(eltType, val) { count.write(0); }
+  proc init(eltType, val) { this.eltType = eltType; this.complete(); count.write(0); }
 
   proc accumulate(x) {
     if x == val then count.add(1);

--- a/test/reductions/sungeun/test_minmaxloc.chpl
+++ b/test/reductions/sungeun/test_minmaxloc.chpl
@@ -1,5 +1,6 @@
 use Random;
 
+pragma "use default init"
 class lastmaxloc: ReduceScanOp {
   type eltType;
   var value: eltType = min(eltType);
@@ -23,6 +24,7 @@ class lastmaxloc: ReduceScanOp {
   proc generate() return value;
 }
 
+pragma "use default init"
 class lastminloc: ReduceScanOp {
   type eltType;
   var value: eltType = max(eltType);

--- a/test/reductions/thomasvandoren/counts.chpl
+++ b/test/reductions/thomasvandoren/counts.chpl
@@ -6,6 +6,7 @@
  * could determine a ranking of the particles within each octant.
  */
 
+pragma "use default init"
 class counts : ReduceScanOp {
   type eltType;
   const k: int = 8;

--- a/test/reductions/thomasvandoren/mini.chpl
+++ b/test/reductions/thomasvandoren/mini.chpl
@@ -3,6 +3,7 @@
  * value and its location (i.e. `(value, location)`).
  */
 
+pragma "use default init"
 class mini : ReduceScanOp {
   type eltType;
   var value: eltType = max(eltType);

--- a/test/reductions/thomasvandoren/mink.chpl
+++ b/test/reductions/thomasvandoren/mink.chpl
@@ -3,6 +3,7 @@
  * eltType.
  */
 
+pragma "use default init"
 class mink : ReduceScanOp {
   type eltType;
   const k: int = 10;

--- a/test/reductions/thomasvandoren/scanCounts.chpl
+++ b/test/reductions/thomasvandoren/scanCounts.chpl
@@ -6,6 +6,7 @@
  * could determine a ranking of the particles within each octant.
  */
 
+pragma "use default init"
 class scanCounts : ReduceScanOp {
   type eltType;
   const k: int = 8;

--- a/test/reductions/thomasvandoren/scanCountsInherit.chpl
+++ b/test/reductions/thomasvandoren/scanCountsInherit.chpl
@@ -10,6 +10,7 @@
 
 use counts;
 
+pragma "use default init"
 class scanCountsInherit : counts {
   // Track the current value, so it can be used in generate() method. Use min()
   // as arbitrary default value here, in lieu of no "default of type" support

--- a/test/reductions/thomasvandoren/sorted.chpl
+++ b/test/reductions/thomasvandoren/sorted.chpl
@@ -16,6 +16,7 @@ use Sort;
 // break, though, so I'm leaving it in for now.
 //
 
+pragma "use default init"
 class isSorted : ReduceScanOp {
   type eltType;
   param communicative = false;  // Note: This has no effect in the current

--- a/test/reductions/thomasvandoren/test/TestMini.bad
+++ b/test/reductions/thomasvandoren/test/TestMini.bad
@@ -10,4 +10,4 @@ $CHPL_HOME/modules/internal/ChapelReduce.chpl:223: note:                 Bitwise
 $CHPL_HOME/modules/internal/ChapelReduce.chpl:241: note:                 BitwiseXorReduceScanOp.accumulate(x)
 $CHPL_HOME/modules/internal/ChapelReduce.chpl:260: note:                 maxloc.accumulate(x)
 $CHPL_HOME/modules/internal/ChapelReduce.chpl:285: note:                 minloc.accumulate(x)
-../mini.chpl:11: note:                 mini.accumulate(t: (eltType, int))
+../mini.chpl:12: note:                 mini.accumulate(t: (eltType, int))

--- a/test/reductions/userdefined/slowSum.chpl
+++ b/test/reductions/userdefined/slowSum.chpl
@@ -1,3 +1,4 @@
+pragma "use default init"
 class slowSum: ReduceScanOp {
   type eltType = real;
   var exps: domain(int);

--- a/test/studies/comd/elegant/arrayOfStructs/CoMD.prediff
+++ b/test/studies/comd/elegant/arrayOfStructs/CoMD.prediff
@@ -8,7 +8,7 @@ tmp_file  = out_file + ".prediff.tmp"
 
 with open(out_file) as outf:
     for line in outf:
-        if re.search(r"\.chpl:\d+: error:", line) != None:
+        if re.search(r"\.chpl:\d+:( internal)? error:", line) != None:
             sys.exit(0);
 
 EPSILON = 1e-6

--- a/test/studies/kmeans/kmeans-blc.chpl
+++ b/test/studies/kmeans/kmeans-blc.chpl
@@ -100,6 +100,7 @@ proc dist(x: coord, y:coord) {
 //
 // User-defined reduction class for computing updated center locations
 //
+pragma "use default init"
 class kmeans: ReduceScanOp {
   type eltType;                        // required field
   var error: real;                     // accumulated error

--- a/test/studies/kmeans/kmeansonepassreduction-minchange.chpl
+++ b/test/studies/kmeans/kmeansonepassreduction-minchange.chpl
@@ -57,6 +57,7 @@ for ii in 1..k
 
 /*Reduction class*/
 
+pragma "use default init"
 class kmeansReduction : ReduceScanOp{
 
 type eltType;

--- a/test/studies/kmeans/kmeansonepassreduction-mystery.chpl
+++ b/test/studies/kmeans/kmeansonepassreduction-mystery.chpl
@@ -68,6 +68,7 @@ for ii in 1..k
 
 /*Reduction class*/
 
+pragma "use default init"
 class kmeansReduction : ReduceScanOp{
 
 type eltType;

--- a/test/studies/kmeans/kmeansonepassreduction-norecord2.chpl
+++ b/test/studies/kmeans/kmeansonepassreduction-norecord2.chpl
@@ -48,6 +48,7 @@ for ii in 1..k
 
 /*Reduction class*/
 
+pragma "use default init"
 class kmeansReduction : ReduceScanOp{
 
 type eltType;

--- a/test/studies/kmeans/kmeansonepassreduction.chpl
+++ b/test/studies/kmeans/kmeansonepassreduction.chpl
@@ -68,6 +68,7 @@ for ii in 1..k
 
 /*Reduction class*/
 
+pragma "use default init"
 class kmeansReduction : ReduceScanOp{
 
 type eltType;

--- a/test/users/csep524/userDefReduceSlim.chpl
+++ b/test/users/csep524/userDefReduceSlim.chpl
@@ -3,6 +3,7 @@ var randInts: [1..10] int;
 const mostCommon = mostFrequent reduce randInts;
 writeln(mostCommon);
 
+pragma "use default init"
 class mostFrequent: ReduceScanOp {
   type eltType;
 

--- a/test/users/ferguson/histogram/reductionex.chpl
+++ b/test/users/ferguson/histogram/reductionex.chpl
@@ -8,6 +8,7 @@
   // var min
   // var max
 
+  pragma "use default init"
   class myhisto: ReduceScanOp {
     type eltType;
     const per = (max - min)/NBUCKETS;

--- a/test/users/ferguson/histogram/reductionex_class.bad
+++ b/test/users/ferguson/histogram/reductionex_class.bad
@@ -1,4 +1,4 @@
-reductionex_class.chpl:43: internal error: CAL0124 chpl version 1.18.0 pre-release (02d6b31f68)
+reductionex_class.chpl:44: internal error: CAL0124 chpl version 1.18.0 pre-release (02d6b31f68)
 
 Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
 and we're sorry for the hassle.  We would appreciate your reporting this bug -- 

--- a/test/users/ferguson/histogram/reductionex_class.chpl
+++ b/test/users/ferguson/histogram/reductionex_class.chpl
@@ -13,6 +13,7 @@
     var max;
     var min;
 
+    pragma "use default init"
     class myhisto: ReduceScanOp {
       type eltType;
       const per = (max - min)/NBUCKETS;

--- a/test/users/ferguson/histogram/reductionex_class2.chpl
+++ b/test/users/ferguson/histogram/reductionex_class2.chpl
@@ -9,6 +9,7 @@ class Test {
   var   max;
   var   min;
 
+  pragma "use default init"
   class myhisto: ReduceScanOp {
     type  eltType;
     const per = (max - min)/NBUCKETS;

--- a/test/users/ferguson/histogram/reductionex_class2.future
+++ b/test/users/ferguson/histogram/reductionex_class2.future
@@ -1,0 +1,3 @@
+bug: nested classes with initializers not supported
+
+Issue #9353

--- a/test/users/ferguson/histogram/reductionex_module.chpl
+++ b/test/users/ferguson/histogram/reductionex_module.chpl
@@ -5,6 +5,7 @@
     param PER;
     */
 
+    pragma "use default init"
     class myhisto: ReduceScanOp {
       type eltType;
       var counts:NBUCKETS*int;

--- a/test/users/ferguson/histogram/reductionex_module2.chpl
+++ b/test/users/ferguson/histogram/reductionex_module2.chpl
@@ -5,6 +5,7 @@
     param PER;
     */
 
+    pragma "use default init"
     class myhisto: ReduceScanOp {
       type eltType;
       var counts:NBUCKETS*int;

--- a/test/users/ferguson/histogram/reductionex_module3.chpl
+++ b/test/users/ferguson/histogram/reductionex_module3.chpl
@@ -6,6 +6,7 @@
     var max;
     */
 
+    pragma "use default init"
     class myhisto: ReduceScanOp {
       type eltType;
       var per = (max-min)/NBUCKETS;

--- a/test/users/ferguson/histogram/reductionex_module4.chpl
+++ b/test/users/ferguson/histogram/reductionex_module4.chpl
@@ -5,6 +5,7 @@
     param PER;
     */
 
+    pragma "use default init"
     class myhisto: ReduceScanOp {
       type eltType;
       var counts:NBUCKETS*int;

--- a/test/users/ferguson/histogram/reductionex_record.bad
+++ b/test/users/ferguson/histogram/reductionex_record.bad
@@ -1,4 +1,4 @@
-reductionex_record.chpl:43: internal error: CAL0124 chpl version 1.18.0 pre-release (02d6b31f68)
+reductionex_record.chpl:44: internal error: CAL0124 chpl version 1.18.0 pre-release (02d6b31f68)
 
 Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
 and we're sorry for the hassle.  We would appreciate your reporting this bug -- 

--- a/test/users/ferguson/histogram/reductionex_record.bad
+++ b/test/users/ferguson/histogram/reductionex_record.bad
@@ -1,4 +1,4 @@
-reductionex_record.chpl:44: internal error: CAL0124 chpl version 1.18.0 pre-release (02d6b31f68)
+reductionex_record.chpl:44: internal error: CALnnnn chpl version mmmm
 
 Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
 and we're sorry for the hassle.  We would appreciate your reporting this bug -- 

--- a/test/users/ferguson/histogram/reductionex_record.chpl
+++ b/test/users/ferguson/histogram/reductionex_record.chpl
@@ -13,6 +13,7 @@
     var max;
     var min;
 
+    pragma "use default init"
     class myhisto: ReduceScanOp {
       type eltType;
       const per = (max - min)/NBUCKETS;

--- a/test/users/ferguson/histogram/reductionex_record2.chpl
+++ b/test/users/ferguson/histogram/reductionex_record2.chpl
@@ -9,6 +9,7 @@
     var max;
     var min;
 
+    pragma "use default init"
     class myhisto: ReduceScanOp {
       type eltType;
       const per = (max - min)/NBUCKETS;

--- a/test/users/ferguson/histogram/reductionex_record2.future
+++ b/test/users/ferguson/histogram/reductionex_record2.future
@@ -1,0 +1,3 @@
+bug: nested classes with initializers not supported
+
+Issue #9353

--- a/test/users/ferguson/histogram/reductionex_record_class.chpl
+++ b/test/users/ferguson/histogram/reductionex_record_class.chpl
@@ -13,6 +13,7 @@ record Test {
     var counts:NBUCKETS*int;
   }
 
+  pragma "use default init"
   class myhisto: ReduceScanOp {
     type  eltType;
 

--- a/test/users/ferguson/histogram/reductionex_record_class.future
+++ b/test/users/ferguson/histogram/reductionex_record_class.future
@@ -1,0 +1,3 @@
+bug: nested classes with initializers not supported
+
+Issue #9353

--- a/test/users/ferguson/histogram/reductionex_record_record.chpl
+++ b/test/users/ferguson/histogram/reductionex_record_record.chpl
@@ -13,6 +13,7 @@
       var counts:NBUCKETS*int;
     }
 
+    pragma "use default init"
     class myhisto: ReduceScanOp {
       type eltType;
       const per = (max - min)/NBUCKETS;

--- a/test/users/ferguson/histogram/reductionex_record_record.future
+++ b/test/users/ferguson/histogram/reductionex_record_record.future
@@ -1,0 +1,3 @@
+bug: nested classes with initializers not supported
+
+Issue #9353

--- a/test/users/ren/mink-blc-arg.chpl
+++ b/test/users/ren/mink-blc-arg.chpl
@@ -1,5 +1,6 @@
 config const n = 10;
 
+pragma "use default init"
 class mink : ReduceScanOp {
 
   type eltType;

--- a/test/users/ren/mink-blc-infer.chpl
+++ b/test/users/ren/mink-blc-infer.chpl
@@ -1,6 +1,7 @@
 config const n = 10,
              numMins = 5;
 
+pragma "use default init"
 class mink : ReduceScanOp {
 
   type eltType;

--- a/test/users/ren/mink-blc-workaround.chpl
+++ b/test/users/ren/mink-blc-workaround.chpl
@@ -1,6 +1,7 @@
 config const n = 10,
              numMins = 5;
 
+pragma "use default init"
 class mink : ReduceScanOp {
 
   type eltType;

--- a/test/users/ren/mink-blc.chpl
+++ b/test/users/ren/mink-blc.chpl
@@ -1,6 +1,7 @@
 config const n = 10,
              numMins = 5;
 
+pragma "use default init"
 class mink : ReduceScanOp {
 
   type eltType;

--- a/test/users/ren/mink-minchange.chpl
+++ b/test/users/ren/mink-minchange.chpl
@@ -1,3 +1,4 @@
+pragma "use default init"
 class mink : ReduceScanOp {
 
   type eltType;


### PR DESCRIPTION
This PR updates the classes implementing reductions to use initializers. Default constructors have been replaced by applying the 'use default init' pragma, and explicit constructors have been replaced with explicit initializers.

A small compiler change was required to work around a point-of-instantiation issue.

A handful of tests have been notest'd or futurized for one of two reasons:
- incorrect usage of generic instantiation initialization
- usage of nested classes, which are ill-supported for initializers

Resolves #9315 

Testing:
- [x] local + futures
- [x] gasnet