### PR TITLE
add back --warn-unstable warnings for arrays, type ctors

### DIFF
--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -882,8 +882,7 @@ static Expr* handleUnstableClassType(SymExpr* se) {
         }
         // Find outer call, but don't count:
         //  * baseExpr
-        //  * calls to types
-        //  * not counting baseExpr
+        //  * type construction (calls to types, buildArrayRuntimeType)
         for (Expr* cur = se; cur != NULL; cur = cur->parentExpr ) {
           if (CallExpr* c = toCallExpr(cur))
             inCall = c;

--- a/test/compflags/ferguson/unstable-class.chpl
+++ b/test/compflags/ferguson/unstable-class.chpl
@@ -26,6 +26,9 @@ proc errorsInArgs( x: MyClass, y: MyGenericClass, z: MyGenericClass(int) ) {
 proc errors() {
   var x: MyClass;
   var y: MyGenericClass(int);
+  var a: [1..10] MyClass;
+  var b: [1..10] MyGenericClass(int);
+  var c: MyGenericRecord(MyClass);
   errorsInArgs(x, y, y);
 }
 

--- a/test/compflags/ferguson/unstable-class.good
+++ b/test/compflags/ferguson/unstable-class.good
@@ -11,5 +11,11 @@ unstable-class.chpl:27: note: in declared type for x
 unstable-class.chpl:27: note: use 'unmanaged MyClass' 'owned MyClass', 'borrowed MyClass', or 'shared MyClass'
 unstable-class.chpl:28: warning: undecorated class type MyGenericClass is unstable
 unstable-class.chpl:28: note: use 'unmanaged MyGenericClass' 'owned MyGenericClass', 'borrowed MyGenericClass', or 'shared MyGenericClass'
+unstable-class.chpl:29: warning: undecorated class type MyClass is unstable
+unstable-class.chpl:29: note: use 'unmanaged MyClass' 'owned MyClass', 'borrowed MyClass', or 'shared MyClass'
+unstable-class.chpl:30: warning: undecorated class type MyGenericClass is unstable
+unstable-class.chpl:30: note: use 'unmanaged MyGenericClass' 'owned MyGenericClass', 'borrowed MyGenericClass', or 'shared MyGenericClass'
+unstable-class.chpl:31: warning: undecorated class type MyClass is unstable
+unstable-class.chpl:31: note: use 'unmanaged MyClass' 'owned MyClass', 'borrowed MyClass', or 'shared MyClass'
 unstable-class.chpl:20: warning: undecorated class type MyClass is unstable
 unstable-class.chpl:20: note: use 'unmanaged MyClass' 'owned MyClass', 'borrowed MyClass', or 'shared MyClass'

--- a/test/compflags/ferguson/unstable-class.init.good
+++ b/test/compflags/ferguson/unstable-class.init.good
@@ -14,3 +14,9 @@ unstable-class.chpl:27: note: in declared type for x
 unstable-class.chpl:27: note: use 'unmanaged MyClass' 'owned MyClass', 'borrowed MyClass', or 'shared MyClass'
 unstable-class.chpl:28: warning: undecorated class type MyGenericClass is unstable
 unstable-class.chpl:28: note: use 'unmanaged MyGenericClass' 'owned MyGenericClass', 'borrowed MyGenericClass', or 'shared MyGenericClass'
+unstable-class.chpl:29: warning: undecorated class type MyClass is unstable
+unstable-class.chpl:29: note: use 'unmanaged MyClass' 'owned MyClass', 'borrowed MyClass', or 'shared MyClass'
+unstable-class.chpl:30: warning: undecorated class type MyGenericClass is unstable
+unstable-class.chpl:30: note: use 'unmanaged MyGenericClass' 'owned MyGenericClass', 'borrowed MyGenericClass', or 'shared MyGenericClass'
+unstable-class.chpl:31: warning: undecorated class type MyClass is unstable
+unstable-class.chpl:31: note: use 'unmanaged MyClass' 'owned MyClass', 'borrowed MyClass', or 'shared MyClass'


### PR DESCRIPTION
PR #10460 stopped --warn-unstable from warning on certain common array
and type construction patterns. This PR adds back the error for the
common case (while leaving arbitrary type arguments unchecked).


- [x] full local testing

Reviewed by @benharsh - thanks!