### PR TITLE
Add documentation for the NetCDF package module

### DIFF
--- a/modules/Makefile
+++ b/modules/Makefile
@@ -106,6 +106,7 @@ PACKAGES_TO_DOCUMENT = \
 	packages/LAPACK.chpl \
 	packages/LinearAlgebra.chpl \
 	packages/MPI.chpl \
+        packages/NetCDF.chpl \
 	packages/Norm.chpl \
 	packages/RangeChunk.chpl \
 	packages/RecordParser.chpl \

--- a/modules/Makefile
+++ b/modules/Makefile
@@ -106,7 +106,7 @@ PACKAGES_TO_DOCUMENT = \
 	packages/LAPACK.chpl \
 	packages/LinearAlgebra.chpl \
 	packages/MPI.chpl \
-        packages/NetCDF.chpl \
+	packages/NetCDF.chpl \
 	packages/Norm.chpl \
 	packages/RangeChunk.chpl \
 	packages/RecordParser.chpl \

--- a/modules/packages/NetCDF.chpl
+++ b/modules/packages/NetCDF.chpl
@@ -19,9 +19,7 @@
 
 /* NetCDF bindings for Chapel
 
-This module implements the C-API for netCDF version 4.6.1.  It is expected
-that higher-level functionality will be built on top of this API similar to
-the functions in the :mod:`HDF5` module.
+This module implements the C-API for netCDF version 4.6.1.
 
 Compiling with netCDF
 ---------------------
@@ -30,6 +28,13 @@ In order to compile a Chapel program that uses this module, the netCDF library
 must be installed on the system.  The paths to the ``netcdf.h`` header file
 and netCDF library must be known to the compiler, either by finding them in
 a default search path, or by using the ``-I`` and ``-L`` compiler arguments.
+
+The compilation command should look something like this:
+
+.. code-block:: sh
+
+    chpl -I$PATH_TO_NETCDF_DIR \
+         -L$PATH_TO_NETCDF_LIBS -lnetcdf source.chpl
 
 On Cray systems with the ``cray-netcdf`` module loaded, no compiler flags
 are necessary to use the HDF5 module.

--- a/modules/packages/NetCDF.chpl
+++ b/modules/packages/NetCDF.chpl
@@ -17,7 +17,29 @@
  * limitations under the License.
  */
 
+/* NetCDF bindings for Chapel
+
+This module implements the C-API for netCDF version 4.6.1.  It is expected
+that higher-level functionality will be built on top of this API similar to
+the functions in the :mod:`HDF5` module.
+
+Compiling with netCDF
+---------------------
+
+In order to compile a Chapel program that uses this module, the netCDF library
+must be installed on the system.  The paths to the ``netcdf.h`` header file
+and netCDF library must be known to the compiler, either by finding them in
+a default search path, or by using the ``-I`` and ``-L`` compiler arguments.
+
+On Cray systems with the ``cray-netcdf`` module loaded, no compiler flags
+are necessary to use the HDF5 module.
+*/
 module NetCDF {
+  /* The NetCDF module defines the interface to the netCDF library.
+     Documentation for its functions, types, and constants can be found
+     at the official netCDF web site:
+     https://www.unidata.ucar.edu/software/netcdf/docs
+   */
   module C_NetCDF {
     // Generated with c2chapel version 0.1.0
 


### PR DESCRIPTION
Add some header documentation for the NetCDF module and C_NetCDF submodule.
Point at the official netCDF web site to document the extern interface.  Add
NetCDF to the Makefile to start generating the documentation for it.