### PR TITLE
Replace "arithmetic" with "rectangular" in examples

### DIFF
--- a/test/release/examples/benchmarks/ssca2/SSCA2_Modules/analyze_torus_graphs_array_rep.chpl
+++ b/test/release/examples/benchmarks/ssca2/SSCA2_Modules/analyze_torus_graphs_array_rep.chpl
@@ -1,7 +1,7 @@
 module analyze_torus_graphs {
 
   // +========================================================================+
-  // |  Define dense arithmetic array-based representations for               |
+  // |  Define dense rectangular array-based representations for              |
   // |  k-dimensional torus graphs. For each k, provide execution template    |
   // |  for executing and verifying SSCA2 kernels 2 through 4.                |
   // +========================================================================+

--- a/test/release/examples/benchmarks/ssca2/SSCA2_Modules/analyze_torus_graphs_stencil_rep_v1.chpl
+++ b/test/release/examples/benchmarks/ssca2/SSCA2_Modules/analyze_torus_graphs_stencil_rep_v1.chpl
@@ -6,7 +6,7 @@ module analyze_torus_graphs {
   // |  for executing and verifying SSCA2 kernels 2 through 4.                |
   // +========================================================================+
   // |                          VERSION 1                                     |
-  // |  Explicit neighbor lists as sparse arithmetic arrays                   |
+  // |  Explicit neighbor lists as sparse rectangular arrays                  |
   // |  defined over the torus stencil as a sparse domain.  Storage overhead  |
   // |  is as many tuples as nonzeros.                                        |
   // +========================================================================+

--- a/test/release/examples/benchmarks/ssca2/SSCA2_Modules/array_rep_torus_graph_generator.chpl
+++ b/test/release/examples/benchmarks/ssca2/SSCA2_Modules/array_rep_torus_graph_generator.chpl
@@ -2,7 +2,7 @@ module array_rep_torus_graph_generator
 
 //  +==========================================================================+
 //  |  Generate graphs corresponding to 1, 2, 3 and 4D regular tori,           |
-//  |  using dense arithmetic arrays to represent the neighbor lists and       |
+//  |  using dense rectangular arrays to represent the neighbor lists and      |
 //  |  edge weights.                                                           |
 //  +==========================================================================+
 

--- a/test/release/examples/primers/arrays.chpl
+++ b/test/release/examples/primers/arrays.chpl
@@ -135,7 +135,7 @@ writeln("After calling printArr, B is:\n", B, "\n");
 // of storing distributed arrays across multiple similar array
 // variables.
 //
-// The following domain declaration defines a 2D arithmetic domain
+// The following domain declaration defines a 2D rectangular domain
 // called ``ProbSpace`` which is the same size and shape as ``B`` was above.
 //
 


### PR DESCRIPTION
We retired, a while back, the term "arithmetic" (about domains, arrays).
Replace it with the modern hotness "rectangular" in our example codes.
