### PR TITLE
Extend checking of JIRA 203 (transient MPP reservation) to handle more

### DIFF
--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -1896,6 +1896,8 @@ for testname in testsrc:
                             launcher_error = 'Jira 193 -- Unexpected close of apsys for'
                         elif re.search('Transient MPP reservation error on create', output, re.IGNORECASE) != None:
                             launcher_error = 'Jira 203 -- Transient MPP reservation error for'
+                        elif re.search('Transient MPP reservation error on confirm', output, re.IGNORECASE) != None:
+                            launcher_error = 'Jira 203 -- Transient MPP reservation error for'
                         elif re.search('Failed to recv data from background qsub', output, re.IGNORECASE) != None:
                             launcher_error = 'Jira 260 -- Failed to recv data from background qsub for'
                         elif (re.search(r'\d+ Killed', output) and re.search('/var/spool/PBS/mom_priv/jobs', output)):


### PR DESCRIPTION
Detect regressions with the following error message in the output,
    "Transient MPP reservation error on confirm",
and mark them with a recognizable error msg,
    "Jira 203 -- Transient MPP reservation error",
for easier triage.

An existing filter was already checking the test output for
    "Transient MPP reservation error on create"
and marking those tests with the same "Jira 203" message.