### PR TITLE
Misc module doc improvements

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1037,6 +1037,7 @@ module ChapelArray {
   }
 
 
+  pragma "no doc"
   record _serialized_domain {
     param rank;
     type idxType;
@@ -1051,6 +1052,7 @@ module ChapelArray {
   //
   // Domain wrapper record.
   //
+  /* The domain type */
   pragma "domain"
   pragma "has runtime type"
   pragma "ignore noinit"
@@ -1138,6 +1140,7 @@ module ChapelArray {
         }
       }
     }
+    pragma "no doc"
     proc deinit () {
       _do_destroy();
     }
@@ -1188,17 +1191,20 @@ module ChapelArray {
       compilerError("associative domains do not support .stridable");
     }
 
+    /* Yield the domain indices */
     iter these() {
       for i in _value.these() {
         yield i;
       }
     }
+    pragma "no doc"
     iter these(param tag: iterKind)
       where tag == iterKind.standalone &&
             __primitive("method call resolves", _value, "these", tag=tag) {
       for i in _value.these(tag) do
         yield i;
     }
+    pragma "no doc"
     iter these(param tag: iterKind)
       where tag == iterKind.leader {
       // If I use forall here, it says
@@ -1207,6 +1213,7 @@ module ChapelArray {
       for followThis in _value.these(tag) do
         yield followThis;
     }
+    pragma "no doc"
     iter these(param tag: iterKind, followThis, param fast: bool = false)
       where tag == iterKind.follower {
 
@@ -1408,6 +1415,7 @@ module ChapelArray {
 
     // For other domain types, the implementation probably knows the most
     // efficient way to clear its index set, so make a dsiClear() call.
+    pragma "no doc"
     proc clear() {
       _value.dsiClear();
     }
@@ -2126,6 +2134,7 @@ module ChapelArray {
   pragma "has runtime type"
   pragma "ignore noinit"
   pragma "default intent is ref if modified"
+  /* The array type */
   record _array {
     var _pid:int;  // only used when privatized
     pragma "owned"
@@ -2179,6 +2188,7 @@ module ChapelArray {
       }
     }
 
+    pragma "no doc"
     proc deinit() {
       _do_destroy();
     }
@@ -2430,6 +2440,7 @@ module ChapelArray {
       return localSlice((...d.getIndices()));
     }
 
+    /* Yield the array elements */
     pragma "reference to const when const this"
     iter these() ref {
       for i in _value.these() {
@@ -2437,6 +2448,7 @@ module ChapelArray {
       }
     }
 
+    pragma "no doc"
     pragma "reference to const when const this"
     iter these(param tag: iterKind) ref
       where tag == iterKind.standalone &&
@@ -2444,11 +2456,13 @@ module ChapelArray {
       for i in _value.these(tag) do
         yield i;
     }
+    pragma "no doc"
     iter these(param tag: iterKind)
       where tag == iterKind.leader {
       for followThis in _value.these(tag) do
         yield followThis;
     }
+    pragma "no doc"
     pragma "reference to const when const this"
     iter these(param tag: iterKind, followThis, param fast: bool = false) ref
       where tag == iterKind.follower {
@@ -2636,12 +2650,13 @@ module ChapelArray {
       _value.dsiSerialRead(f);
     }
 
+    // sparse array interface
+    /* Return the Implicitly Represented Value for sparse arrays */
     proc IRV where !isSparseArr(this) {
       compilerError("only sparse arrays have an IRV");
     }
 
-    // sparse array interface
-    /* Return the Implicitly Represented Value for sparse arrays */
+    pragma "no doc"
     proc IRV ref where isSparseArr(this) {
       return _value.IRV;
     }

--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -379,6 +379,7 @@ module ChapelLocale {
   // replication, set replicateRootLocale to false.
   pragma "no doc"
   pragma "locale private" var rootLocale : locale = nil;
+  pragma "no doc"
   pragma "locale private" var rootLocaleInitialized = false;
 
   pragma "no doc"

--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -2509,6 +2509,7 @@ proc _cast(type t, r: range(?)) where isRangeType(t) {
   // a single underscore where the standalone versions use double
   // underscores.  Reason: otherwise, the calls in range.init() try
   // to call the method version, which isn't currently legal.
+  pragma "no doc"
   inline proc range.chpl_intToIdx(i) {
     return chpl__intToIdx(this.idxType, i);
   }

--- a/modules/standard/GMP.chpl
+++ b/modules/standard/GMP.chpl
@@ -1223,6 +1223,7 @@ module GMP {
       gmp_randinit_lc_2exp_size(this.state, size.safeCast(c_ulong));
     }
 
+    pragma "no doc"
     proc deinit() {
       on this {
         gmp_randclear(this.state);

--- a/modules/standard/List.chpl
+++ b/modules/standard/List.chpl
@@ -216,6 +216,7 @@ record list {
   /*
     Destructor
    */
+  pragma "no doc"
   proc deinit(){
     destroy();
   }


### PR DESCRIPTION
No-doc a bunch of things that are meant to be internal, but were mistakenly rendered:
 - no-doc `rootLocaleInitialized` from ChapelLocale
 - no-doc `range.chpl_intToIdx()`
 - no-doc `GMPRandom.deinit()`
 - no-doc `List.deinit()`
 - no-doc the `_serialized_domain` record
 - no-doc duplicate array/domain `these()` iters
 - no-doc array/domain `deinit()`
 - no-doc duplicate array `IRV` proc
 - no-doc duplicate array `clear()` proc