### PR TITLE
Convert LCALS to use managed classes

### DIFF
--- a/test/release/examples/benchmarks/lcals/LCALSChecksums.chpl
+++ b/test/release/examples/benchmarks/lcals/LCALSChecksums.chpl
@@ -51,7 +51,7 @@ module LCALSChecksums {
       const varStr = (variant:string).toLower();
       for loopKernel in chpl_enumerate(LoopKernelID) {
         const kerStr = (loopKernel:string).toLower();
-        var stat = suite_run_info.getLoopStats(variant)[loopKernel];
+        var stat = suite_run_info.getLoopStats(variant)[loopKernel].borrow();
         for length in chpl_enumerate(LoopLength) {
           const lenStr = (length:string).toLower();
           if run_loop[loopKernel] && stat.loop_is_run && stat.loop_run_count[length] > 0 {

--- a/test/release/examples/benchmarks/lcals/LCALSDataTypes.chpl
+++ b/test/release/examples/benchmarks/lcals/LCALSDataTypes.chpl
@@ -56,7 +56,7 @@ module LCALSDataTypes {
     var loop_weight: real;
     var loop_length_dom = {LoopLength.LONG..LoopLength.SHORT};
 
-    var loop_run_time: [loop_length_dom] unmanaged vector(real);
+    var loop_run_time: [loop_length_dom] owned vector(real);
     var loop_run_count: [loop_length_dom] int;
     var mean: [loop_length_dom] real;
     var std_dev: [loop_length_dom] real;
@@ -71,12 +71,7 @@ module LCALSDataTypes {
     var loop_chksum: [loop_length_dom] real;
 
     proc init() {
-      loop_run_time = for i in loop_length_dom do new unmanaged vector(real);
-    }
-
-    proc deinit() {
-      for lrt in loop_run_time do
-        if lrt != nil then delete lrt;
+      loop_run_time = for i in loop_length_dom do new owned vector(real);
     }
   }
 
@@ -254,12 +249,9 @@ module LCALSDataTypes {
     // class implements the same pattern used in the LCALS reference.
     //
     // var RealArray_3D_2xNx4: [0..#s_num_3D_2xNx4_Real_arrays][0..#2, 0..#aligned_chunksize, 0..#4] real;
-    var RealArray_3D_2xNx4: [0..#s_num_3D_2xNx4_Real_arrays] unmanaged LCALS_Overlapping_Array_3D(real) = [i in 0..#s_num_3D_2xNx4_Real_arrays] new unmanaged LCALS_Overlapping_Array_3D(real, 2*4*aligned_chunksize); // 2 X loop_length X 4 array size
+    var RealArray_3D_2xNx4: [0..#s_num_3D_2xNx4_Real_arrays] owned LCALS_Overlapping_Array_3D(real) = [i in 0..#s_num_3D_2xNx4_Real_arrays] new owned LCALS_Overlapping_Array_3D(real, 2*4*aligned_chunksize); // 2 X loop_length X 4 array size
 
     var RealArray_scalars: [0..#s_num_Real_scalars] real;
-    proc deinit() {
-      for arr in RealArray_3D_2xNx4 do delete arr;
-    }
   }
 
   /* Mimic the strange, self-overlapping 3D array in the LCALS

--- a/test/release/examples/benchmarks/lcals/LCALSDataTypes.chpl
+++ b/test/release/examples/benchmarks/lcals/LCALSDataTypes.chpl
@@ -35,7 +35,7 @@ module LCALSDataTypes {
     var num_suite_passes: int;
     var loop_samp_frac: real;
 
-    var ref_loop_stat: unmanaged LoopStat;
+    var ref_loop_stat: owned LoopStat;
 
     var loop_weights: [weight_group_dom] real;
 
@@ -51,8 +51,6 @@ module LCALSDataTypes {
     }
 
     proc deinit() {
-      if ref_loop_stat != nil then delete ref_loop_stat;
-
       for idx in loop_variant_dom {
         for stat in loop_test_stats[idx] do
           if stat != nil then delete stat;

--- a/test/release/examples/benchmarks/lcals/LCALSDataTypes.chpl
+++ b/test/release/examples/benchmarks/lcals/LCALSDataTypes.chpl
@@ -44,17 +44,10 @@ module LCALSDataTypes {
     var cache_flush_data: [cache_flush_data_dom] real;
     var cache_flush_data_sum: real;
 
-    var loop_test_stats: [loop_variant_dom] [loop_kernel_dom] unmanaged LoopStat;
+    var loop_test_stats: [loop_variant_dom] [loop_kernel_dom] owned LoopStat;
 
     proc getLoopStats(loop_variant: LoopVariantID) ref {
       return loop_test_stats[loop_variant];
-    }
-
-    proc deinit() {
-      for idx in loop_variant_dom {
-        for stat in loop_test_stats[idx] do
-          if stat != nil then delete stat;
-      }
     }
   }
 

--- a/test/release/examples/benchmarks/lcals/LCALSEnums.chpl
+++ b/test/release/examples/benchmarks/lcals/LCALSEnums.chpl
@@ -64,7 +64,7 @@ module LCALSEnums {
     //
     // These variants define LCALS benchmark
     //
-    RAW,
+    RAW = 1,
     RAW_OMP,
     RAW_SPMD,
     RAW_VECTOR_ONLY,

--- a/test/release/examples/benchmarks/lcals/LCALSLoops.chpl
+++ b/test/release/examples/benchmarks/lcals/LCALSLoops.chpl
@@ -382,7 +382,7 @@ module LCALSLoops {
     var loop_data = getLoopData();
     var len: int = lstat.loop_length[ilen];
     var num_samples = lstat.samples_per_pass[ilen];
-    var ltimer = new unmanaged LoopTimer();
+    var ltimer = new owned LoopTimer();
 
     loopInit(LoopKernelID.REF_LOOP, lstat);
 
@@ -404,7 +404,7 @@ module LCALSLoops {
 
     var len = lstat.loop_length[ilen];
     var num_samples = lstat.samples_per_pass[ilen];
-    var ltimer = new unmanaged LoopTimer();
+    var ltimer = new owned LoopTimer();
 
     loopInit(LoopKernelID.REF_LOOP, lstat);
 

--- a/test/release/examples/benchmarks/lcals/LCALSLoops.chpl
+++ b/test/release/examples/benchmarks/lcals/LCALSLoops.chpl
@@ -215,11 +215,11 @@ module LCALSLoops {
     }
   }
 
-  proc initChksum(stat: unmanaged LoopStat, ilength: LoopLength) {
+  proc initChksum(stat: LoopStat, ilength: LoopLength) {
     stat.loop_chksum[ilength] = 0.0;
   }
 
-  proc loopFinalize(iloop: LoopKernelID, stat: unmanaged LoopStat, ilength: LoopLength) {
+  proc loopFinalize(iloop: LoopKernelID, stat: LoopStat, ilength: LoopLength) {
     initChksum(stat, ilength);
     var loop_data = getLoopData();
     select iloop {
@@ -343,7 +343,7 @@ module LCALSLoops {
     }
   }
 
-  proc updateChksum(stat: unmanaged LoopStat, ilength: LoopLength, ra: unmanaged LCALS_Overlapping_Array_3D(real), scale_factor: real = 1.0) {
+  proc updateChksum(stat: LoopStat, ilength: LoopLength, ra: unmanaged LCALS_Overlapping_Array_3D(real), scale_factor: real = 1.0) {
     var len = ra.len;
     var tchk = stat.loop_chksum[ilength];
     for (j, dat) in zip(0..#len, ra) {
@@ -352,7 +352,7 @@ module LCALSLoops {
     stat.loop_chksum[ilength] = tchk;
   }
 
-  proc updateChksum(stat: unmanaged LoopStat, ilength: LoopLength, ra: [] real, scale_factor: real = 1.0) {
+  proc updateChksum(stat: LoopStat, ilength: LoopLength, ra: [] real, scale_factor: real = 1.0) {
     use LongDouble;
 
     ref data = ra;
@@ -365,10 +365,10 @@ module LCALSLoops {
     stat.loop_chksum[ilength] = tchk:real;
   }
 
-  proc updateChksum(stat: unmanaged LoopStat, ilength: LoopLength, val: real) {
+  proc updateChksum(stat: LoopStat, ilength: LoopLength, val: real) {
     stat.loop_chksum[ilength] += val;
   }
-  proc updateChksum(stat: unmanaged LoopStat, ilength: LoopLength, ca: [] complex, scale_factor: real = 1.0) {
+  proc updateChksum(stat: LoopStat, ilength: LoopLength, ca: [] complex, scale_factor: real = 1.0) {
     ref data = ca;
     var len = ca.numElements;
     var tchk = stat.loop_chksum[ilength];

--- a/test/release/examples/benchmarks/lcals/LCALSLoops.chpl
+++ b/test/release/examples/benchmarks/lcals/LCALSLoops.chpl
@@ -39,7 +39,7 @@ module LCALSLoops {
     }
   }
 
-  proc loopInit(iloop:LoopKernelID, stat: unmanaged LoopStat) {
+  proc loopInit(iloop:LoopKernelID, stat: LoopStat) {
     var loop_data = getLoopData();
     flushCache();
     stat.loop_is_run = true;
@@ -378,7 +378,7 @@ module LCALSLoops {
     stat.loop_chksum[ilength] = tchk;
   }
 
-  proc runReferenceLoop0(lstat: unmanaged LoopStat, ilen: LoopLength) {
+  proc runReferenceLoop0(lstat: LoopStat, ilen: LoopLength) {
     var loop_data = getLoopData();
     var len: int = lstat.loop_length[ilen];
     var num_samples = lstat.samples_per_pass[ilen];
@@ -399,7 +399,7 @@ module LCALSLoops {
     copyTimer(lstat, ilen, ltimer);
   }
 
-  proc runReferenceLoop1(lstat: unmanaged LoopStat, ilen: LoopLength) {
+  proc runReferenceLoop1(lstat: LoopStat, ilen: LoopLength) {
     var loop_data = getLoopData();
 
     var len = lstat.loop_length[ilen];

--- a/test/release/examples/benchmarks/lcals/LCALSLoops.chpl
+++ b/test/release/examples/benchmarks/lcals/LCALSLoops.chpl
@@ -25,7 +25,7 @@ module LCALSLoops {
     ia = 0;
   }
 
-  proc initData(ra: unmanaged LCALS_Overlapping_Array_3D(real), id: int) {
+  proc initData(ra: LCALS_Overlapping_Array_3D(real), id: int) {
     const factor: Real_type = if id % 2 != 0 then 0.1 else 0.2;
     for (r,j) in zip(ra, 0..) {
       r = factor*(j + 1.1)/(j + 1.12345);
@@ -343,7 +343,7 @@ module LCALSLoops {
     }
   }
 
-  proc updateChksum(stat: LoopStat, ilength: LoopLength, ra: unmanaged LCALS_Overlapping_Array_3D(real), scale_factor: real = 1.0) {
+  proc updateChksum(stat: LoopStat, ilength: LoopLength, ra: LCALS_Overlapping_Array_3D(real), scale_factor: real = 1.0) {
     var len = ra.len;
     var tchk = stat.loop_chksum[ilength];
     for (j, dat) in zip(0..#len, ra) {

--- a/test/release/examples/benchmarks/lcals/LCALSMain.chpl
+++ b/test/release/examples/benchmarks/lcals/LCALSMain.chpl
@@ -447,7 +447,7 @@ proc writeTimingSummaryReport(loop_variants: [] bool, outchannel) {
     var ref_mean = ref_variant_stat.mean;
 
     if loop_names[iloop].length != 0 && ref_variant_stat.loop_is_run {
-      if iloop > 1 {
+      if iloop:int > 1 {
         outchannel.write("\n", dash_line_part);
       }
       outchannel.writef("%s (%i) --> ", loop_names[iloop], iloop);
@@ -564,7 +564,7 @@ proc writeChecksumReport(loop_variants: [] bool, outchannel) {
     var ref_variant_stat = suite_run_info.getLoopStats(LoopVariantID.RAW)[iloop];
     var ref_chksum = ref_variant_stat.loop_chksum;
     if loop_names[iloop].length != 0 && ref_variant_stat.loop_is_run {
-      if iloop > 1 then
+      if iloop:int > 1 then
         outchannel.write("\n", dash_line_part);
       outchannel.write(loop_names[iloop], "(", iloop:int, ") --> ");
       for (ilv, variant) in zip(0..#nvariants, loop_variant_names.domain) {

--- a/test/release/examples/benchmarks/lcals/LCALSMain.chpl
+++ b/test/release/examples/benchmarks/lcals/LCALSMain.chpl
@@ -183,9 +183,7 @@ proc main {
 
   checkChecksums(run_variants, run_loop, run_loop_length);
 
-  freeLoopData();
   writeln("\n freeLoopSuiteRunInfo...");
-  freeLoopSuiteRunInfo();
   writeln("\n DONE!!! ");
 }
 
@@ -599,14 +597,6 @@ proc generateFOMReport(loop_variants: [] bool,
                        output_dirname: string) {
 }
 
-proc freeLoopData() {
-  delete s_loop_data;
-}
-
-proc freeLoopSuiteRunInfo() {
-  delete getLoopSuiteRunInfo();
-}
-
 proc runLoopVariant(lvid: LoopVariantID, run_loop:[] bool, ilength: LoopLength) {
   var loop_suite_run_info = getLoopSuiteRunInfo();
   var loop_stats = loop_suite_run_info.getLoopStats(lvid);
@@ -707,9 +697,9 @@ proc getVariantNames(lvids: [] bool) {
 
 proc computeReferenceLoopTimes() {
   var suite_info = getLoopSuiteRunInfo();
-  var ref_loop_stat = suite_info.ref_loop_stat;
+  var ref_loop_stat = suite_info.ref_loop_stat.borrow();
 
-  var lstat0: unmanaged LoopStat;
+  var lstat0: LoopStat;
 
   writeln("\n computeReferenceLoopTimes...");
 
@@ -719,7 +709,7 @@ proc computeReferenceLoopTimes() {
     runReferenceLoop0(lstat0, ilen);
   }
 
-  var lstat1: unmanaged LoopStat;
+  var lstat1: LoopStat;
   lstat1 = ref_loop_stat;
 
   for ilen in suite_info.loop_length_dom {
@@ -734,8 +724,8 @@ proc computeReferenceLoopTimes() {
 
 proc defineReferenceLoopRunInfo() {
   var suite_info = getLoopSuiteRunInfo();
-  var ref_loop_stat = new unmanaged LoopStat();
-  suite_info.ref_loop_stat = ref_loop_stat;
+  suite_info.ref_loop_stat = new owned LoopStat();
+  var ref_loop_stat = suite_info.ref_loop_stat.borrow();
 
   ref_loop_stat.loop_length[LoopLength.LONG]        = 24336;
   ref_loop_stat.loop_length[LoopLength.MEDIUM]      = 3844;
@@ -1149,6 +1139,6 @@ proc defineLoopSuiteRunInfo(run_variants, run_loop,
     }
   }
   defineReferenceLoopRunInfo();
-  s_loop_data = new unmanaged LoopData(max(max_loop_length, suite_info.ref_loop_stat.loop_length[LoopLength.LONG]));
+  s_loop_data = new owned LoopData(max(max_loop_length, suite_info.ref_loop_stat.loop_length[LoopLength.LONG]));
 
 }

--- a/test/release/examples/benchmarks/lcals/LCALSMain.chpl
+++ b/test/release/examples/benchmarks/lcals/LCALSMain.chpl
@@ -191,7 +191,7 @@ proc computeStats(ilv: LoopVariantID, loop_stats: [] owned LoopStat, do_fom: boo
   for stat in loop_stats {
     for ilen in stat.loop_length_dom {
       if stat.loop_run_count[ilen] > 0 {
-        var time_sample = stat.loop_run_time[ilen];
+        var time_sample = stat.loop_run_time[ilen].borrow();
         var sample_size = time_sample.numElements;
         var mean = 0.0;
         var sdev = 0.0;

--- a/test/release/examples/benchmarks/lcals/LCALSStatic.chpl
+++ b/test/release/examples/benchmarks/lcals/LCALSStatic.chpl
@@ -1,14 +1,14 @@
 module LCALSStatic {
   use LCALSDataTypes;
 
-  var s_loop_data: unmanaged LoopData;
-  var s_loop_suite_run_info = new unmanaged LoopSuiteRunInfo();
+  var s_loop_data: owned LoopData;
+  var s_loop_suite_run_info = new owned LoopSuiteRunInfo();
 
   proc getLoopSuiteRunInfo() {
-    return s_loop_suite_run_info;
+    return s_loop_suite_run_info.borrow();
   }
 
   proc getLoopData() {
-    return s_loop_data;
+    return s_loop_data.borrow();
   }
 }

--- a/test/release/examples/benchmarks/lcals/RunARawLoops.chpl
+++ b/test/release/examples/benchmarks/lcals/RunARawLoops.chpl
@@ -2,13 +2,13 @@ module RunARawLoops {
   use LCALSDataTypes;
   use Timer;
 
-  proc runARawLoops(loop_stats:[] unmanaged LoopStat, run_loop:[] bool, ilength: LoopLength) {
+  proc runARawLoops(loop_stats:[] owned LoopStat, run_loop:[] bool, ilength: LoopLength) {
     var loop_suite_run_info = getLoopSuiteRunInfo();
     var loop_data = getLoopData();
 
     for iloop in loop_suite_run_info.loop_kernel_dom {
       if run_loop[iloop] {
-        var stat = loop_stats[iloop];
+        var stat = loop_stats[iloop].borrow();
         var len = stat.loop_length[ilength];
         var num_samples = stat.samples_per_pass[ilength];
         var ltimer = new owned LoopTimer();

--- a/test/release/examples/benchmarks/lcals/RunARawLoops.chpl
+++ b/test/release/examples/benchmarks/lcals/RunARawLoops.chpl
@@ -11,7 +11,7 @@ module RunARawLoops {
         var stat = loop_stats[iloop];
         var len = stat.loop_length[ilength];
         var num_samples = stat.samples_per_pass[ilength];
-        var ltimer = new unmanaged LoopTimer();
+        var ltimer = new owned LoopTimer();
 
         select iloop {
           when LoopKernelID.PRESSURE_CALC {
@@ -391,7 +391,6 @@ module RunARawLoops {
           }
         }
         copyTimer(stat, ilength, ltimer);
-        delete ltimer;
       }
     }
   }

--- a/test/release/examples/benchmarks/lcals/RunBRawLoops.chpl
+++ b/test/release/examples/benchmarks/lcals/RunBRawLoops.chpl
@@ -17,7 +17,7 @@ module RunBRawLoops {
         var stat = loop_stats[iloop];
         var len = stat.loop_length[ilength];
         var num_samples = stat.samples_per_pass[ilength];
-        var ltimer = new unmanaged LoopTimer();
+        var ltimer = new owned LoopTimer();
 
         select iloop {
           when LoopKernelID.INIT3 {
@@ -112,7 +112,6 @@ module RunBRawLoops {
           }
         }
         copyTimer(stat, ilength, ltimer);
-        delete ltimer;
       }
     }
   }

--- a/test/release/examples/benchmarks/lcals/RunBRawLoops.chpl
+++ b/test/release/examples/benchmarks/lcals/RunBRawLoops.chpl
@@ -9,12 +9,12 @@ module RunBRawLoops {
     return 1.0 / sqrt(denom);
   }
 
-  proc runBRawLoops(loop_stats:[] unmanaged LoopStat, run_loop:[] bool, ilength: LoopLength) {
+  proc runBRawLoops(loop_stats:[] owned LoopStat, run_loop:[] bool, ilength: LoopLength) {
     var loop_suite_run_info = getLoopSuiteRunInfo();
     var loop_data = getLoopData();
     for iloop in loop_suite_run_info.loop_kernel_dom {
       if run_loop[iloop] {
-        var stat = loop_stats[iloop];
+        var stat = loop_stats[iloop].borrow();
         var len = stat.loop_length[ilength];
         var num_samples = stat.samples_per_pass[ilength];
         var ltimer = new owned LoopTimer();

--- a/test/release/examples/benchmarks/lcals/RunCRawLoops.chpl
+++ b/test/release/examples/benchmarks/lcals/RunCRawLoops.chpl
@@ -10,7 +10,7 @@ module RunCRawLoops {
         var stat = loop_stats[iloop];
         var len = stat.loop_length[ilength];
         var num_samples = stat.samples_per_pass[ilength];
-        var ltimer = new unmanaged LoopTimer();
+        var ltimer = new owned LoopTimer();
 
         select iloop {
           when LoopKernelID.HYDRO_1D {
@@ -532,7 +532,6 @@ module RunCRawLoops {
           }
         }
         copyTimer(stat, ilength, ltimer);
-        delete ltimer;
       }
     }
   }

--- a/test/release/examples/benchmarks/lcals/RunCRawLoops.chpl
+++ b/test/release/examples/benchmarks/lcals/RunCRawLoops.chpl
@@ -2,12 +2,12 @@ module RunCRawLoops {
   use LCALSDataTypes;
   use Timer;
 
-  proc runCRawLoops(loop_stats:[] unmanaged LoopStat, run_loop:[] bool, ilength: LoopLength) {
+  proc runCRawLoops(loop_stats:[] owned LoopStat, run_loop:[] bool, ilength: LoopLength) {
     var loop_suite_run_info = getLoopSuiteRunInfo();
     var loop_data = getLoopData();
     for iloop in loop_suite_run_info.loop_kernel_dom {
       if run_loop[iloop] {
-        var stat = loop_stats[iloop];
+        var stat = loop_stats[iloop].borrow();
         var len = stat.loop_length[ilength];
         var num_samples = stat.samples_per_pass[ilength];
         var ltimer = new owned LoopTimer();

--- a/test/release/examples/benchmarks/lcals/RunCRawLoops.chpl
+++ b/test/release/examples/benchmarks/lcals/RunCRawLoops.chpl
@@ -134,9 +134,9 @@ module RunCRawLoops {
                 du2 = loop_data.RealArray_1D[1],
                 du3 = loop_data.RealArray_1D[2];
 
-            var u1 = loop_data.RealArray_3D_2xNx4[0],
-                u2 = loop_data.RealArray_3D_2xNx4[1],
-                u3 = loop_data.RealArray_3D_2xNx4[2];
+            var u1 = loop_data.RealArray_3D_2xNx4[0].borrow(),
+                u2 = loop_data.RealArray_3D_2xNx4[1].borrow(),
+                u3 = loop_data.RealArray_3D_2xNx4[2].borrow();
 
             const sig = loop_data.RealArray_scalars[0],
                   a11 = loop_data.RealArray_scalars[1],

--- a/test/release/examples/benchmarks/lcals/RunParallelRawLoops.chpl
+++ b/test/release/examples/benchmarks/lcals/RunParallelRawLoops.chpl
@@ -11,7 +11,7 @@ module RunParallelRawLoops {
         var stat = loop_stats[iloop];
         var len = stat.loop_length[ilength];
         var num_samples = stat.samples_per_pass[ilength];
-        var ltimer = new unmanaged LoopTimer();
+        var ltimer = new owned LoopTimer();
 
         select iloop {
           when LoopKernelID.PRESSURE_CALC {
@@ -546,7 +546,6 @@ module RunParallelRawLoops {
           }
         }
         copyTimer(stat, ilength, ltimer);
-        delete ltimer;
       }
     }
   }

--- a/test/release/examples/benchmarks/lcals/RunParallelRawLoops.chpl
+++ b/test/release/examples/benchmarks/lcals/RunParallelRawLoops.chpl
@@ -2,13 +2,13 @@ module RunParallelRawLoops {
   use LCALSDataTypes;
   use Timer;
 
-  proc runParallelRawLoops(loop_stats:[] unmanaged LoopStat, run_loop:[] bool, ilength: LoopLength) {
+  proc runParallelRawLoops(loop_stats:[] owned LoopStat, run_loop:[] bool, ilength: LoopLength) {
     var loop_suite_run_info = getLoopSuiteRunInfo();
     var loop_data = getLoopData();
 
     for iloop in loop_suite_run_info.loop_kernel_dom {
       if run_loop[iloop] {
-        var stat = loop_stats[iloop];
+        var stat = loop_stats[iloop].borrow();
         var len = stat.loop_length[ilength];
         var num_samples = stat.samples_per_pass[ilength];
         var ltimer = new owned LoopTimer();

--- a/test/release/examples/benchmarks/lcals/RunSPMDRawLoops.chpl
+++ b/test/release/examples/benchmarks/lcals/RunSPMDRawLoops.chpl
@@ -29,7 +29,7 @@ module RunSPMDRawLoops {
         var stat = loop_stats[iloop];
         var len = stat.loop_length[ilength];
         var num_samples = stat.samples_per_pass[ilength];
-        var ltimer = new unmanaged LoopTimer();
+        var ltimer = new owned LoopTimer();
 
         select iloop {
           when LoopKernelID.PRESSURE_CALC {
@@ -680,7 +680,6 @@ module RunSPMDRawLoops {
           }
         }
         copyTimer(stat, ilength, ltimer);
-        delete ltimer;
       }
     }
   }

--- a/test/release/examples/benchmarks/lcals/RunSPMDRawLoops.chpl
+++ b/test/release/examples/benchmarks/lcals/RunSPMDRawLoops.chpl
@@ -8,7 +8,7 @@ module RunSPMDRawLoops {
   use LCALSDataTypes;
   use Timer, Barriers, RangeChunk;
 
-  proc runSPMDRawLoops(loop_stats:[] unmanaged LoopStat, run_loop:[] bool, ilength: LoopLength) {
+  proc runSPMDRawLoops(loop_stats:[] owned LoopStat, run_loop:[] bool, ilength: LoopLength) {
     var loop_suite_run_info = getLoopSuiteRunInfo();
     var loop_data = getLoopData();
 
@@ -26,7 +26,7 @@ module RunSPMDRawLoops {
 
     for iloop in loop_suite_run_info.loop_kernel_dom {
       if run_loop[iloop] {
-        var stat = loop_stats[iloop];
+        var stat = loop_stats[iloop].borrow();
         var len = stat.loop_length[ilength];
         var num_samples = stat.samples_per_pass[ilength];
         var ltimer = new owned LoopTimer();

--- a/test/release/examples/benchmarks/lcals/RunVectorizeOnlyRawLoops.chpl
+++ b/test/release/examples/benchmarks/lcals/RunVectorizeOnlyRawLoops.chpl
@@ -11,7 +11,7 @@ module RunVectorizeOnlyRawLoops {
         var stat = loop_stats[iloop];
         var len = stat.loop_length[ilength];
         var num_samples = stat.samples_per_pass[ilength];
-        var ltimer = new unmanaged LoopTimer();
+        var ltimer = new owned LoopTimer();
 
         select iloop {
           when LoopKernelID.PRESSURE_CALC {
@@ -547,7 +547,6 @@ module RunVectorizeOnlyRawLoops {
           }
         }
         copyTimer(stat, ilength, ltimer);
-        delete ltimer;
       }
     }
   }

--- a/test/release/examples/benchmarks/lcals/RunVectorizeOnlyRawLoops.chpl
+++ b/test/release/examples/benchmarks/lcals/RunVectorizeOnlyRawLoops.chpl
@@ -2,13 +2,13 @@ module RunVectorizeOnlyRawLoops {
   use LCALSDataTypes;
   use Timer;
 
-  proc runVectorizeOnlyRawLoops(loop_stats: [] unmanaged LoopStat, run_loop:[] bool, ilength: LoopLength) {
+  proc runVectorizeOnlyRawLoops(loop_stats: [] owned LoopStat, run_loop:[] bool, ilength: LoopLength) {
     var loop_suite_run_info = getLoopSuiteRunInfo();
     var loop_data = getLoopData();
 
     for iloop in loop_suite_run_info.loop_kernel_dom {
       if run_loop[iloop] {
-        var stat = loop_stats[iloop];
+        var stat = loop_stats[iloop].borrow();
         var len = stat.loop_length[ilength];
         var num_samples = stat.samples_per_pass[ilength];
         var ltimer = new owned LoopTimer();

--- a/test/release/examples/benchmarks/lcals/Timer.chpl
+++ b/test/release/examples/benchmarks/lcals/Timer.chpl
@@ -69,22 +69,19 @@ module Timer {
 
 
   class LoopTimer {
-    var t: unmanaged TimerImpl;
+    var t: owned TimerImpl;
     var was_run: bool;
 
     proc init(timerType: TimerType = defaultTimerType) {
       if timerType == TimerType.Chapel {
-        t = new unmanaged ChapelTimer();
+        t = new owned ChapelTimer();
       } else if timerType == TimerType.Clock then {
-        t = new unmanaged ClockTimer();
+        t = new owned ClockTimer();
       } else if timerType == TimerType.Cycle then {
-        t = new unmanaged CycleTimer();
+        t = new owned CycleTimer();
       } else {
         halt("Unknown timer type");
       }
-    }
-    proc deinit() {
-      if t != nil then delete t;
     }
 
     proc start() {
@@ -100,7 +97,7 @@ module Timer {
     }
   }
 
-  proc copyTimer(loop_stat: unmanaged LoopStat, ilength: LoopLength, loop_timer: unmanaged LoopTimer) {
+  proc copyTimer(loop_stat: unmanaged LoopStat, ilength: LoopLength, loop_timer: LoopTimer) {
     if loop_timer.was_run {
       const run_time = loop_timer.elapsed();
       loop_stat.loop_run_time[ilength].push_back(run_time);

--- a/test/release/examples/benchmarks/lcals/Timer.chpl
+++ b/test/release/examples/benchmarks/lcals/Timer.chpl
@@ -97,7 +97,7 @@ module Timer {
     }
   }
 
-  proc copyTimer(loop_stat: unmanaged LoopStat, ilength: LoopLength, loop_timer: LoopTimer) {
+  proc copyTimer(loop_stat: LoopStat, ilength: LoopLength, loop_timer: LoopTimer) {
     if loop_timer.was_run {
       const run_time = loop_timer.elapsed();
       loop_stat.loop_run_time[ilength].push_back(run_time);


### PR DESCRIPTION
Changed several global arrays from `unmanaged` to `owned`.  Made functions that take those
arrays as arguments use `owned`.  Made functions that take elements of those arrays as arguments
use blank (`borrowed`).

Updated some enum uses in a not often tested path to behave correctly when treated as integers.

Tested with `--memLeaks` for two passes with all valid variants and all kernels enabled.  No leaks were reported.  Tested with `start_test -performance` to match the way nightly runs it.