### PR TITLE
Fix a .bad after #9712

### DIFF
--- a/test/arrays/vass/initialization-mapped-1.bad
+++ b/test/arrays/vass/initialization-mapped-1.bad
@@ -1,3 +1,3 @@
-initialization-mapped-1.chpl:8: warning: _domain(unmanaged BlockDom(1,int(64),false,unmanaged DefaultDist))
-initialization-mapped-1.chpl:9: warning: _domain(unmanaged DefaultRectangularDom(1,int(64),false))
+initialization-mapped-1.chpl:8: warning: BlockDom(1,int(64),false,unmanaged DefaultDist)
+initialization-mapped-1.chpl:9: warning: domain(1,int(64),false)
 initialization-mapped-1.chpl:10: error: assert failed


### PR DESCRIPTION
PR #9712 just updated how the compiler prints out
array types and this .bad file changed as a result.

Test change only, not reviewed.