### PR TITLE
chpl_launchcmd.py should wait a bit for qsub output file to appear

### DIFF
--- a/util/test/chpl_launchcmd.py
+++ b/util/test/chpl_launchcmd.py
@@ -327,7 +327,7 @@ class AbstractJob(object):
                         time.sleep(.5)
                         extra_waiting_time = time.time() - start_wait_time
                     if extra_waiting_time > 0.0:
-                        logging.warn('extra waiting time for qsub = {0} sec.'.format(extra_waiting_time))
+                        logging.debug('extra waiting time for qsub = {0} sec.'.format(extra_waiting_time))
                     return 'C', extra_waiting_time
 
             exec_start_time = time.time()


### PR DESCRIPTION
Under certain conditions, chpl_launchcmd may throw an exception
(and thus a false test error) because it looks for the qsub output
file before that file actually exists on the file system where
chpl_launchcmd is running. Maybe because chpl_launchcmd is running
on an "elogin" machine, and the NFS or whatever file transport is
slow to deliver the file from the real login node to the elogin
machine. If chpl_launchcmd allowed a little extra time for the
qsub output file to show up, everything might turn out Okay.

This change implements such a scheme with a max extra waiting time
of 30 seconds. If any extra waiting time occurred (ie, the output
file was not available immediately), a log.debug message is issued.

The extra waiting time (if any) is subtracted from the execution
time reported by sub_test as
"launchcmd reports elapsed execution time"
