### PR TITLE
Fix lifetime checking error with in intents

### DIFF
--- a/compiler/resolution/lifetime.cpp
+++ b/compiler/resolution/lifetime.cpp
@@ -356,10 +356,10 @@ static void markArgumentsReturnScope(FnSymbol* fn) {
       // OK
     } else {
       // Set it to the default
-      if (anyReturnScope)
-        formal->addFlag(FLAG_SCOPE);
-      else
+      if (anyReturnScope == false || formal->originalIntent == INTENT_IN)
         formal->addFlag(FLAG_RETURN_SCOPE);
+      else
+        formal->addFlag(FLAG_SCOPE);
     }
   }
 

--- a/test/classes/delete-free/lifetimes/in-intent-returned.chpl
+++ b/test/classes/delete-free/lifetimes/in-intent-returned.chpl
@@ -1,0 +1,24 @@
+pragma "safe"
+module InIntentReturn {
+  
+  class C { }
+
+  record R { }
+
+  record D {
+    var field:shared C;
+  }
+
+  proc R.doit(in dt: D): D {
+    return dt;
+  }
+
+
+  proc main() {
+    var r = new R();
+    var start = new D();
+    var other = r.doit(start);
+    writeln(other);
+    writeln(start);
+  }
+}

--- a/test/classes/delete-free/lifetimes/in-intent-returned.good
+++ b/test/classes/delete-free/lifetimes/in-intent-returned.good
@@ -1,0 +1,2 @@
+(field = nil)
+(field = nil)


### PR DESCRIPTION
Resolves #10746.

This PR marks `in` intent arguments as return scope,
since they are owned by the called function and can always be returned
(they are more similar to local variables).

- [x] full local testing

Reviewed by @vasslitvinov - thanks!