### PR TITLE
Fix Misc Functions docs to include < etc on types

### DIFF
--- a/modules/internal/UtilMisc_forDocs.chpl
+++ b/modules/internal/UtilMisc_forDocs.chpl
@@ -137,17 +137,17 @@ module UtilMisc_forDocs {
        * `sub` is a type that coerces to `super`
 
      Note that :proc:`isSubtype` is also available as
-     `<=` and `>=` on types.
+     :proc:`<=` and :proc:`>=` on types.
      */
   proc isSubtype(type sub, type super) param {
     __primitive("is_subtype", super, sub);
   }
 
-  /* As with :proc:`isSubtype` but returns `false` if
+  /* Similar to :proc:`isSubtype` but returns `false` if
      `sub` and `super` refer to the same type.
 
      Note that :proc:`isProperSubtype` is alse available as
-     `<` and `>` on types;
+     :proc:`<` and :proc:`>` on types;
      */
   proc isProperSubtype(type sub, type super) param {
     __primitive("is_proper_subtype", super, sub);

--- a/modules/internal/UtilMisc_forDocs.chpl
+++ b/modules/internal/UtilMisc_forDocs.chpl
@@ -135,17 +135,25 @@ module UtilMisc_forDocs {
        * `sub` is an instantiation of a generic type `super`
        * `sub` is a class type inheriting from `super`
        * `sub` is a type that coerces to `super`
+
+     Note that :proc:`isSubtype` is also available as
+     `<=` and `>=` on types.
      */
   proc isSubtype(type sub, type super) param {
     __primitive("is_subtype", super, sub);
   }
 
-   /* As with :proc:`isSubtype` but returns `false` if
-      `sub` and `super` refer to the same type.
+  /* As with :proc:`isSubtype` but returns `false` if
+     `sub` and `super` refer to the same type.
+
+     Note that :proc:`isProperSubtype` is alse available as
+     `<` and `>` on types;
      */
   proc isProperSubtype(type sub, type super) param {
     __primitive("is_proper_subtype", super, sub);
   }
+
+  // Note, below documentation isn't rendered currently!
 
   /* :returns: isProperSubtype(a,b) */
   proc <(type a, type b) param {
@@ -160,7 +168,7 @@ module UtilMisc_forDocs {
     return isProperSubtype(b,a);
   }
   /* :returns: isSubtype(b,a) */
-  proc <=(type a, type b) param {
+  proc >=(type a, type b) param {
     return isSubtype(b,a);
   }
 

--- a/modules/internal/UtilMisc_forDocs.chpl
+++ b/modules/internal/UtilMisc_forDocs.chpl
@@ -153,8 +153,6 @@ module UtilMisc_forDocs {
     __primitive("is_proper_subtype", super, sub);
   }
 
-  // Note, below documentation isn't rendered currently!
-
   /* :returns: isProperSubtype(a,b) */
   proc <(type a, type b) param {
     return isProperSubtype(a,b);

--- a/modules/internal/fixInternalDocs.sh
+++ b/modules/internal/fixInternalDocs.sh
@@ -227,7 +227,8 @@ removeUsage $file
 
 file="./UtilMisc_forDocs.rst"
 
-removePrefixFunctions $file
+# Don't removePrefixFunctions since it's a stand-in documentation file
+# so shouldn't have any that we don't want documented.
 fixTitle "Misc Functions" $file
 removeUsage $file
 


### PR DESCRIPTION
Adds chpldocs for `<` `<=` `>` and `>=` on types and
mentions that these operators are available
in `isSubtype` and `isProperSubtype`.

Note that Sphinx changes will be required for these
operators to be rendered with the right colors in HTML.

Reviewed by @ben-albrecht - thanks!