### PR TITLE
Convert other perf test chameneos variants over to managed classes

### DIFF
--- a/test/studies/shootout/chameneos-redux/elliot/COMPOPTS
+++ b/test/studies/shootout/chameneos-redux/elliot/COMPOPTS
@@ -1,0 +1,1 @@
+--no-warnings

--- a/test/studies/shootout/chameneos-redux/elliot/chameneosredux-ejr.chpl
+++ b/test/studies/shootout/chameneos-redux/elliot/chameneosredux-ejr.chpl
@@ -51,14 +51,14 @@ record Population {
   // a domain and array representing the chameneos in this population
   //
   const chamSpace: domain(1),
-        chameneos: [chamSpace] unmanaged Chameneos;
+        chameneos: [chamSpace] owned Chameneos;
 
   //
   // construct the population in terms of an array of colors passed in
   //
   proc init(colors: [] Color) {
     chamSpace = colors.domain;
-    chameneos = new unmanaged Chameneos(1..colors.size, colors);
+    chameneos = new owned Chameneos(1..colors.size, colors);
   }
 
   //
@@ -66,12 +66,10 @@ record Population {
   // place, and then creating per-chameneos tasks to have meetings.
   //
   proc holdMeetings(numMeetings) {
-    const place = new unmanaged MeetingPlace(numMeetings);
+    const place = new MeetingPlace(numMeetings);
 
     coforall c in chameneos do           // create a task per chameneos
       c.haveMeetings(place, chameneos);
-
-    delete place;
   }
 
   //
@@ -91,14 +89,6 @@ record Population {
 
     spellInt(+ reduce chameneos.meetings);
     writeln();
-  }
-
-  //
-  // Delete the chameneos objects.
-  //
-  proc deinit() {
-    for c in chameneos do
-      delete c;
   }
 }
 

--- a/test/studies/shootout/chameneos-redux/hannah/COMPOPTS
+++ b/test/studies/shootout/chameneos-redux/hannah/COMPOPTS
@@ -1,0 +1,1 @@
+--no-warnings

--- a/test/studies/shootout/chameneos-redux/hannah/chameneos-redux-cas.chpl
+++ b/test/studies/shootout/chameneos-redux/hannah/chameneos-redux-cas.chpl
@@ -86,9 +86,9 @@ class Chameneos {
      with another Chameneos.  If it does, it will get the other's color and
      use this color and its own to compute the color both will have after the
      meeting has ended, setting both of their colors to this value. */
-  proc start(population : [] unmanaged Chameneos, meetingPlace: unmanaged MeetingPlace) {
+  proc start(population : [] owned Chameneos, meetingPlace: MeetingPlace) {
     var stateTemp : uint(32);
-    var peer : unmanaged Chameneos;
+    var peer : Chameneos;
     var peer_idx : uint(32);
     var xchg : uint(32);
     var is_same : int;
@@ -156,15 +156,15 @@ proc populate (size : int(32)) {
                             Color.yellow, Color.blue, Color.red, Color.yellow,
                             Color.red, Color.blue);
   const D : domain(1, int(32)) = {1..size};
-  var population : [D] unmanaged Chameneos;
+  var population : [D] owned Chameneos;
 
   if (size == 10) {
     for i in D {
-      population(i) = new unmanaged Chameneos(i, colorsDefault10(i));
+      population(i) = new owned Chameneos(i, colorsDefault10(i));
     }
   } else {
     for i in D {
-      population(i) = new unmanaged Chameneos(i, ((i-1) % 3):Color);
+      population(i) = new owned Chameneos(i, ((i-1) % 3):Color);
     }
   }
   return population;
@@ -175,7 +175,7 @@ proc populate (size : int(32)) {
    met another Chameneos, spells out the number of times it met with itself,
    then spells out the total number of times all the Chameneos met
    another Chameneos. */
-proc run(population : [] unmanaged Chameneos, meetingPlace : unmanaged MeetingPlace) {
+proc run(population : [] owned Chameneos, meetingPlace : MeetingPlace) {
   for i in population {
     write(" ", i.color);
   }
@@ -187,7 +187,7 @@ proc run(population : [] unmanaged Chameneos, meetingPlace : unmanaged MeetingPl
   meetingPlace.reset();
 }
 
-proc runQuiet(population : [] unmanaged Chameneos, meetingPlace : unmanaged MeetingPlace) {
+proc runQuiet(population : [] owned Chameneos, meetingPlace : MeetingPlace) {
   coforall i in population {
     i.start(population, meetingPlace);
   }
@@ -210,7 +210,7 @@ proc runQuiet(population : [] unmanaged Chameneos, meetingPlace : unmanaged Meet
   writeln();
 }
 
-proc printInfo(population : [] unmanaged Chameneos) {
+proc printInfo(population : [] owned Chameneos) {
   for i in population {
     write(i.meetings);
     spellInt(i.meetingsWithSelf);
@@ -235,7 +235,7 @@ proc main() {
   } else  {
     printColorChanges();
 
-    const forest : unmanaged MeetingPlace = new unmanaged MeetingPlace();
+    const forest : MeetingPlace = new MeetingPlace();
 
     const population1 = populate(numChameneos1);
     const population2 = populate(numChameneos2);
@@ -250,11 +250,6 @@ proc main() {
       runQuiet(population1, forest);
       runQuiet(population2, forest);
     }
-
-    for c in population2 do delete c;
-    for c in population1 do delete c;
-
-    delete forest;
   }
 }
 

--- a/test/studies/shootout/chameneos-redux/lydia/COMPOPTS
+++ b/test/studies/shootout/chameneos-redux/lydia/COMPOPTS
@@ -1,0 +1,1 @@
+--no-warnings

--- a/test/studies/shootout/chameneos-redux/lydia/chameneos-redux-lydia.chpl
+++ b/test/studies/shootout/chameneos-redux/lydia/chameneos-redux-lydia.chpl
@@ -86,7 +86,7 @@ class Chameneos {
      with another Chameneos.  If it does, it will get the other's color and
      use this color and its own to compute the color both will have after the
      meeting has ended, setting both of their colors to this value. */
-  proc start(population : [] unmanaged Chameneos, meetingPlace: unmanaged MeetingPlace) {
+  proc start(population : [] owned Chameneos, meetingPlace: MeetingPlace) {
     var stateTemp, peer_idx, xchg : int;
 
     stateTemp = meetingPlace.state.read(memory_order_acquire);
@@ -119,8 +119,8 @@ class Chameneos {
 
   /* Given the id of its peer, finds and updates the data of its peer and
      itself */
-  proc runMeeting (population : [] unmanaged Chameneos, peer_idx) {
-    var peer : unmanaged Chameneos;
+  proc runMeeting (population : [] owned Chameneos, peer_idx) {
+    var peer : Chameneos;
     var newColor : Color;
     var is_same : int;
     if (id == peer_idx) {
@@ -179,15 +179,15 @@ proc populate (size) {
                             Color.yellow, Color.blue, Color.red, Color.yellow,
                             Color.red, Color.blue);
   const D : domain(1, int) = {1..size};
-  var population : [D] unmanaged Chameneos;
+  var population : [D] owned Chameneos;
 
   if (size == 10) {
     for i in D {
-      population(i) = new unmanaged Chameneos(i, colorsDefault10(i));
+      population(i) = new owned Chameneos(i, colorsDefault10(i));
     }
   } else {
     for i in D {
-      population(i) = new unmanaged Chameneos(i, ((i-1) % numColors):Color);
+      population(i) = new owned Chameneos(i, ((i-1) % numColors):Color);
     }
   }
   return population;
@@ -198,7 +198,7 @@ proc populate (size) {
    met another Chameneos, spells out the number of times it met with itself,
    then spells out the total number of times all the Chameneos met
    another Chameneos. */
-proc run(population : [] unmanaged Chameneos, meetingPlace : unmanaged MeetingPlace) {
+proc run(population : [] owned Chameneos, meetingPlace : MeetingPlace) {
   for i in population {
     write(" ", i.color);
   }
@@ -211,7 +211,7 @@ proc run(population : [] unmanaged Chameneos, meetingPlace : unmanaged MeetingPl
   meetingPlace.reset();
 }
 
-proc printInfo(population : [] unmanaged Chameneos) {
+proc printInfo(population : [] owned Chameneos) {
   for i in population {
     write(i.meetings);
     spellInt(i.meetingsWithSelf);
@@ -236,7 +236,7 @@ proc main() {
   } else  {
     printColorChanges();
 
-    const forest : unmanaged MeetingPlace = new unmanaged MeetingPlace();
+    const forest : MeetingPlace = new MeetingPlace();
 
     const population1 = populate(numChameneos1);
     const population2 = populate(numChameneos2);
@@ -246,15 +246,5 @@ proc main() {
 
     run(population2, forest);
     printInfo(population2);
-
-
-    // clean up after ourselves
-    destroyChameneos(population1);
-    destroyChameneos(population2);
-    delete forest;
   }
-}
-
-proc destroyChameneos(ca: [] unmanaged Chameneos) {
-  for c in ca do delete c;
 }

--- a/test/studies/shootout/chameneos-redux/lydia/chameneos-redux-waitFor.chpl
+++ b/test/studies/shootout/chameneos-redux/lydia/chameneos-redux-waitFor.chpl
@@ -82,7 +82,7 @@ class Chameneos {
      with another Chameneos.  If it does, it will get the other's color and
      use this color and its own to compute the color both will have after the
      meeting has ended, setting both of their colors to this value. */
-  proc start(population : [] unmanaged Chameneos, meetingPlace: unmanaged MeetingPlace) {
+  proc start(population : [] owned Chameneos, meetingPlace: MeetingPlace) {
     var stateTemp, peer_idx, xchg : int;
 
     stateTemp = meetingPlace.state.read(memory_order_acquire);
@@ -116,8 +116,8 @@ class Chameneos {
 
   /* Given the id of its peer, finds and updates the data of its peer and
      itself */
-  proc runMeeting (population : [] unmanaged Chameneos, peer_idx) {
-    var peer : unmanaged Chameneos;
+  proc runMeeting (population : [] owned Chameneos, peer_idx) {
+    var peer : Chameneos;
     var is_same : int;
     var newColor : Color;
     if (id == peer_idx) {
@@ -156,15 +156,15 @@ proc populate (size : int) {
                             Color.yellow, Color.blue, Color.red, Color.yellow,
                             Color.red, Color.blue);
   const D : domain(1, int) = {1..size};
-  var population : [D] unmanaged Chameneos;
+  var population : [D] owned Chameneos;
 
   if (size == 10) {
     for i in D {
-      population(i) = new unmanaged Chameneos(i, colorsDefault10(i));
+      population(i) = new owned Chameneos(i, colorsDefault10(i));
     }
   } else {
     for i in D {
-      population(i) = new unmanaged Chameneos(i, ((i-1) % numColors):Color);
+      population(i) = new owned Chameneos(i, ((i-1) % numColors):Color);
     }
   }
   return population;
@@ -175,7 +175,7 @@ proc populate (size : int) {
    met another Chameneos, spells out the number of times it met with itself,
    then spells out the total number of times all the Chameneos met
    another Chameneos. */
-proc run(population : [] unmanaged Chameneos, meetingPlace : unmanaged MeetingPlace) {
+proc run(population : [] owned Chameneos, meetingPlace : MeetingPlace) {
   for i in population {
     write(" ", i.color);
   }
@@ -188,7 +188,7 @@ proc run(population : [] unmanaged Chameneos, meetingPlace : unmanaged MeetingPl
   meetingPlace.reset();
 }
 
-proc printInfo(population : [] unmanaged Chameneos) {
+proc printInfo(population : [] owned Chameneos) {
   for i in population {
     write(i.meetings);
     spellInt(i.meetingsWithSelf);
@@ -213,7 +213,7 @@ proc main() {
   } else  {
     printColorChanges();
 
-    const forest : unmanaged MeetingPlace = new unmanaged MeetingPlace();
+    const forest : MeetingPlace = new MeetingPlace();
 
     const population1 = populate(numChameneos1);
     const population2 = populate(numChameneos2);
@@ -223,14 +223,5 @@ proc main() {
 
     run(population2, forest);
     printInfo(population2);
-
-    // clean up after ourselves
-    destroyChameneos(population1);
-    destroyChameneos(population2);
-    delete forest;
   }
-}
-
-proc destroyChameneos(ca: [] unmanaged Chameneos) {
-  for c in ca do delete c;
 }

--- a/test/studies/shootout/chameneos-redux/lydia/chameneos-redux-yield.chpl
+++ b/test/studies/shootout/chameneos-redux/lydia/chameneos-redux-yield.chpl
@@ -84,7 +84,7 @@ class Chameneos {
      with another Chameneos.  If it does, it will get the other's color and
      use this color and its own to compute the color both will have after the
      meeting has ended, setting both of their colors to this value. */
-  proc start(population : [] unmanaged Chameneos, meetingPlace: unmanaged MeetingPlace) {
+  proc start(population : [] owned Chameneos, meetingPlace: MeetingPlace) {
     var stateTemp, peer_idx, xchg: int;
 
     stateTemp = meetingPlace.state.read(memory_order_acquire);
@@ -120,8 +120,8 @@ class Chameneos {
 
   /* Given the id of its peer, finds and updates the data of its peer and
      itself */
-  proc runMeeting (population : [] unmanaged Chameneos, peer_idx) {
-    var peer : unmanaged Chameneos;
+  proc runMeeting (population : [] owned Chameneos, peer_idx) {
+    var peer : Chameneos;
     var is_same : int;
     var newColor : Color;
     if (id == peer_idx) {
@@ -160,15 +160,15 @@ proc populate (size : int) {
                             Color.yellow, Color.blue, Color.red, Color.yellow,
                             Color.red, Color.blue);
   const D : domain(1, int) = {1..size};
-  var population : [D] unmanaged Chameneos;
+  var population : [D] owned Chameneos;
 
   if (size == 10) {
     for i in D {
-      population(i) = new unmanaged Chameneos(i, colorsDefault10(i));
+      population(i) = new owned Chameneos(i, colorsDefault10(i));
     }
   } else {
     for i in D {
-      population(i) = new unmanaged Chameneos(i, ((i-1) % numColors):Color);
+      population(i) = new owned Chameneos(i, ((i-1) % numColors):Color);
     }
   }
   return population;
@@ -179,7 +179,7 @@ proc populate (size : int) {
    met another Chameneos, spells out the number of times it met with itself,
    then spells out the total number of times all the Chameneos met
    another Chameneos. */
-proc run(population : [] unmanaged Chameneos, meetingPlace : unmanaged MeetingPlace) {
+proc run(population : [] owned Chameneos, meetingPlace : MeetingPlace) {
   for i in population {
     write(" ", i.color);
   }
@@ -192,7 +192,7 @@ proc run(population : [] unmanaged Chameneos, meetingPlace : unmanaged MeetingPl
   meetingPlace.reset();
 }
 
-proc printInfo(population : [] unmanaged Chameneos) {
+proc printInfo(population : [] owned Chameneos) {
   for i in population {
     write(i.meetings);
     spellInt(i.meetingsWithSelf);
@@ -217,7 +217,7 @@ proc main() {
   } else  {
     printColorChanges();
 
-    const forest : unmanaged MeetingPlace = new unmanaged MeetingPlace();
+    const forest : MeetingPlace = new MeetingPlace();
 
     const population1 = populate(numChameneos1);
     const population2 = populate(numChameneos2);
@@ -227,14 +227,5 @@ proc main() {
 
     run(population2, forest);
     printInfo(population2);
-
-    // clean up after ourselves
-    destroyChameneos(population1);
-    destroyChameneos(population2);
-    delete forest;
   }
-}
-
-proc destroyChameneos(ca: [] unmanaged Chameneos) {
-  for c in ca do delete c;
 }


### PR DESCRIPTION
This converts other performance test copies of chameneos over to use owned chameneos and borrowed meeting places.

TODO:
- [x] see how other chameneos rewrites fared
- [x] memleaks verification
- [x] performance correctness testing