### PR TITLE
Optimize the atomic barrier implementation for network atomics

### DIFF
--- a/modules/packages/AllLocalesBarriers.chpl
+++ b/modules/packages/AllLocalesBarriers.chpl
@@ -70,10 +70,10 @@ module AllLocalesBarriers {
   class AllLocalesBarrier: BarrierBaseType {
 
     const BarrierSpace = LocaleSpace dmapped Block(LocaleSpace);
-    var globalBarrier: [BarrierSpace] unmanaged aBarrier(reusable=true, hackIntoCommBarrier=true);
+    var globalBarrier: [BarrierSpace] unmanaged aBarrier(reusable=true, procAtomics=true, hackIntoCommBarrier=true);
 
     proc init(numTasksPerLocale: int) {
-      globalBarrier = [b in BarrierSpace] new unmanaged aBarrier(numTasksPerLocale, reusable=true, hackIntoCommBarrier=true);
+      globalBarrier = [b in BarrierSpace] new unmanaged aBarrier(numTasksPerLocale, reusable=true, procAtomics=true, hackIntoCommBarrier=true);
     }
 
     proc deinit() {

--- a/modules/standard/Barriers.chpl
+++ b/modules/standard/Barriers.chpl
@@ -129,16 +129,12 @@ module Barriers {
        is true, reset the barrier to be used again.
      */
     inline proc barrier() {
-      on bar {
-        bar.barrier();
-      }
+      bar.barrier();
     }
 
     /* Notify the barrier that this task has reached this point. */
     inline proc notify() {
-      on bar {
-        bar.notify();
-      }
+      bar.notify();
     }
 
     /* Wait until `n` tasks have called :proc:`notify`.  If `reusable` is true,
@@ -151,9 +147,7 @@ module Barriers {
        `n` tasks have called :proc:`notify`.
      */
     inline proc wait() {
-      on bar {
-        bar.wait();
-      }
+      bar.wait();
     }
 
     /* Return `true` if `n` tasks have called :proc:`notify`
@@ -167,9 +161,7 @@ module Barriers {
        when :proc:`reset` is called, the behavior is undefined.
      */
     inline proc reset(nTasks: int) {
-      on bar {
-        bar.reset(nTasks);
-      }
+      bar.reset(nTasks);
     }
   }
 

--- a/modules/standard/Barriers.chpl
+++ b/modules/standard/Barriers.chpl
@@ -195,7 +195,6 @@ module Barriers {
     }
   }
 
-
 /* A task barrier implemented using atomics. Can be used as a simple barrier
    or as a split-phase barrier.
  */
@@ -208,9 +207,11 @@ module Barriers {
     pragma "no doc"
     var n: int;
     pragma "no doc"
-    var count: chpl__processorAtomicType(int);
+    param procAtomics = if CHPL_NETWORK_ATOMICS == "none" then true else false;
     pragma "no doc"
-    var done: chpl__processorAtomicType(bool);
+    var count: if procAtomics then chpl__processorAtomicType(int) else atomic int;
+    pragma "no doc"
+    var done: if procAtomics then chpl__processorAtomicType(bool) else atomic bool;
 
     // Hack for AllLocalesBarrier
     pragma "no doc"
@@ -228,8 +229,9 @@ module Barriers {
 
     // Hack for AllLocalesBarrier
     pragma "no doc"
-    proc init(n: int, param reusable: bool, param hackIntoCommBarrier: bool) {
+    proc init(n: int, param reusable: bool, param procAtomics: bool, param hackIntoCommBarrier: bool) {
       this.reusable = reusable;
+      this.procAtomics = procAtomics;
       this.hackIntoCommBarrier = hackIntoCommBarrier;
       this.complete();
       reset(n);
@@ -237,18 +239,19 @@ module Barriers {
 
     pragma "no doc"
     inline proc reset(nTasks: int) {
-      on this {
+      inline proc innerReset() {
         n = nTasks;
         count.write(n);
         done.write(false);
       }
+      if procAtomics then on this do innerReset(); else innerReset();
     }
 
     /* Block until n tasks have called this method.  If `reusable` is true,
        reset the barrier to be used again.
      */
     inline proc barrier() {
-      on this {
+      inline proc innerBarrier() {
         const myc = count.fetchSub(1);
         if myc<=1 {
           if hackIntoCommBarrier {
@@ -272,11 +275,12 @@ module Barriers {
           }
         }
       }
+      if procAtomics then on this do innerBarrier(); else innerBarrier();
     }
 
     /* Notify the barrier that this task has reached this point. */
     inline proc notify() {
-      on this {
+      inline proc innerNotify() {
         const myc = count.fetchSub(1);
         if myc<=1 {
           const alreadySet = done.testAndSet();
@@ -285,6 +289,7 @@ module Barriers {
           }
         }
       }
+      if procAtomics then on this do innerNotify(); else innerNotify();
     }
 
     /* Wait until `n` tasks have called :proc:`notify`.  If `reusable` is true,
@@ -293,7 +298,7 @@ module Barriers {
        :proc:`notify`.
      */
     inline proc wait() {
-      on this {
+      inline proc innerWait() {
         done.waitFor(true);
         if reusable {
           const myc = count.fetchAdd(1);
@@ -302,6 +307,7 @@ module Barriers {
           done.waitFor(false);
         }
       }
+      if procAtomics then on this do innerWait(); else innerWait();
     }
 
     /* Return `true` if `n` tasks have called :proc:`notify`


### PR DESCRIPTION
This basically just avoids using on-stmts and doesn't force processor atomics
when network atomics are available. This results in a 2x speedup for the empty
atomic barrier test taking it from ~10s to ~5s. Note that there is still an
on-stmt in the network atomic `waitFor()` implementation, but optimizing that
is future work  https://github.com/chapel-lang/chapel/issues/10617
