### PR TITLE
Invoke 'init' directly for init-var instead of chpl__initCopy

### DIFF
--- a/compiler/resolution/ResolutionCandidate.cpp
+++ b/compiler/resolution/ResolutionCandidate.cpp
@@ -308,10 +308,7 @@ bool ResolutionCandidate::verifyGenericFormal(ArgSymbol* formal) const {
     if (fn->hasFlag(FLAG_TYPE_CONSTRUCTOR)) {
       retval = false;
 
-    } else if (fn->isMethod()                       == true  &&
-               strcmp(fn->name, "init")             == 0     &&
-               fn->hasFlag(FLAG_COMPILER_GENERATED) == true  &&
-               fn->hasFlag(FLAG_DEFAULT_COPY_INIT)  == false &&
+    } else if (fn->isDefaultInit() &&
                (formal->hasFlag(FLAG_ARG_THIS)                == false ||
                 formal->hasFlag(FLAG_DELAY_GENERIC_EXPANSION) == false)) {
       // This is a compiler generated initializer, so the argument with

--- a/modules/dists/HashedDist.chpl
+++ b/modules/dists/HashedDist.chpl
@@ -520,13 +520,14 @@ class UserMapAssocDom: BaseAssociativeDom {
 
   proc dsiSupportsPrivatization() param return true;
   proc dsiGetPrivatizeData() return 0;
+  proc dsiGetReprivatizeData() return 0;
   proc dsiPrivatize(privatizeData) {
     var privateDist = new unmanaged Hashed(idxType, dist.mapper, dist);
     var c = new unmanaged UserMapAssocDom(idxType=idxType, mapperType=mapperType, dist=privateDist);
     c.locDoms = locDoms;
     return c;
   }
-  proc dsiReprivatize(other) {
+  proc dsiReprivatize(other, privatizeData) {
     locDoms = other.locDoms;
   }
 

--- a/test/classes/initializers/records/array-from-for-expr.bad
+++ b/test/classes/initializers/records/array-from-for-expr.bad
@@ -1,4 +1,4 @@
-array-from-for-expr.chpl:15: error: non-lvalue actual is passed to a 'ref' formal of chpl__initCopy()
+array-from-for-expr.chpl:15: error: non-lvalue actual is passed to a 'ref' formal of init()
 $CHPL_HOME/modules/internal/ChapelArray.chpl:4216: In function 'chpl__initCopy':
 $CHPL_HOME/modules/internal/ChapelArray.chpl:4248: error: non-lvalue actual is passed to a 'ref' formal of chpl__initCopy()
 array-from-for-expr.chpl:35: In function 'main':

--- a/test/distributions/ferguson/dist-assoc-assign.bad
+++ b/test/distributions/ferguson/dist-assoc-assign.bad
@@ -1,3 +1,1 @@
-dist-assoc-assign.chpl:9: error: unresolved call 'unmanaged UserMapAssocDom(true,real(64),DefaultMapper).dsiGetReprivatizeData()'
-$CHPL_HOME/modules/internal/ArrayViewRankChange.chpl:400: note: candidates are: ArrayViewRankChangeDom.dsiGetReprivatizeData()
-$CHPL_HOME/modules/internal/ArrayViewReindex.chpl:306: note:                 ArrayViewReindexDom.dsiGetReprivatizeData()
+dist-assoc-assign.chpl:9: error: halt reached - Hashed domain assignment not yet supported


### PR DESCRIPTION
This PR updates 'resolveInitVar' to more reliably invoke 'init' for var-decl initialization rather than 'chpl__initCopy'. Some other improvements were made to make the various cases clearer. Minor fixes involving PRIM_SET_MEMBER and point-of-instantiations were required to support the direct 'init' calls.

Testing:
- [x] local + futures
- [x] gasnet + futures
- [x] memleaks
- [x] valgrind