### PR TITLE
Fix valgrind issue with python library compilation

### DIFF
--- a/compiler/codegen/library.cpp
+++ b/compiler/codegen/library.cpp
@@ -467,6 +467,7 @@ static void makePYFile() {
     std::string libraries = getCompilelineOption("libraries");
     char copyOfLib[libraries.length() + 1];
     libraries.copy(copyOfLib, libraries.length(), 0);
+    copyOfLib[libraries.length()] = '\0';
     int prefixLen = strlen("-l");
     char* curSection = strtok(copyOfLib, " \n");
     // Get the libraries from compileline --libraries, taking the `name`


### PR DESCRIPTION
I had missed that string::copy did not add a trailing '\0' when
copying, so valgrind was complaining about uninitialized memory.
Add the missing terminator

Double checked that all the tests which failed with valgrind now
pass again