### PR TITLE
Add a test to track library mode mentioning the need for a main function

### DIFF
--- a/test/compflags/lydia/library/errorMessage/multiMod/multipleModules.bad
+++ b/test/compflags/lydia/library/errorMessage/multiMod/multipleModules.bad
@@ -1,0 +1,2 @@
+error: a program with multiple user modules requires a main function
+note: alternatively, specify a main module with --main-module

--- a/test/compflags/lydia/library/errorMessage/multiMod/multipleModules.chpl
+++ b/test/compflags/lydia/library/errorMessage/multiMod/multipleModules.chpl
@@ -1,0 +1,7 @@
+module A {
+  export proc bar() { }
+}
+module B {
+  export proc baz() { }
+
+}

--- a/test/compflags/lydia/library/errorMessage/multiMod/multipleModules.compopts
+++ b/test/compflags/lydia/library/errorMessage/multiMod/multipleModules.compopts
@@ -1,0 +1,1 @@
+--library

--- a/test/compflags/lydia/library/errorMessage/multiMod/multipleModules.future
+++ b/test/compflags/lydia/library/errorMessage/multiMod/multipleModules.future
@@ -1,0 +1,2 @@
+error message: shouldn't reference main when compiling with --library
+#10462

--- a/test/compflags/lydia/library/errorMessage/multiMod/multipleModules.good
+++ b/test/compflags/lydia/library/errorMessage/multiMod/multipleModules.good
@@ -1,0 +1,1 @@
+error: a program with multiple user modules must specify its library name

--- a/test/compflags/lydia/library/errorMessage/multiMod/sub_test
+++ b/test/compflags/lydia/library/errorMessage/multiMod/sub_test
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+export CHPL_TEST_NO_USE_O=true
+../../../../../../util/test/sub_test $1


### PR DESCRIPTION
main() doesn't have any special meaning in --library compilation, so it is
confusing to require it when compiling a file with multiple modules.