### PR TITLE
Fix problems with new unmanaged SomeModule.SomeType

### DIFF
--- a/test/classes/moduleScope/mod-init-borrowed.chpl
+++ b/test/classes/moduleScope/mod-init-borrowed.chpl
@@ -1,19 +1,15 @@
 proc main() {
-  var a   = new unmanaged A(10);
+  var a   = new borrowed A(10);
 
   writeln();
 
-  var m1a = new unmanaged M1.A(20);
-  var m2a = new unmanaged M2.A(30);
+  var m1a = new borrowed M1.A(20);
+  var m2a = new borrowed M2.A(30);
 
   writeln();
 
   var m3a = new M3.A(40);
   var m4a = new M4.A(50);
-
-  delete m2a;
-  delete m1a;
-  delete a;
 }
 
 class A {

--- a/test/classes/moduleScope/mod-init-borrowed.good
+++ b/test/classes/moduleScope/mod-init-borrowed.good
@@ -1,0 +1,7 @@
+A.init(10)
+
+M1.A.init(20)
+M2.A.A(30)
+
+M3.A.init(40)
+M2.A.A(50)

--- a/test/classes/moduleScope/mod-init-owned.chpl
+++ b/test/classes/moduleScope/mod-init-owned.chpl
@@ -1,19 +1,15 @@
 proc main() {
-  var a   = new unmanaged A(10);
+  var a   = new owned A(10);
 
   writeln();
 
-  var m1a = new unmanaged M1.A(20);
-  var m2a = new unmanaged M2.A(30);
+  var m1a = new owned M1.A(20);
+  var m2a = new owned M2.A(30);
 
   writeln();
 
   var m3a = new M3.A(40);
   var m4a = new M4.A(50);
-
-  delete m2a;
-  delete m1a;
-  delete a;
 }
 
 class A {

--- a/test/classes/moduleScope/mod-init-owned.good
+++ b/test/classes/moduleScope/mod-init-owned.good
@@ -1,0 +1,7 @@
+A.init(10)
+
+M1.A.init(20)
+M2.A.A(30)
+
+M3.A.init(40)
+M2.A.A(50)

--- a/test/classes/moduleScope/mod-init-unmanaged.chpl
+++ b/test/classes/moduleScope/mod-init-unmanaged.chpl
@@ -1,19 +1,19 @@
 proc main() {
-  var a   = new A(10);
+  var a   = new unmanaged A(10);
 
   writeln();
 
-  var m1a = new M1.A(20);
-  var m2a = new M2.A(30);
+  var m1a = new unmanaged M1.A(20);
+  var m2a = new unmanaged M2.A(30);
 
   writeln();
 
   var m3a = new M3.A(40);
   var m4a = new M4.A(50);
 
-  // Would delete m2a, m1a, a
-  // but these might be borrows
-  // at some point
+  delete m2a;
+  delete m1a;
+  delete a;
 }
 
 class A {

--- a/test/classes/moduleScope/mod-init-unmanaged.good
+++ b/test/classes/moduleScope/mod-init-unmanaged.good
@@ -1,0 +1,7 @@
+A.init(10)
+
+M1.A.init(20)
+M2.A.A(30)
+
+M3.A.init(40)
+M2.A.A(50)

--- a/test/classes/moduleScope/mod-init.compopts
+++ b/test/classes/moduleScope/mod-init.compopts
@@ -1,0 +1,1 @@
+--no-warn-unstable


### PR DESCRIPTION
`new unmanaged SomeModule.SomeType` was causing resolution errors because the 
code in scopeResolve that updates the new call with a `module=` argument wasn't
firing if there was a PRIM_TO_UNMANAGED between the module.type call and the
new call which is the AST we get in that case. This PR fixes that and adjusts
the pattern matching function used for this purpose to return the call that 
should be modified (instead of re-computing it).

Resolves #10016.

- [x] full local testing

Reviewed by @lydia-duncan - thanks!