### PR TITLE
Switch perf playground to measure cstdlib atomics

### DIFF
--- a/util/cron/test-perf.chapcs.playground.bash
+++ b/util/cron/test-perf.chapcs.playground.bash
@@ -25,16 +25,18 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.playground"
 # 4) Update START_DATE to be today, using the format mm/dd/yy
 #
 
-# Test performance of enum ranges
-GITHUB_USER=bradcray
-GITHUB_BRANCH=dsiReallocPar
-SHORT_NAME=dsiReallocPar
-START_DATE=06/18/18
+# Test performance of cstdlib atomics
+#GITHUB_USER=bradcray
+#GITHUB_BRANCH=dsiReallocPar
+SHORT_NAME=cstdlib-atomics
+START_DATE=07/02/18
 
-git branch -D $GITHUB_USER-$GITHUB_BRANCH
-git checkout -b $GITHUB_USER-$GITHUB_BRANCH
-git pull https://github.com/$GITHUB_USER/chapel.git $GITHUB_BRANCH
+export CHPL_ATOMICS=cstdlib
+
+#git branch -D $GITHUB_USER-$GITHUB_BRANCH
+#git checkout -b $GITHUB_USER-$GITHUB_BRANCH
+#git pull https://github.com/$GITHUB_USER/chapel.git $GITHUB_BRANCH
 
 perf_args="-performance-description $SHORT_NAME -performance-configs default:v,$SHORT_NAME:v -sync-dir-suffix $SHORT_NAME"
-perf_args="${perf_args} -numtrials 5 -startdate $START_DATE"
+perf_args="${perf_args} -numtrials 1 -startdate $START_DATE"
 $CWD/nightly -cron ${perf_args} ${nightly_args}


### PR DESCRIPTION
We had performance regressions for several tests the last time we tried to use
cstdlib atomics. That was with gcc 6.2 in September of 2016. We're only on gcc
6.3 for most nightly testing now, so I expect to have similar regressions. Once
those regressions are confirmed I want to check with gcc 8.1 so see if things
have improved.

This also drops the playground down to 1 trial since it's been running pretty
late into the day and generally the extra trials don't really help us.