### PR TITLE
Mason: Update base files to use error-handling

### DIFF
--- a/test/mason/pkgconfig-tests/SKIPIF
+++ b/test/mason/pkgconfig-tests/SKIPIF
@@ -1,9 +1,22 @@
 #!/bin/bash
 
-# Check if pkg-config is available
-command -v pkg-config 2> /dev/null || echo False && exit
 
-# Check if packages are available
-pkg-config --exists openssl  || echo False && exit
-pkg-config --exists zlib || echo False && exit
+skip="False"
+zlibcall= $(pkg-config zlib --exists)
+zlib=$?
+if  [ $zlib = 0 ] ; then
+    skip="False"
+else
+    skip="True"
+fi
 
+opensslCall= $(pkg-config openssl --exists)
+openssl=$?
+
+if [ $openssl = 0 ] ; then
+    skip="False"
+else
+    skip="True"
+fi
+
+echo "$skip"

--- a/tools/mason/MasonNew.chpl
+++ b/tools/mason/MasonNew.chpl
@@ -79,7 +79,7 @@ proc masonNew(args) throws {
 
 /* Return 'true' for valid identifiers according to Chapel parser/spec,
    otherwise 'false' */
-proc isIdentifier(name:string) {
+private proc isIdentifier(name:string) {
 
   // Identifiers can't be empty
   if name == "" then
@@ -125,13 +125,13 @@ proc InitProject(name, vcs, show) throws {
 }
 
 
-proc gitInit(name: string, show: bool) {
+private proc gitInit(name: string, show: bool) {
   var initialize = "git init -q " + name;
   if show then initialize = "git init " + name;
   runCommand(initialize);
 }
 
-proc addGitIgnore(name: string) {
+private proc addGitIgnore(name: string) {
   var toIgnore = "\ntarget/\nMason.lock";
   var gitIgnore = open(name+"/.gitignore", iomode.cw);
   var GIwriter = gitIgnore.writer();
@@ -154,7 +154,7 @@ proc makeBasicToml(name: string) {
 }
 
 
-proc makeProjectFiles(name: string) {
+private proc makeProjectFiles(name: string) {
   mkdir(name + "/src");
   mkdir(name + "/test");
   const libTemplate = '/* Documentation for ' + name +

--- a/tools/mason/MasonRun.chpl
+++ b/tools/mason/MasonRun.chpl
@@ -23,7 +23,7 @@ use MasonUtils;
 use FileSystem;
 use TOML;
 
-proc masonRun(args) {
+proc masonRun(args) throws {
 
   try! {
 
@@ -71,18 +71,20 @@ proc masonRun(args) {
         masonBuild(args);
         runCommand(command);
       }
-      else writeln("Mason could not find your Mason.lock file");
+      else {
+        throw new MasonError("Mason could not find your Mason.toml file");
+      }
 
       // Close memory
       toParse.close();
     }
     else {
-      writeln("Mason could not find the compiled program");
-      exit();
+      throw new MasonError("Mason could not find the compiled program");
     }
   }
   catch e: MasonError {
-    writeln(e.message());
+    stderr.writeln(e.message());
+    exit(1);
   }
 }
 

--- a/tools/mason/MasonSystem.chpl
+++ b/tools/mason/MasonSystem.chpl
@@ -53,6 +53,7 @@ proc masonSystem(args) {
   }
   catch e: MasonError {
     stderr.writeln(e.message());
+    exit(1);
   }
 }
 
@@ -160,9 +161,11 @@ proc printPkgPc(args) throws {
     }
     catch e: FileNotFoundError {
       stderr.writeln("Package exists but Mason could not find it's .pc file");
+      exit(1);
     }
     catch e: MasonError {
       stderr.writeln(e.message());
+      exit(1);
     }
   }
 }
@@ -243,6 +246,7 @@ proc getPCDeps(exDeps: unmanaged Toml) {
     }
     catch e: MasonError {
       stderr.writeln(e.message());
+      exit(1);
     }
   }
   return exDepTree;

--- a/tools/mason/MasonTest.chpl
+++ b/tools/mason/MasonTest.chpl
@@ -60,7 +60,7 @@ proc masonTest(args) {
   runTests(show, run, parallel);
 }
 
-private proc runTests(show: bool, run: bool, parallel: bool) {
+private proc runTests(show: bool, run: bool, parallel: bool) throws {
 
   try! {
 
@@ -106,7 +106,7 @@ private proc runTests(show: bool, run: bool, parallel: bool) {
         const compilation = runWithStatus(compCommand);
 
         if compilation != 0 {
-          writeln("compilation failed for " + test);
+          stderr.writeln("compilation failed for " + test);
         }
         else {
           if show || !run then writeln("compiled ", test, " successfully");
@@ -132,11 +132,12 @@ private proc runTests(show: bool, run: bool, parallel: bool) {
       }
     }
     else {
-      writeln("No tests were found in /test");
+      throw new MasonError("No tests were found in /test");
     }
     toParse.close();
   }
   catch e: MasonError {
+    stderr.writeln(e.message());
     exit(1);
   }
 }

--- a/tools/mason/MasonUpdate.chpl
+++ b/tools/mason/MasonUpdate.chpl
@@ -77,7 +77,7 @@ proc UpdateLock(args: [] string, tf="Mason.toml", lf="Mason.lock") {
 
   }
   catch e: MasonError {
-    writeln(e.message());
+    stderr.writeln(e.message());
   }
   return (tf, lf);
 }
@@ -255,7 +255,7 @@ proc chplVersionError(brick:Toml) {
    from the Mason.toml. Starts at the root of the
    project and continues down dep tree recursively
    until each dep is recorded */
-proc createDepTree(root: unmanaged Toml) {
+private proc createDepTree(root: unmanaged Toml) {
   var dp: domain(string);
   var dps: [dp] unmanaged Toml;
   var depTree: unmanaged Toml = dps;
@@ -306,7 +306,7 @@ proc createDepTree(root: unmanaged Toml) {
   return depTree;
 }
 
-proc createDepTrees(depTree: unmanaged Toml, deps: [?d] unmanaged Toml, name: string) : unmanaged Toml {
+private proc createDepTrees(depTree: unmanaged Toml, deps: [?d] unmanaged Toml, name: string) : unmanaged Toml {
   var depList: [1..0] unmanaged Toml;
   while deps.domain.size > 0 {
     var dep = deps[deps.domain.first];
@@ -356,7 +356,7 @@ proc createDepTrees(depTree: unmanaged Toml, deps: [?d] unmanaged Toml, name: st
    - differing major versions are not allowed
    - Always newest minor and patch
    - in accordance with semantic versioning  */
-proc IVRS(A: Toml, B: Toml) {
+private proc IVRS(A: Toml, B: Toml) {
   const name = A["name"].s;
   const (okA, Alo, Ahi) = verifyChapelVersion(A);
   const (okB, Blo, Bhi) = verifyChapelVersion(B);
@@ -407,7 +407,7 @@ proc IVRS(A: Toml, B: Toml) {
 
 
 /* Returns the Mason.toml for each dep listed as a Toml */
-proc getManifests(deps: [?dom] (string, unmanaged Toml)) {
+private proc getManifests(deps: [?dom] (string, unmanaged Toml)) {
   var manifests: [1..0] unmanaged Toml;
   for dep in deps {
     var name = dep(1);
@@ -421,7 +421,7 @@ proc getManifests(deps: [?dom] (string, unmanaged Toml)) {
 
 /* Responsible for parsing the Mason.toml to be given
    back to a call from getManifests */
-proc retrieveDep(name: string, version: string) {
+private proc retrieveDep(name: string, version: string) {
   for cached in MASON_CACHED_REGISTRY {
     const tomlPath = cached + "/Bricks/"+name+"/"+version+".toml";
     if isFile(tomlPath) {
@@ -437,7 +437,7 @@ proc retrieveDep(name: string, version: string) {
 
 /* Checks if a dependency has deps; if so, the
    dependencies are returned as a (string, Toml) */
-proc getDependencies(tomlTbl: unmanaged Toml) {
+private proc getDependencies(tomlTbl: unmanaged Toml) {
   var depsD: domain(1);
   var deps: [depsD] (string, unmanaged Toml);
   for k in tomlTbl.D {

--- a/tools/mason/MasonUpdate.chpl
+++ b/tools/mason/MasonUpdate.chpl
@@ -78,6 +78,7 @@ proc UpdateLock(args: [] string, tf="Mason.toml", lf="Mason.lock") {
   }
   catch e: MasonError {
     stderr.writeln(e.message());
+    exit(1);
   }
   return (tf, lf);
 }

--- a/tools/mason/mason.chpl
+++ b/tools/mason/mason.chpl
@@ -70,7 +70,7 @@ proc main(args: [] string) throws {
   try! {
     if args.size < 2 {
       masonHelp();
-      exit();
+      exit(0);
     }
 
     select (args[1]) {

--- a/tools/mason/mason.chpl
+++ b/tools/mason/mason.chpl
@@ -98,7 +98,7 @@ proc main(args: [] string) throws {
     }
   }
   catch e: MasonError {
-    writeln(e.message());
+    stderr.writeln(e.message());
     exit(1);
   }
 }
@@ -112,7 +112,7 @@ proc masonClean() {
     runCommand('rm -rf ' + projectHome + '/target');
   }
   catch e: MasonError {
-    writeln(e.message());
+    stderr.writeln(e.message());
   }
 }
 
@@ -136,7 +136,7 @@ proc masonDoc(args) {
     }
   }
   catch e: MasonError {
-    writeln(e.message());
+    stderr.writeln(e.message());
   }
 }
 

--- a/tools/mason/mason.chpl
+++ b/tools/mason/mason.chpl
@@ -66,35 +66,40 @@ Full documentation is located in the chapel release in $CHPL_HOME/doc/rst/tools/
 
 
 
-proc main(args: [] string) {
-  if args.size < 2 {
-    masonHelp();
-    exit();
-  }
-
-  select (args[1]) {
-    when 'new' do masonNew(args);
-    when 'build' do masonBuild(args);
-    when 'update' do UpdateLock(args);
-    when 'run' do masonRun(args);
-    when 'search' do masonSearch(args);
-    when 'test' do masonTest(args);
-    when 'env' do masonEnv(args);
-    when 'doc' do masonDoc(args);
-    when 'clean' do masonClean();
-    when 'system' do masonSystem(args);
-    when 'help' do masonHelp();
-    when 'version' do printVersion();
-    when '--list' do masonList();
-    when '-h' do masonHelp();
-    when '--help' do masonHelp();
-    when '-V' do printVersion();
-    when '--version' do printVersion();
-    otherwise {
-      writeln('error: no such subcommand');
-      writeln('try mason --help');
+proc main(args: [] string) throws {
+  try! {
+    if args.size < 2 {
+      masonHelp();
       exit();
     }
+
+    select (args[1]) {
+      when 'new' do masonNew(args);
+      when 'build' do masonBuild(args);
+      when 'update' do UpdateLock(args);
+      when 'run' do masonRun(args);
+      when 'search' do masonSearch(args);
+      when 'system' do masonSystem(args);
+      when 'test' do masonTest(args);
+      when 'env' do masonEnv(args);
+      when 'doc' do masonDoc(args);
+      when 'clean' do masonClean();
+      when 'help' do masonHelp();
+      when 'version' do printVersion();
+      when '--list' do masonList();
+      when '-h' do masonHelp();
+      when '--help' do masonHelp();
+      when '-V' do printVersion();
+      when '--version' do printVersion();
+      otherwise {
+        throw new MasonError('No such subcommand \ntry mason --help');
+        exit(1);
+      }
+    }
+  }
+  catch e: MasonError {
+    writeln(e.message());
+    exit(1);
   }
 }
 


### PR DESCRIPTION
Many of the files that make up Mason have already had the halts/writeln + exits removed and replaced with error handling. This PR updates the rest of the files to use error-handling.

This PR also make some methods private that should have been private in the first place. 

Completion of this issue will resolve #8868 as #10406 as already been merged.