### PR TITLE
rename the spec section Where Expressions -> Where Clauses

### DIFF
--- a/spec/Generics.tex
+++ b/spec/Generics.tex
@@ -965,7 +965,7 @@ generic method to particular cases. Unlike the previous two cases, a
 where clause can be used to declare special implementation of a function
 that works with some set of types - in other words, the special
 implementation can still be a generic function.  See also
-\rsec{Where_Expressions}.
+\rsec{Where_Clauses}.
 
 \section{Example: A Generic Stack}
 \label{Example_Generic_Stack}

--- a/spec/Procedures.tex
+++ b/spec/Procedures.tex
@@ -222,7 +222,7 @@ The \sntx{return-type} is optional and is discussed in~\rsec{Return_Types}.
 A type function may not specify a return type.
 
 The \sntx{where-clause} is optional and is discussed
-in~\rsec{Where_Expressions}.
+in~\rsec{Where_Clauses}.
 
 Function and operator overloading is supported in Chapel and is
 discussed in~\rsec{Function_Overloading}.
@@ -1001,10 +1001,9 @@ is allowed between every other type and that type, and that type becomes the
 inferred return type.
 If the above requirements are not satisfied, it is an error.
 
-\section{Where Expressions}
-\label{Where_Expressions}
+\section{Where Clauses}
+\label{Where_Clauses}
 \index{where@\chpl{where}}
-\index{expressions!where@\chpl{where}}
 \index{functions!where@\chpl{where}}
 
 The list of function candidates can be constrained by {\em where clauses}.  A


### PR DESCRIPTION
I just noticed the title and found it odd because we are
pretty consistent about calling them where clauses.