### PR TITLE
Added a comment with a TODO item

### DIFF
--- a/modules/internal/ChapelIteratorSupport.chpl
+++ b/modules/internal/ChapelIteratorSupport.chpl
@@ -76,6 +76,8 @@ module ChapelIteratorSupport {
   }
 
   proc iteratorToArrayElementType(type t:_iteratorRecord) type {
+    // Todo: chpl__unref() may be unnecessary. Ensure this test passes:
+    //   test/expressions/loop-expr/zip-arrays.chpl
     return chpl__unref(
       chpl_buildStandInRTT(__primitive("scalar promotion type", t)) );
   }


### PR DESCRIPTION
@mppf suggests that chpl__unref() is no longer necessary.
