### PR TITLE
Fix GASNet ZMQ test that relied on enum->int casts

### DIFF
--- a/modules/packages/ZMQ.chpl
+++ b/modules/packages/ZMQ.chpl
@@ -806,7 +806,7 @@ module ZMQ {
     // send, enumerated types
     pragma "no doc"
     proc send(data: ?T, flags: int = 0) throws where isEnumType(T) {
-      try send(data:int, flags);
+      try send(chpl__enumToOrder(data), flags);
     }
 
     // send, records (of other supported things)
@@ -900,7 +900,7 @@ module ZMQ {
     // recv, enumerated types
     pragma "no doc"
     proc recv(type T, flags: int = 0) throws where isEnumType(T) {
-      return try recv(int, flags):T;
+      return try chpl__orderToEnum(recv(int, flags), T);
     }
 
     // recv, records (of other supported things)


### PR DESCRIPTION
This changes how ZMQ sends/recvs enums to avoid relying on casts to integers, using their ordinal values instead.  This was only tested on GASNet which it had not occurred to me would turn up new errors like this.

Thanks Vass for catching this prior to the night's runs!
