### PR TITLE
Fix reduction leak for identity() method

### DIFF
--- a/compiler/resolution/implementForallIntents.cpp
+++ b/compiler/resolution/implementForallIntents.cpp
@@ -1967,11 +1967,10 @@ static void insertInitialization(ShadowVarSymbol* destVar, Symbol* srcVar) {
 
 static void insertInitialization(BlockStmt* destBlock,
                                  Symbol* destVar, Expr* srcExpr) {
-  VarSymbol* initTemp = new VarSymbol("initTemp");
-  destBlock->insertAtTail(new DefExpr(initTemp));
-  destBlock->insertAtTail(new CallExpr(PRIM_MOVE,
-                                                  initTemp, srcExpr));
-  insertInitialization(destBlock, destVar, initTemp);
+
+  Expr* initCall = new_Expr("'init var'(%S,%E)", destVar, srcExpr);
+  destBlock->insertAtTail(initCall);
+  normalize(initCall);
 }
 
 // insertDeinitialization() flavors: as (a1) or (a2) above


### PR DESCRIPTION
The compiler would sometimes leak the result of the ``identity()`` call for a reduction, likely due to missing flags on the ``initTemp`` variable. Instead of copying the right flags from somewhere else, this PR updates the relevant code to invoke normalization (which will apply the right flags).

Resolves #11442

Testing:
- [x] local + futures
- [x] gasnet + futures
- [x] memleaks
- [x] valgrind