### PR TITLE
Remove -show_strings from analyzeMemLeaksLog

### DIFF
--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -843,7 +843,7 @@ if ($runtests == 0) {
 # analyze memory leaks tests
 #
     if (!($memleaks eq "")) {
-        mysystem("$chplhomedir/util/devel/analyzeMemLeaksLog -show_strings $basetmpdir/$memleaks > $memleaksdir/$memleaks");
+        mysystem("$chplhomedir/util/devel/analyzeMemLeaksLog $basetmpdir/$memleaks > $memleaksdir/$memleaks");
 
         # Update the memory leaks status for performance testing runs to
         #  generate graphs for the memory leaks data

--- a/util/devel/analyzeMemLeaksLog
+++ b/util/devel/analyzeMemLeaksLog
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 #
-# Usage: analyzeMemLeaksLog [-show_strings] file ...
+# Usage: analyzeMemLeaksLog file ...
 #
 # Summarize the data in a memleaks log file.
 #
@@ -9,18 +9,11 @@
 # amount of memory leaked.  
 # The output also lists the amount of memory leaked in each category, and in a separate
 # list, the total amount of memory leaked by each program that leaks.
-#
-#  -show_strings -- Causes programs that leak only string-related memory to be included 
-#                   in the list of leaking programs and and in the number of programs
-#                   that leak.  By default, programs that leak only string-related memory
-#                   are not tallied and are not listed.
-#
 
-$show_strings = 0;
 if ($#ARGV > 0) {
     $flag = shift @ARGV;
     if ($flag eq "-show_strings") {
-        $show_strings = 1;
+      print STDERR "[Warning: '-show_strings' is deprecated (string leaks are shown by default)]\n\n";
     }
 }
 
@@ -63,16 +56,7 @@ while (<>) {
         if (m/==============================================================/) {
             $memleaks = 0;
         } elsif (m/(\d*)\s*(\d*)\s*(.*)$/) {
-            if (($show_strings == 0) &&
-                (($3 eq "string copy data") ||
-                 ($3 eq "glom strings data") ||
-                 ($3 eq "string concat data") ||
-                 ($3 eq "set wide string") ||
-                 ($3 eq "get wide string") ||
-                 ($3 eq "string strided select data"))) {
-            } else {
-                $TP{$program} += $2;
-            }
+            $TP{$program} += $2;
             $TZ{$3} += $2; # table of size of leaked memory
             $TN{$3} += $1; # table of number of leaked allocations
         }
@@ -107,7 +91,6 @@ printf("==============================================================\n");
 printf("\n");
 printf("=======================\n");
 printf("Memory Leaking Programs\n");
-printf("   (ignoring strings)\n") unless $show_strings;
 printf("==============================================================\n");
 printf("Total leaked memory (bytes)\n");
 printf("              Program\n");


### PR DESCRIPTION
We used to hide string memory leaks by default because there were so many, but
string leaks were resolved years ago with the string-as-rec push, so there's no
reason to default to not showing string leaks anymore.

Noticed while working on https://github.com/chapel-lang/chapel/issues/10097