### PR TITLE
Turn off Qthreads guard pages for LCALS on high core-count systems

### DIFF
--- a/test/release/examples/benchmarks/lcals/LCALSMain.execenv
+++ b/test/release/examples/benchmarks/lcals/LCALSMain.execenv
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+
+# Guard pages are expensive on high core-count systems. See issue #7533
+
+import os
+if os.getenv('CHPL_TARGET_ARCH', '') in ['arm-thunderx', 'arm-thunderx2', 'mic-knl']:
+    print('QT_GUARD_PAGES=false')


### PR DESCRIPTION
LCALS appears to suffer from the same Qthreads guard pages issue that was afflicting lulesh and miniMD.  See #10530 and #10661 .  This change copies the execenv from those tests to LCALS.

Turning off guard pages also makes LCALS well over 10% faster.