### PR TITLE
Make the error messages for int literals that are too big more consistent

### DIFF
--- a/compiler/AST/baseAST.cpp
+++ b/compiler/AST/baseAST.cpp
@@ -774,6 +774,16 @@ bool isCForLoop(const BaseAST* a)
   return (stmt != 0 && stmt->isCForLoop()) ? true : false;
 }
 
+/* Create a throw-away ast with a given filename and line number.
+   This can be used e.g. to pass a line and filename to USR_FATAL
+   since it only takes those from an AST, not directly. */
+VarSymbol* createASTforLineNumber(const char* filename, int line){
+  astlocT astloc(line, filename);
+  astlocMarker markAstLoc(astloc);
+  VarSymbol* lineTemp = newTemp();
+  return lineTemp;
+}
+
 /************************************* | **************************************
 *                                                                             *
 * Definitions for astlocMarker                                                *

--- a/compiler/include/baseAST.h
+++ b/compiler/include/baseAST.h
@@ -307,6 +307,8 @@ void   trace_remove(BaseAST* ast, char flag);
 void verifyInTree(BaseAST* ast, const char* msg);
 
 
+VarSymbol* createASTforLineNumber(const char* filename, int line);
+
 //
 // macro to update the global line number used to set the line number
 // of an AST node when it is constructed - or to print out the line

--- a/compiler/util/stringutil.cpp
+++ b/compiler/util/stringutil.cpp
@@ -168,14 +168,10 @@ void deleteStrings() {
     }                                                             \
     if (strcmp(str+startPos, checkStr) != 0) {                    \
       if (userSupplied) {                                         \
-        /* Need an ast with the correct line number */            \
-        /* information for the error */                           \
-        astlocT astloc(line, filename);                           \
-        astlocMarker markAstLoc(astloc);                          \
-        VarSymbol* lineTemp = newTemp();                          \
+        VarSymbol* lineTemp = createASTforLineNumber(filename,    \
+                                                     line);       \
         USR_FATAL(lineTemp, "Integer literal overflow: %s is too" \
                   " big for type " #type, str);                   \
-        delete lineTemp;                                          \
       } else {                                                    \
         INT_FATAL("Integer literal overflow: %s is too "          \
                   "big for type " #type, str);                    \
@@ -211,14 +207,9 @@ uint64_t binStr2uint64(const char* str, bool userSupplied,
   }
   if (strlen(str+startPos) > 64) {
     if (userSupplied) {
-      /* Need an ast with the correct line number */
-      /* information for the error */
-      astlocT astloc(line, filename);
-      astlocMarker markAstLoc(astloc);
-      VarSymbol* lineTemp = newTemp();
+      VarSymbol* lineTemp = createASTforLineNumber(filename, line);
       USR_FATAL(lineTemp, "Integer literal overflow: '%s' is too big "
                 "for type uint64", str);
-      delete lineTemp;
     } else {
       INT_FATAL("Integer literal overflow: '%s' is too big "
                 "for type uint64", str);
@@ -258,14 +249,9 @@ uint64_t octStr2uint64(const char* str, bool userSupplied,
 
   if (len-startPos > 22 || (len-startPos == 22 && str[startPos] != '1')) {
     if (userSupplied) {
-      /* Need an ast with the correct line number */
-      /* information for the error */
-      astlocT astloc(line, filename);
-      astlocMarker markAstLoc(astloc);
-      VarSymbol* lineTemp = newTemp();
+      VarSymbol* lineTemp = createASTforLineNumber(filename, line);
       USR_FATAL(lineTemp, "Integer literal overflow: '%s' is too big "
                 "for type uint64", str);
-      delete lineTemp;
     } else {
       INT_FATAL("Integer literal overflow: '%s' is too big "
                 "for type uint64", str);
@@ -296,14 +282,9 @@ uint64_t hexStr2uint64(const char* str, bool userSupplied,
 
   if (strlen(str+startPos) > 16) {
     if (userSupplied) {
-      /* Need an ast with the correct line number */
-      /* information for the error */
-      astlocT astloc(line, filename);
-      astlocMarker markAstLoc(astloc);
-      VarSymbol* lineTemp = newTemp();
+      VarSymbol* lineTemp = createASTforLineNumber(filename, line);
       USR_FATAL(lineTemp, "Integer literal overflow: '%s' is too big "
                 "for type uint64", str);
-      delete lineTemp;
     } else {
       INT_FATAL("Integer literal overflow: '%s' is too big "
                 "for type uint64", str);

--- a/compiler/util/stringutil.cpp
+++ b/compiler/util/stringutil.cpp
@@ -23,8 +23,10 @@
 
 #include "stringutil.h"
 
+#include "baseAST.h"
 #include "map.h"
 #include "misc.h"
+#include "symbol.h"
 
 #include <algorithm>
 #include <climits>
@@ -166,8 +168,14 @@ void deleteStrings() {
     }                                                             \
     if (strcmp(str+startPos, checkStr) != 0) {                    \
       if (userSupplied) {                                         \
-        USR_FATAL("%s:%d: Integer literal overflow: %s is too "   \
-                  "big for type " #type, filename, line, str);    \
+        /* Need an ast with the correct line number */            \
+        /* information for the error */                           \
+        astlocT astloc(line, filename);                           \
+        astlocMarker markAstLoc(astloc);                          \
+        VarSymbol* lineTemp = newTemp();                          \
+        USR_FATAL(lineTemp, "Integer literal overflow: %s is too" \
+                  " big for type " #type, str);                   \
+        delete lineTemp;                                          \
       } else {                                                    \
         INT_FATAL("Integer literal overflow: %s is too "          \
                   "big for type " #type, str);                    \
@@ -203,8 +211,14 @@ uint64_t binStr2uint64(const char* str, bool userSupplied,
   }
   if (strlen(str+startPos) > 64) {
     if (userSupplied) {
-      USR_FATAL("%s:%d: Integer literal overflow: '%s' is too big "
-                "for type uint64", filename, line, str);
+      /* Need an ast with the correct line number */
+      /* information for the error */
+      astlocT astloc(line, filename);
+      astlocMarker markAstLoc(astloc);
+      VarSymbol* lineTemp = newTemp();
+      USR_FATAL(lineTemp, "Integer literal overflow: '%s' is too big "
+                "for type uint64", str);
+      delete lineTemp;
     } else {
       INT_FATAL("Integer literal overflow: '%s' is too big "
                 "for type uint64", str);
@@ -244,8 +258,14 @@ uint64_t octStr2uint64(const char* str, bool userSupplied,
 
   if (len-startPos > 22 || (len-startPos == 22 && str[startPos] != '1')) {
     if (userSupplied) {
-      USR_FATAL("%s:%d: Integer literal overflow: '%s' is too big "
-                "for type uint64", filename, line, str);
+      /* Need an ast with the correct line number */
+      /* information for the error */
+      astlocT astloc(line, filename);
+      astlocMarker markAstLoc(astloc);
+      VarSymbol* lineTemp = newTemp();
+      USR_FATAL(lineTemp, "Integer literal overflow: '%s' is too big "
+                "for type uint64", str);
+      delete lineTemp;
     } else {
       INT_FATAL("Integer literal overflow: '%s' is too big "
                 "for type uint64", str);
@@ -276,8 +296,14 @@ uint64_t hexStr2uint64(const char* str, bool userSupplied,
 
   if (strlen(str+startPos) > 16) {
     if (userSupplied) {
-      USR_FATAL("%s:%d: Integer literal overflow: '%s' is too big "
-                "for type uint64", filename, line, str);
+      /* Need an ast with the correct line number */
+      /* information for the error */
+      astlocT astloc(line, filename);
+      astlocMarker markAstLoc(astloc);
+      VarSymbol* lineTemp = newTemp();
+      USR_FATAL(lineTemp, "Integer literal overflow: '%s' is too big "
+                "for type uint64", str);
+      delete lineTemp;
     } else {
       INT_FATAL("Integer literal overflow: '%s' is too big "
                 "for type uint64", str);

--- a/test/expressions/diten/uintBinaryOverflow.good
+++ b/test/expressions/diten/uintBinaryOverflow.good
@@ -1,1 +1,1 @@
-error: uintBinaryOverflow.chpl:1: Integer literal overflow: '0b10000000000000000000000000000000000000000000000000000000000000000' is too big for type uint64
+uintBinaryOverflow.chpl:1: error: Integer literal overflow: '0b10000000000000000000000000000000000000000000000000000000000000000' is too big for type uint64

--- a/test/expressions/diten/uintDecimalOverflow.good
+++ b/test/expressions/diten/uintDecimalOverflow.good
@@ -1,1 +1,1 @@
-error: uintDecimalOverflow.chpl:1: Integer literal overflow: 18446744073709551616 is too big for type uint64
+uintDecimalOverflow.chpl:1: error: Integer literal overflow: 18446744073709551616 is too big for type uint64

--- a/test/expressions/diten/uintHexOverflow.good
+++ b/test/expressions/diten/uintHexOverflow.good
@@ -1,1 +1,1 @@
-error: uintHexOverflow.chpl:1: Integer literal overflow: '0x10000000000000000' is too big for type uint64
+uintHexOverflow.chpl:1: error: Integer literal overflow: '0x10000000000000000' is too big for type uint64

--- a/test/expressions/diten/uintOctalOverflow.good
+++ b/test/expressions/diten/uintOctalOverflow.good
@@ -1,1 +1,1 @@
-error: uintOctalOverflow.chpl:1: Integer literal overflow: '0o2000000000000000000000' is too big for type uint64
+uintOctalOverflow.chpl:1: error: Integer literal overflow: '0o2000000000000000000000' is too big for type uint64

--- a/test/types/integral/tooBig.good
+++ b/test/types/integral/tooBig.good
@@ -1,1 +1,1 @@
-error: tooBig.chpl:1: Integer literal overflow: 1000000000000000000000000000000 is too big for type uint64
+tooBig.chpl:1: error: Integer literal overflow: 1000000000000000000000000000000 is too big for type uint64


### PR DESCRIPTION
The errors for overflows when converting a string to a uint(64) for an
integer literal don't have an AST around, so had to explicitly give the
filename and line number in the format string.  This led to them being after
the word "error:" instead of before it.  Fix this by creating an otherwise
unused  AST with the correct line and file information and passing it to
USR_ERROR.