### PR TITLE
Fix an issue with PRIM_ARRAY_ALLOC

### DIFF
--- a/compiler/codegen/expr.cpp
+++ b/compiler/codegen/expr.cpp
@@ -3651,13 +3651,24 @@ DEFINE_PRIM(PRIM_ARRAY_SHIFT_BASE_POINTER) {
       codegenWideAddrWithAddr(rv, shifted, ret.chplType);
     }
 }
+
+// Workaround for troubles with allocateData() in ChapelArray.chpl.
+static Expr* destExprForPrimArrayAlloc(CallExpr* call) {
+  Expr* dst = call->get(1);
+  if (! dst->isRefOrWideRef()) return dst; // nothing to do
+
+  CallExpr* deref = new CallExpr(PRIM_DEREF);
+  dst->replace(deref);
+  deref->insertAtTail(dst);
+  return deref;
+}
 DEFINE_PRIM(PRIM_ARRAY_ALLOC) {
     // get(1): return symbol
     // get(2): number of elements
     // get(3): desired sublocale
     // get(4): (temporary) make 2nd call?
     // get(5): (temporary) 2nd call: repeat previously returned ptr
-    GenRet dst = call->get(1);
+    GenRet dst = destExprForPrimArrayAlloc(call);
     GenRet alloced;
 
     INT_ASSERT(dst.isLVPtr);

--- a/compiler/passes/flattenFunctions.cpp
+++ b/compiler/passes/flattenFunctions.cpp
@@ -298,9 +298,11 @@ replaceVarUsesWithFormals(FnSymbol* fn, SymbolMap* vars) {
               }
             }
 
-            if ((call->isPrimitive(PRIM_MOVE)       && call->get(1) == se) ||
-                (call->isPrimitive(PRIM_ASSIGN)     && call->get(1) == se) ||
-                (call->isPrimitive(PRIM_SET_MEMBER) && call->get(1) == se) ||
+            if (( (call->isPrimitive(PRIM_MOVE)        ||
+                   call->isPrimitive(PRIM_ASSIGN)      ||
+                   call->isPrimitive(PRIM_SET_MEMBER)  ||
+                   call->isPrimitive(PRIM_ARRAY_ALLOC) )
+                  && call->get(1) == se)                                   ||
                 (call->isPrimitive(PRIM_GET_MEMBER))                       ||
                 (call->isPrimitive(PRIM_GET_MEMBER_VALUE))                 ||
                 (call->isPrimitive(PRIM_WIDE_GET_LOCALE))                  ||


### PR DESCRIPTION
#### BACKGROUND

#11395 factored out some calls to PRIM_ARRAY_ALLOC into allocateData(),
a nested function. The destination of the allocation, 'data', becomes
allocateData's ref formal upon flattenFunctions. 'data' is also
the first argument in the PRIM_ARRAY_ALLOC CallExpr.

#11395 pioneered having PRIM_ARRAY_ALLOC accept a ref formal as its
first argument, exposing the issue #11312. Turns out it also exposed
an issue when running with --no-denormalize or --baseline.

#### THIS EFFORT

* Upon flattenFunctions, do not add a PRIM_DEREF for the first argument
  of PRIM_ARRAY_ALLOC.

* During codegen, if the first argument of PRIM_ARRAY_ALLOC is a ref,
  replace it with its PRIM_DEREF.

This did not address #11312.

#### TESTING

* linux64
* gasnet
* --baseline
* --no-denormalize
* --no-denormalize --no-local
   for the tests failed in today's nightly tests

Merging immediately to quiet testing.
Seeking post-merge review from @mppf.