### PR TITLE
Default to ibv on cray-cs systems

### DIFF
--- a/util/chplenv/chpl_comm_substrate.py
+++ b/util/chplenv/chpl_comm_substrate.py
@@ -22,7 +22,9 @@ def get():
             elif platform_val == 'cray-xk':
                 substrate_val = 'gemini'
             elif platform_val == 'cray-xc':
-                    substrate_val = 'aries'
+                substrate_val = 'aries'
+            elif platform_val == 'cray-cs':
+                substrate_val = 'ibv'
             elif platform_val == 'marenostrum':
                 substrate_val = 'udp'
             elif platform_val == 'pwr5':


### PR DESCRIPTION
This just corrects our default to match what we document. We used to default to
ibv on cray-cs systems, but this was lost when we rewrote the chplenv scripts
in python in 52aacf2485

Noticed while working on https://github.com/chapel-lang/chapel/issues/10543