### PR TITLE
Update source-highlight syntax highlighter

### DIFF
--- a/highlight/source-highlight/chpl.lang
+++ b/highlight/source-highlight/chpl.lang
@@ -4,22 +4,22 @@
 preproc = "use"
 
 # \< \> means all one token.
-
-# binary, octal, decimal, hexadecimal integer
-number = '\<(0[bB][0-1]([0-1]|_)*)\>'
-number = '\<(0[oO][0-7]([0-7]|_)*)\>'
-number = '\<([[:digit:]]([[:digit:]]|_)*)\>'
-number = '\<(0[xX][[:xdigit:]]([[:xdigit:]]|_)*)\>'
-
+# These need to be ordered with the longest patterns first
 # decimal floating point number
 number = '\<(([[:digit:]]([[:digit:]]|_)*)?\.[[:digit:]]([[:digit:]]|_)*([Ee][+-]?[[:digit:]]([[:digit:]]|_)*)?)\>'
 number = '\<(([[:digit:]]([[:digit:]]|_)*)\.([Ee][+-]?[[:digit:]]([[:digit:]]|_)*))\>'
 number = '\<(([[:digit:]]([[:digit:]]|_)*)([Ee][+-]?[[:digit:]]([[:digit:]]|_)*))\>'
 
 # hexadecimal floating point number
-number = '\<(([[:xdigit:]]([[:xdigit:]]|_)*)?\.[[:xdigit:]]([[:xdigit:]]|_)*([Pp][+-]?[[:digit:]]([[:digit:]]|_)*)?)\>'
-number = '\<(([[:xdigit:]]([[:xdigit:]]|_)*)\.([Pp][+-]?[[:digit:]]([[:digit:]]|_)*))\>'
-number = '\<(([[:xdigit:]]([[:xdigit:]]|_)*)([Pp][+-]?[[:digit:]]([[:digit:]]|_)*))\>'
+number = '\<0(x|X)(([[:xdigit:]]([[:xdigit:]]|_)*)?\.[[:xdigit:]]([[:xdigit:]]|_)*([Pp][+-]?[[:digit:]]([[:digit:]]|_)*)?)\>'
+number = '\<0(x|X)(([[:xdigit:]]([[:xdigit:]]|_)*)\.([Pp][+-]?[[:digit:]]([[:digit:]]|_)*))\>'
+number = '\<0(x|X)(([[:xdigit:]]([[:xdigit:]]|_)*)([Pp][+-]?[[:digit:]]([[:digit:]]|_)*))\>'
+
+# binary, octal, decimal, hexadecimal integer
+number = '\<(0[bB][0-1]([0-1]|_)*)\>'
+number = '\<(0[oO][0-7]([0-7]|_)*)\>'
+number = '\<(0[xX][[:xdigit:]]([[:xdigit:]]|_)*)\>'
+number = '\<([[:digit:]]([[:digit:]]|_)*)\>'
 
 string delim "\"" "\"" escape "\\"
 

--- a/highlight/source-highlight/chpl.lang
+++ b/highlight/source-highlight/chpl.lang
@@ -4,10 +4,22 @@
 preproc = "use"
 
 # \< \> means all one token.
-number =
-'\<[+-]?((0x[[:xdigit:]]+)|(([[:digit:]]*\.)?
-[[:digit:]]+([eE][+-]?[[:digit:]]+)?))\>'
 
+# binary, octal, decimal, hexadecimal integer
+number = '\<(0[bB][0-1]([0-1]|_)*)\>'
+number = '\<(0[oO][0-7]([0-7]|_)*)\>'
+number = '\<([[:digit:]]([[:digit:]]|_)*)\>'
+number = '\<(0[xX][[:xdigit:]]([[:xdigit:]]|_)*)\>'
+
+# decimal floating point number
+number = '\<(([[:digit:]]([[:digit:]]|_)*)?\.[[:digit:]]([[:digit:]]|_)*([Ee][+-]?[[:digit:]]([[:digit:]]|_)*)?)\>'
+number = '\<(([[:digit:]]([[:digit:]]|_)*)\.([Ee][+-]?[[:digit:]]([[:digit:]]|_)*))\>'
+number = '\<(([[:digit:]]([[:digit:]]|_)*)([Ee][+-]?[[:digit:]]([[:digit:]]|_)*))\>'
+
+# hexadecimal floating point number
+number = '\<(([[:xdigit:]]([[:xdigit:]]|_)*)?\.[[:xdigit:]]([[:xdigit:]]|_)*([Pp][+-]?[[:digit:]]([[:digit:]]|_)*)?)\>'
+number = '\<(([[:xdigit:]]([[:xdigit:]]|_)*)\.([Pp][+-]?[[:digit:]]([[:digit:]]|_)*))\>'
+number = '\<(([[:xdigit:]]([[:xdigit:]]|_)*)([Pp][+-]?[[:digit:]]([[:digit:]]|_)*))\>'
 
 string delim "\"" "\"" escape "\\"
 


### PR DESCRIPTION
* Add binary and octal integers.
* Add hexadecimal floating point numbers
* Allow underscores in numbers

- After messing with it for too long, I haven't gotten floating point with
  an exponent but no digits after the decimal working right. e.g. 12.e-1 or
  0x1F.p2. The highlight stops at the decimal point for them even though
  I have rules that I'm pretty sure match the full number.