### PR TITLE
Add specialized .good files for numa and no-local+numa for new test

### DIFF
--- a/test/optimizations/remoteValueForwarding/alwaysRVFpragma.comm-none.lm-numa.good
+++ b/test/optimizations/remoteValueForwarding/alwaysRVFpragma.comm-none.lm-numa.good
@@ -1,0 +1,23 @@
+Initially
+---------
+(x = 42, y = {loc = LOCALE0})
+(x = 23, y = {loc = LOCALE0})
+
+From locale LOCALE0
+------
+(x = 42, y = {loc = LOCALE0})
+LOCALE0
+LOCALE0
+(x = 23, y = {loc = LOCALE0})
+LOCALE0
+LOCALE0
+
+Writing
+-------
+(x = 43, y = {loc = LOCALE0})
+(x = 24, y = {loc = LOCALE0})
+
+Back home
+---------
+(x = 42, y = {loc = LOCALE0})
+(x = 24, y = {loc = LOCALE0})

--- a/test/optimizations/remoteValueForwarding/alwaysRVFpragma.no-local.good
+++ b/test/optimizations/remoteValueForwarding/alwaysRVFpragma.no-local.good
@@ -1,0 +1,23 @@
+Initially
+---------
+(x = 42, y = {loc = LOCALE0})
+(x = 23, y = {loc = LOCALE0})
+
+From locale LOCALE0
+------
+(x = 42, y = {loc = LOCALE0})
+LOCALE0
+LOCALE0
+(x = 23, y = {loc = LOCALE0})
+LOCALE0
+LOCALE0
+
+Writing
+-------
+(x = 43, y = {loc = LOCALE0})
+(x = 24, y = {loc = LOCALE0})
+
+Back home
+---------
+(x = 42, y = {loc = LOCALE0})
+(x = 24, y = {loc = LOCALE0})


### PR DESCRIPTION
It hadn't occurred to me that these cases wouldn't match either the
.good nor the comm-none.good for this new rvf test since they (a) have
one locale but (b) will enable rvf.  Here, I'm checking in the same
.good for these two cases (I almost used a symbolic link but then got
scared away from it out of superstition, remembering historic
challenges with them).