### PR TITLE
Fix chpl_topo_getThreadLocality() for hwloc

### DIFF
--- a/runtime/src/topo/hwloc/topo-hwloc.c
+++ b/runtime/src/topo/hwloc/topo-hwloc.c
@@ -345,7 +345,7 @@ c_sublocid_t chpl_topo_getThreadLocality(void) {
   CHK_ERR_ERRNO((nodeset = hwloc_bitmap_alloc()) != NULL);
 
   flags = HWLOC_CPUBIND_THREAD;
-  CHK_ERR_ERRNO(hwloc_set_cpubind(topology, cpuset, flags) == 0);
+  CHK_ERR_ERRNO(hwloc_get_cpubind(topology, cpuset, flags) == 0);
 
   hwloc_cpuset_to_nodeset(topology, cpuset, nodeset);
 


### PR DESCRIPTION
Previously, it was using `hwloc_set_cpubind`, when it should have been using
`hwloc_get_cpubind`

Noticed while investigating https://github.com/chapel-lang/chapel/issues/10856