### PR TITLE
Fix up some string manipulation in codegen.cpp setupDefaultFilenames()

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -2191,9 +2191,9 @@ static void setupDefaultFilenames() {
       if (strlen(lastSlash) >= sizeof(executableFilename) - 3) {
         INT_FATAL("input filename exceeds executable filename buffer size");
       }
-      strncpy(executableFilename, "lib", 3);
-      strncat(executableFilename, lastSlash, sizeof(executableFilename)-4);
-      executableFilename[sizeof(executableFilename)-1] = '\0';
+      strcpy(executableFilename, "lib");
+      strncat(executableFilename, lastSlash,
+              sizeof(executableFilename)-strlen(executableFilename)-1);
 
     } else {
       // copy from that slash onwards into the executableFilename,
@@ -2218,7 +2218,8 @@ static void setupDefaultFilenames() {
   // If we're in library mode and the executable name was set but the header
   // name wasn't, use the executable name for the header name as well
   if (fLibraryCompile && libmodeHeadername[0] == '\0') {
-    strncpy(libmodeHeadername, executableFilename, sizeof(executableFilename));
+    strncpy(libmodeHeadername, executableFilename, sizeof(libmodeHeadername)-1);
+    libmodeHeadername[sizeof(libmodeHeadername)-1] = '\0';
   }
 }
 


### PR DESCRIPTION
Fix misc string copy/manipulation bugs found by gcc 8:
 - fix incorrect size of strncpy "lib" (and just use strcpy since it's a literal)
 - fix incorrect size of strncat (and remove dupe null termination)
 - fix incorrect buffer size of libmodeHeadername strncpy
 - null terminate libmodeHeadername