### PR TITLE
Thread file/line numbers through _new wrappers

### DIFF
--- a/compiler/passes/initializerRules.cpp
+++ b/compiler/passes/initializerRules.cpp
@@ -1040,6 +1040,8 @@ FnSymbol* buildClassAllocator(FnSymbol* initMethod) {
   fn->addFlag(FLAG_NEW_WRAPPER);
   fn->addFlag(FLAG_COMPILER_GENERATED);
   fn->addFlag(FLAG_LAST_RESORT);
+  fn->addFlag(FLAG_INSERT_LINE_FILE_INFO);
+  fn->addFlag(FLAG_ALWAYS_PROPAGATE_LINE_FILE_INFO);
 
   if (initMethod->hasFlag(FLAG_SUPPRESS_LVALUE_ERRORS)) {
     fn->addFlag(FLAG_SUPPRESS_LVALUE_ERRORS);


### PR DESCRIPTION
Formerly memory leak tracking might report the wrong line number for a "new" expression. Specifically, it would report the line at which the class was defined instead of the line at which the class was allocated. This is easily solved by adding FLAG_INSERT_LINE_FILE_INFO and FLAG_ALWAYS_PROPAGATE_LINE_FILE_INFO to the "_new" wrapper functions.

- [x] local + futures
- [x] gasnet on release/examples, distributions/, multilocale/