### PR TITLE
Fix leak in cast to string from c_ptr

### DIFF
--- a/modules/internal/CPtr.chpl
+++ b/modules/internal/CPtr.chpl
@@ -136,11 +136,11 @@ module CPtr {
   }
   pragma "no doc"
   inline proc _cast(type t:string, x:c_void_ptr) {
-    return __primitive("ref to string", x):string;
+    return new string(__primitive("ref to string", x), needToCopy=false);
   }
   pragma "no doc"
   inline proc _cast(type t:string, x:c_ptr) {
-    return __primitive("ref to string", x):string;
+    return new string(__primitive("ref to string", x), needToCopy=false);
   }
   pragma "no doc"
   inline proc _cast(type t:borrowed, x:c_void_ptr) {


### PR DESCRIPTION
This PR updates the cast functions that convert a c_ptr or c_void_ptr to a string such that they take ownership of the runtime-allocated c_string. Previously the cast functions would simply cast the c_string to a string, which makes a copy but does not take ownership.

Resolve a leak for ``types/cptr/ptr_cast_to_string.chpl``

Testing:
- [x] local + futures
- [x] valgrind
- [x] memleaks for ``types/cptr/ptr_cast_to_string.chpl``