### PR TITLE
Change language level in Cython

### DIFF
--- a/compiler/codegen/library.cpp
+++ b/compiler/codegen/library.cpp
@@ -350,6 +350,8 @@ static void makePYXFile(std::vector<FnSymbol*> functions) {
 
     gGenInfo->cfile = pyx.fptr;
 
+    fprintf(pyx.fptr, "#!python\n");
+    fprintf(pyx.fptr, "#cython: language_level=3\n");
     // Make import statement at top of .pyx file for chpl_library_init and
     // chpl_library_finalize
     fprintf(pyx.fptr, "from chplrt cimport chpl_library_init, ");


### PR DESCRIPTION
Apparently the language_level default is going to change in an
upcoming release (to what we want it to be).  Because of this, it
is generating a warning if the language_level is unset for certain
versions of Cython.  Set it to 3 for now (and hopefully remember
to remove the declaration when using later versions?  It's good to
rely on the default when possible)