### PR TITLE
Mason: refactor build and run

### DIFF
--- a/test/mason/chplVersion/mason-chpl-version-update.chpl
+++ b/test/mason/chplVersion/mason-chpl-version-update.chpl
@@ -7,7 +7,7 @@ use FileSystem;
 config const toml = "";
 
 proc main() {
-  const args = ["foo", "update", "--no-update-registry"];
+  const args = ["foo", "update", "--no-update"];
 
   UpdateLock(args, toml);
 

--- a/test/mason/mason-example-with-opts/mason-example.chpl
+++ b/test/mason/mason-example-with-opts/mason-example.chpl
@@ -5,13 +5,11 @@ use MasonRun;
 proc main() {
 
   // build the examples
-  masonExample(["--no-run", "--force"]);
-
-  // run info list of tests to run
-  masonRun(["mason", "run", "--example"]);
+  masonBuild(["mason", "--build", "--example", "--force"]);
 
   // run each example
-  masonExample(["depExample.chpl", "withOpts.chpl", "examplesubdir/subdirExample.chpl",
-                "example.chpl", "--no-build"]);
+  // over 3 arguments runs all examples
+  var runArgs: [0..3] string = ["mason", "run", "--example", "--force"];
+  masonRun(runArgs);
 
 }

--- a/test/mason/mason-example-with-opts/mason-example.good
+++ b/test/mason/mason-example-with-opts/mason-example.good
@@ -4,12 +4,6 @@ compiled depExample.chpl successfully
 compiled withOpts.chpl successfully
 compiled examplesubdir/subdirExample.chpl successfully
 compiled example.chpl successfully
---- available examples ---
- --- depExample.chpl
- --- withOpts.chpl
- --- examplesubdir/subdirExample.chpl
- --- example.chpl
---------------------------
 Example with dependency Passed!
 Passed!
 Example within subdirectory Passed!

--- a/test/mason/mason-example-with-opts/mason-example.good
+++ b/test/mason/mason-example-with-opts/mason-example.good
@@ -4,7 +4,6 @@ compiled depExample.chpl successfully
 compiled withOpts.chpl successfully
 compiled examplesubdir/subdirExample.chpl successfully
 compiled example.chpl successfully
-Updating mason-registry
 Example with dependency Passed!
 Passed!
 Example within subdirectory Passed!

--- a/test/mason/mason-example-with-opts/mason-example.good
+++ b/test/mason/mason-example-with-opts/mason-example.good
@@ -4,6 +4,7 @@ compiled depExample.chpl successfully
 compiled withOpts.chpl successfully
 compiled examplesubdir/subdirExample.chpl successfully
 compiled example.chpl successfully
+Updating mason-registry
 Example with dependency Passed!
 Passed!
 Example within subdirectory Passed!

--- a/test/mason/mason-example/mason-example.chpl
+++ b/test/mason/mason-example/mason-example.chpl
@@ -5,13 +5,11 @@ use MasonRun;
 proc main() {
 
   // build the examples
-  masonExample(["--no-run", "--force"]);
-
-  // run info list of tests to run
-  masonRun(["mason", "run", "--example"]);
+  masonBuild(["mason", "--build", "--example", "--force"]);
 
   // run each example
-  masonExample(["depExample.chpl", "nomodule.chpl", "examplesubdir/subdirExample.chpl",
-                "example.chpl", "--no-build"]);
+  // over 3 arguments runs all examples
+  var runArgs: [0..3] string = ["mason", "run", "--example", "--force"];
+  masonRun(runArgs);
 
 }

--- a/test/mason/mason-example/mason-example.good
+++ b/test/mason/mason-example/mason-example.good
@@ -4,6 +4,7 @@ compiled depExample.chpl successfully
 compiled example.chpl successfully
 compiled nomodule.chpl successfully
 compiled examplesubdir/subdirExample.chpl successfully
+Updating mason-registry
 Example with dependency Passed!
 Example Passed!
 Example with dependency outside module Passed!

--- a/test/mason/mason-example/mason-example.good
+++ b/test/mason/mason-example/mason-example.good
@@ -4,13 +4,7 @@ compiled depExample.chpl successfully
 compiled example.chpl successfully
 compiled nomodule.chpl successfully
 compiled examplesubdir/subdirExample.chpl successfully
---- available examples ---
- --- depExample.chpl
- --- example.chpl
- --- nomodule.chpl
- --- examplesubdir/subdirExample.chpl
---------------------------
 Example with dependency Passed!
+Example Passed!
 Example with dependency outside module Passed!
 Example within subdirectory Passed!
-Example Passed!

--- a/test/mason/mason-example/mason-example.good
+++ b/test/mason/mason-example/mason-example.good
@@ -4,7 +4,6 @@ compiled depExample.chpl successfully
 compiled example.chpl successfully
 compiled nomodule.chpl successfully
 compiled examplesubdir/subdirExample.chpl successfully
-Updating mason-registry
 Example with dependency Passed!
 Example Passed!
 Example with dependency outside module Passed!

--- a/test/mason/run/mason-run.chpl
+++ b/test/mason/run/mason-run.chpl
@@ -1,6 +1,6 @@
 use MasonRun;
 
 proc main() {
-  const args = ["mason", "run", "--build"];
+  const args: [0..3] string = ["mason", "run", "--build", "--force"];
   masonRun(args);
 }

--- a/test/mason/run/mason-run.good
+++ b/test/mason/run/mason-run.good
@@ -1,5 +1,5 @@
 Updating mason-registry
-Compiling FizzBuzz
+Compiling [debug] target: FizzBuzz
 Build Successful
 
 New library: FizzBuzz

--- a/test/mason/search/mason-search.chpl
+++ b/test/mason/search/mason-search.chpl
@@ -6,7 +6,7 @@ use FileSystem;
 config const pattern = "";
 
 proc main() {
-  var args = ["foo", "search", "--no-update-registry"];
+  var args: [0..2] string = ["foo", "search", "--no-update"];
   if pattern != "" then args.push_back(pattern);
 
 

--- a/test/mason/subdir-commands/mason-run.chpl
+++ b/test/mason/subdir-commands/mason-run.chpl
@@ -1,9 +1,6 @@
 use MasonRun;
-use FileSystem;
-use MasonUtils;
-
 
 proc main() {
-  const args = ["mason", "run", "--build"];
+  const args: [0..3] string = ["mason", "run", "--build", "--force"];
   masonRun(args);
 }

--- a/test/mason/subdir-commands/mason-run.good
+++ b/test/mason/subdir-commands/mason-run.good
@@ -1,5 +1,5 @@
 Updating mason-registry
-Compiling FizzBuzz
+Compiling [debug] target: FizzBuzz
 Build Successful
 
 New library: FizzBuzz

--- a/tools/mason/MasonBuild.chpl
+++ b/tools/mason/MasonBuild.chpl
@@ -44,9 +44,9 @@ proc masonBuild(args) throws {
         masonBuildHelp();
         exit(0);
       }
-      else if arg == '-' {
+      else if arg == '--' {
         if example then
-          throw new MasonError("Examples do not support `-` syntax");
+          throw new MasonError("Examples do not support `--` syntax");
         opt = true;
       }
       else if arg == '--release' {

--- a/tools/mason/MasonBuild.chpl
+++ b/tools/mason/MasonBuild.chpl
@@ -28,17 +28,26 @@ use MasonUpdate;
 use MasonSystem;
 use MasonExample;
 
-proc masonBuild(args) {
+proc masonBuild(args) throws {
   var show = false;
   var release = false;
   var force = false;
   var compopts: [1..0] string;
+  var opt = false;
   var example = false;
   if args.size > 2 {
     for arg in args[2..] {
-      if arg == '-h' || arg == '--help' {
+      if opt == true {
+        compopts.push_back(arg);
+      }
+      else if arg == '-h' || arg == '--help' {
         masonBuildHelp();
         exit(0);
+      }
+      else if arg == '-' {
+        if example then
+          throw new MasonError("Examples do not support `-` syntax");
+        opt = true;
       }
       else if arg == '--release' {
         release = true;
@@ -51,6 +60,10 @@ proc masonBuild(args) {
       }
       else if arg == '--example' {
         example = true;
+      }
+      // passed to UpdateLock
+      else if arg == '--no-update' {
+        continue;
       }
       else {
         compopts.push_back(arg);
@@ -173,8 +186,11 @@ proc compileSrc(lockFile: borrowed Toml, binLoc: string, show: bool,
     }
 
     // Verbosity control
-    if show then writeln(command);
-    else writeln("Compiling "+ project);
+    if show then writeln("Compilation command: " + command);
+    else {
+      if release then writeln("Compiling [release] target: " + project);
+      else writeln("Compiling [debug] target: " + project);
+    }
 
     // compile Program with deps
     var compilation = runWithStatus(command);

--- a/tools/mason/MasonExample.chpl
+++ b/tools/mason/MasonExample.chpl
@@ -260,6 +260,8 @@ private proc runExamples(show: bool, run: bool, build: bool, release: bool,
 private proc runExampleBinary(projectHome: string, exampleName: string,
                               show: bool, execopts: string) throws {
   const command = "".join(projectHome,'/target/example/', exampleName, " ", execopts);
+  if show then writeln("Executing binary: " + command);
+
   const exampleResult = runWithStatus(command, true);
   if exampleResult != 0 {
     throw new MasonError("Mason failed to find and run compiled example: " + exampleName + ".chpl");

--- a/tools/mason/MasonExample.chpl
+++ b/tools/mason/MasonExample.chpl
@@ -64,7 +64,7 @@ proc masonExample(args) {
     }
   }
   var uargs: [1..0] string;
-  if !build then uargs.push_back("--no-update-registry");  
+  if !build then uargs.push_back("--no-update");  
   UpdateLock(uargs);
   runExamples(show, run, build, release, force, examples);
 }

--- a/tools/mason/MasonExample.chpl
+++ b/tools/mason/MasonExample.chpl
@@ -228,7 +228,7 @@ private proc runExamples(show: bool, run: bool, build: bool, release: bool,
             else {
               if show || !run then writeln("compiled ", example, " successfully");
               if run {
-                runExampleBinary(projectHome, exampleName, show, exampleExecopts);
+                runExampleBinary(projectHome, exampleName, release, show, exampleExecopts);
               }
             }
           }
@@ -236,13 +236,13 @@ private proc runExamples(show: bool, run: bool, build: bool, release: bool,
           else {
             writeln("Skipping "+ example + ": no changes made to project or example");
             if run {
-              runExampleBinary(projectHome, exampleName, show, exampleExecopts);
+              runExampleBinary(projectHome, exampleName, release, show, exampleExecopts);
             }
           }
         }
         // just running the example
         else {
-          runExampleBinary(projectHome, exampleName, show, exampleExecopts);
+          runExampleBinary(projectHome, exampleName, release, show, exampleExecopts);
         }
       }
     }
@@ -258,9 +258,12 @@ private proc runExamples(show: bool, run: bool, build: bool, release: bool,
 
 
 private proc runExampleBinary(projectHome: string, exampleName: string,
-                              show: bool, execopts: string) throws {
+                              release: bool, show: bool, execopts: string) throws {
   const command = "".join(projectHome,'/target/example/', exampleName, " ", execopts);
-  if show then writeln("Executing binary: " + command);
+  if show {
+    if release then writeln("Executing [release] target: " + command);
+    else writeln("Executing [debug] target: " + command);
+  }
 
   const exampleResult = runWithStatus(command, true);
   if exampleResult != 0 {

--- a/tools/mason/MasonExample.chpl
+++ b/tools/mason/MasonExample.chpl
@@ -196,8 +196,7 @@ private proc runExamples(show: bool, run: bool, build: bool, release: bool,
         const examplePath = "".join(projectHome, '/example/', example);
         const exampleName = basename(stripExt(example, ".chpl"));
 
-        // retrieves compopts and execopts found per example in the toml file
-        // Adds in cmd line options found after `--`
+        // retrieves compopts and execopts found per example in the toml file      
         const optsFromToml = perExampleOptions[exampleName];
         var exampleCompopts = optsFromToml[1];
         var exampleExecopts = optsFromToml[2];

--- a/tools/mason/MasonExternal.chpl
+++ b/tools/mason/MasonExternal.chpl
@@ -38,8 +38,12 @@ proc masonExternal(args: [] string) {
       exit(0);
     }
     else if args[2] == "--setup" {
-      setupSpack();
-      exit(0);
+      if isDir(MASON_HOME + "/spack") then
+        throw new MasonError("Spack backend is already installed");
+      else {
+        setupSpack();
+        exit(0);
+      }
     }
     if spackInstalled() {
       select (args[2]) {

--- a/tools/mason/MasonHelp.chpl
+++ b/tools/mason/MasonHelp.chpl
@@ -49,7 +49,7 @@ proc masonHelp() {
   writeln('    doc         Build this project\'s documentation');
   writeln('    system      Integrate with system packages found via pkg-config');
   writeln('    test        Compile and run tests found in /test');
-  writeln('    external    Integrate external dependencies into mason pacakges');
+  writeln('    external    Integrate external dependencies into mason packages');
 }
 
 proc masonList() {
@@ -90,8 +90,8 @@ proc masonRunHelp() {
   writeln('   - Execute binary from mason project if target/ is present');
   writeln('   - If no target directory, build and run is Mason.toml is present');
   writeln();
-  writeln('Runtime arguments can be inluded after mason arguments.');
-  writeln('To ensure that runtime arguments and mason arguments to not conflict, seperate them');
+  writeln('Runtime arguments can be included after mason arguments.');
+  writeln('To ensure that runtime arguments and mason arguments to not conflict, separate them');
   writeln('with a single dash(`-`). For example');
   writeln('   e.g. mason run --build - --runtimeArg=true');
 }
@@ -114,8 +114,8 @@ proc masonBuildHelp() {
   writeln('When no options are provided, the following will take place:');
   writeln('   - Build from mason project if Mason.lock present');
   writeln();
-  writeln('Compilation flags and arguments can be inluded after mason arguments.');
-  writeln('To ensure compilation flags and mason arguments to not conlict, seperate them with a');
+  writeln('Compilation flags and arguments can be included after mason arguments.');
+  writeln('To ensure compilation flags and mason arguments to not conflict, separate them with a');
   writeln('single dash(`-`). For example');
   writeln('   e.g. mason build --force - --savec tmpdir');
 }
@@ -321,7 +321,7 @@ proc masonUninstallHelp() {
   writeln("    -h, --help                  Display this message");
   writeln("        --force                 Remove regardless of dependents");
   writeln("        --all                   USE CAREFULLY. remove ALL installed packages that match supplied spec");
-  writeln("        --dependents            Also uninstall any dependent pacakges");
+  writeln("        --dependents            Also uninstall any dependent packages");
   writeln();
   writeln("External Mason packages can be uninstalled as follows:");
   writeln("    mason external uninstall <full Spack spec expression>");

--- a/tools/mason/MasonHelp.chpl
+++ b/tools/mason/MasonHelp.chpl
@@ -84,12 +84,16 @@ proc masonRunHelp() {
   writeln('        --show                   Increase verbosity');
   writeln('        --example <example>      Run an example');
   writeln();
-  writeln('Runtime arguments can also be included after the run arguments ');
   writeln('When --example is thrown without an example, all available examples will be listed');
   writeln();
   writeln('When no options are provided, the following will take place:');
   writeln('   - Execute binary from mason project if target/ is present');
   writeln('   - If no target directory, build and run is Mason.toml is present');
+  writeln();
+  writeln('Runtime arguments can be inluded after mason arguments.');
+  writeln('To ensure that runtime arguments and mason arguments to not conflict, seperate them');
+  writeln('with a single dash(`-`). For example');
+  writeln('   e.g. mason run --build - --runtimeArg=true');
 }
 
 proc masonBuildHelp() {
@@ -104,10 +108,16 @@ proc masonBuildHelp() {
   writeln('        --release                Compile to target/release with optimizations (--fast)');
   writeln('        --force                  Force Mason to build the project');
   writeln('        --example <example>      Build an example from the example/ directory');
+  writeln('        --no-update              Do not update the mason registry before building');
   writeln();
   writeln('When --example is thrown without an example, all examples will be built');
   writeln('When no options are provided, the following will take place:');
-  writeln('   - Build from mason project if Mason.lock present');  
+  writeln('   - Build from mason project if Mason.lock present');
+  writeln();
+  writeln('Compilation flags and arguments can be inluded after mason arguments.');
+  writeln('To ensure compilation flags and mason arguments to not conlict, seperate them with a');
+  writeln('single dash(`-`). For example');
+  writeln('   e.g. mason build --force - --savec tmpdir');
 }
 
 proc masonNewHelp() {

--- a/tools/mason/MasonRun.chpl
+++ b/tools/mason/MasonRun.chpl
@@ -44,8 +44,7 @@ proc masonRun(args) throws {
         masonBuildRun(args);
         exit(1);
       }
-      else if arg == '==' {
-        
+      else if arg == '-' {        
         exec = true;
       }
       else if arg == '--show' {
@@ -104,7 +103,10 @@ proc runProjectBinary(show: bool, release: bool, execopts: [?d] string) throws {
       // add execopts
       command += " " + execs;
 
-      if show then writeln("Executing binary: " + command);
+      if show {
+        if release then writeln("Executing [release] target: " + command);
+        else writeln("Executing [debug] target: " + command);
+      }
 
       // Build if not built, throwing error if Mason.toml doesnt exist
       if isFile(joinPath(projectHome, "Mason.lock")) && built then {
@@ -143,14 +145,15 @@ private proc masonBuildRun(args: [?d] string) {
     var force = false;
     var exec = false;
     var buildExample = false;
+    var updateRegistry = true;
     var execopts: [1..0] string;  
     for arg in args[2..] {
       if exec == true {
         execopts.push_back(arg);
       }
-      else if arg == "==" {
-        if example == true then
-          throw new MasonError("Examples do not support `==` syntax");
+      else if arg == "-" {
+        if example then
+          throw new MasonError("Examples do not support `-` syntax");
         exec = true;
       }
       else if arg == "--example" {
@@ -168,6 +171,9 @@ private proc masonBuildRun(args: [?d] string) {
       else if arg == "--release" {
         release = true;
       }
+      else if arg == '--no-update' {
+        updateRegistry = false;
+      }
       else {
         // could be examples or execopts
         execopts.push_back(arg);
@@ -182,6 +188,7 @@ private proc masonBuildRun(args: [?d] string) {
     }
     else {
       var buildArgs: [0..1] string = ["mason", "build"];
+      if !updateRegistry then buildArgs.push_back("--no-update");
       if release then buildArgs.push_back("--release");
       if force then buildArgs.push_back("--force");
       if show then buildArgs.push_back("--show");

--- a/tools/mason/MasonRun.chpl
+++ b/tools/mason/MasonRun.chpl
@@ -25,6 +25,57 @@ use TOML;
 
 proc masonRun(args) throws {
 
+  var show = false;
+  var example = false;
+  var release = false;
+  var exec = false;
+  var execopts: [1..0] string;
+
+  writeln(" ".join(args));
+  if args.size > 2 {
+    for arg in args[2..] {
+      if exec == true {
+        execopts.push_back(arg);
+      }
+      else if arg == '-h' || arg == '--help' {
+        masonRunHelp();
+        exit(0);
+      }
+      else if arg == '--build' {
+        masonBuildRun(args);
+        exit(1);
+      }
+      else if arg == '==' {
+        
+        exec = true;
+      }
+      else if arg == '--show' {
+        show=true;
+      }
+      else if arg == 'run' {
+        continue;
+      }
+      else if arg == '--release' {
+        release=true;
+      }
+      else if arg == '--example' {        
+        if args.size > 3 {
+          masonBuildRun(args);
+        }
+        // mason run --example
+        else printAvailableExamples();
+        exit(0);
+      }
+      else {
+        execopts.push_back(arg);
+      }
+    }
+  }
+  runProjectBinary(show, release, execopts);
+}
+
+proc runProjectBinary(show: bool, release: bool, execopts: [?d] string) throws {
+
   try! {
 
     const cwd = getEnv("PWD");
@@ -32,74 +83,48 @@ proc masonRun(args) throws {
     const toParse = open(projectHome + "/Mason.toml", iomode.r);
     const tomlFile = new Owned(parseToml(toParse));
     const project = tomlFile["brick"]["name"].s;
-    var show = false;
-    var example = false;
-    var execopts: [1..0] string;
-
-    if args.size > 2 {
-      for arg in args[2..] {
-        if arg == '-h' || arg == '--help' {
-          masonRunHelp();
-          exit(0);
-        }
-        else if arg == '--build' {
-          masonBuildRun(args[2..]);
-          exit(1);
-        }
-        else if arg == '--show' {
-          show=true;
-       }
-       else if arg == 'run' {
-          continue;
-       }
-       else if arg == '--example' {
-         example=true;
-         if args.size > 3 {
-           var exampleArgs = args[3..];
-           exampleArgs.push_back("--no-build");
-           masonExample(exampleArgs);
-         }         
-         else printAvailableExamples(tomlFile, projectHome); 
-       }
-       else {
-          execopts.push_back(arg);
-       }
-      }
-    }
-    if !example {
-      // Find the Binary and execute
-      if isDir(joinPath(projectHome, 'target')) {
-        var execs = ' '.join(execopts);
-        var command: string;
-        if isDir(joinPath(projectHome, 'target/release')) then
+ 
+    // Find the Binary and execute
+    if isDir(joinPath(projectHome, 'target')) {
+      var execs = ' '.join(execopts);
+    
+      // decide which binary(release or debug) to run
+      var command: string;
+      if release {
+        if isDir(joinPath(projectHome, 'target/release')) {
           command = joinPath(projectHome, "target/release", project);
-        else {
-          command = joinPath(projectHome, "target/debug", project);
         }
-
-        var built = false;
-        if isFile(command) then built = true;
-
-        // add execopts
-        command += " " + execs;
-
-        if show then writeln("Executing binary: " + command);
-
-        if isFile(joinPath(projectHome, "Mason.lock")) && built then // If built
-          runCommand(command);
-        else if isFile(joinPath(projectHome, "Mason.toml")) { // If not built
-          masonBuild(args);
-          runCommand(command);
-        }
-        else {
-          throw new MasonError("Mason could not find your Mason.toml file");
-        }
-        // Close memory
-        toParse.close();
       }
       else {
-        throw new MasonError("Mason could not find the compiled program");
+        command = joinPath(projectHome, "target/debug", project);
       }
+
+      var built = false;
+      if isFile(command) then built = true;
+
+      // add execopts
+      command += " " + execs;
+
+      if show then writeln("Executing binary: " + command);
+
+      // Build if not built, throwing error if Mason.toml doesnt exist
+      if isFile(joinPath(projectHome, "Mason.lock")) && built then {
+        runCommand(command);
+      }
+      else if isFile(joinPath(projectHome, "Mason.toml")) {
+        const msg = "Mason could not find your Mason.lock.\n";
+        const help = "To build and run your project use: mason run --build";
+        throw new MasonError(msg + help);
+      }
+      else {
+        throw new MasonError("Mason could not find your Mason.toml file");
+      }
+
+      // Close memory
+      toParse.close();
+    }
+    else {
+      throw new MasonError("Mason could not find the compiled program");
     }
   }
   catch e: MasonError {
@@ -108,52 +133,65 @@ proc masonRun(args) throws {
   }
 }
 
-// Builds before running
+
+/* Builds program before running. */
 private proc masonBuildRun(args: [?d] string) {
-  var example = false;
-  var show = false;
-  var release = false;
-  var force = false;
-  var examples: [1..0] string;  
-  for arg in args {
-    if arg == "--example" {
-      example = true;
+
+  try! {
+    var example = false;
+    var show = false;
+    var release = false;
+    var force = false;
+    var exec = false;
+    var buildExample = false;
+    var execopts: [1..0] string;  
+    for arg in args[2..] {
+      if exec == true {
+        execopts.push_back(arg);
+      }
+      else if arg == "==" {
+        if example == true then
+          throw new MasonError("Examples do not support `==` syntax");
+        exec = true;
+      }
+      else if arg == "--example" {
+        example = true;
+      }
+      else if arg == "--show" {
+        show = true;
+      }
+      else if arg == "--build" {
+        buildExample = true;
+      }
+      else if arg == "--force" {
+        force = true;
+      }
+      else if arg == "--release" {
+        release = true;
+      }
+      else {
+        // could be examples or execopts
+        execopts.push_back(arg);
+      }
     }
-    else if arg == "--show" {
-      show = true;
-    }
-    else if arg == "--build" {
-      continue;
-    }
-    else if arg == "--force" {
-      force = true;
-    }
-    else if arg == "--release" {
-      release = true;
+    if example {
+      if !buildExample then execopts.push_back("--no-build");
+      if release then execopts.push_back("--release");
+      if force then execopts.push_back("--force");
+      if show then execopts.push_back("--show");
+      masonExample(execopts);
     }
     else {
-      examples.push_back(arg);
+      var buildArgs: [0..1] string = ["mason", "build"];
+      if release then buildArgs.push_back("--release");
+      if force then buildArgs.push_back("--force");
+      if show then buildArgs.push_back("--show");
+      masonBuild(buildArgs);
+      runProjectBinary(show, release, execopts);
     }
   }
-  if example {
-    if show then examples.push_back("--show");
-    if release then examples.push_back("--release");
-    if force then examples.push_back("--force");
-    masonExample(examples);
-  }
-  else {
-    var buildArgs = ["mason", "build"];
-    if show then buildArgs.push_back("--show");
-    if release then buildArgs.push_back("--release");
-    if force then buildArgs.push_back("--force");
-    masonBuild(buildArgs);
-    //masonRun(["mason", "run", buildArgs[2..]); when #10622 is completed
-    if show {
-      masonRun(["mason", "run", "--show"]);
-    }
-    else {
-      masonRun(["mason", "run"]);
-    }
+  catch e: MasonError {
+    stderr.writeln(e.message());
   }
 }
 

--- a/tools/mason/MasonRun.chpl
+++ b/tools/mason/MasonRun.chpl
@@ -31,7 +31,6 @@ proc masonRun(args) throws {
   var exec = false;
   var execopts: [1..0] string;
 
-  writeln(" ".join(args));
   if args.size > 2 {
     for arg in args[2..] {
       if exec == true {

--- a/tools/mason/MasonRun.chpl
+++ b/tools/mason/MasonRun.chpl
@@ -44,7 +44,7 @@ proc masonRun(args) throws {
         masonBuildRun(args);
         exit(1);
       }
-      else if arg == '-' {        
+      else if arg == '--' {        
         exec = true;
       }
       else if arg == '--show' {
@@ -151,9 +151,9 @@ private proc masonBuildRun(args: [?d] string) {
       if exec == true {
         execopts.push_back(arg);
       }
-      else if arg == "-" {
+      else if arg == "--" {
         if example then
-          throw new MasonError("Examples do not support `-` syntax");
+          throw new MasonError("Examples do not support `--` syntax");
         exec = true;
       }
       else if arg == "--example" {

--- a/tools/mason/MasonSearch.chpl
+++ b/tools/mason/MasonSearch.chpl
@@ -103,7 +103,7 @@ proc consumeArgs(ref args : [] string) {
   assert(sub == "search");
   args.pop_front();
 
-  const options = {"--no-update-registry", "--debug"};
+  const options = {"--no-update", "--debug"};
 
   while args.size > 0 && options.member(args.head()) {
     args.pop_front();

--- a/tools/mason/MasonTest.chpl
+++ b/tools/mason/MasonTest.chpl
@@ -28,11 +28,12 @@ use Path;
 use FileSystem;
 
 /* Runs the .chpl files found within the /tests directory */
-proc masonTest(args) {
+proc masonTest(args) throws {
 
   var show = false;
   var run = true;
   var parallel = false;
+  var update = true;
   var compopts: [1..0] string;
 
   if args.size > 2 {
@@ -50,12 +51,19 @@ proc masonTest(args) {
       else if arg == '--parallel' {
         parallel = true;
       }
+      else if arg == '--' {
+        throw new MasonError("Testing does not support -- syntax"); 
+      }
+      else if arg == '--no-update' {
+        update = false;
+      }
       else {
         compopts.push_back(arg);
       }
     }
   }
-  const uargs = [""];
+  var uargs: [0..1] string;
+  if !update then uargs.push_back('--no-update');
   UpdateLock(uargs);
   runTests(show, run, parallel, compopts);
 }

--- a/tools/mason/MasonUpdate.chpl
+++ b/tools/mason/MasonUpdate.chpl
@@ -125,10 +125,8 @@ proc checkRegistryChanged() {
 
 /* Pulls the mason-registry. Cloning if !exist */
 proc updateRegistry(tf: string, args : [] string) {
-  for a in args {
-    if a == "--no-update-registry" {
-      return;
-    }
+  if args.find("--no-update")[1] {
+    return;
   }
 
   checkRegistryChanged();


### PR DESCRIPTION
This PR refactors some major LPM tasks of Mason, specifically building and running.

Features added:
- binary for `mason run` can be specified through `--release` flag or lack thereof
- `-` can now be used as a delimiter between mason arguments and options such as runtime arguments and compilations options.
- `--no-update` flag added to build for offline use
- Other minor internal refactors

Other
- A small bug was address in `MasonExternal` as well which prevents the user from installing the Spack backend twice.

This will also close #8852 
