### PR TITLE
Adjust definition of new external array types to use runtime defined type

### DIFF
--- a/modules/packages/ExternalArray.chpl
+++ b/modules/packages/ExternalArray.chpl
@@ -27,6 +27,7 @@ module ExternalArray {
 
   extern type free_func;
   private extern const FREE_FUNC_NIL: free_func;
+  private extern const FREE_FUNC_CHAPEL_WRAP: free_func;
 
   extern record external_array {
     var elts: c_void_ptr;
@@ -82,7 +83,7 @@ module ExternalArray {
     proc dsiBuildArray(type eltType) {
       var data = new external_array(c_malloc(eltType, this.size),
                                     this.size,
-                                    __primitive("cast", free_func, c_free));
+                                    FREE_FUNC_CHAPEL_WRAP);
       var arr = new unmanaged ExternArr(eltType,
                                         _to_unmanaged(this),
                                         data,

--- a/modules/packages/ExternalArray.chpl
+++ b/modules/packages/ExternalArray.chpl
@@ -25,7 +25,6 @@
 module ExternalArray {
   use ChapelStandard;
 
-  extern proc callFree(x: external_array);
   extern type free_func;
   private extern const FREE_FUNC_NIL: free_func;
 
@@ -35,6 +34,7 @@ module ExternalArray {
 
     var free: free_func;
   }
+  extern proc call_free(x: external_array);
 
   pragma "use default init"
   class ExternDist: BaseDist {
@@ -272,7 +272,7 @@ module ExternalArray {
 
     proc dsiDestroyArr() {
       if (_owned) {
-        callFree(_ArrInstance);
+        call_free(_ArrInstance);
       }
     }
 

--- a/runtime/include/chpl-external-array.h
+++ b/runtime/include/chpl-external-array.h
@@ -17,8 +17,6 @@
  * limitations under the License.
  */
 
-#include "chplrt.h"
-
 #ifndef _chplexternarray_H_
 #define _chplexternarray_H_
 
@@ -32,13 +30,8 @@ typedef struct {
 
   free_func free;
 } external_array;
+const free_func FREE_FUNC_NIL;
 
-const free_func FREE_FUNC_NIL = NULL;
-void callFree(external_array x);
+void call_free(external_array x);
 
-void callFree(external_array x) {
-  if (x.free != FREE_FUNC_NIL) {
-    x.free(x.elts);
-  }
-}
 #endif

--- a/runtime/include/chpl-external-array.h
+++ b/runtime/include/chpl-external-array.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2004-2018 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ * 
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * 
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "chplrt.h"
+
+#ifndef _chplexternarray_H_
+#define _chplexternarray_H_
+
+#include <stdint.h>
+
+typedef void (*free_func)(void*);
+
+typedef struct {
+  void* elts;
+  uint64_t size;
+
+  free_func free;
+} external_array;
+
+const free_func FREE_FUNC_NIL = NULL;
+void callFree(external_array x);
+
+void callFree(external_array x) {
+  if (x.free != FREE_FUNC_NIL) {
+    x.free(x.elts);
+  }
+}
+#endif

--- a/runtime/include/chpltypes.h
+++ b/runtime/include/chpltypes.h
@@ -21,7 +21,6 @@
 #define _chpltypes_H_
 
 #include "sys_basic.h"
-#include "chpl-external-array.h"
 
 #include <stdint.h>
 #include <stdio.h>

--- a/runtime/include/chpltypes.h
+++ b/runtime/include/chpltypes.h
@@ -21,6 +21,7 @@
 #define _chpltypes_H_
 
 #include "sys_basic.h"
+#include "chpl-external-array.h"
 
 #include <stdint.h>
 #include <stdio.h>

--- a/runtime/include/stdchpl.h
+++ b/runtime/include/stdchpl.h
@@ -44,6 +44,7 @@
 #include "chpl-comm.h"
 #include "chpldirent.h"
 #include "chplexit.h"
+#include "chpl-external-array.h"
 #include "chpl-file-utils.h"
 #include <chplfp.h>
 #include "chplglob.h"

--- a/runtime/src/Makefile.share
+++ b/runtime/src/Makefile.share
@@ -34,6 +34,7 @@ COMMON_NOGEN_SRCS = \
         chpl-comm-callbacks.c \
 	chpl-init.c \
 	chplexit.c \
+	chpl-external-array.c \
 	chpl-file-utils.c \
 	chplio.c \
 	chpl-mem.c \

--- a/runtime/src/chpl-external-array.c
+++ b/runtime/src/chpl-external-array.c
@@ -16,25 +16,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "chplrt.h"
 
-#ifndef _chplexternarray_H_
-#define _chplexternarray_H_
+#include "chpl-external-array.h"
+#include "chpl-mem.h"
 
-#include <stdint.h>
+const free_func FREE_FUNC_NIL = NULL;
+const free_func FREE_FUNC_CHAPEL_WRAP = wrap_chapel_free_call;
 
-typedef void (*free_func)(void*);
+void call_free(external_array x) {
+  if (x.free != FREE_FUNC_NIL) {
+    x.free(x.elts);
+  }
+}
 
-typedef struct {
-  void* elts;
-  uint64_t size;
-
-  free_func free;
-} external_array;
-
-const free_func FREE_FUNC_NIL;
-const free_func FREE_FUNC_CHAPEL_WRAP;
-
-void call_free(external_array x);
-void wrap_chapel_free_call(void* mem);
-
-#endif
+void wrap_chapel_free_call(void* mem) {
+  chpl_mem_free(mem, 0, 0);
+}


### PR DESCRIPTION
This is a step along the way towards allowing exported functions to return arrays.

We realized that if we returned a pointer to the memory directly then we wouldn't
know the size of the array, so we needed to return a wrapper with the memory,
the size, and a pointer to the appropriate free function.  This implements the
wrapper we need in the runtime for design review, the next step will be to block
out what that return would look like.

Testing:
- [x] fresh checkout
- [x] fifo
- [x] valgrindexe
- [ ] full paratest