### PR TITLE
Remove iteratorLeaderMap, iteratorFollowerMap

### DIFF
--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -56,17 +56,11 @@ extern char                             primCoerceTmpName[];
 
 extern Map<Type*,     FnSymbol*>        autoDestroyMap;
 
-extern Map<FnSymbol*, FnSymbol*>        iteratorLeaderMap;
-
-extern Map<FnSymbol*, FnSymbol*>        iteratorFollowerMap;
-
 extern Map<Type*,     FnSymbol*>        valueToRuntimeTypeMap;
 
 extern std::map<Type*,     Serializers> serializeMap;
 
 extern std::map<CallExpr*, CallExpr*>   eflopiMap;
-
-
 
 
 

--- a/compiler/include/wrappers.h
+++ b/compiler/include/wrappers.h
@@ -31,4 +31,6 @@ FnSymbol* wrapAndCleanUpActuals(FnSymbol*               fn,
                                 std::vector<ArgSymbol*> actualIdxToFormal,
                                 bool                    fastFollowerChecks);
 
+const char* unwrapFnName(FnSymbol* fn);
+
 #endif

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5424,10 +5424,13 @@ static Type* moveDetermineRhsType(CallExpr* call) {
     if (CallExpr* rhsCall = toCallExpr(rhs)) {
       if (FnSymbol* rhsFn = rhsCall->resolvedFunction()) {
         if (rhsFn->hasFlag(FLAG_VOID_NO_RETURN_VALUE) == true) {
+          const char* rhsName = rhsFn->name;
+          if (rhsFn->hasFlag(FLAG_PROMOTION_WRAPPER))
+            rhsName = unwrapFnName(rhsFn);
           USR_FATAL(userCall(call),
                     "illegal use of function that does not "
                     "return a value: '%s'",
-                    rhsFn->name);
+                    rhsName);
         }
       }
     }
@@ -6037,7 +6040,7 @@ static void resolveNewManaged(CallExpr* move, CallExpr* newExpr, Expr* last,
     std::vector<CallExpr*> wrapperCalls;
     collectCallExprs(fn, wrapperCalls);
     for_vector(CallExpr, call, wrapperCalls) {
-      if (call->isNamed(fn->name)) {
+      if (call->isNamedAstr(astrNew)) {
         fixThisNew = call;
       }
     }

--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -805,9 +805,7 @@ static Expr* preFoldPrimOp(CallExpr* call) {
     FnSymbol* iterator     = getTheIteratorFn(call);
     CallExpr* followerCall = NULL;
 
-    if (FnSymbol* follower = iteratorFollowerMap.get(iterator)) {
-      followerCall = new CallExpr(follower);
-    } else if (FnSymbol* f2 = findForallexprFollower(iterator)) {
+    if (FnSymbol* f2 = findForallexprFollower(iterator)) {
       followerCall = new CallExpr(f2);
     } else {
       followerCall = new CallExpr(iterator->name);
@@ -845,13 +843,7 @@ static Expr* preFoldPrimOp(CallExpr* call) {
 
   } else if (call->isPrimitive(PRIM_TO_LEADER)) {
     FnSymbol* iterator   = getTheIteratorFn(call);
-    CallExpr* leaderCall = NULL;
-
-    if (FnSymbol* leader = iteratorLeaderMap.get(iterator)) {
-      leaderCall = new CallExpr(leader);
-    } else {
-      leaderCall = new CallExpr(iterator->name);
-    }
+    CallExpr* leaderCall = new CallExpr(iterator->name);
 
     for_formals(formal, iterator) {
       // Note: this can add a use formal outside of its function

--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -2311,8 +2311,6 @@ static void buildLeaderIterator(FnSymbol* wrapFn,
 
   INT_ASSERT(liFn->hasFlag(FLAG_RESOLVED) == false);
 
-  iteratorLeaderMap.put(wrapFn, liFn);
-
   form_Map(SymbolMapElem, e, leaderMap) {
     if (Symbol* s = paramMap.get(e->key)) {
       paramMap.put(e->value, s);
@@ -2331,6 +2329,7 @@ static void buildLeaderIterator(FnSymbol* wrapFn,
 
   liFn->addFlag(FLAG_INLINE_ITERATOR);
   liFn->addFlag(FLAG_GENERIC);
+  liFn->removeFlag(FLAG_INVISIBLE_FN);
 
   liFn->insertFormalAtTail(liFnTag);
 
@@ -2372,8 +2371,6 @@ static void buildFollowerIterator(PromotionInfo& promotion,
 
   FnSymbol*  fiFn             = wrapFn->copy(&followerMap);
 
-  iteratorFollowerMap.put(wrapFn, fiFn);
-
   form_Map(SymbolMapElem, e, followerMap) {
     if (Symbol* s = paramMap.get(e->key)) {
       paramMap.put(e->value, s);
@@ -2389,6 +2386,7 @@ static void buildFollowerIterator(PromotionInfo& promotion,
   fastFollower = new ArgSymbol(INTENT_PARAM, "fast", dtBool, NULL, symFalse);
 
   fiFn->addFlag(FLAG_GENERIC);
+  fiFn->removeFlag(FLAG_INVISIBLE_FN);
 
   fiFn->insertFormalAtTail(fiFnTag);
   fiFn->insertFormalAtTail(fiFnFollower);
@@ -2479,6 +2477,13 @@ static BlockStmt* followerForLoop(PromotionInfo& promotion,
                                isCallExpr(iterator) ? true : false);
 }
 
+// The returned string is canonical ie from astr().
+const char* unwrapFnName(FnSymbol* fn) {
+  INT_ASSERT(! strncmp(fn->name, "chpl_promo", 10));
+  const char* uscore = strchr(fn->name+11, '_');
+  return astr(uscore+1);
+}
+
 static void initPromotionWrapper(PromotionInfo& promotion,
                                  BlockStmt* instantiationPoint) {
 
@@ -2486,7 +2491,9 @@ static void initPromotionWrapper(PromotionInfo& promotion,
   FnSymbol* retval = buildEmptyWrapper(fn);
   retval->setInstantiationPoint(instantiationPoint);
 
-  retval->cname = astr("_promotion_wrap_", fn->cname);
+  static int wrapId = 0;
+  retval->name = astr("chpl_promo", istr(++wrapId), "_", fn->name);
+  retval->cname = retval->name;
 
   retval->addFlag(FLAG_PROMOTION_WRAPPER);
   retval->addFlag(FLAG_FN_RETURNS_ITERATOR);
@@ -2838,83 +2845,36 @@ static FnSymbol* buildEmptyWrapper(FnSymbol* fn) {
   FnSymbol* wrapper = new FnSymbol(fn->name);
 
   wrapper->addFlag(FLAG_WRAPPER);
-
   wrapper->addFlag(FLAG_INVISIBLE_FN);
-
   wrapper->addFlag(FLAG_INLINE);
-
-  if (fn->hasFlag(FLAG_INIT_COPY_FN)) {
-    wrapper->addFlag(FLAG_INIT_COPY_FN);
-  }
-
-  if (fn->hasFlag(FLAG_AUTO_COPY_FN)) {
-    wrapper->addFlag(FLAG_AUTO_COPY_FN);
-  }
-
-  if (fn->hasFlag(FLAG_AUTO_DESTROY_FN)) {
-    wrapper->addFlag(FLAG_AUTO_DESTROY_FN);
-  }
-
-  if (fn->hasFlag(FLAG_NO_PARENS)) {
-    wrapper->addFlag(FLAG_NO_PARENS);
-  }
-
-  if (fn->hasFlag(FLAG_CONSTRUCTOR)) {
-    wrapper->addFlag(FLAG_CONSTRUCTOR);
-  }
-
-  if (fn->hasFlag(FLAG_FIELD_ACCESSOR)) {
-    wrapper->addFlag(FLAG_FIELD_ACCESSOR);
-  }
-
-  if (fn->hasFlag(FLAG_REF_TO_CONST)) {
-    wrapper->addFlag(FLAG_REF_TO_CONST);
-  }
-
-  if (!fn->isIterator()) { // getValue is var, not iterator
-    wrapper->retTag = fn->retTag;
-  }
-
-  if (fn->isMethod() == true) {
-    wrapper->setMethod(true);
-  }
-
-  if (fn->hasFlag(FLAG_METHOD_PRIMARY)) {
-    wrapper->addFlag(FLAG_METHOD_PRIMARY);
-  }
-
-  if (fn->hasFlag(FLAG_ASSIGNOP)) {
-    wrapper->addFlag(FLAG_ASSIGNOP);
-  }
-
-  if (fn->hasFlag(FLAG_DEFAULT_CONSTRUCTOR)) {
-    wrapper->addFlag(FLAG_DEFAULT_CONSTRUCTOR);
-  }
-
-  if (fn->hasFlag(FLAG_LAST_RESORT)) {
-    wrapper->addFlag(FLAG_LAST_RESORT);
-  }
-
-  if (fn->hasFlag(FLAG_COMPILER_GENERATED)) {
-    wrapper->addFlag(FLAG_WAS_COMPILER_GENERATED);
-  }
-
-  if (fn->hasFlag(FLAG_VOID_NO_RETURN_VALUE)) {
-    wrapper->addFlag(FLAG_VOID_NO_RETURN_VALUE);
-  }
-
-  if (fn->hasFlag(FLAG_FN_RETURNS_ITERATOR)) {
-    wrapper->addFlag(FLAG_FN_RETURNS_ITERATOR);
-  }
-
-  if (fn->hasFlag(FLAG_SUPPRESS_LVALUE_ERRORS)) {
-    wrapper->addFlag(FLAG_SUPPRESS_LVALUE_ERRORS);
-  }
-
   wrapper->addFlag(FLAG_COMPILER_GENERATED);
 
-  if (fn->throwsError())
-    wrapper->throwsErrorInit();
+  if (fn->hasFlag(FLAG_INIT_COPY_FN))   wrapper->addFlag(FLAG_INIT_COPY_FN);
+  if (fn->hasFlag(FLAG_AUTO_COPY_FN))   wrapper->addFlag(FLAG_AUTO_COPY_FN);
+  if (fn->hasFlag(FLAG_AUTO_DESTROY_FN))wrapper->addFlag(FLAG_AUTO_DESTROY_FN);
+  if (fn->hasFlag(FLAG_NO_PARENS))      wrapper->addFlag(FLAG_NO_PARENS);
+  if (fn->hasFlag(FLAG_CONSTRUCTOR))    wrapper->addFlag(FLAG_CONSTRUCTOR);
+  if (fn->hasFlag(FLAG_FIELD_ACCESSOR)) wrapper->addFlag(FLAG_FIELD_ACCESSOR);
+  if (fn->hasFlag(FLAG_REF_TO_CONST))   wrapper->addFlag(FLAG_REF_TO_CONST);
+  if (fn->hasFlag(FLAG_METHOD_PRIMARY)) wrapper->addFlag(FLAG_METHOD_PRIMARY);
+  if (fn->hasFlag(FLAG_ASSIGNOP))       wrapper->addFlag(FLAG_ASSIGNOP);
+  if (fn->hasFlag(FLAG_LAST_RESORT))    wrapper->addFlag(FLAG_LAST_RESORT);
+
+  if (   fn->hasFlag(FLAG_DEFAULT_CONSTRUCTOR))
+    wrapper->addFlag(FLAG_DEFAULT_CONSTRUCTOR);
+  if (   fn->hasFlag(FLAG_VOID_NO_RETURN_VALUE))
+    wrapper->addFlag(FLAG_VOID_NO_RETURN_VALUE);
+  if (   fn->hasFlag(FLAG_FN_RETURNS_ITERATOR))
+    wrapper->addFlag(FLAG_FN_RETURNS_ITERATOR);
+  if (   fn->hasFlag(FLAG_SUPPRESS_LVALUE_ERRORS))
+    wrapper->addFlag(FLAG_SUPPRESS_LVALUE_ERRORS);
+  if (   fn->hasFlag(FLAG_COMPILER_GENERATED))
+    wrapper->addFlag(FLAG_WAS_COMPILER_GENERATED); // note "was"
+
+  // getValue is var, not iterator
+  if (!fn->isIterator()) wrapper->retTag = fn->retTag;
+  if (fn->isMethod())    wrapper->setMethod(true);
+  if (fn->throwsError()) wrapper->throwsErrorInit();
 
   return wrapper;
 }

--- a/test/domains/marybeth/test_compare_range.good
+++ b/test/domains/marybeth/test_compare_range.good
@@ -1,2 +1,2 @@
 test_compare_range.chpl:14: In function 'initMatrix':
-test_compare_range.chpl:20: error: iterator or promoted expression _ir_< used in if or while condition
+test_compare_range.chpl:20: error: iterator or promoted expression _ir_chpl_promo1_< used in if or while condition

--- a/test/trivial/sungeun/bad_reduce_expr.bad
+++ b/test/trivial/sungeun/bad_reduce_expr.bad
@@ -1,1 +1,1 @@
-bad_reduce_expr.chpl:6: error: iterator or promoted expression _ir_== used in if or while condition
+bad_reduce_expr.chpl:6: error: iterator or promoted expression _ir_chpl_promo3_== used in if or while condition

--- a/test/trivial/sungeun/promoted_expr_error.bad
+++ b/test/trivial/sungeun/promoted_expr_error.bad
@@ -1,1 +1,1 @@
-promoted_expr_error.chpl:6: error: iterator or promoted expression _ir_== used in if or while condition
+promoted_expr_error.chpl:6: error: iterator or promoted expression _ir_chpl_promo2_== used in if or while condition


### PR DESCRIPTION
These two maps were used to find the leader/follower iterators for
promoted expressions. To reduce the number of code paths in the compiler,
we switch to finding the leader/follower iterators using regular
call resolution. For that: (a) make those iterators' names unambiguous
and (b) do not flag them with FLAG_INVISIBLE_FN.

While there, reformat a function for improved readability.

When searching the initializer call within a promotion wrapper for
an initializer, expect that call to be named "_new". This will not
work when promoting an (old-style) constructor call, because such
occasions will be disallowed soon.

Update .good/.bad files for the new names of the internal
iterator-record types.