### PR TITLE
Adjust skyline.bad

### DIFF
--- a/test/arrays/shapes/skyline.bad
+++ b/test/arrays/shapes/skyline.bad
@@ -1,3 +1,1 @@
-Invalid read of size 8
-Address xxx is 72 bytes inside a block of size 80 free'd
-Block was alloc'd at
+skyline.comp.out.tmp.tmp

--- a/test/arrays/shapes/skyline.prediff
+++ b/test/arrays/shapes/skyline.prediff
@@ -3,10 +3,8 @@ outfile=$2
 
 mv $outfile $outfile.tmp
 
-# grep for specific items in valgrind output
-egrep 'Invalid read of size 8|Address|Block was alloc' $outfile.tmp | head -3 \
-| sed 's@^==.*Invalid@Invalid@; s@^==.*Block@Block@; s@^.*Address .* is@Address xxx is@' \
-> $outfile
+# grep for C compilation errors
+grep -l "error: conflicting types for .*chpl_gen_main" $outfile.tmp > $outfile
 
 # also grep for expected output
 grep '^[0-9]' $outfile.tmp >> $outfile


### PR DESCRIPTION
This should fix skyline.bad mismatch in nightly valgrind testing.

This test started failing in a different way.
I am updating .bad and .prediff to accomodate.

The new .bad and .prediff are gcc-specific.
This works because we test this test in the nightlies
only under valgrind.

This test is on my short list to investigate already.