### PR TITLE
Warning for initing local domain from distributed

### DIFF
--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -1808,6 +1808,13 @@ static void insertCasts(BaseAST* ast, FnSymbol* fn, Vec<CallExpr*>& casts) {
                 resolveExpr(moveInit);
                 resolveExpr(assign);
 
+                // Enable error messages assignment between local
+                // and distributed domains. It would be better if this
+                // could be handled by some flavor of initializer.
+                CallExpr* check = new CallExpr("chpl_checkCopyInit", to, from);
+                call->insertBefore(check);
+                resolveExpr(check);
+
                 // We've replaced the move with no-init/assign, so remove it.
                 call->remove();
 

--- a/modules/internal/ArrayViewRankChange.chpl
+++ b/modules/internal/ArrayViewRankChange.chpl
@@ -108,6 +108,10 @@ module ArrayViewRankChange {
 
     override proc dsiDestroyDist() {
     }
+
+    proc dsiIsLayout() param {
+      return downDistInst.dsiIsLayout();
+    }
   }
 
   private proc downDomType(param rank : int,

--- a/modules/internal/ArrayViewReindex.chpl
+++ b/modules/internal/ArrayViewReindex.chpl
@@ -90,6 +90,10 @@ module ArrayViewReindex {
       _delete_dom(updom, false);
       //      _delete_dom(downdomInst, _isPrivatized(downdomInst));
     }
+
+    proc dsiIsLayout() param {
+      return downDistInst.dsiIsLayout();
+    }
   }
 
   //

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -4298,6 +4298,12 @@ module ChapelArray {
 
     }
   }
+
+  proc chpl_checkCopyInit(lhs:domain, rhs:domain) param {
+    if lhs.dist._value.dsiIsLayout() && !rhs.dist._value.dsiIsLayout() then
+      compilerWarning("initializing a non-distributed domain from a distributed domain. If you didn't mean to do that, add a dmapped clause to the type expression or remove the type expression altogether");
+  }
+
   /* ================================================
      Set Operations on Associative Domains and Arrays
      ================================================

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -2022,4 +2022,6 @@ module ChapelBase {
   inline proc _removed_cast(in x) {
     return x;
   }
+
+  proc chpl_checkCopyInit(lhs, rhs) param { }
 }

--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -160,6 +160,10 @@ module ChapelDistribution {
     // effort to free it. DefaultDist is a singleton.
     proc singleton() param return false;
     // We could add dsiSingleton as a dynamically-dispatched counterpart
+
+    // indicates if this distribution is a layout. This helps
+    // with certain warnings.
+    proc dsiIsLayout() param return false;
   }
 
   //

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -101,6 +101,8 @@ module DefaultRectangular {
     override proc dsiTrackDomains()    return false;
 
     proc singleton() param return true;
+
+    proc dsiIsLayout() param return true;
   }
 
   //

--- a/modules/internal/ExternalArray.chpl
+++ b/modules/internal/ExternalArray.chpl
@@ -72,6 +72,8 @@ module ExternalArray {
     override proc dsiTrackDomains() return false;
 
     proc singleton() param return true;
+
+    proc dsiIsLayout() param return true;
   }
 
   var defaultExternDist = new unmanaged ExternDist();

--- a/modules/layouts/LayoutCS.chpl
+++ b/modules/layouts/LayoutCS.chpl
@@ -90,6 +90,10 @@ class CS: BaseDist {
   proc dsiEqualDMaps(that) param {
     return false;
   }
+
+  proc dsiIsLayout() param {
+    return true;
+  }
 } // CS
 
 

--- a/test/distributions/dm/s7.chpl
+++ b/test/distributions/dm/s7.chpl
@@ -106,7 +106,8 @@ proc test(X, Y, Z) {
 
 // copy to a default-rectangular array, for writeln()
 proc copyToDF(A:[]) {
-  const D: domain(A.rank, A.domain.idxType, A.domain.stridable) = A.domain;
+  var D: domain(A.rank, A.domain.idxType, A.domain.stridable);
+  D = A.domain;
   var Res: [D] A.eltType = A;
   return Res;
 }

--- a/test/distributions/dm/s8.chpl
+++ b/test/distributions/dm/s8.chpl
@@ -59,7 +59,8 @@ proc test(A, ix1, ix2) {
   forall a in A do msg(a);
   tl();
 
-  const D: domain(A.rank, A.domain.idxType, A.domain.stridable) = A.domain;
+  var D: domain(A.rank, A.domain.idxType, A.domain.stridable);
+  D = A.domain;
 
   hd("zippered iterator (A,D)");
   forall (a,i) in zip(A,D) do msg(i, "  ", a);

--- a/test/distributions/dm/s9.chpl
+++ b/test/distributions/dm/s9.chpl
@@ -61,7 +61,8 @@ proc test(A, ix1, ix2) {
   forall a in A do msg(a);
   tl();
 
-  const D: domain(A.rank, A.domain.idxType, A.domain.stridable) = A.domain;
+  var D: domain(A.rank, A.domain.idxType, A.domain.stridable);
+  D = A.domain;
 
   hd("zippered iterator (A,D)");
   forall (a,i) in zip(A,D) do msg(i, "  ", a);

--- a/test/distributions/ferguson/init-local-from-distributed-warning.chpl
+++ b/test/distributions/ferguson/init-local-from-distributed-warning.chpl
@@ -1,0 +1,32 @@
+use BlockDist;
+use CyclicDist;
+
+config const n = 2;
+
+proc warning1() {
+
+  var myDomain: domain(2) = {1..n, 1..n} dmapped Block({1..n, 1..n});
+  writeln(myDomain);
+
+}
+
+proc warning2() {
+
+  var myDomain: domain(2) = {1..n, 1..n} dmapped Cyclic(startIdx=(1,1));
+  writeln(myDomain);
+
+}
+
+
+proc ok1() {
+
+  var myDomain: domain(2);
+  myDomain = {1..n, 1..n} dmapped Block({1..n, 1..n});
+  writeln(myDomain);
+
+}
+
+
+warning1();
+warning2();
+ok1();

--- a/test/distributions/ferguson/init-local-from-distributed-warning.good
+++ b/test/distributions/ferguson/init-local-from-distributed-warning.good
@@ -1,0 +1,7 @@
+init-local-from-distributed-warning.chpl:6: In function 'warning1':
+init-local-from-distributed-warning.chpl:8: warning: initializing a non-distributed domain from a distributed domain. If you didn't mean to do that, add a dmapped clause to the type expression or remove the type expression altogether
+init-local-from-distributed-warning.chpl:13: In function 'warning2':
+init-local-from-distributed-warning.chpl:15: warning: initializing a non-distributed domain from a distributed domain. If you didn't mean to do that, add a dmapped clause to the type expression or remove the type expression altogether
+{1..2, 1..2}
+{1..2, 1..2}
+{1..2, 1..2}

--- a/test/distributions/ferguson/islayout.chpl
+++ b/test/distributions/ferguson/islayout.chpl
@@ -1,0 +1,34 @@
+use LayoutCS;
+use BlockDist;
+use ExternalArray;
+
+proc main() {
+  // Default is "distributed" so it's not as hard
+  // to keep up to date. But, check one to be sure.
+  var blk = new unmanaged Block(boundingBox={1..10});
+  assert(!blk.dsiIsLayout());
+  delete blk;
+
+  var cs = new unmanaged CS();
+  assert(cs.dsiIsLayout());
+  delete cs;
+
+  // Check also the distribution for default arrays,
+  // array slices, array reindexes, and array rank-changes.
+  var A:[1..3, 1..3] int;
+
+  // check DR
+  assert(A.domain.dist.dsiIsLayout());
+  // check slice
+  assert(A[1..3,1..2].domain.dist.dsiIsLayout());
+  // check rank-change
+  assert(A[..,1].domain.dist.dsiIsLayout());
+  assert(A[1..3,1].domain.dist.dsiIsLayout());
+  // check reindex
+  assert(A.reindex({0..2,0..2}).domain.dist.dsiIsLayout());
+
+  // check external array
+  var ptr:c_ptr(int) = c_calloc(int, 1);
+  var B = makeArrayFromPtr(ptr, 1);
+  assert(B.domain.dist.dsiIsLayout());
+}

--- a/test/distributions/robust/arithmetic/basics/test_domain_align.chpl
+++ b/test/distributions/robust/arithmetic/basics/test_domain_align.chpl
@@ -40,7 +40,8 @@ proc compare(D, R, a, s=2) {
 
 proc test(ref D) {
   D = rangeTuple(D.rank, 1..10);
-  var R : domain(D.rank, D.idxType, D.stridable) = D;
+  var R : domain(D.rank, D.idxType, D.stridable);
+  R = D;
 
   compare(D, R, 0);
   compare(D, R, 1);

--- a/test/studies/hpcc/HPL/bradc/hpl-blc-noreindex.chpl
+++ b/test/studies/hpcc/HPL/bradc/hpl-blc-noreindex.chpl
@@ -183,8 +183,10 @@ proc schurComplement(Ab: [?AbD] elemType, AD: domain, BD: domain, Rest: domain) 
   //var replAbD: domain(2) 
   //            dmapped new Dimensional(BlkCyc(blkSize), Replicated)) = AbD[AD];
   //
-  const replAD: domain(2, indexType) = AD,
-        replBD: domain(2, indexType) = BD;
+  var replAD: domain(2, indexType),
+      replBD: domain(2, indexType);
+  replAD = AD;
+  replBD = BD;
     
   const replA : [replAD] elemType = Ab[replAD],
         replB : [replBD] elemType = Ab[replBD];


### PR DESCRIPTION
Fixes issue #5657. Newer attempt after PR #5661.

For example, in the following code:
``` chapel
 use BlockDist;
  config const n = 100;
  var myDomain: domain(2) = {1..n, 1..n} dmapped Block({1..n, 1..n});
  for d in myDomain {
    writeln(d.locale.id);
  }
```

the user might think that `myDomain` is distributed, when in fact it is not. The purpose of the warning is to call attention to that issue since it's happened to multiple users over time (and been challenging for them to figure out).

- [x] full local testing
- [x] full local gasnet testing