### PR TITLE
Avoid spurious --warn-unstable errors

### DIFF
--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -868,14 +868,16 @@ static Expr* handleUnstableClassType(SymExpr* se) {
           } else if (outerCall && outerCall->isPrimitive(PRIM_NEW) &&
                      inCall == outerCall->get(1)) {
             // 'new SomeClass()'
-            // let ok be set as it was above
+            // let ok be set as it was above unless changing default
+            if (fDefaultUnmanaged) ok = false;
           } else if (outerCall && callSpecifiesClassKind(outerCall) &&
                      inCall->baseExpr == se) {
             // ':borrowed MyGenericClass(int)'
             ok = true;
           } else if (inCall->baseExpr == se) {
             // ':MyGenericClass(int)'
-            // let ok be set as it was above
+            // let ok be set as it was above unless changing default
+            if (fDefaultUnmanaged) ok = false;
           }
           if (inCall->isNamed(".") &&
               inCall->get(1) == se) {
@@ -912,11 +914,15 @@ static Expr* handleUnstableClassType(SymExpr* se) {
           ok = true;
         }
 
-        if (ArgSymbol* arg = toArgSymbol(se->parentSymbol)) {
-          if (arg->hasFlag(FLAG_ARG_THIS)) {
-            // this default intent is currently 'borrowed' always
-            // and there's not yet a way to adjust it.
-            ok = true;
+        // Don't worry about this arguments if we're only warning
+        // (do worry about it if we're changing the default)
+        if (!fDefaultUnmanaged) {
+          if (ArgSymbol* arg = toArgSymbol(se->parentSymbol)) {
+            if (arg->hasFlag(FLAG_ARG_THIS)) {
+              // this default intent is currently 'borrowed' always
+              // and there's not yet a way to adjust it.
+              ok = true;
+            }
           }
         }
 

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -868,14 +868,14 @@ static Expr* handleUnstableClassType(SymExpr* se) {
           } else if (outerCall && outerCall->isPrimitive(PRIM_NEW) &&
                      inCall == outerCall->get(1)) {
             // 'new SomeClass()'
-            ok = false;
+            // let ok be set as it was above
           } else if (outerCall && callSpecifiesClassKind(outerCall) &&
                      inCall->baseExpr == se) {
             // ':borrowed MyGenericClass(int)'
             ok = true;
           } else if (inCall->baseExpr == se) {
             // ':MyGenericClass(int)'
-            ok = false;
+            // let ok be set as it was above
           }
           if (inCall->isNamed(".") &&
               inCall->get(1) == se) {

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -906,6 +906,12 @@ static Expr* handleUnstableClassType(SymExpr* se) {
         if (isStableClassType(ts->type))
           ok = true;
 
+        if (isShadowVarSymbol(se->parentSymbol)) {
+          // Compiler generates reduce intents with e.g. SumReduceScanOp
+          // and might get confused if it's unmanaged.
+          ok = true;
+        }
+
         if (!ok) {
           if (fDefaultUnmanaged) {
             // Change the se to _to_unmanaged(se)

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -912,6 +912,14 @@ static Expr* handleUnstableClassType(SymExpr* se) {
           ok = true;
         }
 
+        if (ArgSymbol* arg = toArgSymbol(se->parentSymbol)) {
+          if (arg->hasFlag(FLAG_ARG_THIS)) {
+            // this default intent is currently 'borrowed' always
+            // and there's not yet a way to adjust it.
+            ok = true;
+          }
+        }
+
         if (!ok) {
           if (fDefaultUnmanaged) {
             // Change the se to _to_unmanaged(se)


### PR DESCRIPTION
* Don't warn for un-decorated class types in ShadowVarSymbols (*)
* Don't warn on unstable class types in this argument
* Don't warn for `new Shared(SomeClassType)`

Helps with
 * associative/ferguson/plus-reduce-intent-assoc.chpl
 * functions/ferguson/spec-insn-method-class.chpl
 * changes in PR #10031 for DateTime tests use
    a pattern like
       `var x:Shared(MyClassType) = new Shared(MyClassType)`
    which was not passing before

(*) It would be better if reductions always used unmanaged
class instances but I ran into issues with that approach
(the compiler needs to work with generic reduction-op
types and instantiates them in specific ways).

- [x] full local testing

Reviewed by @benharsh - thanks!