### PR TITLE
Fix LinearAlgebra isSubType conflict and slurm error

### DIFF
--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -1256,7 +1256,7 @@ private proc isDefaultRectangularArr (A: []) param {
 }
 
 private proc isDefaultSparseDom(D: domain) param {
-  return isSubtype(_to_borrowed(D._value), DefaultSparseDom);
+  return isSubtype(_to_borrowed(D._value.type), DefaultSparseDom);
 }
 private proc isDefaultSparseArr(A: []) param {
   return isDefaultSparseDom(A.domain);

--- a/test/library/packages/LinearAlgebra/correctness/testSVD-error.chpl
+++ b/test/library/packages/LinearAlgebra/correctness/testSVD-error.chpl
@@ -1,7 +1,16 @@
 use LinearAlgebra;
 
-var A = Matrix([1.0, 2.0, 3.0],
-               [3.0, 2.0, 4.0],
-               [1.0, 2.0, NAN]);
+// Test to confirm we get an error thrown for invalid input
 
-var (u, s, vt) = svd(A);
+proc main() throws {
+
+  var A = Matrix([1.0, 2.0, 3.0],
+                 [3.0, 2.0, 4.0],
+                 [1.0, 2.0, NAN]);
+
+  try {
+    var (u, s, vt) = svd(A);
+  } catch e:LinearAlgebraError {
+    writeln(e.info);
+  }
+}

--- a/test/library/packages/LinearAlgebra/correctness/testSVD-error.good
+++ b/test/library/packages/LinearAlgebra/correctness/testSVD-error.good
@@ -1,3 +1,1 @@
-uncaught LinearAlgebraError: LinearAlgebra error : SVD received an illegal argument in LAPACK.gesvd() argument position: -6
-  testSVD-error.chpl:7: thrown here
-  testSVD-error.chpl:7: uncaught here
+SVD received an illegal argument in LAPACK.gesvd() argument position: -6


### PR DESCRIPTION
#10953 resulted in linear algebra tests failing due to the usage of `isSubType` on a value. This adds `.type` to the end of the value being passed to `isSubType()`

Additionally, switch `testSVD-error.chpl` to catch and print the error rather than throwing it. With the old behavior, Cray testing resulted in the following error:

```
> srun: error: nid00076: task 0: Exited with exit code 1
```

I plan to open an issue on this (**#TODO**), as this may be caused by an issue in `start_test`.

**Testing**
```
start_test test/library/packages/LinearAlgebra/ examples/primers/LinearAlgebralib.chpl
```
  - [x] OS X with no dependencies
  - [x] Cray with BLAS/LAPACK