### PR TITLE
Fix problem with forwarding paren-less method

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -3181,6 +3181,8 @@ static FnSymbol* resolveForwardedCall(CallInfo& info, bool checkOnly) {
         actual->remove();
       }
       call->baseExpr->replace(bestCall->baseExpr->remove());
+      call->partialTag = bestCall->partialTag;
+
       for_actuals(actual, bestCall) {
         call->insertAtTail(actual->remove());
       }

--- a/test/classes/forwarding/forward-owned-parethesesless-then-call.chpl
+++ b/test/classes/forwarding/forward-owned-parethesesless-then-call.chpl
@@ -1,0 +1,27 @@
+class Inner {
+  var element: int;
+  proc this(x:int) {
+    return element;
+  }
+}
+
+class Impl {
+  var theData:owned Inner;
+  proc data ref {
+    return theData;
+  }
+}
+
+record Thingy {
+  forwarding var impl:owned Impl;
+}
+
+proc test() {
+  var x = new Thingy(new owned Impl(new owned Inner(1)));
+  writeln(x);
+  writeln(x.data);
+  writeln(x.data(1));
+  // x.data
+}
+
+test();

--- a/test/classes/forwarding/forward-owned-parethesesless-then-call.good
+++ b/test/classes/forwarding/forward-owned-parethesesless-then-call.good
@@ -1,0 +1,3 @@
+(impl = {theData = {element = 1}})
+{element = 1}
+1

--- a/test/classes/forwarding/forward-unmanaged-parethesesless-then-call.chpl
+++ b/test/classes/forwarding/forward-unmanaged-parethesesless-then-call.chpl
@@ -1,0 +1,31 @@
+class Inner {
+  var element: int;
+  proc this(x:int) {
+    return element + x;
+  }
+}
+
+class Impl {
+  var theData:unmanaged Inner;
+  proc data ref {
+    return theData;
+  }
+}
+
+record Thingy {
+  forwarding var impl:unmanaged Impl;
+}
+
+proc test() {
+  var x = new Thingy(new unmanaged Impl(new unmanaged Inner(1)));
+  writeln(x);
+  writeln(x.impl.data);
+  writeln(x.impl.data(2));
+  writeln(x.data);
+  writeln(x.data(3));
+  // x.data
+  delete x.impl.theData;
+  delete x.impl;
+}
+
+test();

--- a/test/classes/forwarding/forward-unmanaged-parethesesless-then-call.good
+++ b/test/classes/forwarding/forward-unmanaged-parethesesless-then-call.good
@@ -1,0 +1,5 @@
+(impl = {theData = {element = 1}})
+{element = 1}
+3
+{element = 1}
+4


### PR DESCRIPTION
e.g.
``` chapel
 something.method(4)
```
if there is a `proc method` that is paren-less, the call (4)
applies to the result of that paren-less call, rather than being
arguments for the call itself.

(See the tests added by this PR for complete examples).

This pattern wasn't working with forwarding and that caused
failures for the LinearAlgebra tests.

- [x] verified LinearAlgebra correctness test now runs
- [x] full local testing

Reviewed by @benharsh - thanks!