### PR TITLE
Add a SET_LINENO call to resolve #9493

### DIFF
--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -537,6 +537,8 @@ static void insertUnrefForArrayReturn(FnSymbol* fn) {
           if ((rhsType->symbol->hasFlag(FLAG_ARRAY) == true ||
                rhsType->symbol->hasFlag(FLAG_ITERATOR_RECORD)) &&
               isTypeExpr(call->get(2))             == false) {
+
+            SET_LINENO(call);
             Expr*      rhs       = call->get(2)->remove();
             VarSymbol* tmp       = newTemp(arrayUnrefName, rhsType);
             CallExpr*  initTmp   = new CallExpr(PRIM_MOVE,     tmp, rhs);


### PR DESCRIPTION
insertUnrefForArrayReturn needed a SET_LINENO to avoid an internal error.
Fixes #9493.

Passed full local testing.
Trivial and not reviewed.
