### PR TITLE
Close DataFrame leaks

### DIFF
--- a/test/library/standard/DataFrames/DataFrames.chpl
+++ b/test/library/standard/DataFrames/DataFrames.chpl
@@ -28,21 +28,21 @@ module DataFrames {
     }
 
     pragma "no doc"
-    proc uni(lhs: borrowed TypedSeries, rhs: borrowed TypedSeries, unifier: borrowed SeriesUnifier): unmanaged Series {
+    proc uni(lhs: borrowed TypedSeries, rhs: borrowed TypedSeries, unifier: borrowed SeriesUnifier): owned Series {
       halt("generic Index cannot be unioned");
-      return _to_unmanaged(lhs);
+      return new owned Series();
     }
 
     pragma "no doc"
-    proc map(s: borrowed TypedSeries, mapper: borrowed SeriesMapper): unmanaged Series {
+    proc map(s: borrowed TypedSeries, mapper: borrowed SeriesMapper): owned Series {
       halt("generic Index cannot be mapped");
-      return _to_unmanaged(s);
+      return new owned Series();
     }
 
     pragma "no doc"
-    proc filter(s: borrowed TypedSeries, filterSeries: borrowed TypedSeries): unmanaged Series {
+    proc filter(s: borrowed TypedSeries, filterSeries: borrowed TypedSeries): owned Series {
       halt("generic Index cannot be filtered");
-      return _to_unmanaged(s);
+      return new owned Series();
     }
 
     pragma "no doc"
@@ -52,7 +52,7 @@ module DataFrames {
     }
 
     pragma "no doc"
-    proc writeThis(f, s: unmanaged TypedSeries(?) = nil) {
+    proc writeThis(f, s: borrowed TypedSeries(?) = nil) {
       halt("cannot writeThis on generic Index");
     }
 
@@ -115,7 +115,7 @@ module DataFrames {
     // TODO: sort Index
     override
     proc uni(lhs: borrowed TypedSeries(?lhsType), rhs: borrowed TypedSeries(?rhsType),
-             unifier: borrowed SeriesUnifier(lhsType)): unmanaged TypedSeries(lhsType)
+             unifier: borrowed SeriesUnifier(lhsType)): owned Series
              where lhsType == rhsType {
       var uni_ords = 1..(lhs.ords.size + rhs.ords.size);
       var uni_rev_idx: [uni_ords] idxType;
@@ -145,22 +145,22 @@ module DataFrames {
         }
       }
 
-      return new unmanaged TypedSeries(uni_data[1..curr_ord],
+      return new owned TypedSeries(uni_data[1..curr_ord],
                              new unmanaged TypedIndex(uni_rev_idx[1..curr_ord]),
                              uni_valid_bits[1..curr_ord]);
     }
 
     override
-    proc map(s: borrowed TypedSeries(?T), mapper: borrowed SeriesMapper(T, ?R)): unmanaged TypedSeries(R) {
+    proc map(s: borrowed TypedSeries(?T), mapper: borrowed SeriesMapper(T, ?R)): owned Series {
       var mapped: [ords] R;
       for (i, d) in s.items(idxType) do
         mapped[this[i]] = mapper.f(d);
 
-      return new unmanaged TypedSeries(mapped, _to_unmanaged(this), s.valid_bits);
+      return new owned TypedSeries(mapped, _to_unmanaged(this), s.valid_bits);
     }
 
     override
-    proc filter(s: borrowed TypedSeries(?T), filterSeries: borrowed TypedSeries(bool)): unmanaged TypedSeries(T) {
+    proc filter(s: borrowed TypedSeries(?T), filterSeries: borrowed TypedSeries(bool)): owned Series {
       var filter_rev_idx: [ords] idxType;
       var filter_data: [ords] T;
       var filter_valid_bits: [ords] bool;
@@ -175,7 +175,7 @@ module DataFrames {
         }
       }
 
-      return new unmanaged TypedSeries(filter_data[1..curr_ord],
+      return new owned TypedSeries(filter_data[1..curr_ord],
                              new unmanaged TypedIndex(filter_rev_idx[1..curr_ord]),
                              filter_valid_bits[1..curr_ord]);
     }
@@ -198,7 +198,7 @@ module DataFrames {
     }
 
     override
-    proc writeThis(f, s: unmanaged TypedSeries(?) = nil) {
+    proc writeThis(f, s: borrowed TypedSeries(?) = nil) {
       var idxWidth = writeIdxWidth() + 4;
       for (idx, (v, d)) in zip(this, s._these()) {
         // TODO: clean up to simple cast after bugfix
@@ -248,7 +248,7 @@ module DataFrames {
   class Series {
     pragma "no doc"
     proc copy() {
-      return _to_unmanaged(this);
+      return new owned Series();
     }
 
     pragma "no doc"
@@ -259,79 +259,79 @@ module DataFrames {
     pragma "no doc"
     proc uni(lhs: borrowed TypedSeries, unifier: borrowed SeriesUnifier) {
       halt("generic Series cannot be unioned");
-      return _to_unmanaged(this);
+      return new owned Series();
     }
 
     pragma "no doc"
     proc map(mapper: borrowed SeriesMapper) {
       halt("generic Series cannot be unioned");
-      return _to_unmanaged(this);
+      return new owned Series();
     }
 
     pragma "no doc"
     proc add(rhs) {
       halt("generic Series cannot be added");
-      return _to_unmanaged(this);
+      return new owned Series();
     }
 
     pragma "no doc"
     proc add_scalar(n) {
       halt("generic Series cannot be added");
-      return _to_unmanaged(this);
+      return new owned Series();
     }
 
     pragma "no doc"
     proc subtr(rhs) {
       halt("generic Series cannot be subtracted");
-      return _to_unmanaged(this);
+      return new owned Series();
     }
 
     pragma "no doc"
     proc subtr_scalar(n) {
       halt("generic Series cannot be subtracted");
-      return _to_unmanaged(this);
+      return new owned Series();
     }
 
     pragma "no doc"
     proc mult(rhs) {
       halt("generic Series cannot be multiplied");
-      return _to_unmanaged(this);
+      return new owned Series();
     }
 
     pragma "no doc"
     proc mult_scalar(n) {
       halt("generic Series cannot be multiplied");
-      return _to_unmanaged(this);
+      return new owned Series();
     }
 
     pragma "no doc"
     proc lt_scalar(n) {
       halt("generic Series cannot be compared");
-      return _to_unmanaged(this);
+      return new owned Series();
     }
 
     pragma "no doc"
     proc gt_scalar(n) {
       halt("generic Series cannot be compared");
-      return _to_unmanaged(this);
+      return new owned Series();
     }
 
     pragma "no doc"
     proc eq_scalar(n) {
       halt("generic Series cannot be compared");
-      return _to_unmanaged(this);
+      return new owned Series();
     }
 
     pragma "no doc"
     proc lteq_scalar(n) {
       halt("generic Series cannot be compared");
-      return _to_unmanaged(this);
+      return new owned Series();
     }
 
     pragma "no doc"
     proc gteq_scalar(n) {
       halt("generic Series cannot be compared");
-      return _to_unmanaged(this);
+      return new owned Series();
     }
 
     pragma "no doc"
@@ -404,8 +404,8 @@ module DataFrames {
     }
 
     override
-    proc copy() {
-      return new unmanaged TypedSeries(this.data, this.idx, this.valid_bits);
+    proc copy() : owned Series {
+      return new owned TypedSeries(this.data, this.idx, this.valid_bits);
     }
 
     /*
@@ -481,8 +481,8 @@ module DataFrames {
     }
 
     // TODO: filterSeries needs to be Owned
-    proc this(filterSeries: ?T) where T: unmanaged Series {
-      var castFilter = filterSeries: unmanaged TypedSeries(bool);
+    proc this(filterSeries: ?T) : owned Series where isSubtype(T, Series) {
+      var castFilter = filterSeries: borrowed TypedSeries(bool);
       if idx then
         return idx.filter(this, castFilter);
 
@@ -492,7 +492,7 @@ module DataFrames {
         if b && i <= data.size then
           filter_data[i] = this.at(i);
       }
-      return new unmanaged TypedSeries(filter_data, this.valid_bits);
+      return new owned TypedSeries(filter_data, this.valid_bits);
     }
 
     proc at(ord: int) {
@@ -520,9 +520,9 @@ module DataFrames {
      */
 
     override
-    proc uni(lhs: borrowed TypedSeries(eltType), unifier: borrowed SeriesUnifier(eltType)): unmanaged TypedSeries(eltType) {
+    proc uni(lhs: borrowed TypedSeries(eltType), unifier: borrowed SeriesUnifier(eltType)): owned Series {
       if lhs.idx then
-        return lhs.idx.uni(lhs, this, unifier):unmanaged TypedSeries(eltType);
+        return lhs.idx.uni(lhs, this, unifier):owned Series;
 
       var uni_ords = if lhs.ords.size > this.ords.size
                      then 1..lhs.ords.size
@@ -545,16 +545,16 @@ module DataFrames {
         }
       }
 
-      return new unmanaged TypedSeries(uni_data, uni_valid_bits);
+      return new owned TypedSeries(uni_data, uni_valid_bits);
     }
 
     override
-    proc map(mapper: borrowed SeriesMapper): unmanaged Series {
+    proc map(mapper: borrowed SeriesMapper): owned Series {
       if idx then
         return idx.map(this, mapper);
 
       var mapped = [d in data] mapper.f(d);
-      return new unmanaged TypedSeries(mapped, this.valid_bits);
+      return new owned TypedSeries(mapped, this.valid_bits);
     }
 
     /*
@@ -563,60 +563,60 @@ module DataFrames {
     // TODO: "in" operator for idx.contains(lab)
 
     override
-    proc add(rhs): unmanaged Series {
+    proc add(rhs : borrowed Series): owned Series {
       return rhs.uni(this, new borrowed SeriesAdd(eltType));
     }
 
     override
-    proc add_scalar(n): unmanaged Series {
+    proc add_scalar(n): owned Series {
       var with_scalar = data + n;
-      return new unmanaged TypedSeries(with_scalar, idx);
+      return new owned TypedSeries(with_scalar, idx);
     }
 
     override
-    proc subtr(rhs): unmanaged Series {
+    proc subtr(rhs): owned Series {
       return rhs.uni(this, new borrowed SeriesSubtr(eltType));
     }
 
     override
-    proc subtr_scalar(n): unmanaged Series {
+    proc subtr_scalar(n): owned Series {
       var with_scalar = data - n;
-      return new unmanaged TypedSeries(with_scalar, idx);
+      return new owned TypedSeries(with_scalar, idx);
     }
 
     override
-    proc mult(rhs): unmanaged Series {
+    proc mult(rhs): owned Series {
       return rhs.uni(this, new borrowed SeriesMult(eltType));
     }
 
     override
-    proc mult_scalar(n): unmanaged Series {
+    proc mult_scalar(n): owned Series {
       var with_scalar = data * n;
-      return new unmanaged TypedSeries(with_scalar, idx);
+      return new owned TypedSeries(with_scalar, idx);
     }
 
     override
-    proc lt_scalar(n): unmanaged Series {
+    proc lt_scalar(n): owned Series {
       return this.map(new borrowed SeriesLessThan(n));
     }
 
     override
-    proc gt_scalar(n): unmanaged Series {
+    proc gt_scalar(n): owned Series {
       return this.map(new borrowed SeriesGreaterThan(n));
     }
 
     override
-    proc eq_scalar(n): unmanaged Series {
+    proc eq_scalar(n): owned Series {
       return this.map(new borrowed SeriesEqualTo(n));
     }
 
     override
-    proc lteq_scalar(n): unmanaged Series {
+    proc lteq_scalar(n): owned Series {
       return this.map(new borrowed SeriesLessThanEqualTo(n));
     }
 
     override
-    proc gteq_scalar(n): unmanaged Series {
+    proc gteq_scalar(n): owned Series {
       return this.map(new borrowed SeriesGreaterThanEqualTo(n));
     }
 
@@ -698,7 +698,11 @@ module DataFrames {
 
   class DataFrame {
     var labels: domain(string);
+
+    // TODO: array of owned Series
+    //   Currently run into confusing const errors in DefaultAssociative
     var columns: [labels] unmanaged Series;
+
     var idx: unmanaged Index;
 
     // TODO: init with labels arg
@@ -707,13 +711,13 @@ module DataFrames {
       this.complete();
     }
 
-    proc init(columns: [?D] unmanaged Series) {
+    proc init(columns: [?D] borrowed Series) {
       this.labels = D;
       this.idx = nil;
       this.complete();
 
       for (lab, s) in zip(labels, columns) do
-        this.columns[lab] = s.copy();
+        this.columns[lab] = s.copy().release();
     }
 
     proc init(columns: [?D], idx: unmanaged Index) {
@@ -725,6 +729,10 @@ module DataFrames {
         this.insert(lab, s);
     }
 
+    proc deinit() {
+      delete columns;
+    }
+
     iter these() {
       for s in columns do
         yield s;
@@ -734,8 +742,8 @@ module DataFrames {
       return columns[lab];
     }
 
-    proc insert(lab: string, s: unmanaged Series) {
-      var sCopy = s.copy();
+    proc insert(lab: string, s: borrowed Series) {
+      var sCopy = s.copy().release();
       sCopy.reindex(idx);
       columns[lab] = sCopy;
     }

--- a/test/library/standard/DataFrames/diten/readHDF5Df.chpl
+++ b/test/library/standard/DataFrames/diten/readHDF5Df.chpl
@@ -1,23 +1,22 @@
-use DataFrames, HDF5_HL;
+use DataFrames, HDF5;
 
 config const inputDir = "hdf5_files";
 
 var colDom: domain(string);
 var columns: [colDom] Series;
-var dataFrame = new DataFrame(columns);
+var dataFrame = new owned DataFrame(columns);
 
 type inputTypes = (int, real);
 
 for param i in 1..inputTypes.size {
   type inType = inputTypes(i);
-  var col: Series;
   param typeName = inType:string;
 
   var arrays = readAllHDF5Files(Locales, inputDir, "/dset",
                                 typeName, inType, rank=1);
 
   for (arr, j) in zip(arrays, 1..) {
-    col = new TypedSeries(arr.A);
+    var col = new owned TypedSeries(arr.A);
     var name = "s" + i + "_" + j;
     dataFrame.insert(name, col);
   }

--- a/test/library/standard/DataFrames/psahabu/AccessSeries.chpl
+++ b/test/library/standard/DataFrames/psahabu/AccessSeries.chpl
@@ -3,7 +3,7 @@ use DataFrames;
 var A = ["a", "b", "c", "d", "e"];
 var I = ["A", "B", "C", "D", "E"];
 
-var letters = new owned TypedSeries(A, new unmanaged TypedIndex(I));
+var letters = new owned TypedSeries(A, new shared TypedIndex(I));
 
 writeln("A: " + letters["A"]);
 writeln("C: " + letters["C"]);

--- a/test/library/standard/DataFrames/psahabu/AccessSeries.chpl
+++ b/test/library/standard/DataFrames/psahabu/AccessSeries.chpl
@@ -3,7 +3,7 @@ use DataFrames;
 var A = ["a", "b", "c", "d", "e"];
 var I = ["A", "B", "C", "D", "E"];
 
-var letters = new unmanaged TypedSeries(A, new unmanaged TypedIndex(I));
+var letters = new owned TypedSeries(A, new unmanaged TypedIndex(I));
 
 writeln("A: " + letters["A"]);
 writeln("C: " + letters["C"]);

--- a/test/library/standard/DataFrames/psahabu/AddSeries.chpl
+++ b/test/library/standard/DataFrames/psahabu/AddSeries.chpl
@@ -2,8 +2,8 @@ use DataFrames;
 
 var I = new unmanaged TypedIndex(["A", "B", "C", "D", "E"]);
 
-var oneDigit = new unmanaged TypedSeries([1, 2, 3, 4, 5], I);
-var twoDigit = new unmanaged TypedSeries([10, 20, 30, 40, 50], I);
+var oneDigit = new owned TypedSeries([1, 2, 3, 4, 5], I);
+var twoDigit = new owned TypedSeries([10, 20, 30, 40, 50], I);
 
 writeln("addends:");
 writeln(oneDigit);
@@ -12,8 +12,8 @@ writeln(twoDigit);
 writeln("\nsum:");
 writeln(oneDigit + twoDigit);
 
-var X = new unmanaged TypedSeries([0, 1, 2], new unmanaged TypedIndex(["A", "B", "C"]));
-var Y = new unmanaged TypedSeries([10, 20, 0, 0], new unmanaged TypedIndex(["B", "C", "D", "E"]));
+var X = new owned TypedSeries([0, 1, 2], new unmanaged TypedIndex(["A", "B", "C"]));
+var Y = new owned TypedSeries([10, 20, 0, 0], new unmanaged TypedIndex(["B", "C", "D", "E"]));
 
 writeln("\naddends:");
 writeln(X);
@@ -22,8 +22,8 @@ writeln(Y);
 writeln("\nsum:");
 writeln(X + Y);
 
-var A = new unmanaged TypedSeries(["hello ", "my ", "name", "is", "brad"]);
-var B = new unmanaged TypedSeries(["world", "real"]);
+var A = new owned TypedSeries(["hello ", "my ", "name", "is", "brad"]);
+var B = new owned TypedSeries(["world", "real"]);
 
 writeln("\naddends:");
 writeln(A);

--- a/test/library/standard/DataFrames/psahabu/AddSeries.chpl
+++ b/test/library/standard/DataFrames/psahabu/AddSeries.chpl
@@ -1,6 +1,6 @@
 use DataFrames;
 
-var I = new unmanaged TypedIndex(["A", "B", "C", "D", "E"]);
+var I = new shared TypedIndex(["A", "B", "C", "D", "E"]);
 
 var oneDigit = new owned TypedSeries([1, 2, 3, 4, 5], I);
 var twoDigit = new owned TypedSeries([10, 20, 30, 40, 50], I);
@@ -12,8 +12,8 @@ writeln(twoDigit);
 writeln("\nsum:");
 writeln(oneDigit + twoDigit);
 
-var X = new owned TypedSeries([0, 1, 2], new unmanaged TypedIndex(["A", "B", "C"]));
-var Y = new owned TypedSeries([10, 20, 0, 0], new unmanaged TypedIndex(["B", "C", "D", "E"]));
+var X = new owned TypedSeries([0, 1, 2], new shared TypedIndex(["A", "B", "C"]));
+var Y = new owned TypedSeries([10, 20, 0, 0], new shared TypedIndex(["B", "C", "D", "E"]));
 
 writeln("\naddends:");
 writeln(X);

--- a/test/library/standard/DataFrames/psahabu/AndOrSeries.chpl
+++ b/test/library/standard/DataFrames/psahabu/AndOrSeries.chpl
@@ -1,8 +1,8 @@
 use DataFrames;
 
-var noTrue = new unmanaged TypedSeries([false, false, false]);
-var oneTrue = new unmanaged TypedSeries([false, true, false]);
-var allTrue = new unmanaged TypedSeries([true, true, true]);
+var noTrue = new owned TypedSeries([false, false, false]);
+var oneTrue = new owned TypedSeries([false, true, false]);
+var allTrue = new owned TypedSeries([true, true, true]);
 
 writeln("noTrue:");
 writeln(noTrue);

--- a/test/library/standard/DataFrames/psahabu/ArithNoneSeries.chpl
+++ b/test/library/standard/DataFrames/psahabu/ArithNoneSeries.chpl
@@ -4,9 +4,9 @@ var I = new unmanaged TypedIndex(["A", "B", "C", "D", "E"]);
 var V1 = [true, false, true, false, true];
 var V2 = [false, true, false, true, false];
 
-var oneDigit = new unmanaged TypedSeries([1, 2, 3, 4, 5], I, V1);
-var twoDigit = new unmanaged TypedSeries([10, 20, 30, 40, 50], I, V1);
-var twoDigitInv = new unmanaged TypedSeries([10, 20, 30, 40, 50], I, V2);
+var oneDigit = new owned TypedSeries([1, 2, 3, 4, 5], I, V1);
+var twoDigit = new owned TypedSeries([10, 20, 30, 40, 50], I, V1);
+var twoDigitInv = new owned TypedSeries([10, 20, 30, 40, 50], I, V2);
 
 writeln("oneDigit:");
 writeln(oneDigit);

--- a/test/library/standard/DataFrames/psahabu/ArithNoneSeries.chpl
+++ b/test/library/standard/DataFrames/psahabu/ArithNoneSeries.chpl
@@ -1,6 +1,6 @@
 use DataFrames;
 
-var I = new unmanaged TypedIndex(["A", "B", "C", "D", "E"]);
+var I = new shared TypedIndex(["A", "B", "C", "D", "E"]);
 var V1 = [true, false, true, false, true];
 var V2 = [false, true, false, true, false];
 

--- a/test/library/standard/DataFrames/psahabu/ContainSeries.chpl
+++ b/test/library/standard/DataFrames/psahabu/ContainSeries.chpl
@@ -2,7 +2,7 @@ use DataFrames;
 
 var A = ["a", "b", "c", "d", "e"];
 var I = ["A", "B", "C", "D", "E"];
-var letters = new owned TypedSeries(A, new unmanaged TypedIndex(I));
+var letters = new owned TypedSeries(A, new shared TypedIndex(I));
 
 writeln(letters);
 writeln();

--- a/test/library/standard/DataFrames/psahabu/ContainSeries.chpl
+++ b/test/library/standard/DataFrames/psahabu/ContainSeries.chpl
@@ -2,7 +2,7 @@ use DataFrames;
 
 var A = ["a", "b", "c", "d", "e"];
 var I = ["A", "B", "C", "D", "E"];
-var letters = new unmanaged TypedSeries(A, new unmanaged TypedIndex(I));
+var letters = new owned TypedSeries(A, new unmanaged TypedIndex(I));
 
 writeln(letters);
 writeln();

--- a/test/library/standard/DataFrames/psahabu/FilterNoIndexSeries.chpl
+++ b/test/library/standard/DataFrames/psahabu/FilterNoIndexSeries.chpl
@@ -1,6 +1,6 @@
 use DataFrames;
 
-var noIndex = new TypedSeries([1, 2, 3, 4, 5]);
+var noIndex = new owned TypedSeries([1, 2, 3, 4, 5]);
 writeln("noIndex:");
 writeln(noIndex);
 writeln();

--- a/test/library/standard/DataFrames/psahabu/FilterNoneSeries.chpl
+++ b/test/library/standard/DataFrames/psahabu/FilterNoneSeries.chpl
@@ -1,6 +1,6 @@
 use DataFrames;
 
-var I = new unmanaged TypedIndex(["A", "B", "C", "D", "E"]);
+var I = new shared TypedIndex(["A", "B", "C", "D", "E"]);
 var V1 = [true, false, true, false, true];
 
 var oneDigit = new owned TypedSeries([1, 2, 3, 4, 5], I, V1);

--- a/test/library/standard/DataFrames/psahabu/FilterNoneSeries.chpl
+++ b/test/library/standard/DataFrames/psahabu/FilterNoneSeries.chpl
@@ -3,8 +3,8 @@ use DataFrames;
 var I = new unmanaged TypedIndex(["A", "B", "C", "D", "E"]);
 var V1 = [true, false, true, false, true];
 
-var oneDigit = new unmanaged TypedSeries([1, 2, 3, 4, 5], I, V1);
-var twoDigit = new unmanaged TypedSeries([10, 20, 30, 40, 50], I, V1);
+var oneDigit = new owned TypedSeries([1, 2, 3, 4, 5], I, V1);
+var twoDigit = new owned TypedSeries([10, 20, 30, 40, 50], I, V1);
 
 writeln("oneDigit:");
 writeln(oneDigit);

--- a/test/library/standard/DataFrames/psahabu/FilterSeries.chpl
+++ b/test/library/standard/DataFrames/psahabu/FilterSeries.chpl
@@ -1,6 +1,6 @@
 use DataFrames;
 
-var I = new unmanaged TypedIndex(["A", "B", "C", "D", "E"]);
+var I = new shared TypedIndex(["A", "B", "C", "D", "E"]);
 var initial = new owned TypedSeries([1, 2, 3, 4, 5], I);
 writeln("initial:");
 writeln(initial);

--- a/test/library/standard/DataFrames/psahabu/FilterSeries.chpl
+++ b/test/library/standard/DataFrames/psahabu/FilterSeries.chpl
@@ -1,7 +1,7 @@
 use DataFrames;
 
 var I = new unmanaged TypedIndex(["A", "B", "C", "D", "E"]);
-var initial = new unmanaged TypedSeries([1, 2, 3, 4, 5], I);
+var initial = new owned TypedSeries([1, 2, 3, 4, 5], I);
 writeln("initial:");
 writeln(initial);
 writeln();

--- a/test/library/standard/DataFrames/psahabu/HelloDataFrame.chpl
+++ b/test/library/standard/DataFrames/psahabu/HelloDataFrame.chpl
@@ -7,7 +7,7 @@ var columnTwo: owned Series = new owned TypedSeries([1, 2, 3, 4, 5], validBits);
 var columnThree: owned Series = new owned TypedSeries([10.0, 20.0, 30.0, 40.0, 50.0]);
 
 var columns = ["columnOne" => columnOne, "columnTwo" => columnTwo, "columnThree" => columnThree];
-var idx = new unmanaged TypedIndex(["rowOne", "rowTwo", "rowThree", "rowFour", "rowFive"]);
+var idx = new shared TypedIndex(["rowOne", "rowTwo", "rowThree", "rowFour", "rowFive"]);
 
 var dataFrame = new owned DataFrame(columns, idx);
 var noIndex = new owned DataFrame(columns);

--- a/test/library/standard/DataFrames/psahabu/HelloDataFrame.chpl
+++ b/test/library/standard/DataFrames/psahabu/HelloDataFrame.chpl
@@ -2,15 +2,15 @@ use DataFrames;
 
 var validBits = [true, false, true, false, true];
 
-var columnOne: unmanaged Series = new unmanaged TypedSeries(["a", "b", "c", "d", "e"], validBits);
-var columnTwo: unmanaged Series = new unmanaged TypedSeries([1, 2, 3, 4, 5], validBits);
-var columnThree: unmanaged Series = new unmanaged TypedSeries([10.0, 20.0, 30.0, 40.0, 50.0]);
+var columnOne: owned Series = new owned TypedSeries(["a", "b", "c", "d", "e"], validBits);
+var columnTwo: owned Series = new owned TypedSeries([1, 2, 3, 4, 5], validBits);
+var columnThree: owned Series = new owned TypedSeries([10.0, 20.0, 30.0, 40.0, 50.0]);
 
 var columns = ["columnOne" => columnOne, "columnTwo" => columnTwo, "columnThree" => columnThree];
 var idx = new unmanaged TypedIndex(["rowOne", "rowTwo", "rowThree", "rowFour", "rowFive"]);
 
-var dataFrame = new unmanaged DataFrame(columns, idx);
-var noIndex = new unmanaged DataFrame(columns);
+var dataFrame = new owned DataFrame(columns, idx);
+var noIndex = new owned DataFrame(columns);
 writeln(dataFrame);
 writeln();
 writeln(dataFrame["columnThree"]);

--- a/test/library/standard/DataFrames/psahabu/HelloSeries.chpl
+++ b/test/library/standard/DataFrames/psahabu/HelloSeries.chpl
@@ -4,7 +4,7 @@ var A = ["a", "b", "c", "d", "e"];
 var I = ["A", "B", "C", "D", "E"];
 
 var just_letters = new owned TypedSeries(A);
-var letters = new owned TypedSeries(A, new unmanaged TypedIndex(I));
+var letters = new owned TypedSeries(A, new shared TypedIndex(I));
 
 writeln(just_letters);
 writeln(letters);

--- a/test/library/standard/DataFrames/psahabu/HelloSeries.chpl
+++ b/test/library/standard/DataFrames/psahabu/HelloSeries.chpl
@@ -3,8 +3,8 @@ use DataFrames;
 var A = ["a", "b", "c", "d", "e"];
 var I = ["A", "B", "C", "D", "E"];
 
-var just_letters = new unmanaged TypedSeries(A);
-var letters = new unmanaged TypedSeries(A, new unmanaged TypedIndex(I));
+var just_letters = new owned TypedSeries(A);
+var letters = new owned TypedSeries(A, new unmanaged TypedIndex(I));
 
 writeln(just_letters);
 writeln(letters);

--- a/test/library/standard/DataFrames/psahabu/IterNoneSeries.chpl
+++ b/test/library/standard/DataFrames/psahabu/IterNoneSeries.chpl
@@ -4,7 +4,7 @@ var A = ["a", "b", "c", "d", "e"];
 var I = ["A", "B", "C", "D", "E"];
 var V = [true, false, true, false, true];
 
-var letters = new owned TypedSeries(A, new unmanaged TypedIndex(I), V);
+var letters = new owned TypedSeries(A, new shared TypedIndex(I), V);
 
 writeln("these():");
 for t in letters do

--- a/test/library/standard/DataFrames/psahabu/IterNoneSeries.chpl
+++ b/test/library/standard/DataFrames/psahabu/IterNoneSeries.chpl
@@ -4,7 +4,7 @@ var A = ["a", "b", "c", "d", "e"];
 var I = ["A", "B", "C", "D", "E"];
 var V = [true, false, true, false, true];
 
-var letters = new unmanaged TypedSeries(A, new unmanaged TypedIndex(I), V);
+var letters = new owned TypedSeries(A, new unmanaged TypedIndex(I), V);
 
 writeln("these():");
 for t in letters do

--- a/test/library/standard/DataFrames/psahabu/IterSeries.chpl
+++ b/test/library/standard/DataFrames/psahabu/IterSeries.chpl
@@ -3,13 +3,13 @@ use DataFrames;
 var A = ["a", "b", "c", "d", "e"];
 var I = ["A", "B", "C", "D", "E"];
 
-var letters = new owned TypedSeries(A, new unmanaged TypedIndex(I));
+var letters = new owned TypedSeries(A, new shared TypedIndex(I));
 
-for i in letters.idx:unmanaged TypedIndex(string) do
+for i in letters.idx.these(string) do
   writeln(i);
 
 writeln();
-for i in (letters.idx:unmanaged TypedIndex(string)).items() do
+for i in letters.idx.items(string) do
   writeln(i);
 
 writeln();

--- a/test/library/standard/DataFrames/psahabu/IterSeries.chpl
+++ b/test/library/standard/DataFrames/psahabu/IterSeries.chpl
@@ -3,7 +3,7 @@ use DataFrames;
 var A = ["a", "b", "c", "d", "e"];
 var I = ["A", "B", "C", "D", "E"];
 
-var letters = new unmanaged TypedSeries(A, new unmanaged TypedIndex(I));
+var letters = new owned TypedSeries(A, new unmanaged TypedIndex(I));
 
 for i in letters.idx:unmanaged TypedIndex(string) do
   writeln(i);

--- a/test/library/standard/DataFrames/psahabu/MixedOperateSeries.chpl
+++ b/test/library/standard/DataFrames/psahabu/MixedOperateSeries.chpl
@@ -2,8 +2,8 @@ use DataFrames;
 
 var I = new unmanaged TypedIndex(["A", "B", "C", "D", "E"]);
 
-var oneDigit = new unmanaged TypedSeries([1, 2, 3, 4, 5], I);
-var twoDigit = new unmanaged TypedSeries([10, 20, 30, 40, 50], I);
+var oneDigit = new owned TypedSeries([1, 2, 3, 4, 5], I);
+var twoDigit = new owned TypedSeries([10, 20, 30, 40, 50], I);
 
 writeln("oneDigit:");
 writeln(oneDigit);

--- a/test/library/standard/DataFrames/psahabu/MixedOperateSeries.chpl
+++ b/test/library/standard/DataFrames/psahabu/MixedOperateSeries.chpl
@@ -1,6 +1,6 @@
 use DataFrames;
 
-var I = new unmanaged TypedIndex(["A", "B", "C", "D", "E"]);
+var I = new shared TypedIndex(["A", "B", "C", "D", "E"]);
 
 var oneDigit = new owned TypedSeries([1, 2, 3, 4, 5], I);
 var twoDigit = new owned TypedSeries([10, 20, 30, 40, 50], I);

--- a/test/library/standard/DataFrames/psahabu/MultiplySeries.chpl
+++ b/test/library/standard/DataFrames/psahabu/MultiplySeries.chpl
@@ -1,6 +1,6 @@
 use DataFrames;
 
-var I = new unmanaged TypedIndex(["A", "B", "C", "D", "E"]);
+var I = new shared TypedIndex(["A", "B", "C", "D", "E"]);
 
 var oneDigit = new owned TypedSeries([1, 2, 3, 4, 5], I);
 var twoDigit = new owned TypedSeries([11, 22, 33, 44, 55], I);
@@ -12,8 +12,8 @@ writeln(twoDigit);
 writeln("\nproduct:");
 writeln(oneDigit * twoDigit);
 
-var X = new owned TypedSeries([5, 1, 2], new unmanaged TypedIndex(["A", "B", "C"]));
-var Y = new owned TypedSeries([10, 20, 6, 7], new unmanaged TypedIndex(["B", "C", "D", "E"]));
+var X = new owned TypedSeries([5, 1, 2], new shared TypedIndex(["A", "B", "C"]));
+var Y = new owned TypedSeries([10, 20, 6, 7], new shared TypedIndex(["B", "C", "D", "E"]));
 
 writeln("\nfactors:");
 writeln(Y);

--- a/test/library/standard/DataFrames/psahabu/MultiplySeries.chpl
+++ b/test/library/standard/DataFrames/psahabu/MultiplySeries.chpl
@@ -2,8 +2,8 @@ use DataFrames;
 
 var I = new unmanaged TypedIndex(["A", "B", "C", "D", "E"]);
 
-var oneDigit = new unmanaged TypedSeries([1, 2, 3, 4, 5], I);
-var twoDigit = new unmanaged TypedSeries([11, 22, 33, 44, 55], I);
+var oneDigit = new owned TypedSeries([1, 2, 3, 4, 5], I);
+var twoDigit = new owned TypedSeries([11, 22, 33, 44, 55], I);
 
 writeln("factors:");
 writeln(oneDigit);
@@ -12,8 +12,8 @@ writeln(twoDigit);
 writeln("\nproduct:");
 writeln(oneDigit * twoDigit);
 
-var X = new unmanaged TypedSeries([5, 1, 2], new unmanaged TypedIndex(["A", "B", "C"]));
-var Y = new unmanaged TypedSeries([10, 20, 6, 7], new unmanaged TypedIndex(["B", "C", "D", "E"]));
+var X = new owned TypedSeries([5, 1, 2], new unmanaged TypedIndex(["A", "B", "C"]));
+var Y = new owned TypedSeries([10, 20, 6, 7], new unmanaged TypedIndex(["B", "C", "D", "E"]));
 
 writeln("\nfactors:");
 writeln(Y);

--- a/test/library/standard/DataFrames/psahabu/MutateDataFrame.chpl
+++ b/test/library/standard/DataFrames/psahabu/MutateDataFrame.chpl
@@ -18,7 +18,7 @@ df.insert("columnOne", columnOne);
 df.insert("columnTwo", columnTwo);
 df.insert("columnThree", columnThree);
 
-var idx = new unmanaged TypedIndex(["rowOne", "rowTwo", "rowThree", "rowFour", "rowFive"]);
+var idx = new shared TypedIndex(["rowOne", "rowTwo", "rowThree", "rowFour", "rowFive"]);
 df.reindex(idx);
 
 writeln(df);

--- a/test/library/standard/DataFrames/psahabu/MutateDataFrame.chpl
+++ b/test/library/standard/DataFrames/psahabu/MutateDataFrame.chpl
@@ -1,11 +1,11 @@
 use DataFrames;
 
-var df = new unmanaged DataFrame();
+var df = new owned DataFrame();
 
 var validBits = [true, false, true, false, true];
-var columnOne: unmanaged Series = new unmanaged TypedSeries(["a", "b", "c", "d", "e"], validBits);
-var columnTwo: unmanaged Series = new unmanaged TypedSeries([1, 2, 3, 4, 5], validBits);
-var columnThree: unmanaged Series = new unmanaged TypedSeries([10.0, 20.0, 30.0, 40.0, 50.0]);
+var columnOne: owned Series = new owned TypedSeries(["a", "b", "c", "d", "e"], validBits);
+var columnTwo: owned Series = new owned TypedSeries([1, 2, 3, 4, 5], validBits);
+var columnThree: owned Series = new owned TypedSeries([10.0, 20.0, 30.0, 40.0, 50.0]);
 
 writeln(columnOne);
 writeln();

--- a/test/library/standard/DataFrames/psahabu/ScalarPromSeries.chpl
+++ b/test/library/standard/DataFrames/psahabu/ScalarPromSeries.chpl
@@ -1,7 +1,7 @@
 use DataFrames;
 
 var oneDigit = new owned TypedSeries([1, 2, 3, 4, 5],
-                               new unmanaged TypedIndex(["A", "B", "C", "D", "E"]));
+                               new shared TypedIndex(["A", "B", "C", "D", "E"]));
 var n = 12;
 
 writeln("series:");

--- a/test/library/standard/DataFrames/psahabu/ScalarPromSeries.chpl
+++ b/test/library/standard/DataFrames/psahabu/ScalarPromSeries.chpl
@@ -1,6 +1,6 @@
 use DataFrames;
 
-var oneDigit = new unmanaged TypedSeries([1, 2, 3, 4, 5],
+var oneDigit = new owned TypedSeries([1, 2, 3, 4, 5],
                                new unmanaged TypedIndex(["A", "B", "C", "D", "E"]));
 var n = 12;
 

--- a/test/library/standard/DataFrames/psahabu/SubtractSeries.chpl
+++ b/test/library/standard/DataFrames/psahabu/SubtractSeries.chpl
@@ -2,8 +2,8 @@ use DataFrames;
 
 var I = new unmanaged TypedIndex(["A", "B", "C", "D", "E"]);
 
-var oneDigit = new unmanaged TypedSeries([1, 2, 3, 4, 5], I);
-var twoDigit = new unmanaged TypedSeries([11, 22, 33, 44, 55], I);
+var oneDigit = new owned TypedSeries([1, 2, 3, 4, 5], I);
+var twoDigit = new owned TypedSeries([11, 22, 33, 44, 55], I);
 
 writeln("terms:");
 writeln(oneDigit);
@@ -12,8 +12,8 @@ writeln(twoDigit);
 writeln("\ndifference:");
 writeln(twoDigit - oneDigit);
 
-var X = new unmanaged TypedSeries([5, 1, 2], new unmanaged TypedIndex(["A", "B", "C"]));
-var Y = new unmanaged TypedSeries([10, 20, 6, 7], new unmanaged TypedIndex(["B", "C", "D", "E"]));
+var X = new owned TypedSeries([5, 1, 2], new unmanaged TypedIndex(["A", "B", "C"]));
+var Y = new owned TypedSeries([10, 20, 6, 7], new unmanaged TypedIndex(["B", "C", "D", "E"]));
 
 writeln("\nterms:");
 writeln(Y);

--- a/test/library/standard/DataFrames/psahabu/SubtractSeries.chpl
+++ b/test/library/standard/DataFrames/psahabu/SubtractSeries.chpl
@@ -1,6 +1,6 @@
 use DataFrames;
 
-var I = new unmanaged TypedIndex(["A", "B", "C", "D", "E"]);
+var I = new shared TypedIndex(["A", "B", "C", "D", "E"]);
 
 var oneDigit = new owned TypedSeries([1, 2, 3, 4, 5], I);
 var twoDigit = new owned TypedSeries([11, 22, 33, 44, 55], I);
@@ -12,8 +12,8 @@ writeln(twoDigit);
 writeln("\ndifference:");
 writeln(twoDigit - oneDigit);
 
-var X = new owned TypedSeries([5, 1, 2], new unmanaged TypedIndex(["A", "B", "C"]));
-var Y = new owned TypedSeries([10, 20, 6, 7], new unmanaged TypedIndex(["B", "C", "D", "E"]));
+var X = new owned TypedSeries([5, 1, 2], new shared TypedIndex(["A", "B", "C"]));
+var Y = new owned TypedSeries([10, 20, 6, 7], new shared TypedIndex(["B", "C", "D", "E"]));
 
 writeln("\nterms:");
 writeln(Y);

--- a/test/library/standard/DataFrames/psahabu/SumMinMaxSeries.chpl
+++ b/test/library/standard/DataFrames/psahabu/SumMinMaxSeries.chpl
@@ -4,9 +4,9 @@ var I = new unmanaged TypedIndex(["A", "B", "C", "D", "E"]);
 var V1 = [true, false, true, false, true];
 var V2 = [false, true, false, true, false];
 
-var noNone = new unmanaged TypedSeries([1, 2, 3, 4, 5], I);
-var someNone = new unmanaged TypedSeries([1, 2, 3, 4, 5], I, V1);
-var moreNone = new unmanaged TypedSeries([10, 20, 30, 40, 50], I, V2);
+var noNone = new owned TypedSeries([1, 2, 3, 4, 5], I);
+var someNone = new owned TypedSeries([1, 2, 3, 4, 5], I, V1);
+var moreNone = new owned TypedSeries([10, 20, 30, 40, 50], I, V2);
 
 writeln("noNone:");
 writeln(noNone);

--- a/test/library/standard/DataFrames/psahabu/SumMinMaxSeries.chpl
+++ b/test/library/standard/DataFrames/psahabu/SumMinMaxSeries.chpl
@@ -1,6 +1,6 @@
 use DataFrames;
 
-var I = new unmanaged TypedIndex(["A", "B", "C", "D", "E"]);
+var I = new shared TypedIndex(["A", "B", "C", "D", "E"]);
 var V1 = [true, false, true, false, true];
 var V2 = [false, true, false, true, false];
 


### PR DESCRIPTION
This PR updates various DataFrame-related types to use owned or shared:

| Type      | Manager |
|-----------|---------|
| Series    | owned   |
| Index     | shared  |
| DataFrame | owned   |

Some new methods were added to the generic Index and Series classes to help with casting issues around owned/shared and parent/child classes.

Resolves #9753

Testing:
- [x] local
- [x] memleaks
- [x] --lifetime-checking