### PR TITLE
Improve override errors for inherited iterators

### DIFF
--- a/compiler/AST/FnSymbol.cpp
+++ b/compiler/AST/FnSymbol.cpp
@@ -917,6 +917,11 @@ bool FnSymbol::isSecondaryMethod() const {
   return isMethod() == true && isPrimaryMethod() == false;
 }
 
+bool FnSymbol::isUserDefined() const {
+  return (!hasFlag(FLAG_COMPILER_GENERATED) &&
+          !hasFlag(FLAG_AUTO_II));
+}
+
 bool FnSymbol::isInitializer() const {
   return isMethod() == true && strcmp(name, "init")     == 0;
 }

--- a/compiler/AST/FnSymbol.cpp
+++ b/compiler/AST/FnSymbol.cpp
@@ -917,9 +917,9 @@ bool FnSymbol::isSecondaryMethod() const {
   return isMethod() == true && isPrimaryMethod() == false;
 }
 
-bool FnSymbol::isUserDefined() const {
-  return (!hasFlag(FLAG_COMPILER_GENERATED) &&
-          !hasFlag(FLAG_AUTO_II));
+bool FnSymbol::isCompilerGenerated() const {
+  return (hasFlag(FLAG_COMPILER_GENERATED) ||
+          hasFlag(FLAG_AUTO_II));
 }
 
 bool FnSymbol::isInitializer() const {

--- a/compiler/include/FnSymbol.h
+++ b/compiler/include/FnSymbol.h
@@ -164,6 +164,7 @@ public:
 
   bool                       isPrimaryMethod()                           const;
   bool                       isSecondaryMethod()                         const;
+  bool                       isUserDefined()                             const;
 
   bool                       isInitializer()                             const;
   bool                       isPostInitializer()                         const;

--- a/compiler/include/FnSymbol.h
+++ b/compiler/include/FnSymbol.h
@@ -164,7 +164,7 @@ public:
 
   bool                       isPrimaryMethod()                           const;
   bool                       isSecondaryMethod()                         const;
-  bool                       isUserDefined()                             const;
+  bool                       isCompilerGenerated()                       const;
 
   bool                       isInitializer()                             const;
   bool                       isPostInitializer()                         const;

--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -717,7 +717,8 @@ static IteratorInfo*  makeIteratorInfo(AggregateType* iClass,
 
 static FnSymbol*      makeIteratorMethod(IteratorInfo* ii,
                                          const char*   name,
-                                         Type*         retType);
+                                         Type*         retType,
+                                         bool          override=false);
 
 static void protoIteratorClass(FnSymbol* fn, Type* yieldedType) {
   INT_ASSERT(yieldedType != NULL);
@@ -854,13 +855,17 @@ static IteratorInfo*  makeIteratorInfo(AggregateType* iClass,
 
 static FnSymbol* makeIteratorMethod(IteratorInfo* ii,
                                     const char*   name,
-                                    Type*         retType) {
+                                    Type*         retType,
+                                    bool          override) {
   FnSymbol* fn = new FnSymbol(name);
 
   fn->addFlag(FLAG_AUTO_II);
 
   if (strcmp(name, "advance") != 0) {
     fn->addFlag(FLAG_INLINE);
+  }
+  if (ii->iterator->hasFlag(FLAG_OVERRIDE)) {
+    fn->addFlag(FLAG_OVERRIDE);
   }
 
   fn->setMethod(true);

--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -862,9 +862,6 @@ static FnSymbol* makeIteratorMethod(IteratorInfo* ii,
   if (strcmp(name, "advance") != 0) {
     fn->addFlag(FLAG_INLINE);
   }
-  if (ii->iterator->hasFlag(FLAG_OVERRIDE)) {
-    fn->addFlag(FLAG_OVERRIDE);
-  }
 
   fn->setMethod(true);
 

--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -717,8 +717,7 @@ static IteratorInfo*  makeIteratorInfo(AggregateType* iClass,
 
 static FnSymbol*      makeIteratorMethod(IteratorInfo* ii,
                                          const char*   name,
-                                         Type*         retType,
-                                         bool          override=false);
+                                         Type*         retType);
 
 static void protoIteratorClass(FnSymbol* fn, Type* yieldedType) {
   INT_ASSERT(yieldedType != NULL);
@@ -855,8 +854,7 @@ static IteratorInfo*  makeIteratorInfo(AggregateType* iClass,
 
 static FnSymbol* makeIteratorMethod(IteratorInfo* ii,
                                     const char*   name,
-                                    Type*         retType,
-                                    bool          override) {
+                                    Type*         retType) {
   FnSymbol* fn = new FnSymbol(name);
 
   fn->addFlag(FLAG_AUTO_II);

--- a/compiler/resolution/virtualDispatch.cpp
+++ b/compiler/resolution/virtualDispatch.cpp
@@ -314,7 +314,14 @@ static bool possibleSignatureMatch(FnSymbol* fn, FnSymbol* gn) {
 
 static bool checkOverrides(FnSymbol* fn) {
   ModuleSymbol* parentMod = fn->getModule();
-  return (fOverrideChecking || (parentMod && parentMod->modTag != MOD_USER));
+  // check overrides if any of these are true...
+          // (a) the flag is on and the function is not compiler-generated
+  return ((fOverrideChecking && !fn->isCompilerGenerated()) ||
+          // (b) developer is on (avoids printing developer cases to users)
+          developer == true ||
+          // (c) the function is in the modules/ hierarchy (which we manage
+          //     and want to keep clean)
+          (parentMod && parentMod->modTag != MOD_USER));
 }
 
 static void checkIntentsMatch(FnSymbol* pfn, FnSymbol* cfn) {
@@ -1010,8 +1017,7 @@ static void checkMethodsOverride() {
             }
           }
 
-          if (okKnown && ok == false &&
-              (developer == true || fn->isUserDefined())) {
+          if (okKnown && ok == false) {
             if (fn->hasFlag(FLAG_OVERRIDE)) {
               USR_FATAL_CONT(fn, "%s.%s override keyword present but no "
                                   "superclass method matches signature "

--- a/compiler/resolution/virtualDispatch.cpp
+++ b/compiler/resolution/virtualDispatch.cpp
@@ -319,12 +319,9 @@ static bool checkOverrides(FnSymbol* fn) {
           //     (a) the function is not compiler-generated or
           //     (b) --devel is on
           //  or...
-  return (((fOverrideChecking &&
-            (!fn->isCompilerGenerated() ||
-             (fn->isCompilerGenerated() && developer == true)))) ||
-          // (2) the function is in the modules/ hierarchy (which we manage
-          //     and want to keep clean); oncer override checking is on by
-          //     default, we'd likely only check these when --devel is on?
+  return ((fOverrideChecking && (!fn->isCompilerGenerated() || developer)) ||
+          // (2) the function is in the modules/ hierarchy
+          //     (which we manage and want to keep clean)
           (parentMod && parentMod->modTag != MOD_USER));
 }
 
@@ -866,15 +863,46 @@ static void findFunctionsProbablyMatching(TypeToNameToFns & map,
   }
 }
 
+// methods on iterator class -> the iterator defining them
+static FnSymbol* getOverrideCandidate(FnSymbol* fn) {
+  FnSymbol* ret = fn;
+  if (fn->_this && fn->hasFlag(FLAG_AUTO_II)) {
+    // e.g. zip, advance, ...
+    if (AggregateType* iteratorClass = toAggregateType(fn->_this->getValType()))
+      if (iteratorClass->symbol->hasFlag(FLAG_ITERATOR_CLASS))
+        ret = getTheIteratorFn(iteratorClass);
+  }
+
+  // Check that ret has a class _this
+  if (ret->_this)
+    if (AggregateType* at = toAggregateType(ret->_this->getValType()))
+      if (at->isClass())
+        return ret;
+
+  // otherwise, not a candidate.
+  return NULL;
+}
+
+// This function helps avoid redundant errors for different
+// instantiations of a generic
+static FnSymbol* getOverrideCandidateGenericFn(FnSymbol* fn)
+{
+  while (fn->instantiatedFrom)
+    fn = fn->instantiatedFrom;
+  return fn;
+}
+
 // This function checks that the override keyword is used appropriately
 // checkOverrides would also be a reasonable name for it.
 static void checkMethodsOverride() {
 
   TypeToNameToFns map;
 
+  std::set<FnSymbol*> erroredFunctions;
+
   // populate the map
-  forv_Vec(FnSymbol, fn, gFnSymbols) {
-    if (fn->_this)
+  forv_Vec(FnSymbol, aFn, gFnSymbols) {
+    if (FnSymbol* fn = getOverrideCandidate(aFn))
       if (checkOverrides(fn))
         if (AggregateType* ct = toAggregateType(fn->_this->getValType()))
           if (isOverrideableMethod(fn))
@@ -882,57 +910,64 @@ static void checkMethodsOverride() {
   }
 
   // now check each function
-  forv_Vec(FnSymbol, fn, gFnSymbols) {
-    if (checkOverrides(fn) &&
-        fn->_this &&
-        // ignore errors with deinit
-        fn->name != astrDeinit &&
-        // ignore errors for init()
-        !fn->isInitializer() &&
-        // ignore errors for postinit()
-        !fn->isPostInitializer()) {
-      if (AggregateType* ct = toAggregateType(fn->_this->getValType())) {
+  forv_Vec(FnSymbol, aFn, gFnSymbols) {
+    // output error for overriding for non-class methods
+    if (aFn->hasFlag(FLAG_OVERRIDE)) {
+      Type* thisType = aFn->_this->getValType();
+      if (!isClass(thisType)) {
+        const char* type = "non-class";
+        if (isRecord(thisType))
+          type = "record";
+        FnSymbol* eFn = getOverrideCandidateGenericFn(aFn);
+        if (erroredFunctions.count(eFn) == 0) {
+          USR_FATAL_CONT(aFn, "%s.%s override keyword present but "
+                         "%s methods cannot override",
+                         thisType->symbol->name, aFn->name, type);
+          erroredFunctions.insert(eFn);
+          continue;
+        }
+      }
+    }
 
-        if (ct->isRecord()) {
-          if (fn->hasFlag(FLAG_OVERRIDE)) {
-             USR_FATAL_CONT(fn, "%s.%s override keyword present but "
-                            "record methods cannot override",
-                            ct->symbol->name, fn->name);
-             continue;
+    if (FnSymbol* fn = getOverrideCandidate(aFn)) {
+      if (checkOverrides(fn) &&
+          // ignore errors with deinit
+          fn->name != astrDeinit &&
+          // ignore errors for init()
+          !fn->isInitializer() &&
+          // ignore errors for postinit()
+          !fn->isPostInitializer() &&
+          // ignore duplicate errors
+          erroredFunctions.count(fn) == 0) {
+
+        AggregateType* ct = toAggregateType(fn->_this->getValType());
+        INT_ASSERT(ct && ct->isClass());
+
+
+        // Do some initial basic checking
+        if (fn->hasFlag(FLAG_OVERRIDE)) {
+          const char* msg = NULL;
+          if (fn->hasFlag(FLAG_NO_PARENS))
+            msg = "parentheses-less methods cannot override";
+          else if (fn->retTag == RET_PARAM)
+             msg = "param return methods cannot override";
+          else if (fn->retTag == RET_TYPE)
+             msg = "type return methods cannot override";
+          else if (!isOverrideableMethod(fn))
+             msg = "signature is not overrideable";
+
+          if (msg != NULL) {
+            FnSymbol* eFn = getOverrideCandidateGenericFn(fn);
+            if (erroredFunctions.count(eFn) == 0) {
+              USR_FATAL_CONT(fn, "%s.%s override keyword present but %s",
+                             ct->symbol->name, fn->name, msg);
+              erroredFunctions.insert(eFn);
+            }
+            continue;
           }
         }
 
-        if (ct->isClass()) {
-          if (fn->hasFlag(FLAG_OVERRIDE)) {
-            if (fn->hasFlag(FLAG_NO_PARENS)) {
-               USR_FATAL_CONT(fn, "%s.%s override keyword present but "
-                              "parentheses-less methods cannot override",
-                              ct->symbol->name, fn->name);
-               continue;
-            }
-
-            if (fn->retTag == RET_PARAM) {
-               USR_FATAL_CONT(fn, "%s.%s override keyword present but "
-                              "param return methods cannot override",
-                              ct->symbol->name, fn->name);
-               continue;
-            }
-
-            if (fn->retTag == RET_TYPE) {
-               USR_FATAL_CONT(fn, "%s.%s override keyword present but "
-                              "type return methods cannot override",
-                              ct->symbol->name, fn->name);
-               continue;
-            }
-
-            if (!isOverrideableMethod(fn)) {
-               USR_FATAL_CONT(fn, "%s.%s override keyword present but "
-                              "signature is not overrideable",
-                              ct->symbol->name, fn->name);
-               continue;
-            }
-          }
-
+        {
           std::vector<FnSymbol*> matches;
           forv_Vec(AggregateType, pt, ct->dispatchParents) {
             findFunctionsProbablyMatching(map, fn, pt, matches);
@@ -1022,15 +1057,19 @@ static void checkMethodsOverride() {
           }
 
           if (okKnown && ok == false) {
-            if (fn->hasFlag(FLAG_OVERRIDE)) {
-              USR_FATAL_CONT(fn, "%s.%s override keyword present but no "
-                                  "superclass method matches signature "
-                                  "to override",
-                                   ct->symbol->name, fn->name);
-            } else {
-              USR_WARN(fn, "%s.%s override keyword required for method "
-                           "matching signature of superclass method",
-                           ct->symbol->name, fn->name);
+            FnSymbol* eFn = getOverrideCandidateGenericFn(fn);
+            if (erroredFunctions.count(eFn) == 0) {
+              if (fn->hasFlag(FLAG_OVERRIDE))
+                USR_FATAL_CONT(fn, "%s.%s override keyword present but no "
+                                    "superclass method matches signature "
+                                    "to override",
+                                     ct->symbol->name, fn->name);
+              else
+                USR_WARN(fn, "%s.%s override keyword required for method "
+                             "matching signature of superclass method",
+                             ct->symbol->name, fn->name);
+
+              erroredFunctions.insert(eFn);
             }
           }
         }

--- a/compiler/resolution/virtualDispatch.cpp
+++ b/compiler/resolution/virtualDispatch.cpp
@@ -314,13 +314,17 @@ static bool possibleSignatureMatch(FnSymbol* fn, FnSymbol* gn) {
 
 static bool checkOverrides(FnSymbol* fn) {
   ModuleSymbol* parentMod = fn->getModule();
-  // check overrides if any of these are true...
-          // (a) the flag is on and the function is not compiler-generated
-  return ((fOverrideChecking && !fn->isCompilerGenerated()) ||
-          // (b) developer is on (avoids printing developer cases to users)
-          developer == true ||
-          // (c) the function is in the modules/ hierarchy (which we manage
-          //     and want to keep clean)
+  // check overrides for a given function if any of these are true...
+          // (1) the flag is on and either
+          //     (a) the function is not compiler-generated or
+          //     (b) --devel is on
+          //  or...
+  return (((fOverrideChecking &&
+            (!fn->isCompilerGenerated() ||
+             (fn->isCompilerGenerated() && developer == true)))) ||
+          // (2) the function is in the modules/ hierarchy (which we manage
+          //     and want to keep clean); oncer override checking is on by
+          //     default, we'd likely only check these when --devel is on?
           (parentMod && parentMod->modTag != MOD_USER));
 }
 

--- a/compiler/resolution/virtualDispatch.cpp
+++ b/compiler/resolution/virtualDispatch.cpp
@@ -1010,7 +1010,8 @@ static void checkMethodsOverride() {
             }
           }
 
-          if (okKnown && ok == false) {
+          if (okKnown && ok == false &&
+              (developer == true || fn->isUserDefined())) {
             if (fn->hasFlag(FLAG_OVERRIDE)) {
               USR_FATAL_CONT(fn, "%s.%s override keyword present but no "
                                   "superclass method matches signature "

--- a/test/classes/dinan/dyndispatch_these.chpl
+++ b/test/classes/dinan/dyndispatch_these.chpl
@@ -8,7 +8,7 @@ class A {
 }
 
 class B:A {
-  iter these() {
+  override iter these() {
     for i in 1..n by -1 do
       yield i;
   }

--- a/test/classes/ferguson/override/override-combined.good
+++ b/test/classes/ferguson/override/override-combined.good
@@ -1,5 +1,4 @@
 override-combined.chpl:9: error: Child.g override keyword present but no superclass method matches signature to override
 override-combined.chpl:12: warning: Child.f override keyword required for method matching signature of superclass method
 override-combined.chpl:15: error: Child.g_generic override keyword present but no superclass method matches signature to override
-override-combined.chpl:15: error: Child.g_generic override keyword present but no superclass method matches signature to override
 override-combined.chpl:18: warning: Child.f_generic override keyword required for method matching signature of superclass method

--- a/test/classes/ferguson/override/override-iter-missing.chpl
+++ b/test/classes/ferguson/override/override-iter-missing.chpl
@@ -1,0 +1,25 @@
+class Parent {
+  iter myiter() {
+    yield 1;
+  }
+  iter these() {
+    yield 1;
+  }
+}
+
+class Child : Parent {
+  iter myiter() {
+    yield 2;
+  }
+  iter these() {
+    yield 2;
+  }
+}
+
+proc main() {
+  var p:Parent = new borrowed Child();
+  for x in p.myiter() do
+    writeln("x ", x);
+  for y in p do
+    writeln("y ", y);
+}

--- a/test/classes/ferguson/override/override-iter-missing.good
+++ b/test/classes/ferguson/override/override-iter-missing.good
@@ -1,0 +1,2 @@
+override-iter-missing.chpl:11: warning: Child.myiter overrides parent class method Parent.myiter but missing override keyword
+override-iter-missing.chpl:14: warning: Child.these overrides parent class method Parent.these but missing override keyword

--- a/test/classes/ferguson/override/override-iter-ok.chpl
+++ b/test/classes/ferguson/override/override-iter-ok.chpl
@@ -1,0 +1,25 @@
+class Parent {
+  iter myiter() {
+    yield 1;
+  }
+  iter these() {
+    yield 1;
+  }
+}
+
+class Child : Parent {
+  override iter myiter() {
+    yield 2;
+  }
+  override iter these() {
+    yield 2;
+  }
+}
+
+proc main() {
+  var p:Parent = new borrowed Child();
+  for x in p.myiter() do
+    writeln("x ", x);
+  for y in p do
+    writeln("y ", y);
+}

--- a/test/classes/ferguson/override/override-iter-spurious.chpl
+++ b/test/classes/ferguson/override/override-iter-spurious.chpl
@@ -1,0 +1,25 @@
+class Parent {
+  iter myiter(arg:int) {
+    yield arg;
+  }
+  iter these(arg:int) {
+    yield 1;
+  }
+}
+
+class Child : Parent {
+  override iter myiter() {
+    yield 2;
+  }
+  override iter these() {
+    yield 2;
+  }
+}
+
+proc main() {
+  var p = new borrowed Child();
+  for x in p.myiter() do
+    writeln("x ", x);
+  for y in p do
+    writeln("y ", y);
+}

--- a/test/classes/ferguson/override/override-iter-spurious.good
+++ b/test/classes/ferguson/override/override-iter-spurious.good
@@ -1,0 +1,2 @@
+override-iter-spurious.chpl:11: error: Child.myiter override keyword present but no superclass method matches signature to override
+override-iter-spurious.chpl:14: error: Child.these override keyword present but no superclass method matches signature to override

--- a/test/functions/deitz/iterators/test_override1.chpl
+++ b/test/functions/deitz/iterators/test_override1.chpl
@@ -6,7 +6,7 @@ class C {
 }
 
 class D: C {
-  iter foo(n: int) {
+  override iter foo(n: int) {
     for i in 1..n by -1 do
       yield i;
   }

--- a/test/functions/deitz/iterators/test_override2.chpl
+++ b/test/functions/deitz/iterators/test_override2.chpl
@@ -6,7 +6,7 @@ class C {
 }
 
 class D: C {
-  iter foo(n: int) {
+  override iter foo(n: int) {
     for i in 1..n do
       yield i;
     for i in 1..n by -1 do

--- a/test/functions/deitz/iterators/test_override3.chpl
+++ b/test/functions/deitz/iterators/test_override3.chpl
@@ -8,7 +8,7 @@ class C {
 }
 
 class D: C {
-  iter foo(n: int) {
+  override iter foo(n: int) {
     for i in 1..n do
       yield i;
   }

--- a/test/functions/deitz/iterators/test_override4.chpl
+++ b/test/functions/deitz/iterators/test_override4.chpl
@@ -6,7 +6,7 @@ class C {
 }
 
 class D: C {
-  iter foo(n: int) {
+  override iter foo(n: int) {
     for i in 1..n by -1 do
       yield i;
   }

--- a/test/functions/deitz/iterators/test_override5_error.chpl
+++ b/test/functions/deitz/iterators/test_override5_error.chpl
@@ -6,7 +6,7 @@ class C {
 }
 
 class D: C {
-  iter foo(n: int) {
+  override iter foo(n: int) {
     for i in 1..n by -1 do
       yield (i,i);
   }

--- a/test/functions/iterators/bradc/override.chpl
+++ b/test/functions/iterators/bradc/override.chpl
@@ -7,7 +7,7 @@ class C {
 }
 
 class D : C {
-  iter these() {
+  override iter these() {
     yield 3;
     yield 2;
     yield 1;

--- a/test/functions/iterators/bradc/override2.chpl
+++ b/test/functions/iterators/bradc/override2.chpl
@@ -7,7 +7,7 @@ class C {
 }
 
 class D : C {
-  iter these() {
+  override iter these() {
     yield 3;
     yield 2;
     yield 1;

--- a/test/functions/iterators/diten/dynamicDispatchIterator3Levels.chpl
+++ b/test/functions/iterators/diten/dynamicDispatchIterator3Levels.chpl
@@ -10,7 +10,7 @@ class Parent {
 }
 
 class Child: Parent {
-  iter myit() {
+  override iter myit() {
     var low = 1;
     var high = 8;
     var stride = 2;
@@ -22,7 +22,7 @@ class Child: Parent {
 }
 
 class Grandchild: Child {
-  iter myit() {
+  override iter myit() {
     var low = 2;
     var high = 8;
     var stride = 2;

--- a/test/functions/iterators/vass/dynamic-dispatch-iterators.chpl
+++ b/test/functions/iterators/vass/dynamic-dispatch-iterators.chpl
@@ -5,8 +5,8 @@ class Superclass {
 }
 
 class Subclass:Superclass {
-  proc parens() { writeln("parens() in Subclass"); }
-  iter itest() { yield "Subclass"; }
+  override proc parens() { writeln("parens() in Subclass"); }
+  override iter itest() { yield "Subclass"; }
 }
 
 var c: unmanaged Superclass;

--- a/test/trivial/jturner/iter_overload_simple-blc.chpl
+++ b/test/trivial/jturner/iter_overload_simple-blc.chpl
@@ -11,7 +11,7 @@ class Parent {
 }
 
 class Child : Parent {
-  iter foo(k:int) {
+  override iter foo(k:int) {
     for l in myiter() {
       yield k+l+100;
     }
@@ -19,7 +19,7 @@ class Child : Parent {
 }
 
 class GrandChild : Child {
-  iter foo(k:int) {
+  override iter foo(k:int) {
     yield 3;
   }
 }

--- a/test/trivial/jturner/iter_overload_simple.chpl
+++ b/test/trivial/jturner/iter_overload_simple.chpl
@@ -11,7 +11,7 @@ class Parent {
 }
 
 class Child : Parent {
-  iter foo(k:int) {
+  override iter foo(k:int) {
     for l in myiter() {
       yield k+l+100;
     }

--- a/test/users/thom/itoverride.chpl
+++ b/test/users/thom/itoverride.chpl
@@ -5,7 +5,7 @@ class C
 
 class SubC : C
 {
-  proc writeThis(w) { w.write("SubC"); }
+  override proc writeThis(w) { w.write("SubC"); }
 }
 
 class OverrideMe
@@ -24,12 +24,12 @@ class OverrideMe
 
 class OverridesIt : OverrideMe
 {
-  proc getC()
+  override proc getC()
   {
     return new unmanaged SubC();
   }
 
-  iter manyC()
+  override iter manyC()
   {
     yield new unmanaged SubC();
     yield new unmanaged SubC();


### PR DESCRIPTION
(This PR is a combination of work by @bradcray and @mppf)
Closes #10731.

This does a few things:

* Updates tests to use `override` for inherited iterator methods when 
  needed
* Updates override checking for iterator methods  (e.g., zip1(),
  advance(), etc.)  to check the related user iterator (e.g. these).
* Avoid redundant override error messages for iterators or instantiations
* Updates generation of `override` warnings/errors to squash them for
  compiler-generated methods unless `--devel` is on.
* Adds a utility function FnSymbol::isCompilerGenerated() that answers
  the question since many compiler-generated functions do not have
  `FLAG_COMPILER_GENERATED`. This will help with the "resolve only
  concrete functions" effort.

- [x] full local testing

Reviewed by @benharsh - thanks!