### PR TITLE
Separate suppression flags out of CHPL_PIP_INSTALL_PARAMS

### DIFF
--- a/third-party/chpl-venv/Makefile
+++ b/third-party/chpl-venv/Makefile
@@ -43,7 +43,7 @@ $(PIP): $(CHPL_VENV_INSTALL_DIR)
 # Install virtualenv program.
 $(CHPL_VENV_VIRTUALENV): check-exes $(PIP)
 	export PYTHONPATH="$$CHPL_PYTHONPATH:$(PIPLIBS):$$PYTHONPATH" && \
-	python -S $(PIP) install -U --force-reinstall --ignore-installed \
+	python -S $(PIP) install -U --force-reinstall --ignore-installed $(LOCAL_PIP_FLAGS) \
 	 --prefix=$(CHPL_VENV_INSTALL_DIR) $(CHPL_PIP_INSTALL_PARAMS) $(shell cat virtualenv.txt)
 
 # Phony convenience target for installing virtualenv.
@@ -74,7 +74,7 @@ $(CHPL_VENV_TEST_REQS): $(CHPL_VENV_VIRTUALENV_DIR)
 	export PATH=$(CHPL_VENV_VIRTUALENV_BIN):$$PATH && \
 	export VIRTUAL_ENV=$(CHPL_VENV_VIRTUALENV_DIR) && \
 	python $(CHPL_VENV_VIRTUALENV_BIN)/pip install \
-	-U --force-reinstall $(CHPL_PIP_INSTALL_PARAMS) -r test-requirements.txt && \
+	-U --force-reinstall $(CHPL_PIP_INSTALL_PARAMS) $(LOCAL_PIP_FLAGS) -r test-requirements.txt && \
 	python $(CHPL_VENV_VIRTUALENV) --relocatable $(CHPL_VENV_VIRTUALENV_DIR) && \
 	touch $(CHPL_VENV_TEST_REQS)
 
@@ -83,7 +83,7 @@ $(CHPL_VENV_SPHINX_BUILD): $(CHPL_VENV_VIRTUALENV_DIR)
 	export PATH=$(CHPL_VENV_VIRTUALENV_BIN):$$PATH && \
 	export VIRTUAL_ENV=$(CHPL_VENV_VIRTUALENV_DIR) && \
 	python $(CHPL_VENV_VIRTUALENV_BIN)/pip install \
-	-U --force-reinstall $(CHPL_PIP_INSTALL_PARAMS) -r chpldoc-requirements.txt && \
+	-U --force-reinstall $(CHPL_PIP_INSTALL_PARAMS) $(LOCAL_PIP_FLAGS) -r chpldoc-requirements.txt && \
 	python $(CHPL_VENV_VIRTUALENV) --relocatable $(CHPL_VENV_VIRTUALENV_DIR)
 
 $(CHPL_VENV_CHPLSPELL_REQS): $(CHPL_VENV_VIRTUALENV_DIR)
@@ -91,7 +91,7 @@ $(CHPL_VENV_CHPLSPELL_REQS): $(CHPL_VENV_VIRTUALENV_DIR)
 	export PATH=$(CHPL_VENV_VIRTUALENV_BIN):$$PATH && \
 	export VIRTUAL_ENV=$(CHPL_VENV_VIRTUALENV_DIR) && \
 	python $(CHPL_VENV_VIRTUALENV_BIN)/pip install \
-	-U --force-reinstall $(CHPL_PIP_INSTALL_PARAMS) -r chplspell-requirements.txt && \
+	-U --force-reinstall $(CHPL_PIP_INSTALL_PARAMS) $(LOCAL_PIP_FLAGS) -r chplspell-requirements.txt && \
 	python $(CHPL_VENV_VIRTUALENV) --relocatable $(CHPL_VENV_VIRTUALENV_DIR) && \
 	touch $(CHPL_VENV_CHPLSPELL_REQS)
 

--- a/third-party/chpl-venv/Makefile.include
+++ b/third-party/chpl-venv/Makefile.include
@@ -49,8 +49,13 @@ ifdef CHPL_PIP
   PIP = $(CHPL_PIP)
 else
   PIP=$(CHPL_VENV_INSTALL_DIR)/bin/pip
-  CHPL_PIP_INSTALL_PARAMS += --no-warn-conflicts --no-warn-script-location
+  # Only add params if locally installed pip was successfully installed
+  ifeq ($(wildcard $(PIP)),)
+  else
+    CHPL_PIP_INSTALL_PARAMS += --no-warn-conflicts --no-warn-script-location
+  endif
 endif
+
 
 # If using python 2.6, get an older version of pip
 ifeq ($(PYTHON_VERSION), 2.6)

--- a/third-party/chpl-venv/Makefile.include
+++ b/third-party/chpl-venv/Makefile.include
@@ -49,11 +49,8 @@ ifdef CHPL_PIP
   PIP = $(CHPL_PIP)
 else
   PIP=$(CHPL_VENV_INSTALL_DIR)/bin/pip
-  # Only add params if locally installed pip was successfully installed
-  ifeq ($(wildcard $(PIP)),)
-  else
-    CHPL_PIP_INSTALL_PARAMS += --no-warn-conflicts --no-warn-script-location
-  endif
+  # This must be separate from global CHPL_PIP_INSTALL_PARAMS
+  LOCAL_PIP_FLAGS=--no-warn-conflicts --no-warn-script-location
 endif
 
 

--- a/tools/c2chapel/Makefile
+++ b/tools/c2chapel/Makefile
@@ -55,7 +55,7 @@ venv:
 ifneq ($(wildcard $(VIRTUAL_ENV)),)
 	$(info Using system virtualenv)
 else ifneq ($(wildcard $(THIRD_PARTY_VENV)),)
-	$(eval VIRTUAL_ENV=$(THIRD_PARTY_VENV))
+	$(eval VIRTUAL_ENV=PYTHONPATH=$(PIPLIBS) && $(THIRD_PARTY_VENV))
 	$(info Using chpl-venv virtualenv ($(VIRTUAL_ENV)))
 else
 	$(error Unable to find virtualenv. Either install virtualenv yourself \
@@ -73,8 +73,9 @@ c2chapel: venv
 	./utils/fixFakes.sh $(FAKES) $(PWD)/utils/custom.h
 
 	$(VIRTUAL_ENV) $(VENV_DIR)
+
 	. $(VENV_DIR)/bin/activate && \
-	  python $(VENV_DIR)/bin/pip install $(INSTALL)/$(TAR) && \
+	  python $(VENV_DIR)/bin/pip install $(CHPL_PIP_INSTALL_PARAMS) $(INSTALL)/$(TAR) && \
 	  python $(VENV_DIR)/bin/pip install $(CHPL_PIP_INSTALL_PARAMS) argparse
 
 check:

--- a/tools/c2chapel/Makefile
+++ b/tools/c2chapel/Makefile
@@ -56,6 +56,8 @@ ifneq ($(wildcard $(VIRTUAL_ENV)),)
 	$(info Using system virtualenv)
 else ifneq ($(wildcard $(THIRD_PARTY_VENV)),)
 	$(eval VIRTUAL_ENV=PYTHONPATH=$(PIPLIBS) && $(THIRD_PARTY_VENV))
+	# Add warning suppression flags
+	$(eval VENV_PIP_FLAGS=--no-warn-conflicts --no-warn-script-location)
 	$(info Using chpl-venv virtualenv ($(VIRTUAL_ENV)))
 else
 	$(error Unable to find virtualenv. Either install virtualenv yourself \
@@ -75,8 +77,8 @@ c2chapel: venv
 	$(VIRTUAL_ENV) $(VENV_DIR)
 
 	. $(VENV_DIR)/bin/activate && \
-	  python $(VENV_DIR)/bin/pip install $(CHPL_PIP_INSTALL_PARAMS) $(INSTALL)/$(TAR) && \
-	  python $(VENV_DIR)/bin/pip install $(CHPL_PIP_INSTALL_PARAMS) argparse
+	  python $(VENV_DIR)/bin/pip install $(VENV_PIP_FLAGS) $(INSTALL)/$(TAR) && \
+	  python $(VENV_DIR)/bin/pip install $(VENV_PIP_FLAGS) $(CHPL_PIP_INSTALL_PARAMS) argparse
 
 check:
 	cd test && ./tester.sh


### PR DESCRIPTION
`make c2chapel` failed on a testing machine using an older system `virtualenv`, which consequently installed an older `pip` version.  This was caused by the `c2chapel/Makefile` including the `chpl-venv/Makefile.include`, which was assuming `pip` 10 or greater whenever `CHPL_PIP` was not set. That assumption broke down here, since the version of `pip` in `c2chapel/Makefile` relies on the version of `virtualenv` instead.

To work around this, I have split off the version-dependent flags into a separate variable which is set and used in the correct conditions.

Separately, this PR fixes a bug I discovered where using the Chapel `virtualenv` from `c2chapel/Makefile` resulted in an import error (needed to update `PYTHONPATH`).

**Testing**
- [x] locally (OS X)
- [x] linux64