### PR TITLE
Make -o flag prepend "lib" in --library compilation

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -2166,9 +2166,8 @@ static void setupDefaultFilenames() {
       if (strlen(filename) >= sizeof(executableFilename) - 3) {
         INT_FATAL("input filename exceeds executable filename buffer size");
       }
-      strcpy(executableFilename, "lib");
-      strncat(executableFilename, filename,
-              sizeof(executableFilename)-strlen(executableFilename)-1);
+      strncpy(executableFilename, filename,
+              sizeof(executableFilename)-1);
 
       if (fLibraryPython && pythonModulename[0] == '\0') {
         strncpy(pythonModulename, filename, sizeof(pythonModulename)-1);

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -681,16 +681,19 @@ void codegen_makefile(fileinfo* mainfile, const char** tmpbinname, bool skip_com
     ensureLibDirExists();
     // In --library compilation, put the generated library in the library
     // directory
-    fprintf(makefile.fptr, "BINNAME = %s/%s%s\n\n",
+    fprintf(makefile.fptr, "BINNAME = %s/lib%s%s\n\n",
             libDir,
             executableFilename,
             exeExt);
+    // BLC: This munging is done so that cp won't complain if the source
+    // and destination are the same file (e.g., myprogram and ./myprogram)
+    tmpbin = astr(tmpDirName, "/lib", strippedExeFilename, ".tmp", exeExt);
   } else {
     fprintf(makefile.fptr, "BINNAME = %s%s\n\n", executableFilename, exeExt);
+    // BLC: This munging is done so that cp won't complain if the source
+    // and destination are the same file (e.g., myprogram and ./myprogram)
+    tmpbin = astr(tmpDirName, "/", strippedExeFilename, ".tmp", exeExt);
   }
-  // BLC: This munging is done so that cp won't complain if the source
-  // and destination are the same file (e.g., myprogram and ./myprogram)
-  tmpbin = astr(tmpDirName, "/", strippedExeFilename, ".tmp", exeExt);
   if( tmpbinname ) *tmpbinname = tmpbin;
   fprintf(makefile.fptr, "TMPBINNAME = %s\n", tmpbin);
   // BLC: We generate a TMPBINNAME which is the name that will be used

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -681,13 +681,22 @@ void codegen_makefile(fileinfo* mainfile, const char** tmpbinname, bool skip_com
     ensureLibDirExists();
     // In --library compilation, put the generated library in the library
     // directory
-    fprintf(makefile.fptr, "BINNAME = %s/lib%s%s\n\n",
-            libDir,
+    fprintf(makefile.fptr, "BINNAME = %s/", libDir);
+    int libLength = strlen("lib");
+    bool startsWithLib = strncmp(executableFilename, "lib", libLength) == 0;
+    if (!startsWithLib) {
+      fprintf(makefile.fptr, "lib");
+    }
+    fprintf(makefile.fptr, "%s%s\n\n",
             executableFilename,
             exeExt);
     // BLC: This munging is done so that cp won't complain if the source
     // and destination are the same file (e.g., myprogram and ./myprogram)
-    tmpbin = astr(tmpDirName, "/lib", strippedExeFilename, ".tmp", exeExt);
+    if (startsWithLib) {
+      tmpbin = astr(tmpDirName, "/", strippedExeFilename, ".tmp", exeExt);
+    } else {
+      tmpbin = astr(tmpDirName, "/lib", strippedExeFilename, ".tmp", exeExt);
+    }
   } else {
     fprintf(makefile.fptr, "BINNAME = %s%s\n\n", executableFilename, exeExt);
     // BLC: This munging is done so that cp won't complain if the source

--- a/test/compflags/library/withMain/cmain.precomp
+++ b/test/compflags/library/withMain/cmain.precomp
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-$3 --library --library-dir lib-dir lib.chpl
+$3 --library --library-dir lib-dir -o liblib lib.chpl

--- a/test/compflags/lydia/library/errorMessage/multiMod/callMultiModLib.lastcompopts
+++ b/test/compflags/lydia/library/errorMessage/multiMod/callMultiModLib.lastcompopts
@@ -1,1 +1,1 @@
--Llib/ lib/givenName.a `$CHPL_HOME/util/config/compileline --libraries`
+-Llib/ lib/libgivenName.a `$CHPL_HOME/util/config/compileline --libraries`

--- a/test/compflags/lydia/library/headerName/checkHeaderAndLibSet.prediff
+++ b/test/compflags/lydia/library/headerName/checkHeaderAndLibSet.prediff
@@ -4,6 +4,6 @@ if [ -f lib/thing1.h ]; then
    echo "found header" >> $2
 fi
 
-if [ -f lib/thing2.a ]; then
+if [ -f lib/libthing2.a ]; then
    echo "found library" >> $2
 fi

--- a/test/compflags/lydia/library/headerName/checkLibNotHeaderSet.prediff
+++ b/test/compflags/lydia/library/headerName/checkLibNotHeaderSet.prediff
@@ -4,6 +4,6 @@ if [ -f lib/noHeaderSet.h ]; then
    echo "found header" >> $2
 fi
 
-if [ -f lib/noHeaderSet.a ]; then
+if [ -f lib/libnoHeaderSet.a ]; then
    echo "found library" >> $2
 fi

--- a/test/compflags/lydia/library/makefiles/Makefile
+++ b/test/compflags/lydia/library/makefiles/Makefile
@@ -10,7 +10,7 @@ endif
 
 ifeq ($(MAKECMDGOALS),renamedTest)
 include lib/Makefile.myLib
-renamedTest: renamedTest.c lib/myLib.a
+renamedTest: renamedTest.c lib/libmyLib.a
 	@$(CHPL_COMPILER) $(CHPL_CFLAGS) -o renamedTest renamedTest.c $(CHPL_LDFLAGS)
 	@./renamedTest
 else

--- a/test/compflags/lydia/library/python/checkExplicitLibname.future
+++ b/test/compflags/lydia/library/python/checkExplicitLibname.future
@@ -1,2 +1,0 @@
-bug: renamed libraries unable to find chpl_filenameTable in static compilation
-#10923


### PR DESCRIPTION
Prior to this change, we would always prepend "lib" to libraries created without
the `-o` flag.  Libraries created with the `-o` flag would use exactly the name
given (plus the relevant extension for static or dynamic code).  This was fine
for using these libraries with C, but Cython expected every library to start
with "lib", especially when compiling statically.

To avoid confusion in --library-python compilation (and follow the unwritten
rules about libraries), we decided to update compilation with `-o` to also
prepend "lib" to the name (if it does not already start with "lib").  This does
mean that the chapel compiler will never create a foo.a/foo.so file but the
user can always rename the generated library after the fact if it is that
important (and they are more likely to be aware of its risks).

Update a few tests that were looking for the "lib"-less version, and resolve the
Cython future now that it works.

Resolves #10938 
Resolves #10923 

Tested on our box where Cython testing runs and passed a full paratest with
futures