### PR TITLE
Skip this test under --llvm since it inspects generated C

### DIFF
--- a/test/functions/ferguson/lineno/no-extra-lineno.skipif
+++ b/test/functions/ferguson/lineno/no-extra-lineno.skipif
@@ -1,0 +1,2 @@
+# This test inspects generated C, so skip under --llvm
+COMPOPTS<=--llvm


### PR DESCRIPTION
Resolve an issue with a new test from PR #10295 .

Trivial and not reviewed.