### PR TITLE
Update enum range branch testing to point to new version

### DIFF
--- a/util/cron/test-perf.chapcs.playground.bash
+++ b/util/cron/test-perf.chapcs.playground.bash
@@ -27,7 +27,7 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.playground"
 
 # Test performance of enum ranges
 GITHUB_USER=bradcray
-GITHUB_BRANCH=enumRanges
+GITHUB_BRANCH=enumRange2
 SHORT_NAME=enumRanges
 START_DATE=06/05/18
 


### PR DESCRIPTION
I'm trying a new approach to supporting enum ranges.  This updates the performance playground to test the new approach.
