### PR TITLE
Change this example from 'unmanaged' to 'owned'

### DIFF
--- a/test/release/examples/users-guide/taskpar/walkTreeUsingBegins.chpl
+++ b/test/release/examples/users-guide/taskpar/walkTreeUsingBegins.chpl
@@ -1,23 +1,23 @@
 class Node {
   var data: int;
-  var left, right: unmanaged Node;
+  var left, right: owned Node;
 
   proc processNode() {
     writeln(data);
   }
 }
 
-const tree = new unmanaged Node(5,
-               new unmanaged Node(2,
-                 new unmanaged Node(1, nil, nil),
-                 new unmanaged Node(4,
-                   new unmanaged Node(3, nil, nil),
+const tree = new owned Node(5,
+               new owned Node(2,
+                 new owned Node(1, nil, nil),
+                 new owned Node(4,
+                   new owned Node(3, nil, nil),
                    nil)),
-               new unmanaged Node(8,
-                 new unmanaged Node(6,
+               new owned Node(8,
+                 new owned Node(6,
                    nil,
-                   new unmanaged Node(7, nil, nil)),
-                   new unmanaged Node(9, nil, nil)));
+                   new owned Node(7, nil, nil)),
+                   new owned Node(9, nil, nil)));
 
 
 sync begin walkTree(tree);
@@ -29,12 +29,3 @@ proc walkTree(node) {
   if node.right != nil then
     begin walkTree(node.right);
 }
-
-proc Node.deinit() {
-  if this.left != nil then
-    delete this.left;
-  if this.right != nil then
-    delete this.right;
-}
-
-delete tree;


### PR DESCRIPTION
Though the code in question isn't rendered within the users guide,
this seems like a nice cleanup for those who poke into the sources
and an ideal use of 'owned' to simplify the code.