### PR TITLE
Address pkg-config nightly failures

### DIFF
--- a/test/mason/env/mason-registry.good
+++ b/test/mason/env/mason-registry.good
@@ -1,5 +1,5 @@
 MASON_HOME: $PWD/tempHome *
 MASON_REGISTRY: myRegistry|$PWD/tempHome/uncached/myRegistry *
-Initializing mason-registry for myRegistry
+Updating mason-registry for myRegistry
 multiple (0.2.0)
 simple (0.1.0)

--- a/test/mason/mason-test/PREDIFF
+++ b/test/mason/mason-test/PREDIFF
@@ -1,1 +1,0 @@
-../sedUpdateMessage

--- a/test/mason/pkgconfig-tests/openssl.good
+++ b/test/mason/pkgconfig-tests/openssl.good
@@ -1,3 +1,4 @@
+Updating mason-registry for mason-registry
 
 [root]
 name = "openssl"

--- a/test/mason/run/PREDIFF
+++ b/test/mason/run/PREDIFF
@@ -1,1 +1,0 @@
-../sedUpdateMessage

--- a/test/mason/subdir-commands/PREDIFF
+++ b/test/mason/subdir-commands/PREDIFF
@@ -1,1 +1,0 @@
-../sedUpdateMessage

--- a/tools/mason/MasonUpdate.chpl
+++ b/tools/mason/MasonUpdate.chpl
@@ -144,7 +144,7 @@ proc updateRegistry(tf: string, args : [] string) {
       const localRegistry = registryHome;
       mkdir(localRegistry, parents=true);
       const cloneRegistry = 'git clone -q ' + registry + ' .';
-      writeln("Initializing mason-registry for ", name);
+      writeln("Updating mason-registry for ", name);
       gitC(localRegistry, cloneRegistry);
     }
   }


### PR DESCRIPTION
This PR changes the message produced by Mason Update upon not finding a mason registry so that moving forward we no longer have to deal with the sed replacements for testing. This PR will address the failures from the pkg-config integration.
