### PR TITLE
Add more LLVM IR checks now that new-exprs result in more temporaries

### DIFF
--- a/test/llvm/llvm-invariant/function_local_const.chpl
+++ b/test/llvm/llvm-invariant/function_local_const.chpl
@@ -8,11 +8,15 @@ record A
 }
 
 // CHECK: @f_chpl
-// CHECK: call void @init_chpl{{.*}}(%A_chpl* [[PTR:%.*]],
-// CHECK: [[CAST:%.*]] = bitcast %A_chpl* [[PTR]] to i8*
+// CHECK: call void @init_chpl{{.*}}(%A_chpl* [[NEW_TEMP:%.*]],
+// CHECK: [[TMP1:%.*]] = load %A_chpl, %A_chpl* [[NEW_TEMP]]
+// CHECK: store %A_chpl [[TMP1]], %A_chpl* [[TMP2:%.*]]
+// CHECK: [[TMP3:%.*]] = load %A_chpl, %A_chpl* [[TMP2]]
+// CHECK: store %A_chpl [[TMP3]], %A_chpl* [[TMP4:%.*]]
+// CHECK: [[CAST:%.*]] = bitcast %A_chpl* [[TMP4]] to i8*
 // CHECK: call {}* @llvm.invariant.start.p0i8(i64 8, i8* [[CAST]])
 // CHECK: getelementptr
-// CHECK-SAME:[[PTR]]
+// CHECK-SAME:[[TMP4]]
 // CHECK: load
 // CHECK: ret
 proc f(n)

--- a/test/llvm/llvm-invariant/global_const.chpl
+++ b/test/llvm/llvm-invariant/global_const.chpl
@@ -1,6 +1,10 @@
 // This test checks whether we add llvm.invariant.start to global const variables
 
-// CHECK: call void @init_chpl{{.*}}(%A_chpl* @globalConst_chpl,
+// CHECK: call void @init_chpl{{.*}}(%A_chpl* [[NEW_TEMP:%.*]],
+// CHECK: [[TMP1:%.*]] = load %A_chpl, %A_chpl* [[NEW_TEMP]]
+// CHECK: store %A_chpl [[TMP1]], %A_chpl* [[TMP2:%.*]]
+// CHECK: [[TMP3:%.*]] = load %A_chpl, %A_chpl* [[TMP2]]
+// CHECK: store %A_chpl [[TMP3]], %A_chpl* @globalConst_chpl
 // CHECK: %{{[0-9]+}} = call {}* @llvm.invariant.start.p0i8(i64 8, i8* bitcast (%A_chpl* @globalConst_chpl to i8*))
 
 record A

--- a/test/llvm/llvm-invariant/program_constructs.chpl
+++ b/test/llvm/llvm-invariant/program_constructs.chpl
@@ -11,7 +11,11 @@ proc f(n)
   var sum = 0;
   for i in 1..10
   {
-// CHECK: call {{.*}} @init_chpl{{.*}}(%A_chpl* [[PTR1:%.*]],
+// CHECK: call {{.*}} @init_chpl{{.*}}(%A_chpl* [[NEW_TEMP:%.*]],
+// CHECK: [[TMP1:%.*]] = load %A_chpl, %A_chpl* [[NEW_TEMP]]
+// CHECK: store %A_chpl [[TMP1]], %A_chpl* [[TMP2:%.*]]
+// CHECK: [[TMP3:%.*]] = load %A_chpl, %A_chpl* [[TMP2]]
+// CHECK: store %A_chpl [[TMP3]], %A_chpl* [[PTR1:%.*]]
 // CHECK: [[CAST1:%.*]] = bitcast %A_chpl* [[PTR1]] to i8*
 // CHECK: call {}* @llvm.invariant.start.p0i8(i64 8, i8* [[CAST1]])
 // CHECK: getelementptr
@@ -21,7 +25,11 @@ proc f(n)
   }
 
   if n < 10 {
-// CHECK: call {{.*}} @init_chpl{{.*}}(%A_chpl* [[PTR2:%.*]],
+// CHECK: call {{.*}} @init_chpl{{.*}}(%A_chpl* [[NEW_TEMP:%.*]],
+// CHECK: [[TMP1:%.*]] = load %A_chpl, %A_chpl* [[NEW_TEMP]]
+// CHECK: store %A_chpl [[TMP1]], %A_chpl* [[TMP2:%.*]]
+// CHECK: [[TMP3:%.*]] = load %A_chpl, %A_chpl* [[TMP2]]
+// CHECK: store %A_chpl [[TMP3]], %A_chpl* [[PTR2:%.*]]
 // CHECK: [[CAST2:%.*]] = bitcast %A_chpl* [[PTR2]] to i8*
 // CHECK: call {}* @llvm.invariant.start.p0i8(i64 8, i8* [[CAST2]])
 // CHECK: getelementptr
@@ -30,7 +38,11 @@ proc f(n)
     return localConst.a;
   }
   else {
-// CHECK: call {{.*}} @init_chpl{{.*}}(%A_chpl* [[PTR3:%.*]],
+// CHECK: call {{.*}} @init_chpl{{.*}}(%A_chpl* [[NEW_TEMP:%.*]],
+// CHECK: [[TMP1:%.*]] = load %A_chpl, %A_chpl* [[NEW_TEMP]]
+// CHECK: store %A_chpl [[TMP1]], %A_chpl* [[TMP2:%.*]]
+// CHECK: [[TMP3:%.*]] = load %A_chpl, %A_chpl* [[TMP2]]
+// CHECK: store %A_chpl [[TMP3]], %A_chpl* [[PTR3:%.*]]
 // CHECK: [[CAST3:%.*]] = bitcast %A_chpl* [[PTR3]] to i8*
 // CHECK: call {}* @llvm.invariant.start.p0i8(i64 8, i8* [[CAST3]])
 // CHECK: getelementptr


### PR DESCRIPTION
PR #10674 simplified the compiler's implementation of field/var initialization, but results in more temporaries than before. This changed the output of LLVM IR, which resulted in failures for a few tests that check for certain patterns.