### PR TITLE
Remove user memory leaks from release/examples tests

### DIFF
--- a/test/release/examples/primers/distributions.chpl
+++ b/test/release/examples/primers/distributions.chpl
@@ -283,8 +283,8 @@ MyLocales = reshape(Locales[0..#nl1*nl2], MyLocaleView);
 
 const DimReplicatedBlockcyclicSpace = Space
   dmapped DimensionalDist2D(MyLocales,
-                            new unmanaged ReplicatedDim(numLocales = nl1),
-                            new unmanaged BlockCyclicDim(numLocales = nl2,
+                            new owned ReplicatedDim(numLocales = nl1),
+                            new owned BlockCyclicDim(numLocales = nl2,
                                                lowIdx = 1, blockSize = 2));
 
 var DRBA: [DimReplicatedBlockcyclicSpace] int;

--- a/test/release/examples/programs/linkedList.chpl
+++ b/test/release/examples/programs/linkedList.chpl
@@ -106,14 +106,18 @@ class List {
       return;
 
     if head.value == value {
+      var temp = head;
       head = head.next;
+      delete temp;
       return;
     }
 
     var current = head;
     while current.next != nil {
       if current.next.value == value {
-        current.next = current.next.next;
+        var temp = current.next;
+        current.next = temp.next;
+        delete temp;
         return;
       }
       current = current.next;


### PR DESCRIPTION
Convert hpl.chpl and distributions.chpl to use owned. Delete unmanaged classes
in linkedList.chpl (I tried switching to use shared, but that had leaks still I
think as a result of contains() doing an early break out of an iterator.)

Related to https://github.com/chapel-lang/chapel/issues/10508