### PR TITLE
Add common functions to snprintf() nnn[KMG] values.

### DIFF
--- a/runtime/include/chpl-format.h
+++ b/runtime/include/chpl-format.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2004-2018 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ * 
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * 
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _chpl_format_h_
+#define _chpl_format_h_
+
+#include <inttypes.h>
+
+//
+// snprintf() a size as nnn[KMG]
+//
+int chpl_snprintf_KMG_z(char* buf, int bufSize, size_t val);
+int chpl_snprintf_KMG_f(char* buf, int bufSize, double val);
+
+#endif // _chpl_format_h_

--- a/runtime/src/Makefile.share
+++ b/runtime/src/Makefile.share
@@ -36,6 +36,7 @@ COMMON_NOGEN_SRCS = \
 	chplexit.c \
 	chpl-external-array.c \
 	chpl-file-utils.c \
+	chpl-format.c \
 	chplio.c \
 	chpl-mem.c \
 	chpl-mem-desc.c \

--- a/runtime/src/chpl-format.c
+++ b/runtime/src/chpl-format.c
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2004-2018 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ * 
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * 
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//
+// Formatted output support.
+//
+
+#include "chplrt.h"
+
+#include "chpl-format.h"
+
+#include <inttypes.h>
+#include <stdio.h>
+
+
+static const size_t KiB = (size_t) (1UL << 10);
+static const size_t MiB = (size_t) (1UL << 20);
+static const size_t GiB = (size_t) (1UL << 30);
+
+
+//
+// snprintf() a size as nnn[KMG]
+//
+
+int chpl_snprintf_KMG_z(char* buf, int bufSize, size_t val) {
+  if (val >= GiB)
+    return snprintf(buf, bufSize, "%zdG", val / GiB);
+  else if (val >= MiB)
+    return snprintf(buf, bufSize, "%zdM", val / MiB);
+  else if (val >= KiB)
+    return snprintf(buf, bufSize, "%zdK", val / KiB);
+  return snprintf(buf, bufSize, "%zd", val);
+}
+
+
+int chpl_snprintf_KMG_f(char* buf, int bufSize, double val) {
+  if (val >= GiB)
+    return snprintf(buf, bufSize, "%.1fG", val / GiB);
+  else if (val >= MiB)
+    return snprintf(buf, bufSize, "%.1fM", val / MiB);
+  else if (val >= KiB)
+    return snprintf(buf, bufSize, "%.1fK", val / KiB);
+  return snprintf(buf, bufSize, "%.1f", val);
+}

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -59,6 +59,7 @@
 #include "chpl-comm-strd-xfer.h"
 #include "chpl-env.h"
 #include "chplexit.h"
+#include "chpl-format.h"
 #include "chpl-mem.h"
 #include "chpl-mem-desc.h"
 #include "chpl-mem-sys.h"
@@ -1449,8 +1450,6 @@ static void      polling_task(void*);
 static void      set_up_for_polling(void);
 static void      ensure_registered_heap_info_set(void);
 static void      make_registered_heap(void);
-static void      printf_KMG_size_t(char*, int, size_t);
-static void      printf_KMG_double(char*, int, double);
 static size_t    get_hugepage_size(void);
 static void      set_hugepage_info(void);
 static void      install_SIGBUS_handler(void);
@@ -3018,9 +3017,9 @@ void make_registered_heap(void)
   if (nic_type == GNI_DEVICE_GEMINI && size > max_heap_size) {
     if (chpl_nodeID == 0) {
       char buf1[20], buf2[20], buf3[20], msg[200];
-      printf_KMG_size_t(buf1, sizeof(buf1), nic_max_mem);
-      printf_KMG_size_t(buf2, sizeof(buf2), page_size);
-      printf_KMG_double(buf3, sizeof(buf3), max_heap_size);
+      chpl_snprintf_KMG_z(buf1, sizeof(buf1), nic_max_mem);
+      chpl_snprintf_KMG_z(buf2, sizeof(buf2), page_size);
+      chpl_snprintf_KMG_f(buf3, sizeof(buf3), max_heap_size);
       (void) snprintf(msg, sizeof(msg),
                       "Gemini TLB can cover %s with %s pages; heap "
                       "reduced to %s to fit",
@@ -3065,9 +3064,9 @@ void make_registered_heap(void)
   if (nic_type == GNI_DEVICE_ARIES && size > max_heap_size) {
     if (chpl_nodeID == 0) {
       char buf1[20], buf2[20], buf3[20], msg[200];
-      printf_KMG_size_t(buf1, sizeof(buf1), nic_max_mem);
-      printf_KMG_size_t(buf2, sizeof(buf2), page_size);
-      printf_KMG_double(buf3, sizeof(buf3), size);
+      chpl_snprintf_KMG_z(buf1, sizeof(buf1), nic_max_mem);
+      chpl_snprintf_KMG_z(buf2, sizeof(buf2), page_size);
+      chpl_snprintf_KMG_f(buf3, sizeof(buf3), size);
       (void) snprintf(msg, sizeof(msg),
                       "Aries TLB cache can cover %s with %s pages; "
                       "with %s heap,\n"
@@ -3081,36 +3080,6 @@ void make_registered_heap(void)
   registered_heap_start = start;
   registered_heap_info_set = 1;
   atomic_thread_fence(memory_order_release);
-}
-
-
-static
-void printf_KMG_size_t(char* buf, int len, size_t val)
-{
-  const size_t GiB = (size_t) (1UL << 30);
-  const size_t MiB = (size_t) (1UL << 20);
-  const size_t KiB = (size_t) (1UL << 10);
-  if (val >= GiB)
-    (void) snprintf(buf, len, "%zdG", val / GiB);
-  else if (val >= MiB)
-    (void) snprintf(buf, len, "%zdM", val / MiB);
-  else
-    (void) snprintf(buf, len, "%zdK", val / KiB);
-}
-
-
-static
-void printf_KMG_double(char* buf, int len, double val)
-{
-  const double GiB = (double) (1UL << 30);
-  const double MiB = (double) (1UL << 20);
-  const double KiB = (double) (1UL << 10);
-  if (val >= GiB)
-    (void) snprintf(buf, len, "%.1fG", val / GiB);
-  else if (val >= MiB)
-    (void) snprintf(buf, len, "%.1fM", val / MiB);
-  else
-    (void) snprintf(buf, len, "%.1fK", val / KiB);
 }
 
 


### PR DESCRIPTION
comm=ugni had a couple of internal functions for `snprintf()`ing a value
of type `size_t` or `double`, in the form 'nnnG', 'nnnM', or 'nnnK' based on
whether they were >= `2**30`, >= `2**20`, or otherwise.  Here, publicize
these for common use in chpl-format, adjust them to properly handle
values less than `2**10`, and replace use of the originals in the ugni
comm layer.

We will use these in comm=ofi soon also.