### PR TITLE
Allow call of parentheses-less call in fields' default values

### DIFF
--- a/compiler/AST/CallExpr.cpp
+++ b/compiler/AST/CallExpr.cpp
@@ -384,8 +384,11 @@ FnSymbol* CallExpr::resolvedFunction() const {
       }
 
     } else if (CallExpr* subCall = toCallExpr(baseExpr)) {
-      // Confirm that this is a partial call
-      INT_ASSERT(subCall->partialTag == true);
+      // Confirm that this is a partial call, but only if the call is not
+      // within a DefExpr (indicated by not having a stmt-expr)
+      if (subCall->getStmtExpr() != NULL) {
+        INT_ASSERT(subCall->partialTag == true);
+      }
 
     } else {
       INT_ASSERT(false);


### PR DESCRIPTION
This PR addresses an issue exposed by the following program:

```chpl
proc bar return (1,2,3);

pragma "use default init"
record R {
  var x = bar(1); // internal compiler error!?
}

var r = new R();
```

The default-value of the field ``x`` would cause an internal compiler error. The cause of the error is related to our mishandling of normalizing expressions within a DefExpr. The solution here is to simply not execute the related assertion if the call is within a DefExpr.

This resolves a --force-initializers bug for ``users/ferguson/resolution-bug-this-nodomain``.

Testing:
- [x] local + futures
- [x] gasnet