### PR TITLE
Fix handful of --force-initializers failures from recent changes

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -2184,7 +2184,7 @@ bool AggregateType::needsConstructor() const {
     // Defining an initializer means we don't need a default constructor
     return false;
   } else {
-    // The above two branches are only relevant in the recursive version
+    // The above three branches are only relevant in the recursive version
     // of this call, as the outside call site for this function has
     // already ensured that the type which is the entry point has defined
     // neither an initializer nor a constructor.

--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -2173,6 +2173,8 @@ bool AggregateType::needsConstructor() const {
   // and library modules
   if (mod && (mod->modTag == MOD_INTERNAL || mod->modTag == MOD_STANDARD))
     return true;
+  else if (initializerStyle == DEFINES_CONSTRUCTOR)
+    return true;
   else if (fUserDefaultInitializers)
     // Don't generate a default constructor when --force-initializers is true,
     // we want to generate a default initializer or fail.
@@ -2181,9 +2183,6 @@ bool AggregateType::needsConstructor() const {
   if (initializerStyle == DEFINES_INITIALIZER) {
     // Defining an initializer means we don't need a default constructor
     return false;
-  } else if (initializerStyle == DEFINES_CONSTRUCTOR) {
-    // Defining a constructor means we need a default constructor
-    return true;
   } else {
     // The above two branches are only relevant in the recursive version
     // of this call, as the outside call site for this function has

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -6435,7 +6435,7 @@ static void temporaryInitializerFixup(CallExpr* call) {
             ct->initializerStyle                == DEFINES_NONE_USE_DEFAULT) {
           // Transitioning to a default initializer world.
           // Lydia note 03/14/17)
-          if (strcmp(ct->defaultInitializer->name, "init") != 0) {
+          if (ct->hasInitializers() == false) {
             // This code should be removed when the compiler generates
             // initializers as the default method of construction and
             // initialization for a type (Lydia note, 08/19/16)

--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -1536,7 +1536,6 @@ static bool isInstantiatedField(Symbol* field) {
     for_formals(formal, at->typeConstructor) {
       if (strcmp(field->name, formal->name) == 0) {
         if (formal->hasFlag(FLAG_TYPE_VARIABLE) == true) {
-          gdbShouldBreakHere();
           retval = true;
           break;
         }

--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -1520,11 +1520,26 @@ static bool isInstantiatedField(Symbol* field) {
   AggregateType* at     = toAggregateType(ts->type);
   bool           retval = false;
 
-  for_formals(formal, at->typeConstructor) {
-    if (strcmp(field->name, formal->name) == 0) {
-      if (formal->hasFlag(FLAG_TYPE_VARIABLE) == true) {
-        retval = true;
-        break;
+  // BHARSH INIT TODO: Sometimes the type constructor is not resolved when
+  // initializers are used. Why?
+  if (at->hasInitializers()) {
+    Symbol* origField = at->getRootInstantiation()->getField(field->name);
+    DefExpr* def = origField->defPoint;
+
+    if (field->hasFlag(FLAG_TYPE_VARIABLE)) {
+      retval = true;
+    } else if (def->exprType == NULL && def->init == NULL) {
+      // Fully-generic types are apparently OK?
+      retval = true;
+    }
+  } else {
+    for_formals(formal, at->typeConstructor) {
+      if (strcmp(field->name, formal->name) == 0) {
+        if (formal->hasFlag(FLAG_TYPE_VARIABLE) == true) {
+          gdbShouldBreakHere();
+          retval = true;
+          break;
+        }
       }
     }
   }

--- a/compiler/resolution/virtualDispatch.cpp
+++ b/compiler/resolution/virtualDispatch.cpp
@@ -828,7 +828,11 @@ static void checkMethodsOverride() {
         // ignore internal module errors for now
         fn->getModule()->modTag == MOD_USER &&
         // ignore errors with deinit
-        0 != strcmp("deinit", fn->name)) {
+        0 != strcmp("deinit", fn->name) &&
+        // ignore errors for init()
+        !fn->isInitializer() &&
+        // ignore errors for postinit()
+        !fn->isPostInitializer()) {
       if (AggregateType* ct = toAggregateType(fn->_this->getValType())) {
         if (isClass(ct)) {
           std::vector<FnSymbol*> matches;


### PR DESCRIPTION
This PR fixes a few --force-initializers failure cases that were introduced in recent weeks:
- Skip init/postinit override errors
- Fix field type queries for types with initializers
- Do not let --force-initializers take precedence over types with constructors
- Workaround for case in which AggregateType::defaultInitializer is NULL

Testing:
- [x] local + futures
- [x] partial gasnet
- [x] local --force-initializers ( less than 100 failures )