### PR TITLE
Remove BlockCycDist's copy initializer

### DIFF
--- a/modules/dists/BlockCycDist.chpl
+++ b/modules/dists/BlockCycDist.chpl
@@ -257,6 +257,18 @@ class BlockCyclic : BaseDist {
       for loc in locDist do writeln(loc);
   }
 
+  // copy initializer for privatization
+  proc init(other: unmanaged BlockCyclic(rank, idxType)) {
+    this.rank = other.rank;
+    this.idxType = other.idxType;
+    lowIdx = other.lowIdx;
+    blocksize = other.blocksize;
+    targetLocDom = other.targetLocDom;
+    targetLocales = other.targetLocales;
+    locDist = other.locDist;
+    dataParTasksPerLocale = other.dataParTasksPerLocale;
+  }
+
   proc dsiClone() {
     return new unmanaged BlockCyclic(lowIdx, blocksize, targetLocales, dataParTasksPerLocale);
   }

--- a/modules/dists/BlockCycDist.chpl
+++ b/modules/dists/BlockCycDist.chpl
@@ -257,18 +257,6 @@ class BlockCyclic : BaseDist {
       for loc in locDist do writeln(loc);
   }
 
-  // copy initializer for privatization
-  proc init(param rank: int, type idxType, other: unmanaged BlockCyclic(rank, idxType)) {
-    this.rank = rank;
-    this.idxType = idxType;
-    lowIdx = other.lowIdx;
-    blocksize = other.blocksize;
-    targetLocDom = other.targetLocDom;
-    targetLocales = other.targetLocales;
-    locDist = other.locDist;
-    dataParTasksPerLocale = other.dataParTasksPerLocale;
-  }
-
   proc dsiClone() {
     return new unmanaged BlockCyclic(lowIdx, blocksize, targetLocales, dataParTasksPerLocale);
   }

--- a/modules/dists/BlockCycDist.chpl
+++ b/modules/dists/BlockCycDist.chpl
@@ -258,7 +258,7 @@ class BlockCyclic : BaseDist {
   }
 
   // copy initializer for privatization
-  proc init(other: unmanaged BlockCyclic(rank, idxType)) {
+  proc init(other: unmanaged BlockCyclic) {
     this.rank = other.rank;
     this.idxType = other.idxType;
     lowIdx = other.lowIdx;
@@ -664,7 +664,7 @@ proc BlockCyclicDom.dsiSupportsPrivatization() param return true;
 proc BlockCyclicDom.dsiGetPrivatizeData() return 0;
 
 proc BlockCyclicDom.dsiPrivatize(privatizeData) {
-  var privateDist = new unmanaged BlockCyclic(rank, idxType, dist);
+  var privateDist = new unmanaged BlockCyclic(dist);
   var c = new unmanaged BlockCyclicDom(rank=rank, idxType=idxType, stridable=stridable, dist=privateDist);
   c.locDoms = locDoms;
   c.whole = whole;


### PR DESCRIPTION
The copy initializer wasn't a true copy initializer, since it had an extra
argument for the type and param fields.  Those aren't necessary in the
initializer world, and with the arguments removed, the initializer looks
basically identical to what the compiler generated copy initializer would look
like, so remove it entirely.

Still needs testing over:
- [x] local paratest (out of paranoia)
- [ ] dist cyclic nightly testing
- [ ] gasnet with release/examples and multilocale/