### PR TITLE
Skip mallocOutOfMemory under --baseline

### DIFF
--- a/test/memory/shannon/outofmemory/mallocOutOfMemory.skipif
+++ b/test/memory/shannon/outofmemory/mallocOutOfMemory.skipif
@@ -3,4 +3,6 @@ CHPL_TEST_VGRND_EXE == on
 # Both cygwin and darwin fail to define ulimit or anything similar
 CHPL_HOST_PLATFORM == darwin
 CHPL_HOST_PLATFORM <= cygwin
+# --baseline stack size requirements are too high
+COMPOPTS <= --baseline
 # Note, this test has a different error for GASNet fast + fifo


### PR DESCRIPTION
We lower the stacksize to 64K for this test, and our stack sizes under baseline
have crept up over the last few months. I don't want to increase the stack size
(because that will probably lead to failures in other configurations) so just
skip. Note that this test is a little wonky because it lowers the virtual
memory limit so we can get an OOM error without actually exhausting the memory
on the system so we have to be careful to set a ulimit that's low enough that
we don't exhaust physical memory, but large enough to get to user main()