### PR TITLE
Simplify version button for user experience; search engine optimization

### DIFF
--- a/doc/util/versionButton.php
+++ b/doc/util/versionButton.php
@@ -48,7 +48,6 @@
   overflow: auto;
   box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
   z-index: 1;
-  height: 150px;
   right: 0;
 }
 
@@ -84,7 +83,7 @@ var chplTitle = "<?php echo "$chplTitle";?>";
 
 // Note: assumes second element is most-recent release
 var chplVersions = [
-  "1.18 pre-release",
+  "1.18 (pre-release)",
   "1.17",
   "1.16",
   "1.15",
@@ -107,10 +106,11 @@ function dropSetup() {
   // Choose button color
   if (chplTitle.includes("pre-release")) {
     button.classList.add("preRelease");
-  } else if (chplTitle != "1.17") {
-    button.classList.add("oldVersion");
-  } else {
+  } else if (chplTitle == "1.17") {
     button.classList.add("currentVersion");
+  } else {
+    button.classList.add("oldVersion");
+    button.innerHTML = chplTitle + " (old version) &#9660;";
   }
 
   // Clear old links (if any)
@@ -119,15 +119,19 @@ function dropSetup() {
   }
 
   // Add links to chapel-lang.org/docs/###/
-  for (var i = 0; i < chplVersions.length; i++) {
+  for (var i = 0; i < 2; i++) {
     var ver = chplVersions[i];
     if (ver != chplTitle) {
       var link = document.createElement("a");
       link.innerHTML = ver;
       if (ver.includes("pre-release")) {
-        ver = "master";
+        ver = "master/";
+      } else if (ver = "1.17") {
+        ver = "";
+      } else {
+        ver = ver + "/";
       }
-      link.href = "http://chapel-lang.org/docs/" + ver + "/" + pagePath + ".html";
+      link.href = "http://chapel-lang.org/docs/" + ver + pagePath + ".html";
       dropDiv.append(link);
     }
   }

--- a/doc/util/versionButton.php
+++ b/doc/util/versionButton.php
@@ -91,7 +91,7 @@ function dropSetup() {
   var button = document.getElementById("versionButton");
   // Uses unicode down-pointing triangle
   var arrow = " &#9660;";
-  button.innerHTML = chplTitle + arrow;
+  button.innerHTML = "version " + chplTitle + arrow;
 
   // Choose button color
   if (chplTitle.includes("pre-release")) {
@@ -99,7 +99,7 @@ function dropSetup() {
   } else if (chplTitle == currentRelease) {
     button.classList.add("currentVersion");
   } else {
-    button.innerHTML = chplTitle + " (old version)" + arrow;
+    button.innerHTML = "version " + chplTitle + " (old release)" + arrow;
     button.classList.add("oldVersion");
   }
 
@@ -111,7 +111,7 @@ function dropSetup() {
   if (chplTitle != currentRelease) {
     // Add links to current version of docs
     var link = document.createElement("a");
-    link.innerHTML = "version "+currentRelease+"<br>(current version)";
+    link.innerHTML = "version "+currentRelease+"<br>(latest release)";
     link.href = "http://chapel-lang.org/docs/" + pagePath + ".html";
     dropDiv.append(link);
   }

--- a/doc/util/versionButton.php
+++ b/doc/util/versionButton.php
@@ -87,6 +87,7 @@ if (pagePath == "") {
   pagePath = "index.html";
 }
 function dropSetup() {
+  var currentRelease = "1.17";
   var button = document.getElementById("versionButton");
   // Uses unicode down-pointing triangle
   var arrow = " &#9660;";
@@ -95,7 +96,7 @@ function dropSetup() {
   // Choose button color
   if (chplTitle.includes("pre-release")) {
     button.classList.add("preRelease");
-  } else if (chplTitle == "1.17") {
+  } else if (chplTitle == currentRelease) {
     button.classList.add("currentVersion");
   } else {
     button.innerHTML = chplTitle + " (old version)" + arrow;
@@ -107,17 +108,21 @@ function dropSetup() {
     dropDiv.removeChild(dropDiv.firstChild);
   }
 
-  // Add links to current version of docs
-  var link = document.createElement("a");
-  link.innerHTML = "version 1.17";
-  link.href = "http://chapel-lang.org/docs/" + pagePath + ".html";
-  dropDiv.append(link);
+  if (chplTitle != currentRelease) {
+    // Add links to current version of docs
+    var link = document.createElement("a");
+    link.innerHTML = "version "+currentRelease+"<br>(current version)";
+    link.href = "http://chapel-lang.org/docs/" + pagePath + ".html";
+    dropDiv.append(link);
+  }
 
-  // Add links to master version of docs
-  var link = document.createElement("a");
-  link.innerHTML = "version 1.18<br>(pre-release)";
-  link.href = "http://chapel-lang.org/docs/master/" + pagePath + ".html";
-  dropDiv.append(link);
+  if (!chplTitle.includes("pre-release")) {
+    // Add links to master version of docs
+    var link = document.createElement("a");
+    link.innerHTML = "version 1.18<br>(pre-release)";
+    link.href = "http://chapel-lang.org/docs/master/" + pagePath + ".html";
+    dropDiv.append(link);
+  }
 }
 dropSetup();
 

--- a/doc/util/versionButton.php
+++ b/doc/util/versionButton.php
@@ -81,18 +81,6 @@ function toggleDropDown() {
 
 var chplTitle = "<?php echo "$chplTitle";?>";
 
-// Note: assumes second element is most-recent release
-var chplVersions = [
-  "1.18 (pre-release)",
-  "1.17",
-  "1.16",
-  "1.15",
-  "1.14",
-  "1.13",
-  "1.12",
-  "1.11"
-];
-
 var pagePath = "<?php echo "$pagename";?>";
 if (pagePath == "") {
   // If no path is given, default to root of other docs
@@ -101,7 +89,8 @@ if (pagePath == "") {
 function dropSetup() {
   var button = document.getElementById("versionButton");
   // Uses unicode down-pointing triangle
-  button.innerHTML = chplTitle + " &#9660;";
+  var arrow = " &#9660;";
+  button.innerHTML = chplTitle + arrow;
 
   // Choose button color
   if (chplTitle.includes("pre-release")) {
@@ -109,8 +98,8 @@ function dropSetup() {
   } else if (chplTitle == "1.17") {
     button.classList.add("currentVersion");
   } else {
+    button.innerHTML = chplTitle + " (old version)" + arrow;
     button.classList.add("oldVersion");
-    button.innerHTML = chplTitle + " (old version) &#9660;";
   }
 
   // Clear old links (if any)
@@ -118,23 +107,17 @@ function dropSetup() {
     dropDiv.removeChild(dropDiv.firstChild);
   }
 
-  // Add links to chapel-lang.org/docs/###/
-  for (var i = 0; i < 2; i++) {
-    var ver = chplVersions[i];
-    if (ver != chplTitle) {
-      var link = document.createElement("a");
-      link.innerHTML = ver;
-      if (ver.includes("pre-release")) {
-        ver = "master/";
-      } else if (ver = "1.17") {
-        ver = "";
-      } else {
-        ver = ver + "/";
-      }
-      link.href = "http://chapel-lang.org/docs/" + ver + pagePath + ".html";
-      dropDiv.append(link);
-    }
-  }
+  // Add links to current version of docs
+  var link = document.createElement("a");
+  link.innerHTML = "version 1.17";
+  link.href = "http://chapel-lang.org/docs/" + pagePath + ".html";
+  dropDiv.append(link);
+
+  // Add links to master version of docs
+  var link = document.createElement("a");
+  link.innerHTML = "version 1.18<br>(pre-release)";
+  link.href = "http://chapel-lang.org/docs/master/" + pagePath + ".html";
+  dropDiv.append(link);
 }
 dropSetup();
 


### PR DESCRIPTION
While thinking and researching about how to have search engines stop pointing to our old versions of documents so much, I realized that a problem that our approach has taken is that all versions of the documentation point to all other versions and therefore no version stands out as being particularly more than anything else.  This happens because of the version button which points to all other versions of a document (when it exists).  But when you think of it, most people using the version button are likely to only want to jump to the latest version or the master version.  Geeks who really want to look at some other old version are probably very willing to hack URLs to get there.

So... this PR simplifies the version button to only include the latest and master versions in the hopes of driving more traffic to the latest version when search engines crawl the page.  While here, it also:

* adds a parenthetical to all old versions saying "(old version)" because it hasn't been clear that the color coding by itself has been sufficient
* puts the latest version above the master version
* changes the wording of the buttons slightly to include the word "version" and to describe the choices
* has the "latest" version point to the top-level documents rather than the version in the 1.17 subdirectory (say).

These changes seem to simplify both the script itself and the user experience.  Hopefully others will agree.
