### PR TITLE
Handle autoDestroy of void shadow variables

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -8871,12 +8871,19 @@ static void cleanupVoidVarsAndFields() {
           call->remove();
         }
       }
-      if (call->isResolved()) {
+      if (FnSymbol* fn = call->resolvedFunction()) {
+        bool seenVoid = false;
         // Remove actual arguments that are void from function calls
         for_actuals(actual, call) {
           if (isVoidOrVoidTupleType(actual->typeInfo())) {
             actual->remove();
+            seenVoid = true;
           }
+        }
+        if (seenVoid && fn->hasFlag(FLAG_AUTO_DESTROY_FN)) {
+          INT_ASSERT(call->numActuals() == 0);
+          // A 0-arg call to autoDestroy would upset later passes.
+          call->remove();
         }
       }
     }

--- a/compiler/resolution/implementForallIntents.cpp
+++ b/compiler/resolution/implementForallIntents.cpp
@@ -1974,11 +1974,6 @@ static void insertInitialization(BlockStmt* destBlock,
   insertInitialization(destBlock, destVar, initTemp);
 }
 
-// unused
-//static void insertInitialization(ShadowVarSymbol* destVar, Expr* srcExpr) {
-//  insertInitialization(destVar->initBlock(), destVar, srcExpr);
-//}
-
 // insertDeinitialization() flavors: as (a1) or (a2) above
 
 static void insertDeinitialization(BlockStmt* destBlock, Symbol* destVar) {

--- a/compiler/resolution/lowerForalls.cpp
+++ b/compiler/resolution/lowerForalls.cpp
@@ -439,6 +439,10 @@ static VarSymbol* createCurrTPV(ShadowVarSymbol* TPV) {
 static void addDefAndMap(Expr* aInit, SymbolMap& map, ShadowVarSymbol* svar,
                          VarSymbol* currVar)
 {
+  if (currVar->type == dtVoid) {
+    INT_ASSERT(currVar->firstSymExpr() == NULL);
+    return;
+  }
   aInit->insertBefore(new DefExpr(currVar));
   map.put(svar, currVar);
 }


### PR DESCRIPTION
The tests with user-level implementation of partial reductions
have reduce accumulation state of void type. This results
in insertion of autoDestroys with void arguments, since #10724.
cleanupVoidVarsAndFields() then remove that argument, making it
a 0-argument call. This was unexpected and caused a crash in the
parallel pass when compiling reductions/partial/DR-with-shaped-exprs
under numa.

This PR extends cleanupVoidVarsAndFields() to remove such 0-arg
autoDestroy calls.

It would be better not to add the autoDestroy call in the first place.
However, when this is done in implementForallIntents.cpp /
insertDeinitialization(), we do not know the types yet.

While there, remove commented-out code left over from #10724.
Also, during lowerForallStmtsInline(), do not insert a DefExpr
for shadow variables of void types.

This resolves the failure in reductions/partial/DR-with-shaped-exprs
in nightly numa testing.

Testing: linux64, numa.
