### PR TITLE
Remove double-delete after PR 8575

### DIFF
--- a/test/performance/thomasvandoren/matrix-multiply-chapelerific.chpl
+++ b/test/performance/thomasvandoren/matrix-multiply-chapelerific.chpl
@@ -11,8 +11,6 @@ proc main() {
 
   timer.stop();
   printResults();
-
-  delete randStream;
 }
 
 proc dotProduct(ref C: [?DC] int, ref A: [?DA] int, ref B: [?DB] int)

--- a/test/performance/thomasvandoren/matrix-multiply-foralls.chpl
+++ b/test/performance/thomasvandoren/matrix-multiply-foralls.chpl
@@ -12,8 +12,6 @@ proc main() {
 
   timer.stop();
   printResults();
-
-  delete randStream;
 }
 
 proc dotProduct(ref C: [?DC] int, ref A: [?DA] int, ref B: [?DB] int)

--- a/test/performance/thomasvandoren/matrix-multiply-reduce.chpl
+++ b/test/performance/thomasvandoren/matrix-multiply-reduce.chpl
@@ -12,8 +12,6 @@ proc main() {
 
   timer.stop();
   printResults();
-
-  delete randStream;
 }
 
 proc dotProduct(ref C: [?DC] int, ref A: [?DA] int, ref B: [?DB] int)

--- a/test/performance/thomasvandoren/matrix-multiply-slice-promotion.chpl
+++ b/test/performance/thomasvandoren/matrix-multiply-slice-promotion.chpl
@@ -11,8 +11,6 @@ proc main() {
 
   timer.stop();
   printResults();
-
-  delete randStream;
 }
 
 proc dotProduct(ref C: [?DC] int, ref A: [?DA] int, ref B: [?DB] int)


### PR DESCRIPTION
PR #8575 made makeRandomStream return owned,
so that the global variable is automatically deleted,
but these tests included a delete in main for the same
variable.

This PR simply removes the delete. (An upcoming PR #10568
would make the pattern here a compilation error).

Trivial and not reviewed.