### PR TITLE
Catch use-before-def errors in default initializers

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -1816,6 +1816,11 @@ void AggregateType::buildDefaultInitializer() {
       preNormalizeInitMethod(fn);
       normalize(fn);
 
+      // BHARSH INIT TODO: Should this be part of normalize(fn)? If we did that
+      // we would emit two use-before-def errors for classes because of the
+      // generated _new function.
+      checkUseBeforeDefs(fn);
+
       methods.add(fn);
     } else {
       fieldToArg(fn, names, fieldArgMap);

--- a/compiler/include/passes.h
+++ b/compiler/include/passes.h
@@ -124,6 +124,7 @@ bool isVirtualIterator(Symbol* iterator);
 // normalize.cpp
 void normalize(FnSymbol* fn);
 void normalize(Expr* expr);
+void checkUseBeforeDefs(FnSymbol* fn);
 
 // parallel.cpp
 Type* getOrMakeRefTypeDuringCodegen(Type* type);

--- a/test/classes/initializers/compilerGenerated/outOfOrderFieldUse.future
+++ b/test/classes/initializers/compilerGenerated/outOfOrderFieldUse.future
@@ -1,4 +1,0 @@
-feature request: expand support for default initializers
-
-This test should generate a reasonable user-facing error message, but instead
-encounters an internal error when creating the call info.

--- a/test/classes/initializers/compilerGenerated/pragmaOnly/outOfOrderFieldUse.future
+++ b/test/classes/initializers/compilerGenerated/pragmaOnly/outOfOrderFieldUse.future
@@ -1,4 +1,0 @@
-feature request: expand support for default initializers
-
-This test should generate a reasonable user-facing error message, but instead
-encounters an internal error when creating the call info.


### PR DESCRIPTION
Prior to this PR the compiler would not catch use-before-def errors in default initializers because ``checkUseBeforeDefs`` was only called during the ``normalize`` pass. Default initializers are created after normalization, and so were not checked. This PR updates the compiler to:
A) Pull use-before-def logic into a function that operates on FnSymbols
B) Invoke this new function after a default initializer is normalized.

Testing:
- [x] local + futures
- [x] gasnet