### PR TITLE
Revert to 1 numtrials for perf playground

### DIFF
--- a/util/cron/test-perf.chapcs.playground.bash
+++ b/util/cron/test-perf.chapcs.playground.bash
@@ -36,5 +36,5 @@ git checkout -b $GITHUB_USER-$GITHUB_BRANCH
 git pull https://github.com/$GITHUB_USER/chapel.git $GITHUB_BRANCH
 
 perf_args="-performance-description $SHORT_NAME -performance-configs default:v,$SHORT_NAME:v -sync-dir-suffix $SHORT_NAME"
-perf_args="${perf_args} -numtrials 5 -startdate $START_DATE"
+perf_args="${perf_args} -numtrials 1 -startdate $START_DATE"
 $CWD/nightly -cron ${perf_args} ${nightly_args}


### PR DESCRIPTION
We would like to stay with 1 numtrials for perf playground so it completes earlier during the nightly testing. See [this comment](https://github.com/chapel-lang/chapel/pull/10306#discussion_r202214116) .