### PR TITLE
Un-future local_privatization.future

### DIFF
--- a/test/multilocale/local/sungeun/local_privatization.future
+++ b/test/multilocale/local/sungeun/local_privatization.future
@@ -1,6 +1,0 @@
-bug: Variable declarations within local blocks for types with privatized data result in seg fault or "cannot access remote data in local block" error.
-
-This currently fails because privatization requires communication.
-Specifically, chpl_localeTree which is used to fan out the privatized
-data has locales for its fields.  Access to these locales require
-communication which is not generated for local blocks.


### PR DESCRIPTION
This test actually doesn't create a privatized type because
non-distributed arrays aren't privatized. Instead, it was
failing because locale.id was generating communication.

After PR #10773, it now passes, but the test name should arguably be
changed.

Trivial test change, not reviewed.