### PR TITLE
Fix valgrind error in Fortran interop test

### DIFF
--- a/test/interop/fortran/FortranCallChapel/chapelProcs.chpl
+++ b/test/interop/fortran/FortranCallChapel/chapelProcs.chpl
@@ -4,7 +4,7 @@ var chplReal: real;
 export proc chpl_library_init_ftn() {
   extern proc chpl_library_init(argc: c_int, argv: c_ptr(c_ptr(c_char)));
   var filename = c"fake";
-  chpl_library_init(0, c_ptrTo(filename): c_ptr(c_ptr(c_char)));;
+  chpl_library_init(1, c_ptrTo(filename): c_ptr(c_ptr(c_char)));;
   chpl__init_chapelProcs();
 }
 

--- a/test/interop/fortran/genFortranInterface/chapelProcs.chpl
+++ b/test/interop/fortran/genFortranInterface/chapelProcs.chpl
@@ -4,7 +4,7 @@ var chplReal: real;
 export proc chpl_library_init_ftn() {
   extern proc chpl_library_init(argc: c_int, argv: c_ptr(c_ptr(c_char)));
   var filename = c"fake";
-  chpl_library_init(0, c_ptrTo(filename): c_ptr(c_ptr(c_char)));;
+  chpl_library_init(1, c_ptrTo(filename): c_ptr(c_ptr(c_char)));;
   chpl__init_chapelProcs();
 }
 


### PR DESCRIPTION
A library initialization call was using 0 for argc, so it allocated 0
spaces, then assigned to one. Pass 1 instead.