### PR TITLE
Update more tests for --warn-unstable

### DIFF
--- a/test/classes/kbrady/nil_cast.chpl
+++ b/test/classes/kbrady/nil_cast.chpl
@@ -3,7 +3,12 @@ class A {
 class B : A {
 }
 
-var a:A;
+var a:borrowed A;
 writeln("a: ",a);
-var b = a:B;
+var b = a:borrowed B;
 writeln("b: ",b);
+
+var aa:unmanaged A;
+writeln("aa: ",aa);
+var bb = aa:unmanaged B;
+writeln("bb: ",bb);

--- a/test/classes/kbrady/nil_cast.good
+++ b/test/classes/kbrady/nil_cast.good
@@ -1,2 +1,4 @@
 a: nil
 b: nil
+aa: nil
+bb: nil

--- a/test/classes/lydia/overrides/basicOverride.chpl
+++ b/test/classes/lydia/overrides/basicOverride.chpl
@@ -12,16 +12,11 @@ class B: A {
   }
 }
 
-var a = new A();
-var b = new B();
-var b2: A = new B();
+var a = new owned A();
+var b = new owned B();
+var b2: owned A = new owned B();
 
 a.foo();
 b.foo();
 
 b2.foo();
-
-delete b2;
-
-delete b;
-delete a;

--- a/test/classes/lydia/overrides/deeperInheritance.chpl
+++ b/test/classes/lydia/overrides/deeperInheritance.chpl
@@ -19,12 +19,12 @@ class C: B {
   }
 }
 
-var a = new A();
-var b = new B();
-var c = new C();
+var a = new borrowed A();
+var b = new borrowed B();
+var c = new borrowed C();
 
-var c2: A = new C();
-var c3: B = new C();
+var c2: borrowed A = new borrowed C();
+var c3: borrowed B = new borrowed C();
 
 a.foo();
 b.foo();
@@ -32,10 +32,3 @@ c.foo();
 
 c2.foo();
 c3.foo();
-
-delete c3;
-delete c2;
-
-delete c;
-delete b;
-delete a;

--- a/test/classes/lydia/overrides/deeperInheritance2.chpl
+++ b/test/classes/lydia/overrides/deeperInheritance2.chpl
@@ -19,12 +19,12 @@ class C: B {
   }
 }
 
-var a = new A();
-var b = new B();
-var c = new C();
+var a = new shared A();
+var b = new shared B();
+var c = new shared C();
 
-var c2: A = new C();
-var c3: B = new C();
+var c2: shared A = new shared C();
+var c3: shared B = new shared C();
 
 a.foo();
 b.foo();
@@ -32,10 +32,3 @@ c.foo();
 
 c2.foo();
 c3.foo();
-
-delete c3;
-delete c2;
-
-delete c;
-delete b;
-delete a;

--- a/test/classes/lydia/overrides/recursiveCall.chpl
+++ b/test/classes/lydia/overrides/recursiveCall.chpl
@@ -17,11 +17,8 @@ class B: A {
   }
 }
 
-var a = new A();
-var b = new B();
+var a = new borrowed A();
+var b = new borrowed B();
 
 a.foo(3);
 b.foo(2);
-
-delete b;
-delete a;

--- a/test/classes/lydia/overrides/secondary.chpl
+++ b/test/classes/lydia/overrides/secondary.chpl
@@ -13,11 +13,8 @@ proc B.foo(x) {
   writeln("in B.foo() with arg ", x);
 }
 
-var a = new A();
-var b = new B();
+var a = new owned A();
+var b = new owned B();
 
 a.foo(3);
 b.foo(2);
-
-delete b;
-delete a;

--- a/test/classes/lydia/overrides/secondary2.chpl
+++ b/test/classes/lydia/overrides/secondary2.chpl
@@ -13,11 +13,8 @@ class B: A {
   }
 }
 
-var a = new A();
-var b = new B();
+var a = new shared A();
+var b = new shared B();
 
 a.foo(3);
 b.foo(2);
-
-delete b;
-delete a;

--- a/test/classes/lydia/useInheritedDestructor.chpl
+++ b/test/classes/lydia/useInheritedDestructor.chpl
@@ -3,8 +3,8 @@ class storage {
 }
 
 class A {
-  var stored: storage = new storage();
-  var uninit: storage;
+  var stored: unmanaged storage = new unmanaged storage();
+  var uninit: unmanaged storage;
 
   proc deinit() {
     delete stored;
@@ -16,6 +16,6 @@ class B: A {
   var count: int = 1;
 }
 
-var instantiated: B = new B();
+var instantiated: unmanaged B = new unmanaged B();
 writeln(instantiated);
 delete instantiated;

--- a/test/classes/marybeth/test-class-init.chpl
+++ b/test/classes/marybeth/test-class-init.chpl
@@ -8,7 +8,7 @@ class Params {
   }
 }
 
-var ListOfParams = new Params();
+var ListOfParams = new unmanaged Params();
 
 writeln(ListOfParams);
 

--- a/test/classes/marybeth/test-init.chpl
+++ b/test/classes/marybeth/test-init.chpl
@@ -9,8 +9,6 @@ class TestRandom {
   }
 }
 
-var randlist = new TestRandom();
+var randlist = new owned TestRandom();
 
 randlist.showseed();
-
-delete randlist;

--- a/test/classes/marybeth/test_dispatch1-error.chpl
+++ b/test/classes/marybeth/test_dispatch1-error.chpl
@@ -19,14 +19,14 @@ class boots : pumps {
   }
 }
 
-proc displayshoe (item:shoe) {
+proc displayshoe (item:borrowed shoe) {
   item.display();
 }
 
-var shoe1:shoe = new shoe(9.5,"brown");
-var shoe2:pumps = new shoe(8.0,"navy");
+var shoe1:borrowed shoe = new borrowed shoe(9.5,"brown");
+var shoe2:borrowed pumps = new borrowed shoe(8.0,"navy");
 shoe2.heel = 1.0;
-var shoe3:boots = new pumps(7.0,"white",3.0);
+var shoe3:borrowed boots = new borrowed pumps(7.0,"white",3.0);
 displayshoe(shoe1);
 displayshoe(shoe2);
 displayshoe(shoe3);

--- a/test/classes/shannon/inoutClassDataMember.chpl
+++ b/test/classes/shannon/inoutClassDataMember.chpl
@@ -7,12 +7,10 @@ proc setVolcano(inout al: int, inout name: string) {
   al = 2;
 }
 
-var mtStHelens: volcano = new volcano();
+var mtStHelens: owned volcano = new owned volcano();
 var name: string;
 
 setVolcano(mtStHelens.alertLevel, name);
 
 writeln("Name: ", name);
 writeln("Alert Level: ", mtStHelens.alertLevel);
-
-delete mtStHelens;

--- a/test/classes/shannon/overloadedFunction.chpl
+++ b/test/classes/shannon/overloadedFunction.chpl
@@ -8,14 +8,12 @@ class C {
 
 }
 
-var myC = new C();
+var myC = new borrowed C();
 
-proc foo(c: C = myC, fmt: string = "foo", x: int) {
+proc foo(c: borrowed C = myC, fmt: string = "foo", x: int) {
   writeln("and got the int foo.");
 
 }
 
 writeln("Calling the overloaded foo function with an int argument,");
 foo(3);
-
-delete myC;

--- a/test/classes/shannon/varIntSetInConstructor.chpl
+++ b/test/classes/shannon/varIntSetInConstructor.chpl
@@ -7,9 +7,9 @@ class setConst {
 
 
 
-const const_testSix     : setConst = new borrowed setConst(thisShouldBeSix     =  6);
-const const_testEleven  : setConst = new borrowed setConst(thisShouldBeEleven  = 11);
-const const_testSixteen : setConst = new borrowed setConst(thisShouldBeSixteen = 16);
+const const_testSix     : borrowed setConst = new borrowed setConst(thisShouldBeSix     =  6);
+const const_testEleven  : borrowed setConst = new borrowed setConst(thisShouldBeEleven  = 11);
+const const_testSixteen : borrowed setConst = new borrowed setConst(thisShouldBeSixteen = 16);
 
 writeln("const_testSix.thisShouldBeSix         = ",
          const_testSix.thisShouldBeSix);
@@ -24,9 +24,9 @@ writeln();
 
 
 
-var var_testSix     : setConst = new borrowed setConst(thisShouldBeSix     =  6);
-var var_testEleven  : setConst = new borrowed setConst(thisShouldBeEleven  = 11);
-var var_testSixteen : setConst = new borrowed setConst(thisShouldBeSixteen = 16);
+var var_testSix     : borrowed setConst = new borrowed setConst(thisShouldBeSix     =  6);
+var var_testEleven  : borrowed setConst = new borrowed setConst(thisShouldBeEleven  = 11);
+var var_testSixteen : borrowed setConst = new borrowed setConst(thisShouldBeSixteen = 16);
 
 writeln("var_testSix.thisShouldBeSix         = ",
          var_testSix.thisShouldBeSix);

--- a/test/classes/shannon/varIntTypedSetInConstructor.chpl
+++ b/test/classes/shannon/varIntTypedSetInConstructor.chpl
@@ -7,9 +7,9 @@ class setConst {
 
 
 
-const const_testSix     : setConst = new setConst(thisShouldBeSix     =  6);
-const const_testEleven  : setConst = new setConst(thisShouldBeEleven  = 11);
-const const_testSixteen : setConst = new setConst(thisShouldBeSixteen = 16);
+const const_testSix     : unmanaged setConst = new unmanaged setConst(thisShouldBeSix     =  6);
+const const_testEleven  : unmanaged setConst = new unmanaged setConst(thisShouldBeEleven  = 11);
+const const_testSixteen : unmanaged setConst = new unmanaged setConst(thisShouldBeSixteen = 16);
 
 writeln("const_testSix.thisShouldBeSix         = ",
          const_testSix.thisShouldBeSix);
@@ -27,9 +27,9 @@ delete const_testSix;
 
 
 
-var var_testSix     : setConst = new setConst(thisShouldBeSix     =  6);
-var var_testEleven  : setConst = new setConst(thisShouldBeEleven  = 11);
-var var_testSixteen : setConst = new setConst(thisShouldBeSixteen = 16);
+var var_testSix     : unmanaged setConst = new unmanaged setConst(thisShouldBeSix     =  6);
+var var_testEleven  : unmanaged setConst = new unmanaged setConst(thisShouldBeEleven  = 11);
+var var_testSixteen : unmanaged setConst = new unmanaged setConst(thisShouldBeSixteen = 16);
 
 writeln("var_testSix.thisShouldBeSix         = ",
          var_testSix.thisShouldBeSix);

--- a/test/classes/stonea/constAndParamInConstructor.chpl
+++ b/test/classes/stonea/constAndParamInConstructor.chpl
@@ -14,10 +14,8 @@ class Bar {
     }
 }
 
-var objA = new Foo();
-var objB = new Bar();
+var objA = new borrowed Foo();
+var objB = new borrowed Bar();
 
 writeln(objA.value);
 writeln(objB.value);
-
-

--- a/test/classes/sungeun/inheritance_noUse_param1.chpl
+++ b/test/classes/sungeun/inheritance_noUse_param1.chpl
@@ -6,15 +6,11 @@ class B: A {
   var y: int;
 }
 
-var a = new A();
-var b: B;
-var c: B;
+var a = new owned A();
+var b: owned B;
+var c: owned B;
 
 writeln(a);
 writeln("{x = ", a.x, "}");
 
-b = new B();
-
-delete b;
-delete a;
-
+b = new owned B();

--- a/test/classes/sungeun/inheritance_param1.chpl
+++ b/test/classes/sungeun/inheritance_param1.chpl
@@ -6,7 +6,5 @@ class B: A {
   var y = x;
 }
 
-var a = new A();
-var b: B;
-
-delete a;
+var a = new borrowed A();
+var b: borrowed B;

--- a/test/classes/sungeun/inheritance_param2.chpl
+++ b/test/classes/sungeun/inheritance_param2.chpl
@@ -9,8 +9,5 @@ class B: A {
   }
 }
 
-var a = new A();
-var b: B;
-
-delete a;
-
+var a = new shared A();
+var b: shared B;

--- a/test/classes/sungeun/inheritance_param3.chpl
+++ b/test/classes/sungeun/inheritance_param3.chpl
@@ -8,7 +8,5 @@ class B: A {
   }
 }
 
-var a = new A();
-var b: B;
-
-delete a;
+var a = new borrowed A();
+var b: borrowed B;

--- a/test/classes/sungeun/inheritance_typeVar3.chpl
+++ b/test/classes/sungeun/inheritance_typeVar3.chpl
@@ -8,7 +8,5 @@ class B: A {
   }
 }
 
-var a = new A();
-var b: B;
-
-delete a;
+var a = new borrowed A();
+var b: borrowed B;

--- a/test/classes/thomasvandoren/InheritGenericClass.chpl
+++ b/test/classes/thomasvandoren/InheritGenericClass.chpl
@@ -5,8 +5,5 @@ class A {
 class B : A {
 }
 
-var a = new A(int);
-var b = new B(int);
-
-delete b;
-delete a;
+var a = new owned A(int);
+var b = new owned B(int);

--- a/test/classes/vass/duplicate-class-names.chpl
+++ b/test/classes/vass/duplicate-class-names.chpl
@@ -1,14 +1,14 @@
 proc p {
   class C { var x=3; }
-  return new C();
+  return new unmanaged C();
 }
 proc q {
   class C { var y=8; }
-  return new C();
+  return new unmanaged C();
 }
 class C { var z=17; }
 proc r {
-  return new C();
+  return new unmanaged C();
 }
 
 var c1 = p;

--- a/test/classes/vass/duplicate-virtual-method-error-1.chpl
+++ b/test/classes/vass/duplicate-virtual-method-error-1.chpl
@@ -1,5 +1,5 @@
 class C     { proc dup(){ return 1; } proc dup(){ return 4; } }
 class D : C { proc dup(){ return 2; } }
 
-var c:C = new borrowed D();
+var c:borrowed C = new borrowed D();
 writeln(c.dup());

--- a/test/classes/vass/duplicate-virtual-method-ok-1.chpl
+++ b/test/classes/vass/duplicate-virtual-method-ok-1.chpl
@@ -1,5 +1,5 @@
 class C     { proc dup(){ return 1; } }
 class D : C { proc dup(){ return 2; } proc dup(a:int){ return 3; } }
 
-var c:C = new borrowed D();
+var c:borrowed C = new borrowed D();
 writeln(c.dup());

--- a/test/classes/vass/generic-method-with-param-arg-4.chpl
+++ b/test/classes/vass/generic-method-with-param-arg-4.chpl
@@ -12,9 +12,6 @@ class D: C {
   }
 }
 
-var c: C = new D();
+var c: owned C = new owned D();
 
 writeln(c.a(3));
-
-delete c;
-

--- a/test/classes/vass/generic-parenthesesless-4.chpl
+++ b/test/classes/vass/generic-parenthesesless-4.chpl
@@ -10,9 +10,6 @@ proc C.g2: int {
   return f2;
 }
 
-var c = new C(1);
+var c = new shared C(1);
 
 writeln(c.g2);
-
-delete c;
-

--- a/test/classes/vass/generic-parenthesesless-big1.chpl
+++ b/test/classes/vass/generic-parenthesesless-big1.chpl
@@ -24,7 +24,7 @@ proc C.h1(): int return f1;
 proc C.h2(): int return f2;
 proc C.h3(): int return f3();
 
-var c = new C(1);
+var c = new borrowed C(1);
 
 writeln((
          c.g1,
@@ -34,5 +34,3 @@ writeln((
          c.h2(),
          c.h3()
          ));
-
-delete c;

--- a/test/classes/vass/is-extern-class.chpl
+++ b/test/classes/vass/is-extern-class.chpl
@@ -27,7 +27,7 @@ testme();
 proc testme() {
 
   compilerWarning("should be false:");
-  compilerWarning(isExternClassType(CC):string);
+  compilerWarning(isExternClassType(borrowed CC):string);
   compilerWarning(isExternClassType(RR):string);
   compilerWarning(isExternClassType(string):string);
   compilerWarning(isExternClassType(int):string);

--- a/test/classes/vass/nested-class-with-outer-1.chpl
+++ b/test/classes/vass/nested-class-with-outer-1.chpl
@@ -8,11 +8,9 @@ record R {
   }
 
   proc pr {
-    var q:Q = new Q();
+    var q:owned Q = new owned Q();
 
     q.pq;
-
-    delete q;
   }
 }
 
@@ -29,15 +27,13 @@ class C {
   }
 
   proc pc {
-    var d:D = new D();
+    var d:borrowed D = new borrowed D();
 
     d.pd;
-
-    delete d;
   }
 }
 
-var c:C = new C();
+var c:unmanaged C = new unmanaged C();
 
 c.pc;
 

--- a/test/classes/vass/old-destructor-name.chpl
+++ b/test/classes/vass/old-destructor-name.chpl
@@ -21,10 +21,10 @@ record R {
   }
 }
 
-var d: C;
+var d: unmanaged C;
 writeln("start");
 {
-var c = new C(44);
+var c = new unmanaged C(44);
 var r = new R(55);
 d = c;
 }

--- a/test/classes/vass/ref-like-intents/inout-subclass.chpl
+++ b/test/classes/vass/ref-like-intents/inout-subclass.chpl
@@ -3,12 +3,12 @@ class D:C {
   proc procInD() { writeln("got a D"); }
 }
 
-proc procInoutC(inout arg: C) {
-  arg = new C();
+proc procInoutC(inout arg: unmanaged C) {
+  arg = new unmanaged C();
 }
 
-var c:C;
-var d:D;
+var c:unmanaged C;
+var d:unmanaged D;
 
 procInoutC(c); // OK
 procInoutC(d); // error

--- a/test/classes/vass/ref-like-intents/inout-superclass.chpl
+++ b/test/classes/vass/ref-like-intents/inout-superclass.chpl
@@ -3,12 +3,12 @@ class D:C {
   proc procInD() { writeln("got a D"); }
 }
 
-proc procInoutD(inout arg: D) {
+proc procInoutD(inout arg: unmanaged D) {
   arg.procInD(); // would be undefined if the error were not reported
 }
 
-var c = new C();
-var d = new D();
+var c = new unmanaged C();
+var d = new unmanaged D();
 
 procInoutD(c); // error
 procInoutD(d); // OK

--- a/test/classes/vass/ref-like-intents/inout-superclass.good
+++ b/test/classes/vass/ref-like-intents/inout-superclass.good
@@ -1,2 +1,2 @@
-inout-superclass.chpl:13: error: unresolved call 'procInoutD(C)'
-inout-superclass.chpl:6: note: candidates are: procInoutD(inout arg: D)
+inout-superclass.chpl:13: error: unresolved call 'procInoutD(unmanaged C)'
+inout-superclass.chpl:6: note: candidates are: procInoutD(inout arg: unmanaged D)

--- a/test/classes/vass/ref-like-intents/out-subclass.chpl
+++ b/test/classes/vass/ref-like-intents/out-subclass.chpl
@@ -3,12 +3,12 @@ class D:C {
   proc procInD() { writeln("got a D"); }
 }
 
-proc procOutC(out arg: C) {
-  arg = new C();
+proc procOutC(out arg: unmanaged C) {
+  arg = new unmanaged C();
 }
 
-var c:C;
-var d:D;
+var c:unmanaged C;
+var d:unmanaged D;
 
 procOutC(c); // OK
 procOutC(d); // error

--- a/test/classes/vass/ref-like-intents/out-superclass.chpl
+++ b/test/classes/vass/ref-like-intents/out-superclass.chpl
@@ -3,12 +3,12 @@ class D:C {
   proc procInD() { writeln("got a D"); }
 }
 
-proc procOutD(out arg: D) {
-  arg = new C();
+proc procOutD(out arg: unmanaged D) {
+  arg = new unmanaged C();
 }
 
-var c: C;
-var d: D;
+var c: unmanaged C;
+var d: unmanaged D;
 
 procOutD(c); // OK
 procOutD(d); // error

--- a/test/classes/vass/ref-like-intents/out-superclass.good
+++ b/test/classes/vass/ref-like-intents/out-superclass.good
@@ -1,2 +1,2 @@
-out-superclass.chpl:13: error: unresolved call 'procOutD(C)'
-out-superclass.chpl:6: note: candidates are: procOutD(out arg: D)
+out-superclass.chpl:13: error: unresolved call 'procOutD(unmanaged C)'
+out-superclass.chpl:6: note: candidates are: procOutD(out arg: unmanaged D)

--- a/test/classes/vass/ref-like-intents/ref-subclass.chpl
+++ b/test/classes/vass/ref-like-intents/ref-subclass.chpl
@@ -3,12 +3,12 @@ class D:C {
   proc procInD() { writeln("got a D"); }
 }
 
-proc procRefC(ref arg: C) {
-  arg = new C();
+proc procRefC(ref arg: unmanaged C) {
+  arg = new unmanaged C();
 }
 
-var c:C;
-var d:D;
+var c:unmanaged C;
+var d:unmanaged D;
 
 procRefC(c); // OK
 procRefC(d); // error

--- a/test/classes/vass/ref-like-intents/ref-superclass.chpl
+++ b/test/classes/vass/ref-like-intents/ref-superclass.chpl
@@ -3,12 +3,12 @@ class D:C {
   proc procInD() { writeln("got a D"); }
 }
 
-proc procRefD(ref arg: D) {
+proc procRefD(ref arg: borrowed D) {
   arg.procInD(); // would be undefined if the error were not reported
 }
 
-var c = new C();
-var d = new D();
+var c = new borrowed C();
+var d = new borrowed D();
 
 procRefD(c); // error
 procRefD(d); // OK

--- a/test/classes/vass/ref-like-intents/ref-superclass.good
+++ b/test/classes/vass/ref-like-intents/ref-superclass.good
@@ -1,2 +1,2 @@
 ref-superclass.chpl:13: error: unresolved call 'procRefD(C)'
-ref-superclass.chpl:6: note: candidates are: procRefD(ref arg: D)
+ref-superclass.chpl:6: note: candidates are: procRefD(ref arg: borrowed D)

--- a/test/classes/vass/subclass-cast-error-borrowed.chpl
+++ b/test/classes/vass/subclass-cast-error-borrowed.chpl
@@ -2,7 +2,7 @@ class C{};
 class D:C{};
 
 var c = new borrowed C();
-var d = c:D;
+var d = c:borrowed D;
 
 writeln(c);
 writeln(d);

--- a/test/classes/vass/subclass-cast-error.chpl
+++ b/test/classes/vass/subclass-cast-error.chpl
@@ -2,7 +2,7 @@ class C{};
 class D:C{};
 
 var c = new unmanaged C();
-var d = c:D;
+var d = c:unmanaged D;
 
 writeln(c);
 writeln(d);

--- a/test/classes/vass/unused-decl-in-proc-3.chpl
+++ b/test/classes/vass/unused-decl-in-proc-3.chpl
@@ -12,10 +12,10 @@ module N {
   }
   proc q {
     class C2 {}
-    return new C2();
+    return new unmanaged C2();
   }
   proc r() {
     class C3 {}
-    return new C3();
+    return new unmanaged C3();
   }
 }

--- a/test/classes/waynew/class-rec.chpl
+++ b/test/classes/waynew/class-rec.chpl
@@ -11,7 +11,7 @@ record R {
 
 class C {
   type ind_type;
-  var inds: CC(R(ind_type));
+  var inds: unmanaged CC(R(ind_type));
 }
 
 var c: unmanaged C(real) = new unmanaged C(real);

--- a/test/classes/waynew/dyndis2.chpl
+++ b/test/classes/waynew/dyndis2.chpl
@@ -8,7 +8,7 @@ class somedata {
 
 
 class base {
-  proc jam( x: int, d: somedata(int)) {
+  proc jam( x: int, d: borrowed somedata(int)) {
     writeln( "base ", " : ", d);
   }
 }
@@ -16,7 +16,7 @@ class base {
 class aclass: base {
   type dtype;
   var data: dtype;
-  proc jam( x: int, d: somedata(int)) {
+  proc jam( x: int, d: borrowed somedata(int)) {
     writeln( "aclass ", data, " ", x, " : ", d);
   }
 }
@@ -24,42 +24,36 @@ class aclass: base {
 class bclass: base {
   type dtype;
   var y: dtype;
-  proc jam( x:int, d: somedata(int)) {
+  proc jam( x:int, d: borrowed somedata(int)) {
     writeln( "bclass ", y, " ", x, " : ", d);
   }
 }
 
 class contain {
-  var objs: list(base);
+  var objs: list(borrowed base);
 
   proc deinit() {
     objs.destroy();
   }
 
   proc xxx() {
-    var something: somedata(int);
+    var something: borrowed somedata(int);
 
-    something = new somedata( int, 10);
+    something = new owned somedata( int, 10);
 
     for e in objs do
        e.jam( 99, something);
-
-    delete something;
   }
 }
 
 
 proc main () {
-  var a : aclass(int)  = new aclass(int);
-  var b : bclass(bool) = new bclass(bool);
-  var c : contain      = new contain();
+  var a : borrowed aclass(int)  = new borrowed aclass(int);
+  var b : borrowed bclass(bool) = new borrowed bclass(bool);
+  var c : borrowed contain      = new borrowed contain();
 
   c.objs.append(b);
   c.objs.append(a);
   c.xxx();
-
-  delete c;
-  delete b;
-  delete a;
 }
 

--- a/test/compflags/lydia/noUseNoinit/tupleWithClass.chpl
+++ b/test/compflags/lydia/noUseNoinit/tupleWithClass.chpl
@@ -2,9 +2,9 @@ class foo {
   var bar: int;
 }
 
-inline proc _defaultOf(type t) where t == (int, foo) {
+inline proc _defaultOf(type t) where t == (int, borrowed foo) {
   writeln("I default initialized!");
-  var innerRec: foo;
+  var innerRec: borrowed foo;
   return (0, innerRec);
 }
 
@@ -12,20 +12,16 @@ inline proc _defaultOf(type t) where t == (int, foo) {
 
 
 
-var tup: (int, foo) = noinit; // Should not print message
+var tup: (int, borrowed foo) = noinit; // Should not print message
 
-tup(2) = new foo(2);
+tup(2) = new borrowed foo(2);
 tup(1) = 5;
 writeln(tup);
 
-delete tup(2);
 
 
 
+var otherTup: (int, borrowed foo);     // Should print message
 
-var otherTup: (int, foo);     // Should print message
-
-otherTup(2) = new foo(3);
+otherTup(2) = new borrowed foo(3);
 writeln(otherTup);
-
-delete otherTup(2);

--- a/test/compflags/sungeun/configs/type_variables/PREDIFF
+++ b/test/compflags/sungeun/configs/type_variables/PREDIFF
@@ -12,7 +12,11 @@ compopts=sys.argv[4]
 l = string.rfind(compopts, 'myType')
 
 if l != -1:
-    myType=compopts[l+7:].split()[0]
+    words=compopts[l+7:].split()
+    if words[0] == "'unmanaged":
+      myType = words[1].split("'")[0]
+    else:
+      myType = words[0]
 else:
     myType=None
 

--- a/test/compflags/sungeun/configs/type_variables/configTypeFun.compopts
+++ b/test/compflags/sungeun/configs/type_variables/configTypeFun.compopts
@@ -1,4 +1,4 @@
 -smyType=rPair
--smyType=cPair
--smyIdxType=uint(8) -smyType=cPair
+-smyType='unmanaged cPair'
+-smyIdxType=uint(8) -smyType='unmanaged cPair'
 -smyType=rPair -smyIdxType=real

--- a/test/compflags/sungeun/configs/type_variables/configTypeFunNoType.compopts
+++ b/test/compflags/sungeun/configs/type_variables/configTypeFunNoType.compopts
@@ -1,4 +1,4 @@
 -smyType=rPair
--smyType=cPair
--smyIdxType=int(64) -smyType=cPair
+-smyType='unmanaged cPair'
+-smyIdxType=int(64) -smyType='unmanaged cPair'
 -smyType=rPair -smyIdxType=real(32)

--- a/test/compflags/sungeun/configs/type_variables/configTypeUserType.compopts
+++ b/test/compflags/sungeun/configs/type_variables/configTypeUserType.compopts
@@ -1,4 +1,4 @@
 -smyType=rPair
--smyType=cPair
--smyIdxType=int(16) -smyType=cPair
+-smyType='unmanaged cPair'
+-smyIdxType=int(16) -smyType='unmanaged cPair'
 -smyType=rPair -smyIdxType=real

--- a/test/deprecated/constructorError/hasConstructor.chpl
+++ b/test/deprecated/constructorError/hasConstructor.chpl
@@ -7,6 +7,5 @@ class Foo {
   }
 }
 
-var foo = new Foo(10);
+var foo = new owned Foo(10);
 writeln(foo);
-delete foo;

--- a/test/deprecated/constructorError/hasConstructor2.chpl
+++ b/test/deprecated/constructorError/hasConstructor2.chpl
@@ -7,6 +7,6 @@ proc Foo.Foo(xVal) {
   x = xVal;
 }
 
-var foo = new Foo(10);
+var foo = new unmanaged Foo(10);
 writeln(foo);
 delete foo;

--- a/test/deprecated/forceInitializers/basic_check.chpl
+++ b/test/deprecated/forceInitializers/basic_check.chpl
@@ -12,8 +12,7 @@ class LotsOFields {
 }
 
 proc main() {
-  var c: LotsOFields = new LotsOFields(2, 6.3, true);
+  var c: borrowed LotsOFields = new borrowed LotsOFields(2, 6.3, true);
 
   writeln(c);
-  delete c;
 }

--- a/test/distributions/bradc/assoc/userAssoc-array-domain-zipper.chpl
+++ b/test/distributions/bradc/assoc/userAssoc-array-domain-zipper.chpl
@@ -10,8 +10,8 @@ class MyMapper {
   }
 }
 
-var myMapper = new MyMapper();
-var newDist = new dmap(new UserMapAssoc(idxType=real, mapper=myMapper));
+var myMapper = new unmanaged MyMapper();
+var newDist = new dmap(new unmanaged UserMapAssoc(idxType=real, mapper=myMapper));
 
 var D: domain(real) dmapped newDist;
 

--- a/test/distributions/bradc/assoc/userAssoc-array-noelt.chpl
+++ b/test/distributions/bradc/assoc/userAssoc-array-noelt.chpl
@@ -8,7 +8,7 @@ class MyMapper {
   }
 }
 
-var newDist = new dmap(new UserMapAssoc(idxType=real, mapper=new MyMapper()));
+var newDist = new dmap(new unmanaged UserMapAssoc(idxType=real, mapper=new unmanaged MyMapper()));
 
 var D: domain(real) dmapped newDist;
 

--- a/test/distributions/bradc/assoc/userAssoc-array-priv-check.chpl
+++ b/test/distributions/bradc/assoc/userAssoc-array-priv-check.chpl
@@ -9,7 +9,7 @@ class MyMapper {
 }
 
 proc doit() {
-  var newDist = new dmap(new UserMapAssoc(idxType=real, mapper=new MyMapper()));
+  var newDist = new dmap(new unmanaged UserMapAssoc(idxType=real, mapper=new unmanaged MyMapper()));
 
   var D: domain(real) dmapped newDist;
 

--- a/test/distributions/bradc/assoc/userAssoc-basic-array.chpl
+++ b/test/distributions/bradc/assoc/userAssoc-basic-array.chpl
@@ -8,7 +8,7 @@ class MyMapper {
   }
 }
 
-var newDist = new dmap(new UserMapAssoc(idxType=real, mapper=new MyMapper()));
+var newDist = new dmap(new unmanaged UserMapAssoc(idxType=real, mapper=new unmanaged MyMapper()));
 
 var D: domain(real) dmapped newDist;
 

--- a/test/distributions/bradc/assoc/userAssoc-basic-domain.chpl
+++ b/test/distributions/bradc/assoc/userAssoc-basic-domain.chpl
@@ -8,7 +8,7 @@ class MyMapper {
   }
 }
 
-var newDist = new dmap(new UserMapAssoc(idxType=real, mapper=new MyMapper()));
+var newDist = new dmap(new unmanaged UserMapAssoc(idxType=real, mapper=new unmanaged MyMapper()));
 
 var D: domain(real) dmapped newDist;
 

--- a/test/distributions/bradc/assoc/userAssoc-domain-priv-check.chpl
+++ b/test/distributions/bradc/assoc/userAssoc-domain-priv-check.chpl
@@ -9,7 +9,7 @@ class MyMapper {
 }
 
 proc doit() {
-  var newDist = new dmap(new UserMapAssoc(idxType=real, mapper=new MyMapper()));
+  var newDist = new dmap(new unmanaged UserMapAssoc(idxType=real, mapper=new unmanaged MyMapper()));
 
   var D: domain(real) dmapped newDist;
 

--- a/test/distributions/bradc/where/dispatchBasedOnDist.chpl
+++ b/test/distributions/bradc/where/dispatchBasedOnDist.chpl
@@ -6,19 +6,19 @@ var DCyc: domain(1) dmapped Cyclic(startIdx=1) = {1..10};
 var ABlk: [DBlk] real;
 var ACyc: [DCyc] real;
 
-proc domproc(D: domain) where _to_borrowed(D.dist.type): Block {
+proc domproc(D: domain) where _to_borrowed(D.dist.type): borrowed Block {
   writeln("In the domproc() for Block");
 }
 
-proc domproc(D: domain) where _to_borrowed(D.dist.type): Cyclic {
+proc domproc(D: domain) where _to_borrowed(D.dist.type): borrowed Cyclic {
   writeln("In the domproc() for Cyclic");
 }
 
-proc arrproc(A: []) where _to_borrowed(A.domain.dist.type): Block {
+proc arrproc(A: []) where _to_borrowed(A.domain.dist.type): borrowed Block {
   writeln("In the arrproc() for Block");
 }
 
-proc arrproc(A: []) where _to_borrowed(A.domain.dist.type): Cyclic {
+proc arrproc(A: []) where _to_borrowed(A.domain.dist.type): borrowed Cyclic {
   writeln("In the arrproc() for Cyclic");
 }
 

--- a/test/distributions/diten/Cyclic.chpl
+++ b/test/distributions/diten/Cyclic.chpl
@@ -72,7 +72,7 @@ class Cyclic1DDist {
   // but this doesn't work yet because an array forall initializer
   // apparently can't refer to a local member domain.
   //
-  const locDist: [targetLocDom] LocCyclic1DDist(glbIdxType);
+  const locDist: [targetLocDom] unmanaged LocCyclic1DDist(glbIdxType);
   //
   // WORKAROUND: Initialize in the constructor instead
   //
@@ -102,7 +102,7 @@ class Cyclic1DDist {
   proc helpConstruct() {
     for locid in targetLocDom do
       on targetLocs(locid) do
-        locDist(locid) = new LocCyclic1DDist(glbIdxType, locid, this);
+        locDist(locid) = new unmanaged LocCyclic1DDist(glbIdxType, locid, _to_unmanaged(this));
   }
 
   proc deinit() {
@@ -134,7 +134,7 @@ class Cyclic1DDist {
   proc newDomain(inds, type idxType = glbIdxType) {
     // Note that I'm fixing the global and local index types to be the
     // same, but making this a generic function would fix this
-    return new Cyclic1DDom(idxType, this, inds);
+    return new unmanaged Cyclic1DDom(idxType, _to_unmanaged(this), inds);
   }
 
   //
@@ -194,7 +194,7 @@ class LocCyclic1DDist {
   //
   proc init(type glbIdxType, 
             _locid: int, // the locale index from the target domain
-            dist: Cyclic1DDist(glbIdxType) // reference to glob dist
+            dist: unmanaged Cyclic1DDist(glbIdxType) // reference to glob dist
                      ) {
     this.glbIdxType = glbIdxType;
 
@@ -228,7 +228,7 @@ class Cyclic1DDom {
   //
   // a pointer to the parent distribution
   //
-  const dist: Cyclic1DDist(glbIdxType);
+  const dist: unmanaged Cyclic1DDist(glbIdxType);
 
   //
   // a domain describing the complete domain
@@ -246,7 +246,7 @@ class Cyclic1DDom {
   // Otherwise, would have to move the allocation into a function
   // just to get it at the statement level.
   //
-  var locDoms: [dist.targetLocDom] LocCyclic1DDom(glbIdxType);
+  var locDoms: [dist.targetLocDom] unmanaged LocCyclic1DDom(glbIdxType);
 
   proc init(type idxType, myDist, myDom) {
     glbIdxType = idxType;
@@ -256,7 +256,7 @@ class Cyclic1DDom {
     this.complete();
     for locid in dist.targetLocDom do
       on dist.targetLocs(locid) do {
-        locDoms(locid) = new LocCyclic1DDom(glbIdxType, this, 
+        locDoms(locid) = new unmanaged LocCyclic1DDom(glbIdxType, _to_unmanaged(this), 
                                            dist.getChunk(whole, locid));
       }
     if debugCyclic1D then
@@ -363,7 +363,7 @@ class Cyclic1DDom {
   // how to allocate a new array over this domain
   //
   proc newArray(type elemType) {
-    return new Cyclic1DArr(glbIdxType, elemType, this);
+    return new unmanaged Cyclic1DArr(glbIdxType, elemType, _to_unmanaged(this));
   }
 
   //
@@ -395,7 +395,7 @@ class LocCyclic1DDom {
   //
   // a reference to the parent global domain class
   //
-  const wholeDom: Cyclic1DDom(glbIdxType);
+  const wholeDom: unmanaged Cyclic1DDom(glbIdxType);
 
   //
   // a local domain describing the indices owned by this locale
@@ -471,7 +471,7 @@ class Cyclic1DArr {
   //
   // the global domain descriptor for this array
   //
-  var dom: Cyclic1DDom(glbIdxType);
+  var dom: unmanaged Cyclic1DDom(glbIdxType);
 
   //
   // an array of local array classes
@@ -482,7 +482,7 @@ class Cyclic1DArr {
   // Otherwise, would have to move the allocation into a function
   // just to get it at the statement level.
   //
-  var locArr: [dom.dist.targetLocDom] LocCyclic1DArr(glbIdxType, elemType);
+  var locArr: [dom.dist.targetLocDom] unmanaged LocCyclic1DArr(glbIdxType, elemType);
 
   proc init(type idxType, type eltType, myDom) {
     glbIdxType = idxType;
@@ -491,7 +491,7 @@ class Cyclic1DArr {
     this.complete();
     for locid in dom.dist.targetLocDom do
       on dom.dist.targetLocs(locid) do
-        locArr(locid) = new LocCyclic1DArr(glbIdxType, elemType, dom.locDoms(locid));
+        locArr(locid) = new unmanaged LocCyclic1DArr(glbIdxType, elemType, dom.locDoms(locid));
   }
 
   proc deinit() {
@@ -591,7 +591,7 @@ class LocCyclic1DArr {
   //
   // a reference to the local domain class for this array and locale
   //
-  const locDom: LocCyclic1DDom(glbIdxType);
+  const locDom: unmanaged LocCyclic1DDom(glbIdxType);
 
   //
   // the block of local array data

--- a/test/distributions/diten/Dimensional.chpl
+++ b/test/distributions/diten/Dimensional.chpl
@@ -28,7 +28,7 @@ class Cyclic: DimensionDistributor {
 class Dimensional {
   param nDims: int;
   type idxType = int;
-  var dimensionDistributors: nDims*DimensionDistributor;
+  var dimensionDistributors: nDims*unmanaged DimensionDistributor;
   var localeDomain: domain(nDims);
   var localeArray: [localeDomain] locale;
 
@@ -52,7 +52,7 @@ class Dimensional {
   }
 
   proc newDomain(inds:domain(nDims,idxType)) {
-    return new DimensionalDomain(nDims, idxType, inds, this);
+    return new unmanaged DimensionalDomain(nDims, idxType, inds, _to_unmanaged(this));
   }
 
   // map an index into the localeArray to a tuple of ranges with
@@ -74,14 +74,14 @@ class DimensionalDomain {
   param nDims: int;
   type idxType;
   var whole: domain(nDims, idxType);
-  var dist:Dimensional(nDims, idxType);
-  var locDoms: [dist.localeDomain] LocDimensionalDomain(nDims, idxType);
+  var dist:unmanaged Dimensional(nDims, idxType);
+  var locDoms: [dist.localeDomain] unmanaged LocDimensionalDomain(nDims, idxType);
 
   proc postinit() {
     for loc in dist.localeDomain {
       on dist.localeArray(loc) {
         var locDist = dist.getLocRanges(loc);
-        locDoms(loc) = new LocDimensionalDomain(nDims, idxType, this, whole((...locDist)));
+        locDoms(loc) = new unmanaged LocDimensionalDomain(nDims, idxType, _to_unmanaged(this), whole((...locDist)));
       }
     }
   }
@@ -115,14 +115,14 @@ class DimensionalDomain {
 
 
   proc newArray(type eltType) {
-    return new DimensionalArray(nDims, idxType, eltType, this);
+    return new unmanaged DimensionalArray(nDims, idxType, eltType, _to_unmanaged(this));
   }
 }
 
 class LocDimensionalDomain {
   param nDims: int;
   type idxType;
-  var whole: DimensionalDomain(nDims, idxType);
+  var whole: unmanaged DimensionalDomain(nDims, idxType);
   var myElems: domain(nDims, idxType, true);
 }
 
@@ -130,13 +130,13 @@ class DimensionalArray {
   param nDims: int;
   type idxType;
   type eltType;
-  var dom: DimensionalDomain(nDims, idxType);
-  var locArrs: [dom.dist.localeDomain] LocDimensionalArray(nDims, idxType, eltType);
+  var dom: unmanaged DimensionalDomain(nDims, idxType);
+  var locArrs: [dom.dist.localeDomain] unmanaged LocDimensionalArray(nDims, idxType, eltType);
 
   proc postinit() {
     for loc in dom.dist.localeDomain {
       on loc {
-        locArrs(loc) = new LocDimensionalArray(nDims, idxType, eltType, this, dom.locDoms(loc));
+        locArrs(loc) = new unmanaged LocDimensionalArray(nDims, idxType, eltType, _to_unmanaged(this), dom.locDoms(loc));
       }
     }
   }
@@ -171,8 +171,8 @@ class LocDimensionalArray {
   param nDims: int;
   type idxType;
   type eltType;
-  var whole: DimensionalArray(nDims, idxType, eltType);
-  var locBlk: LocDimensionalDomain(nDims, idxType);
+  var whole: unmanaged DimensionalArray(nDims, idxType, eltType);
+  var locBlk: unmanaged LocDimensionalDomain(nDims, idxType);
   var locArr: [locBlk.myElems] eltType;
 }
 
@@ -187,8 +187,8 @@ proc main {
   for (i,j) in localeDom do
     locales(i,j) = Locales((i*nLocCols + j)%numLocales);
 
-  var dims: nDims*DimensionDistributor = (new Cyclic(1), new Cyclic(2));
-  var dist = new Dimensional(2, int, dims, localeDom, locales);
+  var dims: nDims*unmanaged DimensionDistributor = (new unmanaged Cyclic(1), new unmanaged Cyclic(2));
+  var dist = new unmanaged Dimensional(2, int, dims, localeDom, locales);
   var dom = dist.newDomain({0..3,0..5});
 
   var arr = dom.newArray(real);

--- a/test/distributions/diten/blockCyclicDist.chpl
+++ b/test/distributions/diten/blockCyclicDist.chpl
@@ -42,7 +42,7 @@ class BlockCyclicDist {
   }
 
   proc buildDomain(d: domain(nDims)) {
-    return new BlockCyclicDom(nDims, idxType, d, this);
+    return new unmanaged BlockCyclicDom(nDims, idxType, d, _to_unmanaged(this));
   }
 
 }
@@ -51,8 +51,8 @@ class BlockCyclicDom {
   param nDims: int = 2;
   type idxType;
   const whole: domain(nDims, idxType);
-  const dist: BlockCyclicDist(idxType);
-  const locDoms: [dist.localeDomain] LocBlockCyclicDom(nDims, idxType);
+  const dist: unmanaged BlockCyclicDist(idxType);
+  const locDoms: [dist.localeDomain] unmanaged LocBlockCyclicDom(nDims, idxType);
   proc initialize() {
     var blksInDim: nDims*idxType;
     for i in 1..nDims {
@@ -78,7 +78,7 @@ class BlockCyclicDom {
         for i in 1..nDims {
           locRanges(i) = 1..locSize(i);
         }
-        locDoms(pos) = new LocBlockCyclicDom(nDims, idxType, this, locRanges);
+        locDoms(pos) = new unmanaged LocBlockCyclicDom(nDims, idxType, _to_unmanaged(this), locRanges);
       }
       //writeln(pos, locSize);
     }
@@ -91,7 +91,7 @@ class BlockCyclicDom {
   }
 
   proc buildArray(type eltType) {
-    return new BlockCyclicArr(nDims, idxType, eltType, this);
+    return new unmanaged BlockCyclicArr(nDims, idxType, eltType, _to_unmanaged(this));
   }
 
 }
@@ -100,7 +100,7 @@ class BlockCyclicDom {
 class LocBlockCyclicDom {
   param nDims: int;
   type idxType;
-  const whole: BlockCyclicDom(nDims, idxType);
+  const whole: unmanaged BlockCyclicDom(nDims, idxType);
   const locRanges: nDims*range(idxType, BoundedRangeType.bounded);
   const locDom: domain(nDims);
   proc initialize() {
@@ -113,12 +113,12 @@ class BlockCyclicArr {
   param nDims: int;
   type idxType;
   type eltType;
-  const dom: BlockCyclicDom(nDims, idxType);
-  const locArrs: [dom.dist.localeDomain] LocBlockCyclicArr(nDims, idxType, eltType);
+  const dom: unmanaged BlockCyclicDom(nDims, idxType);
+  const locArrs: [dom.dist.localeDomain] unmanaged LocBlockCyclicArr(nDims, idxType, eltType);
   proc initialize() {
     for ind in dom.dist.localeDomain {
       on dom.dist.locales(ind) {
-        locArrs(ind) = new LocBlockCyclicArr(nDims, idxType, eltType, this, dom.locDoms(ind));
+        locArrs(ind) = new unmanaged LocBlockCyclicArr(nDims, idxType, eltType, _to_unmanaged(this), dom.locDoms(ind));
       }
     }
   }
@@ -137,8 +137,8 @@ class LocBlockCyclicArr {
   param nDims: int;
   type idxType;
   type eltType;
-  const whole: BlockCyclicArr(nDims, idxType, eltType);
-  const locDom: LocBlockCyclicDom(nDims, idxType);
+  const whole: unmanaged BlockCyclicArr(nDims, idxType, eltType);
+  const locDom: unmanaged LocBlockCyclicDom(nDims, idxType);
   const arr: [locDom.locDom] eltType;
 }
 
@@ -152,7 +152,7 @@ proc main {
 
   [(i,j) in locDom] locs(i,j) = Locales((i*n + j) % numLocales);
 
-  var dist = new BlockCyclicDist(idxType=int, nDims=2,
+  var dist = new unmanaged BlockCyclicDist(idxType=int, nDims=2,
                                    blockSize=(2,2), startLoc=(0,0),
                                    localeDomain=locDom, locales=locs);
   var dom = dist.buildDomain(undistributedDom);

--- a/test/distributions/diten/testCyclic.chpl
+++ b/test/distributions/diten/testCyclic.chpl
@@ -9,7 +9,7 @@ writeln("myLocales = ", myLocales);
 // TODO: That int(64) is really unfortunate.  We really need param
 // domains and ranges and the obvious conversions between them.
 // 
-const ProblemDist = new Cyclic1DDist(targetLocales=myLocales);
+const ProblemDist = new unmanaged Cyclic1DDist(targetLocales=myLocales);
 const ProblemDom = ProblemDist.newDomain({-5..5:int(64)});
 
 var A = ProblemDom.newArray(real);

--- a/test/distributions/jglewis/cyclicOnEvenNumLocales.chpl
+++ b/test/distributions/jglewis/cyclicOnEvenNumLocales.chpl
@@ -14,7 +14,7 @@ module cholesky_test {
 
   proc main {
 
-    var Rand = new RandomStream ( real, seed = 314159) ;
+    var Rand = new owned RandomStream ( real, seed = 314159) ;
 
     const MatIdx = { index_base .. #n, index_base .. #n };
 

--- a/test/distributions/privatization/runtime/PrivatizationWrappers.chpl
+++ b/test/distributions/privatization/runtime/PrivatizationWrappers.chpl
@@ -9,8 +9,8 @@ proc insertPrivatized(o: object, pid: int) {
   __primitive("chpl_newPrivatizedClass", o, pid);
 }
 
-proc getPrivatized(pid:int): C {
-  return __primitive("chpl_getPrivatizedClass", nil:C, pid);
+proc getPrivatized(pid:int): unmanaged C {
+  return __primitive("chpl_getPrivatizedClass", nil:unmanaged C, pid);
 }
 
 proc clearPrivatized(pid:int) {

--- a/test/distributions/privatization/runtime/addAndGetAndClearPrivatizedInParallel.chpl
+++ b/test/distributions/privatization/runtime/addAndGetAndClearPrivatizedInParallel.chpl
@@ -5,7 +5,7 @@ var classSizes = [0, 10, 100, 1000, 10000, 100000];
 
 // add some initial values
 forall i in classSizes[1]..classSizes[3]-1 {
-  var newValue = new C(i);
+  var newValue = new unmanaged C(i);
   insertPrivatized(newValue, i);
 }
 
@@ -16,7 +16,7 @@ for classNum in 3..classSizes.size-1 {
 
     {
       for i in classSizes[classNum]..classSizes[classNum+1]-1 {
-        var newValue = new C(i);
+        var newValue = new unmanaged C(i);
         insertPrivatized(newValue, i);
       }
     }

--- a/test/distributions/privatization/runtime/addAndGetPrivatizedInParallel.chpl
+++ b/test/distributions/privatization/runtime/addAndGetPrivatizedInParallel.chpl
@@ -4,7 +4,7 @@ var classSizes = [0, 10, 100, 1000, 10000, 100000];
 
 // add some initial values
 forall i in classSizes[1]..classSizes[2]-1 {
-  var newValue = new C(i);
+  var newValue = new unmanaged C(i);
   insertPrivatized(newValue, i);
 }
 
@@ -15,7 +15,7 @@ for classNum in 2..classSizes.size-1 {
 
     {
       for i in classSizes[classNum]..classSizes[classNum+1]-1 {
-        var newValue = new C(i);
+        var newValue = new unmanaged C(i);
         insertPrivatized(newValue, i);
       }
     }

--- a/test/distributions/privatization/runtime/addPrivatizedInOrder.chpl
+++ b/test/distributions/privatization/runtime/addPrivatizedInOrder.chpl
@@ -3,7 +3,7 @@ use PrivatizationWrappers;
 config const numIters = 10000;
 
 for i in 0..#numIters {
-  var newValue = new C(i);
+  var newValue = new unmanaged C(i);
   insertPrivatized(newValue, i);
 }
 

--- a/test/distributions/privatization/runtime/addPrivatizedOutOfOrder.chpl
+++ b/test/distributions/privatization/runtime/addPrivatizedOutOfOrder.chpl
@@ -3,7 +3,7 @@ use PrivatizationWrappers;
 var addOrder = [5000, 7500, 2500, 10000, 0];
 
 for i in addOrder {
-  var newValue = new C(i);
+  var newValue = new unmanaged C(i);
   insertPrivatized(newValue, i);
 }
 

--- a/test/distributions/privatization/runtime/addRemovePrivatizedOutOfOrder.chpl
+++ b/test/distributions/privatization/runtime/addRemovePrivatizedOutOfOrder.chpl
@@ -4,7 +4,7 @@ var addOrder = [5000, 7500, 2500, 10000, 0];
 var removeOrder = [5000, -1, 2500, 10000, 0];
 
 for (i,j) in zip(addOrder, removeOrder) {
-  var newValue = new C(i);
+  var newValue = new unmanaged C(i);
   insertPrivatized(newValue, i);
   if j >= 0 {
     var c = getPrivatized(j);

--- a/test/distributions/robust/arithmetic/kernels/stream.chpl
+++ b/test/distributions/robust/arithmetic/kernels/stream.chpl
@@ -105,7 +105,7 @@ proc printConfiguration() {
 // optionally print them to the console
 //
 proc initVectors(B, C) {
-  var randlist = new RandomStream(real, seed);
+  var randlist = new owned RandomStream(real, seed);
 
   randlist.fillRandom(B);
   randlist.fillRandom(C);
@@ -114,8 +114,6 @@ proc initVectors(B, C) {
     writeln("B is: ", B, "\n");
     writeln("C is: ", C, "\n");
   }
-
-  delete randlist;
 }
 
 //

--- a/test/distributions/robust/arithmetic/modules/test_module_Search.chpl
+++ b/test/distributions/robust/arithmetic/modules/test_module_Search.chpl
@@ -5,7 +5,7 @@ use Random;
 use Sort;
 use Search;
 
-var rng = new RandomStream(real, 314159265);
+var rng = new owned RandomStream(real, 314159265);
 
 var found: bool;
 var foundIdx: int;
@@ -88,5 +88,3 @@ checkSearch(found, foundIdx, rc4DR1D, "linearSearch");
 reset(rc4DR1D);
 (found, foundIdx) = binarySearch(rc4DR1D, elem);
 checkSearch(found, foundIdx, rc4DR1D, "binarySearch");
-
-delete rng;

--- a/test/distributions/robust/arithmetic/modules/test_module_Sort.chpl
+++ b/test/distributions/robust/arithmetic/modules/test_module_Sort.chpl
@@ -4,7 +4,7 @@ use driver_real_arrays;
 use Random;
 use Sort;
 
-var rng = new RandomStream(real, 314159265);
+var rng = new owned RandomStream(real, 314159265);
 
 enum SortType { BUBBLE=0, INSERTION, MERGE, SELECTION, QUICK, HEAP };
 
@@ -183,5 +183,3 @@ if !isSorted(rc4DR1D) then writeln('quickSort failed');
 rng.fillRandom(rc4DR1D);
 heapSort(rc4DR1D);
 if !isSorted(rc4DR1D) then writeln('heapSort failed');
-
-delete rng;

--- a/test/distributions/vass/changeBoundingBox.chpl
+++ b/test/distributions/vass/changeBoundingBox.chpl
@@ -9,7 +9,7 @@ use BlockDist;
 const dummyBB: domain(1) = {1..1}; // or whatever bounding box type you want eventually
 
 // Create a distribution without knowing its bounding box dimensions.
-const dist = new Block(dummyBB);
+const dist = new unmanaged Block(dummyBB);
 
 // Any computations here, should not involve 'dist'. //
 
@@ -46,7 +46,7 @@ and destroys the original. We have a .future on this.
 For now, do this instead:
 */
 
-const distTemp = new Block(dummyBB);
+const distTemp = new unmanaged Block(dummyBB);
 const DM = new dmap(distTemp);
 
 DM.changeBoundingBox(1..4);

--- a/test/domains/bradc/domainInClass.chpl
+++ b/test/domains/bradc/domainInClass.chpl
@@ -14,6 +14,5 @@ class C {
   }
 }
 
-var myC = new C();
+var myC = new owned C();
 myC.foo();
-delete myC;

--- a/test/domains/deitz/test_generic_class_of_sparse_domain.chpl
+++ b/test/domains/deitz/test_generic_class_of_sparse_domain.chpl
@@ -3,7 +3,7 @@ writeln("D = ", D);
 
 class CD { const D; }
 
-var cd = new CD(D);
+var cd = new unmanaged CD(D);
 writeln("CD = ", cd);
 delete cd;
 
@@ -14,6 +14,6 @@ writeln("SD = ", SD);
 
 class CS { const SD; }
 
-var cs = new CS(SD);
+var cs = new unmanaged CS(SD);
 writeln("CSD = ", cs);
 delete cs;

--- a/test/domains/vass/assoc-idxtype-error-2.chpl
+++ b/test/domains/vass/assoc-idxtype-error-2.chpl
@@ -11,5 +11,5 @@ proc C.init(d, a) where d: domain(?) {
   this.a = a;
 }
 
-var c1 = new C(d1,a1);
+var c1 = new shared C(d1,a1);
 writeln(c1);

--- a/test/errhandling/errorMessages/throwNew.chpl
+++ b/test/errhandling/errorMessages/throwNew.chpl
@@ -4,7 +4,6 @@ class C {
   }
 }
 
-var c = new C();
+var c = new borrowed C();
 
 c.f();
-

--- a/test/errhandling/errorMessages/throwNew.compopts
+++ b/test/errhandling/errorMessages/throwNew.compopts
@@ -1,0 +1,1 @@
+--no-warn-unstable

--- a/test/errhandling/ferguson/e-inherit-throws-nothrows.chpl
+++ b/test/errhandling/ferguson/e-inherit-throws-nothrows.chpl
@@ -6,16 +6,12 @@ class D : C {
   proc foo() { writeln("D.foo()"); }
 }
 
-var c = new C();
-var d = new D();
-var dc:C = new D();
+var c = new shared C();
+var d = new shared D();
+var dc:shared C = new shared D();
 
 try { c.foo(); } catch { writeln("c.foo threw"); }
 try { d.foo(); } catch { writeln("d.foo threw"); }
 try {dc.foo(); } catch { writeln("dc.foo threw"); }
-
-delete c;
-delete d;
-delete dc;
 
 writeln("Fini");

--- a/test/errhandling/ferguson/e-inherit.chpl
+++ b/test/errhandling/ferguson/e-inherit.chpl
@@ -19,16 +19,12 @@ class D : C {
   }
 }
 
-var c = new C();
-var d = new D();
-var dc:C = new D();
+var c = new owned C();
+var d = new owned D();
+var dc:owned C = new owned D();
 
 try { c.foo(); } catch { writeln("c.foo threw"); }
 try { d.foo(); } catch { writeln("d.foo threw"); }
 try {dc.foo(); } catch { writeln("dc.foo threw"); }
-
-delete c;
-delete d;
-delete dc;
 
 writeln("Fini");


### PR DESCRIPTION
Running testing with --warn-unstable revealed some warnings.
This PR fixes about 80 more tests to not warn.

For #9829.

Trivial test changes only - not reviewed.

- [x] full local testing
