### PR TITLE
Switch perf playground to measure cstdlib atomics with gcc 8.1

### DIFF
--- a/util/cron/test-perf.chapcs.playground.bash
+++ b/util/cron/test-perf.chapcs.playground.bash
@@ -25,12 +25,13 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.playground"
 # 4) Update START_DATE to be today, using the format mm/dd/yy
 #
 
-# Test performance of cstdlib atomics
+# Test performance of cstdlib atomics with gcc 8.1
 #GITHUB_USER=bradcray
 #GITHUB_BRANCH=dsiReallocPar
 SHORT_NAME=cstdlib-atomics
 START_DATE=07/02/18
 
+source /data/cf/chapel/setup_gcc81.bash
 export CHPL_ATOMICS=cstdlib
 
 #git branch -D $GITHUB_USER-$GITHUB_BRANCH


### PR DESCRIPTION
We still see the same performance regressions with gcc 6.3 that we saw with gcc
6.2. Swap to 8.1 to see if things are better there.