### PR TITLE
Add checks at resolution for exporting functions that take or return strings

### DIFF
--- a/compiler/passes/checkResolved.cpp
+++ b/compiler/passes/checkResolved.cpp
@@ -44,6 +44,7 @@ static int isDefinedAllPaths(Expr* expr, Symbol* ret, RefSet& refs);
 static void checkReturnPaths(FnSymbol* fn);
 static void checkCalls();
 static void checkExternProcs();
+static void checkExportedProcs();
 
 
 static void
@@ -94,6 +95,7 @@ checkResolved() {
   checkCalls();
   checkConstLoops();
   checkExternProcs();
+  checkExportedProcs();
 }
 
 
@@ -500,4 +502,21 @@ static void checkExternProcs() {
   }
 }
 
+static void checkExportedProcs() {
+  forv_Vec(FnSymbol, fn, gFnSymbols) {
+    if (!fn->hasFlag(FLAG_EXPORT))
+      continue;
 
+    for_formals(formal, fn) {
+      if (formal->typeInfo() == dtString) {
+        USR_FATAL_CONT(fn, "exported procedures should not take arguments of "
+                       "type string, use c_string instead");
+      }
+    }
+
+    if (fn->retType == dtString) {
+      USR_FATAL_CONT(fn, "exported procedures should not return strings, use "
+                     "c_strings instead");
+    }
+  }
+}

--- a/test/compflags/lydia/library/errorMessage/exportingStrings.chpl
+++ b/test/compflags/lydia/library/errorMessage/exportingStrings.chpl
@@ -1,0 +1,7 @@
+export proc takesString(x: string) {
+  writeln(x);
+}
+
+export proc returnsString(): string {
+  return "whee";
+}

--- a/test/compflags/lydia/library/errorMessage/exportingStrings.compopts
+++ b/test/compflags/lydia/library/errorMessage/exportingStrings.compopts
@@ -1,0 +1,1 @@
+--library

--- a/test/compflags/lydia/library/errorMessage/exportingStrings.good
+++ b/test/compflags/lydia/library/errorMessage/exportingStrings.good
@@ -1,0 +1,2 @@
+exportingStrings.chpl:1: error: exported procedures should not take arguments of type string, use c_string instead
+exportingStrings.chpl:5: error: exported procedures should not return strings, use c_strings instead


### PR DESCRIPTION
Resolves #10636 

The C type definition for our notion of strings is not visible at the moment,
due to not being able to export type definitions in Chapel yet.  But prior to
this change, compiling a library with exported functions involving strings did
not cause an error - the user would discover they had no definition of the type
when they tried to link to the compiled library.  This change adds a compilation
error specifically for strings, so that users are not surprised at library link
time and instead know right away that they should use c_strings for the time
being.

Add a test to lock in the error messages for both string arguments and string
return types.

Running a full standard paratest now