### PR TITLE
Associative coverage improvements

### DIFF
--- a/modules/internal/DefaultAssociative.chpl
+++ b/modules/internal/DefaultAssociative.chpl
@@ -715,43 +715,96 @@ module DefaultAssociative {
         }
       }
     }
-  
-    proc dsiSerialReadWrite(f /*: Reader or Writer*/) {
+
+    proc dsiSerialReadWrite(f /*: channel*/) {
       var binary = f.binary();
       var arrayStyle = f.styleElement(QIO_STYLE_ELEMENT_ARRAY);
       var isspace = arrayStyle == QIO_ARRAY_FORMAT_SPACE && !binary;
       var isjson = arrayStyle == QIO_ARRAY_FORMAT_JSON && !binary;
       var ischpl = arrayStyle == QIO_ARRAY_FORMAT_CHPL && !binary;
 
-      if isjson || ischpl {
-        f <~> new ioLiteral("[");
-      }
+      if !f.writing && ischpl {
+        this.readChapelStyleAssocArray(f);
+      } else {
+        if isjson || ischpl {
+          f <~> new ioLiteral("[");
+        }
 
-      var first = true;
-      for (key, val) in zip(this.dom, this) {
-        if first then first = false;
-        else if isspace then f <~> new ioLiteral(" ");
-        else if isjson || ischpl then f <~> new ioLiteral(", ");
-        f <~> val;
-      }
+        var first = true;
 
+        for (key, val) in zip(this.dom, this) {
+          if first then first = false;
+          else if isspace then f <~> new ioLiteral(" ");
+          else if isjson || ischpl then f <~> new ioLiteral(", ");
+
+          if f.writing && ischpl {
+            f <~> key;
+            f <~> new ioLiteral(" => ");
+          }
+
+          f <~> val;
+        }
+      }
       if isjson || ischpl {
         f <~> new ioLiteral("]");
       }
     }
+
+    proc readChapelStyleAssocArray(f) {
+      var first = true;
+      var read_end = false;
+
+      f <~> new ioLiteral("[");
+
+      while ! f.error() {
+        if first {
+          first = false;
+          // but check for a ]
+          f <~> new ioLiteral("]");
+          if f.error() == EFORMAT {
+            f.clearError();
+          } else {
+            read_end = true;
+            break;
+          }
+        } else {
+          // read a comma or a space.
+          f <~> new ioLiteral(",");
+
+          if f.error() == EFORMAT {
+            f.clearError();
+            // No comma.
+            break;
+          }
+        }
+
+        // Read a key
+        var key: idxType;
+        f <~> key;
+        // Read =>
+        f <~> new ioLiteral("=>");
+        // Read the value
+        f <~> dsiAccess(key);
+      }
+
+      if ! read_end {
+        f <~> new ioLiteral("]");
+      }
+    }
+
     proc dsiSerialWrite(f) { this.dsiSerialReadWrite(f); }
     proc dsiSerialRead(f) { this.dsiSerialReadWrite(f); }
-  
+
     //
     // Associative array interface
     //
-  
+
     iter dsiSorted(comparator) {
       use Sort;
       var tableCopy: [0..dom.dsiNumIndices-1] eltType;
       for (copy, slot) in zip(tableCopy.domain, dom._fullSlots()) do
         tableCopy(copy) = data(slot);
-  
+
       sort(tableCopy, comparator=comparator);
   
       for elem in tableCopy do

--- a/modules/internal/DefaultAssociative.chpl
+++ b/modules/internal/DefaultAssociative.chpl
@@ -729,9 +729,9 @@ module DefaultAssociative {
 
       var first = true;
       for (key, val) in zip(this.dom, this) {
-	if first then first = false;
-	else if isspace then f <~> new ioLiteral(" ");
-	else if isjson || ischpl then f <~> new ioLiteral(", ");
+        if first then first = false;
+        else if isspace then f <~> new ioLiteral(" ");
+        else if isjson || ischpl then f <~> new ioLiteral(", ");
         f <~> val;
       }
 

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1392,7 +1392,7 @@ module DefaultRectangular {
     proc dsiHasSingleLocalSubdomain() param return true;
 
     proc dsiLocalSubdomain() {
-      if (this.data.locale == here) {
+      if this.data.locale == here {
         return _getDomain(dom);
       } else {
         var a: domain(rank, idxType, stridable);

--- a/test/arrays/userAPI/assocArray.chpl
+++ b/test/arrays/userAPI/assocArray.chpl
@@ -1,0 +1,32 @@
+use assocArrayAPItest;
+
+proc main() {
+
+  // Ask that arrays are output with [1,2] style
+  stdout.lock();
+  var style = stdout._style();
+  style.array_style = QIO_ARRAY_FORMAT_CHPL:uint(8);
+  stdout._set_style(style);
+  stdout.unlock();
+
+  writeln([1,2,3]);
+
+  var D:domain(string);
+  var A:[D] real;
+
+  D += "zero";
+  D += "pointone";
+  D += "half";
+  D += "one";
+  D += "two";
+  D += "three";
+  D += "four";
+  D += "five";
+  D += "six";
+  D += "seven";
+  D += "eight";
+  D += "nine";
+  D += "ten";
+
+  testAssocArrayAPI(A);
+}

--- a/test/arrays/userAPI/assocArray.good
+++ b/test/arrays/userAPI/assocArray.good
@@ -1,0 +1,52 @@
+[1, 2, 3]
+----------------
+eltType is: real(64)
+idxType is: string
+rank is: 1
+
+size is: 13
+numElements is: 13
+shape is: (13)
+
+X is:
+[0.0, 0.1, 0.5, 1.0, 10.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
+
+X is:
+[0.1, 0.2, 0.6, 1.1, 10.1, 2.1, 3.1, 4.1, 5.1, 6.1, 7.1, 8.1, 9.1]
+
+X is:
+[0.1, 0.2, 0.6, 1.1, 10.1, 2.1, 3.1, 4.1, 5.1, 6.1, 7.1, 8.1, 9.1]
+
+low element is: 0.1
+
+X is:
+[0.2, 0.3, 0.7, 1.2, 10.2, 2.2, 3.2, 4.2, 5.2, 6.2, 7.2, 8.2, 9.2]
+
+X is:
+[0.2, 0.3, 0.7, 1.2, 10.2, 2.2, 3.2, 4.2, 5.2, 6.2, 7.2, 8.2, 9.2]
+
+low element is: 0.2
+
+X is:
+[0.3, 0.4, 0.8, 1.3, 10.3, 2.3, 3.3, 4.3, 5.3, 6.3, 7.3, 8.3, 9.3]
+
+X is:
+[0.4, 0.5, 0.9, 1.4, 10.4, 2.4, 3.4, 4.4, 5.4, 6.4, 7.4, 8.4, 9.4]
+
+X is:
+[0.5, 0.6, 1.0, 1.5, 10.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5, 9.5]
+
+X is:
+[0.6, 0.7, 1.1, 1.6, 10.6, 2.6, 3.6, 4.6, 5.6, 6.6, 7.6, 8.6, 9.6]
+
+target locales: [LOCALE0]
+local subdomain: {eight, five, four, half, nine, one, pointone, seven, six, ten, three, two, zero}
+local subdomains:
+{eight, five, four, half, nine, one, pointone, seven, six, ten, three, two, zero}
+
+is empty: false
+find last: (true, half)
+count last: 1
+equals same: true
+equals diff: false
+

--- a/test/arrays/userAPI/assocArray.good
+++ b/test/arrays/userAPI/assocArray.good
@@ -9,35 +9,35 @@ numElements is: 13
 shape is: (13)
 
 X is:
-[0.0, 0.1, 0.5, 1.0, 10.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
+[eight => 8.0, five => 5.0, four => 4.0, half => 0.5, nine => 9.0, one => 1.0, pointone => 0.1, seven => 7.0, six => 6.0, ten => 10.0, three => 3.0, two => 2.0, zero => 0.0]
 
 X is:
-[0.1, 0.2, 0.6, 1.1, 10.1, 2.1, 3.1, 4.1, 5.1, 6.1, 7.1, 8.1, 9.1]
+[eight => 8.1, five => 5.1, four => 4.1, half => 0.6, nine => 9.1, one => 1.1, pointone => 0.2, seven => 7.1, six => 6.1, ten => 10.1, three => 3.1, two => 2.1, zero => 0.1]
 
 X is:
-[0.1, 0.2, 0.6, 1.1, 10.1, 2.1, 3.1, 4.1, 5.1, 6.1, 7.1, 8.1, 9.1]
+[eight => 8.1, five => 5.1, four => 4.1, half => 0.6, nine => 9.1, one => 1.1, pointone => 0.2, seven => 7.1, six => 6.1, ten => 10.1, three => 3.1, two => 2.1, zero => 0.1]
 
 low element is: 0.1
 
 X is:
-[0.2, 0.3, 0.7, 1.2, 10.2, 2.2, 3.2, 4.2, 5.2, 6.2, 7.2, 8.2, 9.2]
+[eight => 8.2, five => 5.2, four => 4.2, half => 0.7, nine => 9.2, one => 1.2, pointone => 0.3, seven => 7.2, six => 6.2, ten => 10.2, three => 3.2, two => 2.2, zero => 0.2]
 
 X is:
-[0.2, 0.3, 0.7, 1.2, 10.2, 2.2, 3.2, 4.2, 5.2, 6.2, 7.2, 8.2, 9.2]
+[eight => 8.2, five => 5.2, four => 4.2, half => 0.7, nine => 9.2, one => 1.2, pointone => 0.3, seven => 7.2, six => 6.2, ten => 10.2, three => 3.2, two => 2.2, zero => 0.2]
 
 low element is: 0.2
 
 X is:
-[0.3, 0.4, 0.8, 1.3, 10.3, 2.3, 3.3, 4.3, 5.3, 6.3, 7.3, 8.3, 9.3]
+[eight => 8.3, five => 5.3, four => 4.3, half => 0.8, nine => 9.3, one => 1.3, pointone => 0.4, seven => 7.3, six => 6.3, ten => 10.3, three => 3.3, two => 2.3, zero => 0.3]
 
 X is:
-[0.4, 0.5, 0.9, 1.4, 10.4, 2.4, 3.4, 4.4, 5.4, 6.4, 7.4, 8.4, 9.4]
+[eight => 8.4, five => 5.4, four => 4.4, half => 0.9, nine => 9.4, one => 1.4, pointone => 0.5, seven => 7.4, six => 6.4, ten => 10.4, three => 3.4, two => 2.4, zero => 0.4]
 
 X is:
-[0.5, 0.6, 1.0, 1.5, 10.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5, 9.5]
+[eight => 8.5, five => 5.5, four => 4.5, half => 1.0, nine => 9.5, one => 1.5, pointone => 0.6, seven => 7.5, six => 6.5, ten => 10.5, three => 3.5, two => 2.5, zero => 0.5]
 
 X is:
-[0.6, 0.7, 1.1, 1.6, 10.6, 2.6, 3.6, 4.6, 5.6, 6.6, 7.6, 8.6, 9.6]
+[eight => 8.6, five => 5.6, four => 4.6, half => 1.1, nine => 9.6, one => 1.6, pointone => 0.7, seven => 7.6, six => 6.6, ten => 10.6, three => 3.6, two => 2.6, zero => 0.6]
 
 target locales: [LOCALE0]
 local subdomain: {eight, five, four, half, nine, one, pointone, seven, six, ten, three, two, zero}

--- a/test/arrays/userAPI/assocArray.prediff
+++ b/test/arrays/userAPI/assocArray.prediff
@@ -1,0 +1,1 @@
+../../../util/test/sort-words-within-literals

--- a/test/arrays/userAPI/assocArrayAPItest.chpl
+++ b/test/arrays/userAPI/assocArrayAPItest.chpl
@@ -1,0 +1,124 @@
+config param testError = 0, testDisplayRepresentation = false;
+
+proc readArray(X) {
+  X["zero"]  = 0.0;
+  X["pointone"]  = 0.1;
+  X["half"]  = 0.5;
+  X["one"]   = 1.0;
+  X["two"]   = 2.0;
+  X["three"] = 3.0;
+  X["four"]  = 4.0;
+  X["five"]  = 5.0;
+  X["six"]   = 6.0;
+  X["seven"] = 7.0;
+  X["eight"] = 8.0;
+  X["nine"]  = 9.0;
+  X["ten"]   = 10.0;
+}
+
+proc testAssocArrayAPI(X: []) {
+  // print header
+  writeln("----------------");
+
+  // Test generic aspects of arrays
+  writeln("eltType is: ", X.eltType: string);
+  writeln("idxType is: ", X.idxType: string);
+  writeln("rank is: ", X.rank);
+  writeln();
+
+
+  // Test simple queries
+  writeln("size is: ", X.size);
+  writeln("numElements is: ", X.numElements);
+  writeln("shape is: ", X.shape);
+  writeln();
+
+  // Test I/O
+  readArray(X);
+  writeln("X is:\n", X);
+  if testDisplayRepresentation {
+    writeln("X's representation:"); X.displayRepresentation();
+  }
+  writeln();
+
+  // Test write accesses via tuples and varargs
+  forall ind in X.domain do
+    X[ind] += 0.1;
+  writeln("X is:\n", X);
+  writeln();
+  if (X.rank > 1) then
+    forall ind in X.domain do
+      X[(...ind)] += 0.1;
+  writeln("X is:\n", X);
+  writeln();
+
+  var low = "zero";
+  var high = "half";
+
+  // Test read access via tuples and varargs
+  writeln("low element is: ", X[low]);
+  if (X.rank > 1) then
+    writeln("high element is: ", X[(...high)]);
+  writeln();
+
+  // Test local write accesses via tuples and varargs
+  forall ind in X.domain do
+    X.localAccess[ind] += 0.1;
+  writeln("X is:\n", X);
+  writeln();
+  if (X.rank > 1) then
+    forall ind in X.domain do
+      X.localAccess[(...ind)] += 0.1;
+  writeln("X is:\n", X);
+  writeln();
+
+  const domForLowHigh = if X.hasSingleLocalSubdomain() then X.localSubdomain() else X.domain;
+  // Test local read access via tuples and varargs
+  writeln("low element is: ", X.localAccess[low]);
+  if (X.rank > 1) then
+    writeln("high element is: ", X.localAccess[(...high)]);
+  writeln();
+
+  // Test serial iteration
+  for x in X do
+    x += 0.1;
+  writeln("X is:\n", X);
+  writeln();
+
+  // Test standalone parallel iteration
+  forall x in X do
+    x += 0.1;
+  writeln("X is:\n", X);
+  writeln();
+
+  // Test leader parallel iteration
+  forall (x,i) in zip(X, X.domain) do
+    x += 0.1;
+  writeln("X is:\n", X);
+  writeln();
+
+  // Test follower parallel iteration
+  forall (i,x) in zip(X.domain, X) do
+    x += 0.1;
+  writeln("X is:\n", X);
+  writeln();
+
+  // Test locality interface
+  writeln("target locales: ", X.targetLocales());
+  if (X.hasSingleLocalSubdomain()) then
+    writeln("local subdomain: ", X.localSubdomain());
+  writeln("local subdomains:");
+  for locdom in X.localSubdomains() do
+    writeln(locdom);
+  writeln();
+
+  // Test collection interface
+  writeln("is empty: ", X.isEmpty());
+  writeln("find last: ", X.find(X[high]));
+  writeln("count last: ", X.count(X[high]));
+  var Y = X;
+  writeln("equals same: ", X.equals(Y));
+  var Z = X + 0.1;
+  writeln("equals diff: ", X.equals(Z));
+  writeln();
+}

--- a/test/io/ferguson/assoc-array-chpl.chpl
+++ b/test/io/ferguson/assoc-array-chpl.chpl
@@ -1,0 +1,22 @@
+
+proc main() {
+  var tmp = opentmp();
+
+  var A = ["one"=>1, "two"=>2, "three"=>3];
+  var B:[A.domain] int;
+
+  {
+    tmp.writer().writef("%ht\n", A);
+  }
+
+  {
+    tmp.reader().readf("%ht\n", B);
+  }
+
+  for key in A.domain.sorted() {
+    writeln("A[", key, "]=", A[key]);
+  }
+  for key in B.domain.sorted() {
+    writeln("B[", key, "]=", B[key]);
+  }
+}

--- a/test/io/ferguson/assoc-array-chpl.good
+++ b/test/io/ferguson/assoc-array-chpl.good
@@ -1,0 +1,6 @@
+A[one]=1
+A[three]=3
+A[two]=2
+B[one]=1
+B[three]=3
+B[two]=2


### PR DESCRIPTION
* assoc array api test is based on the 2D one but omits slicing etc
* Added a few methods to DefaultAssociative in the process
* Added the ability to output associative arrays in a literal syntax
   which includes the keys. (I think the keys should be included
   in the default output as well, but that's a matter for issue  #11455).
   I added this so I could use the prediff to sort the array values.

- [x] full local testing

Reviewed by @benharsh - thanks!