### PR TITLE
Don't unpack the LLVM sources for CHPL_LLVM=system

### DIFF
--- a/third-party/llvm/Makefile
+++ b/third-party/llvm/Makefile
@@ -137,7 +137,7 @@ llvm-minimal: $(LLVM_CONFIGURED_HEADER_FILE) $(LLVM_HEADER_FILE) $(LLVM_SUPPORT_
 
 clang-included: llvm
 
-system: $(LLVM_SRC_FILE) $(LLVM_CLANG_CONFIG_FILE)
+system: $(LLVM_CLANG_CONFIG_FILE)
 
 system-minimal:
 

--- a/third-party/llvm/Makefile.include-llvm
+++ b/third-party/llvm/Makefile.include-llvm
@@ -4,6 +4,8 @@ include $(THIRD_PARTY_DIR)/llvm/Makefile.share-included
 # installed to the include directory.
 # Other clang #includes are in $(LLVM_INCLUDE_DIR)/clang
 # and LLVM #includes are in $(LLVM_INCLUDE_DIR)/llvm
+#
+# This won't be necessary once the minimum version is LLVM 6.0
 LLVM_CLANG_CODEGEN_INCLUDE_DIR=$(LLVM_DIR)/$(LLVM_SUBDIR)/tools/clang/lib/CodeGen/
 
 ifndef LLVM_LLVM_LIBS

--- a/third-party/llvm/Makefile.include-system
+++ b/third-party/llvm/Makefile.include-system
@@ -1,11 +1,5 @@
 include $(THIRD_PARTY_DIR)/llvm/Makefile.share-system
 
-# we need access to CodeGenModule.h which is not normally
-# installed to the include directory.
-# Other clang #includes are in $(LLVM_INCLUDE_DIR)/clang
-# and LLVM #includes are in $(LLVM_INCLUDE_DIR)/llvm
-LLVM_CLANG_CODEGEN_INCLUDE_DIR=$(LLVM_DIR)/$(LLVM_SUBDIR)/tools/clang/lib/CodeGen/
-
 ifndef LLVM_LLVM_LIBS
   export LLVM_LLVM_LIBS=$(shell test -x $(LLVM_CONFIG) && $(LLVM_CONFIG) --ldflags --system-libs --libs bitreader bitwriter ipo instrumentation option objcarcopts profiledata all-targets coverage coroutines lto)
 endif
@@ -20,6 +14,6 @@ LLVM_MY_CXXFLAGS=-fno-rtti
 LLVM_CXXFLAGS=$(LLVM_CONFIG_CXXFLAGS) $(LLVM_MY_CXXFLAGS) -DHAVE_LLVM
 LLVM_CFLAGS=$(LLVM_CONFIG_CFLAGS) -DHAVE_LLVM
 
-LLVM_INCLUDES=-I$(LLVM_CONFIG_INCLUDE_DIR) -I$(LLVM_CLANG_CODEGEN_INCLUDE_DIR)
+LLVM_INCLUDES=-I$(LLVM_CONFIG_INCLUDE_DIR)
 LLVM_LIBS=-L$(LLVM_CONFIG_LIB_DIR) $(LLVM_CLANG_LIBS) $(LLVM_LLVM_LIBS)
 

--- a/third-party/llvm/README
+++ b/third-party/llvm/README
@@ -11,4 +11,4 @@ please refer to $CHPL_HOME/doc/rst/technotes/llvm.rst.  For more
 information about LLVM itself, please refer to the website above or to
 the README in the llvm/ subdirectory of this directory.
 
-The version of LLVM used here is 4.0 with two patches.
+The version of LLVM used here is 6.0 with two patches.


### PR DESCRIPTION
Verified that with CHPL_LLVM=system, make clobber/make/chpl --llvm hello.chpl,
and test/extern/ferguson/externblock works:
 - [x] Mac OS X with LLVM 6 from homebrew
 - [x] Ubuntu 18.04

Note that this will *really* require LLVM 6 for CHPL_LLVM=system.
The documentation in chplenv.rst already says "Chapel currently supports LLVM 6.0."
and I don't think the build system would have handled other versions previously.

Reviewed by @dmk42 - thanks!
