### PR TITLE
Pre-release prep. Chapel 1.18.0: post-release version markings on master

### DIFF
--- a/compiler/main/version.cpp
+++ b/compiler/main/version.cpp
@@ -35,7 +35,7 @@ void
 get_version(char *v) {
   v += sprintf(v, "%d.%s.%s", MAJOR_VERSION, MINOR_VERSION, UPDATE_VERSION);
   if (strcmp(BUILD_VERSION, "0") != 0 || developer)
-    sprintf(v, " pre-release (%s)", BUILD_VERSION);
+    sprintf(v, ".%s", BUILD_VERSION);   // post-release
 }
 
 void

--- a/doc/rst/conf.py
+++ b/doc/rst/conf.py
@@ -55,18 +55,18 @@ master_doc = 'index'
 # built documents.
 #
 # The short X.Y version.
-# version = '1.17'
+# version = '1.18'
 
 # We use a custom version variable (shortversion) instead, because setting
 # 'version' adds a redundant version number onto the top of the sidebar
 # automatically (rtd-theme). We also don't use |version| anywhere in rst
 
-chplversion = '1.18 (pre-release)'    # TODO -- parse from `chpl --version`
+chplversion = '1.18'                  # post-release
 shortversion = chplversion.replace('-', '&#8209') # prevent line-break at hyphen
 html_context = {"chplversion":chplversion}
 
 # The full version, including alpha/beta/rc tags.
-release = '1.18.0 (pre-release)'
+release = '1.18.0'                    # post-release
 
 # General information about the project.
 project = u'Chapel Documentation'

--- a/doc/rst/usingchapel/QUICKSTART.rst
+++ b/doc/rst/usingchapel/QUICKSTART.rst
@@ -16,7 +16,7 @@ enable more features, such as distributed memory execution.
 0) See :ref:`prereqs.rst <readme-prereqs>` for more information about system
    tools and packages you may need to have installed to build and run Chapel.
 
-1) If you don't already have Chapel 1.17, see
+1) If you don't already have Chapel 1.18, see
    https://chapel-lang.org/download.html .
 
 2) If you are using a source release, build Chapel in a *quickstart*
@@ -28,14 +28,14 @@ enable more features, such as distributed memory execution.
 
       .. code-block:: bash
 
-         tar xzf chapel-1.17.1.tar.gz
+         tar xzf chapel-1.18.0.tar.gz
 
    b. Make sure that your shell is in the directory containing
       QUICKSTART.rst, for example:
 
       .. code-block:: bash
 
-         cd chapel-1.17.1
+         cd chapel-1.18.0
 
    c. Set up your environment for Chapel's Quickstart mode.
       If you are using a shell other than bash,

--- a/doc/rst/usingchapel/chplenv.rst
+++ b/doc/rst/usingchapel/chplenv.rst
@@ -33,7 +33,7 @@ CHPL_HOME
 
     .. code-block:: sh
 
-        export CHPL_HOME=~/chapel-1.17.1
+        export CHPL_HOME=~/chapel-1.18.0
 
    .. note::
      This, and all other examples in the Chapel documentation, assumes you're

--- a/man/confchpl.rst
+++ b/man/confchpl.rst
@@ -1,5 +1,5 @@
 
-:Version: 1.18.0 pre-release
+:Version: 1.18.0
 :Manual section: 1
 :Title: \\fBchpl\\fP
 :Subtitle: Compiler for the Chapel Programming Language

--- a/man/confchpldoc.rst
+++ b/man/confchpldoc.rst
@@ -1,5 +1,5 @@
 
-:Version: 1.18.0 pre-release
+:Version: 1.18.0
 :Manual section: 1
 :Title: \\fBchpldoc\\fP
 :Subtitle: the Chapel Documentation Tool

--- a/test/compflags/bradc/printstuff/versionhelp.sh
+++ b/test/compflags/bradc/printstuff/versionhelp.sh
@@ -5,4 +5,4 @@ compiler=$3
 echo -n `basename $compiler`
 cat $CWD/version.goodstart
 diff $CWD/../../../../compiler/main/BUILD_VERSION $CWD/zero.txt > /dev/null 2>&1 && echo "" || \
-    { echo -n " pre-release (" && cat $CWD/../../../../compiler/main/BUILD_VERSION | tr -d \"\\n && echo ")" ; }
+    { echo -n "." && cat $CWD/../../../../compiler/main/BUILD_VERSION | tr -d \" ; }    # post-release

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -268,7 +268,7 @@ proc getChapelVersionInfo() {
       }
 
       const semverPattern = "(\\d+\\.\\d+\\.\\d+)";
-      var master  = compile(semverPattern + "\\.([a-z0-9]+)");      // post-release
+      var master  = compile(semverPattern + " pre-release (\\([a-z0-9]+\\))");
       var release = compile(semverPattern);
 
       var semver, sha : string;

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -268,7 +268,7 @@ proc getChapelVersionInfo() {
       }
 
       const semverPattern = "(\\d+\\.\\d+\\.\\d+)";
-      var master  = compile(semverPattern + " pre-release (\\([a-z0-9]+\\))");
+      var master  = compile(semverPattern + "\\.([a-z0-9]+)");      // post-release
       var release = compile(semverPattern);
 
       var semver, sha : string;


### PR DESCRIPTION
NOTE: This is not Chapel release 1.18.0. This change prepares the source on master branch for the upcoming Chapel 1.18.0 release, currently scheduled for 20 Sep 2018.

* Temporarily remove all "pre-release" version markings from master branch,
  prior to creating the release/1.18 branch, so that all the release
  version strings look like they should look in the final Chapel 1.18.0
  release. The automated tests on master branch will be able to test the
  final release.
  Exception: doc/util/versionButton.php is not changed here.
  After release/1.18 branch has been created, this change will be reversed
  on master branch and most 1.18 version numbers will be bumped to 1.19.
* This commit tries to help Mason pass automated testing on master branch
  between now and when the parent commit,
  "Pre-release prep. Chapel 1.18.0: post-release version markings on master",
  is reversed.
  Ie, this commit should be regarded as temporary, like the parent commit.
* This change bumps the most visible "1.17" version numbers still remaining
 on master branch, to "1.18" as needed for the final release.