### PR TITLE
Add skyline.skipif

### DIFF
--- a/test/arrays/shapes/skyline.skipif
+++ b/test/arrays/shapes/skyline.skipif
@@ -1,0 +1,3 @@
+# Currently it fails under valgrind.
+# Do not test it elsewhere, to ensure clean .bad match.
+CHPL_TEST_VGRND_EXE != on


### PR DESCRIPTION
skyline.future was intended in #9994 to run only under valgrind - to ensure clean .bad match.

This adds the missing .skipif.
