### PR TITLE
Improve how processes are mapped to locales for gasnetrun_* launchers

### DIFF
--- a/runtime/src/launch/gasnetrun_common/gasnetrun_common.h
+++ b/runtime/src/launch/gasnetrun_common/gasnetrun_common.h
@@ -36,15 +36,18 @@ static char _nlbuf[16];
 static char** chpl_launch_create_argv(const char *launch_cmd,
                                       int argc, char* argv[],
                                       int32_t numLocales) {
-  const int largc = 5;
+  const int largc = 7;
   char *largv[largc];
+
+  snprintf(_nlbuf, sizeof(_nlbuf), "%d", numLocales);
 
   largv[0] = (char *) launch_cmd;
   largv[1] = (char *) "-n";
-  snprintf(_nlbuf, sizeof(_nlbuf), "%d", numLocales);
   largv[2] = _nlbuf;
-  largv[3] = (char*) "-E";
-  largv[4] = chpl_get_enviro_keys(',');
+  largv[3] = (char *) "-N";
+  largv[4] = _nlbuf;
+  largv[5] = (char*) "-E";
+  largv[6] = chpl_get_enviro_keys(',');
 
   return chpl_bundle_exec_args(argc, argv, largc, largv);
 }

--- a/runtime/src/launch/pbs-gasnetrun_ibv/launch-pbs-gasnetrun_ibv.c
+++ b/runtime/src/launch/pbs-gasnetrun_ibv/launch-pbs-gasnetrun_ibv.c
@@ -169,8 +169,8 @@ static char* chpl_launch_create_command(int argc, char* argv[],
   fprintf(expectFile, "expect -re $prompt\n");
   fprintf(expectFile, "send \"cd \\$PBS_O_WORKDIR\\n\"\n");
   fprintf(expectFile, "expect -re $prompt\n");
-  fprintf(expectFile, "send \"%s/%s/gasnetrun_ibv -n %d %s ",
-          CHPL_THIRD_PARTY, WRAP_TO_STR(LAUNCH_PATH), numLocales, chpl_get_real_binary_name());
+  fprintf(expectFile, "send \"%s/%s/gasnetrun_ibv -n %d -N %d %s ",
+          CHPL_THIRD_PARTY, WRAP_TO_STR(LAUNCH_PATH), numLocales, numLocales, chpl_get_real_binary_name());
   for (i=1; i<argc; i++) {
     fprintf(expectFile, " '%s'", argv[i]);
   }

--- a/runtime/src/launch/slurm-gasnetrun_ibv/launch-slurm-gasnetrun_ibv.c
+++ b/runtime/src/launch/slurm-gasnetrun_ibv/launch-slurm-gasnetrun_ibv.c
@@ -246,8 +246,8 @@ static char* chpl_launch_create_command(int argc, char* argv[],
     else
       fprintf(slurmFile, "#SBATCH -o %s.%%j.out\n", argv[0]);
 //    fprintf(slurmFile, "cd $SBATCH_O_WORKDIR\n");
-      fprintf(slurmFile, "%s/%s/gasnetrun_ibv -n %d",
-              CHPL_THIRD_PARTY, WRAP_TO_STR(LAUNCH_PATH), numLocales);
+      fprintf(slurmFile, "%s/%s/gasnetrun_ibv -n %d -N %d",
+              CHPL_THIRD_PARTY, WRAP_TO_STR(LAUNCH_PATH), numLocales, numLocales);
       propagate_environment(slurmFile);
       fprintf(slurmFile, " %s ", chpl_get_real_binary_name());
       for (i=1; i<argc; i++) {
@@ -282,8 +282,8 @@ static char* chpl_launch_create_command(int argc, char* argv[],
     fprintf(expectFile, " -C %s", constraint);
   }
 //  fprintf(expectFile, "-I %s ", slurmFilename);
-  fprintf(expectFile, " %s/%s/gasnetrun_ibv -n %d",
-          CHPL_THIRD_PARTY, WRAP_TO_STR(LAUNCH_PATH), numLocales);
+  fprintf(expectFile, " %s/%s/gasnetrun_ibv -n %d -N %d",
+          CHPL_THIRD_PARTY, WRAP_TO_STR(LAUNCH_PATH), numLocales, numLocales);
   propagate_environment(expectFile);
   fprintf(expectFile, " %s ", chpl_get_real_binary_name());
   for (i=1; i<argc; i++) {

--- a/third-party/gasnet/README
+++ b/third-party/gasnet/README
@@ -20,6 +20,8 @@ as follows:
 * Added preliminary support for 64-bit ARM.  This adds the new file
   third-party/gasnet/gasnet-src/other/contrib/cross-configure-aarch64-linux
   which is the only ARM change beneath gasnet-src in the tree.
+* Pulled in an upstream fix for mpi-spawner -N support for Open MPI 3.x
+   - https://bitbucket.org/berkeleylab/gasnet/commits/e9088bc72
 
 Upgrading GASNet versions
 =========================

--- a/third-party/gasnet/gasnet-src/mpi-conduit/contrib/gasnetrun_mpi.pl
+++ b/third-party/gasnet/gasnet-src/mpi-conduit/contrib/gasnetrun_mpi.pl
@@ -89,7 +89,7 @@ sub gasnet_encode($) {
     my $platform    = $ENV{'GASNET_PLATFORM'};
     #print "using platform hint: $platform\n";
     my $is_lam      = ($mpirun_help =~ m|LAM/MPI|);
-    my $is_ompi     = ($mpirun_help =~ m|Open ?RTE|);
+    my $is_ompi     = ($mpirun_help =~ m|Open( ?RTE\| MPI)|);
     my $is_mpich2   = ($mpirun_help =~ m|MPICH1 compatibility|);
     my $is_mpiexec  = ($mpirun_help =~ m|mpiexec|);
     my $is_mpiexec_nt = ($mpirun_help =~ m|mpiexec| && $uname =~ m|cygwin|i );
@@ -145,7 +145,7 @@ sub gasnet_encode($) {
 		    'inter' => '-x'
 		  );
         # Seen to crash 1.4.2, but OK for a long time
-        $ppn_opt = '-npernode' if ($mpirun_help =~ m/\bnpernode\b/);
+        $ppn_opt = '-npernode' if ($mpirun_help =~ m/\(Open MPI\) (1\.([5-9]|10)|[2-9])/);
     } elsif ($is_mpich2) {
 	$spawner_desc = "MPICH2/mpiexec";
 	# pass env as "-envlist A,B,C"


### PR DESCRIPTION
Previously we just specified `-n <numLocales>` to gasnetrun_*, which only
controlled how many processes were spawned, but not how those processes were
mapped to nodes. Now we also throw `-N <numLocales>` which specifies how many
locales to map to, so we should always get 1 process per node/locale.

Under the covers gasnetrun_{ibv, mpi, ofi, psm} defaults to using mpirun to
launch. Different vendors have different defaults for how processes are mapped
to nodes and it seems like Open MPI was packing processes and filling up nodes
first, which is bad for us. We want to scatter processes so we end up with 1
process per locale. Now we try to force mpirun to give us a process per node
using the `-N` flag, which GASNet will map to the correct flag for the MPI
vendor/version.

GASNet docs note that `-N` might not be supported by all variants of mpirun,
but they have pretty high confidence in it's portability and testing shows it
works for:
 - Open MPI 1.X, 2.X, 3.X
 - MPICH 3.X
 - Intel MPI 2018

And if it doesn't work the user will just get a warning, which should serve as
a good indication to ping us or the GASNet team.

Resolves https://github.com/chapel-lang/chapel/issues/11030
