### PR TITLE
Preserve non-ref type for ref-intent formals

### DIFF
--- a/compiler/codegen/expr.cpp
+++ b/compiler/codegen/expr.cpp
@@ -2267,7 +2267,9 @@ GenRet codegenArgForFormal(GenRet arg,
     // We need to pass a reference in these cases
     // Don't pass a reference to extern functions
     // Do if requiresCPtr or the argument is of reference type
-    if (isExtern) {
+    if (isExtern &&
+        (!(formal->intent & INTENT_FLAG_REF) ||
+         formal->type->getValType()->symbol->hasFlag(FLAG_TUPLE))) {
       // Don't pass by reference to extern functions
     } else if (formal->requiresCPtr() ||
                formal->isRef() || formal->isWideRef()) {

--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -150,7 +150,10 @@ static void updateIfRefFormal(FnSymbol* fn, ArgSymbol* formal) {
   if (needRefFormal(fn, formal, &needRefIntent) == true) {
     makeRefType(formal->type);
 
-    if (formal->type->refType) {
+    if (formal->intent & INTENT_FLAG_REF) {
+      // Nothing to do. A ref intent is enough to indicate ref-ness.
+
+    } else if (formal->type->refType) {
       formal->type = formal->type->refType;
 
     } else {


### PR DESCRIPTION
This is a step towards eliminating ref types from (most of) the compiler,
by disabling the conversion to a ref type during resolution
for formals with explicit ref intents.

This matches the already-existing behavior of formals with the default
intent, which have non-ref types even if they are records.

To make this work, this change adjusts codegen to add address-of in
certain cases, and removeDeadStringLiteral() to match the more concise
string-literal-initialization pattern that this change results in.

Testing: linux64 --verify and gasnet on multilocale tests.
