### PR TITLE
Fix more tests & modules to pass lifetime checking

### DIFF
--- a/modules/internal/ChapelSyncvar.chpl
+++ b/modules/internal/ChapelSyncvar.chpl
@@ -423,6 +423,8 @@ module ChapelSyncvar {
       return ret;
     }
 
+    pragma "unsafe"
+    // TODO - once we can annotate, val argument should outlive 'this'
     proc writeEF(val : valType) {
       on this {
         chpl_rmem_consist_release();
@@ -435,6 +437,8 @@ module ChapelSyncvar {
       }
     }
 
+    pragma "unsafe"
+    // TODO - once we can annotate, val argument should outlive 'this'
     proc writeFF(val : valType) {
       on this {
         chpl_rmem_consist_release();
@@ -447,6 +451,8 @@ module ChapelSyncvar {
       }
     }
 
+    pragma "unsafe"
+    // TODO - once we can annotate, val argument should outlive 'this'
     proc writeXF(val : valType) {
       on this {
         chpl_rmem_consist_release();
@@ -555,6 +561,8 @@ module ChapelSyncvar {
       return ret;
     }
 
+    pragma "unsafe"
+    // TODO - once we can annotate, val argument should outlive 'this'
     proc writeEF(val : valType) {
       on this {
         chpl_rmem_consist_release();
@@ -563,6 +571,8 @@ module ChapelSyncvar {
       }
     }
 
+    pragma "unsafe"
+    // TODO - once we can annotate, val argument should outlive 'this'
     proc writeFF(val : valType) {
       on this {
         chpl_rmem_consist_release();
@@ -571,6 +581,8 @@ module ChapelSyncvar {
       }
     }
 
+    pragma "unsafe"
+    // TODO - once we can annotate, val argument should outlive 'this'
     proc writeXF(val : valType) {
       on this {
         chpl_rmem_consist_release();
@@ -823,6 +835,8 @@ module ChapelSyncvar {
       return ret;
     }
 
+    pragma "unsafe"
+    // TODO - once we can annotate, val argument should outlive 'this'
     proc writeEF(val : valType) {
       on this {
         chpl_rmem_consist_release();

--- a/modules/packages/DistributedBag.chpl
+++ b/modules/packages/DistributedBag.chpl
@@ -630,7 +630,7 @@ module DistributedBag {
 
     // Contiguous memory containing all elements
     var elems :  c_ptr(eltType);
-    var next : BagSegmentBlock(eltType);
+    var next : unmanaged BagSegmentBlock(eltType);
 
     // The capacity of this block.
     var cap : int;

--- a/modules/packages/DistributedDeque.chpl
+++ b/modules/packages/DistributedDeque.chpl
@@ -804,8 +804,8 @@ module DistributedDeque {
     var headIdx : int = 1;
     var tailIdx : int = 1;
     var size : int;
-    var next : LocalDequeNode(eltType);
-    var prev : LocalDequeNode(eltType);
+    var next : unmanaged LocalDequeNode(eltType);
+    var prev : unmanaged LocalDequeNode(eltType);
 
     inline proc isFull {
       return size == distributedDequeBlockSize;
@@ -870,11 +870,11 @@ module DistributedDeque {
 
     var lock$ : sync bool;
 
-    var head : LocalDequeNode(eltType);
-    var tail : LocalDequeNode(eltType);
+    var head : unmanaged LocalDequeNode(eltType);
+    var tail : unmanaged LocalDequeNode(eltType);
 
     // We cache the last deleted node to handle cases where we have rapid mixed push/pop
-    var cached : LocalDequeNode(eltType);
+    var cached : unmanaged LocalDequeNode(eltType);
 
     // The size of a segment. This is used as both a means of knowing when an element
     // gets added, as well as a barrier to prevent the head and tail from being cached.
@@ -900,7 +900,7 @@ module DistributedDeque {
       return new unmanaged LocalDequeNode(eltType);
     }
 
-    inline proc retireNode(node) {
+    inline proc retireNode(node:unmanaged) {
       if cached != nil {
         delete cached;
       }

--- a/modules/packages/Futures.chpl
+++ b/modules/packages/Futures.chpl
@@ -141,7 +141,7 @@ module Futures {
     type retType;
 
     pragma "no doc"
-    var classRef: FutureClass(retType) = nil;
+    var classRef: unmanaged FutureClass(retType) = nil;
 
     pragma "no doc"
     proc init(type retType) {
@@ -219,7 +219,7 @@ module Futures {
     }
 
     pragma "no doc"
-    proc acquire(newRef: FutureClass) {
+    proc acquire(newRef: unmanaged FutureClass) {
       if isValid() then halt("acquire(newRef) called on valid future!");
       classRef = newRef;
       classRef.incRefCount();

--- a/test/parallel/single/waynew/simple0b.chpl
+++ b/test/parallel/single/waynew/simple0b.chpl
@@ -4,8 +4,8 @@ class C {
   var x: int;
 }
 
-var s: single C;
-var t: C;
+var s: single borrowed C;
+var t: borrowed C;
 
 s = new borrowed C();
 s = t;

--- a/test/parallel/sync/bradc/syncArrInit.chpl
+++ b/test/parallel/sync/bradc/syncArrInit.chpl
@@ -6,7 +6,7 @@ class C {
   }
 }
 
-var arr: [1..3] sync C;
+var arr: [1..3] sync borrowed C;
 
 writeln("made it past declaration of arr");
   

--- a/test/parallel/sync/bradc/syncArrInit2.chpl
+++ b/test/parallel/sync/bradc/syncArrInit2.chpl
@@ -6,7 +6,7 @@ class C {
   }
 }
 
-var arr: [1..3] sync C;
+var arr: [1..3] sync unmanaged C;
 
 writeln("made it past declaration of arr");
   

--- a/test/parallel/sync/deitz/test_sync3.chpl
+++ b/test/parallel/sync/deitz/test_sync3.chpl
@@ -5,11 +5,11 @@ class C {
   var a,b : int;
 }
 
-var l : sync C = new C(1,2);
-var m : C = l; //compiles without any error
+var l : sync unmanaged C = new unmanaged C(1,2);
+var m : unmanaged C = l; //compiles without any error
 
-var n : [1..5] sync C;
-n[1] = new C(3,4);
+var n : [1..5] sync unmanaged C;
+n[1] = new unmanaged C(3,4);
 var o : C = n[1];
 writeln(o);
 

--- a/test/studies/590o/blerner/xml-parse.chpl
+++ b/test/studies/590o/blerner/xml-parse.chpl
@@ -29,7 +29,7 @@ class XmlTag : XmlElement {
   }
 }
 
-var parsedElements: [AllPairs] single XmlElement;
+var parsedElements: [AllPairs] single unmanaged XmlElement;
 
 proc main {
   forall z in AllIndices with (ref StartIndices, ref EndIndices) do {
@@ -91,7 +91,7 @@ proc processTag(i,j) {
   if (!(hasIndex(i+1, j, StartIndices) || hasIndex(i, j-1, EndIndices)) &&
       (sourceText[i] != "<" && sourceText[j] != ">")) then {
     /* all text? assumes all entities are escaped*/
-    var elt = new XmlPCData(j-i+1, sourceText[i..j]);
+    var elt = new unmanaged XmlPCData(j-i+1, sourceText[i..j]);
     parsedElements(i,j) = elt;
     writeln("PCData : ", elt.data);
     return;
@@ -111,7 +111,7 @@ proc processTag(i,j) {
         name = sourceText[i+1..stop-1];
         break;
       }
-    var elt = new XmlTag(j-i+1, name);
+    var elt = new unmanaged XmlTag(j-i+1, name);
     parsedElements(i,j) = elt;
     writeln("Self-closed : ", elt.name);
     return;
@@ -143,10 +143,10 @@ proc processTag(i,j) {
     return;
   }
   var start = min reduce ([x in EndIndices] if x > i then x);
-  var elt = new XmlTag(j-i+1, tagName);
+  var elt = new unmanaged XmlTag(j-i+1, tagName);
   start = min reduce ([x in StartIndices] if x > start then x);
   while (start < stop) {
-    var item : XmlElement = nil;
+    var item : unmanaged XmlElement = nil;
     for e in EndIndices do
       if e > start && e < stop &&
         item == nil && parsedElements(start, e) != nil {


### PR DESCRIPTION
* Mark writeEF/writeFF/writeXF unsafe as a workaround for issue #9853.
* Use unmanaged in DistributedBag/DistributedDeque 
* Use unmanged in Futures
* Use unmanaged in a few tests

Relates to #9998.

- [x] passed full local testing

Reviewed by @benharsh - thanks!