### PR TITLE
Clean error message when forgetting new in a throw

### DIFF
--- a/modules/internal/ChapelError.chpl
+++ b/modules/internal/ChapelError.chpl
@@ -342,8 +342,8 @@ module ChapelError {
 
   pragma "no doc"
   pragma "insert line file info"
-  proc chpl_fix_thrown_error(type Error) {
-    compilerError("Cannot throw a type: '", Error:string, "'. Did you forget the keyword 'new'?");
+  proc chpl_fix_thrown_error(type errType) {
+    compilerError("Cannot throw a type: '", errType:string, "'. Did you forget the keyword 'new'?");
   }
 
   pragma "no doc"

--- a/modules/internal/ChapelError.chpl
+++ b/modules/internal/ChapelError.chpl
@@ -342,6 +342,12 @@ module ChapelError {
 
   pragma "no doc"
   pragma "insert line file info"
+  proc chpl_fix_thrown_error(type Error) {
+    compilerError("Cannot throw a type: '", Error:string, "'. Did you forget the keyword 'new'?");
+  }
+
+  pragma "no doc"
+  pragma "insert line file info"
   proc chpl_fix_thrown_error(err: unmanaged Error): unmanaged Error {
     var fixErr: unmanaged Error = err;
     if fixErr == nil then

--- a/test/errhandling/errorMessages/throwNew.chpl
+++ b/test/errhandling/errorMessages/throwNew.chpl
@@ -1,0 +1,10 @@
+class C {
+  proc f() throws {
+    throw Error();
+  }
+}
+
+var c = new C();
+
+c.f();
+

--- a/test/errhandling/errorMessages/throwNew.good
+++ b/test/errhandling/errorMessages/throwNew.good
@@ -1,0 +1,2 @@
+throwNew.chpl:2: In function 'f':
+throwNew.chpl:3: error: Cannot throw a type: 'Error'. Did you forget the keyword 'new'?


### PR DESCRIPTION
This PR changes the error message for a throwing an `Error` with a missing `new` from this:

```
throwNew.chpl:2: In function 'f':
throwNew.chpl:3: error: unresolved call 'chpl_fix_thrown_error(type Error)'
$CHPL_HOME/modules/internal/ChapelError.chpl:338: note: candidates are: chpl_fix_thrown_error(err: Error)
$CHPL_HOME/modules/internal/ChapelError.chpl:352: note:                 chpl_fix_thrown_error(ref err: Owned(Error))
```

to this:

```
throwNew.chpl:2: In function 'f':
throwNew.chpl:3: error: Cannot throw a type: 'Error'. Did you forget the keyword 'new'?
```