### PR TITLE
Improve the error message upon wrong return type

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -2654,7 +2654,7 @@ void printResolutionErrorUnresolved(CallInfo&       info,
         const char* retKind =
           info.actuals.v[0]->hasFlag(FLAG_RVV) ? "return" : "yield";
         USR_FATAL_CONT(call,
-                       "cannot %s %s when the declared return type is %s",
+                       "cannot %s '%s' when the declared return type is '%s'",
                        retKind,
                        toString(info.actuals.v[1]->type),
                        toString(info.actuals.v[0]->type));

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -2649,6 +2649,16 @@ void printResolutionErrorUnresolved(CallInfo&       info,
                        "type mismatch in assignment from nil to %s",
                        toString(info.actuals.v[0]->type));
 
+      } else if (info.actuals.v[0]->hasFlag(FLAG_RVV) ||
+                 info.actuals.v[0]->hasFlag(FLAG_YVV)) {
+        const char* retKind =
+          info.actuals.v[0]->hasFlag(FLAG_RVV) ? "return" : "yield";
+        USR_FATAL_CONT(call,
+                       "cannot %s %s when the declared return type is %s",
+                       retKind,
+                       toString(info.actuals.v[1]->type),
+                       toString(info.actuals.v[0]->type));
+
       } else {
         USR_FATAL_CONT(call,
                        "type mismatch in assignment from %s to %s",

--- a/test/arrays/ferguson/return-array-as-int.good
+++ b/test/arrays/ferguson/return-array-as-int.good
@@ -1,2 +1,2 @@
 return-array-as-int.chpl:7: In function 'setRowNames':
-return-array-as-int.chpl:8: error: cannot return [domain(1,int(64),false)] int(64) when the declared return type is int(64)
+return-array-as-int.chpl:8: error: cannot return '[domain(1,int(64),false)] int(64)' when the declared return type is 'int(64)'

--- a/test/arrays/ferguson/return-array-as-int.good
+++ b/test/arrays/ferguson/return-array-as-int.good
@@ -1,2 +1,2 @@
 return-array-as-int.chpl:7: In function 'setRowNames':
-return-array-as-int.chpl:8: error: type mismatch in assignment from [domain(1,int(64),false)] int(64) to int(64)
+return-array-as-int.chpl:8: error: cannot return [domain(1,int(64),false)] int(64) when the declared return type is int(64)

--- a/test/functions/ferguson/error-return-parentclass.good
+++ b/test/functions/ferguson/error-return-parentclass.good
@@ -1,2 +1,2 @@
 error-return-parentclass.chpl:14: In function 'f':
-error-return-parentclass.chpl:15: error: cannot return Parent when the declared return type is Child
+error-return-parentclass.chpl:15: error: cannot return 'Parent' when the declared return type is 'Child'

--- a/test/functions/ferguson/error-return-parentclass.good
+++ b/test/functions/ferguson/error-return-parentclass.good
@@ -1,2 +1,2 @@
 error-return-parentclass.chpl:14: In function 'f':
-error-return-parentclass.chpl:15: error: type mismatch in assignment from Parent to Child
+error-return-parentclass.chpl:15: error: cannot return Parent when the declared return type is Child

--- a/test/functions/iterators/errors/incorrectYieldTypes.chpl
+++ b/test/functions/iterators/errors/incorrectYieldTypes.chpl
@@ -1,0 +1,14 @@
+
+proc myYieldType() type return int;
+
+iter IT(): myYieldType() {
+  if numLocales > 1 then
+    yield Locales;
+  else
+    yield LocaleSpace;
+}
+
+proc main {
+  for idx in IT() do
+    writeln(idx);
+}

--- a/test/functions/iterators/errors/incorrectYieldTypes.good
+++ b/test/functions/iterators/errors/incorrectYieldTypes.good
@@ -1,0 +1,2 @@
+incorrectYieldTypes.chpl:4: In iterator 'IT':
+incorrectYieldTypes.chpl:6: error: cannot yield [domain(1,int(64),false)] locale when the declared return type is int(64)

--- a/test/functions/iterators/errors/incorrectYieldTypes.good
+++ b/test/functions/iterators/errors/incorrectYieldTypes.good
@@ -1,2 +1,2 @@
 incorrectYieldTypes.chpl:4: In iterator 'IT':
-incorrectYieldTypes.chpl:6: error: cannot yield [domain(1,int(64),false)] locale when the declared return type is int(64)
+incorrectYieldTypes.chpl:6: error: cannot yield '[domain(1,int(64),false)] locale' when the declared return type is 'int(64)'

--- a/test/types/tuple/errors/returnWrongSize.good
+++ b/test/types/tuple/errors/returnWrongSize.good
@@ -1,2 +1,2 @@
 returnWrongSize.chpl:1: In function 'foo':
-returnWrongSize.chpl:3: error: cannot return 2*int(64) when the declared return type is 3*int(64)
+returnWrongSize.chpl:3: error: cannot return '2*int(64)' when the declared return type is '3*int(64)'

--- a/test/types/tuple/errors/returnWrongSize.good
+++ b/test/types/tuple/errors/returnWrongSize.good
@@ -1,2 +1,2 @@
 returnWrongSize.chpl:1: In function 'foo':
-returnWrongSize.chpl:3: error: type mismatch in assignment from 2*int(64) to 3*int(64)
+returnWrongSize.chpl:3: error: cannot return 2*int(64) when the declared return type is 3*int(64)


### PR DESCRIPTION
Change from "type mismatch in assignment" to
"cannot return XXX when the declared return type is YYY"
or "cannot yield ..." if in an iterator.

Update .good for the new error message.
Add a test for the yield case.

Testing: linux64 with futures.
