### PR TITLE
Fix network atomics for types not implemented in module code

### DIFF
--- a/modules/internal/comm/ugni/NetworkAtomicTypes.chpl
+++ b/modules/internal/comm/ugni/NetworkAtomicTypes.chpl
@@ -26,15 +26,7 @@ module NetworkAtomicTypes {
     else if base_type==uint(64) then return ratomic_uint64;
     else if base_type==int(32) then return ratomic_int32;
     else if base_type==int(64) then return ratomic_int64;
-    else if base_type==real then return ratomic_real64;
-    else {
-      compilerWarning("Unsupported network atomic type");
-      if base_type==uint(8) then return atomic_uint8;
-      else if base_type==uint(16) then return atomic_uint16;
-      else if base_type==int(8) then return atomic_int8;
-      else if base_type==int(16) then return atomic_int16;
-      else compilerError("Unsupported atomic type");
-    }
+    else if base_type==real(64) then return ratomic_real64;
+    else return chpl__processorAtomicType(base_type);
   }
-
 }

--- a/test/runtime/configMatters/comm/atomics.chpl
+++ b/test/runtime/configMatters/comm/atomics.chpl
@@ -2,9 +2,8 @@ config param enable_type_i32 = true;
 config param enable_type_i64 = true;
 config param enable_type_ui32 = true;
 config param enable_type_ui64 = true;
-config param enable_type_r32 = (CHPL_COMM == 'ugni'
-                                && false /* no support in module code */ );
-config param enable_type_r64 = (CHPL_COMM == 'ugni');
+config param enable_type_r32 = true;
+config param enable_type_r64 = true;
 
 config const default_do_type_flag = true;
 


### PR DESCRIPTION
We used to get compilation errors for real(32) network atomics and warnings for
8/16 bit int/uint atomics.

```chpl
// "error: Unsupported atomic type"
var a_r32: atomic real(32);

// "warning: Unsupported network atomic type" (and default to processor atomic)
var i_i8: atomic int(8);
```

Now we just default to processor atomics for real(32) and 8/16 bit integral
types without warning.

I think the old behavior was leftover from when you had to opt-into network
atomics instead of them being the default under ugni. And note that we actually
have runtime support for real(32) network atomics (implemented for real on
aries, and emulated with processor atomics on gemini) but there's no module
code yet.

Discovered as part of https://github.com/chapel-lang/chapel/pull/10533