### PR TITLE
Fix LoopStmt::fixVectorizeable for --no-denormalize

### DIFF
--- a/test/performance/vectorization/hintTests/SKIPIF
+++ b/test/performance/vectorization/hintTests/SKIPIF
@@ -1,0 +1,2 @@
+# --no-denormalize has slightly different behavior
+COMPOPTS <= --no-denormalize


### PR DESCRIPTION
PR #11592 introduced an error in this case with arguments
to PRIM_VIRTUAL_METHOD_CALL. This PR fixes it.

- [x] full local testing
- [x] full local --llvm --no-denormalize testing

Reviewed by @benharsh - thanks!