### PR TITLE
Fix _defaultOf for types with partially-generic fields

### DIFF
--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -1556,6 +1556,13 @@ static void buildInitializerCall(AggregateType* ct,
   bool named = ct->wantsDefaultInitializer();
 
   for_fields(field, ct) {
+    bool isGenericField = false;
+    if (field->type->symbol->hasFlag(FLAG_GENERIC)) {
+      isGenericField = true;
+    } else if (AggregateType* at = toAggregateType(field->type)) {
+      isGenericField = at->isGeneric();
+    }
+
     if (field->isParameter() == true) {
       Flag         flag = FLAG_PARAM;
       PrimitiveTag tag  = PRIM_QUERY_PARAM_FIELD;
@@ -1568,8 +1575,9 @@ static void buildInitializerCall(AggregateType* ct,
 
       buildRecordQuery(fn, arg, call, field, flag, tag, named);
 
-    } else if (field->defPoint->exprType == NULL &&
-               field->defPoint->init     == NULL) {
+    } else if ((field->defPoint->exprType == NULL &&
+               field->defPoint->init     == NULL) ||
+               isGenericField) {
 
       // Can only use a NamedExpr if using a default initializer. Otherwise the
       // user can use an arbitrary identifier.

--- a/test/classes/delete-free/tests-from-design-overview/generic-collection-owned.future
+++ b/test/classes/delete-free/tests-from-design-overview/generic-collection-owned.future
@@ -1,2 +1,0 @@
-bug: record with generic field default-of problem
-#9568

--- a/test/classes/ferguson/generic-field/generic-field-integral-not-inited-record.future
+++ b/test/classes/ferguson/generic-field/generic-field-integral-not-inited-record.future
@@ -1,2 +1,0 @@
-bug: record with generic field default-of problem
-#9568

--- a/test/classes/ferguson/generic-field/generic-field-record-not-inited.future
+++ b/test/classes/ferguson/generic-field/generic-field-record-not-inited.future
@@ -1,2 +1,0 @@
-bug: record with generic field default-of problem
-#9568

--- a/test/classes/ferguson/generic-field/generic-field-record-not-inited2.bad
+++ b/test/classes/ferguson/generic-field/generic-field-record-not-inited2.bad
@@ -1,1 +1,0 @@
-Wrapper(GenericRecord(int(64))) (f = (field = (field = 0)))

--- a/test/classes/ferguson/generic-field/generic-field-record-not-inited2.future
+++ b/test/classes/ferguson/generic-field/generic-field-record-not-inited2.future
@@ -1,2 +1,0 @@
-bug: writing record with generic field outputs extra field=
-#9568

--- a/test/classes/ferguson/generic-field/generic-field-record-not-inited2.good
+++ b/test/classes/ferguson/generic-field/generic-field-record-not-inited2.good
@@ -1,1 +1,1 @@
-Wrapper(GenericRecord(int(64))) (f = (field = 0))
+Wrapper(GenericRecord(int(64))) (f = (field = (field = 0)))

--- a/test/classes/ferguson/generic-field/generic-field-record-not-inited3.chpl
+++ b/test/classes/ferguson/generic-field/generic-field-record-not-inited3.chpl
@@ -4,9 +4,8 @@ record GenericRecord {
 
 record Wrapper {
   var f:GenericRecord;
-  proc init(type recType) {
-    var tmp:recType;
-    this.f = tmp;
+  proc init(f : GenericRecord) {
+    this.f = f;
   }
 }
 

--- a/test/classes/ferguson/generic-field/generic-field-record-not-inited3.future
+++ b/test/classes/ferguson/generic-field/generic-field-record-not-inited3.future
@@ -1,2 +1,0 @@
-bug: record with generic field default-of problem
-#9568


### PR DESCRIPTION
Our _defaultOf generation was incorrectly handling fields with partially-generic type-expressions, like:

```chpl
record R {
   var x : owned;
}
```

The solution is to treat such fields as if they were fully-generic and create a temporary formal based on the field's type from the fully-instantiated type:

```chpl
var x : R(owned SomeClass);
// In _defaultOf becomes...
var temp : owned SomeClass;
x.init(temp);
```

Three futures are resolved by this change, and a couple of futures with incorrect expectations are fixed to indicate they were working as intended.

Testing:
- [x] local + futures