### PR TITLE
Mason: build on last modified

### DIFF
--- a/test/mason/chplVersion/mason-chpl-version-build.chpl
+++ b/test/mason/chplVersion/mason-chpl-version-build.chpl
@@ -31,5 +31,5 @@ proc main() {
   lock.close();
 
   var compopts = ["",];
-  buildProgram(false, false, compopts, "Mason.toml", "Mason.lock");
+  buildProgram(false, false, false, compopts, "Mason.toml", "Mason.lock");
 }

--- a/test/mason/run/mason-run.good
+++ b/test/mason/run/mason-run.good
@@ -1,3 +1,3 @@
 Updating mason-registry for registry
-Build stopped: No changes to project
+Skipping Build... No changes to project
 New library: FizzBuzz

--- a/test/mason/run/mason-run.good
+++ b/test/mason/run/mason-run.good
@@ -1,5 +1,3 @@
 Updating mason-registry for registry
-Compiling FizzBuzz
-Build Successful
-
+Build stopped: No changes to project
 New library: FizzBuzz

--- a/test/mason/subdir-commands/mason-run.good
+++ b/test/mason/subdir-commands/mason-run.good
@@ -1,3 +1,3 @@
 Updating mason-registry for registry
-Build stopped: No changes to project
+Skipping Build... No changes to project
 New library: FizzBuzz

--- a/test/mason/subdir-commands/mason-run.good
+++ b/test/mason/subdir-commands/mason-run.good
@@ -1,5 +1,3 @@
 Updating mason-registry for registry
-Compiling FizzBuzz
-Build Successful
-
+Build stopped: No changes to project
 New library: FizzBuzz

--- a/tools/mason/MasonBuild.chpl
+++ b/tools/mason/MasonBuild.chpl
@@ -123,7 +123,7 @@ proc buildProgram(release: bool, show: bool, force: bool, compopts: [?d] string,
       exit(1);
     }
     else {
-      writeln("Build stopped: No changes to project");
+      writeln("Skipping Build... No changes to project");
     }
   }
   catch e: MasonError {

--- a/tools/mason/MasonBuild.chpl
+++ b/tools/mason/MasonBuild.chpl
@@ -116,6 +116,7 @@ proc buildProgram(release: bool, show: bool, compopts: [?d] string,
         toParse.close();
       }
       else writeln("Cannot build: no Mason.lock found");
+      exit(1);
     }
     else {
       writeln("Build stopped: No changes to project");

--- a/tools/mason/MasonBuild.chpl
+++ b/tools/mason/MasonBuild.chpl
@@ -30,6 +30,7 @@ use MasonUpdate;
 proc masonBuild(args) {
   var show = false;
   var release = false;
+  var force = false;
   var compopts: [1..0] string;
   if args.size > 2 {
     for arg in args[2..] {
@@ -39,6 +40,9 @@ proc masonBuild(args) {
       }
       else if arg == '--release' {
         release = true;
+      }
+      else if arg == '--force' {
+        force = true;
       }
       else if arg == '--show' {
         show = true;
@@ -51,7 +55,7 @@ proc masonBuild(args) {
   const configNames = UpdateLock(args);
   const tomlName = configNames[1];
   const lockName = configNames[2];
-  buildProgram(release, show, compopts, tomlName, lockName);
+  buildProgram(release, show, force, compopts, tomlName, lockName);
 }
 
 private proc checkChplVersion(lockFile : Toml) {
@@ -64,7 +68,7 @@ private proc checkChplVersion(lockFile : Toml) {
   }
 }
 
-proc buildProgram(release: bool, show: bool, compopts: [?d] string,
+proc buildProgram(release: bool, show: bool, force: bool, compopts: [?d] string,
                   tomlName="Mason.toml", lockName="Mason.lock") {
 
   try! {
@@ -82,7 +86,7 @@ proc buildProgram(release: bool, show: bool, compopts: [?d] string,
 
 
     // build on last modification
-    if projectModified(projectHome, projectName, binLoc) {
+    if projectModified(projectHome, projectName, binLoc) || force {
 
       if isFile(projectHome + "/" + lockName) {
 

--- a/tools/mason/MasonBuild.chpl
+++ b/tools/mason/MasonBuild.chpl
@@ -71,47 +71,55 @@ proc buildProgram(release: bool, show: bool, compopts: [?d] string,
 
     const cwd = getEnv("PWD");
     const projectHome = getProjectHome(cwd, tomlName);
+    const toParse = open(projectHome + "/" + lockName, iomode.r);
+    var lockFile = new Owned(parseToml(toParse));
+    const projectName = lockFile["root"]["name"].s;
+    
+    // --fast
+    var binLoc = 'debug';
+    if release then
+      binLoc = 'release';
 
-    if isFile(projectHome + "/" + lockName) {
 
-      // --fast
-      var binLoc = 'debug';
-      if release then
-        binLoc = 'release';
+    // build on last modification
+    if projectModified(projectHome, projectName, binLoc) {
 
-      // Make Binary Directory
-      makeTargetFiles(binLoc, projectHome);
+      if isFile(projectHome + "/" + lockName) {
 
-      // Install dependencies into $MASON_HOME/src
-      var toParse = open(projectHome + "/" + lockName, iomode.r);
-      var lockFile = new Owned(parseToml(toParse));
-      checkChplVersion(lockFile);
+        // Make build files and check chapel version
+        makeTargetFiles(binLoc, projectHome);
+        checkChplVersion(lockFile);
 
-      if isDir(MASON_HOME) == false {
-        mkdir(MASON_HOME, parents=true);
+        if isDir(MASON_HOME) == false {
+          mkdir(MASON_HOME, parents=true);
+        }
+
+        // generate list of dependencies and get src code
+        var sourceList = genSourceList(lockFile);
+        getSrcCode(sourceList, show);
+
+        // Checks for compilation options are present in Mason.toml
+        if lockFile.pathExists('root.compopts') {
+          const cmpFlags = lockFile["root"]["compopts"].s;
+          compopts.push_back(cmpFlags);
+        }
+
+        // Compile Program
+        if compileSrc(lockFile, binLoc, show, release, compopts, projectHome) {
+          writeln("Build Successful\n");
+        }
+        else {
+          writeln("Build Failed");
+          exit(1);
+        }
+        // Close memory
+        toParse.close();
       }
-
-      var sourceList = genSourceList(lockFile);
-      getSrcCode(sourceList, show);
-
-      // Checks if dependencies exist and retrieves them for compilation
-      if lockFile.pathExists('root.compopts') {
-        const cmpFlags = lockFile["root"]["compopts"].s;
-        compopts.push_back(cmpFlags);
-      }
-
-      // Compile Program
-      if compileSrc(lockFile, binLoc, show, release, compopts, projectHome) {
-        writeln("Build Successful\n");
-      }
-      else {
-        writeln("Build Failed");
-        exit(1);
-      }
-      // Close memory
-      toParse.close();
+      else writeln("Cannot build: no Mason.lock found");
     }
-    else writeln("Cannot build: no Mason.lock found");
+    else {
+      writeln("Build stopped: No changes to project");
+    }
   }
   catch e: MasonError {
     exit(1);  

--- a/tools/mason/MasonHelp.chpl
+++ b/tools/mason/MasonHelp.chpl
@@ -91,6 +91,7 @@ proc masonBuildHelp() {
   writeln('    -h, --help                   Display this message');
   writeln('        --show                   Increase verbosity');
   writeln('        --release                Compile to target/release with optimizations (--fast)');
+  writeln('        --force                  Force Mason to build the project');
   writeln();
   writeln('When no options are provided, the following will take place:');
   writeln('   - Build from mason project if Mason.lock present');

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -23,6 +23,7 @@
 use Spawn;
 use FileSystem;
 use TOML;
+use DateTime;
 
 /* Gets environment variables for spawn commands */
 extern proc getenv(name : c_string) : c_string;
@@ -232,4 +233,37 @@ proc getProjectHome(cwd: string, tomlName="Mason.toml") : string throws {
     return cwd;
   }
   return getProjectHome(dirname, tomlName);
+}
+
+
+extern "struct stat" record chpl_stat {
+  var st_mtime: off_t;
+}
+
+proc getLastModified(filename: string) : int {
+  extern proc stat(filename: c_string, ref chpl_stat): c_int;
+
+  var file_buf: chpl_stat;
+  var file_path = filename.c_str();
+
+  if (stat(file_path, file_buf) == 0) {
+    // writeln("file: " + datetime.fromtimestamp(file_buf.st_mtime).ctime());
+    return file_buf.st_mtime;
+    }
+  return -1;
+}
+
+proc projectModified(projectHome, projectName, binLocation) : bool {
+  const binaryPath = joinPath(projectHome, "target", binLocation, projectName);
+
+  if isFile(binaryPath) {
+    for file in listdir(joinPath(projectHome, "src")) {
+      var srcPath = joinPath(projectHome, "src", file);
+      if getLastModified(srcPath) > getLastModified(binaryPath) {
+        return true;
+      }
+    }
+    return false;
+  }
+  return true;
 }

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -23,7 +23,6 @@
 use Spawn;
 use FileSystem;
 use TOML;
-use DateTime;
 
 /* Gets environment variables for spawn commands */
 extern proc getenv(name : c_string) : c_string;
@@ -247,7 +246,6 @@ proc getLastModified(filename: string) : int {
   var file_path = filename.c_str();
 
   if (stat(file_path, file_buf) == 0) {
-    // writeln("file: " + datetime.fromtimestamp(file_buf.st_mtime).ctime());
     return file_buf.st_mtime;
     }
   return -1;


### PR DESCRIPTION
This PR includes the build on last modified feature for Mason. As our compilation time is still pretty slow, this feature allows for mason to decide if your project should be built based on the last modification time of all files within the `src/` directory and the binary found in `target/debug(release)`. Mason will obviously build every time when no binary exists. 

TODO - put `getLastModified` into standard library. 