### PR TITLE
Optionally limit the number of parallel makes to CHPL_MAKE_MAX_CPU_COUNT

### DIFF
--- a/util/buildRelease/chpl-make-cpu_count
+++ b/util/buildRelease/chpl-make-cpu_count
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+""" prints Python cpu_count(), optionally capped by env var CHPL_MAKE_MAX_CPU_COUNT
+"""
+import os
+import multiprocessing
+cpus = multiprocessing.cpu_count()
+try:
+  max = os.getenv('CHPL_MAKE_MAX_CPU_COUNT', '0')
+  if int(max) > 0:
+    cpus = min(int(max), cpus)
+except:
+  pass
+print(cpus)

--- a/util/buildRelease/gen_release
+++ b/util/buildRelease/gen_release
@@ -117,6 +117,7 @@ if (exists($ENV{"CHPL_GEN_RELEASE_NO_CLONE"})) {
        "highlight/README.md",
        "util/README",
        "util/build_configs.py",
+       "util/buildRelease/chpl-make-cpu_count",
        "util/buildRelease/install.sh",
        "util/chpl-completion.bash",
        "util/printchplenv",

--- a/util/buildRelease/smokeTest
+++ b/util/buildRelease/smokeTest
@@ -109,7 +109,7 @@ echo ""
 
 # Number of logical processes on current system. Will be used as number of jobs
 # when calling make with parallel execution.
-num_procs=$(python -c "import multiprocessing; print(multiprocessing.cpu_count())")
+num_procs=$($CHPL_HOME/util/buildRelease/chpl-make-cpu_count)
 
 # If make check fails, store the log file in CHPL_HOME. Also, create a temp dir
 # in $CHPL_HOME where the hello*.chpl tests are copied and run.

--- a/util/buildRelease/testReleaseHelp
+++ b/util/buildRelease/testReleaseHelp
@@ -14,7 +14,7 @@ set mymake = $argv[1]
 
 # Number of logical processes on current system. Will be used as number of jobs
 # when calling make with parallel execution.
-set num_procs = `python -c "import multiprocessing; print(multiprocessing.cpu_count())"`
+set num_procs = `${0:h}/chpl-make-cpu_count`
 
 #
 # execute actions specified in README

--- a/util/build_configs.py
+++ b/util/build_configs.py
@@ -301,7 +301,18 @@ def build_chpl(chpl_home, build_config, env, parallel=False, verbose=False):
 
     make_cmd = chpl_make.get()
     if parallel:
-        make_cmd += ' --jobs={0}'.format(multiprocessing.cpu_count())
+        def _cpu_count:
+            """ return Python cpu_count(), optionally capped by env var CHPL_MAKE_MAX_CPU_COUNT
+            """
+            cpus = multiprocessing.cpu_count()
+            try:
+                max = os.getenv('CHPL_MAKE_MAX_CPU_COUNT', '0')
+                if int(max) > 0:
+                    cpus = min(int(max), cpus)
+            except:
+                pass
+            return cpus
+        make_cmd += ' --jobs={0}'.format(_cpu_count())
     logging.debug('Using make command: {0}'.format(make_cmd))
 
     with elapsed_time(build_config):

--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -281,7 +281,8 @@ if ($basetmpdir eq "") {
 
 # Number of logical processes on current system. Will be used as number of jobs
 # when calling make with parallel execution.
-$num_procs = `python -c "import multiprocessing; print(multiprocessing.cpu_count())"`;
+$here = dirname(__FILE__);
+$num_procs = `$here/../buildRelease/chpl-make-cpu_count`;
 chomp($num_procs);
 
 $cronlogdir = $ENV{'CHPL_NIGHTLY_CRON_LOGDIR'};

--- a/util/pastPerformance/getoldperf
+++ b/util/pastPerformance/getoldperf
@@ -63,7 +63,8 @@ $somethingfailed = 0;
 
 # Number of logical processes on current system. Will be used as number of jobs
 # when calling make with parallel execution.
-$num_procs = `python -c "import multiprocessing; print(multiprocessing.cpu_count())"`;
+$here = dirname(__FILE__);
+$num_procs = `$here/../buildRelease/chpl-make-cpu_count`;
 chomp($num_procs);
 
 #

--- a/util/tokencount/tokctnightly
+++ b/util/tokencount/tokctnightly
@@ -116,7 +116,8 @@ if ($debug == 1) {
 
 # Number of logical processes on current system. Will be used as number of jobs
 # when calling make with parallel execution.
-$num_procs = `python -c "import multiprocessing; print(multiprocessing.cpu_count())"`;
+$here = dirname(__FILE__);
+$num_procs = `$here/../buildRelease/chpl-make-cpu_count`;
 chomp($num_procs);
 
 mysystem("cd $tokctdir && make > /dev/null", "building token counter", 1, 1);


### PR DESCRIPTION
Chapel build and test scripts have often used parallel makes, like
    "make -j $cpu_count"
where $cpu_count is obtained from the multiprocessing.cpu_count() Python
function.

Unfortunately, Python's cpu_count() can return a ridiculously high number,
when run on ARM-based processors.

This change introduces an optional env variable CHPL_MAKE_MAX_CPU_COUNT,
which sets an upper bound on the number of parallel makes ($cpu_count).
CHPL_MAKE_MAX_CPU_COUNT is highly recommended when running on ARM-based processors.
Also may be used on x86 machines to voluntarily limit the load.

If CHPL_MAKE_MAX_CPU_COUNT is not found or not a positive number, then Python's
cpu_count is used, same as before this change - even on ARM-based processors.

Implements https://github.com/chapel-lang/chapel/issues/9243

Note: requires a corresponding change in chapel-code, to pass CHPL_MAKE_MAX_CPU_COUNT to the ssh processes that execute the builds for each configuration. 