### PR TITLE
Update minimal-modules test to include chpl__initCopy

### DIFF
--- a/test/types/coerce/ferguson/coercion-dispatch-minimal-modules.chpl
+++ b/test/types/coerce/ferguson/coercion-dispatch-minimal-modules.chpl
@@ -12,6 +12,7 @@ inline proc _cast(type t, x: uint(?w))
 
 proc chpl__autoCopy(x:uint(?w)) return x;
 proc chpl__initCopy(x:uint(?w)) return x;
+proc chpl__initCopy(x:R) { return x; }
 proc chpl__autoDestroy(r:R) { }
 
 


### PR DESCRIPTION
This test doesn't pass under --force-initializers without a chpl__initCopy for the record ``R``.