### PR TITLE
Add mason to "chapel master" Dockerfiles

### DIFF
--- a/util/dockerfiles/master/Dockerfile
+++ b/util/dockerfiles/master/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:9.4
+FROM debian:9.5
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     wget \
@@ -18,6 +18,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     mawk \
     file \
     pkg-config \
+    git \
     && rm -rf /var/lib/apt/lists/*
 
 ENV CHPL_VERSION master
@@ -28,12 +29,17 @@ RUN mkdir -p /opt/chapel \
     && wget -q -O - https://github.com/chapel-lang/chapel/archive/master.tar.gz | tar -xzC /opt/chapel --transform 's/chapel-//' \
     && make -C $CHPL_HOME \
     && make -C $CHPL_HOME chpldoc \
-    && make -C $CHPL_HOME test-venv 
+    && make -C $CHPL_HOME test-venv \
+    && make -C $CHPL_HOME mason
 
 # Configure locale
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
     echo 'LANG="en_US.UTF-8"'>/etc/default/locale && \
     dpkg-reconfigure --frontend=noninteractive locales && \
     update-locale LANG=en_US.UTF-8
+
+# Configure dummy git user
+RUN git config --global user.email "noreply@example.com" && \
+    git config --global user.name  "Chapel user"
 
 ENV PATH $PATH:$CHPL_HOME/bin/linux64:$CHPL_HOME/util

--- a/util/dockerfiles/master/gasnet/Dockerfile
+++ b/util/dockerfiles/master/gasnet/Dockerfile
@@ -4,6 +4,7 @@ ENV CHPL_COMM gasnet
 
 RUN make -C $CHPL_HOME \
     && make -C $CHPL_HOME chpldoc \
-    && make -C $CHPL_HOME test-venv
+    && make -C $CHPL_HOME test-venv \
+    && make -C $CHPL_HOME mason
 
 ENV GASNET_SPAWNFN L


### PR DESCRIPTION
These updates were developed in preparation for Chapel release 1.18.0

- Updates debian version to 9.5.
- Builds Chapel mason
- Apt-install a git client and configures a dummy git user, so that mason unit tests work.
- Sets default Linux locale to LANG=en_US.UTF-8