### PR TITLE
Update LinearAlgebraJama and tests to use unmanaged

### DIFF
--- a/modules/packages/LinearAlgebraJama.chpl
+++ b/modules/packages/LinearAlgebraJama.chpl
@@ -1,15 +1,15 @@
 /*
  * Copyright 2004-2018 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,68 +24,68 @@ The Jama Chapel module is a port of the JAMA matrix library
 http://math.nist.gov/javanumerics/jama/
 
 JAMA is a basic linear algebra package for Java. This is a port of Jama to Chapel.
-Jama provides user-level classes for constructing and manipulating real, dense 
-matrices. Jama is meant to provide sufficient functionality for routine problems, 
-packaged in a way that is natural and understandable to non-experts. Jama is 
-intended to serve as the standard matrix class for Chapel. Jama is a straightforward 
-public-domain reference implementation has been developed by the MathWorks and 
-NIST as a strawman for such a class. MathWorks and NIST released this version in 
-order to obtain public comment. There was no guarantee that future versions of 
+Jama provides user-level classes for constructing and manipulating real, dense
+matrices. Jama is meant to provide sufficient functionality for routine problems,
+packaged in a way that is natural and understandable to non-experts. Jama is
+intended to serve as the standard matrix class for Chapel. Jama is a straightforward
+public-domain reference implementation has been developed by the MathWorks and
+NIST as a strawman for such a class. MathWorks and NIST released this version in
+order to obtain public comment. There was no guarantee that future versions of
 JAMA will be compatible with this one.
 
-A sibling matrix package, Jampack, has also been developed at NIST and the 
-University of Maryland. The two packages arose from the need to evaluate 
-alternate designs for the implementation of matrices in Java. JAMA is based 
-on a single matrix class within a strictly object-oriented framework. Jampack 
-uses a more open approach that lends itself to extension by the user. As it 
-turns out, for the casual user the packages differ principally in the syntax 
-of the matrix operations. We hope you will take the time to look at Jampack 
+A sibling matrix package, Jampack, has also been developed at NIST and the
+University of Maryland. The two packages arose from the need to evaluate
+alternate designs for the implementation of matrices in Java. JAMA is based
+on a single matrix class within a strictly object-oriented framework. Jampack
+uses a more open approach that lends itself to extension by the user. As it
+turns out, for the casual user the packages differ principally in the syntax
+of the matrix operations. We hope you will take the time to look at Jampack
 along with JAMA. There is much to be learned from both packages.
 
 Capabilities.
 
-JAMA is comprised of six Java classes: Matrix, CholeskyDecomposition, 
-LUDecomposition, QRDecomposition, SingularValueDecomposition and 
+JAMA is comprised of six Java classes: Matrix, CholeskyDecomposition,
+LUDecomposition, QRDecomposition, SingularValueDecomposition and
 EigenvalueDecomposition.
 
 Reference Implementation.
 
-The implementation of JAMA downloadable from this site is meant to be a 
-reference implementation only. As such, it is pedagogical in nature. The 
-algorithms employed are similar to those of the classic Wilkinson and Reinsch 
-Handbook, i.e. the same algorithms used in EISPACK, LINPACK and MATLAB. 
-Matrices are stored internally as native arrays (i.e., double[][]). The 
-coding style is straightforward and readable. While the reference 
-implementation itself should provide reasonable execution speed for small 
-to moderate size applications, we fully expect software vendors to 
+The implementation of JAMA downloadable from this site is meant to be a
+reference implementation only. As such, it is pedagogical in nature. The
+algorithms employed are similar to those of the classic Wilkinson and Reinsch
+Handbook, i.e. the same algorithms used in EISPACK, LINPACK and MATLAB.
+Matrices are stored internally as native arrays (i.e., double[][]). The
+coding style is straightforward and readable. While the reference
+implementation itself should provide reasonable execution speed for small
+to moderate size applications, we fully expect software vendors to
 provide versions which are optimized for particular environments. Not Covered.
 
-JAMA is by no means a complete linear algebra environment. For example, 
-there are no provisions for matrices with particular structure (e.g., 
-banded, sparse) or for more specialized decompositions (e.g. Schur, 
-generalized eigenvalue). Complex matrices are not included. It is not our 
-intention to ignore these important problems. We expect that some of these 
-(e.g. complex) will be addressed in future versions. It is our intent that 
+JAMA is by no means a complete linear algebra environment. For example,
+there are no provisions for matrices with particular structure (e.g.,
+banded, sparse) or for more specialized decompositions (e.g. Schur,
+generalized eigenvalue). Complex matrices are not included. It is not our
+intention to ignore these important problems. We expect that some of these
+(e.g. complex) will be addressed in future versions. It is our intent that
 the design of JAMA not preclude extension to some of these additional areas.
 
-Finally, JAMA is not a general-purpose array class. Instead, it focuses on 
-the principle mathematical functionality required to do numerical linear algebra. 
-As a result, there are no methods for array operations such as reshaping or 
-applying elementary functions (e.g. sine, exp, log) elementwise. Such operations, 
+Finally, JAMA is not a general-purpose array class. Instead, it focuses on
+the principle mathematical functionality required to do numerical linear algebra.
+As a result, there are no methods for array operations such as reshaping or
+applying elementary functions (e.g. sine, exp, log) elementwise. Such operations,
 while quite useful in many applications, are best collected into a separate array
 class.
 
-The Matrix class provides the fundamental operations of numerical linear algebra. 
-Various constructors create Matrices from two dimensional arrays of double precision 
-floating point numbers. Various gets and sets provide access to submatrices and 
-matrix elements. The basic arithmetic operations include matrix addition and 
-multiplication, matrix norms and selected element-by-element array operations. 
+The Matrix class provides the fundamental operations of numerical linear algebra.
+Various constructors create Matrices from two dimensional arrays of double precision
+floating point numbers. Various gets and sets provide access to submatrices and
+matrix elements. The basic arithmetic operations include matrix addition and
+multiplication, matrix norms and selected element-by-element array operations.
 A convenient matrix print method is also included.
 
-Five fundamental matrix decompositions, which consist of pairs or triples of 
-matrices, permutation vectors, and the like, produce results in five 
-decomposition classes. These decompositions are accessed by the Matrix class 
-to compute solutions of simultaneous linear equations, determinants, inverses 
+Five fundamental matrix decompositions, which consist of pairs or triples of
+matrices, permutation vectors, and the like, produce results in five
+decomposition classes. These decompositions are accessed by the Matrix class
+to compute solutions of simultaneous linear equations, determinants, inverses
 and other matrix functions. The five decompositions are
 
     Cholesky Decomposition of symmetric, positive definite matrices
@@ -94,20 +94,20 @@ and other matrix functions. The five decompositions are
     Eigenvalue Decomposition of both symmetric and nonsymmetric square matrices
     Singular Value Decomposition of rectangular matrices
 
-The current JAMA deals only with real matrices. We expect that future versions 
-will also address complex matrices. This has been deferred since crucial design 
-decisions cannot be made until certain issues regarding the implementation of 
+The current JAMA deals only with real matrices. We expect that future versions
+will also address complex matrices. This has been deferred since crucial design
+decisions cannot be made until certain issues regarding the implementation of
 complex in the Java language are resolved.
 
-The design of JAMA represents a compromise between the need for pure and elegant 
-object-oriented design and the need to enable high performance implementations. 
+The design of JAMA represents a compromise between the need for pure and elegant
+object-oriented design and the need to enable high performance implementations.
 
 Authors
 
 JAMA's initial design, as well as this reference implementation, was developed by
 Joe Hicklin
 Cleve Moler
-Peter Webb      ... from The MathWorks             
+Peter Webb      ... from The MathWorks
 
 Ronald F. Boisvert
 Bruce Miller
@@ -116,11 +116,11 @@ Karin Remington      ... from NIST
 
 Copyright Notice
 
-This software is a cooperative product of The MathWorks and the National Institute 
-of Standards and Technology (NIST) which has been released to the public domain. 
-Neither The MathWorks nor NIST assumes any responsibility whatsoever for its use 
-by other parties, and makes no guarantees, expressed or implied, about its quality, 
-reliability, or any other characteristic. 
+This software is a cooperative product of The MathWorks and the National Institute
+of Standards and Technology (NIST) which has been released to the public domain.
+Neither The MathWorks nor NIST assumes any responsibility whatsoever for its use
+by other parties, and makes no guarantees, expressed or implied, about its quality,
+reliability, or any other characteristic.
 
 */
 module LinearAlgebraJama {
@@ -138,11 +138,11 @@ proc hypot(a, b:real) {
    if (abs(a) > abs(b)) {
       r = b/a;
       r = abs(a)*((1.0+r*r)**0.5); //Math.sqrt(1+r*r);
-   } 
+   }
    else if (b != 0.0) {
       r = a/b;
       r = abs(b)*((1.0+r*r)**0.5); //sqrt(1+r*r);
-   } 
+   }
    else {
       r = 0.0;
    }
@@ -156,7 +156,7 @@ proc hypot(a, b:real) {
 
    For a symmetric, positive definite matrix A, the Cholesky decomposition
    is an lower triangular matrix L so that A = L*L'.
-   
+
    If the matrix is not symmetric or positive definite, the constructor
    returns a partial decomposition and sets an internal flag that may
    be queried by the isSPD() method.
@@ -182,7 +182,7 @@ class CholeskyDecomposition {
        Structure to access L and isspd flag.
        Arg a Square, symmetric matrix.
    */
-   proc init (Arg:Matrix) {
+   proc init (Arg: unmanaged Matrix) {
 
 
      // Initialize.
@@ -210,7 +210,7 @@ class CholeskyDecomposition {
             s = (A[j,k] - s)/L[k,k];
             Lrowj[k] = s;
             d = d + s*s;
-            isspd = isspd & (A[k,j] == A[j,k]); 
+            isspd = isspd & (A[k,j] == A[j,k]);
          }
          d = A[j,j] - d;
          isspd = isspd & (d > 0.0);
@@ -235,7 +235,7 @@ class CholeskyDecomposition {
    */
 
    proc getL () {
-      return new Matrix(L,n,n);
+      return new unmanaged Matrix(L,n,n);
    }
 
    /* Solve A*X = B
@@ -243,7 +243,7 @@ class CholeskyDecomposition {
    return     X so that L*L'*X = B
    */
 
-   proc solve (B:Matrix) {
+   proc solve (B: unmanaged Matrix) {
       if (B.getRowDimension() != n) {
          assert(B.getRowDimension() != n, "Matrix row dimensions must agree.");
       }
@@ -269,7 +269,7 @@ class CholeskyDecomposition {
                 X[k,j] /= L[k,k];
              }
            }
-     
+
            // Solve L'*X = Y;
            //for (int k = n-1; k >= 0; k--) {
            for k in 1..n-1 by -1 {
@@ -281,17 +281,17 @@ class CholeskyDecomposition {
                 X[k,j] /= L[k,k];
              }
            }
-      
-      return new Matrix(X,n,nx);
+
+      return new unmanaged Matrix(X,n,nx);
    }
 
 }
 
-/* Eigenvalues and eigenvectors of a real matrix. 
+/* Eigenvalues and eigenvectors of a real matrix.
 
     If A is symmetric, then A = V*D*V' where the eigenvalue matrix D is
     diagonal and the eigenvector matrix V is orthogonal.
-    I.e. A = V.times(D.times(V.transpose())) and 
+    I.e. A = V.times(D.times(V.transpose())) and
     V.times(V.transpose()) equals the identity matrix.
 
     If A is not symmetric, then the eigenvalue matrix D is block diagonal
@@ -331,7 +331,7 @@ class EigenvalueDecomposition {
    internal storage of nonsymmetric Hessenberg form.
    */
    var hDom = {1..1,1..1};
-   var H : [hDom] real; 
+   var H : [hDom] real;
 
    /* Working storage for nonsymmetric algorithm.
    working storage for nonsymmetric algorithm.
@@ -353,7 +353,7 @@ class EigenvalueDecomposition {
       }
 
       // Householder reduction to tridiagonal form.
-   
+
       for i in 2..n by -1 {
          // Scale to avoid under/overflow.
 
@@ -361,7 +361,7 @@ class EigenvalueDecomposition {
          var h = 0.0;
          const irng = {1..i};
 
-         for k in irng { 
+         for k in irng {
             scale = scale + abs(d[k]);
          }
 
@@ -373,13 +373,13 @@ class EigenvalueDecomposition {
                V[i,j] = 0.0;
                V[j,i] = 0.0;
             }
-         } 
+         }
          else {
-   
+
             // Generate Householder vector.
-   
+
             //for (int k = 0; k < i; k++) {
-            for k in irng { 
+            for k in irng {
                d[k] /= scale;
                h += d[k] * d[k];
             }
@@ -395,15 +395,15 @@ class EigenvalueDecomposition {
             for j in irng {
                e[j] = 0.0;
             }
-   
+
             // Apply similarity transformation to remaining columns.
-   
-            for j in irng { 
+
+            for j in irng {
                f = d[j];
                V[j,i] = f;
                g = e[j] + V[j,j] * f;
 
-               for k in j+1..i-1 { 
+               for k in j+1..i-1 {
                   g += V[k,j] * d[k];
                   e[k] += V[k,j] * f;
                }
@@ -422,7 +422,7 @@ class EigenvalueDecomposition {
                e[j] -= hh * d[j];
             }
 
-            for j in irng { 
+            for j in irng {
                f = d[j];
                g = e[j];
 
@@ -435,10 +435,10 @@ class EigenvalueDecomposition {
          }
          d[i] = h;
       }
-   
+
       // Accumulate transformations.
-   
-      for i in 1..n-1 { 
+
+      for i in 1..n-1 {
          const irng = {1..i};
          V[n-1,i] = V[i,i];
          V[i,i] = 1.0;
@@ -450,7 +450,7 @@ class EigenvalueDecomposition {
 
             for j in irng {
                var g = 0.0;
-               for k in irng { 
+               for k in irng {
                   g += V[k,i+1] * V[k,j];
                }
 
@@ -472,31 +472,31 @@ class EigenvalueDecomposition {
 
       V[n-1,n-1] = 1.0;
       e[1] = 0.0;
-   } 
+   }
 
    /* Symmetric tridiagonal QL algorithm. */
-   
+
    proc tql2 () {
 
    //  This is derived from the Algol procedures tql2, by
    //  Bowdler, Martin, Reinsch, and Wilkinson, Handbook for
    //  Auto. Comp., Vol.ii-Linear Algebra, and the corresponding
    //  Fortran subroutine in EISPACK.
-   
+
       //for (int i = 1; i < n; i++) {
       for i in 2..n {
          e[i-1] = e[i];
       }
       e[n-1] = 0.0;
-   
+
       var f = 0.0;
       var tst1 = 0.0;
       var eps = 2.0 ** -52.0;
 
-      for l in 1..n { 
+      for l in 1..n {
 
          // Find small subdiagonal element
-   
+
          tst1 = max(tst1,abs(d[l]) + abs(e[l]));
          var m = l;
          while (m < n) {
@@ -505,17 +505,17 @@ class EigenvalueDecomposition {
             }
             m+=1;
          }
-   
+
          // If m == l, d[l] is an eigenvalue,
          // otherwise, iterate.
-   
+
          if (m > l) {
             var itr = 0;
             do {
                itr = itr + 1;  // (Could check iteration count here.)
-   
+
                // Compute implicit shift
-   
+
                var g = d[l];
                var p = (d[l+1] - g) / (2.0 * e[l]);
                var r = hypot(p,1.0);
@@ -527,13 +527,13 @@ class EigenvalueDecomposition {
                var dl1 = d[l+1];
                var h = g - d[l];
 
-               for i in l+2..n { 
+               for i in l+2..n {
                   d[i] -= h;
                }
                f = f + h;
-   
+
                // Implicit QL transformation.
-   
+
                p = d[m];
                var c = 1.0;
                var c2 = c;
@@ -554,9 +554,9 @@ class EigenvalueDecomposition {
                   c = p / r;
                   p = c * d[i] - s * g;
                   d[i+1] = h + s * (c * g + s * d[i]);
-   
+
                   // Accumulate transformation.
-   
+
                   for k in 1..n {
                      h = V[k,i+1];
                      V[k,i+1] = s * V[k,i] + c * h;
@@ -566,17 +566,17 @@ class EigenvalueDecomposition {
                p = -s * s2 * c3 * el1 * e[l] / dl1;
                e[l] = s * p;
                d[l] = c * p;
-   
+
                // Check for convergence.
-   
+
             } while (abs(e[l]) > eps*tst1);
          }
          d[l] = d[l] + f;
          e[l] = 0.0;
       }
-     
+
       // Sort eigenvalues and corresponding vectors.
-   
+
       //for (int i = 0; i < n-1; i++) {
       for i in d.domain {
          var k = i;
@@ -604,31 +604,31 @@ class EigenvalueDecomposition {
    /* Nonsymmetric reduction to Hessenberg form. */
 
    proc orthes () {
-   
+
       //  This is derived from the Algol procedures orthes and ortran,
       //  by Martin and Wilkinson, Handbook for Auto. Comp.,
       //  Vol.ii-Linear Algebra, and the corresponding
       //  Fortran subroutines in EISPACK.
-   
+
       var low = 1;
       var high = n;
-   
+
       for m in low+1..high-1 {
-   
+
          // Scale column.
-   
+
          var scale = 0.0;
 
-         for i in m..high { 
+         for i in m..high {
             scale = scale + abs(H[i,m-1]);
          }
          if (scale != 0.0) {
-   
+
             // Compute Householder transformation.
-   
+
             var h = 0.0;
 
-            for i in m..high { 
+            for i in m..high {
                ort[i] = H[i,m-1]/scale;
                h += ort[i] * ort[i];
             }
@@ -639,11 +639,11 @@ class EigenvalueDecomposition {
             }
             h = h - ort[m] * g;
             ort[m] = ort[m] - g;
-   
+
             // Apply Householder similarity transformation
             // H = (I-u*u'/h)*H*(I-u*u')/h)
-   
-            for j in m..n { 
+
+            for j in m..n {
                var f = 0.0;
                for i in m..high {
                   f += ort[i]*H[i,j];
@@ -653,7 +653,7 @@ class EigenvalueDecomposition {
                   H[i,j] -= f*ort[i];
                }
            }
-   
+
            for i in 1..high {
                var f = 0.0;
                for j in m..high by -1 {
@@ -668,7 +668,7 @@ class EigenvalueDecomposition {
             H[m,m-1] = scale*g;
          }
       }
-   
+
       // Accumulate transformations (Algol's ortran).
 
       for (i,j) in V.domain {
@@ -718,24 +718,24 @@ class EigenvalueDecomposition {
    /* Nonsymmetric reduction from Hessenberg to real Schur form. */
 
    proc hqr2 () {
-   
+
       //  This is derived from the Algol procedure hqr2,
       //  by Martin and Wilkinson, Handbook for Auto. Comp.,
       //  Vol.ii-Linear Algebra, and the corresponding
       //  Fortran subroutine in EISPACK.
-   
+
       // Initialize
-   
+
       var nn :int = this.n;
       var n :int = nn-1; // suspicious of this subtraction
       var low = 1;
       var high = nn;
-      var eps = 2.0 ** -52.0; 
+      var eps = 2.0 ** -52.0;
       var exshift = 0.0;
       var p,q,r,s,z,t,w,x,y:real;
-   
+
       // Store roots isolated by balanc and compute matrix norm
-   
+
       var norm = 0.0;
       for i in 1..nn {
          if (i < low | i > high) {
@@ -746,14 +746,14 @@ class EigenvalueDecomposition {
             norm = norm + abs(H[i,j]);
          }
       }
-   
+
       // Outer loop over eigenvalue index
-   
+
       var itr = 0;
       while (n >= low) {
-   
+
          // Look for single small sub-diagonal element
-   
+
          var l = n;
          while (l > low) {
             s = abs(H[l-1,l-1]) + abs(H[l,l]);
@@ -765,30 +765,30 @@ class EigenvalueDecomposition {
             }
             l-=1;
          }
-       
+
          // Check for convergence
          // One root found
-   
+
          if (l == n) {
             H[n,n] = H[n,n] + exshift;
             d[n] = H[n,n];
          e[n] = 0.0;
          n-=1;
             itr = 0;
-   
+
          // Two roots found
-   
+
          } else if (l == n-1) {
             w = H[n,n-1] * H[n-1,n];
             p = (H[n-1,n-1] - H[n,n]) / 2.0;
             q = p * p + w;
-            z = abs(q) ** 0.5; 
+            z = abs(q) ** 0.5;
             H[n,n] = H[n,n] + exshift;
             H[n-1,n-1] = H[n-1,n-1] + exshift;
             x = H[n,n];
-   
+
             // Real pair
-   
+
             if (q >= 0) {
                if (p >= 0) {
                   z = p + z;
@@ -806,36 +806,36 @@ class EigenvalueDecomposition {
                s = abs(x) + abs(z);
                p = x / s;
                q = z / s;
-               r = (p * p+q * q) ** 0.5; 
+               r = (p * p+q * q) ** 0.5;
                p = p / r;
                q = q / r;
-   
+
                // Row modification
-   
+
                for j in n-1..nn {
                   z = H[n-1,j];
                   H[n-1,j] = q * z + p * H[n,j];
                   H[n,j] = q * H[n,j] - p * z;
                }
-   
+
                // Column modification
-   
+
                for i in 1..n {
                   z = H[i,n-1];
                   H[i,n-1] = q * z + p * H[i,n];
                   H[i,n] = q * H[i,n] - p * z;
                }
-   
+
                // Accumulate transformations
-   
+
                for i in low..high {
                   z = V[i,n-1];
                   V[i,n-1] = q * z + p * V[i,n];
                   V[i,n] = q * V[i,n] - p * z;
                }
-   
+
             // Complex pair
-   
+
             } else {
                d[n-1] = x + p;
                d[n] = x + p;
@@ -844,13 +844,13 @@ class EigenvalueDecomposition {
             }
             n = n - 2;
             itr = 0;
-   
+
          // No convergence yet
-   
+
          } else {
-   
+
             // Form shift
-   
+
             x = H[n,n];
             y = 0.0;
             w = 0.0;
@@ -858,9 +858,9 @@ class EigenvalueDecomposition {
                y = H[n-1,n-1];
                w = H[n,n-1] * H[n-1,n];
             }
-   
+
             // Wilkinson's original ad hoc shift
-   
+
             if (itr == 10) {
                exshift += x;
                for i in low..n {
@@ -878,7 +878,7 @@ class EigenvalueDecomposition {
                 s = (y - x) / 2.0;
                 s = s * s + w;
                 if (s > 0) {
-                    s = s ** 0.5; 
+                    s = s ** 0.5;
                     if (y < x) {
                        s = -s;
                     }
@@ -890,11 +890,11 @@ class EigenvalueDecomposition {
                     x = 0.964; y = 0.964; w = 0.964;
                 }
             }
-   
+
             itr = itr + 1;   // (Could check iteration count here.)
-   
+
             // Look for two consecutive small sub-diagonal elements
-   
+
             var m = n-2;
             while (m >= l) {
                z = H[m,m];
@@ -917,16 +917,16 @@ class EigenvalueDecomposition {
                }
                m-=1;
             }
-   
+
             for i in m+2..n {
                H[i,i-2] = 0.0;
                if (i > m+2) {
                   H[i,i-3] = 0.0;
                }
             }
-   
+
             // Double QR step involving rows l:n and columns m:n
-   
+
             for k in m..n-1 {
                var notlast = (k != n-1);
                if (k != m) {
@@ -958,9 +958,9 @@ class EigenvalueDecomposition {
                   z = r / s;
                   q = q / p;
                   r = r / p;
-   
+
                   // Row modification
-   
+
                   for j in k..nn {
                      p = H[k,j] + q * H[k+1,j];
                      if (notlast) {
@@ -970,9 +970,9 @@ class EigenvalueDecomposition {
                      H[k,j] = H[k,j] - p * x;
                      H[k+1,j] = H[k+1,j] - p * y;
                   }
-   
+
                   // Column modification
-   
+
                   for i in 1..min(n,k+3) {
                      p = x * H[i,k] + y * H[i,k+1];
                      if (notlast) {
@@ -982,9 +982,9 @@ class EigenvalueDecomposition {
                      H[i,k] = H[i,k] - p;
                      H[i,k+1] = H[i,k+1] - p * q;
                   }
-   
+
                   // Accumulate transformations
-   
+
                   for i in low..high {
                      p = x * V[i,k] + y * V[i,k+1];
                      if (notlast) {
@@ -998,19 +998,19 @@ class EigenvalueDecomposition {
             }  // k loop
          }  // check convergence
       }  // while (n >= low)
-      
+
       // Backsubstitute to find vectors of upper triangular form
 
       if (norm == 0.0) {
          return;
       }
-   
+
       for n in 1..nn-1 by -1 {
          p = d[n];
          q = e[n];
-   
+
          // Real vector
-   
+
          if (q == 0) {
             var l = n;
             H[n,n] = 1.0;
@@ -1031,9 +1031,9 @@ class EigenvalueDecomposition {
                      } else {
                         H[i,n] = -r / (eps * norm);
                      }
-   
+
                   // Solve real equations
-   
+
                   } else {
                      x = H[i,i+1];
                      y = H[i+1,i];
@@ -1046,9 +1046,9 @@ class EigenvalueDecomposition {
                         H[i+1,n] = (-s - y * t) / z;
                      }
                   }
-   
+
                   // Overflow control
-   
+
                   t = abs(H[i,n]);
                   if ((eps * t) * t > 1) {
                      for j in i..n {
@@ -1057,14 +1057,14 @@ class EigenvalueDecomposition {
                   }
                }
             }
-   
+
          // Complex vector
-   
+
          } else if (q < 0) {
             var l = n-1;
 
             // Last vector component imaginary so matrix is triangular
-   
+
             if (abs(H[n,n-1]) > abs(H[n-1,n])) {
                H[n-1,n-1] = q / H[n,n-1];
                H[n-1,n] = -(H[n,n] - p) / H[n,n-1];
@@ -1087,7 +1087,7 @@ class EigenvalueDecomposition {
                   sa = sa + H[i,j] * H[j,n];
                }
                w = H[i,i] - p;
-   
+
                if (e[i] < 0.0) {
                   z = w;
                   r = ra;
@@ -1099,9 +1099,9 @@ class EigenvalueDecomposition {
                      H[i,n-1] = cdivr;
                      H[i,n] = cdivi;
                   } else {
-   
+
                      // Solve complex equations
-   
+
                      x = H[i,i+1];
                      y = H[i+1,i];
                      vr = (d[i] - p) * (d[i] - p) + e[i] * e[i] - q * q;
@@ -1122,7 +1122,7 @@ class EigenvalueDecomposition {
                         H[i+1,n] = cdivi;
                      }
                   }
-   
+
                   // Overflow control
 
                   t = max(abs(H[i,n-1]),abs(H[i,n]));
@@ -1136,9 +1136,9 @@ class EigenvalueDecomposition {
             }
          }
       }
-   
+
       // Vectors of isolated roots
-   
+
       for i in 1..nn {
          if (i < low | i > high) {
             for j in i..nn {
@@ -1146,9 +1146,9 @@ class EigenvalueDecomposition {
             }
          }
       }
-   
+
       // Back transformation to get eigenvectors of original matrix
-   
+
       for j in low..nn-1 by -1 {
          for i in low..high {
             z = 0.0;
@@ -1166,7 +1166,7 @@ class EigenvalueDecomposition {
        Structure to access D and V.
    */
 
-   proc init (Arg:Matrix) {
+   proc init (Arg: unmanaged Matrix) {
       var A = Arg.getArray();
       n = Arg.getColumnDimension();
       issymmetric = true;
@@ -1189,24 +1189,24 @@ class EigenvalueDecomposition {
          for (i,j) in {1..n, 1..n} {
                V[i,j] = A[i,j];
          }
-   
+
          // Tridiagonalize.
          tred2();
-   
+
          // Diagonalize.
          tql2();
 
       } else {
          hDom = {1..n, 1..n};
          ortDom = {1..n};
-         
+
          for (j,i) in {1..n,1..n} {
                H[i,j] = A[i,j];
          }
-   
+
          // Reduce to Hessenberg form.
          orthes();
-   
+
          // Reduce Hessenberg to real Schur form.
          hqr2();
       }
@@ -1215,8 +1215,8 @@ class EigenvalueDecomposition {
    /* Return the eigenvector matrix
    */
 
-   proc getV () : Matrix {
-      return new Matrix(V,n,n);
+   proc getV () : unmanaged Matrix {
+      return new unmanaged Matrix(V,n,n);
    }
 
    /* Return the real parts of the eigenvalues
@@ -1238,8 +1238,8 @@ class EigenvalueDecomposition {
    /* Return the block diagonal eigenvalue matrix
    */
 
-   proc getD () : Matrix {
-      var X = new Matrix(n,n);
+   proc getD () : unmanaged Matrix {
+      var X = new unmanaged Matrix(n,n);
       var D = X.getArray();
       const nrng = {1..n};
       for i in nrng {
@@ -1258,7 +1258,7 @@ class EigenvalueDecomposition {
 
 }
 
-/* 
+/*
    LU Decomposition.
 
    For an m-by-n matrix A with m >= n, the LU decomposition is an m-by-n
@@ -1297,7 +1297,7 @@ class LUDecomposition {
    A Rectangular matrix
    */
 
-   proc init (A:Matrix) {
+   proc init (A: unmanaged Matrix) {
    // Use a "left-looking", dot-product, Crout/Doolittle algorithm.
 
       m = A.getRowDimension();
@@ -1330,21 +1330,21 @@ class LUDecomposition {
 
          // Apply previous transformations.
 
-         for i in mrng { 
+         for i in mrng {
             LUrowi = LU[i,..];
 
             // Most of the time is spent in the following dot product.
 
             var kmax = min(i,j);
             var s = 0.0;
-            for k in 1..kmax { 
+            for k in 1..kmax {
                s += LUrowi[k]*LUcolj[k];
             }
 
             LUcolj[i] -= s;
             LUrowi[j] = LUcolj[i];
          }
-   
+
          // Find pivot and exchange if necessary.
 
          var p = j;
@@ -1362,7 +1362,7 @@ class LUDecomposition {
          }
 
          // Compute multipliers.
-         
+
          if ( (j < m) & (LU[j,j] != 0.0)) {
             for i in j+1..m {
                LU[i,j] /= LU[j,j];
@@ -1387,7 +1387,7 @@ class LUDecomposition {
    */
 
    proc getL () {
-      var X = new Matrix(m,n);
+      var X = new unmanaged Matrix(m,n);
       var L = X.getArray();
       for (i,j) in {1..m,1..n} {
             if (i > j) {
@@ -1405,7 +1405,7 @@ class LUDecomposition {
    */
 
    proc getU () {
-      var X = new Matrix(n,n);
+      var X = new unmanaged Matrix(n,n);
       var U = X.getArray();
       for (i,j) in {1..n, 1..n} {
             if (i <= j) {
@@ -1454,7 +1454,7 @@ class LUDecomposition {
         X so that L*U*X = B(piv,:)
    */
 
-   proc solve (B:Matrix) {
+   proc solve (B: unmanaged Matrix) {
       if (B.getRowDimension() != m) {
          assert(B.getRowDimension() != m, "Matrix row dimensions must agree.");
       }
@@ -1465,7 +1465,7 @@ class LUDecomposition {
       // Copy right hand side with pivoting
       var nx = B.getColumnDimension();
       var Xmat = B.getMatrix(piv,1,nx);
-      var X = Xmat.A; 
+      var X = Xmat.A;
 
       // Solve L*Y = B(piv,:)
       for k in 1..n {
@@ -1495,7 +1495,7 @@ class LUDecomposition {
 */
 
 proc identity (m:int, n:int) {
-   var A = new Matrix(m,n);
+   var A = new unmanaged Matrix(m,n);
    var X = A.getArray();
    for (i,j) in {1..m, 1..n} {
       X[i,j] = if(i == j) then 1.0 else 0.0;
@@ -1509,7 +1509,7 @@ proc identity (m:int, n:int) {
    The Java Matrix Class provides the fundamental operations of numerical
    linear algebra.  Various constructors create Matrices from two dimensional
    arrays of double precision floating point numbers.  Various "gets" and
-   "sets" provide access to submatrices and matrix elements.  Several methods 
+   "sets" provide access to submatrices and matrix elements.  Several methods
    implement basic matrix arithmetic, including matrix addition and
    multiplication, matrix norms, and element-by-element array operations.
    Methods for reading and printing matrices are also included.  All the
@@ -1537,7 +1537,7 @@ author The MathWorks, Inc. and the National Institute of Standards and Technolog
 version 5 August 1998
 */
 
-class Matrix { 
+class Matrix {
 
    /* Row and column dimensions.
      row dimension.
@@ -1550,7 +1550,7 @@ class Matrix {
    var aDom = {1..1, 1..1};
    var A : [aDom] real;
 
-   /* Construct an m-by-n matrix of zeros. 
+   /* Construct an m-by-n matrix of zeros.
         m    Number of rows.
         n    Number of columns.
    */
@@ -1584,8 +1584,8 @@ class Matrix {
          n = 1;
       }
       else {
-        m = aDom.high(1); 
-        n = aDom.high(2); 
+        m = aDom.high(1);
+        n = aDom.high(2);
       }
 
       this.aDom = {1..m, 1..n};
@@ -1642,7 +1642,7 @@ class Matrix {
    proc constructWithCopy(A : [?aDom] real) where aDom.rank == 2 {
       var m = aDom.high(1);
       var n = aDom.high(2);
-      var X = new Matrix(m,n);
+      var X = new unmanaged Matrix(m,n);
       var C = X.getArray();
 
       for i in 1..m {
@@ -1657,7 +1657,7 @@ class Matrix {
    */
 
    proc copy () {
-      var X = new Matrix(m,n);
+      var X = new unmanaged Matrix(m,n);
       var C = X.getArray();
       for (i,j) in {1..m, 1..n} {
             C[i,j] = A[i,j];
@@ -1695,7 +1695,7 @@ class Matrix {
    */
 
    proc getColumnPackedCopy () {
-      var vals : [1..m*n] real; 
+      var vals : [1..m*n] real;
       for (i,j) in {1..m, 1..n} {
          vals[i+j*m] = A[i,j];
       }
@@ -1749,7 +1749,7 @@ class Matrix {
    */
 
    proc getMatrix (i0:int, i1:int, j0:int, j1:int) {
-      var X = new Matrix(i1-i0+1,j1-j0+1);
+      var X = new unmanaged Matrix(i1-i0+1,j1-j0+1);
       for (i,j) in {i0..i1, j0..j1} {
          X.A[(i-i0)+1,(j-j0)+1] = A[i,j];
       }
@@ -1763,7 +1763,7 @@ class Matrix {
    */
 
    proc getMatrix (r:[?rDom] int, c:[?cDom] int) {
-      var X = new Matrix(r.length,c.length);
+      var X = new unmanaged Matrix(r.length,c.length);
       var B = X.getArray();
          for (i,j) in {1..rDom.high, 1..cDom.high} {
                B[i,j] = A[r[i],c[j]];
@@ -1779,7 +1779,7 @@ class Matrix {
    */
 
    proc getMatrix (i0:int, i1:int, c:[?cDom] int) {
-      var X = new Matrix(i1-i0+1,c.length);
+      var X = new unmanaged Matrix(i1-i0+1,c.length);
       var B = X.getArray();
         for (i,j) in {i0..i1, 1..cDom.high} {
                B[i-i0,j] = A[i,c[j]];
@@ -1795,7 +1795,7 @@ class Matrix {
    */
 
    proc getMatrix (r:[?rDom] int, j0:int, j1:int) {
-      var X = new Matrix(rDom.high,j1-j0+1);
+      var X = new unmanaged Matrix(rDom.high,j1-j0+1);
       var B = X.getArray();
          for (i,j) in {1..rDom.high, j0..j1} {
                B[i,(j-j0)+1] = A[r[i],j];
@@ -1821,7 +1821,7 @@ class Matrix {
    X    A(i0:i1,j0:j1)
    */
 
-   proc setMatrix (i0, i1, j0, j1:int, X:Matrix) {
+   proc setMatrix (i0, i1, j0, j1:int, X: unmanaged Matrix) {
          for (i,j) in {i0..i1, j0..j1} {
                A[i,j] = X.get(i-i0,j-j0);
          }
@@ -1833,10 +1833,10 @@ class Matrix {
    X    A(r(:),c(:))
    */
 
-   proc setMatrix (r:[?rDom] int, c:[?cDom] int, X:Matrix) {
+   proc setMatrix (r:[?rDom] int, c:[?cDom] int, X: unmanaged Matrix) {
       for (i,j) in {1..rDom.high, 1..cDom.high} {
                A[r[i],c[j]] = X.get(i,j);
-      } 
+      }
    }
 
    /* Set a submatrix.
@@ -1846,7 +1846,7 @@ class Matrix {
    X    A(r(:),j0:j1)
    */
 
-   proc setMatrix (r:[?rDom] int, j0:int, j1:int, X:Matrix) {
+   proc setMatrix (r:[?rDom] int, j0:int, j1:int, X: unmanaged Matrix) {
          for (i,j) in {1..rDom.high, j0..j1} {
                A[r[i],j] = X.get(i,j-j0);
          }
@@ -1859,7 +1859,7 @@ class Matrix {
    X    A(i0:i1,c(:))
    */
 
-   proc setMatrix (i0, i1:int, c:[?cDom] int, X:Matrix) {
+   proc setMatrix (i0, i1:int, c:[?cDom] int, X: unmanaged Matrix) {
          for (i,j) in {i0..i1, 1..cDom.high} {
                A[i,c[j]] = X.get(i-i0,j);
          }
@@ -1870,7 +1870,7 @@ class Matrix {
    */
 
    proc transpose () {
-      var X = new Matrix(n,m);
+      var X = new unmanaged Matrix(n,m);
       var C = X.A;
       for (i,j) in {1..m, 1..n} {
             C[j,i] = A[i,j];
@@ -1897,7 +1897,7 @@ class Matrix {
    */
 
    proc norm2 () : real{
-      var toret : SingularValueDecomposition = new SingularValueDecomposition(this);
+      var toret : unmanaged SingularValueDecomposition = new unmanaged SingularValueDecomposition(this);
       return toret.norm2();
    }
 
@@ -1931,7 +1931,7 @@ class Matrix {
    */
 
    proc uminus () {
-      var X = new Matrix(m,n);
+      var X = new unmanaged Matrix(m,n);
       var C = X.getArray();
       for (i,j) in {1..m, 1..n} {
             C[i,j] = -A[i,j];
@@ -1944,9 +1944,9 @@ class Matrix {
    return     A + B
    */
 
-   proc plus (B:Matrix) {
+   proc plus (B: unmanaged Matrix) {
       checkMatrixDimensions(B);
-      var X = new Matrix(m,n);
+      var X = new unmanaged Matrix(m,n);
       var C = X.getArray();
       for (i,j) in {1..m, 1..n} {
             C[i,j] = A[i,j] + B.A[i,j];
@@ -1959,7 +1959,7 @@ class Matrix {
    return     A + B
    */
 
-   proc plusEquals (B:Matrix) {
+   proc plusEquals (B: unmanaged Matrix) {
       checkMatrixDimensions(B);
       for (i,j) in {1..m, 1..n} {
             A[i,j] = A[i,j] + B.A[i,j];
@@ -1972,9 +1972,9 @@ class Matrix {
    return     A - B
    */
 
-   proc minus (B:Matrix) {
+   proc minus (B: unmanaged Matrix) {
       checkMatrixDimensions(B);
-      var X = new Matrix(m,n);
+      var X = new unmanaged Matrix(m,n);
       var C = X.getArray();
       for (i,j) in {1..m, 1..n} {
             C[i,j] = A[i,j] - B.A[i,j];
@@ -1987,7 +1987,7 @@ class Matrix {
    return     A - B
    */
 
-   proc minusEquals (B:Matrix) {
+   proc minusEquals (B: unmanaged Matrix) {
       checkMatrixDimensions(B);
       for (i,j) in {1..m, 1..n} {
             A[i,j] = A[i,j] - B.A[i,j];
@@ -2000,9 +2000,9 @@ class Matrix {
    return     A.*B
    */
 
-   proc arrayTimes (B:Matrix) {
+   proc arrayTimes (B: unmanaged Matrix) {
       checkMatrixDimensions(B);
-      var X = new Matrix(m,n);
+      var X = new unmanaged Matrix(m,n);
       var C = X.getArray();
       for (i,j) in {1..m, 1..n} {
             C[i,j] = A[i,j] * B.A[i,j];
@@ -2015,7 +2015,7 @@ class Matrix {
    return     A.*B
    */
 
-   proc arrayTimesEquals (B:Matrix) {
+   proc arrayTimesEquals (B: unmanaged Matrix) {
       checkMatrixDimensions(B);
       for (i,j) in {1..m, 1..n} {
             A[i,j] = A[i,j] * B.A[i,j];
@@ -2028,9 +2028,9 @@ class Matrix {
    return     A./B
    */
 
-   proc arrayRightDivide (B:Matrix) {
+   proc arrayRightDivide (B: unmanaged Matrix) {
       checkMatrixDimensions(B);
-      var X = new Matrix(m,n);
+      var X = new unmanaged Matrix(m,n);
       var C = X.getArray();
       for (i,j) in {1..m, 1..n} {
             C[i,j] = A[i,j] / B.A[i,j];
@@ -2043,7 +2043,7 @@ class Matrix {
    return     A./B
    */
 
-   proc arrayRightDivideEquals (B:Matrix) {
+   proc arrayRightDivideEquals (B: unmanaged Matrix) {
       checkMatrixDimensions(B);
       for (i,j) in {1..m, 1..n} {
             A[i,j] = A[i,j] / B.A[i,j];
@@ -2056,9 +2056,9 @@ class Matrix {
    return     A.\B
    */
 
-   proc arrayLeftDivide (B:Matrix) {
+   proc arrayLeftDivide (B: unmanaged Matrix) {
       checkMatrixDimensions(B);
-      var X = new Matrix(m,n);
+      var X = new unmanaged Matrix(m,n);
       var C = X.getArray();
       for (i,j) in {1..m, 1..n} {
             C[i,j] = B.A[i,j] / A[i,j];
@@ -2071,7 +2071,7 @@ class Matrix {
    return     A.\B
    */
 
-   proc arrayLeftDivideEquals (B:Matrix) {
+   proc arrayLeftDivideEquals (B: unmanaged Matrix) {
       checkMatrixDimensions(B);
       for (i,j) in {1..m, 1..n} {
             A[i,j] = B.A[i,j] / A[i,j];
@@ -2085,7 +2085,7 @@ class Matrix {
    */
 
    proc times (s:real) {
-      var X = new Matrix(m,n);
+      var X = new unmanaged Matrix(m,n);
       var C = X.getArray();
       for (i,j) in {1..m, 1..n} {
             C[i,j] = s*A[i,j];
@@ -2110,11 +2110,11 @@ class Matrix {
    return     Matrix product, A * B
    */
 
-   proc times (B:Matrix) {
+   proc times (B: unmanaged Matrix) {
       if (B.m != n) {
          assert(B.m != n, "Matrix inner dimensions must agree.");
       }
-      var X = new Matrix(m,B.n);
+      var X = new unmanaged Matrix(m,B.n);
       var C = X.getArray();
       var Bcolj : [1..n] real;
       for j in 1..B.n {
@@ -2135,7 +2135,7 @@ class Matrix {
    */
 
    proc lu () {
-      return new LUDecomposition(this);
+      return new unmanaged LUDecomposition(_to_unmanaged(this));
    }
 
    /* QR Decomposition
@@ -2143,7 +2143,7 @@ class Matrix {
    */
 
    proc qr () {
-      return new QRDecomposition(this);
+      return new unmanaged QRDecomposition(_to_unmanaged(this));
    }
 
    /* Cholesky Decomposition
@@ -2151,7 +2151,7 @@ class Matrix {
    */
 
    proc chol () {
-      return new CholeskyDecomposition(this);
+      return new unmanaged CholeskyDecomposition(_to_unmanaged(this));
    }
 
    /* Singular Value Decomposition
@@ -2159,11 +2159,11 @@ class Matrix {
    */
 
    proc svd () {
-      return new SingularValueDecomposition(this);
+      return new unmanaged SingularValueDecomposition(_to_unmanaged(this));
    }
 
    proc rsvd() {
-      return new RandomSingularValueDecomposition(this);
+      return new unmanaged RandomSingularValueDecomposition(_to_unmanaged(this));
    }
 
    /* Eigenvalue Decomposition
@@ -2171,7 +2171,7 @@ class Matrix {
    */
 
    proc eig () {
-      return new EigenvalueDecomposition(this);
+      return new unmanaged EigenvalueDecomposition(_to_unmanaged(this));
    }
 
    /* Solve A*X = B
@@ -2179,9 +2179,9 @@ class Matrix {
    return     solution if A is square, least squares solution otherwise
    */
 
-   proc solve (B:Matrix) {
-      var toret = if(m == n) then (new LUDecomposition(this)).solve(B) 
-                             else (new QRDecomposition(this)).solve(B);
+   proc solve (B: unmanaged Matrix) {
+      var toret = if(m == n) then (new unmanaged LUDecomposition(_to_unmanaged(this))).solve(B)
+                             else (new unmanaged QRDecomposition(_to_unmanaged(this))).solve(B);
       return toret;
    }
 
@@ -2190,7 +2190,7 @@ class Matrix {
    return     solution if A is square, least squares solution otherwise.
    */
 
-   proc solveTranspose (B:Matrix) {
+   proc solveTranspose (B: unmanaged Matrix) {
       return transpose().solve(B.transpose());
    }
 
@@ -2207,7 +2207,7 @@ class Matrix {
    */
 
    proc det () {
-      var toret : LUDecomposition = new LUDecomposition(this);
+      var toret : unmanaged LUDecomposition = new unmanaged LUDecomposition(_to_unmanaged(this));
       return toret.det();
    }
 
@@ -2216,7 +2216,7 @@ class Matrix {
    */
 
    proc rank () {
-      var toret : SingularValueDecomposition = new SingularValueDecomposition(this);
+      var toret : SingularValueDecomposition = new unmanaged SingularValueDecomposition(_to_unmanaged(this));
       return toret.rank();
    }
 
@@ -2225,7 +2225,7 @@ class Matrix {
    */
 
    proc cond () {
-      var toret : SingularValueDecomposition = new SingularValueDecomposition(this);
+      var toret : SingularValueDecomposition = new unmanaged SingularValueDecomposition(_to_unmanaged(this));
       return toret.cond();
    }
 
@@ -2247,15 +2247,15 @@ class Matrix {
    */
 
    proc random (m, n:int) {
-      var A = new Matrix(m,n);
-      var randlist = new RandomStream(real, seed);
+      var A = new unmanaged Matrix(m,n);
+      var randlist = new owned RandomStream(real, seed);
       randlist.fillRandom(A.A);
       return A;
    }
 
    /* Check if size(A) == size(B) */
 
-   proc checkMatrixDimensions (B:Matrix) {
+   proc checkMatrixDimensions (B: unmanaged Matrix) {
       if (B.m != m || B.n != n) {
          assert((B.m != m || B.n != n), "Matrix dimensions must agree.");
       }
@@ -2264,8 +2264,8 @@ class Matrix {
 }
 
 proc random (m, n:int) {
-   var A = new Matrix(m,n);
-   var randlist = new RandomStream(real, seed);
+   var A = new unmanaged Matrix(m,n);
+   var randlist = new owned RandomStream(real, seed);
    randlist.fillRandom(A.A);
    return A;
 }
@@ -2307,12 +2307,12 @@ class QRDecomposition {
    A    Rectangular matrix
    */
 
-   proc init (A:Matrix) {
+   proc init (A: unmanaged Matrix) {
       // Initialize.
       m = A.getRowDimension();
       n = A.getColumnDimension();
 
-      qrDom = {1..m, 1..n}; 
+      qrDom = {1..m, 1..n};
       QR = A.getArrayCopy();
       rdiagDom = {1..n};
       this.complete();
@@ -2337,7 +2337,7 @@ class QRDecomposition {
 
             // Apply transformation to remaining columns.
             for j in k+1..n {
-               var s = 0.0; 
+               var s = 0.0;
                for i in k..m {
                   s += QR[i,k]*QR[i,j];
                }
@@ -2369,9 +2369,9 @@ class QRDecomposition {
    */
 
    proc getH () {
-      var X = new Matrix(m,n);
+      var X = new unmanaged Matrix(m,n);
       var H = X.getArray();
-      for (i,j) in {1..m, 1..n} { 
+      for (i,j) in {1..m, 1..n} {
             if (i >= j) {
                H[i,j] = QR[i,j];
             } else {
@@ -2386,11 +2386,11 @@ class QRDecomposition {
    */
 
    proc getR () {
-      var X = new Matrix(n,n);
+      var X = new unmanaged Matrix(n,n);
       // BUG HERE! Tried to make this a ref to speed things up - it got weird b/c
       // making this a ref instead of a var makes the output from getQ change.
       //
-      var retR = X.A; 
+      var retR = X.A;
       for (i,j) in {1..n, 1..n} {
             if (i < j) {
                retR[i,j] = QR[i,j];
@@ -2409,7 +2409,7 @@ class QRDecomposition {
    */
 
    proc getQ () {
-      var X = new Matrix(m,n);
+      var X = new unmanaged Matrix(m,n);
       var retQ = X.A;
 
       for k in 1..n-1 by -1 {
@@ -2440,14 +2440,14 @@ class QRDecomposition {
    return     X that minimizes the two norm of Q*R*X-B.
    */
 
-   proc solve (B:Matrix) {
+   proc solve (B: unmanaged Matrix) {
       if (B.getRowDimension() != m) {
          assert(B.getRowDimension() != m, "Matrix row dimensions must agree.");
       }
       if (!this.isFullRank()) {
          assert(!this.isFullRank(), "Matrix is rank deficient.");
       }
-      
+
       // Copy right hand side
       var nx = B.getColumnDimension();
       var X = B.getArrayCopy();
@@ -2455,7 +2455,7 @@ class QRDecomposition {
       // Compute Y = transpose(Q)*B
       for k in 1..n {
          for j in 1..nx {
-            var s = 0.0; 
+            var s = 0.0;
             const kmrng = {k..m};
             for i in kmrng {
                s += QR[i,k]*X[i,j];
@@ -2481,22 +2481,22 @@ class QRDecomposition {
 
       }
 
-      var toret = new Matrix(X,n,nx);
+      var toret = new unmanaged Matrix(X,n,nx);
       return toret.getMatrix(1,n,1,nx);
    }
 
 }
 
-/* 
+/*
    Singular Value Decomposition.
-   
+
    For an m-by-n matrix A with m >= n, the singular value decomposition is
    an m-by-n orthogonal matrix U, an n-by-n diagonal matrix S, and
    an n-by-n orthogonal matrix V so that A = U*S*V'.
-   
+
    The singular values, sigma[k] = S[k,k], are ordered so that
    sigma[0] >= sigma[1] >= ... >= sigma[n-1].
-   
+
    The singular value decomposition always exists, so the constructor will
    never fail.  The matrix condition number and the effective numerical
    rank can be computed from this decomposition.
@@ -2530,7 +2530,7 @@ class SingularValueDecomposition {
    Arg    Rectangular matrix
    */
 
-   proc init (Arg:Matrix) {
+   proc init (Arg: unmanaged Matrix) {
 
       // Derived from LINPACK code.
       // Initialize.
@@ -2538,15 +2538,15 @@ class SingularValueDecomposition {
       n = Arg.getColumnDimension();
 
       /* Tactics...This algorithm assumes a zero-index language
-         since chapel is one-index, it was decided for the 
-         sake of developer sanity to use chapel's alias 
-         functionality to temporarily use zero-indexing 
+         since chapel is one-index, it was decided for the
+         sake of developer sanity to use chapel's alias
+         functionality to temporarily use zero-indexing
        */
 
       var aDom = {0..m-1, 0..n-1};
       ref A = Arg.getArrayCopy().reindex(aDom); // alias the matrix
 
-      /* Apparently the failing cases are only a proper subset of (m<n), 
+      /* Apparently the failing cases are only a proper subset of (m<n),
       so let's not throw error.  Correct fix to come later?
       */
       var nu = min(m,n);
@@ -2754,8 +2754,8 @@ class SingularValueDecomposition {
 
       var pp = p-1;
       var itr = 0;
-      var eps = 2.0 ** -52.0; 
-      var tiny = 2.0 ** -966.0; 
+      var eps = 2.0 ** -52.0;
+      var tiny = 2.0 ** -966.0;
 
       while (p > 0) {
          var k,kase : int;
@@ -2772,7 +2772,7 @@ class SingularValueDecomposition {
          //              s(k), ..., s(p) are not negligible (qr step).
          // kase = 4     if e(p-1) is negligible (convergence).
 
-         for z in -1..p-2 by -1 { 
+         for z in -1..p-2 by -1 {
             if (z == -1) {
                k = z;
                break;
@@ -2795,7 +2795,7 @@ class SingularValueDecomposition {
                   ks = ksk;
                   break;
                }
-               var t = if(ksk != p) then abs(e[ksk]) else 0.0 + 
+               var t = if(ksk != p) then abs(e[ksk]) else 0.0 +
                           if(ksk != k+1) then abs(e[ksk-1]) else 0.0;
 
                if (abs(S[ksk]) <= tiny + eps*t)  {
@@ -2870,7 +2870,7 @@ class SingularValueDecomposition {
             when 3 {
 
                // Calculate the shift.
-   
+
                var scale = max(max(max(max(abs(S[p-1]),abs(S[p-2])),abs(e[p-2])),
                                            abs(S[k])),abs(e[k]));
 
@@ -2883,7 +2883,7 @@ class SingularValueDecomposition {
                var c = (sp*epm1)*(sp*epm1);
                var shift = 0.0;
                if ((b != 0.0) | (c != 0.0)) {
-                  shift = ((b*b)+c) ** 0.5; 
+                  shift = ((b*b)+c) ** 0.5;
                   if (b < 0.0) {
                      shift = -shift;
                   }
@@ -2891,9 +2891,9 @@ class SingularValueDecomposition {
                }
                var f = (sk + sp)*(sk - sp) + shift;
                var g = sk*ek;
-   
+
                // Chase zeros.
-   
+
                for j in k..p-2 {
                   var t = hypot(f,g);
                   var cs = f/t;
@@ -2937,7 +2937,7 @@ class SingularValueDecomposition {
             when 4 {
 
                // Make the singular values positive.
-   
+
                if (S[k] <= 0.0) {
                   S[k] = if(S[k] < 0.0) then -S[k] else 0.0;
                   if (wantv) {
@@ -2946,9 +2946,9 @@ class SingularValueDecomposition {
                      }
                   }
                }
-   
+
                // Order the singular values.
-   
+
                while (k < pp) {
                   if (S[k] >= S[k+1]) {
                      break;
@@ -2980,7 +2980,7 @@ class SingularValueDecomposition {
    */
 
    proc getU () {
-      return new Matrix(U,m,min(m+1,n));
+      return new unmanaged Matrix(U,m,min(m+1,n));
    }
 
    /* Return the right singular vectors
@@ -2988,7 +2988,7 @@ class SingularValueDecomposition {
    */
 
    proc getV () {
-      return new Matrix(V,n,n);
+      return new unmanaged Matrix(V,n,n);
    }
 
    /* Return the one-dimensional array of singular values
@@ -3004,7 +3004,7 @@ class SingularValueDecomposition {
    */
 
    proc getS () {
-      var X = new Matrix(n,n);
+      var X = new unmanaged Matrix(n,n);
       var S = X.getArray();
       for i in 1..n {
          for j in 1..n {
@@ -3036,7 +3036,7 @@ class SingularValueDecomposition {
    */
 
    proc rank () {
-      var eps = 2.0 ** -52.0; 
+      var eps = 2.0 ** -52.0;
       var tol = max(m,n)*s[1]*eps;
       var r = 0;
 

--- a/test/functions/bradc/intents/intents-classes2-error.chpl
+++ b/test/functions/bradc/intents/intents-classes2-error.chpl
@@ -4,36 +4,36 @@ class pair {
   var b: real;
 }
 
-proc callin(in x: pair) {
+proc callin(in x: unmanaged pair) {
   writeln("in callin, x is: ", x.a, " ", x.b);
-  x = new pair();
+  x = new unmanaged pair();
   x.a = 11;
   x.b = 3.4;
   writeln("re-assigned to be new instance: ", x.a, " ", x.b);
 }
 
 
-proc callout(out x: pair) {
+proc callout(out x: unmanaged pair) {
   writeln("in callout, x ought to be nil");
-  x = new pair();
+  x = new unmanaged pair();
   x.a = 12;
   x.b = 4.5;
   writeln("re-assigned to be new instance: ", x.a, " ", x.b);
 }
 
 
-proc callinout(inout x: pair) {
+proc callinout(inout x: unmanaged pair) {
   writeln("in callinout, x is: ", x.a, " ", x.b);
-  x = new pair();
+  x = new unmanaged pair();
   x.a = 13;
   x.b = 5.6;
   writeln("re-assigned to be new instance: ", x.a, " ", x.b);
 }
 
 
-proc callblank(x: pair) {
+proc callblank(x: unmanaged pair) {
   writeln("in callblank, x is: ", x.a, " ", x.b);
-  x = new pair();
+  x = new unmanaged pair();
   x.a = 14;
   x.b = 6.7;
   writeln("re-assigned to be new instance: ", x.a, " ", x.b);
@@ -41,7 +41,7 @@ proc callblank(x: pair) {
 
 
 proc main() {
-  var a: pair = new pair();
+  var a: unmanaged pair = new unmanaged pair();
 
   a.a = 10;
   a.b = 2.3;

--- a/test/functions/bradc/intents/intents-classes2.chpl
+++ b/test/functions/bradc/intents/intents-classes2.chpl
@@ -3,10 +3,10 @@ class pair {
   var b: real;
 }
 
-proc callin(in x: pair) {
+proc callin(in x: unmanaged pair) {
   writeln("in callin, x is: ", x.a, " ", x.b);
 
-  x   = new pair();
+  x   = new unmanaged pair();
   x.a = 11;
   x.b = 3.4;
 
@@ -16,10 +16,10 @@ proc callin(in x: pair) {
 }
 
 
-proc callout(out x: pair) {
+proc callout(out x: unmanaged pair) {
   writeln("in callout, x ought to be nil");
 
-  x   = new pair();
+  x   = new unmanaged pair();
   x.a = 12;
   x.b = 4.5;
 
@@ -27,12 +27,12 @@ proc callout(out x: pair) {
 }
 
 
-proc callinout(inout x: pair) {
+proc callinout(inout x: unmanaged pair) {
   writeln("in callinout, x is: ", x.a, " ", x.b);
 
   delete x;
 
-  x   = new pair();
+  x   = new unmanaged pair();
   x.a = 13;
   x.b = 5.6;
 
@@ -40,7 +40,7 @@ proc callinout(inout x: pair) {
 }
 
 
-proc callblank(x: pair) {
+proc callblank(x: unmanaged pair) {
   writeln("in callblank, x is: ", x.a, " ", x.b);
 
   x.a = 14;
@@ -51,7 +51,7 @@ proc callblank(x: pair) {
 
 
 proc main() {
-  var a: pair = new pair();
+  var a: unmanaged pair = new unmanaged pair();
 
   a.a = 10;
   a.b = 2.3;

--- a/test/functions/bradc/intents/intents-classes3.chpl
+++ b/test/functions/bradc/intents/intents-classes3.chpl
@@ -3,9 +3,9 @@ class pair {
   var b: real;
 }
 
-var a: pair = new pair();
+var a: unmanaged pair = new unmanaged pair();
 
-proc callin(in x: pair) {
+proc callin(in x: unmanaged pair) {
   writeln("in callin, x is: ", x.a, " ", x.b);
 
   if (x == a) {
@@ -14,7 +14,7 @@ proc callin(in x: pair) {
     writeln("a and x differ on the way in");
   }
 
-  x   = new pair();
+  x   = new unmanaged pair();
   x.a = 11;
   x.b = 3.4;
 
@@ -30,7 +30,7 @@ proc callin(in x: pair) {
 }
 
 
-proc callout(out x: pair) {
+proc callout(out x: unmanaged pair) {
   writeln("in callout, x should be nil");
 
   if (x == a) {
@@ -39,7 +39,7 @@ proc callout(out x: pair) {
     writeln("a and x differ on the way in");
   }
 
-  x   = new pair();
+  x   = new unmanaged pair();
   x.a = 12;
   x.b = 4.5;
 
@@ -53,7 +53,7 @@ proc callout(out x: pair) {
 }
 
 
-proc callinout(inout x: pair) {
+proc callinout(inout x: unmanaged pair) {
   writeln("in callinout, x is: ", x.a, " ", x.b);
 
   if (x == a) {
@@ -62,7 +62,7 @@ proc callinout(inout x: pair) {
     writeln("a and x differ on the way in");
   }
 
-  x   = new pair();
+  x   = new unmanaged pair();
   x.a = 13;
   x.b = 5.6;
 
@@ -76,7 +76,7 @@ proc callinout(inout x: pair) {
 }
 
 
-proc callblank(x: pair) {
+proc callblank(x: unmanaged pair) {
   writeln("in callblank, x is: ", x.a, " ", x.b);
 
   if (x == a) {

--- a/test/functions/bradc/intents/intents-classes4.chpl
+++ b/test/functions/bradc/intents/intents-classes4.chpl
@@ -3,9 +3,9 @@ class pair {
   var b: real;
 }
 
-var a: pair = new pair();
+var a: unmanaged pair = new unmanaged pair();
 
-proc callin(in x: pair) {
+proc callin(in x: unmanaged pair) {
   writeln("in callin, x is: ", x.a, " ", x.b);
 
   if (x == a) {
@@ -14,7 +14,7 @@ proc callin(in x: pair) {
     writeln("a and x differ on the way in");
   }
 
-  x   = new pair();
+  x   = new unmanaged pair();
   x.a = 11;
   x.b = 3.4;
 
@@ -30,7 +30,7 @@ proc callin(in x: pair) {
 }
 
 
-proc callout(out x: pair) {
+proc callout(out x: unmanaged pair) {
   if (x == nil) {
     writeln("x is nil on the way in as it should be");
   } else {
@@ -43,7 +43,7 @@ proc callout(out x: pair) {
     writeln("a and x differ on the way in");
   }
 
-  x   = new pair();
+  x   = new unmanaged pair();
   x.a = 12;
   x.b = 4.5;
 
@@ -57,7 +57,7 @@ proc callout(out x: pair) {
 }
 
 
-proc callinout(inout x: pair) {
+proc callinout(inout x: unmanaged pair) {
   writeln("in callinout, x is: ", x.a, " ", x.b);
 
   if (x == a) {
@@ -66,7 +66,7 @@ proc callinout(inout x: pair) {
     writeln("a and x differ on the way in");
   }
 
-  x   = new pair();
+  x   = new unmanaged pair();
   x.a = 13;
   x.b = 5.6;
 
@@ -80,7 +80,7 @@ proc callinout(inout x: pair) {
 }
 
 
-proc callblank(x: pair) {
+proc callblank(x: unmanaged pair) {
   writeln("in callblank, x is: ", x.a, " ", x.b);
 
   if (x == a) {

--- a/test/functions/bradc/namedArgs/forceNamedArgs-createdummy.chpl
+++ b/test/functions/bradc/namedArgs/forceNamedArgs-createdummy.chpl
@@ -4,7 +4,7 @@ class dummyarg {
   }
 }
 
-proc momentum(dummy: dummyarg = nil, mass: real, velocity: real) {
+proc momentum(dummy: borrowed dummyarg = nil, mass: real, velocity: real) {
   return mass*velocity;
 }
 

--- a/test/functions/bradc/namedArgs/forceNamedArgs.chpl
+++ b/test/functions/bradc/namedArgs/forceNamedArgs.chpl
@@ -4,7 +4,7 @@ class dummyarg {
   }
 }
 
-proc momentum(dummy: dummyarg = nil, mass: real, velocity: real) {
+proc momentum(dummy: borrowed dummyarg = nil, mass: real, velocity: real) {
   return mass*velocity;
 }
 

--- a/test/functions/bradc/queryTypesParamsOnly.chpl
+++ b/test/functions/bradc/queryTypesParamsOnly.chpl
@@ -7,7 +7,7 @@ class D : C {
   param r: int;
 }
 
-proc foo(argD: D(?t, ?r)) {
+proc foo(argD: unmanaged D(?t, ?r)) {
   writeln("argD.x = ", argD.x);
 }
 

--- a/test/functions/cwailes/disambiguation/dbm_case_L.chpl
+++ b/test/functions/cwailes/disambiguation/dbm_case_L.chpl
@@ -2,11 +2,11 @@ class Base {}
 class Derived1 : Base {}
 class Derived2 : Derived1 {}
 
-proc foo(a:Base) {
+proc foo(a:borrowed Base) {
   writeln("foo1");
 }
 
-proc foo(a:Derived1) {
+proc foo(a:borrowed Derived1) {
   writeln("foo2");
 }
 

--- a/test/functions/deitz/nested/test_nested_global1.chpl
+++ b/test/functions/deitz/nested/test_nested_global1.chpl
@@ -6,7 +6,7 @@ var c = new borrowed C(x = 2);
 
 proc foo(type t) {
   var x : t;
-  proc bar(c : C) {
+  proc bar(c : borrowed C) {
     writeln(c);
   }
   writeln(x);

--- a/test/functions/deitz/test_base_method_call.chpl
+++ b/test/functions/deitz/test_base_method_call.chpl
@@ -12,6 +12,6 @@ class D: C {
   }
 }
 
-var d: D = new borrowed D();
+var d: borrowed D = new borrowed D();
 
-(d:C).foo();
+(d:borrowed C).foo();

--- a/test/functions/deitz/test_promote_generic.chpl
+++ b/test/functions/deitz/test_promote_generic.chpl
@@ -3,11 +3,11 @@ class C {
   var x: t;
 }
 
-proc foo(c: C) {
+proc foo(c: unmanaged C) {
   return c.x;
 }
 
-var A: [1..4] C(int) = [i in 1..4] new C(int, i);
+var A: [1..4] unmanaged C(int) = [i in 1..4] new unmanaged C(int, i);
 
 writeln(A);
 

--- a/test/functions/deitz/test_promote_subclass.chpl
+++ b/test/functions/deitz/test_promote_subclass.chpl
@@ -9,7 +9,7 @@ class D: C {
 
 var A: [1..3] unmanaged D = [i in 1..3] new unmanaged D(x=i);
 
-proc foo(c: C) { writeln(c); }
+proc foo(c: borrowed C) { writeln(c); }
 
 writeln(A);
 

--- a/test/functions/deitz/test_var_function1.chpl
+++ b/test/functions/deitz/test_var_function1.chpl
@@ -2,11 +2,11 @@ class foo {
   var a : int;
 }
 
-proc bar(x : foo) ref {
+proc bar(x : unmanaged foo) ref {
   return x;
 }
 
-var f : foo = new unmanaged foo(a = 12);
+var f : unmanaged foo = new unmanaged foo(a = 12);
 
 writeln(f);
 

--- a/test/functions/deitz/test_var_function_access.chpl
+++ b/test/functions/deitz/test_var_function_access.chpl
@@ -2,11 +2,11 @@ class foo {
   var a : int;
 }
 
-proc bar(x : foo) ref {
+proc bar(x : borrowed foo) ref {
   return x;
 }
 
-var f : foo = new borrowed foo(a = 12);
+var f : borrowed foo = new borrowed foo(a = 12);
 
 writeln(f);
 

--- a/test/functions/deitz/test_var_method.chpl
+++ b/test/functions/deitz/test_var_method.chpl
@@ -5,7 +5,7 @@ class C {
   }
 }
 
-var c : C = new borrowed C();
+var c : borrowed C = new borrowed C();
 c.i = 2;
 writeln(c);
 writeln(c.foo());

--- a/test/functions/deitz/test_visible1.chpl
+++ b/test/functions/deitz/test_visible1.chpl
@@ -5,7 +5,7 @@ class C {
 var c = new borrowed C();
 
 proc foo() {
-  proc bar(c : C) {
+  proc bar(c : borrowed C) {
     writeln("in bar");
   }
   writeln("in foo");

--- a/test/functions/deitz/test_visible2.chpl
+++ b/test/functions/deitz/test_visible2.chpl
@@ -5,7 +5,7 @@ class C {
 var c = new borrowed C();
 
 proc foo() {
-  proc bar(c : C) {
+  proc bar(c : borrowed C) {
     writeln("in bar");
   }
   writeln("in foo");

--- a/test/functions/ferguson/error-return-parentclass.chpl
+++ b/test/functions/ferguson/error-return-parentclass.chpl
@@ -11,7 +11,7 @@ var got = f();
 writeln(got);
 
 
-proc f() : Child {
+proc f() : borrowed Child {
   return globalParent;
 }
 

--- a/test/functions/ferguson/ref-pair/across-scopes.chpl
+++ b/test/functions/ferguson/ref-pair/across-scopes.chpl
@@ -42,7 +42,7 @@ writeln(c.name5);
 writeln(c.name6);
 
 writeln("Calling parent name functions");
-var d = c:Parent;
+var d = c:borrowed Parent;
 writeln(d.name);
 writeln(d.name2);
 writeln(d.name3);

--- a/test/functions/ferguson/spec-insn-method-class.chpl
+++ b/test/functions/ferguson/spec-insn-method-class.chpl
@@ -39,8 +39,8 @@ d.foo();
 
 
 writeln("static C dynamic Child");
-var e:C(real) = new borrowed Child(x=1.0, y=100);
+var e:borrowed C(real) = new borrowed Child(x=1.0, y=100);
 e.foo();
 
-var f:C(int) = new borrowed Child(x=2, y=100);
+var f:borrowed C(int) = new borrowed Child(x=2, y=100);
 f.foo();

--- a/test/functions/ferguson/type-colon-dispatch.chpl
+++ b/test/functions/ferguson/type-colon-dispatch.chpl
@@ -34,16 +34,16 @@ proc foo(type t) {
 proc foo(type t:R) {
   writeln("R");
 }
-proc foo(type t:Parent) {
+proc foo(type t:borrowed Parent) {
   writeln("Parent");
 }
-proc foo(type t:GenericParent) {
+proc foo(type t:borrowed GenericParent) {
   writeln("GenericParent");
 }
-proc foo(type t:GenericChild(int)) {
+proc foo(type t:borrowed GenericChild(int)) {
   writeln("GenericChild(int)");
 }
-proc foo(type t:object) {
+proc foo(type t:borrowed object) {
   writeln("object");
 }
 writeln("foo");
@@ -51,12 +51,12 @@ foo(int);
 foo(int(8));
 foo(real);
 foo(R(complex));
-foo(Parent);
-foo(Child);
-foo(MyClass);
-foo(GenericParent(int));
-foo(GenericChild(int));
-foo(GenericChild(real));
+foo(borrowed Parent);
+foo(borrowed Child);
+foo(borrowed MyClass);
+foo(borrowed GenericParent(int));
+foo(borrowed GenericChild(int));
+foo(borrowed GenericChild(real));
 writeln();
 
 proc bar(type t) where t:int {
@@ -65,23 +65,23 @@ proc bar(type t) where t:int {
 proc bar(type t) where (t:integral && !t:int) {
   writeln("integral");
 }
-proc bar(type t) where !(t:int || t:integral || t:R || t:Parent ||
-                         t:GenericParent || t:object) {
+proc bar(type t) where !(t:int || t:integral || t:R || t:borrowed Parent ||
+                         t:borrowed GenericParent || t:borrowed object) {
   writeln("any type");
 }
 proc bar(type t) where t:R {
   writeln("R");
 }
-proc bar(type t) where t:Parent {
+proc bar(type t) where t:borrowed Parent {
   writeln("Parent");
 }
-proc bar(type t) where (t:GenericParent && !t:GenericChild(int)) {
+proc bar(type t) where (t:borrowed GenericParent && !t:borrowed GenericChild(int)) {
   writeln("GenericParent");
 }
-proc bar(type t) where t:GenericChild(int) {
+proc bar(type t) where t:borrowed GenericChild(int) {
   writeln("GenericChild(int)");
 }
-proc bar(type t) where (t:object && !t:Parent && !t:GenericParent) {
+proc bar(type t) where (t:borrowed object && !t:borrowed Parent && !t:borrowed GenericParent) {
   writeln("object");
 }
 
@@ -90,9 +90,9 @@ bar(int);
 bar(int(8));
 bar(real);
 bar(R(complex));
-bar(Parent);
-bar(Child);
-bar(MyClass);
-bar(GenericParent(int));
-bar(GenericChild(int));
-bar(GenericChild(real));
+bar(borrowed Parent);
+bar(borrowed Child);
+bar(borrowed MyClass);
+bar(borrowed GenericParent(int));
+bar(borrowed GenericChild(int));
+bar(borrowed GenericChild(real));

--- a/test/functions/ferguson/where-subtype-dispatch.chpl
+++ b/test/functions/ferguson/where-subtype-dispatch.chpl
@@ -42,23 +42,23 @@ proc bar(type t) where t:int {
 proc bar(type t) where (t:integral && !t:int) {
   writeln("integral");
 }
-proc bar(type t) where !(t:int || t:integral || t:R || t:Parent ||
-                         t:GenericParent || t:object) {
+proc bar(type t) where !(t:int || t:integral || t:R || t:borrowed Parent ||
+                         t:borrowed GenericParent || t:borrowed object) {
   writeln("any type");
 }
 proc bar(type t) where t:R {
   writeln("R");
 }
-proc bar(type t) where t:Parent {
+proc bar(type t) where t:borrowed Parent {
   writeln("Parent");
 }
-proc bar(type t) where (t:GenericParent && !t:GenericChild(int)) {
+proc bar(type t) where (t:borrowed GenericParent && !t:borrowed GenericChild(int)) {
   writeln("GenericParent");
 }
-proc bar(type t) where t:GenericChild(int) {
+proc bar(type t) where t:borrowed GenericChild(int) {
   writeln("GenericChild(int)");
 }
-proc bar(type t) where (t:object && !t:Parent && !t:GenericParent) {
+proc bar(type t) where (t:borrowed object && !t:borrowed Parent && !t:borrowed GenericParent) {
   writeln("object");
 }
 
@@ -67,25 +67,25 @@ bar(int);
 bar(int(8));
 bar(real);
 bar(R(complex));
-bar(Parent);
-bar(Child);
-bar(MyClass);
-bar(GenericParent(int));
-bar(GenericChild(int));
-bar(GenericChild(real));
+bar(borrowed Parent);
+bar(borrowed Child);
+bar(borrowed MyClass);
+bar(borrowed GenericParent(int));
+bar(borrowed GenericChild(int));
+bar(borrowed GenericChild(real));
 writeln();
 
-proc test1() where GenericParent(int):GenericChild { writeln("BAD"); }
+proc test1() where borrowed GenericParent(int):borrowed GenericChild { writeln("BAD"); }
 proc test1() { writeln("test1"); }
-proc test2() where GenericChild(real):GenericParent { writeln("test2"); }
+proc test2() where borrowed GenericChild(real):borrowed GenericParent { writeln("test2"); }
 proc test2() { writeln("BAD"); }
-proc test3() where GenericChild(int):GenericParent { writeln("test3"); }
+proc test3() where borrowed GenericChild(int):borrowed GenericParent { writeln("test3"); }
 proc test3() { writeln("BAD"); }
-proc test4() where GenericChild(int):GenericParent(int) { writeln("test4"); }
+proc test4() where borrowed GenericChild(int):borrowed GenericParent(int) { writeln("test4"); }
 proc test4() { writeln("BAD"); }
-proc test5() where GenericChild(real):GenericParent(int) { writeln("BAD"); }
+proc test5() where borrowed GenericChild(real):borrowed GenericParent(int) { writeln("BAD"); }
 proc test5() { writeln("test5"); }
-proc test6() where GenericChild(int(8)):GenericParent(int) { writeln("BAD"); }
+proc test6() where borrowed GenericChild(int(8)):borrowed GenericParent(int) { writeln("BAD"); }
 proc test6() { writeln("test6"); }
 
 proc test7() where int:integral { writeln("test7"); }

--- a/test/functions/firstClassFns/captureGenericFn.chpl
+++ b/test/functions/firstClassFns/captureGenericFn.chpl
@@ -6,7 +6,7 @@ class R {
   type t;
 }
 
-proc f2(x:R) {
+proc f2(x:borrowed R) {
   return x;
 }
 

--- a/test/functions/iterators/bharshbarg/recurseHeapBug.chpl
+++ b/test/functions/iterators/bharshbarg/recurseHeapBug.chpl
@@ -18,7 +18,7 @@ class Lower : Base {
 }
 
 class Replicate : Base {
-  var low : Lower;
+  var low : unmanaged Lower;
 
   proc replicate(valToReplicate) {
     coforall i in low do on Locales[i] {

--- a/test/functions/iterators/bradc/leadFollow/followFlexType.chpl
+++ b/test/functions/iterators/bradc/leadFollow/followFlexType.chpl
@@ -30,8 +30,8 @@ class D {
   }
 }
 
-var myC = new C();
-var myD = new D();
+var myC = new borrowed C();
+var myD = new borrowed D();
 
 forall (i,j) in zip(myC, myC) do
   writeln("(i,j) = ", (i,j));
@@ -48,6 +48,3 @@ writeln();
 forall (i,j) in zip(myD,myC) do
   writeln("(i,j) = ", (i,j));
 writeln();
-
-delete myC;
-delete myD;

--- a/test/functions/iterators/bradc/leadFollow/followNoLead.chpl
+++ b/test/functions/iterators/bradc/leadFollow/followNoLead.chpl
@@ -29,12 +29,9 @@ class D {
   }
 }
 
-var myC = new C();
-var myD = new D();
+var myC = new borrowed C();
+var myD = new borrowed D();
 
 forall (i,j) in zip(myC, myD) {
   writeln("(i,j) = ", (i,j));
 }
-
-delete myC;
-delete myD;

--- a/test/functions/iterators/bradc/leadFollow/localfollow.chpl
+++ b/test/functions/iterators/bradc/leadFollow/localfollow.chpl
@@ -18,10 +18,8 @@ class C {
   }
 }
 
-var myC = new C();
+var myC = new borrowed C();
 
 forall i in myC {
   writeln("i is: ", i);
 }
-
-delete myC;

--- a/test/functions/iterators/bradc/leadFollow/localfollow2.chpl
+++ b/test/functions/iterators/bradc/leadFollow/localfollow2.chpl
@@ -20,10 +20,8 @@ class C {
   }
 }
 
-var myC = new C();
+var myC = new borrowed C();
 
 forall i in myC {
   writeln("i is: ", i);
 }
-
-delete myC;

--- a/test/functions/iterators/bradc/override.chpl
+++ b/test/functions/iterators/bradc/override.chpl
@@ -14,9 +14,9 @@ class D : C {
   }
 }
 
-var c1: C = new borrowed C();
-var c2: C = new borrowed D();
-var d : D = new borrowed D();
+var c1: borrowed C = new borrowed C();
+var c2: borrowed C = new borrowed D();
+var d : borrowed D = new borrowed D();
 
 for i in c1 {
   writeln(i);

--- a/test/functions/iterators/bradc/override2.chpl
+++ b/test/functions/iterators/bradc/override2.chpl
@@ -14,15 +14,15 @@ class D : C {
   }
 }
 
-var c1: C = new borrowed C();
-var c2: C = new borrowed D();
-var d : D = new borrowed D();
+var c1: borrowed C = new borrowed C();
+var c2: borrowed C = new borrowed D();
+var d : borrowed D = new borrowed D();
 
 test(c1);
 test(c2);
 test(d);
 
-proc test(x: C) {
+proc test(x: borrowed C) {
   for i in x {
     writeln(i);
   }

--- a/test/functions/iterators/diten/dynamicDispatchIterator3Levels.chpl
+++ b/test/functions/iterators/diten/dynamicDispatchIterator3Levels.chpl
@@ -34,8 +34,8 @@ class Grandchild: Child {
   }
 }
 
-var p1: Parent = new borrowed Child();
-var p2: Parent = new borrowed Grandchild();
+var p1: borrowed Parent = new borrowed Child();
+var p2: borrowed Parent = new borrowed Grandchild();
 
 for i in p1.myit() {
   writeln(i);

--- a/test/functions/iterators/recursive/follow-record-updates.chpl
+++ b/test/functions/iterators/recursive/follow-record-updates.chpl
@@ -7,7 +7,7 @@ class Tree {
   var left: owned Tree;
 }
 
-iter postorder(tree: Tree): Tree {
+iter postorder(tree: borrowed Tree): borrowed Tree {
   if tree != nil {
 
     for child in postorder(tree.left) do

--- a/test/functions/jplevyak/call_mapping-2.chpl
+++ b/test/functions/jplevyak/call_mapping-2.chpl
@@ -21,7 +21,7 @@ var a = new unmanaged A();
 a(1) = 1.0;
 writeln(a(1));
 
-var c = new C();
+var c = new unmanaged C();
 
 c.a(1) = 1.0;
 c.f();

--- a/test/functions/jplevyak/equal-4.chpl
+++ b/test/functions/jplevyak/equal-4.chpl
@@ -1,6 +1,6 @@
 class foo { var a : int;  }
 
-var x : foo = new unmanaged foo();
+var x : unmanaged foo = new unmanaged foo();
 
 delete x;
 

--- a/test/functions/jplevyak/equal-7.chpl
+++ b/test/functions/jplevyak/equal-7.chpl
@@ -1,8 +1,8 @@
 class foo { var a : int;  }
 
-var x : foo = new unmanaged foo();
-var y : foo = new unmanaged foo();
-var z : foo = x;
+var x : unmanaged foo = new unmanaged foo();
+var y : unmanaged foo = new unmanaged foo();
+var z : unmanaged foo = x;
 
 y.a = 1;
 x   = y;

--- a/test/functions/jplevyak/member-1.chpl
+++ b/test/functions/jplevyak/member-1.chpl
@@ -4,7 +4,7 @@ class foo {
 /* proc f() { return 10 + i; } */
 }
 
-proc f(x : foo) {
+proc f(x : borrowed foo) {
   return 20 + x.i;
 }
 
@@ -16,4 +16,3 @@ writeln(f(a));
 /* writeln(a.f()); */
 
 delete a;
-

--- a/test/functions/jplevyak/member-2.chpl
+++ b/test/functions/jplevyak/member-2.chpl
@@ -4,7 +4,7 @@ class foo {
   proc f() { return 10 + i; }
 }
 
-proc f(x : foo) {
+proc f(x : borrowed foo) {
   return 20 + x.i;
 }
 

--- a/test/functions/lydia/userDefinedDefaultFunction/redefine-class.chpl
+++ b/test/functions/lydia/userDefinedDefaultFunction/redefine-class.chpl
@@ -4,11 +4,11 @@ class bar {
 
 var global = new unmanaged bar(4);
 
-proc _defaultOf(type t):t where t:bar {
-  return global:bar;
+proc _defaultOf(type t):t where t:unmanaged bar {
+  return global:unmanaged bar;
 }
 
-var foo: bar;
+var foo: unmanaged bar;
 
 writeln(foo);
 

--- a/test/functions/nspark/generic-varargs1.chpl
+++ b/test/functions/nspark/generic-varargs1.chpl
@@ -13,11 +13,10 @@ class Foo {
 }
 
 {
-  var foo = new Foo(6*int, 4, 8, 15, 16, 23, 42);
-  delete foo;
+  var foo = new owned Foo(6*int, 4, 8, 15, 16, 23, 42);
 }
 
 {
-  var foo = new Foo((int, real), 42, 13.0);
+  var foo = new unmanaged Foo((int, real), 42, 13.0);
   delete foo;
 }

--- a/test/functions/varargs/varargOverride.chpl
+++ b/test/functions/varargs/varargOverride.chpl
@@ -13,6 +13,6 @@ class Child: Parent {
 }
 
 proc main {
-  var p: Parent = new borrowed Child();
+  var p: borrowed Parent = new borrowed Child();
   p.foo(1);
 }

--- a/test/functions/varargs/varargOverrideForwarding.chpl
+++ b/test/functions/varargs/varargOverrideForwarding.chpl
@@ -1,5 +1,5 @@
 class A {
-  forwarding var driver: B;
+  forwarding var driver: borrowed B;
 }
 
 class B {

--- a/test/functions/varargs/varargOverrideGeneric.chpl
+++ b/test/functions/varargs/varargOverrideGeneric.chpl
@@ -16,7 +16,7 @@ class DefaultLogger2: Logger {
   }
 }
 
-var Log: Logger;
+var Log: borrowed Logger;
 Log = new borrowed DefaultLogger();
 Log.Println("I want to print from my DefaultLogger");
 Log = new borrowed DefaultLogger2();

--- a/test/functions/vass/ref-intent-bug-1small.chpl
+++ b/test/functions/vass/ref-intent-bug-1small.chpl
@@ -1,5 +1,5 @@
 var aaa: [1..1] int;
-var bbb: DefaultRectangularArr(eltType=int, rank=1, idxType=int, stridable=false);
+var bbb: unmanaged DefaultRectangularArr(eltType=int, rank=1, idxType=int, stridable=false);
 
 proc storecache(ref cache) {
   on here {

--- a/test/functions/vass/ref-intent-bug-2big.chpl
+++ b/test/functions/vass/ref-intent-bug-2big.chpl
@@ -98,7 +98,7 @@ class LocalData {
 // A class for all node-local data.
 class GlobalData {
   const name: string;
-  var datas: [gridDist] LocalData;
+  var datas: [gridDist] unmanaged LocalData;
 }
 
 // constructor for GlobalData
@@ -106,7 +106,7 @@ proc GlobalData.init(nameArg: string) {
   name=nameArg;
   this.complete();
   coforall (inf, dat, loc) in zip(WI.infos, datas, gridLocales) do on loc {
-    dat = new LocalData(inf);
+    dat = new unmanaged LocalData(inf);
     // sanity checks
     assert(dat.locale == loc);
     assert(dat.linfo.locale == loc);
@@ -144,8 +144,8 @@ proc GlobalData.deinit() {
 }
 
 // Our two global arrays, to switch between.
-const WA = new GlobalData("WA"),
-      WB = new GlobalData("WB");
+const WA = new unmanaged GlobalData("WA"),
+      WB = new unmanaged GlobalData("WB");
 
 proc deinit() {
   delete WA;

--- a/test/functions/vass/subclass-to-ref-formal.chpl
+++ b/test/functions/vass/subclass-to-ref-formal.chpl
@@ -5,10 +5,10 @@
 class C    { }
 class D: C { }
 
-proc test(ref lhs: C) {}
+proc test(ref lhs: unmanaged C) {}
 
-var c: C;
-var d: D;
+var c: unmanaged C;
+var d: unmanaged D;
 
 test(c);
 test(d); // must be an error

--- a/test/functions/waynew/iterator8.chpl
+++ b/test/functions/waynew/iterator8.chpl
@@ -42,7 +42,7 @@ class C {
   var max: int;
 }
 
-iter simple4( c: C) : int {
+iter simple4( c: borrowed C) : int {
   var i : int;
   while i < c.max {
     yield i * 4;
@@ -50,6 +50,6 @@ iter simple4( c: C) : int {
   }
 }
 
-var c: C = new borrowed C();
+var c: borrowed C = new borrowed C();
 c.max = 10;
 writeln( "test4: ", simple4( c));

--- a/test/io/ferguson/read-class-inherited.chpl
+++ b/test/io/ferguson/read-class-inherited.chpl
@@ -7,8 +7,8 @@ class Child : Parent {
   var z: int;
 }
 
-var a: Child = new borrowed Child(x = 1, y = 2, z = 3);
-var b: Child = new borrowed Child(x = 10, y = 20, z = 30);
+var a: borrowed Child = new borrowed Child(x = 1, y = 2, z = 3);
+var b: borrowed Child = new borrowed Child(x = 10, y = 20, z = 30);
 
 writeln("a is ", a);
 writeln("b is ", b);

--- a/test/io/ferguson/read-class-inherited2.chpl
+++ b/test/io/ferguson/read-class-inherited2.chpl
@@ -10,8 +10,8 @@ class Child : Parent {
   var z: int;
 }
 
-var a: Child = new borrowed Child(x = 1, y = 2, z = 3);
-var b: Child = new borrowed Child(x = 10, y = 20, z = 30);
+var a: borrowed Child = new borrowed Child(x = 1, y = 2, z = 3);
+var b: borrowed Child = new borrowed Child(x = 10, y = 20, z = 30);
 
 writeln("a is ", a);
 writeln("b is ", b);

--- a/test/io/ferguson/read-class-reorder.chpl
+++ b/test/io/ferguson/read-class-reorder.chpl
@@ -13,7 +13,7 @@ class Child /*: Parent*/ {
   var z: int;
 }
 
-var a: Child = new borrowed Child(x = 1, y = 2, z = 3);
+var a: borrowed Child = new borrowed Child(x = 1, y = 2, z = 3);
 
 writeln("a is ", a);
 

--- a/test/io/ferguson/read-class-reorder2.chpl
+++ b/test/io/ferguson/read-class-reorder2.chpl
@@ -11,7 +11,7 @@ class Child : Parent {
   var y: int;
 }
 
-var a: Child = new borrowed Child(a = 1, b = 2, x = 3, y = 4);
+var a: borrowed Child = new borrowed Child(a = 1, b = 2, x = 3, y = 4);
 
 writeln("a is ", a);
 

--- a/test/io/ferguson/readThis/readclass.chpl
+++ b/test/io/ferguson/readThis/readclass.chpl
@@ -78,7 +78,7 @@ class subthing : mything {
   var r = f.reader();
 
   var b = new borrowed subthing(5,6);
-  var c:mything = b;
+  var c:borrowed mything = b;
 
   r.read(c);
   r.close();

--- a/test/io/ferguson/writebinaryclass.chpl
+++ b/test/io/ferguson/writebinaryclass.chpl
@@ -4,7 +4,7 @@ class R {
   var c:int;
   var d:int;
   var e:int;
-  proc equals(x:R) {
+  proc equals(x:borrowed R) {
     return a == x.a && b == x.b && c == x.c && d == x.d && e == x.e;
   }
 }

--- a/test/library/packages/LinearAlgebraJama/TestMatrix.chpl
+++ b/test/library/packages/LinearAlgebraJama/TestMatrix.chpl
@@ -15,7 +15,7 @@ Jama is public domain and developed by MathWorks and NIST
 **/
    proc main () {
 
-      var A,B,C,Z,O,I,R,S,X,SUB,M,T,SQ,DEF,SOL : Matrix;
+      var A,B,C,Z,O,I,R,S,X,SUB,M,T,SQ,DEF,SOL : unmanaged Matrix;
       var errorCount=0;
       var warningCount=0;
       var tmp, s : real;
@@ -35,7 +35,7 @@ Jama is public domain and developed by MathWorks and NIST
 
       var subavals : [1..2,1..3] real;
       for (ij, val) in zip(subavals.domain, [5.0,8.0,11.0, 6.0, 9.0, 12.0]) { subavals(ij) = val; }
-      SUB = new Matrix(subavals);
+      SUB = new unmanaged Matrix(subavals);
 
       var rvals : [1..3,1..4] real;
       for (ij, val) in zip(rvals.domain, rowwise) { rvals(ij) = val; }
@@ -89,7 +89,7 @@ Jama is public domain and developed by MathWorks and NIST
          random(int,int)
          identity(int)
 **/
-      A = new Matrix(columnwise,4); // ERROR WORKS!
+      A = new unmanaged Matrix(columnwise,4); // ERROR WORKS!
 
 /** 
       Array-like methods:
@@ -108,7 +108,7 @@ Jama is public domain and developed by MathWorks and NIST
 
       writeln("\nTesting array-like methods...\n");
 
-      S = new Matrix(columnwise,nonconformld);
+      S = new unmanaged Matrix(columnwise,nonconformld);
       R = S.random(A.getRowDimension(),A.getColumnDimension());
       A = R;
 
@@ -120,7 +120,7 @@ Jama is public domain and developed by MathWorks and NIST
 
       A = R.copy();
       A.minusEquals(R);
-      Z = new Matrix(A.getRowDimension(),A.getColumnDimension());
+      Z = new unmanaged Matrix(A.getRowDimension(),A.getColumnDimension());
 
       {
         A.minusEquals(S);
@@ -153,7 +153,7 @@ Jama is public domain and developed by MathWorks and NIST
       writeln("uminus... ","(-A + A != zeros)");
 
       A = R.copy();
-      O = new Matrix(A.getRowDimension(),A.getColumnDimension(),1.0);
+      O = new unmanaged Matrix(A.getRowDimension(),A.getColumnDimension(),1.0);
       C = A.arrayLeftDivide(R);
       S = A.arrayLeftDivide(S);
       writeln("arrayLeftDivide conformance check... ","nonconformance not raised");
@@ -232,8 +232,8 @@ Jama is public domain and developed by MathWorks and NIST
 **/
 
       writeln("\nTesting linear algebra methods...\n");
-      A = new Matrix(columnwise,3);
-      T = new Matrix(tvals);
+      A = new unmanaged Matrix(columnwise,3);
+      T = new unmanaged Matrix(tvals);
       writeln("transpose...","");
       T = A.transpose();
       writeln(A.transpose(),T);
@@ -251,13 +251,13 @@ Jama is public domain and developed by MathWorks and NIST
       check(A.trace(),sumofdiagonals);
       writeln("det()...","");
       check(A.getMatrix(1,A.getRowDimension(),1,A.getRowDimension()).det(),0.0);
-      SQ = new Matrix(square);
+      SQ = new unmanaged Matrix(square);
       writeln("times(double)...","");
       check(A.times(A.transpose()),SQ);
       writeln("times(double)...","");
       check(A.times(0.0),Z);
 
-      A = new Matrix(columnwise,4);
+      A = new unmanaged Matrix(columnwise,4);
       var QR = A.qr();
       R = QR.getR();
       writeln("QRDecomposition...","");
@@ -265,10 +265,10 @@ Jama is public domain and developed by MathWorks and NIST
       var SVD = A.svd();
       writeln("SingularValueDecomposition...","");
       check(A,SVD.getU().times(SVD.getS().times(SVD.getV().transpose())));
-      DEF = new Matrix(rankdef);
+      DEF = new unmanaged Matrix(rankdef);
       check(DEF.rank(),min(DEF.getRowDimension(),DEF.getColumnDimension())-1);
       writeln("rank()...","");
-      B = new Matrix(condmat);
+      B = new unmanaged Matrix(condmat);
       SVD = B.svd(); 
       var singularvalues = SVD.getSingularValues();
       check(B.cond(),singularvalues[1]/singularvalues[min(B.getRowDimension(),B.getColumnDimension())]);
@@ -283,13 +283,13 @@ Jama is public domain and developed by MathWorks and NIST
       check(A.times(X),identity(3,3));
       writeln("inverse()...","");
 
-      O = new Matrix(SUB.getRowDimension(),1,1.0);
-      SOL = new Matrix(sqSolution);
+      O = new unmanaged Matrix(SUB.getRowDimension(),1,1.0);
+      SOL = new unmanaged Matrix(sqSolution);
       SQ = SUB.getMatrix(1,SUB.getRowDimension(),1,SUB.getRowDimension());
 
       check(SQ.solve(SOL),O); 
       writeln("solve()...","");
-      A = new Matrix(pvals);
+      A = new unmanaged Matrix(pvals);
       var Chol = A.chol(); 
       var L = Chol.getL();
       check(A,L.times(L.transpose()));
@@ -299,7 +299,7 @@ Jama is public domain and developed by MathWorks and NIST
       var V = Eig.getV();
       check(A.times(V),V.times(D));
       writeln("EigenvalueDecomposition (symmetric)...","");
-      A = new Matrix(evals);
+      A = new unmanaged Matrix(evals);
       Eig = A.eig();
       D = Eig.getD();
       V = Eig.getV();
@@ -307,7 +307,7 @@ Jama is public domain and developed by MathWorks and NIST
       writeln("EigenvalueDecomposition (nonsymmetric)...","");
 
       writeln("\nTesting Eigenvalue; If this hangs, we've failed\n");
-      var bA = new Matrix(badeigs);
+      var bA = new unmanaged Matrix(badeigs);
       var bEig = bA.eig();
       writeln("EigenvalueDecomposition (hang)...","");
 
@@ -342,14 +342,14 @@ Jama is public domain and developed by MathWorks and NIST
    /** Check norm of difference of arrays. **/
 
    proc check(x:[?xDom] real, y:[?yDom] real) where xDom.rank == 2 {
-      var A = new Matrix(x);
-      var B = new Matrix(y);
+      var A = new unmanaged Matrix(x);
+      var B = new unmanaged Matrix(y);
       check(A,B);
    }
 
    /** Check norm of difference of Matrices. **/
 
-   proc check(X:Matrix, Y:Matrix) {
+   proc check(X:unmanaged Matrix, Y:unmanaged Matrix) {
       var eps = 2.0 ** -52.0;
       if ( (X.norm1() == 0.0) & (Y.norm1() < 10.0*eps)) { writeln("X is good"); return; }
       if ((Y.norm1() == 0.0) & (X.norm1() < 10.0*eps)) { writeln("Y is good"); return; }

--- a/test/library/packages/SharedObject/shared-nil-in-arg.chpl
+++ b/test/library/packages/SharedObject/shared-nil-in-arg.chpl
@@ -4,6 +4,6 @@ class C { }
 
 proc foo(in sc: Shared(C)) { }
 
-var sc = new Shared(nil:C);
+var sc = new Shared(nil:unmanaged C);
 
 foo(sc);

--- a/test/library/packages/ZMQ/not-serializable.chpl
+++ b/test/library/packages/ZMQ/not-serializable.chpl
@@ -9,7 +9,7 @@ class Foo {
   var a: int;
   var b: real;
   var c: string;
-  var d: Bar;
+  var d: borrowed Bar;
 }
 
 var foo = new borrowed Foo(42, 13.0, "hello", new borrowed Bar(29, "goodbye"));

--- a/test/library/standard/GMP/ferguson/gmp_random.chpl
+++ b/test/library/standard/GMP/ferguson/gmp_random.chpl
@@ -2,7 +2,7 @@ use GMP;
 
 config const printrandom = false;
 
-var r = new GMPRandom();
+var r = new owned GMPRandom();
 var b = new bigint();
 var n = new bigint(10);
 var x:uint = 0;

--- a/test/library/standard/GMP/ldelaney/gmp_random_2.chpl
+++ b/test/library/standard/GMP/ldelaney/gmp_random_2.chpl
@@ -6,10 +6,10 @@ config const printrandom = false;
 var a  = new bigint( 10);
 var b  = new bigint(128);
 
-var r1 = new GMPRandom();
-var r2 = new GMPRandom(true);
-var r3 = new GMPRandom(a, 10, 10);
-var r4 = new GMPRandom(8);
+var r1 = new owned GMPRandom();
+var r2 = new owned GMPRandom(true);
+var r3 = new owned GMPRandom(a, 10, 10);
+var r4 = new owned GMPRandom(8);
 
 r1.seed(a);
 r2.seed(10);
@@ -29,8 +29,3 @@ if printrandom then writeln(a);
 r4.urandomm(a, b);
 
 if printrandom then writeln(a);
-
-delete r1;
-delete r2;
-delete r3;
-delete r4;

--- a/test/library/standard/List/deitz/test_seq_class1.chpl
+++ b/test/library/standard/List/deitz/test_seq_class1.chpl
@@ -6,7 +6,7 @@ class C {
 }
 
 var c : unmanaged C = new unmanaged C(1, 2.3);
-var s : list(C) = makeList(c);
+var s : list(unmanaged C) = makeList(c);
 
 writeln(s);
 

--- a/test/library/standard/List/deitz/test_seq_class2.chpl
+++ b/test/library/standard/List/deitz/test_seq_class2.chpl
@@ -8,8 +8,8 @@ class C {
 var c1 : unmanaged C = new unmanaged C(1, 2.3);
 var c2 : unmanaged C = new unmanaged C(2, 3.4);
 
-var l1 : list(C) = makeList(c1, c2);
-var l2 : list(C) = makeList(c1, c2);
+var l1 : list(unmanaged C) = makeList(c1, c2);
+var l2 : list(unmanaged C) = makeList(c1, c2);
 
 writeln(l1);
 

--- a/test/library/standard/List/deitz/test_seq_class3.chpl
+++ b/test/library/standard/List/deitz/test_seq_class3.chpl
@@ -4,7 +4,7 @@ class C {
   var x: int;
 }
 
-var s: list(C);
+var s: list(unmanaged C);
 
 writeln(s);
 

--- a/test/library/standard/Random/ferguson/check-time-seed.chpl
+++ b/test/library/standard/Random/ferguson/check-time-seed.chpl
@@ -8,52 +8,44 @@ proc getRealRandoms(method:int) {
   var A:[1..100] real;
 
   if method == 0 {
-    var R = new RandomStream(real);
+    var R = new owned RandomStream(real);
 
     if debug then
       writeln("method 0, seed ", R.seed);
 
     for a in A do
       a = R.getNext();
-
-    delete R;
   }
 
   if method == 1 {
-    var R = makeRandomStream(eltType=real);
+    var R = new Owned(makeRandomStream(eltType=real));
 
     if debug then
       writeln("method ", method, ", seed ", R.seed);
 
     for a in A do
       a = R.getNext();
-
-    delete R;
   }
 
 
   if method == 2 {
-    var R = makeRandomStream(eltType=real, algorithm=RNG.PCG);
+    var R = new Owned(makeRandomStream(eltType=real, algorithm=RNG.PCG));
 
     if debug then
       writeln("method ", method, ", seed ", R.seed);
 
     for a in A do
       a = R.getNext();
-
-    delete R;
   }
 
   if method == 3 {
-    var R = new NPBRandomStream(real);
+    var R = new owned NPBRandomStream(real);
 
     if debug then
       writeln("method ", method, ", seed ", R.seed);
 
     for a in A do
       a = R.getNext();
-
-    delete R;
   }
 
   if method == 4 {
@@ -75,39 +67,33 @@ proc getUintRandoms(method:int) {
   var A:[1..100] uint;
 
   if method == 0 {
-    var R = new RandomStream(uint);
+    var R = new owned RandomStream(uint);
 
     if debug then
       writeln("method ", method, ", seed ", R.seed);
 
     for a in A do
       a = R.getNext();
-
-    delete R;
   }
 
   if method == 1 {
-    var R = makeRandomStream(eltType=uint);
+    var R = new Owned(makeRandomStream(eltType=uint));
 
     if debug then
       writeln("method ", method, ", seed ", R.seed);
 
     for a in A do
       a = R.getNext();
-
-    delete R;
   }
 
   if method == 2 {
-    var R = makeRandomStream(eltType=uint, algorithm=RNG.PCG);
+    var R = new Owned(makeRandomStream(eltType=uint, algorithm=RNG.PCG));
 
     if debug then
       writeln("method ", method, ", seed ", R.seed);
 
     for a in A do
       a = R.getNext();
-
-    delete R;
   }
 
   return A;

--- a/test/library/standard/Random/ferguson/pcg-rand-check.chpl
+++ b/test/library/standard/Random/ferguson/pcg-rand-check.chpl
@@ -215,7 +215,7 @@ writeln("Checking real(64)");
 
   fillRandom(expect, seed=seed, algorithm=RNG.PCG);
 
-  var rs = new RandomStream(seed = seed, eltType = real(64));
+  var rs = new owned RandomStream(seed = seed, eltType = real(64));
 
   for i in 1..6 {
     //writef("%xu\n", rs.RandomStreamPrivate_rng_states(1));
@@ -241,8 +241,6 @@ writeln("Checking real(64)");
     if verbose then writef("%n\n", got);
     assert( got == expect[i] );
   }
-
-  delete rs;
 }
 
 writeln("Checking random shuffle and permutation");

--- a/test/library/standard/Types/tup-primitive.chpl
+++ b/test/library/standard/Types/tup-primitive.chpl
@@ -23,7 +23,7 @@ class C {
 
 
 test(false, new R(10)); // false
-test(false, new C(10)); // false
+test(false, new borrowed C(10)); // false
 
 test(false, new R(10), 1); // false
 test(false, 1, new R(10), 1); // false


### PR DESCRIPTION
Running testing with --warn-unstable revealed some warnings.
This PR fixes about 60 more tests to not warn.
It fixes the LinearAlgebraJama package module additionally to get
the related tests to pass. There it just (trivially) uses unmanaged everywhere
and tidies up the whitespace.

For #9829.

Module changes reviewed by @ben-albrecht - thanks!
Trivial test changes not reviewed.

 -[x] full local testing
