### PR TITLE
Make segfaulting enum future more stable

### DIFF
--- a/test/types/enum/scope-param-offset-concrete.bad
+++ b/test/types/enum/scope-param-offset-concrete.bad
@@ -1,7 +1,0 @@
-internal error: MIS0564 chpl version 1.18.0 pre-release (49fa9ecc5d)
-
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
-and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
-please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
-

--- a/test/types/enum/scope-param-offset-concrete.skipif
+++ b/test/types/enum/scope-param-offset-concrete.skipif
@@ -1,0 +1,1 @@
+CHPL_TEST_VGRND_COMP != on


### PR DESCRIPTION
This test was segfaulting in the compiler, but couldn't be counted on
to do so reliably and in the same way each night.  Instead of trying to
match against the segfault in a .bad, let's skip it for all configurations
other than ones in which we're valgrinding the compiler.