### PR TITLE
Add a note about vars/fields with generic declared types

### DIFF
--- a/spec/Variables.tex
+++ b/spec/Variables.tex
@@ -85,7 +85,11 @@ The \sntx{type-part} of a variable declaration specifies the type of
 the variable.  It is optional if the \sntx{initialization-part} is
 specified.  If the \sntx{type-part} is omitted, the type of the
 variable is inferred using local type inference described
-in~\rsec{Local_Type_Inference}.
+in~\rsec{Local_Type_Inference}. If the \sntx{type-part} refers
+to a generic type, then an \sntx{initialization-part} is required
+and will be used to determine the type of the variable. In this event,
+the compiler will fail with an error if the \sntx{initialization-part} is
+not coercible to an instantiation of the generic type.
 
 The \sntx{initialization-part} of a variable declaration specifies an
 initial expression to assign to the variable.  If


### PR DESCRIPTION
Relates to PRs #9489 #9356 #9355

Note that record/class fields are specified as variable declarations,
so this change should be sufficient.

Reviewed by @vasslitvinov - thanks!