### PR TITLE
Fix internal error with nested calls in new expressions

### DIFF
--- a/test/classes/ferguson/delete-free/owned-shared-fields2.bad
+++ b/test/classes/ferguson/delete-free/owned-shared-fields2.bad
@@ -1,8 +1,2 @@
-owned-shared-fields2.chpl:11: internal error: CAL0078 chpl version 1.18.0 pre-release (573fcb6282)
-Note: This source location is a guess.
-
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
-and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
-please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
-
+leaks
+3          48         MyClass

--- a/test/classes/initializers/compilerGenerated/call-in-new.chpl
+++ b/test/classes/initializers/compilerGenerated/call-in-new.chpl
@@ -1,0 +1,20 @@
+
+proc foo() {
+  return 1;
+}
+
+class X {
+  var x : int;
+}
+
+class A {
+  var x = new owned X(foo());
+}
+
+var a = new owned A();
+
+class B {
+  var a = new owned A(new owned X(foo()));
+}
+
+var b = new owned B();


### PR DESCRIPTION
Nested calls within a ``new`` expression could sometimes result in an internal compiler error if that expression was used as the default value for a field. The internal error was encountered because normalization left the ``new`` expression in an invalid state.

At the end of normalization, we expect a ``new`` expression to both:
- no longer have a single call as the expression's actual
- not have any nested calls

If the expression was stored within a DefExpr, normalization would not introduce call temporaries, which would leave nested calls in the ``new`` expression. Unaware of this fact, we would still "unpack" the ``new`` expression's single actual into some form expected later. This unpacking would prevent call temps from being inserted, and result in unexpected AST.

This problem is fixed by choosing not to unpack the ``new`` expression if the expression does not belong to a statement. This indicates that the expression is within a DefExpr or something else that will be lowered later.

Resolves #8503

Testing:
- [x] local + futures
- [x] gasnet