### PR TITLE
build_configs: Cray-XC aarch64 should leave cray-mpich module alone

### DIFF
--- a/util/build_configs/cray-internal/setenv-xc-aarch64.bash
+++ b/util/build_configs/cray-internal/setenv-xc-aarch64.bash
@@ -277,9 +277,6 @@ else
         # unload any existing PrgEnv
         unload_module_re PrgEnv-
 
-        # Do not build Gasnet for aarch64, so get rid of mpich.
-        unload_module cray-mpich
-
         # load target PrgEnv with compiler version
         load_module $target_prgenv
         load_module_version $target_compiler $target_version
@@ -293,9 +290,6 @@ else
 
         # unload any existing PrgEnv
         unload_module_re PrgEnv-
-
-        # Do not build Gasnet for aarch64, so get rid of mpich.
-        unload_module cray-mpich
 
         # load target PrgEnv with compiler version
         load_module $target_prgenv


### PR DESCRIPTION
This morning the Cray-XC aarch64 module build broke because command
"module unload cray-mpich" failed.
    
The cray-mpich module caused a lot of problems when I was first trying
these builds on early versions of the Cray-XC aarch64 platform.
That's why that "module unload cray-mpich" was put in the build script
in the first place.
    
It does not seem to be needed any more.