### PR TITLE
Clean files mentioned in directory-wide CLEANFILES for individual test run

### DIFF
--- a/util/test/sub_clean
+++ b/util/test/sub_clean
@@ -100,6 +100,7 @@ for f in clean:
         cleanCleanfiles(f, 'CLEANFILES', True)
     else:
         cleanChapelTest(f)
+        cleanCleanfiles(os.path.dirname(f), 'CLEANFILES', True)
 
 sys.exit(0);
 


### PR DESCRIPTION
Prior to this change, we would only clean up files listed in a directory-wide
CLEANFILES if the whole directory had been specified.  If an individual test
had been listed instead, we would only clean up its expected executable and
anything mentioned in its specific .cleanfiles.  This meant that a CLEANFILES
specified like this:

```
foo/*.tmpfile # each test generates a .tmpfile of its own
```

would only clean up the .tmpfile if the directory as a whole was run, or if the
test writer added an individual .cleanfiles per test (which seemed like a
burden).

Resolves #10937 

Behavior with this change (verified):
- If a directory is specified, everything mentioned in its CLEANFILES and
individual .cleanfiles will get cleaned up before the directory is run (as
before)
- If a single individual test in a directory is specified, everything mentioned
in the directory's CLEANFILES and in that test's individual .cleanfiles will
get cleaned up
- When two tests in the same directory are listed explicitly to the same
start_test run, the second one will clean up files generated by the first one
prior to doing anything else.
- When all the tests in a directory are specified using *.chpl, the same
behavior as the "two test" case will occur, with each successive test cleaning
up after the previous one
  - In both cases, .out.tmp files from failed runs will remain through the end
    of the start_test execution (they will not get cleaned up by the following
    test case, as desired)

I also ran paratest to see its behavior with this change