### PR TITLE
Add modules as a mason dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ chplvis: compiler third-party-fltk FORCE
 	cd tools/chplvis && $(MAKE)
 	cd tools/chplvis && $(MAKE) install
 
-mason: compiler chpldoc FORCE
+mason: compiler chpldoc modules FORCE
 	cd tools/mason && $(MAKE) && $(MAKE) install
 
 c2chapel: FORCE


### PR DESCRIPTION
Mason depends on `SysCTypes` being generated, so it should depend on the `modules` target.