### PR TITLE
Adjust llvm-global-to-wide to pass in Debug mode

### DIFF
--- a/compiler/include/llvmGlobalToWide.h
+++ b/compiler/include/llvmGlobalToWide.h
@@ -155,11 +155,13 @@ struct GlobalToWideInfo {
   // so that they are not removed by the inliner.
   // This function should be removed from the module
   // once GlobalToWide completes.
+  bool hasPreservingFn;
   runtime_fn_t preservingFn;
 
   GlobalToWideInfo()
     : globalSpace(0), wideSpace(0), globalPtrBits(0),
-      localeIdType(NULL), nodeIdType(NULL), gTypes(), specialFunctions() { }
+      localeIdType(NULL), nodeIdType(NULL), gTypes(), specialFunctions(),
+      hasPreservingFn(false) { }
 };
 
 llvm::ModulePass *createGlobalToWide(GlobalToWideInfo* info,

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2450,6 +2450,7 @@ void setupForGlobalToWide(void) {
 
   llvm::verifyFunction(*fn, &errs());
 
+  info->hasPreservingFn = true;
   info->preservingFn = fn;
 }
 static

--- a/compiler/llvm/llvm-global-to-wide/RUN_CONFIG
+++ b/compiler/llvm/llvm-global-to-wide/RUN_CONFIG
@@ -12,4 +12,4 @@ ln -s ../../include/llvmVer.h llvmVer.h
 mkdir -p build
 cd build
 export CMAKE_PREFIX_PATH=$CHPL_HOME/third-party/llvm/install/linux64-gnu/
-cmake .. -DLLVM_ROOT=$CHPL_HOME/third-party/llvm/install/linux64-gnu/ -DLLVM_SRC=$CHPL_HOME/third-party/llvm/llvm
+cmake .. -DLLVM_ROOT=$CHPL_HOME/third-party/llvm/install/linux64-gnu/ -DLLVM_SRC=$CHPL_HOME/third-party/llvm/llvm -DCMAKE_BUILD_TYPE=Debug


### PR DESCRIPTION
TrackingVH shouldn't be read unless it's set to non-NULL.
To fix that,
 * move generating some fns info was NULL (for these tests)
 * add a bool to indicate if a preservingFn was set

- [x] full local --llvm testing

Reviewed by @dmk42 - thanks!