### PR TITLE
Add skipif I missed when copying the test

### DIFF
--- a/test/compflags/lydia/library/noLibFlag/checkHeaderSet.skipif
+++ b/test/compflags/lydia/library/noLibFlag/checkHeaderSet.skipif
@@ -1,0 +1,1 @@
+CHPL_LLVM != none


### PR DESCRIPTION
This test is a copy of one in the header directory, to verify that we get the
same functionality without the --library flag (but with the header flag, since
the various directories are a little inconsistent in how they make libraries).
When copying it, I had seen that there wasn't a skipif file any more but missed
the directory-wide skipif that replaced it.  This commit copies the directory
wide skipif to be an individual skipif for the copied test, but removes the
darwin part because that bit is fine