### PR TITLE
build_configs5: Write new setenv scripts which reproduce current Chapel Cray RPMs

### DIFF
--- a/util/build_configs/README.md
+++ b/util/build_configs/README.md
@@ -3,10 +3,10 @@
 This directory contains scripts to build customizable Chapel binaries
 in multiple configurations.
 
-The `cray-internal` subdirectory adds scripts to package Chapel binaries
-(already pre-built with `setenv-example3.bash` from this directory) into an
-RPM suitable for installation on a Cray-XC. See `./cray-internal/README.md`
-for more info.
+The `cray-internal` subdirectory contains scripts to build and package
+Chapel binaries into RPM modules suitable for installation on a Cray-XC.
+Those scripts are Cray-specific applications of the more general patterns
+presented in this directory. See `./cray-internal/README.md` for more info.
 
 ### Files in this directory:
 

--- a/util/build_configs/README.md
+++ b/util/build_configs/README.md
@@ -4,7 +4,7 @@ This directory contains scripts to build customizable Chapel binaries
 in multiple configurations.
 
 The `cray-internal` subdirectory contains scripts to build and package
-Chapel binaries into RPM modules suitable for installation on a Cray-XC.
+Chapel binaries into RPM modules suitable for installation on a Cray-XC or XE.
 Those scripts are Cray-specific applications of the more general patterns
 presented in this directory. See `./cray-internal/README.md` for more info.
 

--- a/util/build_configs/build-common.bash
+++ b/util/build_configs/build-common.bash
@@ -4,8 +4,7 @@
 # This expects bash functions log_debug, log_error, etc to be defined
 # (see functions.bash)
 
-thiscomm=$( basename ${BASH_SOURCE[0]} )
-log_debug "Begin $thiscomm"
+log_debug "Begin $( basename ${BASH_SOURCE[0]} )"
 
 if [ -n "${verbose:-}" ]; then
     log_info "Using -v (verbose)"
@@ -102,4 +101,4 @@ case "$tarball" in
     ;;
 esac
 
-log_debug "End $thiscomm"
+log_debug "End $( basename ${BASH_SOURCE[0]} )"

--- a/util/build_configs/build_configs.py
+++ b/util/build_configs/build_configs.py
@@ -140,6 +140,20 @@ class Config(object):
                 values.append('\t{0}={1}'.format(dim.name, value))
         return '\n'.join(values)
 
+    def pretty_str(self,header=False):
+        """Return pretty string of configs - one line of a formatted table."""
+        values = []
+        for dim in Dimensions:
+            value = getattr(self, dim.name)
+            if value:
+                if header:
+                    # for a header line at the top with the names of the config variables
+                    values.append('%10.10s' % (dim.name))
+                else:
+                    # a normal line with just the config values
+                    values.append('%10.10s' % (value))
+        return ' '.join(values)
+
     def get_env(self, orig_env):
         """Update and return an existing configuration with this configuration's
         values.
@@ -184,21 +198,42 @@ def main():
         len(build_configs),
         's' if len(build_configs) > 1 else '')
     logging.info('Building {0}.'.format(config_count_str))
-    logging.debug('Build configs: {0}'.format(build_configs))
+
+    def list_config_names():
+        """Return a complete formatted table showing all the chapel configs in this build."""
+        names = []
+        for i, build_config in enumerate(build_configs):
+            if i == 0:
+                # prepend header row
+                build_config_name = build_config.pretty_str(header=True)
+                if not build_config_name:
+                    build_config_name = 'None'
+                names.append('')
+                names.append('           ' + build_config_name)
+            # normal table row
+            build_config_name = build_config.pretty_str()
+            if not build_config_name:
+                build_config_name = 'None'
+            names.append('%3d / %3d  %s' % (i+1, len(build_configs), build_config_name))
+        return names
+
+    logging.info('\n'.join(list_config_names()))
 
     make_logfile = chpl_misc['make_logfile']
     chpl_home = chpl_misc['chpl_home']
     if make_logfile:
-        print('[BUILD_CONFIGS] Building {0}\n'.format(config_count_str), file=make_logfile)
-        print('[BUILD_CONFIGS] CHPL_HOME={0}\n'.format(chpl_home), file=make_logfile)
+        print('\n[BUILD_CONFIGS] CHPL_HOME={0}'.format(chpl_home), file=make_logfile)
+        print('\n[BUILD_CONFIGS] Building {0}'.format(config_count_str), file=make_logfile)
+        print('\n'.join(list_config_names()), file=make_logfile)
 
     statuses = [0,]
     with elapsed_time('All {0}'.format(config_count_str)):
-        for build_config in build_configs:
+        for i, build_config in enumerate(build_configs):
             result = build_chpl(
-                chpl_misc,
+                '{0} / {1}'.format(i+1, len(build_configs)),
                 build_config,
                 build_env,
+                chpl_misc,
                 parallel=opts.parallel,
                 verbose=opts.verbose,
                 dry_run=opts.dry_run,
@@ -387,17 +422,20 @@ def get_configs(opts):
     return configs
 
 
-def build_chpl(chpl_misc, build_config, env, parallel=False, verbose=False, dry_run=False):
+def build_chpl(counter, build_config, env, chpl_misc, parallel=False, verbose=False, dry_run=False):
     """Build Chapel with the provided environment.
 
-    :type chpl_misc: dict
-    :arg chpl_misc: miscellaneous chplenv-related paths, settings, and options
+    :type counter: string
+    :arg counter: current config number / total number of configs, for edits
 
     :type build_config: Config
     :arg build_config: build configuration to build
 
     :type env: dict
     :arg env: Dictionary of key/value pairs to set as the environment.
+
+    :type chpl_misc: dict
+    :arg chpl_misc: miscellaneous chplenv-related paths, settings, and options
 
     :type verbose: bool
     :arg verbose: if True, increase output
@@ -421,10 +459,10 @@ def build_chpl(chpl_misc, build_config, env, parallel=False, verbose=False, dry_
     if not build_config_name:
         build_config_name = 'None'
 
-    logging.info('Building config:\n\t{0}'.format(build_config_name))
+    logging.info('Building config number {0}:\n\t{1}'.format(counter, build_config_name))
     if make_logfile:
-        print('[BUILD_CONFIGS] make_targets:\n\t{0}'.format(make_targets), file=make_logfile)
-        print('[BUILD_CONFIGS] config:\n\t{0}'.format(build_config_name), file=make_logfile)
+        print('\n[BUILD_CONFIGS] config number {0}:\n\t{1}'.format(counter, build_config_name), file=make_logfile)
+        print('\n[BUILD_CONFIGS] make_targets:\n\t{0}'.format(make_targets), file=make_logfile)
 
     build_env['BUILD_CONFIGS_CALLBACK'] = '{0}'.format(build_config_name)
     build_env['BUILD_CONFIGS_VERBOSE'] = '{0}'.format(verbose)
@@ -442,7 +480,7 @@ def build_chpl(chpl_misc, build_config, env, parallel=False, verbose=False, dry_
         #   Printchplenv is run twice if logfile is used, to see Chapel env on both console and logfile
 
         logging.info('DRY-RUN: printchplenv command:\n\t{0}'.format(dryrun_cmd))
-        with elapsed_time(build_config_name):
+        with elapsed_time('Config number {0}'.format(counter)):
             result, output, error = check_output(dryrun_cmd, chpl_home, build_env)
         if result or error:
             logging.warn('Errors/Warnings from printchplenv, config {0}\n{1}\n{2}\nExit code {3}'.format(
@@ -466,7 +504,7 @@ def build_chpl(chpl_misc, build_config, env, parallel=False, verbose=False, dry_
         logging.info('Chapel make command:\n\t{0}'.format(make_cmd))
         if make_logfile:
             print('[BUILD_CONFIGS] Chapel make command:\n\t{0}\n'.format(make_cmd), file=make_logfile)
-        with elapsed_time(build_config_name):
+        with elapsed_time('Config number {0}'.format(counter)):
             result, output, error = check_output(make_cmd, chpl_home, build_env, file=make_logfile)
         if result:
             logging.error('Non-zero exit code {0}'.format(result))

--- a/util/build_configs/chapel_build.bash
+++ b/util/build_configs/chapel_build.bash
@@ -4,16 +4,15 @@
 # using build_configs.py with a given setenv project script.
 
 set -e
-thisfile=$( basename "$0" )
 yourcwd=$PWD
 
-cwd=$( cd $(dirname "$0" ) && pwd )
+cwd=$( cd $(dirname "{BASH_SOURCE[0]}" ) && pwd )
 source $cwd/functions.bash
-log_info "Begin $thisfile"
+log_info "Begin $( basename ${BASH_SOURCE[0]} )"
 
 usage() {
     echo >&2 "
-Usage: $thisfile" '[options]
+Usage: $( basename ${BASH_SOURCE[0]} )" '[options]
 
   where:
     -v : verbose/debug output
@@ -82,4 +81,4 @@ source "$cwd/build-common.bash"
 
 bash "$setenv" $verbose $dry_run
 
-log_info "End $thisfile"
+log_info "End $( basename ${BASH_SOURCE[0]} )"

--- a/util/build_configs/cray-internal/.gitignore
+++ b/util/build_configs/cray-internal/.gitignore
@@ -10,6 +10,7 @@
 !/generate-set_default.bash
 !/setenv-xc-x86_64.bash
 !/setenv-xc-aarch64.bash
+!/setenv-xe-x86_64.bash
 #
 # This hides users subdirectories
 #

--- a/util/build_configs/cray-internal/.gitignore
+++ b/util/build_configs/cray-internal/.gitignore
@@ -8,6 +8,8 @@
 !/generate-modulefile.bash
 !/generate-rpmspec.bash
 !/generate-set_default.bash
+!/setenv-xc-x86_64.bash
+!/setenv-xc-aarch64.bash
 #
 # This hides users subdirectories
 #

--- a/util/build_configs/cray-internal/README.md
+++ b/util/build_configs/cray-internal/README.md
@@ -1,8 +1,9 @@
-## New scripts to package pre-built Chapel binaries into a Cray-compatible RPM.
+## New scripts to build and package Chapel binaries into a Cray-compatible RPM.
 
-This directory adds scripts to package pre-built Chapel binaries as an RPM file.
-The recommended way to build Chapel binaries is to run `chapel_build.bash` from
-the parent directory, with setenv-example-3. See chapel_build.bash for illustration.
+This directory adds scripts to build and package Chapel binaries as an RPM file.
+The recommended way to build Chapel binaries is to run `chapel_build.bash` with
+one of the setenv scripts in this subdir, setenv-example-3 from the parent directory,
+or a new setenv script derived from one of those. See `chapel_build.bash` for illustration.
 
 The Chapel RPM file produced by these scripts is intended to be fully compatible
 with current generation Cray-XC supercomputers and system-management tools.
@@ -15,10 +16,10 @@ a subdirectory like this one (cray-internal), while generic things that should b
 applicable in many kinds of Chapel packages are implemented in the parent directory.
 
 This directory should be used as a model for new scripts to build other kinds of Chapel
-packages. Start by creating a new subdirectory (under build_configs) for each specific
-Chapel package; copy and rename the main script `chapel_package-cray.bash` from here
-to the new subdir; edit that file; and go from there, copy-editing additional files from
-this directory as needed. When appropriate, add to the existing `package-*.bash` support
+packages. Start by creating a new subdirectory (under build_configs) for each new type
+of package; copy and rename the main script `chapel_package-cray.bash` from here to the
+new subdir; edit that file; and go from there, copy-editing additional files from this
+directory as needed. When appropriate, add to the existing `package-*.bash` support
 files in the parent directory. Finally, copy-edit the `.gitignore` file from here to the
 new subdir.
 
@@ -47,6 +48,16 @@ new subdir.
     A Cray system management tool, this script sets the default Chapel version obtained
     when a user runs `module load chapel` without specifying a specific version.
 
+* setenv-\*-\*.bash:
+  Setenv scripts for Chapel Cray RPMs of various types. These setenv scripts are based on
+  the setenv-example-3 script in the parent directory, and their basic structure is the
+  same.  However, many details were added to successfully build a complete Chapel Cray
+  module, including Python-venv, chpldoc, mason, 192 runtime configs, etc.
+  These setenv scripts are located here in this `cray-internal` subdir because they
+  are Cray-specific implementations of the general build_configs/setenv pattern:
+  - setenv-xc-x86_64:  Chapel Cray-XC module for x86_64
+  - setenv-xc-aarch64: Chapel Cray-XC module for aarch64 (ARM)
+  - setenv-xe-x86_64:  Chapel Cray-XE module for x86_64
 
 ### Users local Chapel projects:
 
@@ -94,3 +105,9 @@ export CHPL_HOME=$PWD/chapel-x.y.z
 ./chapel_package-cray.bash -b nightly
 ```
 
+Instead of starting from `setenv-example-3`, a user with more sophisticated requirements
+could start from one of the setenv scripts in this subdirectory: `setenv-xc-x86_64`, for
+example. This would be more challenging, as these setenv scripts are necessarily more
+complicated and site-specific than `setenv-example-3`.
+However, the same basic approach would be used: copy the existing setenv script to a new
+filename; modify as needed; test-build-test; add packaging; etc.

--- a/util/build_configs/cray-internal/README.md
+++ b/util/build_configs/cray-internal/README.md
@@ -6,7 +6,7 @@ one of the setenv scripts in this subdir, setenv-example-3 from the parent direc
 or a new setenv script derived from one of those. See `chapel_build.bash` for illustration.
 
 The Chapel RPM file produced by these scripts is intended to be fully compatible
-with current generation Cray-XC supercomputers and system-management tools.
+with current generation Cray-XC/XE supercomputers and system-management tools.
 As far as the packaging is concerned, these RPMs should be interchangeable with the
 Chapel Cray modules released through Cray, Inc.
 
@@ -52,7 +52,7 @@ new subdir.
   Setenv scripts for Chapel Cray RPMs of various types. These setenv scripts are based on
   the setenv-example-3 script in the parent directory, and their basic structure is the
   same.  However, many details were added to successfully build a complete Chapel Cray
-  module, including Python-venv, chpldoc, mason, 192 runtime configs, etc.
+  module, including Python-venv, chpldoc, mason, over 100 runtime configs, etc.
   These setenv scripts are located here in this `cray-internal` subdir because they
   are Cray-specific implementations of the general build_configs/setenv pattern:
   - setenv-xc-x86_64:  Chapel Cray-XC module for x86_64

--- a/util/build_configs/cray-internal/chapel_build.bash
+++ b/util/build_configs/cray-internal/chapel_build.bash
@@ -43,7 +43,8 @@ Usage: $thisfile" '[options]
 
   CHAPEL_PACKAGE OPTIONS:
 
-    -b release_type     : Build/release type (required) == "nightly" or "release".
+    -b release_type     : Build/release type (required)
+                          == "nightly", "release", or "developer".
     -p chpl_platform    : Chpl target platform, as in $CHPL_HOME/bin/$chpl_platform
                           ("cray-xc" or "cray-xe")
                           Default: cray-xc
@@ -143,6 +144,8 @@ case "$release_type" in
 ( [nN]* | -n | nightly )
     ;;
 ( [rR]* | -r | release )
+    ;;
+( [dD]* | developer )
     ;;
 ( * )
     log_error "-b release_type='$release_type' is invalid."

--- a/util/build_configs/cray-internal/chapel_build.bash
+++ b/util/build_configs/cray-internal/chapel_build.bash
@@ -155,9 +155,9 @@ esac
 
 source "$cwd/../build-common.bash"
 
-# Run the designated setenv build script, adding a "clean" step at the end.
+# Run the designated setenv build script
 
-bash "$setenv" $verbose $dry_run -B +venv_py27 -B +clean 
+bash "$setenv" $verbose $dry_run -B +venv_py27
 
 # Create the Chapel package
 

--- a/util/build_configs/cray-internal/chapel_build.bash
+++ b/util/build_configs/cray-internal/chapel_build.bash
@@ -157,7 +157,7 @@ source "$cwd/../build-common.bash"
 
 # Run the designated setenv build script, adding a "clean" step at the end.
 
-bash "$setenv" $verbose $dry_run -B +clean
+bash "$setenv" $verbose $dry_run -B +venv_py27 -B +clean 
 
 # Create the Chapel package
 

--- a/util/build_configs/cray-internal/chapel_build.bash
+++ b/util/build_configs/cray-internal/chapel_build.bash
@@ -157,7 +157,7 @@ source "$cwd/../build-common.bash"
 
 # Run the designated setenv build script
 
-bash "$setenv" $verbose $dry_run -B +venv_py27
+bash "$setenv" $verbose $dry_run
 
 # Create the Chapel package
 

--- a/util/build_configs/cray-internal/chapel_build.bash
+++ b/util/build_configs/cray-internal/chapel_build.bash
@@ -7,19 +7,17 @@
 # from this directory.
 
 set -e
-thisfile=$( basename "$0" )
 yourcwd=$PWD
 
-cwd=$( cd $(dirname "$0" ) && pwd )
-thisfile=$( basename "$cwd" )/$thisfile
+cwd=$( cd $(dirname "${BASH_SOURCE[0]}" ) && pwd )
 
 source $cwd/../functions.bash
 
-log_info "Begin $thisfile"
+log_info "Begin $( basename "${BASH_SOURCE[0]}" )"
 
 usage() {
     echo >&2 "
-Usage: $thisfile" '[options]
+Usage: $( basename "${BASH_SOURCE[0]}" )" '[options]
 
   where:
     -v : verbose/debug output
@@ -165,4 +163,4 @@ bash "$setenv" $verbose $dry_run -B +clean
 
 "$cwd/chapel_package-cray.bash" $verbose $dry_run $keepdir -C "$workdir" -T "$version_tag" -o "$outputs" -b "$release_type" -p "$chpl_platform" -r "$rc_number"
 
-log_info "End $thisfile"
+log_info "End $( basename "${BASH_SOURCE[0]}" )"

--- a/util/build_configs/cray-internal/chapel_package-cray.bash
+++ b/util/build_configs/cray-internal/chapel_package-cray.bash
@@ -6,20 +6,18 @@
 # scripts in the parent directory (build_configs).
 
 set -e
-thisfile=$( basename "$0" )
 yourcwd=$PWD
 
-cwd=$( cd $(dirname "$0" ) && pwd )
-thisfile=$( basename "$cwd" )/$thisfile
+cwd=$( cd $(dirname "${BASH_SOURCE[0]}" ) && pwd )
 
 source $cwd/../functions.bash
 source $cwd/../package-functions.bash
 
-log_info "Begin $thisfile"
+log_info "Begin $( basename "${BASH_SOURCE[0]}" )"
 
 usage() {
     echo 2>&1 "
-Usage $thisfile" '[options]
+Usage $( basename "${BASH_SOURCE[0]}" )" '[options]
   where:
     -v  : verbose/debug output.
     -n  : Do not actually run rpmbuild (dry_run).
@@ -241,4 +239,4 @@ else
     fi
 fi
 
-log_info "End $thisfile"
+log_info "End $( basename "${BASH_SOURCE[0]}" )"

--- a/util/build_configs/cray-internal/chapel_package-cray.bash
+++ b/util/build_configs/cray-internal/chapel_package-cray.bash
@@ -23,7 +23,8 @@ Usage $thisfile" '[options]
   where:
     -v  : verbose/debug output.
     -n  : Do not actually run rpmbuild (dry_run).
-    -b release_type     : Build/release type (required) == "nightly" or "release".
+    -b release_type     : Build/release type (required)
+                          == "nightly", "release", or "developer".
     -p chpl_platform    : Chpl target platform, as in $CHPL_HOME/bin/$chpl_platform
                           ("cray-xc" or "cray-xe")
                           Default: cray-xc
@@ -103,6 +104,8 @@ case "$release_type" in
     ;;
 ( [rR]* | -r | release )
     ;;
+( [dD]* | developer )
+    ;;
 ( * )
     log_error "-b release_type='$release_type' is invalid."
     usage
@@ -138,7 +141,7 @@ log_debug "Using -C workdir='$workdir'"
 
 # Get Chapel version numbers from source
 
-src_version=$( get_src_version "$CHPL_HOME" )
+src_version=$( get_src_version "$CHPL_HOME" "$release_type" )
 log_debug "Using src_version='$src_version'"
 
 # Sanity-check some common shell variables used for Chapel packages (parent directory)

--- a/util/build_configs/cray-internal/chapel_package-cray.bash
+++ b/util/build_configs/cray-internal/chapel_package-cray.bash
@@ -162,11 +162,25 @@ log_info "Creating CHPL_RPM='$CHPL_RPM'"
 rm -rf "$CHPL_RPM"
 mkdir "$CHPL_RPM"
 
-# Generate draft/placeholder release_info file, w versions
 
-log_debug "Generate release_info ..."
-$cwd/generate-dev-releaseinfo.bash > "$CHPL_RPM/release_info"
-chmod 644 "$CHPL_RPM/release_info"
+if [ "$release_type" = release ]; then
+
+    log_debug "Using existing release_info file in CHPL_HOME"
+
+    if [ ! -f "$CHPL_HOME/release_info" ]; then
+        log_error "Expected release_info file not found in CHPL_HOME='$CHPL_HOME'"
+        exit 2
+    fi
+    cat "$CHPL_HOME/release_info" > "$CHPL_RPM/release_info"
+    rm -f "$CHPL_HOME/release_info"
+    chmod 644 "$CHPL_RPM/release_info"
+else
+
+    log_debug "Generate draft/placeholder release_info ..."
+
+    $cwd/generate-dev-releaseinfo.bash > "$CHPL_RPM/release_info"
+    chmod 644 "$CHPL_RPM/release_info"
+fi
 
 # Generate modulefile, w versions
 

--- a/util/build_configs/cray-internal/common.bash
+++ b/util/build_configs/cray-internal/common.bash
@@ -1,8 +1,7 @@
 
 # Source this for Cray-module-specific shell setups
 
-thiscomm=$( basename ${BASH_SOURCE[0]} )
-log_debug "Begin $thiscomm"
+log_debug "Begin $( basename "${BASH_SOURCE[0]}" )"
 
 # This expects bash functions log_debug, log_error, etc to be defined
 # (see functions.bash and package-functions.bash),
@@ -47,7 +46,7 @@ case "${rc_prefix:-}" in
     rc_prefix=$( sed -e 's,-,,' <<<"$chpl_platform" )
     ;;
 ( *[!0-9a-zA-Z_]* )
-    log_error "$thiscomm: Invalid rc_prefix='$rc_prefix'"; exit 2
+    log_error "$( basename "${BASH_SOURCE[0]}" ): Invalid rc_prefix='$rc_prefix'"; exit 2
     ;;
 ( * )
     # strip out any "dash" in the given value
@@ -60,7 +59,7 @@ esac
 case "$rc_prefix" in
 ( *[0-9] )
     case "${rc_number:=0}" in
-        ( [0-9]* ) log_warn "$thiscomm: rc_prefix='$rc_prefix', rc_number='$rc_number' (too many digits?)";;
+        ( [0-9]* ) log_warn "$( basename "${BASH_SOURCE[0]}" ): rc_prefix='$rc_prefix', rc_number='$rc_number' (too many digits?)";;
     esac
     ;;
 esac
@@ -99,4 +98,4 @@ export pkg_filename
 export rpm_filename
 export rpmbuild_filename
 
-log_debug "End $thiscomm"
+log_debug "End $( basename "${BASH_SOURCE[0]}" )"

--- a/util/build_configs/cray-internal/common.bash
+++ b/util/build_configs/cray-internal/common.bash
@@ -73,6 +73,9 @@ case "${release_type:-}" in
 ( release )
     rpm_version=$date_ymd.$date_hms
     ;;
+( developer )
+    rpm_version=$date_ymd.$date_hms
+    ;;
 esac
 rpm_name="chapel-$pkg_version"
 

--- a/util/build_configs/cray-internal/generate-dev-releaseinfo.bash
+++ b/util/build_configs/cray-internal/generate-dev-releaseinfo.bash
@@ -4,9 +4,8 @@
 # Writes to stdout
 
 set -e
-thisfile=$( basename "$0" )
 
-cwd=$( cd $(dirname "$0" ) && pwd )
+cwd=$( cd $(dirname "${BASH_SOURCE[0]}" ) && pwd )
 source $cwd/../functions.bash
 
 # Accept command line parameters of the form NAME=Value. Or use environment variables.

--- a/util/build_configs/cray-internal/generate-modulefile.bash
+++ b/util/build_configs/cray-internal/generate-modulefile.bash
@@ -4,9 +4,8 @@
 # Writes to stdout
 
 set -e
-thisfile=$( basename "$0" )
 
-cwd=$( cd $(dirname "$0" ) && pwd )
+cwd=$( cd $(dirname "${BASH_SOURCE[0]}" ) && pwd )
 source $cwd/../functions.bash
 
 # Accept command line parameters of the form NAME=Value. Or use environment variables.

--- a/util/build_configs/cray-internal/generate-rpmspec.bash
+++ b/util/build_configs/cray-internal/generate-rpmspec.bash
@@ -4,9 +4,8 @@
 # Writes to stdout
 
 set -e
-thisfile=$( basename "$0" )
 
-cwd=$( cd $(dirname "$0" ) && pwd )
+cwd=$( cd $(dirname "${BASH_SOURCE[0]}" ) && pwd )
 source $cwd/../functions.bash
 
 # Accept command line parameters of the form NAME=Value. Or use environment variables.

--- a/util/build_configs/cray-internal/generate-set_default.bash
+++ b/util/build_configs/cray-internal/generate-set_default.bash
@@ -4,9 +4,8 @@
 # Writes to stdout
 
 set -e
-thisfile=$( basename "$0" )
 
-cwd=$( cd $(dirname "$0" ) && pwd )
+cwd=$( cd $(dirname "${BASH_SOURCE[0]}" ) && pwd )
 source $cwd/../functions.bash
 
 # Accept command line parameters of the form NAME=Value. Or use environment variables.

--- a/util/build_configs/cray-internal/setenv-xc-aarch64.bash
+++ b/util/build_configs/cray-internal/setenv-xc-aarch64.bash
@@ -92,9 +92,10 @@ if [ -z "$BUILD_CONFIGS_CALLBACK" ]; then
     export CHPL_LLVM=llvm       # llvm requires cmake
     export CHPL_AUX_FILESYS=none
 
-    # More CPUs --> faster make. Or, unset CHPL_MAKE_MAX_CPU_COUNT to use all CPUs.
+    # As a general rule, more CPUs --> faster make.
+    # To use all available CPUs, export CHPL_MAKE_MAX_CPU_COUNT=0 before running this setenv.
 
-    export CHPL_MAKE_MAX_CPU_COUNT=${CHPL_MAKE_MAX_CPU_COUNT:-24}
+    export CHPL_MAKE_MAX_CPU_COUNT=${CHPL_MAKE_MAX_CPU_COUNT:-8}
 
     # Show the initial/default Chapel build config with printchplenv
 

--- a/util/build_configs/cray-internal/setenv-xc-aarch64.bash
+++ b/util/build_configs/cray-internal/setenv-xc-aarch64.bash
@@ -121,7 +121,7 @@ if [ -z "$BUILD_CONFIGS_CALLBACK" ]; then
         ;;
     esac
 
-    case ",$components," in
+    case "$components" in
     ( *runtime* )
         log_info "Building Chapel component: runtime"
 
@@ -149,7 +149,7 @@ if [ -z "$BUILD_CONFIGS_CALLBACK" ]; then
         ;;
     esac
 
-    venv_targets="chpldoc test-venv"
+    venv_targets="test-venv chpldoc"
     case ",$components," in
     ( *,venv,* )
         log_info "Building Chapel component: venv ($venv_targets)"
@@ -333,15 +333,10 @@ else
     ( venv )
         load_prgenv_gnu
 
-        # If the installed libssl is too old to support TLS 1.1, some workarounds exist to
-        # enable building Chapel python-venv tools anyway.
-        # For example, the following gives a URL to a local PyPI mirror that accepts http,
-        # and the location of a pre-installed "pip" on the host machine.
+        # The following gives a URL to a local PyPI mirror that accepts http. It is optional for this build.
 
         export CHPL_EASY_INSTALL_PARAMS="-i http://slemaster.us.cray.com/pypi/simple"
         export CHPL_PIP_INSTALL_PARAMS="-i http://slemaster.us.cray.com/pypi/simple --trusted-host slemaster.us.cray.com"
-######  export CHPL_PIP=/cray/css/users/chapelu/opt/lib/pip/__main__.py
-######  export CHPL_PYTHONPATH=/cray/css/users/chapelu/opt/lib
         ;;
     ( "" )
         : ok

--- a/util/build_configs/cray-internal/setenv-xc-aarch64.bash
+++ b/util/build_configs/cray-internal/setenv-xc-aarch64.bash
@@ -1,0 +1,439 @@
+#!/usr/bin/env bash
+
+# setenv script to build a standard Chapel Cray module for release
+
+set +x -e
+
+if [ -z "$BUILD_CONFIGS_CALLBACK" ]; then
+
+# ==============
+# setenv project
+# ==============
+
+    setenv=$( basename "${BASH_SOURCE[0]}" )
+    cwd=$( cd $(dirname "${BASH_SOURCE[0]}") && pwd )
+    source $cwd/../functions.bash
+
+    # cmdline options
+
+    # current list of selected components initially empty
+    components=
+    valid_components="compiler,runtime,venv,venv_py27,mason,clean"
+    default_components="compiler,runtime,venv,mason"
+        ## clean is not default; more developer-friendly
+
+    usage() {
+        echo "Usage:  $setenv [-v] [-n]"
+        echo "  where"
+        echo "    -v : verbose/debug output"
+        echo "    -n : dry-run: show make commands but do not actually run them"
+        echo "    -B COMPONENT : Chapel component to build (optional, repeatable)"
+        echo "               Valid components: '$valid_components'"
+        echo "          Default if -B omitted: '$default_components'"
+        echo "          Selected components are always built in the order shown above."
+        echo "          COMPONENT may be prefixed with a plus sign or a minus sign."
+        echo "          For example, if '-B +clean' is given (as the only -B parameter),"
+        echo "          then the default list of components will be built, followed by"
+        echo "          'make cleanall'. If '-B clean' was given instead, then"
+        echo "          'make cleanall' would be the ONLY thing done by this script."
+        exit 1
+    }
+    while getopts :vnB:h opt; do
+        case $opt in
+        ( v ) verbose=-v ;;
+        ( n ) dry_run=-n ;;
+        ( B )
+            # ck valid component
+            case ",${OPTARG#[+-]}," in
+            ( *,compiler,* | *,runtime,* | *,venv,* | *,venv_py27,* | *,mason,* | *,clean,* ) ;;
+            ( * )   log_error "Invalid -B COMPONENT='$OPTARG'"; usage ;;
+            esac
+            # if + or - prefix, modify the current list of selected components
+            case "$OPTARG" in
+            ( +* )  components="${components:-$default_components}" ;;
+            ( -* )  components= ;;
+            esac
+            # add option to current list of selected components
+            components="${components:+$components,}$OPTARG"
+            ;;
+        ( h ) usage;;
+        ( \?) log_error "Invalid option: -$OPTARG"; usage;;
+        ( : ) log_error "Option -$OPTARG requires an argument."; usage;;
+        esac
+    done
+
+    log_info "Begin project $setenv"
+
+    export CHPL_HOME=${CHPL_HOME:-$( cd $cwd/../../.. && pwd )}
+    log_debug "with CHPL_HOME=$CHPL_HOME"
+    ck_chpl_home "$CHPL_HOME"
+
+    # if no components were given on cmdline, then use the default list
+    if [ -z "$components" ]; then
+        components=$default_components
+    fi
+    log_info "Selected Chapel components: $components"
+    log_info "Valid Chapel components:    $valid_components"
+
+    # Default config
+
+##  # If the CHPL_ env variable is NOT defined here (and not overridden
+##  # by build_configs.py cmdline arguments), Chapel make will determine
+##  # the appropriate default value for the platform / environment it finds.
+
+    export CHPL_HOST_PLATFORM=cray-xc
+    export CHPL_TARGET_PLATFORM=cray-xc
+    export CHPL_REGEXP=re2      # re2 required for mason
+    export CHPL_LOCAL_MODEL=flat
+    export CHPL_COMM=none
+    export CHPL_COMM_SUBSTRATE=none
+    export CHPL_TASKS=qthreads
+    export CHPL_LAUNCHER=none
+    export CHPL_LLVM=llvm       # llvm requires py27 and cmake
+    export CHPL_AUX_FILESYS=none
+
+    # More CPUs --> faster make. Or, unset CHPL_MAKE_MAX_CPU_COUNT to use all CPUs.
+
+#   export CHPL_MAKE_MAX_CPU_COUNT=${CHPL_MAKE_MAX_CPU_COUNT:-8}
+
+    # Show the initial/default Chapel build config with printchplenv
+
+    if [ -n "$verbose" ]; then
+        log_debug "Chapel printchplenv, with initial env:"
+        $CHPL_HOME/util/printchplenv --all --no-tidy --anonymize || echo >&2 ignore error
+    fi
+
+    # NOTE: The --target-compiler values used in this setenv project will never be
+    #       seen by Chapel make. They will be recognized (and discarded) in the
+    #       setenv callback script in the lower section of this file.
+
+    case "$components" in
+    ( *compiler* )
+        log_info "Building Chapel component: compiler"
+
+        log_info "Start build_configs $dry_run $verbose -- compiler"
+
+        $cwd/../build_configs.py -p $dry_run $verbose -s $cwd/$setenv -l "$project.compiler.log" \
+            --target-compiler=compiler -- compiler
+        ;;
+    ( * )
+        log_info "NO building Chapel component: compiler"
+        ;;
+    esac
+
+    case ",$components," in
+    ( *runtime* )
+        log_info "Building Chapel component: runtime"
+
+        compilers=cray,intel,gnu
+        comms=gasnet,none,ugni
+        launchers=pbs-aprun,aprun,none,slurm-srun
+        substrates=aries,mpi,none
+        locale_models=flat,knl
+        auxfs=none,lustre
+
+        log_info "Start build_configs $dry_run $verbose # no make target"
+
+        $cwd/../build_configs.py -p $dry_run $verbose -s $cwd/$setenv -l "$project.runtime.log" \
+            --target-compiler=$compilers \
+            --comm=$comms \
+            --launcher=$launchers \
+            --substrate=$substrates \
+            --locale-model=$locale_models \
+            --auxfs=$auxfs
+
+        # NOTE: "--target-compiler" values shown above will be discarded by the setenv callback.
+        ;;
+    ( * )
+        log_info "NO building Chapel component: runtime"
+        ;;
+    esac
+
+    venv_targets="test-venv chpldoc"
+    case ",$components," in
+    ( *,venv,* )
+        log_info "Building Chapel component: venv ($venv_targets)"
+
+        # Building Chapel python-venv tools requires a working internet connection and either:
+        # - modern version of libssl that supports TLS 1.1
+        # - local workarounds such as the variables shown in the "venv" callback, below.
+
+        log_info "Start build_configs $dry_run $verbose -- $venv_targets"
+
+        $cwd/../build_configs.py $dry_run $verbose -s $cwd/$setenv -l "$project.venv.log" \
+            --target-compiler=venv -- $venv_targets
+        ;;
+    ( * )
+        log_info "NO building Chapel component: venv"
+        ;;
+    esac
+
+    case ",$components," in
+    ( *,venv_py27,* )
+        log_info "Building Chapel component: venv_py27 ($venv_targets)"
+
+        # Alternate python version
+
+        log_info "Start build_configs $dry_run $verbose -- $venv_targets"
+
+        $cwd/../build_configs.py $dry_run $verbose -s $cwd/$setenv -l "$project.venv_py27.log" \
+            --target-compiler=venv_py27 -- $venv_targets
+
+        use_system_python="-C third-party/chpl-venv use-system-python"
+        log_info "Start build_configs $dry_run $verbose -- $use_system_python"
+
+        $cwd/../build_configs.py $dry_run $verbose -s $cwd/$setenv -l "$project.venv_py27-use_system_python.log" \
+            --target-compiler=venv_py27 -- $use_system_python
+        ;;
+    ( * )
+        log_info "NO building Chapel component: venv_py27"
+        ;;
+    esac
+
+    case "$components" in
+    ( *mason* )
+        log_info "Building Chapel component: mason"
+
+        log_info "Start build_configs $dry_run $verbose -- mason"
+
+        $cwd/../build_configs.py $dry_run $verbose -s $cwd/$setenv -l "$project.mason.log" \
+            --target-compiler=gnu -- mason
+        ;;
+    ( * )
+        log_info "NO building Chapel component: mason"
+        ;;
+    esac
+
+    clean_targets="cleanall"
+    case "$components" in
+    ( *clean* )
+        log_info "Building Chapel component: clean (make $clean_targets)"
+
+        log_info "Start build_configs $dry_run $verbose -- $clean_targets"
+
+        $cwd/../build_configs.py $dry_run $verbose -s $cwd/$setenv -l "$project.clean.log" \
+            --target-compiler=gnu -- $clean_targets
+        ;;
+    ( * )
+        log_info "NO building Chapel component: clean"
+        ;;
+    esac
+
+    log_info "End $setenv"
+else
+
+# ===============
+# setenv callback
+# ===============
+
+    setenv=$( basename "${BASH_SOURCE[0]}" )
+    cwd=$( cd $(dirname "${BASH_SOURCE[0]}") && pwd )
+    source $cwd/../functions.bash
+
+    log_info "Begin callback $setenv"
+    log_debug "with config=$BUILD_CONFIGS_CALLBACK"
+
+    # Exit immediately to skip (avoid building) unwanted Chapel configs
+
+    if [ "$CHPL_COMM" == ugni ]; then
+        if [ "$CHPL_LAUNCHER" == none ]; then
+
+            # skip Chapel make because comm == ugni needs a Chapel launcher
+            log_info "Skip Chapel make for comm=$CHPL_COMM, launcher=$CHPL_LAUNCHER"
+            exit 0
+        fi
+        if [ "$CHPL_COMM_SUBSTRATE" != none ]; then
+
+            # skip Chapel make because comm == ugni does not take a substrate
+            log_info "Skip Chapel make for comm=$CHPL_COMM, substrate=$CHPL_COMM_SUBSTRATE"
+            exit 0
+        fi
+        log_info "Unset CHPL_COMM_SUBSTRATE for comm=$CHPL_COMM, substrate=$CHPL_COMM_SUBSTRATE"
+        unset CHPL_COMM_SUBSTRATE
+    elif [ "$CHPL_COMM" == gasnet ]; then
+        if [ "$CHPL_COMM_SUBSTRATE" == none ]; then
+
+            # skip Chapel make because comm == gasnet needs a substrate
+            log_info "Skip Chapel make for comm=$CHPL_COMM, substrate=$CHPL_COMM_SUBSTRATE"
+            exit 0
+        fi
+    elif [ "$CHPL_COMM" == none ]; then
+        if [ "$CHPL_COMM_SUBSTRATE" != none ]; then
+
+            # skip Chapel make because we already built the runtime with comm=none
+            log_info "Skip Chapel make for comm=$CHPL_COMM, substrate=$CHPL_COMM_SUBSTRATE"
+            exit 0
+        fi
+        log_info "Unset CHPL_COMM_SUBSTRATE for comm=$CHPL_COMM, substrate=$CHPL_COMM_SUBSTRATE"
+        unset CHPL_COMM_SUBSTRATE
+    else
+        log_error "unrecognized CHPL_COMM=$CHPL_COMM"
+        exit 2
+    fi
+
+# =========================
+# setenv callback functions
+# =========================
+
+    source $cwd/../module-functions.bash
+
+    # check module system
+    ck_module_list
+
+    if [ -n "$verbose" ] ; then
+        log_debug "Module list (sorted), after build_configs, before setenv:"
+        list_loaded_modules
+    fi
+
+    gen_version_gcc=6.1.0
+    gen_version_intel=18.0.3.222
+    gen_version_cce=8.6.3
+    target_cpu_module=craype-sandybridge
+
+    function load_prgenv_gnu() {
+
+        local target_prgenv="PrgEnv-gnu"
+        local target_compiler="gcc"
+        local target_version=$gen_version_gcc
+
+        # unload any existing PrgEnv
+        unload_module_re PrgEnv-
+
+        # load target PrgEnv with compiler version
+        load_module $target_prgenv
+        load_module_version $target_compiler $target_version
+    }
+
+    function load_prgenv_intel() {
+
+        local target_prgenv="PrgEnv-intel"
+        local target_compiler="intel"
+        local target_version=$gen_version_intel
+
+        # unload any existing PrgEnv
+        unload_module_re PrgEnv-
+
+        # load target PrgEnv with compiler version
+        load_module $target_prgenv
+        load_module_version $target_compiler $target_version
+    }
+
+    function load_prgenv_cray() {
+
+        local target_prgenv="PrgEnv-cray"
+        local target_compiler="cce"
+        local target_version=$gen_version_cce
+
+        # unload any existing PrgEnv
+        unload_module_re PrgEnv-
+
+        # load target PrgEnv with compiler version
+        load_module $target_prgenv
+        load_module_version $target_compiler $target_version
+    }
+
+    function load_target_cpu() {
+
+        # legacy
+        unload_module perftools-base acml totalview atp cray-libsci xt-libsci
+        load_module cray-libsci
+
+        case "$1" in ( "" ) log_error "load_target_cpu missing arg 1"; exit 2;; esac
+        local target=$1
+
+        # target CPU: unload existing target-cpu modules, if any, then load our target-cpu
+        unload_module_re -v -network- craype-
+        load_module $target
+    }
+
+    function use_python27() {
+        log_info "Using Python 2.7 from /cray/css/users/chapelu/setup_python27.bash"
+        if [ ! -f /cray/css/users/chapelu/setup_python27.bash ] ; then
+            log_error "Python 2.7 setup script is not accessible at /cray/css/users/chapelu/setup_python27.bash"
+            exit 1
+        fi
+        source /cray/css/users/chapelu/setup_python27.bash
+    }
+
+    # ---
+
+    # NOTE: The CHPL_TARGET_COMPILER env values from build_configs are not passed to Chapel.
+    # Instead, they drive module load commands in the setenv callback
+
+    case "$CHPL_TARGET_COMPILER" in
+    ( gnu )
+        load_prgenv_gnu
+        ;;
+    ( intel )
+        load_prgenv_intel
+        ;;
+    ( cray )
+        load_prgenv_cray
+        ;;
+    ( compiler )
+        load_prgenv_gnu
+
+        if [ "$CHPL_LLVM" == llvm ]; then
+            # Chapel make compiler with LLVM requires python 2.7 and cmake >= 3.4.1
+            load_module cmake
+            use_python27
+        fi
+        ;;
+    ( venv )
+        load_prgenv_gnu
+
+        # If the installed libssl is too old to support TLS 1.1, some workarounds exist to
+        # enable building Chapel python-venv tools anyway.
+        # For example, the following gives a URL to a local PyPI mirror that accepts http,
+        # and the location of a pre-installed "pip" on the host machine.
+
+        export CHPL_EASY_INSTALL_PARAMS="-i http://slemaster.us.cray.com/pypi/simple"
+        export CHPL_PIP_INSTALL_PARAMS="-i http://slemaster.us.cray.com/pypi/simple --trusted-host slemaster.us.cray.com"
+        export CHPL_PIP=/cray/css/users/chapelu/opt/lib/pip/__main__.py
+        export CHPL_PYTHONPATH=/cray/css/users/chapelu/opt/lib
+        ;;
+    ( venv_py27 )
+        load_prgenv_gnu
+
+        # Alternate python version
+        use_python27
+
+        export CHPL_EASY_INSTALL_PARAMS="-i http://slemaster.us.cray.com/pypi/simple"
+        export CHPL_PIP_INSTALL_PARAMS="-i http://slemaster.us.cray.com/pypi/simple --trusted-host slemaster.us.cray.com"
+        export CHPL_PIP=/cray/css/users/chapelu/opt/lib/pip/__main__.py
+        export CHPL_PYTHONPATH=/cray/css/users/chapelu/opt/lib
+        ;;
+    ( "" )
+        : ok
+        ;;
+    ( * )
+        log_error "unrecognized CHPL_TARGET_COMPILER=$CHPL_TARGET_COMPILER"
+        exit 2
+        ;;
+    esac
+
+    # Discard the artificial CHPL_TARGET_COMPILER value.
+    # Chapel make will select cray-prgenv-gnu, cray-prgenv-intel, or cray-prgenv-cray,
+    # based on which module (PrgEnv-gnu, PrgEnv-intel, or PrgEnv-cray) it finds in the environment
+
+    unset CHPL_TARGET_COMPILER
+    load_target_cpu $target_cpu_module
+
+    if [ "$CHPL_AUX_FILESYS" == lustre ]; then
+        # on login/compute nodes, lustre requires the devel api to make
+        # lustre/lustreapi.h available (it's implicitly available on esl nodes)
+        if pkg-config --exists cray-lustre-api-devel; then
+            export CHPL_AUXIO_INCLUDE="$CHPL_AUXIO_INCLUDE $( pkg-config --cflags cray-lustre-api-devel )"
+            export CHPL_AUXIO_LIBS="$CHPL_AUXIO_LIBS $( pkg-config --libs cray-lustre-api-devel )"
+        fi
+    fi
+
+    # ---
+
+    if [ -n "$verbose" ] ; then
+        log_debug "Module list (sorted), after build_configs and setenv:"
+        list_loaded_modules
+    fi
+
+    log_info "End callback $setenv"
+fi

--- a/util/build_configs/cray-internal/setenv-xc-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-xc-x86_64.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# setenv script to build a standard Chapel Cray module for release
+# setenv script to build a standard Chapel Cray-XC module for release
 
 set +x -e
 
@@ -18,7 +18,7 @@ if [ -z "$BUILD_CONFIGS_CALLBACK" ]; then
 
     # current list of selected components initially empty
     components=
-    valid_components="compiler,runtime,venv,venv_py27,mason,clean"
+    valid_components="compiler,runtime,venv,mason,clean"
     default_components="compiler,runtime,venv,mason"
         ## clean is not default; more developer-friendly
 
@@ -45,7 +45,7 @@ if [ -z "$BUILD_CONFIGS_CALLBACK" ]; then
         ( B )
             # ck valid component
             case ",${OPTARG#[+-]}," in
-            ( *,compiler,* | *,runtime,* | *,venv,* | *,venv_py27,* | *,mason,* | *,clean,* ) ;;
+            ( *,compiler,* | *,runtime,* | *,venv,* | *,mason,* | *,clean,* ) ;;
             ( * )   log_error "Invalid -B COMPONENT='$OPTARG'"; usage ;;
             esac
             # if + or - prefix, modify the current list of selected components
@@ -121,7 +121,7 @@ if [ -z "$BUILD_CONFIGS_CALLBACK" ]; then
         ;;
     esac
 
-    case ",$components," in
+    case "$components" in
     ( *runtime* )
         log_info "Building Chapel component: runtime"
 

--- a/util/build_configs/cray-internal/setenv-xc-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-xc-x86_64.bash
@@ -92,9 +92,10 @@ if [ -z "$BUILD_CONFIGS_CALLBACK" ]; then
     export CHPL_LLVM=llvm       # llvm requires py27 and cmake
     export CHPL_AUX_FILESYS=none
 
-    # More CPUs --> faster make. Or, unset CHPL_MAKE_MAX_CPU_COUNT to use all CPUs.
+    # As a general rule, more CPUs --> faster make.
+    # To use all available CPUs, export CHPL_MAKE_MAX_CPU_COUNT=0 before running this setenv.
 
-#   export CHPL_MAKE_MAX_CPU_COUNT=${CHPL_MAKE_MAX_CPU_COUNT:-8}
+    export CHPL_MAKE_MAX_CPU_COUNT=${CHPL_MAKE_MAX_CPU_COUNT:-4}
 
     # Show the initial/default Chapel build config with printchplenv
 

--- a/util/build_configs/cray-internal/setenv-xc-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-xc-x86_64.bash
@@ -286,7 +286,7 @@ else
     fi
 
     gen_version_gcc=6.1.0
-    gen_version_intel=18.0.3.222
+    gen_version_intel=16.0.3.210
     gen_version_cce=8.6.3
     target_cpu_module=craype-sandybridge
 

--- a/util/build_configs/cray-internal/setenv-xc-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-xc-x86_64.bash
@@ -1,0 +1,439 @@
+#!/usr/bin/env bash
+
+# setenv script to build a standard Chapel Cray module for release
+
+set +x -e
+
+if [ -z "$BUILD_CONFIGS_CALLBACK" ]; then
+
+# ==============
+# setenv project
+# ==============
+
+    setenv=$( basename "${BASH_SOURCE[0]}" )
+    cwd=$( cd $(dirname "${BASH_SOURCE[0]}") && pwd )
+    source $cwd/../functions.bash
+
+    # cmdline options
+
+    # current list of selected components initially empty
+    components=
+    valid_components="compiler,runtime,venv,venv_py27,mason,clean"
+    default_components="compiler,runtime,venv,mason"
+        ## clean is not default; more developer-friendly
+
+    usage() {
+        echo "Usage:  $setenv [-v] [-n]"
+        echo "  where"
+        echo "    -v : verbose/debug output"
+        echo "    -n : dry-run: show make commands but do not actually run them"
+        echo "    -B COMPONENT : Chapel component to build (optional, repeatable)"
+        echo "               Valid components: '$valid_components'"
+        echo "          Default if -B omitted: '$default_components'"
+        echo "          Selected components are always built in the order shown above."
+        echo "          COMPONENT may be prefixed with a plus sign or a minus sign."
+        echo "          For example, if '-B +clean' is given (as the only -B parameter),"
+        echo "          then the default list of components will be built, followed by"
+        echo "          'make cleanall'. If '-B clean' was given instead, then"
+        echo "          'make cleanall' would be the ONLY thing done by this script."
+        exit 1
+    }
+    while getopts :vnB:h opt; do
+        case $opt in
+        ( v ) verbose=-v ;;
+        ( n ) dry_run=-n ;;
+        ( B )
+            # ck valid component
+            case ",${OPTARG#[+-]}," in
+            ( *,compiler,* | *,runtime,* | *,venv,* | *,venv_py27,* | *,mason,* | *,clean,* ) ;;
+            ( * )   log_error "Invalid -B COMPONENT='$OPTARG'"; usage ;;
+            esac
+            # if + or - prefix, modify the current list of selected components
+            case "$OPTARG" in
+            ( +* )  components="${components:-$default_components}" ;;
+            ( -* )  components= ;;
+            esac
+            # add option to current list of selected components
+            components="${components:+$components,}$OPTARG"
+            ;;
+        ( h ) usage;;
+        ( \?) log_error "Invalid option: -$OPTARG"; usage;;
+        ( : ) log_error "Option -$OPTARG requires an argument."; usage;;
+        esac
+    done
+
+    log_info "Begin project $setenv"
+
+    export CHPL_HOME=${CHPL_HOME:-$( cd $cwd/../../.. && pwd )}
+    log_debug "with CHPL_HOME=$CHPL_HOME"
+    ck_chpl_home "$CHPL_HOME"
+
+    # if no components were given on cmdline, then use the default list
+    if [ -z "$components" ]; then
+        components=$default_components
+    fi
+    log_info "Selected Chapel components: $components"
+    log_info "Valid Chapel components:    $valid_components"
+
+    # Default config
+
+##  # If the CHPL_ env variable is NOT defined here (and not overridden
+##  # by build_configs.py cmdline arguments), Chapel make will determine
+##  # the appropriate default value for the platform / environment it finds.
+
+    export CHPL_HOST_PLATFORM=cray-xc
+    export CHPL_TARGET_PLATFORM=cray-xc
+    export CHPL_REGEXP=re2      # re2 required for mason
+    export CHPL_LOCAL_MODEL=flat
+    export CHPL_COMM=none
+    export CHPL_COMM_SUBSTRATE=none
+    export CHPL_TASKS=qthreads
+    export CHPL_LAUNCHER=none
+    export CHPL_LLVM=llvm       # llvm requires py27 and cmake
+    export CHPL_AUX_FILESYS=none
+
+    # More CPUs --> faster make. Or, unset CHPL_MAKE_MAX_CPU_COUNT to use all CPUs.
+
+#   export CHPL_MAKE_MAX_CPU_COUNT=${CHPL_MAKE_MAX_CPU_COUNT:-8}
+
+    # Show the initial/default Chapel build config with printchplenv
+
+    if [ -n "$verbose" ]; then
+        log_debug "Chapel printchplenv, with initial env:"
+        $CHPL_HOME/util/printchplenv --all --no-tidy --anonymize || echo >&2 ignore error
+    fi
+
+    # NOTE: The --target-compiler values used in this setenv project will never be
+    #       seen by Chapel make. They will be recognized (and discarded) in the
+    #       setenv callback script in the lower section of this file.
+
+    case "$components" in
+    ( *compiler* )
+        log_info "Building Chapel component: compiler"
+
+        log_info "Start build_configs $dry_run $verbose -- compiler"
+
+        $cwd/../build_configs.py -p $dry_run $verbose -s $cwd/$setenv -l "$project.compiler.log" \
+            --target-compiler=compiler -- compiler
+        ;;
+    ( * )
+        log_info "NO building Chapel component: compiler"
+        ;;
+    esac
+
+    case ",$components," in
+    ( *runtime* )
+        log_info "Building Chapel component: runtime"
+
+        compilers=cray,intel,gnu
+        comms=gasnet,none,ugni
+        launchers=pbs-aprun,aprun,none,slurm-srun
+        substrates=aries,mpi,none
+        locale_models=flat,knl
+        auxfs=none,lustre
+
+        log_info "Start build_configs $dry_run $verbose # no make target"
+
+        $cwd/../build_configs.py -p $dry_run $verbose -s $cwd/$setenv -l "$project.runtime.log" \
+            --target-compiler=$compilers \
+            --comm=$comms \
+            --launcher=$launchers \
+            --substrate=$substrates \
+            --locale-model=$locale_models \
+            --auxfs=$auxfs
+
+        # NOTE: "--target-compiler" values shown above will be discarded by the setenv callback.
+        ;;
+    ( * )
+        log_info "NO building Chapel component: runtime"
+        ;;
+    esac
+
+    venv_targets="test-venv chpldoc"
+    case ",$components," in
+    ( *,venv,* )
+        log_info "Building Chapel component: venv ($venv_targets)"
+
+        # Building Chapel python-venv tools requires a working internet connection and either:
+        # - modern version of libssl that supports TLS 1.1
+        # - local workarounds such as the variables shown in the "venv" callback, below.
+
+        log_info "Start build_configs $dry_run $verbose -- $venv_targets"
+
+        $cwd/../build_configs.py $dry_run $verbose -s $cwd/$setenv -l "$project.venv.log" \
+            --target-compiler=venv -- $venv_targets
+        ;;
+    ( * )
+        log_info "NO building Chapel component: venv"
+        ;;
+    esac
+
+    case ",$components," in
+    ( *,venv_py27,* )
+        log_info "Building Chapel component: venv_py27 ($venv_targets)"
+
+        # Alternate python version
+
+        log_info "Start build_configs $dry_run $verbose -- $venv_targets"
+
+        $cwd/../build_configs.py $dry_run $verbose -s $cwd/$setenv -l "$project.venv_py27.log" \
+            --target-compiler=venv_py27 -- $venv_targets
+
+        use_system_python="-C third-party/chpl-venv use-system-python"
+        log_info "Start build_configs $dry_run $verbose -- $use_system_python"
+
+        $cwd/../build_configs.py $dry_run $verbose -s $cwd/$setenv -l "$project.venv_py27-use_system_python.log" \
+            --target-compiler=venv_py27 -- $use_system_python
+        ;;
+    ( * )
+        log_info "NO building Chapel component: venv_py27"
+        ;;
+    esac
+
+    case "$components" in
+    ( *mason* )
+        log_info "Building Chapel component: mason"
+
+        log_info "Start build_configs $dry_run $verbose -- mason"
+
+        $cwd/../build_configs.py $dry_run $verbose -s $cwd/$setenv -l "$project.mason.log" \
+            --target-compiler=gnu -- mason
+        ;;
+    ( * )
+        log_info "NO building Chapel component: mason"
+        ;;
+    esac
+
+    clean_targets="cleanall"
+    case "$components" in
+    ( *clean* )
+        log_info "Building Chapel component: clean (make $clean_targets)"
+
+        log_info "Start build_configs $dry_run $verbose -- $clean_targets"
+
+        $cwd/../build_configs.py $dry_run $verbose -s $cwd/$setenv -l "$project.clean.log" \
+            --target-compiler=gnu -- $clean_targets
+        ;;
+    ( * )
+        log_info "NO building Chapel component: clean"
+        ;;
+    esac
+
+    log_info "End $setenv"
+else
+
+# ===============
+# setenv callback
+# ===============
+
+    setenv=$( basename "${BASH_SOURCE[0]}" )
+    cwd=$( cd $(dirname "${BASH_SOURCE[0]}") && pwd )
+    source $cwd/../functions.bash
+
+    log_info "Begin callback $setenv"
+    log_debug "with config=$BUILD_CONFIGS_CALLBACK"
+
+    # Exit immediately to skip (avoid building) unwanted Chapel configs
+
+    if [ "$CHPL_COMM" == ugni ]; then
+        if [ "$CHPL_LAUNCHER" == none ]; then
+
+            # skip Chapel make because comm == ugni needs a Chapel launcher
+            log_info "Skip Chapel make for comm=$CHPL_COMM, launcher=$CHPL_LAUNCHER"
+            exit 0
+        fi
+        if [ "$CHPL_COMM_SUBSTRATE" != none ]; then
+
+            # skip Chapel make because comm == ugni does not take a substrate
+            log_info "Skip Chapel make for comm=$CHPL_COMM, substrate=$CHPL_COMM_SUBSTRATE"
+            exit 0
+        fi
+        log_info "Unset CHPL_COMM_SUBSTRATE for comm=$CHPL_COMM, substrate=$CHPL_COMM_SUBSTRATE"
+        unset CHPL_COMM_SUBSTRATE
+    elif [ "$CHPL_COMM" == gasnet ]; then
+        if [ "$CHPL_COMM_SUBSTRATE" == none ]; then
+
+            # skip Chapel make because comm == gasnet needs a substrate
+            log_info "Skip Chapel make for comm=$CHPL_COMM, substrate=$CHPL_COMM_SUBSTRATE"
+            exit 0
+        fi
+    elif [ "$CHPL_COMM" == none ]; then
+        if [ "$CHPL_COMM_SUBSTRATE" != none ]; then
+
+            # skip Chapel make because we already built the runtime with comm=none
+            log_info "Skip Chapel make for comm=$CHPL_COMM, substrate=$CHPL_COMM_SUBSTRATE"
+            exit 0
+        fi
+        log_info "Unset CHPL_COMM_SUBSTRATE for comm=$CHPL_COMM, substrate=$CHPL_COMM_SUBSTRATE"
+        unset CHPL_COMM_SUBSTRATE
+    else
+        log_error "unrecognized CHPL_COMM=$CHPL_COMM"
+        exit 2
+    fi
+
+# =========================
+# setenv callback functions
+# =========================
+
+    source $cwd/../module-functions.bash
+
+    # check module system
+    ck_module_list
+
+    if [ -n "$verbose" ] ; then
+        log_debug "Module list (sorted), after build_configs, before setenv:"
+        list_loaded_modules
+    fi
+
+    gen_version_gcc=6.1.0
+    gen_version_intel=18.0.3.222
+    gen_version_cce=8.6.3
+    target_cpu_module=craype-sandybridge
+
+    function load_prgenv_gnu() {
+
+        local target_prgenv="PrgEnv-gnu"
+        local target_compiler="gcc"
+        local target_version=$gen_version_gcc
+
+        # unload any existing PrgEnv
+        unload_module_re PrgEnv-
+
+        # load target PrgEnv with compiler version
+        load_module $target_prgenv
+        load_module_version $target_compiler $target_version
+    }
+
+    function load_prgenv_intel() {
+
+        local target_prgenv="PrgEnv-intel"
+        local target_compiler="intel"
+        local target_version=$gen_version_intel
+
+        # unload any existing PrgEnv
+        unload_module_re PrgEnv-
+
+        # load target PrgEnv with compiler version
+        load_module $target_prgenv
+        load_module_version $target_compiler $target_version
+    }
+
+    function load_prgenv_cray() {
+
+        local target_prgenv="PrgEnv-cray"
+        local target_compiler="cce"
+        local target_version=$gen_version_cce
+
+        # unload any existing PrgEnv
+        unload_module_re PrgEnv-
+
+        # load target PrgEnv with compiler version
+        load_module $target_prgenv
+        load_module_version $target_compiler $target_version
+    }
+
+    function load_target_cpu() {
+
+        # legacy
+        unload_module perftools-base acml totalview atp cray-libsci xt-libsci
+        load_module cray-libsci
+
+        case "$1" in ( "" ) log_error "load_target_cpu missing arg 1"; exit 2;; esac
+        local target=$1
+
+        # target CPU: unload existing target-cpu modules, if any, then load our target-cpu
+        unload_module_re -v -network- craype-
+        load_module $target
+    }
+
+    function use_python27() {
+        log_info "Using Python 2.7 from /cray/css/users/chapelu/setup_python27.bash"
+        if [ ! -f /cray/css/users/chapelu/setup_python27.bash ] ; then
+            log_error "Python 2.7 setup script is not accessible at /cray/css/users/chapelu/setup_python27.bash"
+            exit 1
+        fi
+        source /cray/css/users/chapelu/setup_python27.bash
+    }
+
+    # ---
+
+    # NOTE: The CHPL_TARGET_COMPILER env values from build_configs are not passed to Chapel.
+    # Instead, they drive module load commands in the setenv callback
+
+    case "$CHPL_TARGET_COMPILER" in
+    ( gnu )
+        load_prgenv_gnu
+        ;;
+    ( intel )
+        load_prgenv_intel
+        ;;
+    ( cray )
+        load_prgenv_cray
+        ;;
+    ( compiler )
+        load_prgenv_gnu
+
+        if [ "$CHPL_LLVM" == llvm ]; then
+            # Chapel make compiler with LLVM requires python 2.7 and cmake >= 3.4.1
+            load_module cmake
+            use_python27
+        fi
+        ;;
+    ( venv )
+        load_prgenv_gnu
+
+        # If the installed libssl is too old to support TLS 1.1, some workarounds exist to
+        # enable building Chapel python-venv tools anyway.
+        # For example, the following gives a URL to a local PyPI mirror that accepts http,
+        # and the location of a pre-installed "pip" on the host machine.
+
+        export CHPL_EASY_INSTALL_PARAMS="-i http://slemaster.us.cray.com/pypi/simple"
+        export CHPL_PIP_INSTALL_PARAMS="-i http://slemaster.us.cray.com/pypi/simple --trusted-host slemaster.us.cray.com"
+        export CHPL_PIP=/cray/css/users/chapelu/opt/lib/pip/__main__.py
+        export CHPL_PYTHONPATH=/cray/css/users/chapelu/opt/lib
+        ;;
+    ( venv_py27 )
+        load_prgenv_gnu
+
+        # Alternate python version
+        use_python27
+
+        export CHPL_EASY_INSTALL_PARAMS="-i http://slemaster.us.cray.com/pypi/simple"
+        export CHPL_PIP_INSTALL_PARAMS="-i http://slemaster.us.cray.com/pypi/simple --trusted-host slemaster.us.cray.com"
+        export CHPL_PIP=/cray/css/users/chapelu/opt/lib/pip/__main__.py
+        export CHPL_PYTHONPATH=/cray/css/users/chapelu/opt/lib
+        ;;
+    ( "" )
+        : ok
+        ;;
+    ( * )
+        log_error "unrecognized CHPL_TARGET_COMPILER=$CHPL_TARGET_COMPILER"
+        exit 2
+        ;;
+    esac
+
+    # Discard the artificial CHPL_TARGET_COMPILER value.
+    # Chapel make will select cray-prgenv-gnu, cray-prgenv-intel, or cray-prgenv-cray,
+    # based on which module (PrgEnv-gnu, PrgEnv-intel, or PrgEnv-cray) it finds in the environment
+
+    unset CHPL_TARGET_COMPILER
+    load_target_cpu $target_cpu_module
+
+    if [ "$CHPL_AUX_FILESYS" == lustre ]; then
+        # on login/compute nodes, lustre requires the devel api to make
+        # lustre/lustreapi.h available (it's implicitly available on esl nodes)
+        if pkg-config --exists cray-lustre-api-devel; then
+            export CHPL_AUXIO_INCLUDE="$CHPL_AUXIO_INCLUDE $( pkg-config --cflags cray-lustre-api-devel )"
+            export CHPL_AUXIO_LIBS="$CHPL_AUXIO_LIBS $( pkg-config --libs cray-lustre-api-devel )"
+        fi
+    fi
+
+    # ---
+
+    if [ -n "$verbose" ] ; then
+        log_debug "Module list (sorted), after build_configs and setenv:"
+        list_loaded_modules
+    fi
+
+    log_info "End callback $setenv"
+fi

--- a/util/build_configs/cray-internal/setenv-xe-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-xe-x86_64.bash
@@ -91,9 +91,10 @@ if [ -z "$BUILD_CONFIGS_CALLBACK" ]; then
     export CHPL_LLVM=llvm       # llvm requires py27 and cmake
     export CHPL_AUX_FILESYS=none
 
-    # More CPUs --> faster make. Or, unset CHPL_MAKE_MAX_CPU_COUNT to use all CPUs.
+    # As a general rule, more CPUs --> faster make.
+    # To use all available CPUs, export CHPL_MAKE_MAX_CPU_COUNT=0 before running this setenv.
 
-#   export CHPL_MAKE_MAX_CPU_COUNT=${CHPL_MAKE_MAX_CPU_COUNT:-8}
+    export CHPL_MAKE_MAX_CPU_COUNT=${CHPL_MAKE_MAX_CPU_COUNT:-1}
 
     # Show the initial/default Chapel build config with printchplenv
 

--- a/util/build_configs/cray-internal/setenv-xe-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-xe-x86_64.bash
@@ -1,0 +1,468 @@
+#!/usr/bin/env bash
+
+# setenv script to build a standard Chapel Cray module for release
+
+set +x -e
+
+if [ -z "$BUILD_CONFIGS_CALLBACK" ]; then
+
+# ==============
+# setenv project
+# ==============
+
+    setenv=$( basename "${BASH_SOURCE[0]}" )
+    cwd=$( cd $(dirname "${BASH_SOURCE[0]}") && pwd )
+    source $cwd/../functions.bash
+
+    # cmdline options
+
+    # current list of selected components initially empty
+    components=
+    valid_components="compiler,runtime,venv,venv_py27,mason,clean"
+    default_components="compiler,runtime,venv,mason"
+        ## clean is not default; more developer-friendly
+
+    usage() {
+        echo "Usage:  $setenv [-v] [-n]"
+        echo "  where"
+        echo "    -v : verbose/debug output"
+        echo "    -n : dry-run: show make commands but do not actually run them"
+        echo "    -B COMPONENT : Chapel component to build (optional, repeatable)"
+        echo "               Valid components: '$valid_components'"
+        echo "          Default if -B omitted: '$default_components'"
+        echo "          Selected components are always built in the order shown above."
+        echo "          COMPONENT may be prefixed with a plus sign or a minus sign."
+        echo "          For example, if '-B +clean' is given (as the only -B parameter),"
+        echo "          then the default list of components will be built, followed by"
+        echo "          'make cleanall'. If '-B clean' was given instead, then"
+        echo "          'make cleanall' would be the ONLY thing done by this script."
+        exit 1
+    }
+    while getopts :vnB:h opt; do
+        case $opt in
+        ( v ) verbose=-v ;;
+        ( n ) dry_run=-n ;;
+        ( B )
+            # ck valid component
+            case ",${OPTARG#[+-]}," in
+            ( *,compiler,* | *,runtime,* | *,venv,* | *,venv_py27,* | *,mason,* | *,clean,* ) ;;
+            ( * )   log_error "Invalid -B COMPONENT='$OPTARG'"; usage ;;
+            esac
+            # if + or - prefix, modify the current list of selected components
+            case "$OPTARG" in
+            ( +* )  components="${components:-$default_components}" ;;
+            ( -* )  components= ;;
+            esac
+            # add option to current list of selected components
+            components="${components:+$components,}$OPTARG"
+            ;;
+        ( h ) usage;;
+        ( \?) log_error "Invalid option: -$OPTARG"; usage;;
+        ( : ) log_error "Option -$OPTARG requires an argument."; usage;;
+        esac
+    done
+
+    log_info "Begin project $setenv"
+
+    export CHPL_HOME=${CHPL_HOME:-$( cd $cwd/../../.. && pwd )}
+    log_debug "with CHPL_HOME=$CHPL_HOME"
+    ck_chpl_home "$CHPL_HOME"
+
+    # if no components were given on cmdline, then use the default list
+    if [ -z "$components" ]; then
+        components=$default_components
+    fi
+    log_info "Selected Chapel components: $components"
+    log_info "Valid Chapel components:    $valid_components"
+
+    # Default config
+
+##  # If the CHPL_ env variable is NOT defined here (and not overridden
+##  # by build_configs.py cmdline arguments), Chapel make will determine
+##  # the appropriate default value for the platform / environment it finds.
+
+    export CHPL_HOST_PLATFORM=cray-xc
+    export CHPL_TARGET_PLATFORM=cray-xc
+    export CHPL_REGEXP=re2      # re2 required for mason
+    export CHPL_LOCAL_MODEL=flat
+    export CHPL_COMM=none
+    export CHPL_COMM_SUBSTRATE=none
+    export CHPL_TASKS=qthreads
+    export CHPL_LAUNCHER=none
+    export CHPL_LLVM=llvm       # llvm requires py27 and cmake
+    export CHPL_AUX_FILESYS=none
+
+    # More CPUs --> faster make. Or, unset CHPL_MAKE_MAX_CPU_COUNT to use all CPUs.
+
+#   export CHPL_MAKE_MAX_CPU_COUNT=${CHPL_MAKE_MAX_CPU_COUNT:-8}
+
+    # Show the initial/default Chapel build config with printchplenv
+
+    if [ -n "$verbose" ]; then
+        log_debug "Chapel printchplenv, with initial env:"
+        $CHPL_HOME/util/printchplenv --all --no-tidy --anonymize || echo >&2 ignore error
+    fi
+
+    # NOTE: The --target-compiler values used in this setenv project will never be
+    #       seen by Chapel make. They will be recognized (and discarded) in the
+    #       setenv callback script in the lower section of this file.
+
+    case "$components" in
+    ( *compiler* )
+        log_info "Building Chapel component: compiler"
+
+        log_info "Start build_configs $dry_run $verbose -- compiler"
+
+        $cwd/../build_configs.py -p $dry_run $verbose -s $cwd/$setenv -l "$project.compiler.log" \
+            --target-compiler=compiler -- compiler
+        ;;
+    ( * )
+        log_info "NO building Chapel component: compiler"
+        ;;
+    esac
+
+    case ",$components," in
+    ( *runtime* )
+        log_info "Building Chapel component: runtime"
+
+        compilers=cray,intel,gnu
+        comms=gasnet,none,ugni
+        launchers=pbs-aprun,aprun,none,slurm-srun
+        substrates=aries,mpi,none
+        locale_models=flat,knl
+        auxfs=none,lustre
+
+        log_info "Start build_configs $dry_run $verbose # no make target"
+
+        $cwd/../build_configs.py -p $dry_run $verbose -s $cwd/$setenv -l "$project.runtime.log" \
+            --target-compiler=$compilers \
+            --comm=$comms \
+            --launcher=$launchers \
+            --substrate=$substrates \
+            --locale-model=$locale_models \
+            --auxfs=$auxfs
+
+        # NOTE: "--target-compiler" values shown above will be discarded by the setenv callback.
+        ;;
+    ( * )
+        log_info "NO building Chapel component: runtime"
+        ;;
+    esac
+
+    venv_targets="test-venv chpldoc"
+    case ",$components," in
+    ( *,venv,* )
+
+        # Build Chapel python-venv tools with the system-installed Python, no matter which version
+
+        log_info "Building Chapel component: venv ($venv_targets)"
+
+        log_debug "Checking the system-installed Python"
+
+        pyLT27=$( /usr/bin/python -c "import sys; print(sys.version_info[0:2] < (2, 7))" || : ok )
+        whichPy=$( which python || : ok )
+        case "$pyLT27" in
+        ( False | True )
+            case "$whichPy" in
+            ( /usr/bin/python )
+                ;;
+            ( * )
+                log_error "Found unexpected path to default python executable: '$whichPy'"
+                log_error "The expected path was '/usr/bin/python'"
+                exit 2
+                ;;
+            esac
+            ;;
+        ( * )
+            log_error "/usr/bin/python broken or not found"
+            echo >&2 "stdout:'$pyLT27'"
+            ls -ldL >&2 /usr/bin/python || : ok
+            exit 2
+            ;;
+        esac
+
+            # Chapel python-venv tools requires a working internet connection and either:
+            # - modern version of libssl that supports TLS 1.1
+            # - local workarounds such as the variables shown in the "venv" callback, below.
+
+        log_info "Start build_configs $dry_run $verbose -- $venv_targets"
+
+        $cwd/../build_configs.py $dry_run $verbose -s $cwd/$setenv -l "$project.venv.log" \
+            --target-compiler=venv -- $venv_targets
+
+        if [ "$pyLT27" = "True" ]; then
+
+            # If the system-installed Python was 2.6, Build a second copy of Chapel
+            # python-venv tools using the alternate Python 2.7 installation,
+            # which must be implemented by the "venv_py27" callback, below.
+
+            log_info "Building Chapel component: venv ($venv_targets with venv_py27 callback)"
+
+            log_info "Start build_configs $dry_run $verbose -- $venv_targets"
+
+            $cwd/../build_configs.py $dry_run $verbose -s $cwd/$setenv -l "$project.venv_py27.log" \
+                --target-compiler=venv_py27 -- $venv_targets
+
+            # Custom Chapel make target to rm files or links named "python" from the installed py27
+            # bin dir, forcing users of the installed Chapel RPM to get "python" from the system.
+
+            use_system_python="-C third-party/chpl-venv use-system-python"
+
+            log_info "Start build_configs $dry_run $verbose -- $use_system_python"
+
+            $cwd/../build_configs.py $dry_run $verbose -s $cwd/$setenv -l "$project.venv_py27-use_system_python.log" \
+                --target-compiler=venv_py27 -- $use_system_python
+        fi
+        ;;
+    ( * )
+        log_info "NO building Chapel component: venv"
+        ;;
+    esac
+
+    case "$components" in
+    ( *mason* )
+        log_info "Building Chapel component: mason"
+
+        log_info "Start build_configs $dry_run $verbose -- mason"
+
+        $cwd/../build_configs.py $dry_run $verbose -s $cwd/$setenv -l "$project.mason.log" \
+            --target-compiler=gnu -- mason
+        ;;
+    ( * )
+        log_info "NO building Chapel component: mason"
+        ;;
+    esac
+
+    clean_targets="cleanall"
+    case "$components" in
+    ( *clean* )
+        log_info "Building Chapel component: clean (make $clean_targets)"
+
+        log_info "Start build_configs $dry_run $verbose -- $clean_targets"
+
+        $cwd/../build_configs.py $dry_run $verbose -s $cwd/$setenv -l "$project.clean.log" \
+            --target-compiler=gnu -- $clean_targets
+        ;;
+    ( * )
+        log_info "NO building Chapel component: clean"
+        ;;
+    esac
+
+    log_info "End $setenv"
+else
+
+# ===============
+# setenv callback
+# ===============
+
+    setenv=$( basename "${BASH_SOURCE[0]}" )
+    cwd=$( cd $(dirname "${BASH_SOURCE[0]}") && pwd )
+    source $cwd/../functions.bash
+
+    log_info "Begin callback $setenv"
+    log_debug "with config=$BUILD_CONFIGS_CALLBACK"
+
+    # Exit immediately to skip (avoid building) unwanted Chapel configs
+
+    if [ "$CHPL_COMM" == ugni ]; then
+        if [ "$CHPL_LAUNCHER" == none ]; then
+
+            # skip Chapel make because comm == ugni needs a Chapel launcher
+            log_info "Skip Chapel make for comm=$CHPL_COMM, launcher=$CHPL_LAUNCHER"
+            exit 0
+        fi
+        if [ "$CHPL_COMM_SUBSTRATE" != none ]; then
+
+            # skip Chapel make because comm == ugni does not take a substrate
+            log_info "Skip Chapel make for comm=$CHPL_COMM, substrate=$CHPL_COMM_SUBSTRATE"
+            exit 0
+        fi
+        log_info "Unset CHPL_COMM_SUBSTRATE for comm=$CHPL_COMM, substrate=$CHPL_COMM_SUBSTRATE"
+        unset CHPL_COMM_SUBSTRATE
+    elif [ "$CHPL_COMM" == gasnet ]; then
+        if [ "$CHPL_COMM_SUBSTRATE" == none ]; then
+
+            # skip Chapel make because comm == gasnet needs a substrate
+            log_info "Skip Chapel make for comm=$CHPL_COMM, substrate=$CHPL_COMM_SUBSTRATE"
+            exit 0
+        fi
+    elif [ "$CHPL_COMM" == none ]; then
+        if [ "$CHPL_COMM_SUBSTRATE" != none ]; then
+
+            # skip Chapel make because we already built the runtime with comm=none
+            log_info "Skip Chapel make for comm=$CHPL_COMM, substrate=$CHPL_COMM_SUBSTRATE"
+            exit 0
+        fi
+        log_info "Unset CHPL_COMM_SUBSTRATE for comm=$CHPL_COMM, substrate=$CHPL_COMM_SUBSTRATE"
+        unset CHPL_COMM_SUBSTRATE
+    else
+        log_error "unrecognized CHPL_COMM=$CHPL_COMM"
+        exit 2
+    fi
+
+# =========================
+# setenv callback functions
+# =========================
+
+    source $cwd/../module-functions.bash
+
+    # check module system
+    ck_module_list
+
+    if [ -n "$verbose" ] ; then
+        log_debug "Module list (sorted), after build_configs, before setenv:"
+        list_loaded_modules
+    fi
+
+    gen_version_gcc=6.1.0
+    gen_version_intel=16.0.3.210
+    gen_version_cce=8.6.3
+    target_cpu_module=craype-sandybridge
+
+    function load_prgenv_gnu() {
+
+        local target_prgenv="PrgEnv-gnu"
+        local target_compiler="gcc"
+        local target_version=$gen_version_gcc
+
+        # unload any existing PrgEnv
+        unload_module_re PrgEnv-
+
+        # load target PrgEnv with compiler version
+        load_module $target_prgenv
+        load_module_version $target_compiler $target_version
+    }
+
+    function load_prgenv_intel() {
+
+        local target_prgenv="PrgEnv-intel"
+        local target_compiler="intel"
+        local target_version=$gen_version_intel
+
+        # unload any existing PrgEnv
+        unload_module_re PrgEnv-
+
+        # load target PrgEnv with compiler version
+        load_module $target_prgenv
+        load_module_version $target_compiler $target_version
+    }
+
+    function load_prgenv_cray() {
+
+        local target_prgenv="PrgEnv-cray"
+        local target_compiler="cce"
+        local target_version=$gen_version_cce
+
+        # unload any existing PrgEnv
+        unload_module_re PrgEnv-
+
+        # load target PrgEnv with compiler version
+        load_module $target_prgenv
+        load_module_version $target_compiler $target_version
+    }
+
+    function load_target_cpu() {
+
+        # legacy
+        unload_module perftools-base acml totalview atp cray-libsci xt-libsci
+        load_module cray-libsci
+
+        case "$1" in ( "" ) log_error "load_target_cpu missing arg 1"; exit 2;; esac
+        local target=$1
+
+        # target CPU: unload existing target-cpu modules, if any, then load our target-cpu
+        unload_module_re -v -network- craype-
+        load_module $target
+    }
+
+    function use_python27() {
+        log_info "Using Python 2.7 from /cray/css/users/chapelu/setup_python27.bash"
+        if [ ! -f /cray/css/users/chapelu/setup_python27.bash ] ; then
+            log_error "Python 2.7 setup script is not accessible at /cray/css/users/chapelu/setup_python27.bash"
+            exit 1
+        fi
+        source /cray/css/users/chapelu/setup_python27.bash
+    }
+
+    # ---
+
+    # NOTE: The CHPL_TARGET_COMPILER env values from build_configs are not passed to Chapel.
+    # Instead, they drive module load commands in the setenv callback
+
+    case "$CHPL_TARGET_COMPILER" in
+    ( gnu )
+        load_prgenv_gnu
+        ;;
+    ( intel )
+        load_prgenv_intel
+        ;;
+    ( cray )
+        load_prgenv_cray
+        ;;
+    ( compiler )
+        load_prgenv_gnu
+
+        if [ "$CHPL_LLVM" == llvm ]; then
+            # Chapel make compiler with LLVM requires python 2.7 and cmake >= 3.4.1
+            load_module cmake
+            use_python27
+        fi
+        ;;
+    ( venv )
+        load_prgenv_gnu
+
+        # If the installed libssl is too old to support TLS 1.1, some workarounds exist to
+        # enable building Chapel python-venv tools anyway.
+        # For example, the following gives a URL to a local PyPI mirror that accepts http,
+        # and the location of a pre-installed "pip" on the host machine.
+
+        export CHPL_EASY_INSTALL_PARAMS="-i http://slemaster.us.cray.com/pypi/simple"
+        export CHPL_PIP_INSTALL_PARAMS="-i http://slemaster.us.cray.com/pypi/simple --trusted-host slemaster.us.cray.com"
+        export CHPL_PIP=/cray/css/users/chapelu/opt/lib/pip/__main__.py
+        export CHPL_PYTHONPATH=/cray/css/users/chapelu/opt/lib
+        ;;
+    ( venv_py27 )
+        load_prgenv_gnu
+
+        # Alternate python version
+        use_python27
+
+        export CHPL_EASY_INSTALL_PARAMS="-i http://slemaster.us.cray.com/pypi/simple"
+        export CHPL_PIP_INSTALL_PARAMS="-i http://slemaster.us.cray.com/pypi/simple --trusted-host slemaster.us.cray.com"
+        export CHPL_PIP=/cray/css/users/chapelu/opt/lib/pip/__main__.py
+        export CHPL_PYTHONPATH=/cray/css/users/chapelu/opt/lib
+        ;;
+    ( "" )
+        : ok
+        ;;
+    ( * )
+        log_error "unrecognized CHPL_TARGET_COMPILER=$CHPL_TARGET_COMPILER"
+        exit 2
+        ;;
+    esac
+
+    # Discard the artificial CHPL_TARGET_COMPILER value.
+    # Chapel make will select cray-prgenv-gnu, cray-prgenv-intel, or cray-prgenv-cray,
+    # based on which module (PrgEnv-gnu, PrgEnv-intel, or PrgEnv-cray) it finds in the environment
+
+    unset CHPL_TARGET_COMPILER
+    load_target_cpu $target_cpu_module
+
+    if [ "$CHPL_AUX_FILESYS" == lustre ]; then
+        # on login/compute nodes, lustre requires the devel api to make
+        # lustre/lustreapi.h available (it's implicitly available on esl nodes)
+        if pkg-config --exists cray-lustre-api-devel; then
+            export CHPL_AUXIO_INCLUDE="$CHPL_AUXIO_INCLUDE $( pkg-config --cflags cray-lustre-api-devel )"
+            export CHPL_AUXIO_LIBS="$CHPL_AUXIO_LIBS $( pkg-config --libs cray-lustre-api-devel )"
+        fi
+    fi
+
+    # ---
+
+    if [ -n "$verbose" ] ; then
+        log_debug "Module list (sorted), after build_configs and setenv:"
+        list_loaded_modules
+    fi
+
+    log_info "End callback $setenv"
+fi

--- a/util/build_configs/package-common.bash
+++ b/util/build_configs/package-common.bash
@@ -4,8 +4,7 @@
 # This expects bash functions log_debug, log_error, etc to be defined
 # (see functions.bash and package-functions.bash)
 
-thiscomm=$( basename ${BASH_SOURCE[0]} )
-log_debug "Begin $thiscomm"
+log_debug "Begin $( basename "${BASH_SOURCE[0]}" )"
 
 if [ -n "${verbose:-}" ]; then
     log_info "Using -v (verbose)"
@@ -35,10 +34,10 @@ fi
 # date_ymd,
 #   date_hms    : date and time for use within the pkg, in YYYYMMDD and HHMMSS
 
-case "${chpl_platform:=}"   in ( "" | *\ * | */* )  log_error "$thiscomm: Invalid chpl_platform='$chpl_platform'";  exit 2;; esac
-case "${date_ymd:=}"        in ( "" | *[!0-9]* )    log_error "$thiscomm: Invalid date_ymd='$date_ymd'";            exit 2;; esac
-case "${date_hms:=}"        in ( "" | *[!0-9]* )    log_error "$thiscomm: Invalid date_hms='$date_hms'";            exit 2;; esac
-case "${rc_number:=0}"      in ( *[!0-9]* )         log_error "$thiscomm: Invalid rc_number='$rc_number'";          exit 2;; esac
+case "${chpl_platform:=}"   in ( "" | *\ * | */* )  log_error "$( basename "${BASH_SOURCE[0]}" ): Invalid chpl_platform='$chpl_platform'";  exit 2;; esac
+case "${date_ymd:=}"        in ( "" | *[!0-9]* )    log_error "$( basename "${BASH_SOURCE[0]}" ): Invalid date_ymd='$date_ymd'";            exit 2;; esac
+case "${date_hms:=}"        in ( "" | *[!0-9]* )    log_error "$( basename "${BASH_SOURCE[0]}" ): Invalid date_hms='$date_hms'";            exit 2;; esac
+case "${rc_number:=0}"      in ( *[!0-9]* )         log_error "$( basename "${BASH_SOURCE[0]}" ): Invalid rc_number='$rc_number'";          exit 2;; esac
 
 ck_chpl_home_bin "$CHPL_HOME" $chpl_platform
 
@@ -53,26 +52,26 @@ case "${release_type:=}" in
 ( [dD]* | developer )
     case "${src_version:=}" in
     ( "" | *[!0-9a-z.]* | *.*.*.*.* | *..* | .* | *. )
-        log_error "$thiscomm: Invalid src_version='$src_version' for release_type '$release_type'"; exit 2
+        log_error "$( basename "${BASH_SOURCE[0]}" ): Invalid src_version='$src_version' for release_type '$release_type'"; exit 2
         ;;
     ( *.*.*.* )
         read major minor update gitrev junk <<<$( tr '.' ' ' <<<$src_version )
         ;;
     ( * )
-        log_error "$thiscomm: Invalid src_version='$src_version' for release_type '$release_type'"; exit 2
+        log_error "$( basename "${BASH_SOURCE[0]}" ): Invalid src_version='$src_version' for release_type '$release_type'"; exit 2
         ;;
     esac
     ;;
 ( * )
     case "${src_version:=}" in
     ( "" | *[!0-9.]* | *.*.*.* | *..* | .* | *. )
-        log_error "$thiscomm: Invalid src_version='$src_version' for release_type '$release_type'"; exit 2
+        log_error "$( basename "${BASH_SOURCE[0]}" ): Invalid src_version='$src_version' for release_type '$release_type'"; exit 2
         ;;
     ( *.*.* )
         read major minor update junk <<<$( tr '.' ' ' <<<$src_version )
         ;;
     ( * )
-        log_error "$thiscomm: Invalid src_version='$src_version' for release_type '$release_type'"; exit 2
+        log_error "$( basename "${BASH_SOURCE[0]}" ): Invalid src_version='$src_version' for release_type '$release_type'"; exit 2
         ;;
     esac
     ;;
@@ -81,7 +80,7 @@ esac
 # version_tag may be null; if non-null, it must not begin with a _ character
 case "${version_tag:=}" in
 ( *[!0-9a-zA-Z_]* | _* | *_ )
-    log_error "$thiscomm: Invalid version_tag='$version_tag'"; exit 2
+    log_error "$( basename "${BASH_SOURCE[0]}" ): Invalid version_tag='$version_tag'"; exit 2
     ;;
 esac
 
@@ -99,7 +98,7 @@ case "${release_type:=}" in
     pkg_version=$major.$minor.$update${version_tag:+_}$version_tag.$gitrev
     ;;
 ( * )
-    log_error "$thiscomm: Invalid release_type='$release_type'"
+    log_error "$( basename "${BASH_SOURCE[0]}" ): Invalid release_type='$release_type'"
     exit 2
     ;;
 esac
@@ -122,4 +121,4 @@ export rc_number
 export date_ymd
 export date_hms
 
-log_debug "End $thiscomm"
+log_debug "End $( basename "${BASH_SOURCE[0]}" )"

--- a/util/build_configs/setenv-example-1.bash
+++ b/util/build_configs/setenv-example-1.bash
@@ -47,7 +47,7 @@ if [ -z "$BUILD_CONFIGS_CALLBACK" ]; then
 
     # CHPL_HOME from the environment, or default to this Chapel workspace
 
-    export CHPL_HOME=${CHPL_HOME:-$( cd $( dirname "$0" )/../.. && pwd )}
+    export CHPL_HOME=${CHPL_HOME:-$( cd $( dirname "${BASH_SOURCE[0]}" )/../.. && pwd )}
 
     # Default Chapel build config values may be defined here
 

--- a/util/build_configs/setenv-example-2.bash
+++ b/util/build_configs/setenv-example-2.bash
@@ -20,8 +20,8 @@ if [ -z "$BUILD_CONFIGS_CALLBACK" ]; then
 
     # setenv, cwd == name and directory location of this script file
 
-    setenv=$( basename "$0" )
-    cwd=$( cd $(dirname "$0") && pwd )
+    setenv=$( basename "${BASH_SOURCE[0]}" )
+    cwd=$( cd $(dirname "${BASH_SOURCE[0]}") && pwd )
 
     # functions.bash provides local bash functions like log_info, and
     #   sets shell variable project from the filename of this setenv file

--- a/util/build_configs/setenv-example-3.bash
+++ b/util/build_configs/setenv-example-3.bash
@@ -16,8 +16,8 @@ if [ -z "$BUILD_CONFIGS_CALLBACK" ]; then
 # setenv project
 # ==============
 
-    setenv=$( basename "$0" )
-    cwd=$( cd $(dirname "$0") && pwd )
+    setenv=$( basename "${BASH_SOURCE[0]}" )
+    cwd=$( cd $(dirname "${BASH_SOURCE[0]}") && pwd )
     source $cwd/functions.bash
 
     # cmdline options


### PR DESCRIPTION
Adds three new setenv scripts scripts to build Chapel Cray RPMs of various types, in util/build_configs/cray-internal. These setenv scripts are based on the setenv-example-3 script in the parent directory, and their basic structure is the  same.  However, many details were added to successfully build a complete Chapel Cray module, including Python-venv, chpldoc, mason, 192 runtime configs, etc.
- setenv-xc-x86_64:  Chapel Cray-XC module for x86_64
- setenv-xc-aarch64: Chapel Cray-XC module for aarch64 (ARM)
- setenv-xe-x86_64:  Chapel Cray-XE module for x86_64

Many related changes in existing files: 
* are backward-compatible
* support the new cray-internal setenv scripts 
* were needed for the packaging process to accurately reproduce Chapel Cray Module RPMs.

Note: none of this will Chapel's current build and test automation in any way, until related changes in chapel-code and chapel-ci-config repositories are merged. Only then will Jenkins try to use these scripts for anything. This PR can go in any time, without waiting for the related changes. 

Commit summary:
* build_configs: New release_type "developer" uses BUILD_VERSION in packaging
* build_configs: Use ${BASH_SOURCE[0]} instead of $0 for bash script filenames
* build_configs: prettier output when running hundreds of configs
* build_configs/cray: Add setenv-xc-x86_64.bash for Chapel Cray XC modules
* build_configs/cray: Copy setenv-xc-x86_64.bash -> setenv-xc-aarch64.bash
* build_configs/cray: fix setenv-xc-x86_64 correct intel gen version
* build_configs/cray: Implement setenv-xc-aarch64.bash
* build_configs/cray: Make clean before packaging the Chapel Cray Module
* build_configs/cray: chapel-package script may use existing release_info file
* build_configs/cray: chapel-build script needs to forget venv_py27
* build_configs/cray: setenv-xc-x86_64 builds venv_py27 automatically if needed
* build_configs: README updates
* build_configs/cray: Copy setenv-xc-x86_64.bash -> setenv-xe-x86_64.bash
* build_configs/cray: Implement setenv-xe-x86_64.bash
* build_configs/cray: Minor cosmetic corrections to working setenv scripts