### PR TITLE
Add a compiler error for using '.type' on something that is already a type

### DIFF
--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -923,9 +923,13 @@ static Expr* preFoldPrimOp(CallExpr* call) {
     call->replace(retval);
 
   } else if (call->isPrimitive(PRIM_TYPEOF)) {
-    Type* type = call->get(1)->getValType();
+    SymExpr* se = toSymExpr(call->get(1));
+    Type* type = se->getValType();
 
-    if (type->symbol->hasFlag(FLAG_HAS_RUNTIME_TYPE)) {
+    if (se->symbol()->hasFlag(FLAG_TYPE_VARIABLE)) {
+      USR_FATAL_CONT(call, "can't apply '.type' to a type (%s)",
+                     toString(se->typeInfo()));
+    } else if (type->symbol->hasFlag(FLAG_HAS_RUNTIME_TYPE)) {
       retval = new CallExpr("chpl__convertValueToRuntimeType",
                             call->get(1)->remove());
 

--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -977,7 +977,7 @@ module ChapelDistribution {
       on e {
         var eCast = e:arrType;
         if eCast == nil then
-          halt("internal error: ", t.type:string,
+          halt("internal error: ", t:string,
                " contains an bad array type ", arrType:string);
 
         var inds = rhs.getIndices();

--- a/test/arrays/ferguson/runtime-type-type.future
+++ b/test/arrays/ferguson/runtime-type-type.future
@@ -1,2 +1,0 @@
-bug: redundant .type for array type fails
-#9715

--- a/test/arrays/ferguson/runtime-type-type.good
+++ b/test/arrays/ferguson/runtime-type-type.good
@@ -1,0 +1,2 @@
+runtime-type-type.chpl:3: In function 'tf':
+runtime-type-type.chpl:4: error: can't apply '.type' to a type ([domain(1,int(64),false)] int(64))

--- a/test/classes/deitz/class-constructor/constructor_disambiguity.chpl
+++ b/test/classes/deitz/class-constructor/constructor_disambiguity.chpl
@@ -4,7 +4,7 @@ class C {
 }
 
 var c = (new unmanaged C(
-           t=(unmanaged C(int)).type,
+           t=(unmanaged C(int)),
            x=new unmanaged C(int)));
 writeln(c);
 delete c.x;

--- a/test/classes/ferguson/generic-type-method-simple3.chpl
+++ b/test/classes/ferguson/generic-type-method-simple3.chpl
@@ -1,7 +1,7 @@
 record MyRecord {
   type myType;
 
-  proc type getType() type return this.type.myType;
+  proc type getType() type return this.myType;
 }
 
 writeln(MyRecord(int).getType():string);

--- a/test/expressions/diten/returntypedottype.chpl
+++ b/test/expressions/diten/returntypedottype.chpl
@@ -1,0 +1,6 @@
+proc f() type {
+  return complex;
+}
+
+writeln(f().type:string);
+writeln(int.type:string);

--- a/test/expressions/diten/returntypedottype.good
+++ b/test/expressions/diten/returntypedottype.good
@@ -1,0 +1,2 @@
+returntypedottype.chpl:5: error: can't apply '.type' to a type (complex(128))
+returntypedottype.chpl:6: error: can't apply '.type' to a type (int(64))

--- a/test/expressions/diten/typedottype.chpl
+++ b/test/expressions/diten/typedottype.chpl
@@ -1,0 +1,2 @@
+writeln(int.type:string);
+writeln(3.14.type.type:string);

--- a/test/expressions/diten/typedottype.good
+++ b/test/expressions/diten/typedottype.good
@@ -1,0 +1,2 @@
+typedottype.chpl:1: error: can't apply '.type' to a type (int(64))
+typedottype.chpl:2: error: can't apply '.type' to a type (real(64))

--- a/test/library/standard/Reflection/fielderator-generic.chpl
+++ b/test/library/standard/Reflection/fielderator-generic.chpl
@@ -3,7 +3,8 @@ use Reflection;
 proc parse(ref data: ?t) {
   param numfield = numFields(t);
   for param i in 1..numfield {
-    type vtype = getField(data, i).type;
+    type vtype = if isType(getField(data, i)) then getField(data, i)
+                                              else getField(data, i).type;
     writeln(getFieldName(t, i));
     if isRecordType(vtype) || isClassType(vtype) {
       parse(getFieldRef(data, i));

--- a/test/trivial/waynew/maxtest.chpl
+++ b/test/trivial/waynew/maxtest.chpl
@@ -8,7 +8,7 @@ writeln( max( i8.type));
 writeln( max( i16.type));
 writeln( max( i32.type));
 writeln( max( i64.type));
-writeln( max( int(64).type));
+writeln( max( int(64)));
 
 var ui8:uint(8);
 var ui16:uint(16);
@@ -18,13 +18,13 @@ writeln( max( ui8.type));
 writeln( max( ui16.type));
 writeln( max( ui32.type));
 writeln( max( ui64.type));
-writeln( max( uint(64).type));
+writeln( max( uint(64)));
 
 var f32:real(32);
 var f64:real;
 writeln( max( f32.type));
 writeln( max( f64.type));
-writeln( max( real.type));
+writeln( max( real));
 
 var c1:complex(64);
 var c2:complex(128);


### PR DESCRIPTION
Applying the .type operation to something that is already a type now results
in a compiler error instead of getting ignored in most cases.  This is handled
during preFold for PRIM_TYPEOF.  It needs to be handled during resolution so
that it can apply to uses of '.type' on function calls that return types.

Updated one spot in the modules where .type was used on a type.

Updated test/arrays/ferguson/runtime-type-type.good to expect the error
message instead of silently ignoring the .type operation. Removed the .future
because it now generates a nice error instead of an unresolved call error
about an internal function.

Added a test that tries to use '.type' on some simple types, and another that
uses '.type' on a function call that returns a type.

Update a few tests that used .type on types.