### PR TITLE
Default assign owned field

### DIFF
--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -753,16 +753,13 @@ static void build_enum_size_function(EnumType* et) {
 
   fn->insertFormalAtTail(new ArgSymbol(INTENT_BLANK, "_mt", dtMethodToken));
 
-  fn->_this = new ArgSymbol(INTENT_BLANK, "this", dtAny);
+  fn->_this = new ArgSymbol(INTENT_BLANK, "this", et);
   fn->_this->addFlag(FLAG_ARG_THIS);
-  fn->_this->addFlag(FLAG_MARKED_GENERIC);
   fn->_this->addFlag(FLAG_TYPE_VARIABLE);
 
   fn->insertFormalAtTail(fn->_this);
 
   fn->retTag = RET_PARAM;
-  //use this function only where the argument is an enum
-  fn->where = new BlockStmt(new CallExpr("==", fn->_this, et->symbol));
 
   VarSymbol*  varS = new_IntSymbol(et->constants.length);
   fn->insertAtTail(new CallExpr(PRIM_RETURN, varS));
@@ -792,13 +789,10 @@ static void build_enum_first_function(EnumType* et) {
   // _defaultOf function for the enum to obtain this functionality (and
   // that is the encouraged path to take).
   fn->addFlag(FLAG_INLINE);
-  ArgSymbol* arg = new ArgSymbol(INTENT_BLANK, "t", dtAny);
-  arg->addFlag(FLAG_MARKED_GENERIC);
+  ArgSymbol* arg = new ArgSymbol(INTENT_BLANK, "t", et);
   arg->addFlag(FLAG_TYPE_VARIABLE);
   fn->insertFormalAtTail(arg);
   fn->retTag = RET_PARAM;
-
-  fn->where = new BlockStmt(new CallExpr("==", arg, et->symbol));
 
   DefExpr* defExpr = toDefExpr(et->constants.head);
   if (defExpr)
@@ -824,10 +818,9 @@ static void build_enum_enumerate_function(EnumType* et) {
   FnSymbol* fn = new FnSymbol("chpl_enum_enumerate");
   fn->addFlag(FLAG_COMPILER_GENERATED);
   fn->addFlag(FLAG_LAST_RESORT);
-  ArgSymbol* arg = new ArgSymbol(INTENT_BLANK, "t", dtAny);
+  ArgSymbol* arg = new ArgSymbol(INTENT_BLANK, "t", et);
   arg->addFlag(FLAG_TYPE_VARIABLE);
   fn->insertFormalAtTail(arg);
-  fn->where = new BlockStmt(new CallExpr("==", arg, et->symbol));
 
   baseModule->block->insertAtTail(new DefExpr(fn));
 
@@ -975,7 +968,7 @@ static void build_enum_cast_function(EnumType* et) {
   fn = new FnSymbol(astr_cast);
   fn->addFlag(FLAG_COMPILER_GENERATED);
   fn->addFlag(FLAG_LAST_RESORT);
-  arg1 = new ArgSymbol(INTENT_BLANK, "t", dtAny);
+  arg1 = new ArgSymbol(INTENT_BLANK, "t", et);
   arg1->addFlag(FLAG_TYPE_VARIABLE);
   arg2 = new ArgSymbol(INTENT_BLANK, "_arg2", dtString);
   fn->insertFormalAtTail(arg1);
@@ -1011,7 +1004,6 @@ static void build_enum_cast_function(EnumType* et) {
   fn->insertAtTail(new CallExpr(PRIM_RETURN,
                                 toDefExpr(et->constants.first())->sym));
 
-  fn->where = new BlockStmt(new CallExpr("==", arg1, et->symbol));
   def = new DefExpr(fn);
   //
   // these cast functions need to go in the base module because they
@@ -1854,13 +1846,12 @@ static void buildStringCastFunction(EnumType* et) {
   FnSymbol* fn = new FnSymbol(astr_cast);
   fn->addFlag(FLAG_COMPILER_GENERATED);
   fn->addFlag(FLAG_LAST_RESORT);
-  ArgSymbol* t = new ArgSymbol(INTENT_BLANK, "t", dtAny);
+  ArgSymbol* t = new ArgSymbol(INTENT_BLANK, "t", dtString);
   t->addFlag(FLAG_TYPE_VARIABLE);
   fn->insertFormalAtTail(t);
   ArgSymbol* arg = new ArgSymbol(INTENT_BLANK, "this", et);
   arg->addFlag(FLAG_ARG_THIS);
   fn->insertFormalAtTail(arg);
-  fn->where = new BlockStmt(new CallExpr("==", t, dtString->symbol));
 
   for_enums(constant, et) {
     fn->insertAtTail(

--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -1128,7 +1128,7 @@ static void build_record_assignment_function(AggregateType* ct) {
 
   ArgSymbol* arg1 = new ArgSymbol(INTENT_REF, "_arg1", ct);
   arg1->addFlag(FLAG_MARKED_GENERIC);
-  ArgSymbol* arg2 = new ArgSymbol(INTENT_BLANK, "_arg2", ct);
+  ArgSymbol* arg2 = new ArgSymbol(INTENT_REF_MAYBE_CONST, "_arg2", ct);
   arg2->addFlag(FLAG_MARKED_GENERIC);
 
   fn->insertFormalAtTail(arg1);

--- a/test/types/records/ferguson/default-compare-mixed-insn.chpl
+++ b/test/types/records/ferguson/default-compare-mixed-insn.chpl
@@ -1,0 +1,19 @@
+record R {
+  type t = int;
+  var x:t;
+}
+
+proc main() {
+  var r64 = new R(int(64), 1);
+  var r64a = new R(int(64), 1);
+  var r32 = new R(int(32), 1);
+  var r32a = new R(int(32), 1);
+
+  writeln(r64 == r64a);
+  writeln(r32 == r32a);
+
+  // These return false because the default == fn
+  // compares the type fields and they differ.
+  writeln(r32 == r64);
+  writeln(r64 == r32);
+}

--- a/test/types/records/ferguson/default-compare-mixed-insn.good
+++ b/test/types/records/ferguson/default-compare-mixed-insn.good
@@ -1,0 +1,4 @@
+true
+true
+false
+false


### PR DESCRIPTION
This PR addresses a problem with the compiler-generated `=` for records
containing owned fields. It does that by marking the RHS of the record
assignment with `INTENT_REF_MAYBE_CONST` so that it will be inferred with
appropriate constness.

While working in buildDefaultFunctions, it removes some `where` clauses
that are no longer necessary from the default functions built.

Addresses part of #10872 (now the behavior is symmetrical).

Closes #8664 (the problem with default generated `=` for records
containing owned was the last unresolved problem there).

- [x] full local futures testing

Reviewed by @lydia-duncan - thanks!