### PR TITLE
Squash undecorated 'new' warnings for this test

### DIFF
--- a/test/studies/hpcc/CommDiags/stream-ep_commDiags.compopts
+++ b/test/studies/hpcc/CommDiags/stream-ep_commDiags.compopts
@@ -1,1 +1,1 @@
---main-module streamEP
+--main-module streamEP --no-warnings


### PR DESCRIPTION
In updating tests to use 'new C()' rather than 'new * C()' yesterday,
I failed to note that a file I was modifying is used by this test in
another directory that's only tested for CHPL_COMM!=none.  The result
was that it started printing out the undecorated warning messages.
Here, I'm adding --no-warnings to the test to squash them.