### PR TITLE
Update hpcc benchmarks to pass with --warn-unstable

### DIFF
--- a/test/release/examples/benchmarks/hpcc/ptrans.chpl
+++ b/test/release/examples/benchmarks/hpcc/ptrans.chpl
@@ -62,10 +62,10 @@ proc main() {
   // Create Block-Cyclic distributions for both the Matrix and its
   // transpose:
   //
-  const MatrixDist = new BlockCyclic(startIdx=(1,1),
+  const MatrixDist = new unmanaged BlockCyclic(startIdx=(1,1),
                                      blocksize=(rowBlkSize, colBlkSize));
 
-  const TransposeDist = new BlockCyclic(startIdx=(1,1),
+  const TransposeDist = new unmanaged BlockCyclic(startIdx=(1,1),
                                         blocksize=(colBlkSize, rowBlkSize));
 
   //

--- a/test/release/examples/benchmarks/hpcc/stream-ep.chpl
+++ b/test/release/examples/benchmarks/hpcc/stream-ep.chpl
@@ -153,7 +153,7 @@ proc printConfiguration() {
 // Initialize vectors B and C using a random stream of values
 //
 proc initVectors(B, C) {
-  var randlist = new borrowed RandomStream(eltType=real, seed=seed);
+  var randlist = new owned RandomStream(eltType=real, seed=seed);
 
   randlist.fillRandom(B);
   randlist.fillRandom(C);

--- a/test/release/examples/benchmarks/hpcc/stream.chpl
+++ b/test/release/examples/benchmarks/hpcc/stream.chpl
@@ -105,7 +105,7 @@ proc printConfiguration() {
 // optionally print them to the console
 //
 proc initVectors(B, C) {
-  var randlist = new NPBRandomStream(eltType=real, seed=seed);
+  var randlist = new owned NPBRandomStream(eltType=real, seed=seed);
 
   randlist.fillRandom(B);
   randlist.fillRandom(C);
@@ -114,8 +114,6 @@ proc initVectors(B, C) {
     writeln("B is: ", B, "\n");
     writeln("C is: ", C, "\n");
   }
-
-  delete randlist;
 }
 
 //

--- a/test/release/examples/benchmarks/hpcc/variants/stream-promoted.chpl
+++ b/test/release/examples/benchmarks/hpcc/variants/stream-promoted.chpl
@@ -103,7 +103,7 @@ proc printConfiguration() {
 // optionally print them to the console
 //
 proc initVectors(B, C) {
-  var randlist = new NPBRandomStream(eltType=real, seed=seed);
+  var randlist = new owned NPBRandomStream(eltType=real, seed=seed);
 
   randlist.fillRandom(B);
   randlist.fillRandom(C);
@@ -112,8 +112,6 @@ proc initVectors(B, C) {
     writeln("B is: ", B, "\n");
     writeln("C is: ", C, "\n");
   }
-
-  delete randlist;
 }
 
 //


### PR DESCRIPTION
Updates release/examples/benchmarks/hpcc to
use delete-free features and to pass with --warn-unstable.

- [x] full local testing

Reviewed by @ben-albrecht - thanks!