### PR TITLE
Fix miscellaneous execution-time failures under --force-initializers

### DIFF
--- a/test/arrays/ferguson/semantic-examples/4-init-record-field2.chpl
+++ b/test/arrays/ferguson/semantic-examples/4-init-record-field2.chpl
@@ -1,4 +1,5 @@
 use myrecord; 
+pragma "use default init"
 record RecordStoringArray{
   var field:[1..2] R;
 }

--- a/test/arrays/ferguson/semantic-examples/4-init-record-field2.good
+++ b/test/arrays/ferguson/semantic-examples/4-init-record-field2.good
@@ -1,4 +1,2 @@
 copy/assign from 0
 copy/assign from 0
-copy/assign from 0
-copy/assign from 0

--- a/test/functions/lydia/userDefinedDefaultFunction/redefine-param-record.chpl
+++ b/test/functions/lydia/userDefinedDefaultFunction/redefine-param-record.chpl
@@ -1,3 +1,4 @@
+pragma "use default init"
 record bar {
   param size: int;
   var whatev = 5;

--- a/test/functions/lydia/userDefinedDefaultFunction/redefine-param-record.future
+++ b/test/functions/lydia/userDefinedDefaultFunction/redefine-param-record.future
@@ -1,0 +1,1 @@
+feature request: noinit support for initializers

--- a/test/functions/lydia/userDefinedDefaultFunction/redefine-record.chpl
+++ b/test/functions/lydia/userDefinedDefaultFunction/redefine-record.chpl
@@ -1,3 +1,4 @@
+pragma "use default init"
 record bar {
   var aField: int;
 }

--- a/test/functions/lydia/userDefinedDefaultFunction/redefine-record.future
+++ b/test/functions/lydia/userDefinedDefaultFunction/redefine-record.future
@@ -1,0 +1,1 @@
+feature request: noinit support for initializers

--- a/test/functions/lydia/userDefinedDefaultFunction/redefine-type-record.chpl
+++ b/test/functions/lydia/userDefinedDefaultFunction/redefine-type-record.chpl
@@ -1,3 +1,4 @@
+pragma "use default init"
 record bar {
   type t;
   var aField: t;

--- a/test/functions/lydia/userDefinedDefaultFunction/redefine-type-record.future
+++ b/test/functions/lydia/userDefinedDefaultFunction/redefine-type-record.future
@@ -1,0 +1,1 @@
+feature request: noinit support for initializers

--- a/test/functions/lydia/userDefinedDefaultFunction/useDefaultOf.chpl
+++ b/test/functions/lydia/userDefinedDefaultFunction/useDefaultOf.chpl
@@ -1,3 +1,4 @@
+pragma "use default init"
 record foo {
   var a: int;
   var b: int;

--- a/test/functions/lydia/userDefinedDefaultFunction/useDefaultOf.future
+++ b/test/functions/lydia/userDefinedDefaultFunction/useDefaultOf.future
@@ -1,0 +1,1 @@
+feature request: noinit support for initializers

--- a/test/types/records/ferguson/copy-report.chpl
+++ b/test/types/records/ferguson/copy-report.chpl
@@ -13,51 +13,25 @@ record R {
   var ptr: Instance = nil;
 }
 
-proc R.R(x:int) {
-  this.x = x;
-  this.ptr = new Instance(x);
-}
-
-/*
 proc R.init() {
   this.x = 0;
   this.ptr = nil;
-  super.init();
 }
 
 proc R.init(x:int) {
   this.x = x;
   this.ptr = new Instance(x);
-  super.init();
 }
 
 proc R.init(from: R) {
   this.x = from.x + 1;
   this.ptr = new Instance(this.x);
-  super.init();
-  writeln("    initCopy"); // ie copy-init
+  writeln("    R.init(R)"); // ie copy-init
 }
-*/
 
 proc R.deinit() {
   delete this.ptr;
   this.ptr = nil;
-}
-
-// I'd like this to be ref, but that breaks
-//    var outerX: R; begin { var x = outerX; }
-pragma "init copy fn"
-proc chpl__initCopy(arg: R) {
-  // TODO - is no auto destroy necessary here?
-  pragma "no auto destroy"
-  var ret: R;
-
-  ret.x = arg.x + 1;
-  ret.ptr = new Instance(ret.x);
-
-  writeln("    initCopy");
-
-  return ret;
 }
 
 proc =(ref lhs: R, rhs: R) {
@@ -268,7 +242,7 @@ proc varInitArgInout(inout arg)
 
 
 
-
+pragma "use default init"
 record Container {
   var field: R;
 }

--- a/test/types/records/ferguson/copy-report.good
+++ b/test/types/records/ferguson/copy-report.good
@@ -8,121 +8,120 @@ VARIABLE INITIALIZATION -- VALUE CALL
  call in arg / call
  field initialization / value call
    default constructor
-    initCopy
 
 VARIABLE INITIALIZATION -- LOCAL VAR
  variable initialization / local var
    untyped variable
-    initCopy
+    R.init(R)
    typed variable
-    initCopy
+    R.init(R)
  field initialization / local var
    default constructor
-    initCopy
+    R.init(R)
 
 VARIABLE INITIALIZATION -- IN ARG (GLOBAL)
-    initCopy
+    R.init(R)
  variable initialization / in-intent arg
    untyped variable
-    initCopy
+    R.init(R)
    typed variable
-    initCopy
+    R.init(R)
 
-    initCopy
+    R.init(R)
  variable initialization / const-in-intent arg
    untyped variable
-    initCopy
+    R.init(R)
    typed variable
-    initCopy
+    R.init(R)
 
 VARIABLE INITIALIZATION -- IN ARG (IN ARG (CALL-EXPR)))
  passing in intent arg to in intent arg
-    initCopy
+    R.init(R)
  variable initialization / in-intent arg
    untyped variable
-    initCopy
+    R.init(R)
    typed variable
-    initCopy
+    R.init(R)
  passing const in intent arg to const in intent arg
-    initCopy
+    R.init(R)
  variable initialization / const-in-intent arg
    untyped variable
-    initCopy
+    R.init(R)
    typed variable
-    initCopy
+    R.init(R)
 
 VARIABLE INITIALIZATION -- OUTER VAR
  variable initialization / outer var
    untyped variable
-    initCopy
+    R.init(R)
    typed variable
-    initCopy
+    R.init(R)
 
 VARIABLE INITIALIZATION -- GLOBAL / REF
  variable initialization / global var
    untyped variable
-    initCopy
+    R.init(R)
    typed variable
-    initCopy
+    R.init(R)
  variable initialization / global ref
    untyped variable
-    initCopy
+    R.init(R)
    typed variable
-    initCopy
+    R.init(R)
  variable initialization / local ref
    untyped variable
-    initCopy
+    R.init(R)
    typed variable
-    initCopy
+    R.init(R)
  variable initialization / blank-intent arg
    untyped variable
-    initCopy
+    R.init(R)
    typed variable
-    initCopy
+    R.init(R)
  variable initialization / const-ref arg
    untyped variable
-    initCopy
+    R.init(R)
    typed variable
-    initCopy
+    R.init(R)
  variable initialization / ref arg
    untyped variable
-    initCopy
+    R.init(R)
    typed variable
-    initCopy
-    initCopy
+    R.init(R)
+    R.init(R)
  variable initialization / inout-intent arg
    untyped variable
-    initCopy
+    R.init(R)
    typed variable
-    initCopy
+    R.init(R)
    function epilogue
     assign
  field initialization / global var
    default constructor
-    initCopy
+    R.init(R)
  field initialization / global ref
    default constructor
-    initCopy
+    R.init(R)
  field initialization / local ref
    default constructor
-    initCopy
+    R.init(R)
  field initialization / blank-intent arg
    default constructor
-    initCopy
+    R.init(R)
  field initialization / const-ref arg
    default constructor
-    initCopy
+    R.init(R)
  field initialization / ref arg
    default constructor
-    initCopy
-    initCopy
+    R.init(R)
+    R.init(R)
  field initialization / in arg
    default constructor
-    initCopy
-    initCopy
+    R.init(R)
+    R.init(R)
  field initialization / inout arg
    default constructor
-    initCopy
+    R.init(R)
     assign
 
 VALUE RETURN -- VALUE CALL
@@ -134,13 +133,13 @@ VALUE RETURN -- LOCAL VAR
 
 VALUE RETURN -- OUTER VAR
  return / outer variable
-    initCopy
+    R.init(R)
 
 VALUE RETURN -- IN ARG (GLOBAL)
-    initCopy
+    R.init(R)
  return / in arg
 
-    initCopy
+    R.init(R)
  return / const in arg
 
 VALUE RETURN -- IN ARG (CALL-EXPR)
@@ -149,19 +148,19 @@ VALUE RETURN -- IN ARG (CALL-EXPR)
 
 VALUE RETURN -- GLOBAL/REF
  return / global variable
-    initCopy
+    R.init(R)
  return / ref global variable
-    initCopy
+    R.init(R)
  return / blank intent arg
-    initCopy
+    R.init(R)
  return / ref intent arg
-    initCopy
+    R.init(R)
  return / const ref intent arg
-    initCopy
+    R.init(R)
  return / call returning ref
-    initCopy
+    R.init(R)
  return / call returning const ref
-    initCopy
+    R.init(R)
 
 REF USE -- REF VALUE
  return ref / global variable

--- a/test/types/records/ferguson/expiring-value-alias.chpl
+++ b/test/types/records/ferguson/expiring-value-alias.chpl
@@ -330,34 +330,13 @@ proc R.deinit() {
   if debug then writeln("  delete ", getNum(c));
 }
 
-pragma "donor fn"
-pragma "auto copy fn"
-proc chpl__autoCopy(arg: R) {
-  if debug then writeln("  auto copy from ", getNum(arg.c));
-  // Note -- this auto copy could be the same as
-  // init copy and it wouldn't affect the test.
-
-  // TODO - is no auto destroy necessary here?
-  pragma "no auto destroy"
-  var ret: R;
-
-  //ret.c = arg.c;
-  ret.c = new C(arg.c.x);
-
-  return ret;
+proc R.init(c:C = nil) {
+  this.c = c;
 }
 
-// I'd like this to be ref, but that breaks
-//    var outerX: R; begin { var x = outerX; }
-pragma "init copy fn"
-proc chpl__initCopy(arg: R) {
-  if debug then writeln("  init copy from ", getNum(arg.c));
-
-  var ret: R;
-
-  ret.c = new C(arg.c.x);
-
-  return ret;
+proc R.init(other:R) {
+  if debug then writeln("  R.init(R) from ", getNum(other.c));
+  this.c = new C(other.c.x);
 }
 
 proc =(ref lhs: R, rhs: R) {

--- a/test/types/records/ferguson/tracking-record/myrecord.chpl
+++ b/test/types/records/ferguson/tracking-record/myrecord.chpl
@@ -21,6 +21,20 @@ record R {
   var c: C;
 }
 
+proc R.init(x : int = 0, c : C = nil) {
+  if debug then writeln("in R.init(", x, ", ", c, ")");
+  this.x = x;
+  this.c = c;
+  this.complete();
+  this.setup(x, true);
+}
+
+proc R.init(other:R) {
+  if debug then writeln("in R.init(", other, ")");
+  this.complete();
+  this.setup(other.x, true);
+}
+
 proc ref R.setup(x:int, allow_zero:bool=false) {
   if !allow_zero then assert(x != 0);
 
@@ -74,7 +88,9 @@ proc R.verify() {
   extern proc printf(fmt:c_string, arg:c_ptr(int), arg2:c_ptr(int));
 
   // default initialized records have nil ptr, OK
-  if c == nil && x == 0 then return;
+  if c == nil && x == 0 {
+    return;
+  }
 
   if c == nil {
     // any time we set x!=0 the class should be initialized
@@ -86,56 +102,6 @@ proc R.verify() {
     writeln("R.verify failed - got x=", x, " but c.x=", c.x);
     assert(false);
   }
-}
-
-pragma "donor fn"
-pragma "auto copy fn"
-proc chpl__autoCopy(arg: R) {
-  extern proc printf(fmt:c_string, arg:C);
-  extern proc printf(fmt:c_string, arg:C, arg2:C);
-  if debug {
-    printf("in auto copy from arg.c=%p ", arg.c);
-    writeln("x=", arg.x, " ", arg.c);
-  }
-
-  // TODO - is no auto destroy necessary here?
-  pragma "no auto destroy"
-  var ret: R;
-
-  // allow copies of default initialized record
-  if allocateAlways || arg.x!=0 || arg.c!=nil {
-    ret.setup(x = arg.x, true);
-  }
-
-  if debug {
-    printf("leaving auto copy from arg.c=%p to ret.c=%p ", arg.c, ret.c);
-    writeln(arg.c, ret.c);
-  }
-
-  return ret;
-}
-
-// I'd like this to be ref, but that breaks
-//    var outerX: R; begin { var x = outerX; }
-pragma "init copy fn"
-proc chpl__initCopy(arg: R) {
-  extern proc printf(fmt:c_string, arg:C);
-  extern proc printf(fmt:c_string, arg:C, arg2:C);
-  if debug {
-    printf("in init copy from arg.c=%p ", arg.c);
-    writeln(arg.c);
-  }
-
-  var ret: R;
-
-  ret.setup(x = arg.x, true);
-
-  if debug {
-    printf("leaving init copy from arg.c=%p to ret.c=%p ", arg.c, ret.c);
-    writeln(arg.c, ret.c);
-  }
-
-  return ret;
 }
 
 proc =(ref lhs: R, rhs: R) {

--- a/test/users/ferguson/refcnt.chpl
+++ b/test/users/ferguson/refcnt.chpl
@@ -28,19 +28,15 @@ record R {
 
 }
 
-pragma "init copy fn"
-proc chpl__initCopy(x: R) {
-  writeln("In R initCopy ", x.refcnt);
-  x.retain();
-  return x;
+proc R.init() {
 }
-/*
-proc chpl__autoCopy(x: R) {
-  writeln("In R autoCopy ", x.refcnt);
-  x.retain();
-  return x;
+
+proc R.init(x: R) {
+  writeln("In R.init(R) ", x.refcnt);
+  this.refcnt = x.refcnt;
+  this.complete();
+  this.retain();
 }
-*/
 
 
 proc =(ref ret:R, x:R) {

--- a/test/users/ferguson/refcnt.good
+++ b/test/users/ferguson/refcnt.good
@@ -12,7 +12,7 @@ Destroying a RefCount
 After scope
 Before scope (copy initialization)
 Initializing a RefCount
-In R initCopy {count = 1}
+In R.init(R) {count = 1}
 Starting test_one {count = 2}
 In R.routine {count = 2}
 In test_two {count = 2}
@@ -23,7 +23,7 @@ Destroying a RefCount
 After scope (copy initialization)
 Before scope (copy initialization 2)
 Initializing a RefCount
-In R initCopy {count = 1}
+In R.init(R) {count = 1}
 Starting test_one {count = 2}
 In R.routine {count = 2}
 In test_two {count = 2}


### PR DESCRIPTION
This PR resolves a number of failures listed in #9519:
- arrays/ferguson/semantic-examples/4-init-record-field2 (update .good file)
- functions/lydia/userDefinedDefaultFunction/* (futurize)
- types/records/ferguson/* (autoCopy -> init)
- users/ferguson/refcnt (autoCopy -> init)

Testing:
- [x] types/records/ferguson with futures
- [x] gasnet for types/records/ferguson/multilocale/