### PR TITLE
Add missing chpl-topo.h includes in gasnet and ofi comm layers

### DIFF
--- a/runtime/src/comm/gasnet/comm-gasnet.c
+++ b/runtime/src/comm/gasnet/comm-gasnet.c
@@ -29,6 +29,7 @@
 #include "chpl-mem.h"
 #include "chplsys.h"
 #include "chpl-tasks.h"
+#include "chpl-topo.h"
 #include "chplcgfns.h"
 #include "chpl-gen-includes.h"
 #include "chpl-atomics.h"

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -27,6 +27,7 @@
 #include "chpl-mem-sys.h"
 // #include "chpl-cache.h"
 #include "chpl-tasks.h"
+#include "chpl-topo.h"
 #include "chpl-gen-includes.h"
 #include "chplsys.h"
 #include "chplexit.h"


### PR DESCRIPTION
Missed in https://github.com/chapel-lang/chapel/pull/9862

Resolves https://github.com/chapel-lang/chapel/issues/9888