### PR TITLE
Migrate AMR tests to use unmanaged

### DIFF
--- a/test/studies/amr/advection/amr/AMRBC_AdvectionCTU.chpl
+++ b/test/studies/amr/advection/amr/AMRBC_AdvectionCTU.chpl
@@ -2,11 +2,11 @@ use AMRBC_def;
 
 class ZeroInflowBC: AMRBC {
   
-  proc apply(level_idx: int, q: LevelVariable, t: real) {
+  proc apply(level_idx: int, q: unmanaged LevelVariable, t: real) {
     apply_Homogeneous(level_idx, q);
   }
   
-  proc apply_Homogeneous(level_idx: int, q: LevelVariable) 
+  proc apply_Homogeneous(level_idx: int, q: unmanaged LevelVariable) 
   {
     
     //---- Safety check ----

--- a/test/studies/amr/advection/amr/AMRHierarchy_AdvectionCTU.chpl
+++ b/test/studies/amr/advection/amr/AMRHierarchy_AdvectionCTU.chpl
@@ -18,7 +18,7 @@ use AMRBC_def;
 //------------------------------------------------------------------
 
 proc AMRHierarchy.advance_AdvectionCTU(
-  bc:             AMRBC,
+  bc:             unmanaged AMRBC,
   velocity:       dimension*real,
   time_requested: real)
 {
@@ -101,7 +101,7 @@ proc AMRHierarchy.advance_AdvectionCTU(
 
 proc AMRHierarchy.stepLevel_AdvectionCTU(
   i_level: int,
-  bc:        AMRBC,
+  bc:        unmanaged AMRBC,
   velocity:  dimension*real,
   dt:        real)
 {

--- a/test/studies/amr/advection/amr/AMR_AdvectionCTU_driver.chpl
+++ b/test/studies/amr/advection/amr/AMR_AdvectionCTU_driver.chpl
@@ -26,7 +26,7 @@ class GradientFlagger: Flagger {
   //----------------------------------------------------------------------
   
   proc setFlags (
-    level_solution: LevelSolution, 
+    level_solution: unmanaged LevelSolution, 
     flags:          [level_solution.level.possible_cells] bool )
   {
     
@@ -138,8 +138,8 @@ proc main {
     else return 0.0;
   }
   
-  const flagger = new GradientFlagger(tolerance = 0.1);
-  const hierarchy = new AMRHierarchy(hierarchy_file_name,
+  const flagger = new unmanaged GradientFlagger(tolerance = 0.1);
+  const hierarchy = new unmanaged AMRHierarchy(hierarchy_file_name,
                                      flagger,
                                      elevatedCircle);
 
@@ -163,7 +163,7 @@ proc main {
 
 
   //---- Set boundary conditions ----
-  var bc = new ZeroInflowBC(hierarchy = hierarchy);
+  var bc = new unmanaged ZeroInflowBC(hierarchy = hierarchy);
 
 
 

--- a/test/studies/amr/advection/grid/GridBC_AdvectionCTU.chpl
+++ b/test/studies/amr/advection/grid/GridBC_AdvectionCTU.chpl
@@ -10,10 +10,10 @@ class ZeroInflowAdvectionBC: GridBC {
   
   //---- This type of BC is homogeneous ----
   
-  proc apply ( q: GridVariable, t: real ) { apply_Homogeneous(q); }
+  proc apply ( q: unmanaged GridVariable, t: real ) { apply_Homogeneous(q); }
   
   
-  proc apply_Homogeneous(q: GridVariable) {
+  proc apply_Homogeneous(q: unmanaged GridVariable) {
 
     for ghost_domain in grid.ghost_domains {
       forall cell in ghost_domain do

--- a/test/studies/amr/advection/grid/GridSolution_AdvectionCTU.chpl
+++ b/test/studies/amr/advection/grid/GridSolution_AdvectionCTU.chpl
@@ -17,7 +17,7 @@ use GridVariable_AdvectionCTU;
 //------------------------------------------------------------------
 
 proc GridSolution.advance_AdvectionCTU(
-  bc:             GridBC,
+  bc:             unmanaged GridBC,
   velocity:       dimension*real,
   time_requested: real)
 {
@@ -72,7 +72,7 @@ proc GridSolution.advance_AdvectionCTU(
 //-------------------------------------------------------------
 
 proc GridSolution.step_AdvectionCTU(
-  bc:       GridBC,
+  bc:       unmanaged GridBC,
   velocity: dimension*real,
   dt:       real)
 {

--- a/test/studies/amr/advection/grid/GridVariable_AdvectionCTU.chpl
+++ b/test/studies/amr/advection/grid/GridVariable_AdvectionCTU.chpl
@@ -22,7 +22,7 @@ use GridVariable_def;
 //----------------------------------------------------------------
 
 proc GridVariable.storeCTUOperator(
-  q_in:     GridVariable,
+  q_in:     unmanaged GridVariable,
   velocity: dimension*real,
   dt:       real)
 {

--- a/test/studies/amr/advection/grid/Grid_AdvectionCTU_driver.chpl
+++ b/test/studies/amr/advection/grid/Grid_AdvectionCTU_driver.chpl
@@ -34,7 +34,7 @@ proc main {
     return f;
   }
 
-  var sol = new GridSolution(grid = grid);
+  var sol = new unmanaged GridSolution(grid = grid);
 
   sol.setToFunction(initial_condition, output_times(0));
   //<=== Initialize solution <===
@@ -51,7 +51,7 @@ proc main {
 
   //==== Initialize boundary conditions ====
 /*   var bc = new ZeroInflowAdvectionGridBC(grid = grid); */
-  var bc = new PeriodicGridBC(grid = grid);
+  var bc = new unmanaged PeriodicGridBC(grid = grid);
 
 
 

--- a/test/studies/amr/advection/level/LevelBC_AdvectionCTU.chpl
+++ b/test/studies/amr/advection/level/LevelBC_AdvectionCTU.chpl
@@ -5,11 +5,11 @@ use LevelBC_def;
 //|/___________________________________|/
 class ZeroInflowBC: LevelBC {
 
-  proc apply(q: LevelVariable, t: real){
+  proc apply(q: unmanaged LevelVariable, t: real){
     apply_Homogeneous(q);
   }
 
-  proc apply_Homogeneous(q: LevelVariable){
+  proc apply_Homogeneous(q: unmanaged LevelVariable){
 
     for grid in level.grids {
 

--- a/test/studies/amr/advection/level/LevelSolution_AdvectionCTU.chpl
+++ b/test/studies/amr/advection/level/LevelSolution_AdvectionCTU.chpl
@@ -18,7 +18,7 @@ use LevelBC_def;
 //-----------------------------------------------------------
 
 proc LevelSolution.advance_AdvectionCTU(
-  bc:             LevelBC,
+  bc:             unmanaged LevelBC,
   velocity:       dimension*real,
   time_requested: real)
 {

--- a/test/studies/amr/advection/level/LevelVariable_AdvectionCTU.chpl
+++ b/test/studies/amr/advection/level/LevelVariable_AdvectionCTU.chpl
@@ -3,7 +3,7 @@ use LevelVariable_def;
 
 
 proc LevelVariable.storeCTUOperator(
-  q:        LevelVariable,
+  q:        unmanaged LevelVariable,
   velocity: dimension*real,
   dt:       real)
 {

--- a/test/studies/amr/advection/level/Level_AdvectionCTU_driver.chpl
+++ b/test/studies/amr/advection/level/Level_AdvectionCTU_driver.chpl
@@ -32,7 +32,7 @@ proc main {
     return f;
   }
 
-  var solution = new LevelSolution(level = level);
+  var solution = new unmanaged LevelSolution(level = level);
   solution.setToFunction(initial_condition, output_times(0));
   write("done.\n");
   //<=== Initialize  solution <===
@@ -54,7 +54,7 @@ proc main {
 
   //==== Set boundary conditions ====
   write("Setting boundary conditions...");
-  var bc = new ZeroInflowBC(level = level);
+  var bc = new unmanaged ZeroInflowBC(level = level);
   write("done.\n");
 
 

--- a/test/studies/amr/diffusion/grid/GridBC_DiffusionBE.chpl
+++ b/test/studies/amr/diffusion/grid/GridBC_DiffusionBE.chpl
@@ -7,13 +7,13 @@ use GridBC_def;
 
 class ZeroFluxDiffusionBC: GridBC {
   
-  proc apply(q: GridVariable, t: real)
+  proc apply(q: unmanaged GridVariable, t: real)
   {
     apply_Homogeneous(q);
   }
 
 
-  proc apply_Homogeneous(q: GridVariable) {
+  proc apply_Homogeneous(q: unmanaged GridVariable) {
 
     for ghost_domain in grid.ghost_domains {
       var loc = grid.relativeLocation(ghost_domain);

--- a/test/studies/amr/diffusion/grid/GridSolution_DiffusionBE.chpl
+++ b/test/studies/amr/diffusion/grid/GridSolution_DiffusionBE.chpl
@@ -10,7 +10,7 @@ use GridBC_def;
 // diffusion via Backward Euler.
 //----------------------------------------------------------------------
 proc GridSolution.advance_DiffusionBE(
-  bc:             GridBC,
+  bc:             unmanaged GridBC,
   diffusivity:    real,
   time_requested: real,
   dt_max:         real)
@@ -55,7 +55,7 @@ proc GridSolution.advance_DiffusionBE(
 //===> GridSolution.step_DiffusionBE method ===>
 //====================================>
 proc GridSolution.step_DiffusionBE(
-  bc:          GridBC,
+  bc:          unmanaged GridBC,
   diffusivity: real,
   dt:          real, 
   tolerance:   real
@@ -84,7 +84,7 @@ proc GridSolution.step_DiffusionBE(
   // a clean decoupling of the "ghostFill" and "homogeneousGhostFill"
   // methods.
   //----------------------------------------------------------------------
-  var rhs = new GridVariable(grid);
+  var rhs = new unmanaged GridVariable(grid);
   bc.apply(current_data, t_new);
   rhs.storeFluxDivergence(current_data, diffusivity);
   rhs(grid.cells) *= -dt;
@@ -97,7 +97,7 @@ proc GridSolution.step_DiffusionBE(
   //------------------------------------------------------------
   // residual = rhs - (dq + dt*flux_divergence(dq))
   //------------------------------------------------------------
-  var residual = new GridVariable(grid);
+  var residual = new unmanaged GridVariable(grid);
   bc.apply_Homogeneous(dq);
   residual.storeBEOperator(dq, diffusivity, dt);
   residual(grid.cells) = rhs(grid.cells) - residual(grid.cells);
@@ -105,7 +105,7 @@ proc GridSolution.step_DiffusionBE(
 
 
   //==== Initialize search direction ====
-  var search_dir = new GridVariable(grid);
+  var search_dir = new unmanaged GridVariable(grid);
   search_dir(grid.cells) = residual(grid.cells);
   
 
@@ -113,7 +113,7 @@ proc GridSolution.step_DiffusionBE(
   //--------------------------------------------------
   // Initializes to homogeneousBEOperator(search_dir)
   //--------------------------------------------------
-  var residual_update = new GridVariable(grid);
+  var residual_update = new unmanaged GridVariable(grid);
   bc.apply_Homogeneous(search_dir);
   residual_update.storeBEOperator(search_dir, diffusivity, dt);
   

--- a/test/studies/amr/diffusion/grid/GridVariable_DiffusionBE.chpl
+++ b/test/studies/amr/diffusion/grid/GridVariable_DiffusionBE.chpl
@@ -9,7 +9,7 @@ use GridVariable_def;
 // As with FluxDivergence, ghost cells must be filled beforehand.
 //----------------------------------------------------------------
 proc GridVariable.storeBEOperator(
-  q:           GridVariable,
+  q:           unmanaged GridVariable,
   diffusivity: real,
   dt:          real
 ){
@@ -31,7 +31,7 @@ proc GridVariable.storeBEOperator(
 // cells of q must be filled beforehand
 //-----------------------------------------------------------
 proc GridVariable.storeFluxDivergence(
-  q:               GridVariable,
+  q:               unmanaged GridVariable,
   diffusivity:     real)
 {
 

--- a/test/studies/amr/diffusion/grid/Grid_DiffusionBE_driver.chpl
+++ b/test/studies/amr/diffusion/grid/Grid_DiffusionBE_driver.chpl
@@ -35,7 +35,7 @@ proc main {
     return f;
   }
 
-  var solution = new GridSolution(grid);
+  var solution = new unmanaged GridSolution(grid);
   solution.setToFunction(initial_condition, output_times(0));
 
   var dt_max = 0.05;
@@ -44,7 +44,7 @@ proc main {
 
 
   //==== Initialize boundary conditions ====
-  var bc = new ZeroFluxDiffusionBC(grid = grid);
+  var bc = new unmanaged ZeroFluxDiffusionBC(grid = grid);
 /*   var bc = new PeriodicGridBC(grid = grid); */
 
 

--- a/test/studies/amr/diffusion/level/LevelBC_DiffusionBE.chpl
+++ b/test/studies/amr/diffusion/level/LevelBC_DiffusionBE.chpl
@@ -6,12 +6,12 @@ use LevelBC_def;
 //|/__________________________________________|/
 class ZeroFluxDiffusionBC: LevelBC {
   
-  proc apply(q: LevelVariable, t: real) {
+  proc apply(q: unmanaged LevelVariable, t: real) {
     apply_Homogeneous(q);
   }
 
   
-  proc apply_Homogeneous(q: LevelVariable) {
+  proc apply_Homogeneous(q: unmanaged LevelVariable) {
     
     for grid in level.grids {
     

--- a/test/studies/amr/diffusion/level/LevelSolution_DiffusionBE.chpl
+++ b/test/studies/amr/diffusion/level/LevelSolution_DiffusionBE.chpl
@@ -7,7 +7,7 @@ use LevelBC_def;
 //|/_________________________________________________|/
 
 proc LevelSolution.advance_DiffusionBE(
-  bc:             LevelBC,
+  bc:             unmanaged LevelBC,
   diffusivity:    real,
   time_requested: real,
   dt_max:         real)
@@ -51,14 +51,14 @@ proc LevelSolution.advance_DiffusionBE(
 //|/______________________________________________|/
 
 proc LevelSolution.step_DiffusionBE(
-  bc:           LevelBC,
+  bc:           unmanaged LevelBC,
   diffusivity:  real,
   dt:           real,
   tolerance:    real)
 {
 
   //==== Set rhs ====
-  var rhs = new LevelVariable(level = level);
+  var rhs = new unmanaged LevelVariable(level = level);
   bc.apply(current_data, current_time+dt);
   rhs.storeFluxDivergence(current_data, diffusivity);
   for grid in level.grids do rhs(grid,grid.cells) *= -dt;

--- a/test/studies/amr/diffusion/level/LevelVariable_DiffusionBE.chpl
+++ b/test/studies/amr/diffusion/level/LevelVariable_DiffusionBE.chpl
@@ -7,29 +7,29 @@ use LevelBC_def;
 //|===> LevelVariable.storeCGSolution ===>
 //|__________________________________/
 proc LevelVariable.storeCGSolution(
-  rhs: LevelVariable,
-  bc:  LevelBC,
+  rhs: unmanaged LevelVariable,
+  bc:  unmanaged LevelBC,
   diffusivity: real,
   dt: real,
   tolerance: real)
 {
   
   //==== Initialize residual ====
-  var residual = new LevelVariable(level = level);
-  bc.apply_Homogeneous(this);
-  residual.storeBEOperator(this, diffusivity, dt);
+  var residual = new unmanaged LevelVariable(level = level);
+  bc.apply_Homogeneous(_to_unmanaged(this));
+  residual.storeBEOperator(_to_unmanaged(this), diffusivity, dt);
   for grid in level.grids do
     residual(grid,grid.cells) = rhs(grid,grid.cells) - residual(grid,grid.cells);			       
 
 
   //==== Initialize search direction ====
-  var search_dir = new LevelVariable(level = level);
+  var search_dir = new unmanaged LevelVariable(level = level);
   for grid in level.grids do
     search_dir(grid,grid.cells) = residual(grid,grid.cells);
 
 
   //==== Initialize residual update direction ====
-  var residual_update = new LevelVariable(level = level);
+  var residual_update = new unmanaged LevelVariable(level = level);
   bc.apply_Homogeneous(search_dir);
   residual_update.storeBEOperator(search_dir, diffusivity, dt);
 
@@ -107,7 +107,7 @@ proc LevelVariable.storeCGSolution(
 //|===> LevelVariable.storeBEOperator ===>
 //|__________________________________/
 proc LevelVariable.storeBEOperator(
-  q:           LevelVariable,
+  q:           unmanaged LevelVariable,
   diffusivity: real,
   dt:          real)
 {
@@ -126,7 +126,7 @@ proc LevelVariable.storeBEOperator(
 
 
 proc LevelVariable.storeFluxDivergence(
-  q:           LevelVariable,
+  q:           unmanaged LevelVariable,
   diffusivity: real)
 {
   q.fillOverlaps();

--- a/test/studies/amr/diffusion/level/Level_DiffusionBE_driver.chpl
+++ b/test/studies/amr/diffusion/level/Level_DiffusionBE_driver.chpl
@@ -30,7 +30,7 @@ proc main {
     return f;
   }
 
-  var solution = new LevelSolution(level = level);
+  var solution = new unmanaged LevelSolution(level = level);
   solution.setToFunction(initial_condition, output_times(0));
 
   //==== Max time step ====
@@ -57,7 +57,7 @@ proc main {
 
   //==== Set boundary conditions ====
   write("Setting boundary conditions...");
-  var bc = new ZeroFluxDiffusionBC(level = level);
+  var bc = new unmanaged ZeroFluxDiffusionBC(level = level);
   write("done.\n");
 
 

--- a/test/studies/amr/lib/amr/AMRBC_def.chpl
+++ b/test/studies/amr/lib/amr/AMRBC_def.chpl
@@ -6,10 +6,10 @@ use AMRHierarchy_def;
 //|___________________/
 class AMRBC {
 
-  const hierarchy: AMRHierarchy;
+  const hierarchy: unmanaged AMRHierarchy;
 
-  proc apply(level_idx: int, q: LevelVariable, t: real) {}
-  proc apply_Homogeneous(level_idx: int, q: LevelVariable) {}
+  proc apply(level_idx: int, q: unmanaged LevelVariable, t: real) {}
+  proc apply_Homogeneous(level_idx: int, q: unmanaged LevelVariable) {}
 
 }
 // /"""""""""""""""""""|

--- a/test/studies/amr/lib/amr/AMRHierarchy_def.chpl
+++ b/test/studies/amr/lib/amr/AMRHierarchy_def.chpl
@@ -29,24 +29,24 @@ class AMRHierarchy {
 
   //---- Spatial structure ----
 
-  var levels:              [level_indices] Level;
-  var invalid_regions:     [level_indices] LevelInvalidRegion;
-  var cf_ghost_regions:    [level_indices] LevelCFGhostRegion;
-  var physical_boundaries: [level_indices] PhysicalBoundary;
+  var levels:              [level_indices] unmanaged Level;
+  var invalid_regions:     [level_indices] unmanaged LevelInvalidRegion;
+  var cf_ghost_regions:    [level_indices] unmanaged LevelCFGhostRegion;
+  var physical_boundaries: [level_indices] unmanaged PhysicalBoundary;
 
 
 
   //---- Solution information ----
 
-  var level_solutions:    [level_indices] LevelSolution;
-  var cf_ghost_solutions: [level_indices] LevelCFGhostSolution;
+  var level_solutions:    [level_indices] unmanaged LevelSolution;
+  var cf_ghost_solutions: [level_indices] unmanaged LevelCFGhostSolution;
   var time:               real;
 
 
 
   //---- Regridding ----
   
-  const flagger:             Flagger;  // Flagger class is defined below  
+  const flagger:             unmanaged Flagger;  // Flagger class is defined below  
   const target_efficiency:   real;
   const steps_before_regrid: int = 2;
   var   regrid_counters:     [level_indices] int;
@@ -71,7 +71,7 @@ class AMRHierarchy {
     max_n_levels:      int,
     ref_ratio:         dimension*int,
     target_efficiency: real,
-    flagger:           Flagger,
+    flagger:           unmanaged Flagger,
     initialCondition:  func(dimension*real, real) )
   {
 
@@ -88,18 +88,18 @@ class AMRHierarchy {
 
     //---- Create the base level ----
     
-    levels(1) = new Level(x_low = x_low,  x_high = x_high,
+    levels(1) = new unmanaged Level(x_low = x_low,  x_high = x_high,
                           n_cells       = n_coarsest_cells,
                           n_ghost_cells = n_ghost_cells);
     writeln("Adding grid to level 1.");         
     levels(1).addGrid(levels(1).possible_cells);
     levels(1).complete();
-    physical_boundaries(1) = new PhysicalBoundary(levels(1));
+    physical_boundaries(1) = new unmanaged PhysicalBoundary(levels(1));
 
 
     //---- Create base solution ----
     
-    level_solutions(1) = new LevelSolution(levels(1));
+    level_solutions(1) = new unmanaged LevelSolution(levels(1));
     level_solutions(1).setToFunction(initialCondition, time);
     
     
@@ -124,7 +124,7 @@ class AMRHierarchy {
 
 
         //---- Create new solution ----
-        level_solutions(i_finest) = new LevelSolution(new_level);
+        level_solutions(i_finest) = new unmanaged LevelSolution(new_level);
         level_solutions(i_finest).setToFunction( initialCondition, time );
         
       
@@ -226,7 +226,7 @@ proc AMRHierarchy.regrid ( i_base: int )
 
 
       //---- Create and fill new solution ----
-      level_solutions(i_finest) = new LevelSolution( new_level );
+      level_solutions(i_finest) = new unmanaged LevelSolution( new_level );
       level_solutions(i_finest+1).initialFill( level_solutions(i_finest) );
 
 
@@ -287,7 +287,7 @@ proc AMRHierarchy.regrid ( i_base: int )
             
       //---- Create solution on regridded level ----
 
-      var regridded_level_solution = new LevelSolution(regridded_level);
+      var regridded_level_solution = new unmanaged LevelSolution(regridded_level);
       regridded_level_solution.initialFill( level_solutions(i_regridding), 
                                             level_solutions(i_regridding-1) );
 
@@ -414,12 +414,12 @@ proc AMRHierarchy.buildRefinedLevel ( i_refining: int )
   
   //===> Ensure proper nesting ===>
 
-  var domains_to_refine = new List( domain(dimension,stridable=true) );  
+  var domains_to_refine = new unmanaged List( domain(dimension,stridable=true) );  
   
   
   //---- Form exterior of coarse level ----
   
-  var coarse_exterior = new MultiDomain(dimension,stridable=true);
+  var coarse_exterior = new unmanaged MultiDomain(dimension,stridable=true);
   coarse_exterior.add( coarse_level.possible_cells );
   
   for grid in coarse_level.grids do
@@ -432,7 +432,7 @@ proc AMRHierarchy.buildRefinedLevel ( i_refining: int )
     
     //---- Remove any portion of D within 1 cell of coarse_exterior ----
     
-    var properly_nested_domains = new MultiDomain(dimension,stridable=true);
+    var properly_nested_domains = new unmanaged MultiDomain(dimension,stridable=true);
     properly_nested_domains.add(D);
 
     for exterior_D in coarse_exterior do 
@@ -461,7 +461,7 @@ proc AMRHierarchy.buildRefinedLevel ( i_refining: int )
   
   //===> Create new level, and return ===>
   
-  var new_level = new Level(x_low   = this.x_low,
+  var new_level = new unmanaged Level(x_low   = this.x_low,
                             x_high  = this.x_high,
                             n_cells = levels(i_refining).n_cells * ref_ratio,
                             n_ghost_cells = this.n_ghost_cells);
@@ -503,13 +503,13 @@ proc AMRHierarchy.buildRefinedLevel ( i_refining: int )
 proc AMRHierarchy.createBoundaryStructures( i: int )
 {
 
-  invalid_regions(i-1)   = new LevelInvalidRegion( levels(i-1), levels(i) );
+  invalid_regions(i-1)   = new unmanaged LevelInvalidRegion( levels(i-1), levels(i) );
   
-  cf_ghost_regions(i)    = new LevelCFGhostRegion( levels(i), levels(i-1) );
+  cf_ghost_regions(i)    = new unmanaged LevelCFGhostRegion( levels(i), levels(i-1) );
 
-  cf_ghost_solutions(i)  = new LevelCFGhostSolution( cf_ghost_regions(i), levels(i) );
+  cf_ghost_solutions(i)  = new unmanaged LevelCFGhostSolution( cf_ghost_regions(i), levels(i) );
 
-  physical_boundaries(i) = new PhysicalBoundary( levels(i) );
+  physical_boundaries(i) = new unmanaged PhysicalBoundary( levels(i) );
   
   
 }
@@ -564,9 +564,9 @@ proc AMRHierarchy.deleteBoundaryStructures( i: int )
 class PhysicalBoundary
 {
 
-  const level:        Level;
-  const grids:        domain(Grid);
-  const multidomains: [grids] MultiDomain(dimension,stridable=true);
+  const level:        unmanaged Level;
+  const grids:        domain(unmanaged Grid);
+  const multidomains: [grids] unmanaged MultiDomain(dimension,stridable=true);
 
 
 
@@ -574,12 +574,12 @@ class PhysicalBoundary
   //| >    initializer    | >
   //|/....................|/
   
-  proc init ( level: Level ) 
+  proc init ( level: unmanaged Level ) 
   {
     this.complete();
     for grid in level.grids {
 
-      var boundary_multidomain = new MultiDomain(dimension,stridable=true);
+      var boundary_multidomain = new unmanaged MultiDomain(dimension,stridable=true);
 
       for D in grid.ghost_domains do boundary_multidomain.add( D );
 
@@ -644,7 +644,7 @@ class PhysicalBoundary
 //----------------------------------------------------------
 
 class Flagger {
-  proc setFlags( level_solution: LevelSolution, 
+  proc setFlags( level_solution: unmanaged LevelSolution, 
                  flags: [level_solution.level.possible_cells] bool ) {}
 }
 // /|""""""""""""""""""""""/|
@@ -665,7 +665,7 @@ class Flagger {
 
 proc AMRHierarchy.init (
   file_name:  string,
-  flagger:    Flagger,
+  flagger:    unmanaged Flagger,
   inputIC:    func(dimension*real,real))
 {
 
@@ -732,8 +732,8 @@ proc AMRHierarchy.init (
 //----------------------------------------------------------------------
 
 proc LevelSolution.initialFill (
-  old_solution:    LevelSolution,
-  coarse_solution: LevelSolution )
+  old_solution:    unmanaged LevelSolution,
+  coarse_solution: unmanaged LevelSolution )
 {
   assert( abs(old_solution.current_time - coarse_solution.current_time) < 1.0e-8);
   
@@ -748,7 +748,7 @@ proc LevelSolution.initialFill (
 // This version purely interpolates data from 'coarse_solution'.
 //--------------------------------------------------------------------------
 
-proc LevelSolution.initialFill ( coarse_solution: LevelSolution )
+proc LevelSolution.initialFill ( coarse_solution: unmanaged LevelSolution )
 {
   current_data.initialFill( coarse_solution.current_data );
   current_time = coarse_solution.current_time;
@@ -777,8 +777,8 @@ proc LevelSolution.initialFill ( coarse_solution: LevelSolution )
 //----------------------------------------------------------------
 
 proc LevelVariable.initialFill (
-  q_old:     LevelVariable,
-  q_coarse:  LevelVariable)
+  q_old:     unmanaged LevelVariable,
+  q_coarse:  unmanaged LevelVariable)
 {
 
   //---- Safety check ----
@@ -797,7 +797,7 @@ proc LevelVariable.initialFill (
 
     //---- Initialize structure of unfilled cell blocks ----
     
-    var unfilled_region = new MultiDomain(dimension, true);
+    var unfilled_region = new unmanaged MultiDomain(dimension, true);
     unfilled_region.add( grid.cells );
 
 
@@ -893,9 +893,9 @@ proc LevelVariable.initialFill (
 // LevelVariable.initialFill defined above
 //----------------------------------------------------------------------
 
-proc LevelVariable.initialFill ( q_coarse: LevelVariable )
+proc LevelVariable.initialFill ( q_coarse: unmanaged LevelVariable )
 {
-  const q_old: LevelVariable;
+  const q_old: unmanaged LevelVariable;
   initialFill( q_old, q_coarse );
 }
 // /|""""""""""""""""""""""""""""""""""/|
@@ -982,7 +982,7 @@ proc main {
     const tolerance: real = 0.05;
     
     proc setFlags(
-      level_solution: LevelSolution, 
+      level_solution: unmanaged LevelSolution, 
       flags:          [level_solution.level.possible_cells] bool)
     {
       const current_data = level_solution.current_data;
@@ -1036,11 +1036,11 @@ proc main {
     return f;
   }
   
-  const flagger = new GradientFlagger(tolerance = 0.1);
+  const flagger = new unmanaged GradientFlagger(tolerance = 0.1);
   const target_efficiency = 0.7;
   
   
-  const hierarchy = new AMRHierarchy(x_low,
+  const hierarchy = new unmanaged AMRHierarchy(x_low,
                                      x_high,
                                      n_coarsest_cells,
                                      n_ghost_cells,

--- a/test/studies/amr/lib/amr/BergerRigoutsosClustering.chpl
+++ b/test/studies/amr/lib/amr/BergerRigoutsosClustering.chpl
@@ -24,13 +24,13 @@ proc clusterFlags (
 
   //---- Create stack of unprocessed domains ----
   
-  var unprocessed_domain_stack = new Stack( domain(rank,stridable=true) );
+  var unprocessed_domain_stack = new unmanaged Stack( domain(rank,stridable=true) );
   unprocessed_domain_stack.push(full_domain);
   
   
   //---- List of finished domains ----
   
-  var finished_domain_list = new List( domain(rank, stridable=true) );
+  var finished_domain_list = new unmanaged List( domain(rank, stridable=true) );
   
   
   while !unprocessed_domain_stack.isEmpty()
@@ -39,7 +39,7 @@ proc clusterFlags (
     //---- Make the top domain a candidate ----
     
     var D = unprocessed_domain_stack.pop();
-    var candidate = new CandidateDomain(rank,D,flags(D),min_width);
+    var candidate = new unmanaged CandidateDomain(rank,D,flags(D),min_width);
     
     
     //===> If candidate is inefficient, then split ===>
@@ -102,7 +102,7 @@ class CandidateDomain {
   const D:          domain(rank,stridable=true);
   const flags:      [D] bool;
   const min_width:  rank*int;
-  var   signatures: rank*ArrayWrapper;
+  var   signatures: rank*unmanaged ArrayWrapper;
 
   
   pragma "use default init"
@@ -143,7 +143,7 @@ class CandidateDomain {
     this.complete();
     //---- Calculate signatures ----
     for d in 1..rank do
-      signatures(d) = new ArrayWrapper( {D.dim(d)} );
+      signatures(d) = new unmanaged ArrayWrapper( {D.dim(d)} );
       
     for idx in D 
     {

--- a/test/studies/amr/lib/cfboundary/CFUtilities.chpl
+++ b/test/studies/amr/lib/cfboundary/CFUtilities.chpl
@@ -13,9 +13,9 @@ use Level_def;
 //----------------------------------------------------------
 
 proc refinementRatio( coarse_object, fine_object )
-  where (coarse_object.type == Grid || coarse_object.type == Level)
-     && (fine_object.type == Grid || fine_object.type == Level)
-     && (coarse_object.type == Grid || fine_object.type == Grid)
+  where (coarse_object.type == unmanaged Grid || coarse_object.type == unmanaged Level)
+     && (fine_object.type == unmanaged Grid || fine_object.type == unmanaged Level)
+     && (coarse_object.type == unmanaged Grid || fine_object.type == unmanaged Grid)
 {
   var ref_ratio: dimension*int;
   
@@ -25,7 +25,7 @@ proc refinementRatio( coarse_object, fine_object )
   return ref_ratio;
 }
 
-proc refinementRatio ( coarse_level: Level, fine_level: Level )
+proc refinementRatio ( coarse_level: unmanaged Level, fine_level: unmanaged Level )
 {
   const ref_ratio = fine_level.n_cells / coarse_level.n_cells;
   return ref_ratio;

--- a/test/studies/amr/lib/cfboundary/CoarseningTransfer.chpl
+++ b/test/studies/amr/lib/cfboundary/CoarseningTransfer.chpl
@@ -20,7 +20,7 @@ class GridInvalidRegion {
   //| >    fields    | >
   //|/...............|/
   
-  const fine_neighbors: domain(Grid);
+  const fine_neighbors: domain(unmanaged Grid);
   const domains:        [fine_neighbors] domain(dimension,stridable=true);
   
   // /|'''''''''''''''/|
@@ -34,9 +34,9 @@ class GridInvalidRegion {
   //|/....................|/
   
   proc init (
-    grid:         Grid,
-    parent_level: Level,
-    fine_level:   Level )
+    grid:         unmanaged Grid,
+    parent_level: unmanaged Level,
+    fine_level:   unmanaged Level )
   {
     this.complete();
     //==== Calculate refinement ratio ====
@@ -104,10 +104,10 @@ class LevelInvalidRegion {
   //| >    fields    | >
   //|/...............|/
   
-  const level:      Level;
-  const fine_level: Level;
+  const level:      unmanaged Level;
+  const fine_level: unmanaged Level;
   
-  var grid_invalid_regions: [level.grids] GridInvalidRegion;
+  var grid_invalid_regions: [level.grids] unmanaged GridInvalidRegion;
 
   // /|'''''''''''''''/|
   //< |    fields    < |
@@ -129,7 +129,7 @@ class LevelInvalidRegion {
   proc initialize ()
   {
     for grid in level.grids do
-      grid_invalid_regions(grid) = new GridInvalidRegion(grid, level, fine_level);
+      grid_invalid_regions(grid) = new unmanaged GridInvalidRegion(grid, level, fine_level);
   }
   // /|'''''''''''''''''''''''''''''''''''/|
   //< |    special method: initialize    < |
@@ -155,7 +155,7 @@ class LevelInvalidRegion {
   //| >    special method: this    | >
   //|/.............................|/
   
-  proc this (grid: Grid) 
+  proc this (grid: unmanaged Grid) 
   {
     return grid_invalid_regions(grid);
   }
@@ -184,8 +184,8 @@ class LevelInvalidRegion {
 //----------------------------------------------------------------------
 
 proc LevelSolution.correctInvalidRegion (
-  level_invalid_region: LevelInvalidRegion,
-  fine_level_solution:  LevelSolution )
+  level_invalid_region: unmanaged LevelInvalidRegion,
+  fine_level_solution:  unmanaged LevelSolution )
 {
   //==== Safety checks ====
   assert(this.level == level_invalid_region.level);
@@ -214,8 +214,8 @@ proc LevelSolution.correctInvalidRegion (
 //------------------------------------------------------------
 
 proc LevelVariable.fillInvalidRegion (
-  level_invalid_region: LevelInvalidRegion,
-  fine_level_variable:  LevelVariable )
+  level_invalid_region: unmanaged LevelInvalidRegion,
+  fine_level_variable:  unmanaged LevelVariable )
 {
 
   //---- Safety check ----

--- a/test/studies/amr/lib/cfboundary/RefiningTransfer.chpl
+++ b/test/studies/amr/lib/cfboundary/RefiningTransfer.chpl
@@ -20,9 +20,9 @@ class GridCFGhostRegion {
   //| >    fields    | >
   //|/...............|/
 
-  const grid:             Grid;
-  var coarse_neighbors: domain(Grid);
-  var transfer_regions:  [coarse_neighbors] MultiDomain(dimension,stridable=true);
+  const grid:             unmanaged Grid;
+  var coarse_neighbors: domain(unmanaged Grid);
+  var transfer_regions:  [coarse_neighbors] unmanaged MultiDomain(dimension,stridable=true);
   
   // /|'''''''''''''''/|
   //< |    fields    < |
@@ -35,9 +35,9 @@ class GridCFGhostRegion {
   //|/....................|/
   
   proc init (
-    grid:         Grid,
-    parent_level: Level,
-    coarse_level: Level)
+    grid:         unmanaged Grid,
+    parent_level: unmanaged Level,
+    coarse_level: unmanaged Level)
   {
         
     this.grid = grid;
@@ -56,7 +56,7 @@ class GridCFGhostRegion {
         
         //---- Initialize a MultiDomain to the intersection, less grid's interior ----
         
-        var boundary_multidomain = new MultiDomain(dimension, stridable=true);
+        var boundary_multidomain = new unmanaged MultiDomain(dimension, stridable=true);
         boundary_multidomain.add( fine_intersection );
         boundary_multidomain.subtract( grid.cells );
         
@@ -144,9 +144,9 @@ class LevelCFGhostRegion {
   //| >    fields    | >
   //|/...............|/
   
-  const level:               Level;  
-  const coarse_level:        Level;
-  var grid_cf_ghost_regions: [level.grids] GridCFGhostRegion;
+  const level:               unmanaged Level;  
+  const coarse_level:        unmanaged Level;
+  var grid_cf_ghost_regions: [level.grids] unmanaged GridCFGhostRegion;
   
   // /|'''''''''''''''/|
   //< |    fields    < |
@@ -169,7 +169,7 @@ class LevelCFGhostRegion {
   { 
         
     for grid in level.grids do
-      grid_cf_ghost_regions(grid) = new GridCFGhostRegion(grid, level, coarse_level);
+      grid_cf_ghost_regions(grid) = new unmanaged GridCFGhostRegion(grid, level, coarse_level);
       
   }
   // /|'''''''''''''''''''''''''''''''''''/|
@@ -194,7 +194,7 @@ class LevelCFGhostRegion {
   //|\'''''''''''''''''''''''''''''|\
   //| >    special method: this    | >
   //|/.............................|/
-  proc this ( grid: Grid )
+  proc this ( grid: unmanaged Grid )
   {
     return grid_cf_ghost_regions( grid );
   }
@@ -228,12 +228,12 @@ class GridCFGhostSolution {
   //| >    fields    | >
   //|/...............|/
   
-  const grid_cf_ghost_region: GridCFGhostRegion;
+  const grid_cf_ghost_region: unmanaged GridCFGhostRegion;
   
-  var old_data: [grid_cf_ghost_region.coarse_neighbors] MultiArray(dimension,true,real);
+  var old_data: [grid_cf_ghost_region.coarse_neighbors] unmanaged MultiArray(dimension,true,real);
   var old_time: real;
 
-  var current_data: [grid_cf_ghost_region.coarse_neighbors] MultiArray(dimension,true,real);
+  var current_data: [grid_cf_ghost_region.coarse_neighbors] unmanaged MultiArray(dimension,true,real);
   var current_time: real;
 
 
@@ -264,10 +264,10 @@ class GridCFGhostSolution {
   {      
     for c_neighbor in grid_cf_ghost_region.coarse_neighbors {
 
-      old_data(c_neighbor) = new MultiArray(dimension,true,real);
+      old_data(c_neighbor) = new unmanaged MultiArray(dimension,true,real);
       old_data(c_neighbor).allocate( grid_cf_ghost_region.transfer_regions(c_neighbor) );
 
-      current_data(c_neighbor) = new MultiArray(dimension,true,real);
+      current_data(c_neighbor) = new unmanaged MultiArray(dimension,true,real);
       current_data(c_neighbor).allocate( grid_cf_ghost_region.transfer_regions(c_neighbor) );
     }
   }
@@ -330,7 +330,7 @@ class GridCFGhostSolution {
   // data from the input coarse LevelSolution.
   //---------------------------------------------------------
 
-  proc fill ( coarse_level_solution: LevelSolution )
+  proc fill ( coarse_level_solution: unmanaged LevelSolution )
   {
 
     //---- Calculate refinement ratio ----
@@ -398,11 +398,11 @@ class LevelCFGhostSolution {
   //| >    fields    | >
   //|/...............|/
   
-  const level_cf_ghost_region: LevelCFGhostRegion;
+  const level_cf_ghost_region: unmanaged LevelCFGhostRegion;
   
-  const level:                 Level;
+  const level:                 unmanaged Level;
   
-  var grid_cf_ghost_solutions: [level.grids] GridCFGhostSolution;
+  var grid_cf_ghost_solutions: [level.grids] unmanaged GridCFGhostSolution;
 
   var old_time:     real;    
   var current_time: real;
@@ -440,7 +440,7 @@ class LevelCFGhostSolution {
            "Error: LevelCFGhostRegion.initialize: Input level must equal level_cf_ghost_region.level");
     
     for grid in level.grids do
-      grid_cf_ghost_solutions(grid) = new GridCFGhostSolution( level_cf_ghost_region(grid) );
+      grid_cf_ghost_solutions(grid) = new unmanaged GridCFGhostSolution( level_cf_ghost_region(grid) );
 
   }
   // /|'''''''''''''''''''''''''''''''''''/|
@@ -472,7 +472,7 @@ class LevelCFGhostSolution {
   // GridCFGhostSolution.
   //-----------------------------------------------------------
   
-  proc this ( grid: Grid )
+  proc this ( grid: unmanaged Grid )
   {
     return grid_cf_ghost_solutions( grid );
   }
@@ -492,7 +492,7 @@ class LevelCFGhostSolution {
   // data from the input coarse LevelSolution.
   //---------------------------------------------------------------
   
-  proc fill ( coarse_level_solution: LevelSolution)
+  proc fill ( coarse_level_solution: unmanaged LevelSolution)
   {
     //==== Make aliases for the levels involved ====
     const level        = this.level_cf_ghost_region.level;
@@ -543,7 +543,7 @@ class LevelCFGhostSolution {
 //-----------------------------------------------------------------
 
 proc GridVariable.fillCFGhostRegion (
-  grid_cf_ghost_solution: GridCFGhostSolution,
+  grid_cf_ghost_solution: unmanaged GridCFGhostSolution,
   time:                   real )
 {
   //==== Safety check ====
@@ -595,7 +595,7 @@ proc GridVariable.fillCFGhostRegion (
 //------------------------------------------------------------------
 
 proc LevelVariable.fillCFGhostRegion (
-  level_cf_ghost_solution: LevelCFGhostSolution,
+  level_cf_ghost_solution: unmanaged LevelCFGhostSolution,
   time:                    real )
 {
 

--- a/test/studies/amr/lib/grid/GridBC_def.chpl
+++ b/test/studies/amr/lib/grid/GridBC_def.chpl
@@ -8,11 +8,11 @@ use GridSolution_def;
 //|____________________/
 class GridBC {
 
-  const grid: Grid;
+  const grid: unmanaged Grid;
 
   //==== Dummy routines to be provided in derived classes ====
-  proc apply(q: GridVariable, t: real) {}
-  proc apply_Homogeneous(q: GridVariable) {}
+  proc apply(q: unmanaged GridVariable, t: real) {}
+  proc apply_Homogeneous(q: unmanaged GridVariable) {}
   
 }
 // /""""""""""""""""""""|
@@ -30,13 +30,13 @@ class GridBC {
 class PeriodicGridBC: GridBC {
 
 
-  proc apply(q: GridVariable, t: real) {
+  proc apply(q: unmanaged GridVariable, t: real) {
     //==== Periodic BCs are homogeneous ====
     apply_Homogeneous(q);
   }
 
 
-  proc apply_Homogeneous(q: GridVariable) {
+  proc apply_Homogeneous(q: unmanaged GridVariable) {
 
     for ghost_domain in grid.ghost_domains {
       var loc = grid.relativeLocation(ghost_domain);

--- a/test/studies/amr/lib/grid/GridSolution_def.chpl
+++ b/test/studies/amr/lib/grid/GridSolution_def.chpl
@@ -15,10 +15,10 @@ use GridVariable_def;
 
 class GridSolution {
 
-  const grid:     Grid;
+  const grid:     unmanaged Grid;
   
-  var old_data:     GridVariable;
-  var current_data: GridVariable;
+  var old_data:     unmanaged GridVariable;
+  var current_data: unmanaged GridVariable;
   var old_time:     real;
   var current_time: real;
   
@@ -28,10 +28,10 @@ class GridSolution {
   //| >    initializer    | >
   //|/....................|/
   
-  proc init (grid: Grid) {
+  proc init (grid: unmanaged Grid) {
     this.grid = grid;
-    old_data =     new GridVariable(grid = grid);
-    current_data = new GridVariable(grid = grid);
+    old_data =     new unmanaged GridVariable(grid = grid);
+    current_data = new unmanaged GridVariable(grid = grid);
   }
   // /|''''''''''''''''''''/|
   //< |    initializer    < |

--- a/test/studies/amr/lib/grid/GridVariable_def.chpl
+++ b/test/studies/amr/lib/grid/GridVariable_def.chpl
@@ -23,7 +23,7 @@ use Grid_def;
 
 class GridVariable {
 
-  const grid: Grid;
+  const grid: unmanaged Grid;
   var  value: [grid.extended_cells] real;
 
 

--- a/test/studies/amr/lib/grid/Grid_def.chpl
+++ b/test/studies/amr/lib/grid/Grid_def.chpl
@@ -44,7 +44,7 @@ class Grid {
   const extended_cells: domain(dimension, stridable=true);
   
   // const ghost_domains: MultiDomain(dimension, stridable=true);
-  const ghost_domains: List( domain(dimension, stridable=true) );
+  const ghost_domains: unmanaged List( domain(dimension, stridable=true) );
 
 
 
@@ -99,7 +99,7 @@ class Grid {
     // the grid and stored in a linked list.
     //-------------------------------------------------------------
 
-    ghost_domains = new List( domain(dimension,stridable=true) );
+    ghost_domains = new unmanaged List( domain(dimension,stridable=true) );
     this.complete();
 
     //==== Sanity check ====
@@ -311,7 +311,7 @@ proc readGrid(file_name: string) {
   var i_low: dimension*int;
 
 
-  return new Grid(x_low, x_high, i_low, n_cells, n_ghost_cells);
+  return new unmanaged Grid(x_low, x_high, i_low, n_cells, n_ghost_cells);
 
 }
 // /|"""""""""""""""""""""""""/|

--- a/test/studies/amr/lib/level/LevelBC_def.chpl
+++ b/test/studies/amr/lib/level/LevelBC_def.chpl
@@ -6,10 +6,10 @@ use LevelVariable_def;
 //======================>
 class LevelBC {
   
-  const level: Level;
+  const level: unmanaged Level;
 
-  proc apply(q: LevelVariable, t: real) {}
-  proc apply_Homogeneous(q: LevelVariable) {}
+  proc apply(q: unmanaged LevelVariable, t: real) {}
+  proc apply_Homogeneous(q: unmanaged LevelVariable) {}
 
 }
 //<=== LevelBC class <===

--- a/test/studies/amr/lib/level/LevelSolution_def.chpl
+++ b/test/studies/amr/lib/level/LevelSolution_def.chpl
@@ -7,10 +7,10 @@ use LevelVariable_def;
 //| >    LevelSolution class    | >
 //|/____________________________|/
 class LevelSolution {
-  const level:    Level;
+  const level:    unmanaged Level;
 
-  var old_data:     LevelVariable;
-  var current_data: LevelVariable;
+  var old_data:     unmanaged LevelVariable;
+  var current_data: unmanaged LevelVariable;
   var old_time:     real;
   var current_time: real;
 
@@ -19,10 +19,10 @@ class LevelSolution {
   //|\''''''''''''''''''''|\
   //| >    initializer    | >
   //|/....................|/
-  proc init(level: Level) {
+  proc init(level: unmanaged Level) {
     this.level  = level;
-    old_data     = new LevelVariable(level = level);
-    current_data = new LevelVariable(level = level);
+    old_data     = new unmanaged LevelVariable(level = level);
+    current_data = new unmanaged LevelVariable(level = level);
   }
   // /|''''''''''''''''''''/|
   //< |    initializer    < |

--- a/test/studies/amr/lib/level/LevelVariable_def.chpl
+++ b/test/studies/amr/lib/level/LevelVariable_def.chpl
@@ -14,8 +14,8 @@ use GridVariable_def;
 
 class LevelVariable {
   
-  const level:        Level;
-  var grid_variables: [level.grids] GridVariable;
+  const level:        unmanaged Level;
+  var grid_variables: [level.grids] unmanaged GridVariable;
 
 
 
@@ -32,7 +32,7 @@ class LevelVariable {
 
   proc postinit() {
     for grid in level.grids do
-      grid_variables(grid) = new GridVariable(grid = grid);                          
+      grid_variables(grid) = new unmanaged GridVariable(grid = grid);                          
   }
   // /|''''''''''''''''''''''''''''/|
   //< |    postinit() method    < |
@@ -71,13 +71,13 @@ class LevelVariable {
   // the GridVariable's 'value' field.
   //---------------------------------------------------------------
   
-  proc this(grid: Grid) ref {
+  proc this(grid: unmanaged Grid) ref {
     return grid_variables(grid);
   }
 
   pragma "no copy return"
   proc this(
-    grid: Grid, 
+    grid: unmanaged Grid, 
     D: domain(dimension, stridable=true)) 
   {
     return grid_variables(grid).value(D);

--- a/test/studies/amr/lib/level/Level_def.chpl
+++ b/test/studies/amr/lib/level/Level_def.chpl
@@ -52,9 +52,9 @@ class Level {
   // arithmetic domains.  Iteration syntax is the same as well.
   //---------------------------------------------------------------------
 
-  var grids:                 domain(Grid);
-  var sibling_ghost_regions: [grids] SiblingGhostRegion;
-  var boundary:              [grids] MultiDomain(dimension,stridable=true);
+  var grids:                 domain(unmanaged Grid);
+  var sibling_ghost_regions: [grids] unmanaged SiblingGhostRegion;
+  var boundary:              [grids] unmanaged MultiDomain(dimension,stridable=true);
 
 
 
@@ -211,7 +211,7 @@ proc Level.addGrid(
 
 
   //==== Create and add new grid ====
-  var new_grid = new Grid(x_low         = x_low_grid,
+  var new_grid = new unmanaged Grid(x_low         = x_low_grid,
                           x_high        = x_high_grid,
                           i_low         = i_low_grid,
                           n_cells       = n_cells_grid,
@@ -274,9 +274,10 @@ proc Level.complete ()
 
   for grid in grids 
   {
-    sibling_ghost_regions(grid) = new SiblingGhostRegion(this,grid);
+    sibling_ghost_regions(grid) = new unmanaged
+      SiblingGhostRegion(_to_unmanaged(this),grid);
     
-    boundary(grid) = new MultiDomain(dimension,stridable=true);
+    boundary(grid) = new unmanaged MultiDomain(dimension,stridable=true);
 
     for D in grid.ghost_domains do boundary(grid).add( D );
 
@@ -313,7 +314,7 @@ proc Level.complete ()
 
 class SiblingGhostRegion {
 
-  const neighbors: domain(Grid);
+  const neighbors: domain(unmanaged Grid);
   const overlaps:  [neighbors] domain(dimension,stridable=true);
   
   
@@ -322,8 +323,8 @@ class SiblingGhostRegion {
   //|/....................|/
   
   proc init (
-    level: Level,
-    grid:  Grid)
+    level: unmanaged Level,
+    grid:  unmanaged Grid)
   {
     this.complete();
     for sibling in level.grids 
@@ -413,7 +414,7 @@ iter Level.ordered_grids {
   var grid_list = grids;
   
   while grid_list.numIndices > 0 {
-    var lowest_grid: Grid;
+    var lowest_grid: unmanaged Grid;
     var i_lowest = possible_ghost_cells.high;
 
     for grid in grid_list {
@@ -466,7 +467,7 @@ proc readLevel(file_name: string){
   input_file.readln( (...n_cells) );
   input_file.readln( (...n_ghost) );
 
-  var level = new Level(x_low         = x_low,
+  var level = new unmanaged Level(x_low         = x_low,
                         x_high        = x_high,
                         n_cells       = n_cells,
                         n_ghost_cells = n_ghost);

--- a/test/studies/amr/lib/misc/BasicDataStructures.chpl
+++ b/test/studies/amr/lib/misc/BasicDataStructures.chpl
@@ -1,7 +1,7 @@
 proc main {
   
   writeln("List test:");
-  var l = new List(int);
+  var l = new unmanaged List(int);
   l.add(1);
   l.add(2);
   l.add(3);
@@ -17,7 +17,7 @@ proc main {
   
   writeln("");
   writeln("Stack test:");
-  var s = new Stack(int);
+  var s = new unmanaged Stack(int);
   s.push(1);
   s.push(2);
   s.push(3);
@@ -25,7 +25,7 @@ proc main {
   
   
   writeln("\nQueue test:");
-  var q = new Queue(string);
+  var q = new unmanaged Queue(string);
   q.enqueue("a");
   q.enqueue("b");
   q.enqueue("c");
@@ -46,14 +46,14 @@ class List
 {
   
   type data_type;
-  var head: Node(data_type);
+  var head: unmanaged Node(data_type);
   
   
   class Node 
   {
     type data_type;
     var data: data_type;
-    var next: Node(data_type);
+    var next: unmanaged Node(data_type);
   }
   
   
@@ -71,13 +71,13 @@ class List
   {
     // This should work even if head==nil.
     
-    head = new Node(data_type, data, head );
+    head = new unmanaged Node(data_type, data, head );
   }
   
   
   proc clear ()
   {
-    var next_node: Node(data_type);
+    var next_node: unmanaged Node(data_type);
     
     while head {
       next_node = head.next;
@@ -109,13 +109,13 @@ class Stack
 {
 
   type data_type;
-  var top:  Node(data_type);
+  var top:  unmanaged Node(data_type);
 
   
   class Node {
     type data_type;
     var data: data_type;
-    var next: Node(data_type);
+    var next: unmanaged Node(data_type);
   }
 
 
@@ -127,7 +127,7 @@ class Stack
   
   proc push ( data: data_type )
   {
-    top = new Node(data_type, data, top);
+    top = new unmanaged Node(data_type, data, top);
   }
 
   
@@ -166,14 +166,14 @@ class Queue
 {
   
   type data_type;
-  var head: Node(data_type);
-  var tail: Node(data_type);
+  var head: unmanaged Node(data_type);
+  var tail: unmanaged Node(data_type);
 
   class Node {
     type data_type;
     var data: data_type;
-    var prev: Node(data_type);
-    var next: Node(data_type);
+    var prev: unmanaged Node(data_type);
+    var next: unmanaged Node(data_type);
   }
 
 
@@ -189,12 +189,12 @@ class Queue
   {
     if tail {
       var old_tail = tail;
-      tail = new Node(data_type, data);
+      tail = new unmanaged Node(data_type, data);
       old_tail.next = tail;
       tail.prev     = old_tail;
     }
     else {
-      head = new Node(data_type, data);
+      head = new unmanaged Node(data_type, data);
       tail = head;
     }
   }

--- a/test/studies/amr/lib/misc/MultiArray_def.chpl
+++ b/test/studies/amr/lib/misc/MultiArray_def.chpl
@@ -4,7 +4,7 @@ use MultiDomain_def;
 
 proc main {
   
-  var mD = new MultiDomain(2,false);
+  var mD = new unmanaged MultiDomain(2,false);
   mD.add( {1..12, 1..12} );
   mD.subtract( {3..5, 4..7} );
   mD.subtract( {4..9, 6..8} );
@@ -14,7 +14,7 @@ proc main {
 
 
   
-  var mA = new MultiArray(2,false,int);
+  var mA = new unmanaged MultiArray(2,false,int);
   mA.allocate( mD );
   
   var i = 0;
@@ -52,8 +52,8 @@ class MultiArray
   param stridable: bool;
   type  eltType;
   
-  var array_wrappers: List( ArrayWrapper(rank, stridable, eltType) ) =
-                  new List( ArrayWrapper(rank, stridable, eltType) );
+  var array_wrappers: unmanaged List( unmanaged ArrayWrapper(rank, stridable, eltType) ) =
+                  new unmanaged List( unmanaged ArrayWrapper(rank, stridable, eltType) );
 
 
 
@@ -105,9 +105,9 @@ class MultiArray
   //     array_wrappers.add( new ArrayWrapper(D) ); 
   // }
   
-  proc allocate ( mD: MultiDomain(rank,stridable) )
+  proc allocate ( mD: unmanaged MultiDomain(rank,stridable) )
   {
-    for D in mD do array_wrappers.add( new ArrayWrapper(rank, stridable, eltType, D) );
+    for D in mD do array_wrappers.add( new unmanaged ArrayWrapper(rank, stridable, eltType, D) );
   }
   // /|'''''''''''''''''''''''''/|
   //< |    method: allocate    < |

--- a/test/studies/amr/lib/misc/MultiDomain_def.chpl
+++ b/test/studies/amr/lib/misc/MultiDomain_def.chpl
@@ -5,7 +5,7 @@ use BasicDataStructures;
 proc main {
   
       
-  const mD = new MultiDomain( 2, false );
+  const mD = new unmanaged MultiDomain( 2, false );
   
   mD.add( {1..10,1..10} );
   
@@ -59,14 +59,14 @@ class MultiDomain
   param rank:      int;
   param stridable: bool;
       
-  var root: MDNode(rank,stridable);
+  var root: unmanaged MDNode(rank,stridable);
 
 
   proc init (param rank=0, param stridable=false)
   {
     this.rank = rank;
     this.stridable = stridable;
-    root = new MDNode( rank, stridable );
+    root = new unmanaged MDNode( rank, stridable );
   }
 
 
@@ -75,7 +75,7 @@ class MultiDomain
 
   proc copy ()
   {
-    const new_mD = new MultiDomain(rank,stridable);
+    const new_mD = new unmanaged MultiDomain(rank,stridable);
     root.copy(new_mD.root);  // the initializer has already allocated 'root', so pass it in for re-use
     return new_mD;
   }
@@ -139,8 +139,8 @@ class MultiDomain
   iter these ()
   {
     
-    const q = new Queue( MDNode(rank,stridable) );
-    var node: MDNode(rank,stridable);
+    const q = new unmanaged Queue( unmanaged MDNode(rank,stridable) );
+    var node: unmanaged MDNode(rank,stridable);
 
     q.enqueue( root );
     
@@ -161,11 +161,11 @@ class MultiDomain
   
   
   
-  iter nodes () : MDNode(rank,stridable)
+  iter nodes () : unmanaged MDNode(rank,stridable)
   {
     
-    const q = new Queue( MDNode(rank,stridable) );
-    var node: MDNode(rank,stridable);
+    const q = new unmanaged Queue( unmanaged MDNode(rank,stridable) );
+    var node: unmanaged MDNode(rank,stridable);
   
     if root then q.enqueue( root );
     
@@ -229,7 +229,7 @@ class MDNode
   var bisect_dim: int = -1;  // Indicates temporary, unfilled status
   var right_low:  int = 0;
 
-  var left, right:  MDNode(rank,stridable);
+  var left, right:  unmanaged MDNode(rank,stridable);
 
 
 
@@ -243,10 +243,10 @@ class MDNode
   }
 
 
-  proc copy (in new_node: MDNode(rank, stridable) = nil) : MDNode(rank,stridable)
+  proc copy (in new_node: unmanaged MDNode(rank, stridable) = nil) : unmanaged MDNode(rank,stridable)
   {
     if new_node == nil then
-      new_node = new MDNode(rank, stridable);
+      new_node = new unmanaged MDNode(rank, stridable);
 
     new_node.Domain     = Domain;
     new_node.bisect_dim = bisect_dim;
@@ -583,8 +583,8 @@ class MDNode
     
     var child_domain: domain(rank, stridable=stridable) = subranges;
     
-    if filled then left = new MDNode( rank, stridable, child_domain, 0 );
-    else           left = new MDNode( rank, stridable, child_domain, -1 );
+    if filled then left = new unmanaged MDNode( rank, stridable, child_domain, 0 );
+    else           left = new unmanaged MDNode( rank, stridable, child_domain, -1 );
     
   }
 
@@ -602,8 +602,8 @@ class MDNode
     
     var child_domain: domain(rank, stridable=stridable) = subranges;
     
-    if filled then right = new MDNode( rank, stridable, child_domain, 0 );
-    else           right = new MDNode( rank, stridable, child_domain, -1 );
+    if filled then right = new unmanaged MDNode( rank, stridable, child_domain, 0 );
+    else           right = new unmanaged MDNode( rank, stridable, child_domain, -1 );
   }
 
 
@@ -631,13 +631,13 @@ class MDNode
 // to the new root of the structure.
 //---------------------------------------------------------------
 
-proc MDNode.extendToContain( D: domain(rank,stridable=stridable) ) : MDNode(rank,stridable)
+proc MDNode.extendToContain( D: domain(rank,stridable=stridable) ) : unmanaged MDNode(rank,stridable)
 {
   
   // writeln("Beginning MDNode.extendToContain on node with ", Domain, " ", left!=nil, " ", filled);
   // writeln("  Input domain is ", D);
   
-  var new_root: MDNode(rank,stridable);
+  var new_root: unmanaged MDNode(rank,stridable);
   
   
   //===> Select the shortest dimension to extend ===>
@@ -664,7 +664,7 @@ proc MDNode.extendToContain( D: domain(rank,stridable=stridable) ) : MDNode(rank
   
   //---- If ext_d==0, that means D is contained in this.Domain, and this is the new root ----
   
-  if ext_d == 0 then new_root = this;
+  if ext_d == 0 then new_root = _to_unmanaged(this);
   
   
   //---- Otherwise, we split along dimension ext_d ----
@@ -676,7 +676,7 @@ proc MDNode.extendToContain( D: domain(rank,stridable=stridable) ) : MDNode(rank
     var s = Domain.stride(ext_d);
     var ext_index: int;
     
-    var parent:  MDNode(rank,stridable);
+    var parent:  unmanaged MDNode(rank,stridable);
     // var sibling: MDNode(rank,stridable);
     
     var subranges: rank*range(stridable=stridable);
@@ -704,12 +704,12 @@ proc MDNode.extendToContain( D: domain(rank,stridable=stridable) ) : MDNode(rank
       
       subranges(ext_d) = D.low(ext_d) .. Domain.high(ext_d) by s;
       D_temp           = subranges;
-      parent            = new MDNode( rank, stridable, D_temp );
+      parent            = new unmanaged MDNode( rank, stridable, D_temp );
       parent.bisect_dim = ext_d;
       parent.right_low  = ext_index;
       
       // parent.left  = sibling;
-      parent.right = this;
+      parent.right = _to_unmanaged(this);
        
     }
     
@@ -727,11 +727,11 @@ proc MDNode.extendToContain( D: domain(rank,stridable=stridable) ) : MDNode(rank
       
       subranges(ext_d)  = Domain.low(ext_d) .. D.high(ext_d) by s;
       D_temp            = subranges;
-      parent            = new MDNode( rank, stridable, D_temp );
+      parent            = new unmanaged MDNode( rank, stridable, D_temp );
       parent.bisect_dim = ext_d;
       parent.right_low  = ext_index;
       
-      parent.left  = this;
+      parent.left  = _to_unmanaged(this);
       // parent.right = sibling;
     }
     
@@ -772,7 +772,7 @@ proc MDNode.extendToContain( D: domain(rank,stridable=stridable) ) : MDNode(rank
 // the data of the argument, and then the argument is deleted.
 //-------------------------------------------------------------
 
-proc MDNode.merge( node: MDNode )
+proc MDNode.merge( node: unmanaged MDNode )
 {
   
   this.Domain     = node.Domain;

--- a/test/studies/amr/lib/python/regression_test.py
+++ b/test/studies/amr/lib/python/regression_test.py
@@ -89,11 +89,14 @@ def approximateDiff(file_name_1, file_name_2, tolerance):
 #----------------------------------------------------------
 output_file_name = sys.argv[1]
 
-output_file = open(output_file_name, 'w')
 if output_file_name.endswith(".comp.out.tmp"):
+    output_file = open(output_file_name, 'w')
     output_file.write("Compilation failed!\n");
+    output_file.write("See the errors in the file "+output_file_name+".save\n")
     output_file.close()
     exit(0)
+
+output_file = open(output_file_name, 'w')
 
 #==== Tolerance for approximate diff-ing ====
 tolerance = 1e-4


### PR DESCRIPTION
It would be better to use `owned`/`shared`/`borrowed` in these AMR
tests but that would take me quite a bit longer, so this PR just updates
the AMR classes to always be `unmanaged` (i.e. to behave as they used to).

Relates to #9998.

Trivial and not reviewed.

- [x] full local testing