### PR TITLE
Fix typos

### DIFF
--- a/compiler/codegen/LoopStmt.cpp
+++ b/compiler/codegen/LoopStmt.cpp
@@ -49,7 +49,7 @@ void LoopStmt::fixVectorizeable()
   // that don't need to be cloned should be in registers anyway.
 
   // This runs late in the compiler because we want to do this check
-  // after inlining and other late simplifications have occured.
+  // after inlining and other late simplifications have occurred.
 
   bool hazard = false;
 

--- a/doc/rst/technotes/libraries.rst
+++ b/doc/rst/technotes/libraries.rst
@@ -35,7 +35,7 @@ specified takes precedence.
    recommended.  To do this, set the environment variable ``CHPL_LIB_PIC`` to
    ``pic`` and ensure this configuration is built by performing a ``make``
    command from ``$CHPL_HOME``.  Note that position independent code will likely
-   encounter some performance degradataion as opposed to normal Chapel code.
+   encounter some performance degradation as opposed to normal Chapel code.
    For this reason, we recommend only using ``CHPL_LIB_PIC`` when position
    independent code is required.
 

--- a/modules/dists/HashedDist.chpl
+++ b/modules/dists/HashedDist.chpl
@@ -361,7 +361,7 @@ class UserMapAssocDom: BaseAssociativeDom {
     //    it would also be possible to iterate through
     //    locDom.sorted() and pipe it through a channel or something.
     //     (such a use of a channel would probably benefit from
-    //      "shallow write/read" or "nonpersistant write/read"
+    //      "shallow write/read" or "nonpersistent write/read"
     //      meaning that the channel would just store the same information
     //      as a GET).
     //  * include in mapper something to indicate if indexToLocaleIndex


### PR DESCRIPTION
Fix typos in libraries.rst, HashedDist, and LoopStmt.cpp