### PR TITLE
Add missing then to update-llvm.sh

### DIFF
--- a/third-party/llvm/update-llvm.sh
+++ b/third-party/llvm/update-llvm.sh
@@ -56,6 +56,7 @@ git clone $CLONEARGS https://git.llvm.org/git/clang.git llvm/tools/clang
 echo Checking out POLLY $BRANCH
 git clone $CLONEARGS https://git.llvm.org/git/polly.git llvm/tools/polly
 if [ "$ENABLE_RV" -ne 0 ]
+then
 echo Checking out RV $BRANCH
 git clone $CLONEARGS https://github.com/cdl-saarland/rv llvm/tools/rv
 fi


### PR DESCRIPTION
Updates a script that can be used manually during LLVM development.
PR #9567 added a conditional but forgot to add the `then` required by bash.

Trivial and not reviewed.