### PR TITLE
Simple fix for array casts

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -3918,6 +3918,12 @@ module ChapelArray {
     } else if chpl__tryToken { // try to parallelize using leader and follower iterators
       forall (aa,bb) in zip(a,b) do
         aa = bb;
+    } else if chpl__tryToken { // try to parallelize using leader and follower iterators
+      forall (aa,bb) in zip(a,b) do
+        aa = bb:aa.type;
+    } else if chpl__tryToken { // try to parallelize using leader and follower iterators
+      for (aa,bb) in zip(a,b) do
+        aa = bb:aa.type;
     } else {
       for (aa,bb) in zip(a,b) do
         aa = bb;

--- a/test/arrays/cast/castToArrType.chpl
+++ b/test/arrays/cast/castToArrType.chpl
@@ -1,0 +1,7 @@
+var A = [1, 2, 3, 4]: [0..3] uint(8);
+writeln(A);
+writeln(A.type:string);
+
+var tmp = (reshape([1,2,3,4], {0..1, 0..1}): [{0..1, 0..1}] uint(8));
+writeln(tmp);
+writeln(tmp.type:string);

--- a/test/arrays/cast/castToArrType.good
+++ b/test/arrays/cast/castToArrType.good
@@ -1,0 +1,5 @@
+1 2 3 4
+[domain(1,int(64),false)] uint(8)
+1 2
+3 4
+[domain(2,int(64),false)] uint(8)


### PR DESCRIPTION
Add support for casting an array to another array type when
an explicit downcast is required per element.

The approach taken here is a little regrettable in that it uses
trytoken, but so did the code surrounding it that this is
specializing, so maybe it's acceptable...