### PR TITLE
Improve override checking

### DIFF
--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -1636,7 +1636,10 @@ static void buildDefaultReadWriteFunctions(AggregateType* ct) {
 
     fn->addFlag(FLAG_COMPILER_GENERATED);
     fn->addFlag(FLAG_LAST_RESORT);
-    fn->addFlag(FLAG_INLINE);
+    if (ct->isClass() && ct != dtObject)
+      fn->addFlag(FLAG_OVERRIDE);
+    else
+      fn->addFlag(FLAG_INLINE);
 
     fn->cname = astr("_auto_", ct->symbol->name, "_write");
     fn->_this = new ArgSymbol(INTENT_BLANK, "this", ct);
@@ -1685,7 +1688,10 @@ static void buildDefaultReadWriteFunctions(AggregateType* ct) {
 
     fn->addFlag(FLAG_COMPILER_GENERATED);
     fn->addFlag(FLAG_LAST_RESORT);
-    fn->addFlag(FLAG_INLINE);
+    if (ct->isClass() && ct != dtObject)
+      fn->addFlag(FLAG_OVERRIDE);
+    else
+      fn->addFlag(FLAG_INLINE);
 
     fn->cname = astr("_auto_", ct->symbol->name, "_read");
 

--- a/modules/dists/BlockCycDist.chpl
+++ b/modules/dists/BlockCycDist.chpl
@@ -273,7 +273,7 @@ class BlockCyclic : BaseDist {
     return new unmanaged BlockCyclic(lowIdx, blocksize, targetLocales, dataParTasksPerLocale);
   }
 
-  proc dsiDestroyDist() {
+  override proc dsiDestroyDist() {
     coforall ld in locDist do {
       on ld do
         delete ld;
@@ -312,7 +312,7 @@ proc BlockCyclic._locsize {
 //
 // create a new rectangular domain over this distribution
 //
-proc BlockCyclic.dsiNewRectangularDom(param rank: int, type idxType,
+override proc BlockCyclic.dsiNewRectangularDom(param rank: int, type idxType,
                                       param stridable: bool, inds) {
   if idxType != this.idxType then
     compilerError("BlockCyclic domain index type does not match distribution's");
@@ -631,7 +631,7 @@ proc BlockCyclicDom.dsiGetIndices() {
   return whole.getIndices();
 }
 
-proc BlockCyclicDom.dsiMyDist() return dist;
+override proc BlockCyclicDom.dsiMyDist() return dist;
 
 proc BlockCyclicDom.setup() {
   coforall localeIdx in dist.targetLocDom do
@@ -816,7 +816,7 @@ class BlockCyclicArr: BaseRectangularArr {
   var myLocArr: unmanaged LocBlockCyclicArr(eltType, rank, idxType, stridable);
 }
 
-proc BlockCyclicArr.dsiGetBaseDom() return dom;
+override proc BlockCyclicArr.dsiGetBaseDom() return dom;
 
 proc BlockCyclicArr.setup() {
   coforall localeIdx in dom.dist.targetLocDom {
@@ -828,7 +828,7 @@ proc BlockCyclicArr.setup() {
   }
 }
 
-proc BlockCyclicArr.dsiDestroyArr() {
+override proc BlockCyclicArr.dsiDestroyArr() {
   coforall localeIdx in dom.dist.targetLocDom {
     on dom.dist.targetLocales(localeIdx) {
       delete locArr(localeIdx);

--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -520,7 +520,7 @@ proc Block.dsiClone() {
                    sparseLayoutType);
 }
 
-proc Block.dsiDestroyDist() {
+override proc Block.dsiDestroyDist() {
   coforall ld in locDist do {
     on ld do
       delete ld;
@@ -538,8 +538,8 @@ proc Block.dsiDisplayRepresentation() {
     writeln("locDist[", tli, "].myChunk = ", locDist[tli].myChunk);
 }
 
-proc Block.dsiNewRectangularDom(param rank: int, type idxType,
-                                param stridable: bool, inds) {
+override proc Block.dsiNewRectangularDom(param rank: int, type idxType,
+                                         param stridable: bool, inds) {
   if idxType != this.idxType then
     compilerError("Block domain index type does not match distribution's");
   if rank != this.rank then
@@ -555,7 +555,8 @@ proc Block.dsiNewRectangularDom(param rank: int, type idxType,
   return dom;
 }
 
-proc Block.dsiNewSparseDom(param rank: int, type idxType, dom: domain) {
+override proc Block.dsiNewSparseDom(param rank: int, type idxType,
+                                    dom: domain) {
   return new unmanaged SparseBlockDom(rank=rank, idxType=idxType,
                             sparseLayoutType=sparseLayoutType,
                             stridable=dom.stridable,
@@ -659,7 +660,7 @@ proc LocBlock.init(param rank: int,
 }
 
 
-proc BlockDom.dsiMyDist() return dist;
+override proc BlockDom.dsiMyDist() return dist;
 
 proc BlockDom.dsiDisplayRepresentation() {
   writeln("whole = ", whole);
@@ -898,7 +899,7 @@ proc BlockArr.dsiDisplayRepresentation() {
   }
 }
 
-proc BlockArr.dsiGetBaseDom() return dom;
+override proc BlockArr.dsiGetBaseDom() return dom;
 
 //
 // NOTE: Each locale's myElems array must be initialized prior to
@@ -938,7 +939,7 @@ proc BlockArr.setup() {
   if doRADOpt && disableBlockLazyRAD then setupRADOpt();
 }
 
-proc BlockArr.dsiDestroyArr() {
+override proc BlockArr.dsiDestroyArr() {
   coforall localeIdx in dom.dist.targetLocDom {
     on locArr(localeIdx) {
       delete locArr(localeIdx);
@@ -1170,7 +1171,7 @@ proc _extendTuple(type t, idx, args) {
   return tup;
 }
 
-proc BlockArr.dsiReallocate(bounds:rank*range(idxType,BoundedRangeType.bounded,stridable))
+override proc BlockArr.dsiReallocate(bounds:rank*range(idxType,BoundedRangeType.bounded,stridable))
 {
   //
   // For the default rectangular array, this function changes the data
@@ -1185,7 +1186,7 @@ proc BlockArr.dsiReallocate(bounds:rank*range(idxType,BoundedRangeType.bounded,s
   //
 }
 
-proc BlockArr.dsiPostReallocate() {
+override proc BlockArr.dsiPostReallocate() {
   // Call this *after* the domain has been reallocated
   if doRADOpt then setupRADOpt();
 }

--- a/modules/dists/CyclicDist.chpl
+++ b/modules/dists/CyclicDist.chpl
@@ -340,7 +340,7 @@ proc Cyclic.dsiReprivatize(other, reprivatizeData) {
   dataParMinGranularity = other.dataParMinGranularity;
 }
 
-proc Cyclic.dsiNewRectangularDom(param rank: int, type idxType, param stridable: bool, inds) {
+override proc Cyclic.dsiNewRectangularDom(param rank: int, type idxType, param stridable: bool, inds) {
   if idxType != this.idxType then
     compilerError("Cyclic domain index type does not match distribution's");
   if rank != this.rank then

--- a/modules/dists/DimensionalDist2D.chpl
+++ b/modules/dists/DimensionalDist2D.chpl
@@ -751,7 +751,7 @@ proc DimensionalDom.dsiReprivatize(other, reprivatizeData) {
 
 //== miscellanea
 
-proc DimensionalDom.dsiMyDist() return dist;
+override proc DimensionalDom.dsiMyDist() return dist;
 
 proc DimensionalDom.dsiDims()             return whole.dims();
 proc DimensionalDom.dsiDim(d)             return whole.dim(d);
@@ -778,7 +778,7 @@ proc DimensionalDom.dsiSerialWrite(f): void {
 //== creation, SetIndices
 
 // create a new domain mapped with this distribution
-proc DimensionalDist2D.dsiNewRectangularDom(param rank: int,
+override proc DimensionalDist2D.dsiNewRectangularDom(param rank: int,
                                             type idxType,
                                             param stridable: bool,
                                             inds)
@@ -931,7 +931,7 @@ proc DimensionalArr.dsiPrivatize(privatizeData) {
 
 proc DimensionalArr.idxType type return dom.idxType; // (could be a field)
 
-proc DimensionalArr.dsiGetBaseDom() return dom;
+override proc DimensionalArr.dsiGetBaseDom() return dom;
 
 proc DimensionalArr.dimSpecifier(param dim: int) {
   return dom.dimSpecifier(dim);
@@ -1076,11 +1076,11 @@ proc DimensionalArr.dsiReallocate(d: domain) {
   // TODO: handle block-cyclic 1d when the stride changes
 }
 
-proc DimensionalArr.dsiPostReallocate() {
+override proc DimensionalArr.dsiPostReallocate() {
   // nothing for now
 }
 
-proc DimensionalArr.dsiDestroyArr() {
+override proc DimensionalArr.dsiDestroyArr() {
   coforall desc in localAdescs do
     on desc do
       delete desc;

--- a/modules/dists/ReplicatedDist.chpl
+++ b/modules/dists/ReplicatedDist.chpl
@@ -139,7 +139,7 @@ proc Replicated.dsiEqualDMaps(that) param {
   return false;
 }
 
-proc Replicated.dsiDestroyDist() {
+override proc Replicated.dsiDestroyDist() {
   // no action necessary here
 }
 
@@ -233,7 +233,7 @@ proc ReplicatedDom.redirectee(): domain(rank, idxType, stridable)
   return domRep;
 
 // The same across all domain maps
-proc ReplicatedDom.dsiMyDist() return dist;
+override proc ReplicatedDom.dsiMyDist() return dist;
 
 
 // privatization
@@ -282,7 +282,7 @@ proc Replicated.dsiClone(): _to_unmanaged(this.type) {
 }
 
 // create a new domain mapped with this distribution
-proc Replicated.dsiNewRectangularDom(param rank: int,
+override proc Replicated.dsiNewRectangularDom(param rank: int,
                                          type idxType,
                                          param stridable: bool,
                                          inds)
@@ -494,7 +494,7 @@ proc ReplicatedArr.rank param {
 }
 
 // The same across all domain maps
-proc ReplicatedArr.dsiGetBaseDom() return dom;
+override proc ReplicatedArr.dsiGetBaseDom() return dom;
 
 
 // privatization
@@ -558,7 +558,7 @@ proc chpl_serialReadWriteRectangular(f, arr, dom) where _to_borrowed(chpl__getAc
     chpl_serialReadWriteRectangularHelper(f, arr, dom);
 }
 
-proc ReplicatedArr.dsiDestroyArr() {
+override proc ReplicatedArr.dsiDestroyArr() {
   coforall (loc, locArr) in zip(dom.dist.targetLocales, localArrs) {
     on loc do
       delete locArr;

--- a/modules/dists/SparseBlockDist.chpl
+++ b/modules/dists/SparseBlockDist.chpl
@@ -271,7 +271,7 @@ class SparseBlockDom: BaseSparseDomImpl {
         locDom.dsiClear();
   }
 
-  proc dsiMyDist() return dist;
+  override proc dsiMyDist() return dist;
 
   proc dsiAssignDomain(rhs: domain, lhsPrivate:bool) {
     if !lhsPrivate then
@@ -369,7 +369,7 @@ class SparseBlockArr: BaseSparseArr {
     }
   }
 
-  proc dsiDestroyArr() {
+  override proc dsiDestroyArr() {
     coforall localeIdx in dom.dist.targetLocDom {
       on locArr(localeIdx) {
         delete locArr(localeIdx);

--- a/modules/internal/ArrayViewRankChange.chpl
+++ b/modules/internal/ArrayViewRankChange.chpl
@@ -72,7 +72,7 @@ module ArrayViewRankChange {
         return downDistInst;
     }
 
-    proc dsiNewRectangularDom(param rank, type idxType, param stridable, inds) {
+    override proc dsiNewRectangularDom(param rank, type idxType, param stridable, inds) {
       var newdom = new unmanaged ArrayViewRankChangeDom(rank=rank,
                                               idxType=idxType,
                                               stridable=stridable,
@@ -107,7 +107,7 @@ module ArrayViewRankChange {
                                          idx = privatizeData(4));
     }
 
-    proc dsiDestroyDist() {
+    override proc dsiDestroyDist() {
     }
   }
 
@@ -315,7 +315,7 @@ module ArrayViewRankChange {
       f <~> "}";
     }
 
-    proc dsiMyDist() {
+    override proc dsiMyDist() {
       return dist;
     }
 
@@ -741,7 +741,7 @@ module ArrayViewRankChange {
     }
 
     // not sure what this is, but everyone seems to have one...
-    inline proc dsiGetBaseDom() {
+    override proc dsiGetBaseDom() {
       return dom;
     }
 
@@ -767,7 +767,7 @@ module ArrayViewRankChange {
       return this;
     }
 
-    proc dsiDestroyArr() {
+    override proc dsiDestroyArr() {
       if ownsArrInstance {
         _delete_arr(_ArrInstance, _isPrivatized(_ArrInstance));
       }

--- a/modules/internal/ArrayViewReindex.chpl
+++ b/modules/internal/ArrayViewReindex.chpl
@@ -49,7 +49,7 @@ module ArrayViewReindex {
         return downDistInst;
     }
 
-    proc dsiNewRectangularDom(param rank, type idxType, param stridable, inds) {
+    override proc dsiNewRectangularDom(param rank, type idxType, param stridable, inds) {
       var newdom = new unmanaged ArrayViewReindexDom(rank=rank,
                                            idxType=idxType,
                                            //                                           stridable=true,
@@ -87,7 +87,7 @@ module ArrayViewReindex {
                                       downdomInst = privatizeData(5));
     }
 
-    proc dsiDestroyDist() {
+    override proc dsiDestroyDist() {
       _delete_dom(updom, false);
       //      _delete_dom(downdomInst, _isPrivatized(downdomInst));
     }
@@ -243,7 +243,7 @@ module ArrayViewReindex {
       return ind;
     }
 
-    proc dsiMyDist() {
+    override proc dsiMyDist() {
       return dist;
     }
 
@@ -627,7 +627,7 @@ module ArrayViewReindex {
     }
 
     // not sure what this is, but everyone seems to have one...
-    inline proc dsiGetBaseDom() {
+    override proc dsiGetBaseDom() {
       return privDom;
     }
 
@@ -656,7 +656,7 @@ module ArrayViewReindex {
       return this;
     }
 
-    proc dsiDestroyArr() {
+    override proc dsiDestroyArr() {
       if ownsArrInstance {
         _delete_arr(_ArrInstance, _isPrivatized(_ArrInstance));
       }

--- a/modules/internal/ArrayViewSlice.chpl
+++ b/modules/internal/ArrayViewSlice.chpl
@@ -296,7 +296,7 @@ module ArrayViewSlice {
     }
 
     // not sure what this is, but everyone seems to have one...
-    inline proc dsiGetBaseDom() {
+    override proc dsiGetBaseDom() {
       return dom;
     }
 

--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -788,7 +788,7 @@ module ChapelDistribution {
       halt("reallocating not supported for this array type");
     }
 
-    proc dsiPostReallocate() {
+    override proc dsiPostReallocate() {
     }
 
     proc deinit() {
@@ -827,7 +827,7 @@ module ChapelDistribution {
     pragma "local field"
     var data: [dom.nnzDom] eltType;
 
-    proc dsiGetBaseDom() return dom;
+    override proc dsiGetBaseDom() return dom;
 
     proc deinit() {
       // this is a bug workaround
@@ -881,7 +881,7 @@ module ChapelDistribution {
     }
 
     // shift data array after single index addition. Fills the new index with irv
-    proc sparseShiftArray(shiftrange, initrange) {
+    override proc sparseShiftArray(shiftrange, initrange) {
       for i in initrange {
         data(i) = irv;
       }
@@ -891,7 +891,7 @@ module ChapelDistribution {
       data(shiftrange.low) = irv;
     }
 
-    proc sparseShiftArrayBack(shiftrange) {
+    override proc sparseShiftArrayBack(shiftrange) {
       for i in shiftrange {
         data(i) = data(i+1);
       }

--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -288,7 +288,7 @@ module ChapelLocale {
 
     // A useful default definition is provided (not pure virtual).
     pragma "no doc"
-    proc writeThis(f) {
+    override proc writeThis(f) {
       f <~> name;
     }
 

--- a/modules/internal/DefaultAssociative.chpl
+++ b/modules/internal/DefaultAssociative.chpl
@@ -288,7 +288,7 @@ module DefaultAssociative {
       return _findFilledSlot(idx)(1);
     }
   
-    proc dsiAdd(idx) {
+    override proc dsiAdd(idx) {
       // add helpers will return a tuple like (slotNum, numIndicesAdded);
 
       // these two seemingly redundant lines were necessary to work around a

--- a/modules/internal/DefaultOpaque.chpl
+++ b/modules/internal/DefaultOpaque.chpl
@@ -67,7 +67,7 @@ module DefaultOpaque {
     var adomain: unmanaged DefaultAssociativeDom(idxType=_OpaqueIndex, parSafe=parSafe);
   
     proc linksDistribution() param return false;
-    proc dsiLinksDistribution()     return false;
+    override proc dsiLinksDistribution() return false;
   
     proc init(dist: unmanaged DefaultDist, param parSafe: bool) {
       this.parSafe = parSafe;
@@ -85,7 +85,7 @@ module DefaultOpaque {
       return i;
     }
 
-    proc dsiMyDist() {
+    override proc dsiMyDist() {
       return dist;
     }
 
@@ -167,7 +167,7 @@ module DefaultOpaque {
       delete anarray;
     }
   
-    proc dsiGetBaseDom() return dom;
+    override proc dsiGetBaseDom() return dom;
   
     proc dsiAccess(ind : idxType) ref : eltType
       return anarray.dsiAccess(ind);

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -39,19 +39,19 @@ module DefaultRectangular {
 
   pragma "use default init"
   class DefaultDist: BaseDist {
-    proc dsiNewRectangularDom(param rank: int, type idxType, param stridable: bool, inds) {
+    override proc dsiNewRectangularDom(param rank: int, type idxType, param stridable: bool, inds) {
       const dom = new unmanaged DefaultRectangularDom(rank, idxType, stridable, _to_unmanaged(this));
       dom.dsiSetIndices(inds);
       return dom;
     }
 
-    proc dsiNewAssociativeDom(type idxType, param parSafe: bool)
+    override proc dsiNewAssociativeDom(type idxType, param parSafe: bool)
       return new unmanaged DefaultAssociativeDom(idxType, parSafe, _to_unmanaged(this));
 
-    proc dsiNewOpaqueDom(type idxType, param parSafe: bool)
+    override proc dsiNewOpaqueDom(type idxType, param parSafe: bool)
       return new unmanaged DefaultOpaqueDom(_to_unmanaged(this), parSafe);
 
-    proc dsiNewSparseDom(param rank: int, type idxType, dom: domain)
+    override proc dsiNewSparseDom(param rank: int, type idxType, dom: domain)
       return new unmanaged DefaultSparseDom(rank, idxType, _to_unmanaged(this), dom);
 
     proc dsiIndexToLocale(ind) return this.locale;

--- a/modules/internal/DefaultSparse.chpl
+++ b/modules/internal/DefaultSparse.chpl
@@ -32,7 +32,7 @@ module DefaultSparse {
     var indices: [nnzDom] index(rank, idxType);
 
     proc linksDistribution() param return false;
-    proc dsiLinksDistribution()     return false;
+    override proc dsiLinksDistribution() return false;
 
     proc init(param rank, type idxType, dist: unmanaged DefaultDist,
         parentDom: domain) {
@@ -322,11 +322,11 @@ module DefaultSparse {
       return actualAddCnt;
     }
 
-    proc dsiMyDist() : unmanaged BaseDist {
+    override proc dsiMyDist() : unmanaged BaseDist {
       return dist;
     }
 
-    proc dsiClear() {
+    override proc dsiClear() {
       nnz = 0;
       // should we empty the domain too ?
       // nnzDom = {1..0};

--- a/modules/internal/ExternalArray.chpl
+++ b/modules/internal/ExternalArray.chpl
@@ -134,7 +134,7 @@ module ExternalArray {
         yield i;
     }
 
-    proc dsiMyDist() {
+    override proc dsiMyDist() {
       return dist;
     }
 
@@ -279,9 +279,8 @@ module ExternalArray {
           halt("array index out of bounds: " + _stringify_tuple(i));
         }
     }
-    // arr inline proc?
 
-    inline proc dsiGetBaseDom() {
+    override proc dsiGetBaseDom() {
       return dom;
     }
 
@@ -295,7 +294,7 @@ module ExternalArray {
     // doiCanBulkTransferRankChange? doiBulkTransferFromKnown?
     // doiBulkTransferToKnown?
 
-    proc dsiDestroyArr() {
+    override proc dsiDestroyArr() {
       if (_owned) {
         chpl_free_external_array(_ArrInstance);
       }

--- a/modules/internal/localeModels/apu/LocaleModel.chpl
+++ b/modules/internal/localeModels/apu/LocaleModel.chpl
@@ -295,8 +295,8 @@ module LocaleModel {
         yield loc;
     }
 
-    proc getDefaultLocaleSpace() const ref return this.myLocaleSpace;
-    proc getDefaultLocaleArray() const ref return myLocales;
+    override proc getDefaultLocaleSpace() const ref return this.myLocaleSpace;
+    override proc getDefaultLocaleArray() const ref return myLocales;
 
     proc localeIDtoLocale(id : chpl_localeID_t) {
       const node = chpl_nodeFromLocaleID(id);

--- a/modules/internal/localeModels/flat/LocaleModel.chpl
+++ b/modules/internal/localeModels/flat/LocaleModel.chpl
@@ -218,8 +218,8 @@ module LocaleModel {
         yield loc;
     }
 
-    proc getDefaultLocaleSpace() const ref return this.myLocaleSpace;
-    proc getDefaultLocaleArray() const ref return myLocales;
+    override proc getDefaultLocaleSpace() const ref return this.myLocaleSpace;
+    override proc getDefaultLocaleArray() const ref return myLocales;
 
     override proc localeIDtoLocale(id : chpl_localeID_t) {
       // In the default architecture, there are only nodes and no sublocales.

--- a/modules/internal/localeModels/knl/LocaleModel.chpl
+++ b/modules/internal/localeModels/knl/LocaleModel.chpl
@@ -519,8 +519,8 @@ module LocaleModel {
         yield loc;
     }
 
-    proc getDefaultLocaleSpace() const ref return this.myLocaleSpace;
-    proc getDefaultLocaleArray() const ref return myLocales;
+    override proc getDefaultLocaleSpace() const ref return this.myLocaleSpace;
+    override proc getDefaultLocaleArray() const ref return myLocales;
 
     proc localeIDtoLocale(id : chpl_localeID_t) {
       const node = chpl_nodeFromLocaleID(id);

--- a/modules/internal/localeModels/numa/LocaleModel.chpl
+++ b/modules/internal/localeModels/numa/LocaleModel.chpl
@@ -264,8 +264,8 @@ module LocaleModel {
         yield loc;
     }
 
-    proc getDefaultLocaleSpace() const ref return this.myLocaleSpace;
-    proc getDefaultLocaleArray() const ref return myLocales;
+    override proc getDefaultLocaleSpace() const ref return this.myLocaleSpace;
+    override proc getDefaultLocaleArray() const ref return myLocales;
 
     override proc localeIDtoLocale(id : chpl_localeID_t) {
       const node = chpl_nodeFromLocaleID(id);

--- a/modules/layouts/LayoutCS.chpl
+++ b/modules/layouts/LayoutCS.chpl
@@ -132,7 +132,7 @@ class CSDom: BaseSparseDomImpl {
     dsiClear();
   }
 
-  proc dsiMyDist() return dist;
+  override proc dsiMyDist() return dist;
 
   proc dsiAssignDomain(rhs: domain, lhsPrivate:bool) {
     chpl_assignDomainWithIndsIterSafeForRemoving(this, rhs);

--- a/modules/standard/Regexp.chpl
+++ b/modules/standard/Regexp.chpl
@@ -401,7 +401,7 @@ class BadRegexpError : Error {
   proc init(msg: string) {
     this.msg = msg;
   }
-  proc message() {
+  override proc message() {
     return msg;
   }
 }

--- a/test/classes/ferguson/override/override-combined.good
+++ b/test/classes/ferguson/override/override-combined.good
@@ -1,5 +1,5 @@
-override-combined.chpl:9: warning: Child.g override keyword present but no superclass method matches signature to override
+override-combined.chpl:9: error: Child.g override keyword present but no superclass method matches signature to override
 override-combined.chpl:12: warning: Child.f override keyword required for method matching signature of superclass method
-override-combined.chpl:15: warning: Child.g_generic override keyword present but no superclass method matches signature to override
-override-combined.chpl:15: warning: Child.g_generic override keyword present but no superclass method matches signature to override
+override-combined.chpl:15: error: Child.g_generic override keyword present but no superclass method matches signature to override
+override-combined.chpl:15: error: Child.g_generic override keyword present but no superclass method matches signature to override
 override-combined.chpl:18: warning: Child.f_generic override keyword required for method matching signature of superclass method

--- a/test/classes/ferguson/override/override-mix.good
+++ b/test/classes/ferguson/override/override-mix.good
@@ -1,4 +1,4 @@
-override-mix.chpl:9: warning: Child.f override keyword present but no superclass method matches signature to override
-override-mix.chpl:11: warning: Child.g override keyword present but no superclass method matches signature to override
-override-mix.chpl:12: warning: Child.g override keyword present but no superclass method matches signature to override
+override-mix.chpl:9: error: Child.f override keyword present but no superclass method matches signature to override
+override-mix.chpl:11: error: Child.g override keyword present but no superclass method matches signature to override
+override-mix.chpl:12: error: Child.g override keyword present but no superclass method matches signature to override
 override-mix.chpl:14: warning: Child.h override keyword required for method matching signature of superclass method

--- a/test/classes/ferguson/override/override-no-parens.chpl
+++ b/test/classes/ferguson/override/override-no-parens.chpl
@@ -1,0 +1,12 @@
+class Parent {
+  proc foo { }
+}
+
+class Child : Parent {
+  override proc foo { }
+}
+
+proc main() {
+  var x = new borrowed Child();
+  x.foo;
+}

--- a/test/classes/ferguson/override/override-no-parens.good
+++ b/test/classes/ferguson/override/override-no-parens.good
@@ -1,0 +1,1 @@
+override-no-parens.chpl:6: error: Child.foo override keyword present but parentheses-less methods cannot override

--- a/test/classes/ferguson/override/override-param.chpl
+++ b/test/classes/ferguson/override/override-param.chpl
@@ -1,0 +1,65 @@
+class Parent {
+  proc accepts_type(type t) {
+    writeln("Parent.accepts_type");
+  }
+  proc returns_type() type {
+    writeln("Parent.returns_type");
+    return int;
+  }
+  proc accepts_param(param t) {
+    writeln("Parent.accepts_param");
+  }
+  proc returns_param() param {
+    writeln("Parent.returns_param");
+    return 1;
+  }
+
+  proc returns_rtt() type {
+    var A:[1..10] int;
+    writeln("Parent.returns_rtt");
+    return A.type;
+  }
+}
+
+class Child : Parent {
+  override proc accepts_type(type t) {
+    writeln("Child.accepts_type");
+  }
+  override proc returns_type() type {
+    writeln("Child.returns_type");
+    return int;
+  }
+  override proc accepts_param(param t) {
+    writeln("Child.accepts_param");
+  }
+  override proc returns_param() param {
+    writeln("Child.returns_param");
+    return 1;
+  }
+  override proc returns_rtt() type {
+    var A:[1..10] int;
+    writeln("Child.returns_rtt");
+    return A.type;
+  }
+}
+
+proc main() {
+  var a = new borrowed Parent();
+  var b = new borrowed Child();
+  var c:Parent = new borrowed Child();
+  a.accepts_type(int);
+  b.accepts_type(int);
+  c.accepts_type(int);
+  a.returns_type();
+  b.returns_type();
+  c.returns_type();
+  a.accepts_param(1);
+  b.accepts_param(1);
+  c.accepts_param(1);
+  a.returns_param();
+  b.returns_param();
+  c.returns_param();
+  a.returns_rtt();
+  b.returns_rtt();
+  c.returns_rtt();
+}

--- a/test/classes/ferguson/override/override-param.good
+++ b/test/classes/ferguson/override/override-param.good
@@ -1,0 +1,3 @@
+override-param.chpl:28: error: Child.returns_type override keyword present but type return methods cannot override
+override-param.chpl:35: error: Child.returns_param override keyword present but param return methods cannot override
+override-param.chpl:39: error: Child.returns_rtt override keyword present but type return methods cannot override

--- a/test/classes/ferguson/override/override-record.chpl
+++ b/test/classes/ferguson/override/override-record.chpl
@@ -1,0 +1,10 @@
+record Parent {
+  override proc foo() {
+    writeln("Parent.foo");
+  }
+}
+
+proc main() {
+  var a = new Parent();
+  a.foo();
+}

--- a/test/classes/ferguson/override/override-record.good
+++ b/test/classes/ferguson/override/override-record.good
@@ -1,0 +1,1 @@
+override-record.chpl:2: error: Parent.foo override keyword present but record methods cannot override

--- a/test/classes/ferguson/override/override-spurious.good
+++ b/test/classes/ferguson/override/override-spurious.good
@@ -1,1 +1,1 @@
-override-spurious.chpl:7: warning: Child.g override keyword present but no superclass method matches signature to override
+override-spurious.chpl:7: error: Child.g override keyword present but no superclass method matches signature to override

--- a/test/classes/ferguson/override/override-spurious2.good
+++ b/test/classes/ferguson/override/override-spurious2.good
@@ -1,1 +1,1 @@
-override-spurious2.chpl:7: warning: Child.g override keyword present but no superclass method matches signature to override
+override-spurious2.chpl:7: error: Child.g override keyword present but no superclass method matches signature to override

--- a/test/release/examples/primers/classes.chpl
+++ b/test/release/examples/primers/classes.chpl
@@ -53,7 +53,7 @@ writeln(foo.sum_a_b_b(3));
 //
 class D: C {
   var c = 1.2, d = 3.4;
-  proc printFields() {
+  override proc printFields() {
     writeln("a = ", a, " b = ", b, " c = ", c, " d = ", d);
   }
 }


### PR DESCRIPTION
* override present but not an override now an error (vs warning)
 * correct handling of no-parens methods & add testing of these
 * correct handling of type, param return methods & add testing of these
 * adjust build default functions for setting FLAG_OVERRIDE on
   writeThis/readThis appropriately
* scatter enough override keywords in modules for primers to pass with the flag
* based on above, include override checking for internal modules when flag is used

Passed full local --futures testing.
Reviewed by @benharsh - thanks!