### PR TITLE
Adjust analyzeMemLeaksLog to handle the new memStats format

### DIFF
--- a/util/devel/analyzeMemLeaksLog
+++ b/util/devel/analyzeMemLeaksLog
@@ -24,26 +24,16 @@ while (<>) {
         $path = $1;
         $path =~ s/\-/\//g;
         $program = "$path/$program";
-    } elsif (m/Memory Statistics/) {
-        $memstats = 1;
     } elsif (m/Leaked Memory Report/) {
         $memleaks = 1;
-    } elsif ($memstats == 1) {
-        if (m/==============================================================/) {
-            $memstats = 2;
-        }
-    } elsif ($memstats == 2) {
-        if (m/==============================================================/) {
-            $memstats = 0;
-        } elsif (m/Current Allocated Memory\s*(\d*)$/) {
-            $totalLeakedMemory += $1;
-        } elsif (m/Maximum Simultaneous Allocated Memory\s*(\d*)$/) {
-            $maximumAllocatedMemory += $1;
-        } elsif (m/Total Allocated Memory\s*(\d*)$/) {
-            $totalAllocatedMemory += $1;
-        } elsif (m/Total Freed Memory\s*(\d*)$/) {
-            $totalFreedMemory += $1;
-        }
+    } elsif (m/Allocated Now:\s*(\d*)$/) {
+        $totalLeakedMemory += $1;
+    } elsif (m/Allocation High Water Mark:\s*(\d*)$/) {
+        $maximumAllocatedMemory += $1;
+    } elsif (m/Sum of Allocations:\s*(\d*)$/) {
+        $totalAllocatedMemory += $1;
+    } elsif (m/Sum of Frees:\s*(\d*)$/) {
+        $totalFreedMemory += $1;
     } elsif ($memleaks == 1) {
         if (m/==============================================================/) {
             $memleaks = 2;


### PR DESCRIPTION
We adjusted `--memStats` output in #10061 and that broke analyzeMemLeaksLog,
which looks for sentinels and specific strings. In order to get `--memStats`
working with multi-locale we removed the header/footer that analyzeMemLeaksLog
looked for, and we changed some of the wording. This ajdusts analyzeMemLeaksLog
to stop looking for the header/footer and to expect the new wording.

This resolves https://github.com/chapel-lang/chapel/issues/10097