### PR TITLE
Don't run the LCALS if_quad kernel in regular testing

### DIFF
--- a/test/release/examples/benchmarks/lcals/LCALSMain.execopts
+++ b/test/release/examples/benchmarks/lcals/LCALSMain.execopts
@@ -1,1 +1,1 @@
---run_shortLoops=false --run_mediumLoops=false
+--run_shortLoops=false --run_mediumLoops=false --runB_ifQuad=false


### PR DESCRIPTION
There is a numerical instability that causes it to get different answers
based on specifics of compiler used and optimization level. The
numerical instability can also cause performance differences.  See
issue #11336.

Turn it off using the config const runB_ifQuad.