### PR TITLE
Retire enum array future

### DIFF
--- a/test/classes/initializers/compilerGenerated/enumArray.future
+++ b/test/classes/initializers/compilerGenerated/enumArray.future
@@ -1,2 +1,0 @@
-bug: enum array field not copied appropriately when record has default initializer
-#9032

--- a/test/classes/initializers/compilerGenerated/enumArray.skipif
+++ b/test/classes/initializers/compilerGenerated/enumArray.skipif
@@ -1,2 +1,0 @@
-# skip if valgrind not present, to ensure reliable behavior.
-CHPL_TEST_VGRND_EXE == off


### PR DESCRIPTION
PR #9695 updated the compiler to correctly copy the record, and so resolves #9032 .