### PR TITLE
Errors for super.postinit in conditionals and loops

### DIFF
--- a/test/classes/initializers/postInit/invalidSuperPostinit.chpl
+++ b/test/classes/initializers/postInit/invalidSuperPostinit.chpl
@@ -1,0 +1,70 @@
+
+class A {
+  var x : int;
+
+  proc postinit() {
+    writeln("A.postinit");
+  }
+}
+
+class B : A {
+  proc postinit() {
+    if false then super.postinit();
+  }
+}
+
+class C : A {
+  proc postinit() {
+    if false then super.postinit();
+    else writeln();
+  }
+}
+
+class D : A {
+  proc postinit() {
+    super.postinit();
+    super.postinit();
+  }
+}
+
+class E : A {
+  proc postinit() {
+    for i in 1..10 do
+      super.postinit();
+
+    var i = 0;
+    do {
+      super.postinit();
+      i += 1;
+    } while i < 10;
+
+    i = 0;
+    while i < 10 {
+      super.postinit();
+      i += 1;
+    }
+
+    forall i in 1..10 do
+      super.postinit();
+
+    for param i in 1..10 do
+      super.postinit();
+  }
+}
+
+class F : A {
+  proc postinit() {
+    coforall i in 1..10 do
+      super.postinit();
+    coforall i in 1..10 do on here do
+      super.postinit();
+
+    begin super.postinit();
+    begin on here do super.postinit();
+
+    cobegin {
+      super.postinit();
+      writeln();
+    }
+  }
+}

--- a/test/classes/initializers/postInit/invalidSuperPostinit.good
+++ b/test/classes/initializers/postInit/invalidSuperPostinit.good
@@ -1,0 +1,18 @@
+invalidSuperPostinit.chpl:11: In function 'postinit':
+invalidSuperPostinit.chpl:12: error: "super.postinit()" may not be called in a if-statement without an else-branch
+invalidSuperPostinit.chpl:17: In function 'postinit':
+invalidSuperPostinit.chpl:18: error: "super.postinit()" must be called in each branch of a conditional or not at all
+invalidSuperPostinit.chpl:24: In function 'postinit':
+invalidSuperPostinit.chpl:26: error: Multiple calls to "super.postinit()"
+invalidSuperPostinit.chpl:31: In function 'postinit':
+invalidSuperPostinit.chpl:32: error: "super.postinit()" is not allowed in loop statements
+invalidSuperPostinit.chpl:36: error: "super.postinit()" is not allowed in loop statements
+invalidSuperPostinit.chpl:42: error: "super.postinit()" is not allowed in loop statements
+invalidSuperPostinit.chpl:48: error: "super.postinit()" is not allowed in loop statements
+invalidSuperPostinit.chpl:50: error: "super.postinit()" is not allowed in loop statements
+invalidSuperPostinit.chpl:56: In function 'postinit':
+invalidSuperPostinit.chpl:57: error: "super.postinit()" is not allowed in a coforall satement
+invalidSuperPostinit.chpl:59: error: "super.postinit()" is not allowed in a coforall satement
+invalidSuperPostinit.chpl:62: error: "super.postinit()" is not allowed in a begin satement
+invalidSuperPostinit.chpl:63: error: "super.postinit()" is not allowed in a begin satement
+invalidSuperPostinit.chpl:66: error: "super.postinit()" is not allowed in a cobegin satement


### PR DESCRIPTION
This PR adds error messages for invalid uses of super.postinit:
- invoked in one branch of conditional but not another
- invoked in a loop
- invoked multiple times

An AstVisitor is used to walk the body of the postinit method, looking for any calls to super.postinit and emits errors when necessary. A new test is added to ensure these errors are emitted.

Resolves #11148 

Testing:
- [x] local + futures
- [x] gasnet + futures