### PR TITLE
Help cray-module correctness tests adapt to new requirement (Cray-internal)

### DIFF
--- a/util/test/chpl_launchcmd.py
+++ b/util/test/chpl_launchcmd.py
@@ -845,6 +845,7 @@ class PbsProJob(AbstractJob):
         if self.hostlist is not None:
             # This relies on the caller to use the correct select syntax.
             select_stmt = select_pattern.format(self.hostlist)
+            select_stmt = select_stmt.replace('<num_locales>', str(num_locales))
         elif num_locales > 0:
             select_stmt = select_pattern.format(num_locales)
 


### PR DESCRIPTION
This enables Cray-internal testing to continue after one of
Cray's internal test machines was upgraded, and PBS on that
machine no longer supports the old "MPP" style of node selection.

This should have no effect on anyone else.

Thanks, ronawho.