### PR TITLE
Adjust PCG proc iterate leader to have same resultType

### DIFF
--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -822,7 +822,7 @@ module Random {
       // Forward the leader iterator as well.
       pragma "no doc"
       pragma "fn returns iterator"
-      proc iterate(D: domain, type resultType=real, param tag)
+      proc iterate(D: domain, type resultType=eltType, param tag)
         where tag == iterKind.leader
       {
         // Note that proc iterate() for the serial case (i.e. the one above)


### PR DESCRIPTION
I don't think the compiler actually uses this default value
but it should be the same as the serial version.

- [x] quickstart testing
- [x] full local testing

Reviewed by @vasslitvinov - thanks!