### PR TITLE
Limit the number of parallel makes to a fixed maximum of 24

### DIFF
--- a/util/buildRelease/smokeTest
+++ b/util/buildRelease/smokeTest
@@ -109,7 +109,7 @@ echo ""
 
 # Number of logical processes on current system. Will be used as number of jobs
 # when calling make with parallel execution.
-num_procs=$(python -c "import multiprocessing; print(multiprocessing.cpu_count())")
+num_procs=$(python -c "import multiprocessing; print(min(24, multiprocessing.cpu_count()))")
 
 # If make check fails, store the log file in CHPL_HOME. Also, create a temp dir
 # in $CHPL_HOME where the hello*.chpl tests are copied and run.

--- a/util/buildRelease/testReleaseHelp
+++ b/util/buildRelease/testReleaseHelp
@@ -14,7 +14,7 @@ set mymake = $argv[1]
 
 # Number of logical processes on current system. Will be used as number of jobs
 # when calling make with parallel execution.
-set num_procs = `python -c "import multiprocessing; print(multiprocessing.cpu_count())"`
+set num_procs = `python -c "import multiprocessing; print(min(24, multiprocessing.cpu_count()))"`
 
 #
 # execute actions specified in README

--- a/util/build_configs.py
+++ b/util/build_configs.py
@@ -301,7 +301,7 @@ def build_chpl(chpl_home, build_config, env, parallel=False, verbose=False):
 
     make_cmd = chpl_make.get()
     if parallel:
-        make_cmd += ' --jobs={0}'.format(multiprocessing.cpu_count())
+        make_cmd += ' --jobs={0}'.format(min(24, multiprocessing.cpu_count()))
     logging.debug('Using make command: {0}'.format(make_cmd))
 
     with elapsed_time(build_config):

--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -281,7 +281,7 @@ if ($basetmpdir eq "") {
 
 # Number of logical processes on current system. Will be used as number of jobs
 # when calling make with parallel execution.
-$num_procs = `python -c "import multiprocessing; print(multiprocessing.cpu_count())"`;
+$num_procs = `python -c "import multiprocessing; print(min(24, multiprocessing.cpu_count()))"`;
 chomp($num_procs);
 
 $cronlogdir = $ENV{'CHPL_NIGHTLY_CRON_LOGDIR'};

--- a/util/pastPerformance/getoldperf
+++ b/util/pastPerformance/getoldperf
@@ -63,7 +63,7 @@ $somethingfailed = 0;
 
 # Number of logical processes on current system. Will be used as number of jobs
 # when calling make with parallel execution.
-$num_procs = `python -c "import multiprocessing; print(multiprocessing.cpu_count())"`;
+$num_procs = `python -c "import multiprocessing; print(min(24, multiprocessing.cpu_count()))"`;
 chomp($num_procs);
 
 #

--- a/util/tokencount/tokctnightly
+++ b/util/tokencount/tokctnightly
@@ -116,7 +116,7 @@ if ($debug == 1) {
 
 # Number of logical processes on current system. Will be used as number of jobs
 # when calling make with parallel execution.
-$num_procs = `python -c "import multiprocessing; print(multiprocessing.cpu_count())"`;
+$num_procs = `python -c "import multiprocessing; print(min(24, multiprocessing.cpu_count()))"`;
 chomp($num_procs);
 
 mysystem("cd $tokctdir && make > /dev/null", "building token counter", 1, 1);


### PR DESCRIPTION
Chapel build and test scripts have often used parallel makes, like
    "make -j $cpu_count"
where $cpu_count is obtained from the multiprocessing.cpu_count() Python
function.

Unfortunately, Python's cpu_count() can return a ridiculously high number,
when run on ARM-based processors.

This change simply forces $cpu_count <= 24, in all existing instances
of make -j $cpu_count. "24" is an arbitrary constant.

Implements https://github.com/chapel-lang/chapel/issues/9243