### PR TITLE
Remove more where clauses

### DIFF
--- a/modules/internal/CString.chpl
+++ b/modules/internal/CString.chpl
@@ -141,7 +141,7 @@ module CString {
   //
   // casts from complex
   //
-  inline proc _cast(type t:c_string, x: complex(?w)) {
+  inline proc _cast(type t:c_string, x: chpl_anycomplex) {
     if isnan(x.re) || isnan(x.im) then
       return __primitive("string_copy", "nan");
     var re = (x.re):c_string;
@@ -186,6 +186,26 @@ module CString {
     var r = __primitive("cast", real(64), x);
     return real_to_c_string(r, true);
   }
+
+  //
+  // casts from integral
+  //
+  proc _cast(type t:c_string, x: integral) {
+    extern proc integral_to_c_string(x:int(64), size:uint(32), isSigned: bool, ref err: bool) : c_string;
+
+    var isErr: bool;
+    var csc = integral_to_c_string(x:int(64), numBytes(x.type), isIntType(x.type), isErr);
+
+    // this should only happen if the runtime is broken
+    if isErr {
+      try! {
+        throw new unmanaged IllegalArgumentError("Unexpected case in integral_to_c_string");
+      }
+    }
+
+    return csc;
+  }
+
 
   //
   // primitive c_string functions and methods

--- a/modules/internal/StringCasts.chpl
+++ b/modules/internal/StringCasts.chpl
@@ -27,7 +27,7 @@ module StringCasts {
   //
   // Type -- Foo.type:string
   //
-  proc _cast(type t, type x)  param : string where t == string {
+  proc _cast(type t:string, type x)  param : string {
     return __primitive("typeToString", x);
   }
 
@@ -35,7 +35,7 @@ module StringCasts {
   // Bool
   //
 
-  inline proc _cast(type t, x: bool) where t == string {
+  inline proc _cast(type t:string, x: bool) {
     if (x) {
       return "true";
     } else {
@@ -43,7 +43,7 @@ module StringCasts {
     }
   }
 
-  proc _cast(type t, x: string) throws where isBoolType(t) {
+  proc _cast(type t:chpl_anybool, x: string) throws {
     var str = x.strip();
     if str.isEmptyString() {
       throw new unmanaged IllegalArgumentError("bad cast from empty string to bool");
@@ -60,7 +60,7 @@ module StringCasts {
   //
   // int
   //
-  proc _cast(type t, x: integral) where t == string {
+  proc _cast(type t:string, x: integral) {
     //TODO: switch to using qio's writef somehow
     extern proc integral_to_c_string(x:int(64), size:uint(32), isSigned: bool, ref err: bool) : c_string;
     extern proc strlen(const str: c_string) : size_t;
@@ -83,7 +83,7 @@ module StringCasts {
     return ret;
   }
 
-  inline proc _cast(type t, x: string) throws where isIntegralType(t) {
+  inline proc _cast(type t:integral, x: string) throws {
     //TODO: switch to using qio's readf somehow
     pragma "insert line file info"
     extern proc c_string_to_int8_t  (x:c_string, ref err: bool) : int(8);
@@ -156,12 +156,12 @@ module StringCasts {
     return ret;
   }
 
-  proc _cast(type t, x:real(?w)) where t == string {
+  proc _cast(type t:string, x:chpl_anyreal) {
     //TODO: switch to using qio's writef somehow
     return _real_cast_helper(x:real(64), false);
   }
 
-  proc _cast(type t, x:imag(?w)) where t == string {
+  proc _cast(type t:string, x:chpl_anyimag) {
     //TODO: switch to using qio's writef somehow
     // The Chapel version of the imag --> real cast smashes it flat rather than
     // just stripping off the "i".  See the cast in ChapelBase.
@@ -169,7 +169,7 @@ module StringCasts {
     return _real_cast_helper(r, true);
   }
 
-  inline proc _cast(type t, x: string) throws where isRealType(t) {
+  inline proc _cast(type t:chpl_anyreal, x: string) throws {
     pragma "insert line file info"
     extern proc c_string_to_real32(x: c_string, ref err: bool) : real(32);
     pragma "insert line file info"
@@ -194,7 +194,7 @@ module StringCasts {
     return retVal;
   }
 
-  inline proc _cast(type t, x: string) throws where isImagType(t) {
+  inline proc _cast(type t:chpl_anyimag, x: string) throws {
     pragma "insert line file info"
     extern proc c_string_to_imag32(x: c_string, ref err: bool) : imag(32);
     pragma "insert line file info"
@@ -223,7 +223,7 @@ module StringCasts {
   //
   // complex
   //
-  proc _cast(type t, x: complex(?w)) where t == string {
+  proc _cast(type t:string, x: chpl_anycomplex) {
     if isnan(x.re) || isnan(x.im) then
       return "nan";
     var re = (x.re):string;
@@ -246,7 +246,7 @@ module StringCasts {
   }
 
 
-  inline proc _cast(type t, x: string) throws where isComplexType(t) {
+  inline proc _cast(type t:chpl_anycomplex, x: string) throws {
     pragma "insert line file info"
     extern proc c_string_to_complex64(x:c_string, ref err: bool) : complex(64);
     pragma "insert line file info"

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -2031,7 +2031,7 @@ record ioChar {
 }
 
 pragma "no doc"
-inline proc _cast(type t, x: ioChar) where t == string {
+inline proc _cast(type t:string, x: ioChar) {
   var csc: c_string =  qio_encode_to_string(x.ch);
   // The caller has responsibility for freeing the returned string.
   return new string(csc, needToCopy=false);
@@ -2067,7 +2067,7 @@ record ioNewline {
 }
 
 pragma "no doc"
-inline proc _cast(type t, x: ioNewline) where t == string {
+inline proc _cast(type t:string, x: ioNewline) {
   return "\n";
 }
 
@@ -2097,7 +2097,7 @@ record ioLiteral {
 }
 
 pragma "no doc"
-inline proc _cast(type t, x: ioLiteral) where t == string {
+inline proc _cast(type t:string, x: ioLiteral) {
   return x.val;
 }
 
@@ -2121,7 +2121,7 @@ record ioBits {
 }
 
 pragma "no doc"
-inline proc _cast(type t, x: ioBits) where t == string {
+inline proc _cast(type t:string, x: ioBits) {
   const ret = "ioBits(v=" + x.v:string + ", nbits=" + x.nbits:string + ")";
   return ret;
 }

--- a/test/classes/delete-free/borrowed/borrowed-generic-query.future
+++ b/test/classes/delete-free/borrowed/borrowed-generic-query.future
@@ -1,2 +1,0 @@
-bug: borrowed MyGenericClass(?t) doesn't work
-#9725

--- a/test/types/string/thomasvandoren/int-to-c_string.bad
+++ b/test/types/string/thomasvandoren/int-to-c_string.bad
@@ -1,3 +1,0 @@
-5 : int(64)
-5.0 : c_string
-5 : string

--- a/test/types/string/thomasvandoren/int-to-c_string.future
+++ b/test/types/string/thomasvandoren/int-to-c_string.future
@@ -1,7 +1,0 @@
-bug: casting int to c_string makes it a real
-
-For example:
-
-    const n: 5,
-      s: c_string;
-    writeln(s);  // prints 5.0

--- a/test/types/type_variables/nelson/dependentTypeOverClasses.future
+++ b/test/types/type_variables/nelson/dependentTypeOverClasses.future
@@ -1,7 +1,0 @@
-feature request: support instantiating a class through a type
-variable. This would improve (and perhaps complete) Chapel's support
-for resolving function calls within generic functions at the point of
-instantiation.
-
-After PR #3728 this test should work but instead it reveals
-a different bug.


### PR DESCRIPTION
* Continue removing where clauses when possible (following #10143).
* Add integral -> c_string cast based on string version (to get
  int-to-c_string future passing, but we might decide to remove
  all such casts - discuss that in #10248).
* Retire passing futures 

- [x] passed full local futures testing

Reviewed by @vasslitvinov - thanks!