### PR TITLE
Update documentation for accessing methods and fields after a limited use statement

### DIFF
--- a/spec/Statements.tex
+++ b/spec/Statements.tex
@@ -794,9 +794,42 @@ listed visible symbols in the module or enumerated type will be made available
 without prefix.  All visible symbols not provided via these limited use
 statements are still accessible with the module or enumerated type name prefix.
 It is an error to provide a name in a \sntx{limitation-clause} that does not
-exist or is not visible in the respective module or enumerated type.  If an
-\chpl{only} list is left empty or \chpl{except} is followed by $*$ then no
-symbols are made available to the scope without prefix.
+exist or is not visible in the respective module or enumerated type.
+
+If an \chpl{only} list is left empty or \chpl{except} is followed by $*$ then no
+symbols are made available to the scope without prefix.  However, any methods or
+fields defined within a module used in this way will still be accessible on
+instances of the type.  For example:
+
+\begin{chapelexample}{limited-access.chpl}
+\begin{chapel}
+module M1 {
+  record A {
+    var x = 1;
+
+    proc foo() {
+      writeln("In A.foo()");
+    }
+  }
+}
+
+module M2 {
+  proc main() {
+    use M1 only;
+
+    var a = new M1.A(3); // Only accessible via the module prefix
+    writeln(a.x); // Accessible because we have a record instance
+    a.foo(); // Ditto
+  }
+}
+\end{chapel}
+
+will print out
+\begin{chapelprintoutput}{}
+3
+In A.foo()
+\end{chapelprintoutput}
+\end{chapelexample}
 
 Within an \chpl{only} list, a visible symbol from that module may optionally be
 given a new name using the \chpl{as} keyword.  This new name will be usable from

--- a/test/release/examples/primers/modules.chpl
+++ b/test/release/examples/primers/modules.chpl
@@ -58,6 +58,22 @@ module modToUse {
     return a + 3;
   }
 
+  /* ``Rec`` is a top-level record, with a field and a method defined inside
+     it.
+   */
+  record Rec {
+    var field: int;
+
+    proc method1 () {
+      writeln("In Rec.method1()");
+    }
+  }
+
+  /* ``method2`` is a secondary method defined on ``Rec``. */
+  proc Rec.method2() {
+    writeln("In Rec.method2()");
+  }
+
 } // end of modToUse module
 
 /* In the current implementation, private cannot be applied to type
@@ -342,6 +358,17 @@ module MainModule {
       writeln(modToUse.bar);  // Outputs modToUse.bar ('2')
       writeln(Conflict.bar);  // Outputs Conflict.bar ('5')
       // writeln(bar);        // this won't resolve since bar isn't available
+    }
+
+    /* When either of these are present, any instances of classes or records
+       will be able to access their symbols defined in that module.
+    */
+    {
+      use modToUse only;
+      var rec = new modToUse.Rec(4); // Only accessible via the module prefix
+      writeln(rec.field);            // Accessible because we have an instance
+      rec.method1();                 // Ditto to the field case
+      rec.method2();
     }
 
     writeln();

--- a/test/release/examples/primers/modules.good
+++ b/test/release/examples/primers/modules.good
@@ -24,6 +24,9 @@ Limiting a use
 5
 2
 5
+4
+In Rec.method1()
+In Rec.method2()
 
 Application to enums
 blue


### PR DESCRIPTION
In the spec:
Splits the limited use statement information into a separate paragraph, and adds
a code example to demonstrate it.

In the primer:
Adds a record to the module and an example similar to the spec example.

Passed a fresh checkout of the spec and primer tests