### PR TITLE
Restore comm=none performance lost in PR 11197.

### DIFF
--- a/runtime/include/chpl-comm-strd-xfer.h
+++ b/runtime/include/chpl-comm-strd-xfer.h
@@ -102,15 +102,12 @@ void strd_nb_helper(chpl_comm_nb_handle_t (*xferFn)(void*, int32_t, void*,
 }
 
 
-void chpl_comm_put_strd_common(void* dstaddr_arg, size_t* dststrides,
-                               int32_t dstlocale,
-                               void* srcaddr_arg, size_t* srcstrides,
-                               size_t* count, int32_t stridelevels,
-                               size_t elemSize,
-                               size_t maxOutstandingXfers,
-                               void (yieldFn)(void),
-                               int32_t typeIndex, int32_t commID,
-                               int ln, int32_t fn) {
+static inline
+void put_strd_common(void* dstaddr_arg, size_t* dststrides, int32_t dstlocale,
+                     void* srcaddr_arg, size_t* srcstrides,
+                     size_t* count, int32_t stridelevels, size_t elemSize,
+                     size_t maxOutstandingXfers, void (yieldFn)(void),
+                     int32_t typeIndex, int32_t commID, int ln, int32_t fn) {
   const size_t strlvls=(size_t)stridelevels;
   size_t i,j,k,t,total,off,x,carry;
 
@@ -252,15 +249,12 @@ void chpl_comm_put_strd_common(void* dstaddr_arg, size_t* dststrides,
 }
 
 
-void chpl_comm_get_strd_common(void* dstaddr_arg, size_t* dststrides,
-                               int32_t srclocale,
-                               void* srcaddr_arg, size_t* srcstrides,
-                               size_t* count, int32_t stridelevels,
-                               size_t elemSize,
-                               size_t maxOutstandingXfers,
-                               void (yieldFn)(void),
-                               int32_t typeIndex, int32_t commID,
-                               int ln, int32_t fn) {
+static inline
+void get_strd_common(void* dstaddr_arg, size_t* dststrides, int32_t srclocale,
+                     void* srcaddr_arg, size_t* srcstrides,
+                     size_t* count, int32_t stridelevels, size_t elemSize,
+                     size_t maxOutstandingXfers, void (yieldFn)(void),
+                     int32_t typeIndex, int32_t commID, int ln, int32_t fn) {
   const size_t strlvls=(size_t)stridelevels;
   size_t i,j,k,t,total,off,x,carry;
 
@@ -402,3 +396,6 @@ void chpl_comm_get_strd_common(void* dstaddr_arg, size_t* dststrides,
     (void) chpl_comm_wait_nb_some(handles, currHandles);
   }
 }
+
+
+#include "chpl-comm-warning-macros.h"

--- a/runtime/include/chpl-comm.h
+++ b/runtime/include/chpl-comm.h
@@ -434,30 +434,6 @@ void  chpl_comm_get_strd(void* dstaddr, size_t* dststrides, c_nodeid_t srcnode,
                      int32_t commID, int ln, int32_t fn);
 
 //
-// Common versions of the above, for comm layer implementations that
-// do not have native strided transfers.
-//
-void chpl_comm_put_strd_common(void* dstaddr, size_t* dststrides,
-                               c_nodeid_t dstnode,
-                               void* srcaddr, size_t* srcstrides,
-                               size_t* count,
-                               int32_t stridelevels, size_t elemSize,
-                               size_t maxOutstandingXfers,
-                               void (yieldFn)(void),
-                               int32_t typeIndex, int32_t commID,
-                               int ln, int32_t fn);
-
-void chpl_comm_get_strd_common(void* dstaddr, size_t* dststrides,
-                               c_nodeid_t srcnode,
-                               void* srcaddr, size_t* srcstrides,
-                               size_t* count,
-                               int32_t stridelevels, size_t elemSize,
-                               size_t maxOutstandingXfers,
-                               void (yieldFn)(void),
-                               int32_t typeIndex, int32_t commID,
-                               int ln, int32_t fn);
-
-//
 // Get a local copy of a wide string.
 //
 // The local copy is also a wide string pointer, but its addr field points to 

--- a/runtime/include/chpl-mem.h
+++ b/runtime/include/chpl-mem.h
@@ -136,12 +136,18 @@ void chpl_mem_free(void* memAlloc, int32_t lineno, int32_t filename) {
   chpl_free(memAlloc);
 }
 
-// Provide a handle to instrument Chapel calls to memcpy.
+// Provide handles to instrument Chapel calls to memcpy and memmove
 static inline
 void* chpl_memcpy(void* dest, const void* src, size_t num)
 {
   assert(dest != src || num == 0);
   return memcpy(dest, src, num);
+}
+
+static inline
+void* chpl_memmove(void* dest, const void* src, size_t num)
+{
+  return memmove(dest, src, num);
 }
 
 // Query the allocator to ask for a good size to allocate that is at least

--- a/runtime/src/Makefile.share
+++ b/runtime/src/Makefile.share
@@ -31,7 +31,6 @@ COMMON_NOGEN_SRCS = \
 	chpl-bitops.c \
 	chpl-cache.c \
 	chpl-comm.c \
-	chpl-comm-strd-xfer.c \
         chpl-comm-callbacks.c \
 	chpl-init.c \
 	chplexit.c \

--- a/runtime/src/comm/none/comm-none.c
+++ b/runtime/src/comm/none/comm-none.c
@@ -20,6 +20,7 @@
 #include "chplrt.h"
 
 #include "chpl-comm.h"
+#include "chpl-comm-strd-xfer.h"
 #include "chplexit.h"
 #include "error.h"
 #include "chpl-mem.h"
@@ -60,7 +61,7 @@ chpl_comm_nb_handle_t chpl_comm_put_nb(void *addr, c_nodeid_t node, void* raddr,
                                        int32_t commID, int ln, int32_t fn)
 {
   assert(node == 0);
-  chpl_memcpy(raddr, addr, size);
+  chpl_memmove(raddr, addr, size);
   return NULL;
 }
 
@@ -69,7 +70,7 @@ chpl_comm_nb_handle_t chpl_comm_get_nb(void* addr, c_nodeid_t node, void* raddr,
                                        int32_t commID, int ln, int32_t fn)
 {
   assert(node == 0);
-  chpl_memcpy(addr, raddr, size);
+  chpl_memmove(addr, raddr, size);
   return NULL;
 }
 
@@ -163,12 +164,11 @@ void  chpl_comm_put_strd(void* dstaddr_arg, size_t* dststrides, c_nodeid_t dstno
                          int32_t commID, int ln, int32_t fn)
 {
   assert(dstnode==0);
-  chpl_comm_put_strd_common(dstaddr_arg, dststrides,
-                            dstnode,
-                            srcaddr_arg, srcstrides,
-                            count, stridelevels, elemSize,
-                            1, NULL, // "nb" xfers block, so no need for yield
-                            typeIndex, commID, ln, fn);
+  put_strd_common(dstaddr_arg, dststrides, dstnode,
+                  srcaddr_arg, srcstrides,
+                  count, stridelevels, elemSize,
+                  1, NULL, // "nb" xfers block, so no need for yield
+                  typeIndex, commID, ln, fn);
 }
 
 void  chpl_comm_get_strd(void* dstaddr_arg, size_t* dststrides, c_nodeid_t srcnode,
@@ -177,12 +177,11 @@ void  chpl_comm_get_strd(void* dstaddr_arg, size_t* dststrides, c_nodeid_t srcno
                          int32_t commID, int ln, int32_t fn)
 {
   assert(srcnode==0);
-  chpl_comm_get_strd_common(dstaddr_arg, dststrides,
-                            srcnode,
-                            srcaddr_arg, srcstrides,
-                            count, stridelevels, elemSize,
-                            1, NULL, // "nb" xfers block, so no need for yield
-                            typeIndex, commID, ln, fn);
+  get_strd_common(dstaddr_arg, dststrides, srcnode,
+                  srcaddr_arg, srcstrides,
+                  count, stridelevels, elemSize,
+                  1, NULL, // "nb" xfers block, so no need for yield
+                  typeIndex, commID, ln, fn);
 }
 
 typedef struct {

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -56,6 +56,7 @@
 #include "chpl-comm-diags.h"
 #include "chpl-comm-callbacks.h"
 #include "chpl-comm-callbacks-internal.h"
+#include "chpl-comm-strd-xfer.h"
 #include "chpl-env.h"
 #include "chplexit.h"
 #include "chpl-mem.h"
@@ -5587,13 +5588,12 @@ void chpl_comm_put_strd(void* dstaddr_arg, size_t* dststrides,
                         int32_t typeIndex, int32_t commID, int ln, int32_t fn)
 {
   PERFSTATS_INC(put_strd_cnt);
-
-  chpl_comm_put_strd_common(dstaddr_arg, dststrides,
-                            dstlocale,
-                            srcaddr_arg, srcstrides,
-                            count, stridelevels, elemSize,
-                            strd_maxHandles, local_yield,
-                            typeIndex, commID, ln, fn);
+  put_strd_common(dstaddr_arg, dststrides,
+                  dstlocale,
+                  srcaddr_arg, srcstrides,
+                  count, stridelevels, elemSize,
+                  strd_maxHandles, local_yield,
+                  typeIndex, commID, ln, fn);
 }
 
 
@@ -5604,13 +5604,12 @@ void chpl_comm_get_strd(void* dstaddr_arg, size_t* dststrides,
                         int32_t typeIndex, int32_t commID, int ln, int32_t fn)
 {
   PERFSTATS_INC(get_strd_cnt);
-
-  chpl_comm_get_strd_common(dstaddr_arg, dststrides,
-                            srclocale,
-                            srcaddr_arg, srcstrides,
-                            count, stridelevels, elemSize,
-                            strd_maxHandles, local_yield,
-                            typeIndex, commID, ln, fn);
+  get_strd_common(dstaddr_arg, dststrides,
+                  srclocale,
+                  srcaddr_arg, srcstrides,
+                  count, stridelevels, elemSize,
+                  strd_maxHandles, local_yield,
+                  typeIndex, commID, ln, fn);
 }
 
 


### PR DESCRIPTION
PR 11197 created common code for strided bulk transfer and changed
comm=none and comm=ugni to call that.  Unfortunately that caused a
performance regression with comm=none for NPB sizes A and B.  In the old
code the memmove() that actually moved the bytes was visible to the
compiler when it was compiling its caller and thus effectively, could be
inlined.  But in the new code that was not possible.  Here, move the
common code into static inline functions whose source is again available
to the compiler at the call sites, restoring the old performance.

While here, change chpl_memcpy() to chpl_memmove() in the "nonblocking"
transfer functions for comm=none.  They always should have been such,
since we don't know what the overlap state is for the source and target
arguments to the NB routines.  In addition to causing the performance
regression PR 11197 effectively made the opposite (unsafe) change, but
apparently without breaking any tests.