### PR TITLE
Generate default-initializers for unions under --force-initializers

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -2146,9 +2146,6 @@ void AggregateType::buildCopyInitializer() {
 // generate default initializers for types where neither an initializer nor a
 // constructor has been defined.
 bool AggregateType::needsConstructor() const {
-  // Temporarily only generate default initializers for classes and records
-  if (isUnion())
-    return true;
 
   // We don't want a default constructor if the type has been explicitly marked
   if (symbol->hasFlag(FLAG_USE_DEFAULT_INIT))

--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -2260,10 +2260,6 @@ bool AggregateType::wantsDefaultInitializer() const {
   } else if (initializerStyle != DEFINES_NONE_USE_DEFAULT) {
     retval = false;
 
-  // For now, no default initializers for unions
-  } else if (isUnion()  == true) {
-    retval = false;
-
   } else if (symbol->hasFlag(FLAG_REF) == true) {
     retval = false;
 

--- a/compiler/passes/initializerRules.cpp
+++ b/compiler/passes/initializerRules.cpp
@@ -258,7 +258,7 @@ static void preNormalizeInit(FnSymbol* fn) {
   if (fn->throwsError() == true) {
     USR_FATAL(fn, "initializers are not yet allowed to throw errors");
 
-  } else if (at->isRecord() == true) {
+  } else if (at->isRecord() == true || at->isUnion()) {
     preNormalizeInitRecord(fn);
 
   } else if (at->isClass()  == true) {


### PR DESCRIPTION
This PR updates the compiler to generate default initializers for unions when --force-initializers is thrown. Like constructors, initializers don't really work for unions. This change is more about getting us away from constructors.

Testing:
- [x] local + futures
- [x] --force-initializers