### PR TITLE
Clean up halts in glob() iterators

### DIFF
--- a/modules/standard/ChapelHaltWrappers.chpl
+++ b/modules/standard/ChapelHaltWrappers.chpl
@@ -66,4 +66,25 @@ module ChapelHaltWrappers {
   proc pureVirtualMethodHalt() {
     halt("pure virtual method called");
   }
+
+
+  //
+  // Halt wrappers for misc runtime time checks (where we expect these checks
+  // to halt even in an error-handling world.)
+  //
+
+  /* Halt wrapper for zippered iteration of unequal lengths */
+  pragma "function terminates program"
+  pragma "always propagate line file info"
+  proc zipLengthHalt(s:string) {
+    halt(s);
+  }
+
+  /* Halt wrapper for out of memory that mimics the runtime error */
+  pragma "function terminates program"
+  pragma "always propagate line file info"
+  proc outOfMemoryHalt(s:string) {
+    const err = "Out of memory allocating \"" + s + "\"";
+    __primitive("chpl_error", err.localize().c_str());
+  }
 }


### PR DESCRIPTION
Previously, the glob iterators used a `__primitive("chpl_error", ...)` if there
was an unhandled error from `chpl_clob()` (a thin wrapper over `glob()`). When
calling `glob()` with no flags like we do, the only possible error codes are
`GLOB_NOMATCH` and `GLOB_NOSPACE`. `GLOB_NOMATCH` is innocuous and will just
result in an empty iterator. `GLOB_NOSPACE` occurs if the `malloc()` inside of
glob fails, so just convert that into our usual "Out of memory allocating ..."
error

I didn't want to update all the callsites of chpl_glob to do this error
checking so I just made a glob_w wrapper that does the checking. That seemed
like a nice cleanup, so I made similar wrappers for the other glob routines to
cleanup a lot of safeCasts at callsites.

This also converts a halt() for bad zippered iteration to use the new
zipLengthHalt() wrapper.

Closes https://github.com/chapel-lang/chapel/issues/9654