### PR TITLE
Allow the Allinea compiler to compile the Chapel runtime

### DIFF
--- a/doc/rst/platforms/cray.rst
+++ b/doc/rst/platforms/cray.rst
@@ -139,6 +139,7 @@ Building Chapel for a Cray System from Source
    On a Cray X-series system, ensure that you have one of the following
    Programming Environment modules loaded to specify your target compiler::
 
+       PrgEnv-allinea (ARM only)
        PrgEnv-cray
        PrgEnv-gnu
        PrgEnv-intel

--- a/doc/rst/usingchapel/chplenv.rst
+++ b/doc/rst/usingchapel/chplenv.rst
@@ -141,20 +141,22 @@ CHPL_*_COMPILER
    and generated code for ``CHPL_TARGET_PLATFORM``.  Currently supported values
    are as follows:
 
-        =================  ===================================================
-        Value              Description
-        =================  ===================================================
-        clang              The Clang compiler suite -- clang and clang++
-        clang-included     The Clang compiler in third-party/llvm
-        cray-prgenv-cray   The Cray PrgEnv compiler using the Cray CCE backend
-        cray-prgenv-gnu    The Cray PrgEnv compiler using the GNU backend
-        cray-prgenv-intel  The Cray PrgEnv compiler using the Intel backend
-        cray-prgenv-pgi    The Cray PrgEnv compiler using the PGI backend
-        gnu                The GNU compiler suite -- gcc and g++
-        ibm                The IBM compiler suite -- xlc and xlC
-        intel              The Intel compiler suite -- icc and icpc
-        pgi                The PGI compiler suite -- pgcc and pgc++
-        =================  ===================================================
+        =================== ===================================================
+        Value               Description
+        =================== ===================================================
+        allinea             The Allinea ARM compiler suite -- clang and clang++
+        clang               The Clang compiler suite -- clang and clang++
+        clang-included      The Clang compiler in third-party/llvm
+        cray-prgenv-allinea The Cray PrgEnv compiler using the Allinea backend
+        cray-prgenv-cray    The Cray PrgEnv compiler using the Cray CCE backend
+        cray-prgenv-gnu     The Cray PrgEnv compiler using the GNU backend
+        cray-prgenv-intel   The Cray PrgEnv compiler using the Intel backend
+        cray-prgenv-pgi     The Cray PrgEnv compiler using the PGI backend
+        gnu                 The GNU compiler suite -- gcc and g++
+        ibm                 The IBM compiler suite -- xlc and xlC
+        intel               The Intel compiler suite -- icc and icpc
+        pgi                 The PGI compiler suite -- pgcc and pgc++
+        =================== ===================================================
 
    The default for ``CHPL_*_COMPILER`` depends on the value of the corresponding
    ``CHPL_*_PLATFORM`` environment variable:

--- a/make/compiler/Makefile.allinea
+++ b/make/compiler/Makefile.allinea
@@ -20,4 +20,7 @@
 include $(CHPL_MAKE_HOME)/make/compiler/Makefile.clang
 
 # Any allinea-specific settings can go here.
+
+# By default with -Wall, the Allinea compiler does not tolerate linker
+# flags when they are not used.
 RUNTIME_CFLAGS += -Wno-unused-command-line-argument

--- a/make/compiler/Makefile.allinea
+++ b/make/compiler/Makefile.allinea
@@ -20,3 +20,4 @@
 include $(CHPL_MAKE_HOME)/make/compiler/Makefile.clang
 
 # Any allinea-specific settings can go here.
+RUNTIME_CFLAGS += -Wno-unused-command-line-argument

--- a/util/chplenv/chpl_arch.py
+++ b/util/chplenv/chpl_arch.py
@@ -256,7 +256,7 @@ class argument_map(object):
             return 'none'
         elif compiler == 'intel':
             return cls.intel.get(arch, '')
-        elif compiler in ['clang', 'clang-included']:
+        elif compiler in ['clang', 'clang-included', 'allinea']:
             # Clang doesn't know how to do architecture detection for aarch64.
             if arch == 'native':
                 if get_native_machine() == 'aarch64':

--- a/util/chplenv/chpl_atomics.py
+++ b/util/chplenv/chpl_atomics.py
@@ -42,7 +42,7 @@ def get(flag='target'):
                 atomics_val = 'intrinsics'
             elif compiler_val == 'cray-prgenv-cray':
                 atomics_val = 'intrinsics'
-            elif compiler_val == 'cray-prgenv-allinea':
+            elif compiler_val == 'allinea' or compiler_val == 'cray-prgenv-allinea':
                 atomics_val = 'cstdlib'
             elif compiler_val == 'clang':
                 atomics_val = 'intrinsics'

--- a/util/chplenv/chpl_atomics.py
+++ b/util/chplenv/chpl_atomics.py
@@ -42,7 +42,7 @@ def get(flag='target'):
                 atomics_val = 'intrinsics'
             elif compiler_val == 'cray-prgenv-cray':
                 atomics_val = 'intrinsics'
-            elif compiler_val == 'allinea' or compiler_val == 'cray-prgenv-allinea':
+            elif compiler_val in ['allinea', 'cray-prgenv-allinea']:
                 atomics_val = 'cstdlib'
             elif compiler_val == 'clang':
                 atomics_val = 'intrinsics'


### PR DESCRIPTION
#8742 added most of the support for the Allinea compiler (ARM's HPC compiler).  This change adds the final tweak to allow it to work.  It also updates the documentation to include Allinea.

Closes #10474 
Closes #8743
