### PR TITLE
Use a seed to guarantee behavior and avoid failure mode

### DIFF
--- a/test/users/npadmana/mpi/test_mpi.chpl
+++ b/test/users/npadmana/mpi/test_mpi.chpl
@@ -118,7 +118,7 @@ proc pi() {
   var x : [0.. #N] real;
   var y : [0.. #N] real;
 
-  fillRandom(x); fillRandom(y);
+  fillRandom(x, here.id*2 + 1); fillRandom(y, here.id*4 + 1);
   var sum = 0.0;
   forall (x1,y1) in zip(x,y) with (+ reduce sum) {
     if (x1*x1+y1*y1) <= 1 then sum += 1;


### PR DESCRIPTION
This test uses random numbers to compute the value of pi to one decimal place as
a way to exercise MPI_Reduce.  Usually the random numbers generate an average in
the appropriate range but sometimes they produced a number that rounded to
3.2 instead of to 3.1.  This commit adds a seed to the random numbers used,
which allows us to continue to test the functionality we care about without the
variability that could result in failure.

No failure in 1000 runs (was sufficient for 5+ errors before this change).  Strategy
suggested by Brad and discussed with Ben A