### PR TITLE
Like PR #9970, update more test output w.r.t. numa locale setup

### DIFF
--- a/test/functions/iterators/sungeun/localDataPar.lm-numa.good
+++ b/test/functions/iterators/sungeun/localDataPar.lm-numa.good
@@ -1,19 +1,24 @@
+### ignoreRunning = false
 ### ignoreRunning = true
 ### ignoreRunning = true
 ### ignoreRunning = true
 ### ignoreRunning = true
 ### minIndicesPerTask = 1
 ### minIndicesPerTask = 1
+### minIndicesPerTask = 1
 ### minIndicesPerTask = 19
 ### minIndicesPerTask = 19
+### nranges = (1..0)
 ### nranges = (9..17, 10..18, 11..19, 12..20)
 ### nranges = (9..17, 10..18, 11..19, 12..20)
 ### nranges = (9..17, 10..18, 11..19, 12..20)
 ### nranges = (9..17, 10..18, 11..19, 12..20)
+### numChunks = 0 (parDim = -1)
 ### numChunks = 3 (parDim = 1)
 ### numChunks = 3 (parDim = 1)
 ### numChunks = 9 (parDim = 1)
 ### numChunks = 9 (parDim = 1)
+### numTasksPerLoc = 19
 ### numTasksPerLoc = 19
 ### numTasksPerLoc = 19
 ### numTasksPerLoc = 3


### PR DESCRIPTION
We apparently don't test this for gasnet.numa, and the results came
back late enough on Friday that I hadn't noticed this case needed to
be updated as well.  Same reason as the others: the numa locale model
does a realloc and so gets parallel debugging printing for this test
requiring the output to be updated.