### PR TITLE
Make initial variable configuration constant to prevent folding

### DIFF
--- a/test/expressions/hilde/constOverflow.chpl
+++ b/test/expressions/hilde/constOverflow.chpl
@@ -8,8 +8,9 @@
 // behavior is OK, but Chapel should try to protect users from such
 // platform-dependencies.
 
+config const maxS = max(int(32));
+
 proc main() {
-  const maxS = max(int(32));
   const maxS1 = maxS + 1;
   const m = 10;
 


### PR DESCRIPTION
Follow-on to PR #11591 and #11570. Updates a future test.
Puts the initial value in a `config const` so enterprising
C compilers don't fold all the expressions at compile-time.

Trivial and not reviewed.