### PR TITLE
Update DateTime tests to pass with --warn-unstable

### DIFF
--- a/test/library/standard/DateTime/testDatetime.chpl
+++ b/test/library/standard/DateTime/testDatetime.chpl
@@ -212,7 +212,7 @@ proc test_combine() {
 proc test_replace() {
   var args = (1, 2, 3, 4, 5, 6, 7);
   var base = new datetime((...args));
-  var nilTZ = new Shared(nil: TZInfo);
+  var nilTZ:Shared(TZInfo);
 
   assert(base == base.replace(tzinfo=nilTZ));
 

--- a/test/library/standard/DateTime/testDatetimeTZ.chpl
+++ b/test/library/standard/DateTime/testDatetimeTZ.chpl
@@ -49,10 +49,10 @@ proc test_trivial() {
 proc test_even_more_compare() {
   // Smallest possible after UTC adjustment.
   var t1 = new datetime(1, 1, 1,
-                        tzinfo=new Shared(new FixedOffset(1439, ""): TZInfo));
+                        tzinfo=new shared FixedOffset(1439, ""));
   // Largest possible after UTC adjustment.
   var t2 = new datetime(MAXYEAR, 12, 31, 23, 59, 59, 999999,
-                        tzinfo=new Shared(new FixedOffset(-1439, ""): TZInfo));
+                        tzinfo=new shared FixedOffset(-1439, ""));
 
   // Make sure those compare correctly, and w/o overflow.
   assert(t1 < t2);
@@ -64,38 +64,38 @@ proc test_even_more_compare() {
 
   // Equal afer adjustment.
   t1 = new datetime(1, 12, 31, 23, 59,
-                    tzinfo=new Shared(new FixedOffset(1, ""): TZInfo));
+                    tzinfo=new shared FixedOffset(1, ""));
   t2 = new datetime(2, 1, 1, 3, 13,
-                    tzinfo=new Shared(new FixedOffset(3*60+13+2, ""): TZInfo));
+                    tzinfo=new shared FixedOffset(3*60+13+2, ""));
   assert(t1 == t2);
 
   // Change t1 not to subtract a minute, and t1 should be larger.
   t1 = new datetime(1, 12, 31, 23, 59,
-                    tzinfo=new Shared(new FixedOffset(0, ""): TZInfo));
+                    tzinfo=new shared FixedOffset(0, ""));
   assert(t1 > t2);
 
   // Change t1 to subtract 2 minutes, and t1 should be smaller.
   t1 = new datetime(1, 12, 31, 23, 59,
-                    tzinfo=new Shared(new FixedOffset(2, ""): TZInfo));
+                    tzinfo=new shared FixedOffset(2, ""));
   assert(t1 < t2);
 
   // Back to the original t1, but make seconds resolve it.
   t1 = new datetime(1, 12, 31, 23, 59,
-                    tzinfo=new Shared(new FixedOffset(1, ""): TZInfo),
+                    tzinfo=new shared FixedOffset(1, ""),
                     second=1);
   assert(t1 > t2);
 
   // Likewise, but make microseconds resolve it.
   t1 = new datetime(1, 12, 31, 23, 59,
-                    tzinfo=new Shared(new FixedOffset(1, ""): TZInfo),
+                    tzinfo=new shared FixedOffset(1, ""),
                     microsecond=1);
   assert(t1 > t2);
 }
 
 proc test_zones() {
-  var est = new Shared(new FixedOffset(-300, "EST"): TZInfo);
-  var utc = new Shared(new FixedOffset(0, "UTC"): TZInfo);
-  var met = new Shared(new FixedOffset(60, "MET"): TZInfo);
+  var est = new shared FixedOffset(-300, "EST");
+  var utc = new shared FixedOffset(0, "UTC");
+  var met = new shared FixedOffset(60, "MET");
   var t1 = new datetime(2002, 3, 19,  7, 47, tzinfo=est);
   var t2 = new datetime(2002, 3, 19, 12, 47, tzinfo=utc);
   var t3 = new datetime(2002, 3, 19, 13, 47, tzinfo=met);
@@ -114,7 +114,7 @@ proc test_zones() {
 }
 
 proc test_combine() {
-  var met = new Shared(new FixedOffset(60, "MET"): TZInfo);
+  var met = new shared FixedOffset(60, "MET");
   var d = new date(2002, 3, 4);
   var tz = new time(18, 45, 3, 1234, tzinfo=met);
   var dt = datetime.combine(d, tz);
@@ -123,7 +123,7 @@ proc test_combine() {
 }
 
 proc test_extract() {
-  var met = new Shared(new FixedOffset(60, "MET"): TZInfo);
+  var met = new shared FixedOffset(60, "MET");
   var dt = new datetime(2002, 3, 4, 18, 45, 3, 1234, tzinfo=met);
   assert(dt.getdate() == new date(2002, 3, 4));
   assert(dt.gettime() == new time(18, 45, 3, 1234));
@@ -135,7 +135,7 @@ proc test_tz_aware_arithmetic() {
   var rng = makeRandomStream(eltType=int);
 
   var now = datetime.now();
-  var tz55 = new Shared(new FixedOffset(-330, "west 5:30"): TZInfo);
+  var tz55 = new shared FixedOffset(-330, "west 5:30");
   var timeaware = now.gettime().replace(tzinfo=tz55);
   var nowaware = datetime.combine(now.getdate(), timeaware);
   assert(nowaware.tzinfo == tz55);
@@ -162,8 +162,7 @@ proc test_tz_aware_arithmetic() {
   assert(nowawareplus - nowaware == delta);
 
   // Make up a random timezone.
-  var tzr = new Shared(new FixedOffset(rng.getNext(-1439, 1439),
-                                       "randomtimezone"): TZInfo);
+  var tzr = new shared FixedOffset(rng.getNext(-1439, 1439), "randomtimezone");
   // Attach it to nowawareplus.
   nowawareplus = nowawareplus.replace(tzinfo=tzr);
   assert(nowawareplus.tzinfo == tzr);
@@ -179,9 +178,9 @@ proc test_tz_aware_arithmetic() {
 
   // Try max possible difference.
   var min = new datetime(1, 1, 1,
-                         tzinfo=new Shared(new FixedOffset(1439, "min"): TZInfo));
+                         tzinfo=new shared FixedOffset(1439, "min"));
   var max = new datetime(MAXYEAR, 12, 31, 23, 59, 59, 999999,
-                      tzinfo=new Shared(new FixedOffset(-1439, "max"): TZInfo));
+                      tzinfo=new shared FixedOffset(-1439, "max"));
   var maxdiff = max - min;
   assert(maxdiff == datetime.max - datetime.min +
                     new timedelta(minutes=2*1439));
@@ -192,7 +191,7 @@ proc test_tzinfo_now() {
   // Ensure it doesn't require tzinfo (i.e., that this doesn't blow up).
   var base = datetime.now();
   // Try with and without naming the keyword.
-  var off42 = new Shared(new FixedOffset(42, "42"): TZInfo);
+  var off42 = new shared FixedOffset(42, "42");
   var another = datetime.now(off42);
   var again = datetime.now(tz=off42);
   assert(another.tzinfo == again.tzinfo);
@@ -201,9 +200,9 @@ proc test_tzinfo_now() {
   // We don't know which time zone we're in, and don't have a tzinfo
   // class to represent it, so seeing whether a tz argument actually
   // does a conversion is tricky.
-  var weirdtz = new Shared(new FixedOffset(new timedelta(hours=15, minutes=58),
-                                           "weirdtz", new timedelta(0)): TZInfo);
-  var utc = new Shared(new FixedOffset(0, "utc", 0): TZInfo);
+  var weirdtz = new shared FixedOffset(new timedelta(hours=15, minutes=58),
+                                           "weirdtz", new timedelta(0));
+  var utc = new shared FixedOffset(0, "utc", 0);
   for 0..2 {
     var now = datetime.now(weirdtz);
     assert(now.tzinfo == weirdtz);
@@ -238,7 +237,7 @@ proc test_tzinfo_fromtimestamp() {
   // Ensure it doesn't require tzinfo (i.e., that this doesn't blow up).
   var base = datetime.fromtimestamp(ts);
   // Try with and without naming the keyword.
-  var off42 = new Shared(new FixedOffset(42, "42"): TZInfo);
+  var off42 = new shared FixedOffset(42, "42");
   var another = datetime.fromtimestamp(ts, off42);
   var again = datetime.fromtimestamp(ts, tz=off42);
   assert(another.tzinfo == again.tzinfo);
@@ -252,10 +251,10 @@ proc test_tzinfo_fromtimestamp() {
   // any idea here what time that actually is, we can only test that
   // relative changes match.
   var utcoffset = new timedelta(hours=-15, minutes=39); // arbitrary, but not zero
-  var tz = new Shared(new FixedOffset(utcoffset, "tz", new timedelta()): TZInfo);
+  var tz = new shared FixedOffset(utcoffset, "tz", new timedelta());
   var expected = utcdatetime + utcoffset;
   var got = datetime.fromtimestamp(timestamp, tz);
-  assert(expected == got.replace(tzinfo=new Shared(nil:TZInfo)));
+  assert(expected == got.replace(tzinfo=new Shared(nil:unmanaged TZInfo)));
 }
 
 proc test_tzinfo_timetuple() {
@@ -273,7 +272,7 @@ proc test_tzinfo_timetuple() {
 
   for (dstvalue, flag) in ((-33, 1), (33, 1), (0, 0)) {
     var d = new datetime(1, 1, 1, 10, 20, 30, 40,
-                         tzinfo=new Shared(new DST(dstvalue): TZInfo));
+                         tzinfo=new shared DST(dstvalue));
     var t = d.timetuple();
     assert(1 == t.tm_year);
     assert(1 == t.tm_mon);
@@ -287,8 +286,8 @@ proc test_tzinfo_timetuple() {
   }
 
   // dst() at the edge.
-  assert((new datetime(1,1,1, tzinfo=new Shared(new DST(1439): TZInfo))).timetuple().tm_isdst == 1);
-  assert((new datetime(1,1,1, tzinfo=new Shared(new DST(-1439): TZInfo))).timetuple().tm_isdst == 1);
+  assert((new datetime(1,1,1, tzinfo=new shared DST(1439))).timetuple().tm_isdst == 1);
+  assert((new datetime(1,1,1, tzinfo=new shared DST(-1439))).timetuple().tm_isdst == 1);
 }
 
 proc test_utctimetuple() {
@@ -316,7 +315,7 @@ proc test_utctimetuple() {
   // Ensure tm_isdst is 0 regardless of what dst() says:  DST is never
   // in effect for a UTC time.
   for dstvalue in (-33, 33, 0) {
-    var d = new datetime(1, 2, 3, 10, 20, 30, 40, tzinfo=new Shared(new UOFS(-53, dstvalue): TZInfo));
+    var d = new datetime(1, 2, 3, 10, 20, 30, 40, tzinfo=new shared UOFS(-53, dstvalue));
     var t = d.utctimetuple();
     assert(d.year == t.tm_year);
     assert(d.month == t.tm_mon);
@@ -332,7 +331,7 @@ proc test_utctimetuple() {
   // At the edges, UTC adjustment can normalize into years out-of-range
   // for a datetime object.  Ensure that a correct timetuple is
   // created anyway.
-  var tiny = new datetime(MINYEAR, 1, 1, 0, 0, 37, tzinfo=new Shared(new UOFS(1439): TZInfo));
+  var tiny = new datetime(MINYEAR, 1, 1, 0, 0, 37, tzinfo=new shared UOFS(1439));
   // That goes back 1 minute less than a full day.
   var t = tiny.utctimetuple();
   assert(t.tm_year == MINYEAR-1);
@@ -344,7 +343,7 @@ proc test_utctimetuple() {
   assert(t.tm_yday == 366);    // "year 0" is a leap year
   assert(t.tm_isdst == 0);
 
-  var huge = new datetime(MAXYEAR, 12, 31, 23, 59, 37, 999999, tzinfo=new Shared(new UOFS(-1439): TZInfo));
+  var huge = new datetime(MAXYEAR, 12, 31, 23, 59, 37, 999999, tzinfo=new shared UOFS(-1439));
   // That goes forward 1 minute less than a full day.
   t = huge.utctimetuple();
   assert(t.tm_year == MAXYEAR+1);
@@ -358,9 +357,9 @@ proc test_utctimetuple() {
 }
 
 proc test_tzinfo_isoformat() {
-  var zero = new Shared(new FixedOffset(0, "+00:00"): TZInfo);
-  var plus = new Shared(new FixedOffset(220, "+03:40"): TZInfo);
-  var minus = new Shared(new FixedOffset(-231, "-03:51"): TZInfo);
+  var zero = new shared FixedOffset(0, "+00:00");
+  var plus = new shared FixedOffset(220, "+03:40");
+  var minus = new shared FixedOffset(-231, "-03:51");
 
   var datestr = '0001-02-03';
   for ofs in (zero, plus, minus) {
@@ -379,8 +378,8 @@ proc test_tzinfo_isoformat() {
 }
 
 proc test_replace() {
-  var z100 = new Shared(new FixedOffset(100, "+100"): TZInfo);
-  var zm200 = new Shared(new FixedOffset(new timedelta(minutes=-200), "-200"): TZInfo);
+  var z100 = new shared FixedOffset(100, "+100");
+  var zm200 = new shared FixedOffset(new timedelta(minutes=-200), "-200");
   var args = (1, 2, 3, 4, 5, 6, 7);
   var base = new datetime((...args), z100);
   assert(base == base.replace(tzinfo=base.tzinfo));
@@ -424,7 +423,7 @@ proc test_replace() {
 
   // Ensure we can get rid of a tzinfo.
   assert(base.tzname() == "+100");
-  var base2 = base.replace(tzinfo=new Shared(nil: TZInfo));
+  var base2 = base.replace(tzinfo=new Shared(nil: unmanaged TZInfo));
   assert(base2.tzinfo.borrow() == nil);
 
   // Ensure we can add one.
@@ -435,8 +434,8 @@ proc test_replace() {
 
 proc test_more_astimezone() {
   // The inherited test_astimezone covered some trivial and error cases.
-  var f44m = new Shared(new FixedOffset(44, "44"): TZInfo);
-  var fm5h = new Shared(new FixedOffset(-(new timedelta(hours=5)), "m300"): TZInfo);
+  var f44m = new shared FixedOffset(44, "44");
+  var fm5h = new shared FixedOffset(-(new timedelta(hours=5)), "m300");
 
   var dt = datetime.now(tz=f44m);
   assert(dt.tzinfo == f44m);
@@ -477,7 +476,7 @@ proc test_aware_subtract() {
     }
   }
 
-  var base = new datetime(8, 9, 10, 11, 12, 13, 14, tzinfo=new Shared(new OperandDependentOffset(): TZInfo));
+  var base = new datetime(8, 9, 10, 11, 12, 13, 14, tzinfo=new shared OperandDependentOffset());
   var d0 = base.replace(minute=3, tzinfo=base.tzinfo);
   var d1 = base.replace(minute=9, tzinfo=base.tzinfo);
   var d2 = base.replace(minute=11, tzinfo=base.tzinfo);
@@ -491,9 +490,9 @@ proc test_aware_subtract() {
   // OTOH, if the tzinfo members are distinct, utcoffsets aren't
   // ignored.
   base = new datetime(8, 9, 10, 11, 12, 13, 14);
-  d0 = base.replace(minute=3, tzinfo=new Shared(new OperandDependentOffset(): TZInfo));
-  d1 = base.replace(minute=9, tzinfo=new Shared(new OperandDependentOffset(): TZInfo));
-  d2 = base.replace(minute=11, tzinfo=new Shared(new OperandDependentOffset(): TZInfo));
+  d0 = base.replace(minute=3, tzinfo=new shared OperandDependentOffset());
+  d1 = base.replace(minute=9, tzinfo=new shared OperandDependentOffset());
+  d2 = base.replace(minute=11, tzinfo=new shared OperandDependentOffset());
   for x in (d0, d1, d2) {
     for y in (d0, d1, d2) {
       var got = x - y;
@@ -517,9 +516,9 @@ proc test_mixed_compare() {
   var t1 = new datetime(1, 2, 3, 4, 5, 6, 7);
   var t2 = new datetime(1, 2, 3, 4, 5, 6, 7);
   assert(t1 == t2);
-  t2 = t2.replace(tzinfo=new Shared(nil: TZInfo));
+  t2 = t2.replace(tzinfo=new Shared(nil: unmanaged TZInfo));
   assert(t1 == t2);
-  t2 = t2.replace(tzinfo=new Shared(new FixedOffset(0, ""): TZInfo));
+  t2 = t2.replace(tzinfo=new shared FixedOffset(0, ""));
 
   // In datetime w/ identical tzinfo objects, utcoffset is ignored.
   class Varies: TZInfo {
@@ -533,7 +532,7 @@ proc test_mixed_compare() {
     }
   }
 
-  var v = new Shared(new Varies(): TZInfo);
+  var v = new shared Varies();
   t1 = t2.replace(tzinfo=v);
   t2 = t2.replace(tzinfo=v);
   assert(t1.utcoffset() == new timedelta(minutes=23));
@@ -541,7 +540,7 @@ proc test_mixed_compare() {
   assert(t1 == t2);
 
   // But if they're not identical, it isn't ignored.
-  t2 = t2.replace(tzinfo=new Shared(new Varies(): TZInfo));
+  t2 = t2.replace(tzinfo=new shared Varies());
   assert(t1 < t2);  // t1's offset counter still going up
 }
 

--- a/test/library/standard/DateTime/testTimezone.chpl
+++ b/test/library/standard/DateTime/testTimezone.chpl
@@ -38,9 +38,9 @@ proc test_empty() {
 }
 
 proc test_zones() {
-  var est = new Shared(new FixedOffset(-300, "EST", 1): TZInfo);
-  var utc = new Shared(new FixedOffset(0, "UTC", -2): TZInfo);
-  var met = new Shared(new FixedOffset(60, "MET", 3): TZInfo);
+  var est = new shared FixedOffset(-300, "EST", 1);
+  var utc = new shared FixedOffset(0, "UTC", -2);
+  var met = new shared FixedOffset(60, "MET", 3);
   var t1 = new time( 7, 47, tzinfo=est);
   var t2 = new time(12, 47, tzinfo=utc);
   var t3 = new time(13, 47, tzinfo=met);
@@ -95,8 +95,8 @@ proc test_zones() {
 }
 
 proc test_replace() {
-  var z100 = new Shared(new FixedOffset(100, "+100"): TZInfo);
-  var zm200 = new Shared(new FixedOffset(new timedelta(minutes=-200), "-200"): TZInfo);
+  var z100 = new shared FixedOffset(100, "+100");
+  var zm200 = new shared FixedOffset(new timedelta(minutes=-200), "-200");
   var args = (1, 2, 3, 4);
   var base = new time((...args), z100);
   assert(base == base.replace(tzinfo=base.tzinfo));
@@ -132,7 +132,7 @@ proc test_replace() {
 
   // Ensure we can get rid of a tzinfo.
   assert(base.tzname() == "+100");
-  var base2 = base.replace(tzinfo=new Shared(nil: TZInfo));
+  var base2 = base.replace(tzinfo=new Shared(TZInfo));
   assert(base2.tzinfo.borrow() == nil);
   assert(base2.tzname() == "");
 
@@ -146,9 +146,9 @@ proc test_mixed_compare() {
   var t1 = new time(1, 2, 3);
   var t2 = new time(1, 2, 3);
   assert(t1 == t2);
-  t2 = t2.replace(tzinfo=new Shared(nil: TZInfo));
+  t2 = t2.replace(tzinfo=new Shared(TZInfo));
   assert(t1 == t2);
-  t2 = t2.replace(tzinfo=new Shared(new FixedOffset(0, ""): TZInfo));
+  t2 = t2.replace(tzinfo=new shared FixedOffset(0, ""));
 
   // In time w/ identical tzinfo objects, utcoffset is ignored.
   class Varies: TZInfo {
@@ -169,7 +169,7 @@ proc test_mixed_compare() {
     }
   }
 
-  var v = new Shared(new Varies(): TZInfo);
+  var v = new shared Varies();
   t1 = t2.replace(tzinfo=v);
   t2 = t2.replace(tzinfo=v);
   assert(t1.utcoffset() == new timedelta(minutes=23));
@@ -177,7 +177,7 @@ proc test_mixed_compare() {
   assert(t1 == t2);
 
   // But if they're not identical, it isn't ignored.
-  t2 = t2.replace(tzinfo=new Shared(new Varies(): TZInfo));
+  t2 = t2.replace(tzinfo=new shared Varies());
   assert(t1 < t2);  // t1's offset counter still going up
 }
 

--- a/test/library/standard/DateTime/testTimezoneConversions.chpl
+++ b/test/library/standard/DateTime/testTimezoneConversions.chpl
@@ -56,7 +56,7 @@ class USTimeZone: TZInfo {
 
     // Can't compare naive to aware objects, so strip the timezone from
     // dt first.
-    if start <= dt.replace(tzinfo=new Shared(nil: TZInfo)) && dt.replace(tzinfo=new Shared(nil:TZInfo)) < end {
+    if start <= dt.replace(tzinfo=new Shared(nil: unmanaged TZInfo)) && dt.replace(tzinfo=new Shared(nil:unmanaged TZInfo)) < end {
       return HOUR;
     } else {
       return ZERO;
@@ -114,12 +114,12 @@ proc first_sunday_on_or_after(in dt) {
   return dt;
 }
 
-var Eastern  = new Shared(new USTimeZone(-5, "Eastern",  "EST", "EDT"): TZInfo);
-var Central  = new Shared(new USTimeZone(-6, "Central",  "CST", "CDT"): TZInfo);
-var Mountain = new Shared(new USTimeZone(-7, "Mountain", "MST", "MDT"): TZInfo);
-var Pacific  = new Shared(new USTimeZone(-8, "Pacific",  "PST", "PDT"): TZInfo);
-var utc_real = new Shared(new FixedOffset(0, "UTC", 0): TZInfo);
-var utc_fake = new Shared(new FixedOffset(-12*60, "UTCfake", 0): TZInfo);
+var Eastern  = new shared USTimeZone(-5, "Eastern",  "EST", "EDT");
+var Central  = new shared USTimeZone(-6, "Central",  "CST", "CDT");
+var Mountain = new shared USTimeZone(-7, "Mountain", "MST", "MDT");
+var Pacific  = new shared USTimeZone(-8, "Pacific",  "PST", "PDT");
+var utc_real = new shared FixedOffset(0, "UTC", 0);
+var utc_fake = new shared FixedOffset(-12*60, "UTCfake", 0);
 
 // DST switch times for 2002
 var dston = new datetime(2002, 4, 7, 2);
@@ -247,7 +247,7 @@ proc test_easy() {
 proc test_tricky() {
   // 22:00 on day before daylight starts.
   var fourback = dston - new timedelta(hours=4);
-  var ninewest = new Shared(new FixedOffset(-9*60, "-0900", 0): TZInfo);
+  var ninewest = new shared FixedOffset(-9*60, "-0900", 0);
   fourback = fourback.replace(tzinfo=ninewest);
   // 22:00-0900 is 7:00 UTC == 2:00 EST == 3:00 DST.  Since it's "after
   // 2", we should get the 3 spelling.
@@ -257,7 +257,7 @@ proc test_tricky() {
   // local clock jumps from 1 to 3).  The point here is to make sure we
   // get the 3 spelling.
   var expected = dston.replace(hour=3, tzinfo=dston.tzinfo);
-  var got = fourback.astimezone(Eastern).replace(tzinfo=new Shared(nil: TZInfo));
+  var got = fourback.astimezone(Eastern).replace(tzinfo=new Shared(TZInfo));
   assert(expected == got);
 
   // Similar, but map to 6:00 UTC == 1:00 EST == 2:00 DST.  In that
@@ -267,7 +267,7 @@ proc test_tricky() {
   // and adding -4-0 == -4 gives the 2:00 spelling.  We want the 1:00 EST
   // spelling.
   expected = dston.replace(hour=1, tzinfo=dston.tzinfo);
-  got = sixutc.astimezone(Eastern).replace(tzinfo=new Shared(nil: TZInfo));
+  got = sixutc.astimezone(Eastern).replace(tzinfo=new Shared(TZInfo));
   assert(expected == got);
 
   // Now on the day DST ends, we want "repeat an hour" behavior.
@@ -291,7 +291,7 @@ proc test_tricky() {
           expected = expectedbase.replace(minute=minute, tzinfo=expectedbase.tzinfo);
           asutc = asutcbase.replace(minute=minute, tzinfo=asutcbase.tzinfo);
           var astz = asutc.astimezone(tz);
-          assert(astz.replace(tzinfo=new Shared(nil: TZInfo)) == expected);
+          assert(astz.replace(tzinfo=new Shared(TZInfo)) == expected);
         }
         asutcbase += HOUR;
       }
@@ -316,8 +316,8 @@ proc test_fromutc() {
     }
   }
 
-  var FEastern  = new Shared(new FauxUSTimeZone(-5, "FEastern",  "FEST", "FEDT"): TZInfo);
-  var FEasternRef = FEastern.borrow(): USTimeZone;
+  var FEastern  = new shared FauxUSTimeZone(-5, "FEastern",  "FEST", "FEDT");
+  var FEasternRef = FEastern.borrow(): borrowed USTimeZone;
 
   //  UTC  4:MM  5:MM  6:MM  7:MM  8:MM  9:MM
   //  EST 23:MM  0:MM  1:MM  2:MM  3:MM  4:MM


### PR DESCRIPTION
Relies on PR  #9999 to actually get these tests passing with --warn-unstable
but I'm committing the changes in a separate and independent branch
so the review is easier.

- [x] full local testing

Reviewed by @daviditen - thanks!