### PR TITLE
Module load PrgEnv-gnu if no module loaded for --llvm

### DIFF
--- a/util/config/gather-cray-prgenv-arguments.bash
+++ b/util/config/gather-cray-prgenv-arguments.bash
@@ -28,7 +28,7 @@ if [[ $FAIL == 1 || -z $2 || -z $3 || -z $4 ]]; then
 fi
 
 # Try loading PrgEnv-gnu if no module is loaded
-module list 2>&1 | grep -q PrgEnv
+module list --terse 2>&1 | grep -q PrgEnv
 if [ $? != 0 ]
 then
   module load PrgEnv-gnu

--- a/util/config/gather-cray-prgenv-arguments.bash
+++ b/util/config/gather-cray-prgenv-arguments.bash
@@ -27,7 +27,14 @@ if [[ $FAIL == 1 || -z $2 || -z $3 || -z $4 ]]; then
     exit 1
 fi
 
-# Set up the environment to amke the proper libraries and include
+# Try loading PrgEnv-gnu if no module is loaded
+module list 2>&1 | grep -q PrgEnv
+if [ $? != 0 ]
+then
+  module load PrgEnv-gnu
+fi
+
+# Set up the environment to make the proper libraries and include
 # files available.
 export PE_PKGCONFIG_PRODUCTS="PE_CHAPEL:$PE_PKGCONFIG_PRODUCTS"
 export PE_CHAPEL_MODULE_NAME="chapel"


### PR DESCRIPTION
Resolves #11166.

includes fix for using chpl --llvm without a PrgEnv loaded on a Cray.
This fix is a stop-gap and not ideal because the query takes 2s.

- [x] verified that --llvm can compile a program without PrgEnv loaded

Reviewed by @ronawho - thanks!