### PR TITLE
Add a function to the HDF5 package to write multiple files in parallel

### DIFF
--- a/modules/packages/HDF5_HL.chpl
+++ b/modules/packages/HDF5_HL.chpl
@@ -3598,35 +3598,89 @@ module HDF5_HL {
 
       type eltType = data.eltType;
 
-      proc getHDF5Type(type eltType) {
-        var hdf5Type: hid_t;
-        select eltType {
-          when int(8)   do hdf5Type = H5T_STD_I8LE;
-          when int(16)  do hdf5Type = H5T_STD_I16LE;
-          when int(32)  do hdf5Type = H5T_STD_I32LE;
-          when int(64)  do hdf5Type = H5T_STD_I64LE;
-          when uint(8)  do hdf5Type = H5T_STD_U8LE;
-          when uint(16) do hdf5Type = H5T_STD_U16LE;
-          when uint(32) do hdf5Type = H5T_STD_U32LE;
-          when uint(64) do hdf5Type = H5T_STD_U64LE;
-          when real(32) do hdf5Type = H5T_IEEE_F32LE;
-          when real(64) do hdf5Type = H5T_IEEE_F64LE;
-
-          when c_string {
-            hdf5Type = H5Tcopy(H5T_C_S1);
-            H5Tset_size(hdf5Type, H5T_VARIABLE);
-          }
-
-          otherwise {
-            halt("Unhandled type in getHDF5Type: ", eltType:string);
-          }
-        }
-        return hdf5Type;
-      }
-
       const hdf5Type = getHDF5Type(eltType);
       H5LTread_dataset(file_id, dsetName.c_str(), hdf5Type, c_ptrTo(data));
     }
+
+    /* Return the HDF5 type equivalent to the Chapel type `eltType` */
+    proc getHDF5Type(type eltType) {
+      var hdf5Type: hid_t;
+      select eltType {
+        when int(8)   do hdf5Type = H5T_STD_I8LE;
+        when int(16)  do hdf5Type = H5T_STD_I16LE;
+        when int(32)  do hdf5Type = H5T_STD_I32LE;
+        when int(64)  do hdf5Type = H5T_STD_I64LE;
+        when uint(8)  do hdf5Type = H5T_STD_U8LE;
+        when uint(16) do hdf5Type = H5T_STD_U16LE;
+        when uint(32) do hdf5Type = H5T_STD_U32LE;
+        when uint(64) do hdf5Type = H5T_STD_U64LE;
+        when real(32) do hdf5Type = H5T_IEEE_F32LE;
+        when real(64) do hdf5Type = H5T_IEEE_F64LE;
+
+        when c_string {
+          hdf5Type = H5Tcopy(H5T_C_S1);
+          H5Tset_size(hdf5Type, H5T_VARIABLE);
+        }
+
+        otherwise {
+          halt("Unhandled type in getHDF5Type: ", eltType:string);
+        }
+      }
+      return hdf5Type;
+    }
+
+    /* Enum indicating the way to open a file for writing.  `Truncate` will
+       clear the contents of an existing file.  `Append` will add to a file
+       that already exists.  Both will open a new empty file.
+     */
+    enum Hdf5OpenMode { Truncate, Append };
+
+    /* Write the arrays from the :record:`ArrayWrapper` records stored in
+       the `data` argument to the corresponding filename in the
+       `filenames` array. The dataset name is taken from the corresponding
+       position in the `dsetNames` array.
+
+       The `data` argument should be a Block distributed array with
+       `dataParTasksPerLocale==1`.
+
+       Either truncate or append to the file depending on the `mode` argument.
+
+       It would be preferable to find the `eltType` and `rank` values
+       directly from the `data` argument instead of needing explicit
+       arguments for them, but it isn't obvious how to do that currently.
+       If the generic fields in the `ArrayWrapper` could be queried that
+       would be a nice replacement for these arguments.  e.g.
+       `data: [] ArrayWrapper(?eltType, ?rank)`.
+     */
+    proc writeArraysToHDF5Files(dirName: string, dsetNames: [] string,
+                                filenames: [] string, type eltType,
+                                param rank: int,
+                                data: [] ArrayWrapper(eltType, rank),
+                                mode: Hdf5OpenMode) throws {
+      use BlockDist, HDF5_WAR, FileSystem;
+
+      // assert(isBlockDistributed(data) &&
+      //        data.<dist>.dataParTasksPerLocale==1);
+
+      forall (arr, dsetName, fname) in zip(data, dsetNames, filenames) {
+        var file_id: hid_t;
+        const filename = dirName + "/" + fname;
+        var fileExists: bool;
+
+        if mode == Hdf5OpenMode.Truncate || !exists(filename) {
+          file_id = H5Fcreate(filename.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+        } else {
+          file_id = H5Fopen(filename.c_str(), H5F_ACC_RDWR, H5P_DEFAULT);
+        }
+        var dims: [0..#rank] hsize_t;
+        for param i in 0..rank-1 {
+          dims[i] = arr.D.dim(i+1).size: hsize_t;
+        }
+        H5LTmake_dataset_WAR(file_id, dsetName.c_str(), rank, c_ptrTo(dims), getHDF5Type(eltType), c_ptrTo(arr.A));
+        H5Fclose(file_id);
+      }
+    }
+
 
     /* A record that stores a rectangular array.  An array of `ArrayWrapper`
        records can store multiple differently sized arrays.

--- a/test/library/packages/HDF5/parallelWriteMultitype.chpl
+++ b/test/library/packages/HDF5/parallelWriteMultitype.chpl
@@ -1,0 +1,68 @@
+use BlockDist, HDF5_HL, FileSystem;
+
+record MyRec {
+  var D: domain(1);
+  var Ar: [D] real;
+  var Ai: [D] int;
+  proc init(n: int, low: int) {
+    D = {1..n};
+    this.complete();
+    for i in 1..n {
+      Ar[i] = low + i/10.0;
+      Ai[i] = low + i/2;
+    }
+  }
+  proc init() {
+    init(0, 0);
+  }
+}
+
+config const nFiles = 5;
+config const cleanupFiles = true;
+
+// This directory will be created and removed. Since it will be removed
+// don't allow setting it via 'config'.
+const hdf5Dir = "hdf5_dir";
+
+proc main {
+  var Space = {1..nFiles};
+  var BlockSpace = Space dmapped Block(Space, Locales, dataParTasksPerLocale=1);
+  var data: [BlockSpace] MyRec;
+
+  // create the directory hdf5Dir
+  if !exists(hdf5Dir) then
+    mkdir(hdf5Dir);
+
+  // create data
+  forall (d, size, low) in zip (data, 100.., 1..) {
+    d = new MyRec(size, low);
+  }
+
+  var filenames: [1..nFiles] string;
+  for i in filenames.domain do filenames[i] = "datafile" + i + ".h5";
+
+  // write data to files
+  {
+    var dsetNames: [1..nFiles] string = "/Ar";
+    var Ars: [BlockSpace] ArrayWrapper(data[1].Ar.eltType, data[1].Ar.rank);
+    forall (ar, d) in zip(Ars, data) {
+      ar = new ArrayWrapper(d.Ar.eltType, d.Ar.rank, d.Ar.domain, d.Ar);
+    }
+    writeArraysToHDF5Files(hdf5Dir, dsetNames, filenames, data[1].Ar.eltType,
+                           data[1].Ar.rank, Ars, Hdf5OpenMode.Truncate);
+  }
+
+  {
+    var dsetNames: [1..nFiles] string = "/Ai";
+    var Ais: [BlockSpace] ArrayWrapper(data[1].Ai.eltType, data[1].Ai.rank);
+    forall (ai, d) in zip(Ais, data) {
+      ai = new ArrayWrapper(d.Ai.eltType, d.Ai.rank, d.Ai.domain, d.Ai);
+    }
+    writeArraysToHDF5Files(hdf5Dir, dsetNames, filenames, data[1].Ai.eltType,
+                           data[1].Ai.rank, Ais, Hdf5OpenMode.Append);
+  }
+
+  // cleanup: remove hdf5Dir and its contents
+  if cleanupFiles then
+    rmTree(hdf5Dir);
+}


### PR DESCRIPTION
Add a function 'writeArraysToHDF5Files' that can write arrays to multiple HDF5
files in parallel in the same way 'readAllHDF5Files' reads them.  It works
with the same set of types 'readAllHDF5Files' does.

Add a test that writes int(64) and real(64) arrays to files using the new
function.