### PR TITLE
build_configs: GBT post-merge review comments (PR #10663)

### DIFF
--- a/util/build_configs/setenv-example-3.bash
+++ b/util/build_configs/setenv-example-3.bash
@@ -53,14 +53,14 @@ if [ -z "$BUILD_CONFIGS_CALLBACK" ]; then
 
     export CHPL_HOST_PLATFORM=cray-xc
     export CHPL_TARGET_PLATFORM=cray-xc
-##  export CHPL_REGEXP=re2      # re2 required for mason
+    export CHPL_REGEXP=re2      # re2 required for mason
     export CHPL_LOCAL_MODEL=flat
     export CHPL_COMM=none
-##  export CHPL_COMM_SUBSTRATE=none
-##  export CHPL_TASKS=qthreads
+    export CHPL_COMM_SUBSTRATE=none
+    export CHPL_TASKS=qthreads
     export CHPL_LAUNCHER=none
-##  export CHPL_LLVM=none       # llvm requires py27 and cmake
-##  export CHPL_AUX_FILESYS=none
+    export CHPL_LLVM=none       # llvm requires py27 and cmake
+    export CHPL_AUX_FILESYS=none
 
     # More CPUs --> faster make. Or, unset CHPL_MAKE_MAX_CPU_COUNT to use all CPUs.
 

--- a/util/build_configs/setenv-example-3.bash
+++ b/util/build_configs/setenv-example-3.bash
@@ -62,6 +62,9 @@ if [ -z "$BUILD_CONFIGS_CALLBACK" ]; then
 ##  export CHPL_LLVM=none       # llvm requires py27 and cmake
 ##  export CHPL_AUX_FILESYS=none
 
+    # More CPUs --> faster make. Or, unset CHPL_MAKE_MAX_CPU_COUNT to use all CPUs.
+
+    export CHPL_MAKE_MAX_CPU_COUNT=${CHPL_MAKE_MAX_CPU_COUNT:-4}
 
     # Show the initial/default Chapel build config with printchplenv
 
@@ -208,8 +211,6 @@ else
         unload_module_re -v -network- craype-
         load_module $target
     }
-
-    export CHPL_MAKE_MAX_CPU_COUNT=24
 
     # ---
 


### PR DESCRIPTION
* setenv-example-3 (for Cray) should not use all the CPUs
  At least, not by default
* setenv-example-3 should set most CHPL_* default values
  Especially REGEXP=re2 

