### PR TITLE
Minor cleanup in dsiDestroyArr and autoDestroy

### DIFF
--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -990,22 +990,16 @@ module DefaultRectangular {
     override proc dsiGetBaseDom() return dom;
 
     proc dsiDestroyDataHelper(dd, ddiNumIndices) {
-      pragma "no copy" pragma "no auto destroy" var dr = dd;
-      pragma "no copy" pragma "no auto destroy" var dv = __primitive("deref", dr);
+      compilerAssert(chpl_isDdata(dd.type));
       for i in 0..ddiNumIndices-1 {
-        pragma "no copy" pragma "no auto destroy" var er = __primitive("array_get", dv, i);
-        pragma "no copy" pragma "no auto destroy" var ev = __primitive("deref", er);
-        chpl__autoDestroy(ev);
+        chpl__autoDestroy(dd[i]);
       }
     }
 
     override proc dsiDestroyArr() {
       if dom.dsiNumIndices > 0 {
-        pragma "no copy" pragma "no auto destroy" var dr = data;
-        pragma "no copy" pragma "no auto destroy" var dv = __primitive("deref", dr);
-        pragma "no copy" pragma "no auto destroy" var er = __primitive("array_get", dv, 0);
-        pragma "no copy" pragma "no auto destroy" var ev = __primitive("deref", er);
-        param needsDestroy = __primitive("needs auto destroy", ev);
+        param needsDestroy = __primitive("needs auto destroy",
+                                         __primitive("deref", data[0]));
         if needsDestroy {
           var numElts:intIdxType = 0;
           // dataAllocRange may be empty or contain a meaningful value

--- a/modules/internal/OwnedObject.chpl
+++ b/modules/internal/OwnedObject.chpl
@@ -359,8 +359,8 @@ module OwnedObject {
   // chpl__autoDestroy(x:object) from internal coercions.
   pragma "no doc"
   pragma "auto destroy fn"
-  proc chpl__autoDestroy(x: _owned) {
-    __primitive("call destructor", x);
+  proc chpl__autoDestroy(ref x: _owned) {
+    __primitive("call destructor", __primitive("deref", x));
   }
 
   // Don't print out 'chpl_p' when printing an _owned, just print class pointer

--- a/modules/internal/SharedObject.chpl
+++ b/modules/internal/SharedObject.chpl
@@ -358,8 +358,8 @@ module SharedObject {
   // This is a workaround
   pragma "no doc"
   pragma "auto destroy fn"
-  proc chpl__autoDestroy(x: _shared) {
-    __primitive("call destructor", x);
+  proc chpl__autoDestroy(ref x: _shared) {
+    __primitive("call destructor", __primitive("deref", x));
   }
 
   // Don't print out 'chpl_p' when printing an Shared, just print class pointer


### PR DESCRIPTION
* Remove bunch of pragmas and primitives in dsiDestroyArr and
  dsiDestroyDataHelper. These data back to 2016 or earlier.

* Switch to explicit 'ref' intent for the formal for chpl__autoDestroy
  on owned and shared. I need this so I can call chpl__autoDestroy()
  in some cases in my other work. This required an explicit dereference
  of the formal in the chpl__autoDestroy body - otherwise the compiler
  leaves the body empty. I did not investigate this, however I think
  that the compiler sees a pointer and concludes that nothing is needed
  to destroy it.

Tested: linux64, valgrind, memleaks.

Discussed with / suggested by @mppf.