### PR TITLE
Remove spinwaiting from qthreads chpl_sync_lock()

### DIFF
--- a/modules/internal/ChapelSyncvar.chpl
+++ b/modules/internal/ChapelSyncvar.chpl
@@ -194,6 +194,8 @@ module ChapelSyncvar {
     :returns: The value of the sync variable.
   */
   proc _syncvar.readXX() {
+    // Yield to allow readXX in a loop to make progress
+    chpl_task_yield();
     return wrapped.readXX();
   }
 
@@ -549,9 +551,6 @@ module ChapelSyncvar {
         var alignedLocalRet : aligned_t;
 
         chpl_rmem_consist_release();
-        // currently have to yield to allow readXX in a loop to make progress
-        // TODO only yield every X accesses?
-        chpl_task_yield();
         qthread_readXX(alignedLocalRet, alignedValue);
         chpl_rmem_consist_acquire();
 
@@ -710,6 +709,8 @@ module ChapelSyncvar {
     :returns: The value of the single variable.
   */
   proc _singlevar.readXX() {
+    // Yield to allow readXX in a loop to make progress
+    chpl_task_yield();
     return wrapped.readXX();
   }
 

--- a/runtime/include/tasks/qthreads/chpl-tasks-impl.h
+++ b/runtime/include/tasks/qthreads/chpl-tasks-impl.h
@@ -60,9 +60,7 @@ typedef unsigned int chpl_taskID_t;
 // Sync variables
 //
 typedef struct {
-    aligned_t lockers_in;
-    aligned_t lockers_out;
-    uint_fast32_t uncontested_locks;
+    aligned_t lock;
     int       is_full;
     aligned_t signal_full;
     aligned_t signal_empty;


### PR DESCRIPTION
Previously `chpl_sync_lock()`/`chpl_sync_unlock()` mapped down to an atomic
spinlock under qthreads. Under high contention, this leads to serious
performance loss as seen in https://github.com/chapel-lang/chapel/issues/7748.

Here we convert an atomic spinlock to `qthread_lock()`/`qthread_unlock()`,
which are really just thin wrappers over `qthread_readFE()`/`qthread_fill()`.
This significantly improves performance of highly contended locks/unlocks at
the cost of worse uncontested performance. We're really just making a tradeoff
here, but the previous performance loss under contention is much worse than the
current loss under low contention.

There are 3 main places where we use `chpl_sync_lock()`:
 - For privatization when adding a new privatized object -- very infrequently
   written to, performance shouldn't matter
 - For non-native qthread sync vars -- sync vars are supposed to put tasks to
   sleep, so this is better behavior than what we had (and more closely matches
   native sync vars)
 - For `qio_lock()`/`qio_unlock()` -- this case really wants some sort of
   hybrid spinwait/blocking lock. Switching to a qthread_lock, hurts serial
   performance for small writteln's by about 2x though for larger writes or real
   IO this overhead of locking shouldn't matter. Plus if I/O performance is a
   bottleneck you can always drop down to a non-locking channel and do more
   optimized locking yourself. On the flip side, switching to a qthread_lock
   significantly improves performance for highly contended writes and resolves
   a serious performance degradation for parallel I/O (#7748)

In the old atomic spinlock code we took special care to do a chpl_task_yield
once in a while so that a readXX in a spinloop could eventually make progress.
Since we no longer have a place to do this during chpl_sync_lock, we now just
take the same approach we used for native sync vars and do a yield before every
readXX call.

Resolves https://github.com/chapel-lang/chapel/issues/7748
Resolves https://chapel.atlassian.net/browse/CHAPEL-170
Related to https://github.com/chapel-lang/chapel/issues/10000