### PR TITLE
Simplify minloc/maxloc reductions

### DIFF
--- a/modules/internal/ChapelReduce.chpl
+++ b/modules/internal/ChapelReduce.chpl
@@ -261,26 +261,24 @@ module ChapelReduce {
     proc clone() return new unmanaged BitwiseXorReduceScanOp(eltType=eltType);
   }
 
+  proc _maxloc_id(type eltType) return (min(eltType(1)), max(eltType(2)));
+  proc _minloc_id(type eltType) return max(eltType); // max() on both components
+
   pragma "use default init"
   class maxloc: ReduceScanOp {
     type eltType;
-    var value = min(eltType);
-    var uninitialized = true;
+    var value = _maxloc_id(eltType);
 
-    proc identity return min(eltType);
+    proc identity return _maxloc_id(eltType);
     proc accumulate(x) {
-      if uninitialized || (x(1) > value(1)) ||
+      if x(1) > value(1) ||
         ((x(1) == value(1)) && (x(2) < value(2))) then
         value = x;
-      uninitialized = false;
     }
     proc combine(x) {
-      if uninitialized || (x.value(1) > value(1)) ||
+      if x.value(1) > value(1) ||
         ((x.value(1) == value(1)) && (x.value(2) < value(2))) {
-        if !x.uninitialized {
           value = x.value;
-          uninitialized = false;
-        }
       }
     }
     proc generate() return value;
@@ -290,23 +288,18 @@ module ChapelReduce {
   pragma "use default init"
   class minloc: ReduceScanOp {
     type eltType;
-    var value = max(eltType);
-    var uninitialized = true;
+    var value = _minloc_id(eltType);
 
-    proc identity return max(eltType);
+    proc identity return _minloc_id(eltType);
     proc accumulate(x) {
-      if uninitialized || (x(1) < value(1)) ||
+      if x(1) < value(1) ||
         ((x(1) == value(1)) && (x(2) < value(2))) then
         value = x;
-      uninitialized = false;
     }
     proc combine(x) {
-      if uninitialized || (x.value(1) < value(1)) ||
+      if x.value(1) < value(1) ||
         ((x.value(1) == value(1)) && (x.value(2) < value(2))) {
-        if !x.uninitialized {
           value = x.value;
-          uninitialized = false;
-        }
       }
     }
     proc generate() return value;


### PR DESCRIPTION
This change simplifies the implementation of minloc/maxloc reductions
by eliminating the 'uninitialized' field in the reduction classes
and its uses in accumulate() and combine().

### WHY? HOW?

We used to have 'uninitialized' field in the minloc and maxloc classes
in ChapelReduce.chpl. Those are the classes that implement Chapel's
built-in minloc/maxloc reductions. This field used to be checked
upon each accumulate() and combine() operation.

This field was relied on in the following scenario:

```chpl
  // from  test/reductions/sungeun/test_minmaxloc3.chpl

  var A: [1..n] int;
  A = min(int);
  var (elt, loc) = maxloc reduce zip(A, A.domain);
```

#### Details

The maxloc reduction implementation initializes the "element"
part of the accumulation state with min(int). Whenever the input
element exceeds that, the accumulation state is updated with
that element's value and location.

In this example, this update does not happen for any of the inputs.
This is OK for the "element" output of the reduction.
It is NOT ok for the "location" output, though.

The "location" part of the accumulation state is set initially
to min(int), because this is a "max"-like reduction.
So when the implementation sees a maximal input (which all inputs
are in this case), it needs to distinguish these two cases:

* The "location" in the accumulation state has not been initialized
  yet. If so, initialize it to the input location. Which is BIGGER
  than what was in the "location" state at this point.

* The "location" in the accumulation state HAS been initialized
  earlier. If so, update it to the input location if the input
  location is SMALLER. (*)

(*) Our minloc/maxloc reductions are defined to return the smallest of
minimal/ maximal locations. This is to match Fortran (as per b81dc88635).

#### Solution

Treat updates to "location" state as a MIN-reduction, regardless of
whether the elements are min-reduced or max-reduced. This means
initialize the location state to max(int) instead of min(int).

This handles the above scenario without the 'uninitialized' field.

### RELATED

A similar simplification could be done here:

  test/reductions/sungeun/test_minmaxloc.chpl

I am not doing it to reduce the scope of this change.

### ARCHAELOGY

The "return the smallest of all minimal (maximal) locations" was enacted
in b81dc88635 . This was to make minloc/maxloc behave as in Fortran.

Curiously, the 'uninitialized' flag was already in the implementation
by then. It was introduced for an unrelated reason when minloc/maxloc
were first introduced, seemingly in 0566cb59f2 .

### TESTING

Passes a full paratest in linux64 configuration.