### PR TITLE
Finish setting UTF-8 environment for testing

### DIFF
--- a/util/start_test
+++ b/util/start_test
@@ -627,7 +627,8 @@ def check_environment_with_args():
     if not tgt_platform == "sunos":
         os.environ["LC_COLLATE"] = "C"
         os.environ["LANG"] = "en_US.UTF-8"
-        del os.environ["LC_ALL"]
+        if "LC_ALL" in os.environ:
+            del os.environ["LC_ALL"]
 
     global log_file
     log_file = os.path.join(logs_dir, "{0}.{1}.log"

--- a/util/start_test
+++ b/util/start_test
@@ -627,6 +627,7 @@ def check_environment_with_args():
     if not tgt_platform == "sunos":
         os.environ["LC_COLLATE"] = "C"
         os.environ["LANG"] = "en_US.UTF-8"
+        del os.environ["LC_ALL"]
 
     global log_file
     log_file = os.path.join(logs_dir, "{0}.{1}.log"


### PR DESCRIPTION
In #10213 , I set the LANG and LC_COLLATE environment variables in start_test to enable UTF-8 without destroying the sort order.  I forgot one last step, which is to unset LC_ALL, because that overrides the other two.  This change corrects that oversight.

@vasslitvinov was being impacted by the problem that this change fixes.
