### PR TITLE
update README, TestSystem.rst for Valgrind.rst

### DIFF
--- a/doc/rst/developer/bestPractices/README
+++ b/doc/rst/developer/bestPractices/README
@@ -51,3 +51,6 @@ SpellChecking.rst
 
 Potpourri.txt
   Notes not in any of the above categories.
+
+Valgrind.rst
+  Building the Chapel compiler so that compiled programs work with valgrind.

--- a/doc/rst/developer/bestPractices/TestSystem.rst
+++ b/doc/rst/developer/bestPractices/TestSystem.rst
@@ -746,6 +746,10 @@ stored in the ``typeTests/`` and ``OOPTests/`` subdirectories.
 If invoked without any arguments, ``start_test`` will start in the current
 directory and recursively look for tests in subdirectories.
 
+If invoked with the ``--valgrind`` flag, ``start_test`` will compile the
+program and execute it with ``valgrind``. To learn about best practices with
+``valgrind``, see ``Valgrind.rst``.
+
 Performance Testing
 -------------------
 To run performance testing, add the ``--performance`` flag to ``start_test``

--- a/doc/rst/developer/bestPractices/TestSystem.rst
+++ b/doc/rst/developer/bestPractices/TestSystem.rst
@@ -747,7 +747,7 @@ If invoked without any arguments, ``start_test`` will start in the current
 directory and recursively look for tests in subdirectories.
 
 If invoked with the ``--valgrindexe`` flag, ``start_test`` will compile the
-program and execute it with ``valgrind``. The flag ``--valgrind`` does the
+program and execute it with ``valgrind``. The ``--valgrind`` flag does the
 same, plus it also runs the compiler under ``valgrind``, which increases
 testing time compared to ``--valgrindexe``. To learn about best practices
 with ``valgrind``, see ``Valgrind.rst``.

--- a/doc/rst/developer/bestPractices/TestSystem.rst
+++ b/doc/rst/developer/bestPractices/TestSystem.rst
@@ -746,9 +746,11 @@ stored in the ``typeTests/`` and ``OOPTests/`` subdirectories.
 If invoked without any arguments, ``start_test`` will start in the current
 directory and recursively look for tests in subdirectories.
 
-If invoked with the ``--valgrind`` flag, ``start_test`` will compile the
-program and execute it with ``valgrind``. To learn about best practices with
-``valgrind``, see ``Valgrind.rst``.
+If invoked with the ``--valgrindexe`` flag, ``start_test`` will compile the
+program and execute it with ``valgrind``. The flag ``--valgrind`` does the
+same, plus it also runs the compiler under ``valgrind``, which increases
+testing time compared to ``--valgrindexe``. To learn about best practices
+with ``valgrind``, see ``Valgrind.rst``.
 
 Performance Testing
 -------------------


### PR DESCRIPTION
At Vass's suggestion, I have updated `bestPractices/README` and `bestPractices/TestSystem.rst` to reflect the new Valgrind instructions.