### PR TITLE
Fix compiler performance issues in nilChecking

### DIFF
--- a/compiler/AST/bb.cpp
+++ b/compiler/AST/bb.cpp
@@ -527,6 +527,92 @@ void BasicBlock::buildLocalsVectorMap(FnSymbol*          fn,
   }
 }
 
+static
+void computeOrders(FnSymbol* fn,
+                   std::set<int>& visited,
+                   BasicBlock* bb,
+                   // mapping bb->id -> order in pre-order
+                   std::vector<int>& Pre,
+                   // mapping bb->id -> order in post-order
+                   std::vector<int>& Post,
+                   int & preJ,
+                   int & postI) {
+
+  // Following Muchnick p 180 Depth_First_search_PP
+
+  int x = bb->id;
+  visited.insert(x);
+  Pre[x] = preJ;
+  preJ += 1;
+
+  for_vector(BasicBlock, bbout, bb->outs) {
+    int y = bbout->id;
+    if (visited.count(y) == 0) {
+      computeOrders(fn, visited, bbout, Pre, Post, preJ, postI);
+    }
+  }
+
+  Post[x] = postI;
+  postI += 1;
+}
+
+void BasicBlock::computeForwardOrder(FnSymbol* fn,
+                                     std::vector<int> & order) {
+
+  size_t nbbs = fn->basicBlocks->size();
+  std::set<int> visited;
+  std::vector<int> Pre(nbbs);
+  std::vector<int> Post(nbbs);
+
+  int preJ = 0;
+  int postI = 0;
+
+  BasicBlock* root = (*fn->basicBlocks)[0];
+  computeOrders(fn, visited, root, Pre, Post, preJ, postI);
+
+  // This will fail for unreachable blocks
+  INT_ASSERT(Pre.size() == nbbs && Post.size() == nbbs);
+
+  order.resize(nbbs);
+
+  // Pre and Post map bb ids -> order, but the order to return
+  // is the inverse of that permutation. Plus we want reverse
+  // postorder...
+  for (size_t ii = 0; ii < nbbs; ii++) {
+    int index = Post[ii];
+    int reverseIndex = nbbs-index-1;
+    order[reverseIndex] = ii;
+  }
+}
+
+void BasicBlock::computeBackwardOrder(FnSymbol* fn,
+                                      std::vector<int> & order) {
+
+  size_t nbbs = fn->basicBlocks->size();
+  std::set<int> visited;
+  std::vector<int> Pre(nbbs);
+  std::vector<int> Post(nbbs);
+
+  int preJ = 0;
+  int postI = 0;
+
+  BasicBlock* root = (*fn->basicBlocks)[0];
+  computeOrders(fn, visited, root, Pre, Post, preJ, postI);
+
+  // This will fail for unreachable blocks
+  INT_ASSERT(Pre.size() == nbbs && Post.size() == nbbs);
+
+  order.resize(nbbs);
+
+  // Pre and Post map bb ids -> order, but the order to return
+  // is the inverse of that permutation. Plus we want reverse
+  // preorder...
+  for (size_t ii = 0; ii < nbbs; ii++) {
+    int index = Pre[ii];
+    int reverseIndex = nbbs-index-1;
+    order[reverseIndex] = ii;
+  }
+}
 
 //#define DEBUG_FLOW
 void BasicBlock::backwardFlowAnalysis(FnSymbol*             fn,

--- a/compiler/include/bb.h
+++ b/compiler/include/bb.h
@@ -64,6 +64,18 @@ public:
                                           Vec<Symbol*>&      locals,
                                           Map<Symbol*, int>& localMap);
 
+  // Stores the basic block ids in order in according to reverse postorder.
+  // Reverse postorder is useful for forward flow analysis
+  // to visit a node before any successors
+  static void        computeForwardOrder(FnSymbol* fn,
+                                         std::vector<int> & order);
+
+  // Stores the basic block ids in order according to reverse preorder.
+  // Reverse preorder is useful for backward flow analysis
+  // to visit a node after any successors
+  static void        computeBackwardOrder(FnSymbol* fn,
+                                          std::vector<int> & order);
+
   static void        backwardFlowAnalysis(FnSymbol*     fn,
                                           BitVecVector& GEN,
                                           BitVecVector& KILL,


### PR DESCRIPTION
Resolves #11351.

Improve nilChecking data flow analysis

 * only consider variables that can point to something (classes, refs)
 * renames aliasLocationCopyValueFrom to aliasLocationFromValue
 * adds aliasLocationFrom
 * adds update() to only update variables that can point to something
   (otherwise we get the default-constructed nodes from the
    map access; these were slowing the algorithm down)
 * quit early if the function has no refs or class instances
 * improve data flow fixed-point iteration to be more optimal
    * don't revisit blocks that have no new information
    * visit blocks in the reverse postorder ideal for forward data flow
       * adds functions to BasicBlock to compute these ideal orders
    * remove logic about separately creating nextIn;
      instead use a single combine() function that updates an IN[i]
      based on changes to an OUT[j].

- [x] full local testing

Reviewed by @vasslitvinov - thanks!