### PR TITLE
Enable chpldoc to print out override proc

### DIFF
--- a/compiler/AST/FnSymbol.cpp
+++ b/compiler/AST/FnSymbol.cpp
@@ -939,6 +939,10 @@ void FnSymbol::printDocs(std::ostream* file, unsigned int tabs) {
       *file << "export ";
     }
 
+    if (this->hasFlag(FLAG_OVERRIDE)) {
+      *file << "override ";
+    }
+
     // Print iter/proc.
     if (this->isIterator()) {
       *file << "iter ";

--- a/test/chpldoc/classes/override-doc.doc.catfiles
+++ b/test/chpldoc/classes/override-doc.doc.catfiles
@@ -1,0 +1,1 @@
+docs/source/modules/override-doc.doc.rst

--- a/test/chpldoc/classes/override-doc.doc.chpl
+++ b/test/chpldoc/classes/override-doc.doc.chpl
@@ -1,0 +1,11 @@
+class Parent {
+  proc f(arg:int) { }
+  proc g(arg:int(32)) { }
+  proc h(x) { }
+}
+
+class Child : Parent {
+  override proc f(x:int) { }
+  override proc g(arg:int(32)) { }
+  override proc h(x) { }
+}

--- a/test/chpldoc/classes/override-doc.doc.good
+++ b/test/chpldoc/classes/override-doc.doc.good
@@ -1,0 +1,28 @@
+.. default-domain:: chpl
+
+.. module:: override-doc.doc
+
+override-doc.doc
+================
+**Usage**
+
+.. code-block:: chapel
+
+   use override-doc.doc;
+
+.. class:: Parent
+
+   .. method:: proc f(arg: int)
+
+   .. method:: proc g(arg: int(32))
+
+   .. method:: proc h(x)
+
+.. class:: Child : Parent
+
+   .. method:: override proc f(x: int)
+
+   .. method:: override proc g(arg: int(32))
+
+   .. method:: override proc h(x)
+


### PR DESCRIPTION
chpldoc should show `override` when appropriate with method signatures.

- [x] full local testing

Reviewed by @lydia-duncan - thanks!