### PR TITLE
Clean up our use of halt wrappers

### DIFF
--- a/modules/internal/ChapelStandard.chpl
+++ b/modules/internal/ChapelStandard.chpl
@@ -69,6 +69,7 @@ module ChapelStandard {
 
   // Standard modules.
   use Assert;
+  use HaltWrappers only ;
   use Types;
   use Math;
 

--- a/modules/packages/HDF5_HL.chpl
+++ b/modules/packages/HDF5_HL.chpl
@@ -3893,8 +3893,7 @@ module HDF5_HL {
      */
     class HDF5Preprocessor {
       proc preprocess(A: []) {
-        use ChapelHaltWrappers;
-        pureVirtualMethodHalt();
+        HaltWrappers.pureVirtualMethodHalt();
       }
     }
 

--- a/modules/standard/Barriers.chpl
+++ b/modules/standard/Barriers.chpl
@@ -100,8 +100,7 @@ module Barriers {
           }
         }
         otherwise {
-          use ChapelHaltWrappers;
-          exhaustiveSelectHalt("unknown barrier type");
+          HaltWrappers.exhaustiveSelectHalt("unknown barrier type");
         }
       }
       isowned = true;
@@ -181,32 +180,27 @@ module Barriers {
   class BarrierBaseType {
     pragma "no doc"
     proc barrier() {
-      use ChapelHaltWrappers;
-      pureVirtualMethodHalt();
+      HaltWrappers.pureVirtualMethodHalt();
     }
 
     pragma "no doc"
     proc notify() {
-      use ChapelHaltWrappers;
-      pureVirtualMethodHalt();
+      HaltWrappers.pureVirtualMethodHalt();
     }
 
     pragma "no doc"
     proc wait() {
-      use ChapelHaltWrappers;
-      pureVirtualMethodHalt();
+      HaltWrappers.pureVirtualMethodHalt();
     }
 
     pragma "no doc"
     proc check(): bool {
-      use ChapelHaltWrappers;
-      pureVirtualMethodHalt();
+      HaltWrappers.pureVirtualMethodHalt();
     }
 
     pragma "no doc"
     proc reset(nTasks: int) {
-      use ChapelHaltWrappers;
-      pureVirtualMethodHalt();
+      HaltWrappers.pureVirtualMethodHalt();
     }
   }
 
@@ -272,8 +266,7 @@ module Barriers {
           }
           const alreadySet = done.testAndSet();
           if boundsChecking && alreadySet {
-            use ChapelHaltWrappers;
-            boundsCheckHalt("Too many callers to barrier()");
+            HaltWrappers.boundsCheckHalt("Too many callers to barrier()");
           }
           if reusable {
             count.waitFor(n-1);
@@ -297,8 +290,7 @@ module Barriers {
         if myc<=1 {
           const alreadySet = done.testAndSet();
           if boundsChecking && alreadySet {
-            use ChapelHaltWrappers;
-            boundsCheckHalt("Too many callers to notify()");
+            HaltWrappers.boundsCheckHalt("Too many callers to notify()");
           }
         }
       }
@@ -367,8 +359,7 @@ module Barriers {
     inline proc barrier() {
       on this {
         if boundsChecking && blockers.read() >= maxBlockers {
-          use ChapelHaltWrappers;
-          boundsCheckHalt("Too many callers to barrier()");
+          HaltWrappers.boundsCheckHalt("Too many callers to barrier()");
         }
         inGate.readFF();
         var waiters = blockers.fetchAdd(1) + 1;
@@ -394,8 +385,7 @@ module Barriers {
     inline proc notify() {
       on this {
         if boundsChecking && blockers.read() >= maxBlockers {
-          use ChapelHaltWrappers;
-          boundsCheckHalt("Too many callers to notify()");
+          HaltWrappers.boundsCheckHalt("Too many callers to notify()");
         }
 
         inGate.readFF();

--- a/modules/standard/DateTime.chpl
+++ b/modules/standard/DateTime.chpl
@@ -269,14 +269,13 @@ module DateTime {
      1 <= `day` <= the number of days in the given month and year
   */
   proc date.init(year, month, day) {
-    use ChapelHaltWrappers;
     if year < MINYEAR-1 || year > MAXYEAR+1 then
-      initHalt("year is out of the valid range");
+      HaltWrappers.initHalt("year is out of the valid range");
     if month < 1 || month > 12 then
-      initHalt("month is out of the valid range");
+      HaltWrappers.initHalt("month is out of the valid range");
     const dim = try! daysInMonth(year, month);
     if day < 1 || day > dim then
-      initHalt("day is out of the valid range");
+      HaltWrappers.initHalt("day is out of the valid range");
 
     this.chpl_year = year;
     this.chpl_month = month;
@@ -563,15 +562,14 @@ module DateTime {
    */
   proc time.init(hour=0, minute=0, second=0, microsecond=0,
                  tzinfo: Shared(TZInfo)=nilTZ) {
-    use ChapelHaltWrappers;
     if hour < 0 || hour >= 24 then
-      initHalt("hour out of range");
+      HaltWrappers.initHalt("hour out of range");
     if minute < 0 || minute >= 60 then
-      initHalt("minute out of range");
+      HaltWrappers.initHalt("minute out of range");
     if second < 0 || second >= 60 then
-      initHalt("second out of range");
+      HaltWrappers.initHalt("second out of range");
     if microsecond < 0 || microsecond >= 1000000 then
-      initHalt("microsecond out of range");
+      HaltWrappers.initHalt("microsecond out of range");
     this.chpl_hour = hour;
     this.chpl_minute = minute;
     this.chpl_second = second;
@@ -1488,7 +1486,6 @@ module DateTime {
      and microseconds. */
   proc timedelta.init(days=0, seconds=0, microseconds=0,
                       milliseconds=0, minutes=0, hours=0, weeks=0) {
-    use ChapelHaltWrappers;
     param usps = 1000000,  // microseconds per second
           uspms = 1000,    // microseconds per millisecond
           spd = 24*60*60; // seconds per day
@@ -1517,10 +1514,10 @@ module DateTime {
     this.chpl_microseconds = us;
 
     if this.days < -999999999 then
-      initHalt("Overflow: days < -999999999");
+      HaltWrappers.initHalt("Overflow: days < -999999999");
 
     if this.days > 999999999 then
-      initHalt("Overflow: days > 999999999");
+      HaltWrappers.initHalt("Overflow: days > 999999999");
   }
 
   /* Create a `timedelta` from a given number of seconds */
@@ -1666,29 +1663,25 @@ module DateTime {
   class TZInfo {
     /* The offset from UTC this class represents */
     proc utcoffset(dt: datetime): timedelta {
-      use ChapelHaltWrappers;
-      pureVirtualMethodHalt();
+      HaltWrappers.pureVirtualMethodHalt();
       return new timedelta();
     }
 
     /* The `timedelta` for daylight saving time */
     proc dst(dt: datetime): timedelta {
-      use ChapelHaltWrappers;
-      pureVirtualMethodHalt();
+      HaltWrappers.pureVirtualMethodHalt();
       return new timedelta();
     }
 
     /* The name of this time zone */
     proc tzname(dt: datetime): string {
-      use ChapelHaltWrappers;
-      pureVirtualMethodHalt();
+      HaltWrappers.pureVirtualMethodHalt();
       return "";
     }
 
     /* Convert a `time` in UTC to this time zone */
     proc fromutc(in dt: datetime): datetime {
-      use ChapelHaltWrappers;
-      pureVirtualMethodHalt();
+      HaltWrappers.pureVirtualMethodHalt();
       return new datetime(0,0,0);
     }
   }

--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -830,7 +830,6 @@ private module GlobWrappers {
 
   // glob wrapper that takes care of casting and error checking
   inline proc glob_w(pattern: string, ref ret_glob:glob_t): void {
-    use ChapelHaltWrappers;
     extern proc chpl_glob(pattern: c_string, flags: c_int,
                           ref ret_glob: glob_t): c_int;
 
@@ -843,7 +842,7 @@ private module GlobWrappers {
     // convert that into an out of memory error.
     assert (err == 0 || err == GLOB_NOMATCH || err == GLOB_NOSPACE);
     if err == GLOB_NOSPACE then
-      outOfMemoryHalt("glob()");
+      HaltWrappers.outOfMemoryHalt("glob()");
   }
 
   // glob_num wrapper that takes care of casting
@@ -932,7 +931,6 @@ iter glob(pattern: string = "*", param tag: iterKind)
 pragma "no doc"
 iter glob(pattern: string = "*", followThis, param tag: iterKind): string
        where tag == iterKind.follower {
-  use ChapelHaltWrappers;
   use GlobWrappers;
   var glb : glob_t;
   if (followThis.size != 1) then
@@ -942,7 +940,7 @@ iter glob(pattern: string = "*", followThis, param tag: iterKind): string
   glob_w(pattern, glb);
   const num = glob_num_w(glb);
   if (r.high >= num) then
-    zipLengthHalt("glob() is being zipped with something too big; it only has " + num + " matches");
+    HaltWrappers.zipLengthHalt("glob() is being zipped with something too big; it only has " + num + " matches");
 
   for i in r do
     yield glob_index_w(glb, i);

--- a/modules/standard/HaltWrappers.chpl
+++ b/modules/standard/HaltWrappers.chpl
@@ -21,8 +21,7 @@
    This module provides halt wrappers to make it easier to find and identify
    particular use-cases.
  */
-module ChapelHaltWrappers {
-  use ChapelIO; // for halt()
+module HaltWrappers {
 
   //
   // Halt wrappers for cases where we want error-handling, but error-handling

--- a/modules/standard/List.chpl
+++ b/modules/standard/List.chpl
@@ -187,8 +187,7 @@ record list {
    */
  proc pop_front():eltType {
    if boundsChecking && length < 1 {
-     use ChapelHaltWrappers;
-     boundsCheckHalt("pop_front on empty list");
+     HaltWrappers.boundsCheckHalt("pop_front on empty list");
    }
    var oldfirst = first;
    var newfirst = first.next;

--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -2065,8 +2065,6 @@ module Random {
       proc init(type eltType = real(64),
                 seed: int(64) = SeedGenerator.oddCurrentTime,
                 param parSafe: bool = true) {
-        use ChapelHaltWrappers;
-
         this.eltType = eltType;
 
         // The mod operation is written in these steps in order
@@ -2078,7 +2076,7 @@ module Random {
         var useed = seed:uint(64);
         var mod:uint(64);
         if useed % 2 == 0 then
-          initHalt("NPBRandomStream seed must be an odd integer");
+          HaltWrappers.initHalt("NPBRandomStream seed must be an odd integer");
         // Adjust seed to be between 0 and 2**46.
         mod = useed & two_46_mask;
         this.seed = mod:int(64);
@@ -2086,7 +2084,7 @@ module Random {
         this.complete();
 
         if this.seed % 2 == 0 || this.seed < 1 || this.seed > two_46:int(64) then
-          initHalt("NPBRandomStream seed must be an odd integer between 0 and 2**46");
+          HaltWrappers.initHalt("NPBRandomStream seed must be an odd integer between 0 and 2**46");
 
         NPBRandomStreamPrivate_cursor = seed;
         NPBRandomStreamPrivate_count = 1;

--- a/modules/standard/Types.chpl
+++ b/modules/standard/Types.chpl
@@ -620,18 +620,18 @@ no checks at all will be done.
 */
 inline proc integral.safeCast(type T) : T where isUintType(T) {
   if castChecking {
-    use ChapelHaltWrappers;
     if isIntType(this.type) {
       // int(?) -> uint(?)
       if this < 0 then // runtime check
-        safeCastCheckHalt("casting "+this.type:string+" less than 0 to "+T:string);
+        HaltWrappers.safeCastCheckHalt("casting "+this.type:string+
+            " less than 0 to "+T:string);
     }
 
     if max(this.type):uint > max(T):uint {
       // [u]int(?) -> uint(?)
       if (this:uint > max(T):uint) then // runtime check
-        safeCastCheckHalt("casting "+this.type:string+" with a value " +
-            "greater than the maximum of "+ T:string+" to "+T:string);
+        HaltWrappers.safeCastCheckHalt("casting "+this.type:string+
+            " with a value greater than the maximum of "+ T:string+" to "+T:string);
     }
   }
   return this:T;
@@ -640,28 +640,27 @@ inline proc integral.safeCast(type T) : T where isUintType(T) {
 pragma "no doc" // documented with the other safeCast above
 inline proc integral.safeCast(type T) : T where isIntType(T) {
   if castChecking {
-    use ChapelHaltWrappers;
     if max(this.type):uint > max(T):uint {
       // this isUintType check lets us avoid a runtime check for this < 0
       if isUintType(this.type) {
         // uint(?) -> int(?)
         if this:uint > max(T):uint then // runtime check
-          safeCastCheckHalt("casting "+this.type:string+" with a value " +
-              "greater than the maximum of "+ T:string+" to "+T:string);
+          HaltWrappers.safeCastCheckHalt("casting "+this.type:string+
+              " with a value greater than the maximum of "+ T:string+" to "+T:string);
       } else {
         // int(?) -> int(?)
         // max(T) <= max(int), so cast to int is safe
         if this:int > max(T):int then // runtime check
-          safeCastCheckHalt("casting "+this.type:string+" with a value " +
-              "greater than the maximum of "+ T:string+" to "+T:string);
+          HaltWrappers.safeCastCheckHalt("casting "+this.type:string+
+              " with a value greater than the maximum of "+ T:string+" to "+T:string);
       }
     }
     if isIntType(this.type) {
       if min(this.type):int < min(T):int {
         // int(?) -> int(?)
         if this:int < min(T):int then // runtime check
-          safeCastCheckHalt("casting "+this.type:string+" with a value less " +
-              "than the minimum of "+ T:string+" to "+T:string);
+          HaltWrappers.safeCastCheckHalt("casting "+this.type:string+
+              " with a value less than the minimum of "+ T:string+" to "+T:string);
       }
     }
   }

--- a/test/modules/bradc/printModStuff/foo.good
+++ b/test/modules/bradc/printModStuff/foo.good
@@ -22,6 +22,7 @@ Parsing module files:
   subdir4/subdir/bax.chpl
   ./bah.chpl
   $CHPL_HOME/modules/standard/Assert.chpl
+  $CHPL_HOME/modules/standard/HaltWrappers.chpl
   $CHPL_HOME/modules/standard/Types.chpl
   $CHPL_HOME/modules/standard/Math.chpl
   $CHPL_HOME/modules/standard/CommDiagnostics.chpl
@@ -35,7 +36,6 @@ Parsing module files:
   $CHPL_HOME/modules/packages/RangeChunk.chpl
   $CHPL_HOME/modules/packages/Search.chpl
   $CHPL_HOME/modules/standard/Sys.chpl
-  $CHPL_HOME/modules/standard/ChapelHaltWrappers.chpl
   $CHPL_HOME/modules/standard/SysError.chpl
   $CHPL_HOME/modules/standard/Regexp.chpl
 In bar

--- a/test/modules/sungeun/init/printModuleInitOrder.good
+++ b/test/modules/sungeun/init/printModuleInitOrder.good
@@ -29,12 +29,12 @@ Initializing Modules:
     LocalesArray
     ChapelDistribution
      List
-      ChapelHaltWrappers
-       ChapelIO
-        IO
-         SysError
-         FormattedIO
-          Regexp
+      HaltWrappers
+    ChapelIO
+     IO
+      SysError
+      FormattedIO
+       Regexp
     LocaleTree
     DefaultAssociative
     ExternalArray

--- a/test/modules/vass/deinit-order-modules.verbose.good
+++ b/test/modules/vass/deinit-order-modules.verbose.good
@@ -28,8 +28,8 @@ uv4ae.deinit UC
   MemTracking
   ExternalArray
   LocaleTree
-  ChapelDistribution
   IO
+  ChapelDistribution
   LocalesArray
   LocaleModel
   DefaultRectangular


### PR DESCRIPTION
Clean up our use of halt wrappers. This switches to using fully qualified halt
wrappers and renames `ChapelHaltWrappers` to `HaltWrappers`. e.g. this changes:

```chpl
use ChapelHaltWrappers;
pureVirtualMethodHalt();
```

to

```chpl
HaltWrappers.pureVirtualMethodHalt();
```

I've been trying to ensure that we don't expose the halt wrappers into the user
namespace so I was putting `use`s into local function bodies, but this ended up
adding a lot of `use` lines. This just switches ChapelHaltWrappers to
HaltWrappers and uses fully qualified names instead of `use`ing the module
anywhere to avoid the duplication.

Note that I had to add HaltWrapper into ChapelStandard, but I'm doing it with
`use HaltWrappers only ;` to avoid leaking the actual wrappers (this is needed
since we use the halt wrappers in base internal modules)