### PR TITLE
Enable LLVM assertions for ASSERTS=1 builds

### DIFF
--- a/doc/rst/usingchapel/building.rst
+++ b/doc/rst/usingchapel/building.rst
@@ -131,6 +131,7 @@ are described below. Set the value to 1 to enable the feature.
   OPTIMIZE  Enable optimizations (e.g. add -O3 to C compiler).
   PROFILE   Enable profiling support (e.g. add -pg to C compiler).
   WARNINGS  Promote backend C compiler warnings to errors.
+  ASSERTS   Enables correctness assertions in the compiler and runtime.
   ========  =======================================================
 
 

--- a/third-party/llvm/Makefile
+++ b/third-party/llvm/Makefile
@@ -9,7 +9,14 @@ include $(CHPL_MAKE_HOME)/make/Makefile.base
 ifdef CHPL_LLVM_DEVELOPER
 CHPL_LLVM_DEBUG = -DCMAKE_BUILD_TYPE=Debug -DLLVM_OPTIMIZED_TABLEGEN=1
 else
+
+# activate LLVM asserts if it's a WARNINGS=1 build
+ifeq ($(WARNINGS), 1)
+CHPL_LLVM_DEBUG = -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=ON
+else
 CHPL_LLVM_DEBUG = -DCMAKE_BUILD_TYPE=Release
+endif
+
 endif
 
 LLVM_SRC_FILE := llvm/CMakeLists.txt

--- a/third-party/llvm/Makefile
+++ b/third-party/llvm/Makefile
@@ -7,16 +7,24 @@ include $(CHPL_MAKE_HOME)/make/Makefile.base
 
 # decide whether to do a debug or no-debug build
 ifdef CHPL_LLVM_DEVELOPER
-CHPL_LLVM_DEBUG = -DCMAKE_BUILD_TYPE=Debug -DLLVM_OPTIMIZED_TABLEGEN=1
+  CHPL_LLVM_DEBUG := -DCMAKE_BUILD_TYPE=Debug -DLLVM_OPTIMIZED_TABLEGEN=1
 else
-
-# activate LLVM asserts if it's a WARNINGS=1 build
-ifeq ($(WARNINGS), 1)
-CHPL_LLVM_DEBUG = -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=ON
-else
-CHPL_LLVM_DEBUG = -DCMAKE_BUILD_TYPE=Release
+  CHPL_LLVM_DEBUG := -DCMAKE_BUILD_TYPE=Release
 endif
 
+# activate LLVM asserts if it's from `make ASSERTS=1`
+# or if CHPL_DEVELOPER is set
+CHPL_LLVM_ASSERTS := 0
+ifdef CHPL_DEVELOPER
+  CHPL_LLVM_ASSERTS := 1
+endif
+
+ifeq ($(ASSERTS),1)
+  CHPL_LLVM_ASSERTS := 1
+endif
+
+ifeq ($(CHPL_LLVM_ASSERTS),1)
+  CHPL_LLVM_DEBUG += -DLLVM_ENABLE_ASSERTIONS=ON
 endif
 
 LLVM_SRC_FILE := llvm/CMakeLists.txt

--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -28,6 +28,7 @@ $valgrind = 0;
 $interpret = 0;
 $printusage = 1;
 $debug = 1;
+$asserts = 0;
 $runtests = 1;
 $buildruntime = 1;
 $hello = 0;
@@ -150,6 +151,8 @@ while (@ARGV) {
         $llvm = 1;
     } elsif ($flag eq "-junit-xml") {
         $junit_xml = 1;
+    } elsif ($flag eq "-asserts") {
+        $asserts = 1;
     } else {
         $printusage = 1;
         last;
@@ -481,7 +484,7 @@ if ($hostplatform =~ "cygwin") {
 $hostcompiler = `$utildir/chplenv/chpl_compiler.py --host`; chomp($hostcompiler);
 
 # Setup variables to pass to all make calls.
-$make_vars_no_opt = "DEBUG=0 WARNINGS=1";
+$make_vars_no_opt = "DEBUG=0 WARNINGS=1 ASSERTS=$asserts";
 
 # Add OPTIMIZE=1 for most environments. If using the cray programming
 # environment, disable optimizations when building the compiler. This is an

--- a/util/cron/test-llvm.bash
+++ b/util/cron/test-llvm.bash
@@ -14,7 +14,7 @@ source $CWD/common-localnode-paratest.bash
 unset CHPL_NIGHTLY_TEST_DIRS
 
 # paratest with 8 nodes on localhost
-nightly_args="${nightly_args} $(set +x ; get_nightly_paratest_args 8)"
+nightly_args="${nightly_args} $(set +x ; get_nightly_paratest_args 8) -asserts"
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="llvm"
 


### PR DESCRIPTION
Resolves #11266.

- [x] verified CHPL_DEVELOPER gets an asserts build of LLVM
- [x] verified `make ASSERTS=1` gets an asserts build of LLVM
- [x] verified nightly command runs hellos

Reviewed by @ronawho - thanks!