### PR TITLE
build_configs: minor corrections/improvements to setenv-3 (PR #10663

### DIFF
--- a/util/build_configs/build_configs.py
+++ b/util/build_configs/build_configs.py
@@ -92,6 +92,7 @@ known_dimensions = [
     ( 'unwind',             'CHPL_UNWIND', ),
     ( 'mem',                'CHPL_MEM', ),
     ( 'atomics',            'CHPL_ATOMICS', ),
+    ( 'gmp',                'CHPL_GMP', ),
     ( 'hwloc',              'CHPL_HWLOC', ),
     ( 'regexp',             'CHPL_REGEXP', ),
     ( 'llvm',               'CHPL_LLVM', ),

--- a/util/build_configs/build_configs.py
+++ b/util/build_configs/build_configs.py
@@ -259,7 +259,7 @@ def get_chpl_misc(opts, args, build_env):
         sys.exit(2)
 
     # run "printchplenv" without any commandline config options or setenv, check for errors
-    chplenv_cmd = chplenv_exe + ' --simple --all --no-tidy'
+    chplenv_cmd = chplenv_exe + ' --all --no-tidy --anonymize'
     result, output, error = check_output(chplenv_cmd, chpl_home, build_env)
     if result:
         logging.error('From {0}\n{1}\n{2}\nexit code {3}'.format(chplenv_cmd, error, output, result))

--- a/util/build_configs/setenv-example-2.bash
+++ b/util/build_configs/setenv-example-2.bash
@@ -64,7 +64,7 @@ if [ -z "$BUILD_CONFIGS_CALLBACK" ]; then
     # Show the initial/default Chapel build config with printchplenv
 
     log_info "Chapel printchplenv, with initial env:"
-    $CHPL_HOME/util/printchplenv --all --no-tidy || echo >&2 ignore error
+    $CHPL_HOME/util/printchplenv --all --no-tidy --anonymize || echo >&2 ignore error
 
     # Use build_configs.py to make Chapel compiler
 

--- a/util/build_configs/setenv-example-3.bash
+++ b/util/build_configs/setenv-example-3.bash
@@ -172,7 +172,7 @@ else
     fi
 
     gen_version_gcc=6.1.0
-    gen_version_intel=18.0.3.222
+ ## gen_version_intel=18.0.3.222    # For portability, this example just accepts the default version.
     target_cpu_module=craype-sandybridge
 
     function load_prgenv_gnu() {
@@ -193,14 +193,14 @@ else
 
         local target_prgenv="PrgEnv-intel"
         local target_compiler="intel"
-        local target_version=$gen_version_intel
+     ## local target_version=$gen_version_intel     # Just accept the default version
 
         # unload any existing PrgEnv
         unload_module_re PrgEnv-
 
         # load target PrgEnv with compiler version
         load_module $target_prgenv
-        load_module_version $target_compiler $target_version
+     ## load_module_version $target_compiler $target_version
     }
 
     function load_target_cpu() {

--- a/util/build_configs/setenv-example-3.bash
+++ b/util/build_configs/setenv-example-3.bash
@@ -70,7 +70,7 @@ if [ -z "$BUILD_CONFIGS_CALLBACK" ]; then
 
     if [ -n "$verbose" ]; then
         log_debug "Chapel printchplenv, with initial env:"
-        $CHPL_HOME/util/printchplenv --all --no-tidy || echo >&2 ignore error
+        $CHPL_HOME/util/printchplenv --all --no-tidy --anonymize || echo >&2 ignore error
     fi
 
     # NOTE: The --target-compiler values used in this setenv project will never be


### PR DESCRIPTION
These low-impact changes are in response to feedback/experience with external setenv-example-3 user, and should be promoted asap. 

All commits were previously developed (and tested) with PR #10837, and are now moved into this separate PR for transparency:
* For portability, setenv-examples-3 should just accept the default intel version
* build_configs: add CHPL_GMP to build_configs.py dimensions
* build_configs: all printchplenv's should use --anonymize    
  And otherwise use the same options throughout build_configs, for consistency.
