### PR TITLE
Update the name of the compiler-generated symbol

### DIFF
--- a/test/classes/delete-free/lifetimes/forall-of-new-borrowed-escapes.bad
+++ b/test/classes/delete-free/lifetimes/forall-of-new-borrowed-escapes.bad
@@ -9,7 +9,7 @@ forall-of-new-borrowed-escapes.chpl:13: note: 'new unmanaged C' gives old behavi
 forall-of-new-borrowed-escapes.chpl:13: note: 'new borrowed C' is the new default
 forall-of-new-borrowed-escapes.chpl:13: note: 'new owned C', 'new shared C' also available
 forall-of-new-borrowed-escapes.chpl:13: note: get more help with --warn-unstable
-forall-of-new-borrowed-escapes.chpl:13: In iterator 'chpl__loopexpr_iter2':
+forall-of-new-borrowed-escapes.chpl:13: In iterator 'chpl__loopexpr_iter3':
 forall-of-new-borrowed-escapes.chpl:13: warning: result of new C is now managed by default
 forall-of-new-borrowed-escapes.chpl:13: note: 'new unmanaged C' gives old behavior
 forall-of-new-borrowed-escapes.chpl:13: note: 'new borrowed C' is the new default


### PR DESCRIPTION
PRs #11501 and #11484 both updated the same file and the result of merging wasn't quite right. This PR just fixes test/classes/delete-free/lifetimes/forall-of-new-borrowed-escapes.bad.