### PR TITLE
Update generic formal test to use initializers

### DIFF
--- a/test/classes/diten/instantiatedClassname.chpl
+++ b/test/classes/diten/instantiatedClassname.chpl
@@ -1,3 +1,4 @@
+pragma "use default init"
 class C {
   param a: int = 1;
   param b: int = 2;

--- a/test/classes/diten/instantiatedClassname.good
+++ b/test/classes/diten/instantiatedClassname.good
@@ -1,2 +1,1 @@
-instantiatedClassname.chpl:12: error: unresolved call 'foo(C(1,1,3))'
-instantiatedClassname.chpl:7: note: candidates are: foo(c: borrowed C)
+1


### PR DESCRIPTION
This test compiles successfully with initializers now that generic formals are more robust. The test was originally added as a future involving weird instantiation of ``C``, but eventually turned into a test expecting the pattern to fail.