### PR TITLE
comm=ofi: get RMA working in a rudimentary way.

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi-oob-sockets.c
+++ b/runtime/src/comm/ofi/comm-ofi-oob-sockets.c
@@ -46,13 +46,13 @@ void chpl_comm_ofi_oob_init(void) {
     int ev_i;
 
     if (sscanf(ev, "%i", &ev_i) != 1) {
-      chpl_internal_error("SLURM_PROCID");
+      INTERNAL_ERROR_V("SLURM_PROCID");
     }
     chpl_nodeID = ev_i;
 
     if ((ev = getenv("SLURM_NTASKS")) == NULL
         || sscanf(ev, "%i", &ev_i) != 1) {
-      chpl_internal_error("SLURM_NTASKS");
+      INTERNAL_ERROR_V("SLURM_NTASKS");
     }
     chpl_numNodes = ev_i;
 
@@ -66,21 +66,21 @@ void chpl_comm_ofi_oob_init(void) {
     }
 #endif
   } else {
-    chpl_internal_error("need slurm system launcher");
+    INTERNAL_ERROR_V("need slurm system launcher");
   }
 }
 
 
 void chpl_comm_ofi_oob_fini(void) {
   if (chpl_numNodes != 1) {
-    chpl_internal_error("multi-locale fini not supported");
+    INTERNAL_ERROR_V("multi-locale fini not supported");
   }
 }
 
 
 void chpl_comm_ofi_oob_barrier(void) {
   if (chpl_numNodes != 1) {
-    chpl_internal_error("multi-locale barrier not supported");
+    INTERNAL_ERROR_V("multi-locale barrier not supported");
   }
 }
 
@@ -89,6 +89,6 @@ void chpl_comm_ofi_oob_allgather(void* in, void* out, int len) {
   if (chpl_numNodes == 1) {
     chpl_memcpy(out, in, len);
   } else {
-    chpl_internal_error("multi-locale allgather not supported");
+    INTERNAL_ERROR_V("multi-locale allgather not supported");
   }
 }


### PR DESCRIPTION
Get basic `chpl_comm_put()` and `chpl_comm_get()` working, along with
anything that reduces to them such as "non-blocking" PUTs and GETs which
for now are actually blocking.  In support of this, also add convenience
functions for looking up local registered memory region descriptors and
remote registered memory region keys that correspond to address ranges,
a function to associate a transmit context with each thread as it enters
the comm layer for the first time, support for allocating bounce buffers
in registered memory for cases where a PUT's local source or a GET's
local target is not registered, and code to consume completion queue
entries for in-flight transactions.  In a number of ways this support is
a bit unfinished; for example, eventually we need to support having more
threads than there are transmit contexts, and for now whenever we need a
bounce buffer we allocate a new one from the Chapel memory manager and
free it right away when we're done.  But the basic functionality is
here, and what is not yet done I believe can reasonably be viewed as
tuning, or improving corner case behavior.

As a temporary measure, switch to `FI_PROGRESS_AUTO` automatic control and
data progress.  Once the AM handler is running and making regular calls
into libfabric and the provider, we can revert to `FI_PROGRESS_MANUAL`
which is expected to perform better.  But absent an AM handler, for now
we need the providers to handle this themselves to prevent RMA progress
stalls.

As of this commit, running 'hello' on 2 Cray XC nodes, with the sockets
provider we execute successfully up to the point at which the first
`executeOn` (on-stmt) is encountered.  This would require an AM.  And with
the gni provider we execute up until the point at which we do an RMA
whose remote address is not registered.  For this we also need to do an
AM, to initiate the opposite kind of RMA through a registered bounce
buffer on the remote side.  So for both providers, functionally we are
now limited by our inability to do AMs, though in different ways for the
two.

While here, remove the libfabric-related include directives from the
internal .h file, where they're not needed.

While here, add an internal error wrapper that adds the source file and
line number to the message printed.

While here, add the capability to send debug output to separate files
for each locale.  This is to deal with situations in which debug output
emitted right before a failure or hang does not show up, due to system
launchers and/or job management process trees buffering `stdout`/`stderr`
internally.)

While here, add debug support for barriers.

While here, delay initializing the debug support until after we know our
node ID.  This avoids a minor problem in the debug output prefix caching
when we don't know our ID at the time of the first output.  The result
is that we can't do debug output during out-of-band initialization, but
that hardly seems like a necessity.

This closes #11171.