### PR TITLE
Resolve some global array-of-array leaks

### DIFF
--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -364,8 +364,18 @@ Expr* Symbol::getInitialization() const {
   FnSymbol* fn = toFnSymbol(defPoint->parentSymbol);
   ModuleSymbol* mod = toModuleSymbol(defPoint->parentSymbol);
   if (fn == NULL && mod != NULL ) {
-    // Global variables are initialized in their module init function
-    fn = mod->initFn;
+    // Global variables are initialized in their module init function, unless
+    // it's used in a loopexpr wrapper function for an array type.
+    //
+    // BHARSH 2018-10-03: A temporary at global scope whose first SymExpr
+    // is inside a loopexpr wrapper *should* have been initialized in that
+    // wrapper function.
+    if (firstSymExpr()->getFunction()->hasFlag(FLAG_MAYBE_ARRAY_TYPE) &&
+        this->hasFlag(FLAG_TEMP)) {
+      fn = firstSymExpr()->getFunction();
+    } else {
+      fn = mod->initFn;
+    }
   }
 
   Expr* stmt;

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -1844,19 +1844,21 @@ static void evaluateAutoDestroy(CallExpr* call, VarSymbol* tmp) {
     tmp->addFlag(FLAG_INSERT_AUTO_DESTROY);
   }
 
-  // MPF 2016-10-20
-  // This is a workaround for a problem in
-  //   types/typedefs/bradc/arrayTypedef
-  //
-  // I'm sure that there is a better way to handle this either in the
-  // module init function or in a sequence of forall-expr functions
-  // computing an array type that are in a module init fn
+  FnSymbol* initFn = fn->getModule()->initFn;
 
-  while (fn->hasFlag(FLAG_MAYBE_ARRAY_TYPE) == true) {
-    fn = fn->defPoint->getFunction();
-  }
+  // Sometimes an array type is represented with a loop-expression, so we
+  // need to hoist the resulting runtime type into global scope so that it
+  // isn't destroyed at the end of the loop-expr wrapper function.
+  bool isGlobalLoopExpr = fn->hasFlag(FLAG_MAYBE_ARRAY_TYPE) &&
+                          fn->defPoint->getFunction() == initFn;
 
-  if (fn == fn->getModule()->initFn) {
+  // This code used to look at any call in the initFn, and could trigger for
+  // temporaries in nested scopes (e.g. a param for-loop). We should only look
+  // for top-level calls/temps.
+  bool isCandidateGlobal = fn == initFn &&
+                           fn->body == call->getStmtExpr()->parentExpr;
+
+  if (isGlobalLoopExpr || isCandidateGlobal) {
     CallExpr* cur = parentCall;
     CallExpr* sub = call;
 
@@ -1878,6 +1880,8 @@ static void evaluateAutoDestroy(CallExpr* call, VarSymbol* tmp) {
     }
 
     if (cur) {
+      // Add to a set of temps to be hoisted into module scope, and later
+      // auto-destroyed in the module deinit.
       globalTemps.insert(tmp);
     }
   }


### PR DESCRIPTION
Prior to this PR the compiler would find temps in the module init function that were related to runtime types and flag them such that they were not auto-destroyed. This resulted in some leaks for arrays-of-arrays and type aliases to arrays-of-arrays.

This PR instead hoists those temps to be global, does not apply any flags, and lets them be destroyed in the module deinit function.

Resolves #11264 
Resolves #5660 

Testing:
- [x] local + futures
- [x] gasnet + futures
- [x] memleaks (~50 fewer tests leaking, about ~12K less memory leaked)
- [x] valgrind