### PR TITLE
AST dumps indicate varargs

### DIFF
--- a/compiler/AST/AstDump.cpp
+++ b/compiler/AST/AstDump.cpp
@@ -838,6 +838,8 @@ void AstDump::writeSymbol(Symbol* sym, bool def) {
         case INTENT_TYPE:      write("type arg");      break;
         case INTENT_BLANK:     write("arg");           break;
       }
+      if (arg->variableExpr)
+        write("...");
     }
   }
 

--- a/compiler/AST/AstDump.cpp
+++ b/compiler/AST/AstDump.cpp
@@ -838,8 +838,6 @@ void AstDump::writeSymbol(Symbol* sym, bool def) {
         case INTENT_TYPE:      write("type arg");      break;
         case INTENT_BLANK:     write("arg");           break;
       }
-      if (arg->variableExpr)
-        write("...");
     }
   }
 
@@ -859,6 +857,11 @@ void AstDump::writeSymbol(Symbol* sym, bool def) {
 
   if (sym->hasFlag(FLAG_GENERIC))
     write(false, "?", false);
+
+  if (def)
+    if (ArgSymbol* arg = toArgSymbol(sym))
+      if (arg->variableExpr)
+        write("...");
 
   mNeedSpace = true;
 }


### PR DESCRIPTION
In debugging issues with varargs I was surprised
that the `--log` output did not identify the `...` argument.
This adjusts it to do so.

Earlier version passed full local testing.

Reviewed by @daviditen - thanks!