### PR TITLE
Allow mpiccc and mpicxx values to be overridden

### DIFF
--- a/make/compiler/Makefile.intel
+++ b/make/compiler/Makefile.intel
@@ -25,6 +25,13 @@
 CXX = icpc
 CC = icc
 
+ifeq (, $(MPI_CC))
+MPI_CC = mpiicc
+endif
+ifeq (, $(MPI_CXX))
+MPI_CXX = mpiicpc
+endif
+
 RANLIB = ranlib
 
 

--- a/make/compiler/Makefile.mpi-gnu
+++ b/make/compiler/Makefile.mpi-gnu
@@ -19,5 +19,13 @@
 
 include $(CHPL_MAKE_HOME)/make/compiler/Makefile.gnu
 
-CC=mpicc
-CXX=mpicxx
+ifeq (, $(MPI_CC))
+MPI_CC=mpicc
+endif
+
+ifeq (, $(MPI_CXX))
+MPI_CXX=mpicxx
+endif
+
+CC=$(MPI_CC)
+CXX=$(MPI_CXX)

--- a/runtime/etc/Makefile.comm-gasnet
+++ b/runtime/etc/Makefile.comm-gasnet
@@ -58,7 +58,10 @@ LD = $(GASNET_LD)   # GASNet chose C++ linker so stick with it
 else ifeq ($(GASNET_LD),$(GASNET_CC))
 LD = $(GASNET_CXX)  # GASNet chose C, so switch to C++
 else ifeq ($(GASNET_LD_REQUIRES_MPI),1)
-LD = mpicxx         # GASNet chose mpicc, so we'll choose mpicxx
+ifeq (, $(MPI_CXX))
+MPI_CXX = mpicxx    # GASNet defaults to mpicc, so we'll default to mpicxx
+endif
+LD = $(MPI_CXX)
 else
 LD = $(CXX)
 $(warning GASNET_LD unexpectedly set to '$(GASNET_LD)'.  Please file a Chapel bug against this.)


### PR DESCRIPTION
Previously we hardcoded LD=mpicxx for when GASNet required MPI support, but not
all MPI C++ wrappers use that name. e.g. Intel's is named mpiicpc.

This allows users to set MPI_CXX to override the default value (and gasnet
already supports setting MPI_CC to override the default compiler.

It also defaults to MPI_CC=mpiicc and MPI_CXX=mpiicpc for the Intel compiler

Resolves https://github.com/chapel-lang/chapel/issues/10624