### PR TITLE
Adjust --warn-unstable to not warn for dmap type construction

### DIFF
--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -922,6 +922,9 @@ static Expr* handleUnstableClassType(SymExpr* se) {
               pCall == outerCall->get(1)) {
             // 'new Owned(SomeClass(int))'
             ok = true;
+          } else if (outerCall && callMakesDmap(outerCall)) {
+            // var something: dmap( Block( ) )
+            ok = true;
           } else if (outerOuterCall && callMakesDmap(outerOuterCall)) {
             // new dmap( new Block( ) )
             ok = true;


### PR DESCRIPTION
see e.g.
test/classes/initializers/phase1/domainMaps/init-dmap-dom-arr-local.chpl

- [x] full local testing

Reviewed by @benharsh - thanks!