### PR TITLE
Convert npadmana tests over to use managed classes

### DIFF
--- a/test/users/npadmana/npb-mg/mg.chpl
+++ b/test/users/npadmana/npb-mg/mg.chpl
@@ -49,8 +49,8 @@ var fluffTime : Timer;
 
 proc main() {
   // Allocate the levels
-  var Levels : [LevelDom] unmanaged MGLevel;
-  for ilevel in LevelDom do Levels[ilevel] = new unmanaged MGLevel(2**ilevel);
+  var Levels : [LevelDom] owned MGLevel;
+  for ilevel in LevelDom do Levels[ilevel] = new owned MGLevel(2**ilevel);
 
   var U,V,R : [Levels[numlevels].dom] real;
 
@@ -92,9 +92,6 @@ proc main() {
     writeln("Elapsed time (seconds):", timeit.elapsed());
     writeln("Fluff time :", fluffTime.elapsed());
   }
-
-  for il in Levels do delete il;
-
 }
 
 

--- a/test/users/npadmana/twopt/COMPOPTS
+++ b/test/users/npadmana/twopt/COMPOPTS
@@ -1,0 +1,1 @@
+--no-warnings

--- a/test/users/npadmana/twopt/do_smu_soa.chpl
+++ b/test/users/npadmana/twopt/do_smu_soa.chpl
@@ -56,7 +56,7 @@ class Particle3D {
     Darr = {ParticleAttrib, 0.. #npart};
     Dpart = {0.. #npart};
     if random {
-      var rng = new borrowed RandomStream(eltType=real);
+      var rng = new RandomStream(eltType=real);
       var x, y, z : real;
       for ii in Dpart {
         x = rng.getNext()*1000.0; y = rng.getNext()*1000.0; z = rng.getNext()*1000.0;
@@ -97,7 +97,7 @@ class Particle3D {
     }
 
     // Set the random number generator
-    var rng = new borrowed RandomStream(eltType=real, seed=41);
+    var rng = new RandomStream(eltType=real, seed=41);
     var jj : int;
     for ii in 0..(npart-2) {
       jj = (rng.getNext()*(npart-ii)):int + ii;
@@ -120,9 +120,9 @@ proc countLines(fn : string) : int {
   return ipart;
 }
 
-proc readFile(fn : string) : unmanaged Particle3D  {
+proc readFile(fn : string) : owned Particle3D  {
   var npart = countLines(fn);
-  var pp = new unmanaged Particle3D(npart);
+  var pp = new owned Particle3D(npart);
 
   var ff = openreader(fn);
   var ipart = 0;
@@ -137,7 +137,7 @@ proc readFile(fn : string) : unmanaged Particle3D  {
   return pp;
 }
 
-proc splitOn(pp : borrowed Particle3D, idom : domain(1), splitDim : int, xsplit : real) : int {
+proc splitOn(pp : Particle3D, idom : domain(1), splitDim : int, xsplit : real) : int {
   // Setup for a prefix scan
   forall ii in idom {
     if (pp.arr[splitDim,ii] < xsplit) {
@@ -171,22 +171,16 @@ class KDNode {
   var dom : domain(1);
   var xcen : [DimSpace]real;
   var rcell : real;
-  var left, right : unmanaged KDNode;
+  var left, right : owned KDNode;
 
   proc isLeaf() : bool {
     return (left==nil) && (right==nil);
   }
-
-  proc deinit() {
-    if left then delete left;
-    if right then delete right;
-  }
-
 }
 
 
-proc BuildTree(pp : borrowed Particle3D, lo : int, hi : int, id : int) : unmanaged KDNode  {
-  var me : unmanaged KDNode = new unmanaged KDNode();
+proc BuildTree(pp : Particle3D, lo : int, hi : int, id : int) : owned KDNode  {
+  var me : owned KDNode = new owned KDNode();
   me.lo = lo;
   me.hi = hi;
   me.dom = {lo..hi};
@@ -229,7 +223,7 @@ proc BuildTree(pp : borrowed Particle3D, lo : int, hi : int, id : int) : unmanag
   return me;
 }
 
-proc TreeAccumulate(hh : borrowed UniformBins, p1, p2 : borrowed Particle3D, node1, node2 : unmanaged KDNode) {
+proc TreeAccumulate(hh : UniformBins, p1, p2 : Particle3D, node1, node2 :  KDNode) {
   // Compute the distance between node1 and node2
   var rr = sqrt (+ reduce(node1.xcen - node2.xcen)**2);
   var rmin = rr - (node1.rcell+node2.rcell);
@@ -271,7 +265,7 @@ proc TreeAccumulate(hh : borrowed UniformBins, p1, p2 : borrowed Particle3D, nod
   
 
 // The basic pair counter
-proc smuAccumulate(hh : borrowed UniformBins, p1,p2 : borrowed Particle3D, d1,d2 : domain(1), scale : real) {
+proc smuAccumulate(hh : UniformBins, p1,p2 : Particle3D, d1,d2 : domain(1), scale : real) {
   for ii in d1 { // Loop over first set of particles
    
     var x1,y1,z1,w1,r2 : real;
@@ -301,10 +295,10 @@ proc doPairs() {
 
   // Read in the file
   tt.clear(); tt.start();
-  var pp1, pp2 : unmanaged Particle3D;
+  var pp1, pp2 : owned Particle3D;
   if isPerf {
-    pp1 = new unmanaged Particle3D(nParticles, true);
-    pp2 = new unmanaged Particle3D(nParticles, true);
+    pp1 = new owned Particle3D(nParticles, true);
+    pp2 = new owned Particle3D(nParticles, true);
   } else {
     pp1 = readFile(fn1);
     pp2 = readFile(fn2);
@@ -336,7 +330,7 @@ proc doPairs() {
   
 
   // Set up the histogram
-  var hh = new unmanaged UniformBins(2,(nsbins,nmubins), ((0.0,smax),(0.0,1.0+1.e-10)));
+  var hh = new UniformBins(2,(nsbins,nmubins), ((0.0,smax),(0.0,1.0+1.e-10)));
 
   // Do the paircounts with a tree
   hh.reset();
@@ -354,14 +348,5 @@ proc doPairs() {
     hh.set((0,0),0.0);
     writeHist(stdout,hh,"%20.5er ");
   }
-
-  //
-  // clean up
-  //
-  delete pp1;
-  delete pp2;
-  delete root1;
-  delete root2;
-  delete hh;
 }
 


### PR DESCRIPTION
This converts Nikhil's tests from using 'unmanaged' classes to
various types of managed classes as code cleanup and under an
expectation that it won't affect performance too much.

TODO:
- [ ] memleaks verification
- [ ] performance correctness testing