### PR TITLE
Retire .futures for generic records and _defaultOf

### DIFF
--- a/test/functions/lydia/userDefinedDefaultFunction/redefine-param-record.future
+++ b/test/functions/lydia/userDefinedDefaultFunction/redefine-param-record.future
@@ -1,1 +1,0 @@
-feature request: noinit support for initializers

--- a/test/functions/lydia/userDefinedDefaultFunction/redefine-type-record.future
+++ b/test/functions/lydia/userDefinedDefaultFunction/redefine-type-record.future
@@ -1,1 +1,0 @@
-feature request: noinit support for initializers


### PR DESCRIPTION
_defaultOf happens to be triggered for generic records at this time so remove these futures.