### PR TITLE
Add override keyword to spec

### DIFF
--- a/spec/Classes.tex
+++ b/spec/Classes.tex
@@ -310,7 +310,7 @@ particular, dynamic dispatch will be used when the method receiver has a
 static type of the base class but refers to an instance of a derived
 class type.
 
-In order to have identical signature, two methods must have the same the
+In order to have identical signatures, two methods must have the same the
 names, intents, types, and order of formal arguments. The return type of
 the overriding method must either be the same as the return type of the base
 class's method or be a subclass of the base class method's return
@@ -319,7 +319,7 @@ type.
 Methods that override a base class method must be marked with the
 \chpl{override} keyword in the \sntx{procedure-kind}. Additionally,
 methods marked with \chpl{override} but for which there is no parent class
-method with an identical signature will cause an error.
+method with an identical signature will result in a compiler error.
 
 \begin{rationale}
   This feature is designed to help avoid cases where class authors

--- a/spec/Classes.tex
+++ b/spec/Classes.tex
@@ -309,10 +309,13 @@ base class's method.  Such a method is a candidate for dynamic
 dispatch in the event that a variable that has the base class type
 references an object that has the derived class type.
 
-The identical signature requires that the names, types, and order of
+The identical signature requires that the names, intents, types, and order of
 the formal arguments be identical. The return type of the overriding
 method must be the same as the return type of the base class's method,
 or must be a subclass of the base class method's return type.
+
+Methods that override a base class method must be marked with the
+\chpl{override} keyword in the \sntx{linkage-specifier}.
 
 Methods without parentheses are not candidates for dynamic dispatch.
 \begin{rationale}

--- a/spec/Classes.tex
+++ b/spec/Classes.tex
@@ -303,19 +303,31 @@ defined at this time.
 \index{dynamic dispatch}
 \index{methods!base class!overriding}
 
-If a method in a derived class is declared with a
-signature identical to that of a method in a base class, then it is said to override the
-base class's method.  Such a method is a candidate for dynamic
-dispatch in the event that a variable that has the base class type
-references an object that has the derived class type.
+If a method in a derived class is declared with a signature identical to
+that of a method in a base class, then it is said to override the base
+class's method. Such methods are considered for dynamic dispatch.  In
+particular, dynamic dispatch will be used when the method receiver has a
+static type of the base class but refers to an instance of a derived
+class type.
 
-The identical signature requires that the names, intents, types, and order of
-the formal arguments be identical. The return type of the overriding
-method must be the same as the return type of the base class's method,
-or must be a subclass of the base class method's return type.
+In order to have identical signature, two methods must have the same the
+names, intents, types, and order of formal arguments. The return type of
+the overriding method must either be the same as the return type of the base
+class's method or be a subclass of the base class method's return
+type.
 
 Methods that override a base class method must be marked with the
-\chpl{override} keyword in the \sntx{linkage-specifier}.
+\chpl{override} keyword in the \sntx{procedure-kind}. Additionally,
+methods marked with \chpl{override} but for which there is no parent class
+method with an identical signature will cause an error.
+
+\begin{rationale}
+  This feature is designed to help avoid cases where class authors
+  accidentally override a method without knowing it; or fail to override
+  a method that they intended to due to not meeting the identical
+  signature condition.
+\end{rationale}
+
 
 Methods without parentheses are not candidates for dynamic dispatch.
 \begin{rationale}

--- a/spec/Methods.tex
+++ b/spec/Methods.tex
@@ -12,7 +12,7 @@ expression known as the \emph{receiver}.
 Methods are declared with the following syntax:
 \begin{syntax}
 method-declaration-statement:
-  linkage-specifier[OPT] proc-or-iter this-intent[OPT] type-binding[OPT] function-name argument-list[OPT] 
+  procedure-kind[OPT] proc-or-iter this-intent[OPT] type-binding[OPT] function-name argument-list[OPT]
     return-intent[OPT] return-type[OPT] where-clause[OPT] function-body
 
 proc-or-iter:

--- a/spec/Procedures.tex
+++ b/spec/Procedures.tex
@@ -122,6 +122,9 @@ procedure-declaration-statement:
 
 linkage-specifier:
   `inline'
+  `export'
+  `extern'
+  `override'
 
 function-name:
   identifier

--- a/spec/Procedures.tex
+++ b/spec/Procedures.tex
@@ -117,10 +117,10 @@ Calls to methods are defined in Section~\rsec{Class_Method_Calls}.
 Procedures are defined with the following syntax:
 \begin{syntax}
 procedure-declaration-statement:
-  privacy-specifier[OPT] linkage-specifier[OPT] `proc' function-name argument-list[OPT] return-intent[OPT] return-type[OPT] where-clause[OPT]
+  privacy-specifier[OPT] procedure-kind[OPT] `proc' function-name argument-list[OPT] return-intent[OPT] return-type[OPT] where-clause[OPT]
     function-body
 
-linkage-specifier:
+procedure-kind:
   `inline'
   `export'
   `extern'


### PR DESCRIPTION
* linkage-specifier now includes override, extern, export
* note that intents much match in overriden methods
* note that override keyword is now required on overriding methods

Relevant to PRs #10752 #9724.

Reviewed by @bradcray - thanks!