### PR TITLE
chplspell dictionary update

### DIFF
--- a/util/devel/chplspell
+++ b/util/devel/chplspell
@@ -87,7 +87,7 @@ FILTEROUT="compiler/include/bison-chapel.h  \
            doc/rst/modules                  \
            doc/rst/primers                  \
            doc/rst/examples                 \
-           modules/packages/HDF5_HL.chpl    \
+           modules/packages/HDF5.chpl       \
            modules/packages/LAPACK.chpl"
 
 

--- a/util/devel/chplspell-dictionary
+++ b/util/devel/chplspell-dictionary
@@ -2710,6 +2710,7 @@ blarg
 strct
 
 FILEID: e5dbc400-1d83-11e6-a3a6-10ddb1d4c3d5
+gparent
 hashset
 outervar
 urse
@@ -2720,6 +2721,7 @@ yret
 FILEID: 0fdc1a0c-1d84-11e6-a3a6-10ddb1d4c3d5
 ppne
 sdef
+typefunction
 urse
 
 FILEID: 7e73d6b2-1d84-11e6-a3a6-10ddb1d4c3d5
@@ -2746,11 +2748,15 @@ urse
 
 FILEID: 4f065520-1d85-11e6-a3a6-10ddb1d4c3d5
 fivec
+inov
 intented
 orse
 shadowvar
+sovar
 ssvar
+svdef
 tupcom
+unboundslice
 ytemp
 
 FILEID: 803ee256-1d85-11e6-a3a6-10ddb1d4c3d5
@@ -2769,8 +2775,10 @@ ipra
 maino
 mcpu
 mpicxx
+ploc
 qunused
 reassoc
+srcm
 thunderx
 tlii
 wmissing
@@ -2838,6 +2846,7 @@ FILEID: 5f5c9598-1e47-11e6-a3a6-10ddb1d4c3d5
 gloop
 lfoo
 libfoo
+libname
 
 FILEID: 8a9f313e-1e47-11e6-a3a6-10ddb1d4c3d5
 fltdbl
@@ -3206,6 +3215,7 @@ mywriteln
 parenthesesless
 
 FILEID: e1d71c80-2952-11e6-a3a6-10ddb1d4c3d5
+addone
 fltdbl
 
 FILEID: f72f3d38-2952-11e6-a3a6-10ddb1d4c3d5
@@ -3816,6 +3826,7 @@ gaxpy
 
 FILEID: 2fa429f4-b859-11e6-9740-843835579daa
 aaaaa
+absdiff
 clight
 coefflen
 cslamt
@@ -4243,6 +4254,7 @@ nbobjs
 
 FILEID: aa0e6b5c-0c12-11e7-980e-10ddb1d4c3d5
 adrerr
+allgathers
 blockhere
 cmps
 cmpval
@@ -4260,6 +4272,7 @@ fiadd
 fpadd
 fswap
 fxor
+gcef
 gdata
 iadd
 iptag
@@ -4457,6 +4470,7 @@ mpmc
 
 FILEID: f81d91a2-8aba-11e7-b3f1-10ddb1d4c3d5
 ivrs
+openblas
 
 FILEID: 081f50fc-91e8-11e7-b3f1-10ddb1d4c3d5
 cabsf
@@ -4652,6 +4666,24 @@ FILEID: 203d644e-8648-11e8-ad82-10ddb1d4c3d5
 nbobjs
 schedaffinity
 
+FILEID: 6de8d7ca-9c7b-11e8-b963-10ddb1d4c3d5
+bint
+cimport
+ctypedef
+fixpath
+libhdrfile
+libname
+linkershared
+
+FILEID: e6ecf3ae-9c7b-11e8-b963-10ddb1d4c3d5
+codepoints
+cpindex
+mblength
+mbsize
+
+FILEID: f5a43844-9c7b-11e8-b963-10ddb1d4c3d5
+timeunits
+
 NATURAL:
 aarch
 abcd
@@ -4739,6 +4771,7 @@ asts
 atanh
 atlassian
 atmpvc
+atoi
 atomicbool
 atomicness
 attaches
@@ -4951,6 +4984,7 @@ codebook
 codegened
 codegenned
 codegenning
+codegens
 codepoint
 codesign
 coforall
@@ -6322,6 +6356,7 @@ pontelli
 popcount
 portably
 poslast
+postamble
 postblit
 postfields
 postfieldsize
@@ -6699,6 +6734,7 @@ sphinxcontrib
 spincount
 spinlock
 spinlocks
+spinwaiting
 spmd
 springfield
 sprintf
@@ -6785,6 +6821,7 @@ subtime
 subtree
 subvec
 sudo
+sudoku
 sundanese
 sunday
 sungeun
@@ -6902,6 +6939,7 @@ toolchain
 tooltip
 toordinal
 topdown
+toposort
 toraw
 toret
 tounmanaged
@@ -6941,6 +6979,7 @@ ugni
 uintptr
 uints
 uiui
+ulength
 ulong
 ulonglong
 umask

--- a/util/devel/chplspell-dictionary.fileids.json
+++ b/util/devel/chplspell-dictionary.fileids.json
@@ -68,6 +68,9 @@
   "75f1ecaa-1d83-11e6-a3a6-10ddb1d4c3d5": [
     "compiler/codegen/codegen.cpp"
   ],
+  "6de8d7ca-9c7b-11e8-b963-10ddb1d4c3d5": [
+    "compiler/codegen/library.cpp"
+  ],
   "d20c5afc-1d7e-11e6-a3a6-10ddb1d4c3d5": [
     "compiler/ifa/num.cpp"
   ],
@@ -440,6 +443,9 @@
   "c3e70026-8645-11e8-ad82-10ddb1d4c3d5": [
     "modules/internal/ExternalArray.chpl"
   ],
+  "e6ecf3ae-9c7b-11e8-b963-10ddb1d4c3d5": [
+    "modules/internal/String.chpl"
+  ],
   "5cb0944a-0c15-11e7-980e-10ddb1d4c3d5": [
     "modules/internal/localeModels/knl/LocaleModel.chpl"
   ],
@@ -528,6 +534,9 @@
   ],
   "d41572f2-1f2c-11e6-a3a6-10ddb1d4c3d5": [
     "modules/standard/SysBasic.chpl"
+  ],
+  "f5a43844-9c7b-11e8-b963-10ddb1d4c3d5": [
+    "modules/standard/Time.chpl"
   ],
   "e9347814-1f30-11e6-a3a6-10ddb1d4c3d5": [
     "modules/standard/Types.chpl"


### PR DESCRIPTION
chplspell dictionary update

Also, the HDF5_HL.chpl file that chpslpell is hardcoded to ignore was renamed.
Update the list entry that ignores it.