### PR TITLE
Fix test errors for new external array set up

### DIFF
--- a/modules/packages/ExternalArray.chpl
+++ b/modules/packages/ExternalArray.chpl
@@ -28,12 +28,13 @@ module ExternalArray {
   extern record chpl_external_array {
     var elts: c_void_ptr;
     var size: uint;
-
-    var freer: c_void_ptr;
   }
 
   extern proc
   chpl_make_external_array(elt_size: uint, num_elts: uint): chpl_external_array;
+
+  extern proc chpl_make_external_array_ptr(elts: c_void_ptr,
+                                           size: uint): chpl_external_array;
 
   extern proc chpl_free_external_array(x: chpl_external_array);
 
@@ -305,7 +306,7 @@ module ExternalArray {
   // Creates an instance of our new array type
   pragma "no copy return"
   proc makeArrayFromPtr(value: c_ptr, size: uint) {
-    var data = new chpl_external_array(value, size, c_nil);
+    var data = chpl_make_external_array_ptr(value : c_void_ptr, size);
     return makeArrayFromExternArray(data, value.eltType);
   }
 

--- a/runtime/include/chpl-external-array.h
+++ b/runtime/include/chpl-external-array.h
@@ -33,6 +33,8 @@ typedef struct {
 
 chpl_external_array chpl_make_external_array(uint64_t elt_size,
                                              uint64_t num_elts);
+chpl_external_array chpl_make_external_array_ptr(void* elts,
+                                                 uint64_t size);
 void chpl_free_external_array(chpl_external_array x);
 
 #endif

--- a/runtime/src/chpl-external-array.c
+++ b/runtime/src/chpl-external-array.c
@@ -38,6 +38,15 @@ chpl_external_array chpl_make_external_array(uint64_t elt_size,
   return ret;
 }
 
+chpl_external_array chpl_make_external_array_ptr(void* elts,
+                                                 uint64_t size) {
+  chpl_external_array ret;
+  ret.elts = elts;
+  ret.size = size;
+  ret.freer = NULL;
+  return ret;
+}
+
 void chpl_free_external_array(chpl_external_array x) {
   if (x.freer != NULL) {
     x.freer(x.elts);

--- a/test/compflags/lydia/library/exportArray/callFuncReturnsArray.test.c
+++ b/test/compflags/lydia/library/exportArray/callFuncReturnsArray.test.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <inttypes.h>
 
 #include "returnExternArray.h"
 
@@ -20,7 +21,7 @@ int main(int argc, char* argv[]) {
 
   // Write its elements
   for (int i = 0; i < 4; i++) {
-    printf("Element[%d] = %lld\n", i, actual[i]);
+    printf("Element[%d] = %" PRId64 "\n", i, actual[i]);
   }
 
   // Call the cleanup function


### PR DESCRIPTION
One setting didn't accept int64_ts as long long ints, so use a macro instead.
The other was more strict about assigning from a void pointer to an extern
type, so set it in the runtime instead.