### PR TITLE
Fix some typos in user-facing documentation

### DIFF
--- a/modules/internal/ChapelIteratorSupport.chpl
+++ b/modules/internal/ChapelIteratorSupport.chpl
@@ -98,7 +98,7 @@ module ChapelIteratorSupport {
   // The two chpl_buildStandInRTT(type) functions accept, at run time,
   // the _RuntimeTypeInfo for domType/arrType that is **uninitialized**.
   // They returns a fresh domain/array type of the same kind, whose
-  // RTT is **initiaized**. Important: no accessing the uninitialized RTTs.
+  // RTT is **initialized**. Important: no accessing the uninitialized RTTs.
   //
   // It took some acrobatics to get the domain's distribution type,
   // rank, idxType, stridable from 'domType', and the same plus

--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -35,8 +35,8 @@ through compiler flags and/or environment variables.
 
 Some procedures have implementations both with `and` without dependencies. By
 default, the implementation with dependencies will be selected. Users can
-explicitly opt out of using the :mod:`BLAS` and :mod:`LAPACK` dependendent
-implentations by setting the ``blasImpl`` and ``lapackImpl`` flags to ``none``.
+explicitly opt out of using the :mod:`BLAS` and :mod:`LAPACK` dependent
+implementations by setting the ``blasImpl`` and ``lapackImpl`` flags to ``none``.
 
 **Building programs with no dependencies**
 

--- a/spec/Classes.tex
+++ b/spec/Classes.tex
@@ -1316,7 +1316,7 @@ writeln(c);
 \end{chapelcompopts}
 Once the parent's initializer is finished, the parent method \chpl{foo} may be
 called. After the \chpl{complete} method is invoked, a call to \chpl{foo}
-resolves to the child's overriden (\rsec{Overriding_Base_Class_Methods})
+resolves to the child's overridden (\rsec{Overriding_Base_Class_Methods})
 implementation:
 \begin{chapelprintoutput}{}
 Parent.foo
@@ -1574,7 +1574,7 @@ nil
 \end{chapeloutput}
 \end{chapelexample}
 
-In constrast, assignment for \chpl{shared} variables allows both
+In contrast, assignment for \chpl{shared} variables allows both
 variables to refer to the same class instance.
 
 \subsection{Implicit Class Conversions}

--- a/spec/Generics.tex
+++ b/spec/Generics.tex
@@ -340,7 +340,7 @@ proc f(tuple: (?t,real)) {
 specifies that \chpl{tuple.size == 2 && tuple(2).type == real}.
 \end{example}
 
-Homogenous tuple arguments of generic type are also supported:
+Homogeneous tuple arguments of generic type are also supported:
 \begin{chapelexample}{partially-concrete-star-tuple.chpl}
 \begin{chapel}
 record Number {


### PR DESCRIPTION
Fix some typos in the spec and linear algebra documentation that chplspell found