### PR TITLE
Update fixupDefaultInitCopy to look for default-inits

### DIFF
--- a/compiler/resolution/generics.cpp
+++ b/compiler/resolution/generics.cpp
@@ -566,8 +566,7 @@ static bool fixupDefaultInitCopy(FnSymbol* fn,
   bool       retval = false;
 
   if (AggregateType* ct = toAggregateType(arg->type)) {
-    if (isUserDefinedRecord(ct) == true &&
-        ct->initializerStyle    == DEFINES_INITIALIZER) {
+    if (isUserDefinedRecord(ct) == true && ct->hasInitializers()) {
       // If the user has defined any initializer,
       // initCopy function should call the copy-initializer.
       //


### PR DESCRIPTION
We should attempt to use any initializer instead of an initCopy, not just user-defined initializers.

Testing:
- [x] local + futures
- [x] memleaks
- [x] gasnet on release/examples, distributions/, multilocale/