### PR TITLE
Cleanup upon an error in initCopy(_iteratorRecord)

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -4212,6 +4212,7 @@ module ChapelArray {
   }
 
   pragma "init copy fn"
+  pragma "unchecked throws"
   proc chpl__initCopy(ir: _iteratorRecord) {
 
     // We'd like to know the yielded type of the record, but we can't
@@ -4235,6 +4236,8 @@ module ChapelArray {
 
     var callAgain: bool;
     var subloc = c_sublocid_none;
+
+   try {
 
     for elt in ir {
 
@@ -4276,6 +4279,13 @@ module ChapelArray {
       i += 1;
     }
 
+   } catch exceptn {
+     // Exit early without creating an array below. Clean up first.
+     for j in 0..#i do
+       chpl__autoDestroy(data[j]);
+     _ddata_free(data, size);
+     throw exceptn; // re-throw
+   }
 
     if data != nil {
 
@@ -4323,12 +4333,4 @@ module ChapelArray {
       compilerWarning("initializing a non-distributed domain from a distributed domain. If you didn't mean to do that, add a dmapped clause to the type expression or remove the type expression altogether");
   }
 
-  /* ================================================
-     Set Operations on Associative Domains and Arrays
-     ================================================
-
-     Associative domains and arrays support a number of operators for
-     set manipulations.
-
-   */
 }

--- a/test/errhandling/ferguson/loopexprs-uncaught.good
+++ b/test/errhandling/ferguson/loopexprs-uncaught.good
@@ -1,3 +1,3 @@
 uncaught Error: 
-  loopexprs-uncaught.chpl:3: thrown here
+  loopexprs-uncaught.chpl:7: thrown here
   loopexprs-uncaught.chpl:6: uncaught here

--- a/test/errhandling/ferguson/loopexprs-uncaught.readme
+++ b/test/errhandling/ferguson/loopexprs-uncaught.readme
@@ -1,0 +1,6 @@
+We would like the "thrown here" line number in .good to be 3, not 7.
+See #11300.
+
+The main point of the test is to ensure the exception is reported,
+not specifically about the line number. So we leave 7 in .good for now,
+until #11300 is resolved.


### PR DESCRIPTION
When creating an array using a loop expression and the computation
of a to-be array element throws an exception, do not create the array.
Instead, clean up the to-be array elements that have already been computed.

This came from observing the bug in #11301, where initCopy(_iteratorRecord)
is the function in which pragma "init copy fn" interferes.
I added the pragma "unchecked throws" so that client code does not have
to insert try or throws annotations.

I needed to adjust .good due to #11300. I added a .readme to explain
that the .good is not the ultimately-desired output.

This removes memory leaks in the tests:

    test/errhandling/ferguson/loopexprs-caught.chpl
    test/errhandling/ferguson/loopexprs-uncaught.chpl

While there, removed a stray comment, as suggested by DavidI.

Future work:
* Add similar cleanup to the shape-ful version of initCopy(_iteratorRecord).
* Split the tests loopexprs-caught, loopexprs-uncaught so that all three
  variants on creating an array using a loop expression get tested.
* Test the case where it is the iterator that throws, not the computation
  of the current element.

Testing:
- [ ] linux64 -futures
- [ ] valgrind
