### PR TITLE
Minor cleanup+reorg of ForallStmt-related code

### DIFF
--- a/compiler/AST/foralls.cpp
+++ b/compiler/AST/foralls.cpp
@@ -372,7 +372,7 @@ bool astUnderFI(const Expr* ast, ForallIntents* fi) {
 //
 //  * find the target parallel iterator (standalone or leader) and resolve it
 //  * issue an error, if neither is found
-//  * handle forall intents, using implementForallIntentsNew()
+//  * handle forall intents, using implementForallIntents1New()
 //  * partly lower by building leader+follow loop(s) as needed
 //
 // This happens when resolveExpr() encounters the first iterated expression
@@ -778,6 +778,15 @@ static void addParIdxVarsAndRestruct(ForallStmt* fs, bool gotSA) {
   INT_ASSERT(fs->numInductionVars() == 1);
 }
 
+static void checkForNonIterator(CallExpr* parCall, FnSymbol* dest) {
+  AggregateType* retType = toAggregateType(dest->retType);
+  if (!retType || !retType->symbol->hasFlag(FLAG_ITERATOR_RECORD)) {
+    USR_FATAL_CONT(parCall, "The iterable-expression resolves to a non-iterator function '%s' when looking for a parallel iterator", dest->name);
+    USR_PRINT(dest, "The function '%s' is declared here", dest->name);
+    USR_STOP();
+  }
+}
+
 static void resolveParallelIteratorAndIdxVar(ForallStmt* pfs,
                                              CallExpr* iterCall,
                                              FnSymbol* origIterator,
@@ -788,6 +797,7 @@ static void resolveParallelIteratorAndIdxVar(ForallStmt* pfs,
   bool alreadyResolved = parIter->isResolved();
 
   resolveFunction(parIter);
+  checkForNonIterator(iterCall, parIter);
 
   // Set QualifiedType of the index variable.
   QualifiedType iType = fsIterYieldType(pfs, parIter,
@@ -945,9 +955,9 @@ CallExpr* resolveForallHeader(ForallStmt* pfs, SymExpr* origSE)
   {
     addParIdxVarsAndRestruct(pfs, gotSA);
 
-    implementForallIntentsNew(pfs, iterCall);
-
     resolveParallelIteratorAndIdxVar(pfs, iterCall, origIterFn, gotSA);
+
+    implementForallIntents1New(pfs, iterCall);
 
     setupShadowVariables(pfs);
 

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -929,7 +929,6 @@ ShadowVarSymbol::ShadowVarSymbol(ForallIntentTag iIntent,
   specBlock(NULL),
   svInitBlock(new BlockStmt()),
   svDeinitBlock(new BlockStmt()),
-  reduceGlobalOp(NULL),
   pruneit(false)
 {
   if (intentsResolved)

--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -146,7 +146,7 @@ CallExpr* resolveForallHeader(ForallStmt* pfs, SymExpr* origSE);
 void implementForallIntents1(DefExpr* defChplIter);
 void implementForallIntents2(CallExpr* call, CallExpr* origToLeaderCall);
 void implementForallIntents2wrapper(CallExpr* call, CallExpr* origToLeaderCall);
-void implementForallIntentsNew(ForallStmt* fs, CallExpr* parCall);
+void implementForallIntents1New(ForallStmt* fs, CallExpr* parCall);
 void stashPristineCopyOfLeaderIter(FnSymbol* origLeader, bool ignoreIsResolved);
 
 // reduce intents

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -450,9 +450,6 @@ public:
   BlockStmt* svInitBlock;      // always present
   BlockStmt* svDeinitBlock;    //  "
 
-  // A reduction class instance aka "Operator".
-  Symbol* reduceGlobalOp;
-
   // Once pruning is no longer needed, this should be removed.
   bool pruneit;
 };


### PR DESCRIPTION
* Importantly, move implementForallIntentsNew() to go AFTER
resolveParallelIteratorAndIdxVar(). This sets me up for
merging implementForallIntents1New() and setupShadowVariables(),
which do different aspects of the same task.

* Get rid of implementForallIntentsNew(), instead call
implementForallIntents1New() (with the `1`) and checkForNonIterator()
directly.

* Note that placing checkForNonIterator() requires some care.
(This was the case before as well.) It needs to happen after
the iterator is resolved, and before its yield time is queried.

* Remove the unused field reduceGlobalOp.

* list_ast() now produces prettier output for ForallStmts.

* Move ForallStmt- and UseStmt-specific code from list_ast()
into helper functions.

* Relocate print_indent() and print_on_its_own_line() towards
the top of view.cpp as they are used by other helpers and
have more general applicability.