### PR TITLE
Revert "Update enum range branch testing to point to new version"

### DIFF
--- a/util/cron/test-perf.chapcs.playground.bash
+++ b/util/cron/test-perf.chapcs.playground.bash
@@ -27,7 +27,7 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.playground"
 
 # Test performance of enum ranges
 GITHUB_USER=bradcray
-GITHUB_BRANCH=enumRange2
+GITHUB_BRANCH=enumRanges
 SHORT_NAME=enumRanges
 START_DATE=06/05/18
 


### PR DESCRIPTION
Reverts chapel-lang/chapel#9791

Switch back to the original branch for tonight.
