### PR TITLE
Skip new bigint test on 32 bit platforms

### DIFF
--- a/test/library/standard/BigInteger/testUintLiteralCast.skipif
+++ b/test/library/standard/BigInteger/testUintLiteralCast.skipif
@@ -1,0 +1,3 @@
+# GMP initializers convert values from uint to c_ulong or int to c_long
+# so the size of c_ulong or c_long need to be 64 bits if the value is large
+CHPL_TARGET_PLATFORM <= 32


### PR DESCRIPTION
This new bigint test converts a large uint to c_ulong in a bigint initializer,
and c_ulong is 32 bits on 32-bit platforms.  Skip this test on 32-bit
platforms until the initializer is improved to handle 64-bit values better.