### PR TITLE
Add an example of Fortran calling Chapel functions

### DIFF
--- a/test/interop/fortran/FortranCallChapel/Makefile
+++ b/test/interop/fortran/FortranCallChapel/Makefile
@@ -1,0 +1,16 @@
+FTN=gfortran
+CHPL=chpl
+
+FTN_OPTS=-fno-underscoring
+
+testCallChapel: testCallChapel.o lib/libchapelProcs.a
+	$(FTN) testCallChapel.o -Llib -lchapelProcs `$(CHPL_HOME)/util/config/compileline --libraries` -o testCallChapel $(FTN_OPTS)
+
+lib/libchapelProcs.a: chapelProcs.chpl
+	$(CHPL) --library chapelProcs.chpl --ccflags=-Wno-incompatible-pointer-types
+
+testCallChapel.o: testCallChapel.f90
+	$(FTN) -c testCallChapel.f90 $(FTN_OPTS)
+
+clean:
+	rm -rf lib testCallChapel testCallChapel.o chapelinterface.mod

--- a/test/interop/fortran/FortranCallChapel/chapelProcs.chpl
+++ b/test/interop/fortran/FortranCallChapel/chapelProcs.chpl
@@ -6,6 +6,7 @@ export proc chpl_library_init_ftn() {
   extern proc chpl_library_init(argc: c_int, argv: c_ptr(c_ptr(c_char)));
   var filename = c"fake";
   chpl_library_init(0, c_ptrTo(filename): c_ptr(c_ptr(c_char)));;
+  chpl__init_chapelProcs();
 }
 
 export proc setint(i: int) {

--- a/test/interop/fortran/FortranCallChapel/chapelProcs.chpl
+++ b/test/interop/fortran/FortranCallChapel/chapelProcs.chpl
@@ -1,0 +1,29 @@
+var chplInt: int;
+var chplReal: real;
+
+// Note: These exported functions need to be all lowercase
+export proc chpl_library_init_ftn() {
+  extern proc chpl_library_init(argc: c_int, argv: c_ptr(c_ptr(c_char)));
+  var filename = c"fake";
+  chpl_library_init(0, c_ptrTo(filename): c_ptr(c_ptr(c_char)));;
+}
+
+export proc setint(i: int) {
+  writeln("in setint, i = ", i);
+  chplInt = i;
+}
+
+export proc setreal(r: real) {
+  writeln("in setreal, r = ", r);
+  chplReal = r;
+}
+
+export proc getint(): int {
+  writeln("in getint, chplInt = ", chplInt);
+  return chplInt;
+}
+
+export proc getreal(): real {
+  writeln("in getreal, chplReal = ", chplReal);
+  return chplReal;
+}

--- a/test/interop/fortran/FortranCallChapel/chapelProcs.cleanfiles
+++ b/test/interop/fortran/FortranCallChapel/chapelProcs.cleanfiles
@@ -1,0 +1,1 @@
+lib testCallChapel testCallChapel.o chapelinterface.mod

--- a/test/interop/fortran/FortranCallChapel/chapelProcs.compopts
+++ b/test/interop/fortran/FortranCallChapel/chapelProcs.compopts
@@ -1,0 +1,1 @@
+--library --ccflags=-Wno-incompatible-pointer-types

--- a/test/interop/fortran/FortranCallChapel/chapelProcs.good
+++ b/test/interop/fortran/FortranCallChapel/chapelProcs.good
@@ -1,0 +1,6 @@
+in setreal, r = 2.71828
+in setint, i = 1
+in getreal, chplReal = 2.71828
+in getint, chplInt = 1
+   2.7182817459106445     
+                    1

--- a/test/interop/fortran/FortranCallChapel/chapelProcs.prediff
+++ b/test/interop/fortran/FortranCallChapel/chapelProcs.prediff
@@ -5,7 +5,6 @@ FTN=gfortran
 $FTN -c testCallChapel.f90 -fno-underscoring
 $FTN testCallChapel.o -Llib -lchapelProcs `$CHPL_HOME/util/config/compileline --libraries` -o chapelProcs -fno-underscoring
 
-echo $2
 ./chapelProcs >> $2
 
 make clean

--- a/test/interop/fortran/FortranCallChapel/chapelProcs.prediff
+++ b/test/interop/fortran/FortranCallChapel/chapelProcs.prediff
@@ -1,10 +1,7 @@
 #!/bin/bash
 
-FTN=gfortran
+make
 
-$FTN -c testCallChapel.f90 -fno-underscoring
-$FTN testCallChapel.o -Llib -lchapelProcs `$CHPL_HOME/util/config/compileline --libraries` -o chapelProcs -fno-underscoring
-
-./chapelProcs >> $2
+./testCallChapel >> $2
 
 make clean

--- a/test/interop/fortran/FortranCallChapel/chapelProcs.prediff
+++ b/test/interop/fortran/FortranCallChapel/chapelProcs.prediff
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+FTN=gfortran
+
+$FTN -c testCallChapel.f90 -fno-underscoring
+$FTN testCallChapel.o -Llib -lchapelProcs `$CHPL_HOME/util/config/compileline --libraries` -o chapelProcs -fno-underscoring
+
+echo $2
+./chapelProcs >> $2
+
+make clean

--- a/test/interop/fortran/FortranCallChapel/chapelProcs.skipif
+++ b/test/interop/fortran/FortranCallChapel/chapelProcs.skipif
@@ -1,6 +1,11 @@
 #!/bin/bash
+
+launcher=`$CHPL_HOME/util/chplenv/chpl_launcher.py`
+
 `which gfortran 2>&1 >/dev/null`
-if [[ $? == 0 ]] ; then
+gfortranFound=$?
+
+if [[ $gfortranFound == 0 && $launcher == "none" ]] ; then
   echo 0
 else
   echo 1

--- a/test/interop/fortran/FortranCallChapel/chapelProcs.skipif
+++ b/test/interop/fortran/FortranCallChapel/chapelProcs.skipif
@@ -1,0 +1,7 @@
+#!/bin/bash
+`which gfortran 2>&1 >/dev/null`
+if [[ $? == 0 ]] ; then
+  echo 0
+else
+  echo 1
+fi

--- a/test/interop/fortran/FortranCallChapel/testCallChapel.f90
+++ b/test/interop/fortran/FortranCallChapel/testCallChapel.f90
@@ -1,0 +1,51 @@
+module ChapelInterface
+  use ISO_C_BINDING
+
+  interface
+    subroutine chpl_library_init_ftn() bind(C, name="chpl_library_init_ftn")
+    end subroutine chpl_library_init_ftn
+
+    subroutine chpl_library_finalize() bind(C, name="chpl_library_finalize")
+    end subroutine chpl_library_finalize
+
+    subroutine setint(i) bind(C, name="setint")
+      import c_int64_t
+      integer(kind=c_int64_t), value :: i
+    end subroutine setint
+
+    subroutine setreal(r) bind(C, name="setreal")
+      import c_double
+      real(kind=c_double), value :: r
+    end subroutine setreal
+
+    function getint() bind(C, name="getint")
+      import c_int64_t
+      integer(kind=c_int64_t) :: getint
+    end function getint
+
+    function getreal() bind(C, name="getreal")
+      import c_double
+      real(kind=c_double) :: getreal
+    end function getreal
+  end interface
+end module ChapelInterface
+
+program callChapel
+  use ChapelInterface
+  implicit none
+
+  integer(8) :: i, j
+  real(8) :: r, s
+  i = 1
+  r = 2.718281828
+  call chpl_library_init_ftn()
+  call setReal(r)
+  call setInt(i)
+
+  s = getReal()
+  j = getInt()
+
+  print *, s
+  print *, j
+  call chpl_library_finalize()
+end program callChapel


### PR DESCRIPTION
Add an example of Fortran calling Chapel functions using F2003 interfaces on
the Fortran side and the '--library' flag and 'export' on the Chapel side.

I added a new top-level test directory "interop" that I think is worth having
now that we have interoperability tests for several different languages.