### PR TITLE
Alphabetize expandVars, and add documentation link to Path Manipulations header

### DIFF
--- a/modules/standard/Path.chpl
+++ b/modules/standard/Path.chpl
@@ -41,6 +41,7 @@
 
    Path Manipulations
    ------------------
+   :proc:`expandVars`
    :proc:`joinPath`
    :proc:`splitPath`
 
@@ -234,6 +235,77 @@ proc commonPath(paths: []): string {
 proc dirname(name: string): string {
   return splitPath(name)[1];
 }
+
+/* Expands any environment variables in the path of the form `$<name>` or
+   `${<name>}` into their values.  If <name> does not exist, they are left
+   in place. Returns the path which includes these expansions.
+
+   :arg path: a string representation of a path, which may or may not include
+                   `$<name>` or `${<name>}`.
+   :type path: `string`
+
+   :return: `path`, having replaced all references to environment variables with
+                their values
+   :rtype: `string`
+*/
+ proc expandVars(path: string): string {
+   var path_p: string = path;
+   var varChars: string = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_";
+   var res: string = "";
+   var ind: int = 1;
+   var pathlen: int = path_p.length;
+   while (ind <= pathlen) {
+     var c: string = path_p(ind);
+     if (c == "$" && ind + 1 <= pathlen) {
+       if (path_p(ind+1) == "$") {
+         res = res + c;
+         ind += 1;
+       } else if (path_p(ind+1) == "{") {
+         path_p = path_p((ind+2)..);
+         pathlen = path_p.length;
+         ind = path_p.find("}");
+         if (ind == 0) {
+           res += "${" +path_p;
+           ind = pathlen;
+         } else {
+           var env_var: string = path_p(..(ind-1));
+           var value: string;
+           var value_c: c_string;
+           var h: int = sys_getenv(env_var.c_str(), value_c);
+           if (h != 1) {
+             value = "${" + env_var + "}";
+           } else {
+             value = value_c: string;
+           }
+           res += value;
+         }
+       } else {
+         var env_var: string = "";
+         ind += 1;
+         while (ind <= path_p.length && varChars.find(path_p(ind)) != 0) {
+           env_var += path_p(ind);
+           ind += 1;
+         }
+         var value: string;
+         var value_c: c_string;
+         var h: int = sys_getenv(env_var.c_str(), value_c);
+         if (h != 1) {
+           value = "$" + env_var;
+         } else {
+           value = value_c: string;
+         }
+         res += value;
+         if (ind <= path_p.length) {
+           ind -= 1;
+         }
+       }
+     } else {
+       res += c;
+     }
+     ind +=1;
+   }
+   return res;
+ }
 
 /*
   Returns the parent directory of the :type:`~IO.file` record.  For instance,
@@ -461,83 +533,4 @@ proc file.realPath(out error: syserr): string {
      return ("", name);
    }
  }
-
-
-/* Expands any environment variables in the path of the form `$<name>` or
-   `${<name>}` into their values.  If <name> does not exist, they are left
-   in place. Returns the path which includes these expansions.
-
-   :arg path: a string representation of a path, which may or may not include
-                   `$<name>` or `${<name>}`.
-   :type path: `string`
-
-   :return: `path`, having replaced all references to environment variables with
-                their values
-   :rtype: `string`
-*/
-  proc expandVars(path: string): string {
-    var path_p:string = path;
-    var varChars:string = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_";
-    var res:string = "";
-    var ind:int = 1;
-    var pathlen:int = path_p.length;
-    while(ind <= pathlen){
-        var c:string = path_p(ind);
-        if(c == "$" && ind+1<=pathlen){
-            if(path_p(ind+1) == "$"){
-                res = res + c;
-                ind += 1;
-            }
-            else if(path_p(ind+1) == "{"){
-                path_p = path_p((ind+2)..);
-                pathlen = path_p.length;
-                ind = path_p.find("}");
-                if(ind == 0){
-                    res += "${" +path_p;
-                    ind = pathlen;
-                }
-                else{
-                    var env_var:string = path_p(..(ind-1));
-                    var value:string;
-                    var value_c:c_string;
-                    var h:int = sys_getenv(env_var.c_str(), value_c);
-                    if(h != 1){
-                        value = "${" + env_var + "}";
-                    }
-                    else{
-                        value = value_c:string;
-                    }
-                    res += value;
-                }
-            }
-            else{
-                var env_var:string = "";
-                ind += 1;
-                while(ind <= path_p.length && varChars.find(path_p(ind))!= 0){
-                    env_var += path_p(ind);
-                    ind += 1;
-                }
-                var value:string;
-                var value_c:c_string;
-                var h:int = sys_getenv(env_var.c_str(), value_c);
-                if(h != 1){
-                    value = "$" + env_var;
-                }
-                else{
-                    value = value_c:string;
-                }
-                res += value;
-                if(ind <= path_p.length){
-                    ind -= 1;
-                }
-            }
-        }
-        else{
-            res += c;
-        }
-        ind +=1;
-    }
-    return res;
-  }
 }
-

--- a/modules/standard/Path.chpl
+++ b/modules/standard/Path.chpl
@@ -236,12 +236,12 @@ proc dirname(name: string): string {
   return splitPath(name)[1];
 }
 
-/* Expands any environment variables in the path of the form `$<name>` or
-   `${<name>}` into their values.  If <name> does not exist, they are left
+/* Expands any environment variables in the path of the form ``$<name>`` or
+   ``${<name>}`` into their values.  If ``<name>`` does not exist, they are left
    in place. Returns the path which includes these expansions.
 
    :arg path: a string representation of a path, which may or may not include
-                   `$<name>` or `${<name>}`.
+                   ``$<name>`` or ``${<name>}``.
    :type path: `string`
 
    :return: `path`, having replaced all references to environment variables with


### PR DESCRIPTION
I noticed we hadn't added expandVars to the operations categorization quick-link
when looking for a documentation link for the new function.  Rectify that, and
move it so that it is in alphabetical order in the file.

Passed a full paratest with futures, also verified the generated documentation
output