### PR TITLE
Allow .borrow() on unmanaged or borrowed

### DIFF
--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -1304,7 +1304,7 @@ static void build_union_assignment_function(AggregateType* ct) {
 }
 
 static void buildClassBorrowMethod(AggregateType* ct) {
-  if (function_exists("borrow", ct, ct))
+  if (function_exists("borrow", dtMethodToken, ct))
     return;
 
   FnSymbol* fn = new FnSymbol("borrow");

--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -40,6 +40,7 @@ static void build_accessors(AggregateType* ct, Symbol* field);
 static void buildDefaultOfFunction(AggregateType* ct);
 
 static void build_union_assignment_function(AggregateType* ct);
+static void buildClassBorrowMethod(AggregateType* ct);
 
 static void build_enum_cast_function(EnumType* et);
 static void build_enum_first_function(EnumType* et);
@@ -120,6 +121,10 @@ void buildDefaultFunctions() {
 
         if (isUnion(ct)) {
           build_union_assignment_function(ct);
+        }
+
+        if (isClass(ct)) {
+          buildClassBorrowMethod(ct);
         }
 
       } else if (EnumType* et = toEnumType(type->type)) {
@@ -1292,6 +1297,35 @@ static void build_union_assignment_function(AggregateType* ct) {
       }
     }
   }
+  DefExpr* def = new DefExpr(fn);
+  ct->symbol->defPoint->insertBefore(def);
+  reset_ast_loc(def, ct->symbol);
+  normalize(fn);
+}
+
+static void buildClassBorrowMethod(AggregateType* ct) {
+  if (function_exists("borrow", ct, ct))
+    return;
+
+  FnSymbol* fn = new FnSymbol("borrow");
+  fn->addFlag(FLAG_COMPILER_GENERATED);
+
+  if (ct->isClass() && ct != dtObject)
+    fn->addFlag(FLAG_OVERRIDE);
+  else
+    fn->addFlag(FLAG_INLINE);
+
+  fn->cname = astr("borrow");
+  fn->_this = new ArgSymbol(INTENT_BLANK, "this", ct);
+  fn->_this->addFlag(FLAG_ARG_THIS);
+  fn->setMethod(true);
+  fn->insertFormalAtTail(new ArgSymbol(INTENT_BLANK, "_mt", dtMethodToken));
+  fn->insertFormalAtTail(fn->_this);
+
+  fn->retType = ct;
+
+  fn->insertAtTail(new CallExpr(PRIM_RETURN, fn->_this));
+
   DefExpr* def = new DefExpr(fn);
   ct->symbol->defPoint->insertBefore(def);
   reset_ast_loc(def, ct->symbol);

--- a/test/classes/delete-free/borrowed/user-defined-borrow.chpl
+++ b/test/classes/delete-free/borrowed/user-defined-borrow.chpl
@@ -1,0 +1,14 @@
+class MyClass {
+
+  var x:int;
+
+  proc borrow() {
+    return "You just borrowed " + x;
+  }
+}
+
+var a = new owned MyClass(1);
+var b = a.borrow(); // owned.borrow()
+
+var c = b.borrow(); // MyClass.borrow()
+writeln(c.type:string, " ", c);

--- a/test/classes/delete-free/borrowed/user-defined-borrow.good
+++ b/test/classes/delete-free/borrowed/user-defined-borrow.good
@@ -1,0 +1,1 @@
+string You just borrowed 1

--- a/test/classes/delete-free/unmanaged/unmanaged-dot-borrow.chpl
+++ b/test/classes/delete-free/unmanaged/unmanaged-dot-borrow.chpl
@@ -1,0 +1,12 @@
+class MyClass {
+  var x:int;
+}
+
+var ptr = new unmanaged MyClass();
+var b = ptr.borrow();
+var bb = b.borrow();
+writeln(ptr.type:string, " ", ptr);
+writeln(b.type:string, " ", b);
+writeln(bb.type:string, " ", bb);
+
+delete ptr;

--- a/test/classes/delete-free/unmanaged/unmanaged-dot-borrow.good
+++ b/test/classes/delete-free/unmanaged/unmanaged-dot-borrow.good
@@ -1,0 +1,3 @@
+unmanaged MyClass {x = 0}
+MyClass {x = 0}
+MyClass {x = 0}


### PR DESCRIPTION
Implement .borrow() for borrowed/unmanaged classes

This PR adds buildClassBorrowMethod() to run during
buildDefaultFunctions.  In some ways it would be preferable to create a
generic method with `borrowed` as the receiver; however making that work
was not simple/easy.  The new .borrow() method is built for class types.
That has the effect of enabling `.borrow()` on unmanaged because
unmanaged can coerce to owned.  `owned` and `shared` still have their own
implementations of `.borrow()` that should be preferred, but the coercion
to borrow & then call this `.borrow()` would have the same result.

Resolves #9501 (which includes design discussion).

- [x] full local testing

Reviewed by @vasslitvinov - thanks!