### PR TITLE
Add initial support for buffered atomics

### DIFF
--- a/modules/packages/BufferedAtomics.chpl
+++ b/modules/packages/BufferedAtomics.chpl
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2004-2018 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module BufferedAtomics {
+
+  private proc externFunc(param s: string, type T) param {
+    if isInt(T)  then return "chpl_comm_atomic_" + s + "_int"  + numBits(T):string;
+    if isUint(T) then return "chpl_comm_atomic_" + s + "_uint" + numBits(T):string;
+    if isReal(T) then return "chpl_comm_atomic_" + s + "_real" + numBits(T):string;
+  }
+
+  inline proc RAtomicT.addBuff(value:T): void {
+    pragma "insert line file info" extern externFunc("add_buff", T)
+      proc atomic_add_buff(ref op:T, l:int(32), ref obj:T): void;
+
+    var v = value;
+    atomic_add_buff(v, _localeid(), _v);
+  }
+
+  inline proc RAtomicT.subBuff(value:T): void {
+    pragma "insert line file info" extern externFunc("sub_buff", T)
+      proc atomic_sub_buff(ref op:T, l:int(32), ref obj:T): void;
+
+    var v = value;
+    atomic_sub_buff(v, _localeid(), _v);
+  }
+
+  inline proc RAtomicT.orBuff(value:T): void {
+    if !isIntegral(T) then compilerError("or is only defined for integer atomic types");
+    pragma "insert line file info" extern externFunc("or_buff", T)
+      proc atomic_or_buff(ref op:T, l:int(32), ref obj:T): void;
+
+    var v = value;
+    atomic_or_buff(v, _localeid(), _v);
+  }
+
+  inline proc RAtomicT.andBuff(value:T): void {
+    if !isIntegral(T) then compilerError("and is only defined for integer atomic types");
+    pragma "insert line file info" extern externFunc("and_buff", T)
+      proc atomic_and_buff(ref op:T, l:int(32), ref obj:T): void;
+
+    var v = value;
+    atomic_and_buff(v, _localeid(), _v);
+  }
+
+  inline proc RAtomicT.xorBuff(value:T): void {
+    if !isIntegral(T) then compilerError("xor is only defined for integer atomic types");
+    pragma "insert line file info" extern externFunc("xor_buff", T)
+      proc atomic_xor_buff(ref op:T, l:int(32), ref obj:T): void;
+
+    var v = value;
+    atomic_xor_buff(v, _localeid(), _v);
+  }
+
+  inline proc atomicBuffFlush(): void {
+    if CHPL_NETWORK_ATOMICS != "none" {
+      extern proc chpl_comm_atomic_buff_flush();
+      coforall loc in Locales do on loc {
+        chpl_comm_atomic_buff_flush();
+      }
+    }
+  }
+}

--- a/modules/packages/BufferedAtomics.chpl
+++ b/modules/packages/BufferedAtomics.chpl
@@ -32,6 +32,9 @@ module BufferedAtomics {
     var v = value;
     atomic_add_buff(v, _localeid(), _v);
   }
+  inline proc AtomicT.addBuff(value:T): void {
+    this.add(value);
+  }
 
   inline proc RAtomicT.subBuff(value:T): void {
     pragma "insert line file info" extern externFunc("sub_buff", T)
@@ -39,6 +42,9 @@ module BufferedAtomics {
 
     var v = value;
     atomic_sub_buff(v, _localeid(), _v);
+  }
+  inline proc AtomicT.subBuff(value:T): void {
+    this.sub(value);
   }
 
   inline proc RAtomicT.orBuff(value:T): void {
@@ -49,6 +55,9 @@ module BufferedAtomics {
     var v = value;
     atomic_or_buff(v, _localeid(), _v);
   }
+  inline proc AtomicT.orBuff(value:T): void {
+    this.or(value);
+  }
 
   inline proc RAtomicT.andBuff(value:T): void {
     if !isIntegral(T) then compilerError("and is only defined for integer atomic types");
@@ -58,6 +67,9 @@ module BufferedAtomics {
     var v = value;
     atomic_and_buff(v, _localeid(), _v);
   }
+  inline proc AtomicT.andBuff(value:T): void {
+    this.and(value);
+  }
 
   inline proc RAtomicT.xorBuff(value:T): void {
     if !isIntegral(T) then compilerError("xor is only defined for integer atomic types");
@@ -66,6 +78,9 @@ module BufferedAtomics {
 
     var v = value;
     atomic_xor_buff(v, _localeid(), _v);
+  }
+  inline proc AtomicT.xorBuff(value:T): void {
+    this.xor(value);
   }
 
   inline proc atomicBuffFlush(): void {

--- a/modules/packages/BufferedAtomics.chpl
+++ b/modules/packages/BufferedAtomics.chpl
@@ -83,7 +83,7 @@ module BufferedAtomics {
     this.xor(value);
   }
 
-  inline proc atomicBuffFlush(): void {
+  inline proc flushAtomicBuff(): void {
     if CHPL_NETWORK_ATOMICS != "none" {
       extern proc chpl_comm_atomic_buff_flush();
       coforall loc in Locales do on loc {

--- a/runtime/include/comm/ugni/chpl-comm-impl.h
+++ b/runtime/include/comm/ugni/chpl-comm-impl.h
@@ -56,10 +56,9 @@ chpl_bool chpl_comm_impl_regMemFree(void* p, size_t size);
 //
 // Network atomic operations.
 //
-// We support 32- and 64-bit signed integers and reals, although we
+// We support 32- and 64-bit signed ints, uints and reals, although we
 // don't necessarily support all of these types for all operations.
-// In the future we might like to add other types, such as unsigned
-// integers.
+// In the future we might like to add other types
 //
 
 //
@@ -158,6 +157,10 @@ DECL_CHPL_COMM_ATOMIC_CMPXCHG(real64)
         void chpl_comm_atomic_ ## op ## _ ## type                       \
                 (void* operand, int32_t locale, void* object,           \
                  int ln, int32_t fn);
+#define DECL_CHPL_COMM_ATOMIC_NONFETCH_BUFF_BINARY(op, type)            \
+        void chpl_comm_atomic_ ## op ## _buff_ ## type                  \
+                (void* operand, int32_t locale, void* object,           \
+                 int ln, int32_t fn);
 #define DECL_CHPL_COMM_ATOMIC_FETCH_BINARY(op, type)                    \
         void chpl_comm_atomic_fetch_ ## op ## _ ## type                 \
                 (void* operand, int32_t locale, void* object,           \
@@ -165,6 +168,7 @@ DECL_CHPL_COMM_ATOMIC_CMPXCHG(real64)
                  int ln, int32_t fn);
 #define DECL_CHPL_COMM_ATOMIC_BINARY(op, type)                          \
         DECL_CHPL_COMM_ATOMIC_NONFETCH_BINARY(op, type)                 \
+        DECL_CHPL_COMM_ATOMIC_NONFETCH_BUFF_BINARY(op, type)            \
         DECL_CHPL_COMM_ATOMIC_FETCH_BINARY(op, type)
 
 DECL_CHPL_COMM_ATOMIC_BINARY(and, int32)
@@ -195,6 +199,8 @@ DECL_CHPL_COMM_ATOMIC_BINARY(sub, uint32)
 DECL_CHPL_COMM_ATOMIC_BINARY(sub, uint64)
 DECL_CHPL_COMM_ATOMIC_BINARY(sub, real32)
 DECL_CHPL_COMM_ATOMIC_BINARY(sub, real64)
+
+void chpl_comm_atomic_buff_flush(void);
 
 //
 // Internal statistics gathering and reporting.

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -6550,7 +6550,7 @@ DEFINE_CHPL_COMM_ATOMIC_CMPXCHG(real64, cmpxchg_64, int_least64_t)
         {                                                               \
           mem_region_t* remote_mr;                                      \
           DBG_P_LP(DBGF_IFACE|DBGF_AMO,                                 \
-                   "IFACE chpl_comm_atomic_"#_o"_"#_f                   \
+                   "IFACE chpl_comm_atomic_"#_o"_buff_"#_f              \
                    "(%p, %d, %p)",                                      \
                    opnd, (int) loc, obj);                               \
                                                                         \
@@ -6682,7 +6682,7 @@ DEFINE_CHPL_COMM_ATOMIC_INT_OP(uint64, add, add_i64, uint_least64_t)
         {                                                               \
           mem_region_t* remote_mr;                                      \
           DBG_P_LP(DBGF_IFACE|DBGF_AMO,                                 \
-                   "IFACE chpl_comm_atomic_add_"#_f                     \
+                   "IFACE chpl_comm_atomic_add_buff_"#_f                \
                    "(%p, %d, %p)",                                      \
                    opnd, (int) loc, obj);                               \
                                                                         \
@@ -6774,7 +6774,7 @@ DEFINE_CHPL_COMM_ATOMIC_REAL_OP(real64, add_r64, double)
           _t nopnd = - *(_t*) opnd;                                     \
                                                                         \
           DBG_P_LP(DBGF_IFACE|DBGF_AMO,                                 \
-                   "IFACE chpl_comm_atomic_sub_"#_f                     \
+                   "IFACE chpl_comm_atomic_sub_buff_"#_f                \
                    "(%p, %d, %p)",                                      \
                    opnd, (int) loc, obj);                               \
                                                                         \

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -1507,6 +1507,7 @@ static void      do_nic_amo(void*, void*, c_nodeid_t, void*, size_t,
                             gni_fma_cmd_type_t, void*, mem_region_t*);
 static void      do_nic_amo_nf(void*, c_nodeid_t, void*, size_t,
                                gni_fma_cmd_type_t, mem_region_t*);
+static void      buff_amo_init(void);
 static void      do_nic_amo_nf_buff(void*, c_nodeid_t, void*, size_t,
                                     gni_fma_cmd_type_t, mem_region_t*);
 static void      amo_add_real32_cpu_cmpxchg(void*, void*, void*);
@@ -1991,6 +1992,7 @@ void chpl_comm_post_task_init(void)
   nb_desc_init();
   rf_done_init();
   amo_res_init();
+  buff_amo_init();
 
   //
   // Create all the communication domains, including their GNI NIC
@@ -6837,6 +6839,14 @@ static atomic_bool* amo_lock_v[1024];
 static atomic_bool amo_init_lock = false;
 static atomic_uint_least32_t amo_pdc_sz = 0;
 #endif // HAVE_GNI_FMA_CHAIN_TRANSACTIONS
+
+static
+void buff_amo_init(void) {
+#if HAVE_GNI_FMA_CHAIN_TRANSACTIONS
+  atomic_init_bool(&amo_init_lock, false);
+  atomic_init_uint_least32_t(&amo_pdc_sz, 0);
+#endif // HAVE_GNI_FMA_CHAIN_TRANSACTIONS
+}
 
 void chpl_comm_atomic_buff_flush() {
 #if HAVE_GNI_FMA_CHAIN_TRANSACTIONS

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -771,11 +771,12 @@ static size_t rdma_threshold = DEFAULT_RDMA_THRESHOLD;
 #define UI64_TO_VP(x)     ((void*) (intptr_t) (x))
 
 //
-// Maximum number of PUTs in a chained transaction list.  This number
-// was determined empirically (on XC/Aries).  Doing more than this at
-// once didn't seem to improve performance.
+// Maximum number of PUTs/AMOs in a chained transaction list.  This
+// number was determined empirically (on XC/Aries).  Doing more than
+// this at once didn't seem to improve performance.
 //
 #define MAX_CHAINED_PUT_LEN 64
+#define MAX_CHAINED_AMO_LEN 64
 
 
 //
@@ -1506,6 +1507,8 @@ static void      do_nic_amo(void*, void*, c_nodeid_t, void*, size_t,
                             gni_fma_cmd_type_t, void*, mem_region_t*);
 static void      do_nic_amo_nf(void*, c_nodeid_t, void*, size_t,
                                gni_fma_cmd_type_t, mem_region_t*);
+static void      do_nic_amo_nf_buff(void*, c_nodeid_t, void*, size_t,
+                                    gni_fma_cmd_type_t, mem_region_t*);
 static void      amo_add_real32_cpu_cmpxchg(void*, void*, void*);
 static void      amo_add_real64_cpu_cmpxchg(void*, void*, void*);
 static void      fork_call_common(int, c_sublocid_t,
@@ -5234,6 +5237,7 @@ void do_remote_put_V(int v_len, void** src_addr_v, c_nodeid_t* locale_v,
   //
   // This GNI is too old to support chained transactions.  Just do
   // normal ones.
+  // TODO -- do NB puts and wait for them to complete?
   //
   for (int vi = 0; vi < v_len; vi++) {
     do_remote_put(src_addr_v[vi], locale_v[vi], tgt_addr_v[vi], size_v[vi],
@@ -6537,6 +6541,37 @@ DEFINE_CHPL_COMM_ATOMIC_CMPXCHG(real64, cmpxchg_64, int_least64_t)
         }                                                               \
                                                                         \
         /*==============================*/                              \
+        void chpl_comm_atomic_##_o##_buff_##_f(void* opnd,              \
+                                               int32_t loc,             \
+                                               void* obj,               \
+                                               int ln, int32_t fn)      \
+        {                                                               \
+          mem_region_t* remote_mr;                                      \
+          DBG_P_LP(DBGF_IFACE|DBGF_AMO,                                 \
+                   "IFACE chpl_comm_atomic_"#_o"_"#_f                   \
+                   "(%p, %d, %p)",                                      \
+                   opnd, (int) loc, obj);                               \
+                                                                        \
+          if (chpl_numNodes == 1) {                                     \
+            (void) atomic_fetch_##_o##_##_t((atomic_##_t*) obj,         \
+                                            *(_t*) opnd);               \
+            return;                                                     \
+          }                                                             \
+                                                                        \
+          if (IS_32_BIT_AMO_ON_GEMINI(_t)                               \
+              || (remote_mr = mreg_for_remote_addr(obj, loc)) == NULL) {\
+            if (loc == chpl_nodeID)                                     \
+              (void) do_amo_on_cpu(_c, NULL, obj, opnd, NULL);          \
+            else                                                        \
+              do_fork_amo_##_c##_##_f(obj, NULL, opnd, NULL, loc);      \
+          }                                                             \
+          else {                                                        \
+            do_nic_amo_nf_buff(opnd, loc, obj, sizeof(_t),              \
+                               amo_cmd_2_nic_op(_c, 0), remote_mr);     \
+          }                                                             \
+        }                                                               \
+                                                                        \
+        /*==============================*/                              \
         void chpl_comm_atomic_fetch_##_o##_##_f(void* opnd,             \
                                                 int32_t loc,            \
                                                 void* obj,              \
@@ -6638,6 +6673,37 @@ DEFINE_CHPL_COMM_ATOMIC_INT_OP(uint64, add, add_i64, uint_least64_t)
         }                                                               \
                                                                         \
         /*==============================*/                              \
+        void chpl_comm_atomic_add_buff_##_f(void* opnd,                 \
+                                            int32_t loc,                \
+                                            void* obj,                  \
+                                            int ln, int32_t fn)         \
+        {                                                               \
+          mem_region_t* remote_mr;                                      \
+          DBG_P_LP(DBGF_IFACE|DBGF_AMO,                                 \
+                   "IFACE chpl_comm_atomic_add_"#_f                     \
+                   "(%p, %d, %p)",                                      \
+                   opnd, (int) loc, obj);                               \
+                                                                        \
+          if (chpl_numNodes == 1) {                                     \
+            amo_add_##_f##_cpu_cmpxchg(NULL, obj, opnd);                \
+            return;                                                     \
+          }                                                             \
+                                                                        \
+          if (sizeof(_t) == sizeof(int_least32_t)                       \
+              && nic_type == GNI_DEVICE_ARIES                           \
+              && (remote_mr = mreg_for_remote_addr(obj, loc)) != NULL) {\
+            do_nic_amo_nf_buff(opnd, loc, obj, sizeof(_t),              \
+                               amo_cmd_2_nic_op(_c, 0), remote_mr);     \
+          }                                                             \
+          else {                                                        \
+            if (loc == chpl_nodeID)                                     \
+              (void) do_amo_on_cpu(_c, NULL, obj, opnd, NULL);          \
+            else                                                        \
+              do_fork_amo_##_c##_##_f(obj, NULL, opnd, NULL, loc);      \
+          }                                                             \
+        }                                                               \
+                                                                        \
+        /*==============================*/                              \
         void chpl_comm_atomic_fetch_add_##_f(void* opnd,                \
                                              int32_t loc,               \
                                              void* obj,                 \
@@ -6697,6 +6763,22 @@ DEFINE_CHPL_COMM_ATOMIC_REAL_OP(real64, add_r64, double)
           chpl_comm_atomic_add_##_f(&nopnd, loc, obj, ln, fn);          \
         }                                                               \
                                                                         \
+         /*==============================*/                             \
+        void chpl_comm_atomic_sub_buff_##_f(void* opnd,                 \
+                                            int32_t loc,                \
+                                            void* obj,                  \
+                                            int ln, int32_t fn)         \
+        {                                                               \
+          _t nopnd = - *(_t*) opnd;                                     \
+                                                                        \
+          DBG_P_LP(DBGF_IFACE|DBGF_AMO,                                 \
+                   "IFACE chpl_comm_atomic_sub_"#_f                     \
+                   "(%p, %d, %p)",                                      \
+                   opnd, (int) loc, obj);                               \
+                                                                        \
+          chpl_comm_atomic_add_buff_##_f(&nopnd, loc, obj, ln, fn);     \
+        }                                                               \
+                                                                        \
         /*==============================*/                              \
         void chpl_comm_atomic_fetch_sub_##_f(void* opnd,                \
                                              int32_t loc,               \
@@ -6747,6 +6829,85 @@ int amo_cmd_2_nic_op(fork_amo_cmd_t cmd, int fetching)
   return nic_cmd;
 }
 
+static gni_post_descriptor_t* amo_pdc[1024];
+static c_nodeid_t* amo_node_v[1024];
+static int64_t* amo_vi_v[1024];
+
+static atomic_uint_least32_t amo_pdc_sz;
+void chpl_comm_atomic_buff_flush() {
+  uint32_t sz, i;
+   sz = atomic_load_uint_least32_t(&amo_pdc_sz);
+   for(i=0; i<sz; i++) {
+    if (*amo_vi_v[i] != -1) {
+      post_fma_ct_and_wait(amo_node_v[i], amo_pdc[i]);
+      *amo_vi_v[i] = -1;
+    }
+  }
+}
+
+static
+inline
+void do_nic_amo_nf_buff(void* opnd1, c_nodeid_t locale,
+                        void* object, size_t size,
+                        gni_fma_cmd_type_t cmd,
+                        mem_region_t* remote_mr)
+{
+  static __thread gni_post_descriptor_t post_desc;
+  static __thread gni_ct_amo_post_descriptor_t pdc[MAX_CHAINED_AMO_LEN - 1];
+  static __thread c_nodeid_t node_v[MAX_CHAINED_AMO_LEN];
+  static __thread int64_t vi = -1;
+
+  static __thread chpl_bool inited = false;
+  if (!inited) {
+    uint32_t idx;
+    idx = atomic_fetch_add_uint_least32_t(&amo_pdc_sz, 1);
+    amo_pdc[idx] = &post_desc;
+    amo_node_v[idx] = &node_v[0];
+    amo_vi_v[idx] = &vi;
+    inited = true;
+  }
+
+  if (remote_mr == NULL)
+    CHPL_INTERNAL_ERROR("do_nic_amo(): "
+                        "remote address is not NIC-registered");
+   //
+  // Fill in the POST descriptor.
+  //
+  if (vi == -1) {
+    post_desc.next_descr      = NULL;
+    post_desc.type            = GNI_POST_AMO;
+    post_desc.cq_mode         = GNI_CQMODE_GLOBAL_EVENT;
+    post_desc.dlvr_mode       = GNI_DLVMODE_PERFORMANCE;
+    post_desc.rdma_mode       = 0;
+    post_desc.src_cq_hndl     = 0;
+    post_desc.remote_addr     = (uint64_t) (intptr_t) object;
+    post_desc.remote_mem_hndl = remote_mr->mdh;
+    post_desc.length          = size;
+    post_desc.amo_cmd         = cmd;
+    post_desc.first_operand = *(uint64_t*) opnd1;
+  } else {
+    if (vi == 0)
+      post_desc.next_descr = &pdc[0];
+    else
+      pdc[vi-1].next_descr = &pdc[vi];
+    pdc[vi].next_descr      = NULL;
+    pdc[vi].remote_addr     = (uint64_t) (intptr_t) object;
+    pdc[vi].remote_mem_hndl = remote_mr->mdh;
+    pdc[vi].length          = size;
+    pdc[vi].amo_cmd         = cmd;
+    pdc[vi].first_operand = *(uint64_t*) opnd1;
+  }
+  node_v[vi+1] = locale;
+  vi++;
+  //
+  // Initiate the transaction and wait for it to complete.
+  //
+  PERFSTATS_INC(amo_cnt);
+  if (vi == MAX_CHAINED_AMO_LEN-1) {
+    post_fma_ct_and_wait(node_v, &post_desc);
+    vi = -1;
+  }
+}
 
 static
 inline
@@ -7708,7 +7869,7 @@ int post_fma_ct(c_nodeid_t* locale_v, gni_post_descriptor_t* post_desc)
   cdi = cd_idx;
   PERFSTATS_ADD_POST(post_desc);
 
-  {
+  if (post_desc->type == GNI_POST_FMA_PUT) {
     gni_ct_put_post_descriptor_t* pdc;
     int i;
 
@@ -7717,6 +7878,15 @@ int post_fma_ct(c_nodeid_t* locale_v, gni_post_descriptor_t* post_desc)
          pdc = pdc->next_descr, i++) {
       pdc->ep_hndl = cd->remote_eps[locale_v[i]];
       PERFSTATS_ADD(sent_bytes, pdc->length);
+    }
+  } else if (post_desc->type == GNI_POST_AMO) {
+    gni_ct_amo_post_descriptor_t* pdc;
+    int i;
+
+    for (pdc = post_desc->next_descr, i = 1;
+         pdc != NULL;
+         pdc = pdc->next_descr, i++) {
+      pdc->ep_hndl = cd->remote_eps[locale_v[i]];
     }
   }
 


### PR DESCRIPTION
This adds a package module that supports buffered network atomics for
non-fetching operations. It includes `addBuff()`, `subBuff()`, `orBuff()`,
`andBuff()`, and `xorBuff()`. These buffered atomics are not consistent with
regular atomic operations and currently must be synchronized manually with a
call to `flushAtomicBuff()`. e.g.

```chpl
var a: atomic int;
a.addBuff(1);
writeln(a);        // prints 0
flushAtomicBuff();
writeln(a);        // prints 1
```

Under the covers these buffered atomics are implemented with 64 element
thread-local buffers. When full, these buffers are flushed. We use chained
transactions to initiate the network atomics, which offers significantly
increased transaction rate.

For the bale histogram benchmark this improves performance by over 4x.

Currently the code is written like:

```chpl
forall r in rindex do
  A[r].add(1);
```

And with buffered atomics looks something like:

```chpl
use BufferedAtomics;
forall r in rindex do
  A[r].addBuff(1);
flushAtomicBuff();
```

On a 28-core broadwell system the normal atomic implementation gets 80 MB/s per
node and the buffered atomic implementation achieves 360 MB/s per node, which
is on par with the non-blocking UPC implementation.

Using buffered atomics significantly improve ra-atomics as well and we see a
similar ~4.5x speedup. Scalability results with 256M hugepages up to 256 nodes
show below:

![ra-perf](https://user-images.githubusercontent.com/1588337/43859638-338a7d52-9b1f-11e8-8b72-cec2ffb65c40.png)


Closes https://github.com/chapel-lang/chapel/issues/10495