### PR TITLE
Disable nvml in the included hwloc build

### DIFF
--- a/third-party/hwloc/Makefile
+++ b/third-party/hwloc/Makefile
@@ -28,6 +28,7 @@ CHPL_HWLOC_CFG_OPTIONS += --enable-static \
                           --disable-libxml2 \
                           --disable-libudev \
                           --disable-cuda \
+                          --disable-nvml \
                           --disable-opencl \
                           --disable-pci
 


### PR DESCRIPTION
An Ubuntu 18.04 system was unable to build Chapel in the standard configuration
- it led to an error along the lines of

```
configure: error: Specified topology library (hwloc_via_chapel) does not work.
```
during the qthreads configure run.

This machine has the `cuda-dev` package as well as a system install of
libhwloc-dev.

This PR just follows on the strategy used in PR #7794 which simply disables the
GPU-specific functionality in the build of the included hwloc. For sure a
better strategy would be preferred - but I wasn't sure how hard it would be to
get the qthreads configure to learn about the additional libraries required for
a particular hwloc. I believe qthreads could gather this information from
hwloc.pc or from libhwloc.la (both of which end up in the
third-party/hwloc/install directory). Alternatively, we could try to pass the
Chapel third-party (maybe just hwloc?) link arguments to qthreads's configure.

Resolves #9643.

Passed full local testing.
Reviewed by @ronawho - thanks!