### PR TITLE
Optimize block distribution's fast-follower iterator

### DIFF
--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -1088,12 +1088,18 @@ iter BlockArr.these(param tag: iterKind, followThis, param fast: bool = false) r
       arrSection = myLocArr;
 
     //
+    // Forcibly narrow the array section. We know it's narrow because we're in
+    // a fast follower, but the compiler can't determine this currently.
+    //
+    const narrowArrSection = __primitive("_wide_get_addr", arrSection):arrSection.type;
+
+    //
     // Slicing arrSection.myElems will require reference counts to be updated.
     // If myElems is an array of arrays, the inner array's domain or dist may
     // live on a different locale and require communication for reference
     // counting. Simply put: don't slice inside a local block.
     //
-    ref chunk = arrSection.myElems(myFollowThisDom);
+    ref chunk = narrowArrSection.myElems(myFollowThisDom);
     local {
       for i in chunk do yield i;
     }


### PR DESCRIPTION
Prevent the compiler from widening the elements being yielded from the fast
follower. We know they're local, but the compiler can't currently prove that
today so force them to be narrow by using the `_wide_get_addr` primitive.

This improves the generated code for stream-global. For the main kernel
(a = b + alpha * c) we used to generate:

```c
local_coerce_tmp = (&coerce_tmp47)->addr;
local_call_tmp = (local_coerce_tmp + _ic__F13_i3);
chpl_macro_tmp_2587.locale = chpl_gen_getLocaleID();
chpl_macro_tmp_2587.addr = local_call_tmp;
call_tmp180 = chpl_macro_tmp_2587;
local_coerce_tmp2 = (&coerce_tmp49)->addr;
local_call_tmp2 = (local_coerce_tmp2 + _ic__F13_i2);
chpl_macro_tmp_2588.locale = chpl_gen_getLocaleID();
chpl_macro_tmp_2588.addr = local_call_tmp2;
call_tmp181 = chpl_macro_tmp_2588;
local_coerce_tmp3 = (&coerce_tmp51)->addr;
local_call_tmp3 = (local_coerce_tmp3 + _ic__F13_i);
chpl_macro_tmp_2589.locale = chpl_gen_getLocaleID();
chpl_macro_tmp_2589.addr = local_call_tmp3;
call_tmp182 = chpl_macro_tmp_2589;
chpl_gen_comm_get(((void*)(&chpl_macro_tmp_2590)), chpl_nodeFromLocaleID(&((call_tmp180).locale), ...);
chpl_gen_comm_get(((void*)(&chpl_macro_tmp_2591)), chpl_nodeFromLocaleID(&((call_tmp181).locale), ...);
chpl_macro_tmp_2592 = ((_real64)((chpl_macro_tmp_2591 + ((_real64)((alpha2 * chpl_macro_tmp_2590))))));
chpl_gen_comm_put(((void*)(&chpl_macro_tmp_2592)), chpl_nodeFromLocaleID(&((call_tmp182).locale), ...);
```

and we now generate:

```c
call_tmp196 = (coerce_tmp42 + _ic__F13_i3);
call_tmp197 = (coerce_tmp44 + _ic__F13_i2);
call_tmp198 = (coerce_tmp46 + _ic__F13_i);
*(call_tmp198) = ((_real64)((*(call_tmp197) + ((_real64)((alpha2 * *(call_tmp196)))))));
```

This improves stream-global performance slightly (~2% at 256 nodes). At 256
nodes this takes us from 23,720 GB/s to 24,180 GB/s

![stream-perf](https://user-images.githubusercontent.com/1588337/48516974-c616a780-e819-11e8-9996-4a182fe7b8cb.png)