### PR TITLE
Include defaults in printchplenv --all output, as intended

### DIFF
--- a/util/printchplenv
+++ b/util/printchplenv
@@ -373,7 +373,7 @@ def main():
 
     # Handle --all flag
     if options.all:
-        options.content.extend(['runtime', 'launcher', 'compiler'])
+        options.content.extend(['runtime', 'launcher', 'compiler', 'default'])
 
     # Handle --tidy / --no-tidy flags
     if options.tidy:


### PR DESCRIPTION
The documentation for `printchplenv --help` says:

```
   --all         Shortcut for --compiler --runtime --launcher, includes defaults
```

However, `--all` did not actually include defaults. This bug resulted in `CHPL_NETWORK_ATOMICS` and `CHPL_GMP` (after #8944) being omitted from `printchplenv --all` when it was expected.

Resolves #10892

**Testing**

- [x] full linux64 testing