### PR TITLE
Switch to atomic counters for gasnet's comm diagnostics

### DIFF
--- a/runtime/include/chpl-comm-diags.h
+++ b/runtime/include/chpl-comm-diags.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2004-2018 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _chpl_comm_diags_h_
+#define _chpl_comm_diags_h_
+
+#include "chpl-atomics.h"
+#include "chpl-comm.h"
+
+typedef struct _chpl_atomic_commDiagnostics {
+#define _COMM_DIAGS_DECL_ATOMIC(cdv) atomic_uint_least64_t cdv;
+  CHPL_COMM_DIAGS_VARS_ALL(_COMM_DIAGS_DECL_ATOMIC)
+#undef _COMM_DIAGS_DECL_ATOMIC
+} chpl_atomic_commDiagnostics;
+
+
+static inline
+void chpl_comm_diags_init(chpl_atomic_commDiagnostics* acd) {
+#define _COMM_DIAGS_INIT(cdv) atomic_init_uint_least64_t(&acd->cdv, 0);
+  CHPL_COMM_DIAGS_VARS_ALL(_COMM_DIAGS_INIT);
+#undef _COMM_DIAGS_INIT
+}
+
+static inline
+void chpl_comm_diags_reset(chpl_atomic_commDiagnostics* acd) {
+#define _COMM_DIAGS_RESET(cdv) atomic_store_uint_least64_t(&acd->cdv, 0);
+  CHPL_COMM_DIAGS_VARS_ALL(_COMM_DIAGS_RESET);
+#undef _COMM_DIAGS_RESET
+}
+
+static inline
+void chpl_comm_diags_copy(chpl_commDiagnostics* cd,
+                          chpl_atomic_commDiagnostics* acd) {
+#define _COMM_DIAGS_COPY(cdv) cd->cdv = atomic_load_uint_least64_t(&acd->cdv);
+  CHPL_COMM_DIAGS_VARS_ALL(_COMM_DIAGS_COPY);
+#undef _COMM_DIAGS_COPY
+}
+
+static inline
+void chpl_comm_diags_incr(atomic_uint_least64_t* op) {
+  (void) atomic_fetch_add_uint_least64_t(op, 1);
+}
+
+#endif

--- a/runtime/include/chpl-comm.h
+++ b/runtime/include/chpl-comm.h
@@ -28,7 +28,6 @@
 #include "chpl-comm-impl.h"
 #include "chpl-comm-heap-macros.h"
 #include "chpl-tasks.h"
-#include "chpl-atomics.h"
 #include "chpl-comm-task-decls.h"
 #include "chpl-comm-locales.h"
 #include "chpl-mem-desc.h"
@@ -496,82 +495,24 @@ void chpl_comm_make_progress(void);
 //
 // Comm diagnostics stuff
 //
-// We have a struct of non-atomic counters to simplify interfacing with module
-// code, and a struct of atomic counters for use in communication layers
-//
+
+#define CHPL_COMM_DIAGS_VARS_ALL(MACRO) \
+  MACRO(get) \
+  MACRO(get_nb) \
+  MACRO(put) \
+  MACRO(put_nb) \
+  MACRO(test_nb) \
+  MACRO(wait_nb) \
+  MACRO(try_nb) \
+  MACRO(execute_on) \
+  MACRO(execute_on_fast) \
+  MACRO(execute_on_nb)
+
 typedef struct _chpl_commDiagnostics {
-  uint64_t get;
-  uint64_t get_nb;
-  uint64_t put;
-  uint64_t put_nb;
-  uint64_t test_nb;
-  uint64_t wait_nb;
-  uint64_t try_nb;
-  uint64_t execute_on;
-  uint64_t execute_on_fast;
-  uint64_t execute_on_nb;
+#define _COMM_DIAGS_DECL(cdv) uint64_t cdv;
+  CHPL_COMM_DIAGS_VARS_ALL(_COMM_DIAGS_DECL)
+#undef _COMM_DIAGS_DECL
 } chpl_commDiagnostics;
-
-typedef struct _chpl_atomic_commDiagnostics {
-  atomic_uint_least64_t get;
-  atomic_uint_least64_t get_nb;
-  atomic_uint_least64_t put;
-  atomic_uint_least64_t put_nb;
-  atomic_uint_least64_t test_nb;
-  atomic_uint_least64_t wait_nb;
-  atomic_uint_least64_t try_nb;
-  atomic_uint_least64_t execute_on;
-  atomic_uint_least64_t execute_on_fast;
-  atomic_uint_least64_t execute_on_nb;
-} chpl_atomic_commDiagnostics;
-
-static inline
-void chpl_comm_diags_incr(atomic_uint_least64_t* op) {
-  (void) atomic_fetch_add_uint_least64_t(op, 1);
-}
-
-static inline
-void chpl_comm_diags_init(chpl_atomic_commDiagnostics* acd) {
-  atomic_init_uint_least64_t(&acd->get, 0);
-  atomic_init_uint_least64_t(&acd->get_nb, 0);
-  atomic_init_uint_least64_t(&acd->put, 0);
-  atomic_init_uint_least64_t(&acd->put_nb, 0);
-  atomic_init_uint_least64_t(&acd->test_nb, 0);
-  atomic_init_uint_least64_t(&acd->wait_nb, 0);
-  atomic_init_uint_least64_t(&acd->try_nb, 0);
-  atomic_init_uint_least64_t(&acd->execute_on, 0);
-  atomic_init_uint_least64_t(&acd->execute_on_fast, 0);
-  atomic_init_uint_least64_t(&acd->execute_on_nb, 0);
-}
-
-static inline
-void chpl_comm_diags_reset(chpl_atomic_commDiagnostics* acd) {
-  atomic_store_uint_least64_t(&acd->get, 0);
-  atomic_store_uint_least64_t(&acd->get_nb, 0);
-  atomic_store_uint_least64_t(&acd->put, 0);
-  atomic_store_uint_least64_t(&acd->put_nb, 0);
-  atomic_store_uint_least64_t(&acd->test_nb, 0);
-  atomic_store_uint_least64_t(&acd->wait_nb, 0);
-  atomic_store_uint_least64_t(&acd->try_nb, 0);
-  atomic_store_uint_least64_t(&acd->execute_on, 0);
-  atomic_store_uint_least64_t(&acd->execute_on_fast, 0);
-  atomic_store_uint_least64_t(&acd->execute_on_nb, 0);
-}
-
-static inline
-void chpl_comm_diags_copy(chpl_commDiagnostics* cd,
-                          chpl_atomic_commDiagnostics* acd) {
-  cd->get             = atomic_load_uint_least64_t(&acd->get);
-  cd->get_nb          = atomic_load_uint_least64_t(&acd->get_nb);
-  cd->put             = atomic_load_uint_least64_t(&acd->put);
-  cd->put_nb          = atomic_load_uint_least64_t(&acd->put_nb);
-  cd->test_nb         = atomic_load_uint_least64_t(&acd->test_nb);
-  cd->wait_nb         = atomic_load_uint_least64_t(&acd->wait_nb);
-  cd->try_nb          = atomic_load_uint_least64_t(&acd->try_nb);
-  cd->execute_on      = atomic_load_uint_least64_t(&acd->execute_on);
-  cd->execute_on_fast = atomic_load_uint_least64_t(&acd->execute_on_fast);
-  cd->execute_on_nb   = atomic_load_uint_least64_t(&acd->execute_on_nb);
-}
 
 void chpl_startVerboseComm(void);
 void chpl_stopVerboseComm(void);

--- a/runtime/src/comm/gasnet/comm-gasnet.c
+++ b/runtime/src/comm/gasnet/comm-gasnet.c
@@ -24,6 +24,7 @@
 #include "gasnet_coll.h"
 #include "gasnet_tools.h"
 #include "chpl-comm.h"
+#include "chpl-comm-diags.h"
 #include "chpl-comm-callbacks.h"
 #include "chpl-comm-callbacks-internal.h"
 #include "chpl-mem.h"

--- a/runtime/src/comm/gasnet/comm-gasnet.c
+++ b/runtime/src/comm/gasnet/comm-gasnet.c
@@ -50,8 +50,7 @@
 #include <assert.h>
 #include <time.h>
 
-static chpl_sync_aux_t chpl_comm_diagnostics_sync;
-static chpl_commDiagnostics chpl_comm_commDiagnostics;
+static chpl_atomic_commDiagnostics comm_diagnostics;
 static int chpl_comm_no_debug_private = 0;
 static gasnet_seginfo_t* seginfo_table = NULL;
 
@@ -642,9 +641,7 @@ chpl_comm_nb_handle_t chpl_comm_put_nb(void *addr, c_nodeid_t node, void* raddr,
   ret = gasnet_put_nb_bulk(node, raddr, addr, size);
 
   if (chpl_comm_diagnostics && !chpl_comm_no_debug_private) {
-    chpl_sync_lock(&chpl_comm_diagnostics_sync);
-    chpl_comm_commDiagnostics.put_nb++;
-    chpl_sync_unlock(&chpl_comm_diagnostics_sync);
+    chpl_comm_diags_incr(&comm_diagnostics.put_nb);
   }
 
   return (chpl_comm_nb_handle_t) ret;
@@ -680,9 +677,7 @@ chpl_comm_nb_handle_t chpl_comm_get_nb(void* addr, c_nodeid_t node, void* raddr,
   ret = gasnet_get_nb_bulk(addr, node, raddr, size);
 
   if (chpl_comm_diagnostics && !chpl_comm_no_debug_private) {
-    chpl_sync_lock(&chpl_comm_diagnostics_sync);
-    chpl_comm_commDiagnostics.get_nb++;
-    chpl_sync_unlock(&chpl_comm_diagnostics_sync);
+    chpl_comm_diags_incr(&comm_diagnostics.get_nb);
   }
 
   return (chpl_comm_nb_handle_t) ret;
@@ -930,15 +925,14 @@ void chpl_comm_post_task_init(void) {
     sched_yield();
   }
 
-  // clear diags
-  memset(&chpl_comm_commDiagnostics, 0, sizeof(chpl_commDiagnostics));
-
   // Initialize the caching layer, if it is active.
   chpl_cache_init();
 }
 
 void chpl_comm_rollcall(void) {
-  chpl_sync_initAux(&chpl_comm_diagnostics_sync);
+  // Initialize diags
+  chpl_comm_diags_init(&comm_diagnostics);
+
   chpl_msg(2, "executing on node %d of %d node(s): %s\n", chpl_nodeID, 
            chpl_numNodes, chpl_nodeName());
 }
@@ -1159,9 +1153,7 @@ void  chpl_comm_put(void* addr, c_nodeid_t node, void* raddr,
       printf("%d: %s:%d: remote put to %d\n", chpl_nodeID,
              chpl_lookupFilename(fn), ln, node);
     if (chpl_comm_diagnostics && !chpl_comm_no_debug_private) {
-      chpl_sync_lock(&chpl_comm_diagnostics_sync);
-      chpl_comm_commDiagnostics.put++;
-      chpl_sync_unlock(&chpl_comm_diagnostics_sync);
+      chpl_comm_diags_incr(&comm_diagnostics.put);
     }
 
     // Handle remote address not in remote segment.
@@ -1241,9 +1233,7 @@ void  chpl_comm_get(void* addr, c_nodeid_t node, void* raddr,
       printf("%d: %s:%d: remote get from %d\n", chpl_nodeID,
              chpl_lookupFilename(fn), ln, node);
     if (chpl_comm_diagnostics && !chpl_comm_no_debug_private) {
-      chpl_sync_lock(&chpl_comm_diagnostics_sync);
-      chpl_comm_commDiagnostics.get++;
-      chpl_sync_unlock(&chpl_comm_diagnostics_sync);
+      chpl_comm_diags_incr(&comm_diagnostics.get);
     }
 
     // Handle remote address not in remote segment.
@@ -1406,9 +1396,7 @@ void  chpl_comm_get_strd(void* dstaddr, size_t* dststrides, c_nodeid_t srcnode_i
     printf("%d: %s:%d: remote get from %d\n", chpl_nodeID,
            chpl_lookupFilename(fn), ln, srcnode);
   if (chpl_comm_diagnostics && !chpl_comm_no_debug_private) {
-    chpl_sync_lock(&chpl_comm_diagnostics_sync);
-    chpl_comm_commDiagnostics.get++;
-    chpl_sync_unlock(&chpl_comm_diagnostics_sync);
+    chpl_comm_diags_incr(&comm_diagnostics.get);
   }
 
   // TODO -- handle strided get for non-registered memory
@@ -1471,9 +1459,7 @@ void  chpl_comm_put_strd(void* dstaddr, size_t* dststrides, c_nodeid_t dstnode_i
     printf("%d: %s:%d: remote get from %d\n", chpl_nodeID,
            chpl_lookupFilename(fn), ln, dstnode);
   if (chpl_comm_diagnostics && !chpl_comm_no_debug_private) {
-    chpl_sync_lock(&chpl_comm_diagnostics_sync);
-    chpl_comm_commDiagnostics.put++;
-    chpl_sync_unlock(&chpl_comm_diagnostics_sync);
+    chpl_comm_diags_incr(&comm_diagnostics.put);
   }
   // TODO -- handle strided put for non-registered memory
   gasnet_puts_bulk(dstnode, dstaddr, dststr, srcaddr, srcstr, cnt, strlvls); 
@@ -1612,9 +1598,7 @@ void  chpl_comm_execute_on(c_nodeid_t node, c_sublocid_t subloc,
     if (chpl_verbose_comm && !chpl_comm_no_debug_private)
       printf("%d: remote task created on %d\n", chpl_nodeID, node);
     if (chpl_comm_diagnostics && !chpl_comm_no_debug_private) {
-      chpl_sync_lock(&chpl_comm_diagnostics_sync);
-      chpl_comm_commDiagnostics.execute_on++;
-      chpl_sync_unlock(&chpl_comm_diagnostics_sync);
+      chpl_comm_diags_incr(&comm_diagnostics.execute_on);
     }
 
     execute_on_common(node, subloc, fid, arg, arg_size,
@@ -1640,9 +1624,7 @@ void  chpl_comm_execute_on_nb(c_nodeid_t node, c_sublocid_t subloc,
     if (chpl_verbose_comm && !chpl_comm_no_debug_private)
       printf("%d: remote non-blocking task created on %d\n", chpl_nodeID, node);
     if (chpl_comm_diagnostics && !chpl_comm_no_debug_private) {
-      chpl_sync_lock(&chpl_comm_diagnostics_sync);
-      chpl_comm_commDiagnostics.execute_on_nb++;
-      chpl_sync_unlock(&chpl_comm_diagnostics_sync);
+      chpl_comm_diags_incr(&comm_diagnostics.execute_on_nb);
     }
   
     execute_on_common(node, subloc, fid, arg, arg_size,
@@ -1670,9 +1652,7 @@ void  chpl_comm_execute_on_fast(c_nodeid_t node, c_sublocid_t subloc,
       printf("%d: remote (no-fork) task created on %d\n",
              chpl_nodeID, node);
     if (chpl_comm_diagnostics && !chpl_comm_no_debug_private) {
-      chpl_sync_lock(&chpl_comm_diagnostics_sync);
-      chpl_comm_commDiagnostics.execute_on_fast++;
-      chpl_sync_unlock(&chpl_comm_diagnostics_sync);
+      chpl_comm_diags_incr(&comm_diagnostics.execute_on_fast);
     }
 
   execute_on_common(node, subloc, fid, arg, arg_size,
@@ -1735,15 +1715,11 @@ void chpl_stopCommDiagnosticsHere() {
 }
 
 void chpl_resetCommDiagnosticsHere() {
-  chpl_sync_lock(&chpl_comm_diagnostics_sync);
-  memset(&chpl_comm_commDiagnostics, 0, sizeof(chpl_commDiagnostics));
-  chpl_sync_unlock(&chpl_comm_diagnostics_sync);
+  chpl_comm_diags_reset(&comm_diagnostics);
 }
 
 void chpl_getCommDiagnosticsHere(chpl_commDiagnostics *cd) {
-  chpl_sync_lock(&chpl_comm_diagnostics_sync);
-  chpl_memcpy(cd, &chpl_comm_commDiagnostics, sizeof(chpl_commDiagnostics));
-  chpl_sync_unlock(&chpl_comm_diagnostics_sync);
+  chpl_comm_diags_copy(cd, &comm_diagnostics);
 }
 
 void chpl_comm_gasnet_help_register_global_var(int i, wide_ptr_t wide_addr) {

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -53,6 +53,7 @@
 #include "chplrt.h"
 #include "chpl-cache.h"
 #include "chpl-comm.h"
+#include "chpl-comm-diags.h"
 #include "chpl-comm-callbacks.h"
 #include "chpl-comm-callbacks-internal.h"
 #include "chpl-env.h"


### PR DESCRIPTION
Previously, our gasnet shim used non-atomic variables with access protected by
`chpl_sync_lock()`/`chpl_sync_unlock()`. Protecting counters with a lock is
very heavyweight, so just switch to atomic counters, like we were already doing
in ugni.

This makes comm diagnostics much more lightweight under gasnet. This also
cleans up and unifies the comm diagnostics code for ugni and gasnet.

I noticed this while making changes to `chpl_sync_lock()`/`chpl_sync_unlock()`,
which motivated me to look at uses of these routines in the runtime.

This closes https://github.com/chapel-lang/chapel/issues/10089
