### PR TITLE
shape preservation in the spec

### DIFF
--- a/spec/Arrays.tex
+++ b/spec/Arrays.tex
@@ -678,32 +678,14 @@ index set.  If the formal array's domain was declared using an
 explicit domain map, the actual array's domain must use an equivalent
 domain map.
 
-\section{Returning Arrays from Functions}
-\label{Returning_Arrays_from_Functions}
-\index{arrays!returning}
-\index{returning!array}
-
-Arrays return by value by default. The \chpl{ref} and \chpl{const ref}
-return intents can be used to return a reference to an array.
-
-Similarly to array arguments, the element type and/or domain of an array return
-type can be omitted.
-
 \subsection{Array Promotion of Scalar Functions}
 \label{Array_Promotion_of_Scalar_Functions}
 \index{arrays!promotion}
 \index{promotion!arrays}
 
-Array promotion of a scalar function is defined over the array type
-and the element type of the array.  The domain of the returned array,
-if an array is captured by the promotion, is the domain of the array
-that promoted the function.  In the event of zipper promotion over
-multiple arrays, the promoted function returns an array with a domain
-that is equal to the domain of the first argument to the function that
-enables promotion.  If the first argument is an iterator or a range,
-the result is a one-based one-dimensional array.
-
-See also~\rsec{Promotion}.
+Arrays may be passed to a scalar function argument whose type
+matches the array's element type.  This results in a promotion of the
+scalar function as defined in~\rsec{Promotion}.
 
 \begin{chapelexample}{whole-array-ops.chpl}
 Whole array operations is a special case of array promotion of scalar
@@ -728,9 +710,17 @@ element in \chpl{A} the element-wise sum of the elements in \chpl{B}
 and \chpl{C}.
 \end{chapelexample}
 
-%
-% TODO: should have an example of promoting an actual function here
-%
+
+\section{Returning Arrays from Functions}
+\label{Returning_Arrays_from_Functions}
+\index{arrays!returning}
+\index{returning!array}
+
+Arrays return by value by default. The \chpl{ref} and \chpl{const ref}
+return intents can be used to return a reference to an array.
+
+Similarly to array arguments, the element type and/or domain of an array return
+type can be omitted.
 
 
 \section{Sparse Arrays}

--- a/spec/Data_Parallelism.tex
+++ b/spec/Data_Parallelism.tex
@@ -169,14 +169,25 @@ convenience.
 The handling of the outer variables within the forall expression and
 the role of \sntx{task-intent-clause} are defined in \rsec{Forall_Intents}.
 
-\subsection{Execution and Serializability}
-\label{Forall_Expression_Execution_and_Serializability}
+\subsection{Execution}
+\label{Forall_Expression_Execution}
 \index{expressions!forall!semantics}
 
-The forall expression executes a forall loop (\rsec{Forall}),
-evaluates the body expression on each iteration of the loop, and
-returns the resulting values as a collection.  The size and shape of
-that collection are determined by the iteratable-expression.
+The forall expression is an iterator that executes a forall loop (\rsec{Forall}),
+evaluates the body expression on each iteration of the loop,
+and yields each resulting value.
+
+When a forall expression is used to initialize a variable, such as
+%\begin{chapel}
+%var X = forall /*iteratable-expression*/ do /*expression*/;
+%\end{chapel}
+\\ %formatting
+{\tt \mbox{$$ $$ $$ $$ $$} {\bf var} X = {\bf forall} /*iteratable-expression*/ {\bf do} /*expression*/;}
+\\ %formatting
+the variable is an array. The array's domain is defined by the
+\sntx{iterable-expression} following the same rules as for promotion,
+both in the regular case \rsec{Promotion} and in the
+zipper case \rsec{Zipper_Promotion}.
 
 \begin{chapelexample}{forallExpr.chpl}
 The code
@@ -209,6 +220,9 @@ by a forall expression and does not have an
 else clause.  Such an if expression filters the iterations of the
 forall expression.  The iterations for which the condition does not
 hold are not reflected in the result of the forall expression.
+
+When a forall expression with a filtering predicate is captured into
+a variable, the resulting array has a 1-based one-dimensional domain.
 
 \begin{chapelexample}{forallFilter.chpl}
 The following expression returns every other element starting with the
@@ -405,6 +419,32 @@ and methods. Also note that since class and record field access
 is performed with getter methods~(\rsec{Getter_Methods}), field
 access can also be promoted.
 
+If the original function returns a value, the corresponding promoted
+expression is an iterator yielding each computed value in turn.
+
+When a promoted expression is used to initialize a variable, such as
+\chpl{var X = A.x;} in the above example, the variable is an array.
+The array's domain is defined by the expression that causes promotion:
+
+\begin{center}
+\begin{tabular}[c]{|l|l|}
+\hline
+input expression & resulting array's domain \\
+\hline
+array    &  that array's domain \\
+domain   &  that domain \\
+range    &  one-dimensional domain built from that range \\
+iterator &  1-based one-dimensional domain \\
+\hline
+\end{tabular}
+\end{center}
+
+\begin{future}
+If the iterator iterates over an array, a domain or a range,
+we may want the resulting array's domain to be the same as
+if the input expression were that array/domain/range.
+\end{future}
+
 \begin{chapelexample}{promotion.chpl}
 Given the array
 \begin{chapel}
@@ -461,22 +501,9 @@ writeln(A);
 \end{chapelexample}
 
 
-%%
-%% sungeun: 10/2011
-%% I axed the following paragraph because comments from the peanut
-%% gallery suggested it was confusing, too much implementation
-%% details, etc.  One idea was to add something about defining
-%% iterators to support promotion.  Not sure where that would
-%% eventually go.
-%%
-%% If a promoted function returns a value, the promoted function becomes
-%% an iterator that is controlled by a loop over the iterator (or array,
-%% domain, or range) that it is promoted by.  If the function does not
-%% return a value, the function is controlled by a loop over the iterator
-%% that it is promoted by, but the promotion does not become an iterator.
-
-Whole array operations are a form of promotion as applied to operators
-rather than functions.
+\subsection{Default Arguments}
+\label{Promotion_Default_Arguments}
+\index{promotion!default arguments}
 
 When a call is promoted and that call relied upon default
 arguments~(\rsec{Default_Values}), the default argument expression can
@@ -518,7 +545,6 @@ writeln(A.sorted());
 \end{chapelexample}
 
 
-
 \subsection{Zipper Promotion}
 \label{Zipper_Promotion}
 \index{promotion!zipper iteration}
@@ -540,6 +566,12 @@ is equivalent to
 The usual constraints of zipper iteration apply to zipper promotion so
 the promoted actuals must have the same shape.
 
+A zipper promotion can be captured in a variable, such as
+\chpl{var X = f(s1, s2, ..., a1, a2, ...);} using the above example.
+If so, the domain of the resulting array is defined by the first argument
+that causes promotion. The rules are the same as in the non-zipper case.
+
+
 \begin{chapelexample}{zipper-promotion.chpl}
 Given a function defined as
 \begin{chapel}
@@ -557,14 +589,20 @@ then the output is
 \end{chapelprintoutput}
 \end{chapelexample}
 
-\subsection{Whole Array Assignment}
-\label{Whole_Array_Assignment}
+
+\subsection{Whole Array Operations and Evaluation Order}
+\label{Whole_Array_Operations}
 \index{whole array assignment}
+\index{whole array operations}
 \index{arrays!assignment}
 \index{assignment!whole array}
+\index{data parallelism!evaluation order}
 
-Whole array assignment is a considered a degenerate case of promotion
-and is implicitly parallel.  The assignment statement
+Whole array operations are a form of promotion as applied to operators
+rather than functions.
+
+Whole array assignment is one example. It is is implicitly parallel.
+The array assignment statement:
 \begin{chapel}
 LHS = RHS;
 \end{chapel}
@@ -574,9 +612,6 @@ forall (e1,e2) in zip(LHS,RHS) do
   e1 = e2;
 \end{chapel}
 
-\subsection{Evaluation Order}
-\label{Evaluation_Order}
-\index{data parallelism!evaluation order}
 The semantics of whole array assignment and promotion are different
 from most array programming languages.  Specifically, the compiler
 does not insert array temporaries for such operations if any of the

--- a/spec/Data_Parallelism.tex
+++ b/spec/Data_Parallelism.tex
@@ -173,21 +173,18 @@ the role of \sntx{task-intent-clause} are defined in \rsec{Forall_Intents}.
 \label{Forall_Expression_Execution}
 \index{expressions!forall!semantics}
 
-The forall expression is an iterator that executes a forall loop (\rsec{Forall}),
+A forall expression is an iterator that executes a forall loop (\rsec{Forall}),
 evaluates the body expression on each iteration of the loop,
 and yields each resulting value.
 
 When a forall expression is used to initialize a variable, such as
-%\begin{chapel}
-%var X = forall /*iteratable-expression*/ do /*expression*/;
-%\end{chapel}
-\\ %formatting
-{\tt \mbox{$$ $$ $$ $$ $$} {\bf var} X = {\bf forall} /*iteratable-expression*/ {\bf do} /*expression*/;}
-\\ %formatting
-the variable is an array. The array's domain is defined by the
-\sntx{iterable-expression} following the same rules as for promotion,
-both in the regular case \rsec{Promotion} and in the
-zipper case \rsec{Zipper_Promotion}.
+\begin{chapel}
+var X = forall iterableExpression() do computeValue();
+\end{chapel}
+the variable will be inferred to have an array type.
+The array's domain is defined by the \sntx{iterable-expression}
+following the same rules as for promotion, both in the regular
+case \rsec{Promotion} and in the zipper case \rsec{Zipper_Promotion}.
 
 \begin{chapelexample}{forallExpr.chpl}
 The code
@@ -419,11 +416,13 @@ and methods. Also note that since class and record field access
 is performed with getter methods~(\rsec{Getter_Methods}), field
 access can also be promoted.
 
-If the original function returns a value, the corresponding promoted
-expression is an iterator yielding each computed value in turn.
+If the original function returns a value or a reference, the
+corresponding promoted expression is an iterator yielding each
+computed value or reference.
 
-When a promoted expression is used to initialize a variable, such as
-\chpl{var X = A.x;} in the above example, the variable is an array.
+When a promoted expression is used to initialize a variable,
+such as \chpl{var X = A.x;} in the above example,
+the variable's type will be inferred to be an array.
 The array's domain is defined by the expression that causes promotion:
 
 \begin{center}
@@ -440,9 +439,15 @@ iterator &  1-based one-dimensional domain \\
 \end{center}
 
 \begin{future}
-If the iterator iterates over an array, a domain or a range,
-we may want the resulting array's domain to be the same as
-if the input expression were that array/domain/range.
+We would like to allow the iterator author to specify the shape
+of the iterator, i.e. the domain of the array that would capture
+the result of the corresponding promoted expression, such as
+\begin{chapel}
+var myArray = myScalarFunction(myIterator());
+\end{chapel}
+This will be helpful, for example, when the iterator yields
+one value per an array or domain element that it iterates over
+internally.
 \end{future}
 
 \begin{chapelexample}{promotion.chpl}

--- a/spec/Expressions.tex
+++ b/spec/Expressions.tex
@@ -1514,11 +1514,21 @@ for-expression:
   `for' index-var-declaration `in' iteratable-expression `do' expression
   `for' iteratable-expression `do' expression
 \end{syntax}
-The for expression executes a for loop (\rsec{The_For_Loop}),
+The for expression is an iterator that executes a for loop (\rsec{The_For_Loop}),
 evaluates the body expression on each iteration of the loop,
-and returns the resulting values as a collection.
-The size and shape of that collection
-are determined by the iteratable-expression.
+and yields each resulting value.
+
+When a for expression is used to initialize a variable, such as
+%\begin{chapel}
+%var X = for /*iteratable-expression*/ do /*expression*/;
+%\end{chapel}
+\\ %formatting
+{\tt \mbox{$$ $$ $$ $$ $$} {\bf var} X = {\bf for} /*iteratable-expression*/ {\bf do} /*expression*/;}
+\\ %formatting
+the variable is an array. The array's domain is defined by the
+\sntx{iterable-expression} following the same rules as for promotion,
+both in the regular case \rsec{Promotion} and in the
+zipper case \rsec{Zipper_Promotion}.
 
 \subsection{Filtering Predicates in For Expressions}
 \label{Filtering_Predicates_For}
@@ -1529,6 +1539,9 @@ A conditional expression that is immediately enclosed in a for
 expression and does not require an else clause filters the iterations of the for expression.
 The iterations for which the condition does not hold
 are not reflected in the result of the for expression.
+
+When a for expression with a filtering predicate is captured into
+a variable, the resulting array has a 1-based one-dimensional domain.
 
 \begin{chapelexample}{yieldPredicates.chpl}
 The code

--- a/spec/Expressions.tex
+++ b/spec/Expressions.tex
@@ -1514,21 +1514,18 @@ for-expression:
   `for' index-var-declaration `in' iteratable-expression `do' expression
   `for' iteratable-expression `do' expression
 \end{syntax}
-The for expression is an iterator that executes a for loop (\rsec{The_For_Loop}),
+A for expression is an iterator that executes a for loop (\rsec{The_For_Loop}),
 evaluates the body expression on each iteration of the loop,
 and yields each resulting value.
 
 When a for expression is used to initialize a variable, such as
-%\begin{chapel}
-%var X = for /*iteratable-expression*/ do /*expression*/;
-%\end{chapel}
-\\ %formatting
-{\tt \mbox{$$ $$ $$ $$ $$} {\bf var} X = {\bf for} /*iteratable-expression*/ {\bf do} /*expression*/;}
-\\ %formatting
-the variable is an array. The array's domain is defined by the
-\sntx{iterable-expression} following the same rules as for promotion,
-both in the regular case \rsec{Promotion} and in the
-zipper case \rsec{Zipper_Promotion}.
+\begin{chapel}
+var X = for iterableExpression() do computeValue();
+\end{chapel}
+the variable will be inferred to have an array type.
+The array's domain is defined by the \sntx{iterable-expression}
+following the same rules as for promotion, both in the regular
+case \rsec{Promotion} and in the zipper case \rsec{Zipper_Promotion}.
 
 \subsection{Filtering Predicates in For Expressions}
 \label{Filtering_Predicates_For}
@@ -1536,7 +1533,8 @@ zipper case \rsec{Zipper_Promotion}.
 \index{expressions!for@\chpl{for}!filtering predicates}
 
 A conditional expression that is immediately enclosed in a for
-expression and does not require an else clause filters the iterations of the for expression.
+expression and does not require an else clause filters the iterations
+of the for expression.
 The iterations for which the condition does not hold
 are not reflected in the result of the for expression.
 

--- a/spec/Procedures.tex
+++ b/spec/Procedures.tex
@@ -597,7 +597,7 @@ separate categories in the table above.  One proposed approach is to
 apply the default intent to each component of the tuple independently.
 \end{openissue}
 
-\subsubsection{Default Intent for Arrays and Record \chpl{this}}
+\subsubsection{Default Intent for Arrays and Record 'this'}
 \label{Default_Intent_for_Arrays_and_Record_this}
 \index{intents!array default}
 \index{intents!record \chpl{this} default}
@@ -610,7 +610,7 @@ cause an array or record to be copied by default.  The choice between
 \chpl{ref} and \chpl{const ref} is similar to and interacts with return
 intent overloads (see \rsec{Return_Intent_Overloads}).
 
-\subsubsection{Default Intent for \chpl{owned} and \chpl{shared}}
+\subsubsection{Default Intent for 'owned' and 'shared'}
 \label{Default_Intent_for_owned_and_shared}
 \index{intents!default for owned}
 \index{intents!default for shared}


### PR DESCRIPTION
Add the specification of shape preservation

* Improve how promotion is presented.
In particular, move the details of promotion over arrays
from the Arrays chapter to Data Parallelism chapter.
Make arrays reference that subsection so that we are consistent
in defining promotion for:

  - iterators
  - ranges
  - domains
  - arrays

* State that for-, forall- and promoted expressions
are iterators yielding one element at a time.
They become arrays when used to initialize a variable.
Remove Sung's earlier trial paragraph

* Create a table defining the domain of such an array
based on what kind of thing causes promotion.
The table is where promotion is defined.

* Have for- and forall-expressions reference that table
by pointing to the promotion section. If the for/forall expression
has a filtering predicate, then the resulting array has a
1-based one-dimensional domain.

* Move array-promotion sub-section from "Returning Arrays" section
to "Array Arguments" section, as it is fone for domain-promotion.
(The diffs show that the "Returning Arrays" section moved.)

* While there, remove \chpl from \subsubsection
as Latex gets upset otherwise.