### PR TITLE
Free the result of '_build_tuple_always_allow_ref' for index vars

### DIFF
--- a/compiler/AST/ForallStmt.cpp
+++ b/compiler/AST/ForallStmt.cpp
@@ -376,6 +376,7 @@ static void fsDestructureWhenSingleIdxVar(ForallStmt* fs, AList& fIterVars,
 
   VarSymbol* idxUser = new VarSymbol(index->unresolved);
   idxUser->addFlag(FLAG_INDEX_VAR);
+  idxUser->addFlag(FLAG_INSERT_AUTO_DESTROY);
   DefExpr* idxDef = new DefExpr(idxUser);
   fs->loopBody()->insertAtHead(idxDef);
   idxDef->insertAfter("'move'(%S,%E)", idxUser, bt);


### PR DESCRIPTION
This PR fixes a memory leak when a single index identifier is used with a zippered forall loop. See the test ``types/tuple/these/zip_forall.chpl`` for an example.

Testing:
- [x] local + futures
- [x] gasnet + futures
- [x] memleaks
- [x] valgrind