### PR TITLE
Improve work-in-progress messages in module documentation

### DIFF
--- a/modules/packages/Collection.chpl
+++ b/modules/packages/Collection.chpl
@@ -39,8 +39,7 @@
 
   .. note::
 
-    The interface for the Collection modules may change. The documentation for
-    the Collection modules are being incrementally revised and improved.
+    This module is a work in progress and may change in future releases.
 
   Bugs and Known Issues
   _____________________

--- a/modules/packages/DistributedBag.chpl
+++ b/modules/packages/DistributedBag.chpl
@@ -76,8 +76,7 @@
 
   .. note::
 
-    This package module is new in 1.16 and may contain bugs. The interface may
-    change.  The documentation is being incrementally revised and improved.
+    This module is a work in progress and may change in future releases.
 
   Usage
   _____

--- a/modules/packages/DistributedDeque.chpl
+++ b/modules/packages/DistributedDeque.chpl
@@ -73,8 +73,7 @@
 
   .. note::
 
-    This package module is new in 1.16 and may contain bugs. The interface may
-    change.  The documentation is being incrementally revised and improved
+    This module is a work in progress and may change in future releases.
 
   Usage
   _____

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -274,7 +274,7 @@ proc chpl_check_comparator(comparator, type eltType) {
 /* Basic Functions */
 
 /*
-   General purpose sorting interface. This procedure calls :proc:`quickSort`.
+   General purpose sorting interface.
 
    :arg Data: The array to be sorted
    :type Data: [] `eltType`
@@ -528,7 +528,7 @@ proc binaryInsertionSort(Data: [?Dom] ?eltType, comparator:?rec=defaultComparato
   for i in low..high by stride {
     var valToInsert = Data[i],
         lo = low,
-        hi = i - stride; 
+        hi = i - stride;
 
     var (found, loc) = _binarySearchForLastOccurrence(Data, valToInsert, comparator, lo, hi);
     loc = if found then loc + stride else loc;              // insert after last occurrence if exists; else insert after expected location

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -274,10 +274,7 @@ proc chpl_check_comparator(comparator, type eltType) {
 /* Basic Functions */
 
 /*
-   General purpose sorting interface.
-
-   .. note:: Currently this method calls a sequential :proc:`quickSort`, but
-             this may change the future as other algorithms are implemented.
+   General purpose sorting interface. This procedure calls :proc:`quickSort`.
 
    :arg Data: The array to be sorted
    :type Data: [] `eltType`

--- a/modules/packages/TOML.chpl
+++ b/modules/packages/TOML.chpl
@@ -25,15 +25,8 @@ This module provides support for parsing and writing toml files.
 
   .. note::
 
-    The TOML library for chapel is a work in progress. Many of the types listed in the `TOML specification <https://github.com/toml-lang/toml>`_ are not supported by this library. A core group of the spec is followed, but the library currently does not support the following types:
-      - Array of tables
-      - Exponent reals
-      - Underscore notation for integers and reals
-      - Date
-      - Time
-      - Datetime with offset
-
-    Other known issues with the library can be found in the `Improve Toml issue <https://github.com/chapel-lang/chapel/issues/7104>`_.
+    The planned features and known limitations of this module can be found in
+    `Improve Toml issue <https://github.com/chapel-lang/chapel/issues/7104>`_.
 
 
 */

--- a/modules/standard/Spawn.chpl
+++ b/modules/standard/Spawn.chpl
@@ -20,9 +20,6 @@
 
 /*
 
-.. versionadded:: 1.12
-  Spawn module added.
-
 Support launching and interacting with other programs.
 
 Using functions in this module, one can create a subprocess
@@ -123,7 +120,7 @@ other task is consuming it.
 
 .. note::
 
-  As of Chapel v1.12, creating a subprocess that uses :const:`PIPE` to provide
+  Creating a subprocess that uses :const:`PIPE` to provide
   input or capture output does not work when using the ugni communications layer
   with hugepages enabled and when using more than one locale. In this
   circumstance, the program will halt with an error message. These scenarios do


### PR DESCRIPTION
This PR aims to reduce redundant text in WIP documentation notes, remove version numbers referenced in WIP messages, and remove planned feature lists when an issue link is already present.

This PR only updates messages that should be pretty straightforward and not require much discussion. Other messages might be best handled once a best practice is established for these WIP notes (https://github.com/chapel-lang/chapel/issues/11071).