### PR TITLE
Do not copy the coforall's iterator expression

### DIFF
--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -1378,6 +1378,7 @@ BlockStmt* buildCoforallLoopStmt(Expr* indices,
   VarSymbol* tmpIter = newTemp("tmpIter");
   tmpIter->addFlag(FLAG_EXPR_TEMP);
   tmpIter->addFlag(FLAG_MAYBE_REF);
+  tmpIter->addFlag(FLAG_NO_COPY);
 
   BlockStmt* coforallBlk = new BlockStmt();
   coforallBlk->insertAtTail(new DefExpr(tmpIter));


### PR DESCRIPTION
During callDestructors in `ReturnByRef::updateAssignmentsFromModuleLevelValue`
the compiler was inserting an autoCopy for PRIM_MOVEs from a global record.
The compiler-generated 'tmpIter' would never be freed, and so the copy leaked.

Instead, add FLAG_NO_COPY to the 'tmpIter' variable and avoid the copy entirely.

Testing:
- [x] local + futures
- [x] gasnet + futures
- [x] memleaks (resolves ``parallel/forall/vass/reduce-fatter-with-for-in-par-iter.chpl``)
- [x] valgrind