### PR TITLE
Rename return-intent/return-type to yield-intent/yield-type for iterators

### DIFF
--- a/spec/Iterators.tex
+++ b/spec/Iterators.tex
@@ -52,6 +52,10 @@ yielded, not the type returned (see previous bullet).  However, they are
 syntactically the same as a \sntx{return-intent} and a \sntx{return-type}.
 \end{itemize}
 
+\begin{openissue}
+Iterators that yield types or params are not currently supported.
+\end{openissue}
+
 \section{The Yield Statement}
 \label{The_Yield_Statement}
 \index{yield@\chpl{yield}}

--- a/spec/Iterators.tex
+++ b/spec/Iterators.tex
@@ -18,11 +18,21 @@ The syntax to declare an iterator is given
 by:
 \begin{syntax}
 iterator-declaration-statement:
-  privacy-specifier[OPT] `iter' iterator-name argument-list[OPT] return-intent[OPT] return-type[OPT] where-clause[OPT]
+  privacy-specifier[OPT] `iter' iterator-name argument-list[OPT] yield-intent[OPT] yield-type[OPT] where-clause[OPT]
   iterator-body
 
 iterator-name:
   identifier
+
+yield-intent:
+  `const'
+  `const ref'
+  `ref'
+  `param'
+  `type'
+
+yield-type:
+  : type-specifier
 
 iterator-body:
   block-statement
@@ -37,6 +47,9 @@ some key differences:
 \item \chpl{yield} statements may appear in the body of an iterator, but not in
 a procedure.
 \item A \chpl{return} statement in the body of an iterator is not allowed to have an expression.
+\item The intent and type specified after the argument list refer to the type
+yielded, not the type returned (see previous bullet).  However, they are
+syntactically the same as a \sntx{return-intent} and a \sntx{return-type}.
 \end{itemize}
 
 \section{The Yield Statement}


### PR DESCRIPTION
The spec repeatedly says you can't return anything from an iterator, but the
syntax for the declaration statement refers to return types and return intents.
Update the syntax to add a "yield-intent" and "yield-type" and mention that they
are syntactically identical to the return intent and return type in procedures,
though they refer to what is yielded from the iterator.

Also note that type and param yields are not supported at the beginning of that
section (it was already noted in the Procedures chapter)

I had to add a syntax definition for these new terms or LaTeX would complain.