### PR TITLE
Update HDF5 file_id instances to be type hid_t

### DIFF
--- a/modules/packages/HDF5.chpl
+++ b/modules/packages/HDF5.chpl
@@ -3438,7 +3438,7 @@ module HDF5 {
     var files: [BlockSpace] ArrayWrapper(eltType, rank);
     forall (f, name) in zip(files, filenames) {
       var locName = name; // copy this string to be local
-      var file_id = C_HDF5.H5Fopen(locName.c_str(), C_HDF5.H5F_ACC_RDONLY, C_HDF5.H5P_DEFAULT);
+      var file_id = C_HDF5.H5Fopen(locName.c_str(), C_HDF5.H5F_ACC_RDONLY, C_HDF5.H5P_DEFAULT): hid_t;
       var dims: [0..#rank] C_HDF5.hsize_t;
       var dsetRank: c_int;
 
@@ -3624,7 +3624,7 @@ module HDF5 {
     param outRank = chunkShape.rank;
     var file_id = C_HDF5.H5Fopen(filename.c_str(),
                                  C_HDF5.H5F_ACC_RDONLY,
-                                 C_HDF5.H5P_DEFAULT);
+                                 C_HDF5.H5P_DEFAULT): hid_t;
     var dataset = C_HDF5.H5Dopen(file_id, dset.c_str(),
                                  C_HDF5.H5P_DEFAULT);
     var dataspace = C_HDF5.H5Dget_space(dataset);

--- a/modules/packages/HDF5.chpl
+++ b/modules/packages/HDF5.chpl
@@ -3438,7 +3438,7 @@ module HDF5 {
     var files: [BlockSpace] ArrayWrapper(eltType, rank);
     forall (f, name) in zip(files, filenames) {
       var locName = name; // copy this string to be local
-      var file_id = C_HDF5.H5Fopen(locName.c_str(), C_HDF5.H5F_ACC_RDONLY, C_HDF5.H5P_DEFAULT): hid_t;
+      var file_id = C_HDF5.H5Fopen(locName.c_str(), C_HDF5.H5F_ACC_RDONLY, C_HDF5.H5P_DEFAULT): C_HDF5.hid_t;
       var dims: [0..#rank] C_HDF5.hsize_t;
       var dsetRank: c_int;
 
@@ -3624,7 +3624,7 @@ module HDF5 {
     param outRank = chunkShape.rank;
     var file_id = C_HDF5.H5Fopen(filename.c_str(),
                                  C_HDF5.H5F_ACC_RDONLY,
-                                 C_HDF5.H5P_DEFAULT): hid_t;
+                                 C_HDF5.H5P_DEFAULT): C_HDF5.hid_t;
     var dataset = C_HDF5.H5Dopen(file_id, dset.c_str(),
                                  C_HDF5.H5P_DEFAULT);
     var dataspace = C_HDF5.H5Dget_space(dataset);
@@ -3793,7 +3793,7 @@ module HDF5 {
         var filenameCopy = filename;
         var file_id = C_HDF5.H5Fopen(filenameCopy.c_str(),
                                      C_HDF5.H5F_ACC_RDONLY,
-                                     C_HDF5.H5P_DEFAULT);
+                                     C_HDF5.H5P_DEFAULT): C_HDF5.hid_t;
         var dataset = C_HDF5.H5Dopen(file_id, dsetName.c_str(),
                                      C_HDF5.H5P_DEFAULT);
         var dataspace = C_HDF5.H5Dget_space(dataset);


### PR DESCRIPTION
After #10246, some instances of `file_id` could be passed to `C_HDF5.H5Fopen()` as an `int(64)`.

Chapel's coercion rules forbid downcasting an `int(64)` to an `int(32)` resulting in an error about calling an internal function (`C_HDF5.H5Fopen()`) to the end-user.

This PR updates instances of `file_id` to be explicitly cast to `C_HDF5.hid_t`.