### PR TITLE
Fix local testing issues from pcTest

### DIFF
--- a/test/mason/env/mason-registry.good
+++ b/test/mason/env/mason-registry.good
@@ -1,5 +1,5 @@
 MASON_HOME: $PWD/tempHome *
 MASON_REGISTRY: myRegistry|$PWD/tempHome/uncached/myRegistry *
-Updating mason-registry for myRegistry
+Updating mason-registry
 multiple (0.2.0)
 simple (0.1.0)

--- a/test/mason/mason-test/mason-test.good
+++ b/test/mason/mason-test/mason-test.good
@@ -1,4 +1,4 @@
-Updating mason-registry for registry
+Updating mason-registry
 Downloading dependency: _MasonTest1-0.2.0
 --- Results ---
 Test: nomodule Passed

--- a/test/mason/pkgconfig-tests/openssl.good
+++ b/test/mason/pkgconfig-tests/openssl.good
@@ -1,4 +1,3 @@
-Updating mason-registry for mason-registry
 
 [root]
 name = "openssl"

--- a/test/mason/pkgconfig-tests/pcTest.chpl
+++ b/test/mason/pkgconfig-tests/pcTest.chpl
@@ -25,7 +25,7 @@ proc main() {
     w.close();
   }
 
-  var args : [1..0] string;
+  var args = ["--no-update-registry"]; 
   var configs = UpdateLock(args, tf, temp.tryGetPath());
   var lock = open(temp.tryGetPath(), iomode.r);
   var lockFile = parseToml(lock);

--- a/test/mason/run/mason-run.good
+++ b/test/mason/run/mason-run.good
@@ -1,4 +1,4 @@
-Updating mason-registry for registry
+Updating mason-registry
 Compiling FizzBuzz
 Build Successful
 

--- a/test/mason/subdir-commands/mason-run.good
+++ b/test/mason/subdir-commands/mason-run.good
@@ -1,4 +1,4 @@
-Updating mason-registry for registry
+Updating mason-registry
 Compiling FizzBuzz
 Build Successful
 

--- a/tools/mason/MasonUpdate.chpl
+++ b/tools/mason/MasonUpdate.chpl
@@ -135,7 +135,7 @@ proc updateRegistry(tf: string, args : [] string) {
     if isDir(registryHome) {
       var pullRegistry = 'git pull -q origin master';
       if tf == "Mason.toml" then
-        writeln("Updating mason-registry for ", name);
+        writeln("Updating mason-registry");
       gitC(registryHome, pullRegistry);
     }
     // Registry has moved or does not exist
@@ -144,7 +144,7 @@ proc updateRegistry(tf: string, args : [] string) {
       const localRegistry = registryHome;
       mkdir(localRegistry, parents=true);
       const cloneRegistry = 'git clone -q ' + registry + ' .';
-      writeln("Updating mason-registry for ", name);
+      writeln("Updating mason-registry");
       gitC(localRegistry, cloneRegistry);
     }
   }


### PR DESCRIPTION
The fix put in yesterday #10515 fixed the nightly testing, but did not address local testing. Local testing still failed as there was still a mason-registry on most users machines. This PR should fix that while still passing nightly testing.