### PR TITLE
Deprecate Shared and Owned

### DIFF
--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -1036,6 +1036,14 @@ static void resolveUnresolvedSymExpr(UnresolvedSymExpr* usymExpr) {
     FnSymbol* fn = toFnSymbol(sym);
 
     if (fn == NULL) {
+      // This deprecation should be removed in 1.19
+      if (sym->hasFlag(FLAG_TYPE_VARIABLE)) {
+        if (0 == strcmp(name, "Owned"))
+          USR_WARN(usymExpr, "Owned is deprecated, use owned instead");
+        if (0 == strcmp(name, "Shared"))
+          USR_WARN(usymExpr, "Shared is deprecated, use shared instead");
+      }
+
       SymExpr* symExpr = new SymExpr(sym);
 
       usymExpr->replace(symExpr);

--- a/modules/internal/ChapelError.chpl
+++ b/modules/internal/ChapelError.chpl
@@ -364,7 +364,7 @@ module ChapelError {
   pragma "no doc"
   pragma "insert line file info"
   pragma "always propagate line file info"
-  proc chpl_fix_thrown_error(ref err: Owned(Error)): unmanaged Error {
+  proc chpl_fix_thrown_error(ref err: owned Error): unmanaged Error {
     return chpl_fix_thrown_error(err.release());
   }
 

--- a/modules/internal/OwnedObject.chpl
+++ b/modules/internal/OwnedObject.chpl
@@ -204,6 +204,12 @@ module OwnedObject {
       this.chpl_p = nil;
     }
 
+    pragma "no doc"
+    proc init(p:borrowed) {
+      compilerWarning("initializing owned from a borrow is deprecated");
+      this.init(_to_unmanaged(p));
+    }
+
     /*
        Initialize a :record:`owned` with a class instance.
        When this :record:`owned` goes out of scope, it will
@@ -212,18 +218,14 @@ module OwnedObject {
        It is an error to directly delete the class instance
        while it is managed by a :record:`owned`.
 
-       .. note::
-          In the future, the argument `p` will be required to be
-          of `unmanaged` type.
-
-       :arg p: the class instance to manage. Must be of class type.
+       :arg p: the class instance to manage. Must be of unmanaged class type.
 
      */
-    proc init(p:borrowed) {
-      this.chpl_t = p.type;
-
-      this.chpl_p = p;
+    proc init(p:unmanaged) {
+      this.chpl_t = _to_borrowed(p.type);
+      this.chpl_p = _to_borrowed(p);
     }
+
 
     proc init(p:?T) where isClass(T) == false && isSubtype(T, _owned) == false  &&
                     isIterator(p) == false {
@@ -378,7 +380,7 @@ module OwnedObject {
   where isSubtype(x.chpl_t,t.chpl_t) {
     // the :t.chpl_t cast in the next line is what actually changes the
     // returned value to have type t; otherwise it'd have type _owned(x.type).
-    var ret = new _owned(x.release():t.chpl_t);
+    var ret = new _owned(x.release():_to_unmanaged(t.chpl_t));
     return ret;
   }
 

--- a/modules/internal/SharedObject.chpl
+++ b/modules/internal/SharedObject.chpl
@@ -161,20 +161,22 @@ module SharedObject {
       this.chpl_pn = nil;
     }
 
+    pragma "no doc"
+    proc init(p : borrowed) {
+      compilerWarning("initializing shared from a borrow is deprecated");
+      this.init(_to_unmanaged(p));
+    }
+
     /*
        Initialize a :record:`shared` with a class instance.
        This :record:`shared` will take over the deletion of the class
        instance. It is an error to directly delete the class instance
        while it is managed by :record:`shared`.
 
-       .. note::
-          In the future, the argument `p` will be required to be
-          of `unmanaged` type.
-
-       :arg p: the class instance to manage. Must be of class type.
+       :arg p: the class instance to manage. Must be of unmanaged class type.
      */
-    proc init(p : borrowed) {
-      this.chpl_t = p.type;
+    proc init(p : unmanaged) {
+      this.chpl_t = _to_borrowed(p.type);
 
       // Boost version default-initializes px and pn
       // and then swaps in different values.
@@ -184,7 +186,7 @@ module SharedObject {
       if p != nil then
         rc = new unmanaged ReferenceCount();
 
-      this.chpl_p = p;
+      this.chpl_p = _to_borrowed(p);
       this.chpl_pn = rc;
 
       this.complete();

--- a/modules/packages/DistributedBag.chpl
+++ b/modules/packages/DistributedBag.chpl
@@ -125,7 +125,6 @@ module DistributedBag {
 
   use Collection;
   use BlockDist;
-  use SharedObject;
 
   /*
     Below are segment statuses, which is a way to make visible to outsiders the
@@ -237,13 +236,13 @@ module DistributedBag {
 
     // Reference Counting...
     pragma "no doc"
-    var _rc : Shared(DistributedBagRC(eltType));
+    var _rc : shared DistributedBagRC(eltType);
 
     pragma "no doc"
     proc init(type eltType, targetLocales = Locales) {
       this.eltType = eltType;
       this._pid = (new unmanaged DistributedBagImpl(eltType, targetLocales = targetLocales)).pid;
-      this._rc = new Shared(new DistributedBagRC(eltType, _pid = _pid));
+      this._rc = new shared DistributedBagRC(eltType, _pid = _pid);
     }
 
     pragma "no doc"

--- a/modules/packages/DistributedDeque.chpl
+++ b/modules/packages/DistributedDeque.chpl
@@ -168,7 +168,6 @@
 module DistributedDeque {
 
   use Collection;
-  use SharedObject;
 
   /*
     Size of each unroll block for each local deque node.
@@ -218,12 +217,12 @@ module DistributedDeque {
     var _pid : int;
     // Reference counting
     pragma "no doc"
-    var _rc : Shared(DistributedDequeRC(eltType));
+    var _rc : shared DistributedDequeRC(eltType);
 
     proc init(type eltType, cap = -1, targetLocales = Locales) {
       this.eltType = eltType;
       this._pid = (new unmanaged DistributedDequeImpl(eltType, cap, targetLocales)).pid;
-      this._rc = new Shared(new DistributedDequeRC(eltType, _pid = _pid));
+      this._rc = new shared DistributedDequeRC(eltType, _pid = _pid);
     }
 
     pragma "no doc"

--- a/modules/standard/DateTime.chpl
+++ b/modules/standard/DateTime.chpl
@@ -33,7 +33,6 @@
  */
 
 module DateTime {
-  use SharedObject;
   /* The minimum year allowed in `date` objects */
   param MINYEAR = 1;
   /* The maximum year allowed in `date` objects */
@@ -49,8 +48,8 @@ module DateTime {
   private const DI100Y = daysBeforeYear(101);
   private const DI4Y   = daysBeforeYear(5);
 
-  // This avoids needing to create new Shared objects everywhere we need nil
-  private const nilTZ = new Shared(nil: TZInfo);
+  // This avoids needing to create new shared objects everywhere we need nil
+  private const nilTZ = new shared(nil: unmanaged TZInfo);
 
   // This is here to work around issue #5267
   private const chpl_today = datetime.today();
@@ -512,7 +511,7 @@ module DateTime {
     pragma "no doc"
     var chpl_hour, chpl_minute, chpl_second, chpl_microsecond: int;
     pragma "no doc"
-    var chpl_tzinfo: Shared(TZInfo);
+    var chpl_tzinfo: shared TZInfo;
 
     /* The hour represented by this `time` value */
     proc hour {
@@ -561,7 +560,7 @@ module DateTime {
      `microsecond`, and `timezone`.  All arguments are optional
    */
   proc time.init(hour=0, minute=0, second=0, microsecond=0,
-                 tzinfo: Shared(TZInfo)=nilTZ) {
+                 tzinfo: shared TZInfo=nilTZ) {
     if hour < 0 || hour >= 24 then
       HaltWrappers.initHalt("hour out of range");
     if minute < 0 || minute >= 60 then
@@ -907,7 +906,7 @@ module DateTime {
    */
   proc datetime.init(year, month, day,
                      hour=0, minute=0, second=0, microsecond=0,
-                     tzinfo: Shared(TZInfo)=new Shared(nil: TZInfo)) {
+                     tzinfo: shared TZInfo = nil) {
     // For some reason, the compiler fails if we use nilTZ for the
     // tzinfo argument above.  Almost everywhere else it works fine.
     // Testcase: test/library/standard/DateTime/testTimezone.chpl
@@ -921,7 +920,7 @@ module DateTime {
   }
 
   /* Return a `datetime` value representing the current time and date */
-  proc type datetime.now(tz: Shared(TZInfo) = nilTZ) {
+  proc type datetime.now(tz: shared TZInfo = nilTZ) {
     if tz.borrow() == nil {
       const timeSinceEpoch = getTimeOfDay();
       const lt = getLocalTime(timeSinceEpoch);
@@ -948,7 +947,7 @@ module DateTime {
   }
 
   /* The `datetime` that is `timestamp` seconds from the epoch */
-  proc type datetime.fromtimestamp(timestamp: real, tz: Shared(TZInfo) = nilTZ) {
+  proc type datetime.fromtimestamp(timestamp: real, tz: shared TZInfo = nilTZ) {
     if tz.borrow() == nil {
       var t = (timestamp: int, ((timestamp - timestamp: int)*1000000): int);
       const lt = getLocalTime(t);
@@ -1020,7 +1019,7 @@ module DateTime {
   }
 
   /* Return the date and time converted into the timezone in the argument */
-  proc datetime.astimezone(tz: Shared(TZInfo)) {
+  proc datetime.astimezone(tz: shared TZInfo) {
     if tzinfo == tz {
       return this;
     }

--- a/test/classes/delete-free/coercions-covariant-const-ref.chpl
+++ b/test/classes/delete-free/coercions-covariant-const-ref.chpl
@@ -1,3 +1,5 @@
+
+
 class MyClass {
   var x:int;
 }

--- a/test/classes/delete-free/coercions-covariant-const-ref.chpl
+++ b/test/classes/delete-free/coercions-covariant-const-ref.chpl
@@ -1,5 +1,3 @@
-use OwnedObject;
-
 class MyClass {
   var x:int;
 }
@@ -9,12 +7,12 @@ class SubClass : MyClass {
 }
 
 
-proc acceptOwnedMyClassA(const ref own:Owned(MyClass)) {
+proc acceptOwnedMyClassA(const ref own:owned MyClass) {
   writeln(own);
 }
 
 proc testA() {
-  var instance = new Owned(new SubClass(1,1));
+  var instance = new owned SubClass(1,1);
   acceptOwnedMyClassA(instance);
   writeln(instance);
 }

--- a/test/classes/delete-free/coercions-covariant-const-ref.good
+++ b/test/classes/delete-free/coercions-covariant-const-ref.good
@@ -1,3 +1,3 @@
 coercions-covariant-const-ref.chpl:16: In function 'testA':
 coercions-covariant-const-ref.chpl:18: error: unresolved call 'acceptOwnedMyClassA(_owned(SubClass))'
-coercions-covariant-const-ref.chpl:12: note: candidates are: acceptOwnedMyClassA(const ref own: Owned(MyClass))
+coercions-covariant-const-ref.chpl:12: note: candidates are: acceptOwnedMyClassA(const ref own: owned MyClass)

--- a/test/classes/delete-free/coercions-covariant-in-const-in-shared.chpl
+++ b/test/classes/delete-free/coercions-covariant-in-const-in-shared.chpl
@@ -1,4 +1,4 @@
-use SharedObject;
+
 
 class MyClass {
   var x:int;
@@ -9,21 +9,21 @@ class SubClass : MyClass {
 }
 
 
-proc acceptSharedMyClass4(const in arg:Shared(MyClass)) {
+proc acceptSharedMyClass4(const in arg:shared MyClass) {
   writeln(arg);
 }
-proc acceptSharedMyClass5(in arg:Shared(MyClass)) {
+proc acceptSharedMyClass5(in arg:shared MyClass) {
   writeln(arg);
 }
 
 proc test4() {
-  var instance = new Shared(new SubClass(4,4));
+  var instance = new shared SubClass(4,4);
   acceptSharedMyClass4(instance);
   writeln("still have ", instance);
 }
 
 proc test5() {
-  var instance = new Shared(new SubClass(5,5));
+  var instance = new shared SubClass(5,5);
   acceptSharedMyClass5(instance);
   writeln("still have ", instance);
 }

--- a/test/classes/delete-free/coercions-covariant-in-const-in.chpl
+++ b/test/classes/delete-free/coercions-covariant-in-const-in.chpl
@@ -1,5 +1,3 @@
-use OwnedObject;
-
 class MyClass {
   var x:int;
 }
@@ -9,21 +7,21 @@ class SubClass : MyClass {
 }
 
 
-proc acceptOwnedMyClass4(const in own:Owned(MyClass)) {
+proc acceptOwnedMyClass4(const in own:owned MyClass) {
   writeln(own);
 }
-proc acceptOwnedMyClass5(in own:Owned(MyClass)) {
+proc acceptOwnedMyClass5(in own:owned MyClass) {
   writeln(own);
 }
 
 proc test4() {
-  var instance = new Owned(new SubClass(4,4));
+  var instance = new owned SubClass(4,4);
   acceptOwnedMyClass4(instance);
   writeln("expect nil, got ", instance);
 }
 
 proc test5() {
-  var instance = new Owned(new SubClass(5,5));
+  var instance = new owned SubClass(5,5);
   acceptOwnedMyClass5(instance);
   writeln("expect nil, got ", instance);
 }

--- a/test/classes/delete-free/coercions-covariant-ref.chpl
+++ b/test/classes/delete-free/coercions-covariant-ref.chpl
@@ -1,3 +1,5 @@
+
+
 class MyClass {
   var x:int;
 }

--- a/test/classes/delete-free/coercions-covariant-ref.chpl
+++ b/test/classes/delete-free/coercions-covariant-ref.chpl
@@ -1,5 +1,3 @@
-use OwnedObject;
-
 class MyClass {
   var x:int;
 }
@@ -9,12 +7,12 @@ class SubClass : MyClass {
 }
 
 
-proc acceptOwnedMyClassB(ref own:Owned(MyClass)) {
+proc acceptOwnedMyClassB(ref own:owned MyClass) {
   writeln(own);
 }
 
 proc testB() {
-  var instance = new Owned(new SubClass(2,2));
+  var instance = new owned SubClass(2,2);
   acceptOwnedMyClassB(instance);
   writeln(instance);
 }

--- a/test/classes/delete-free/coercions-covariant-ref.good
+++ b/test/classes/delete-free/coercions-covariant-ref.good
@@ -1,3 +1,3 @@
 coercions-covariant-ref.chpl:16: In function 'testB':
 coercions-covariant-ref.chpl:18: error: unresolved call 'acceptOwnedMyClassB(_owned(SubClass))'
-coercions-covariant-ref.chpl:12: note: candidates are: acceptOwnedMyClassB(ref own: Owned(MyClass))
+coercions-covariant-ref.chpl:12: note: candidates are: acceptOwnedMyClassB(ref own: owned MyClass)

--- a/test/classes/delete-free/coercions-covariant-varinit.chpl
+++ b/test/classes/delete-free/coercions-covariant-varinit.chpl
@@ -1,5 +1,3 @@
-use OwnedObject;
-
 class MyClass {
   var x:int;
 }
@@ -10,8 +8,8 @@ class SubClass : MyClass {
 
 
 proc test6() {
-  var oChild = new Owned(new SubClass(1,2));
-  var oParent: Owned(MyClass) = oChild;
+  var oChild = new owned SubClass(1,2);
+  var oParent: owned MyClass = oChild;
 
   writeln("expect nil, oChild = ", oChild);
   writeln("oParent = ", oParent);

--- a/test/classes/delete-free/coercions-covariant.chpl
+++ b/test/classes/delete-free/coercions-covariant.chpl
@@ -1,5 +1,3 @@
-use OwnedObject;
-
 class MyClass {
   var x:int;
 }
@@ -9,21 +7,21 @@ class SubClass : MyClass {
 }
 
 
-proc acceptOwnedMyClass1(own:Owned(MyClass)) {
+proc acceptOwnedMyClass1(own:owned MyClass) {
   writeln(own);
 }
-proc acceptOwnedMyClass3(const own:Owned(MyClass)) {
+proc acceptOwnedMyClass3(const own:owned MyClass) {
   writeln(own);
 }
 
 proc test1() {
-  var instance = new Owned(new SubClass(1,1));
+  var instance = new owned SubClass(1,1);
   acceptOwnedMyClass1(instance);
   writeln(instance);
 }
 
 proc test3() {
-  var instance = new Owned(new SubClass(3,3));
+  var instance = new owned SubClass(3,3);
   acceptOwnedMyClass3(instance);
   writeln(instance);
 }

--- a/test/classes/delete-free/coercions-generic.chpl
+++ b/test/classes/delete-free/coercions-generic.chpl
@@ -1,15 +1,15 @@
-use OwnedObject;
+
 
 class MyClass {
   var x;
 }
 
 proc test1() {
-  var instance = new Owned(new MyClass(1));
+  var instance = new owned MyClass(1);
 }
 
 proc test2() {
-  var instance:borrowed MyClass(int) = new Owned(new MyClass(1));
+  var instance:borrowed MyClass(int) = new owned MyClass(1);
 }
 
 proc acceptMyClass(c:borrowed MyClass) {
@@ -17,15 +17,15 @@ proc acceptMyClass(c:borrowed MyClass) {
 }
 
 proc test3() {
-  var instance = new Owned(new MyClass(1));
+  var instance = new owned MyClass(1);
 
   acceptMyClass(instance);
 }
 
 proc test5() {
-  var instance = new Owned(new MyClass(1));
+  var instance = new owned MyClass(1);
 
-  var otherInstance: Owned(MyClass(int)) = instance;
+  var otherInstance: owned MyClass(int) = instance;
 
   acceptMyClass(otherInstance);
 }

--- a/test/classes/delete-free/coercions-shared.chpl
+++ b/test/classes/delete-free/coercions-shared.chpl
@@ -1,5 +1,3 @@
-use SharedObject;
-
 class MyClass {
   var x:int;
 }
@@ -14,7 +12,7 @@ proc test1() {
 }
 
 proc test2() {
-  var instance:borrowed MyClass = new Shared(new MyClass(1));
+  var instance:borrowed MyClass = new shared MyClass(1);
 }
 
 proc acceptMyClass(c:borrowed MyClass) {
@@ -22,15 +20,15 @@ proc acceptMyClass(c:borrowed MyClass) {
 }
 
 proc test3() {
-  var instance = new Shared(new MyClass(1));
+  var instance = new shared MyClass(1);
 
   acceptMyClass(instance);
 }
 
 proc test5() {
-  var instance = new Shared(new SubClass(1, 2));
+  var instance = new shared SubClass(1, 2);
 
-  var otherInstance: Shared(MyClass) = instance;
+  var otherInstance: shared MyClass = instance;
 
   acceptMyClass(otherInstance);
 }

--- a/test/classes/delete-free/coercions.chpl
+++ b/test/classes/delete-free/coercions.chpl
@@ -1,5 +1,3 @@
-use OwnedObject;
-
 class MyClass {
   var x:int;
 }
@@ -14,7 +12,7 @@ proc test1() {
 }
 
 proc test2() {
-  var instance:Owned(MyClass) = new Owned(new MyClass(1));
+  var instance:owned MyClass = new owned MyClass(1);
 }
 
 proc acceptMyClass(c:borrowed MyClass) {
@@ -22,15 +20,15 @@ proc acceptMyClass(c:borrowed MyClass) {
 }
 
 proc test3() {
-  var instance = new Owned(new MyClass(1));
+  var instance = new owned MyClass(1);
 
   acceptMyClass(instance);
 }
 
 proc test5() {
-  var instance = new Owned(new SubClass(1, 2));
+  var instance = new owned SubClass(1, 2);
 
-  var otherInstance: Owned(MyClass) = instance;
+  var otherInstance: owned MyClass = instance;
 
   acceptMyClass(otherInstance);
 }

--- a/test/classes/delete-free/lifetimes/borrow-escapes.chpl
+++ b/test/classes/delete-free/lifetimes/borrow-escapes.chpl
@@ -1,7 +1,7 @@
 pragma "safe"
 module borrowescapes {
 
-use OwnedObject;
+
 
 class MyClass {
   var data:int;
@@ -9,7 +9,7 @@ class MyClass {
 
 record R {
   // TODO - get init with owned fields working
-  var c:Owned(MyClass);// = new Owned(nil:MyClass);
+  var c:owned MyClass;// = new Owned(nil:MyClass);
   proc init() {
     //var tmp = new Owned(new MyClass(data));
     //c = tmp;

--- a/test/classes/delete-free/lifetimes/bug-like-timezones.chpl
+++ b/test/classes/delete-free/lifetimes/bug-like-timezones.chpl
@@ -1,20 +1,20 @@
 pragma "safe"
 module tz {
 
-use SharedObject;
+
 
 class MyClass {
   var x:int;
 }
 
-private const nilTZ = new Shared(MyClass);
+private const nilTZ = new shared MyClass;
 
 record R {
-  var tz:Shared(MyClass);
+  var tz:shared MyClass;
   proc init() {
     this.tz = nilTZ;
   }
-  proc init(tz:Shared(MyClass)) {
+  proc init(tz:shared MyClass) {
     this.tz = tz;
   }
 }
@@ -23,11 +23,11 @@ proc makeNilR() {
   return new R(nilTZ);
 }
 
-proc R.replace(tzinfo:Shared(MyClass) = this.tz) {
+proc R.replace(tzinfo:shared MyClass = this.tz) {
   return new R(tzinfo);
 }
 
-proc type R.now(tz:Shared(MyClass) = nilTZ) {
+proc type R.now(tz:shared MyClass = nilTZ) {
   if tz.borrow() == nil {
     return new R();
   } else {
@@ -39,7 +39,7 @@ proc type R.now(tz:Shared(MyClass) = nilTZ) {
 
 
 proc test() {
-  var c = new Shared(new MyClass(1));
+  var c = new shared MyClass(1);
   var x = R.now();
   var y = R.now(c);
 

--- a/test/classes/delete-free/lifetimes/current-gaps.chpl
+++ b/test/classes/delete-free/lifetimes/current-gaps.chpl
@@ -1,7 +1,7 @@
 pragma "safe"
 module zzz {
 
-use OwnedObject;
+
 
 class MyClass {
   var x:int;
@@ -25,7 +25,7 @@ proc bad2(arg:borrowed MyClass) {
 }
 
 proc test() {
-  var myowned = new Owned(new MyClass(1));
+  var myowned = new owned MyClass(1);
 
   var borrow = myowned.borrow();
   bad2(borrow);

--- a/test/classes/delete-free/lifetimes/raw-return-ok.chpl
+++ b/test/classes/delete-free/lifetimes/raw-return-ok.chpl
@@ -1,7 +1,7 @@
 pragma "safe"
 module rawOK {
 
-  use OwnedObject;
+
 
   class MyClass {
     var x:int;

--- a/test/classes/delete-free/lifetimes/record-borrows.chpl
+++ b/test/classes/delete-free/lifetimes/record-borrows.chpl
@@ -1,7 +1,7 @@
 pragma "safe"
 module l5 {
 
-use OwnedObject;
+
 
 record Rint {
   var x:int;
@@ -82,7 +82,7 @@ proc buildR(sub:SubRA) {
 var globalRA:RA;
 
 proc bad() {
-  var c = new Owned(new unmanaged MyClassA(1));
+  var c = new owned MyClassA(1);
   var subr = new SubRA(c.borrow());
   globalRA = buildR(subr);
 }

--- a/test/classes/delete-free/lifetimes/record-owns.chpl
+++ b/test/classes/delete-free/lifetimes/record-owns.chpl
@@ -1,7 +1,6 @@
 pragma "safe"
 module recordOwns {
 
-use OwnedObject;
 
 record Rint {
   var x:int;
@@ -20,18 +19,18 @@ class SubClass {
 }
 
 class MyClass {
-  var sub:Owned(SubClass);
-  proc init(in sub:Owned(SubClass)) {
+  var sub:owned SubClass;
+  proc init(in sub:owned SubClass) {
     this.sub = sub;
   }
 }
 
 record RMyClass {
-  var c:Owned(MyClass);
+  var c:owned MyClass;
   proc init() {
-    this.c = new Owned(nil:unmanaged MyClass);
+    this.c = new owned(nil:unmanaged MyClass);
   }
-  proc init(in c:Owned(MyClass)) {
+  proc init(in c:owned MyClass) {
     this.c = c;
   }
 }
@@ -41,14 +40,14 @@ proc =(ref lhs:RMyClass, ref rhs:RMyClass) {
 }
 
 // Globals
-var globalMyClass:Owned(MyClass);
+var globalMyClass:owned MyClass;
 var globalRMyClass:RMyClass;
 
 // Test initialization block
 {
   var ri = new Rint(1);
-  var sub = new Owned(new SubClass(1, ri));
-  globalMyClass = new Owned(new MyClass(sub));
+  var sub = new owned SubClass(1, ri);
+  globalMyClass = new owned MyClass(sub);
 }
 
 proc refIdentity(ref x) ref {
@@ -57,8 +56,8 @@ proc refIdentity(ref x) ref {
 
 proc setGlobalRecord() {
   var ri = new Rint(1);
-  var sub = new Owned(new SubClass(1, ri));
-  var c = new Owned(new MyClass(sub));
+  var sub = new owned SubClass(1, ri);
+  var c = new owned MyClass(sub);
   var r = new RMyClass(c);
   
   globalRMyClass = r;

--- a/test/classes/delete-free/lifetimes/ref-borrow-escapes.chpl
+++ b/test/classes/delete-free/lifetimes/ref-borrow-escapes.chpl
@@ -1,6 +1,6 @@
 pragma "safe"
 module refborrowescapes {
-use OwnedObject;
+
 
 class MyClass {
   var x:int;
@@ -15,7 +15,7 @@ proc badReturnRefIdentityArg(arg) const ref {
 }
 
 proc test0() {
-  var c = new Owned(new unmanaged MyClass(1));
+  var c = new owned MyClass(1);
   var borrow = c.borrow();
   const ref r = badReturnRefIdentityArg(borrow);
   writeln(r);
@@ -48,7 +48,7 @@ proc bad(const ref r) const ref {
 }
 
 proc test2() {
-  var r = new Owned(new unmanaged MyClass(1));
+  var r = new owned MyClass(1);
   const ref re = bad(r);
   writeln(re);
 }

--- a/test/classes/delete-free/lifetimes/shared-borrows-default.chpl
+++ b/test/classes/delete-free/lifetimes/shared-borrows-default.chpl
@@ -1,31 +1,31 @@
 pragma "safe"
 module l16 {
 
-use SharedObject;
+
 
 class MyClass {
   var x:int;
 }
 
 record R {
-  var c:Shared(MyClass);
+  var c:shared MyClass;
 }
 
-proc f(c:Shared(MyClass)) {
+proc f(c:shared MyClass) {
   var r = new R(c);
   return r;
 }
 
-proc g(c:Shared(MyClass)) {
+proc g(c:shared MyClass) {
   return new R(c);
 }
 
 proc h() {
-  return new R(new Shared(new MyClass(10)));
+  return new R(new shared MyClass(10));
 }
 
 proc i() {
-  var r = new R(new Shared(new MyClass(10)));
+  var r = new R(new shared MyClass(10));
   return r;
 }
 
@@ -38,17 +38,17 @@ proc k() {
   return r;
 }
 
-proc l(c:Shared(MyClass)) {
+proc l(c:shared MyClass) {
   var r = f(c);
   return r;
 }
 
-proc m(c:Shared(MyClass)) {
+proc m(c:shared MyClass) {
   return f(c);
 }
 
 proc test() {
-  var myshared = new Shared(new MyClass(1));
+  var myshared = new shared MyClass(1);
 
   var v1 = f(myshared);
   var v2 = g(myshared);

--- a/test/classes/delete-free/lifetimes/shared-borrows-init.chpl
+++ b/test/classes/delete-free/lifetimes/shared-borrows-init.chpl
@@ -1,7 +1,7 @@
 pragma "safe"
 module l17 {
 
-use SharedObject;
+
 
 class MyClass {
   var x:int;
@@ -11,27 +11,27 @@ class MyClass {
 }
 
 record R {
-  var c:Shared(MyClass);
-  proc init(c:Shared(MyClass)) {
+  var c:shared MyClass;
+  proc init(c:shared MyClass) {
     this.c = c;
   }
 }
 
-proc f(c:Shared(MyClass)) {
+proc f(c:shared MyClass) {
   return new R(c);
 }
 
-proc g(c:Shared(MyClass)) {
+proc g(c:shared MyClass) {
   var r = new R(c);
   return r;
 }
 
 proc h() {
-  return new R(new Shared(new MyClass(10)));
+  return new R(new shared MyClass(10));
 }
 
 proc i() {
-  var r = new R(new Shared(new MyClass(10)));
+  var r = new R(new shared MyClass(10));
   return r;
 }
 
@@ -44,17 +44,17 @@ proc k() {
   return r;
 }
 
-proc l(c:Shared(MyClass)) {
+proc l(c:shared MyClass) {
   var r = f(c);
   return r;
 }
 
-proc m(c:Shared(MyClass)) {
+proc m(c:shared MyClass) {
   return f(c);
 }
 
 proc test() {
-  var myshared = new Shared(new MyClass(1));
+  var myshared = new shared MyClass(1);
 
   var v1 = f(myshared);
   var v2 = g(myshared);

--- a/test/classes/delete-free/owned/owned-comp.chpl
+++ b/test/classes/delete-free/owned/owned-comp.chpl
@@ -1,5 +1,3 @@
-use OwnedObject;
-
 class C {
   var x: int;
 
@@ -12,8 +10,8 @@ class C {
 }
 
 proc main() {
-  var a = new Owned(new C(1));
-  var b = new Owned(new C(2));
+  var a = new owned C(1);
+  var b = new owned C(2);
 
   a.matches(b);
   a.matches(a);

--- a/test/classes/delete-free/owned/owned-error-handling.chpl
+++ b/test/classes/delete-free/owned/owned-error-handling.chpl
@@ -1,5 +1,5 @@
 
-use OwnedObject;
+
 
 class Foo {
   proc foobar() throws {
@@ -8,7 +8,7 @@ class Foo {
 }
 
 proc main() {
-  var f = new Owned(new Foo());
+  var f = new owned Foo();
   try {
     f.foobar();
   } catch e : Error {

--- a/test/classes/delete-free/owned/owned-implicit-copy-const-error.chpl
+++ b/test/classes/delete-free/owned/owned-implicit-copy-const-error.chpl
@@ -1,5 +1,5 @@
 class MyClass { var x:int; }
-proc f( const ref arg:Owned(MyClass) ) {
+proc f( const ref arg:owned MyClass ) {
   return arg;
   // compiler adds copy initialization to this return
   // since it's returning a reference by value
@@ -7,7 +7,7 @@ proc f( const ref arg:Owned(MyClass) ) {
 }
 
 proc main() {
-  const x = new Owned(new MyClass(1));
+  const x = new owned MyClass(1);
   f(x);
   writeln(x); // is it surprising that x now stores nil?
 }

--- a/test/classes/delete-free/owned/owned-implicit-copy-tuple-error.chpl
+++ b/test/classes/delete-free/owned/owned-implicit-copy-tuple-error.chpl
@@ -1,4 +1,4 @@
-use OwnedObject;
+
 
 class Foo {
   var x: int;
@@ -8,7 +8,7 @@ class Foo {
   }
 }
 
-const a = new Owned(new Foo(1));
-const b = new Owned(new Foo(2));
+const a = new owned Foo(1);
+const b = new owned Foo(2);
 
 var c = (a, b);

--- a/test/classes/delete-free/owned/owned-implicit-copy-tuple.chpl
+++ b/test/classes/delete-free/owned/owned-implicit-copy-tuple.chpl
@@ -1,5 +1,3 @@
-use OwnedObject;
-
 class Foo {
   var x: int;
 
@@ -8,8 +6,8 @@ class Foo {
   }
 }
 
-var a = new Owned(new Foo(1));
-var b = new Owned(new Foo(2));
+var a = new owned Foo(1);
+var b = new owned Foo(2);
 
 var c = (a, b);
 

--- a/test/classes/delete-free/owned/owned-implicit-copy.chpl
+++ b/test/classes/delete-free/owned/owned-implicit-copy.chpl
@@ -1,5 +1,5 @@
 class MyClass { var x:int; }
-proc f( ref arg:Owned(MyClass) ) {
+proc f( ref arg:owned MyClass ) {
   return arg;
   // compiler adds copy initialization to this return
   // since it's returning a reference by value
@@ -7,7 +7,7 @@ proc f( ref arg:Owned(MyClass) ) {
 }
 
 proc main() {
-  var x = new Owned(new MyClass(1));
+  var x = new owned MyClass(1);
   f(x);
   writeln(x); // is it surprising that x now stores nil?
 }

--- a/test/classes/delete-free/owned/owned-in-tuple.chpl
+++ b/test/classes/delete-free/owned/owned-in-tuple.chpl
@@ -1,13 +1,13 @@
-use OwnedObject;
+
 class Foo {
   var x: int;
 };
 
-type Bar = (Owned(Foo), int); // <-- Error here?
+type Bar = (owned Foo, int); // <-- Error here?
 
 proc test() {
   var x:Bar;
-  x(1) = new Owned(new Foo(1));
+  x(1) = new owned Foo(1);
   x(2) = 2;
 
   writeln(x(1).borrow());

--- a/test/classes/delete-free/owned/owned-init.chpl
+++ b/test/classes/delete-free/owned/owned-init.chpl
@@ -1,4 +1,4 @@
-use OwnedObject;
+
 
 class C {
   var x: int;
@@ -12,7 +12,7 @@ class C {
 }
 
 proc main() {
-  const a = [i in 1..3] new Owned(new C(i));
+  const a = [i in 1..3] new owned C(i);
   
   writeln(a);
 }

--- a/test/classes/delete-free/owned/owned-init2.chpl
+++ b/test/classes/delete-free/owned/owned-init2.chpl
@@ -1,4 +1,4 @@
-use OwnedObject;
+
 
 class C {
   var x: int;
@@ -12,9 +12,9 @@ class C {
 }
 
 proc main() {
-  var a: [1..3] Owned(C);
+  var a: [1..3] owned C;
   for i in 1..3 do
-    a[i] = new Owned(new C(i));
+    a[i] = new owned C(i);
   
   writeln(a);
 }

--- a/test/classes/delete-free/owned/owned-ref-borrow-explicit.chpl
+++ b/test/classes/delete-free/owned/owned-ref-borrow-explicit.chpl
@@ -1,16 +1,16 @@
-use OwnedObject;
+
 
 class MyClass {
   var x:int;
 }
 
 proc acceptRef(ref arg:borrowed MyClass) {
-  var other = new Owned(new MyClass(2));
+  var other = new owned MyClass(2);
   arg = other;
 }
 
 proc test() {
-  var x = new Owned(new MyClass(1));
+  var x = new owned MyClass(1);
 
   acceptRef(x.borrow());
 

--- a/test/classes/delete-free/owned/owned-ref-borrow-implicit.chpl
+++ b/test/classes/delete-free/owned/owned-ref-borrow-implicit.chpl
@@ -1,16 +1,16 @@
-use OwnedObject;
+
 
 class MyClass {
   var x:int;
 }
 
 proc acceptRef(ref arg:borrowed MyClass) {
-  var other = new Owned(new MyClass(2));
+  var other = new owned MyClass(2);
   arg = other;
 }
 
 proc test() {
-  var x = new Owned(new MyClass(1));
+  var x = new owned MyClass(1);
 
   acceptRef(x);
 

--- a/test/classes/delete-free/push-back-owned.chpl
+++ b/test/classes/delete-free/push-back-owned.chpl
@@ -1,13 +1,11 @@
-use OwnedObject;
-
 class MyClass {
   var x: int;
 }
 
 var D = {1..3};
-var A: [D] Owned(MyClass);
+var A: [D] owned MyClass;
 
-var c = new Owned(new MyClass(1));
+var c = new owned MyClass(1);
 A.push_back(c);
 
 writeln(A[4].x);

--- a/test/classes/delete-free/shared/shared-ref-problem.chpl
+++ b/test/classes/delete-free/shared/shared-ref-problem.chpl
@@ -1,13 +1,13 @@
-use SharedObject;
+
 
 class State {
   var done: int;
 }
 
-proc foo(old: Shared(State)): int {
+proc foo(old: shared State): int {
   return old.done;
 }
 
-var x = new Shared(new State(42));
+var x = new shared State(42);
 var y = foo(x);
 writeln(y);

--- a/test/classes/delete-free/shared/sharedClassInRecord.chpl
+++ b/test/classes/delete-free/shared/sharedClassInRecord.chpl
@@ -1,9 +1,9 @@
-use SharedObject;
+
 
 class C { }
 
 record R {
-  var sc: Shared(C);
+  var sc: shared C;
 }
 
 proc main {

--- a/test/classes/delete-free/swap-managed.chpl
+++ b/test/classes/delete-free/swap-managed.chpl
@@ -1,5 +1,3 @@
-use OwnedObject;
-
 class Foo {
   var x: int;
 
@@ -8,16 +6,16 @@ class Foo {
   }
 }
 
-var a = new Owned(new Foo(1));
-var b = new Owned(new Foo(2));
+var a = new owned Foo(1);
+var b = new owned Foo(2);
 
 a <=> b;
 
 writeln(a);
 writeln(b);
 
-var c = new Shared(new Foo(3));
-var d = new Shared(new Foo(4));
+var c = new shared Foo(3);
+var d = new shared Foo(4);
 var copyOfD = d;
 var anotherCopOfD = d;
 

--- a/test/classes/ferguson/delete-free/owned-array.chpl
+++ b/test/classes/ferguson/delete-free/owned-array.chpl
@@ -1,13 +1,11 @@
-use OwnedObject;
-
 class MyClass {
   var x: int;
 }
 
 proc test() {
   
-  // Can we make an array of Owned?
-  var A:[1..3] Owned(MyClass);
+  // Can we make an array of owned?
+  var A:[1..3] owned MyClass;
 
   A[1].retain(new unmanaged MyClass(1));
 

--- a/test/classes/ferguson/delete-free/owned-borrow-check.chpl
+++ b/test/classes/ferguson/delete-free/owned-borrow-check.chpl
@@ -1,5 +1,3 @@
-use OwnedObject;
-
 class C {
   var x:int;
   proc deinit() {
@@ -13,7 +11,7 @@ proc bar(arg:C) {
 }
 
 proc foo() {
-  var x = new Owned(new C());
+  var x = new owned C();
 
   bar(x.borrow());
   // but bar saves the borrow in myGlobal! Oops!

--- a/test/classes/ferguson/delete-free/owned-coerce.chpl
+++ b/test/classes/ferguson/delete-free/owned-coerce.chpl
@@ -1,5 +1,3 @@
-use OwnedObject;
-
 class C {
   var x:int;
   proc deinit() {
@@ -12,7 +10,7 @@ proc myLegacyFunction(arg:borrowed C) {
 }
 
 proc test() {
-  var x = new Owned(new C());
+  var x = new owned C();
 
   myLegacyFunction(x); // feature request: coerce from Owned to C (borrow)
 }

--- a/test/classes/ferguson/delete-free/owned-const-in-error.chpl
+++ b/test/classes/ferguson/delete-free/owned-const-in-error.chpl
@@ -1,4 +1,4 @@
-use OwnedObject;
+
 
 class C {
   var x:int;
@@ -7,12 +7,12 @@ class C {
   }
 }
 
-proc takeOwnershipAgain(in arg:Owned(C)) {
+proc takeOwnershipAgain(in arg:owned C) {
   writeln("in takeOwnershipAgain with arg=", arg.borrow());
 }
 
 
-proc takeOwnership(const in arg:Owned(C)) {
+proc takeOwnership(const in arg:owned C) {
   writeln("in takeOwnership with arg=", arg.borrow());
   takeOwnershipAgain(arg);
   writeln("in takeOwnership, now arg=", arg.borrow());
@@ -20,7 +20,7 @@ proc takeOwnership(const in arg:Owned(C)) {
 
 
 proc make() {
-  var x = new Owned(new C(1));
+  var x = new owned C(1);
   return x;
 }
 

--- a/test/classes/ferguson/delete-free/owned-const-in.chpl
+++ b/test/classes/ferguson/delete-free/owned-const-in.chpl
@@ -1,5 +1,3 @@
-use OwnedObject;
-
 class C {
   var x:int;
   proc deinit() {
@@ -7,13 +5,13 @@ class C {
   }
 }
 
-proc takeOwnership(const in arg:Owned(C)) {
+proc takeOwnership(const in arg:owned C) {
   writeln("in takeOwnership with arg=", arg.borrow());
 }
 
 
 proc make() {
-  var x = new Owned(new C(1));
+  var x = new owned C(1);
   return x;
 }
 

--- a/test/classes/ferguson/delete-free/owned-default-concrete.chpl
+++ b/test/classes/ferguson/delete-free/owned-default-concrete.chpl
@@ -1,5 +1,3 @@
-use OwnedObject;
-
 class MyClass {
   var x = 1;
   proc deinit() {

--- a/test/classes/ferguson/delete-free/owned-default-generic.chpl
+++ b/test/classes/ferguson/delete-free/owned-default-generic.chpl
@@ -1,5 +1,3 @@
-use OwnedObject;
-
 class MyClass {
   var x = 1;
   proc deinit() {

--- a/test/classes/ferguson/delete-free/owned-delegate-field.chpl
+++ b/test/classes/ferguson/delete-free/owned-delegate-field.chpl
@@ -1,5 +1,3 @@
-use OwnedObject;
-
 class Impl {
   var field: int;
   proc init(arg:int) {
@@ -17,7 +15,7 @@ class Impl {
 }
 
 proc run() {
-  var x = new Owned(new Impl(1));
+  var x = new owned Impl(1);
   x.field = 34;
   writeln(x.field);
 }

--- a/test/classes/ferguson/delete-free/owned-delegate.chpl
+++ b/test/classes/ferguson/delete-free/owned-delegate.chpl
@@ -1,5 +1,3 @@
-use OwnedObject;
-
 class Impl {
   var field: int;
   proc init(arg:int) {
@@ -17,7 +15,7 @@ class Impl {
 }
 
 proc run() {
-  var x = new Owned(new Impl(1));
+  var x = new owned Impl(1);
   x.foo(); // calls x.borrow().foo()
   writeln(x.borrow());
 }

--- a/test/classes/ferguson/delete-free/owned-demo.chpl
+++ b/test/classes/ferguson/delete-free/owned-demo.chpl
@@ -1,5 +1,3 @@
-use OwnedObject;
-
 // a class we will manage
 class C {
   var x:int;
@@ -9,12 +7,12 @@ proc examples() {
 
   writeln("declaring owned1 storing C(1)"); 
   // 'owned1' has a unique pointer to a new C instance
-  var owned1 = new Owned(new unmanaged C(1));
+  var owned1 = new owned C(1);
   writeln("owned1 = ", owned1.borrow());
 
   writeln("declaring owned2 storing nil");
-  // it's OK to have Owned initially empty. It will point to 'nil'.
-  var owned2: Owned(C);
+  // it's OK to have owned initially empty. It will point to 'nil'.
+  var owned2: owned C;
   writeln("owned2 = ", owned2.borrow());
 
   // Assignment is supported, but it empties the RHS
@@ -27,10 +25,10 @@ proc examples() {
   writeln("owned1 = ", owned1.borrow());
 
   writeln("declaring owned3 storing C(3)");
-  var owned3 = new Owned(new unmanaged C(3));
+  var owned3 = new owned C(3);
   writeln("owned3 = ", owned3.borrow());
 
-  // An Owned variable can be re-used. Here, owned3 is filled
+  // An owned variable can be re-used. Here, owned3 is filled
   // and the assignment statement passes its ownership to owned1.
   // After this line,
   //  'owned1' will contain C(3)
@@ -41,10 +39,10 @@ proc examples() {
   writeln("owned3 = ", owned3.borrow());
 
   writeln("declaring owned4 storing C(4)");
-  var owned4 = new Owned(new unmanaged C(4));
+  var owned4 = new owned C(4);
   writeln("owned4 = ", owned4.borrow());
 
-  // An non-empty Owned variable can also be pointed to
+  // An non-empty owned variable can also be pointed to
   // something else. The value it stored before will be destructed.
   // After this line,
   //  'owned1' will contain C(4); previous object C(3) will be destroyed
@@ -55,7 +53,7 @@ proc examples() {
   writeln("owned4 = ", owned4.borrow());
 
   writeln("declaring owned5 storing C(5)");
-  var owned5 = new Owned(new unmanaged C(5));
+  var owned5 = new owned C(5);
   writeln("owned5 = ", owned5.borrow());
 
   // The clear method can be used to delete the
@@ -65,7 +63,7 @@ proc examples() {
   writeln("owned5 = ", owned5.borrow());
 
   // The retain method can be used to provide a new value for
-  // an Owned to point to.
+  // an owned to point to.
   // After this line:
   //  'owned1' will contain C(100); previous object C(4) will be destroyed
   owned1.retain(new unmanaged C(100));
@@ -74,7 +72,7 @@ proc examples() {
 
   // The release method can be used to extract the
   // owned pointer when something else will have responsibility
-  // for freeing it. Whatever Owned has release() called on it
+  // for freeing it. Whatever owned has release() called on it
   // will contain nil after the call.
   var ptr = owned1.release();
   writeln("after owned1.release()");
@@ -84,13 +82,13 @@ proc examples() {
 
   // The `in` intent can be used to pass ownership from a call
   // site to the called function.
-  proc takesOwnership(in arg: Owned(C)) {
+  proc takesOwnership(in arg: owned C) {
    writeln("in takesOwnership, arg = ", arg.borrow());
     // arg's contained pointer will be deleted at the end of this function
   }
 
   writeln("declaring owned6 storing C(6)");
-  var owned6 = new Owned(new unmanaged C(6));
+  var owned6 = new owned C(6);
   takesOwnership(owned6);
   // After that call, owned6 contains nil
    writeln("owned6 = ", owned6.borrow());

--- a/test/classes/ferguson/delete-free/owned-error-nonclass.chpl
+++ b/test/classes/ferguson/delete-free/owned-error-nonclass.chpl
@@ -1,12 +1,12 @@
-use OwnedObject;
+
 
 record R {
   var field: int;
 }
 
 proc run() {
-  var x = new Owned(new R(1));
-  writeln(x.borrow());
+  var x = new owned R(1);
+  //writeln(x.borrow());
 }
 
 run();

--- a/test/classes/ferguson/delete-free/owned-error-nonclass.good
+++ b/test/classes/ferguson/delete-free/owned-error-nonclass.good
@@ -1,2 +1,2 @@
 owned-error-nonclass.chpl:7: In function 'run':
-owned-error-nonclass.chpl:8: error: owned only works with classes
+owned-error-nonclass.chpl:8: error: Cannot use new owned with record R

--- a/test/classes/ferguson/delete-free/owned-in.chpl
+++ b/test/classes/ferguson/delete-free/owned-in.chpl
@@ -1,5 +1,3 @@
-use OwnedObject;
-
 class C {
   var x:int;
   proc deinit() {
@@ -7,12 +5,12 @@ class C {
   }
 }
 
-proc takeOwnershipAgain(in arg:Owned(C)) {
+proc takeOwnershipAgain(in arg:owned C) {
   writeln("in takeOwnershipAgain with arg=", arg.borrow());
 }
 
 
-proc takeOwnership(in arg:Owned(C)) {
+proc takeOwnership(in arg:owned C) {
   writeln("in takeOwnership with arg=", arg.borrow());
   takeOwnershipAgain(arg);
   writeln("in takeOwnership, now arg=", arg.borrow());
@@ -20,7 +18,7 @@ proc takeOwnership(in arg:Owned(C)) {
 
 
 proc make() {
-  var x = new Owned(new C(1));
+  var x = new owned C(1);
   return x;
 }
 

--- a/test/classes/ferguson/delete-free/owned-return-blank-arg-value.chpl
+++ b/test/classes/ferguson/delete-free/owned-return-blank-arg-value.chpl
@@ -1,5 +1,3 @@
-use OwnedObject;
-
 class C {
   var x:int;
   proc deinit() {

--- a/test/classes/ferguson/delete-free/owned-return-ref-arg-value.chpl
+++ b/test/classes/ferguson/delete-free/owned-return-ref-arg-value.chpl
@@ -1,5 +1,3 @@
-use OwnedObject;
-
 class C {
   var x:int;
   proc deinit() {
@@ -15,7 +13,7 @@ proc returnByValue(ref arg)
 
 
 proc foo() {
-  var x = new Owned(new C(1));
+  var x = new owned C(1);
   writeln(" x=", x);
 
   var y = returnByValue(x);

--- a/test/classes/ferguson/delete-free/owned-shared-fields.chpl
+++ b/test/classes/ferguson/delete-free/owned-shared-fields.chpl
@@ -1,78 +1,75 @@
 // This test checks several patterns of
-// records and classes with Owned and Shared fields.
+// records and classes with owned and shared fields.
 // This test is intended to make sure that fields
-// of Owned or Shared type continue to function.
-
-use OwnedObject;
-use SharedObject;
+// of owned or shared type continue to function.
 
 class MyClass {
   var x:int;
 }
 
 record R1 {
-  var fo:Owned(MyClass);
-  var fs:Shared(MyClass);
+  var fo:owned MyClass;
+  var fs:shared MyClass;
   proc init() {
   }
 }
 
 record R2 {
-  var fo:Owned(MyClass) = new Owned(nil:unmanaged MyClass);
-  var fs:Shared(MyClass) = new Shared(nil:unmanaged MyClass);
+  var fo:owned MyClass = new owned(nil:unmanaged MyClass);
+  var fs:shared MyClass = new shared(nil:unmanaged MyClass);
   proc init() {
   }
 }
 
 record R3 {
-  var fo:Owned(MyClass);
-  var fs:Shared(MyClass);
+  var fo:owned MyClass;
+  var fs:shared MyClass;
   proc init(a:unmanaged MyClass, b:unmanaged MyClass) {
-    fo = new Owned(a);
-    fs = new Shared(b);
+    fo = new owned(a);
+    fs = new shared(b);
   }
 }
 
 record R4 {
-  var fo:Owned(MyClass);
-  var fs:Shared(MyClass);
+  var fo:owned MyClass;
+  var fs:shared MyClass;
   proc init(a:unmanaged MyClass, b:unmanaged MyClass) {
     this.complete();
-    fo = new Owned(a);
-    fs = new Shared(b);
+    fo = new owned(a);
+    fs = new shared(b);
   }
 }
 
 class C1 {
-  var fo:Owned(MyClass);
-  var fs:Shared(MyClass);
+  var fo:owned MyClass;
+  var fs:shared MyClass;
   proc init() {
   }
 }
 
 class C2 {
-  var fo:Owned(MyClass) = new Owned(nil:unmanaged MyClass);
-  var fs:Shared(MyClass) = new Shared(nil:unmanaged MyClass);
+  var fo:owned MyClass = new owned(nil:unmanaged MyClass);
+  var fs:shared MyClass = new shared(nil:unmanaged MyClass);
   proc init() {
   }
 }
 
 class C3 {
-  var fo:Owned(MyClass);
-  var fs:Shared(MyClass);
+  var fo:owned MyClass;
+  var fs:shared MyClass;
   proc init(a:unmanaged MyClass, b:unmanaged MyClass) {
-    fo = new Owned(a);
-    fs = new Shared(b);
+    fo = new owned(a);
+    fs = new shared(b);
   }
 }
 
 class C4 {
-  var fo:Owned(MyClass);
-  var fs:Shared(MyClass);
+  var fo:owned MyClass;
+  var fs:shared MyClass;
   proc init(a:unmanaged MyClass, b:unmanaged MyClass) {
     super.init();
-    fo = new Owned(a);
-    fs = new Shared(b);
+    fo = new owned(a);
+    fs = new shared(b);
   }
 }
 

--- a/test/classes/ferguson/delete-free/owned-writeln.chpl
+++ b/test/classes/ferguson/delete-free/owned-writeln.chpl
@@ -1,5 +1,3 @@
-use OwnedObject;
-
 class MyClass {
   var x = 1;
   proc deinit() {

--- a/test/classes/ferguson/delete-free/owned1.chpl
+++ b/test/classes/ferguson/delete-free/owned1.chpl
@@ -1,5 +1,3 @@
-use OwnedObject;
-
 class C {
   proc deinit() {
     writeln("Destroying C");
@@ -7,7 +5,7 @@ class C {
 }
 
 proc foo() {
-  var x = new Owned(new C());
+  var x = new owned C();
 
 }
 

--- a/test/classes/ferguson/delete-free/owned2.chpl
+++ b/test/classes/ferguson/delete-free/owned2.chpl
@@ -1,5 +1,3 @@
-use OwnedObject;
-
 class C {
   proc deinit() {
     writeln("Destroying C");
@@ -7,7 +5,7 @@ class C {
 }
 
 proc foo() {
-  var x = new Owned(new C());
+  var x = new owned C();
 
   var y = x;
 }

--- a/test/classes/ferguson/delete-free/owned3.chpl
+++ b/test/classes/ferguson/delete-free/owned3.chpl
@@ -1,5 +1,3 @@
-use OwnedObject;
-
 class C {
   proc deinit() {
     writeln("Destroying C");
@@ -7,8 +5,8 @@ class C {
 }
 
 proc foo() {
-  var x:Owned(C);
-  var y = new Owned(new C());
+  var x:owned C;
+  var y = new owned C();
 
   x = y;
 }

--- a/test/classes/ferguson/delete-free/owned4.chpl
+++ b/test/classes/ferguson/delete-free/owned4.chpl
@@ -1,5 +1,3 @@
-use OwnedObject;
-
 class C {
   var x = 1;
   proc deinit() {
@@ -8,8 +6,8 @@ class C {
 }
 
 proc foo() {
-  var x:Owned(C);
-  var y = new Owned(new C(2));
+  var x:owned C;
+  var y = new owned C(2);
 
   x.retain(y.release());
 }

--- a/test/classes/ferguson/delete-free/shared-delegate-field.chpl
+++ b/test/classes/ferguson/delete-free/shared-delegate-field.chpl
@@ -1,4 +1,4 @@
-use SharedObject;
+
 
 class Impl {
   var field: int;
@@ -17,7 +17,7 @@ class Impl {
 }
 
 proc run() {
-  var x = new Shared(new Impl(1));
+  var x = new shared Impl(1);
   x.field = 34;
   writeln(x.field);
 }

--- a/test/classes/ferguson/delete-free/shared-delegate.chpl
+++ b/test/classes/ferguson/delete-free/shared-delegate.chpl
@@ -1,4 +1,4 @@
-use SharedObject;
+
 
 class Impl {
   var field: int;
@@ -17,7 +17,7 @@ class Impl {
 }
 
 proc run() {
-  var x = new Shared(new Impl(1));
+  var x = new shared Impl(1);
   x.foo(); // calls x.borrow().foo()
   writeln(x.borrow());
 }

--- a/test/classes/ferguson/delete-free/shared-demo.chpl
+++ b/test/classes/ferguson/delete-free/shared-demo.chpl
@@ -1,4 +1,4 @@
-use SharedObject;
+
 
 // a class we will manage
 class C {
@@ -9,12 +9,12 @@ proc examples() {
 
   writeln("declaring shared1 storing C(1)"); 
   // 'shared1' points to a new C instance
-  var shared1 = new Shared(new unmanaged C(1));
+  var shared1 = new shared C(1);
   writeln("shared1 = ", shared1.borrow());
 
   writeln("declaring shared2 storing nil");
-  // it's OK to have Shared initially empty. It will point to 'nil'.
-  var shared2: Shared(C);
+  // it's OK to have shared initially empty. It will point to 'nil'.
+  var shared2: shared C;
   writeln("shared2 = ", shared2.borrow());
 
   // Assignment is supported. The LHS and RHS will both point
@@ -25,10 +25,10 @@ proc examples() {
   writeln("shared1 = ", shared1.borrow());
 
   writeln("declaring shared3 storing C(3)");
-  var shared3 = new Shared(new C(3));
+  var shared3 = new shared C(3);
   writeln("shared3 = ", shared3.borrow());
 
-  // A Shared variable can be set to something else.
+  // A shared variable can be set to something else.
   // Here, shared1 is set to shared3.
   //  'shared1' will contain C(3)
   //  'shared3' will contain C(3)
@@ -38,35 +38,35 @@ proc examples() {
   writeln("shared3 = ", shared3.borrow());
 
   // The retain method can be used to provide a new value
-  // for a Shared to point to.
+  // for a shared to point to.
   // After this line:
   //  shared1 will contain C(100)
   shared1.retain(new unmanaged C(100));
   writeln("after shared1.retain C(100)");
   writeln("shared1 = ", shared1.borrow());
 
-  // The clear method can be used to empty a Shared immediately.
-  // If the Shared record is the last one referring to the object
+  // The clear method can be used to empty a shared immediately.
+  // If the shared record is the last one referring to the object
   // it contains, that object will be deleted.
-  // For Shared, release does not return a value. That is because
-  // it could still be managed by other Shared record instances.
+  // For shared, release does not return a value. That is because
+  // it could still be managed by other shared record instances.
   shared1.clear();
   writeln("after shared1.clear()");
   writeln("shared1 = ", shared1.borrow());
 
   writeln("declaring shared4 storing C(4)");
-  var shared4 = new Shared(new C(4));
+  var shared4 = new shared C(4);
   writeln("shared4 = ", shared4.borrow());
 
   // The `in` intent can be used to share ownership from a call
   // site to the called function.
-  proc sharesOwnership(in arg: Shared(C)) {
+  proc sharesOwnership(in arg: shared C) {
    writeln("in sharesOwnership, arg = ", arg.borrow());
     // arg's contained pointer will be deleted at the end of this function
   }
 
   writeln("declaring shared5 storing C(5)");
-  var shared5 = new Shared(new C(5));
+  var shared5 = new shared C(5);
   sharesOwnership(shared5);
   // After that call, shared5 contains nil
    writeln("shared5 = ", shared5.borrow());

--- a/test/classes/ferguson/delete-free/shared-error-nonclass.chpl
+++ b/test/classes/ferguson/delete-free/shared-error-nonclass.chpl
@@ -1,12 +1,12 @@
-use SharedObject;
+
 
 record R {
   var field: int;
 }
 
 proc run() {
-  var x = new Shared(new R(1));
-  writeln(x.borrow());
+  var x = new shared R(1);
+  //writeln(x.borrow());
 }
 
 run();

--- a/test/classes/ferguson/delete-free/shared-error-nonclass.good
+++ b/test/classes/ferguson/delete-free/shared-error-nonclass.good
@@ -1,2 +1,2 @@
 shared-error-nonclass.chpl:7: In function 'run':
-shared-error-nonclass.chpl:8: error: shared only works with classes
+shared-error-nonclass.chpl:8: error: Cannot use new shared with record R

--- a/test/classes/ferguson/delete-free/shared-in.chpl
+++ b/test/classes/ferguson/delete-free/shared-in.chpl
@@ -1,5 +1,3 @@
-use SharedObject;
-
 class C {
   var x:int;
   proc deinit() {
@@ -7,19 +5,19 @@ class C {
   }
 }
 
-proc shareOwnershipAgain(in arg:Shared(C)) {
+proc shareOwnershipAgain(in arg:shared C) {
   writeln("in shareOwnershipAgain with arg=", arg.borrow());
 }
 
 
-proc shareOwnership(in arg:Shared(C)) {
+proc shareOwnership(in arg:shared C) {
   writeln("in shareOwnership with arg=", arg.borrow());
   shareOwnershipAgain(arg);
   writeln("in shareOwnership, now arg=", arg.borrow());
 }
 
 proc make() {
-  var x = new Shared(new C(1));
+  var x = new shared C(1);
   return x;
 }
 

--- a/test/classes/ferguson/delete-free/shared1.chpl
+++ b/test/classes/ferguson/delete-free/shared1.chpl
@@ -1,4 +1,4 @@
-use SharedObject;
+
 
 class Impl {
   var field: int;
@@ -13,11 +13,11 @@ class Impl {
 }
 
 proc run() {
-  var x = new Shared(new Impl(1));
+  var x = new shared Impl(1);
   writeln(x.borrow());
 
   var c:unmanaged Impl = nil;
-  var y = new Shared(c);
+  var y = new shared(c);
   writeln(y.borrow());
 }
 

--- a/test/classes/ferguson/delete-free/shared2.chpl
+++ b/test/classes/ferguson/delete-free/shared2.chpl
@@ -1,4 +1,4 @@
-use SharedObject;
+
 
 class Impl {
   var field: int;
@@ -13,7 +13,7 @@ class Impl {
 }
 
 proc run() {
-  var x = new Shared(new Impl(1));
+  var x = new shared Impl(1);
 
   // check initCopy
   var y = x;

--- a/test/classes/ferguson/delete-free/shared3.chpl
+++ b/test/classes/ferguson/delete-free/shared3.chpl
@@ -1,4 +1,4 @@
-use SharedObject;
+
 
 class Impl {
   var field: int;
@@ -13,8 +13,8 @@ class Impl {
 }
 
 proc run() {
-  var x = new Shared(new Impl(1));
-  var y: Shared(Impl);
+  var x = new shared Impl(1);
+  var y: shared Impl;
 
   // check assignment
   y = x;

--- a/test/classes/ferguson/delete-free/shared4.chpl
+++ b/test/classes/ferguson/delete-free/shared4.chpl
@@ -1,4 +1,4 @@
-use SharedObject;
+
 
 class Impl {
   var field: int;
@@ -12,10 +12,10 @@ class Impl {
   }
 }
 
-var globalSharedObject:Shared(Impl);
+var globalSharedObject:shared Impl;
 
 proc makeGlobalSharedObject() {
-  var x = new Shared(new Impl(1));
+  var x = new shared Impl(1);
 
   globalSharedObject = x;
 }

--- a/test/classes/initializers/records/init-with-call.chpl
+++ b/test/classes/initializers/records/init-with-call.chpl
@@ -9,7 +9,7 @@ class Impl {
 }
 
 proc makeit() {
-  return new Shared(new Impl(1));
+  return new shared Impl(1);
 }
 
 record R {

--- a/test/classes/initializers/records/init-with-new.chpl
+++ b/test/classes/initializers/records/init-with-new.chpl
@@ -12,7 +12,7 @@ record R {
   var field;
 
   proc init() {
-    field = new Shared(new Impl(1));
+    field = new shared Impl(1);
   }
 }
 

--- a/test/compflags/ferguson/unstable-class.good
+++ b/test/compflags/ferguson/unstable-class.good
@@ -17,5 +17,10 @@ unstable-class.chpl:30: warning: undecorated class type MyGenericClass is unstab
 unstable-class.chpl:30: note: use 'unmanaged MyGenericClass' 'owned MyGenericClass', 'borrowed MyGenericClass', or 'shared MyGenericClass'
 unstable-class.chpl:31: warning: undecorated class type MyClass is unstable
 unstable-class.chpl:31: note: use 'unmanaged MyClass' 'owned MyClass', 'borrowed MyClass', or 'shared MyClass'
+unstable-class.chpl:38: In function 'ok':
+unstable-class.chpl:45: warning: Owned is deprecated, use owned instead
+unstable-class.chpl:46: warning: Shared is deprecated, use shared instead
+unstable-class.chpl:52: warning: Owned is deprecated, use owned instead
+unstable-class.chpl:53: warning: Shared is deprecated, use shared instead
 unstable-class.chpl:20: warning: undecorated class type MyClass is unstable
 unstable-class.chpl:20: note: use 'unmanaged MyClass' 'owned MyClass', 'borrowed MyClass', or 'shared MyClass'

--- a/test/compflags/ferguson/unstable-class.init.good
+++ b/test/compflags/ferguson/unstable-class.init.good
@@ -20,3 +20,8 @@ unstable-class.chpl:30: warning: undecorated class type MyGenericClass is unstab
 unstable-class.chpl:30: note: use 'unmanaged MyGenericClass' 'owned MyGenericClass', 'borrowed MyGenericClass', or 'shared MyGenericClass'
 unstable-class.chpl:31: warning: undecorated class type MyClass is unstable
 unstable-class.chpl:31: note: use 'unmanaged MyClass' 'owned MyClass', 'borrowed MyClass', or 'shared MyClass'
+unstable-class.chpl:38: In function 'ok':
+unstable-class.chpl:45: warning: Owned is deprecated, use owned instead
+unstable-class.chpl:46: warning: Shared is deprecated, use shared instead
+unstable-class.chpl:52: warning: Owned is deprecated, use owned instead
+unstable-class.chpl:53: warning: Shared is deprecated, use shared instead

--- a/test/compflags/ferguson/unstable-new.good
+++ b/test/compflags/ferguson/unstable-new.good
@@ -3,12 +3,19 @@ unstable-new.chpl:20: warning: undecorated class type MyClass is unstable
 unstable-new.chpl:20: note: use 'unmanaged MyClass' 'owned MyClass', 'borrowed MyClass', or 'shared MyClass'
 unstable-new.chpl:21: warning: undecorated class type MyGenericClass is unstable
 unstable-new.chpl:21: note: use 'unmanaged MyGenericClass' 'owned MyGenericClass', 'borrowed MyGenericClass', or 'shared MyGenericClass'
+unstable-new.chpl:31: In function 'ok':
+unstable-new.chpl:36: warning: Owned is deprecated, use owned instead
+unstable-new.chpl:37: warning: Owned is deprecated, use owned instead
+unstable-new.chpl:19: In function 'errors':
 unstable-new.chpl:20: warning: new MyClass is unstable
 unstable-new.chpl:20: note: use 'new unmanaged MyClass' 'new owned MyClass' 'new shared MyClass' or 'new borrowed MyClass'
 unstable-new.chpl:21: warning: new MyGenericClass is unstable
 unstable-new.chpl:21: note: use 'new unmanaged MyGenericClass' 'new owned MyGenericClass' 'new shared MyGenericClass' or 'new borrowed MyGenericClass'
 unstable-new.chpl:27: warning: 'delete' can only be applied to unmanaged classes
 unstable-new.chpl:28: warning: 'delete' can only be applied to unmanaged classes
+unstable-new.chpl:31: In function 'ok':
+unstable-new.chpl:36: warning: initializing owned from a borrow is deprecated
+unstable-new.chpl:37: warning: initializing owned from a borrow is deprecated
 in errors
 {x = 1}
 {y = 1}

--- a/test/deprecated/owned-shared-from-borrow.good
+++ b/test/deprecated/owned-shared-from-borrow.good
@@ -1,0 +1,8 @@
+owned-shared-from-borrow.chpl:18: In function 'testOwned':
+owned-shared-from-borrow.chpl:20: warning: Owned is deprecated, use owned instead
+owned-shared-from-borrow.chpl:24: In function 'testShared':
+owned-shared-from-borrow.chpl:26: warning: Shared is deprecated, use shared instead
+owned-shared-from-borrow.chpl:18: In function 'testOwned':
+owned-shared-from-borrow.chpl:20: warning: initializing owned from a borrow is deprecated
+owned-shared-from-borrow.chpl:24: In function 'testShared':
+owned-shared-from-borrow.chpl:26: warning: initializing shared from a borrow is deprecated

--- a/test/library/packages/SharedObject/shared-nil-assign.chpl
+++ b/test/library/packages/SharedObject/shared-nil-assign.chpl
@@ -1,7 +1,5 @@
-use SharedObject;
-
 class C { }
 
-var sc1: Shared(C);
-var sc2: Shared(C);
+var sc1: shared C;
+var sc2: shared C;
 sc1 = sc2;

--- a/test/library/packages/SharedObject/shared-nil-in-arg.chpl
+++ b/test/library/packages/SharedObject/shared-nil-in-arg.chpl
@@ -1,9 +1,7 @@
-use SharedObject;
-
 class C { }
 
-proc foo(in sc: Shared(C)) { }
+proc foo(in sc: shared C) { }
 
-var sc = new Shared(nil:unmanaged C);
+var sc = new shared(nil:unmanaged C);
 
 foo(sc);

--- a/test/library/packages/SharedObject/shared-nil-return.chpl
+++ b/test/library/packages/SharedObject/shared-nil-return.chpl
@@ -1,9 +1,7 @@
-use SharedObject;
-
 class C { }
 
 class D {
-  var sc: Shared(C);
+  var sc: shared C;
   proc foo() {
     return sc;
   }

--- a/test/library/standard/DateTime/testDatetime.chpl
+++ b/test/library/standard/DateTime/testDatetime.chpl
@@ -212,7 +212,7 @@ proc test_combine() {
 proc test_replace() {
   var args = (1, 2, 3, 4, 5, 6, 7);
   var base = new datetime((...args));
-  var nilTZ:Shared(TZInfo);
+  var nilTZ:shared TZInfo;
 
   assert(base == base.replace(tzinfo=nilTZ));
 

--- a/test/library/standard/DateTime/testDatetimeTZ.chpl
+++ b/test/library/standard/DateTime/testDatetimeTZ.chpl
@@ -253,7 +253,7 @@ proc test_tzinfo_fromtimestamp() {
   var tz = new shared FixedOffset(utcoffset, "tz", new timedelta());
   var expected = utcdatetime + utcoffset;
   var got = datetime.fromtimestamp(timestamp, tz);
-  assert(expected == got.replace(tzinfo=new Shared(nil:unmanaged TZInfo)));
+  assert(expected == got.replace(tzinfo=new shared(nil:unmanaged TZInfo)));
 }
 
 proc test_tzinfo_timetuple() {
@@ -422,7 +422,7 @@ proc test_replace() {
 
   // Ensure we can get rid of a tzinfo.
   assert(base.tzname() == "+100");
-  var base2 = base.replace(tzinfo=new Shared(nil: unmanaged TZInfo));
+  var base2 = base.replace(tzinfo=new shared(nil: unmanaged TZInfo));
   assert(base2.tzinfo.borrow() == nil);
 
   // Ensure we can add one.
@@ -514,7 +514,7 @@ proc test_mixed_compare() {
   var t1 = new datetime(1, 2, 3, 4, 5, 6, 7);
   var t2 = new datetime(1, 2, 3, 4, 5, 6, 7);
   assert(t1 == t2);
-  t2 = t2.replace(tzinfo=new Shared(nil: unmanaged TZInfo));
+  t2 = t2.replace(tzinfo=new shared(nil: unmanaged TZInfo));
   assert(t1 == t2);
   t2 = t2.replace(tzinfo=new shared FixedOffset(0, ""));
 

--- a/test/library/standard/DateTime/testTimezone.chpl
+++ b/test/library/standard/DateTime/testTimezone.chpl
@@ -1,4 +1,4 @@
-use DateTime, SharedObject;
+use DateTime;
 
 class FixedOffset: TZInfo {
   var offset: timedelta;
@@ -132,7 +132,7 @@ proc test_replace() {
 
   // Ensure we can get rid of a tzinfo.
   assert(base.tzname() == "+100");
-  var base2 = base.replace(tzinfo=new Shared(TZInfo));
+  var base2 = base.replace(tzinfo=new shared(TZInfo));
   assert(base2.tzinfo.borrow() == nil);
   assert(base2.tzname() == "");
 
@@ -146,7 +146,7 @@ proc test_mixed_compare() {
   var t1 = new time(1, 2, 3);
   var t2 = new time(1, 2, 3);
   assert(t1 == t2);
-  t2 = t2.replace(tzinfo=new Shared(TZInfo));
+  t2 = t2.replace(tzinfo=new shared(TZInfo));
   assert(t1 == t2);
   t2 = t2.replace(tzinfo=new shared FixedOffset(0, ""));
 

--- a/test/library/standard/DateTime/testTimezoneConversions.chpl
+++ b/test/library/standard/DateTime/testTimezoneConversions.chpl
@@ -56,7 +56,7 @@ class USTimeZone: TZInfo {
 
     // Can't compare naive to aware objects, so strip the timezone from
     // dt first.
-    if start <= dt.replace(tzinfo=new Shared(nil: unmanaged TZInfo)) && dt.replace(tzinfo=new Shared(nil:unmanaged TZInfo)) < end {
+    if start <= dt.replace(tzinfo=new shared(nil: unmanaged TZInfo)) && dt.replace(tzinfo=new shared(nil:unmanaged TZInfo)) < end {
       return HOUR;
     } else {
       return ZERO;
@@ -257,7 +257,7 @@ proc test_tricky() {
   // local clock jumps from 1 to 3).  The point here is to make sure we
   // get the 3 spelling.
   var expected = dston.replace(hour=3, tzinfo=dston.tzinfo);
-  var got = fourback.astimezone(Eastern).replace(tzinfo=new Shared(TZInfo));
+  var got = fourback.astimezone(Eastern).replace(tzinfo=new shared(TZInfo));
   assert(expected == got);
 
   // Similar, but map to 6:00 UTC == 1:00 EST == 2:00 DST.  In that
@@ -267,7 +267,7 @@ proc test_tricky() {
   // and adding -4-0 == -4 gives the 2:00 spelling.  We want the 1:00 EST
   // spelling.
   expected = dston.replace(hour=1, tzinfo=dston.tzinfo);
-  got = sixutc.astimezone(Eastern).replace(tzinfo=new Shared(TZInfo));
+  got = sixutc.astimezone(Eastern).replace(tzinfo=new shared(TZInfo));
   assert(expected == got);
 
   // Now on the day DST ends, we want "repeat an hour" behavior.
@@ -291,7 +291,7 @@ proc test_tricky() {
           expected = expectedbase.replace(minute=minute, tzinfo=expectedbase.tzinfo);
           asutc = asutcbase.replace(minute=minute, tzinfo=asutcbase.tzinfo);
           var astz = asutc.astimezone(tz);
-          assert(astz.replace(tzinfo=new Shared(TZInfo)) == expected);
+          assert(astz.replace(tzinfo=new shared(TZInfo)) == expected);
         }
         asutcbase += HOUR;
       }

--- a/test/library/standard/Random/ferguson/check-time-seed.chpl
+++ b/test/library/standard/Random/ferguson/check-time-seed.chpl
@@ -18,7 +18,7 @@ proc getRealRandoms(method:int) {
   }
 
   if method == 1 {
-    var R = new Owned(makeRandomStream(eltType=real));
+    var R = makeRandomStream(eltType=real);
 
     if debug then
       writeln("method ", method, ", seed ", R.seed);
@@ -29,7 +29,7 @@ proc getRealRandoms(method:int) {
 
 
   if method == 2 {
-    var R = new Owned(makeRandomStream(eltType=real, algorithm=RNG.PCG));
+    var R = makeRandomStream(eltType=real, algorithm=RNG.PCG);
 
     if debug then
       writeln("method ", method, ", seed ", R.seed);
@@ -75,7 +75,7 @@ proc getUintRandoms(method:int) {
   }
 
   if method == 1 {
-    var R = new Owned(makeRandomStream(eltType=uint));
+    var R = makeRandomStream(eltType=uint);
 
     if debug then
       writeln("method ", method, ", seed ", R.seed);
@@ -85,7 +85,7 @@ proc getUintRandoms(method:int) {
   }
 
   if method == 2 {
-    var R = new Owned(makeRandomStream(eltType=uint, algorithm=RNG.PCG));
+    var R = makeRandomStream(eltType=uint, algorithm=RNG.PCG);
 
     if debug then
       writeln("method ", method, ", seed ", R.seed);

--- a/tools/mason/MasonBuild.chpl
+++ b/tools/mason/MasonBuild.chpl
@@ -105,7 +105,7 @@ proc buildProgram(release: bool, show: bool, force: bool, cmdLineCompopts: [?d] 
     const cwd = getEnv("PWD");
     const projectHome = getProjectHome(cwd, tomlName);
     const toParse = open(projectHome + "/" + lockName, iomode.r);
-    var lockFile = new Owned(parseToml(toParse));
+    var lockFile = new owned(parseToml(toParse));
     const projectName = lockFile["root"]["name"].s;
     
     // --fast

--- a/tools/mason/MasonExample.chpl
+++ b/tools/mason/MasonExample.chpl
@@ -75,8 +75,8 @@ private proc getBuildInfo(projectHome: string) {
   // parse lock and toml(examples dont make it to lock file)
   const lock = open(projectHome + "/Mason.lock", iomode.r);
   const toml = open(projectHome + "/Mason.toml", iomode.r);
-  const lockFile = new Owned(parseToml(lock));
-  const tomlFile = new Owned(parseToml(toml));
+  const lockFile = new owned(parseToml(lock));
+  const tomlFile = new owned(parseToml(toml));
   
   // Get project source code and dependencies
   const sourceList = genSourceList(lockFile);
@@ -338,7 +338,7 @@ proc printAvailableExamples() {
     const cwd = getEnv("PWD");
     const projectHome = getProjectHome(cwd);
     const toParse = open(projectHome + "/Mason.toml", iomode.r);
-    const toml = new Owned(parseToml(toParse));
+    const toml = new owned(parseToml(toParse));
     const examples = getExamples(toml, projectHome);
     writeln("--- available examples ---");
     for example in examples {

--- a/tools/mason/MasonRun.chpl
+++ b/tools/mason/MasonRun.chpl
@@ -79,7 +79,7 @@ proc runProjectBinary(show: bool, release: bool, execopts: [?d] string) throws {
     const cwd = getEnv("PWD");
     const projectHome = getProjectHome(cwd);
     const toParse = open(projectHome + "/Mason.toml", iomode.r);
-    const tomlFile = new Owned(parseToml(toParse));
+    const tomlFile = new owned(parseToml(toParse));
     const project = tomlFile["brick"]["name"].s;
  
     // Find the Binary and execute

--- a/tools/mason/MasonTest.chpl
+++ b/tools/mason/MasonTest.chpl
@@ -77,7 +77,7 @@ private proc runTests(show: bool, run: bool, parallel: bool, cmdLineCompopts: [?
 
     // parse lockfile
     const toParse = open(projectHome + "/Mason.lock", iomode.r);
-    const lockFile = new Owned(parseToml(toParse));
+    const lockFile = new owned(parseToml(toParse));
 
     // Get project source code and dependencies
     const sourceList = genSourceList(lockFile);


### PR DESCRIPTION
This PR adds a deprecation warning for 
Shared and Owned (in favor of shared and owned)
and also deprecates the initializer for these that
takes in a borrow (rather than an unmanaged).

- [x] full local futures testing

Reviewed by @vasslitvinov - thanks!