### PR TITLE
Add error message when we can't determine an iterator's yielded type

### DIFF
--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -673,7 +673,9 @@ static FnSymbol*      makeIteratorMethod(IteratorInfo* ii,
 
 static void protoIteratorClass(FnSymbol* fn, Type* yieldedType) {
   INT_ASSERT(yieldedType != NULL);
-  INT_ASSERT(yieldedType != dtUnknown);
+  if (yieldedType == dtUnknown) {
+    USR_FATAL(fn, "Can't determine type yielded by iterator");
+  }
 
   SET_LINENO(fn);
 

--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -674,7 +674,7 @@ static FnSymbol*      makeIteratorMethod(IteratorInfo* ii,
 static void protoIteratorClass(FnSymbol* fn, Type* yieldedType) {
   INT_ASSERT(yieldedType != NULL);
   if (yieldedType == dtUnknown) {
-    USR_FATAL(fn, "Can't determine type yielded by iterator");
+    USR_FATAL(fn, "unable to resolve yielded type");
   }
 
   SET_LINENO(fn);

--- a/test/functions/iterators/errors/inconsistentYieldType.chpl
+++ b/test/functions/iterators/errors/inconsistentYieldType.chpl
@@ -1,0 +1,10 @@
+iter foo() {
+  for i in 1..10 do
+    if i%2 == 0 then
+      yield "hi";
+    else
+      yield 1.2;
+}
+
+for i in foo() do
+  writeln(i);

--- a/test/functions/iterators/errors/inconsistentYieldType.good
+++ b/test/functions/iterators/errors/inconsistentYieldType.good
@@ -1,1 +1,1 @@
-inconsistentYieldType.chpl:1: error: Can't determine type yielded by iterator
+inconsistentYieldType.chpl:1: error: unable to resolve yielded type

--- a/test/functions/iterators/errors/inconsistentYieldType.good
+++ b/test/functions/iterators/errors/inconsistentYieldType.good
@@ -1,0 +1,1 @@
+inconsistentYieldType.chpl:1: error: Can't determine type yielded by iterator


### PR DESCRIPTION
While working on ranges of enums, I was surprised to find that the
compiler generates an unclear assertion error in the case that it
can't resolve the type yielded by an iterator.  This is a very
simple fix to at least turn it into a user-facing error pointing to
the iterator in question.