### PR TITLE
Get LLVM smoke testing back on track after disabling enum->int casts

### DIFF
--- a/compiler/codegen/type.cpp
+++ b/compiler/codegen/type.cpp
@@ -110,12 +110,16 @@ void EnumType::codegenDef() {
       type = ty->codegen().type;
       info->lvt->addGlobalType(symbol->cname, type);
 
+      int order = 0;
       for_enums(constant, this) {
         //llvm::Constant *initConstant;
 
-        if(constant->init == NULL) INT_FATAL(this, "no constant->init");
-
-        VarSymbol* s = toVarSymbol(toSymExpr(constant->init)->symbol());
+        VarSymbol* s;
+        if (constant->init) {
+          s = toVarSymbol(toSymExpr(constant->init)->symbol());
+        } else {
+          s = new_IntSymbol(order, INT_SIZE_64);
+        }
         INT_ASSERT(s);
         INT_ASSERT(s->immediate);
 
@@ -123,6 +127,7 @@ void EnumType::codegenDef() {
 
         info->lvt->addGlobalValue(constant->sym->cname,
                                   sizedImmediate->codegen());
+        order++;
       }
     }
 #endif

--- a/compiler/codegen/type.cpp
+++ b/compiler/codegen/type.cpp
@@ -110,6 +110,12 @@ void EnumType::codegenDef() {
       type = ty->codegen().type;
       info->lvt->addGlobalType(symbol->cname, type);
 
+      // Convert enums to constants with the user-specified immediate,
+      // sized appropraitely, when it exists.  When it doesn't, give
+      // it the semi-arbitrary 0-based ordinal value (similar to what
+      // the C back-end would do itself).  Note that once some enum
+      // has a non-NULL constant->init, all subsequent ones should as
+      // well.
       int order = 0;
       for_enums(constant, this) {
         //llvm::Constant *initConstant;


### PR DESCRIPTION
Summary: This should fix the llvm smoke-test that I broke...

In PR #10114, I stopped giving each enum an integer value since we're
moving towards supporting abstract enums that don't have underlying
integer values.  However, this broke LLVM code generation which seems
to generate enum values as integers (h/t to DavidK for sleuthing that
out for me).  This PR takes a stab at getting things running again,
and seems to be working, though I haven't taken the time to do a full
LLVM build + test on chapcs...

Specifically, what I've done here is preserve the old logic (which uses the
enums' initializer values when they're available) while having cases
that don't define initializers simply define the integer values to be
the enum's 0-based order.  This should match what the C back-end is
currently doing.

This seems to get testing working again, but seems as though it could
cause problems if/when there are conflicts between a user's enum values
and the ordinal values.  But, I suspect that the C back-end would have the
same issues.

I _suspect_ that the better thing to do would be to always generate enums
as ordinal values as proposed in issue #8561 for both the LLVM and C
back-ends.