### PR TITLE
Optimize dsiAccess for new array type

### DIFF
--- a/modules/internal/CPtr.chpl
+++ b/modules/internal/CPtr.chpl
@@ -153,6 +153,10 @@ module CPtr {
     return __primitive("cast", t, x);
   }
   pragma "no doc"
+  inline proc _cast(type t, x) where (t:_ddata && x.type: c_void_ptr) {
+    return __primitive("cast", t, x);
+  }
+  pragma "no doc"
   inline proc _cast(type t, x)
   where (t:c_intptr || t:c_uintptr || t:int(64) || t:uint(64)) &&
         (x.type:c_void_ptr || x.type:c_ptr) {

--- a/modules/internal/ExternalArray.chpl
+++ b/modules/internal/ExternalArray.chpl
@@ -180,6 +180,7 @@ module ExternalArray {
     const dom;
     
     const _ArrInstance: chpl_external_array;
+    const elts = _ArrInstance.elts: _ddata(eltType);
 
     const _owned: bool;
 
@@ -250,19 +251,19 @@ module ExternalArray {
 
     inline proc dsiAccess(i) ref {
       checkBounds(i);
-      return (_ArrInstance.elts: c_ptr(eltType))(i(1));
+      return elts(i(1));
     }
 
     inline proc dsiAccess(i)
       where shouldReturnRvalueByValue(eltType) {
       checkBounds(i);
-      return (_ArrInstance.elts: c_ptr(eltType))(i(1));
+      return elts(i(1));
     }
 
     inline proc dsiAccess(i) const ref
       where shouldReturnRvalueByConstRef(eltType)  {
       checkBounds(i);
-      return (_ArrInstance.elts: c_ptr(eltType))(i(1));
+      return elts(i(1));
     }
 
     inline proc checkBounds(i) {


### PR DESCRIPTION
Save a version of the stored pointer within the chpl_external_array type into
a cast version of itself within the ExternArr class so that we don't have to
cast on every dsiAccess call (which will get very expensive over time).
Suggested by Michael.

This meant that I needed to add the ability to cast between c_void_ptrs and
_ddata.

Testing:
- [x] fresh checkout on export tests
- [x] fifo on export tests
- [x] valgrindexe on export tests
- [x] memleaks on export tests
- [ ] standard paratest (in progress after rebase)