### PR TITLE
Replace an INT_ASSERT with a USR_FATAL

### DIFF
--- a/compiler/AST/foralls.cpp
+++ b/compiler/AST/foralls.cpp
@@ -629,6 +629,13 @@ static CallExpr* buildForallParIterCall(ForallStmt* pfs, SymExpr* origSE)
   if (origSE->symbol()->type->symbol->hasFlag(FLAG_ITERATOR_RECORD)) {
     // Our iterable expression is an iterator call.
 
+    if (ArgSymbol* origArg = toArgSymbol(origSE->symbol())) {
+      FnSymbol* iterator = getTheIteratorFnFromIteratorRec(origArg->type);
+      USR_FATAL_CONT(origSE, "a forall loop over a formal argument corresponding to a for/forall/promoted expression or an iterator call is not implemented");
+      USR_PRINT(iterator, "the actual argument is here");
+      USR_STOP();
+    }
+
     CallExpr* origIterCall = toCallExpr(findDefOfTemp(origSE));
     // What to do if we do not find it?
     INT_ASSERT(origIterCall);

--- a/test/functions/iterators/vass/forall-over-iteratorRecord-arg.chpl
+++ b/test/functions/iterators/vass/forall-over-iteratorRecord-arg.chpl
@@ -1,0 +1,39 @@
+
+iter myIterator(n:int) {
+  writeln("myIterator serial");
+  yield n;
+}
+
+iter myIterator(n:int, param tag) where tag == iterKind.leader {
+  writeln("myIterator leader");
+  yield 777;
+}
+
+iter myIterator(n:int, param tag, followThis) {
+  writeln("myIterator follower ", followThis);
+  yield n;
+}
+
+proc myPlusOp(x:int,y:int) return x+y+7;
+
+var A,B: [-1..1] int;
+
+proc myTestProc(IR) {
+  // todo: same with a zippered forall, with IR either leader or follower
+  forall IDX in IR {
+    writeln("myTestProc ", IDX);
+  }
+
+  // The following works, however.
+  var ARR = IR;
+  compilerWarning(ARR.type:string);
+  writeln("ARR = ", ARR, "  ", ARR.domain);
+}
+
+proc main {
+  myTestProc(A+B);
+  myTestProc(myPlusOp(A,B));
+  myTestProc(myIterator(5));
+  myTestProc(for i in A do i * 3);
+  myTestProc(forall i in A do i * 3);
+}

--- a/test/functions/iterators/vass/forall-over-iteratorRecord-arg.good
+++ b/test/functions/iterators/vass/forall-over-iteratorRecord-arg.good
@@ -1,0 +1,3 @@
+forall-over-iteratorRecord-arg.chpl:21: In function 'myTestProc':
+forall-over-iteratorRecord-arg.chpl:23: error: a forall loop over a formal argument corresponding to a for/forall/promoted expression or an iterator call is not implemented
+forall-over-iteratorRecord-arg.chpl:34: note: the actual argument is here


### PR DESCRIPTION
The following code:
```chpl
    proc test(ARG) {
      forall ARG do ...;
    }
```
used to crash the compiler.
Convert that to a user-facing "not implemented" message.

Resolves #10950.