### PR TITLE
Pre-release prep. Chapel 1.18.0: bump version numbers on master from 1.18 to 1.19

### DIFF
--- a/compiler/main/version.cpp
+++ b/compiler/main/version.cpp
@@ -35,7 +35,7 @@ void
 get_version(char *v) {
   v += sprintf(v, "%d.%s.%s", MAJOR_VERSION, MINOR_VERSION, UPDATE_VERSION);
   if (strcmp(BUILD_VERSION, "0") != 0 || developer)
-    sprintf(v, ".%s", BUILD_VERSION);   // post-release
+    sprintf(v, " pre-release (%s)", BUILD_VERSION);
 }
 
 void

--- a/compiler/main/version_num.h
+++ b/compiler/main/version_num.h
@@ -21,7 +21,7 @@
 #define _version_num_H_
 
 #define MAJOR_VERSION 1
-#define MINOR_VERSION "18"
+#define MINOR_VERSION "19"
 #define UPDATE_VERSION "0"
 
 static const char* BUILD_VERSION =

--- a/doc/rst/conf.py
+++ b/doc/rst/conf.py
@@ -55,18 +55,18 @@ master_doc = 'index'
 # built documents.
 #
 # The short X.Y version.
-# version = '1.18'
+# version = '1.17'
 
 # We use a custom version variable (shortversion) instead, because setting
 # 'version' adds a redundant version number onto the top of the sidebar
 # automatically (rtd-theme). We also don't use |version| anywhere in rst
 
-chplversion = '1.18'                  # post-release
+chplversion = '1.18 (pre-release)'    # TODO -- parse from `chpl --version`
 shortversion = chplversion.replace('-', '&#8209') # prevent line-break at hyphen
 html_context = {"chplversion":chplversion}
 
 # The full version, including alpha/beta/rc tags.
-release = '1.18.0'                    # post-release
+release = '1.18.0 (pre-release)'
 
 # General information about the project.
 project = u'Chapel Documentation'

--- a/doc/rst/conf.py
+++ b/doc/rst/conf.py
@@ -61,8 +61,8 @@ master_doc = 'index'
 # 'version' adds a redundant version number onto the top of the sidebar
 # automatically (rtd-theme). We also don't use |version| anywhere in rst
 
-chplversion = '1.19 (pre-release)'    # TODO -- parse from `chpl --version`
-shortversion = chplversion.replace('-', '&#8209') # prevent line-break at hyphen
+chplversion = '1.19'                  # TODO -- parse from `chpl --version`
+shortversion = chplversion.replace('-', '&#8209') # prevent line-break at hyphen, if any
 html_context = {"chplversion":chplversion}
 
 # The full version, including alpha/beta/rc tags.

--- a/doc/rst/conf.py
+++ b/doc/rst/conf.py
@@ -55,18 +55,18 @@ master_doc = 'index'
 # built documents.
 #
 # The short X.Y version.
-# version = '1.17'
+# version = '1.19'
 
 # We use a custom version variable (shortversion) instead, because setting
 # 'version' adds a redundant version number onto the top of the sidebar
 # automatically (rtd-theme). We also don't use |version| anywhere in rst
 
-chplversion = '1.18 (pre-release)'    # TODO -- parse from `chpl --version`
+chplversion = '1.19 (pre-release)'    # TODO -- parse from `chpl --version`
 shortversion = chplversion.replace('-', '&#8209') # prevent line-break at hyphen
 html_context = {"chplversion":chplversion}
 
 # The full version, including alpha/beta/rc tags.
-release = '1.18.0 (pre-release)'
+release = '1.19.0 (pre-release)'
 
 # General information about the project.
 project = u'Chapel Documentation'

--- a/man/confchpl.rst
+++ b/man/confchpl.rst
@@ -1,5 +1,5 @@
 
-:Version: 1.18.0 pre-release
+:Version: 1.19.0 pre-release
 :Manual section: 1
 :Title: \\fBchpl\\fP
 :Subtitle: Compiler for the Chapel Programming Language

--- a/man/confchpl.rst
+++ b/man/confchpl.rst
@@ -1,5 +1,5 @@
 
-:Version: 1.18.0
+:Version: 1.18.0 pre-release
 :Manual section: 1
 :Title: \\fBchpl\\fP
 :Subtitle: Compiler for the Chapel Programming Language

--- a/man/confchpldoc.rst
+++ b/man/confchpldoc.rst
@@ -1,5 +1,5 @@
 
-:Version: 1.18.0 pre-release
+:Version: 1.19.0 pre-release
 :Manual section: 1
 :Title: \\fBchpldoc\\fP
 :Subtitle: the Chapel Documentation Tool

--- a/man/confchpldoc.rst
+++ b/man/confchpldoc.rst
@@ -1,5 +1,5 @@
 
-:Version: 1.18.0
+:Version: 1.18.0 pre-release
 :Manual section: 1
 :Title: \\fBchpldoc\\fP
 :Subtitle: the Chapel Documentation Tool

--- a/test/compflags/bradc/printstuff/version.goodstart
+++ b/test/compflags/bradc/printstuff/version.goodstart
@@ -1,1 +1,1 @@
- version 1.18.0
+ version 1.19.0

--- a/test/compflags/bradc/printstuff/versionhelp.sh
+++ b/test/compflags/bradc/printstuff/versionhelp.sh
@@ -5,4 +5,4 @@ compiler=$3
 echo -n `basename $compiler`
 cat $CWD/version.goodstart
 diff $CWD/../../../../compiler/main/BUILD_VERSION $CWD/zero.txt > /dev/null 2>&1 && echo "" || \
-    { echo -n "." && cat $CWD/../../../../compiler/main/BUILD_VERSION | tr -d \" ; }    # post-release
+    { echo -n " pre-release (" && cat $CWD/../../../../compiler/main/BUILD_VERSION | tr -d \"\\n && echo ")" ; }


### PR DESCRIPTION
NOTE: This is not Chapel release 1.18.0 or 1.19.0. This change prepares the source on
master branch for next development cycle AFTER the upcoming Chapel 1.18.0 release,
currently scheduled for 20 Sep 2018.

The release/1.18 branch has been created, now set up for the next development
cycle.
* Revert "post-release version markings on master"
  (ie, put the "pre-release" strings back in)
* Bump version numbers on master from 1.18 to 1.19
