### PR TITLE
Make 'for' loop in dsiReallocate parallel

### DIFF
--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1210,8 +1210,7 @@ module DefaultRectangular {
                                             stridable=d._value.stridable,
                                             dom=d._value);
 
-        // MPF: could this be parallel?
-        for i in d((...dom.ranges)) do
+        forall i in d((...dom.ranges)) do
           copy.dsiAccess(i) = dsiAccess(i);
         off = copy.off;
         blk = copy.blk;


### PR DESCRIPTION
As noted in JIRA 189 and a comment in the code, our dsiReallocate()
code contained a serial for loop that by all rights should have been
parallel.  The last time I tried to convert it over, I had failures in
testing, but those failures were addressed by @mppf in 5f6c815,
and this seems to be working now, so great!