### PR TITLE
convert a new added by compiler for reductions to new unmanaged

### DIFF
--- a/compiler/passes/createTaskFunctions.cpp
+++ b/compiler/passes/createTaskFunctions.cpp
@@ -340,7 +340,9 @@ static void addReduceIntentSupport(FnSymbol* fn, CallExpr* call,
 
   CallExpr* newOp = new CallExpr(PRIM_NEW,
                                  reduceAt->symbol,
-                                 new NamedExpr("eltType", new SymExpr(eltType)));
+                                 new NamedExpr("eltType", new SymExpr(eltType)),
+                                 new NamedExpr(astr_chpl_manager,
+                                             new SymExpr(dtUnmanaged->symbol)));
   headAnchor->insertBefore(new CallExpr(PRIM_MOVE, globalOp, newOp));
 
   insertInitialAccumulate(headAnchor, globalOp, origSym);


### PR DESCRIPTION
to help with compiling certain reduction tests with --warn-unstable, e.g.
  test/parallel/taskPar/taskIntents/ri-coforall+on.chpl

- [x] full local testing

Reviewed by @vasslitvinov - thanks!