### PR TITLE
Allow undecorated type a=b / type args with --warn-unstable

### DIFF
--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -868,26 +868,47 @@ static Expr* handleUnstableClassType(SymExpr* se) {
     if (TypeSymbol* ts = toTypeSymbol(se->symbol())) {
       if (isClass(ts->type)) {
         bool ok = false;
-        CallExpr* inCall = toCallExpr(se->parentExpr);
-        DefExpr* inDef = toDefExpr(se->parentExpr);
+        CallExpr* pCall = toCallExpr(se->parentExpr);
+        DefExpr* inDef = NULL;
+        CatchStmt* inCatch = NULL;
+        CallExpr* inCall = NULL;
+
+        // Find outer def/catch
+        for (Expr* cur = se; cur != NULL; cur = cur->parentExpr ) {
+          if (CatchStmt* c = toCatchStmt(cur))
+            inCatch = c;
+          if (DefExpr* d = toDefExpr(cur))
+            inDef = d;
+        }
+        // Find outer call, not counting baseExpr
+        for (Expr* cur = se; cur != NULL; cur = cur->parentExpr ) {
+          if (CallExpr* c = toCallExpr(cur))
+            inCall = c;
+          if (CallExpr* p = toCallExpr(cur->parentExpr))
+            if (p->baseExpr == cur)
+              // don't count base expr so we can warn on
+              // var x:MyGenericClass(int).
+              break;
+        }
+
         FnSymbol* inFn = se->getFunction();
-        if (inCall) {
-          if (callSpecifiesClassKind(inCall)) {
+        if (pCall) {
+          if (callSpecifiesClassKind(pCall)) {
             // It's OK, it's decorated
             ok = true;
           }
-          CallExpr* outerCall = toCallExpr(inCall->parentExpr);
+          CallExpr* outerCall = toCallExpr(pCall->parentExpr);
           CallExpr* outerOuterCall = NULL;
           if (outerCall) outerOuterCall = toCallExpr(outerCall->parentExpr);
 
-          if (hasChplManagerArgument(inCall) ||
+          if (hasChplManagerArgument(pCall) ||
               hasChplManagerArgument(outerCall)) {
             ok = true;
           } else if (outerOuterCall && outerCall &&
               callSpecifiesClassKind(outerOuterCall) &&
               outerCall == outerOuterCall->get(1) &&
               outerCall->isPrimitive(PRIM_NEW) &&
-              inCall == outerCall->get(1)) {
+              pCall == outerCall->get(1)) {
             // 'new Owned(SomeClass(int))'
             ok = true;
           } else if (outerOuterCall && callMakesDmap(outerOuterCall)) {
@@ -898,38 +919,37 @@ static Expr* handleUnstableClassType(SymExpr* se) {
             // throw new Error()
             ok = true;
           } else if (outerCall && outerCall->isPrimitive(PRIM_NEW) &&
-                     inCall == outerCall->get(1)) {
+                     pCall == outerCall->get(1)) {
             // 'new SomeClass()'
             // let ok be set as it was above unless changing default
             if (fDefaultUnmanaged) ok = false;
           } else if (outerCall && callSpecifiesClassKind(outerCall) &&
-                     inCall->baseExpr == se) {
+                     pCall->baseExpr == se) {
             // ':borrowed MyGenericClass(int)'
             ok = true;
-          } else if (inCall->baseExpr == se) {
+          } else if (pCall->baseExpr == se) {
             // ':MyGenericClass(int)'
             // let ok be set as it was above unless changing default
             if (fDefaultUnmanaged) ok = false;
           }
-          if (inCall->isNamed(".") &&
-              inCall->get(1) == se) {
+          if (pCall->isNamed(".") &&
+              pCall->get(1) == se) {
             // Another pattern for the above case
             ok = true;
           }
         }
 
-        // Types in catch block specifications are OK
-        {
-          Expr* cur = se;
-          while (cur) {
-            if (CatchStmt* c = toCatchStmt(cur)) {
-              if (c->expr() == inDef) {
-                ok = true;
-                break;
-              }
-            }
-            cur = cur->parentExpr;
-          }
+        if (inDef && inDef->sym->hasFlag(FLAG_TYPE_VARIABLE)) {
+          // Types in type aliases are OK
+          ok = true;
+        } else if (inCatch) {
+          // Types in catch block specifications are OK
+          ok = true;
+        } else if (inCall && !inCall->isPrimitive(PRIM_NEW)) {
+          // typefunction(SomeClass)
+          // typefunction(SomeGenericClass(int))
+          if (!fDefaultUnmanaged)
+            ok = true;
         }
 
         // Types in extern function procs are assumed to

--- a/test/compflags/ferguson/unstable-class.chpl
+++ b/test/compflags/ferguson/unstable-class.chpl
@@ -29,6 +29,9 @@ proc errors() {
   errorsInArgs(x, y, y);
 }
 
+proc okTypeMethod(type t) {
+}
+
 proc ok() {
   var a:MyRecord;
   var b:MyGenericRecord(int);
@@ -48,6 +51,11 @@ proc ok() {
 
   extern proc printf(fmt:c_string, arg:MyClass);
   if debug then printf("%p\n", d);
+
+  okTypeMethod(unmanaged MyClass);
+  okTypeMethod(MyClass); // intentionally allowed
+
+  type okType = MyClass; // intentionally allowed
 }
 
 

--- a/test/compflags/ferguson/unstable-class.good
+++ b/test/compflags/ferguson/unstable-class.good
@@ -13,5 +13,3 @@ unstable-class.chpl:28: warning: undecorated class type MyGenericClass is unstab
 unstable-class.chpl:28: note: use 'unmanaged MyGenericClass' 'owned MyGenericClass', 'borrowed MyGenericClass', or 'shared MyGenericClass'
 unstable-class.chpl:20: warning: undecorated class type MyClass is unstable
 unstable-class.chpl:20: note: use 'unmanaged MyClass' 'owned MyClass', 'borrowed MyClass', or 'shared MyClass'
-unstable-class.chpl:20: warning: undecorated class type MyClass is unstable
-unstable-class.chpl:20: note: use 'unmanaged MyClass' 'owned MyClass', 'borrowed MyClass', or 'shared MyClass'


### PR DESCRIPTION
See for example test/classes/ferguson/class-alias.chpl

``` chapel
class A {
  var x:int;
}

type C = A;

var c = new unmanaged C(1);
writeln(c);
writeln(c.x);

delete c;
```

The code
``` chapel
type C = A
```

no longer raises an error with --warn-unstable. Additionally
`type` arguments can be used without generating a
warning (since they can have a similar role to type aliases).

Resolves #10017

Reviewed by @benharsh - thanks!

- [x] passed full local testing

