### PR TITLE
Address problems with ffloatOpt in --llvm

### DIFF
--- a/test/studies/parboil/stencil/stencilSerial.compopts
+++ b/test/studies/parboil/stencil/stencilSerial.compopts
@@ -1,0 +1,1 @@
+--ieee-float


### PR DESCRIPTION
ffloatOpt can have 3 values but one spot only handled 0,!=0
additionally other compilers fuse multiply-add by default,
so we will do so as well.

I noticed these issues while investigating issue #11154.

- [x] full local --llvm testing

Reviewed by @dmk42 - thanks!