### PR TITLE
Minor touch-ups on #11420

### DIFF
--- a/compiler/codegen/expr.cpp
+++ b/compiler/codegen/expr.cpp
@@ -3656,6 +3656,7 @@ DEFINE_PRIM(PRIM_ARRAY_SHIFT_BASE_POINTER) {
 static Expr* destExprForPrimArrayAlloc(CallExpr* call) {
   Expr* dst = call->get(1);
   if (! dst->isRefOrWideRef()) return dst; // nothing to do
+  INT_ASSERT(! dst->isWideRef()); // how to handle a wide ref?
 
   CallExpr* deref = new CallExpr(PRIM_DEREF);
   dst->replace(deref);

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -4255,8 +4255,7 @@ module ChapelArray {
     var callAgain: bool;
     var subloc = c_sublocid_none;
 
-    // can be 'inline' once we fix #11312
-    proc allocateData(param initialAlloc, allocSize) {
+    inline proc allocateData(param initialAlloc, allocSize) {
       // data allocation should match DefaultRectangular
       if initialAlloc then
         __primitive("array_alloc", data, allocSize, subloc, c_ptrTo(callAgain), c_nil);


### PR DESCRIPTION
* Mark allocateData() as 'inline'.

* Assert that the first arg of PRIM_ARRAY_ALLOC is never a wide ref.
  Handling the case of it being a wide ref, if encountered, is left
  as future work.

Passes testing: linux64, baseline, no-denormalize, ND + no-local,
gasnet mutlilocale tests.