### PR TITLE
Update except/only to handle 'init' and '_new' specially

### DIFF
--- a/compiler/AST/UseStmt.cpp
+++ b/compiler/AST/UseStmt.cpp
@@ -479,7 +479,10 @@ void UseStmt::createRelatedNames(Symbol* maybeType) {
     Type* type = ts->type;
 
     forv_Vec(FnSymbol, method, type->methods) {
-      relatedNames.push_back(method->name);
+      if (method->isInitializer() == false &&
+          method->hasFlag(FLAG_NEW_WRAPPER) == false) {
+        relatedNames.push_back(method->name);
+      }
     }
 
     if (AggregateType* at = toAggregateType(type)) {
@@ -502,6 +505,11 @@ void UseStmt::createRelatedNames(Symbol* maybeType) {
 
     relatedNames.push_back(constrName);
     relatedNames.push_back(typeConstrName);
+
+    if (except == false) {
+      relatedNames.push_back("init");
+      relatedNames.push_back("_new");
+    }
   }
 }
 


### PR DESCRIPTION
This PR updates handling of except/only lists to handle 'init' and '_new' specially. When identifying symbols from a type, 'init' and '_new' will not be added for ``except`` lists and will be added for ``only`` lists. This is only a workaround, and does not address general issues with except/only lists and method names.

Testing:
- [x] local + futures