### PR TITLE
Convert a few other shootouts to use managed classes

### DIFF
--- a/test/studies/shootout/fannkuch-redux/bharshbarg/fannkuch-redux-coforall.chpl
+++ b/test/studies/shootout/fannkuch-redux/bharshbarg/fannkuch-redux-coforall.chpl
@@ -22,8 +22,8 @@ var maxFlips, checkSums : [0..#NTASKS] int;
 
 var taskCount : atomic int;
 
-var Fanns : [ntasks] unmanaged Fann;
-for f in Fanns do f = new unmanaged Fann();
+var Fanns : [ntasks] owned Fann;
+for f in Fanns do f = new owned Fann();
 
 coforall i in ntasks {
   var task = taskCount.fetchAdd(1);
@@ -35,8 +35,6 @@ coforall i in ntasks {
 const c = + reduce checkSums;
 const r = max reduce maxFlips;
 writeln(c, "\nPfannkuchen(", n, ") = ", r);
-
-for f in Fanns do delete f;
 
 class Fann {
   const D = {0..#n};

--- a/test/studies/shootout/nbody/sidelnik/nbody_orig_1.chpl
+++ b/test/studies/shootout/nbody/sidelnik/nbody_orig_1.chpl
@@ -19,8 +19,8 @@ class Planet {
   var mass : real;
 }
 
-proc advance(nbodies:int, B: [] unmanaged Planet, dt: real) {
-  var b2 : unmanaged Planet;
+proc advance(nbodies:int, B: [] Planet, dt: real) {
+  var b2 : Planet;
   
   for (b1, i) in zip(B, 0..) {
     for j in i+1..nbodies-1 {
@@ -46,8 +46,8 @@ proc advance(nbodies:int, B: [] unmanaged Planet, dt: real) {
   }
 }
 
-proc energy(nbodies:int, B : [] unmanaged Planet) : real {
-  var b2 : unmanaged Planet;
+proc energy(nbodies:int, B : [] Planet) : real {
+  var b2 : Planet;
   var e : real;
   
   for (b1, i) in zip(B, 0..) {
@@ -65,7 +65,7 @@ proc energy(nbodies:int, B : [] unmanaged Planet) : real {
   return e;
 }
 
-proc offset_momentum(nbodies:int, B : [] unmanaged Planet) {
+proc offset_momentum(nbodies:int, B : [] Planet) {
   var px,py,pz : real;
   for b in B {
     px += b.vx * b.mass;
@@ -79,10 +79,10 @@ proc offset_momentum(nbodies:int, B : [] unmanaged Planet) {
 
 proc main() {
   param NBODIES = 5;
-  var bodies : [0..#NBODIES] unmanaged Planet;
+  var bodies : [0..#NBODIES] Planet;
   
-  bodies(0) = new unmanaged Planet(0, 0, 0, 0, 0, 0, solar_mass);
-  bodies(1) = new unmanaged Planet(4.84143144246472090e+00,
+  bodies(0) = new Planet(0, 0, 0, 0, 0, 0, solar_mass);
+  bodies(1) = new Planet(4.84143144246472090e+00,
                          -1.16032004402742839e+00,
                          -1.03622044471123109e-01,
                          1.66007664274403694e-03 * days_per_year,
@@ -90,7 +90,7 @@ proc main() {
                          -6.90460016972063023e-05 * days_per_year,
                          9.54791938424326609e-04 * solar_mass
                          );
-  bodies(2) = new unmanaged Planet(8.34336671824457987e+00,
+  bodies(2) = new Planet(8.34336671824457987e+00,
                          4.12479856412430479e+00,
                          -4.03523417114321381e-01,
                          -2.76742510726862411e-03 * days_per_year,
@@ -98,7 +98,7 @@ proc main() {
                          2.30417297573763929e-05 * days_per_year,
                          2.85885980666130812e-04 * solar_mass
                          );
-  bodies(3) = new unmanaged Planet(1.28943695621391310e+01,
+  bodies(3) = new Planet(1.28943695621391310e+01,
                          -1.51111514016986312e+01,
                          -2.23307578892655734e-01,
                          2.96460137564761618e-03 * days_per_year,
@@ -106,7 +106,7 @@ proc main() {
                          -2.96589568540237556e-05 * days_per_year,
                          4.36624404335156298e-05 * solar_mass
                          );				
-  bodies(4) = new unmanaged Planet(1.53796971148509165e+01,
+  bodies(4) = new Planet(1.53796971148509165e+01,
                          -2.59193146099879641e+01,
                          1.79258772950371181e-01,
                          2.68067772490389322e-03 * days_per_year,
@@ -120,5 +120,4 @@ proc main() {
     advance(NBODIES, bodies, 0.01);
   }
   writef("%{#.#########}\n", energy(NBODIES, bodies));
-  for body in bodies do delete body;
 }

--- a/test/studies/shootout/nbody/sidelnik/nbody_orig_1.compopts
+++ b/test/studies/shootout/nbody/sidelnik/nbody_orig_1.compopts
@@ -1,0 +1,1 @@
+--no-warnings

--- a/test/studies/shootout/spectral-norm/lydia/spectral-norm-barrier.chpl
+++ b/test/studies/shootout/spectral-norm/lydia/spectral-norm-barrier.chpl
@@ -10,7 +10,7 @@
 config const n = 500;
 
 use barrierWF;
-var b: unmanaged BarrierWF;
+var b: owned BarrierWF;
 
 /* Return: 1.0 / (i + j) * (i + j +1) / 2 + i + 1; */
 inline proc eval_A(i,j : int) : real
@@ -63,7 +63,7 @@ proc main() {
   const chunk = n / numThreads;
 
   u = 1.0;
-  b = new unmanaged BarrierWF(numThreads);
+  b = new owned BarrierWF(numThreads);
 
   coforall i in 0..#numThreads {
     const r_begin = i * chunk;
@@ -83,6 +83,4 @@ proc main() {
 
   const res = sqrt(vBv/vv);
   writeln(res, new iostyle(precision=10));
-
-  delete b;
 }

--- a/test/studies/shootout/spectral-norm/sidelnik/spectralnorm.chpl
+++ b/test/studies/shootout/spectral-norm/sidelnik/spectralnorm.chpl
@@ -9,7 +9,7 @@
 config const n = 500;
 
 use barrierWF;
-var b: unmanaged BarrierWF;
+var b: owned BarrierWF;
 
 /* Return: 1.0 / (i + j) * (i + j +1) / 2 + i + 1; */
 proc eval_A(i,j : int) : real
@@ -49,7 +49,7 @@ proc main() {
   var chunk = n / numThreads;
 
   u = 1.0;
-  b = new unmanaged BarrierWF(numThreads);
+  b = new owned BarrierWF(numThreads);
 
   coforall i in 0..#numThreads do {
     var r_begin = i * chunk;
@@ -70,6 +70,4 @@ proc main() {
   const res = sqrt(vBv/vv);
 
   writeln(res, new iostyle(precision=10));
-
-  delete b;
 }


### PR DESCRIPTION
This converts other shootout performance tests over to use managed
classes.  In the case of Albert Sidelnik's nbody, we can get away with
borrowed classes only resulting in a code that should work with older
versions of the compiler (albeit by leaking).  In the other cases, I
switched from unmanaged to managed pointers to use the language more
as we think we'd like.

TODO:
- [x] memleaks verification
- [x] performance correctness testing