### PR TITLE
build_configs: add config Dimensions for CHPL_LIB_PIC, _NETWORK_ATOMICS

### DIFF
--- a/util/build_configs/build_configs.py
+++ b/util/build_configs/build_configs.py
@@ -92,11 +92,13 @@ known_dimensions = [
     ( 'unwind',             'CHPL_UNWIND', ),
     ( 'mem',                'CHPL_MEM', ),
     ( 'atomics',            'CHPL_ATOMICS', ),
+    ( 'network_atomics',    'CHPL_NETWORK_ATOMICS', ),
     ( 'gmp',                'CHPL_GMP', ),
     ( 'hwloc',              'CHPL_HWLOC', ),
     ( 'regexp',             'CHPL_REGEXP', ),
     ( 'llvm',               'CHPL_LLVM', ),
     ( 'auxfs',              'CHPL_AUX_FILESYS', ),
+    ( 'lib_pic',            'CHPL_LIB_PIC', ),
 ]
 Dimensions = []
 for (name, var_name) in known_dimensions:


### PR DESCRIPTION
https://github.com/chapel-lang/chapel/issues/11394

Chapel config variable CHPL_LIB_PIC was recently introduced, and
on principle every Chapel config variable should be represented in
build_configs.py.

Noticed we were missing a Dimension for CHPL_NETWORK_ATOMICS- don't
know the reason- so I added that as well.

The current build_configs.py will not try to use the new Dimensions
unless the user gives the corresponding env variable and/or cmdline
parameters:

```
env var                 cmdline parameter
-------                 -----------------
CHPL_LIB_PIC            --lib-pic
CHPL_NETWORK_ATOMICS    --network-atomics
```