### PR TITLE
Add reminder about gen compiler versions in compiler_versions.bash

### DIFF
--- a/util/build_configs/cray-internal/setenv-xc-aarch64.bash
+++ b/util/build_configs/cray-internal/setenv-xc-aarch64.bash
@@ -264,8 +264,10 @@ else
         list_loaded_modules
     fi
 
+    # Please keep the gen versions in compiler_versions.bash the same as these!
     gen_version_gcc=7.3.0
     gen_version_cce=8.7.3
+
     target_cpu_module=craype-arm-thunderx2
 
     function load_prgenv_gnu() {

--- a/util/build_configs/cray-internal/setenv-xc-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-xc-x86_64.bash
@@ -315,9 +315,11 @@ else
         list_loaded_modules
     fi
 
+    # Please keep the gen versions in compiler_versions.bash the same as these!
     gen_version_gcc=6.1.0
     gen_version_intel=16.0.3.210
     gen_version_cce=8.6.3
+
     target_cpu_module=craype-sandybridge
 
     function load_prgenv_gnu() {

--- a/util/build_configs/cray-internal/setenv-xe-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-xe-x86_64.bash
@@ -261,9 +261,11 @@ else
         list_loaded_modules
     fi
 
+    # Please keep the gen versions in compiler_versions.bash the same as these!
     gen_version_gcc=6.1.0
     gen_version_intel=16.0.3.210
     gen_version_cce=8.6.3
+
     target_cpu_module=craype-barcelona
 
     function load_prgenv_gnu() {


### PR DESCRIPTION
This change adds a comment to a shell script.
"compiler_versions.bash" is maintained in "chapel-code", a Cray-internal Git repo.