### PR TITLE
Improve LinearAlgebra documentation

### DIFF
--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -66,7 +66,8 @@ headers and libraries available would result in a compilation error.
 
   // example2.chpl
   var A = Matrix([2, 1],
-                 [1, 2], eltType=real);
+                 [1, 2],
+                 eltType=real);
   var (eigenvalues, eigenvectors) = eigvals(A, right=true);
 
 The program above uses :proc:`eigvals`, which depends on :mod:`LAPACK`.
@@ -1109,7 +1110,6 @@ proc cholesky(A: [] ?t, lower = true)
 
  */
 // TODO: example
-// TODO: LaTeX
 proc eigvals(A: [] ?t, param left = false, param right = false)
   where isRealType(t) && A.domain.rank == 2 && usingLAPACK {
 
@@ -1196,20 +1196,47 @@ proc eigvals(A: [] ?t, param left = false, param right = false)
 /*
   Singular Value Decomposition.
 
-  Factorizes the matrix ``A`` into two unitary matrices, ``U`` and ``Vt`` and
-  a vector of singular values ``s``, such that::
+  Factorizes the `m x n` matrix ``A`` such that:
 
-    A = U * s * Vt
 
-  Will throw a ``LinearAlgebraError`` if the SVD computation does not converge
-  or an illegal argument (such as ``NAN``) is given.
+  .. math::
+
+    \mathbf{A} = \textbf{U} \cdot \Sigma \cdot \mathbf{V^H}
+
+  where
+
+    - :math:`\mathbf{U}` is an `m x m` unitary matrix,
+    - :math:`\Sigma` is a diagonal `m x n` matrix,
+    - :math:`\mathbf{V}` is an `n x n` unitary matrix, and
+      :math:`\mathbf{V^H}` is the Hermitian transpose.
+
+  This procedure returns a tuple of ``(U, s, Vh)``, where ``s`` is a vector
+  containing the diagonal elements of :math:`\Sigma`, known as the
+  singular values.
+
+  For example:
+
+  .. code-block:: chapel
+
+    var A = Matrix([3, 2,  2],
+                   [2, 3, -2],
+                   eltType=real);
+    var (U, s, Vh) = svd(A);
+
+  ``LinearAlgebraError`` will be thrown if the SVD computation does not
+  converge or an illegal argument, such as a matrix containing a ``NAN`` value,
+  is given.
 
   .. note::
 
    A temporary copy of ``A`` will be created within this computation.
+
+  .. note::
+
+    This procedure depends on the :mod:`LAPACK` module, and will generate a
+    compiler error if ``lapackImpl`` is ``none``.
 */
 // TODO: example
-// TODO: LaTeX
 proc svd(A: [?Adom] ?t) throws
   where isLAPACKType(t) && usingLAPACK && Adom.rank == 2
 {

--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -21,13 +21,6 @@
 
 A high-level interface to linear algebra operations and procedures.
 
-If using a procedure that depends on :mod:`BLAS` or
-
-depend
-on :mod:`BLAS` and :mod:`LAPACK`. These dependencies will be required at
-compile-time if a program calls a procedure that uses them.
-Procedure dependencies are annotated in the documentation below.
-
 Compiling with Linear Algebra
 -----------------------------
 
@@ -50,7 +43,9 @@ implentations by setting the ``blasImpl`` and ``lapackImpl`` flags to ``none``.
 .. code-block:: chpl
 
   // example1.chpl
-  var A = Matrix(3,3);
+  var A = Matrix([0.0, 1.0, 1.0],
+                 [1.0, 0.0, 1.0],
+                 [1.0, 1.0, 0.0]);
   var I = eye(3,3);
   var B = A + I;
 
@@ -70,10 +65,9 @@ headers and libraries available would result in a compilation error.
 .. code-block:: chpl
 
   // example2.chpl
-  var A = Matrix(3,3);
-  A = 2;
-  var eigenvalues = eigvals(A);
-
+  var A = Matrix([2, 1],
+                 [1, 2], eltType=real);
+  var (eigenvalues, eigenvectors) = eigvals(A, right=true);
 
 The program above uses :proc:`eigvals`, which depends on :mod:`LAPACK`.
 Compilation without ``LAPACK`` headers and libraries available would result in
@@ -105,6 +99,7 @@ on the system and specified with the following compilation flags:
 
   // example3.chpl
   var A = Matrix(3,5);
+  A = 2;
   var AA = A.dot(A.T);
 
 

--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -493,12 +493,26 @@ proc _array.T where isDefaultRectangularArr(this) && this.domain.rank == 2
   return transpose(this);
 }
 
+/* Element-wise addition. Deprecated for ``A + B`` */
+proc matPlus(A: [?Adom] ?eltType, B: [?Bdom] eltType) where isDefaultRectangularArr(A) && isDefaultRectangularArr(B) {
+  compilerWarning('matPlus has been deprecated. ' +
+                  'try: A + B');
+  return A.plus(B);
+}
+
 /* Element-wise addition. Same as ``A + B``. */
 proc _array.plus(A: [?Adom] ?eltType) where isDefaultRectangularArr(A) && isDefaultRectangularArr(this) {
   if Adom.rank != this.domain.rank then compilerError("Unmatched ranks");
   if Adom.shape != this.domain.shape then halt("Unmatched shapes");
   var C: [Adom] eltType = this + A;
   return C;
+}
+
+/* Element-wise subtraction. Deprecated for ``A - B``*/
+proc matMinus(A: [?Adom] ?eltType, B: [?Bdom] eltType) where isDefaultRectangularArr(A) && isDefaultRectangularArr(B) {
+  compilerWarning('matMinus has been deprecated. ' +
+                  'try: A - B');
+  return A.minus(B);
 }
 
 /* Element-wise subtraction. Same as ``A - B``. */
@@ -640,7 +654,7 @@ private proc _matmatMult(A: [?Adom] ?eltType, B: [?Bdom] eltType)
 }
 
 
-/* Inner product of 2 vectors */
+/* Inner product of 2 vectors. */
 proc inner(A: [?Adom], B: [?Bdom]) {
   if Adom.rank != 1 || Bdom.rank != 1 then
     compilerError("Rank sizes are not 1");
@@ -651,7 +665,7 @@ proc inner(A: [?Adom], B: [?Bdom]) {
 }
 
 
-/* Outer product of 2 vectors */
+/* Outer product of 2 vectors. */
 proc outer(A: [?Adom] ?eltType, B: [?Bdom] eltType) {
   if Adom.rank != 1 || Bdom.rank != 1 then
     compilerError("Rank sizes are not 1");
@@ -664,7 +678,7 @@ proc outer(A: [?Adom] ?eltType, B: [?Bdom] eltType) {
 
 
 pragma "no doc"
-/* Generic matrix-vector multiplication */
+/* Generic matrix-vector multiplication. */
 proc _matvecMult(A: [?Adom] ?eltType, X: [?Xdom] eltType, trans=false)
   where !usingBLAS || !isBLASType(eltType)
 {
@@ -752,7 +766,7 @@ private proc _expBySquaring(x: ?t, n): _wrap(t) {
 }
 
 /* Return cross-product of 3-element vectors ``A`` and ``B`` with domain of
-  ``A`` */
+  ``A``. */
 proc cross(A: [?Adom] ?eltType, B: [?Bdom] eltType) {
   if Adom.rank != 1 || Bdom.rank != 1 then
     compilerError("Rank sizes are not 1");
@@ -1086,6 +1100,7 @@ proc cholesky(A: [] ?t, lower = true)
 }
 
 
+// TODO: add example usage to docs
 /* Find the eigenvalues and eigenvectors of matrix ``A``. ``A`` must be square.
 
    * If ``left`` is ``true`` then the "left" eigenvectors are computed. The
@@ -1109,7 +1124,6 @@ proc cholesky(A: [] ?t, lower = true)
       compiler error if ``lapackImpl`` is ``none``.
 
  */
-// TODO: example
 proc eigvals(A: [] ?t, param left = false, param right = false)
   where isRealType(t) && A.domain.rank == 2 && usingLAPACK {
 
@@ -1236,7 +1250,6 @@ proc eigvals(A: [] ?t, param left = false, param right = false)
     This procedure depends on the :mod:`LAPACK` module, and will generate a
     compiler error if ``lapackImpl`` is ``none``.
 */
-// TODO: example
 proc svd(A: [?Adom] ?t) throws
   where isLAPACKType(t) && usingLAPACK && Adom.rank == 2
 {

--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -158,48 +158,6 @@ specified in the function's documentation. Other domain maps
 are supported through submodules, such ``LinearAlgebra.Sparse`` for the
 ``CS`` layout.
 
-**Promotion flattening**
-
-Promotion flattening is an unintended consequence of Chapel's
-:ref:`promotion feature <ug-promotion>`, when a multi-dimensional array assignment
-gets type-inferred as a 1-dimensional array of the same size, effectively
-flattening the array dimensionality. This can result in unexpected behavior in
-programs such as this:
-
-.. code-block:: chapel
-
-  var A = Matrix(4, 4),
-      B = Matrix(4, 4);
-  // A + B is a promoted operation, and C becomes a 1D array
-  var C = A + B;
-  // This code would then result in an error due to rank mismatch:
-  C += A;
-
-To avoid this, you can avoid relying on inferred-types for new arrays:
-
-.. code-block:: chapel
-
-  var A = Matrix(4, 4),
-      B = Matrix(4, 4);
-  // C's type is not inferred and promotion flattening is not a problem
-  var C: [A.domain] A.eltType = A + B;
-  // Works as expected
-  C += A;
-
-Alternatively, you can use the LinearAlgebra helper routines, which create
-and return a new array:
-
-.. code-block:: chapel
-
-  var A = Matrix(4, 4),
-      B = Matrix(4, 4);
-  // matPlus will create a new array with an explicit type
-  var C = matPlus(A, B);
-  // Works as expected
-  C += A;
-
-Promotion flattening is not expected to be an issue in future releases.
-
 */
 
 module LinearAlgebra {

--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -177,15 +177,6 @@ arrays) will work with any other Chapel library that works with arrays.
 All functions that return arrays will inherit their domains from the input
 array if possible.  Otherwise they will return arrays with 1-based indices.
 
-**Matrix multiplication**
-
-:proc:`dot` is the general matrix multiplication function provided in this module.
-This function supports any combination of scalars, vectors (1D arrays), and
-matrices (2D arrays). See the :proc:`dot` documentation for more information.
-
-The :proc:`dot` function, along with others may be given a matrix-specific
-operator in future releases.
-
 **Row vs Column vectors**
 
 Row and column vectors are both represented as 1D arrays and are

--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -492,14 +492,7 @@ proc _array.T where isDefaultRectangularArr(this) && this.domain.rank == 2
   return transpose(this);
 }
 
-/* Add matrices, maintaining dimensions, deprecated for ``_array.plus`` */
-proc matPlus(A: [?Adom] ?eltType, B: [?Bdom] eltType) where isDefaultRectangularArr(A) && isDefaultRectangularArr(B) {
-  compilerWarning('matPlus has been deprecated for _array.plus, ' +
-                  'try: A.plus(B)');
-  return A.plus(B);
-}
-
-/* Add matrices, maintaining dimensions */
+/* Element-wise addition. Same as ``A + B``. */
 proc _array.plus(A: [?Adom] ?eltType) where isDefaultRectangularArr(A) && isDefaultRectangularArr(this) {
   if Adom.rank != this.domain.rank then compilerError("Unmatched ranks");
   if Adom.shape != this.domain.shape then halt("Unmatched shapes");
@@ -507,14 +500,7 @@ proc _array.plus(A: [?Adom] ?eltType) where isDefaultRectangularArr(A) && isDefa
   return C;
 }
 
-/* Subtract matrices, maintaining dimensions, deprecated for ``_array.minus``*/
-proc matMinus(A: [?Adom] ?eltType, B: [?Bdom] eltType) where isDefaultRectangularArr(A) && isDefaultRectangularArr(B) {
-  compilerWarning('matMinus has been deprecated for _array.plus, ' +
-                  'try: A.minus(B)');
-  return A.minus(B);
-}
-
-/* Subtract matrices, maintaining dimensions */
+/* Element-wise subtraction. Same as ``A - B``. */
 proc _array.minus(A: [?Adom] ?eltType) where isDefaultRectangularArr(A) && isDefaultRectangularArr(this) {
   if Adom.rank != this.domain.rank then compilerError("Unmatched ranks");
   if Adom.shape != this.domain.shape then halt("Unmatched shapes");
@@ -522,7 +508,7 @@ proc _array.minus(A: [?Adom] ?eltType) where isDefaultRectangularArr(A) && isDef
   return C;
 }
 
-/* Element-wise multiplication, maintaining dimensions */
+/* Element-wise multiplication. Same as ``A * B``. */
 proc _array.times(A: [?Adom]) where isDefaultRectangularArr(A) && isDefaultRectangularArr(this) {
   if Adom.rank != this.domain.rank then compilerError("Unmatched ranks");
   if Adom.shape != this.domain.shape then halt("Unmatched shapes");
@@ -530,7 +516,7 @@ proc _array.times(A: [?Adom]) where isDefaultRectangularArr(A) && isDefaultRecta
   return C;
 }
 
-/* Element-wise division, maintaining dimensions */
+/* Element-wise division. Same as ``A / B``. */
 proc _array.elementDiv(A: [?Adom]) where isDefaultRectangularArr(A) && isDefaultRectangularArr(this) {
   if Adom.rank != this.domain.rank then compilerError("Unmatched ranks");
   if Adom.shape != this.domain.shape then halt("Unmatched shapes");
@@ -578,7 +564,7 @@ proc _array.dot(A: []) where isDefaultRectangularArr(this) && isDefaultRectangul
 
 
 pragma "no doc"
-/* Element-wise scalar multiplication */
+/* Element-wise scalar multiplication. */
 proc dot(A: [?Adom] ?eltType, b) where isNumeric(b) {
   var C: A.type = A * b;
   return C;
@@ -1122,6 +1108,8 @@ proc cholesky(A: [] ?t, lower = true)
       compiler error if ``lapackImpl`` is ``none``.
 
  */
+// TODO: example
+// TODO: LaTeX
 proc eigvals(A: [] ?t, param left = false, param right = false)
   where isRealType(t) && A.domain.rank == 2 && usingLAPACK {
 
@@ -1220,6 +1208,8 @@ proc eigvals(A: [] ?t, param left = false, param right = false)
 
    A temporary copy of ``A`` will be created within this computation.
 */
+// TODO: example
+// TODO: LaTeX
 proc svd(A: [?Adom] ?t) throws
   where isLAPACKType(t) && usingLAPACK && Adom.rank == 2
 {
@@ -1248,7 +1238,7 @@ proc svd(A: [?Adom] ?t) throws
   // elements of upper bidiagonal matrix 'B' whose diagonal is in 's'.
   var superb: [1..minDim-1] realType;
 
-  // TODO: Support gesdd for better performance
+  // TODO: Support option for gesdd (trading memory usage for speed)
   const info = LAPACK.gesvd(lapack_memory_order.row_major, 'A', 'A', Acopy, s, u, vt, superb);
 
   if info > 0 {
@@ -1814,7 +1804,7 @@ module Sparse {
   /* Transpose CSR matrix */
   proc _array.T where isCSArr(this) { return transpose(this); }
 
-  /* Element-wise addition */
+  /* Element-wise addition. */
   proc _array.plus(A: [?Adom] ?eltType) where isCSArr(this) && isCSArr(A) {
     if Adom.rank != this.domain.rank then compilerError("Unmatched ranks");
     if this.domain.shape != Adom.shape then halt("Unmatched shapes");
@@ -1828,7 +1818,7 @@ module Sparse {
     return S;
   }
 
-  /* Element-wise subtraction */
+  /* Element-wise subtraction. */
   proc _array.minus(A: [?Adom] ?eltType) where isCSArr(this) && isCSArr(A) {
     if Adom.rank != this.domain.rank then compilerError("Unmatched ranks");
     if this.domain.shape != Adom.shape then halt("Unmatched shapes");
@@ -1842,7 +1832,7 @@ module Sparse {
     return S;
   }
 
-  /* Element-wise multiplication */
+  /* Element-wise multiplication. */
   proc _array.times(A) where isCSArr(this) && isCSArr(A) {
     if this.domain._value.parentDom != A.domain._value.parentDom then
       halt('Cannot subtract sparse arrays with non-matching parent domains');
@@ -1863,7 +1853,7 @@ module Sparse {
     return B;
   }
 
-  /* Element-wise division */
+  /* Element-wise division. */
   proc _array.elementDiv(A) where isCSArr(this) && isCSArr(A) {
     if this.domain._value.parentDom != A.domain._value.parentDom then
       halt('Cannot element-wise divide sparse arrays with non-matching parent domains');

--- a/test/release/examples/primers/LinearAlgebralib.chpl
+++ b/test/release/examples/primers/LinearAlgebralib.chpl
@@ -261,21 +261,17 @@ A = 1.0;
 B = 2.0;
 
 
-// Element-wise addition (avoiding promotion flattening)
-var ApB = A.plus(B);
-assert(ApB.rank == 2); // not flattened!
+// Element-wise addition
+var ApB = A + B;
 
-// Element-wise subtraction (avoiding promotion flattening)
-var AmB = A.minus(B);
-assert(AmB.rank == 2); // not flattened!
+// Element-wise subtraction
+var AmB = A - B;
 
-// Element-wise multiplication (avoiding promotion flattening)
-var AtB = A.times(B);
-assert(AtB.rank == 2); // not flattened!
+// Element-wise multiplication
+var AtB = A * B;
 
-// Element-wise division (avoiding promotion flattening)
-var AdB = A.elementDiv(B);
-assert(AdB.rank == 2); // not flattened!
+// Element-wise division
+var AdB = A / B;
 
 // Taking the transpose of a matrix:
 var M0T = transpose(M0);
@@ -390,19 +386,6 @@ writeln(upper);
 // Confirm that a matrix is upper triangular
 writeln(isTriu(upper));         // true
 writeln(isTriu(upper, k=1));    // false (k=1 does not include diagonal)
-
-/*
-
-  Caveats
-  -------
-
-  There are a few pitfalls to be aware of when working with the
-  :mod:`LinearAlgebra` module.
-
-  One potential *gotcha* is **Promotion Flattening**, which is described in the
-  :ref:`LinearAlgebraInterface` documentation.
-
-*/
 
 /*
 


### PR DESCRIPTION
This PR improves documentation for `LinearAlgebra` in a number of ways:

- Adds more information about building with and without dependencies
- Removes mentions of promotion flattening from documentation and primer
  - Redirects users of `matPlus` / `matMinus` to use `A + B` / `A - B` now.
- Improves documentation of `svd()`
- Removes documentation of `dot` from top section

