### PR TITLE
Resolve some leaks in user code

### DIFF
--- a/test/distributions/bradc/assoc/UserMapAssoc.chpl
+++ b/test/distributions/bradc/assoc/UserMapAssoc.chpl
@@ -487,7 +487,7 @@ class UserMapAssocDom: BaseAssociativeDom {
   }
 
   proc setup() {
-    for localeIdx in dist.targetLocDom do
+    coforall localeIdx in dist.targetLocDom do
       on dist.targetLocales(localeIdx) do
         if (locDoms(localeIdx) == nil) then
           locDoms(localeIdx) = new unmanaged LocUserMapAssocDom(idxType=idxType,
@@ -510,7 +510,7 @@ class UserMapAssocDom: BaseAssociativeDom {
   }
 
   proc dsiDestroyDom() {
-    for localeIdx in dist.targetLocDom do
+    coforall localeIdx in dist.targetLocDom do
       on dist.targetLocales(localeIdx) do
         delete locDoms(localeIdx);
   }

--- a/test/distributions/bradc/assoc/UserMapAssoc.chpl
+++ b/test/distributions/bradc/assoc/UserMapAssoc.chpl
@@ -508,6 +508,12 @@ class UserMapAssocDom: BaseAssociativeDom {
   proc dsiReprivatize(other) {
     locDoms = other.locDoms;
   }
+
+  proc dsiDestroyDom() {
+    for localeIdx in dist.targetLocDom do
+      on dist.targetLocales(localeIdx) do
+        delete locDoms(localeIdx);
+  }
 }
 
 
@@ -655,6 +661,12 @@ class UserMapAssocArr: BaseArr {
       //locAssocDoms += locDomImpl;
       //locArrsByAssoc[locDomImpl] = locArrs(localeIdx);
     }
+  }
+
+  proc dsiDestroyArr() {
+    coforall localeIdx in dom.dist.targetLocDom do
+      on dom.dist.targetLocales(localeIdx) do
+        delete locArrs(localeIdx);
   }
 
   proc dsiSupportsPrivatization() param return true;

--- a/test/distributions/bradc/assoc/userAssoc-array-domain-zipper.chpl
+++ b/test/distributions/bradc/assoc/userAssoc-array-domain-zipper.chpl
@@ -2,7 +2,7 @@ use UserMapAssoc;
 
 config const verbose = false;
 
-class MyMapper {
+record MyMapper {
   proc indexToLocaleIndex(ind, targetLocs: [] locale) {
     const numlocs = targetLocs.domain.size;
     const indAsInt = ind: int;
@@ -10,7 +10,7 @@ class MyMapper {
   }
 }
 
-var myMapper = new unmanaged MyMapper();
+var myMapper = new MyMapper();
 var newDist = new dmap(new unmanaged UserMapAssoc(idxType=real, mapper=myMapper));
 
 var D: domain(real) dmapped newDist;

--- a/test/distributions/bradc/assoc/userAssoc-array-noelt.chpl
+++ b/test/distributions/bradc/assoc/userAssoc-array-noelt.chpl
@@ -1,6 +1,6 @@
 use UserMapAssoc;
 
-class MyMapper {
+record MyMapper {
   proc indexToLocaleIndex(ind, targetLocs: [] locale) : int {
     const numlocs = targetLocs.domain.size;
     const indAsInt = ind: int;
@@ -8,7 +8,7 @@ class MyMapper {
   }
 }
 
-var newDist = new dmap(new unmanaged UserMapAssoc(idxType=real, mapper=new unmanaged MyMapper()));
+var newDist = new dmap(new unmanaged UserMapAssoc(idxType=real, mapper=new MyMapper()));
 
 var D: domain(real) dmapped newDist;
 

--- a/test/distributions/bradc/assoc/userAssoc-array-priv-check.chpl
+++ b/test/distributions/bradc/assoc/userAssoc-array-priv-check.chpl
@@ -1,6 +1,6 @@
 use UserMapAssoc;
 
-class MyMapper {
+record MyMapper {
   proc indexToLocaleIndex(ind, targetLocs: [] locale) : int {
     const numlocs = targetLocs.domain.size;
     const indAsInt = ind: int;
@@ -9,7 +9,7 @@ class MyMapper {
 }
 
 proc doit() {
-  var newDist = new dmap(new unmanaged UserMapAssoc(idxType=real, mapper=new unmanaged MyMapper()));
+  var newDist = new dmap(new unmanaged UserMapAssoc(idxType=real, mapper=new MyMapper()));
 
   var D: domain(real) dmapped newDist;
 

--- a/test/distributions/bradc/assoc/userAssoc-basic-array.chpl
+++ b/test/distributions/bradc/assoc/userAssoc-basic-array.chpl
@@ -1,6 +1,6 @@
 use UserMapAssoc;
 
-class MyMapper {
+record MyMapper {
   proc indexToLocaleIndex(ind, targetLocs: [] locale) : int {
     const numlocs = targetLocs.domain.size;
     const indAsInt = ind: int;
@@ -8,7 +8,7 @@ class MyMapper {
   }
 }
 
-var newDist = new dmap(new unmanaged UserMapAssoc(idxType=real, mapper=new unmanaged MyMapper()));
+var newDist = new dmap(new unmanaged UserMapAssoc(idxType=real, mapper=new MyMapper()));
 
 var D: domain(real) dmapped newDist;
 

--- a/test/distributions/bradc/assoc/userAssoc-basic-domain.chpl
+++ b/test/distributions/bradc/assoc/userAssoc-basic-domain.chpl
@@ -1,6 +1,6 @@
 use UserMapAssoc;
 
-class MyMapper {
+record MyMapper {
   proc indexToLocaleIndex(ind, targetLocs: [] locale) : int {
     const numlocs = targetLocs.domain.size;
     const indAsInt = ind: int;
@@ -8,7 +8,7 @@ class MyMapper {
   }
 }
 
-var newDist = new dmap(new unmanaged UserMapAssoc(idxType=real, mapper=new unmanaged MyMapper()));
+var newDist = new dmap(new unmanaged UserMapAssoc(idxType=real, mapper=new MyMapper()));
 
 var D: domain(real) dmapped newDist;
 

--- a/test/distributions/bradc/assoc/userAssoc-domain-priv-check.chpl
+++ b/test/distributions/bradc/assoc/userAssoc-domain-priv-check.chpl
@@ -1,6 +1,6 @@
 use UserMapAssoc;
 
-class MyMapper {
+record MyMapper {
   proc indexToLocaleIndex(ind, targetLocs: [] locale) : int {
     const numlocs = targetLocs.domain.size;
     const indAsInt = ind: int;
@@ -9,7 +9,7 @@ class MyMapper {
 }
 
 proc doit() {
-  var newDist = new dmap(new unmanaged UserMapAssoc(idxType=real, mapper=new unmanaged MyMapper()));
+  var newDist = new dmap(new unmanaged UserMapAssoc(idxType=real, mapper=new MyMapper()));
 
   var D: domain(real) dmapped newDist;
 

--- a/test/studies/hpcc/RA/diten/buckets.chpl
+++ b/test/studies/hpcc/RA/diten/buckets.chpl
@@ -44,9 +44,9 @@ class Buckets {
 
   const numLocs: int = numLocales;
   var pendingUpdates = 0;
-  var BucketArray: [0..#numLocs] unmanaged Bucket = [0..#numLocs] new unmanaged Bucket(nil, 0);
-  var heap = new unmanaged MaxHeap(numLocs);
-  var updateManager = new unmanaged UpdateManager();
+  var BucketArray: [0..#numLocs] Bucket = [0..#numLocs] new borrowed Bucket(nil, 0);
+  var heap = new borrowed MaxHeap(numLocs);
+  var updateManager = new borrowed UpdateManager();
 
   proc insertUpdate(ran: uint(64), loc: int) {
     local {

--- a/test/studies/hpcc/RA/diten/ra.chpl
+++ b/test/studies/hpcc/RA/diten/ra.chpl
@@ -154,6 +154,8 @@ proc main() {
 
   const validAnswer = verifyResults();             // verify the updates
   printResults(validAnswer, execTime);             // print the results
+
+  for loc in Locales do on loc do delete myBuckets;
 }
 
 //

--- a/test/studies/hpcc/RA/diten/ra.good
+++ b/test/studies/hpcc/RA/diten/ra.good
@@ -1,4 +1,4 @@
-ra.chpl:185: warning: atomic statement is ignored (not implemented)
+ra.chpl:187: warning: atomic statement is ignored (not implemented)
 Problem size = 1024 (2**10)
 Bytes per array = 8192
 Total memory required (GB) = 7.62939e-06

--- a/test/studies/hpcc/common/bradc/unit/leadFollowOpt.chpl
+++ b/test/studies/hpcc/common/bradc/unit/leadFollowOpt.chpl
@@ -2,10 +2,10 @@ use BlockDist;
 
 var Dist = new dmap(new Block(boundingBox={1..9}));
 
-var D1 = Dist.newRectangularDom(1, int(64), false);
-var D2 = Dist.newRectangularDom(1, int(64), false);
-D1.dsiSetIndices({1..9});
-D2.dsiSetIndices({2..10});
+var D1 = _newDomain(Dist.newRectangularDom(1, int(64), false));
+var D2 = _newDomain(Dist.newRectangularDom(1, int(64), false));
+D1.setIndices({1..9});
+D2.setIndices({2..10});
 
 forall (i,j) in zip(D1, D2) do
   writeln("(i,j) is: ", (i,j));

--- a/test/studies/hpcc/common/bradc/unit/parBlock1D.chpl
+++ b/test/studies/hpcc/common/bradc/unit/parBlock1D.chpl
@@ -2,13 +2,10 @@ use BlockDist;
 
 var Dist = new dmap(new Block(boundingBox={1..9}));
 
-var D1 = Dist.newRectangularDom(1, int(64), false);
-var D2 = Dist.newRectangularDom(1, int(64), false);
-D1.dsiSetIndices({1..9});
-D2.dsiSetIndices({2..10});
+var D1 = _newDomain(Dist.newRectangularDom(1, int(64), false));
+var D2 = _newDomain(Dist.newRectangularDom(1, int(64), false));
+D1.setIndices({1..9});
+D2.setIndices({2..10});
 
 forall (i,j) in zip(D1, D2) do
   writeln("on ", here.id, ", (i,j) is: ", (i,j));
-
-delete D2;
-delete D1;


### PR DESCRIPTION
This PR updates some tests such that they no longer leak (or leak less). The highlights include:
- not break-ing from a loop (leaking iter classes)
- adding dsiDestroy* methods to a non-standard domain map
- more use of ``borrowed`` over ``unmanaged``

Testing:
- [x] local + futures
- [x] gasnet + futures
- [x] memleaks (down to ~25K leaked)