### PR TITLE
Prevent serialization from qthread sync vars

### DIFF
--- a/third-party/qthread/README
+++ b/third-party/qthread/README
@@ -7,5 +7,17 @@ convenience and was obtained from:
 
   https://github.com/qthreads/qthreads
 
-Any Chapel issues that seem to be related to Qthreads should be
-directed to the Chapel team at https://chapel-lang.org/bugs.html.
+Any Chapel issues that seem to be related to Qthreads should be directed
+to the Chapel team at https://chapel-lang.org/bugs.html.
+
+
+Chapel modifications to Qthreads
+================================
+
+The modifications that we have made to the official Qthreads release are
+as follows:
+
+* We force tasks being woken from sync vars to run on their original
+  shepherd. This is to work around a task serialization bug that stems
+  from us using schedulers that don't support work stealing (nemesis)
+  or running with work stealing disabled (distrib w/ QT_STEAL_RATIO=0)

--- a/third-party/qthread/qthread-src/src/feb.c
+++ b/third-party/qthread/qthread-src/src/feb.c
@@ -175,7 +175,11 @@ static inline void qt_feb_schedule(qthread_t          *waiter,
 {
     qthread_debug(FEB_DETAILS, "waiter(%p:%i), shep(%p:%i): setting waiter to 'RUNNING'\n", waiter, (int)waiter->thread_id, shep, (int)shep->shepherd_id);
     waiter->thread_state = QTHREAD_STATE_RUNNING;
-    if ((waiter->flags & QTHREAD_UNSTEALABLE) && (waiter->rdata->shepherd_ptr != shep)) {
+    // Chapel hack -- we either use schedulers that don't support work stealing
+    // (nemesis), or we run with stealing disabled (distrib w/ STEAL_RATIO=0).
+    // Spawning to the current shepherd below serializes execution and relies
+    // on work stealing to redistribute, so just always spawn to the orig shep
+    if (1) { //(waiter->flags & QTHREAD_UNSTEALABLE) && (waiter->rdata->shepherd_ptr != shep)) {
         qthread_debug(FEB_DETAILS, "waiter(%p:%i), shep(%p:%i): enqueueing waiter in target_shep's ready queue (%p:%i)\n", waiter, (int)waiter->thread_id, shep, (int)shep->shepherd_id, waiter->rdata->shepherd_ptr, waiter->rdata->shepherd_ptr->shepherd_id);
         qt_threadqueue_enqueue(waiter->rdata->shepherd_ptr->ready, waiter);
     } else


### PR DESCRIPTION
Previously, qthreads/tasks that were blocked on a sync var got scheduled onto
whatever shepherd happened to wake them up. The implementation then relied on
work stealing to redistribute the tasks. However, we either use schedulers that
don't support stealing (nemesis) or we run with stealing disabled (distrib w/
STEAL_RATIO=0) so this resulted in all tasks getting scheduled onto the same
shepherd, which effectively serializes execution for those tasks until they
complete.

This just forces qthreads/tasks to get rescheduled on their original shepherd.
Ideally we would check if the scheduler supports stealing and if stealing is
enabled, but there's currently no reliable way to detect those things for all
schedulers, and adding them is more work than I want to take on right now.

This prevents serialization from sync vars, which allows the SPMD version of
stream to achieve full performance when using a sync barrier:

| config           | performance |
| ---------------- | ----------- |
| no barrier       | 84 GB/s     |
| atomic barrier   | 84 GB/s     |
| old sync barrier | 10 GB/s     |
| sync barrier     | 84 GB/s     |

Note that this will hurt threadring's performance. Threadring just passes a
sync token between ~500 tasks one at a time, so running the tasks serially was
actually beneficial. I expect threadring to have a 2x or so slowdown, but it's
not an important benchmark and the serializing behavior was wrong.

This resolves https://github.com/chapel-lang/chapel/issues/9651