### PR TITLE
Allow foralls over non-yielding iterators.

### DIFF
--- a/compiler/AST/ForallStmt.cpp
+++ b/compiler/AST/ForallStmt.cpp
@@ -257,6 +257,15 @@ ForallStmt* enclosingForallStmt(Expr* expr) {
   return NULL;
 }
 
+// Is 'expr' the DefExpr of an induction variable in some ForallStmt?
+bool isForallIterVarDef(Expr* expr) {
+  if (expr->list != NULL)
+    if (ForallStmt* pfs = toForallStmt(expr->parentExpr))
+      if (expr->list == &pfs->inductionVariables())
+        return true;
+  return false;
+}
+
 // Is 'expr' an iterable-expression for some ForallStmt?
 bool isForallIterExpr(Expr* expr) {
   if (expr->list != NULL)

--- a/compiler/include/ForallStmt.h
+++ b/compiler/include/ForallStmt.h
@@ -137,6 +137,7 @@ inline Expr* ForallStmt::firstIteratedExpr() const { return fIterExprs.head;  }
 
 /// helpers ///
 
+bool        isForallIterVarDef(Expr* expr);
 bool        isForallIterExpr(Expr* expr);
 bool        isForallRecIterHelper(Expr* expr);
 bool        isForallLoopBody(Expr* expr);

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -9036,7 +9036,9 @@ static void cleanupVoidVarsAndFields() {
           def->sym->type == dtVoid->refType) {
         if (VarSymbol* var = toVarSymbol(def->sym)) {
           // Avoid removing the "_val" field from refs
-          if (!def->parentSymbol->hasFlag(FLAG_REF)) {
+          // and forall statements' induction variables.
+          if (! def->parentSymbol->hasFlag(FLAG_REF) &&
+              ! isForallIterVarDef(def)              ) {
             if (var != gVoid) {
               def->remove();
             }

--- a/test/parallel/forall/vass/empty-parallel-iterator.chpl
+++ b/test/parallel/forall/vass/empty-parallel-iterator.chpl
@@ -1,0 +1,9 @@
+
+iter badIterator() {}
+iter badIterator(param tag : iterKind) where tag == iterKind.standalone {
+  writeln("in badIterator");
+}
+
+writeln("start");
+forall x in badIterator() do writeln("yielded ", x);
+writeln("end");

--- a/test/parallel/forall/vass/empty-parallel-iterator.good
+++ b/test/parallel/forall/vass/empty-parallel-iterator.good
@@ -1,0 +1,3 @@
+start
+in badIterator
+end


### PR DESCRIPTION
When a parallel iterator does not contain a yield statement,
the corresponding index variable is considered to be of void type.
So it was getting removed during cleanupVoidVarsAndFields().
This change prevents such removal.

Resolves #10357.
