### PR TITLE
Manual partial reductions of forall-expressions in cg-sparse-partred

### DIFF
--- a/test/reductions/partial/utilities.chpl
+++ b/test/reductions/partial/utilities.chpl
@@ -6,6 +6,11 @@ proc partRedEnsureArray(srcArr) {
     compilerError("partial reductions are currently available only for arrays");
 }
 
+proc partRedForallExprElmType(srcDom, fExpr) type {
+  var idx: srcDom.rank * srcDom.idxType;
+  return fExpr(idx).type;
+}
+
 // TODO if resDimSpec is a tuple of singletons and unbounded ranges (..),
 // then we can determine the preserved vs. reduced dimensions at compile
 // time and use fewer conditionals in the generated code.


### PR DESCRIPTION
Switch cg-sparse-partred.chpl to a manual implementation
of partial reductions over forall expressions.

* Introduce a record type per partial reduction: ForallExpr1,2.
An instance of that type serves as a first-class function
that computes the body of the forall expression given the index,
via its this(idx) method.

* Pass such an instance into the partial reduction implementation.
This way the implementation works with any forall-expression.
(It is instantiated for each forall-expression due to a different
record type.)

* Manually transform the code so that the partial reduction is
computed into an already-allocated-by-user array.
I.e. the partial reduction client passes the destination array into
the partial reduction implementation.
Instead of having the PR implementation allocate the result array
and return it to the client.

#### Other notes

* ForallExpr.this() methods refer to the variables in the enclosing
scopes: A, P, Z. The compiler flattens them, propagating those
variables through arguments down into the partial reduction
implementation. As a result, the forall loop in dsiPartialReduceInto()
accesses them by reference. We may want to propagate them
manually so that, in general, they are passed into the forall loop
by the default intent. That is faster for integers, when present.

* Remove the now-unused temporary array AtimesRow and related computations.

* Remove the implementation of partial reductions over arrays from
CSimpl.chpl because it is currently unused. If needed, it can
be recovered or simply copied from DRimpl.chpl.

#### Performance

On my desktop, execution time of cg-sparse-partred is within 1.2x
of cg-sparse for probClass B and within 1.5x for probClass A.
One cause may be that cg-sparse-partred runs transpose()
of the result of the partial reduction, while cg-sparse does not.