### PR TITLE
Fix how we determine the size of qthread_runtime_data_s

### DIFF
--- a/doc/rst/usingchapel/executing.rst
+++ b/doc/rst/usingchapel/executing.rst
@@ -290,9 +290,9 @@ automatically when the program or task starts executing, and remains in
 existence until it completes.  The default call stack size is ~8 MiB on
 Linux-based systems, since this is a common value for the process stack
 limit on such systems.  On Cygwin systems the default call stack size is
-~2 MiB. Note that up to 3 system pages of each stack may be reserved for
-use by the tasking layer. 1 page for runtime data structures and up to 2
-additional pages if guard pages (--stack-checks) are enabled.
+~2 MiB. Note that up to 4 system pages of each stack may be reserved for
+use by the tasking layer. Up to 2 pages for runtime data structures and
+up to 2 additional pages if guard pages (--stack-checks) are enabled.
 
 The default call stack size may not be appropriate in all cases.  For
 programs in which some tasks have large stack frames or deep call trees

--- a/third-party/qthread/README
+++ b/third-party/qthread/README
@@ -35,3 +35,5 @@ as follows:
   functional and performance benefits.
 * Added missing `no` affinity shim (src/affinity/no.c) that was omitted
   from the official qthreads release. Only used when CHPL_HWLOC=none
+* Provide a way to determine the size of the runtime data structure for
+  each qthread for the purpose of selecting a better stack size.

--- a/third-party/qthread/README
+++ b/third-party/qthread/README
@@ -37,3 +37,5 @@ as follows:
   from the official qthreads release. Only used when CHPL_HWLOC=none
 * Provide a way to determine the size of the runtime data structure for
   each qthread for the purpose of selecting a better stack size.
+* Fix a bug in the memory pool limiting code to ensure that each pool
+  is large enough for at least 2 items.

--- a/third-party/qthread/qthread-src/include/qthread/qthread.h
+++ b/third-party/qthread/qthread-src/include/qthread/qthread.h
@@ -367,6 +367,7 @@ qthread_worker_id_t   qthread_num_workers_local(qthread_shepherd_id_t shepherd_i
 /* queries the current state */
 enum introspective_state {
     STACK_SIZE,
+    RUNTIME_DATA_SIZE,
     BUSYNESS,
     NODE_BUSYNESS,
     ACTIVE_SHEPHERDS,

--- a/third-party/qthread/qthread-src/man/man3/qthread_readstate.3
+++ b/third-party/qthread/qthread-src/man/man3/qthread_readstate.3
@@ -20,6 +20,10 @@ STACK_SIZE
 This causes the function to return the size stack, measured in bytes, that all
 spawned qthreads receive.
 .TP
+RUNTIME_DATA_SIZE
+This causes the function to return the size of the runtime data structure that
+all spawned qthreads require.
+.TP
 BUSYNESS
 This causes the function to return the approximate number of threads available
 in the run queue of the current shepherd.

--- a/third-party/qthread/qthread-src/src/mpool.c
+++ b/third-party/qthread/qthread-src/src/mpool.c
@@ -180,6 +180,9 @@ qt_mpool INTERNAL qt_mpool_create_aligned(size_t item_size,
       /* adjust item_size to be a multiple of pagesize */
       item_size += pagesize - (item_size % pagesize);
       max_num_items = max_alloc_size / item_size; /* floor */
+      if (max_num_items < 2) {
+          max_num_items = 2;
+      }
       alloc_size = item_size * max_num_items;
     }
 

--- a/third-party/qthread/qthread-src/src/qthread.c
+++ b/third-party/qthread/qthread-src/src/qthread.c
@@ -1926,6 +1926,9 @@ size_t API_FUNC qthread_readstate(const enum introspective_state type)
         case STACK_SIZE:
             return qlib->qthread_stack_size;
 
+        case RUNTIME_DATA_SIZE:
+            return sizeof(struct qthread_runtime_data_s);
+
         case BUSYNESS:
         {
             qthread_shepherd_t *shep = qthread_internal_getshep();


### PR DESCRIPTION
Previously, we just hardcoded the size to be less than 1 page, but it turns out
that it's actually larger than that on systems without a native swapcontext
(such as ARM.)

Instead of assuming data structure less than a page, add a mechanism to
determine the real size from qthreads and use that to compute how many pages to
reserve.