### PR TITLE
Revert "Revert "Make Chapel 1.18 the "current" release for online docs""

### DIFF
--- a/doc/util/versionButton.php
+++ b/doc/util/versionButton.php
@@ -87,8 +87,8 @@ if (pagePath == "") {
   pagePath = "index.html";
 }
 function dropSetup() {
-  var currentRelease = "1.17"; // what does the public have?
-  var stagedRelease = "1.18";  // is there a release staged but not yet public?
+  var currentRelease = "1.18"; // what does the public have?
+  var stagedRelease = "1.19";  // is there a release staged but not yet public?
   var nextRelease = "1.19";    // what's the next release? (on docs/master)
   var button = document.getElementById("versionButton");
   // Uses unicode down-pointing triangle


### PR DESCRIPTION
Putting Tony's earlier commit from this morning back in place, as I've pushed the 1.18 web updates now.