### PR TITLE
Fix BLAS and LinearAlgebra tests after where : deprecation

### DIFF
--- a/modules/packages/BLAS.chpl
+++ b/modules/packages/BLAS.chpl
@@ -2316,7 +2316,7 @@ module BLAS {
 
   */
   proc amax(X: [?D]?eltType, incX: c_int = 1)
-  where D.rank == 1: D.idxType {
+  where D.rank == 1 {
 
     const N = D.size: c_int;
 

--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -1099,11 +1099,11 @@ proc kron(A: [?ADom] ?eltType, B: [?BDom] eltType) {
 //
 // Type helpers
 //
-private proc isDefaultRectangularDom (D: domain) param where _to_borrowed(D._value): DefaultRectangularDom { return true; }
+private proc isDefaultRectangularDom (D: domain) param where isSubtype(_to_borrowed(D._value), DefaultRectangularDom) { return true; }
 private proc isDefaultRectangularDom (D: domain) param { return false; }
 private proc isDefaultRectangularArr (A: []) param { return isDefaultRectangularDom(A.domain); }
 
-private proc isDefaultSparseDom(D: domain) param where _to_borrowed(D._value): DefaultSparseDom { return true; }
+private proc isDefaultSparseDom(D: domain) param where isSubtype(_to_borrowed(D._value), DefaultSparseDom) { return true; }
 private proc isDefaultSparseDom(D: domain) param { return false; }
 private proc isDefaultSparseArr(A: []) param { return isDefaultSparseDom(A.domain); }
 


### PR DESCRIPTION
Follow-on to PR #10850

- [ ] passed library/packages/LinearAlgebra and library/packages/BLAS on a Cray XC