### PR TITLE
Avoid using syncvar_t in the qthreads shim

### DIFF
--- a/runtime/include/tasks/qthreads/chpl-tasks-impl.h
+++ b/runtime/include/tasks/qthreads/chpl-tasks-impl.h
@@ -64,8 +64,8 @@ typedef struct {
     aligned_t lockers_out;
     uint_fast32_t uncontested_locks;
     int       is_full;
-    syncvar_t signal_full;
-    syncvar_t signal_empty;
+    aligned_t signal_full;
+    aligned_t signal_empty;
 } chpl_sync_aux_t;
 
 //


### PR DESCRIPTION
Qthreads has 2 sync variable implementations. One that operates on syncvar_t
and one that operates on aligned_t. The main difference is that syncvar_t uses
3 bits to store the FEB state only leaving 61 bits to store values, and the
aligned_t version stores the FEB state externally and all 64 bits are available
for storage. From module code we map Chapel sync vars down to aligned_t since
we need the full 64 bits, but there were some cases left in the runtime shim
that used syncar_t.

This switches the remaining uses of syncvar_t in the shim to aligned_t.
syncvar_t still has a serialization issue that we fixed the aligned_t variant
in #9737. Additionally, since we map Chapel sync vars down to aligned_t sync
vars they're significantly more tested.

This resolves #9651 for non-native sync variables (non-integral sync variables
or single variables, or if -suseNativeSyncVar=false)

This allows the SPMD version of stream to achieve full performance when
compiled with `-suseNativeSyncVar=false`

| config           | performance |
| ---------------- | ----------- |
| no barrier       | 84 GB/s     |
| atomic barrier   | 84 GB/s     |
| old sync barrier | 10 GB/s     |
| now sync barrier | 84 GB/s     |

Related to https://github.com/chapel-lang/chapel/issues/10000