### PR TITLE
Make dsiDestroyDom an inherited method

### DIFF
--- a/modules/dists/BlockCycDist.chpl
+++ b/modules/dists/BlockCycDist.chpl
@@ -646,7 +646,7 @@ proc BlockCyclicDom.setup() {
     enumerateBlocks();
 }
 
-proc BlockCyclicDom.dsiDestroyDom() {
+override proc BlockCyclicDom.dsiDestroyDom() {
   coforall localeIdx in dist.targetLocDom do
     on dist.targetLocales(localeIdx) do
       delete locDoms(localeIdx);

--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -866,7 +866,7 @@ proc BlockDom.setup() {
   }
 }
 
-proc BlockDom.dsiDestroyDom() {
+override proc BlockDom.dsiDestroyDom() {
   coforall localeIdx in dist.targetLocDom do {
     on locDoms(localeIdx) do
       delete locDoms(localeIdx);

--- a/modules/dists/CyclicDist.chpl
+++ b/modules/dists/CyclicDist.chpl
@@ -470,7 +470,7 @@ proc CyclicDom.setup() {
   }
 }
 
-proc CyclicDom.dsiDestroyDom() {
+override proc CyclicDom.dsiDestroyDom() {
     coforall localeIdx in dist.targetLocDom {
       on dist.targetLocs(localeIdx) do
         delete locDoms(localeIdx);

--- a/modules/dists/DimensionalDist2D.chpl
+++ b/modules/dists/DimensionalDist2D.chpl
@@ -966,7 +966,7 @@ proc DimensionalDom.dsiBuildArray(type eltType)
 }
 
 
-proc DimensionalDom.dsiDestroyDom() {
+override proc DimensionalDom.dsiDestroyDom() {
   coforall desc in localDdescs do
     on desc do
       delete desc;

--- a/modules/dists/ReplicatedDist.chpl
+++ b/modules/dists/ReplicatedDist.chpl
@@ -398,7 +398,7 @@ proc ReplicatedDom.dsiMember(indexx)
 proc ReplicatedDom.dsiIndexOrder(indexx)
   return redirectee().dsiIndexOrder(indexx);
 
-proc ReplicatedDom.dsiDestroyDom() {
+override proc ReplicatedDom.dsiDestroyDom() {
   coforall localeIdx in dist.targetLocDom {
     on dist.targetLocales(localeIdx) do
       delete localDoms(localeIdx);

--- a/modules/dists/SparseBlockDist.chpl
+++ b/modules/dists/SparseBlockDist.chpl
@@ -106,7 +106,7 @@ class SparseBlockDom: BaseSparseDomImpl {
     //    writeln("Exiting setup()");
   }
 
-  proc dsiDestroyDom() {
+  override proc dsiDestroyDom() {
     coforall localeIdx in dist.targetLocDom do {
       on locDoms(localeIdx) do
         delete locDoms(localeIdx);

--- a/modules/dists/StencilDist.chpl
+++ b/modules/dists/StencilDist.chpl
@@ -971,7 +971,7 @@ proc StencilDom.setup() {
   }
 }
 
-proc StencilDom.dsiDestroyDom() {
+override proc StencilDom.dsiDestroyDom() {
   coforall localeIdx in dist.targetLocDom {
     on locDoms(localeIdx) do
       delete locDoms(localeIdx);

--- a/modules/internal/ArrayViewRankChange.chpl
+++ b/modules/internal/ArrayViewRankChange.chpl
@@ -368,7 +368,7 @@ module ArrayViewRankChange {
       }
     }
 
-    proc dsiDestroyDom() {
+    override proc dsiDestroyDom() {
       if upDom != nil then
         _delete_dom(upDom, false);
       if downDomInst != nil then

--- a/modules/internal/ArrayViewReindex.chpl
+++ b/modules/internal/ArrayViewReindex.chpl
@@ -277,7 +277,7 @@ module ArrayViewReindex {
       }
     }
 
-    proc dsiDestroyDom() {
+    override proc dsiDestroyDom() {
       _delete_dom(updom, false);
       _delete_dom(downdomInst, _isPrivatized(downdomInst));
     }

--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -326,13 +326,7 @@ module ChapelDistribution {
     proc dsiLinksDistribution() return true;
 
     // Overload to to customize domain destruction
-    //
-    // BHARSH 2017-02-05: Making dsiDestroyDom a virtual method 'tricks' the
-    // compiler into thinking there's recursion for dsiDestroyDom when there is
-    // none. This can result in incorrect generated code if recursive iterators
-    // are inlined. See GitHub issue #5311 for more.
-    //
-    //proc dsiDestroyDom() { }
+    proc dsiDestroyDom() { }
 
     proc dsiDisplayRepresentation() { writeln("<no way to display representation>"); }
 
@@ -916,14 +910,7 @@ module ChapelDistribution {
 
   proc _delete_dom(dom, param privatized:bool) {
 
-    // This is a workaround for the recursive iterator bug discussed in
-    // GitHub issue #5311. Implementing 'dsiDestroyDom' on 'BaseDom' leads
-    // the compiler into thinking there's recursion due to virtual methods,
-    // when in fact there is no recursion at all.
-    use Reflection;
-    if canResolveMethod(dom, "dsiDestroyDom") {
-      dom.dsiDestroyDom();
-    }
+    dom.dsiDestroyDom();
 
     if privatized {
       _freePrivatizedClass(dom.pid, dom);


### PR DESCRIPTION
This PR removes the workaround for #5311 (pointed out by #11215).

Testing:
- [x] local + futures
- [x] gasnet + futures
- [x] memleaks