### PR TITLE
Better error for initializing param field with non-param

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -4939,7 +4939,7 @@ static void resolveInitField(CallExpr* call) {
     // Check against the symbol's Immediate is required because the symbol is
     // likely a temporary, which generally will suppress an error if
     // initialized from a non-param.
-    if (srcSym->isParameter() == false ||
+    else if (srcSym->isParameter() == false ||
         (isVarSymbol(srcSym) && getImmediate(srcSym) == NULL)) {
       USR_FATAL_CONT(call, "Initializing parameter '%s' to value not known at compile time", fs->name);
     }

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -4939,6 +4939,10 @@ static void resolveInitField(CallExpr* call) {
     // Check against the symbol's Immediate is required because the symbol is
     // likely a temporary, which generally will suppress an error if
     // initialized from a non-param.
+    //
+    // Note: This unfortunately relies on not checking the error when
+    // initializing the temporary, where it would be more difficult to
+    // determine the context of the initialization.
     else if (srcSym->isParameter() == false ||
             (isVarSymbol(srcSym) && getImmediate(srcSym) == NULL)) {
       USR_FATAL_CONT(call, "Initializing parameter '%s' to value not known at compile time", fs->name);

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -4940,7 +4940,7 @@ static void resolveInitField(CallExpr* call) {
     // likely a temporary, which generally will suppress an error if
     // initialized from a non-param.
     else if (srcSym->isParameter() == false ||
-        (isVarSymbol(srcSym) && getImmediate(srcSym) == NULL)) {
+            (isVarSymbol(srcSym) && getImmediate(srcSym) == NULL)) {
       USR_FATAL_CONT(call, "Initializing parameter '%s' to value not known at compile time", fs->name);
     }
   }

--- a/test/classes/initializers/generics/param-field-default-value-non-param-config-var.chpl
+++ b/test/classes/initializers/generics/param-field-default-value-non-param-config-var.chpl
@@ -4,6 +4,5 @@ class C {
   proc init() { }
 }
 
-var c = new C();
+var c = new owned C();
 writeln(c);
-delete c;

--- a/test/classes/initializers/generics/param-field-default-value-non-param-config-var.future
+++ b/test/classes/initializers/generics/param-field-default-value-non-param-config-var.future
@@ -1,5 +1,0 @@
-bug: class with initializer allows non-param default value for param field
-#8423
-
-Without the writeln() it compiles.
-With the writeln(), there's an error compiling the generated ChapelIO.c.

--- a/test/classes/initializers/generics/param-field-default-value-non-param-config-var.good
+++ b/test/classes/initializers/generics/param-field-default-value-non-param-config-var.good
@@ -1,1 +1,2 @@
-param-field-default-value-non-param-config-var.chpl:3: error: default value for param is not a param
+param-field-default-value-non-param-config-var.chpl:4: In initializer:
+param-field-default-value-non-param-config-var.chpl:4: error: Initializing parameter 'p' to value not known at compile time

--- a/test/classes/initializers/generics/param-field-default-value-non-param-field.chpl
+++ b/test/classes/initializers/generics/param-field-default-value-non-param-field.chpl
@@ -4,6 +4,5 @@ class C {
   proc init() { }
 }
 
-var c = new C();
+var c = new owned C();
 writeln(c);
-delete c;

--- a/test/classes/initializers/generics/param-field-default-value-non-param-field.future
+++ b/test/classes/initializers/generics/param-field-default-value-non-param-field.future
@@ -1,2 +1,0 @@
-bug: compiler segfault on class param field w/default value from non-param field
-#8443

--- a/test/classes/initializers/generics/param-field-default-value-non-param-field.good
+++ b/test/classes/initializers/generics/param-field-default-value-non-param-field.good
@@ -1,1 +1,2 @@
-param-field-default-value-non-param-field.chpl:3: error: default value for param is not a param
+param-field-default-value-non-param-field.chpl:4: In initializer:
+param-field-default-value-non-param-field.chpl:4: error: Initializing parameter 'p' to value not known at compile time


### PR DESCRIPTION
When initializing a param field, the compiler would insert a param temporary to store the default value for the param field. If the default value could not be evaluated at compile-time, the compiler would silently continue and later fail during code generation. This PR checks that the param temporary actually has an immediate, and if not issues an error.

Resolves #8423
Resolves #8443

Testing:
- [x] local + futures
- [x] gasnet + futures