### PR TITLE
Specialized error messages for main()

### DIFF
--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -744,6 +744,8 @@ extern VarSymbol *gModuleInitIndentLevel;
 extern Symbol *gSyncVarAuxFields;
 extern Symbol *gSingleVarAuxFields;
 
+extern FnSymbol* chplUserMain;
+
 #define FUNC_NAME_MAX 256
 extern char llvmPrintIrName[FUNC_NAME_MAX+1];
 extern char llvmPrintIrStage[FUNC_NAME_MAX+1];

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5266,6 +5266,15 @@ static void  moveSetFlagsForConstAccess(Symbol*   lhs,
 
 static void  moveFinalize(CallExpr* call);
 
+// Helper: is this a move from the result of main()?
+static bool isMoveFromMain(CallExpr* call) {
+  INT_ASSERT(call->isPrimitive(PRIM_MOVE)); // caller responsibility
+  if (CallExpr* rhs = toCallExpr(call->get(2)))
+    if (FnSymbol* target = rhs->resolvedFunction())
+      if (target == chplUserMain)
+        return true;
+  return false;
+}
 
 
 static void resolveMove(CallExpr* call) {
@@ -5797,7 +5806,10 @@ static void moveFinalize(CallExpr* call) {
 
   } else {
     if (rhsValType != lhsValType) {
-      if (rhsType != dtNil) {
+      if (isMoveFromMain(call)) {
+        USR_FATAL(chplUserMain, "main() returns a non-integer (%s)",
+                  rhsValType->name());
+      } else if (rhsType != dtNil) {
         USR_FATAL(userCall(call),
                   "type mismatch in assignment from %s to %s",
                   toString(rhsType),

--- a/test/functions/vass/main-returns-non-int.chpl
+++ b/test/functions/vass/main-returns-non-int.chpl
@@ -1,0 +1,7 @@
+
+proc hi() { writeln("hello"); }
+
+proc main() {
+  hi();
+  return 0.0;
+}

--- a/test/functions/vass/main-returns-non-int.good
+++ b/test/functions/vass/main-returns-non-int.good
@@ -1,0 +1,1 @@
+main-returns-non-int.chpl:4: error: main() returns a non-integer (real(64))

--- a/test/functions/vass/main-returns-param.chpl
+++ b/test/functions/vass/main-returns-param.chpl
@@ -1,0 +1,9 @@
+// Returning a param is not a good idea because the body of main()
+// will not get executed.
+
+proc hi() { writeln("hello"); }
+
+proc main() param {
+  hi();
+  return 0;
+}

--- a/test/functions/vass/main-returns-param.good
+++ b/test/functions/vass/main-returns-param.good
@@ -1,0 +1,1 @@
+main-returns-param.chpl:6: error: main function cannot return a type or a param

--- a/test/functions/vass/main-returns-type.chpl
+++ b/test/functions/vass/main-returns-type.chpl
@@ -1,0 +1,7 @@
+
+proc hi() { writeln("hello"); }
+
+proc main() type {
+  hi();
+  return int;
+}

--- a/test/functions/vass/main-returns-type.good
+++ b/test/functions/vass/main-returns-type.good
@@ -1,0 +1,1 @@
+main-returns-type.chpl:4: error: main function cannot return a type or a param


### PR DESCRIPTION
Issue clearer error messages than "type mismatch in assignment" when:

* main() returns a non-integer
* main() has `type` or `param` return intent

While there, stash away the FnSymbol* for main() for the current Chapel program
and rename mainReturnsInt to mainReturnsSomething.

Add tests for these error messages.

Testing: linux64 -futures.