### PR TITLE
Fix a few minor bugs in ugni

### DIFF
--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -6503,7 +6503,6 @@ DEFINE_CHPL_COMM_ATOMIC_CMPXCHG(real64, cmpxchg_64, int_least64_t)
             return;                                                     \
           }                                                             \
                                                                         \
-          remote_mr = mreg_for_remote_addr(obj, loc);                   \
           if (IS_32_BIT_AMO_ON_GEMINI(_t)                               \
               || (remote_mr = mreg_for_remote_addr(obj, loc)) == NULL) {\
             if (loc == chpl_nodeID)                                     \
@@ -6537,7 +6536,6 @@ DEFINE_CHPL_COMM_ATOMIC_CMPXCHG(real64, cmpxchg_64, int_least64_t)
             return;                                                     \
           }                                                             \
                                                                         \
-          remote_mr = mreg_for_remote_addr(obj, loc);                   \
           if (IS_32_BIT_AMO_ON_GEMINI(_t)                               \
               || (remote_mr = mreg_for_remote_addr(obj, loc)) == NULL) {\
             if (loc == chpl_nodeID)                                     \

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -7696,7 +7696,7 @@ int post_fma_ct(c_nodeid_t* locale_v, gni_post_descriptor_t* post_desc)
          pdc != NULL;
          pdc = pdc->next_descr, i++) {
       pdc->ep_hndl = cd->remote_eps[locale_v[i]];
-      PERFSTATS_ADD_POST(post_desc);
+      PERFSTATS_ADD(sent_bytes, pdc->length);
     }
   }
 


### PR DESCRIPTION
Fix bugs in ugni that I noticed while working on buffered atomics. These didn't
impact correctness, just a micro optimization and an incorrect perf counter.

Correct sent_bytes performance counter for chained transactions:
 - Since #10709, we were mistakenly counting the base post descriptor length
   each time instead of the length of the current chained post descriptor

Remove duplicate memory region lookups for binary network atomic ops:
 - Mistakenly added in #9868 (which was supposed to remove duplicate lookups!)
