### PR TITLE
Add StencilDist support for zero fluff in one or more dimensions

### DIFF
--- a/test/distributions/bharshbarg/stencil/periodic.chpl
+++ b/test/distributions/bharshbarg/stencil/periodic.chpl
@@ -5,14 +5,15 @@ config const debug = false;
 config const maxFluff = 2;
 
 proc test(dom : domain) {
-  for i in 1..maxFluff do
-    test(dom, i);
+  for i in 1..maxFluff {
+    var halo : dom.rank * int;
+    for j in 1..dom.rank do halo(j) = i;
+    test(dom, halo);
+  }
 }
 
-proc test(dom : domain, hval : int) {
+proc test(dom : domain, halo : dom.rank * int) {
   param rank = dom.rank;
-  var halo : rank*int;
-  for i in 1..rank do halo(i) = hval;
 
   if debug then writeln("Testing domain ", dom, " with halo ", halo);
   var Space = dom dmapped Stencil(dom, fluff=halo, periodic=true);
@@ -39,5 +40,12 @@ test({-20..-10, -20..-10});
 test({1..10, 1..10, 1..10});
 test({-10..#30, -10..#30, -10..#30} by 3);
 test({-10..1, 5..24, 0..10} by 2);
+
+// At least one dimension has no fluff
+test({1..10, 1..10}, (1, 0));
+test({1..10, 1..10}, (0, 1));
+test({1..10, 1..10, 1..10}, (0, 1, 0));
+test({1..10, 1..10, 1..10}, (1, 0, 1));
+
 
 writeln("Success!");

--- a/test/distributions/bharshbarg/stencil/util.chpl
+++ b/test/distributions/bharshbarg/stencil/util.chpl
@@ -23,6 +23,14 @@ proc verifyStencil(A : [?dom], debug = false) {
     const base : rank*int;
     if neigh == base then continue; // skip when neigh is all 0s
 
+    // If halo(i) is zero, then there is nothing to check when neigh(i) != 0
+    //
+    // For example, if halo is '(1, 0)', then there is no fluff in the second
+    // dimension. Therefore the only valid 'neigh' values can be:
+    //   (-1, 0) (1, 0)
+    const skip = || reduce for (h,n) in zip(halo, neigh) do (h == 0 && n != 0);
+    if skip then continue;
+
     var ghost : rank*dom.dim(1).type;
     var actual : rank*dom.dim(1).type;
     for i in 1..rank {


### PR DESCRIPTION
This PR adds StencilDist support for 'fluff' values that contain zeroes. This allows users to define halo/fluff space in only some dimensions instead of all dimensions.

Resolves #10113

Tests that use StencilDist ( local + gasnet ):
- [x] distributions/bharshbarg/stencil
- [x] distributions/bharshbarg/subQuery.chpl
- [x] parallel/forall/vass/reduce-expr-with-forall-in-par-iter*.chpl
- [x] release/examples/benchmarks/miniMD
- [x] studies/prk/Stencil
- [x] studies/stencil9/stencil9-stencildist.chpl
- [x] users/npadmana/npb-mg/mg.chpl