### PR TITLE
Add fixed heap support.

### DIFF
--- a/runtime/include/comm/ofi/chpl-comm-impl.h
+++ b/runtime/include/comm/ofi/chpl-comm-impl.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2004-2018 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _chpl_comm_impl_h_
+#define _chpl_comm_impl_h_
+
+//
+// This is the comm layer sub-interface for dynamic allocation and
+// registration of memory.
+//
+#define CHPL_COMM_IMPL_REG_MEM_HEAP_INFO(start_p, size_p) \
+    chpl_comm_impl_regMemHeapInfo(start_p, size_p)
+void chpl_comm_impl_regMemHeapInfo(void** start_p, size_t* size_p);
+
+#define CHPL_COMM_IMPL_REG_MEM_HEAP_PAGE_SIZE() \
+        chpl_comm_impl_regMemHeapPageSize()
+size_t chpl_comm_impl_regMemHeapPageSize(void);
+
+#endif // _chpl_comm_impl_h_

--- a/runtime/src/comm/ofi/Makefile.share
+++ b/runtime/src/comm/ofi/Makefile.share
@@ -22,16 +22,16 @@ COMM_SRCS = \
 	$(COMM_LAUNCHER_SRCS) \
 	comm-ofi.c
 
+#
+# Use PMI out-of-band support on Cray X*, "sockets" everywhere else.
+# Use hugepages only on Cray X*, so far.
+#
 ifneq (, $(filter cray-x%,$(CHPL_MAKE_TARGET_PLATFORM)))
-  #
-  # Use PMI out-of-band support on Cray X*.
-  #
   COMM_SRCS += comm-ofi-oob-pmi.c
+  COMM_SRCS += comm-ofi-hugepages.c
 else
-  #
-  # Use "sockets" out-of-band support everywhere else.
-  #
   COMM_SRCS += comm-ofi-oob-sockets.c
+  COMM_SRCS += comm-ofi-no-hugepages.c
 endif
 
 SRCS = $(COMM_SRCS)

--- a/runtime/src/comm/ofi/comm-ofi-hugepages.c
+++ b/runtime/src/comm/ofi/comm-ofi-hugepages.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2004-2018 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ * 
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * 
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//
+// Interface to hugepages for the OFI-based Chapel comm layer.
+//
+
+#include "chplrt.h"
+
+#include "comm-ofi-internal.h"
+
+#include <stdint.h>
+#include <sys/types.h>
+#include <hugetlbfs.h>  // <sys/types.h> must come first
+
+
+void* chpl_comm_ofi_hp_get_huge_pages(size_t size) {
+  return get_huge_pages(size, GHP_DEFAULT);
+}
+
+
+size_t chpl_comm_ofi_hp_gethugepagesize(void) {
+  return gethugepagesize();
+}

--- a/runtime/src/comm/ofi/comm-ofi-internal.h
+++ b/runtime/src/comm/ofi/comm-ofi-internal.h
@@ -57,6 +57,7 @@ uint64_t chpl_comm_ofi_dbg_level;
 #define DBG_ACK              0x100000UL
 #define DBG_COMMPROGRESS     0x200000UL
 #define DBG_MR              0x1000000UL
+#define DBG_HUGEPAGES       0x8000000UL
 #define DBG_FAB            0x10000000UL
 #define DBG_FABSALL        0x20000000UL
 #define DBG_FABFAIL        0x40000000UL
@@ -149,6 +150,14 @@ void chpl_comm_ofi_oob_init(void);
 void chpl_comm_ofi_oob_fini(void);
 void chpl_comm_ofi_oob_barrier(void);
 void chpl_comm_ofi_oob_allgather(void*, void*, int);
+
+
+//
+// Hugepage interface
+//
+
+void* chpl_comm_ofi_hp_get_huge_pages(size_t);
+size_t chpl_comm_ofi_hp_gethugepagesize(void);
 
 
 //

--- a/runtime/src/comm/ofi/comm-ofi-internal.h
+++ b/runtime/src/comm/ofi/comm-ofi-internal.h
@@ -127,6 +127,15 @@ char* chpl_comm_ofi_dbg_prefix(void);
 
 #define CHK_SYS_CALLOC(p, n) CHK_SYS_CALLOC_SZ(p, n, sizeof(*(p)))
 
+#define CHK_SYS_POSIX_MEMALIGN(p, a, s)                                 \
+    do {                                                                \
+        if ((posix_memalign(&(p), (a), (s))) != 0) {                    \
+          chpl_internal_error_v("posix_memalign(%#zx, %#zx): "          \
+                                "out of memory",                        \
+                                (size_t) (a), (size_t) (s));            \
+      }                                                                 \
+    } while (0)
+
 #define CHPL_CALLOC_SZ(p, n, s)                                         \
   do {                                                                  \
     p = chpl_mem_calloc((n), (s), CHPL_RT_MD_COMM_UTIL, 0, 0);          \

--- a/runtime/src/comm/ofi/comm-ofi-internal.h
+++ b/runtime/src/comm/ofi/comm-ofi-internal.h
@@ -24,11 +24,16 @@
 #ifndef _comm_ofi_internal_h_
 #define _comm_ofi_internal_h_
 
+#include "chpl-mem.h"
+#include "chpl-mem-sys.h"
+#include "error.h"
+
 #include <rdma/fabric.h>
 #include <rdma/fi_cm.h>
 #include <rdma/fi_domain.h>
 #include <rdma/fi_endpoint.h>
 #include <rdma/fi_errno.h>
+#include <stdint.h>
 
 
 //
@@ -127,12 +132,12 @@ char* chpl_comm_ofi_dbg_prefix(void);
 
 #define CHK_SYS_CALLOC(p, n) CHK_SYS_CALLOC_SZ(p, n, sizeof(*(p)))
 
-#define CHK_SYS_POSIX_MEMALIGN(p, a, s)                                 \
+#define CHK_SYS_MEMALIGN(p, a, s)                                       \
     do {                                                                \
-        if ((posix_memalign(&(p), (a), (s))) != 0) {                    \
-          chpl_internal_error_v("posix_memalign(%#zx, %#zx): "          \
-                                "out of memory",                        \
-                                (size_t) (a), (size_t) (s));            \
+      if ((p = sys_memalign((a), (s))) == NULL) {                       \
+        chpl_internal_error_v("sys_memalign(%#zx, %#zx): "              \
+                              "out of memory",                          \
+                              (size_t) (a), (size_t) (s));              \
       }                                                                 \
     } while (0)
 

--- a/runtime/src/comm/ofi/comm-ofi-no-hugepages.c
+++ b/runtime/src/comm/ofi/comm-ofi-no-hugepages.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2004-2018 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ * 
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * 
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//
+// Nil interface to hugepages for the OFI-based Chapel comm layer.
+//
+
+#include "chplrt.h"
+
+#include "comm-ofi-internal.h"
+
+#include <stdint.h>
+
+
+void* chpl_comm_ofi_hp_get_huge_pages(size_t size) { return NULL; }
+
+
+size_t chpl_comm_ofi_hp_gethugepagesize(void) { return 0; }

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -913,7 +913,7 @@ void init_fixedHeap(void) {
     if (have_hugepages) {
       start = chpl_comm_ofi_hp_get_huge_pages(size);
     } else {
-      CHK_SYS_POSIX_MEMALIGN(start, page_size, size);
+      CHK_SYS_MEMALIGN(start, page_size, size);
     }
   } while (start == NULL && size > decrement);
 


### PR DESCRIPTION
This adds comm=ofi versions of `chpl_comm_impl_regMemHeapInfo()` and
`chpl_comm_impl_regMemHeapPageSize()`, to support a fixed heap when
using the gni provider.  Other providers typically support scalable
memory registration, so a fixed heap isn't needed.  But the limited
support for scalable memory registration in the gni provider makes it
much less work for us to simply require a fixed heap in that case.

The new support includes both allocation and registration.  The fixed
heap is on hugepages if a hugepage module is loaded, and on regular
pages otherwise.  For now this only works with the Aries NIC.  At some
point it will work with the Gemini NIC as well, although for Gemini we
will likely need to make hugepages mandatory instead of optional, due to
limitations in that NIC's on-board TLB.

While here, get rid of the support for multiple memory region sets,
which we inherited from the ofi mockup and were an experimental feature
even there.  Also replace the statically-defined memory regions we
inherited from the mockup with a small (10-entry) table of dynamically
added entries.  This small table should be sufficient since we won't be
supporting full dynamic registration.  In other words, we'll be able to
dynamically add regions to be registered, but only a few of them and
only during initialization, not generally during execution.

As a necessary side effect, this also introduces a tiny interface to
`libhugetlbfs`, so that we can link user programs with that when we have
it and avoid undefined symbols when we don't.

For the most part confirmation that this code is working was done by
observing debug output.  However, `hello.chpl` now runs on 2 Cray XC nodes
with either the sockets or gni providers and reaches the point where it
gets an internal error when trying to do its first communication.  In
other words, we've gotten through registration successfully.  Also, on 2
XC nodes with the gni provider we produce the correct (Aries) warning
for the `runtime/configMatters/comm/ugni/overflow-nic-tlb `test, before
halting due to the lack of actual communication support.