### PR TITLE
Force first-class functions to use initializers

### DIFF
--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -1577,6 +1577,7 @@ static Expr* createFunctionAsValue(CallExpr *call) {
   fcf_name << "_chpl_fcf_" << unique_fcf_id++ << "_" << flname;
 
   TypeSymbol *ts = new TypeSymbol(astr(fcf_name.str().c_str()), ct);
+  ts->addFlag(FLAG_USE_DEFAULT_INIT);
 
   // Allow a use of a FCF to appear at the statement level i.e.
   //    nameOfFunc;
@@ -1602,11 +1603,10 @@ static Expr* createFunctionAsValue(CallExpr *call) {
 
   ct->fields.insertAtHead(new DefExpr(super));
 
+  // Builds type constructor
   ct->buildConstructors();
 
-  if (ct->wantsDefaultInitializer()) {
-    ct->buildDefaultInitializer();
-  }
+  ct->buildDefaultInitializer();
 
   buildDefaultDestructor(ct);
 
@@ -1888,6 +1888,7 @@ static AggregateType* createAndInsertFunParentClass(CallExpr*   call,
   TypeSymbol*    parentTs = new TypeSymbol(name, parent);
 
   parentTs->addFlag(FLAG_FUNCTION_CLASS);
+  parentTs->addFlag(FLAG_USE_DEFAULT_INIT);
 
   // Because this function type needs to be globally visible (because
   // we don't know the modules it will be passed to), we put it at the
@@ -1904,7 +1905,10 @@ static AggregateType* createAndInsertFunParentClass(CallExpr*   call,
 
   parent->fields.insertAtHead(new DefExpr(parentSuper));
 
+  // Builds type constructor
   parent->buildConstructors();
+
+  parent->buildDefaultInitializer();
 
   buildDefaultDestructor(parent);
 


### PR DESCRIPTION
This PR builds upon prior work to allow initializers for first-class-functions, and simply requires that we always generate initializers instead of only generating them under --force-initializers.

Resolves #9535 

Testing:
- [x] local + futures