### PR TITLE
Update these prediffs to avoid clock skew errors

### DIFF
--- a/test/compflags/lydia/library/makefiles/getMakefile.prediff
+++ b/test/compflags/lydia/library/makefiles/getMakefile.prediff
@@ -2,4 +2,7 @@
 
 make mytest >> $2 2>&1
 sed '/mytest.c:/d' $2 > $2.tmp
-mv $2.tmp $2
+grep < $2.tmp > $2 -v \
+     -e '^g*make\(\[[0-9]*\]\)*: Warning: File .* has modification time .* in the future *$' \
+     -e '^g*make\(\[[0-9]*\]\)*: warning:  Clock skew detected\.  Your build may be incomplete\. *$'
+

--- a/test/compflags/lydia/library/makefiles/renamedLib.prediff
+++ b/test/compflags/lydia/library/makefiles/renamedLib.prediff
@@ -2,4 +2,7 @@
 
 make renamedTest >> $2 2>&1
 sed '/renamedTest.c:/d' $2 > $2.tmp
-mv $2.tmp $2
+grep < $2.tmp > $2 -v \
+     -e '^g*make\(\[[0-9]*\]\)*: Warning: File .* has modification time .* in the future *$' \
+     -e '^g*make\(\[[0-9]*\]\)*: warning:  Clock skew detected\.  Your build may be incomplete\. *$'
+


### PR DESCRIPTION
Just ignore it if it happens.  I suspect this won't be the last of the sub_test
filtering I end up needing to redo or find a way to trigger, but I'm not sure it
is worth tracking them down ahead of time.