### PR TITLE
Make some usability improvements to slurm-gasnetrun_ibv launcher

### DIFF
--- a/doc/rst/platforms/cray.rst
+++ b/doc/rst/platforms/cray.rst
@@ -225,15 +225,6 @@ Using Chapel on a Cray System
         Alternatively, you can set the wall clock time limit on your
         Chapel program command line using the ``--walltime`` flag.
 
-   If ``CHPL_LAUNCHER`` is ``slurm-gasnetrun_ibv``:
-
-     You must set the amount of time to request from SLURM.
-     For example, the following requests 15 minutes:
-
-      .. code-block:: sh
-
-        export CHPL_LAUNCHER_WALLTIME=00:15:00
-
    For further information about launchers, please refer to
    :ref:`readme-launcher`.
 

--- a/doc/rst/platforms/infiniband.rst
+++ b/doc/rst/platforms/infiniband.rst
@@ -31,13 +31,9 @@ and to try removing it once everything else is working.
 Using Slurm for Job Launch
 ++++++++++++++++++++++++++
 
-For clusters using Slurm, there are three options:
+For clusters using Slurm, there are a few options:
 
-a. In the future, we expect that ``CHPL_LAUNCHER=slurm-srun`` will be the best
-   option. However, this configuration is not yet sufficiently tested
-   with InfiniBand.
-
-#. The current best option for InfiniBand+Slurm is
+a. The current best option for InfiniBand+Slurm is
    ``CHPL_LAUNCHER=slurm-gasnetrun_ibv``:
 
    .. code-block:: bash
@@ -61,11 +57,8 @@ a. In the future, we expect that ``CHPL_LAUNCHER=slurm-srun`` will be the best
 
    .. code-block:: bash
 
-      # Specify a 15-minute maximum run time
-      export CHPL_LAUNCHER_WALLTIME=00:15:00
       # Specify the Slurm partition to use
-      export SALLOC_PARTITION=debug
-      export SLURM_PARTITION=$SALLOC_PARTITION
+      export CHPL_LAUNCHER_PARTITION=debug
 
       # Run the sample program
       ./hello6-taskpar-dist -nl 2

--- a/doc/rst/usingchapel/launcher.rst
+++ b/doc/rst/usingchapel/launcher.rst
@@ -118,9 +118,11 @@ To use native Slurm, set:
 
   export CHPL_LAUNCHER=slurm-srun
 
-On Cray systems, this will happen automatically if srun is found in your path,
-but not when both srun and aprun are found in your path. Native Slurm is the
-best option where it works, but at the time of this writing, there are problems with it when combined with UDP or InfiniBand conduits. So, for these configurations please see:
+On Cray systems, this will happen automatically if srun is found in your
+path, but not when both srun and aprun are found in your path. Native
+Slurm is the best option where it works, but at the time of this writing,
+there are problems with it when combined with UDP or InfiniBand conduits.
+So, for these configurations please see:
 
   * :ref:`readme-infiniband` for information about using Slurm with
     InfiniBand.
@@ -132,20 +134,13 @@ best option where it works, but at the time of this writing, there are problems 
 Common Slurm Settings
 *********************
 
-Before running, you will need to set the amount of time to request
-from SLURM. For example, the following requests 15 minutes:
+If needed, you can request a specific partition from slurm by putting it
+in the ``CHPL_LAUNCHER_PARTITION`` environment variable. For example, to
+use the 'debug' partition, set:
 
 .. code-block:: bash
 
-  export CHPL_LAUNCHER_WALLTIME=00:15:00
-
-Another Slurm variable that usually needs to be set is the Slurm partition to
-use. For example, set the Slurm partition to 'debug' with the commands:
-
-.. code-block:: bash
-
-  export SALLOC_PARTITION=debug
-  export SLURM_PARTITION=$SALLOC_PARTITION
+  export CHPL_LAUNCHER_PARTITION=debug
 
 If needed, you can request a specific node feature from SLURM by putting
 it in the ``CHPL_LAUNCHER_CONSTRAINT`` environment variable. For example,

--- a/runtime/src/launch/slurm-gasnetrun_ibv/launch-slurm-gasnetrun_ibv.c
+++ b/runtime/src/launch/slurm-gasnetrun_ibv/launch-slurm-gasnetrun_ibv.c
@@ -36,7 +36,6 @@
 
 #define baseSBATCHFilename ".chpl-slurm-sbatch-"
 #define baseExpectFilename ".chpl-expect-"
-#define baseSysFilename ".chpl-sys-"
 
 #define CHPL_WALLTIME_FLAG "--walltime"
 #define CHPL_PARTITION_FLAG "--partition"
@@ -48,7 +47,6 @@ static char* partition = NULL;
 static char* exclude = NULL;
 char slurmFilename[FILENAME_MAX];
 char expectFilename[FILENAME_MAX];
-char sysFilename[FILENAME_MAX];
 
 /* copies of binary to run per node */
 #define procsPerNode 1  
@@ -228,7 +226,6 @@ static char* chpl_launch_create_command(int argc, char* argv[],
   } else {
     mypid = getpid();
   }
-  sprintf(sysFilename, "%s%d", baseSysFilename, (int)mypid);
   sprintf(expectFilename, "%s%d", baseExpectFilename, (int)mypid);
   sprintf(slurmFilename, "%s%d", baseSBATCHFilename, (int)mypid);
 
@@ -268,12 +265,13 @@ static char* chpl_launch_create_command(int argc, char* argv[],
   fprintf(expectFile, "set prompt \"(%%|#|\\\\$|>) $\"\n");
 
 //  fprintf(expectFile, "spawn sbatch ");
-  fprintf(expectFile, "spawn -noecho salloc ");
+  fprintf(expectFile, "spawn -noecho salloc --quiet ");
   fprintf(expectFile, "-J %.10s ",basenamePtr); // pass 
   fprintf(expectFile, "-N %d ",numLocales); 
   fprintf(expectFile, "--ntasks-per-node=1 ");
   fprintf(expectFile, "--exclusive "); //  give exclusive access to the nodes
-  fprintf(expectFile, "--time=%s ",walltime); 
+  if (walltime)
+    fprintf(expectFile, "--time=%s ",walltime);
   if(partition)
     fprintf(expectFile, "--partition=%s ",partition);
   if(exclude)
@@ -327,8 +325,6 @@ static void chpl_launch_cleanup(void) {
       system(command);
     } else {
       sprintf(command, "rm %s", slurmFilename);
-      system(command);
-      sprintf(command, "rm %s", sysFilename);
       system(command);
     }
   }


### PR DESCRIPTION
- Don't require setting --walltime/CHPL_LAUNCHER_WALLTIME for interactive runs
- Throw --quiet for interactive runs to hide useless "salloc granted" messages
- Stop trying to remove never created sysFilename for batch submissions
  - quiet failed `rm` messages

This also updates docs to stop saying that CHPL_LAUNCHER_WALLTIME is
required for slurm, and recommends using CHPL_LAUNCHER_PARTITION instead
of the underlying slurm env vars. It also removes a "in the future note"
about slurm-srun being a good option for ibv -- we can update the docs
if/when that becomes true.