### PR TITLE
Allow POD identification for compiler-generated copy-initializers

### DIFF
--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -1135,7 +1135,10 @@ static bool hasUserDefinedConstructor(AggregateType* at);
 static void build_record_copy_function(AggregateType* at) {
   if (function_exists("chpl__initCopy", at) == NULL) {
     if (isRecordWithInitializers(at) == true) {
-      if (function_exists("init", dtMethodToken, at, at) != NULL) {
+
+      // Compiler-generated copy-initializers should not disable POD
+      FnSymbol* fn = function_exists("init", dtMethodToken, at, at);
+      if (fn != NULL && fn->hasFlag(FLAG_COMPILER_GENERATED) == false) {
         at->symbol->addFlag(FLAG_NOT_POD);
       }
 

--- a/test/types/type_variables/ferguson/ispod.chpl
+++ b/test/types/type_variables/ferguson/ispod.chpl
@@ -46,6 +46,16 @@ record NotPod7 {
   var x:NotPod6;
 }
 
+record NotPod8 {
+  var x : int;
+  var y : int;
+  proc init() { }
+  proc init(other:NotPod8) {
+    this.x = other.x + 1;
+    this.y = other.y + 1;
+  }
+}
+
 record Pod1 {
   var x:int;
   var y:int;
@@ -83,6 +93,7 @@ doit(NotPod4);
 doit(NotPod5);
 doit(NotPod6);
 doit(NotPod7);
+doit(NotPod8);
 doit(Pod1);
 doit(Pod2);
 doit(Pod3);

--- a/test/types/type_variables/ferguson/ispod.good
+++ b/test/types/type_variables/ferguson/ispod.good
@@ -14,6 +14,7 @@ NotPod4 : false
 NotPod5 : false
 NotPod6 : false
 NotPod7 : false
+NotPod8 : false
 Pod1 : true
 Pod2 : true
 Pod3 : true


### PR DESCRIPTION
This PR stops the compiler from rejecting a type from plain-old-data tagging if it has a compiler-generated initializer.

Testing:
- [x] local + futures
- [x] gasnet