### PR TITLE
Update binarytrees to take advantage of 1.18

### DIFF
--- a/test/studies/shootout/submitted/binarytrees.chpl
+++ b/test/studies/shootout/submitted/binarytrees.chpl
@@ -18,30 +18,30 @@ proc main() {
   var stats: [depths] (int,int);           // stores statistics for the trees
 
   //
-  // Create the "stretch" tree, checksum it, print its stats, and free it.
+  // Create the short-lived "stretch" tree, checksum it, and print its stats.
   //
-  const strTree = new unmanaged Tree(strDepth);
-  writeln("stretch tree of depth ", strDepth, "\t check: ", strTree.sum());
-  delete strTree;
+  {
+    const strTree = new Tree(strDepth);
+    writeln("stretch tree of depth ", strDepth, "\t check: ", strTree.sum());
+  }
 
   //
   // Build the long-lived tree.
   //
-  const llTree = new unmanaged Tree(maxDepth);
+  const llTree = new Tree(maxDepth);
 
   //
   // Iterate over the depths in parallel, dynamically assigning them
   // to tasks.  At each depth, create the required trees, compute
   // their sums, and free them.
   //
-  forall depth in dynamic(depths, chunkSize=1) {
+  forall depth in dynamic(depths) {
     const iterations = 2**(maxDepth - depth + minDepth);
     var sum = 0;
 			
     for i in 1..iterations {
-      const t = new unmanaged Tree(depth);
+      const t = new Tree(depth);
       sum += t.sum();
-      delete t;
     }
     stats[depth] = (iterations, sum);
   }
@@ -57,7 +57,6 @@ proc main() {
   // Checksum the long-lived tree, print its stats, and free it.
   //
   writeln("long lived tree of depth ", maxDepth, "\t check: ", llTree.sum());
-  delete llTree;
 }
 
 
@@ -84,8 +83,7 @@ class Tree {
     var sum = 1;
     if left {
       sum += left.sum() + right.sum();
-      delete left;
-      delete right;
+      delete left, right;
     }
     return sum;
   }

--- a/test/studies/shootout/submitted/binarytrees.compopts
+++ b/test/studies/shootout/submitted/binarytrees.compopts
@@ -1,0 +1,1 @@
+--no-warnings

--- a/test/studies/shootout/submitted/binarytrees.perfcompopts
+++ b/test/studies/shootout/submitted/binarytrees.perfcompopts
@@ -1,0 +1,1 @@
+--no-warnings


### PR DESCRIPTION
This submitted version of binarytrees had already (accidentally) been
updated to no longer match the version on the website; this goes
further by making it match the release version by:

1) Taking advantage of implicit scope-based frees
2) Taking advantage of the ability to delete multiple expressions at once
3) Taking advantage of the default chunkSize of 1 in the dynamic iterator

Note that because it uses scope-based frees, this code generates a warning
by default, so I needed to add .compopts / .perfcompopts files to silence
those in testing.