### PR TITLE
Skip an HDF5 test if the HDF5 library is not found

### DIFF
--- a/test/library/standard/DataFrames/diten/readHDF5Df.skipif
+++ b/test/library/standard/DataFrames/diten/readHDF5Df.skipif
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+
+# The HDF5 package requires the hdf5 library.
+#
+# Installation of the HDF5 library is detected with the find_library function,
+# which looks for the appropriate dynamic library (e.g. libhdf5.so).
+# Note that if the dynamic library is found, this test assumes that the
+# header and static library are available.
+
+from __future__ import print_function
+from ctypes.util import find_library
+
+print(find_library('hdf5') is None)


### PR DESCRIPTION
Add a .skipif to skip running this HDF5 test when the HDF5 library is not
available on the system.