### PR TITLE
Improve the speed of codegenPrimitive

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -2234,6 +2234,9 @@ void codegen(void) {
     if (!llvmCodegen ) USR_FATAL("--llvm-wide-opt requires --llvm");
   }
 
+  // Prepare primitives for codegen
+  CallExpr::registerPrimitivesForCodegen();
+
   setupDefaultFilenames();
 
   if( llvmCodegen ) {

--- a/compiler/include/CallExpr.h
+++ b/compiler/include/CallExpr.h
@@ -117,9 +117,12 @@ public:
 
   void            convertToNoop();
 
+  static void     registerPrimitivesForCodegen();
+
 private:
   GenRet          codegenPrimitive();
   GenRet          codegenPrimMove();
+
 
   // Declare CallExpr::codegenPRIM_UNKNOWN() etc
 #define PRIMITIVE_G(NAME) static void codegen ## NAME (CallExpr*, GenRet&);

--- a/compiler/include/codegen.h
+++ b/compiler/include/codegen.h
@@ -144,5 +144,6 @@ const char* idCommentTemp(BaseAST* ast);
 void genComment(const char* comment, bool push=false);
 void flushStatements(void);
 
+void registerPrimitiveCodegens();
 
 #endif //CODEGEN_H


### PR DESCRIPTION
This PR hopefully addresses the compiler performance regression from
PR #10187 noted in issue #10304. It improves the speed of
codegenPrimitive by:

* registering the primitive codegen handlers in another function (called at the
  start of code generation)

While there, it also makes these changes:

* simplified the structure of the function, to consolidate cases and use
  conditionals instead of a switch

* the first conditional is for PRIM_MOVE because that's the most common
  primitive (by far). Having a conditional here is intended to help with branch
  prediction & allow inlining codegenPrimMove if the C++ compiler wants to do
  that. Note though that in my experiments I didn't see any noticeable
  performance difference from this on my machine. Handling PRIM_MOVE specially
  doesn't seem problematic though (since it already has codegenPrimMove to call)
  and it might help on other hardware.

The most common primitives for Hello World are, in order: move, set reference,
cast, check_nil, return. Move occurs about 5x more than set reference.


- [x] full local testing

Reviewed by @benharsh - thanks!