### PR TITLE
Don't include chpl-tasks.h in standalone mode.

### DIFF
--- a/runtime/include/qio/qio.h
+++ b/runtime/include/qio/qio.h
@@ -20,8 +20,6 @@
 #ifndef _QIO_H_
 #define _QIO_H_
 
-#include "chpl-tasks.h"
-
 #include "sys_basic.h"
 #include "bswap.h"
 #include "qbuffer.h"
@@ -197,6 +195,8 @@ typedef qio_file_functions_t* qio_file_functions_ptr_t;
 #endif
 
 #ifdef _chplrt_H_
+#include "chpl-tasks.h"
+
 // also export iohint_t and fdflag_t
 typedef qio_hint_t iohints;
 typedef qio_fdflag_t fdflag_t;


### PR DESCRIPTION
In PR #9736 I added an include of chpl-tasks.h to qio.h, to make up for
the removal of a nested include of that same file in something else
qio.h included.  Unfortunately I added the new chpl-tasks.h include in a
place that shadowed the include of pthreads.h in the "standalone" side
of qio.h, which changed what pthread.h declared and thus caused failures
in standalone testing.  Here, move the include of chpl-tasks.h to the
"runtime" side of qio.h and thus remove the shadowing.