### PR TITLE
Unfuturize unusedClassForallArg.chpl

### DIFF
--- a/test/parallel/forall/diten/unusedClassForallArg.bad
+++ b/test/parallel/forall/diten/unusedClassForallArg.bad
@@ -1,8 +1,0 @@
-unusedClassForallArg.chpl:8: internal error: BAS0407 chpl version 1.18.0 pre-release (a91223789c)
-Note: This source location is a guess.
-
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
-and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
-please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
-

--- a/test/parallel/forall/diten/unusedClassForallArg.future
+++ b/test/parallel/forall/diten/unusedClassForallArg.future
@@ -1,3 +1,0 @@
-bug: otherwise unused class argument causes internal error in forall loop
-
-Issue: #10122


### PR DESCRIPTION
#10645 resulted in correct compilation or this test.
Making it a regular test now.

While I did not investigate, #10645 removed a call to getRefType()
in formerly processShadowVarsNew(), now resolveShadowVarTypeIntent().
That could explain the improvement.