### PR TITLE
Skip llnl CoMD under fifo

### DIFF
--- a/test/studies/comd/llnl/CoMD.skipif
+++ b/test/studies/comd/llnl/CoMD.skipif
@@ -1,0 +1,3 @@
+# This test can create an absurd number of tasks, which lead to extremely long
+# execution times under fifo for low core-count systems
+CHPL_TASKS == fifo


### PR DESCRIPTION
This test creates 8,000+ concurrent tasks even for correctness testing.
Under fifo on low core count machines that results in too many threads
to process in a reasonable amount of time.