### PR TITLE
Fix some SparseBlockDist leaks

### DIFF
--- a/modules/dists/SparseBlockDist.chpl
+++ b/modules/dists/SparseBlockDist.chpl
@@ -810,16 +810,8 @@ proc SparseBlockDom.dsiHasSingleLocalSubdomain() param return true;
 proc SparseBlockArr.dsiHasSingleLocalSubdomain() param return true;
 
 proc SparseBlockDom.dsiLocalSubdomain() {
-  // TODO -- could be replaced by a privatized myLocDom in BlockDom
-  // as it is with BlockArr
-  var myLocDom:unmanaged LocSparseBlockDom(rank, idxType, stridable, sparseLayoutType) = nil;
-  for (loc, locDom) in zip(dist.targetLocales, locDoms) {
-    if loc == here {
-      myLocDom = locDom;
-      break;
-    }
-  }
-  return myLocDom.mySparseBlock;
+  const (found, targetIdx) = dist.targetLocales.find(here);
+  return locDoms[targetIdx].mySparseBlock;
 }
 
 proc SparseBlockArr.dsiLocalSubdomain() {

--- a/modules/dists/SparseBlockDist.chpl
+++ b/modules/dists/SparseBlockDist.chpl
@@ -298,8 +298,9 @@ class LocSparseBlockDom {
   param stridable: bool;
   type sparseLayoutType;
   var parentDom: domain(rank, idxType, stridable);
-  var sparseDist = new unmanaged sparseLayoutType; //unresolved call workaround
-  var mySparseBlock: sparse subdomain(parentDom) dmapped new dmap(sparseDist);
+  var sparseDist = if sparseLayoutType == DefaultDist then defaultDist
+                   else new dmap(new unmanaged sparseLayoutType); //unresolved call workaround
+  var mySparseBlock: sparse subdomain(parentDom) dmapped sparseDist;
 
   proc dsiAdd(ind: rank*idxType) {
     return mySparseBlock.add(ind);

--- a/modules/dists/SparseBlockDist.chpl
+++ b/modules/dists/SparseBlockDist.chpl
@@ -298,7 +298,7 @@ class LocSparseBlockDom {
   param stridable: bool;
   type sparseLayoutType;
   var parentDom: domain(rank, idxType, stridable);
-  var sparseDist = if sparseLayoutType == DefaultDist then defaultDist
+  var sparseDist = if _to_borrowed(sparseLayoutType) == DefaultDist then defaultDist
                    else new dmap(new unmanaged sparseLayoutType); //unresolved call workaround
   var mySparseBlock: sparse subdomain(parentDom) dmapped sparseDist;
 

--- a/test/users/engin/partial_reduction_support/modules/templates.chpl
+++ b/test/users/engin/partial_reduction_support/modules/templates.chpl
@@ -62,6 +62,7 @@ proc bulkPartialReduce(arr, param onlyDim) {
           var __target = ResultArr._value.locArr[l2].clone();
           partialReduceToTarget(arr.locArr[l], onlyDim, __target);
           partialResult += __target.myElems;
+          delete __target;
         }
       }
     }


### PR DESCRIPTION
This PR fixes some memory leaks involving SparseBlockDist.

1) Rewrite SparseBlockDom. dsiLocalSubdomain to avoid using a break-ing zippered loop, which leaked iterator classes.

2) Re-use the global ``defaultDist`` variable instead of creating a new DefaultDist domain map.

3) Manually delete an unmanaged class in a partial reduction test.

These fixes bring the leaks from ~96K down to ~67K.

Testing:
- [x] local + futures
- [x] gasnet + futures
- [x] memleaks