### PR TITLE
Make performance tests make better use of managed classes

### DIFF
--- a/test/arrays/diten/arrayPerformance.chpl
+++ b/test/arrays/diten/arrayPerformance.chpl
@@ -32,7 +32,7 @@ proc main {
 
 proc initialize(B) {
   use Random;
-  var rnd = new owned RandomStream(eltType=real, seed=randSeed);
+  var rnd = new RandomStream(eltType=real, seed=randSeed);
   rnd.fillRandom(B);
 }
 

--- a/test/exercises/c-ray/c-ray.chpl
+++ b/test/exercises/c-ray/c-ray.chpl
@@ -108,7 +108,7 @@ record camera {
 //
 // variables used to store the scene
 //
-var objects: [1..0] unmanaged sphere,  // the scene's spheres; start with an empty array
+var objects: [1..0] owned sphere,  // the scene's spheres; start with an empty array
     lights: [1..0] vec3,     // the scene's lights;  "
     cam: camera;             // camera (there will be only one)
 
@@ -163,9 +163,6 @@ proc main() {
                   rendTime, rendTime*1000);
 
   writeImage(image, imgType, pixels);
-
-  for obj in objects do
-    delete obj;
 }
 
 //
@@ -232,7 +229,7 @@ proc trace(ray, depth=0): vec3 {
     return (0.0, 0.0, 0.0);
 
   // find the nearest intersection...
-  var nearestObj: unmanaged sphere,
+  var nearestObj: borrowed sphere,
       nearestSp: spoint;
 
   for obj in objects {
@@ -411,13 +408,13 @@ proc loadScene() {
   // be problematic in any way.
   //
   if scene == "built-in" {
-    objects.push_back(new unmanaged sphere((-1.5, -0.3, -1), 0.7,
+    objects.push_back(new owned sphere((-1.5, -0.3, -1), 0.7,
                                  new material((1.0, 0.2, 0.05), 50.0, 0.3)));
-    objects.push_back(new unmanaged sphere((1.5, -0.4, 0), 0.6,
+    objects.push_back(new owned sphere((1.5, -0.4, 0), 0.6,
                                  new material((0.1, 0.85, 1.0), 50.0, 0.4)));
-    objects.push_back(new unmanaged sphere((0, -1000, 2), 999,
+    objects.push_back(new owned sphere((0, -1000, 2), 999,
                                  new material((0.1, 0.2, 0.6), 80.0, 0.8)));
-    objects.push_back(new unmanaged sphere((0, 0, 2), 1,
+    objects.push_back(new owned sphere((0, 0, 2), 1,
                                  new material((1.0, 0.5, 0.1), 60.0, 0.7)));
     lights.push_back((-50, 100, -50));
     lights.push_back((40, 40, 150));
@@ -484,7 +481,7 @@ proc loadScene() {
           refl = columns[10]: real;
 
     // this must be a sphere, so store it
-    objects.push_back(new unmanaged sphere(pos, rad, new material(col, spow, refl)));
+    objects.push_back(new owned sphere(pos, rad, new material(col, spow, refl)));
 
     // helper routine for printing errors in the input file
     proc inputError(msg) {
@@ -517,7 +514,7 @@ proc initRands() {
   } else {
     use Random;
 
-    var rng = new unmanaged RandomStream(seed=(if seed then seed
+    var rng = new RandomStream(seed=(if seed then seed
                                              else SeedGenerator.currentTime),
                                eltType=real);
     for u in urand do
@@ -526,8 +523,6 @@ proc initRands() {
       u(Y) = rng.getNext() - 0.5;
     for r in irand do
       r = (nran * rng.getNext()): int;
-
-    delete rng;
   }
 }
 

--- a/test/npb/cg/bradc/cg-makea.chpl
+++ b/test/npb/cg/bradc/cg-makea.chpl
@@ -11,7 +11,7 @@ module CGMakeA {
     var size = 1.0;
     const ratio = rcond ** (1.0 / n);
 
-    var randStr = new unmanaged NPBRandomStream(eltType=real, seed=314159265);
+    var randStr = new NPBRandomStream(eltType=real, seed=314159265);
     randStr.getNext();   // drop a value on floor to match NPB version
 
     for iouter in 1..n {
@@ -35,8 +35,6 @@ module CGMakeA {
       size *= ratio;
     }
 
-    delete randStr;
-    
     for i in 1..n {
       yield ((i, i), rcond - shift);
     }

--- a/test/npb/ep/mcahir/ep.chpl
+++ b/test/npb/ep/mcahir/ep.chpl
@@ -85,7 +85,7 @@ proc gaussPairsBatch(k: int(64), numPairs: int) {
 	
 	var startTime, randTime, gaussTime: real;
 
-	var rs = new borrowed NPBRandomStream(real, seed=seed, parSafe=false);
+	var rs = new NPBRandomStream(real, seed=seed, parSafe=false);
 	//Find starting seed for this batch
 	rs.skipToNth(k * 2*nk + 1);
 

--- a/test/performance/compiler/bradc/cg-makea.chpl
+++ b/test/performance/compiler/bradc/cg-makea.chpl
@@ -11,7 +11,7 @@ module CGMakeA {
     var size = 1.0;
     const ratio = rcond ** (1.0 / n);
 
-    var randStr = new owned NPBRandomStream(eltType=real, seed=314159265);
+    var randStr = new NPBRandomStream(eltType=real, seed=314159265);
     randStr.getNext();   // drop a value on floor to match NPB version
 
     for iouter in 1..n {

--- a/test/release/examples/benchmarks/hpcc/ptrans.chpl
+++ b/test/release/examples/benchmarks/hpcc/ptrans.chpl
@@ -62,10 +62,10 @@ proc main() {
   // Create Block-Cyclic distributions for both the Matrix and its
   // transpose:
   //
-  const MatrixDist = new unmanaged BlockCyclic(startIdx=(1,1),
+  const MatrixDist = new BlockCyclic(startIdx=(1,1),
                                      blocksize=(rowBlkSize, colBlkSize));
 
-  const TransposeDist = new unmanaged BlockCyclic(startIdx=(1,1),
+  const TransposeDist = new BlockCyclic(startIdx=(1,1),
                                         blocksize=(colBlkSize, rowBlkSize));
 
   //

--- a/test/release/examples/benchmarks/hpcc/stream-ep.chpl
+++ b/test/release/examples/benchmarks/hpcc/stream-ep.chpl
@@ -153,7 +153,7 @@ proc printConfiguration() {
 // Initialize vectors B and C using a random stream of values
 //
 proc initVectors(B, C) {
-  var randlist = new owned RandomStream(eltType=real, seed=seed);
+  var randlist = new RandomStream(eltType=real, seed=seed);
 
   randlist.fillRandom(B);
   randlist.fillRandom(C);

--- a/test/release/examples/benchmarks/hpcc/stream.chpl
+++ b/test/release/examples/benchmarks/hpcc/stream.chpl
@@ -105,7 +105,7 @@ proc printConfiguration() {
 // optionally print them to the console
 //
 proc initVectors(B, C) {
-  var randlist = new owned NPBRandomStream(eltType=real, seed=seed);
+  var randlist = new NPBRandomStream(eltType=real, seed=seed);
 
   randlist.fillRandom(B);
   randlist.fillRandom(C);

--- a/test/release/examples/benchmarks/hpcc/variants/stream-promoted.chpl
+++ b/test/release/examples/benchmarks/hpcc/variants/stream-promoted.chpl
@@ -103,7 +103,7 @@ proc printConfiguration() {
 // optionally print them to the console
 //
 proc initVectors(B, C) {
-  var randlist = new owned NPBRandomStream(eltType=real, seed=seed);
+  var randlist = new NPBRandomStream(eltType=real, seed=seed);
 
   randlist.fillRandom(B);
   randlist.fillRandom(C);

--- a/test/release/examples/benchmarks/shootout/binarytrees.chpl
+++ b/test/release/examples/benchmarks/shootout/binarytrees.chpl
@@ -20,14 +20,15 @@ proc main() {
   //
   // Create the "stretch" tree, checksum it, print its stats, and free it.
   //
-  const strTree = new unmanaged Tree(strDepth);
-  writeln("stretch tree of depth ", strDepth, "\t check: ", strTree.sum());
-  delete strTree;
+  {
+    const strTree = new Tree(strDepth);
+    writeln("stretch tree of depth ", strDepth, "\t check: ", strTree.sum());
+  }
 
   //
   // Build the long-lived tree.
   //
-  const llTree = new unmanaged Tree(maxDepth);
+  const llTree = new Tree(maxDepth);
 
   //
   // Iterate over the depths in parallel, dynamically assigning them
@@ -39,9 +40,8 @@ proc main() {
     var sum = 0;
 
     for i in 1..iterations {
-      const t = new unmanaged Tree(depth);
+      const t = new Tree(depth);
       sum += t.sum();
-      delete t;
     }
     stats[depth] = (iterations, sum);
   }
@@ -57,7 +57,6 @@ proc main() {
   // Checksum the long-lived tree, print its stats, and free it.
   //
   writeln("long lived tree of depth ", maxDepth, "\t check: ", llTree.sum());
-  delete llTree;
 }
 
 
@@ -65,15 +64,15 @@ proc main() {
 // A simple balanced tree node class
 //
 class Tree {
-  var left, right: unmanaged Tree;
+  var left, right: owned Tree;
 
   //
   // A Tree-building initializer
   //
   proc init(depth) {
     if depth > 0 {
-      left  = new unmanaged Tree(depth-1);
-      right = new unmanaged Tree(depth-1);
+      left  = new owned Tree(depth-1);
+      right = new owned Tree(depth-1);
     }
   }
 
@@ -84,8 +83,6 @@ class Tree {
     var sum = 1;
     if left {
       sum += left.sum() + right.sum();
-      delete left;
-      delete right;
     }
     return sum;
   }

--- a/test/release/examples/benchmarks/shootout/chameneosredux-fast.chpl
+++ b/test/release/examples/benchmarks/shootout/chameneosredux-fast.chpl
@@ -25,8 +25,8 @@ const colors10 = [blue, red, yellow, red, yellow, blue, red, yellow, red, blue];
 proc main() {
   printColorEquations();
 
-  const group1 = [i in 1..popSize1] new unmanaged Chameneos(i, ((i-1)%3):Color);
-  const group2 = [i in 1..popSize2] new unmanaged Chameneos(i, colors10[i]);
+  const group1 = [i in 1..popSize1] new Chameneos(i, ((i-1)%3):Color);
+  const group2 = [i in 1..popSize2] new Chameneos(i, colors10[i]);
 
   cobegin {
     holdMeetings(group1, n);
@@ -35,9 +35,6 @@ proc main() {
 
   print(group1);
   print(group2);
-
-  for c in group1 do delete c;
-  for c in group2 do delete c;
 }
 
 
@@ -57,12 +54,10 @@ proc printColorEquations() {
 // place, and then creating per-chameneos tasks to have meetings.
 //
 proc holdMeetings(population, numMeetings) {
-  const place = new unmanaged MeetingPlace(numMeetings);
+  const place = new MeetingPlace(numMeetings);
 
   coforall c in population do           // create a task per chameneos
     c.haveMeetings(place, population);
-
-  delete place;
 }
 
 //

--- a/test/release/examples/benchmarks/shootout/chameneosredux.chpl
+++ b/test/release/examples/benchmarks/shootout/chameneosredux.chpl
@@ -64,7 +64,7 @@ record Population {
   // an array of chameneos objects representing the population
   //
   var chameneos = [i in 1..size]
-                    new unmanaged Chameneos(i, if size == 10 then colors10[i]
+                    new Chameneos(i, if size == 10 then colors10[i]
                                                    else ((i-1)%3): Color);
 
   //
@@ -81,7 +81,7 @@ record Population {
   // place, and then creating per-chameneos tasks to have meetings.
   //
   proc holdMeetings(numMeetings) {
-    const place = new borrowed MeetingPlace(numMeetings);
+    const place = new MeetingPlace(numMeetings);
 
     coforall c in chameneos do           // create a task per chameneos
       c.haveMeetings(place, chameneos);
@@ -101,14 +101,6 @@ record Population {
     
     spellInt(+ reduce chameneos.meetings);
     writeln();
-  }
-
-  //
-  // Delete the chameneos objects.
-  //
-  proc deinit() {
-    for c in chameneos do
-      delete c;
   }
 }
 

--- a/test/studies/colostate/Jacobi1D-DiamondByHand-Chapel_dyn.chpl
+++ b/test/studies/colostate/Jacobi1D-DiamondByHand-Chapel_dyn.chpl
@@ -111,7 +111,7 @@ proc main(){
   var space: [0..1, totalSpaceRange ] Cell;
   var timer: Timer;
   // initialize space with values
-  var generator = new owned RandomStream( real, globalSeed, parSafe = false );
+  var generator = new RandomStream( real, globalSeed, parSafe = false );
 
   forall i in computationSpaceRange do{
     space[0, i] = 0;
@@ -159,7 +159,7 @@ proc verifyResult(space: [] Cell, lowerBound: int, upperBound: int,
   for x in computationSpaceRange do
     spaceEndState[ x ] = space[ T & 1, x ];
 
-  var generator = new owned RandomStream( real, globalSeed, parSafe = false );
+  var generator = new RandomStream( real, globalSeed, parSafe = false );
 
   for i in computationSpaceRange do
     space[0, i] = generator.getNext();

--- a/test/studies/colostate/Jacobi1D-DiamondByHand-Chapel_static.chpl
+++ b/test/studies/colostate/Jacobi1D-DiamondByHand-Chapel_static.chpl
@@ -111,7 +111,7 @@ proc main(){
   var timer: Timer;
 
   // initialize space with values
-  var generator = new owned RandomStream( real, globalSeed, parSafe = false );
+  var generator = new RandomStream( real, globalSeed, parSafe = false );
 
   forall i in computationSpaceRange do{
     space[0, i] = 0;
@@ -159,7 +159,7 @@ proc verifyResult(space: [] Cell, lowerBound: int, upperBound: int,
   for x in computationSpaceRange do
     spaceEndState[ x ] = space[ T & 1, x ];
 
-  var generator = new owned RandomStream( real, globalSeed, parSafe = false );
+  var generator = new RandomStream( real, globalSeed, parSafe = false );
 
   for i in computationSpaceRange do
     space[0, i] = generator.getNext();

--- a/test/studies/colostate/Jacobi1D-NaiveParallel-Chapel_static.chpl
+++ b/test/studies/colostate/Jacobi1D-NaiveParallel-Chapel_static.chpl
@@ -46,7 +46,7 @@ proc main(){
   var space: [0..1, totalSpaceRange ] Cell;
   var timer: Timer;
   // initialize space with values
-  var generator = new owned RandomStream( real, globalSeed, parSafe = false );
+  var generator = new RandomStream( real, globalSeed, parSafe = false );
 
   forall i in computationSpaceRange do{
      space[0, i] = 0;
@@ -100,7 +100,7 @@ proc verifyResult(space: [] Cell, lowerBound: int, upperBound: int,
   for x in computationSpaceRange do
      spaceEndState[ x ] = space[ T & 1, x ];
 
-  var generator = new owned RandomStream( real, globalSeed, parSafe = false );
+  var generator = new RandomStream( real, globalSeed, parSafe = false );
 
   for i in computationSpaceRange do
      space[0, i] = generator.getNext();

--- a/test/studies/colostate/Jacobi2D-DiamondByHandParam-Chapel_dyn.chpl
+++ b/test/studies/colostate/Jacobi2D-DiamondByHandParam-Chapel_dyn.chpl
@@ -173,7 +173,7 @@ proc main(){
   var space: [0..1, totalSpaceRange.dim(1), totalSpaceRange.dim(2) ] Cell;
   var timer: Timer;
   // initialize space with values
-  var generator = new borrowed RandomStream( real, globalSeed, parSafe = false );
+  var generator = new RandomStream( real, globalSeed, parSafe = false );
 
   forall (x,y) in computationDomain do{
      space[0, x, y] = 0;
@@ -225,7 +225,7 @@ proc verifyResult( space: [] Cell, computationalDomain: domain(2),
   forall (x, y) in computationalDomain do
      spaceEndState[ x, y ] = space[ T & 1, x, y ];
 
-  var generator = new borrowed RandomStream( real, globalSeed, parSafe = false );
+  var generator = new RandomStream( real, globalSeed, parSafe = false );
 
   for (x, y) in computationalDomain do
      space[0, x, y] = generator.getNext();

--- a/test/studies/colostate/Jacobi2D-DiamondByHandParam-Chapel_static.chpl
+++ b/test/studies/colostate/Jacobi2D-DiamondByHandParam-Chapel_static.chpl
@@ -173,7 +173,7 @@ proc main(){
   var timer: Timer;
 
   // initialize space with values
-  var generator = new owned RandomStream( real, globalSeed, parSafe = false );
+  var generator = new RandomStream( real, globalSeed, parSafe = false );
 
   forall (x,y) in computationDomain do{
      space[0, x, y] = 0;
@@ -226,7 +226,7 @@ proc verifyResult( space: [] Cell, computationalDomain: domain(2),
   forall (x, y) in computationalDomain do
      spaceEndState[ x, y ] = space[ T & 1, x, y ];
 
-  var generator = new owned RandomStream( real, globalSeed, parSafe = false );
+  var generator = new RandomStream( real, globalSeed, parSafe = false );
 
   for (x, y) in computationalDomain do
      space[0, x, y] = generator.getNext();

--- a/test/studies/colostate/Jacobi2D-NaiveParallel-Chapel_dyn.chpl
+++ b/test/studies/colostate/Jacobi2D-NaiveParallel-Chapel_dyn.chpl
@@ -46,7 +46,7 @@ proc main(){
   var space: [0..1, totalSpaceRange.dim(1), totalSpaceRange.dim(2) ] Cell;
   var timer: Timer;
   // initialize space with values
-  var generator = new owned RandomStream( real, globalSeed, parSafe = false );
+  var generator = new RandomStream( real, globalSeed, parSafe = false );
 
   forall (x,y) in computationDomain do{
      space[0, x, y] = 0;
@@ -103,7 +103,7 @@ proc verifyResult( space: [] Cell, computationalDomain: domain(2),
   forall (x, y) in computationalDomain do
      spaceEndState[ x, y ] = space[ T & 1, x, y ];
 
-  var generator = new owned RandomStream( real, globalSeed, parSafe = false );
+  var generator = new RandomStream( real, globalSeed, parSafe = false );
 
   for (x, y) in computationalDomain do
      space[0, x, y] = generator.getNext();

--- a/test/studies/colostate/Jacobi2D-NaiveParallel-Chapel_static.chpl
+++ b/test/studies/colostate/Jacobi2D-NaiveParallel-Chapel_static.chpl
@@ -46,7 +46,7 @@ proc main(){
   var space: [0..1, totalSpaceRange.dim(1), totalSpaceRange.dim(2) ] Cell;
   var timer: Timer;
   // initialize space with values
-  var generator = new owned RandomStream( real, globalSeed, parSafe = false );
+  var generator = new RandomStream( real, globalSeed, parSafe = false );
 
   forall (x,y) in computationDomain do{
      space[0, x, y] = 0;
@@ -104,7 +104,7 @@ proc verifyResult( space: [] Cell, computationalDomain: domain(2),
   forall (x, y) in computationalDomain do
      spaceEndState[ x, y ] = space[ T & 1, x, y ];
 
-  var generator = new owned RandomStream( real, globalSeed, parSafe = false );
+  var generator = new RandomStream( real, globalSeed, parSafe = false );
 
   for (x, y) in computationalDomain do
      space[0, x, y] = generator.getNext();

--- a/test/studies/hpcc/STREAMS/bradc/stream-block1d-local.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-block1d-local.chpl
@@ -61,7 +61,7 @@ proc printConfiguration() {
 
 
 proc initVectors(B, C) {
-  var randlist = new owned NPBRandomStream(eltType=real, seed=seed);
+  var randlist = new NPBRandomStream(eltType=real, seed=seed);
 
   randlist.fillRandom(B);
   randlist.fillRandom(C);

--- a/test/studies/hpcc/STREAMS/bradc/stream-block1d-promote.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-block1d-promote.chpl
@@ -52,7 +52,7 @@ proc printConfiguration() {
 
 
 proc initVectors(B, C) {
-  var randlist = new owned NPBRandomStream(eltType=real, seed=seed);
+  var randlist = new NPBRandomStream(eltType=real, seed=seed);
 
   randlist.fillRandom(B);
   randlist.fillRandom(C);

--- a/test/studies/hpcc/STREAMS/bradc/stream-block1d.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-block1d.chpl
@@ -71,7 +71,7 @@ proc printConfiguration() {
 
 
 proc initVectors(B, C) {
-  var randlist = new owned NPBRandomStream(eltType=real, seed=seed);
+  var randlist = new NPBRandomStream(eltType=real, seed=seed);
 
   randlist.fillRandom(B);
   randlist.fillRandom(C);

--- a/test/studies/hpcc/STREAMS/bradc/stream-fragmented.chpl
+++ b/test/studies/hpcc/STREAMS/bradc/stream-fragmented.chpl
@@ -67,7 +67,7 @@ proc printConfiguration() {
 
 
 proc initVectors(B, C, ProblemSpace) {
-  var randlist = new owned NPBRandomStream(eltType=real, seed=seed);
+  var randlist = new NPBRandomStream(eltType=real, seed=seed);
 
   randlist.skipToNth(B.domain.low);
   randlist.fillRandom(B);

--- a/test/studies/hpcc/STREAMS/diten/stream-fragmented-local.chpl
+++ b/test/studies/hpcc/STREAMS/diten/stream-fragmented-local.chpl
@@ -67,7 +67,7 @@ proc printConfiguration() {
 
 
 proc initVectors(B, C, ProblemSpace) {
-  var randlist = new owned NPBRandomStream(eltType=real, seed=seed);
+  var randlist = new NPBRandomStream(eltType=real, seed=seed);
 
   randlist.skipToNth(B.domain.low);
   randlist.fillRandom(B);

--- a/test/studies/hpcc/STREAMS/elliot/stream-spmd-barrier.chpl
+++ b/test/studies/hpcc/STREAMS/elliot/stream-spmd-barrier.chpl
@@ -61,7 +61,7 @@ proc printConfiguration() {
 
 
 proc initVectors(B, C) {
-  var randlist = new borrowed NPBRandomStream(eltType=real, seed=seed);
+  var randlist = new NPBRandomStream(eltType=real, seed=seed);
 
   randlist.fillRandom(B);
   randlist.fillRandom(C);

--- a/test/studies/shootout/binary-trees/binarytrees-blc.chpl
+++ b/test/studies/shootout/binary-trees/binarytrees-blc.chpl
@@ -20,17 +20,18 @@ proc main() {
   //
   // Create the "stretch" tree, checksum it, print its stats, and free it.
   //
-  const strTree = new unmanaged Tree(strDepth);
-  writeln("stretch tree of depth ", strDepth, "\t check: ", strTree.sum());
-  delete strTree;
+  {
+    const strTree = new Tree(strDepth);
+    writeln("stretch tree of depth ", strDepth, "\t check: ", strTree.sum());
+  }
 
   //
   // Build the long-lived tree.
   //
-  var llTree: unmanaged Tree;
+  var llTree: owned Tree;
 
   cobegin with (ref llTree) {
-    llTree = new unmanaged Tree(maxDepth);
+    llTree = new owned Tree(maxDepth);
 
     {
       //
@@ -43,9 +44,8 @@ proc main() {
         var sum = 0;
 
         for i in 1..iterations {
-          const t = new unmanaged Tree(depth);
+          const t = new Tree(depth);
           sum += t.sum();
-          delete t;
         }
         stats[depth] = (iterations, sum);
       }
@@ -63,7 +63,6 @@ proc main() {
   // Checksum the long-lived tree, print its stats, and free it.
   //
   writeln("long lived tree of depth ", maxDepth, "\t check: ", llTree.sum());
-  delete llTree;
 }
 
 


### PR DESCRIPTION
While running release-over-release testing, a number of performance
tests fail on old versions of the compiler due to using 'owned',
'unmanaged', etc.  This PR represents an attempt to (a) use
undecorated 'new's on performance tests in hopes of making them more
backwards compatible and (b) using more principled ownership types to
clean up the implementations and make them more representative of the
type of Chapel we'd like to be writing going forward.

A challenge to this approach is that using `new C()` without a decorator
generates a warning at present which adds a lot of noise when used in
that mode here.  We could handle this by (a) updating the tests to work
around those warnings (though that might break the release-over-release
testing as well), (b) throwing `--no-warnings` for these tests and having
those messages respond to the flag better (I have a prototype for this),
or (c) not throwing that warning by default.

This does not hit all such performance tests.  Some key missing ones
are: LCALS, CoMD which were bigger than I had time to take on in this
pass.