### PR TITLE
fix gasnet test after out error deprecation

### DIFF
--- a/test/io/ferguson/remote-error/error2.chpl
+++ b/test/io/ferguson/remote-error/error2.chpl
@@ -23,7 +23,13 @@ for i in 0..#numLocales {
       stdout.flush();
     }
 
-    stdout.writef("%", 1, error=errs[i]);
+    try {
+      stdout.writef("%", 1);
+    } catch e: SystemError {
+      errs[i] = e.err;
+    } catch {
+      errs[i] = e.err;
+    }
 
     writeln("loc ", i, " error ", errorToString(errs[i]));
     stdout.flush();

--- a/test/io/ferguson/remote-error/error2.chpl
+++ b/test/io/ferguson/remote-error/error2.chpl
@@ -28,7 +28,7 @@ for i in 0..#numLocales {
     } catch e: SystemError {
       errs[i] = e.err;
     } catch {
-      errs[i] = e.err;
+      errs[i] = EINVAL;
     }
 
     writeln("loc ", i, " error ", errorToString(errs[i]));


### PR DESCRIPTION
#9450 caused the failure of `test/io/ferguson/remote-error/error2.chpl` because the test uses a deprecated function. This fix changes the test to use the current function.