### PR TITLE
Convert more tests for --warn-unstable

### DIFF
--- a/test/classes/ferguson/override/override-missing-ignored.chpl
+++ b/test/classes/ferguson/override/override-missing-ignored.chpl
@@ -9,7 +9,7 @@ class Child : Parent {
 
 proc test() {
   var x = new owned Child();
-  var y = x.borrow():Parent;
+  var y = x.borrow():borrowed Parent;
   y.f();
 }
 test();

--- a/test/classes/ferguson/override/override-ok.chpl
+++ b/test/classes/ferguson/override/override-ok.chpl
@@ -12,7 +12,7 @@ class Child : Parent {
 
 proc test() {
   var x = new owned Child();
-  var y = x.borrow():Parent;
+  var y = x.borrow():borrowed Parent;
   y.f();
 }
 test();

--- a/test/classes/figueroa/BogusDestructors.chpl
+++ b/test/classes/figueroa/BogusDestructors.chpl
@@ -6,5 +6,5 @@ class C {
 
 proc C.deinit () {writeln("inside C.~C");}
 
-var c: C;
+var c: unmanaged C;
 delete c; // not intended to be executed

--- a/test/classes/figueroa/DestructorSubclassing1.chpl
+++ b/test/classes/figueroa/DestructorSubclassing1.chpl
@@ -8,4 +8,4 @@ class C2: C1 {
   proc deinit () {writeln("Inside ~C2");}
 }
 
-var c2: C2 = new borrowed C2();
+var c2: borrowed C2 = new borrowed C2();

--- a/test/classes/figueroa/ErroneousOpOverloading1.chpl
+++ b/test/classes/figueroa/ErroneousOpOverloading1.chpl
@@ -2,4 +2,4 @@ class C {
   proc +(x) {writeln("In +, x is ", x);}
 }
 
-var c: C = new C();
+var c: borrowed C = new borrowed C();

--- a/test/classes/figueroa/ErroneousOpOverloading2.chpl
+++ b/test/classes/figueroa/ErroneousOpOverloading2.chpl
@@ -2,4 +2,4 @@ class C {
 }
 
 proc C.-(x) {writeln("In -, x is ", x);}
-var c: C = new C();
+var c: borrowed C = new borrowed C();

--- a/test/classes/forwarding/forwardErrors.chpl
+++ b/test/classes/forwarding/forwardErrors.chpl
@@ -1,7 +1,7 @@
 
 record B {
   proc foo() throws {
-    throw new Error();
+    throw new unmanaged Error();
   }
 }
 

--- a/test/classes/generic/varOverBadGeneric.chpl
+++ b/test/classes/generic/varOverBadGeneric.chpl
@@ -3,6 +3,6 @@ class C {
   var x: t;
 }
 
-var myC: C;
-myC = new C();
+var myC: borrowed C;
+myC = new borrowed C();
 writeln(myC);

--- a/test/classes/generic/varOverGeneric.chpl
+++ b/test/classes/generic/varOverGeneric.chpl
@@ -3,5 +3,5 @@ class C {
   var x: t;
 }
 
-var myC: C = new C(int, 1);
+var myC: borrowed C = new borrowed C(int, 1);
 writeln(myC);

--- a/test/classes/hilde/callUserDefaultConstructor.chpl
+++ b/test/classes/hilde/callUserDefaultConstructor.chpl
@@ -7,7 +7,7 @@ class C
   proc deinit() { writeln("Called ~C()."); }
 }
 
-var c = new C();
+var c = new unmanaged C();
 delete c;
 
 writeln("Done.");

--- a/test/classes/hilde/inheritance/fields.chpl
+++ b/test/classes/hilde/inheritance/fields.chpl
@@ -23,8 +23,8 @@ class Derived : Base {
   proc dbName() return "dynamic Derived";
 }
 
-var b:Base;
-var d:Derived;
+var b:borrowed Base;
+var d:borrowed Derived;
 
 b = new borrowed Base();
 writeln(b.field);		// Expect "Base"

--- a/test/classes/initializers/array_passed_to_initializer.chpl
+++ b/test/classes/initializers/array_passed_to_initializer.chpl
@@ -22,7 +22,7 @@ var x: [1..M] int;
 for xx in x do xx = 1;
 
 var pre  = memoryUsed() - prepre;
-var y    = new Doppelganger(x);
+var y    = new unmanaged Doppelganger(x);
 var post = memoryUsed() - prepre;
 
 if post >= 2*pre then

--- a/test/classes/initializers/bothInitCalls.chpl
+++ b/test/classes/initializers/bothInitCalls.chpl
@@ -17,11 +17,11 @@ class EitherOr {
 }
 
 proc main() {
-  var c1: EitherOr = new unmanaged EitherOr(true);
+  var c1: unmanaged EitherOr = new unmanaged EitherOr(true);
   writeln(c1);
   delete c1;
 
-  var c2: EitherOr = new unmanaged EitherOr(false);
+  var c2: unmanaged EitherOr = new unmanaged EitherOr(false);
   writeln(c2);
   delete c2;
 }

--- a/test/classes/initializers/callUserDefaultInitializer.chpl
+++ b/test/classes/initializers/callUserDefaultInitializer.chpl
@@ -7,7 +7,7 @@ class C
   proc deinit() { writeln("Called C.deinit()."); }
 }
 
-var c = new C();
+var c = new unmanaged C();
 delete c;
 
 writeln("Done.");

--- a/test/classes/initializers/compilerGenerated/arrayField-sync.chpl
+++ b/test/classes/initializers/compilerGenerated/arrayField-sync.chpl
@@ -7,6 +7,6 @@ class C {
   }
 }
 
-var c = new C();
+var c = new unmanaged C();
 writeln(c);
 delete c;

--- a/test/classes/initializers/compilerGenerated/arrayField-userInit.chpl
+++ b/test/classes/initializers/compilerGenerated/arrayField-userInit.chpl
@@ -11,6 +11,5 @@ class C {
 const D = {1..3} dmapped Block({1..3});
 var A: [D] real;
 
-var myC = new C(A);
+var myC = new borrowed C(A);
 writeln("myC is: ", myC);
-delete myC;

--- a/test/classes/initializers/compilerGenerated/basic_check.chpl
+++ b/test/classes/initializers/compilerGenerated/basic_check.chpl
@@ -5,7 +5,7 @@ class LotsOFields {
 }
 
 proc main() {
-  var c: LotsOFields = new unmanaged LotsOFields(2, 6.3, true);
+  var c: unmanaged LotsOFields = new unmanaged LotsOFields(2, 6.3, true);
 
   writeln(c);
   delete c;

--- a/test/classes/initializers/compilerGenerated/classHoldsRecordDefaultArg.chpl
+++ b/test/classes/initializers/compilerGenerated/classHoldsRecordDefaultArg.chpl
@@ -10,6 +10,6 @@ class Holder {
   var h: Held;
 }
 
-var holder = new Holder();
+var holder = new unmanaged Holder();
 writeln(holder);
 delete holder;

--- a/test/classes/initializers/compilerGenerated/constructorChild.chpl
+++ b/test/classes/initializers/compilerGenerated/constructorChild.chpl
@@ -16,6 +16,5 @@ class Child: Parent {
   }
 }
 
-var child = new Child(4);
+var child = new borrowed Child(4);
 writeln(child);
-delete child;

--- a/test/classes/initializers/compilerGenerated/constructor_inherits_default.chpl
+++ b/test/classes/initializers/compilerGenerated/constructor_inherits_default.chpl
@@ -10,6 +10,6 @@ class Child: Parent {
   }
 }
 
-var c = new Child(3);
+var c = new unmanaged Child(3);
 writeln(c);
 delete c;

--- a/test/classes/initializers/compilerGenerated/defaultValueClassArg.chpl
+++ b/test/classes/initializers/compilerGenerated/defaultValueClassArg.chpl
@@ -2,7 +2,7 @@ class Foo {
   var x: int;
 }
 
-proc anyFunc(yVal = new Foo(2)) {
+proc anyFunc(yVal = new owned Foo(2)) {
   writeln(yVal);
 }
 

--- a/test/classes/initializers/compilerGenerated/dflt-ctor-generic-uninit-field-const-err-1.chpl
+++ b/test/classes/initializers/compilerGenerated/dflt-ctor-generic-uninit-field-const-err-1.chpl
@@ -4,4 +4,4 @@ class A {
   const c;
 }
 
-var x = new A();
+var x = new borrowed A();

--- a/test/classes/initializers/compilerGenerated/dflt-ctor-generic-uninit-field-param-err-1.chpl
+++ b/test/classes/initializers/compilerGenerated/dflt-ctor-generic-uninit-field-param-err-1.chpl
@@ -4,4 +4,4 @@ class A {
   param p;
 }
 
-var x = new A();
+var x = new borrowed A();

--- a/test/classes/initializers/compilerGenerated/dflt-ctor-generic-uninit-field-type-err-1.chpl
+++ b/test/classes/initializers/compilerGenerated/dflt-ctor-generic-uninit-field-type-err-1.chpl
@@ -4,4 +4,4 @@ class A {
   type t;
 }
 
-var x = new A();
+var x = new borrowed A();

--- a/test/classes/initializers/compilerGenerated/dflt-ctor-generic-uninit-field-var-err-1.chpl
+++ b/test/classes/initializers/compilerGenerated/dflt-ctor-generic-uninit-field-var-err-1.chpl
@@ -4,4 +4,4 @@ class A {
   var v;
 }
 
-var x = new A();
+var x = new borrowed A();

--- a/test/classes/initializers/compilerGenerated/fieldDefaultGlobalArray.chpl
+++ b/test/classes/initializers/compilerGenerated/fieldDefaultGlobalArray.chpl
@@ -7,9 +7,9 @@ class C {
   var a = A(2);
 }
 
-var c = new C();
+var c = new unmanaged C();
 A(2) = 2;
-var d = new C();
+var d = new unmanaged C();
 
 writeln(c);
 writeln(d);

--- a/test/classes/initializers/compilerGenerated/fieldDefaultGlobalArrayModified.chpl
+++ b/test/classes/initializers/compilerGenerated/fieldDefaultGlobalArrayModified.chpl
@@ -7,12 +7,9 @@ class C {
   var a = A(2) + 2;
 }
 
-var c = new C();
+var c = new borrowed C();
 A(2) = 2;
-var d = new C();
+var d = new borrowed C();
 
 writeln(c);
 writeln(d);
-
-delete c;
-delete d;

--- a/test/classes/initializers/compilerGenerated/generics/defaultTypeField.chpl
+++ b/test/classes/initializers/compilerGenerated/generics/defaultTypeField.chpl
@@ -15,5 +15,5 @@ class Child : Parent {
   var x : foo;
 }
 
-var c : Child(int);
+var c : borrowed Child(int);
 writeln("c.type = ", c.type:string);

--- a/test/classes/initializers/compilerGenerated/generics/grandParentField.chpl
+++ b/test/classes/initializers/compilerGenerated/generics/grandParentField.chpl
@@ -17,6 +17,5 @@ class Child : Parent {
   var indices : index(rank, idxType);
 }
 
-var c = new Child(1, int);
+var c = new borrowed Child(1, int);
 writeln("c = ", c);
-delete c;

--- a/test/classes/initializers/compilerGenerated/generics/namedParam.chpl
+++ b/test/classes/initializers/compilerGenerated/generics/namedParam.chpl
@@ -19,6 +19,5 @@ class Z : A {
   var d : Dummy(int, stridable=stridable);
 }
 
-var z = new Z(int, false);
+var z = new owned Z(int, false);
 writeln("z = ", z);
-delete z;

--- a/test/classes/initializers/compilerGenerated/generics/parentParamChildType.chpl
+++ b/test/classes/initializers/compilerGenerated/generics/parentParamChildType.chpl
@@ -13,10 +13,10 @@ class Parent {
 }
 
 class Child : Parent {
-  var y : Dummy(stridable);
+  var y : unmanaged Dummy(stridable);
 }
 
-var c = new Child(false, 5);
+var c = new unmanaged Child(false, 5);
 writeln('c = ', c);
 delete c;
 
@@ -32,10 +32,10 @@ class A {
 }
 
 class Z : A {
-  var x : Dummy(stridable);
+  var x : unmanaged Dummy(stridable);
 }
 
-var z = new Z(1, int, false);
+var z = new unmanaged Z(1, int, false);
 writeln("z = ", z);
 
 //
@@ -51,15 +51,16 @@ class DummyBaseDom {
 }
 
 class DummyMyDom : DummyBaseDom {
-  var locs : [1..4] DummyLocMyDom(rank, idxType, stridable);
+  var locs : [1..4] unmanaged DummyLocMyDom(rank, idxType, stridable);
 }
 
 class DummyLocMyDom {
   param rank : int;
   type idxType;
   param stridable : bool;
-  var parent : DummyMyDom(rank, idxType, stridable);
+  var parent : unmanaged DummyMyDom(rank, idxType, stridable);
 }
 
-var dmd = new DummyMyDom(1, int, false);
+var dmd = new unmanaged DummyMyDom(1, int, false);
 writeln("dmd = ", dmd);
+delete dmd;

--- a/test/classes/initializers/compilerGenerated/generics/withTypeDefault2.chpl
+++ b/test/classes/initializers/compilerGenerated/generics/withTypeDefault2.chpl
@@ -4,14 +4,11 @@ class Foo {
   var y = 12*3; // Verifies I haven't accidentally aborted resolution
 }
 
-var foo = new Foo(int);
+var foo = new borrowed Foo(int);
 
 writeln(foo.type: string);
 writeln(foo);
 
-var foo2 = new Foo();
+var foo2 = new borrowed Foo();
 writeln(foo2.type: string);
 writeln(foo2);
-
-delete foo;
-delete foo2;

--- a/test/classes/initializers/compilerGenerated/generics_check.chpl
+++ b/test/classes/initializers/compilerGenerated/generics_check.chpl
@@ -8,16 +8,14 @@ class GenericClass {
 }
 
 proc main() {
-  var c1 = new GenericClass(bool, 5, 3.0, 2);
+  var c1 = new borrowed GenericClass(bool, 5, 3.0, 2);
   writeln(c1.type:string);
   writeln(c1);
-  delete c1;
 
-  var c2: GenericClass(int, 2, bool);
+  var c2: borrowed GenericClass(int, 2, bool);
   writeln(c2.type:string);
 
-  var c3: GenericClass(real, 5, real) = new GenericClass(real, 5, 2.4, 8);
+  var c3: borrowed GenericClass(real, 5, real) = new borrowed GenericClass(real, 5, 2.4, 8);
   writeln(c3.type:string);
   writeln(c3);
-  delete c3;
 }

--- a/test/classes/initializers/compilerGenerated/had_constructor.chpl
+++ b/test/classes/initializers/compilerGenerated/had_constructor.chpl
@@ -13,7 +13,7 @@ class LotsOFields {
 }
 
 proc main() {
-  var c: LotsOFields = new LotsOFields(2, 6.3, true);
+  var c: unmanaged LotsOFields = new unmanaged LotsOFields(2, 6.3, true);
 
   writeln(c);
   delete c;

--- a/test/classes/initializers/compilerGenerated/inOrderFieldUse.chpl
+++ b/test/classes/initializers/compilerGenerated/inOrderFieldUse.chpl
@@ -6,6 +6,5 @@ class Foo {
   var y = x + 1;
 }
 
-var foo = new Foo();
+var foo = new shared Foo();
 writeln(foo);
-delete foo;

--- a/test/classes/initializers/compilerGenerated/inherits_constructor.chpl
+++ b/test/classes/initializers/compilerGenerated/inherits_constructor.chpl
@@ -16,7 +16,7 @@ class Child : Parent {
 }
 
 proc main() {
-  var c = new Child(4);
+  var c = new unmanaged Child(4);
 
   writeln(c);
   delete c;

--- a/test/classes/initializers/compilerGenerated/inherits_default.chpl
+++ b/test/classes/initializers/compilerGenerated/inherits_default.chpl
@@ -9,11 +9,10 @@ class Child : Parent {
 }
 
 proc main() {
-  var c = new Child(2, 4);
+  var c = new borrowed Child(2, 4);
   // Note: the order of arguments in the default case is parent first, then
   // child.  This reflects the order in which fields are initialized in a
   // user-defined initializer.
 
   writeln(c); // So we expect this to be {a = 2, b = 4}
-  delete c;
 }

--- a/test/classes/initializers/compilerGenerated/inherits_initializer.chpl
+++ b/test/classes/initializers/compilerGenerated/inherits_initializer.chpl
@@ -16,8 +16,7 @@ class Child : Parent {
 }
 
 proc main() {
-  var c = new Child(4);
+  var c = new owned Child(4);
 
   writeln(c);
-  delete c;
 }

--- a/test/classes/initializers/compilerGenerated/inherits_initializer_bad.chpl
+++ b/test/classes/initializers/compilerGenerated/inherits_initializer_bad.chpl
@@ -18,10 +18,9 @@ class Child : Parent {
 }
 
 proc main() {
-  var c = new Child(4);
+  var c = new shared Child(4);
   // TODO: I would like a better error message, this current one is confusing
   // (but reasonable when you know why it is complaining)
 
   writeln(c);
-  delete c;
 }

--- a/test/classes/initializers/compilerGenerated/initializeMethod.chpl
+++ b/test/classes/initializers/compilerGenerated/initializeMethod.chpl
@@ -14,11 +14,8 @@ class Foo {
   }
 }
 
-var foo1 = new Foo(3, true);
-var foo2 = new Foo(5, false);
+var foo1 = new shared Foo(3, true);
+var foo2 = new shared Foo(5, false);
 
 writeln(foo1);
 writeln(foo2);
-
-delete foo1;
-delete foo2;

--- a/test/classes/initializers/compilerGenerated/modifyDomain-array-created-by-init.chpl
+++ b/test/classes/initializers/compilerGenerated/modifyDomain-array-created-by-init.chpl
@@ -6,14 +6,13 @@ class C {
 }
 
 var arr1 = [1, 3, 5, 7];
-var c1 = new C(arr1.domain);
+var c1 = new unmanaged C(arr1.domain);
 writeln(c1);
 delete c1;
 
 var arr2 = [2, 4, 6];
-var c2 = new C(arr2.domain);
+var c2 = new unmanaged C(arr2.domain);
 writeln(c2);
 c2.D = {1..4};
 c2.A[4] = 8;
 writeln(c2);
-delete c2;

--- a/test/classes/initializers/compilerGenerated/nested-class-in-class.chpl
+++ b/test/classes/initializers/compilerGenerated/nested-class-in-class.chpl
@@ -6,12 +6,12 @@ class enclosing {
   }
 
   proc checkInner() {
-    var myInner = new inner(true);
+    var myInner = new unmanaged inner(true);
     writeln(myInner);
     delete myInner;
   }
 }
 
-var mine = new enclosing(5);
+var mine = new unmanaged enclosing(5);
 mine.checkInner();
 delete mine;

--- a/test/classes/initializers/compilerGenerated/omittedIfExpr.chpl
+++ b/test/classes/initializers/compilerGenerated/omittedIfExpr.chpl
@@ -3,9 +3,7 @@ class Foo {
   var y = if x then 10 else 11;
 }
 
-var foo1 = new Foo(true);
-var foo2 = new Foo(false);
+var foo1 = new shared Foo(true);
+var foo2 = new shared Foo(false);
 writeln(foo1);
 writeln(foo2);
-delete foo1;
-delete foo2;

--- a/test/classes/initializers/compilerGenerated/outOfOrderFieldUse.chpl
+++ b/test/classes/initializers/compilerGenerated/outOfOrderFieldUse.chpl
@@ -6,6 +6,5 @@ class Foo {
   var y = 3;
 }
 
-var foo = new Foo();
+var foo = new owned Foo();
 writeln(foo);
-delete foo;

--- a/test/classes/initializers/compilerGenerated/parent_inherits_constructor.chpl
+++ b/test/classes/initializers/compilerGenerated/parent_inherits_constructor.chpl
@@ -20,8 +20,7 @@ class Child : Parent {
 }
 
 proc main() {
-  var child = new Child(4);
+  var child = new shared Child(4);
 
   writeln(child);
-  delete child;
 }

--- a/test/classes/initializers/compilerGenerated/parent_inherits_initializer.chpl
+++ b/test/classes/initializers/compilerGenerated/parent_inherits_initializer.chpl
@@ -21,8 +21,7 @@ class Child : Parent {
 }
 
 proc main() {
-  var child = new Child(2, 4);
+  var child = new shared Child(2, 4);
 
   writeln(child);
-  delete child;
 }

--- a/test/classes/initializers/compilerGenerated/parent_inherits_initializer_bad.chpl
+++ b/test/classes/initializers/compilerGenerated/parent_inherits_initializer_bad.chpl
@@ -22,10 +22,9 @@ class Child : Parent {
 }
 
 proc main() {
-  var child = new Child(4);
+  var child = new owned Child(4);
   // TODO: I would like a better error message, this current one is confusing
   // (but reasonable when you know why it is complaining)
 
   writeln(child);
-  delete child;
 }

--- a/test/classes/initializers/compilerGenerated/pragmaOnly/basic_check.chpl
+++ b/test/classes/initializers/compilerGenerated/pragmaOnly/basic_check.chpl
@@ -6,7 +6,7 @@ class LotsOFields {
 }
 
 proc main() {
-  var c: LotsOFields = new borrowed LotsOFields(2, 6.3, true);
+  var c: borrowed LotsOFields = new borrowed LotsOFields(2, 6.3, true);
 
   writeln(c);
 }

--- a/test/classes/initializers/compilerGenerated/pragmaOnly/dflt-ctor-generic-uninit-field-const-err-1.chpl
+++ b/test/classes/initializers/compilerGenerated/pragmaOnly/dflt-ctor-generic-uninit-field-const-err-1.chpl
@@ -5,4 +5,4 @@ class A {
   const c;
 }
 
-var x = new A();
+var x = new borrowed A();

--- a/test/classes/initializers/compilerGenerated/pragmaOnly/dflt-ctor-generic-uninit-field-param-err-1.chpl
+++ b/test/classes/initializers/compilerGenerated/pragmaOnly/dflt-ctor-generic-uninit-field-param-err-1.chpl
@@ -5,4 +5,4 @@ class A {
   param p;
 }
 
-var x = new A();
+var x = new borrowed A();

--- a/test/classes/initializers/compilerGenerated/pragmaOnly/dflt-ctor-generic-uninit-field-type-err-1.chpl
+++ b/test/classes/initializers/compilerGenerated/pragmaOnly/dflt-ctor-generic-uninit-field-type-err-1.chpl
@@ -5,4 +5,4 @@ class A {
   type t;
 }
 
-var x = new A();
+var x = new borrowed A();

--- a/test/classes/initializers/compilerGenerated/pragmaOnly/dflt-ctor-generic-uninit-field-var-err-1.chpl
+++ b/test/classes/initializers/compilerGenerated/pragmaOnly/dflt-ctor-generic-uninit-field-var-err-1.chpl
@@ -5,4 +5,4 @@ class A {
   var v;
 }
 
-var x = new A();
+var x = new borrowed A();

--- a/test/classes/initializers/compilerGenerated/pragmaOnly/inherits_constructor.chpl
+++ b/test/classes/initializers/compilerGenerated/pragmaOnly/inherits_constructor.chpl
@@ -16,8 +16,7 @@ class Child : Parent {
 }
 
 proc main() {
-  var c = new Child(4);
+  var c = new shared Child(4);
 
   writeln(c);
-  delete c;
 }

--- a/test/classes/initializers/compilerGenerated/pragmaOnly/inherits_default1.chpl
+++ b/test/classes/initializers/compilerGenerated/pragmaOnly/inherits_default1.chpl
@@ -10,11 +10,10 @@ class Child : Parent {
 }
 
 proc main() {
-  var c = new Child(4, 2);
+  var c = new unmanaged Child(4, 2);
   // Note: the order of arguments in the default case is child first, then
   // parent.  This reflects the order in which fields are initialized in a
   // user-defined initializer.
 
   writeln(c); // So we expect this to be {a = 2, b = 4}
-  delete c;
 }

--- a/test/classes/initializers/compilerGenerated/pragmaOnly/inherits_default2.chpl
+++ b/test/classes/initializers/compilerGenerated/pragmaOnly/inherits_default2.chpl
@@ -11,11 +11,10 @@ class Child : Parent {
 }
 
 proc main() {
-  var c = new Child(2, 4);
+  var c = new owned Child(2, 4);
   // Note: the order of arguments in the default case is parent first, then
   // child.  This reflects the order in which fields are initialized in a
   // user-defined initializer.
 
   writeln(c); // So we expect this to be {a = 2, b = 4}
-  delete c;
 }

--- a/test/classes/initializers/compilerGenerated/pragmaOnly/inherits_default3.chpl
+++ b/test/classes/initializers/compilerGenerated/pragmaOnly/inherits_default3.chpl
@@ -10,11 +10,10 @@ class Child : Parent {
 }
 
 proc main() {
-  var c = new Child(4, 2);
+  var c = new borrowed Child(4, 2);
   // Note: the order of arguments in the default case is child first, then
   // parent.  This reflects the order in which fields are initialized in a
   // user-defined initializer.
 
   writeln(c); // So we expect this to be {a = 2, b = 4}
-  delete c;
 }

--- a/test/classes/initializers/compilerGenerated/pragmaOnly/inherits_initializer.chpl
+++ b/test/classes/initializers/compilerGenerated/pragmaOnly/inherits_initializer.chpl
@@ -17,7 +17,7 @@ class Child : Parent {
 }
 
 proc main() {
-  var c = new Child(4);
+  var c = new unmanaged Child(4);
 
   writeln(c);
   delete c;

--- a/test/classes/initializers/compilerGenerated/pragmaOnly/inherits_initializer_bad.chpl
+++ b/test/classes/initializers/compilerGenerated/pragmaOnly/inherits_initializer_bad.chpl
@@ -19,10 +19,9 @@ class Child : Parent {
 }
 
 proc main() {
-  var c = new Child(4);
+  var c = new shared Child(4);
   // TODO: I would like a better error message, this current one is confusing
   // (but reasonable when you know why it is complaining)
 
   writeln(c);
-  delete c;
 }

--- a/test/classes/initializers/compilerGenerated/pragmaOnly/outOfOrderFieldUse.chpl
+++ b/test/classes/initializers/compilerGenerated/pragmaOnly/outOfOrderFieldUse.chpl
@@ -6,6 +6,5 @@ class Foo {
   var y = 3;
 }
 
-var foo = new Foo();
+var foo = new borrowed Foo();
 writeln(foo);
-delete foo;

--- a/test/classes/initializers/compilerGenerated/pragmaOnly/parent_inherits_constructor1.chpl
+++ b/test/classes/initializers/compilerGenerated/pragmaOnly/parent_inherits_constructor1.chpl
@@ -21,8 +21,7 @@ class Child : Parent {
 }
 
 proc main() {
-  var child = new Child(4);
+  var child = new owned Child(4);
 
   writeln(child);
-  delete child;
 }

--- a/test/classes/initializers/compilerGenerated/pragmaOnly/parent_inherits_constructor2.chpl
+++ b/test/classes/initializers/compilerGenerated/pragmaOnly/parent_inherits_constructor2.chpl
@@ -22,8 +22,7 @@ class Child : Parent {
 }
 
 proc main() {
-  var child = new Child(4);
+  var child = new borrowed Child(4);
 
   writeln(child);
-  delete child;
 }

--- a/test/classes/initializers/compilerGenerated/pragmaOnly/parent_inherits_constructor3.chpl
+++ b/test/classes/initializers/compilerGenerated/pragmaOnly/parent_inherits_constructor3.chpl
@@ -21,8 +21,7 @@ class Child : Parent {
 }
 
 proc main() {
-  var child = new Child(4);
+  var child = new shared Child(4);
 
   writeln(child);
-  delete child;
 }

--- a/test/classes/initializers/compilerGenerated/pragmaOnly/parent_inherits_default2.chpl
+++ b/test/classes/initializers/compilerGenerated/pragmaOnly/parent_inherits_default2.chpl
@@ -16,11 +16,10 @@ class Child : Parent {
 }
 
 proc main() {
-  var child = new Child(4, 2, 1);
+  var child = new owned Child(4, 2, 1);
   // Note: the order of arguments in the default case is child first, then
   // parent.  This reflects the order in which fields are initialized in a
   // user-defined initializer.
 
   writeln(child); // So we expect this to be {a = 1, b = 2, c = 4}
-  delete child;
 }

--- a/test/classes/initializers/compilerGenerated/pragmaOnly/parent_inherits_default3.chpl
+++ b/test/classes/initializers/compilerGenerated/pragmaOnly/parent_inherits_default3.chpl
@@ -17,11 +17,10 @@ class Child : Parent {
 }
 
 proc main() {
-  var child = new Child(1, 2, 4);
+  var child = new borrowed Child(1, 2, 4);
   // Note: the order of arguments in the default case is parent first, then
   // child.  This reflects the order in which fields are initialized in a
   // user-defined initializer.
 
   writeln(child); // So we expect this to be {a = 1, b = 2, c = 4}
-  delete child;
 }

--- a/test/classes/initializers/compilerGenerated/pragmaOnly/parent_inherits_default4.chpl
+++ b/test/classes/initializers/compilerGenerated/pragmaOnly/parent_inherits_default4.chpl
@@ -16,7 +16,7 @@ class Child : Parent {
 }
 
 proc main() {
-  var child = new Child(4, 2, 1);
+  var child = new unmanaged Child(4, 2, 1);
   // Note: the order of arguments in the default case is child first, then
   // parent.  This reflects the order in which fields are initialized in a
   // user-defined initializer.

--- a/test/classes/initializers/compilerGenerated/pragmaOnly/parent_inherits_default5.chpl
+++ b/test/classes/initializers/compilerGenerated/pragmaOnly/parent_inherits_default5.chpl
@@ -16,11 +16,10 @@ class Child : Parent {
 }
 
 proc main() {
-  var child = new Child(4, 2, 1);
+  var child = new borrowed Child(4, 2, 1);
   // Note: the order of arguments in the default case is child first, then
   // parent.  This reflects the order in which fields are initialized in a
   // user-defined initializer.
 
   writeln(child); // So we expect this to be {a = 1, b = 2, c = 4}
-  delete child;
 }

--- a/test/classes/initializers/compilerGenerated/pragmaOnly/parent_inherits_default6.chpl
+++ b/test/classes/initializers/compilerGenerated/pragmaOnly/parent_inherits_default6.chpl
@@ -15,11 +15,10 @@ class Child : Parent {
 }
 
 proc main() {
-  var child = new Child(4, 2, 1);
+  var child = new shared Child(4, 2, 1);
   // Note: the order of arguments in the default case is child first, then
   // parent.  This reflects the order in which fields are initialized in a
   // user-defined initializer.
 
   writeln(child); // So we expect this to be {a = 1, b = 2, c = 4}
-  delete child;
 }

--- a/test/classes/initializers/compilerGenerated/pragmaOnly/parent_inherits_default7.chpl
+++ b/test/classes/initializers/compilerGenerated/pragmaOnly/parent_inherits_default7.chpl
@@ -15,11 +15,10 @@ class Child : Parent {
 }
 
 proc main() {
-  var child = new Child(4, 2, 1);
+  var child = new owned Child(4, 2, 1);
   // Note: the order of arguments in the default case is child first, then
   // parent.  This reflects the order in which fields are initialized in a
   // user-defined initializer.
 
   writeln(child); // So we expect this to be {a = 1, b = 2, c = 4}
-  delete child;
 }

--- a/test/classes/initializers/compilerGenerated/pragmaOnly/parent_inherits_initializer.chpl
+++ b/test/classes/initializers/compilerGenerated/pragmaOnly/parent_inherits_initializer.chpl
@@ -23,7 +23,7 @@ class Child : Parent {
 }
 
 proc main() {
-  var child = new Child(2, 4);
+  var child = new unmanaged Child(2, 4);
 
   writeln(child);
   delete child;

--- a/test/classes/initializers/compilerGenerated/shadow_with_different_type.chpl
+++ b/test/classes/initializers/compilerGenerated/shadow_with_different_type.chpl
@@ -8,16 +8,13 @@ class Sub: Base {
 }
 
 proc main() {
-  var sub         = new Sub();
-  var base:Base() = sub;
-  var base2       = new Base();
+  var sub         = new borrowed Sub();
+  var base:borrowed Base() = sub;
+  var base2       = new borrowed Base();
 
   base.s = "Base";
 
   writeln(sub.s);
   writeln(base.s);
   writeln(base2.s);
-
-  delete base2;
-  delete sub;
 }

--- a/test/classes/initializers/compilerGenerated/sparseDomain.chpl
+++ b/test/classes/initializers/compilerGenerated/sparseDomain.chpl
@@ -5,9 +5,8 @@ class C {
 }
 var d = {1..10};
 var s : sparse subdomain(d) = (1,5);
-var c = new C(d,s);
+var c = new owned C(d,s);
 writeln("c = ", c);
 c.sps += (7,);
 c.sps += (9);
 writeln("c = ", c);
-delete c;

--- a/test/classes/initializers/compilerGenerated/typeFieldDependsOnPriorParam.chpl
+++ b/test/classes/initializers/compilerGenerated/typeFieldDependsOnPriorParam.chpl
@@ -13,10 +13,10 @@ class C {
   }
 }
 
-var c = new C(2,int);
+var c = new unmanaged C(2,int);
 c.foo();
 
-var c2 = new C(3,real);
+var c2 = new unmanaged C(3,real);
 c2.foo();
 
 delete c;

--- a/test/classes/initializers/compilerGenerated/uses-in-intent.chpl
+++ b/test/classes/initializers/compilerGenerated/uses-in-intent.chpl
@@ -13,20 +13,18 @@ class Simple {
 
 writeln("\nSimple zero actuals");
 {
-  var s = new Simple();
+  var s = new unmanaged Simple();
   writeln("s = ", s);
   delete s;
 }
 writeln("\nSimple var actual");
 {
   var r = new R();
-  var s = new Simple(r);
+  var s = new borrowed Simple(r);
   writeln("s = ", s);
-  delete s;
 }
 writeln("\nSimple new actual");
 {
-  var s = new Simple(new R());
+  var s = new owned Simple(new R());
   writeln("s = ", s);
-  delete s;
 }

--- a/test/classes/initializers/complete-0.chpl
+++ b/test/classes/initializers/complete-0.chpl
@@ -12,9 +12,7 @@ class MyClass {
 }
 
 proc main() {
-  var c : MyClass = new MyClass(50);
+  var c : borrowed MyClass = new borrowed MyClass(50);
 
   writeln(c);
-
-  delete c;
 }

--- a/test/classes/initializers/complete-1.chpl
+++ b/test/classes/initializers/complete-1.chpl
@@ -14,9 +14,7 @@ class MyClass {
 }
 
 proc main() {
-  var c : MyClass = new MyClass(50);
+  var c : owned MyClass = new owned MyClass(50);
 
   writeln(c);
-
-  delete c;
 }

--- a/test/classes/initializers/complete-2.chpl
+++ b/test/classes/initializers/complete-2.chpl
@@ -17,7 +17,7 @@ class MyClass1 : MyClass0 {
 }
 
 proc main() {
-  var c : MyClass1 = new MyClass1(50);
+  var c : unmanaged MyClass1 = new unmanaged MyClass1(50);
 
   writeln(c);
 

--- a/test/classes/initializers/constAndParamInHeader.chpl
+++ b/test/classes/initializers/constAndParamInHeader.chpl
@@ -16,8 +16,8 @@ class Bar {
     }
 }
 
-var objA = new Foo();
-var objB = new Bar();
+var objA = new shared Foo();
+var objB = new shared Bar();
 
 writeln(objA.value);
 writeln(objB.value);

--- a/test/classes/initializers/empty-class.chpl
+++ b/test/classes/initializers/empty-class.chpl
@@ -11,7 +11,7 @@ class MyClass {
 }
 
 proc main() {
-  var cls : MyClass = new borrowed MyClass();
+  var cls : borrowed MyClass = new borrowed MyClass();
 
   writeln('cls: ', cls);
 }

--- a/test/classes/initializers/error-initializer-return-type.compopts
+++ b/test/classes/initializers/error-initializer-return-type.compopts
@@ -1,0 +1,1 @@
+--no-warn-unstable

--- a/test/classes/initializers/errors/bothGeneric-lhsConsRhsInit.chpl
+++ b/test/classes/initializers/errors/bothGeneric-lhsConsRhsInit.chpl
@@ -17,6 +17,5 @@ class hasConstruct {
 }
 
 
-var hi: hasConstruct(int) = new hasInit(10);
+var hi: borrowed hasConstruct(int) = new borrowed hasInit(10);
 writeln(hi);
-delete hi;

--- a/test/classes/initializers/errors/bothGeneric-lhsInitRhsCons.chpl
+++ b/test/classes/initializers/errors/bothGeneric-lhsInitRhsCons.chpl
@@ -17,6 +17,5 @@ class hasConstruct {
 }
 
 
-var hi: hasInit(int) = new hasConstruct(10);
+var hi: borrowed hasInit(int) = new borrowed hasConstruct(10);
 writeln(hi);
-delete hi;

--- a/test/classes/initializers/errors/errHandling/initThrows.chpl
+++ b/test/classes/initializers/errors/errHandling/initThrows.chpl
@@ -8,6 +8,6 @@ class Foo {
   }
 }
 
-var foo = new Foo();
+var foo = new unmanaged Foo();
 writeln(foo);
 delete foo;

--- a/test/classes/initializers/errors/errHandling/initWithThrow.chpl
+++ b/test/classes/initializers/errors/errHandling/initWithThrow.chpl
@@ -6,10 +6,9 @@ class Foo {
 
   proc init() {
     x = 10;
-    throw new Error();
+    throw new unmanaged Error();
   }
 }
 
-var foo = new Foo();
+var foo = new owned Foo();
 writeln(foo);
-delete foo;

--- a/test/classes/initializers/errors/errHandling/initWithTry.chpl
+++ b/test/classes/initializers/errors/errHandling/initWithTry.chpl
@@ -11,9 +11,9 @@ class Foo {
 }
 
 proc outerFunc() throws {
-  throw new Error();
+  throw new unmanaged Error();
 }
 
-var foo = new Foo();
+var foo = new unmanaged Foo();
 writeln(foo);
 delete foo;

--- a/test/classes/initializers/errors/errHandling/initWithTry2.chpl
+++ b/test/classes/initializers/errors/errHandling/initWithTry2.chpl
@@ -13,9 +13,9 @@ class Foo {
 }
 
 proc outerFunc() throws {
-  throw new Error();
+  throw new unmanaged Error();
 }
 
-var foo = new Foo();
+var foo = new unmanaged Foo();
 writeln(foo);
 delete foo;

--- a/test/classes/initializers/errors/errHandling/initWithTryBang.chpl
+++ b/test/classes/initializers/errors/errHandling/initWithTryBang.chpl
@@ -13,7 +13,7 @@ class Foo {
 }
 
 proc outerFunc() throws {
-  throw new Error();
+  throw new unmanaged Error();
 }
 
 var foo = new unmanaged Foo();

--- a/test/classes/initializers/errors/errHandling/initWithTryBangCatch.chpl
+++ b/test/classes/initializers/errors/errHandling/initWithTryBangCatch.chpl
@@ -15,9 +15,9 @@ class Foo {
 }
 
 proc outerFunc() throws {
-  throw new Error();
+  throw new unmanaged Error();
 }
 
-var foo = new Foo();
+var foo = new unmanaged Foo();
 writeln(foo);
 delete foo;

--- a/test/classes/initializers/errors/errHandling/initWithTryCatch.chpl
+++ b/test/classes/initializers/errors/errHandling/initWithTryCatch.chpl
@@ -15,9 +15,9 @@ class Foo {
 }
 
 proc outerFunc() throws {
-  throw new Error();
+  throw new unmanaged Error();
 }
 
-var foo = new Foo();
+var foo = new unmanaged Foo();
 writeln(foo);
 delete foo;

--- a/test/classes/initializers/errors/errHandling/tryDeeper.chpl
+++ b/test/classes/initializers/errors/errHandling/tryDeeper.chpl
@@ -13,9 +13,9 @@ class Foo {
 }
 
 proc outerFunc() throws {
-  throw new Error();
+  throw new unmanaged Error();
 }
 
-var foo = new Foo();
+var foo = new unmanaged Foo();
 writeln(foo);
 delete foo;

--- a/test/classes/initializers/errors/fieldBeforeSuper.chpl
+++ b/test/classes/initializers/errors/fieldBeforeSuper.chpl
@@ -8,5 +8,4 @@ class C {
   }
 }
 
-var c = new C();
-delete c;
+var c = new borrowed C();

--- a/test/classes/initializers/errors/fieldRecordTypeMismatch.chpl
+++ b/test/classes/initializers/errors/fieldRecordTypeMismatch.chpl
@@ -14,4 +14,4 @@ class C {
   }
 }
 
-var myC = new C(new R2(1.2));
+var myC = new shared C(new R2(1.2));

--- a/test/classes/initializers/errors/generic-lhsConsRhsInit.chpl
+++ b/test/classes/initializers/errors/generic-lhsConsRhsInit.chpl
@@ -17,6 +17,5 @@ class hasConstruct {
 }
 
 
-var hi: hasConstruct(int) = new hasInit(10);
+var hi: borrowed hasConstruct(int) = new borrowed hasInit(10);
 writeln(hi);
-delete hi;

--- a/test/classes/initializers/errors/generic-lhsConsRhsInit2.chpl
+++ b/test/classes/initializers/errors/generic-lhsConsRhsInit2.chpl
@@ -17,6 +17,5 @@ class hasConstruct {
 }
 
 
-var hi: hasConstruct = new hasInit(10);
+var hi: borrowed hasConstruct = new borrowed hasInit(10);
 writeln(hi);
-delete hi;

--- a/test/classes/initializers/errors/generic-lhsInitRhsCons.chpl
+++ b/test/classes/initializers/errors/generic-lhsInitRhsCons.chpl
@@ -17,6 +17,5 @@ class hasConstruct {
 }
 
 
-var hi: hasInit(int) = new hasConstruct(10);
+var hi: borrowed hasInit(int) = new borrowed hasConstruct(10);
 writeln(hi);
-delete hi;

--- a/test/classes/initializers/errors/generic-lhsInitRhsCons2.chpl
+++ b/test/classes/initializers/errors/generic-lhsInitRhsCons2.chpl
@@ -17,6 +17,5 @@ class hasConstruct {
 }
 
 
-var hi: hasInit = new hasConstruct(10);
+var hi: borrowed hasInit = new borrowed hasConstruct(10);
 writeln(hi);
-delete hi;

--- a/test/classes/initializers/errors/grandFieldInit.chpl
+++ b/test/classes/initializers/errors/grandFieldInit.chpl
@@ -18,4 +18,4 @@ class Child : Parent {
   }
 }
 
-var c = new Child();
+var c = new owned Child();


### PR DESCRIPTION
Running testing with --warn-unstable revealed some warnings.
This PR fixes about 100 more tests to not warn.

For #9829.

Trivial test changes only - not reviewed.

- [x] full local testing
