### PR TITLE
Revert #10730 thanks to #10750

### DIFF
--- a/test/parallel/forall/task-private-vars/block.chpl
+++ b/test/parallel/forall/task-private-vars/block.chpl
@@ -22,8 +22,7 @@ proc nextLocalTaskCounter(hereId:int) {
 
 const MessageDom = {1..numMessages};
 const MessageSpace = MessageDom dmapped Block(MessageDom,
-                                            dataParTasksPerLocale = dptpl,
-     /* ensure determinism w.r.t. #10729 */ dataParIgnoreRunningTasks = true);
+                                              dataParTasksPerLocale = dptpl);
 
 var MessageVisited: [MessageSpace] bool;
 


### PR DESCRIPTION
#10730 was applied to deal with #10729.
#10750 fixed #10729, so we do not need #10730 any longer.
Reverting #10730 should exercise the fix in #10750 just a bit more.