### PR TITLE
Use unsorted LayoutCS in LinearAlgebra

### DIFF
--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -1206,7 +1206,7 @@ module Sparse {
     nonzeros as ``Dom``
   */
   proc CSRDomain(Dom: domain) where Dom.rank == 2 && isCSDom(Dom) {
-    var csrDom: sparse subdomain(Dom._value.parentDom) dmapped CS();
+    var csrDom: sparse subdomain(Dom._value.parentDom) dmapped CS(sortedIndices=false);
     csrDom += Dom;
     return csrDom;
   }
@@ -1214,7 +1214,7 @@ module Sparse {
   pragma "no doc"
   /* Return a CSR domain based on domain: ``Dom`` - Dense case */
   proc CSRDomain(Dom: domain(2)) where Dom.rank == 2 {
-    var csrDom: sparse subdomain(Dom) dmapped CS();
+    var csrDom: sparse subdomain(Dom) dmapped CS(sortedIndices=false);
     return csrDom;
   }
 
@@ -1292,7 +1292,7 @@ module Sparse {
     where indDom.rank == 1 && nnzDom.rank == 1 {
     const (M, N) = shape;
     const D = {1..M, 1..N};
-    var ADom: sparse subdomain(D) dmapped CS();
+    var ADom: sparse subdomain(D) dmapped CS(sortedIndices=false);
 
     ADom.startIdxDom = {1..indptr.size};
     ADom.startIdx = indptr;
@@ -1580,7 +1580,7 @@ module Sparse {
     }
 
     const parentDT = transpose(D._value.parentDom);
-    var Dom: sparse subdomain(parentDT) dmapped CS();
+    var Dom: sparse subdomain(parentDT) dmapped CS(sortedIndices=false);
     Dom += indices;
     return Dom;
   }

--- a/test/library/packages/LinearAlgebra/correctness/correctness.chpl
+++ b/test/library/packages/LinearAlgebra/correctness/correctness.chpl
@@ -113,7 +113,7 @@ use TestUtils;
   /* CSR Sparse array -> Dense array */
   {
     use LayoutCS;
-    var spsD: sparse subdomain(MDom) dmapped CS();
+    var spsD: sparse subdomain(MDom) dmapped CS(sortedIndices=false);
     var spsA: [spsD] real;
     spsD += (1,1);
     spsD += (2,2);
@@ -596,11 +596,11 @@ use TestUtils;
         tParentDom = {1..3, 1..5},
         tParentDomT = {1..5, 1..3};
 
-  var   Dom: sparse subdomain(parentDom) dmapped CS(),
-        Dom2: sparse subdomain(parentDom2) dmapped CS(),
-        IDom: sparse subdomain (parentDom) dmapped CS(),
-        tDom: sparse subdomain (tParentDom) dmapped CS(),
-        tDomT: sparse subdomain (tParentDomT) dmapped CS();
+  var   Dom: sparse subdomain(parentDom) dmapped CS(sortedIndices=false),
+        Dom2: sparse subdomain(parentDom2) dmapped CS(sortedIndices=false),
+        IDom: sparse subdomain (parentDom) dmapped CS(sortedIndices=false),
+        tDom: sparse subdomain (tParentDom) dmapped CS(sortedIndices=false),
+        tDomT: sparse subdomain (tParentDomT) dmapped CS(sortedIndices=false);
 
 
   // Identity sparse domain

--- a/test/library/packages/LinearAlgebra/correctness/sparse-sorted.chpl
+++ b/test/library/packages/LinearAlgebra/correctness/sparse-sorted.chpl
@@ -20,7 +20,7 @@ config const debug = false;
 proc main() {
   const R = 1..n;
   const parent = {R,R};
-  var D : sparse subdomain(parent) dmapped CS();
+  var D : sparse subdomain(parent) dmapped CS(sortedIndices=false);
 
   for i in R {
     const s = 1 + i % 10;

--- a/test/library/packages/LinearAlgebra/performance/SPA-perf.chpl
+++ b/test/library/packages/LinearAlgebra/performance/SPA-perf.chpl
@@ -116,7 +116,7 @@ proc memberCheck(A) {
 proc SPAdot(A: [?Adom], B: [?Bdom]) where isCSArr(A) && isCSArr(B) {
 
   const D = {Adom.dim(1), Bdom.dim(2)};
-  var Cdom: sparse subdomain(D) dmapped CS();
+  var Cdom: sparse subdomain(D) dmapped CS(sortedIndices=false);
   var C: [Cdom] A.eltType;
 
   // pre-allocate nnz(A) + nnz(B) -- TODO: shrink later
@@ -200,4 +200,3 @@ record _SPA {
     return nzi;
   }
 }
-


### PR DESCRIPTION
This PR addresses #10040 (Using LayoutCS( unsorted ) in LinearAlgebra.
Anywhere that invoked the CS constructor now invokes it as `CS(sortedIndices=false)`.