### PR TITLE
File a pair of "error message" futures about type mismatches in generic initializations

### DIFF
--- a/test/types/records/init/generic/mismatch.bad
+++ b/test/types/records/init/generic/mismatch.bad
@@ -1,0 +1,4 @@
+mismatch.chpl:16: error: unresolved call 'A.init(type int(64))'
+mismatch.chpl:5: note: candidates are: A.init(x)
+mismatch.chpl:10: note:                 A.init(a: A)
+mismatch.chpl:1: note:                 A.init(other: A)

--- a/test/types/records/init/generic/mismatch.chpl
+++ b/test/types/records/init/generic/mismatch.chpl
@@ -1,0 +1,17 @@
+record A {
+  type t;
+  var x: t;
+
+  proc init(x) {
+    this.t = x.type;
+    this.x = x;
+  }
+
+  proc init(a:A) { // copy initializer to avoid confusion with the above
+    this.t = a.t;
+    this.x = a.x;
+  }
+}
+
+var a: A(int) = new A(42.0);
+writeln(a);

--- a/test/types/records/init/generic/mismatch.future
+++ b/test/types/records/init/generic/mismatch.future
@@ -1,0 +1,7 @@
+error message: confusing error for mismatched generic type assignment
+
+This test is complaining about an unresolved call to an initializer
+that we're arguably not making.  Compiling in developer mode, it seems
+to be coming from one of our compiler-generated `defaultOf()` calls.
+But why should we be calling `defaultOf()` for a case that has an
+explicit initializer.  Are we still double-initializing?

--- a/test/types/records/init/generic/mismatch.good
+++ b/test/types/records/init/generic/mismatch.good
@@ -1,0 +1,1 @@
+mismatch.chpl:16: error: type mismatch in assignment from A(real(64)) to A(int(64))

--- a/test/types/records/init/generic/mismatch2.bad
+++ b/test/types/records/init/generic/mismatch2.bad
@@ -1,0 +1,1 @@
+mismatch2.chpl:20: error: type mismatch in assignment from real(64) to int(64)

--- a/test/types/records/init/generic/mismatch2.chpl
+++ b/test/types/records/init/generic/mismatch2.chpl
@@ -1,0 +1,21 @@
+record A {
+  type t;
+  var x: t;
+
+  proc init(type t) {
+    this.t = t;
+  }
+
+  proc init(x) {
+    this.t = x.type;
+    this.x = x;
+  }
+
+  proc init(a:A) { // copy initializer to avoid confusion with the above
+    this.t = a.t;
+    this.x = a.x;
+  }
+}
+
+var a: A(int) = new A(42.0);
+writeln(a);

--- a/test/types/records/init/generic/mismatch2.future
+++ b/test/types/records/init/generic/mismatch2.future
@@ -1,0 +1,7 @@
+error message: confusing error for mismatched generic type assignment
+
+This test is complaining about an assignment from real to integer,
+apparently from within a compiler-generated assignment operator,
+suggesting that we're using assignment where we should simply be using
+initialization.  I believe the error message should be complaining
+about an (initialization) assignment between A(real) and A(int).

--- a/test/types/records/init/generic/mismatch2.good
+++ b/test/types/records/init/generic/mismatch2.good
@@ -1,0 +1,1 @@
+mismatch2.chpl:20: error: type mismatch in assignment from A(real(64)) to A(int(64))


### PR DESCRIPTION
These tests shouldn't compile, but don't generate clear error messages
that are likely to make sense to end-users.  Digging into them also
seems to suggest that we're still default initializing + assigning
records rather than simply initializing them in-place once.
Specifically, compiling in --devel mode with
--print-callstack-on-error seems to reveal calls to defaultOf() and
the compiler-generated assignment operator which seem surprising.
(Lydia confirms that this is the case for generic records still which
I'd apparently forgotten).

The .good files show what I think a better error message would be; the
.bad shows what they are today for users (for developers they differ
in ways that sometimes more illuminating, sometimes less so).

Also curious: I was surprised that adding the `proc init(type t)`
overload to mismatch2.chpl improved the behavior of mismatch.chpl.  It
doesn't seem like defining this initializer should be required does
it?  (or am I forgetting something?)