### PR TITLE
Fix reversed sense of vectorize enable flag

### DIFF
--- a/compiler/codegen/CForLoop.cpp
+++ b/compiler/codegen/CForLoop.cpp
@@ -189,9 +189,9 @@ GenRet CForLoop::codegen()
 
     llvm::MDNode* loopMetadata = nullptr;
     if(fNoVectorize == false && isOrderIndependent()) {
-      bool addVectorizeEnable = true;
+      bool addVectorizeEnable = false;
 #ifdef HAVE_LLVM_RV
-      addVectorizeEnable = false;
+      addVectorizeEnable = true;
 #endif
       loopMetadata = generateLoopMetadata(addVectorizeEnable);
       info->loopStack.emplace(loopMetadata, true);


### PR DESCRIPTION
In #9567 , explicit vectorization metadata was enabled when not using the Region Vectorizer, causing messages about failed vectorization to print out.  This causes some tests to fail.

This happened because the metadata was enabled when not using the RV, and disabled when using the RV.  I believe it was meant to be the other way around.
