### PR TITLE
Updates top-level advisory Dockerfiles ahead of Chapel release 1.18.0.

### DIFF
--- a/util/dockerfiles/Dockerfile
+++ b/util/dockerfiles/Dockerfile
@@ -2,8 +2,8 @@ FROM debian:stretch
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     wget \
-    curl \
     ca-certificates \
+    curl \
     gcc \
     g++ \
     perl \
@@ -12,22 +12,33 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python-setuptools \
     libgmp10 \
     libgmp-dev \
+    locales \
     bash \
     make \
     mawk \
     file \
     pkg-config \
+    git \
     && rm -rf /var/lib/apt/lists/*
 
-ENV CHPL_VERSION 1.17.1
+ENV CHPL_VERSION master
 ENV CHPL_HOME    /opt/chapel/$CHPL_VERSION
 ENV CHPL_GMP     system
 
 RUN mkdir -p /opt/chapel \
-    && wget -q -O - https://github.com/chapel-lang/chapel/releases/download/$CHPL_VERSION/chapel-$CHPL_VERSION.tar.gz | tar -xzC /opt/chapel --transform 's/chapel-//' \
+    && wget -q -O - https://github.com/chapel-lang/chapel/archive/$CHPL_VERSION.tar.gz | tar -xzC /opt/chapel --transform 's/chapel-//' \
     && make -C $CHPL_HOME \
-    && make -C $CHPL_HOME chpldoc \
-    && make -C $CHPL_HOME test-venv \
+    && make -C $CHPL_HOME chpldoc test-venv mason \
     && make -C $CHPL_HOME cleanall
+
+# Configure locale
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    echo 'LANG="en_US.UTF-8"'>/etc/default/locale && \
+    dpkg-reconfigure --frontend=noninteractive locales && \
+    update-locale LANG=en_US.UTF-8
+
+# Configure dummy git user
+RUN git config --global user.email "noreply@example.com" && \
+    git config --global user.name  "Chapel user"
 
 ENV PATH $PATH:$CHPL_HOME/bin/linux64:$CHPL_HOME/util

--- a/util/dockerfiles/gasnet/Dockerfile
+++ b/util/dockerfiles/gasnet/Dockerfile
@@ -1,10 +1,9 @@
-FROM chapel/chapel:latest
+FROM chapel/chapel-master:latest
 
 ENV CHPL_COMM gasnet
 
 RUN make -C $CHPL_HOME \
-    && make -C $CHPL_HOME chpldoc \
-    && make -C $CHPL_HOME test-venv \
+    && make -C $CHPL_HOME chpldoc test-venv mason \
     && make -C $CHPL_HOME cleanall
 
 ENV GASNET_SPAWNFN L


### PR DESCRIPTION
- Pulls source (as tar archive) from Github master branch instead of Chapel release tarball.
- Builds Chapel mason
- Apt-install a git client and configures a dummy git user, so that mason unit tests work.
- Sets default Linux locale to LANG=en_US.UTF-8
