### PR TITLE
Remove qthreads "support" for --blockreport and --taskreport

### DIFF
--- a/doc/rst/usingchapel/debugging.rst
+++ b/doc/rst/usingchapel/debugging.rst
@@ -66,8 +66,7 @@ flags are as follows:
                      variable.  Running with this flag will also cause
                      the executable to attempt to automatically detect
                      deadlock for single-locale executions.  This is
-                     only supported with ``CHPL_TASKS=qthreads`` or
-                     ``CHPL_TASKS=fifo``.
+                     only supported with ``CHPL_TASKS=fifo``.
 
   -t, --taskreport   When ``<CTRL-C>`` is entered during a program
                      executing under this flag, a list of pending and

--- a/runtime/include/tasks/qthreads/chpl-tasks-impl.h
+++ b/runtime/include/tasks/qthreads/chpl-tasks-impl.h
@@ -100,9 +100,6 @@ typedef struct chpl_qthread_tls_s {
   // That would reduce the size of the task local storage,
   // but increase the size of executeOn bundles.
   chpl_task_prvData_t prvdata;
-  /* Reports */
-  int     lock_filename;
-  int     lock_lineno;
 } chpl_qthread_tls_t;
 
 extern pthread_t chpl_qthread_process_pthread;


### PR DESCRIPTION
Qthreads had very experimental support for --blockreport that no longer works
correctly and no support for --taskreport. Instead of trying to get either of
these flags working, just remove the existing code since we don't believe these
features are practically useful anyways.

Related to https://github.com/chapel-lang/chapel/issues/10000