### PR TITLE
Fix testReplWrites

### DIFF
--- a/modules/dists/ReplicatedDist.chpl
+++ b/modules/dists/ReplicatedDist.chpl
@@ -539,7 +539,6 @@ proc ReplicatedArr.dsiAccess(indexx) ref {
 
 // Write the array out to the given Writer serially.
 proc ReplicatedArr.dsiSerialWrite(f): void {
-  //  writeln("in dsiSerialWrite() on locale ", here.id);
   localArrs[f.readWriteThisFromLocale().id].arrLocalRep._value.dsiSerialWrite(f);
 }
 

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1400,6 +1400,15 @@ module DefaultRectangular {
     chpl_serialReadWriteRectangular(f, arr, arr.dom);
   }
 
+  // ReplicatedDist declares a version of this method with a 'where'
+  // clause, but current resolution rules prefer the more visible
+  // function (rather than the one with a 'where' clause) and this
+  // call is more visible (e.g. ArrayViewSlice uses DefaultRectangular
+  // but not ReplicatedDist). Applying "last resort" to this function
+  // requests the compiler prefer another overload if one is applicable.
+  // Overload sets (or a similar idea) would be a better user-facing
+  // way to solve this problem (see CHIP 20).
+  pragma "last resort"
   proc chpl_serialReadWriteRectangular(f, arr, dom) {
     chpl_serialReadWriteRectangularHelper(f, arr, dom);
   }


### PR DESCRIPTION
This is a follow-on to PR #8079.

chpl_serialReadWriteRectangular is declared in DefaultRectangular and
then ReplicatedDist declares a version of this method with a 'where'
clause. Current resolution rules prefer the more visible function (rather
than the one with a 'where' clause) and PR #8079 made this sense of
"visibility" no longer include point of instantiation (to solve the first
"Hijacking" case from CHIP 20). 

So, after PR #8079, the DefaultRectangular version is more visible to a
call site in ArrayViewSlice. Applying "last resort" to this function
requests the compiler prefer another overload if one is applicable.
Overload sets (or a similar idea) would be a better user-facing way to
solve this problem (see CHIP 20).

- [x] full local testing
- [x] full GASNet testing

Reviewed by @benharsh - thanks!