### PR TITLE
build_configs: Fix rpmspec bug which had lost the release_info file.

### DIFF
--- a/util/build_configs/cray-internal/generate-rpmspec.bash
+++ b/util/build_configs/cray-internal/generate-rpmspec.bash
@@ -93,6 +93,8 @@ mkdir -p                                                $RPM_BUILD_ROOT/%{prefix
 
 cd          $RPM_BUILD_DIR/%{chpl_home_basename}
 find . -mindepth 1 -maxdepth 1 -exec mv -f {}           $RPM_BUILD_ROOT/%{prefix}/%{real_name}/%{pkg_version}/%{build_type} \;
+cd          %{_topdir}
+cp -p       release_info                                $RPM_BUILD_ROOT/%{prefix}/%{real_name}/%{pkg_version}/%{build_type}
 # Clean up *.o files
 #rm -rf     $RPM_BUILD_ROOT/%{prefix}/%{real_name}/%{pkg_version}/*/*/gen
 rm -rf      $RPM_BUILD_ROOT/%{prefix}/%{real_name}/%{pkg_version}/%{build_type}/*/compiler/*/gen


### PR DESCRIPTION
I forgot a step the last time I reorganized how the cray-internal
Chapel RPM would be generated, and that oversight caused the `release_info`
file to be silently omitted from the installed Chapel module.

If release_info is missing, then `module help chapel` will not display
the expected information. There isn't even an error.

This change fixes my oversight and restores the release_info file to
the cray-internal Chapel RPM produced by the build_configs/cray-internal
scripts.

See https://github.com/chapel-lang/chapel/issues/10458#issuecomment-418917800