### PR TITLE
Add future showing uncaptured new owned/shared/"" C() is leaked

### DIFF
--- a/test/classes/delete-free/uncaptured-new.bad
+++ b/test/classes/delete-free/uncaptured-new.bad
@@ -1,0 +1,20 @@
+entering foo
+init(1)
+exiting foo
+returned from foo()
+
+entering bar
+init(2)
+exiting bar
+deinit(2)
+returned from bar()
+
+entering baz
+init(3)
+exiting baz
+returned from baz()
+
+entering qux
+init(4)
+exiting qux
+returned from qux()

--- a/test/classes/delete-free/uncaptured-new.chpl
+++ b/test/classes/delete-free/uncaptured-new.chpl
@@ -1,0 +1,42 @@
+class C {
+  var x: int;
+  proc init(_x) {x = _x; writeln("init(",x,")"); }
+  proc deinit() { writeln("deinit(",x,")"); }
+}
+
+proc foo() {
+  writeln("entering foo");
+  new owned C(1);
+  writeln("exiting foo");
+}
+
+foo();
+writeln("returned from foo()\n");
+
+proc bar() {
+  writeln("entering bar");
+  new borrowed C(2);
+  writeln("exiting bar");
+}
+
+bar();
+writeln("returned from bar()\n");
+
+proc baz() {
+  writeln("entering baz");
+  new shared C(3);
+  writeln("exiting baz");
+}
+
+baz();
+writeln("returned from baz()\n");
+
+
+proc qux() {
+  writeln("entering qux");
+  new C(4);
+  writeln("exiting qux");
+}
+
+qux();
+writeln("returned from qux()");

--- a/test/classes/delete-free/uncaptured-new.future
+++ b/test/classes/delete-free/uncaptured-new.future
@@ -1,0 +1,2 @@
+bug: uncaptured new owned/shared/"" C() object is leaked
+#11101

--- a/test/classes/delete-free/uncaptured-new.good
+++ b/test/classes/delete-free/uncaptured-new.good
@@ -1,0 +1,23 @@
+entering foo
+init(1)
+exiting foo
+deinit(1)
+returned from foo()
+
+entering bar
+init(2)
+exiting bar
+deinit(2)
+returned from bar()
+
+entering baz
+init(3)
+exiting baz
+deinit(3)
+returned from baz()
+
+entering qux
+init(4)
+exiting qux
+deinit(4)
+returned from qux()


### PR DESCRIPTION
Taking the missing deinit() calls to indicate a leak for .bad purposes.

Run with --memLeaks, it shows

```
======================================================================================================================================
Allocated Memory (Bytes)                              Number   Size     Total    Description                      Address             
======================================================================================================================================
test/classes/delete-free/uncaptured-new.chpl:9        1        16       16       C                                0x00007f7d7ea0f100  
test/classes/delete-free/uncaptured-new.chpl:27       1        16       16       C                                0x00007f7d7ea0f110  
test/classes/delete-free/uncaptured-new.chpl:37       1        16       16       C                                0x00007f7d7ea0f140  
$CHPL_HOME/modules/internal/SharedObject.chpl:188     1        16       16       ReferenceCount                   0x00007f7d7ea0f130  
======================================================================================================================================
```
