### PR TITLE
Improve fixTypeNames

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -199,6 +199,7 @@ static void insertReturnTemps();
 static void initializeClass(Expr* stmt, Symbol* sym);
 static void ensureAndResolveInitStringLiterals();
 static void handleRuntimeTypes();
+//static void fixTypeNames();
 static void pruneResolvedTree();
 static void removeUnusedFunctions();
 static void removeUnusedTypes();
@@ -7599,6 +7600,11 @@ void resolve() {
 
   handleRuntimeTypes();
 
+  // fix array type names so that later passes can create
+  // reasonable errors even though the eltType field will
+  // not generally be present anymore.
+  //fixTypeNames();
+
   if (fPrintCallGraph) {
     // This needs to go after resolution is complete, but before
     // pruneResolvedTree() removes unused functions (like the uninstantiated
@@ -8440,6 +8446,18 @@ static void handleRuntimeTypes()
   replaceReturnedValuesWithRuntimeTypes();
   insertRuntimeInitTemps();
 }
+
+/*
+static void fixTypeNames() {
+  if (developer == false) {
+    forv_Vec(TypeSymbol, ts, gTypeSymbols) {
+      const char* typeName = toString(ts->type);
+      if (ts->name != typeName)
+        ts->name = typeName;
+    }
+  }
+}
+*/
 
 //
 // A few internal pointers may point to nodes not in tree.

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -199,7 +199,6 @@ static void insertReturnTemps();
 static void initializeClass(Expr* stmt, Symbol* sym);
 static void ensureAndResolveInitStringLiterals();
 static void handleRuntimeTypes();
-//static void fixTypeNames();
 static void pruneResolvedTree();
 static void removeUnusedFunctions();
 static void removeUnusedTypes();
@@ -7600,11 +7599,6 @@ void resolve() {
 
   handleRuntimeTypes();
 
-  // fix array type names so that later passes can create
-  // reasonable errors even though the eltType field will
-  // not generally be present anymore.
-  //fixTypeNames();
-
   if (fPrintCallGraph) {
     // This needs to go after resolution is complete, but before
     // pruneResolvedTree() removes unused functions (like the uninstantiated
@@ -8446,18 +8440,6 @@ static void handleRuntimeTypes()
   replaceReturnedValuesWithRuntimeTypes();
   insertRuntimeInitTemps();
 }
-
-/*
-static void fixTypeNames() {
-  if (developer == false) {
-    forv_Vec(TypeSymbol, ts, gTypeSymbols) {
-      const char* typeName = toString(ts->type);
-      if (ts->name != typeName)
-        ts->name = typeName;
-    }
-  }
-}
-*/
 
 //
 // A few internal pointers may point to nodes not in tree.

--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -858,7 +858,10 @@ static Expr* preFoldPrimOp(CallExpr* call) {
 
     INT_ASSERT(se && se->symbol()->hasFlag(FLAG_TYPE_VARIABLE));
 
-    retval = new SymExpr(new_StringSymbol(se->symbol()->type->symbol->name));
+    Type* t = se->symbol()->type;
+    const char* typeName = toString(t);
+
+    retval = new SymExpr(new_StringSymbol(typeName));
 
     call->replace(retval);
 

--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -902,22 +902,10 @@ static void resolveTypeConstructor(FnSymbol* fn) {
 }
 
 void fixTypeNames(AggregateType* at) {
-  const char* drDomName = "DefaultRectangularDom";
-  const int   drDomNameLen = strlen(drDomName);
+  const char* typeName = toString(at);
 
-  if (at->symbol->hasFlag(FLAG_BASE_ARRAY) == false &&
-      isArrayClass(at)                     ==  true) {
-    const char* domainType = canonicalClassType(at->getField("dom")->type)->symbol->name;
-    const char* eltType    = at->getField("eltType")->type->symbol->name;
-
-    at->symbol->name = astr("[", domainType, "] ", eltType);
-
-  } else if (strncmp(at->symbol->name, drDomName, drDomNameLen) == 0) {
-    at->symbol->name = astr("domain", at->symbol->name + drDomNameLen);
-
-  } else if (isRecordWrappedType(at) == true) {
-    at->symbol->name = canonicalClassType(at->getField("_instance")->type)->symbol->name;
-  }
+  if (at->symbol->name != typeName)
+    at->symbol->name = typeName;
 }
 
 static void resolveDefaultTypeConstructor(AggregateType* at) {


### PR DESCRIPTION
 * adjusts type.cpp toString to contain the same logic, in
   case order of resolution changes
 * fixTypeNames now calls toString

I considered having a late stage of resolution call toString
on all of the types. However the current issue with that is
that array fields in records would cause rebuilding the record
or class type name, e.g.:

    functions/vass/compile-time-messages.chpl

which complicates the implementation enough that it made
me question whether or not it would be an improvement
(over computing it at generic-field-resolution time).

We can't just call toString later in compilation (and never
bother to adjust the ->name fields) because the eltType
field won't generally exist after resolution.

Passed full local testing.

Reviewed by @benharsh - thanks!