### PR TITLE
Convert halts in timer start()/stop() to warnings

### DIFF
--- a/modules/standard/Time.chpl
+++ b/modules/standard/Time.chpl
@@ -230,9 +230,7 @@ private proc _convert_to_seconds(unit: TimeUnits, us: real) {
     when TimeUnits.hours        do return us * 3600.0;
   }
 
-  halt("internal error in module Time");
-
-  // will never get here, but to avoid warnings:
+  HaltWrappers.exhaustiveSelectHalt("unknown timeunits type");
   return -1.0;
 }
 
@@ -246,9 +244,7 @@ private proc _convert_microseconds(unit: TimeUnits, us: real) {
     when TimeUnits.hours        do return us / 3600.0e+6;
   }
 
-  halt("internal error in module Time");
-
-  // will never get here, but to avoid warnings:
+  HaltWrappers.exhaustiveSelectHalt("unknown timeunits type");
   return -1.0;
 }
 

--- a/modules/standard/Time.chpl
+++ b/modules/standard/Time.chpl
@@ -111,7 +111,9 @@ proc getCurrentDayOfWeek() : Day {
 }
 
 /*
-   Delay a task for a duration in the units specified
+   Delay a task for a duration in the units specified. This function
+   will return without sleeping and emit a warning if the duration is
+   negative.
 
    :arg  t: The duration for the time to sleep
    :type t: `real`
@@ -123,7 +125,7 @@ inline proc sleep(t: real, unit: TimeUnits = TimeUnits.seconds) : void {
   extern proc chpl_task_sleep(s:c_double) : void;
 
   if t < 0 {
-    try! stderr.writeln("Warning: sleep() called with negative time parameter");
+    warning("sleep() called with negative time parameter: '"+t+"'");
     return;
   }
   chpl_task_sleep(_convert_to_seconds(unit, t:real):c_double);
@@ -160,17 +162,17 @@ record Timer {
     }
   }
 
-  /* Starts the timer. It is an error to start a timer that is already running. */
+  /* Starts the timer. A warning is emitted if the timer is already running. */
   proc start() : void {
     if !running {
       running = true;
       time    = chpl_now_timevalue();
     } else {
-      halt("start called on a timer that has not been stopped");
+      warning("start called on a timer that has not been stopped");
     }
   }
 
-  /* Stops the timer. It is an error to stop a timer that is not running. */
+  /* Stops the timer. A warning is emitted if the timer is not running. */
   proc stop() : void {
     if running {
       var time2: _timevalue = chpl_now_timevalue();
@@ -178,7 +180,7 @@ record Timer {
       accumulated += _diff_time(time2, time);
       running      = false;
     } else {
-      halt("stop called on a timer that has not been started");
+      warning("stop called on a timer that has not been started");
     }
   }
 

--- a/test/library/standard/Time/badStartStopTimer.chpl
+++ b/test/library/standard/Time/badStartStopTimer.chpl
@@ -1,0 +1,8 @@
+use Time;
+
+var timer: Timer;
+timer.stop();  // warn -- stop on never started timer
+timer.start(); // ok
+timer.start(); // warn -- start on running timer
+timer.stop();  // ok
+timer.stop();  // warn -- stop on stopped timer

--- a/test/library/standard/Time/badStartStopTimer.good
+++ b/test/library/standard/Time/badStartStopTimer.good
@@ -1,0 +1,3 @@
+badStartStopTimer.chpl:4: warning: stop called on a timer that has not been started
+badStartStopTimer.chpl:6: warning: start called on a timer that has not been stopped
+badStartStopTimer.chpl:8: warning: stop called on a timer that has not been started

--- a/test/library/standard/Time/sleepTimeUnits.good
+++ b/test/library/standard/Time/sleepTimeUnits.good
@@ -1,2 +1,2 @@
-Warning: sleep() called with negative time parameter
+sleepTimeUnits.chpl:16: warning: sleep() called with negative time parameter: '-5.0'
 Done


### PR DESCRIPTION
Calling start() on a started timer or stop() on a stopped timer certainly
shouldn't be a halt, but it likely indicates a programmer error. We probably
want a richer warning interface that allows users to turn warnings on/off, but
this is at least better than halting. This also update sleep() to use the
official `warning()` wrapper which adds helpful line numbers.

Closes https://github.com/chapel-lang/chapel/issues/9836
