### PR TITLE
Suppress this test for Intel compilers

### DIFF
--- a/test/classes/deitz/unions/union_method2.suppressif
+++ b/test/classes/deitz/unions/union_method2.suppressif
@@ -1,0 +1,2 @@
+CHPL_TARGET_COMPILER==cray-prgenv-intel
+CHPL_TARGET_COMPILER==intel


### PR DESCRIPTION
The test started failing after PR #11570.

This PR just adds a .suppressif to suppress the error for Intel compilers because:

* we're only seeing this error with Intel C compilers
* the error goes away if I wrap the program in a `main`
* the error goes away if I remove the x.printf method call
* the error goes away with --no-inline
* the error goes away with --ccflags -O0
* the error goes away with --ccflags -g