### PR TITLE
Skipif for mason test that omits cl argument

### DIFF
--- a/test/mason/masonNewBadName.skipif
+++ b/test/mason/masonNewBadName.skipif
@@ -1,1 +1,20 @@
-suseSkipif
+#!/bin/bash
+
+# Skip this test for SuSE 11 and earlier. It requires an OpenSSL version that
+# is newer than is available on SuSe 11 due to github requirements.
+skip="False"
+if [ -f /etc/SuSE-release ] ; then
+    slesVersion=`sed -n -e 's/VERSION = //p' /etc/SuSE-release`
+    if [ $slesVersion -le 11 ] ; then
+        skip="True"
+    fi
+fi
+
+# Also skip for memleaks testing
+if [ "$CHPL_MEM_LEAK_TESTING" = "true" ]; then
+    skip="True"
+fi
+
+echo "$skip"
+
+


### PR DESCRIPTION
Vass brought to my attention that there was a mason test, masonNewBadName, that errors on `-memleaks` testing due to its purposeful omission of a command line argument. This skipif should skip the test if `-memleaks is thrown`.

