### PR TITLE
Add annotations for chameneos improvement and revcomp regression

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -465,6 +465,8 @@ chameneos-redux:
     - altered output order for chameneos data, old data incompatible
   09/15/17:
     - Chameneos initializer updates (#7328)
+  10/31/18:
+    - Enable parallelism for shape-ful expressions over ranges (#11501)
 
 CoMD:
   07/26/17:
@@ -1192,6 +1194,8 @@ revcomp:
     - Update revcomp problem size; filenames for fasta-based inputs (#9043)
   04/19/18:
     - Use zero-arg initializer in BaseDom (#9250)
+  10/30/18:
+    - Improve string comparisons (#11479)
 
 sad:
   05/03/16:


### PR DESCRIPTION
Links to the graphs:

https://chapel-lang.org/perf/chapcs/?startdate=2018/10/14&enddate=2018/11/01&graphs=chameneosreduxshootoutbenchmarkn6000000,reversecomplementshootoutbenchmark

#11501 improved chameneos performance (which I find surprising). But editing the test to use a for-loop instead of a forall-loop (undoing the effect of the PR) results in the slower numbers, so it seems to be a real improvement.

#11479 had a minor performance regression for the worst-performing reverse-complement study.