### PR TITLE
Fix error from testReleaseHelp: "./chpl-make-cpu_count: Command not found"

### DIFF
--- a/util/buildRelease/testRelease
+++ b/util/buildRelease/testRelease
@@ -138,8 +138,7 @@ mysystem("$chplhome/util/buildRelease/gen_release test", "creating release", 1, 
 mysystem("cp $chplhome/tar/chapel-test.tar.gz $tmpdir", "copying release", 1, 1);
 mysystem("cd $tmpdir && gunzip chapel-test.tar.gz", "unzipping release", 1, 1);
 mysystem("cd $tmpdir && tar xf chapel-test.tar", "untarring release", 1, 1);
-mysystem("cp $chplhome/util/buildRelease/testReleaseHelp $tmpdir/chapel-test/", "copying testReleaseHelp script", 1, 1);
-$teststatus = mysystem("cd $tmpdir/chapel-test && ./testReleaseHelp `$chplhome/util/chplenv/chpl_make.py`", "running testReleaseHelp script", 1, 1);
+$teststatus = mysystem("cd $tmpdir/chapel-test && $chplhome/util/buildRelease/testReleaseHelp `$chplhome/util/chplenv/chpl_make.py`", "running testReleaseHelp script", 1, 1);
 
 
 #


### PR DESCRIPTION
The fix is actually made in testRelease. The error in testReleaseHelp occurs because testRelease copied testReleaseHelp out of its folder in the git space before running it. With this change, testRelease just runs testReleaseHelp directly, without copying it first. 

testReleaseHelp expects to find chpl-make-cpu-count in the same directory as itself.  If not, it will throw this error. When that happens, several "make -j$num_proc " commands are run with "$num_proc" empty. "make -j<nothing>" means, run as many processes in parallel as you can. I think this has overloaded some build slaves, causing builds to crash intermittently. However, there's no direct evidence of that. 