### PR TITLE
Fix DateTime leak and add override intent checking

### DIFF
--- a/compiler/resolution/virtualDispatch.cpp
+++ b/compiler/resolution/virtualDispatch.cpp
@@ -330,11 +330,12 @@ static void checkIntentsMatch(FnSymbol* pfn, FnSymbol* cfn) {
     ArgSymbol* ca = cfn->getFormal(i);
 
     if (pa->originalIntent != ca->originalIntent) {
-      USR_FATAL_CONT(cfn, "%s.%s conflicting intent for argument '%s'",
+      USR_FATAL_CONT(cfn, "%s.%s conflicting intent for argument '%s' "
+                          "in overriding method",
                            ct->symbol->name, cfn->name, ca->name);
-      USR_FATAL_CONT(pa, "this function uses %s",
+      USR_FATAL_CONT(pa, "base method uses %s",
                           intentDescrString(pa->originalIntent));
-      USR_FATAL_CONT(ca, "this function uses %s",
+      USR_FATAL_CONT(ca, "overriding method uses %s",
                           intentDescrString(ca->originalIntent));
 
       // "fix" the intent to report errors only once.

--- a/compiler/resolution/virtualDispatch.cpp
+++ b/compiler/resolution/virtualDispatch.cpp
@@ -323,10 +323,6 @@ static void checkIntentsMatch(FnSymbol* pfn, FnSymbol* cfn) {
   INT_ASSERT(pfn->numFormals() == cfn->numFormals());
   INT_ASSERT(ct);
 
-
-  if (0 == strcmp(pfn->name, "inout_in"))
-    gdbShouldBreakHere();
-
   int nFormals = pfn->numFormals();
 
   for (int i = 3; i <= nFormals; i++) {

--- a/compiler/resolution/virtualDispatch.cpp
+++ b/compiler/resolution/virtualDispatch.cpp
@@ -317,6 +317,39 @@ static bool checkOverrides(FnSymbol* fn) {
   return (fOverrideChecking || (parentMod && parentMod->modTag != MOD_USER));
 }
 
+static void checkIntentsMatch(FnSymbol* pfn, FnSymbol* cfn) {
+  AggregateType* ct = toAggregateType(cfn->_this->getValType());
+  // these are really a preconditions for the following code
+  INT_ASSERT(pfn->numFormals() == cfn->numFormals());
+  INT_ASSERT(ct);
+
+
+  if (0 == strcmp(pfn->name, "inout_in"))
+    gdbShouldBreakHere();
+
+  int nFormals = pfn->numFormals();
+
+  for (int i = 3; i <= nFormals; i++) {
+    ArgSymbol* pa = pfn->getFormal(i);
+    ArgSymbol* ca = cfn->getFormal(i);
+
+    if (pa->originalIntent != ca->originalIntent) {
+      USR_FATAL_CONT(cfn, "%s.%s conflicting intent for argument '%s'",
+                           ct->symbol->name, cfn->name, ca->name);
+      USR_FATAL_CONT(pa, "this function uses %s",
+                          intentDescrString(pa->originalIntent));
+      USR_FATAL_CONT(ca, "this function uses %s",
+                          intentDescrString(ca->originalIntent));
+
+      // "fix" the intent to report errors only once.
+      // This would be totally unreasonable if the compiler were
+      // to continue compiling beyond this pass.
+      ca->originalIntent = pa->originalIntent;
+    }
+  }
+}
+
+
 static void resolveOverride(FnSymbol* pfn, FnSymbol* cfn) {
   resolveSignature(cfn);
 
@@ -377,6 +410,10 @@ static void resolveOverride(FnSymbol* pfn, FnSymbol* cfn) {
       USR_STOP();
 
     } else {
+
+      // check that the intents match
+      checkIntentsMatch(pfn, cfn);
+
       virtualDispatchUpdate(pfn, cfn);
     }
   }

--- a/modules/standard/DateTime.chpl
+++ b/modules/standard/DateTime.chpl
@@ -1679,7 +1679,7 @@ module DateTime {
     }
 
     /* Convert a `time` in UTC to this time zone */
-    proc fromutc(in dt: datetime): datetime {
+    proc fromutc(dt: datetime): datetime {
       HaltWrappers.pureVirtualMethodHalt();
       return new datetime(0,0,0);
     }

--- a/test/classes/ferguson/delete-free/owned-shared-fields2.bad
+++ b/test/classes/ferguson/delete-free/owned-shared-fields2.bad
@@ -1,2 +1,0 @@
-leaks
-3          48         MyClass

--- a/test/classes/ferguson/delete-free/owned-shared-fields2.chpl
+++ b/test/classes/ferguson/delete-free/owned-shared-fields2.chpl
@@ -1,28 +1,25 @@
-use OwnedObject;
-use SharedObject;
-
 class MyClass {
   var x:int;
 }
 
 record R5 {
-  var fo:Owned(MyClass) = new Owned(nil:MyClass);
-  var fs:Shared(MyClass) = new Shared(nil:MyClass);
+  var fo:owned MyClass = nil;
+  var fs:shared MyClass = nil;
 }
 
 record R6 {
-  var fo:Owned(MyClass);
-  var fs:Shared(MyClass);
+  var fo:owned MyClass;
+  var fs:shared MyClass;
 }
 
 class C5 {
-  var fo:Owned(MyClass) = new Owned(nil:MyClass);
-  var fs:Shared(MyClass) = new Shared(nil:MyClass);
+  var fo:owned MyClass = nil;
+  var fs:shared MyClass = nil;
 }
 
 class C6 {
-  var fo:Owned(MyClass);
-  var fs:Shared(MyClass);
+  var fo:owned MyClass;
+  var fs:shared MyClass;
 }
 
 proc test5a() {
@@ -31,12 +28,12 @@ proc test5a() {
   delete cc;
 }
 proc test5b() {
-  var a = new MyClass(1);
-  var b = new MyClass(2);
-  var c = new MyClass(3);
-  var d = new MyClass(4);
-  var r = new R5(new Owned(a), new Shared(b));
-  var cc = new unmanaged C5(new Owned(a), new Shared(b));
+  var a = new owned MyClass(1);
+  var b = new shared MyClass(2);
+  var c = new owned MyClass(3);
+  var d = new shared MyClass(4);
+  var r = new R5(a, b);
+  var cc = new unmanaged C5(c, d);
   delete cc;
 }
 proc test6a() {
@@ -45,12 +42,12 @@ proc test6a() {
   delete cc;
 }
 proc test6b() {
-  var a = new MyClass(1);
-  var b = new MyClass(2);
-  var c = new MyClass(3);
-  var d = new MyClass(4);
-  var r = new R6(new Owned(a), new Shared(b));
-  var cc = new unmanaged C6(new Owned(a), new Shared(b));
+  var a = new owned MyClass(1);
+  var b = new shared MyClass(2);
+  var c = new owned MyClass(3);
+  var d = new shared MyClass(4);
+  var r = new R6(a, b);
+  var cc = new unmanaged C6(c, d);
   delete cc;
 }
 

--- a/test/classes/ferguson/delete-free/owned-shared-fields2.future
+++ b/test/classes/ferguson/delete-free/owned-shared-fields2.future
@@ -1,1 +1,0 @@
-bug: errors with records containing Owned

--- a/test/classes/ferguson/override-intents.chpl
+++ b/test/classes/ferguson/override-intents.chpl
@@ -1,0 +1,229 @@
+// This test verifies expected compilation errors for
+// overrides with differing intent.
+
+class Parent {
+  proc in_in              (in arg:string) { }
+  proc in_out             (in arg:string) { }
+  proc in_inout           (in arg:string) { }
+  proc in_const           (in arg:string) { }
+  proc in_const_in        (in arg:string) { }
+  proc in_ref             (in arg:string) { }
+  proc in_const_ref       (in arg:string) { }
+  proc in_blank           (in arg:string) { }
+ 
+  proc out_in             (out arg:string) { }
+  proc out_out            (out arg:string) { }
+  proc out_inout          (out arg:string) { }
+  proc out_const          (out arg:string) { }
+  proc out_const_in       (out arg:string) { }
+  proc out_ref            (out arg:string) { }
+  proc out_const_ref      (out arg:string) { }
+  proc out_blank          (out arg:string) { }
+ 
+  proc inout_in           (inout arg:string) { }
+  proc inout_out          (inout arg:string) { }
+  proc inout_inout        (inout arg:string) { }
+  proc inout_const        (inout arg:string) { }
+  proc inout_const_in     (inout arg:string) { }
+  proc inout_ref          (inout arg:string) { }
+  proc inout_const_ref    (inout arg:string) { }
+  proc inout_blank        (inout arg:string) { }
+
+  proc const_in           (const arg:string) { }
+  proc const_out          (const arg:string) { }
+  proc const_inout        (const arg:string) { }
+  proc const_const        (const arg:string) { }
+  proc const_const_in     (const arg:string) { }
+  proc const_ref          (const arg:string) { }
+  proc const_const_ref    (const arg:string) { }
+  proc const_blank        (const arg:string) { }
+
+  proc const_in_in        (const in arg:string) { }
+  proc const_in_out       (const in arg:string) { }
+  proc const_in_inout     (const in arg:string) { }
+  proc const_in_const     (const in arg:string) { }
+  proc const_in_const_in  (const in arg:string) { }
+  proc const_in_ref       (const in arg:string) { }
+  proc const_in_const_ref (const in arg:string) { }
+  proc const_in_blank     (const in arg:string) { }
+
+  proc ref_in             (ref arg:string) { }
+  proc ref_out            (ref arg:string) { }
+  proc ref_inout          (ref arg:string) { }
+  proc ref_const          (ref arg:string) { }
+  proc ref_const_in       (ref arg:string) { }
+  proc ref_ref            (ref arg:string) { }
+  proc ref_const_ref      (ref arg:string) { }
+  proc ref_blank          (ref arg:string) { }
+
+  proc const_ref_in       (const ref arg:string) { }
+  proc const_ref_out      (const ref arg:string) { }
+  proc const_ref_inout    (const ref arg:string) { }
+  proc const_ref_const    (const ref arg:string) { }
+  proc const_ref_const_in (const ref arg:string) { }
+  proc const_ref_ref      (const ref arg:string) { }
+  proc const_ref_const_ref(const ref arg:string) { }
+  proc const_ref_blank    (const ref arg:string) { }
+
+  proc blank_in           (arg:string) { }
+  proc blank_out          (arg:string) { }
+  proc blank_inout        (arg:string) { }
+  proc blank_const        (arg:string) { }
+  proc blank_const_in     (arg:string) { }
+  proc blank_ref          (arg:string) { }
+  proc blank_const_ref    (arg:string) { }
+  proc blank_blank        (arg:string) { }
+}
+
+class Child : Parent {
+  override proc in_in(in arg:string) { }
+  override proc in_out(out arg:string) { }                  // not overriding
+  override proc in_inout(inout arg:string) { }              // not overriding
+  override proc in_const(const arg:string) { }              // intent error
+  override proc in_const_in(const in arg:string) { }        // intent error
+  override proc in_ref(ref arg:string) { }                  // not overriding
+  override proc in_const_ref(const ref arg:string) { }      // not overriding
+  override proc in_blank(arg:string) { }                    // intent error
+ 
+  override proc out_in(in arg:string) { }                   // not overriding
+  override proc out_out(out arg:string) { }                 // 
+  override proc out_inout(inout arg:string) { }             // intent error
+  override proc out_const(const arg:string) { }             // not overriding
+  override proc out_const_in(const in arg:string) { }       // not overriding
+  override proc out_ref(ref arg:string) { }                 // intent error
+  override proc out_const_ref(const ref arg:string) { }     // intent error
+  override proc out_blank(arg:string) { }                   // not overriding
+
+  override proc inout_in(in arg:string) { }                 // not overriding
+  override proc inout_out(out arg:string) { }               // intent error
+  override proc inout_inout(inout arg:string) { }           // 
+  override proc inout_const(const arg:string) { }           // not overriding
+  override proc inout_const_in(const in arg:string) { }     // not overriding
+  override proc inout_ref(ref arg:string) { }               // intent error
+  override proc inout_const_ref(const ref arg:string) { }   // intent error
+  override proc inout_blank(arg:string) { }                 // not overriding
+
+  override proc const_in(in arg:string) { }                 // intent error
+  override proc const_out(out arg:string) { }               // not overriding
+  override proc const_inout(inout arg:string) { }           // not overriding
+  override proc const_const(const arg:string) { }           //
+  override proc const_const_in(const in arg:string) { }     // intent error
+  override proc const_ref(ref arg:string) { }               // not overriding
+  override proc const_const_ref(const ref arg:string) { }   // not overriding
+  override proc const_blank(arg:string) { }                 // intent error
+
+  override proc const_in_in(in arg:string) { }              // intent error
+  override proc const_in_out(out arg:string) { }            // not overriding
+  override proc const_in_inout(inout arg:string) { }        // not overriding
+  override proc const_in_const(const arg:string) { }        // intent error
+  override proc const_in_const_in(const in arg:string) { }  //
+  override proc const_in_ref(ref arg:string) { }            // not overriding
+  override proc const_in_const_ref(const ref arg:string) {} // not overriding
+  override proc const_in_blank(arg:string) { }              // intent error
+
+  override proc ref_in(in arg:string) { }                   // not overriding
+  override proc ref_out(out arg:string) { }                 // intent error
+  override proc ref_inout(inout arg:string) { }             // intent error
+  override proc ref_const(const arg:string) { }             // not overriding
+  override proc ref_const_in(const in arg:string) { }       // not overriding
+  override proc ref_ref(ref arg:string) { }                 //
+  override proc ref_const_ref(const ref arg:string) {}      // intent error
+  override proc ref_blank(arg:string) { }                   // not overriding
+
+  override proc const_ref_in(in arg:string) { }             // not overriding
+  override proc const_ref_out(out arg:string) { }           // intent error
+  override proc const_ref_inout(inout arg:string) { }       // intent error
+  override proc const_ref_const(const arg:string) { }       // not overriding
+  override proc const_ref_const_in(const in arg:string) { } // not overriding
+  override proc const_ref_ref(ref arg:string) { }           // intent error
+  override proc const_ref_const_ref(const ref arg:string) {}//
+  override proc const_ref_blank(arg:string) { }             // not overriding
+
+  override proc blank_in(in arg:string) { }                 // intent error
+  override proc blank_out(out arg:string) { }               // not overriding
+  override proc blank_inout(inout arg:string) { }           // not overriding
+  override proc blank_const(const arg:string) { }           // intent error
+  override proc blank_const_in(const in arg:string) { }     // intent error
+  override proc blank_ref(ref arg:string) { }               // not overriding
+  override proc blank_const_ref(const ref arg:string) {}    // not overriding
+  override proc blank_blank(arg:string) { }                 //
+}
+
+proc main() {
+  var x:Parent = new Child();
+
+  var s = "hi"*2;
+
+  x.in_in(s);
+  x.in_out(s);
+  x.in_inout(s);
+  x.in_const(s);
+  x.in_const_in(s);
+  x.in_ref(s);
+  x.in_const_ref(s);
+  x.in_blank(s);
+ 
+  x.out_in(s);
+  x.out_out(s);
+  x.out_inout(s);
+  x.out_const(s);
+  x.out_const_in(s);
+  x.out_ref(s);
+  x.out_const_ref(s);
+  x.out_blank(s);
+ 
+  x.inout_in(s);
+  x.inout_out(s);
+  x.inout_inout(s);
+  x.inout_const(s);
+  x.inout_const_in(s);
+  x.inout_ref(s);
+  x.inout_const_ref(s);
+  x.inout_blank(s);
+
+  x.const_in(s);
+  x.const_out(s);
+  x.const_inout(s);
+  x.const_const(s);
+  x.const_const_in(s);
+  x.const_ref(s);
+  x.const_const_ref(s);
+  x.const_blank(s);
+
+  x.const_in_in(s);
+  x.const_in_out(s);
+  x.const_in_inout(s);
+  x.const_in_const(s);
+  x.const_in_const_in(s);
+  x.const_in_ref(s);
+  x.const_in_const_ref(s);
+  x.const_in_blank(s);
+
+  x.ref_in(s);
+  x.ref_out(s);
+  x.ref_inout(s);
+  x.ref_const(s);
+  x.ref_const_in(s);
+  x.ref_ref(s);
+  x.ref_const_ref(s);
+  x.ref_blank(s);
+
+  x.const_ref_in(s);
+  x.const_ref_out(s);
+  x.const_ref_inout(s);
+  x.const_ref_const(s);
+  x.const_ref_const_in(s);
+  x.const_ref_ref(s);
+  x.const_ref_const_ref(s);
+  x.const_ref_blank(s);
+
+  x.blank_in(s);
+  x.blank_out(s);
+  x.blank_inout(s);
+  x.blank_const(s);
+  x.blank_const_in(s);
+  x.blank_ref(s);
+  x.blank_const_ref(s);
+  x.blank_blank(s);
+
+}

--- a/test/classes/ferguson/override-intents.compopts
+++ b/test/classes/ferguson/override-intents.compopts
@@ -1,0 +1,1 @@
+--override-checking

--- a/test/classes/ferguson/override-intents.good
+++ b/test/classes/ferguson/override-intents.good
@@ -1,75 +1,75 @@
-override-intents.chpl:82: error: Child.in_const conflicting intent for argument 'arg'
-override-intents.chpl:8: error: this function uses 'in' intent
-override-intents.chpl:82: error: this function uses 'const' intent
-override-intents.chpl:83: error: Child.in_const_in conflicting intent for argument 'arg'
-override-intents.chpl:9: error: this function uses 'in' intent
-override-intents.chpl:83: error: this function uses 'const in' intent
-override-intents.chpl:86: error: Child.in_blank conflicting intent for argument 'arg'
-override-intents.chpl:12: error: this function uses 'in' intent
-override-intents.chpl:86: error: this function uses default intent
-override-intents.chpl:90: error: Child.out_inout conflicting intent for argument 'arg'
-override-intents.chpl:16: error: this function uses 'out' intent
-override-intents.chpl:90: error: this function uses 'inout' intent
-override-intents.chpl:93: error: Child.out_ref conflicting intent for argument 'arg'
-override-intents.chpl:19: error: this function uses 'out' intent
-override-intents.chpl:93: error: this function uses 'ref' intent
-override-intents.chpl:94: error: Child.out_const_ref conflicting intent for argument 'arg'
-override-intents.chpl:20: error: this function uses 'out' intent
-override-intents.chpl:94: error: this function uses 'const ref' intent
-override-intents.chpl:98: error: Child.inout_out conflicting intent for argument 'arg'
-override-intents.chpl:24: error: this function uses 'inout' intent
-override-intents.chpl:98: error: this function uses 'out' intent
-override-intents.chpl:102: error: Child.inout_ref conflicting intent for argument 'arg'
-override-intents.chpl:28: error: this function uses 'inout' intent
-override-intents.chpl:102: error: this function uses 'ref' intent
-override-intents.chpl:103: error: Child.inout_const_ref conflicting intent for argument 'arg'
-override-intents.chpl:29: error: this function uses 'inout' intent
-override-intents.chpl:103: error: this function uses 'const ref' intent
-override-intents.chpl:106: error: Child.const_in conflicting intent for argument 'arg'
-override-intents.chpl:32: error: this function uses 'const' intent
-override-intents.chpl:106: error: this function uses 'in' intent
-override-intents.chpl:110: error: Child.const_const_in conflicting intent for argument 'arg'
-override-intents.chpl:36: error: this function uses 'const' intent
-override-intents.chpl:110: error: this function uses 'const in' intent
-override-intents.chpl:113: error: Child.const_blank conflicting intent for argument 'arg'
-override-intents.chpl:39: error: this function uses 'const' intent
-override-intents.chpl:113: error: this function uses default intent
-override-intents.chpl:115: error: Child.const_in_in conflicting intent for argument 'arg'
-override-intents.chpl:41: error: this function uses 'const in' intent
-override-intents.chpl:115: error: this function uses 'in' intent
-override-intents.chpl:118: error: Child.const_in_const conflicting intent for argument 'arg'
-override-intents.chpl:44: error: this function uses 'const in' intent
-override-intents.chpl:118: error: this function uses 'const' intent
-override-intents.chpl:122: error: Child.const_in_blank conflicting intent for argument 'arg'
-override-intents.chpl:48: error: this function uses 'const in' intent
-override-intents.chpl:122: error: this function uses default intent
-override-intents.chpl:125: error: Child.ref_out conflicting intent for argument 'arg'
-override-intents.chpl:51: error: this function uses 'ref' intent
-override-intents.chpl:125: error: this function uses 'out' intent
-override-intents.chpl:126: error: Child.ref_inout conflicting intent for argument 'arg'
-override-intents.chpl:52: error: this function uses 'ref' intent
-override-intents.chpl:126: error: this function uses 'inout' intent
-override-intents.chpl:130: error: Child.ref_const_ref conflicting intent for argument 'arg'
-override-intents.chpl:56: error: this function uses 'ref' intent
-override-intents.chpl:130: error: this function uses 'const ref' intent
-override-intents.chpl:134: error: Child.const_ref_out conflicting intent for argument 'arg'
-override-intents.chpl:60: error: this function uses 'const ref' intent
-override-intents.chpl:134: error: this function uses 'out' intent
-override-intents.chpl:135: error: Child.const_ref_inout conflicting intent for argument 'arg'
-override-intents.chpl:61: error: this function uses 'const ref' intent
-override-intents.chpl:135: error: this function uses 'inout' intent
-override-intents.chpl:138: error: Child.const_ref_ref conflicting intent for argument 'arg'
-override-intents.chpl:64: error: this function uses 'const ref' intent
-override-intents.chpl:138: error: this function uses 'ref' intent
-override-intents.chpl:142: error: Child.blank_in conflicting intent for argument 'arg'
-override-intents.chpl:68: error: this function uses default intent
-override-intents.chpl:142: error: this function uses 'in' intent
-override-intents.chpl:145: error: Child.blank_const conflicting intent for argument 'arg'
-override-intents.chpl:71: error: this function uses default intent
-override-intents.chpl:145: error: this function uses 'const' intent
-override-intents.chpl:146: error: Child.blank_const_in conflicting intent for argument 'arg'
-override-intents.chpl:72: error: this function uses default intent
-override-intents.chpl:146: error: this function uses 'const in' intent
+override-intents.chpl:82: error: Child.in_const conflicting intent for argument 'arg' in overriding method
+override-intents.chpl:8: error: base method uses 'in' intent
+override-intents.chpl:82: error: overriding method uses 'const' intent
+override-intents.chpl:83: error: Child.in_const_in conflicting intent for argument 'arg' in overriding method
+override-intents.chpl:9: error: base method uses 'in' intent
+override-intents.chpl:83: error: overriding method uses 'const in' intent
+override-intents.chpl:86: error: Child.in_blank conflicting intent for argument 'arg' in overriding method
+override-intents.chpl:12: error: base method uses 'in' intent
+override-intents.chpl:86: error: overriding method uses default intent
+override-intents.chpl:90: error: Child.out_inout conflicting intent for argument 'arg' in overriding method
+override-intents.chpl:16: error: base method uses 'out' intent
+override-intents.chpl:90: error: overriding method uses 'inout' intent
+override-intents.chpl:93: error: Child.out_ref conflicting intent for argument 'arg' in overriding method
+override-intents.chpl:19: error: base method uses 'out' intent
+override-intents.chpl:93: error: overriding method uses 'ref' intent
+override-intents.chpl:94: error: Child.out_const_ref conflicting intent for argument 'arg' in overriding method
+override-intents.chpl:20: error: base method uses 'out' intent
+override-intents.chpl:94: error: overriding method uses 'const ref' intent
+override-intents.chpl:98: error: Child.inout_out conflicting intent for argument 'arg' in overriding method
+override-intents.chpl:24: error: base method uses 'inout' intent
+override-intents.chpl:98: error: overriding method uses 'out' intent
+override-intents.chpl:102: error: Child.inout_ref conflicting intent for argument 'arg' in overriding method
+override-intents.chpl:28: error: base method uses 'inout' intent
+override-intents.chpl:102: error: overriding method uses 'ref' intent
+override-intents.chpl:103: error: Child.inout_const_ref conflicting intent for argument 'arg' in overriding method
+override-intents.chpl:29: error: base method uses 'inout' intent
+override-intents.chpl:103: error: overriding method uses 'const ref' intent
+override-intents.chpl:106: error: Child.const_in conflicting intent for argument 'arg' in overriding method
+override-intents.chpl:32: error: base method uses 'const' intent
+override-intents.chpl:106: error: overriding method uses 'in' intent
+override-intents.chpl:110: error: Child.const_const_in conflicting intent for argument 'arg' in overriding method
+override-intents.chpl:36: error: base method uses 'const' intent
+override-intents.chpl:110: error: overriding method uses 'const in' intent
+override-intents.chpl:113: error: Child.const_blank conflicting intent for argument 'arg' in overriding method
+override-intents.chpl:39: error: base method uses 'const' intent
+override-intents.chpl:113: error: overriding method uses default intent
+override-intents.chpl:115: error: Child.const_in_in conflicting intent for argument 'arg' in overriding method
+override-intents.chpl:41: error: base method uses 'const in' intent
+override-intents.chpl:115: error: overriding method uses 'in' intent
+override-intents.chpl:118: error: Child.const_in_const conflicting intent for argument 'arg' in overriding method
+override-intents.chpl:44: error: base method uses 'const in' intent
+override-intents.chpl:118: error: overriding method uses 'const' intent
+override-intents.chpl:122: error: Child.const_in_blank conflicting intent for argument 'arg' in overriding method
+override-intents.chpl:48: error: base method uses 'const in' intent
+override-intents.chpl:122: error: overriding method uses default intent
+override-intents.chpl:125: error: Child.ref_out conflicting intent for argument 'arg' in overriding method
+override-intents.chpl:51: error: base method uses 'ref' intent
+override-intents.chpl:125: error: overriding method uses 'out' intent
+override-intents.chpl:126: error: Child.ref_inout conflicting intent for argument 'arg' in overriding method
+override-intents.chpl:52: error: base method uses 'ref' intent
+override-intents.chpl:126: error: overriding method uses 'inout' intent
+override-intents.chpl:130: error: Child.ref_const_ref conflicting intent for argument 'arg' in overriding method
+override-intents.chpl:56: error: base method uses 'ref' intent
+override-intents.chpl:130: error: overriding method uses 'const ref' intent
+override-intents.chpl:134: error: Child.const_ref_out conflicting intent for argument 'arg' in overriding method
+override-intents.chpl:60: error: base method uses 'const ref' intent
+override-intents.chpl:134: error: overriding method uses 'out' intent
+override-intents.chpl:135: error: Child.const_ref_inout conflicting intent for argument 'arg' in overriding method
+override-intents.chpl:61: error: base method uses 'const ref' intent
+override-intents.chpl:135: error: overriding method uses 'inout' intent
+override-intents.chpl:138: error: Child.const_ref_ref conflicting intent for argument 'arg' in overriding method
+override-intents.chpl:64: error: base method uses 'const ref' intent
+override-intents.chpl:138: error: overriding method uses 'ref' intent
+override-intents.chpl:142: error: Child.blank_in conflicting intent for argument 'arg' in overriding method
+override-intents.chpl:68: error: base method uses default intent
+override-intents.chpl:142: error: overriding method uses 'in' intent
+override-intents.chpl:145: error: Child.blank_const conflicting intent for argument 'arg' in overriding method
+override-intents.chpl:71: error: base method uses default intent
+override-intents.chpl:145: error: overriding method uses 'const' intent
+override-intents.chpl:146: error: Child.blank_const_in conflicting intent for argument 'arg' in overriding method
+override-intents.chpl:72: error: base method uses default intent
+override-intents.chpl:146: error: overriding method uses 'const in' intent
 override-intents.chpl:80: error: Child.in_out override keyword present but no superclass method matches signature to override
 override-intents.chpl:81: error: Child.in_inout override keyword present but no superclass method matches signature to override
 override-intents.chpl:84: error: Child.in_ref override keyword present but no superclass method matches signature to override

--- a/test/classes/ferguson/override-intents.good
+++ b/test/classes/ferguson/override-intents.good
@@ -1,0 +1,104 @@
+override-intents.chpl:82: error: Child.in_const conflicting intent for argument 'arg'
+override-intents.chpl:8: error: this function uses 'in' intent
+override-intents.chpl:82: error: this function uses 'const' intent
+override-intents.chpl:83: error: Child.in_const_in conflicting intent for argument 'arg'
+override-intents.chpl:9: error: this function uses 'in' intent
+override-intents.chpl:83: error: this function uses 'const in' intent
+override-intents.chpl:86: error: Child.in_blank conflicting intent for argument 'arg'
+override-intents.chpl:12: error: this function uses 'in' intent
+override-intents.chpl:86: error: this function uses default intent
+override-intents.chpl:90: error: Child.out_inout conflicting intent for argument 'arg'
+override-intents.chpl:16: error: this function uses 'out' intent
+override-intents.chpl:90: error: this function uses 'inout' intent
+override-intents.chpl:93: error: Child.out_ref conflicting intent for argument 'arg'
+override-intents.chpl:19: error: this function uses 'out' intent
+override-intents.chpl:93: error: this function uses 'ref' intent
+override-intents.chpl:94: error: Child.out_const_ref conflicting intent for argument 'arg'
+override-intents.chpl:20: error: this function uses 'out' intent
+override-intents.chpl:94: error: this function uses 'const ref' intent
+override-intents.chpl:98: error: Child.inout_out conflicting intent for argument 'arg'
+override-intents.chpl:24: error: this function uses 'inout' intent
+override-intents.chpl:98: error: this function uses 'out' intent
+override-intents.chpl:102: error: Child.inout_ref conflicting intent for argument 'arg'
+override-intents.chpl:28: error: this function uses 'inout' intent
+override-intents.chpl:102: error: this function uses 'ref' intent
+override-intents.chpl:103: error: Child.inout_const_ref conflicting intent for argument 'arg'
+override-intents.chpl:29: error: this function uses 'inout' intent
+override-intents.chpl:103: error: this function uses 'const ref' intent
+override-intents.chpl:106: error: Child.const_in conflicting intent for argument 'arg'
+override-intents.chpl:32: error: this function uses 'const' intent
+override-intents.chpl:106: error: this function uses 'in' intent
+override-intents.chpl:110: error: Child.const_const_in conflicting intent for argument 'arg'
+override-intents.chpl:36: error: this function uses 'const' intent
+override-intents.chpl:110: error: this function uses 'const in' intent
+override-intents.chpl:113: error: Child.const_blank conflicting intent for argument 'arg'
+override-intents.chpl:39: error: this function uses 'const' intent
+override-intents.chpl:113: error: this function uses default intent
+override-intents.chpl:115: error: Child.const_in_in conflicting intent for argument 'arg'
+override-intents.chpl:41: error: this function uses 'const in' intent
+override-intents.chpl:115: error: this function uses 'in' intent
+override-intents.chpl:118: error: Child.const_in_const conflicting intent for argument 'arg'
+override-intents.chpl:44: error: this function uses 'const in' intent
+override-intents.chpl:118: error: this function uses 'const' intent
+override-intents.chpl:122: error: Child.const_in_blank conflicting intent for argument 'arg'
+override-intents.chpl:48: error: this function uses 'const in' intent
+override-intents.chpl:122: error: this function uses default intent
+override-intents.chpl:125: error: Child.ref_out conflicting intent for argument 'arg'
+override-intents.chpl:51: error: this function uses 'ref' intent
+override-intents.chpl:125: error: this function uses 'out' intent
+override-intents.chpl:126: error: Child.ref_inout conflicting intent for argument 'arg'
+override-intents.chpl:52: error: this function uses 'ref' intent
+override-intents.chpl:126: error: this function uses 'inout' intent
+override-intents.chpl:130: error: Child.ref_const_ref conflicting intent for argument 'arg'
+override-intents.chpl:56: error: this function uses 'ref' intent
+override-intents.chpl:130: error: this function uses 'const ref' intent
+override-intents.chpl:134: error: Child.const_ref_out conflicting intent for argument 'arg'
+override-intents.chpl:60: error: this function uses 'const ref' intent
+override-intents.chpl:134: error: this function uses 'out' intent
+override-intents.chpl:135: error: Child.const_ref_inout conflicting intent for argument 'arg'
+override-intents.chpl:61: error: this function uses 'const ref' intent
+override-intents.chpl:135: error: this function uses 'inout' intent
+override-intents.chpl:138: error: Child.const_ref_ref conflicting intent for argument 'arg'
+override-intents.chpl:64: error: this function uses 'const ref' intent
+override-intents.chpl:138: error: this function uses 'ref' intent
+override-intents.chpl:142: error: Child.blank_in conflicting intent for argument 'arg'
+override-intents.chpl:68: error: this function uses default intent
+override-intents.chpl:142: error: this function uses 'in' intent
+override-intents.chpl:145: error: Child.blank_const conflicting intent for argument 'arg'
+override-intents.chpl:71: error: this function uses default intent
+override-intents.chpl:145: error: this function uses 'const' intent
+override-intents.chpl:146: error: Child.blank_const_in conflicting intent for argument 'arg'
+override-intents.chpl:72: error: this function uses default intent
+override-intents.chpl:146: error: this function uses 'const in' intent
+override-intents.chpl:80: error: Child.in_out override keyword present but no superclass method matches signature to override
+override-intents.chpl:81: error: Child.in_inout override keyword present but no superclass method matches signature to override
+override-intents.chpl:84: error: Child.in_ref override keyword present but no superclass method matches signature to override
+override-intents.chpl:85: error: Child.in_const_ref override keyword present but no superclass method matches signature to override
+override-intents.chpl:88: error: Child.out_in override keyword present but no superclass method matches signature to override
+override-intents.chpl:91: error: Child.out_const override keyword present but no superclass method matches signature to override
+override-intents.chpl:92: error: Child.out_const_in override keyword present but no superclass method matches signature to override
+override-intents.chpl:95: error: Child.out_blank override keyword present but no superclass method matches signature to override
+override-intents.chpl:97: error: Child.inout_in override keyword present but no superclass method matches signature to override
+override-intents.chpl:100: error: Child.inout_const override keyword present but no superclass method matches signature to override
+override-intents.chpl:101: error: Child.inout_const_in override keyword present but no superclass method matches signature to override
+override-intents.chpl:104: error: Child.inout_blank override keyword present but no superclass method matches signature to override
+override-intents.chpl:107: error: Child.const_out override keyword present but no superclass method matches signature to override
+override-intents.chpl:108: error: Child.const_inout override keyword present but no superclass method matches signature to override
+override-intents.chpl:111: error: Child.const_ref override keyword present but no superclass method matches signature to override
+override-intents.chpl:112: error: Child.const_const_ref override keyword present but no superclass method matches signature to override
+override-intents.chpl:116: error: Child.const_in_out override keyword present but no superclass method matches signature to override
+override-intents.chpl:117: error: Child.const_in_inout override keyword present but no superclass method matches signature to override
+override-intents.chpl:120: error: Child.const_in_ref override keyword present but no superclass method matches signature to override
+override-intents.chpl:121: error: Child.const_in_const_ref override keyword present but no superclass method matches signature to override
+override-intents.chpl:124: error: Child.ref_in override keyword present but no superclass method matches signature to override
+override-intents.chpl:127: error: Child.ref_const override keyword present but no superclass method matches signature to override
+override-intents.chpl:128: error: Child.ref_const_in override keyword present but no superclass method matches signature to override
+override-intents.chpl:131: error: Child.ref_blank override keyword present but no superclass method matches signature to override
+override-intents.chpl:133: error: Child.const_ref_in override keyword present but no superclass method matches signature to override
+override-intents.chpl:136: error: Child.const_ref_const override keyword present but no superclass method matches signature to override
+override-intents.chpl:137: error: Child.const_ref_const_in override keyword present but no superclass method matches signature to override
+override-intents.chpl:140: error: Child.const_ref_blank override keyword present but no superclass method matches signature to override
+override-intents.chpl:143: error: Child.blank_out override keyword present but no superclass method matches signature to override
+override-intents.chpl:144: error: Child.blank_inout override keyword present but no superclass method matches signature to override
+override-intents.chpl:147: error: Child.blank_ref override keyword present but no superclass method matches signature to override
+override-intents.chpl:148: error: Child.blank_const_ref override keyword present but no superclass method matches signature to override


### PR DESCRIPTION
Resolves #7894.

In investigating #7894, I eventually learned that the memory leak is due
to an inconsistent intent on an overridden method.

The issue is that fromutc had `in` intent in the TZInfo class but was
overridden to use default intent. That confused the compiler, since the
`in` intent now happens at the call site. The compiler ran the copy at
the call site (per the `in` intent) but the virtual method chosen didn't
delete the formal temp, leading to the memory leak.

This PR fixes that problem by making TZInfo.fromutc use the blank intent.

Then, it adds a compiler error for overriding when the intent doesn't
match and adds an ~~~exhausting~~~ exhaustive test of overridden intents.
Note that the error might be that an override isn't found (with
--override-checking) or an error from the new checking, depending on what
the compiler considered to be a "match".

- [x] full local testing

Reviewed by @daviditen - thanks!