### PR TITLE
Revert to stack-allocated rfDone indicators.

### DIFF
--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -1472,7 +1472,8 @@ static void      fork_amo_wrapper(fork_amo_info_t*);
 static void      release_req_buf(uint32_t, int, int);
 static void      indicate_done(fork_base_info_t* b);
 static void      indicate_done2(int, rf_done_t *);
-static void      send_polling_response(void*, c_nodeid_t, void*, size_t);
+static void      send_polling_response(void*, c_nodeid_t, void*, size_t,
+                                       mem_region_t*);
 static nb_desc_idx_t nb_desc_idx_encode(int, int);
 static void      nb_desc_idx_decode(int*, int*, nb_desc_idx_t);
 static nb_desc_t* nb_desc_idx_2_ptr(nb_desc_idx_t);
@@ -4319,7 +4320,7 @@ void release_req_buf(uint32_t li, int cdi, int rbi)
   static chpl_bool32 free_flag = true;
   send_polling_response(&free_flag, li,
                         RECV_SIDE_FORK_REQ_FREE_ADDR(li, cdi, rbi),
-                        sizeof(free_flag));
+                        sizeof(free_flag), &gnr_mreg_map[li]);
 }
 
 
@@ -4336,13 +4337,13 @@ inline
 void indicate_done2(int caller, rf_done_t *ack)
 {
   static rf_done_t done = 1;
-  send_polling_response(&done, caller, ack, sizeof(done));
+  send_polling_response(&done, caller, ack, sizeof(done), NULL);
 }
 
 
 static
 void send_polling_response(void* src_addr, c_nodeid_t locale, void* tgt_addr,
-                           size_t size)
+                           size_t size, mem_region_t* mr)
 {
   gni_post_descriptor_t* post_desc;
 
@@ -4353,11 +4354,8 @@ void send_polling_response(void* src_addr, c_nodeid_t locale, void* tgt_addr,
   // This gets nearly all the benefit of not waiting for completions,
   // while avoiding concurrency control entirely.
   //
-  // TODO I'm not what to do for the the polling task response, so just force
-  // it to go through the blocking put case, so I can test fft perf.
-  if (true || cd == NULL || !cd->firmly_bound) {
-    do_remote_put(src_addr, locale, tgt_addr, size, NULL, // &gnr_mreg_map[locale],
-                  may_proxy_false);
+  if (cd == NULL || !cd->firmly_bound) {
+    do_remote_put(src_addr, locale, tgt_addr, size, mr, may_proxy_false);
     return;
   }
 
@@ -4409,6 +4407,12 @@ void send_polling_response(void* src_addr, c_nodeid_t locale, void* tgt_addr,
   //
   // Fill in the POST descriptor.
   //
+  if (mr == NULL
+      && (mr = mreg_for_remote_addr(tgt_addr, locale)) == NULL) {
+    CHPL_INTERNAL_ERROR("send_polling_response(): "
+                        "remote address is not NIC-registered");
+  }
+
   post_desc->type            = GNI_POST_FMA_PUT;
   post_desc->cq_mode         = GNI_CQMODE_GLOBAL_EVENT;
   post_desc->dlvr_mode       = GNI_DLVMODE_PERFORMANCE;
@@ -4416,7 +4420,7 @@ void send_polling_response(void* src_addr, c_nodeid_t locale, void* tgt_addr,
   post_desc->src_cq_hndl     = 0;
   post_desc->local_addr      = (uint64_t) (intptr_t) src_addr;
   post_desc->remote_addr     = (uint64_t) (intptr_t) tgt_addr;
-  post_desc->remote_mem_hndl = gnr_mreg_map[locale].mdh;
+  post_desc->remote_mem_hndl = mr->mdh;
   post_desc->length          = size;
 
   //


### PR DESCRIPTION
As part of dynamic heap registration we switched from using stack-based
"remote fork done" indicators as our primary resource, with dynamically
allocated ones as a backup, to always using dynamically allocated ones.
This allowed the AM handler to avoid doing a memory region lookup for
its "done" responses, because it knew all the response indicator flags
must be in the guaranteed-registered segment.  We expected this to give
a small marginal improvement in AM handler performance.  Unfortunately,
the only performance change we saw was a pretty big regression for FFT,
and a somewhat smaller one for HPL.  So here, revert this change and go
back to stack-based `rf_done` indicators.

This resolves #8967.