### PR TITLE
Adjust array implementation and lifetime checker to avoid errors

### DIFF
--- a/compiler/resolution/lifetime.cpp
+++ b/compiler/resolution/lifetime.cpp
@@ -375,6 +375,11 @@ static bool shouldCheckLifetimesInFn(FnSymbol* fn) {
     return true;
   if (fn->hasFlag(FLAG_COMPILER_GENERATED))
     return false;
+  // This pass has trouble following certain compiler-generated
+  // patterns in constructors. Since they're being deprecated anyway,
+  // don't check lifetimes in constructors.
+  if (fn->hasFlag(FLAG_CONSTRUCTOR))
+    return false;
 
   // this is a workaround for problems with init functions
   // where temporaries are used to store results that are

--- a/modules/dists/BlockCycDist.chpl
+++ b/modules/dists/BlockCycDist.chpl
@@ -991,7 +991,7 @@ iter BlockCyclicArr.dsiLocalSubdomains() {
 iter BlockCyclicDom.dsiLocalSubdomains() {
   // TODO -- could be replaced by a privatized myLocDom in BlockCyclicDom
   // as it is with BlockCyclicArr
-  var myLocDom:LocBlockCyclicDom(rank, idxType, stridable) = nil;
+  var myLocDom:unmanaged LocBlockCyclicDom(rank, idxType, stridable) = nil;
   for (loc, locDom) in zip(dist.targetLocales, locDoms) {
     if loc == here then
       myLocDom = locDom;

--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -1430,7 +1430,7 @@ proc BlockArr.dsiLocalSubdomain() {
 proc BlockDom.dsiLocalSubdomain() {
   // TODO -- could be replaced by a privatized myLocDom in BlockDom
   // as it is with BlockArr
-  var myLocDom:LocBlockDom(rank, idxType, stridable) = nil;
+  var myLocDom:unmanaged LocBlockDom(rank, idxType, stridable) = nil;
   for (loc, locDom) in zip(dist.targetLocales, locDoms) {
     if loc == here then
       myLocDom = locDom;

--- a/modules/dists/CyclicDist.chpl
+++ b/modules/dists/CyclicDist.chpl
@@ -1164,7 +1164,7 @@ proc CyclicArr.dsiLocalSubdomain() {
 proc CyclicDom.dsiLocalSubdomain() {
   // TODO -- could be replaced by a privatized myLocDom in CyclicDom
   // as it is with CyclicArr
-  var myLocDom:LocCyclicDom(rank, idxType, stridable) = nil;
+  var myLocDom:unmanaged LocCyclicDom(rank, idxType, stridable) = nil;
   for (loc, locDom) in zip(dist.targetLocs, locDoms) {
     if loc == here then
       myLocDom = locDom;

--- a/modules/dists/StencilDist.chpl
+++ b/modules/dists/StencilDist.chpl
@@ -1845,7 +1845,7 @@ proc StencilArr.dsiLocalSubdomain() {
 proc StencilDom.dsiLocalSubdomain() {
   // TODO -- could be replaced by a privatized myLocDom in StencilDom
   // as it is with StencilArr
-  var myLocDom:LocStencilDom(rank, idxType, stridable) = nil;
+  var myLocDom:unmanaged LocStencilDom(rank, idxType, stridable) = nil;
   for (loc, locDom) in zip(dist.targetLocales, locDoms) {
     if loc == here then
       myLocDom = locDom;

--- a/modules/internal/ArrayViewRankChange.chpl
+++ b/modules/internal/ArrayViewRankChange.chpl
@@ -131,7 +131,7 @@ module ArrayViewRankChange {
  pragma "use default init"
  class ArrayViewRankChangeDom: BaseRectangularDom {
     // the lower-dimensional index set that we represent upwards
-    var upDom: DefaultRectangularDom(rank, idxType, stridable);
+    var upDom: unmanaged DefaultRectangularDom(rank, idxType, stridable);
     forwarding upDom except these;
 
     // the collapsed dimensions and indices in those dimensions

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -2801,6 +2801,8 @@ module ChapelArray {
        The array must be a rectangular 1-D array; its domain must be
        non-stridable and not shared with other arrays.
      */
+    pragma "unsafe"
+    // TODO - once we can annotate, val argument should outlive 'this'
     proc push_back(in val: this.eltType) {
       if (!chpl__isDense1DArray()) then
         compilerError("push_back() is only supported on dense 1D arrays");
@@ -2823,6 +2825,8 @@ module ChapelArray {
        The array must be a rectangular 1-D array; its domain must be
        non-stridable and not shared with other arrays.
      */
+    pragma "unsafe"
+    // TODO - once we can annotate, vals argument should outlive 'this'
     proc push_back(vals) where isArray(vals) {
       if (!chpl__isDense1DArray()) then
         compilerError("push_back() is only supported on dense 1D arrays");
@@ -2881,6 +2885,7 @@ module ChapelArray {
        The array must be a rectangular 1-D array; its domain must be
        non-stridable and not shared with other arrays.
      */
+    pragma "unsafe"
     proc push_front(in val: this.eltType) {
       if (!chpl__isDense1DArray()) then
         compilerError("push_front() is only supported on dense 1D arrays");
@@ -2898,6 +2903,7 @@ module ChapelArray {
        The array must be a rectangular 1-D array; its domain must be
        non-stridable and not shared with other arrays.
      */
+    pragma "unsafe"
     proc push_front(vals) where isArray(vals) {
       if (!chpl__isDense1DArray()) then
         compilerError("push_front() is only supported on dense 1D arrays");


### PR DESCRIPTION
* marks push_back/push_front as unsafe (not lifetime checked - workaround until #9853  is resolved)
* adds unmanaged in several dsiLocalSubdomain implementations
* ArrayViewRankChangeDom upDom is unmanaged
* lifetime checker avoids checking old-style constructors, since these will be deprecated and present challenging AST for it to follow.

Relates to #9998.

- [x] full local testing

Reviewed by @benharsh - thanks!