### PR TITLE
Add halt wrappers for use in initializers and iterators

### DIFF
--- a/modules/internal/ChapelIO.chpl
+++ b/modules/internal/ChapelIO.chpl
@@ -689,6 +689,34 @@ module ChapelIO {
     __primitive("chpl_error", tmpstring.c_str());
   }
 
+
+  //
+  // Halt wrappers for cases where we want error-handling, but error-handling
+  // isn't supported yet
+  //
+
+  /*
+     Halt wrapper for cases where we want error-handling in initializers. For
+     more info see: https://github.com/chapel-lang/chapel/issues/8793
+   */
+  pragma "no doc"
+  pragma "function terminates program"
+  pragma "always propagate line file info"
+  proc initHalt(s:string) {
+    halt(s);
+  }
+  /*
+     Halt wrapper for cases where we want error-handling in iterators. For more
+     info see: https://github.com/chapel-lang/chapel/issues/7134
+   */
+  pragma "no doc"
+  pragma "function terminates program"
+  pragma "always propagate line file info"
+  proc iterHalt(s:string) {
+    halt(s);
+  }
+
+
   /*
     Prints a warning to stderr giving the location of the call to ``warning``
     in the Chapel source, followed by the argument(s) to the call.

--- a/modules/internal/ChapelIO.chpl
+++ b/modules/internal/ChapelIO.chpl
@@ -689,34 +689,6 @@ module ChapelIO {
     __primitive("chpl_error", tmpstring.c_str());
   }
 
-
-  //
-  // Halt wrappers for cases where we want error-handling, but error-handling
-  // isn't supported yet
-  //
-
-  /*
-     Halt wrapper for cases where we want error-handling in initializers. For
-     more info see: https://github.com/chapel-lang/chapel/issues/8793
-   */
-  pragma "no doc"
-  pragma "function terminates program"
-  pragma "always propagate line file info"
-  proc initHalt(s:string) {
-    halt(s);
-  }
-  /*
-     Halt wrapper for cases where we want error-handling in iterators. For more
-     info see: https://github.com/chapel-lang/chapel/issues/7134
-   */
-  pragma "no doc"
-  pragma "function terminates program"
-  pragma "always propagate line file info"
-  proc iterHalt(s:string) {
-    halt(s);
-  }
-
-
   /*
     Prints a warning to stderr giving the location of the call to ``warning``
     in the Chapel source, followed by the argument(s) to the call.

--- a/modules/standard/ChapelHaltWrappers.chpl
+++ b/modules/standard/ChapelHaltWrappers.chpl
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2004-2018 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+   This module provides halt wrappers to make it easier to find and identify
+   particular use-cases.
+ */
+module ChapelHaltWrappers {
+  use ChapelIO; // for halt()
+
+  //
+  // Halt wrappers for cases where we want error-handling, but error-handling
+  // isn't supported yet
+  //
+
+  /*
+     Halt wrapper for cases where we want error-handling in initializers. For
+     more info see: https://github.com/chapel-lang/chapel/issues/8793
+   */
+  pragma "no doc"
+  pragma "function terminates program"
+  pragma "always propagate line file info"
+  proc initHalt(s:string) {
+    halt(s);
+  }
+
+  /*
+     Halt wrapper for cases where we want error-handling in iterators. For more
+     info see: https://github.com/chapel-lang/chapel/issues/7134
+   */
+  pragma "no doc"
+  pragma "function terminates program"
+  pragma "always propagate line file info"
+  proc iterHalt(s:string) {
+    halt(s);
+  }
+}


### PR DESCRIPTION
Error handling isn't supported for initializers or iterators today. These halt
wrappers are intended to mark such cases so that we can more easily
find/identify them in the future.

See https://github.com/chapel-lang/chapel/issues/7134 and https://github.com/chapel-lang/chapel/issues/8793 for more info