### PR TITLE
Fix nightly testing failures after new returns borrow

### DIFF
--- a/modules/internal/tasktable/on/ChapelTaskTable.chpl
+++ b/modules/internal/tasktable/on/ChapelTaskTable.chpl
@@ -68,7 +68,7 @@ module ChapelTaskTable {
   }
   
   pragma "locale private"
-  var chpldev_taskTable : chpldev_taskTable_t;
+  var chpldev_taskTable : unmanaged chpldev_taskTable_t;
   
   //----------------------------------------------------------------------{
   //- Code to initialize the task table on each locale.
@@ -78,7 +78,7 @@ module ChapelTaskTable {
     // initialized late (after DefaultRectangular and most other
     // internal modules are already initialized)
     coforall loc in Locales with (ref chpldev_taskTable) do on loc {
-      chpldev_taskTable = new chpldev_taskTable_t();
+      chpldev_taskTable = new unmanaged chpldev_taskTable_t();
     }
   }
 

--- a/test/functions/sungeun/promotionWithNoInline.chpl
+++ b/test/functions/sungeun/promotionWithNoInline.chpl
@@ -7,5 +7,5 @@ class C {
   var r: [-4..7] R;
 }
 
-var tmpC = new C();
+var tmpC = new owned C();
 tmpC.r.t = 99;

--- a/test/functions/sungeun/promotionWithNoInline.skipif
+++ b/test/functions/sungeun/promotionWithNoInline.skipif
@@ -1,1 +1,0 @@
-CHPL_TEST_VGRND_EXE == off

--- a/test/library/packages/LAPACK/LAPACK_Matrix_test.chpl
+++ b/test/library/packages/LAPACK/LAPACK_Matrix_test.chpl
@@ -19,57 +19,57 @@ writeln( "1D row input => row" );
 var input_1_row: [1..4] real = 
   [ 3.0, 1.0, 
     4.0, 2.0 ];
-var A_1_row = new LAPACK_Matrix( real, 2, 2, lapack_memory_order.row_major, input_array = input_1_row  ); 
+var A_1_row = new owned LAPACK_Matrix( real, 2, 2, lapack_memory_order.row_major, input_array = input_1_row  ); 
 writeln( A_1_row.data, "\n", A_1_row.toString(), "\n" );
 
 writeln( "1D col input => col" );
 var input_1_col: [1..4] real  = 
   [ 3.0, 4.0,   // tranpose of [ 3.0, 1.0,
     1.0, 2.0 ]; //                 4.0, 2.0 ];
-var A_1_col = new LAPACK_Matrix( real, 2, 2, lapack_memory_order.column_major, input_array = input_1_col  );  
+var A_1_col = new owned LAPACK_Matrix( real, 2, 2, lapack_memory_order.column_major, input_array = input_1_col  );  
 writeln( A_1_col.data, "\n", A_1_col.toString(), "\n" );
 
 writeln( "1D col input => row" );
-var A_1_row_f_col = new LAPACK_Matrix( real, 2, 2, lapack_memory_order.row_major, input_array = input_1_col,  input_array_order = lapack_memory_order.column_major ); 
+var A_1_row_f_col = new owned LAPACK_Matrix( real, 2, 2, lapack_memory_order.row_major, input_array = input_1_col,  input_array_order = lapack_memory_order.column_major ); 
 writeln( A_1_row_f_col.data, "\n", A_1_row_f_col.toString(), "\n" );
 
 writeln( "1D row input => col" );
-var A_1_col_f_row = new LAPACK_Matrix( real, 2, 2, lapack_memory_order.column_major, input_array = input_1_row, input_array_order = lapack_memory_order.row_major );  
+var A_1_col_f_row = new owned LAPACK_Matrix( real, 2, 2, lapack_memory_order.column_major, input_array = input_1_row, input_array_order = lapack_memory_order.row_major );  
 writeln( A_1_col_f_row.data, "\n", A_1_col_f_row.toString(), "\n" );
 
 // 1.5D data
 var input_1_5_row: [1..2][1..2] real =
   [ [3.0, 1.0], 
     [4.0, 2.0] ];
-//var A_1_5_row = new LAPACK_Matrix( real, 2, 2, lapack_memory_order.row_major, input_array = input_1_5_row  ); 
+//var A_1_5_row = new owned LAPACK_Matrix( real, 2, 2, lapack_memory_order.row_major, input_array = input_1_5_row  ); 
 
 var input_1_5_col: [1..2][1..2] real =
   [ [3.0, 4.0], 
     [1.0, 2.0] ];
-//var A_1_5_col = new LAPACK_Matrix( real, 2, 2, lapack_memory_order.column_major, input_array = input_1_5_col  ); 
+//var A_1_5_col = new owned LAPACK_Matrix( real, 2, 2, lapack_memory_order.column_major, input_array = input_1_5_col  ); 
 
 
 // 2D data
 writeln( "2D row input => row" );
 var input_2_row: [1..2,1..2] real;
 putInto2D( input_1_5_row, input_2_row );
-var A_2_row = new LAPACK_Matrix( real, 2, 2, lapack_memory_order.row_major, input_array = input_2_row ); 
+var A_2_row = new owned LAPACK_Matrix( real, 2, 2, lapack_memory_order.row_major, input_array = input_2_row ); 
 writeln( A_2_row.data, "\n", A_2_row.toString(), "\n" );
 
 writeln( "2D col input => col" );
 var input_2_col: [1..2,1..2] real;
 putInto2D( input_1_5_col, input_2_col );
-var A_2_col = new LAPACK_Matrix( real, 2, 2, lapack_memory_order.column_major, input_array = input_2_col ); 
+var A_2_col = new owned LAPACK_Matrix( real, 2, 2, lapack_memory_order.column_major, input_array = input_2_col ); 
 writeln( A_2_col.data, "\n", A_2_col.toString(), "\n" );
 
 writeln( "2D col input => row" );
 putInto2D( input_1_5_col, input_2_row );
-var A_2_row_f_col = new LAPACK_Matrix( real, 2, 2, lapack_memory_order.row_major, input_array = input_2_row, input_array_order = lapack_memory_order.column_major ); 
+var A_2_row_f_col = new owned LAPACK_Matrix( real, 2, 2, lapack_memory_order.row_major, input_array = input_2_row, input_array_order = lapack_memory_order.column_major ); 
 writeln( A_2_row_f_col.data, "\n", A_2_row_f_col.toString(), "\n" );
 
 writeln( "2d row input => col" );
 putInto2D( input_1_5_row, input_2_col );
-var A_2_col_f_row = new LAPACK_Matrix( real, 2, 2, lapack_memory_order.column_major, input_array = input_2_col, input_array_order = lapack_memory_order.row_major  ); 
+var A_2_col_f_row = new owned LAPACK_Matrix( real, 2, 2, lapack_memory_order.column_major, input_array = input_2_col, input_array_order = lapack_memory_order.row_major  ); 
 writeln( A_2_col_f_row.data, "\n", A_2_col_f_row.toString(), "\n" );
 
 

--- a/test/library/packages/LAPACK/TestHelpers.chpl
+++ b/test/library/packages/LAPACK/TestHelpers.chpl
@@ -191,7 +191,7 @@ module TestHelpers {
     return (matrix_order == lapack_memory_order.row_major);
   }
   
-  proc *( A: LAPACK_Matrix(?t), B: LAPACK_Matrix(t) ): LAPACK_Matrix(t) {
+  proc *( A: LAPACK_Matrix(?t), B: LAPACK_Matrix(t) ): owned LAPACK_Matrix(t) {
     assert( A.columns == B.rows );
     var row_ordered = if ( A.isRowMajor &&  B.isRowMajor)
                       || (!A.isRowMajor && !B.isRowMajor) 
@@ -199,7 +199,7 @@ module TestHelpers {
                     else
                       true;
     
-    var retmatrix = new LAPACK_Matrix( t, A.rows, B.columns, row_ordered, error = min( A.epsilon, B.epsilon ) );
+    var retmatrix = new owned LAPACK_Matrix( t, A.rows, B.columns, row_ordered, error = min( A.epsilon, B.epsilon ) );
     
     for i in A.rowRange do
       for j in B.columnRange do

--- a/test/library/packages/LAPACK/cgesv.chpl
+++ b/test/library/packages/LAPACK/cgesv.chpl
@@ -6,12 +6,12 @@ proc LAPACK_cgesv_test(){
   if verbose_test then
     writeln( "LAPACK_cgesv\n===============================" );
 
-  var A = new LAPACK_Matrix( complex(64), 2, 2, lapack_memory_order.column_major, input_array = [ ( 5.0 + 1.0i ) : complex(64), ( 2.0 + 1.0i ) : complex(64), ( 1.0 + 1.0i ) : complex(64), ( 6.0 + 1.0i ) : complex(64) ], input_array_order = lapack_memory_order.row_major, error = 10e-6 );
-  var X = new LAPACK_Matrix( complex(64), 2, 2, lapack_memory_order.column_major, input_array = [ ( 3.0 + 1.0i ) : complex(64), ( 1.0 + 1.0i ) : complex(64), ( 4.0 + 1.0i ) : complex(64), ( 2.0 + 1.0i ) : complex(64) ], input_array_order = lapack_memory_order.row_major, error = 10e-6 ); 
+  var A = new owned LAPACK_Matrix( complex(64), 2, 2, lapack_memory_order.column_major, input_array = [ ( 5.0 + 1.0i ) : complex(64), ( 2.0 + 1.0i ) : complex(64), ( 1.0 + 1.0i ) : complex(64), ( 6.0 + 1.0i ) : complex(64) ], input_array_order = lapack_memory_order.row_major, error = 10e-6 );
+  var X = new owned LAPACK_Matrix( complex(64), 2, 2, lapack_memory_order.column_major, input_array = [ ( 3.0 + 1.0i ) : complex(64), ( 1.0 + 1.0i ) : complex(64), ( 4.0 + 1.0i ) : complex(64), ( 2.0 + 1.0i ) : complex(64) ], input_array_order = lapack_memory_order.row_major, error = 10e-6 ); 
   var B = A*X;
   
-  var A_work = new LAPACK_Matrix( A );
-  var B_work = new LAPACK_Matrix( B );
+  var A_work = new owned LAPACK_Matrix( A );
+  var B_work = new owned LAPACK_Matrix( B );
   if verbose_test then
     writeln(  "A\n", A_work.toString(), 
             "\nX\n", X.toString(), 
@@ -52,12 +52,12 @@ proc LAPACKE_cgesv_row_major_test(){
   if verbose_test then
     writeln( "LAPACKE_cgesv_row_major\n===============================" );
 
-  var A = new LAPACK_Matrix( complex(64), 2, 2, lapack_memory_order.row_major, input_array = [ ( 5.0 + 1.0i ) : complex(64), ( 2.0 + 1.0i ) : complex(64), ( 1.0 + 1.0i ) : complex(64), ( 6.0 + 1.0i ) : complex(64) ], input_array_order = lapack_memory_order.row_major, error = 10e-6  );
-  var X = new LAPACK_Matrix( complex(64), 2, 2, lapack_memory_order.row_major, input_array = [ ( 3.0 + 1.0i ) : complex(64), ( 1.0 + 1.0i ) : complex(64), ( 4.0 + 1.0i ) : complex(64), ( 2.0 + 1.0i ) : complex(64) ], input_array_order = lapack_memory_order.row_major, error = 10e-6  ); 
+  var A = new owned LAPACK_Matrix( complex(64), 2, 2, lapack_memory_order.row_major, input_array = [ ( 5.0 + 1.0i ) : complex(64), ( 2.0 + 1.0i ) : complex(64), ( 1.0 + 1.0i ) : complex(64), ( 6.0 + 1.0i ) : complex(64) ], input_array_order = lapack_memory_order.row_major, error = 10e-6  );
+  var X = new owned LAPACK_Matrix( complex(64), 2, 2, lapack_memory_order.row_major, input_array = [ ( 3.0 + 1.0i ) : complex(64), ( 1.0 + 1.0i ) : complex(64), ( 4.0 + 1.0i ) : complex(64), ( 2.0 + 1.0i ) : complex(64) ], input_array_order = lapack_memory_order.row_major, error = 10e-6  ); 
   var B = A*X;
   
-  var A_work = new LAPACK_Matrix( A );
-  var B_work = new LAPACK_Matrix( B );
+  var A_work = new owned LAPACK_Matrix( A );
+  var B_work = new owned LAPACK_Matrix( B );
   if verbose_test then
     writeln(  "A\n", A_work.toString(), 
             "\nX\n", X.toString(), 
@@ -96,12 +96,12 @@ proc LAPACKE_cgesv_col_major_test(){
   if verbose_test then
     writeln( "LAPACKE_cgesv_col_major\n===============================" );
 
-  var A = new LAPACK_Matrix( complex(64), 2, 2, lapack_memory_order.column_major, input_array = [ ( 5.0 + 1.0i ) : complex(64), ( 2.0 + 1.0i ) : complex(64), ( 1.0 + 1.0i ) : complex(64), ( 6.0 + 1.0i ) : complex(64) ], input_array_order = lapack_memory_order.row_major, error = 10e-6 );
-  var X = new LAPACK_Matrix( complex(64), 2, 2, lapack_memory_order.column_major, input_array = [ ( 3.0 + 1.0i ) : complex(64), ( 1.0 + 1.0i ) : complex(64), ( 4.0 + 1.0i ) : complex(64), ( 2.0 + 1.0i ) : complex(64) ], input_array_order = lapack_memory_order.row_major, error = 10e-6 ); 
+  var A = new owned LAPACK_Matrix( complex(64), 2, 2, lapack_memory_order.column_major, input_array = [ ( 5.0 + 1.0i ) : complex(64), ( 2.0 + 1.0i ) : complex(64), ( 1.0 + 1.0i ) : complex(64), ( 6.0 + 1.0i ) : complex(64) ], input_array_order = lapack_memory_order.row_major, error = 10e-6 );
+  var X = new owned LAPACK_Matrix( complex(64), 2, 2, lapack_memory_order.column_major, input_array = [ ( 3.0 + 1.0i ) : complex(64), ( 1.0 + 1.0i ) : complex(64), ( 4.0 + 1.0i ) : complex(64), ( 2.0 + 1.0i ) : complex(64) ], input_array_order = lapack_memory_order.row_major, error = 10e-6 ); 
   var B = A*X;
   
-  var A_work = new LAPACK_Matrix( A );
-  var B_work = new LAPACK_Matrix( B );
+  var A_work = new owned LAPACK_Matrix( A );
+  var B_work = new owned LAPACK_Matrix( B );
   if verbose_test then
     writeln(  "A\n", A_work.toString(), 
             "\nX\n", X.toString(), 
@@ -140,12 +140,12 @@ proc gesv_row_major_test(){
   if verbose_test then
     writeln( "gesv_row_major\n===============================" );
 
-  var A = new LAPACK_Matrix( complex(64), 2, 2, lapack_memory_order.row_major, input_array = [ ( 5.0 + 1.0i ) : complex(64), ( 2.0 + 1.0i ) : complex(64), ( 1.0 + 1.0i ) : complex(64), ( 6.0 + 1.0i ) : complex(64) ], input_array_order = lapack_memory_order.row_major, error = 10e-6  );
-  var X = new LAPACK_Matrix( complex(64), 2, 2, lapack_memory_order.row_major, input_array = [ ( 3.0 + 1.0i ) : complex(64), ( 1.0 + 1.0i ) : complex(64), ( 4.0 + 1.0i ) : complex(64), ( 2.0 + 1.0i ) : complex(64) ], input_array_order = lapack_memory_order.row_major, error = 10e-6  ); 
+  var A = new owned LAPACK_Matrix( complex(64), 2, 2, lapack_memory_order.row_major, input_array = [ ( 5.0 + 1.0i ) : complex(64), ( 2.0 + 1.0i ) : complex(64), ( 1.0 + 1.0i ) : complex(64), ( 6.0 + 1.0i ) : complex(64) ], input_array_order = lapack_memory_order.row_major, error = 10e-6  );
+  var X = new owned LAPACK_Matrix( complex(64), 2, 2, lapack_memory_order.row_major, input_array = [ ( 3.0 + 1.0i ) : complex(64), ( 1.0 + 1.0i ) : complex(64), ( 4.0 + 1.0i ) : complex(64), ( 2.0 + 1.0i ) : complex(64) ], input_array_order = lapack_memory_order.row_major, error = 10e-6  ); 
   var B = A*X;
   
-  var A_work = new LAPACK_Matrix( A );
-  var B_work = new LAPACK_Matrix( B );
+  var A_work = new owned LAPACK_Matrix( A );
+  var B_work = new owned LAPACK_Matrix( B );
   if verbose_test then
     writeln(  "A\n", A_work.toString(), 
             "\nX\n", X.toString(), 
@@ -180,12 +180,12 @@ proc gesv_col_major_test(){
   if verbose_test then
     writeln( "gesv_col_major\n===============================" );
 
-  var A = new LAPACK_Matrix( complex(64), 2, 2, lapack_memory_order.column_major, input_array = [ ( 5.0 + 1.0i ) : complex(64), ( 2.0 + 1.0i ) : complex(64), ( 1.0 + 1.0i ) : complex(64), ( 6.0 + 1.0i ) : complex(64) ], input_array_order = lapack_memory_order.row_major, error = 10e-6 );
-  var X = new LAPACK_Matrix( complex(64), 2, 2, lapack_memory_order.column_major, input_array = [ ( 3.0 + 1.0i ) : complex(64), ( 1.0 + 1.0i ) : complex(64), ( 4.0 + 1.0i ) : complex(64), ( 2.0 + 1.0i ) : complex(64) ], input_array_order = lapack_memory_order.row_major, error = 10e-6 ); 
+  var A = new owned LAPACK_Matrix( complex(64), 2, 2, lapack_memory_order.column_major, input_array = [ ( 5.0 + 1.0i ) : complex(64), ( 2.0 + 1.0i ) : complex(64), ( 1.0 + 1.0i ) : complex(64), ( 6.0 + 1.0i ) : complex(64) ], input_array_order = lapack_memory_order.row_major, error = 10e-6 );
+  var X = new owned LAPACK_Matrix( complex(64), 2, 2, lapack_memory_order.column_major, input_array = [ ( 3.0 + 1.0i ) : complex(64), ( 1.0 + 1.0i ) : complex(64), ( 4.0 + 1.0i ) : complex(64), ( 2.0 + 1.0i ) : complex(64) ], input_array_order = lapack_memory_order.row_major, error = 10e-6 ); 
   var B = A*X;
   
-  var A_work = new LAPACK_Matrix( A );
-  var B_work = new LAPACK_Matrix( B );
+  var A_work = new owned LAPACK_Matrix( A );
+  var B_work = new owned LAPACK_Matrix( B );
   if verbose_test then
     writeln(  "A\n", A_work.toString(), 
             "\nX\n", X.toString(), 

--- a/test/library/packages/LAPACK/dgesv.chpl
+++ b/test/library/packages/LAPACK/dgesv.chpl
@@ -6,12 +6,12 @@ proc LAPACK_dgesv_test(){
   if verbose_test then
     writeln( "LAPACK_dgesv\n===============================" );
 
-  var A = new LAPACK_Matrix( real(64), 2, 2, lapack_memory_order.column_major, input_array = [ ( 5.0 ), ( 2.0 ), ( 1.0 ), ( 6.0 ) ], input_array_order = lapack_memory_order.row_major );
-  var X = new LAPACK_Matrix( real(64), 2, 2, lapack_memory_order.column_major, input_array = [ ( 3.0 ), ( 1.0 ), ( 4.0 ), ( 2.0 ) ], input_array_order = lapack_memory_order.row_major ); 
+  var A = new owned LAPACK_Matrix( real(64), 2, 2, lapack_memory_order.column_major, input_array = [ ( 5.0 ), ( 2.0 ), ( 1.0 ), ( 6.0 ) ], input_array_order = lapack_memory_order.row_major );
+  var X = new owned LAPACK_Matrix( real(64), 2, 2, lapack_memory_order.column_major, input_array = [ ( 3.0 ), ( 1.0 ), ( 4.0 ), ( 2.0 ) ], input_array_order = lapack_memory_order.row_major ); 
   var B = A*X;
   
-  var A_work = new LAPACK_Matrix( A );
-  var B_work = new LAPACK_Matrix( B );
+  var A_work = new owned LAPACK_Matrix( A );
+  var B_work = new owned LAPACK_Matrix( B );
   if verbose_test then
     writeln(  "A\n", A_work.toString(), 
             "\nX\n", X.toString(), 
@@ -52,12 +52,12 @@ proc LAPACKE_dgesv_row_major_test(){
   if verbose_test then
     writeln( "LAPACKE_dgesv_row_major\n===============================" );
 
-  var A = new LAPACK_Matrix( real(64), 2, 2, lapack_memory_order.row_major, input_array = [ ( 5.0 ), ( 2.0 ), ( 1.0 ), ( 6.0 ) ], input_array_order = lapack_memory_order.row_major  );
-  var X = new LAPACK_Matrix( real(64), 2, 2, lapack_memory_order.row_major, input_array = [ ( 3.0 ), ( 1.0 ), ( 4.0 ), ( 2.0 ) ], input_array_order = lapack_memory_order.row_major  ); 
+  var A = new owned LAPACK_Matrix( real(64), 2, 2, lapack_memory_order.row_major, input_array = [ ( 5.0 ), ( 2.0 ), ( 1.0 ), ( 6.0 ) ], input_array_order = lapack_memory_order.row_major  );
+  var X = new owned LAPACK_Matrix( real(64), 2, 2, lapack_memory_order.row_major, input_array = [ ( 3.0 ), ( 1.0 ), ( 4.0 ), ( 2.0 ) ], input_array_order = lapack_memory_order.row_major  ); 
   var B = A*X;
   
-  var A_work = new LAPACK_Matrix( A );
-  var B_work = new LAPACK_Matrix( B );
+  var A_work = new owned LAPACK_Matrix( A );
+  var B_work = new owned LAPACK_Matrix( B );
   if verbose_test then
     writeln(  "A\n", A_work.toString(), 
             "\nX\n", X.toString(), 
@@ -96,12 +96,12 @@ proc LAPACKE_dgesv_col_major_test(){
   if verbose_test then
     writeln( "LAPACKE_dgesv_col_major\n===============================" );
 
-  var A = new LAPACK_Matrix( real(64), 2, 2, lapack_memory_order.column_major, input_array = [ ( 5.0 ), ( 2.0 ), ( 1.0 ), ( 6.0 ) ], input_array_order = lapack_memory_order.row_major );
-  var X = new LAPACK_Matrix( real(64), 2, 2, lapack_memory_order.column_major, input_array = [ ( 3.0 ), ( 1.0 ), ( 4.0 ), ( 2.0 ) ], input_array_order = lapack_memory_order.row_major ); 
+  var A = new owned LAPACK_Matrix( real(64), 2, 2, lapack_memory_order.column_major, input_array = [ ( 5.0 ), ( 2.0 ), ( 1.0 ), ( 6.0 ) ], input_array_order = lapack_memory_order.row_major );
+  var X = new owned LAPACK_Matrix( real(64), 2, 2, lapack_memory_order.column_major, input_array = [ ( 3.0 ), ( 1.0 ), ( 4.0 ), ( 2.0 ) ], input_array_order = lapack_memory_order.row_major ); 
   var B = A*X;
   
-  var A_work = new LAPACK_Matrix( A );
-  var B_work = new LAPACK_Matrix( B );
+  var A_work = new owned LAPACK_Matrix( A );
+  var B_work = new owned LAPACK_Matrix( B );
   if verbose_test then
     writeln(  "A\n", A_work.toString(), 
             "\nX\n", X.toString(), 
@@ -140,12 +140,12 @@ proc gesv_row_major_test(){
   if verbose_test then
     writeln( "gesv_row_major\n===============================" );
 
-  var A = new LAPACK_Matrix( real(64), 2, 2, lapack_memory_order.row_major, input_array = [ ( 5.0 ), ( 2.0 ), ( 1.0 ), ( 6.0 ) ], input_array_order = lapack_memory_order.row_major  );
-  var X = new LAPACK_Matrix( real(64), 2, 2, lapack_memory_order.row_major, input_array = [ ( 3.0 ), ( 1.0 ), ( 4.0 ), ( 2.0 ) ], input_array_order = lapack_memory_order.row_major  ); 
+  var A = new owned LAPACK_Matrix( real(64), 2, 2, lapack_memory_order.row_major, input_array = [ ( 5.0 ), ( 2.0 ), ( 1.0 ), ( 6.0 ) ], input_array_order = lapack_memory_order.row_major  );
+  var X = new owned LAPACK_Matrix( real(64), 2, 2, lapack_memory_order.row_major, input_array = [ ( 3.0 ), ( 1.0 ), ( 4.0 ), ( 2.0 ) ], input_array_order = lapack_memory_order.row_major  ); 
   var B = A*X;
   
-  var A_work = new LAPACK_Matrix( A );
-  var B_work = new LAPACK_Matrix( B );
+  var A_work = new owned LAPACK_Matrix( A );
+  var B_work = new owned LAPACK_Matrix( B );
   if verbose_test then
     writeln(  "A\n", A_work.toString(), 
             "\nX\n", X.toString(), 
@@ -180,12 +180,12 @@ proc gesv_col_major_test(){
   if verbose_test then
     writeln( "gesv_col_major\n===============================" );
 
-  var A = new LAPACK_Matrix( real(64), 2, 2, lapack_memory_order.column_major, input_array = [ ( 5.0 ), ( 2.0 ), ( 1.0 ), ( 6.0 ) ], input_array_order = lapack_memory_order.row_major );
-  var X = new LAPACK_Matrix( real(64), 2, 2, lapack_memory_order.column_major, input_array = [ ( 3.0 ), ( 1.0 ), ( 4.0 ), ( 2.0 ) ], input_array_order = lapack_memory_order.row_major ); 
+  var A = new owned LAPACK_Matrix( real(64), 2, 2, lapack_memory_order.column_major, input_array = [ ( 5.0 ), ( 2.0 ), ( 1.0 ), ( 6.0 ) ], input_array_order = lapack_memory_order.row_major );
+  var X = new owned LAPACK_Matrix( real(64), 2, 2, lapack_memory_order.column_major, input_array = [ ( 3.0 ), ( 1.0 ), ( 4.0 ), ( 2.0 ) ], input_array_order = lapack_memory_order.row_major ); 
   var B = A*X;
   
-  var A_work = new LAPACK_Matrix( A );
-  var B_work = new LAPACK_Matrix( B );
+  var A_work = new owned LAPACK_Matrix( A );
+  var B_work = new owned LAPACK_Matrix( B );
   if verbose_test then
     writeln(  "A\n", A_work.toString(), 
             "\nX\n", X.toString(), 

--- a/test/library/packages/LAPACK/dgesvd.chpl
+++ b/test/library/packages/LAPACK/dgesvd.chpl
@@ -7,10 +7,10 @@ proc LAPACKE_dgesvd_row_major_test(){
     writeln( "LAPACKE_dgesvd_row_major_test\n===============================" );
     
   var order: lapack_memory_order = lapack_memory_order.row_major;
-  var A = new LAPACK_Matrix( real(64), 4, 5, order );
-  var U = new LAPACK_Matrix( real(64), 4, 4, order ); 
-  var S = new LAPACK_Matrix( real(64), 4, 5, order ); 
-  var V = new LAPACK_Matrix( real(64), 5, 5, order );
+  var A = new owned LAPACK_Matrix( real(64), 4, 5, order );
+  var U = new owned LAPACK_Matrix( real(64), 4, 4, order ); 
+  var S = new owned LAPACK_Matrix( real(64), 4, 5, order ); 
+  var V = new owned LAPACK_Matrix( real(64), 5, 5, order );
   
   A.populateFromArray( 
                       [ 1.0, 0.0, 0.0, 0.0, 2.0,
@@ -45,10 +45,10 @@ proc LAPACKE_dgesvd_row_major_test(){
                        lapack_memory_order.row_major
                       );
 
-  var A_work = new LAPACK_Matrix( A );
-  var U_work = new LAPACK_Matrix( U );
-  var S_work = new LAPACK_Matrix( S );
-  var V_work = new LAPACK_Matrix( V );
+  var A_work = new owned LAPACK_Matrix( A );
+  var U_work = new owned LAPACK_Matrix( U );
+  var S_work = new owned LAPACK_Matrix( S );
+  var V_work = new owned LAPACK_Matrix( V );
   
   if verbose_test then
     writeln(  "A\n", A_work.toString(), 
@@ -95,10 +95,10 @@ proc LAPACKE_dgesvd_col_major_test(){
     writeln( "LAPACKE_dgesvd_col_major_test\n===============================" );
     
   var order: lapack_memory_order = lapack_memory_order.column_major;
-  var A = new LAPACK_Matrix( real(64), 4, 5, order );
-  var U = new LAPACK_Matrix( real(64), 4, 4, order ); 
-  var S = new LAPACK_Matrix( real(64), 4, 5, order ); 
-  var V = new LAPACK_Matrix( real(64), 5, 5, order );
+  var A = new owned LAPACK_Matrix( real(64), 4, 5, order );
+  var U = new owned LAPACK_Matrix( real(64), 4, 4, order ); 
+  var S = new owned LAPACK_Matrix( real(64), 4, 5, order ); 
+  var V = new owned LAPACK_Matrix( real(64), 5, 5, order );
   
   A.populateFromArray( 
                       [ 1.0, 0.0, 0.0, 0.0, 2.0,
@@ -133,10 +133,10 @@ proc LAPACKE_dgesvd_col_major_test(){
                        lapack_memory_order.row_major
                       );
 
-  var A_work = new LAPACK_Matrix( A );
-  var U_work = new LAPACK_Matrix( U );
-  var S_work = new LAPACK_Matrix( S );
-  var V_work = new LAPACK_Matrix( V );
+  var A_work = new owned LAPACK_Matrix( A );
+  var U_work = new owned LAPACK_Matrix( U );
+  var S_work = new owned LAPACK_Matrix( S );
+  var V_work = new owned LAPACK_Matrix( V );
   
   if verbose_test then
     writeln(  "A\n", A_work.toString(), 
@@ -184,10 +184,10 @@ proc gesvd_row_major_test(){
     writeln( "gesvd_row_major_test\n===============================" );
     
   var order: lapack_memory_order = lapack_memory_order.row_major;
-  var A = new LAPACK_Matrix( real(64), 4, 5, order );
-  var U = new LAPACK_Matrix( real(64), 4, 4, order ); 
-  var S = new LAPACK_Matrix( real(64), 4, 5, order ); 
-  var V = new LAPACK_Matrix( real(64), 5, 5, order );
+  var A = new owned LAPACK_Matrix( real(64), 4, 5, order );
+  var U = new owned LAPACK_Matrix( real(64), 4, 4, order ); 
+  var S = new owned LAPACK_Matrix( real(64), 4, 5, order ); 
+  var V = new owned LAPACK_Matrix( real(64), 5, 5, order );
   
   A.populateFromArray( 
                       [ 1.0, 0.0, 0.0, 0.0, 2.0,
@@ -222,10 +222,10 @@ proc gesvd_row_major_test(){
                        lapack_memory_order.row_major
                       );
 
-  var A_work = new LAPACK_Matrix( A );
-  var U_work = new LAPACK_Matrix( U );
-  var S_work = new LAPACK_Matrix( S );
-  var V_work = new LAPACK_Matrix( V );
+  var A_work = new owned LAPACK_Matrix( A );
+  var U_work = new owned LAPACK_Matrix( U );
+  var S_work = new owned LAPACK_Matrix( S );
+  var V_work = new owned LAPACK_Matrix( V );
   
   if verbose_test then
     writeln(  "A\n", A_work.toString(), 
@@ -268,10 +268,10 @@ proc gesvd_col_major_test(){
     writeln( "gesvd_col_major_test\n===============================" );
     
   var order: lapack_memory_order = lapack_memory_order.column_major;
-  var A = new LAPACK_Matrix( real(64), 4, 5, order );
-  var U = new LAPACK_Matrix( real(64), 4, 4, order ); 
-  var S = new LAPACK_Matrix( real(64), 4, 5, order ); 
-  var V = new LAPACK_Matrix( real(64), 5, 5, order );
+  var A = new owned LAPACK_Matrix( real(64), 4, 5, order );
+  var U = new owned LAPACK_Matrix( real(64), 4, 4, order ); 
+  var S = new owned LAPACK_Matrix( real(64), 4, 5, order ); 
+  var V = new owned LAPACK_Matrix( real(64), 5, 5, order );
   
   A.populateFromArray( 
                       [ 1.0, 0.0, 0.0, 0.0, 2.0,
@@ -306,10 +306,10 @@ proc gesvd_col_major_test(){
                        lapack_memory_order.row_major
                       );
 
-  var A_work = new LAPACK_Matrix( A );
-  var U_work = new LAPACK_Matrix( U );
-  var S_work = new LAPACK_Matrix( S );
-  var V_work = new LAPACK_Matrix( V );
+  var A_work = new owned LAPACK_Matrix( A );
+  var U_work = new owned LAPACK_Matrix( U );
+  var S_work = new owned LAPACK_Matrix( S );
+  var V_work = new owned LAPACK_Matrix( V );
   
   if verbose_test then
     writeln(  "A\n", A_work.toString(), 

--- a/test/library/packages/LAPACK/sgesv.chpl
+++ b/test/library/packages/LAPACK/sgesv.chpl
@@ -6,12 +6,12 @@ proc LAPACK_sgesv_test(){
   if verbose_test then
     writeln( "LAPACK_sgesv\n===============================" );
 
-  var A = new LAPACK_Matrix( real(32), 2, 2, lapack_memory_order.column_major, input_array = [ ( 5.0 ) : real(32), ( 2.0 ) : real(32), ( 1.0 ) : real(32), ( 6.0 ) : real(32) ], input_array_order = lapack_memory_order.row_major );
-  var X = new LAPACK_Matrix( real(32), 2, 2, lapack_memory_order.column_major, input_array = [ ( 3.0 ) : real(32), ( 1.0 ) : real(32), ( 4.0 ) : real(32), ( 2.0 ) : real(32) ], input_array_order = lapack_memory_order.row_major ); 
+  var A = new owned LAPACK_Matrix( real(32), 2, 2, lapack_memory_order.column_major, input_array = [ ( 5.0 ) : real(32), ( 2.0 ) : real(32), ( 1.0 ) : real(32), ( 6.0 ) : real(32) ], input_array_order = lapack_memory_order.row_major );
+  var X = new owned LAPACK_Matrix( real(32), 2, 2, lapack_memory_order.column_major, input_array = [ ( 3.0 ) : real(32), ( 1.0 ) : real(32), ( 4.0 ) : real(32), ( 2.0 ) : real(32) ], input_array_order = lapack_memory_order.row_major ); 
   var B = A*X;
   
-  var A_work = new LAPACK_Matrix( A );
-  var B_work = new LAPACK_Matrix( B );
+  var A_work = new owned LAPACK_Matrix( A );
+  var B_work = new owned LAPACK_Matrix( B );
   if verbose_test then
     writeln(  "A\n", A_work.toString(), 
             "\nX\n", X.toString(), 
@@ -52,12 +52,12 @@ proc LAPACKE_sgesv_row_major_test(){
   if verbose_test then
     writeln( "LAPACKE_sgesv_row_major\n===============================" );
 
-  var A = new LAPACK_Matrix( real(32), 2, 2, lapack_memory_order.row_major, input_array = [ ( 5.0 ) : real(32), ( 2.0 ) : real(32), ( 1.0 ) : real(32), ( 6.0 ) : real(32) ], input_array_order = lapack_memory_order.row_major  );
-  var X = new LAPACK_Matrix( real(32), 2, 2, lapack_memory_order.row_major, input_array = [ ( 3.0 ) : real(32), ( 1.0 ) : real(32), ( 4.0 ) : real(32), ( 2.0 ) : real(32) ], input_array_order = lapack_memory_order.row_major  ); 
+  var A = new owned LAPACK_Matrix( real(32), 2, 2, lapack_memory_order.row_major, input_array = [ ( 5.0 ) : real(32), ( 2.0 ) : real(32), ( 1.0 ) : real(32), ( 6.0 ) : real(32) ], input_array_order = lapack_memory_order.row_major  );
+  var X = new owned LAPACK_Matrix( real(32), 2, 2, lapack_memory_order.row_major, input_array = [ ( 3.0 ) : real(32), ( 1.0 ) : real(32), ( 4.0 ) : real(32), ( 2.0 ) : real(32) ], input_array_order = lapack_memory_order.row_major  ); 
   var B = A*X;
   
-  var A_work = new LAPACK_Matrix( A );
-  var B_work = new LAPACK_Matrix( B );
+  var A_work = new owned LAPACK_Matrix( A );
+  var B_work = new owned LAPACK_Matrix( B );
   if verbose_test then
     writeln(  "A\n", A_work.toString(), 
             "\nX\n", X.toString(), 
@@ -96,12 +96,12 @@ proc LAPACKE_sgesv_col_major_test(){
   if verbose_test then
     writeln( "LAPACKE_sgesv_col_major\n===============================" );
 
-  var A = new LAPACK_Matrix( real(32), 2, 2, lapack_memory_order.column_major, input_array = [ ( 5.0 ) : real(32), ( 2.0 ) : real(32), ( 1.0 ) : real(32), ( 6.0 ) : real(32) ], input_array_order = lapack_memory_order.row_major );
-  var X = new LAPACK_Matrix( real(32), 2, 2, lapack_memory_order.column_major, input_array = [ ( 3.0 ) : real(32), ( 1.0 ) : real(32), ( 4.0 ) : real(32), ( 2.0 ) : real(32) ], input_array_order = lapack_memory_order.row_major ); 
+  var A = new owned LAPACK_Matrix( real(32), 2, 2, lapack_memory_order.column_major, input_array = [ ( 5.0 ) : real(32), ( 2.0 ) : real(32), ( 1.0 ) : real(32), ( 6.0 ) : real(32) ], input_array_order = lapack_memory_order.row_major );
+  var X = new owned LAPACK_Matrix( real(32), 2, 2, lapack_memory_order.column_major, input_array = [ ( 3.0 ) : real(32), ( 1.0 ) : real(32), ( 4.0 ) : real(32), ( 2.0 ) : real(32) ], input_array_order = lapack_memory_order.row_major ); 
   var B = A*X;
   
-  var A_work = new LAPACK_Matrix( A );
-  var B_work = new LAPACK_Matrix( B );
+  var A_work = new owned LAPACK_Matrix( A );
+  var B_work = new owned LAPACK_Matrix( B );
   if verbose_test then
     writeln(  "A\n", A_work.toString(), 
             "\nX\n", X.toString(), 
@@ -140,12 +140,12 @@ proc gesv_row_major_test(){
   if verbose_test then
     writeln( "gesv_row_major\n===============================" );
 
-  var A = new LAPACK_Matrix( real(32), 2, 2, lapack_memory_order.row_major, input_array = [ ( 5.0 ) : real(32), ( 2.0 ) : real(32), ( 1.0 ) : real(32), ( 6.0 ) : real(32) ], input_array_order = lapack_memory_order.row_major  );
-  var X = new LAPACK_Matrix( real(32), 2, 2, lapack_memory_order.row_major, input_array = [ ( 3.0 ) : real(32), ( 1.0 ) : real(32), ( 4.0 ) : real(32), ( 2.0 ) : real(32) ], input_array_order = lapack_memory_order.row_major  ); 
+  var A = new owned LAPACK_Matrix( real(32), 2, 2, lapack_memory_order.row_major, input_array = [ ( 5.0 ) : real(32), ( 2.0 ) : real(32), ( 1.0 ) : real(32), ( 6.0 ) : real(32) ], input_array_order = lapack_memory_order.row_major  );
+  var X = new owned LAPACK_Matrix( real(32), 2, 2, lapack_memory_order.row_major, input_array = [ ( 3.0 ) : real(32), ( 1.0 ) : real(32), ( 4.0 ) : real(32), ( 2.0 ) : real(32) ], input_array_order = lapack_memory_order.row_major  ); 
   var B = A*X;
   
-  var A_work = new LAPACK_Matrix( A );
-  var B_work = new LAPACK_Matrix( B );
+  var A_work = new owned LAPACK_Matrix( A );
+  var B_work = new owned LAPACK_Matrix( B );
   if verbose_test then
     writeln(  "A\n", A_work.toString(), 
             "\nX\n", X.toString(), 
@@ -180,12 +180,12 @@ proc gesv_col_major_test(){
   if verbose_test then
     writeln( "gesv_col_major\n===============================" );
 
-  var A = new LAPACK_Matrix( real(32), 2, 2, lapack_memory_order.column_major, input_array = [ ( 5.0 ) : real(32), ( 2.0 ) : real(32), ( 1.0 ) : real(32), ( 6.0 ) : real(32) ], input_array_order = lapack_memory_order.row_major );
-  var X = new LAPACK_Matrix( real(32), 2, 2, lapack_memory_order.column_major, input_array = [ ( 3.0 ) : real(32), ( 1.0 ) : real(32), ( 4.0 ) : real(32), ( 2.0 ) : real(32) ], input_array_order = lapack_memory_order.row_major ); 
+  var A = new owned LAPACK_Matrix( real(32), 2, 2, lapack_memory_order.column_major, input_array = [ ( 5.0 ) : real(32), ( 2.0 ) : real(32), ( 1.0 ) : real(32), ( 6.0 ) : real(32) ], input_array_order = lapack_memory_order.row_major );
+  var X = new owned LAPACK_Matrix( real(32), 2, 2, lapack_memory_order.column_major, input_array = [ ( 3.0 ) : real(32), ( 1.0 ) : real(32), ( 4.0 ) : real(32), ( 2.0 ) : real(32) ], input_array_order = lapack_memory_order.row_major ); 
   var B = A*X;
   
-  var A_work = new LAPACK_Matrix( A );
-  var B_work = new LAPACK_Matrix( B );
+  var A_work = new owned LAPACK_Matrix( A );
+  var B_work = new owned LAPACK_Matrix( B );
   if verbose_test then
     writeln(  "A\n", A_work.toString(), 
             "\nX\n", X.toString(), 

--- a/test/library/packages/LAPACK/zgesv.chpl
+++ b/test/library/packages/LAPACK/zgesv.chpl
@@ -6,12 +6,12 @@ proc LAPACK_zgesv_test(){
   if verbose_test then
     writeln( "LAPACK_zgesv\n===============================" );
 
-  var A = new LAPACK_Matrix( complex(128), 2, 2, lapack_memory_order.column_major, input_array = [ ( 5.0 + 1.0i ) : complex(128), ( 2.0 + 1.0i ) : complex(128), ( 1.0 + 1.0i ) : complex(128), ( 6.0 + 1.0i ) : complex(128) ], input_array_order = lapack_memory_order.row_major, error = 1e-7 );
-  var X = new LAPACK_Matrix( complex(128), 2, 2, lapack_memory_order.column_major, input_array = [ ( 3.0 + 1.0i ) : complex(128), ( 1.0 + 1.0i ) : complex(128), ( 4.0 + 1.0i ) : complex(128), ( 2.0 + 1.0i ) : complex(128) ], input_array_order = lapack_memory_order.row_major, error = 1e-7 ); 
+  var A = new owned LAPACK_Matrix( complex(128), 2, 2, lapack_memory_order.column_major, input_array = [ ( 5.0 + 1.0i ) : complex(128), ( 2.0 + 1.0i ) : complex(128), ( 1.0 + 1.0i ) : complex(128), ( 6.0 + 1.0i ) : complex(128) ], input_array_order = lapack_memory_order.row_major, error = 1e-7 );
+  var X = new owned LAPACK_Matrix( complex(128), 2, 2, lapack_memory_order.column_major, input_array = [ ( 3.0 + 1.0i ) : complex(128), ( 1.0 + 1.0i ) : complex(128), ( 4.0 + 1.0i ) : complex(128), ( 2.0 + 1.0i ) : complex(128) ], input_array_order = lapack_memory_order.row_major, error = 1e-7 ); 
   var B = A*X;
   
-  var A_work = new LAPACK_Matrix( A );
-  var B_work = new LAPACK_Matrix( B );
+  var A_work = new owned LAPACK_Matrix( A );
+  var B_work = new owned LAPACK_Matrix( B );
   if verbose_test then
     writeln(  "A\n", A_work.toString(), 
             "\nX\n", X.toString(), 
@@ -52,12 +52,12 @@ proc LAPACKE_zgesv_row_major_test(){
   if verbose_test then
     writeln( "LAPACKE_zgesv_row_major\n===============================" );
 
-  var A = new LAPACK_Matrix( complex(128), 2, 2, lapack_memory_order.row_major, input_array = [ ( 5.0 + 1.0i ) : complex(128), ( 2.0 + 1.0i ) : complex(128), ( 1.0 + 1.0i ) : complex(128), ( 6.0 + 1.0i ) : complex(128) ], input_array_order = lapack_memory_order.row_major, error = 1e-7  );
-  var X = new LAPACK_Matrix( complex(128), 2, 2, lapack_memory_order.row_major, input_array = [ ( 3.0 + 1.0i ) : complex(128), ( 1.0 + 1.0i ) : complex(128), ( 4.0 + 1.0i ) : complex(128), ( 2.0 + 1.0i ) : complex(128) ], input_array_order = lapack_memory_order.row_major, error = 1e-7  ); 
+  var A = new owned LAPACK_Matrix( complex(128), 2, 2, lapack_memory_order.row_major, input_array = [ ( 5.0 + 1.0i ) : complex(128), ( 2.0 + 1.0i ) : complex(128), ( 1.0 + 1.0i ) : complex(128), ( 6.0 + 1.0i ) : complex(128) ], input_array_order = lapack_memory_order.row_major, error = 1e-7  );
+  var X = new owned LAPACK_Matrix( complex(128), 2, 2, lapack_memory_order.row_major, input_array = [ ( 3.0 + 1.0i ) : complex(128), ( 1.0 + 1.0i ) : complex(128), ( 4.0 + 1.0i ) : complex(128), ( 2.0 + 1.0i ) : complex(128) ], input_array_order = lapack_memory_order.row_major, error = 1e-7  ); 
   var B = A*X;
   
-  var A_work = new LAPACK_Matrix( A );
-  var B_work = new LAPACK_Matrix( B );
+  var A_work = new owned LAPACK_Matrix( A );
+  var B_work = new owned LAPACK_Matrix( B );
   if verbose_test then
     writeln(  "A\n", A_work.toString(), 
             "\nX\n", X.toString(), 
@@ -96,12 +96,12 @@ proc LAPACKE_zgesv_col_major_test(){
   if verbose_test then
     writeln( "LAPACKE_zgesv_col_major\n===============================" );
 
-  var A = new LAPACK_Matrix( complex(128), 2, 2, lapack_memory_order.column_major, input_array = [ ( 5.0 + 1.0i ) : complex(128), ( 2.0 + 1.0i ) : complex(128), ( 1.0 + 1.0i ) : complex(128), ( 6.0 + 1.0i ) : complex(128) ], input_array_order = lapack_memory_order.row_major, error = 1e-7 );
-  var X = new LAPACK_Matrix( complex(128), 2, 2, lapack_memory_order.column_major, input_array = [ ( 3.0 + 1.0i ) : complex(128), ( 1.0 + 1.0i ) : complex(128), ( 4.0 + 1.0i ) : complex(128), ( 2.0 + 1.0i ) : complex(128) ], input_array_order = lapack_memory_order.row_major , error = 1e-7); 
+  var A = new owned LAPACK_Matrix( complex(128), 2, 2, lapack_memory_order.column_major, input_array = [ ( 5.0 + 1.0i ) : complex(128), ( 2.0 + 1.0i ) : complex(128), ( 1.0 + 1.0i ) : complex(128), ( 6.0 + 1.0i ) : complex(128) ], input_array_order = lapack_memory_order.row_major, error = 1e-7 );
+  var X = new owned LAPACK_Matrix( complex(128), 2, 2, lapack_memory_order.column_major, input_array = [ ( 3.0 + 1.0i ) : complex(128), ( 1.0 + 1.0i ) : complex(128), ( 4.0 + 1.0i ) : complex(128), ( 2.0 + 1.0i ) : complex(128) ], input_array_order = lapack_memory_order.row_major , error = 1e-7); 
   var B = A*X;
   
-  var A_work = new LAPACK_Matrix( A );
-  var B_work = new LAPACK_Matrix( B );
+  var A_work = new owned LAPACK_Matrix( A );
+  var B_work = new owned LAPACK_Matrix( B );
   if verbose_test then
     writeln(  "A\n", A_work.toString(), 
             "\nX\n", X.toString(), 
@@ -140,12 +140,12 @@ proc gesv_row_major_test(){
   if verbose_test then
     writeln( "gesv_row_major\n===============================" );
 
-  var A = new LAPACK_Matrix( complex(128), 2, 2, lapack_memory_order.row_major, input_array = [ ( 5.0 + 1.0i ) : complex(128), ( 2.0 + 1.0i ) : complex(128), ( 1.0 + 1.0i ) : complex(128), ( 6.0 + 1.0i ) : complex(128) ], input_array_order = lapack_memory_order.row_major, error = 1e-7  );
-  var X = new LAPACK_Matrix( complex(128), 2, 2, lapack_memory_order.row_major, input_array = [ ( 3.0 + 1.0i ) : complex(128), ( 1.0 + 1.0i ) : complex(128), ( 4.0 + 1.0i ) : complex(128), ( 2.0 + 1.0i ) : complex(128) ], input_array_order = lapack_memory_order.row_major, error = 1e-7  ); 
+  var A = new owned LAPACK_Matrix( complex(128), 2, 2, lapack_memory_order.row_major, input_array = [ ( 5.0 + 1.0i ) : complex(128), ( 2.0 + 1.0i ) : complex(128), ( 1.0 + 1.0i ) : complex(128), ( 6.0 + 1.0i ) : complex(128) ], input_array_order = lapack_memory_order.row_major, error = 1e-7  );
+  var X = new owned LAPACK_Matrix( complex(128), 2, 2, lapack_memory_order.row_major, input_array = [ ( 3.0 + 1.0i ) : complex(128), ( 1.0 + 1.0i ) : complex(128), ( 4.0 + 1.0i ) : complex(128), ( 2.0 + 1.0i ) : complex(128) ], input_array_order = lapack_memory_order.row_major, error = 1e-7  ); 
   var B = A*X;
   
-  var A_work = new LAPACK_Matrix( A );
-  var B_work = new LAPACK_Matrix( B );
+  var A_work = new owned LAPACK_Matrix( A );
+  var B_work = new owned LAPACK_Matrix( B );
   if verbose_test then
     writeln(  "A\n", A_work.toString(), 
             "\nX\n", X.toString(), 
@@ -180,12 +180,12 @@ proc gesv_col_major_test(){
   if verbose_test then
     writeln( "gesv_col_major\n===============================" );
 
-  var A = new LAPACK_Matrix( complex(128), 2, 2, lapack_memory_order.column_major, input_array = [ ( 5.0 + 1.0i ) : complex(128), ( 2.0 + 1.0i ) : complex(128), ( 1.0 + 1.0i ) : complex(128), ( 6.0 + 1.0i ) : complex(128) ], input_array_order = lapack_memory_order.row_major, error = 1e-7 );
-  var X = new LAPACK_Matrix( complex(128), 2, 2, lapack_memory_order.column_major, input_array = [ ( 3.0 + 1.0i ) : complex(128), ( 1.0 + 1.0i ) : complex(128), ( 4.0 + 1.0i ) : complex(128), ( 2.0 + 1.0i ) : complex(128) ], input_array_order = lapack_memory_order.row_major, error = 1e-7 ); 
+  var A = new owned LAPACK_Matrix( complex(128), 2, 2, lapack_memory_order.column_major, input_array = [ ( 5.0 + 1.0i ) : complex(128), ( 2.0 + 1.0i ) : complex(128), ( 1.0 + 1.0i ) : complex(128), ( 6.0 + 1.0i ) : complex(128) ], input_array_order = lapack_memory_order.row_major, error = 1e-7 );
+  var X = new owned LAPACK_Matrix( complex(128), 2, 2, lapack_memory_order.column_major, input_array = [ ( 3.0 + 1.0i ) : complex(128), ( 1.0 + 1.0i ) : complex(128), ( 4.0 + 1.0i ) : complex(128), ( 2.0 + 1.0i ) : complex(128) ], input_array_order = lapack_memory_order.row_major, error = 1e-7 ); 
   var B = A*X;
   
-  var A_work = new LAPACK_Matrix( A );
-  var B_work = new LAPACK_Matrix( B );
+  var A_work = new owned LAPACK_Matrix( A );
+  var B_work = new owned LAPACK_Matrix( B );
   if verbose_test then
     writeln(  "A\n", A_work.toString(), 
             "\nX\n", X.toString(), 

--- a/test/library/packages/LinearAlgebra/correctness/test_identities1.chpl
+++ b/test/library/packages/LinearAlgebra/correctness/test_identities1.chpl
@@ -49,7 +49,7 @@ proc test_assoc(type t) {
   var B = Matrix(M, N, t);
   var C = Matrix(N, P, t);
 
-  var rng=new RandomStream(t, seed=seed);
+  var rng=new owned RandomStream(t, seed=seed);
   for ii in 0.. #nIters {
     rng.fillRandom(A);
     rng.fillRandom(B);
@@ -75,7 +75,7 @@ proc test_transpose_product(type t) {
   var A = Matrix(L, M, t);
   var B = Matrix(M, N, t);
 
-  var rng=new RandomStream(t, seed=seed);
+  var rng=new owned RandomStream(t, seed=seed);
   for ii in 0.. #nIters {
     rng.fillRandom(A);
     rng.fillRandom(B);
@@ -99,7 +99,7 @@ proc test_trace_rotate(type t) {
   var A = Matrix(M, N, t);
   var B = Matrix(N, M, t);
 
-  var rng=new RandomStream(t, seed=seed);
+  var rng=new owned RandomStream(t, seed=seed);
   for ii in 0.. #nIters {
     rng.fillRandom(A);
     rng.fillRandom(B);
@@ -123,7 +123,7 @@ proc test_trace_vector_rotate(type t) {
   var v = Vector(M, t);
   var w = Vector(M, t);
 
-  var rng=new RandomStream(t, seed=seed);
+  var rng=new owned RandomStream(t, seed=seed);
   for ii in 0.. #nIters {
     rng.fillRandom(A);
     rng.fillRandom(v);

--- a/test/trivial/mjoyner/inlinefunc/inlfunc2_report.chpl
+++ b/test/trivial/mjoyner/inlinefunc/inlfunc2_report.chpl
@@ -8,7 +8,7 @@ class Foo {
 }
 
 proc main() {
-  var f : Foo = new Foo();
+  var f : unmanaged Foo = new unmanaged Foo();
 
   /* setter method will be created, temporary should not be created for f
    * since formal param this will be a ref */

--- a/test/types/records/sungeun/stringInRecordInClass.chpl
+++ b/test/types/records/sungeun/stringInRecordInClass.chpl
@@ -7,7 +7,7 @@ class myC {
 }
 
 proc main {
-  var c = new myC();
+  var c = new owned myC();
   var s = "hi";
   writeln(c);
   c.r.s = s;

--- a/test/types/records/sungeun/stringInRecordInClass.skipif
+++ b/test/types/records/sungeun/stringInRecordInClass.skipif
@@ -1,1 +1,0 @@
-CHPL_TEST_VGRND_EXE == off

--- a/test/types/string/sungeun/string2InRecordInClass.chpl
+++ b/test/types/string/sungeun/string2InRecordInClass.chpl
@@ -4,7 +4,7 @@ record myR {
 class myC {
   var r: myR;
 }
-var c = new myC();
+var c = new owned myC();
 var s1 = "hi";
 
 writeln(c);

--- a/test/types/string/sungeun/string2InRecordInClass.skipif
+++ b/test/types/string/sungeun/string2InRecordInClass.skipif
@@ -1,1 +1,0 @@
-CHPL_TEST_VGRND_EXE == off

--- a/test/users/engin/partial_reduction_support/unit_tests/sparsePartialThese.chpl
+++ b/test/users/engin/partial_reduction_support/unit_tests/sparsePartialThese.chpl
@@ -7,7 +7,7 @@ use LayoutCS;
 config const N = 10;
 config type layoutType = DefaultDist;
 
-const layout = new layoutType;
+const layout = new unmanaged layoutType;
 const ParentDom = {0..#N, 0..#2*N};
 var SparseDom: sparse subdomain(ParentDom) dmapped new dmap(layout);
 var SparseMat: [SparseDom] int;


### PR DESCRIPTION
This PR is a follow-on to PR #10775

* Fix tasks=fifo issues
* Fix problems with LAPACK and LinearAlgebra tests
* Fix problems on tests that only ran under valgrind testing

- [x] full quickstart testing
- [x] test/library/packages/LAPACK and test/library/packages/LinearAlgebra pass on a Cray XC

Reviewed by @benharsh - thanks!