### PR TITLE
Remove some halts from the DateTime module

### DIFF
--- a/modules/standard/ChapelHaltWrappers.chpl
+++ b/modules/standard/ChapelHaltWrappers.chpl
@@ -50,4 +50,20 @@ module ChapelHaltWrappers {
   proc iterHalt(s:string) {
     halt(s);
   }
+
+
+  //
+  // Halt wrappers for misc cases where a language, compiler, or library
+  // feature is missing.
+  //
+
+  /*
+     Halt wrapper for pure virtual methods. For more info see
+     https://github.com/chapel-lang/chapel/issues/8566
+   */
+  pragma "function terminates program"
+  pragma "always propagate line file info"
+  proc pureVirtualMethodHalt() {
+    halt("pure virtual method called");
+  }
 }

--- a/modules/standard/DateTime.chpl
+++ b/modules/standard/DateTime.chpl
@@ -86,8 +86,8 @@ module DateTime {
     extern proc gettimeofday(ref tv: timeval, tz): int;
 
     var tv: timeval;
-    if gettimeofday(tv, nil) != 0 then
-      halt("error in call to gettimeofday()");
+    var ret = gettimeofday(tv, c_nil);
+    assert(ret == 0);
     return (tv.tv_sec, tv.tv_usec);
   }
 

--- a/modules/standard/DateTime.chpl
+++ b/modules/standard/DateTime.chpl
@@ -1656,25 +1656,29 @@ module DateTime {
   class TZInfo {
     /* The offset from UTC this class represents */
     proc utcoffset(dt: datetime): timedelta {
-      halt("Abstract base method called");
+      use ChapelHaltWrappers;
+      pureVirtualMethodHalt();
       return new timedelta();
     }
 
     /* The `timedelta` for daylight saving time */
     proc dst(dt: datetime): timedelta {
-      halt("Abstract base method called");
+      use ChapelHaltWrappers;
+      pureVirtualMethodHalt();
       return new timedelta();
     }
 
     /* The name of this time zone */
     proc tzname(dt: datetime): string {
-      halt("Abstract base method called");
+      use ChapelHaltWrappers;
+      pureVirtualMethodHalt();
       return "";
     }
 
     /* Convert a `time` in UTC to this time zone */
     proc fromutc(in dt: datetime): datetime {
-      halt("Abstract base method called");
+      use ChapelHaltWrappers;
+      pureVirtualMethodHalt();
       return new datetime(0,0,0);
     }
   }

--- a/modules/standard/DateTime.chpl
+++ b/modules/standard/DateTime.chpl
@@ -754,8 +754,6 @@ module DateTime {
       //return (t1.replace(tzinfo=nilTZ) - t1.utcoffset()) <
       //       (t2.replace(tzinfo=nilTZ) - t2.utcoffset());
     }
-    halt("unreachable");
-    return false;
   }
 
   pragma "no doc"
@@ -779,8 +777,6 @@ module DateTime {
       const dt2 = datetime.combine(new date(1900, 1, 1), t2);
       return dt1 <= dt2;
     }
-    halt("unreachable");
-    return false;
   }
 
   pragma "no doc"
@@ -804,8 +800,6 @@ module DateTime {
       const dt2 = datetime.combine(new date(1900, 1, 1), t2);
       return dt1 > dt2;
     }
-    halt("unreachable");
-    return false;
   }
 
   pragma "no doc"
@@ -829,8 +823,6 @@ module DateTime {
       const dt2 = datetime.combine(new date(1900, 1, 1), t2);
       return dt1 >= dt2;
     }
-    halt("unreachable");
-    return false;
   }
 
   /* A record representing a combined `date` and `time` */
@@ -1324,8 +1316,6 @@ module DateTime {
                                 dt2.replace(tzinfo=nilTZ) +
                                 dt2.utcoffset() - dt1.utcoffset();
     }
-    halt("this should be unreachable");
-    return new timedelta();
   }
 
   pragma "no doc"
@@ -1370,8 +1360,6 @@ module DateTime {
       return (dt1.replace(tzinfo=nilTZ) - dt1.utcoffset()) <
              (dt2.replace(tzinfo=nilTZ) - dt2.utcoffset());
     }
-    halt("this should be unreachable");
-    return false;
   }
 
   pragma "no doc"
@@ -1389,8 +1377,6 @@ module DateTime {
       return (dt1.replace(tzinfo=nilTZ) - dt1.utcoffset()) <=
              (dt2.replace(tzinfo=nilTZ) - dt2.utcoffset());
     }
-    halt("this should be unreachable");
-    return false;
   }
 
   pragma "no doc"
@@ -1408,8 +1394,6 @@ module DateTime {
       return (dt1.replace(tzinfo=nilTZ) - dt1.utcoffset()) >
              (dt2.replace(tzinfo=nilTZ) - dt2.utcoffset());
     }
-    halt("this should be unreachable");
-    return false;
   }
 
   pragma "no doc"
@@ -1427,8 +1411,6 @@ module DateTime {
       return (dt1.replace(tzinfo=nilTZ) - dt1.utcoffset()) >=
              (dt2.replace(tzinfo=nilTZ) - dt2.utcoffset());
     }
-    halt("this should be unreachable");
-    return false;
   }
 
 


### PR DESCRIPTION
Remove or convert some unnecessary halts in Datetime: 
 - convert a halt for gettimeofday to an assert since it should never be able to fail
 - remove some "unreachable" halts that are no longer needed
 - convert some ad-hoc "Abstract base method called" halts to a pureVirtualMethodHalt() wrapper

Related to https://github.com/chapel-lang/chapel/issues/9552