### PR TITLE
Use BTE RDMA for large transfers under ugni

### DIFF
--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -717,7 +717,7 @@ static __thread int cd_idx = -1;
 // BTE RDMA is profitable around 1-4K. It's neck-and-neck under 4K, so
 // for now follow gasnet-aries and use the higher default of 4K
 #define DEFAULT_RDMA_THRESHOLD 4096
-static size_t RDMA_THRESHOLD = DEFAULT_RDMA_THRESHOLD;
+static size_t rdma_threshold = DEFAULT_RDMA_THRESHOLD;
 
 #define ALIGN_32_DN(x)    ALIGN_DN((x), sizeof(int32_t))
 #define ALIGN_32_UP(x)    ALIGN_UP((x), sizeof(int32_t))
@@ -1869,7 +1869,7 @@ void chpl_comm_post_task_init(void)
   //
   // Get FMA/BTE threshold
   //
-  RDMA_THRESHOLD = chpl_env_rt_get_size("UGNI_RDMA_THRESHOLD",
+  rdma_threshold = chpl_env_rt_get_size("UGNI_RDMA_THRESHOLD",
                                         DEFAULT_RDMA_THRESHOLD);
 
   //
@@ -5033,7 +5033,7 @@ void do_remote_put(void* src_addr, c_nodeid_t locale, void* tgt_addr,
   // If the PUT size merits RDMA and the source addr is registered,
   // then do an RDMA put instead of FMA
   //
- if (size >= RDMA_THRESHOLD &&
+ if (size >= rdma_threshold &&
      (local_mr = mreg_for_local_addr(src_addr)) != NULL) {
     do_rdma = true;
     max_trans_sz = MAX_RDMA_TRANS_SZ;
@@ -5413,7 +5413,7 @@ void do_nic_get(void* tgt_addr, c_nodeid_t locale, mem_region_t* remote_mr,
   //
   // If the GET size merits RDMA do an RDMA get instead of FMA
   //
- if (size >= RDMA_THRESHOLD) {
+ if (size >= rdma_threshold) {
     do_rdma = true;
     max_trans_sz = MAX_RDMA_TRANS_SZ;
     post_desc.type = GNI_POST_RDMA_GET;
@@ -5928,7 +5928,7 @@ chpl_comm_nb_handle_t chpl_comm_get_nb(void* addr, c_nodeid_t locale,
   //
   // If the GET size merits RDMA do an RDMA get instead of FMA
   //
-  if (size >= RDMA_THRESHOLD) {
+  if (size >= rdma_threshold) {
     do_rdma = true;
     post_desc->type = GNI_POST_RDMA_GET;
   }


### PR DESCRIPTION
Bring ISx performance on par with the reference version by using uGNI's block
transfer engine (BTE) to significantly increase sustained bandwidth.

This enables uGNI's block transfer engine for puts/gets larger than 4K. This
significantly increases the performance of the arrayTransfer microbenchmark,
allowing point-to-point puts/gets over 1M to achieve over 8 GB/s, which is very
close to maximum hardware bandwidth. Using BTE significantly improves the
all-to-all bucket exchange step in ISx, which closes the main performance gap
between Chapel and the reference SHMEM version. At 256 locales, ISx is now ~30%
faster, which brings it within ~5% of the reference version. This also seems to
stabilize ISx timings, particularly on busy systems.

Below is a table comparing the PUT version of the arrayTransfer benchmark at
different sizes. It compares ugni with FMA vs. ugni with BTE for large
transfers vs. gn-aries. gn-aries appears to be slightly ahead of ugni for large
transfers still, but this is just because the entire array under gn-aries is on
numa-domain 0, which is closer to the NIC. ugni permits first-touch, so half
the array is on numa-domain 1. Putting the entire array on numa-domain 0 by
wrapping the benchmark with a `serial` block lets ugni achieve 8700 MB/s as
well.

| size    | FMA-ugni   | BTE-ugni   | gn-aries  |
| ------- | ---------- | ---------- | --------- |
|  512B   |   35 MB/s  |   35 MB/s  |   30 MB/s |
| 4096B   |  290 MB/s  |  295 MB/s  |  230 MB/s |
|    1MB  | 3650 MB/s  | 7500 MB/s  | 7900 MB/s |
|    1GB  | 3707 MB/s  | 8200 MB/s  | 8500 MB/s |
| 1/4 mem | 3799 MB/s  | 8400 MB/s  | 8700 MB/s |


And the new ISx results:

![isx-time](https://user-images.githubusercontent.com/1588337/40895518-db88b2d8-6764-11e8-82a7-bae0aefe9297.png)

This closes https://github.com/chapel-lang/chapel/issues/9615