### PR TITLE
Filter -Wno-class-memaccess from LLVM options

### DIFF
--- a/third-party/llvm/filter-llvm-config.awk
+++ b/third-party/llvm/filter-llvm-config.awk
@@ -6,6 +6,7 @@ BEGIN { RS=" " }
 /^-O[0-4s]?$/ { next }
 /^-pedantic$/ { next }
 /^-W.,/ { printf " %s",$0 }
+/^-Wno-class-memaccess/ { next }
 /^-Wno-/ { printf " %s",$0 }
 /^-W/ { next }
 { printf " %s",$0 }


### PR DESCRIPTION
In LLVM 7.0.0, "llvm-config --cxxflags" adds -Wno-class-memaccess to the list
of options it wants to use.  That option isn't recognized by clang++, and so
breaks the compiler build.  Filter it out of the options we use.