### PR TITLE
Regress to serial compilation to quiet cygwin testing

### DIFF
--- a/test/mason/mason-test/Mason.lock
+++ b/test/mason/mason-test/Mason.lock
@@ -4,11 +4,11 @@ name = "sampleModule"
 version = "0.1.0"
 chplVersion = "1.18.0..1.18.0"
 tests = ["sampletest.chpl", "sampletest2.chpl", "dependencytest.chpl", "nomodule.chpl", "testdir/subdirectorytest.chpl", "shallnotpass.chpl"]
-dependencies = ["_MasonTest1 0.1.0 https://github.com/Spartee/_MasonTest1"]
+dependencies = ["_MasonTest1 0.2.0 https://github.com/Spartee/_MasonTest1"]
 
 [_MasonTest1]
 name = "_MasonTest1"
-version = "0.1.0"
+version = "0.2.0"
 chplVersion = "1.18.0..1.18.0"
 source = "https://github.com/Spartee/_MasonTest1"
 

--- a/test/mason/mason-test/Mason.toml
+++ b/test/mason/mason-test/Mason.toml
@@ -11,4 +11,4 @@ tests = ["sampletest.chpl",
          "shallnotpass.chpl"]
 
 [dependencies]
-_MasonTest1 = "0.1.0"
+_MasonTest1 = "0.2.0"

--- a/test/mason/mason-test/mason-test.good
+++ b/test/mason/mason-test/mason-test.good
@@ -1,5 +1,5 @@
 Updating mason-registry for registry
-Downloading dependency: _MasonTest1-0.1.0
+Downloading dependency: _MasonTest1-0.2.0
 --- Results ---
 Test: nomodule Passed
 Test: shallnotpass Failed

--- a/tools/mason/MasonTest.chpl
+++ b/tools/mason/MasonTest.chpl
@@ -93,7 +93,7 @@ private proc runTests(show: bool, run: bool, parallel: bool) {
       var resultDomain: domain(string);
       var testResults: [resultDomain] string;
 
-      forall test in testNames {
+      for test in testNames {
 
         const testPath = "".join(projectHome, '/test/', test);
         const testName = basename(stripExt(test, ".chpl"));


### PR DESCRIPTION
This PR addresses issues with the mason test tests on cygwin. Due to what seems like a race condition the parallel compilation causes the test to fail sporadically. Parallel compilation will be opened up as a separate issue soon. The _MasonTest version used as a dependency in the tests was also upgraded to v0.2.0 as there is a bug(intentionally) in v0.1.0 which was included in the testing for mason test unintentionally. 