### PR TITLE
Fix typos

### DIFF
--- a/compiler/resolution/implementForallIntents.cpp
+++ b/compiler/resolution/implementForallIntents.cpp
@@ -2306,7 +2306,7 @@ static void handleReduce(ForallStmt* fs, ShadowVarSymbol* AS) {
   AS->qual = QUAL_REF;
   AS->type = dtUnknown;
 
-  // PRP, PAS, RP preceed AS in fs->shadowVariables() in this order.
+  // PRP, PAS, RP precede AS in fs->shadowVariables() in this order.
   ShadowVarSymbol* PRP = create_REDUCE_PRP(fs, AS);
   ShadowVarSymbol* PAS = create_REDUCE_PAS(fs, AS);
   ShadowVarSymbol* RP  = create_REDUCE_RP(fs, PRP, AS);

--- a/compiler/resolution/lowerForalls.cpp
+++ b/compiler/resolution/lowerForalls.cpp
@@ -669,7 +669,7 @@ static void expandShadowVarTaskFn(FnSymbol* cloneTaskFn, CallExpr* callToTFn,
          PRP+PAS svars --> the PRP+PAS formals
          RP+AS svars --> the curr RP+AS vars
 
-      [Curently there is no PAS/AS formal/actual. They are upcoming.]
+      [Currently there is no PAS/AS formal/actual. They are upcoming.]
       */
 
       addArgAndMap(cloneTaskFn, callToTFn, numOrigAct, iMap,

--- a/doc/rst/tools/mason/mason.rst
+++ b/doc/rst/tools/mason/mason.rst
@@ -457,7 +457,7 @@ and build and run ``hdf5Example.chpl``.
 When constructing the lock file (see below section), Mason will work with Spack to gather dependencies.
 In the case of ``HDF5``, at the time of this writing, ``zlib`` will be added to the lock file since the
 ``HDF5`` Spack package depends on it. Any dependency a Spack package has will be handled in this manner.
-This highlights another great feature of the integartion. Mason can install and retrieve all dependencies
+This highlights another great feature of the integration. Mason can install and retrieve all dependencies
 necessary for any package from Spack without ever interfering with a previous package installation.
 
 Using System Packages


### PR DESCRIPTION
Fix typos in mason.rst, implementForallIntents.cpp, and lowerForalls.cpp.