### PR TITLE
Update LCALS tests to compile with --warn-unstable

### DIFF
--- a/test/release/examples/benchmarks/lcals/LCALSDataTypes.chpl
+++ b/test/release/examples/benchmarks/lcals/LCALSDataTypes.chpl
@@ -35,7 +35,7 @@ module LCALSDataTypes {
     var num_suite_passes: int;
     var loop_samp_frac: real;
 
-    var ref_loop_stat: LoopStat;
+    var ref_loop_stat: unmanaged LoopStat;
 
     var loop_weights: [weight_group_dom] real;
 
@@ -44,7 +44,7 @@ module LCALSDataTypes {
     var cache_flush_data: [cache_flush_data_dom] real;
     var cache_flush_data_sum: real;
 
-    var loop_test_stats: [loop_variant_dom] [loop_kernel_dom] LoopStat;
+    var loop_test_stats: [loop_variant_dom] [loop_kernel_dom] unmanaged LoopStat;
 
     proc getLoopStats(loop_variant: LoopVariantID) ref {
       return loop_test_stats[loop_variant];
@@ -65,7 +65,7 @@ module LCALSDataTypes {
     var loop_weight: real;
     var loop_length_dom = {LoopLength.LONG..LoopLength.SHORT};
 
-    var loop_run_time: [loop_length_dom] vector(real);
+    var loop_run_time: [loop_length_dom] unmanaged vector(real);
     var loop_run_count: [loop_length_dom] int;
     var mean: [loop_length_dom] real;
     var std_dev: [loop_length_dom] real;
@@ -80,7 +80,7 @@ module LCALSDataTypes {
     var loop_chksum: [loop_length_dom] real;
 
     proc init() {
-      loop_run_time = for i in loop_length_dom do new vector(real);
+      loop_run_time = for i in loop_length_dom do new unmanaged vector(real);
     }
 
     proc deinit() {
@@ -263,7 +263,7 @@ module LCALSDataTypes {
     // class implements the same pattern used in the LCALS reference.
     //
     // var RealArray_3D_2xNx4: [0..#s_num_3D_2xNx4_Real_arrays][0..#2, 0..#aligned_chunksize, 0..#4] real;
-    var RealArray_3D_2xNx4: [0..#s_num_3D_2xNx4_Real_arrays] LCALS_Overlapping_Array_3D(real) = [i in 0..#s_num_3D_2xNx4_Real_arrays] new LCALS_Overlapping_Array_3D(real, 2*4*aligned_chunksize); // 2 X loop_length X 4 array size
+    var RealArray_3D_2xNx4: [0..#s_num_3D_2xNx4_Real_arrays] unmanaged LCALS_Overlapping_Array_3D(real) = [i in 0..#s_num_3D_2xNx4_Real_arrays] new unmanaged LCALS_Overlapping_Array_3D(real, 2*4*aligned_chunksize); // 2 X loop_length X 4 array size
 
     var RealArray_scalars: [0..#s_num_Real_scalars] real;
     proc deinit() {

--- a/test/release/examples/benchmarks/lcals/LCALSLoops.chpl
+++ b/test/release/examples/benchmarks/lcals/LCALSLoops.chpl
@@ -25,7 +25,7 @@ module LCALSLoops {
     ia = 0;
   }
 
-  proc initData(ra: LCALS_Overlapping_Array_3D(real), id: int) {
+  proc initData(ra: unmanaged LCALS_Overlapping_Array_3D(real), id: int) {
     const factor: Real_type = if id % 2 != 0 then 0.1 else 0.2;
     for (r,j) in zip(ra, 0..) {
       r = factor*(j + 1.1)/(j + 1.12345);
@@ -39,7 +39,7 @@ module LCALSLoops {
     }
   }
 
-  proc loopInit(iloop:LoopKernelID, stat: LoopStat) {
+  proc loopInit(iloop:LoopKernelID, stat: unmanaged LoopStat) {
     var loop_data = getLoopData();
     flushCache();
     stat.loop_is_run = true;
@@ -215,11 +215,11 @@ module LCALSLoops {
     }
   }
 
-  proc initChksum(stat: LoopStat, ilength: LoopLength) {
+  proc initChksum(stat: unmanaged LoopStat, ilength: LoopLength) {
     stat.loop_chksum[ilength] = 0.0;
   }
 
-  proc loopFinalize(iloop: LoopKernelID, stat: LoopStat, ilength: LoopLength) {
+  proc loopFinalize(iloop: LoopKernelID, stat: unmanaged LoopStat, ilength: LoopLength) {
     initChksum(stat, ilength);
     var loop_data = getLoopData();
     select iloop {
@@ -343,7 +343,7 @@ module LCALSLoops {
     }
   }
 
-  proc updateChksum(stat: LoopStat, ilength: LoopLength, ra: LCALS_Overlapping_Array_3D(real), scale_factor: real = 1.0) {
+  proc updateChksum(stat: unmanaged LoopStat, ilength: LoopLength, ra: unmanaged LCALS_Overlapping_Array_3D(real), scale_factor: real = 1.0) {
     var len = ra.len;
     var tchk = stat.loop_chksum[ilength];
     for (j, dat) in zip(0..#len, ra) {
@@ -352,7 +352,7 @@ module LCALSLoops {
     stat.loop_chksum[ilength] = tchk;
   }
 
-  proc updateChksum(stat: LoopStat, ilength: LoopLength, ra: [] real, scale_factor: real = 1.0) {
+  proc updateChksum(stat: unmanaged LoopStat, ilength: LoopLength, ra: [] real, scale_factor: real = 1.0) {
     use LongDouble;
 
     ref data = ra;
@@ -365,10 +365,10 @@ module LCALSLoops {
     stat.loop_chksum[ilength] = tchk:real;
   }
 
-  proc updateChksum(stat: LoopStat, ilength: LoopLength, val: real) {
+  proc updateChksum(stat: unmanaged LoopStat, ilength: LoopLength, val: real) {
     stat.loop_chksum[ilength] += val;
   }
-  proc updateChksum(stat: LoopStat, ilength: LoopLength, ca: [] complex, scale_factor: real = 1.0) {
+  proc updateChksum(stat: unmanaged LoopStat, ilength: LoopLength, ca: [] complex, scale_factor: real = 1.0) {
     ref data = ca;
     var len = ca.numElements;
     var tchk = stat.loop_chksum[ilength];
@@ -378,11 +378,11 @@ module LCALSLoops {
     stat.loop_chksum[ilength] = tchk;
   }
 
-  proc runReferenceLoop0(lstat: LoopStat, ilen: LoopLength) {
+  proc runReferenceLoop0(lstat: unmanaged LoopStat, ilen: LoopLength) {
     var loop_data = getLoopData();
     var len: int = lstat.loop_length[ilen];
     var num_samples = lstat.samples_per_pass[ilen];
-    var ltimer = new LoopTimer();
+    var ltimer = new unmanaged LoopTimer();
 
     loopInit(LoopKernelID.REF_LOOP, lstat);
 
@@ -399,12 +399,12 @@ module LCALSLoops {
     copyTimer(lstat, ilen, ltimer);
   }
 
-  proc runReferenceLoop1(lstat: LoopStat, ilen: LoopLength) {
+  proc runReferenceLoop1(lstat: unmanaged LoopStat, ilen: LoopLength) {
     var loop_data = getLoopData();
 
     var len = lstat.loop_length[ilen];
     var num_samples = lstat.samples_per_pass[ilen];
-    var ltimer = new LoopTimer();
+    var ltimer = new unmanaged LoopTimer();
 
     loopInit(LoopKernelID.REF_LOOP, lstat);
 

--- a/test/release/examples/benchmarks/lcals/LCALSMain.chpl
+++ b/test/release/examples/benchmarks/lcals/LCALSMain.chpl
@@ -189,7 +189,7 @@ proc main {
   writeln("\n DONE!!! ");
 }
 
-proc computeStats(ilv: LoopVariantID, loop_stats: [] LoopStat, do_fom: bool) {
+proc computeStats(ilv: LoopVariantID, loop_stats: [] unmanaged LoopStat, do_fom: bool) {
   for stat in loop_stats {
     for ilen in stat.loop_length_dom {
       if stat.loop_run_count[ilen] > 0 {
@@ -709,7 +709,7 @@ proc computeReferenceLoopTimes() {
   var suite_info = getLoopSuiteRunInfo();
   var ref_loop_stat = suite_info.ref_loop_stat;
 
-  var lstat0: LoopStat;
+  var lstat0: unmanaged LoopStat;
 
   writeln("\n computeReferenceLoopTimes...");
 
@@ -719,7 +719,7 @@ proc computeReferenceLoopTimes() {
     runReferenceLoop0(lstat0, ilen);
   }
 
-  var lstat1: LoopStat;
+  var lstat1: unmanaged LoopStat;
   lstat1 = ref_loop_stat;
 
   for ilen in suite_info.loop_length_dom {
@@ -734,7 +734,7 @@ proc computeReferenceLoopTimes() {
 
 proc defineReferenceLoopRunInfo() {
   var suite_info = getLoopSuiteRunInfo();
-  var ref_loop_stat = new LoopStat();
+  var ref_loop_stat = new unmanaged LoopStat();
   suite_info.ref_loop_stat = ref_loop_stat;
 
   ref_loop_stat.loop_length[LoopLength.LONG]        = 24336;
@@ -777,7 +777,7 @@ proc defineLoopSuiteRunInfo(run_variants, run_loop,
   for ilv in run_variants.domain {
     for iloop in suite_info.loop_kernel_dom {
       var loop_name = iloop:string;
-      var loop_stat = new LoopStat();
+      var loop_stat = new unmanaged LoopStat();
       var max_loop_indx = 0;
       if run_loop[iloop] {
         select iloop {
@@ -1149,6 +1149,6 @@ proc defineLoopSuiteRunInfo(run_variants, run_loop,
     }
   }
   defineReferenceLoopRunInfo();
-  s_loop_data = new LoopData(max(max_loop_length, suite_info.ref_loop_stat.loop_length[LoopLength.LONG]));
+  s_loop_data = new unmanaged LoopData(max(max_loop_length, suite_info.ref_loop_stat.loop_length[LoopLength.LONG]));
 
 }

--- a/test/release/examples/benchmarks/lcals/LCALSStatic.chpl
+++ b/test/release/examples/benchmarks/lcals/LCALSStatic.chpl
@@ -1,8 +1,8 @@
 module LCALSStatic {
   use LCALSDataTypes;
 
-  var s_loop_data: LoopData;
-  var s_loop_suite_run_info = new LoopSuiteRunInfo();
+  var s_loop_data: unmanaged LoopData;
+  var s_loop_suite_run_info = new unmanaged LoopSuiteRunInfo();
 
   proc getLoopSuiteRunInfo() {
     return s_loop_suite_run_info;

--- a/test/release/examples/benchmarks/lcals/RunARawLoops.chpl
+++ b/test/release/examples/benchmarks/lcals/RunARawLoops.chpl
@@ -2,7 +2,7 @@ module RunARawLoops {
   use LCALSDataTypes;
   use Timer;
 
-  proc runARawLoops(loop_stats:[] LoopStat, run_loop:[] bool, ilength: LoopLength) {
+  proc runARawLoops(loop_stats:[] unmanaged LoopStat, run_loop:[] bool, ilength: LoopLength) {
     var loop_suite_run_info = getLoopSuiteRunInfo();
     var loop_data = getLoopData();
 
@@ -11,7 +11,7 @@ module RunARawLoops {
         var stat = loop_stats[iloop];
         var len = stat.loop_length[ilength];
         var num_samples = stat.samples_per_pass[ilength];
-        var ltimer = new LoopTimer();
+        var ltimer = new unmanaged LoopTimer();
 
         select iloop {
           when LoopKernelID.PRESSURE_CALC {

--- a/test/release/examples/benchmarks/lcals/RunBRawLoops.chpl
+++ b/test/release/examples/benchmarks/lcals/RunBRawLoops.chpl
@@ -9,7 +9,7 @@ module RunBRawLoops {
     return 1.0 / sqrt(denom);
   }
 
-  proc runBRawLoops(loop_stats:[] LoopStat, run_loop:[] bool, ilength: LoopLength) {
+  proc runBRawLoops(loop_stats:[] unmanaged LoopStat, run_loop:[] bool, ilength: LoopLength) {
     var loop_suite_run_info = getLoopSuiteRunInfo();
     var loop_data = getLoopData();
     for iloop in loop_suite_run_info.loop_kernel_dom {
@@ -17,7 +17,7 @@ module RunBRawLoops {
         var stat = loop_stats[iloop];
         var len = stat.loop_length[ilength];
         var num_samples = stat.samples_per_pass[ilength];
-        var ltimer = new LoopTimer();
+        var ltimer = new unmanaged LoopTimer();
 
         select iloop {
           when LoopKernelID.INIT3 {

--- a/test/release/examples/benchmarks/lcals/RunCRawLoops.chpl
+++ b/test/release/examples/benchmarks/lcals/RunCRawLoops.chpl
@@ -2,7 +2,7 @@ module RunCRawLoops {
   use LCALSDataTypes;
   use Timer;
 
-  proc runCRawLoops(loop_stats:[] LoopStat, run_loop:[] bool, ilength: LoopLength) {
+  proc runCRawLoops(loop_stats:[] unmanaged LoopStat, run_loop:[] bool, ilength: LoopLength) {
     var loop_suite_run_info = getLoopSuiteRunInfo();
     var loop_data = getLoopData();
     for iloop in loop_suite_run_info.loop_kernel_dom {
@@ -10,7 +10,7 @@ module RunCRawLoops {
         var stat = loop_stats[iloop];
         var len = stat.loop_length[ilength];
         var num_samples = stat.samples_per_pass[ilength];
-        var ltimer = new LoopTimer();
+        var ltimer = new unmanaged LoopTimer();
 
         select iloop {
           when LoopKernelID.HYDRO_1D {

--- a/test/release/examples/benchmarks/lcals/RunParallelRawLoops.chpl
+++ b/test/release/examples/benchmarks/lcals/RunParallelRawLoops.chpl
@@ -2,7 +2,7 @@ module RunParallelRawLoops {
   use LCALSDataTypes;
   use Timer;
 
-  proc runParallelRawLoops(loop_stats:[] LoopStat, run_loop:[] bool, ilength: LoopLength) {
+  proc runParallelRawLoops(loop_stats:[] unmanaged LoopStat, run_loop:[] bool, ilength: LoopLength) {
     var loop_suite_run_info = getLoopSuiteRunInfo();
     var loop_data = getLoopData();
 
@@ -11,7 +11,7 @@ module RunParallelRawLoops {
         var stat = loop_stats[iloop];
         var len = stat.loop_length[ilength];
         var num_samples = stat.samples_per_pass[ilength];
-        var ltimer = new LoopTimer();
+        var ltimer = new unmanaged LoopTimer();
 
         select iloop {
           when LoopKernelID.PRESSURE_CALC {

--- a/test/release/examples/benchmarks/lcals/RunSPMDRawLoops.chpl
+++ b/test/release/examples/benchmarks/lcals/RunSPMDRawLoops.chpl
@@ -8,7 +8,7 @@ module RunSPMDRawLoops {
   use LCALSDataTypes;
   use Timer, Barriers, RangeChunk;
 
-  proc runSPMDRawLoops(loop_stats:[] LoopStat, run_loop:[] bool, ilength: LoopLength) {
+  proc runSPMDRawLoops(loop_stats:[] unmanaged LoopStat, run_loop:[] bool, ilength: LoopLength) {
     var loop_suite_run_info = getLoopSuiteRunInfo();
     var loop_data = getLoopData();
 
@@ -29,7 +29,7 @@ module RunSPMDRawLoops {
         var stat = loop_stats[iloop];
         var len = stat.loop_length[ilength];
         var num_samples = stat.samples_per_pass[ilength];
-        var ltimer = new LoopTimer();
+        var ltimer = new unmanaged LoopTimer();
 
         select iloop {
           when LoopKernelID.PRESSURE_CALC {

--- a/test/release/examples/benchmarks/lcals/RunVectorizeOnlyRawLoops.chpl
+++ b/test/release/examples/benchmarks/lcals/RunVectorizeOnlyRawLoops.chpl
@@ -2,7 +2,7 @@ module RunVectorizeOnlyRawLoops {
   use LCALSDataTypes;
   use Timer;
 
-  proc runVectorizeOnlyRawLoops(loop_stats: [] LoopStat, run_loop:[] bool, ilength: LoopLength) {
+  proc runVectorizeOnlyRawLoops(loop_stats: [] unmanaged LoopStat, run_loop:[] bool, ilength: LoopLength) {
     var loop_suite_run_info = getLoopSuiteRunInfo();
     var loop_data = getLoopData();
 
@@ -11,7 +11,7 @@ module RunVectorizeOnlyRawLoops {
         var stat = loop_stats[iloop];
         var len = stat.loop_length[ilength];
         var num_samples = stat.samples_per_pass[ilength];
-        var ltimer = new LoopTimer();
+        var ltimer = new unmanaged LoopTimer();
 
         select iloop {
           when LoopKernelID.PRESSURE_CALC {

--- a/test/release/examples/benchmarks/lcals/Timer.chpl
+++ b/test/release/examples/benchmarks/lcals/Timer.chpl
@@ -69,16 +69,16 @@ module Timer {
 
 
   class LoopTimer {
-    var t: TimerImpl;
+    var t: unmanaged TimerImpl;
     var was_run: bool;
 
     proc init(timerType: TimerType = defaultTimerType) {
       if timerType == TimerType.Chapel {
-        t = new ChapelTimer();
+        t = new unmanaged ChapelTimer();
       } else if timerType == TimerType.Clock then {
-        t = new ClockTimer();
+        t = new unmanaged ClockTimer();
       } else if timerType == TimerType.Cycle then {
-        t = new CycleTimer();
+        t = new unmanaged CycleTimer();
       } else {
         halt("Unknown timer type");
       }
@@ -100,7 +100,7 @@ module Timer {
     }
   }
 
-  proc copyTimer(loop_stat: LoopStat, ilength: LoopLength, loop_timer: LoopTimer) {
+  proc copyTimer(loop_stat: unmanaged LoopStat, ilength: LoopLength, loop_timer: unmanaged LoopTimer) {
     if loop_timer.was_run {
       const run_time = loop_timer.elapsed();
       loop_stat.loop_run_time[ilength].push_back(run_time);


### PR DESCRIPTION
Updates LCALS to use unmanaged to pass with --warn-unstable (except for an
enum-related error). This is a first step -- in the future it would be better
to use `borrowed` `owned` and `shared`.

- [x] full local testing

Reviewed by @daviditen - thanks!