### PR TITLE
Un-future passing future

### DIFF
--- a/test/classes/delete-free/shared/shared-default-arg-nil.bad
+++ b/test/classes/delete-free/shared/shared-default-arg-nil.bad
@@ -1,1 +1,0 @@
-shared-default-arg-nil.chpl:7: error: Default expression not convertible to formal type

--- a/test/classes/delete-free/shared/shared-default-arg-nil.future
+++ b/test/classes/delete-free/shared/shared-default-arg-nil.future
@@ -1,2 +1,0 @@
-design: allow nil default for shared argument?
-#8180


### PR DESCRIPTION
Now passes due to PR #10561.
Closes #8180.

Trivial and not reviewed.