### PR TITLE
Partially convert DateTime to error-handling

### DIFF
--- a/modules/standard/DateTime.chpl
+++ b/modules/standard/DateTime.chpl
@@ -113,6 +113,10 @@ module DateTime {
     var tm_zone:   tm_zoneType; // Timezone abbreviation
   }
 
+  private proc assertInRange(val, low, high) {
+    assert(val >= low && val <= high);
+  }
+
   private proc getLocalTime(t: 2*int) {
     extern type time_t;
 
@@ -138,9 +142,9 @@ module DateTime {
     return y*365 + y/4 - y/100 + y/400;
   }
 
+  // assumes callee has checked for valid month range
   private proc daysBeforeMonth(year: int, month: int) {
-    if month < 1 || month > 12 then
-      halt("month must be between 1 and 12");
+    assertInRange(month, 1, 12);
     return DAYS_BEFORE_MONTH(month) + if (month > 2 && isLeapYear(year)) then 1 else 0;
   }
 

--- a/modules/standard/DateTime.chpl
+++ b/modules/standard/DateTime.chpl
@@ -148,12 +148,11 @@ module DateTime {
     return DAYS_BEFORE_MONTH(month) + if (month > 2 && isLeapYear(year)) then 1 else 0;
   }
 
+  // assumes callee has checked for valid month/day ranges
   private proc ymdToOrd(year: int, month: int, day: int) {
+    assertInRange(month, 1, 12);
     const dim = daysInMonth(year, month);
-    if month < 1 || month > 12 then
-      halt("month must be between 1 and 12");
-    if day < 1 || day > dim then
-      halt("day must be between 1 and ", dim);
+    assertInRange(day, 1, dim);
     return daysBeforeYear(year) + daysBeforeMonth(year, month) + day;
   }
 

--- a/modules/standard/DateTime.chpl
+++ b/modules/standard/DateTime.chpl
@@ -151,7 +151,7 @@ module DateTime {
   // assumes callee has checked for valid month/day ranges
   private proc ymdToOrd(year: int, month: int, day: int) {
     assertInRange(month, 1, 12);
-    const dim = daysInMonth(year, month);
+    const dim = try! daysInMonth(year, month);
     assertInRange(day, 1, dim);
     return daysBeforeYear(year) + daysBeforeMonth(year, month) + day;
   }
@@ -189,10 +189,12 @@ module DateTime {
         month = 12;
         year -= 1;
       }
-      preceding -= daysInMonth(year, month);
+      const dim = try! daysInMonth(year, month);
+      preceding -= dim;
     }
     n -= preceding;
-    assert(0 <= n && n < daysInMonth(year, month));
+    const dim = try! daysInMonth(year, month);
+    assertInRange(n+1, 1, dim);
     return (year, month, n+1);
   }
 
@@ -202,10 +204,11 @@ module DateTime {
   }
 
   /* Return the number of days in month `month` during the year `year`.
-     The number for a month can change from year to year due to leap years. */
-  proc daysInMonth(year: int, month: int) {
+     The number for a month can change from year to year due to leap years.
+     Throws an IllegalArgumentError month is out of range. */
+  proc daysInMonth(year: int, month: int) throws {
     if month < 1 || month > 12 then
-      halt("month must be between 1 and 12");
+      throw new IllegalArgumentError("month must be between 1 and 12");
     if month == 2 && isLeapYear(year) then
       return 29;
     else
@@ -270,7 +273,8 @@ module DateTime {
       halt("year is out of the valid range");
     if month < 1 || month > 12 then
       halt("month is out of the valid range");
-    if day < 1 || day > daysInMonth(year, month) then
+    const dim = try! daysInMonth(year, month);
+    if day < 1 || day > dim then
       halt("day is out of the valid range");
 
     this.chpl_year = year;

--- a/modules/standard/DateTime.chpl
+++ b/modules/standard/DateTime.chpl
@@ -269,13 +269,14 @@ module DateTime {
      1 <= `day` <= the number of days in the given month and year
   */
   proc date.init(year, month, day) {
+    use ChapelHaltWrappers;
     if year < MINYEAR-1 || year > MAXYEAR+1 then
-      halt("year is out of the valid range");
+      initHalt("year is out of the valid range");
     if month < 1 || month > 12 then
-      halt("month is out of the valid range");
+      initHalt("month is out of the valid range");
     const dim = try! daysInMonth(year, month);
     if day < 1 || day > dim then
-      halt("day is out of the valid range");
+      initHalt("day is out of the valid range");
 
     this.chpl_year = year;
     this.chpl_month = month;
@@ -562,14 +563,15 @@ module DateTime {
    */
   proc time.init(hour=0, minute=0, second=0, microsecond=0,
                  tzinfo: Shared(TZInfo)=nilTZ) {
+    use ChapelHaltWrappers;
     if hour < 0 || hour >= 24 then
-      halt("hour out of range");
+      initHalt("hour out of range");
     if minute < 0 || minute >= 60 then
-      halt("minute out of range");
+      initHalt("minute out of range");
     if second < 0 || second >= 60 then
-      halt("second out of range");
+      initHalt("second out of range");
     if microsecond < 0 || microsecond >= 1000000 then
-      halt("microsecond out of range");
+      initHalt("microsecond out of range");
     this.chpl_hour = hour;
     this.chpl_minute = minute;
     this.chpl_second = second;
@@ -1486,6 +1488,7 @@ module DateTime {
      and microseconds. */
   proc timedelta.init(days=0, seconds=0, microseconds=0,
                       milliseconds=0, minutes=0, hours=0, weeks=0) {
+    use ChapelHaltWrappers;
     param usps = 1000000,  // microseconds per second
           uspms = 1000,    // microseconds per millisecond
           spd = 24*60*60; // seconds per day
@@ -1514,10 +1517,10 @@ module DateTime {
     this.chpl_microseconds = us;
 
     if this.days < -999999999 then
-      halt("Overflow: days < -999999999");
+      initHalt("Overflow: days < -999999999");
 
     if this.days > 999999999 then
-      halt("Overflow: days > 999999999");
+      initHalt("Overflow: days > 999999999");
   }
 
   /* Create a `timedelta` from a given number of seconds */


### PR DESCRIPTION
This converts some halts to asserts for internal/private functions, converts
some halts in initializers to initHalts, and actually converts a few halts to
throwing functions. Individual commits have more details but at a high level
this:
 - Converts halts in daysBeforeMonth() and ymdToOrd() to asserts. These are
   private functions and all callsites within DateTime have valid arguments.
 - Converts daysInMonth() to throw an IllegalArgumentError() instead of halting
 - Converts halt() calls in time, date, and timedelta initializers to
   initHalt() calls. These are cases where we want error-handling, but it's
   currently not supported

The remaining uses of halt are for operations between datetimes with mixed
timezone awareness. It's not obvious to me if these should be throwing
routines, or if we should make timezone awareness part of the static type. I've
opened https://github.com/chapel-lang/chapel/issues/9941 to discuss this.

Related to https://github.com/chapel-lang/chapel/issues/9552