### PR TITLE
Mock up exported function that returns an array

### DIFF
--- a/modules/packages/ExternalArray.chpl
+++ b/modules/packages/ExternalArray.chpl
@@ -307,15 +307,16 @@ module ExternalArray {
     return _newArray(arr);
   }
 
-  proc makeReturnableArr(arr: []) {
+  proc convertToExternalArray(arr: []) {
     if (arr.domain.stridable) {
-      halt("cannot return a strided array at this time");
+      compilerError("cannot return a strided array");
     }
     if (arr.domain.rank != 1) {
-      halt("cannot return an array with rank != 1");
+      compilerError("cannot return an array with rank != 1");
     }
     if (!isIntegralType(arr.domain.idxType)) {
-      halt("cannot return an array with indices that are not integrals");
+      compilerError("cannot return an array with indices that are not " +
+                    "integrals");
     }
     if (arr.domain.low != 0) {
       halt("cannot return an array when the lower bounds is not 0");

--- a/modules/packages/ExternalArray.chpl
+++ b/modules/packages/ExternalArray.chpl
@@ -306,4 +306,25 @@ module ExternalArray {
     dom.add_arr(arr, locking = false);
     return _newArray(arr);
   }
+
+  proc makeReturnableArr(arr: []) {
+    if (arr.domain.stridable) {
+      halt("cannot return a strided array at this time");
+    }
+    if (arr.domain.rank != 1) {
+      halt("cannot return an array with rank != 1");
+    }
+    if (!isIntegralType(arr.domain.idxType)) {
+      halt("cannot return an array with indices that are not integrals");
+    }
+    if (arr.domain.low != 0) {
+      halt("cannot return an array when the lower bounds is not 0");
+    }
+    var externalArr = chpl_make_external_array(c_sizeof(arr.eltType),
+                                               arr.size: uint);
+    chpl__uncheckedArrayTransfer(makeArrayFromExternArray(externalArr,
+                                                          arr.eltType),
+                                 arr);
+    return externalArr;
+  }
 }

--- a/modules/packages/ExternalArray.chpl
+++ b/modules/packages/ExternalArray.chpl
@@ -302,7 +302,7 @@ module ExternalArray {
     var arr = new unmanaged ExternArr(eltType,
                                       dom,
                                       value,
-                                      false);
+                                      _owned=false);
     dom.add_arr(arr, locking = false);
     return _newArray(arr);
   }

--- a/test/compflags/lydia/library/exportArray/callFuncReturnsArray.cleanfiles
+++ b/test/compflags/lydia/library/exportArray/callFuncReturnsArray.cleanfiles
@@ -1,0 +1,1 @@
+libreturnExternArray.a

--- a/test/compflags/lydia/library/exportArray/callFuncReturnsArray.good
+++ b/test/compflags/lydia/library/exportArray/callFuncReturnsArray.good
@@ -1,0 +1,5 @@
+1 2 3 4
+Element[0] = 1
+Element[1] = 2
+Element[2] = 3
+Element[3] = 4

--- a/test/compflags/lydia/library/exportArray/callFuncReturnsArray.lastcompopts
+++ b/test/compflags/lydia/library/exportArray/callFuncReturnsArray.lastcompopts
@@ -1,0 +1,1 @@
+-L. -lreturnExternArray `$CHPL_HOME/util/config/compileline --libraries`

--- a/test/compflags/lydia/library/exportArray/callFuncReturnsArray.precomp
+++ b/test/compflags/lydia/library/exportArray/callFuncReturnsArray.precomp
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo Compiling returnExternArray.chpl
+$3 --library --static returnExternArray.chpl -o libreturnExternArray

--- a/test/compflags/lydia/library/exportArray/callFuncReturnsArray.test.c
+++ b/test/compflags/lydia/library/exportArray/callFuncReturnsArray.test.c
@@ -24,7 +24,7 @@ int main(int argc, char* argv[]) {
   }
 
   // Call the cleanup function
-  chpl_call_free(arr);
+  chpl_free_external_array(arr);
 
   // Shutdown the Chapel runtime and standard modules
   chpl_library_finalize();

--- a/test/compflags/lydia/library/exportArray/callFuncReturnsArray.test.c
+++ b/test/compflags/lydia/library/exportArray/callFuncReturnsArray.test.c
@@ -1,0 +1,33 @@
+#include <stdio.h>
+#include <stdint.h>
+
+#include "returnExternArray.h"
+
+extern void chpl_library_init(int argc, char* argv[]);
+extern void chpl_library_finalize(void);
+
+
+extern void chpl_call_free(chpl_external_array x);
+
+// Test of calling an exported function that returns an array
+int main(int argc, char* argv[]) {
+  // Initialize the Chapel runtime and standard modules
+  chpl_library_init(argc, argv);
+
+  // Call the function to get the array
+  chpl_external_array arr = foo();
+  int64_t* actual = (int64_t*)arr.elts;
+
+  // Write its elements
+  for (int i = 0; i < 4; i++) {
+    printf("Element[%d] = %lld\n", i, actual[i]);
+  }
+
+  // Call the cleanup function
+  chpl_call_free(arr);
+
+  // Shutdown the Chapel runtime and standard modules
+  chpl_library_finalize();
+
+  return 0;
+}

--- a/test/compflags/lydia/library/exportArray/returnExternArray.chpl
+++ b/test/compflags/lydia/library/exportArray/returnExternArray.chpl
@@ -1,0 +1,13 @@
+use ExternalArray;
+
+export proc foo(): chpl_external_array {
+  var x = getArray();
+  writeln(x);
+  var retval = makeReturnableArr(x);
+  return retval;
+}
+
+proc getArray(): [0..3] int {
+  var x: [0..3] int = [1, 2, 3, 4];
+  return x;
+}

--- a/test/compflags/lydia/library/exportArray/returnExternArray.chpl
+++ b/test/compflags/lydia/library/exportArray/returnExternArray.chpl
@@ -3,7 +3,7 @@ use ExternalArray;
 export proc foo(): chpl_external_array {
   var x = getArray();
   writeln(x);
-  var retval = makeReturnableArr(x);
+  var retval = convertToExternalArray(x);
   return retval;
 }
 

--- a/test/compflags/lydia/library/exportArray/returnExternArray.h
+++ b/test/compflags/lydia/library/exportArray/returnExternArray.h
@@ -1,0 +1,3 @@
+#include "chpl-external-array.h"
+
+chpl_external_array foo(void);


### PR DESCRIPTION
This creates a helper that will be used by the compiler to transform an array into
the external array type I created in #9758 .  It also adds a test that mocks up what
that transformation should look like.

Testing:
- [x] fresh checkout of exportArrays tests
- [x] fifo on exportArrays tests
- [x] valgrind on exportArrays tests
- [x] local paratest