### PR TITLE
Fix an embarrassing bug in the atomic barrier implementation

### DIFF
--- a/modules/standard/Barriers.chpl
+++ b/modules/standard/Barriers.chpl
@@ -270,7 +270,8 @@ module Barriers {
             extern proc chpl_comm_barrier(msg: c_string);
             chpl_comm_barrier("local barrier call".localize().c_str());
           }
-          if boundsChecking && done.testAndSet() {
+          const alreadySet = done.testAndSet();
+          if boundsChecking && alreadySet {
             use ChapelHaltWrappers;
             boundsCheckHalt("Too many callers to barrier()");
           }
@@ -294,7 +295,8 @@ module Barriers {
       on this {
         const myc = count.fetchSub(1);
         if myc<=1 {
-          if boundsChecking && done.testAndSet() {
+          const alreadySet = done.testAndSet();
+          if boundsChecking && alreadySet {
             use ChapelHaltWrappers;
             boundsCheckHalt("Too many callers to notify()");
           }


### PR DESCRIPTION
In #10220 I put a "too many callers" halt inside a `boundsChecking`
conditional. Unfortunately, I also put a testAndSet() that's always required
inside the branch as well, completely breaking the atomic based barrier when
`--no-bounds-checks` is throw :(

Fix that here but pulling the testAndSet() out of the conditional check