### PR TITLE
Fix instantiation point for serialization functions

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -8085,7 +8085,13 @@ static FnSymbol* resolveNormalSerializer(CallExpr* call) {
 
   block->remove();
 
-  return call->resolvedFunction();
+  FnSymbol* ret = call->resolvedFunction();
+
+  if (ret != NULL) {
+    ret->instantiationPoint = chpl_gen_main->body;
+  }
+
+  return ret;
 }
 
 static bool resolveSerializeDeserialize(AggregateType* at) {


### PR DESCRIPTION
This was yet another case in which we resolved a function in a temp block-statement, removed that block, and later tried to use the old instantiation point.

Testing:
- [x] local + futures
- [x] gasnet + futures