### PR TITLE
Fix leak in locale.cwd()

### DIFF
--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -578,7 +578,7 @@ proc locale.cwd(): string throws {
     var tmp:c_string;
     // c_strings can't cross on statements.
     err = chpl_fs_cwd(tmp);
-    ret = tmp: string;
+    ret = new string(tmp, isowned=true, needToCopy=false);
   }
   if err != ENOERR then try ioerror(err, "in cwd");
   return ret;


### PR DESCRIPTION
Fix memory leak introduced in PR #9450.

The `locale.cwd` method needs to deallocate the `c_string` allocated in the runtime.
That PR replaced the string construction that takes the buffer with a cast.

Issue #10410 proposes making an easier-to-follow and more recognizeable function for creating a new string that takes ownership of a c_string.

Resolves #9688

- [x] full local testing

Reviewed by @benharsh - thanks!