### PR TITLE
Disable ipa-cp-clone for gcc 7

### DIFF
--- a/make/compiler/Makefile.cray-prgenv-gnu
+++ b/make/compiler/Makefile.cray-prgenv-gnu
@@ -27,3 +27,8 @@ include $(CHPL_MAKE_HOME)/make/compiler/Makefile.gnu
 
 include $(CHPL_MAKE_HOME)/make/compiler/Makefile.cray-prgenv
 
+# Makefile.cray-prgenv overrides OPT_CLFAGS set in Makefile.gnu
+ifeq ($(shell test $(GNU_GPP_MAJOR_VERSION) -eq 7; echo "$$?"),0)
+OPT_CFLAGS += -fno-ipa-cp-clone
+endif
+

--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -170,6 +170,7 @@ endif
 # Avoid false positive warnings about string overflows
 #
 ifeq ($(shell test $(GNU_GPP_MAJOR_VERSION) -eq 7; echo "$$?"),0)
+OPT_CFLAGS += -fno-ipa-cp-clone
 SQUASH_WARN_GEN_CFLAGS += -Wno-stringop-overflow
 endif
 


### PR DESCRIPTION
Disable ipa-cp-clone (function cloning for interprocedural constant
propagation) for gcc 7. This optimization seems to be the cause of the
multi-locale lulesh regression. This seems to have been fixed in gcc 8, so only
disable for gcc 7.1

Without this multi-locale lulesh perf test fails 1/5 runs. It passed 500 trials
with this patch.

This resolves https://chapel.atlassian.net/browse/CHAPEL-306
Related to https://github.com/chapel-lang/chapel/issues/6481