### PR TITLE
Reduce rfDone contention in comm=ugni.

### DIFF
--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -904,15 +904,6 @@ void rf_done_ensure_pool_partition(void) {
     rf_done_prt_hi = ((prt == nPrts - 1)
                       ? RF_DONE_NUM_POOLS - 1
                       : CEIL_X_DIV_Y((prt + 1) * RF_DONE_NUM_POOLS, nPrts) - 1);
-#if 0
-    if (chpl_nodeID == 0) {
-      printf("rf_done_ensure_pool_partition(): "
-             "thr %d, nPrts %d, prt %d, lo %d, hi %d\n",
-             (int) my_thread_idx(), (int) nPrts, (int) prt,
-             (int) rf_done_prt_lo, (int) rf_done_prt_hi);
-      fflush(stdout);
-    }
-#endif
   }
 
 #undef CEIL_X_DIV_Y

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -858,30 +858,27 @@ static gni_mem_handle_t* rf_mdh_map;    // all locales' remote fork space mdhs
 //
 // To ensure that these are in registered memory we allocate them up
 // front, with a fixed size, through the registered-memory manager.
-// There are RF_DONE_NUM_POOLS pools, with RF_DONE_NUM_PER_POOL in
-// each one.  The requirements/constraints on these values are as
-// follows.
-//   - RF_DONE_NUM_POOLS limits the allocate/free concurrency, so it
-//     should be at least as large as the number of hardware threads
-//     in use.
-//   - We emulate an unsigned mod by RF_DONE_NUM_POOLS by means of
-//     & (RF_DONE_NUM_POOLS - 1), so that has to be a power of 2.
-//   - The code does divides and mods with RF_DONE_NUM_PER_POOL, so
-//     for performance that should be a power of 2.
+// There are RF_DONE_NUM_PER_THREAD * (chpl_task_getMaxPar()+1) of
+// them.  The only requirement/constraint this value is:
 //   - It's possible (though highly unlikely) that every task in the
 //     program could need one of these at the same time, and we can't
 //     get more dynamically, so we potentially need a lot of them: the
-//     product of RF_DONE_NUM_POOLS and RF_DONE_NUM_PER_POOL should be
-//     "large".  Fortunately they're small, so over-provisioning isn't
-//     particularly costly.
+//     value of RF_DONE_NUM_PER_THREAD should be "large" with respect
+//     to the likely maximum number of tasks with active on-stmts.
+//     Fortunately these are small, so over-provisioning isn't very
+//     costly.
 //
-#define RF_DONE_NUM_POOLS 512
-#define RF_DONE_NUM_PER_POOL 32
+#define RF_DONE_NUM_PER_THREAD 1024
 
 typedef int64_t rf_done_t;
 
-static rf_done_t (*rf_done_pool)[RF_DONE_NUM_PER_POOL];
-static atomic_bool rf_done_pool_lock[RF_DONE_NUM_POOLS][RF_DONE_NUM_PER_POOL];
+static int rf_done_num;
+static rf_done_t* rf_done_pool;
+static __thread int rf_done_private_prt;
+static __thread int rf_done_prt_lo = -1;
+static __thread int rf_done_prt_hi = -1;
+
+static atomic_bool* rf_done_pool_lock;
 
 
 //
@@ -4566,83 +4563,78 @@ void rf_done_pre_init(void)
   chpl_comm_mem_reg_add_request(FORK_REQ_BUFS_PER_LOCALE
                                 * sizeof(fork_reqs_free[0]));
 
-  chpl_comm_mem_reg_add_request(RF_DONE_NUM_POOLS
-                                * sizeof(rf_done_pool[0]));
+  rf_done_num = RF_DONE_NUM_PER_THREAD * (chpl_task_getMaxPar() + 1);
+  chpl_comm_mem_reg_add_request(rf_done_num * sizeof(rf_done_pool[0]));
 }
 
 
 static
 void rf_done_init(void)
 {
-  int i, j;
+  int i;
 
-  if (RF_DONE_NUM_POOLS * RF_DONE_NUM_PER_POOL
-      < comm_dom_cnt_max * FORK_REQ_BUFS_PER_CD)
-    chpl_warning("(RF_DONE_NUM_POOLS * RF_DONE_NUM_PER_POOL "
-                 "< comm_dom_cnt_max * FORK_REQ_BUFS_PER_CD) "
+  if (rf_done_num < comm_dom_cnt_max * FORK_REQ_BUFS_PER_CD)
+    chpl_warning("(RF_DONE_NUM < comm_dom_cnt_max * FORK_REQ_BUFS_PER_CD) "
                  "may lead to hangs",
                  0, 0);
 
   // Must be directly communicable without proxy.
-  rf_done_pool = (rf_done_t (*)[RF_DONE_NUM_PER_POOL])
-                 chpl_comm_mem_reg_allocMany(RF_DONE_NUM_POOLS,
+  rf_done_pool = (rf_done_t*)
+                 chpl_comm_mem_reg_allocMany(rf_done_num,
                                              sizeof(rf_done_pool[0]),
                                              CHPL_RT_MD_COMM_PER_LOC_INFO,
                                              0, 0);
 
-  for (i = 0; i < RF_DONE_NUM_POOLS; i++) {
-    for (j = 0; j < RF_DONE_NUM_PER_POOL - 1; j++) {
-      rf_done_pool[i][j] = 0;
-      atomic_init_bool(&rf_done_pool_lock[i][j], false);
-    }
+  for (i = 0; i < rf_done_num; i++) {
+    rf_done_pool[i] = -1;
   }
 }
 
 
-static __thread int rf_done_private_prt;
+static
+pthread_once_t rf_done_init_locks_once = PTHREAD_ONCE_INIT;
+
+static
+void rf_done_init_locks(void)
+{
+  const int num_locks = rf_done_prt_hi - rf_done_prt_lo;
+
+  rf_done_pool_lock = ((atomic_bool*)
+                       chpl_mem_allocMany(num_locks,
+                                          sizeof(rf_done_pool_lock[0]),
+                                          CHPL_RT_MD_COMM_PER_LOC_INFO,
+                                          0, 0));
+  for (int i = 0; i < num_locks; i++) {
+    atomic_init_bool(&rf_done_pool_lock[i], false);
+  }
+}
+
 
 static
 inline
 rf_done_t* rf_done_alloc(void)
 {
-  static __thread int prt_lo = -1;
-  static __thread int prt_hi = -1;
   static __thread int last_i = -1;
-  static __thread int last_j = -1;
 
-#define CEIL_X_DIV_Y(x, y) (1 + ((x) - 1) / (y))
-
-  if (prt_lo == -1) {
+  if (rf_done_prt_lo == -1) {
     const int nPrts = chpl_task_getMaxPar() + 1;
     const int tidx = my_thread_idx();
     int prt;
-    if (tidx < nPrts - 1) {
-      prt = tidx;
-      rf_done_private_prt = 1;
-    } else {
+
+    rf_done_private_prt = 1;
+    if ((prt = tidx) >= nPrts) {
       prt = nPrts - 1;
       rf_done_private_prt = 0;
     }
-    prt_lo = ((prt == 0)
-              ? 0
-              : CEIL_X_DIV_Y(prt * RF_DONE_NUM_POOLS, nPrts));
-    prt_hi = ((prt == nPrts - 1)
-              ? RF_DONE_NUM_POOLS - 1
-              : CEIL_X_DIV_Y((prt + 1) * RF_DONE_NUM_POOLS, nPrts) - 1);
 
-    if (rf_done_private_prt) {
-      for (int i = prt_lo; i < prt_hi; i++) {
-        for (int j = 0; j < RF_DONE_NUM_PER_POOL; j ++) {
-          rf_done_pool[i][j] = -1;
-        }
-      }
+    rf_done_prt_lo = prt * RF_DONE_NUM_PER_THREAD;
+    rf_done_prt_hi = rf_done_prt_lo + RF_DONE_NUM_PER_THREAD - 1;
+    last_i = rf_done_prt_lo;
+
+    if (!rf_done_private_prt) {
+      pthread_once(&rf_done_init_locks_once, rf_done_init_locks);
     }
-
-    last_i = prt_lo;
-    last_j = 0;
   }
-
-#undef CEIL_X_DIV_Y
 
   //
   // Cycle through our partition of the pools and find one that contains
@@ -4652,40 +4644,29 @@ rf_done_t* rf_done_alloc(void)
   // we ever do, we'll have to revisit how we've approached this.
   //
   int i = last_i;
-  int j = last_j;
 
   if (rf_done_private_prt) {
     do {
-      if (++j >= RF_DONE_NUM_PER_POOL) {
-        j = 0;
-        if (++i >= prt_hi)
-          i = prt_lo;
+      if (++i > rf_done_prt_hi) {
+        i = rf_done_prt_lo;
+        if (i == last_i)
+          CHPL_INTERNAL_ERROR("rf_done_pool empty");
       }
-
-      if (i == last_i && j == last_j) {
-        CHPL_INTERNAL_ERROR("rf_done_pool empty");
-      }
-    } while (rf_done_pool[i][j] != -1);
+    } while (rf_done_pool[i] != -1);
   } else {
     do {
-      if (++j >= RF_DONE_NUM_PER_POOL) {
-        j = 0;
-        if (++i >= prt_hi)
-          i = prt_lo;
+      if (++i > rf_done_prt_hi) {
+        i = rf_done_prt_lo;
+        if (i == last_i)
+          CHPL_INTERNAL_ERROR("rf_done_pool empty");
       }
-
-      if (i == last_i && j == last_j) {
-        CHPL_INTERNAL_ERROR("rf_done_pool empty");
-      }
-    } while (atomic_exchange_bool(&rf_done_pool_lock[i][j], true));
+    } while (atomic_exchange_bool(&rf_done_pool_lock[i - rf_done_prt_lo],
+                                  true));
   }
 
   last_i = i;
-  last_j = j;
 
-  rf_done_pool[i][j] = 0;
-
-  return &rf_done_pool[i][j];
+  return &rf_done_pool[i];
 }
 
 
@@ -4693,13 +4674,11 @@ static
 inline
 void rf_done_free(rf_done_t* rf_done_p)
 {
-  const int linearized_ij = rf_done_p - &rf_done_pool[0][0];
-  const int i = linearized_ij / RF_DONE_NUM_PER_POOL;
-  const int j = linearized_ij % RF_DONE_NUM_PER_POOL;
+  const int i = rf_done_p - &rf_done_pool[0];
   if (rf_done_private_prt)
-    rf_done_pool[i][j] = -1;
+    rf_done_pool[i] = -1;
   else
-    atomic_store_bool(&rf_done_pool_lock[i][j], false);
+    atomic_store_bool(&rf_done_pool_lock[i - rf_done_prt_lo], false);
 }
 
 

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -120,20 +120,9 @@ static chpl_bool debug_exiting = false;
 
 static pthread_t proc_thread_id;
 
-static __thread uint32_t thread_idx      = ~(uint32_t) 0;
-static atomic_uint_least32_t next_thread_idx;
-#define _DBG_NEXT_THREAD_IDX() \
-        atomic_fetch_add_uint_least32_t(&next_thread_idx, 1)
-
 #define _DBG_P(dbg_do, f, ...)                                          \
         do {                                                            \
           if (dbg_do) {                                                 \
-            if (thread_idx == ~(uint32_t) 0) {                          \
-              thread_idx = _DBG_NEXT_THREAD_IDX();                      \
-              fprintf(debug_file,                                       \
-                      "DBG: %s:%d (%d): thread_id %" PRIu32 "\n",       \
-                      __FILE__, __LINE__, chpl_nodeID, thread_idx);     \
-            }                                                           \
             fprintf(debug_file, "DBG: %s:%d" f "\n",                    \
                     __FILE__, __LINE__, ## __VA_ARGS__);                \
           }                                                             \
@@ -147,12 +136,12 @@ static atomic_uint_least32_t next_thread_idx;
         _DBG_P(_DBG_DO(flg),                                            \
                " (%d/%s/%d): " f,                                       \
                chpl_nodeID, task_id(cd != NULL && cd->firmly_bound),    \
-               (int) thread_idx, ## __VA_ARGS__)
+               (int) my_thread_idx(), ## __VA_ARGS__)
 #define DBG_P_LPS(flg, f, li, cdi, rbi, seq, ...)                       \
         _DBG_P(_DBG_DO(flg),                                            \
                " (%d/%s/%d) %d/%d/%d <%" PRIu64 ">: " f,                \
                chpl_nodeID, task_id(cd != NULL && cd->firmly_bound),    \
-               (int) thread_idx,                                        \
+               (int) my_thread_idx(),                                   \
                (int) li, cdi, rbi, seq, ## __VA_ARGS__)
 
 #define CHPL_INTERNAL_ERROR(msg)                                        \
@@ -448,6 +437,20 @@ static inline void perfstats_add_post(gni_post_descriptor_t* post_desc) {
                    what, (int) rc, _cqeBuf);                            \
           CHPL_INTERNAL_ERROR(_gcefBuf);                                \
         } while (0)
+
+
+//
+// Threads.
+//
+static atomic_int_least64_t next_thread_idx;
+
+static inline
+int_least64_t my_thread_idx(void) {
+  static __thread int_least64_t tidx = -1;
+  if (tidx == -1)
+    tidx = atomic_fetch_add_int_least64_t(&next_thread_idx, 1);
+  return tidx;
+}
 
 
 //
@@ -1552,7 +1555,6 @@ static void dbg_init(void)
 {
   const char* ev;
 
-  atomic_init_uint_least32_t(&next_thread_idx, 0);
   proc_thread_id = pthread_self();
 
   debug_flag = (uint64_t) chpl_env_rt_get_int("COMM_UGNI_DEBUG", 0);
@@ -1777,6 +1779,8 @@ int32_t chpl_comm_getMaxThreads(void)
 
 void chpl_comm_init(int *argc_p, char ***argv_p)
 {
+  atomic_init_int_least64_t(&next_thread_idx, 0);
+
   // Sanity check: a maximal small call fits into a fork_t
   assert(sizeof(fork_small_call_info_t)+MAX_SMALL_CALL_PAYLOAD
          <= sizeof(fork_t));


### PR DESCRIPTION
The rf_done pools provide guaranteed-registered completion indicators
for remote executeOns, in the event that the default stack-based ones
are found not to be in registered memory.  Here, reduce contention in
those pools.

Instead of having all the pthreads contend across multiple pools of many
rf_done indicators, here we flatten the indicators into a simple array
and then chunk the array such that each worker pthread has a private
chunk of indicators and doesn't have to lock, while other pthreads share
a single chunk and do have to lock.

The performance impact of this isn't large, varies with configuration,
and only shows in performance/comm/low-level/many-to-one (op=opFastOn).
With a hugepage module loaded, so that stack-based rf_done indicators
are always in registered memory, this has no effect.  This is expected,
because then we never have to allocate from the rf_done pool.  But in
minimal-registration mode, without a hugepage module loaded, we always
allocate from the pool, since the stack-based rf_done indicators are
never in registered memory.  In that case best performance actually
comes when the stack-based rf_done PR (#10728) is removed and this
change (appropriately rebased) is made in its place.  That seems to
produce about a 15% improvement in fastOn performance.  Applying this
change on top of #10728 gives only about a 3-4% improvement, probably
because in that case we still have the overhead of looking up the
rf_done memory region in the AM handler.

Although in normal configurations this gives no benefit it still seems
worth merging, both for the improvement in the minimal-registration
case and for the example of contention reduction by chunking a shared
resource across the workers.

This closes #9427.