### PR TITLE
Suppress pip 10 warnings for venv builds

### DIFF
--- a/third-party/chpl-venv/Makefile
+++ b/third-party/chpl-venv/Makefile
@@ -30,8 +30,8 @@ $(CHPL_VENV_INSTALL_DIR):
 
 # Install pip via get-pip.py to ensure we have an updated version
 $(PIP): $(CHPL_VENV_INSTALL_DIR)
-	@echo "Installing local copy of pip with get-pip.py from $(GETPIP)"
 	@if [ -z "$$CHPL_PIP" ]; then \
+	  echo "Installing local copy of pip with get-pip.py from $(GETPIP)"; \
 	  (cd install && curl -O $(GETPIP) || \
 	  { echo "Failed on command: curl -O $(GETPIP)."; \
 	    echo "Try setting CHPL_PIP to $$(which pip) and trying again"; \

--- a/third-party/chpl-venv/Makefile.include
+++ b/third-party/chpl-venv/Makefile.include
@@ -49,6 +49,7 @@ ifdef CHPL_PIP
   PIP = $(CHPL_PIP)
 else
   PIP=$(CHPL_VENV_INSTALL_DIR)/bin/pip
+  CHPL_PIP_INSTALL_PARAMS=$$CHPL_PIP_INSTALL_PARAMS --no-warn-conflicts --no-warn-script-location
 endif
 
 # If using python 2.6, get an older version of pip


### PR DESCRIPTION
`pip 10` includes new warnings and flags to suppress them:

- a warning about installing a scripts into a location that is not included in `PATH`
- a warning about missing dependencies for any pip packages globally installed

We can guarantee that we're using `pip 10` or greater when installing pip from `get-pip.py`, so this PR adds the suppression flags under that condition.

This PR suppresses the `get-pip.py` message unless we are actually installing `pip`.