### PR TITLE
Add a future with a Shared class in a record that causes an internal error

### DIFF
--- a/test/classes/delete-free/shared/sharedClassInRecord.chpl
+++ b/test/classes/delete-free/shared/sharedClassInRecord.chpl
@@ -1,0 +1,11 @@
+use SharedObject;
+
+class C { }
+
+record R {
+  var sc: Shared(C);
+}
+
+proc main {
+  var r = new R();
+}

--- a/test/classes/delete-free/shared/sharedClassInRecord.future
+++ b/test/classes/delete-free/shared/sharedClassInRecord.future
@@ -1,0 +1,3 @@
+bug: shared class as record member causes internal compiler error
+
+Issue #10182


### PR DESCRIPTION
This simple test is currently causing: "internal error: would add problematic
deref".  Issue #10182.