### PR TITLE
Improve error message when throwing something that is not an Error subtype

### DIFF
--- a/modules/internal/ChapelError.chpl
+++ b/modules/internal/ChapelError.chpl
@@ -370,7 +370,8 @@ module ChapelError {
 
   pragma "no doc"
   proc chpl_fix_thrown_error(err: ?t) where !isSubtype(t, Error) {
-    compilerError("cannot throw something that is not a subtype of Error");
+    compilerError("Cannot throw an instance of type \'", (t: borrowed): string,
+                  "\', not a subtype of Error");
   }
 
   pragma "no doc"

--- a/modules/internal/ChapelError.chpl
+++ b/modules/internal/ChapelError.chpl
@@ -369,8 +369,26 @@ module ChapelError {
   }
 
   pragma "no doc"
-  proc chpl_fix_thrown_error(err: ?t) where !isSubtype(t, Error) {
+  pragma "last resort"
+  proc chpl_fix_thrown_error(err: ?t) where !isSubtype(t, Error) &&
+    isRecordType(t) {
+    compilerError("Cannot throw an instance of type \'", t: string,
+                  "\', not a subtype of Error");
+  }
+
+  pragma "no doc"
+  pragma "last resort"
+  proc chpl_fix_thrown_error(err: ?t) where !isSubtype(t, Error) &&
+    isClassType(t) {
     compilerError("Cannot throw an instance of type \'", (t: borrowed): string,
+                  "\', not a subtype of Error");
+  }
+
+  pragma "no doc"
+  pragma "last resort"
+  proc chpl_fix_thrown_error(err: ?t) where !isSubtype(t, Error) &&
+    !isRecordType(t) && !isClassType(t) {
+    compilerError("Cannot throw an instance of type \'", t: string,
                   "\', not a subtype of Error");
   }
 

--- a/modules/internal/ChapelError.chpl
+++ b/modules/internal/ChapelError.chpl
@@ -369,6 +369,11 @@ module ChapelError {
   }
 
   pragma "no doc"
+  proc chpl_fix_thrown_error(err: ?t) where !isSubtype(t, Error) {
+    compilerError("cannot throw something that is not a subtype of Error");
+  }
+
+  pragma "no doc"
   proc chpl_delete_error(err: unmanaged Error) {
     if err != nil then delete err;
   }

--- a/test/errhandling/lydia/notAnErrorSubtype-caught2.bad
+++ b/test/errhandling/lydia/notAnErrorSubtype-caught2.bad
@@ -1,6 +1,0 @@
-notAnErrorSubtype-caught2.chpl:5: In function 'main':
-notAnErrorSubtype-caught2.chpl:7: error: unresolved call 'chpl_fix_thrown_error(unmanaged Foo)'
-$CHPL_HOME/modules/internal/ChapelError.chpl:339: note: candidates are: chpl_fix_thrown_error(err: borrowed Error)
-$CHPL_HOME/modules/internal/ChapelError.chpl:345: note:                 chpl_fix_thrown_error(type errType)
-$CHPL_HOME/modules/internal/ChapelError.chpl:352: note:                 chpl_fix_thrown_error(err: unmanaged Error)
-$CHPL_HOME/modules/internal/ChapelError.chpl:367: note:                 chpl_fix_thrown_error(ref err: owned Error)

--- a/test/errhandling/lydia/notAnErrorSubtype-caught2.future
+++ b/test/errhandling/lydia/notAnErrorSubtype-caught2.future
@@ -1,2 +1,0 @@
-error message: throwing something that is not an Error subtype
-#11403

--- a/test/errhandling/lydia/notAnErrorSubtype-caught2.good
+++ b/test/errhandling/lydia/notAnErrorSubtype-caught2.good
@@ -1,2 +1,2 @@
 notAnErrorSubtype-caught2.chpl:5: In function 'main':
-notAnErrorSubtype-caught2.chpl:7: error: cannot throw something that is not a subtype of Error
+notAnErrorSubtype-caught2.chpl:7: error: Cannot throw an instance of type 'Foo', not a subtype of Error

--- a/test/errhandling/lydia/notAnErrorSubtype-rethrown.bad
+++ b/test/errhandling/lydia/notAnErrorSubtype-rethrown.bad
@@ -1,6 +1,0 @@
-notAnErrorSubtype-rethrown.chpl:5: In function 'main':
-notAnErrorSubtype-rethrown.chpl:10: error: unresolved call 'chpl_fix_thrown_error(Foo)'
-$CHPL_HOME/modules/internal/ChapelError.chpl:339: note: candidates are: chpl_fix_thrown_error(err: borrowed Error)
-$CHPL_HOME/modules/internal/ChapelError.chpl:345: note:                 chpl_fix_thrown_error(type errType)
-$CHPL_HOME/modules/internal/ChapelError.chpl:352: note:                 chpl_fix_thrown_error(err: unmanaged Error)
-$CHPL_HOME/modules/internal/ChapelError.chpl:367: note:                 chpl_fix_thrown_error(ref err: owned Error)

--- a/test/errhandling/lydia/notAnErrorSubtype-rethrown.future
+++ b/test/errhandling/lydia/notAnErrorSubtype-rethrown.future
@@ -1,2 +1,0 @@
-error message: throwing something that is not an Error subtype
-#11403

--- a/test/errhandling/lydia/notAnErrorSubtype-rethrown.good
+++ b/test/errhandling/lydia/notAnErrorSubtype-rethrown.good
@@ -1,2 +1,2 @@
 notAnErrorSubtype-rethrown.chpl:5: In function 'main':
-notAnErrorSubtype-rethrown.chpl:10: error: cannot throw something that is not a subtype of Error
+notAnErrorSubtype-rethrown.chpl:10: error: Cannot throw an instance of type 'Foo', not a subtype of Error

--- a/test/errhandling/lydia/notAnErrorSubtype-rethrown2.bad
+++ b/test/errhandling/lydia/notAnErrorSubtype-rethrown2.bad
@@ -1,6 +1,0 @@
-notAnErrorSubtype-rethrown2.chpl:5: In function 'main':
-notAnErrorSubtype-rethrown2.chpl:7: error: unresolved call 'chpl_fix_thrown_error(unmanaged Foo)'
-$CHPL_HOME/modules/internal/ChapelError.chpl:339: note: candidates are: chpl_fix_thrown_error(err: borrowed Error)
-$CHPL_HOME/modules/internal/ChapelError.chpl:345: note:                 chpl_fix_thrown_error(type errType)
-$CHPL_HOME/modules/internal/ChapelError.chpl:352: note:                 chpl_fix_thrown_error(err: unmanaged Error)
-$CHPL_HOME/modules/internal/ChapelError.chpl:367: note:                 chpl_fix_thrown_error(ref err: owned Error)

--- a/test/errhandling/lydia/notAnErrorSubtype-rethrown2.future
+++ b/test/errhandling/lydia/notAnErrorSubtype-rethrown2.future
@@ -1,2 +1,0 @@
-error message: throwing something that is not an Error subtype
-#11403

--- a/test/errhandling/lydia/notAnErrorSubtype-rethrown2.good
+++ b/test/errhandling/lydia/notAnErrorSubtype-rethrown2.good
@@ -1,2 +1,2 @@
 notAnErrorSubtype-rethrown2.chpl:5: In function 'main':
-notAnErrorSubtype-rethrown2.chpl:7: error: cannot throw something that is not a subtype of Error
+notAnErrorSubtype-rethrown2.chpl:7: error: Cannot throw an instance of type 'Foo', not a subtype of Error

--- a/test/errhandling/lydia/notAnErrorSubtype-thrown-int.chpl
+++ b/test/errhandling/lydia/notAnErrorSubtype-thrown-int.chpl
@@ -1,0 +1,5 @@
+proc main() throws {
+  try {
+    throw 5;
+  }
+}

--- a/test/errhandling/lydia/notAnErrorSubtype-thrown-int.good
+++ b/test/errhandling/lydia/notAnErrorSubtype-thrown-int.good
@@ -1,0 +1,2 @@
+notAnErrorSubtype-thrown-int.chpl:1: In function 'main':
+notAnErrorSubtype-thrown-int.chpl:3: error: Cannot throw an instance of type 'int(64)', not a subtype of Error

--- a/test/errhandling/lydia/notAnErrorSubtype-thrown-owned.chpl
+++ b/test/errhandling/lydia/notAnErrorSubtype-thrown-owned.chpl
@@ -1,0 +1,9 @@
+class Foo {
+  var s: string = "I ain't no error subtype";
+}
+
+proc main() throws {
+  try {
+    throw new owned Foo();
+  }
+}

--- a/test/errhandling/lydia/notAnErrorSubtype-thrown-owned.good
+++ b/test/errhandling/lydia/notAnErrorSubtype-thrown-owned.good
@@ -1,0 +1,2 @@
+notAnErrorSubtype-thrown-owned.chpl:5: In function 'main':
+notAnErrorSubtype-thrown-owned.chpl:7: error: Cannot throw an instance of type 'Foo', not a subtype of Error

--- a/test/errhandling/lydia/notAnErrorSubtype-thrown-record.chpl
+++ b/test/errhandling/lydia/notAnErrorSubtype-thrown-record.chpl
@@ -1,0 +1,9 @@
+record Foo {
+  var s: string = "I ain't no error subtype";
+}
+
+proc main() throws {
+  try {
+    throw new Foo();
+  }
+}

--- a/test/errhandling/lydia/notAnErrorSubtype-thrown-record.good
+++ b/test/errhandling/lydia/notAnErrorSubtype-thrown-record.good
@@ -1,0 +1,2 @@
+notAnErrorSubtype-thrown-record.chpl:5: In function 'main':
+notAnErrorSubtype-thrown-record.chpl:7: error: Cannot throw an instance of type 'Foo', not a subtype of Error

--- a/test/errhandling/lydia/notAnErrorSubtype-thrown.bad
+++ b/test/errhandling/lydia/notAnErrorSubtype-thrown.bad
@@ -1,6 +1,0 @@
-notAnErrorSubtype-thrown.chpl:5: In function 'main':
-notAnErrorSubtype-thrown.chpl:7: error: unresolved call 'chpl_fix_thrown_error(unmanaged Foo)'
-$CHPL_HOME/modules/internal/ChapelError.chpl:339: note: candidates are: chpl_fix_thrown_error(err: borrowed Error)
-$CHPL_HOME/modules/internal/ChapelError.chpl:345: note:                 chpl_fix_thrown_error(type errType)
-$CHPL_HOME/modules/internal/ChapelError.chpl:352: note:                 chpl_fix_thrown_error(err: unmanaged Error)
-$CHPL_HOME/modules/internal/ChapelError.chpl:367: note:                 chpl_fix_thrown_error(ref err: owned Error)

--- a/test/errhandling/lydia/notAnErrorSubtype-thrown.future
+++ b/test/errhandling/lydia/notAnErrorSubtype-thrown.future
@@ -1,2 +1,0 @@
-error message: throwing something that is not an Error subtype
-#11403

--- a/test/errhandling/lydia/notAnErrorSubtype-thrown.good
+++ b/test/errhandling/lydia/notAnErrorSubtype-thrown.good
@@ -1,2 +1,2 @@
 notAnErrorSubtype-thrown.chpl:5: In function 'main':
-notAnErrorSubtype-thrown.chpl:7: error: cannot throw something that is not a subtype of Error
+notAnErrorSubtype-thrown.chpl:7: error: Cannot throw an instance of type 'Foo', not a subtype of Error


### PR DESCRIPTION
Prior to this change, we would get a resolution error on the call to
chpl_fix_thrown_error when trying to throw a function that wasn't a subtype of
Error.  The user could probably figure out this meant they were throwing a bad
type, but it is better to say so plainly and not rely on error messages involving
calls to implementation specific functions.  This change adds an overload of
chpl_fix_thrown_error which takes in types that aren't subtypes of Error and
will emit a nicer error message

Resolves #11403 

Fixes the futures linked in #11403, and adds a variant for an explicitly owned
class instance, and for throwing an int instead of a class.  All of these tests pass.

Passed full paratest with futures