### PR TITLE
Resolve concrete user functions

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -8019,7 +8019,10 @@ static void resolveExports() {
     }
 
     if (fn->hasFlag(FLAG_EXPORT) ||
-        (!fn->hasFlag(FLAG_GENERIC) && fn->defPoint->getModule()->modTag == MOD_USER)) {
+        (!fn->hasFlag(FLAG_GENERIC) &&
+         fn->defPoint &&
+         fn->defPoint->getModule() &&
+         fn->defPoint->getModule()->modTag == MOD_USER)) {
       SET_LINENO(fn);
 
       resolveSignatureAndFunction(fn);

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -8020,10 +8020,24 @@ static void resolveExports() {
 
     if (fn->hasFlag(FLAG_EXPORT) ||
         (!fn->hasFlag(FLAG_GENERIC) &&
+         !fn->hasFlag(FLAG_RESOLVED) &&
+         !fn->hasFlag(FLAG_INVISIBLE_FN) &&
+         !fn->hasFlag(FLAG_INLINE) &&
+         //         !fn->hasFlag(FLAG_COMPILER_NESTED_FUNCTION)
+         !fn->hasFlag(FLAG_COMPILER_GENERATED) &&
+         // TODO: What chpl_ functions are not marked compiler-generated?
+         (strncmp(fn->name, "chpl_", 5) != 0) &&
          fn->defPoint &&
          fn->defPoint->getModule() &&
          fn->defPoint->getModule()->modTag == MOD_USER)) {
       SET_LINENO(fn);
+      /*
+      printf("---\n");
+      printf("%s\n", fn->name);
+      printf("---\n");
+      viewFlags(fn->id);
+      printf("---\n\n");
+      */
 
       resolveSignatureAndFunction(fn);
     }

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -8018,7 +8018,8 @@ static void resolveExports() {
       continue;
     }
 
-    if (fn->hasFlag(FLAG_EXPORT) == true) {
+    if (fn->hasFlag(FLAG_EXPORT) ||
+        (!fn->hasFlag(FLAG_GENERIC) && fn->defPoint->getModule()->modTag == MOD_USER)) {
       SET_LINENO(fn);
 
       resolveSignatureAndFunction(fn);


### PR DESCRIPTION
This is a quick attempt at a branch that will resolve concrete user functions as proposed in issue #10276.  I have not yet had a chance to run full testing on it, but spot-checking it, it was looking promising.  Something to finish up after vacation (making it a PR to avoid the potential for duplicated effort).

Even if it were to test cleanly, I think we'd want to add flags to extend this support to standard/internal modules (which will be nontrivial because we have error overloads that are concrete) and also potentially to package modules.