### PR TITLE
Fix octal literals larger than 32 bits

### DIFF
--- a/compiler/util/stringutil.cpp
+++ b/compiler/util/stringutil.cpp
@@ -252,10 +252,12 @@ uint64_t octStr2uint64(const char* str, bool userSupplied,
     }
   }
 
-  uint64_t val = strtoul(str+2, NULL, 8);
-  // strtoul() converts the string to a number with base provided, in this
-  // case 8.  It returns a long; we are assuming here that an implicit
-  // conversion to a uint64_t is safe.
+  uint64_t val;
+  int numitems = sscanf(str+2, "%" SCNo64, &val);
+  if (numitems != 1) {
+    INT_FATAL("Illegal string passed to octStrToUint64");
+  }
+
   return val;
 }
 


### PR DESCRIPTION
Octal literals were read during parsing using the 'strtoul' function, which
returns a 'long'.  On some systems 'long' is 32 bits.  Instead, use 'sscanf'
with an explicit 64 bit specifier.  This fixes the new uintLiteralsNoOverflow
test to work on systems where 'long' is 32 bits.