### PR TITLE
Skipif some tests

### DIFF
--- a/test/arrays/bradc/sliceViaSingleton.skipif
+++ b/test/arrays/bradc/sliceViaSingleton.skipif
@@ -1,0 +1,4 @@
+# This test exercises bounds checking.
+# Skip it when bounds checking is off.
+COMPOPTS <= --fast
+COMPOPTS <= --no-bounds-checks

--- a/test/users/engin/retInnerFunction.skipif
+++ b/test/users/engin/retInnerFunction.skipif
@@ -1,0 +1,3 @@
+# The failure mode is different under gasnet.
+# Do not test it there, to ensure clean .bad match.
+CHPL_COMM != none


### PR DESCRIPTION
This should fix nightly testing failures:

* This test exercises bounds checking. Skip it when bounds checking is off.

    arrays/bradc/sliceViaSingleton

* The failure mode is different under gasnet, causing .bad mismatch.
  So, do not test it there.

    users/engin/retInnerFunction