### PR TITLE
bfs.suppressif when CCE 8.6.3 --fast

### DIFF
--- a/test/studies/parboil/BFS/bfs.suppressif
+++ b/test/studies/parboil/BFS/bfs.suppressif
@@ -1,0 +1,22 @@
+#! /usr/bin/env bash
+#
+# CCE 8.6.3 produces buggy code for this test under --fast.
+#
+case "$COMPOPTS" in
+  (*--fast*|*-O*) true;;   # continue on to check for cce
+  (*) echo 0; exit;;       # no --fast ==> do not suppress
+esac
+
+eval `$CHPL_HOME/util/printchplenv --make`
+
+if [ "$CHPL_MAKE_TARGET_COMPILER" = cray-prgenv-cray -a "$CHPL_MAKE_COMM" = none ]; then
+
+  cce_version=`module list -t 2>&1 | grep "^cce/" | sed -e "s,^cce/,,"`
+
+  case "$cce_version" in
+    (8.6.*)  echo 1; exit;;  # yes, suppress
+    (*)      true;
+  esac
+
+fi
+echo 0


### PR DESCRIPTION
The bfs test fails -performance testing when the generated C code is
compiled with CCE 8.6.3 . We conjecture it is a CCE 8.6 bug, so suppress
the failure.

Bug Details

* The test succeeds when CCE is invoked with -O0 instead of -O3 -hipa2.
* The test succeeds when compiled with cce/8.7.3.
* It comes down to this function in hand-tweaked generated code:
```c
static int32_t getFront(deque_int32_t * this10) {
    int32_t ret;
    int32_t t;
    int64_t call_tmp2;
    _ref_deque_t call_tmp3 = NULL;
    deque_iterator_t call_tmp4;
    _ref_int32_t _ref_tmp_ = NULL;
    t = INT32(0);
    call_tmp2 = sizeof(int32_t);
    call_tmp3 = &((this10)->d);
    call_tmp4 = deque_begin(call_tmp3);
//  _ref_tmp_ = &t;
    deque_it_get_cur(call_tmp2, call_tmp4, &t);
    ret = t;
    return ret;
}
```
where we have in runtime/include/qio/deque.h:

void deque_it_get_cur(const ssize_t item_size, const deque_iterator_t it, void* out) ...

Un-commenting the _ref_tmp_ line in the above changes the behavior of
the executable to be as expected.