### PR TITLE
Eliminate unnecessary array creation for in-intents

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -1865,36 +1865,6 @@ void AggregateType::fieldToArg(FnSymbol*              fn,
         // Type inference is required if this is a param or variable field
         //
         } else if (defPoint->exprType == NULL && defPoint->init != NULL) {
-          VarSymbol* tmp      = newTemp();
-          BlockStmt* typeExpr = new BlockStmt(new DefExpr(tmp), BLOCK_TYPE);
-
-          // tmp->addFlag(FLAG_INSERT_AUTO_DESTROY);
-          // Lydia NOTE 06/16/17: The default constructor adds this flag
-          // to its equivalent temporary.  I have decided not to do so
-          // and am not seeing issues so far, but may have missed something,
-          // so I am leaving it here just in case.
-
-          tmp->addFlag(FLAG_MAYBE_TYPE);
-          tmp->addFlag(FLAG_MAYBE_PARAM);
-
-          typeExpr->insertAtTail(new CallExpr(PRIM_MOVE,
-                                              tmp,
-                                              defPoint->init->copy()));
-
-          // Lydia NOTE 06/16/17: I believe we don't need to make an
-          // initCopy call for the field's init (like the default
-          // constructor version attempts).
-          // I might have missed something, though, so if it turns out we
-          // do need that initCopy, use this instead of the above statement:
-          // typeExpr->insertAtTail(
-          //           new CallExpr(PRIM_MOVE,
-          //                        tmp,
-          //                        new CallExpr("chpl__initCopy",
-          //                                     defPoint->init->copy())));
-
-          typeExpr->insertAtTail(new CallExpr(PRIM_TYPEOF, tmp));
-
-          arg->typeExpr = typeExpr;
           if (arg->hasFlag(FLAG_TYPE_VARIABLE)) {
             arg->type = dtAny;
           }
@@ -1902,6 +1872,9 @@ void AggregateType::fieldToArg(FnSymbol*              fn,
           // set up the ArgSymbol appropriately for the type
           // and initialization from the field declaration.
           arg->defaultExpr = new BlockStmt(defPoint->init->copy());
+
+          // mimic normalize's hack_resolve_types
+          arg->typeExpr = arg->defaultExpr->copy();
 
 
         //

--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -690,7 +690,13 @@ static DefaultExprFnEntry buildDefaultedActualFn(FnSymbol*  fn,
   normalize(block);
   resolveBlockStmt(block);
 
-  block->insertAtTail(new CallExpr(PRIM_MOVE, rvv, temp));
+  if (temp->isRef() && formal->isRef() == false) {
+    CallExpr* copy = new CallExpr("chpl__initCopy", temp);
+    block->insertAtTail(new CallExpr(PRIM_MOVE, rvv, copy));
+    resolveCallAndCallee(copy);
+  } else {
+    block->insertAtTail(new CallExpr(PRIM_MOVE, rvv, temp));
+  }
   block->flattenAndRemove();
 
   // Now we know if 'temp' is a param or a type.

--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -111,6 +111,8 @@ static bool mustUseRuntimeTypeDefault(ArgSymbol* formal);
 
 static bool typeExprReturnsType(ArgSymbol* formal);
 
+static IntentTag getIntent(ArgSymbol* formal);
+
 typedef struct DefaultExprFnEntry_s {
   FnSymbol* defaultExprFn;
   std::vector<std::pair<ArgSymbol*,ArgSymbol*> > usedFormals;
@@ -647,7 +649,7 @@ static DefaultExprFnEntry buildDefaultedActualFn(FnSymbol*  fn,
   if (formal->type   != dtTypeDefaultToken &&
       formal->type   != dtMethodToken      &&
       formal->intent == INTENT_BLANK) {
-    formalIntent = blankIntentForType(formal->type);
+    formalIntent = getIntent(formal);
   }
 
   if ((formalIntent & INTENT_FLAG_REF) != 0)
@@ -1343,7 +1345,6 @@ static bool      needToAddCoercion(Type*      actualType,
                                    ArgSymbol* formal,
                                    FnSymbol*  fn);
 
-static IntentTag getIntent(ArgSymbol* formal);
 
 static void      addArgCoercion(FnSymbol*  fn,
                                 CallExpr*  call,

--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -690,7 +690,7 @@ static DefaultExprFnEntry buildDefaultedActualFn(FnSymbol*  fn,
   normalize(block);
   resolveBlockStmt(block);
 
-  if (temp->isRef() && formal->isRef() == false) {
+  if (temp->isRef() && (formalIntent & INTENT_FLAG_REF) == 0) {
     CallExpr* copy = new CallExpr("chpl__initCopy", temp);
     block->insertAtTail(new CallExpr(PRIM_MOVE, rvv, copy));
     resolveCallAndCallee(copy);

--- a/test/arrays/intents/in/ref-default-value.chpl
+++ b/test/arrays/intents/in/ref-default-value.chpl
@@ -1,0 +1,42 @@
+
+record R {
+  var x : int;
+  proc poke() {
+    this.x += 100;
+  }
+}
+
+var Global, Master : [1..4] R;
+ref RefGlobal = Global;
+
+proc helper() ref {
+  return Global;
+}
+
+proc testRefGlobal(in A = RefGlobal) {
+  A[1].poke();
+  writeln(Global);
+}
+proc testHelper(in A = helper()) {
+  A[1].poke();
+  writeln(Global);
+}
+
+writeln("----- testRefGlobal() -----");
+testRefGlobal();
+writeln();
+
+writeln("----- testRefGlobal(RefGlobal) -----");
+testRefGlobal(RefGlobal);
+writeln();
+
+writeln("----- testHelper() -----");
+testHelper();
+writeln();
+
+writeln("----- testHelper(helper()) -----");
+testHelper(helper());
+writeln();
+
+writeln("----- Final Global -----");
+writeln(Global);

--- a/test/arrays/intents/in/ref-default-value.good
+++ b/test/arrays/intents/in/ref-default-value.good
@@ -1,0 +1,14 @@
+----- testRefGlobal() -----
+(x = 0) (x = 0) (x = 0) (x = 0)
+
+----- testRefGlobal(RefGlobal) -----
+(x = 0) (x = 0) (x = 0) (x = 0)
+
+----- testHelper() -----
+(x = 0) (x = 0) (x = 0) (x = 0)
+
+----- testHelper(helper()) -----
+(x = 0) (x = 0) (x = 0) (x = 0)
+
+----- Final Global -----
+(x = 0) (x = 0) (x = 0) (x = 0)


### PR DESCRIPTION
Prior to this PR wrapper-creation during resolution would create an unnecessary instance of the formal's default value if that formal satisfied all of the following conditions:
- formal was for a default-initializer
- formal was for an array field
- array field did not have an explicit type

For example:
```chpl
record R {
  var A = [1, 2, 3];
}
var r = new R();
```

The cause of this extra array was the insertion of ``PRIM_TYPEOF`` at the end of the formal's typeExpr. Wrapper creation identified this typeof and assumed that the formal had a user-defined type associated with it. In order to preserve the runtime type, the compiler would create two instance of the default value, when only one was necessary. One of these arrays would then be leaked. See ``types/records/ferguson/array/array-in-record.chpl`` for an example.

The solution is to not insert PRIM_TYPEOF for the formal's typeExpr, and simply copy the formal's defaultExpr.

This change exposed an additional bug with wrapper creation in which a default value with a ``ref`` kind would not be copied when the call was invoked:

```chpl
var A : [1..10] int;
proc helper() ref {
  return A;
}

proc foo(in X = helper()) {
  X[1] = 100; // modifies A!
}
```

To resolve this bug, wrapper creation is updated to insert a copy of the default value if the result is a reference and the formal does not have any kind of ``ref`` intent. A new test is added to ensure we catch this kind of bug in the future.

Testing:
- [x] local + futures
- [x] gasnet
- [x] --force-initializers (no new failures)
- [x] memleaks
- [x] valgrind