### PR TITLE
Update more tests to compile with --warn-unstable

### DIFF
--- a/test/release/examples/benchmarks/ssca2/SSCA2_Modules/SSCA2_RMAT_graph_generator.chpl
+++ b/test/release/examples/benchmarks/ssca2/SSCA2_Modules/SSCA2_RMAT_graph_generator.chpl
@@ -271,9 +271,9 @@ NPBRandomPrivate_iterate(real, edge_domain, seed, start=rndPos+4*delta)) {
     // Random Numbers return in the range [0.0, 1.0)
 
     var Rand_Gen = if REPRODUCIBLE_PROBLEMS then
-                     new NPBRandomStream (real, seed = 0556707007)
+                     new owned NPBRandomStream (real, seed = 0556707007)
                    else
-                     new NPBRandomStream (real);
+                     new owned NPBRandomStream (real);
 
     var   Noisy_a     : [edge_domain] real,
           Noisy_b     : [edge_domain] real,
@@ -336,7 +336,6 @@ NPBRandomPrivate_iterate(real, edge_domain, seed, start=rndPos+4*delta)) {
         permutation (v) <=> permutation (new_id);
       };
 
-    delete Rand_Gen;
   } // if newEG
 
     forall e in Edges do {

--- a/test/release/examples/benchmarks/ssca2/SSCA2_Modules/SSCA2_kernels.chpl
+++ b/test/release/examples/benchmarks/ssca2/SSCA2_Modules/SSCA2_kernels.chpl
@@ -535,8 +535,8 @@ module SSCA2_kernels
   class Level_Set {
     type Sparse_Vertex_List;
     var Members  : Sparse_Vertex_List;
-    var previous : Level_Set (Sparse_Vertex_List);
-    var next : Level_Set (Sparse_Vertex_List);
+    var previous : unmanaged Level_Set (Sparse_Vertex_List);
+    var next : unmanaged Level_Set (Sparse_Vertex_List);
   }
 
   //
@@ -572,7 +572,7 @@ module SSCA2_kernels
     const vertex_domain;
     var used  : atomic bool;
     var BCaux : [vertex_domain] taskPrivateArrayData(index(vertex_domain));
-    var Active_Level : [PrivateSpace] Level_Set (Sparse_Vertex_List);
+    var Active_Level : [PrivateSpace] unmanaged Level_Set (Sparse_Vertex_List);
   }
 
   // This is a simple class that hands out task private variables from the

--- a/test/studies/IMSuite/vertexColor/vertexColoring-serial.chpl
+++ b/test/studies/IMSuite/vertexColor/vertexColoring-serial.chpl
@@ -68,7 +68,7 @@ module vertexColoring {
     }
 
     /** Abstract node representation */
-    var nodeSet:[D] Node;
+    var nodeSet:[D] unmanaged Node;
     var again:[D] bool;
 
     /*
@@ -119,7 +119,7 @@ module vertexColoring {
     proc initialize() {
         forall (node, num_label, i) in zip(nodeSet, nlabel, D) {
             num_label = i;
-            node = new Node();
+            node = new unmanaged Node();
             node.parent = parent[i];
             var count = 0;
             for j in D {
@@ -218,7 +218,7 @@ module vertexColoring {
    proc six2three() {
        for k in 1..3 {
             var x = 6-k;
-            var randStream = new RandomStream(real, 3);
+            var randStream = new owned RandomStream(real, 3);
             var ncolor : int = randStream.getNext(): int;
             ncolor = ncolor%3;
             shiftDown();
@@ -247,8 +247,6 @@ module vertexColoring {
 
             if(loadValue != 0) then nval[i] = loadweight(nval[i]+i);
             }
-
-            delete randStream;
         }
 
     }

--- a/test/studies/hpcc/HPL/marybeth/Init.chpl
+++ b/test/studies/hpcc/HPL/marybeth/Init.chpl
@@ -183,10 +183,8 @@ proc init(A:[?D]) {
   var n = D.dim(1).length;
   ref Asquare = A(..,1..n);
   ref b = A(..,n+1);
-  var rstream = new RandomStream(real, seed=1234567891);
+  var rstream = new owned RandomStream(real, seed=1234567891);
 
   rstream.fillRandom(Asquare);
   rstream.fillRandom(b);
-
-  delete rstream;
 }

--- a/test/studies/hpcc/HPL/stonea/errors/writelnCausesError.chpl
+++ b/test/studies/hpcc/HPL/stonea/errors/writelnCausesError.chpl
@@ -317,7 +317,7 @@ proc test_permuteMatrix(rprt = true) : bool {
     // little too meta here?)
 
     param n = 10;
-    var rand = new RandomStream();
+    var rand = new owned RandomStream();
 
     // this n by n array is filled so each element is assigned to its
     // row number. This test will permute these elements, keeping a pivot
@@ -351,7 +351,7 @@ proc test_permuteMatrix(rprt = true) : bool {
 }
 
 proc test_panelSolve(rprt = true) : bool {
-    var rand = new RandomStream();
+    var rand = new owned RandomStream();
 
     var piv : [1..8] int = [i in 1..8] i;
     var A : [1..8, 1..9] real =
@@ -391,7 +391,7 @@ proc test_panelSolve(rprt = true) : bool {
 }
 
 proc test_updateBlockRow(rprt = true) : bool {
-    var rand = new RandomStream();
+    var rand = new owned RandomStream();
 
     // construct a matrix A = [X | Y], where X is an already LU-factorized
     // submatrix and Y is the block row we wish to update and test

--- a/test/studies/hpcc/HPL/stonea/serial/hplExample2.chpl
+++ b/test/studies/hpcc/HPL/stonea/serial/hplExample2.chpl
@@ -313,7 +313,7 @@ proc test_permuteMatrix(rprt = true) : bool {
     // little too meta here?)
 
     param n = 10;
-    var rand = new RandomStream(real);
+    var rand = new owned RandomStream(real);
 
     // this n by n array is filled so each element is assigned to its
     // row number. This test will permute these elements, keeping a pivot
@@ -331,8 +331,6 @@ proc test_permuteMatrix(rprt = true) : bool {
         piv[randRow1] <=> piv[randRow2];
     }
 
-    delete rand;
-
     // permute original version of A
     permuteMatrix(AOrig, piv);
 
@@ -349,7 +347,7 @@ proc test_permuteMatrix(rprt = true) : bool {
 }
 
 proc test_panelSolve(rprt = true) : bool {
-    var rand = new RandomStream(real);
+    var rand = new owned RandomStream(real);
 
     var piv : [1..8] int = [i in 1..8] i;
     var A : [1..8, 1..9] real =
@@ -357,8 +355,6 @@ proc test_panelSolve(rprt = true) : bool {
     var AOrig = A;
 
     var AOrig2 = A;
-
-    delete rand;
 
     // grab a panel and solve it
     param offset = 3;
@@ -391,7 +387,7 @@ proc test_panelSolve(rprt = true) : bool {
 }
 
 proc test_updateBlockRow(rprt = true) : bool {
-    var rand = new RandomStream(real);
+    var rand = new owned RandomStream(real);
 
     // construct a matrix A = [X | Y], where X is an already LU-factorized
     // submatrix and Y is the block row we wish to update and test
@@ -401,7 +397,7 @@ proc test_updateBlockRow(rprt = true) : bool {
     var A : [randomOffset..randomOffset+randomHeight-1,
              randomOffset..randomOffset+randomWidth-1] real;
     rand.fillRandom(A);
-    delete rand;
+
     var OrigA = A;
     
     // capture X and Y
@@ -471,13 +467,11 @@ proc test_LUFactorizeNorms(
 
 proc test_LUFactorize(rprt = true, seed = -1) : bool {
     // construct a matrix of random size with random values 
-    var rand = new RandomStream(real, seed);
+    var rand = new owned RandomStream(real, seed);
 
     var randomN : int = (rand.getNext() * 10):int + 1;
     var A : [1..randomN, 1..randomN+1] real;
     for idx in A.domain do A[idx] = rand.getNext() * 2.0 - 1.0;
-
-    delete rand;
 
     // save a copy
     var origA = A;

--- a/test/studies/hpcc/HPL/stonea/serial/hplExample4.chpl
+++ b/test/studies/hpcc/HPL/stonea/serial/hplExample4.chpl
@@ -316,10 +316,9 @@ proc test_LUFactorizeNorms(
 
 proc test_LUFactorize(rprt = true) : bool {
     // construct a 100x100 matrix filled with random values
-    var rand = new RandomStream(real, seed);
+    var rand = new owned RandomStream(real, seed);
     var A : [1..n, 1..n+1] real;
     for idx in A.domain do A[idx] = rand.getNext();
-    delete rand;
 
     // save a copy
     var origA = A;

--- a/test/studies/hpcc/PTRANS/jglewis/ptrans_2011-blkcyc.chpl
+++ b/test/studies/hpcc/PTRANS/jglewis/ptrans_2011-blkcyc.chpl
@@ -34,11 +34,11 @@ module HPCC_PTRANS {
     // declare distribution rules for matrix and transpose
 
     const Matrix_Block_Dist 
-      = new BlockCyclic ( startIdx=(1,1),
+      = new unmanaged BlockCyclic ( startIdx=(1,1),
                           blocksize=(row_block_size, col_block_size) );
 
     const Transpose_Block_Dist 
-      = new BlockCyclic ( startIdx=(1,1),
+      = new unmanaged BlockCyclic ( startIdx=(1,1),
                           blocksize=(row_block_size, col_block_size) );
 
     // declare domains (index sets) for matrix and transpose

--- a/test/studies/hpcc/PTRANS/jglewis/ptrans_2011.chpl
+++ b/test/studies/hpcc/PTRANS/jglewis/ptrans_2011.chpl
@@ -34,10 +34,10 @@ module HPCC_PTRANS {
     // declare distribution rules for matrix and transpose
 
     const Matrix_Block_Dist 
-      = new Block ( boundingBox = { 1..n_rows, 1..n_cols } );
+      = new unmanaged Block ( boundingBox = { 1..n_rows, 1..n_cols } );
 
     const Transpose_Block_Dist 
-      = new Block ( boundingBox = { 1..n_cols, 1..n_rows } );
+      = new unmanaged Block ( boundingBox = { 1..n_cols, 1..n_rows } );
 
     // declare domains (index sets) for matrix and transpose
 

--- a/test/studies/hpcc/RA/diten/buckets.chpl
+++ b/test/studies/hpcc/RA/diten/buckets.chpl
@@ -1,19 +1,19 @@
 class Update {
   var value: uint(64);
-  var forward: Update;
+  var forward: unmanaged Update;
 }
 
 class Bucket {
-  var updateList: Update;
+  var updateList: unmanaged Update;
   var numUpdates: int = 0;
 }
 
 class UpdateManager {
-  var updateList: Update;
+  var updateList: unmanaged Update;
 
   proc getUpdate() {
     if updateList == nil {
-      return new Update();
+      return new unmanaged Update();
     } else {
       var update = updateList;
       updateList = updateList.forward;
@@ -44,9 +44,9 @@ class Buckets {
 
   const numLocs: int = numLocales;
   var pendingUpdates = 0;
-  var BucketArray: [0..#numLocs] Bucket = [0..#numLocs] new Bucket(nil, 0);
-  var heap = new MaxHeap(numLocs);
-  var updateManager = new UpdateManager();
+  var BucketArray: [0..#numLocs] unmanaged Bucket = [0..#numLocs] new unmanaged Bucket(nil, 0);
+  var heap = new unmanaged MaxHeap(numLocs);
+  var updateManager = new unmanaged UpdateManager();
 
   proc insertUpdate(ran: uint(64), loc: int) {
     local {

--- a/test/studies/hpcc/RA/diten/maxHeap.chpl
+++ b/test/studies/hpcc/RA/diten/maxHeap.chpl
@@ -2,7 +2,7 @@ class MaxHeap {
 
   const maxSize: int;
   var size: int = 0;
-  var heap: [0..#maxSize] HeapNode;
+  var heap: [0..#maxSize] unmanaged HeapNode;
   var IndexToHeapNode: [0..#maxSize] int;
 
   class HeapNode {
@@ -53,7 +53,7 @@ class MaxHeap {
   }
 
   proc extractMax() {
-    var node: HeapNode;
+    var node: unmanaged HeapNode;
     var parent, child, ind, key: int;
     node = heap(0);
     ind = node.ind;
@@ -86,7 +86,7 @@ class MaxHeap {
   proc insert(ind: int, key: int) {
     var node: int = size;
     var par: int = parent(node);
-    var newNode = new HeapNode(ind, key);
+    var newNode = new unmanaged HeapNode(ind, key);
     size += 1;
     while node != 0 && key > heap(par).key {
       heap(node) = heap(par);

--- a/test/studies/hpcc/RA/diten/ra.chpl
+++ b/test/studies/hpcc/RA/diten/ra.chpl
@@ -89,7 +89,7 @@ var T: [TableSpace] elemType;
 
 config const maxLookahead = 1024;
 
-pragma "locale private" var myBuckets: Buckets;
+pragma "locale private" var myBuckets: unmanaged Buckets;
 
 //
 // The program entry point
@@ -105,7 +105,7 @@ proc main() {
   [i in TableSpace] T(i) = i;
   for loc in Locales {
     on loc {
-      myBuckets = new Buckets();
+      myBuckets = new unmanaged Buckets();
     }
   }
   const startTime = getCurrentTime();              // capture the start time

--- a/test/studies/hpcc/STREAMS/bradc/stream-block1d-dom.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-block1d-dom.chpl
@@ -61,7 +61,7 @@ proc printConfiguration() {
 
 
 proc initVectors(B, C) {
-  var randlist = new NPBRandomStream(eltType=real, seed=seed);
+  var randlist = new owned NPBRandomStream(eltType=real, seed=seed);
 
   randlist.fillRandom(B);
   randlist.fillRandom(C);
@@ -70,8 +70,6 @@ proc initVectors(B, C) {
     writeln("B is: ", B, "\n");
     writeln("C is: ", C, "\n");
   }
-
-  delete randlist;
 }
 
 

--- a/test/studies/hpcc/STREAMS/bradc/stream-block1d-local.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-block1d-local.chpl
@@ -61,7 +61,7 @@ proc printConfiguration() {
 
 
 proc initVectors(B, C) {
-  var randlist = new NPBRandomStream(eltType=real, seed=seed);
+  var randlist = new owned NPBRandomStream(eltType=real, seed=seed);
 
   randlist.fillRandom(B);
   randlist.fillRandom(C);
@@ -70,8 +70,6 @@ proc initVectors(B, C) {
     writeln("B is: ", B, "\n");
     writeln("C is: ", C, "\n");
   }
-
-  delete randlist;
 }
 
 

--- a/test/studies/hpcc/STREAMS/bradc/stream-block1d-promote.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-block1d-promote.chpl
@@ -52,7 +52,7 @@ proc printConfiguration() {
 
 
 proc initVectors(B, C) {
-  var randlist = new NPBRandomStream(eltType=real, seed=seed);
+  var randlist = new owned NPBRandomStream(eltType=real, seed=seed);
 
   randlist.fillRandom(B);
   randlist.fillRandom(C);
@@ -61,8 +61,6 @@ proc initVectors(B, C) {
     writeln("B is: ", B, "\n");
     writeln("C is: ", C, "\n");
   }
-
-  delete randlist;
 }
 
 

--- a/test/studies/hpcc/STREAMS/bradc/stream-block1d.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-block1d.chpl
@@ -71,7 +71,7 @@ proc printConfiguration() {
 
 
 proc initVectors(B, C) {
-  var randlist = new NPBRandomStream(eltType=real, seed=seed);
+  var randlist = new owned NPBRandomStream(eltType=real, seed=seed);
 
   randlist.fillRandom(B);
   randlist.fillRandom(C);
@@ -80,8 +80,6 @@ proc initVectors(B, C) {
     writeln("B is: ", B, "\n");
     writeln("C is: ", C, "\n");
   }
-
-  delete randlist;
 }
 
 

--- a/test/studies/hpcc/STREAMS/bradc/stream-block1dclass.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-block1dclass.chpl
@@ -24,7 +24,7 @@ config const printParams = true,
 proc main() {
   printConfiguration();
 
-  const ProblemDist = new Block1DDist(bbox={1..m}, targetLocs=Locales);
+  const ProblemDist = new unmanaged Block1DDist(bbox={1..m}, targetLocs=Locales);
 
   const ProblemSpace = ProblemDist.newDomain({1..m}, int(64));
 
@@ -69,13 +69,12 @@ proc initVectors(B, C) {
   // TODO: should write a fillRandom() implementation that does this
   coforall loc in B.dom.dist.targetLocs {
     on loc {
-      var randlist = new NPBRandomStream(eltType=real, seed=seed);
+      var randlist = new owned NPBRandomStream(eltType=real, seed=seed);
       // TODO: Need to clean this up to use more normal method names
       randlist.skipToNth(B.locArr(loc).locDom.low);
       randlist.fillRandom(B.locArr(loc).myElems);
       randlist.skipToNth(B.numElements + C.locArr(loc).locDom.low);
       randlist.fillRandom(C.locArr(loc).myElems);
-      delete randlist;
     }
   }
 

--- a/test/studies/hpcc/STREAMS/bradc/stream-block1dpar-arr.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-block1dpar-arr.chpl
@@ -24,7 +24,7 @@ config const printParams = true,
 proc main() {
   printConfiguration();
 
-  const ProblemDist = new Block1DDist(bbox={1..m}, targetLocales=Locales);
+  const ProblemDist = new unmanaged Block1DDist(bbox={1..m}, targetLocales=Locales);
 
   const ProblemSpace = ProblemDist.newDomain({1..m}, int(64));
 
@@ -82,13 +82,12 @@ proc initVectors(B, C) {
   // TODO: should write a fillRandom() implementation that does this
   coforall loc in B.dom.dist.targetLocDom {
     on B.dom.dist.targetLocs(loc) {
-      var randlist = new NPBRandomStream(eltType=real, seed=seed);
+      var randlist = new owned NPBRandomStream(eltType=real, seed=seed);
       // TODO: Need to clean this up to use more normal method names
       randlist.skipToNth(B.locArr(loc).locDom.low);
       randlist.fillRandom(B.locArr(loc).myElems);
       randlist.skipToNth(B.numElements + C.locArr(loc).locDom.low);
       randlist.fillRandom(C.locArr(loc).myElems);
-      delete randlist;
     }
   }
 

--- a/test/studies/hpcc/STREAMS/bradc/stream-block1dpar.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-block1dpar.chpl
@@ -24,7 +24,7 @@ config const printParams = true,
 proc main() {
   printConfiguration();
 
-  const ProblemDist = new Block1DDist(bbox={1..m}, targetLocales=Locales);
+  const ProblemDist = new unmanaged Block1DDist(bbox={1..m}, targetLocales=Locales);
 
   const ProblemSpace = ProblemDist.newDomain({1..m}, int(64));
 
@@ -88,13 +88,12 @@ proc initVectors(B, C) {
   // TODO: should write a fillRandom() implementation that does this
   coforall loc in B.dom.dist.targetLocDom {
     on B.dom.dist.targetLocs(loc) {
-      var randlist = new NPBRandomStream(eltType=real, seed=seed);
+      var randlist = new owned NPBRandomStream(eltType=real, seed=seed);
       // TODO: Need to clean this up to use more normal method names
       randlist.skipToNth(B.locArr(loc).locDom.low);
       randlist.fillRandom(B.locArr(loc).myElems);
       randlist.skipToNth(B.numElements + C.locArr(loc).locDom.low);
       randlist.fillRandom(C.locArr(loc).myElems);
-      delete randlist;
     }
   }
 

--- a/test/studies/hpcc/STREAMS/bradc/stream-fragmented-timecoforall.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-fragmented-timecoforall.chpl
@@ -64,7 +64,7 @@ proc printConfiguration() {
 
 
 proc initVectors(B, C, ProblemSpace, print) {
-  var randlist = new NPBRandomStream(eltType=real, seed=seed);
+  var randlist = new owned NPBRandomStream(eltType=real, seed=seed);
 
   randlist.skipToNth(B.domain.low);
   randlist.fillRandom(B);
@@ -75,8 +75,6 @@ proc initVectors(B, C, ProblemSpace, print) {
     writelnFragArray("B is: ", B, "\n");
     writelnFragArray("C is: ", C, "\n");
   }
-
-  delete randlist;
 }
 
 

--- a/test/studies/hpcc/STREAMS/bradc/stream-fragmented.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-fragmented.chpl
@@ -67,7 +67,7 @@ proc printConfiguration() {
 
 
 proc initVectors(B, C, ProblemSpace) {
-  var randlist = new NPBRandomStream(eltType=real, seed=seed);
+  var randlist = new owned NPBRandomStream(eltType=real, seed=seed);
 
   randlist.skipToNth(B.domain.low);
   randlist.fillRandom(B);
@@ -78,8 +78,6 @@ proc initVectors(B, C, ProblemSpace) {
     writelnFragArray("B is: ", B, "\n");
     writelnFragArray("C is: ", C, "\n");
   }
-
-  delete randlist;
 }
 
 

--- a/test/studies/hpcc/STREAMS/bradc/stream-slice.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-slice.chpl
@@ -52,7 +52,7 @@ proc printConfiguration() {
 
 
 proc initVectors(B, C) {
-  var randlist = new NPBRandomStream(eltType=real, seed=seed);
+  var randlist = new owned NPBRandomStream(eltType=real, seed=seed);
 
   randlist.fillRandom(B);
   randlist.fillRandom(C);
@@ -61,8 +61,6 @@ proc initVectors(B, C) {
     writeln("B is: ", B, "\n");
     writeln("C is: ", C, "\n");
   }
-
-  delete randlist;
 }
 
 

--- a/test/studies/hpcc/STREAMS/diten/stream-fragmented-local.chpl
+++ b/test/studies/hpcc/STREAMS/diten/stream-fragmented-local.chpl
@@ -67,7 +67,7 @@ proc printConfiguration() {
 
 
 proc initVectors(B, C, ProblemSpace) {
-  var randlist = new NPBRandomStream(eltType=real, seed=seed);
+  var randlist = new owned NPBRandomStream(eltType=real, seed=seed);
 
   randlist.skipToNth(B.domain.low);
   randlist.fillRandom(B);
@@ -78,8 +78,6 @@ proc initVectors(B, C, ProblemSpace) {
     writelnFragArray("B is: ", B, "\n");
     writelnFragArray("C is: ", C, "\n");
   }
-
-  delete randlist;
 }
 
 

--- a/test/studies/hpcc/STREAMS/stream-hpcc06.chpl
+++ b/test/studies/hpcc/STREAMS/stream-hpcc06.chpl
@@ -52,7 +52,7 @@ proc printConfiguration() {
 
 
 proc initVectors(B, C) {
-  var randlist = new NPBRandomStream(eltType=real, seed=seed);
+  var randlist = new owned NPBRandomStream(eltType=real, seed=seed);
 
   randlist.fillRandom(B);
   randlist.fillRandom(C);
@@ -61,8 +61,6 @@ proc initVectors(B, C) {
     writeln("B is: ", B, "\n");
     writeln("C is: ", C, "\n");
   }
-
-  delete randlist;
 }
 
 

--- a/test/studies/hpcc/STREAMS/stream-nopromote.chpl
+++ b/test/studies/hpcc/STREAMS/stream-nopromote.chpl
@@ -50,7 +50,7 @@ proc printConfiguration() {
 
 
 proc initVectors(B, C) {
-  var randlist = new NPBRandomStream(eltType=real, seed=seed);
+  var randlist = new owned NPBRandomStream(eltType=real, seed=seed);
 
   randlist.fillRandom(B);
   randlist.fillRandom(C);
@@ -59,8 +59,6 @@ proc initVectors(B, C) {
     writeln("B is: ", B, "\n");
     writeln("C is: ", C, "\n");
   }
-
-  delete randlist;
 }
 
 

--- a/test/studies/hpcc/common/bradc/BradsBlock1D.chpl
+++ b/test/studies/hpcc/common/bradc/BradsBlock1D.chpl
@@ -47,12 +47,12 @@ class Block1DDist {
   // with explicit typing of locid field in LocBlock1DDist class.  Particularly
   // since I'm passing in a value from 0.. rather than an actual index value.
   //
-  var locDist: [targetLocDom] LocBlock1DDist(glbIdxType, index(targetLocs.domain));
+  var locDist: [targetLocDom] unmanaged LocBlock1DDist(glbIdxType, index(targetLocs.domain));
 
   proc postinit() {
     for (loc, locid) in zip(targetLocs, 0..) do
       on loc do
-        locDist(loc) = new LocBlock1DDist(glbIdxType, locid, this);
+        locDist(loc) = new unmanaged LocBlock1DDist(glbIdxType, locid, _to_unmanaged(this));
   }
 
   proc deinit() {
@@ -69,7 +69,7 @@ class Block1DDist {
   proc newDomain(inds, type idxType = glbIdxType, type locIdxType = idxType) {
     // Note that I'm fixing the global and local index types to be the
     // same, but making this a generic function would fix this
-    return new Block1DDom(idxType, locIdxType, this, inds);
+    return new unmanaged Block1DDom(idxType, locIdxType, _to_unmanaged(this), inds);
   }
 
   //
@@ -138,7 +138,7 @@ class LocBlock1DDist {
   // classes well yet).
   //
   const locid;
-  const dist: Block1DDist(glbIdxType);
+  const dist: unmanaged Block1DDist(glbIdxType);
 
   //
   // This stores the piece of the global bounding box owned by
@@ -163,7 +163,7 @@ class Block1DDom {
   //
   // a pointer to the parent distribution
   //
-  const dist: Block1DDist(glbIdxType);
+  const dist: unmanaged Block1DDist(glbIdxType);
 
   //
   // a domain describing the complete domain
@@ -177,12 +177,12 @@ class Block1DDom {
   // TODO: would like this to be const and initialize in-place,
   // removing the initialize method
   //
-  var locDom: [dist.targetLocDom] LocBlock1DDom(glbIdxType, lclIdxType);
+  var locDom: [dist.targetLocDom] unmanaged LocBlock1DDom(glbIdxType, lclIdxType);
 
   proc postinit() {
     for loc in dist.targetLocs do
       on loc do
-        locDom(loc) = new LocBlock1DDom(glbIdxType, lclIdxType, this, dist.getChunk(whole));
+        locDom(loc) = new unmanaged LocBlock1DDom(glbIdxType, lclIdxType, _to_unmanaged(this), dist.getChunk(whole));
     if debugBradsBlock1D then
       [loc in dist.targetLocs] writeln(loc, " owns ", locDom(loc));
   }
@@ -217,7 +217,7 @@ class Block1DDom {
   // how to allocate a new array over this domain
   //
   proc newArray(type elemType) {
-    return new Block1DArr(glbIdxType, lclIdxType, elemType, this);
+    return new unmanaged Block1DArr(glbIdxType, lclIdxType, elemType, _to_unmanaged(this));
   }
 
   //
@@ -250,7 +250,7 @@ class LocBlock1DDom {
   //
   // a reference to the parent global domain class
   //
-  const wholeDom: Block1DDom(glbIdxType, lclIdxType);
+  const wholeDom: unmanaged Block1DDom(glbIdxType, lclIdxType);
 
   //
   // a local domain describing the indices owned by this locale
@@ -310,7 +310,7 @@ class Block1DArr {
   //
   // the global domain descriptor for this array
   //
-  var dom: Block1DDom(glbIdxType, lclIdxType);
+  var dom: unmanaged Block1DDom(glbIdxType, lclIdxType);
 
   //
   // an associative array of local array classes, indexed by locale
@@ -318,12 +318,12 @@ class Block1DArr {
   // TODO: would like this to be const and initialize in-place,
   // removing the postinit method
   //
-  var locArr: [dom.dist.targetLocDom] LocBlock1DArr(glbIdxType, lclIdxType, elemType);
+  var locArr: [dom.dist.targetLocDom] unmanaged LocBlock1DArr(glbIdxType, lclIdxType, elemType);
 
   proc postinit() {
     for loc in dom.dist.targetLocs do
       on loc do
-        locArr(loc) = new LocBlock1DArr(glbIdxType, lclIdxType, elemType, dom.locDom(loc));
+        locArr(loc) = new unmanaged LocBlock1DArr(glbIdxType, lclIdxType, elemType, dom.locDom(loc));
   }
 
   proc deinit() {
@@ -414,7 +414,7 @@ class LocBlock1DArr {
   //
   // a reference to the local domain class for this array and locale
   //
-  const locDom: LocBlock1DDom(glbIdxType, lclIdxType);
+  const locDom: unmanaged LocBlock1DDom(glbIdxType, lclIdxType);
 
   //
   // the block of local array data

--- a/test/studies/hpcc/common/bradc/unit/parRandom2-fill.chpl
+++ b/test/studies/hpcc/common/bradc/unit/parRandom2-fill.chpl
@@ -10,8 +10,8 @@ const ProblemSpace: domain(1, int(64)) dmapped(ProblemDist) = {1..n};
 var A: [ProblemSpace] real;
 var B: [ProblemSpace] real;
 
-var randStr1 = new NPBRandomStream(real, 314159265);
-var randStr2 = new NPBRandomStream(real, 314159265);
+var randStr1 = new owned NPBRandomStream(real, 314159265);
+var randStr2 = new owned NPBRandomStream(real, 314159265);
 
 randStr1.fillRandom(A);
 
@@ -24,6 +24,3 @@ for (i,a,b) in zip(ProblemSpace,A,B) {
   else
     writef("#%{#####} = %r\n", i, a);
 }
-
-delete randStr1;
-delete randStr2;

--- a/test/studies/kmeans/kmeans-blc.chpl
+++ b/test/studies/kmeans/kmeans-blc.chpl
@@ -122,7 +122,7 @@ class kmeans: ReduceScanOp {
   // the combine function takes two kmeans classes and combines
   // them
   //
-  proc combine(other: kmeans) {
+  proc combine(other: borrowed kmeans) {
     error += other.error;
     clusterSize += other.clusterSize;
     offset += other.offset;

--- a/test/studies/kmeans/kmeansonepassreduction-minchange.chpl
+++ b/test/studies/kmeans/kmeansonepassreduction-minchange.chpl
@@ -101,7 +101,7 @@ proc accumulate (da: eltType)
     }
 }
 
-proc combine(km: kmeansReduction(eltType))
+proc combine(km: borrowed kmeansReduction(eltType))
 {
     counts = counts + km.counts;
     error = error + km.error;

--- a/test/studies/kmeans/kmeansonepassreduction-mystery.chpl
+++ b/test/studies/kmeans/kmeansonepassreduction-mystery.chpl
@@ -110,7 +110,7 @@ proc accumulate (da: eltType)
     }
 }
 
-proc combine(km: kmeansReduction(eltType))
+proc combine(km: borrowed kmeansReduction(eltType))
 {
     RO.counts = RO.counts + km.RO.counts;
     RO.error = RO.error + km.RO.error;

--- a/test/studies/kmeans/kmeansonepassreduction-norecord2.chpl
+++ b/test/studies/kmeans/kmeansonepassreduction-norecord2.chpl
@@ -90,7 +90,7 @@ proc accumulate (da: eltType)
     }
 }
 
-proc combine(km: kmeansReduction(eltType))
+proc combine(km: borrowed kmeansReduction(eltType))
 {
     counts = counts + km.counts;
     error = error + km.error;

--- a/test/studies/kmeans/kmeansonepassreduction.chpl
+++ b/test/studies/kmeans/kmeansonepassreduction.chpl
@@ -110,7 +110,7 @@ proc accumulate (da: eltType)
     }
 }
 
-proc combine(km: kmeansReduction(eltType))
+proc combine(km: borrowed kmeansReduction(eltType))
 {
     RO.counts = RO.counts + km.RO.counts;
     RO.error = RO.error + km.RO.error;

--- a/test/studies/labelprop/Graph.chpl
+++ b/test/studies/labelprop/Graph.chpl
@@ -215,10 +215,10 @@ module Graph {
 
       // atomic version, tidier
       var r: triples.eltType;
-      var G = new Graph(nodeIdType = r.to.type,
-                        edgeWeightType = r.weight.type,
-                        vertices = vertices,
-                        initialLastAvail=0);
+      var G = new unmanaged Graph(nodeIdType = r.to.type,
+                                  edgeWeightType = r.weight.type,
+                                  vertices = vertices,
+                                  initialLastAvail=0);
       var next$: [vertices] atomic int;
 
       forall x in next$ {

--- a/test/studies/madness/aniruddha/madchap/FTree.chpl
+++ b/test/studies/madness/aniruddha/madchap/FTree.chpl
@@ -166,7 +166,7 @@ class LocTree {
     }
 
     //AGS: Provide constructor that can copy a tree instead of create-then-copy
-    proc copy(t: LocTree) {
+    proc copy(t: unmanaged LocTree) {
         nodes = t.nodes;
         // get around restriction of matching domains for assoc arrays
         forall i in coeffs.domain do coeffs(i) = t.coeffs(i);
@@ -176,7 +176,7 @@ class LocTree {
 class FTree {
     const order   : int;
     const coeffDom: domain(1);
-    const tree    : [LocaleSpace] LocTree;
+    const tree    : [LocaleSpace] unmanaged LocTree;
 
     proc init(order: int) {
         if order == 0 then
@@ -273,10 +273,10 @@ class FTree {
 }
 
 proc main() {
-    var f = new FTree(2);
+    var f = new unmanaged FTree(2);
 
     for (i, j) in {1..3, 2..4} {
-        const node = new Node(i, j); 
+        const node = new unmanaged Node(i, j); 
         f[node] = (i, j);
     }
 
@@ -286,7 +286,7 @@ proc main() {
             writeln(coeffs);
     }
     
-    var node = new Node(4, 5);
+    var node = new unmanaged Node(4, 5);
     writeln("\n\nf.has_coeffs((4, 5)) = ", f.has_coeffs(node));
     writeln("f.peek((4, 5)) = ", f.peek(node));
     writeln("f[(4, 5)] = ", f[node]);
@@ -294,7 +294,7 @@ proc main() {
     f.remove(node);
     delete node;
 
-    node = new Node(1, 2);
+    node = new unmanaged Node(1, 2);
     writeln("\n\nf.has_coeffs((1, 2)) = ", f.has_coeffs(node));
     writeln("f.peek((1, 2)) = ", f.peek(node));
     writeln("f[(1, 2)] = ", f[node]);

--- a/test/studies/madness/aniruddha/madchap/MRA.chpl
+++ b/test/studies/madness/aniruddha/madchap/MRA.chpl
@@ -28,7 +28,7 @@ config const debug   = false;
 class Function {
     const k            : int;  // use first k Legendre polynomials as the basis in each box
     const thresh       : real; // truncation threshold for small wavelet coefficients
-    var   f            : AFcn; // analytic f(x) to project into the numerical represntation
+    var   f            : unmanaged AFcn; // analytic f(x) to project into the numerical represntation
     const initial_level: int;  // initial level of refinement
     const max_level    : int;  // maximum level of refinement mostly as a sanity check
     const autorefine   : bool; // automatically refine during multiplication
@@ -59,7 +59,7 @@ class Function {
     const r0   : [dcDom] real;
     const rp   : [dcDom] real;
 
-    proc init(k:int=5, thresh:real=1e-5, f:AFcn=nil, initial_level:int=2,
+    proc init(k:int=5, thresh:real=1e-5, f:unmanaged AFcn=nil, initial_level:int=2,
               max_level:int=30, autorefine:bool=true, compressed:bool=false,
               sumC:unmanaged FTree=new unmanaged FTree(order=k),
               diffC:unmanaged FTree=new unmanaged FTree(order=k)) {
@@ -149,7 +149,7 @@ class Function {
      */
     proc skeletonCopy() {
         // Omit: f, compressed, sumC, diffC
-        return new Function(k=k, thresh=thresh, initial_level=initial_level,
+        return new unmanaged Function(k=k, thresh=thresh, initial_level=initial_level,
                 max_level=max_level, autorefine=autorefine);
     }
 
@@ -458,7 +458,7 @@ class Function {
         }
 
         // return this so operations can be chained
-        return this;
+        return _to_unmanaged(this);
     }
 
 
@@ -613,14 +613,14 @@ class Function {
 /*************************************************************************/
 
 
-proc +(F: Function, G: Function): Function {
+proc +(F: unmanaged Function, G: unmanaged Function): unmanaged Function {
     return F.add(G);
 }
 
-proc -(F: Function, G: Function): Function {
+proc -(F: unmanaged Function, G: unmanaged Function): unmanaged Function {
     return F.subtract(G);
 }
     
-proc *(F: Function, G: Function): Function {
+proc *(F: unmanaged Function, G: unmanaged Function): unmanaged Function {
     return F.multiply(G);
 }

--- a/test/studies/madness/aniruddha/madchap/mytests/par-compress/MRA.chpl
+++ b/test/studies/madness/aniruddha/madchap/mytests/par-compress/MRA.chpl
@@ -28,15 +28,15 @@ config const debug   = false;
 class Function {
     const k             = 5;    // use first k Legendre polynomials as the basis in each box
     const thresh        = 1e-5; // truncation threshold for small wavelet coefficients
-    const f: AFcn       = nil;  // analytic f(x) to project into the numerical represntation
+    const f: unmanaged AFcn       = nil;  // analytic f(x) to project into the numerical represntation
     const initial_level = 2;    // initial level of refinement
     const max_level     = 30;   // maximum level of refinement mostly as a sanity check
     var   autorefine    = true; // automatically refine during multiplication
     var   compressed    = false;// keep track of what basis we are in
 
     // Sum and Difference coefficients
-    var   sumC = new FTree(order=k);
-    var   diffC = new FTree(order=k);
+    var   sumC = new unmanaged FTree(order=k);
+    var   diffC = new unmanaged FTree(order=k);
 
     // FIXME: Ideally all of these matrices should be const as well but they
     //        can't be presently since they must be assigned in initialize()
@@ -137,7 +137,7 @@ class Function {
     /** Return a deep copy of this Function
      */
     proc copy() {
-        return new Function(k=k, thresh=thresh, f=f, initial_level=initial_level,
+        return new unmanaged Function(k=k, thresh=thresh, f=f, initial_level=initial_level,
                 max_level=max_level, autorefine=autorefine, compressed=compressed,
                 sumC=sumC.copy(), diffC=diffC.copy());
     }
@@ -147,7 +147,7 @@ class Function {
      */
     proc skeletonCopy() {
         // Omit: f, compressed, sumC, diffC
-        return new Function(k=k, thresh=thresh, initial_level=initial_level,
+        return new unmanaged Function(k=k, thresh=thresh, initial_level=initial_level,
                 max_level=max_level, autorefine=autorefine);
     }
 
@@ -621,14 +621,14 @@ class Function {
 /*************************************************************************/
 
 
-proc +(F: Function, G: Function): Function {
+proc +(F: unmanaged Function, G: unmanaged Function): unmanaged Function {
     return F.add(G);
 }
 
-proc -(F: Function, G: Function): Function {
+proc -(F: unmanaged Function, G: unmanaged Function): unmanaged Function {
     return F.subtract(G);
 }
     
-proc *(F: Function, G: Function): Function {
+proc *(F: unmanaged Function, G: unmanaged Function): unmanaged Function {
     return F.multiply(G);
 }

--- a/test/studies/madness/aniruddha/madchap/mytests/par-compress/test_compress.chpl
+++ b/test/studies/madness/aniruddha/madchap/mytests/par-compress/test_compress.chpl
@@ -6,12 +6,12 @@ proc main() {
 
     writeln("Mad Chapel -- Concurrent Compression Test\n");
 
-    var fcn  : [1..4] AFcn = ((new Fn_Test1():AFcn),  (new Fn_Test2():AFcn),  (new Fn_Test3():AFcn), (new Fn_Unity():AFcn));
-    var dfcn : [1..4] AFcn = ((new Fn_dTest1():AFcn), (new Fn_dTest2():AFcn), (new Fn_dTest3():AFcn), (new Fn_dUnity():AFcn));
+    var fcn  : [1..4] unmanaged AFcn = ((new unmanaged Fn_Test1():unmanaged AFcn),  (new unmanaged Fn_Test2():unmanaged AFcn),  (new unmanaged Fn_Test3():unmanaged AFcn), (new unmanaged Fn_Unity():unmanaged AFcn));
+    var dfcn : [1..4] unmanaged AFcn = ((new unmanaged Fn_dTest1():unmanaged AFcn), (new unmanaged Fn_dTest2():unmanaged AFcn), (new unmanaged Fn_dTest3():unmanaged AFcn), (new unmanaged Fn_dUnity():unmanaged AFcn));
 
     for i in fcn.domain {
         writeln("** Testing function ", i);
-        var F = new Function(k=5, thresh=1e-5, f=fcn[i]);
+        var F = new unmanaged Function(k=5, thresh=1e-5, f=fcn[i]);
         writeln("F", i, ".norm2() = ", F.norm2());
 
         writeln("Compressing F", i, " ...");

--- a/test/studies/madness/aniruddha/madchap/mytests/par-reconstruct/MRA.chpl
+++ b/test/studies/madness/aniruddha/madchap/mytests/par-reconstruct/MRA.chpl
@@ -28,15 +28,15 @@ config const debug   = false;
 class Function {
     const k             = 5;    // use first k Legendre polynomials as the basis in each box
     const thresh        = 1e-5; // truncation threshold for small wavelet coefficients
-    const f: AFcn       = nil;  // analytic f(x) to project into the numerical represntation
+    const f: unmanaged AFcn       = nil;  // analytic f(x) to project into the numerical represntation
     const initial_level = 2;    // initial level of refinement
     const max_level     = 30;   // maximum level of refinement mostly as a sanity check
     var   autorefine    = true; // automatically refine during multiplication
     var   compressed    = false;// keep track of what basis we are in
 
     // Sum and Difference coefficients
-    var   sumC = new FTree(order=k);
-    var   diffC = new FTree(order=k);
+    var   sumC = new unmanaged FTree(order=k);
+    var   diffC = new unmanaged FTree(order=k);
 
     // FIXME: Ideally all of these matrices should be const as well but they
     //        can't be presently since they must be assigned in postinit()
@@ -137,7 +137,7 @@ class Function {
     /** Return a deep copy of this Function
      */
     proc copy() {
-        return new Function(k=k, thresh=thresh, f=f, initial_level=initial_level,
+        return new unmanaged Function(k=k, thresh=thresh, f=f, initial_level=initial_level,
                 max_level=max_level, autorefine=autorefine, compressed=compressed,
                 sumC=sumC.copy(), diffC=diffC.copy());
     }
@@ -147,7 +147,7 @@ class Function {
      */
     proc skeletonCopy() {
         // Omit: f, compressed, sumC, diffC
-        return new Function(k=k, thresh=thresh, initial_level=initial_level,
+        return new unmanaged Function(k=k, thresh=thresh, initial_level=initial_level,
                 max_level=max_level, autorefine=autorefine);
     }
 
@@ -618,14 +618,14 @@ class Function {
 /*************************************************************************/
 
 
-proc +(F: Function, G: Function): Function {
+proc +(F: unmanaged Function, G: unmanaged Function): unmanaged Function {
     return F.add(G);
 }
 
-proc -(F: Function, G: Function): Function {
+proc -(F: unmanaged Function, G: unmanaged Function): unmanaged Function {
     return F.subtract(G);
 }
     
-proc *(F: Function, G: Function): Function {
+proc *(F: unmanaged Function, G: unmanaged Function): unmanaged Function {
     return F.multiply(G);
 }

--- a/test/studies/madness/aniruddha/madchap/mytests/par-refine/MRA.chpl
+++ b/test/studies/madness/aniruddha/madchap/mytests/par-refine/MRA.chpl
@@ -28,15 +28,15 @@ config const debug   = false;
 class Function {
     const k             = 5;    // use first k Legendre polynomials as the basis in each box
     const thresh        = 1e-5; // truncation threshold for small wavelet coefficients
-    const f: AFcn       = nil;  // analytic f(x) to project into the numerical represntation
+    const f: unmanaged AFcn       = nil;  // analytic f(x) to project into the numerical represntation
     const initial_level = 2;    // initial level of refinement
     const max_level     = 30;   // maximum level of refinement mostly as a sanity check
     var   autorefine    = true; // automatically refine during multiplication
     var   compressed    = false;// keep track of what basis we are in
 
     // Sum and Difference coefficients
-    var   sumC = new FTree(order=k);
-    var   diffC = new FTree(order=k);
+    var   sumC = new unmanaged FTree(order=k);
+    var   diffC = new unmanaged FTree(order=k);
 
     // FIXME: Ideally all of these matrices should be const as well but they
     //        can't be presently since they must be assigned in postinit()
@@ -135,7 +135,7 @@ class Function {
     /** Return a deep copy of this Function
      */
     proc copy() {
-        return new Function(k=k, thresh=thresh, f=f, initial_level=initial_level,
+        return new unmanaged Function(k=k, thresh=thresh, f=f, initial_level=initial_level,
                 max_level=max_level, autorefine=autorefine, compressed=compressed,
                 sumC=sumC.copy(), diffC=diffC.copy());
     }
@@ -145,7 +145,7 @@ class Function {
      */
     proc skeletonCopy() {
         // Omit: f, compressed, sumC, diffC
-        return new Function(k=k, thresh=thresh, initial_level=initial_level,
+        return new unmanaged Function(k=k, thresh=thresh, initial_level=initial_level,
                 max_level=max_level, autorefine=autorefine);
     }
 
@@ -621,14 +621,14 @@ class Function {
 /*************************************************************************/
 
 
-proc +(F: Function, G: Function): Function {
+proc +(F: unmanaged Function, G: unmanaged Function): unmanaged Function {
     return F.add(G);
 }
 
-proc -(F: Function, G: Function): Function {
+proc -(F: unmanaged Function, G: unmanaged Function): unmanaged Function {
     return F.subtract(G);
 }
     
-proc *(F: Function, G: Function): Function {
+proc *(F: unmanaged Function, G: unmanaged Function): unmanaged Function {
     return F.multiply(G);
 }

--- a/test/studies/madness/aniruddha/madchap/recordBug/FTree.chpl
+++ b/test/studies/madness/aniruddha/madchap/recordBug/FTree.chpl
@@ -187,7 +187,7 @@ class FTree {
     /** Return a copy of this FTree
      */
     proc copy() {
-        var t = new FTree(order);
+        var t = new unmanaged FTree(order);
         forall i in t.nodes.domain do t.nodes(i) = nodes(i);
         return t;
     }
@@ -253,7 +253,7 @@ proc main() {
             writeln(i, ": ", n);
     */
 
-    var f = new FTree(2);
+    var f = new unmanaged FTree(2);
     
     for (i, j) in {1..3, 2..4} do f[(i, j)] = (i, j);
   

--- a/test/studies/madness/aniruddha/madchap/recordBug/MRA.chpl
+++ b/test/studies/madness/aniruddha/madchap/recordBug/MRA.chpl
@@ -28,7 +28,7 @@ config const debug   = false;
 class Function {
     const k             = 5;    // use first k Legendre polynomials as the basis in each box
     const thresh        = 1e-5; // truncation threshold for small wavelet coefficients
-    const f: AFcn       = nil;  // analytic f(x) to project into the numerical represntation
+    const f: unmanaged AFcn       = nil;  // analytic f(x) to project into the numerical represntation
     const initial_level = 2;    // initial level of refinement
     const max_level     = 30;   // maximum level of refinement mostly as a sanity check
     var   autorefine    = true; // automatically refine during multiplication
@@ -134,7 +134,7 @@ class Function {
     /** Return a deep copy of this Function
      */
     proc copy() {
-        return new Function(k=k, thresh=thresh, f=f, initial_level=initial_level,
+        return new unmanaged Function(k=k, thresh=thresh, f=f, initial_level=initial_level,
                 max_level=max_level, autorefine=autorefine, compressed=compressed,
                 sumC=sumC.copy(), diffC=diffC.copy());
     }
@@ -144,7 +144,7 @@ class Function {
      */
     proc skeletonCopy() {
         // Omit: f, compressed, sumC, diffC
-        return new Function(k=k, thresh=thresh, initial_level=initial_level,
+        return new unmanaged Function(k=k, thresh=thresh, initial_level=initial_level,
                 max_level=max_level, autorefine=autorefine);
     }
 
@@ -602,14 +602,14 @@ class Function {
 /*************************************************************************/
 
 
-proc +(F: Function, G: Function): Function {
+proc +(F: unmanaged Function, G: unmanaged Function): unmanaged Function {
     return F.add(G);
 }
 
-proc -(F: Function, G: Function): Function {
+proc -(F: unmanaged Function, G: unmanaged Function): unmanaged Function {
     return F.subtract(G);
 }
     
-proc *(F: Function, G: Function): Function {
+proc *(F: unmanaged Function, G: unmanaged Function): unmanaged Function {
     return F.multiply(G);
 }

--- a/test/studies/madness/aniruddha/madchap/recordBug/test_likepy.chpl
+++ b/test/studies/madness/aniruddha/madchap/recordBug/test_likepy.chpl
@@ -2,16 +2,16 @@ use MRA;
 use MadAnalytics;
 
 class Sum: AFcn {
-    var f: AFcn;
-    var g: AFcn;
+    var f: unmanaged AFcn;
+    var g: unmanaged AFcn;
     proc this(x) {
         return f(x)+g(x);
     }
 }
 
 class Product: AFcn {
-    var f: AFcn;
-    var g: AFcn;
+    var f: unmanaged AFcn;
+    var g: unmanaged AFcn;
     proc this(x) {
         return f(x)*g(x);
     }

--- a/test/studies/madness/aniruddha/madchap/test_diff.chpl
+++ b/test/studies/madness/aniruddha/madchap/test_diff.chpl
@@ -6,12 +6,12 @@ proc main() {
 
     writeln("Mad Chapel -- Differentiation Test\n");
 
-    var fcn  : [1..4] AFcn = ((new Fn_Test1():AFcn),  (new Fn_Test2():AFcn),  (new Fn_Test3():AFcn), (new Fn_Unity():AFcn));
-    var dfcn : [1..4] AFcn = ((new Fn_dTest1():AFcn), (new Fn_dTest2():AFcn), (new Fn_dTest3():AFcn), (new Fn_dUnity():AFcn));
+    var fcn  : [1..4] unmanaged AFcn = ((new unmanaged Fn_Test1():unmanaged AFcn),  (new unmanaged Fn_Test2():unmanaged AFcn),  (new unmanaged Fn_Test3():unmanaged AFcn), (new unmanaged Fn_Unity():unmanaged AFcn));
+    var dfcn : [1..4] unmanaged AFcn = ((new unmanaged Fn_dTest1():unmanaged AFcn), (new unmanaged Fn_dTest2():unmanaged AFcn), (new unmanaged Fn_dTest3():unmanaged AFcn), (new unmanaged Fn_dUnity():unmanaged AFcn));
 
     for i in fcn.domain {
         writeln("** Testing function ", i);
-        var F = new Function(k=5, thresh=1e-5, f=fcn[i]);
+        var F = new unmanaged Function(k=5, thresh=1e-5, f=fcn[i]);
 
         writeln("F", i, ".norm2() = ", F.norm2());
 
@@ -36,7 +36,7 @@ proc main() {
 
         writeln("\nDifferentiating F", i, " ...");
         var dF = F.diff();
-        dF.f = dfcn[i]:AFcn; // Fudge it for the sake of evalNPT()
+        dF.f = dfcn[i]:unmanaged AFcn; // Fudge it for the sake of evalNPT()
         if verbose then dF.summarize();
 
         writeln("\nEvaluating dF", i, " on [0, 1]:");

--- a/test/studies/madness/aniruddha/madchap/test_likepy.chpl
+++ b/test/studies/madness/aniruddha/madchap/test_likepy.chpl
@@ -2,16 +2,16 @@ use MRA;
 use MadAnalytics;
 
 class Sum: AFcn {
-    var f: AFcn;
-    var g: AFcn;
+    var f: unmanaged AFcn;
+    var g: unmanaged AFcn;
     proc this(x) {
         return f(x)+g(x);
     }
 }
 
 class Product: AFcn {
-    var f: AFcn;
-    var g: AFcn;
+    var f: unmanaged AFcn;
+    var g: unmanaged AFcn;
     proc this(x) {
         return f(x)*g(x);
     }
@@ -30,14 +30,14 @@ proc main() {
     var k   = 5;       // order of wavelet
     var thresh = 1e-5; // truncation threshold
 
-    var tests  : [1..3] AFcn = (new Fn_Test1():AFcn,  new Fn_Test2():AFcn,  new Fn_Test3():AFcn);
-    var dtests : [1..3] AFcn = (new Fn_dTest1():AFcn, new Fn_dTest2():AFcn, new Fn_dTest3():AFcn);
+    var tests  : [1..3] unmanaged AFcn = (new unmanaged Fn_Test1():unmanaged AFcn,  new unmanaged Fn_Test2():unmanaged AFcn,  new unmanaged Fn_Test3():unmanaged AFcn);
+    var dtests : [1..3] unmanaged AFcn = (new unmanaged Fn_dTest1():unmanaged AFcn, new unmanaged Fn_dTest2():unmanaged AFcn, new unmanaged Fn_dTest3():unmanaged AFcn);
 
     var buf = "                           ";
 
     for (test, dtest) in zip(tests, dtests) {
         writeln("\n\n");
-        var f = new Function(k, thresh, test);
+        var f = new unmanaged Function(k, thresh, test);
         writeln("norm of function is ", f.norm2());
 
         f.evalNPT(npt);
@@ -68,12 +68,12 @@ proc main() {
     for tf2 in tests {
         var tf1 = tests[1];
         writeln("\n\n");
-        var f1 = new Function(k, thresh, tf1);
+        var f1 = new unmanaged Function(k, thresh, tf1);
         writeln("norm of f1 is ", f1.norm2());
-        var f2 = new Function(k, thresh, tf2);
+        var f2 = new unmanaged Function(k, thresh, tf2);
         writeln("norm of f2 is ", f2.norm2());
         var f3 = f1 + f2;
-        f3.f = new Sum(tf1, tf2):AFcn;
+        f3.f = new unmanaged Sum(tf1, tf2):unmanaged AFcn;
         writeln("norm of f3 = f1 + f2 is ", f3.norm2());
         f3.summarize();
 
@@ -91,12 +91,12 @@ proc main() {
     for tf2 in tests {
         var tf1 = tests[1];
         writeln("\n\n");
-        var f1 = new Function(k, thresh, tf1);
+        var f1 = new unmanaged Function(k, thresh, tf1);
         writeln("norm of f1 is ", f1.norm2());
-        var f2 = new Function(k, thresh, tf2);
+        var f2 = new unmanaged Function(k, thresh, tf2);
         writeln("norm of f2 is ", f2.norm2());
         var f3 = f1 * f2;
-        f3.f = new Product(tf1, tf2):AFcn;
+        f3.f = new unmanaged Product(tf1, tf2):unmanaged AFcn;
         writeln("norm of f3 = f1 * f2 is ", f3.norm2());
         f3.summarize();
 

--- a/test/studies/madness/aniruddha/madchap/test_mul.chpl
+++ b/test/studies/madness/aniruddha/madchap/test_mul.chpl
@@ -2,7 +2,7 @@ use MRA;
 use MadAnalytics;
 
 class Square: AFcn {
-    var f: AFcn;
+    var f: unmanaged AFcn;
     proc this(x: real): real {
         return f(x)**2;
     }
@@ -13,13 +13,13 @@ proc main() {
 
     writeln("Mad Chapel -- Multiplication Test\n");
 
-    var fcn  : [1..4] AFcn = (new Fn_Test1():AFcn,  new Fn_Test2():AFcn,  new Fn_Test3():AFcn, new Fn_Unity():AFcn);
+    var fcn  : [1..4] unmanaged AFcn = (new unmanaged Fn_Test1():unmanaged AFcn, new unmanaged Fn_Test2():unmanaged AFcn,  new unmanaged Fn_Test3():unmanaged AFcn, new unmanaged Fn_Unity():unmanaged AFcn);
 
     for i in fcn.domain {
         writeln("** Testing function ", i);
-        var F1 = new Function(k=5, thresh=1e-5, f=fcn[i], autorefine=false);
-        var F2 = new Function(k=5, thresh=1e-5, f=fcn[i]);
-        var G = new Function(k=5, thresh=1e-5, f=new Fn_Unity());
+        var F1 = new unmanaged Function(k=5, thresh=1e-5, f=fcn[i], autorefine=false);
+        var F2 = new unmanaged Function(k=5, thresh=1e-5, f=fcn[i]);
+        var G = new unmanaged Function(k=5, thresh=1e-5, f=new unmanaged Fn_Unity());
 
         writeln("\nMultiplying F", i, "*Unity ...");
         var H1 = F1 * G;
@@ -31,7 +31,7 @@ proc main() {
 
         writeln("\nMultiplying F",i,"*F",i," ...");
         var H2 = F1 * F1;
-        H2.f = new Square(fcn[i]):AFcn;
+        H2.f = new unmanaged Square(fcn[i]):unmanaged AFcn;
         delete H2.f;
         H2.f = fcn[i];
         if verbose then H2.summarize();

--- a/test/studies/madness/common/FTree.chpl
+++ b/test/studies/madness/common/FTree.chpl
@@ -170,7 +170,7 @@ class FTree {
 }
 
 proc main() {
-    var f = new FTree(2);
+    var f = new unmanaged FTree(2);
 
     for (i, j) in {0..2, 0..2} do f[i, j] = (i, j);
 

--- a/test/studies/madness/common/MRA.chpl
+++ b/test/studies/madness/common/MRA.chpl
@@ -26,7 +26,7 @@ config const debug   = false;
 class Function {
     const k             = 5;    // use first k Legendre polynomials as the basis in each box
     const thresh        = 1e-5; // truncation threshold for small wavelet coefficients
-    var   f: AFcn       = nil;  // analytic f(x) to project into the numerical represntation
+    var   f: unmanaged AFcn       = nil;  // analytic f(x) to project into the numerical represntation
     const initial_level = 2;    // initial level of refinement
     const max_level     = 30;   // maximum level of refinement mostly as a sanity check
     var   autorefine    = true; // automatically refine during multiplication
@@ -449,7 +449,7 @@ class Function {
         }
 
         // return this so operations can be chained
-        return this;
+        return _to_unmanaged(this);
     }
 
 
@@ -604,14 +604,14 @@ class Function {
 /*************************************************************************/
 
 
-proc +(F: Function, G: Function): Function {
+proc +(F: unmanaged Function, G: unmanaged Function): unmanaged Function {
     return F.add(G);
 }
 
-proc -(F: Function, G: Function): Function {
+proc -(F: unmanaged Function, G: unmanaged Function): unmanaged Function {
     return F.subtract(G);
 }
     
-proc *(F: Function, G: Function): Function {
+proc *(F: unmanaged Function, G: unmanaged Function): unmanaged Function {
     return F.multiply(G);
 }

--- a/test/studies/madness/common/MadAnalytics.chpl
+++ b/test/studies/madness/common/MadAnalytics.chpl
@@ -26,7 +26,7 @@ class Fn_dTest1: AFcn {
 
 /** superposition of multiple gaussians */
 class Fn_Test2: AFcn {
-    var g = new Fn_Test1();
+    var g = new unmanaged Fn_Test1();
 
     proc deinit() {
       delete g;
@@ -40,7 +40,7 @@ class Fn_Test2: AFcn {
 
 /** derivative of test2 */
 class Fn_dTest2: AFcn {
-    var g = new Fn_dTest1();
+    var g = new unmanaged Fn_dTest1();
 
     proc deinit() {
       delete g;

--- a/test/studies/madness/common/test_diff.chpl
+++ b/test/studies/madness/common/test_diff.chpl
@@ -6,12 +6,12 @@ proc main() {
 
     writeln("Mad Chapel -- Differentiation Test\n");
 
-    var fcn  : [1..4] AFcn = ((new Fn_Test1():AFcn),  (new Fn_Test2():AFcn),  (new Fn_Test3():AFcn), (new Fn_Unity():AFcn));
-    var dfcn : [1..4] AFcn = ((new Fn_dTest1():AFcn), (new Fn_dTest2():AFcn), (new Fn_dTest3():AFcn), (new Fn_dUnity():AFcn));
+    var fcn  : [1..4] unmanaged AFcn = ((new unmanaged Fn_Test1():unmanaged AFcn),  (new unmanaged Fn_Test2():unmanaged AFcn),  (new unmanaged Fn_Test3():unmanaged AFcn), (new unmanaged Fn_Unity():unmanaged AFcn));
+    var dfcn : [1..4] unmanaged AFcn = ((new unmanaged Fn_dTest1():unmanaged AFcn), (new unmanaged Fn_dTest2():unmanaged AFcn), (new unmanaged Fn_dTest3():unmanaged AFcn), (new unmanaged Fn_dUnity():unmanaged AFcn));
 
     for i in fcn.domain {
         writeln("** Testing function ", i);
-        var F = new Function(k=5, thresh=1e-5, f=fcn[i]);
+        var F = new unmanaged Function(k=5, thresh=1e-5, f=fcn[i]);
 
         writeln("F", i, ".norm2() = ", F.norm2());
 
@@ -36,7 +36,7 @@ proc main() {
 
         writeln("\nDifferentiating F", i, " ...");
         var dF = F.diff();
-        dF.f = dfcn[i]:AFcn; // Fudge it for the sake of evalNPT()
+        dF.f = dfcn[i]:unmanaged AFcn; // Fudge it for the sake of evalNPT()
         if verbose then dF.summarize();
 
         writeln("\nEvaluating dF", i, " on [0, 1]:");

--- a/test/studies/madness/common/test_gaxpy.chpl
+++ b/test/studies/madness/common/test_gaxpy.chpl
@@ -6,13 +6,13 @@ proc main() {
 
     writeln("Mad Chapel -- Gaxpy Test\n");
 
-    var fcn  : [1..3] AFcn = ((new Fn_Test1()):AFcn,  (new Fn_Test2()):AFcn,  (new Fn_Test3()):AFcn);
-    var dfcn : [1..3] AFcn = ((new Fn_dTest1()):AFcn, (new Fn_dTest2()):AFcn, (new Fn_dTest3()):AFcn);
+    var fcn  : [1..3] unmanaged AFcn = ((new unmanaged Fn_Test1()):unmanaged AFcn,  (new unmanaged Fn_Test2()):unmanaged AFcn,  (new unmanaged Fn_Test3()):unmanaged AFcn);
+    var dfcn : [1..3] unmanaged AFcn = ((new unmanaged Fn_dTest1()):unmanaged AFcn, (new unmanaged Fn_dTest2()):unmanaged AFcn, (new unmanaged Fn_dTest3()):unmanaged AFcn);
 
     for i in fcn.domain {
         writeln("** Testing function ", i);
-        var F = new Function(k=5, thresh=1e-5, f=fcn[i]);
-        var G = new Function(k=5, thresh=1e-5, f=fcn[i]);
+        var F = new unmanaged Function(k=5, thresh=1e-5, f=fcn[i]);
+        var G = new unmanaged Function(k=5, thresh=1e-5, f=fcn[i]);
 
         writeln("\nAdding F", i, " ...");
         var H = F + G;

--- a/test/studies/madness/common/test_likepy.chpl
+++ b/test/studies/madness/common/test_likepy.chpl
@@ -2,16 +2,16 @@ use MRA;
 use MadAnalytics;
 
 class Sum: AFcn {
-    var f: AFcn;
-    var g: AFcn;
+    var f: unmanaged AFcn;
+    var g: unmanaged AFcn;
     proc this(x) {
         return f(x)+g(x);
     }
 }
 
 class Product: AFcn {
-    var f: AFcn;
-    var g: AFcn;
+    var f: unmanaged AFcn;
+    var g: unmanaged AFcn;
     proc this(x) {
         return f(x)*g(x);
     }
@@ -30,14 +30,14 @@ proc main() {
     var k   = 5;       // order of wavelet
     var thresh = 1e-5; // truncation threshold
 
-    var tests  : [1..3] AFcn = (new Fn_Test1():AFcn,  new Fn_Test2():AFcn,  new Fn_Test3():AFcn);
-    var dtests : [1..3] AFcn = (new Fn_dTest1():AFcn, new Fn_dTest2():AFcn, new Fn_dTest3():AFcn);
+    var tests  : [1..3] unmanaged AFcn = (new unmanaged Fn_Test1():unmanaged AFcn,  new unmanaged Fn_Test2():unmanaged AFcn,  new unmanaged Fn_Test3():unmanaged AFcn);
+    var dtests : [1..3] unmanaged AFcn = (new unmanaged Fn_dTest1():unmanaged AFcn, new unmanaged Fn_dTest2():unmanaged AFcn, new unmanaged Fn_dTest3():unmanaged AFcn);
 
     var buf = "                           ";
 
     for (test, dtest) in zip(tests, dtests) {
         writeln("\n\n");
-        var f = new Function(k, thresh, test);
+        var f = new unmanaged Function(k, thresh, test);
         writeln("norm of function is ", f.norm2());
 
         f.evalNPT(npt);
@@ -67,12 +67,12 @@ proc main() {
     for tf2 in tests {
         var tf1 = tests[1];
         writeln("\n\n");
-        var f1 = new Function(k, thresh, tf1);
+        var f1 = new unmanaged Function(k, thresh, tf1);
         writeln("norm of f1 is ", f1.norm2());
-        var f2 = new Function(k, thresh, tf2);
+        var f2 = new unmanaged Function(k, thresh, tf2);
         writeln("norm of f2 is ", f2.norm2());
         var f3 = f1 + f2;
-        f3.f = new Sum(tf1, tf2):AFcn;
+        f3.f = new unmanaged Sum(tf1, tf2):unmanaged AFcn;
         writeln("norm of f3 = f1 + f2 is ", f3.norm2());
         f3.summarize();
 
@@ -89,12 +89,12 @@ proc main() {
     for tf2 in tests {
         var tf1 = tests[1];
         writeln("\n\n");
-        var f1 = new Function(k, thresh, tf1);
+        var f1 = new unmanaged Function(k, thresh, tf1);
         writeln("norm of f1 is ", f1.norm2());
-        var f2 = new Function(k, thresh, tf2);
+        var f2 = new unmanaged Function(k, thresh, tf2);
         writeln("norm of f2 is ", f2.norm2());
         var f3 = f1 * f2;
-        f3.f = new Product(tf1, tf2):AFcn;
+        f3.f = new unmanaged Product(tf1, tf2):unmanaged AFcn;
         writeln("norm of f3 = f1 * f2 is ", f3.norm2());
         f3.summarize();
 

--- a/test/studies/madness/common/test_mul.chpl
+++ b/test/studies/madness/common/test_mul.chpl
@@ -2,7 +2,7 @@ use MRA;
 use MadAnalytics;
 
 class Square: AFcn {
-    var f: AFcn;
+    var f: unmanaged AFcn;
     proc this(x: real): real {
         return f(x)**2;
     }
@@ -13,13 +13,13 @@ proc main() {
 
     writeln("Mad Chapel -- Multiplication Test\n");
 
-    var fcn  : [1..4] AFcn = (new Fn_Test1():AFcn,  new Fn_Test2():AFcn,  new Fn_Test3():AFcn, new Fn_Unity():AFcn);
+    var fcn  : [1..4] unmanaged AFcn = (new unmanaged Fn_Test1():unmanaged AFcn, new unmanaged Fn_Test2():unmanaged AFcn,  new unmanaged Fn_Test3():unmanaged AFcn, new unmanaged Fn_Unity():unmanaged AFcn);
 
     for i in fcn.domain {
         writeln("** Testing function ", i);
-        var F1 = new Function(k=5, thresh=1e-5, f=fcn[i], autorefine=false);
-        var F2 = new Function(k=5, thresh=1e-5, f=fcn[i]);
-        var G = new Function(k=5, thresh=1e-5, f=new Fn_Unity());
+        var F1 = new unmanaged Function(k=5, thresh=1e-5, f=fcn[i], autorefine=false);
+        var F2 = new unmanaged Function(k=5, thresh=1e-5, f=fcn[i]);
+        var G = new unmanaged Function(k=5, thresh=1e-5, f=new unmanaged Fn_Unity());
 
         writeln("\nMultiplying F", i, "*Unity ...");
         var H1 = F1 * G;
@@ -31,7 +31,7 @@ proc main() {
 
         writeln("\nMultiplying F",i,"*F",i," ...");
         var H2 = F1 * F1;
-        H2.f = new Square(fcn[i]):AFcn;
+        H2.f = new unmanaged Square(fcn[i]):unmanaged AFcn;
         delete H2.f;
         H2.f = fcn[i];
         if verbose then H2.summarize();

--- a/test/studies/madness/dinan/mad_chapel/FTree.chpl
+++ b/test/studies/madness/dinan/mad_chapel/FTree.chpl
@@ -132,7 +132,7 @@ class FTree {
 
 
 proc main() {
-    var f = new FTree(2);
+    var f = new unmanaged FTree(2);
 
     for (i, j) in {0..2, 0..2} do f[i, j] = (i, j);
 

--- a/test/studies/madness/dinan/mad_chapel/MRA.chpl
+++ b/test/studies/madness/dinan/mad_chapel/MRA.chpl
@@ -24,7 +24,7 @@ config const debug   = false;
 class Function {
     const k             = 5;    // use first k Legendre polynomials as the basis in each box
     const thresh        = 1e-5; // truncation threshold for small wavelet coefficients
-    var   f: AFcn       = nil;  // analytic f(x) to project into the numerical represntation
+    var   f: unmanaged AFcn       = nil;  // analytic f(x) to project into the numerical represntation
     const initial_level = 2;    // initial level of refinement
     const max_level     = 30;   // maximum level of refinement mostly as a sanity check
     var   autorefine    = true; // automatically refine during multiplication
@@ -437,7 +437,7 @@ class Function {
         gaxpy_iter();                                 // Do multi-wavelet coeffs
 
         // return this so operations can be chained
-        return this;
+        return _to_unmanaged(this);
     }
 
 
@@ -586,14 +586,14 @@ class Function {
 /*************************************************************************/
 
 
-proc +(F: Function, G: Function): Function {
+proc +(F: unmanaged Function, G: unmanaged Function): unmanaged Function {
     return F.add(G);
 }
 
-proc -(F: Function, G: Function): Function {
+proc -(F: unmanaged Function, G: unmanaged Function): unmanaged Function {
     return F.subtract(G);
 }
     
-proc *(F: Function, G: Function): Function {
+proc *(F: unmanaged Function, G: unmanaged Function): unmanaged Function {
     return F.multiply(G);
 }

--- a/test/studies/madness/dinan/mad_chapel/test_diff.chpl
+++ b/test/studies/madness/dinan/mad_chapel/test_diff.chpl
@@ -6,12 +6,12 @@ proc main() {
 
     writeln("Mad Chapel -- Differentiation Test\n");
 
-    var fcn  : [1..4] AFcn = (new Fn_Test1():AFcn,  new Fn_Test2():AFcn,  new Fn_Test3():AFcn, new Fn_Unity():AFcn);
-    var dfcn : [1..4] AFcn = (new Fn_dTest1():AFcn, new Fn_dTest2():AFcn, new Fn_dTest3():AFcn, new Fn_dUnity():AFcn);
+    var fcn  : [1..4] unmanaged AFcn = (new unmanaged Fn_Test1():unmanaged AFcn, new unmanaged Fn_Test2():unmanaged AFcn,  new unmanaged Fn_Test3():unmanaged AFcn, new unmanaged Fn_Unity():unmanaged AFcn);
+    var dfcn : [1..4] unmanaged AFcn = (new unmanaged Fn_dTest1():unmanaged AFcn, new unmanaged Fn_dTest2():unmanaged AFcn, new unmanaged Fn_dTest3():unmanaged AFcn, new unmanaged Fn_dUnity():unmanaged AFcn);
 
     for i in fcn.domain {
         writeln("** Testing function ", i);
-        var F = new Function(k=5, thresh=1e-5, f=fcn[i]);
+        var F = new unmanaged Function(k=5, thresh=1e-5, f=fcn[i]);
 
         writeln("F", i, ".norm2() = ", F.norm2());
 
@@ -36,7 +36,7 @@ proc main() {
 
         writeln("\nDifferentiating F", i, " ...");
         var dF = F.diff();
-        dF.f = dfcn[i]:AFcn; // Fudge it for the sake of evalNPT()
+        dF.f = dfcn[i]:unmanaged AFcn; // Fudge it for the sake of evalNPT()
         if verbose then dF.summarize();
 
         writeln("\nEvaluating dF", i, " on [0, 1]:");

--- a/test/studies/madness/dinan/mad_chapel/test_gaxpy.chpl
+++ b/test/studies/madness/dinan/mad_chapel/test_gaxpy.chpl
@@ -6,13 +6,13 @@ proc main() {
 
     writeln("Mad Chapel -- Gaxpy Test\n");
 
-    var fcn  : [1..3] AFcn = (new Fn_Test1():AFcn,  new Fn_Test2():AFcn,  new Fn_Test3():AFcn);
-    var dfcn : [1..3] AFcn = (new Fn_dTest1():AFcn, new Fn_dTest2():AFcn, new Fn_dTest3():AFcn);
+    var fcn  : [1..3] unmanaged AFcn = (new unmanaged Fn_Test1():unmanaged AFcn, new unmanaged Fn_Test2():unmanaged AFcn,  new unmanaged Fn_Test3():unmanaged AFcn);
+    var dfcn : [1..3] unmanaged AFcn = (new unmanaged Fn_dTest1():unmanaged AFcn, new unmanaged Fn_dTest2():unmanaged AFcn, new unmanaged Fn_dTest3():unmanaged AFcn);
 
     for i in fcn.domain {
         writeln("** Testing function ", i);
-        var F = new Function(k=5, thresh=1e-5, f=fcn[i]);
-        var G = new Function(k=5, thresh=1e-5, f=fcn[i]);
+        var F = new unmanaged Function(k=5, thresh=1e-5, f=fcn[i]);
+        var G = new unmanaged Function(k=5, thresh=1e-5, f=fcn[i]);
 
         writeln("\nAdding F", i, " ...");
         var H = F + G;

--- a/test/studies/madness/dinan/mad_chapel/test_likepy.chpl
+++ b/test/studies/madness/dinan/mad_chapel/test_likepy.chpl
@@ -2,16 +2,16 @@ use MRA;
 use MadAnalytics;
 
 class Sum: AFcn {
-    var f: AFcn;
-    var g: AFcn;
+    var f: unmanaged AFcn;
+    var g: unmanaged AFcn;
     proc this(x) {
         return f(x)+g(x);
     }
 }
 
 class Product: AFcn {
-    var f: AFcn;
-    var g: AFcn;
+    var f: unmanaged AFcn;
+    var g: unmanaged AFcn;
     proc this(x) {
         return f(x)*g(x);
     }
@@ -30,14 +30,14 @@ proc main() {
     var k   = 5;       // order of wavelet
     var thresh = 1e-5; // truncation threshold
 
-    var tests  : [1..3] AFcn = (new Fn_Test1():AFcn,  new Fn_Test2():AFcn,  new Fn_Test3():AFcn);
-    var dtests : [1..3] AFcn = (new Fn_dTest1():AFcn, new Fn_dTest2():AFcn, new Fn_dTest3():AFcn);
+    var tests  : [1..3] unmanaged AFcn = (new unmanaged Fn_Test1():unmanaged AFcn,  new unmanaged Fn_Test2():unmanaged AFcn,  new unmanaged Fn_Test3():unmanaged AFcn);
+    var dtests : [1..3] unmanaged AFcn = (new unmanaged Fn_dTest1():unmanaged AFcn, new unmanaged Fn_dTest2():unmanaged AFcn, new unmanaged Fn_dTest3():unmanaged AFcn);
 
     var buf = "                           ";
 
     for (test, dtest) in zip(tests, dtests) {
         writeln("\n\n");
-        var f = new Function(k, thresh, test);
+        var f = new unmanaged Function(k, thresh, test);
         writeln("norm of function is ", f.norm2());
 
         f.evalNPT(npt);
@@ -68,12 +68,12 @@ proc main() {
     for tf2 in tests {
         var tf1 = tests[1];
         writeln("\n\n");
-        var f1 = new Function(k, thresh, tf1);
+        var f1 = new unmanaged Function(k, thresh, tf1);
         writeln("norm of f1 is ", f1.norm2());
-        var f2 = new Function(k, thresh, tf2);
+        var f2 = new unmanaged Function(k, thresh, tf2);
         writeln("norm of f2 is ", f2.norm2());
         var f3 = f1 + f2;
-        f3.f = new Sum(tf1, tf2):AFcn;
+        f3.f = new unmanaged Sum(tf1, tf2):unmanaged AFcn;
         writeln("norm of f3 = f1 + f2 is ", f3.norm2());
         f3.summarize();
 
@@ -91,12 +91,12 @@ proc main() {
     for tf2 in tests {
         var tf1 = tests[1];
         writeln("\n\n");
-        var f1 = new Function(k, thresh, tf1);
+        var f1 = new unmanaged Function(k, thresh, tf1);
         writeln("norm of f1 is ", f1.norm2());
-        var f2 = new Function(k, thresh, tf2);
+        var f2 = new unmanaged Function(k, thresh, tf2);
         writeln("norm of f2 is ", f2.norm2());
         var f3 = f1 * f2;
-        f3.f = new Product(tf1, tf2):AFcn;
+        f3.f = new unmanaged Product(tf1, tf2):unmanaged AFcn;
         writeln("norm of f3 = f1 * f2 is ", f3.norm2());
         f3.summarize();
 

--- a/test/studies/madness/dinan/mad_chapel/test_mul.chpl
+++ b/test/studies/madness/dinan/mad_chapel/test_mul.chpl
@@ -2,7 +2,7 @@ use MRA;
 use MadAnalytics;
 
 class Square: AFcn {
-    var f: AFcn;
+    var f: unmanaged AFcn;
     proc this(x: real): real {
         return f(x)**2;
     }
@@ -31,7 +31,7 @@ proc main() {
 
         writeln("\nMultiplying F",i,"*F",i," ...");
         var H2 = F1 * F1;
-        H2.f = new Square(fcn[i]):AFcn;
+        H2.f = new unmanaged Square(fcn[i]):unmanaged AFcn;
         delete H2.f;
         H2.f = fcn[i];
         if verbose then H2.summarize();

--- a/test/studies/madness/dinan/mad_chapel/test_showboxes.chpl
+++ b/test/studies/madness/dinan/mad_chapel/test_showboxes.chpl
@@ -9,10 +9,10 @@ proc main() {
 
     writeln("Mad Chapel -- Show me the boxes\n");
 
-    var fcn  = new Fn_Test1();
-    var dfcn = new Fn_dTest1();
+    var fcn  = new unmanaged Fn_Test1();
+    var dfcn = new unmanaged Fn_dTest1();
 
-    var F = new Function(k=k, thresh=thresh, f=fcn);
+    var F = new unmanaged Function(k=k, thresh=thresh, f=fcn);
 
     writeln("F.norm2() = ", F.norm2());
     F.summarize();

--- a/test/studies/nqueens/nqueens-2-par.chpl
+++ b/test/studies/nqueens/nqueens-2-par.chpl
@@ -57,7 +57,7 @@ proc countSolutions(boardSize: int, showEachSoln: bool) {
 // If the column succeeds, we proceed to the next row
 // (or show the result if we have filled all rows).
 //
-proc tryQueenInNextRow(board: Board): void {
+proc tryQueenInNextRow(board: unmanaged Board): void {
   // iterate over the columns
   for col in 1..board.boardSize {
     // place the queen in that column if legal
@@ -120,12 +120,12 @@ class Board {
 // NB could not do this by writing our own constructor.
 //
 proc createBoard(boardSize:int) {
-  return new Board(boardSize = boardSize);
+  return new unmanaged Board(boardSize = boardSize);
 }
 
 // Return a (newly-created) clone of this board.
 //
-proc Board.clone(taskNumArg: int): Board {
+proc Board.clone(taskNumArg: int): unmanaged Board {
 
   // Linguistic remark: this code looks funny, but it does the following.
   // It invokes Board's default constructor (since we have not defined any
@@ -138,10 +138,10 @@ proc Board.clone(taskNumArg: int): Board {
   // rather than to this.taskNum. So we give the argument a (slightly)
   // different name to make our intentions (slightly) clear.
   //
-  return new Board(boardSize  = boardSize,
-                   queencol   = queencol,
-                   lastfilled = lastfilled,
-                   taskNum    = taskNumArg);
+  return new unmanaged Board(boardSize  = boardSize,
+                             queencol   = queencol,
+                             lastfilled = lastfilled,
+                             taskNum    = taskNumArg);
 }
 
 // If placing a queen at (lastfilled+1,col) is legal, do so and return true.

--- a/test/studies/nqueens/nqueens-2-seq.chpl
+++ b/test/studies/nqueens/nqueens-2-seq.chpl
@@ -48,7 +48,7 @@ proc countSolutions(boardSize: int, showEachSoln: bool) {
 // If the column succeeds, we proceed to the next row
 // (or show the result if we have filled all rows).
 //
-proc tryQueenInNextRow(board: Board): void {
+proc tryQueenInNextRow(board: unmanaged Board): void {
   // iterate over the columns
   for col in 1..board.boardSize {
     // place the queen in that column if legal
@@ -96,7 +96,7 @@ class Board {
 // NB could not do this by writing our own constructor.
 //
 proc createBoard(boardSize:int) {
-  return new Board(boardSize = boardSize);
+  return new unmanaged Board(boardSize = boardSize);
 }
 
 // If placing a queen at (lastfilled+1,col) is legal, do so and return true.

--- a/test/studies/nqueens/nqueens-par.chpl
+++ b/test/studies/nqueens/nqueens-par.chpl
@@ -35,7 +35,7 @@ class Board {
 // NB could not do this by writing our own constructor.
 //
 proc createBoard(boardSize:int) {
-  return new Board(boardSize = boardSize);
+  return new unmanaged Board(boardSize = boardSize);
 }
 
 //
@@ -87,7 +87,7 @@ proc Board.removeLast(row: int, col: int): void {
 // Public interface.
 // Return a (newly-created) clone of this board.
 //
-proc Board.clone(taskNumArg: int): Board {
+proc Board.clone(taskNumArg: int): unmanaged Board {
 
   // Linguistic remark: this code looks funny, but it does the following.
   // It invokes Board's default constructor (since we have not defined any
@@ -100,10 +100,10 @@ proc Board.clone(taskNumArg: int): Board {
   // rather than to this.taskNum. So we give the argument a (slightly)
   // different name to make our intentions (slightly) clear.
   //
-  return new Board(boardSize  = boardSize,
-                   queenvec   = queenvec,
-                   lastfilled = lastfilled,
-                   taskNum    = taskNumArg);
+  return new unmanaged Board(boardSize  = boardSize,
+                             queenvec   = queenvec,
+                             lastfilled = lastfilled,
+                             taskNum    = taskNumArg);
 }
 
 //
@@ -192,7 +192,7 @@ config const parRow: int = 3;
 // If the column succeeds, we proceed to the next row
 // (or show the result if we have filled all rows).
 //
-proc tryQueenInNextRow(board: Board): void {
+proc tryQueenInNextRow(board: unmanaged Board): void {
   // the row we will be placing in
   var nextRow = board.lastfilled + 1;
 

--- a/test/studies/nqueens/nqueens-seq.chpl
+++ b/test/studies/nqueens/nqueens-seq.chpl
@@ -31,7 +31,7 @@ class Board {
 // NB could not do this by writing our own constructor.
 //
 proc createBoard(boardSize:int) {
-  return new Board(boardSize = boardSize);
+  return new unmanaged Board(boardSize = boardSize);
 }
 
 //
@@ -152,7 +152,7 @@ config var showEachSolution: bool = true;
 // If the column succeeds, we proceed to the next row
 // (or show the result if we have filled all rows).
 //
-proc tryQueenInNextRow(board: Board): void {
+proc tryQueenInNextRow(board: unmanaged Board): void {
   // the row we will be placing in
   var nextRow = board.lastfilled + 1;
 

--- a/test/studies/shootout/binary-trees/binary-trees_iter.chpl
+++ b/test/studies/shootout/binary-trees/binary-trees_iter.chpl
@@ -4,7 +4,7 @@
 config const n = 10;
 
 class Tree {
-  var left, right: Tree;
+  var left, right: unmanaged Tree;
 }
 
 proc main() {
@@ -17,7 +17,7 @@ proc main() {
   writeln("stretch tree of depth ",stretchDepth,"\t check: ",check);
 
   var results: [1..maxDepth, 1..2] int;
-  var longLivedTree : Tree = bottomUpTree(maxDepth);
+  var longLivedTree : unmanaged Tree = bottomUpTree(maxDepth);
 
   forall depth in minDepth..maxDepth by 2 {
     var iterations: int = 1 << (maxDepth - depth + minDepth);
@@ -41,8 +41,8 @@ proc main() {
   free_iter(longLivedTree);
 }
 
-proc bottomUpTree(depth: int): Tree {
-  var T = new Tree();
+proc bottomUpTree(depth: int): unmanaged Tree {
+  var T = new unmanaged Tree();
   if depth > 0 {
     T.left  = bottomUpTree(depth-1);
     T.right = bottomUpTree(depth-1);
@@ -50,14 +50,14 @@ proc bottomUpTree(depth: int): Tree {
   return T;
 }
 
-proc itemCheck(T: Tree): int{
+proc itemCheck(T: borrowed Tree): int{
   if (T.left==nil) then return 1;
   else return 1 + itemCheck(T.left) + itemCheck(T.right);
 }
 
 // Feel free to turn this into a parallel leader-follower
 // for additional testing goodness
-iter postorder(tree: Tree): Tree {
+iter postorder(tree: unmanaged Tree): unmanaged Tree {
   if tree != nil {
     for child in postorder(tree.left) do yield child;
     for child in postorder(tree.right) do yield child;
@@ -65,6 +65,6 @@ iter postorder(tree: Tree): Tree {
   }
 }
 
-proc free_iter(T: Tree) {
+proc free_iter(T: unmanaged Tree) {
   for node in postorder(T) { delete node; }
 }

--- a/test/studies/shootout/binary-trees/binarytrees-blc.chpl
+++ b/test/studies/shootout/binary-trees/binarytrees-blc.chpl
@@ -20,17 +20,17 @@ proc main() {
   //
   // Create the "stretch" tree, checksum it, print its stats, and free it.
   //
-  const strTree = new Tree(strDepth);
+  const strTree = new unmanaged Tree(strDepth);
   writeln("stretch tree of depth ", strDepth, "\t check: ", strTree.sum());
   delete strTree;
 
   //
   // Build the long-lived tree.
   //
-  var llTree: Tree;
+  var llTree: unmanaged Tree;
 
   cobegin with (ref llTree) {
-    llTree = new Tree(maxDepth);
+    llTree = new unmanaged Tree(maxDepth);
 
     {
       //
@@ -43,7 +43,7 @@ proc main() {
         var sum = 0;
 
         for i in 1..iterations {
-          const t = new Tree(depth);
+          const t = new unmanaged Tree(depth);
           sum += t.sum();
           delete t;
         }
@@ -71,15 +71,15 @@ proc main() {
 // A simple balanced tree node class
 //
 class Tree {
-  var left, right: Tree;
+  var left, right: unmanaged Tree;
 
   //
   // A Tree-building initializer
   //
   proc init(depth) {
     if depth > 0 {
-      left  = new Tree(depth-1);
-      right = new Tree(depth-1);
+      left  = new unmanaged Tree(depth-1);
+      right = new unmanaged Tree(depth-1);
     }
   }
 

--- a/test/studies/shootout/binary-trees/binarytrees-freeWhileAdding-exp.chpl
+++ b/test/studies/shootout/binary-trees/binarytrees-freeWhileAdding-exp.chpl
@@ -65,14 +65,14 @@ proc main() {
 // A simple balanced tree node class
 //
 class Tree {
-  const left, right: Tree;
+  const left, right: unmanaged Tree;
 
-  proc type build(depth): Tree {
+  proc type build(depth): unmanaged Tree {
     if depth <= 0 then
-      return new Tree();
+      return new unmanaged Tree();
     else
-      return new Tree(Tree.build(depth-1),
-                      Tree.build(depth-1));
+      return new unmanaged Tree(Tree.build(depth-1),
+                                Tree.build(depth-1));
   }
 
   //

--- a/test/studies/shootout/binary-trees/binarytrees-freeWhileAdding.chpl
+++ b/test/studies/shootout/binary-trees/binarytrees-freeWhileAdding.chpl
@@ -65,14 +65,14 @@ proc main() {
 // A simple balanced tree node class
 //
 class Tree {
-  const left, right: Tree;
+  const left, right: unmanaged Tree;
 
-  proc type build(depth): Tree {
+  proc type build(depth): unmanaged Tree {
     if depth <= 0 then
-      return new Tree();
+      return new unmanaged Tree();
     else
-      return new Tree(Tree.build(depth-1),
-                      Tree.build(depth-1));
+      return new unmanaged Tree(Tree.build(depth-1),
+                                Tree.build(depth-1));
   }
 
   //

--- a/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc-ideal.chpl
+++ b/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc-ideal.chpl
@@ -53,7 +53,7 @@ record Population {
   // construct the population in terms of an array of colors passed in
   //
   proc init(colors : [] Color) {
-    chameneos = new Chameneos(1..colors.size, colors);
+    chameneos = new unmanaged Chameneos(1..colors.size, colors);
   }
 
   //
@@ -61,7 +61,7 @@ record Population {
   // place, and then creating per-chameneos tasks to have meetings.
   //
   proc holdMeetings(numMeetings) {
-    const place = new MeetingPlace(numMeetings);
+    const place = new unmanaged MeetingPlace(numMeetings);
 
     coforall c in chameneos do           // create a task per chameneos
       c.haveMeetings(place, chameneos);

--- a/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc.chpl
+++ b/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc.chpl
@@ -53,7 +53,7 @@ record Population {
   // construct the population in terms of an array of colors passed in
   //
   proc init(colors: [] Color) {
-    chameneos = [i in colors.domain] new Chameneos(i, colors[i]);
+    chameneos = [i in colors.domain] new unmanaged Chameneos(i, colors[i]);
   }
 
   //
@@ -61,7 +61,7 @@ record Population {
   // place, and then creating per-chameneos tasks to have meetings.
   //
   proc holdMeetings(numMeetings) {
-    const place = new MeetingPlace(numMeetings);
+    const place = new unmanaged MeetingPlace(numMeetings);
 
     coforall c in chameneos do           // create a task per chameneos
       c.haveMeetings(place, chameneos);

--- a/test/studies/shootout/chameneos-redux/elliot/chameneosredux-ejr.chpl
+++ b/test/studies/shootout/chameneos-redux/elliot/chameneosredux-ejr.chpl
@@ -51,14 +51,14 @@ record Population {
   // a domain and array representing the chameneos in this population
   //
   const chamSpace: domain(1),
-        chameneos: [chamSpace] Chameneos;
+        chameneos: [chamSpace] unmanaged Chameneos;
 
   //
   // construct the population in terms of an array of colors passed in
   //
   proc init(colors: [] Color) {
     chamSpace = colors.domain;
-    chameneos = new Chameneos(1..colors.size, colors);
+    chameneos = new unmanaged Chameneos(1..colors.size, colors);
   }
 
   //
@@ -66,7 +66,7 @@ record Population {
   // place, and then creating per-chameneos tasks to have meetings.
   //
   proc holdMeetings(numMeetings) {
-    const place = new MeetingPlace(numMeetings);
+    const place = new unmanaged MeetingPlace(numMeetings);
 
     coforall c in chameneos do           // create a task per chameneos
       c.haveMeetings(place, chameneos);

--- a/test/studies/shootout/chameneos-redux/hannah/chameneos-redux-cas.chpl
+++ b/test/studies/shootout/chameneos-redux/hannah/chameneos-redux-cas.chpl
@@ -86,9 +86,9 @@ class Chameneos {
      with another Chameneos.  If it does, it will get the other's color and
      use this color and its own to compute the color both will have after the
      meeting has ended, setting both of their colors to this value. */
-  proc start(population : [] Chameneos, meetingPlace: MeetingPlace) {
+  proc start(population : [] unmanaged Chameneos, meetingPlace: unmanaged MeetingPlace) {
     var stateTemp : uint(32);
-    var peer : Chameneos;
+    var peer : unmanaged Chameneos;
     var peer_idx : uint(32);
     var xchg : uint(32);
     var is_same : int;
@@ -156,15 +156,15 @@ proc populate (size : int(32)) {
                             Color.yellow, Color.blue, Color.red, Color.yellow,
                             Color.red, Color.blue);
   const D : domain(1, int(32)) = {1..size};
-  var population : [D] Chameneos;
+  var population : [D] unmanaged Chameneos;
 
   if (size == 10) {
     for i in D {
-      population(i) = new Chameneos(i, colorsDefault10(i));
+      population(i) = new unmanaged Chameneos(i, colorsDefault10(i));
     }
   } else {
     for i in D {
-      population(i) = new Chameneos(i, ((i-1) % 3):Color);
+      population(i) = new unmanaged Chameneos(i, ((i-1) % 3):Color);
     }
   }
   return population;
@@ -175,7 +175,7 @@ proc populate (size : int(32)) {
    met another Chameneos, spells out the number of times it met with itself,
    then spells out the total number of times all the Chameneos met
    another Chameneos. */
-proc run(population : [] Chameneos, meetingPlace : MeetingPlace) {
+proc run(population : [] unmanaged Chameneos, meetingPlace : unmanaged MeetingPlace) {
   for i in population {
     write(" ", i.color);
   }
@@ -187,7 +187,7 @@ proc run(population : [] Chameneos, meetingPlace : MeetingPlace) {
   meetingPlace.reset();
 }
 
-proc runQuiet(population : [] Chameneos, meetingPlace : MeetingPlace) {
+proc runQuiet(population : [] unmanaged Chameneos, meetingPlace : unmanaged MeetingPlace) {
   coforall i in population {
     i.start(population, meetingPlace);
   }
@@ -210,7 +210,7 @@ proc runQuiet(population : [] Chameneos, meetingPlace : MeetingPlace) {
   writeln();
 }
 
-proc printInfo(population : [] Chameneos) {
+proc printInfo(population : [] unmanaged Chameneos) {
   for i in population {
     write(i.meetings);
     spellInt(i.meetingsWithSelf);
@@ -235,7 +235,7 @@ proc main() {
   } else  {
     printColorChanges();
 
-    const forest : MeetingPlace = new MeetingPlace();
+    const forest : unmanaged MeetingPlace = new unmanaged MeetingPlace();
 
     const population1 = populate(numChameneos1);
     const population2 = populate(numChameneos2);

--- a/test/studies/shootout/chameneos-redux/hannah/chameneos-redux-v1.chpl
+++ b/test/studies/shootout/chameneos-redux/hannah/chameneos-redux-v1.chpl
@@ -51,7 +51,7 @@ class MeetingPlace {
      otherwise returns the color of the chameneos who arrives 1st
      (denies meetings of 3+ chameneos) */
 
-  proc meet(chameneos : Chameneos) {
+  proc meet(chameneos : unmanaged Chameneos) {
     /* peek at spotsLeft$ */
     if (peek) {
       if (spotsLeft$.readXX() == 0) {
@@ -107,12 +107,12 @@ class Chameneos {
      with another Chameneos.  If it does, it will get the complement of the
      color of the Chameneos it met with, and change to the complement of that
      color. */
-  proc start(place : MeetingPlace) {
-    var meetingPlace : MeetingPlace = place;
+  proc start(place : unmanaged MeetingPlace) {
+    var meetingPlace : unmanaged MeetingPlace = place;
     var stop : bool = false;
     var otherColor : color;
     while (!stop) {
-      (stop, otherColor) = meetingPlace.meet(this);
+      (stop, otherColor) = meetingPlace.meet(_to_unmanaged(this));
       myColor = getComplement(myColor, otherColor);
     }
   }
@@ -138,15 +138,15 @@ proc populate (size : int) {
                             color.yellow, color.blue, color.red, color.yellow,
                             color.red, color.blue);
   const D : domain(1) = {1..size};
-  var population : [D] Chameneos;
+  var population : [D] unmanaged Chameneos;
 
   if (size == 10) {
     for i in D {
-      population(i) = new Chameneos(i, colorsDefault10(i));
+      population(i) = new unmanaged Chameneos(i, colorsDefault10(i));
     }
   } else {
     for i in D {
-      population(i) = new Chameneos(i, ((i-1) % 3):color);
+      population(i) = new unmanaged Chameneos(i, ((i-1) % 3):color);
     }
   }
   return population;
@@ -157,7 +157,7 @@ proc populate (size : int) {
    met another Chameneos, spells out the number of times it met with itself,
    then spells out the total number of times all the Chameneos met
    another Chameneos. */
-proc run(population : [] Chameneos, meetingPlace : MeetingPlace) {
+proc run(population : [] unmanaged Chameneos, meetingPlace : unmanaged MeetingPlace) {
   for i in population {
     write(" ", i.myColor);
   }
@@ -169,7 +169,7 @@ proc run(population : [] Chameneos, meetingPlace : MeetingPlace) {
   meetingPlace.reset();
 }
 
-proc runQuiet(population : [] Chameneos, meetingPlace : MeetingPlace) {
+proc runQuiet(population : [] unmanaged Chameneos, meetingPlace : unmanaged MeetingPlace) {
   coforall i in population {
     i.start(meetingPlace);
   }
@@ -180,7 +180,7 @@ proc runQuiet(population : [] Chameneos, meetingPlace : MeetingPlace) {
   printInfoQuiet(totalMeetings, totalMeetingsWithSelf);
 }
 
-proc printInfo(population : [] Chameneos) {
+proc printInfo(population : [] unmanaged Chameneos) {
   for i in population {
     write(i.meetings);
     spellInt(i.meetingsWithSelf);
@@ -224,7 +224,7 @@ proc main() {
 
     printColorChanges();
 
-    const forest : MeetingPlace = new MeetingPlace();
+    const forest : unmanaged MeetingPlace = new unmanaged MeetingPlace();
 
     const population1 = populate(numChameneos1);
     const population2 = populate(numChameneos2);

--- a/test/studies/shootout/chameneos-redux/hannah/chameneos-redux.chpl
+++ b/test/studies/shootout/chameneos-redux/hannah/chameneos-redux.chpl
@@ -25,7 +25,7 @@ config const verbose = false;
 
 class MeetingPlace {
   var spotsLeft$ : sync int;
-  var partner : Chameneos;
+  var partner : unmanaged Chameneos;
 
   /* constructor for MeetingPlace, sets the
      number of meetings to take place */
@@ -62,8 +62,8 @@ class Chameneos {
      with another Chameneos.  If it does, it will get the complement of the
      color of the Chameneos it met with, and change to the complement of that
      color. */
-  proc start(place : MeetingPlace) {
-    var meetingPlace : MeetingPlace = place;
+  proc start(place : unmanaged MeetingPlace) {
+    var meetingPlace : unmanaged MeetingPlace = place;
     var stop : bool = false;
     while (!stop) {
       stop = this.meet(place);
@@ -73,8 +73,8 @@ class Chameneos {
   /* meet, if called on by the chameneos who arrives 1st,
      returns the color of the chameneos who arrives 2nd,
      otherwise returns the color of the chameneos who arrives 1st */
-  proc meet(place : MeetingPlace) {
-    var partner : Chameneos;
+  proc meet(place : unmanaged MeetingPlace) {
+    var partner : unmanaged Chameneos;
     var spotsLeft = place.spotsLeft$;
 
     if (spotsLeft == 0) {
@@ -83,7 +83,7 @@ class Chameneos {
     }
 
     if (spotsLeft % 2 == 0) {
-      place.partner = this;
+      place.partner = _to_unmanaged(this);
       place.spotsLeft$ = spotsLeft - 1;
       meetingCompleted$;
     } else if (spotsLeft % 2 == 1) {
@@ -125,7 +125,7 @@ proc populate (size : int) {
                             Color.yellow, Color.blue, Color.red, Color.yellow,
                             Color.red, Color.blue);
   const D : domain(1) = {1..size};
-  var population : [D] Chameneos;
+  var population : [D] unmanaged Chameneos;
 
   if (size == 10) {
     for i in D {
@@ -144,7 +144,7 @@ proc populate (size : int) {
    another Chameneos, spells out the number of times it met with itself, then
    spells out the total number of times all the Chameneos met another
    Chameneos. */
-proc run(population : [] Chameneos, meetingPlace : MeetingPlace) {
+proc run(population : [] unmanaged Chameneos, meetingPlace : unmanaged MeetingPlace) {
   for i in population {
     write(" ", i.color);
   }
@@ -156,7 +156,7 @@ proc run(population : [] Chameneos, meetingPlace : MeetingPlace) {
   meetingPlace.reset();
 }
 
-proc runQuiet(population : [] Chameneos, meetingPlace : MeetingPlace) {
+proc runQuiet(population : [] unmanaged Chameneos, meetingPlace : unmanaged MeetingPlace) {
   coforall i in population {
     i.start(meetingPlace);
   }
@@ -167,7 +167,7 @@ proc runQuiet(population : [] Chameneos, meetingPlace : MeetingPlace) {
   printInfoQuiet(totalMeetings, totalMeetingsWithSelf);
 }
 
-proc printInfo(population : [] Chameneos) {
+proc printInfo(population : [] unmanaged Chameneos) {
   for i in population {
     write(i.meetings);
     spellInt(i.meetingsWithSelf);

--- a/test/studies/shootout/chameneos-redux/lydia/chameneos-redux-lydia.chpl
+++ b/test/studies/shootout/chameneos-redux/lydia/chameneos-redux-lydia.chpl
@@ -86,7 +86,7 @@ class Chameneos {
      with another Chameneos.  If it does, it will get the other's color and
      use this color and its own to compute the color both will have after the
      meeting has ended, setting both of their colors to this value. */
-  proc start(population : [] Chameneos, meetingPlace: MeetingPlace) {
+  proc start(population : [] unmanaged Chameneos, meetingPlace: unmanaged MeetingPlace) {
     var stateTemp, peer_idx, xchg : int;
 
     stateTemp = meetingPlace.state.read(memory_order_acquire);
@@ -119,8 +119,8 @@ class Chameneos {
 
   /* Given the id of its peer, finds and updates the data of its peer and
      itself */
-  proc runMeeting (population : [] Chameneos, peer_idx) {
-    var peer : Chameneos;
+  proc runMeeting (population : [] unmanaged Chameneos, peer_idx) {
+    var peer : unmanaged Chameneos;
     var newColor : Color;
     var is_same : int;
     if (id == peer_idx) {
@@ -179,15 +179,15 @@ proc populate (size) {
                             Color.yellow, Color.blue, Color.red, Color.yellow,
                             Color.red, Color.blue);
   const D : domain(1, int) = {1..size};
-  var population : [D] Chameneos;
+  var population : [D] unmanaged Chameneos;
 
   if (size == 10) {
     for i in D {
-      population(i) = new Chameneos(i, colorsDefault10(i));
+      population(i) = new unmanaged Chameneos(i, colorsDefault10(i));
     }
   } else {
     for i in D {
-      population(i) = new Chameneos(i, ((i-1) % numColors):Color);
+      population(i) = new unmanaged Chameneos(i, ((i-1) % numColors):Color);
     }
   }
   return population;
@@ -198,7 +198,7 @@ proc populate (size) {
    met another Chameneos, spells out the number of times it met with itself,
    then spells out the total number of times all the Chameneos met
    another Chameneos. */
-proc run(population : [] Chameneos, meetingPlace : MeetingPlace) {
+proc run(population : [] unmanaged Chameneos, meetingPlace : unmanaged MeetingPlace) {
   for i in population {
     write(" ", i.color);
   }
@@ -211,7 +211,7 @@ proc run(population : [] Chameneos, meetingPlace : MeetingPlace) {
   meetingPlace.reset();
 }
 
-proc printInfo(population : [] Chameneos) {
+proc printInfo(population : [] unmanaged Chameneos) {
   for i in population {
     write(i.meetings);
     spellInt(i.meetingsWithSelf);
@@ -236,7 +236,7 @@ proc main() {
   } else  {
     printColorChanges();
 
-    const forest : MeetingPlace = new MeetingPlace();
+    const forest : unmanaged MeetingPlace = new unmanaged MeetingPlace();
 
     const population1 = populate(numChameneos1);
     const population2 = populate(numChameneos2);
@@ -255,6 +255,6 @@ proc main() {
   }
 }
 
-proc destroyChameneos(ca: [] Chameneos) {
+proc destroyChameneos(ca: [] unmanaged Chameneos) {
   for c in ca do delete c;
 }

--- a/test/studies/shootout/chameneos-redux/lydia/chameneos-redux-waitFor.chpl
+++ b/test/studies/shootout/chameneos-redux/lydia/chameneos-redux-waitFor.chpl
@@ -82,7 +82,7 @@ class Chameneos {
      with another Chameneos.  If it does, it will get the other's color and
      use this color and its own to compute the color both will have after the
      meeting has ended, setting both of their colors to this value. */
-  proc start(population : [] Chameneos, meetingPlace: MeetingPlace) {
+  proc start(population : [] unmanaged Chameneos, meetingPlace: unmanaged MeetingPlace) {
     var stateTemp, peer_idx, xchg : int;
 
     stateTemp = meetingPlace.state.read(memory_order_acquire);
@@ -116,8 +116,8 @@ class Chameneos {
 
   /* Given the id of its peer, finds and updates the data of its peer and
      itself */
-  proc runMeeting (population : [] Chameneos, peer_idx) {
-    var peer : Chameneos;
+  proc runMeeting (population : [] unmanaged Chameneos, peer_idx) {
+    var peer : unmanaged Chameneos;
     var is_same : int;
     var newColor : Color;
     if (id == peer_idx) {
@@ -156,15 +156,15 @@ proc populate (size : int) {
                             Color.yellow, Color.blue, Color.red, Color.yellow,
                             Color.red, Color.blue);
   const D : domain(1, int) = {1..size};
-  var population : [D] Chameneos;
+  var population : [D] unmanaged Chameneos;
 
   if (size == 10) {
     for i in D {
-      population(i) = new Chameneos(i, colorsDefault10(i));
+      population(i) = new unmanaged Chameneos(i, colorsDefault10(i));
     }
   } else {
     for i in D {
-      population(i) = new Chameneos(i, ((i-1) % numColors):Color);
+      population(i) = new unmanaged Chameneos(i, ((i-1) % numColors):Color);
     }
   }
   return population;
@@ -175,7 +175,7 @@ proc populate (size : int) {
    met another Chameneos, spells out the number of times it met with itself,
    then spells out the total number of times all the Chameneos met
    another Chameneos. */
-proc run(population : [] Chameneos, meetingPlace : MeetingPlace) {
+proc run(population : [] unmanaged Chameneos, meetingPlace : unmanaged MeetingPlace) {
   for i in population {
     write(" ", i.color);
   }
@@ -188,7 +188,7 @@ proc run(population : [] Chameneos, meetingPlace : MeetingPlace) {
   meetingPlace.reset();
 }
 
-proc printInfo(population : [] Chameneos) {
+proc printInfo(population : [] unmanaged Chameneos) {
   for i in population {
     write(i.meetings);
     spellInt(i.meetingsWithSelf);
@@ -213,7 +213,7 @@ proc main() {
   } else  {
     printColorChanges();
 
-    const forest : MeetingPlace = new MeetingPlace();
+    const forest : unmanaged MeetingPlace = new unmanaged MeetingPlace();
 
     const population1 = populate(numChameneos1);
     const population2 = populate(numChameneos2);
@@ -231,6 +231,6 @@ proc main() {
   }
 }
 
-proc destroyChameneos(ca: [] Chameneos) {
+proc destroyChameneos(ca: [] unmanaged Chameneos) {
   for c in ca do delete c;
 }

--- a/test/studies/shootout/chameneos-redux/lydia/chameneos-redux-yield.chpl
+++ b/test/studies/shootout/chameneos-redux/lydia/chameneos-redux-yield.chpl
@@ -84,7 +84,7 @@ class Chameneos {
      with another Chameneos.  If it does, it will get the other's color and
      use this color and its own to compute the color both will have after the
      meeting has ended, setting both of their colors to this value. */
-  proc start(population : [] Chameneos, meetingPlace: MeetingPlace) {
+  proc start(population : [] unmanaged Chameneos, meetingPlace: unmanaged MeetingPlace) {
     var stateTemp, peer_idx, xchg: int;
 
     stateTemp = meetingPlace.state.read(memory_order_acquire);
@@ -120,8 +120,8 @@ class Chameneos {
 
   /* Given the id of its peer, finds and updates the data of its peer and
      itself */
-  proc runMeeting (population : [] Chameneos, peer_idx) {
-    var peer : Chameneos;
+  proc runMeeting (population : [] unmanaged Chameneos, peer_idx) {
+    var peer : unmanaged Chameneos;
     var is_same : int;
     var newColor : Color;
     if (id == peer_idx) {
@@ -160,15 +160,15 @@ proc populate (size : int) {
                             Color.yellow, Color.blue, Color.red, Color.yellow,
                             Color.red, Color.blue);
   const D : domain(1, int) = {1..size};
-  var population : [D] Chameneos;
+  var population : [D] unmanaged Chameneos;
 
   if (size == 10) {
     for i in D {
-      population(i) = new Chameneos(i, colorsDefault10(i));
+      population(i) = new unmanaged Chameneos(i, colorsDefault10(i));
     }
   } else {
     for i in D {
-      population(i) = new Chameneos(i, ((i-1) % numColors):Color);
+      population(i) = new unmanaged Chameneos(i, ((i-1) % numColors):Color);
     }
   }
   return population;
@@ -179,7 +179,7 @@ proc populate (size : int) {
    met another Chameneos, spells out the number of times it met with itself,
    then spells out the total number of times all the Chameneos met
    another Chameneos. */
-proc run(population : [] Chameneos, meetingPlace : MeetingPlace) {
+proc run(population : [] unmanaged Chameneos, meetingPlace : unmanaged MeetingPlace) {
   for i in population {
     write(" ", i.color);
   }
@@ -192,7 +192,7 @@ proc run(population : [] Chameneos, meetingPlace : MeetingPlace) {
   meetingPlace.reset();
 }
 
-proc printInfo(population : [] Chameneos) {
+proc printInfo(population : [] unmanaged Chameneos) {
   for i in population {
     write(i.meetings);
     spellInt(i.meetingsWithSelf);
@@ -217,7 +217,7 @@ proc main() {
   } else  {
     printColorChanges();
 
-    const forest : MeetingPlace = new MeetingPlace();
+    const forest : unmanaged MeetingPlace = new unmanaged MeetingPlace();
 
     const population1 = populate(numChameneos1);
     const population2 = populate(numChameneos2);
@@ -235,6 +235,6 @@ proc main() {
   }
 }
 
-proc destroyChameneos(ca: [] Chameneos) {
+proc destroyChameneos(ca: [] unmanaged Chameneos) {
   for c in ca do delete c;
 }

--- a/test/studies/shootout/fannkuch-redux/bharshbarg/fannkuch-redux-coforall.chpl
+++ b/test/studies/shootout/fannkuch-redux/bharshbarg/fannkuch-redux-coforall.chpl
@@ -22,8 +22,8 @@ var maxFlips, checkSums : [0..#NTASKS] int;
 
 var taskCount : atomic int;
 
-var Fanns : [ntasks] Fann;
-for f in Fanns do f = new Fann();
+var Fanns : [ntasks] unmanaged Fann;
+for f in Fanns do f = new unmanaged Fann();
 
 coforall i in ntasks {
   var task = taskCount.fetchAdd(1);

--- a/test/studies/shootout/fasta/caseyb/fasta.chpl
+++ b/test/studies/shootout/fasta/caseyb/fasta.chpl
@@ -25,28 +25,28 @@ var ALU : string = "GGCCGGGCGCGGTGGCTCACGCCTGTAATCCCAGCAC" +
                    "GCGACAGAGCGAGACTCCGTCTCAAAAA";
 
 //Sequences to be randomly generated (probability table)
-var IUB : [0..14] Freq;
-IUB[0] = new Freq('a', 0.27);
-IUB[1] = new Freq('c', 0.12);
-IUB[2] = new Freq('g', 0.12);
-IUB[3] = new Freq('t', 0.27);
-IUB[4] = new Freq('B', 0.02);
-IUB[5] = new Freq('D', 0.02);
-IUB[6] = new Freq('H', 0.02);
-IUB[7] = new Freq('K', 0.02);
-IUB[8] = new Freq('M', 0.02);
-IUB[9] = new Freq('N', 0.02);
-IUB[10] = new Freq('R', 0.02);
-IUB[11] = new Freq('S', 0.02);
-IUB[12] = new Freq('V', 0.02);
-IUB[13] = new Freq('W', 0.02);
-IUB[14] = new Freq('Y', 0.02);
+var IUB : [0..14] unmanaged Freq;
+IUB[0] = new unmanaged Freq('a', 0.27);
+IUB[1] = new unmanaged Freq('c', 0.12);
+IUB[2] = new unmanaged Freq('g', 0.12);
+IUB[3] = new unmanaged Freq('t', 0.27);
+IUB[4] = new unmanaged Freq('B', 0.02);
+IUB[5] = new unmanaged Freq('D', 0.02);
+IUB[6] = new unmanaged Freq('H', 0.02);
+IUB[7] = new unmanaged Freq('K', 0.02);
+IUB[8] = new unmanaged Freq('M', 0.02);
+IUB[9] = new unmanaged Freq('N', 0.02);
+IUB[10] = new unmanaged Freq('R', 0.02);
+IUB[11] = new unmanaged Freq('S', 0.02);
+IUB[12] = new unmanaged Freq('V', 0.02);
+IUB[13] = new unmanaged Freq('W', 0.02);
+IUB[14] = new unmanaged Freq('Y', 0.02);
 
-var HomoSapiens : [0..3] Freq;
-HomoSapiens[0] = new Freq('a', 0.3029549426680);
-HomoSapiens[1] = new Freq('c', 0.1979883004921);
-HomoSapiens[2] = new Freq('g', 0.1975473066391);
-HomoSapiens[3] = new Freq('t', 0.3015094502008);
+var HomoSapiens : [0..3] unmanaged Freq;
+HomoSapiens[0] = new unmanaged Freq('a', 0.3029549426680);
+HomoSapiens[1] = new unmanaged Freq('c', 0.1979883004921);
+HomoSapiens[2] = new unmanaged Freq('g', 0.1975473066391);
+HomoSapiens[3] = new unmanaged Freq('t', 0.3015094502008);
 
 // (Scan operation)
 proc sumAndScale(a :[?D]) {
@@ -72,8 +72,8 @@ class Random {
   }
 }
 
-var lookup : [0..LOOKUP_SIZE-1] Freq;
-var random = new Random();
+var lookup : [0..LOOKUP_SIZE-1] unmanaged Freq;
+var random = new unmanaged Random();
 
 // Make lookup table for random sequence generation
 proc makeLookup(a :[?D]) {

--- a/test/studies/shootout/fasta/kbrady/fasta-enum.chpl
+++ b/test/studies/shootout/fasta/kbrady/fasta-enum.chpl
@@ -103,7 +103,7 @@ proc makeLookup(a) {
 }
 
 // Add a line of random sequence
-var random = new Random();
+var random = new unmanaged Random();
 var line_buff : [0..LINE_LENGTH] int(8);
 proc addLine(bytes: int) {
   for (i, r) in random.get(bytes) {

--- a/test/studies/shootout/fasta/kbrady/fasta-lines.chpl
+++ b/test/studies/shootout/fasta/kbrady/fasta-lines.chpl
@@ -29,28 +29,28 @@ var ALU : string = "GGCCGGGCGCGGTGGCTCACGCCTGTAATCCCAGCAC" +
                    "GCGACAGAGCGAGACTCCGTCTCAAAAA";
 
 //Sequences to be randomly generated (probability table)
-var IUB : [0..14] Freq;
-IUB[0] = new Freq('a', 0.27);
-IUB[1] = new Freq('c', 0.12);
-IUB[2] = new Freq('g', 0.12);
-IUB[3] = new Freq('t', 0.27);
-IUB[4] = new Freq('B', 0.02);
-IUB[5] = new Freq('D', 0.02);
-IUB[6] = new Freq('H', 0.02);
-IUB[7] = new Freq('K', 0.02);
-IUB[8] = new Freq('M', 0.02);
-IUB[9] = new Freq('N', 0.02);
-IUB[10] = new Freq('R', 0.02);
-IUB[11] = new Freq('S', 0.02);
-IUB[12] = new Freq('V', 0.02);
-IUB[13] = new Freq('W', 0.02);
-IUB[14] = new Freq('Y', 0.02);
+var IUB : [0..14] unmanaged Freq;
+IUB[0] = new unmanaged Freq('a', 0.27);
+IUB[1] = new unmanaged Freq('c', 0.12);
+IUB[2] = new unmanaged Freq('g', 0.12);
+IUB[3] = new unmanaged Freq('t', 0.27);
+IUB[4] = new unmanaged Freq('B', 0.02);
+IUB[5] = new unmanaged Freq('D', 0.02);
+IUB[6] = new unmanaged Freq('H', 0.02);
+IUB[7] = new unmanaged Freq('K', 0.02);
+IUB[8] = new unmanaged Freq('M', 0.02);
+IUB[9] = new unmanaged Freq('N', 0.02);
+IUB[10] = new unmanaged Freq('R', 0.02);
+IUB[11] = new unmanaged Freq('S', 0.02);
+IUB[12] = new unmanaged Freq('V', 0.02);
+IUB[13] = new unmanaged Freq('W', 0.02);
+IUB[14] = new unmanaged Freq('Y', 0.02);
 
-var HomoSapiens : [0..3] Freq;
-HomoSapiens[0] = new Freq('a', 0.3029549426680);
-HomoSapiens[1] = new Freq('c', 0.1979883004921);
-HomoSapiens[2] = new Freq('g', 0.1975473066391);
-HomoSapiens[3] = new Freq('t', 0.3015094502008);
+var HomoSapiens : [0..3] unmanaged Freq;
+HomoSapiens[0] = new unmanaged Freq('a', 0.3029549426680);
+HomoSapiens[1] = new unmanaged Freq('c', 0.1979883004921);
+HomoSapiens[2] = new unmanaged Freq('g', 0.1975473066391);
+HomoSapiens[3] = new unmanaged Freq('t', 0.3015094502008);
 
 // (Scan operation)
 proc sumAndScale(a :[?D]) {
@@ -76,8 +76,8 @@ class Random {
   }
 }
 
-var lookup : [0..LOOKUP_SIZE-1] Freq;
-var random = new Random();
+var lookup : [0..LOOKUP_SIZE-1] unmanaged Freq;
+var random = new unmanaged Random();
 
 // Make lookup table for random sequence generation
 proc makeLookup(a :[?D]) {

--- a/test/studies/shootout/fasta/kbrady/fasta-printf.chpl
+++ b/test/studies/shootout/fasta/kbrady/fasta-printf.chpl
@@ -67,28 +67,28 @@ const ALU : [0..286] int(8) = [
 ];
 
 //Sequences to be randomly generated (probability table)
-var IUB : [0..14] Freq;
-IUB[0] = new Freq(97, 0.27);  // a -> 97
-IUB[1] = new Freq(99, 0.12);  // c -> 99
-IUB[2] = new Freq(103, 0.12); // g -> 103
-IUB[3] = new Freq(116, 0.27); // t -> 116
-IUB[4] = new Freq(66, 0.02);  // B -> 66
-IUB[5] = new Freq(68, 0.02);  // D -> 68
-IUB[6] = new Freq(72, 0.02);  // H -> 72
-IUB[7] = new Freq(75, 0.02);  // K -> 75
-IUB[8] = new Freq(77, 0.02);  // M -> 77
-IUB[9] = new Freq(78, 0.02);  // N -> 78
-IUB[10] = new Freq(82, 0.02); // R -> 82
-IUB[11] = new Freq(83, 0.02); // S -> 83
-IUB[12] = new Freq(86, 0.02); // V -> 86
-IUB[13] = new Freq(87, 0.02); // W -> 87
-IUB[14] = new Freq(89, 0.02); // Y -> 89
+var IUB : [0..14] unmanaged Freq;
+IUB[0] = new unmanaged Freq(97, 0.27);  // a -> 97
+IUB[1] = new unmanaged Freq(99, 0.12);  // c -> 99
+IUB[2] = new unmanaged Freq(103, 0.12); // g -> 103
+IUB[3] = new unmanaged Freq(116, 0.27); // t -> 116
+IUB[4] = new unmanaged Freq(66, 0.02);  // B -> 66
+IUB[5] = new unmanaged Freq(68, 0.02);  // D -> 68
+IUB[6] = new unmanaged Freq(72, 0.02);  // H -> 72
+IUB[7] = new unmanaged Freq(75, 0.02);  // K -> 75
+IUB[8] = new unmanaged Freq(77, 0.02);  // M -> 77
+IUB[9] = new unmanaged Freq(78, 0.02);  // N -> 78
+IUB[10] = new unmanaged Freq(82, 0.02); // R -> 82
+IUB[11] = new unmanaged Freq(83, 0.02); // S -> 83
+IUB[12] = new unmanaged Freq(86, 0.02); // V -> 86
+IUB[13] = new unmanaged Freq(87, 0.02); // W -> 87
+IUB[14] = new unmanaged Freq(89, 0.02); // Y -> 89
 
-var HomoSapiens : [0..3] Freq;
-HomoSapiens[0] = new Freq(97, 0.3029549426680);  // a -> 97
-HomoSapiens[1] = new Freq(99, 0.1979883004921);  // c -> 99
-HomoSapiens[2] = new Freq(103, 0.1975473066391); // g -> 103
-HomoSapiens[3] = new Freq(116, 0.3015094502008); // t -> 116
+var HomoSapiens : [0..3] unmanaged Freq;
+HomoSapiens[0] = new unmanaged Freq(97, 0.3029549426680);  // a -> 97
+HomoSapiens[1] = new unmanaged Freq(99, 0.1979883004921);  // c -> 99
+HomoSapiens[2] = new unmanaged Freq(103, 0.1975473066391); // g -> 103
+HomoSapiens[3] = new unmanaged Freq(116, 0.3015094502008); // t -> 116
 
 // (Scan operation)
 proc sumAndScale(a :[?D]) {
@@ -114,8 +114,8 @@ class Random {
   }
 }
 
-var lookup : [0..LOOKUP_SIZE-1] Freq;
-var random = new Random();
+var lookup : [0..LOOKUP_SIZE-1] unmanaged Freq;
+var random = new unmanaged Random();
 
 // Make lookup table for random sequence generation
 proc makeLookup(a :[?D]) {

--- a/test/studies/shootout/fasta/kbrady/fasta-qio.chpl
+++ b/test/studies/shootout/fasta/kbrady/fasta-qio.chpl
@@ -100,7 +100,7 @@ proc makeLookup(a) {
 }
 
 // Add a line of random sequence
-var random = new Random();
+var random = new unmanaged Random();
 var line_buff: [0..LINE_LENGTH] int(8);
 proc addLine(bytes: int) {
   for (i, r) in random.get(bytes) {

--- a/test/studies/shootout/k-nucleotide/bharshbarg/knucleotide-chaining.chpl
+++ b/test/studies/shootout/k-nucleotide/bharshbarg/knucleotide-chaining.chpl
@@ -21,11 +21,11 @@ tochar[3] = "G";
 class Node {
   var data : uint;
   var count : int;
-  var next : Node;
+  var next : unmanaged Node;
 }
 
 class Table {
-  var table : [0..tableSize-1] Node;
+  var table : [0..tableSize-1] unmanaged Node;
   var size : int;
 
   proc this(d : uint) ref {
@@ -33,7 +33,7 @@ class Table {
     ref head = table[slot];
     var n = head;
     if n == nil {
-      n = new Node(d, 0, nil);
+      n = new unmanaged Node(d, 0, nil);
       size += 1;
       head = n;
       return n.count;
@@ -43,7 +43,7 @@ class Table {
       if n.data == d then return n.count;
       n = n.next;
     }
-    n = new Node(d, 0, head);
+    n = new unmanaged Node(d, 0, head);
     size += 1;
     head = n;
     return n.count;
@@ -91,13 +91,13 @@ proc decode(data : uint, size : int) {
 }
 
 proc calculate(data : [] uint(8), size : int) {
-  var freqs = new Table();
+  var freqs = new unmanaged Table();
 
   var lock : sync bool;
   lock = true;
   const sizeRange = 0..size-1;
   coforall tid in 1..here.maxTaskPar {
-    var curArr = new Table();
+    var curArr = new unmanaged Table();
     for i in tid .. data.size-size by here.maxTaskPar {
       curArr[hash(data, i, sizeRange)] += 1;
     }

--- a/test/studies/shootout/nbody/sidelnik/nbody_iterator_7-refInIterator.chpl
+++ b/test/studies/shootout/nbody/sidelnik/nbody_iterator_7-refInIterator.chpl
@@ -21,7 +21,7 @@ class Planet {
   var mass : real;
 }
 
-iter TriangleIter(B: [] Planet) {
+iter TriangleIter(B: [] unmanaged Planet) {
   for i in NBODIES {
     ref b1 = B[i];
     for j in i+1..numBodies {
@@ -30,7 +30,7 @@ iter TriangleIter(B: [] Planet) {
   }
 }
 
-proc advance(B: [] Planet, dt: real) {
+proc advance(B: [] unmanaged Planet, dt: real) {
   for (b1,b2) in TriangleIter(B) {
     var d : [vecLen] real = b1.coord_vector - b2.coord_vector;
     var distance = sqrt(+ reduce d**2);
@@ -43,7 +43,7 @@ proc advance(B: [] Planet, dt: real) {
   }
 }
 
-proc energy(B : [] Planet) : real {
+proc energy(B : [] unmanaged Planet) : real {
   var e : real;
   for (b1,i) in zip(B,NBODIES) {
     e += 0.5 * b1.mass * (+ reduce b1.vel_vector**2);
@@ -56,7 +56,7 @@ proc energy(B : [] Planet) : real {
   return e;
 }
 
-proc offset_momentum(B : [] Planet) {
+proc offset_momentum(B : [] unmanaged Planet) {
   var p : [vecLen] real;
   for b in B do
     p += b.vel_vector * b.mass;
@@ -64,38 +64,38 @@ proc offset_momentum(B : [] Planet) {
 }
 
 proc main() {
-  var bodies : [NBODIES] Planet;
+  var bodies : [NBODIES] unmanaged Planet;
   
   var p0,v0 : [vecLen] real = (0,0,0);
-  bodies(0) = new Planet(p0,v0, solar_mass);
+  bodies(0) = new unmanaged Planet(p0,v0, solar_mass);
   var p1 : [vecLen] real = (4.84143144246472090e+00,
                             -1.16032004402742839e+00,
                             -1.03622044471123109e-01);
   var v1 : [vecLen] real = (1.66007664274403694e-03 * days_per_year,
                             7.69901118419740425e-03 * days_per_year,
                             -6.90460016972063023e-05 * days_per_year);
-  bodies(1) = new Planet(p1, v1, 9.54791938424326609e-04 * solar_mass);
+  bodies(1) = new unmanaged Planet(p1, v1, 9.54791938424326609e-04 * solar_mass);
   var p2 : [vecLen] real = (8.34336671824457987e+00,
                             4.12479856412430479e+00,
                             -4.03523417114321381e-01);
   var v2 : [vecLen] real = (-2.76742510726862411e-03 * days_per_year,
                             4.99852801234917238e-03 * days_per_year,
                             2.30417297573763929e-05 * days_per_year);
-  bodies(2) = new Planet(p2, v2, 2.85885980666130812e-04 * solar_mass);
+  bodies(2) = new unmanaged Planet(p2, v2, 2.85885980666130812e-04 * solar_mass);
   var p3 : [vecLen] real = (1.28943695621391310e+01,
                             -1.51111514016986312e+01,
                             -2.23307578892655734e-01);
   var v3 : [vecLen] real = (2.96460137564761618e-03 * days_per_year,
                             2.37847173959480950e-03 * days_per_year,
                             -2.96589568540237556e-05 * days_per_year);
-  bodies(3) = new Planet(p3,v3, 4.36624404335156298e-05 * solar_mass);
+  bodies(3) = new unmanaged Planet(p3,v3, 4.36624404335156298e-05 * solar_mass);
   var p4 : [vecLen] real = (1.53796971148509165e+01,
                             -2.59193146099879641e+01,
                             1.79258772950371181e-01);
   var v4 : [vecLen] real = (2.68067772490389322e-03 * days_per_year,
                             1.62824170038242295e-03 * days_per_year,
                             -9.51592254519715870e-05 * days_per_year);
-  bodies(4) = new Planet(p4,v4, 5.15138902046611451e-05 * solar_mass);
+  bodies(4) = new unmanaged Planet(p4,v4, 5.15138902046611451e-05 * solar_mass);
   
   offset_momentum(bodies);
   writef("%{#.#########}\n", energy(bodies));

--- a/test/studies/shootout/nbody/sidelnik/nbody_iterator_7.chpl
+++ b/test/studies/shootout/nbody/sidelnik/nbody_iterator_7.chpl
@@ -21,7 +21,7 @@ class Planet {
   var mass : real;
 }
 
-iter TriangleIter(B: [] Planet) {
+iter TriangleIter(B: [] unmanaged Planet) {
   for i in NBODIES {
     for j in i+1..numBodies {
       yield (B[i],B[j]);
@@ -29,7 +29,7 @@ iter TriangleIter(B: [] Planet) {
   }
 }
 
-proc advance(B: [] Planet, dt: real) {
+proc advance(B: [] unmanaged Planet, dt: real) {
   for (b1,b2) in TriangleIter(B) {
     var d : [vecLen] real = b1.coord_vector - b2.coord_vector;
     var distance = sqrt(+ reduce d**2);
@@ -42,7 +42,7 @@ proc advance(B: [] Planet, dt: real) {
   }
 }
 
-proc energy(B : [] Planet) : real {
+proc energy(B : [] unmanaged Planet) : real {
   var e : real;
   for (b1,i) in zip(B,NBODIES) {
     e += 0.5 * b1.mass * (+ reduce b1.vel_vector**2);
@@ -55,7 +55,7 @@ proc energy(B : [] Planet) : real {
   return e;
 }
 
-proc offset_momentum(B : [] Planet) {
+proc offset_momentum(B : [] unmanaged Planet) {
   var p : [vecLen] real;
   for b in B do
     p += b.vel_vector * b.mass;
@@ -63,38 +63,38 @@ proc offset_momentum(B : [] Planet) {
 }
 
 proc main() {
-  var bodies : [NBODIES] Planet;
+  var bodies : [NBODIES] unmanaged Planet;
   
   var p0,v0 : [vecLen] real = (0,0,0);
-  bodies(0) = new Planet(p0,v0, solar_mass);
+  bodies(0) = new unmanaged Planet(p0,v0, solar_mass);
   var p1 : [vecLen] real = (4.84143144246472090e+00,
                             -1.16032004402742839e+00,
                             -1.03622044471123109e-01);
   var v1 : [vecLen] real = (1.66007664274403694e-03 * days_per_year,
                             7.69901118419740425e-03 * days_per_year,
                             -6.90460016972063023e-05 * days_per_year);
-  bodies(1) = new Planet(p1, v1, 9.54791938424326609e-04 * solar_mass);
+  bodies(1) = new unmanaged Planet(p1, v1, 9.54791938424326609e-04 * solar_mass);
   var p2 : [vecLen] real = (8.34336671824457987e+00,
                             4.12479856412430479e+00,
                             -4.03523417114321381e-01);
   var v2 : [vecLen] real = (-2.76742510726862411e-03 * days_per_year,
                             4.99852801234917238e-03 * days_per_year,
                             2.30417297573763929e-05 * days_per_year);
-  bodies(2) = new Planet(p2, v2, 2.85885980666130812e-04 * solar_mass);
+  bodies(2) = new unmanaged Planet(p2, v2, 2.85885980666130812e-04 * solar_mass);
   var p3 : [vecLen] real = (1.28943695621391310e+01,
                             -1.51111514016986312e+01,
                             -2.23307578892655734e-01);
   var v3 : [vecLen] real = (2.96460137564761618e-03 * days_per_year,
                             2.37847173959480950e-03 * days_per_year,
                             -2.96589568540237556e-05 * days_per_year);
-  bodies(3) = new Planet(p3,v3, 4.36624404335156298e-05 * solar_mass);
+  bodies(3) = new unmanaged Planet(p3,v3, 4.36624404335156298e-05 * solar_mass);
   var p4 : [vecLen] real = (1.53796971148509165e+01,
                             -2.59193146099879641e+01,
                             1.79258772950371181e-01);
   var v4 : [vecLen] real = (2.68067772490389322e-03 * days_per_year,
                             1.62824170038242295e-03 * days_per_year,
                             -9.51592254519715870e-05 * days_per_year);
-  bodies(4) = new Planet(p4,v4, 5.15138902046611451e-05 * solar_mass);
+  bodies(4) = new unmanaged Planet(p4,v4, 5.15138902046611451e-05 * solar_mass);
   
   offset_momentum(bodies);
   writef("%{#.#########}\n", energy(bodies));

--- a/test/studies/shootout/nbody/sidelnik/nbody_orig_1.chpl
+++ b/test/studies/shootout/nbody/sidelnik/nbody_orig_1.chpl
@@ -19,8 +19,8 @@ class Planet {
   var mass : real;
 }
 
-proc advance(nbodies:int, B: [] Planet, dt: real) {
-  var b2 : Planet;
+proc advance(nbodies:int, B: [] unmanaged Planet, dt: real) {
+  var b2 : unmanaged Planet;
   
   for (b1, i) in zip(B, 0..) {
     for j in i+1..nbodies-1 {
@@ -46,8 +46,8 @@ proc advance(nbodies:int, B: [] Planet, dt: real) {
   }
 }
 
-proc energy(nbodies:int, B : [] Planet) : real {
-  var b2 : Planet;
+proc energy(nbodies:int, B : [] unmanaged Planet) : real {
+  var b2 : unmanaged Planet;
   var e : real;
   
   for (b1, i) in zip(B, 0..) {
@@ -65,7 +65,7 @@ proc energy(nbodies:int, B : [] Planet) : real {
   return e;
 }
 
-proc offset_momentum(nbodies:int, B : [] Planet) {
+proc offset_momentum(nbodies:int, B : [] unmanaged Planet) {
   var px,py,pz : real;
   for b in B {
     px += b.vx * b.mass;
@@ -79,10 +79,10 @@ proc offset_momentum(nbodies:int, B : [] Planet) {
 
 proc main() {
   param NBODIES = 5;
-  var bodies : [0..#NBODIES] Planet;
+  var bodies : [0..#NBODIES] unmanaged Planet;
   
-  bodies(0) = new Planet(0, 0, 0, 0, 0, 0, solar_mass);
-  bodies(1) = new Planet(4.84143144246472090e+00,
+  bodies(0) = new unmanaged Planet(0, 0, 0, 0, 0, 0, solar_mass);
+  bodies(1) = new unmanaged Planet(4.84143144246472090e+00,
                          -1.16032004402742839e+00,
                          -1.03622044471123109e-01,
                          1.66007664274403694e-03 * days_per_year,
@@ -90,7 +90,7 @@ proc main() {
                          -6.90460016972063023e-05 * days_per_year,
                          9.54791938424326609e-04 * solar_mass
                          );
-  bodies(2) = new Planet(8.34336671824457987e+00,
+  bodies(2) = new unmanaged Planet(8.34336671824457987e+00,
                          4.12479856412430479e+00,
                          -4.03523417114321381e-01,
                          -2.76742510726862411e-03 * days_per_year,
@@ -98,7 +98,7 @@ proc main() {
                          2.30417297573763929e-05 * days_per_year,
                          2.85885980666130812e-04 * solar_mass
                          );
-  bodies(3) = new Planet(1.28943695621391310e+01,
+  bodies(3) = new unmanaged Planet(1.28943695621391310e+01,
                          -1.51111514016986312e+01,
                          -2.23307578892655734e-01,
                          2.96460137564761618e-03 * days_per_year,
@@ -106,7 +106,7 @@ proc main() {
                          -2.96589568540237556e-05 * days_per_year,
                          4.36624404335156298e-05 * solar_mass
                          );				
-  bodies(4) = new Planet(1.53796971148509165e+01,
+  bodies(4) = new unmanaged Planet(1.53796971148509165e+01,
                          -2.59193146099879641e+01,
                          1.79258772950371181e-01,
                          2.68067772490389322e-03 * days_per_year,

--- a/test/studies/shootout/spectral-norm/lydia/spectral-norm-barrier.chpl
+++ b/test/studies/shootout/spectral-norm/lydia/spectral-norm-barrier.chpl
@@ -10,7 +10,7 @@
 config const n = 500;
 
 use barrierWF;
-var b: BarrierWF;
+var b: unmanaged BarrierWF;
 
 /* Return: 1.0 / (i + j) * (i + j +1) / 2 + i + 1; */
 inline proc eval_A(i,j : int) : real
@@ -63,7 +63,7 @@ proc main() {
   const chunk = n / numThreads;
 
   u = 1.0;
-  b = new BarrierWF(numThreads);
+  b = new unmanaged BarrierWF(numThreads);
 
   coforall i in 0..#numThreads {
     const r_begin = i * chunk;

--- a/test/studies/shootout/spectral-norm/sidelnik/spectralnorm.chpl
+++ b/test/studies/shootout/spectral-norm/sidelnik/spectralnorm.chpl
@@ -9,7 +9,7 @@
 config const n = 500;
 
 use barrierWF;
-var b: BarrierWF;
+var b: unmanaged BarrierWF;
 
 /* Return: 1.0 / (i + j) * (i + j +1) / 2 + i + 1; */
 proc eval_A(i,j : int) : real
@@ -49,7 +49,7 @@ proc main() {
   var chunk = n / numThreads;
 
   u = 1.0;
-  b = new BarrierWF(numThreads);
+  b = new unmanaged BarrierWF(numThreads);
 
   coforall i in 0..#numThreads do {
     var r_begin = i * chunk;

--- a/test/studies/ssca2/rachels/SSCA2_kernels.chpl
+++ b/test/studies/ssca2/rachels/SSCA2_kernels.chpl
@@ -245,7 +245,7 @@ module SSCA2_kernels
 
       // There will be numTPVs copies of the temps, thus throttling the
       // number of starting vertices being considered simultaneously.
-      var TPV: [TPVLocaleSpace] taskPrivateData(domain(index(vertex_domain)),
+      var TPV: [TPVLocaleSpace] unmanaged taskPrivateData(domain(index(vertex_domain)),
                                                 vertex_domain.type);
 
       // Initialize
@@ -555,8 +555,8 @@ module SSCA2_kernels
   class Level_Set {
     type Sparse_Vertex_List;
     var Members  : Sparse_Vertex_List;
-    var previous : Level_Set (Sparse_Vertex_List);
-    var next : Level_Set (Sparse_Vertex_List);
+    var previous : unmanaged Level_Set (Sparse_Vertex_List);
+    var next : unmanaged Level_Set (Sparse_Vertex_List);
   }
 
   //
@@ -592,7 +592,7 @@ module SSCA2_kernels
     const vertex_domain;
     var used  : atomic bool;
     var BCaux : [vertex_domain] taskPrivateArrayData(index(vertex_domain));
-    var Active_Level : [PrivateSpace] Level_Set (Sparse_Vertex_List);
+    var Active_Level : [PrivateSpace] unmanaged Level_Set (Sparse_Vertex_List);
   }
 
   // This is a simple class that hands out task private variables from the

--- a/test/studies/stencil9/stencil9-explicit.chpl
+++ b/test/studies/stencil9/stencil9-explicit.chpl
@@ -75,7 +75,7 @@ class DomArr {
 // an array of everyone's chunks of the global problem space that they own
 // in a sense it's the distributed A array in a local view
 //
-var LocalDomArrs: [LocaleGridDom] DomArr;
+var LocalDomArrs: [LocaleGridDom] unmanaged DomArr;
 
 var numIters: atomic int;
 
@@ -96,7 +96,7 @@ coforall (lr,lc) in LocaleGridDom {
     // Store my domain, with fluff, into the global directory so that
     // other locales can refer to it.
     //
-    var MyDomArr = new DomArr(Dom=WithFluff);
+    var MyDomArr = new unmanaged DomArr(Dom=WithFluff);
     LocalDomArrs[lr,lc] = MyDomArr;
 
     //

--- a/test/studies/sudoku/dinan/sudoku-smart.chpl
+++ b/test/studies/sudoku/dinan/sudoku-smart.chpl
@@ -8,7 +8,7 @@ config const MAX_ITER  = 500000;
 var givenBoard: [1..9, 1..9] int;  // The given board
 var initBoard:  [1..9, 1..9] int;  // The initialized board
 
-var myRand = new RandomStream(real);
+var myRand = new owned RandomStream(real);
 
 
 // Return a random number on the range [1, n]
@@ -350,6 +350,4 @@ proc main() {
   }
 
   writeln("\nSolution:\n", bestBoard);
-
-  delete myRand;
 }

--- a/test/studies/sudoku/dinan/sudoku.chpl
+++ b/test/studies/sudoku/dinan/sudoku.chpl
@@ -8,7 +8,7 @@ config const MAX_ITER  = 1000000;
 var givenBoard: [1..9, 1..9] int;  // The given board
 var initBoard:  [1..9, 1..9] int;  // The initialized board
 
-var myRand = new NPBRandomStream(real, seed=314159265);
+var myRand = new owned NPBRandomStream(real, seed=314159265);
 
 
 // Return a random number on the range [1, n]
@@ -154,6 +154,4 @@ proc main() {
   }
 
   writeln("\nSolution:\n", bestBoard);
-
-  delete myRand;
 }

--- a/test/studies/uts/dequeue.chpl
+++ b/test/studies/uts/dequeue.chpl
@@ -5,19 +5,19 @@ module dequeue {
     class MyNode {
       type itemType;              // type of item
       var item: itemType;         // item in node
-      var prev: MyNode(itemType); // reference to prev node (same type)
-      var next: MyNode(itemType); // reference to next node (same type)
+      var prev: unmanaged MyNode(itemType); // reference to prev node (same type)
+      var next: unmanaged MyNode(itemType); // reference to next node (same type)
     }
 
     type itemType;             // type of items
     var size: int;             // Length of the DeQueue
-    var top: MyNode(itemType); // top node on DeQueue linked list
-    var bottom: MyNode(itemType);
+    var top: unmanaged MyNode(itemType); // top node on DeQueue linked list
+    var bottom: unmanaged MyNode(itemType);
     var id: int;
 
     // pushTop: add an item to the top of the DeQueue
     proc pushTop(item: itemType) {
-      var newTop = new MyNode(itemType, item, nil, top);
+      var newTop = new unmanaged MyNode(itemType, item, nil, top);
       if top == nil {
         bottom = newTop;
       } else {
@@ -29,7 +29,7 @@ module dequeue {
 
     // pushBottom: add an item to the bottom of the DeQueue
     proc pushBottom(item: itemType) {
-      var newBottom = new MyNode(itemType, item, bottom, nil);
+      var newBottom = new unmanaged MyNode(itemType, item, bottom, nil);
       if bottom == nil {
         top = newBottom;
       } else {

--- a/test/studies/uts/uts_deq.chpl
+++ b/test/studies/uts/uts_deq.chpl
@@ -65,7 +65,7 @@ class TreeNode {
   var nChildren: int = 0;
 
   // Generate this node's children
-  proc genChildren(ref q: DeQueue(TreeNode)): int {
+  proc genChildren(ref q: DeQueue(unmanaged TreeNode)): int {
     select distrib {
       when NodeDistrib.Geometric do 
         nChildren = numGeoChildren(geoDist);
@@ -81,7 +81,7 @@ class TreeNode {
 
     for i in 0..nChildren-1 {
       if debug then writeln("  + (", depth, ", ", i, ")");
-      var t = new TreeNode(depth+1);
+      var t = new unmanaged TreeNode(depth+1);
       rng_spawn(hash[1], t.hash[1], i:sha_int);
       q.pushTop(t);
     }
@@ -202,7 +202,7 @@ proc uts_showSearchParams() {
 }
 
 
-proc balance_load(ref state: LDBalanceState, ref q: DeQueue(TreeNode)): int {
+proc balance_load(ref state: LDBalanceState, ref q: DeQueue(unmanaged TreeNode)): int {
   if (parallel) {
     // Trade some imbalance here for blocking overhead
     if (q.size > 2*chunkSize && thread_cnt.read() < MAX_THREADS) {
@@ -233,7 +233,7 @@ proc balance_load(ref state: LDBalanceState, ref q: DeQueue(TreeNode)): int {
 /*
 **  Parallel Tree Creation
 */
-proc create_tree(ref q: DeQueue(TreeNode)) {
+proc create_tree(ref q: DeQueue(unmanaged TreeNode)) {
   var count, maxDepth: int;
   var ldbal_state = new LDBalanceState();
 
@@ -262,11 +262,11 @@ proc create_tree(ref q: DeQueue(TreeNode)) {
 
 proc main() {
   var t_create: Timer;
-  var root: TreeNode;
-  var queue: DeQueue(TreeNode);
+  var root: unmanaged TreeNode;
+  var queue: DeQueue(unmanaged TreeNode);
  
   // Create the root and push it into a queue
-  root = new TreeNode(0);
+  root = new unmanaged TreeNode(0);
   rng_init(root.hash[1], SEED:sha_int);
   global_count.add(1);
   queue.pushTop(root);

--- a/test/studies/uts/uts_rec.chpl
+++ b/test/studies/uts/uts_rec.chpl
@@ -50,7 +50,7 @@ class TreeNode {
   // By default, children will be empty since it has range [1..0]
   var nChildren: int = 0;
   var childDom = {1..nChildren};
-  var children:  [childDom] TreeNode;
+  var children:  [childDom] unmanaged TreeNode;
 
 
   // Generate this node's children
@@ -72,7 +72,7 @@ class TreeNode {
 
     forall i in childDom {
       if debug then writeln("  + (", depth, ", ", i, ")");
-      children[i]    = new TreeNode(depth+1);
+      children[i]    = new unmanaged TreeNode(depth+1);
       rng_spawn(hash[1], children[i].hash[1], (i-1):sha_int);
     }
 
@@ -214,7 +214,7 @@ proc requestThreads(n:int): int {
 /*
 **  Parallel DFS
 */
-proc dfs_count(n: TreeNode, wasParallel: bool = false):int {
+proc dfs_count(n: unmanaged TreeNode, wasParallel: bool = false):int {
   if n != nil {
     if (parallel) {
       var threads_granted = requestThreads(n.nChildren);
@@ -248,7 +248,7 @@ proc dfs_count(n: TreeNode, wasParallel: bool = false):int {
 /*
 **  Parallel Tree Creation
 */
-proc create_tree(parent: TreeNode, wasParallel: bool = false): int {
+proc create_tree(parent: unmanaged TreeNode, wasParallel: bool = false): int {
   if parent == nil {
     writeln("create_tree(): Warning, called with nil");
     return 0;
@@ -281,7 +281,7 @@ proc create_tree(parent: TreeNode, wasParallel: bool = false): int {
 } 
 
 
-proc destroyTree(tn: TreeNode) {
+proc destroyTree(tn: unmanaged TreeNode) {
   for child in tn.children do
     destroyTree(child);
   delete tn;
@@ -292,9 +292,9 @@ proc main {
   var t_create: Timer();
   var t_dfs   : Timer();
   var counted, created: int;
-  var root: TreeNode;
+  var root: unmanaged TreeNode;
   
-  root = new TreeNode(0);
+  root = new unmanaged TreeNode(0);
   rng_init(root.hash[1], SEED:sha_int);
 
   uts_showSearchParams();

--- a/test/trivial/bradc/testAllScopes.chpl
+++ b/test/trivial/bradc/testAllScopes.chpl
@@ -32,7 +32,7 @@ proc main() {
 
   writeln("b(3) is: ", myB);
 
-  var myE: e = new e();
+  var myE: borrowed e = new borrowed e();
   var myG: int;
 
   myG = myE.g(8);
@@ -48,6 +48,4 @@ proc main() {
       writeln("o is: ", o);
     }
   }
-
-  delete myE;
 }

--- a/test/trivial/bradc/testAllScopes2.chpl
+++ b/test/trivial/bradc/testAllScopes2.chpl
@@ -30,7 +30,7 @@ proc main() {
 
   writeln("b(3) is: ", myB);
 
-  var myE: e = new e();
+  var myE: borrowed e = new borrowed e();
   var myG: int = myE.g(8);
 
   writeln("e.g(8) is: ", myG);
@@ -45,6 +45,4 @@ proc main() {
       writeln("o is: ", o);
     }
   }
-
-  delete myE;
 }

--- a/test/trivial/deitz/coerce-assign/plusassign.chpl
+++ b/test/trivial/deitz/coerce-assign/plusassign.chpl
@@ -8,7 +8,7 @@ class C : D {
     proc bar(_x) {
       writeln("default bar");
     }
-    proc bar(_x : D) {
+    proc bar(_x : borrowed D) {
       writeln("bar of D");
     }
     bar(x);
@@ -17,11 +17,9 @@ class C : D {
   }
 }
 
-var d = new D();
+var d = new borrowed D();
 writeln(d);
-delete d;
 
-var c = new C();
+var c = new borrowed C();
 c.foo();
 writeln(c);
-delete c;


### PR DESCRIPTION
Running testing with --warn-unstable revealed some warnings.
This PR fixes about 100 more tests to not warn.

For #9829.

Trivial test changes only - not reviewed.

- [x] full local testing
