### PR TITLE
Fix regression in field-in-task-ref-clause.chpl

### DIFF
--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -1748,14 +1748,12 @@ Symbol* lookup(const char* name, BaseAST* context) {
     //   otherwise fail
 
     for_vector(Symbol, sym, symbols) {
-      if (isFnSymbol(sym) == false) {
+      if (! isFnSymbol(sym)) {
         USR_FATAL_CONT(sym, "symbol %s is multiply defined", name);
         printConflictingSymbols(symbols, sym);
         break;
       }
     }
-
-    USR_STOP();
 
     retval = NULL;
   }


### PR DESCRIPTION
#7381 introduced a USR_STOP() inside a lookup() overload in scopeResolve.cpp.
Unfortunately it prevents reporting additional errors when:
* there has already been a USR_FATAL_CONTINUE, whether related to lookup()
  or not, and
* this lookup() overload is invoked.

Upon code examination and para-testing, it turns out that this USR_STOP
is not necessary. Removing it now.

Tested: linux64 -futures.

Trivial, not reviewed.
