### PR TITLE
Update URL for shootout benchmarks in release and submitted directories

### DIFF
--- a/test/release/examples/benchmarks/shootout/binarytrees.chpl
+++ b/test/release/examples/benchmarks/shootout/binarytrees.chpl
@@ -1,5 +1,5 @@
 /* The Computer Language Benchmarks Game
-   http://benchmarksgame.alioth.debian.org/
+   https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
 
    contributed by Casey Battaglino, Ben Harshbarger, and Brad Chamberlain
    derived from the GNU C version by Jeremy Zerfas

--- a/test/release/examples/benchmarks/shootout/chameneosredux-fast.chpl
+++ b/test/release/examples/benchmarks/shootout/chameneosredux-fast.chpl
@@ -1,5 +1,5 @@
 /* The Computer Language Benchmarks Game
-   http://benchmarksgame.alioth.debian.org/
+   https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
 
    contributed by Hannah Hemmaplardh, Lydia Duncan, Brad Chamberlain,
      and Elliot Ronaghan

--- a/test/release/examples/benchmarks/shootout/chameneosredux.chpl
+++ b/test/release/examples/benchmarks/shootout/chameneosredux.chpl
@@ -1,5 +1,5 @@
 /* The Computer Language Benchmarks Game
-   http://benchmarksgame.alioth.debian.org/
+   https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
 
    contributed by Hannah Hemmaplardh, Lydia Duncan, and Brad Chamberlain
    derived in part from the GNU C version by Dmitry Vyukov

--- a/test/release/examples/benchmarks/shootout/fannkuchredux.chpl
+++ b/test/release/examples/benchmarks/shootout/fannkuchredux.chpl
@@ -1,5 +1,5 @@
 /* The Computer Language Benchmarks Game
-   http://benchmarksgame.alioth.debian.org/
+   https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
 
    contributed by Ben Harshbarger and Brad Chamberlain
    derived from the Swift implementation by Ralph Ganszky

--- a/test/release/examples/benchmarks/shootout/fasta.chpl
+++ b/test/release/examples/benchmarks/shootout/fasta.chpl
@@ -1,5 +1,5 @@
 /* The Computer Language Benchmarks Game
-   http://benchmarksgame.alioth.debian.org/
+   https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
 
    contributed by Brad Chamberlain
    derived from the GNU C version by Аноним Легионов and Jeremy Zerfas

--- a/test/release/examples/benchmarks/shootout/knucleotide.chpl
+++ b/test/release/examples/benchmarks/shootout/knucleotide.chpl
@@ -1,5 +1,5 @@
 /* The Computer Language Benchmarks Game
-   http://benchmarksgame.alioth.debian.org/
+   https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
 
    contributed by Ben Harshbarger and Brad Chamberlain
    derived from the GNU C++ version by Branimir Maksimovic

--- a/test/release/examples/benchmarks/shootout/mandelbrot-fast.chpl
+++ b/test/release/examples/benchmarks/shootout/mandelbrot-fast.chpl
@@ -1,5 +1,5 @@
 /* The Computer Language Benchmarks Game
-   http://benchmarksgame.alioth.debian.org/
+   https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
 
    contributed by Brad Chamberlain
    derived from the Swift version by Ralph Ganszky

--- a/test/release/examples/benchmarks/shootout/mandelbrot.chpl
+++ b/test/release/examples/benchmarks/shootout/mandelbrot.chpl
@@ -1,5 +1,5 @@
 /* The Computer Language Benchmarks Game
-   http://benchmarksgame.alioth.debian.org/
+   https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
 
    contributed by Jacob Nelson, Lydia Duncan, Brad Chamberlain,
    and Ben Harshbarger

--- a/test/release/examples/benchmarks/shootout/meteor-fast.chpl
+++ b/test/release/examples/benchmarks/shootout/meteor-fast.chpl
@@ -1,5 +1,5 @@
 /* The Computer Language Benchmarks Game
-   http://benchmarksgame.alioth.debian.org/
+   https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
 
    contributed by Kyle Brady and Ben Albrecht
    derived from the C++ implementation by Stefan Westen

--- a/test/release/examples/benchmarks/shootout/meteor.chpl
+++ b/test/release/examples/benchmarks/shootout/meteor.chpl
@@ -1,5 +1,5 @@
 /* The Computer Language Benchmarks Game
-   http://benchmarksgame.alioth.debian.org/
+   https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
 
    contributed by Kyle Brady and Lydia Duncan
    derived from the C implementation by Christian Vosteen

--- a/test/release/examples/benchmarks/shootout/nbody.chpl
+++ b/test/release/examples/benchmarks/shootout/nbody.chpl
@@ -1,5 +1,5 @@
 /* The Computer Language Benchmarks Game
-   http://benchmarksgame.alioth.debian.org/
+   https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
 
    contributed by Albert Sidelnik and Brad Chamberlain
    derived from the Java version by Mark C. Lewis and Chad Whipkey

--- a/test/release/examples/benchmarks/shootout/pidigits-fast.chpl
+++ b/test/release/examples/benchmarks/shootout/pidigits-fast.chpl
@@ -1,5 +1,5 @@
 /* The Computer Language Benchmarks Game
-   http://benchmarksgame.alioth.debian.org/
+   https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
 
    contributed by Thomas Van Doren, Michael Noakes, Brad Chamberlain, and
      Elliot Ronaghan

--- a/test/release/examples/benchmarks/shootout/pidigits.chpl
+++ b/test/release/examples/benchmarks/shootout/pidigits.chpl
@@ -1,5 +1,5 @@
 /* The Computer Language Benchmarks Game
-   http://benchmarksgame.alioth.debian.org/
+   https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
 
    contributed by Thomas Van Doren, Michael Noakes, Brad Chamberlain, and
      Elliot Ronaghan

--- a/test/release/examples/benchmarks/shootout/regexdna-redux.chpl
+++ b/test/release/examples/benchmarks/shootout/regexdna-redux.chpl
@@ -1,5 +1,5 @@
 /* The Computer Language Benchmarks Game
-   http://benchmarksgame.alioth.debian.org/
+   https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
 
    regex-dna program contributed by Ben Harshbarger
    derived from the GNU C++ RE2 version by Alexey Zolotov

--- a/test/release/examples/benchmarks/shootout/regexdna.chpl
+++ b/test/release/examples/benchmarks/shootout/regexdna.chpl
@@ -1,5 +1,5 @@
 /* The Computer Language Benchmarks Game
-   http://benchmarksgame.alioth.debian.org/
+   https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
 
    contributed by Ben Harshbarger
    derived from the GNU C++ RE2 version by Alexey Zolotov

--- a/test/release/examples/benchmarks/shootout/revcomp-fast.chpl
+++ b/test/release/examples/benchmarks/shootout/revcomp-fast.chpl
@@ -1,5 +1,6 @@
 /* The Computer Language Benchmarks Game
    https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
+
    contributed by Ben Harshbarger and Brad Chamberlain
    derived from the Rust #2 version by Matt Brubeck
 */

--- a/test/release/examples/benchmarks/shootout/revcomp-fast.chpl
+++ b/test/release/examples/benchmarks/shootout/revcomp-fast.chpl
@@ -1,5 +1,5 @@
 /* The Computer Language Benchmarks Game
-   http://benchmarksgame.alioth.debian.org/
+   https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
    contributed by Ben Harshbarger and Brad Chamberlain
    derived from the Rust #2 version by Matt Brubeck
 */

--- a/test/release/examples/benchmarks/shootout/revcomp.chpl
+++ b/test/release/examples/benchmarks/shootout/revcomp.chpl
@@ -1,5 +1,5 @@
 /* The Computer Language Benchmarks Game
-   http://benchmarksgame.alioth.debian.org/
+   https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
 
    contributed by Ben Harshbarger and Brad Chamberlain
    derived from the GNU C version by Mr Ledrug

--- a/test/release/examples/benchmarks/shootout/spectralnorm.chpl
+++ b/test/release/examples/benchmarks/shootout/spectralnorm.chpl
@@ -1,5 +1,5 @@
 /* The Computer Language Benchmarks Game
-   http://benchmarksgame.alioth.debian.org/
+   https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
 
    contributed by Lydia Duncan, Albert Sidelnik, and Brad Chamberlain
    derived from the GNU C version by Sebastien Loisel and the C# version

--- a/test/release/examples/benchmarks/shootout/threadring.chpl
+++ b/test/release/examples/benchmarks/shootout/threadring.chpl
@@ -1,5 +1,5 @@
 /* The Computer Language Benchmarks Game
-   http://benchmarksgame.alioth.debian.org/
+   https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
 
    contributed by Sung-Eun Choi, Lydia Duncan, and Brad Chamberlain
 */

--- a/test/studies/shootout/submitted/binarytrees.chpl
+++ b/test/studies/shootout/submitted/binarytrees.chpl
@@ -1,5 +1,5 @@
 /* The Computer Language Benchmarks Game
-   http://benchmarksgame.alioth.debian.org/
+   https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
 
    contributed by Casey Battaglino, Ben Harshbarger, and Brad Chamberlain
    derived from the GNU C version by Jeremy Zerfas

--- a/test/studies/shootout/submitted/fannkuchredux.chpl
+++ b/test/studies/shootout/submitted/fannkuchredux.chpl
@@ -1,5 +1,5 @@
 /* The Computer Language Benchmarks Game
-   http://benchmarksgame.alioth.debian.org/
+   https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
 
    contributed by Ben Harshbarger and Brad Chamberlain
    derived from the Swift implementation by Ralph Ganszky

--- a/test/studies/shootout/submitted/fasta.chpl
+++ b/test/studies/shootout/submitted/fasta.chpl
@@ -24,7 +24,7 @@ use nucleotide;
 //
 // Sequence to be repeated
 //
-const ALU: [0..286] nucleotide = [
+const ALU: [0..286] int(8) = [
   G, G, C, C, G, G, G, C, G, C, G, G, T, G, G, C, T, C, A, C,
   G, C, C, T, G, T, A, A, T, C, C, C, A, G, C, A, C, T, T, T,
   G, G, G, A, G, G, C, C, G, A, G, G, C, G, G, G, C, G, G, A,
@@ -119,7 +119,7 @@ proc randomMake(desc, a, n) {
   proc addLine(bytes) {
     for (r, i) in zip(getRands(bytes), 0..) {
       if r < a[1](prob) {
-        line_buff[i] = a[1](nucl):int(8);
+        line_buff[i] = a[1](nucl);
       } else {
         var lo = a.domain.low,
             hi = a.domain.high;
@@ -130,7 +130,7 @@ proc randomMake(desc, a, n) {
           else
             lo = ai;
         }
-        line_buff[i] = a[hi](nucl):int(8);
+        line_buff[i] = a[hi](nucl);
       }
     }
     line_buff[bytes] = newline;

--- a/test/studies/shootout/submitted/fasta.chpl
+++ b/test/studies/shootout/submitted/fasta.chpl
@@ -1,5 +1,5 @@
 /* The Computer Language Benchmarks Game
-   http://benchmarksgame.alioth.debian.org/
+   https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
 
    contributed by Preston Sahabu
    derived from the Chapel fastaredux version by Casey Battaglino et al.
@@ -24,7 +24,7 @@ use nucleotide;
 //
 // Sequence to be repeated
 //
-const ALU: [0..286] int(8) = [
+const ALU: [0..286] nucleotide = [
   G, G, C, C, G, G, G, C, G, C, G, G, T, G, G, C, T, C, A, C,
   G, C, C, T, G, T, A, A, T, C, C, C, A, G, C, A, C, T, T, T,
   G, G, G, A, G, G, C, C, G, A, G, G, C, G, G, G, C, G, G, A,
@@ -119,7 +119,7 @@ proc randomMake(desc, a, n) {
   proc addLine(bytes) {
     for (r, i) in zip(getRands(bytes), 0..) {
       if r < a[1](prob) {
-        line_buff[i] = a[1](nucl);
+        line_buff[i] = a[1](nucl):int(8);
       } else {
         var lo = a.domain.low,
             hi = a.domain.high;
@@ -130,7 +130,7 @@ proc randomMake(desc, a, n) {
           else
             lo = ai;
         }
-        line_buff[i] = a[hi](nucl);
+        line_buff[i] = a[hi](nucl):int(8);
       }
     }
     line_buff[bytes] = newline;

--- a/test/studies/shootout/submitted/fasta2.chpl
+++ b/test/studies/shootout/submitted/fasta2.chpl
@@ -8,16 +8,16 @@
 */
 
 config const n = 1000,            // the length of the generated strings
-             lineLength = 60,     // the number of columns in the output
-             blockSize = 1024,    // the parallelization granularity
-             numTasks = min(4, here.maxTaskPar);  // how many tasks to use?
+    lineLength = 60,     // the number of columns in the output
+    blockSize = 1024,    // the parallelization granularity
+    numTasks = min(4, here.maxTaskPar);  // how many tasks to use?
 
 config type randType = uint(32);  // type to use for random numbers
 
 config param IM = 139968,         // parameters for random number generation
-             IA = 3877,
-             IC = 29573,
-             seed: randType = 42;
+    IA = 3877,
+    IC = 29573,
+    seed: randType = 42;
 
 //
 // Nucleotide definitions
@@ -34,7 +34,7 @@ use nucleotide;
 //
 // Sequence to be repeated
 //
-const ALU: [0..286] nucleotide = [
+const ALU: [0..286] int(8) = [
   G, G, C, C, G, G, G, C, G, C, G, G, T, G, G, C, T, C, A, C,
   G, C, C, T, G, T, A, A, T, C, C, C, A, G, C, A, C, T, T, T,
   G, G, G, A, G, G, C, C, G, A, G, G, C, G, G, G, C, G, G, A,
@@ -62,14 +62,14 @@ param nucl = 1,
 // Probability tables for sequences to be randomly generated
 //
 const IUB = [(a, 0.27), (c, 0.12), (g, 0.12), (t, 0.27),
-             (B, 0.02), (D, 0.02), (H, 0.02), (K, 0.02),
-             (M, 0.02), (N, 0.02), (R, 0.02), (S, 0.02),
-             (V, 0.02), (W, 0.02), (Y, 0.02)];
+    (B, 0.02), (D, 0.02), (H, 0.02), (K, 0.02),
+    (M, 0.02), (N, 0.02), (R, 0.02), (S, 0.02),
+    (V, 0.02), (W, 0.02), (Y, 0.02)];
 
 const HomoSapiens = [(a, 0.3029549426680),
-                     (c, 0.1979883004921),
-                     (g, 0.1975473066391),
-                     (t, 0.3015094502008)];
+            (c, 0.1979883004921),
+            (g, 0.1975473066391),
+            (t, 0.3015094502008)];
 
 proc main() {
   repeatMake(">ONE Homo sapiens alu", ALU, 2*n);
@@ -81,7 +81,7 @@ proc main() {
 // Redefine stdout to use lock-free binary I/O and capture a newline
 //
 const stdout = openfd(1).writer(kind=iokind.native, locking=false);
-param newline = ascii("\n");
+param newline = ascii("\n"): int(8);
 
 //
 // Repeat 'alu' to generate a sequence of length 'n'
@@ -92,8 +92,6 @@ proc repeatMake(desc, alu, n) {
   const r = alu.size,
         s = [i in 0..(r+lineLength)] alu[i % r];
 
-  //  writeln(s.domain);
-  
   for i in 0..n by lineLength {
     const lo = i % r + 1,
           len = min(lineLength, n-i);
@@ -148,7 +146,7 @@ proc randomMake(desc, nuclInfo, n) {
           if r >= cumulProb[k] then
             nid += 1;
 
-        myBuff[off] = nuclInfo[nid](nucl):int(8);
+        myBuff[off] = nuclInfo[nid](nucl);
         off += 1;
         col += 1;
 
@@ -182,3 +180,4 @@ proc getRands(n, arr) {
     arr[i] = lastRand;
   }
 }
+

--- a/test/studies/shootout/submitted/fasta2.chpl
+++ b/test/studies/shootout/submitted/fasta2.chpl
@@ -1,5 +1,5 @@
 /* The Computer Language Benchmarks Game
-   http://benchmarksgame.alioth.debian.org/
+   https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
 
    contributed by Brad Chamberlain
    derived from the GNU C version by Аноним Легионов and Jeremy Zerfas
@@ -8,16 +8,16 @@
 */
 
 config const n = 1000,            // the length of the generated strings
-    lineLength = 60,     // the number of columns in the output
-    blockSize = 1024,    // the parallelization granularity
-    numTasks = min(4, here.maxTaskPar);  // how many tasks to use?
+             lineLength = 60,     // the number of columns in the output
+             blockSize = 1024,    // the parallelization granularity
+             numTasks = min(4, here.maxTaskPar);  // how many tasks to use?
 
 config type randType = uint(32);  // type to use for random numbers
 
 config param IM = 139968,         // parameters for random number generation
-    IA = 3877,
-    IC = 29573,
-    seed: randType = 42;
+             IA = 3877,
+             IC = 29573,
+             seed: randType = 42;
 
 //
 // Nucleotide definitions
@@ -34,7 +34,7 @@ use nucleotide;
 //
 // Sequence to be repeated
 //
-const ALU: [0..286] int(8) = [
+const ALU: [0..286] nucleotide = [
   G, G, C, C, G, G, G, C, G, C, G, G, T, G, G, C, T, C, A, C,
   G, C, C, T, G, T, A, A, T, C, C, C, A, G, C, A, C, T, T, T,
   G, G, G, A, G, G, C, C, G, A, G, G, C, G, G, G, C, G, G, A,
@@ -62,14 +62,14 @@ param nucl = 1,
 // Probability tables for sequences to be randomly generated
 //
 const IUB = [(a, 0.27), (c, 0.12), (g, 0.12), (t, 0.27),
-    (B, 0.02), (D, 0.02), (H, 0.02), (K, 0.02),
-    (M, 0.02), (N, 0.02), (R, 0.02), (S, 0.02),
-    (V, 0.02), (W, 0.02), (Y, 0.02)];
+             (B, 0.02), (D, 0.02), (H, 0.02), (K, 0.02),
+             (M, 0.02), (N, 0.02), (R, 0.02), (S, 0.02),
+             (V, 0.02), (W, 0.02), (Y, 0.02)];
 
 const HomoSapiens = [(a, 0.3029549426680),
-            (c, 0.1979883004921),
-            (g, 0.1975473066391),
-            (t, 0.3015094502008)];
+                     (c, 0.1979883004921),
+                     (g, 0.1975473066391),
+                     (t, 0.3015094502008)];
 
 proc main() {
   repeatMake(">ONE Homo sapiens alu", ALU, 2*n);
@@ -81,7 +81,7 @@ proc main() {
 // Redefine stdout to use lock-free binary I/O and capture a newline
 //
 const stdout = openfd(1).writer(kind=iokind.native, locking=false);
-param newline = ascii("\n"): int(8);
+param newline = ascii("\n");
 
 //
 // Repeat 'alu' to generate a sequence of length 'n'
@@ -92,6 +92,8 @@ proc repeatMake(desc, alu, n) {
   const r = alu.size,
         s = [i in 0..(r+lineLength)] alu[i % r];
 
+  //  writeln(s.domain);
+  
   for i in 0..n by lineLength {
     const lo = i % r + 1,
           len = min(lineLength, n-i);
@@ -146,7 +148,7 @@ proc randomMake(desc, nuclInfo, n) {
           if r >= cumulProb[k] then
             nid += 1;
 
-        myBuff[off] = nuclInfo[nid](nucl);
+        myBuff[off] = nuclInfo[nid](nucl):int(8);
         off += 1;
         col += 1;
 
@@ -180,4 +182,3 @@ proc getRands(n, arr) {
     arr[i] = lastRand;
   }
 }
-

--- a/test/studies/shootout/submitted/knucleotide.chpl
+++ b/test/studies/shootout/submitted/knucleotide.chpl
@@ -1,5 +1,5 @@
 /* The Computer Language Benchmarks Game
-   http://benchmarksgame.alioth.debian.org/
+   https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
 
    contributed by Ben Harshbarger and Brad Chamberlain
    derived from the GNU C++ version by Branimir Maksimovic

--- a/test/studies/shootout/submitted/mandelbrot.chpl
+++ b/test/studies/shootout/submitted/mandelbrot.chpl
@@ -1,5 +1,5 @@
 /* The Computer Language Benchmarks Game
-   http://benchmarksgame.alioth.debian.org/
+   https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
 
    contributed by Jacob Nelson, Lydia Duncan, Brad Chamberlain,
    and Ben Harshbarger

--- a/test/studies/shootout/submitted/mandelbrot2.chpl
+++ b/test/studies/shootout/submitted/mandelbrot2.chpl
@@ -1,5 +1,5 @@
 /* The Computer Language Benchmarks Game
-   http://benchmarksgame.alioth.debian.org/
+   https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
 
    contributed by Brad Chamberlain
    derived from the Swift version by Ralph Ganszky

--- a/test/studies/shootout/submitted/nbody.chpl
+++ b/test/studies/shootout/submitted/nbody.chpl
@@ -1,5 +1,5 @@
 /* The Computer Language Benchmarks Game
-   http://benchmarksgame.alioth.debian.org/
+   https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
 
    contributed by Albert Sidelnik and Brad Chamberlain
    derived from the Java version by Mark C. Lewis and Chad Whipkey

--- a/test/studies/shootout/submitted/pidigits.chpl
+++ b/test/studies/shootout/submitted/pidigits.chpl
@@ -1,5 +1,5 @@
 /* The Computer Language Benchmarks Game
-   http://benchmarksgame.alioth.debian.org/
+   https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
 
    contributed by Tom Hildebrandt, Brad Chamberlain, and Lydia Duncan
    derived from the GNU C version by Mr Ledrug

--- a/test/studies/shootout/submitted/pidigits2.chpl
+++ b/test/studies/shootout/submitted/pidigits2.chpl
@@ -1,5 +1,5 @@
 /* The Computer Language Benchmarks Game
-   http://benchmarksgame.alioth.debian.org
+   https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
 
    contributed by Thomas Van Doren, Michael Noakes, Brad Chamberlain, and
      Elliot Ronaghan

--- a/test/studies/shootout/submitted/regexdna.chpl
+++ b/test/studies/shootout/submitted/regexdna.chpl
@@ -1,5 +1,5 @@
 /* The Computer Language Benchmarks Game
-   http://benchmarksgame.alioth.debian.org/
+   https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
 
    contributed by Ben Harshbarger
    derived from the GNU C++ RE2 version by Alexey Zolotov

--- a/test/studies/shootout/submitted/regexredux.chpl
+++ b/test/studies/shootout/submitted/regexredux.chpl
@@ -1,5 +1,5 @@
 /* The Computer Language Benchmarks Game
-   http://benchmarksgame.alioth.debian.org/
+   https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
 
    regex-dna program contributed by Ben Harshbarger
    derived from the GNU C++ RE2 version by Alexey Zolotov

--- a/test/studies/shootout/submitted/revcomp.chpl
+++ b/test/studies/shootout/submitted/revcomp.chpl
@@ -1,5 +1,5 @@
 /* The Computer Language Benchmarks Game
-   http://benchmarksgame.alioth.debian.org/
+   https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
 
    contributed by Ben Harshbarger and Brad Chamberlain
    derived from the GNU C version by Mr Ledrug

--- a/test/studies/shootout/submitted/spectralnorm.chpl
+++ b/test/studies/shootout/submitted/spectralnorm.chpl
@@ -1,5 +1,5 @@
 /* The Computer Language Benchmarks Game
-   http://benchmarksgame.alioth.debian.org/
+   https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
 
    contributed by Lydia Duncan, Albert Sidelnik, and Brad Chamberlain
    derived from the GNU C version by Sebastien Loisel and the C# version


### PR DESCRIPTION
This changes the URLs for our main (release and submitted) shootout versions to show the one for the new / current website.  I didn't bother changing the other studies/ cases because they're less public and I wasn't that bored (but this could be done lazily as we touch them).