### PR TITLE
Better prediffs for CoMD

### DIFF
--- a/test/studies/comd/elegant/arrayOfStructs/CoMD.prediff
+++ b/test/studies/comd/elegant/arrayOfStructs/CoMD.prediff
@@ -6,11 +6,6 @@ test_name = sys.argv[1]
 out_file  = sys.argv[2]
 tmp_file  = out_file + ".prediff.tmp"
 
-with open(out_file) as outf:
-    for line in outf:
-        if re.search(r"\.chpl:\d+:( internal)? error:", line) != None:
-            sys.exit(0);
-
 EPSILON = 1e-6
 vals = {}
 vals['  Initial energy  :'] = -1.166063303458
@@ -26,28 +21,38 @@ def verify(line):
             pre += ' SUCCESS\n'
         else:
             pre += ' FAILURE\n'
+        vals[pre] = True # indicate pattern was found
         return pre
     else:
         return line
 
 def printChunk(start, numAfter):
-    with open(tmp_file, 'a') as tf:
-        with open(out_file) as outf:
-            started = False
-            numRead = 0
-            for line in outf:
-                if start in line:
-                    tf.write(verify(line))
-                    started = True
-                elif started and numRead < numAfter:
-                    tf.write(verify(line))
-                    numRead += 1
-                elif numRead == numAfter:
-                    break
+    ret = ""
 
-printChunk("Simulation Validation:", 4)
+    with open(out_file) as outf:
+        started = False
+        numRead = 0
+        for line in outf:
+            if start in line:
+                ret += line
+                started = True
+            elif started and numRead < numAfter:
+                ret += verify(line)
+                numRead += 1
+            elif numRead == numAfter:
+                break
+
+    if numRead == numAfter:
+        return ret
+    else:
+        return ""
+
+text = printChunk("Simulation Validation:", 4)
 
 if os.getenv('CHPL_TEST_PERF') == 'on':
-    printChunk("Timings", 10)
+    text += printChunk("Timings", 10)
 
-shutil.move(tmp_file, out_file)
+if text != "" and all(vals.values()):
+    with open(tmp_file, 'a') as tf:
+        tf.write(text)
+    shutil.move(tmp_file, out_file)

--- a/test/studies/comd/elegant/arrayOfStructs/CoMD.prediff
+++ b/test/studies/comd/elegant/arrayOfStructs/CoMD.prediff
@@ -52,7 +52,11 @@ def printChunk(start, numAfter):
 text = printChunk("Simulation Validation:", 4)
 
 if os.getenv('CHPL_TEST_PERF') == 'on':
-    text += printChunk("Timings", 10)
+    perfText = printChunk("Timings", 10)
+    if perfText == "":
+      text = "" # error during processing of timings output
+    else:
+      text += perfText
 
 if text != "" and all(found.values()):
     with open(tmp_file, 'a') as tf:

--- a/test/studies/comd/elegant/arrayOfStructs/CoMD.prediff
+++ b/test/studies/comd/elegant/arrayOfStructs/CoMD.prediff
@@ -12,16 +12,18 @@ vals['  Initial energy  :'] = -1.166063303458
 vals['  Final energy    :'] = -1.166049767266
 vals['  eFinal/eInitial :'] = 0.999988
 
+found = dict.fromkeys(vals.keys(), False)
+
 def verify(line):
     info = line.split(' ')
     pre = ' '.join(info[:-1])
     if pre in vals:
         last = float(info[-1])
+        found[pre] = True # indicate pattern was found
         if abs(last - vals[pre]) < EPSILON:
             pre += ' SUCCESS\n'
         else:
             pre += ' FAILURE\n'
-        vals[pre] = True # indicate pattern was found
         return pre
     else:
         return line
@@ -52,7 +54,16 @@ text = printChunk("Simulation Validation:", 4)
 if os.getenv('CHPL_TEST_PERF') == 'on':
     text += printChunk("Timings", 10)
 
-if text != "" and all(vals.values()):
+if text != "" and all(found.values()):
     with open(tmp_file, 'a') as tf:
         tf.write(text)
     shutil.move(tmp_file, out_file)
+else:
+    with open(tmp_file, 'a') as tf:
+        with open(out_file) as outf:
+            tf.write(outf.read())
+        if text == "":
+            tf.write("\nPREDIFF ERROR: Unexpected number of lines\n")
+        if all(found.values()) == False:
+            tf.write("\nPREDIFF ERROR: Unable to find validation values\n")
+        shutil.move(tmp_file, out_file)

--- a/test/studies/comd/llnl/CoMD.prediff
+++ b/test/studies/comd/llnl/CoMD.prediff
@@ -52,7 +52,11 @@ def printChunk(start, numAfter):
 text = printChunk("Simulation Validation:", 4)
 
 if os.getenv('CHPL_TEST_PERF') == 'on':
-    text += printChunk("Timings", 10)
+    perfText = printChunk("Timings", 16)
+    if perfText == "":
+      text = "" # error during processing of timings output
+    else:
+      text += perfText
 
 if text != "" and all(found.values()):
     with open(tmp_file, 'a') as tf:

--- a/test/studies/comd/llnl/CoMD.prediff
+++ b/test/studies/comd/llnl/CoMD.prediff
@@ -12,16 +12,18 @@ vals['   Initial energy  :'] = -1.166063303477
 vals['   Final energy    :'] = -1.166049767266
 vals['   eFinal/eInitial :'] = 0.999988
 
+found = dict.fromkeys(vals.keys(), False)
+
 def verify(line):
     info = line.split(' ')
     pre = ' '.join(info[:-1])
     if pre in vals:
         last = float(info[-1])
+        found[pre] = True # indicate pattern was found
         if abs(last - vals[pre]) < EPSILON:
             pre += ' SUCCESS\n'
         else:
             pre += ' FAILURE\n'
-        vals[pre] = True # indicate pattern was found
         return pre
     else:
         return line
@@ -52,7 +54,16 @@ text = printChunk("Simulation Validation:", 4)
 if os.getenv('CHPL_TEST_PERF') == 'on':
     text += printChunk("Timings", 10)
 
-if text != "" and all(vals.values()):
+if text != "" and all(found.values()):
     with open(tmp_file, 'a') as tf:
         tf.write(text)
     shutil.move(tmp_file, out_file)
+else:
+    with open(tmp_file, 'a') as tf:
+        with open(out_file) as outf:
+            tf.write(outf.read())
+        if text == "":
+            tf.write("\nPREDIFF ERROR: Unexpected number of lines\n")
+        if all(found.values()) == False:
+            tf.write("\nPREDIFF ERROR: Unable to find validation values\n")
+        shutil.move(tmp_file, out_file)

--- a/test/studies/comd/llnl/CoMD.prediff
+++ b/test/studies/comd/llnl/CoMD.prediff
@@ -6,12 +6,6 @@ test_name = sys.argv[1]
 out_file  = sys.argv[2]
 tmp_file  = out_file + ".prediff.tmp"
 
-# Do not modify the output if it looks like there was a compiler error
-with open(out_file) as outf:
-    for line in outf:
-        if re.search(r"\.chpl:\d+:( internal)? error:", line) != None:
-            sys.exit(0)
-
 EPSILON = 1e-6
 vals = {}
 vals['   Initial energy  :'] = -1.166063303477
@@ -27,27 +21,38 @@ def verify(line):
             pre += ' SUCCESS\n'
         else:
             pre += ' FAILURE\n'
+        vals[pre] = True # indicate pattern was found
         return pre
     else:
         return line
 
 def printChunk(start, numAfter):
-    with open(tmp_file, 'a') as tf:
-        with open(out_file) as outf:
-            started = False
-            numRead = 0
-            for line in outf:
-                if start in line:
-                    tf.write(verify(line))
-                    started = True
-                elif started and numRead < numAfter:
-                    tf.write(verify(line))
-                    numRead += 1
-                elif numRead == numAfter:
-                    break
-printChunk("Simulation Validation:", 4)
+    ret = ""
+
+    with open(out_file) as outf:
+        started = False
+        numRead = 0
+        for line in outf:
+            if start in line:
+                ret += line
+                started = True
+            elif started and numRead < numAfter:
+                ret += verify(line)
+                numRead += 1
+            elif numRead == numAfter:
+                break
+
+    if numRead == numAfter:
+        return ret
+    else:
+        return ""
+
+text = printChunk("Simulation Validation:", 4)
 
 if os.getenv('CHPL_TEST_PERF') == 'on':
-    printChunk("Timings", 16)
+    text += printChunk("Timings", 10)
 
-shutil.move(tmp_file, out_file)
+if text != "" and all(vals.values()):
+    with open(tmp_file, 'a') as tf:
+        tf.write(text)
+    shutil.move(tmp_file, out_file)


### PR DESCRIPTION
This PR updates the CoMD prediffs such that they will only filter test output if both of the following conditions hold:
- The expected number of lines is found
- Each correctness line is found

The prediff will also add error messages if one of the conditions was not met. In general, this should avoid the case where CoMD would fail unexpectedly but nightly test logs showed no output.

Resolves #9890 

Testing:
- [x] catches segfaults and halts
- [x] catches mispelled validation output
- [x] catches too-few lines of validation output
- [x] catches too-few lines of performance output
- [x] start_test with and without -performance