### PR TITLE
Better line numbers in errors for fields with default values

### DIFF
--- a/compiler/include/flags_list.h
+++ b/compiler/include/flags_list.h
@@ -172,6 +172,8 @@ symbolFlag( FLAG_ITERATOR_WITH_ON , npr, "iterator with on" , "iterator which co
 // a pattern enabling user-supplied replacement of default behavior.
 symbolFlag( FLAG_LAST_RESORT , ypr, "last resort" , "overload of last resort in resolution" )
 
+// Tells resolution to use this function's line number even if that function
+// has FLAG_COMPILER_GENERATED.
 symbolFlag( FLAG_LINE_NUMBER_OK, npr, "lineno ok", ncm )
 
 symbolFlag( FLAG_LOCALE_MODEL_ALLOC , ypr, "locale model alloc" , "locale model specific alloc" )

--- a/compiler/include/flags_list.h
+++ b/compiler/include/flags_list.h
@@ -171,6 +171,9 @@ symbolFlag( FLAG_ITERATOR_WITH_ON , npr, "iterator with on" , "iterator which co
 // no functions without that flag are found. This usually is used to create
 // a pattern enabling user-supplied replacement of default behavior.
 symbolFlag( FLAG_LAST_RESORT , ypr, "last resort" , "overload of last resort in resolution" )
+
+symbolFlag( FLAG_LINE_NUMBER_OK, npr, "lineno ok", ncm )
+
 symbolFlag( FLAG_LOCALE_MODEL_ALLOC , ypr, "locale model alloc" , "locale model specific alloc" )
 symbolFlag( FLAG_LOCALE_MODEL_FREE , ypr, "locale model free" , "locale model specific free" )
 symbolFlag( FLAG_INC_RUNNING_TASK , ypr, "inc running task" , "running task incrementer" )

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -1539,20 +1539,14 @@ userCall(CallExpr* call) {
   // modules, back up the stack until a call is encountered whose target
   // function is neither.
 
-  CallExpr* cur = call;
-  int i = callStack.n-1;
-  while (cur != NULL && i >= 0 && shouldSkip(cur)) {
-    cur = callStack.v[i];
-    i -= 1;
+  if (shouldSkip(call)) {
+    for (int i = callStack.n-1; i >= 0; i--) {
+      CallExpr* cur = callStack.v[i];
+      if (!shouldSkip(cur))
+        return cur;
+    }
   }
-
-  // If we could not find a suitable call in the callStack, return the original
-  // call.
-  if (shouldSkip(cur)) {
-    return call;
-  } else {
-    return cur;
-  }
+  return call;
 }
 
 static void reissueCompilerWarning(const char* str, int offset) {

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -1546,7 +1546,13 @@ userCall(CallExpr* call) {
     i -= 1;
   }
 
-  return cur;
+  // If we could not find a suitable call in the callStack, return the original
+  // call.
+  if (shouldSkip(cur)) {
+    return call;
+  } else {
+    return cur;
+  }
 }
 
 static void reissueCompilerWarning(const char* str, int offset) {

--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -475,6 +475,8 @@ static DefaultExprFnEntry buildDefaultedActualFn(FnSymbol*  fn,
 
   wrapper->addFlag(FLAG_INLINE);
 
+  wrapper->addFlag(FLAG_LINE_NUMBER_OK);
+
   wrapper->retTag = RET_VALUE;
 
   if (fn->hasFlag(FLAG_METHOD)) {


### PR DESCRIPTION
Prior to this PR the compiler was reporting incorrect line numbers for errors involving the default value of a field. For example, in the following program the compiler would print the error at line ``5`` instead of the correct line (``3``).
```chpl
/*1*/ pragma "use default init"
/*2*/ record R {
/*3*/   var x : int = 2.0;
/*4*/ }
/*5*/ var r : R;
```

The problem was that the compiler would not use the line number for functions that create default-values, and would walk up the call stack until something more 'appropriate' was found. The compiler rejected the default-value function because it was 'compiler generated'.

This PR adds a new flag, FLAG_LINE_NUMBER_OK, which informs the compiler that the function's line number is OK regardless of whether it is compiler-generated. This new flag is now applied to all default-value functions.

This resolves a --force-initializers failure for the test ``classes/diten/error_default_field_init.chpl``.

Testing:
- [x] local + futures
- [x] gasnet