### PR TITLE
Reduce hugepage waste from call stacks

### DIFF
--- a/doc/rst/usingchapel/executing.rst
+++ b/doc/rst/usingchapel/executing.rst
@@ -287,10 +287,12 @@ Controlling the Call Stack Size
 The main Chapel program requires space for its call stack, as does any
 task created by it.  This stack space has a fixed size.  It is created
 automatically when the program or task starts executing, and remains in
-existence until it completes.  The default call stack size is 8 MiB on
+existence until it completes.  The default call stack size is ~8 MiB on
 Linux-based systems, since this is a common value for the process stack
 limit on such systems.  On Cygwin systems the default call stack size is
-2 MiB.
+~2 MiB. Note that up to 3 system pages of each stack may be reserved for
+use by the tasking layer. 1 page for runtime data structures and up to 2
+additional pages if guard pages (--stack-checks) are enabled.
 
 The default call stack size may not be appropriate in all cases.  For
 programs in which some tasks have large stack frames or deep call trees

--- a/test/execflags/bradc/callStackSize.prediff
+++ b/test/execflags/bradc/callStackSize.prediff
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 #
-# In practice, CHPL_RT_CALL_STACK_SIZE is really a minimum task call
-# stack size.  Some tasking layers actually use a higher value.  We
-# adjust for that here.
+# In practice, CHPL_RT_CALL_STACK_SIZE is really an approximate call
+# stack size.  Some tasking layers use a higher value and some
+# lower.  We adjust for that here.
 #
 icss=$( sed -n 's/^CHPL_RT_CALL_STACK_SIZE=\([0-9]*\).*$/\1/p' $1.execenv )
 
@@ -13,8 +13,10 @@ fifo)
   pagesize=$( getconf PAGESIZE )
   ocss=$(( ($icss + $pagesize - 1) & ~($pagesize - 1) ));;
 qthreads)
-  # qthreads rounds the call stack size to the next system page boundary
-  # iff it's using guard pages
+  # qthreads uses 1 system page from the stack for runtime data
+  # structures and an additional 2 pages for guard pages if they are
+  # enabled. if guard pages are enabled, qthreads also rounds the
+  # call stack size to the next system page
   # Note: There are a multitude of ways that guard pages can be enabled or
   #       disabled. They can be disabled at qthreads build time, by compopts,
   #       and by both qthread and chapel level env vars. Instead of checking
@@ -23,11 +25,11 @@ qthreads)
   #       appears if qthreads was built with guard pages, and they are on at
   #       execution time, no matter how they were set.
   guardPages=`grep "QTHREADS: Guard Pages Enabled" $logfile`
+  pagesize=$( getconf PAGESIZE )
   if [ -n "$guardPages" ] ; then
-    pagesize=$( getconf PAGESIZE )
-    ocss=$(( ($icss + $pagesize - 1) & ~($pagesize - 1) ))
+    ocss=$(( (($icss - 3*$pagesize) + $pagesize - 1) & ~($pagesize - 1) ))
   else
-    ocss=$icss
+    ocss=$(( $icss - $pagesize ))
   fi;;
 *)
   ocss=$icss;;

--- a/third-party/qthread/Makefile
+++ b/third-party/qthread/Makefile
@@ -67,7 +67,9 @@ CHPL_QTHREAD_CFG_OPTIONS += --enable-oversubscription
 endif
 
 # enable guard pages for stack overflow detection, unless directed not to
+HAVE_GUARD_PAGES = 0
 ifeq (, $(call isTrue, $(CHPL_QTHREAD_NO_GUARD_PAGES)))
+HAVE_GUARD_PAGES = 1
 CHPL_QTHREAD_CFG_OPTIONS += --enable-guard-pages
 endif
 
@@ -179,6 +181,9 @@ qthread-chapel-h: FORCE
 	     > $(QTHREAD_INSTALL_DIR)/include/qthread-chapel.h
 	echo "#define CHPL_QTHREAD_SCHEDULER_ONE_WORKER_PER_SHEPHERD" \
 	     $(ONE_WORKER_PER_SHEPHERD) \
+	     >> $(QTHREAD_INSTALL_DIR)/include/qthread-chapel.h
+	echo "#define CHPL_QTHREAD_HAVE_GUARD_PAGES" \
+	     $(HAVE_GUARD_PAGES) \
 	     >> $(QTHREAD_INSTALL_DIR)/include/qthread-chapel.h
 
 qthread: qthread-config qthread-build qthread-chapel-h


### PR DESCRIPTION
Previously, we defaulted to 8 MiB stacks, and 16 MiB hugepages. However, in
addition to 8 MiB for the actual stack qthreads also allocated space for a
runtime data structure `qthread_runtime_data_s`. This meant that 2 stacks
actually used 2 16 MiB hugepages, with 1 mostly wasted.

This lowers the actual stack space by 1 system page, so that we can fit the
entire "stack" inside the 8 MiB envelope. If guard pages are enabled (not
possible with hugepages) we'll use an additional 2 pages.

This also lowers the amount of pooling from ~8 default sized stacks to 2
stacks to limit the amount of memory used for "most" programs. Most of our
benchmarks tend to only create #cores tasks, so on systems that require
registration (and faulting in of physical memory to support the pages) we'd
take up lot of space that often isn't used.

Closes https://github.com/chapel-lang/chapel/issues/5749
Related to https://github.com/chapel-lang/chapel/issues/10000