### PR TITLE
Improve Bessel function portability and convert halts to halt wrappers

### DIFF
--- a/modules/standard/Math.chpl
+++ b/modules/standard/Math.chpl
@@ -1074,7 +1074,10 @@ module Math {
 
 
   /* Returns the Bessel function of the first kind of order `0` of `x`. */
-  extern "j0f" proc j0(x: real(32)): real(32);
+  inline proc j0(x: real(32)): real(32) {
+    extern proc chpl_float_j0(x: real(32)): real(32);
+    return chpl_float_j0(x);
+  }
 
   /* Returns the Bessel function of the first kind of order `0` of `x`. */
   inline proc j0(x: real(64)): real(64) {
@@ -1082,9 +1085,11 @@ module Math {
     return j0(x);
   }
 
-
   /* Returns the Bessel function of the first kind of order `1` of `x`. */
-  extern "j1f" proc j1(x: real(32)): real(32);
+  inline proc j1(x: real(32)): real(32) {
+    extern proc chpl_float_j1(x: real(32)): real(32);
+    return chpl_float_j1(x);
+  }
 
   /* Returns the Bessel function of the first kind of order `1` of `x`. */
   inline proc j1(x: real(64)): real(64) {
@@ -1092,11 +1097,10 @@ module Math {
     return j1(x);
   }
 
-
   /* Returns the Bessel function of the first kind of order `n` of `x`. */
   inline proc jn(n: int, x: real(32)): real(32) {
-    extern proc jnf(n: c_int, x: real(32)): real(32);
-    return jnf(n.safeCast(c_int), x);
+    extern proc chpl_float_jn(n: c_int, x: real(32)): real(32);
+    return chpl_float_jn(n.safeCast(c_int), x);
   }
 
   /* Returns the Bessel function of the first kind of order `n` of `x`. */
@@ -1105,57 +1109,62 @@ module Math {
     return jn(n.safeCast(c_int), x);
   }
 
+  /* Returns the Bessel function of the second kind of order `0` of `x`, where
+     `x` must be greater than 0 */
+  inline proc y0(x: real(32)): real(32) {
+    if boundsChecking && x < 0 then
+      HaltWrappers.boundsCheckHalt("Input value for y0() must be non-negative");
+
+    extern proc chpl_float_y0(x: real(32)): real(32);
+    return chpl_float_y0(x);
+  }
 
   /* Returns the Bessel function of the second kind of order `0` of `x`,
-     if and only if the value of `x` is greater than 0*/
-  extern "y0f" proc y0(x: real(32)): real(32);
-
-  /* Returns the Bessel function of the second kind of order `0` of `x`,
-     if and only if the value of `x` is greater than 0 */
+     where `x` must be greater than 0 */
   inline proc y0(x: real(64)): real(64) {
-    if boundsChecking {
-      if x < 0 then
-        halt("Input value for Bessel function of second kind must be greater than 0");
-    }
+    if boundsChecking && x < 0 then
+      HaltWrappers.boundsCheckHalt("Input value for y0() must be non-negative");
+
     extern proc y0(x: real(64)): real(64);
     return y0(x);
   }
 
+  /* Returns the Bessel function of the second kind of order `1` of `x`,
+     where `x` must be greater than 0 */
+  inline proc y1(x: real(32)): real(32) {
+    if boundsChecking && x < 0 then
+      HaltWrappers.boundsCheckHalt("Input value for y1() must be non-negative");
+
+    extern proc chpl_float_y1(x: real(32)): real(32);
+    return chpl_float_y1(x);
+  }
 
   /* Returns the Bessel function of the second kind of order `1` of `x`,
-     if and only if the value of `x` is greater than 0 */
-  extern "y1f" proc y1(x: real(32)): real(32);
-
-  /* Returns the Bessel function of the second kind of order `1` of `x`,
-     if and only if the value of `x` is greater than 0 */
+     where `x` must be greater than 0 */
   inline proc y1(x: real(64)): real(64) {
-    if boundsChecking {
-      if x < 0 then
-        halt("Input value for Bessel function of second kind must be greater than 0");
-    }
+    if boundsChecking && x < 0 then
+      HaltWrappers.boundsCheckHalt("Input value for y1() must be non-negative");
+
     extern proc y1(x: real(64)): real(64);
     return y1(x);
   }
 
-
   /* Returns the Bessel function of the second kind of order `n` of `x`,
-     if and only if the value of `x` is greater than 0 */
+     where `x` must be greater than 0 */
   inline proc yn(n: int, x: real(32)): real(32) {
-    if boundsChecking {
-      if x < 0 then
-        halt("Input value for Bessel function of second kind must be greater than 0");
-    }
-    extern proc ynf(n: c_int, x: real(32)): real(32);
-    return ynf(n.safeCast(c_int), x);
+    if boundsChecking && x < 0 then
+      HaltWrappers.boundsCheckHalt("Input value for yn() must be non-negative");
+
+    extern proc chpl_float_yn(n: c_int, x: real(32)): real(32);
+    return chpl_float_yn(n.safeCast(c_int), x);
   }
 
   /* Returns the Bessel function of the second kind of order `n` of `x`,
-     if and only if the value of `x` is greater than 0 */
+     where `x` must be greater than 0 */
   inline proc yn(n: int, x: real(64)): real(64) {
-    if boundsChecking {
-      if x < 0 then
-        halt("Input value for Bessel function of second kind must be greater than 0");
-    }
+    if boundsChecking && x < 0 then
+      HaltWrappers.boundsCheckHalt("Input value for yn() must be non-negative");
+
     extern proc yn(n: c_int, x: real(64)): real(64);
     return yn(n.safeCast(c_int), x);
   }

--- a/runtime/include/chplmath.h
+++ b/runtime/include/chplmath.h
@@ -35,6 +35,24 @@ static inline int chpl_macro_float_isfinite(float x) { return isfinite(x); }
 static inline int chpl_macro_double_isnan(double x) { return isnan(x); }
 static inline int chpl_macro_float_isnan(float x) { return isnan(x); }
 
+// 32-bit Bessel functions aren't available on all platforms. For cases where
+// we know they're available use them since they should be faster, but in other
+// cases default to using the 64-bit versions and casting.
+#ifdef __linux__
+static inline float chpl_float_j0(float x) { return j0f(x); }
+static inline float chpl_float_j1(float x) { return j1f(x); }
+static inline float chpl_float_jn(int n, float x) { return jnf(n, x); }
+static inline float chpl_float_y0(float x) { return y0f(x); }
+static inline float chpl_float_y1(float x) { return y1f(x); }
+static inline float chpl_float_yn(int n, float x) { return ynf(n, x); }
+#else
+static inline float chpl_float_j0(float x) { return (float)j0(x); }
+static inline float chpl_float_j1(float x) { return (float)j1(x); }
+static inline float chpl_float_jn(int n, float x) { return (float)jn(n, x); }
+static inline float chpl_float_y0(float x) { return (float)y0(x); }
+static inline float chpl_float_y1(float x) { return (float)y1(x); }
+static inline float chpl_float_yn(int n, float x) { return (float)yn(n, x); }
+#endif
 
 #ifdef DEFINE_32_BIT_MATH_FNS
 #define fabsf(x) (float)fabs(x)

--- a/test/library/standard/Math/j0.skipif
+++ b/test/library/standard/Math/j0.skipif
@@ -1,1 +1,0 @@
-CHPL_TARGET_PLATFORM == darwin

--- a/test/library/standard/Math/j1.skipif
+++ b/test/library/standard/Math/j1.skipif
@@ -1,1 +1,0 @@
-CHPL_TARGET_PLATFORM == darwin

--- a/test/library/standard/Math/jn.skipif
+++ b/test/library/standard/Math/jn.skipif
@@ -1,1 +1,0 @@
-CHPL_TARGET_PLATFORM == darwin

--- a/test/library/standard/Math/y0.skipif
+++ b/test/library/standard/Math/y0.skipif
@@ -1,1 +1,0 @@
-CHPL_TARGET_PLATFORM == darwin

--- a/test/library/standard/Math/y1.skipif
+++ b/test/library/standard/Math/y1.skipif
@@ -1,1 +1,0 @@
-CHPL_TARGET_PLATFORM == darwin

--- a/test/library/standard/Math/yn.skipif
+++ b/test/library/standard/Math/yn.skipif
@@ -1,1 +1,0 @@
-CHPL_TARGET_PLATFORM == darwin

--- a/test/modules/sungeun/init/printModuleInitOrder.good
+++ b/test/modules/sungeun/init/printModuleInitOrder.good
@@ -12,12 +12,12 @@ Initializing Modules:
     ChapelThreads
     ChapelTuple
     ChapelRange
+     HaltWrappers
     ChapelTaskDataHelp
     LocaleModel
      LocaleModelHelpFlat
       LocaleModelHelpSetup
        ChapelLocale
-        HaltWrappers
        DefaultRectangular
         DSIUtil
         ChapelArray


### PR DESCRIPTION
Previously, we skipped the Bessel tests on Darwin because the 32-bit routines
weren't available. It seems pretty bad to have something in the "standard"
library that didn't work on a platform as popular as macs, so this just adds a
portability layer that will use the 32-bit routines if available, and will fall
back to the 64-bit routines with casts otherwise.

This also converts bounds checks halts to HaltWrappers.boundsCheckHalt()

Related to https://github.com/chapel-lang/chapel/issues/10002