### PR TITLE
Fix timeouts for high core-count systems

### DIFF
--- a/test/release/examples/benchmarks/lulesh/lulesh.execenv
+++ b/test/release/examples/benchmarks/lulesh/lulesh.execenv
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Guard pages are expensive on Xeon Phi. See issue #7533
+# Guard pages are expensive on high core-count systems. See issue #7533
 
 import os
 if os.getenv('CHPL_TARGET_ARCH', '') in ['arm-thunderx', 'arm-thunderx2', 'mic-knl']:

--- a/test/release/examples/benchmarks/lulesh/lulesh.execenv
+++ b/test/release/examples/benchmarks/lulesh/lulesh.execenv
@@ -3,5 +3,5 @@
 # Guard pages are expensive on Xeon Phi. See issue #7533
 
 import os
-if os.getenv('CHPL_TARGET_ARCH', '') in ['mic-knl']:
+if os.getenv('CHPL_TARGET_ARCH', '') in ['arm-thunderx', 'arm-thunderx2', 'mic-knl']:
     print('QT_GUARD_PAGES=false')

--- a/test/release/examples/benchmarks/miniMD/miniMD.execenv
+++ b/test/release/examples/benchmarks/miniMD/miniMD.execenv
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Guard pages are expensive on Xeon Phi. See issue #7533
+# Guard pages are expensive on high core-count systems. See issue #7533
 
 import os
 if os.getenv('CHPL_TARGET_ARCH', '') in ['arm-thunderx', 'arm-thunderx2', 'mic-knl']:

--- a/test/release/examples/benchmarks/miniMD/miniMD.execenv
+++ b/test/release/examples/benchmarks/miniMD/miniMD.execenv
@@ -3,5 +3,5 @@
 # Guard pages are expensive on Xeon Phi. See issue #7533
 
 import os
-if os.getenv('CHPL_TARGET_ARCH', '') in ['mic-knl']:
+if os.getenv('CHPL_TARGET_ARCH', '') in ['arm-thunderx', 'arm-thunderx2', 'mic-knl']:
     print('QT_GUARD_PAGES=false')


### PR DESCRIPTION
In some tests, high core-count systems spend most of their time in the `mprotect()` system call when guard pages are used in qthreads.  The arm-thunderx has 96 cores per locale, and arm-thunderx2 has 64.  This change turns off guard pages for two tests where this makes a big difference.

One remaining item to investigate is that on arm-thunderx2, there appears to be more than just a performance problem.  Intermittently, high contention in the `mprotect()` system call can lead to an application hanging indefinitely, which might be an indication of a kernel bug.

Closes #10475 