### PR TITLE
Add join() that takes iterator expressions

### DIFF
--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -960,6 +960,20 @@ module String {
       return _join(S);
     }
 
+    pragma "no doc"
+    proc join(ir: _iteratorRecord) {
+      var s: string;
+      var first: bool = true;
+      for i in ir {
+        if first then
+          first = false;
+        else
+          s += this;
+        s += i;
+      }
+      return s;
+    }
+
     proc _join(const ref S) : string where isTuple(S) || isArray(S) {
       if S.size == 0 {
         return '';

--- a/test/types/string/methods/join-loop-expr.chpl
+++ b/test/types/string/methods/join-loop-expr.chpl
@@ -1,0 +1,14 @@
+var list = ["one", "two", "three"];
+
+writeln(",".join([l in list] l));
+writeln(",".join(forall l in list do l));
+writeln(",".join(for l in list do l));
+
+var x = [l in list] l;
+writeln(",".join(x));
+
+var v = [i in 1..3] (i : string);
+writeln( "=", "".join( v ), "=" );
+writeln( "=", "".join( ([i in 1..3] (i : string)) ), "=" );
+writeln( "=", "-".join( ([i in 1..3] (i : string)) ), "=" );
+

--- a/test/types/string/methods/join-loop-expr.good
+++ b/test/types/string/methods/join-loop-expr.good
@@ -1,0 +1,7 @@
+one,two,three
+one,two,three
+one,two,three
+one,two,three
+=123=
+=123=
+=1-2-3=


### PR DESCRIPTION
Issue #9372 points out that, for people coming from Python, Chapel's
join() works in strange ways when called with for[all] expressions.  In
the discussion, I postulated that an overload which took an iterator
expression could potentially be provided to address this confusion.
This PR adds such an overload (with no attempts to optimize it for
parallelism or minimizing string operation overheads).  It also adds a
test case capturing the original cases filed on issue #9372.

I did not document the new overload for now because of the fact
that `_iteratorRecord` isn't a user-facing type.  Ultimately, it seems
that we'd want to write this routine to take types that satisfy the
`iterable` interface once we have constrained generics, traits, or the
like.

Resolves #9372.