### PR TITLE
Add a buffered variant of bale histo

### DIFF
--- a/test/studies/bale/histogram/histo-atomics.chpl
+++ b/test/studies/bale/histogram/histo-atomics.chpl
@@ -10,6 +10,8 @@ config const printStats = true,
 config const useRandomSeed = true,
              seed = if useRandomSeed then SeedGenerator.oddCurrentTime else 314159265;
 
+config const useBufferedAtomics = false;
+
 config const numTasksPerLocale = here.maxTaskPar;
 const numTasks = numLocales * numTasksPerLocale;
 config const N = 2000000; // number of updates per task
@@ -38,8 +40,13 @@ proc main() {
   var t: Timer;
   t.start();
 
-  /* main loop */
-  forall r in rindex {
+  if useBufferedAtomics {
+    use BufferedAtomics;
+    forall r in rindex do
+      A[r].addBuff(1);
+    flushAtomicBuff();
+  } else {
+   forall r in rindex do
     A[r].add(1);
   }
 

--- a/test/studies/bale/histogram/histo-atomics.execopts
+++ b/test/studies/bale/histogram/histo-atomics.execopts
@@ -1,1 +1,2 @@
---N=2000 --M=10 --printStats=false --printArrays=true --useRandomSeed=false --numTasksPerLocale=2
+--N=2000 --M=10 --printStats=false --printArrays=true --useRandomSeed=false --numTasksPerLocale=2 --useBufferedAtomics=false
+--N=2000 --M=10 --printStats=false --printArrays=true --useRandomSeed=false --numTasksPerLocale=2 --useBufferedAtomics=true

--- a/test/studies/bale/histogram/histo-atomics.ml-execopts
+++ b/test/studies/bale/histogram/histo-atomics.ml-execopts
@@ -11,4 +11,5 @@ N = 20000
 if ugni:
   N = 2000000
 
-print('--N={0} --printStats # bale-hist-atomic'.format(N))
+print('--N={0} --printStats --useBufferedAtomics=false # bale-hist-atomic'.format(N))
+print('--N={0} --printStats --useBufferedAtomics=true  # bale-hist-buff-atomic'.format(N))

--- a/test/studies/bale/histogram/histo-atomics.ml-perf.graph
+++ b/test/studies/bale/histogram/histo-atomics.ml-perf.graph
@@ -1,5 +1,5 @@
-perfkeys: MB/s per node: 
-files: bale-hist-atomic.dat
-graphkeys: MB/s per node
+perfkeys: MB/s per node:, MB/s per node:
+files: bale-hist-atomic.dat, bale-hist-buff-atomic.dat
+graphkeys: MB/s per node (naive), MB/s per node (buffered)
 graphtitle: Bale: Histogram Perf (MB/s per node)
 ylabel: Performance (MB/s per node)

--- a/test/studies/bale/histogram/histo-atomics.ml-time.graph
+++ b/test/studies/bale/histogram/histo-atomics.ml-time.graph
@@ -1,5 +1,5 @@
-perfkeys: Time: 
-files: bale-hist-atomic.dat
-graphkeys: runtime
+perfkeys: Time:, Time:
+files: bale-hist-atomic.dat, bale-hist-buff-atomic.dat
+graphkeys: runtime (naive), runtime (buffered)
 graphtitle: Bale: Histogram Time (sec)
 ylabel: Time (seconds)


### PR DESCRIPTION
The buffered versions achieves 360 MB/s per node compared to the non-buffered
80 MB/s per node. This version performs on par with the non-blocking UPC
version (tested on 16 nodes of a Cray XC with 28 core Broadwell nodes)
