### PR TITLE
Avoid using spool files for PBSPro

### DIFF
--- a/util/test/chpl_launchcmd.py
+++ b/util/test/chpl_launchcmd.py
@@ -754,7 +754,7 @@ class PbsProJob(AbstractJob):
     hostlist_resource = 'mppnodes'
     num_nodes_resource = 'mppwidth'
     num_cpus_resource = 'ncpus'
-    redirect_output = False
+    redirect_output = True
 
     @property
     def job_name(self):


### PR DESCRIPTION
We redirect stdout/stderr directly to the output file for moab/torque systems,
but we stuck with using spool files on PBSPro systems because of slowness
encountered with redirection in the past.

Now we're running into issues on newer PBSPro systems because of spooling, so
try out redirection again. At least in limited testing I'm not seeing any
issues on the older XE PBSPro system that gave us trouble before.

For history see https://github.com/chapel-lang/chapel/pull/4084