### PR TITLE
Reduce special-case pruning of shadow variables

### DIFF
--- a/compiler/resolution/implementForallIntents.cpp
+++ b/compiler/resolution/implementForallIntents.cpp
@@ -1984,7 +1984,6 @@ static void findOuterVarsNew(ForallStmt* fs, SymbolMap& outer2shadow,
         !sym->hasFlag(FLAG_TEMP)     && // not a temp
         !isFsIndexVar(fs, sym)       && // not fs's index var
         !isFsShadowVar(fs, sym)      && // not fs's intent var
-        !sym->hasFlag(FLAG_ARG_THIS) && // todo: no special case for 'this'
         isOuterVarNew(sym, block)       // it must be an outer variable
     ) {
       // if not there already
@@ -2300,16 +2299,6 @@ static void processShadowVarsNew(ForallStmt* fs, int& numShadowVars)
       if (tiIntent == INTENT_REF || tiIntent == INTENT_REF_MAYBE_CONST) {
         // do we want this? does this lead to more efficient generated code?
          pruneit = true;
-
-      } else if (isAtomicType(ovar->type)) {
-        // Currently we need it because sync variables do not get tupled
-        // and detupled properly when threading through the leader iterator.
-        // See e.g. test/distributions/dm/s7.chpl
-        // Atomic vars might not work either.
-        // And anyway, only 'ref' intent makes sense here.
-        pruneit = true;
-
-        USR_WARN(fs, "an atomic var currently can be passed into a forall loop by 'ref' intent only - %s is ignored for '%s'", intentDescrString(tiIntent), ovar->name);
       }
 
       if (pruneit) {

--- a/test/studies/madness/aniruddha/madchap/MRA.chpl
+++ b/test/studies/madness/aniruddha/madchap/MRA.chpl
@@ -77,6 +77,7 @@ class Function {
         if debug then writeln("  initializing two-scale relation coefficients");
         hgDom = {0..2*k-1, 0..2*k-1};
         hg = hg_getCoeffs(k);
+        hgT = [(i,j) in hgDom] hg[j,i];
 
        
         if debug then writeln("  initializing quadrature coefficients");
@@ -91,8 +92,6 @@ class Function {
         dcDom = {0..k-1, 0..k-1};
 
         this.complete();
-
-        [(i,j) in hgDom] hgT[i,j] = hg[j,i];
 
         for i in quad_phiDom.dim(1) {
             const p = phi(quad_x[i], k);


### PR DESCRIPTION
During resolution, the compiler converts references to outer variables
in a forall loop body to shadow variables.  The compiler used to
exclude the 'this' variable and variables of atomic types from this
treatment. This was done because the inclusion of such variables
caused issues elsewhere in the compiler that would need to be addressed.

Now the compiler is in a better shape and we do not need these exclusions.

With this change, the compiler detects previously-unnoticed invalid
access to a const field after this.complete() in an initializer.
To avoid switching this field to non-const, instead initialize that field
to a forall-expression prior to this.complete().

I examined manually the AST at the end of resolution to confirm
that a temporary array is not created for the forall-expression.

In the future we may also want to Chapel-ify hg_getCoeffs()
by having it return a forall-expression instead of a temporary array.
I did not do it because the other use of hg_getCoeffs()
would be expressed better as a rank-changing slice.