### PR TITLE
Cleanup leaked extern dist

### DIFF
--- a/modules/packages/ExternalArray.chpl
+++ b/modules/packages/ExternalArray.chpl
@@ -65,8 +65,20 @@ module ExternalArray {
     }
 
     proc dsiClone() {
-      return this;
+      return _to_unmanaged(this);
     }
+
+    proc trackDomains() param return false;
+    override proc dsiTrackDomains() return false;
+
+    proc singleton() param return true;
+  }
+
+  var defaultExternDist = new unmanaged ExternDist();
+
+  // Module deinit
+  proc deinit() {
+    delete defaultExternDist;
   }
 
   class ExternDom: BaseRectangularDom {
@@ -122,6 +134,9 @@ module ExternalArray {
     proc dsiMyDist() {
       return dist;
     }
+
+    proc linksDistribution() param return false;
+    override proc dsiLinksDistribution()     return false;
 
     proc dsiMember(ind: rank*idxType) {
       if (ind(1) < size && ind(1) >= 0) {
@@ -296,8 +311,7 @@ module ExternalArray {
 
   pragma "no copy return"
   proc makeArrayFromExternArray(value: chpl_external_array, type eltType) {
-    var dist = new unmanaged ExternDist();
-    var dom = dist.dsiNewRectangularDom(idxType=int, inds=(0..#value.size,));
+    var dom = defaultExternDist.dsiNewRectangularDom(idxType=int, inds=(0..#value.size,));
     dom._free_when_no_arrs = true;
     var arr = new unmanaged ExternArr(eltType,
                                       dom,

--- a/test/compflags/lydia/library/exportArray/callFuncReturnsArray.test.c
+++ b/test/compflags/lydia/library/exportArray/callFuncReturnsArray.test.c
@@ -1,5 +1,4 @@
 #include <stdio.h>
-#include <stdint.h>
 
 #include "returnExternArray.h"
 
@@ -13,6 +12,7 @@ extern void chpl_call_free(chpl_external_array x);
 int main(int argc, char* argv[]) {
   // Initialize the Chapel runtime and standard modules
   chpl_library_init(argc, argv);
+  chpl__init_returnExternArray(1, 2);
 
   // Call the function to get the array
   chpl_external_array arr = foo();

--- a/test/compflags/lydia/library/exportArray/returnExternArray.h
+++ b/test/compflags/lydia/library/exportArray/returnExternArray.h
@@ -1,3 +1,6 @@
+#include <stdint.h>
+
 #include "chpl-external-array.h"
 
 chpl_external_array foo(void);
+void chpl__init_returnExternArray(int64_t ln, int32_t fn);


### PR DESCRIPTION
The new tests of external arrays that I added were leaking memory.  This
was because the distribution I created was a singleton and thus was not
getting cleaned up when the domain was.  This adds more formality to it
being a singleton, and creates a global instance that can be referenced
(and cleaned up when the module gets cleaned up)

Note: I based this on the changes in #9758 and #9770 because there were
going to be merge conflicts either way, and I expect one or both of them to
have minimal changes remaining.

Resolves #9751 

Testing:
- [x] fresh checkout with exportArray tests
- [x] fifo with exportArray tests
- [x] valgrind with exportArray tests
- [x] local memleaks check on the exportArray tests
- [x] full local paratest