### PR TITLE
File bug against overload checking when child class is generic

### DIFF
--- a/test/functions/resolution/overload-in-generic.bad
+++ b/test/functions/resolution/overload-in-generic.bad
@@ -1,0 +1,2 @@
+overload-in-generic.chpl:13: error: D.foo override keyword present but no superclass method matches signature to override
+overload-in-generic.chpl:13: error: D.foo override keyword present but no superclass method matches signature to override

--- a/test/functions/resolution/overload-in-generic.chpl
+++ b/test/functions/resolution/overload-in-generic.chpl
@@ -1,0 +1,19 @@
+class A {
+}
+
+class C {
+  proc foo(x: shared A) {
+    writeln("In parent foo()");
+  }
+}
+
+class D : C {
+  type t;
+  
+  override proc foo(x: shared A) {
+    writeln("In child foo()");
+  }
+}
+
+var myD2: C = new owned D(int);
+myD2.foo(new shared A());

--- a/test/functions/resolution/overload-in-generic.compopts
+++ b/test/functions/resolution/overload-in-generic.compopts
@@ -1,0 +1,1 @@
+--override-checking

--- a/test/functions/resolution/overload-in-generic.future
+++ b/test/functions/resolution/overload-in-generic.future
@@ -1,0 +1,1 @@
+bug: override checking errneous in generic child subclass case

--- a/test/functions/resolution/overload-in-generic.good
+++ b/test/functions/resolution/overload-in-generic.good
@@ -1,0 +1,1 @@
+In child foo()


### PR DESCRIPTION
I ran into an overload bug in the DataFrames prototype in which a
method marked as override was claimed to be problematic due to not
having a matching parent method; yet removing the override caused the
complaint that the override was missing (i.e., there was no way to
please the override checker).

This is my best attempt to reduce that case to a simple standalone
case.  I believe that in order for it to work, the sublcass had to be
generic.  It also seemed to depend on the argument being a 'shared'
class type (though I didn't try very hard to explore this).