### PR TITLE
Fix issue with overloaded private function

### DIFF
--- a/compiler/passes/ResolveScope.cpp
+++ b/compiler/passes/ResolveScope.cpp
@@ -403,8 +403,11 @@ bool ResolveScope::extend(Symbol* newSym) {
                 newSym->stringLoc());
     }
 
-    // If oldSym is a constructor and newSym is a type, update with the type
-    if (newFn == NULL || newFn->_this == NULL) {
+    // Prefer storage of non-functions over functions,
+    //                   functions over methods,
+    //                   public functions over private functions
+    if (newFn == NULL || (newFn->_this == NULL &&
+                          newFn->hasFlag(FLAG_PRIVATE) == false)) {
       mBindings[name] = newSym;
     }
 

--- a/test/visibility/private/functions/overloaded.chpl
+++ b/test/visibility/private/functions/overloaded.chpl
@@ -1,0 +1,17 @@
+module A {
+  private proc aproc(x: int) {
+    writeln("private aproc ", x);
+  }
+
+  proc aproc() {
+    writeln("public aproc");
+    aproc(1);
+  }
+}
+
+module B {
+  use A;
+  proc main() {
+    A.aproc();
+  }
+}

--- a/test/visibility/private/functions/overloaded.good
+++ b/test/visibility/private/functions/overloaded.good
@@ -1,0 +1,2 @@
+public aproc
+private aproc 1

--- a/test/visibility/private/functions/overloaded2.chpl
+++ b/test/visibility/private/functions/overloaded2.chpl
@@ -1,0 +1,17 @@
+module A {
+  proc aproc() {
+    writeln("public aproc");
+    aproc(1);
+  }
+
+  private proc aproc(x: int) {
+    writeln("private aproc ", x);
+  }
+}
+
+module B {
+  use A;
+  proc main() {
+    A.aproc();
+  }
+}

--- a/test/visibility/private/functions/overloaded2.good
+++ b/test/visibility/private/functions/overloaded2.good
@@ -1,0 +1,2 @@
+public aproc
+private aproc 1

--- a/test/visibility/private/functions/overloaded3.chpl
+++ b/test/visibility/private/functions/overloaded3.chpl
@@ -1,0 +1,17 @@
+module A {
+  proc aproc() {
+    writeln("public aproc");
+    aproc(1);
+  }
+
+  private proc aproc(x: int) {
+    writeln("private aproc ", x);
+  }
+}
+
+module B {
+  use A;
+  proc main() {
+    aproc();
+  }
+}

--- a/test/visibility/private/functions/overloaded3.good
+++ b/test/visibility/private/functions/overloaded3.good
@@ -1,0 +1,2 @@
+public aproc
+private aproc 1

--- a/test/visibility/private/functions/overloaded4.chpl
+++ b/test/visibility/private/functions/overloaded4.chpl
@@ -1,0 +1,17 @@
+module A {
+  private proc aproc(x: int) {
+    writeln("private aproc ", x);
+  }
+
+  private proc aproc() {
+    writeln("public aproc");
+    aproc(1);
+  }
+}
+
+module B {
+  use A;
+  proc main() {
+    A.aproc();
+  }
+}

--- a/test/visibility/private/functions/overloaded4.good
+++ b/test/visibility/private/functions/overloaded4.good
@@ -1,0 +1,2 @@
+overloaded4.chpl:14: In function 'main':
+overloaded4.chpl:15: error: Cannot access 'aproc', 'aproc' is private to 'A'

--- a/test/visibility/private/functions/symbolResError.chpl
+++ b/test/visibility/private/functions/symbolResError.chpl
@@ -1,0 +1,18 @@
+module A {
+  proc aproc() {
+    writeln("public aproc");
+    aproc(1);
+  }
+
+  private proc aproc(x: int) {
+    writeln(y);
+    writeln("private aproc ", x);
+  }
+}
+
+module B {
+  use A;
+  proc main() {
+    aproc();
+  }
+}

--- a/test/visibility/private/functions/symbolResError.good
+++ b/test/visibility/private/functions/symbolResError.good
@@ -1,0 +1,2 @@
+symbolResError.chpl:7: In function 'aproc':
+symbolResError.chpl:8: error: 'y' undeclared (first use this function)


### PR DESCRIPTION
Resolves #9793 

Depending on its placement in the module and whether it was accessed using a
module prefix or not, we would complain about calling a private function even
if a public function of the same name were available.  This resolves that issue.

It also adds five tests to lock in the new behavior.
Checks:
- module prefix access
  - private function defined first
  - private function defined last
  - all functions are private
- no module prefix access
  - private function defined last
- ensures that the change does not prevent us from finding symbol resolution
  errors.

Passed a full paratest