### PR TITLE
Update LLNL CoMD to use initializers

### DIFF
--- a/test/studies/comd/llnl/CoMD.prediff
+++ b/test/studies/comd/llnl/CoMD.prediff
@@ -1,10 +1,16 @@
 #!/usr/bin/env python
 
-import sys, os, shutil
+import sys, os, shutil, re
 
 test_name = sys.argv[1]
 out_file  = sys.argv[2]
 tmp_file  = out_file + ".prediff.tmp"
+
+# Do not modify the output if it looks like there was a compiler error
+with open(out_file) as outf:
+    for line in outf:
+        if re.search(r"\.chpl:\d+:( internal)? error:", line) != None:
+            sys.exit(0)
 
 EPSILON = 1e-6
 vals = {}

--- a/test/studies/comd/llnl/utils/force.chpl
+++ b/test/studies/comd/llnl/utils/force.chpl
@@ -1,6 +1,7 @@
 use MDTypes;
 use configs;
 
+pragma "use default init"
 class Force {
   var cutoff : real;        // potential cutoff distance in Angstroms
   var mass : real;          // mass of atoms in internal units

--- a/test/studies/comd/llnl/utils/forceeam.chpl
+++ b/test/studies/comd/llnl/utils/forceeam.chpl
@@ -95,18 +95,15 @@ class ForceEAM : Force {
   var eamPot : EAMPot;
   var phiIO, rhoIO, fIO : InterpolationObject;
 
-  proc ForceEAM() {}
+  proc init() {}
 
-  proc ForceEAM(potDir:string, potFile:string, potType:string) {
+  proc init(potDir:string, potFile:string, potType:string) {
+    this.complete();
+
     this.potName = "EAM";
     var input_file = potDir + "/" + potFile;
     var fchan: file;
-    try {
-      open(input_file, iomode.r);
-    } catch {
-      var errMsg : string = "Can't open file " + input_file + ". Fatal Error";
-      throwError(errMsg);
-    }
+    try! open(input_file, iomode.r);
 
     if (potType == "setfl") then eamReadSetfl(fchan);
     else if (potType == "funcfl") then eamReadFuncfl(fchan);


### PR DESCRIPTION
This PR updates the Force classes in LLNL's CoMD to use initializers. Prior to this PR this test would fail under --force-initializers.