### PR TITLE
Oops -- minor fix to enumRanges branch I just merged

### DIFF
--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -1076,7 +1076,7 @@ proc _cast(type t, r: range(?)) where isRangeType(t) {
   //
   inline proc +(r: range(?e, ?b, ?s), offset: integral)
   {
-    const i = offset.safeCast(r.intIdxType);
+    const i = offset:r.intIdxType;
     type strType = chpl__rangeStrideType(e);
 
     return new range(e, b, s,


### PR DESCRIPTION
I missed that this edit wasn't in the PR I just merged.
This reflects an improvement Ben asked me to make to
turn an unsafe cast into a safe cast.  It turns out that
our code has long relied on unsigned integer wraparound
in the unsafe cast case, so the change was not possible.
I thought I'd committed this before merging, but forgot
that I had not.