### PR TITLE
Use NamedExprs in _defaultOf

### DIFF
--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -1438,35 +1438,10 @@ static void build_record_hash_function(AggregateType *ct) {
 *                                                                             *
 ************************************** | *************************************/
 
-static void buildRecordDefaultOf(AggregateType* ct,
-                                 FnSymbol*      fn,
-                                 ArgSymbol*     arg);
-
-static void buildRecordQuery(FnSymbol*      fn,
-                             ArgSymbol*     arg,
-                             CallExpr*      call,
-                             Symbol*        formal,
-                             Flag           flag,
-                             PrimitiveTag   tag,
-                             bool           named);
-
-static void buildRecordQueryVarField(FnSymbol*  fn,
-                                     ArgSymbol* arg,
-                                     CallExpr*  call,
-                                     Symbol*    formal,
-                                     bool       named);
-
 static void buildDefaultOfFunction(AggregateType* ct) {
-  if        (isNonGenericClassWithInitializers(ct)  == true) {
-
-
-  } else if (isNonGenericRecordWithInitializers(ct) == true) {
-
-
-  } else if (function_exists("_defaultOf", ct)        == NULL  &&
-             ct->symbol->hasFlag(FLAG_ITERATOR_CLASS) == false &&
-             (ct->symbol->hasEitherFlag(FLAG_TUPLE, FLAG_ITERATOR_RECORD)) &&
-             ct->defaultValue                         != gNil) {
+  if (ct->symbol->hasEitherFlag(FLAG_TUPLE, FLAG_ITERATOR_RECORD) &&
+      ct->defaultValue != gNil &&
+      function_exists("_defaultOf", ct) == NULL) {
 
     FnSymbol*  fn  = new FnSymbol("_defaultOf");
     ArgSymbol* arg = new ArgSymbol(INTENT_BLANK, "t", ct);
@@ -1489,10 +1464,8 @@ static void buildDefaultOfFunction(AggregateType* ct) {
     } else if (ct->symbol->hasFlag(FLAG_ITERATOR_RECORD)) {
       fn->insertAtTail(new CallExpr(PRIM_RETURN, arg));
 
-    } else if (ct->hasUserDefinedInit == true ||
-               ct->wantsDefaultInitializer()) {
     } else {
-      buildRecordDefaultOf(ct, fn, arg);
+      INT_FATAL("Unhandled _defaultOf generation case");
     }
 
     ct->symbol->defPoint->insertBefore(def);
@@ -1501,95 +1474,6 @@ static void buildDefaultOfFunction(AggregateType* ct) {
 
     // Do not normalize until the definition has been inserted
     normalize(fn);
-  }
-}
-
-static void buildRecordDefaultOf(AggregateType* ct,
-                                 FnSymbol*      fn,
-                                 ArgSymbol*     arg) {
-  CallExpr* call = new CallExpr(ct->defaultInitializer->name);
-
-  // Insert all required arguments into this call
-  for_formals(formal, ct->defaultInitializer) {
-    if (formal->type == dtMethodToken) {
-      call->insertAtTail(gMethodToken);
-
-    } else if (formal->isParameter() == true) {
-      Flag         flag = FLAG_PARAM;
-      PrimitiveTag tag  = PRIM_QUERY_PARAM_FIELD;
-
-      buildRecordQuery(fn, arg, call, formal, flag, tag, true);
-
-    } else if (formal->hasFlag(FLAG_TYPE_VARIABLE) == true) {
-      Flag         flag = FLAG_TYPE_VARIABLE;
-      PrimitiveTag tag  = PRIM_QUERY_TYPE_FIELD;
-
-      buildRecordQuery(fn, arg, call, formal, flag, tag, true);
-
-    } else if (formal->defaultExpr == NULL) {
-      buildRecordQueryVarField(fn, arg, call, formal, true);
-    }
-  }
-
-  fn->insertAtTail(new CallExpr(PRIM_RETURN, call));
-}
-
-static void buildRecordQuery(FnSymbol*      fn,
-                             ArgSymbol*     arg,
-                             CallExpr*      call,
-                             Symbol*        formal,
-                             Flag           flag,
-                             PrimitiveTag   tag,
-                             bool           named) {
-  VarSymbol* tmp   = newTemp(formal->name);
-  VarSymbol* name  = new_CStringSymbol(formal->name);
-  CallExpr*  query = new CallExpr(tag, arg, name);
-
-  tmp->addFlag(flag);
-
-  fn->insertAtTail(new CallExpr(PRIM_MOVE, tmp, query));
-  fn->insertAtHead(new DefExpr(tmp));
-
-  if (named) {
-    call->insertAtTail(new NamedExpr(formal->name, new SymExpr(tmp)));
-  } else {
-    call->insertAtTail(new SymExpr(tmp));
-  }
-}
-
-static void buildRecordQueryVarField(FnSymbol*  fn,
-                                     ArgSymbol* arg,
-                                     CallExpr*  call,
-                                     Symbol*    formal,
-                                     bool       named) {
-  VarSymbol* tmp  = newTemp(formal->name);
-  CallExpr*  init = NULL;
-
-  fn->insertAtHead(new DefExpr(tmp));
-
-  VarSymbol* typeTmp   = newTemp("type_tmp");
-  VarSymbol* callTmp   = newTemp("call_tmp");
-  VarSymbol* name      = new_CStringSymbol(formal->name);
-
-  CallExpr*  getMember = new CallExpr(PRIM_GET_MEMBER_VALUE, arg, name);
-  CallExpr*  typeOf    = new CallExpr(PRIM_TYPEOF, callTmp);
-
-  typeTmp->addFlag(FLAG_TYPE_VARIABLE);
-
-  fn->insertAtHead(new DefExpr(callTmp));
-  fn->insertAtHead(new DefExpr(typeTmp));
-
-  fn->insertAtTail(new CallExpr(PRIM_MOVE, callTmp, getMember));
-  fn->insertAtTail(new CallExpr(PRIM_MOVE, typeTmp, typeOf));
-
-  init = new CallExpr(PRIM_INIT, typeTmp);
-
-  fn->insertAtTail(new CallExpr(PRIM_MOVE, tmp, init));
-
-  if (named) {
-    call->insertAtTail(new NamedExpr(formal->name, new SymExpr(tmp)));
-  } else {
-    call->insertAtTail(new SymExpr(tmp));
   }
 }
 

--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -1469,6 +1469,7 @@ static void buildDefaultOfFunction(AggregateType* ct) {
 
   } else if (function_exists("_defaultOf", ct)        == NULL  &&
              ct->symbol->hasFlag(FLAG_ITERATOR_CLASS) == false &&
+             (ct->symbol->hasEitherFlag(FLAG_TUPLE, FLAG_ITERATOR_RECORD) || isUnion(ct)) &&
              ct->defaultValue                         != gNil) {
 
     FnSymbol*  fn  = new FnSymbol("_defaultOf");

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -9462,9 +9462,7 @@ static Expr* resolvePrimInit(CallExpr* call, Type* type) {
         INT_FATAL("Unhandled case for default-init");
       }
 
-      if (at->wantsDefaultInitializer()) {
-        appendExpr = new NamedExpr(e->key->name, appendExpr);
-      }
+      appendExpr = new NamedExpr(e->key->name, appendExpr);
 
       initCall->insertAtTail(appendExpr);
     }

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -9409,7 +9409,8 @@ static Expr* resolvePrimInit(CallExpr* call, Type* type) {
              at->instantiatedFrom                         == NULL &&
              isNonGenericRecordWithInitializers(at)       == true) {
     // Parent PRIM_MOVE will be updated to init() later in resolution
-  } else if (at != NULL && at->isRecord() && at->symbol->hasFlag(FLAG_TUPLE) == false) {
+  } else if (at != NULL && at->symbol->hasFlag(FLAG_TUPLE) == false &&
+            (at->isRecord() || at->isUnion())) {
     AggregateType* root = at->getRootInstantiation();
     VarSymbol* default_temp = newTemp("default_init_temp", root);
     Expr* stmt = call->getStmtExpr();

--- a/modules/internal/OwnedObject.chpl
+++ b/modules/internal/OwnedObject.chpl
@@ -194,14 +194,14 @@ module OwnedObject {
     forwarding chpl_p;
 
     /*
-       Default-initialize a :record:`owned` to store type `t`
+       Default-initialize a :record:`owned` to store type `chpl_t`
      */
     pragma "leaves this nil"
-    proc init(type t) {
-      if !isClass(t) then
+    proc init(type chpl_t) {
+      if !isClass(chpl_t) then
         compilerError("owned only works with classes");
 
-      this.chpl_t = _to_borrowed(t);
+      this.chpl_t = _to_borrowed(chpl_t);
       this.chpl_p = nil;
     }
 

--- a/modules/internal/SharedObject.chpl
+++ b/modules/internal/SharedObject.chpl
@@ -153,11 +153,11 @@ module SharedObject {
        Default-initialize a :record:`shared`.
      */
     pragma "leaves this nil"
-    proc init(type t) {
-      if !isClass(t) then
+    proc init(type chpl_t) {
+      if !isClass(chpl_t) then
         compilerError("shared only works with classes");
 
-      this.chpl_t = _to_borrowed(t);
+      this.chpl_t = _to_borrowed(chpl_t);
       this.chpl_p = nil;
       this.chpl_pn = nil;
     }

--- a/test/classes/delete-free/owned/owned-record-instantiation-types-user-init-borrows-error.chpl
+++ b/test/classes/delete-free/owned/owned-record-instantiation-types-user-init-borrows-error.chpl
@@ -8,8 +8,8 @@ record GenericCollection {
     var default:t;
     field = default;
   }
-  proc init(arg) { // borrows but that might be surprising
-    field = arg;
+  proc init(field) { // borrows but that might be surprising
+    this.field = field;
   }
 }
 

--- a/test/classes/delete-free/owned/owned-record-instantiation-types-user-init.chpl
+++ b/test/classes/delete-free/owned/owned-record-instantiation-types-user-init.chpl
@@ -8,11 +8,11 @@ record GenericCollection {
     var default:t;
     field = default;
   }
-  proc init(arg:owned) {
-    field = arg;
+  proc init(field:owned) {
+    this.field = field;
   }
-  proc init(arg:borrowed) {
-    field = arg;
+  proc init(field:borrowed) {
+    this.field = field;
   }
 }
 

--- a/test/classes/ferguson/generic-field/generic-field-record-not-inited2.chpl
+++ b/test/classes/ferguson/generic-field/generic-field-record-not-inited2.chpl
@@ -5,10 +5,10 @@ record GenericRecord {
 record Wrapper {
   type t;
   var f:GenericRecord(t);
-  proc init(type recType) {
+  proc init(type t) {
     //var tmp:recType;
     //this.f = tmp;
-    t = recType;
+    this.t = t;
   }
 }
 

--- a/test/classes/initializers/compilerGenerated/generics/namedParam.chpl
+++ b/test/classes/initializers/compilerGenerated/generics/namedParam.chpl
@@ -3,9 +3,9 @@ record Dummy {
   type idxType;
   param stridable : bool;
 
-  proc init(type i, param s : bool) {
-    this.idxType = i;
-    this.stridable = s;
+  proc init(type idxType, param stridable : bool) {
+    this.idxType = idxType;
+    this.stridable = stridable;
   }
 }
 

--- a/test/classes/initializers/generics/namedParam.chpl
+++ b/test/classes/initializers/generics/namedParam.chpl
@@ -3,9 +3,9 @@ record Dummy {
   type idxType;
   param stridable : bool;
 
-  proc init(type i, param s : bool) {
-    this.idxType = i;
-    this.stridable = s;
+  proc init(type idxType, param stridable : bool) {
+    this.idxType = idxType;
+    this.stridable = stridable;
   }
 }
 

--- a/test/classes/initializers/records/generics/explicitAssignment.chpl
+++ b/test/classes/initializers/records/generics/explicitAssignment.chpl
@@ -3,12 +3,12 @@
 record Foo {
   var x;
 
-  proc init(xVal: int) {
-    x = xVal;
+  proc init(x: int) {
+    this.x = x;
   }
 
-  proc init(xVal: real) {
-    x = xVal;
+  proc init(x: real) {
+    this.x = x;
   }
 }
 

--- a/test/classes/initializers/records/generics/moreTypeFields.chpl
+++ b/test/classes/initializers/records/generics/moreTypeFields.chpl
@@ -7,9 +7,9 @@ record Foo {
   type t2;
   var x2: t2;
 
-  proc init(type t1Val, type t2Val) {
-    t1 = t1Val;
-    t2 = t2Val;
+  proc init(type t1, type t2) {
+    this.t1 = t1;
+    this.t2 = t2;
   }
 }
 

--- a/test/classes/initializers/records/generics/paramArgDefaultValue.chpl
+++ b/test/classes/initializers/records/generics/paramArgDefaultValue.chpl
@@ -4,8 +4,8 @@
 record Foo {
   param p: int;
 
-  proc init(param pVal = 3) {
-    p = pVal;
+  proc init(param p = 3) {
+    this.p = p;
   }
 }
 

--- a/test/classes/initializers/records/generics/reuse-class-instantiation.chpl
+++ b/test/classes/initializers/records/generics/reuse-class-instantiation.chpl
@@ -5,8 +5,8 @@ record Foo {
   type t;
   var x: t;
 
-  proc init(type tVal) {
-    t = tVal;
+  proc init(type t) {
+    this.t = t;
   }
 
   proc init(xVal) where !isSubtype(xVal.type, Foo) {

--- a/test/classes/initializers/records/generics/reuse-init-instantiation-param.chpl
+++ b/test/classes/initializers/records/generics/reuse-init-instantiation-param.chpl
@@ -5,8 +5,8 @@ record Foo {
   param p: int;
   var x: int;
 
-  proc init(param pVal) {
-    p = pVal;
+  proc init(param p) {
+    this.p = p;
   }
 }
 

--- a/test/classes/initializers/records/generics/reuse-init-instantiation-var.chpl
+++ b/test/classes/initializers/records/generics/reuse-init-instantiation-var.chpl
@@ -4,8 +4,8 @@
 record Foo {
   var x;
 
-  proc init(xVal) where !isSubtype(xVal.type, Foo) {
-    x = xVal;
+  proc init(x) where !isSubtype(x.type, Foo) {
+    this.x = x;
   }
 }
 

--- a/test/classes/initializers/records/generics/reuse-init-instantiation.chpl
+++ b/test/classes/initializers/records/generics/reuse-init-instantiation.chpl
@@ -5,8 +5,8 @@ record Foo {
   type t;
   var x: t;
 
-  proc init(type tVal) {
-    t = tVal;
+  proc init(type t) {
+    this.t = t;
   }
 }
 

--- a/test/classes/initializers/records/generics/reuse-init-new-instantiation-var.chpl
+++ b/test/classes/initializers/records/generics/reuse-init-new-instantiation-var.chpl
@@ -4,8 +4,8 @@
 record Foo {
   var x;
 
-  proc init(xVal) where !isSubtype(xVal.type, Foo) {
-    x = xVal;
+  proc init(x) where !isSubtype(x.type, Foo) {
+    this.x = x;
   }
 }
 

--- a/test/classes/initializers/records/generics/reuse-init-new-instantiation.chpl
+++ b/test/classes/initializers/records/generics/reuse-init-new-instantiation.chpl
@@ -5,8 +5,8 @@ record Foo {
   type t;
   var x: t;
 
-  proc init(type tVal) {
-    t = tVal;
+  proc init(type t) {
+    this.t = t;
   }
 }
 

--- a/test/classes/initializers/records/generics/typeArgDefaultValue.chpl
+++ b/test/classes/initializers/records/generics/typeArgDefaultValue.chpl
@@ -5,8 +5,8 @@ record Foo {
   type t;
   var x: t;
 
-  proc init(type tVal = bool) {
-    t = tVal;
+  proc init(type t = bool) {
+    this.t = t;
   }
 }
 

--- a/test/classes/initializers/records/generics/use-param-in-concrete-default.chpl
+++ b/test/classes/initializers/records/generics/use-param-in-concrete-default.chpl
@@ -6,8 +6,8 @@ record Foo {
   param p: int;
   var x = p * 3;
 
-  proc init(param pVal) {
-    p = pVal;
+  proc init(param p) {
+    this.p = p;
   }
 }
 

--- a/test/classes/initializers/records/generics/use-param-in-concrete-default2.chpl
+++ b/test/classes/initializers/records/generics/use-param-in-concrete-default2.chpl
@@ -6,9 +6,9 @@ record Foo {
   param p: int;
   var x = p * 3;
 
-  proc init(param pVal) {
-    p = pVal;
-    x = pVal + 2;
+  proc init(param p) {
+    this.p = p;
+    x = p + 2;
   }
 }
 

--- a/test/classes/initializers/records/generics/use-param-in-concrete-default3.chpl
+++ b/test/classes/initializers/records/generics/use-param-in-concrete-default3.chpl
@@ -12,6 +12,6 @@ record Foo {
   }
 }
 
-var foo1: Foo(2);
+var foo1 = new Foo(2);
 
 writeln(foo1);

--- a/test/classes/initializers/records/generics/varArgDefaultValue.chpl
+++ b/test/classes/initializers/records/generics/varArgDefaultValue.chpl
@@ -4,8 +4,8 @@
 record Foo {
   var v;
 
-  proc init(vVal = 3) {
-    v = vVal;
+  proc init(v = 3) {
+    this.v = v;
   }
 }
 

--- a/test/expressions/lydia/noinit/recordHasTypeField.chpl
+++ b/test/expressions/lydia/noinit/recordHasTypeField.chpl
@@ -1,13 +1,12 @@
 record foo {
   type t;
   var i: t;
-}
 
-inline proc _defaultOf (type t) where t == foo(int) {
-  writeln("I default initialized!");
-  var res: t = noinit;
-  res.i = 3;
-  return res;
+  proc init(type t) {
+    writeln("I default initialized!");
+    this.t = t;
+    this.i = 3;
+  }
 }
 
 var bar: foo(int) = noinit; // Should not print message

--- a/test/functions/lydia/userDefinedDefaultFunction/redefine-param-record.chpl
+++ b/test/functions/lydia/userDefinedDefaultFunction/redefine-param-record.chpl
@@ -1,12 +1,13 @@
 record bar {
   param size: int;
   var whatev = 5;
-}
 
-proc _defaultOf(type t:bar(3)) {
-  var res: bar(3) = noinit;
-  res.whatev = 7;
-  return res;
+  proc init(param size : int) {
+    this.size = size;
+    if size == 3 {
+      this.whatev = 7;
+    }
+  }
 }
 
 var foo: bar(3);

--- a/test/functions/lydia/userDefinedDefaultFunction/redefine-record.chpl
+++ b/test/functions/lydia/userDefinedDefaultFunction/redefine-record.chpl
@@ -1,11 +1,9 @@
 record bar {
   var aField: int;
-}
 
-inline proc _defaultOf(type t:bar) {
-  var res: t = noinit;
-  res.aField = 4;
-  return res;
+  proc init() {
+    this.aField = 4;
+  }
 }
 
 var foo: bar;

--- a/test/functions/lydia/userDefinedDefaultFunction/redefine-record.future
+++ b/test/functions/lydia/userDefinedDefaultFunction/redefine-record.future
@@ -1,1 +1,0 @@
-feature request: noinit support for initializers

--- a/test/functions/lydia/userDefinedDefaultFunction/redefine-string.chpl
+++ b/test/functions/lydia/userDefinedDefaultFunction/redefine-string.chpl
@@ -1,4 +1,0 @@
-inline proc _defaultOf(type t:string ) return "Look ma, no hands!";
-
-var foo: string;
-writeln(foo);

--- a/test/functions/lydia/userDefinedDefaultFunction/redefine-string.future
+++ b/test/functions/lydia/userDefinedDefaultFunction/redefine-string.future
@@ -1,4 +1,0 @@
-bug: redefining _defaultOf for string causes compilation errors
-
-It seems likely that the root cause here is the current point-of-instantiation
-behavior.

--- a/test/functions/lydia/userDefinedDefaultFunction/redefine-string.good
+++ b/test/functions/lydia/userDefinedDefaultFunction/redefine-string.good
@@ -1,1 +1,0 @@
-Look ma, no hands!

--- a/test/functions/lydia/userDefinedDefaultFunction/redefine-type-record.chpl
+++ b/test/functions/lydia/userDefinedDefaultFunction/redefine-type-record.chpl
@@ -1,12 +1,13 @@
 record bar {
   type t;
   var aField: t;
-}
 
-inline proc _defaultOf(type t:bar(int(8))) {
-  var res: t = noinit;
-  res.aField = -1;
-  return res;
+  proc init(type t) {
+    this.t = t;
+    if t == int(8) {
+      this.aField = -1;
+    }
+  }
 }
 
 var foo: bar(int(32));

--- a/test/parallel/forall/vass/visibility-of-record-for-reduce.chpl
+++ b/test/parallel/forall/vass/visibility-of-record-for-reduce.chpl
@@ -2,7 +2,6 @@
 module B {
 
   record foo { var v:int; }
-  proc _defaultOf(type t) where (t == foo) { return new foo(0); }
   proc +(a:foo,b:foo):foo { return new foo(a.v+b.v); }
 
   proc doB() {
@@ -17,7 +16,6 @@ module B {
 module C {
   
   record bar { var v:int; }
-  proc _defaultOf(type t) where (t == bar) { return new bar(0); }
   proc +(a:bar,b:bar):bar{ return new bar(a.v+b.v); }
 
   proc doC() {
@@ -35,7 +33,6 @@ module D {
   use C;
 
   record baz { var v:int; }
-  proc _defaultOf(type t) where (t == baz) { return new baz(0); }
   proc +(a:baz,b:baz):baz { return new baz(a.v+b.v); }
 
   proc main() {

--- a/test/types/records/init/copy/localUseNoCopyGeneric.chpl
+++ b/test/types/records/init/copy/localUseNoCopyGeneric.chpl
@@ -9,10 +9,10 @@ module Bar {
     y = other.y;
     z = other.z;
   }
-  proc R.init(a,b,c) {
-    x = a;
-    y = b;
-    z = c;
+  proc R.init(x,y,z) {
+    this.x = x;
+    this.y = y;
+    this.z = z;
   }
 
   proc getter() {

--- a/test/types/records/init/copy/localUseNoCopyGenericD.chpl
+++ b/test/types/records/init/copy/localUseNoCopyGenericD.chpl
@@ -9,10 +9,10 @@ module Bar {
     y = other.y;
     z = other.z;
   }
-  proc R.init(a,b,c) {
-    x = a;
-    y = b;
-    z = c;
+  proc R.init(x,y,z) {
+    this.x = x;
+    this.y = y;
+    this.z = z;
   }
   proc R.deinit() {
   }

--- a/test/types/records/init/generic/mismatch.bad
+++ b/test/types/records/init/generic/mismatch.bad
@@ -1,4 +1,4 @@
-mismatch.chpl:16: error: unresolved call 'A.init(type int(64))'
+mismatch.chpl:16: error: unresolved call 'A.init(t=type int(64))'
 mismatch.chpl:5: note: candidates are: A.init(x)
 mismatch.chpl:10: note:                 A.init(a: A)
 mismatch.chpl:1: note:                 A.init(other: A)


### PR DESCRIPTION
This PR updates the handling of default initialization to use named-expressions when invoking the type's initializer. Prior to this PR, the compiler would invoke the initializer differently depending on whether it was a default initializer or a user-defined initializer. By always using named-expressions, users have a clear and simple rule to remember when implementing initializers for default initialization.

Some tests were updated to rename initializer formals in order to continue passing.

This PR also takes the opportunity to eliminate _defaultOf for records instead of an 'init' call generated during resolution.

Testing:
- [x] local + futures
- [x] gasnet + futures
- [x] memleaks
- [x] valgrind