### PR TITLE
Add sub_test filtering for Jira 333 (Text file busy)

### DIFF
--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -1904,6 +1904,8 @@ for testname in testsrc:
                             launcher_error = 'Jira 329 -- Fatal MPP reservation error for'
                         elif re.search('Fatal MPP reservation error on create', output, re.IGNORECASE) != None:
                             launcher_error = 'Jira 329 -- Fatal MPP reservation error for'
+                        elif re.search('Text file busy', output, re.IGNORECASE) != None:
+                            launcher_error = 'Jira 333 -- Text file busy for'
                         elif (re.search('PBS: job killed: walltime', output, re.IGNORECASE) != None or
                               re.search('slurm.* CANCELLED .* DUE TO TIME LIMIT', output, re.IGNORECASE) != None):
                             exectimeout = True


### PR DESCRIPTION
Jira 333 (Text file busy) is a sporadic failure we've been seeing relatively
frequently the last 3 months. Add sub_test filtering so it's easier to pick out
when this error occurs.