### PR TITLE
linearSearch and binarySearch updates

### DIFF
--- a/modules/packages/Search.chpl
+++ b/modules/packages/Search.chpl
@@ -84,7 +84,7 @@ proc search(Data:[?Dom], val, comparator:?rec=defaultComparator, lo=Dom.low, hi=
    Searches through the array `Data` looking for the value `val` using
    a sequential linear search.  Returns a tuple indicating (1) whether or not
    the value was found and (2) the location of the first occurrence of the
-   value if it was found, or ``Data.domain.high+1`` if it was not found.
+   value if it was found, or ``hi+abs(Dom.stride)`` if it was not found.
 
    :arg Data: The array to search
    :type Data: [] `eltType`

--- a/modules/packages/Search.chpl
+++ b/modules/packages/Search.chpl
@@ -98,31 +98,29 @@ proc search(Data:[?Dom], val, comparator:?rec=defaultComparator, lo=Dom.low, hi=
    :type hi: `Dom.idxType`
 
    :returns: A tuple indicating (1) if the value was found and (2) the location
-      of the value if it was found or ``Data.domain.high+1`` if it was not
+      of the value if it was found or ``hi+abs(Dom.stride)`` if it was not
       found.
    :rtype: (`bool`, `Dom.idxType`)
 
  */
 proc linearSearch(Data:[?Dom], val, comparator:?rec=defaultComparator, lo=Dom.low, hi=Dom.high) {
 
-  chpl_check_comparator(comparator, Data.eltType);
+ chpl_check_comparator(comparator, Data.eltType);
 
-  const stride = if Dom.stridable then abs(Dom.stride) else 1;
-  // Domain slicing is cheap, but avoiding it when possible helps performance
-  if lo == Dom.low && hi == Dom.high {
-    for i in Dom {
-      if chpl_compare(Data[i], val, comparator=comparator) == 0 then
-        return (true, i);
-    }
-  } else {
-    const r = if Dom.stridable then lo..hi by stride else lo..hi;
-    for i in Dom[r] {
-      if chpl_compare(Data[i], val, comparator=comparator) == 0 then
-        return (true, i);
-    }
-  }
+ const stride = if Dom.stridable then abs(Dom.stride) else 1;
+ if Dom.stridable {
+   for i in lo..hi by stride {
+     if chpl_compare( Data[i], val, comparator=comparator ) == 0 then
+       return (true, i);
+   }
+ } else {
+   for i in lo..hi {
+     if chpl_compare( Data[i], val, comparator=comparator ) == 0 then
+       return (true, i);
+   }
+ }
 
-  return (false, Dom.high+stride);
+ return (false, hi+stride);
 }
 
 
@@ -159,7 +157,7 @@ proc linearSearch(Data:[?Dom], val, comparator:?rec=defaultComparator, lo=Dom.lo
    :rtype: (`bool`, `Dom.idxType`)
 
  */
-proc binarySearch(Data:[?Dom], val, comparator:?rec=defaultComparator, in lo=Dom.low, in hi=Dom.high) {
+proc binarySearch(Data:[?Dom], val, comparator:?rec=defaultComparator, in lo=Dom.low, in hi=Dom.alignedHigh ) {
   chpl_check_comparator(comparator, Data.eltType);
 
   const stride = if Dom.stridable then abs(Dom.stride) else 1;

--- a/modules/packages/Search.chpl
+++ b/modules/packages/Search.chpl
@@ -110,12 +110,12 @@ proc linearSearch(Data:[?Dom], val, comparator:?rec=defaultComparator, lo=Dom.lo
  const stride = if Dom.stridable then abs(Dom.stride) else 1;
  if Dom.stridable {
    for i in lo..hi by stride {
-     if chpl_compare( Data[i], val, comparator=comparator ) == 0 then
+     if chpl_compare(Data[i], val, comparator=comparator) == 0 then
        return (true, i);
    }
  } else {
    for i in lo..hi {
-     if chpl_compare( Data[i], val, comparator=comparator ) == 0 then
+     if chpl_compare(Data[i], val, comparator=comparator) == 0 then
        return (true, i);
    }
  }
@@ -157,7 +157,7 @@ proc linearSearch(Data:[?Dom], val, comparator:?rec=defaultComparator, lo=Dom.lo
    :rtype: (`bool`, `Dom.idxType`)
 
  */
-proc binarySearch(Data:[?Dom], val, comparator:?rec=defaultComparator, in lo=Dom.low, in hi=Dom.alignedHigh ) {
+proc binarySearch(Data:[?Dom], val, comparator:?rec=defaultComparator, in lo=Dom.low, in hi=Dom.alignedHigh) {
   chpl_check_comparator(comparator, Data.eltType);
 
   const stride = if Dom.stridable then abs(Dom.stride) else 1;


### PR DESCRIPTION
Addresses the issues #9908 and #9912, and changes in the pull request #9877.


In #9877 we discuss removing the domain slicing from linearSearch to increase performance, and in #9908 (and #9877) we discuss linearSearch returning `hi+abs(Dom.stride)` instead of `Dom.high+abs(stride)` to be symmetrical to binarySearch.

In #9912 I noted a bug in binarySearch that can cause an infinite loop with duplicates elements on some strided domains. This was fixed by changing the default input parameter `hi` to be `Dom.alignedHigh` instead of `Dom.high`.

Changes in linearSearch:
+ return hi+abs(stride) instead of Dom.high+abs(stride) (Dom.high is still the default value for hi)
+ removed domain slicing

Changes in binarySearch:
+ changes hi default from Doma.high to Dom.alignedHigh