### PR TITLE
Avoid running this directory with CHPL_COMM != none or llvm

### DIFF
--- a/test/compflags/lydia/library/makefiles/SKIPIF
+++ b/test/compflags/lydia/library/makefiles/SKIPIF
@@ -1,0 +1,4 @@
+# Does not currently work with multilocale
+CHPL_COMM != none
+# Also not yet supported on LLVM
+CHPL_LLVM != none


### PR DESCRIPTION
For llvm, we haven't implemented the support that would be necessary yet.  For
multi-locale, the intended strategy is to utilize communication via ZMQ to a
separately spawned Chapel process, since Chapel wants to control the nodes it
runs on.