### PR TITLE
Common DSI Methods Refactor

### DIFF
--- a/modules/dists/BlockCycDist.chpl
+++ b/modules/dists/BlockCycDist.chpl
@@ -1,15 +1,15 @@
 /*
  * Copyright 2004-2018 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,7 +19,7 @@
 
 //
 // BlockCyclic Distribution
-// 
+//
 //      BlockCyclic    BlockCyclicDom     BlockCyclicArr
 //
 //   LocBlockCyclic    LocBlockCyclicDom  LocBlockCyclicArr
@@ -106,7 +106,7 @@ to the ID of the locale to which it is mapped.
 
     const Space = {1..8, 1..8};
     const D: domain(2)
-      dmapped BlockCyclic(startIdx=Space.low,blocksize=(2,3)) 
+      dmapped BlockCyclic(startIdx=Space.low,blocksize=(2,3))
       = Space;
     var A: [D] int;
 
@@ -138,7 +138,7 @@ The ``BlockCyclic`` class initializer is defined as follows:
     proc BlockCyclic.init(
       startIdx,
       blocksize,
-      targetLocales: [] locale = Locales, 
+      targetLocales: [] locale = Locales,
       dataParTasksPerLocale    = // value of dataParTasksPerLocale config const
       param rank: int          = // inferred from startIdx argument,
       type idxType             = // inferred from startIdx argument )
@@ -234,7 +234,7 @@ class BlockCyclic : BaseDist {
         var thisRange = targetLocales.domain.dim(i);
         ranges(i) = 0..#thisRange.length;
       }
-      
+
       targetLocDom = {(...ranges)};
       if debugBlockCyclicDist then writeln(targetLocDom);
 
@@ -368,7 +368,7 @@ proc BlockCyclic.getStarts(inds, locid) {
   var R: rank*range(idxType, stridable=true);
   for i in 1..rank {
     var lo, hi: idxType;
-    const domlo = inds.dim(i).low, 
+    const domlo = inds.dim(i).low,
           domhi = inds.dim(i).high;
     const mylo = locDist(locid).myStarts(i).low;
     const mystr = locDist(locid).myStarts(i).stride;
@@ -386,7 +386,7 @@ proc BlockCyclic.getStarts(inds, locid) {
       }
     } else {
       halt("BLC: need to handle domain low less than lowIdx");
-        }     
+        }
       } else {
         lo = domlo;
         hi = domhi;
@@ -425,7 +425,7 @@ proc BlockCyclic.idxToLocaleInd(ind: rank*idxType) where rank != 1 {
   var locInd: rank*int;
   for param i in 1..rank {
     const ind0 = ind(i) - lowIdx(i);
-    locInd(i) = ((ind0 / blocksize(i)) % targetLocDom.dim(i).length): int; 
+    locInd(i) = ((ind0 / blocksize(i)) % targetLocDom.dim(i).length): int;
   }
   return locInd;
 }
@@ -593,11 +593,6 @@ proc BlockCyclicDom.dsiBuildArray(type eltType) {
   return arr;
 }
 
-proc BlockCyclicDom.dsiNumIndices return whole.numIndices;
-proc BlockCyclicDom.dsiLow return whole.low;
-proc BlockCyclicDom.dsiHigh return whole.high;
-proc BlockCyclicDom.dsiStride return whole.stride;
-
 //
 // INTERFACE NOTES: Could we make setIndices() for a rectangular
 // domain take a domain rather than something else?
@@ -747,13 +742,13 @@ proc LocBlockCyclicDom.enumerateBlocks() {
         lo = i;
       else
         lo = i(j);
-      write(lo, "..", min(lo + globDom.dist.blocksize(j)-1, 
+      write(lo, "..", min(lo + globDom.dist.blocksize(j)-1,
                           globDom.whole.dim(j).high));
     }
     writeln("}");
-  } 
+  }
 }
-  
+
 
 //
 // queries for this locale's number of indices, low, and high bounds

--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -672,8 +672,6 @@ proc BlockDom.dsiDims() return whole.dims();
 
 proc BlockDom.dsiDim(d: int) return whole.dim(d);
 
-/* proc BlockDom.dsiDim(param d: int) return whole.dim(d); */
-
 // stopgap to avoid accessing locDoms field (and returning an array)
 proc BlockDom.getLocDom(localeIdx) return locDoms(localeIdx);
 

--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -672,7 +672,7 @@ proc BlockDom.dsiDims() return whole.dims();
 
 proc BlockDom.dsiDim(d: int) return whole.dim(d);
 
-proc BlockDom.dsiDim(param d: int) return whole.dim(d);
+/* proc BlockDom.dsiDim(param d: int) return whole.dim(d); */
 
 // stopgap to avoid accessing locDoms field (and returning an array)
 proc BlockDom.getLocDom(localeIdx) return locDoms(localeIdx);

--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -802,14 +802,6 @@ proc BlockDom.dsiBuildArray(type eltType) {
   return arr;
 }
 
-proc BlockDom.dsiNumIndices return whole.numIndices;
-proc BlockDom.dsiLow return whole.low;
-proc BlockDom.dsiHigh return whole.high;
-proc BlockDom.dsiStride return whole.stride;
-proc BlockDom.dsiAlignedLow return whole.alignedLow;
-proc BlockDom.dsiAlignedHigh return whole.alignedHigh;
-proc BlockDom.dsiAlignment return whole.alignment;
-
 //
 // INTERFACE NOTES: Could we make dsiSetIndices() for a rectangular
 // domain take a domain rather than something else?

--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -1,15 +1,15 @@
 /*
  * Copyright 2004-2018 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -208,7 +208,7 @@ The ``Block`` class initializer is defined as follows:
 
     proc Block.init(
       boundingBox: domain,
-      targetLocales: [] locale  = Locales, 
+      targetLocales: [] locale  = Locales,
       dataParTasksPerLocale     = // value of  dataParTasksPerLocale      config const,
       dataParIgnoreRunningTasks = // value of  dataParIgnoreRunningTasks  config const,
       dataParMinGranularity     = // value of  dataParMinGranularity      config const,
@@ -440,7 +440,7 @@ proc Block.init(boundingBox: domain,
     compilerError("specified Block rank != rank of specified bounding box");
   if idxType != boundingBox.idxType then
     compilerError("specified Block index type != index type of specified bounding box");
-  if rank != 2 && isCSType(sparseLayoutType) then 
+  if rank != 2 && isCSType(sparseLayoutType) then
     compilerError("CS layout is only supported for 2 dimensional domains");
 
   if boundingBox.size == 0 then
@@ -671,6 +671,8 @@ proc BlockDom.dsiDisplayRepresentation() {
 proc BlockDom.dsiDims() return whole.dims();
 
 proc BlockDom.dsiDim(d: int) return whole.dim(d);
+
+proc BlockDom.dsiDim(param d: int) return whole.dim(d);
 
 // stopgap to avoid accessing locDoms field (and returning an array)
 proc BlockDom.getLocDom(localeIdx) return locDoms(localeIdx);

--- a/modules/dists/CyclicDist.chpl
+++ b/modules/dists/CyclicDist.chpl
@@ -493,18 +493,6 @@ proc CyclicDom.dsiDisplayRepresentation() {
   dist.dsiDisplayRepresentation();
 }
 
-proc CyclicDom.dsiLow return whole.low;
-
-proc CyclicDom.dsiHigh return whole.high;
-
-proc CyclicDom.dsiAlignedLow return whole.alignedLow;
-
-proc CyclicDom.dsiAlignedHigh return whole.alignedHigh;
-
-proc CyclicDom.dsiAlignment return whole.alignment;
-
-proc CyclicDom.dsiStride return whole.stride;
-
 proc CyclicDom.dsiMember(i) return whole.member(i);
 
 proc CyclicDom.dsiIndexOrder(i) return whole.indexOrder(i);

--- a/modules/dists/DimensionalDist2D.chpl
+++ b/modules/dists/DimensionalDist2D.chpl
@@ -755,7 +755,6 @@ override proc DimensionalDom.dsiMyDist() return dist;
 
 proc DimensionalDom.dsiDims()             return whole.dims();
 proc DimensionalDom.dsiDim(d)             return whole.dim(d);
-/* proc DimensionalDom.dsiDim(param d)       return whole.dim(d); */
 proc DimensionalDom.dsiLow                return whole.low;
 proc DimensionalDom.dsiHigh               return whole.high;
 proc DimensionalDom.dsiStride             return whole.stride;

--- a/modules/dists/DimensionalDist2D.chpl
+++ b/modules/dists/DimensionalDist2D.chpl
@@ -1,15 +1,15 @@
 /*
  * Copyright 2004-2018 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -755,7 +755,7 @@ override proc DimensionalDom.dsiMyDist() return dist;
 
 proc DimensionalDom.dsiDims()             return whole.dims();
 proc DimensionalDom.dsiDim(d)             return whole.dim(d);
-proc DimensionalDom.dsiDim(param d)       return whole.dim(d);
+/* proc DimensionalDom.dsiDim(param d)       return whole.dim(d); */
 proc DimensionalDom.dsiLow                return whole.low;
 proc DimensionalDom.dsiHigh               return whole.high;
 proc DimensionalDom.dsiStride             return whole.stride;

--- a/modules/dists/DimensionalDist2D.chpl
+++ b/modules/dists/DimensionalDist2D.chpl
@@ -755,10 +755,6 @@ override proc DimensionalDom.dsiMyDist() return dist;
 
 proc DimensionalDom.dsiDims()             return whole.dims();
 proc DimensionalDom.dsiDim(d)             return whole.dim(d);
-proc DimensionalDom.dsiLow                return whole.low;
-proc DimensionalDom.dsiHigh               return whole.high;
-proc DimensionalDom.dsiStride             return whole.stride;
-proc DimensionalDom.dsiNumIndices         return whole.numIndices;
 proc DimensionalDom.dsiMember(indexx)     return whole.member(indexx);
 proc DimensionalDom.dsiIndexOrder(indexx) return whole.indexOrder(indexx);
 

--- a/modules/dists/StencilDist.chpl
+++ b/modules/dists/StencilDist.chpl
@@ -1,15 +1,15 @@
 /*
  * Copyright 2004-2018 Cray Inc.
  * Other additional copyright holders may be indicated within.
- * 
+ *
  * The entirety of this work is licensed under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
- * 
+ *
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -129,7 +129,7 @@ config param disableStencilLazyRAD = defaultDisableLazyRADOpt;
   elements. The user must manually refresh these caches after writes by calling
   the ``updateFluff`` method. Otherwise, reading and writing array elements
   behaves the same as a Block-distributed array.
-  
+
   The indices are partitioned in the same way as the :mod:`Block <BlockDist>`
   distribution.
 
@@ -176,11 +176,11 @@ config param disableStencilLazyRAD = defaultDisableLazyRADOpt;
   The ``periodic`` functionality is disabled by default.
 
   .. note::
-  
+
      Note that this domain does not currently handle indices outside of
      the expanded bounding box, so a user must manually wrap periodic indices
      themselves.
-  
+
   Iterating directly over a Stencil-distributed domain or array will only yield
   indices and elements within the ``boundingBox``.
 
@@ -765,11 +765,6 @@ proc StencilDom.dsiBuildArray(type eltType) {
   arr.setup();
   return arr;
 }
-
-proc StencilDom.dsiNumIndices return whole.numIndices;
-proc StencilDom.dsiLow return whole.low;
-proc StencilDom.dsiHigh return whole.high;
-proc StencilDom.dsiStride return whole.stride;
 
 //
 // INTERFACE NOTES: Could we make dsiSetIndices() for a rectangular

--- a/modules/internal/ArrayViewRankChange.chpl
+++ b/modules/internal/ArrayViewRankChange.chpl
@@ -207,6 +207,8 @@ module ArrayViewRankChange {
       chpl_assignDomainWithGetSetIndices(this, rhs);
     }
 
+    proc dsiDim(d) return this.upDom.dsiDim(d);
+
     iter these() {
       if chpl__isDROrDRView(downDom) {
         for i in upDom do

--- a/modules/internal/ArrayViewReindex.chpl
+++ b/modules/internal/ArrayViewReindex.chpl
@@ -121,7 +121,7 @@ module ArrayViewReindex {
       else
         return distInst;
     }
-    
+
     //
     // TODO: If we put this expression into the variable declaration
     // above, we get a memory leak.  File a future against this?
@@ -177,6 +177,8 @@ module ArrayViewReindex {
       downdomInst = downdomLoc._instance;
       ownsDownDomInst = true;
     }
+
+    proc dsiDim(d) return this.updom.dsiDim(d);
 
     iter these() {
       if chpl__isDROrDRView(downdom) {

--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -390,6 +390,23 @@ module ChapelDistribution {
       compilerError("Cannot remove indices from a rectangular domain");
       return 0;
     }
+
+    proc dsiNumIndices {
+      var sum = 1:intIdxType;
+      for param i in 1..rank do
+        sum *= this.dsiDim(i).length;
+      return sum;
+      // WANT: return * reduce (this(1..rank).length);
+    }
+
+    proc intIdxType type {
+      return chpl__idxTypeToIntIdxType(idxType);
+    }
+
+    proc dsiDim(i){
+      halt("Cannot invoke dsiDim on " + (this.type : string) + " instantiation");
+      return 1..0; // dummy
+    }
   }
 
   pragma "use default init"

--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -399,6 +399,94 @@ module ChapelDistribution {
       // WANT: return * reduce (this(1..rank).length);
     }
 
+    proc dsiLow {
+      if rank == 1 {
+        return dsiDim(1).low;
+      } else {
+        var result: rank*idxType;
+        for param i in 1..rank do
+          result(i) = dsiDim(i).low;
+        return result;
+      }
+    }
+
+    proc dsiHigh {
+      if rank == 1 {
+        return dsiDim(1).high;
+      } else {
+        var result: rank*idxType;
+        for param i in 1..rank do
+          result(i) = dsiDim(i).high;
+        return result;
+      }
+    }
+
+    proc dsiAlignedLow {
+      if rank == 1 {
+        return ds(1).alignedLow;
+      } else {
+        var result: rank*idxType;
+        for param i in 1..rank do
+          result(i) = dsiDim(i).alignedLow;
+        return result;
+      }
+    }
+
+    proc dsiAlignedHigh {
+      if rank == 1 {
+        return dsiDim(1).alignedHigh;
+      } else {
+        var result: rank*idxType;
+        for param i in 1..rank do
+          result(i) = dsiDim(i).alignedHigh;
+        return result;
+      }
+    }
+
+    proc dsiStride {
+      if rank == 1 {
+        return dsiDim(1).stride;
+      } else {
+        var result: rank*chpl__signedType(intIdxType);
+        for param i in 1..rank do
+          result(i) = dsiDim(i).stride;
+        return result;
+      }
+    }
+
+    proc dsiAlignment {
+      if rank == 1 {
+        return dsiDim(1).alignment;
+      } else {
+        var result: rank*idxType;
+        for param i in 1..rank do
+          result(i) = dsiDim(i).alignment;
+        return result;
+      }
+    }
+
+    proc dsiFirst {
+      if rank == 1 {
+        return dsiDim(1).first;
+      } else {
+        var result: rank*idxType;
+        for param i in 1..rank do
+          result(i) = dsiDim(i).first;
+        return result;
+      }
+    }
+
+    proc dsiLast {
+      if rank == 1 {
+        return dsiDim(1).last;
+      } else {
+        var result: rank*idxType;
+        for param i in 1..rank do
+          result(i) = dsiDim(i).last;
+        return result;
+      }
+    }
+
     proc intIdxType type {
       return chpl__idxTypeToIntIdxType(idxType);
     }

--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -423,7 +423,7 @@ module ChapelDistribution {
 
     proc dsiAlignedLow {
       if rank == 1 {
-        return ds(1).alignedLow;
+        return dsiDim(1).alignedLow;
       } else {
         var result: rank*idxType;
         for param i in 1..rank do
@@ -491,9 +491,8 @@ module ChapelDistribution {
       return chpl__idxTypeToIntIdxType(idxType);
     }
 
-    proc dsiDim(d){
+    proc dsiDim(d) : range(idxType, BoundedRangeType.bounded, stridable) {
       halt("Cannot invoke dsiDim on " + (this.type : string) + " instantiation");
-      return 1..0; // dummy
     }
 
     // optional, is this necessary? probably not now that

--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -494,9 +494,6 @@ module ChapelDistribution {
     proc dsiDim(d) : range(idxType, BoundedRangeType.bounded, stridable) {
       halt("Cannot invoke dsiDim on " + (this.type : string) + " instantiation");
     }
-    /* proc dsiDim(param d : int) : range(idxType, BoundedRangeType.bounded, stridable) {
-      halt("Cannot invoke dsiDim on " + (this.type : string) + " instantiation");
-    } */
   }
 
   pragma "use default init"

--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -494,12 +494,8 @@ module ChapelDistribution {
     proc dsiDim(d) : range(idxType, BoundedRangeType.bounded, stridable) {
       halt("Cannot invoke dsiDim on " + (this.type : string) + " instantiation");
     }
-
-    // optional, is this necessary? probably not now that
-    // homogeneous tuples are implemented as C vectors.
-    /* proc dsiDim(param d : int){
-      compilerError("Cannot invoke dsiDim on " + (this.type : string) + " instantiation");
-      return 1..0; // dummy
+    /* proc dsiDim(param d : int) : range(idxType, BoundedRangeType.bounded, stridable) {
+      halt("Cannot invoke dsiDim on " + (this.type : string) + " instantiation");
     } */
   }
 

--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -392,9 +392,10 @@ module ChapelDistribution {
     }
 
     proc dsiNumIndices {
+      compilerWarning((this.type:string) + ".dsiNumIndices");
       var sum = 1:intIdxType;
-      for param i in 1..rank do
-        sum *= this.dsiDim(i).length;
+      for d in 1..rank do
+        sum *= dsiDim(d).length;
       return sum;
       // WANT: return * reduce (this(1..rank).length);
     }
@@ -403,10 +404,17 @@ module ChapelDistribution {
       return chpl__idxTypeToIntIdxType(idxType);
     }
 
-    proc dsiDim(i){
-      halt("Cannot invoke dsiDim on " + (this.type : string) + " instantiation");
+    proc dsiDim(d){
+      compilerError("Cannot invoke dsiDim on " + (this.type : string) + " instantiation");
       return 1..0; // dummy
     }
+
+    // optional, is this necessary? probably not now that
+    // homogeneous tuples are implemented as C vectors.
+    /* proc dsiDim(param d : int){
+      compilerError("Cannot invoke dsiDim on " + (this.type : string) + " instantiation");
+      return 1..0; // dummy
+    } */
   }
 
   pragma "use default init"

--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -392,7 +392,6 @@ module ChapelDistribution {
     }
 
     proc dsiNumIndices {
-      compilerWarning((this.type:string) + ".dsiNumIndices");
       var sum = 1:intIdxType;
       for d in 1..rank do
         sum *= dsiDim(d).length;
@@ -405,7 +404,7 @@ module ChapelDistribution {
     }
 
     proc dsiDim(d){
-      compilerError("Cannot invoke dsiDim on " + (this.type : string) + " instantiation");
+      halt("Cannot invoke dsiDim on " + (this.type : string) + " instantiation");
       return 1..0; // dummy
     }
 

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -106,9 +106,9 @@ module DefaultRectangular {
       this.dist = dist;
     }
 
-    proc intIdxType type {
+    /* proc intIdxType type {
       return chpl__idxTypeToIntIdxType(idxType);
-    }
+    } */
 
     override proc dsiMyDist() {
       return dist;
@@ -503,13 +503,13 @@ module DefaultRectangular {
     proc dsiDim(param d : int)
       return ranges(d);
 
-    proc dsiNumIndices {
+    /* proc dsiNumIndices {
       var sum = 1:intIdxType;
       for param i in 1..rank do
         sum *= ranges(i).length;
       return sum;
       // WANT: return * reduce (this(1..rank).length);
-    }
+    } */
 
     proc dsiLow {
       if rank == 1 {
@@ -647,7 +647,7 @@ module DefaultRectangular {
   }
 
   // helper routines for converting tuples of integers into tuple indices
-  
+
   inline proc chpl__intToIdx(type idxType, i: integral, j ...) {
     const first = chpl__intToIdx(idxType, i);
     const rest = chpl__intToIdx(idxType, (...j));

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -497,10 +497,6 @@ module DefaultRectangular {
 
     override proc dsiDim(d : int) return ranges(d);
 
-    // optional, is this necessary? probably not now that
-    // homogeneous tuples are implemented as C vectors.
-    /* override proc dsiDim(param d : int) return ranges(d); */
-
     /* proc dsiNumIndices {
       var sum = 1:intIdxType;
       for param i in 1..rank do

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -509,7 +509,7 @@ module DefaultRectangular {
       // WANT: return * reduce (this(1..rank).length);
     } */
 
-    proc dsiLow {
+    /* proc dsiLow {
       if rank == 1 {
         return ranges(1).low;
       } else {
@@ -595,7 +595,7 @@ module DefaultRectangular {
           result(i) = ranges(i).last;
         return result;
       }
-    }
+    } */
 
     proc dsiBuildArray(type eltType) {
       return new unmanaged DefaultRectangularArr(eltType=eltType, rank=rank, idxType=idxType,

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -495,13 +495,11 @@ module DefaultRectangular {
     proc dsiDims()
       return ranges;
 
-    proc dsiDim(d : int)
-      return ranges(d);
+    override proc dsiDim(d : int) return ranges(d);
 
     // optional, is this necessary? probably not now that
     // homogeneous tuples are implemented as C vectors.
-    proc dsiDim(param d : int)
-      return ranges(d);
+    /* override proc dsiDim(param d : int) return ranges(d); */
 
     /* proc dsiNumIndices {
       var sum = 1:intIdxType;

--- a/modules/internal/ExternalArray.chpl
+++ b/modules/internal/ExternalArray.chpl
@@ -158,14 +158,6 @@ module ExternalArray {
       return domRange;
     }
 
-    // Necessary?
-    /* proc dsiDim(param d: int) {
-      if (d != rank) {
-        halt("domains over external arrays have only one dimension");
-      }
-      return dsiGetIndices();
-    } */
-
     proc dsiDims()
       return dsiGetIndices();
 

--- a/modules/internal/ExternalArray.chpl
+++ b/modules/internal/ExternalArray.chpl
@@ -159,12 +159,12 @@ module ExternalArray {
     }
 
     // Necessary?
-    proc dsiDim(param d: int) {
+    /* proc dsiDim(param d: int) {
       if (d != rank) {
         halt("domains over external arrays have only one dimension");
       }
       return dsiGetIndices();
-    }
+    } */
 
     proc dsiDims()
       return dsiGetIndices();
@@ -187,7 +187,7 @@ module ExternalArray {
     type eltType;
 
     const dom;
-    
+
     const _ArrInstance: chpl_external_array;
     const elts = _ArrInstance.elts: _ddata(eltType);
 

--- a/test/distributions/dm/n.chpl
+++ b/test/distributions/dm/n.chpl
@@ -280,7 +280,7 @@ proc WrapperRectDom.dsiMyDist() return dist;
 
 proc WrapperRectDom.dsiDims()             return whole.dims();
 proc WrapperRectDom.dsiDim(d)             return whole.dim(d);
-proc WrapperRectDom.dsiDim(param d)       return whole.dim(d);
+/* proc WrapperRectDom.dsiDim(param d)       return whole.dim(d); */
 proc WrapperRectDom.dsiLow                return whole.low;
 proc WrapperRectDom.dsiHigh               return whole.high;
 proc WrapperRectDom.dsiStride             return whole.stride;

--- a/test/distributions/dm/n.chpl
+++ b/test/distributions/dm/n.chpl
@@ -280,7 +280,6 @@ proc WrapperRectDom.dsiMyDist() return dist;
 
 proc WrapperRectDom.dsiDims()             return whole.dims();
 proc WrapperRectDom.dsiDim(d)             return whole.dim(d);
-/* proc WrapperRectDom.dsiDim(param d)       return whole.dim(d); */
 proc WrapperRectDom.dsiLow                return whole.low;
 proc WrapperRectDom.dsiHigh               return whole.high;
 proc WrapperRectDom.dsiStride             return whole.stride;


### PR DESCRIPTION
Resolves #9942.

These methods have been removed from DefaultRectangularDomain and moved to BaseRectangularDomain:
+ dsiNumIndices
+ dsiLow
+ dsiHigh
+ dsiStride
+ dsiAlignment
+ dsiFirst
+ dsiLast
+ dsiAlignedLow
+ dsiAlignedHigh

They retain the same functionality by invoking `dsiDim( d )` in place of `this.ranges( d )`.

Any class inheriting from BaseRectangularDomain has had these methods removed if they are redundant.

`BaseRectangularDom.dsiDim( d ) : range( idxType, Bounded, stridable )` has been added as a halting-abstract method added to BaseRectangularDomain.

All definitions of `dsiDim( param d )` has also been removed. This required modifying one test (distributions/dm/n.chpl)

No changes were made to any sparse domains, as these kinds of methods were already pushed up to BaseSparseDomImpl.
