### PR TITLE
Update test to skip under --force-initializers

### DIFF
--- a/test/execflags/sungeun/about.skipif
+++ b/test/execflags/sungeun/about.skipif
@@ -8,3 +8,4 @@ COMPOPTS <= --incremental
 COMPOPTS <= --denormalize
 COMPOPTS <= --warn-unstable
 COMPOPTS <= --lifetime-checking
+COMPOPTS <= --force-initializers


### PR DESCRIPTION
Quiet this test under paratesting when --force-initializers is thrown.