### PR TITLE
Improves internal error output

### DIFF
--- a/compiler/include/misc.h
+++ b/compiler/include/misc.h
@@ -36,6 +36,13 @@
 #define chpl_noreturn
 #endif
 
+#ifndef COMPILER_SUBDIR
+#define COMPILER_SUBDIR
+#endif
+
+#define DO_TOSTRING(tok) #tok
+#define TOSTRING(tok) DO_TOSTRING(tok)
+
 // INT_FATAL(ast, format, ...)
 //   where ast         == BaseAST* or NULL
 //         format, ... == normal printf stuff
@@ -43,17 +50,17 @@
 // INTERNAL ERROR in compilerSrc.c (lineno): your text here (usrSrc:usrLineno)
 
 #define INT_FATAL      gdbShouldBreakHere(), \
-                       setupError(__FILE__, __LINE__, 1), handleError
+                       setupError(TOSTRING(COMPILER_SUBDIR), __FILE__, __LINE__, 1), handleError
 
 #define USR_FATAL      gdbShouldBreakHere(), \
-                       setupError(__FILE__, __LINE__, 2), handleError
+                       setupError(TOSTRING(COMPILER_SUBDIR), __FILE__, __LINE__, 2), handleError
 
 #define USR_FATAL_CONT gdbShouldBreakHere(), \
-                       setupError(__FILE__, __LINE__, 3), handleError
+                       setupError(TOSTRING(COMPILER_SUBDIR), __FILE__, __LINE__, 3), handleError
 
-#define USR_WARN       setupError(__FILE__, __LINE__, 4), handleError
+#define USR_WARN       setupError(TOSTRING(COMPILER_SUBDIR), __FILE__, __LINE__, 4), handleError
 
-#define USR_PRINT      setupError(__FILE__, __LINE__, 5), handleError
+#define USR_PRINT      setupError(TOSTRING(COMPILER_SUBDIR), __FILE__, __LINE__, 5), handleError
 
 #define USR_STOP       exitIfFatalErrorsEncountered
 
@@ -77,7 +84,7 @@ bool        requireOutlinedOn();
 const char* cleanFilename(const BaseAST* ast);
 const char* cleanFilename(const char*    name);
 
-void        setupError(const char* filename, int lineno, int tag);
+void        setupError(const char* subdir, const char* filename, int lineno, int tag);
 
 void        handleError(const char* fmt, ...);
 void        handleError(const BaseAST* ast, const char* fmt, ...);

--- a/compiler/make/Makefile.compiler.foot
+++ b/compiler/make/Makefile.compiler.foot
@@ -51,7 +51,7 @@ echocompilerdir:
 #
 
 $(OBJ_SUBDIR)/%.o: %.cpp $(OBJ_SUBDIR_MADE) $(OBJ_PREREQS)
-	$(CXX) -c $(COMP_CXXFLAGS) -o $@ $<
+	$(CXX) -c $(COMP_CXXFLAGS) -DCOMPILER_SUBDIR=$(COMPILER_SUBDIR) -o $@ $<
 
 FORCE:
 

--- a/compiler/parser/bison-chapel.cpp
+++ b/compiler/parser/bison-chapel.cpp
@@ -510,7 +510,7 @@ void yypstate_delete ();
                const char*    str) {
 
     // like USR_FATAL_CONT
-    setupError(__FILE__, __LINE__, 3);
+    setupError("parser", __FILE__, __LINE__, 3);
 
     // TODO -- should this begin with error:
     if (!chplParseString) {

--- a/compiler/parser/chapel.ypp
+++ b/compiler/parser/chapel.ypp
@@ -234,7 +234,7 @@
                const char*    str) {
 
     // like USR_FATAL_CONT
-    setupError(__FILE__, __LINE__, 3);
+    setupError("parser", __FILE__, __LINE__, 3);
 
     // TODO -- should this begin with error:
     if (!chplParseString) {

--- a/compiler/util/misc.cpp
+++ b/compiler/util/misc.cpp
@@ -149,7 +149,7 @@ static void print_user_internal_error() {
   char        version[128]   = { '\0' };
 
   // Fill error with _
-  for (int i = 0; i < sizeof(error) - 1; i++) {
+  for (int i = 0; i < (int)sizeof(error) - 1; i++) {
     error[i] = ' ';
   }
   error[sizeof(error)-1] = '\0';
@@ -190,7 +190,7 @@ static void print_user_internal_error() {
   sprintf(&error[idx], "%04d", err_lineno);
 
   // now make the error string upper case
-  for (int i = 0; i < sizeof(error) && error[i]; i++) {
+  for (int i = 0; i < (int)sizeof(error) && error[i]; i++) {
     if (error[i] >= 'a' && error[i] <= 'z') {
       error[i] += 'A' - 'a';
     }

--- a/compiler/util/misc.cpp
+++ b/compiler/util/misc.cpp
@@ -43,6 +43,7 @@ static bool        exit_immediately = true;
 static bool        exit_eventually  = false;
 static bool        exit_end_of_pass = false;
 
+static const char* err_subdir       = NULL;
 static const char* err_filename     = NULL;
 
 static int         err_lineno       =    0;
@@ -60,7 +61,8 @@ void gdbShouldBreakHere() {
 
 }
 
-void setupError(const char* filename, int lineno, int tag) {
+void setupError(const char* subdir, const char* filename, int lineno, int tag) {
+  err_subdir        = subdir;
   err_filename      = filename;
   err_lineno        = lineno;
   err_fatal         = tag == 1 || tag == 2 || tag == 3;
@@ -139,10 +141,18 @@ static bool forceWidePtrs() {
 }
 
 static void print_user_internal_error() {
-  static char error[8];
+  char error[20];
 
   const char* filename_start = strrchr(err_filename, '/');
+  const char* filename_end = NULL;
+  const char* directory_start = err_subdir;
   char        version[128]   = { '\0' };
+
+  // Fill error with _
+  for (int i = 0; i < sizeof(error) - 1; i++) {
+    error[i] = ' ';
+  }
+  error[sizeof(error)-1] = '\0';
 
   if (filename_start) {
     filename_start++;
@@ -150,11 +160,37 @@ static void print_user_internal_error() {
     filename_start = err_filename;
   }
 
-  strncpy(error, filename_start, 3);
+  filename_end = strrchr(filename_start, '.');
+  if (filename_end - filename_start >= 6)
+    filename_end = filename_end - 3;
+  else
+    filename_end = NULL;
 
-  sprintf(error + 3, "%04d", err_lineno);
+  int idx = 0;
+  // first 3 characters are from directory
+  if (directory_start && strlen(directory_start) >= 3) {
+    strncpy(&error[idx], directory_start, 3);
+    idx += 3;
+    error[idx++] = '-';
+  }
 
-  for (int i = 0; i < 7; i++) {
+  // next 3 characters are start of filename
+  strncpy(&error[idx], filename_start, 3);
+  idx += 3;
+
+  // next 3 characters are end of the filename
+  if (filename_end) {
+    error[idx++] = '-';
+    strncpy(&error[idx], filename_end, 3);
+    idx += 3;
+  }
+
+  error[idx++] = '-';
+  // next 4 characters are the line number
+  sprintf(&error[idx], "%04d", err_lineno);
+
+  // now make the error string upper case
+  for (int i = 0; i < sizeof(error) && error[i]; i++) {
     if (error[i] >= 'a' && error[i] <= 'z') {
       error[i] += 'A' - 'a';
     }
@@ -317,7 +353,7 @@ static void printErrorFooter(bool guess) {
   // internal error was generated.
   //
   if (developer && !err_user)
-    fprintf(stderr, " [%s:%d]", err_filename, err_lineno);
+    fprintf(stderr, " [%s/%s:%d]", err_subdir, err_filename, err_lineno);
 
   //
   // For users and developers, if the source line was a guess (i.e., an

--- a/test/classes/ferguson/class-alias-generic-arg.bad
+++ b/test/classes/ferguson/class-alias-generic-arg.bad
@@ -1,4 +1,4 @@
-class-alias-generic-arg.chpl:12: internal error: CAL0124 chpl version 1.18.0 pre-release (8e7e52cff4)
+class-alias-generic-arg.chpl:12: internal error: RES-CAL-NFO-0124 chpl version 1.19.0 pre-release (cfeb6592b3)
 
 Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
 and we're sorry for the hassle.  We would appreciate your reporting this bug -- 

--- a/test/classes/vass/no-instance-for-arg-type.bad
+++ b/test/classes/vass/no-instance-for-arg-type.bad
@@ -1,4 +1,4 @@
-no-instance-for-arg-type.chpl:3: internal error: SYMnnnn chpl version mmmm
+no-instance-for-arg-type.chpl:3: internal error: AST-SYM-BOL-0074 chpl version 1.19.0 pre-release (cfeb6592b3)
 
 Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
 and we're sorry for the hassle.  We would appreciate your reporting this bug -- 

--- a/test/expressions/loop-expr/forall-over-zip-over-arrays.bad
+++ b/test/expressions/loop-expr/forall-over-zip-over-arrays.bad
@@ -1,4 +1,4 @@
-forall-over-zip-over-arrays.chpl:3: internal error: CHEnnnn chpl version mmmm
+forall-over-zip-over-arrays.chpl:3: internal error: MAI-CHE-CKS-0760 chpl version 1.19.0 pre-release (cfeb6592b3)
 
 Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
 and we're sorry for the hassle.  We would appreciate your reporting this bug -- 

--- a/test/functions/bradc/paramThis/funParamThis3.bad
+++ b/test/functions/bradc/paramThis/funParamThis3.bad
@@ -1,4 +1,4 @@
-funParamThis3.chpl:2: internal error: FNS0107 chpl version 1.11.0.e5a07fc
+funParamThis3.chpl:2: internal error: AST-FNS-BOL-0107 chpl version 1.19.0 pre-release (cfeb6592b3)
 
 Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
 and we're sorry for the hassle.  We would appreciate your reporting this bug -- 

--- a/test/functions/diten/formalArrayWithQueriedEltSize.bad
+++ b/test/functions/diten/formalArrayWithQueriedEltSize.bad
@@ -1,4 +1,4 @@
-formalArrayWithQueriedEltSize.chpl:1: internal error: CAL0078 chpl version 1.17.0 pre-release (4904c578ec)
+formalArrayWithQueriedEltSize.chpl:1: internal error: RES-CAL-NFO-0078 chpl version 1.19.0 pre-release (cfeb6592b3)
 Note: This source location is a guess.
 
 Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),

--- a/test/functions/lydia/infinite-recursion-arg.bad
+++ b/test/functions/lydia/infinite-recursion-arg.bad
@@ -1,4 +1,4 @@
-infinite-recursion-arg.chpl:1: internal error: RES0120 chpl version 1.17.0 pre-release (06f19a352b)
+infinite-recursion-arg.chpl:1: internal error: PAS-RES-NTS-0127 chpl version 1.19.0 pre-release (cfeb6592b3)
 Note: This source location is a guess.
 
 Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),

--- a/test/parallel/forall/vass/reduce-with-for-in-par-iter.reduce2.bad
+++ b/test/parallel/forall/vass/reduce-with-for-in-par-iter.reduce2.bad
@@ -1,4 +1,4 @@
-$CHPL_HOME/modules/internal/ChapelIteratorSupport.chpl:267: internal error: MISnnnn chpl version mmmm
+$CHPL_HOME/modules/internal/ChapelIteratorSupport.chpl:453: internal error: UTI-MIS-0597 chpl version 1.19.0 pre-release (cfeb6592b3)
 Note: This source location is a guess.
 
 Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),

--- a/test/types/enum/lydia/declaredInClass-initializer.bad
+++ b/test/types/enum/lydia/declaredInClass-initializer.bad
@@ -1,4 +1,4 @@
-declaredInClass-initializer.chpl:21: internal error: MIS0558 chpl version 1.16.0 pre-release (830a53f)
+declaredInClass-initializer.chpl:21: internal error: UTI-MIS-0597 chpl version 1.19.0 pre-release (cfeb6592b3)
 Note: This source location is a guess.
 
 Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),

--- a/test/types/enum/scope-param-offset-type.bad
+++ b/test/types/enum/scope-param-offset-type.bad
@@ -1,4 +1,4 @@
-scope-param-offset-type.chpl:5: internal error: CALnnnn chpl version mmmm
+scope-param-offset-type.chpl:5: internal error: RES-CAL-NFO-0124 chpl version 1.19.0 pre-release (cfeb6592b3)
 
 Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
 and we're sorry for the hassle.  We would appreciate your reporting this bug -- 

--- a/test/types/records/init/nested-empty-record.bad
+++ b/test/types/records/init/nested-empty-record.bad
@@ -1,4 +1,4 @@
-nested-empty-record.chpl:29: internal error: SYMnnnn chpl version mmmm
+nested-empty-record.chpl:29: internal error: AST-SYM-BOL-0074 chpl version 1.19.0 pre-release (cfeb6592b3)
 
 Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
 and we're sorry for the hassle.  We would appreciate your reporting this bug -- 

--- a/test/types/records/tupleFields/detupleFieldDecl.bad
+++ b/test/types/records/tupleFields/detupleFieldDecl.bad
@@ -1,4 +1,4 @@
-detupleFieldDecl.chpl:10: internal error: AGG0411 chpl version 1.18.0 pre-release (b50c8c7)
+detupleFieldDecl.chpl:10: internal error: AST-AGG-YPE-0422 chpl version 1.19.0 pre-release (cfeb6592b3)
 
 Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
 and we're sorry for the hassle.  We would appreciate your reporting this bug -- 

--- a/test/users/engin/retInnerFunction.bad
+++ b/test/users/engin/retInnerFunction.bad
@@ -1,4 +1,4 @@
-internal error: DENnnnn chpl version mmmm
+internal error: PAS-DEN-IZE-0304 chpl version 1.19.0 pre-release (cfeb6592b3)
 
 Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
 and we're sorry for the hassle.  We would appreciate your reporting this bug -- 

--- a/test/users/vass/tuple-crash-1.bad
+++ b/test/users/vass/tuple-crash-1.bad
@@ -1,4 +1,4 @@
-$CHPL_HOME/modules/internal/ChapelBase.chpl:172: internal error: FUN2570 chpl version 1.11.0.e5a07fc
+$CHPL_HOME/modules/internal/ChapelBase.chpl:55: internal error: RES-FUN-ION-7214 chpl version 1.19.0 pre-release (cfeb6592b3)
 Note: This source location is a guess.
 
 Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),

--- a/test/users/vass/uniquify/u1-local-user-extern.bad
+++ b/test/users/vass/uniquify/u1-local-user-extern.bad
@@ -1,4 +1,4 @@
-u1-local-user-extern.chpl:12: internal error: CODnnnn chpl version mmmm
+u1-local-user-extern.chpl:12: internal error: COD-COD-GEN-1030 chpl version 1.19.0 pre-release (cfeb6592b3)
 
 Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
 and we're sorry for the hassle.  We would appreciate your reporting this bug -- 

--- a/test/users/vass/uniquify/u2-local-extern-extern.bad
+++ b/test/users/vass/uniquify/u2-local-extern-extern.bad
@@ -1,4 +1,4 @@
-u2-local-extern-extern.chpl:8: internal error: CODnnnn chpl version mmmm
+u2-local-extern-extern.chpl:8: internal error: COD-COD-GEN-1030 chpl version 1.19.0 pre-release (cfeb6592b3)
 
 Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
 and we're sorry for the hassle.  We would appreciate your reporting this bug -- 

--- a/util/test/diff-ignoring-module-line-numbers
+++ b/util/test/diff-ignoring-module-line-numbers
@@ -16,7 +16,7 @@ tmptmp=`mktemp "tmp.XXXXXX"`
 command='
   \|CHPL_HOME/modules|s/:[0-9:]*:/:nnnn:/
   s/chpl version [0-9]*.*$/chpl version mmmm/
-  s/internal error: \([A-Z][A-Z][A-Z]\)[0-9][0-9][0-9][0-9] chpl version mmmm/internal error: \1nnnn chpl version mmmm/
+  s/internal error: \([A-Z][A-Z\-]*\)[0-9][0-9]* chpl version mmmm/internal error: \1nnnn chpl version mmmm/
 '
 
 sed -e "$command" $badfile > $badtmp


### PR DESCRIPTION
Addresses #9107 by making the user-facing internal error consist of
```
 DIR-ABC-XYZ-####
```

where DIR is the 1st 3 of the compiler subdir, ABC is the first 3 of the file, and XYZ is the last 3 of the file before the period.

Additionally makes developer-mode internal errors print out the compiler subdir.

For example, this developer mode error:
```
x.chpl:12: In function 'g':
x.chpl:12: internal error: the type of the actual argument 'integral' is generic [resolution/callInfo.cpp:124]
```

has this --no-developer output:
```
x.chpl:12: In function 'g':
x.chpl:12: internal error: RES-CAL-NFO-0124 chpl version 1.18.0.64d5d1b66c

Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
the filename + line number above may be useful in working around the issue.
```

Reviewed by @lydia-duncan - thanks!

- [x] full local futures testing
