### PR TITLE
Update fastas for 1.18 and do some other cleanups

### DIFF
--- a/test/studies/shootout/submitted/fasta.chpl
+++ b/test/studies/shootout/submitted/fasta.chpl
@@ -24,7 +24,7 @@ use nucleotide;
 //
 // Sequence to be repeated
 //
-const ALU: [0..286] int(8) = [
+const ALU: [0..286] nucleotide = [
   G, G, C, C, G, G, G, C, G, C, G, G, T, G, G, C, T, C, A, C,
   G, C, C, T, G, T, A, A, T, C, C, C, A, G, C, A, C, T, T, T,
   G, G, G, A, G, G, C, C, G, A, G, G, C, G, G, G, C, G, G, A,
@@ -85,7 +85,7 @@ proc sumProbs(alphabet: []) {
 // Redefine stdout to use lock-free binary I/O and capture a newline
 //
 const stdout = openfd(1).writer(kind=iokind.native, locking=false);
-param newline = ascii("\n"): int(8);
+param newline = ascii("\n");
 
 //
 // Repeat sequence "alu" for n characters
@@ -94,10 +94,10 @@ proc repeatMake(desc, alu, n) {
   stdout.writef("%s", desc);
 
   const r = alu.size,
-        s = [i in 0..(r+lineLength)] alu[i % r];
+        s = [i in {0..r+lineLength}] alu[i % r]: int(8);
 
   for i in 0..n by lineLength {
-    const lo = i % r + 1,
+    const lo = i % r,
           len = min(lineLength, n-i);
     stdout.write(s[lo..#len], newline);
   }
@@ -108,7 +108,7 @@ proc repeatMake(desc, alu, n) {
 //
 proc randomMake(desc, a, n) {
   var line_buff: [0..lineLength] int(8);
-    
+
   stdout.writef("%s", desc);
   for i in 1..n by lineLength do
     addLine(min(lineLength, n-i+1));
@@ -119,7 +119,7 @@ proc randomMake(desc, a, n) {
   proc addLine(bytes) {
     for (r, i) in zip(getRands(bytes), 0..) {
       if r < a[1](prob) {
-        line_buff[i] = a[1](nucl);
+        line_buff[i] = a[1](nucl): int(8);
       } else {
         var lo = a.domain.low,
             hi = a.domain.high;
@@ -130,7 +130,7 @@ proc randomMake(desc, a, n) {
           else
             lo = ai;
         }
-        line_buff[i] = a[hi](nucl);
+        line_buff[i] = a[hi](nucl): int(8);
       }
     }
     line_buff[bytes] = newline;

--- a/test/studies/shootout/submitted/fasta.future
+++ b/test/studies/shootout/submitted/fasta.future
@@ -1,4 +1,0 @@
-shootout resubmission: update once enum->int coercions are disabled on master
-
-Once we've disabled enum->int coercions on master, we'll need to update
-this on the CLBG website to use casts in repeatMake and randomMake.

--- a/test/studies/shootout/submitted/fasta2.chpl
+++ b/test/studies/shootout/submitted/fasta2.chpl
@@ -8,16 +8,16 @@
 */
 
 config const n = 1000,            // the length of the generated strings
-    lineLength = 60,     // the number of columns in the output
-    blockSize = 1024,    // the parallelization granularity
-    numTasks = min(4, here.maxTaskPar);  // how many tasks to use?
+             lineLength = 60,     // the number of columns in the output
+             blockSize = 1024,    // the parallelization granularity
+             numTasks = min(4, here.maxTaskPar);  // how many tasks to use?
 
 config type randType = uint(32);  // type to use for random numbers
 
 config param IM = 139968,         // parameters for random number generation
-    IA = 3877,
-    IC = 29573,
-    seed: randType = 42;
+             IA = 3877,
+             IC = 29573,
+             seed: randType = 42;
 
 //
 // Nucleotide definitions
@@ -34,7 +34,7 @@ use nucleotide;
 //
 // Sequence to be repeated
 //
-const ALU: [0..286] int(8) = [
+const ALU: [0..286] nucleotide = [
   G, G, C, C, G, G, G, C, G, C, G, G, T, G, G, C, T, C, A, C,
   G, C, C, T, G, T, A, A, T, C, C, C, A, G, C, A, C, T, T, T,
   G, G, G, A, G, G, C, C, G, A, G, G, C, G, G, G, C, G, G, A,
@@ -62,14 +62,14 @@ param nucl = 1,
 // Probability tables for sequences to be randomly generated
 //
 const IUB = [(a, 0.27), (c, 0.12), (g, 0.12), (t, 0.27),
-    (B, 0.02), (D, 0.02), (H, 0.02), (K, 0.02),
-    (M, 0.02), (N, 0.02), (R, 0.02), (S, 0.02),
-    (V, 0.02), (W, 0.02), (Y, 0.02)];
+             (B, 0.02), (D, 0.02), (H, 0.02), (K, 0.02),
+             (M, 0.02), (N, 0.02), (R, 0.02), (S, 0.02),
+             (V, 0.02), (W, 0.02), (Y, 0.02)];
 
 const HomoSapiens = [(a, 0.3029549426680),
-            (c, 0.1979883004921),
-            (g, 0.1975473066391),
-            (t, 0.3015094502008)];
+                     (c, 0.1979883004921),
+                     (g, 0.1975473066391),
+                     (t, 0.3015094502008)];
 
 proc main() {
   repeatMake(">ONE Homo sapiens alu", ALU, 2*n);
@@ -81,7 +81,7 @@ proc main() {
 // Redefine stdout to use lock-free binary I/O and capture a newline
 //
 const stdout = openfd(1).writer(kind=iokind.native, locking=false);
-param newline = ascii("\n"): int(8);
+param newline = ascii("\n");
 
 //
 // Repeat 'alu' to generate a sequence of length 'n'
@@ -90,10 +90,10 @@ proc repeatMake(desc, alu, n) {
   stdout.writeln(desc);
 
   const r = alu.size,
-        s = [i in 0..(r+lineLength)] alu[i % r];
+        s = [i in {0..(r+lineLength)}] alu[i % r]: int(8);
 
   for i in 0..n by lineLength {
-    const lo = i % r + 1,
+    const lo = i % r,
           len = min(lineLength, n-i);
     stdout.write(s[lo..#len], newline);
   }
@@ -146,7 +146,7 @@ proc randomMake(desc, nuclInfo, n) {
           if r >= cumulProb[k] then
             nid += 1;
 
-        myBuff[off] = nuclInfo[nid](nucl);
+        myBuff[off] = nuclInfo[nid](nucl): int(8);
         off += 1;
         col += 1;
 

--- a/test/studies/shootout/submitted/fasta2.future
+++ b/test/studies/shootout/submitted/fasta2.future
@@ -1,4 +1,0 @@
-shootout resubmission: update once enum->int coercions are disabled on master
-
-Once we've disabled enum->int coercions on master, we'll need to update
-this on the CLBG website to use casts in repeatMake and randomMake


### PR DESCRIPTION
This makes a few changes to our submitted fasta versions for the
purposes of making them compatible with 1.18 and doing some other
cleanups:

* started relying on param int->int(8) coercions
* stopped relying on enum->int coercions
* took advantage of shape preservation fix to retain 0-based indices
  - would be even nicer if we supported shape preservation for ranges
* restored preferred whitespace (removed in last submission)