### PR TITLE
Subdir-testing fix for cygwin

### DIFF
--- a/test/mason/subdir-commands/PREDIFF
+++ b/test/mason/subdir-commands/PREDIFF
@@ -3,6 +3,6 @@
 outfile=$2
 temp=$outfile.temp
 
-cat $outfile | sed "s@${PWD}@\$PWD@" | sed 's/Initializing mason-registry for mason-registry/Updating mason-registry for mason-registry/' > $temp
+cat $outfile | sed "s@${PWD}@\$PWD@" | sed 's/Initializing mason-registry for registry/Updating mason-registry for registry/' > $temp
 
 mv $temp $outfile

--- a/test/mason/subdir-commands/PREEXEC
+++ b/test/mason/subdir-commands/PREEXEC
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+cd $PWD/src

--- a/test/mason/subdir-commands/mason-run.good
+++ b/test/mason/subdir-commands/mason-run.good
@@ -1,4 +1,4 @@
-Updating mason-registry for mason-registry
+Updating mason-registry for registry
 Compiling FizzBuzz
 Build Successful
 


### PR DESCRIPTION
This should be the last merge to fix the mason sub-directory command errors seen on cygwin.