### PR TITLE
Add "babel<2.6.0" constraint to chpldoc-venv Pip requirements (cp PR #9673)

### DIFF
--- a/third-party/chpl-venv/chpldoc-requirements.txt
+++ b/third-party/chpl-venv/chpldoc-requirements.txt
@@ -6,3 +6,4 @@ docutils==0.12
 argparse==1.3.0
 sphinx-rtd-theme==0.1.9
 sphinxcontrib-chapeldomain>=0.0.10
+babel<2.6.0


### PR DESCRIPTION
Cray-internal Cray module builds broke today 5/29.

chpldoc no longer builds, because its Python virtualenv no longer builds,
because Babel (a PyPI dependency) updated itself to version 2.6.0 today
on PyPI, and Babel 2.6.0 is no longer compatible with Python < 2.7.
(Babel version yesterday was 2.5.3)

As long as Chapel must build RPMs for older Cray-XE and Cray-XC CLE-5
systems, which are SLES-11 based, Chapel must be able to use Python 2.6.9.

This change forces pip to install Babel version < 2.6.0 when building
chpldoc-venv.

Implements https://github.com/chapel-lang/chapel/issues/9641.