### PR TITLE
Update memstatPrint .good files to match the new memStats formatting

### DIFF
--- a/test/memory/shannon/memstatPrint.comm-gasnet.good
+++ b/test/memory/shannon/memstatPrint.comm-gasnet.good
@@ -1,40 +1,20 @@
-=================
-Memory Statistics
-==============================================================
-Current Allocated Memory               0
-Maximum Simultaneous Allocated Memory  0
-Total Allocated Memory                 0
-Total Freed Memory                     0
-==============================================================
-=================
-Memory Statistics
-==============================================================
-Current Allocated Memory               64
-Maximum Simultaneous Allocated Memory  64
-Total Allocated Memory                 64
-Total Freed Memory                     0
-==============================================================
-=================
-Memory Statistics
-==============================================================
-Current Allocated Memory               128
-Maximum Simultaneous Allocated Memory  128
-Total Allocated Memory                 128
-Total Freed Memory                     0
-==============================================================
-=================
-Memory Statistics
-==============================================================
-Current Allocated Memory               192
-Maximum Simultaneous Allocated Memory  192
-Total Allocated Memory                 192
-Total Freed Memory                     0
-==============================================================
-=================
-Memory Statistics
-==============================================================
-Current Allocated Memory               256
-Maximum Simultaneous Allocated Memory  256
-Total Allocated Memory                 256
-Total Freed Memory                     0
-==============================================================
+memStats: Allocated Now:              0
+memStats: Allocation High Water Mark: 0
+memStats: Sum of Allocations:         0
+memStats: Sum of Frees:               0
+memStats: Allocated Now:              64
+memStats: Allocation High Water Mark: 64
+memStats: Sum of Allocations:         64
+memStats: Sum of Frees:                0
+memStats: Allocated Now:              128
+memStats: Allocation High Water Mark: 128
+memStats: Sum of Allocations:         128
+memStats: Sum of Frees:                 0
+memStats: Allocated Now:              192
+memStats: Allocation High Water Mark: 192
+memStats: Sum of Allocations:         192
+memStats: Sum of Frees:                 0
+memStats: Allocated Now:              256
+memStats: Allocation High Water Mark: 256
+memStats: Sum of Allocations:         256
+memStats: Sum of Frees:                 0

--- a/test/memory/shannon/memstatPrint.good
+++ b/test/memory/shannon/memstatPrint.good
@@ -1,40 +1,20 @@
-=================
-Memory Statistics
-==============================================================
-Current Allocated Memory               0
-Maximum Simultaneous Allocated Memory  0
-Total Allocated Memory                 0
-Total Freed Memory                     0
-==============================================================
-=================
-Memory Statistics
-==============================================================
-Current Allocated Memory               64
-Maximum Simultaneous Allocated Memory  64
-Total Allocated Memory                 64
-Total Freed Memory                     0
-==============================================================
-=================
-Memory Statistics
-==============================================================
-Current Allocated Memory               128
-Maximum Simultaneous Allocated Memory  128
-Total Allocated Memory                 128
-Total Freed Memory                     0
-==============================================================
-=================
-Memory Statistics
-==============================================================
-Current Allocated Memory               192
-Maximum Simultaneous Allocated Memory  192
-Total Allocated Memory                 192
-Total Freed Memory                     0
-==============================================================
-=================
-Memory Statistics
-==============================================================
-Current Allocated Memory               256
-Maximum Simultaneous Allocated Memory  256
-Total Allocated Memory                 256
-Total Freed Memory                     0
-==============================================================
+memStats: Allocated Now:              0
+memStats: Allocation High Water Mark: 0
+memStats: Sum of Allocations:         0
+memStats: Sum of Frees:               0
+memStats: Allocated Now:              64
+memStats: Allocation High Water Mark: 64
+memStats: Sum of Allocations:         64
+memStats: Sum of Frees:                0
+memStats: Allocated Now:              128
+memStats: Allocation High Water Mark: 128
+memStats: Sum of Allocations:         128
+memStats: Sum of Frees:                 0
+memStats: Allocated Now:              192
+memStats: Allocation High Water Mark: 192
+memStats: Sum of Allocations:         192
+memStats: Sum of Frees:                 0
+memStats: Allocated Now:              256
+memStats: Allocation High Water Mark: 256
+memStats: Sum of Allocations:         256
+memStats: Sum of Frees:                 0

--- a/test/memory/shannon/memstatPrint.no-local.good
+++ b/test/memory/shannon/memstatPrint.no-local.good
@@ -1,40 +1,20 @@
-=================
-Memory Statistics
-==============================================================
-Current Allocated Memory               0
-Maximum Simultaneous Allocated Memory  0
-Total Allocated Memory                 0
-Total Freed Memory                     0
-==============================================================
-=================
-Memory Statistics
-==============================================================
-Current Allocated Memory               64
-Maximum Simultaneous Allocated Memory  64
-Total Allocated Memory                 64
-Total Freed Memory                     0
-==============================================================
-=================
-Memory Statistics
-==============================================================
-Current Allocated Memory               128
-Maximum Simultaneous Allocated Memory  128
-Total Allocated Memory                 128
-Total Freed Memory                     0
-==============================================================
-=================
-Memory Statistics
-==============================================================
-Current Allocated Memory               192
-Maximum Simultaneous Allocated Memory  192
-Total Allocated Memory                 192
-Total Freed Memory                     0
-==============================================================
-=================
-Memory Statistics
-==============================================================
-Current Allocated Memory               256
-Maximum Simultaneous Allocated Memory  256
-Total Allocated Memory                 256
-Total Freed Memory                     0
-==============================================================
+memStats: Allocated Now:              0
+memStats: Allocation High Water Mark: 0
+memStats: Sum of Allocations:         0
+memStats: Sum of Frees:               0
+memStats: Allocated Now:              64
+memStats: Allocation High Water Mark: 64
+memStats: Sum of Allocations:         64
+memStats: Sum of Frees:                0
+memStats: Allocated Now:              128
+memStats: Allocation High Water Mark: 128
+memStats: Sum of Allocations:         128
+memStats: Sum of Frees:                 0
+memStats: Allocated Now:              192
+memStats: Allocation High Water Mark: 192
+memStats: Sum of Allocations:         192
+memStats: Sum of Frees:                 0
+memStats: Allocated Now:              256
+memStats: Allocation High Water Mark: 256
+memStats: Sum of Allocations:         256
+memStats: Sum of Frees:                 0


### PR DESCRIPTION
PR #10061 changed the formatting of memStats, but we missed changing
memstatPrint as part of that work since this test uses `printMemAllocStats()`
directly instead of using the `--memStats` flag. This just updates the .good
file to match the new formatting.