### PR TITLE
Reduce problem size for LinearAlgebra sparse dot test

### DIFF
--- a/test/library/packages/LinearAlgebra/correctness/no-dependencies/correctness.chpl
+++ b/test/library/packages/LinearAlgebra/correctness/no-dependencies/correctness.chpl
@@ -834,8 +834,8 @@ use TestUtils;
     B[1, ..] =  1.0;
     test_CSRdot(A, B);
 
-    // A big matrix
-    var C = eye(1000, 2000);
+    // A bigger matrix
+    var C = eye(100, 20);
     test_CSRdot(C);
   }
 

--- a/test/library/packages/LinearAlgebra/correctness/no-dependencies/correctness.skipif
+++ b/test/library/packages/LinearAlgebra/correctness/no-dependencies/correctness.skipif
@@ -1,3 +1,0 @@
-# baseline and valgrind timeout - see issue #11027 for more info
-CHPL_TEST_VGRND_EXE == on
-COMPOPTS <= --baseline


### PR DESCRIPTION
Reduces total execution time of `correctness.chpl` by ~1000x locally (OS X), and removes the valgrind/baseline skipif.

**Testing**
- [x] Confirm reasonable time for valgrind - `9.727 seconds`
- [x] Confirm reasonable time for baseline - `0.136 seconds`

Resolves #11027