### PR TITLE
Tolerate Cygwin's different multibyte encoding

### DIFF
--- a/test/io/ferguson/ctests/qio_formatted_test.test.c
+++ b/test/io/ferguson/ctests/qio_formatted_test.test.c
@@ -1508,8 +1508,13 @@ int main(int argc, char** argv)
     qbytes_iobuf_size = sizes[i];
 
     if( 0 == strcmp(codeset, "UTF-8") ) {
+#ifndef __CYGWIN__
+      // Cygwin's native functions perform a different encoding for
+      // code points outside the Basic Multilingual Plane (16 bits).
       qio_glocale_utf8 = -1;
       test_utf8();
+#endif
+      // The fast path had better produce the same encoding everywhere.
       qio_glocale_utf8 = 1;
       test_utf8();
     }


### PR DESCRIPTION
Cygwin's native library functions perform a different UTF-8 encoding for codepoints larger than 16 bits.  This isn't so surprising because Windows is native UTF-16, which may affect other choices.

This change skips a portion of a test that expects the native library to yield the reference encoding.  It still expects the code built into Chapel to perform the same encoding everywhere.
