### PR TITLE
Knucleotide for Chapel 1.18

### DIFF
--- a/test/studies/shootout/submitted/knucleotide.chpl
+++ b/test/studies/shootout/submitted/knucleotide.chpl
@@ -53,9 +53,10 @@ proc main(args: [] string) {
 proc writeFreqs(data, param nclSize) {
   const freqs = calculate(data, nclSize);
 
-  var arr = for (k,v) in zip(freqs.domain, freqs) do (v,k);
+  // create an array of (frequency, sequence) tuples
+  var arr = for (s,f) in zip(freqs.domain, freqs) do (f,s);
 
-  // sort by frequencies
+  // print the array, sorted by decreasing frequency
   for (f, s) in arr.sorted(reverseComparator) do
    writef("%s %.3dr\n", decode(s, nclSize), 
            (100.0 * f) / (data.size - nclSize));

--- a/test/studies/shootout/submitted/knucleotide.chpl
+++ b/test/studies/shootout/submitted/knucleotide.chpl
@@ -53,12 +53,10 @@ proc main(args: [] string) {
 proc writeFreqs(data, param nclSize) {
   const freqs = calculate(data, nclSize);
 
-  // sort by frequencies
   var arr = for (k,v) in zip(freqs.domain, freqs) do (v,k);
 
-  quickSort(arr, comparator=reverseComparator);
-
-  for (f, s) in arr do
+  // sort by frequencies
+  for (f, s) in arr.sorted(reverseComparator) do
    writef("%s %.3dr\n", decode(s, nclSize), 
            (100.0 * f) / (data.size - nclSize));
   writeln();
@@ -74,13 +72,13 @@ proc writeCount(data, param str) {
 
 
 proc calculate(data, param nclSize) {
-  var freqDom: domain(int, parSafe=false),
+  var freqDom: domain(int),
       freqs: [freqDom] int;
 
   var lock$: sync bool = true;
   const numTasks = here.maxTaskPar;
   coforall tid in 1..numTasks {
-    var myDom: domain(int, parSafe=false),
+    var myDom: domain(int),
         myArr: [myDom] int;
 
     for i in tid..(data.size-nclSize) by numTasks do

--- a/test/studies/shootout/submitted/knucleotide.notest
+++ b/test/studies/shootout/submitted/knucleotide.notest
@@ -1,3 +1,0 @@
-No longer compiles due to shape preservation.
-'arr' in writeFreqs() is now an associative array,
-not suitable for sorting.


### PR DESCRIPTION
This updates our submitted version of knucleotide to work with 1.18.  The
main difference is that where before a loop expression over an associative
domain was resulting in a 1D array result, now shape preservation is
causing it to be associative, requiring sorting to behave differently
(as Vass has already implemented on master).  While here, I also
incorporated the removal of the parSafe argument which we retired
from master some time ago but never submitted to the site (figuring
it was too minor to bother with previously).  I also updated some comments.