### PR TITLE
See how converting from 'unmanaged' to 'owned' affects chameneos perf

### DIFF
--- a/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc.chpl
+++ b/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc.chpl
@@ -53,7 +53,7 @@ record Population {
   // construct the population in terms of an array of colors passed in
   //
   proc init(colors: [] Color) {
-    chameneos = [i in colors.domain] new unmanaged Chameneos(i, colors[i]);
+    chameneos = [i in colors.domain] new owned Chameneos(i, colors[i]);
   }
 
   //
@@ -61,12 +61,10 @@ record Population {
   // place, and then creating per-chameneos tasks to have meetings.
   //
   proc holdMeetings(numMeetings) {
-    const place = new unmanaged MeetingPlace(numMeetings);
+    const place = new owned MeetingPlace(numMeetings);
 
     coforall c in chameneos do           // create a task per chameneos
       c.haveMeetings(place, chameneos);
-
-    delete place;
   }
 
   //
@@ -86,14 +84,6 @@ record Population {
 
     spellInt(+ reduce chameneos.meetings);
     writeln();
-  }
-
-  //
-  // Delete the chameneos objects.
-  //
-  proc deinit() {
-    for c in chameneos do
-      delete c;
   }
 }
 

--- a/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc.chpl
+++ b/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc.chpl
@@ -61,7 +61,7 @@ record Population {
   // place, and then creating per-chameneos tasks to have meetings.
   //
   proc holdMeetings(numMeetings) {
-    const place = new owned MeetingPlace(numMeetings);
+    const place = new borrowed MeetingPlace(numMeetings);
 
     coforall c in chameneos do           // create a task per chameneos
       c.haveMeetings(place, chameneos);

--- a/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc.compopts
+++ b/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc.compopts
@@ -1,0 +1,1 @@
+--no-warnings


### PR DESCRIPTION
It's a nice code cleanup to use 'owned'/'borrowed' rather than 'unmanaged'
classes in chameneos.  Checking it in to see how it impacts nightly
performance.

(Note: I wanted to use an undecorated class allocation for the
meetingPlace type, but this caused a memory leak to my surprise.
Using explicit owned or borrowed does not).
