### PR TITLE
Suppress error for ZMQ with PrgEnv-cray

### DIFF
--- a/make/compiler/Makefile.cray-prgenv-cray
+++ b/make/compiler/Makefile.cray-prgenv-cray
@@ -28,6 +28,11 @@ CRAYPE_GEN_CFLAGS += -hnomessage=3140
 # Suppress warnings about floating-point value cannot be represented exactly.
 CRAYPE_GEN_CFLAGS += -hnomessage=1046
 
+# Suppress warnings about incompatible casts that are acceptable in other
+# settings.  Temporary fix for a ZMQ issue
+# https://github.com/chapel-lang/chapel/issues/9961
+CRAYPE_GEN_CFLAGS += -hnomessage=167
+
 # Could set CRAYPE_COMP_CXXFLAGS, CRAYPE_GEN_CFLAGS
 
 FAST_FLOAT_GEN_CFLAGS = -hfp2


### PR DESCRIPTION
Closes #9961

Sets -hnomessage to avoid messages about casting between "incompatible types",
because CCE is stricter about such circumstances than our normal compilation
with other compilers.

This is a temporary solution; we'd like to improve our handling of the type
c_fn_ptr (which is what is involved in the incompatible cast), but that's
going to require more effort and is not a high priority at the moment.

I checked that this change suppresses the warning with a basic ZMQ test and
PrgEnv-cray, and that test/release/examples/hello* and one of the hpcc
directories under test/release/examples also still work.