### PR TITLE
Post-release branch Chapel 1.18.0: versionButton.php (cherry-pick to #11121)

### DIFF
--- a/doc/util/versionButton.php
+++ b/doc/util/versionButton.php
@@ -97,13 +97,13 @@ function dropSetup() {
 
   // Choose button color
   if (chplTitle == nextRelease || chplTitle == nextNextRelease) {
-    # add pre-release label using a non-breaking hyphen
+    // add pre-release label using a non-breaking hyphen
     button.innerHTML = "version " + chplTitle + " (pre&#8209;release)" + arrow;
     button.classList.add("preRelease");
   } else if (chplTitle == currentRelease) {
     button.classList.add("currentVersion");
   } else {
-    # add old release label using a non-blocking space
+    // add old release label using a non-blocking space
     button.innerHTML = "version " + chplTitle + " (old&nbsp;release)" + arrow;
     button.classList.add("oldVersion");
   }

--- a/doc/util/versionButton.php
+++ b/doc/util/versionButton.php
@@ -89,13 +89,14 @@ if (pagePath == "") {
 function dropSetup() {
   var currentRelease = "1.17";
   var nextRelease = "1.18";
+  var nextNextRelease = "1.19";
   var button = document.getElementById("versionButton");
   // Uses unicode down-pointing triangle
   var arrow = " &#9660;";
   button.innerHTML = "version " + chplTitle + arrow;
 
   // Choose button color
-  if (chplTitle == nextRelease) {
+  if (chplTitle == nextRelease || chplTitle == nextNextRelease) {
     button.innerHTML = "version " + chplTitle + " (pre-release)" + arrow;
     button.classList.add("preRelease");
   } else if (chplTitle == currentRelease) {

--- a/doc/util/versionButton.php
+++ b/doc/util/versionButton.php
@@ -97,12 +97,14 @@ function dropSetup() {
 
   // Choose button color
   if (chplTitle == nextRelease || chplTitle == nextNextRelease) {
-    button.innerHTML = "version " + chplTitle + " (pre-release)" + arrow;
+    # add pre-release label using a non-breaking hyphen
+    button.innerHTML = "version " + chplTitle + " (pre&#8209;release)" + arrow;
     button.classList.add("preRelease");
   } else if (chplTitle == currentRelease) {
     button.classList.add("currentVersion");
   } else {
-    button.innerHTML = "version " + chplTitle + " (old release)" + arrow;
+    # add old release label using a non-blocking space
+    button.innerHTML = "version " + chplTitle + " (old&nbsp;release)" + arrow;
     button.classList.add("oldVersion");
   }
 


### PR DESCRIPTION
NOTE: This is not Chapel release 1.18.0. This change cherry-picks some changes made on master, after the release/1.18 branch was created, but before the official release of Chapel 1.18.0 (currently scheduled for Sep 20 2018). 

This change only affects doc/util/versionButton.php. That file only affects the "version button" in the top-left corner of the Chapel online docs, https://chapel-lang.org/docs/. 

The only reason to cherry-pick this to release/1.18 branch is to avoid possible confusion when generating online docs. These commits will not be included in the official release tag 1.18.0, unless other unrelated changes need to be made on the release/1.18 branch between now and Sep 20.  