### PR TITLE
Add a future to track an internal error for a generic type argument

### DIFF
--- a/test/functions/lydia/genericActualTypeArg.bad
+++ b/test/functions/lydia/genericActualTypeArg.bad
@@ -1,0 +1,7 @@
+genericActualTypeArg.chpl:6: internal error: CAL0124 chpl version 1.19.0 pre-release (ac8b4804db)
+
+Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
+please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
+the filename + line number above may be useful in working around the issue.
+

--- a/test/functions/lydia/genericActualTypeArg.chpl
+++ b/test/functions/lydia/genericActualTypeArg.chpl
@@ -1,0 +1,11 @@
+proc bar(type t) {
+  writeln(t: string);
+}
+
+bar(int);
+bar(Foo);
+
+
+class Foo {
+  var x;
+}

--- a/test/functions/lydia/genericActualTypeArg.future
+++ b/test/functions/lydia/genericActualTypeArg.future
@@ -1,0 +1,2 @@
+error message: internal error for generic type as arg should be user error
+#11410

--- a/test/functions/lydia/genericActualTypeArg.good
+++ b/test/functions/lydia/genericActualTypeArg.good
@@ -1,0 +1,1 @@
+genericActualTypeArg.chpl:6: error: the type of the actual argument 'Foo' is generic


### PR DESCRIPTION
I discovered that sending a generic type as an argument to a function resulted
in an internal error instead of a user-facing one.  This sounded familiar, but
I wasn't finding an issue for it, so I opened one (#11410).

It's probably pretty easy to fix though there is the consideration that
sometimes I've triggered that error by implementing something poorly in the
compiler.