### PR TITLE
Don't run the comm=ugni SIGBUS tests on ARM.

### DIFF
--- a/test/runtime/configMatters/comm/ugni/SIGBUS-array-alloc.skipif
+++ b/test/runtime/configMatters/comm/ugni/SIGBUS-array-alloc.skipif
@@ -1,7 +1,11 @@
 #!/usr/bin/env python
 
-# This test only makes sense with hugepages.
+# This test only makes sense with hugepages, but not on ARM where it
+# runs for a really long time and nevertheless may not fail.
 
 import os
-print(os.getenv('HUGETLB_DEFAULT_PAGE_SIZE') == None)
+print(os.getenv('HUGETLB_DEFAULT_PAGE_SIZE') == None or
+      os.getenv('CHPL_TARGET_ARCH', '') in ['aarch64',
+                                            'arm-thunderx',
+                                            'arm-thunderx2'])
 

--- a/test/runtime/configMatters/comm/ugni/SIGBUS-heap-extend.skipif
+++ b/test/runtime/configMatters/comm/ugni/SIGBUS-heap-extend.skipif
@@ -1,10 +1,14 @@
 #!/usr/bin/env python
 
 # This test only makes sense with mem=jemalloc, hugepages,
-# and dynamic heap extension.
+# and dynamic heap extension, but not on ARM where it runs
+# for a really long time and nevertheless may not fail.
 
 import os
 print(os.getenv('CHPL_MEM') != 'jemalloc' or
       os.getenv('HUGETLB_DEFAULT_PAGE_SIZE') == None or
-      os.getenv('CHPL_RT_MAX_HEAP_SIZE') != None)
+      os.getenv('CHPL_RT_MAX_HEAP_SIZE') != None or 
+      os.getenv('CHPL_TARGET_ARCH', '') in ['aarch64',
+                                            'arm-thunderx',
+                                            'arm-thunderx2'])
 


### PR DESCRIPTION
It can take a really long time to run an ARM node out of memory, so skip
the comm=ugni SIGBUS tests on ARM.