### PR TITLE
Improve timing and stability of the create-views performance test

### DIFF
--- a/test/performance/bharshbarg/create-views.chpl
+++ b/test/performance/bharshbarg/create-views.chpl
@@ -50,7 +50,7 @@ proc test(m : mode, X : []) {
 
   t.start();
   while true {
-    if t.elapsed() > limit then break;
+    if c % 10000 == 0 && t.elapsed() > limit then break;
     if      m == mode.Slice      then makeSlice(X);
     else if m == mode.RankChange then makeRankChange(X);
     else if m == mode.Reindex    then makeReindex(X);


### PR DESCRIPTION
This test creates array-views in a loop in order to see how fast we can
slice, rank-change, and reindex. It tries to run each operation for 2
seconds and then reports a rate of creation. Previously, it was checking
the elapsed time every iteration of the loop, but checking the current
time is relatively expensive, so this test was mostly measuring how fast
timers are.

This updates the test to only check the timer every 10,000 iterations,
which will "improve" performance and stabilize timings. For 1D slicing,
we should expect to see 11.2M ops/s compared to 3.4M ops/s currently.

I'll note that we saw a weird regression for this test when we upgraded
to sles 12 and we had another regression that was only resolved by a
reboot. I believe both of these are side-effects of the test mostly
measuring timers and we shouldn't see that in the future.