### PR TITLE
Skip Fortran interop test for cray-xc target platform

### DIFF
--- a/test/interop/fortran/FortranCallChapel/chapelProcs.skipif
+++ b/test/interop/fortran/FortranCallChapel/chapelProcs.skipif
@@ -11,7 +11,7 @@ llvm=$?
 `command -v gfortran 2>&1 >/dev/null`
 gfortranFound=$?
 
-if [[ $gfortranFound == 0 && $launcher == "none" && $llvm != 0 ]] ; then
+if [[ $gfortranFound == 0 && $launcher == "none" && $llvm != 0 && $CHPL_TARGET_PLATFORM != "cray-xc" ]] ; then
   echo False
 else
   echo True


### PR DESCRIPTION
Skip this test on cray-xc so we don't have to worry about differing flags and
interactions of the various target compilers and gfortran.