### PR TITLE
Skip HDF5 test if not using LLVM

### DIFF
--- a/test/library/standard/DataFrames/diten/readHDF5Df.skipif
+++ b/test/library/standard/DataFrames/diten/readHDF5Df.skipif
@@ -9,5 +9,8 @@
 
 from __future__ import print_function
 from ctypes.util import find_library
+import os
 
-print(find_library('hdf5') is None)
+llvm=os.getenv('CHPL_LLVM')
+
+print((find_library('hdf5') is None) | (llvm is None) | (llvm == 'none'))


### PR DESCRIPTION
The HDF5 module uses an extern block, which requires LLVM. Skip this test
if not using LLVM.