### PR TITLE
Stop throwing -D_POSIX_C_SOURCE for darwin

### DIFF
--- a/make/compiler/Makefile.clang
+++ b/make/compiler/Makefile.clang
@@ -99,8 +99,7 @@ ifeq ($(CHPL_MAKE_PLATFORM), darwin)
 ARCH := $(shell test -x /usr/bin/machine -a `/usr/bin/machine` == ppc970 && echo -arch ppc64)
 RUNTIME_CFLAGS += $(ARCH)
 RUNTIME_CXXFLAGS += $(ARCH)
-# the -D_POSIX_C_SOURCE flag prevents nonstandard functions from polluting the global name space
-GEN_CFLAGS += -D_POSIX_C_SOURCE $(ARCH) -fno-strict-overflow
+GEN_CFLAGS += $(ARCH) -fno-strict-overflow
 GEN_LFLAGS += $(ARCH)
 endif
 

--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -87,8 +87,7 @@ IEEE_FLOAT_GEN_CFLAGS = -fno-fast-math
 ifeq ($(CHPL_MAKE_PLATFORM), darwin)
 # build 64-bit binaries when on a 64-bit capable PowerPC
 ARCH := $(shell test -x /usr/bin/machine -a `/usr/bin/machine` = ppc970 && echo -arch ppc64)
-# the -D_POSIX_C_SOURCE flag prevents nonstandard functions from polluting the global name space
-GEN_CFLAGS += -D_POSIX_C_SOURCE $(ARCH)
+GEN_CFLAGS += $(ARCH)
 GEN_LFLAGS += $(ARCH)
 endif
 


### PR DESCRIPTION
This was originally added in 51eab78edac, but there was no clear explanation
given (and this was back when our mac support was hit-or-miss and we didn't
have any nightly testing.) It doesn't seem to hurt anything by not defining it
now, and defining it prevented the Bessel functions added in #10391 from being
accessible.