### PR TITLE
Add cast for integral:bigint

### DIFF
--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -381,6 +381,9 @@ module BigInteger {
   //
   // Cast operators
   //
+  proc _cast(type toType: bigint, src) {
+    return new bigint(src);
+  }
 
   pragma "no doc"
   inline proc _cast(type t, const ref x: bigint) where isIntType(t) {

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -381,7 +381,8 @@ module BigInteger {
   //
   // Cast operators
   //
-  proc _cast(type toType: bigint, src) {
+  pragma "no doc"
+  inline proc _cast(type toType: bigint, src: integral): bigint {
     return new bigint(src);
   }
 

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -430,6 +430,11 @@ module BigInteger {
   }
 
   pragma "no doc"
+  inline proc _cast(type toType: bigint, src: string): bigint {
+    return new bigint(src);
+  }
+
+  pragma "no doc"
   inline proc _cast(type t, const ref x: bigint) where isIntType(t) {
     var ret: c_long;
 

--- a/modules/standard/BigInteger.chpl
+++ b/modules/standard/BigInteger.chpl
@@ -36,7 +36,9 @@ The primary benefits of ``bigint`` over ``mpz_t`` are
   3) automatic memory management of GMP data structures
 
 In addition to the expected set of operations, this record provides
-a number of methods that wrap GMP functions in a natural way::
+a number of methods that wrap GMP functions in a natural way:
+
+.. code-block:: chapel
 
  use BigInteger;
 
@@ -49,6 +51,35 @@ a number of methods that wrap GMP functions in a natural way::
  c.fac(100);
  writeln(c);
 
+Casting and declarations can be used to create ``bigint`` records as
+well:
+
+.. code-block:: chapel
+
+ use BigInteger;
+
+ var   a = 234958444: bigint;
+ const b = "4847382292989382987395534934347": bigint;
+ var   c: bigint;
+
+.. warning::
+
+  Creating a ``bigint`` from an integer literal that is larger than
+  ``max(int(64))`` will result in integer overflow before the
+  ``bigint`` is created. Strings should be used instead of integer
+  literals for cases like this:
+
+  .. code-block:: chapel
+
+    // These result in integer overflow and give value of 18446744073709551615
+    var bad1 = 4847382292989382987395534934347: bigint;
+    var bad2 = new bigint(4847382292989382987395534934347);
+
+    // These result in the expected result
+    var good1 = "4847382292989382987395534934347": bigint;
+    var good2 = new bigint("4847382292989382987395534934347");
+
+
 Wrapping an ``mpz_t`` in a ``bigint`` record may introduce a
 measurable overhead in some cases.
 
@@ -59,13 +90,17 @@ than using many values of short duration.
 
 Matching this style using ``bigint`` records and the compound
 assignment operators is likely to provide comparable performance to an
-implementation based on ``mpz_t``.  So, for example::
+implementation based on ``mpz_t``.  So, for example:
+
+.. code-block:: chapel
 
   x  = b
   x *= c;
   x += a;
 
-is likely to achieve better performance than::
+is likely to achieve better performance than:
+
+.. code-block:: chapel
 
   x = a + b * c;
 
@@ -75,11 +110,15 @@ temporaries for the intermediate results of the binary operators.
 
 If peak performance is required, perhaps in a critical loop, then it
 is always possible to invoke the GMP functions directly.  For example
-one might express::
+one might express:
+
+.. code-block:: chapel
 
   a = a + b * c;
 
-as::
+as:
+
+.. code-block:: chapel
 
   mpz_addmul(a.mpz, b.mpz, c.mpz);
 
@@ -88,7 +127,9 @@ As usual the details are application specific and it is best to
 measure when peak performance is required.
 
 The operators on ``bigint`` include variations that accept Chapel
-integers e.g.::
+integers e.g.:
+
+.. code-block:: chapel
 
   var a = new bigint("9738639463465935");
   var b = 9395739153 * a;
@@ -110,7 +151,9 @@ truncated.  GMP primitives are used to first cast to platform-specific C
 types, which are then cast to Chapel types.  As a result, casting to
 64-bit types on 32-bit platforms may result in additional truncation.
 Additionally, casting a negative ``bigint`` to a ``uint`` will result in
-the absolute value truncated to fit within the type.::
+the absolute value truncated to fit within the type.:
+
+.. code-block:: chapel
 
   var a = new bigint(-1);
   writeln(a:uint);        // prints "1"
@@ -2226,7 +2269,7 @@ module BigInteger {
 /*
 Computes ``n/d`` and stores the result in ``bigint`` instance.
 
-``divexact`` is optimized to handle cases where ``n/d`` results in an integer. 
+``divexact`` is optimized to handle cases where ``n/d`` results in an integer.
 When ``n/d`` does not produce an integer, this method may produce incorrect results.
 
 :arg n: numerator

--- a/test/library/standard/BigInteger/testOps.chpl
+++ b/test/library/standard/BigInteger/testOps.chpl
@@ -63,6 +63,11 @@ proc testOps(x, y:bigint) {
 
   writeln(1:x.type, " >= ", y, " = ", 1:x.type>=y);
   writeln(y, " >= ", 1:x.type, " = ", y>=1:x.type);
+
+  // Casts to bigint
+  writeln(1:x.type:bigint:string, " == ", new bigint(1:x.type), " = ", 1:x.type:bigint == new bigint(1:x.type));
+  writeln((1:x.type:bigint).type:string, " == ", (new bigint(1:x.type)).type:string, " = ", (1:x.type:bigint).type == (new bigint(1:x.type)).type);
+
   writeln();
 }
 

--- a/test/library/standard/BigInteger/testOps.chpl
+++ b/test/library/standard/BigInteger/testOps.chpl
@@ -65,8 +65,12 @@ proc testOps(x, y:bigint) {
   writeln(y, " >= ", 1:x.type, " = ", y>=1:x.type);
 
   // Casts to bigint
-  writeln(1:x.type:bigint:string, " == ", new bigint(1:x.type), " = ", 1:x.type:bigint == new bigint(1:x.type));
-  writeln((1:x.type:bigint).type:string, " == ", (new bigint(1:x.type)).type:string, " = ", (1:x.type:bigint).type == (new bigint(1:x.type)).type);
+  writeln(x:bigint, " == ", new bigint(x), " = ", x:bigint == new bigint(x));
+  writeln((x:bigint).type:string, " == ", (new bigint(x)).type:string, " = ", (x:bigint).type == (new bigint(x)).type);
+
+  // String casts
+  writeln((x:string):bigint, " == ", new bigint(x), " = ", (x:string):bigint == new bigint(x));
+  writeln(new bigint(x:string), " == ", new bigint(x), " = ", new bigint(x:string) == new bigint(x));
 
   writeln();
 }

--- a/test/library/standard/BigInteger/testOps.good
+++ b/test/library/standard/BigInteger/testOps.good
@@ -37,6 +37,8 @@ Testing ops between int(64) and bigint
 1 > 1 = false
 1 >= 1 = true
 1 >= 1 = true
+1 == 1 = true
+bigint == bigint = true
 
 Testing ops between int(64) and bigint
 1 + 2 = 3
@@ -77,6 +79,8 @@ Testing ops between int(64) and bigint
 2 > 1 = true
 1 >= 2 = false
 2 >= 1 = true
+1 == 1 = true
+bigint == bigint = true
 
 Testing ops between uint(64) and bigint
 1 + 1 = 2
@@ -117,6 +121,8 @@ Testing ops between uint(64) and bigint
 1 > 1 = false
 1 >= 1 = true
 1 >= 1 = true
+1 == 1 = true
+bigint == bigint = true
 
 Testing ops between uint(64) and bigint
 1 + 2 = 3
@@ -157,6 +163,8 @@ Testing ops between uint(64) and bigint
 2 > 1 = true
 1 >= 2 = false
 2 >= 1 = true
+1 == 1 = true
+bigint == bigint = true
 
 Testing ops between bigint and bigint
 1 + 1 = 2
@@ -197,6 +205,8 @@ Testing ops between bigint and bigint
 1 > 1 = false
 1 >= 1 = true
 1 >= 1 = true
+1 == 1 = true
+bigint == bigint = true
 
 Testing ops between bigint and bigint
 1 + 2 = 3
@@ -237,4 +247,6 @@ Testing ops between bigint and bigint
 2 > 1 = true
 1 >= 2 = false
 2 >= 1 = true
+1 == 1 = true
+bigint == bigint = true
 

--- a/test/library/standard/BigInteger/testOps.good
+++ b/test/library/standard/BigInteger/testOps.good
@@ -39,6 +39,8 @@ Testing ops between int(64) and bigint
 1 >= 1 = true
 1 == 1 = true
 bigint == bigint = true
+1 == 1 = true
+1 == 1 = true
 
 Testing ops between int(64) and bigint
 1 + 2 = 3
@@ -81,6 +83,8 @@ Testing ops between int(64) and bigint
 2 >= 1 = true
 1 == 1 = true
 bigint == bigint = true
+1 == 1 = true
+1 == 1 = true
 
 Testing ops between uint(64) and bigint
 1 + 1 = 2
@@ -123,6 +127,8 @@ Testing ops between uint(64) and bigint
 1 >= 1 = true
 1 == 1 = true
 bigint == bigint = true
+1 == 1 = true
+1 == 1 = true
 
 Testing ops between uint(64) and bigint
 1 + 2 = 3
@@ -165,6 +171,8 @@ Testing ops between uint(64) and bigint
 2 >= 1 = true
 1 == 1 = true
 bigint == bigint = true
+1 == 1 = true
+1 == 1 = true
 
 Testing ops between bigint and bigint
 1 + 1 = 2
@@ -207,6 +215,8 @@ Testing ops between bigint and bigint
 1 >= 1 = true
 1 == 1 = true
 bigint == bigint = true
+1 == 1 = true
+1 == 1 = true
 
 Testing ops between bigint and bigint
 1 + 2 = 3
@@ -249,4 +259,6 @@ Testing ops between bigint and bigint
 2 >= 1 = true
 1 == 1 = true
 bigint == bigint = true
+1 == 1 = true
+1 == 1 = true
 


### PR DESCRIPTION
Adds a cast to the `BigInteger` module for integral types to `bigint`.

Additionally:
- Added a test case to `testOps.chpl` 
- Updated documentation to mention ability to cast
- Updated documentation to warn about integer literal overflows when creating `bigint`s
- Updated documentation to use Chapel syntax highlighting

## Testing
- [x] linux64

Closes #11365