### PR TITLE
Update helper classes in distributions to use initializers

### DIFF
--- a/modules/dists/BlockCycDist.chpl
+++ b/modules/dists/BlockCycDist.chpl
@@ -449,10 +449,15 @@ class LocBlockCyclic {
   // Constructor computes what chunk of index(1) is owned by the
   // current locale
   //
-  proc LocBlockCyclic(param rank: int,
-                 type idxType, 
-                 locid,   // the locale index from the target domain
-                 dist: unmanaged BlockCyclic(rank, idxType)) { // reference to glob dist
+  proc init(param rank: int,
+            type idxType,
+            locid,   // the locale index from the target domain
+            dist: unmanaged BlockCyclic(rank, idxType)) { // reference to glob dist
+    this.rank = rank;
+    this.idxType = idxType;
+
+    this.complete();
+
     if rank == 1 {
       const lo = dist.lowIdx(1) + (locid * dist.blocksize(1));
       const str = dist.blocksize(1) * dist.targetLocDom.numIndices;
@@ -685,6 +690,7 @@ proc BlockCyclicDom.dsiIndexOrder(i) {
 ////////////////////////////////////////////////////////////////////////////////
 // BlockCyclic Local Domain Class
 //
+pragma "use default init"
 class LocBlockCyclicDom {
   param rank: int;
   type idxType;
@@ -998,6 +1004,7 @@ iter BlockCyclicDom.dsiLocalSubdomains() {
 ////////////////////////////////////////////////////////////////////////////////
 // BlockCyclic Local Array Class
 //
+pragma "use default init"
 class LocBlockCyclicArr {
   type eltType;
   param rank: int;

--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -353,6 +353,7 @@ class BlockDom: BaseRectangularDom {
 // stridable: generic domain stridable parameter
 // myBlock: a non-distributed domain that defines the local indices
 //
+pragma "use default init"
 class LocBlockDom {
   param rank: int;
   type idxType;
@@ -392,6 +393,7 @@ class BlockArr: BaseRectangularArr {
 // locDom: reference to local domain class
 // myElems: a non-distributed array of local elements
 //
+pragma "use default init"
 class LocBlockArr {
   type eltType;
   param rank: int;
@@ -626,11 +628,13 @@ proc Block.targetLocsIdx(ind: rank*idxType) {
   return if rank == 1 then result(1) else result;
 }
 
-proc LocBlock.LocBlock(param rank: int,
-                      type idxType, 
-                      locid, // the locale index from the target domain
-                      boundingBox: rank*range(idxType),
-                      targetLocBox: rank*range) {
+proc LocBlock.init(param rank: int,
+                   type idxType,
+                   locid, // the locale index from the target domain
+                   boundingBox: rank*range(idxType),
+                   targetLocBox: rank*range) {
+  this.rank = rank;
+  this.idxType = idxType;
   if rank == 1 {
     const lo = boundingBox(1).low;
     const hi = boundingBox(1).high;

--- a/modules/dists/CyclicDist.chpl
+++ b/modules/dists/CyclicDist.chpl
@@ -953,14 +953,6 @@ class LocCyclicArr {
 
   // INIT TODO: using default-init resulted in extra GETs for the tests in
   // distributions/robust/arithmetic/performance/multilocale
-  proc init(type eltType, param rank : int, type idxType, param stridable : bool,
-            locDom : LocCyclicDom(rank, idxType, stridable)) {
-    this.eltType = eltType;
-    this.rank = rank;
-    this.idxType = idxType;
-    this.stridable = stridable;
-    this.locDom = locDom;
-  }
 
   // These functions will always be called on this.locale, and so we do
   // not have an on statement around the while loop below (to avoid

--- a/modules/dists/CyclicDist.chpl
+++ b/modules/dists/CyclicDist.chpl
@@ -417,7 +417,10 @@ class LocCyclic {
 
   const myChunk: domain(rank, idxType, true);
 
-  proc LocCyclic(param rank, type idxType, locid, dist: Cyclic(rank, idxType)) {
+  proc init(param rank, type idxType, locid, dist: Cyclic(rank, idxType)) {
+    this.rank = rank;
+    this.idxType = idxType;
+
     var locidx: rank*idxType;
     var startIdx = dist.startIdx;
 
@@ -642,6 +645,7 @@ proc CyclicDom.dsiLocalSlice(param stridable: bool, ranges) {
 }
 
 
+pragma "use default init"
 class LocCyclicDom {
   param rank: int;
   type idxType;
@@ -947,6 +951,17 @@ class LocCyclicArr {
   var locRADLock: atomicbool; // This will only be accessed locally, so
                               // force the use of processor atomics
 
+  // INIT TODO: using default-init resulted in extra GETs for the tests in
+  // distributions/robust/arithmetic/performance/multilocale
+  proc init(type eltType, param rank : int, type idxType, param stridable : bool,
+            locDom : LocCyclicDom(rank, idxType, stridable)) {
+    this.eltType = eltType;
+    this.rank = rank;
+    this.idxType = idxType;
+    this.stridable = stridable;
+    this.locDom = locDom;
+  }
+
   // These functions will always be called on this.locale, and so we do
   // not have an on statement around the while loop below (to avoid
   // the repeated on's from calling testAndSet()).
@@ -983,7 +998,13 @@ class LocCyclicRADCache /* : LocRADCache */ {
   var startIdx: rank*idxType;
   var targetLocDomDimLength: rank*idxType;
 
-  proc LocCyclicRADCache(param rank: int, type idxType, startIdx, targetLocDom) {
+  proc init(param rank: int, type idxType, startIdx, targetLocDom) {
+    this.rank = rank;
+    this.idxType = idxType;
+    this.startIdx = startIdx;
+
+    this.complete();
+
     for param i in 1..rank do
       // NOTE: Not bothering to check to see if length can fit into idxType
       targetLocDomDimLength(i) = targetLocDom.dim(i).length:idxType;

--- a/modules/dists/CyclicDist.chpl
+++ b/modules/dists/CyclicDist.chpl
@@ -993,7 +993,6 @@ class LocCyclicRADCache /* : LocRADCache */ {
   proc init(param rank: int, type idxType, startIdx, targetLocDom) {
     this.rank = rank;
     this.idxType = idxType;
-    this.startIdx = startIdx;
 
     this.complete();
 

--- a/modules/dists/DimensionalDist2D.chpl
+++ b/modules/dists/DimensionalDist2D.chpl
@@ -332,6 +332,7 @@ class DimensionalDom : BaseRectangularDom {
   var localDdescs: [dist.targetIds] unmanaged locDescTypeHelper(rank, idxType, dom1, dom2); // locDdescType
 }
 
+pragma "use default init"
 class LocDimensionalDom {
   type myStorageDomT;
 
@@ -373,6 +374,7 @@ class DimensionalArr : BaseRectangularArr {
                       unmanaged LocDimensionalArr(eltType, allocDom.locDdescType);
 }
 
+pragma "use default init"
 class LocDimensionalArr {
   type eltType;
   const locDom;  // a LocDimensionalDom

--- a/modules/dists/ReplicatedDist.chpl
+++ b/modules/dists/ReplicatedDist.chpl
@@ -207,6 +207,7 @@ class ReplicatedDom : BaseRectangularDom {
 //
 // local domain class
 //
+pragma "use default init"
 class LocReplicatedDom {
   // copy from the global domain
   param rank: int;
@@ -443,6 +444,7 @@ proc _array.replicand(loc: locale) ref {
 //
 // local array class
 //
+pragma "use default init"
 class LocReplicatedArr {
   // these generic fields let us give types to the other fields easily
   type eltType;

--- a/modules/dists/SparseBlockDist.chpl
+++ b/modules/dists/SparseBlockDist.chpl
@@ -284,6 +284,7 @@ class SparseBlockDom: BaseSparseDomImpl {
 // stridable: generic domain stridable parameter
 // mySparseBlock: a non-distributed domain that defines the local indices
 //
+pragma "use default init"
 class LocSparseBlockDom {
   param rank: int;
   type idxType;
@@ -467,6 +468,7 @@ class SparseBlockArr: BaseSparseArr {
 // locDom: reference to local domain class
 // myElems: a non-distributed array of local elements
 //
+pragma "use default init"
 class LocSparseBlockArr {
   type eltType;
   param rank: int;

--- a/modules/dists/StencilDist.chpl
+++ b/modules/dists/StencilDist.chpl
@@ -300,6 +300,7 @@ class StencilDom: BaseRectangularDom {
 // NeighDom will be a rectangular domain where each dimension is the range
 // -1..1
 //
+pragma "use default init"
 class LocStencilDom {
   param rank: int;
   type idxType;
@@ -344,6 +345,7 @@ class StencilArr: BaseRectangularArr {
 // locDom: reference to local domain class
 // myElems: a non-distributed array of local elements
 //
+pragma "use default init"
 class LocStencilArr {
   type eltType;
   param rank: int;
@@ -578,11 +580,13 @@ proc Stencil.targetLocsIdx(ind: rank*idxType) {
   return if rank == 1 then result(1) else result;
 }
 
-proc LocStencil.LocStencil(param rank: int,
-                      type idxType, 
-                      locid, // the locale index from the target domain
-                      boundingBox: rank*range(idxType),
-                      targetLocBox: rank*range) {
+proc LocStencil.init(param rank: int,
+                     type idxType,
+                     locid, // the locale index from the target domain
+                     boundingBox: rank*range(idxType),
+                     targetLocBox: rank*range) {
+  this.rank = rank;
+  this.idxType = idxType;
   if rank == 1 {
     const lo = boundingBox(1).low;
     const hi = boundingBox(1).high;

--- a/modules/dists/dims/BlockCycDim.chpl
+++ b/modules/dists/dims/BlockCycDim.chpl
@@ -46,13 +46,13 @@ This Block-Cyclic dimension specifier is for use with the
 It specifies the mapping of indices in its dimension
 that would be produced by a 1D :class:`~BlockCycDist.BlockCyclic` distribution.
 
-**Constructor Arguments**
+**Initializer Arguments**
 
-The ``BlockCyclicDim`` class constructor is defined as follows:
+The ``BlockCyclicDim`` class initializer is defined as follows:
 
   .. code-block:: chapel
 
-    proc BlockCyclicDim(
+    proc init(
       numLocales:   int,
       lowIdx:       int,
       blockSize:    int,
@@ -73,6 +73,7 @@ The arguments are as follows:
       is used internally by the implementation and
       should not be specified by the user code
 */
+pragma "use default init"
 class BlockCyclicDim {
   // distribution parameters
   const numLocales: int;
@@ -85,9 +86,10 @@ class BlockCyclicDim {
   // tell the compiler these are positive
   proc blockSizePos   return blockSize: bcdPosInt;
   proc numLocalesPos  return numLocales: bcdPosInt;
-  const cycleSizePos: bcdPosInt = blockSizePos * numLocalesPos;
+  const cycleSizePos: bcdPosInt = (blockSize:bcdPosInt) * (numLocales:bcdPosInt);
 }
 
+pragma "use default init"
 class BlockCyclic1dom {
   type idxType;
   type stoIndexT;
@@ -100,7 +102,7 @@ class BlockCyclic1dom {
   proc rangeT type  return range(idxType, BoundedRangeType.bounded, stridable);
 
   // our range, normalized; its absolute stride
-  var wholeR: rangeT;
+  var wholeR: range(idxType, BoundedRangeType.bounded, stridable);
   var wholeRstrideAbs: idxType;
 
   // a copy of BlockCyclicDim constants
@@ -114,6 +116,7 @@ class BlockCyclic1dom {
   var dsiSetIndicesUnimplementedCase: bool;
 }
 
+pragma "use default init"
 class BlockCyclic1locdom {
   type idxType;
   type stoIndexT;
@@ -183,7 +186,7 @@ proc BlockCyclic1dom.dsiLocalDescUsesPrivatizedGlobalDesc1d() param return false
 
 
 // Check all restrictions/assumptions that must be satisfied by the user
-// when constructing a 1-d BlockCyclic distribution.
+// when initializing a 1-d BlockCyclic distribution.
 inline proc BlockCyclicDim.checkInvariants() {
   assert(blockSize > 0, "BlockCyclic1d-blockSize");
   assert(numLocales > 0, "BlockCyclic1d-numLocales");

--- a/modules/dists/dims/BlockDim.chpl
+++ b/modules/dists/dims/BlockDim.chpl
@@ -31,28 +31,22 @@ This Block dimension specifier is for use with the
 It specifies the mapping of indices in its dimension
 that would be produced by a 1D :class:`~BlockDist.Block` distribution.
 
-**Constructor Arguments**
+**Initializer Arguments**
 
-The following ``BlockDim`` class constructors are available:
+The following ``BlockDim`` class initializers are available:
 
   .. code-block:: chapel
 
-    proc BlockDim.BlockDim(
+    proc BlockDim.init(
       numLocales,
       boundingBoxLow,
       boundingBoxHigh,
       type idxType = boundingBoxLow.type)
 
-    proc BlockDim.BlockDim(
+    proc BlockDim.init(
       numLocales: int,
       boundingBox: range(?),
       type idxType = boundingBox.idxType)
-
-.. Is there also the compiler-generated constructor:
-   proc BlockDim.BlockDim(type idxType, numLocales: int, bbStart, bbLength)
-   If so, do we want to list it here?
-   Ideally, the compiler will not generate that constructor
-   since user-defined constructors are provided
 
 The ``numLocales`` argument specifies the number of locales
 that this dimension's bounding box is to be distributed over.
@@ -80,6 +74,7 @@ class BlockDim {
   proc boundingBox return bbStart .. (bbStart + bbLength - 1);
 }
 
+pragma "use default init"
 class Block1dom {
   type idxType;
   param stridable: bool;
@@ -88,7 +83,7 @@ class Block1dom {
   proc rangeT type  return range(idxType, BoundedRangeType.bounded, stridable);
 
   // our range
-  var wholeR: rangeT;
+  var wholeR: range(idxType, BoundedRangeType.bounded, stridable);
 
   // privatized distribution descriptor
   const pdist;
@@ -96,18 +91,20 @@ class Block1dom {
   proc dsiSetIndicesUnimplementedCase param return false;
 }
 
+pragma "use default init"
 class Block1locdom {
   var myRange;
 }
 
 
-/////////// user constructor, for convenience
+/////////// user initializer, for convenience
 
-proc BlockDim.BlockDim(numLocales: int, boundingBox: range(?),
-                 type idxType = boundingBox.idxType)
+proc BlockDim.init(numLocales: int, boundingBox: range(?),
+                   type idxType = boundingBox.idxType)
 {
   if !isBoundedRange(boundingBox) then
-    compilerError("The 1-d block descriptor constructor was passed an unbounded range as the boundingBox");
+    compilerError("The 1-d block descriptor initializer was passed an unbounded range as the boundingBox");
+  this.idxType = idxType;
 
   this.numLocales = numLocales;
   this.bbStart = boundingBox.low;
@@ -126,8 +123,9 @@ proc BlockDim.dsiPrivatize1d(privatizeData) {
   return new unmanaged BlockDim(privatizeData, this.idxType);
 }
 
-// constructor for privatization
-proc BlockDim.BlockDim(privatizeData, type idxType) {
+// initializer for privatization
+proc BlockDim.init(privatizeData, type idxType) {
+  this.idxType = idxType;
   numLocales = privatizeData(1);
   bbStart = privatizeData(2);
   bbLength = privatizeData(3);
@@ -168,11 +166,12 @@ proc Block1dom.dsiLocalDescUsesPrivatizedGlobalDesc1d() param return false;
 /////////// privatization - end
 
 
-// Constructor. idxType is inferred from the 'bbLow' argument
+// Initializer. idxType is inferred from the 'bbLow' argument
 // (alternative: default to 'int' instead).
-proc BlockDim.BlockDim(numLocales, boundingBoxLow, boundingBoxHigh, type idxType = boundingBoxLow.type) {
+proc BlockDim.init(numLocales, boundingBoxLow, boundingBoxHigh, type idxType = boundingBoxLow.type) {
   if !(boundingBoxLow <= boundingBoxHigh) then halt("'BlockDim' distribution must have a non-empty bounding box between boundingBoxLow and boundingBoxHigh; got ", boundingBoxLow, " .. ", boundingBoxHigh);
   assert(numLocales > 0); // so we can cast it to any int type
+  this.idxType = idxType;
   this.numLocales = numLocales;
   this.bbStart = boundingBoxLow;
   this.bbLength = (boundingBoxHigh - boundingBoxLow + 1):idxType;

--- a/modules/dists/dims/ReplicatedDim.chpl
+++ b/modules/dists/dims/ReplicatedDim.chpl
@@ -38,16 +38,17 @@ in the same dimension. This is similar to the Replicated distribution
 in that it always accesses the local replicand, whereas the Replicated
 distribution accesses all replicands in certain cases, as specified there.
 
-**Constructor Arguments**
+**Initializer Arguments**
 
-The ``ReplicatedDim`` class constructor is available as follows:
+The ``ReplicatedDim`` class initializer is available as follows:
 
   .. code-block:: chapel
 
-    proc ReplicatedDim.ReplicatedDim(numLocales:int)
+    proc ReplicatedDim.init(numLocales:int)
 
 It creates a dimension specifier for replication over ``numLocales`` locales.
 */
+pragma "use default init"
 class ReplicatedDim {
   // REQ over how many locales
   // todo: can the Dimensional do without this one?
@@ -60,6 +61,7 @@ class ReplicatedDim {
   var localLocIDlegit = false;
 }
 
+pragma "use default init"
 class Replicated1dom {
   // REQ the parameters of our dimension of the domain being created
   type idxType;
@@ -70,7 +72,7 @@ class Replicated1dom {
 //todo-remove?  proc domainT type return domain(1, idxType, stridable);
 
   // our range
-  var wholeR: rangeT;
+  var wholeR: range(idxType, BoundedRangeType.bounded, stridable);
 
   // locale ID in our dimension of the locale this instance is on
   var localLocID = invalidLocID;
@@ -80,6 +82,7 @@ class Replicated1dom {
   proc dsiSetIndicesUnimplementedCase param return false;
 }
 
+pragma "use default init"
 class Replicated1locdom {
   type stoIndexT;
   param stridable;


### PR DESCRIPTION
This PR updates the various ``Loc`` helper classes in distributions to use initializers. Many can be trivially converted by applying the 'use default init' pragma, but some need to be translated from constructors to initializers.

Resolves #9314 

Testing:
- [x] local + futures
- [x] gasnet + futures