### PR TITLE
Add a note about explicit array return types and omitting domains/element types

### DIFF
--- a/spec/Arrays.tex
+++ b/spec/Arrays.tex
@@ -686,6 +686,9 @@ domain map.
 Arrays return by value by default. The \chpl{ref} and \chpl{const ref}
 return intents can be used to return a reference to an array.
 
+Similarly to array arguments, the element type and/or domain of an array return
+type can be omitted.
+
 \subsection{Array Promotion of Scalar Functions}
 \label{Array_Promotion_of_Scalar_Functions}
 \index{arrays!promotion}


### PR DESCRIPTION
This was the only place where array return types are mentioned.  I think it
isn't necessary to add this information to places that don't talk about array
return types at all, since the behavior in this case seems "expected" to me, but
others are welcome to disagree.

Spot-checked the generated spec.  Since no example was added, I don't feel the
need to do further testing.