### PR TITLE
Update Using Chapel "prerequisites" list

### DIFF
--- a/doc/rst/usingchapel/prereqs.rst
+++ b/doc/rst/usingchapel/prereqs.rst
@@ -40,8 +40,9 @@ about your environment for using Chapel:
   * If you wish to use chpldoc or Chapel's test system, ``curl`` and
     python-devel (or equivalent packages for your platform) are required.
 
-  * If you wish to use the ``mason system``, chapel's package manager, ``pkg-config`` is
-    required.
+  * If you wish to use :ref:`readme-mason`, chapel's package manager,  ``git`` is required.
+
+    * The ``mason system`` subcommands additionally require ``pkg-config``.
 
 .. _readme-prereqs-installation:
 
@@ -50,22 +51,22 @@ Installation
 
 We have used the following commands to install the above prerequisites:
 
-  * CentOS, Fedora 21::
+  * CentOS::
 
-      sudo yum install gcc gcc-c++ m4 perl python python-devel python-setuptools bash make gawk
+      sudo yum install gcc gcc-c++ m4 perl python python-devel python-setuptools bash make gawk git
 
-  * Fedora 22::
+  * Fedora::
 
-      sudo dnf install gcc gcc-c++ m4 perl python python-devel python-setuptools bash make gawk
+      sudo dnf install gcc gcc-c++ m4 perl python python-devel python-setuptools bash make gawk git
 
   * SLES, openSUSE::
 
-      sudo zypper install gcc gcc-c++ m4 perl python python-devel python-setuptools bash make gawk
+      sudo zypper install gcc gcc-c++ m4 perl python python-devel python-setuptools bash make gawk git
 
   * Debian, Ubuntu::
 
-      sudo apt-get install gcc g++ m4 perl python python-dev python-setuptools bash make mawk
+      sudo apt-get install gcc g++ m4 perl python python-dev python-setuptools bash make mawk git pkg-config
 
   * FreeBSD::
 
-     sudo pkg install m4 python py27-setuptools bash gmake gawk
+     sudo pkg install gcc m4 perl5 python py27-setuptools bash gmake gawk git pkgconf


### PR DESCRIPTION
* `Mason` almost always requires git; `mason system` requires pkg-config.
* Recommended `FreeBSD` packages are updated consistent with current Vagrant tests. 
* The `Fedora 21/Fedora 22` distinction is obsolete; that was 2015.
