### PR TITLE
Put constOverflow routine in main

### DIFF
--- a/test/expressions/hilde/constOverflow.chpl
+++ b/test/expressions/hilde/constOverflow.chpl
@@ -8,10 +8,12 @@
 // behavior is OK, but Chapel should try to protect users from such
 // platform-dependencies.
 
-const maxS = max(int(32));
-const maxS1 = maxS + 1;
-const m = 10;
+proc main() {
+  const maxS = max(int(32));
+  const maxS1 = maxS + 1;
+  const m = 10;
 
-writeln(maxS % m);
-writeln((maxS+1) % m);
-writeln(maxS1 % 10);
+  writeln(maxS % m);
+  writeln((maxS+1) % m);
+  writeln(maxS1 % 10);
+}


### PR DESCRIPTION
This test is demonstrating problems with integer overflow but PR #11570 changed its behavior. So this PR just puts the test into main so it works like it used to.