### PR TITLE
Fix problem where instantiationPoint might be removed by tryToken

### DIFF
--- a/compiler/AST/FnSymbol.cpp
+++ b/compiler/AST/FnSymbol.cpp
@@ -522,6 +522,24 @@ Symbol* FnSymbol::replaceReturnSymbol(Symbol* newRetSymbol, Type* newRetType) {
   return retval;
 }
 
+// Removes all statements from body and adds all statements from block.
+void FnSymbol::replaceBodyStmtsWithStmts(BlockStmt* block) {
+  for_alist(stmt, this->body->body) {
+    stmt->remove();
+  }
+  for_alist(stmt, block->body) {
+    this->body->insertAtTail(stmt->remove());
+  }
+}
+
+// Removes all statements from body and adds expr
+void FnSymbol::replaceBodyStmtsWithStmt(Expr* stmt) {
+  for_alist(stmt, this->body->body) {
+    stmt->remove();
+  }
+  this->body->insertAtTail(stmt);
+}
+
 
 void FnSymbol::insertBeforeEpilogue(Expr* ast) {
   LabelSymbol* label = getEpilogueLabel();

--- a/compiler/AST/FnSymbol.cpp
+++ b/compiler/AST/FnSymbol.cpp
@@ -31,6 +31,7 @@
 #include "passes.h"
 #include "stmt.h"
 #include "stringutil.h"
+#include "visibleFunctions.h"
 
 FnSymbol*                 chpl_gen_main         = NULL;
 FnSymbol*                 initStringLiterals    = NULL;
@@ -53,7 +54,8 @@ FnSymbol::FnSymbol(const char* initName) : Symbol(E_FnSymbol, initName) {
   _this              = NULL;
   _outer             = NULL;
   instantiatedFrom   = NULL;
-  instantiationPoint = NULL;
+  _instantiationPoint = NULL;
+  _backupInstantiationPoint = NULL;
   basicBlocks        = NULL;
   calledBy           = NULL;
   userString         = NULL;
@@ -145,7 +147,8 @@ void FnSymbol::verify() {
   verifyInTree(_this,              "FnSymbol::_this");
   verifyInTree(_outer,             "FnSymbol::_outer");
   verifyInTree(instantiatedFrom,   "FnSymbol::instantiatedFrom");
-  verifyInTree(instantiationPoint, "FnSymbol::instantiationPoint");
+  verifyInTree(_instantiationPoint, "FnSymbol::instantiationPoint");
+  verifyInTree(_backupInstantiationPoint, "FnSymbol::backupInstantiationPoint");
   verifyInTree(valueFunction,      "FnSymbol::valueFunction");
   verifyInTree(retSymbol,          "FnSymbol::retSymbol");
 }
@@ -194,7 +197,8 @@ FnSymbol* FnSymbol::copyInnerCore(SymbolMap* map) {
   newFn->_outer             = this->_outer;
   newFn->retTag             = this->retTag;
   newFn->instantiatedFrom   = this->instantiatedFrom;
-  newFn->instantiationPoint = this->instantiationPoint;
+  newFn->_instantiationPoint = this->_instantiationPoint;
+  newFn->_backupInstantiationPoint = this->_backupInstantiationPoint;
 
   return newFn;
 }
@@ -540,6 +544,27 @@ void FnSymbol::replaceBodyStmtsWithStmt(Expr* stmt) {
   this->body->insertAtTail(stmt);
 }
 
+void FnSymbol::setInstantiationPoint(Expr* expr) {
+  if (expr == NULL) {
+    this->_instantiationPoint = NULL;
+    this->_backupInstantiationPoint = NULL;
+  } else {
+    BlockStmt* block = toBlockStmt(expr);
+    if (block == NULL || block->blockTag == BLOCK_SCOPELESS)
+      block = getInstantiationPoint(expr);
+    this->_instantiationPoint = block;
+    this->_backupInstantiationPoint = block->getFunction();
+  }
+}
+
+BlockStmt* FnSymbol::instantiationPoint() const {
+  if (this->_instantiationPoint && this->_instantiationPoint->parentSymbol)
+    return this->_instantiationPoint;
+  else if (this->_backupInstantiationPoint)
+    return this->_backupInstantiationPoint->body;
+  else
+    return NULL;
+}
 
 void FnSymbol::insertBeforeEpilogue(Expr* ast) {
   LabelSymbol* label = getEpilogueLabel();

--- a/compiler/AST/FnSymbol.cpp
+++ b/compiler/AST/FnSymbol.cpp
@@ -537,11 +537,11 @@ void FnSymbol::replaceBodyStmtsWithStmts(BlockStmt* block) {
 }
 
 // Removes all statements from body and adds expr
-void FnSymbol::replaceBodyStmtsWithStmt(Expr* stmt) {
+void FnSymbol::replaceBodyStmtsWithStmt(Expr* addStmt) {
   for_alist(stmt, this->body->body) {
     stmt->remove();
   }
-  this->body->insertAtTail(stmt);
+  this->body->insertAtTail(addStmt);
 }
 
 void FnSymbol::setInstantiationPoint(Expr* expr) {

--- a/compiler/AST/foralls.cpp
+++ b/compiler/AST/foralls.cpp
@@ -836,7 +836,7 @@ static void buildLeaderLoopBody(ForallStmt* pfs, Expr* iterExpr) {
   BlockStmt*    userBody = toBlockStmt(pfs->loopBody()->body.tail->remove());
   INT_ASSERT(pfs->loopBody()->body.empty());
 
-  BlockStmt* preFS           = new BlockStmt();
+  BlockStmt* preFS           = new BlockStmt(BLOCK_SCOPELESS);
   // cf in build.cpp: new ForLoop(leadIdx, leadIter, NULL, zippered)
   BlockStmt* leadForLoop     = pfs->loopBody();
 

--- a/compiler/AST/stmt.cpp
+++ b/compiler/AST/stmt.cpp
@@ -81,6 +81,22 @@ BlockStmt::BlockStmt(Expr* initBody, BlockTag initBlockTag) :
   gBlockStmts.add(this);
 }
 
+BlockStmt::BlockStmt(BlockTag initBlockTag) :
+  Stmt(E_BlockStmt) {
+
+
+  blockTag      = initBlockTag;
+  useList       = NULL;
+  userLabel     = NULL;
+  byrefVars     = NULL;
+  forallIntents = NULL;
+  blockInfo     = NULL;
+
+  body.parent   = this;
+
+  gBlockStmts.add(this);
+}
+
 
 BlockStmt::~BlockStmt() {
   if (forallIntents)

--- a/compiler/include/FnSymbol.h
+++ b/compiler/include/FnSymbol.h
@@ -53,7 +53,12 @@ public:
   Symbol*                    _outer;
   FnSymbol*                  instantiatedFrom;
   SymbolMap                  substitutions;
-  BlockStmt*                 instantiationPoint;
+
+private:
+  BlockStmt*                 _instantiationPoint;
+  FnSymbol*                  _backupInstantiationPoint;
+
+public:
   std::vector<BasicBlock*>*  basicBlocks;
   Vec<CallExpr*>*            calledBy;
   const char*                userString;
@@ -124,6 +129,13 @@ public:
   void                       replaceBodyStmtsWithStmts(BlockStmt* block);
   // Removes all statements from body and adds the passed statement.
   void                       replaceBodyStmtsWithStmt(Expr* stmt);
+
+  // Sets instantiationPoint and backupInstantiationPoint appropriately
+  //  expr might be a call or a BlockStmt
+  void                       setInstantiationPoint(Expr* expr);
+  // returns instantiationPoint or uses the backupInstantiationPoint
+  // if necessary
+  BlockStmt*                 instantiationPoint()                        const;
 
   int                        numFormals()                                const;
   ArgSymbol*                 getFormal(int i)                            const;

--- a/compiler/include/FnSymbol.h
+++ b/compiler/include/FnSymbol.h
@@ -120,6 +120,11 @@ public:
   Symbol*                    replaceReturnSymbol(Symbol* newRetSymbol,
                                                  Type*   newRetType);
 
+  // Removes all statements from body and adds all statements from block.
+  void                       replaceBodyStmtsWithStmts(BlockStmt* block);
+  // Removes all statements from body and adds the passed statement.
+  void                       replaceBodyStmtsWithStmt(Expr* stmt);
+
   int                        numFormals()                                const;
   ArgSymbol*                 getFormal(int i)                            const;
 

--- a/compiler/include/stmt.h
+++ b/compiler/include/stmt.h
@@ -80,6 +80,7 @@ class BlockStmt : public Stmt {
 public:
                       BlockStmt(Expr*    initBody     = NULL,
                                 BlockTag initBlockTag = BLOCK_NORMAL);
+                      BlockStmt(BlockTag initBlockTag);
   virtual            ~BlockStmt();
 
   DECLARE_COPY(BlockStmt);

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -2055,7 +2055,7 @@ static void init_typed_var(VarSymbol* var,
   if (var->hasFlag(FLAG_EXTERN) == true) {
     INT_ASSERT(var->hasFlag(FLAG_PARAM) == false);
 
-    BlockStmt* block = new BlockStmt(NULL, BLOCK_EXTERN_TYPE);
+    BlockStmt* block = new BlockStmt(BLOCK_EXTERN_TYPE);
 
     block->insertAtTail(typeDefn);
     block->insertAtTail(initMove);
@@ -2361,7 +2361,7 @@ static void normVarTypeWoutInit(DefExpr* defExpr) {
   //
   // expects to find the init code inside a block stmt.
   if (var->hasFlag(FLAG_EXTERN) == true) {
-    BlockStmt* block    = new BlockStmt(NULL, BLOCK_EXTERN_TYPE);
+    BlockStmt* block    = new BlockStmt(BLOCK_EXTERN_TYPE);
 
     VarSymbol* typeTemp = newTemp("type_tmp");
     DefExpr*   typeDefn = new DefExpr(typeTemp);

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -9486,7 +9486,7 @@ static void buildRuntimeTypeInitFn(FnSymbol* fn, Type* runtimeType)
   fn->getReturnSymbol()->type = runtimeType;
 
   // Build a new body for the original function.
-  BlockStmt* block = new BlockStmt();
+  BlockStmt* block = new BlockStmt(BLOCK_SCOPELESS);
   VarSymbol* var = newTemp("_return_tmp_", fn->retType);
   block->insertAtTail(new DefExpr(var));
 
@@ -9509,7 +9509,7 @@ static void buildRuntimeTypeInitFn(FnSymbol* fn, Type* runtimeType)
   block->insertAtTail(new CallExpr(PRIM_RETURN, var));
 
   // Replace the body of the original chpl__buildRuntime...Type() function.
-  fn->body->replace(block);
+  fn->replaceBodyStmtsWithStmts(block);
 }
 
 static void removeFormalTypeAndInitBlocks()

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -1812,14 +1812,14 @@ static Expr*     getInsertPointForTypeFunction(Type* type) {
     retval = chpl_gen_main->body;
 
   } else if (at->defaultInitializer &&
-             at->defaultInitializer->instantiationPoint) {
+             at->defaultInitializer->instantiationPoint()) {
     // Here for historical reasons
-    retval = at->defaultInitializer->instantiationPoint;
+    retval = at->defaultInitializer->instantiationPoint();
 
   } else if (at->typeConstructor &&
-             at->typeConstructor->instantiationPoint) {
+             at->typeConstructor->instantiationPoint()) {
     // This case can apply to generic types with initializers
-    retval = at->typeConstructor->instantiationPoint;
+    retval = at->typeConstructor->instantiationPoint();
 
   } else {
     // This case applies to non-generic AggregateTypes and
@@ -1928,8 +1928,8 @@ void resolveTypeWithInitializer(AggregateType* at, FnSymbol* fn) {
   }
 
   if (at->symbol->instantiationPoint == NULL &&
-      fn->instantiationPoint != NULL) {
-    at->symbol->instantiationPoint = fn->instantiationPoint;
+      fn->instantiationPoint() != NULL) {
+    at->symbol->instantiationPoint = fn->instantiationPoint();
   }
   if (at->scalarPromotionType == NULL) {
     resolvePromotionType(at);
@@ -1956,7 +1956,7 @@ void resolvePromotionType(AggregateType* at) {
   FnSymbol* promoFn = resolveUninsertedCall(at, promoCall, false);
 
   if (promoFn != NULL) {
-    promoFn->instantiationPoint = at->symbol->instantiationPoint;
+    promoFn->setInstantiationPoint(at->symbol->instantiationPoint);
     resolveFunction(promoFn);
 
     INT_ASSERT(promoFn->retType != dtUnknown);
@@ -1975,7 +1975,7 @@ void resolveDestructor(AggregateType* at) {
   FnSymbol* deinitFn = resolveUninsertedCall(at, call, false);
 
   if (deinitFn != NULL) {
-    deinitFn->instantiationPoint = at->symbol->instantiationPoint;
+    deinitFn->setInstantiationPoint(at->symbol->instantiationPoint);
     resolveFunction(deinitFn);
     at->setDestructor(deinitFn);
   }
@@ -5102,7 +5102,7 @@ FnSymbol* findCopyInit(AggregateType* at) {
   // ret's instantiationPoint points to the dummy BlockStmt created by
   // resolveUninsertedCall, so it needs to be updated.
   if (ret != NULL) {
-    ret->instantiationPoint = at->symbol->instantiationPoint;
+    ret->setInstantiationPoint(at->symbol->instantiationPoint);
   }
 
   return ret;
@@ -8082,7 +8082,7 @@ static void resolveAutoCopyEtc(AggregateType* at) {
       INT_ASSERT(fn);
 
       if (at->hasInitializers()) {
-        fn->instantiationPoint = at->symbol->instantiationPoint;
+        fn->setInstantiationPoint(at->symbol->instantiationPoint);
       }
 
       resolveFunction(fn);
@@ -8512,7 +8512,7 @@ static void cleanupAfterRemoves() {
     if (fn->instantiatedFrom != NULL)
       fn->addFlag(FLAG_INSTANTIATED_GENERIC);
     fn->instantiatedFrom = NULL;
-    fn->instantiationPoint = NULL;
+    fn->setInstantiationPoint(NULL);
     // How about fn->substitutions, basicBlocks, calledBy ?
   }
 

--- a/compiler/resolution/generics.cpp
+++ b/compiler/resolution/generics.cpp
@@ -705,7 +705,7 @@ FnSymbol* instantiateFunction(FnSymbol*  fn,
   newFn->substitutions.map_union(allSubs);
 
   if (call) {
-    newFn->instantiationPoint = getInstantiationPoint(call);
+    newFn->setInstantiationPoint(call);
   }
 
   Expr* putBefore = fn->defPoint;

--- a/compiler/resolution/implementForallIntents.cpp
+++ b/compiler/resolution/implementForallIntents.cpp
@@ -1676,7 +1676,7 @@ static void extendLeader(CallExpr* call, CallExpr* origToLeaderCall,
   }
 
   FnSymbol* iterFn = copyLeaderFn(origIterFn, /*ignore_isResolved:*/false);
-  iterFn->instantiationPoint = getInstantiationPoint(call);
+  iterFn->setInstantiationPoint(call);
   call->baseExpr->replace(new SymExpr(iterFn));
 
   int numExtraArgs = origToLeaderCall->numActuals()-1;
@@ -1773,7 +1773,7 @@ void implementForallIntents2wrapper(CallExpr* call, CallExpr* eflopiHelper)
     // and may be reused for an unrelated call. Create a clone.
     FnSymbol* wDest = dest->copy();
     wDest->addFlag(FLAG_INVISIBLE_FN);
-    wDest->instantiationPoint = getInstantiationPoint(call);
+    wDest->setInstantiationPoint(call);
     // Do we also need to update paramMap like in copyLeaderFn() ?
     dest->defPoint->insertAfter(new DefExpr(wDest));
     call->baseExpr->replace(new SymExpr(wDest));
@@ -2069,12 +2069,13 @@ static void moveInstantiationPoint(BlockStmt* to, BlockStmt* from, Type* type) {
   // This snippet updates the instantiation point of the reduction class and
   // its methods to point to the surviving Block (parent of 'hld').
   //
+  // MPF 2018-07-25: I believe this workaround can be removed
   AggregateType* reductionClass = toAggregateType(canonicalClassType(type));
   if (reductionClass->symbol->instantiationPoint == from) {
     reductionClass->symbol->instantiationPoint = to;
     forv_Vec(FnSymbol, fn, reductionClass->methods) {
-      if (fn->instantiationPoint == from) {
-        fn->instantiationPoint = to;
+      if (fn->instantiationPoint() == from) {
+        fn->setInstantiationPoint(to);
       }
     }
   }

--- a/compiler/resolution/tuples.cpp
+++ b/compiler/resolution/tuples.cpp
@@ -516,7 +516,7 @@ instantiate_tuple_hash( FnSymbol* fn) {
 
   CallExpr* ret = new CallExpr(PRIM_RETURN, call);
 
-  fn->body->replace( new BlockStmt( ret));
+  fn->replaceBodyStmtsWithStmt(ret);
   normalize(fn);
 }
 
@@ -736,7 +736,7 @@ static void instantiate_tuple_cast(FnSymbol* fn, CallExpr* context) {
   ArgSymbol*     arg   = fn->getFormal(2);
   AggregateType* fromT = toAggregateType(arg->type);
 
-  BlockStmt* block = new BlockStmt();
+  BlockStmt* block = new BlockStmt(BLOCK_SCOPELESS);
 
   VarSymbol* retv = new VarSymbol("retv", toT);
   block->insertAtTail(new DefExpr(retv));
@@ -825,7 +825,7 @@ static void instantiate_tuple_cast(FnSymbol* fn, CallExpr* context) {
   }
 
   block->insertAtTail(new CallExpr(PRIM_RETURN, retv));
-  fn->body->replace(block);
+  fn->replaceBodyStmtsWithStmts(block);
   normalize(fn);
 }
 
@@ -845,7 +845,7 @@ instantiate_tuple_initCopy_or_autoCopy(FnSymbol* fn,
     ct = computeCopyTuple(origCt, valueOnly, copy_fun, fn->body);
   }
 
-  BlockStmt* block = new BlockStmt();
+  BlockStmt* block = new BlockStmt(BLOCK_SCOPELESS);
 
   VarSymbol* retv = new VarSymbol("retv", ct);
   block->insertAtTail(new DefExpr(retv));
@@ -879,7 +879,7 @@ instantiate_tuple_initCopy_or_autoCopy(FnSymbol* fn,
   }
 
   block->insertAtTail(new CallExpr(PRIM_RETURN, retv));
-  fn->body->replace(block);
+  fn->replaceBodyStmtsWithStmts(block);
   normalize(fn);
 }
 
@@ -917,7 +917,7 @@ instantiate_tuple_unref(FnSymbol* fn)
   const char* useCopy = "chpl__initCopy";
   ct = computeCopyTuple(origCt, true, useCopy, fn->body);
 
-  BlockStmt* block = new BlockStmt();
+  BlockStmt* block = new BlockStmt(BLOCK_SCOPELESS);
 
   if( ct == origCt ) {
     // Just return the passed argument.
@@ -964,7 +964,7 @@ instantiate_tuple_unref(FnSymbol* fn)
     block->insertAtTail(new CallExpr(PRIM_RETURN, retv));
   }
 
-  fn->body->replace(block);
+  fn->replaceBodyStmtsWithStmts(block);
   normalize(fn);
 }
 

--- a/compiler/resolution/tuples.cpp
+++ b/compiler/resolution/tuples.cpp
@@ -122,7 +122,7 @@ makeTupleTypeCtor(std::vector<ArgSymbol*> typeCtorArgs,
   typeCtor->retTag             = RET_TYPE;
   typeCtor->retType            = newType;
   typeCtor->instantiatedFrom   = gGenericTupleTypeCtor;
-  typeCtor->instantiationPoint = instantiationPoint;
+  typeCtor->setInstantiationPoint(instantiationPoint);
 
   typeCtor->insertAtTail(ret);
 
@@ -164,7 +164,7 @@ FnSymbol* makeBuildTupleType(std::vector<ArgSymbol*> typeCtorArgs,
   buildTupleType->substitutions.copy(newType->substitutions);
 
   buildTupleType->instantiatedFrom = gBuildTupleType;
-  buildTupleType->instantiationPoint = instantiationPoint;
+  buildTupleType->setInstantiationPoint(instantiationPoint);
 
   tupleModule->block->insertAtTail(new DefExpr(buildTupleType));
 
@@ -201,7 +201,7 @@ FnSymbol* makeBuildStarTupleType(std::vector<ArgSymbol*> typeCtorArgs,
   buildStarTupleType->substitutions.copy(newType->substitutions);
 
   buildStarTupleType->instantiatedFrom = gBuildStarTupleType;
-  buildStarTupleType->instantiationPoint = instantiationPoint;
+  buildStarTupleType->setInstantiationPoint(instantiationPoint);
 
   tupleModule->block->insertAtTail(new DefExpr(buildStarTupleType));
   return buildStarTupleType;
@@ -272,7 +272,7 @@ FnSymbol* makeConstructTuple(std::vector<TypeSymbol*>& args,
   ctor->insertAtTail(ret);
   ctor->substitutions.copy(newType->substitutions);
 
-  ctor->instantiationPoint = instantiationPoint;
+  ctor->setInstantiationPoint(instantiationPoint);
 
   tupleModule->block->insertAtTail(new DefExpr(ctor));
 
@@ -315,7 +315,7 @@ FnSymbol* makeDestructTuple(TypeSymbol* newTypeSymbol,
   dtor->substitutions.copy(newType->substitutions);
 
   dtor->instantiatedFrom = gGenericTupleDestroy;
-  dtor->instantiationPoint = instantiationPoint;
+  dtor->setInstantiationPoint(instantiationPoint);
 
   tupleModule->block->insertAtTail(new DefExpr(dtor));
 
@@ -995,7 +995,7 @@ static AggregateType* do_computeTupleWithIntent(bool           valueOnly,
   std::vector<TypeSymbol*> args;
   bool                     allSame            = true;
   FnSymbol*                typeConstr         = at->typeConstructor;
-  BlockStmt*               instantiationPoint = typeConstr->instantiationPoint;
+  BlockStmt*             instantiationPoint = typeConstr->instantiationPoint();
   int                      i                  = 0;
   AggregateType*           retval             = NULL;
 

--- a/compiler/resolution/virtualDispatch.cpp
+++ b/compiler/resolution/virtualDispatch.cpp
@@ -223,13 +223,13 @@ static FnSymbol* getInstantiatedFunction(FnSymbol* pfn,
 
     if (ct->hasInitializers() == false) {
       FnSymbol*  typeConstr         = ct->typeConstructor;
-      BlockStmt* instantiationPoint = typeConstr->instantiationPoint;
+      BlockStmt* instantiationPoint = typeConstr->instantiationPoint();
 
       if (instantiationPoint == NULL) {
         instantiationPoint = toBlockStmt(typeConstr->defPoint->parentExpr);
       }
 
-      fn->instantiationPoint = instantiationPoint;
+      fn->setInstantiationPoint(instantiationPoint);
     } else {
       //
       // BHARSH 2018-04-06:
@@ -239,7 +239,7 @@ static FnSymbol* getInstantiatedFunction(FnSymbol* pfn,
       // A smaller test case:
       //   types/type_variables/deitz/test_point_of_instantiation3.chpl
       //
-      fn->instantiationPoint = ct->symbol->instantiationPoint;
+      fn->setInstantiationPoint(ct->symbol->instantiationPoint);
     }
 
     return fn;

--- a/compiler/resolution/visibleFunctions.cpp
+++ b/compiler/resolution/visibleFunctions.cpp
@@ -211,6 +211,8 @@ static void getVisibleFunctions(const char*           name,
                  isArgSymbol(block->parentSymbol) ||
                  isShadowVarSymbol(block->parentSymbol));
       fnBlock = true;
+      if (inFn->instantiationPoint)
+        INT_ASSERT(inFn->instantiationPoint->parentSymbol);
       if (inFn->instantiationPoint && inFn->instantiationPoint->parentSymbol)
         instantiationPt = inFn->instantiationPoint;
     }

--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -616,7 +616,7 @@ static DefaultExprFnEntry buildDefaultedActualFn(FnSymbol*  fn,
   wrapper->insertAtTail(new DefExpr(rvv));
 
   // This is the block we'll resolve to compute the return intent
-  BlockStmt* block = new BlockStmt();
+  BlockStmt* block = new BlockStmt(BLOCK_SCOPELESS);
   wrapper->insertAtTail(block);
 
   wrapper->insertAtTail(new CallExpr(PRIM_RETURN, rvv));

--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -345,7 +345,7 @@ static void addDefaultsAndReorder(FnSymbol *fn,
 
   // Create a Block to store the default values
   // We'll flatten this back out again in a minute.
-  BlockStmt* body = new BlockStmt();
+  BlockStmt* body = new BlockStmt(BLOCK_SCOPELESS);
   call->getStmtExpr()->insertBefore(body);
 
   // Fill in the NULLs in newActuals with the appropriate default argument.
@@ -1777,7 +1777,7 @@ static void insertRuntimeTypeDefaultWrapper(FnSymbol* fn,
     i++;
   }
 
-  BlockStmt* body = new BlockStmt();
+  BlockStmt* body = new BlockStmt(BLOCK_SCOPELESS);
   call->getStmtExpr()->insertBefore(body);
 
   Symbol* newSym = insertRuntimeTypeDefault(fn, formal, call, body, copyMap, curActual->symbol());

--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -489,7 +489,7 @@ static DefaultExprFnEntry buildDefaultedActualFn(FnSymbol*  fn,
     wrapper->addFlag(FLAG_METHOD_PRIMARY);
   }
 
-  wrapper->instantiationPoint = fn->instantiationPoint;
+  wrapper->setInstantiationPoint(fn->instantiationPoint());
 
   if (fn->hasFlag(FLAG_LAST_RESORT)) {
     wrapper->addFlag(FLAG_LAST_RESORT);
@@ -856,7 +856,7 @@ static FnSymbol* buildWrapperForDefaultedFormals(FnSymbol*     fn,
   SymbolMap copyMap;
   CallExpr* call    = new CallExpr(fn);
   FnSymbol* retval  = buildEmptyWrapper(fn);
-  retval->instantiationPoint = getInstantiationPoint(info.call);
+  retval->setInstantiationPoint(info.call);
 
   retval->cname = astr("_default_wrap_", fn->cname);
 
@@ -2347,7 +2347,7 @@ static void buildLeaderIterator(FnSymbol* wrapFn,
 
   normalize(liFn);
 
-  liFn->instantiationPoint = instantiationPt;
+  liFn->setInstantiationPoint(instantiationPt);
 }
 
 static void buildFollowerIterator(PromotionInfo& promotion,
@@ -2412,7 +2412,7 @@ static void buildFollowerIterator(PromotionInfo& promotion,
 
   normalize(fiFn);
 
-  fiFn->instantiationPoint = instantiationPt;
+  fiFn->setInstantiationPoint(instantiationPt);
 
   fixUnresolvedSymExprsForPromotionWrapper(fiFn, fn);
 }
@@ -2481,7 +2481,7 @@ static void initPromotionWrapper(PromotionInfo& promotion,
 
   FnSymbol* fn = promotion.fn;
   FnSymbol* retval = buildEmptyWrapper(fn);
-  retval->instantiationPoint = instantiationPoint;
+  retval->setInstantiationPoint(instantiationPoint);
 
   retval->cname = astr("_promotion_wrap_", fn->cname);
 
@@ -2822,7 +2822,7 @@ static void buildFastFollowerCheck(bool                  isStatic,
 
   normalize(checkFn);
 
-  checkFn->instantiationPoint = getInstantiationPoint(info.call);
+  checkFn->setInstantiationPoint(info.call);
 }
 
 /************************************* | **************************************


### PR DESCRIPTION
@ben-albrecht was seeing a problem where `=` was failing to resolve for an
array of a user-defined record type. The issue was that the instantiationPoint
for a relevant function to find the visible `=` overload was no longer in the
tree. (Unfortunately we havn't yet been able to make a small reproducer).

This PR:
 * adjusts logic finding tryToken conditionals to find nested blocks
   (this was the cause of the original bug)
 * renames --break-on-delete-id to --break-on-remove-id since it breaks
   on remove, not when the AST node is freed ( I used this a lot in
   debugging these problems )
 * adds a 1-argument BlockTag constructor for BlockStmt
 * adjusts several BlockStmts that are intentionally created to be
   removed to be scopeless
 * instead of removing fn's body, adjusted several code paths to replace
   the body stmts, so that the body can be a valid instantiation point
 * adds an assert that instantiationPoint is in the tree in
   getVisibleFunctions to catch this issue earlier next time.
 * adds a backupInstantiationPoint, which is the FnSymbol that originally
   held instantiationPoint. I don't know of another way to resolve
   instantiationPoints missing from replaceEflopiWithForall but I'm sure
   another strategy could be used... But since this issue seems to come
   up a lot, a more robust strategy seemed called for. Made
   instantiationPoint and backupInstantiationPoint private and now use
   instantiationPoint() to read whichever is available and
   setInstantiationPoint() to set them.


- [x] full local futures testing

Reviewed by @benharsh - thanks!