### PR TITLE
Fix reindex bulk-transfer for non-strided domains

### DIFF
--- a/modules/internal/ArrayViewReindex.chpl
+++ b/modules/internal/ArrayViewReindex.chpl
@@ -753,6 +753,8 @@ module ArrayViewReindex {
         const relStride = max(1, (dims(d).stride / updom.dsiDim(d).stride) * downdom.dsiDim(d).stride);
         // Slicing the ranges preserves the stride
         ranges(d) = downdom.dsiDim(d)[actualLow(d)..actualHigh(d) by relStride];
+      } else {
+        ranges(d) = downdom.dsiDim(d)[actualLow(d)..actualHigh(d)];
       }
     }
     return {(...ranges)};

--- a/test/optimizations/bulkcomm/bharshbarg/misc.chpl
+++ b/test/optimizations/bulkcomm/bharshbarg/misc.chpl
@@ -85,4 +85,11 @@ proc main() {
     var A, B : [1..4, 1..4, 1..4, 1..4] int;
     stridedAssign(A[1, 1..4, 1..4, 1], B[1..4, 1, 1, 1..4]);
   }
+  {
+    // Based on #9457
+    var A : [1..8] int = 1..8;
+    ref reA = A.reindex(1..8);
+    var temp = reA[5..8];
+    stridedAssign(reA[1..4], temp);
+  }
 }

--- a/test/optimizations/bulkcomm/bharshbarg/reindexNoStride.chpl
+++ b/test/optimizations/bulkcomm/bharshbarg/reindexNoStride.chpl
@@ -1,0 +1,51 @@
+
+use util;
+
+iter halves(dom) {
+  var ret : dom.rank*range;
+  for i in 0..#2**dom.rank {
+    for j in 0..#dom.rank {
+      const r = dom.dim(j+1);
+      if i & 1<<j then ret(j+1) = r[r.low + r.size/2..];
+      else ret(j+1) = r[..r.high - r.size/2];
+    }
+    yield ret;
+  }
+}
+
+proc assignHalves(left, right) {
+  var ldoms = halves(left.domain);
+  var rdoms = halves(right.domain);
+  assert(ldoms.size == rdoms.size);
+  for (i, j) in zip(1..ldoms.size, 1..rdoms.size by -1) {
+    stridedAssign(left[(...ldoms[i])], right[(...rdoms[j])]);
+  }
+}
+
+proc testDim(param rank : int) {
+  var ones, zeroes : rank*range;
+  for param i in 1..rank {
+    ones(i) = 1..8;
+    zeroes(i) = 0..7;
+  }
+
+  var oneDom = {(...ones)};
+  var zeroDom = {(...zeroes)};
+  var A, B : [oneDom] int;
+  ref oneA = A.reindex(oneDom);
+  ref oneB = B.reindex(oneDom);
+  ref zeroA = A.reindex(zeroDom);
+  ref zeroB = B.reindex(zeroDom);
+
+  stridedAssign(oneA, oneB);
+  stridedAssign(zeroA, zeroB);
+
+  assignHalves(oneA, zeroB);
+  assignHalves(zeroA, oneB);
+}
+
+proc main() {
+  for param i in 1..3 {
+    testDim(i);
+  }
+}


### PR DESCRIPTION
PR #9460 fixed a variety of reindex transfer bugs, but failed to handle non-strided domains. The ``stridedAssignDR`` test converts all domains to be strided (i.e. at least 'by 1'), so the non-strided case was untested. This PR introduces a new test dedicated to non-strided reindexes.

Testing:
- [x] local + futures
- [x] subset of gasnet (arrays/, distributions/, optimizations/, release/)