### PR TITLE
Fix an unused variable

### DIFF
--- a/compiler/codegen/expr.cpp
+++ b/compiler/codegen/expr.cpp
@@ -5155,7 +5155,6 @@ DEFINE_PRIM(PRIM_COPIES_NO_ALIAS_SET) {
 #ifdef HAVE_LLVM
     Symbol* sym = toSymExpr(call->get(1))->symbol();
     Symbol* otherSym = toSymExpr(call->get(2))->symbol();
-    llvm::LLVMContext &ctx = info->llvmContext;
 
     if (info->noAliasScopeLists.count(otherSym) > 0) {
       llvm::MDNode *&scopeList = info->noAliasScopeLists[sym];


### PR DESCRIPTION
Fixes an unused variable some C++ compilers warn about.

Follow-on to PR #11324.

Trivial and not reviewed.