### PR TITLE
fix RandomNumber6 on baseline

### DIFF
--- a/test/exercises/RandomNumber6.execenv
+++ b/test/exercises/RandomNumber6.execenv
@@ -8,4 +8,4 @@ CHPL_RT_NUM_THREADS_PER_LOCALE=100
 # of the tasks are small. Note that this is not an issue for fifo
 # since not every task has it's own stack.
 #
-CHPL_RT_CALL_STACK_SIZE=64k
+CHPL_RT_CALL_STACK_SIZE=128k


### PR DESCRIPTION
`test/exercises/RandomNumber6.chpl` was segfaulting in the baseline testing configuration as a result of #9450. The likely culprit is that the deprecation of out error in favor of error handling increased the size of each stack frame, thus requiring a larger stack size to allocate all the necessary memory.  This change expands the stack size under start_test.