### PR TITLE
Hoist nested unmanaged types to module scope

### DIFF
--- a/compiler/passes/flattenClasses.cpp
+++ b/compiler/passes/flattenClasses.cpp
@@ -24,10 +24,11 @@
 
 void flattenClasses() {
   forv_Vec(TypeSymbol, ts, gTypeSymbols) {
-    if (AggregateType* ct = toAggregateType(ts->type)) {
-      if (toAggregateType(ct->symbol->defPoint->parentSymbol->type)) {
-        ModuleSymbol* mod = ct->getModule();
-        DefExpr*      def = ct->symbol->defPoint;
+    Type* t = ts->type;
+    if (isAggregateType(t) || isUnmanagedClassType(t)) {
+      if (toAggregateType(t->symbol->defPoint->parentSymbol->type)) {
+        ModuleSymbol* mod = t->getModule();
+        DefExpr*      def = t->symbol->defPoint;
 
         def->remove();
         mod->block->insertAtTail(def);

--- a/test/classes/initializers/nested/unmanaged-problem-use-before-def.bad
+++ b/test/classes/initializers/nested/unmanaged-problem-use-before-def.bad
@@ -1,2 +1,0 @@
-unmanaged-problem-use-before-def.chpl:10: In initializer:
-unmanaged-problem-use-before-def.chpl:3: error: 'unmanaged Inner' used before defined (first used here)

--- a/test/classes/initializers/nested/unmanaged-problem-use-before-def.future
+++ b/test/classes/initializers/nested/unmanaged-problem-use-before-def.future
@@ -1,2 +1,0 @@
-bug: problem compiling nested type using unmanaged
-#10284

--- a/test/classes/initializers/nested/unmanaged-problem-with-default.bad
+++ b/test/classes/initializers/nested/unmanaged-problem-with-default.bad
@@ -1,1 +1,0 @@
-unmanaged-problem-with-default.chpl:2: error: can't omit initialization of field "unmanaged Inner", no type or default value provided

--- a/test/classes/initializers/nested/unmanaged-problem-with-default.future
+++ b/test/classes/initializers/nested/unmanaged-problem-with-default.future
@@ -1,2 +1,0 @@
-bug: problem compiling nested type using unmanaged
-#10284


### PR DESCRIPTION
The defPoint for UnmanagedClassTypes needs to be hoisted to module scope, just like regular AggregateTypes, if it's nested within an AggregateType.

Resolves #10284

Testing:
- [x] local + futures
- [x] --force-initializers