### PR TITLE
Force GASNet to build the specified substrate

### DIFF
--- a/third-party/gasnet/Makefile
+++ b/third-party/gasnet/Makefile
@@ -10,6 +10,10 @@ ifneq ($(CHPL_MAKE_COMM_SEGMENT),none)
 CHPL_GASNET_CFG_OPTIONS += --enable-segment-$(CHPL_MAKE_COMM_SEGMENT)
 endif
 
+ifneq ($(CHPL_MAKE_COMM_SUBSTRATE),none)
+CHPL_GASNET_CFG_OPTIONS += --enable-$(CHPL_MAKE_COMM_SUBSTRATE)
+endif
+
 # PSHM (inter-Process SHared Memory) provide a mechanism for gasnet instances
 # on the same node to communicate through shared memory instead of the real
 # conduit. In "production" we only run a single gasnet client per node so this
@@ -37,7 +41,6 @@ ifeq ($(CHPL_MAKE_COMM_SUBSTRATE),gemini)
 CHPL_GASNET_CFG_OPTIONS += --enable-gemini-multi-domain
 else
 ifeq ($(CHPL_MAKE_COMM_SUBSTRATE),aries)
-CHPL_GASNET_CFG_OPTIONS += --enable-aries
 CHPL_GASNET_CFG_OPTIONS += --enable-aries-multi-domain
 else
 # We need to do this because the auto-detect stuff for gemini is not


### PR DESCRIPTION
Previously, we just let GASNet auto-detect the substrate/conduit. This meant
that a user could explicitly build with CHPL_COMM_SUBSTRATE=mpi and even if mpi
wasn't available on the system we wouldn't error, which led to much more
cryptic build or even runtime issues later on.

Now we throw `--enable-$CHPL_COMM_SUBSTRATE` to the GASNet build and if GASNet
can't build the specified substrate it will stop with a clear error message.

Closes https://github.com/chapel-lang/chapel/issues/10543