### PR TITLE
Fix Cray lustre builds

### DIFF
--- a/util/config/gather-pe-chapel-pkgconfig-libs.bash
+++ b/util/config/gather-pe-chapel-pkgconfig-libs.bash
@@ -30,7 +30,7 @@ fi
 # on login/compute nodes, lustre requires the devel api to make
 # lustre/lustreapi.h available (it's implicitly available on esl nodes)
 if [[ "$chpl_auxfs" == *lustre* ]]; then
-  if pkg-config --libs cray-lustre-api-devel 2>/dev/null; then
+  if pkg-config --exists cray-lustre-api-devel; then
     pe_chapel_pkgconfig_libs="cray-lustre-api-devel:$pe_chapel_pkgconfig_libs"
   fi
 fi


### PR DESCRIPTION
Correct a translation mistake from #10902. To check if the lustre-devel API is
available we used to do `pkg-config --libs cray-lustre-api-devel &>/dev/null`.
#10902 transitioned that to `2>/dev/null`, which meant the lib output was
actually getting printed out too.

Would could have gone back to redirecting all output to `/dev/null`, but
instead just switch to using `pkg-config --exists` since that's a little
cleaner anyways.