### PR TITLE
Specialize/optimize non-fetching network atomics

### DIFF
--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -1487,6 +1487,8 @@ static void      do_nic_get(void*, c_nodeid_t, mem_region_t*,
 static int       amo_cmd_2_nic_op(fork_amo_cmd_t, int);
 static void      do_nic_amo(void*, void*, c_nodeid_t, void*, size_t,
                             gni_fma_cmd_type_t, void*, mem_region_t*);
+static void      do_nic_amo_nf(void*, void*, c_nodeid_t, void*, size_t,
+                               gni_fma_cmd_type_t, void*, mem_region_t*);
 static void      amo_add_real32_cpu_cmpxchg(void*, void*, void*);
 static void      amo_add_real64_cpu_cmpxchg(void*, void*, void*);
 static void      fork_call_common(int, c_sublocid_t,
@@ -6473,8 +6475,8 @@ DEFINE_CHPL_COMM_ATOMIC_CMPXCHG(real64, cmpxchg_64, int_least64_t)
               do_fork_amo_##_c##_##_f(obj, NULL, opnd, NULL, loc);      \
           }                                                             \
           else {                                                        \
-            do_nic_amo(opnd, NULL, loc, obj, sizeof(_t),                \
-                       amo_cmd_2_nic_op(_c, 0), NULL, remote_mr);       \
+            do_nic_amo_nf(opnd, NULL, loc, obj, sizeof(_t),             \
+                          amo_cmd_2_nic_op(_c, 0), NULL, remote_mr);    \
           }                                                             \
         }                                                               \
                                                                         \
@@ -6569,8 +6571,8 @@ DEFINE_CHPL_COMM_ATOMIC_INT_OP(uint64, add, add_i64, uint_least64_t)
           if (sizeof(_t) == sizeof(int_least32_t)                       \
               && nic_type == GNI_DEVICE_ARIES                           \
               && (remote_mr = mreg_for_remote_addr(obj, loc)) != NULL) {\
-            do_nic_amo(opnd, NULL, loc, obj, sizeof(_t),                \
-                       amo_cmd_2_nic_op(_c, 0), NULL, remote_mr);       \
+            do_nic_amo_nf(opnd, NULL, loc, obj, sizeof(_t),             \
+                          amo_cmd_2_nic_op(_c, 0), NULL, remote_mr);    \
           }                                                             \
           else {                                                        \
             if (loc == chpl_nodeID)                                     \
@@ -6688,6 +6690,97 @@ int amo_cmd_2_nic_op(fork_amo_cmd_t cmd, int fetching)
     CHPL_INTERNAL_ERROR("amo_cmd_2_nic_op(): unexpected AMO cmd");
 
   return nic_cmd;
+}
+
+
+static
+void do_nic_amo_nf(void* opnd1, void* opnd2, c_nodeid_t locale,
+                   void* object, size_t size,
+                   gni_fma_cmd_type_t cmd, void* result,
+                   mem_region_t* remote_mr)
+{
+  mem_region_t*         local_mr;
+  void*                 p_result = result;
+  fork_amo_data_t       tmp_result;
+  gni_post_descriptor_t post_desc;
+
+  if (size == 4) {
+    if (!IS_ALIGNED_32(VP_TO_UI64(object)))
+      CHPL_INTERNAL_ERROR("remote AMO object must be 4-byte aligned");
+  }
+  else if (size == 8) {
+    if (!IS_ALIGNED_64(VP_TO_UI64(object)))
+      CHPL_INTERNAL_ERROR("remote AMO object must be 8-byte aligned");
+  }
+  else
+    CHPL_INTERNAL_ERROR("unexpected AMO size");
+
+  //
+  // Make sure that, if we need a result, it is in memory known to the
+  // NIC.
+  //
+  if (result == NULL)
+    local_mr = NULL;
+  else {
+    local_mr = mreg_for_local_addr(p_result);
+    if (local_mr == NULL) {
+      p_result = &tmp_result;
+      local_mr = mreg_for_local_addr(p_result);
+      if (local_mr == NULL) {
+        p_result = amo_res_alloc();
+        local_mr = gnr_mreg;
+        if (local_mr == NULL)
+          CHPL_INTERNAL_ERROR("do_nic_amo(): "
+                              "result address is not NIC-registered");
+      }
+    }
+  }
+
+  if (remote_mr == NULL)
+    CHPL_INTERNAL_ERROR("do_nic_amo(): "
+                        "remote address is not NIC-registered");
+
+  //
+  // Fill in the POST descriptor.
+  //
+  post_desc.type            = GNI_POST_AMO;
+  post_desc.cq_mode         = GNI_CQMODE_GLOBAL_EVENT;
+  post_desc.dlvr_mode       = GNI_DLVMODE_PERFORMANCE;
+  post_desc.rdma_mode       = 0;
+  post_desc.src_cq_hndl     = 0;
+
+  post_desc.local_addr      = (uint64_t) (intptr_t) p_result;
+  if (p_result != NULL)
+    post_desc.local_mem_hndl = local_mr->mdh;
+  post_desc.remote_addr     = (uint64_t) (intptr_t) object;
+  post_desc.remote_mem_hndl = remote_mr->mdh;
+  post_desc.length          = size;
+
+  post_desc.amo_cmd         = cmd;
+
+  if (size == 4) {
+    post_desc.first_operand = *(uint32_t*) opnd1;
+    if (opnd2 != NULL)
+      post_desc.second_operand = *(uint32_t*) opnd2;
+  }
+  else {
+    post_desc.first_operand = *(uint64_t*) opnd1;
+    if (opnd2 != NULL)
+      post_desc.second_operand = *(uint64_t*) opnd2;
+  }
+
+  //
+  // Initiate the transaction and wait for it to complete.
+  //
+  PERFSTATS_INC(amo_cnt);
+
+  post_fma_and_wait(locale, &post_desc, true);
+
+  if (p_result != result) {
+    memcpy(result, p_result, size);
+    if (p_result != &tmp_result)
+      amo_res_free(p_result);
+  }
 }
 
 


### PR DESCRIPTION
This adds a version of `do_nic_amo()` that's optimized for non-fetching
atomics. Compared to the fetching version, `do_nic_amo_nf()` eliminates 5
branches and is small enough to mark it as inline. If the compiler actually
inlines, it should be able to fold away sizeof branches as well.

I don't expect to see any noticeable performance improvements for things like
many-to-one-amo or RA-atomics. They do the same atomic operation in a pretty
tight loop, so all of these branches are probably correctly predicted. Still,
this seems worthwhile and I suspect we'll want to further specialize the
non-fetching case even more in the future.