### PR TITLE
Don't assume the _real_real is where the _wrap_real is.

### DIFF
--- a/test/runtime/configMatters/comm/ugni/hugepage-sanity.wrap_real
+++ b/test/runtime/configMatters/comm/ugni/hugepage-sanity.wrap_real
@@ -7,4 +7,4 @@ case $(echo $1 | sed "s/^.*=\([0-9]\)/\1/") in
 3) unset CHPL_JE_MALLOC_CONF;;
 esac
 
-exec ${0}_real $*
+exec ./$(basename ${0})_real $*


### PR DESCRIPTION
The _real wrapper was assuming that it could find the _real_real in the
same directory the _wrap_real itself was in.  That's not true when the
executable run by the launch/placement utility is a temporary copy
transmitted to the compute node via the job's control network, rather
than the original accessed from a network-mounted filesystem.  (PBS does
this on Cray X*, for speed at scale.)  We are guaranteed that the CWD is
the dir that contains the test, though, so since speed at scale surely
doesn't matter here, just get the _real_real from the CWD.