### PR TITLE
Reduce output for unresolved 'init' calls

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -1823,7 +1823,7 @@ void AggregateType::buildDefaultInitializer() {
 
       methods.add(fn);
     } else {
-      fieldToArg(fn, names, fieldArgMap);
+      USR_FATAL(this, "Unable to generate initializer for type '%s'", this->symbol->name);
     }
 
   }

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -1885,6 +1885,7 @@ const char* astrSdot = NULL;
 const char* astrSequals = NULL;
 const char* astr_cast = NULL;
 const char* astrInit = NULL;
+const char* astrNew = NULL;
 const char* astrDeinit = NULL;
 const char* astrTag = NULL;
 const char* astrThis = NULL;
@@ -1895,6 +1896,7 @@ void initAstrConsts() {
   astrSequals = astr("=");
   astr_cast   = astr("_cast");
   astrInit    = astr("init");
+  astrNew     = astr("_new");
   astrDeinit  = astr("deinit");
   astrTag     = astr("tag");
   astrThis    = astr("this");

--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -276,4 +276,8 @@ Type* getInstantiationType(Type* actualType, Type* formalType);
 
 void resolveIfExprType(CondStmt* stmt);
 
+void trimVisibleCandidates(CallInfo& call,
+                           Vec<FnSymbol*>& mostApplicable,
+                           Vec<FnSymbol*>& visibleFns);
+
 #endif

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -656,6 +656,7 @@ extern const char* astrSdot;
 extern const char* astrSequals;
 extern const char* astr_cast;
 extern const char* astrInit;
+extern const char* astrNew;
 extern const char* astrDeinit;
 extern const char* astrTag;
 extern const char* astrThis;

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -2725,13 +2725,13 @@ void trimVisibleCandidates(CallInfo&       info,
   CallExpr* call = info.call;
 
   bool isInit = false;
-  if (call->numActuals() >= 2 && call->isNamed("init")) {
+  if (call->numActuals() >= 2 && call->isNamedAstr(astrInit)) {
     if (SymExpr* se = toSymExpr(call->get(1))) {
       isInit = se->symbol() == gMethodToken;
     }
   }
 
-  bool isNew = call->numActuals() >= 1 && call->isNamed("_new");
+  bool isNew = call->numActuals() >= 1 && call->isNamedAstr(astrNew);
 
   if (isInit == false && isNew == false) {
     mostApplicable = visibleFns;

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -2113,7 +2113,7 @@ static bool isGenericRecordInit(CallExpr* call) {
 }
 
 static FnSymbol* resolveNormalCall(CallInfo& info, bool checkOnly) {
-  Vec<FnSymbol*>            visibleFns;
+  Vec<FnSymbol*>            mostApplicable;
   Vec<ResolutionCandidate*> candidates;
 
   ResolutionCandidate*      bestRef    = NULL;
@@ -2124,7 +2124,7 @@ static FnSymbol* resolveNormalCall(CallInfo& info, bool checkOnly) {
 
   FnSymbol*                 retval     = NULL;
 
-  findVisibleFunctionsAndCandidates(info, visibleFns, candidates);
+  findVisibleFunctionsAndCandidates(info, mostApplicable, candidates);
 
   numMatches = disambiguateByMatch(info,
                                    candidates,
@@ -2140,7 +2140,7 @@ static FnSymbol* resolveNormalCall(CallInfo& info, bool checkOnly) {
           tryFailure = true;
 
         } else if (candidates.n == 0) {
-          printResolutionErrorUnresolved(info, visibleFns);
+          printResolutionErrorUnresolved(info, mostApplicable);
 
         } else {
           printResolutionErrorAmbiguous (info, candidates);
@@ -2719,12 +2719,60 @@ static bool typeUsesForwarding(Type* t);
 
 static bool populateForwardingMethods(CallInfo& info);
 
+void trimVisibleCandidates(CallInfo&       info,
+                           Vec<FnSymbol*>& mostApplicable,
+                           Vec<FnSymbol*>& visibleFns) {
+  CallExpr* call = info.call;
+
+  bool isInit = false;
+  if (call->numActuals() >= 2 && call->isNamed("init")) {
+    if (SymExpr* se = toSymExpr(call->get(1))) {
+      isInit = se->symbol() == gMethodToken;
+    }
+  }
+
+  bool isNew = call->numActuals() >= 1 && call->isNamed("_new");
+
+  if (isInit == false && isNew == false) {
+    mostApplicable = visibleFns;
+  } else {
+    forv_Vec(FnSymbol, fn, visibleFns) {
+      bool shouldKeep = true;
+      BaseAST* actual = NULL;
+      BaseAST* formal = NULL;
+
+      if (isInit && fn->isInitializer()) {
+        actual = call->get(2);
+        formal = fn->_this;
+      } else if (isNew && (fn->hasFlag(FLAG_NEW_WRAPPER) || fn->isInitializer())) {
+        actual = call->get(1);
+        formal = toDefExpr(fn->formals.head)->sym;
+      }
+
+      if (actual != NULL && formal != NULL) {
+        AggregateType* actualType = toAggregateType(actual->getValType())->getRootInstantiation();
+        AggregateType* formalType = toAggregateType(formal->getValType())->getRootInstantiation();
+        if (actualType != formalType) {
+          shouldKeep = false;
+        }
+      } else {
+        shouldKeep = false;
+      }
+
+      if (shouldKeep) {
+        mostApplicable.add(fn);
+      }
+    }
+  }
+}
+
 static void findVisibleFunctionsAndCandidates(
                                 CallInfo&                  info,
-                                Vec<FnSymbol*>&            visibleFns,
+                                Vec<FnSymbol*>&            mostApplicable,
                                 Vec<ResolutionCandidate*>& candidates) {
   CallExpr* call = info.call;
   FnSymbol* fn   = call->resolvedFunction();
+  Vec<FnSymbol*> visibleFns;
 
   // First, try finding candidates without forwarding
   if (fn != NULL) {
@@ -2736,7 +2784,9 @@ static void findVisibleFunctionsAndCandidates(
     findVisibleFunctions(info, visibleFns);
   }
 
-  findVisibleCandidates(info, visibleFns, candidates);
+  trimVisibleCandidates(info, mostApplicable, visibleFns);
+
+  findVisibleCandidates(info, mostApplicable, candidates);
 
   // If no candidates were found and it's a method, try forwarding
   if (candidates.n             == 0 &&
@@ -2748,6 +2798,7 @@ static void findVisibleFunctionsAndCandidates(
     if (typeUsesForwarding(receiverType) == true &&
         populateForwardingMethods(info)  == true) {
       visibleFns.clear();
+      mostApplicable.clear();
 
       forv_Vec(ResolutionCandidate*, candidate, candidates) {
         delete candidate;
@@ -2763,6 +2814,8 @@ static void findVisibleFunctionsAndCandidates(
       } else {
         findVisibleFunctions(info, visibleFns);
       }
+
+      trimVisibleCandidates(info, mostApplicable, visibleFns);
 
       findVisibleCandidates(info, visibleFns, candidates);
     }

--- a/compiler/resolution/initializerResolution.cpp
+++ b/compiler/resolution/initializerResolution.cpp
@@ -117,13 +117,15 @@ static void resolveInitCall(CallExpr* call) {
   }
 
   if (info.isWellFormed(call) == true) {
-    Vec<FnSymbol*>            visibleFns;
+    Vec<FnSymbol*>            visibleFns, mostApplicable;
     Vec<ResolutionCandidate*> candidates;
     ResolutionCandidate*      best        = NULL;
 
     findVisibleFunctions(info, visibleFns);
 
-    gatherInitCandidates(info, visibleFns, candidates);
+    trimVisibleCandidates(info, mostApplicable, visibleFns);
+
+    gatherInitCandidates(info, mostApplicable, candidates);
 
     explainGatherCandidate(info, candidates);
 
@@ -132,7 +134,7 @@ static void resolveInitCall(CallExpr* call) {
     if (best == NULL) {
       if (call->partialTag == false) {
         if (candidates.n == 0) {
-          printResolutionErrorUnresolved(info, visibleFns);
+          printResolutionErrorUnresolved(info, mostApplicable);
         } else {
           printResolutionErrorAmbiguous (info, candidates);
         }

--- a/test/classes/initializers/compilerGenerated/arrayField-compInit.bad
+++ b/test/classes/initializers/compilerGenerated/arrayField-compInit.bad
@@ -1,3 +1,2 @@
 arrayField-compInit.chpl:14: error: unresolved call '_new(type C, [BlockDom(1,int(64),false,unmanaged DefaultDist)] real(64))'
 arrayField-compInit.chpl:3: note: candidates are: _new(type chpl_t, X: [domain(1,int(64),false)] real(64))
-(prediff deleted module lines)

--- a/test/classes/initializers/compilerGenerated/arrayField-compInit.prediff
+++ b/test/classes/initializers/compilerGenerated/arrayField-compInit.prediff
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-output=$2
-cat $output | sed '/^\$CHPL_HOME\/modules\// d' > $output.tmp
-echo "(prediff deleted module lines)" >> $output.tmp
-mv $output.tmp $output

--- a/test/classes/initializers/compilerGenerated/dflt-ctor-generic-uninit-field-const-err-1.good
+++ b/test/classes/initializers/compilerGenerated/dflt-ctor-generic-uninit-field-const-err-1.good
@@ -1,3 +1,2 @@
 dflt-ctor-generic-uninit-field-const-err-1.chpl:7: error: unresolved call 'A.init()'
 dflt-ctor-generic-uninit-field-const-err-1.chpl:3: note: candidates are: A.init(c)
-deleted module lines

--- a/test/classes/initializers/compilerGenerated/dflt-ctor-generic-uninit-field-const-err-1.prediff
+++ b/test/classes/initializers/compilerGenerated/dflt-ctor-generic-uninit-field-const-err-1.prediff
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-output=$2
-cat $output | sed '/^\$CHPL_HOME\/modules\// d' > $output.tmp
-echo "deleted module lines" >> $output.tmp
-mv $output.tmp $output

--- a/test/classes/initializers/compilerGenerated/dflt-ctor-generic-uninit-field-param-err-1.good
+++ b/test/classes/initializers/compilerGenerated/dflt-ctor-generic-uninit-field-param-err-1.good
@@ -1,3 +1,2 @@
 dflt-ctor-generic-uninit-field-param-err-1.chpl:7: error: unresolved call 'A.init()'
 dflt-ctor-generic-uninit-field-param-err-1.chpl:3: note: candidates are: A.init(param p)
-deleted module lines

--- a/test/classes/initializers/compilerGenerated/dflt-ctor-generic-uninit-field-param-err-1.prediff
+++ b/test/classes/initializers/compilerGenerated/dflt-ctor-generic-uninit-field-param-err-1.prediff
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-output=$2
-cat $output | sed '/^\$CHPL_HOME\/modules\// d' > $output.tmp
-echo "deleted module lines" >> $output.tmp
-mv $output.tmp $output

--- a/test/classes/initializers/compilerGenerated/dflt-ctor-generic-uninit-field-type-err-1.good
+++ b/test/classes/initializers/compilerGenerated/dflt-ctor-generic-uninit-field-type-err-1.good
@@ -1,3 +1,2 @@
 dflt-ctor-generic-uninit-field-type-err-1.chpl:7: error: unresolved call 'A.init()'
 dflt-ctor-generic-uninit-field-type-err-1.chpl:3: note: candidates are: A.init(type t)
-deleted module lines

--- a/test/classes/initializers/compilerGenerated/dflt-ctor-generic-uninit-field-type-err-1.prediff
+++ b/test/classes/initializers/compilerGenerated/dflt-ctor-generic-uninit-field-type-err-1.prediff
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-output=$2
-cat $output | sed '/^\$CHPL_HOME\/modules\// d' > $output.tmp
-echo "deleted module lines" >> $output.tmp
-mv $output.tmp $output

--- a/test/classes/initializers/compilerGenerated/dflt-ctor-generic-uninit-field-var-err-1.good
+++ b/test/classes/initializers/compilerGenerated/dflt-ctor-generic-uninit-field-var-err-1.good
@@ -1,3 +1,2 @@
 dflt-ctor-generic-uninit-field-var-err-1.chpl:7: error: unresolved call 'A.init()'
 dflt-ctor-generic-uninit-field-var-err-1.chpl:3: note: candidates are: A.init(v)
-deleted module lines

--- a/test/classes/initializers/compilerGenerated/dflt-ctor-generic-uninit-field-var-err-1.prediff
+++ b/test/classes/initializers/compilerGenerated/dflt-ctor-generic-uninit-field-var-err-1.prediff
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-output=$2
-cat $output | sed '/^\$CHPL_HOME\/modules\// d' > $output.tmp
-echo "deleted module lines" >> $output.tmp
-mv $output.tmp $output

--- a/test/classes/initializers/compilerGenerated/generics/withParamTypeNoDefNoArgsInCall.good
+++ b/test/classes/initializers/compilerGenerated/generics/withParamTypeNoDefNoArgsInCall.good
@@ -1,3 +1,2 @@
 withParamTypeNoDefNoArgsInCall.chpl:5: error: unresolved call 'Foo.init()'
 withParamTypeNoDefNoArgsInCall.chpl:1: note: candidates are: Foo.init(param p: bool)
-deleted module lines

--- a/test/classes/initializers/compilerGenerated/generics/withParamTypeNoDefNoArgsInCall.prediff
+++ b/test/classes/initializers/compilerGenerated/generics/withParamTypeNoDefNoArgsInCall.prediff
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-output=$2
-cat $output | sed '/^\$CHPL_HOME\/modules\// d' > $output.tmp
-echo "deleted module lines" >> $output.tmp
-mv $output.tmp $output

--- a/test/classes/initializers/compilerGenerated/inherits_initializer_bad.good
+++ b/test/classes/initializers/compilerGenerated/inherits_initializer_bad.good
@@ -1,5 +1,3 @@
 inherits_initializer_bad.chpl:20: In function 'main':
 inherits_initializer_bad.chpl:21: error: unresolved call 'Parent.init()'
 inherits_initializer_bad.chpl:10: note: candidates are: Parent.init(x1: int, x2: int)
-inherits_initializer_bad.chpl:16: note:                 Child.init(b: int(64))
-deleted module lines

--- a/test/classes/initializers/compilerGenerated/inherits_initializer_bad.prediff
+++ b/test/classes/initializers/compilerGenerated/inherits_initializer_bad.prediff
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-output=$2
-cat $output | sed '/^\$CHPL_HOME\/modules\// d' > $output.tmp
-echo "deleted module lines" >> $output.tmp
-mv $output.tmp $output

--- a/test/classes/initializers/compilerGenerated/parent_inherits_initializer_bad.good
+++ b/test/classes/initializers/compilerGenerated/parent_inherits_initializer_bad.good
@@ -1,6 +1,3 @@
 parent_inherits_initializer_bad.chpl:24: In function 'main':
 parent_inherits_initializer_bad.chpl:25: error: unresolved call 'GrandParent.init()'
 parent_inherits_initializer_bad.chpl:10: note: candidates are: GrandParent.init(x1: int, x2: int)
-parent_inherits_initializer_bad.chpl:16: note:                 Parent.init(b: int(64))
-parent_inherits_initializer_bad.chpl:20: note:                 Child.init(b: int(64), c: int(64))
-deleted module lines

--- a/test/classes/initializers/compilerGenerated/parent_inherits_initializer_bad.prediff
+++ b/test/classes/initializers/compilerGenerated/parent_inherits_initializer_bad.prediff
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-output=$2
-cat $output | sed '/^\$CHPL_HOME\/modules\// d' > $output.tmp
-echo "deleted module lines" >> $output.tmp
-mv $output.tmp $output

--- a/test/classes/initializers/compilerGenerated/pragmaOnly/dflt-ctor-generic-uninit-field-const-err-1.good
+++ b/test/classes/initializers/compilerGenerated/pragmaOnly/dflt-ctor-generic-uninit-field-const-err-1.good
@@ -1,3 +1,2 @@
 dflt-ctor-generic-uninit-field-const-err-1.chpl:8: error: unresolved call 'A.init()'
 dflt-ctor-generic-uninit-field-const-err-1.chpl:4: note: candidates are: A.init(c)
-deleted module lines

--- a/test/classes/initializers/compilerGenerated/pragmaOnly/dflt-ctor-generic-uninit-field-const-err-1.prediff
+++ b/test/classes/initializers/compilerGenerated/pragmaOnly/dflt-ctor-generic-uninit-field-const-err-1.prediff
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-output=$2
-cat $output | sed '/^\$CHPL_HOME\/modules\// d' > $output.tmp
-echo "deleted module lines" >> $output.tmp
-mv $output.tmp $output

--- a/test/classes/initializers/compilerGenerated/pragmaOnly/dflt-ctor-generic-uninit-field-param-err-1.good
+++ b/test/classes/initializers/compilerGenerated/pragmaOnly/dflt-ctor-generic-uninit-field-param-err-1.good
@@ -1,3 +1,2 @@
 dflt-ctor-generic-uninit-field-param-err-1.chpl:8: error: unresolved call 'A.init()'
 dflt-ctor-generic-uninit-field-param-err-1.chpl:4: note: candidates are: A.init(param p)
-deleted module lines

--- a/test/classes/initializers/compilerGenerated/pragmaOnly/dflt-ctor-generic-uninit-field-param-err-1.prediff
+++ b/test/classes/initializers/compilerGenerated/pragmaOnly/dflt-ctor-generic-uninit-field-param-err-1.prediff
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-output=$2
-cat $output | sed '/^\$CHPL_HOME\/modules\// d' > $output.tmp
-echo "deleted module lines" >> $output.tmp
-mv $output.tmp $output

--- a/test/classes/initializers/compilerGenerated/pragmaOnly/dflt-ctor-generic-uninit-field-type-err-1.good
+++ b/test/classes/initializers/compilerGenerated/pragmaOnly/dflt-ctor-generic-uninit-field-type-err-1.good
@@ -1,3 +1,2 @@
 dflt-ctor-generic-uninit-field-type-err-1.chpl:8: error: unresolved call 'A.init()'
 dflt-ctor-generic-uninit-field-type-err-1.chpl:4: note: candidates are: A.init(type t)
-deleted module lines

--- a/test/classes/initializers/compilerGenerated/pragmaOnly/dflt-ctor-generic-uninit-field-type-err-1.prediff
+++ b/test/classes/initializers/compilerGenerated/pragmaOnly/dflt-ctor-generic-uninit-field-type-err-1.prediff
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-output=$2
-cat $output | sed '/^\$CHPL_HOME\/modules\// d' > $output.tmp
-echo "deleted module lines" >> $output.tmp
-mv $output.tmp $output

--- a/test/classes/initializers/compilerGenerated/pragmaOnly/dflt-ctor-generic-uninit-field-var-err-1.good
+++ b/test/classes/initializers/compilerGenerated/pragmaOnly/dflt-ctor-generic-uninit-field-var-err-1.good
@@ -1,3 +1,2 @@
 dflt-ctor-generic-uninit-field-var-err-1.chpl:8: error: unresolved call 'A.init()'
 dflt-ctor-generic-uninit-field-var-err-1.chpl:4: note: candidates are: A.init(v)
-deleted module lines

--- a/test/classes/initializers/compilerGenerated/pragmaOnly/dflt-ctor-generic-uninit-field-var-err-1.prediff
+++ b/test/classes/initializers/compilerGenerated/pragmaOnly/dflt-ctor-generic-uninit-field-var-err-1.prediff
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-output=$2
-cat $output | sed '/^\$CHPL_HOME\/modules\// d' > $output.tmp
-echo "deleted module lines" >> $output.tmp
-mv $output.tmp $output

--- a/test/classes/initializers/compilerGenerated/pragmaOnly/inherits_initializer_bad.good
+++ b/test/classes/initializers/compilerGenerated/pragmaOnly/inherits_initializer_bad.good
@@ -1,5 +1,3 @@
 inherits_initializer_bad.chpl:21: In function 'main':
 inherits_initializer_bad.chpl:22: error: unresolved call 'Parent.init()'
 inherits_initializer_bad.chpl:10: note: candidates are: Parent.init(x1: int, x2: int)
-inherits_initializer_bad.chpl:17: note:                 Child.init(b: int(64))
-deleted module lines

--- a/test/classes/initializers/compilerGenerated/pragmaOnly/inherits_initializer_bad.prediff
+++ b/test/classes/initializers/compilerGenerated/pragmaOnly/inherits_initializer_bad.prediff
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-output=$2
-cat $output | sed '/^\$CHPL_HOME\/modules\// d' > $output.tmp
-echo "deleted module lines" >> $output.tmp
-mv $output.tmp $output

--- a/test/classes/initializers/compilerGenerated/pragmaOnly/parent_inherits_default4.good
+++ b/test/classes/initializers/compilerGenerated/pragmaOnly/parent_inherits_default4.good
@@ -1,4 +1,1 @@
-parent_inherits_default4.chpl:18: In function 'main':
-parent_inherits_default4.chpl:19: error: unresolved call '_new(type Child, 4, 2, 1)'
-parent_inherits_default4.chpl:5: note: candidates are: _new(type chpl_t, a: int(64))
-deleted module lines
+parent_inherits_default4.chpl:14: error: Unable to generate initializer for type 'Child'

--- a/test/classes/initializers/compilerGenerated/pragmaOnly/parent_inherits_default4.prediff
+++ b/test/classes/initializers/compilerGenerated/pragmaOnly/parent_inherits_default4.prediff
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-output=$2
-cat $output | sed '/^\$CHPL_HOME\/modules\// d' > $output.tmp
-echo "deleted module lines" >> $output.tmp
-mv $output.tmp $output

--- a/test/classes/initializers/compilerGenerated/pragmaOnly/parent_inherits_initializer_bad.good
+++ b/test/classes/initializers/compilerGenerated/pragmaOnly/parent_inherits_initializer_bad.good
@@ -1,6 +1,3 @@
 parent_inherits_initializer_bad.chpl:25: In function 'main':
 parent_inherits_initializer_bad.chpl:26: error: unresolved call 'GrandParent.init()'
 parent_inherits_initializer_bad.chpl:10: note: candidates are: GrandParent.init(x1: int, x2: int)
-parent_inherits_initializer_bad.chpl:16: note:                 Parent.init(b: int(64))
-parent_inherits_initializer_bad.chpl:21: note:                 Child.init(b: int(64), c: int(64))
-deleted module lines

--- a/test/classes/initializers/compilerGenerated/pragmaOnly/parent_inherits_initializer_bad.prediff
+++ b/test/classes/initializers/compilerGenerated/pragmaOnly/parent_inherits_initializer_bad.prediff
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-output=$2
-cat $output | sed '/^\$CHPL_HOME\/modules\// d' > $output.tmp
-echo "deleted module lines" >> $output.tmp
-mv $output.tmp $output

--- a/test/classes/initializers/generics/declarations/default_value_bad.chpl
+++ b/test/classes/initializers/generics/declarations/default_value_bad.chpl
@@ -3,11 +3,9 @@
 // anything assigned into it.
 class Foo {
   var x;
-  var y;
 
   proc init(xVal = 3) {
     x = xVal;
-    y = xVal + 2;
   }
 }
 

--- a/test/classes/initializers/generics/declarations/default_value_bad.future
+++ b/test/classes/initializers/generics/declarations/default_value_bad.future
@@ -1,5 +1,0 @@
-feature request: new initializer story
-
-This test is not expected to pass until at least part of the initializers story
-is on master.  Make it a future so that Lydia can stay in step with master
-without disrupting testing overly much.

--- a/test/classes/initializers/generics/declarations/default_value_bad.good
+++ b/test/classes/initializers/generics/declarations/default_value_bad.good
@@ -1,3 +1,2 @@
-default_value_bad.chpl:16: error: unresolved call 'Foo.init("blah")'
-default_value_bad.chpl:8: note: candidates are: Foo.init(xVal = 3)
-deleted module lines
+default_value_bad.chpl:13: error: unresolved call 'Foo.init("blah")'
+default_value_bad.chpl:7: note: candidates are: Foo.init(xVal = 3)

--- a/test/classes/initializers/generics/declarations/default_value_bad.prediff
+++ b/test/classes/initializers/generics/declarations/default_value_bad.prediff
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-output=$2
-cat $output | sed '/^\$CHPL_HOME\/modules\// d' > $output.tmp
-echo "deleted module lines" >> $output.tmp
-mv $output.tmp $output

--- a/test/classes/initializers/inheritance/constructorParent.good
+++ b/test/classes/initializers/inheritance/constructorParent.good
@@ -1,4 +1,2 @@
 constructorParent.chpl:12: In initializer:
 constructorParent.chpl:13: error: unresolved call 'Parent.init(13)'
-constructorParent.chpl:12: note: candidates are: Child.init(yVal)
-deleted module lines

--- a/test/classes/initializers/inheritance/constructorParent.prediff
+++ b/test/classes/initializers/inheritance/constructorParent.prediff
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-output=$2
-cat $output | sed '/^\$CHPL_HOME\/modules\// d' > $output.tmp
-echo "deleted module lines" >> $output.tmp
-mv $output.tmp $output

--- a/test/classes/initializers/inheritance/inheritedInitWrongName.good
+++ b/test/classes/initializers/inheritance/inheritedInitWrongName.good
@@ -1,3 +1,2 @@
 inheritedInitWrongName.chpl:20: error: unresolved call '_new(type D, x=3, "hi", 4.6)'
-inheritedInitWrongName.chpl:1: note: candidates are: _new(type chpl_t, x, y, z)
-inheritedInitWrongName.chpl:14: note:                 _new(type chpl_t, a, b, c)
+inheritedInitWrongName.chpl:14: note: candidates are: _new(type chpl_t, a, b, c)

--- a/test/classes/initializers/inheritance/inheritedInitWrongName.good
+++ b/test/classes/initializers/inheritance/inheritedInitWrongName.good
@@ -1,4 +1,3 @@
 inheritedInitWrongName.chpl:20: error: unresolved call '_new(type D, x=3, "hi", 4.6)'
 inheritedInitWrongName.chpl:1: note: candidates are: _new(type chpl_t, x, y, z)
 inheritedInitWrongName.chpl:14: note:                 _new(type chpl_t, a, b, c)
-deleted module lines

--- a/test/classes/initializers/inheritance/inheritedInitWrongName.prediff
+++ b/test/classes/initializers/inheritance/inheritedInitWrongName.prediff
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-output=$2
-cat $output | sed '/^\$CHPL_HOME\/modules\// d' > $output.tmp
-echo "deleted module lines" >> $output.tmp
-mv $output.tmp $output

--- a/test/classes/initializers/promotion/copyInitLookalike.good
+++ b/test/classes/initializers/promotion/copyInitLookalike.good
@@ -3,4 +3,3 @@ copyInitLookalike.chpl:43: error: unresolved call 'C.init(C(real(64)))'
 copyInitLookalike.chpl:14: note: candidates are: C.init(x: int)
 copyInitLookalike.chpl:20: note:                 C.init(r: real)
 copyInitLookalike.chpl:26: note:                 C.init(other: C(int))
-(prediff deleted module lines)

--- a/test/classes/initializers/promotion/copyInitLookalike.prediff
+++ b/test/classes/initializers/promotion/copyInitLookalike.prediff
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-output=$2
-cat $output | sed '/^\$CHPL_HOME\/modules\// d' > $output.tmp
-echo "(prediff deleted module lines)" >> $output.tmp
-mv $output.tmp $output

--- a/test/classes/initializers/records/declaration.good
+++ b/test/classes/initializers/records/declaration.good
@@ -1,4 +1,3 @@
 declaration.chpl:11: error: unresolved call 'Foo.init()'
 declaration.chpl:6: note: candidates are: Foo.init(xVal)
 declaration.chpl:3: note:                 Foo.init(other: Foo)
-deleted module lines

--- a/test/classes/initializers/records/declaration.prediff
+++ b/test/classes/initializers/records/declaration.prediff
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-output=$2
-cat $output | sed '/^\$CHPL_HOME\/modules\// d' > $output.tmp
-echo "deleted module lines" >> $output.tmp
-mv $output.tmp $output

--- a/test/classes/initializers/records/declaration2.good
+++ b/test/classes/initializers/records/declaration2.good
@@ -1,4 +1,3 @@
 declaration2.chpl:11: error: unresolved call 'Foo.init()'
 declaration2.chpl:6: note: candidates are: Foo.init(xVal: int)
 declaration2.chpl:3: note:                 Foo.init(other: Foo)
-deleted module lines

--- a/test/classes/initializers/records/declaration2.prediff
+++ b/test/classes/initializers/records/declaration2.prediff
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-output=$2
-cat $output | sed '/^\$CHPL_HOME\/modules\// d' > $output.tmp
-echo "deleted module lines" >> $output.tmp
-mv $output.tmp $output

--- a/test/classes/initializers/records/where-clause4.good
+++ b/test/classes/initializers/records/where-clause4.good
@@ -1,4 +1,3 @@
 where-clause4.chpl:11: error: unresolved call 'Foo.init(3.4)'
 where-clause4.chpl:5: note: candidates are: Foo.init(xVal)
 where-clause4.chpl:2: note:                 Foo.init(other: Foo)
-deleted module lines

--- a/test/classes/initializers/records/where-clause4.prediff
+++ b/test/classes/initializers/records/where-clause4.prediff
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-output=$2
-cat $output | sed '/^\$CHPL_HOME\/modules\// d' > $output.tmp
-echo "deleted module lines" >> $output.tmp
-mv $output.tmp $output

--- a/test/classes/initializers/where-clause4.good
+++ b/test/classes/initializers/where-clause4.good
@@ -1,3 +1,2 @@
 where-clause4.chpl:12: error: unresolved call '_new(type Foo, 3.4)'
 where-clause4.chpl:2: note: candidates are: _new(type chpl_t, xVal)
-(prediff deleted module lines)

--- a/test/classes/initializers/where-clause4.prediff
+++ b/test/classes/initializers/where-clause4.prediff
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-output=$2
-cat $output | sed '/^\$CHPL_HOME\/modules\// d' > $output.tmp
-echo "(prediff deleted module lines)" >> $output.tmp
-mv $output.tmp $output


### PR DESCRIPTION
This PR introduces a new function, ``trimVisibleCandidates``, to the process of resolving calls. This function accepts list of FnSymbols and populates a list with the most applicable FnSymbols for the given call. This function currently only works for 'init' and '_new' calls, but could conceivably be expanded to support any method.

The core approach is to only accept init functions whose 'this' type is instantiated from the same generic type as the corresponding actual. Regular candidate-filtering will find the best match, if one exists.

If no such match exists, then the most applicable FnSymbols will be display to the user, instead of every single initializer in the program.

As a result, many prediffs can be removed from the testing system.

Testing:
- [x] local + futures
- [x] gasnet