### PR TITLE
Convert the halt in List.chpl to a boundsCheckHalt

### DIFF
--- a/modules/standard/List.chpl
+++ b/modules/standard/List.chpl
@@ -186,7 +186,10 @@ record list {
      It is an error to call this function on an empty list.
    */
  proc pop_front():eltType {
-   if length < 1 then halt("pop_front on empty list");
+   if boundsChecking && length < 1 {
+     use ChapelHaltWrappers;
+     boundsCheckHalt("pop_front on empty list");
+   }
    var oldfirst = first;
    var newfirst = first.next;
    var ret = oldfirst.data;


### PR DESCRIPTION
Convert a halt for pop_front() on an empty list to be a boundCheckHalt since
it's similar to trying to do `A[0]` on an empty array.

Closes https://github.com/chapel-lang/chapel/issues/9838