### PR TITLE
Remove ForallStmt::fFromResolvedForLoop

### DIFF
--- a/compiler/AST/ForallStmt.cpp
+++ b/compiler/AST/ForallStmt.cpp
@@ -38,7 +38,6 @@ ForallStmt::ForallStmt(bool zippered, BlockStmt* body):
   fFromForLoop(false),
   fContinueLabel(NULL),
   fErrorHandlerLabel(NULL),
-  fFromResolvedForLoop(false),
   fRecIterIRdef(NULL),
   fRecIterICdef(NULL),
   fRecIterGetIterator(NULL),
@@ -62,7 +61,6 @@ ForallStmt* ForallStmt::copyInner(SymbolMap* map) {
     _this->fShadowVars.insertAtTail(COPY_INT(expr));
 
   _this->fFromForLoop = fFromForLoop;
-  _this->fFromResolvedForLoop = fFromResolvedForLoop;
   // todo: fContinueLabel, fErrorHandlerLabel
 
   _this->fRecIterIRdef        = COPY_INT(fRecIterIRdef);

--- a/compiler/AST/foralls.cpp
+++ b/compiler/AST/foralls.cpp
@@ -492,7 +492,6 @@ static QualifiedType buildIterYieldType(ForallStmt* fs, FnSymbol* iterFn, FnSymb
   return result;
 }
 
-
 //
 // Given an iterator function, find the type that it yields.
 // It would be fn->retType, alas protoIteratorClass() messes with that.
@@ -519,6 +518,13 @@ static QualifiedType fsIterYieldType(ForallStmt* fs, FnSymbol* iterFn,
     return fsIterYieldType(fs, iterator, origIterFn, alreadyResolved);
   }
 }
+
+
+static bool acceptUnmodifiedIterCall(ForallStmt* pfs, CallExpr* iterCall)
+{
+  return pfs->createdFromForLoop();
+}
+
 
 // Like in build.cpp, here for ForallStmt.
 static BlockStmt*
@@ -638,7 +644,7 @@ static CallExpr* buildForallParIterCall(ForallStmt* pfs, SymExpr* origSE)
       targetName = astr(astr_loopexpr_iter, targetName + forallExprNameLen);
     }
 
-    if (pfs->fFromResolvedForLoop) {
+    if (acceptUnmodifiedIterCall(pfs, origIterCall)) {
       iterCall = origIterCall;
       iterCall->remove();
     } else {
@@ -668,11 +674,6 @@ static void checkForExplicitTagArgs(CallExpr* iterCall) {
       USR_STOP();
     }
   }
-}
-
-static bool acceptUnmodifiedIterCall(ForallStmt* pfs, CallExpr* iterCall)
-{
-  return pfs->iterCallAlreadyTagged();
 }
 
 static bool findStandaloneOrLeader(ForallStmt* pfs, CallExpr* iterCall)

--- a/compiler/include/ForallStmt.h
+++ b/compiler/include/ForallStmt.h
@@ -39,7 +39,6 @@ public:
 
   // when originating from a ForLoop
   bool       createdFromForLoop()    const;  // is converted from a for-loop
-  bool       iterCallAlreadyTagged() const;  // already has 'tag' actual
   bool       needToHandleOuterVars() const;  // yes, convert to shadow vars
 
   DECLARE_COPY(ForallStmt);
@@ -82,7 +81,6 @@ private:
 public:
   LabelSymbol*   fContinueLabel;     // update_symbols() needs the labels
   LabelSymbol*   fErrorHandlerLabel;
-  bool           fFromResolvedForLoop;
 
   // for recursive iterators during lowerIterators
   DefExpr*       fRecIterIRdef;
@@ -113,7 +111,6 @@ inline AList& ForallStmt::iteratedExpressions()    { return fIterExprs;  }
 inline AList& ForallStmt::shadowVariables()        { return fShadowVars; }
 inline BlockStmt* ForallStmt::loopBody()     const { return fLoopBody;   }
 
-inline bool ForallStmt::iterCallAlreadyTagged() const { return  fFromForLoop; }
 inline bool ForallStmt::needToHandleOuterVars() const { return !fFromForLoop; }
 inline bool ForallStmt::createdFromForLoop()    const { return  fFromForLoop; }
 

--- a/compiler/resolution/implementForallIntents2.cpp
+++ b/compiler/resolution/implementForallIntents2.cpp
@@ -240,7 +240,6 @@ Expr* replaceForWithForallIfNeeded(ForLoop* forLoop) {
   // findCallToParallelIterator() filled out eflopiInfo.
   ForallStmt* fs = replaceEflopiWithForall(eflopiInfo);
 
-  fs->fFromResolvedForLoop = true;
   // If >1 iterated exprs, how to call resolveForallHeader?
   INT_ASSERT(fs->numIteratedExprs() == 1);
   SymExpr* itExpr = toSymExpr(fs->iteratedExpressions().head);


### PR DESCRIPTION
fFromResolvedForLoop duplicates fFromForLoop.
This change removes it.

While there, replace iterCallAlreadyTagged() with createdFromForLoop(),
for simplicity.