### PR TITLE
Fix bugs with recursive-iterator argument bundles.

### DIFF
--- a/compiler/optimizations/remoteValueForwarding.cpp
+++ b/compiler/optimizations/remoteValueForwarding.cpp
@@ -104,7 +104,8 @@ static void updateLoopBodyClasses(Map<Symbol*, Vec<SymExpr*>*>& defMap,
   forv_Vec(AggregateType, ct, gAggregateTypes) {
     if (ct->symbol->hasFlag(FLAG_LOOP_BODY_ARGUMENT_CLASS)) {
       for_fields(field, ct) {
-        if (field->isRef()) {
+        if (field->hasFlag(FLAG_REF_TO_IMMUTABLE)) {
+          INT_ASSERT(field->isRef());
           if (isSafeToDerefField(defMap, useMap, field) == true) {
             Type* vt = field->getValType();
 

--- a/test/functions/iterators/recursive/follow-record-updates.chpl
+++ b/test/functions/iterators/recursive/follow-record-updates.chpl
@@ -1,0 +1,59 @@
+// Inpired by: test/release/examples/primers/iterators.chpl
+
+/////////////////////////////////
+
+class Tree {
+  var first: bool;
+  var left: owned Tree;
+}
+
+iter postorder(tree: Tree): Tree {
+  if tree != nil {
+
+    for child in postorder(tree.left) do
+      yield child;
+
+    yield tree;
+  }
+}
+
+var GlobalTree = new owned Tree(true,
+                   new owned Tree(false,
+                     new owned Tree(true,
+                       new owned Tree(false
+                         ))));
+
+/////////////////////////////////
+
+record RRR {
+  var FFF: int = 3;
+}
+
+var GlobalRec: RRR;
+
+proc update() {
+  GlobalRec.FFF += 10;
+  writeln("updating FFF to ", GlobalRec.FFF);
+}
+
+proc report(const ref REPO: RRR) {
+  writeln("FFF = ", REPO.FFF);
+}
+
+/////////////////////////////////
+
+// The former bug was not seen if we add 'const ref' to 'ARG'.
+proc WriteThis(ARG: RRR) {
+
+  for node in postorder(GlobalTree) {
+    if node.first {
+      report(ARG);
+    } else {
+      update();
+    }
+  }
+}
+
+proc main {
+  WriteThis(GlobalRec);
+}

--- a/test/functions/iterators/recursive/follow-record-updates.good
+++ b/test/functions/iterators/recursive/follow-record-updates.good
@@ -1,0 +1,4 @@
+updating FFF to 13
+FFF = 13
+updating FFF to 23
+FFF = 23


### PR DESCRIPTION
* Ensure that references are passed as references.
Add a test that shows where this was broken.

* Ensure that references are remote-value-forwarded
only when the thing being referenced cannot change.
The newly-added test does not work correctly without this fix.

These bugs were not exposed in our testing because of
low test coverage for recursive iterators.

The original code for RVF for recursive-iterator argument bundles
appears due to r16357, r16375:
https://github.com/chapel-lang/chapel/commit/91e6c748e24a0b288b267a22e28043379329c4f6
https://github.com/chapel-lang/chapel/commit/42c872068bc73a50a9a0387cbcf9c2e29ada0b0b

Possible future improvements:

* Change remote value forwarding for recursive-iterator argument
bundles, updateLoopBodyClasses(), to invoke the same implementation as
RVF for on-function arg bundles, updateTaskFunctions(). The latter is
well tested and should be more robust than the existing
updateLoopBodyClasses().

* Run inferConstRefs() at start of lowerIterators(), rather than
or in addition to at start of remoteValueForwarding(). That way
bundleLoopBodyFnArgsForIteratorFnCall() will mark more bundle fields
with FLAG_REF_TO_IMMUTABLE, enabling more remote value forwarding
for those. This is for recursive-iterator arg bundles only.

* When recursive-iterator-arg-bundle field DOES get forwarded, streamline
the following pattern in the corresponding _rec_iter_loop_wrapper_XXX function:

    MyRecord _arg5 = *(bundle->_arg5);
    _rec_iter_loop_XXX(..., &_arg5, ...);

by either passing &(bundle->_arg5) into _rec_iter_loop_XXX, or
changing _rec_iter_loop_XXX to accept that argument by value, to allow
C-level optimizations within that function.

Testing:
- [x] linux64 --verify
- [x] gasnet (full paratest)
