### PR TITLE
Range API test and simple fixes

### DIFF
--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -839,8 +839,14 @@ proc _cast(type t, r: range(?)) where isRangeType(t) {
       __primitive("chpl_error", c"indexOrder -- Undefined on a range with ambiguous alignment.");
 
     if ! member(ind) then return (-1):intIdxType;
-    if ! stridable then return chpl__idxToInt(ind) - _low;
-    else return ((chpl__idxToInt(ind):strType - chpl__idxToInt(this.first):strType) / _stride):intIdxType;
+    if ! stridable {
+      if this.hasLowBound() then
+        return chpl__idxToInt(ind) - _low;
+    } else {
+      if this.hasFirst() then
+        return ((chpl__idxToInt(ind):strType - chpl__idxToInt(this.first):strType) / _stride):intIdxType;
+    }
+    return (-1):intIdxType;
   }
 
   /* Returns the zero-based ``ord``-th element of this range's represented
@@ -859,6 +865,9 @@ proc _cast(type t, r: range(?)) where isRangeType(t) {
    */
   proc range.orderToIndex(ord: integral): idxType
   {
+    if !hasFirst() then
+      halt("invoking orderToIndex on a range that has no first index");
+
     if isAmbiguous() then
       halt("invoking orderToIndex on a range that is ambiguously aligned");
 

--- a/test/types/range/userAPI/rangeAPItest.chpl
+++ b/test/types/range/userAPI/rangeAPItest.chpl
@@ -1,0 +1,87 @@
+config param testError = 0, testDisplayRepresentation = false;
+
+proc testRangeAPI(lbl, r: range(?), idx, subr) {
+  writeln(lbl);
+  writeln("------------");
+  writeln(r);
+  writeln("idxType          = ", r.idxType:string);
+  writeln("stridable        = ", r.stridable);
+  writeln("boundedType      = ", r.boundedType);
+  writeln("isRangeType()    = ", isRangeType(r.type));
+  writeln("isBoundedRange() = ", isBoundedRange(r));
+  writeln("hasLowBound()    = ", r.hasLowBound());
+  writeln("hasHighBound()   = ", r.hasHighBound());
+  writeln("stride           = ", r.stride);
+  writeln("alignment        = ", r.alignment);
+  writeln("aligned          = ", r.aligned);
+  writeln("first            = ", r.first);
+  writeln("last             = ", r.last);
+  writeln("low              = ", r.low);
+  writeln("high             = ", r.high);
+  writeln("alignedLow       = ", r.alignedLow);
+  writeln("alignedHigh      = ", r.alignedHigh);
+  writeln("isEmpty()        = ", r.isEmpty());
+  if (isBoundedRange(r)) {
+    writeln("size             = ", r.size);
+    writeln("length           = ", r.length);
+  }
+  writeln("hasFirst()       = ", r.hasFirst());
+  writeln("hasLast()        = ", r.hasLast());
+  writeln("isNat.Algned()   = ", r.isNaturallyAligned());
+  writeln("isAmbiguous      = ", r.isAmbiguous());
+  writeln("member(", idx, ") = ", r.member(idx));
+  writeln("member(", subr, ") = ", r.member(subr));
+  writeln("ident(self)      = ", ident(r, r));
+  writeln("ident(other)     = ", ident(r, subr));
+  writeln("boundsCheck(", idx, ") = ", r.boundsCheck(idx));
+  writeln("boundsCheck(", subr, ") = ", r.boundsCheck(subr));
+  writeln("indexOrder(", idx, ") = ", r.indexOrder(idx));
+  if (r.hasFirst()) then
+    writeln("orderToIndex(3)  = ", r.orderToIndex(3));
+  if (isBoundedRange(r)) {
+    writeln("expand(2)        = ", r.expand(2));
+    writeln("offset(1)        = ", r.offset(1));
+  }
+  writeln("translate(2)     = ", r.translate(2));
+  writeln("translate(-2)    = ", r.translate(-2));
+  if (isBoundedRange(r)) {
+    writeln("exterior(2)      = ", r.exterior(2));
+    writeln("exterior(-2)     = ", r.exterior(-2));
+    writeln("interior(2)      = ", r.interior(2));
+    writeln("interior(-2)     = ", r.interior(-2));
+  }
+          
+  writeln("serial iteration = ");
+  if (isBoundedRange(r)) {
+    for i in r do
+      write(i, " ");
+  } else {
+    if r.hasFirst() {
+      var count = 1;
+      for i in r {
+        count += 1;
+        if (count == 5) then
+          break;
+        writeln(i, " ");
+      }
+      writeln("...");
+    } else {
+      writeln("<can't be done>");
+    }
+  }
+        
+  writeln();
+
+  if r.hasFirst() then
+    writeln("r#2               = ", r#2);
+  if r.hasLast() then
+    writeln("r#-2              = ", r#-2);
+  writeln("r == subr         = ", r == subr);
+  writeln("r != subr         = ", r != subr);
+  writeln("r[subr]           = ", r[subr]);
+  writeln("r[subr] == subr[r]= ", r[subr] == subr[r]);
+  
+  var r2 = r;
+  writeln("Copying...        = ", r2);
+  writeln();
+}

--- a/test/types/range/userAPI/rangeAPItest.notest
+++ b/test/types/range/userAPI/rangeAPItest.notest
@@ -1,0 +1,1 @@
+This is a helper module

--- a/test/types/range/userAPI/simpleRangeTest.chpl
+++ b/test/types/range/userAPI/simpleRangeTest.chpl
@@ -1,0 +1,10 @@
+use rangeAPITest;
+
+// not exhaustive, but test some simple cases
+testRangeAPI("basic range", 1..10, 4, 3..6);
+testRangeAPI("strided range", 1..20 by 2, 7, 5..13 by 2);
+testRangeAPI("neg. str. range", 1..20 by -2, 14, 16..8 by -2);
+testRangeAPI("unbounded range", 1.., 4, 3..6);
+testRangeAPI("upper unbnd range", ..10, 4, 3..6);
+testRangeAPI("neg upper unbnd range", ..10 by -1, 4, 3..6 by -1);
+testRangeAPI("unbounded range", .., 4, 3..6);

--- a/test/types/range/userAPI/simpleRangeTest.chpl
+++ b/test/types/range/userAPI/simpleRangeTest.chpl
@@ -1,4 +1,4 @@
-use rangeAPITest;
+use rangeAPItest;
 
 // not exhaustive, but test some simple cases
 testRangeAPI("basic range", 1..10, 4, 3..6);

--- a/test/types/range/userAPI/simpleRangeTest.good
+++ b/test/types/range/userAPI/simpleRangeTest.good
@@ -1,5 +1,5 @@
-./rangeAPITest.chpl:3: In function 'testRangeAPI':
-./rangeAPITest.chpl:43: warning: invoking 'offset' on an unstrided range has no effect.
+./rangeAPItest.chpl:3: In function 'testRangeAPI':
+./rangeAPItest.chpl:43: warning: invoking 'offset' on an unstrided range has no effect.
 basic range
 ------------
 1..10

--- a/test/types/range/userAPI/simpleRangeTest.good
+++ b/test/types/range/userAPI/simpleRangeTest.good
@@ -1,0 +1,337 @@
+./rangeAPITest.chpl:3: In function 'testRangeAPI':
+./rangeAPITest.chpl:43: warning: invoking 'offset' on an unstrided range has no effect.
+basic range
+------------
+1..10
+idxType          = int(64)
+stridable        = false
+boundedType      = bounded
+isRangeType()    = true
+isBoundedRange() = true
+hasLowBound()    = true
+hasHighBound()   = true
+stride           = 1
+alignment        = 1
+aligned          = true
+first            = 1
+last             = 10
+low              = 1
+high             = 10
+alignedLow       = 1
+alignedHigh      = 10
+isEmpty()        = false
+size             = 10
+length           = 10
+hasFirst()       = true
+hasLast()        = true
+isNat.Algned()   = true
+isAmbiguous      = false
+member(4) = true
+member(3..6) = true
+ident(self)      = true
+ident(other)     = false
+boundsCheck(4) = true
+boundsCheck(3..6) = true
+indexOrder(4) = 3
+orderToIndex(3)  = 4
+expand(2)        = -1..12
+offset(1)        = 1..10
+translate(2)     = 3..12
+translate(-2)    = -1..8
+exterior(2)      = 11..12
+exterior(-2)     = -1..0
+interior(2)      = 9..10
+interior(-2)     = 1..2
+serial iteration = 
+1 2 3 4 5 6 7 8 9 10 
+r#2               = 1..2
+r#-2              = 9..10
+r == subr         = false
+r != subr         = true
+r[subr]           = 3..6
+r[subr] == subr[r]= true
+Copying...        = 1..10
+
+strided range
+------------
+1..20 by 2
+idxType          = int(64)
+stridable        = true
+boundedType      = bounded
+isRangeType()    = true
+isBoundedRange() = true
+hasLowBound()    = true
+hasHighBound()   = true
+stride           = 2
+alignment        = 1
+aligned          = true
+first            = 1
+last             = 19
+low              = 1
+high             = 20
+alignedLow       = 1
+alignedHigh      = 19
+isEmpty()        = false
+size             = 10
+length           = 10
+hasFirst()       = true
+hasLast()        = true
+isNat.Algned()   = true
+isAmbiguous      = false
+member(7) = true
+member(5..13 by 2) = true
+ident(self)      = true
+ident(other)     = false
+boundsCheck(7) = true
+boundsCheck(5..13 by 2) = true
+indexOrder(7) = 3
+orderToIndex(3)  = 7
+expand(2)        = -1..22 by 2
+offset(1)        = 1..20 by 2 align 0
+translate(2)     = 3..22 by 2
+translate(-2)    = -1..18 by 2
+exterior(2)      = 21..22 by 2
+exterior(-2)     = -1..0 by 2
+interior(2)      = 19..20 by 2
+interior(-2)     = 1..2 by 2
+serial iteration = 
+1 3 5 7 9 11 13 15 17 19 
+r#2               = 1..4 by 2
+r#-2              = 17..20 by 2
+r == subr         = false
+r != subr         = true
+r[subr]           = 5..13 by 2
+r[subr] == subr[r]= true
+Copying...        = 1..20 by 2
+
+neg. str. range
+------------
+1..20 by -2
+idxType          = int(64)
+stridable        = true
+boundedType      = bounded
+isRangeType()    = true
+isBoundedRange() = true
+hasLowBound()    = true
+hasHighBound()   = true
+stride           = -2
+alignment        = 20
+aligned          = true
+first            = 20
+last             = 2
+low              = 1
+high             = 20
+alignedLow       = 2
+alignedHigh      = 20
+isEmpty()        = false
+size             = 10
+length           = 10
+hasFirst()       = true
+hasLast()        = true
+isNat.Algned()   = true
+isAmbiguous      = false
+member(14) = true
+member(16..8 by -2) = true
+ident(self)      = true
+ident(other)     = false
+boundsCheck(14) = true
+boundsCheck(16..8 by -2) = true
+indexOrder(14) = 3
+orderToIndex(3)  = 14
+expand(2)        = -1..22 by -2
+offset(1)        = 1..20 by -2 align 1
+translate(2)     = 3..22 by -2
+translate(-2)    = -1..18 by -2
+exterior(2)      = 21..22 by -2
+exterior(-2)     = -1..0 by -2
+interior(2)      = 19..20 by -2
+interior(-2)     = 1..2 by -2
+serial iteration = 
+20 18 16 14 12 10 8 6 4 2 
+r#2               = 17..20 by -2
+r#-2              = 1..4 by -2
+r == subr         = false
+r != subr         = true
+r[subr]           = 16..8 by -2
+r[subr] == subr[r]= true
+Copying...        = 1..20 by -2
+
+unbounded range
+------------
+1..
+idxType          = int(64)
+stridable        = false
+boundedType      = boundedLow
+isRangeType()    = true
+isBoundedRange() = false
+hasLowBound()    = true
+hasHighBound()   = false
+stride           = 1
+alignment        = 1
+aligned          = true
+first            = 1
+last             = 0
+low              = 1
+high             = 0
+alignedLow       = 1
+alignedHigh      = 0
+isEmpty()        = false
+hasFirst()       = true
+hasLast()        = false
+isNat.Algned()   = true
+isAmbiguous      = false
+member(4) = true
+member(3..6) = true
+ident(self)      = true
+ident(other)     = false
+boundsCheck(4) = true
+boundsCheck(3..6) = true
+indexOrder(4) = 3
+orderToIndex(3)  = 4
+translate(2)     = 3..
+translate(-2)    = -1..
+serial iteration = 
+1 
+2 
+3 
+...
+
+r#2               = 1..2
+r == subr         = false
+r != subr         = true
+r[subr]           = 3..6
+r[subr] == subr[r]= true
+Copying...        = 1..
+
+upper unbnd range
+------------
+..10
+idxType          = int(64)
+stridable        = false
+boundedType      = boundedHigh
+isRangeType()    = true
+isBoundedRange() = false
+hasLowBound()    = false
+hasHighBound()   = true
+stride           = 1
+alignment        = 0
+aligned          = false
+first            = 1
+last             = 10
+low              = 1
+high             = 10
+alignedLow       = 1
+alignedHigh      = 10
+isEmpty()        = false
+hasFirst()       = false
+hasLast()        = true
+isNat.Algned()   = false
+isAmbiguous      = false
+member(4) = true
+member(3..6) = true
+ident(self)      = true
+ident(other)     = false
+boundsCheck(4) = true
+boundsCheck(3..6) = true
+indexOrder(4) = -1
+translate(2)     = ..12
+translate(-2)    = ..8
+serial iteration = 
+<can't be done>
+
+r#-2              = 9..10
+r == subr         = false
+r != subr         = true
+r[subr]           = 3..6
+r[subr] == subr[r]= true
+Copying...        = ..10
+
+neg upper unbnd range
+------------
+..10 by -1
+idxType          = int(64)
+stridable        = true
+boundedType      = boundedHigh
+isRangeType()    = true
+isBoundedRange() = false
+hasLowBound()    = false
+hasHighBound()   = true
+stride           = -1
+alignment        = 10
+aligned          = true
+first            = 10
+last             = 1
+low              = 1
+high             = 10
+alignedLow       = 1
+alignedHigh      = 10
+isEmpty()        = false
+hasFirst()       = true
+hasLast()        = false
+isNat.Algned()   = true
+isAmbiguous      = false
+member(4) = true
+member(3..6 by -1) = true
+ident(self)      = true
+ident(other)     = false
+boundsCheck(4) = true
+boundsCheck(3..6 by -1) = true
+indexOrder(4) = 6
+orderToIndex(3)  = 7
+translate(2)     = ..12 by -1
+translate(-2)    = ..8 by -1
+serial iteration = 
+10 
+9 
+8 
+...
+
+r#2               = 9..10 by -1
+r == subr         = false
+r != subr         = true
+r[subr]           = 3..6 by -1
+r[subr] == subr[r]= true
+Copying...        = ..10 by -1
+
+unbounded range
+------------
+..
+idxType          = int(64)
+stridable        = false
+boundedType      = boundedNone
+isRangeType()    = true
+isBoundedRange() = false
+hasLowBound()    = false
+hasHighBound()   = false
+stride           = 1
+alignment        = 0
+aligned          = false
+first            = 1
+last             = 0
+low              = 1
+high             = 0
+alignedLow       = 1
+alignedHigh      = 0
+isEmpty()        = false
+hasFirst()       = false
+hasLast()        = false
+isNat.Algned()   = false
+isAmbiguous      = false
+member(4) = true
+member(3..6) = true
+ident(self)      = true
+ident(other)     = false
+boundsCheck(4) = true
+boundsCheck(3..6) = true
+indexOrder(4) = -1
+translate(2)     = ..
+translate(-2)    = ..
+serial iteration = 
+<can't be done>
+
+r == subr         = false
+r != subr         = true
+r[subr]           = 3..6
+r[subr] == subr[r]= true
+Copying...        = ..
+


### PR DESCRIPTION
This adds a framework for testing the range API, as it currently stands, similar to the ones
that have been developed in recent years for testing domains and arrays.  It exercises the
framework for some simple strided vs. unstrided and bounded vs. unbounded ranges.
I originally authored this as part of the bigint range work, but never split it off into its own
PR until now.

While writing the test, I found a few cases that seemed erroneous / inconsistent and fixed
them while here (mostly involving filtering out cases that should not be referring to values
like _low or _high which are currently stored even for unbounded or partially bounded ranges).

Note that other than the above bugs, nothing about this PR is meant to imply that all of
these routines are ideal as currently written.  There are asymmetries in terms of naming,
error-handling, etc. which arguably ought to be addressed, but that was not my goal at
this time (rather, it was to create a framework for testing ranges of other types for basic
feature coverage).