### PR TITLE
Reject default-init as candidate for copy-init call

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -2833,6 +2833,10 @@ void trimVisibleCandidates(CallInfo&       info,
   bool isNew    = call->numActuals() >= 1 && call->isNamedAstr(astrNew);
   bool isDeinit = isMethod && call->isNamedAstr(astrDeinit);
 
+  // 3 actuals: _mt, 'this', thing-to-be-copied
+  bool maybeCopyInit = isInit && call->numActuals() == 3 &&
+                       call->get(2)->getValType() == call->get(3)->getValType();
+
   if (!(isInit || isNew || isDeinit)) {
     mostApplicable = visibleFns;
   } else {
@@ -2868,6 +2872,12 @@ void trimVisibleCandidates(CallInfo&       info,
           shouldKeep = false;
         }
       } else {
+        shouldKeep = false;
+      }
+
+      // Default-initializers should not be considered for calls that look
+      // like a copy-init
+      if (shouldKeep && maybeCopyInit && fn->isDefaultInit()) {
         shouldKeep = false;
       }
 

--- a/test/classes/initializers/generics/copy-init-generic-field.chpl
+++ b/test/classes/initializers/generics/copy-init-generic-field.chpl
@@ -1,0 +1,19 @@
+
+// Eventually the compiler should attempt to resolve a copy-initializer for
+// "R(int)". If the compiler attempts to use the default-initializer, the
+// compiler will emit an error because 'foobar(R(int))' cannot be resolved.
+//
+// The compiler should not attempt to use a default-initializer when resolving
+// a call that looks like a copy-init.
+
+proc foobar(foo : int) {
+  return 0;
+}
+
+record R {
+  var foo;
+
+  var something = foobar(foo);
+}
+
+var r : R(int);


### PR DESCRIPTION
Testing:
- [x] local + futures