### PR TITLE
Reduce the amount of memory used by oversubscribedArrayAlloc

### DIFF
--- a/test/runtime/configMatters/comm/oversubscribedArrayAlloc.chpl
+++ b/test/runtime/configMatters/comm/oversubscribedArrayAlloc.chpl
@@ -8,7 +8,7 @@ var memAvail = here.physicalMemory(unit=MemUnits.Bytes);
 if numBits(size_t) < 64 then
   memAvail = min(memAvail, 2**30);
 
-config const memFraction = 3;
+config const memFraction = 10;
 config var maxMem = memAvail / memFraction;
 const arrSize = maxMem / desiredTasks;
 


### PR DESCRIPTION
This test allocates large arrays in parallel to stress ugni's dynamic array
allocation/registration code. Previously, it was using 1/3 of physical memory,
but this drops it to use 1/10.

We've been seeing sporadic OOMs on ARM nodes that have severe fragmentation and
dropping to 1/10 mem helps quiet testing. All we really care about is that each
array is large enough to trigger the ugni code path, and we're still well above
that on any node type that I know of.