### PR TITLE
Update weirdParamInit3 for initializers

### DIFF
--- a/test/classes/bradc/paramInClass/weirdParamInit3.chpl
+++ b/test/classes/bradc/paramInClass/weirdParamInit3.chpl
@@ -5,7 +5,7 @@ class C {
 
 pragma "use default init"
 class D {
-  var c: borrowed C = new borrowed C();
+  var c: borrowed C = new borrowed C(2);
   param y: int = c.x;
 }
 

--- a/test/classes/bradc/paramInClass/weirdParamInit3.chpl
+++ b/test/classes/bradc/paramInClass/weirdParamInit3.chpl
@@ -1,7 +1,9 @@
+pragma "use default init"
 class C {
   param x: int;
 }
 
+pragma "use default init"
 class D {
   var c: borrowed C = new borrowed C();
   param y: int = c.x;

--- a/test/classes/bradc/paramInClass/weirdParamInit3.good
+++ b/test/classes/bradc/paramInClass/weirdParamInit3.good
@@ -1,2 +1,2 @@
-weirdParamInit3.chpl:5: error: unresolved type specifier 'D(c=type C(2), y=2)'
-weirdParamInit3.chpl:5: note: candidates are: D(param y: int(64))
+c is: {}
+d is: {c = {}}


### PR DESCRIPTION
This program should successfully compile with initializers, so this PR updates the test to use default initializers and updates the .good file accordingly.