### PR TITLE
Use const-ref in chpl__readXX to avoid const errors

### DIFF
--- a/modules/internal/ChapelSyncvar.chpl
+++ b/modules/internal/ChapelSyncvar.chpl
@@ -315,7 +315,7 @@ module ChapelSyncvar {
   }
 
   pragma "no doc"
-  proc chpl__readXX(x : _syncvar(?)) return x.readXX();
+  proc chpl__readXX(const ref x : _syncvar(?)) return x.readXX();
 
   proc <=>(lhs : _syncvar, ref rhs) {
     const tmp = lhs;
@@ -748,7 +748,7 @@ module ChapelSyncvar {
   }
 
   pragma "no doc"
-  proc chpl__readXX(x : _singlevar(?)) return x.readXX();
+  proc chpl__readXX(const ref x : _singlevar(?)) return x.readXX();
 
   /************************************ | *************************************
   *                                                                           *


### PR DESCRIPTION
There were a handful of tests that failed under --force-initializers because of a "const actual is passed to 'ref' formal" error:
- exercises/boundedBuffer/solutions/boundedBuffer-sync
- users/shetag/fock/fock-3-blc
- users/shetag/fock/fock-3
- users/shetag/fock/fock-dyn-prog-pool

This error is easily resolved by setting the intent of the standalone ``chpl__readXX`` function to be ``const ref``. The default for sync/single is ``ref``, which was triggering the failure. The ``chpl__readXX`` call is inserted in order to implement var-decl lists, and in these cases was used to declare fields in a type without a constructor or initializer.

Testing:
- [x] local + futures
- [x] gasnet on release/examples, distributions/, multilocale/