### PR TITLE
Improve developer experience for building docs

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -122,10 +122,6 @@ clean-symlinks: FORCE
 	find $(SOURCEDIR) -type l -delete
 
 error_docs: FORCE
-	@echo;
-	@echo "If a documentation hierarchy change was made on the master branch,"
-	@echo "try resolving with: \`git clean "'$$CHPL_HOME'"/doc/*\`"
-	@echo;
 	@exit 1 # Note that 'make' will return exit code of 2, despite exit 1
 
 

--- a/doc/Makefile.sphinx
+++ b/doc/Makefile.sphinx
@@ -72,7 +72,7 @@ html-release: check-sphinxbuild source clean-build
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@chmod -R ugo+rX $(BUILDDIR)
 	cp util/versionButton.php $(BUILDDIR)/html/
-	echo "ErrorDocument 404 https://chapel-lang.org/docs/$(WEB_DOC_VERSION)/index.html" > $(BUILDDIR)/html/.htaccess
+	@echo "ErrorDocument 404 https://chapel-lang.org/docs/$(WEB_DOC_VERSION)/index.html" > $(BUILDDIR)/html/.htaccess
 	mv $(BUILDDIR)/html .
 	@echo
 	@echo "Build finished. The HTML pages are in "'$$CHPL_HOME'"/doc/html."


### PR DESCRIPTION
This PR makes 2 small changes to the docs build:

1. One of the last outputs from a successful docs build print a message with
alarming words like "Error", "404", and "HTML".

This PR suppresses this output to collectively reduce developer anxiety.

2. The doc hierarchy seems to have reached stability in the past few
releases, so the `git clean` suggestion every docs build failure has become dated.

This PR removes this suggestion.