### PR TITLE
Add deprecation for : in where clauses

### DIFF
--- a/compiler/passes/cleanup.cpp
+++ b/compiler/passes/cleanup.cpp
@@ -364,6 +364,11 @@ static void changeCastInWhere(FnSymbol* fn) {
           to->remove();
           from->remove();
 
+          // Note, this deprecation warning along with the rest of
+          // changeCastInWhere should be removed after 1.18.
+          USR_WARN(call, "Special handling for : in where clauses has "
+                         "been deprecated. Please use isSubtype instead.");
+
           call->replace(new CallExpr(PRIM_IS_SUBTYPE, to, from));
         }
       }

--- a/modules/packages/ReplicatedVar.chpl
+++ b/modules/packages/ReplicatedVar.chpl
@@ -112,7 +112,7 @@ const rcDomain     = rcDomainBase dmapped new dmap(rcDomainMap);
 private param _rcErr1 = " must be 'rcDomain' or 'rcDomainBase dmapped Replicated(an array of locales)'";
 
 private proc _rcTargetLocalesHelper(replicatedVar: [?D])
-  where _to_borrowed(replicatedVar._value.type): ReplicatedArr
+  where isSubtype(_to_borrowed(replicatedVar._value.type), ReplicatedArr)
 {
   return replicatedVar.targetLocales();
 }
@@ -124,7 +124,7 @@ proc rcReplicate(replicatedVar: [?D] ?MYTYPE, valToReplicate: MYTYPE): void
 /* Assign a value `valToReplicate` to copies of the replicated variable
    `replicatedVar` on all locales. */
 proc rcReplicate(replicatedVar: [?D] ?MYTYPE, valToReplicate: MYTYPE): void
-  where _to_borrowed(replicatedVar._value.type): ReplicatedArr
+  where isSubtype(_to_borrowed(replicatedVar._value.type), ReplicatedArr)
 {
   assert(replicatedVar.domain == rcDomainBase);
   coforall loc in _rcTargetLocalesHelper(replicatedVar) do
@@ -134,13 +134,13 @@ proc rcReplicate(replicatedVar: [?D] ?MYTYPE, valToReplicate: MYTYPE): void
 
 pragma "no doc" // documented with the following entry
 proc rcCollect(replicatedVar: [?D] ?MYTYPE, collected: [?CD] MYTYPE): void
-  where ! _to_borrowed(replicatedVar._value.type): ReplicatedArr
+  where ! isSubtype(_to_borrowed(replicatedVar._value.type), ReplicatedArr)
 { compilerError("the domain of first argument to rcCollect()", _rcErr1); }
 
 /* Copy the value of the replicated variable `replicatedVar` on each locale
    into the element of the array `collected` that corresponds to that locale.*/
 proc rcCollect(replicatedVar: [?D] ?MYTYPE, collected: [?CD] MYTYPE): void
-  where _to_borrowed(replicatedVar._value.type): ReplicatedArr
+  where isSubtype(_to_borrowed(replicatedVar._value.type), ReplicatedArr)
 {
   var targetLocales = _rcTargetLocalesHelper(replicatedVar);
   assert(replicatedVar.domain == rcDomainBase);

--- a/spec/Domains.tex
+++ b/spec/Domains.tex
@@ -939,7 +939,7 @@ Returns the domain map that implements this domain
 In the code
 \begin{chapel}
 use BlockDist;
-proc foo(d : domain) where d.dist : Block {
+proc foo(d : domain) where isSubtype(d.dist, Block) {
   writeln("Block-distributed domain");
 }
 proc foo(d : domain) {

--- a/test/classes/delete-free/borrowed/borrowed-in-where.chpl
+++ b/test/classes/delete-free/borrowed/borrowed-in-where.chpl
@@ -4,7 +4,7 @@ class MyDomain : Domain {
   var x;
 }
 
-proc foo(type t) where t:borrowed Domain
+proc foo(type t) where isSubtype(t, borrowed Domain)
 {
   writeln("In foo where");
 }

--- a/test/classes/delete-free/unmanaged/unmanaged-in-where.chpl
+++ b/test/classes/delete-free/unmanaged/unmanaged-in-where.chpl
@@ -4,7 +4,7 @@ class MyDomain : Domain {
   var x;
 }
 
-proc foo(type t) where t:unmanaged Domain
+proc foo(type t) where isSubtype(t, unmanaged Domain)
 {
   writeln("In foo where");
 }

--- a/test/classes/ferguson/generic-inherit-bug1.chpl
+++ b/test/classes/ferguson/generic-inherit-bug1.chpl
@@ -40,7 +40,7 @@ module Structure {
     }
   }
 
-  proc test(lhs:?t) where unmanaged t:unmanaged ListerParent {
+  proc test(lhs:?t) where isSubtype(unmanaged t, unmanaged ListerParent) {
     type subType = lhs.getListedType();
     for e in lhs.lst {
       var eCast = e:unmanaged subType;

--- a/test/classes/initializers/generics/phase1/newInit-class-record.chpl
+++ b/test/classes/initializers/generics/phase1/newInit-class-record.chpl
@@ -13,7 +13,7 @@ class Container {
 record Stored {
   var x: bool;
 
-  proc init(xVal) where !xVal: Stored {
+  proc init(xVal) where !isSubtype(xVal, Stored) {
     x = xVal;
   }
 }

--- a/test/classes/initializers/generics/phase1/newInit-record-record.chpl
+++ b/test/classes/initializers/generics/phase1/newInit-record-record.chpl
@@ -13,7 +13,7 @@ record Container {
 record Stored {
   var x: bool;
 
-  proc init(xVal) where !xVal: Stored {
+  proc init(xVal) where !isSubtype(xVal, Stored) {
     x = xVal;
 
   }

--- a/test/classes/initializers/generics/phase1/simpleThis.chpl
+++ b/test/classes/initializers/generics/phase1/simpleThis.chpl
@@ -3,7 +3,7 @@ record MyRecord {
   var y : int = 2;
 
 
-  proc init(param xVal) where !xVal: MyRecord {
+  proc init(param xVal) where !isSubtype(xVal, MyRecord) {
     x = xVal;
     y = 1 + this.x;
 

--- a/test/classes/initializers/initCallsDom.chpl
+++ b/test/classes/initializers/initCallsDom.chpl
@@ -4,7 +4,7 @@ record R {
   var d: domain(1);
   var a: [d] real;
 
-  proc init(x) where !x: R {
+  proc init(x) where !isSubtype(x, R) {
     d = x.domain;
     this.complete();
     for i in d do

--- a/test/classes/initializers/not-a-copy-initializer.chpl
+++ b/test/classes/initializers/not-a-copy-initializer.chpl
@@ -15,7 +15,7 @@ record Foo {
 
   // We must explicitly exclude this initializer from consideration for copy
   // initializers
-  proc init(genericArg) where (!genericArg: Foo) {
+  proc init(genericArg) where !isSubtype(genericArg, Foo) {
     genericArg.someMethod();
     a = true;
   }

--- a/test/classes/initializers/phase1/newInit-class-record.chpl
+++ b/test/classes/initializers/phase1/newInit-class-record.chpl
@@ -11,7 +11,7 @@ class Container {
 record Stored {
   var x: bool;
 
-  proc init(xVal) where !xVal: Stored {
+  proc init(xVal) where !isSubtype(xVal, Stored) {
     x = xVal;
   }
 }

--- a/test/classes/initializers/phase1/newInit-record-record.chpl
+++ b/test/classes/initializers/phase1/newInit-record-record.chpl
@@ -11,7 +11,7 @@ record Container {
 record Stored {
   var x: bool;
 
-  proc init(xVal) where !xVal: Stored {
+  proc init(xVal) where !isSubtype(xVal, Stored) {
     x = xVal;
 
   }

--- a/test/classes/initializers/phase1/simpleThis.chpl
+++ b/test/classes/initializers/phase1/simpleThis.chpl
@@ -3,7 +3,7 @@ record MyRecord {
   var y : int = 2;
 
 
-  proc init(xVal) where !xVal: MyRecord {
+  proc init(xVal) where !isSubtype(xVal, MyRecord) {
     x = xVal;
     y = 1 + this.x;
 

--- a/test/classes/initializers/records/generics/argument_type.chpl
+++ b/test/classes/initializers/records/generics/argument_type.chpl
@@ -3,7 +3,7 @@ record Foo {
   type t;
   var x;
 
-  proc init(xVal) where !xVal: Foo {
+  proc init(xVal) where !isSubtype(xVal, Foo) {
     t = xVal.type;
     x = xVal;
   }

--- a/test/classes/initializers/records/generics/assignment/init-type4.chpl
+++ b/test/classes/initializers/records/generics/assignment/init-type4.chpl
@@ -9,7 +9,7 @@
 record A {
   type t = int;
   var x:t;
-  proc init(xVal) where !xVal: A {
+  proc init(xVal) where !isSubtype(xVal, A) {
     // I removed the argument and explicit setting of field t, to show that
     // omitted type fields work just fine.
     this.x = xVal;

--- a/test/classes/initializers/records/generics/assignment/omittedGenerics1.chpl
+++ b/test/classes/initializers/records/generics/assignment/omittedGenerics1.chpl
@@ -6,7 +6,7 @@ record SoManyParams {
   param b = -6;
   var otherField = 10;
 
-  proc init(otherFieldVal) where !otherFieldVal: SoManyParams {
+  proc init(otherFieldVal) where !isSubtype(otherFieldVal, SoManyParams) {
     otherField = otherFieldVal;
     // the above is used to make the initializer actually do something.  The
     // other two fields should be given their appropriate default value.

--- a/test/classes/initializers/records/generics/assignment/reuse-init-new-instantiation-var.chpl
+++ b/test/classes/initializers/records/generics/assignment/reuse-init-new-instantiation-var.chpl
@@ -4,7 +4,7 @@
 record Foo {
   var x;
 
-  proc init(xVal) where !xVal: Foo {
+  proc init(xVal) where !isSubtype(xVal, Foo) {
     x = xVal;
   }
 }

--- a/test/classes/initializers/records/generics/assignment/typeAlias.chpl
+++ b/test/classes/initializers/records/generics/assignment/typeAlias.chpl
@@ -2,7 +2,7 @@ record Generic {
   type eltType;
   var value: eltType;
 
-  proc init(value: ?eltType) where !value: Generic {
+  proc init(value: ?eltType) where !isSubtype(value, Generic) {
     this.eltType = eltType;
     this.value   = value;
   }

--- a/test/classes/initializers/records/generics/defaultValueRecordArg-explicitInstance.chpl
+++ b/test/classes/initializers/records/generics/defaultValueRecordArg-explicitInstance.chpl
@@ -1,7 +1,7 @@
 record Foo {
   var x;
 
-  proc init(xVal) where !xVal: Foo {
+  proc init(xVal) where !isSubtype(xVal, Foo) {
     x = xVal;
   }
 }

--- a/test/classes/initializers/records/generics/defaultValueRecordArg-regularProc.chpl
+++ b/test/classes/initializers/records/generics/defaultValueRecordArg-regularProc.chpl
@@ -1,7 +1,7 @@
 record Foo {
   var x;
 
-  proc init(xVal) where !xVal: Foo {
+  proc init(xVal) where !isSubtype(xVal, Foo) {
     x = xVal;
   }
 }

--- a/test/classes/initializers/records/generics/defaultValueRecordArg.chpl
+++ b/test/classes/initializers/records/generics/defaultValueRecordArg.chpl
@@ -1,7 +1,7 @@
 record Foo {
   var x;
 
-  proc init(xVal) where !xVal: Foo {
+  proc init(xVal) where !isSubtype(xVal, Foo) {
     x = xVal;
   }
 }

--- a/test/classes/initializers/records/generics/fullySpecifiedAssignment/reuse-init-new-instantiation-var.chpl
+++ b/test/classes/initializers/records/generics/fullySpecifiedAssignment/reuse-init-new-instantiation-var.chpl
@@ -4,7 +4,7 @@
 record Foo {
   var x;
 
-  proc init(xVal) where !xVal: Foo {
+  proc init(xVal) where !isSubtype(xVal, Foo) {
     x = xVal;
   }
 }

--- a/test/classes/initializers/records/generics/returnNewGeneric.chpl
+++ b/test/classes/initializers/records/generics/returnNewGeneric.chpl
@@ -3,7 +3,7 @@ record Option {
   var state: bool;
   var value: eltType;
 
-  proc init(value: ?eltType) where !value: Option {
+  proc init(value: ?eltType) where !isSubtype(value, Option) {
     this.eltType = eltType;
     this.state   = true;
     this.value   = value;

--- a/test/classes/initializers/records/generics/reuse-class-instantiation.chpl
+++ b/test/classes/initializers/records/generics/reuse-class-instantiation.chpl
@@ -9,7 +9,7 @@ record Foo {
     t = tVal;
   }
 
-  proc init(xVal) where !xVal: Foo {
+  proc init(xVal) where !isSubtype(xVal, Foo) {
     t = xVal.type;
     x = xVal;
   }

--- a/test/classes/initializers/records/generics/reuse-init-instantiation-var.chpl
+++ b/test/classes/initializers/records/generics/reuse-init-instantiation-var.chpl
@@ -4,7 +4,7 @@
 record Foo {
   var x;
 
-  proc init(xVal) where !xVal: Foo {
+  proc init(xVal) where !isSubtype(xVal, Foo) {
     x = xVal;
   }
 }

--- a/test/classes/initializers/records/generics/reuse-init-instantiation-var2.chpl
+++ b/test/classes/initializers/records/generics/reuse-init-instantiation-var2.chpl
@@ -4,7 +4,7 @@
 record Foo {
   var x;
 
-  proc init(xVal) where !xVal: Foo {
+  proc init(xVal) where !isSubtype(xVal, Foo) {
     x = xVal;
   }
 }

--- a/test/classes/initializers/records/generics/reuse-init-new-instantiation-var.chpl
+++ b/test/classes/initializers/records/generics/reuse-init-new-instantiation-var.chpl
@@ -4,7 +4,7 @@
 record Foo {
   var x;
 
-  proc init(xVal) where (!xVal: Foo) {
+  proc init(xVal) where !isSubtype(xVal, Foo) {
     x = xVal;
   }
 }

--- a/test/classes/initializers/records/generics/siblingCall-generic.chpl
+++ b/test/classes/initializers/records/generics/siblingCall-generic.chpl
@@ -2,7 +2,7 @@ record Foo {
   type t;
   var x;
 
-  proc init(xVal) where !xVal: Foo {
+  proc init(xVal) where !isSubtype(xVal, Foo) {
     this.init(xVal.type, xVal);
   }
 

--- a/test/deprecated/colon-where.chpl
+++ b/test/deprecated/colon-where.chpl
@@ -1,0 +1,21 @@
+// This tests the deprecation warning for : in
+// where clauses. After the 1.18 release, the :
+// in a where clause should mean a cast.
+
+class Parent {
+}
+
+class Child : Parent {
+}
+
+proc myfunc(x) where x.type : Parent {
+  writeln("in myfunc, type is ", x.type:string);
+}
+
+proc main() {
+  var x = new borrowed Child();
+  var y = new borrowed Parent();
+
+  myfunc(x);
+  myfunc(y);
+}

--- a/test/deprecated/colon-where.good
+++ b/test/deprecated/colon-where.good
@@ -1,0 +1,4 @@
+colon-where.chpl:11: In function 'myfunc':
+colon-where.chpl:11: warning: Special handling for : in where clauses has been deprecated. Please use isSubtype instead.
+in myfunc, type is Child
+in myfunc, type is Parent

--- a/test/distributions/bradc/where/dispatchBasedOnDist.chpl
+++ b/test/distributions/bradc/where/dispatchBasedOnDist.chpl
@@ -6,19 +6,19 @@ var DCyc: domain(1) dmapped Cyclic(startIdx=1) = {1..10};
 var ABlk: [DBlk] real;
 var ACyc: [DCyc] real;
 
-proc domproc(D: domain) where _to_borrowed(D.dist.type): borrowed Block {
+proc domproc(D: domain) where isSubtype(_to_borrowed(D.dist.type), borrowed Block) {
   writeln("In the domproc() for Block");
 }
 
-proc domproc(D: domain) where _to_borrowed(D.dist.type): borrowed Cyclic {
+proc domproc(D: domain) where isSubtype(_to_borrowed(D.dist.type), borrowed Cyclic) {
   writeln("In the domproc() for Cyclic");
 }
 
-proc arrproc(A: []) where _to_borrowed(A.domain.dist.type): borrowed Block {
+proc arrproc(A: []) where isSubtype(_to_borrowed(A.domain.dist.type), borrowed Block) {
   writeln("In the arrproc() for Block");
 }
 
-proc arrproc(A: []) where _to_borrowed(A.domain.dist.type): borrowed Cyclic {
+proc arrproc(A: []) where isSubtype(_to_borrowed(A.domain.dist.type), borrowed Cyclic) {
   writeln("In the arrproc() for Cyclic");
 }
 

--- a/test/domains/vass/assoc-idxtype-error-2.chpl
+++ b/test/domains/vass/assoc-idxtype-error-2.chpl
@@ -6,7 +6,7 @@ class C {
   var a: [d] int;
 }
 
-proc C.init(d, a) where d: domain(?) {
+proc C.init(d, a) where isSubtype(d, domain(?)) {
   this.d = d;
   this.a = a;
 }

--- a/test/extern/ferguson/externblock/extern_block_primer.chpl
+++ b/test/extern/ferguson/externblock/extern_block_primer.chpl
@@ -92,13 +92,13 @@ c_free(hostname_ptr);
 
 // allow casts from c_ptr(c_char) to c_string
 pragma "no doc"
-inline proc _cast(type t, x) where t:c_string && x.type:c_ptr(c_char) {
+inline proc _cast(type t, x) where isSubtype(t,c_string) && isSubtype(x.type,c_ptr(c_char)) {
     return __primitive("cast", t, x);
 }
 
 // allow casts from c_string to c_ptr(c_char)
 pragma "no doc"
-inline proc _cast(type t, x) where t:c_ptr(c_char) && x.type:c_string {
+inline proc _cast(type t, x) where isSubtype(t,c_ptr(c_char)) && isSubtype(x.type,c_string) {
     return __primitive("cast", t, x);
 }
 

--- a/test/functions/diten/overloadBy.chpl
+++ b/test/functions/diten/overloadBy.chpl
@@ -1,4 +1,4 @@
-proc by(a, b) where !a:range {
+proc by(a, b) where !isSubtype(a,range) {
   return a * b;
 }
 

--- a/test/functions/ferguson/type-colon-dispatch.chpl
+++ b/test/functions/ferguson/type-colon-dispatch.chpl
@@ -59,29 +59,34 @@ foo(borrowed GenericChild(int));
 foo(borrowed GenericChild(real));
 writeln();
 
-proc bar(type t) where t:int {
+proc bar(type t) where isSubtype(t,int) {
   writeln("int");
 }
-proc bar(type t) where (t:integral && !t:int) {
+proc bar(type t) where (isSubtype(t,integral) && !isSubtype(t,int)) {
   writeln("integral");
 }
-proc bar(type t) where !(t:int || t:integral || t:R || t:borrowed Parent ||
-                         t:borrowed GenericParent || t:borrowed object) {
+proc bar(type t) where !(isSubtype(t,int) || isSubtype(t,integral) ||
+                         isSubtype(t,R) || isSubtype(t,borrowed Parent) ||
+                         isSubtype(t,borrowed GenericParent) ||
+                         isSubtype(t,borrowed object)) {
   writeln("any type");
 }
-proc bar(type t) where t:R {
+proc bar(type t) where isSubtype(t,R) {
   writeln("R");
 }
-proc bar(type t) where t:borrowed Parent {
+proc bar(type t) where isSubtype(t,borrowed Parent) {
   writeln("Parent");
 }
-proc bar(type t) where (t:borrowed GenericParent && !t:borrowed GenericChild(int)) {
+proc bar(type t) where (isSubtype(t,borrowed GenericParent) &&
+                        !isSubtype(t,borrowed GenericChild(int))) {
   writeln("GenericParent");
 }
-proc bar(type t) where t:borrowed GenericChild(int) {
+proc bar(type t) where isSubtype(t,borrowed GenericChild(int)) {
   writeln("GenericChild(int)");
 }
-proc bar(type t) where (t:borrowed object && !t:borrowed Parent && !t:borrowed GenericParent) {
+proc bar(type t) where (isSubtype(t,borrowed object) &&
+                        !isSubtype(t,borrowed Parent) &&
+                        !isSubtype(t,borrowed GenericParent)) {
   writeln("object");
 }
 

--- a/test/functions/ferguson/where-subtype-dispatch.chpl
+++ b/test/functions/ferguson/where-subtype-dispatch.chpl
@@ -1,6 +1,6 @@
 
 
-proc foo(x) where x:integral {
+proc foo(x) where isSubtype(x,integral) {
   writeln("integral");
 }
 proc foo(x) {
@@ -36,29 +36,34 @@ class GenericChild : GenericParent {
   var z:int;
 }
 
-proc bar(type t) where t:int {
+proc bar(type t) where isSubtype(t,int) {
   writeln("int");
 }
-proc bar(type t) where (t:integral && !t:int) {
+proc bar(type t) where (isSubtype(t,integral) && !isSubtype(t,int)) {
   writeln("integral");
 }
-proc bar(type t) where !(t:int || t:integral || t:R || t:borrowed Parent ||
-                         t:borrowed GenericParent || t:borrowed object) {
+proc bar(type t) where !(isSubtype(t,int) || isSubtype(t,integral) ||
+                         isSubtype(t,R) || isSubtype(t,borrowed Parent) ||
+                         isSubtype(t,borrowed GenericParent) ||
+                         isSubtype(t,borrowed object)) {
   writeln("any type");
 }
-proc bar(type t) where t:R {
+proc bar(type t) where isSubtype(t,R) {
   writeln("R");
 }
-proc bar(type t) where t:borrowed Parent {
+proc bar(type t) where isSubtype(t,borrowed Parent) {
   writeln("Parent");
 }
-proc bar(type t) where (t:borrowed GenericParent && !t:borrowed GenericChild(int)) {
+proc bar(type t) where (isSubtype(t,borrowed GenericParent) &&
+                        !isSubtype(t,borrowed GenericChild(int))) {
   writeln("GenericParent");
 }
-proc bar(type t) where t:borrowed GenericChild(int) {
+proc bar(type t) where isSubtype(t,borrowed GenericChild(int)) {
   writeln("GenericChild(int)");
 }
-proc bar(type t) where (t:borrowed object && !t:borrowed Parent && !t:borrowed GenericParent) {
+proc bar(type t) where (isSubtype(t,borrowed object) &&
+                        !isSubtype(t,borrowed Parent) &&
+                        !isSubtype(t,borrowed GenericParent)) {
   writeln("object");
 }
 
@@ -75,24 +80,24 @@ bar(borrowed GenericChild(int));
 bar(borrowed GenericChild(real));
 writeln();
 
-proc test1() where borrowed GenericParent(int):borrowed GenericChild { writeln("BAD"); }
+proc test1() where isSubtype(borrowed GenericParent(int),borrowed GenericChild) { writeln("BAD"); }
 proc test1() { writeln("test1"); }
-proc test2() where borrowed GenericChild(real):borrowed GenericParent { writeln("test2"); }
+proc test2() where isSubtype(borrowed GenericChild(real),borrowed GenericParent) { writeln("test2"); }
 proc test2() { writeln("BAD"); }
-proc test3() where borrowed GenericChild(int):borrowed GenericParent { writeln("test3"); }
+proc test3() where isSubtype(borrowed GenericChild(int),borrowed GenericParent) { writeln("test3"); }
 proc test3() { writeln("BAD"); }
-proc test4() where borrowed GenericChild(int):borrowed GenericParent(int) { writeln("test4"); }
+proc test4() where isSubtype(borrowed GenericChild(int),borrowed GenericParent(int)) { writeln("test4"); }
 proc test4() { writeln("BAD"); }
-proc test5() where borrowed GenericChild(real):borrowed GenericParent(int) { writeln("BAD"); }
+proc test5() where isSubtype(borrowed GenericChild(real),borrowed GenericParent(int)) { writeln("BAD"); }
 proc test5() { writeln("test5"); }
-proc test6() where borrowed GenericChild(int(8)):borrowed GenericParent(int) { writeln("BAD"); }
+proc test6() where isSubtype(borrowed GenericChild(int(8)),borrowed GenericParent(int)) { writeln("BAD"); }
 proc test6() { writeln("test6"); }
 
-proc test7() where int:integral { writeln("test7"); }
+proc test7() where isSubtype(int,integral) { writeln("test7"); }
 proc test7() { writeln("BAD"); }
-proc test8() where real:integral { writeln("BAD"); }
+proc test8() where isSubtype(real,integral) { writeln("BAD"); }
 proc test8() { writeln("test8"); }
-proc test9() where real:numeric { writeln("test9"); }
+proc test9() where isSubtype(real,numeric) { writeln("test9"); }
 proc test9() { writeln("BAD"); }
 
 test1();

--- a/test/types/type_variables/jplevyak/typevar_constraint-1.chpl
+++ b/test/types/type_variables/jplevyak/typevar_constraint-1.chpl
@@ -1,8 +1,8 @@
-proc foo(type t, a : t) where t:A {
+proc foo(type t, a : t) where isSubtype(t,A) {
   writeln("foo1 ", a.x);
 }
 
-proc foo(type t, c : t) where t:C {
+proc foo(type t, c : t) where isSubtype(t,C) {
   writeln("foo2 ", c.x);
 }
 

--- a/test/users/thom/domCapture.chpl
+++ b/test/users/thom/domCapture.chpl
@@ -1,9 +1,9 @@
-proc idamax(dx : [?D] real) where D.rank==1 : int {
+proc idamax(dx : [?D] real) where D.rank==1 {
   writeln("In idamax, dx is: ", dx);
 }
 
 
-proc idamax2(dx : [?D]) where D.rank==1 : int {
+proc idamax2(dx : [?D]) where D.rank==1 {
   writeln("In idamax2, dx is: ", dx);
 }
 


### PR DESCRIPTION
Related to #10838 and #10019.

Design direction has been discussed in #10060 (and #9273).

This PR makes using `:` in a where clause deprecated and adjusts tests not to do it.

- [x] full local futures testing

Reviewed by @vasslitvinov - thanks!