### PR TITLE
Change error when calling throwing task function to calling function within it

### DIFF
--- a/compiler/passes/errorHandling.cpp
+++ b/compiler/passes/errorHandling.cpp
@@ -945,10 +945,10 @@ bool ErrorCheckingVisitor::enterCallExpr(CallExpr* node) {
         inThrowingFunction = parentFn->throwsError();
 
         if (!inThrowingFunction && isTaskFun(calledFn)) {
-          taskFunctionDepth = 1;
+          taskFunctionDepth++;
           calledFn->body->accept(this);
 
-          taskFunctionDepth = 0;
+          taskFunctionDepth--;
           return true;
         } else if (taskFunctionDepth > 0) {
           if (isTaskFun(calledFn)) {

--- a/test/errhandling/parallel/begin-calls-throwing-fn.chpl
+++ b/test/errhandling/parallel/begin-calls-throwing-fn.chpl
@@ -1,0 +1,18 @@
+// Double check error message when non-throws function calls throwing function
+// from begin statement
+use ExampleErrors;
+
+module M {
+  proc throwingFn() throws {
+    throw new StringError("test error");
+  }
+
+  proc badFn() {
+    begin {
+      throwingFn();
+    }
+  }
+}
+
+use M;
+badFn();

--- a/test/errhandling/parallel/begin-calls-throwing-fn.good
+++ b/test/errhandling/parallel/begin-calls-throwing-fn.good
@@ -1,0 +1,3 @@
+begin-calls-throwing-fn.chpl:10: In function 'badFn':
+begin-calls-throwing-fn.chpl:12: error: call to throwing function throwingFn without throws, try, or try! (relaxed mode)
+begin-calls-throwing-fn.chpl:6: note: throwing function throwingFn defined here

--- a/test/errhandling/parallel/begin-on-calls-throwing-fn.chpl
+++ b/test/errhandling/parallel/begin-on-calls-throwing-fn.chpl
@@ -1,0 +1,18 @@
+// Double check error message when non-throws function calls throwing function
+// from begin+on statement
+use ExampleErrors;
+
+module M {
+  proc throwingFn() throws {
+    throw new StringError("test error");
+  }
+
+  proc badFn() {
+    begin on Locales[numLocales-1] {
+      throwingFn();
+    }
+  }
+}
+
+use M;
+badFn();

--- a/test/errhandling/parallel/begin-on-calls-throwing-fn.good
+++ b/test/errhandling/parallel/begin-on-calls-throwing-fn.good
@@ -1,0 +1,3 @@
+begin-on-calls-throwing-fn.chpl:10: In function 'badFn':
+begin-on-calls-throwing-fn.chpl:12: error: call to throwing function throwingFn without throws, try, or try! (relaxed mode)
+begin-on-calls-throwing-fn.chpl:6: note: throwing function throwingFn defined here

--- a/test/errhandling/parallel/cobegin-calls-throwing-fn.chpl
+++ b/test/errhandling/parallel/cobegin-calls-throwing-fn.chpl
@@ -1,0 +1,19 @@
+// Double check error message when a non-throws function calls a throwing
+// function from a cobegin statement
+use ExampleErrors;
+
+module M {
+  proc throwingFn() throws {
+    throw new StringError("test error");
+  }
+
+  proc badFn() {
+    cobegin {
+      throwingFn();
+      throwingFn();
+    }
+  }
+}
+
+use M;
+badFn();

--- a/test/errhandling/parallel/cobegin-calls-throwing-fn.good
+++ b/test/errhandling/parallel/cobegin-calls-throwing-fn.good
@@ -1,0 +1,5 @@
+cobegin-calls-throwing-fn.chpl:10: In function 'badFn':
+cobegin-calls-throwing-fn.chpl:12: error: call to throwing function throwingFn without throws, try, or try! (relaxed mode)
+cobegin-calls-throwing-fn.chpl:6: note: throwing function throwingFn defined here
+cobegin-calls-throwing-fn.chpl:13: error: call to throwing function throwingFn without throws, try, or try! (relaxed mode)
+cobegin-calls-throwing-fn.chpl:6: note: throwing function throwingFn defined here

--- a/test/errhandling/parallel/cobegin-on-calls-throwing-fn.chpl
+++ b/test/errhandling/parallel/cobegin-on-calls-throwing-fn.chpl
@@ -1,0 +1,27 @@
+// Double check error message when a non-throws function calls a throwing
+// function from a cobegin+on statement
+use ExampleErrors;
+
+module M {
+  proc throwingFn() throws {
+    throw new StringError("test error");
+  }
+
+  proc badFn() {
+    cobegin {
+      {
+        on Locales[numLocales-1] {
+          throwingFn();
+        }
+      }
+      {
+        on Locales[numLocales-1] {
+          throwingFn();
+        }
+      }
+    }
+  }
+}
+
+use M;
+badFn();

--- a/test/errhandling/parallel/cobegin-on-calls-throwing-fn.good
+++ b/test/errhandling/parallel/cobegin-on-calls-throwing-fn.good
@@ -1,0 +1,5 @@
+cobegin-on-calls-throwing-fn.chpl:10: In function 'badFn':
+cobegin-on-calls-throwing-fn.chpl:14: error: call to throwing function throwingFn without throws, try, or try! (relaxed mode)
+cobegin-on-calls-throwing-fn.chpl:6: note: throwing function throwingFn defined here
+cobegin-on-calls-throwing-fn.chpl:19: error: call to throwing function throwingFn without throws, try, or try! (relaxed mode)
+cobegin-on-calls-throwing-fn.chpl:6: note: throwing function throwingFn defined here

--- a/test/errhandling/parallel/coforall-calls-throwing-fn.chpl
+++ b/test/errhandling/parallel/coforall-calls-throwing-fn.chpl
@@ -1,0 +1,14 @@
+// Example from Louis Jenkins in #10805
+// Covers error message when non-throws function calls a throwing function
+// from within a coforall statement
+module M {
+	proc throwingFn() throws {}
+	proc badFn() {
+		coforall i in 1..10 {
+			throwingFn();
+		}
+	}
+}
+
+use M;
+badFn();

--- a/test/errhandling/parallel/coforall-calls-throwing-fn.good
+++ b/test/errhandling/parallel/coforall-calls-throwing-fn.good
@@ -1,0 +1,3 @@
+coforall-calls-throwing-fn.chpl:6: In function 'badFn':
+coforall-calls-throwing-fn.chpl:8: error: call to throwing function throwingFn without throws, try, or try! (relaxed mode)
+coforall-calls-throwing-fn.chpl:5: note: throwing function throwingFn defined here

--- a/test/errhandling/parallel/coforall-on-calls-throwing-fn.chpl
+++ b/test/errhandling/parallel/coforall-on-calls-throwing-fn.chpl
@@ -1,0 +1,14 @@
+// Example from Louis Jenkins in #10805
+// Covers error message when non-throws function calls a throwing function
+// from within a coforall+on statement
+module M {
+	proc throwingFn() throws {}
+	proc badFn() {
+		coforall loc in Locales do on loc {
+			throwingFn();
+		}
+	}
+}
+
+use M;
+badFn();

--- a/test/errhandling/parallel/coforall-on-calls-throwing-fn.good
+++ b/test/errhandling/parallel/coforall-on-calls-throwing-fn.good
@@ -1,0 +1,3 @@
+coforall-on-calls-throwing-fn.chpl:6: In function 'badFn':
+coforall-on-calls-throwing-fn.chpl:8: error: call to throwing function throwingFn without throws, try, or try! (relaxed mode)
+coforall-on-calls-throwing-fn.chpl:5: note: throwing function throwingFn defined here

--- a/test/errhandling/parallel/for-calls-throwing-fn.chpl
+++ b/test/errhandling/parallel/for-calls-throwing-fn.chpl
@@ -1,0 +1,19 @@
+// Test calling a throwing function from a non-throwing function via a for loop
+use ExampleErrors;
+
+config const n = 1000;
+
+module M {
+  proc throwingFn() throws { }
+
+  proc test() {
+    writeln("before for block");
+    for i in 1..n {
+      throwingFn();
+    }
+    writeln("after for block");
+  }
+}
+
+use M;
+test();

--- a/test/errhandling/parallel/for-calls-throwing-fn.good
+++ b/test/errhandling/parallel/for-calls-throwing-fn.good
@@ -1,0 +1,3 @@
+for-calls-throwing-fn.chpl:9: In function 'test':
+for-calls-throwing-fn.chpl:12: error: call to throwing function throwingFn without throws, try, or try! (relaxed mode)
+for-calls-throwing-fn.chpl:7: note: throwing function throwingFn defined here

--- a/test/errhandling/parallel/forall-calls-throwing-fn.chpl
+++ b/test/errhandling/parallel/forall-calls-throwing-fn.chpl
@@ -1,0 +1,20 @@
+// Test calling a throwing function from a non-throwing function via a forall
+// loop
+use ExampleErrors;
+
+config const n = 1000;
+
+module M {
+  proc throwingFn() throws { }
+
+  proc test() {
+    writeln("before for block");
+    forall i in 1..n {
+      throwingFn();
+    }
+    writeln("after for block");
+  }
+}
+
+use M;
+test();

--- a/test/errhandling/parallel/forall-calls-throwing-fn.good
+++ b/test/errhandling/parallel/forall-calls-throwing-fn.good
@@ -1,0 +1,3 @@
+forall-calls-throwing-fn.chpl:10: In function 'test':
+forall-calls-throwing-fn.chpl:13: error: call to throwing function throwingFn without throws, try, or try! (relaxed mode)
+forall-calls-throwing-fn.chpl:8: note: throwing function throwingFn defined here

--- a/test/errhandling/parallel/strict/coforall-throws-strict-error.good
+++ b/test/errhandling/parallel/strict/coforall-throws-strict-error.good
@@ -1,4 +1,2 @@
 coforall-throws-strict-error.chpl:4: In function 'test':
-coforall-throws-strict-error.chpl:5: error: call to throwing function coforall_fn without try or try! (strict mode)
-coforall-throws-strict-error.chpl:5: note: throwing function coforall_fn defined here
-coforall-throws-strict-error.chpl:6: note: call to throwing function here
+coforall-throws-strict-error.chpl:6: error: cannot throw in a non-throwing function

--- a/test/errhandling/psahabu/coforall-try-bang.good
+++ b/test/errhandling/psahabu/coforall-try-bang.good
@@ -1,4 +1,3 @@
 coforall-try-bang.chpl:6: In function 'test':
-coforall-try-bang.chpl:7: error: call to throwing function coforall_fn without throws, try, or try! (relaxed mode)
-coforall-try-bang.chpl:7: note: throwing function coforall_fn defined here
-coforall-try-bang.chpl:10: note: call to throwing function here
+coforall-try-bang.chpl:9: error: call to throwing function throwme without throws, try, or try! (relaxed mode)
+coforall-try-bang.chpl:2: note: throwing function throwme defined here


### PR DESCRIPTION
Prior to this change, if a non-throwing function called a throwing function
within a coforall, cobegin, on, or begin, we would complain about the call to the
task function and use its name instead of the name of the function being called
within the task function.  This changes allows us to point to the actual call.

Basically, detects if a non-throwing function calls a task function marked as
throws.  If so, track how deep into that function we go and once we reach the
first call to a throwing function that is not a task function, act as though
the task functions weren't present (but only in the case where we know we have
gone into it from a non-throwing function and need to indicate the error).

Solves one of the two remaining issues in #10805 

Adds eight tests of the different variants where throws calls are wrapped.
Two worked prior to this change (the for and forall cases), while the other
six (begin, begin+on, cobegin, cobegin+on, coforall, and coforall+on) did not.

Also updates two old tests for the new behavior (both failed and used the coforall_fn
in the error message, one now fails in a different way and the other uses the
appropriate name instead of the coforall_fn)

Passed full standard paratest with futures, and the error handling directory with
CHPL_COMM=gasnet.