### PR TITLE
Improve lifetime checking for iterators and loop expressions

### DIFF
--- a/compiler/resolution/lifetime.cpp
+++ b/compiler/resolution/lifetime.cpp
@@ -1314,10 +1314,11 @@ bool InferLifetimesVisitor::enterForLoop(ForLoop* forLoop) {
     // as the iterable in the event that 'these' is called.
     // For that reason, if we can't find the iterator anywhere, we
     // assume it's a method.
-    if (AggregateType* at = toAggregateType(iterable->getValType()))
-      if (at->iteratorInfo != NULL)
-        if (FnSymbol* fn = getTheIteratorFnFromIteratorRec(at))
-          method = (fn->_this != NULL);
+    if (iterable != NULL)
+      if (AggregateType* at = toAggregateType(iterable->getValType()))
+        if (at->iteratorInfo != NULL)
+          if (FnSymbol* fn = getTheIteratorFnFromIteratorRec(at))
+            method = (fn->_this != NULL);
 
     bool usedAsRef = index->isRef();
     bool usedAsBorrow = isOrContainsBorrowedClass(index->type);
@@ -1393,6 +1394,9 @@ static bool isUser(BaseAST* ast) {
 
 static BaseAST* findUserPlace(BaseAST* ast) {
   if (developer)
+    return ast;
+
+  if (isUser(ast))
     return ast;
 
   // Otherwise, look at the call sites to find

--- a/compiler/resolution/lifetime.cpp
+++ b/compiler/resolution/lifetime.cpp
@@ -1828,9 +1828,6 @@ static bool isSubjectToBorrowLifetimeAnalysis(Type* type) {
         isRecordContainingFieldsSubjectToAnalysis))
     return false;
 
-  if (typeHasInfiniteBorrowLifetime(type))
-    return false;
-
   return true;
 }
 

--- a/test/classes/delete-free/lifetimes/bad-for-expr.chpl
+++ b/test/classes/delete-free/lifetimes/bad-for-expr.chpl
@@ -1,0 +1,6 @@
+class C { var x:int; }
+
+proc badForExpr() {
+  var x = for i in 1..3 do new borrowed C(i);
+}
+badForExpr();

--- a/test/classes/delete-free/lifetimes/bad-for-expr.good
+++ b/test/classes/delete-free/lifetimes/bad-for-expr.good
@@ -1,0 +1,2 @@
+bad-for-expr.chpl:3: In function 'badForExpr':
+bad-for-expr.chpl:4: error: Scoped variable would outlive the value it is set to

--- a/test/classes/delete-free/lifetimes/bad-iteration.chpl
+++ b/test/classes/delete-free/lifetimes/bad-iteration.chpl
@@ -1,0 +1,66 @@
+class C { var x:int; }
+
+iter yieldLoopTmpBorrow() {
+  for i in 1..10 {
+    var tmp = new owned C(i);
+    yield tmp.borrow();
+  }
+}
+proc badIteration1() {
+  var b: borrowed C;
+  for x in yieldLoopTmpBorrow() {
+    b = x; // expecting error
+  }
+  var v = b.x; // uh-oh, use after free
+  writeln(v);
+}
+badIteration1();
+
+iter yieldIteratorTmpBorrow() {
+  var tmp = new owned C();
+  for i in 1..10 {
+    yield tmp.borrow();
+  }
+}
+proc badIteration2() {
+  var b: borrowed C;
+  for x in yieldIteratorTmpBorrow() {
+    b = x; // expecting error
+  }
+  var v = b.x; // uh-oh, use after free
+  writeln(v);
+}
+badIteration2();
+
+var global = new owned C();
+// this iterator yields borrows from globals
+iter yieldGlobalBorrows() {
+  for i in 1..10 {
+    yield global.borrow();
+  }
+}
+proc maybeOkGlobalBorrow() {
+  var b: borrowed C;
+  for x in yieldGlobalBorrows() {
+    b = x; // expecting error
+  }
+  var v = b.x;
+  writeln(v);
+}
+maybeOkGlobalBorrow();
+
+iter yieldRefX() ref {
+  var x = 0;
+  for i in 1..10 {
+    yield x;
+  }
+  writeln(x);
+}
+proc okIterX() {
+  var b: C;
+  var first = true;
+  for x in yieldRefX() {
+    x = 2;
+  }
+}
+okIterX();

--- a/test/classes/delete-free/lifetimes/bad-iteration.good
+++ b/test/classes/delete-free/lifetimes/bad-iteration.good
@@ -1,0 +1,9 @@
+bad-iteration.chpl:9: In function 'badIteration1':
+bad-iteration.chpl:12: error: Scoped variable b would outlive the value it is set to
+bad-iteration.chpl:11: note: consider scope of x
+bad-iteration.chpl:25: In function 'badIteration2':
+bad-iteration.chpl:28: error: Scoped variable b would outlive the value it is set to
+bad-iteration.chpl:27: note: consider scope of x
+bad-iteration.chpl:42: In function 'maybeOkGlobalBorrow':
+bad-iteration.chpl:45: error: Scoped variable b would outlive the value it is set to
+bad-iteration.chpl:44: note: consider scope of x

--- a/test/classes/delete-free/lifetimes/iter-return-first-borrow.good
+++ b/test/classes/delete-free/lifetimes/iter-return-first-borrow.good
@@ -1,1 +1,3 @@
-{x = 1}
+iter-return-first-borrow.chpl:14: In function 'getfirstborrow':
+iter-return-first-borrow.chpl:16: error: Scoped variable i cannot be returned
+iter-return-first-borrow.chpl:15: note: consider scope of i


### PR DESCRIPTION
Closes #11022.

This PR makes code like the following:
``` chapel
var x = [i in 1..3] new borrowed C(i);
```

result in a lifetime-checker error at compile time. This code is creating an
array of borrows but these are borrowing from `owned` temporaries that are
local to each iteration of the loop expression.

There are 3 parts to the change:

1. The inferred lifetime for the value yielded by an iterator is now:
   * the receiver lifetime, if the iterator is a method
   * the scope of the loop itself, if not
2. The lifetime checker no longer ignores `move`s to types with infinite
   lifetime
3. The lifetime checker now tries a little bit to find a user line number to
   report errors.

- [x] full local testing

Reviewed by @vasslitvinov - thanks!