### PR TITLE
Update documentation to note that the mxm substrate is deprecated

### DIFF
--- a/doc/rst/usingchapel/multilocale.rst
+++ b/doc/rst/usingchapel/multilocale.rst
@@ -110,11 +110,11 @@ gemini
 aries
     Aries for Cray XC series
     (see :ref:`Using Chapel on Cray Systems <readme-cray>`)
-
 mpi
     MPI - portable conduit, works on any network with MPI 1.1 or newer
 mxm
     Mellanox MXM for InfiniBand
+    (mxm is deprecated -- the ibv substrate is recommended)
 ofi
     OFI for multiple networks supported by libfabric
 pami


### PR DESCRIPTION
GASNet 1.32.0 deprecated mxm in favor of the ibv conduit. From the changelog:

```
* Mellanox ConnectX series HCAs (mxm-conduit)
  - This conduit is now DEPRECATED.
  - Use of ibv-conduit is recommended for users with InfiniBand hardware.
  - Adjust envvar GASNET_PHYSMEM_{MAX,PROBE} handling to match other conduits
```

Noticed while working on https://github.com/chapel-lang/chapel/issues/10543