### PR TITLE
Records with postinits are not POD

### DIFF
--- a/compiler/passes/initializerRules.cpp
+++ b/compiler/passes/initializerRules.cpp
@@ -1443,6 +1443,10 @@ void preNormalizePostInit(AggregateType* at) {
     }
   }
 
+  if (isRecord(at) && at->hasPostInitializer()) {
+    at->symbol->addFlag(FLAG_NOT_POD);
+  }
+
   if (errors > 0) {
     USR_STOP();
   }

--- a/test/types/type_variables/ferguson/ispod-posinit.chpl
+++ b/test/types/type_variables/ferguson/ispod-posinit.chpl
@@ -1,0 +1,12 @@
+proc doit(type t) {
+  writeln(t:string, " : ", __primitive("is pod type", t));
+}
+
+record NotPod1 {
+  var x:int;
+  proc postinit() {
+    writeln("in postinit");
+  }
+}
+
+doit(NotPod1);

--- a/test/types/type_variables/ferguson/ispod-posinit.good
+++ b/test/types/type_variables/ferguson/ispod-posinit.good
@@ -1,0 +1,1 @@
+NotPod1 : false


### PR DESCRIPTION
This PR updates the compiler to add FLAG_NOT_POD to any record with a postinit method.

Testing:
- [x] local + futures
- [x] gasnet