### PR TITLE
Get more tests working with --warn-unstable

### DIFF
--- a/test/classes/deitz/types/type_to_value_error.chpl
+++ b/test/classes/deitz/types/type_to_value_error.chpl
@@ -2,7 +2,7 @@ class C {
   var x: int;
 }
 
-var c: C;
+var c: borrowed C;
 
 c = C();
 

--- a/test/classes/deitz/types/type_to_value_error.compopts
+++ b/test/classes/deitz/types/type_to_value_error.compopts
@@ -1,0 +1,1 @@
+--no-warn-unstable

--- a/test/classes/delete-free/coercions-generic.chpl
+++ b/test/classes/delete-free/coercions-generic.chpl
@@ -9,10 +9,10 @@ proc test1() {
 }
 
 proc test2() {
-  var instance:MyClass(int) = new Owned(new MyClass(1));
+  var instance:borrowed MyClass(int) = new Owned(new MyClass(1));
 }
 
-proc acceptMyClass(c:MyClass) {
+proc acceptMyClass(c:borrowed MyClass) {
   writeln(c);
 }
 

--- a/test/classes/delete-free/coercions-shared.chpl
+++ b/test/classes/delete-free/coercions-shared.chpl
@@ -9,11 +9,12 @@ class SubClass : MyClass {
 }
 
 proc test1() {
-  var instance = new MyClass(1);
+  var instance = new unmanaged MyClass(1);
+  delete instance;
 }
 
 proc test2() {
-  var instance:MyClass = new Shared(new MyClass(1));
+  var instance:borrowed MyClass = new Shared(new MyClass(1));
 }
 
 proc acceptMyClass(c:MyClass) {

--- a/test/classes/delete-free/coercions.chpl
+++ b/test/classes/delete-free/coercions.chpl
@@ -9,14 +9,15 @@ class SubClass : MyClass {
 }
 
 proc test1() {
-  var instance = new MyClass(1);
+  var instance = new unmanaged MyClass(1);
+  delete instance;
 }
 
 proc test2() {
-  var instance:MyClass = new Owned(new MyClass(1));
+  var instance:Owned(MyClass) = new Owned(new MyClass(1));
 }
 
-proc acceptMyClass(c:MyClass) {
+proc acceptMyClass(c:borrowed MyClass) {
   writeln(c);
 }
 

--- a/test/classes/delete-free/owned/make-owned-in-forall-expr-typed.chpl
+++ b/test/classes/delete-free/owned/make-owned-in-forall-expr-typed.chpl
@@ -3,7 +3,7 @@ class C {
   var x: t;
 }
 
-proc foo(c: C) {
+proc foo(c: borrowed C) {
   return c.x;
 }
 

--- a/test/classes/delete-free/owned/make-owned-in-forall-expr.chpl
+++ b/test/classes/delete-free/owned/make-owned-in-forall-expr.chpl
@@ -3,7 +3,7 @@ class C {
   var x: t;
 }
 
-proc foo(c: C) {
+proc foo(c: borrowed C) {
   return c.x;
 }
 

--- a/test/classes/delete-free/owned/owned-error-handling.chpl
+++ b/test/classes/delete-free/owned/owned-error-handling.chpl
@@ -3,7 +3,7 @@ use OwnedObject;
 
 class Foo {
   proc foobar() throws {
-    throw new Error();
+    throw new unmanaged Error();
   }
 }
 

--- a/test/classes/delete-free/owned/owned-ref-borrow-explicit.chpl
+++ b/test/classes/delete-free/owned/owned-ref-borrow-explicit.chpl
@@ -4,7 +4,7 @@ class MyClass {
   var x:int;
 }
 
-proc acceptRef(ref arg:MyClass) {
+proc acceptRef(ref arg:borrowed MyClass) {
   var other = new Owned(new MyClass(2));
   arg = other;
 }

--- a/test/classes/delete-free/owned/owned-ref-borrow-implicit.chpl
+++ b/test/classes/delete-free/owned/owned-ref-borrow-implicit.chpl
@@ -4,7 +4,7 @@ class MyClass {
   var x:int;
 }
 
-proc acceptRef(ref arg:MyClass) {
+proc acceptRef(ref arg:borrowed MyClass) {
   var other = new Owned(new MyClass(2));
   arg = other;
 }

--- a/test/classes/delete-free/owned/owned-subtyping.chpl
+++ b/test/classes/delete-free/owned/owned-subtyping.chpl
@@ -7,7 +7,7 @@ class Array {
   proc foo(in arg:owned Domain) {
     writeln("In parent foo");
   }
-  proc bar(arg:Domain) {
+  proc bar(arg:borrowed Domain) {
     writeln("In parent bar");
   }
 }
@@ -15,7 +15,7 @@ class MyArray : Array {
   var x;
 }
 
-proc baz(arg:Domain) {
+proc baz(arg:borrowed Domain) {
   writeln("In bar arg:Domain");
 }
 

--- a/test/classes/delete-free/shared/shared-subtyping.chpl
+++ b/test/classes/delete-free/shared/shared-subtyping.chpl
@@ -7,7 +7,7 @@ class Array {
   proc foo(in arg:shared Domain) {
     writeln("In parent foo");
   }
-  proc bar(arg:Domain) {
+  proc bar(arg:borrowed Domain) {
     writeln("In parent bar");
   }
 }
@@ -15,7 +15,7 @@ class MyArray : Array {
   var x;
 }
 
-proc baz(arg:Domain) {
+proc baz(arg:borrowed Domain) {
   writeln("In bar arg:Domain");
 }
 

--- a/test/classes/delete-free/tests-from-design-overview/class-subtyping.chpl
+++ b/test/classes/delete-free/tests-from-design-overview/class-subtyping.chpl
@@ -27,7 +27,7 @@ proc test1() {
 }
 test1();
 
-proc borrowParent(arg: ParentClass) {
+proc borrowParent(arg: borrowed ParentClass) {
   writeln("in borrowParent");
 }
 

--- a/test/classes/delete-free/tests-from-design-overview/lifetime-checking.chpl
+++ b/test/classes/delete-free/tests-from-design-overview/lifetime-checking.chpl
@@ -11,7 +11,7 @@ class MyClass {
 proc test() {
   var a: owned MyClass = new owned MyClass();
   // the instance referred to by a is deleted at end of scope
-  var c: MyClass = a.borrow();
+  var c: borrowed MyClass = a.borrow();
   // c "borrows" to the instance managed by a
   return c; // lifetime checker error! returning borrow from local variable
   // a is deleted here

--- a/test/classes/delete-free/unmanaged/make-unmanaged-in-forall-expr-typed.chpl
+++ b/test/classes/delete-free/unmanaged/make-unmanaged-in-forall-expr-typed.chpl
@@ -3,7 +3,7 @@ class C {
   var x: t;
 }
 
-proc foo(c: C) {
+proc foo(c: unmanaged C) {
   return c.x;
 }
 

--- a/test/classes/delete-free/unmanaged/make-unmanaged-in-forall-expr.chpl
+++ b/test/classes/delete-free/unmanaged/make-unmanaged-in-forall-expr.chpl
@@ -3,7 +3,7 @@ class C {
   var x: t;
 }
 
-proc foo(c: C) {
+proc foo(c: unmanaged C) {
   return c.x;
 }
 

--- a/test/classes/delete-free/unmanaged/unmanaged-cast-void-ptr.chpl
+++ b/test/classes/delete-free/unmanaged/unmanaged-cast-void-ptr.chpl
@@ -10,7 +10,7 @@ class MyClass : ParentClass {
 
 proc test() {
   var x = new unmanaged MyClass(1);
-  var y = x:ParentClass;
+  var y = x:borrowed ParentClass;
   var z = x:c_void_ptr;
 
   if debug {
@@ -20,7 +20,7 @@ proc test() {
   }
 
   var x2 = x:unmanaged ParentClass;
-  var y2 = x2:MyClass;
+  var y2 = x2:borrowed MyClass;
   var z2 = x2:c_void_ptr;
 
   if debug {

--- a/test/classes/delete-free/unmanaged/unmanaged-in-where.chpl
+++ b/test/classes/delete-free/unmanaged/unmanaged-in-where.chpl
@@ -17,8 +17,8 @@ proc foo(type t)
 
 proc test() {
   foo(unmanaged MyDomain(int));
-  foo(MyDomain(int));
+  foo(borrowed MyDomain(int));
   foo(unmanaged Domain);
-  foo(Domain);
+  foo(borrowed Domain);
 }
 test();

--- a/test/classes/delete-free/unmanaged/unmanaged-subtyping.chpl
+++ b/test/classes/delete-free/unmanaged/unmanaged-subtyping.chpl
@@ -7,7 +7,7 @@ class Array {
   proc foo(arg:unmanaged Domain) {
     writeln("In parent foo");
   }
-  proc bar(arg:Domain) {
+  proc bar(arg:borrowed Domain) {
     writeln("In parent bar");
   }
 }
@@ -15,7 +15,7 @@ class MyArray : Array {
   var x;
 }
 
-proc baz(arg:Domain) {
+proc baz(arg:borrowed Domain) {
   writeln("In bar arg:Domain");
 }
 

--- a/test/classes/deleting/deinitOnNil.chpl
+++ b/test/classes/deleting/deinitOnNil.chpl
@@ -4,5 +4,5 @@ class C {
   }
 }
 
-var myC: C;
+var myC: unmanaged C;
 delete myC;

--- a/test/classes/deleting/deleteMultiple.chpl
+++ b/test/classes/deleting/deleteMultiple.chpl
@@ -6,7 +6,7 @@ class C {
   }
 }
 
-var x = new C(1),
-    y = new C(2);
+var x = new unmanaged C(1),
+    y = new unmanaged C(2);
 
 delete x, y;

--- a/test/classes/dinan/array_of_recursive_classes.chpl
+++ b/test/classes/dinan/array_of_recursive_classes.chpl
@@ -1,10 +1,10 @@
 class A {
   var x: int;
-  var b: [1..x] B;
+  var b: [1..x] unmanaged B;
 }
 
 class B {
-  var a: A;   // This produces an error
+  var a: unmanaged A;   // This produces an error
 //var a: A(); // This works
 }
 

--- a/test/classes/dinan/array_passed_to_constructor.chpl
+++ b/test/classes/dinan/array_passed_to_constructor.chpl
@@ -19,7 +19,7 @@ var x: [1..M] int;
 for xx in x do xx = 1;
 
 var pre  = memoryUsed() - prepre;
-var y    = new Doppelganger(x);
+var y    = new unmanaged Doppelganger(x);
 var post = memoryUsed() - prepre;
 
 if post >= 2*pre then

--- a/test/classes/dinan/circular_init_broken.chpl
+++ b/test/classes/dinan/circular_init_broken.chpl
@@ -3,6 +3,6 @@ class C {
   var b: int = a-1;
 }
 
-var c: C = new C(1);
+var c: borrowed C = new borrowed C(1);
 
 writeln("a=", c.a, " b=", c.b);

--- a/test/classes/dinan/circular_init_broken2.chpl
+++ b/test/classes/dinan/circular_init_broken2.chpl
@@ -3,6 +3,6 @@ class C {
   var b: int = a-1;
 }
 
-var c: C = new C(b=1);
+var c: borrowed C = new borrowed C(b=1);
 
 writeln("a=", c.a, " b=", c.b);

--- a/test/classes/dinan/circular_init_unbroken.chpl
+++ b/test/classes/dinan/circular_init_unbroken.chpl
@@ -3,6 +3,6 @@ class C {
   var b: int = a-1;
 }
 
-var c: C = new C();
+var c: borrowed C = new borrowed C();
 
 writeln("a=", c.a, " b=", c.b);

--- a/test/classes/dinan/default_initializer.chpl
+++ b/test/classes/dinan/default_initializer.chpl
@@ -6,7 +6,4 @@ class Matrix {
   var data: [dom] element_t = initVal;
 }
 
-var m = new Matrix(real, {1..10, 1..10}, 1.0);
-
-delete m;
-
+var m = new owned Matrix(real, {1..10, 1..10}, 1.0);

--- a/test/classes/dinan/dynamic_dispatch.chpl
+++ b/test/classes/dinan/dynamic_dispatch.chpl
@@ -12,7 +12,7 @@ class B: A {
 
 var a  = new borrowed A();
 var b  = new borrowed B();
-var ba = b:A;
+var ba = b:borrowed A;
 
 writeln("a   says: ", a.fcn());
 writeln("b   says: ", b.fcn());

--- a/test/classes/dinan/generic_constructor.chpl
+++ b/test/classes/dinan/generic_constructor.chpl
@@ -7,6 +7,6 @@ class Foo {
   }
 }
 
-var bar = new Foo(int, 5, 10);
+var bar = new owned Foo(int, 5, 10);
 
 writeln(bar.x);

--- a/test/classes/dinan/parent_class_cast.chpl
+++ b/test/classes/dinan/parent_class_cast.chpl
@@ -11,7 +11,7 @@ class D: P {
 }
 
 // OK: var ps: [1..2] P = (C():P, D():P);
-var ps: [1..2] P = (new borrowed C(), new borrowed D());
+var ps: [1..2] borrowed P = (new borrowed C(), new borrowed D());
 
 for i in ps do
     writeln(i.f());

--- a/test/classes/dinan/use_of_uninitialized_field.chpl
+++ b/test/classes/dinan/use_of_uninitialized_field.chpl
@@ -3,6 +3,6 @@ class C {
   var y: int = 1;
 }
 
-var c: C = new C();
+var c: borrowed C = new borrowed C();
 
 writeln(c.x, " ", c.y);

--- a/test/classes/diten/callNilClassesMethod.chpl
+++ b/test/classes/diten/callNilClassesMethod.chpl
@@ -9,6 +9,6 @@ class Unallocated {
 }
 
 proc main {
-  var aaa: Unallocated;
+  var aaa: unmanaged Unallocated;
   writeln(aaa.method());
 }

--- a/test/classes/diten/class_nest_simple.chpl
+++ b/test/classes/diten/class_nest_simple.chpl
@@ -20,7 +20,7 @@ class myouter {
 }
 
 proc main() {
-  var outside: myouter = new unmanaged myouter();
+  var outside: unmanaged myouter = new unmanaged myouter();
 
   outside.foo();
 

--- a/test/classes/diten/class_with_domain_and_array.chpl
+++ b/test/classes/diten/class_with_domain_and_array.chpl
@@ -8,6 +8,6 @@ class Function1d {
 }
 
 proc main() {
-  var f: Function1d;
+  var f: unmanaged Function1d;
   //var ff = new Function1d();
 }

--- a/test/classes/diten/instantiatedClassname.chpl
+++ b/test/classes/diten/instantiatedClassname.chpl
@@ -4,9 +4,9 @@ class C {
   param c: int = 3;
 }
 
-proc foo(c: C) {
+proc foo(c: borrowed C) {
   writeln(c.b);
 }
 
-var c: C(b = 1);
+var c: borrowed C(b = 1);
 foo(c);

--- a/test/classes/diten/instantiatedClassname.good
+++ b/test/classes/diten/instantiatedClassname.good
@@ -1,2 +1,2 @@
 instantiatedClassname.chpl:12: error: unresolved call 'foo(C(1,1,3))'
-instantiatedClassname.chpl:7: note: candidates are: foo(c: C)
+instantiatedClassname.chpl:7: note: candidates are: foo(c: borrowed C)

--- a/test/classes/diten/method_named_chpl_destroy.chpl
+++ b/test/classes/diten/method_named_chpl_destroy.chpl
@@ -4,6 +4,6 @@ class C {
   }
 }
 proc main {
-  var c = new C();
+  var c = new unmanaged C();
   delete c;
 }

--- a/test/classes/diten/multipledestructor.chpl
+++ b/test/classes/diten/multipledestructor.chpl
@@ -4,6 +4,6 @@ class C {
 proc C.deinit() { writeln("In deinit #2"); }
 
 proc main {
-  var c = new C();
+  var c = new unmanaged C();
   delete c;
 }

--- a/test/classes/diten/nearestMutualParentClass.chpl
+++ b/test/classes/diten/nearestMutualParentClass.chpl
@@ -84,8 +84,8 @@ proc nearestMutualParentClass(type car, type cdr...?k) type where k != 1 {
 }
 
 proc main {
-  var c: nearestMutualParentClass(E, D, C, C2, F) = new borrowed E();
-  var d: nearestMutualParentClass(E, D, C) = new borrowed E();
+  var c: borrowed nearestMutualParentClass(borrowed E, borrowed D, borrowed C, borrowed C2, borrowed F) = new borrowed E();
+  var d: borrowed nearestMutualParentClass(borrowed E, borrowed D, borrowed C) = new borrowed E();
   writeln(c.name);
   writeln(c.ddName());
   writeln(d.name);

--- a/test/classes/diten/nesting_with_inheritance2.chpl
+++ b/test/classes/diten/nesting_with_inheritance2.chpl
@@ -1,12 +1,12 @@
 class intList {
-  var head: Node;
+  var head: unmanaged Node;
   class Node {
     var value: int;
-    var next: Node;
+    var next: unmanaged Node;
   }
 
   proc insert(value: int) {
-    head = new Node(value, head);
+    head = new unmanaged Node(value, head);
   }
 
   iter these() {
@@ -21,18 +21,18 @@ class intList {
 class intSortedList: intList {
   proc insert(value: int) {
     if head == nil || head.value >= value {
-      head = new Node(value, head);
+      head = new unmanaged Node(value, head);
       return;
     }
     var current = head;
     while current.next != nil && current.next.value < value do
       current = current.next;
-    current.next = new Node(value, current.next);
+    current.next = new unmanaged Node(value, current.next);
   }
 }
 
 proc main() {
-  var lst = new intSortedList();
+  var lst = new unmanaged intSortedList();
 
   delete lst;
 }

--- a/test/classes/diten/nilDynamicDispatch.chpl
+++ b/test/classes/diten/nilDynamicDispatch.chpl
@@ -10,7 +10,7 @@ class D:C {
   }
 }
 
-var c: C;
-var d: D;
+var c: borrowed C;
+var d: borrowed D;
 
 c.foo();

--- a/test/classes/diten/override_with_subclass_ret_type.chpl
+++ b/test/classes/diten/override_with_subclass_ret_type.chpl
@@ -28,7 +28,7 @@ class B: A {
 }
 
 proc main {
-  var a: A = new unmanaged B(1, 2.0);
+  var a: unmanaged A = new unmanaged B(1, 2.0);
   var ic_b = a.foo();
 
   ic_b.bar();

--- a/test/classes/diten/override_with_subclass_ret_type_generic.chpl
+++ b/test/classes/diten/override_with_subclass_ret_type_generic.chpl
@@ -26,8 +26,8 @@ class B: A {
 }
 
 proc main {
-  var a: A = new unmanaged B(1, "a string");
-  var d: C = a.foo();
+  var a: unmanaged A = new unmanaged B(1, "a string");
+  var d: unmanaged C = a.foo();
 
   d.bar();
 

--- a/test/classes/diten/paramFieldNonParamInit.chpl
+++ b/test/classes/diten/paramFieldNonParamInit.chpl
@@ -6,5 +6,5 @@ class Foo {
   param field = notParam(1);
 }
 
-var f = new Foo();
+var f = new unmanaged Foo();
 delete f;

--- a/test/classes/diten/shadow_with_different_type.chpl
+++ b/test/classes/diten/shadow_with_different_type.chpl
@@ -8,7 +8,7 @@ class Sub: Base {
 
 proc main() {
   var sub         = new unmanaged Sub();
-  var base:Base() = sub;
+  var base:unmanaged Base() = sub;
   var base2       = new unmanaged Base();
 
   base.s = "Base";

--- a/test/classes/diten/test_destroy.chpl
+++ b/test/classes/diten/test_destroy.chpl
@@ -6,6 +6,6 @@ proc C.deinit() { writeln("In destructor"); }
 
 
 proc main {
-  var c: C = new unmanaged C(1,2,3);
+  var c: unmanaged C = new unmanaged C(1,2,3);
   delete c;
 }

--- a/test/classes/diten/test_destroy2.chpl
+++ b/test/classes/diten/test_destroy2.chpl
@@ -11,6 +11,6 @@ class C {
 }
 
 proc main {
-  var c = new C(1,2,3);
+  var c = new unmanaged C(1,2,3);
   delete c;
 }

--- a/test/classes/diten/test_shadowing.chpl
+++ b/test/classes/diten/test_shadowing.chpl
@@ -14,7 +14,7 @@ class Extension : Base {
 
 proc main() {
   var ext       = new unmanaged Extension();
-  var base:Base = ext;
+  var base:borrowed Base = ext;
 
   writeln(ext.total);  // expect the total field from Extension
   ext.printTotal();    // expect the method from Extension

--- a/test/classes/elliot/non-captured-virtual-return.chpl
+++ b/test/classes/elliot/non-captured-virtual-return.chpl
@@ -6,5 +6,5 @@ class Child: Parent {
   proc foo() { return (1,1); }
 }
 
-var child: Parent = new borrowed Child();
+var child: borrowed Parent = new borrowed Child();
 child.foo();

--- a/test/classes/ferguson/default-type-ctor-bug.chpl
+++ b/test/classes/ferguson/default-type-ctor-bug.chpl
@@ -10,7 +10,7 @@ class MyClass {
 }
 
 proc test() {
-  var c:MyClass(int);
+  var c:borrowed MyClass(int);
 }
 
 test();

--- a/test/classes/ferguson/delete-free/owned-coerce.chpl
+++ b/test/classes/ferguson/delete-free/owned-coerce.chpl
@@ -7,7 +7,7 @@ class C {
   }
 }
 
-proc myLegacyFunction(arg:C) {
+proc myLegacyFunction(arg:borrowed C) {
   writeln(arg.x);
 }
 

--- a/test/classes/ferguson/delete-free/owned-shared-fields.chpl
+++ b/test/classes/ferguson/delete-free/owned-shared-fields.chpl
@@ -18,8 +18,8 @@ record R1 {
 }
 
 record R2 {
-  var fo:Owned(MyClass) = new Owned(nil:MyClass);
-  var fs:Shared(MyClass) = new Shared(nil:MyClass);
+  var fo:Owned(MyClass) = new Owned(nil:unmanaged MyClass);
+  var fs:Shared(MyClass) = new Shared(nil:unmanaged MyClass);
   proc init() {
   }
 }
@@ -51,8 +51,8 @@ class C1 {
 }
 
 class C2 {
-  var fo:Owned(MyClass) = new Owned(nil:MyClass);
-  var fs:Shared(MyClass) = new Shared(nil:MyClass);
+  var fo:Owned(MyClass) = new Owned(nil:unmanaged MyClass);
+  var fs:Shared(MyClass) = new Shared(nil:unmanaged MyClass);
   proc init() {
   }
 }
@@ -60,7 +60,7 @@ class C2 {
 class C3 {
   var fo:Owned(MyClass);
   var fs:Shared(MyClass);
-  proc init(a:MyClass, b:MyClass) {
+  proc init(a:unmanaged MyClass, b:unmanaged MyClass) {
     fo = new Owned(a);
     fs = new Shared(b);
   }
@@ -69,7 +69,7 @@ class C3 {
 class C4 {
   var fo:Owned(MyClass);
   var fs:Shared(MyClass);
-  proc init(a:MyClass, b:MyClass) {
+  proc init(a:unmanaged MyClass, b:unmanaged MyClass) {
     super.init();
     fo = new Owned(a);
     fs = new Shared(b);

--- a/test/classes/ferguson/delete-free/shared-demo.chpl
+++ b/test/classes/ferguson/delete-free/shared-demo.chpl
@@ -41,7 +41,7 @@ proc examples() {
   // for a Shared to point to.
   // After this line:
   //  shared1 will contain C(100)
-  shared1.retain(new C(100));
+  shared1.retain(new unmanaged C(100));
   writeln("after shared1.retain C(100)");
   writeln("shared1 = ", shared1.borrow());
 

--- a/test/classes/ferguson/delete-free/shared1.chpl
+++ b/test/classes/ferguson/delete-free/shared1.chpl
@@ -16,7 +16,7 @@ proc run() {
   var x = new Shared(new Impl(1));
   writeln(x.borrow());
 
-  var c:Impl = nil;
+  var c:unmanaged Impl = nil;
   var y = new Shared(c);
   writeln(y.borrow());
 }

--- a/test/classes/ferguson/dynamic-cast-generic-insn.chpl
+++ b/test/classes/ferguson/dynamic-cast-generic-insn.chpl
@@ -17,12 +17,12 @@ for param i in 1..n {
   A[i] = new unmanaged Grandchild(p=i, x=i, y=i, z=i);
 }
 
-var first:Parent = A[1];
+var first:borrowed Parent = A[1];
 writeln("Attempting dynamic cast to Child");
-var c = first:Child;
+var c = first:borrowed Child;
 writeln(c);
 writeln("Attempting dynamic cast to Grandchild");
-var gc = first:Grandchild(1);
+var gc = first:borrowed Grandchild(1);
 writeln(gc);
 
 for a in A do delete a;

--- a/test/classes/ferguson/forwarding/d-class-to-class.chpl
+++ b/test/classes/ferguson/forwarding/d-class-to-class.chpl
@@ -15,7 +15,7 @@ class C {
   proc baz() { field = 1; }
 }
 
-var r = new Wrapper(new unmanaged C());
+var r = new unmanaged Wrapper(new unmanaged C());
 r.foo(); // direct method shadows forwarding method
 r.bar(); // same as r.instance.bar(), prints "in C.foo()"
 

--- a/test/classes/ferguson/forwarding/d-defaultargs.chpl
+++ b/test/classes/ferguson/forwarding/d-defaultargs.chpl
@@ -32,7 +32,7 @@ record WrapperTwo {
 }
 
 {
-  var b = new WrapperTwo(new WrapperOne(new D(1.0)));
+  var b = new WrapperTwo(new WrapperOne(new unmanaged D(1.0)));
 
   b.f(2.0,3.0);
   b.f(2.0,3.0,4.0);

--- a/test/classes/ferguson/forwarding/d-duplicate.chpl
+++ b/test/classes/ferguson/forwarding/d-duplicate.chpl
@@ -1,6 +1,6 @@
 record Wrapper {
-  forwarding var a:A;
-  forwarding var b:B;
+  forwarding var a:unmanaged A;
+  forwarding var b:unmanaged B;
   proc deinit() {
     delete a, b;
   }

--- a/test/classes/ferguson/forwarding/d-multiple.chpl
+++ b/test/classes/ferguson/forwarding/d-multiple.chpl
@@ -1,6 +1,6 @@
 record Wrapper {
-  forwarding var a:A;
-  forwarding var b:B;
+  forwarding var a:unmanaged A;
+  forwarding var b:unmanaged B;
   proc deinit() {
     delete a,b;
   }

--- a/test/classes/ferguson/forwarding/d-short.chpl
+++ b/test/classes/ferguson/forwarding/d-short.chpl
@@ -1,5 +1,5 @@
 record Wrapper {
-  forwarding var instance:C;
+  forwarding var instance:unmanaged C;
   proc foo() { writeln("in Wrapper.foo()"); }
   proc deinit() {
     delete instance;

--- a/test/classes/ferguson/forwarding/forward-inherited-generic.chpl
+++ b/test/classes/ferguson/forwarding/forward-inherited-generic.chpl
@@ -14,7 +14,7 @@ class Deque : Collection {
 
 record wrapper {
     type t;
-    var instance : Deque(t);
+    var instance : unmanaged Deque(t);
 
     inline proc _value { 
         if instance == nil then

--- a/test/classes/ferguson/forwarding/forward-inherited.chpl
+++ b/test/classes/ferguson/forwarding/forward-inherited.chpl
@@ -7,7 +7,7 @@ class Child : Parent {
 }
 
 record wrapper {
-  var c:Child;
+  var c:unmanaged Child;
   forwarding c;
 }
 

--- a/test/classes/ferguson/forwarding/forward-iterator-lf.chpl
+++ b/test/classes/ferguson/forwarding/forward-iterator-lf.chpl
@@ -21,11 +21,11 @@ class Impl {
 }
 
 record R {
-  forwarding var impl:Impl;
+  forwarding var impl:unmanaged Impl;
 }
 
 proc test() {
-  var r = new R(new Impl());
+  var r = new R(new unmanaged Impl());
   forall i in r {
     writeln(i);
   }

--- a/test/classes/ferguson/forwarding/forward-iterator-modify-ref.chpl
+++ b/test/classes/ferguson/forwarding/forward-iterator-modify-ref.chpl
@@ -9,11 +9,11 @@ class Impl {
 }
 
 record R {
-  forwarding var impl:Impl;
+  forwarding var impl:unmanaged Impl;
 }
 
 proc test() {
-  var r = new R(new Impl());
+  var r = new R(new unmanaged Impl());
   for i in r.these() {
     writeln(i);
     globalOne += 1;

--- a/test/classes/ferguson/forwarding/forward-iterator-modify.chpl
+++ b/test/classes/ferguson/forwarding/forward-iterator-modify.chpl
@@ -9,7 +9,7 @@ class Impl {
 }
 
 record R {
-  forwarding var impl:Impl;
+  forwarding var impl:unmanaged Impl;
 }
 
 proc test() {

--- a/test/classes/ferguson/forwarding/forward-iterator-standalone.chpl
+++ b/test/classes/ferguson/forwarding/forward-iterator-standalone.chpl
@@ -26,14 +26,15 @@ class Impl {
 }
 
 record R {
-  forwarding var impl:Impl;
+  forwarding var impl:unmanaged Impl;
 }
 
 proc test() {
-  var r = new R(new Impl());
+  var r = new R(new unmanaged Impl());
   forall i in r {
     writeln(i);
   }
+  delete r.impl;
 }
 
 test();

--- a/test/classes/ferguson/generic-field/generic-field-default-init.chpl
+++ b/test/classes/ferguson/generic-field/generic-field-default-init.chpl
@@ -9,9 +9,9 @@ class GenericClass {
 }
 
 proc test() {
-  var x = new GenericClass(new GenericRecord(1));
-  var y:GenericClass = new GenericClass(new GenericRecord(1));
-  var z:GenericClass(GenericRecord(int)) = new GenericClass(new GenericRecord(1));
+  var x = new borrowed GenericClass(new GenericRecord(1));
+  var y:borrowed GenericClass = new borrowed GenericClass(new GenericRecord(1));
+  var z:borrowed GenericClass(GenericRecord(int)) = new borrowed GenericClass(new GenericRecord(1));
 
   writeln(x.type:string, " ", x);
   writeln(y.type:string, " ", y);

--- a/test/classes/ferguson/generic-field/generic-field-integral-not-inited.chpl
+++ b/test/classes/ferguson/generic-field/generic-field-integral-not-inited.chpl
@@ -5,7 +5,7 @@ class GenericClass {
 
 
 proc test() {
-  var x:GenericClass(int);
+  var x:borrowed GenericClass(int);
 
   writeln(x.type:string, " ", x);
 }

--- a/test/classes/ferguson/generic-field/generic-field-integral.chpl
+++ b/test/classes/ferguson/generic-field/generic-field-integral.chpl
@@ -8,8 +8,8 @@ class GenericClass {
 
 proc test() {
   var x = new borrowed GenericClass(1);
-  var y:GenericClass = new borrowed GenericClass(2);
-  var z:GenericClass(int) = new borrowed GenericClass(2);
+  var y:borrowed GenericClass = new borrowed GenericClass(2);
+  var z:borrowed GenericClass(int) = new borrowed GenericClass(2);
 
   writeln(x.type:string, " ", x);
   writeln(y.type:string, " ", y);

--- a/test/classes/ferguson/generic-field/generic-field.chpl
+++ b/test/classes/ferguson/generic-field/generic-field.chpl
@@ -13,8 +13,8 @@ class GenericClass {
 
 proc test() {
   var x = new borrowed GenericClass(new GenericRecord(1));
-  var y:GenericClass = new borrowed GenericClass(new GenericRecord(1));
-  var z:GenericClass(GenericRecord(int)) = new borrowed GenericClass(new GenericRecord(1));
+  var y:borrowed GenericClass = new borrowed GenericClass(new GenericRecord(1));
+  var z:borrowed GenericClass(GenericRecord(int)) = new borrowed GenericClass(new GenericRecord(1));
 
   writeln(x.type:string, " ", x);
   writeln(y.type:string, " ", y);

--- a/test/classes/ferguson/generic-inherit-bug1.chpl
+++ b/test/classes/ferguson/generic-inherit-bug1.chpl
@@ -27,7 +27,7 @@ module Structure {
 
 
   class ListerGrandParent {
-    var lst: list(GrandParent);
+    var lst: unmanaged list(unmanaged GrandParent);
   }
 
   class ListerParent : ListerGrandParent {
@@ -36,14 +36,14 @@ module Structure {
     param stridable: bool;
 
     proc getListedType() type {
-      return Parent(rank=rank, idxType=idxType, stridable=stridable);
+      return unmanaged Parent(rank=rank, idxType=idxType, stridable=stridable);
     }
   }
 
-  proc test(lhs:?t) where t:ListerParent {
+  proc test(lhs:?t) where unmanaged t:unmanaged ListerParent {
     type subType = lhs.getListedType();
     for e in lhs.lst {
-      var eCast = e:subType;
+      var eCast = e:unmanaged subType;
       if eCast == nil then
         halt("X");
 

--- a/test/classes/ferguson/generic-inherit2.chpl
+++ b/test/classes/ferguson/generic-inherit2.chpl
@@ -32,6 +32,6 @@ c.overridden_method();
 c.child_method();
 
 writeln("Dynamic Child(int)");
-var pc:Parent(int) = c;
+var pc:borrowed Parent(int) = c;
 pc.parent_method();
 pc.overridden_method();

--- a/test/classes/ferguson/generic-inherit2a.chpl
+++ b/test/classes/ferguson/generic-inherit2a.chpl
@@ -20,6 +20,6 @@ class Child : Parent {
   }
 }
 writeln("Dynamic Child(int)");
-var pc:Parent(int) = new borrowed Child(int, 1, 2);
+var pc:borrowed Parent(int) = new borrowed Child(int, 1, 2);
 pc.parent_method();
 pc.overridden_method();

--- a/test/classes/ferguson/generic-inherit3.chpl
+++ b/test/classes/ferguson/generic-inherit3.chpl
@@ -33,7 +33,7 @@ c.overridden_method();
 c.child_method();
 
 writeln("Dynamic Child(int)");
-var pc:Parent = c;
+var pc:borrowed Parent = c;
 pc.parent_method();
 pc.overridden_method();
 delete pc;

--- a/test/classes/ferguson/generic-inherit4.chpl
+++ b/test/classes/ferguson/generic-inherit4.chpl
@@ -34,7 +34,7 @@ c.overridden_method();
 c.child_method();
 
 writeln("Dynamic Child(int,real)");
-var pc:Parent(int) = c;
+var pc:borrowed Parent(int) = c;
 pc.parent_method();
 pc.overridden_method();
 delete pc;

--- a/test/classes/ferguson/override/override-concrete-generic.chpl
+++ b/test/classes/ferguson/override/override-concrete-generic.chpl
@@ -14,7 +14,7 @@ class Child : Parent {
 proc test() {
   var x = new owned Child();
   var y = x.borrow();
-  var z = y:Parent;
+  var z = y:borrowed Parent;
   //y.f(1); // leads to ambiguity error currently
   z.f(1);
 }

--- a/test/classes/ferguson/override/override-concrete-generic2.chpl
+++ b/test/classes/ferguson/override/override-concrete-generic2.chpl
@@ -14,7 +14,7 @@ class Child : Parent {
 proc test() {
   var x = new owned Child();
   var y = x.borrow();
-  var z = y:Parent;
+  var z = y:borrowed Parent;
   y.f(1);
   // Currently an ambiguity error but the important
   // thing is that it's *some* sort of compilation failure.

--- a/test/classes/ferguson/override/override-missing1.chpl
+++ b/test/classes/ferguson/override/override-missing1.chpl
@@ -9,7 +9,7 @@ class Child : Parent {
 
 proc test() {
   var x = new owned Child();
-  var y = x.borrow():Parent;
+  var y = x.borrow():borrowed Parent;
   y.f();
 }
 test();


### PR DESCRIPTION
Running testing with --warn-unstable revealed some warnings.
This PR fixes about 80 tests to not warn.

For #9829.

Trivial test changes only - not reviewed.

- [x]  full local testing
