### PR TITLE
Remove length 0 halts from DynamicIterators.chpl

### DIFF
--- a/modules/standard/DynamicIters.chpl
+++ b/modules/standard/DynamicIters.chpl
@@ -106,7 +106,6 @@ where tag == iterKind.leader
   const remain:rType=densify(c,c);
 
   // If the number of tasks is insufficient, yield in serial
-  if c.length == 0 then halt("The range is empty");
   if nTasks == 1 then {
     if debugDynamicIters then
       writeln("Dynamic Iterator: serial execution because there is not enough work");
@@ -282,7 +281,6 @@ where tag == iterKind.leader
   type rType=c.type;
   var remain:rType = densify(c,c);
   // If the number of tasks is insufficient, yield in serial
-  if c.length == 0 then halt("The range is empty");
   if nTasks == 1 then {
     if debugDynamicIters then
       writeln("Guided Iterator: serial execution because there is not enough work");
@@ -488,7 +486,6 @@ where tag == iterKind.leader
   type rType=c.type;
 
   // If the number of tasks is insufficient, yield in serial
-  if c.length == 0 then halt("The range is empty");
   if nTasks == 1 then {
     if debugDynamicIters then
       writeln("Adaptive work-stealing Iterator: serial execution because there is not enough work");

--- a/test/functions/iterators/elliot/dynamicIters/emptyDynamicIters.chpl
+++ b/test/functions/iterators/elliot/dynamicIters/emptyDynamicIters.chpl
@@ -1,0 +1,23 @@
+use DynamicIters;
+
+proc testIters(iterand) {
+  for    i in iterand                              do writeln(i);
+  forall i in iterand                              do writeln(i);
+  forall (i, j) in zip(iterand, iterand)           do writeln(i);
+
+  for    i in dynamic(iterand)                     do writeln(i);
+  forall i in dynamic(iterand)                     do writeln(i);
+  forall (i, j) in zip(dynamic(iterand), iterand)  do writeln(i);
+
+  for    i in guided(iterand)                      do writeln(i);
+  forall i in guided(iterand)                      do writeln(i);
+  forall (i, j) in zip(guided(iterand), iterand)   do writeln(i);
+
+  for    i in adaptive(iterand)                    do writeln(i);
+  forall i in adaptive(iterand)                    do writeln(i);
+  forall (i, j) in zip(adaptive(iterand), iterand) do writeln(i);
+}
+
+// test iteration over empty ranges and domains
+testIters(1..0);
+testIters({1..0});


### PR DESCRIPTION
Previously, the adaptive/guided/dynamic leader iterators would halt if they
were operating on an empty range. There's no reason you shouldn't be able to
iterate over an empty range, so this removes those halts and adds a test to
ensure that nothing is done when iterating over empty domains/ranges.

Related to https://github.com/chapel-lang/chapel/issues/10002