### PR TITLE
Skip certain TPV tests under NUMA

### DIFF
--- a/test/parallel/forall/task-private-vars/block.skipif
+++ b/test/parallel/forall/task-private-vars/block.skipif
@@ -1,0 +1,3 @@
+# As of this writing, this test generates fewer tasks under NUMA,
+# which makes the output different and causes mismatch against .good.
+CHPL_LOCALE_MODEL == numa

--- a/test/parallel/forall/task-private-vars/local-slice.skipif
+++ b/test/parallel/forall/task-private-vars/local-slice.skipif
@@ -1,0 +1,3 @@
+# As of this writing, this test generates fewer tasks under NUMA,
+# which makes the output different and causes mismatch against .good.
+CHPL_LOCALE_MODEL == numa

--- a/test/parallel/forall/task-private-vars/refs.skipif
+++ b/test/parallel/forall/task-private-vars/refs.skipif
@@ -1,0 +1,3 @@
+# As of this writing, this test generates fewer tasks under NUMA,
+# which makes the output different and causes mismatch against .good.
+CHPL_LOCALE_MODEL == numa


### PR DESCRIPTION
The DefaultRectangularDom leader iterator spawns just 1 task under NUMA where it spawns multiple tasks under FLAT. This causes the output of these three tests to change and testing to fail.

I am adding skipif to avoid testing failures under NUMA.

BTW this does not seem to be the case for the standalone iterator, which is unaware of sublocales and so behaves identically under NUMA and under FLAT.