### PR TITLE
Add more 'override' clause to LocaleModels

### DIFF
--- a/modules/internal/localeModels/apu/LocaleModel.chpl
+++ b/modules/internal/localeModels/apu/LocaleModel.chpl
@@ -53,7 +53,7 @@ module LocaleModel {
     const name: string;
 
     override proc chpl_id() return (parent:LocaleModel)._node_id; // top-level node id
-    proc chpl_localeid() {
+    override proc chpl_localeid() {
       return chpl_buildLocaleID((parent:LocaleModel)._node_id:chpl_nodeID_t,
                                 sid);
     }
@@ -68,7 +68,7 @@ module LocaleModel {
       name = _parent.chpl_name() + "-CPU" + sid;
     }
 
-    proc writeThis(f) {
+    override proc writeThis(f) {
       parent.writeThis(f);
       f <~> '.'+name;
     }
@@ -89,7 +89,7 @@ module LocaleModel {
     const name: string;
 
     override proc chpl_id() return (parent:LocaleModel)._node_id; // top-level node id
-    proc chpl_localeid() {
+    override proc chpl_localeid() {
       return chpl_buildLocaleID((parent:LocaleModel)._node_id:chpl_nodeID_t,
                                 sid);
     }
@@ -112,7 +112,7 @@ module LocaleModel {
       name = _parent.chpl_name() + "-GPU" + sid;
     }
 
-    proc writeThis(f) {
+    override proc writeThis(f) {
       parent.writeThis(f);
       f <~> '.'+name;
     }
@@ -171,13 +171,13 @@ module LocaleModel {
     }
 
     override proc chpl_id() return _node_id;     // top-level locale (node) number
-    proc chpl_localeid() {
+    override proc chpl_localeid() {
       return chpl_buildLocaleID(_node_id:chpl_nodeID_t, c_sublocid_any);
     }
     override proc chpl_name() return local_name;
 
 
-    proc writeThis(f) {
+    override proc writeThis(f) {
       // Most classes will define it like this:
       //      f <~> name;
       // but here it is defined thus for backward compatibility.
@@ -269,13 +269,13 @@ module LocaleModel {
     // numbered less than this.
     // -1 is used in the abstract locale class to specify an invalid node ID.
     override proc chpl_id() return numLocales;
-    proc chpl_localeid() {
+    override proc chpl_localeid() {
       return chpl_buildLocaleID(numLocales:chpl_nodeID_t, c_sublocid_none);
     }
     override proc chpl_name() return local_name();
     proc local_name() return "rootLocale";
 
-    proc writeThis(f) {
+    override proc writeThis(f) {
       f <~> name;
     }
 

--- a/modules/internal/localeModels/knl/LocaleModel.chpl
+++ b/modules/internal/localeModels/knl/LocaleModel.chpl
@@ -178,7 +178,7 @@ module LocaleModel {
     const mlName: string; // note: locale provides `proc name`
 
     override proc chpl_id() return parent.chpl_id(); // top-level node id
-    proc chpl_localeid() {
+    override proc chpl_localeid() {
       return chpl_buildLocaleID(parent.chpl_id():chpl_nodeID_t, sid);
     }
     override proc chpl_name() return mlName;
@@ -222,7 +222,7 @@ module LocaleModel {
       mlName = kindstr+whichNuma;
     }
 
-    proc writeThis(f) {
+    override proc writeThis(f) {
       parent.writeThis(f);
       f <~> '.'+mlName;
     }
@@ -241,7 +241,7 @@ module LocaleModel {
     var hbm : MemoryLocale; // should never be modified after first assignment
 
     override proc chpl_id() return parent.chpl_id(); // top-level node id
-    proc chpl_localeid() {
+    override proc chpl_localeid() {
       return chpl_buildLocaleID(parent.chpl_id():chpl_nodeID_t, sid);
     }
     override proc chpl_name() return ndName;
@@ -304,7 +304,7 @@ module LocaleModel {
       delete _to_unmanaged(hbm);
     }
 
-    proc writeThis(f) {
+    override proc writeThis(f) {
       parent.writeThis(f);
       f <~> '.'+ndName;
     }
@@ -365,7 +365,7 @@ module LocaleModel {
     }
 
     override proc chpl_id() return _node_id;     // top-level locale (node) number
-    proc chpl_localeid() {
+    override proc chpl_localeid() {
       return chpl_buildLocaleID(_node_id:chpl_nodeID_t, c_sublocid_any);
     }
     override proc chpl_name() return local_name;
@@ -391,7 +391,7 @@ module LocaleModel {
     }
 
 
-    proc writeThis(f) {
+    override proc writeThis(f) {
       // Most classes will define it like this:
       //      f <~> name;
       // but here it is defined thus for backward compatibility.
@@ -493,13 +493,13 @@ module LocaleModel {
     // numbered less than this.
     // -1 is used in the abstract locale class to specify an invalid node ID.
     override proc chpl_id() return numLocales;
-    proc chpl_localeid() {
+    override proc chpl_localeid() {
       return chpl_buildLocaleID(numLocales:chpl_nodeID_t, c_sublocid_none);
     }
     override proc chpl_name() return local_name();
     proc local_name() return "rootLocale";
 
-    proc writeThis(f) {
+    override proc writeThis(f) {
       f <~> name;
     }
 

--- a/modules/internal/localeModels/numa/LocaleModel.chpl
+++ b/modules/internal/localeModels/numa/LocaleModel.chpl
@@ -57,7 +57,7 @@ module LocaleModel {
     const ndName: string; // note: locale provides `proc name`
 
     override proc chpl_id() return (parent:LocaleModel)._node_id; // top-level node id
-    proc chpl_localeid() {
+    override proc chpl_localeid() {
       return chpl_buildLocaleID((parent:LocaleModel)._node_id:chpl_nodeID_t,
                                 sid);
     }
@@ -72,7 +72,7 @@ module LocaleModel {
       ndName = "ND"+sid;
     }
 
-    proc writeThis(f) {
+    override proc writeThis(f) {
       parent.writeThis(f);
       f <~> '.'+ndName;
     }
@@ -131,7 +131,7 @@ module LocaleModel {
     }
 
     override proc chpl_id() return _node_id;     // top-level locale (node) number
-    proc chpl_localeid() {
+    override proc chpl_localeid() {
       return chpl_buildLocaleID(_node_id:chpl_nodeID_t, c_sublocid_any);
     }
     override proc chpl_name() return local_name;
@@ -159,7 +159,7 @@ module LocaleModel {
     }
 
 
-    proc writeThis(f) {
+    override proc writeThis(f) {
       // Most classes will define it like this:
       //      f <~> name;
       // but here it is defined thus for backward compatibility.
@@ -238,13 +238,13 @@ module LocaleModel {
     // numbered less than this.
     // -1 is used in the abstract locale class to specify an invalid node ID.
     override proc chpl_id() return numLocales;
-    proc chpl_localeid() {
+    override proc chpl_localeid() {
       return chpl_buildLocaleID(numLocales:chpl_nodeID_t, c_sublocid_none);
     }
     override proc chpl_name() return local_name();
     proc local_name() return "rootLocale";
 
-    proc writeThis(f) {
+    override proc writeThis(f) {
       f <~> name;
     }
 


### PR DESCRIPTION
Yesterday, when fixing the broken numa configurations, I naively
thought that since I'd passed a 'make check', the locale models
were now correct.  This turned out to be incorrect.  Here, I've
attached 'override' to writeThis() and chpl_localeid() methods
as well which seems to make last night's failing gasnet+numa
tests pass again.