### PR TITLE
Parenthesize "(pre-release)" to match other version formatting changes

### DIFF
--- a/doc/rst/conf.py
+++ b/doc/rst/conf.py
@@ -61,12 +61,12 @@ master_doc = 'index'
 # 'version' adds a redundant version number onto the top of the sidebar
 # automatically (rtd-theme). We also don't use |version| anywhere in rst
 
-chplversion = '1.18 pre-release'    # TODO -- parse from `chpl --version`
+chplversion = '1.18 (pre-release)'    # TODO -- parse from `chpl --version`
 shortversion = chplversion.replace('-', '&#8209') # prevent line-break at hyphen
 html_context = {"chplversion":chplversion}
 
 # The full version, including alpha/beta/rc tags.
-release = '1.18.0 pre-release'
+release = '1.18.0 (pre-release)'
 
 # General information about the project.
 project = u'Chapel Documentation'


### PR DESCRIPTION
As a follow-up to PR #9965, this adds parenthesis to the "pre-release" label for 'master' documentation.