### PR TITLE
Convert more tests for owned/borrowed/unmanaged

### DIFF
--- a/test/arrays/jplevyak/simple-4.chpl
+++ b/test/arrays/jplevyak/simple-4.chpl
@@ -16,9 +16,9 @@ var a : arr;
 var x = 1;
 var z = 1;
 
-var y1 = new C();
-var y2 = new D();
-var y3 = new E();
+var y1 = new owned C();
+var y2 = new owned D();
+var y3 = new owned E();
 
 
 a(x) = z;
@@ -29,7 +29,3 @@ y2.a(2) = z;
 writeln(y2.a(2));
 y3.a(2) = z;
 writeln(y3.a(2));
-
-delete y1;
-delete y2;
-delete y3;

--- a/test/arrays/opaque/bradc/opaque-segfaults.chpl
+++ b/test/arrays/opaque/bradc/opaque-segfaults.chpl
@@ -46,7 +46,7 @@ proc createRandomGraph() {
 
   // set up random number stream
   use Random;
-  var myRandNums = new RandomStream(real, seed=314159265);
+  var myRandNums = new borrowed RandomStream(real, seed=314159265);
 
   // allocate vertices
   for i in 1..numVertices {

--- a/test/associative/bradc/localeDom/assocLocales3.chpl
+++ b/test/associative/bradc/localeDom/assocLocales3.chpl
@@ -13,7 +13,7 @@ class C {
 
   var D: domain(locale) = targetLocs;
 
-  var A: [D] LocC(idxType);
+  var A: [D] unmanaged LocC(idxType);
 
   proc postinit() {
     for (loc, locid) in zip(targetLocs, 0..) do

--- a/test/classes/bradc/arrayInClass/genericArrayInClass-otharrs.chpl
+++ b/test/classes/bradc/arrayInClass/genericArrayInClass-otharrs.chpl
@@ -95,11 +95,11 @@ proc foo(C) {
   var opaqueDom: domain(opaque);
   type opaqueArr = [opaqueDom] real;
 
-  var myArithC = new ArithC(opaqueArr);
-  var myAssocC = new AssocC(opaqueArr);
-  var myOpaqueC = new OpaqueC(opaqueArr);
-  var mySparseC = new SparseC(opaqueArr);
-  var myEnumC = new EnumC(opaqueArr);
+  var myArithC = new unmanaged ArithC(opaqueArr);
+  var myAssocC = new unmanaged AssocC(opaqueArr);
+  var myOpaqueC = new unmanaged OpaqueC(opaqueArr);
+  var mySparseC = new unmanaged SparseC(opaqueArr);
+  var myEnumC = new unmanaged EnumC(opaqueArr);
 
   opaqueDom.create();
 
@@ -140,11 +140,11 @@ proc foo(C) {
   var sparseDom: sparse subdomain({1..3});
   type sparseArr = [sparseDom] real;
 
-  var myArithC = new ArithC(sparseArr);
-  var myAssocC = new AssocC(sparseArr);
-  var myOpaqueC = new OpaqueC(sparseArr);
-  var mySparseC = new SparseC(sparseArr);
-  var myEnumC = new EnumC(sparseArr);
+  var myArithC = new unmanaged ArithC(sparseArr);
+  var myAssocC = new unmanaged AssocC(sparseArr);
+  var myOpaqueC = new unmanaged OpaqueC(sparseArr);
+  var mySparseC = new unmanaged SparseC(sparseArr);
+  var myEnumC = new unmanaged EnumC(sparseArr);
 
   sparseDom += 2;
 
@@ -186,11 +186,11 @@ proc foo(C) {
   var enumDom: domain(probClass);
   type enumArr = [enumDom] real;
 
-  var myArithC = new ArithC(enumArr);
-  var myAssocC = new AssocC(enumArr);
-  var myOpaqueC = new OpaqueC(enumArr);
-  var mySparseC = new SparseC(enumArr);
-  var myEnumC = new EnumC(enumArr);
+  var myArithC = new unmanaged ArithC(enumArr);
+  var myAssocC = new unmanaged AssocC(enumArr);
+  var myOpaqueC = new unmanaged OpaqueC(enumArr);
+  var mySparseC = new unmanaged SparseC(enumArr);
+  var myEnumC = new unmanaged EnumC(enumArr);
 
   // initialize class instances
 

--- a/test/classes/bradc/bitOpOnClass.chpl
+++ b/test/classes/bradc/bitOpOnClass.chpl
@@ -21,7 +21,7 @@ class MyClass {
 }
 
 
-proc |(lhs: MyClass, rhs: MyClass): unmanaged MyClass {
+proc |(lhs: borrowed MyClass, rhs: borrowed MyClass): unmanaged MyClass {
   var res = new unmanaged MyClass(min(lhs.len, rhs.len));
   forall (r,a,b) in zip(res.arr, lhs.arr, rhs.arr) do
     r = a | b;

--- a/test/classes/bradc/callMethodOnClass.chpl
+++ b/test/classes/bradc/callMethodOnClass.chpl
@@ -3,13 +3,13 @@ class C {
 }
 
 proc newC() {
-  var c = new C();
+  var c = new owned C();
   c.x = 2.3;
   return c;
 }
 
 class D {
-  var y: C;
+  var y: owned C;
 
   proc start {
     y = newC();
@@ -21,7 +21,7 @@ class D {
 }
 
 proc main() {
-  var myD = new D();
+  var myD = new borrowed D();
   D.start;  // BUG if I call this on D!!
   D.testit;
 }

--- a/test/classes/bradc/compilerErrorInMethod/testClear-snap1.chpl
+++ b/test/classes/bradc/compilerErrorInMethod/testClear-snap1.chpl
@@ -50,9 +50,9 @@ class Assoc: Abstract {
   }
 }
 
-var d = new Wrap(_value = new Dense());
-var s = new Wrap(_value = new Sparse());
-var a = new Wrap(_value = new Assoc());
+var d = new Wrap(_value = new unmanaged Dense());
+var s = new Wrap(_value = new unmanaged Sparse());
+var a = new Wrap(_value = new unmanaged Assoc());
 
 if doDense {
   d = 1;

--- a/test/classes/bradc/compilerErrorInMethod/testClear-snap2.chpl
+++ b/test/classes/bradc/compilerErrorInMethod/testClear-snap2.chpl
@@ -60,9 +60,9 @@ class Assoc : AbsAssoc {
 }
 
 
-var d = new Wrap(_value = new Dense());
-var s = new Wrap(_value = new Sparse());
-var a = new Wrap(_value = new Assoc());
+var d = new Wrap(_value = new unmanaged Dense());
+var s = new Wrap(_value = new unmanaged Sparse());
+var a = new Wrap(_value = new unmanaged Assoc());
 
 if doDense {
   d = 1;

--- a/test/classes/bradc/compilerErrorInMethod/testClear-workaround.chpl
+++ b/test/classes/bradc/compilerErrorInMethod/testClear-workaround.chpl
@@ -58,9 +58,9 @@ class Assoc : AbsAssoc {
 }
 
 
-var d = new Wrap(_value = new Dense());
-var s = new Wrap(_value = new Sparse());
-var a = new Wrap(_value = new Assoc());
+var d = new Wrap(_value = new unmanaged Dense());
+var s = new Wrap(_value = new unmanaged Sparse());
+var a = new Wrap(_value = new unmanaged Assoc());
 
 if doDense {
   d = 1;

--- a/test/classes/bradc/compilerErrorInMethod/testClear2.chpl
+++ b/test/classes/bradc/compilerErrorInMethod/testClear2.chpl
@@ -62,9 +62,9 @@ class Assoc : AbsAssoc {
 }
 
 
-var d = new Wrap(_value = new Dense());
-var s = new Wrap(_value = new Sparse());
-var a = new Wrap(_value = new Assoc());
+var d = new Wrap(_value = new unmanaged Dense());
+var s = new Wrap(_value = new unmanaged Sparse());
+var a = new Wrap(_value = new unmanaged Assoc());
 
 if doDense {
   d = 1;

--- a/test/classes/bradc/declClassType.chpl
+++ b/test/classes/bradc/declClassType.chpl
@@ -2,11 +2,11 @@ class C {
   var x = 10;
 }
 
-var globc: C;
+var globc: borrowed C;
 
 class D {
   var y = 20;
-  var locc: C;
+  var locc: borrowed C;
 
   proc doit {
     locc = globc;
@@ -14,7 +14,7 @@ class D {
 }
 
 proc main() {
-  var d: D = new borrowed D();
+  var d: borrowed D = new borrowed D();
 
   d.doit;
   writeln(d);

--- a/test/classes/bradc/declClassType1a.chpl
+++ b/test/classes/bradc/declClassType1a.chpl
@@ -2,11 +2,11 @@ class C {
   var x = 10;
 }
 
-var globc: C = new unmanaged C();
+var globc: unmanaged C = new unmanaged C();
 
 class D {
   var y = 20;
-  var locc: C;
+  var locc: unmanaged C;
 
   proc doit {
     locc = globc;
@@ -14,7 +14,7 @@ class D {
 }
 
 proc main() {
-  var d: D = new unmanaged D();
+  var d: unmanaged D = new unmanaged D();
   d.doit;
   writeln(d);
   delete d;

--- a/test/classes/bradc/declClassType1b.chpl
+++ b/test/classes/bradc/declClassType1b.chpl
@@ -6,7 +6,7 @@ var globc: unmanaged C = new unmanaged C();
 
 class D {
   var y = 20;
-  var locc: C;
+  var locc: unmanaged C;
 
   proc doit {
     locc = globc;

--- a/test/classes/bradc/declClassType1c.chpl
+++ b/test/classes/bradc/declClassType1c.chpl
@@ -2,11 +2,11 @@ class C {
   var x = 10;
 }
 
-var globc: C = nil;
+var globc: borrowed C = nil;
 
 class D {
   var y = 20;
-  var locc: C;
+  var locc: borrowed C;
 
   proc doit {
     locc = globc;
@@ -14,10 +14,8 @@ class D {
 }
 
 proc main() {
-  var d: D = new unmanaged D();
+  var d: borrowed D = new borrowed D();
 
   d.doit;
   writeln(d);
-
-  delete d;
 }

--- a/test/classes/bradc/dispatch-nevernil.chpl
+++ b/test/classes/bradc/dispatch-nevernil.chpl
@@ -6,11 +6,11 @@ class D {
   var y: unmanaged C = new unmanaged C();
 }
 
-proc foo(c: C) {
+proc foo(c: borrowed C) {
   writeln("x is: ", c.x);
 }
 
-proc foo(d: D) {
+proc foo(d: borrowed D) {
   foo(d.y);
 }
 

--- a/test/classes/bradc/dispatch-nevernil2.chpl
+++ b/test/classes/bradc/dispatch-nevernil2.chpl
@@ -6,11 +6,11 @@ class D {
   var y: unmanaged C;
 }
 
-proc foo(c: C) {
+proc foo(c: borrowed C) {
   writeln("x is: ", c.x);
 }
 
-proc foo(d: D) {
+proc foo(d: borrowed D) {
   foo(d.y);
 }
 

--- a/test/classes/bradc/dispatch-nevernil2a.chpl
+++ b/test/classes/bradc/dispatch-nevernil2a.chpl
@@ -6,11 +6,11 @@ class D {
   var y: unmanaged C;
 }
 
-proc foo(c: C) {
+proc foo(c: unmanaged C) {
   writeln("x is: ", c.x);
 }
 
-proc foo(d: D) {
+proc foo(d: unmanaged D) {
   foo(d.y);
 }
 

--- a/test/classes/bradc/dispatch-nevernil2b.chpl
+++ b/test/classes/bradc/dispatch-nevernil2b.chpl
@@ -6,11 +6,11 @@ class D {
   var y: unmanaged C;
 }
 
-proc foo(c: C) {
+proc foo(c: unmanaged C) {
   writeln("x is: ", c.x);
 }
 
-proc foo(d: D) {
+proc foo(d: unmanaged D) {
   foo(d.y);
 }
 

--- a/test/classes/bradc/dispatch-nevernil2c.chpl
+++ b/test/classes/bradc/dispatch-nevernil2c.chpl
@@ -6,11 +6,11 @@ class D {
   var y: unmanaged C;
 }
 
-proc foo(c: C) {
+proc foo(c: unmanaged C) {
   writeln("x is: ", c.x);
 }
 
-proc foo(d: D) {
+proc foo(d: unmanaged D) {
   foo(d.y);
 }
 

--- a/test/classes/bradc/dispatch-withnil.chpl
+++ b/test/classes/bradc/dispatch-withnil.chpl
@@ -3,14 +3,14 @@ class C {
 }
 
 class D {
-  var y: C;
+  var y: borrowed C;
 }
 
-proc foo(c: C) {
+proc foo(c: borrowed C) {
   writeln("x is: ", c.x);
 }
 
-proc foo(d: D) {
+proc foo(d: borrowed D) {
   foo(d.y);
 }
 

--- a/test/classes/bradc/dispatch.chpl
+++ b/test/classes/bradc/dispatch.chpl
@@ -3,14 +3,14 @@ class C {
 }
 
 class D {
-  var y: C;
+  var y: unmanaged C;
 }
 
-proc foo(c: C) {
+proc foo(c: borrowed C) {
   writeln("x is: ", c.x);
 }
 
-proc foo(d: D) {
+proc foo(d: borrowed D) {
   foo(d.y);
 }
 

--- a/test/classes/bradc/dispatchNil/dispatchNil-alistError.chpl
+++ b/test/classes/bradc/dispatchNil/dispatchNil-alistError.chpl
@@ -11,7 +11,7 @@ class C {
 }
 
 class D : C {
-  var DsC: C;
+  var DsC: unmanaged C;
   var y = DsC.baz();
 
   proc foo() {

--- a/test/classes/bradc/dispatchNil/dispatchNil.chpl
+++ b/test/classes/bradc/dispatchNil/dispatchNil.chpl
@@ -11,7 +11,7 @@ class C {
 }
 
 class D : C {
-  var DsC: C;
+  var DsC: unmanaged C;
   var y: int = DsC.baz();
 
   proc foo() {

--- a/test/classes/bradc/dynDispatchOnArg.chpl
+++ b/test/classes/bradc/dynDispatchOnArg.chpl
@@ -5,15 +5,15 @@ class C {
 class D : C {
 }
 
-proc writeType(c:C) {
+proc writeType(c: borrowed C) {
   writeln("I am a C");
 }
 
-proc writeType(d:D) {
+proc writeType(d: borrowed D) {
   writeln("I am a D");
 }
 
-proc foo(cOrD:C) {
+proc foo(cOrD: borrowed C) {
   writeType(cOrD);
 }
 

--- a/test/classes/bradc/newKeyword/typeInsteadOfNew.chpl
+++ b/test/classes/bradc/newKeyword/typeInsteadOfNew.chpl
@@ -7,5 +7,5 @@ class C {
   var locDom: [LocaleSpace] domain(1, indexType);
 }
 
-const myC = C({1..m});
+const myC = unmanaged C({1..m});
 

--- a/test/classes/bradc/noinit.chpl
+++ b/test/classes/bradc/noinit.chpl
@@ -4,7 +4,7 @@ class pair {
 }
 
 proc main() {
-  var a: pair;
+  var a: unmanaged pair;
 
   a   = new unmanaged pair();
   a.x = 10;

--- a/test/classes/bradc/noinit2.chpl
+++ b/test/classes/bradc/noinit2.chpl
@@ -4,9 +4,10 @@ class pair {
 }
 
 proc main() {
-  var a: pair;
+  var a: unmanaged pair;
+  var aa: borrowed pair;
 
-  if (a == nil) {
+  if (a == nil && aa == nil) {
     writeln("a initialized properly");
   }
 }

--- a/test/classes/bradc/overloadMethods/printType.chpl
+++ b/test/classes/bradc/overloadMethods/printType.chpl
@@ -14,7 +14,7 @@ class D : C {
 
 
 class E : C {
-  var myC: C;
+  var myC: borrowed C;
   var myCType = myC.printType();
 }
 

--- a/test/classes/bradc/overloadMethods/v1NoReturnValue.chpl
+++ b/test/classes/bradc/overloadMethods/v1NoReturnValue.chpl
@@ -20,7 +20,7 @@ class D : C {
   }
 }
 
-var d:C = new borrowed D(4);
+var d:borrowed C = new borrowed D(4);
 writeln(d.bbox(1));
 writeln(d.bbox(2));
 writeln(d.bbox(3));

--- a/test/classes/bradc/overloadMethods/v2NoReturnValueButType.chpl
+++ b/test/classes/bradc/overloadMethods/v2NoReturnValueButType.chpl
@@ -18,7 +18,7 @@ class D : C {
   }
 }
 
-var d:C = new borrowed D(4);
+var d:borrowed C = new borrowed D(4);
 
 writeln(d.bbox(1));
 writeln(d.bbox(2));

--- a/test/classes/bradc/overloadMethods/v3aoneClassReturnMatch.chpl
+++ b/test/classes/bradc/overloadMethods/v3aoneClassReturnMatch.chpl
@@ -19,7 +19,7 @@ class E : C {
   }
 }
 
-var e:C = new borrowed E(4);
+var e:borrowed C = new borrowed E(4);
 
 writeln(e.bbox(1));
 writeln(e.bbox(2));

--- a/test/classes/bradc/overloadMethods/v3oneClassReturnMatch.chpl
+++ b/test/classes/bradc/overloadMethods/v3oneClassReturnMatch.chpl
@@ -19,7 +19,7 @@ class D : C {
   }
 }
 
-var d:C = new borrowed D(4);
+var d:borrowed C = new borrowed D(4);
 
 writeln(d.bbox(1));
 writeln(d.bbox(2));

--- a/test/classes/bradc/overloadMethods/v4oneClassReturnNoMatch.chpl
+++ b/test/classes/bradc/overloadMethods/v4oneClassReturnNoMatch.chpl
@@ -19,7 +19,7 @@ class D : C {
   }
 }
 
-var d:C = new borrowed D(4);
+var d:borrowed C = new borrowed D(4);
 writeln(d.bbox(1));
 writeln(d.bbox(2));
 writeln(d.bbox(3));

--- a/test/classes/bradc/overloadMethods/v5bothReturnTypes.chpl
+++ b/test/classes/bradc/overloadMethods/v5bothReturnTypes.chpl
@@ -33,13 +33,13 @@ class E : C {
   }
 }
 
-var d:C = new borrowed D(4);
+var d:borrowed C = new borrowed D(4);
 writeln(d.bbox(1));
 writeln(d.bbox(2));
 writeln(d.bbox(3));
 writeln(d.bbox(4));
 
-var e:C = new borrowed E(4);
+var e:borrowed C = new borrowed E(4);
 writeln(e.bbox(1));
 writeln(e.bbox(2));
 writeln(e.bbox(3));

--- a/test/classes/bradc/overloadMethods/virtualIsHalt.chpl
+++ b/test/classes/bradc/overloadMethods/virtualIsHalt.chpl
@@ -20,7 +20,7 @@ class D : C {
 }
 
 class E : C {
-  var parentDom: C;
+  var parentDom: owned C;
 
   var rowRange = parentDom.bbox(1);
 }

--- a/test/classes/bradc/paramInClass/weirdParamInit3.chpl
+++ b/test/classes/bradc/paramInClass/weirdParamInit3.chpl
@@ -3,7 +3,7 @@ class C {
 }
 
 class D {
-  var c: C = new borrowed C();
+  var c: borrowed C = new borrowed C();
   param y: int = c.x;
 }
 

--- a/test/classes/bradc/records/assignRecord.chpl
+++ b/test/classes/bradc/records/assignRecord.chpl
@@ -4,7 +4,7 @@ class myclass {
 }
 
 record myrecord {
-  var c: myclass;
+  var c: borrowed myclass;
 }
 
 proc main() {

--- a/test/classes/bradc/weirdinit.chpl
+++ b/test/classes/bradc/weirdinit.chpl
@@ -4,6 +4,6 @@ class pair {
 }
 
 proc main() {
-  var a: pair = a();
+  var a: borrowed pair = a();
   writeln("Shouldn't that line have generated an error?");
 }

--- a/test/classes/bradc/writeclass.chpl
+++ b/test/classes/bradc/writeclass.chpl
@@ -3,8 +3,8 @@ class myclass {
   var y: real;
 }
 
-var a: myclass = new unmanaged myclass();
-var b: myclass = new unmanaged myclass();
+var a: unmanaged myclass = new unmanaged myclass();
+var b: unmanaged myclass = new unmanaged myclass();
 
 writeln("a is: ", a, ", b is: ", b);
 writeln("a is: (", a.x, ", ", a.y, ") -- b is: (", b.x, ", ", b.y, ")");

--- a/test/classes/bradc/writeclass1a.chpl
+++ b/test/classes/bradc/writeclass1a.chpl
@@ -7,8 +7,8 @@ proc myclass.writeThis(f) {
   f.write(x, " ", y);
 }
 
-var a: myclass = new borrowed myclass();
-var b: myclass = new borrowed myclass();
+var a: borrowed myclass = new borrowed myclass();
+var b: borrowed myclass = new borrowed myclass();
 
 writeln("a is: ", a, ", b is: ", b);
 

--- a/test/classes/bradc/writeclass2.chpl
+++ b/test/classes/bradc/writeclass2.chpl
@@ -3,8 +3,8 @@ class myclass {
   var y: real = 4.2;
 }
 
-var a: myclass;
-var b: myclass;
+var a: borrowed myclass;
+var b: unmanaged myclass;
 
 writeln("a is: ", a);
 writeln("b is: ", b);

--- a/test/classes/bradc/writeclass2a.chpl
+++ b/test/classes/bradc/writeclass2a.chpl
@@ -3,8 +3,8 @@ class myclass {
   var y: real = 4.2;
 }
 
-var a: myclass = nil;
-var b: myclass = nil;
+var a: borrowed myclass = nil;
+var b: unmanaged myclass = nil;
 
 writeln("a is: ", a);
 writeln("b is: ", b);

--- a/test/classes/bradc/writeclass3.chpl
+++ b/test/classes/bradc/writeclass3.chpl
@@ -3,8 +3,8 @@ class myclass {
   var y: real = 4.2;
 }
 
-var a: myclass = new borrowed myclass();
-var b: myclass = new borrowed myclass();
+var a: borrowed myclass = new borrowed myclass();
+var b: borrowed myclass = new borrowed myclass();
 
 writeln("a is: ", a, ", b is: ", b);
 

--- a/test/classes/constructors/dflt-ctor-generic-uninit-field-const-err-1.chpl
+++ b/test/classes/constructors/dflt-ctor-generic-uninit-field-const-err-1.chpl
@@ -2,4 +2,4 @@ class A {
   const c;
 }
 
-var x = new A();
+var x = new borrowed A();

--- a/test/classes/constructors/dflt-ctor-generic-uninit-field-param-err-1.chpl
+++ b/test/classes/constructors/dflt-ctor-generic-uninit-field-param-err-1.chpl
@@ -2,4 +2,4 @@ class A {
   param p;
 }
 
-var x = new A();
+var x = new borrowed A();

--- a/test/classes/constructors/dflt-ctor-generic-uninit-field-type-err-1.chpl
+++ b/test/classes/constructors/dflt-ctor-generic-uninit-field-type-err-1.chpl
@@ -2,4 +2,4 @@ class A {
   type t;
 }
 
-var x = new A();
+var x = new borrowed A();

--- a/test/classes/constructors/dflt-ctor-generic-uninit-field-var-err-1.chpl
+++ b/test/classes/constructors/dflt-ctor-generic-uninit-field-var-err-1.chpl
@@ -2,4 +2,4 @@ class A {
   var v;
 }
 
-var x = new A();
+var x = new borrowed A();

--- a/test/classes/constructors/error-constructor-return-type.chpl
+++ b/test/classes/constructors/error-constructor-return-type.chpl
@@ -1,2 +1,2 @@
 class C{}
-proc C.C():C {}
+proc C.C():unmanaged C {}

--- a/test/classes/deinitializers/deinit.chpl
+++ b/test/classes/deinitializers/deinit.chpl
@@ -4,5 +4,5 @@ class C {
   }
 }
 
-var myC = new C();
+var myC = new unmanaged C();
 delete myC;

--- a/test/classes/deinitializers/deinitAndDestruct.chpl
+++ b/test/classes/deinitializers/deinitAndDestruct.chpl
@@ -8,5 +8,5 @@ class C {
   }
 }
 
-var myC = new C();
+var myC = new unmanaged C();
 delete myC;

--- a/test/classes/deinitializers/deinitParenlessError.chpl
+++ b/test/classes/deinitializers/deinitParenlessError.chpl
@@ -4,5 +4,5 @@ class C {
   proc deinit { writeln("C.deinit"); }
 }
 
-var c = new C();
+var c = new unmanaged C();
 delete c;

--- a/test/classes/deinitializers/deinitWithArg.chpl
+++ b/test/classes/deinitializers/deinitWithArg.chpl
@@ -4,5 +4,5 @@ class C {
   }
 }
 
-var myC = new C();
+var myC = new unmanaged C();
 delete myC;

--- a/test/classes/deinitializers/fieldorder.chpl
+++ b/test/classes/deinitializers/fieldorder.chpl
@@ -22,8 +22,7 @@ record RR { var f1: F1; var f2: F2; }
 class CC { var f1: F1; var f2: F2; }
 {
   writeln("checking field order in CC");
-  var cc = new CC();
-  delete cc;
+  var cc = new borrowed CC();
 }
 
 class DD: CC { var f3: F3; var f4: F4; }

--- a/test/classes/deitz/class-constructor/class_construct1.chpl
+++ b/test/classes/deitz/class-constructor/class_construct1.chpl
@@ -5,7 +5,7 @@ class foo {
   }
 }
 
-var f : foo = new unmanaged foo(50);
+var f : unmanaged foo = new unmanaged foo(50);
 
 writeln(f);
 

--- a/test/classes/deitz/class-constructor/constructor_ambiguity.chpl
+++ b/test/classes/deitz/class-constructor/constructor_ambiguity.chpl
@@ -3,7 +3,7 @@ class C {
   var x: t;
 }
 
-var c = (new unmanaged C(t=C(int),x=new unmanaged C(int)));
+var c = (new unmanaged C(t=unmanaged C(int),x=new unmanaged C(int)));
 writeln(c);
 delete c.x;
 delete c;

--- a/test/classes/deitz/class-constructor/constructor_ambiguity2.chpl
+++ b/test/classes/deitz/class-constructor/constructor_ambiguity2.chpl
@@ -7,4 +7,4 @@ proc foo(type t) { writeln("in foo(type t)"); }
 
 proc foo(c) { writeln("in foo(c)"); }
 
-foo(C(int));
+foo(borrowed C(int));

--- a/test/classes/deitz/class-constructor/constructor_disambiguity.chpl
+++ b/test/classes/deitz/class-constructor/constructor_disambiguity.chpl
@@ -3,7 +3,7 @@ class C {
   var x: t;
 }
 
-var c = (new unmanaged C(t=C(int).type,x=new unmanaged C(int)));
+var c = (new unmanaged C(t=unmanaged C(int).type,x=new unmanaged C(int)));
 writeln(c);
 delete c.x;
 delete c;

--- a/test/classes/deitz/class-numbered/class1-old.chpl
+++ b/test/classes/deitz/class-numbered/class1-old.chpl
@@ -3,14 +3,14 @@ class foo {
   var f : real;
 }
 
-var x : foo = foo();
+var x : borrowed foo = foo();
 
 x.i = -1;
 x.f = 3.1415;
 
 writeln("x: (", x.i, ", ", x.f, ")");
 
-var y : foo = x;
+var y : borrowed foo = x;
 
 writeln("y: (", y.i, ", ", y.f, ")");
 

--- a/test/classes/deitz/class-numbered/class1-old.compopts
+++ b/test/classes/deitz/class-numbered/class1-old.compopts
@@ -1,0 +1,1 @@
+--no-warn-unstable

--- a/test/classes/deitz/class-numbered/class1.chpl
+++ b/test/classes/deitz/class-numbered/class1.chpl
@@ -3,7 +3,7 @@ class foo {
   var f : real;
 }
 
-var x : foo = new borrowed foo();
+var x : borrowed foo = new borrowed foo();
 
 writeln("x: (", x.i, ", ", x.f, ")");
 
@@ -15,7 +15,7 @@ writeln("x: (", x.i, ", ", x.f, ")");
 
 
 
-var y : foo = x;
+var y : borrowed foo = x;
 
 writeln("y: (", y.i, ", ", y.f, ")");
 
@@ -24,6 +24,6 @@ y.i = -2;
 writeln("x: (", x.i, ", ", x.f, ")");
 
 
-var z : foo = new borrowed foo(i=12,f=18.2);
+var z : borrowed foo = new borrowed foo(i=12,f=18.2);
 
 writeln("z: (", z.i, ", ", z.f, ")");

--- a/test/classes/deitz/class-numbered/class1a.chpl
+++ b/test/classes/deitz/class-numbered/class1a.chpl
@@ -3,14 +3,14 @@ class foo {
   var f : real;
 }
 
-var x : foo = new borrowed foo(2, 3.2);
+var x : borrowed foo = new borrowed foo(2, 3.2);
 
 x.i = -1;
 x.f = 3.1415;
 
 writeln("x: (", x.i, ", ", x.f, ")");
 
-var y : foo = x;
+var y : borrowed foo = x;
 
 writeln("y: (", y.i, ", ", y.f, ")");
 

--- a/test/classes/deitz/class-numbered/class4.chpl
+++ b/test/classes/deitz/class-numbered/class4.chpl
@@ -3,7 +3,7 @@ class foo {
   var f : real = 3.14;
 }
 
-var x : foo = new unmanaged foo();
+var x : unmanaged foo = new unmanaged foo();
 
 writeln("x: (", x.i, ", ", x.f, ")");
 

--- a/test/classes/deitz/class/default_param2.chpl
+++ b/test/classes/deitz/class/default_param2.chpl
@@ -4,7 +4,7 @@ class C {
   var x: t;
 }
 
-var c: C(int);
+var c: borrowed C(int);
 
 c = new borrowed C(int);
 

--- a/test/classes/deitz/class/nil1.chpl
+++ b/test/classes/deitz/class/nil1.chpl
@@ -2,7 +2,7 @@ class C {
   var x : int = 10;
 }
 
-var c : C;
+var c : borrowed C;
 
 if c != nil then
   writeln(c.x);

--- a/test/classes/deitz/class/nil2.chpl
+++ b/test/classes/deitz/class/nil2.chpl
@@ -2,7 +2,7 @@ class C {
   var x : int = 10;
 }
 
-var c : C;
+var c : borrowed C;
 
 if c != nil then
   writeln(c.x);

--- a/test/classes/deitz/class/nomembers1.chpl
+++ b/test/classes/deitz/class/nomembers1.chpl
@@ -4,6 +4,6 @@ class addition {
   }
 }
 
-var a : addition = new borrowed addition();
+var a : borrowed addition = new borrowed addition();
 
 writeln(a.identity(2));

--- a/test/classes/deitz/dispatch/test_dc1.chpl
+++ b/test/classes/deitz/dispatch/test_dc1.chpl
@@ -10,24 +10,24 @@ class E: D {
   var z: int;
 }
 
-var c: C;
-var d: D;
-var e: E;
+var c: borrowed C;
+var d: borrowed D;
+var e: borrowed E;
 
 c = new borrowed C();
-d = c:D;
+d = c:borrowed D;
 if d then writeln(d); else writeln("nil value");
-e = c:E;
+e = c:borrowed E;
 if e then writeln(e); else writeln("nil value");
 
 c = new borrowed D();
-d = c:D;
+d = c:borrowed D;
 if d then writeln(d); else writeln("nil value");
-e = c:E;
+e = c:borrowed E;
 if e then writeln(e); else writeln("nil value");
 
 c = new borrowed E();
-d = c:D;
+d = c:borrowed D;
 if d then writeln(d); else writeln("nil value");
-e = c:E;
+e = c:borrowed E;
 if e then writeln(e); else writeln("nil value");

--- a/test/classes/deitz/dispatch/test_dd1.chpl
+++ b/test/classes/deitz/dispatch/test_dd1.chpl
@@ -13,7 +13,7 @@ var c: unmanaged C = new unmanaged D(x=3,y=4);
 c.foo(12);
 c.foo(true);
 
-var d: D = c:D;
+var d: unmanaged D = c:unmanaged D;
 d.foo(true);
 
 delete c;

--- a/test/classes/deitz/dispatch/test_dd5.chpl
+++ b/test/classes/deitz/dispatch/test_dd5.chpl
@@ -10,7 +10,7 @@ class D: C {
   proc foo() { writeln("D: ", this); }
 }
 
-var s: list(C) = makeList( new borrowed C(1), new borrowed D(2,3), new borrowed C(4), new borrowed D(5,6) );
+var s: list(borrowed C) = makeList( new borrowed C(1), new borrowed D(2,3), new borrowed C(4), new borrowed D(5,6) );
 
 writeln(s);
 

--- a/test/classes/deitz/field/string_field.chpl
+++ b/test/classes/deitz/field/string_field.chpl
@@ -2,7 +2,7 @@ class C {
   var s : string;
 }
 
-var c : C = new unmanaged C("hello world");
+var c : unmanaged C = new unmanaged C("hello world");
 
 writeln(c);
 

--- a/test/classes/deitz/field/string_field2.chpl
+++ b/test/classes/deitz/field/string_field2.chpl
@@ -3,7 +3,7 @@ class C {
   var s : string;
 }
 
-var c : C = new unmanaged C(2, "hello world");
+var c : unmanaged C = new unmanaged C(2, "hello world");
 
 writeln(c);
 

--- a/test/classes/deitz/infer/infer_field1.chpl
+++ b/test/classes/deitz/infer/infer_field1.chpl
@@ -3,12 +3,12 @@ class C {
   var y;
 }
 
-proc foo(c : C) {
+proc foo(c : borrowed C) {
   c.x = 2;
   c.y = 3;
 }
 
-proc bar(c : C) {
+proc bar(c : borrowed C) {
   c.x = "hello";
   c.y = "world";
 }

--- a/test/classes/deitz/inherit-class-record/class_with1.chpl
+++ b/test/classes/deitz/inherit-class-record/class_with1.chpl
@@ -11,14 +11,14 @@ class cpoint : point {
   var color : int;
 }
 
-var p : point = new borrowed point();
+var p : borrowed point = new borrowed point();
 
 p.x = 3.0;
 p.y = 4.5;
 
 writeln("p { ", p.x, ", ", p.y, " }");
 
-var cp : cpoint = new borrowed cpoint();
+var cp : borrowed cpoint = new borrowed cpoint();
 
 cp.color = 5;
 cp.x = 2.2;

--- a/test/classes/deitz/inherit-class-record/inherit_mod1.chpl
+++ b/test/classes/deitz/inherit-class-record/inherit_mod1.chpl
@@ -8,13 +8,13 @@ class D2 : C {
   var x : real;
 }
 
-var c1 : C = new borrowed D1();
-var c2 : C = new borrowed D2();
+var c1 : borrowed C = new borrowed D1();
+var c2 : borrowed C = new borrowed D2();
 
 writeln(c1);
 writeln(c2);
 
-proc foo(c : C) {
+proc foo(c : borrowed C) {
   writeln(c.x);
 }
 

--- a/test/classes/deitz/inherit-class-record/inherit_mod2.chpl
+++ b/test/classes/deitz/inherit-class-record/inherit_mod2.chpl
@@ -8,13 +8,13 @@ class D2 : C {
   var x : real;
 }
 
-var c1 : C = new borrowed D1();
-var c2 : C = new borrowed D2();
+var c1 : borrowed C = new borrowed D1();
+var c2 : borrowed C = new borrowed D2();
 
 writeln(c1);
 writeln(c2);
 
-proc foo(c : C) {
+proc foo(c : borrowed C) {
   var y = c.x;
   writeln(y);
 }

--- a/test/classes/deitz/inherit-class-record/inherit_mod3.chpl
+++ b/test/classes/deitz/inherit-class-record/inherit_mod3.chpl
@@ -8,11 +8,11 @@ class D2 : C {
   var x : real;
 }
 
-proc foo(c : C) {
+proc foo(c : borrowed C) {
   writeln(c.x);
 }
 
-var c : C;
+var c : borrowed C;
 c = new borrowed D1();
 foo(c);
 c = new borrowed D2();

--- a/test/classes/deitz/inherit/test_inherit1.chpl
+++ b/test/classes/deitz/inherit/test_inherit1.chpl
@@ -6,7 +6,7 @@ class D : C {
   var y : real = 2.0;
 }
 
-var c : C = new borrowed C(), d : D = new borrowed D();
+var c : borrowed C = new borrowed C(), d : borrowed D = new borrowed D();
 
 writeln(c);
 writeln(d);

--- a/test/classes/deitz/inherit/test_inherit2.chpl
+++ b/test/classes/deitz/inherit/test_inherit2.chpl
@@ -6,11 +6,11 @@ class D : C {
   var y : real = 2.0;
 }
 
-proc foo(c : C) {
+proc foo(c : borrowed C) {
   writeln(c.x);
 }
 
-var c : C = new borrowed C(), d : D = new borrowed D();
+var c : borrowed C = new borrowed C(), d : borrowed D = new borrowed D();
 
 writeln(c);
 writeln(d);

--- a/test/classes/deitz/inherit/test_inherit3.chpl
+++ b/test/classes/deitz/inherit/test_inherit3.chpl
@@ -6,7 +6,7 @@ class D : C {
   var y : real = 2.0;
 }
 
-proc foo(c : C) {
+proc foo(c : unmanaged C) {
   writeln(c.x);
 }
 

--- a/test/classes/deitz/inherit/test_inherit4.chpl
+++ b/test/classes/deitz/inherit/test_inherit4.chpl
@@ -6,7 +6,7 @@ class D : C {
   var y : real = 2.0;
 }
 
-proc foo(c : C) {
+proc foo(c : unmanaged C) {
   writeln(c);
 }
 

--- a/test/classes/deitz/inherit/test_inherit4b.chpl
+++ b/test/classes/deitz/inherit/test_inherit4b.chpl
@@ -12,11 +12,11 @@ class D : C {
   }
 }
 
-proc foo(c : C) {
+proc foo(c : borrowed C) {
   c.print();
 }
 
-var c : C;
+var c : borrowed C;
 
 c = new borrowed C();
 foo(c);

--- a/test/classes/deitz/method-numbered/method1.chpl
+++ b/test/classes/deitz/method-numbered/method1.chpl
@@ -12,7 +12,7 @@ class dog {
   }
 }
 
-var d : dog = new borrowed dog();
+var d : borrowed dog = new borrowed dog();
 
 d.weight = 38.5;
 d.paws   = 4;

--- a/test/classes/deitz/method-numbered/method3.chpl
+++ b/test/classes/deitz/method-numbered/method3.chpl
@@ -14,7 +14,7 @@ class foo {
   }
 }
 
-var f : foo = new borrowed foo();
+var f : borrowed foo = new borrowed foo();
 
 writeln(f.x);
 writeln(f.getx());

--- a/test/classes/deitz/method-numbered/method7.chpl
+++ b/test/classes/deitz/method-numbered/method7.chpl
@@ -13,7 +13,7 @@ class foo {
   }
 }
 
-var f : foo = new borrowed foo();
+var f : borrowed foo = new borrowed foo();
 
 f.x = 4;
 f.print();

--- a/test/classes/deitz/method-numbered/method8.chpl
+++ b/test/classes/deitz/method-numbered/method8.chpl
@@ -5,7 +5,7 @@ class foo {
   }
 }
 
-var f : foo = new unmanaged foo();
+var f : unmanaged foo = new unmanaged foo();
 
 f.x = 12;
 f.bar(13);

--- a/test/classes/deitz/method-this/primary_method1.chpl
+++ b/test/classes/deitz/method-this/primary_method1.chpl
@@ -8,7 +8,7 @@ class foo {
   }
 }
 
-var f : foo = new unmanaged foo();
+var f : unmanaged foo = new unmanaged foo();
 
 f.setx();
 f.primary();

--- a/test/classes/deitz/method-this/secondary_method2.chpl
+++ b/test/classes/deitz/method-this/secondary_method2.chpl
@@ -11,7 +11,7 @@ class foo {
 
 
 
-var f1 : foo = new borrowed foo();
+var f1 : borrowed foo = new borrowed foo();
 
 f1.primary();
 f1.secondary();
@@ -19,7 +19,7 @@ f1.secondary();
 
 
 
-var f2 : foo = new borrowed foo();
+var f2 : borrowed foo = new borrowed foo();
 f2.i = 4;
 
 f2.primary();

--- a/test/classes/deitz/method-this/this1.chpl
+++ b/test/classes/deitz/method-this/this1.chpl
@@ -3,12 +3,12 @@ class D {
 }
 
 class C {
-  var d : D = new unmanaged D();
-  proc this() ref : D
+  var d : unmanaged D = new unmanaged D();
+  proc this() ref : unmanaged D
     return d;
 }
 
-var c : C = new unmanaged C();
+var c : unmanaged C = new unmanaged C();
 
 writeln(c);
 writeln(c.d);

--- a/test/classes/deitz/method/method_initialize_error.chpl
+++ b/test/classes/deitz/method/method_initialize_error.chpl
@@ -3,6 +3,6 @@ class C {
   proc foo() return x;
 }
 
-var c = new C();
+var c = new owned C();
 
 writeln(c);

--- a/test/classes/deitz/method/mf_class.chpl
+++ b/test/classes/deitz/method/mf_class.chpl
@@ -5,7 +5,7 @@ class foo {
   }
 }
 
-proc bar(f : foo) {
+proc bar(f : borrowed foo) {
   writeln("function bar ", f.x);
 }
 

--- a/test/classes/deitz/record/generics2.chpl
+++ b/test/classes/deitz/record/generics2.chpl
@@ -4,7 +4,7 @@ record C {
 }
 
 class D {
-  var c: C(D);
+  var c: C(borrowed D);
 }
 
 var d = new borrowed D();

--- a/test/classes/deitz/suite1/test1.chpl
+++ b/test/classes/deitz/suite1/test1.chpl
@@ -3,6 +3,6 @@ class C {
   var x : t;
 }
 
-var c : C(int) = new unmanaged C(int, 12);
+var c : unmanaged C(int) = new unmanaged C(int, 12);
 writeln(c);
 delete c;

--- a/test/classes/deitz/suite1/test2.chpl
+++ b/test/classes/deitz/suite1/test2.chpl
@@ -3,6 +3,6 @@ class C {
   var x : t;
 }
 
-var c : C(int) = new unmanaged C(int, 12);
+var c : unmanaged C(int) = new unmanaged C(int, 12);
 writeln(c);
 delete c;

--- a/test/classes/deitz/suite1/test5.chpl
+++ b/test/classes/deitz/suite1/test5.chpl
@@ -3,6 +3,6 @@ class C {
   var x : t;
 }
 
-var c : C(t = int) = new borrowed C(t = int);
+var c : borrowed C(t = int) = new borrowed C(t = int);
 c.x = 12;
 writeln(c);

--- a/test/classes/deitz/types/sum_type1.chpl
+++ b/test/classes/deitz/types/sum_type1.chpl
@@ -6,11 +6,11 @@ class D {
   var y : real = 2.0;
 }
 
-proc foo(c : C) {
+proc foo(c : borrowed C) {
   writeln(c.x);
 }
 
-proc foo(d : D) {
+proc foo(d : borrowed D) {
   writeln(d.y);
 }
 
@@ -18,7 +18,7 @@ proc bar(e) {
   foo(e);
 }
 
-var c : C = new borrowed C(), d : D = new borrowed D();
+var c : borrowed C = new borrowed C(), d : borrowed D = new borrowed D();
 
 foo(c);
 foo(d);

--- a/test/classes/deitz/types/type_constructor_error.chpl
+++ b/test/classes/deitz/types/type_constructor_error.chpl
@@ -3,5 +3,5 @@ class C {
   var x: t;
 }
 
-var c: C(int, 1);
+var c: borrowed C(int, 1);
 writeln(c);

--- a/test/classes/deitz/types/type_constructor_error2.chpl
+++ b/test/classes/deitz/types/type_constructor_error2.chpl
@@ -3,5 +3,5 @@ class C {
   var x: t;
 }
 
-var c = C(int, 1);
+var c = borrowed C(int, 1);
 writeln(c);

--- a/test/classes/deitz/types/type_constructor_error3.chpl
+++ b/test/classes/deitz/types/type_constructor_error3.chpl
@@ -3,5 +3,5 @@ class C {
   var x: t;
 }
 
-var c = C(int);
+var c = unmanaged C(int);
 writeln(c);


### PR DESCRIPTION
Running testing with --warn-unstable revealed some warnings.
This PR fixes about 100 tests to not warn.

For #9829.

Trivial test changes only - not reviewed.

- [x] full local testing