### PR TITLE
Remove trailing slashes for consistent BSD/GNU cp

### DIFF
--- a/modules/Makefile
+++ b/modules/Makefile
@@ -163,10 +163,10 @@ documentation: $(SYS_CTYPES_MODULE_DOC)
 	@echo "Copying generated module documentation to ${DOC}"
 	mkdir -p ${DOC}/modules
 	mkdir -p ${DOC}/builtins
-	cp -rf ${MODULE_SPHINX}/source/modules/standard ${DOC}/modules
-	cp -rf ${MODULE_SPHINX}/source/modules/packages ${DOC}/modules
-	cp -rf ${MODULE_SPHINX}/source/modules/dists    ${DOC}/modules
-	cp -rf ${MODULE_SPHINX}/source/modules/layouts  ${DOC}/modules
+	cp -rf ${MODULE_SPHINX}/source/modules/standard   ${DOC}/modules
+	cp -rf ${MODULE_SPHINX}/source/modules/packages   ${DOC}/modules
+	cp -rf ${MODULE_SPHINX}/source/modules/dists      ${DOC}/modules
+	cp -rf ${MODULE_SPHINX}/source/modules/layouts    ${DOC}/modules
 	cp -rf ${MODULE_SPHINX}/source/modules/internal/* ${DOC}/builtins
 	@echo "Removing generated files and directories"
 	rm -rf ./docs

--- a/modules/Makefile
+++ b/modules/Makefile
@@ -163,11 +163,11 @@ documentation: $(SYS_CTYPES_MODULE_DOC)
 	@echo "Copying generated module documentation to ${DOC}"
 	mkdir -p ${DOC}/modules
 	mkdir -p ${DOC}/builtins
-	cp -rf ${MODULE_SPHINX}/source/modules/standard ${DOC}/modules/
-	cp -rf ${MODULE_SPHINX}/source/modules/packages ${DOC}/modules/
-	cp -rf ${MODULE_SPHINX}/source/modules/dists    ${DOC}/modules/
-	cp -rf ${MODULE_SPHINX}/source/modules/layouts  ${DOC}/modules/
-	cp -rf ${MODULE_SPHINX}/source/modules/internal/ ${DOC}/builtins/
+	cp -rf ${MODULE_SPHINX}/source/modules/standard ${DOC}/modules
+	cp -rf ${MODULE_SPHINX}/source/modules/packages ${DOC}/modules
+	cp -rf ${MODULE_SPHINX}/source/modules/dists    ${DOC}/modules
+	cp -rf ${MODULE_SPHINX}/source/modules/layouts  ${DOC}/modules
+	cp -rf ${MODULE_SPHINX}/source/modules/internal/* ${DOC}/builtins
 	@echo "Removing generated files and directories"
 	rm -rf ./docs
 	rm -rf ${MODULE_SPHINX}


### PR DESCRIPTION
GNU cp does not recognize trailing slashes, so this PR removes them to avoid inconsistent behavior across platforms.

Prior to this PR, we were getting an inconsistency in the docs path:

```
# BSD (good)
chapel/doc/html/builtins/*.chpl

# GNU (bad)
chapel/doc/html/builtins/internal/*.chpl
```

This resulted in an inconsistency between our docs built nightly (built on linux) vs. release docs (built on OS X).


