### PR TITLE
Fix mason modify leak

### DIFF
--- a/test/mason/add-remove-tests/masonModifyTest.chpl
+++ b/test/mason/add-remove-tests/masonModifyTest.chpl
@@ -17,4 +17,5 @@ proc main() {
   const result = modifyToml(add, "test@1.2.3", external, system, projectHome, tf=tf);
   writeln(result[1]);
 
+  delete result(1);
 }

--- a/tools/mason/MasonModify.chpl
+++ b/tools/mason/MasonModify.chpl
@@ -160,7 +160,9 @@ private proc masonAdd(toml: unmanaged Toml, toAdd: string, version: string) thro
 private proc masonRemove(toml: unmanaged Toml, toRm: string) throws {
   if toml.pathExists("dependencies") {
     if toml.pathExists("dependencies." + toRm) {
+      var old = toml["dependencies"][toRm];
       toml["dependencies"].D.remove(toRm);
+      delete old;
     }
     else {
       throw new MasonError("No dependency exists by that name");
@@ -196,7 +198,9 @@ private proc masonSystemAdd(toml: unmanaged Toml, toAdd: string, version: string
 private proc masonSystemRemove(toml: unmanaged Toml, toRm: string) throws {
   if toml.pathExists("system") {
     if toml.pathExists("system." + toRm) {
+      var old = toml["system"][toRm];
       toml["system"].D.remove(toRm);
+      delete old;
     }
     else {
       throw new MasonError("No system dependency exists by " + toRm);
@@ -231,7 +235,9 @@ private proc masonExternalAdd(toml: unmanaged Toml, toAdd: string, spec: string)
 private proc masonExternalRemove(toml: unmanaged Toml, toRm: string) throws {
   if toml.pathExists("external") {
     if toml.pathExists("external." + toRm) {
+      var old = toml["external"][toRm];
       toml["external"].D.remove(toRm);
+      delete old;
     }
     else {
       throw new MasonError("No external dependency exists by that name");


### PR DESCRIPTION
This PR updates MasonModify and its test to delete TOML classes manually.

Resolves #10882 

Testing:
- [x] memleaks (only 'string copy data' left)