### PR TITLE
Add warning on deleting a borrow

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -265,7 +265,7 @@ module ChapelArray {
     proc _freePrivatizedClassHelp(pid, original) {
       var prv = chpl_getPrivatizedCopy(object, pid);
       if prv != original then
-        delete prv;
+        delete _to_unmanaged(prv);
 
       extern proc chpl_clearPrivatizedClass(pid:int);
       chpl_clearPrivatizedClass(pid);

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1378,7 +1378,7 @@ module ChapelBase {
       compilerError("should not delete 'nil'");
 
     // TODO - this should be an error after 1.18
-    if !isSubtype(arg.type, _unmanaged) then
+    if !isExternClassType(arg.type) && !isSubtype(arg.type, _unmanaged) then
       compilerWarning("'delete' can only be applied to unmanaged classes");
 
     if (arg != nil) {

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -939,7 +939,7 @@ module ChapelBase {
   // on statement needed.
   pragma "dont disable remote value forwarding"
   inline proc _endCountFree(e: _EndCount) {
-    delete e;
+    delete _to_unmanaged(e);
   }
 
   // This function is called by the initiating task once for each new
@@ -1367,6 +1367,7 @@ module ChapelBase {
 
 
   // implements 'delete' statement
+  pragma "no borrow convert"
   inline proc chpl__delete(arg)
     where isClassType(arg.type) || isExternClassType(arg.type) {
 
@@ -1375,6 +1376,10 @@ module ChapelBase {
 
     if arg.type == _nilType then
       compilerError("should not delete 'nil'");
+
+    // TODO - this should be an error after 1.18
+    if !isSubtype(arg.type, _unmanaged) then
+      compilerWarning("'delete' can only be applied to unmanaged classes");
 
     if (arg != nil) {
       arg.deinit();
@@ -1390,8 +1395,13 @@ module ChapelBase {
   }
 
   // report an error when 'delete' is inappropriate
+  pragma "no borrow convert"
   proc chpl__delete(arg) {
-    if isRecord(arg) then
+    if isSubtype(arg.type, _owned) then
+      compilerError("'delete' is not allowed on an owned class type");
+    else if isSubtype(arg.type, _shared) then
+      compilerError("'delete' is not allowed on a shared class type");
+    else if isRecord(arg) then
       // special case for records as a more likely occurrence
       compilerError("'delete' is not allowed on records");
     else

--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -713,6 +713,6 @@ module ChapelLocale {
   //
   pragma "no doc"
   proc deinit() {
-    delete origRootLocale;
+    delete _to_unmanaged(origRootLocale);
   }
 }

--- a/modules/internal/ChapelSyncvar.chpl
+++ b/modules/internal/ChapelSyncvar.chpl
@@ -136,7 +136,7 @@ module ChapelSyncvar {
 
     proc deinit() {
       if isOwned == true then
-        delete wrapped;
+        delete _to_unmanaged(wrapped);
     }
 
     // Do not allow implicit reads of sync vars.
@@ -312,7 +312,7 @@ module ChapelSyncvar {
   // This version has to be available to take precedence
   inline proc chpl__autoDestroy(x : _syncvar(?)) {
     if x.isOwned == true then
-      delete x.wrapped;
+      delete _to_unmanaged(x.wrapped);
   }
 
   pragma "no doc"
@@ -661,7 +661,7 @@ module ChapelSyncvar {
 
     proc deinit() {
       if isOwned == true then
-        delete wrapped;
+        delete _to_unmanaged(wrapped);
     }
 
     // Do not allow implicit reads of single vars.
@@ -755,7 +755,7 @@ module ChapelSyncvar {
   // This version has to be available to take precedence
   inline proc chpl__autoDestroy(x : _singlevar(?)) {
     if x.isOwned == true then
-      delete x.wrapped;
+      delete _to_unmanaged(x.wrapped);
   }
 
   pragma "no doc"

--- a/modules/internal/OwnedObject.chpl
+++ b/modules/internal/OwnedObject.chpl
@@ -155,7 +155,7 @@ module OwnedObject {
     proc deinit() {
       if isClass(p) { // otherwise, let error happen on init call
         if p != nil then
-          delete p;
+          delete _to_unmanaged(p);
       }
     }
 
@@ -165,7 +165,7 @@ module OwnedObject {
      */
     proc ref clear() {
       if p != nil {
-        delete p;
+        delete _to_unmanaged(p);
         p = nil;
       }
     }
@@ -180,7 +180,7 @@ module OwnedObject {
       var oldPtr = p;
       p = newPtr;
       if oldPtr then
-        delete oldPtr;
+        delete _to_unmanaged(oldPtr);
     }
 
     /*

--- a/modules/internal/SharedObject.chpl
+++ b/modules/internal/SharedObject.chpl
@@ -227,7 +227,7 @@ module SharedObject {
         if p != nil && pn != nil {
           var count = pn.release();
           if count == 0 {
-            delete p;
+            delete _to_unmanaged(p);
             delete pn;
           }
         }

--- a/modules/internal/localeModels/apu/LocaleModel.chpl
+++ b/modules/internal/localeModels/apu/LocaleModel.chpl
@@ -231,8 +231,8 @@ module LocaleModel {
       if (debugAPULocale) {
         chpl_debug_writeln("** Destructing CPU/GPU locales and shutting down HSA.");
       }
-      delete CPU;
-      delete GPU;
+      delete _to_unmanaged(CPU);
+      delete _to_unmanaged(GPU);
     }
  }
 
@@ -311,7 +311,7 @@ module LocaleModel {
       for loc in myLocales {
         on loc {
           rootLocaleInitialized = false;
-          delete loc;
+          delete _to_unmanaged(loc);
         }
       }
     }

--- a/modules/internal/localeModels/flat/LocaleModel.chpl
+++ b/modules/internal/localeModels/flat/LocaleModel.chpl
@@ -233,7 +233,7 @@ module LocaleModel {
       for loc in myLocales {
         on loc {
           rootLocaleInitialized = false;
-          delete loc;
+          delete _to_unmanaged(loc);
         }
       }
     }

--- a/modules/internal/localeModels/knl/LocaleModel.chpl
+++ b/modules/internal/localeModels/knl/LocaleModel.chpl
@@ -300,8 +300,8 @@ module LocaleModel {
     }
 
     proc deinit() {
-      delete ddr;
-      delete hbm;
+      delete _to_unmanaged(ddr);
+      delete _to_unmanaged(hbm);
     }
 
     proc writeThis(f) {
@@ -454,9 +454,9 @@ module LocaleModel {
 
     proc deinit() {
       for loc in childLocales do
-        delete loc;
-      delete ddr;
-      delete hbm;
+        delete _to_unmanaged(loc);
+      delete _to_unmanaged(ddr);
+      delete _to_unmanaged(hbm);
     }
  }
 
@@ -538,7 +538,7 @@ module LocaleModel {
       for loc in myLocales {
         on loc {
           rootLocaleInitialized = false;
-          delete loc;
+          delete _to_unmanaged(loc);
         }
       }
     }

--- a/modules/internal/localeModels/numa/LocaleModel.chpl
+++ b/modules/internal/localeModels/numa/LocaleModel.chpl
@@ -201,7 +201,7 @@ module LocaleModel {
 
     proc deinit() {
       for loc in childLocales do
-        delete loc;
+        delete _to_unmanaged(loc);
     }
  }
 
@@ -280,7 +280,7 @@ module LocaleModel {
       for loc in myLocales {
         on loc {
           rootLocaleInitialized = false;
-          delete loc;
+          delete _to_unmanaged(loc);
         }
       }
     }

--- a/spec/Classes.tex
+++ b/spec/Classes.tex
@@ -139,6 +139,8 @@ delete c;   // This deletes the new D.
 delete c2;  // This deletes the new C.
 \end{chapelpost}
 \begin{chapeloutput}
+declaration.chpl:8: warning: 'delete' can only be applied to unmanaged classes
+declaration.chpl:9: warning: 'delete' can only be applied to unmanaged classes
 \end{chapeloutput}
 When the variable \chpl{c} is declared, it initially has the value
 of \chpl{nil}.  The next statement assigned to it an instance of the
@@ -445,6 +447,8 @@ delete mp2;
 --no-warn-constructors
 \end{chapelcompopts}
 \begin{chapeloutput}
+simpleConstructors.chpl:23: warning: 'delete' can only be applied to unmanaged classes
+simpleConstructors.chpl:24: warning: 'delete' can only be applied to unmanaged classes
 {x = 1.0, y = 2.0, message = a point}
 {x = 0.0, y = 0.0, message = point mp2}
 \end{chapeloutput}
@@ -666,6 +670,7 @@ writeln(c.setCount);
 delete c;
 \end{chapelpost}
 \begin{chapeloutput}
+getterSetter.chpl:21: warning: 'delete' can only be applied to unmanaged classes
 1
 2
 3
@@ -771,6 +776,8 @@ delete c;        // Deletes that object.
 --memLeaksByType
 \end{chapelexecopts}
 \begin{chapeloutput}
+delete.chpl:5: warning: 'delete' can only be applied to unmanaged classes
+delete.chpl:8: warning: 'delete' can only be applied to unmanaged classes
 
 ====================
 Leaked Memory Report
@@ -820,6 +827,8 @@ delete c;        // Deletes that object: Writes out "Bye, bye."
                  // and reclaims the memory that was held by c.
 \end{chapel}
 \begin{chapeloutput}
+classDeinitializer.chpl:7: warning: 'delete' can only be applied to unmanaged classes
+classDeinitializer.chpl:10: warning: 'delete' can only be applied to unmanaged classes
 Bye, bye.
 \end{chapeloutput}
 \end{chapelexample}

--- a/spec/Generics.tex
+++ b/spec/Generics.tex
@@ -510,6 +510,7 @@ writeln(n.next.type:string);
 delete n;
 \end{chapelpost}
 \begin{chapeloutput}
+NodeClass.chpl:10: warning: 'delete' can only be applied to unmanaged classes
 3.14
 nil
 Node(real(64))
@@ -626,6 +627,8 @@ delete list.next;
 delete list;
 \end{chapelpost}
 \begin{chapeloutput}
+fieldWithoutType.chpl:9: warning: 'delete' can only be applied to unmanaged classes
+fieldWithoutType.chpl:10: warning: 'delete' can only be applied to unmanaged classes
 1
 2
 \end{chapeloutput}
@@ -773,6 +776,8 @@ delete g2;
 --no-warn-constructors
 \end{chapelcompopts}
 \begin{chapeloutput}
+constructorsForGenericFields.chpl:28: warning: 'delete' can only be applied to unmanaged classes
+constructorsForGenericFields.chpl:29: warning: 'delete' can only be applied to unmanaged classes
 1
 a string
 {c1 = 11, v1 = 111, x1 = 0, c5 = 5.5, v5 = 555, x5 = 0.0}
@@ -1000,6 +1005,8 @@ while !s.isEmpty do
   writeln(s.pop());
 \end{chapelpost}
 \begin{chapeloutput}
+genericStack.chpl:15: In function 'pop':
+genericStack.chpl:21: warning: 'delete' can only be applied to unmanaged classes
 3
 2
 1

--- a/spec/Iterators.tex
+++ b/spec/Iterators.tex
@@ -184,6 +184,10 @@ and \chpl{postorder(tree.right)} as stand-alone statements would
 result in generating temporary arrays containing the outcomes of these
 recursive calls, which would then be discarded.
 \begin{chapeloutput}
+recursive.chpl:4: In function 'deinit':
+recursive.chpl:5: warning: 'delete' can only be applied to unmanaged classes
+recursive.chpl:6: warning: 'delete' can only be applied to unmanaged classes
+recursive.chpl:31: warning: 'delete' can only be applied to unmanaged classes
 Tree Data
 b d e c a
 \end{chapeloutput}

--- a/spec/Methods.tex
+++ b/spec/Methods.tex
@@ -89,7 +89,7 @@ class Actor {
   var name: string;
   var age: uint;
 }
-var anActor = new Actor(name="Tommy", age=27);
+var anActor = new owned Actor(name="Tommy", age=27);
 writeln(anActor);
 \end{chapelpre}
 \begin{chapel}
@@ -99,7 +99,6 @@ proc Actor.print() {
 \end{chapel}
 \begin{chapelpost}
 anActor.print();
-delete anActor;
 \end{chapelpost}
 \begin{chapeloutput}
 {name = Tommy, age = 27}
@@ -147,9 +146,8 @@ class C {
 proc bar(c: C) { writeln(c); }
 \end{chapel}
 \begin{chapelpost}
-var c1: C = new C();
+var c1: C = new owned C();
 c1.foo();
-delete c1;
 \end{chapelpost}
 \begin{chapeloutput}
 {}
@@ -352,13 +350,12 @@ class ThreeArray {
 }
 \end{chapel}
 \begin{chapelpost}
-var ta = new ThreeArray();
+var ta = new owned ThreeArray();
 for (i, j) in zip(ta, 1..) do
   i = j;
 
 for i in ta do
   writeln(i);
-delete ta;
 \end{chapelpost}
 \begin{chapeloutput}
 1

--- a/spec/Records.tex
+++ b/spec/Records.tex
@@ -301,6 +301,8 @@ foo();
 --no-warn-constructors
 \end{chapelcompopts}
 \begin{chapeloutput}
+recordDeinitializer.chpl:9: In function 'deinit':
+recordDeinitializer.chpl:9: warning: 'delete' can only be applied to unmanaged classes
 (c = {x = 0})
 
 ====================

--- a/spec/Statements.tex
+++ b/spec/Statements.tex
@@ -875,10 +875,16 @@ proc deferInFunction() {
 deferInFunction();
 \end{chapel}
 produces the output
-\begin{chapelprintoutput}{}
+\begin{chapeloutput}
+defer1.chpl:4: In function 'deferInFunction':
+defer1.chpl:9: warning: 'delete' can only be applied to unmanaged classes
 created {x = 1}
 defer action: deleting {x = 1}
-\end{chapelprintoutput}
+\end{chapeloutput}
+\begin{commandline}
+created {x = 1}
+defer action: deleting {x = 1}
+\end{commandline}
 \end{chapelexample}
 
 
@@ -909,13 +915,23 @@ proc deferInNestedBlock() {
 deferInNestedBlock();
 \end{chapel}
 produces the output
-\begin{chapelprintoutput}{}
+\begin{chapeloutput}
+defer2.chpl:4: In function 'deferInNestedBlock':
+defer2.chpl:12: warning: 'delete' can only be applied to unmanaged classes
 before inner block
 created {x = 1}
 in inner block
 defer action: deleting {x = 1}
 after inner block
-\end{chapelprintoutput}
+\end{chapeloutput}
+\begin{commandline}
+before inner block
+created {x = 1}
+in inner block
+defer action: deleting {x = 1}
+after inner block
+\end{commandline}
+
 \end{chapelexample}
 
 Lastly, this example shows that when \chpl{defer} is used in a loop, the
@@ -943,14 +959,24 @@ proc deferInLoop() {
 deferInLoop();
 \end{chapel}
 produces the output
-\begin{chapelprintoutput}{}
+\begin{chapeloutput}
+defer3.chpl:4: In function 'deferInLoop':
+defer3.chpl:10: warning: 'delete' can only be applied to unmanaged classes
 created {x = 1}
 {x = 1}
 defer action: deleting {x = 1}
 created {x = 2}
 {x = 2}
 defer action: deleting {x = 2}
-\end{chapelprintoutput}
+\end{chapeloutput}
+\begin{commandline}
+created {x = 1}
+{x = 1}
+defer action: deleting {x = 1}
+created {x = 2}
+{x = 2}
+defer action: deleting {x = 2}
+\end{commandline}
 \end{chapelexample}
 
 

--- a/spec/Task_Parallelism_and_Synchronization.tex
+++ b/spec/Task_Parallelism_and_Synchronization.tex
@@ -222,6 +222,10 @@ proc Tree.deinit() {
 delete tree;
 \end{chapelpost}
 \begin{chapeloutput}
+beginWithSyncVar.chpl:21: In function 'deinit':
+beginWithSyncVar.chpl:23: warning: 'delete' can only be applied to unmanaged classes
+beginWithSyncVar.chpl:24: warning: 'delete' can only be applied to unmanaged classes
+beginWithSyncVar.chpl:26: warning: 'delete' can only be applied to unmanaged classes
 4
 \end{chapeloutput}
 the sync variable \chpl{x$\mbox{\texttt{\$}}$} is assigned by an

--- a/test/classes/delete-free/delete-borrowed.chpl
+++ b/test/classes/delete-free/delete-borrowed.chpl
@@ -1,0 +1,6 @@
+class MyClass {
+  var field:int;
+}
+
+var x = new borrowed MyClass(1);
+delete x;

--- a/test/classes/delete-free/delete-borrowed.good
+++ b/test/classes/delete-free/delete-borrowed.good
@@ -1,0 +1,1 @@
+delete-borrowed.chpl:6: warning: 'delete' can only be applied to unmanaged classes

--- a/test/classes/delete-free/delete-borrowed.noexec
+++ b/test/classes/delete-free/delete-borrowed.noexec
@@ -1,0 +1,1 @@
+dont run it

--- a/test/classes/delete-free/owned/delete-owned.chpl
+++ b/test/classes/delete-free/owned/delete-owned.chpl
@@ -1,0 +1,6 @@
+class MyClass {
+  var field:int;
+}
+
+var y = new owned MyClass(2);
+delete y;

--- a/test/classes/delete-free/owned/delete-owned.good
+++ b/test/classes/delete-free/owned/delete-owned.good
@@ -1,0 +1,1 @@
+delete-owned.chpl:6: error: 'delete' is not allowed on an owned class type

--- a/test/classes/delete-free/shared/delete-shared.chpl
+++ b/test/classes/delete-free/shared/delete-shared.chpl
@@ -1,0 +1,6 @@
+class MyClass {
+  var field:int;
+}
+
+var z = new shared MyClass(3);
+delete z;

--- a/test/classes/delete-free/shared/delete-shared.good
+++ b/test/classes/delete-free/shared/delete-shared.good
@@ -1,0 +1,1 @@
+delete-shared.chpl:6: error: 'delete' is not allowed on a shared class type

--- a/test/classes/delete-free/tests-from-design-overview/borrowed-arguments.good
+++ b/test/classes/delete-free/tests-from-design-overview/borrowed-arguments.good
@@ -1,3 +1,4 @@
 borrowed-arguments.chpl:12: In function 'saveit':
+borrowed-arguments.chpl:14: warning: 'delete' can only be applied to unmanaged classes
 borrowed-arguments.chpl:13: error: Scoped variable global would outlive the value it is set to
 borrowed-arguments.chpl:12: note: consider scope of arg

--- a/test/classes/diten/subclassMethodCall.chpl
+++ b/test/classes/diten/subclassMethodCall.chpl
@@ -26,7 +26,7 @@ class Sub2: Base {
 }
 
 proc main {
-  var s1: Base;
-  s1 = new Sub1(); s1.method(new C1(int)); delete s1;
-  s1 = new Sub2(); s1.method(new C2()); delete s1;
+  var s1: borrowed Base;
+  s1 = new borrowed Sub1(); s1.method(new C1(int));
+  s1 = new borrowed Sub2(); s1.method(new C2());
 }

--- a/test/classes/ferguson/delete-free/owned-shared-fields2.chpl
+++ b/test/classes/ferguson/delete-free/owned-shared-fields2.chpl
@@ -27,7 +27,7 @@ class C6 {
 
 proc test5a() {
   var r = new R5();
-  var cc = new C5();
+  var cc = new unmanaged C5();
   delete cc;
 }
 proc test5b() {
@@ -36,12 +36,12 @@ proc test5b() {
   var c = new MyClass(3);
   var d = new MyClass(4);
   var r = new R5(new Owned(a), new Shared(b));
-  var cc = new C5(new Owned(a), new Shared(b));
+  var cc = new unmanaged C5(new Owned(a), new Shared(b));
   delete cc;
 }
 proc test6a() {
   var r = new R6();
-  var cc = new C6();
+  var cc = new unmanaged C6();
   delete cc;
 }
 proc test6b() {
@@ -50,7 +50,7 @@ proc test6b() {
   var c = new MyClass(3);
   var d = new MyClass(4);
   var r = new R6(new Owned(a), new Shared(b));
-  var cc = new C6(new Owned(a), new Shared(b));
+  var cc = new unmanaged C6(new Owned(a), new Shared(b));
   delete cc;
 }
 

--- a/test/classes/forwarding/forwarding-generic-default-unm.bad
+++ b/test/classes/forwarding/forwarding-generic-default-unm.bad
@@ -1,0 +1,1 @@
+forwarding-generic-default-unm.chpl:35: error: cannot assign expression of type unmanaged C(3*string) to field 'driver' of type unmanaged B(3*string)

--- a/test/classes/forwarding/forwarding-generic-default-unm.chpl
+++ b/test/classes/forwarding/forwarding-generic-default-unm.chpl
@@ -1,7 +1,7 @@
 // This test case represents a bug originally reported in issue #7783
 
 class A{
-  forwarding var driver: borrowed B;
+  forwarding var driver: unmanaged B;
 }
 
 class B{
@@ -31,27 +31,24 @@ class C:B{
   var cfield:int;
 }
 
-var c1d = new unmanaged C();
-var c1 = new unmanaged A(c1d);
+
+var c1 = new unmanaged A(new unmanaged C());
 writeln(c1.foo1());
 
-var c2d = new unmanaged C();
-var c2 = new unmanaged A(c2d);
+var c2 = new unmanaged A(new unmanaged C());
 writeln(c2.foo2("Test"));
 
-var c3d = new unmanaged C();
-var c3 = new unmanaged A(c3d);
+var c3 = new unmanaged A(new unmanaged C());
 writeln(c3.foo3("Test", "Test"));
 
-var c4d = new unmanaged C();
-var c4 = new unmanaged A(c4d);
+var c4 = new unmanaged A(new unmanaged C());
 writeln(c4.foo4("Test"));
 
-delete c4d;
+delete c4.driver;
 delete c4;
-delete c3d;
+delete c3.driver;
 delete c3;
-delete c2d;
+delete c2.driver;
 delete c2;
-delete c1d;
+delete c1.driver;
 delete c1;

--- a/test/classes/forwarding/forwarding-generic-default-unm.future
+++ b/test/classes/forwarding/forwarding-generic-default-unm.future
@@ -1,0 +1,2 @@
+bug: problem compiling forwarding to unmanaged
+#10627

--- a/test/classes/forwarding/forwarding-generic-default-unm.good
+++ b/test/classes/forwarding/forwarding-generic-default-unm.good
@@ -1,0 +1,4 @@
+{bfield = (, , ), cfield = 0}
+{bfield = (, , ), cfield = 0}
+{bfield = (, , ), cfield = 0}
+{bfield = (, , ), cfield = 0}

--- a/test/classes/initializers/errors/errHandling/initWithTryBang2.chpl
+++ b/test/classes/initializers/errors/errHandling/initWithTryBang2.chpl
@@ -14,6 +14,6 @@ proc outerFunc() throws {
   throw new Error();
 }
 
-var foo = new Foo();
+var foo = new unmanaged Foo();
 writeln(foo);
 delete foo;

--- a/test/classes/initializers/generics/typeFunctions/fnReturnsGeneric.chpl
+++ b/test/classes/initializers/generics/typeFunctions/fnReturnsGeneric.chpl
@@ -12,6 +12,6 @@ proc getType() type {
   return C;
 }
 
-var myC = new (getType())(int);
+var myC = new unmanaged (getType())(int);
 writeln(myC);
 delete myC;

--- a/test/classes/initializers/parentCall/inDefer.chpl
+++ b/test/classes/initializers/parentCall/inDefer.chpl
@@ -9,6 +9,6 @@ class Foo {
   }
 }
 
-var foo = new Foo(3);
+var foo = new unmanaged Foo(3);
 writeln(foo);
 delete foo;

--- a/test/classes/initializers/parentCall/inOnLocal.chpl
+++ b/test/classes/initializers/parentCall/inOnLocal.chpl
@@ -9,6 +9,6 @@ class Foo {
   }
 }
 
-var foo = new Foo(5);
+var foo = new unmanaged Foo(5);
 writeln(foo);
 delete foo;

--- a/test/classes/initializers/phase1/domainMaps/init-dmap-dom-arr.chpl
+++ b/test/classes/initializers/phase1/domainMaps/init-dmap-dom-arr.chpl
@@ -10,7 +10,7 @@ class VDistArray {
   }
 }
 
-var foo = new VDistArray(0, -4, 4);
+var foo = new unmanaged VDistArray(0, -4, 4);
 
 for i in -4..4 do
   writeln(i, " ", foo.data[i].locale.id);

--- a/test/classes/initializers/phase1/hasDeferBad.chpl
+++ b/test/classes/initializers/phase1/hasDeferBad.chpl
@@ -12,6 +12,6 @@ class Foo {
   }
 }
 
-var foo = new Foo(10);
+var foo = new unmanaged Foo(10);
 writeln(foo);
 delete foo;

--- a/test/classes/initializers/phase1/methodCallOverloaded.chpl
+++ b/test/classes/initializers/phase1/methodCallOverloaded.chpl
@@ -20,6 +20,6 @@ class Foo {
   }
 }
 
-var foo = new Foo(-1);
+var foo = new unmanaged Foo(-1);
 writeln(foo);
 delete foo;

--- a/test/classes/initializers/phase1/nested-function-mods-field1.chpl
+++ b/test/classes/initializers/phase1/nested-function-mods-field1.chpl
@@ -13,7 +13,7 @@ class Foo {
 }
 
 proc main() {
-  var f = new Foo(13);
+  var f = new unmanaged Foo(13);
   writeln(f);
   delete f;
 }

--- a/test/classes/initializers/phase1/nested-function-mods-field2.chpl
+++ b/test/classes/initializers/phase1/nested-function-mods-field2.chpl
@@ -14,7 +14,7 @@ class Foo {
 }
 
 proc main() {
-  var f = new Foo(13);
+  var f = new unmanaged Foo(13);
   writeln(f);
   delete f;
 }

--- a/test/classes/initializers/phase1/nested-function-phase-2-mods-fields.chpl
+++ b/test/classes/initializers/phase1/nested-function-phase-2-mods-fields.chpl
@@ -20,7 +20,7 @@ class Foo {
 }
 
 proc main() {
-  var f = new Foo(13);
+  var f = new unmanaged Foo(13);
   writeln(f);
   delete f;
 }

--- a/test/classes/initializers/phase1/setGrandparentField.chpl
+++ b/test/classes/initializers/phase1/setGrandparentField.chpl
@@ -25,6 +25,6 @@ class C : B {
   }
 }
 
-var c = new C(6.2, true, 3);
+var c = new unmanaged C(6.2, true, 3);
 writeln(c);
 delete c;

--- a/test/classes/initializers/phase2/constArrayMod.chpl
+++ b/test/classes/initializers/phase2/constArrayMod.chpl
@@ -10,6 +10,6 @@ class Foo {
   }
 }
 
-var foo = new Foo(10);
+var foo = new unmanaged Foo(10);
 writeln(foo);
 delete foo;

--- a/test/classes/initializers/siblingCall/inDefer.chpl
+++ b/test/classes/initializers/siblingCall/inDefer.chpl
@@ -12,6 +12,6 @@ class Foo {
   }
 }
 
-var foo = new Foo();
+var foo = new unmanaged Foo();
 writeln(foo);
 delete foo;

--- a/test/classes/lydia/overrides/remoteVersion.chpl
+++ b/test/classes/lydia/overrides/remoteVersion.chpl
@@ -13,12 +13,12 @@ class B: A {
   }
 }
 
-var a = new A();
-var b = new B();
+var a = new unmanaged A();
+var b = new unmanaged B();
 
 on Locales(1) {
-  var a2 = new A();
-  var b2 = new B();
+  var a2 = new unmanaged A();
+  var b2 = new unmanaged B();
 
   a.foo();
   b.foo();

--- a/test/compflags/ferguson/default-unmanaged.default.good
+++ b/test/compflags/ferguson/default-unmanaged.default.good
@@ -1,3 +1,7 @@
+default-unmanaged.chpl:73: In function 'test4':
+default-unmanaged.chpl:77: warning: 'delete' can only be applied to unmanaged classes
+default-unmanaged.chpl:68: In function 'f_then_free':
+default-unmanaged.chpl:70: warning: 'delete' can only be applied to unmanaged classes
 Calling f(unmanaged)
 in f unmanaged
 Calling f(borrowed)

--- a/test/compflags/ferguson/unstable-new.good
+++ b/test/compflags/ferguson/unstable-new.good
@@ -7,6 +7,8 @@ unstable-new.chpl:20: warning: new MyClass is unstable
 unstable-new.chpl:20: note: use 'new unmanaged MyClass' 'new owned MyClass' or 'new shared MyClass'
 unstable-new.chpl:21: warning: new MyGenericClass is unstable
 unstable-new.chpl:21: note: use 'new unmanaged MyGenericClass' 'new owned MyGenericClass' or 'new shared MyGenericClass'
+unstable-new.chpl:27: warning: 'delete' can only be applied to unmanaged classes
+unstable-new.chpl:28: warning: 'delete' can only be applied to unmanaged classes
 in errors
 {x = 1}
 {y = 1}

--- a/test/deprecated/delete-borrowed.chpl
+++ b/test/deprecated/delete-borrowed.chpl
@@ -1,0 +1,11 @@
+// The warning emitted by the compiler for this test
+// should be an error after 1.18.
+// At that point, this test can be removed in favor of
+//   test/classes/delete-free/delete-borrowed.chpl
+
+class MyClass {
+  var field:int;
+}
+
+var x = new borrowed MyClass(1);
+delete x;

--- a/test/deprecated/delete-borrowed.good
+++ b/test/deprecated/delete-borrowed.good
@@ -1,0 +1,1 @@
+delete-borrowed.chpl:11: warning: 'delete' can only be applied to unmanaged classes

--- a/test/functions/diten/refIntents.chpl
+++ b/test/functions/diten/refIntents.chpl
@@ -9,7 +9,7 @@ proc main {
       var a: int;
       var b: int;
     }
-    var c = new C(1,2);
+    var c = new unmanaged C(1,2);
     writeln(c);
     swap(c.a, c.b);
     writeln(c);

--- a/test/functions/ferguson/hijacking/Application10.chpl
+++ b/test/functions/ferguson/hijacking/Application10.chpl
@@ -22,7 +22,7 @@
     }
 
     proc main() {
-      var instance = new Widget();
+      var instance = new unmanaged Widget();
       var x = 1;
       instance.setup(); // calls Base.setup()
       instance.run(x); // calls Widget.run()

--- a/test/functions/ferguson/hijacking/Application12.chpl
+++ b/test/functions/ferguson/hijacking/Application12.chpl
@@ -25,7 +25,7 @@
     }
 
     proc main() {
-      var instance = new Widget();
+      var instance = new unmanaged Widget();
       instance.setup(); // calls Base.setup() and that runs Widget.helpSetup
       delete instance;
     }

--- a/test/functions/ferguson/hijacking/Application8_cast.chpl
+++ b/test/functions/ferguson/hijacking/Application8_cast.chpl
@@ -15,7 +15,7 @@
     }
 
     proc main() {
-      var instance:Base = new Widget();
+      var instance:unmanaged Base = new unmanaged Widget();
       var x = 1;
       instance.run(x);
       delete instance;

--- a/test/io/ferguson/readThis/read-write-locale-arg.chpl
+++ b/test/io/ferguson/readThis/read-write-locale-arg.chpl
@@ -28,9 +28,9 @@ class C {
 }
 
 
-var a = new A(1);
-var b = new B(1);
-var c = new C(1);
+var a = new unmanaged A(1);
+var b = new unmanaged B(1);
+var c = new unmanaged C(1);
 
 var f = openmem();
 var w = f.writer();

--- a/test/memory/gbt/test-memLog.chpl
+++ b/test/memory/gbt/test-memLog.chpl
@@ -7,7 +7,7 @@ class C {
 proc main() {
   for loc in Locales do on loc {
     startVerboseMemHere();
-    var c = new C();
+    var c = new unmanaged C();
     delete c;
     stopVerboseMemHere();
   }

--- a/test/multilocale/deitz/needMultiLocales/test_frag_main.chpl
+++ b/test/multilocale/deitz/needMultiLocales/test_frag_main.chpl
@@ -30,28 +30,28 @@ proc fragmentedMain() {
 
 class node {
   var data: int;
-  var next: node;
+  var next: unmanaged node;
 }
 
 class list {
-  var head, tail: node;
+  var head, tail: unmanaged node;
   var lock$: sync bool;
   var signal$: sync bool;
 }
 
 use PrivateDist;
 
-var buffer: [PrivateSpace] [0..numLocales-1] list;
+var buffer: [PrivateSpace] [0..numLocales-1] unmanaged list;
 forall p in PrivateSpace do
   forall l in LocaleSpace do
-    buffer[p][l] = new list();
+    buffer[p][l] = new unmanaged list();
 
 proc chpl_send_int(data: int, loc) {
   var from = here.id;
   on Locales[loc] {
     var b = buffer[here.id][from];
     b.lock$ = true;
-    b.tail = new node(data, b.tail);
+    b.tail = new unmanaged node(data, b.tail);
     if b.head == nil then
       b.head = b.tail;
     b.signal$.writeXF(true);

--- a/test/multilocale/sungeun/rvf/rvfTest.chpl
+++ b/test/multilocale/sungeun/rvf/rvfTest.chpl
@@ -69,7 +69,7 @@ proc f(lid, rid) {
       on rx.x do if noisy then writeln(here.id); else assert(here.id==lid);
     }
     
-    var cx = new C();
+    var cx = new unmanaged C();
     if noisy {
       writeln(cx.locale.id);
       writeln(cx.x.locale.id);

--- a/test/optimizations/remoteValueForwarding/serialization/destroyGlobals.chpl
+++ b/test/optimizations/remoteValueForwarding/serialization/destroyGlobals.chpl
@@ -6,7 +6,7 @@ class Helper {
 }
 
 record Foo {
-  var h : Helper;
+  var h : unmanaged Helper;
   var serialized = false;
 
   proc chpl__serialize() {
@@ -15,7 +15,7 @@ record Foo {
 
   proc type chpl__deserialize(data) {
     var f : Foo;
-    f.h = new Helper(data);
+    f.h = new unmanaged Helper(data);
     f.serialized = true;
     return f;
   }
@@ -30,7 +30,7 @@ record Foo {
   }
 }
 
-const f = new Foo(new Helper((1,2,3)));
+const f = new Foo(new unmanaged Helper((1,2,3)));
 
 proc main() {
   on Locales.tail() {

--- a/test/optimizations/remoteValueForwarding/serialization/globals.chpl
+++ b/test/optimizations/remoteValueForwarding/serialization/globals.chpl
@@ -7,7 +7,7 @@ class Helper {
 }
 
 record Foo {
-  var h : Helper;
+  var h : unmanaged Helper;
   inline proc ranges {
     return h.x;
   }
@@ -18,7 +18,7 @@ record Foo {
 
   proc type chpl__deserialize(data) {
     var f : Foo;
-    f.h = new Helper(data);
+    f.h = new unmanaged Helper(data);
     return f;
   }
 
@@ -42,9 +42,9 @@ proc stop(msg : string) {
 }
 
 const R = (1..n-1, 1..n, 1..n+1);
-const f = new Foo(new Helper(R));
+const f = new Foo(new unmanaged Helper(R));
 
-const otherF = new Foo(new Helper(R));
+const otherF = new Foo(new unmanaged Helper(R));
 
 proc main() {
   {

--- a/test/optimizations/remoteValueForwarding/serialization/missingDeserializer.chpl
+++ b/test/optimizations/remoteValueForwarding/serialization/missingDeserializer.chpl
@@ -7,7 +7,7 @@ class Helper {
 }
 
 record Foo {
-  var h : Helper;
+  var h : unmanaged Helper;
   var serialized = false;
 
   proc chpl__serialize() {
@@ -16,7 +16,7 @@ record Foo {
 
   proc type chpl__deserialize(data) where foo {
     var f : Foo;
-    f.h = new Helper(data);
+    f.h = new unmanaged Helper(data);
     f.serialized = true;
     return f;
   }
@@ -27,7 +27,7 @@ record Foo {
 }
 
 proc main() {
-  const ff = new Foo(new Helper((1,2,3)));
+  const ff = new Foo(new unmanaged Helper((1,2,3)));
 
   startCommDiagnostics();
   on Locales.tail() {

--- a/test/optimizations/remoteValueForwarding/serialization/staticSize.chpl
+++ b/test/optimizations/remoteValueForwarding/serialization/staticSize.chpl
@@ -7,7 +7,7 @@ class Helper {
 }
 
 record Foo {
-  var h : Helper;
+  var h : unmanaged Helper;
   inline proc ranges {
     return h.x;
   }
@@ -18,7 +18,7 @@ record Foo {
 
   proc type chpl__deserialize(data) {
     var f : Foo;
-    f.h = new Helper(data);
+    f.h = new unmanaged Helper(data);
     return f;
   }
 
@@ -43,7 +43,7 @@ proc stop(msg : string) {
 
 proc main() {
   const R = (1..n-1, 1..n, 1..n+1);
-  const f = new Foo(new Helper(R));
+  const f = new Foo(new unmanaged Helper(R));
 
   start();
   on Locales[numLocales-1] {

--- a/test/types/records/const-checking/initArrOfRecConstField2.chpl
+++ b/test/types/records/const-checking/initArrOfRecConstField2.chpl
@@ -12,7 +12,7 @@ class C  {
   }
 }
 
-var myC = new C();
+var myC = new unmanaged C();
 
 writeln(myC);
 

--- a/test/types/records/const-checking/initArrOfRecConstField2a.chpl
+++ b/test/types/records/const-checking/initArrOfRecConstField2a.chpl
@@ -12,7 +12,7 @@ class C  {
   }
 }
 
-var myC = new C();
+var myC = new unmanaged C();
 
 writeln(myC);
 

--- a/test/types/records/const-checking/initArrOfRecConstField2b.chpl
+++ b/test/types/records/const-checking/initArrOfRecConstField2b.chpl
@@ -12,7 +12,7 @@ class C  {
   }
 }
 
-var myC = new C();
+var myC = new unmanaged C();
 
 writeln(myC);
 


### PR DESCRIPTION
Adds a warning if what the compiler considers to be a borrow (including an undecorated class type) is deleted. Adjusts testing so that it will pass.
 * in internal modules, used a cast from the borrow type to unmanaged before deleting
 * in spec tests, just added the warning to the expected output. Updating the spec for delete-free has its own issue: #10631

Resolves  #9092.

- [x] full local testing
- [x] futures testing
- [x] gasnet testing