### PR TITLE
Skip tpv/arrays.chpl upon --baseline

### DIFF
--- a/test/parallel/forall/task-private-vars/arrays.skipif
+++ b/test/parallel/forall/task-private-vars/arrays.skipif
@@ -1,3 +1,6 @@
 # The output is different for multi-locale,
 # so we do not run there.
 CHPL_COMM != none
+# Iterator classes leak with --baseline,
+# so skip that testing too.
+COMPOPTS <= --baseline


### PR DESCRIPTION
Iterator classes leak in --baseline mode,
causing .good mismatch for this test.
So skip it upon baseline.

(These leaks are independent of task-private variables.)
