### PR TITLE
Fix segfault for use of runtime type field

### DIFF
--- a/compiler/passes/InitNormalize.cpp
+++ b/compiler/passes/InitNormalize.cpp
@@ -1168,7 +1168,12 @@ void InitNormalize::updateFieldsMember(Expr* expr) const {
         SymExpr* _this = new SymExpr(mFn->_this);
         SymExpr* name  = new SymExpr(new_CStringSymbol(sym->name));
 
-        symExpr->replace(new CallExpr(PRIM_GET_MEMBER, _this, name));
+        if (field->sym->hasFlag(FLAG_PARAM) ||
+            field->sym->hasFlag(FLAG_TYPE_VARIABLE)) {
+          symExpr->replace(new CallExpr(PRIM_GET_MEMBER_VALUE, _this, name));
+        } else {
+          symExpr->replace(new CallExpr(PRIM_GET_MEMBER, _this, name));
+        }
 
       } else {
         USR_FATAL(expr,

--- a/test/classes/initializers/generics/runtime-type-field.chpl
+++ b/test/classes/initializers/generics/runtime-type-field.chpl
@@ -1,0 +1,38 @@
+
+// From #10085
+
+class Map {
+  type domain_type;
+  var parent_domain : domain_type;
+  proc init( in_domain : ?T )
+    where isRectangularDom( in_domain ) || isSparseDom( in_domain )
+    {
+      writeln( "Creating Map(", T : string, ")" );
+      this.domain_type = T;
+      this.parent_domain = in_domain; // Fault happens in this statement
+      writeln( this.parent_domain );
+    }
+}
+
+proc main() {
+  var D : domain(2) = {1..5, 1..5 };
+  var sD : sparse subdomain( D );
+
+  // add some indexes into sD
+  for idx in D {
+    if sD.size >= D.size / 2 then break;
+    sD += idx;
+  }
+
+  var M1 = new owned Map( D );
+
+  writeln();
+
+  // In #10085, this call to Map's initializer would result in a segfault
+  // because the compiler used the static type of 'domain_type' instead of its
+  // runtime type. This lead to use of uninitialized memory when creating the
+  // 'parent_domain' field.
+  var M2 = new owned Map( sD );
+
+  writeln("after");
+}

--- a/test/classes/initializers/generics/runtime-type-field.chpl
+++ b/test/classes/initializers/generics/runtime-type-field.chpl
@@ -30,7 +30,7 @@ proc main() {
 
   // In #10085, this call to Map's initializer would result in a segfault
   // because the compiler used the static type of 'domain_type' instead of its
-  // runtime type. This lead to use of uninitialized memory when creating the
+  // runtime type. This led to use of uninitialized memory when creating the
   // 'parent_domain' field.
   var M2 = new owned Map( sD );
 

--- a/test/classes/initializers/generics/runtime-type-field.good
+++ b/test/classes/initializers/generics/runtime-type-field.good
@@ -1,0 +1,11 @@
+Creating Map(domain(2,int(64),false))
+{1..5, 1..5}
+
+Creating Map(DefaultSparseDom(2,int(64),domain(2,int(64),false)))
+{
+ (1, 1) (1, 2) (1, 3) (1, 4) (1, 5)
+ (2, 1) (2, 2) (2, 3) (2, 4) (2, 5)
+ (3, 1) (3, 2)
+}
+
+after


### PR DESCRIPTION
This PR  fixes a segfault due to the compiler failing to initialize a temporary. The temporary was not initialized because the compiler erroneously used a type field's static type when it should have used the runtime type. This is easily fixed by replacing a prim-get-member with prim-get-member-value during normalization. A test is added to lock in the correct behavior.

Resolves #10085

Testing:
- [x] local + futures
- [x] gasnet over release/, distributions/, arrays/