### PR TITLE
Optimize non-fetching network atomics by yielding less while waiting for ACK

### DIFF
--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -1509,6 +1509,8 @@ static chpl_bool reacquire_comm_dom(int);
 static int       post_fma(c_nodeid_t, gni_post_descriptor_t*);
 static void      post_fma_and_wait(c_nodeid_t, gni_post_descriptor_t*,
                                    chpl_bool);
+static void      post_fma_and_wait_amo(c_nodeid_t, gni_post_descriptor_t*,
+                                       chpl_bool);
 #if HAVE_GNI_FMA_CHAIN_TRANSACTIONS
 static int       post_fma_ct(c_nodeid_t*, gni_post_descriptor_t*);
 static void      post_fma_ct_and_wait(c_nodeid_t*, gni_post_descriptor_t*);
@@ -6744,7 +6746,7 @@ void do_nic_amo_nf(void* opnd1, c_nodeid_t locale,
   //
   PERFSTATS_INC(amo_cnt);
 
-  post_fma_and_wait(locale, &post_desc, true);
+  post_fma_and_wait_amo(locale, &post_desc, true);
 }
 
 
@@ -6829,7 +6831,7 @@ void do_nic_amo(void* opnd1, void* opnd2, c_nodeid_t locale,
   //
   PERFSTATS_INC(amo_cnt);
 
-  post_fma_and_wait(locale, &post_desc, true);
+  post_fma_and_wait_amo(locale, &post_desc, true);
 
   if (p_result != result) {
     memcpy(result, p_result, size);
@@ -7598,6 +7600,33 @@ int post_fma(c_nodeid_t locale, gni_post_descriptor_t* post_desc)
 static
 void post_fma_and_wait(c_nodeid_t locale, gni_post_descriptor_t* post_desc,
                        chpl_bool do_yield)
+{
+  int cdi;
+  atomic_bool post_done;
+
+  atomic_init_bool(&post_done, false);
+  post_desc->post_id = (uint64_t) (intptr_t) &post_done;
+
+  cdi = post_fma(locale, post_desc);
+
+  //
+  // Wait for the transaction to complete.  Yield initially; the
+  // minimum round-trip time on the network isn't small and maybe
+  // we can find something else to do in the meantime.
+  //
+  do {
+    if (do_yield) {
+      local_yield();
+    }
+    consume_all_outstanding_cq_events(cdi);
+  } while (!atomic_load_explicit_bool(&post_done, memory_order_acquire));
+
+  CQ_CNT_DEC(&comm_doms[cdi]);
+}
+
+static
+void post_fma_and_wait_amo(c_nodeid_t locale, gni_post_descriptor_t* post_desc,
+                           chpl_bool do_yield)
 {
   int cdi;
   atomic_bool post_done;

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -1509,8 +1509,7 @@ static chpl_bool reacquire_comm_dom(int);
 static int       post_fma(c_nodeid_t, gni_post_descriptor_t*);
 static void      post_fma_and_wait(c_nodeid_t, gni_post_descriptor_t*,
                                    chpl_bool);
-static void      post_fma_and_wait_amo(c_nodeid_t, gni_post_descriptor_t*,
-                                       chpl_bool);
+static void      post_fma_and_wait_amo(c_nodeid_t, gni_post_descriptor_t*);
 #if HAVE_GNI_FMA_CHAIN_TRANSACTIONS
 static int       post_fma_ct(c_nodeid_t*, gni_post_descriptor_t*);
 static void      post_fma_ct_and_wait(c_nodeid_t*, gni_post_descriptor_t*);
@@ -6746,7 +6745,7 @@ void do_nic_amo_nf(void* opnd1, c_nodeid_t locale,
   //
   PERFSTATS_INC(amo_cnt);
 
-  post_fma_and_wait_amo(locale, &post_desc, true);
+  post_fma_and_wait_amo(locale, &post_desc);
 }
 
 
@@ -6831,7 +6830,7 @@ void do_nic_amo(void* opnd1, void* opnd2, c_nodeid_t locale,
   //
   PERFSTATS_INC(amo_cnt);
 
-  post_fma_and_wait_amo(locale, &post_desc, true);
+  post_fma_and_wait(locale, &post_desc, true);
 
   if (p_result != result) {
     memcpy(result, p_result, size);
@@ -7625,11 +7624,11 @@ void post_fma_and_wait(c_nodeid_t locale, gni_post_descriptor_t* post_desc,
 }
 
 static
-void post_fma_and_wait_amo(c_nodeid_t locale, gni_post_descriptor_t* post_desc,
-                           chpl_bool do_yield)
+void post_fma_and_wait_amo(c_nodeid_t locale, gni_post_descriptor_t* post_desc)
 {
   int cdi;
   atomic_bool post_done;
+  uint64_t iters = 0;
 
   atomic_init_bool(&post_done, false);
   post_desc->post_id = (uint64_t) (intptr_t) &post_done;
@@ -7639,13 +7638,15 @@ void post_fma_and_wait_amo(c_nodeid_t locale, gni_post_descriptor_t* post_desc,
   //
   // Wait for the transaction to complete.  Yield initially; the
   // minimum round-trip time on the network isn't small and maybe
-  // we can find something else to do in the meantime.
+  // we can find something else to do in the meantime.  AMOs are
+  // fast so after initial yield, only yield every 64 attempts.
   //
   do {
-    if (do_yield) {
+    if ((iters & 0x3F) == 0) {
       local_yield();
     }
     consume_all_outstanding_cq_events(cdi);
+    iters++;
   } while (!atomic_load_explicit_bool(&post_done, memory_order_acquire));
 
   CQ_CNT_DEC(&comm_doms[cdi]);


### PR DESCRIPTION
Improve the performance of non-fetching atomics by yielding less frequently
while waiting for a remote ACK.

At the runtime level for a non-fetching network atomics we do something like:

```c
do_nic_amo_nf(void* opnd, c_nodeid_t locale, void* obj) {
  // setup post descriptor
  post_desc.type          = GNI_POST_AMO;
  post_desc.remote_addr   = obj;
  post_desc.first_operand = opnd;
  post_desc.post_id       = &post_done;

  // post to the NIC (initiate the remote operation)
  cdi = post_fma(locale, &post_desc);

  // wait for ACK from remote node
  do {
    chpl_task_yield();                      // yield every iter
    consume_all_outstanding_cq_events(cdi);
  } while(!atomic_load_bool(&post_done))
}
```

Non-fetching network atomics will be extremely fast, and we're really just
waiting for an ACK back. So here we optimize how we wait for that ACK by only
yielding every 64 CQ read attempts instead of after every one. So now we do
something like:

```c
uint64_t iters = 0;
do {
  if ((iters & 0x3F) == 0)                // yield initially, then 1/64 iters
    chpl_task_yield();
  consume_all_outstanding_cq_events(cdi);
  iters++;
} while(!atomic_load_bool(&post_done))
```

Note that we're still yielding initially, but after that we only yield every 64
attempts. I believe this means that a no-op chpl_task_yield takes longer than
we expect and we'll probably want to optimize/investigate that later.

Related to https://github.com/chapel-lang/chapel/issues/9835

This has a pretty significant impact on on non-fetching atomics. This improves
the many-to-one-amo microbenchmark by 15% taking it from from ~210 Mops/s to
~240 Mops/s. This also improves the bale histogram benchmark by ~15%. Lastly,
this improves RA-atomics by 25-35% depending on the node count. At 256 nodes
this takes us from 2 GUPS to 2.7 GUPS:

![ra-perf](https://user-images.githubusercontent.com/1588337/41616050-c7c7a55c-73b1-11e8-9be9-93402c3e6ce4.png)
