### PR TITLE
Optimize enum->int casts for concrete types

### DIFF
--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -387,6 +387,20 @@ bool EnumType::isAbstract() {
   return true;
 }
 
+bool EnumType::isConcrete() {
+  // if the first constant has an initializer, it's concrete;
+  // otherwise, it's not.  This loop with a guaranteed return is a
+  // lazy way of getting that first constant.
+  for_enums(constant, this) {
+    if (constant->init) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+  return true;
+}
+
 
 PrimitiveType* EnumType::getIntegerType() {
   INT_ASSERT(integerType);

--- a/compiler/include/type.h
+++ b/compiler/include/type.h
@@ -325,6 +325,7 @@ class EnumType : public Type {
   int codegenStructure(FILE* outfile, const char* baseoffset);
 
   bool isAbstract();  // is the enum abstract?  (has no associated values)
+  bool isConcrete();  // is the enum concrete?  (all have associated values)
   PrimitiveType* getIntegerType();
 
   virtual void printDocs(std::ostream *file, unsigned int tabs);


### PR DESCRIPTION
In removing enum->int casts for abstract enums in PR #10114, I rewrote
casts for other cases to use a select statement, in part for
simplicity, and in part to generate errors for the semi-concrete case.
This turned out to have a major performance impact for fasta which
relies on a lot of enum->int casts.

Here, I'm optimizing the enum->int cast in the case where an enum is
concrete by having it fall back to the old primitive-based
implementation that used to be implemented in ChapelBase.chpl before
PR #10114.  The semi-concrete case is still handled using a switch
statement.

With more effort, other cases could also be similarlt optimized, but I
think the better use of that effort would be to implement issue #10307
and convert all these functions as lookups into C arrays.  So for now, I'm
stopping here in hopes that it restores the performance we expect for
benchmarks we're currently invested in and can prioritize #10307 if
other cases are required.

Resolves #10303.