### PR TITLE
Add perf annotations for 2018-09-27

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -348,6 +348,9 @@ all:
   08/15/18:
     - text: Revert to stack-allocated rfDone indicators. (#10728)
       config: 16 node XC
+  09/25/18:
+    - text: Optimize blocking puts/gets and fetching network AMOs (#11176)
+      config: 16 node XC
 
 
 AllCompTime:
@@ -432,6 +435,10 @@ binary-trees: &binary-trees-base
     - Updated to n=21 problem size and new rules (#5907)
   06/23/18:
     - Update more tests to compile with --warn-unstable (#9986)
+  09/06/18:
+    - Make performance tests make better use of managed classes (#10945)
+  09/19/18:
+    - Switch study version of binary trees from owned to unmanaged (#11128)
 binarytrees-submitted:
   <<: *binary-trees-base
 
@@ -841,6 +848,10 @@ memleaks:
     - Initializers on by default (#10459)
   07/25/18:
     - Fix size of loop expr in LCALS (#10499)
+  09/06/18:
+    - Enable usage of LinearAlgebra without BLAS/LAPACK (#10929)
+  09/19/18:
+    - Use runtime type field in chpl__distributed for sparse domains (#11140)
 
 memleaksfull:
   07/08/14:
@@ -932,6 +943,10 @@ memleaksfull:
     - Fix leak in cast to string from c_ptr (#10523)
   08/01/18:
     - Additional SparseBlockDom/Arr dsi methods to support bale-toposort (#10604)
+  09/06/18:
+    - Enable usage of LinearAlgebra without BLAS/LAPACK (#10929)
+  09/19/18:
+    - Use runtime type field in chpl__distributed for sparse domains (#11140)
 
 meteor:
   12/18/13:
@@ -939,7 +954,7 @@ meteor:
   08/10/16:
     - Updated meteor's lock to yield less frequently (#4300)
 
-mg-b:
+mg: &mg-base
   05/23/17:
     - Fix NPB MG (#6284)
   06/13/17:
@@ -948,6 +963,12 @@ mg-b:
     - Only perform packed updateFluff when there are multiple locales (#6512)
   06/22/18:
     - Make 'for' loop in dsiReallocate parallel (#9895)
+  09/20/18:
+    -  Move strided bulk transfer into common code (#11197)
+  09/21/18:
+    -  Restore comm=none performance lost in PR 11197 (#11206)
+mg-b:
+  <<: *mg-base
 
 mg.ml-time:
   05/11/17:
@@ -1002,6 +1023,8 @@ nbody:
     - upgrade jemalloc to 4.2.0 (#3919)
   04/19/18:
     - Use zero-arg initializer in BaseDom (#9250)
+  08/31/18:
+    - Refactor PRIM_NEW resolution to enable promotion (#10919)
 
 no-op:
   02/24/17:
@@ -1249,7 +1272,7 @@ testSerialReductions:
   08/16/14:
     - result of Greg's commit to let the tasking layer determine parallelism
 
-thread-ring: &thread-ring-base
+thread-ring:
   03/19/15:
     - text: memory related, qthreads memory pool bug fix
       config: chap03
@@ -1259,6 +1282,8 @@ thread-ring: &thread-ring-base
     - Enforce qualified refs after inlining (#7906)
   06/07/18:
     - Prevent serialization from qthread sync vars (#9737)
+  08/30/18:
+    - Reduce hugepage waste from call stacks (#10254)
 
 time_array_vs_ddata:
   05/31/14:
@@ -1317,6 +1342,8 @@ timeVectorArray:
     - Make 'for' loop in dsiReallocate parallel (#9895)
   08/17/18:
     - Add a new dsiReallocate that is aware of allocated size (#10793)
+  09/07/18:
+    - Fix performance regression in pop_front/pop_back from PR 10793 (#11017)
 
 views-forall-iter:
   10/12/17:


### PR DESCRIPTION
Add annotations for:
 - [ra-rmo, ptrans, bale-indexgather, fetching-amo](https://chapel-lang.org/perf/16-node-xc/?startdate=2018/09/17&enddate=2018/09/25&graphs=hpccptransperfgbsecn2000nb100,hpccrarmoperfgupsn233,baleindexgatherperfmbspernode,remotefetchingamoperformance) improvements (#11176)
 - [study binary trees](https://chapel-lang.org/perf/chapcs/?startdate=2018/08/27&enddate=2018/09/24&graphs=binarytreesshootoutbenchmarkn21) changes from managed/unmanaged mem (#10945, #11128)
 - leaks from new [LA test and sparse domain](https://chapel-lang.org/perf/chapcs/?startdate=2018/08/27&enddate=2018/09/24&graphs=memoryleaksforexamplestests,memoryleaksforalltests) leak plug (#10929, #11140)
 - single-node [MG](https://chapel-lang.org/perf/chapcs/?startdate=2018/09/16&enddate=2018/09/23&graphs=npbmgsizea,npbmgsizeb) regression and fix (#11197, #11206)
 - [nbody](https://chapel-lang.org/perf/chapcs/?startdate=2018/08/17&enddate=2018/09/14&graphs=nbodyvariations) improvement (#10919)
 - [threadring](https://chapel-lang.org/perf/chapcs/?startdate=2018/08/14&enddate=2018/09/14&graphs=threadringshootoutbenchmarkn50000000) improvement (#10254)
 - [array-as-vec](https://chapel-lang.org/perf/chapcs/?startdate=2018/08/06&enddate=2018/09/14&graphs=arrayvectoroperations) regression fix (#11017)