### PR TITLE
Futurize a noinit test due to initializers

### DIFF
--- a/test/expressions/lydia/noinit/usedWithRecord.bad
+++ b/test/expressions/lydia/noinit/usedWithRecord.bad
@@ -1,0 +1,2 @@
+(bar = 4, baz = true)
+(bar = 0, baz = false)

--- a/test/expressions/lydia/noinit/usedWithRecord.chpl
+++ b/test/expressions/lydia/noinit/usedWithRecord.chpl
@@ -1,3 +1,4 @@
+pragma "use default init"
 record Foo {
   var bar: int;
   var baz: bool;

--- a/test/expressions/lydia/noinit/usedWithRecord.future
+++ b/test/expressions/lydia/noinit/usedWithRecord.future
@@ -1,0 +1,1 @@
+bug: compiler does not respect _defaultOf for concrete records with initializers


### PR DESCRIPTION
Noinit and _defaultOf don't really work with initializers, so futurize this test to make progress on --force-initializers failures.