### PR TITLE
Fix double-free for initializers with const-in formal

### DIFF
--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -1338,10 +1338,12 @@ static void addLocalCopiesAndWritebacks(FnSymbol*  fn,
         fn->insertAtHead(new CallExpr(PRIM_MOVE, tmp, formal));
 
         // Default-initializers and '_new' wrappers take ownership
-        // TODO: check for leaks with new wrapper around user init with 'in'
-        // formal
-        if (fn->isDefaultInit() == false &&
-            fn->hasFlag(FLAG_NEW_WRAPPER) == false) {
+        // Note: FLAG_INSERT_AUTO_DESTROY is blindly applied to any formal
+        // with const-in intent at the start of this function, so we need
+        // to apply FLAG_NO_AUTO_DESTROY to avoid double-frees.
+        if (fn->hasFlag(FLAG_NEW_WRAPPER) || fn->isDefaultInit()) {
+          tmp->addFlag(FLAG_NO_AUTO_DESTROY);
+        } else {
           tmp->addFlag(FLAG_INSERT_AUTO_DESTROY);
         }
       }

--- a/test/classes/initializers/memory/explicit-const-in.chpl
+++ b/test/classes/initializers/memory/explicit-const-in.chpl
@@ -1,0 +1,32 @@
+
+// BHARSH 2018-05-11: At one point the compiler was handling destruction of
+// formals with 'const in' intent differently from 'in' intent. This test
+// tracks the amount of initializing and destroying to avoid future
+// double-frees.
+
+record R {
+  var x : int;
+  proc init() {
+    this.x = 0;
+    writeln("R.init: ", x);
+  }
+  proc init(other:R) {
+    this.x = other.x + 1;
+    writeln("R.init(R): ", x);
+  }
+  proc deinit() {
+    writeln("R.deinit: ", x);
+  }
+}
+
+class C {
+  var r : R;
+  proc init(const in r : R) {
+    this.r = r;
+  }
+}
+
+var r = new R();
+var c = new C(r);
+writeln("c = ", c);
+delete c;

--- a/test/classes/initializers/memory/explicit-const-in.good
+++ b/test/classes/initializers/memory/explicit-const-in.good
@@ -1,0 +1,7 @@
+R.init: 0
+R.init(R): 1
+R.init(R): 2
+R.deinit: 1
+c = {r = (x = 2)}
+R.deinit: 2
+R.deinit: 0


### PR DESCRIPTION
A portion of ``addLocalCopiesAndWritebacks`` took special care to not add FLAG_INSERT_AUTO_DESTROY for default initializers or _new wrappers. It failed to take into account that other parts of the compiler could add that problematic flag. Instead, add FLAG_NO_AUTO_DESTROY explicitly.

Testing:
- [x] local + futures
- [x] memleaks