### PR TITLE
NULL entry for empty chpl_mem_descs

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -1411,11 +1411,16 @@ static void codegen_defn(std::set<const char*> & cnames, std::vector<TypeSymbol*
   if( hdrfile ) {
     fprintf(hdrfile, "\nconst char* chpl_mem_descs[] = {\n");
     bool first = true;
-    forv_Vec(const char*, memDesc, memDescsVec) {
-      if (!first)
-        fprintf(hdrfile, ",\n");
-      fprintf(hdrfile, "\"%s\"", memDesc);
-      first = false;
+    if (memDescsVec.n == 0) {
+      // Quiet PGI warning about empty initializer
+      fprintf(hdrfile, "\nNULL,");
+    } else {
+      forv_Vec(const char*, memDesc, memDescsVec) {
+        if (!first)
+          fprintf(hdrfile, ",\n");
+        fprintf(hdrfile, "\"%s\"", memDesc);
+        first = false;
+      }
     }
     fprintf(hdrfile, "\n};\n");
   }


### PR DESCRIPTION
Prior to this PR the compiler would insert a single chpl_mem_descs entry, "_ref", for some tests when compiled with --minimal-modules. A recent PR updated _ref to use initializers, which (correctly) stopped the generation of "_ref" in chpl_mem_descs and resulted in an empty array. PGI would emit a warning/error for such array initializations.

This PR simply generates a NULL entry if chpl_mem_descs would otherwise be empty.

Testing:
- [x] gcc local + futures
- [x] PGI tests that failed in nightly testing