### PR TITLE
Add perf annotations for 2018-07-12

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -338,6 +338,10 @@ all:
   06/20/18:
     - text: Optimize non-fetching network atomics (#9876)
       config: 16 node XC
+  06/29/18:
+    - Avoid using syncvar_t in the qthreads shim (#10082)
+  07/04/18:
+    - Remove spinwaiting from qthreads chpl_sync_lock() (#10133)
 
 
 AllCompTime:
@@ -460,6 +464,9 @@ compSampler-timecomp: &timecomp-base
     - Faster 'fixStringLiteralInit' implementation (#9506)
   05/23/18:
     - Fix problems with tuples (#9572)
+  07/10/18:
+    - use isSubtype in preference to ':' in where clauses (#10143)
+    - Refactor codegenPrimitive, add limit to denormalize (#10187)
 
 cg:
   09/20/16:
@@ -553,6 +560,8 @@ fasta:
       config: chapcs
   08/02/17:
     - Remove handling of references from copyPropagation (#6779)
+  07/04/18:
+    - Disable enum->int casts for enums without values (#10114)
 
 fastaredux:
   01/14/14:
@@ -563,6 +572,8 @@ fastaredux:
     - optimize certain functions that return with ref-intent (#3101)
   03/12/16:
     - implemented good_alloc_size for jemalloc(#3446)
+  07/04/18:
+    - Disable enum->int casts for enums without values (#10114)
 
 fft-timecomp:
   <<: *timecomp-base
@@ -671,6 +682,8 @@ jacobi:
     - Remove handling of references from copyPropagation (#6779)
   03/13/18:
     - Enable phase one dynamic dispatch (#8790)
+  07/10/18:
+    - use isSubtype in preference to ':' in where clauses (#10143)
 
 knucleotide:
   10/17/15:


### PR DESCRIPTION
Add perf annotations for:
 - [compiler speed](https://chapel-lang.org/perf/chapcs/?startdate=2018/07/06&enddate=2018/07/13&graphs=fftcompilationtimebypass,samplercompilationtimebypass,cgsparsecompilationtimebypass,compilationtime,jacobiastsize) improvements (and regressions)
   - resolution is faster and AST size is down from #10143
   - codegen is slower from #10187 (should be resolved by #10321)
 - [Fasta](https://chapel-lang.org/perf/chapcs/?startdate=2018/06/25&enddate=2018/07/12&graphs=fastashootoutbenchmarkn25000000,fastareduxshootoutbenchmarkn25000000) is slower from #10114 (should be resolved by #10308)
 - Improvements to [meteor, pidigits, array-init, spectral norm](https://chapel-lang.org/perf/chapcs/?startdate=2018/06/15&enddate=2018/07/12&graphs=meteorshootoutbenchmarkn2098,pidigitsvariations,1ddomainvsrangeparalleliteration,promotedoptimenolocal,arrayinitializationsloweridioms,spectralnormshootoutbenchmark) from #10082
 - Regressions to [serial I/O](https://chapel-lang.org/perf/chapcs/?startdate=2018/06/27&enddate=2018/07/10&graphs=parboilbfsexecutiontime,parboilsadserialexecutiontime,timetotreepaircount,cvschplwritingsinglenewlinestostdout) from #10133 (future work captured in #10141)