### PR TITLE
Add a performance test for reduce intents with arrays-of-arrays.

### DIFF
--- a/test/GRAPHFILES
+++ b/test/GRAPHFILES
@@ -272,6 +272,7 @@ library/packages/Sort/RadixSort/radixsortMSB.graph
 users/franzf/v0/chpl/main.graph
 reductions/diten/testSerialReductions.graph
 reductions/vass/reductions-perf.graph
+parallel/forall/reduce-intents/ri-a2-AoA.graph
 spectests.graph
 studies/paracr/asenjo/PARACR-BC.graph
 library/standard/BitOps/c-tests/performance/bitops.graph

--- a/test/parallel/forall/reduce-intents/ri-a2-AoA.chpl
+++ b/test/parallel/forall/reduce-intents/ri-a2-AoA.chpl
@@ -1,0 +1,62 @@
+// Timing of in- and reduce-intents for an array-of-arrays.
+// Note that it may somewhat depend on how the loop body is optimized.
+
+use Time;
+
+config var n_bodies = 10000;
+const pDomain = {0..#n_bodies};
+type vec3 = [0..#3] real;
+
+// The arrays' names are insignificant.
+var forces: [pDomain] vec3;
+var velocities: [pDomain] vec3;
+
+var timer: Timer;
+var snapshot, completion: real;
+proc snapTime() { snapshot = timer.elapsed(); }
+timer.start();
+
+// in-intent, vec3
+timer.clear();
+forall q in pDomain with (in forces) {
+  if (q == 0) then
+    snapTime();
+}
+completion = timer.elapsed();
+writeln("vec3 in-intent - startup: ", snapshot);
+writeln("vec3 in-intent - completion: ", completion);
+
+// reduce intent, vec3
+timer.clear();
+forall q in pDomain with (+ reduce velocities) {
+  if (q == 0) then
+    snapTime();
+}
+completion = timer.elapsed();
+writeln("vec3 reduce intent - startup: ", snapshot);
+writeln("vec3 reduce intent - completion: ", completion);
+
+// The arrays' names are insignificant.
+type tup3 = 3*real;
+var positions: [pDomain] tup3;
+var masses: [pDomain] tup3;
+
+// in-intent, tup3
+timer.clear();
+forall q in pDomain with (in positions) {
+  if (q == 0) then
+    snapTime();
+}
+completion = timer.elapsed();
+writeln("tup3 in-intent - startup: ", snapshot);
+writeln("tup3 in-intent - completion: ", completion);
+
+// reduce intent, tup3
+timer.clear();
+forall q in pDomain with (+ reduce masses) {
+  if (q == 0) then
+    snapTime();
+}
+completion = timer.elapsed();
+writeln("tup3 reduce intent - startup: ", snapshot);
+writeln("tup3 reduce intent - completion: ", completion);

--- a/test/parallel/forall/reduce-intents/ri-a2-AoA.graph
+++ b/test/parallel/forall/reduce-intents/ri-a2-AoA.graph
@@ -1,0 +1,5 @@
+perfkeys: vec3 in-intent - startup:, vec3 in-intent - completion:, vec3 reduce intent - startup:, vec3 reduce intent - completion:, tup3 in-intent - startup:, tup3 in-intent - completion:, tup3 reduce intent - startup:, tup3 reduce intent - completion:
+repeat-files: ri-a2-AoA.dat
+graphkeys: vec3/in startup, vec3/in completion, vec3/reduce startup, vec3/reduce completion, tup3/in startup, tup3/in completion, tup3/reduce startup, tup3/reduce completion
+ylabel: Time (seconds)
+graphtitle: Forall with AoA In and Reduce Intents

--- a/test/parallel/forall/reduce-intents/ri-a2-AoA.perfkeys
+++ b/test/parallel/forall/reduce-intents/ri-a2-AoA.perfkeys
@@ -1,0 +1,8 @@
+vec3 in-intent - startup:
+vec3 in-intent - completion:
+vec3 reduce intent - startup:
+vec3 reduce intent - completion:
+tup3 in-intent - startup:
+tup3 in-intent - completion:
+tup3 reduce intent - startup:
+tup3 reduce intent - completion:

--- a/test/parallel/forall/reduce-intents/ri-a2-AoA.skipif
+++ b/test/parallel/forall/reduce-intents/ri-a2-AoA.skipif
@@ -1,0 +1,2 @@
+# This test is not doing anything correctness-check-worthy.
+CHPL_TEST_PERF != on


### PR DESCRIPTION
Related to the performance issues #11133 / #11426.

Since it is not doing anything correctness-check-worthy,
I skipif it unless testing performance.

FYI, the numbers I got on my Linux desktop ("dt") and
the machine doing nightly perf testing in perf.chapcs
configuration ("ni"), without/with the fix in #11556 are,
in seconds:

| test | dt-without | dt-with | ni-without | ni-with |
| :--- | :--- | :--- | :--- | :--- |
vec3 in-intent - startup | 0.011575 | 0.011829 | 43.1271 | 43.3579
vec3 in-intent - completion | 7.54034 | 7.61882 | 69.1676 | 68.8521
vec3 reduce intent - startup | 16.8032 | 0.634863 | 495.341 | 200.894
vec3 reduce intent - completion | 38.3702 | 19.1754 | 606.599 | 338.495

Also testing arrays fo tuples (unaffected by #11556), in seconds:

| test | dt | ni |
| :--- | :--- | :--- |
tup3 in-intent - startup | 0.000096 | 0.00012
tup3 in-intent - completion | 0.000286 | 0.000542
tup3 reduce intent - startup | 0.000281 | 0.000258
tup3 reduce intent - completion | 0.000371 | 0.001276