### PR TITLE
Fix comm count regression due to change in nested tuples

### DIFF
--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -1253,16 +1253,24 @@ proc Block.dsiReprivatize(other, reprivatizeData) {
 
 proc BlockDom.dsiSupportsPrivatization() param return true;
 
-proc BlockDom.dsiGetPrivatizeData() return (dist.pid, whole.dims());
+pragma "use default init"
+record BlockDomPrvData {
+  var distpid;
+  var dims;
+}
+
+proc BlockDom.dsiGetPrivatizeData() {
+  return new BlockDomPrvData(dist.pid, whole.dims());
+}
 
 proc BlockDom.dsiPrivatize(privatizeData) {
-  var privdist = chpl_getPrivatizedCopy(dist.type, privatizeData(1));
+  var privdist = chpl_getPrivatizedCopy(dist.type, privatizeData.distpid);
   // in initializer we have to pass sparseLayoutType as it has no default value
   var c = new unmanaged BlockDom(rank=rank, idxType=idxType, stridable=stridable,
       sparseLayoutType=privdist.sparseLayoutType, dist=privdist);
   for i in c.dist.targetLocDom do
     c.locDoms(i) = locDoms(i);
-  c.whole = {(...privatizeData(2))};
+  c.whole = {(...privatizeData.dims)};
   return c;
 }
 

--- a/test/distributions/robust/arithmetic/performance/multilocale/assignReindex.chpl
+++ b/test/distributions/robust/arithmetic/performance/multilocale/assignReindex.chpl
@@ -1,17 +1,23 @@
 use driver_domains;
 
+config const doVerboseComm = false;
+
 const bigDom4D = Dom4D.expand((1,1,1,1));
 var A: [bigDom4D] 4*int = {(...bigDom4D.dims())};
 var B: [Dom4D] 4*int;
 
 resetCommDiagnostics();
 startCommDiagnostics();
+if doVerboseComm then startVerboseComm();
 ref Areind = A.reindex({0..n4+1,0..n4+1,0..n4+1,0..n4+1});
+if doVerboseComm then stopVerboseComm();
 stopCommDiagnostics();
 writeln(getCommDiagnostics());
 resetCommDiagnostics();
 startCommDiagnostics();
+if doVerboseComm then startVerboseComm();
 B = Areind;
+if doVerboseComm then stopVerboseComm();
 stopCommDiagnostics();
 writeln(getCommDiagnostics());
 

--- a/test/distributions/robust/arithmetic/performance/multilocale/assignReindex.replicated.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/assignReindex.replicated.good
@@ -1,2 +1,2 @@
-(put = 12, execute_on = 10, execute_on_nb = 9) (get = 62, put = 1, execute_on = 9, execute_on_fast = 3) (get = 62, put = 1, execute_on = 4, execute_on_fast = 3) (get = 62, put = 1, execute_on = 4, execute_on_fast = 3)
+(put = 12, execute_on = 10, execute_on_nb = 9) (get = 61, put = 1, execute_on = 9, execute_on_fast = 3) (get = 61, put = 1, execute_on = 4, execute_on_fast = 3) (get = 61, put = 1, execute_on = 4, execute_on_fast = 3)
 (<no communication>) (<no communication>) (<no communication>) (<no communication>)

--- a/test/distributions/robust/arithmetic/performance/multilocale/assignSlice.chpl
+++ b/test/distributions/robust/arithmetic/performance/multilocale/assignSlice.chpl
@@ -1,12 +1,16 @@
 use driver_domains;
 
+config const doVerboseComm = false;
+
 const bigDom4D = Dom4D.expand((1,1,1,1));
 var A: [bigDom4D] 4*int = {(...bigDom4D.dims())};
 var B: [Dom4D] 4*int;
 
 resetCommDiagnostics();
 startCommDiagnostics();
+if doVerboseComm then startVerboseComm();
 B = A[1..n4,1..n4,1..n4,1..n4];
+if doVerboseComm then stopVerboseComm();
 stopCommDiagnostics();
 writeln(getCommDiagnostics());
 for i in Dom4D do if B[i]!=i then writeln("ERROR: B[", i, "]==", B[i]);


### PR DESCRIPTION
PR #9572 changed the behavior of nested tuples so that they are captured by 
reference rather than by value. This had the impact of increasing comm counts 
for privatization when the privatization state includes a tuple of other
values. To address this problem, this PR modifies the distribution code where
the nested tuple causes new communication and replaces it with a record.

Issue #9610 discusses to what extent nested tuples should be captured by 
reference.

- [x] pass failing tests with replicated 
- [x] pass failing tests with block
- [x] full gasnet testing 

Reviewed by @benharsh - thanks!