### PR TITLE
Destroy the result of a reduction's generate()

### DIFF
--- a/compiler/resolution/implementForallIntents.cpp
+++ b/compiler/resolution/implementForallIntents.cpp
@@ -2045,6 +2045,8 @@ static void insertFinalGenerate(Expr* ref, Symbol* fiVarSym, Symbol* globalOp) {
   Expr* next = ref->next; // nicer ordering of the following insertions
   INT_ASSERT(next);
   VarSymbol* genTemp = newTemp("chpl_gentemp");
+  // TODO: Should we try to free chpl_gentemp right after the assignment?
+  genTemp->addFlag(FLAG_INSERT_AUTO_DESTROY);
   next->insertBefore(new DefExpr(genTemp));
   next->insertBefore("'move'(%S, generate(%S,%S))",
                      genTemp, gMethodToken, globalOp);


### PR DESCRIPTION
This PR simply adds FLAG_INSERT_AUTO_DESTROY to the result of a reduction's generate call, fixing some leaks in the process.

Testing:
- [x] local + futures
- [x] memleaks
- [x] valgrind
- [x] gasnet