### PR TITLE
Implement initial comm=ofi AM support.

### DIFF
--- a/runtime/etc/Makefile.comm-ofi
+++ b/runtime/etc/Makefile.comm-ofi
@@ -15,13 +15,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#
-# Assume this variable is set:
-# - LIBFABRIC_LIB_DIR
-#
-
-GEN_LFLAGS += -L$(LIBFABRIC_LIB_DIR) -Wl,-rpath,$(LIBFABRIC_LIB_DIR)
+ifneq ($(LIBFABRIC_DIR),)
+GEN_LFLAGS += -L$(LIBFABRIC_DIR)/lib -Wl,-rpath,$(LIBFABRIC_DIR)/lib
 LIBS += -lfabric -ldl
+endif
 
 #
 # Conservatively use CXX as the linker, in case regexp (or other C++

--- a/runtime/etc/Makefile.comm-ofi
+++ b/runtime/etc/Makefile.comm-ofi
@@ -17,8 +17,8 @@
 
 ifneq ($(LIBFABRIC_DIR),)
 GEN_LFLAGS += -L$(LIBFABRIC_DIR)/lib -Wl,-rpath,$(LIBFABRIC_DIR)/lib
-LIBS += -lfabric -ldl
 endif
+LIBS += -lfabric -ldl
 
 #
 # Conservatively use CXX as the linker, in case regexp (or other C++

--- a/runtime/make/Makefile.runtime.comm-ofi
+++ b/runtime/make/Makefile.runtime.comm-ofi
@@ -15,6 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ifneq ($(LIBFABRIC_INCLUDE_DIR),)
-RUNTIME_INCLS += -I$(LIBFABRIC_INCLUDE_DIR)
+ifneq ($(LIBFABRIC_DIR),)
+RUNTIME_INCLS += -I$(LIBFABRIC_DIR)/include
 endif

--- a/runtime/src/comm/ofi/comm-ofi-internal.h
+++ b/runtime/src/comm/ofi/comm-ofi-internal.h
@@ -60,7 +60,9 @@ FILE* chpl_comm_ofi_dbg_file;
 #define DBG_ACK              0x100000UL
 #define DBG_COMMPROGRESS     0x200000UL
 #define DBG_MR              0x1000000UL
-#define DBG_HUGEPAGES       0x8000000UL
+#define DBG_HUGEPAGES       0x2000000UL
+#define DBG_MRDESC          0x4000000UL
+#define DBG_MRKEY           0x8000000UL
 #define DBG_FAB            0x10000000UL
 #define DBG_FABSALL        0x20000000UL
 #define DBG_FABFAIL        0x40000000UL
@@ -98,9 +100,19 @@ char* chpl_comm_ofi_dbg_prefix(void);
 //
 // Simplify internal error checking
 //
+int chpl_comm_ofi_abort_on_error;
+
 #define INTERNAL_ERROR_V(fmt, ...)                                      \
-  chpl_internal_error_v("%s:%d: " fmt, __FILE__, (int) __LINE__,        \
-                        ## __VA_ARGS__)
+  do {                                                                  \
+    if (chpl_comm_ofi_abort_on_error) {                                 \
+      fprintf(stderr, "%d: %s:%d: " fmt, chpl_nodeID,                   \
+              __FILE__, (int) __LINE__, ## __VA_ARGS__);                \
+      abort();                                                          \
+    } else {                                                            \
+      chpl_internal_error_v("%d: %s:%d: " fmt, chpl_nodeID,             \
+                            __FILE__, (int) __LINE__, ## __VA_ARGS__);  \
+    }                                                                   \
+  } while (0)
 
 #define CHK_TRUE(expr)                                                  \
     do {                                                                \


### PR DESCRIPTION
This gets basic AMs working in comm=ofi.  At least, with the sockets
provider all the hellos pass.  (With the gni provider everything seems
to hang; I'll tackle that next.)

The AM descriptor declarations are in the public `chpl_comm_bundleData_t`
in the implementation-specific `chpl-comm-task-decls.h` file now, which
lets us use the stack-based `executeOn` bundles directly on the initiating
side rather than making copies of them.  There is functional support for
blocking and non-blocking normal `executeOn`.  "Fast" `executeOn` is present
nominally but in reality is done the "slow" way: rather than calling the
`executeOn` body function directly from the AM handler we initiate a task
to run it.  There is also support here for AM-mediated GET and PUT,
which are used in situations where RMA is not possible due to lack of
registration, and there are new calls to this support in the appropriate
situations.

This closes #11542.