### PR TITLE
Ignore unmanaged, etc. on records with initializers

### DIFF
--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -2261,6 +2261,10 @@ static void normVarTypeInference(DefExpr* defExpr) {
         // Add a call to postinit() if present
         insertPostInit(var, argExpr);
 
+        // BHARSH 2018-07-11: This NamedExpr was originally removed to fix a
+        // test for --force-initializers, but PR #10171 was merged first and
+        // somehow fixed that test. The test in question was:
+        //   test/classes/delete-free/owned/owned-raw-ingored-record.chpl
         if (NamedExpr* ne = toNamedExpr(argExpr->argList.tail)) {
           if (ne->name == astr_chpl_manager) {
             ne->remove();
@@ -2407,6 +2411,10 @@ static void normVarTypeWithInit(DefExpr* defExpr) {
       // Add a call to postinit() if present
       insertPostInit(var, argExpr);
 
+      // BHARSH 2018-07-11: This NamedExpr was originally removed to fix a
+      // test for --force-initializers, but PR #10171 was merged first and
+      // somehow fixed that test. The test in question was:
+      //   test/classes/delete-free/owned/owned-raw-ingored-record.chpl
       if (NamedExpr* ne = toNamedExpr(argExpr->argList.tail)) {
         if (ne->name == astr_chpl_manager) {
           ne->remove();
@@ -2441,6 +2449,10 @@ static void normVarTypeWithInit(DefExpr* defExpr) {
       // Add a call to postinit() if present
       insertPostInit(initExprTemp, argExpr);
 
+      // BHARSH 2018-07-11: This NamedExpr was originally removed to fix a
+      // test for --force-initializers, but PR #10171 was merged first and
+      // somehow fixed that test. The test in question was:
+      //   test/classes/delete-free/owned/owned-raw-ingored-record.chpl
       if (NamedExpr* ne = toNamedExpr(argExpr->argList.tail)) {
         if (ne->name == astr_chpl_manager) {
           ne->remove();

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -2262,7 +2262,7 @@ static void normVarTypeInference(DefExpr* defExpr) {
         insertPostInit(var, argExpr);
 
         if (NamedExpr* ne = toNamedExpr(argExpr->argList.tail)) {
-          if (strcmp(ne->name, astr_chpl_manager) == 0) {
+          if (ne->name == astr_chpl_manager) {
             ne->remove();
           }
         }
@@ -2408,7 +2408,7 @@ static void normVarTypeWithInit(DefExpr* defExpr) {
       insertPostInit(var, argExpr);
 
       if (NamedExpr* ne = toNamedExpr(argExpr->argList.tail)) {
-        if (strcmp(ne->name, astr_chpl_manager) == 0) {
+        if (ne->name == astr_chpl_manager) {
           ne->remove();
         }
       }
@@ -2442,7 +2442,7 @@ static void normVarTypeWithInit(DefExpr* defExpr) {
       insertPostInit(initExprTemp, argExpr);
 
       if (NamedExpr* ne = toNamedExpr(argExpr->argList.tail)) {
-        if (strcmp(ne->name, astr_chpl_manager) == 0) {
+        if (ne->name == astr_chpl_manager) {
           ne->remove();
         }
       }

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -2261,6 +2261,12 @@ static void normVarTypeInference(DefExpr* defExpr) {
         // Add a call to postinit() if present
         insertPostInit(var, argExpr);
 
+        if (NamedExpr* ne = toNamedExpr(argExpr->argList.tail)) {
+          if (strcmp(ne->name, astr_chpl_manager) == 0) {
+            ne->remove();
+          }
+        }
+
       } else {
         defExpr->insertAfter(new CallExpr(PRIM_MOVE, var, initExpr));
       }
@@ -2400,6 +2406,12 @@ static void normVarTypeWithInit(DefExpr* defExpr) {
 
       // Add a call to postinit() if present
       insertPostInit(var, argExpr);
+
+      if (NamedExpr* ne = toNamedExpr(argExpr->argList.tail)) {
+        if (strcmp(ne->name, astr_chpl_manager) == 0) {
+          ne->remove();
+        }
+      }
     }
 
   } else if (isNewExpr(initExpr) == true) {
@@ -2428,6 +2440,12 @@ static void normVarTypeWithInit(DefExpr* defExpr) {
 
       // Add a call to postinit() if present
       insertPostInit(initExprTemp, argExpr);
+
+      if (NamedExpr* ne = toNamedExpr(argExpr->argList.tail)) {
+        if (strcmp(ne->name, astr_chpl_manager) == 0) {
+          ne->remove();
+        }
+      }
 
       initExprTemp->addFlag(FLAG_DELAY_GENERIC_EXPANSION);
 


### PR DESCRIPTION
The compiler was immediately lowering PRIM_NEW on certain records into an 'init' call, but left the NamedExpr for chpl_manager in place. This would later lead to resolution errors. Instead, remove the NamedExpr when creating the 'init' call.

Resolves a --force-initializers failure for ``classes/delete-free/owned/owned-raw-ingored-record.chpl``

Testing:
- [x] local + futures
- [x] gasnet