### PR TITLE
Better error messages for trying to create nil refs

### DIFF
--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -2212,12 +2212,6 @@ static void normRefVar(DefExpr* defExpr) {
                    "References must be initialized when they are defined.");
   }
 
-  if (SymExpr* initSym = toSymExpr(init)) {
-    if (initSym->symbol() == gNil) {
-      USR_FATAL_CONT(var, "References must be non-nil");
-    }
-  }
-
   // If this is a const reference to an immediate, we need to insert a temp
   // variable so we can take the address of it, non-const references to an
   // immediate are not allowed.
@@ -2255,8 +2249,12 @@ static void normRefVar(DefExpr* defExpr) {
     }
 
     if (error == true) {
-      USR_FATAL_CONT(sym,
-                     "Cannot set a non-const reference to a const variable.");
+      SymExpr* initSym = toSymExpr(init);
+      if (initSym && initSym->symbol() == gNil)
+        USR_FATAL_CONT(sym, "Cannot create a non-const reference to nil");
+      else
+        USR_FATAL_CONT(sym,
+                       "Cannot set a non-const reference to a const variable.");
     }
   }
 

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -2212,6 +2212,12 @@ static void normRefVar(DefExpr* defExpr) {
                    "References must be initialized when they are defined.");
   }
 
+  if (SymExpr* initSym = toSymExpr(init)) {
+    if (initSym->symbol() == gNil) {
+      USR_FATAL_CONT(var, "References must be non-nil");
+    }
+  }
+
   // If this is a const reference to an immediate, we need to insert a temp
   // variable so we can take the address of it, non-const references to an
   // immediate are not allowed.

--- a/test/statements/ferguson/ref-to-nil.chpl
+++ b/test/statements/ferguson/ref-to-nil.chpl
@@ -1,0 +1,2 @@
+const ref x = nil;
+ref y = nil;

--- a/test/statements/ferguson/ref-to-nil.good
+++ b/test/statements/ferguson/ref-to-nil.good
@@ -1,3 +1,1 @@
-ref-to-nil.chpl:1: error: References must be non-nil
-ref-to-nil.chpl:2: error: References must be non-nil
-ref-to-nil.chpl:2: error: Cannot set a non-const reference to a const variable.
+ref-to-nil.chpl:2: error: Cannot create a non-const reference to nil

--- a/test/statements/ferguson/ref-to-nil.good
+++ b/test/statements/ferguson/ref-to-nil.good
@@ -1,0 +1,3 @@
+ref-to-nil.chpl:1: error: References must be non-nil
+ref-to-nil.chpl:2: error: References must be non-nil
+ref-to-nil.chpl:2: error: Cannot set a non-const reference to a const variable.


### PR DESCRIPTION
Resolves #11257.

Gives a better error message for programs such as
``` chapel
ref x = nil;
```

Intentionally does not give an error for the `const ref` case such as
``` chapel
const ref y = nil;
```
since this would be allowed for integer literals and `nil` can be considered analogous.

- [x] full local testing

Reviewed by @lydia-duncan - thanks!