### PR TITLE
Set Qthreads build options in a more principled way.

### DIFF
--- a/third-party/Makefile
+++ b/third-party/Makefile
@@ -127,17 +127,21 @@ $(MASSIVETHREADS_INSTALL_DIR): $(MASSIVETHREADS_DEPEND)
 	rm -rf $(MASSIVETHREADS_INSTALL_DIR) && rm -rf $(MASSIVETHREADS_BUILD_DIR)
 	cd massivethreads && $(MAKE)
 
-# Qthreads may use hwloc and/or jemalloc. Ensure they are built first
+# Qthreads may use hwloc and/or jemalloc, and its use of compileline
+# to get build options requires a completed GASNet build if we're
+# using that. Ensure they are built first.
 ifeq ($(CHPL_MAKE_HWLOC), hwloc)
-QTHREAD_DEPEND_INSTALL_DIRS += $(HWLOC_INSTALL_DIR)
+QTHREAD_OTHER_INSTALL_DIR_DEPS += $(HWLOC_INSTALL_DIR)
 endif
 ifeq ($(CHPL_MAKE_JEMALLOC), jemalloc)
-QTHREAD_DEPEND_INSTALL_DIRS += $(JEMALLOC_INSTALL_DIR)
+QTHREAD_OTHER_INSTALL_DIR_DEPS += $(JEMALLOC_INSTALL_DIR)
 endif
-QTHREAD_DEPEND_INSTALL_DIRS += $(QTHREAD_INSTALL_DIR)
-qthread: $(QTHREAD_DEPEND_INSTALL_DIRS)
+ifeq ($(CHPL_MAKE_COMM), gasnet)
+QTHREAD_OTHER_INSTALL_DIR_DEPS += $(GASNET_INSTALL_DIR)
+endif
+qthread: $(QTHREAD_INSTALL_DIR)
 
-$(QTHREAD_INSTALL_DIR): $(QTHREAD_DEPEND) $(HWLOC_DEPEND) $(JEMALLOC_DEPEND)
+$(QTHREAD_INSTALL_DIR): $(QTHREAD_DEPEND) $(QTHREAD_OTHER_INSTALL_DIR_DEPS)
 	rm -rf $(QTHREAD_INSTALL_DIR) && rm -rf $(QTHREAD_BUILD_DIR)
 	cd qthread && $(MAKE)
 $(QTHREAD_ALIASES): qthread

--- a/third-party/qthread/Makefile
+++ b/third-party/qthread/Makefile
@@ -49,7 +49,7 @@ ifeq ($(CFLAGS_NEEDS_RT_INCLUDES), y)
   # When building the Chapel allocator file we need all the Chapel runtime
   # defs and include directories, plus the third-party include dirs other
   # than that for Qthreads itself (since we're building it).  Notably, we
-  # do not want -DOPTIMIZE; if we have that set when building Qthreads it
+  # do not want -DNDEBUG; if we have that set when building Qthreads it
   # seems to cause Chapel programs built with the result to hang during
   # exit when shutting down Qthreads.
   CFLAGS += \

--- a/third-party/qthread/Makefile
+++ b/third-party/qthread/Makefile
@@ -46,14 +46,19 @@ ifeq (, $(call isTrue, $(CHPL_QTHREAD_NO_CHPL_ALLOC)))
 endif
 
 ifeq ($(CFLAGS_NEEDS_RT_INCLUDES), y)
-  CFLAGS += -I$(CHPL_MAKE_HOME)/runtime/include/localeModels/$(CHPL_MAKE_LOCALE_MODEL)
-  CFLAGS += -I$(CHPL_MAKE_HOME)/runtime/include/mem/$(CHPL_MAKE_MEM)
-  CFLAGS += -I$(CHPL_MAKE_HOME)/runtime/include
-  ifeq (, $(call isTrue, $(CHPL_QTHREAD_NO_CHPL_ALLOC)))
-    ifeq ($(CHPL_MAKE_MEM),jemalloc)
-      CFLAGS += -I$(JEMALLOC_INCLUDE_DIR)
-    endif
-  endif
+  # When building the Chapel allocator file we need all the Chapel runtime
+  # defs and include directories, plus the third-party include dirs other
+  # than that for Qthreads itself (since we're building it).  Notably, we
+  # do not want -DOPTIMIZE; if we have that set when building Qthreads it
+  # seems to cause Chapel programs built with the result to hang during
+  # exit when shutting down Qthreads.
+  CFLAGS += \
+    $(shell $(CHPL_MAKE_HOME)/util/config/compileline --includes-and-defines \
+            | tr ' ' '\n' \
+            | grep '^-DCHPL\|/runtime//*include\|/third-party/.*/install' \
+            | grep -v '/third-party/qthread/install' \
+            | tr '\n' ' ' \
+            | sed 's/ $$//')
 endif
 
 # enable oversubscription for testing


### PR DESCRIPTION
We used to set -I options ad-hoc when using the Chapel allocator and/or
the Chapel runtime copy of the hwloc topology.  Here, get them from the
compileline --includes-and-defines output instead.  As part of this, add
a third-party/Makefile dependence to ensure that we build GASNet before
Qthreads when both are in use, because compileline can't produce the
includes and defines information until after GASNet is installed.

This improves and re-applies a change originally made as part of PR
#9736, which was reverted in #9761 because it broke comm=gasnet
builds.

This resolves #9797.