### PR TITLE
Optimize blocking puts/gets and fetching network AMOs

### DIFF
--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -7706,7 +7706,6 @@ void post_fma_and_wait(c_nodeid_t locale, gni_post_descriptor_t* post_desc,
   int cdi;
   atomic_bool post_done;
   uint64_t iters = 0;
-  uint64_t yield_freq = 0x3F;
 
   atomic_init_bool(&post_done, false);
   post_desc->post_id = (uint64_t) (intptr_t) &post_done;
@@ -7716,24 +7715,13 @@ void post_fma_and_wait(c_nodeid_t locale, gni_post_descriptor_t* post_desc,
   //
   // Wait for the transaction to complete.  Yield initially; the
   // minimum round-trip time on the network isn't small and maybe
-  // we can find something else to do in the meantime. However,
-  // yielding isn't free either, so after the initial yield, only
-  // yield every so often (but yield more often the longer we've
-  // waited.)
-  //
-  // The idea here is that we want to yield initially in case some
-  // other task is waiting, but if the original task has been
-  // rescheduled then it's likely no other task is running and the
-  // current transaction is likely to be done (or be done soon)
-  // since we use FMA primarily for small transactions.  We
-  // yield more frequently over time since there's no real latency
-  // benefit for slower operations (on the off chance it's a big
-  // transaction.)
+  // we can find something else to do in the meantime.  FMA is only
+  // used for small tranasctions which will be relatively fast, so
+  // after the initial yield, only yield every 64 attempts.
   //
   do {
-    if (do_yield && (iters & yield_freq) == 0) {
+    if (do_yield && (iters & 0x3F) == 0) {
       local_yield();
-      yield_freq >>= 1;
     }
     consume_all_outstanding_cq_events(cdi);
     iters++;

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -1530,7 +1530,6 @@ static chpl_bool reacquire_comm_dom(int);
 static int       post_fma(c_nodeid_t, gni_post_descriptor_t*);
 static void      post_fma_and_wait(c_nodeid_t, gni_post_descriptor_t*,
                                    chpl_bool);
-static void      post_fma_and_wait_amo(c_nodeid_t, gni_post_descriptor_t*);
 #if HAVE_GNI_FMA_CHAIN_TRANSACTIONS
 static int       post_fma_ct(c_nodeid_t*, gni_post_descriptor_t*);
 static void      post_fma_ct_and_wait(c_nodeid_t*, gni_post_descriptor_t*);
@@ -6868,7 +6867,7 @@ void do_nic_amo_nf(void* opnd1, c_nodeid_t locale,
   //
   // Initiate the transaction and wait for it to complete.
   //
-  post_fma_and_wait_amo(locale, &post_desc);
+  post_fma_and_wait(locale, &post_desc, true);
 }
 
 
@@ -7729,36 +7728,6 @@ void post_fma_and_wait(c_nodeid_t locale, gni_post_descriptor_t* post_desc,
 
   CQ_CNT_DEC(&comm_doms[cdi]);
 }
-
-static
-void post_fma_and_wait_amo(c_nodeid_t locale, gni_post_descriptor_t* post_desc)
-{
-  int cdi;
-  atomic_bool post_done;
-  uint64_t iters = 0;
-
-  atomic_init_bool(&post_done, false);
-  post_desc->post_id = (uint64_t) (intptr_t) &post_done;
-
-  cdi = post_fma(locale, post_desc);
-
-  //
-  // Wait for the transaction to complete.  Yield initially; the
-  // minimum round-trip time on the network isn't small and maybe
-  // we can find something else to do in the meantime.  AMOs are
-  // fast so after initial yield, only yield every 64 attempts.
-  //
-  do {
-    if ((iters & 0x3F) == 0) {
-      local_yield();
-    }
-    consume_all_outstanding_cq_events(cdi);
-    iters++;
-  } while (!atomic_load_explicit_bool(&post_done, memory_order_acquire));
-
-  CQ_CNT_DEC(&comm_doms[cdi]);
-}
-
 
 #if HAVE_GNI_FMA_CHAIN_TRANSACTIONS
 


### PR DESCRIPTION
This is identical to #9876, but for puts/gets and fetching AMOs insead of
non-fetching AMOs. Here we optimize post_fma_and_wait to only yield every 64
iterations while we're waiting for the network ACK/payload. It's important to
yield initially in the case of task oversubscription so we can get comm/compute
overlap. If we're not oversubscribed, we benefit from yielding less frequently
because yielding isn't free and the network ACK will often complete while we're
in the middle of a yield which would increase the total latency. 

This has a pretty significant performance impact on fetching atomics and small
puts/gets. This improves the many-to-one fetchingAMO microbenchmark by ~15%,
improves the bale indexgather code, and improves RA-rmo by 20-35% depending on
the node count. At 256 nodes this takes us from  1.2 GUPS to 1.6 GUPS:

![ra-rmo-perf](https://user-images.githubusercontent.com/1588337/45708473-690eb600-bb36-11e8-839f-d51d2883ebdc.png)

This brings ra-rmo ahead of the reference (with and without bucketing) at higher node counts:

![ra-rmo-perf-ref](https://user-images.githubusercontent.com/1588337/45708467-6744f280-bb36-11e8-8437-ee3614ae81af.png)

Closes https://github.com/chapel-lang/chapel/issues/9915