### PR TITLE
Switch study version of binary trees from owned to unmanaged

### DIFF
--- a/test/studies/shootout/binary-trees/binarytrees-blc.chpl
+++ b/test/studies/shootout/binary-trees/binarytrees-blc.chpl
@@ -64,15 +64,15 @@ proc main() {
 // A simple balanced tree node class
 //
 class Tree {
-  var left, right: owned Tree;
+  var left, right: unmanaged Tree;
 
   //
   // A Tree-building initializer
   //
   proc init(depth) {
     if depth > 0 {
-      left  = new owned Tree(depth-1);
-      right = new owned Tree(depth-1);
+      left  = new unmanaged Tree(depth-1);
+      right = new unmanaged Tree(depth-1);
     }
   }
 
@@ -85,5 +85,9 @@ class Tree {
       sum += left.sum() + right.sum();
     }
     return sum;
+  }
+
+  proc deinit() {
+    delete left, right;
   }
 }


### PR DESCRIPTION
This changes my study version of binary trees from owned to unmanaged,
but frees in a distinct step at the end rather than freeing while
we're computing a tree's sum.  By comparing to the previous and
release versions, this should help us distinguish the overhead for
using 'owned' from the overhead for deleting in a separate step
(requiring a re-traversal of the tree).