### PR TITLE
dsiAlignment information in Cyclic Replicated distributions

### DIFF
--- a/modules/dists/CyclicDist.chpl
+++ b/modules/dists/CyclicDist.chpl
@@ -497,6 +497,12 @@ proc CyclicDom.dsiLow return whole.low;
 
 proc CyclicDom.dsiHigh return whole.high;
 
+proc CyclicDom.dsiAlignedLow return whole.alignedLow;
+
+proc CyclicDom.dsiAlignedHigh return whole.alignedHigh;
+
+proc CyclicDom.dsiAlignment return whole.alignment;
+
 proc CyclicDom.dsiStride return whole.stride;
 
 proc CyclicDom.dsiMember(i) return whole.member(i);

--- a/modules/dists/ReplicatedDist.chpl
+++ b/modules/dists/ReplicatedDist.chpl
@@ -382,6 +382,15 @@ proc ReplicatedDom.dsiHigh
 proc ReplicatedDom.dsiStride
   return redirectee().stride;
 
+proc ReplicatedDom.dsiAlignedLow
+  return redirectee().alignedLow;
+
+proc ReplicatedDom.dsiAlignedHigh
+  return redirectee().alignedHigh;
+
+proc ReplicatedDom.dsiAlignment
+  return redirectee().alignment;
+
 // here replication is visible
 proc ReplicatedDom.dsiNumIndices
   return redirectee().numIndices;


### PR DESCRIPTION
adds to both CyclicDom and ReplicatedDom:
+ dsiAlignment
+ dsiAlignedHigh
+ dsiAlignedLow

Fixes broken test cause by new Search module lo and hi search function defaults.