### PR TITLE
Fix performance regression in pop_front/pop_back from PR #10793

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -2912,7 +2912,7 @@ module ChapelArray {
             writeln("pop_back reallocate: ",
                     oldRng, " => ", nextAllocRange,
                     " (", newRange, ")");
-          this._value.dsiReallocate((nextAllocRange,), (newRange,));
+          this._value.dsiReallocate(nextAllocRange, newRange);
           // note: dsiReallocate sets _value.dataAllocRange = nextAllocRange
         }
         this.domain.setIndices((newRange,));
@@ -3007,7 +3007,7 @@ module ChapelArray {
             writeln("pop_front reallocate: ",
                     oldRng, " => ", nextAllocRange,
                     " (", newRange, ")");
-          this._value.dsiReallocate((nextAllocRange,), (newRange,));
+          this._value.dsiReallocate(nextAllocRange, newRange);
           // note: dsiReallocate sets _value.dataAllocRange = nextAllocRange
         }
         this.domain.setIndices((newRange,));
@@ -3108,7 +3108,7 @@ module ChapelArray {
         }
         if newRange.length < (this._value.dataAllocRange.length / (arrayAsVecGrowthFactor*arrayAsVecGrowthFactor)):int {
           const nextAllocRange = resizeAllocRange(newRange, grow=-1);
-          this._value.dsiReallocate((nextAllocRange,), (newRange,));
+          this._value.dsiReallocate(nextAllocRange, newRange);
           // note: dsiReallocate sets _value.dataAllocRange = nextAllocRange
         }
         this.domain.setIndices((newRange,));
@@ -3143,7 +3143,7 @@ module ChapelArray {
         }
         if newRange.length < (this._value.dataAllocRange.length / (arrayAsVecGrowthFactor*arrayAsVecGrowthFactor)):int {
           const nextAllocRange = resizeAllocRange(newRange, grow=-1);
-          this._value.dsiReallocate((nextAllocRange,), (newRange,));
+          this._value.dsiReallocate(nextAllocRange, newRange);
           // note: dsiReallocate sets _value.dataAllocRange = nextAllocRange
         }
         this.domain.setIndices((newRange,));

--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -779,7 +779,7 @@ module ChapelDistribution {
     // the matching tuple of ranges.
 
     // Q. Should this pass in a BaseRectangularDom or ranges?
-    proc dsiReallocate(allocBounds:rank*range(idxType,BoundedRangeType.bounded,stridable)) {
+    proc dsiReallocate(bounds: rank*range(idxType,BoundedRangeType.bounded,stridable)) {
       halt("reallocating not supported for this array type");
     }
 

--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -779,17 +779,17 @@ module ChapelDistribution {
     // the matching tuple of ranges.
 
     // Q. Should this pass in a BaseRectangularDom or ranges?
-    proc dsiReallocate(bounds:rank*range(idxType,BoundedRangeType.bounded,stridable)) {
+    proc dsiReallocate(allocBounds:rank*range(idxType,BoundedRangeType.bounded,stridable)) {
       halt("reallocating not supported for this array type");
     }
 
-    proc dsiReallocate(allocBounds:rank*range(idxType,
-                                              BoundedRangeType.bounded,
-                                              stridable),
-                       arrayBounds:rank*range(idxType,
-                                              BoundedRangeType.bounded,
-                                              stridable)) {
-      halt("reallocating not supported for this array type");
+    // This dsiReallocate version is used by array vector operations, which
+    // are supported on 1-D arrays only, so can work directly with ranges
+    // instead of requiring tuples of ranges.  They require two ranges
+    // because the allocated size and logical size can differ.
+    proc dsiReallocate(allocBound: range(idxType, BoundedRangeType.bounded, stridable),
+                       arrayBound: range(idxType, BoundedRangeType.bounded, stridable)) where rank == 1 {
+       halt("reallocating not supported for this array type");
     }
 
     override proc dsiPostReallocate() {

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1328,13 +1328,12 @@ module DefaultRectangular {
     }
 
 
-    // Reallocate the array to have space for elements specified by
-    // `allocBounds` while maintaining the elements specified by `arrayBounds`
-    override proc dsiReallocate(allocBounds:rank*range(idxType,
-                                                       BoundedRangeType.bounded,
-                                                       stridable)) {
+    // Reallocate the array to have space for elements specified by `bounds`
+    override proc dsiReallocate(bounds: rank*range(idxType,
+                                                   BoundedRangeType.bounded,
+                                                   stridable)) {
       on this {
-        const allocD = {(...allocBounds)};
+        const allocD = {(...bounds)};
 
         var copy = new unmanaged DefaultRectangularArr(eltType=eltType,
                                             rank=rank,

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1285,29 +1285,64 @@ module DefaultRectangular {
       }
     }
 
-    override proc dsiReallocate(bounds:rank*range(idxType,BoundedRangeType.bounded,stridable)) {
-      dsiReallocate(bounds, bounds);
+    override proc dsiReallocate(allocBound: range(idxType,
+                                                  BoundedRangeType.bounded,
+                                                  stridable),
+                                arrayBound: range(idxType,
+                                                  BoundedRangeType.bounded,
+                                                  stridable)) where rank == 1 {
+      on this {
+        const allocD = {allocBound};
+        var copy = new unmanaged DefaultRectangularArr(eltType=eltType,
+                                                       rank=rank,
+                                                       idxType=idxType,
+                                                       stridable=allocD._value.stridable,
+                                                       dom=allocD._value);
+
+        forall i in arrayBound(dom.ranges(1)) do
+          copy.dsiAccess(i) = dsiAccess(i);
+
+        off = copy.off;
+        blk = copy.blk;
+        str = copy.str;
+        factoredOffs = copy.factoredOffs;
+
+        dsiDestroyArr();
+        data = copy.data;
+        // We can't call initShiftedData here because the new domain
+        // has not yet been updated (this is called from within the
+        // = function for domains.
+        if earlyShiftData && !allocD._value.stridable {
+          // Lydia note 11/04/15: a question was raised as to whether this
+          // check on numIndices added any value.  Performance results
+          // from removing this line seemed inconclusive, which may indicate
+          // that the check is not necessary, but it seemed like unnecessary
+          // work for something with no immediate reward.
+          if allocD.numIndices > 0 {
+            shiftedData = copy.shiftedData;
+          }
+        }
+        dataAllocRange = copy.dataAllocRange;
+        delete copy;
+      }
     }
+
 
     // Reallocate the array to have space for elements specified by
     // `allocBounds` while maintaining the elements specified by `arrayBounds`
     override proc dsiReallocate(allocBounds:rank*range(idxType,
                                                        BoundedRangeType.bounded,
-                                                       stridable),
-                                arrayBounds:rank*range(idxType,
-                                                       BoundedRangeType.bounded,
                                                        stridable)) {
-
       on this {
-        var allocD = {(...allocBounds)};
-        var arrayD = {(...arrayBounds)};
+        const allocD = {(...allocBounds)};
+
         var copy = new unmanaged DefaultRectangularArr(eltType=eltType,
                                             rank=rank,
                                             idxType=idxType,
                                             stridable=allocD._value.stridable,
                                             dom=allocD._value);
 
-        forall i in arrayD((...dom.ranges)) do
+        forall i in allocD((...dom.ranges)) do
           copy.dsiAccess(i) = dsiAccess(i);
 
         off = copy.off;


### PR DESCRIPTION
PR #10793 fixed a memory leak by tracking both the allocated memory and
the logical array size within dsiReallocate.  It did this by creating an
extra domain from an extra tuple of ranges for the logical size.

This extra domain added some performance overhead when reallocating arrays
for pop_front and pop_back.  Remove the overload of dsiReallocate that was
added in #10793.  Add a new overload (for rank==1 only) that has range
arguments instead of tuples of ranges, and avoids creating the extra domain.

This should fix the performance regression while continuing to avoid the
memory leak.