### PR TITLE
Time and graph mergesort

### DIFF
--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -606,15 +606,15 @@ private proc _MergeSort(Data: [?Dom], minlen=16, comparator:?rec=defaultComparat
     return;
   }
   const mid = (hi-lo)/2+lo;
-  var A1 = Data[lo..mid];
-  var A2 = Data[mid+1..hi];
+  ref A1 = Data[lo..mid];
+  ref A2 = Data[mid+1..hi];
   cobegin {
     { _MergeSort(A1, minlen, comparator); }
     { _MergeSort(A2, minlen, comparator); }
   }
 
   // TODO -- This iterator causes unnecessary overhead - we can do without it
-  for (a, _a) in zip(Data[lo..hi], _MergeIterator(A1, A2, comparator=comparator)) do a = _a;
+  for (a, _a) in zip(Data, _MergeIterator(A1, A2, comparator=comparator)) do a = _a;
 }
 
 
@@ -638,8 +638,8 @@ private iter _MergeIterator(A1: [] ?eltType, A2: [] eltType, comparator:?rec=def
   }
   if a1 == a1hi then yield A1(a1);
   else if a2 == a2hi then yield A2(a2);
-  if a1 < a1hi then for a in A1[a1..a1hi] do yield a;
-  else if a2 < a2hi then for a in A2[a2..a2hi] do yield a;
+  if a1 < a1hi then for i in a1..a1hi do yield A1[i];
+  else if a2 < a2hi then for i in a2..a2hi do yield A2[i];
 }
 
 

--- a/test/library/packages/Sort/performance/performance.perfexecopts
+++ b/test/library/packages/Sort/performance/performance.perfexecopts
@@ -1,5 +1,6 @@
 --sorts='q' --M=24 --correctness=false            # quickSort
 --sorts='h' --M=24 --correctness=false            # heapSort
+--sorts='m' --M=24 --correctness=false            # mergeSort
 --sorts='i' --M=12 --correctness=false            # insertionSort
 --sorts='s' --M=12 --correctness=false            # selectionSort
 --sorts='b' --M=12 --correctness=false            # bubbleSort

--- a/test/library/packages/Sort/performance/sorts-linearithmic.graph
+++ b/test/library/packages/Sort/performance/sorts-linearithmic.graph
@@ -1,5 +1,5 @@
 perfkeys: (seconds):, (seconds):
-files: quickSort.dat, heapSort.dat
+files: quickSort.dat, heapSort.dat, mergeSort.dat
 graphkeys: quickSort, heapSort
 graphtitle: Linearithmic sorts on 2^24 bytes of shuffled data
 ylabel: Time (seconds)

--- a/test/library/packages/Sort/performance/sorts-linearithmic.graph
+++ b/test/library/packages/Sort/performance/sorts-linearithmic.graph
@@ -1,6 +1,6 @@
-perfkeys: (seconds):, (seconds):
+perfkeys: (seconds):, (seconds):, (seconds):
 files: quickSort.dat, heapSort.dat, mergeSort.dat
-graphkeys: quickSort, heapSort
+graphkeys: quickSort, heapSort, mergeSort
 graphtitle: Linearithmic sorts on 2^24 bytes of shuffled data
 ylabel: Time (seconds)
 


### PR DESCRIPTION
In this performance test, mergesort was not part of the cases that were timed and graphed.  Perhaps it was too slow at the time.  Currently it seems fast enough, and this will set a good
baseline for the improvements in PR #10602.
