### PR TITLE
Fix SPA-perf SPA record

### DIFF
--- a/test/library/packages/LinearAlgebra/performance/SPA-perf.chpl
+++ b/test/library/packages/LinearAlgebra/performance/SPA-perf.chpl
@@ -123,7 +123,7 @@ proc SPAdot(A: [?Adom], B: [?Bdom]) where isCSArr(A) && isCSArr(B) {
   const nnzAB = Adom._value.nnz + Bdom._value.nnz;
   Cdom._value.nnzDom = {1..nnzAB};
 
-  var spa = new _SPA(cols=D.dim(1), eltType=A.eltType);
+  var spa = new _SPA(cols={D.dim(1)}, eltType=A.eltType);
 
   /*
    IR (row)     - nnz-rows  - A.domain._value.startIdx
@@ -159,7 +159,7 @@ proc SPAdot(A: [?Adom], B: [?Bdom]) where isCSArr(A) && isCSArr(B) {
 pragma "no doc"
 /* Sparse-accumulator */
 record _SPA {
-  var cols; // range(?)
+  var cols: domain(1);
   type eltType = int;
   var b: [cols] bool,      // occupation
       w: [cols] eltType,   // values


### PR DESCRIPTION
This test began failing after the initializers change with the error:

```
Error: unresolved call 'chpl__defaultHash(type int(64))'
```

Changing the `cols` field from generic to concrete (`domain(1)`) resolved this error.