### PR TITLE
Update NetCDF.skipif to avoid cray-xc and whiteboxes

### DIFF
--- a/test/library/packages/NetCDF.skipif
+++ b/test/library/packages/NetCDF.skipif
@@ -7,7 +7,16 @@
 # Note that if the dynamic library is found, this test assumes that the
 # header and static library are available.
 
+# On systems with Cray modules, this finds the library inside a module even
+# though the module is not loaded.  Avoid those "false positive" systems.
+
 from __future__ import print_function
 from ctypes.util import find_library
+from os import getenv, path
+from socket import gethostname
 
-print(find_library('netcdf') is None)
+foundLib = not (find_library('netcdf') is None)
+isXC = getenv('CHPL_TARGET_PLATFORM') == 'cray-xc'
+isWhitebox = gethostname().startswith("esxbld");
+
+print((not foundLib) or isXC or isWhitebox)


### PR DESCRIPTION
The modules on Cray systems and whiteboxes trick the python find_library()
call into thinking the netcdf library is available even when the proper module
is not loaded.  Skip these tests on those systems.