### PR TITLE
Include hwloc and target mem in qthread unique config path

### DIFF
--- a/third-party/qthread/README
+++ b/third-party/qthread/README
@@ -33,3 +33,5 @@ as follows:
   fails.  Doing so ensures that when the Chapel runtime and Qthreads
   both use hwloc topologies, they use the same one.  This has both
   functional and performance benefits.
+* Added missing `no` affinity shim (src/affinity/no.c) that was omitted
+  from the official qthreads release. Only used when CHPL_HWLOC=none

--- a/third-party/qthread/qthread-src/src/Makefile.am
+++ b/third-party/qthread/qthread-src/src/Makefile.am
@@ -113,6 +113,7 @@ EXTRA_DIST += \
 			 affinity/hwloc_via_chapel.c \
 			 affinity/binders.c \
 			 affinity/hwloc_v2.c \
+			 affinity/no.c \
 			 affinity/sys.c \
 			 affinity/libnuma.c \
 			 affinity/libnumaV2.c \

--- a/third-party/qthread/qthread-src/src/Makefile.in
+++ b/third-party/qthread/qthread-src/src/Makefile.in
@@ -611,9 +611,10 @@ EXTRA_DIST = ds/dictionary/dictionary_shavit.c \
 	barrier/array.c barrier/log.c barrier/sinc.c alloc/base.c \
 	alloc/chapel.c affinity/common.c affinity/hwloc.c \
 	affinity/hwloc_via_chapel.c affinity/binders.c \
-	affinity/hwloc_v2.c affinity/sys.c affinity/libnuma.c \
-	affinity/libnumaV2.c affinity/mach.c affinity/tilera.c \
-	affinity/plpa.c affinity/lgrp.c affinity/shepcomp.h
+	affinity/hwloc_v2.c affinity/no.c affinity/sys.c \
+	affinity/libnuma.c affinity/libnumaV2.c affinity/mach.c \
+	affinity/tilera.c affinity/plpa.c affinity/lgrp.c \
+	affinity/shepcomp.h
 
 # version-info fields are:
 # 1. the current interface revision number (i.e. whenever arguments of existing

--- a/third-party/qthread/qthread-src/src/affinity/no.c
+++ b/third-party/qthread/qthread-src/src/affinity/no.c
@@ -1,0 +1,48 @@
+#ifdef HAVE_CONFIG_H
+# include "config.h"
+#endif
+
+#include "qt_alloc.h"
+#include "qt_affinity.h"
+#include "qt_asserts.h"
+#include "qt_debug.h"
+#include "qt_envariables.h"
+#include "shufflesheps.h"
+
+void INTERNAL qt_affinity_init(qthread_shepherd_id_t *nbshepherds,
+                               qthread_worker_id_t   *nbworkers,
+                               size_t                *hw_par)
+{                                      /*{{{ */
+    if (*nbshepherds == 0) {
+        *nbshepherds = 1;
+    }
+    if (*nbworkers == 0) {
+        *nbworkers = 1;
+    }
+}                                      /*}}} */
+
+void INTERNAL qt_affinity_set(qthread_worker_t *me, unsigned int Q_UNUSED(nw))
+{}
+
+int INTERNAL qt_affinity_gendists(qthread_shepherd_t   *sheps,
+                                  qthread_shepherd_id_t nshepherds)
+{                                      /*{{{ */
+    qthread_debug(AFFINITY_CALLS, "start (%p, %i)\n", sheps, (int)nshepherds);
+    for (size_t i = 0; i < nshepherds; ++i) {
+        sheps[i].sorted_sheplist = qt_calloc(nshepherds - 1,
+                                             sizeof(qthread_shepherd_id_t));
+        sheps[i].shep_dists      = qt_calloc(nshepherds, sizeof(unsigned int));
+        for (size_t j = 0, k = 0; j < nshepherds; ++j) {
+            if (j != i) {
+                assert(k < (nshepherds - 1));
+                sheps[i].shep_dists[j]        = 10;
+                sheps[i].sorted_sheplist[k++] = j;
+            }
+        }
+        // no need to sort; they're all equidistant
+        shuffle_sheps(sheps[i].sorted_sheplist, nshepherds - 1);
+    }
+    return QTHREAD_SUCCESS;
+}                                      /*}}} */
+
+/* vim:set expandtab: */

--- a/util/chplenv/chpl_3p_qthreads_configs.py
+++ b/util/chplenv/chpl_3p_qthreads_configs.py
@@ -4,15 +4,19 @@ import sys
 chplenv_dir = os.path.dirname(__file__)
 sys.path.insert(0, os.path.abspath(chplenv_dir))
 
-import chpl_compiler, chpl_llvm, chpl_locale_model, third_party_utils
+import chpl_compiler, chpl_hwloc, chpl_llvm, chpl_locale_model, chpl_mem
+import third_party_utils
 from compiler_utils import compiler_is_prgenv
 from utils import memoize
 
 
 @memoize
 def get_uniq_cfg_path():
-    return '{0}-{1}'.format(third_party_utils.default_uniq_cfg_path(),
-                            chpl_locale_model.get())
+    def_uniq_cfg = third_party_utils.default_uniq_cfg_path()
+    lm = chpl_locale_model.get();
+    target_mem = chpl_mem.get('target')
+    hwloc = chpl_hwloc.get()
+    return '{0}-{1}-{2}-{3}'.format(def_uniq_cfg, lm, target_mem, hwloc)
 
 @memoize
 def get_link_args():


### PR DESCRIPTION
Qthread depends on hwloc and our target mem, but previously we didn't embed
these in the unique configuration path, which meant we wouldn't trigger
rebuilds when one of these values changed.

This also adds a missing `no` topology layer to qthreads. This is in the
qthreads repo, but accidentally omitted from official releases. Note that this
is only used on linux systems when CHPL_HWLOC=none (which was discovered while
testing this PR)

This resolves https://github.com/chapel-lang/chapel/issues/10022