### PR TITLE
Use initializer for LocCyclicArr

### DIFF
--- a/modules/dists/CyclicDist.chpl
+++ b/modules/dists/CyclicDist.chpl
@@ -943,6 +943,7 @@ proc CyclicArr.setRADOpt(val=true) {
   if doRADOpt then setupRADOpt();
 }
 
+pragma "use default init"
 class LocCyclicArr {
   type eltType;
   param rank: int;
@@ -956,9 +957,6 @@ class LocCyclicArr {
   var myElems: [locDom.myBlock] eltType;
   var locRADLock: atomicbool; // This will only be accessed locally, so
                               // force the use of processor atomics
-
-  // INIT TODO: using default-init resulted in extra GETs for the tests in
-  // distributions/robust/arithmetic/performance/multilocale
 
   // These functions will always be called on this.locale, and so we do
   // not have an on statement around the while loop below (to avoid


### PR DESCRIPTION
At some point in the past, using a default initializer for the ``LocCyclicArr`` class resulted in extra GETs. This is no longer the case.

Testing:
- [x] local + futures
- [x] gasnet