### PR TITLE
Fixed error from incorrect offset of timespec struct conversion to llvm

### DIFF
--- a/test/extern/spartee/sys-stat-extern.chpl
+++ b/test/extern/spartee/sys-stat-extern.chpl
@@ -4,8 +4,8 @@ extern "struct sys_stat_s" record chpl_stat {
 }
 
 extern "struct timespec" record chpl_timespec {
-  var tv_nsec: int;
   var tv_sec: int;
+  var tv_nsec: int;
 }
 
 proc getLastModified(filename: string) : int {


### PR DESCRIPTION
Fixes a bug where the order of the timespec struct fields would cause llvm to error in the function verification stage because of an incorrect offset. 