### PR TITLE
Add --break-on-id and --break-on-delete-id to chpldoc

### DIFF
--- a/compiler/main/commonFlags.h
+++ b/compiler/main/commonFlags.h
@@ -43,7 +43,7 @@ void driverSetDevelSettings(const ArgumentDescription* desc, const char* arg_unu
 
 #define DRIVER_ARG_BREAKFLAGS_COMMON \
   {"break-on-id", ' ', NULL, "Break when AST id is created", "I", &breakOnID, "CHPL_BREAK_ON_ID", NULL}, \
- {"break-on-delete-id", ' ', NULL, "Break when AST id is deleted", "I", &breakOnDeleteID, "CHPL_BREAK_ON_DELETE_ID", NULL}
+  {"break-on-delete-id", ' ', NULL, "Break when AST id is deleted", "I", &breakOnDeleteID, "CHPL_BREAK_ON_DELETE_ID", NULL}
 
 #define DRIVER_ARG_DEBUGGERS                                            \
   {"gdb", ' ', NULL, "Run compiler in gdb", "F", &fRungdb, NULL, NULL}, \

--- a/compiler/main/commonFlags.h
+++ b/compiler/main/commonFlags.h
@@ -41,6 +41,10 @@ void driverSetDevelSettings(const ArgumentDescription* desc, const char* arg_unu
 #define DRIVER_ARG_COPYRIGHT \
   {"copyright", ' ', NULL, "Show copyright", "F", &fPrintCopyright, NULL, NULL}
 
+#define DRIVER_ARG_BREAKFLAGS_COMMON \
+  {"break-on-id", ' ', NULL, "Break when AST id is created", "I", &breakOnID, "CHPL_BREAK_ON_ID", NULL}, \
+ {"break-on-delete-id", ' ', NULL, "Break when AST id is deleted", "I", &breakOnDeleteID, "CHPL_BREAK_ON_DELETE_ID", NULL}
+
 #define DRIVER_ARG_DEBUGGERS                                            \
   {"gdb", ' ', NULL, "Run compiler in gdb", "F", &fRungdb, NULL, NULL}, \
   {"lldb", ' ', NULL, "Run compiler in lldb", "F", &fRunlldb, NULL, NULL}

--- a/compiler/main/docsDriver.cpp
+++ b/compiler/main/docsDriver.cpp
@@ -106,6 +106,7 @@ ArgumentDescription docs_arg_desc[] = {
 
  {"", ' ', NULL, "Developer Flags", NULL, NULL, NULL, NULL},
  DRIVER_ARG_DEVELOPER,
+ DRIVER_ARG_BREAKFLAGS_COMMON,
  DRIVER_ARG_DEBUGGERS,
  DRIVER_ARG_PRINT_CHPL_HOME,
 

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -963,8 +963,7 @@ static ArgumentDescription arg_desc[] = {
  {"default-unmanaged", ' ', NULL, "Enable [disable] class type defaulting to unmanaged", "N", &fDefaultUnmanaged, "CHPL_DEFAULT_UNMANAGED", NULL},
 
  {"", ' ', NULL, "Developer Flags -- Miscellaneous", NULL, NULL, NULL, NULL},
- {"break-on-id", ' ', NULL, "Break when AST id is created", "I", &breakOnID, "CHPL_BREAK_ON_ID", NULL},
- {"break-on-delete-id", ' ', NULL, "Break when AST id is deleted", "I", &breakOnDeleteID, "CHPL_BREAK_ON_DELETE_ID", NULL},
+ DRIVER_ARG_BREAKFLAGS_COMMON,
  {"break-on-codegen", ' ', NULL, "Break when function cname is code generated", "S256", &breakOnCodegenCname, "CHPL_BREAK_ON_CODEGEN", NULL},
  {"break-on-codegen-id", ' ', NULL, "Break when id is code generated", "I", &breakOnCodegenID, "CHPL_BREAK_ON_CODEGEN_ID", NULL},
  {"default-dist", ' ', "<distribution>", "Change the default distribution", "S256", defaultDist, "CHPL_DEFAULT_DIST", NULL},


### PR DESCRIPTION
Resolves #9823 

When debugging an issue with `chpldoc` recently, I realized that I could debug
its operations, but couldn't use `--break-on-id` (a developer flag with normal
chpl compilation that I have found quite helpful when I know the id to use)

This change makes it so that `chpldoc` allows `--break-on-id` and
`--break-on-delete-id` to work, by defining them through a macro that is used
both in the normal driver and in the `chpldoc` driver.  I figured
`--break-on-delete-id` was also useful, but that anything that would apply after
(like `--break-on-resolve-id` or `--break-on-codegen-id`) was absolutely not going
to be necessary.

Double checked on a local `--lldb` run for both flags both in `chpldoc` and `chpl`
compilation.  Passed a full paratest (I know there is a help output test but I don't
remember where it lives)