### PR TITLE
Minor test cleanups

### DIFF
--- a/test/compflags/lydia/library/noLibFlag/checkDiffPythonModname.prediff
+++ b/test/compflags/lydia/library/noLibFlag/checkDiffPythonModname.prediff
@@ -18,5 +18,6 @@ sed '/^$/d' $2 > $2.tmp
 sed '/^ld: warning/d' $2.tmp > $2
 sed '/from bar.c:[0-9]*/d' $2 > $2.tmp
 sed '/^[ ]*$/d' $2.tmp > $2
+rm $2.tmp
 export PYTHONPATH=lib/
 python3 use_bar.py >> $2

--- a/test/compflags/lydia/library/noLibFlag/pythonCompile.prediff
+++ b/test/compflags/lydia/library/noLibFlag/pythonCompile.prediff
@@ -18,5 +18,6 @@ sed '/^$/d' $2 > $2.tmp
 sed '/^ld: warning/d' $2.tmp > $2
 sed '/from pythonCompile.c:[0-9]*/d' $2 > $2.tmp
 sed '/^[ ]*$/d' $2.tmp > $2
+rm $2.tmp
 export PYTHONPATH=lib/
 python3 use_pythonCompile.py >> $2

--- a/test/compflags/lydia/library/python/PREDIFF
+++ b/test/compflags/lydia/library/python/PREDIFF
@@ -16,3 +16,4 @@ sed '/^[ ]*$/d' $2 > $2.tmp
 # avoid sporadic ld: warning errors (I'm sometimes seeing just that on a line,
 # or just multiple copies of it)
 sed '/^ld: warning/d' $2.tmp > $2
+rm $2.tmp

--- a/test/compflags/lydia/library/python/boolFunctions.prediff
+++ b/test/compflags/lydia/library/python/boolFunctions.prediff
@@ -2,5 +2,6 @@
 
 sed '/from boolFunctions.c:[0-9]*/d' $2 > $2.tmp
 sed '/^ *$/d' $2.tmp > $2
+rm $2.tmp
 export PYTHONPATH=lib/
 python3 use_boolFunctions.py >> $2

--- a/test/compflags/lydia/library/python/checkDiffModname.prediff
+++ b/test/compflags/lydia/library/python/checkDiffModname.prediff
@@ -2,5 +2,6 @@
 
 sed '/from bar.c:[0-9]*/d' $2 > $2.tmp
 sed '/^ *$/d' $2.tmp > $2
+rm $2.tmp
 export PYTHONPATH=lib/
 python3 use_bar.py >> $2

--- a/test/compflags/lydia/library/python/checkExplicitLibname.prediff
+++ b/test/compflags/lydia/library/python/checkExplicitLibname.prediff
@@ -2,5 +2,6 @@
 
 sed '/from checkExplicitLibname.c:[0-9]*/d' $2 > $2.tmp
 sed '/^ *$/d' $2.tmp > $2
+rm $2.tmp
 export PYTHONPATH=lib/
 python3 use_checkExplicitLibname.py >> $2

--- a/test/compflags/lydia/library/python/complexFunctions.prediff
+++ b/test/compflags/lydia/library/python/complexFunctions.prediff
@@ -2,5 +2,6 @@
 
 sed '/from complexFunctions.c:[0-9]*/d' $2 > $2.tmp
 sed '/^ *$/d' $2.tmp > $2
+rm $2.tmp
 export PYTHONPATH=lib/
 python3 use_complexFunctions.py >> $2

--- a/test/compflags/lydia/library/python/intArrays.prediff
+++ b/test/compflags/lydia/library/python/intArrays.prediff
@@ -2,5 +2,6 @@
 
 sed '/from intArrays.c:[0-9]*/d' $2 > $2.tmp
 sed '/^ *$/d' $2.tmp > $2
+rm $2.tmp
 export PYTHONPATH=lib/
 python3 use_intArrays.py >> $2

--- a/test/compflags/lydia/library/python/realArrays.prediff
+++ b/test/compflags/lydia/library/python/realArrays.prediff
@@ -2,5 +2,6 @@
 
 sed '/from realArrays.c:[0-9]*/d' $2 > $2.tmp
 sed '/^ *$/d' $2.tmp > $2
+rm $2.tmp
 export PYTHONPATH=lib/
 python3 use_realArrays.py >> $2

--- a/test/compflags/lydia/library/python/realFunctions.prediff
+++ b/test/compflags/lydia/library/python/realFunctions.prediff
@@ -2,5 +2,6 @@
 
 sed '/from realFunctions.c:[0-9]*/d' $2 > $2.tmp
 sed '/^ *$/d' $2.tmp > $2
+rm $2.tmp
 export PYTHONPATH=lib/
 python3 use_realFunctions.py >> $2

--- a/test/compflags/lydia/library/python/stringFunctions.prediff
+++ b/test/compflags/lydia/library/python/stringFunctions.prediff
@@ -2,5 +2,6 @@
 
 sed '/from stringFunctions.c:[0-9]*/d' $2 > $2.tmp
 sed '/^ *$/d' $2.tmp > $2
+rm $2.tmp
 export PYTHONPATH=lib/
 python3 use_stringFunctions.py >> $2

--- a/test/compflags/lydia/library/python/testing.prediff
+++ b/test/compflags/lydia/library/python/testing.prediff
@@ -2,5 +2,6 @@
 
 sed '/from testing.c:[0-9]*/d' $2 > $2.tmp
 sed '/^ *$/d' $2.tmp > $2
+rm $2.tmp
 export PYTHONPATH=lib/
 python3 use_testing.py >> $2

--- a/test/compflags/lydia/library/python/uintFunctions.prediff
+++ b/test/compflags/lydia/library/python/uintFunctions.prediff
@@ -2,5 +2,6 @@
 
 sed '/from uintFunctions.c:[0-9]*[:]*$/d' $2 > $2.tmp
 sed '/^ *$/d' $2.tmp > $2
+rm $2.tmp
 export PYTHONPATH=lib/
 python3 use_uintFunctions.py >> $2

--- a/util/cron/test-python-modules.bash
+++ b/util/cron/test-python-modules.bash
@@ -10,4 +10,4 @@ export CHPL_LIBMODE=shared
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="python-modules"
 export CHPL_NIGHTLY_TEST_DIRS="compflags/lydia/library/python compflags/lydia/library/noLibFlag"
 
-$CWD/nightly -cron
+$CWD/nightly -cron -futures


### PR DESCRIPTION
Include futures in the directories run with the nightly python tests and
clean up the leftover .tmp.tmp files from my sed commands in the
python test prediffs

Verified that the .tmp.tmp files were cleaned up locally and in a fresh
checkout, and that running the cron script resulted in the futures
executing as well