### PR TITLE
Fix issue with rethrowing specific errors that were just caught

### DIFF
--- a/test/errhandling/lydia/notAnErrorSubtype-caught.chpl
+++ b/test/errhandling/lydia/notAnErrorSubtype-caught.chpl
@@ -1,0 +1,11 @@
+class Foo {
+  var s: string = "I ain't no error subtype";
+}
+
+proc main() throws {
+  try {
+    throw new NilThrownError();
+  } catch e1: Foo {
+    writeln("Wait, how did I catch a Foo, that's not an error subtype");
+  }
+}

--- a/test/errhandling/lydia/notAnErrorSubtype-caught.good
+++ b/test/errhandling/lydia/notAnErrorSubtype-caught.good
@@ -1,0 +1,3 @@
+uncaught NilThrownError: thrown error was nil
+  notAnErrorSubtype-caught.chpl:7: thrown here
+  notAnErrorSubtype-caught.chpl:5: uncaught here

--- a/test/errhandling/lydia/notAnErrorSubtype-caught2.bad
+++ b/test/errhandling/lydia/notAnErrorSubtype-caught2.bad
@@ -1,0 +1,6 @@
+notAnErrorSubtype-caught2.chpl:5: In function 'main':
+notAnErrorSubtype-caught2.chpl:7: error: unresolved call 'chpl_fix_thrown_error(unmanaged Foo)'
+$CHPL_HOME/modules/internal/ChapelError.chpl:339: note: candidates are: chpl_fix_thrown_error(err: borrowed Error)
+$CHPL_HOME/modules/internal/ChapelError.chpl:345: note:                 chpl_fix_thrown_error(type errType)
+$CHPL_HOME/modules/internal/ChapelError.chpl:352: note:                 chpl_fix_thrown_error(err: unmanaged Error)
+$CHPL_HOME/modules/internal/ChapelError.chpl:367: note:                 chpl_fix_thrown_error(ref err: owned Error)

--- a/test/errhandling/lydia/notAnErrorSubtype-caught2.chpl
+++ b/test/errhandling/lydia/notAnErrorSubtype-caught2.chpl
@@ -1,0 +1,11 @@
+class Foo {
+  var s: string = "I ain't no error subtype";
+}
+
+proc main() throws {
+  try {
+    throw new Foo();
+  } catch e1: Foo {
+    writeln("Wait, how did I catch a Foo, that's not an error subtype");
+  }
+}

--- a/test/errhandling/lydia/notAnErrorSubtype-caught2.future
+++ b/test/errhandling/lydia/notAnErrorSubtype-caught2.future
@@ -1,0 +1,2 @@
+error message: throwing something that is not an Error subtype
+#11403

--- a/test/errhandling/lydia/notAnErrorSubtype-caught2.good
+++ b/test/errhandling/lydia/notAnErrorSubtype-caught2.good
@@ -1,0 +1,2 @@
+notAnErrorSubtype-caught2.chpl:5: In function 'main':
+notAnErrorSubtype-caught2.chpl:7: error: cannot throw something that is not a subtype of Error

--- a/test/errhandling/lydia/notAnErrorSubtype-rethrown.bad
+++ b/test/errhandling/lydia/notAnErrorSubtype-rethrown.bad
@@ -1,0 +1,6 @@
+notAnErrorSubtype-rethrown.chpl:5: In function 'main':
+notAnErrorSubtype-rethrown.chpl:10: error: unresolved call 'chpl_fix_thrown_error(Foo)'
+$CHPL_HOME/modules/internal/ChapelError.chpl:339: note: candidates are: chpl_fix_thrown_error(err: borrowed Error)
+$CHPL_HOME/modules/internal/ChapelError.chpl:345: note:                 chpl_fix_thrown_error(type errType)
+$CHPL_HOME/modules/internal/ChapelError.chpl:352: note:                 chpl_fix_thrown_error(err: unmanaged Error)
+$CHPL_HOME/modules/internal/ChapelError.chpl:367: note:                 chpl_fix_thrown_error(ref err: owned Error)

--- a/test/errhandling/lydia/notAnErrorSubtype-rethrown.chpl
+++ b/test/errhandling/lydia/notAnErrorSubtype-rethrown.chpl
@@ -1,0 +1,12 @@
+class Foo {
+  var s: string = "I ain't no error subtype";
+}
+
+proc main() throws {
+  try {
+    throw new NilThrownError();
+  } catch e1: Foo {
+    writeln("Wait, how did I catch a Foo, that's not an error subtype");
+    throw e1;
+  }
+}

--- a/test/errhandling/lydia/notAnErrorSubtype-rethrown.future
+++ b/test/errhandling/lydia/notAnErrorSubtype-rethrown.future
@@ -1,0 +1,2 @@
+error message: throwing something that is not an Error subtype
+#11403

--- a/test/errhandling/lydia/notAnErrorSubtype-rethrown.good
+++ b/test/errhandling/lydia/notAnErrorSubtype-rethrown.good
@@ -1,0 +1,2 @@
+notAnErrorSubtype-rethrown.chpl:5: In function 'main':
+notAnErrorSubtype-rethrown.chpl:10: error: cannot throw something that is not a subtype of Error

--- a/test/errhandling/lydia/notAnErrorSubtype-rethrown2.bad
+++ b/test/errhandling/lydia/notAnErrorSubtype-rethrown2.bad
@@ -1,0 +1,6 @@
+notAnErrorSubtype-rethrown2.chpl:5: In function 'main':
+notAnErrorSubtype-rethrown2.chpl:7: error: unresolved call 'chpl_fix_thrown_error(unmanaged Foo)'
+$CHPL_HOME/modules/internal/ChapelError.chpl:339: note: candidates are: chpl_fix_thrown_error(err: borrowed Error)
+$CHPL_HOME/modules/internal/ChapelError.chpl:345: note:                 chpl_fix_thrown_error(type errType)
+$CHPL_HOME/modules/internal/ChapelError.chpl:352: note:                 chpl_fix_thrown_error(err: unmanaged Error)
+$CHPL_HOME/modules/internal/ChapelError.chpl:367: note:                 chpl_fix_thrown_error(ref err: owned Error)

--- a/test/errhandling/lydia/notAnErrorSubtype-rethrown2.chpl
+++ b/test/errhandling/lydia/notAnErrorSubtype-rethrown2.chpl
@@ -1,0 +1,12 @@
+class Foo {
+  var s: string = "I ain't no error subtype";
+}
+
+proc main() throws {
+  try {
+    throw new Foo();
+  } catch e1: Foo {
+    writeln("Wait, how did I catch a Foo, that's not an error subtype");
+    throw e1;
+  }
+}

--- a/test/errhandling/lydia/notAnErrorSubtype-rethrown2.future
+++ b/test/errhandling/lydia/notAnErrorSubtype-rethrown2.future
@@ -1,0 +1,2 @@
+error message: throwing something that is not an Error subtype
+#11403

--- a/test/errhandling/lydia/notAnErrorSubtype-rethrown2.good
+++ b/test/errhandling/lydia/notAnErrorSubtype-rethrown2.good
@@ -1,0 +1,2 @@
+notAnErrorSubtype-rethrown2.chpl:5: In function 'main':
+notAnErrorSubtype-rethrown2.chpl:7: error: cannot throw something that is not a subtype of Error

--- a/test/errhandling/lydia/notAnErrorSubtype-thrown.bad
+++ b/test/errhandling/lydia/notAnErrorSubtype-thrown.bad
@@ -1,0 +1,6 @@
+notAnErrorSubtype-thrown.chpl:5: In function 'main':
+notAnErrorSubtype-thrown.chpl:7: error: unresolved call 'chpl_fix_thrown_error(unmanaged Foo)'
+$CHPL_HOME/modules/internal/ChapelError.chpl:339: note: candidates are: chpl_fix_thrown_error(err: borrowed Error)
+$CHPL_HOME/modules/internal/ChapelError.chpl:345: note:                 chpl_fix_thrown_error(type errType)
+$CHPL_HOME/modules/internal/ChapelError.chpl:352: note:                 chpl_fix_thrown_error(err: unmanaged Error)
+$CHPL_HOME/modules/internal/ChapelError.chpl:367: note:                 chpl_fix_thrown_error(ref err: owned Error)

--- a/test/errhandling/lydia/notAnErrorSubtype-thrown.chpl
+++ b/test/errhandling/lydia/notAnErrorSubtype-thrown.chpl
@@ -1,0 +1,9 @@
+class Foo {
+  var s: string = "I ain't no error subtype";
+}
+
+proc main() throws {
+  try {
+    throw new Foo();
+  }
+}

--- a/test/errhandling/lydia/notAnErrorSubtype-thrown.future
+++ b/test/errhandling/lydia/notAnErrorSubtype-thrown.future
@@ -1,0 +1,2 @@
+error message: throwing something that is not an Error subtype
+#11403

--- a/test/errhandling/lydia/notAnErrorSubtype-thrown.good
+++ b/test/errhandling/lydia/notAnErrorSubtype-thrown.good
@@ -1,0 +1,2 @@
+notAnErrorSubtype-thrown.chpl:5: In function 'main':
+notAnErrorSubtype-thrown.chpl:7: error: cannot throw something that is not a subtype of Error

--- a/test/errhandling/lydia/rethrownGenerally-nested.chpl
+++ b/test/errhandling/lydia/rethrownGenerally-nested.chpl
@@ -1,4 +1,4 @@
-// Code from issue opened by BryantLam on Github
+// Code from issue #10224 opened by BryantLam on Github
 module ExceptionWarning {
   proc main() {
     try {

--- a/test/errhandling/lydia/rethrownGenerally-nested.chpl
+++ b/test/errhandling/lydia/rethrownGenerally-nested.chpl
@@ -1,0 +1,17 @@
+// Code from issue opened by BryantLam on Github
+module ExceptionWarning {
+  proc main() {
+    try {
+      try {
+        throw new NilThrownError();
+      }
+      catch e1: NilThrownError {
+        writeln("Caught NilThrownError");
+        throw e1;
+      }
+    }
+    catch e2 {
+      writeln("Caught general error");
+    }
+  }
+}

--- a/test/errhandling/lydia/rethrownGenerally-nested.good
+++ b/test/errhandling/lydia/rethrownGenerally-nested.good
@@ -1,0 +1,2 @@
+Caught NilThrownError
+Caught general error

--- a/test/errhandling/lydia/rethrownGenerally.chpl
+++ b/test/errhandling/lydia/rethrownGenerally.chpl
@@ -1,4 +1,4 @@
-// Code from issue opened by BryantLam on Github
+// Code from issue #10224 opened by BryantLam on Github
 module ExceptionWarning {
   proc main() throws {
     try {

--- a/test/errhandling/lydia/rethrownGenerally.chpl
+++ b/test/errhandling/lydia/rethrownGenerally.chpl
@@ -1,0 +1,12 @@
+// Code from issue opened by BryantLam on Github
+module ExceptionWarning {
+  proc main() throws {
+    try {
+      throw new NilThrownError();
+    }
+    catch e1: NilThrownError {
+      writeln("Caught NilThrownError");
+      throw e1;
+    }
+  }
+}

--- a/test/errhandling/lydia/rethrownGenerally.good
+++ b/test/errhandling/lydia/rethrownGenerally.good
@@ -1,0 +1,4 @@
+Caught NilThrownError
+uncaught NilThrownError: thrown error was nil
+  rethrownGenerally.chpl:9: thrown here
+  rethrownGenerally.chpl:3: uncaught here


### PR DESCRIPTION
We were getting a compilation warning/error about comparing distinct pointer
types without a cast when trying to rethrow an error that had been caught using
a specified subtype of Error.  E.g.

```chapel
try {
  ...
} catch e: SubError {
   throw e;
}
```

This change adds a cast when the type of the error being rethrown is not just
Error (and avoids adding a cast otherwise).

Resolves #10224 

Adds two tests to track this improved behavior (both of which failed before the
change).
- One where the rethrown error is in a top-level try/catch statement
- One where the rethrown error is in a nested try/catch statement (as provided
 in the issue which reported this problem)

Also adds five tests tracking classes that are not subtypes of Error:
- Throwing something that is not an error
- Catching something that is not an error
- Throwing and catching something that is not an error
- Catching something that is not an error and then rethrowing it
- Throwing, catching, and rethrowing something that is not an error

Passed a full paratest with futures