### PR TITLE
Add perf annotations for 2018-05-31

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -327,6 +327,9 @@ all:
     - Update strings to use initializers (#9217)
   04/19/19:
     - Use zero-arg initializer in BaseDom (#9250)
+  05/17/18:
+    - text: ubuntu update to 18.04 (gcc upgraded to 7.3)
+      config: shootout
 
 AllCompTime:
   11/09/14:
@@ -341,6 +344,8 @@ AllCompTime:
     - Fix parse slowdown (#5257)
   02/07/17:
     - Loop over Defs and Uses with SymbolSymExprs (#5285)
+  05/23/18:
+    - Fix problems with tuples (#9572)
 
 arguments:
   09/20/17:
@@ -439,11 +444,15 @@ CoMD:
   07/26/17:
     - Update PR 5296 (#6722)
 
-compSampler-timecomp:
+compSampler-timecomp: &timecomp-base
   09/09/16:
     - disable function resolution optimization (#4476)
   09/14/16:
     - re-enable function resolution optimization (#4517)
+  05/16/18:
+    - Faster 'fixStringLiteralInit' implementation (#9506)
+  05/23/18:
+    - Fix problems with tuples (#9572)
 
 cg:
   09/20/16:
@@ -457,10 +466,7 @@ cg-a:
 
 
 cg-sparse-timecomp:
-  09/09/16:
-    - disable function resolution optimization (#4476)
-  09/14/16:
-    - re-enable function resolution optimization (#4517)
+  <<: *timecomp-base
 
 c-ray:
   10/11/16:
@@ -497,6 +503,8 @@ ep-b:
 ep.ml-perf:
   07/26/17:
     - Update PR 5296 (#6722)
+  05/23/18:
+    - Fix problems with tuples (#9572)
 
 ep.ml-time:
   07/26/17:
@@ -550,10 +558,7 @@ fastaredux:
     - implemented good_alloc_size for jemalloc(#3446)
 
 fft-timecomp:
-  09/09/16:
-    - disable function resolution optimization (#4476)
-  09/14/16:
-    - re-enable function resolution optimization (#4517)
+  <<: *timecomp-base
 
 forall-dom-range:
   01/22/15:
@@ -849,6 +854,12 @@ memleaksfull:
     - Partial reductions for LayoutCS (#9269)
   04/20/18:
     - Adjust partial-reduction tests (#9284)
+  05/16/18:
+    - deprecate 'out error' pattern from modules (#9450)
+  05/17/18:
+    - Enable fields with generic declared type (#9489)
+  05/24/18:
+    - Migrate tests to use decorated new(#9499)
 
 meteor:
   12/18/13:
@@ -930,17 +941,15 @@ parOpEquals:
   02/28/15:
     - (no-local) Move the check for src==dst from comm_get to array op= (#1410)
 
-pidigits:
+pidigits: &pidigits-base
   05/16/16:
     - switched release version to use ledrug algorithm
   09/24/16:
-    - rearranged pidigits; release versions now use bigints (#4655-6)
-
+    - rearranged pidigits; release versions now use bigints (#4655) (#4656)
+  05/01/18:
+    - Move chplgmp.c out of runtime (#8944)
 pidigits-submitted:
-  05/16/16:
-    - switched release version to use ledrug algorithm
-  09/24/16:
-    - rearranged pidigits; release versions now use bigints (#4655-6)
+  <<: *pidigits-base
 
 prk-stencil:
   02/14/16:
@@ -1047,6 +1056,8 @@ regexdnaredux-submitted:
 return-array-8: &return-array-base
   03/04/17:
     - remove unnecessary return from array-return tests (#5486)
+  05/01/18:
+    - Enable variables declared with generic type (#9355)
 return-array-20000000:
   <<: *return-array-base
 return-array-40000000:
@@ -1156,6 +1167,8 @@ twopt-paircount:
 search:
   04/20/17:
     - Update RE2 (#6024)
+  05/26/18:
+    - Update tuples to use special function instead of constructors (#9317)
 
 testSerialReductions:
   08/16/14:


### PR DESCRIPTION
Add perf annotations for the past couple weeks:
 - upgrade shootout box to ubuntu 18.04
 - compilation (normalize) speedups from faster string normalization
 - compilation (resolve) slowdown from tuple fixes
 - small regression for 16-node-ep from tuple fixes
 - new memory leaks from out-error deprecation
 - new memory leaks from fields with generic declared type
 - closed memory leaks from switching tests to use decorated news
 - faster string search from using special functions vs constructors for tuple