### PR TITLE
Fix memory leak in list.pop_front

### DIFF
--- a/modules/standard/List.chpl
+++ b/modules/standard/List.chpl
@@ -184,18 +184,19 @@ record list {
      Remove the first element from the list and return it.
      It is an error to call this function on an empty list.
    */
- proc pop_front():eltType {
-   if boundsChecking && length < 1 {
-     HaltWrappers.boundsCheckHalt("pop_front on empty list");
+   proc pop_front():eltType {
+     if boundsChecking && length < 1 {
+       HaltWrappers.boundsCheckHalt("pop_front on empty list");
+     }
+     var oldfirst = first;
+     var newfirst = first.next;
+     var ret = oldfirst.data;
+     first = newfirst;
+     if last == oldfirst then last = newfirst;
+     length -= 1;
+     delete oldfirst;
+     return ret;
    }
-   var oldfirst = first;
-   var newfirst = first.next;
-   var ret = oldfirst.data;
-   first = newfirst;
-   if last == oldfirst then last = newfirst;
-   length -= 1;
-   return ret;
- }
 
   /*
     Delete every node in the list.


### PR DESCRIPTION
Previously, list.pop_front did not delete the unmanaged listNode instances that it removes from the list, resulting in memory leaking, which this corrects.
(additionally, there was some inconstant formatting which was brought in line with the rest of the file.)

Tests pass on my end.