### PR TITLE
Forward the these() iterators for arrays, domains, and distributions

### DIFF
--- a/modules/dists/BlockCycDist.chpl
+++ b/modules/dists/BlockCycDist.chpl
@@ -522,8 +522,8 @@ iter BlockCyclicDom.these(param tag: iterKind) where tag == iterKind.leader {
     // result of the reduction is always 0 (for an array of ints). Looking at
     // the generated code, it seems like the reduction object is not being
     // passed through nested loops correctly (or at all).
-    for follow in locDom.myStarts._value.these(iterKind.leader, maxTasks, ignoreRunning, minSize) {
-      for i in locDom.myStarts._value.these(iterKind.follower, follow, maxTasks, ignoreRunning, minSize) {
+    for follow in locDom.myStarts.these(iterKind.leader, maxTasks, ignoreRunning, minSize) {
+      for i in locDom.myStarts.these(iterKind.follower, follow, maxTasks, ignoreRunning, minSize) {
         var retblock: rank*range(idxType);
         for param j in 1..rank {
           const lo     = if rank == 1 then i else i(j);

--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -736,9 +736,8 @@ iter BlockDom.these(param tag: iterKind) where tag == iterKind.leader {
       locOffset(i) = tmpBlock.dim(i).first / stride:idxType;
     }
     // Forward to defaultRectangular
-    for followThis in tmpBlock._value.these(iterKind.leader, maxTasks,
-                                            myIgnoreRunning, minSize,
-                                            locOffset) do
+    for followThis in tmpBlock.these(iterKind.leader, maxTasks,
+                                     myIgnoreRunning, minSize, locOffset) do
       yield followThis;
   }
 }

--- a/modules/dists/ReplicatedDist.chpl
+++ b/modules/dists/ReplicatedDist.chpl
@@ -344,13 +344,13 @@ iter ReplicatedDom.these() {
 
 iter ReplicatedDom.these(param tag: iterKind) where tag == iterKind.leader {
   // redirect to DefaultRectangular's leader
-  for follow in chpl_myLocDom().domLocalRep._value.these(tag) do
+  for follow in chpl_myLocDom().domLocalRep.these(tag) do
     yield follow;
 }
 
 iter ReplicatedDom.these(param tag: iterKind, followThis) where tag == iterKind.follower {
   // redirect to DefaultRectangular
-  for i in redirectee()._value.these(tag, followThis) do
+  for i in redirectee().these(tag, followThis) do
     yield i;
 }
 
@@ -579,7 +579,7 @@ iter ReplicatedArr.these(param tag: iterKind) where tag == iterKind.leader {
 
 iter ReplicatedArr.these(param tag: iterKind, followThis) ref where tag == iterKind.follower {
   // redirect to DefaultRectangular
-  for a in chpl_myLocArr().arrLocalRep._value.these(tag, followThis) do
+  for a in chpl_myLocArr().arrLocalRep.these(tag, followThis) do
     yield a;
 }
 

--- a/modules/dists/SparseBlockDist.chpl
+++ b/modules/dists/SparseBlockDist.chpl
@@ -222,14 +222,14 @@ class SparseBlockDom: BaseSparseDomImpl {
       //on blk do
       // But can't currently have yields in on clauses:
       // invalid use of 'yield' within 'on' in serial iterator
-      for x in locDom.mySparseBlock._value.these() do
+      for x in locDom.mySparseBlock.these() do
         yield x;
   }
 
   iter these(param tag: iterKind) where tag == iterKind.leader {
     coforall (locDom,localeIndex) in zip(locDoms,dist.targetLocDom) {
       on locDom {
-        for followThis in locDom.mySparseBlock._value.these(tag) {
+        for followThis in locDom.mySparseBlock.these(tag) {
           yield (followThis, localeIndex);
         }
       }

--- a/modules/dists/StencilDist.chpl
+++ b/modules/dists/StencilDist.chpl
@@ -705,9 +705,8 @@ iter StencilDom.these(param tag: iterKind) where tag == iterKind.leader {
     for param i in 1..tmpStencil.rank do
       locOffset(i) = tmpStencil.dim(i).first/tmpStencil.dim(i).stride:strType;
     // Forward to defaultRectangular
-    for followThis in tmpStencil._value.these(iterKind.leader, maxTasks,
-                                            myIgnoreRunning, minSize,
-                                            locOffset) do
+    for followThis in tmpStencil.these(iterKind.leader, maxTasks,
+                                       myIgnoreRunning, minSize, locOffset) do
       yield followThis;
   }
 }

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -937,7 +937,7 @@ module ChapelArray {
       }
     }
 
-    forwarding _value except these, targetLocales;
+    forwarding _value except targetLocales;
 
     inline proc _do_destroy() {
       if ! _unowned && ! _instance.singleton() {
@@ -1076,7 +1076,7 @@ module ChapelArray {
       }
     }
 
-    forwarding _value except these;
+    forwarding _value;
 
     pragma "no doc"
     proc chpl__serialize()
@@ -2172,9 +2172,8 @@ module ChapelArray {
       }
     }
 
-    forwarding _value except these,
-                      doiBulkTransferFromKnown, doiBulkTransferToKnown,
-                      doiBulkTransferFromAny,  doiBulkTransferToAny;
+    forwarding _value except doiBulkTransferFromKnown, doiBulkTransferToKnown,
+                             doiBulkTransferFromAny,  doiBulkTransferToAny;
 
     inline proc _do_destroy() {
       if ! _unowned {

--- a/modules/packages/DistributedBag.chpl
+++ b/modules/packages/DistributedBag.chpl
@@ -252,19 +252,6 @@ module DistributedBag {
       return chpl_getPrivatizedCopy(DistributedBagImpl(eltType), _pid);
     }
 
-    pragma "no doc"
-    pragma "fn returns iterator"
-    inline proc these() {
-      return _value.these();
-    }
-
-    pragma "no doc"
-    pragma "fn returns iterator"
-    inline proc these(param tag) where (tag == iterKind.leader || tag == iterKind.standalone)
-      && __primitive("method call resolves", _value, "these", tag=tag){
-      return _value.these(tag=tag);
-    }
-
     forwarding _value;
   }
 

--- a/modules/packages/DistributedDeque.chpl
+++ b/modules/packages/DistributedDeque.chpl
@@ -232,20 +232,6 @@ module DistributedDeque {
       return chpl_getPrivatizedCopy(DistributedDequeImpl(eltType), _pid);
     }
 
-    pragma "no doc"
-    pragma "fn returns iterator"
-    inline proc these(param order : Ordering = Ordering.NONE) {
-      return _value.these(order);
-    }
-
-    pragma "no doc"
-    pragma "fn returns iterator"
-    inline proc these(param order : Ordering = Ordering.NONE, param tag) where
-        (tag == iterKind.leader || tag == iterKind.standalone)
-        && __primitive("method call resolves", _value, "these", tag=tag) {
-      return _value.these(order, tag=tag);
-    }
-
     forwarding _value;
   }
 

--- a/modules/packages/DistributedIters.chpl
+++ b/modules/packages/DistributedIters.chpl
@@ -308,8 +308,7 @@ where tag == iterKind.follower
                   + "valid domain or range"),
                  1);
   const current = if isDomain(c)
-                  then c._value.these(tag=iterKind.follower,
-                                      followThis=followThis)
+                  then c.these(tag=iterKind.follower, followThis=followThis)
                   else unDensify(followThis(1), c);
 
   if debugDistributedIters
@@ -566,8 +565,7 @@ where tag == iterKind.follower
                   + "valid domain or range"),
                  1);
   const current = if isDomain(c)
-                  then c._value.these(tag=iterKind.follower,
-                                      followThis=followThis)
+                  then c.these(tag=iterKind.follower, followThis=followThis)
                   else unDensify(followThis(1), c);
 
   if debugDistributedIters

--- a/modules/standard/DynamicIters.chpl
+++ b/modules/standard/DynamicIters.chpl
@@ -235,7 +235,7 @@ iter dynamic(param tag:iterKind, c:domain, chunkSize:int=1, numTasks:int, parDim
 where tag == iterKind.follower
 {
   //Invoke the default rectangular domain follower iterator
-  for i in c._value.these(tag=iterKind.follower, followThis=followThis) do
+  for i in c.these(tag=iterKind.follower, followThis=followThis) do
     yield i;
 }
 
@@ -399,7 +399,7 @@ iter guided(param tag:iterKind, c:domain, numTasks:int, parDim:int, followThis)
 where tag == iterKind.follower
 {
   // Invoke the default rectangular domain follower iterator.
-  for i in c._value.these(tag=iterKind.follower, followThis=followThis) do {
+  for i in c.these(tag=iterKind.follower, followThis=followThis) do {
     yield i;
   }
 }
@@ -690,7 +690,7 @@ iter adaptive(param tag:iterKind, c:domain, numTasks:int, parDim:int, followThis
 where tag == iterKind.follower
 {
   // Invoke the default rectangular domain follower iterator.
-  for i in c._value.these(tag=iterKind.follower, followThis=followThis) do {
+  for i in c.these(tag=iterKind.follower, followThis=followThis) do {
     yield i;
   }
 }

--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -1116,7 +1116,7 @@ module Random {
     iter PCGRandomPrivate_iterate(type resultType, D: domain, seed: int(64),
                                start: int(64), param tag: iterKind)
           where tag == iterKind.leader {
-      for block in D._value.these(tag=iterKind.leader) do
+      for block in D.these(tag=iterKind.leader) do
         yield block;
     }
 
@@ -2356,7 +2356,7 @@ module Random {
                          start: int(64), param tag: iterKind)
           where tag == iterKind.leader {
       // forward to the domain D's iterator
-      for block in D._value.these(tag=iterKind.leader) do
+      for block in D.these(tag=iterKind.leader) do
         yield block;
     }
 

--- a/test/distributions/bradc/assoc/UserMapAssoc.chpl
+++ b/test/distributions/bradc/assoc/UserMapAssoc.chpl
@@ -396,11 +396,11 @@ class UserMapAssocDom: BaseAssociativeDom {
         // redirect to the DefaultAssociative's leader
         // note that DefaultAssociative's leader returns (lo..hi, this)
         // ie. a range of table slots and then the DefaultAssociativeDom.
-        for follow in locDom.myInds._value.these(tag) do
+        for follow in locDom.myInds.these(tag) do
           yield (follow, localeIndex);
-        //  for followThis in tmpBlock._value.these(iterKind.leader, maxTasks,
-        //                                           myIgnoreRunning, minSize,
-        //                                           locOffset)
+        //  for followThis in tmpBlock.these(iterKind.leader, maxTasks,
+        //                                   myIgnoreRunning, minSize,
+        //                                   locOffset)
         //yield locDom;
       }
     }
@@ -412,14 +412,14 @@ class UserMapAssocDom: BaseAssociativeDom {
 
     var locDom = locDoms[localeIndex];
 
-    for i in locDom.myInds._value.these(tag, locFollowThis) do
+    for i in locDom.myInds.these(tag, locFollowThis) do
       yield i;
   }
 
   iter these(param tag: iterKind) where tag == iterKind.standalone {
     coforall locDom in locDoms do on locDom {
       // Forward to associative domain standalone iterator
-      for i in locDom.myInds._value.these(tag) {
+      for i in locDom.myInds.these(tag) {
         yield i;
       }
     }
@@ -753,14 +753,14 @@ class UserMapAssocArr: BaseArr {
     var locArr = locArrs[localeIndex];
 
     // forward to locArr
-    for i in locArr.myElems._value.these(tag, locFollowThis) do
+    for i in locArr.myElems.these(tag, locFollowThis) do
       yield i;
   }
 
   iter these(param tag: iterKind) ref where tag == iterKind.standalone {
     coforall locArr in locArrs do on locArr {
       // Forward to associative array standalone iterator
-      for i in locArr.myElems._value.these(tag) {
+      for i in locArr.myElems.these(tag) {
         yield i;
       }
     }

--- a/test/functions/iterators/sungeun/forwarding/forwardDefaultArr.chpl
+++ b/test/functions/iterators/sungeun/forwarding/forwardDefaultArr.chpl
@@ -10,7 +10,7 @@ iter myThese(A,
              dptpl=dataParTasksPerLocale,
              ir=dataParIgnoreRunningTasks,
              mg=dataParMinGranularity) {
-  for i in A._value.these() do yield i;
+  for i in A.these() do yield i;
 }
 
 iter myThese(param tag: iterKind, A,
@@ -18,7 +18,7 @@ iter myThese(param tag: iterKind, A,
              ir=dataParIgnoreRunningTasks,
              mg=dataParMinGranularity)
   where tag==iterKind.leader {
-  for followThis in A._value.these(iterKind.leader, dptpl, ir, mg) do
+  for followThis in A.these(iterKind.leader, dptpl, ir, mg) do
     yield followThis;
 }
 
@@ -27,7 +27,7 @@ iter myThese(param tag: iterKind, followThis, A,
              ir=dataParIgnoreRunningTasks,
              mg=dataParMinGranularity)
   where tag==iterKind.follower {
-  for i in A._value.these(iterKind.follower, followThis, dptpl, ir, mg) do
+  for i in A.these(iterKind.follower, followThis, dptpl, ir, mg) do
     yield i;
 }
 
@@ -45,13 +45,13 @@ forall a in myThese(A, ir=!dataParIgnoreRunningTasks) do
 forall a in myThese(A, mg=dataParMinGranularity*2) do
   if noisy then writeln(a);
 
-forall a in A._value.these() do
+forall a in A.these() do
   if noisy then writeln(a);
-forall a in A._value.these(tasksPerLocale=dataParTasksPerLocale/2) do
+forall a in A.these(tasksPerLocale=dataParTasksPerLocale/2) do
   if noisy then writeln(a);
-forall a in A._value.these(ignoreRunning=!dataParIgnoreRunningTasks) do
+forall a in A.these(ignoreRunning=!dataParIgnoreRunningTasks) do
   if noisy then writeln(a);
-forall a in A._value.these(minIndicesPerTask=dataParMinGranularity*2) do
+forall a in A.these(minIndicesPerTask=dataParMinGranularity*2) do
   if noisy then writeln(a);
 
 writeln("=== leaving forwardDefaultArr ===");

--- a/test/functions/iterators/sungeun/forwarding/forwardDefaultDom.chpl
+++ b/test/functions/iterators/sungeun/forwarding/forwardDefaultDom.chpl
@@ -9,7 +9,7 @@ iter myThese(D,
              dptpl=dataParTasksPerLocale,
              ir=dataParIgnoreRunningTasks,
              mg=dataParMinGranularity) {
-  for i in D._value.these() do yield i;
+  for i in D.these() do yield i;
 }
 
 iter myThese(param tag: iterKind, D,
@@ -17,7 +17,7 @@ iter myThese(param tag: iterKind, D,
              ir=dataParIgnoreRunningTasks,
              mg=dataParMinGranularity)
   where tag==iterKind.leader {
-  for followThis in D._value.these(iterKind.leader, dptpl, ir, mg) do
+  for followThis in D.these(iterKind.leader, dptpl, ir, mg) do
     yield followThis;
 }
 
@@ -26,7 +26,7 @@ iter myThese(param tag: iterKind, followThis, D,
              ir=dataParIgnoreRunningTasks,
              mg=dataParMinGranularity)
   where tag==iterKind.follower {
-  for i in D._value.these(iterKind.follower, followThis, dptpl, ir, mg) do
+  for i in D.these(iterKind.follower, followThis, dptpl, ir, mg) do
     yield i;
 }
 
@@ -39,13 +39,13 @@ forall i in myThese(D, ir=!dataParIgnoreRunningTasks) do
 forall i in myThese(D, mg=dataParMinGranularity*2) do
   if noisy then writeln(i);
 
-forall i in D._value.these() do
+forall i in D.these() do
   if noisy then writeln(i);
-forall i in D._value.these(tasksPerLocale=dataParTasksPerLocale/2) do
+forall i in D.these(tasksPerLocale=dataParTasksPerLocale/2) do
   if noisy then writeln(i);
-forall i in D._value.these(ignoreRunning=!dataParIgnoreRunningTasks) do
+forall i in D.these(ignoreRunning=!dataParIgnoreRunningTasks) do
   if noisy then writeln(i);
-forall i in D._value.these(minIndicesPerTask=dataParMinGranularity*2) do
+forall i in D.these(minIndicesPerTask=dataParMinGranularity*2) do
   if noisy then writeln(i);
 
 writeln("=== leaving forwardDefaultDom ===");

--- a/test/functions/iterators/sungeun/localDataPar.chpl
+++ b/test/functions/iterators/sungeun/localDataPar.chpl
@@ -9,19 +9,19 @@ config const mg = 19;
 const D = {lo..hi, (lo..hi)+1, (lo..hi)+2, (lo..hi)+3};
 var A: [D] real;
 
-forall i in D._value.these(tasksPerLocale=dptpl, ignoreRunning=ir) {
+forall i in D.these(tasksPerLocale=dptpl, ignoreRunning=ir) {
   if noisy then writeln(i);
 }
 
-forall i in D._value.these(minIndicesPerTask=mg, ignoreRunning=ir) {
+forall i in D.these(minIndicesPerTask=mg, ignoreRunning=ir) {
   if noisy then writeln(i);
 }
 
-forall i in A._value.these(tasksPerLocale=dptpl, ignoreRunning=ir) {
+forall i in A.these(tasksPerLocale=dptpl, ignoreRunning=ir) {
   if noisy then writeln(i);
 }
 
-forall i in A._value.these(minIndicesPerTask=mg, ignoreRunning=ir) {
+forall i in A.these(minIndicesPerTask=mg, ignoreRunning=ir) {
   if noisy then writeln(i);
 }
 

--- a/test/parallel/forall/task-private-vars/records.chpl
+++ b/test/parallel/forall/task-private-vars/records.chpl
@@ -22,7 +22,7 @@ config const dptpl = 3;
 
 const MessageSpace = {1..numMessages};
 
-forall msg in MessageSpace._value.these(tasksPerLocale = dptpl)
+forall msg in MessageSpace.these(tasksPerLocale = dptpl)
   with (var cnt: Count, var itr = cnt.counter * 100)
 {
   itr += 1;
@@ -32,7 +32,7 @@ forall msg in MessageSpace._value.these(tasksPerLocale = dptpl)
   writef("%i %i\n", cnt.counter, itr);
 }
 
-forall msg in MessageSpace._value.these(tasksPerLocale = dptpl)
+forall msg in MessageSpace.these(tasksPerLocale = dptpl)
   with (var wrap: Wrapper,
         // make sure that other ways to declare a TPV
         // are usable, too

--- a/test/reductions/bharshbarg/reduceWithoutTag.chpl
+++ b/test/reductions/bharshbarg/reduceWithoutTag.chpl
@@ -21,8 +21,8 @@ iter good(n : int) {
 
 iter good(param tag: iterKind, n : int) where tag == iterKind.leader {
   var dom = {1..n};
-  for follow in dom._value.these(iterKind.leader) {
-    for i in dom._value.these(iterKind.follower, follow) {
+  for follow in dom.these(iterKind.leader) {
+    for i in dom.these(iterKind.follower, follow) {
       yield i;
     }
   }

--- a/test/studies/bale/toposort/toposort.chpl
+++ b/test/studies/bale/toposort/toposort.chpl
@@ -244,22 +244,6 @@ class DistributedWorkQueue {
   proc deinit(){
     delete this.localInstance;
   }
-
-  pragma "fn returns iterator"
-  inline proc these(param tag ) where (tag == iterKind.standalone)
-    && __primitive("method call resolves", _value, "these", tag=tag){
-    var maxTasks : [0..#Locales.size] int;
-    forall onLocale in Locales {
-      maxTasks[ onLocale.id ] = onLocale.maxTaskPar;
-    }
-    return _value.these(tag=tag, maxTasks);
-  }
-
-  pragma "fn returns iterator"
-  inline proc these(param tag, maxTasksPerLocale : [?d] int ) where (tag == iterKind.standalone)
-    && __primitive("method call resolves", _value, "these", tag=tag){
-    return _value.these(tag=tag, maxTasksPerLocale);
-  }
 }
 
 class LocalDistributedWorkQueue {

--- a/test/studies/bale/toposort/toposort.chpl
+++ b/test/studies/bale/toposort/toposort.chpl
@@ -193,7 +193,7 @@ class ParallelWorkQueue {
       // yield all in local chunk
       if unlockedQueue.size > 0 {
         unlockedQueue.compact();
-        forall work in unlockedQueue.listArray._value.these( tasksPerLocale = maxTasks ) {
+        forall work in unlockedQueue.listArray.these( tasksPerLocale = maxTasks ) {
           yield work;
         }
       } else  {
@@ -372,7 +372,7 @@ class LocalDistributedWorkQueue {
         // yield all in local chunk
         if unlockedQueue.size > 0 {
           unlockedQueue.compact();
-          forall work in unlockedQueue.listArray._value.these( tasksPerLocale = maxTasks ) {
+          forall work in unlockedQueue.listArray.these( tasksPerLocale = maxTasks ) {
             yield work;
           }
         } else  {

--- a/test/studies/comd/elegant/arrayOfStructs/util/AccumStencilDist.chpl
+++ b/test/studies/comd/elegant/arrayOfStructs/util/AccumStencilDist.chpl
@@ -564,7 +564,7 @@ iter AccumStencilDom.these(param tag: iterKind) where tag == iterKind.leader {
     for param i in 1..tmpAccumStencil.rank do
       locOffset(i) = tmpAccumStencil.dim(i).first/tmpAccumStencil.dim(i).stride:strType;
     // Forward to defaultRectangular
-    for followThis in tmpAccumStencil._value.these(iterKind.leader, maxTasks,
+    for followThis in tmpAccumStencil.these(iterKind.leader, maxTasks,
                                             myIgnoreRunning, minSize,
                                             locOffset) do
       yield followThis;

--- a/test/studies/comd/elegant/arrayOfStructs/util/Simulation.chpl
+++ b/test/studies/comd/elegant/arrayOfStructs/util/Simulation.chpl
@@ -291,13 +291,13 @@ iter allAtoms() ref {
 }
 
 iter allAtoms(param tag : iterKind) ref where tag == iterKind.leader {
-  for follow in Boxes._value.these(iterKind.leader) {
+  for follow in Boxes.these(iterKind.leader) {
     yield follow;
   }
 }
 
 iter allAtoms(param tag : iterKind, followThis) ref where tag == iterKind.follower {
-  for box in Boxes._value.these(iterKind.follower, followThis) {
+  for box in Boxes.these(iterKind.follower, followThis) {
     for a in box.liveAtoms() do yield a;
   }
 }

--- a/test/studies/labelprop/Graph.chpl
+++ b/test/studies/labelprop/Graph.chpl
@@ -134,7 +134,7 @@ module Graph {
        */
       iter Neighbors( v : index (vertices), param tag: iterKind)
       where tag == iterKind.leader {
-        for block in Row(v).neighborList._value.these(tag) do
+        for block in Row(v).neighborList.these(tag) do
           yield block;
       }
 
@@ -142,7 +142,7 @@ module Graph {
        */
       iter Neighbors( v : index (vertices), param tag: iterKind, followThis)
       where tag == iterKind.follower {
-        for nlElm in Row(v).neighborList._value.these(tag, followThis) do
+        for nlElm in Row(v).neighborList.these(tag, followThis) do
           yield nElm(1);
       }
 
@@ -157,7 +157,7 @@ module Graph {
        */
       iter edge_weight( v : index (vertices), param tag: iterKind)
       where tag == iterKind.leader {
-        for block in Row(v).neighborList._value.these(tag) do
+        for block in Row(v).neighborList.these(tag) do
           yield block;
       }
 
@@ -165,7 +165,7 @@ module Graph {
        */
       iter edge_weight( v : index (vertices), param tag: iterKind, followThis)
       where tag == iterKind.follower {
-        for nlElm in Row(v).neighborList._value.these(tag, followThis) do
+        for nlElm in Row(v).neighborList.these(tag, followThis) do
           yield nlElm(2); // todo -- use VertexData.weight
       }
 

--- a/test/studies/ssca2/kristyn/analyze_RMAT_graph_1D_array.chpl
+++ b/test/studies/ssca2/kristyn/analyze_RMAT_graph_1D_array.chpl
@@ -144,13 +144,13 @@ module analyze_RMAT_graph_1D_array {
       // FYI: no fast follower opt
       iter   edge_weight(v : index (vertices), param tag: iterKind)
       where tag == iterKind.leader {
-        for block in Row(v).Weight._value.these(tag) do
+        for block in Row(v).Weight.these(tag) do
           yield block;
       }
 
       iter   edge_weight(v : index (vertices), param tag: iterKind, followThis)
       where tag == iterKind.follower {
-        for elem in Row(v).Weight._value.these(tag, followThis) do
+        for elem in Row(v).Weight.these(tag, followThis) do
           yield elem;
       }
 

--- a/test/studies/ssca2/kristyn/analyze_RMAT_graph_associative_array.chpl
+++ b/test/studies/ssca2/kristyn/analyze_RMAT_graph_associative_array.chpl
@@ -86,13 +86,13 @@ module analyze_RMAT_graph_associative_array {
       // FYI: no fast follower opt
       iter   edge_weight(v : index (vertices), param tag: iterKind)
       where tag == iterKind.leader {
-        for block in Row(v).Row_Neighbors._value.these(tag) do
+        for block in Row(v).Row_Neighbors.these(tag) do
           yield block;
       }
 
       iter   edge_weight(v : index (vertices), param tag: iterKind, followThis)
       where tag == iterKind.follower {
-        for elem in Row(v).Row_Neighbors._value.these(tag, followThis) do
+        for elem in Row(v).Row_Neighbors.these(tag, followThis) do
           yield elem;
       }
 


### PR DESCRIPTION
Previously, they were excluded from forwarding because of some bugs, but it
seems like those bugs have been fixed. I did not track down the responsible
commit, but there were numerous forwarding and other bug fixes in the last
release.

This also converts most uses of `_value.these()` to `these()`. The only
remaining use of `_value.these()` is in domain/array iterators themselves.

Closes https://github.com/chapel-lang/chapel/issues/11466