### PR TITLE
Revert "Reduce rfDone contention in comm=ugni."

### DIFF
--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -878,7 +878,7 @@ static gni_mem_handle_t* rf_mdh_map;    // all locales' remote fork space mdhs
 #define RF_DONE_NUM_POOLS 512
 #define RF_DONE_NUM_PER_POOL 32
 
-typedef int64_t rf_done_t;
+typedef int8_t rf_done_t;
 
 static rf_done_t (*rf_done_pool)[RF_DONE_NUM_PER_POOL];
 static atomic_bool rf_done_pool_lock[RF_DONE_NUM_POOLS][RF_DONE_NUM_PER_POOL];
@@ -4630,8 +4630,6 @@ void rf_done_init(void)
 }
 
 
-static __thread int rf_done_private_prt;
-
 static
 inline
 rf_done_t* rf_done_alloc(void)
@@ -4644,31 +4642,14 @@ rf_done_t* rf_done_alloc(void)
 #define CEIL_X_DIV_Y(x, y) (1 + ((x) - 1) / (y))
 
   if (prt_lo == -1) {
-    const int nPrts = chpl_task_getMaxPar() + 1;
-    const int tidx = my_thread_idx();
-    int prt;
-    if (tidx < nPrts - 1) {
-      prt = tidx;
-      rf_done_private_prt = 1;
-    } else {
-      prt = nPrts - 1;
-      rf_done_private_prt = 0;
-    }
+    const int nPrts = chpl_task_getMaxPar();
+    const int prt = my_thread_idx() % nPrts;
     prt_lo = ((prt == 0)
               ? 0
               : CEIL_X_DIV_Y(prt * RF_DONE_NUM_POOLS, nPrts));
     prt_hi = ((prt == nPrts - 1)
               ? RF_DONE_NUM_POOLS - 1
               : CEIL_X_DIV_Y((prt + 1) * RF_DONE_NUM_POOLS, nPrts) - 1);
-
-    if (rf_done_private_prt) {
-      for (int i = prt_lo; i < prt_hi; i++) {
-        for (int j = 0; j < RF_DONE_NUM_PER_POOL; j ++) {
-          rf_done_pool[i][j] = -1;
-        }
-      }
-    }
-
     last_i = prt_lo;
     last_j = 0;
   }
@@ -4685,31 +4666,17 @@ rf_done_t* rf_done_alloc(void)
   int i = last_i;
   int j = last_j;
 
-  if (rf_done_private_prt) {
-    do {
-      if (++j >= RF_DONE_NUM_PER_POOL) {
-        j = 0;
-        if (++i >= prt_hi)
-          i = prt_lo;
-      }
+  do {
+    if (++j >= RF_DONE_NUM_PER_POOL) {
+      j = 0;
+      if (++i >= prt_hi)
+        i = prt_lo;
+    }
 
-      if (i == last_i && j == last_j) {
-        CHPL_INTERNAL_ERROR("rf_done_pool empty");
-      }
-    } while (rf_done_pool[i][j] != -1);
-  } else {
-    do {
-      if (++j >= RF_DONE_NUM_PER_POOL) {
-        j = 0;
-        if (++i >= prt_hi)
-          i = prt_lo;
-      }
-
-      if (i == last_i && j == last_j) {
-        CHPL_INTERNAL_ERROR("rf_done_pool empty");
-      }
-    } while (atomic_exchange_bool(&rf_done_pool_lock[i][j], true));
-  }
+    if (i == last_i && j == last_j) {
+      CHPL_INTERNAL_ERROR("rf_done_pool empty");
+    }
+  } while (atomic_exchange_bool(&rf_done_pool_lock[i][j], true));
 
   last_i = i;
   last_j = j;
@@ -4727,10 +4694,7 @@ void rf_done_free(rf_done_t* rf_done_p)
   const int linearized_ij = rf_done_p - &rf_done_pool[0][0];
   const int i = linearized_ij / RF_DONE_NUM_PER_POOL;
   const int j = linearized_ij % RF_DONE_NUM_PER_POOL;
-  if (rf_done_private_prt)
-    rf_done_pool[i][j] = -1;
-  else
-    atomic_store_bool(&rf_done_pool_lock[i][j], false);
+  atomic_store_bool(&rf_done_pool_lock[i][j], false);
 }
 
 

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -904,6 +904,15 @@ void rf_done_ensure_pool_partition(void) {
     rf_done_prt_hi = ((prt == nPrts - 1)
                       ? RF_DONE_NUM_POOLS - 1
                       : CEIL_X_DIV_Y((prt + 1) * RF_DONE_NUM_POOLS, nPrts) - 1);
+#if 0
+    if (chpl_nodeID == 0) {
+      printf("rf_done_ensure_pool_partition(): "
+             "thr %d, nPrts %d, prt %d, lo %d, hi %d\n",
+             (int) my_thread_idx(), (int) nPrts, (int) prt,
+             (int) rf_done_prt_lo, (int) rf_done_prt_hi);
+      fflush(stdout);
+    }
+#endif
   }
 
 #undef CEIL_X_DIV_Y

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -853,8 +853,10 @@ static gni_mem_handle_t* rf_mdh_map;    // all locales' remote fork space mdhs
 // Blocking remote forks need a "remote fork done" (rf_done) flag, for
 // the remote side to set when it completes.  Such flags have to be in
 // memory registered with the NIC so that the remote side can PUT to
-// them directly.  We allocate rf_done flags out of these pools, which
-// we have arranged to be always in registered memory.
+// them directly.  When the initiating side's stack is in registered
+// memory we can use an rf_done flag local to the fork function.  But
+// if not, we allocate an rf_done flag out of these pools, which we
+// have arranged to be always in registered memory.
 //
 // To ensure that these are in registered memory we allocate them up
 // front, with a fixed size, through the registered-memory manager.
@@ -875,14 +877,37 @@ static gni_mem_handle_t* rf_mdh_map;    // all locales' remote fork space mdhs
 //     "large".  Fortunately they're small, so over-provisioning isn't
 //     particularly costly.
 //
-#define RF_DONE_NUM_POOLS 512
-#define RF_DONE_NUM_PER_POOL 32
+#define RF_DONE_NUM_POOLS 128
+#define RF_DONE_NUM_PER_POOL 128
 
-typedef int8_t rf_done_t;
+typedef mpool_idx_base_t rf_done_t;
+typedef mpool_idx_base_t rf_done_pool_t;
 
-static rf_done_t (*rf_done_pool)[RF_DONE_NUM_PER_POOL];
-static atomic_bool rf_done_pool_lock[RF_DONE_NUM_POOLS][RF_DONE_NUM_PER_POOL];
+static rf_done_pool_t (*rf_done_pool)[RF_DONE_NUM_PER_POOL];
+static mpool_idx_t rf_done_pool_head[RF_DONE_NUM_POOLS];
+static atomic_bool rf_done_pool_lock[RF_DONE_NUM_POOLS];
 
+static __thread mpool_idx_base_t rf_done_prt_lo = -1;
+static __thread mpool_idx_base_t rf_done_prt_hi = -1;
+
+static inline
+void rf_done_ensure_pool_partition(void) {
+#define CEIL_X_DIV_Y(x, y) (1 + ((x) - 1) / (y))
+
+  if (rf_done_prt_lo == -1) {
+    const int_least64_t nPrts = chpl_task_getMaxPar();
+    const int_least64_t prt = my_thread_idx() % nPrts;
+
+    rf_done_prt_lo = ((prt == 0)
+                      ? 0
+                      : CEIL_X_DIV_Y(prt * RF_DONE_NUM_POOLS, nPrts));
+    rf_done_prt_hi = ((prt == nPrts - 1)
+                      ? RF_DONE_NUM_POOLS - 1
+                      : CEIL_X_DIV_Y((prt + 1) * RF_DONE_NUM_POOLS, nPrts) - 1);
+  }
+
+#undef CEIL_X_DIV_Y
+}
 
 //
 // Each locale has an array of spaces for fork requests targeted to
@@ -4586,6 +4611,12 @@ static
 void rf_done_pre_init(void)
 {
   //
+  // We overload rf_done indicators as pool "next" links, so the
+  // latter have to fit in the former.
+  //
+  assert(sizeof(rf_done_pool_t) <= sizeof(rf_done_t));
+
+  //
   // The fork request buffers and their is-free flags aren't part of
   // the rf_done flags as such, but both have to do with remote forks
   // and the former have to be in NIC-registered memory just as the
@@ -4615,7 +4646,7 @@ void rf_done_init(void)
                  0, 0);
 
   // Must be directly communicable without proxy.
-  rf_done_pool = (rf_done_t (*)[RF_DONE_NUM_PER_POOL])
+  rf_done_pool = (rf_done_pool_t (*)[RF_DONE_NUM_PER_POOL])
                  chpl_comm_mem_reg_allocMany(RF_DONE_NUM_POOLS,
                                              sizeof(rf_done_pool[0]),
                                              CHPL_RT_MD_COMM_PER_LOC_INFO,
@@ -4623,9 +4654,13 @@ void rf_done_init(void)
 
   for (i = 0; i < RF_DONE_NUM_POOLS; i++) {
     for (j = 0; j < RF_DONE_NUM_PER_POOL - 1; j++) {
-      rf_done_pool[i][j] = 0;
-      atomic_init_bool(&rf_done_pool_lock[i][j], false);
+      rf_done_pool[i][j] = j + 1;
     }
+    rf_done_pool[i][j] = -1;
+
+    mpool_idx_init(&rf_done_pool_head[i], 0);
+
+    atomic_init_bool(&rf_done_pool_lock[i], false);
   }
 }
 
@@ -4634,27 +4669,7 @@ static
 inline
 rf_done_t* rf_done_alloc(void)
 {
-  static __thread int prt_lo = -1;
-  static __thread int prt_hi = -1;
-  static __thread int last_i = -1;
-  static __thread int last_j = -1;
-
-#define CEIL_X_DIV_Y(x, y) (1 + ((x) - 1) / (y))
-
-  if (prt_lo == -1) {
-    const int nPrts = chpl_task_getMaxPar();
-    const int prt = my_thread_idx() % nPrts;
-    prt_lo = ((prt == 0)
-              ? 0
-              : CEIL_X_DIV_Y(prt * RF_DONE_NUM_POOLS, nPrts));
-    prt_hi = ((prt == nPrts - 1)
-              ? RF_DONE_NUM_POOLS - 1
-              : CEIL_X_DIV_Y((prt + 1) * RF_DONE_NUM_POOLS, nPrts) - 1);
-    last_i = prt_lo;
-    last_j = 0;
-  }
-
-#undef CEIL_X_DIV_Y
+  rf_done_pool_t* rf_done_p;
 
   //
   // Cycle through our partition of the pools and find one that contains
@@ -4663,27 +4678,26 @@ rf_done_t* rf_done_alloc(void)
   // We don't expect to run out of these in any reasonable program.  If
   // we ever do, we'll have to revisit how we've approached this.
   //
-  int i = last_i;
-  int j = last_j;
+  rf_done_ensure_pool_partition();
 
-  do {
-    if (++j >= RF_DONE_NUM_PER_POOL) {
-      j = 0;
-      if (++i >= prt_hi)
-        i = prt_lo;
+  rf_done_p = NULL;
+  for (int i = rf_done_prt_lo; i <= rf_done_prt_hi && rf_done_p == NULL; i++) {
+    if (mpool_idx_load(&rf_done_pool_head[i]) >= 0 &&
+        !atomic_exchange_bool(&rf_done_pool_lock[i], true)) {
+      int j;
+      if ((j = mpool_idx_load(&rf_done_pool_head[i])) >= 0) {
+        rf_done_p = &rf_done_pool[i][j];
+        mpool_idx_store(&rf_done_pool_head[i], *rf_done_p);
+      }
+
+      atomic_store_bool(&rf_done_pool_lock[i], false);
     }
+  }
 
-    if (i == last_i && j == last_j) {
-      CHPL_INTERNAL_ERROR("rf_done_pool empty");
-    }
-  } while (atomic_exchange_bool(&rf_done_pool_lock[i][j], true));
+  if (rf_done_p == NULL)
+    CHPL_INTERNAL_ERROR("rf_done_pool empty");
 
-  last_i = i;
-  last_j = j;
-
-  rf_done_pool[i][j] = 0;
-
-  return &rf_done_pool[i][j];
+  return (rf_done_t*) rf_done_p;
 }
 
 
@@ -4691,10 +4705,17 @@ static
 inline
 void rf_done_free(rf_done_t* rf_done_p)
 {
-  const int linearized_ij = rf_done_p - &rf_done_pool[0][0];
-  const int i = linearized_ij / RF_DONE_NUM_PER_POOL;
-  const int j = linearized_ij % RF_DONE_NUM_PER_POOL;
-  atomic_store_bool(&rf_done_pool_lock[i][j], false);
+  rf_done_pool_t* rfdpp = (rf_done_pool_t*) rf_done_p;
+  int i = (rfdpp - (rf_done_pool_t*) rf_done_pool) / RF_DONE_NUM_PER_POOL;
+  int j = (rfdpp - (rf_done_pool_t*) rf_done_pool) % RF_DONE_NUM_PER_POOL;
+
+  //
+  // Add this flag back to its pool.
+  //
+  while (atomic_exchange_bool(&rf_done_pool_lock[i], true))
+    ;
+  rf_done_pool[i][j] = mpool_idx_exchange(&rf_done_pool_head[i], j);
+  atomic_store_bool(&rf_done_pool_lock[i], false);
 }
 
 

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -887,35 +887,12 @@ static rf_done_pool_t (*rf_done_pool)[RF_DONE_NUM_PER_POOL];
 static mpool_idx_t rf_done_pool_head[RF_DONE_NUM_POOLS];
 static atomic_bool rf_done_pool_lock[RF_DONE_NUM_POOLS];
 
-static __thread mpool_idx_base_t rf_done_prt_lo = -1;
-static __thread mpool_idx_base_t rf_done_prt_hi = -1;
+static mpool_idx_t rf_done_pool_i;
 
 static inline
-void rf_done_ensure_pool_partition(void) {
-#define CEIL_X_DIV_Y(x, y) (1 + ((x) - 1) / (y))
-
-  if (rf_done_prt_lo == -1) {
-    const int_least64_t nPrts = chpl_task_getMaxPar();
-    const int_least64_t prt = my_thread_idx() % nPrts;
-
-    rf_done_prt_lo = ((prt == 0)
-                      ? 0
-                      : CEIL_X_DIV_Y(prt * RF_DONE_NUM_POOLS, nPrts));
-    rf_done_prt_hi = ((prt == nPrts - 1)
-                      ? RF_DONE_NUM_POOLS - 1
-                      : CEIL_X_DIV_Y((prt + 1) * RF_DONE_NUM_POOLS, nPrts) - 1);
-#if 0
-    if (chpl_nodeID == 0) {
-      printf("rf_done_ensure_pool_partition(): "
-             "thr %d, nPrts %d, prt %d, lo %d, hi %d\n",
-             (int) my_thread_idx(), (int) nPrts, (int) prt,
-             (int) rf_done_prt_lo, (int) rf_done_prt_hi);
-      fflush(stdout);
-    }
-#endif
-  }
-
-#undef CEIL_X_DIV_Y
+mpool_idx_base_t rf_done_next_pool_i(void) 
+{
+  return mpool_idx_finc(&rf_done_pool_i) & (RF_DONE_NUM_POOLS - 1);
 }
 
 //
@@ -4671,6 +4648,8 @@ void rf_done_init(void)
 
     atomic_init_bool(&rf_done_pool_lock[i], false);
   }
+
+  mpool_idx_init(&rf_done_pool_i, 0);
 }
 
 
@@ -4678,22 +4657,27 @@ static
 inline
 rf_done_t* rf_done_alloc(void)
 {
+  int pool_tries;
+  int i, j;
   rf_done_pool_t* rf_done_p;
 
   //
-  // Cycle through our partition of the pools and find one that contains
-  // a free rf_done flag we can use.
+  // Cycle through the pools and find one that contains a free rf_done
+  // flag we can use.  We give up when we've looked at all the pools
+  // twice without finding anything.
   //
-  // We don't expect to run out of these in any reasonable program.  If
-  // we ever do, we'll have to revisit how we've approached this.
+  // We need a termination test because we can actually run out of
+  // these, if for example RF_DONE_NUM_POOLS*RF_DONE_NUM_IN_POOL tasks
+  // do remote on-stmts all at once, and each of those tries to do
+  // another on-stmt.  If we ever see that happen in a program that
+  // isn't specifically designed to achieve it, we'll have to revisit
+  // how we've approached this.
   //
-  rf_done_ensure_pool_partition();
-
-  rf_done_p = NULL;
-  for (int i = rf_done_prt_lo; i <= rf_done_prt_hi && rf_done_p == NULL; i++) {
+  for (pool_tries = 0, i = rf_done_next_pool_i(), rf_done_p = NULL;
+       pool_tries < 2 * RF_DONE_NUM_POOLS && rf_done_p == NULL;
+       pool_tries++, i = (i + 1) % RF_DONE_NUM_POOLS) {
     if (mpool_idx_load(&rf_done_pool_head[i]) >= 0 &&
         !atomic_exchange_bool(&rf_done_pool_lock[i], true)) {
-      int j;
       if ((j = mpool_idx_load(&rf_done_pool_head[i])) >= 0) {
         rf_done_p = &rf_done_pool[i][j];
         mpool_idx_store(&rf_done_pool_head[i], *rf_done_p);


### PR DESCRIPTION
Revert the `rf_done` partitioning introduced in [PR 10780](https://github.com/chapel-lang/chapel/pull/10780).  It has a significant flaw in that it presumes a task will not allocate a `done` indicator on one thread and free it on another, despite that there is a `yield()` which has the potential to thread-switch between the allocate and free calls.  Further, it turns out that the Qthreads scheduler used for the knl and numa locale models does sometimes thread-switch there.  Since the `rf_done` partitioning relies on thread-local storage to avoid locking, it cannot work when thread-switching might occur.  Fortunately, this partitioning code hardly improved performance at all.