### PR TITLE
Remove claim in documentation that mergesort is in-place

### DIFF
--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -582,7 +582,7 @@ proc binaryInsertionSort(Data: [?Dom] ?eltType, comparator:?rec=defaultComparato
 
 
 /*
-   Sort the 1D array `Data` in-place using a parallel merge sort algorithm.
+   Sort the 1D array `Data` using a parallel merge sort algorithm.
 
    :arg Data: The array to be sorted
    :type Data: [] `eltType`


### PR DESCRIPTION
This one is definitely not and, in general, this isn't possible with mergesort so far as I understand it.

Tested by running on test/library/packages/Sort and by building and inspecting the documents.

Resolves #10502
