### PR TITLE
Join the initer thread in the qthreads shim

### DIFF
--- a/test/regexp/ferguson/regex-no-leak.skipif
+++ b/test/regexp/ferguson/regex-no-leak.skipif
@@ -1,3 +1,0 @@
-# Relies upon pthread destructor called before mem leak report
-# see issue #9819
-CHPL_TASKS != fifo


### PR DESCRIPTION
Instead of creating it in a detached state (which makes when it's destroyed
variable) force it to be joined during normal task shutdown. This ensures that
the pthread is joined as part of task shutdown, which also ensures that any
pthread key destructors are called before we do memory reporting.

This allows us to stop skipping a memory leak test that relies on pthread key
destructors running. Previously this test failed sporadically since the
destructor could run at anytime since the thread was detached, but it now runs
during chpl_task_exit(). Passes 10,000 trials for regexp/ferguson/regex-no-leak

This resolves https://github.com/chapel-lang/chapel/issues/9819