### PR TITLE
Unify gasnetrun_{ibv, mpi, ofi, psm} implementations

### DIFF
--- a/runtime/src/launch/gasnetrun_common/gasnetrun_common.h
+++ b/runtime/src/launch/gasnetrun_common/gasnetrun_common.h
@@ -24,6 +24,10 @@
 #include "chpl-mem.h"
 #include "error.h"
 
+#ifndef GASNETRUN_LAUNCHER
+#error GASNETRUN_LAUNCHER must be defined
+#endif
+
 #define LAUNCH_PATH_HELP WRAP_TO_STR(LAUNCH_PATH)
 #define WRAP_TO_STR(x) TO_STR(x)
 #define TO_STR(x) #x
@@ -46,9 +50,9 @@ static char** chpl_launch_create_argv(const char *launch_cmd,
 }
 
 int chpl_launch(int argc, char* argv[], int32_t numLocales) {
-  int len = strlen(CHPL_THIRD_PARTY) + strlen(WRAP_TO_STR(LAUNCH_PATH)) + strlen("gasnetrun_mpi") + 2;
+  int len = strlen(CHPL_THIRD_PARTY) + strlen(WRAP_TO_STR(LAUNCH_PATH)) + strlen(GASNETRUN_LAUNCHER) + 2;
   char *cmd = chpl_mem_allocMany(len, sizeof(char), CHPL_RT_MD_COMMAND_BUFFER, -1, 0);
-  sprintf(cmd, "%s/%sgasnetrun_mpi", CHPL_THIRD_PARTY, WRAP_TO_STR(LAUNCH_PATH));
+  sprintf(cmd, "%s/%s%s", CHPL_THIRD_PARTY, WRAP_TO_STR(LAUNCH_PATH), GASNETRUN_LAUNCHER);
 
   return chpl_launch_using_exec(cmd,
                                 chpl_launch_create_argv(cmd, argc, argv,

--- a/runtime/src/launch/gasnetrun_common/gasnetrun_common.h
+++ b/runtime/src/launch/gasnetrun_common/gasnetrun_common.h
@@ -41,7 +41,7 @@ static char** chpl_launch_create_argv(const char *launch_cmd,
 
   largv[0] = (char *) launch_cmd;
   largv[1] = (char *) "-n";
-  sprintf(_nlbuf, "%d", numLocales);
+  snprintf(_nlbuf, sizeof(_nlbuf), "%d", numLocales);
   largv[2] = _nlbuf;
   largv[3] = (char*) "-E";
   largv[4] = chpl_get_enviro_keys(',');
@@ -52,7 +52,7 @@ static char** chpl_launch_create_argv(const char *launch_cmd,
 int chpl_launch(int argc, char* argv[], int32_t numLocales) {
   int len = strlen(CHPL_THIRD_PARTY) + strlen(WRAP_TO_STR(LAUNCH_PATH)) + strlen(GASNETRUN_LAUNCHER) + 2;
   char *cmd = chpl_mem_allocMany(len, sizeof(char), CHPL_RT_MD_COMMAND_BUFFER, -1, 0);
-  sprintf(cmd, "%s/%s%s", CHPL_THIRD_PARTY, WRAP_TO_STR(LAUNCH_PATH), GASNETRUN_LAUNCHER);
+  snprintf(cmd, len, "%s/%s%s", CHPL_THIRD_PARTY, WRAP_TO_STR(LAUNCH_PATH), GASNETRUN_LAUNCHER);
 
   return chpl_launch_using_exec(cmd,
                                 chpl_launch_create_argv(cmd, argc, argv,

--- a/runtime/src/launch/gasnetrun_common/gasnetrun_common.h
+++ b/runtime/src/launch/gasnetrun_common/gasnetrun_common.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2004-2018 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ * 
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * 
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include "chplcgfns.h"
+#include "chpllaunch.h"
+#include "chpl-mem.h"
+#include "error.h"
+
+#define LAUNCH_PATH_HELP WRAP_TO_STR(LAUNCH_PATH)
+#define WRAP_TO_STR(x) TO_STR(x)
+#define TO_STR(x) #x
+
+static char _nlbuf[16];
+static char** chpl_launch_create_argv(const char *launch_cmd,
+                                      int argc, char* argv[],
+                                      int32_t numLocales) {
+  const int largc = 5;
+  char *largv[largc];
+
+  largv[0] = (char *) launch_cmd;
+  largv[1] = (char *) "-n";
+  sprintf(_nlbuf, "%d", numLocales);
+  largv[2] = _nlbuf;
+  largv[3] = (char*) "-E";
+  largv[4] = chpl_get_enviro_keys(',');
+
+  return chpl_bundle_exec_args(argc, argv, largc, largv);
+}
+
+int chpl_launch(int argc, char* argv[], int32_t numLocales) {
+  int len = strlen(CHPL_THIRD_PARTY) + strlen(WRAP_TO_STR(LAUNCH_PATH)) + strlen("gasnetrun_mpi") + 2;
+  char *cmd = chpl_mem_allocMany(len, sizeof(char), CHPL_RT_MD_COMMAND_BUFFER, -1, 0);
+  sprintf(cmd, "%s/%sgasnetrun_mpi", CHPL_THIRD_PARTY, WRAP_TO_STR(LAUNCH_PATH));
+
+  return chpl_launch_using_exec(cmd,
+                                chpl_launch_create_argv(cmd, argc, argv,
+                                                        numLocales),
+                                argv[0]);
+}
+
+
+int chpl_launch_handle_arg(int argc, char* argv[], int argNum,
+                           int32_t lineno, int32_t filename) {
+  return 0;
+}
+
+
+void chpl_launch_print_help(void) {
+}

--- a/runtime/src/launch/gasnetrun_ibv/launch-gasnetrun_ibv.c
+++ b/runtime/src/launch/gasnetrun_ibv/launch-gasnetrun_ibv.c
@@ -28,8 +28,6 @@
 #define WRAP_TO_STR(x) TO_STR(x)
 #define TO_STR(x) #x
 
-// TODO: Un-hard-code this stuff:
-
 static char _nlbuf[16];
 static char** chpl_launch_create_argv(const char *launch_cmd,
                                       int argc, char* argv[],
@@ -46,7 +44,6 @@ static char** chpl_launch_create_argv(const char *launch_cmd,
 
   return chpl_bundle_exec_args(argc, argv, largc, largv);
 }
-
 
 int chpl_launch(int argc, char* argv[], int32_t numLocales) {
   int len = strlen(CHPL_THIRD_PARTY) + strlen(WRAP_TO_STR(LAUNCH_PATH)) + strlen("gasnetrun_ibv") + 2;

--- a/runtime/src/launch/gasnetrun_ibv/launch-gasnetrun_ibv.c
+++ b/runtime/src/launch/gasnetrun_ibv/launch-gasnetrun_ibv.c
@@ -17,51 +17,5 @@
  * limitations under the License.
  */
 
-#include <stdio.h>
-#include <string.h>
-#include "chplcgfns.h"
-#include "chpllaunch.h"
-#include "chpl-mem.h"
-#include "error.h"
-
-#define LAUNCH_PATH_HELP WRAP_TO_STR(LAUNCH_PATH)
-#define WRAP_TO_STR(x) TO_STR(x)
-#define TO_STR(x) #x
-
-static char _nlbuf[16];
-static char** chpl_launch_create_argv(const char *launch_cmd,
-                                      int argc, char* argv[],
-                                      int32_t numLocales) {
-  const int largc = 5;
-  char *largv[largc];
-
-  largv[0] = (char *) launch_cmd;
-  largv[1] = (char *) "-n";
-  sprintf(_nlbuf, "%d", numLocales);
-  largv[2] = _nlbuf;
-  largv[3] = (char*) "-E";
-  largv[4] = chpl_get_enviro_keys(',');
-
-  return chpl_bundle_exec_args(argc, argv, largc, largv);
-}
-
-int chpl_launch(int argc, char* argv[], int32_t numLocales) {
-  int len = strlen(CHPL_THIRD_PARTY) + strlen(WRAP_TO_STR(LAUNCH_PATH)) + strlen("gasnetrun_ibv") + 2;
-  char *cmd = chpl_mem_allocMany(len, sizeof(char), CHPL_RT_MD_COMMAND_BUFFER, -1, 0);
-  sprintf(cmd, "%s/%sgasnetrun_ibv", CHPL_THIRD_PARTY, WRAP_TO_STR(LAUNCH_PATH));
-
-  return chpl_launch_using_exec(cmd,
-                                chpl_launch_create_argv(cmd, argc, argv,
-                                                        numLocales),
-                                argv[0]);
-}
-
-
-int chpl_launch_handle_arg(int argc, char* argv[], int argNum,
-                           int32_t lineno, int32_t filename) {
-  return 0;
-}
-
-
-void chpl_launch_print_help(void) {
-}
+#define GASNETRUN_LAUNCHER "gasnetrun_ibv"
+#include "../gasnetrun_common/gasnetrun_common.h"

--- a/runtime/src/launch/gasnetrun_mpi/launch-gasnetrun_mpi.c
+++ b/runtime/src/launch/gasnetrun_mpi/launch-gasnetrun_mpi.c
@@ -28,20 +28,19 @@
 #define WRAP_TO_STR(x) TO_STR(x)
 #define TO_STR(x) #x
 
-// TODO: Un-hard-code this stuff:
-// sungeun: what stuff?
-
 static char _nlbuf[16];
 static char** chpl_launch_create_argv(const char *launch_cmd,
                                       int argc, char* argv[],
                                       int32_t numLocales) {
-  const int largc = 3;
+  const int largc = 5;
   char *largv[largc];
 
   largv[0] = (char *) launch_cmd;
-  largv[1] = (char *) "-np";
+  largv[1] = (char *) "-n";
   sprintf(_nlbuf, "%d", numLocales);
   largv[2] = _nlbuf;
+  largv[3] = (char*) "-E";
+  largv[4] = chpl_get_enviro_keys(',');
 
   return chpl_bundle_exec_args(argc, argv, largc, largv);
 }

--- a/runtime/src/launch/gasnetrun_mpi/launch-gasnetrun_mpi.c
+++ b/runtime/src/launch/gasnetrun_mpi/launch-gasnetrun_mpi.c
@@ -17,51 +17,5 @@
  * limitations under the License.
  */
 
-#include <stdio.h>
-#include <string.h>
-#include "chplcgfns.h"
-#include "chpllaunch.h"
-#include "chpl-mem.h"
-#include "error.h"
-
-#define LAUNCH_PATH_HELP WRAP_TO_STR(LAUNCH_PATH)
-#define WRAP_TO_STR(x) TO_STR(x)
-#define TO_STR(x) #x
-
-static char _nlbuf[16];
-static char** chpl_launch_create_argv(const char *launch_cmd,
-                                      int argc, char* argv[],
-                                      int32_t numLocales) {
-  const int largc = 5;
-  char *largv[largc];
-
-  largv[0] = (char *) launch_cmd;
-  largv[1] = (char *) "-n";
-  sprintf(_nlbuf, "%d", numLocales);
-  largv[2] = _nlbuf;
-  largv[3] = (char*) "-E";
-  largv[4] = chpl_get_enviro_keys(',');
-
-  return chpl_bundle_exec_args(argc, argv, largc, largv);
-}
-
-int chpl_launch(int argc, char* argv[], int32_t numLocales) {
-  int len = strlen(CHPL_THIRD_PARTY) + strlen(WRAP_TO_STR(LAUNCH_PATH)) + strlen("gasnetrun_mpi") + 2;
-  char *cmd = chpl_mem_allocMany(len, sizeof(char), CHPL_RT_MD_COMMAND_BUFFER, -1, 0);
-  sprintf(cmd, "%s/%sgasnetrun_mpi", CHPL_THIRD_PARTY, WRAP_TO_STR(LAUNCH_PATH));
-
-  return chpl_launch_using_exec(cmd,
-                                chpl_launch_create_argv(cmd, argc, argv,
-                                                        numLocales),
-                                argv[0]);
-}
-
-
-int chpl_launch_handle_arg(int argc, char* argv[], int argNum,
-                           int32_t lineno, int32_t filename) {
-  return 0;
-}
-
-
-void chpl_launch_print_help(void) {
-}
+#define GASNETRUN_LAUNCHER "gasnetrun_mpi"
+#include "../gasnetrun_common/gasnetrun_common.h"

--- a/runtime/src/launch/gasnetrun_ofi/launch-gasnetrun_ofi.c
+++ b/runtime/src/launch/gasnetrun_ofi/launch-gasnetrun_ofi.c
@@ -28,8 +28,6 @@
 #define WRAP_TO_STR(x) TO_STR(x)
 #define TO_STR(x) #x
 
-// TODO: Un-hard-code this stuff:
-
 static char _nlbuf[16];
 static char** chpl_launch_create_argv(const char *launch_cmd,
                                       int argc, char* argv[],
@@ -46,7 +44,6 @@ static char** chpl_launch_create_argv(const char *launch_cmd,
 
   return chpl_bundle_exec_args(argc, argv, largc, largv);
 }
-
 
 int chpl_launch(int argc, char* argv[], int32_t numLocales) {
   int len = strlen(CHPL_THIRD_PARTY) + strlen(WRAP_TO_STR(LAUNCH_PATH)) + strlen("gasnetrun_ofi") + 2;

--- a/runtime/src/launch/gasnetrun_ofi/launch-gasnetrun_ofi.c
+++ b/runtime/src/launch/gasnetrun_ofi/launch-gasnetrun_ofi.c
@@ -17,51 +17,5 @@
  * limitations under the License.
  */
 
-#include <stdio.h>
-#include <string.h>
-#include "chplcgfns.h"
-#include "chpllaunch.h"
-#include "chpl-mem.h"
-#include "error.h"
-
-#define LAUNCH_PATH_HELP WRAP_TO_STR(LAUNCH_PATH)
-#define WRAP_TO_STR(x) TO_STR(x)
-#define TO_STR(x) #x
-
-static char _nlbuf[16];
-static char** chpl_launch_create_argv(const char *launch_cmd,
-                                      int argc, char* argv[],
-                                      int32_t numLocales) {
-  const int largc = 5;
-  char *largv[largc];
-
-  largv[0] = (char *) launch_cmd;
-  largv[1] = (char *) "-n";
-  sprintf(_nlbuf, "%d", numLocales);
-  largv[2] = _nlbuf;
-  largv[3] = (char*) "-E";
-  largv[4] = chpl_get_enviro_keys(',');
-
-  return chpl_bundle_exec_args(argc, argv, largc, largv);
-}
-
-int chpl_launch(int argc, char* argv[], int32_t numLocales) {
-  int len = strlen(CHPL_THIRD_PARTY) + strlen(WRAP_TO_STR(LAUNCH_PATH)) + strlen("gasnetrun_ofi") + 2;
-  char *cmd = chpl_mem_allocMany(len, sizeof(char), CHPL_RT_MD_COMMAND_BUFFER, -1, 0);
-  sprintf(cmd, "%s/%sgasnetrun_ofi", CHPL_THIRD_PARTY, WRAP_TO_STR(LAUNCH_PATH));
-
-  return chpl_launch_using_exec(cmd,
-                                chpl_launch_create_argv(cmd, argc, argv,
-                                                        numLocales),
-                                argv[0]);
-}
-
-
-int chpl_launch_handle_arg(int argc, char* argv[], int argNum,
-                           int32_t lineno, int32_t filename) {
-  return 0;
-}
-
-
-void chpl_launch_print_help(void) {
-}
+#define GASNETRUN_LAUNCHER "gasnetrun_ofi"
+#include "../gasnetrun_common/gasnetrun_common.h"

--- a/runtime/src/launch/gasnetrun_psm/launch-gasnetrun_psm.c
+++ b/runtime/src/launch/gasnetrun_psm/launch-gasnetrun_psm.c
@@ -28,8 +28,6 @@
 #define WRAP_TO_STR(x) TO_STR(x)
 #define TO_STR(x) #x
 
-// TODO: Un-hard-code this stuff:
-
 static char _nlbuf[16];
 static char** chpl_launch_create_argv(const char *launch_cmd,
                                       int argc, char* argv[],
@@ -46,7 +44,6 @@ static char** chpl_launch_create_argv(const char *launch_cmd,
 
   return chpl_bundle_exec_args(argc, argv, largc, largv);
 }
-
 
 int chpl_launch(int argc, char* argv[], int32_t numLocales) {
   int len = strlen(CHPL_THIRD_PARTY) + strlen(WRAP_TO_STR(LAUNCH_PATH)) + strlen("gasnetrun_psm") + 2;

--- a/runtime/src/launch/gasnetrun_psm/launch-gasnetrun_psm.c
+++ b/runtime/src/launch/gasnetrun_psm/launch-gasnetrun_psm.c
@@ -17,51 +17,5 @@
  * limitations under the License.
  */
 
-#include <stdio.h>
-#include <string.h>
-#include "chplcgfns.h"
-#include "chpllaunch.h"
-#include "chpl-mem.h"
-#include "error.h"
-
-#define LAUNCH_PATH_HELP WRAP_TO_STR(LAUNCH_PATH)
-#define WRAP_TO_STR(x) TO_STR(x)
-#define TO_STR(x) #x
-
-static char _nlbuf[16];
-static char** chpl_launch_create_argv(const char *launch_cmd,
-                                      int argc, char* argv[],
-                                      int32_t numLocales) {
-  const int largc = 5;
-  char *largv[largc];
-
-  largv[0] = (char *) launch_cmd;
-  largv[1] = (char *) "-n";
-  sprintf(_nlbuf, "%d", numLocales);
-  largv[2] = _nlbuf;
-  largv[3] = (char*) "-E";
-  largv[4] = chpl_get_enviro_keys(',');
-
-  return chpl_bundle_exec_args(argc, argv, largc, largv);
-}
-
-int chpl_launch(int argc, char* argv[], int32_t numLocales) {
-  int len = strlen(CHPL_THIRD_PARTY) + strlen(WRAP_TO_STR(LAUNCH_PATH)) + strlen("gasnetrun_psm") + 2;
-  char *cmd = chpl_mem_allocMany(len, sizeof(char), CHPL_RT_MD_COMMAND_BUFFER, -1, 0);
-  sprintf(cmd, "%s/%sgasnetrun_psm", CHPL_THIRD_PARTY, WRAP_TO_STR(LAUNCH_PATH));
-
-  return chpl_launch_using_exec(cmd,
-                                chpl_launch_create_argv(cmd, argc, argv,
-                                                        numLocales),
-                                argv[0]);
-}
-
-
-int chpl_launch_handle_arg(int argc, char* argv[], int argNum,
-                           int32_t lineno, int32_t filename) {
-  return 0;
-}
-
-
-void chpl_launch_print_help(void) {
-}
+#define GASNETRUN_LAUNCHER "gasnetrun_psm"
+#include "../gasnetrun_common/gasnetrun_common.h"


### PR DESCRIPTION
Previously these launchers were all effectively code clones of each other,
though some had become out of date as others were updated. This just makes a
gasnetrun_common.h file that has a single implementation where the gasnet
launcher being called is specified through a macro. This slightly cleans up the
implementation and should allow us to keep the launchers more in sync over time
with less effort
