### PR TITLE
Quiet deadlock test

### DIFF
--- a/test/parallel/sync/deitz/test_deadlock_detection1.notest
+++ b/test/parallel/sync/deitz/test_deadlock_detection1.notest
@@ -1,0 +1,4 @@
+Disabling this test...
+
+...because (a) it sometimes fails (e.g., Aug 2nd, quickstart), (b) we're
+looking at retiring the -b flag anyway (issue #10127).


### PR DESCRIPTION
Quieting this test because (a) it fails sporadically (e.g., Aug 2nd
for Quickstart) and (b) we intend to retire the '-b' flag.