### PR TITLE
First class functions always override

### DIFF
--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -1734,6 +1734,7 @@ static Expr* createFunctionAsValue(CallExpr *call) {
 
   thisMethod->addFlag(FLAG_FIRST_CLASS_FUNCTION_INVOCATION);
   thisMethod->addFlag(FLAG_COMPILER_GENERATED);
+  thisMethod->addFlag(FLAG_OVERRIDE);
 
   thisMethod->insertFormalAtTail(new ArgSymbol(INTENT_BLANK,
                                                "_mt",


### PR DESCRIPTION
First class functions are currently implemented as classes that override methods on a class representing the FCF type. With `--developer` compilations, that meant that uses of first class functions generated a warning. This PR fixes the warning.

- [x] full local testing

Reviewed by @bradcray - thanks!