### PR TITLE
Update llvm.invariant.start emission for records

### DIFF
--- a/compiler/codegen/expr.cpp
+++ b/compiler/codegen/expr.cpp
@@ -3497,7 +3497,7 @@ GenRet CallExpr::codegen() {
 
       // Handle setting LLVM invariant on const records after
       // they are initialized
-      if (this->isNamedAstr(astrInit)) {
+      if (fn->isInitializer()) {
         if (isUserDefinedRecord(get(1)->typeInfo())) {
           if (SymExpr* initedSe = toSymExpr(get(1))) {
             if (initedSe->symbol()->isConstValWillNotChange()) {

--- a/compiler/codegen/expr.cpp
+++ b/compiler/codegen/expr.cpp
@@ -411,7 +411,7 @@ GenRet codegenWideAddrWithAddr(GenRet base, GenRet newAddr, Type* wideType = NUL
 #define USE_TBAA 1
 
 static
-void codegenInvariantStart(llvm::Value *val, llvm::Value *addr)
+void codegenInvariantStart(llvm::Type *valType, llvm::Value *addr)
 {
   GenInfo *info = gGenInfo;
 
@@ -425,8 +425,8 @@ void codegenInvariantStart(llvm::Value *val, llvm::Value *addr)
   const llvm::DataLayout& dataLayout = info->module->getDataLayout();
 
   uint64_t sizeInBytes;
-  if(val->getType()->isSized())
-    sizeInBytes = dataLayout.getTypeSizeInBits(val->getType())/8;
+  if(valType->isSized())
+    sizeInBytes = dataLayout.getTypeSizeInBits(valType)/8;
   else
     return;
 
@@ -477,7 +477,7 @@ llvm::StoreInst* codegenStoreLLVM(llvm::Value* val,
   }
 
   if(addInvariantStart)
-    codegenInvariantStart(val, ptr);
+    codegenInvariantStart(val->getType(), ptr);
 
   return ret;
 }
@@ -3494,6 +3494,25 @@ GenRet CallExpr::codegen() {
           ret.val = converted;
         }
       }
+
+      // Handle setting LLVM invariant on const records after
+      // they are initialized
+      if (this->isNamedAstr(astrInit)) {
+        if (isUserDefinedRecord(get(1)->typeInfo())) {
+          if (SymExpr* initedSe = toSymExpr(get(1))) {
+            if (initedSe->symbol()->isConstValWillNotChange()) {
+              GenRet genSe = args[0];
+              llvm::Value* ptr = genSe.val;
+              INT_ASSERT(ptr);
+              llvm::Type* ptrTy = ptr->getType();
+              INT_ASSERT(ptrTy && ptrTy->isPointerTy());
+              llvm::Type* eltTy = ptrTy->getPointerElementType();
+              codegenInvariantStart(eltTy, ptr);
+            }
+          }
+        }
+      }
+
 #endif
     }
   }

--- a/test/llvm/llvm-invariant/function_local_const.chpl
+++ b/test/llvm/llvm-invariant/function_local_const.chpl
@@ -7,12 +7,10 @@ record A
   var a : int;
 }
 
-// CHECK: call {{.*}} @_construct_A_chpl
-// CHECK: store
-// CHECK: load
-// CHECK-DAG: call {}* @llvm.invariant.start.p0i8(i64 8, i8* [[CAST:%.*]])
-// CHECK-DAG: [[CAST]] = bitcast %A_chpl* [[PTR:%.*]] to i8*
-// CHECK_DAG: store %A_chpl {{%.*}}, %A_chpl* [[PTR]]
+// CHECK: @f_chpl
+// CHECK: call void @init_chpl{{.*}}(%A_chpl* [[PTR:%.*]],
+// CHECK: [[CAST:%.*]] = bitcast %A_chpl* [[PTR]] to i8*
+// CHECK: call {}* @llvm.invariant.start.p0i8(i64 8, i8* [[CAST]])
 // CHECK: getelementptr
 // CHECK-SAME:[[PTR]]
 // CHECK: load

--- a/test/llvm/llvm-invariant/global_const.chpl
+++ b/test/llvm/llvm-invariant/global_const.chpl
@@ -1,6 +1,6 @@
 // This test checks whether we add llvm.invariant.start to global const variables
 
-// CHECK: store %A_chpl %{{[0-9]+}}, %A_chpl* @globalConst_chpl
+// CHECK: call void @init_chpl{{.*}}(%A_chpl* @globalConst_chpl,
 // CHECK: %{{[0-9]+}} = call {}* @llvm.invariant.start.p0i8(i64 8, i8* bitcast (%A_chpl* @globalConst_chpl to i8*))
 
 record A

--- a/test/llvm/llvm-invariant/program_constructs.chpl
+++ b/test/llvm/llvm-invariant/program_constructs.chpl
@@ -11,12 +11,9 @@ proc f(n)
   var sum = 0;
   for i in 1..10
   {
-// CHECK: call {{.*}} @_construct_A_chpl
-// CHECK: store
-// CHECK: load
-// CHECK-DAG: call {}* @llvm.invariant.start.p0i8(i64 8, i8* [[CAST1:%.*]])
-// CHECK-DAG: [[CAST1]] = bitcast %A_chpl* [[PTR1:%.*]] to i8*
-// CHECK_DAG: store %A_chpl {{%.*}}, %A_chpl* [[PTR1]]
+// CHECK: call {{.*}} @init_chpl{{.*}}(%A_chpl* [[PTR1:%.*]],
+// CHECK: [[CAST1:%.*]] = bitcast %A_chpl* [[PTR1]] to i8*
+// CHECK: call {}* @llvm.invariant.start.p0i8(i64 8, i8* [[CAST1]])
 // CHECK: getelementptr
 // CHECK-SAME:[[PTR1]]
     const localConst = new A(i*10);
@@ -24,24 +21,18 @@ proc f(n)
   }
 
   if n < 10 {
-// CHECK: call {{.*}} @_construct_A_chpl
-// CHECK: store
-// CHECK: load
-// CHECK-DAG: call {}* @llvm.invariant.start.p0i8(i64 8, i8* [[CAST2:%.*]])
-// CHECK-DAG: [[CAST2]] = bitcast %A_chpl* [[PTR2:%.*]] to i8*
-// CHECK_DAG: store %A_chpl {{%.*}}, %A_chpl* [[PTR2]]
+// CHECK: call {{.*}} @init_chpl{{.*}}(%A_chpl* [[PTR2:%.*]],
+// CHECK: [[CAST2:%.*]] = bitcast %A_chpl* [[PTR2]] to i8*
+// CHECK: call {}* @llvm.invariant.start.p0i8(i64 8, i8* [[CAST2]])
 // CHECK: getelementptr
 // CHECK-SAME:[[PTR2]]
     const localConst = new A(n*10);
     return localConst.a;
   }
   else {
-// CHECK: call {{.*}} @_construct_A_chpl
-// CHECK: store
-// CHECK: load
-// CHECK-DAG: call {}* @llvm.invariant.start.p0i8(i64 8, i8* [[CAST3:%.*]])
-// CHECK-DAG: [[CAST3]] = bitcast %A_chpl* [[PTR3:%.*]] to i8*
-// CHECK_DAG: store %A_chpl {{%.*}}, %A_chpl* [[PTR3]]
+// CHECK: call {{.*}} @init_chpl{{.*}}(%A_chpl* [[PTR3:%.*]],
+// CHECK: [[CAST3:%.*]] = bitcast %A_chpl* [[PTR3]] to i8*
+// CHECK: call {}* @llvm.invariant.start.p0i8(i64 8, i8* [[CAST3]])
 // CHECK: getelementptr
 // CHECK-SAME:[[PTR3]]
     const localConst = new A(n*5);


### PR DESCRIPTION
Now that records are using initializers, the code generator
needed to handle a slightly different pattern for initializing
a const record so that it can add llvm.invariant.start.

Additionally the tests of this feature needed updating to match
the initializer call sequence instead of the constructor one.

- [x] full local testing
- [x] full local --llvm testing

Reviewed by @ronawho - thanks!