### PR TITLE
Throw error instead of segfault for empty Spawn calls

### DIFF
--- a/modules/standard/Spawn.chpl
+++ b/modules/standard/Spawn.chpl
@@ -375,6 +375,7 @@ module Spawn {
      without heroic effort on our part.  Boo.
    */
 
+  // TODO: Document throws when is #11374 merged
   /*
      Create a subprocess.
 
@@ -449,6 +450,9 @@ module Spawn {
     else compilerError("only FORWARD/CLOSE/PIPE/STDOUT supported");
     if isIntegralType(stderr.type) then stderr_fd = stderr;
     else compilerError("only FORWARD/CLOSE/PIPE/STDOUT supported");
+
+    if args.size == 0 then
+      throw new IllegalArgumentError('args cannot be an empty array');
 
     // When memory is registered with the NIC under ugni, a fork will currently
     // segfault. Here we halt before such a call is made to provide an
@@ -589,6 +593,7 @@ module Spawn {
     return ret;
   }
 
+  // TODO: Document throws when is #11374 merged
   /*
      Create a subprocess by invoking a shell.
 
@@ -650,6 +655,9 @@ module Spawn {
                   executable="/bin/sh", shellarg="-c",
                   param kind=iokind.dynamic, param locking=true) throws
   {
+    if command.isEmptyString() then
+      throw new IllegalArgumentError('command cannot be an empty string');
+
     var args = [command];
     if shellarg != "" then args.push_front(shellarg);
     args.push_front(executable);

--- a/modules/standard/Spawn.chpl
+++ b/modules/standard/Spawn.chpl
@@ -375,7 +375,6 @@ module Spawn {
      without heroic effort on our part.  Boo.
    */
 
-  // TODO: Document throws when is #11374 merged
   /*
      Create a subprocess.
 
@@ -430,6 +429,7 @@ module Spawn {
      :returns: a :record:`subprocess` with kind and locking set according
                to the arguments.
 
+     :throws IllegalArgumentError: Thrown when ``args`` is an empty array.
      */
   proc spawn(args:[] string, env:[] string=Spawn.empty_env, executable="",
              stdin:?t = FORWARD, stdout:?u = FORWARD, stderr:?v = FORWARD,
@@ -593,7 +593,6 @@ module Spawn {
     return ret;
   }
 
-  // TODO: Document throws when is #11374 merged
   /*
      Create a subprocess by invoking a shell.
 
@@ -649,6 +648,7 @@ module Spawn {
      :returns: a :record:`subprocess` with kind and locking set according
                to the arguments.
 
+     :throws IllegalArgumentError: Thrown when ``command`` is an empty string.
   */
   proc spawnshell(command:string, env:[] string=Spawn.empty_env,
                   stdin:?t = FORWARD, stdout:?u = FORWARD, stderr:?v = FORWARD,

--- a/test/library/standard/Spawn/illegal-args.chpl
+++ b/test/library/standard/Spawn/illegal-args.chpl
@@ -1,0 +1,19 @@
+use Spawn only;
+
+proc main() throws {
+  try {
+    var s: [1..0] string;
+    var p = Spawn.spawn(s);
+    p.communicate();
+  } catch e: IllegalArgumentError {
+    writeln(e.message());
+  }
+
+  try {
+    var p = Spawn.spawnshell('');
+    p.communicate();
+  } catch e: IllegalArgumentError {
+    writeln(e.message());
+  }
+
+}

--- a/test/library/standard/Spawn/illegal-args.good
+++ b/test/library/standard/Spawn/illegal-args.good
@@ -1,0 +1,2 @@
+args cannot be an empty array
+command cannot be an empty string


### PR DESCRIPTION
Passing an empty array and string to `Spawn.spawn()` and `Spawn.spawnshell()`, respectively, resulted in a seg fault. This PR adds a check to throw an `IllegalArgumentError` when this happens.
