### PR TITLE
Fix self-inflicted Python error introduced in PR #9496.

### DIFF
--- a/util/build_configs.py
+++ b/util/build_configs.py
@@ -301,7 +301,7 @@ def build_chpl(chpl_home, build_config, env, parallel=False, verbose=False):
 
     make_cmd = chpl_make.get()
     if parallel:
-        def _cpu_count:
+        def _cpu_count():
             """ return Python cpu_count(), optionally capped by env var CHPL_MAKE_MAX_CPU_COUNT
             """
             cpus = multiprocessing.cpu_count()


### PR DESCRIPTION
PR #9496 touched util/build_config.py (as well as other files), and I did not test them all.
I am chagrined. This change corrects the obvious Python error I inflicted on build_config.py.
