### PR TITLE
Add a cron script for running the tests of built python modules

### DIFF
--- a/util/cron/test-python-modules.bash
+++ b/util/cron/test-python-modules.bash
@@ -1,0 +1,13 @@
+#!/bin/bash
+#
+# Test generated Python modules
+
+CWD=$(cd $(dirname $0) ; pwd)
+source $CWD/common.bash
+
+export CHPL_LIBMODE=shared
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="python-modules"
+export CHPL_NIGHTLY_TEST_DIRS="compflags/lydia/library/python compflags/lydia/library/noLibFlag"
+
+$CWD/nightly -cron


### PR DESCRIPTION
Sets the environment variable CHPL_LIBMODE to shared and runs the specific
tests for this feature.

I double checked that this worked on the machine I was pointed to

Resolves #10441 

Note: Don't merge until after #10924 has been merged