### PR TITLE
Resolve issue where sync blocks were preventing proper error handling analysis

### DIFF
--- a/compiler/AST/TryStmt.cpp
+++ b/compiler/AST/TryStmt.cpp
@@ -31,8 +31,9 @@ BlockStmt* TryStmt::build(bool tryBang, BlockStmt* body) {
   return buildChplStmt(new TryStmt(tryBang, body, NULL));
 }
 
-BlockStmt* TryStmt::build(bool tryBang, BlockStmt* body, BlockStmt* catches) {
-  return buildChplStmt(new TryStmt(tryBang, body, catches));
+BlockStmt* TryStmt::build(bool tryBang, BlockStmt* body, BlockStmt* catches,
+                          bool isSyncTry) {
+  return buildChplStmt(new TryStmt(tryBang, body, catches, isSyncTry));
 }
 
 BlockStmt* TryStmt::buildChplStmt(Expr* expr) {
@@ -40,9 +41,11 @@ BlockStmt* TryStmt::buildChplStmt(Expr* expr) {
 }
 
 // catches are stored in a BlockStmt for convenient parsing
-TryStmt::TryStmt(bool tryBang, BlockStmt* body, BlockStmt* catches) : Stmt(E_TryStmt) {
+TryStmt::TryStmt(bool tryBang, BlockStmt* body, BlockStmt* catches,
+                 bool isSyncTry) : Stmt(E_TryStmt) {
   _tryBang = tryBang;
   _body    = body;
+  _isSyncTry = isSyncTry;
 
   _catches.parent = this;
   if (catches) {
@@ -65,6 +68,12 @@ BlockStmt* TryStmt::body() const {
 
 bool TryStmt::tryBang() const {
   return _tryBang;
+}
+
+// Indicates if the try/catch statement was inserted due to the presence of a
+// sync block instead of explicit user code.
+bool TryStmt::isSyncTry() const {
+  return _isSyncTry;
 }
 
 void TryStmt::accept(AstVisitor* visitor) {

--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -2689,7 +2689,8 @@ buildSyncStmt(Expr* stmt) {
   BlockStmt* body = toBlockStmt(stmt);
   INT_ASSERT(body);
 
-  TryStmt* t = new TryStmt(/* try! */ false, body, catches);
+  TryStmt* t = new TryStmt(/* try! */ false, body, catches,
+                           /* isSyncTry */ true);
 
   block->insertAtTail(t);
 

--- a/compiler/include/TryStmt.h
+++ b/compiler/include/TryStmt.h
@@ -29,13 +29,16 @@ public:
 
   static BlockStmt*   build(bool tryBang, Expr*      expr);
   static BlockStmt*   build(bool tryBang, BlockStmt* body);
-  static BlockStmt*   build(bool tryBang, BlockStmt* body, BlockStmt* catches);
+  static BlockStmt*   build(bool tryBang, BlockStmt* body, BlockStmt* catches,
+                            bool isSyncTry = false);
   static BlockStmt*   buildWithCatchall(BlockStmt* body, BlockStmt* onErr);
 
-                      TryStmt(bool tryBang, BlockStmt* body, BlockStmt* catches);
+  TryStmt(bool tryBang, BlockStmt* body, BlockStmt* catches,
+          bool isSyncTry = false);
                       ~TryStmt();
   BlockStmt*          body() const;
   bool                tryBang() const;
+  bool                isSyncTry() const;
 
   void                accept(AstVisitor* visitor);
   void                replaceChild(Expr* old_ast, Expr* new_ast);
@@ -51,6 +54,7 @@ public:
 
 private:
   bool                _tryBang;
+  bool                _isSyncTry;
 
   static BlockStmt*   buildChplStmt(Expr* expr);
                       TryStmt();

--- a/compiler/passes/errorHandling.cpp
+++ b/compiler/passes/errorHandling.cpp
@@ -890,13 +890,17 @@ ErrorCheckingVisitor::ErrorCheckingVisitor(bool inThrowingFn,
 }
 
 bool ErrorCheckingVisitor::enterTryStmt(TryStmt* node) {
-  tryDepth++;
+  if (!node->isSyncTry()) {
+    tryDepth++;
+  }
 
   return true;
 }
 
 void ErrorCheckingVisitor::exitTryStmt(TryStmt* node) {
-  tryDepth--;
+  if (!node->isSyncTry()) {
+    tryDepth--;
+  }
 
   checkCatches(node);
 

--- a/test/errhandling/parallel/sync-around-bad-throws-call.chpl
+++ b/test/errhandling/parallel/sync-around-bad-throws-call.chpl
@@ -1,0 +1,14 @@
+// Courtesy of Louis Jenkins via #10805
+// Tracks a non-throwing function using a sync around a coforall+on that calls
+// a throwing function
+module M {
+	proc throwingFn() throws {}
+	proc badFn() {
+		sync coforall loc in Locales do on loc {
+			throwingFn();
+		}
+	}
+}
+
+use M;
+badFn();

--- a/test/errhandling/parallel/sync-around-bad-throws-call.good
+++ b/test/errhandling/parallel/sync-around-bad-throws-call.good
@@ -1,0 +1,3 @@
+sync-around-bad-throws-call.chpl:6: In function 'badFn':
+sync-around-bad-throws-call.chpl:8: error: call to throwing function throwingFn without throws, try, or try! (relaxed mode)
+sync-around-bad-throws-call.chpl:5: note: throwing function throwingFn defined here

--- a/test/errhandling/parallel/try-sync-throws.chpl
+++ b/test/errhandling/parallel/try-sync-throws.chpl
@@ -1,0 +1,16 @@
+// Courtesy of Louis Jenkins via #10805
+// Tracks a non-throwing function using a try around a sync around a
+// coforall+on that calls a throwing function
+module M {
+	proc throwingFn() throws {}
+	proc goodFn() {
+    try! {
+      sync coforall loc in Locales do on loc {
+          throwingFn();
+        }
+		}
+	}
+}
+
+use M;
+goodFn();


### PR DESCRIPTION
Sync blocks rethrow the errors they have gathered using their inserted catch
statement, but our throws analysis assumed that try/catch statements would
either handle the error or have an additional throw statement that would be
checked - this meant that our analysis was not complaining about throw
statements or throws calls in non-throwing functions if the call or statement
happened to only be within a sync block.

This change alters TryStmt to track this fact about its creation via a private
field and a const method to access that field.  When the error handling pass
traverses the AST and performs these checks, it will now act as though the sync
try/catch statements are not present for the purpose of determining whether to
error about throwing errors in non-throwing functions.

Resolves #10805 

Add two tests of syncs around throwing calls in non-throwing functions.
- One covers the case where there isn't a try/try! around the sync, meaning the
error would get rethrown.  In relaxed mode, this should trigger and did not
until the changes that will get added in this PR.
- The other covers the case where the is one, to demonstrate that having these
structures around the sync do not trigger the error (this is probably a
duplicate of other tests, but I wanted to be certain)

The first did not work prior to this change, while the second ensures that the
change did not break good code.

Passed a standard paratest with futures