### PR TITLE
Add chpl_task_getFixedNumThreads(), and one implementation thereof.

### DIFF
--- a/runtime/include/chpl-tasks.h
+++ b/runtime/include/chpl-tasks.h
@@ -339,10 +339,11 @@ int32_t chpl_task_getNumBlockedTasks(void);
 // Threads
 
 //
-// If the tasking layer runs tasks on a fixed number of threads, and has
-// been initialized, this returns the number of such threads.  Otherwise
-// it returns 0 (zero).  As examples, for CHPL_TASKS=qthreads it returns
-// the number of worker threads, while for CHPL_TASKS=fifo it returns 0.
+// If the tasking layer runs tasks on a fixed number of threads, this
+// returns the number of such threads.  Otherwise it returns 0 (zero).
+// As examples, for CHPL_TASKS=qthreads it returns the number of worker
+// threads, while for CHPL_TASKS=fifo it returns 0.  If this is called
+// prior to tasking layer initialization the result is unpredictable.
 //
 #ifndef CHPL_TASK_IMPL_GET_FIXED_NUM_THREADS
 #define CHPL_TASK_IMPL_GET_FIXED_NUM_THREADS() 0

--- a/runtime/include/chpl-tasks.h
+++ b/runtime/include/chpl-tasks.h
@@ -339,6 +339,20 @@ int32_t chpl_task_getNumBlockedTasks(void);
 // Threads
 
 //
+// If the tasking layer runs tasks on a fixed number of threads, and has
+// been initialized, this returns the number of such threads.  Otherwise
+// it returns 0 (zero).  As examples, for CHPL_TASKS=qthreads it returns
+// the number of worker threads, while for CHPL_TASKS=fifo it returns 0.
+//
+#ifndef CHPL_TASK_IMPL_GET_FIXED_NUM_THREADS
+#define CHPL_TASK_IMPL_GET_FIXED_NUM_THREADS() 0
+#endif
+static inline
+uint32_t chpl_task_getFixedNumThreads(void) {
+  return CHPL_TASK_IMPL_GET_FIXED_NUM_THREADS();
+}
+
+//
 // returns the total number of threads that currently exist, whether running,
 // blocked, or idle
 //

--- a/runtime/include/tasks/qthreads/chpl-tasks-impl.h
+++ b/runtime/include/tasks/qthreads/chpl-tasks-impl.h
@@ -231,6 +231,12 @@ void chpl_task_setSubloc(c_sublocid_t full_subloc)
     }
 }
 
+
+#define CHPL_TASK_IMPL_GET_FIXED_NUM_THREADS() \
+    chpl_task_impl_getFixedNumThreads()
+uint32_t chpl_task_impl_getFixedNumThreads(void);
+
+
 //
 // Can we support remote caching?
 //

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -1029,9 +1029,8 @@ int32_t chpl_task_getNumBlockedTasks(void)
 // Threads
 
 uint32_t chpl_task_impl_getFixedNumThreads(void) {
-    if (chpl_qthread_done_initializing)
-        return (uint32_t)qthread_num_workers();
-    return 0;
+    assert(chpl_qthread_done_initializing);
+    return (uint32_t)qthread_num_workers();
 }
 
 uint32_t chpl_task_getNumThreads(void)

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -1030,8 +1030,8 @@ int32_t chpl_task_getNumBlockedTasks(void)
 
 uint32_t chpl_task_impl_getFixedNumThreads(void) {
     if (chpl_qthread_done_initializing)
-        return 0;
-    return (uint32_t)qthread_num_workers();
+        return (uint32_t)qthread_num_workers();
+    return 0;
 }
 
 uint32_t chpl_task_getNumThreads(void)

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -1028,6 +1028,12 @@ int32_t chpl_task_getNumBlockedTasks(void)
 
 // Threads
 
+uint32_t chpl_task_impl_getFixedNumThreads(void) {
+    if (chpl_qthread_done_initializing)
+        return 0;
+    return (uint32_t)qthread_num_workers();
+}
+
 uint32_t chpl_task_getNumThreads(void)
 {
     return (uint32_t)qthread_num_workers();


### PR DESCRIPTION
Add a new tasking layer function that, if the implementation runs tasks
by hosting them on a fixed number of threads, returns the number of such
threads.  Otherwise it returns 0 (zero).  So far only tasks=qthreads
returns a non-zero value for this function.  tasks=massivethreads would
do so as well, I believe, but for now I've left that as future work.
For tasks=fifo this function returns 0.

This will be used in the comm=ofi implementation, and we have discussed
using it in the comm=ugni implementation.