### PR TITLE
Remove the requirement that strings be ASCII in the spec

### DIFF
--- a/spec/Types.tex
+++ b/spec/Types.tex
@@ -209,7 +209,7 @@ and \chpl{2.72} respectively.
 \index{types!string@\chpl{string}}
 
 Strings are a primitive type designated by the symbol \chpl{string}
-comprised of ASCII characters.  Their length is unbounded.
+comprised of multibyte characters (normally UTF-8).  Their length is unbounded.
 
 
 \begin{openissue}


### PR DESCRIPTION
Currently the spec requires strings to be composed of ASCII characters.  This change removes that requirement from the spec.

Note that we lack string documentation in general, so this is the only place we can update to indicate that there is UTF-8 support.  In the long run, we should have some string documentation, as noted in #11052 .
