### PR TITLE
Add a new dsiReallocate that is aware of allocated size and actual array size

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -2924,7 +2924,7 @@ module ChapelArray {
             writeln("pop_back reallocate: ",
                     oldRng, " => ", nextAllocRange,
                     " (", newRange, ")");
-          this._value.dsiReallocate((nextAllocRange,));
+          this._value.dsiReallocate((nextAllocRange,), (newRange,));
           // note: dsiReallocate sets _value.dataAllocRange = nextAllocRange
         }
         this.domain.setIndices((newRange,));
@@ -3019,7 +3019,7 @@ module ChapelArray {
             writeln("pop_front reallocate: ",
                     oldRng, " => ", nextAllocRange,
                     " (", newRange, ")");
-          this._value.dsiReallocate((nextAllocRange,));
+          this._value.dsiReallocate((nextAllocRange,), (newRange,));
           // note: dsiReallocate sets _value.dataAllocRange = nextAllocRange
         }
         this.domain.setIndices((newRange,));
@@ -3120,7 +3120,7 @@ module ChapelArray {
         }
         if newRange.length < (this._value.dataAllocRange.length / (arrayAsVecGrowthFactor*arrayAsVecGrowthFactor)):int {
           const nextAllocRange = resizeAllocRange(newRange, grow=-1);
-          this._value.dsiReallocate((nextAllocRange,));
+          this._value.dsiReallocate((nextAllocRange,), (newRange,));
           // note: dsiReallocate sets _value.dataAllocRange = nextAllocRange
         }
         this.domain.setIndices((newRange,));
@@ -3155,7 +3155,7 @@ module ChapelArray {
         }
         if newRange.length < (this._value.dataAllocRange.length / (arrayAsVecGrowthFactor*arrayAsVecGrowthFactor)):int {
           const nextAllocRange = resizeAllocRange(newRange, grow=-1);
-          this._value.dsiReallocate((nextAllocRange,));
+          this._value.dsiReallocate((nextAllocRange,), (newRange,));
           // note: dsiReallocate sets _value.dataAllocRange = nextAllocRange
         }
         this.domain.setIndices((newRange,));

--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -779,6 +779,15 @@ module ChapelDistribution {
       halt("reallocating not supported for this array type");
     }
 
+    proc dsiReallocate(allocBounds:rank*range(idxType,
+                                              BoundedRangeType.bounded,
+                                              stridable),
+                       arrayBounds:rank*range(idxType,
+                                              BoundedRangeType.bounded,
+                                              stridable)) {
+      halt("reallocating not supported for this array type");
+    }
+
     override proc dsiPostReallocate() {
     }
 

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1281,47 +1281,56 @@ module DefaultRectangular {
       }
     }
 
-    // TODO
     override proc dsiReallocate(bounds:rank*range(idxType,BoundedRangeType.bounded,stridable)) {
-      //if (d._value.type == dom.type) {
+      dsiReallocate(bounds, bounds);
+    }
+
+    // Reallocate the array to have space for elements specified by
+    // `allocBounds` while maintaining the elements specified by `arrayBounds`
+    override proc dsiReallocate(allocBounds:rank*range(idxType,
+                                                       BoundedRangeType.bounded,
+                                                       stridable),
+                                arrayBounds:rank*range(idxType,
+                                                       BoundedRangeType.bounded,
+                                                       stridable)) {
 
       on this {
-        var d = {(...bounds)};
-        var copy = new unmanaged DefaultRectangularArr(eltType=eltType, rank=rank,
+        var allocD = {(...allocBounds)};
+        var arrayD = {(...arrayBounds)};
+        var copy = new unmanaged DefaultRectangularArr(eltType=eltType,
+                                            rank=rank,
                                             idxType=idxType,
-                                            stridable=d._value.stridable,
-                                            dom=d._value);
+                                            stridable=allocD._value.stridable,
+                                            dom=allocD._value);
 
-        forall i in d((...dom.ranges)) do
+        forall i in arrayD((...dom.ranges)) do
           copy.dsiAccess(i) = dsiAccess(i);
+
         off = copy.off;
         blk = copy.blk;
         str = copy.str;
         factoredOffs = copy.factoredOffs;
+
         dsiDestroyArr();
         data = copy.data;
         // We can't call initShiftedData here because the new domain
         // has not yet been updated (this is called from within the
         // = function for domains.
-        if earlyShiftData && !d._value.stridable {
+        if earlyShiftData && !allocD._value.stridable {
           // Lydia note 11/04/15: a question was raised as to whether this
           // check on numIndices added any value.  Performance results
           // from removing this line seemed inconclusive, which may indicate
           // that the check is not necessary, but it seemed like unnecessary
           // work for something with no immediate reward.
-          if d.numIndices > 0 {
+          if allocD.numIndices > 0 {
             shiftedData = copy.shiftedData;
           }
         }
-        // also set dataAllocRange
         dataAllocRange = copy.dataAllocRange;
-        //numelm = copy.numelm;
         delete copy;
       }
-      //} else {
-      //  halt("illegal reallocation");
-      //}
     }
+
     override proc dsiPostReallocate() {
       // No action necessary here
     }

--- a/test/arrays/bharshbarg/popFrontLeak.chpl
+++ b/test/arrays/bharshbarg/popFrontLeak.chpl
@@ -1,0 +1,29 @@
+class C {
+  var x : int;
+}
+
+record R {
+  var c : unmanaged C;
+  proc init() { }
+  proc init(x:int) {
+    c = new unmanaged C(x);
+  }
+  proc init(other:R) {
+    this.c = new unmanaged C(other.c.x);
+  }
+  proc deinit() {
+    if c != nil then delete c;
+  }
+}
+
+proc =(ref LHS : R, rhs : R) {
+  if LHS.c then delete LHS.c;
+  LHS.c = new unmanaged C(rhs.c.x);
+}
+
+proc main() {
+  var A = for i in 1..4 do new R(i);
+
+  // A copy of R(4) is leaked
+  while A.size > 0 do A.pop_front();
+}


### PR DESCRIPTION
When array.pop_front and friends caused a reallocation, they were only paying
attention to the allocated size, which resulted in copies of elements that
were not going to be in the newly resized array.  Make dsiReallocate use both
the allocated bounds and the logical array bounds.  Allocate and free based
on the allocated bounds, but copy elements based on the logical array bounds.

This fixes a leak in the newly added test from issue #10520.