### PR TITLE
Revert "Time mergesort in sort performance testing"

### DIFF
--- a/test/library/packages/Sort/performance/performance.perfexecopts
+++ b/test/library/packages/Sort/performance/performance.perfexecopts
@@ -1,6 +1,5 @@
 --sorts='q' --M=24 --correctness=false            # quickSort
 --sorts='h' --M=24 --correctness=false            # heapSort
---sorts='m' --M=24 --correctness=false            # mergeSort
 --sorts='i' --M=12 --correctness=false            # insertionSort
 --sorts='s' --M=12 --correctness=false            # selectionSort
 --sorts='b' --M=12 --correctness=false            # bubbleSort

--- a/test/library/packages/Sort/performance/sorts-linearithmic.graph
+++ b/test/library/packages/Sort/performance/sorts-linearithmic.graph
@@ -1,6 +1,6 @@
-perfkeys: (seconds):, (seconds):, (seconds):
-files: quickSort.dat, heapSort.dat, mergeSort.dat
-graphkeys: quickSort, heapSort, mergeSort
+perfkeys: (seconds):, (seconds):
+files: quickSort.dat, heapSort.dat
+graphkeys: quickSort, heapSort
 graphtitle: Linearithmic sorts on 2^24 bytes of shuffled data
 ylabel: Time (seconds)
 


### PR DESCRIPTION
Reverts chapel-lang/chapel#10654

In reverting this PR, I'm turning mergesort performance testing back off because our current implementation is a bit of a space hog and this causes problems on chap04 that I didn't have time recently to address more directly (e.g., if I'm reading it right, I believe the wikipedia implementation of mergesort results in just a single copy of the input array).  I've made a placeholder for this in issue #10755.