### PR TITLE
Time mergesort in sort performance testing

### DIFF
--- a/test/library/packages/Sort/performance/performance.perfexecopts
+++ b/test/library/packages/Sort/performance/performance.perfexecopts
@@ -1,5 +1,6 @@
 --sorts='q' --M=24 --correctness=false            # quickSort
 --sorts='h' --M=24 --correctness=false            # heapSort
+--sorts='m' --M=24 --correctness=false            # mergeSort
 --sorts='i' --M=12 --correctness=false            # insertionSort
 --sorts='s' --M=12 --correctness=false            # selectionSort
 --sorts='b' --M=12 --correctness=false            # bubbleSort

--- a/test/library/packages/Sort/performance/sorts-linearithmic.graph
+++ b/test/library/packages/Sort/performance/sorts-linearithmic.graph
@@ -1,5 +1,5 @@
 perfkeys: (seconds):, (seconds):
-files: quickSort.dat, heapSort.dat
+files: quickSort.dat, heapSort.dat, mergeSort.dat
 graphkeys: quickSort, heapSort
 graphtitle: Linearithmic sorts on 2^24 bytes of shuffled data
 ylabel: Time (seconds)

--- a/test/library/packages/Sort/performance/sorts-linearithmic.graph
+++ b/test/library/packages/Sort/performance/sorts-linearithmic.graph
@@ -1,6 +1,6 @@
-perfkeys: (seconds):, (seconds):
+perfkeys: (seconds):, (seconds):, (seconds):
 files: quickSort.dat, heapSort.dat, mergeSort.dat
-graphkeys: quickSort, heapSort
+graphkeys: quickSort, heapSort, mergeSort
 graphtitle: Linearithmic sorts on 2^24 bytes of shuffled data
 ylabel: Time (seconds)
 


### PR DESCRIPTION
In this performance test, mergesort was not part of the cases that were timed and graphed. Perhaps it was too slow at the time. Currently it seems fast enough, and this will set a good
baseline for the improvements in PR #10602.