### PR TITLE
Fix valgrind error in last night's code

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -6791,12 +6791,10 @@ void ensureEnumTypeResolved(EnumType* etype) {
     // referring to previous enum constants.
     // This might be temporarily incorrect, but it's good enough
     // for resolving the enum constant initializers.
-    // We'll set finally and correctly in the call to sizeAndNormalize()
-    // below.
     etype->integerType = dtInt[INT_SIZE_DEFAULT];
 
-    int64_t v;
-    uint64_t uv;
+    int64_t v=0;
+    uint64_t uv=0;
     bool foundInit = false;
     bool foundNegs = false;
 


### PR DESCRIPTION
In refactoring this pre-existing code, I missed that I'd created
a case where a variable was used before it was defined.  This
fixes it.

I believe this should resolve last night's valgrind errors, but am
running a paratest on valgrind right now to gain more confidence.
This definitely fixes an issue, though, so I'm merging it now
to get master into better shape for all the other July 4th developers.
