### PR TITLE
Update a test's .good files now that dsiReallocate() is parallel

### DIFF
--- a/test/distributions/sungeun/dataPar2.tpl=1.lm-numa.good
+++ b/test/distributions/sungeun/dataPar2.tpl=1.lm-numa.good
@@ -1,8 +1,13 @@
 ### END ###
 ### START ###
 ### ignoreRunning = false
+### ignoreRunning = false
 ### minIndicesPerTask = 1
+### minIndicesPerTask = 1
+### nranges = (1..0)
 ### nranges = (1..1, 1..6, 1..3, 1..3, 1..3, 1..3)
+### numChunks = 0 (parDim = -1)
 ### numChunks = 1 (parDim = 1)
+### numTasksPerLoc = 1
 ### numTasksPerLoc = 1
 OK

--- a/test/distributions/sungeun/dataPar2.tpl=5.lm-numa.good
+++ b/test/distributions/sungeun/dataPar2.tpl=5.lm-numa.good
@@ -1,8 +1,13 @@
 ### END ###
 ### START ###
 ### ignoreRunning = false
+### ignoreRunning = false
 ### minIndicesPerTask = 1
+### minIndicesPerTask = 1
+### nranges = (1..0)
 ### nranges = (1..1, 1..6, 1..3, 1..3, 1..3, 1..3)
+### numChunks = 0 (parDim = -1)
 ### numChunks = 5 (parDim = 2)
+### numTasksPerLoc = 5
 ### numTasksPerLoc = 5
 OK

--- a/test/distributions/sungeun/dataPar2.tpl=6.mg=100.lm-numa.good
+++ b/test/distributions/sungeun/dataPar2.tpl=6.mg=100.lm-numa.good
@@ -1,8 +1,13 @@
 ### END ###
 ### START ###
 ### ignoreRunning = false
+### ignoreRunning = false
 ### minIndicesPerTask = 100
+### minIndicesPerTask = 100
+### nranges = (1..0)
 ### nranges = (1..1, 1..6, 1..3, 1..3, 1..3, 1..3)
+### numChunks = 0 (parDim = -1)
 ### numChunks = 4 (parDim = 2)
+### numTasksPerLoc = 6
 ### numTasksPerLoc = 6
 OK


### PR DESCRIPTION
Now that dsiReallocate() is parallel, it is adding extra output
to these tests which print out debugging information for forall
loops.  Note that the numa locale model uses a reallocation in
its setup.

I also found myself wondering whether we should skip this test
for numa (are we gaining much?) or should have finer-grained
execution time controls for squashing this debugging output
including only having it on for user code, but this was the
quickest resolution.