### PR TITLE
Tasks borrow owned/shared variables by default

### DIFF
--- a/test/classes/delete-free/owned/task-shadow-vars.chpl
+++ b/test/classes/delete-free/owned/task-shadow-vars.chpl
@@ -1,0 +1,100 @@
+class MyClass {
+  var x:int;
+}
+
+config const n = 4;
+proc test() {
+
+  {
+    var outerOwnedMyClass = new owned MyClass(1);
+    var outerSharedMyClass = new shared MyClass(2);
+
+    writeln("blank owned");
+    writeln(" coforall");
+    coforall i in 1..n {
+      writeln("  ", outerOwnedMyClass.type:string);
+    }
+    writeln(" cobegin");
+    cobegin {
+      writeln("  ", outerOwnedMyClass.type:string);
+      writeln("  ", outerOwnedMyClass.type:string);
+    }
+    writeln("blank shared");
+    writeln(" coforall");
+    coforall i in 1..4 {
+      writeln("  ", outerSharedMyClass.type:string);
+    }
+    writeln(" cobegin");
+    cobegin {
+      writeln("  ", outerSharedMyClass.type:string);
+      writeln("  ", outerSharedMyClass.type:string);
+    }
+
+    writeln("const ref owned");
+    writeln(" coforall");
+    coforall i in 1..4 with (const ref outerOwnedMyClass) {
+      writeln("  ", outerOwnedMyClass.type:string);
+    }
+
+    writeln("ref owned");
+    writeln(" coforall");
+    coforall i in 1..4 with (ref outerOwnedMyClass) {
+      writeln("  ", outerOwnedMyClass.type:string);
+    }
+
+
+    writeln("blank begin");
+    sync {
+      begin {
+        writeln("  ", outerOwnedMyClass.type:string);
+        writeln("  ", outerSharedMyClass.type:string);
+      }
+    }
+    
+    writeln("const ref begin");
+    sync {
+      begin with (const ref outerOwnedMyClass, const ref outerSharedMyClass) {
+        writeln("  ", outerOwnedMyClass.type:string);
+        writeln("  ", outerSharedMyClass.type:string);
+      }
+    }
+    
+    writeln("ref begin");
+    sync {
+      begin with (ref outerOwnedMyClass, ref outerSharedMyClass) {
+        writeln("  ", outerOwnedMyClass.type:string);
+        writeln("  ", outerSharedMyClass.type:string);
+      }
+    }
+  }
+
+  {
+    var outerOwnedMyClass = new owned MyClass(1);
+    var outerSharedMyClass = new shared MyClass(2);
+
+    writeln("in begin");
+    sync {
+      begin with (in outerOwnedMyClass, in outerSharedMyClass) {
+        writeln("  ", outerOwnedMyClass.type:string);
+        writeln("  ", outerSharedMyClass.type:string);
+      }
+    }
+    writeln(outerOwnedMyClass);
+  }
+  
+  {
+    var outerOwnedMyClass = new owned MyClass(1);
+    var outerSharedMyClass = new shared MyClass(2);
+
+    writeln("const in begin");
+    sync {
+      begin with (const in outerOwnedMyClass, const in outerSharedMyClass) {
+        writeln("  ", outerOwnedMyClass.type:string);
+        writeln("  ", outerSharedMyClass.type:string);
+      }
+    }
+    writeln(outerOwnedMyClass);
+  }
+}
+
+test();

--- a/test/classes/delete-free/owned/task-shadow-vars.good
+++ b/test/classes/delete-free/owned/task-shadow-vars.good
@@ -1,0 +1,47 @@
+blank owned
+ coforall
+  MyClass
+  MyClass
+  MyClass
+  MyClass
+ cobegin
+  MyClass
+  MyClass
+blank shared
+ coforall
+  MyClass
+  MyClass
+  MyClass
+  MyClass
+ cobegin
+  MyClass
+  MyClass
+const ref owned
+ coforall
+  _owned(MyClass)
+  _owned(MyClass)
+  _owned(MyClass)
+  _owned(MyClass)
+ref owned
+ coforall
+  _owned(MyClass)
+  _owned(MyClass)
+  _owned(MyClass)
+  _owned(MyClass)
+blank begin
+  MyClass
+  MyClass
+const ref begin
+  _owned(MyClass)
+  _shared(MyClass)
+ref begin
+  _owned(MyClass)
+  _shared(MyClass)
+in begin
+  _owned(MyClass)
+  _shared(MyClass)
+nil
+const in begin
+  _owned(MyClass)
+  _shared(MyClass)
+nil


### PR DESCRIPTION
Following the proposal in #10142, this PR adjusts the
compiler to default to borrowing an `owned` or
`shared` variable that is referred to in a task.

- [x] passed full local testing

Reviewed by @vasslitvinov - thanks!