### PR TITLE
Ensure determinism in tpv/block.chpl

### DIFF
--- a/test/parallel/forall/task-private-vars/block.chpl
+++ b/test/parallel/forall/task-private-vars/block.chpl
@@ -22,7 +22,8 @@ proc nextLocalTaskCounter(hereId:int) {
 
 const MessageDom = {1..numMessages};
 const MessageSpace = MessageDom dmapped Block(MessageDom,
-                                              dataParTasksPerLocale = dptpl);
+                                            dataParTasksPerLocale = dptpl,
+     /* ensure determinism w.r.t. #10729 */ dataParIgnoreRunningTasks = true);
 
 var MessageVisited: [MessageSpace] bool;
 


### PR DESCRIPTION
This test has failed in nightly testing due to #10729.

By passing dataParIgnoreRunningTasks=true, we avoid
reliance on here.runningTasks(). This ensures deterministic
execution and prevents this failure mode.

Note that this test's output still depends on the structure of Block
and DefaultRectangular leader iterator implementations.