### PR TITLE
Allow send_email.py "--sender" to come from env var CHPL_UTIL_SMTP_SENDER

### DIFF
--- a/util/test/send_email.py
+++ b/util/test/send_email.py
@@ -101,9 +101,10 @@ def _parse_headers(option, opt, value, parser, *args, **kwargs):
 
 
 def _default_sender():
-    """Return default sender address, which is <user>@<hostname>."""
-    return '{0}@{1}'.format(getpass.getuser(), socket.getfqdn())
-
+    """Return default sender address, which is <user>@<hostname> unless
+    CHPL_UTIL_SMTP_SENDER is set in environment.
+    """
+    return os.environ.get('CHPL_UTIL_SMTP_SENDER', '{0}@{1}'.format(getpass.getuser(), socket.getfqdn()))
 
 def _default_smtp_host():
     """Return default smtp host, which is localhost unless CHPL_UTIL_SMTP_HOST is
@@ -195,6 +196,7 @@ def _parse_args():
     )
     mail_group.add_option(
         '-S', '--sender',
+        metavar='CHPL_UTIL_SMTP_SENDER',
         default=_default_sender(),
         help='Sender email address. (default: %default)'
     )


### PR DESCRIPTION
Allow send_email.py "--sender" to come from env var CHPL_UTIL_SMTP_SENDER
  
Unfortunately, the conversion to authenticated SMTP that was
attempted on Oct 27-28 is NOT working on many build slaves.
I forgot that the "--sender" of the email message must match the
userid (email address) used to login to the authenticated SMTP.
On many build slaves, neither the build/test scripts nor 
the Jenkins configuration specifies "--sender", so send_email.py
uses a built-in default value - which does not match the
SMTP login.

This change will fix that oversight. Rather than add "--sender"
in various places, I am going to define CHPL_UTIL_SMTP_SENDER in
the Jenkins configuration as a Global environment variable. This
change will enable send_email.py to recognize that setting.

An alternative would be to just force "--sender" to match the 
SMTP login, when authenticated SMTP was used. That would certainly
fix the present problem w the Cray-internal infrastructure. I did
not do it that way because it seemed needlessly restrictive.
Who knows what the requirements are on other SMTP servers besides ours.
