### PR TITLE
Stop make(1) explicitly when the compileline utility fails.

### DIFF
--- a/third-party/qthread/Makefile
+++ b/third-party/qthread/Makefile
@@ -52,13 +52,20 @@ ifeq ($(CFLAGS_NEEDS_RT_INCLUDES), y)
   # do not want -DNDEBUG; if we have that set when building Qthreads it
   # seems to cause Chapel programs built with the result to hang during
   # exit when shutting down Qthreads.
-  CFLAGS += \
+  INCS_DEFS := \
     $(shell $(CHPL_MAKE_HOME)/util/config/compileline --includes-and-defines \
+            || echo compilelineFAILURE)
+  ifneq (, $(findstring compilelineFAILURE,$(INCS_DEFS)))
+    $(error compileline failed!)
+  endif
+  INCS_DEFS_PROCESSED := \
+    $(shell echo $(INCS_DEFS) \
             | tr ' ' '\n' \
             | grep '^-DCHPL\|/runtime//*include\|/third-party/.*/install' \
             | grep -v '/third-party/qthread/install' \
             | tr '\n' ' ' \
             | sed 's/ $$//')
+  CFLAGS += $(INCS_DEFS_PROCESSED)
 endif
 
 # enable oversubscription for testing


### PR DESCRIPTION
The Qthreads build needs some of the runtime build -I and -D options,
which we get with the compileline utility.  But that can fail to run
correctly; the most common reason has been that one of the things it
needs to reference hasn't been built yet.  Such a failure doesn't halt
the make since compileline is run in a make 'shell' function invocation
to set a make variable, not in a target build command.  The make will
eventually fail, due to an error compiling some Qthreads source file
because the -I or -D options it needs aren't there.  But the root cause
is buried much earlier in the log, where the compileline invocation
failed, and the connection between the two isn't at all obvious.

We've solved the instances of this we've seen, by adding prerequisites
reflecting compileline's dependencies, but we may not have seen all of
them and certainly new dependencies lacking corresponding prerequisites
could be created in the future.  So here, force the make to halt right
away when the compileline invocation fails.

This resolves #10542.