### PR TITLE
Propagate forwarded type instantiation point to scratch fn

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -3068,6 +3068,9 @@ static bool populateForwardingMethods(CallInfo& info) {
       FnSymbol* scratch = new FnSymbol("delegate_scratch_fn");
       scratch->addFlag(FLAG_COMPILER_GENERATED);
 
+      if (at->symbol->instantiationPoint)
+        scratch->instantiationPoint = at->symbol->instantiationPoint;
+
       Expr* where = getInsertPointForTypeFunction(at);
       if (BlockStmt* block = toBlockStmt(where))
         block->insertAtHead(new DefExpr(scratch));

--- a/test/reductions/partial/CSimpl.chpl
+++ b/test/reductions/partial/CSimpl.chpl
@@ -12,7 +12,7 @@ proc plusPRinto(ref RES,DOM,FEXPR) throws {
   defer {
     delete OP;
   }
-  DOM.dist.dsiPartialReduceInto(RES, OP, DOM, FEXPR);
+  DOM.dist._value.dsiPartialReduceInto(RES, OP, DOM, FEXPR);
 }
 
 // At the moment, this is an exact copy of DefaultDist.dsiPartialReduce()


### PR DESCRIPTION
Resolves #10358 

Resolution for generic forwarded functions are currently added to a "scratch 
function" to be resolved. This was causing problems when these functions used
the point-of-instantiation rule to find relevant functions that are called. 
This PR adjusts the scratch function to have a point-of-instantiation based 
upon the relevant AggregateType (on which forwarding is occurring).

This change makes the pattern of forwarding in cg-sparse-partred.chpl no longer work, since in that case the scratch function would need a different 
instantiation point. In particular, cg-sparse-parted expects that a method only
available at the instantiation of the call (vs at the creation of the type) is
available to be called. I'm looking at adjusting the forwarding implementation 
to not have the scratch function but I think the change in cg-sparse-parted is
minor and acceptable to allow the more common patterns.

- [x] full local testing

Reviewed by @vasslitvinov - thanks!