### PR TITLE
When compileline fails, only error out in Qthreads config step.

### DIFF
--- a/third-party/qthread/Makefile
+++ b/third-party/qthread/Makefile
@@ -45,6 +45,7 @@ ifeq (, $(call isTrue, $(CHPL_QTHREAD_NO_CHPL_ALLOC)))
   CFLAGS_NEEDS_RT_INCLUDES = y
 endif
 
+FAILBUILD=
 ifeq ($(CFLAGS_NEEDS_RT_INCLUDES), y)
   # When building the Chapel allocator file we need all the Chapel runtime
   # defs and include directories, plus the third-party include dirs other
@@ -56,16 +57,17 @@ ifeq ($(CFLAGS_NEEDS_RT_INCLUDES), y)
     $(shell $(CHPL_MAKE_HOME)/util/config/compileline --includes-and-defines \
             || echo compilelineFAILURE)
   ifneq (, $(findstring compilelineFAILURE,$(INCS_DEFS)))
-    $(error compileline failed!)
+    FAILBUILD=y
+  else
+    INCS_DEFS_PROCESSED := \
+      $(shell echo $(INCS_DEFS) \
+              | tr ' ' '\n' \
+              | grep '^-DCHPL\|/runtime//*include\|/third-party/.*/install' \
+              | grep -v '/third-party/qthread/install' \
+              | tr '\n' ' ' \
+              | sed 's/ $$//')
+    CFLAGS += $(INCS_DEFS_PROCESSED)
   endif
-  INCS_DEFS_PROCESSED := \
-    $(shell echo $(INCS_DEFS) \
-            | tr ' ' '\n' \
-            | grep '^-DCHPL\|/runtime//*include\|/third-party/.*/install' \
-            | grep -v '/third-party/qthread/install' \
-            | tr '\n' ' ' \
-            | sed 's/ $$//')
-  CFLAGS += $(INCS_DEFS_PROCESSED)
 endif
 
 # enable oversubscription for testing
@@ -133,6 +135,8 @@ clobber: FORCE
 
 
 qthread-config: FORCE
+	@if [ -n "$(FAILBUILD)" ]; then echo 'compileline failed!'; false; fi
+
 #
 # These first few lines touch a bunch of autoconf-oriented files in a
 # certain order to prevent autoconf from running again; otherwise, we

--- a/third-party/qthread/Makefile
+++ b/third-party/qthread/Makefile
@@ -47,14 +47,21 @@ endif
 
 FAILBUILD=
 ifeq ($(CFLAGS_NEEDS_RT_INCLUDES), y)
+  #
   # When building the Chapel allocator file we need all the Chapel runtime
   # defs and include directories, plus the third-party include dirs other
   # than that for Qthreads itself (since we're building it).  Notably, we
   # do not want -DNDEBUG; if we have that set when building Qthreads it
   # seems to cause Chapel programs built with the result to hang during
   # exit when shutting down Qthreads.
+  #
+  # Throw COMPILELINE_STDERR_REDIRECT= if compileline failure is reported
+  # and you want to see the stderr from that.
+  #
+  COMPILELINE_STDERR_REDIRECT=2> /dev/null
   INCS_DEFS := \
     $(shell $(CHPL_MAKE_HOME)/util/config/compileline --includes-and-defines \
+               $(COMPILELINE_STDERR_REDIRECT) \
             || echo compilelineFAILURE)
   ifneq (, $(findstring compilelineFAILURE,$(INCS_DEFS)))
     FAILBUILD=y

--- a/third-party/qthread/Makefile
+++ b/third-party/qthread/Makefile
@@ -135,7 +135,7 @@ clobber: FORCE
 
 
 qthread-config: FORCE
-	@if [ -n "$(FAILBUILD)" ]; then echo 'compileline failed!'; false; fi
+	@test -z "$(FAILBUILD)" || ( echo 'compileline failed!' && false )
 
 #
 # These first few lines touch a bunch of autoconf-oriented files in a


### PR DESCRIPTION
(Co-developed with @ronawho .)

Our solution for making it more obvious when the compileline utility had
failed during Qthreads builds had a flaw: it would halt the make not
only for builds but indeed for any target the Makefile was asked to
"make", including clean and clobber.  Since the third-party ordering is
such that GASNet is cleaned/clobbered before Qthreads is, this halted
Qthreads clean/clobber prematurely.

Here, restructure so that when compileline fails, during make's first
pass over the Makefile when it's processing make syntax, we just leave a
token in a make variable.  Then later, during make's second pass over
the Makefile when it's processing rules and recipes, check that make
variable in the QThreads configuration recipe and if it's set, error
out at that point.