### PR TITLE
Improve override errors for inherited iterators

### DIFF
--- a/compiler/AST/FnSymbol.cpp
+++ b/compiler/AST/FnSymbol.cpp
@@ -917,6 +917,11 @@ bool FnSymbol::isSecondaryMethod() const {
   return isMethod() == true && isPrimaryMethod() == false;
 }
 
+bool FnSymbol::isUserDefined() const {
+  return (!hasFlag(FLAG_COMPILER_GENERATED) &&
+          !hasFlag(FLAG_AUTO_II));
+}
+
 bool FnSymbol::isInitializer() const {
   return isMethod() == true && strcmp(name, "init")     == 0;
 }

--- a/compiler/AST/FnSymbol.cpp
+++ b/compiler/AST/FnSymbol.cpp
@@ -917,9 +917,9 @@ bool FnSymbol::isSecondaryMethod() const {
   return isMethod() == true && isPrimaryMethod() == false;
 }
 
-bool FnSymbol::isUserDefined() const {
-  return (!hasFlag(FLAG_COMPILER_GENERATED) &&
-          !hasFlag(FLAG_AUTO_II));
+bool FnSymbol::isCompilerGenerated() const {
+  return (hasFlag(FLAG_COMPILER_GENERATED) ||
+          hasFlag(FLAG_AUTO_II));
 }
 
 bool FnSymbol::isInitializer() const {

--- a/compiler/include/FnSymbol.h
+++ b/compiler/include/FnSymbol.h
@@ -162,7 +162,7 @@ public:
 
   bool                       isPrimaryMethod()                           const;
   bool                       isSecondaryMethod()                         const;
-  bool                       isUserDefined()                             const;
+  bool                       isCompilerGenerated()                       const;
 
   bool                       isInitializer()                             const;
   bool                       isPostInitializer()                         const;

--- a/compiler/include/FnSymbol.h
+++ b/compiler/include/FnSymbol.h
@@ -162,6 +162,7 @@ public:
 
   bool                       isPrimaryMethod()                           const;
   bool                       isSecondaryMethod()                         const;
+  bool                       isUserDefined()                             const;
 
   bool                       isInitializer()                             const;
   bool                       isPostInitializer()                         const;

--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -717,7 +717,8 @@ static IteratorInfo*  makeIteratorInfo(AggregateType* iClass,
 
 static FnSymbol*      makeIteratorMethod(IteratorInfo* ii,
                                          const char*   name,
-                                         Type*         retType);
+                                         Type*         retType,
+                                         bool          override=false);
 
 static void protoIteratorClass(FnSymbol* fn, Type* yieldedType) {
   INT_ASSERT(yieldedType != NULL);
@@ -854,13 +855,17 @@ static IteratorInfo*  makeIteratorInfo(AggregateType* iClass,
 
 static FnSymbol* makeIteratorMethod(IteratorInfo* ii,
                                     const char*   name,
-                                    Type*         retType) {
+                                    Type*         retType,
+                                    bool          override) {
   FnSymbol* fn = new FnSymbol(name);
 
   fn->addFlag(FLAG_AUTO_II);
 
   if (strcmp(name, "advance") != 0) {
     fn->addFlag(FLAG_INLINE);
+  }
+  if (ii->iterator->hasFlag(FLAG_OVERRIDE)) {
+    fn->addFlag(FLAG_OVERRIDE);
   }
 
   fn->setMethod(true);

--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -717,8 +717,7 @@ static IteratorInfo*  makeIteratorInfo(AggregateType* iClass,
 
 static FnSymbol*      makeIteratorMethod(IteratorInfo* ii,
                                          const char*   name,
-                                         Type*         retType,
-                                         bool          override=false);
+                                         Type*         retType);
 
 static void protoIteratorClass(FnSymbol* fn, Type* yieldedType) {
   INT_ASSERT(yieldedType != NULL);
@@ -855,8 +854,7 @@ static IteratorInfo*  makeIteratorInfo(AggregateType* iClass,
 
 static FnSymbol* makeIteratorMethod(IteratorInfo* ii,
                                     const char*   name,
-                                    Type*         retType,
-                                    bool          override) {
+                                    Type*         retType) {
   FnSymbol* fn = new FnSymbol(name);
 
   fn->addFlag(FLAG_AUTO_II);

--- a/compiler/resolution/virtualDispatch.cpp
+++ b/compiler/resolution/virtualDispatch.cpp
@@ -314,7 +314,14 @@ static bool possibleSignatureMatch(FnSymbol* fn, FnSymbol* gn) {
 
 static bool checkOverrides(FnSymbol* fn) {
   ModuleSymbol* parentMod = fn->getModule();
-  return (fOverrideChecking || (parentMod && parentMod->modTag != MOD_USER));
+  // check overrides if any of these are true...
+          // (a) the flag is on and the function is not compiler-generated
+  return ((fOverrideChecking && !fn->isCompilerGenerated()) ||
+          // (b) developer is on (avoids printing developer cases to users)
+          developer == true ||
+          // (c) the function is in the modules/ hierarchy (which we manage
+          //     and want to keep clean)
+          (parentMod && parentMod->modTag != MOD_USER));
 }
 
 static void resolveOverride(FnSymbol* pfn, FnSymbol* cfn) {
@@ -966,8 +973,7 @@ static void checkMethodsOverride() {
             }
           }
 
-          if (okKnown && ok == false &&
-              (developer == true || fn->isUserDefined())) {
+          if (okKnown && ok == false) {
             if (fn->hasFlag(FLAG_OVERRIDE)) {
               USR_FATAL_CONT(fn, "%s.%s override keyword present but no "
                                   "superclass method matches signature "

--- a/compiler/resolution/virtualDispatch.cpp
+++ b/compiler/resolution/virtualDispatch.cpp
@@ -966,7 +966,8 @@ static void checkMethodsOverride() {
             }
           }
 
-          if (okKnown && ok == false) {
+          if (okKnown && ok == false &&
+              (developer == true || fn->isUserDefined())) {
             if (fn->hasFlag(FLAG_OVERRIDE)) {
               USR_FATAL_CONT(fn, "%s.%s override keyword present but no "
                                   "superclass method matches signature "

--- a/compiler/resolution/virtualDispatch.cpp
+++ b/compiler/resolution/virtualDispatch.cpp
@@ -314,13 +314,17 @@ static bool possibleSignatureMatch(FnSymbol* fn, FnSymbol* gn) {
 
 static bool checkOverrides(FnSymbol* fn) {
   ModuleSymbol* parentMod = fn->getModule();
-  // check overrides if any of these are true...
-          // (a) the flag is on and the function is not compiler-generated
-  return ((fOverrideChecking && !fn->isCompilerGenerated()) ||
-          // (b) developer is on (avoids printing developer cases to users)
-          developer == true ||
-          // (c) the function is in the modules/ hierarchy (which we manage
-          //     and want to keep clean)
+  // check overrides for a given function if any of these are true...
+          // (1) the flag is on and either
+          //     (a) the function is not compiler-generated or
+          //     (b) --devel is on
+          //  or...
+  return (((fOverrideChecking &&
+            (!fn->isCompilerGenerated() ||
+             (fn->isCompilerGenerated() && developer == true)))) ||
+          // (2) the function is in the modules/ hierarchy (which we manage
+          //     and want to keep clean); oncer override checking is on by
+          //     default, we'd likely only check these when --devel is on?
           (parentMod && parentMod->modTag != MOD_USER));
 }
 

--- a/test/classes/dinan/dyndispatch_these.chpl
+++ b/test/classes/dinan/dyndispatch_these.chpl
@@ -8,7 +8,7 @@ class A {
 }
 
 class B:A {
-  iter these() {
+  override iter these() {
     for i in 1..n by -1 do
       yield i;
   }

--- a/test/functions/deitz/iterators/test_override1.chpl
+++ b/test/functions/deitz/iterators/test_override1.chpl
@@ -6,7 +6,7 @@ class C {
 }
 
 class D: C {
-  iter foo(n: int) {
+  override iter foo(n: int) {
     for i in 1..n by -1 do
       yield i;
   }

--- a/test/functions/deitz/iterators/test_override2.chpl
+++ b/test/functions/deitz/iterators/test_override2.chpl
@@ -6,7 +6,7 @@ class C {
 }
 
 class D: C {
-  iter foo(n: int) {
+  override iter foo(n: int) {
     for i in 1..n do
       yield i;
     for i in 1..n by -1 do

--- a/test/functions/deitz/iterators/test_override3.chpl
+++ b/test/functions/deitz/iterators/test_override3.chpl
@@ -8,7 +8,7 @@ class C {
 }
 
 class D: C {
-  iter foo(n: int) {
+  override iter foo(n: int) {
     for i in 1..n do
       yield i;
   }

--- a/test/functions/deitz/iterators/test_override4.chpl
+++ b/test/functions/deitz/iterators/test_override4.chpl
@@ -6,7 +6,7 @@ class C {
 }
 
 class D: C {
-  iter foo(n: int) {
+  override iter foo(n: int) {
     for i in 1..n by -1 do
       yield i;
   }

--- a/test/functions/deitz/iterators/test_override5_error.chpl
+++ b/test/functions/deitz/iterators/test_override5_error.chpl
@@ -6,7 +6,7 @@ class C {
 }
 
 class D: C {
-  iter foo(n: int) {
+  override iter foo(n: int) {
     for i in 1..n by -1 do
       yield (i,i);
   }

--- a/test/functions/iterators/bradc/override.chpl
+++ b/test/functions/iterators/bradc/override.chpl
@@ -7,7 +7,7 @@ class C {
 }
 
 class D : C {
-  iter these() {
+  override iter these() {
     yield 3;
     yield 2;
     yield 1;

--- a/test/functions/iterators/bradc/override2.chpl
+++ b/test/functions/iterators/bradc/override2.chpl
@@ -7,7 +7,7 @@ class C {
 }
 
 class D : C {
-  iter these() {
+  override iter these() {
     yield 3;
     yield 2;
     yield 1;

--- a/test/functions/iterators/diten/dynamicDispatchIterator3Levels.chpl
+++ b/test/functions/iterators/diten/dynamicDispatchIterator3Levels.chpl
@@ -10,7 +10,7 @@ class Parent {
 }
 
 class Child: Parent {
-  iter myit() {
+  override iter myit() {
     var low = 1;
     var high = 8;
     var stride = 2;
@@ -22,7 +22,7 @@ class Child: Parent {
 }
 
 class Grandchild: Child {
-  iter myit() {
+  override iter myit() {
     var low = 2;
     var high = 8;
     var stride = 2;

--- a/test/functions/iterators/vass/dynamic-dispatch-iterators.chpl
+++ b/test/functions/iterators/vass/dynamic-dispatch-iterators.chpl
@@ -5,8 +5,8 @@ class Superclass {
 }
 
 class Subclass:Superclass {
-  proc parens() { writeln("parens() in Subclass"); }
-  iter itest() { yield "Subclass"; }
+  override proc parens() { writeln("parens() in Subclass"); }
+  override iter itest() { yield "Subclass"; }
 }
 
 var c: unmanaged Superclass;

--- a/test/trivial/jturner/iter_overload_simple-blc.chpl
+++ b/test/trivial/jturner/iter_overload_simple-blc.chpl
@@ -11,7 +11,7 @@ class Parent {
 }
 
 class Child : Parent {
-  iter foo(k:int) {
+  override iter foo(k:int) {
     for l in myiter() {
       yield k+l+100;
     }
@@ -19,7 +19,7 @@ class Child : Parent {
 }
 
 class GrandChild : Child {
-  iter foo(k:int) {
+  override iter foo(k:int) {
     yield 3;
   }
 }

--- a/test/trivial/jturner/iter_overload_simple.chpl
+++ b/test/trivial/jturner/iter_overload_simple.chpl
@@ -11,7 +11,7 @@ class Parent {
 }
 
 class Child : Parent {
-  iter foo(k:int) {
+  override iter foo(k:int) {
     for l in myiter() {
       yield k+l+100;
     }

--- a/test/users/thom/itoverride.chpl
+++ b/test/users/thom/itoverride.chpl
@@ -5,7 +5,7 @@ class C
 
 class SubC : C
 {
-  proc writeThis(w) { w.write("SubC"); }
+  override proc writeThis(w) { w.write("SubC"); }
 }
 
 class OverrideMe
@@ -24,12 +24,12 @@ class OverrideMe
 
 class OverridesIt : OverrideMe
 {
-  proc getC()
+  override proc getC()
   {
     return new unmanaged SubC();
   }
 
-  iter manyC()
+  override iter manyC()
   {
     yield new unmanaged SubC();
     yield new unmanaged SubC();


### PR DESCRIPTION
This does a few things:

1) Updates tests to use `override` for inherited iterator methods when needed
2) Updates compiler-generated methods implementing iterators (e.g., zip1(), advance(), etc.) to inherit `override` from the original iterator when specified
3) Updates generation of `override` warnings/errors to squash them for compiler-generated methods unless `--devel` is on.  An implication of this is that step 2 isn't technically necessary for user compilations; but this still seemed like good practice for consistency and makes --devel compilations cleaner.
4) Adds a utility function FnSymbol::isCompilerGenerated() that answers the question since many compiler-generated functions do not have FLAG_COMPILER_GENERATED (though I've only checked for one additional case here).  This will also help with my "resolve only concrete functions effort" where I found many cases like this where compiler-generated routines were not flagged as such (but had other things one could check for).  As this function evolves we should (a) add more flags to it as we find them and ultimately (b) add FLAG_COMPILER_GENERATED to such cases when we create them.
