### PR TITLE
Fix problem with throwing nested call var init

### DIFF
--- a/compiler/resolution/callDestructors.cpp
+++ b/compiler/resolution/callDestructors.cpp
@@ -749,8 +749,11 @@ void ReturnByRef::transformMove(CallExpr* moveExpr)
 
   // Ignore a CondStmt containing a PRIM_CHECK_ERROR
   // so that we can still detect initCopy after a call that can throw
-  if (isCheckErrorStmt(nextExpr))
-      nextExpr = nextExpr->next;
+  //
+  // Also ignore a DefExpr which might e.g. define a user variable
+  // which is = initCopy(call_tmp).
+  while (nextExpr && (isCheckErrorStmt(nextExpr) || isDefExpr(nextExpr)))
+    nextExpr = nextExpr->next;
 
   CallExpr* copyExpr  = NULL;
 
@@ -826,7 +829,7 @@ void ReturnByRef::transformMove(CallExpr* moveExpr)
     if (rhsFn->hasFlag(FLAG_INIT_COPY_FN) && unaliasFn != NULL) {
       // BHARSH: It seems important that there's a temporary to store the
       // result of the unaliasFn call. Otherwise we'll move into a variable
-      // that has multiplie uses, which seems to cause a variety of problems.
+      // that has multiple uses, which seems to cause a variety of problems.
       //
       // In particular, I noticed that `changeRetToArgAndClone` generates
       // bad AST if I simply did this:

--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -1893,7 +1893,7 @@ static Expr* dropUnnecessaryCast(CallExpr* call) {
 
           if (newType == oldType) {
             if (isUserDefinedRecord(newType) && !getSymbolImmediate(var)) {
-              result = new CallExpr("chpl__initCopy", var);
+              result = new CallExpr("_removed_cast", var);
               call->replace(result);
             } else {
               result = new SymExpr(var);

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -2018,6 +2018,7 @@ module ChapelBase {
     return __primitive("cast", t, x);
   }
 
+  pragma "no borrow convert"
   inline proc _removed_cast(in x) {
     return x;
   }

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1065,10 +1065,19 @@ module ChapelBase {
       throw new unmanaged TaskErrors(e.errors);
   }
 
+  proc _do_command_line_cast(type t, x:c_string) throws {
+    var str = x:string;
+    if t == string {
+      return str;
+    } else {
+      return str:t;
+    }
+  }
+  // param s is used for error reporting
   pragma "command line setting"
-  proc _command_line_cast(param s: c_string, type t, x) {
+  proc _command_line_cast(param s: c_string, type t, x:c_string) {
     try! {
-      return _cast(t, x:string);
+      return _do_command_line_cast(t, x);
     }
   }
 

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -2017,4 +2017,8 @@ module ChapelBase {
   inline proc _cast(type t:borrowed, x:_unmanaged) where isSubtype(_to_borrowed(x.type),t) {
     return __primitive("cast", t, x);
   }
+
+  inline proc _removed_cast(in x) {
+    return x;
+  }
 }

--- a/modules/internal/SharedObject.chpl
+++ b/modules/internal/SharedObject.chpl
@@ -313,12 +313,13 @@ module SharedObject {
   // It only works in a value context (i.e. when the result of the
   // coercion is a value, not a reference).
   pragma "no doc"
-  inline proc _cast(type t:_shared, x:_shared) where isSubtype(x.t,t.t) {
+  inline proc _cast(type t:_shared, in x:_shared) where isSubtype(x.t,t.t) {
     var ret:t; // default-init the Shared type to return
     ret.p = x.p:t.t; // cast the class type
     ret.pn = x.pn;
-    if ret.pn != nil then
-      ret.pn.retain();
+    // steal the reference count increment we did for 'in' intent
+    x.p = nil;
+    x.pn = nil;
     return ret;
   }
 

--- a/modules/standard/Regexp.chpl
+++ b/modules/standard/Regexp.chpl
@@ -617,11 +617,15 @@ record regexp {
         captures[i] = m;
       } else {
         if m.matched {
-          try {
-            captures[i] = text[m]:captures[i].type;
-          } catch {
-            var empty:captures[i].type;
-            captures[i] = empty;
+          if captures[i].type == string {
+            captures[i] = text[m];
+          } else {
+            try {
+              captures[i] = text[m]:captures[i].type;
+            } catch {
+              var empty:captures[i].type;
+              captures[i] = empty;
+            }
           }
         } else {
           var empty:captures[i].type;

--- a/test/errhandling/ferguson/ifexpr-array-literal.future
+++ b/test/errhandling/ferguson/ifexpr-array-literal.future
@@ -1,2 +1,2 @@
 bug: valgrind errors when throwing from if and array literal
-#10204
+#10735

--- a/test/errhandling/ferguson/nested-call-expr-var-init-throws.chpl
+++ b/test/errhandling/ferguson/nested-call-expr-var-init-throws.chpl
@@ -1,0 +1,47 @@
+record R {
+  var s = "world";
+  proc hello() { writeln("Hello ", s); return this; }
+
+  proc init() { writeln("in init"); }
+  proc deinit() { writeln("in deinit"); }
+}
+
+proc gimmeanr(): R throws {
+  var ret: R;
+  throw new Error();
+  return ret;
+}
+
+proc testa() throws {
+  var r = gimmeanr();
+}
+proc testb() throws {
+  var r = gimmeanr().hello();
+}
+proc testc() throws {
+  var r = gimmeanr().hello().hello();
+}
+proc testd() throws {
+  var tmp: R;
+  var r = gimmeanr().hello().hello();
+}
+
+writeln("testa");
+try {
+  testa();
+} catch { /* ignore errors for test */ }
+
+writeln("testb");
+try {
+  testb();
+} catch { /* ignore errors for test */ }
+
+writeln("testc");
+try {
+  testc();
+} catch { /* ignore errors for test */ }
+
+writeln("testd");
+try {
+  testd();
+} catch { /* ignore errors for test */ }

--- a/test/errhandling/ferguson/nested-call-expr-var-init-throws.good
+++ b/test/errhandling/ferguson/nested-call-expr-var-init-throws.good
@@ -1,0 +1,14 @@
+testa
+in init
+in deinit
+testb
+in init
+in deinit
+testc
+in init
+in deinit
+testd
+in init
+in init
+in deinit
+in deinit

--- a/test/types/string/ferguson/string-useless-cast.chpl
+++ b/test/types/string/ferguson/string-useless-cast.chpl
@@ -1,0 +1,10 @@
+proc bad(type t, x:c_string) {
+  try! {
+    //return _cast(t, x:string); // fails
+    return x:string:t; // fails
+    //var tmp = x:string; return tmp:string; // OK
+  }
+}
+
+//bad(int, c"1"); // OK
+bad(string, c"1"); // OK

--- a/test/types/string/ferguson/string-useless-cast.chpl
+++ b/test/types/string/ferguson/string-useless-cast.chpl
@@ -1,10 +1,7 @@
 proc bad(type t, x:c_string) {
   try! {
-    //return _cast(t, x:string); // fails
-    return x:string:t; // fails
-    //var tmp = x:string; return tmp:string; // OK
+    return x:string:t;
   }
 }
 
-//bad(int, c"1"); // OK
 bad(string, c"1"); // OK


### PR DESCRIPTION
Resolves #10204.

This PR fixes a problem with code like this:
``` chapel
proc foo() throws {
  var r = makeMyRecord().returnThis();
}
```
in the event that makeMyRecord() throws.

The problem was that callDestructors considers any variable for which a DefExpr exists in the current control flow to be subject to deinitialization. But the normalizer was adding call-expr temps and nested calls between the DefExpr for a variable init and the initialization itself. This confused callDestructors.

The fix here is to identify this pattern in the normalizer and to add the call-expr temps before the DefExpr for the variable being initialized in that case. An alternative strategy could be to modify callDestructors to only consider a variable initialized after it is defined *and* it is possibly set.

The change to normalization caused problems with tests such as coercions-covariant.chpl, where a coercion combines with the `in` intent. Adjusted callDestructors to detect the "move" in this case by the FLAG_NO_AUTO_DESTROY and also to remove a destruction when the copy is removed.

This change to normalization caused issues with the previous handling of removing useless casts (added in #9796). To solve that problem, this PR introduces a new function `_removed_cast`. Removed record casts are converted into calls to this function so that the copy behavior is preserved. Along these lines, adjusted two module functions to avoid useless casts (since the code can be simpler without it).

Lastly, while debugging an earlier version of these changes, I noticed that a `shared` `_cast` function was changing reference counts twice (because the default intent for shared is `in`). Fixed this by explicitly marking the default intent (to be clearer to humans) and then stealing the already-incremented reference count from the argument.

- [x] full local testing
- [x] primers leak no more after this PR than they do on master
- [x] primers pass valgrindexe testing

Reviewed by @vasslitvinov - thanks!