### PR TITLE
Remove reference to closed issue

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -431,7 +431,7 @@ static void codegenGlobalConstArray(const char*          name,
 
 // This uses Schubert Numbering but we could use Cohen's Display,
 // which can be computed more incrementally.
-// See issue ##5887 and/or
+// See
 // "Implementing statically typed object-oriented programming languages",
 // by Roland Ducournau
 static void


### PR DESCRIPTION
Removes a reference to the closed issue #5887 pointed out in #11215.

The paper referred to is a better long-term reference.

Comment change only.
