### PR TITLE
Fix issue with external array created using another's domain not having initial contents

### DIFF
--- a/modules/internal/ExternalArray.chpl
+++ b/modules/internal/ExternalArray.chpl
@@ -99,6 +99,8 @@ module ExternalArray {
                                         _to_unmanaged(this),
                                         data,
                                         true);
+      // Only give the pointer initial contents if we created it ourselves.
+      init_elts(data.elts:c_ptr(eltType), this.size, eltType);
       return arr;
     }
 

--- a/test/compflags/lydia/library/exportArray/returningArr/callFuncReturnsArrayTakesArrayArg3.future
+++ b/test/compflags/lydia/library/exportArray/returningArr/callFuncReturnsArrayTakesArrayArg3.future
@@ -1,2 +1,0 @@
-bug: arrays made with ExternDom don't get initial contents
-#9934

--- a/test/compflags/lydia/library/exportArray/returningArr/callFuncReturnsArrayTakesArrayArg3.skipif
+++ b/test/compflags/lydia/library/exportArray/returningArr/callFuncReturnsArrayTakesArrayArg3.skipif
@@ -1,2 +1,0 @@
-# only run under valgrind
-CHPL_TEST_VGRND_EXE != on


### PR DESCRIPTION
Resolves #9934 

Because we allocate the contents using chpl_make_external_array instead of
_ddata_allocate, we were missing the init_elts step which gave it its initial
contents.  Explicitly call init_elts in dsiBuildArray, since that is when we
create the pointer ourselves for sure.  Don't call init_elts otherwise, though,
since in those cases the array contents are controlled by someone else

Testing over:
- [x] fresh checkout with test/compflags/lydia/library and futures
- [x] fifo testing with the above
- [x] valgrind testing with the above
- [x] full local paratest with futures