### PR TITLE
Make docs version button work better at release time

### DIFF
--- a/doc/util/versionButton.php
+++ b/doc/util/versionButton.php
@@ -88,13 +88,15 @@ if (pagePath == "") {
 }
 function dropSetup() {
   var currentRelease = "1.17";
+  var nextRelease = "1.18";
   var button = document.getElementById("versionButton");
   // Uses unicode down-pointing triangle
   var arrow = " &#9660;";
   button.innerHTML = "version " + chplTitle + arrow;
 
   // Choose button color
-  if (chplTitle.includes("pre-release")) {
+  if (chplTitle == nextRelease) {
+    button.innerHTML = "version " + chplTitle + " (pre-release)" + arrow;
     button.classList.add("preRelease");
   } else if (chplTitle == currentRelease) {
     button.classList.add("currentVersion");


### PR DESCRIPTION
The current version of the version button logic for the docs looks
at whether or not the version string in doc/rst/conf.py contains
the text (pre-release) or not, which makes things a bit dicey
right around release time, like now, when we start pulling that
string from the version text.

This change uses a version variable with the version button logic
itself to keep track of which version is the next release and
adds the (pre-release) text there so that it will always be
applied.  This should also reduce the maintenance burden within
doc/rst/conf.py slightly.