### PR TITLE
Add Jenkins Job for testing Spack Integration

### DIFF
--- a/util/cron/test-rhel.mason-spack.bash
+++ b/util/cron/test-rhel.mason-spack.bash
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+#
+# Test mason-spack integration (only) on RHEL linux64 slaves
+# The SKIPIF will make sure mason external and spack have been installed and configured
+
+CWD=$(cd $(dirname $0) ; pwd)
+source $CWD/common.bash
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="rhel.mason-spack"
+
+export CHPL_NIGHTLY_TEST_DIRS=mason/spack-integration
+
+$CWD/nightly -cron 


### PR DESCRIPTION
Adds new Nightly test driver: `test-rhel.mason-spack.bash`

New Jenkins job name: `correctness-test-rhel.mason-spack`

Implements #10833 