### PR TITLE
DataFrame ADT

### DIFF
--- a/test/library/standard/DataFrames/DataFrames.chpl
+++ b/test/library/standard/DataFrames/DataFrames.chpl
@@ -700,11 +700,8 @@ module DataFrames {
       this.idx = idx;
       this.complete();
 
-      for (lab, s) in zip(labels, columns) {
-        var sCopy = s.copy();
-        sCopy.reindex(idx);
-        this.columns[lab] = sCopy;
-      }
+      for (lab, s) in zip(labels, columns) do
+        this.insert(lab, s);
     }
 
     iter these() {
@@ -716,8 +713,10 @@ module DataFrames {
       return columns[lab];
     }
 
-    proc this(lab: string) ref {
-      return columns[lab];
+    proc insert(lab: string, s: Series) {
+      var sCopy = s.copy();
+      sCopy.reindex(idx);
+      columns[lab] = sCopy;
     }
 
     proc reindex(idx: Index) {

--- a/test/library/standard/DataFrames/DataFrames.chpl
+++ b/test/library/standard/DataFrames/DataFrames.chpl
@@ -638,8 +638,14 @@ module DataFrames {
       if idx {
         idx.writeThis(f, this);
       } else {
-        for (i, d) in this.items() do
-          f <~> i + "    " + d + "\n";
+        for (v, (i, d)) in this._items() {
+          f <~> i + "    ";
+          if v then
+            f <~> d;
+          else
+            f <~> "None";
+          f <~> "\n";
+        }
       }
       f <~> "dtype: " + eltType:string;
     }

--- a/test/library/standard/DataFrames/DataFrames.chpl
+++ b/test/library/standard/DataFrames/DataFrames.chpl
@@ -219,9 +219,9 @@ module DataFrames {
       for lab in d.labels {
         f <~> lab + "   ";
       }
-      f <~> "\n";
 
       for idx in this {
+        f <~> "\n";
         // TODO: clean up to simple cast after bugfix
         var idxStr = new string(idx: string);
         f <~> idxStr;
@@ -232,7 +232,6 @@ module DataFrames {
           ser.writeElem(f, idx, lab.length);
           f <~> "   ";
         }
-        f <~> "\n";
       }
     }
 
@@ -677,6 +676,10 @@ module DataFrames {
 
     // TODO: init with labels arg
 
+    proc init() {
+      this.complete();
+    }
+
     proc init(columns: [?D] Series) {
       this.labels = D;
       this.idx = nil;
@@ -707,6 +710,16 @@ module DataFrames {
       return columns[lab];
     }
 
+    proc this(lab: string) ref {
+      return columns[lab];
+    }
+
+    proc reindex(idx: Index) {
+      this.idx = idx;
+      for s in columns do
+        s.reindex(idx);
+    }
+
     proc nrows() {
       var nMax = 0;
       for s in this {
@@ -729,9 +742,9 @@ module DataFrames {
         for lab in labels {
           f <~> lab + "   ";
         }
-        f <~> "\n";
 
         for i in 1..n {
+          f <~> "\n";
           var iStr = new string(i: string);
           f <~> iStr;
           for space in 1..idxWidth-iStr.length do
@@ -741,7 +754,6 @@ module DataFrames {
             ser.writeElemNoIndex(f, i, lab.length);
             f <~> "   ";
           }
-          f <~> "\n";
         }
       }
     }

--- a/test/library/standard/DataFrames/DataFrames.chpl
+++ b/test/library/standard/DataFrames/DataFrames.chpl
@@ -189,6 +189,11 @@ module DataFrames {
 
   class Series {
     pragma "no doc"
+    proc reindex(idx) {
+      halt("generic Series cannot be reindexed");
+    }
+
+    pragma "no doc"
     proc uni(lhs: TypedSeries, unifier: SeriesUnifier) {
       halt("generic Series cannot be unioned");
       return this;
@@ -421,6 +426,10 @@ module DataFrames {
       return valid_bits[ord];
     }
 
+    proc reindex(idx: Index) {
+      this.idx = idx;
+    }
+
     /*
      * Functional Constructs
      */
@@ -547,6 +556,40 @@ module DataFrames {
           f <~> i + "\t" + d + "\n";
       }
       f <~> "dtype: " + eltType:string;
+    }
+  }
+
+  class DataFrame {
+    var labels: domain(string);
+    var columns: [labels] Series;
+    var idx: Index;
+
+    // TODO: init with labels arg
+
+    /* TODO: init with no idx arg
+    proc init(columns: [?D] Series) {
+      this.idx = nil;
+      this.labels = D;
+      this.columns = columns;
+    }
+     */
+
+    proc init(columns: [?D], idx: Index) {
+      this.labels = D;
+      this.columns = columns;
+      this.idx = idx;
+
+      this.complete();
+      for s in this.columns do
+        s.reindex(idx);
+    }
+
+    proc writeThis(f) {
+      for (l, s) in zip(labels, columns) {
+        f <~> l + ":\n";
+        s.writeThis(f);
+        f <~> "\n\n";
+      }
     }
   }
 

--- a/test/library/standard/DataFrames/DataFrames.chpl
+++ b/test/library/standard/DataFrames/DataFrames.chpl
@@ -168,8 +168,19 @@ module DataFrames {
                              filter_valid_bits[1..curr_ord]);
     }
 
-
     proc writeThis(f, s: TypedSeries(?) = nil) {
+      for (i, (v, d)) in zip(this, s._these()) {
+        f <~> i;
+        f <~> "\t";
+        if v then
+          f <~> d;
+        else
+          f <~> "None";
+        f <~> "\n";
+      }
+    }
+
+    proc writeThis(f, d: DataFrame = nil) {
       for (i, (v, d)) in zip(this, s._these()) {
         f <~> i;
         f <~> "\t";
@@ -584,11 +595,35 @@ module DataFrames {
         s.reindex(idx);
     }
 
+    // TODO: iterates over the axes
+    /*
+    iter these() {
+    }
+     */
+
+    // TODO: need new data structures for this, or flexible-len tups
+    /*
+    iter tuples(type idxType) {
+      if idx {
+        for i in idx:TypedIndex(idxType) {
+     */
+
+    // TODO: no idx
+    /*
+      iter tuples_fast() {
+     */
+
     proc writeThis(f) {
-      for (l, s) in zip(labels, columns) {
-        f <~> l + ":\n";
-        s.writeThis(f);
-        f <~> "\n\n";
+      if idx {
+        idx.writeThis(f, this);
+      } else {
+        for l in labels do
+          f <~> l + ":\t\t";
+        for s in this.columns {
+          f <~> l + ":\n";
+          s.writeThis(f);
+          f <~> "\n\n";
+        }
       }
     }
   }

--- a/test/library/standard/DataFrames/psahabu/AddSeries.good
+++ b/test/library/standard/DataFrames/psahabu/AddSeries.good
@@ -40,20 +40,20 @@ E    0
 dtype: int(64)
 
 addends:
-1	hello 
-2	my 
-3	name
-4	is
-5	brad
+1    hello 
+2    my 
+3    name
+4    is
+5    brad
 dtype: string
-1	world
-2	real
+1    world
+2    real
 dtype: string
 
 sum:
-1	hello world
-2	my real
-3	name
-4	is
-5	brad
+1    hello world
+2    my real
+3    name
+4    is
+5    brad
 dtype: string

--- a/test/library/standard/DataFrames/psahabu/AddSeries.good
+++ b/test/library/standard/DataFrames/psahabu/AddSeries.good
@@ -1,42 +1,42 @@
 addends:
-A	1
-B	2
-C	3
-D	4
-E	5
+A    1
+B    2
+C    3
+D    4
+E    5
 dtype: int(64)
-A	10
-B	20
-C	30
-D	40
-E	50
+A    10
+B    20
+C    30
+D    40
+E    50
 dtype: int(64)
 
 sum:
-A	11
-B	22
-C	33
-D	44
-E	55
+A    11
+B    22
+C    33
+D    44
+E    55
 dtype: int(64)
 
 addends:
-A	0
-B	1
-C	2
+A    0
+B    1
+C    2
 dtype: int(64)
-B	10
-C	20
-D	0
-E	0
+B    10
+C    20
+D    0
+E    0
 dtype: int(64)
 
 sum:
-A	0
-B	11
-C	22
-D	0
-E	0
+A    0
+B    11
+C    22
+D    0
+E    0
 dtype: int(64)
 
 addends:

--- a/test/library/standard/DataFrames/psahabu/AndOrSeries.good
+++ b/test/library/standard/DataFrames/psahabu/AndOrSeries.good
@@ -1,19 +1,19 @@
 noTrue:
-1	false
-2	false
-3	false
+1    false
+2    false
+3    false
 dtype: bool
 
 oneTrue:
-1	false
-2	true
-3	false
+1    false
+2    true
+3    false
 dtype: bool
 
 allTrue:
-1	true
-2	true
-3	true
+1    true
+2    true
+3    true
 dtype: bool
 
 noTrue.and(): false

--- a/test/library/standard/DataFrames/psahabu/ArithNoneSeries.good
+++ b/test/library/standard/DataFrames/psahabu/ArithNoneSeries.good
@@ -1,55 +1,55 @@
 oneDigit:
-A	1
-B	None
-C	3
-D	None
-E	5
+A    1
+B    None
+C    3
+D    None
+E    5
 dtype: int(64)
 
 twoDigit:
-A	10
-B	None
-C	30
-D	None
-E	50
+A    10
+B    None
+C    30
+D    None
+E    50
 dtype: int(64)
 
 twoDigitInv:
-A	None
-B	20
-C	None
-D	40
-E	None
+A    None
+B    20
+C    None
+D    40
+E    None
 dtype: int(64)
 
 oneDigit + twoDigit:
-A	11
-B	None
-C	33
-D	None
-E	55
+A    11
+B    None
+C    33
+D    None
+E    55
 dtype: int(64)
 
 oneDigit - twoDigit:
-A	-9
-B	None
-C	-27
-D	None
-E	-45
+A    -9
+B    None
+C    -27
+D    None
+E    -45
 dtype: int(64)
 
 oneDigit + twoDigitInv:
-A	None
-B	None
-C	None
-D	None
-E	None
+A    None
+B    None
+C    None
+D    None
+E    None
 dtype: int(64)
 
 oneDigit - twoDigitInv:
-A	None
-B	None
-C	None
-D	None
-E	None
+A    None
+B    None
+C    None
+D    None
+E    None
 dtype: int(64)

--- a/test/library/standard/DataFrames/psahabu/ContainSeries.good
+++ b/test/library/standard/DataFrames/psahabu/ContainSeries.good
@@ -1,8 +1,8 @@
-A	a
-B	b
-C	c
-D	d
-E	e
+A    a
+B    b
+C    c
+D    d
+E    e
 dtype: string
 
 contains A: true

--- a/test/library/standard/DataFrames/psahabu/FilterNoneSeries.good
+++ b/test/library/standard/DataFrames/psahabu/FilterNoneSeries.good
@@ -1,23 +1,23 @@
 oneDigit:
-A	1
-B	None
-C	3
-D	None
-E	5
+A    1
+B    None
+C    3
+D    None
+E    5
 dtype: int(64)
 
 twoDigit:
-A	10
-B	None
-C	30
-D	None
-E	50
+A    10
+B    None
+C    30
+D    None
+E    50
 dtype: int(64)
 
 oneDigit < 3
-A	1
+A    1
 dtype: int(64)
 
 twoDigit > 30
-E	50
+E    50
 dtype: int(64)

--- a/test/library/standard/DataFrames/psahabu/FilterSeries.good
+++ b/test/library/standard/DataFrames/psahabu/FilterSeries.good
@@ -1,69 +1,69 @@
 initial:
-A	1
-B	2
-C	3
-D	4
-E	5
+A    1
+B    2
+C    3
+D    4
+E    5
 dtype: int(64)
 
 less than 3:
-A	true
-B	true
-C	false
-D	false
-E	false
+A    true
+B    true
+C    false
+D    false
+E    false
 dtype: bool
 filtered(less than 3):
-A	1
-B	2
+A    1
+B    2
 dtype: int(64)
 
 greater than 3:
-A	false
-B	false
-C	false
-D	true
-E	true
+A    false
+B    false
+C    false
+D    true
+E    true
 dtype: bool
 filtered(greater than 3):
-D	4
-E	5
+D    4
+E    5
 dtype: int(64)
 
 equal to 3:
-A	false
-B	false
-C	true
-D	false
-E	false
+A    false
+B    false
+C    true
+D    false
+E    false
 dtype: bool
 filtered(equal to 3):
-C	3
+C    3
 dtype: int(64)
 
 less than or equal to 3:
-A	true
-B	true
-C	true
-D	false
-E	false
+A    true
+B    true
+C    true
+D    false
+E    false
 dtype: bool
 filtered(less than or equal to 3):
-A	1
-B	2
-C	3
+A    1
+B    2
+C    3
 dtype: int(64)
 
 greater than or equal to 3:
-A	false
-B	false
-C	true
-D	true
-E	true
+A    false
+B    false
+C    true
+D    true
+E    true
 dtype: bool
 filtered(greater than or equal to 3):
-C	3
-D	4
-E	5
+C    3
+D    4
+E    5
 dtype: int(64)
 

--- a/test/library/standard/DataFrames/psahabu/HelloDataFrame.chpl
+++ b/test/library/standard/DataFrames/psahabu/HelloDataFrame.chpl
@@ -1,6 +1,7 @@
 use DataFrames;
 
 var validBits = [true, false, true, false, true];
+
 var columnOne: Series = new TypedSeries(["a", "b", "c", "d", "e"], validBits);
 var columnTwo: Series = new TypedSeries([1, 2, 3, 4, 5], validBits);
 var columnThree: Series = new TypedSeries([10.0, 20.0, 30.0, 40.0, 50.0]);

--- a/test/library/standard/DataFrames/psahabu/HelloDataFrame.chpl
+++ b/test/library/standard/DataFrames/psahabu/HelloDataFrame.chpl
@@ -1,12 +1,13 @@
 use DataFrames;
 
-// TODO: if columns are homogenous
-var columnOne: Series = new TypedSeries(["a", "b", "c", "d", "e"]);
-var columnTwo: Series = new TypedSeries([1, 2, 3, 4, 5]);
-var columnTree: Series = new TypedSeries([10.0, 20.0, 30.0, 40.0, 50.0]);
+var validBits = [true, false, true, false, true];
+var columnOne: Series = new TypedSeries(["a", "b", "c", "d", "e"], validBits);
+var columnTwo: Series = new TypedSeries([1, 2, 3, 4, 5], validBits);
+var columnThree: Series = new TypedSeries([10.0, 20.0, 30.0, 40.0, 50.0]);
 
-var columns = ["columnOne" => columnOne, "columnTwo" => columnTwo, "columnTree" => columnTree];
-var idx = new TypedIndex(["rowOne", "rowTwo", "rowTree", "rowFour", "rowFive"]);
+var columns = ["columnOne" => columnOne, "columnTwo" => columnTwo, "columnThree" => columnThree];
+var idx = new TypedIndex(["rowOne", "rowTwo", "rowThree", "rowFour", "rowFive"]);
 
 var dataFrame = new DataFrame(columns, idx);
 writeln(dataFrame);
+writeln(dataFrame["columnThree"]);

--- a/test/library/standard/DataFrames/psahabu/HelloDataFrame.chpl
+++ b/test/library/standard/DataFrames/psahabu/HelloDataFrame.chpl
@@ -12,5 +12,7 @@ var idx = new TypedIndex(["rowOne", "rowTwo", "rowThree", "rowFour", "rowFive"])
 var dataFrame = new DataFrame(columns, idx);
 var noIndex = new DataFrame(columns);
 writeln(dataFrame);
+writeln();
 writeln(dataFrame["columnThree"]);
+writeln();
 writeln(noIndex);

--- a/test/library/standard/DataFrames/psahabu/HelloDataFrame.chpl
+++ b/test/library/standard/DataFrames/psahabu/HelloDataFrame.chpl
@@ -9,5 +9,7 @@ var columns = ["columnOne" => columnOne, "columnTwo" => columnTwo, "columnThree"
 var idx = new TypedIndex(["rowOne", "rowTwo", "rowThree", "rowFour", "rowFive"]);
 
 var dataFrame = new DataFrame(columns, idx);
+var noIndex = new DataFrame(columns);
 writeln(dataFrame);
 writeln(dataFrame["columnThree"]);
+writeln(noIndex);

--- a/test/library/standard/DataFrames/psahabu/HelloDataFrame.chpl
+++ b/test/library/standard/DataFrames/psahabu/HelloDataFrame.chpl
@@ -1,0 +1,12 @@
+use DataFrames;
+
+// TODO: if columns are homogenous
+var columnOne: Series = new TypedSeries(["a", "b", "c", "d", "e"]);
+var columnTwo: Series = new TypedSeries([1, 2, 3, 4, 5]);
+var columnTree: Series = new TypedSeries([10.0, 20.0, 30.0, 40.0, 50.0]);
+
+var columns = ["columnOne" => columnOne, "columnTwo" => columnTwo, "columnTree" => columnTree];
+var idx = new TypedIndex(["rowOne", "rowTwo", "rowTree", "rowFour", "rowFive"]);
+
+var dataFrame = new DataFrame(columns, idx);
+writeln(dataFrame);

--- a/test/library/standard/DataFrames/psahabu/HelloDataFrame.good
+++ b/test/library/standard/DataFrames/psahabu/HelloDataFrame.good
@@ -11,3 +11,10 @@ rowThree    30.0
 rowFour     40.0
 rowFive     50.0
 dtype: real(64)
+  columnThree   columnOne   columnTwo   
+1        10.0           a           1   
+2        20.0        None        None   
+3        30.0           c           3   
+4        40.0        None        None   
+5        50.0           e           5   
+

--- a/test/library/standard/DataFrames/psahabu/HelloDataFrame.good
+++ b/test/library/standard/DataFrames/psahabu/HelloDataFrame.good
@@ -1,0 +1,13 @@
+         columnThree   columnOne   columnTwo   
+rowOne          10.0           a           1   
+rowTwo          20.0        None        None   
+rowThree        30.0           c           3   
+rowFour         40.0        None        None   
+rowFive         50.0           e           5   
+
+rowOne      10.0
+rowTwo      20.0
+rowThree    30.0
+rowFour     40.0
+rowFive     50.0
+dtype: real(64)

--- a/test/library/standard/DataFrames/psahabu/HelloDataFrame.good
+++ b/test/library/standard/DataFrames/psahabu/HelloDataFrame.good
@@ -11,10 +11,10 @@ rowThree    30.0
 rowFour     40.0
 rowFive     50.0
 dtype: real(64)
+
   columnThree   columnOne   columnTwo   
 1        10.0           a           1   
 2        20.0        None        None   
 3        30.0           c           3   
 4        40.0        None        None   
 5        50.0           e           5   
-

--- a/test/library/standard/DataFrames/psahabu/HelloDataFrame.py
+++ b/test/library/standard/DataFrames/psahabu/HelloDataFrame.py
@@ -1,0 +1,15 @@
+import pandas as pd
+
+columnOne = ["a", None, "c", None, "e"]
+columnTwo = [1, None, 3, None, 5]
+columnThree = [10.0, 20.0, 30.0, 40.0, 50.0]
+
+idx = pd.Index(["rowOne", "rowTwo", "rowThree", "rowFour", "rowFive"])
+dataFrame = pd.DataFrame({ "columnOne": columnOne,
+                           "columnTwo": columnTwo,
+                           "columnThree": columnThree },
+                          idx)
+
+print dataFrame
+print
+print dataFrame["columnThree"]

--- a/test/library/standard/DataFrames/psahabu/HelloDataFrame.py
+++ b/test/library/standard/DataFrames/psahabu/HelloDataFrame.py
@@ -9,7 +9,13 @@ dataFrame = pd.DataFrame({ "columnOne": columnOne,
                            "columnTwo": columnTwo,
                            "columnThree": columnThree },
                           idx)
+noIndex = pd.DataFrame({ "columnOne": columnOne,
+                         "columnTwo": columnTwo,
+                         "columnThree": columnThree })
+
 
 print dataFrame
 print
 print dataFrame["columnThree"]
+print
+print noIndex

--- a/test/library/standard/DataFrames/psahabu/HelloSeries.good
+++ b/test/library/standard/DataFrames/psahabu/HelloSeries.good
@@ -4,9 +4,9 @@
 4	d
 5	e
 dtype: string
-A	a
-B	b
-C	c
-D	d
-E	e
+A    a
+B    b
+C    c
+D    d
+E    e
 dtype: string

--- a/test/library/standard/DataFrames/psahabu/HelloSeries.good
+++ b/test/library/standard/DataFrames/psahabu/HelloSeries.good
@@ -1,8 +1,8 @@
-1	a
-2	b
-3	c
-4	d
-5	e
+1    a
+2    b
+3    c
+4    d
+5    e
 dtype: string
 A    a
 B    b

--- a/test/library/standard/DataFrames/psahabu/MixedOperateSeries.good
+++ b/test/library/standard/DataFrames/psahabu/MixedOperateSeries.good
@@ -1,28 +1,28 @@
 oneDigit:
-A	1
-B	2
-C	3
-D	4
-E	5
+A    1
+B    2
+C    3
+D    4
+E    5
 dtype: int(64)
 
 twoDigit:
-A	10
-B	20
-C	30
-D	40
-E	50
+A    10
+B    20
+C    30
+D    40
+E    50
 dtype: int(64)
 
 oneDigit + twoDigit:
-A	11
-B	22
-C	33
-D	44
-E	55
+A    11
+B    22
+C    33
+D    44
+E    55
 dtype: int(64)
 
 oneDigit < 3
-A	1
-B	2
+A    1
+B    2
 dtype: int(64)

--- a/test/library/standard/DataFrames/psahabu/MultiplySeries.good
+++ b/test/library/standard/DataFrames/psahabu/MultiplySeries.good
@@ -1,40 +1,40 @@
 factors:
-A	1
-B	2
-C	3
-D	4
-E	5
+A    1
+B    2
+C    3
+D    4
+E    5
 dtype: int(64)
-A	11
-B	22
-C	33
-D	44
-E	55
+A    11
+B    22
+C    33
+D    44
+E    55
 dtype: int(64)
 
 product:
-A	11
-B	44
-C	99
-D	176
-E	275
+A    11
+B    44
+C    99
+D    176
+E    275
 dtype: int(64)
 
 factors:
-B	10
-C	20
-D	6
-E	7
+B    10
+C    20
+D    6
+E    7
 dtype: int(64)
-A	5
-B	1
-C	2
+A    5
+B    1
+C    2
 dtype: int(64)
 
 product:
-A	0
-B	10
-C	40
-D	0
-E	0
+A    0
+B    10
+C    40
+D    0
+E    0
 dtype: int(64)

--- a/test/library/standard/DataFrames/psahabu/MutateDataFrame.chpl
+++ b/test/library/standard/DataFrames/psahabu/MutateDataFrame.chpl
@@ -7,10 +7,18 @@ var columnOne: Series = new TypedSeries(["a", "b", "c", "d", "e"], validBits);
 var columnTwo: Series = new TypedSeries([1, 2, 3, 4, 5], validBits);
 var columnThree: Series = new TypedSeries([10.0, 20.0, 30.0, 40.0, 50.0]);
 
+writeln(columnOne);
+writeln();
+writeln(columnTwo);
+writeln();
+writeln(columnThree);
+writeln();
+
 df["columnOne"] = columnOne;
 df["columnTwo"] = columnTwo;
 df["columnThree"] = columnThree;
 
 var idx = new TypedIndex(["rowOne", "rowTwo", "rowThree", "rowFour", "rowFive"]);
 df.reindex(idx);
+
 writeln(df);

--- a/test/library/standard/DataFrames/psahabu/MutateDataFrame.chpl
+++ b/test/library/standard/DataFrames/psahabu/MutateDataFrame.chpl
@@ -14,9 +14,9 @@ writeln();
 writeln(columnThree);
 writeln();
 
-df["columnOne"] = columnOne;
-df["columnTwo"] = columnTwo;
-df["columnThree"] = columnThree;
+df.insert("columnOne", columnOne);
+df.insert("columnTwo", columnTwo);
+df.insert("columnThree", columnThree);
 
 var idx = new TypedIndex(["rowOne", "rowTwo", "rowThree", "rowFour", "rowFive"]);
 df.reindex(idx);

--- a/test/library/standard/DataFrames/psahabu/MutateDataFrame.chpl
+++ b/test/library/standard/DataFrames/psahabu/MutateDataFrame.chpl
@@ -1,0 +1,16 @@
+use DataFrames;
+
+var df = new DataFrame();
+
+var validBits = [true, false, true, false, true];
+var columnOne: Series = new TypedSeries(["a", "b", "c", "d", "e"], validBits);
+var columnTwo: Series = new TypedSeries([1, 2, 3, 4, 5], validBits);
+var columnThree: Series = new TypedSeries([10.0, 20.0, 30.0, 40.0, 50.0]);
+
+df["columnOne"] = columnOne;
+df["columnTwo"] = columnTwo;
+df["columnThree"] = columnThree;
+
+var idx = new TypedIndex(["rowOne", "rowTwo", "rowThree", "rowFour", "rowFive"]);
+df.reindex(idx);
+writeln(df);

--- a/test/library/standard/DataFrames/psahabu/MutateDataFrame.good
+++ b/test/library/standard/DataFrames/psahabu/MutateDataFrame.good
@@ -1,0 +1,27 @@
+1    a
+2    None
+3    c
+4    None
+5    e
+dtype: string
+
+1    1
+2    None
+3    3
+4    None
+5    5
+dtype: int(64)
+
+1    10.0
+2    20.0
+3    30.0
+4    40.0
+5    50.0
+dtype: real(64)
+
+         columnThree   columnOne   columnTwo   
+rowOne          10.0           a           1   
+rowTwo          20.0        None        None   
+rowThree        30.0           c           3   
+rowFour         40.0        None        None   
+rowFive         50.0           e           5   

--- a/test/library/standard/DataFrames/psahabu/ScalarPromSeries.good
+++ b/test/library/standard/DataFrames/psahabu/ScalarPromSeries.good
@@ -1,31 +1,31 @@
 series:
-A	1
-B	2
-C	3
-D	4
-E	5
+A    1
+B    2
+C    3
+D    4
+E    5
 dtype: int(64)
 scalar:
 12
 
 sum:
-A	13
-B	14
-C	15
-D	16
-E	17
+A    13
+B    14
+C    15
+D    16
+E    17
 dtype: int(64)
 difference:
-A	-11
-B	-10
-C	-9
-D	-8
-E	-7
+A    -11
+B    -10
+C    -9
+D    -8
+E    -7
 dtype: int(64)
 product:
-A	12
-B	24
-C	36
-D	48
-E	60
+A    12
+B    24
+C    36
+D    48
+E    60
 dtype: int(64)

--- a/test/library/standard/DataFrames/psahabu/SubtractSeries.good
+++ b/test/library/standard/DataFrames/psahabu/SubtractSeries.good
@@ -1,40 +1,40 @@
 terms:
-A	1
-B	2
-C	3
-D	4
-E	5
+A    1
+B    2
+C    3
+D    4
+E    5
 dtype: int(64)
-A	11
-B	22
-C	33
-D	44
-E	55
+A    11
+B    22
+C    33
+D    44
+E    55
 dtype: int(64)
 
 difference:
-A	10
-B	20
-C	30
-D	40
-E	50
+A    10
+B    20
+C    30
+D    40
+E    50
 dtype: int(64)
 
 terms:
-B	10
-C	20
-D	6
-E	7
+B    10
+C    20
+D    6
+E    7
 dtype: int(64)
-A	5
-B	1
-C	2
+A    5
+B    1
+C    2
 dtype: int(64)
 
 difference:
-A	5
-B	-9
-C	-18
-D	-6
-E	-7
+A    5
+B    -9
+C    -18
+D    -6
+E    -7
 dtype: int(64)

--- a/test/library/standard/DataFrames/psahabu/SumMinMaxSeries.good
+++ b/test/library/standard/DataFrames/psahabu/SumMinMaxSeries.good
@@ -1,25 +1,25 @@
 noNone:
-A	1
-B	2
-C	3
-D	4
-E	5
+A    1
+B    2
+C    3
+D    4
+E    5
 dtype: int(64)
 
 someNone:
-A	1
-B	None
-C	3
-D	None
-E	5
+A    1
+B    None
+C    3
+D    None
+E    5
 dtype: int(64)
 
 moreNone:
-A	None
-B	20
-C	None
-D	40
-E	None
+A    None
+B    20
+C    None
+D    40
+E    None
 dtype: int(64)
 
 noNone.sum(): 15


### PR DESCRIPTION
### Motivation
The motivation for the DataFrame ADT can be found in the connected issue.

### Limitations
Currently it is not possible to emit a row from a DataFrame because a row requires a variable length, variable type ADT. See #9660 for exploration of this issue.

### Notes
Included in this PR are pandas equivalents to our tests. Note that the only significant differences are:
- slightly different spacing when printing a DataFrame