### PR TITLE
Convert mason and some tests to `override`

### DIFF
--- a/test/errhandling/ExampleErrors.chpl
+++ b/test/errhandling/ExampleErrors.chpl
@@ -16,7 +16,7 @@ class StringError : Error {
     this.msg = msg;
   }
 
-  proc message() {
+  override proc message() {
     return msg;
   }
 }

--- a/test/library/standard/DataFrames/DataFrames.chpl
+++ b/test/library/standard/DataFrames/DataFrames.chpl
@@ -123,7 +123,7 @@ module DataFrames {
         yield tup;
     }
 
-    proc this(lab: idxType) ref : int {
+    override proc this(lab: idxType) ref : int {
       return labelToOrd[lab];
     }
 
@@ -543,8 +543,7 @@ module DataFrames {
       return valid_bits[ord];
     }
 
-    override
-    proc reindex(idx: shared Index) {
+    override proc reindex(idx: shared Index) {
       this.idx = idx;
     }
 

--- a/test/release/examples/benchmarks/lcals/Timer.chpl
+++ b/test/release/examples/benchmarks/lcals/Timer.chpl
@@ -19,13 +19,13 @@ module Timer {
 
   class ChapelTimer: TimerImpl {
     var t: Timer;
-    proc start() {
+    override proc start() {
       t.start();
     }
-    proc stop() {
+    override proc stop() {
       t.stop();
     }
-    proc elapsed() {
+    override proc elapsed() {
       return t.elapsed();
     }
   }
@@ -37,13 +37,13 @@ module Timer {
     var startTime: uint(64);
     var endTime: uint(64);
 
-    proc start() {
+    override proc start() {
       startTime = clock();
     }
-    proc stop() {
+    override proc stop() {
       endTime = clock();
     }
-    proc elapsed() {
+    override proc elapsed() {
       return (endTime - startTime): real(64) / CLOCKS_PER_SEC;
     }
   }
@@ -56,13 +56,13 @@ module Timer {
     proc init() {
       halt("CycleTimer not implemented");
     }
-    proc start() {
+    override proc start() {
       startTime = 0; // = getticks();
     }
-    proc stop() {
+    override proc stop() {
       endTime = 0; // = getticks();
     }
-    proc elapsed() {
+    override proc elapsed() {
       return 0.0;
     }
   }

--- a/test/release/examples/benchmarks/miniMD/helpers/forces.chpl
+++ b/test/release/examples/benchmarks/miniMD/helpers/forces.chpl
@@ -213,7 +213,7 @@ class ForceEAM : Force  {
     list[1] = list[2];
   }
 
-  proc compute(store : bool) {
+  override proc compute(store : bool) {
     if debug then writeln("entering EAM compute...");
     var evdwl, vir : atomic real;
     virial = 0.0;
@@ -316,7 +316,7 @@ class ForceLJ : Force {
     cutforcesq = cf * cf;
   }
 
-  proc compute(store : bool) : void {
+  override proc compute(store : bool) : void {
     eng_vdwl = 0;
     virial = 0;
     var fTimer : Timer;

--- a/test/studies/madness/aniruddha/madchap/MadAnalytics.chpl
+++ b/test/studies/madness/aniruddha/madchap/MadAnalytics.chpl
@@ -8,7 +8,7 @@ const PI = 3.14159265358979323846;
 
 /** gaussian with square normalized to 1 */
 class Fn_Test1: AFcn {
-    proc this(x: real): real {
+    override proc this(x: real): real {
         var a = 500.0;
         return (2*a/PI)**0.25 * exp(-a * (x-0.5)**2.0);
     }
@@ -17,7 +17,7 @@ class Fn_Test1: AFcn {
 
 /** derivative of test1 */
 class Fn_dTest1: AFcn {
-    proc this(x: real): real {
+    override proc this(x: real): real {
         var a = 500.0;
         return -2.0*a*(x-0.5) * (2*a/PI) ** 0.25 * exp(-a * (x-0.5)**2.0);
     }
@@ -32,7 +32,7 @@ class Fn_Test2: AFcn {
       delete g;
     }
 
-    proc this(x: real): real {
+    override proc this(x: real): real {
         return g(x-0.3) + g(x) + g(x+0.3);
     }
 };
@@ -46,7 +46,7 @@ class Fn_dTest2: AFcn {
       delete g;
     }
 
-    proc this(x: real): real {
+    override proc this(x: real): real {
         return g(x-0.3) + g(x) + g(x+0.3);
     }
 };
@@ -57,7 +57,7 @@ class Fn_dTest2: AFcn {
   the test code below.
  */
 class Fn_Test3: AFcn {
-    proc this(x: real): real {
+    override proc this(x: real): real {
         var a = 100.0*PI;
         if (x == 0.5) then
             return 0.0;
@@ -69,7 +69,7 @@ class Fn_Test3: AFcn {
 
 /** derivative of test3 */
 class Fn_dTest3: AFcn {
-    proc this(x: real): real {
+    override proc this(x: real): real {
         var a = 100.0*PI;
         if (x == 0.5) {
             return 0.0;
@@ -84,7 +84,7 @@ class Fn_dTest3: AFcn {
 
 /** 1 over the whole interval */
 class Fn_Unity: AFcn {
-    proc this(x: real): real {
+    override proc this(x: real): real {
         return 1.0;
     }
 }
@@ -92,7 +92,7 @@ class Fn_Unity: AFcn {
 
 /** 1 over the whole interval */
 class Fn_dUnity: AFcn {
-    proc this(x: real): real {
+    override proc this(x: real): real {
         return 0.0;
     }
 }

--- a/test/studies/madness/aniruddha/madchap/recordBug/MadAnalytics.chpl
+++ b/test/studies/madness/aniruddha/madchap/recordBug/MadAnalytics.chpl
@@ -8,7 +8,7 @@ const PI = 3.14159265358979323846;
 
 /** gaussian with square normalized to 1 */
 class Fn_Test1: AFcn {
-    proc this(x: real): real {
+    override proc this(x: real): real {
         var a = 500.0;
         return (2*a/PI)**0.25 * exp(-a * (x-0.5)**2.0);
     }
@@ -17,7 +17,7 @@ class Fn_Test1: AFcn {
 
 /** derivative of test1 */
 class Fn_dTest1: AFcn {
-    proc this(x: real): real {
+    override proc this(x: real): real {
         var a = 500.0;
         return -2.0*a*(x-0.5) * (2*a/PI) ** 0.25 * exp(-a * (x-0.5)**2.0);
     }
@@ -32,7 +32,7 @@ class Fn_Test2: AFcn {
       delete g;
     }
 
-    proc this(x: real): real {
+    override proc this(x: real): real {
         return g(x-0.3) + g(x) + g(x+0.3);
     }
 };
@@ -46,7 +46,7 @@ class Fn_dTest2: AFcn {
       delete g;
     }
 
-    proc this(x: real): real {
+    override proc this(x: real): real {
         return g(x-0.3) + g(x) + g(x+0.3);
     }
 };
@@ -57,7 +57,7 @@ class Fn_dTest2: AFcn {
   the test code below.
  */
 class Fn_Test3: AFcn {
-    proc this(x: real): real {
+    override proc this(x: real): real {
         var a = 100.0*PI;
         if (x == 0.5) then
             return 0.0;
@@ -69,7 +69,7 @@ class Fn_Test3: AFcn {
 
 /** derivative of test3 */
 class Fn_dTest3: AFcn {
-    proc this(x: real): real {
+    override proc this(x: real): real {
         var a = 100.0*PI;
         if (x == 0.5) {
             return 0.0;
@@ -84,7 +84,7 @@ class Fn_dTest3: AFcn {
 
 /** 1 over the whole interval */
 class Fn_Unity: AFcn {
-    proc this(x: real): real {
+    override proc this(x: real): real {
         return 1.0;
     }
 }
@@ -92,7 +92,7 @@ class Fn_Unity: AFcn {
 
 /** 1 over the whole interval */
 class Fn_dUnity: AFcn {
-    proc this(x: real): real {
+    override proc this(x: real): real {
         return 0.0;
     }
 }

--- a/test/studies/madness/common/MadAnalytics.chpl
+++ b/test/studies/madness/common/MadAnalytics.chpl
@@ -8,7 +8,7 @@ const PI = 3.14159265358979323846;
 
 /** gaussian with square normalized to 1 */
 class Fn_Test1: AFcn {
-    proc this(x: real): real {
+    override proc this(x: real): real {
         var a = 500.0;
         return (2*a/PI)**0.25 * exp(-a * (x-0.5)**2.0);
     }
@@ -17,7 +17,7 @@ class Fn_Test1: AFcn {
 
 /** derivative of test1 */
 class Fn_dTest1: AFcn {
-    proc this(x: real): real {
+    override proc this(x: real): real {
         var a = 500.0;
         return -2.0*a*(x-0.5) * (2*a/PI) ** 0.25 * exp(-a * (x-0.5)**2.0);
     }
@@ -32,7 +32,7 @@ class Fn_Test2: AFcn {
       delete g;
     }
 
-    proc this(x: real): real {
+    override proc this(x: real): real {
         return g(x-0.3) + g(x) + g(x+0.3);
     }
 };
@@ -46,7 +46,7 @@ class Fn_dTest2: AFcn {
       delete g;
     }
 
-    proc this(x: real): real {
+    override proc this(x: real): real {
         return g(x-0.3) + g(x) + g(x+0.3);
     }
 };
@@ -57,7 +57,7 @@ class Fn_dTest2: AFcn {
   the test code below.
  */
 class Fn_Test3: AFcn {
-    proc this(x: real): real {
+    override proc this(x: real): real {
         var a = 100.0*PI;
         if (x == 0.5) then
             return 0.0;
@@ -69,7 +69,7 @@ class Fn_Test3: AFcn {
 
 /** derivative of test3 */
 class Fn_dTest3: AFcn {
-    proc this(x: real): real {
+    override proc this(x: real): real {
         var a = 100.0*PI;
         if (x == 0.5) {
             return 0.0;
@@ -84,7 +84,7 @@ class Fn_dTest3: AFcn {
 
 /** 1 over the whole interval */
 class Fn_Unity: AFcn {
-    proc this(x: real): real {
+    override proc this(x: real): real {
         return 1.0;
     }
 }
@@ -92,7 +92,7 @@ class Fn_Unity: AFcn {
 
 /** 1 over the whole interval */
 class Fn_dUnity: AFcn {
-    proc this(x: real): real {
+    override proc this(x: real): real {
         return 0.0;
     }
 }

--- a/test/studies/madness/dinan/mad_chapel/MadAnalytics.chpl
+++ b/test/studies/madness/dinan/mad_chapel/MadAnalytics.chpl
@@ -8,7 +8,7 @@ const PI = 3.14159265358979323846;
 
 /** gaussian with square normalized to 1 */
 class Fn_Test1: AFcn {
-    proc this(x: real): real {
+    override proc this(x: real): real {
         var a = 500.0;
         return (2*a/PI)**0.25 * exp(-a * (x-0.5)**2.0);
     }
@@ -17,7 +17,7 @@ class Fn_Test1: AFcn {
 
 /** derivative of test1 */
 class Fn_dTest1: AFcn {
-    proc this(x: real): real {
+    override proc this(x: real): real {
         var a = 500.0;
         return -2.0*a*(x-0.5) * (2*a/PI) ** 0.25 * exp(-a * (x-0.5)**2.0);
     }
@@ -32,7 +32,7 @@ class Fn_Test2: AFcn {
       delete g;
     }
 
-    proc this(x: real): real {
+    override proc this(x: real): real {
         return g(x-0.3) + g(x) + g(x+0.3);
     }
 };
@@ -46,7 +46,7 @@ class Fn_dTest2: AFcn {
       delete g;
     }
 
-    proc this(x: real): real {
+    override proc this(x: real): real {
         return g(x-0.3) + g(x) + g(x+0.3);
     }
 };
@@ -57,7 +57,7 @@ class Fn_dTest2: AFcn {
   the test code below.
  */
 class Fn_Test3: AFcn {
-    proc this(x: real): real {
+    override proc this(x: real): real {
         var a = 100.0*PI;
         if (x == 0.5) then
             return 0.0;
@@ -69,7 +69,7 @@ class Fn_Test3: AFcn {
 
 /** derivative of test3 */
 class Fn_dTest3: AFcn {
-    proc this(x: real): real {
+    override proc this(x: real): real {
         var a = 100.0*PI;
         if (x == 0.5) {
             return 0.0;
@@ -84,7 +84,7 @@ class Fn_dTest3: AFcn {
 
 /** 1 over the whole interval */
 class Fn_Unity: AFcn {
-    proc this(x: real): real {
+    override proc this(x: real): real {
         return 1.0;
     }
 }
@@ -92,7 +92,7 @@ class Fn_Unity: AFcn {
 
 /** 1 over the whole interval */
 class Fn_dUnity: AFcn {
-    proc this(x: real): real {
+    override proc this(x: real): real {
         return 0.0;
     }
 }

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -39,7 +39,7 @@ class MasonError : Error {
   proc init(msg:string) {
     this.msg = msg;
   }
-  proc message() {
+  override proc message() {
     return msg;
   }
 }


### PR DESCRIPTION
This converts mason and some tests in which files are shared between many cases over to use `override` such that they pass (or work better) with `--override-checking`.  Though it only touches 9 files, it makes ~100 tests pass that hadn't before.  Note that the DataFrames updates should make additional tests pass once issue #10707 is closed.