### PR TITLE
Convert programs directory to use delete-free features

### DIFF
--- a/test/release/examples/programs/genericStack.chpl
+++ b/test/release/examples/programs/genericStack.chpl
@@ -9,7 +9,7 @@
  *
  */
 
-// A stack class that is generic over the type of data that it
+// A stack type that is generic over the type of data that it
 // contains.  This implementation uses a linked list implemented using
 // the node class contained within it.
 record ListStack {
@@ -18,15 +18,15 @@ record ListStack {
   class MyNode {
     type itemType;              // type of item
     var item: itemType;         // item in node
-    var next: unmanaged MyNode(itemType); // reference to next node (same type)
+    var next: owned MyNode(itemType); // reference to next node (same type)
   }
 
   type itemType;             // type of items
-  var top: unmanaged MyNode(itemType); // top node on stack linked list
+  var top: owned MyNode(itemType); // top node on stack linked list
 
   // push method: add an item to the top of the stack
   proc push(item: itemType) {
-    top = new unmanaged MyNode(itemType, item, top);
+    top = new owned MyNode(itemType, item, top);
   }
 
   // pop method: remove an item from the top of the stack
@@ -34,10 +34,10 @@ record ListStack {
   proc pop() {
     if isEmpty then
       halt("attempt to pop an item off an empty stack");
-    var oldTop = top;
     var oldItem = top.item;
-    top = top.next;
-    delete oldTop;
+    var oldTop = top;
+    top = oldTop.next;
+    oldTop.next = nil;
     return oldItem;
   }
 
@@ -46,7 +46,7 @@ record ListStack {
 }
 
 
-// A stack class that is generic over the type of data that it
+// A stack type that is generic over the type of data that it
 // contains.  This implementation uses an array to store the elements
 // in the stack.
 record ArrayStack {

--- a/test/release/examples/programs/tree.chpl
+++ b/test/release/examples/programs/tree.chpl
@@ -17,11 +17,7 @@ config const treeHeight: uint = 4;
 //
 class node {
   var id: int;
-  var left, right: unmanaged node;
-  proc deinit() {
-    if left then delete left;
-    if right then delete right;
-  }
+  var left, right: owned node;
 }
 
 
@@ -31,7 +27,6 @@ class node {
 proc main() {
   var root = buildTree();
   writeln("sum=", sum(root));
-  delete root;
 }
 
 //
@@ -39,8 +34,8 @@ proc main() {
 // node's children in parallel.  It uses the monotonically decreasing
 // height variable to control the recursion.
 //
-proc buildTree(height: uint = treeHeight, id: int = 1): unmanaged node {
-  var newNode = new unmanaged node(id);
+proc buildTree(height: uint = treeHeight, id: int = 1): owned node {
+  var newNode = new owned node(id);
 
   if height > 1 {
     cobegin {
@@ -57,7 +52,7 @@ proc buildTree(height: uint = treeHeight, id: int = 1): unmanaged node {
 // sum() walks the tree in parallel using a cobegin, computing the sum
 // of the node IDs using a postorder traversal.
 //
-proc sum(n: unmanaged node): int {
+proc sum(n: node): int {
   var total = n.id;
 
   if n.left != nil {


### PR DESCRIPTION
This was more challenging than I'd expected and resulted in some
surprises (though I'm not sure that if the implementation had done
differently there wouldn't have been other surprises).

E.g., at one point I was surprised that:

      var x = new owned();
      var y = x;

would make 'y' take ownership of 'x' rather than borrowing from it.
Though on reflection it makes sense that this is the case or else
'x' would arguably be borrowed as well.

It was also much more difficult to delete elements from the middle
of the linked list than I expected due to the fact that the 'next'
field carries the ownership and so copying that out into an owned
temp requires some juggling.