### PR TITLE
Strengthen retInnerFunction.skipif

### DIFF
--- a/test/users/engin/retInnerFunction.skipif
+++ b/test/users/engin/retInnerFunction.skipif
@@ -1,3 +1,6 @@
-# The failure mode is different under gasnet.
+# The failure mode may differ on certain configurations.
 # Do not test it there, to ensure clean .bad match.
 CHPL_COMM != none
+CHPL_LOCALE_MODEL != flat
+COMPOPTS <= --baseline
+COMPOPTS <= --no-local


### PR DESCRIPTION
The future test:

    users/engin/retInnerFunction

#10010 caused this test to have different failure modes
under different configurations. #10431 reacted to that
by skipif-ing it under gasnet.

Before #10431, since this test was a .future and did not have
a .skipif, it was tested only under linux64 and gasnet.

With the addition of a .skipif in #10431, this test is now
tested under tons of configurations. Rule out the ones
with differing failure modes.