### PR TITLE
Fix getTheIteratorFn() on tuples

### DIFF
--- a/compiler/AST/foralls.cpp
+++ b/compiler/AST/foralls.cpp
@@ -630,7 +630,7 @@ static CallExpr* buildForallParIterCall(ForallStmt* pfs, SymExpr* origSE)
     // Our iterable expression is an iterator call.
 
     if (ArgSymbol* origArg = toArgSymbol(origSE->symbol())) {
-      FnSymbol* iterator = getTheIteratorFnFromIteratorRec(origArg->type);
+      FnSymbol* iterator = getTheIteratorFn(origArg->type);
       USR_FATAL_CONT(origSE, "a forall loop over a formal argument corresponding to a for/forall/promoted expression or an iterator call is not implemented");
       USR_PRINT(iterator, "the actual argument is here");
       USR_STOP();
@@ -1175,7 +1175,7 @@ static void convertIteratorForLoopexpr(ForallStmt* fs) {
         if (isLoopExprFun(calleeFn)) {
           // In this case, we have a _toLeader call and no side effects.
           // Just use the iterator corresponding to the iterator record.
-          FnSymbol* iterator = getTheIteratorFnFromIteratorRec(calleeFn->retType);
+          FnSymbol* iterator = getTheIteratorFn(calleeFn->retType);
           SET_LINENO(calleeSE);
           calleeSE->replace(new SymExpr(iterator));
           if (calleeFn->firstSymExpr() == NULL)

--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -133,7 +133,6 @@ FnSymbol* findCopyInit(AggregateType* ct);
 FnSymbol* getTheIteratorFn(Symbol* ic);
 FnSymbol* getTheIteratorFn(CallExpr* call);
 FnSymbol* getTheIteratorFn(Type* icType);
-FnSymbol* getTheIteratorFnFromIteratorRec(Type* irType);
 
 // forall intents
 CallExpr* resolveForallHeader(ForallStmt* pfs, SymExpr* origSE);

--- a/compiler/resolution/callDestructors.cpp
+++ b/compiler/resolution/callDestructors.cpp
@@ -199,8 +199,7 @@ static inline bool isParIterOrForwarder(FnSymbol* fn) {
 
   if (fn->retType->symbol->hasFlag(FLAG_ITERATOR_RECORD))
     // This is a forwarder. Query the iterator itself.
-    return getTheIteratorFnFromIteratorRec(fn->retType)
-             ->hasFlag(FLAG_INLINE_ITERATOR);
+    return getTheIteratorFn(fn->retType)->hasFlag(FLAG_INLINE_ITERATOR);
 
   // Otherwise, no.
   return false;

--- a/compiler/resolution/lifetime.cpp
+++ b/compiler/resolution/lifetime.cpp
@@ -1317,7 +1317,7 @@ bool InferLifetimesVisitor::enterForLoop(ForLoop* forLoop) {
     if (iterable != NULL)
       if (AggregateType* at = toAggregateType(iterable->getValType()))
         if (at->iteratorInfo != NULL)
-          if (FnSymbol* fn = getTheIteratorFnFromIteratorRec(at))
+          if (FnSymbol* fn = getTheIteratorFn(at))
             method = (fn->_this != NULL);
 
     bool usedAsRef = index->isRef();

--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -831,8 +831,7 @@ static Expr* preFoldPrimOp(CallExpr* call) {
     retval = followerCall;
 
   } else if (call->isPrimitive(PRIM_TO_LEADER)) {
-    FnSymbol* iterator =
-      getTheIteratorFnFromIteratorRec(call->get(1)->typeInfo());
+    FnSymbol* iterator   = getTheIteratorFn(call->get(1)->typeInfo());
     CallExpr* leaderCall = new CallExpr(iterator->name);
 
     for_formals(formal, iterator) {


### PR DESCRIPTION
**(1)** When getTheIteratorFn() is invoked on a tuple of iterator classes,
return the iterator function corresponding to the first of them.
Previously it was returning the first IC's getIterator function,
which is not useful.

This required an adjustment in expandForLoop() (towards the lowerIterators.cpp)
to preserve the behavior of skipping expandIteratorInline() in the tuple case.

We see only one level of tuple-ness when combining multiple iterator classes,
as tested over our entire test suite. This is probably because a loop can have
only one level of syntactic zipper-ness in its iterable expression. If we
encounter multiple levels, getTheIteratorFn(Type*) can be made recursive.

**(2)** Remove getTheIteratorFnFromIteratorRec(). Instead, have getTheIteratorFn()
handle the iterator record case as well. An iterator record and an iterator class
point to the same IteratorInfo, so it is natural to handle them both along
the same code path.

Trivial, not reviewed.
