### PR TITLE
Fix internal errors related to borrowed and owned

### DIFF
--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -3489,6 +3489,17 @@ static void expandQueryForGenericTypeSpecifier(FnSymbol*  fn,
   } else if (call->isNamed("*")) {
     // it happens to be that 1st actual == size so that will be checked below
     addToWhereClause(fn, formal, new CallExpr(PRIM_IS_STAR_TUPLE_TYPE, queried));
+  } else if (call->isPrimitive(PRIM_TO_BORROWED_CLASS)) {
+    // Check that whatever it is is a borrow
+    addToWhereClause(fn, formal, new CallExpr(PRIM_IS_SUBTYPE,
+                                              dtBorrowed->symbol, queried));
+    // And then proceed as if the PRIM_TO_BORROWED_CLASS wasn't there
+    // that's because the borrowed class is the 'canonical' class representation
+    // used in the compiler.
+    call = toCallExpr(call->get(1));
+    // And don't try to do anything else if it wasn't a call
+    if (call == NULL)
+      return;
   } else if (call->isPrimitive(PRIM_TO_UNMANAGED_CLASS)) {
     if (CallExpr* subCall = toCallExpr(call->get(1))) {
       if (SymExpr* subBase = toSymExpr(subCall->baseExpr)) {

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -2467,8 +2467,6 @@ static AggregateType* typeForNewExpr(CallExpr* newExpr) {
           if (SymExpr* se = toSymExpr(ne->actual))
             if (isTypeSymbol(se->symbol()))
               return NULL;
-            //if (TypeSymbol* ts = toTypeSymbol(se->symbol()))
-              //return toAggregateType(ts->type);
     }
 
     if (SymExpr* baseExpr = toSymExpr(constructor->baseExpr)) {
@@ -3493,13 +3491,15 @@ static void expandQueryForGenericTypeSpecifier(FnSymbol*  fn,
     // Check that whatever it is is a borrow
     addToWhereClause(fn, formal, new CallExpr(PRIM_IS_SUBTYPE,
                                               dtBorrowed->symbol, queried));
-    // And then proceed as if the PRIM_TO_BORROWED_CLASS wasn't there
+    // don't try to do anything else if there isn't a nested call
+    if (!isCallExpr(call->get(1)))
+        return;
+
+    // For nested calls, proceed as if the PRIM_TO_BORROWED_CLASS wasn't there
     // that's because the borrowed class is the 'canonical' class representation
     // used in the compiler.
     call = toCallExpr(call->get(1));
-    // And don't try to do anything else if it wasn't a call
-    if (call == NULL)
-      return;
+
   } else if (call->isPrimitive(PRIM_TO_UNMANAGED_CLASS)) {
     if (CallExpr* subCall = toCallExpr(call->get(1))) {
       if (SymExpr* subBase = toSymExpr(subCall->baseExpr)) {

--- a/test/classes/deitz/class-constructor/constructor_disambiguity.chpl
+++ b/test/classes/deitz/class-constructor/constructor_disambiguity.chpl
@@ -3,7 +3,9 @@ class C {
   var x: t;
 }
 
-var c = (new unmanaged C(t=unmanaged C(int).type,x=new unmanaged C(int)));
+var c = (new unmanaged C(
+           t=(unmanaged C(int)).type,
+           x=new unmanaged C(int)));
 writeln(c);
 delete c.x;
 delete c;

--- a/test/classes/ferguson/generic-field/generic-field-unmanaged-borrowed.chpl
+++ b/test/classes/ferguson/generic-field/generic-field-unmanaged-borrowed.chpl
@@ -1,7 +1,9 @@
+pragma "use default init"
 class ClassA {
   var a:int;
 }
 
+pragma "use default init"
 class ClassB {
   var b:real;
 }
@@ -25,8 +27,8 @@ proc test1a() {
   var b = new unmanaged ClassA(2);
   var c = new unmanaged ClassA(3);
   var x = new borrowed GenericClassUnmanaged(a);
-  var y:GenericClassUnmanaged = new borrowed GenericClassUnmanaged(b);
-  var z:GenericClassUnmanaged(unmanaged ClassA) = new borrowed GenericClassUnmanaged(c);
+  var y:borrowed GenericClassUnmanaged = new borrowed GenericClassUnmanaged(b);
+  var z:borrowed GenericClassUnmanaged(unmanaged ClassA) = new borrowed GenericClassUnmanaged(c);
 
   writeln(x.type:string, " ", x);
   writeln(y.type:string, " ", y);
@@ -44,8 +46,8 @@ proc test1b() {
   var b = new unmanaged ClassB(2);
   var c = new unmanaged ClassB(3);
   var x = new owned GenericClassUnmanaged(a);
-  var y:GenericClassUnmanaged = new owned GenericClassUnmanaged(b);
-  var z:GenericClassUnmanaged(unmanaged ClassB) = new owned GenericClassUnmanaged(c);
+  var y:borrowed GenericClassUnmanaged = new owned GenericClassUnmanaged(b);
+  var z:borrowed GenericClassUnmanaged(unmanaged ClassB) = new owned GenericClassUnmanaged(c);
 
   writeln(x.type:string, " ", x);
   writeln(y.type:string, " ", y);
@@ -64,8 +66,8 @@ proc test2a() {
   var b = (new owned ClassA(2)).borrow();
   var c = (new owned ClassA(3)).borrow();
   var x = new unmanaged GenericClassBorrowed(a);
-  var y:GenericClassBorrowed = new borrowed GenericClassBorrowed(b);
-  var z:GenericClassBorrowed(borrowed ClassA) = new borrowed GenericClassBorrowed(c);
+  var y:borrowed GenericClassBorrowed = new borrowed GenericClassBorrowed(b);
+  var z:borrowed GenericClassBorrowed(borrowed ClassA) = new borrowed GenericClassBorrowed(c);
 
   writeln(x.type:string, " ", x);
   writeln(y.type:string, " ", y);
@@ -81,8 +83,8 @@ proc test2b() {
   var b = (new owned ClassB(2)).borrow();
   var c = (new owned ClassB(3)).borrow();
   var x = new borrowed GenericClassBorrowed(a);
-  var y:GenericClassBorrowed = new owned GenericClassBorrowed(b);
-  var z:GenericClassBorrowed(borrowed ClassB) = new owned GenericClassBorrowed(c);
+  var y:borrowed GenericClassBorrowed = new owned GenericClassBorrowed(b);
+  var z:borrowed GenericClassBorrowed(borrowed ClassB) = new owned GenericClassBorrowed(c);
 
   writeln(x.type:string, " ", x);
   writeln(y.type:string, " ", y);

--- a/test/classes/initializers/compilerGenerated/nested-class-in-record.chpl
+++ b/test/classes/initializers/compilerGenerated/nested-class-in-record.chpl
@@ -6,7 +6,7 @@ record enclosing {
   }
 
   proc checkInner() {
-    var myInner = new inner(true);
+    var myInner = new unmanaged inner(true);
     writeln(myInner);
     delete myInner;
   }

--- a/test/distributions/bradc/spsBlk/blockSparse2CSR.chpl
+++ b/test/distributions/bradc/spsBlk/blockSparse2CSR.chpl
@@ -15,7 +15,7 @@ config const n = 8;
 // domain for the sparse one.
 //
 const Elems = {0..#n, 0..#n} dmapped Block({0..#n, 0..#n},
-    sparseLayoutType=CS);
+    sparseLayoutType=unmanaged CS);
 
 //
 // The sparse subdomain.  In the current code framework, the parent

--- a/test/exercises/boundedBuffer-old/boundedBuffer2.chpl
+++ b/test/exercises/boundedBuffer-old/boundedBuffer2.chpl
@@ -43,7 +43,7 @@ class BoundedBuffer {
   }
 }
 
-var buffers: [0..nMiddleSteps] BoundedBuffer = [0..nMiddleSteps] new unmanaged BoundedBuffer();
+var buffers: [0..nMiddleSteps] unmanaged BoundedBuffer = [0..nMiddleSteps] new unmanaged BoundedBuffer();
 
 // Given a value, do some work on it to create the next value. In this
 // case, the work is sleeping for a second and leaving the value unchanged.

--- a/test/functions/ferguson/query/query-borrowed.chpl
+++ b/test/functions/ferguson/query/query-borrowed.chpl
@@ -1,0 +1,39 @@
+pragma "use default init"
+class MyClass {
+  var x;
+}
+
+pragma "use default init"
+class OtherClass {
+  var y;
+}
+
+proc g(arg:borrowed MyClass(?t)) {
+  writeln(t:string);
+}
+proc h(arg:borrowed MyClass(borrowed OtherClass(?t))) {
+  writeln(t:string);
+}
+
+proc i(arg:borrowed) {
+  writeln(arg.type:string);
+}
+proc j(arg:borrowed MyClass) {
+  writeln(arg.type:string);
+}
+proc k(arg:borrowed MyClass(borrowed OtherClass)) {
+  writeln(arg.type:string);
+}
+
+
+
+proc test() {
+  var a = new borrowed MyClass(new borrowed OtherClass(1));
+  g(a);
+  h(a);
+  i(a);
+  j(a);
+  k(a);
+}
+
+test();

--- a/test/functions/ferguson/query/query-borrowed.good
+++ b/test/functions/ferguson/query/query-borrowed.good
@@ -1,0 +1,5 @@
+OtherClass(int(64))
+int(64)
+MyClass(OtherClass(int(64)))
+MyClass(OtherClass(int(64)))
+MyClass(OtherClass(int(64)))

--- a/test/functions/ferguson/query/subquery.chpl
+++ b/test/functions/ferguson/query/subquery.chpl
@@ -5,15 +5,15 @@ class SubClass {
   var z;
 }
 
-proc qrr(arg: MyClass(?t)) {
+proc qrr(arg: borrowed MyClass(?t)) {
   writeln(t:string);
 }
 
-proc grr(arg: SubClass(?t)) {
+proc grr(arg: borrowed SubClass(?t)) {
   writeln(t:string);
 }
 
-proc sub(arg: MyClass(SubClass(?t))) {
+proc sub(arg: borrowed MyClass(borrowed SubClass(?t))) {
   writeln(t:string);
 }
 

--- a/test/functions/generic/genericTypeArgQuery.chpl
+++ b/test/functions/generic/genericTypeArgQuery.chpl
@@ -1,4 +1,4 @@
-proc foo(type t: C(?et)) {
+proc foo(type t: borrowed C(?et)) {
   writeln(" t is: ", t:string);
   writeln("et is: ", et: string);
 }
@@ -8,5 +8,5 @@ class C {
   var x: eltType;
 }
 
-foo(C(int));
-foo(C(real));
+foo(borrowed C(int));
+foo(borrowed C(real));


### PR DESCRIPTION
* Avoid setting a wrong type when normalizing a managed new (e.g. `new owned C`)
* fix problems with nested type query and borrowed
* adjust specific tests to pass with --warn-unstable

Resolves #10018.
Reviewed by @lydia-duncan - thanks!

- [x] full local testing