### PR TITLE
Allow DimensionalDist2D to take ownership of sub-dists

### DIFF
--- a/modules/dists/DimensionalDist2D.chpl
+++ b/modules/dists/DimensionalDist2D.chpl
@@ -385,10 +385,11 @@ class LocDimensionalArr {
 
 // initializer
 // gotta list all the things we let the user set
+pragma "no borrow convert"
 proc DimensionalDist2D.init(
   targetLocales: [] locale,
-  di1,
-  di2,
+  in di1,
+  in di2,
   name: string = "dimensional distribution",
   type idxType = int,
   dataParTasksPerLocale: int      = getDataParTasksPerLocale(),
@@ -410,7 +411,7 @@ proc DimensionalDist2D.init(
 
   checkInvariants();
 
-  _passLocalLocIDsDist(di1, true, di2, true,
+  _passLocalLocIDsDist(this.di1, true, this.di2, true,
                      this.targetLocales, true, this.targetLocales.domain.low);
 }
 
@@ -421,9 +422,10 @@ proc DimensionalDist2D.init(
 // using 'Locales' for targetLocales by default.
 // Recall that di1 and di2 determine the number of locales in each dimension.
 //
+pragma "no borrow convert"
 proc newDimensionalDist2D(
-  di1,
-  di2,
+  in di1,
+  in di2,
   targetLocales: [] locale = Locales,
   name: string = "dimensional distribution",
   type idxType = int,

--- a/modules/dists/DimensionalDist2D.chpl
+++ b/modules/dists/DimensionalDist2D.chpl
@@ -244,6 +244,8 @@ class DimensionalDist2D : BaseDist {
   proc targetIds return targetLocales.domain;
 
   // the dimension specifiers - ones being combined
+  const managed_di1, managed_di2;
+  // these ones are always unmanaged
   const di1, di2;
 
   // for debugging/tracing (remove later)
@@ -397,8 +399,12 @@ proc DimensionalDist2D.init(
   dataParMinGranularity: int      = getDataParMinGranularity()
 ) {
   this.targetLocales = targetLocales;
-  this.di1 = di1;
-  this.di2 = di2;
+  var unmanaged_di1 = _to_unmanaged(di1.borrow());
+  var unmanaged_di2 = _to_unmanaged(di2.borrow());
+  this.managed_di1 = di1;
+  this.managed_di2 = di2;
+  this.di1 = unmanaged_di1;
+  this.di2 = unmanaged_di2;
   this.name = name;
   this.idxType = idxType;
   this.dataParTasksPerLocale = if dataParTasksPerLocale==0
@@ -518,6 +524,8 @@ proc DimensionalDist2D.dsiPrivatize(privatizeData) {
   return new unmanaged DimensionalDist2D(targetLocales = privTargetLocales,
                              name          = privatizeData(2),
                              idxType       = this.idxType,
+                             managed_di1t  = managed_di1.type,
+                             managed_di2t  = managed_di2.type,
                              di1           = di1new,
                              di2           = di2new,
                              dataParTasksPerLocale     = privatizeData(3),
@@ -532,13 +540,20 @@ proc DimensionalDist2D.init(param dummy: int,
   targetLocales: [] locale,
   name,
   type idxType,
+  type managed_di1t,
+  type managed_di2t,
   di1,
   di2,
   dataParTasksPerLocale,
   dataParIgnoreRunningTasks,
   dataParMinGranularity
 ) {
+  var empty1:managed_di1t;
+  var empty2:managed_di2t;
+
   this.targetLocales = targetLocales;
+  this.managed_di1 = empty1;
+  this.managed_di2 = empty2;
   this.di1 = di1;
   this.di2 = di2;
   this.name = name;

--- a/test/release/examples/primers/distributions.chpl
+++ b/test/release/examples/primers/distributions.chpl
@@ -283,8 +283,8 @@ MyLocales = reshape(Locales[0..#nl1*nl2], MyLocaleView);
 
 const DimReplicatedBlockcyclicSpace = Space
   dmapped DimensionalDist2D(MyLocales,
-                            new unmanaged ReplicatedDim(numLocales = nl1),
-                            new unmanaged BlockCyclicDim(numLocales = nl2,
+                            new owned ReplicatedDim(numLocales = nl1),
+                            new owned BlockCyclicDim(numLocales = nl2,
                                                lowIdx = 1, blockSize = 2));
 
 var DRBA: [DimReplicatedBlockcyclicSpace] int;


### PR DESCRIPTION
For example, now when passed an `owned` argument, DimensionalDist2D will manage freeing it & take ownership of it, instead of borrowing it.

- [ ] revisit with #10215 / #11046 in mind
- [ ] rebase after PR #10511 goes in
- [ ] full local testing
- [x] fix primer with --no-local
- [ ] check some tests with valgrind and --no-local
- [ ] check with reviewer