### PR TITLE
Convert uses of internal processor atomic types to chpl__processorAtomicType

### DIFF
--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -399,8 +399,7 @@ class LocBlockArr {
   var locRAD: unmanaged LocRADCache(eltType, rank, idxType, stridable); // non-nil if doRADOpt=true
   pragma "local field"
   var myElems: [locDom.myBlock] eltType;
-  var locRADLock: atomicbool; // This will only be accessed locally
-                              // force the use of processor atomics
+  var locRADLock: chpl__processorAtomicType(bool); // only accessed locally
 
   // These functions will always be called on this.locale, and so we do
   // not have an on statement around the while loop below (to avoid

--- a/modules/dists/CyclicDist.chpl
+++ b/modules/dists/CyclicDist.chpl
@@ -951,8 +951,7 @@ class LocCyclicArr {
   var locRAD: LocRADCache(eltType, rank, idxType, stridable); // non-nil if doRADOpt=true
   var locCyclicRAD: LocCyclicRADCache(rank, idxType); // see below for why
   var myElems: [locDom.myBlock] eltType;
-  var locRADLock: atomicbool; // This will only be accessed locally, so
-                              // force the use of processor atomics
+  var locRADLock: chpl__processorAtomicType(bool); // only accessed locally
 
   // These functions will always be called on this.locale, and so we do
   // not have an on statement around the while loop below (to avoid

--- a/modules/dists/StencilDist.chpl
+++ b/modules/dists/StencilDist.chpl
@@ -352,8 +352,7 @@ class LocStencilArr {
   var locRAD: unmanaged LocRADCache(eltType, rank, idxType, stridable); // non-nil if doRADOpt=true
   pragma "local field"
   var myElems: [locDom.myFluff] eltType;
-  var locRADLock: atomicbool; // This will only be accessed locally
-                              // force the use of processor atomics
+  var locRADLock: chpl__processorAtomicType(bool); // only accessed locally
 
   // TODO: use void type when packed update is disabled
   var recvBufs, sendBufs : [locDom.NeighDom] [locDom.bufDom] eltType;

--- a/modules/internal/AtomicsCommon.chpl
+++ b/modules/internal/AtomicsCommon.chpl
@@ -26,7 +26,7 @@ module AtomicsCommon {
     // atomics are available. In the future, we could have both
     // network and processor atomic versions of atomic_refcnt if
     // necessary.
-    var _cnt:atomic_int64;
+    var _cnt:chpl__processorAtomicType(int);
     // Reference counting implemented according to
 // http://www.chaoticmind.net/~hcb/projects/boost.atomic/doc/atomic/usage_examples.html#boost_atomic.usage_examples.example_reference_counters
 // http://stackoverflow.com/questions/10268737/c11-atomics-and-intrusive-shared-pointer-reference-count

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -170,7 +170,7 @@ module ChapelArray {
   // Explicitly use a processor atomic, as most calls to this function are
   // likely be on locale 0
   pragma "no doc"
-  var numPrivateObjects: atomic_int64;
+  var numPrivateObjects: chpl__processorAtomicType(int);
   pragma "no doc"
   param nullPid = -1;
 

--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -31,10 +31,9 @@ module ChapelDistribution {
     // The common case seems to be local access to this class, so we
     // will use explicit processor atomics, even when network
     // atomics are available
-    var _doms: list(unmanaged BaseDom);     // domains declared over this distribution
-    var _domsLock: atomicbool;    //   and lock for concurrent access
-    var _free_when_no_doms: bool; // true when the original _distribution
-                                  // has been destroyed
+    var _doms: list(unmanaged BaseDom); // domains declared over this distribution
+    var _domsLock: chpl__processorAtomicType(bool); // lock for concurrent access
+    var _free_when_no_doms: bool; // true when original _distribution is destroyed
     var pid:int = nullPid; // privatized ID, if privatization is supported
 
     proc deinit() {
@@ -175,7 +174,7 @@ module ChapelDistribution {
     var _arrs_containing_dom: int; // number of arrays using this domain
                                    // as var A: [D] [1..2] real
                                    // is using {1..2}
-    var _arrsLock: atomicbool; //   and lock for concurrent access
+    var _arrsLock: chpl__processorAtomicType(bool); // lock for concurrent access
     var _free_when_no_arrs: bool;
     var pid:int = nullPid; // privatized ID, if privatization is supported
 

--- a/modules/internal/ChapelError.chpl
+++ b/modules/internal/ChapelError.chpl
@@ -105,7 +105,7 @@ module ChapelError {
   pragma "no doc"
   record chpl_TaskErrors {
     var _head: unmanaged Error;
-    var _errorsLock: atomicbool;
+    var _errorsLock: chpl__processorAtomicType(bool);
     // this atomic controls:
     //  - _head
     //  - all list elements ->_next

--- a/modules/internal/ChapelReduce.chpl
+++ b/modules/internal/ChapelReduce.chpl
@@ -67,7 +67,7 @@ module ChapelReduce {
 
   pragma "ReduceScanOp"
   class ReduceScanOp {
-    var l: atomicbool; // only accessed locally
+    var l: chpl__processorAtomicType(bool); // only accessed locally
 
     proc lock() {
       var lockAttempts = 0,

--- a/modules/internal/DefaultAssociative.chpl
+++ b/modules/internal/DefaultAssociative.chpl
@@ -61,8 +61,8 @@ module DefaultAssociative {
   
     // We explicitly use processor atomics here since this is not
     // by design a distributed data structure
-    var numEntries: atomic_int64;
-    var tableLock: atomicbool; // do not access directly, use function below
+    var numEntries: chpl__processorAtomicType(int);
+    var tableLock: chpl__processorAtomicType(bool); // do not access directly
     var tableSizeNum = 1;
     var tableSize : int;
     var tableDom = {0..tableSize-1};

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -881,8 +881,7 @@ module DefaultRectangular {
     var targetLocDom: domain(rank);
     var RAD: [targetLocDom] _remoteAccessData(eltType, rank, idxType,
                                               stridable);
-    var RADLocks: [targetLocDom] atomicbool; // only accessed locally
-                                             // force processor atomics
+    var RADLocks: [targetLocDom] chpl__processorAtomicType(bool); // only accessed locally
 
     proc init(type eltType, param rank: int, type idxType,
               param stridable: bool, newTargetLocDom: domain(rank)) {

--- a/test/release/examples/benchmarks/ssca2/SSCA2_Modules/SSCA2_kernels.chpl
+++ b/test/release/examples/benchmarks/ssca2/SSCA2_Modules/SSCA2_kernels.chpl
@@ -561,7 +561,7 @@ module SSCA2_kernels
   //
   record taskPrivateArrayData {
     type vertex;
-    var min_distance  : atomic_int64; // used only on home locale
+    var min_distance  : chpl__processorAtomicType(int); // used only on home locale
     var path_count$   : atomic real;
     var depend        : real;
     var children_list : child_struct(vertex);

--- a/test/studies/comd/elegant/arrayOfStructs/util/AccumStencilDist.chpl
+++ b/test/studies/comd/elegant/arrayOfStructs/util/AccumStencilDist.chpl
@@ -149,8 +149,7 @@ class LocAccumStencilArr {
   var locRAD: unmanaged LocRADCache(eltType, rank, idxType, stridable); // non-nil if doRADOpt=true
   pragma "local field"
   var myElems: [locDom.myFluff] eltType;
-  var locRADLock: atomicbool; // This will only be accessed locally
-                              // force the use of processor atomics
+  var locRADLock: chpl__processorAtomicType(bool); // only accessed locally
 
   var recvM, recvP : [locDom.recvDom] eltType;
   var recvMFlag, recvPFlag : atomic bool;

--- a/test/studies/hpcc/HPL/vass/hpl.hpcc2012.chpl
+++ b/test/studies/hpcc/HPL/vass/hpl.hpcc2012.chpl
@@ -169,9 +169,9 @@ compilerAssert(CHPL_NETWORK_ATOMICS == "none",
   // Additional data structures for backwardSub().
   //
   type cpuAtomicElemType = // presently unused
-    if elemType == real(64) then atomic_real64
+    if elemType == real(64) then chpl__processorAtomicType(real)
     else compilerError("need to define cpuAtomicElemType");
-  type cpuAtomicCountType = atomic_int64;
+  type cpuAtomicCountType = chpl__processorAtomicType(int);
   const replPD = {0..#blkSize} dmapped new dmap(distReplicated);
 
   // for the working 'x' vector, replX, we'll reuse replK

--- a/test/studies/hpcc/HPL/vass/hpl.performance.chpl
+++ b/test/studies/hpcc/HPL/vass/hpl.performance.chpl
@@ -171,9 +171,9 @@ var tInit, tPS1iter, tUBR1iter, tSC1call, tLF1iter, tBScall, tVer: VTimer;
   // additional data structures for backwardSub()
   //
   type cpuAtomicElemType = // presently unused
-    if elemType == real(64) then atomic_real64
+    if elemType == real(64) then chpl__processorAtomicType(real)
     else compilerError("need to define cpuAtomicElemType");
-  type cpuAtomicCountType = atomic_int64;
+  type cpuAtomicCountType = chpl__processorAtomicType(int);
   const replPD = {0..#blkSize} dmapped new dmap(distReplicated);
 
   // the working 'x' vector - we reuse replK

--- a/test/studies/lulesh/bradc/lulesh-dense.chpl
+++ b/test/studies/lulesh/bradc/lulesh-dense.chpl
@@ -203,11 +203,13 @@ var elemBC: [Elems] int,
 
 /* Nodal fields */
 
+type atomicReal = if useNetworkAtomics then atomic real
+                                       else chpl__processorAtomicType(real);
 var xd, yd, zd: [Nodes] real, // velocities
 
     xdd, ydd, zdd: [Nodes] real, // acceleration
 
-    fx, fy, fz: [Nodes] if useNetworkAtomics then atomic real else atomic_real64, // forces
+    fx, fy, fz: [Nodes] atomicReal, // forces
 
     nodalMass: [Nodes] real; // mass
 

--- a/test/users/aroonsharma/CyclicZipOpt.chpl
+++ b/test/users/aroonsharma/CyclicZipOpt.chpl
@@ -1016,8 +1016,7 @@ class LocCyclicZipOptArr {
   var locRAD: LocRADCache(eltType, rank, idxType); // non-nil if doRADOpt=true
   var locCyclicZipOptRAD: LocCyclicZipOptRADCache(rank, idxType); // see below for why
   var myElems: [locDom.myBlock] eltType;
-  var locRADLock: atomicbool; // This will only be accessed locally, so
-                              // force the use of processor atomics
+  var locRADLock: chpl__processorAtomicType(bool); // only accessed locally
 
   // These function will always be called on this.locale, and so we do
   // not have an on statement around the while loop below (to avoid


### PR DESCRIPTION
Convert uses of things like `atomic_int64` to `chpl__processorAtomicType(int)`.
The atomic_* types are the internal names for the processor atomic
implementation, but they're going to be removed as part of #10493.

chpl__processorAtomicType() isn't user-facing either, but it's the best we have
until we implement a user-facing mechanism to force processor atomics. See
https://github.com/chapel-lang/chapel/issues/10551 for more information.