### PR TITLE
Check for self-definitions

### DIFF
--- a/test/trivial/deitz/vars-scopes/self-defs.chpl
+++ b/test/trivial/deitz/vars-scopes/self-defs.chpl
@@ -1,0 +1,15 @@
+
+var a = a;  // a#1
+
+if a > 1 {
+  var a = a;  // a#2
+  writeln(a);
+}
+
+if a > 2 {
+  var a: int = a;  // a#3
+  writeln(a);
+  var b: int = b;
+}
+
+writeln(a);

--- a/test/trivial/deitz/vars-scopes/self-defs.good
+++ b/test/trivial/deitz/vars-scopes/self-defs.good
@@ -1,0 +1,4 @@
+self-defs.chpl:2: error: 'a' is used to define itself
+self-defs.chpl:5: error: 'a' is used to define itself
+self-defs.chpl:10: error: 'a' is used to define itself
+self-defs.chpl:12: error: 'b' is used to define itself


### PR DESCRIPTION
This PR adds a check for self-definitions like `var a: int = a;` .

While there, simplify some adjacent code and edit some comments.

DETAILS

The check I added works specifically on ASTs like `move(a,a)`.

I first tried a "principled approach" by making theDefinedSymbol()
return the Symbol for `a` when encountering `move(a,a)`.
Cf. currently it does so when encountering the SymExpr that is
the first arg of `move(a,a)`.
That attempt did not work for the following reason.
Consider a legitimate `move(a,b)`.  The SymExpr for `a` is encountered
before `a` is considered "defined" upon encountering the `move`. So
the SymExpr for `a` is flagged as an erroneous "use before def".

Resolves #9750.