### PR TITLE
Initializes sizesPerDim only if usePollyArrayIndex

### DIFF
--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1122,8 +1122,10 @@ module DefaultRectangular {
       computeFactoredOffs();
       const size = blk(1) * dom.dsiDim(1).length;
 
-      for param dim in 1..rank {
-       sizesPerDim(dim) = dom.dsiDim(dim).length;
+      if usePollyArrayIndex {
+        for param dim in 1..rank {
+         sizesPerDim(dim) = dom.dsiDim(dim).length;
+        }
       }
 
       // Allow DR array initialization to pass in existing data
@@ -1167,11 +1169,11 @@ module DefaultRectangular {
           var useOffset:int = 0;
           var useSizesPerDim = sizesPerDim;
 
-          if (usePollyArrayIndex) {
+          if usePollyArrayIndex {
             // Polly works better if we provide 0-based indices from the start.
             // So instead of using factoredOffs at the end, we initially subtract
             // the dimension offsets from the index subscripts beforehand.
-            if (!wantShiftedIndex) {
+            if !wantShiftedIndex {
              for param i in 1..rank do {
                 useInd(i) = chpl__idxToInt(useInd(i)) - chpl__idxToInt(off(i));
              }


### PR DESCRIPTION
PR #10727 added sizesPerDim to DefaultRectangular.  This field is only
used in an experimental Polly integration, which is enabled (for now)
with the config param usePollyArrayIndex.

After PR #10727, the test
`optimizations/remoteValueForwarding/serialization/domains`
failed due to an increase in communication when creating a
DefaultRectangular array. The new communication comes from
initializing sizesPerDim.

This PR puts the initialization of sizesPerDim under a conditional
checking usePollyArrayIndex, which resolves the problem
with that test.

If performance testing indicates it to be important, we will additionally
make sizesPerDim a void field in another PR. If sizesPerDim is used more
in the future, we can instead accept the increased communication
for this test.

- [x] full local testing

Reviewed by @benharsh - thanks!