### PR TITLE
allow throw new Error() for --warn-unstable

### DIFF
--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -852,6 +852,10 @@ static Expr* handleUnstableClassType(SymExpr* se) {
           } else if (outerOuterCall && callMakesDmap(outerOuterCall)) {
             // new dmap( new Block( ) )
             ok = true;
+          } else if (outerOuterCall &&
+                     outerOuterCall->isPrimitive(PRIM_THROW)) {
+            // throw new Error()
+            ok = true;
           } else if (outerCall && outerCall->isPrimitive(PRIM_NEW) &&
                      inCall == outerCall->get(1)) {
             // 'new SomeClass()'


### PR DESCRIPTION
Allow `throw new Error()` even though Error is an undecorated class.

Passed full local testing.

Reviewed by @benharsh - thanks!