### PR TITLE
Change some aspects of _toLeader

### DIFF
--- a/compiler/resolution/lowerIterators.cpp
+++ b/compiler/resolution/lowerIterators.cpp
@@ -2224,7 +2224,7 @@ static void cleanupLeaderFollowerIteratorCalls()
              !strcmp(toDefExpr(fn->formals.tail)->sym->name, "_retArg") &&
              toDefExpr(fn->formals.tail)->sym->getValType() &&
              toDefExpr(fn->formals.tail)->sym->getValType()->symbol->hasFlag(FLAG_ITERATOR_RECORD))) {
-          if (
+          if (// "_toLeader" case is handled in cleanupLeaderIteratorCalls()
               !strcmp(call->parentSymbol->name, "_toFollower") ||
               !strcmp(call->parentSymbol->name, "_toFastFollower") ||
               !strcmp(call->parentSymbol->name, "_toStandalone")) {

--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -831,7 +831,8 @@ static Expr* preFoldPrimOp(CallExpr* call) {
     retval = followerCall;
 
   } else if (call->isPrimitive(PRIM_TO_LEADER)) {
-    FnSymbol* iterator   = getTheIteratorFn(call);
+    FnSymbol* iterator =
+      getTheIteratorFnFromIteratorRec(call->get(1)->typeInfo());
     CallExpr* leaderCall = new CallExpr(iterator->name);
 
     for_formals(formal, iterator) {

--- a/modules/internal/ChapelIteratorSupport.chpl
+++ b/modules/internal/ChapelIteratorSupport.chpl
@@ -362,17 +362,10 @@ module ChapelIteratorSupport {
       _freeIterator(x(i));
   }
 
+  pragma "fn returns iterator"
   pragma "no implicit copy"
-  pragma "fn returns iterator"
-  inline proc _toLeader(iterator: _iteratorClass)
-    return chpl__autoCopy(__primitive("to leader", iterator));
-
-  pragma "fn returns iterator"
   inline proc _toLeader(ir: _iteratorRecord) {
-    pragma "no copy" var ic = _getIterator(ir);
-    pragma "no copy" var leader = _toLeader(ic);
-    _freeIterator(ic);
-    return leader;
+    return chpl__autoCopy(__primitive("to leader", ir));
   }
 
   pragma "suppress lvalue error"
@@ -418,16 +411,8 @@ module ChapelIteratorSupport {
   pragma "no implicit copy"
   pragma "expand tuples with values"
   pragma "fn returns iterator"
-  inline proc _toLeader(iterator: _iteratorClass, args...)
-    return chpl__autoCopy(__primitive("to leader", iterator, (...args)));
-
-  pragma "expand tuples with values"
-  pragma "fn returns iterator"
   inline proc _toLeader(ir: _iteratorRecord, args...) {
-    pragma "no copy" var ic = _getIterator(ir);
-    pragma "no copy" var leader = _toLeader(ic, (...args));
-    _freeIterator(ic);
-    return leader;
+    return chpl__autoCopy(__primitive("to leader", ir, (...args)));
   }
 
   pragma "suppress lvalue error"


### PR DESCRIPTION
This PR is in support of my WIP on reduce expressions and ForallStmt.

### Changes

* Move _toLeader-related processing from cleanupLeaderFollowerIteratorCalls(),
which happens towards the end of lowerIterators(), into the newly-created
cleanupLeaderIteratorCalls() close to the start of lowerIterators().
That way, lowerForallStmtsInline() is free to inline _toLeader calls,
which I need in my WIP. (This PR does not introduce such inlining.)
Without this change, the processing in cleanupLeaderFollowerIteratorCalls()
would no longer fire if such inlining happened.

* Remove `proc _toLeader(iterator: _iteratorClass)` .
It was invoked from `_toLeader(_iteratorRecord)`.
Have the latter do the work of the former directly, instead.
This is to simplify things slightly. It required the change in preFold.cpp.

### Some details

The transformation in `cleanupLeaderIteratorCalls()` differs from that in `cleanupLeaderFollowerIteratorCalls()`.

Namely, `cleanupLeaderIteratorCalls` - which runs towards the beginning of `lowerIterators()` - converts a reference to the iterator formal to
```
CallExpr(PRIM_ITERATOR_RECORD_FIELD_VALUE_BY_FORMAL, iterator record, iterator formal)
```
This happens when iterator record and class Types do not have fields added to them yet.

Here, "iterator formal" is the formal of the serial iterator's FnSymbol. A reference to it is inserted by preFold on PRIM_TO_LEADER. This is the troublesome out-of-scope reference. It still remains in the AST after `cleanupLeaderIteratorCalls()`. It is removed later in lowerIterators() when the fields are created, in `addLocalsToClassAndRecord()` invoked during lowerIterator(fn).

Cf. `cleanupLeaderFollowerIteratorCalls` - towards the end of `lowerIterators()` - converts such a reference to accessing the corresponding field of the iterator class (or the iterator record?). Because these fields HAVE been created by then. This conversion eliminates this out-of-scope reference.

### An observant reader might ask...

* Q: How about doing the work that's now in cleanupLeaderIteratorCalls()
directly in preFold.cpp / the PRIM_TO_LEADER case?

  - A: That should be possible. The downside would be the introduction of
extra temps (see `ftemp`) at resolution, rather than later during
lowerIterators(). Also, this would not address the main issue with
the current _toLeader, which is referencing formals outside their
function. (See the comment there in preFold.cpp.)

* Q: How about making the same change for _toFollower and _toStandalone?

  - A: That should also be possible. I have not seen the need for that
yet in my WIP. It is likely that I will need it for _toStandalone
and not for _toFollower. Ideally we will elimnate the _to* machinery
altogether.

Testing: linux64 -futures -verify; gasnet; valgrind; memleaks.