### PR TITLE
Fix CHPL_PIP_INSTALL_PARAMS append from #9504

### DIFF
--- a/third-party/chpl-venv/Makefile
+++ b/third-party/chpl-venv/Makefile
@@ -37,7 +37,7 @@ $(PIP): $(CHPL_VENV_INSTALL_DIR)
 	    echo "Try setting CHPL_PIP to $$(which pip) and trying again"; \
 	    exit 1; } && \
 	  export PYTHONUSERBASE=$(CHPL_VENV_INSTALL_DIR) && \
-	  python get-pip.py --user) \
+	  python get-pip.py --user --no-warn-conflicts) \
 	fi
 
 # Install virtualenv program.

--- a/third-party/chpl-venv/Makefile.include
+++ b/third-party/chpl-venv/Makefile.include
@@ -49,7 +49,7 @@ ifdef CHPL_PIP
   PIP = $(CHPL_PIP)
 else
   PIP=$(CHPL_VENV_INSTALL_DIR)/bin/pip
-  CHPL_PIP_INSTALL_PARAMS=$$CHPL_PIP_INSTALL_PARAMS --no-warn-conflicts --no-warn-script-location
+  CHPL_PIP_INSTALL_PARAMS := $(CHPL_PIP_INSTALL_PARAMS) --no-warn-conflicts --no-warn-script-location
 endif
 
 # If using python 2.6, get an older version of pip

--- a/third-party/chpl-venv/Makefile.include
+++ b/third-party/chpl-venv/Makefile.include
@@ -49,7 +49,7 @@ ifdef CHPL_PIP
   PIP = $(CHPL_PIP)
 else
   PIP=$(CHPL_VENV_INSTALL_DIR)/bin/pip
-  CHPL_PIP_INSTALL_PARAMS := $(CHPL_PIP_INSTALL_PARAMS) --no-warn-conflicts --no-warn-script-location
+  CHPL_PIP_INSTALL_PARAMS += --no-warn-conflicts --no-warn-script-location
 endif
 
 # If using python 2.6, get an older version of pip


### PR DESCRIPTION
Use `+=` to append to `CHPL_PIP_INSTALL_PARAMS`

Also, added `--no-warn-conflicts` to the `get-pip.py` call, since it can also emit conflict warnings, and will always be using pip versions `10` or greater.