### PR TITLE
Fix another timeout for high core-count systems

### DIFF
--- a/test/release/examples/benchmarks/lulesh/test3DLulesh.execenv
+++ b/test/release/examples/benchmarks/lulesh/test3DLulesh.execenv
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+
+# Guard pages are expensive on high core-count systems. See issue #7533
+
+import os
+if os.getenv('CHPL_TARGET_ARCH', '') in ['arm-thunderx', 'arm-thunderx2', 'mic-knl']:
+    print('QT_GUARD_PAGES=false')


### PR DESCRIPTION
#10530 turned off qthreads guard pages on ARM for certain benchmarks that were getting stuck in the `mprotect()` system call.  This change does the same thing for one more benchmark that was missed, test3DLulesh.
