### PR TITLE
Improvements to lifetime checker

### DIFF
--- a/compiler/resolution/lifetime.cpp
+++ b/compiler/resolution/lifetime.cpp
@@ -653,7 +653,7 @@ static bool formalArgumentDoesNotImpactReturnLifetime(ArgSymbol* formal)
   // of a returned variable, since only return scope returns are allowed.
   if (formal->hasFlag(FLAG_SCOPE))
     return true;
- 
+
   return false;
 }
 
@@ -919,7 +919,7 @@ bool GatherRefTempsVisitor::enterCallExpr(CallExpr* call) {
         }
       }
     }
-    
+
     if (a && b) {
       addPairToDetempMap(a, b, lifetimes->detemp);
       lifetimes->callsToIgnore.insert(call);
@@ -998,11 +998,11 @@ bool IntrinsicLifetimesVisitor::enterDefExpr(DefExpr* def) {
 
     if (arg->hasFlag(FLAG_RETURN_SCOPE)) {
       if (sym->isRef() &&
-	  !intentIsLocalVariable(arg->intent) &&
-	  !intentIsLocalVariable(arg->originalIntent))
-	lp.referent.returnScope = true;
+          !intentIsLocalVariable(arg->intent) &&
+          !intentIsLocalVariable(arg->originalIntent))
+        lp.referent.returnScope = true;
       if (isSubjectToBorrowLifetimeAnalysis(sym->type))
-	lp.borrowed.returnScope = true;
+        lp.borrowed.returnScope = true;
     }
   } else if (VarSymbol* var = toVarSymbol(sym)) {
     // Don't bother getting intrinsic lifetime for RVV
@@ -1034,7 +1034,7 @@ bool IntrinsicLifetimesVisitor::enterDefExpr(DefExpr* def) {
     // Handle types that should have infinite borrow lifetime
     if (sym->type && typeHasInfiniteBorrowLifetime(sym->type))
       lp.borrowed = infiniteLifetime();
-   
+
     if (sym->id == debugLifetimesForId)
       gdbShouldBreakHere();
 
@@ -1045,13 +1045,13 @@ bool IntrinsicLifetimesVisitor::enterDefExpr(DefExpr* def) {
 }
 
 static bool isCallToFunctionReturningNotOwned(CallExpr* call) {
-  
+
   FnSymbol* calledFn = call->resolvedOrVirtualFunction();
   if (calledFn &&
       calledFn->hasEitherFlag(FLAG_RETURN_NOT_OWNED,
                               FLAG_RETURNS_ALIASING_ARRAY))
     return true;
-  
+
   return false;
 }
 
@@ -1075,7 +1075,7 @@ bool IntrinsicLifetimesVisitor::enterCallExpr(CallExpr* call) {
 
     AggregateType* at = toAggregateType(initSym->getValType());
     INT_ASSERT(at && isRecord(at));
- 
+
     // Start with a lifetime already determined, in case we
     // visit the same one more than once due to canonicalizing temps
     if (lifetimes->intrinsicLifetime.count(initSym))
@@ -1083,10 +1083,10 @@ bool IntrinsicLifetimesVisitor::enterCallExpr(CallExpr* call) {
 
     if (recordContainsOwnedClassFields(at)) {
       if (isCallToFunctionReturningNotOwned(initCall)) {
-	// leave it unknown. 
+        // leave it unknown.
       } else {
-	// set it to this variable's reachability, under the assumption that
-	// it will be destroyed when it goes out of scope.
+        // set it to this variable's reachability, under the assumption that
+        // it will be destroyed when it goes out of scope.
         lt = reachabilityLifetimeForSymbol(initSym);
       }
     }
@@ -1099,7 +1099,7 @@ bool IntrinsicLifetimesVisitor::enterCallExpr(CallExpr* call) {
     Symbol* lhs = lhsSe->symbol();
     CallExpr* rhsCall = toCallExpr(rhsExpr);
     initSym = lifetimes->getCanonicalSymbol(lhs);
-    
+
     if (initSym->hasFlag(FLAG_TEMP) &&
         rhsCall &&
         shouldPropagateLifetimeTo(rhsCall, initSym)) {
@@ -1135,10 +1135,10 @@ bool IntrinsicLifetimesVisitor::enterCallExpr(CallExpr* call) {
     lifetimes->intrinsicLifetime[initSym].borrowed = lt;
   }
 
-  return false; 
+  return false;
 }
 
- 
+
 bool InferLifetimesVisitor::enterCallExpr(CallExpr* call) {
 
   if (call->id == debugLifetimesForId)
@@ -1171,16 +1171,16 @@ bool InferLifetimesVisitor::enterCallExpr(CallExpr* call) {
     if (shouldPropagateLifetimeTo(call, lhs)) {
 
       Expr* rhsExpr = call->get(2);
-      
+
       bool usedAsRef = lhs->isRef() && rhsExpr->isRef();
       bool usedAsBorrow = isOrContainsBorrowedClass(lhs->type);
 
       LifetimePair lp = lifetimes->inferredLifetimeForExpr(rhsExpr,
                                                            usedAsRef,
                                                            usedAsBorrow);
- 
+
       if (lhs->isRef() && rhsExpr->isRef()) {
-        // When setting the reference, set its intrinsic lifetime. 
+        // When setting the reference, set its intrinsic lifetime.
         if (!lp.referent.unknown || !lp.borrowed.unknown) {
           if (lhs->id == debugLifetimesForId)
             gdbShouldBreakHere();
@@ -1189,14 +1189,14 @@ bool InferLifetimesVisitor::enterCallExpr(CallExpr* call) {
           intrinsic = minimumLifetimePair(intrinsic, lp);
         }
       }
-      
+
       if (!(lhs->isRef() && rhsExpr->isRef()))
-	// lhs can't have ref lifetime if it isn't a ref
-	lp.referent = unknownLifetime();
+        // lhs can't have ref lifetime if it isn't a ref
+        lp.referent = unknownLifetime();
 
       if (!isOrContainsBorrowedClass(lhs->type))
         // lhs can't have borrow lifetime if it can't borrow
-	lp.borrowed = unknownLifetime();
+        lp.borrowed = unknownLifetime();
 
       lp.referent.relevantExpr = call;
       lp.borrowed.relevantExpr = call;
@@ -1261,7 +1261,7 @@ bool InferLifetimesVisitor::enterForLoop(ForLoop* forLoop) {
       lp = infiniteLifetimePair();
     }
 
-    // Set intrinsic lifetime for index here at it's definition point 
+    // Set intrinsic lifetime for index here at it's definition point
     if (index->isRef()) {
       if (!lp.referent.unknown || !lp.borrowed.unknown) {
         if (index->id == debugLifetimesForId)

--- a/compiler/resolution/lifetime.cpp
+++ b/compiler/resolution/lifetime.cpp
@@ -1335,7 +1335,6 @@ bool EmitLifetimeErrorsVisitor::enterCallExpr(CallExpr* call) {
 
     SymExpr* lhsSe = toSymExpr(call->get(1));
     Symbol* lhs = lhsSe->symbol();
-    Expr* rhsExpr = call->get(2);
 
     if (isSubjectToRefLifetimeAnalysis(lhs) ||
         isSubjectToBorrowLifetimeAnalysis(lhs)) {
@@ -1427,8 +1426,6 @@ void EmitLifetimeErrorsVisitor::emitBadAssignErrors(CallExpr* call) {
   SymExpr* lhsSe = toSymExpr(call->get(1));
   Symbol* lhs = lhsSe->symbol();
   Expr* rhsExpr = call->get(2);
-
-  FnSymbol* inFn = call->getFunction();
 
   LifetimePair lhsInferred = lifetimes->inferredLifetimeForSymbol(lhs);
   LifetimePair lhsIntrinsic = lifetimes->intrinsicLifetimeForSymbol(lhs);

--- a/modules/internal/OwnedObject.chpl
+++ b/modules/internal/OwnedObject.chpl
@@ -172,7 +172,7 @@ module OwnedObject {
        If this record was already managing a non-nil instance,
        that instance will be deleted.
      */
-    proc ref retain(newPtr:p.type) {
+    proc ref retain(newPtr:unmanaged p.type) {
       var oldPtr = p;
       p = newPtr;
       if oldPtr then
@@ -183,10 +183,10 @@ module OwnedObject {
        Empty this :record:`Owned` so that it manages `nil`.
        Returns the instance previously managed by this :record:`Owned`.
      */
-    proc ref release():p.type {
+    proc ref release():unmanaged p.type {
       var oldPtr = p;
       p = nil;
-      return oldPtr;
+      return _to_unmanaged(oldPtr);
     }
 
     /*

--- a/modules/internal/SharedObject.chpl
+++ b/modules/internal/SharedObject.chpl
@@ -177,7 +177,7 @@ module SharedObject {
        If this record was the last :record:`Shared` managing a
        non-nil instance, that instance will be deleted.
      */
-    proc ref retain(newPtr:p.type) {
+    proc ref retain(newPtr:unmanaged p.type) {
       clear();
       this.p = newPtr;
       if newPtr != nil {

--- a/test/classes/delete-free/lifetimes/bad-push-back-borrow.chpl
+++ b/test/classes/delete-free/lifetimes/bad-push-back-borrow.chpl
@@ -1,0 +1,34 @@
+pragma "safe"
+module BadPushBackBorrow {
+
+class I {
+  var dom: domain(1);
+  var r: [dom] string; 
+  proc init(in r: [?dom] string) {
+    this.dom = dom;
+    this.r = r;
+  }
+}
+
+class D {
+  var iArr: [1..0] borrowed I;
+}
+
+var i = new shared I(['a', 'b']);
+var d = new owned D();
+
+proc addone()
+{
+  // This should result in lifetime checking errror.
+  //  * shared I destroyed at the end of this function
+  //  * a borrow of it is saved in d.iArr.
+  d.iArr.push_back(new shared I(i.r));
+}
+
+addone();
+
+for element in d.iArr {
+  writeln(element);
+}
+
+}

--- a/test/classes/delete-free/lifetimes/bad-push-back-borrow.future
+++ b/test/classes/delete-free/lifetimes/bad-push-back-borrow.future
@@ -1,0 +1,2 @@
+bug: lifetime checking does not work with push_back
+#9853

--- a/test/classes/delete-free/lifetimes/bad-push-back-borrow.good
+++ b/test/classes/delete-free/lifetimes/bad-push-back-borrow.good
@@ -1,0 +1,2 @@
+bad-push-back-borrow.chpl:20: In function 'addone':
+bad-push-back-borrow.chpl:25: error: Scoped variable would outlive the value it is set to

--- a/test/classes/delete-free/lifetimes/bad-return-infinite-lifetime-error.chpl
+++ b/test/classes/delete-free/lifetimes/bad-return-infinite-lifetime-error.chpl
@@ -1,0 +1,18 @@
+pragma "safe"
+module TestInfiniteLifetime {
+
+  class MyClass {
+    var x:int;
+  }
+
+  pragma "fn returns infinite lifetime"
+  proc f(const ref arg: borrowed MyClass) const ref {
+    return arg; // this should be an error
+  }
+
+  proc test() {
+    var x = new MyClass(1);
+    var y = f(x);
+  }
+  test();
+}

--- a/test/classes/delete-free/lifetimes/bad-return-infinite-lifetime-error.good
+++ b/test/classes/delete-free/lifetimes/bad-return-infinite-lifetime-error.good
@@ -1,0 +1,5 @@
+bad-return-infinite-lifetime-error.chpl:9: In function 'f':
+bad-return-infinite-lifetime-error.chpl:10: error: Reference to return scoped variable arg cannot be returned in function returning infinite lifetime
+bad-return-infinite-lifetime-error.chpl:9: note: consider scope of arg
+bad-return-infinite-lifetime-error.chpl:10: error: Return scope variable arg cannot be returned in function returning infinite lifetime
+bad-return-infinite-lifetime-error.chpl:9: note: consider scope of arg

--- a/test/classes/delete-free/lifetimes/bad-save-borrow-outer-array.chpl
+++ b/test/classes/delete-free/lifetimes/bad-save-borrow-outer-array.chpl
@@ -1,0 +1,33 @@
+pragma "safe"
+module BadSaveBorrowInOuterArray {
+
+class C { }
+
+
+proc error1() {
+  var c: [1..3] C;
+  for i in 1..3 {
+    c[i] = new owned C();
+  }
+}
+error1();
+
+proc error2() {
+  var c: [1..3] C;
+  for i in 1..3 {
+    var myowned = new owned C();
+    c[i] = myowned;
+  }
+}
+error2();
+
+proc error3() {
+  var c: [1..3] C;
+  for i in 1..3 {
+    var myowned = new owned C();
+    c[i] = myowned.borrow();
+  }
+}
+error3();
+
+}

--- a/test/classes/delete-free/lifetimes/bad-save-borrow-outer-array.good
+++ b/test/classes/delete-free/lifetimes/bad-save-borrow-outer-array.good
@@ -1,0 +1,8 @@
+bad-save-borrow-outer-array.chpl:7: In function 'error1':
+bad-save-borrow-outer-array.chpl:10: error: Scoped variable would outlive the value it is set to
+bad-save-borrow-outer-array.chpl:15: In function 'error2':
+bad-save-borrow-outer-array.chpl:19: error: Scoped variable would outlive the value it is set to
+bad-save-borrow-outer-array.chpl:18: note: consider scope of myowned
+bad-save-borrow-outer-array.chpl:24: In function 'error3':
+bad-save-borrow-outer-array.chpl:28: error: Scoped variable would outlive the value it is set to
+bad-save-borrow-outer-array.chpl:27: note: consider scope of myowned

--- a/test/classes/delete-free/lifetimes/borrow-escapes.good
+++ b/test/classes/delete-free/lifetimes/borrow-escapes.good
@@ -2,7 +2,8 @@ borrow-escapes.chpl:45: In function 'bad1':
 borrow-escapes.chpl:48: error: Scoped variable global would outlive the value it is set to
 borrow-escapes.chpl:46: note: consider scope of r
 borrow-escapes.chpl:52: In function 'bad2':
-borrow-escapes.chpl:57: error: Scoped variable outer reachable after lifetime ends
+borrow-escapes.chpl:57: error: Scoped variable outer would outlive the value it is set to
+borrow-escapes.chpl:55: note: consider scope of r
 borrow-escapes.chpl:63: In function 'bad3':
 borrow-escapes.chpl:67: error: Scoped variable global would outlive the value it is set to
 borrow-escapes.chpl:64: note: consider scope of group
@@ -12,8 +13,11 @@ borrow-escapes.chpl:73: In function 'bad10':
 borrow-escapes.chpl:79: error: Scoped variable cannot be returned
 borrow-escapes.chpl:77: note: consider scope of r
 borrow-escapes.chpl:83: In function 'bad21':
-borrow-escapes.chpl:88: error: Scoped variable outer reachable after lifetime ends
+borrow-escapes.chpl:88: error: Scoped variable outer would outlive the value it is set to
+borrow-escapes.chpl:86: note: consider scope of r
 borrow-escapes.chpl:94: In function 'bad22':
-borrow-escapes.chpl:100: error: Scoped variable outer reachable after lifetime ends
+borrow-escapes.chpl:100: error: Scoped variable outer would outlive the value it is set to
+borrow-escapes.chpl:97: note: consider scope of r
 borrow-escapes.chpl:106: In function 'bad23':
-borrow-escapes.chpl:111: error: Scoped variable outer reachable after lifetime ends
+borrow-escapes.chpl:111: error: Scoped variable outer would outlive the value it is set to
+borrow-escapes.chpl:109: note: consider scope of r

--- a/test/classes/delete-free/lifetimes/current-gaps.chpl
+++ b/test/classes/delete-free/lifetimes/current-gaps.chpl
@@ -8,15 +8,6 @@ class MyClass {
 }
 
 
-/*(The question is, if you mutated a ref to a borrow, would  the other borrow
-  checking rules catch an error, or would it cause a gap in the checking?)
- */
-proc bad1(ref r:MyClass) {
-
-  var owny = new Owned(new MyClass(1));
-  r = owny.borrow();
-}
-
 /* 
    Another question: What if a method on a global variable of record or class
    type sets a field from a borrow?
@@ -37,7 +28,6 @@ proc test() {
   var myowned = new Owned(new MyClass(1));
 
   var borrow = myowned.borrow();
-  bad1(borrow);
   bad2(borrow);
 }
 

--- a/test/classes/delete-free/lifetimes/current-gaps.future
+++ b/test/classes/delete-free/lifetimes/current-gaps.future
@@ -1,3 +1,0 @@
-feature request: more complete lifetime checking
-
-#8382

--- a/test/classes/delete-free/lifetimes/current-gaps.good
+++ b/test/classes/delete-free/lifetimes/current-gaps.good
@@ -1,2 +1,6 @@
-error: bad2
-error: badF3
+current-gaps.chpl:21: In function 'bad2':
+current-gaps.chpl:24: error: Scoped variable would outlive the value it is set to
+current-gaps.chpl:21: note: consider scope of arg
+current-gaps.chpl:57: In function 'badF3':
+current-gaps.chpl:62: error: Scoped variable r2 cannot be returned
+current-gaps.chpl:59: note: consider scope of r

--- a/test/classes/delete-free/lifetimes/current-gaps.good
+++ b/test/classes/delete-free/lifetimes/current-gaps.good
@@ -1,3 +1,2 @@
-error: bad1
 error: bad2
 error: badF3

--- a/test/classes/delete-free/lifetimes/mutate-ref-borrow.chpl
+++ b/test/classes/delete-free/lifetimes/mutate-ref-borrow.chpl
@@ -1,0 +1,27 @@
+pragma "safe"
+module MutateRefBorrow {
+
+class MyClass {
+  var x:int;
+}
+
+
+/*(The question is, if you mutated a ref to a borrow, would  the other borrow
+  checking rules catch an error, or would it cause a gap in the checking?)
+ */
+proc bad1(ref r:MyClass) {
+
+  var owny = new owned MyClass(1);
+  r = owny.borrow();
+}
+
+proc test() {
+  var myowned = new owned MyClass(1);
+
+  var borrow = myowned.borrow();
+  bad1(borrow);
+}
+
+test();
+
+}

--- a/test/classes/delete-free/lifetimes/mutate-ref-borrow.good
+++ b/test/classes/delete-free/lifetimes/mutate-ref-borrow.good
@@ -1,0 +1,3 @@
+mutate-ref-borrow.chpl:12: In function 'bad1':
+mutate-ref-borrow.chpl:15: error: Scoped variable r would outlive the value it is set to
+mutate-ref-borrow.chpl:14: note: consider scope of owny

--- a/test/classes/delete-free/lifetimes/push-back-borrow.chpl
+++ b/test/classes/delete-free/lifetimes/push-back-borrow.chpl
@@ -1,0 +1,29 @@
+pragma "safe"
+module SaveBorrowInCollection {
+
+class MyClass {
+  var x:int;
+}
+
+var A:[1..1] borrowed MyClass;
+
+proc setA(arg: borrowed MyClass) {
+  A[1] = arg;
+}
+
+var global: borrowed MyClass;
+
+var globalA: [1..1] borrowed MyClass;
+
+proc error7(arg: borrowed MyClass) {
+  globalA.push_back(arg);
+}
+
+proc test() {
+  var x = new owned MyClass(1);
+  var b = x.borrow();
+  error7(b);
+}
+test();
+
+}

--- a/test/classes/delete-free/lifetimes/push-back-borrow.future
+++ b/test/classes/delete-free/lifetimes/push-back-borrow.future
@@ -1,0 +1,3 @@
+bug: lifetime checking does not error on bad push_back
+
+#9853

--- a/test/classes/delete-free/lifetimes/push-back-borrow.good
+++ b/test/classes/delete-free/lifetimes/push-back-borrow.good
@@ -1,0 +1,3 @@
+push-back-borrow.chpl:18: In function 'error7':
+push-back-borrow.chpl:19: error: Scoped variable would outlive the value it is set to
+push-back-borrow.chpl:18: note: consider scope of arg

--- a/test/classes/delete-free/lifetimes/record-borrows-and-owns.chpl
+++ b/test/classes/delete-free/lifetimes/record-borrows-and-owns.chpl
@@ -1,10 +1,12 @@
 pragma "safe"
 module zz {
 
+pragma "use default init"
 class MyClass {
   var x:int;
 }
 
+pragma "use default init"
 record R {
   var _borrowed:MyClass;
 
@@ -31,7 +33,7 @@ proc makeR2(borrow:MyClass) {
   return r;
 }
 
-proc myfun(ref lhs:R, const ref arg:R) {
+proc badMyFun(ref lhs:R, const ref arg:R) {
   var tmp:R;
   tmp = arg;
   tmp.myowned = nil;
@@ -51,7 +53,8 @@ proc badF2(borrow:MyClass) {
 }
 
 proc badF3() {
-  var c = new MyClass(1);
+  var own = new owned MyClass(1);
+  var c = own.borrow();
   var r = makeR(c);
   {
     var r2 = makeR(r._borrowed);
@@ -59,8 +62,24 @@ proc badF3() {
   }
 }
 
+proc badF4() {
+  var a = new R(nil, new MyClass(10));
+  return makeR(a.myowned);
+  // a's destructor will delete a.myowned
+}
+
+proc badF5() {
+  var a = makeR(nil);
+  return makeR(a.myowned);
+}
+
+proc badF6() {
+  var a = makeR(nil);
+  return makeR(a.readOwned());
+}
+
 config const branch = false;
-proc g() {
+proc badF7() {
   var a = makeR(nil);
   if branch then
     return a;
@@ -68,7 +87,7 @@ proc g() {
     return makeR(a.myowned);
 }
 
-proc h() {
+proc badF8() {
   var a = makeR(nil);
   if branch then
     return a;
@@ -78,19 +97,25 @@ proc h() {
 
 
 proc test() {
-  var c = new MyClass(1);
+  var myborrow = new MyClass(1);
   
-  var v1 = makeR(c);
-  var v2:R;
-  myfun(v2, v1);
+  var a = makeR(myborrow);
+  var b:R;
+  badMyFun(b, a);
   
-  var v3 = badF1(c);
-  var v4 = makeR2(c);
-  var v5 = g();
-  var v6 = h();
-  var v7 = badF2(c);
-  badF3();
+  var v1 = badF1(myborrow);
+  var c = makeR2(myborrow);
+  var v2 = badF2(myborrow);
+  var v3 = badF3();
+  var v4 = badF4();
+  var v5 = badF5();
+  var v6 = badF6();
+  var v7 = badF7();
+  var v8 = badF8();
 
+  writeln(a);
+  writeln(b);
+  writeln(c);
   writeln(v1);
   writeln(v2);
   writeln(v3);
@@ -98,6 +123,7 @@ proc test() {
   writeln(v5);
   writeln(v6);
   writeln(v7);
+  writeln(v8);
 }
 
 test();

--- a/test/classes/delete-free/lifetimes/record-borrows-and-owns.good
+++ b/test/classes/delete-free/lifetimes/record-borrows-and-owns.good
@@ -1,6 +1,27 @@
-record-borrows-and-owns.chpl:41: In function 'badF1':
-record-borrows-and-owns.chpl:43: error: Scoped variable cannot be returned
-record-borrows-and-owns.chpl:42: note: consider scope of r
-record-borrows-and-owns.chpl:47: In function 'badF2':
-record-borrows-and-owns.chpl:49: error: Scoped variable cannot be returned
-record-borrows-and-owns.chpl:48: note: consider scope of r
+record-borrows-and-owns.chpl:36: In function 'badMyFun':
+record-borrows-and-owns.chpl:40: error: Scoped variable lhs would outlive the value it is set to
+record-borrows-and-owns.chpl:37: note: consider scope of tmp
+record-borrows-and-owns.chpl:43: In function 'badF1':
+record-borrows-and-owns.chpl:45: error: Scoped variable cannot be returned
+record-borrows-and-owns.chpl:44: note: consider scope of r
+record-borrows-and-owns.chpl:49: In function 'badF2':
+record-borrows-and-owns.chpl:51: error: Scoped variable cannot be returned
+record-borrows-and-owns.chpl:50: note: consider scope of r
+record-borrows-and-owns.chpl:55: In function 'badF3':
+record-borrows-and-owns.chpl:61: error: Scoped variable r2 cannot be returned
+record-borrows-and-owns.chpl:56: note: consider scope of own
+record-borrows-and-owns.chpl:65: In function 'badF4':
+record-borrows-and-owns.chpl:67: error: Scoped variable cannot be returned
+record-borrows-and-owns.chpl:66: note: consider scope of a
+record-borrows-and-owns.chpl:71: In function 'badF5':
+record-borrows-and-owns.chpl:73: error: Scoped variable cannot be returned
+record-borrows-and-owns.chpl:72: note: consider scope of a
+record-borrows-and-owns.chpl:76: In function 'badF6':
+record-borrows-and-owns.chpl:78: error: Scoped variable cannot be returned
+record-borrows-and-owns.chpl:77: note: consider scope of a
+record-borrows-and-owns.chpl:82: In function 'badF7':
+record-borrows-and-owns.chpl:87: error: Scoped variable cannot be returned
+record-borrows-and-owns.chpl:83: note: consider scope of a
+record-borrows-and-owns.chpl:90: In function 'badF8':
+record-borrows-and-owns.chpl:95: error: Scoped variable cannot be returned
+record-borrows-and-owns.chpl:91: note: consider scope of a

--- a/test/classes/delete-free/lifetimes/ref-borrow-escapes.good
+++ b/test/classes/delete-free/lifetimes/ref-borrow-escapes.good
@@ -7,3 +7,5 @@ ref-borrow-escapes.chpl:32: note: consider scope of arg
 ref-borrow-escapes.chpl:45: In function 'bad':
 ref-borrow-escapes.chpl:47: error: Reference to scoped variable cannot be returned
 ref-borrow-escapes.chpl:46: note: consider scope of b
+ref-borrow-escapes.chpl:47: error: Scoped variable cannot be returned
+ref-borrow-escapes.chpl:46: note: consider scope of b

--- a/test/classes/delete-free/lifetimes/save-borrow-in-collection.bad
+++ b/test/classes/delete-free/lifetimes/save-borrow-in-collection.bad
@@ -1,9 +1,0 @@
-save-borrow-in-collection.chpl:16: In function 'error1':
-save-borrow-in-collection.chpl:17: error: Scoped variable global would outlive the value it is set to
-save-borrow-in-collection.chpl:16: note: consider scope of arg
-save-borrow-in-collection.chpl:20: In function 'error2':
-save-borrow-in-collection.chpl:22: error: Scoped variable global would outlive the value it is set to
-save-borrow-in-collection.chpl:20: note: consider scope of arg
-save-borrow-in-collection.chpl:40: In function 'error5':
-save-borrow-in-collection.chpl:41: error: Scoped variable would outlive the value it is set to
-save-borrow-in-collection.chpl:40: note: consider scope of arg

--- a/test/classes/delete-free/lifetimes/save-borrow-in-collection.bad
+++ b/test/classes/delete-free/lifetimes/save-borrow-in-collection.bad
@@ -1,0 +1,9 @@
+save-borrow-in-collection.chpl:16: In function 'error1':
+save-borrow-in-collection.chpl:17: error: Scoped variable global would outlive the value it is set to
+save-borrow-in-collection.chpl:16: note: consider scope of arg
+save-borrow-in-collection.chpl:20: In function 'error2':
+save-borrow-in-collection.chpl:22: error: Scoped variable global would outlive the value it is set to
+save-borrow-in-collection.chpl:20: note: consider scope of arg
+save-borrow-in-collection.chpl:40: In function 'error5':
+save-borrow-in-collection.chpl:41: error: Scoped variable would outlive the value it is set to
+save-borrow-in-collection.chpl:40: note: consider scope of arg

--- a/test/classes/delete-free/lifetimes/save-borrow-in-collection.chpl
+++ b/test/classes/delete-free/lifetimes/save-borrow-in-collection.chpl
@@ -1,0 +1,72 @@
+pragma "safe"
+module SaveBorrowInCollection {
+
+class MyClass {
+  var x:int;
+}
+
+var A:[1..1] borrowed MyClass;
+
+proc setA(arg: borrowed MyClass) {
+  A[1] = arg;
+}
+
+var global: borrowed MyClass;
+
+proc error1(arg: borrowed MyClass) {
+  global = arg;
+}
+
+proc error2(arg: borrowed MyClass) {
+  var x = arg;
+  global = x;
+}
+
+proc error3(arg: borrowed MyClass) {
+  ref x = global;
+  x = arg;
+}
+
+record BorrowedThing {
+  var b: borrowed MyClass;
+}
+
+var globalB: BorrowedThing;
+
+proc error4(arg: borrowed MyClass) {
+  globalB.b = arg;
+}
+
+proc BorrowedThing.error5(arg: borrowed MyClass) {
+  this.b = arg;
+}
+
+proc call_error5(arg: borrowed MyClass) {
+  globalB.error5(arg);
+}
+
+var globalA: [1..1] borrowed MyClass;
+
+proc error6(arg: borrowed MyClass) {
+  globalA[1] = arg;
+}
+
+proc error7(arg: borrowed MyClass) {
+  globalA.push_back(arg);
+}
+
+
+proc test() {
+  var x = new owned MyClass(1);
+  var b = x.borrow();
+  error1(b);
+  error2(b);
+  error3(b);
+  error4(b);
+  call_error5(b);
+  error6(b);
+  error7(b);
+}
+test();
+
+}

--- a/test/classes/delete-free/lifetimes/save-borrow-in-collection.chpl
+++ b/test/classes/delete-free/lifetimes/save-borrow-in-collection.chpl
@@ -51,11 +51,6 @@ proc error6(arg: borrowed MyClass) {
   globalA[1] = arg;
 }
 
-proc error7(arg: borrowed MyClass) {
-  globalA.push_back(arg);
-}
-
-
 proc test() {
   var x = new owned MyClass(1);
   var b = x.borrow();
@@ -65,7 +60,6 @@ proc test() {
   error4(b);
   call_error5(b);
   error6(b);
-  error7(b);
 }
 test();
 

--- a/test/classes/delete-free/lifetimes/save-borrow-in-collection.future
+++ b/test/classes/delete-free/lifetimes/save-borrow-in-collection.future
@@ -1,0 +1,2 @@
+bug: lifetime checking does misses invalid borrows saved in collection
+#9853

--- a/test/classes/delete-free/lifetimes/save-borrow-in-collection.future
+++ b/test/classes/delete-free/lifetimes/save-borrow-in-collection.future
@@ -1,2 +1,0 @@
-bug: lifetime checking does misses invalid borrows saved in collection
-#9853

--- a/test/classes/delete-free/lifetimes/save-borrow-in-collection.good
+++ b/test/classes/delete-free/lifetimes/save-borrow-in-collection.good
@@ -16,6 +16,3 @@ save-borrow-in-collection.chpl:40: note: consider scope of arg
 save-borrow-in-collection.chpl:50: In function 'error6':
 save-borrow-in-collection.chpl:51: error: Scoped variable would outlive the value it is set to
 save-borrow-in-collection.chpl:50: note: consider scope of arg
-save-borrow-in-collection.chpl:54: In function 'error7':
-save-borrow-in-collection.chpl:55: error: Scoped variable would outlive the value it is set to
-save-borrow-in-collection.chpl:54: note: consider scope of arg

--- a/test/classes/delete-free/lifetimes/save-borrow-in-collection.good
+++ b/test/classes/delete-free/lifetimes/save-borrow-in-collection.good
@@ -1,0 +1,21 @@
+save-borrow-in-collection.chpl:16: In function 'error1':
+save-borrow-in-collection.chpl:17: error: Scoped variable global would outlive the value it is set to
+save-borrow-in-collection.chpl:16: note: consider scope of arg
+save-borrow-in-collection.chpl:20: In function 'error2':
+save-borrow-in-collection.chpl:22: error: Scoped variable global would outlive the value it is set to
+save-borrow-in-collection.chpl:20: note: consider scope of arg
+save-borrow-in-collection.chpl:25: In function 'error3':
+save-borrow-in-collection.chpl:27: error: Scoped variable x would outlive the value it is set to
+save-borrow-in-collection.chpl:25: note: consider scope of arg
+save-borrow-in-collection.chpl:36: In function 'error4':
+save-borrow-in-collection.chpl:37: error: Scoped variable would outlive the value it is set to
+save-borrow-in-collection.chpl:36: note: consider scope of arg
+save-borrow-in-collection.chpl:40: In function 'error5':
+save-borrow-in-collection.chpl:41: error: Scoped variable would outlive the value it is set to
+save-borrow-in-collection.chpl:40: note: consider scope of arg
+save-borrow-in-collection.chpl:50: In function 'error6':
+save-borrow-in-collection.chpl:51: error: Scoped variable would outlive the value it is set to
+save-borrow-in-collection.chpl:50: note: consider scope of arg
+save-borrow-in-collection.chpl:54: In function 'error7':
+save-borrow-in-collection.chpl:55: error: Scoped variable would outlive the value it is set to
+save-borrow-in-collection.chpl:54: note: consider scope of arg

--- a/test/classes/delete-free/tests-from-design-overview/generic-collection-unspecified-with-type.chpl
+++ b/test/classes/delete-free/tests-from-design-overview/generic-collection-unspecified-with-type.chpl
@@ -7,6 +7,7 @@ record Collection {
   var element: elementType;
 }
 
+pragma "unsafe" // TODO
 proc Collection.addElement(arg: elementType) {
   element = arg;
 }

--- a/test/classes/delete-free/tests-from-design-overview/generic-collection-unspecified.chpl
+++ b/test/classes/delete-free/tests-from-design-overview/generic-collection-unspecified.chpl
@@ -6,6 +6,7 @@ record Collection {
   var element;
 }
 
+pragma "unsafe" // TODO
 proc Collection.addElement(arg: element.type) {
   element = arg;
 }


### PR DESCRIPTION
* Does a better job of removing reference and other compiler-added temporaries 
  for the purpose of the analysis
* Removes several workarounds
* Distinguishes between unknown and infinite lifetimes
* Separate traversal now computes the intrinsic lifetime for each variable. 
  This is the "natural" lifetime of the variable (e.g. the reachability / 
  scope for a record). Doing this separately clarifies the follow on code 
  that uses this concept.
* Several erroneous cases that were previously undetected are now detected.

Resolves #9857
Resolves #9714

Passed full local testing.
Passed full local futures testing.

Reviewed by @vasslitvinov - thanks!