### PR TITLE
Stop inserting declarations for certain internal exported functions in the .h

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -1108,7 +1108,9 @@ static void codegen_library_header(std::vector<FnSymbol*> functions) {
       // Print out the module initialization function headers and the exported
       // functions
       for_vector(FnSymbol, fn, functions) {
-        if (fn->hasFlag(FLAG_EXPORT)) {
+        if (fn->hasFlag(FLAG_EXPORT) &&
+            fn->getModule()->modTag != MOD_INTERNAL &&
+            fn->hasFlag(FLAG_GEN_MAIN_FUNC) == false) {
           fn->codegenPrototype();
         }
       }

--- a/compiler/include/flags_list.h
+++ b/compiler/include/flags_list.h
@@ -137,6 +137,7 @@ symbolFlag( FLAG_FUNCTION_TERMINATES_PROGRAM, ypr, "function terminates program"
 // but has unspecified type.
 symbolFlag( FLAG_GENERIC , npr, "generic" , "generic types, functions and arguments" )
 symbolFlag( FLAG_DELAY_GENERIC_EXPANSION, npr, "delay instantiation", "generics instances whose instantiation  will be determined shortly")
+symbolFlag( FLAG_GEN_MAIN_FUNC, npr, "generated main", "compiler generated main function")
 symbolFlag( FLAG_GLOBAL_TYPE_SYMBOL, npr, "global type symbol", "is accessible through a global type variable")
 symbolFlag( FLAG_HAS_RUNTIME_TYPE , ypr, "has runtime type" , "type that has an associated runtime type" )
 symbolFlag( FLAG_RVV, npr, "RVV", "variable is the return value variable" )

--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -573,6 +573,7 @@ static void build_chpl_entry_points() {
   chpl_gen_main->addFlag(FLAG_EXPORT);  // chpl_gen_main is always exported.
   chpl_gen_main->addFlag(FLAG_LOCAL_ARGS);
   chpl_gen_main->addFlag(FLAG_COMPILER_GENERATED);
+  chpl_gen_main->addFlag(FLAG_GEN_MAIN_FUNC);
 
   mainModule->block->insertAtTail(new DefExpr(chpl_gen_main));
 


### PR DESCRIPTION
Prior to this change, the generated header file in library mode would contain
declarations for exported functions from our internal modules, as well as the
generated "main" function.  This updates the generation of the header file to
explicitly skip those functions.

Spot checked a couple of the generated header files (since we no longer commit
them to the repository), and passed a full paratest