### PR TITLE
Add a use of the `:throws:` tag to FileSystem.chmod

### DIFF
--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -200,6 +200,11 @@ proc locale.chdir(out error: syserr, name: string) {
               See description of :const:`S_IRUSR`, for instance, for potential
               values.
    :type mode: `int`
+
+   :throws FileNotFoundError: Thrown when the name specified does not correspond
+                              to a file or directory that exists.
+   :throws PermissionError: Thrown when the current user does not have
+                            permission to change the permissions
 */
 proc chmod(name: string, mode: int) throws {
   extern proc chpl_fs_chmod(name: c_string, mode: int): syserr;


### PR DESCRIPTION
Documents two errors, FileNotFoundError and PermissionError.

Note: this is a mock up of what such documentation would look like.  I am open to tweaking the wording as well as the style, and we will want to put this before the larger team before converting our documentation wholesale.

Here's what it looks like with only one Error mentioned:
![one throw](https://user-images.githubusercontent.com/2454710/47029159-b6734880-d11f-11e8-9494-ed2a15251b61.png)


Here's what it looks like with two Errors:
![two throw](https://user-images.githubusercontent.com/2454710/47029160-b70bdf00-d11f-11e8-80f4-e41eee5be72b.png)
