### PR TITLE
Repurpose language spec archives to language archives in general

### DIFF
--- a/doc/rst/index.rst
+++ b/doc/rst/index.rst
@@ -33,7 +33,7 @@ Chapel Documentation
    :maxdepth: 1
 
    Chapel Evolution <language/evolution>
-   Archived Language Specifications <language/archivedSpecs>
+   Documentation Archives <language/archivedSpecs>
 
 Index
 -----

--- a/doc/rst/language/archivedSpecs.rst
+++ b/doc/rst/language/archivedSpecs.rst
@@ -1,18 +1,33 @@
 .. _chapel-archived-specs:
 
-Archived Language Specifications
-================================
+Documentation Archives
+======================
 
-**Latest Spec Version**
+Online Documentation Archives
+-----------------------------
+
+* `Chapel 1.17 <https://chapel-lang.org/docs/1.17/index.html>`_
+* `Chapel 1.16 <https://chapel-lang.org/docs/1.16/index.html>`_
+* `Chapel 1.15 <https://chapel-lang.org/docs/1.15/index.html>`_
+* `Chapel 1.14 <https://chapel-lang.org/docs/1.14/index.html>`_
+* `Chapel 1.13 <https://chapel-lang.org/docs/1.13/index.html>`_
+* `Chapel 1.12 <https://chapel-lang.org/docs/1.12/index.html>`_
+* `Chapel 1.11 <https://chapel-lang.org/docs/1.11/index.html>`_
+
+
+Language Specification Archives
+-------------------------------
+
+**Latest Version**
 
 * `Language Specification`_
 
-**Spec Version >= 0.981**
+**Versions corresponding to Chapel 1.13.0 and later**
 
-* Visit ``chapel-lang.org/docs/<X.YY>/language/spec.html``, where ``X.YY`` is
-  their associated Chapel release version
+* Visit ``https://chapel-lang.org/docs/<X.YY>/language/spec.html``,
+  where ``X.YY`` is the associated Chapel release version
 
-**Spec Version < 0.981**
+**Older Versions**
 
 Spec *<version>* (Chapel *<release in which specification was made available>*)
 


### PR DESCRIPTION
* Add a new section with links to old versions of the online
  documentation

* Tweak wordings of language spec archives

Resolves #9979
