### PR TITLE
Bale-Toposort Improvements

### DIFF
--- a/test/studies/bale/toposort/toposort.chpl
+++ b/test/studies/bale/toposort/toposort.chpl
@@ -1675,7 +1675,7 @@ proc main(){
 
   const sparseUpperTriangularIndexList = createSparseUpperTriangluarIndexList( D, density, seed, defaultFillModeDensity );
 
-  if !silentMode then writeln( "Actual Density: density: %dr%%\nTotal Number NonZeros: %n".format((sparseUpperTriangularIndexList.size / (1.0*N*N))*100, sparseUpperTriangularIndexList.size) );
+  if !silentMode then writeln( "Actual Density: %dr%%\nTotal Number NonZeros: %n".format((sparseUpperTriangularIndexList.size / (1.0*N*N))*100, sparseUpperTriangularIndexList.size) );
 
   var permutationMap = createRandomPermutationMap( D, seed );
   if printPermutations then writeln("Permutation Map:\n", permutationMap);

--- a/test/studies/bale/toposort/toposort.chpl
+++ b/test/studies/bale/toposort/toposort.chpl
@@ -384,7 +384,7 @@ class ParallelWorkQueueChunkedLoopWaitPadding {
   type lockType;
 
   // tuple that will pad the record through the cache line
-  type paddingType = ParallelWorkQueueChunkedLoopWaitPaddingBytes*uint(64);
+  type paddingType = ParallelWorkQueueChunkedLoopWaitPaddingBytes*uint(8);
 
   record arrayType {
     type arrayTypeEltType;

--- a/test/studies/bale/toposort/toposort.chpl
+++ b/test/studies/bale/toposort/toposort.chpl
@@ -950,13 +950,13 @@ where D.rank == 2
   for column in columns {
     if enableRuntimeDebugging && debugTopo then writeln( "accumulating in column ", column );
     if useDimIterRow {
-     if warnDimIterMethod then compilerWarning("toposortParallel.init iterating over rows in init with dimIter");
+     if warnDimIterMethod then compilerWarning("toposortSerial.init iterating over rows in init with dimIter");
       for row in D.dimIter(1,column) {
         rowCount[row] += 1;
         rowSum[row] += column ;
       }
     } else {
-      if warnDimIterMethod then compilerWarning("toposortParallel.init iterating over rows in init with dim");
+      if warnDimIterMethod then compilerWarning("toposortSerial.init iterating over rows in init with dim");
       for row in rows {
         if D.member((row,column)) {
           rowCount[row] += 1;

--- a/test/studies/bale/toposort/toposort.chpl
+++ b/test/studies/bale/toposort/toposort.chpl
@@ -1651,7 +1651,17 @@ config const seed : int = SeedGenerator.oddCurrentTime;
 enum ToposortImplementation { Serial, ParallelChunkedLoopWait, ParallelSyncWait, ParallelLoopWait, Distributed };
 config const implementation : ToposortImplementation = ToposortImplementation.ParallelChunkedLoopWait;
 
+config const printImplementations : bool = false;
+
 proc main(){
+  if printImplementations then {
+    writeln("Available implementation options:");
+    for i in ToposortImplementation {
+      writeln( i );
+    }
+    return;
+  }
+
   if density < minDensity then halt("Specified density (%n) is less than min density (%n) for N (%n)".format( density, minDensity, N));
   if density > maxDensity then halt("Specified density (%n) is greater than max density (%n) for N (%n)".format( density, maxDensity, N));
 
@@ -1693,7 +1703,6 @@ proc main(){
       dmappedPermutedSparseD.bulkAdd( permutedSparseUpperTriangularIndexList );
 
       var workQueue = new unmanaged ParallelWorkQueueChunkedLoopWait( eltType = dmappedPermutedSparseD.idxType, lockType = unmanaged AtomicLock, retries = 0, maxTasks = numTasks : uint );
-      //var workQueue = new unmanaged ParallelWorkQueueSyncWait( eltType = dmappedPermutedSparseD.idxType, lockType = unmanaged AtomicLock, retries = 0, maxTasks = numTasks : uint );
 
       if !silentMode then writeln("Toposorting permuted upper triangluar domain using Parallel implementation with Chunked-Loop-Wait work queue.");
       topoResult = toposortParallel( dmappedPermutedSparseD, workQueue, numTasks );

--- a/test/studies/bale/toposort/toposort.chpl
+++ b/test/studies/bale/toposort/toposort.chpl
@@ -1,3 +1,11 @@
+/*
+Acknowledgement:
+The distribution methods in this application were heavily influenced and
+informed by previous work done by Louis Jenkins on the DistributedBag and
+DistributedQueue modules, and his personal assistance was influential in
+improving the performance of the distributions used here.
+*/
+
 use Random;
 use Time;
 use LayoutCS;

--- a/test/studies/bale/toposort/toposort.execopts
+++ b/test/studies/bale/toposort/toposort.execopts
@@ -1,2 +1,4 @@
 --N 20 --additionalDensity=0.3 --silentMode --implementation Serial
---N 20 --additionalDensity=0.3 --silentMode --implementation Parallel
+--N 20 --additionalDensity=0.3 --silentMode --implementation ParallelChunkedLoopWait
+--N 20 --additionalDensity=0.3 --silentMode --implementation ParallelSyncWait
+--N 20 --additionalDensity=0.3 --silentMode --implementation ParallelLoopWait

--- a/test/studies/bale/toposort/toposort.perfexecopts
+++ b/test/studies/bale/toposort/toposort.perfexecopts
@@ -1,1 +1,1 @@
---silentMode --printPerfStats --seed 123456789 --N 10000 --additionalDensity=0.3 --implementation Parallel
+--silentMode --printPerfStats --seed 123456789 --N 10000 --additionalDensity=0.3 --implementation ParallelChunkedLoopWait

--- a/test/studies/bale/toposort/toposort.perfexecopts
+++ b/test/studies/bale/toposort/toposort.perfexecopts
@@ -1,1 +1,1 @@
---N 10000 --additionalDensity=0.3 --silentMode --printPerfStats --implementation Parallel
+--silentMode --printPerfStats --seed 123456789 --N 10000 --additionalDensity=0.3 --implementation Parallel


### PR DESCRIPTION
This adds several improvements to the Bale-Toposort Benchmark:
+ Complete Sphinx documentation of all classes and methods.
+ Multiple parallel work queue implementations.
+ Parallel Toposort method that accepts a work queue instance as a parameter to test multiple queue implementations without requiring the actual benchmark procedure to be rewritten.
+ New `ToposortImplementation` enumerations to test parallel toposort for the various queue implementations.
+ New iteration method for both serial and parallel that improves performance without requiring a transposed sparse domain.
+ Use constant seed for perftesting to limit variation in nightly performance testing.
+ Uses lifetime type modifiers to pass `--warn-unstable`
