### PR TITLE
Update memcpy intrinsic generation for LLVM 7

### DIFF
--- a/compiler/codegen/expr.cpp
+++ b/compiler/codegen/expr.cpp
@@ -2806,7 +2806,7 @@ void codegenCallMemcpy(GenRet dest, GenRet src, GenRet size,
     llArgs[1] = convertValueToType(src.val, types[1], false);
     llArgs[2] = convertValueToType(size.val, types[2], false);
 
-    // LLVM memcpy intrinsic has additional arguments alignment, isvolatile
+    // LLVM memcpy intrinsic has additional argument isvolatile
     // isVolatile?
     llArgs[3] = llvm::ConstantInt::get(llvm::Type::getInt1Ty(info->module->getContext()), 0, false);
 

--- a/compiler/llvm/llvm-global-to-wide/RUN_CONFIG
+++ b/compiler/llvm/llvm-global-to-wide/RUN_CONFIG
@@ -8,6 +8,7 @@ ln -s ../llvmAggregateGlobalOps.cpp llvmAggregateGlobalOps.cpp
 ln -s ../../include/llvmGlobalToWide.h llvmGlobalToWide.h
 ln -s ../../include/llvmUtil.h llvmUtil.h
 ln -s ../../include/llvmAggregateGlobalOps.h llvmAggregateGlobalOps.h
+ln -s ../../include/llvmVer.h llvmVer.h
 mkdir -p build
 cd build
 export CMAKE_PREFIX_PATH=$CHPL_HOME/third-party/llvm/install/linux64-gnu/

--- a/compiler/llvm/llvm-global-to-wide/test/a.ll
+++ b/compiler/llvm/llvm-global-to-wide/test/a.ll
@@ -2,6 +2,7 @@
 
 target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64-S128-p100:128:64:64-p101:128:64:64"
 
+; Note after LLVM 7 memcpy will no longer take an alignment argument
 declare void @llvm.memcpy.p0i8.p100i8.i64(i8* nocapture, i8 addrspace(100)* nocapture, i64, i32, i1)
 declare void @llvm.memcpy.p100i8.p0i8.i64(i8 addrspace(100)* nocapture, i8* nocapture, i64, i32, i1)
 declare void @llvm.memcpy.p100i8.p100i8.i64(i8 addrspace(100)* nocapture, i8 addrspace(100)* nocapture, i64, i32, i1)

--- a/compiler/llvm/llvm-global-to-wide/test/aggregate.ll
+++ b/compiler/llvm/llvm-global-to-wide/test/aggregate.ll
@@ -2,6 +2,7 @@
 
 target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64-S128-p100:128:64:64-p101:128:64:64"
 
+; Note after LLVM 7 memcpy will no longer take an alignment argument
 declare void @llvm.memcpy.p0i8.p100i8.i64(i8* nocapture, i8 addrspace(100)* nocapture, i64, i32, i1)
 declare void @llvm.memcpy.p100i8.p0i8.i64(i8 addrspace(100)* nocapture, i8* nocapture, i64, i32, i1)
 declare void @llvm.memcpy.p100i8.p100i8.i64(i8 addrspace(100)* nocapture, i8 addrspace(100)* nocapture, i64, i32, i1)

--- a/compiler/llvm/llvm-global-to-wide/test/d.ll
+++ b/compiler/llvm/llvm-global-to-wide/test/d.ll
@@ -16,7 +16,7 @@ target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f3
 %type_two = type { %type_one addrspace(100)* }
 ; CHECK: %type_two = type { { %struct.c_localeid_t, %type_one* } }
 
-; A function to keep those types from dissapearing 
+; A function to keep those types from dissapearing
 define void @test(%recurs %a, %type_one %b, %type_two %c) {
 ; CHECK: void @test(%recurs %a, %type_one %b, %type_two %c)
 entry:

--- a/compiler/llvm/llvm-global-to-wide/test/e.ll
+++ b/compiler/llvm/llvm-global-to-wide/test/e.ll
@@ -19,7 +19,7 @@ declare i32 @.gf.node.2(%mystruct addrspace(100)*) readnone
 declare %struct.c_localeid_t @.gf.loc.2(%mystruct addrspace(100)*) readnone
 declare %mystruct addrspace(100)* @.gf.make.2(%struct.c_localeid_t, %mystruct*) readnone
 
-; A function to keep those types from dissapearing 
+; A function to keep those types from dissapearing
 define void @test(%mystruct %a) {
 ; CHECK: void @test(%mystruct %a)
 entry:

--- a/compiler/llvm/llvm-global-to-wide/test/f.ll
+++ b/compiler/llvm/llvm-global-to-wide/test/f.ll
@@ -19,7 +19,7 @@ declare i32 @.gf.node.2(%mystruct addrspace(100)*) readnone
 declare %struct.c_localeid_t @.gf.loc.2(%mystruct addrspace(100)*) readnone
 declare %mystruct addrspace(100)* @.gf.make.2(%struct.c_localeid_t, %mystruct*) readnone
 
-; A function to keep those types from dissapearing 
+; A function to keep those types from dissapearing
 define void @test(%mystruct %a) {
 ; CHECK: void @test(%mystruct %a)
 entry:

--- a/compiler/llvm/llvm-global-to-wide/test/g.ll
+++ b/compiler/llvm/llvm-global-to-wide/test/g.ll
@@ -2,6 +2,7 @@
 
 target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64-S128-p100:128:64:64-p101:128:64:64"
 
+; Note after LLVM 7 memcpy will no longer take an alignment argument
 declare void @llvm.memcpy.p0i8.p100i8.i64(i8* nocapture, i8 addrspace(100)* nocapture, i64, i32, i1)
 declare void @llvm.memcpy.p100i8.p0i8.i64(i8 addrspace(100)* nocapture, i8* nocapture, i64, i32, i1)
 declare void @llvm.memcpy.p100i8.p100i8.i64(i8 addrspace(100)* nocapture, i8 addrspace(100)* nocapture, i64, i32, i1)


### PR DESCRIPTION
Allows Chapel to build with LLVM master. The memcpy
intrinsic no longer takes in an alignment argument.

Future work: run llvm-global-to-wide tests nightly (issue #11192).
Passed full llvm testing, gasnet testing.

Reviewed by @dmk42 - thanks!