### PR TITLE
Remove IBM pwr5 documentation

### DIFF
--- a/doc/rst/platforms/ibm.rst
+++ b/doc/rst/platforms/ibm.rst
@@ -30,8 +30,7 @@ the following settings:
 #. Set ``CHPL_HOME`` and ``MANPATH`` as indicated in :ref:`readme-chplenv`.
 
 
-#. Set ``CHPL_HOST_PLATFORM`` to ``pwr5`` for a Power5 cluster or
-   ``pwr6`` for a Power6 cluster.  For example:
+#. Set ``CHPL_HOST_PLATFORM`` to ``pwr6`` for a Power6 cluster.  e.g.:
 
    .. code-block:: sh
 

--- a/doc/rst/usingchapel/chplenv.rst
+++ b/doc/rst/usingchapel/chplenv.rst
@@ -71,7 +71,6 @@ CHPL_HOST_PLATFORM
         marenostrum  BSC's MareNostrum platform
         netbsd32     32-bit NetBSD platforms
         netbsd64     64-bit NetBSD platforms
-        pwr5         IBM Power5 SMP cluster
         pwr6         IBM Power6 SMP cluster
         sunos        SunOS platforms
         cray-cs      Cray CS\ |trade|
@@ -169,7 +168,7 @@ CHPL_*_COMPILER
                         where PE_ENV is set by PrgEnv-* modules)
         darwin        clang if available, otherwise gnu
         marenostrum   ibm
-        pwr5, pwr6    ibm
+        pwr6          ibm
         other         gnu
         ============  ==================================================
 

--- a/doc/rst/usingchapel/multilocale.rst
+++ b/doc/rst/usingchapel/multilocale.rst
@@ -138,7 +138,6 @@ cray-cs                ibv
 cray-xc                aries
 cray-xe                gemini
 cray-xk                gemini
-pwr5                   lapi
 pwr6                   ibv
 other                  udp
 ====================  ===================

--- a/third-party/gasnet/Makefile
+++ b/third-party/gasnet/Makefile
@@ -27,10 +27,6 @@ ifneq ($(CHPL_MAKE_COMM_SEGMENT),everything)
 CHPL_GASNET_CFG_OPTIONS += --disable-aligned-segments
 endif
 
-ifeq ($(CHPL_MAKE_TARGET_PLATFORM),pwr5)
-CHPL_GASNET_CFG_OPTIONS += -with-mpi-cc=mpcc
-endif
-
 ifeq ($(CHPL_MAKE_TARGET_PLATFORM),pwr6)
 CHPL_GASNET_CFG_OPTIONS += -with-mpi-cc=mpcc
 endif

--- a/util/chplenv/chpl_comm_substrate.py
+++ b/util/chplenv/chpl_comm_substrate.py
@@ -27,8 +27,6 @@ def get():
                 substrate_val = 'ibv'
             elif platform_val == 'marenostrum':
                 substrate_val = 'udp'
-            elif platform_val == 'pwr5':
-                substrate_val = 'lapi'
             elif platform_val == 'pwr6':
                 substrate_val = 'ibv'
             else:

--- a/util/chplenv/chpl_launcher.py
+++ b/util/chplenv/chpl_launcher.py
@@ -64,11 +64,6 @@ def get():
                 launcher_val = 'gasnetrun_ofi'
             elif substrate_val == 'psm':
                 launcher_val = 'gasnetrun_psm'
-            elif substrate_val == 'lapi':
-                # our loadleveler launcher is not yet portable/stable/flexible
-                # enough to serve as a good default
-                #launcher_val = 'loadleveler'
-                launcher_val = 'none'
         elif comm_val == 'mpi':
             launcher_val = 'mpirun'
         else:


### PR DESCRIPTION
pwr5 is obsolete and GASNet removed support for the lapi substrate years ago,
so remove any remaining documentation.

Noticed while working on https://github.com/chapel-lang/chapel/issues/10543