### PR TITLE
Remove origin field from DefaultRectangular

### DIFF
--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -893,7 +893,6 @@ module DefaultRectangular {
     var off: rank*idxType;
     var blk: rank*idxType;
     var str: rank*idxSignedType;
-    var origin: idxType;
     var factoredOffs: idxType;
 
     pragma "local field"
@@ -919,7 +918,6 @@ module DefaultRectangular {
       writeln("off=", off);
       writeln("blk=", blk);
       writeln("str=", str);
-      writeln("origin=", origin);
       writeln("factoredOffs=", factoredOffs);
       writeln("noinit_data=", noinit_data);
     }
@@ -1040,10 +1038,10 @@ module DefaultRectangular {
         // work for something with no immediate reward.
         if dom.dsiNumIndices > 0 {
           const shiftDist = if isIntType(idxType) then
-                              origin - factoredOffs
+                              0:idxType - factoredOffs
                             else
                               // Not bothering to check for over/underflow
-                              origin:idxSignedType - factoredOffs:idxSignedType;
+                              0:idxSignedType - factoredOffs:idxSignedType;
           shiftedData = _ddata_shift(eltType, data, shiftDist);
         }
       }
@@ -1086,7 +1084,7 @@ module DefaultRectangular {
     inline proc getDataIndex(ind: rank*idxType,
                              param getShifted = true) {
       if stridable {
-        var sum = origin;
+        var sum = 0:idxType;
         for param i in 1..rank do
           sum += (ind(i) - off(i)) * blk(i) / abs(str(i)):idxType;
         return sum;
@@ -1097,7 +1095,7 @@ module DefaultRectangular {
         if (rank == 1 && wantShiftedIndex) {
           return ind(1);
         } else {
-          var sum = if wantShiftedIndex then 0:idxType else origin;
+          var sum = 0:idxType;
 
           for param i in 1..rank-1 {
             sum += ind(i) * blk(i);
@@ -1216,7 +1214,6 @@ module DefaultRectangular {
         off = copy.off;
         blk = copy.blk;
         str = copy.str;
-        origin = copy.origin;
         factoredOffs = copy.factoredOffs;
         dsiDestroyArr();
         data = copy.data;
@@ -1255,7 +1252,7 @@ module DefaultRectangular {
       rad.off = off;
       rad.blk = blk;
       rad.str = str;
-      rad.origin = origin;
+      rad.origin = 0;
       rad.factoredOffs = factoredOffs;
       rad.data = data;
       rad.shiftedData = shiftedData;
@@ -1590,7 +1587,7 @@ module DefaultRectangular {
   // This is very conservative.
   proc DefaultRectangularArr.isDataContiguous(dom) {
     if debugDefaultDistBulkTransfer then
-      chpl_debug_writeln("isDataContiguous(): origin=", origin, " off=", off, " blk=", blk);
+      chpl_debug_writeln("isDataContiguous(): off=", off, " blk=", blk);
 
     if blk(rank) != 1 then return false;
 

--- a/test/distributions/robust/arithmetic/performance/multilocale/assignReindex.block.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/assignReindex.block.good
@@ -1,2 +1,2 @@
 (execute_on = 12, execute_on_nb = 6) (get = 101, put = 1, execute_on = 6, execute_on_fast = 2) (get = 101, put = 1, execute_on_fast = 2) (get = 101, put = 1, execute_on_fast = 2)
-(execute_on_nb = 3) (get = 122, execute_on_fast = 1) (get = 122, execute_on_fast = 1) (get = 77, execute_on_fast = 1)
+(execute_on_nb = 3) (get = 121, execute_on_fast = 1) (get = 121, execute_on_fast = 1) (get = 76, execute_on_fast = 1)

--- a/test/distributions/robust/arithmetic/performance/multilocale/assignReindex.cyclic.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/assignReindex.cyclic.good
@@ -1,2 +1,2 @@
 (execute_on = 12, execute_on_nb = 6) (get = 244, put = 1, execute_on = 6, execute_on_fast = 2) (get = 244, put = 1, execute_on_fast = 2) (get = 244, put = 1, execute_on_fast = 2)
-(get = 17, execute_on_nb = 3) (get = 142, execute_on_fast = 1) (get = 142, execute_on_fast = 1) (get = 232, execute_on_fast = 1)
+(get = 16, execute_on_nb = 3) (get = 141, execute_on_fast = 1) (get = 141, execute_on_fast = 1) (get = 231, execute_on_fast = 1)

--- a/test/distributions/robust/arithmetic/performance/multilocale/assignReindex.lm-numa.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/assignReindex.lm-numa.good
@@ -1,2 +1,2 @@
 (execute_on = 12, execute_on_nb = 6) (get = 101, put = 1, execute_on = 6, execute_on_fast = 2) (get = 101, put = 1, execute_on_fast = 2) (get = 101, put = 1, execute_on_fast = 2)
-(execute_on_nb = 3) (get = 130, execute_on_fast = 1) (get = 130, execute_on_fast = 1) (get = 85, execute_on_fast = 1)
+(execute_on_nb = 3) (get = 129, execute_on_fast = 1) (get = 129, execute_on_fast = 1) (get = 84, execute_on_fast = 1)

--- a/test/optimizations/bulkcomm/bharshbarg/remote.good.orig
+++ b/test/optimizations/bulkcomm/bharshbarg/remote.good.orig
@@ -7,7 +7,7 @@ proc =(a:[],b:[]): in chpl__bulkTransferArray
 proc =(a:[],b:[]): attempting doiBulkTransferToKnown
 proc =(a:[],b:[]): in chpl__bulkTransferArray
 proc =(a:[],b:[]): attempting doiBulkTransferFromKnown
-isDataContiguous(): origin=0 off=(1, 1) blk=(10, 1)
+isDataContiguous(): off=(1, 1) blk=(10, 1)
 isDataContiguous return False
 Performing complex DefaultRectangular transfer
 Transferring views :{1..10, 1..5} <-- {1..10, 1..5}
@@ -32,7 +32,7 @@ proc =(a:[],b:[]): in chpl__bulkTransferArray
 proc =(a:[],b:[]): attempting doiBulkTransferToKnown
 proc =(a:[],b:[]): in chpl__bulkTransferArray
 proc =(a:[],b:[]): attempting doiBulkTransferFromKnown
-isDataContiguous(): origin=0 off=(1, 1) blk=(10, 1)
+isDataContiguous(): off=(1, 1) blk=(10, 1)
 isDataContiguous return False
 Performing complex DefaultRectangular transfer
 Transferring views :{1..10, 1..5} <-- {1..10, 1..5}
@@ -61,7 +61,7 @@ proc =(a:[],b:[]): in chpl__bulkTransferArray
 proc =(a:[],b:[]): attempting doiBulkTransferToKnown
 proc =(a:[],b:[]): in chpl__bulkTransferArray
 proc =(a:[],b:[]): attempting doiBulkTransferFromKnown
-isDataContiguous(): origin=0 off=(1, 1) blk=(10, 1)
+isDataContiguous(): off=(1, 1) blk=(10, 1)
 isDataContiguous return False
 Performing complex DefaultRectangular transfer
 Transferring views :{1..10, 1..5} <-- {1..10, 1..5}
@@ -86,7 +86,7 @@ proc =(a:[],b:[]): in chpl__bulkTransferArray
 proc =(a:[],b:[]): attempting doiBulkTransferToKnown
 proc =(a:[],b:[]): in chpl__bulkTransferArray
 proc =(a:[],b:[]): attempting doiBulkTransferFromKnown
-isDataContiguous(): origin=0 off=(1, 1) blk=(10, 1)
+isDataContiguous(): off=(1, 1) blk=(10, 1)
 isDataContiguous return False
 Performing complex DefaultRectangular transfer
 Transferring views :{1..10, 1..5} <-- {1..10, 1..5}
@@ -115,7 +115,7 @@ proc =(a:[],b:[]): in chpl__bulkTransferArray
 proc =(a:[],b:[]): attempting doiBulkTransferToKnown
 proc =(a:[],b:[]): in chpl__bulkTransferArray
 proc =(a:[],b:[]): attempting doiBulkTransferFromKnown
-isDataContiguous(): origin=0 off=(1, 1) blk=(10, 1)
+isDataContiguous(): off=(1, 1) blk=(10, 1)
 isDataContiguous return False
 Performing complex DefaultRectangular transfer
 BulkTransferStride: Both arrays on different locale, moving to locale of destination: LOCALE0
@@ -141,7 +141,7 @@ proc =(a:[],b:[]): in chpl__bulkTransferArray
 proc =(a:[],b:[]): attempting doiBulkTransferToKnown
 proc =(a:[],b:[]): in chpl__bulkTransferArray
 proc =(a:[],b:[]): attempting doiBulkTransferFromKnown
-isDataContiguous(): origin=0 off=(1, 1) blk=(10, 1)
+isDataContiguous(): off=(1, 1) blk=(10, 1)
 isDataContiguous return False
 Performing complex DefaultRectangular transfer
 BulkTransferStride: Both arrays on different locale, moving to locale of destination: LOCALE1


### PR DESCRIPTION
As far as I can tell, it is never set, and always 0.
This patch just replaces uses of it with 0.

Passed full local testing.
Passed gasnet testing.

Reviewed by @daviditen - thanks!
Thanks to @ysahil97 for asking about origin which led me to notice it is unused.