### PR TITLE
Try to quiet hwloc warnings under travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ compiler:
 
 matrix:
   include:
-    - env: NIGHTLY_TEST_SETTINGS=true QTHREAD_AFFINITY=no CHPL_SMOKE_SKIP_DOC=true TEST_COMMAND="./util/buildRelease/smokeTest"
+    - env: NIGHTLY_TEST_SETTINGS=true QTHREAD_AFFINITY=no HWLOC_HIDE_ERRORS=1 CHPL_SMOKE_SKIP_DOC=true TEST_COMMAND="./util/buildRelease/smokeTest"
     - env: NIGHTLY_TEST_SETTINGS=true CHPL_SMOKE_SKIP_MAKE_CHECK=true TEST_COMMAND="./util/buildRelease/smokeTest"
     - env: TEST_COMMAND="make test-venv && CHPL_HOME=$PWD ./util/run-in-venv.bash ./util/test/check_annotations.py"
       git:


### PR DESCRIPTION
Set `HWLOC_HIDE_ERRORS=1` during travis testing to hopefully avoid the sporadic
hwloc warnings we've been seeing recently. When travis testing happens to run
on a 4.4 kernel we've been getting errors about bad L3 cache detection. We
don't care about that for travis testing (and we already disable affinity under
travis because of weirdness with trying to pin under a VM/container.)

This isn't an ideal solution (HWLOC_HIDE_ERRORS=1 sounds extreme/bad), but I
don't think this is worth digging into too much.

This closes https://github.com/chapel-lang/chapel/issues/9680