### PR TITLE
Use unmanaged in tree example in one more place

### DIFF
--- a/test/release/examples/programs/tree.chpl
+++ b/test/release/examples/programs/tree.chpl
@@ -57,7 +57,7 @@ proc buildTree(height: uint = treeHeight, id: int = 1): unmanaged node {
 // sum() walks the tree in parallel using a cobegin, computing the sum
 // of the node IDs using a postorder traversal.
 //
-proc sum(n: node): int {
+proc sum(n: unmanaged node): int {
   var total = n.id;
 
   if n.left != nil {


### PR DESCRIPTION
PR #9499 updated this test to use unmanaged types
but missed one place. Note that this test should be
revisited to maybe use owned/shared/borrowed
as described in issue #10598.

Relates to #9087.

Trivial and not reviewed.