### PR TITLE
Add a .future for issue #10122

### DIFF
--- a/test/parallel/forall/diten/unusedClassForallArg.bad
+++ b/test/parallel/forall/diten/unusedClassForallArg.bad
@@ -1,0 +1,8 @@
+unusedClassForallArg.chpl:8: internal error: BAS0407 chpl version 1.18.0 pre-release (a91223789c)
+Note: This source location is a guess.
+
+Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
+please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
+the filename + line number above may be useful in working around the issue.
+

--- a/test/parallel/forall/diten/unusedClassForallArg.chpl
+++ b/test/parallel/forall/diten/unusedClassForallArg.chpl
@@ -1,0 +1,19 @@
+class C {
+  proc foo(A: []) {
+  }
+}
+
+proc bar(A: [], x: C = nil) {
+  forall a in A {
+    if x then x.foo(A);
+  }
+}
+
+// The internal error this test is about goes away if
+// the declaration below is uncommented.
+//const c: C;
+
+var A: [1..10] int;
+
+bar(A);
+

--- a/test/parallel/forall/diten/unusedClassForallArg.future
+++ b/test/parallel/forall/diten/unusedClassForallArg.future
@@ -1,0 +1,3 @@
+bug: otherwise unused class argument causes internal error in forall loop
+
+Issue: #10122


### PR DESCRIPTION
This future has an otherwise unused class as an argument to a function with a
forall loop.  It uses the class in the forall loop if it is not nil.

It hits an internal compiler error due to the reference type for the class
being missing while handling shadow variables.