### PR TITLE
Add a future for declaring the return type as generic

### DIFF
--- a/test/functions/lydia/declaredGenericReturnType.bad
+++ b/test/functions/lydia/declaredGenericReturnType.bad
@@ -1,0 +1,2 @@
+declaredGenericReturnType.chpl:5: In function 'retsGen':
+declaredGenericReturnType.chpl:6: error: type mismatch in assignment from Gen(int(64)) to Gen

--- a/test/functions/lydia/declaredGenericReturnType.chpl
+++ b/test/functions/lydia/declaredGenericReturnType.chpl
@@ -1,0 +1,13 @@
+class Gen {
+  type t;
+}
+
+proc retsGen(type t): Gen {
+  return new unmanaged Gen(t);
+}
+
+var x = retsGen(int);
+var y = retsGen(real);
+writeln(x.type: string);
+writeln(y.type: string);
+delete x, y;

--- a/test/functions/lydia/declaredGenericReturnType.future
+++ b/test/functions/lydia/declaredGenericReturnType.future
@@ -1,0 +1,2 @@
+feature request: allow declared generic return types (if instantiated)
+#10184

--- a/test/functions/lydia/declaredGenericReturnType.good
+++ b/test/functions/lydia/declaredGenericReturnType.good
@@ -1,0 +1,2 @@
+unmanaged Gen(int(64))
+unmanaged Gen(real(64))


### PR DESCRIPTION
I discovered (perhaps unsurprisingly) that you cannot declare a function as
returning a generic type, even if all you return is instantiations of that type.
I think it might be reasonable to support this, but it would take some
thought and reworking of the compiler.

Note that the same function without the return type declaration works without
incident.