### PR TITLE
Disable guard pages on thunderx* processors

### DIFF
--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -529,10 +529,10 @@ static chpl_bool setupGuardPages(void) {
 
     // Setup guard pages. Default to enabling guard pages, only disabling them
     // under the following conditions (Precedence high-to-low):
-    // 1) Guard pages disabled at configure time
-    // 2) Guard pages not supported because of huge pages
-    // 3) QT_GUARD_PAGES set to a 'false' value
-    // 4) CHPL_STACK_CHECKS set (--no-stack-checks thrown at compilation time)
+    //  - Guard pages disabled at configure time
+    //  - Guard pages not supported because of huge pages
+    //  - QT_GUARD_PAGES set to a 'false' value
+    //  - CHPL_STACK_CHECKS set (--no-stack-checks thrown at compilation time)
     if (!CHPL_QTHREAD_HAVE_GUARD_PAGES) {
         guardPagesEnabled = false;
     } else if (chpl_getHeapPageSize() != chpl_getSysPageSize()) {

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -523,6 +523,7 @@ static void setupAvailableParallelism(int32_t maxThreads) {
 }
 
 static chpl_bool setupGuardPages(void) {
+    const char *armArch = "arm-thunderx";
     chpl_bool guardPagesEnabled = true;
     // default value set by compiler (--[no-]stack-checks)
     chpl_bool defaultVal = (CHPL_STACK_CHECKS == 1);
@@ -531,11 +532,14 @@ static chpl_bool setupGuardPages(void) {
     // under the following conditions (Precedence high-to-low):
     //  - Guard pages disabled at configure time
     //  - Guard pages not supported because of huge pages
+    //  - Guard pages not supported by processor
     //  - QT_GUARD_PAGES set to a 'false' value
     //  - CHPL_STACK_CHECKS set (--no-stack-checks thrown at compilation time)
     if (!CHPL_QTHREAD_HAVE_GUARD_PAGES) {
         guardPagesEnabled = false;
     } else if (chpl_getHeapPageSize() != chpl_getSysPageSize()) {
+        guardPagesEnabled = false;
+    } else if (strncmp(armArch, CHPL_TARGET_ARCH, strlen(armArch)) == 0) {
         guardPagesEnabled = false;
     } else {
         guardPagesEnabled = chpl_qt_getenv_bool("GUARD_PAGES", defaultVal);

--- a/test/release/examples/benchmarks/lcals/LCALSMain.execenv
+++ b/test/release/examples/benchmarks/lcals/LCALSMain.execenv
@@ -1,7 +1,0 @@
-#!/usr/bin/env python
-
-# Guard pages are expensive on high core-count systems. See issue #7533
-
-import os
-if os.getenv('CHPL_TARGET_ARCH', '') in ['arm-thunderx', 'arm-thunderx2', 'mic-knl']:
-    print('QT_GUARD_PAGES=false')

--- a/test/release/examples/benchmarks/lulesh/lulesh.execenv
+++ b/test/release/examples/benchmarks/lulesh/lulesh.execenv
@@ -3,5 +3,5 @@
 # Guard pages are expensive on high core-count systems. See issue #7533
 
 import os
-if os.getenv('CHPL_TARGET_ARCH', '') in ['arm-thunderx', 'arm-thunderx2', 'mic-knl']:
+if os.getenv('CHPL_TARGET_ARCH', '') in ['mic-knl']:
     print('QT_GUARD_PAGES=false')

--- a/test/release/examples/benchmarks/lulesh/test3DLulesh.execenv
+++ b/test/release/examples/benchmarks/lulesh/test3DLulesh.execenv
@@ -1,7 +1,0 @@
-#!/usr/bin/env python
-
-# Guard pages are expensive on high core-count systems. See issue #7533
-
-import os
-if os.getenv('CHPL_TARGET_ARCH', '') in ['arm-thunderx', 'arm-thunderx2', 'mic-knl']:
-    print('QT_GUARD_PAGES=false')

--- a/test/release/examples/benchmarks/miniMD/miniMD.execenv
+++ b/test/release/examples/benchmarks/miniMD/miniMD.execenv
@@ -3,5 +3,5 @@
 # Guard pages are expensive on high core-count systems. See issue #7533
 
 import os
-if os.getenv('CHPL_TARGET_ARCH', '') in ['arm-thunderx', 'arm-thunderx2', 'mic-knl']:
+if os.getenv('CHPL_TARGET_ARCH', '') in ['mic-knl']:
     print('QT_GUARD_PAGES=false')


### PR DESCRIPTION
We've been seeing sporadic hangs in several tests. We still haven't identified
the root cause, but disabling guard pages seems to resolve the hang.

Related to https://github.com/chapel-lang/chapel/issues/10840
