### PR TITLE
Remove argv from 'chpl_main_argument' in module definition

### DIFF
--- a/modules/internal/ChapelUtil.chpl
+++ b/modules/internal/ChapelUtil.chpl
@@ -101,7 +101,7 @@ module ChapelUtil {
   pragma "use default init"
   extern record chpl_main_argument {
     var argc: int(64);
-    var argv: _ddata(string);
+    // var argv: c_ptr(c_string);
     var return_value: int(32);
   }
 


### PR DESCRIPTION
'argv' is a char**, not a _ddata(string). This would result in a failure in chpl_main_argument's default initializer if denormalization was disabled. Since the field is not used in the module code, I opted to update the type and comment it out in order to indicate that there are not just two fields in the struct.

Testing:
- [x] local + Futures
- [x] baseline