### PR TITLE
Get CPU counts from the runtime topology interface

### DIFF
--- a/modules/internal/LocaleModelHelpSetup.chpl
+++ b/modules/internal/LocaleModelHelpSetup.chpl
@@ -137,13 +137,13 @@ module LocaleModelHelpSetup {
     extern proc chpl_task_getCallStackSize(): size_t;
     dst.callStackSize = chpl_task_getCallStackSize();
 
-    extern proc chpl_getNumPhysicalCpus(accessible_only: bool): c_int;
-    dst.nPUsPhysAcc = chpl_getNumPhysicalCpus(true);
-    dst.nPUsPhysAll = chpl_getNumPhysicalCpus(false);
+    extern proc chpl_topo_getNumCPUsPhysical(accessible_only: bool): c_int;
+    dst.nPUsPhysAcc = chpl_topo_getNumCPUsPhysical(true);
+    dst.nPUsPhysAll = chpl_topo_getNumCPUsPhysical(false);
 
-    extern proc chpl_getNumLogicalCpus(accessible_only: bool): c_int;
-    dst.nPUsLogAcc = chpl_getNumLogicalCpus(true);
-    dst.nPUsLogAll = chpl_getNumLogicalCpus(false);
+    extern proc chpl_topo_getNumCPUsLogical(accessible_only: bool): c_int;
+    dst.nPUsLogAcc = chpl_topo_getNumCPUsLogical(true);
+    dst.nPUsLogAll = chpl_topo_getNumCPUsLogical(false);
 
     extern proc chpl_task_getMaxPar(): uint(32);
     dst.maxTaskPar = chpl_task_getMaxPar();

--- a/runtime/include/chpl-topo.h
+++ b/runtime/include/chpl-topo.h
@@ -44,6 +44,12 @@ void chpl_topo_exit(void);
 void* chpl_topo_getHwlocTopology(void);
 
 //
+// How many CPUs are there?
+//
+int chpl_topo_getNumCPUsPhysical(chpl_bool /*accessible_only*/);
+int chpl_topo_getNumCPUsLogical(chpl_bool /*accessible_only*/);
+
+//
 // how many NUMA domains are there?
 //
 int chpl_topo_getNumNumaDomains(void);

--- a/runtime/include/chplsys.h
+++ b/runtime/include/chplsys.h
@@ -28,8 +28,8 @@ size_t chpl_getSysPageSize(void);
 size_t chpl_getHeapPageSize(void); // note: only works after mem layer inited
 uint64_t chpl_sys_physicalMemoryBytes(void);
 uint64_t chpl_sys_availMemoryBytes(void);
-int chpl_getNumPhysicalCpus(chpl_bool accessible_only);
-int chpl_getNumLogicalCpus(chpl_bool accessible_only);
+int chpl_sys_getNumCPUsPhysical(chpl_bool accessible_only);
+int chpl_sys_getNumCPUsLogical(chpl_bool accessible_only);
 
 void chpl_moveToLastCPU(void);
 

--- a/runtime/src/chpl-tasks.c
+++ b/runtime/src/chpl-tasks.c
@@ -23,8 +23,8 @@
 //
 #include "chplrt.h"
 #include "chpl-comm.h"
-#include "chplsys.h"
 #include "chpl-tasks.h"
+#include "chpl-topo.h"
 #include "error.h"
 
 #include <inttypes.h>
@@ -49,12 +49,12 @@ int32_t chpl_task_getenvNumThreadsPerLocale(void)
     int32_t lim = chpl_comm_getMaxThreads();
 
     if (strcmp(p, "MAX_PHYSICAL") == 0) {
-      num = chpl_getNumPhysicalCpus(true);
+      num = chpl_topo_getNumCPUsPhysical(true);
       if (lim > 0 && lim < num)
         num = lim;
     }
     else if (strcmp(p, "MAX_LOGICAL") == 0) {
-      num = chpl_getNumLogicalCpus(true);
+      num = chpl_topo_getNumCPUsLogical(true);
       if (lim > 0 && lim < num)
         num = lim;
     }

--- a/runtime/src/chplsys.c
+++ b/runtime/src/chplsys.c
@@ -672,7 +672,7 @@ static void getCpuInfo(int* p_numPhysCpus, int* p_numLogCpus) {
 #endif
 
 
-int chpl_getNumPhysicalCpus(chpl_bool accessible_only) {
+int chpl_sys_getNumCPUsPhysical(chpl_bool accessible_only) {
   //
   // Support for the accessible_only flag here is spotty.  For non-Linux
   // systems we ignore it.  For Linux systems we obey it, but we may
@@ -697,7 +697,7 @@ int chpl_getNumPhysicalCpus(chpl_bool accessible_only) {
   //
   static int numCpus = 0;
   if (numCpus == 0)
-    numCpus = chpl_getNumLogicalCpus(true);
+    numCpus = chpl_sys_getNumCPUsLogical(true);
   return numCpus;
 #elif defined  __FreeBSD__
   //
@@ -705,7 +705,7 @@ int chpl_getNumPhysicalCpus(chpl_bool accessible_only) {
   //
   static int numCpus = 0;
   if (numCpus == 0)
-    numCpus = chpl_getNumLogicalCpus(true);
+    numCpus = chpl_sys_getNumCPUsLogical(true);
   return numCpus;
 
 #elif defined(__linux__) || defined(__NetBSD__)
@@ -763,7 +763,7 @@ int chpl_getNumPhysicalCpus(chpl_bool accessible_only) {
 }
 
 
-int chpl_getNumLogicalCpus(chpl_bool accessible_only) {
+int chpl_sys_getNumCPUsLogical(chpl_bool accessible_only) {
   //
   // Support for the accessible_only flag here is spotty -- we only obey
   // it for Linux systems.

--- a/runtime/src/comm/gasnet/comm-gasnet.c
+++ b/runtime/src/comm/gasnet/comm-gasnet.c
@@ -798,7 +798,7 @@ static void set_num_comm_domains() {
   char num_cpus_val[22]; // big enough for an unsigned 64-bit quantity
   int num_cpus;
 
-  num_cpus = chpl_getNumPhysicalCpus(true) + 1;
+  num_cpus = chpl_topo_getNumCPUsPhysical(true) + 1;
 
   snprintf(num_cpus_val, sizeof(num_cpus_val), "%d", num_cpus);
   if (setenv("GASNET_DOMAIN_COUNT", num_cpus_val, 0) != 0) {

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -165,7 +165,7 @@ static int get_comm_concurrency() {
     }
   }
 
-  if ((lcpus = chpl_getNumLogicalCpus(true)) > 0) {
+  if ((lcpus = chpl_topo_getNumCPUsLogical(true)) > 0) {
     return lcpus;
   }
 

--- a/runtime/src/tasks/fifo/tasks-fifo.c
+++ b/runtime/src/tasks/fifo/tasks-fifo.c
@@ -30,7 +30,7 @@
 #include "chpl-mem.h"
 #include "chpl-tasks.h"
 #include "chpl-tasks-callbacks-internal.h"
-#include "chplsys.h"
+#include "chpl-topo.h"
 #include "chpl-linefile-support.h"
 #include "error.h"
 #include <stdio.h>
@@ -167,7 +167,7 @@ static void sync_wait_and_lock(chpl_sync_aux_t *s,
   // in order to ensure fairness and thus progress.  If we're not, we
   // can spin-wait.
   suspend_using_cond = (chpl_thread_getNumThreads() >=
-                        chpl_getNumLogicalCpus(true));
+                        chpl_topo_getNumCPUsLogical(true));
 
   while (s->is_full != want_full) {
     if (!suspend_using_cond) {
@@ -822,7 +822,7 @@ uint32_t chpl_task_getMaxPar(void) {
   // lesser of the number of physical CPUs and whatever the threading
   // layer says it can do.
   //
-  max = (uint32_t) chpl_getNumPhysicalCpus(true);
+  max = (uint32_t) chpl_topo_getNumCPUsPhysical(true);
   maxThreads = chpl_thread_getMaxThreads();
   if (maxThreads < max && maxThreads > 0)
     max = maxThreads;

--- a/runtime/src/tasks/massivethreads/tasks-massivethreads.c
+++ b/runtime/src/tasks/massivethreads/tasks-massivethreads.c
@@ -30,7 +30,7 @@
 #include "chpl-mem.h"
 #include "chpl-tasks.h"
 #include "chpl-tasks-callbacks-internal.h"
-#include "chplsys.h"
+#include "chpl-topo.h"
 #include "chpl-linefile-support.h"
 #include "error.h"
 #include <stdio.h>
@@ -703,7 +703,7 @@ int chpl_task_supportsRemoteCache(void) {
 uint32_t chpl_task_getMaxPar(void) {
   uint32_t n;
   enter_();
-  n = (uint32_t) chpl_getNumPhysicalCpus(true);
+  n = (uint32_t) chpl_topo_getNumCPUsPhysical(true);
   return_from_();
   return n;
 }

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -46,6 +46,7 @@
 #include "chpl-linefile-support.h"
 #include "chpl-tasks.h"
 #include "chpl-tasks-callbacks-internal.h"
+#include "chpl-topo.h"
 #include "tasks-qthreads.h"
 
 #include "qthread.h"
@@ -541,7 +542,7 @@ static int32_t setupAvailableParallelism(int32_t maxThreads) {
 
         hwpar = numThreadsPerLocale;
 
-        numPUsPerLocale = chpl_getNumLogicalCpus(true);
+        numPUsPerLocale = chpl_topo_getNumCPUsLogical(true);
         if (0 < numPUsPerLocale && numPUsPerLocale < hwpar) {
             if (verbosity > 0) {
                 printf("QTHREADS: Reduced numThreadsPerLocale=%d to %d "
@@ -560,7 +561,7 @@ static int32_t setupAvailableParallelism(int32_t maxThreads) {
     }
     // User did not set chapel or qthreads vars -- our default
     else {
-        hwpar = chpl_getNumPhysicalCpus(true);
+        hwpar = chpl_topo_getNumCPUsPhysical(true);
     }
 
     // hwpar will only be <= 0 if the user set QT_NUM_SHEPHERDS and/or
@@ -574,7 +575,7 @@ static int32_t setupAvailableParallelism(int32_t maxThreads) {
 
         // If there is more parallelism requested than the number of cores, set the
         // worker unit to pu, otherwise core.
-        if (hwpar > chpl_getNumPhysicalCpus(true)) {
+        if (hwpar > chpl_topo_getNumCPUsPhysical(true)) {
           chpl_qt_setenv("WORKER_UNIT", "pu", 0);
         } else {
           chpl_qt_setenv("WORKER_UNIT", "core", 0);

--- a/runtime/src/topo/hwloc/topo-hwloc.c
+++ b/runtime/src/topo/hwloc/topo-hwloc.c
@@ -250,7 +250,7 @@ void getNumCPUs(void) {
                                                          HWLOC_OBJ_CORE,
                                                          pu))
                   != NULL);
-    hwloc_bitmap_set(physAccSet, core->os_index);
+    hwloc_bitmap_set(physAccSet, core->logical_index);
   }
 
 #undef NEXT_PU

--- a/runtime/src/topo/hwloc/topo-hwloc.c
+++ b/runtime/src/topo/hwloc/topo-hwloc.c
@@ -188,6 +188,16 @@ void* chpl_topo_getHwlocTopology(void) {
 }
 
 
+int chpl_topo_getNumCPUsPhysical(chpl_bool accessible_only) {
+  return chpl_sys_getNumCPUsPhysical(accessible_only);
+}
+
+
+int chpl_topo_getNumCPUsLogical(chpl_bool accessible_only) {
+  return chpl_sys_getNumCPUsLogical(accessible_only);
+}
+
+
 int chpl_topo_getNumNumaDomains(void) {
   return numNumaDomains;
 }

--- a/runtime/src/topo/hwloc/topo-hwloc.c
+++ b/runtime/src/topo/hwloc/topo-hwloc.c
@@ -73,6 +73,8 @@ static void chpl_topo_setMemLocalityByPages(unsigned char*, size_t,
 //
 // Error reporting.
 //
+// CHK_ERR*() must evaluate 'expr' precisely once!
+//
 static void chk_err_fn(const char*, int, const char*);
 static void chk_err_errno_fn(const char*, int, const char*);
 

--- a/runtime/src/topo/none/topo-none.c
+++ b/runtime/src/topo/none/topo-none.c
@@ -41,6 +41,16 @@ void* chpl_topo_getHwlocTopology(void) {
 }
 
 
+int chpl_topo_getNumCPUsPhysical(chpl_bool accessible_only) {
+  return chpl_sys_getNumCPUsPhysical(accessible_only);
+}
+
+
+int chpl_topo_getNumCPUsLogical(chpl_bool accessible_only) {
+  return chpl_sys_getNumCPUsLogical(accessible_only);
+}
+
+
 int chpl_topo_getNumNumaDomains(void) {
   return 1;
 }


### PR DESCRIPTION
Change the authoritative runtime interface for CPU counts from the
"system" layer to the topology layer.  Implement new topology layer
functions that get CPU counts, and change most of the calls to the old
system-based functions so that they go to the new topology-based ones
instead.  (The only remaining calls to the system-based functions are in
the backstop topo=none topology implementation and chplsys itself.)
Rename the old system-based functions, to better indicate where they get
their information and to differentiate them from the new functions.

This resolves #9395.