### PR TITLE
Add jemalloc's lib dir to the runtime path

### DIFF
--- a/runtime/etc/Makefile.jemalloc-jemalloc
+++ b/runtime/etc/Makefile.jemalloc-jemalloc
@@ -15,4 +15,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-GEN_LFLAGS += -L$(JEMALLOC_LIB_DIR)
+GEN_LFLAGS += -L$(JEMALLOC_LIB_DIR) -Wl,-rpath,$(JEMALLOC_LIB_DIR)


### PR DESCRIPTION
Add `-Wl,-rpath,$(JEMALLOC_LIB_DIR)` like we do for other third-party libraries
to the jemalloc runtime Makefile. Without this, we can't build/use our bundled
jemalloc as a shared object. Historically, this hasn't been an issue since we
only built a static library, but we have some uses cases that want shared
objects now.

Related to https://github.com/chapel-lang/chapel/issues/10036