### PR TITLE
Generate last file needed for compiling a Python module using Cython 

### DIFF
--- a/compiler/codegen/library.cpp
+++ b/compiler/codegen/library.cpp
@@ -455,6 +455,7 @@ static void makePYFile() {
     // Get the static Chapel runtime and third-party libraries
     fprintf(py.fptr, "chpl_libraries=[");
     bool first = true;
+    // Get the libraries listed in require statements
     for_vector(const char, libName, libFiles) {
       if (first) {
         first = false;
@@ -468,6 +469,8 @@ static void makePYFile() {
     libraries.copy(copyOfLib, libraries.length(), 0);
     int prefixLen = strlen("-l");
     char* curSection = strtok(copyOfLib, " \n");
+    // Get the libraries from compileline --libraries, taking the `name`
+    // portion from all `-lname` parts of that command's output
     while (curSection != NULL) {
       if (strncmp(curSection, "-l", prefixLen) == 0) {
         if (first) {

--- a/compiler/codegen/library.cpp
+++ b/compiler/codegen/library.cpp
@@ -286,6 +286,7 @@ static void setupPythonTypeMap() {
 
 static void makePXDFile(std::vector<FnSymbol*> functions);
 static void makePYXFile(std::vector<FnSymbol*> functions);
+static void makePYFile();
 
 void codegen_library_python(std::vector<FnSymbol*> functions) {
   if (fLibraryCompile && fLibraryPython) {
@@ -296,6 +297,7 @@ void codegen_library_python(std::vector<FnSymbol*> functions) {
 
     makePXDFile(functions);
     makePYXFile(functions);
+    makePYFile();
   }
 }
 
@@ -419,6 +421,53 @@ static void makePYXSetupFunctions(std::vector<FnSymbol*> moduleInits) {
   // the exported Chapel code is no longer needed
   fprintf(outfile, "def chpl_cleanup():\n");
   fprintf(outfile, "\tchpl_library_finalize()\n");
+}
+
+// create the Python file which will be used to compile the .pyx, .pxd, library,
+// and header files into a Python module.
+static void makePYFile() {
+  fileinfo py = { NULL, NULL, NULL };
+
+  openLibraryHelperFile(&py, pythonModulename, "py");
+
+  if (py.fptr != NULL) {
+    FILE* save_cfile = gGenInfo->cfile;
+
+    gGenInfo->cfile = py.fptr;
+
+    std::string libname = "";
+    int libLength = strlen("lib");
+    bool startsWithLib = strncmp(executableFilename, "lib", libLength) == 0;
+    if (startsWithLib) {
+      libname += &executableFilename[libLength];
+    } else {
+      libname = executableFilename;
+    }
+
+    // Imports
+    fprintf(py.fptr, "from distutils.core import setup\n");
+    fprintf(py.fptr, "from distutils.core import Extension\n");
+    fprintf(py.fptr, "from Cython.Build import cythonize\n");
+    fprintf(py.fptr, "import numpy\n\n");
+
+    // Get the static Chapel runtime and third-party libraries
+    fprintf(py.fptr, "import compileline\n");
+    fprintf(py.fptr, "chpl_libraries=[l[len('-l'):] for l in compileline.");
+    fprintf(py.fptr, "libraries.split() if l.startswith('-l')]\n");
+
+    // Cythonize me, Captain!
+    fprintf(py.fptr, "setup(name = '%s library',\n", pythonModulename);
+    fprintf(py.fptr, "\text_modules = cythonize(\n");
+    fprintf(py.fptr, "\t\tExtension(\"%s\",\n", pythonModulename);
+    fprintf(py.fptr, "\t\t\tinclude_dirs=[numpy.get_include()],\n");
+    fprintf(py.fptr, "\t\t\tsources=[\"%s.pyx\"],\n", pythonModulename);
+    fprintf(py.fptr, "\t\t\tlibraries=[\"%s\"] + chpl_libraries)))\n",
+            libname.c_str());
+
+    gGenInfo->cfile = save_cfile;
+  }
+  // Don't "beautify", it will remove the tabs
+  closeLibraryHelperFile(&py, false);
 }
 
 // Skip this function if it is defined in an internal module, or if it is

--- a/test/compflags/lydia/library/noLibFlag/pythonCompile.catfiles
+++ b/test/compflags/lydia/library/noLibFlag/pythonCompile.catfiles
@@ -1,2 +1,3 @@
 lib/chpl_pythonCompile.pxd
 lib/pythonCompile.pyx
+lib/pythonCompile.py

--- a/test/compflags/lydia/library/noLibFlag/pythonCompile.good
+++ b/test/compflags/lydia/library/noLibFlag/pythonCompile.good
@@ -44,8 +44,6 @@ from distutils.core import Extension
 from Cython.Build import cythonize
 import numpy
 
-import compileline
-chpl_libraries=[l[len('-l'):] for l in compileline.libraries.split() if l.startswith('-l')]
 setup(name = 'pythonCompile library',
 	ext_modules = cythonize(
 		Extension("pythonCompile",

--- a/test/compflags/lydia/library/noLibFlag/pythonCompile.good
+++ b/test/compflags/lydia/library/noLibFlag/pythonCompile.good
@@ -39,3 +39,16 @@ def parallelProg(numpy.int64 numTasksToRun):
 
 def threadring(numpy.int64 passes, numpy.int64 tasks):
 	chpl_threadring(passes, tasks)
+from distutils.core import setup
+from distutils.core import Extension
+from Cython.Build import cythonize
+import numpy
+
+import compileline
+chpl_libraries=[l[len('-l'):] for l in compileline.libraries.split() if l.startswith('-l')]
+setup(name = 'pythonCompile library',
+	ext_modules = cythonize(
+		Extension("pythonCompile",
+			include_dirs=[numpy.get_include()],
+			sources=["pythonCompile.pyx"],
+			libraries=["pythonCompile"] + chpl_libraries)))

--- a/test/compflags/lydia/library/noLibFlag/pythonCompile.prediff
+++ b/test/compflags/lydia/library/noLibFlag/pythonCompile.prediff
@@ -2,4 +2,5 @@
 
 # The value in that variable will vary depending on the system, so don't check
 # its contents
-sed -i '' '/^chpl_libraries/d' $2
+sed '/^chpl_libraries/d' $2 > $2.tmp
+mv $2.tmp $2

--- a/test/compflags/lydia/library/noLibFlag/pythonCompile.prediff
+++ b/test/compflags/lydia/library/noLibFlag/pythonCompile.prediff
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# The value in that variable will vary depending on the system, so don't check
+# its contents
+sed -i '' '/^chpl_libraries/d' $2

--- a/test/compflags/lydia/library/python/PREDIFF
+++ b/test/compflags/lydia/library/python/PREDIFF
@@ -2,4 +2,5 @@
 
 # The value in that variable will vary depending on the system, so don't check
 # its contents
-sed -i '' '/^chpl_libraries/d' $2
+sed '/^chpl_libraries/d' $2 > $2.tmp
+mv $2.tmp $2

--- a/test/compflags/lydia/library/python/PREDIFF
+++ b/test/compflags/lydia/library/python/PREDIFF
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# The value in that variable will vary depending on the system, so don't check
+# its contents
+sed -i '' '/^chpl_libraries/d' $2

--- a/test/compflags/lydia/library/python/boolFunctions.catfiles
+++ b/test/compflags/lydia/library/python/boolFunctions.catfiles
@@ -1,2 +1,3 @@
 lib/chpl_boolFunctions.pxd
 lib/boolFunctions.pyx
+lib/boolFunctions.py

--- a/test/compflags/lydia/library/python/boolFunctions.good
+++ b/test/compflags/lydia/library/python/boolFunctions.good
@@ -36,3 +36,16 @@ def getBool():
 def takeAndReturn(bint x):
 	ret = chpl_takeAndReturn(x)
 	return ret
+from distutils.core import setup
+from distutils.core import Extension
+from Cython.Build import cythonize
+import numpy
+
+import compileline
+chpl_libraries=[l[len('-l'):] for l in compileline.libraries.split() if l.startswith('-l')]
+setup(name = 'boolFunctions library',
+	ext_modules = cythonize(
+		Extension("boolFunctions",
+			include_dirs=[numpy.get_include()],
+			sources=["boolFunctions.pyx"],
+			libraries=["boolFunctions"] + chpl_libraries)))

--- a/test/compflags/lydia/library/python/boolFunctions.good
+++ b/test/compflags/lydia/library/python/boolFunctions.good
@@ -41,8 +41,6 @@ from distutils.core import Extension
 from Cython.Build import cythonize
 import numpy
 
-import compileline
-chpl_libraries=[l[len('-l'):] for l in compileline.libraries.split() if l.startswith('-l')]
 setup(name = 'boolFunctions library',
 	ext_modules = cythonize(
 		Extension("boolFunctions",

--- a/test/compflags/lydia/library/python/checkExplicitLibname.catfiles
+++ b/test/compflags/lydia/library/python/checkExplicitLibname.catfiles
@@ -1,2 +1,3 @@
 lib/chpl_checkExplicitLibname.pxd
 lib/checkExplicitLibname.pyx
+lib/checkExplicitLibname.py

--- a/test/compflags/lydia/library/python/checkExplicitLibname.good
+++ b/test/compflags/lydia/library/python/checkExplicitLibname.good
@@ -39,3 +39,16 @@ def parallelProg(numpy.int64 numTasksToRun):
 
 def threadring(numpy.int64 passes, numpy.int64 tasks):
 	chpl_threadring(passes, tasks)
+from distutils.core import setup
+from distutils.core import Extension
+from Cython.Build import cythonize
+import numpy
+
+import compileline
+chpl_libraries=[l[len('-l'):] for l in compileline.libraries.split() if l.startswith('-l')]
+setup(name = 'checkExplicitLibname library',
+	ext_modules = cythonize(
+		Extension("checkExplicitLibname",
+			include_dirs=[numpy.get_include()],
+			sources=["checkExplicitLibname.pyx"],
+			libraries=["checkExplicitLibname"] + chpl_libraries)))

--- a/test/compflags/lydia/library/python/checkExplicitLibname.good
+++ b/test/compflags/lydia/library/python/checkExplicitLibname.good
@@ -44,8 +44,6 @@ from distutils.core import Extension
 from Cython.Build import cythonize
 import numpy
 
-import compileline
-chpl_libraries=[l[len('-l'):] for l in compileline.libraries.split() if l.startswith('-l')]
 setup(name = 'checkExplicitLibname library',
 	ext_modules = cythonize(
 		Extension("checkExplicitLibname",

--- a/test/compflags/lydia/library/python/complexFunctions.catfiles
+++ b/test/compflags/lydia/library/python/complexFunctions.catfiles
@@ -1,2 +1,3 @@
 lib/chpl_complexFunctions.pxd
 lib/complexFunctions.pyx
+lib/complexFunctions.py

--- a/test/compflags/lydia/library/python/complexFunctions.good
+++ b/test/compflags/lydia/library/python/complexFunctions.good
@@ -36,3 +36,16 @@ def getComplex():
 def takeAndReturn(numpy.complex128 x):
 	ret = chpl_takeAndReturn(x)
 	return ret
+from distutils.core import setup
+from distutils.core import Extension
+from Cython.Build import cythonize
+import numpy
+
+import compileline
+chpl_libraries=[l[len('-l'):] for l in compileline.libraries.split() if l.startswith('-l')]
+setup(name = 'complexFunctions library',
+	ext_modules = cythonize(
+		Extension("complexFunctions",
+			include_dirs=[numpy.get_include()],
+			sources=["complexFunctions.pyx"],
+			libraries=["complexFunctions"] + chpl_libraries)))

--- a/test/compflags/lydia/library/python/complexFunctions.good
+++ b/test/compflags/lydia/library/python/complexFunctions.good
@@ -41,8 +41,6 @@ from distutils.core import Extension
 from Cython.Build import cythonize
 import numpy
 
-import compileline
-chpl_libraries=[l[len('-l'):] for l in compileline.libraries.split() if l.startswith('-l')]
 setup(name = 'complexFunctions library',
 	ext_modules = cythonize(
 		Extension("complexFunctions",

--- a/test/compflags/lydia/library/python/realFunctions.catfiles
+++ b/test/compflags/lydia/library/python/realFunctions.catfiles
@@ -1,2 +1,3 @@
 lib/chpl_realFunctions.pxd
 lib/realFunctions.pyx
+lib/realFunctions.py

--- a/test/compflags/lydia/library/python/realFunctions.good
+++ b/test/compflags/lydia/library/python/realFunctions.good
@@ -41,8 +41,6 @@ from distutils.core import Extension
 from Cython.Build import cythonize
 import numpy
 
-import compileline
-chpl_libraries=[l[len('-l'):] for l in compileline.libraries.split() if l.startswith('-l')]
 setup(name = 'realFunctions library',
 	ext_modules = cythonize(
 		Extension("realFunctions",

--- a/test/compflags/lydia/library/python/realFunctions.good
+++ b/test/compflags/lydia/library/python/realFunctions.good
@@ -36,3 +36,16 @@ def getReal():
 def takeAndReturn(float x):
 	ret = chpl_takeAndReturn(x)
 	return ret
+from distutils.core import setup
+from distutils.core import Extension
+from Cython.Build import cythonize
+import numpy
+
+import compileline
+chpl_libraries=[l[len('-l'):] for l in compileline.libraries.split() if l.startswith('-l')]
+setup(name = 'realFunctions library',
+	ext_modules = cythonize(
+		Extension("realFunctions",
+			include_dirs=[numpy.get_include()],
+			sources=["realFunctions.pyx"],
+			libraries=["realFunctions"] + chpl_libraries)))

--- a/test/compflags/lydia/library/python/stringFunctions.catfiles
+++ b/test/compflags/lydia/library/python/stringFunctions.catfiles
@@ -1,2 +1,3 @@
 lib/chpl_stringFunctions.pxd
 lib/stringFunctions.pyx
+lib/stringFunctions.py

--- a/test/compflags/lydia/library/python/stringFunctions.good
+++ b/test/compflags/lydia/library/python/stringFunctions.good
@@ -38,3 +38,16 @@ def takeAndReturn(bytes x):
 	cdef const char* chpl_x = x
 	ret = chpl_takeAndReturn(chpl_x)
 	return ret
+from distutils.core import setup
+from distutils.core import Extension
+from Cython.Build import cythonize
+import numpy
+
+import compileline
+chpl_libraries=[l[len('-l'):] for l in compileline.libraries.split() if l.startswith('-l')]
+setup(name = 'stringFunctions library',
+	ext_modules = cythonize(
+		Extension("stringFunctions",
+			include_dirs=[numpy.get_include()],
+			sources=["stringFunctions.pyx"],
+			libraries=["stringFunctions"] + chpl_libraries)))

--- a/test/compflags/lydia/library/python/stringFunctions.good
+++ b/test/compflags/lydia/library/python/stringFunctions.good
@@ -43,8 +43,6 @@ from distutils.core import Extension
 from Cython.Build import cythonize
 import numpy
 
-import compileline
-chpl_libraries=[l[len('-l'):] for l in compileline.libraries.split() if l.startswith('-l')]
 setup(name = 'stringFunctions library',
 	ext_modules = cythonize(
 		Extension("stringFunctions",

--- a/test/compflags/lydia/library/python/testing.catfiles
+++ b/test/compflags/lydia/library/python/testing.catfiles
@@ -1,2 +1,3 @@
 lib/chpl_testing.pxd
 lib/testing.pyx
+lib/testing.py

--- a/test/compflags/lydia/library/python/testing.good
+++ b/test/compflags/lydia/library/python/testing.good
@@ -44,8 +44,6 @@ from distutils.core import Extension
 from Cython.Build import cythonize
 import numpy
 
-import compileline
-chpl_libraries=[l[len('-l'):] for l in compileline.libraries.split() if l.startswith('-l')]
 setup(name = 'testing library',
 	ext_modules = cythonize(
 		Extension("testing",

--- a/test/compflags/lydia/library/python/testing.good
+++ b/test/compflags/lydia/library/python/testing.good
@@ -39,3 +39,16 @@ def parallelProg(numpy.int64 numTasksToRun):
 
 def threadring(numpy.int64 passes, numpy.int64 tasks):
 	chpl_threadring(passes, tasks)
+from distutils.core import setup
+from distutils.core import Extension
+from Cython.Build import cythonize
+import numpy
+
+import compileline
+chpl_libraries=[l[len('-l'):] for l in compileline.libraries.split() if l.startswith('-l')]
+setup(name = 'testing library',
+	ext_modules = cythonize(
+		Extension("testing",
+			include_dirs=[numpy.get_include()],
+			sources=["testing.pyx"],
+			libraries=["testing"] + chpl_libraries)))

--- a/test/compflags/lydia/library/python/uintFunctions.catfiles
+++ b/test/compflags/lydia/library/python/uintFunctions.catfiles
@@ -1,2 +1,3 @@
 lib/chpl_uintFunctions.pxd
 lib/uintFunctions.pyx
+lib/uintFunctions.py

--- a/test/compflags/lydia/library/python/uintFunctions.good
+++ b/test/compflags/lydia/library/python/uintFunctions.good
@@ -41,8 +41,6 @@ from distutils.core import Extension
 from Cython.Build import cythonize
 import numpy
 
-import compileline
-chpl_libraries=[l[len('-l'):] for l in compileline.libraries.split() if l.startswith('-l')]
 setup(name = 'uintFunctions library',
 	ext_modules = cythonize(
 		Extension("uintFunctions",

--- a/test/compflags/lydia/library/python/uintFunctions.good
+++ b/test/compflags/lydia/library/python/uintFunctions.good
@@ -36,3 +36,16 @@ def getUint():
 def takeAndReturn(numpy.uint64 x):
 	ret = chpl_takeAndReturn(x)
 	return ret
+from distutils.core import setup
+from distutils.core import Extension
+from Cython.Build import cythonize
+import numpy
+
+import compileline
+chpl_libraries=[l[len('-l'):] for l in compileline.libraries.split() if l.startswith('-l')]
+setup(name = 'uintFunctions library',
+	ext_modules = cythonize(
+		Extension("uintFunctions",
+			include_dirs=[numpy.get_include()],
+			sources=["uintFunctions.pyx"],
+			libraries=["uintFunctions"] + chpl_libraries)))


### PR DESCRIPTION
This file handles pulling in the various components needed for a successful
Cython compile - the libraries, the .pyx file, the name to generate, numpy, etc.

Resolves #9311
Resolves #10818

Updates the python tests to include the new file.

Note that this doesn't build the Python module yet, even though all the files
are in place.  That needs to wait until we have a testing environment with
Cython installed.

TODO: merge in python arrays branch changes

Passed full paratest with futures