### PR TITLE
Minor tweaks to support upcoming changes

### DIFF
--- a/compiler/include/build.h
+++ b/compiler/include/build.h
@@ -95,7 +95,6 @@ BlockStmt* buildCoforallLoopStmt(Expr* indices,
 BlockStmt* buildGotoStmt(GotoTag tag, const char* name);
 BlockStmt* buildPrimitiveStmt(PrimitiveTag tag, Expr* e1 = NULL, Expr* e2 = NULL);
 BlockStmt* buildDeleteStmt(CallExpr* exprlist);
-CallExpr* zipToTuple(CallExpr* zipExpr);
 BlockStmt* buildForallLoopStmt(Expr* indices,
                                Expr* iterator,
                                ForallIntents* forall_intents,

--- a/compiler/optimizations/copyPropagation.cpp
+++ b/compiler/optimizations/copyPropagation.cpp
@@ -199,10 +199,10 @@ static bool needsKilling(SymExpr* se, std::set<Symbol*>& liveRefs)
 
     ArgSymbol* arg = actual_to_formal(se);
 
-    if (arg->intent == INTENT_OUT   ||  // TODO: Try removing this
-        arg->intent == INTENT_INOUT ||  // and this
-        arg->intent == INTENT_REF   ||  // and this.
-        arg->hasFlag(FLAG_ARG_THIS))    // We need this case.
+    if (arg->intent == INTENT_OUT   ||
+        arg->intent == INTENT_INOUT ||
+        arg->intent == INTENT_REF   ||
+        arg->hasFlag(FLAG_ARG_THIS)) // Todo: replace with arg intent check?
     {
       liveRefs.insert(se->symbol());
       return true;

--- a/compiler/parser/chapel.ypp
+++ b/compiler/parser/chapel.ypp
@@ -693,7 +693,7 @@ loop_stmt:
   TDO stmt TWHILE expr TSEMI                    { $$ = DoWhileStmt::build($4, $2); }
 | TWHILE expr do_stmt                           { $$ = WhileDoStmt::build($2, $3); }
 | TCOFORALL expr TIN expr opt_task_intent_ls do_stmt { $$ = buildCoforallLoopStmt($2, $4, $5, $6); }
-| TCOFORALL expr TIN zippered_iterator opt_task_intent_ls do_stmt { $$ = buildCoforallLoopStmt($2, zipToTuple($4), $5, $6, true); }
+| TCOFORALL expr TIN zippered_iterator opt_task_intent_ls do_stmt { $$ = buildCoforallLoopStmt($2, $4, $5, $6, true); }
 | TCOFORALL expr opt_task_intent_ls do_stmt     { $$ = buildCoforallLoopStmt(NULL, $2, $3, $4); }
 | TFOR expr TIN expr do_stmt                    { $$ = ForLoop::buildForLoop(  $2, $4, $5, false, false); }
 | TFOR expr TIN zippered_iterator do_stmt       { $$ = ForLoop::buildForLoop(  $2, $4, $5, false,  true); }
@@ -1542,25 +1542,25 @@ for_expr:
   TFOR expr TIN expr TDO expr %prec TFOR
     { $$ = buildForLoopExpr($2, $4, $6); }
 | TFOR expr TIN zippered_iterator TDO expr %prec TFOR
-    { $$ = buildForLoopExpr($2, zipToTuple($4), $6, NULL, false, true); }
+    { $$ = buildForLoopExpr($2, $4, $6, NULL, false, true); }
 | TFOR expr TDO expr %prec TFOR
     { $$ = buildForLoopExpr(NULL, $2, $4); }
 | TFOR expr TIN expr TDO TIF expr TTHEN expr %prec TNOELSE
     { $$ = buildForLoopExpr($2, $4, $9, $7); }
 | TFOR expr TIN zippered_iterator TDO TIF expr TTHEN expr %prec TNOELSE
-    { $$ = buildForLoopExpr($2, zipToTuple($4), $9, $7, false, true); }
+    { $$ = buildForLoopExpr($2, $4, $9, $7, false, true); }
 | TFOR expr TDO TIF expr TTHEN expr %prec TNOELSE
     { $$ = buildForLoopExpr(NULL, $2, $7, $5); }
 | TFORALL expr TIN expr TDO expr %prec TFOR
     { $$ = buildForallLoopExpr($2, $4, $6); }
 | TFORALL expr TIN zippered_iterator TDO expr %prec TFOR
-    { $$ = buildForallLoopExpr($2, zipToTuple($4), $6, NULL, false, true); }
+    { $$ = buildForallLoopExpr($2, $4, $6, NULL, false, true); }
 | TFORALL expr TDO expr %prec TFOR
     { $$ = buildForallLoopExpr(NULL, $2, $4); }
 | TFORALL expr TIN expr TDO TIF expr TTHEN expr %prec TNOELSE
     { $$ = buildForallLoopExpr($2, $4, $9, $7); }
 | TFORALL expr TIN zippered_iterator TDO TIF expr TTHEN expr %prec TNOELSE
-    { $$ = buildForallLoopExpr($2, zipToTuple($4), $9, $7, false, true); }
+    { $$ = buildForallLoopExpr($2, $4, $9, $7, false, true); }
 | TFORALL expr TDO TIF expr TTHEN expr %prec TNOELSE
     { $$ = buildForallLoopExpr(NULL, $2, $7, $5); }
 | TLSBR expr_ls TRSBR expr %prec TFOR
@@ -1580,7 +1580,7 @@ for_expr:
     {
       if ($2->argList.length != 1)
         USR_FATAL($4, "invalid index expression");
-      $$ = buildForallLoopExpr($2->get(1)->remove(), zipToTuple($4), $6, NULL, false, true);
+      $$ = buildForallLoopExpr($2->get(1)->remove(), $4, $6, NULL, false, true);
     }
 | TLSBR expr_ls TIN expr TRSBR TIF expr TTHEN expr %prec TNOELSE
     {
@@ -1592,7 +1592,7 @@ for_expr:
     {
       if ($2->argList.length != 1)
         USR_FATAL($4, "invalid index expression");
-      $$ = buildForallLoopExpr($2->get(1)->remove(), zipToTuple($4), $9, $7, false, true);
+      $$ = buildForallLoopExpr($2->get(1)->remove(), $4, $9, $7, false, true);
     }
 ;
 
@@ -1825,16 +1825,16 @@ unary_op_expr:
 
 reduce_expr:
   expr TREDUCE expr                              { $$ = buildReduceExpr($1, $3); }
-| expr TREDUCE zippered_iterator                 { $$ = buildReduceExpr($1, zipToTuple($3), true); }
+| expr TREDUCE zippered_iterator                 { $$ = buildReduceExpr($1, $3, true); }
 | reduce_scan_op_expr TREDUCE expr               { $$ = buildReduceExpr($1, $3); }
-| reduce_scan_op_expr TREDUCE zippered_iterator  { $$ = buildReduceExpr($1, zipToTuple($3), true); }
+| reduce_scan_op_expr TREDUCE zippered_iterator  { $$ = buildReduceExpr($1, $3, true); }
 ;
 
 scan_expr:
   expr TSCAN expr                              { $$ = buildScanExpr($1, $3); }
-| expr TSCAN zippered_iterator                 { $$ = buildScanExpr($1, zipToTuple($3), true); }
+| expr TSCAN zippered_iterator                 { $$ = buildScanExpr($1, $3, true); }
 | reduce_scan_op_expr TSCAN expr               { $$ = buildScanExpr($1, $3); }
-| reduce_scan_op_expr TSCAN zippered_iterator  { $$ = buildScanExpr($1, zipToTuple($3), true); }
+| reduce_scan_op_expr TSCAN zippered_iterator  { $$ = buildScanExpr($1, $3, true); }
 ;
 
 

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -9224,14 +9224,20 @@ static void removeRandomPrimitive(CallExpr* call) {
       // Remove member accesses of types
       // Replace string literals with field symbols in member primitives
       Type* baseType = call->get(1)->typeInfo();
-      if (baseType->symbol->hasFlag(FLAG_RUNTIME_TYPE_VALUE))
-        break;
 
       if (!call->parentSymbol->hasFlag(FLAG_REF) &&
           baseType->symbol->hasFlag(FLAG_REF))
         baseType = baseType->getValType();
 
-      const char* memberName = get_string(call->get(2));
+      SymExpr* memberSE = toSymExpr(call->get(2));
+      const char* memberName = NULL;
+
+      if (!get_string(memberSE, &memberName)) {
+        // Confirm that this is already a correct field Symbol.
+        INT_ASSERT(memberSE->symbol()->defPoint->parentSymbol
+                   == baseType->symbol);
+        break;
+      }
 
       Symbol* sym = baseType->getField(memberName);
       if (sym->hasFlag(FLAG_TYPE_VARIABLE) ||

--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -1956,6 +1956,7 @@ namespace {
   struct PromotionInfo {
     FnSymbol* fn;
     FnSymbol* wrapperFn;
+    bool      zippered;
     // The following vectors are indexed by the i'th formal to fn (0-based).
 
     // The TypeSymbol representing the type that is promoted (e.g. array)
@@ -1992,7 +1993,8 @@ static BlockStmt* buildPromotionLoop(PromotionInfo& promotion,
 
 static void       buildLeaderIterator(FnSymbol* wrapFn,
                                       BlockStmt* visibilityBlock,
-                                      Expr*     iterator);
+                                      Expr*     iterator,
+                                      bool      zippered);
 
 static void       buildFollowerIterator(PromotionInfo& promotion,
                                         BlockStmt* visibilityBlock,
@@ -2106,11 +2108,12 @@ static FnSymbol* promotionWrap(FnSymbol* fn,
  */
 PromotionInfo::PromotionInfo(FnSymbol* fn,
                              CallInfo& info,
-                             std::vector<ArgSymbol*>& actualFormals) {
-
-  this->fn = fn;
-  this->wrapperFn = NULL; // established later along with wrapperFormals
-
+                             std::vector<ArgSymbol*>& actualFormals) :
+  fn(fn),
+  // these are established later along with wrapperFormals
+  wrapperFn(NULL),
+  zippered(false)
+{
   int numActuals = actualFormals.size();
 
   for (int j = 0; j < numActuals; j++) {
@@ -2178,7 +2181,8 @@ static FnSymbol* buildPromotionWrapper(PromotionInfo& promotion,
     Expr*      iterator = getIterator(promotion);
     CallExpr*  wrapCall = createPromotedCallForWrapper(promotion);
     BlockStmt* block    = new BlockStmt(wrapCall);
-    bool       zippered = isCallExpr(iterator) ? true : false;
+    bool       zippered = promotion.zippered;
+    INT_ASSERT(zippered == isCallExpr(iterator)); //vass
 
     loop = buildForallLoopStmt(indices, iterator, NULL, block, zippered);
 
@@ -2210,7 +2214,8 @@ static BlockStmt* buildPromotionLoop(PromotionInfo& promotion,
   Expr*      indices    = getIndices(promotion);
   Expr*      iterator   = getIterator(promotion);
   CallExpr*  wrapCall   = createPromotedCallForWrapper(promotion);
-  bool       zippered   = isCallExpr(iterator) ? true : false;
+  bool       zippered   = promotion.zippered;
+  INT_ASSERT(zippered == isCallExpr(iterator)); //vass
   BlockStmt* yieldBlock = new BlockStmt();
   VarSymbol* yieldTmp   = newTemp("p_yield");
 
@@ -2219,7 +2224,7 @@ static BlockStmt* buildPromotionLoop(PromotionInfo& promotion,
 
   yieldTmp->addFlag(FLAG_EXPR_TEMP);
 
-  buildLeaderIterator(wrapFn, visibilityBlock, iterator);
+  buildLeaderIterator(wrapFn, visibilityBlock, iterator, zippered);
 
   buildFollowerIterator(promotion, visibilityBlock, indices, iterator, wrapCall);
 
@@ -2249,7 +2254,8 @@ static BlockStmt* buildPromotionLoop(PromotionInfo& promotion,
 
 static void buildLeaderIterator(FnSymbol* wrapFn,
                                 BlockStmt* visibilityBlock,
-                                Expr*     iterator) {
+                                Expr*     iterator,
+                                bool      zippered) {
   SymbolMap   leaderMap;
   FnSymbol*   liFn       = wrapFn->copy(&leaderMap);
 
@@ -2259,7 +2265,7 @@ static void buildLeaderIterator(FnSymbol* wrapFn,
   VarSymbol*  liIndex    = newTemp("p_leaderIndex");
   VarSymbol*  liIterator = newTemp("p_leaderIterator");
 
-  bool        zippered   = isCallExpr(iterator) ? true : false;
+  INT_ASSERT(zippered == isCallExpr(iterator)); //vass
   const char* leaderName = zippered ? "_toLeaderZip" : "_toLeader";
 
   BlockStmt*  loop       = NULL;
@@ -2538,8 +2544,10 @@ static Expr* getIterator(PromotionInfo& promotion) {
   // If there was only one promoted argument, don't call _build_tuple after all
   if (iteratorCall->numActuals() == 1) {
     retval = iteratorCall->get(1)->remove();
+    promotion.zippered = false;
   } else {
     retval = iteratorCall;
+    promotion.zippered = true;
   }
 
   return retval;

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -121,6 +121,10 @@ module String {
   pragma "no doc"
   extern proc chpl__getInPlaceBufferData(const ref data : chpl__inPlaceBuffer) : c_ptr(uint(8));
 
+  // Signal to the Chapel compiler that the actual argument may be modified.
+  pragma "no doc"
+  extern proc chpl__getInPlaceBufferDataForWrite(ref data : chpl__inPlaceBuffer) : c_ptr(uint(8));
+
   private inline proc chpl_string_comm_get(dest: bufferType, src_loc_id: int(64),
                                            src_addr: bufferType, len: integral) {
     __primitive("chpl_comm_get", dest, src_loc_id, src_addr, len.safeCast(size_t));
@@ -259,7 +263,7 @@ module String {
     proc chpl__serialize() {
       var data : chpl__inPlaceBuffer;
       if len <= CHPL_SHORT_STRING_SIZE {
-        chpl_string_comm_get(chpl__getInPlaceBufferData(data), locale_id, buff, len);
+        chpl_string_comm_get(chpl__getInPlaceBufferDataForWrite(data), locale_id, buff, len);
       }
       return new __serializeHelper(len, buff, _size, locale_id, data);
     }

--- a/runtime/include/chpl-string.h
+++ b/runtime/include/chpl-string.h
@@ -42,5 +42,6 @@ typedef struct chpl__inPlaceBuffer_t {
 } chpl__inPlaceBuffer;
 
 uint8_t* chpl__getInPlaceBufferData(chpl__inPlaceBuffer* buf);
+uint8_t* chpl__getInPlaceBufferDataForWrite(chpl__inPlaceBuffer* buf);
 
 #endif

--- a/runtime/src/chpl-string.c
+++ b/runtime/src/chpl-string.c
@@ -123,3 +123,6 @@ uint8_t* chpl__getInPlaceBufferData(chpl__inPlaceBuffer* buf) {
   return buf->data;
 }
 
+uint8_t* chpl__getInPlaceBufferDataForWrite(chpl__inPlaceBuffer* buf) {
+  return chpl__getInPlaceBufferData(buf);
+}


### PR DESCRIPTION
* Store "zippered" in PromotionInfo instead of heuristically recalculating it.

* Allow PRIM_SET_MEMBER et al. to contain field symbols, in addition to
  field names, during pruneResolvedTree().

* Move zipToTuple() out from chapel.ypp.

* Indicate to the compiler that chpl__serialize() updates 'data'. Note 1.

* Updated a comment. Note 2.

Parser files will be committed separately.

Testing:
* [x] linux64 --verify
* [x] gasnet multilocale tests

Optional notes:

Note 1. In chpl__serialize(), the compiler did not realize that 'data'
could be modified. So it could potentially do incorrect copy propagation.
To prevent that, create a clone of chpl__getInPlaceBufferData() that
takes it argument ('data') by ref, instead of const ref.

Note 2. Update a comment in copyPropagation.cpp .
It was initially added in 31a8a95ca47. Since then, things have changed.
Now, if we remove the checks suggested in the comment, we will
overlook those cases where our Symbol gets modified, so it may be
const-propagated incorrectly.
Conversely, the intents for 'this' argument have improved since the comment.
So maybe the intent checks will work instead of the special case.
Remember to check for the ref maybe-const intent, too.