### PR TITLE
Avoid creating an array in chpl__sumType()

### DIFF
--- a/test/reductions/vass/illegal-elttype.chpl
+++ b/test/reductions/vass/illegal-elttype.chpl
@@ -1,0 +1,9 @@
+
+record RRR { }
+
+var AAA: [1..100] RRR;
+
+proc main {
+  var result = + reduce AAA;
+  writeln(result);
+}

--- a/test/reductions/vass/illegal-elttype.good
+++ b/test/reductions/vass/illegal-elttype.good
@@ -1,0 +1,2 @@
+illegal-elttype.chpl:6: In function 'main':
+illegal-elttype.chpl:7: error: + reduce cannot be used on values of the type RRR


### PR DESCRIPTION
chpl__sumType() computes the type of `x+x` given the type of `x`.
To do so, it declares the variable `x`, computes `x+x` and takes its type.
All this happens strictly at compile time, which is desired, as long as
the type is not a "runtime type" i.e. an array or a domain.

This is time-consuming in the case `x` is an array. Even though chpl__sumType()
is smart to run `x+x` only on a variable of the array's element type, and
if that itself is an array, then only on its element type recursively,
allocating an array is already expensive, especially when:
* an array is large,
* it is an array of arrays, and/or
* it is a distributed array.

This is one of the causes of the slowdown discussed in #11333 / #11426.

In most practical cases, the type of `x+x` is the same as the type of `x`.
If so, we can save the hassle of allocating the array.

This PR adds a check "is the type of `x+x` the same as the type of `x` ?".
If so, chpl__sumType() skips declaring the variable `x`, instead returning
its type immediately.

This check is "conservative" aka has false negatives. I.e. it may say "no"
in some cases where chpl__sumType() could return immediately. If so,
chpl__sumType() will do the unnecessary work of allocating the `x`.
This is largly only a performance concern - because chpl__sumType()
still produces a correct result. In practice this situation should be rare.

While there, emit user-friendly error when + reducing something that does not
have a valid + implementation.

Testing: linux64 -futures; test/reductions under gasnet.