### PR TITLE
Add non-buffered atomics to the many-to-one buffered amo graph

### DIFF
--- a/test/performance/comm/low-level/remote-buffAmos.ml-perf.graph
+++ b/test/performance/comm/low-level/remote-buffAmos.ml-perf.graph
@@ -1,5 +1,5 @@
-perfkeys: Performance (mOps/sec) =
-files: many-to-one-buffAmos.dat
-graphkeys: Buffered AMOs to 1 node
+perfkeys: Performance (mOps/sec) =, Performance (mOps/sec) =
+files: many-to-one-amos.dat, many-to-one-buffAmos.dat
+graphkeys: AMOs to 1 node, Buffered AMOs to 1 node
 graphtitle: Remote Buffered AMO Performance
 ylabel: Performance (10**6 ops/sec)


### PR DESCRIPTION
Show the non-buffered and buffered performance on the same graph so it's easier
to compare. This is already being done for bale-histo and buffered ra-atomics.