### PR TITLE
Use pthread mutexes instead of chpl syncs for lock based atomics

### DIFF
--- a/doc/rst/technotes/atomics.rst
+++ b/doc/rst/technotes/atomics.rst
@@ -46,7 +46,7 @@ If compiler support for atomics is available, the atomic operations
 will be mapped down the appropriate compiler intrinsics which often
 map directly to processor atomics.  If intrinsics are not available,
 the atomic implementation defaults to using locks in the form of
-Chapel's sync vars. As a result the locks implementation will be
+Pthread mutexes. As a result the locks implementation will be
 slower than the intrinsic implementation. Since Chapel's atomics
 were modeled after the C11 edition of the C standard, the cstdlib
 implementation is just a wrapper around C standard atomics.  As C11

--- a/doc/rst/usingchapel/chplenv.rst
+++ b/doc/rst/usingchapel/chplenv.rst
@@ -414,8 +414,8 @@ CHPL_ATOMICS
                      standard atomics (from C11)
         intrinsics   implement atomics using target compiler intrinsics
                      (which typically map down to hardware capabilities)
-        locks        implement atomics by using Chapel sync variables to
-                     protect normal operations
+        locks        implement atomics by using mutexes to protect normal
+                     operations
         ===========  =====================================================
 
    If unset, CHPL_ATOMICS defaults to ``intrinsics`` for most configurations.

--- a/runtime/include/atomics/locks/chpl-atomics.h
+++ b/runtime/include/atomics/locks/chpl-atomics.h
@@ -17,19 +17,24 @@
  * limitations under the License.
  */
 
-// chpl-atomics.h
-//
-// Since some of these non-intrinsic atomic routines are somewhat verbose, the GNU
-// compiler issues a warning if inlining is requested and denied.
-// If inlining is desired anyway, supply -DINLINE_LOCK_BASED_ATOMICS
-//
-
 #ifndef _chpl_atomics_h_
 #define _chpl_atomics_h_
 
-#include "chpltypes.h" // chpl_bool
-#include "chpl-tasks.h" // chpl_sync_aux_t
+#include "chpltypes.h"
+#include <pthread.h>
 
+// Locks based atomic implementation. Note that we use pthread mutexes instead
+// of chpl sync variables because we need to use atomics during runtime init
+// and teardown (when the tasking layer is not active.) It's safe to use
+// pthread mutexes because the critical section of these routines never yield.
+// Since there are no yields, there's no possibility of recursive locking on
+// the same thread from different tasks or unlocking from a different thread,
+// both of which violate pthread semantics.
+
+
+// Since some of these non-intrinsic atomic routines are somewhat verbose, the GNU
+// compiler issues a warning if inlining is requested and denied.
+// If inlining is desired anyway, supply -DINLINE_LOCK_BASED_ATOMICS
 #ifdef MAYBE_INLINE
  #error No fair.  I want to use this name.
 #endif
@@ -40,54 +45,54 @@
 #endif
 
 typedef struct atomic_int_least8_s {
-  chpl_sync_aux_t sv;
+  pthread_mutex_t lock;
   int_least8_t v;
 } atomic_int_least8_t;
 typedef struct atomic_int_least16_s {
-  chpl_sync_aux_t sv;
+  pthread_mutex_t lock;
   int_least16_t v;
 } atomic_int_least16_t;
 typedef struct atomic_int_least32_s {
-  chpl_sync_aux_t sv;
+  pthread_mutex_t lock;
   int_least32_t v;
 } atomic_int_least32_t;
 typedef struct atomic_int_least64_s {
-  chpl_sync_aux_t sv;
+  pthread_mutex_t lock;
   int_least64_t v;
 } atomic_int_least64_t;
 typedef struct atomic_uint_least8_s {
-  chpl_sync_aux_t sv;
+  pthread_mutex_t lock;
   uint_least8_t v;
 } atomic_uint_least8_t;
 typedef struct atomic_uint_least16_s {
-  chpl_sync_aux_t sv;
+  pthread_mutex_t lock;
   uint_least16_t v;
 } atomic_uint_least16_t;
 typedef struct atomic_uint_least32_s {
-  chpl_sync_aux_t sv;
+  pthread_mutex_t lock;
   uint_least32_t v;
 } atomic_uint_least32_t;
 typedef struct atomic_uint_least64_s {
-  chpl_sync_aux_t sv;
+  pthread_mutex_t lock;
   uint_least64_t v;
 } atomic_uint_least64_t;
 typedef struct atomic_uintptr_s {
-  chpl_sync_aux_t sv;
+  pthread_mutex_t lock;
   uintptr_t v;
 } atomic_uintptr_t;
 
 typedef struct atomic_bool_s {
-  chpl_sync_aux_t sv;
+  pthread_mutex_t lock;
   chpl_bool v;
 } atomic_bool;
 
 typedef struct atomic__real32_s {
-  chpl_sync_aux_t sv;
+  pthread_mutex_t lock;
   _real32 v;
 } atomic__real32;
 
 typedef struct atomic__real64_s {
-  chpl_sync_aux_t sv;
+  pthread_mutex_t lock;
   _real64 v;
 } atomic__real64;
 
@@ -117,16 +122,16 @@ static inline chpl_bool atomic_is_lock_free_ ## type(atomic_ ## type * obj) { \
 } \
 static inline void atomic_init_ ## type(atomic_ ## type * obj, basetype value) { \
   obj->v = value; \
-  chpl_sync_initAux(&obj->sv); \
+  (void) pthread_mutex_init(&obj->lock, NULL); \
 } \
 static inline void atomic_destroy_ ## type(atomic_ ## type * obj) { \
-  chpl_sync_destroyAux(&obj->sv); \
+  (void) pthread_mutex_destroy(&obj->lock); \
 } \
 static MAYBE_INLINE void \
 atomic_store_explicit_ ## type(atomic_ ## type * obj, basetype value, memory_order order) { \
-  chpl_sync_lock(&obj->sv); \
+  (void) pthread_mutex_lock(&obj->lock); \
   obj->v = value; \
-  chpl_sync_unlock(&obj->sv); \
+  (void) pthread_mutex_unlock(&obj->lock); \
 } \
 static inline void atomic_store_ ## type(atomic_ ## type * obj, basetype value) { \
   atomic_store_explicit_ ## type(obj, value, memory_order_seq_cst); \
@@ -134,9 +139,9 @@ static inline void atomic_store_ ## type(atomic_ ## type * obj, basetype value) 
 static MAYBE_INLINE basetype \
 atomic_load_explicit_ ## type(atomic_ ## type * obj, memory_order order) { \
   basetype ret; \
-  chpl_sync_lock(&obj->sv); \
+  (void) pthread_mutex_lock(&obj->lock); \
   ret = obj->v; \
-  chpl_sync_unlock(&obj->sv); \
+  (void) pthread_mutex_unlock(&obj->lock); \
   return ret; \
 } \
 static inline basetype atomic_load_ ## type(atomic_ ## type * obj) { \
@@ -145,10 +150,10 @@ static inline basetype atomic_load_ ## type(atomic_ ## type * obj) { \
 static MAYBE_INLINE basetype \
 atomic_exchange_explicit_ ## type(atomic_ ## type * obj, basetype value, memory_order order) { \
   basetype ret; \
-  chpl_sync_lock(&obj->sv); \
+  (void) pthread_mutex_lock(&obj->lock); \
   ret = obj->v; \
   obj->v = value; \
-  chpl_sync_unlock(&obj->sv); \
+  (void) pthread_mutex_unlock(&obj->lock); \
   return ret; \
 } \
 static inline basetype atomic_exchange_ ## type(atomic_ ## type * obj, basetype value) { \
@@ -157,14 +162,14 @@ static inline basetype atomic_exchange_ ## type(atomic_ ## type * obj, basetype 
 static MAYBE_INLINE chpl_bool \
 atomic_compare_exchange_strong_explicit_ ## type(atomic_ ## type * obj, basetype expected, basetype desired, memory_order order) { \
   basetype ret; \
-  chpl_sync_lock(&obj->sv); \
+  (void) pthread_mutex_lock(&obj->lock); \
   if( obj->v == expected ) { \
     obj->v = desired; \
     ret = true; \
   } else { \
     ret = false; \
   } \
-  chpl_sync_unlock(&obj->sv); \
+  (void) pthread_mutex_unlock(&obj->lock); \
   return ret; \
 } \
 static inline chpl_bool atomic_compare_exchange_strong_ ## type(atomic_ ## type * obj, basetype expected, basetype desired) { \
@@ -181,10 +186,10 @@ static inline chpl_bool atomic_compare_exchange_weak_ ## type(atomic_ ## type * 
 static MAYBE_INLINE type \
 atomic_fetch_add_explicit_ ## type(atomic_ ## type * obj, type operand, memory_order order) { \
   type ret; \
-  chpl_sync_lock(&obj->sv); \
+  (void) pthread_mutex_lock(&obj->lock); \
   ret = obj->v; \
   obj->v += operand; \
-  chpl_sync_unlock(&obj->sv); \
+  (void) pthread_mutex_unlock(&obj->lock); \
   return ret; \
 } \
 static inline type atomic_fetch_add_ ## type(atomic_ ## type * obj, type operand) { \
@@ -193,10 +198,10 @@ static inline type atomic_fetch_add_ ## type(atomic_ ## type * obj, type operand
 static MAYBE_INLINE type \
 atomic_fetch_sub_explicit_ ## type(atomic_ ## type * obj, type operand, memory_order order) { \
   type ret; \
-  chpl_sync_lock(&obj->sv); \
+  (void) pthread_mutex_lock(&obj->lock); \
   ret = obj->v; \
   obj->v -= operand; \
-  chpl_sync_unlock(&obj->sv); \
+  (void) pthread_mutex_unlock(&obj->lock); \
   return ret; \
 } \
 static inline type atomic_fetch_sub_ ## type(atomic_ ## type * obj, type operand) { \
@@ -205,10 +210,10 @@ static inline type atomic_fetch_sub_ ## type(atomic_ ## type * obj, type operand
 static MAYBE_INLINE type \
 atomic_fetch_or_explicit_ ## type(atomic_ ## type * obj, type operand, memory_order order) { \
   type ret; \
-  chpl_sync_lock(&obj->sv); \
+  (void) pthread_mutex_lock(&obj->lock); \
   ret = obj->v; \
   obj->v |= operand; \
-  chpl_sync_unlock(&obj->sv); \
+  (void) pthread_mutex_unlock(&obj->lock); \
   return ret; \
 } \
 static inline type atomic_fetch_or_ ## type(atomic_ ## type * obj, type operand) { \
@@ -217,10 +222,10 @@ static inline type atomic_fetch_or_ ## type(atomic_ ## type * obj, type operand)
 static MAYBE_INLINE type \
 atomic_fetch_and_explicit_ ## type(atomic_ ## type * obj, type operand, memory_order order) { \
   type ret; \
-  chpl_sync_lock(&obj->sv); \
+  (void) pthread_mutex_lock(&obj->lock); \
   ret = obj->v; \
   obj->v &= operand; \
-  chpl_sync_unlock(&obj->sv); \
+  (void) pthread_mutex_unlock(&obj->lock); \
   return ret; \
 } \
 static inline type atomic_fetch_and_ ## type(atomic_ ## type * obj, type operand) { \
@@ -229,10 +234,10 @@ static inline type atomic_fetch_and_ ## type(atomic_ ## type * obj, type operand
 static MAYBE_INLINE type \
 atomic_fetch_xor_explicit_ ## type(atomic_ ## type * obj, type operand, memory_order order) { \
   type ret; \
-  chpl_sync_lock(&obj->sv); \
+  (void) pthread_mutex_lock(&obj->lock); \
   ret = obj->v; \
   obj->v ^= operand; \
-  chpl_sync_unlock(&obj->sv); \
+  (void) pthread_mutex_unlock(&obj->lock); \
   return ret; \
 } \
 static inline type atomic_fetch_xor_ ## type(atomic_ ## type * obj, type operand) { \
@@ -243,10 +248,10 @@ static inline type atomic_fetch_xor_ ## type(atomic_ ## type * obj, type operand
 static MAYBE_INLINE type \
 atomic_fetch_add_explicit_ ## type(atomic_ ## type * obj, type operand, memory_order order) { \
   type ret; \
-  chpl_sync_lock(&obj->sv); \
+  (void) pthread_mutex_lock(&obj->lock); \
   ret = obj->v; \
   obj->v += operand; \
-  chpl_sync_unlock(&obj->sv); \
+  (void) pthread_mutex_unlock(&obj->lock); \
   return ret; \
 } \
 static inline type atomic_fetch_add_ ## type(atomic_ ## type * obj, type operand) { \
@@ -255,10 +260,10 @@ static inline type atomic_fetch_add_ ## type(atomic_ ## type * obj, type operand
 static MAYBE_INLINE type \
 atomic_fetch_sub_explicit_ ## type(atomic_ ## type * obj, type operand, memory_order order) { \
   type ret; \
-  chpl_sync_lock(&obj->sv); \
+  (void) pthread_mutex_lock(&obj->lock); \
   ret = obj->v; \
   obj->v -= operand; \
-  chpl_sync_unlock(&obj->sv); \
+  (void) pthread_mutex_unlock(&obj->lock); \
   return ret; \
 } \
 static inline type atomic_fetch_sub_ ## type(atomic_ ## type * obj, type operand) { \


### PR DESCRIPTION
`CHPL_ATOMICS=locks` is a low performance, but portable atomics implementation.
Currently, it's only used for pgi where neither the __sync intrinsics nor c11
atomics are supported.

Historically we've used `chpl_sync_lock()/unlock()` to implement these portable
atomics, but this switches to use `pthread_mutex_lock()/unlock()`. The primary
motivation for this is because we use atomics before the tasking layer is
initialized and after it's shutdown, so we can't actually rely on using chpl
syncs. Historically we've gotten away with it because lock/unlock under fifo
used pthread mutexes, which didn't require tasking layer initialization and
until recently (#10133) qthreads lock/unlock was implemented with an atomic
spinwait using qthread_incr which will usually not require qthreads to be
initialized (if inline asm or __sync primitives are used) but that's not
guaranteed so we just lucky.

Now that chpl_sync_lock maps down to qthread_lock (thin wrapper over
qthread_readFE()), the tasking layer must be initialized in order to use
lock/unlock. Since we need to use atomics when the tasking layer isn't
initialized, this just switches the locks based atomic implementation over to
using pthread mutexes. This is safe to do because the critical section can
never yield, so we can't run into situations where we yield to another task
while holding the mutex. This rational (and motivation) is similar to the
switch to a pthread_mutex for the mem tracking table (ae050cd3c0, ffb4c55ac1)

As a side-benefit, pthread mutexes are really optimized (and do hybrid
spin-waiting/blocking) so they get better performance. Here's some results for
a very simple microbenchmark that just does an atomic add under heavy and under
no contention.

```chpl
use Time;

config const iters = 10000000;
config const doSerial = false;

var a: atomic int;

var t: Timer; t.start();
serial doSerial {
  forall 1..iters {
    a.add(1);
  }
}
t.stop();

writeln("a: ", a.read(), " elapsed: ", t.elapsed());
```

| lock version               | serial | parallel |
| -------------------------- | ------ | -------- |
| qthread_incr  (pre #10133) | 0.15s  | 10.1s    |
| chpl sync     (master)     | 1.36s  | 5.77s    |
| pthread mutex (this PR)    | 0.16s  | 0.93s    |

Which shows that pthread mutex is as fast as the atomic spinwait under no
contention and faster than our sync under contention.