### PR TITLE
Check LCALS answers using relative differences rather than absolute

### DIFF
--- a/test/release/examples/benchmarks/lcals/LCALSChecksums.chpl
+++ b/test/release/examples/benchmarks/lcals/LCALSChecksums.chpl
@@ -42,7 +42,7 @@ module LCALSChecksums {
   Checksums[LoopKernelID.IMP_HYDRO_2D]   = (17128640997.592403680086135864258,  6020185880.7030686540529131889343,  4839252917.2536934632807970046997);
   Checksums[LoopKernelID.FIND_FIRST_MIN] = (135961480.71599999070167541503906,  101474692.50000000000000000000000,  83639989.545000001788139343261719);
 
-  config const checksumTolerance = 0.17;
+  config const checksumTolerance = 6e-9;
   config const noisyChecksumChecks = false;
 
   proc checkChecksums(run_variants: [] bool, run_loop: [] bool, run_loop_length: [] bool) {
@@ -56,18 +56,19 @@ module LCALSChecksums {
           const lenStr = (length:string).toLower();
           if run_loop[loopKernel] && stat.loop_is_run && stat.loop_run_count[length] > 0 {
             if run_loop_length[length] {
-              const diff = abs(Checksums[loopKernel](1+length:int) - stat.loop_chksum[length]);
-              if diff > checksumTolerance {
+              const absdiff = abs(Checksums[loopKernel](1+length:int) - stat.loop_chksum[length]);
+              const reldiff = abs(absdiff/Checksums[loopKernel](1+length:int));
+              if reldiff > checksumTolerance {
                 writeln("FAIL: ", (varStr, kerStr, lenStr),
                         " (expected, computed) = ",
                         (Checksums[loopKernel](1+length:int),
                          stat.loop_chksum[length]),
-                        " difference: ", diff);
+                        " absolute difference: ", absdiff, " relative difference: ", reldiff);
               } else if noisyChecksumChecks {
                 writeln("PASS: ", (varStr, kerStr, lenStr),
                         " (expected, computed) = ",
                         (Checksums[loopKernel](1+length:int),
-                         stat.loop_chksum[length]), " difference: ", diff);
+                         stat.loop_chksum[length]), " absolute difference: ", absdiff, " relative difference: ", reldiff);
               }
             }
           }

--- a/test/release/examples/benchmarks/lcals/LCALSMain.skipif
+++ b/test/release/examples/benchmarks/lcals/LCALSMain.skipif
@@ -4,9 +4,3 @@ CHPL_COMM != none
 COMPOPTS <= --no-local
 CHPL_TEST_VGRND_EXE == on
 COMPOPTS <= --baseline
-# Some checksums differ from expected values on the following configurations.
-# I think it is caused by sizeof(long double) being less than 16.
-CHPL_TARGET_PLATFORM == cygwin32
-CHPL_TARGET_PLATFORM == cygwin64
-CHPL_TARGET_PLATFORM == linux32
-CHPL_TARGET_COMPILER == cray-prgenv-cray


### PR DESCRIPTION
LCALS answers were being checked using absolute error instead of relative error.
```
absolute_error = abs(expected - actual)
relative_error = abs(absolute_error / expected)
```
Specifically, an absolute error of 0.17 was the criterion for passing.  This allowed 17% error in some answers, and not even a single-bit error in others.

I switched to checking relative error instead.  Both linux64 and darwin were passing before, so I chose the minimum relative error that would still allow them to pass.

Having done that, I noticed that now, all the platforms in the skipif pass too.  I have deleted them all from the skipif.

ARM passes as well, which was the original reason for investigating this.