### PR TITLE
Fix 'more specific' bug related to initializers

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -3289,7 +3289,6 @@ static ResolutionCandidate*
 disambiguateByMatch(Vec<ResolutionCandidate*>&   candidates,
                     const DisambiguationContext& DC,
                     bool                         ignoreWhere,
-                    bool                         forGenericInit,
                     Vec<ResolutionCandidate*>&   ambiguous);
 
 static int  compareSpecificity(ResolutionCandidate*         candidate1,
@@ -3315,7 +3314,7 @@ disambiguateForInit(CallInfo& info, Vec<ResolutionCandidate*>& candidates) {
   DisambiguationContext     DC(info);
   Vec<ResolutionCandidate*> ambiguous;
 
-  return disambiguateByMatch(candidates, DC, false, true, ambiguous);
+  return disambiguateByMatch(candidates, DC, false, ambiguous);
 }
 
 static int disambiguateByMatch(CallInfo&                  info,
@@ -3471,20 +3470,11 @@ static int disambiguateByMatch(CallInfo&                  info,
   return retval;
 }
 
-static ResolutionCandidate*
-disambiguateByMatch(Vec<ResolutionCandidate*>&   candidates,
-                    const DisambiguationContext& DC,
-                    bool                         ignoreWhere,
-                    Vec<ResolutionCandidate*>&   ambiguous) {
-  return disambiguateByMatch(candidates, DC, ignoreWhere, false, ambiguous);
-}
 
-// BHARSH INIT TODO: Do we need 'forGenericInit' anymore?
 static ResolutionCandidate*
 disambiguateByMatch(Vec<ResolutionCandidate*>&   candidates,
                     const DisambiguationContext& DC,
                     bool                         ignoreWhere,
-                    bool                         forGenericInit,
                     Vec<ResolutionCandidate*>&   ambiguous) {
   // MPF note: A more straightforwardly O(n) version of this
   // function did not appear to be faster. See history of this comment.
@@ -3501,9 +3491,7 @@ disambiguateByMatch(Vec<ResolutionCandidate*>&   candidates,
     ResolutionCandidate* candidate1         = candidates.v[i];
     bool                 singleMostSpecific = true;
 
-    if (candidate1->fn->isInitializer()) {
-      forGenericInit = true;
-    }
+    bool forGenericInit = candidate1->fn->isInitializer();
 
     EXPLAIN("%s\n\n", toString(candidate1->fn));
 

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -3479,7 +3479,7 @@ disambiguateByMatch(Vec<ResolutionCandidate*>&   candidates,
   return disambiguateByMatch(candidates, DC, ignoreWhere, false, ambiguous);
 }
 
-
+// BHARSH INIT TODO: Do we need 'forGenericInit' anymore?
 static ResolutionCandidate*
 disambiguateByMatch(Vec<ResolutionCandidate*>&   candidates,
                     const DisambiguationContext& DC,

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -3501,6 +3501,10 @@ disambiguateByMatch(Vec<ResolutionCandidate*>&   candidates,
     ResolutionCandidate* candidate1         = candidates.v[i];
     bool                 singleMostSpecific = true;
 
+    if (candidate1->fn->isInitializer()) {
+      forGenericInit = true;
+    }
+
     EXPLAIN("%s\n\n", toString(candidate1->fn));
 
     if (notBest[i]) {

--- a/test/classes/initializers/generics/reuse-class-instantiation3.chpl
+++ b/test/classes/initializers/generics/reuse-class-instantiation3.chpl
@@ -1,0 +1,40 @@
+class Foo {
+  type T;
+  var x: T;
+
+  proc init(param is_int: bool) {
+    writeln("init(param)");
+    T = if is_int then int else real;
+    x = if is_int then 1 else 2;
+  }
+
+  proc init(val: ?T) {
+    writeln("init(?T)");
+    this.T = T;
+    this.x = val;
+  }
+
+  proc init(param is_int: bool, val: ?T) {
+    writeln("init(param, ?T)");
+    // Problem was here: unresolved call
+    // Compiler was incorrectly comparing method token and 'this' types
+    this.init(is_int);
+    this.x = val;
+  }
+
+  proc writeThis(f) {
+    f.write(T:string, " x=", x);
+  }
+}
+
+proc main() {
+  var f1 = new Foo(true);
+  writeln("\t", f1); // int(64) x=1
+  var f2 = new Foo(3:int(32));
+  writeln("\t", f2); // int(32) x=3
+  var f3 = new Foo(true, 4);
+  writeln("\t", f3); // int(64) x=4
+
+  delete f3, f2, f1;
+}
+

--- a/test/classes/initializers/generics/reuse-class-instantiation3.good
+++ b/test/classes/initializers/generics/reuse-class-instantiation3.good
@@ -1,0 +1,7 @@
+init(param)
+	int(64) x=1
+init(?T)
+	int(32) x=3
+init(param, ?T)
+init(param)
+	int(64) x=4


### PR DESCRIPTION
The 'forGenericInit' argument appeared to only be true for generic records, when it should have been true for generic classes as well. Instead of trying to thread another boolean through, we can check for the presence of an initializer while disambiguating.

Resolves #9459

Testing:
- [x] local + futures
- [x] subset of gasnet
  - [x] distributions/
  - [x] classes/initializers/
  - [x] release/