### PR TITLE
Don't sanity check CHPL_JE_MALLOC_CONF with a fixed heap.

### DIFF
--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -1910,6 +1910,7 @@ void chpl_comm_post_task_init(void)
     }
 
     if (strcmp(CHPL_MEM, "jemalloc") == 0
+        && chpl_comm_getenvMaxHeapSize() == 0
         && getenv(chpl_comm_ugni_jemalloc_conf_ev_name()) == NULL) {
       if (chpl_nodeID == 0) {
         char buf[100];


### PR DESCRIPTION
The launcher doesn't set the MALLOC_CONF environment variable when we
have a fixed heap, because we don't need it in that case.  Therefore,
don't sanity-check it in that case either.