### PR TITLE
Strengthen const checking

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5229,11 +5229,11 @@ static bool  moveTypesAreAcceptable(Type* lhsType, Type* rhsType);
 
 static void  moveHaltForUnacceptableTypes(CallExpr* call);
 
-static void  resolveMoveForRhsSymExpr(CallExpr* call);
+static void  resolveMoveForRhsSymExpr(CallExpr* call, SymExpr* rhs);
 
 static void  resolveMoveForRhsCallExpr(CallExpr* call);
 
-static void  moveSetConstFlagsAndCheck(CallExpr* call);
+static void  moveSetConstFlagsAndCheck(CallExpr* call, CallExpr* rhs);
 
 static void  moveSetFlagsAndCheckForConstAccess(Symbol*   lhs,
                                                 CallExpr* rhs,
@@ -5277,8 +5277,8 @@ static void resolveMove(CallExpr* call) {
       // NB: This call will not return
       moveHaltForUnacceptableTypes(call);
 
-    } else if (isSymExpr(rhs)  == true) {
-      resolveMoveForRhsSymExpr(call);
+    } else if (SymExpr* rhsSymExpr = toSymExpr(rhs)) {
+      resolveMoveForRhsSymExpr(call, rhsSymExpr);
 
     } else if (isCallExpr(rhs) == true) {
       resolveMoveForRhsCallExpr(call);
@@ -5470,10 +5470,6 @@ static Type* moveDetermineLhsType(CallExpr* call) {
   return lhsSym->type;
 }
 
-
-
-
-
 //
 //
 //
@@ -5520,25 +5516,24 @@ static void moveHaltForUnacceptableTypes(CallExpr* call) {
   }
 }
 
-
 //
 //
 //
 
-static void resolveMoveForRhsSymExpr(CallExpr* call) {
-  SymExpr* rhs = toSymExpr(call->get(2));
+static void resolveMoveForRhsSymExpr(CallExpr* call, SymExpr* rhs) {
+  Symbol* lhsSym = toSymExpr(call->get(1))->symbol();
+  Symbol* rhsSym = rhs->symbol();
 
   // If this assigns into a loop index variable from a non-var iterator,
   // mark the variable constant.
   // If RHS is this special variable...
-  if (rhs->symbol()->hasFlag(FLAG_INDEX_OF_INTEREST) == true) {
-    Symbol* lhsSym  = toSymExpr(call->get(1))->symbol();
+  if (rhsSym->hasFlag(FLAG_INDEX_OF_INTEREST) == true) {
     Type*   rhsType = rhs->typeInfo();
 
     if (lhsSym->hasFlag(FLAG_INDEX_VAR) ||
         // non-zip forall over a standalone iterator
         (lhsSym->hasFlag(FLAG_TEMP) &&
-         rhs->symbol()->hasFlag(FLAG_INDEX_VAR))) {
+         rhsSym->hasFlag(FLAG_INDEX_VAR))) {
 
       // ... and not of a reference type
       // ... and not an array (arrays are always yielded by reference)
@@ -5552,9 +5547,12 @@ static void resolveMoveForRhsSymExpr(CallExpr* call) {
         lhsSym->addFlag(FLAG_CONST);
       }
     }
-  } else if (rhs->symbol()->hasFlag(FLAG_DELAY_GENERIC_EXPANSION)) {
-    Symbol* lhsSym  = toSymExpr(call->get(1))->symbol();
+  } else if (rhsSym->hasFlag(FLAG_DELAY_GENERIC_EXPANSION)) {
     lhsSym->addFlag(FLAG_DELAY_GENERIC_EXPANSION);
+
+  } else if (rhsSym->hasFlag(FLAG_REF_TO_CONST)) {
+    lhsSym->addFlag(FLAG_REF_TO_CONST);
+
   }
 
   moveFinalize(call);
@@ -5563,7 +5561,7 @@ static void resolveMoveForRhsSymExpr(CallExpr* call) {
 static void resolveMoveForRhsCallExpr(CallExpr* call) {
   CallExpr* rhs = toCallExpr(call->get(2));
 
-  moveSetConstFlagsAndCheck(call);
+  moveSetConstFlagsAndCheck(call, rhs);
 
   if (rhs->resolvedFunction() == gChplHereAlloc) {
     Symbol*  lhsType = call->get(1)->typeInfo()->symbol;
@@ -5679,10 +5677,10 @@ static void resolveMoveForRhsCallExpr(CallExpr* call) {
 }
 
 
-static void moveSetConstFlagsAndCheck(CallExpr* call) {
-  CallExpr* rhs    = toCallExpr(call->get(2));
-
-  if (rhs->isPrimitive(PRIM_GET_MEMBER)) {
+static void moveSetConstFlagsAndCheck(CallExpr* call, CallExpr* rhs) {
+  if (rhs->isPrimitive(PRIM_GET_MEMBER) ||
+      rhs->isPrimitive(PRIM_ADDR_OF))
+  {
     if (SymExpr* rhsBase = toSymExpr(rhs->get(1))) {
       if (rhsBase->symbol()->hasFlag(FLAG_CONST)        == true  ||
           rhsBase->symbol()->hasFlag(FLAG_REF_TO_CONST) == true) {

--- a/test/arrays/ferguson/enumerated-array.chpl
+++ b/test/arrays/ferguson/enumerated-array.chpl
@@ -1,7 +1,7 @@
 enum classVals {S, W, A, B, C, D};
 
 const Class: domain(classVals) = classVals.S..classVals.D;
-const probSizes:   [Class] int = [classVals.S=>1400, classVals.W=>7000, classVals.A=>14000, classVals.B=>75000, classVals.C=>150000, classVals.D=>150000];
+var   probSizes:   [Class] int = [classVals.S=>1400, classVals.W=>7000, classVals.A=>14000, classVals.B=>75000, classVals.C=>150000, classVals.D=>150000];
 
 ref x = probSizes(classVals.S);
 x += 1;

--- a/test/library/packages/Collection/DequeParity.chpl
+++ b/test/library/packages/Collection/DequeParity.chpl
@@ -39,13 +39,12 @@ coforall loc in Locales do on loc {
 
 // Half of the numbers are even, the other half are odd... Concurrent remove
 // half, expecting it to be even, then the other half expecting it to be odd...
-var (hasElem, elem) : (bool, int);
 forall 1 .. totalElems / 2 {
-  (hasElem, elem) = deque.popFront();
+  const (hasElem, elem) = deque.popFront();
   assert(hasElem && elem % 2 == 0);
 }
-forall i in 1 .. totalElems / 2 {
-  (hasElem, elem) = deque.popFront();
+forall 1 .. totalElems / 2 {
+  const (hasElem, elem) = deque.popFront();
   assert(hasElem && elem % 2 != 0);
 }
 

--- a/test/studies/comd/elegant/arrayOfStructs/util/Configs.chpl
+++ b/test/studies/comd/elegant/arrayOfStructs/util/Configs.chpl
@@ -18,7 +18,7 @@ config const nx   = nxyz,
              ny   = nxyz,
              nz   = nxyz;
 
-config const xproc = 1,
+config var   xproc = 1,
              yproc = 1,
              zproc = 1;
 

--- a/test/types/tuple/errors/tuple-assignment-1.chpl
+++ b/test/types/tuple/errors/tuple-assignment-1.chpl
@@ -1,0 +1,7 @@
+// from #9982
+
+proc main() {
+  const x = 12;
+  (x,) = (x + 1,); // x += 1;
+  writeln(x);
+}

--- a/test/types/tuple/errors/tuple-assignment-1.good
+++ b/test/types/tuple/errors/tuple-assignment-1.good
@@ -1,0 +1,2 @@
+tuple-assignment-1.chpl:3: In function 'main':
+tuple-assignment-1.chpl:5: error: illegal lvalue in assignment

--- a/test/types/tuple/errors/tuple-assignment-2.chpl
+++ b/test/types/tuple/errors/tuple-assignment-2.chpl
@@ -1,0 +1,11 @@
+// from #9982
+
+proc modify(const ref A) {
+  (A[0],) = (1,); // A[0] = 1;
+}
+
+proc main() {
+  var array: [0..#10] int;
+  modify(array);
+  writeln(array);
+}

--- a/test/types/tuple/errors/tuple-assignment-2.good
+++ b/test/types/tuple/errors/tuple-assignment-2.good
@@ -1,0 +1,2 @@
+tuple-assignment-2.chpl:3: In function 'modify':
+tuple-assignment-2.chpl:4: error: illegal lvalue in assignment


### PR DESCRIPTION
... by propagating FLAG_REF_TO_CONST upon a PRIM_MOVE
in a couple of cases where it wasn't propagated before:

* upon a 'move' from a PRIM_ADDR_OF of a constant or a ref-to-const,
* upon a 'move' from a ref-to-const.

While there, pass 'rhs' as an extra argument to a couple of functions
because it is already computed. Tidy up formatting.

Add the codes from #9982 as tests.

Fix const violations in existing code. The troublesome change in:

    test/library/packages/Collection/DequeParity.chpl

was made in #7322 for obscure reasons. Revert that here.

Testing: linux64 -futures, gasnet.

Resolves #9982.