### PR TITLE
Add flag to specify classes are unmanaged by default

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -460,7 +460,8 @@ void AggregateType::addDeclaration(DefExpr* defExpr) {
                      "or union",
                      name);
     } else {
-      ArgSymbol* arg = new ArgSymbol(fn->thisTag, "this", this);
+      ArgSymbol* arg = new ArgSymbol(fn->thisTag, "this", dtUnknown,
+                                     new UnresolvedSymExpr(this->symbol->name));
 
       fn->_this = arg;
 

--- a/compiler/include/driver.h
+++ b/compiler/include/driver.h
@@ -179,6 +179,7 @@ extern bool ignore_errors_for_pass;
 extern int  squelch_header_errors;
 extern bool fWarnConstLoops;
 extern bool fWarnUnstable;
+extern bool fDefaultUnmanaged;
 
 extern bool fReportOptimizedLoopIterators;
 extern bool fReportInlinedIterators;

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -143,6 +143,7 @@ bool fLLVMWideOpt = false;
 
 bool fWarnConstLoops = true;
 bool fWarnUnstable = false;
+bool fDefaultUnmanaged = false;
 
 // Enable all extra special warnings
 static bool fNoWarnSpecial = true;
@@ -958,6 +959,7 @@ static ArgumentDescription arg_desc[] = {
  {"report-promotion", ' ', NULL, "Print information about scalar promotion", "F", &fReportPromotion, NULL, NULL},
  {"report-scalar-replace", ' ', NULL, "Print scalar replacement stats", "F", &fReportScalarReplace, NULL, NULL},
  {"warn-unstable", ' ', NULL, "Enable [disable] warnings code that is about to change or recently changed behavior", "N", &fWarnUnstable, "CHPL_WARN_UNSTABLE", NULL},
+ {"default-unmanaged", ' ', NULL, "Enable [disable] class type defaulting to unmanaged", "N", &fDefaultUnmanaged, "CHPL_DEFAULT_UNMANAGED", NULL},
 
  {"", ' ', NULL, "Developer Flags -- Miscellaneous", NULL, NULL, NULL, NULL},
  {"break-on-id", ' ', NULL, "Break when AST id is created", "I", &breakOnID, "CHPL_BREAK_ON_ID", NULL},

--- a/compiler/passes/errorHandling.cpp
+++ b/compiler/passes/errorHandling.cpp
@@ -28,6 +28,7 @@
 #include "stmt.h"
 #include "symbol.h"
 #include "TryStmt.h"
+#include "UnmanagedClassType.h"
 #include "wellknown.h"
 
 #include <stack>
@@ -397,8 +398,12 @@ bool ErrorHandlingVisitor::enterCallExpr(CallExpr* node) {
     SymExpr*   thrownExpr  = toSymExpr(node->get(1)->remove());
     VarSymbol* thrownError = toVarSymbol(thrownExpr->symbol());
 
+    Type* thrownType = thrownError->typeInfo();
+    if (UnmanagedClassType* ut = toUnmanagedClassType(thrownType))
+      thrownType = ut->getCanonicalClass();
+
     // normalizeThrows should give us this invariant earlier
-    INT_ASSERT(thrownError->typeInfo() == dtError);
+    INT_ASSERT(thrownType == dtError);
 
     VarSymbol* fixedError = thrownError;
 

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -35,6 +35,7 @@
 #include "stringutil.h"
 #include "TryStmt.h"
 #include "visibleFunctions.h"
+#include "wellknown.h"
 
 #include <algorithm>
 #include <map>
@@ -695,6 +696,85 @@ void resolveUnresolvedSymExprs(BaseAST* inAst) {
    }
 }
 
+static void warnUnstableClassType(SymExpr* se) {
+  if (TypeSymbol* ts = toTypeSymbol(se->symbol())) {
+    if (isClass(ts->type)) {
+      if (se->getModule()->modTag == MOD_USER) {
+        CallExpr* inCall = toCallExpr(se->parentExpr);
+        DefExpr* inDef = toDefExpr(se->parentExpr);
+        FnSymbol* inFn = se->getFunction();
+        bool ok = false;
+        if (inCall) {
+          if (inCall->isNamed("_to_borrowed") ||
+              inCall->isNamed("_to_unmanaged") ||
+              inCall->isNamed("_owned") ||
+              inCall->isNamed("_shared") ||
+              inCall->isNamed("Owned") ||
+              inCall->isNamed("Shared")) {
+            // It's OK, it's decorated
+            ok = true;
+          }
+          if (inCall->baseExpr == se) {
+            // It's OK as the base of a call of a type method
+            ok = true;
+          }
+          if (inCall->isNamed(".") &&
+              inCall->get(1) == se) {
+            // Another pattern for the above case
+            ok = true;
+          }
+        }
+        // Always consider locale type unmanaged
+        if (ts->type == dtLocale)
+          ok = true;
+        // Always consider ddata type unmanaged
+        if (ts->hasFlag(FLAG_DATA_CLASS))
+          ok = true;
+        // Something with "no object" flag isn't really an object anyway
+        if (ts->hasFlag(FLAG_NO_OBJECT))
+          ok = true;
+
+        // Types in catch block specifications are OK
+        {
+          Expr* cur = se;
+          while (cur) {
+            if (CatchStmt* c = toCatchStmt(cur)) {
+              if (c->expr() == inDef) {
+                ok = true;
+                break;
+              }
+            }
+            cur = cur->parentExpr;
+          }
+        }
+
+        // Types in extern function procs are assumed to
+        // be unmanaged, so OK
+        if (inFn && inFn->hasFlag(FLAG_EXTERN))
+          ok = true;
+
+        if (!ok) {
+          // error
+          USR_WARN(se, "undecorated class type %s is unstable", ts->name);
+          if (inDef && se == inDef->exprType)
+              USR_PRINT(inDef, "in declared type for %s",
+                                   inDef->sym->name);
+
+          USR_PRINT(se, "use 'unmanaged %s' "
+                        "'owned %s', "
+                        "'borrowed %s', or "
+                        "'shared %s'",
+                        ts->name, ts->name, ts->name, ts->name);
+
+	  if (developer)
+	    USR_PRINT(se, "undecorated symexpr has id %i", se->id);
+
+        }
+      }
+    }
+  }
+}
+
 static void resolveUnresolvedSymExpr(UnresolvedSymExpr* usymExpr) {
   SET_LINENO(usymExpr);
 
@@ -709,6 +789,8 @@ static void resolveUnresolvedSymExpr(UnresolvedSymExpr* usymExpr) {
       SymExpr* symExpr = new SymExpr(sym);
 
       usymExpr->replace(symExpr);
+
+      if (fWarnUnstable) warnUnstableClassType(symExpr);
 
       updateMethod(usymExpr, sym, symExpr);
 

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -766,8 +766,8 @@ static void warnUnstableClassType(SymExpr* se) {
                         "'shared %s'",
                         ts->name, ts->name, ts->name, ts->name);
 
-	  if (developer)
-	    USR_PRINT(se, "undecorated symexpr has id %i", se->id);
+          if (developer)
+            USR_PRINT(se, "undecorated symexpr has id %i", se->id);
 
         }
       }

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5476,7 +5476,7 @@ static void moveHaltForUnacceptableTypes(CallExpr* call) {
     USR_FATAL(call, "unable to resolve type");
 
   } else if (rhsType == dtNil) {
-    if (lhsType != dtNil && isClass(lhsType) == false) {
+    if (lhsType != dtNil && isClassLike(lhsType) == false) {
       USR_FATAL(userCall(call),
                 "type mismatch in assignment from nil to %s",
                 toString(lhsType));

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1112,7 +1112,7 @@ module ChapelArray {
           // the distribution and possibly get the distribution to free.
           const inst = _instance;
           var (domToFree, distToRemove) = inst.remove();
-          var distToFree:BaseDist = nil;
+          var distToFree:unmanaged BaseDist = nil;
           if distToRemove != nil {
             distToFree = distToRemove.remove();
           }
@@ -2129,9 +2129,9 @@ module ChapelArray {
       if ! _unowned {
         on _instance {
           var (arrToFree, domToRemove) = _instance.remove();
-          var domToFree:BaseDom = nil;
-          var distToRemove:BaseDist = nil;
-          var distToFree:BaseDist = nil;
+          var domToFree:unmanaged BaseDom = nil;
+          var distToRemove:unmanaged BaseDist = nil;
+          var distToFree:unmanaged BaseDist = nil;
           // The dead code to access the fields of _instance are left in the
           // generated code with --baseline on. This means that these
           // statements cannot come after the _delete_arr call.
@@ -3692,7 +3692,7 @@ module ChapelArray {
     return isPODType(t);
   }
   proc chpl__supportedDataTypeForBulkTransfer(x: ?t) param where isUnionType(t) return false;
-  proc chpl__supportedDataTypeForBulkTransfer(x: object) param return false;
+  proc chpl__supportedDataTypeForBulkTransfer(x: borrowed object) param return false;
   proc chpl__supportedDataTypeForBulkTransfer(x) param return true;
 
   pragma "no doc"

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1043,7 +1043,7 @@ module ChapelBase {
 
     // Throw any error raised by a task this sync statement is waiting for
     if ! e.errors.empty() then
-      throw new TaskErrors(e.errors);
+      throw new unmanaged TaskErrors(e.errors);
   }
 
   pragma "command line setting"

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1099,7 +1099,7 @@ module ChapelBase {
 
   // this version handles unmanaged -> unmanaged
   pragma "unsafe"
-  inline proc _cast(type t, x:_unmanaged) where t:_unmanaged && t:x && (x.type != t)
+  inline proc _cast(type t:unmanaged, x:_unmanaged) where t:x && (x.type != t)
     return if x != nil then __primitive("dynamic_cast", t, x) else __primitive("cast", t, nil);
 
   // this version handles unmanaged -> borrow

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -124,7 +124,7 @@ module ChapelBase {
   inline proc ==(a: real(?w), b: real(w)) return __primitive("==", a, b);
   inline proc ==(a: imag(?w), b: imag(w)) return __primitive("==", a, b);
   inline proc ==(a: complex(?w), b: complex(w)) return a.re == b.re && a.im == b.im;
-  inline proc ==(a: object, b: object) return __primitive("ptr_eq", a, b);
+  inline proc ==(a: borrowed object, b: borrowed object) return __primitive("ptr_eq", a, b);
   inline proc ==(a: enumerated, b: enumerated) where (a.type == b.type) {
     return __primitive("==", a, b);
   }
@@ -140,7 +140,7 @@ module ChapelBase {
   inline proc !=(a: real(?w), b: real(w)) return __primitive("!=", a, b);
   inline proc !=(a: imag(?w), b: imag(w)) return __primitive("!=", a, b);
   inline proc !=(a: complex(?w), b: complex(w)) return a.re != b.re || a.im != b.im;
-  inline proc !=(a: object, b: object) return __primitive("ptr_neq", a, b);
+  inline proc !=(a: borrowed object, b: borrowed object) return __primitive("ptr_neq", a, b);
   inline proc !=(a: enumerated, b: enumerated) where (a.type == b.type) {
     return __primitive("!=", a, b);
   }
@@ -566,7 +566,7 @@ module ChapelBase {
   //   incorrectness; it is used to give better error messages for
   //   promotion of && and ||
   //
-  inline proc _cond_test(x: object) return x != nil;
+  inline proc _cond_test(x: borrowed object) return x != nil;
   inline proc _cond_test(x: bool) return x;
   inline proc _cond_test(x: integral) return x != 0:x.type;
 
@@ -581,7 +581,7 @@ module ChapelBase {
     compilerError("iterator or promoted expression ", x.type:string, " used in if or while condition");
   }
 
-  proc _cond_invalid(x: object) param return false;
+  proc _cond_invalid(x: borrowed object) param return false;
   proc _cond_invalid(x: bool) param return false;
   proc _cond_invalid(x: integral) param return false;
   proc _cond_invalid(x) param return true;
@@ -873,7 +873,7 @@ module ChapelBase {
   pragma "no default functions"
   pragma "use default init"
   class _EndCountBase {
-    var errors: chpl_TaskErrors;
+    var errors: unmanaged chpl_TaskErrors;
     var taskList: c_void_ptr = _defaultOf(c_void_ptr);
   }
 
@@ -964,7 +964,7 @@ module ChapelBase {
   // fork (on) if needed.
   pragma "dont disable remote value forwarding"
   pragma "down end count fn"
-  proc _downEndCount(e: _EndCount, err: Error) {
+  proc _downEndCount(e: _EndCount, err: unmanaged Error) {
     // save the task error
     chpl_save_task_error(e, err);
     // inform anybody waiting that we're done
@@ -999,7 +999,7 @@ module ChapelBase {
 
     // Throw any error raised by a task this is waiting for
     if ! e.errors.empty() then
-      throw new TaskErrors(e.errors);
+      throw new unmanaged TaskErrors(e.errors);
   }
 
   // called for bounded coforalls and cobegins
@@ -1020,7 +1020,7 @@ module ChapelBase {
 
     // Throw any error raised by a task this is waiting for
     if ! e.errors.empty() then
-      throw new TaskErrors(e.errors);
+      throw new unmanaged TaskErrors(e.errors);
   }
 
   proc _upDynamicEndCount(param countRunningTasks=true) {
@@ -1030,7 +1030,7 @@ module ChapelBase {
 
   pragma "dont disable remote value forwarding"
   pragma "down end count fn"
-  proc _downDynamicEndCount(err: Error) {
+  proc _downDynamicEndCount(err: unmanaged Error) {
     var e = __primitive("get dynamic end count");
     _downEndCount(e, err);
   }
@@ -1899,10 +1899,10 @@ module ChapelBase {
   class chpl_ModuleDeinit {
     const moduleName: c_string;          // for debugging; non-null, not owned
     const deinitFun:  c_fn_ptr;          // module deinit function
-    const prevModule: chpl_ModuleDeinit; // singly-linked list / LIFO queue
+    const prevModule: unmanaged chpl_ModuleDeinit; // singly-linked list / LIFO queue
     proc writeThis(ch) {ch.writef("chpl_ModuleDeinit(%s)",moduleName:string);}
   }
-  var chpl_moduleDeinitFuns = nil: chpl_ModuleDeinit;
+  var chpl_moduleDeinitFuns = nil: unmanaged chpl_ModuleDeinit;
 
   // What follows are the type _defaultOf methods, used to initialize types
   // Booleans

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1091,13 +1091,25 @@ module ChapelBase {
   inline proc _cast(type t, x) where t:object && x:_nilType
     return __primitive("cast", t, x);
 
+  // dynamic cast handles class casting based upon runtime class type
+  // this also might be called a downcast
   pragma "unsafe"
   inline proc _cast(type t, x) where x:object && t:x && (x.type != t)
     return if x != nil then __primitive("dynamic_cast", t, x) else __primitive("cast", t, nil);
 
+  // this version handles unmanaged -> unmanaged
   pragma "unsafe"
-  inline proc _cast(type t, x) where x:_unmanaged && t:_unmanaged && t:x && (x.type != t)
+  inline proc _cast(type t, x:_unmanaged) where t:_unmanaged && t:x && (x.type != t)
     return if x != nil then __primitive("dynamic_cast", t, x) else __primitive("cast", t, nil);
+
+  // this version handles unmanaged -> borrow
+  pragma "unsafe"
+  inline proc _cast(type t, x:_unmanaged) where t:object && t:_to_borrowed(x.type) && (x.type != t) {
+    // first convert to borrow
+    var casttmp = __primitive("to borrowed class", x);
+    // then cast the borrow
+    return if x != nil then __primitive("dynamic_cast", t, casttmp) else __primitive("cast", t, nil);
+  }
 
   inline proc _cast(type t, x:_nilType) where t == _nilType
     return nil;
@@ -1975,7 +1987,7 @@ module ChapelBase {
     return __primitive("cast", t, x);
   }
   // cast from unmanaged to borrow
-  inline proc _cast(type t, x) where t:object && x:_unmanaged {
+  inline proc _cast(type t, x) where t:object && _to_borrowed(x.type):t && x:_unmanaged {
     return __primitive("cast", t, x);
   }
 }

--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -1009,9 +1009,9 @@ module ChapelDistribution {
 
 
   proc chpl_assignDomainWithIndsIterSafeForRemoving(lhs:?t, rhs: domain)
-    where _to_borrowed(t):borrowed BaseSparseDom ||
-          _to_borrowed(t):borrowed BaseAssociativeDom ||
-          _to_borrowed(t):borrowed BaseOpaqueDom
+    where _to_borrowed(t):BaseSparseDom ||
+          _to_borrowed(t):BaseAssociativeDom ||
+          _to_borrowed(t):BaseOpaqueDom
   {
     //
     // BLC: It's tempting to do a clear + add here, but because

--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -43,7 +43,7 @@ module ChapelDistribution {
 
     // Returns a distribution that should be freed or nil.
     pragma "dont disable remote value forwarding"
-    proc remove(): BaseDist {
+    proc remove(): unmanaged BaseDist {
       var free_dist = false;
       if dsiTrackDomains() {
         on this {
@@ -65,7 +65,7 @@ module ChapelDistribution {
         free_dist = true;
       }
       if free_dist then
-        return this;
+        return _to_unmanaged(this);
       else
         return nil;
     }
@@ -903,7 +903,7 @@ module ChapelDistribution {
   // param privatized here is a workaround for the fact that
   // we can't include the privatized freeing for DefaultRectangular
   // because of resolution order issues
-  proc _delete_dist(dist:BaseDist, param privatized:bool) {
+  proc _delete_dist(dist:unmanaged BaseDist, param privatized:bool) {
     dist.dsiDestroyDist();
 
     if privatized {
@@ -1009,9 +1009,9 @@ module ChapelDistribution {
 
 
   proc chpl_assignDomainWithIndsIterSafeForRemoving(lhs:?t, rhs: domain)
-    where _to_borrowed(t):BaseSparseDom ||
-          _to_borrowed(t):BaseAssociativeDom ||
-          _to_borrowed(t):BaseOpaqueDom
+    where _to_borrowed(t):borrowed BaseSparseDom ||
+          _to_borrowed(t):borrowed BaseAssociativeDom ||
+          _to_borrowed(t):borrowed BaseOpaqueDom
   {
     //
     // BLC: It's tempting to do a clear + add here, but because

--- a/modules/internal/ChapelError.chpl
+++ b/modules/internal/ChapelError.chpl
@@ -335,6 +335,13 @@ module ChapelError {
   }
   pragma "no doc"
   pragma "insert line file info"
+  // TODO -- deprecate this version
+  proc chpl_fix_thrown_error(err: borrowed Error): unmanaged Error {
+    return chpl_fix_thrown_error(_to_unmanaged(err));
+  }
+
+  pragma "no doc"
+  pragma "insert line file info"
   proc chpl_fix_thrown_error(err: unmanaged Error): unmanaged Error {
     var fixErr: unmanaged Error = err;
     if fixErr == nil then

--- a/modules/internal/ChapelIO.chpl
+++ b/modules/internal/ChapelIO.chpl
@@ -203,8 +203,8 @@ module ChapelIO {
   // TODO -- this should probably be private
   pragma "no doc"
   proc _isNilObject(val) {
-    proc helper(o: object) return o == nil;
-    proc helper(o)         return false;
+    proc helper(o: borrowed object) return o == nil;
+    proc helper(o)                  return false;
     return helper(val);
   }
 
@@ -257,7 +257,7 @@ module ChapelIO {
       var isBinary = writer.binary();
 
       if (isClassType(t)) {
-        if t != object {
+        if t != borrowed object {
           // only write parent fields for subclasses of object
           // since object has no .super field.
           writeThisFieldsDefaultImpl(writer, x.super, first);
@@ -401,7 +401,7 @@ module ChapelIO {
       var superclass_error : syserr = ENOERR;
 
       if (isClassType(t)) {
-        if t != object {
+        if t != borrowed object {
           // only write parent fields for subclasses of object
           // since object has no .super field.
           type superType = x.super.type;

--- a/modules/internal/ChapelTaskDataHelp.chpl
+++ b/modules/internal/ChapelTaskDataHelp.chpl
@@ -36,9 +36,10 @@ module ChapelTaskDataHelp {
   }
 
   // Propagate an error from a task to its caller / sync point.
-  proc chpl_save_task_error(e: _EndCountBase, err: unmanaged Error) {
+  // TODO: should be accepting an unmanaged / owned error
+  proc chpl_save_task_error(e: _EndCountBase, err: Error) {
     if err != nil {
-      e.errors.append(err);
+      e.errors.append(_to_unmanaged(err));
     }
   }
 }

--- a/modules/internal/ChapelTaskDataHelp.chpl
+++ b/modules/internal/ChapelTaskDataHelp.chpl
@@ -36,7 +36,7 @@ module ChapelTaskDataHelp {
   }
 
   // Propagate an error from a task to its caller / sync point.
-  proc chpl_save_task_error(e: _EndCountBase, err: Error) {
+  proc chpl_save_task_error(e: _EndCountBase, err: unmanaged Error) {
     if err != nil {
       e.errors.append(err);
     }

--- a/modules/internal/DefaultAssociative.chpl
+++ b/modules/internal/DefaultAssociative.chpl
@@ -860,7 +860,7 @@ module DefaultAssociative {
     return hash;
   }
   
-  inline proc chpl__defaultHash(o: object): uint {
+  inline proc chpl__defaultHash(o: borrowed object): uint {
     return _gen_key(__primitive( "object2int", o));
   }
 

--- a/modules/internal/DefaultOpaque.chpl
+++ b/modules/internal/DefaultOpaque.chpl
@@ -95,7 +95,7 @@ module DefaultOpaque {
   
     proc dsiGetIndices() return adomain;
   
-    proc dsiSetIndices(b: DefaultAssociativeDom) {
+    proc dsiSetIndices(b: unmanaged DefaultAssociativeDom) {
       adomain.dsiSetIndices(b);
     }
   

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1618,11 +1618,11 @@ module DefaultRectangular {
 
   proc DefaultRectangularArr.doiCanBulkTransferRankChange() param return true;
 
-  proc DefaultRectangularArr.doiBulkTransferToKnown(srcDom, destClass:unmanaged DefaultRectangularArr, destDom) : bool {
+  proc DefaultRectangularArr.doiBulkTransferToKnown(srcDom, destClass:DefaultRectangularArr, destDom) : bool {
     return transferHelper(destClass, destDom, this, srcDom);
   }
 
-  proc DefaultRectangularArr.doiBulkTransferFromKnown(destDom, srcClass:unmanaged DefaultRectangularArr, srcDom) : bool {
+  proc DefaultRectangularArr.doiBulkTransferFromKnown(destDom, srcClass:DefaultRectangularArr, srcDom) : bool {
     return transferHelper(this, destDom, srcClass, srcDom);
   }
 

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -62,7 +62,7 @@ module DefaultRectangular {
 
     proc dsiAssign(other: unmanaged this.type) { }
 
-    proc dsiEqualDMaps(d:DefaultDist) param return true;
+    proc dsiEqualDMaps(d:unmanaged DefaultDist) param return true;
     proc dsiEqualDMaps(d) param return false;
 
     proc trackDomains() param return false;
@@ -1169,8 +1169,8 @@ module DefaultRectangular {
     where shouldReturnRvalueByConstRef(eltType)
       return dsiAccess(i);
 
-    proc adjustBlkOffStrForNewDomain(d: DefaultRectangularDom,
-                                     alias: DefaultRectangularArr)
+    proc adjustBlkOffStrForNewDomain(d: unmanaged DefaultRectangularDom,
+                                     alias: unmanaged DefaultRectangularArr)
     {
       for param i in 1..rank {
         var s: idxType;
@@ -1188,8 +1188,8 @@ module DefaultRectangular {
       }
     }
 
-    proc adjustBlkOffStrForNewDomain(d: DefaultRectangularDom,
-                                     alias: DefaultRectangularArr)
+    proc adjustBlkOffStrForNewDomain(d: unmanaged DefaultRectangularDom,
+                                     alias: unmanaged DefaultRectangularArr)
       where dom.stridable == false && this.stridable == false
     {
       for param i in 1..rank {
@@ -1618,11 +1618,11 @@ module DefaultRectangular {
 
   proc DefaultRectangularArr.doiCanBulkTransferRankChange() param return true;
 
-  proc DefaultRectangularArr.doiBulkTransferToKnown(srcDom, destClass:DefaultRectangularArr, destDom) : bool {
+  proc DefaultRectangularArr.doiBulkTransferToKnown(srcDom, destClass:unmanaged DefaultRectangularArr, destDom) : bool {
     return transferHelper(destClass, destDom, this, srcDom);
   }
 
-  proc DefaultRectangularArr.doiBulkTransferFromKnown(destDom, srcClass:DefaultRectangularArr, srcDom) : bool {
+  proc DefaultRectangularArr.doiBulkTransferFromKnown(destDom, srcClass:unmanaged DefaultRectangularArr, srcDom) : bool {
     return transferHelper(this, destDom, srcClass, srcDom);
   }
 

--- a/modules/internal/LocaleModelHelpSetup.chpl
+++ b/modules/internal/LocaleModelHelpSetup.chpl
@@ -56,7 +56,7 @@ module LocaleModelHelpSetup {
       nPUsLogAll.add(loc.nPUsLogAll);
       maxTaskPar.add(loc.maxTaskPar);
     }
-    proc setRootLocaleValues(dst:RootLocale) {
+    proc setRootLocaleValues(dst:borrowed RootLocale) {
       dst.nPUsPhysAcc = nPUsPhysAcc.read();
       dst.nPUsPhysAll = nPUsPhysAll.read();
       dst.nPUsLogAcc = nPUsLogAcc.read();
@@ -65,7 +65,7 @@ module LocaleModelHelpSetup {
     }
   }
 
-  proc helpSetupRootLocaleFlat(dst:RootLocale) {
+  proc helpSetupRootLocaleFlat(dst:borrowed RootLocale) {
     var root_accum:chpl_root_locale_accum;
 
     forall locIdx in dst.chpl_initOnLocales() with (ref root_accum) {
@@ -77,7 +77,7 @@ module LocaleModelHelpSetup {
     root_accum.setRootLocaleValues(dst);
   }
 
-  proc helpSetupRootLocaleNUMA(dst:RootLocale) {
+  proc helpSetupRootLocaleNUMA(dst:borrowed RootLocale) {
     var root_accum:chpl_root_locale_accum;
 
     forall locIdx in dst.chpl_initOnLocales() with (ref root_accum) {
@@ -90,7 +90,7 @@ module LocaleModelHelpSetup {
     root_accum.setRootLocaleValues(dst);
   }
 
-  proc helpSetupRootLocaleAPU(dst:RootLocale) {
+  proc helpSetupRootLocaleAPU(dst:borrowed RootLocale) {
     var root_accum:chpl_root_locale_accum;
 
     forall locIdx in dst.chpl_initOnLocales() with (ref root_accum) {
@@ -131,7 +131,7 @@ module LocaleModelHelpSetup {
     return if localSpawn() then _node_name + "-" + _node_id else _node_name;
   }
 
-  proc helpSetupLocaleFlat(dst:LocaleModel, out local_name:string) {
+  proc helpSetupLocaleFlat(dst:borrowed LocaleModel, out local_name:string) {
     local_name = getNodeName();
 
     extern proc chpl_task_getCallStackSize(): size_t;
@@ -149,7 +149,7 @@ module LocaleModelHelpSetup {
     dst.maxTaskPar = chpl_task_getMaxPar();
   }
 
-  proc helpSetupLocaleNUMA(dst:LocaleModel, out local_name:string, out numSublocales) {
+  proc helpSetupLocaleNUMA(dst:borrowed LocaleModel, out local_name:string, out numSublocales) {
     helpSetupLocaleFlat(dst, local_name);
 
     extern proc chpl_task_getNumSublocales(): int(32);
@@ -181,7 +181,7 @@ module LocaleModelHelpSetup {
     }
   }
 
-  proc helpSetupLocaleAPU(dst:LocaleModel, out local_name:string, out numSublocales) {
+  proc helpSetupLocaleAPU(dst:borrowed LocaleModel, out local_name:string, out numSublocales) {
     helpSetupLocaleFlat(dst, local_name);
 
     extern proc chpl_task_getMaxPar(): uint(32);

--- a/modules/internal/LocalesArray.chpl
+++ b/modules/internal/LocalesArray.chpl
@@ -50,7 +50,7 @@ module LocalesArray {
   // initialization (see chpl_rootLocaleInitPrivate()).  The copy for
   // locale 0 is set up here for the declaration.
   pragma "locale private"
-  const ref Locales = (rootLocale:RootLocale).getDefaultLocaleArray();
+  const ref Locales = (rootLocale:borrowed RootLocale).getDefaultLocaleArray();
 
   // We don't use the same private "trick" as with Locales above with
   // LocaleSpace/ because it's small enough to not matter.

--- a/modules/internal/SharedObject.chpl
+++ b/modules/internal/SharedObject.chpl
@@ -103,7 +103,7 @@ module SharedObject {
 
     pragma "no doc"
     pragma "owned"
-    var pn:ReferenceCount; // reference counter
+    var pn:unmanaged ReferenceCount; // reference counter
 
     /*
        Default-initialize a :record:`Shared`.
@@ -131,7 +131,7 @@ module SharedObject {
       if !isClass(p) then
         compilerError("Shared only works with classes");
 
-      var rc:ReferenceCount = nil;
+      var rc:unmanaged ReferenceCount = nil;
 
       if p != nil then
         rc = new ReferenceCount();

--- a/modules/internal/SharedObject.chpl
+++ b/modules/internal/SharedObject.chpl
@@ -134,7 +134,7 @@ module SharedObject {
       var rc:unmanaged ReferenceCount = nil;
 
       if p != nil then
-        rc = new ReferenceCount();
+        rc = new unmanaged ReferenceCount();
 
       this.p = p;
       this.pn = rc;
@@ -181,7 +181,7 @@ module SharedObject {
       clear();
       this.p = newPtr;
       if newPtr != nil {
-        this.pn = new ReferenceCount();
+        this.pn = new unmanaged ReferenceCount();
       }
     }
 

--- a/modules/internal/StringCasts.chpl
+++ b/modules/internal/StringCasts.chpl
@@ -46,13 +46,13 @@ module StringCasts {
   proc _cast(type t, x: string) throws where isBoolType(t) {
     var str = x.strip();
     if str.isEmptyString() {
-      throw new IllegalArgumentError("bad cast from empty string to bool");
+      throw new unmanaged IllegalArgumentError("bad cast from empty string to bool");
     } else if (str == "true") {
       return true;
     } else if (str == "false") {
       return false;
     } else {
-      throw new IllegalArgumentError("bad cast from string '" + x + "' to bool");
+      throw new unmanaged IllegalArgumentError("bad cast from string '" + x + "' to bool");
     }
     return false;
   }
@@ -71,7 +71,7 @@ module StringCasts {
     // this should only happen if the runtime is broken
     if isErr {
       try! {
-        throw new IllegalArgumentError("Unexpected case in integral_to_c_string");
+        throw new unmanaged IllegalArgumentError("Unexpected case in integral_to_c_string");
       }
     }
 
@@ -108,7 +108,7 @@ module StringCasts {
 
     if isIntType(t) {
       if localX.isEmptyString() then
-        throw new IllegalArgumentError("bad cast from empty string to int(" + numBits(t) + ")");
+        throw new unmanaged IllegalArgumentError("bad cast from empty string to int(" + numBits(t) + ")");
 
       select numBits(t) {
         when 8  do retVal = c_string_to_int8_t(localX.c_str(), isErr);
@@ -119,10 +119,10 @@ module StringCasts {
       }
 
       if isErr then
-        throw new IllegalArgumentError("bad cast from string '" + x + "' to int(" + numBits(t) + ")");
+        throw new unmanaged IllegalArgumentError("bad cast from string '" + x + "' to int(" + numBits(t) + ")");
     } else {
       if localX.isEmptyString() then
-        throw new IllegalArgumentError("bad cast from empty string to uint(" + numBits(t) + ")");
+        throw new unmanaged IllegalArgumentError("bad cast from empty string to uint(" + numBits(t) + ")");
 
       select numBits(t) {
         when 8  do retVal = c_string_to_uint8_t(localX.c_str(), isErr);
@@ -133,7 +133,7 @@ module StringCasts {
       }
 
       if isErr then
-        throw new IllegalArgumentError("bad cast from string '" + x + "' to uint(" + numBits(t) + ")");
+        throw new unmanaged IllegalArgumentError("bad cast from string '" + x + "' to uint(" + numBits(t) + ")");
     }
 
     return retVal;
@@ -180,7 +180,7 @@ module StringCasts {
     const localX = x.localize();
 
     if localX.isEmptyString() then
-      throw new IllegalArgumentError("bad cast from empty string to real(" + numBits(t) + ")");
+      throw new unmanaged IllegalArgumentError("bad cast from empty string to real(" + numBits(t) + ")");
 
     select numBits(t) {
       when 32 do retVal = c_string_to_real32(localX.c_str(), isErr);
@@ -189,7 +189,7 @@ module StringCasts {
     }
 
     if isErr then
-      throw new IllegalArgumentError("bad cast from string '" + x + "' to real(" + numBits(t) + ")");
+      throw new unmanaged IllegalArgumentError("bad cast from string '" + x + "' to real(" + numBits(t) + ")");
 
     return retVal;
   }
@@ -205,7 +205,7 @@ module StringCasts {
     const localX = x.localize();
 
     if localX.isEmptyString() then
-      throw new IllegalArgumentError("bad cast from empty string to imag(" + numBits(t) + ")");
+      throw new unmanaged IllegalArgumentError("bad cast from empty string to imag(" + numBits(t) + ")");
 
     select numBits(t) {
       when 32 do retVal = c_string_to_imag32(localX.c_str(), isErr);
@@ -214,7 +214,7 @@ module StringCasts {
     }
 
     if isErr then
-      throw new IllegalArgumentError("bad cast from string '" + x + "' to imag(" + numBits(t) + ")");
+      throw new unmanaged IllegalArgumentError("bad cast from string '" + x + "' to imag(" + numBits(t) + ")");
 
     return retVal;
   }
@@ -257,7 +257,7 @@ module StringCasts {
     const localX = x.localize();
 
     if localX.isEmptyString() then
-      throw new IllegalArgumentError("bad cast from empty string to complex(" + numBits(t) + ")");
+      throw new unmanaged IllegalArgumentError("bad cast from empty string to complex(" + numBits(t) + ")");
 
     select numBits(t) {
       when 64 do retVal = c_string_to_complex64(localX.c_str(), isErr);
@@ -266,7 +266,7 @@ module StringCasts {
     }
 
     if isErr then
-      throw new IllegalArgumentError("bad cast from string '" + x + "' to complex(" + numBits(t) + ")");
+      throw new unmanaged IllegalArgumentError("bad cast from string '" + x + "' to complex(" + numBits(t) + ")");
 
     return retVal;
   }

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -4351,7 +4351,7 @@ proc channel.isclosed() {
 pragma "no doc"
 proc channel.readBytes(x, len:ssize_t) throws {
   if here != this.home then
-    throw new IllegalArgumentError("bad remote channel.readBytes");
+    throw new unmanaged IllegalArgumentError("bad remote channel.readBytes");
   var err = qio_channel_read_amt(false, _channel_internal, x, len);
   if err then try this._ch_ioerror(err, "in channel.readBytes");
 }

--- a/modules/standard/List.chpl
+++ b/modules/standard/List.chpl
@@ -31,7 +31,7 @@ pragma "use default init"
 class listNode {
   type eltType;
   var data: eltType;
-  var next: listNode(eltType);
+  var next: unmanaged listNode(eltType);
 }
 
 
@@ -58,17 +58,17 @@ record list {
   type eltType;
   pragma "no doc"
   pragma "owned"
-  var first: listNode(eltType);
+  var first: unmanaged listNode(eltType);
   pragma "no doc"
   pragma "owned"
-  var last: listNode(eltType);
+  var last: unmanaged listNode(eltType);
   /*
     The number of nodes in the list.
    */
   var length: int;
 
   pragma "no doc"
-  proc init(type eltType, first : listNode(eltType) = nil, last : listNode(eltType) = nil) {
+  proc init(type eltType, first : unmanaged listNode(eltType) = nil, last : unmanaged listNode(eltType) = nil) {
     this.eltType = eltType;
     this.first = first;
     this.last = last;

--- a/test/compflags/ferguson/default-unmanaged.chpl
+++ b/test/compflags/ferguson/default-unmanaged.chpl
@@ -1,0 +1,73 @@
+class MyClass {
+  var x:int;
+  
+  proc primaryMethod() {
+    writeln("In MyClass.primaryMethod(), this.type is ", this.type:string);
+  }
+}
+
+proc f(arg:unmanaged MyClass) {
+  writeln("in f unmanaged");
+}
+proc f(arg:borrowed MyClass) {
+  writeln("in f borrowed");
+}
+
+proc call_f(type t) {
+  var something = new t();
+  f(something);
+}
+
+proc MyClass.secondaryMethod() {
+  writeln("In MyClass.secondaryMethod(), this.type is ", this.type:string);
+}
+
+proc test1() {
+  var unm:unmanaged MyClass = new unmanaged MyClass();
+  var bor:borrowed MyClass = unm;
+  var def:MyClass = unm;
+
+  writeln("Calling f(unmanaged)");
+  f(unm);
+  writeln("Calling f(borrowed)");
+  f(bor);
+  writeln("Calling f(default)");
+  f(def);
+
+  delete unm;
+}
+test1();
+
+proc test2() {
+  var unm:unmanaged MyClass = new unmanaged MyClass();
+  var def:MyClass = unm;
+
+  writeln("Calling call_f(unmanaged MyClass)");
+  call_f(unmanaged MyClass);
+  call_f(unm.type);
+  writeln("Calling call_f(MyClass)");
+  call_f(MyClass);
+  call_f(def.type);
+
+  delete unm;
+}
+test2();
+
+proc test3() {
+  var unm:unmanaged MyClass = new unmanaged MyClass();
+
+  writeln("Calling method on unmanaged");
+  unm.primaryMethod();
+  unm.secondaryMethod();
+
+  delete unm;
+}
+test3();
+
+proc test4() {
+  var def = new MyClass();
+  writeln("Calling f(new MyClass())");
+  f(def);
+  f(new MyClass());
+}
+test4();

--- a/test/compflags/ferguson/default-unmanaged.compopts
+++ b/test/compflags/ferguson/default-unmanaged.compopts
@@ -1,0 +1,2 @@
+--no-default-unmanaged --no-warn-unstable # default-unmanaged.default.good
+--default-unmanaged --no-warn-unstable    # default-unmanaged.unmanaged.good

--- a/test/compflags/ferguson/default-unmanaged.default.good
+++ b/test/compflags/ferguson/default-unmanaged.default.good
@@ -1,0 +1,18 @@
+Calling f(unmanaged)
+in f unmanaged
+Calling f(borrowed)
+in f borrowed
+Calling f(default)
+in f borrowed
+Calling call_f(unmanaged MyClass)
+in f unmanaged
+in f unmanaged
+Calling call_f(MyClass)
+in f borrowed
+in f borrowed
+Calling method on unmanaged
+In MyClass.primaryMethod(), this.type is MyClass
+In MyClass.secondaryMethod(), this.type is MyClass
+Calling f(new MyClass())
+in f borrowed
+in f borrowed

--- a/test/compflags/ferguson/default-unmanaged.unmanaged.good
+++ b/test/compflags/ferguson/default-unmanaged.unmanaged.good
@@ -1,0 +1,18 @@
+Calling f(unmanaged)
+in f unmanaged
+Calling f(borrowed)
+in f borrowed
+Calling f(default)
+in f unmanaged
+Calling call_f(unmanaged MyClass)
+in f unmanaged
+in f unmanaged
+Calling call_f(MyClass)
+in f unmanaged
+in f unmanaged
+Calling method on unmanaged
+In MyClass.primaryMethod(), this.type is unmanaged MyClass
+In MyClass.secondaryMethod(), this.type is unmanaged MyClass
+Calling f(new MyClass())
+in f unmanaged
+in f unmanaged


### PR DESCRIPTION
Adds `--default-unmanaged` as a (currently) internal/developer flag.
It should get more testing somehow if it's to be a user-facing flag.

Resolves #9289.

- [ ] full local testing
- [ ] rebase and merge after PR #9612