### PR TITLE
Fix scripts for Fortran calling Chapel interop tests

### DIFF
--- a/test/interop/fortran/FortranCallChapel/chapelProcs.prediff
+++ b/test/interop/fortran/FortranCallChapel/chapelProcs.prediff
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-make
+make CHPL=$3
 
 ./testCallChapel >> $2
 

--- a/test/interop/fortran/FortranCallChapel/chapelProcs.skipif
+++ b/test/interop/fortran/FortranCallChapel/chapelProcs.skipif
@@ -1,12 +1,18 @@
 #!/bin/bash
 
+# Skip this test if using a launcher, or if using --llvm, or if gfortran is not
+# available.
+
 launcher=`$CHPL_HOME/util/chplenv/chpl_launcher.py`
 
-`which gfortran 2>&1 >/dev/null`
+[[ $COMPOPTS == *"--llvm"* ]]
+llvm=$?
+
+`command -v gfortran 2>&1 >/dev/null`
 gfortranFound=$?
 
-if [[ $gfortranFound == 0 && $launcher == "none" ]] ; then
-  echo 0
+if [[ $gfortranFound == 0 && $launcher == "none" && $llvm != 0 ]] ; then
+  echo False
 else
-  echo 1
+  echo True
 fi


### PR DESCRIPTION
* Skip the test if --llvm is in the compopts
* Use the shell built-in 'command' instead of 'which' to see if a command exists
* Change '#!' lines to use /usr/bin/env instead of a direct file path
* Pass the path to 'chpl' to make