### PR TITLE
Warning for modifying scalar argument in promoted call

### DIFF
--- a/compiler/resolution/lateConstCheck.cpp
+++ b/compiler/resolution/lateConstCheck.cpp
@@ -313,4 +313,23 @@ void lateConstCheck(std::map<BaseAST*, BaseAST*> * reasonNotConst)
     // For now, don't check primitives. Compiler can be loose
     // with const-ness on its own internal temporaries.
   }
+
+  // Additionally check that promotion wrappers using a scalar this
+  // don't take it in by `ref`
+  forv_Vec(FnSymbol, fn, gFnSymbols) {
+    if (fn->hasFlag(FLAG_PROMOTION_WRAPPER)) {
+      for_formals(formal, fn) {
+        if (formal->intent == INTENT_REF) {
+          Type* vt = formal->getValType();
+          bool  scalar = vt->scalarPromotionType == NULL;
+          if (scalar) {
+            const char* err = "Racy promotion of scalar value";
+            if (formal == fn->_this)
+              err = "Racy promotion of scalar method receiver";
+            USR_FATAL_CONT(fn, err);
+          }
+        }
+      }
+    }
+  }
 }

--- a/compiler/resolution/lateConstCheck.cpp
+++ b/compiler/resolution/lateConstCheck.cpp
@@ -321,8 +321,9 @@ void lateConstCheck(std::map<BaseAST*, BaseAST*> * reasonNotConst)
       for_formals(formal, fn) {
         if (formal->intent == INTENT_REF) {
           Type* vt = formal->getValType();
-          bool  scalar = vt->scalarPromotionType == NULL;
-          if (scalar) {
+          if (vt->scalarPromotionType == NULL &&
+              !(isAtomicType(vt) || isSyncType(vt) || isSingleType(vt)) &&
+              !formal->hasFlag(FLAG_ERROR_VARIABLE)) {
             const char* err = "Racy promotion of scalar value";
             if (formal == fn->_this)
               err = "Racy promotion of scalar method receiver";

--- a/test/functions/promotion/racy-arg.chpl
+++ b/test/functions/promotion/racy-arg.chpl
@@ -25,7 +25,7 @@ proc test1() {
     writeln(B);
 
   noop(x, A);
-  increment(x, A); // "works" but should arguably generate an error
+  increment(x, A); // racy!
   writeln("1C expect ", 43 + (+ reduce A));
   writeln("1C    got ", x);
 }
@@ -55,7 +55,7 @@ proc test2() {
   var result:R;
 
   noop(result, A, B);
-  addem(result, A, B); // almost always a race condition!
+  addem(result, A, B); // racy!
   writeln("2B expect ", 2 * (+ reduce A.value));
   writeln("2B    got ", result.value);
 }

--- a/test/functions/promotion/racy-arg.chpl
+++ b/test/functions/promotion/racy-arg.chpl
@@ -1,0 +1,62 @@
+proc increment(ref rcv: int, x: int) {
+  rcv += x;
+}
+
+proc noop(const ref rcv: int, x: int) {
+}
+
+config const n = 5000;
+config const verbose = false;
+
+proc test1() {
+  var x = 42;
+  noop(x, 1);
+  increment(x, 1); // works as expected
+  writeln("1A expect ", 43);
+  writeln("1A    got ", 43);
+
+  var A: [1..n] int = 1..n;
+  var B: [1..n] int;
+  noop(B, A);
+  increment(B, A); // works as expected
+  writeln("1B expect ", + reduce A);
+  writeln("1B    got ", + reduce B);
+  if verbose then
+    writeln(B);
+
+  noop(x, A);
+  increment(x, A); // "works" but should arguably generate an error
+  writeln("1C expect ", 43 + (+ reduce A));
+  writeln("1C    got ", x);
+}
+test1();
+
+record R {
+  var value:int;
+}
+
+proc noop(const ref rcv: R, a:R, b:R) {
+}
+
+proc addem(ref rcv: R, a:R, b:R) {
+  rcv.value = a.value + b.value;
+}
+
+proc test2() {
+  var A:[1..n] R = [i in 1..n] new R(i);
+  var B:[1..n] R = [i in 1..n] new R(i);
+  var C:[1..n] R;
+
+  noop(C, A, B); //OK
+  addem(C, A, B); //OK
+  writeln("2A expect ", 2 * (+ reduce A.value));
+  writeln("2A    got ", + reduce C.value);
+
+  var result:R;
+
+  noop(result, A, B);
+  addem(result, A, B); // almost always a race condition!
+  writeln("2B expect ", 2 * (+ reduce A.value));
+  writeln("2B    got ", result.value);
+}
+test2();

--- a/test/functions/promotion/racy-arg.good
+++ b/test/functions/promotion/racy-arg.good
@@ -1,0 +1,4 @@
+racy-arg.chpl:1: error: non-lvalue actual is passed to 'ref' formal 'rcv' of increment()
+racy-arg.chpl:28: note: The shadow variable 'rcv' is constant due to forall intents in this loop
+racy-arg.chpl:41: error: non-lvalue actual is passed to 'ref' formal 'rcv' of addem()
+racy-arg.chpl:58: note: The shadow variable 'rcv' is constant due to forall intents in this loop

--- a/test/functions/promotion/racy-method-receiver.chpl
+++ b/test/functions/promotion/racy-method-receiver.chpl
@@ -1,0 +1,62 @@
+proc ref int.increment(x: int) {
+  this += x;
+}
+
+proc const ref int.noop(x: int) {
+}
+
+config const n = 5000;
+config const verbose = false;
+
+proc test1() {
+  var x = 42;
+  x.noop(1);
+  x.increment(1); // works as expected
+  writeln("1A expect ", 43);
+  writeln("1A    got ", 43);
+
+  var A: [1..n] int = 1..n;
+  var B: [1..n] int;
+  B.noop(A);
+  B.increment(A); // works as expected
+  writeln("1B expect ", + reduce A);
+  writeln("1B    got ", + reduce B);
+  if verbose then
+    writeln(B);
+
+  x.noop(A);
+  x.increment(A); // "works" but should arguably generate an error
+  writeln("1C expect ", 43 + (+ reduce A));
+  writeln("1C    got ", x);
+}
+test1();
+
+record R {
+  var value:int;
+}
+
+proc R.addem(a:R, b:R) {
+  this.value = a.value + b.value;
+}
+
+proc R.noop(a:R, b:R) {
+}
+
+proc test2() {
+  var A:[1..n] R = [i in 1..n] new R(i);
+  var B:[1..n] R = [i in 1..n] new R(i);
+  var C:[1..n] R;
+
+  C.noop(A, B); //OK
+  C.addem(A, B); //OK
+  writeln("2A expect ", 2 * (+ reduce A.value));
+  writeln("2A    got ", + reduce C.value);
+
+  var result:R;
+
+  result.noop(A, B); // OK
+  result.addem(A, B); // almost always a race condition!
+  writeln("2B expect ", 2 * (+ reduce A.value));
+  writeln("2B    got ", result.value);
+}
+test2();

--- a/test/functions/promotion/racy-method-receiver.chpl
+++ b/test/functions/promotion/racy-method-receiver.chpl
@@ -25,7 +25,7 @@ proc test1() {
     writeln(B);
 
   x.noop(A);
-  x.increment(A); // "works" but should arguably generate an error
+  x.increment(A); // racy!
   writeln("1C expect ", 43 + (+ reduce A));
   writeln("1C    got ", x);
 }
@@ -55,7 +55,7 @@ proc test2() {
   var result:R;
 
   result.noop(A, B); // OK
-  result.addem(A, B); // almost always a race condition!
+  result.addem(A, B); // racy!
   writeln("2B expect ", 2 * (+ reduce A.value));
   writeln("2B    got ", result.value);
 }

--- a/test/functions/promotion/racy-method-receiver.good
+++ b/test/functions/promotion/racy-method-receiver.good
@@ -1,0 +1,2 @@
+racy-method-receiver.chpl:28: error: Racy promotion of scalar method receiver
+racy-method-receiver.chpl:58: error: Racy promotion of scalar method receiver


### PR DESCRIPTION
Resolves #10412.

Added checking in lateConstChecking because default
record `this` intent is only established at that point
(between `ref` and `const ref`). The check finds scalar
values passed to promotion wrappers that aren't on a
list of acceptable types.

- [x] full local testing

Reviewed by @lydia-duncan - thanks!