### PR TITLE
Mason Test Improvements

### DIFF
--- a/test/mason/mason-test/Mason.lock
+++ b/test/mason/mason-test/Mason.lock
@@ -3,7 +3,7 @@
 name = "sampleModule"
 version = "0.1.0"
 chplVersion = "1.18.0..1.18.0"
-tests = ["sampletest.chpl", "sampletest2.chpl", "dependencytest.chpl", "nomodule.chpl", "testdir/subdirectorytest.chpl"]
+tests = ["sampletest.chpl", "sampletest2.chpl", "dependencytest.chpl", "nomodule.chpl", "testdir/subdirectorytest.chpl", "shallnotpass.chpl"]
 dependencies = ["_MasonTest1 0.1.0 https://github.com/Spartee/_MasonTest1"]
 
 [_MasonTest1]

--- a/test/mason/mason-test/Mason.toml
+++ b/test/mason/mason-test/Mason.toml
@@ -3,7 +3,12 @@
 name = "sampleModule"
 version = "0.1.0"
 chplVersion = "1.17.0"
-tests = ["sampletest.chpl", "sampletest2.chpl", "dependencytest.chpl", "nomodule.chpl", "testdir/subdirectorytest.chpl"]
+tests = ["sampletest.chpl",
+         "sampletest2.chpl",
+         "dependencytest.chpl",
+         "nomodule.chpl",
+         "testdir/subdirectorytest.chpl",
+         "shallnotpass.chpl"]
 
 [dependencies]
 _MasonTest1 = "0.1.0"

--- a/test/mason/mason-test/mason-test.good
+++ b/test/mason/mason-test/mason-test.good
@@ -1,7 +1,12 @@
 Updating mason-registry for registry
 Downloading dependency: _MasonTest1-0.1.0
-Test Passed!
-Test 2 Passed!
-Test with dependency Passed!
-Test with dependency outside module Passed!
-Test with dependency within subdirectory Passed!
+--- Results ---
+Test: nomodule Passed
+Test: subdirectorytest Passed
+Test: sampletest2 Passed
+Test: dependencytest Passed
+Test: sampletest Passed
+
+--- Summary:  5 tests run ---
+-----> 5 Passed
+-----> 0 Failed

--- a/test/mason/mason-test/mason-test.good
+++ b/test/mason/mason-test/mason-test.good
@@ -2,11 +2,12 @@ Updating mason-registry for registry
 Downloading dependency: _MasonTest1-0.1.0
 --- Results ---
 Test: nomodule Passed
+Test: shallnotpass Failed
 Test: subdirectorytest Passed
 Test: sampletest2 Passed
 Test: dependencytest Passed
 Test: sampletest Passed
 
---- Summary:  5 tests run ---
+--- Summary:  6 tests run ---
 -----> 5 Passed
------> 0 Failed
+-----> 1 Failed

--- a/tools/mason/MasonBuild.chpl
+++ b/tools/mason/MasonBuild.chpl
@@ -119,23 +119,6 @@ proc buildProgram(release: bool, show: bool, compopts: [?d] string,
 }
 
 
-/* Creates the rest of the project structure */
-proc makeTargetFiles(binLoc: string, projectHome: string) {
-
-  if !isDir(projectHome + '/target') {
-    mkdir(projectHome + '/target');
-  }
-  if !isDir(projectHome + '/target/' + binLoc) {
-    mkdir(projectHome + '/target/' + binLoc);
-    mkdir(projectHome + '/target/test');
-
-    // TODO:
-    //mkdir(projectHome + '/target/'+ binLoc + '/examples');
-    //mkdir(projectHome + '/target/' + binLoc + '/bench');
-  }
-}
-
-
 /* Compiles the program into the main project src
    folder. Requires that the main library file be
    named after the project folder in which it is

--- a/tools/mason/MasonHelp.chpl
+++ b/tools/mason/MasonHelp.chpl
@@ -150,10 +150,11 @@ proc masonTestHelp() {
   writeln();
   writeln("Options:");
   writeln("    -h, --help                  Display this message");
-  writeln("        --show                  Increase verbosity");
+  writeln("        --show                  Direct output of tests to stdout");
   writeln("        --no-run                Compile tests without running them");
+  writeln("        --parallel              Run tests in parallel(sequential by default");
   writeln();
   writeln("Test configuration is up to the user");
-  writeln("Test output is piped to stdout");
+  writeln("Tests pass if they exit with status code 0");
 }
 

--- a/tools/mason/MasonTest.chpl
+++ b/tools/mason/MasonTest.chpl
@@ -92,9 +92,8 @@ private proc runTests(show: bool, run: bool, parallel: bool) {
 
       var resultDomain: domain(string);
       var testResults: [resultDomain] string;
-      var numPassed = 0;
 
-      forall test in testNames with (+ reduce numPassed) {
+      forall test in testNames {
 
         const testPath = "".join(projectHome, '/test/', test);
         const testName = basename(stripExt(test, ".chpl"));
@@ -118,18 +117,19 @@ private proc runTests(show: bool, run: bool, parallel: bool) {
             }
             else {
               testResults[testName] = "Passed";
-              numPassed += 1;
             }
           }
         }
       }
       if run && !parallel {
         var testBinResults = runTestBinaries(projectHome, testNames, numTests, show);
-        resultDomain = testBinResults[1].domain;
-        testResults = testBinResults[1];
-        numPassed = testBinResults[2];
+        resultDomain = testBinResults.domain;
+        testResults = testBinResults;
       }
-      if run then printTestResults(testResults, numTests, numPassed, show);
+      if run {
+        const numPassed = testResults.count("Passed");
+        printTestResults(testResults, numTests, numPassed, show);
+      }
     }
     else {
       writeln("No tests were found in /test");
@@ -154,8 +154,7 @@ private proc runTestBinaries(projectHome: string, testNames: [?D] string,
 
   var resultDomain: domain(string);
   var testResults: [resultDomain] string;
-  var numPassed: int;
-
+  
   for test in testNames {
     const testName = basename(stripExt(test, ".chpl"));
     const result = runTestBinary(projectHome, testName, show);
@@ -164,10 +163,9 @@ private proc runTestBinaries(projectHome: string, testNames: [?D] string,
     }
     else {
       testResults[testName] = "Passed";
-      numPassed +=1;
     }
   }
-  return (testResults, numPassed);
+  return testResults;
 }
 
 

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -64,6 +64,15 @@ proc makeTargetFiles(binLoc: string, projectHome: string) {
 }
 
 
+proc stripExt(toStrip: string, ext: string) : string {
+  if toStrip.endsWith(ext) {
+    var stripped = toStrip[..toStrip.size - ext.length];
+    return stripped;
+  }
+  else {
+    return toStrip;
+  }
+}
 
 
 /* Uses the Spawn module to create a subprocess */

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -64,12 +64,14 @@ proc runCommand(cmd, quiet=false) : string {
 
 /* Same as runCommand but for situations where an
    exit status is needed */
-proc runWithStatus(command): int {
+proc runWithStatus(command, show=true): int {
   var cmd = command.split();
   var sub = spawn(cmd, stdout=PIPE);
 
   var line:string;
-  while sub.stdout.readline(line) do write(line);
+  if show {
+    while sub.stdout.readline(line) do write(line);
+  }
   sub.wait();
   return sub.exit_status;
 }


### PR DESCRIPTION
This PR adds three new features to the mason test command:
- Parallel compilation and the option via flag to run tests in parallel with `--parallel` flag.
- Test results are abstracted from user view via status codes with the option to view stdout of tests with`--show` flag.
- Tests are found by mason recursively within the `test/` directory with the option for the user to specify them manually in their `Mason.toml`.