### PR TITLE
Update more tests and TaskErrors iterator

### DIFF
--- a/modules/internal/ChapelError.chpl
+++ b/modules/internal/ChapelError.chpl
@@ -225,7 +225,7 @@ module ChapelError {
     iter these() {
       var e = _head;
       while e != nil {
-        yield e;
+        yield _to_unmanaged(e);
         e = e._next;
       }
     }
@@ -299,7 +299,7 @@ module ChapelError {
      */
     iter filter(type t) where _to_borrowed(t):borrowed Error {
       for e in these() {
-        var tmp = e:_to_borrowed(t);
+        var tmp = _to_unmanaged(e):_to_unmanaged(t);
         if tmp then
           yield tmp;
       }

--- a/test/errhandling/nspark/generic-record-throws.chpl
+++ b/test/errhandling/nspark/generic-record-throws.chpl
@@ -3,7 +3,7 @@ record Wrapper {
 
   type retType;
   var val: retType;
-  var err: Error = nil;
+  var err: unmanaged Error = nil;
 
   proc get(): retType throws {
     if err then throw err;

--- a/test/errhandling/nspark/method-returns-or-throws.chpl
+++ b/test/errhandling/nspark/method-returns-or-throws.chpl
@@ -2,7 +2,7 @@ use ExampleErrors;
 record Wrapper {
 
   var val: int;
-  var err: Error = nil;
+  var err: unmanaged Error = nil;
 
   proc get(): int throws {
     if err then throw err;
@@ -10,7 +10,7 @@ record Wrapper {
   }
 
   proc oops() {
-    err = new StringError("called oops()");
+    err = new unmanaged StringError("called oops()");
   }
 }
 

--- a/test/errhandling/nspark/method-throws.chpl
+++ b/test/errhandling/nspark/method-throws.chpl
@@ -2,7 +2,7 @@ use ExampleErrors;
 record Wrapper {
 
   var val: int;
-  var err: Error = nil;
+  var err: unmanaged Error = nil;
 
   proc action() throws {
     if err then throw err;
@@ -10,7 +10,7 @@ record Wrapper {
   }
 
   proc oops() {
-    err = new StringError("called oops()");
+    err = new unmanaged StringError("called oops()");
   }
 }
 

--- a/test/errhandling/nspark/record-deinit-throws.chpl
+++ b/test/errhandling/nspark/record-deinit-throws.chpl
@@ -2,7 +2,7 @@ use ExampleErrors;
 record Wrapper {
 
   var val: int;
-  var err: Error;
+  var err: unmanaged Error;
 
   proc init(v: int) {
     val = v;
@@ -14,7 +14,7 @@ record Wrapper {
   }
 
   proc oops() {
-    err = new StringError("called oops()");
+    err = new unmanaged StringError("called oops()");
   }
 }
 

--- a/test/errhandling/parallel/convenience.chpl
+++ b/test/errhandling/parallel/convenience.chpl
@@ -24,15 +24,15 @@ proc test() {
     }
     writeln("after coforall block");
   } catch errors: TaskErrors {
-    var hasMyError = errors.contains(MyError);
+    var hasMyError = errors.contains(borrowed MyError);
     writeln("contains MyError? ", hasMyError);
     writeln("iterating MyError:");
-    for error in errors.filter(MyError) {
+    for error in errors.filter(borrowed MyError) {
       writeln(error.x);
     }
     writeln("iterating everything else:");
     for error in errors {
-      var e = error:MyError;
+      var e = error:borrowed MyError;
       if e == nil then
         writeln(error);
     }

--- a/test/errhandling/parallel/nested-coforall-throws.chpl
+++ b/test/errhandling/parallel/nested-coforall-throws.chpl
@@ -2,10 +2,10 @@ use ExampleErrors;
 
 config const option = 2;
 
-proc printErrors(errors: TaskErrors, depth:int)
+proc printErrors(errors: borrowed TaskErrors, depth:int)
 {
   for e in errors { 
-    var g = e:TaskErrors;
+    var g = e:borrowed TaskErrors;
     if g {
       writeln(" "*depth, "TaskErrors");
       printErrors(g, depth + 1);

--- a/test/execflags/sungeun/about.skipif
+++ b/test/execflags/sungeun/about.skipif
@@ -6,3 +6,5 @@ COMPOPTS <= --verify
 COMPOPTS <= --llvm
 COMPOPTS <= --incremental
 COMPOPTS <= --denormalize
+COMPOPTS <= --warn-unstable
+COMPOPTS <= --lifetime-checking

--- a/test/execflags/vass/print-callstack-on-error-2.chpl
+++ b/test/execflags/vass/print-callstack-on-error-2.chpl
@@ -7,5 +7,5 @@ class myiter1 {
   }
 }
 
-var mi1 = new myiter1();
+var mi1 = new borrowed myiter1();
 for i in mi1 do writeln(i);

--- a/test/execflags/vass/print-callstack-on-warning-2.chpl
+++ b/test/execflags/vass/print-callstack-on-warning-2.chpl
@@ -1,6 +1,6 @@
 // generate compiler warnings when some calls are created by the compiler
 
-var mi1 = new myiter1();
+var mi1 = new unmanaged myiter1();
 
 for i in mi1 do writeln(i);
 
@@ -22,7 +22,7 @@ proc test1() {
 
 /////////////////////////////////
 
-var mi2 = new myiter2();
+var mi2 = new unmanaged myiter2();
 
 for i in mi2 do writeln(i);
 

--- a/test/exercises/MonteCarloPi/dataParallel.chpl
+++ b/test/exercises/MonteCarloPi/dataParallel.chpl
@@ -7,7 +7,7 @@ writeln("Number of points      = ", n);
 writeln("Random number seed    = ", seed);
 writeln("dataParTasksPerLocale = ", dataParTasksPerLocale);
 
-var rs = new NPBRandomStream(real, seed, parSafe=false);
+var rs = new owned NPBRandomStream(real, seed, parSafe=false);
 
 //
 // Create a domain over the number of random points to generate.
@@ -25,5 +25,3 @@ var count = + reduce [(x,y) in zip(rs.iterate(D), rs.iterate(D))]
                        (x**2 + y**2) <= 1.0;
 
 writef("Approximation of pi   = %{#.#######}\n", count * 4.0 / n);
-
-delete rs;

--- a/test/exercises/MonteCarloPi/deitz/MonteCarloPi/dataParallelMonteCarloPi.chpl
+++ b/test/exercises/MonteCarloPi/deitz/MonteCarloPi/dataParallelMonteCarloPi.chpl
@@ -27,7 +27,7 @@ writeln("dataParTasksPerLocale = ", dataParTasksPerLocale);
 // accesses to this object, set parSafe to false to avoid locking
 // overhead.
 //
-var rs = new NPBRandomStream(real, seed, parSafe=false);
+var rs = new owned NPBRandomStream(real, seed, parSafe=false);
 
 //
 // Create a domain over the number of random points to generate.
@@ -43,11 +43,6 @@ var D = {1..n};
 // to iterate starts at the point after the first iterator finishes).
 //
 var count = + reduce [(x,y) in zip(rs.iterate(D),rs.iterate(D))] x**2+y**2 <= 1.0;
-
-//
-// Delete the Random Stream object.
-//
-delete rs;
 
 //
 // Output the approximation of PI.

--- a/test/exercises/MonteCarloPi/deitz/MonteCarloPi/multiLocaleDataParallelMonteCarloPi.chpl
+++ b/test/exercises/MonteCarloPi/deitz/MonteCarloPi/multiLocaleDataParallelMonteCarloPi.chpl
@@ -29,7 +29,7 @@ writeln("dataParTasksPerLocale = ", dataParTasksPerLocale);
 // accesses to this object, set parSafe to false to avoid locking
 // overhead.
 //
-var rs = new NPBRandomStream(real, seed, parSafe=false);
+var rs = new owned NPBRandomStream(real, seed, parSafe=false);
 
 //
 // Create a domain over the number of random points to generate.
@@ -46,11 +46,6 @@ var D = {1..n} dmapped Block({1..n});
 // to iterate starts at the point after the first iterator finishes).
 //
 var count = + reduce [(x,y) in zip(rs.iterate(D),rs.iterate(D))] x**2+y**2 <= 1.0;
-
-//
-// Delete the Random Stream object.
-//
-delete rs;
 
 //
 // Output the approximation of PI.

--- a/test/exercises/MonteCarloPi/deitz/MonteCarloPi/serialMonteCarloPi.chpl
+++ b/test/exercises/MonteCarloPi/deitz/MonteCarloPi/serialMonteCarloPi.chpl
@@ -26,7 +26,7 @@ writeln("Random number seed  = ", seed);
 // accesses to this object, set parSafe to false to avoid locking
 // overhead.
 //
-var rs = new NPBRandomStream(real, seed, parSafe=false);
+var rs = new owned NPBRandomStream(real, seed, parSafe=false);
 
 //
 // Run the Monte Carlo simulation.
@@ -34,11 +34,6 @@ var rs = new NPBRandomStream(real, seed, parSafe=false);
 var count = 0;
 for i in 1..n do
   count += rs.getNext()**2 + rs.getNext()**2 <= 1.0;
-
-//
-// Delete the Random Stream object.
-//
-delete rs;
 
 //
 // Output the approximation of PI.

--- a/test/exercises/MonteCarloPi/deitz/MonteCarloPi/taskParallelMonteCarloPi.chpl
+++ b/test/exercises/MonteCarloPi/deitz/MonteCarloPi/taskParallelMonteCarloPi.chpl
@@ -34,11 +34,10 @@ writeln("Number of tasks     = ", tasks);
 //
 var counts: [1..tasks] int;
 coforall task in 1..tasks {
-  var rs = new NPBRandomStream(real, seed + task*2, parSafe=false);
+  var rs = new owned NPBRandomStream(real, seed + task*2, parSafe=false);
   var count = 0;
   for i in (task-1)*n/tasks+1..task*n/tasks do
     count += rs.getNext()**2 + rs.getNext()**2 <= 1.0;
-  delete rs;
   counts[task] = count;
 }
 

--- a/test/exercises/MonteCarloPi/multiLocaleDataParallel.chpl
+++ b/test/exercises/MonteCarloPi/multiLocaleDataParallel.chpl
@@ -8,7 +8,7 @@ writeln("Number of points      = ", n);
 writeln("Random number seed    = ", seed);
 writeln("dataParTasksPerLocale = ", dataParTasksPerLocale);
 
-var rs = new NPBRandomStream(real, seed, parSafe=false);
+var rs = new owned NPBRandomStream(real, seed, parSafe=false);
 
 //
 // Distribute the domain representing the random points in a 
@@ -23,6 +23,3 @@ var count = + reduce [(x,y) in zip(rs.iterate(D), rs.iterate(D))]
                        (x**2 + y**2) <= 1.0;
 
 writef("Approximation of pi   = %{#.#######}\n", count * 4.0 / n);
-
-delete rs;
-

--- a/test/exercises/MonteCarloPi/multiLocaleTaskParallel.chpl
+++ b/test/exercises/MonteCarloPi/multiLocaleTaskParallel.chpl
@@ -50,7 +50,7 @@ coforall loc in Locales {
     // delete the RandomStream object.
     //
     coforall tid in 0..#tasksPerLocale {
-      var rs = new NPBRandomStream(real, seed, parSafe=false);
+      var rs = new owned NPBRandomStream(real, seed, parSafe=false);
       const locNPerTask = locN/tasksPerLocale,
             extras = locN%tasksPerLocale;
       rs.skipToNth(2*(locFirstPt + 
@@ -62,8 +62,6 @@ coforall loc in Locales {
         count += (rs.getNext()**2 + rs.getNext()**2) <= 1.0;
 
       locCounts[tid] = count;
-
-      delete rs;
     }
 
     //

--- a/test/exercises/MonteCarloPi/serial.chpl
+++ b/test/exercises/MonteCarloPi/serial.chpl
@@ -29,7 +29,7 @@ writeln("Random number seed  = ", seed);
 // accesses to this object by distinct tasks, parSafe can be set to
 // false to avoid thread safety overheads.
 // 
-var rs = new NPBRandomStream(real, seed, parSafe=false);
+var rs = new owned NPBRandomStream(real, seed, parSafe=false);
 
 //
 // Run the Monte Carlo simulation.  'count' is the number of random
@@ -43,8 +43,3 @@ for i in 1..n do
 // Output the approximation of pi.
 //
 writef("Approximation of pi = %{#.#######}\n", count * 4.0 / n);
-
-//
-// Delete the Random Stream object.
-//
-delete rs;

--- a/test/exercises/MonteCarloPi/serialVariant.chpl
+++ b/test/exercises/MonteCarloPi/serialVariant.chpl
@@ -14,7 +14,7 @@ const pi = 3.14159265358979323846;
 writef("Epsilon             = %{#.#################}\n", epsilon);
 writeln("Random number seed  = ", seed);
 
-var rs = new NPBRandomStream(real, seed, parSafe=false);
+var rs = new owned NPBRandomStream(real, seed, parSafe=false);
 
 //
 // keep track of the number of points we generate before converging
@@ -27,5 +27,3 @@ do {
 
 writef("Approximation of pi = %{#.###############}\n", count * 4.0 / n);
 writeln("Number of points    = ", count);
-
-delete rs;

--- a/test/exercises/MonteCarloPi/taskParallel.chpl
+++ b/test/exercises/MonteCarloPi/taskParallel.chpl
@@ -20,7 +20,7 @@ writeln("Number of tasks     = ", tasks);
 //
 var counts: [0..#tasks] int;
 coforall tid in 0..#tasks {
-  var rs = new NPBRandomStream(real, seed, parSafe=false);
+  var rs = new owned NPBRandomStream(real, seed, parSafe=false);
   const nPerTask = n/tasks,
         extras = n%tasks;
   rs.skipToNth(2*(tid*nPerTask + (if tid < extras then tid else extras)) + 1);
@@ -30,8 +30,6 @@ coforall tid in 0..#tasks {
     count += (rs.getNext()**2 + rs.getNext()**2) <= 1.0;
 
   counts[tid] = count;
-
-  delete rs;
 }
 
 //

--- a/test/exercises/boundedBuffer-old/boundedBuffer.chpl
+++ b/test/exercises/boundedBuffer-old/boundedBuffer.chpl
@@ -47,7 +47,7 @@ class BoundedBuffer {
   }
 }
 
-var buffer: BoundedBuffer = new BoundedBuffer();
+var buffer: unmanaged BoundedBuffer = new unmanaged BoundedBuffer();
 
 // Given a value, do some work on it to create the next value. In this
 // case, the work is sleeping for a second and leaving the value unchanged.

--- a/test/exercises/boundedBuffer/boundedBuffer.chpl
+++ b/test/exercises/boundedBuffer/boundedBuffer.chpl
@@ -52,7 +52,7 @@ if (numProducers > 1 || numConsumers > 1) then
 //
 proc main() {
   // a shared bounded buffer with the requested capacity
-  var buffer = new BoundedBuffer(capacity=bufferSize);
+  var buffer = new borrowed BoundedBuffer(capacity=bufferSize);
 
   // per-producer/consumer counts of the number of items they processed
   var prodCounts: [1..numProducers] int,
@@ -95,8 +95,6 @@ proc main() {
                   consTot, numItems);
   else
     stderr.writef("Producers/consumers processed %i items total.\n", numItems);
-
-  delete buffer;
 }
 
 
@@ -104,7 +102,7 @@ proc main() {
 // produce 1/numProducers of the requested 'numItems' items using an
 // aligned strided range.  Return the number of items we produced.
 //
-proc producer(b: BoundedBuffer, pid: int) {
+proc producer(b: borrowed BoundedBuffer, pid: int) {
   var myItems = 0..#numItems by numProducers align pid-1;
 
   for i in myItems {
@@ -119,7 +117,7 @@ proc producer(b: BoundedBuffer, pid: int) {
 // consume items greedily until a sentinel value is found.  Return
 // the number of items we successfully consumed.
 //
-proc consumer(b: BoundedBuffer, cid: int) {
+proc consumer(b: borrowed BoundedBuffer, cid: int) {
   var count = 0;
   do {
     const (data, more) = b.consume();
@@ -215,7 +213,7 @@ class BoundedBuffer {
       head = 0,                            // the head's cursor position
       tail = 0;                            // the tail's cursor position
 
-  var rng = new RandomStream(real);
+  var rng = new owned RandomStream(real);
 
   //
   // Place an item at the head position of the buffer, assuming
@@ -260,12 +258,5 @@ class BoundedBuffer {
     pos = (pos + 1) % capacity;
 
     return prevPos;
-  }
-
-  //
-  // Clean up after ourselves
-  //
-  proc deinit() {
-    delete rng;
   }
 }

--- a/test/exercises/boundedBuffer/solutions/boundedBuffer-sync.chpl
+++ b/test/exercises/boundedBuffer/solutions/boundedBuffer-sync.chpl
@@ -81,7 +81,7 @@ proc main() {
 // produce 1/numProducers of the requested 'numItems' items using an
 // aligned strided range.  Return the number of items we produced.
 //
-proc producer(b: BoundedBuffer, pid: int) {
+proc producer(b: borrowed BoundedBuffer, pid: int) {
   var myItems = 0..#numItems by numProducers align pid-1;
 
   for i in myItems {
@@ -96,7 +96,7 @@ proc producer(b: BoundedBuffer, pid: int) {
 // consume items greedily until a sentinel value is found.  Return
 // the number of items we successfully consumed.
 //
-proc consumer(b: BoundedBuffer, cid: int) {
+proc consumer(b: borrowed BoundedBuffer, cid: int) {
   var count = 0;
   do {
     const (data, more) = b.consume();

--- a/test/exercises/c-ray/c-ray.chpl
+++ b/test/exercises/c-ray/c-ray.chpl
@@ -108,7 +108,7 @@ record camera {
 //
 // variables used to store the scene
 //
-var objects: [1..0] sphere,  // the scene's spheres; start with an empty array
+var objects: [1..0] unmanaged sphere,  // the scene's spheres; start with an empty array
     lights: [1..0] vec3,     // the scene's lights;  "
     cam: camera;             // camera (there will be only one)
 
@@ -232,7 +232,7 @@ proc trace(ray, depth=0): vec3 {
     return (0.0, 0.0, 0.0);
 
   // find the nearest intersection...
-  var nearestObj: sphere,
+  var nearestObj: unmanaged sphere,
       nearestSp: spoint;
 
   for obj in objects {

--- a/test/exercises/c-ray/forStudents/c-ray.chpl
+++ b/test/exercises/c-ray/forStudents/c-ray.chpl
@@ -116,7 +116,7 @@ record camera {
 //
 // variables used to store the scene
 //
-var objects: [1..0] sphere,  // the scene's spheres; start with an empty array
+var objects: [1..0] unmanaged sphere,  // the scene's spheres; start with an empty array
     lights: [1..0] vec3,     // the scene's lights;  "
     cam: camera;             // camera (there will be only one)
 
@@ -273,7 +273,7 @@ proc trace(ray, depth=0): vec3 {
     return (0.0, 0.0, 0.0);
 
   // find the nearest intersection...
-  var nearestObj: sphere,
+  var nearestObj: unmanaged sphere,
       nearestSp: spoint;
 
   for obj in objects {
@@ -452,13 +452,13 @@ proc loadScene() {
   // be problematic in any way.
   //
   if scene == "built-in" {
-    objects.push_back(new sphere((-1.5, -0.3, -1), 0.7,
+    objects.push_back(new unmanaged sphere((-1.5, -0.3, -1), 0.7,
                                  new material((1.0, 0.2, 0.05), 50.0, 0.3)));
-    objects.push_back(new sphere((1.5, -0.4, 0), 0.6,
+    objects.push_back(new unmanaged sphere((1.5, -0.4, 0), 0.6,
                                  new material((0.1, 0.85, 1.0), 50.0, 0.4)));
-    objects.push_back(new sphere((0, -1000, 2), 999,
+    objects.push_back(new unmanaged sphere((0, -1000, 2), 999,
                                  new material((0.1, 0.2, 0.6), 80.0, 0.8)));
-    objects.push_back(new sphere((0, 0, 2), 1,
+    objects.push_back(new unmanaged sphere((0, 0, 2), 1,
                                  new material((1.0, 0.5, 0.1), 60.0, 0.7)));
     lights.push_back((-50, 100, -50));
     lights.push_back((40, 40, 150));
@@ -525,7 +525,7 @@ proc loadScene() {
           refl = columns[10]: real;
 
     // this must be a sphere, so store it
-    objects.push_back(new sphere(pos, rad, new material(col, spow, refl)));
+    objects.push_back(new unmanaged sphere(pos, rad, new material(col, spow, refl)));
 
     // helper routine for printing errors in the input file
     proc inputError(msg) {
@@ -558,9 +558,9 @@ proc initRands() {
   } else {
     use Random;
 
-    var rng = new RandomStream(seed=(if seed then seed
-                                             else SeedGenerator.currentTime),
-                               eltType=real);
+    var rng = new owned RandomStream(seed=(if seed then seed
+                                           else SeedGenerator.currentTime),
+                                     eltType=real);
     for u in urand do
       u(X) = rng.getNext() - 0.5;
     for u in urand do

--- a/test/expressions/AtomicObject/voidPtrTest-unmanaged.chpl
+++ b/test/expressions/AtomicObject/voidPtrTest-unmanaged.chpl
@@ -1,14 +1,14 @@
 class Obj { var x : int; var y : int; var z : int;}
 
 proc fn(f : c_void_ptr) {
-	writeln(f : Obj);
+	writeln(f : unmanaged Obj);
 }
 
 
 var obj = new unmanaged Obj(1,2,3);
 fn(obj : c_void_ptr);
 
-var obj2 : Obj = new unmanaged Obj(4,5,6);
+var obj2 : unmanaged Obj = new unmanaged Obj(4,5,6);
 fn(obj2 : c_void_ptr);
 
 delete obj;

--- a/test/expressions/AtomicObject/voidPtrTest.chpl
+++ b/test/expressions/AtomicObject/voidPtrTest.chpl
@@ -1,12 +1,12 @@
 class Obj { var x : int; var y : int; var z : int;}
 
 proc fn(f : c_void_ptr) {
-	writeln(f : Obj);
+	writeln(f : borrowed Obj);
 }
 
 
 var obj = new borrowed Obj(1,2,3);
 fn(obj : c_void_ptr);
 
-var obj2 : Obj = new borrowed Obj(4,5,6);
+var obj2 : borrowed Obj = new borrowed Obj(4,5,6);
 fn(obj2 : c_void_ptr);

--- a/test/expressions/bradc/condExprInClassInit.chpl
+++ b/test/expressions/bradc/condExprInClassInit.chpl
@@ -5,6 +5,6 @@ class C {
   }
 }
 
-var myC = new C();
+var myC = new unmanaged C();
 //myC.foo();
 delete myC;

--- a/test/expressions/ferguson/dynamic-class-name.chpl
+++ b/test/expressions/ferguson/dynamic-class-name.chpl
@@ -14,9 +14,7 @@ class Child : Parent {
   var y:int;
 }
 
-var x:Parent = new Parent(1);
-var y:Parent = new Child(1,2);
+var x:owned Parent = new owned Parent(1);
+var y:owned Parent = new owned Child(1,2);
 writeln(getNameFromClass(x), " ", x);
 writeln(getNameFromClass(y), " ", y);
-
-delete y, x;

--- a/test/expressions/ferguson/make-wide.chpl
+++ b/test/expressions/ferguson/make-wide.chpl
@@ -10,12 +10,12 @@ proc test() {
     c = new unmanaged C(1);
   }
 
-  var cc:C = c;
+  var cc:unmanaged C = c;
 
   var loc = __primitive("_wide_get_locale", cc);
   var adr = __primitive("_wide_get_addr", cc);
 
-  var b = __primitive("_wide_make", C, loc, adr);
+  var b = __primitive("_wide_make", unmanaged C, loc, adr);
 
   assert( b == c );
 
@@ -23,26 +23,26 @@ proc test() {
 }
 
 proc test2() {
-  var c:C;
+  var own:owned C;
+  var c:borrowed C;
   
   on Locales[numLocales-1] {
-    c = new C(1);
+    own = new owned C(1);
+    c = own:borrowed C;
   }
 
-  var cc:C = c;
+  var cc:borrowed C = c;
 
   var loc = __primitive("_wide_get_locale", cc);
   var adr = __primitive("_wide_get_addr", cc);
 
-  var b = __primitive("_wide_make", C, loc, adr);
+  var b = __primitive("_wide_make", borrowed C, loc, adr);
   var loc2 = __primitive("_wide_get_locale", b);
   var adr2 = __primitive("_wide_get_addr", b);
 
   assert( b == c );
   assert( loc == loc2 );
   assert( adr == adr2 );
-
-  delete c;
 }
 
 test();

--- a/test/expressions/lydia/noinit/recordHasClassField.chpl
+++ b/test/expressions/lydia/noinit/recordHasClassField.chpl
@@ -3,7 +3,7 @@ class aClass {
 }
 
 record foo {
-  var t: aClass;
+  var t: unmanaged aClass;
 }
 
 var bar: foo = noinit;

--- a/test/expressions/lydia/noinit/tupleWithClass.chpl
+++ b/test/expressions/lydia/noinit/tupleWithClass.chpl
@@ -2,25 +2,20 @@ class foo {
   var bar: int;
 }
 
-inline proc _defaultOf(type t) where t == (int, foo) {
+inline proc _defaultOf(type t) where t == (int, borrowed foo) {
   writeln("I default initialized!");
-  var innerRec: foo;
+  var innerRec: borrowed foo;
   return (0, innerRec);
 }
 
-var tup: (int, foo) = noinit; // Should not print message
+var tup: (int, borrowed foo) = noinit; // Should not print message
 
-tup(2) = new foo(2);
+tup(2) = new borrowed foo(2);
 tup(1) = 5;
 
 writeln(tup);
 
-delete tup(2);
+var otherTup: (int, borrowed foo);     // Should print message
 
-var otherTup: (int, foo);     // Should print message
-
-otherTup(2) = new foo(3);
+otherTup(2) = new borrowed foo(3);
 writeln(otherTup);
-
-delete otherTup(2);
-

--- a/test/expressions/lydia/noinit/usedWithClass.chpl
+++ b/test/expressions/lydia/noinit/usedWithClass.chpl
@@ -4,16 +4,16 @@ class Foo {
 
 }
 
-inline proc _defaultOf(type t) where t == Foo {
+inline proc _defaultOf(type t) where t == unmanaged Foo {
   writeln("I default initialized!");
   return nil:t;
 }
 
 
 
-var foo:Foo = noinit; // Should not print out message
+var foo:unmanaged Foo = noinit; // Should not print out message
 
-foo = new Foo(4, true);
+foo = new unmanaged Foo(4, true);
 
 writeln(foo);
 
@@ -21,9 +21,9 @@ delete foo;
 
 
 
-var bam:Foo;          // Should print out message
+var bam:unmanaged Foo;          // Should print out message
 
-bam = new Foo(3, false);
+bam = new unmanaged Foo(3, false);
 
 writeln(bam);
 

--- a/test/flowanalysis/recursion/rec_obj-1.chpl
+++ b/test/flowanalysis/recursion/rec_obj-1.chpl
@@ -3,18 +3,18 @@ class Cons {
   var cdr; 
 };
 
-proc print(c : Cons) {
+proc print(c : borrowed Cons) {
   if (c != nil) {
      writeln(c.car);
      print(c.cdr);
   }
 }
 
-var a = new Cons(1, nil);
-var aa = new Cons(2, a);
+var a = new borrowed Cons(1, nil);
+var aa = new borrowed Cons(2, a);
 
-var b = new Cons(1.0, nil);
-var bb = new Cons(2.0, b);
+var b = new borrowed Cons(1.0, nil);
+var bb = new borrowed Cons(2.0, b);
 
 
 print(aa);

--- a/test/flowanalysis/recursion/rec_obj-2.chpl
+++ b/test/flowanalysis/recursion/rec_obj-2.chpl
@@ -3,15 +3,15 @@ class Cons {
   var cdr; 
 };
 
-proc print(c : Cons) {
+proc print(c : borrowed Cons) {
   if (c != nil) {
      writeln(c.car);
      print(c.cdr);
   }
 }
 
-var a = new Cons(1, new Cons(2, nil));
-var b = new Cons(1.0, new Cons(2.0, nil));
+var a = new borrowed Cons(1, new borrowed Cons(2, nil));
+var b = new borrowed Cons(1.0, new borrowed Cons(2.0, nil));
 
 print(a);
 print(b);

--- a/test/flowanalysis/recursion/rec_obj-3.chpl
+++ b/test/flowanalysis/recursion/rec_obj-3.chpl
@@ -3,7 +3,7 @@ class Cons {
   var cdr; 
 };
 
-proc print(c : Cons) {
+proc print(c : borrowed Cons) {
   if (c != nil) {
      writeln(c.car);
      print(c.cdr);
@@ -17,7 +17,7 @@ proc reverse_internal(c, e) {
     return e;
 }
 
-proc reverse(c : Cons) { return reverse_internal(c, nil); }
+proc reverse(c : unmanaged Cons) { return reverse_internal(c, nil); }
 
 var a = new unmanaged Cons(1, new unmanaged Cons(2, new unmanaged Cons(3, nil)));
 var b = new unmanaged Cons(1.0, new unmanaged Cons(2.0, new unmanaged Cons(3.0, nil)));

--- a/test/functions/bradc/intents/intents-classes.chpl
+++ b/test/functions/bradc/intents/intents-classes.chpl
@@ -3,24 +3,31 @@ class pair {
   var b: real;
 }
 
-proc callin(in x: pair) {
-  writeln("in callin, x is: ", x.a, " ", x.b);
+proc callin_borrowed(in x: borrowed pair) {
+  writeln("in callin borrowed, x is: ", x.a, " ", x.b);
+  x.a += 1;
+  x.b += 1.1;
+  writeln("re-assigned to be: ", x.a, " ", x.b);
+}
+
+proc callin_unmanaged(in x: unmanaged pair) {
+  writeln("in callin unmanaged, x is: ", x.a, " ", x.b);
   x.a += 1;
   x.b += 1.1;
   writeln("re-assigned to be: ", x.a, " ", x.b);
 }
 
 
-proc callout(out x: pair) {
+proc callout(out x: unmanaged pair) {
   writeln("in callout, x ought to be nil");
-  x = new pair();
+  x = new unmanaged pair();
   x.a = 12;
   x.b = 4.5;
   writeln("re-assigned new instance to be: ", x.a, " ", x.b);
 }
 
 
-proc callinout(inout x: pair) {
+proc callinout(inout x: unmanaged pair) {
   writeln("in callinout, x is: ", x.a, " ", x.b);
   x.a += 1;
   x.b += 1.1;
@@ -28,8 +35,15 @@ proc callinout(inout x: pair) {
 }
 
 
-proc callblank(x: pair) {
-  writeln("in callblank, x is: ", x.a, " ", x.b);
+proc callblank_borrowed(x: borrowed pair) {
+  writeln("in callblank borrowed, x is: ", x.a, " ", x.b);
+  x.a += 1;
+  x.b += 1.1;
+  writeln("re-assigned to be: ", x.a, " ", x.b);
+}
+
+proc callblank_unmanaged(x: unmanaged pair) {
+  writeln("in callblank unmanaged, x is: ", x.a, " ", x.b);
   x.a += 1;
   x.b += 1.1;
   writeln("re-assigned to be: ", x.a, " ", x.b);
@@ -37,16 +51,21 @@ proc callblank(x: pair) {
 
 
 proc main() {
-  var a: pair = new pair();
+  var a: unmanaged pair = new unmanaged pair();
 
   a.a = 10;
   a.b = 2.3;
 
-  callin(a);
+  callin_borrowed(a);
+  writeln("back at callsite, a is: ", a.a, " ", a.b);
+  writeln();
+
+  callin_unmanaged(a);
   writeln("back at callsite, a is: ", a.a, " ", a.b);
   writeln();
 
   delete a;
+  a = nil;
 
   callout(a);
   writeln("back at callsite, a is: ", a.a, " ", a.b);
@@ -56,8 +75,13 @@ proc main() {
   writeln("back at callsite, a is: ", a.a, " ", a.b);
   writeln();
 
-  callblank(a);
+  callblank_borrowed(a);
   writeln("back at callsite, a is: ", a.a, " ", a.b);
+  writeln();
+
+  callblank_unmanaged(a);
+  writeln("back at callsite, a is: ", a.a, " ", a.b);
+
 
   delete a;
 }

--- a/test/functions/bradc/intents/intents-classes.good
+++ b/test/functions/bradc/intents/intents-classes.good
@@ -1,6 +1,10 @@
-in callin, x is: 10 2.3
+in callin borrowed, x is: 10 2.3
 re-assigned to be: 11 3.4
 back at callsite, a is: 11 3.4
+
+in callin unmanaged, x is: 11 3.4
+re-assigned to be: 12 4.5
+back at callsite, a is: 12 4.5
 
 in callout, x ought to be nil
 re-assigned new instance to be: 12 4.5
@@ -10,6 +14,10 @@ in callinout, x is: 12 4.5
 re-assigned to be: 13 5.6
 back at callsite, a is: 13 5.6
 
-in callblank, x is: 13 5.6
+in callblank borrowed, x is: 13 5.6
 re-assigned to be: 14 6.7
 back at callsite, a is: 14 6.7
+
+in callblank unmanaged, x is: 14 6.7
+re-assigned to be: 15 7.8
+back at callsite, a is: 15 7.8


### PR DESCRIPTION
Running testing with --warn-unstable revealed some warnings.
This PR fixes about 80 more tests to not warn.

One of the fixes is in the form of modification to ChapelError.chpl to make the TaskErrors iterator yield unmanaged errors. In the future, we probably will 
want error handling to use owned though (but this PR isn't trying to help with 
that).

For #9829.

 - [x] full local testing

Reviewed by @psahabu - thanks!