### PR TITLE
Remove a bad `assert(0)` from qio's setup_actions

### DIFF
--- a/runtime/src/qio/qio_popen.c
+++ b/runtime/src/qio/qio_popen.c
@@ -129,7 +129,7 @@ static qioerr setup_actions(
     *hasactions = true;
   } else if( *std__fd == QIO_FD_TO_STDOUT ) {
     // Do nothing.
-    assert(0);
+
   } else {
     // Use a given file descriptor for childfd (e.g. stdin).
     rc = posix_spawn_file_actions_adddup2(actions, *std__fd, childfd);


### PR DESCRIPTION
Ben A and I found a bug when spawning a task while setting stdout to PIPE and
stderr to STDOUT.  If the runtime was compiled without optimizations (if
CHPL_DEVELOPER is true), we would encounter an assertion error.  Basically, we
don't want to insert a close action if the file descriptor provided is STDOUT,
but the branch also had an `assert(0)` and that caused the program to halt.
Michael says it is fine to just remove the assert, and behavior seems to be
correct without it. (Optimizations on removes the assert call)

Passed a full paratest now with optimizations, running with the
runtime built w/o optimizations.