### PR TITLE
Fix typos

### DIFF
--- a/compiler/AST/primitive.cpp
+++ b/compiler/AST/primitive.cpp
@@ -923,7 +923,7 @@ initPrimitive() {
   // Remaining arguments are SymExprs referring to Symbols that this one
   // does not alias.
   // Translates to llvm alias.scope and noalias metadata:
-  //    - alias.scope with metadata corresonding to the 1st symbol
+  //    - alias.scope with metadata corresponding to the 1st symbol
   //    - noalias with metadata corresponding to the remaining symbols
   // Result of call can be used as a final argument in a memory instruction,
   // e.g. PRIM_ARRAY_GET.

--- a/compiler/passes/initializerRules.cpp
+++ b/compiler/passes/initializerRules.cpp
@@ -1254,7 +1254,7 @@ bool PostinitVisitor::enterBlockStmt(BlockStmt* node) {
       for_alist(next_ast, node->body)
         next_ast->accept(&vis);
       if (vis.found && isLoweredElseCoforall == false) {
-        USR_FATAL_CONT(node, "\"super.postinit()\" is not allowed in a %s satement", name);
+        USR_FATAL_CONT(node, "\"super.postinit()\" is not allowed in a %s statement", name);
       }
       return false;
     }

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -7702,7 +7702,7 @@ void post_fma_and_wait(c_nodeid_t locale, gni_post_descriptor_t* post_desc,
   // Wait for the transaction to complete.  Yield initially; the
   // minimum round-trip time on the network isn't small and maybe
   // we can find something else to do in the meantime.  FMA is only
-  // used for small tranasctions which will be relatively fast, so
+  // used for small transactions which will be relatively fast, so
   // after the initial yield, only yield every 64 attempts.
   //
   do {

--- a/spec/TODO
+++ b/spec/TODO
@@ -158,7 +158,7 @@ yet.
 Is this a good idea?  I don't understand the semantic guarantees we
 can make for this construct in the presence of optimizations...
 
-* describe how to specify a homogenous varargs type (e.g., x: int...n)?
+* describe how to specify a homogeneous varargs type (e.g., x: int...n)?
 
 These are orthogonal.  I added an example.
 

--- a/test/classes/initializers/postInit/invalidSuperPostinit.good
+++ b/test/classes/initializers/postInit/invalidSuperPostinit.good
@@ -11,8 +11,8 @@ invalidSuperPostinit.chpl:42: error: "super.postinit()" is not allowed in loop s
 invalidSuperPostinit.chpl:48: error: "super.postinit()" is not allowed in loop statements
 invalidSuperPostinit.chpl:50: error: "super.postinit()" is not allowed in loop statements
 invalidSuperPostinit.chpl:56: In function 'postinit':
-invalidSuperPostinit.chpl:57: error: "super.postinit()" is not allowed in a coforall satement
-invalidSuperPostinit.chpl:59: error: "super.postinit()" is not allowed in a coforall satement
-invalidSuperPostinit.chpl:62: error: "super.postinit()" is not allowed in a begin satement
-invalidSuperPostinit.chpl:63: error: "super.postinit()" is not allowed in a begin satement
-invalidSuperPostinit.chpl:66: error: "super.postinit()" is not allowed in a cobegin satement
+invalidSuperPostinit.chpl:57: error: "super.postinit()" is not allowed in a coforall statement
+invalidSuperPostinit.chpl:59: error: "super.postinit()" is not allowed in a coforall statement
+invalidSuperPostinit.chpl:62: error: "super.postinit()" is not allowed in a begin statement
+invalidSuperPostinit.chpl:63: error: "super.postinit()" is not allowed in a begin statement
+invalidSuperPostinit.chpl:66: error: "super.postinit()" is not allowed in a cobegin statement

--- a/test/release/examples/primers/records.chpl
+++ b/test/release/examples/primers/records.chpl
@@ -153,7 +153,7 @@ proc Point.this(i: int): real {
 // Now we can access the coordinates numerically instead of by name:
 writeln(myPoint(1)); // outputs: 1.0
 
-// The ``this`` method enables both paretheses-style access and square
+// The ``this`` method enables both parenthesis-style access and square
 // brace style:
 writeln(myPoint[1]);
 

--- a/test/release/examples/primers/tuples.chpl
+++ b/test/release/examples/primers/tuples.chpl
@@ -65,7 +65,7 @@ threeReals += 1.0;
 writeln(threeReals); // output: (1.0, 1.0, 1.0)
 
 // Tuples with only one component type are also called
-// homogenous tuples.
+// homogeneous tuples.
 
 // Tuple Iteration
 // ***************


### PR DESCRIPTION
Fix typos in 
  spec/TODO
  primitive.cpp
  initializerRules.cpp and invalidSuperPostinit.good
  comm-ugni.c
  primers/records.chpl
  primers/tuples.chpl