### PR TITLE
Remove all references to SMTP host "relaya"

### DIFF
--- a/util/cron/common-darwin.bash
+++ b/util/cron/common-darwin.bash
@@ -1,10 +1,5 @@
 #!/usr/bin/env bash
 
-
-# Use relay SMTP server, since postfix does not reliably start when test
-# machine is rebooted.
-export CHPL_UTIL_SMTP_HOST=relaya
-
 # 2017-11-03: needed on chapelmac since I.T. updates on 2017-10-10
 #             known to be needed on a Macbook when connected over VPN
 export GASNET_MASTERIP=127.0.0.1

--- a/util/cron/test-cygwin32.bat
+++ b/util/cron/test-cygwin32.bat
@@ -8,7 +8,7 @@ IF "%WORKSPACE%"=="" GOTO ErrExit
 REM NOTE: This is pretty messy, but it is the only way I could figure out how to
 REM       get the correct environment setup and then invoke
 REM       nightly. (thomasvandoren, 2014-07-14)
-c:\cygwin\bin\bash -exc "export PATH='/usr/local/bin:/usr/bin:/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/Wbem:/cygdrive/c/Program Files/SysinternalsSuite' ; export CHPL_TEST_LIMIT_RUNNING_EXECUTABLES=yes ; export CHPL_HOME=$PWD ; num_procs=`python -c 'import multiprocessing; print (multiprocessing.cpu_count()+1)/2'` ; for i in $(seq 1 $num_procs); do echo localhost; done > $CHPL_HOME/test/NODES/$num_procs-localhost ; export CHPL_UTIL_SMTP_HOST=relaya ; source $CHPL_HOME/util/cron/common.bash && export CHPL_NIGHTLY_TEST_CONFIG_NAME="cygwin32" && $CHPL_HOME/util/cron/nightly -cron -parnodefile $CHPL_HOME/test/NODES/$num_procs-localhost"
+c:\cygwin\bin\bash -exc "export PATH='/usr/local/bin:/usr/bin:/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/Wbem:/cygdrive/c/Program Files/SysinternalsSuite' ; export CHPL_TEST_LIMIT_RUNNING_EXECUTABLES=yes ; export CHPL_HOME=$PWD ; num_procs=`python -c 'import multiprocessing; print (multiprocessing.cpu_count()+1)/2'` ; for i in $(seq 1 $num_procs); do echo localhost; done > $CHPL_HOME/test/NODES/$num_procs-localhost ; source $CHPL_HOME/util/cron/common.bash && export CHPL_NIGHTLY_TEST_CONFIG_NAME="cygwin32" && $CHPL_HOME/util/cron/nightly -cron -parnodefile $CHPL_HOME/test/NODES/$num_procs-localhost"
 GOTO End
 
 :ErrExit

--- a/util/cron/test-cygwin64.bat
+++ b/util/cron/test-cygwin64.bat
@@ -8,7 +8,7 @@ IF "%WORKSPACE%"=="" GOTO ErrExit
 REM NOTE: This is pretty messy, but it is the only way I could figure out how to
 REM       get the correct environment setup and then invoke
 REM       nightly. (thomasvandoren, 2014-07-14)
-c:\cygwin64\bin\bash -exc "export PATH='/usr/local/bin:/usr/bin:/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/Wbem:/cygdrive/c/Program Files/SysinternalsSuite' ; export CHPL_TEST_LIMIT_RUNNING_EXECUTABLES=yes ; export CHPL_HOME=$PWD ; num_procs=`python -c 'import multiprocessing; print (multiprocessing.cpu_count()+1)/2'` ; for i in $(seq 1 $num_procs); do echo localhost; done > $CHPL_HOME/test/NODES/$num_procs-localhost ; export CHPL_UTIL_SMTP_HOST=relaya ; source $CHPL_HOME/util/cron/common.bash && export CHPL_NIGHTLY_TEST_CONFIG_NAME="cygwin64" && $CHPL_HOME/util/cron/nightly -cron -parnodefile $CHPL_HOME/test/NODES/$num_procs-localhost"
+c:\cygwin64\bin\bash -exc "export PATH='/usr/local/bin:/usr/bin:/cygdrive/c/Windows/system32:/cygdrive/c/Windows:/cygdrive/c/Windows/System32/Wbem:/cygdrive/c/Program Files/SysinternalsSuite' ; export CHPL_TEST_LIMIT_RUNNING_EXECUTABLES=yes ; export CHPL_HOME=$PWD ; num_procs=`python -c 'import multiprocessing; print (multiprocessing.cpu_count()+1)/2'` ; for i in $(seq 1 $num_procs); do echo localhost; done > $CHPL_HOME/test/NODES/$num_procs-localhost ; source $CHPL_HOME/util/cron/common.bash && export CHPL_NIGHTLY_TEST_CONFIG_NAME="cygwin64" && $CHPL_HOME/util/cron/nightly -cron -parnodefile $CHPL_HOME/test/NODES/$num_procs-localhost"
 GOTO End
 
 :ErrExit


### PR DESCRIPTION
"relaya" is a Cray-internal host soon to be retired. See PR #11360 for related info. 