### PR TITLE
Use network atomics for real(32) atomics

### DIFF
--- a/modules/internal/comm/ugni/NetworkAtomicTypes.chpl
+++ b/modules/internal/comm/ugni/NetworkAtomicTypes.chpl
@@ -24,7 +24,7 @@ module NetworkAtomicTypes {
     return T == bool     ||
            T ==  int(32) || T ==  int(64) ||
            T == uint(32) || T == uint(64) ||
-           T == real(64);
+           T == real(32) || T == real(64);
   }
 
   proc chpl__networkAtomicType(type T) type {


### PR DESCRIPTION
Previously we used processor atomics, but we have runtime support for 32 bit
reals. Gemini lacks hardware support for this so it's still just AM+processor
atomics, but Aries has support for it.