### PR TITLE
Const check tuple args

### DIFF
--- a/compiler/resolution/cullOverReferences.cpp
+++ b/compiler/resolution/cullOverReferences.cpp
@@ -664,7 +664,8 @@ void cullOverReferences() {
         SymExpr* aggregateSe = toSymExpr(call->get(1));
         SymExpr* lhsSe = toSymExpr(move->get(1));
         AggregateType* at = toAggregateType(aggregateSe->getValType());
-        if (!at->isClass() && aggregateSe->symbol()->qualType().isConst())
+        // note, at might be NULL for unmanaged SomeClass
+        if (at && !at->isClass() && aggregateSe->symbol()->qualType().isConst())
             markSymbolConst(lhsSe->symbol());
       }
     }

--- a/compiler/resolution/cullOverReferences.cpp
+++ b/compiler/resolution/cullOverReferences.cpp
@@ -663,8 +663,9 @@ void cullOverReferences() {
       if (move->isPrimitive(PRIM_MOVE)) {
         SymExpr* aggregateSe = toSymExpr(call->get(1));
         SymExpr* lhsSe = toSymExpr(move->get(1));
-        if (aggregateSe->symbol()->qualType().isConst())
-          markSymbolConst(lhsSe->symbol());
+        AggregateType* at = toAggregateType(aggregateSe->getValType());
+        if (!at->isClass() && aggregateSe->symbol()->qualType().isConst())
+            markSymbolConst(lhsSe->symbol());
       }
     }
   }

--- a/compiler/resolution/cullOverReferences.cpp
+++ b/compiler/resolution/cullOverReferences.cpp
@@ -654,6 +654,21 @@ void cullOverReferences() {
       }
     }
   }
+  // forward-flow constness for getting refs to tuples
+  // this would be handled by a FLAG_REF_TO_CONST_WHEN_CONST_THIS accessor
+  // but for whatever reason the compiler doesn't always use that for tuples.
+  forv_Vec(CallExpr, call, gCallExprs) {
+    if (call->isPrimitive(PRIM_GET_MEMBER)) {
+      CallExpr* move = toCallExpr(call->parentExpr);
+      if (move->isPrimitive(PRIM_MOVE)) {
+        SymExpr* aggregateSe = toSymExpr(call->get(1));
+        SymExpr* lhsSe = toSymExpr(move->get(1));
+        if (aggregateSe->symbol()->qualType().isConst())
+          markSymbolConst(lhsSe->symbol());
+      }
+    }
+  }
+
 
   // Determine const-ness of ArgSymbols with INTENT_REF_MAYBE_CONST
   forv_Vec(ArgSymbol, arg, gArgSymbols) {

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -3918,7 +3918,7 @@ module ChapelArray {
 */
 
   proc =(ref a: [], b: _tuple) where isRectangularArr(a) {
-    proc chpl__tupleInit(j, param rank: int, b: _tuple) {
+    proc chpl__tupleInit(ref j, param rank: int, b: _tuple) {
       type idxType = a.domain.idxType,
            strType = chpl__signedType(a.domain.intIdxType);
 

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -3214,7 +3214,7 @@ proc channel.readIt(ref x) {
 }
 
 pragma "no doc"
-proc channel.writeIt(x) {
+proc channel.writeIt(const x) {
   if !writing then compilerError("write on read-only channel");
   const origLocale = this.getLocaleOfIoRequest();
   on this.home {
@@ -3235,7 +3235,7 @@ proc channel.writeIt(x) {
    For a reading channel, reads as with :proc:`channel.read`.
    Stores any error encountered in the channel. Does not return anything.
  */
-inline proc channel.readwrite(x) where this.writing {
+inline proc channel.readwrite(const x) where this.writing {
   this.writeIt(x);
 }
 // documented in the writing version.

--- a/test/types/records/const-checking/assign-to-tuple-element.chpl
+++ b/test/types/records/const-checking/assign-to-tuple-element.chpl
@@ -1,0 +1,19 @@
+pragma "suppress lvalue error" // or error!
+proc intfn(const ref arg: int) {
+  arg = 0;
+}
+proc tupfn(arg: 1*int) {
+  arg(1) = 0;
+}
+
+
+proc main() {
+  var i = 1;
+  var tup = (1,);
+
+  intfn(i);
+  tupfn(tup);
+
+  writeln(i);
+  writeln(tup(1));
+}

--- a/test/types/records/const-checking/assign-to-tuple-element.good
+++ b/test/types/records/const-checking/assign-to-tuple-element.good
@@ -1,0 +1,3 @@
+assign-to-tuple-element.chpl:5: In function 'tupfn':
+assign-to-tuple-element.chpl:6: error: const actual is passed to 'ref' formal 'a' of =
+note: to formal of type int(64)

--- a/test/types/tuple/ferguson/capture-2-refs-to-blank.good
+++ b/test/types/tuple/ferguson/capture-2-refs-to-blank.good
@@ -1,1 +1,5 @@
-00
+capture-2-refs-to-blank.chpl:6: In function 'test':
+capture-2-refs-to-blank.chpl:7: error: const actual is passed to 'ref' formal 'a' of =
+note: to formal of type int(64)
+capture-2-refs-to-blank.chpl:8: error: const actual is passed to 'ref' formal 'a' of =
+note: to formal of type int(64)


### PR DESCRIPTION
Resolves #10711.

This PR adjusts cullOverReferences to make references created by
PRIM_GET_MEMBER to be considered const if the aggregate record/tuple is
const. It corrects several module code errors revealed by the new
checking.

- [x] full local testing

Reviewed by @vasslitvinov - thanks!