### PR TITLE
Remove added "name.c:" output from these tests

### DIFF
--- a/test/compflags/lydia/library/makefiles/getMakefile.prediff
+++ b/test/compflags/lydia/library/makefiles/getMakefile.prediff
@@ -1,3 +1,5 @@
 #!/bin/bash
 
 make mytest >> $2 2>&1
+sed '/mytest.c:/d' $2 > $2.tmp
+mv $2.tmp $2

--- a/test/compflags/lydia/library/makefiles/renamedLib.prediff
+++ b/test/compflags/lydia/library/makefiles/renamedLib.prediff
@@ -1,3 +1,5 @@
 #!/bin/bash
 
 make renamedTest >> $2 2>&1
+sed '/renamedTest.c:/d' $2 > $2.tmp
+mv $2.tmp $2


### PR DESCRIPTION
When compiling with multiple files, sometimes PrgEnvs will output the C file
used.  We were avoiding this in our testing system with an update for sub_test
from 2015 (#1670), but these tests avoided that guard (because I was
compiling through a makefile instead of the testing system).  To avoid this issue,
use `sed` to remove the output when it is there.

Checked that this worked correctly both when the extra output was and was not
present.