### PR TITLE
Add support for --compiler, --linker, and --ldshared to compileline

### DIFF
--- a/runtime/etc/Makefile.include
+++ b/runtime/etc/Makefile.include
@@ -110,15 +110,24 @@ printcompileline:
 printcxxcompileline:
 	@echo $(CXX) $(CHPL_MAKE_BASE_CXXFLAGS) $(GEN_CXXFLAGS) $(COMP_GEN_CXXFLAGS) $(CHPL_RT_INC_DIR)
 
+printccompiler:
+	@echo $(CC)
+
 printcflags:
 	@echo $(CHPL_MAKE_BASE_CFLAGS) $(GEN_CFLAGS) $(COMP_GEN_CFLAGS)
 
 printcxxflags:
 	@echo $(CHPL_MAKE_BASE_CXXFLAGS) $(GEN_CXXFLAGS) $(COMP_GEN_CXXFLAGS)
 
+printldshared:
+	@echo $(LD) $(LIB_DYNAMIC_FLAG)
+
 printlibraries:
 	@echo $(GEN_LFLAGS) $(COMP_GEN_LFLAGS) -L$(CHPL_RT_LIB_DIR) \
 	      -lchpl $(LIBS) -lm $(CHPL_MAKE_THIRD_PARTY_LINK_ARGS) $(CHPL_MAKE_BASE_LFLAGS)
+
+printlinker:
+	@echo $(LD)
 
 printlinkline:
 	@echo $(LD) $(GEN_LFLAGS) $(COMP_GEN_LFLAGS) -L$(CHPL_RT_LIB_DIR) \

--- a/runtime/etc/Makefile.include
+++ b/runtime/etc/Makefile.include
@@ -119,7 +119,7 @@ printcflags:
 printcxxflags:
 	@echo $(CHPL_MAKE_BASE_CXXFLAGS) $(GEN_CXXFLAGS) $(COMP_GEN_CXXFLAGS)
 
-printldshared:
+printlinkershared:
 	@echo $(LD) $(LIB_DYNAMIC_FLAG)
 
 printlibraries:

--- a/util/config/compileline
+++ b/util/config/compileline
@@ -59,6 +59,9 @@ def parseArguments():
                       dest="actions", action='append_const',
                       help="print a C++ compiler invocation that can use "
                            "the Chapel runtime")
+    parser.add_option("--compiler", const="compiler",
+                      dest="actions", action='append_const',
+                      help="print the C compiler used")
     parser.add_option("--cflags", const="cflags",
                       dest="actions", action='append_const',
                       help="print C compilation flags that Chapel would use")
@@ -69,10 +72,16 @@ def parseArguments():
                       dest="actions", action='append_const',
                       help="Print -D and -I compilation flags to include "
                            "the Chapel runtime")
+    parser.add_option("--ldshared", const="ldshared",
+                      dest="actions", action='append_const',
+                      help="print out the command for ldshared")
     parser.add_option("--libraries", const="libraries",
                       dest="actions", action='append_const',
                       help="print out -L and -l options to link with "
                            "the Chapel runtime")
+    parser.add_option("--linker", const="linker",
+                      dest="actions", action='append_const',
+                      help="print the linker used")
     parser.add_option("--main.o", const="maino",
                       dest="actions", action='append_const',
                       help="print out the path to the main.o file")
@@ -181,14 +190,20 @@ def main():
             mysystem(make_helper, "printcompileline")
         elif a == "compilecxx":
             mysystem(make_helper, "printcxxcompileline")
+        elif a == "compiler":
+            mysystem(make_helper, "printccompiler")
         elif a == "cflags":
             mysystem(make_helper, "printcflags")
         elif a == "cxxflags":
             mysystem(make_helper, "printcxxflags")
         elif a == "includesanddefines":
             mysystem(make_helper, "printincludesanddefines")
+        elif a == "ldshared":
+            mysystem(make_helper, "printldshared")
         elif a == "libraries":
             mysystem(make_helper, "printlibraries")
+        elif a == "linker":
+            mysystem(make_helper, "printlinker")
         elif a == "maino":
             mysystem(make_helper, "printmaino")
         elif a == "llvminstalldir":

--- a/util/config/compileline
+++ b/util/config/compileline
@@ -72,9 +72,9 @@ def parseArguments():
                       dest="actions", action='append_const',
                       help="Print -D and -I compilation flags to include "
                            "the Chapel runtime")
-    parser.add_option("--ldshared", const="ldshared",
+    parser.add_option("--linkershared", const="linkershared",
                       dest="actions", action='append_const',
-                      help="print out the command for ldshared")
+                      help="print out the command for linking with shared")
     parser.add_option("--libraries", const="libraries",
                       dest="actions", action='append_const',
                       help="print out -L and -l options to link with "
@@ -198,12 +198,12 @@ def main():
             mysystem(make_helper, "printcxxflags")
         elif a == "includesanddefines":
             mysystem(make_helper, "printincludesanddefines")
-        elif a == "ldshared":
-            mysystem(make_helper, "printldshared")
         elif a == "libraries":
             mysystem(make_helper, "printlibraries")
         elif a == "linker":
             mysystem(make_helper, "printlinker")
+        elif a == "linkershared":
+            mysystem(make_helper, "printlinkershared")
         elif a == "maino":
             mysystem(make_helper, "printmaino")
         elif a == "llvminstalldir":


### PR DESCRIPTION
Resolves #10206

This will allow us to get just the compiler and linking commands when
interoperating with Cython, which is necessary on Crays to ensure we can access
loaded modules like ugni, for instance.

Tested over a full standard paratest (with futures because why not)