### PR TITLE
Quiet miscellaneous --force-initializers failures

### DIFF
--- a/test/classes/deitz/class-constructor/method_in_constructor.compopts
+++ b/test/classes/deitz/class-constructor/method_in_constructor.compopts
@@ -1,0 +1,1 @@
+--no-force-initializers

--- a/test/classes/deitz/class-constructor/method_in_constructor2.compopts
+++ b/test/classes/deitz/class-constructor/method_in_constructor2.compopts
@@ -1,0 +1,1 @@
+--no-force-initializers

--- a/test/classes/initializers/compilerGenerated/pragmaOnly/SKIPIF
+++ b/test/classes/initializers/compilerGenerated/pragmaOnly/SKIPIF
@@ -1,0 +1,1 @@
+COMPOPTS <= --force-initializers

--- a/test/classes/initializers/inherits_initializer.compopts
+++ b/test/classes/initializers/inherits_initializer.compopts
@@ -1,0 +1,1 @@
+--no-force-initializers

--- a/test/users/shetag/classWithArray/initArrWithFn.compopts
+++ b/test/users/shetag/classWithArray/initArrWithFn.compopts
@@ -1,0 +1,1 @@
+--no-force-initializers


### PR DESCRIPTION
This PR updates a handful of tests to never run with --force-initializers, because they will never be supported by initializers. The custom Block implementation is updated to use a helper function instead of a method during initialization.

Tested impacted tests under:
- [x] local
- [x] gasnet
- [x] --force-initializers