### PR TITLE
Follow up on #10102

### DIFF
--- a/compiler/AST/AstDump.cpp
+++ b/compiler/AST/AstDump.cpp
@@ -339,7 +339,7 @@ bool AstDump::enterLoopExpr(LoopExpr* node) {
     write(" then ");
   }
 
-  node->expr->accept(this);
+  node->loopBody->accept(this);
 
   write(")");
 

--- a/compiler/AST/AstDumpToHtml.cpp
+++ b/compiler/AST/AstDumpToHtml.cpp
@@ -432,7 +432,7 @@ bool AstDumpToHtml::enterLoopExpr(LoopExpr* node) {
     fprintf(mFP, " <B>then</B> ");
   }
 
-  node->expr->accept(this);
+  node->loopBody->accept(this);
 
   fprintf(mFP, ")");
 

--- a/compiler/AST/Makefile.share
+++ b/compiler/AST/Makefile.share
@@ -32,7 +32,7 @@ AST_SRCS =                                          \
            flags.cpp                                \
            FnSymbol.cpp                             \
            ForallStmt.cpp                           \
-           IfExpr.cpp			            \
+           IfExpr.cpp                               \
            iterator.cpp                             \
            LoopExpr.cpp                             \
            ModuleSymbol.cpp                         \

--- a/compiler/AST/view.cpp
+++ b/compiler/AST/view.cpp
@@ -102,7 +102,7 @@ forall_explanation_start(BaseAST* ast, BaseAST* parentAst) {
   if (LoopExpr* fe = toLoopExpr(parentAst)) {
     if (ast == fe->iteratorExpr)
       return ") in( ";
-    if (ast == fe->expr)
+    if (ast == fe->loopBody)
       return ") { ";
     if (ast == fe->cond)
       return "} if( ";

--- a/compiler/include/LoopExpr.h
+++ b/compiler/include/LoopExpr.h
@@ -26,8 +26,14 @@ public:
 
   Expr* indices;       // Optional: [Unresolved]SymExpr or CallExpr to _build_tuple
   Expr* iteratorExpr;  // Expr or CallExpr to _build_tuple in zippered case
-  BlockStmt* expr;     // Loop body
-  Expr* cond;          // Optional: conditional expression (NB: not an IfExpr)
+  Expr* cond;          // filtering condition or NULL if none
+  BlockStmt* loopBody;
+
+  // Indicates whether this loop-expression is a forall-expr or for-expr
+  bool forall;
+
+  // 'true' if the iteratorExpr is zippered
+  bool zippered;
 
   // 'true' for forall-exprs with square brackets, like:
   //     [i in 1..10] i;
@@ -36,20 +42,14 @@ public:
   //     for    i in 1..10 do i;
   bool maybeArrayType;
 
-  // 'true' if the iteratorExpr is zippered
-  bool zippered;
-
-  // Indicates whether this loop-expression is a forall-expr or for-expr
-  bool forall;
-
   LoopExpr(Expr* indices,
            Expr* iteratorExpr,
-           Expr* expr,
            Expr* cond,
-           bool maybeArrayType,
+           Expr* loopBody,
+           bool forall,
            bool zippered,
-           bool forall);
-  LoopExpr(bool maybeArrayType, bool zippered, bool forall);
+           bool maybeArrayType);
+  LoopExpr(bool forall, bool zippered, bool maybeArrayType);
 
   DECLARE_COPY(LoopExpr);
 

--- a/compiler/include/ResolveScope.h
+++ b/compiler/include/ResolveScope.h
@@ -55,19 +55,7 @@ public:
                         ResolveScope(ModuleSymbol*       modSym,
                                      const ResolveScope* parent);
 
-                        ResolveScope(FnSymbol*           fnSym,
-                                     const ResolveScope* parent);
-
-                        ResolveScope(TypeSymbol*         typeSym,
-                                     const ResolveScope* parent);
-
-                        ResolveScope(ForallStmt*         forallStmt,
-                                     const ResolveScope* parent);
-
-                        ResolveScope(BlockStmt*          blockStmt,
-                                     const ResolveScope* parent);
-
-                        ResolveScope(LoopExpr*         forallExpr,
+                        ResolveScope(BaseAST*            ast,
                                      const ResolveScope* parent);
 
   std::string           name()                                           const;

--- a/compiler/include/baseAST.h
+++ b/compiler/include/baseAST.h
@@ -568,12 +568,12 @@ static inline const CallExpr* toConstCallExpr(const BaseAST* a)
   case E_ContextCallExpr:                                               \
     AST_CALL_LIST(_a, ContextCallExpr, options, call, __VA_ARGS__);     \
     break;                                                              \
-  case E_LoopExpr:                                                    \
-    AST_CALL_LIST(_a, LoopExpr, defIndices, call, __VA_ARGS__);       \
-    AST_CALL_CHILD(_a, LoopExpr, indices,      call, __VA_ARGS__);    \
-    AST_CALL_CHILD(_a, LoopExpr, iteratorExpr, call, __VA_ARGS__);    \
-    AST_CALL_CHILD(_a, LoopExpr, expr,         call, __VA_ARGS__);    \
-    AST_CALL_CHILD(_a, LoopExpr, cond,         call, __VA_ARGS__);    \
+  case E_LoopExpr:                                                      \
+    AST_CALL_LIST(_a,  LoopExpr, defIndices,   call, __VA_ARGS__);      \
+    AST_CALL_CHILD(_a, LoopExpr, indices,      call, __VA_ARGS__);      \
+    AST_CALL_CHILD(_a, LoopExpr, iteratorExpr, call, __VA_ARGS__);      \
+    AST_CALL_CHILD(_a, LoopExpr, cond,         call, __VA_ARGS__);      \
+    AST_CALL_CHILD(_a, LoopExpr, loopBody,     call, __VA_ARGS__);      \
     break;                                                              \
   case E_NamedExpr:                                                     \
     AST_CALL_CHILD(_a, NamedExpr, actual, call, __VA_ARGS__);           \

--- a/compiler/passes/InitNormalize.cpp
+++ b/compiler/passes/InitNormalize.cpp
@@ -1138,7 +1138,7 @@ bool InitNormalize::isFieldAccessible(Expr* expr) const {
   } else if (LoopExpr* fe = toLoopExpr(expr)) {
     isFieldAccessible(fe->iteratorExpr);
     if (fe->cond) isFieldAccessible(fe->cond);
-    isFieldAccessible(fe->expr);
+    isFieldAccessible(fe->loopBody);
   } else if (BlockStmt* block = toBlockStmt(expr)) {
     for_alist(stmt, block->body) {
       isFieldAccessible(stmt);
@@ -1215,7 +1215,7 @@ void InitNormalize::updateFieldsMember(Expr* expr) const {
   } else if (LoopExpr* fe = toLoopExpr(expr)) {
     updateFieldsMember(fe->iteratorExpr);
     if (fe->cond) updateFieldsMember(fe->cond);
-    updateFieldsMember(fe->expr);
+    updateFieldsMember(fe->loopBody);
 
   } else if (BlockStmt* block = toBlockStmt(expr)) {
     for_alist(stmt, block->body) {
@@ -1641,7 +1641,7 @@ static void collectThisUses(Expr* expr, std::vector<CallExpr*>& uses) {
   } else if (LoopExpr* fe = toLoopExpr(expr)) {
     collectThisUses(fe->iteratorExpr, uses);
     if (fe->cond) collectThisUses(fe->cond, uses);
-    collectThisUses(fe->expr, uses);
+    collectThisUses(fe->loopBody, uses);
   } else if (BlockStmt* block = toBlockStmt(expr)) {
     for_alist(stmt, block->body) {
       collectThisUses(stmt, uses);

--- a/compiler/passes/ResolveScope.cpp
+++ b/compiler/passes/ResolveScope.cpp
@@ -124,63 +124,18 @@ ResolveScope::ResolveScope(ModuleSymbol*       modSymbol,
   mAstRef = modSymbol;
   mParent = parent;
 
+  // Use modSymbol->block for sScopeMap
   INT_ASSERT(getScopeFor(modSymbol->block) == NULL);
-
   sScopeMap[modSymbol->block] = this;
 }
 
-ResolveScope::ResolveScope(FnSymbol*           fnSymbol,
+ResolveScope::ResolveScope(BaseAST*            ast,
                            const ResolveScope* parent) {
-  mAstRef = fnSymbol;
+  mAstRef = ast;
   mParent = parent;
 
-  INT_ASSERT(getScopeFor(fnSymbol) == NULL);
-
-  sScopeMap[fnSymbol] = this;
-}
-
-ResolveScope::ResolveScope(TypeSymbol*         typeSymbol,
-                           const ResolveScope* parent) {
-  Type* type = typeSymbol->type;
-
-  INT_ASSERT(isEnumType(type) || isAggregateType(type));
-
-  mAstRef = typeSymbol;
-  mParent = parent;
-
-  INT_ASSERT(getScopeFor(typeSymbol) == NULL);
-
-  sScopeMap[typeSymbol] = this;
-}
-
-ResolveScope::ResolveScope(ForallStmt*         forallStmt,
-                           const ResolveScope* parent) {
-  mAstRef = forallStmt;
-  mParent = parent;
-
-  INT_ASSERT(getScopeFor(forallStmt) == NULL);
-
-  sScopeMap[forallStmt] = this;
-}
-
-ResolveScope::ResolveScope(BlockStmt*          blockStmt,
-                           const ResolveScope* parent) {
-  mAstRef = blockStmt;
-  mParent = parent;
-
-  INT_ASSERT(getScopeFor(blockStmt) == NULL);
-
-  sScopeMap[blockStmt] = this;
-}
-
-ResolveScope::ResolveScope(LoopExpr*         forallExpr,
-                           const ResolveScope* parent) {
-  mAstRef = forallExpr;
-  mParent = parent;
-
-  INT_ASSERT(getScopeFor(forallExpr) == NULL);
-
-  sScopeMap[forallExpr] = this;
+  INT_ASSERT(getScopeFor(ast) == NULL);
+  sScopeMap[ast] = this;
 }
 
 /************************************* | **************************************

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -471,7 +471,7 @@ static void scopeResolve(LoopExpr* fe, ResolveScope* parent) {
   if (fe->indices) scopeResolveExpr(fe->indices, scope);
   if (fe->cond) scopeResolveExpr(fe->cond, scope);
 
-  scopeResolveExpr(fe->expr, scope);
+  scopeResolveExpr(fe->loopBody, scope);
 }
 
 static void scopeResolve(CallExpr* call, ResolveScope* scope) {


### PR DESCRIPTION
This PR implements the review suggestions in #10102.

Most notably:
* rename `expr` field to `loopBody`
* reorder the boolean fields
* move `cond` field consistently ahead of `loopBody` field
   - in constructors, AST_CHILDREN_CALL, accept()
   - this makes it consistent with the execution order
* reduce the number of ResolveScope constructors
   - as they are identical
   - this eliminates one INT_ASSERT, which we feel does not add much value
* add pieces to the second LoopExpr ctor (resolves verify failures)

Discussed with @benharsh .