### PR TITLE
Improve environment variable handling in slurm-gasnet_ibv launcher

### DIFF
--- a/runtime/src/launch/slurm-gasnetrun_ibv/launch-slurm-gasnetrun_ibv.c
+++ b/runtime/src/launch/slurm-gasnetrun_ibv/launch-slurm-gasnetrun_ibv.c
@@ -175,9 +175,10 @@ static void propagate_environment(FILE *f)
   char *lc_all = getenv("LC_ALL");
   char *lc_collate = getenv("LC_COLLATE");
   if (lang || lc_all || lc_collate) {
-    fprintf(f, " -E LANG=%s", lang ? lang : "");
-    fprintf(f, " -E LC_ALL=%s", lc_all ? lc_all : "");
-    fprintf(f, " -E LC_COLLATE=%s", lc_collate ? lc_collate : "");
+    fprintf(f, " env");
+    fprintf(f, " LANG=%s", lang ? lang : "");
+    fprintf(f, " LC_ALL=%s", lc_all ? lc_all : "");
+    fprintf(f, " LC_COLLATE=%s", lc_collate ? lc_collate : "");
   }
 }
 

--- a/runtime/src/launch/slurm-gasnetrun_ibv/launch-slurm-gasnetrun_ibv.c
+++ b/runtime/src/launch/slurm-gasnetrun_ibv/launch-slurm-gasnetrun_ibv.c
@@ -170,11 +170,13 @@ static void propagate_environment(FILE *f)
   // If any of the relevant character set environment variables
   // are set, replicate the state of all of them.  This needs to
   // be done separately from the -E mechanism because the launcher
-  // is written in Perl, which mangles the character set environment.
+  // is written in Perl, which mangles the character set
+  // environment.
   //
-  // Note that if one or more of these variables is empty, we must
-  // set it with explicitly empty contents (e.g. LC_ALL= instead of
-  // -u LC_ALL) so that the launcher will not overwrite it.
+  // Note that if we are setting these variables, and one or more
+  // of them is empty, we must set it with explicitly empty
+  // contents (e.g. LC_ALL= instead of -u LC_ALL) so that the
+  // launcher will not overwrite it.
   char *lang = getenv("LANG");
   char *lc_all = getenv("LC_ALL");
   char *lc_collate = getenv("LC_COLLATE");

--- a/runtime/src/launch/slurm-gasnetrun_ibv/launch-slurm-gasnetrun_ibv.c
+++ b/runtime/src/launch/slurm-gasnetrun_ibv/launch-slurm-gasnetrun_ibv.c
@@ -160,12 +160,20 @@ static void genNumLocalesOptions(FILE* slurmFile, sbatchVersion sbatch,
 
 static void propagate_environment(FILE *f)
 {
+  // Indiscriminately propagate all environment variables.
+  // We could do this more selectively, but we would be likely
+  // to leave out something important.
+  char *enviro_keys = chpl_get_enviro_keys(',');
+  if (enviro_keys)
+    fprintf(f, " -E '%s'", enviro_keys);
+
+  // If any of the relevant character set environment variables
+  // are set, replicate the state of all of them.  This needs to
+  // be done separately from the -E mechanism because the launcher
+  // is written in Perl, which mangles the character set environment.
   char *lang = getenv("LANG");
   char *lc_all = getenv("LC_ALL");
   char *lc_collate = getenv("LC_COLLATE");
-
-  // If any of the relevant character set environment variables
-  // are set, replicate the state of all of them.
   if (lang || lc_all || lc_collate) {
     fprintf(f, " env");
     fprintf(f, " 'LANG=%s'", lang ? lang : "");

--- a/runtime/src/launch/slurm-gasnetrun_ibv/launch-slurm-gasnetrun_ibv.c
+++ b/runtime/src/launch/slurm-gasnetrun_ibv/launch-slurm-gasnetrun_ibv.c
@@ -165,7 +165,7 @@ static void propagate_environment(FILE *f)
   // to leave out something important.
   char *enviro_keys = chpl_get_enviro_keys(',');
   if (enviro_keys)
-    fprintf(f, " -E '%s'", enviro_keys);
+    fprintf(f, " -E %s", enviro_keys);
 
   // If any of the relevant character set environment variables
   // are set, replicate the state of all of them.  This needs to

--- a/runtime/src/launch/slurm-gasnetrun_ibv/launch-slurm-gasnetrun_ibv.c
+++ b/runtime/src/launch/slurm-gasnetrun_ibv/launch-slurm-gasnetrun_ibv.c
@@ -168,13 +168,9 @@ static void propagate_environment(FILE *f)
   // are set, replicate the state of all of them.
   if (lang || lc_all || lc_collate) {
     fprintf(f, " env");
-
-    if (lang)
-      fprintf(f, " 'LANG=%s'", lang ? lang : "");
-    if (lc_all)
-      fprintf(f, " 'LC_ALL=%s'", lc_all ? lc_all : "");
-    if (lc_collate)
-      fprintf(f, " 'LC_COLLATE=%s'", lc_collate ? lc_collate : "");
+    fprintf(f, " 'LANG=%s'", lang ? lang : "");
+    fprintf(f, " 'LC_ALL=%s'", lc_all ? lc_all : "");
+    fprintf(f, " 'LC_COLLATE=%s'", lc_collate ? lc_collate : "");
   }
 }
 

--- a/runtime/src/launch/slurm-gasnetrun_ibv/launch-slurm-gasnetrun_ibv.c
+++ b/runtime/src/launch/slurm-gasnetrun_ibv/launch-slurm-gasnetrun_ibv.c
@@ -176,7 +176,7 @@ static void propagate_environment(FILE *f)
   // Note that if we are setting these variables, and one or more
   // of them is empty, we must set it with explicitly empty
   // contents (e.g. LC_ALL= instead of -u LC_ALL) so that the
-  // launcher will not overwrite it.
+  // Chapel launch mechanism will not overwrite it.
   char *lang = getenv("LANG");
   char *lc_all = getenv("LC_ALL");
   char *lc_collate = getenv("LC_COLLATE");

--- a/runtime/src/launch/slurm-gasnetrun_ibv/launch-slurm-gasnetrun_ibv.c
+++ b/runtime/src/launch/slurm-gasnetrun_ibv/launch-slurm-gasnetrun_ibv.c
@@ -229,71 +229,66 @@ static char* chpl_launch_create_command(int argc, char* argv[],
     genNumLocalesOptions(slurmFile, determineSlurmVersion(), numLocales, getNumCoresPerLocale());
     if (projectString && strlen(projectString) > 0)
       fprintf(slurmFile, "#SBATCH -A %s\n", projectString);
-    if (getenv("CHPL_LAUNCHER_USE_SBATCH") != NULL) {
-//    fprintf(slurmFile, "#SBATCH -joe\n");  
+    //fprintf(slurmFile, "#SBATCH -joe\n");  
     if (outputfn!=NULL) 
       fprintf(slurmFile, "#SBATCH -o %s\n", outputfn);
     else
       fprintf(slurmFile, "#SBATCH -o %s.%%j.out\n", argv[0]);
-//    fprintf(slurmFile, "cd $SBATCH_O_WORKDIR\n");
-      fprintf(slurmFile, "%s/%s/gasnetrun_ibv -n %d",
-              CHPL_THIRD_PARTY, WRAP_TO_STR(LAUNCH_PATH), numLocales);
-      propagate_environment(slurmFile);
-      fprintf(slurmFile, " %s ", chpl_get_real_binary_name());
-      for (i=1; i<argc; i++) {
-        fprintf(slurmFile, " '%s'", argv[i]);
-      }
-      fprintf(slurmFile, "\n");
+    //fprintf(slurmFile, "cd $SBATCH_O_WORKDIR\n");
+    fprintf(slurmFile, "%s/%s/gasnetrun_ibv -n %d",
+            CHPL_THIRD_PARTY, WRAP_TO_STR(LAUNCH_PATH), numLocales);
+    propagate_environment(slurmFile);
+    fprintf(slurmFile, " %s ", chpl_get_real_binary_name());
+    for (i=1; i<argc; i++) {
+      fprintf(slurmFile, " '%s'", argv[i]);
     }
-  fclose(slurmFile);
-  chmod( slurmFilename, 0755);
-  }
-  if (getenv("CHPL_LAUNCHER_USE_SBATCH") == NULL) {
-  expectFile = fopen(expectFilename, "w");
-  if (verbosity < 2) {
-//    fprintf(expectFile, "log_user 0\n");
-  }
-  fprintf(expectFile, "set timeout -1\n");
-//  fprintf(expectFile, "chmod +x %s\n",slurmFilename);
-  fprintf(expectFile, "set prompt \"(%%|#|\\\\$|>) $\"\n");
-
-//  fprintf(expectFile, "spawn sbatch ");
-  fprintf(expectFile, "spawn -noecho salloc ");
-  fprintf(expectFile, "-J %.10s ",basenamePtr); // pass 
-  fprintf(expectFile, "-N %d ",numLocales); 
-  fprintf(expectFile, "--ntasks-per-node=1 ");
-  fprintf(expectFile, "--exclusive "); //  give exclusive access to the nodes
-  fprintf(expectFile, "--time=%s ",walltime); 
-  if(partition)
-    fprintf(expectFile, "--partition=%s ",partition);
-  if(exclude)
-    fprintf(expectFile, "--exclude=%s ",exclude);
-  if (constraint) {
-    fprintf(expectFile, " -C %s", constraint);
-  }
-//  fprintf(expectFile, "-I %s ", slurmFilename);
-  fprintf(expectFile, " %s/%s/gasnetrun_ibv -n %d",
-          CHPL_THIRD_PARTY, WRAP_TO_STR(LAUNCH_PATH), numLocales);
-  propagate_environment(expectFile);
-  fprintf(expectFile, " %s ", chpl_get_real_binary_name());
-  for (i=1; i<argc; i++) {
-    fprintf(expectFile, " %s", argv[i]);
-  }
-//  fprintf(expectFile, "\\n\"\n");
-  fprintf(expectFile, "\n\n");
-//  fprintf(expectFile, "expect -re $prompt\n");
-//  fprintf(expectFile, "send \"cd \\$SBATCH_O_WORKDIR\\n\"\n");
-//  fprintf(expectFile, "expect -re $prompt\n");
-//  fprintf(expectFile, "sleep 10\n");
-//  fprintf(expectFile, "interact -o -re $prompt {return}\n");
-//  fprintf(expectFile, "send_user \"\\n\"\n");
-//  fprintf(expectFile, "send \"exit\\n\"\n");
-  fprintf(expectFile, "interact -o -re $prompt {return}\n");
-  fclose(expectFile);
-  sprintf(baseCommand, "expect %s", expectFilename);
-  } else {
-//    sprintf(baseCommand, "sbatch %s\n", slurmFilename);
+    fprintf(slurmFile, "\n");
+    fclose(slurmFile);
+    chmod( slurmFilename, 0755);
     sprintf(baseCommand, "sbatch %s\n", slurmFilename);
+  } else /* getenv("CHPL_LAUNCHER_USE_SBATCH") == NULL */ {
+    expectFile = fopen(expectFilename, "w");
+    if (verbosity < 2) {
+      //fprintf(expectFile, "log_user 0\n");
+    }
+    fprintf(expectFile, "set timeout -1\n");
+    //fprintf(expectFile, "chmod +x %s\n",slurmFilename);
+    fprintf(expectFile, "set prompt \"(%%|#|\\\\$|>) $\"\n");
+
+    //fprintf(expectFile, "spawn sbatch ");
+    fprintf(expectFile, "spawn -noecho salloc ");
+    fprintf(expectFile, "-J %.10s ",basenamePtr); // pass 
+    fprintf(expectFile, "-N %d ",numLocales); 
+    fprintf(expectFile, "--ntasks-per-node=1 ");
+    fprintf(expectFile, "--exclusive "); //  give exclusive access to the nodes
+    fprintf(expectFile, "--time=%s ",walltime); 
+    if(partition)
+      fprintf(expectFile, "--partition=%s ",partition);
+    if(exclude)
+      fprintf(expectFile, "--exclude=%s ",exclude);
+    if (constraint) {
+      fprintf(expectFile, " -C %s", constraint);
+    }
+    //fprintf(expectFile, "-I %s ", slurmFilename);
+    fprintf(expectFile, " %s/%s/gasnetrun_ibv -n %d",
+            CHPL_THIRD_PARTY, WRAP_TO_STR(LAUNCH_PATH), numLocales);
+    propagate_environment(expectFile);
+    fprintf(expectFile, " %s ", chpl_get_real_binary_name());
+    for (i=1; i<argc; i++) {
+      fprintf(expectFile, " %s", argv[i]);
+    }
+    //fprintf(expectFile, "\\n\"\n");
+    fprintf(expectFile, "\n\n");
+    //fprintf(expectFile, "expect -re $prompt\n");
+    //fprintf(expectFile, "send \"cd \\$SBATCH_O_WORKDIR\\n\"\n");
+    //fprintf(expectFile, "expect -re $prompt\n");
+    //fprintf(expectFile, "sleep 10\n");
+    //fprintf(expectFile, "interact -o -re $prompt {return}\n");
+    //fprintf(expectFile, "send_user \"\\n\"\n");
+    //fprintf(expectFile, "send \"exit\\n\"\n");
+    fprintf(expectFile, "interact -o -re $prompt {return}\n");
+    fclose(expectFile);
+    sprintf(baseCommand, "expect %s", expectFilename);
   }
 
   size = strlen(baseCommand) + 1;

--- a/runtime/src/launch/slurm-gasnetrun_ibv/launch-slurm-gasnetrun_ibv.c
+++ b/runtime/src/launch/slurm-gasnetrun_ibv/launch-slurm-gasnetrun_ibv.c
@@ -229,7 +229,7 @@ static char* chpl_launch_create_command(int argc, char* argv[],
     genNumLocalesOptions(slurmFile, determineSlurmVersion(), numLocales, getNumCoresPerLocale());
     if (projectString && strlen(projectString) > 0)
       fprintf(slurmFile, "#SBATCH -A %s\n", projectString);
-    //fprintf(slurmFile, "#SBATCH -joe\n");  
+    //fprintf(slurmFile, "#SBATCH -joe\n");
     if (outputfn!=NULL) 
       fprintf(slurmFile, "#SBATCH -o %s\n", outputfn);
     else
@@ -257,11 +257,11 @@ static char* chpl_launch_create_command(int argc, char* argv[],
 
     //fprintf(expectFile, "spawn sbatch ");
     fprintf(expectFile, "spawn -noecho salloc ");
-    fprintf(expectFile, "-J %.10s ",basenamePtr); // pass 
-    fprintf(expectFile, "-N %d ",numLocales); 
+    fprintf(expectFile, "-J %.10s ",basenamePtr); // pass
+    fprintf(expectFile, "-N %d ",numLocales);
     fprintf(expectFile, "--ntasks-per-node=1 ");
     fprintf(expectFile, "--exclusive "); //  give exclusive access to the nodes
-    fprintf(expectFile, "--time=%s ",walltime); 
+    fprintf(expectFile, "--time=%s ",walltime);
     if(partition)
       fprintf(expectFile, "--partition=%s ",partition);
     if(exclude)

--- a/runtime/src/launch/slurm-gasnetrun_ibv/launch-slurm-gasnetrun_ibv.c
+++ b/runtime/src/launch/slurm-gasnetrun_ibv/launch-slurm-gasnetrun_ibv.c
@@ -169,20 +169,12 @@ static void propagate_environment(FILE *f)
   if (lang || lc_all || lc_collate) {
     fprintf(f, " env");
 
-    // All the undefines have to come first.
-    if (!lang)
-      fprintf(f, " -u LANG");
-    if (!lc_all)
-      fprintf(f, " -u LC_ALL");
-    if (!lc_collate)
-      fprintf(f, " -u LC_COLLATE");
-
     if (lang)
-      fprintf(f, " LANG=%s", lang);
+      fprintf(f, " 'LANG=%s'", lang ? lang : "");
     if (lc_all)
-      fprintf(f, " LC_ALL=%s", lc_all);
+      fprintf(f, " 'LC_ALL=%s'", lc_all ? lc_all : "");
     if (lc_collate)
-      fprintf(f, " LC_COLLATE=%s", lc_collate);
+      fprintf(f, " 'LC_COLLATE=%s'", lc_collate ? lc_collate : "");
   }
 }
 

--- a/runtime/src/launch/slurm-gasnetrun_ibv/launch-slurm-gasnetrun_ibv.c
+++ b/runtime/src/launch/slurm-gasnetrun_ibv/launch-slurm-gasnetrun_ibv.c
@@ -175,10 +175,9 @@ static void propagate_environment(FILE *f)
   char *lc_all = getenv("LC_ALL");
   char *lc_collate = getenv("LC_COLLATE");
   if (lang || lc_all || lc_collate) {
-    fprintf(f, " env");
-    fprintf(f, " 'LANG=%s'", lang ? lang : "");
-    fprintf(f, " 'LC_ALL=%s'", lc_all ? lc_all : "");
-    fprintf(f, " 'LC_COLLATE=%s'", lc_collate ? lc_collate : "");
+    fprintf(f, " -E LANG=%s", lang ? lang : "");
+    fprintf(f, " -E LC_ALL=%s", lc_all ? lc_all : "");
+    fprintf(f, " -E LC_COLLATE=%s", lc_collate ? lc_collate : "");
   }
 }
 


### PR DESCRIPTION
This change passes all environment variables to the compute nodes when the gasnet_ibv launcher is being used, taking care to handle the character-locale variables such as `LC_ALL` properly.  (The launcher is written in Perl, which sets those variable incorrectly when left to its own devices.)

While working on this launcher, it was noticed that some other launchers may have similar problems.  Issue #11536 was created to track those.

Closes #11355 
