### PR TITLE
Improve robustness of doc version menu during release times

### DIFF
--- a/doc/util/versionButton.php
+++ b/doc/util/versionButton.php
@@ -89,13 +89,14 @@ if (pagePath == "") {
 function dropSetup() {
   var currentRelease = "1.17";
   var nextRelease = "1.18";
+  var nextNextRelease = "1.19";
   var button = document.getElementById("versionButton");
   // Uses unicode down-pointing triangle
   var arrow = " &#9660;";
   button.innerHTML = "version " + chplTitle + arrow;
 
   // Choose button color
-  if (chplTitle == nextRelease) {
+  if (chplTitle == nextRelease || chplTitle == nextNextRelease) {
     button.innerHTML = "version " + chplTitle + " (pre-release)" + arrow;
     button.classList.add("preRelease");
   } else if (chplTitle == currentRelease) {

--- a/doc/util/versionButton.php
+++ b/doc/util/versionButton.php
@@ -97,12 +97,14 @@ function dropSetup() {
 
   // Choose button color
   if (chplTitle == nextRelease || chplTitle == nextNextRelease) {
-    button.innerHTML = "version " + chplTitle + " (pre-release)" + arrow;
+    # add pre-release label using a non-breaking hyphen
+    button.innerHTML = "version " + chplTitle + " (pre&#8209;release)" + arrow;
     button.classList.add("preRelease");
   } else if (chplTitle == currentRelease) {
     button.classList.add("currentVersion");
   } else {
-    button.innerHTML = "version " + chplTitle + " (old release)" + arrow;
+    # add old release label using a non-blocking space
+    button.innerHTML = "version " + chplTitle + " (old&nbsp;release)" + arrow;
     button.classList.add("oldVersion");
   }
 


### PR DESCRIPTION
During the period when we're branching the release and setting up for the next
one, the version button can get a bit wonky because it needs to track not just
the current version, but potentially two future versions (the one we're about to
release and the one that comes after that).  This updates the logic to support
tagging two releases as pre-releases.

While here, I also made the "pre-release" and "old release" labels use non-breaking
hyphens and spaces (when the pre-release logic used to be in the doc building
logic itself, it did this, but now that we've moved it here, it wasn't).  It looks to me
like this rarely comes into play, but it makes things look nicer when it does.