### PR TITLE
Add override keyword to writeThis-on future

### DIFF
--- a/test/io/vass/writeThis-on.chpl
+++ b/test/io/vass/writeThis-on.chpl
@@ -2,7 +2,7 @@
 
 class C {
   const home = here.id;
-  proc writeThis(f) { f.write("here=", here.id, " home=", home); }
+  override proc writeThis(f) { f.write("here=", here.id, " home=", home); }
 }
 
 for l in Locales do on l do { const c = new borrowed C(); writeln(c); }


### PR DESCRIPTION
So the test will match its .bad file after PR #10850.

Trivial and not reviewed.