### PR TITLE
Adjust a test to avoid delete-borrow warning

### DIFF
--- a/test/classes/diten/test_destructor3.chpl
+++ b/test/classes/diten/test_destructor3.chpl
@@ -4,11 +4,11 @@ class C {
 
 record R {
 // private:
-  var c, c2: C;
+  var c, c2: unmanaged C;
 // public:
   proc init(a:int, b:int) {
-    c = new C(a, b);
-    c2 = new C(a, b);
+    c = new unmanaged C(a, b);
+    c2 = new unmanaged C(a, b);
   }
   proc deinit() {
     delete c;


### PR DESCRIPTION
This test was reporting "'delete' can only be applied to unmanaged classes"
due to #10568. Convert the being-deleted things to 'unmanaged', as was done
in #10568.

The Chapel-erific style calls for these fields to be 'owned' instead.
However, this test was added to exercise the pattern of 'delete'-ing
in the destructor, now deinitializer. So we keep it that way.