### PR TITLE
Turn override checking on by default

### DIFF
--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -177,7 +177,7 @@ bool fLocal;   // initialized in postLocal()
 bool fIgnoreLocalClasses = false;
 bool fUserDefaultInitializers = true;
 bool fLifetimeChecking = true;
-bool fOverrideChecking = false;
+bool fOverrideChecking = true;
 bool fHeterogeneous = false;
 bool fieeefloat = false;
 int ffloatOpt = 0; // 0 -> backend default; -1 -> strict; 1 -> opt

--- a/test/classes/diten/subclassMethodCall.chpl
+++ b/test/classes/diten/subclassMethodCall.chpl
@@ -14,13 +14,13 @@ record C2 {
 }
 
 class Sub1: Base {
-  proc method(c: C1) {
+  override proc method(c: C1) {
     c.foo();
   }
 }
 
 class Sub2: Base {
-  proc method(c: C2) {
+  override proc method(c: C2) {
     c.bar();
   }
 }

--- a/test/classes/lydia/overrides/remoteVersion.chpl
+++ b/test/classes/lydia/overrides/remoteVersion.chpl
@@ -7,7 +7,7 @@ class A {
 }
 
 class B: A {
-  proc foo() {
+  override proc foo() {
     super.foo();
     writeln("in B.foo()");
   }

--- a/test/classes/sungeun/remoteDynamicDispatch.chpl
+++ b/test/classes/sungeun/remoteDynamicDispatch.chpl
@@ -5,13 +5,13 @@ class C {
 }
 
 class C0: C {
-  proc foo() {
+  override proc foo() {
     writeln((here.id, "C0"));
   }
 }
 
 class C1: C {
-  proc foo() {
+  override proc foo() {
     writeln((here.id, "C1"));
   }
 }

--- a/test/functions/default-arguments/default-argument-class-override.chpl
+++ b/test/functions/default-arguments/default-argument-class-override.chpl
@@ -3,7 +3,7 @@ class C {
 }
 
 class D : C {
-  proc foo(x = 20) { writeln("D.foo:", x); }
+  override proc foo(x = 20) { writeln("D.foo:", x); }
 }
 
 var d = new borrowed D();

--- a/test/functions/ferguson/hijacking/Application10.chpl
+++ b/test/functions/ferguson/hijacking/Application10.chpl
@@ -16,7 +16,7 @@
     use LibraryZ4;
 
     class Widget : Base {
-      proc run(x:int) {
+      override proc run(x:int) {
         writeln("In Application.Widget.run");
       }
     }

--- a/test/functions/iterators/elliot/dynamicDispatch/parallel-virtual-par-iters.chpl
+++ b/test/functions/iterators/elliot/dynamicDispatch/parallel-virtual-par-iters.chpl
@@ -6,10 +6,10 @@ class Parent {
 }
 
 class Child: Parent {
-  iter these(): int { for i in 1..10 do yield i; }
-  iter these(param tag: iterKind): int where tag == iterKind.standalone { coforall i in 1..10 do yield i; }
-  iter these(param tag: iterKind): int where tag == iterKind.leader { coforall i in 1..10 do yield i; }
-  iter these(param tag: iterKind, followThis): int where tag == iterKind.follower { yield followThis; }
+  override iter these(): int { for i in 1..10 do yield i; }
+  override iter these(param tag: iterKind): int where tag == iterKind.standalone { coforall i in 1..10 do yield i; }
+  override iter these(param tag: iterKind): int where tag == iterKind.leader { coforall i in 1..10 do yield i; }
+  override iter these(param tag: iterKind, followThis): int where tag == iterKind.follower { yield followThis; }
 }
 
 var A: [1..10] int;

--- a/test/functions/iterators/elliot/dynamicDispatch/remote-virtual-par-iters.chpl
+++ b/test/functions/iterators/elliot/dynamicDispatch/remote-virtual-par-iters.chpl
@@ -6,10 +6,10 @@ class Parent {
 }
 
 class Child: Parent {
-  iter these(): int { for loc in Locales do yield loc.id; }
-  iter these(param tag: iterKind): int where tag == iterKind.standalone { coforall loc in Locales do on loc do yield here.id; }
-  iter these(param tag: iterKind): int where tag == iterKind.leader { coforall loc in Locales do on loc do yield here.id; }
-  iter these(param tag: iterKind, followThis): int where tag == iterKind.follower { yield followThis; }
+  override iter these(): int { for loc in Locales do yield loc.id; }
+  override iter these(param tag: iterKind): int where tag == iterKind.standalone { coforall loc in Locales do on loc do yield here.id; }
+  override iter these(param tag: iterKind): int where tag == iterKind.leader { coforall loc in Locales do on loc do yield here.id; }
+  override iter these(param tag: iterKind, followThis): int where tag == iterKind.follower { yield followThis; }
 }
 
 var A: [0..#numLocales] int;

--- a/test/functions/iterators/elliot/dynamicDispatch/serial-virtual-par-iters.chpl
+++ b/test/functions/iterators/elliot/dynamicDispatch/serial-virtual-par-iters.chpl
@@ -6,10 +6,10 @@ class Parent {
 }
 
 class Child: Parent {
-  iter these(): int { for i in 1..10 do yield i; }
-  iter these(param tag: iterKind): int where tag == iterKind.standalone { for i in 1..10 do yield i; }
-  iter these(param tag: iterKind): int where tag == iterKind.leader { for i in 1..10 do yield i; }
-  iter these(param tag: iterKind, followThis): int where tag == iterKind.follower { yield followThis; }
+  override iter these(): int { for i in 1..10 do yield i; }
+  override iter these(param tag: iterKind): int where tag == iterKind.standalone { for i in 1..10 do yield i; }
+  override iter these(param tag: iterKind): int where tag == iterKind.leader { for i in 1..10 do yield i; }
+  override iter these(param tag: iterKind, followThis): int where tag == iterKind.follower { yield followThis; }
 }
 
 var A: [1..10] int;

--- a/test/functions/iterators/elliot/dynamicDispatch/trivial-virtual-par-iters.chpl
+++ b/test/functions/iterators/elliot/dynamicDispatch/trivial-virtual-par-iters.chpl
@@ -6,10 +6,10 @@ class Parent {
 }
 
 class Child: Parent {
-  iter these(): int { yield 1; }
-  iter these(param tag: iterKind): int where tag == iterKind.standalone { yield 2; }
-  iter these(param tag: iterKind): int where tag == iterKind.leader { yield 3; }
-  iter these(param tag: iterKind, followThis): int where tag == iterKind.follower { yield 4; }
+  override iter these(): int { yield 1; }
+  override iter these(param tag: iterKind): int where tag == iterKind.standalone { yield 2; }
+  override iter these(param tag: iterKind): int where tag == iterKind.leader { yield 3; }
+  override iter these(param tag: iterKind, followThis): int where tag == iterKind.follower { yield 4; }
 }
 
 var child: borrowed Parent = new borrowed Child();


### PR DESCRIPTION
Resolves #10828 

It can be disabled with --no-override-checking.

- [x] full local futures testing
- [x] full gasnet testing
- [x] full CHPL_LOCALE_MODEL=numa testing

Reviewed by @benharsh - thanks!