### PR TITLE
This test relies on bounds checking, disable it with --fast

### DIFF
--- a/test/arrays/return/returnArbitraryBadDomain.skipif
+++ b/test/arrays/return/returnArbitraryBadDomain.skipif
@@ -1,0 +1,1 @@
+COMPOPTS <= --fast


### PR DESCRIPTION
Suggested by Michael