### PR TITLE
Fix candidate matching for _new after #9710

### DIFF
--- a/compiler/resolution/ResolutionCandidate.cpp
+++ b/compiler/resolution/ResolutionCandidate.cpp
@@ -578,13 +578,14 @@ static bool isCandidateFn(ResolutionCandidate* res, CallInfo& info) {
   // signature.
   //
   // TODO: Expand this check for all methods
-  if (info.call->numActuals() >= 2) {
-    if (res->fn->isInitializer() && isCandidateInit(res, info) == false) {
-      return false;
-    } else if (strcmp(res->fn->name, "_new") == 0 &&
-               isCandidateNew(res, info) == false) {
-      return false;
-    }
+  if (info.call->numActuals() >= 2 &&
+      res->fn->isInitializer() &&
+      isCandidateInit(res, info) == false) {
+    return false;
+  } else if (info.call->numActuals() >= 1 &&
+             res->fn->hasFlag(FLAG_NEW_WRAPPER) &&
+             isCandidateNew(res, info) == false) {
+    return false;
   }
 
   return true;


### PR DESCRIPTION
In #9710 a conditional was introduced to skip ``isCandidateFn`` if there were less than 2 actuals in the call. This was introduced for initializers (method token, 'this'), but overlooked the fact that ``_new`` wrappers can have one actual (the type). This PR adjusts ``isCandidateFn`` to check the correct number of actuals in each case individually.

Testing:
- [x] local + futures
- [x] gasnet
- [x] fifo for test/parallel/ nightly failures