### PR TITLE
#10510 new Docker image for building against master branch

### DIFF
--- a/util/dockerfiles/master/Dockerfile
+++ b/util/dockerfiles/master/Dockerfile
@@ -1,0 +1,32 @@
+FROM debian:stretch
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    wget \
+    ca-certificates \
+    curl \
+    gcc \
+    g++ \
+    perl \
+    python \
+    python-dev \
+    python-setuptools \
+    libgmp10 \
+    libgmp-dev \
+    bash \
+    make \
+    mawk \
+    file \
+    pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV CHPL_VERSION master
+ENV CHPL_HOME    /opt/chapel/$CHPL_VERSION
+ENV CHPL_GMP     system
+
+RUN mkdir -p /opt/chapel \
+    && wget -q -O - https://github.com/chapel-lang/chapel/archive/master.tar.gz | tar -xzC /opt/chapel --transform 's/chapel-//' \
+    && make -C $CHPL_HOME \
+    && make -C $CHPL_HOME chpldoc \
+    && make -C $CHPL_HOME test-venv
+
+ENV PATH $PATH:$CHPL_HOME/bin/linux64:$CHPL_HOME/util

--- a/util/dockerfiles/master/Dockerfile
+++ b/util/dockerfiles/master/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:9.4
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     wget \
@@ -12,6 +12,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python-setuptools \
     libgmp10 \
     libgmp-dev \
+    locales \
     bash \
     make \
     mawk \
@@ -27,6 +28,12 @@ RUN mkdir -p /opt/chapel \
     && wget -q -O - https://github.com/chapel-lang/chapel/archive/master.tar.gz | tar -xzC /opt/chapel --transform 's/chapel-//' \
     && make -C $CHPL_HOME \
     && make -C $CHPL_HOME chpldoc \
-    && make -C $CHPL_HOME test-venv
+    && make -C $CHPL_HOME test-venv 
+
+# Configure locale
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    echo 'LANG="en_US.UTF-8"'>/etc/default/locale && \
+    dpkg-reconfigure --frontend=noninteractive locales && \
+    update-locale LANG=en_US.UTF-8
 
 ENV PATH $PATH:$CHPL_HOME/bin/linux64:$CHPL_HOME/util

--- a/util/dockerfiles/master/gasnet/Dockerfile
+++ b/util/dockerfiles/master/gasnet/Dockerfile
@@ -1,0 +1,9 @@
+FROM chapel/chapel:master
+
+ENV CHPL_COMM gasnet
+
+RUN make -C $CHPL_HOME \
+    && make -C $CHPL_HOME chpldoc \
+    && make -C $CHPL_HOME test-venv
+
+ENV GASNET_SPAWNFN L


### PR DESCRIPTION
This is a Docker image that has worked for PNNL so far in building against master from GitlabCI.

The ``locales`` dependency and ``RUN`` work seems like a kludge to get around perl warnings when running ``start_test``. I'm not sure how this was handled with the previous releases?

I added ``curl`` as an install so that the ``pip`` calls in ``make test-venv`` work. I was getting errors without it saying that ``curl`` didn't exist.