### PR TITLE
Reduce dependence on CHPL_HOME in updateBuildVersion

### DIFF
--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -135,7 +135,7 @@ CLEAN_TARGS += $(CLANG_SETTINGS_FILE)
 
 $(BUILD_VERSION_FILE): FORCE
 	@({ test -e $(CHPL_MAKE_HOME)/.git ; } && \
-	test -x $(UPDATE_BUILD_VERSION) && $(UPDATE_BUILD_VERSION) $@) || \
+	test -x $(UPDATE_BUILD_VERSION) && $(UPDATE_BUILD_VERSION) $@ $(CHPL_MAKE_HOME)) || \
 	test -r $(BUILD_VERSION_FILE) || (echo '"0"' > $@);
 
 $(CHPL_MAKE_HOME)/configured-prefix:

--- a/util/devel/updateBuildVersion
+++ b/util/devel/updateBuildVersion
@@ -7,8 +7,8 @@
 # compared to how we normally count BUILD_VERSIONS
 #
 
-$chplhome = $ENV{'CHPL_HOME'};
 $build_version_file = $ARGV[0];
+$chplhome = $ARGV[1];
 
 if ($build_version_file eq "") {
     print "usage: updateBuildVersion <filename for build version>\n";
@@ -22,10 +22,9 @@ if (-r "$build_version_file") {
     $last_build_version = "!!!";
 }
 
-if (defined $ENV{'CHPL_HOME'} &&
-    -e "$chplhome/.git") {
+if (-e "$chplhome/.git") {
 
-    $git_rev = `cd $ENV{'CHPL_HOME'} && git rev-parse --short HEAD`;
+    $git_rev = `cd $chplhome && git rev-parse --short HEAD`;
     chomp($git_rev);
 
     $build_version = "$git_rev";


### PR DESCRIPTION
It used to be that we required CHPL_HOME to be set when building
Chapel and, as a result, the updateBuildVersion script required it to
be set.  Over time, we've relaxed that requirement, but
updateBuildVersion still needed it to be set in order to avoid setting
the "SHA" part of the version number to -999.  This mod changes the
way it's defined to accept CHPL_HOME as a second argument.  Given that
the Makefile calling it has already determined where CHPL_HOME is and
can pass it in, this reduces the requirement that it be set by the user.