### PR TITLE
Re-enable testing of partial reductions over DR

### DIFF
--- a/test/reductions/partial/DRimpl.chpl
+++ b/test/reductions/partial/DRimpl.chpl
@@ -18,7 +18,7 @@ proc DefaultDist.dsiPartialReduce(const perElemOp, const resDimSpec,
   const     srcDims = srcDom.dims();
 
   const (resDom, resDims) =
-    partRedCheckAndCreateResultDimensions(_to_unmanaged(this), resDimSpec, srcArr, srcDims);
+    partRedCheckAndCreateResultDimensions(this, resDimSpec, srcArr, srcDims);
 
   var resArr: [resDom] srcArr.eltType = perElemOp.identity;
   const resReduceOp = new unmanaged PartRedOp(eltType=resArr.type,
@@ -33,48 +33,4 @@ proc DefaultDist.dsiPartialReduce(const perElemOp, const resDimSpec,
 
   delete resReduceOp;
   return  resArr;
-}
-
-pragma "use default init"
-class PartRedOp: ReduceScanOp {
-  type eltType;
-  const perElemOp;
-  var value: eltType = perElemOp.identity;
-
-  // User-accessible AS will be nothing.
-  proc identity() {
-    var x: void; return x;
-  }
-  proc initialAccumulate(x) {
-/* We just created the array that's the outer var.
-   So no need to do anything like:
-    value += x;
-   Verify that instead:
-*/
-    if boundsChecking then
-      forall initElm in x do
-        assert(initElm == perElemOp.identity);
-  }
-  proc accumulate(x) {
-    // This should be invoked just before deleting the AS.
-    // Nothing to do.
-    compilerAssert(x.type == void);
-  }
-  proc accumulateOntoState(ref state, x) {
-    compilerAssert(state.type == void);
-    compilerAssert(isTuple(x) && x.size == 2);
-    // Accumulate onto the built-in AS instead.
-    perElemOp.accumulateOntoState(value[x(1)], x(2));
-  }
-  proc combine(x) {
-    forall (parent, child) in zip(value, x.value) {
-      // TODO replace with perElemOp.combine()
-      perElemOp.accumulateOntoState(parent, child);
-    }
-  }
-  // TODO (a): avoid this when not needed.
-  // TODO (b): invoke perElemOp.generate() when needed.
-  proc generate() ref return value;
-  proc clone() return new unmanaged PartRedOp(eltType=eltType,
-                                              perElemOp = perElemOp);
 }

--- a/test/reductions/partial/utilities.chpl
+++ b/test/reductions/partial/utilities.chpl
@@ -100,3 +100,46 @@ proc partRedHelpCheckDimensions(resDims, srcDims) throws {
     else throw new IllegalArgumentError("the preserved dimension " + dim + " in the shape of the partial reduction differs from that in the array being reduced");
   }
 }
+
+/* This class implements the reduction of partial results. */
+pragma "use default init"
+class PartRedOp: ReduceScanOp {
+  type eltType;
+  const perElemOp;
+  var value: eltType = perElemOp.identity;
+
+  // User-accessible AS will contain no data, i.e. void.
+  proc identity() { return _void; }
+  proc initialAccumulate(x) {
+/* We just created the array that's the outer var.
+   So no need to do anything like:
+    value += x;
+   Verify that instead:
+*/
+    if boundsChecking then
+      forall initElm in x do
+        assert(initElm == perElemOp.identity);
+  }
+  proc accumulate(x) {
+    // This should be invoked just before deleting the AS.
+    // Nothing to do.
+    compilerAssert(x.type == void);
+  }
+  proc accumulateOntoState(ref state, x) {
+    compilerAssert(state.type == void);
+    compilerAssert(isTuple(x) && x.size == 2);
+    // Accumulate onto the built-in AS instead.
+    perElemOp.accumulateOntoState(value[x(1)], x(2));
+  }
+  proc combine(x) {
+    forall (parent, child) in zip(value, x.value) {
+      // TODO replace with perElemOp.combine()
+      perElemOp.accumulateOntoState(parent, child);
+    }
+  }
+  // TODO (a): avoid this when not needed.
+  // TODO (b): invoke perElemOp.generate() when needed.
+  proc generate() ref return value;
+  proc clone() return new unmanaged PartRedOp(eltType=eltType,
+                                              perElemOp = perElemOp);
+}


### PR DESCRIPTION
This re-enables testing of cg-sparse-partred.chpl,
following the lead of #9755.

* CSimpl.chpl, which implements partial reduction for the CS layout,
is again essentially identical to DRimpl.chpl, as it was before.

* Both impls use the utility class PartRedOp, so I moved it to
utilities.chpl.

* I removed _to_unmanaged in DRimpl.chpl. The corresponding formal
is not used. When/if we start using it, we can decide what kind
of class thing to pass to it.

TODO remains: I would like to replace the two "new unmanaged" +
"delete" pairs in each impl with just "new owned". This is what
the desired semantics is. However that change gave me some
compilation errors so I reverted it.

The TODOs regarding generate() in #9755 apply here equally.

Memory Leaks: cg-sparse-partred.chpl leaks 456 bytes.

This leak is unrelated to partial reductions. cg-sparse-partred.chpl leaks
exactly the same objects as cg-sparse.chpl. They are due solely to the line:

    const MatrixSpace: sparse subdomain(DenseSpace) dmapped(new dmap(new CS()))
                     = genAIndsSorted(elemType, n, nonzer, shift);