### PR TITLE
Fix two problems with override checking

### DIFF
--- a/test/arrays/diten/timeVectorArray.chpl
+++ b/test/arrays/diten/timeVectorArray.chpl
@@ -11,7 +11,7 @@ class Runner {
 
 class PushBack: Runner {
   const n: int;
-  proc run(A: [] int) {
+  override proc run(A: [] int) {
     for i in 1..n {
       A.push_back(i);
     }
@@ -20,7 +20,7 @@ class PushBack: Runner {
 
 class SumElements: Runner {
   const n: int;
-  proc run(A: [] int) {
+  override proc run(A: [] int) {
     var sum = 0;
     for a in A {
       sum += a;
@@ -31,7 +31,7 @@ class SumElements: Runner {
 
 class PushFront: Runner {
   const n: int;
-  proc run(A: [] int) {
+  override proc run(A: [] int) {
     for i in 1..n {
       A.push_front(i);
     }
@@ -39,7 +39,7 @@ class PushFront: Runner {
 }
 
 class PopBack: Runner {
-  proc run(A: [] int) {
+  override proc run(A: [] int) {
     while !A.isEmpty() {
       A.pop_back();
     }
@@ -47,7 +47,7 @@ class PopBack: Runner {
 }
 
 class PopFront: Runner {
-  proc run(A: [] int) {
+  override proc run(A: [] int) {
     while !A.isEmpty() {
       A.pop_front();
     }
@@ -57,7 +57,7 @@ class PopFront: Runner {
 // time inserting into a random index in the array
 class InsertRandom: Runner {
   const n: int;
-  proc run(A: [] int) {
+  override proc run(A: [] int) {
     extern proc srand(int);
     extern proc rand(): int;
     srand(randSeed);
@@ -70,7 +70,7 @@ class InsertRandom: Runner {
 // generate random numbers and put them in order in the array
 class InsertSorted: Runner {
   const n: int;
-  proc run(A: [] int) {
+  override proc run(A: [] int) {
     extern proc srand(int);
     extern proc rand(): int;
     srand(randSeed);
@@ -85,7 +85,7 @@ class InsertSorted: Runner {
 class Remove: Runner {
   const n: int;
   const front: bool;
-  proc run(A: [] int) {
+  override proc run(A: [] int) {
     if front {
       for i in 1..linearN {
         A.remove(1);
@@ -103,7 +103,7 @@ class Remove: Runner {
 // try a few similar operation on a list to compare
 class ListAppend: Runner {
   const n: int;
-  proc runList(ref L: list(int)) {
+  override proc runList(ref L: list(int)) {
     for i in 1..n {
       L.append(i);
     }
@@ -112,7 +112,7 @@ class ListAppend: Runner {
 
 class SumReduceList: Runner {
   const n: int;
-  proc runList(ref L: list(int)) {
+  override proc runList(ref L: list(int)) {
     var sum = 0;
     for val in L {
       sum += val;
@@ -122,7 +122,7 @@ class SumReduceList: Runner {
 }
 
 class ListDestroy: Runner {
-  proc runList(ref L: list(int)) {
+  override proc runList(ref L: list(int)) {
     L.destroy();
   }
 }

--- a/test/classes/deitz/dispatch/test_generic_where2.chpl
+++ b/test/classes/deitz/dispatch/test_generic_where2.chpl
@@ -8,7 +8,7 @@ class C {
 class D: C {
   param rank: int;
   var y: int;
-  proc foo() where rank == 1 {
+  override proc foo() where rank == 1 {
     writeln("foo<", rank, ">: (x = ", x, ", y = ", y, ")");
   }
 }

--- a/test/classes/initializers/postInit/dispatch.chpl
+++ b/test/classes/initializers/postInit/dispatch.chpl
@@ -29,7 +29,7 @@ class E : C {
     writeln("In E.foo()");
   }
 
-  override proc baz() {
+  proc baz() {
     writeln("In E.baz()");
   }
 

--- a/test/classes/override/where-mixed-no-override.chpl
+++ b/test/classes/override/where-mixed-no-override.chpl
@@ -1,0 +1,31 @@
+class Parent {
+  proc f(param p) where p == 1 || p == 2 { }
+  proc g(type t) where t == int || t == uint { }
+  proc h(x) where x.type == int || x.type == uint { }
+}
+
+class Child : Parent {
+  proc f(param p) where p == 2 || p == 3 { }
+  proc g(type t) where t == uint || t == string { }
+  proc h(x) where x.type == uint || x.type == string { }
+}
+
+proc test() {
+  var x = new owned Child();
+  var y = x.borrow():borrowed Parent;
+  y.f(1);
+  y.f(2);
+  x.f(2);
+  x.f(3);
+
+  y.g(int);
+  y.g(uint);
+  x.g(uint);
+  x.g(string);
+  
+  y.h(1:int);
+  y.h(1:uint);
+  x.h(1:uint);
+  x.h("hi");
+}
+test();

--- a/test/classes/override/where-mixed-no-override.good
+++ b/test/classes/override/where-mixed-no-override.good
@@ -1,0 +1,3 @@
+where-mixed-no-override.chpl:8: warning: Child.f overrides parent class method Parent.f but missing override keyword
+where-mixed-no-override.chpl:9: warning: Child.g overrides parent class method Parent.g but missing override keyword
+where-mixed-no-override.chpl:10: warning: Child.h overrides parent class method Parent.h but missing override keyword

--- a/test/classes/override/where-mixed-override.chpl
+++ b/test/classes/override/where-mixed-override.chpl
@@ -1,0 +1,31 @@
+class Parent {
+  proc f(param p) where p == 1 || p == 2 { }
+  proc g(type t) where t == int || t == uint { }
+  proc h(x) where x.type == int || x.type == uint { }
+}
+
+class Child : Parent {
+  override proc f(param p) where p == 2 || p == 3 { }
+  override proc g(type t) where t == uint || t == string { }
+  override proc h(x) where x.type == uint || x.type == string { }
+}
+
+proc test() {
+  var x = new owned Child();
+  var y = x.borrow():borrowed Parent;
+  y.f(1);
+  y.f(2);
+  x.f(2);
+  x.f(3);
+
+  y.g(int);
+  y.g(uint);
+  x.g(uint);
+  x.g(string);
+  
+  y.h(1:int);
+  y.h(1:uint);
+  x.h(1:uint);
+  x.h("hi");
+}
+test();

--- a/test/classes/override/where-mixed-override.good
+++ b/test/classes/override/where-mixed-override.good
@@ -1,0 +1,3 @@
+where-mixed-override.chpl:8: error: Child.f override keyword present but no superclass method matches signature to override
+where-mixed-override.chpl:9: error: Child.g override keyword present but no superclass method matches signature to override
+where-mixed-override.chpl:10: error: Child.h override keyword present but no superclass method matches signature to override

--- a/test/classes/override/where-no-override.chpl
+++ b/test/classes/override/where-no-override.chpl
@@ -1,0 +1,19 @@
+class Parent {
+  proc f() { }
+  proc g() where false { }
+}
+
+class Child : Parent {
+  // overrides parent f()
+  proc f() where false { }
+  // doesn't override parent b/c of parent where clause
+  proc g() { }
+}
+
+proc test() {
+  var x = new owned Child();
+  var y = x.borrow():borrowed Parent;
+  y.f();
+  x.g();
+}
+test();

--- a/test/classes/override/where-no-override.good
+++ b/test/classes/override/where-no-override.good
@@ -1,0 +1,1 @@
+where-no-override.chpl:8: warning: Child.f override keyword required for method matching signature of superclass method

--- a/test/classes/override/where-override.chpl
+++ b/test/classes/override/where-override.chpl
@@ -1,0 +1,19 @@
+class Parent {
+  proc f() { }
+  proc g() where false { }
+}
+
+class Child : Parent {
+  // overrides parent f()
+  override proc f() where false { }
+  // doesn't override parent b/c of parent where clause
+  override proc g() { }
+}
+
+proc test() {
+  var x = new owned Child();
+  var y = x.borrow():borrowed Parent;
+  y.f();
+  x.g();
+}
+test();

--- a/test/classes/override/where-override.good
+++ b/test/classes/override/where-override.good
@@ -1,0 +1,1 @@
+where-override.chpl:10: error: Child.g override keyword present but no superclass method matches signature to override

--- a/test/classes/override/where-split.chpl
+++ b/test/classes/override/where-split.chpl
@@ -1,0 +1,23 @@
+class Parent {
+  proc f(param p) where p == 1 { }
+  proc g(type t) where t == int { }
+  proc h(x) where x.type == int { }
+}
+
+class Child : Parent {
+  proc f(param p) where p == 2 { }
+  proc g(type t) where t == string { }
+  proc h(x) where x.type == string { }
+}
+
+proc test() {
+  var x = new owned Child();
+  var y = x.borrow():borrowed Parent;
+  y.f(1);
+  x.f(2);
+  y.g(int);
+  x.g(string);
+  y.h(1);
+  x.h("hi");
+}
+test();


### PR DESCRIPTION
* Fix problems with where clauses and overrides checking. The checking
  was ignoring possible matches if the overriding function had a where
  clause that didn't match, but that doesn't help answer the question "Is
  this method overriding another method"?

* Ignore override errors for postinit, check for special functions to
  ignore in a shared function.

Resolves #10814.
Resolves #9733.

- [x] full local testing

Reviewed by @benharsh - thanks!