### PR TITLE
Remove dtSymbol

### DIFF
--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -617,8 +617,6 @@ void initPrimitiveTypes() {
   gCVoidPtr->cname = "NULL";
   gCVoidPtr->addFlag(FLAG_EXTERN);
 
-  dtSymbol = createPrimitiveType( "symbol", "_symbol");
-
   dtFile = createPrimitiveType ("_file", "_cfile");
   dtFile->symbol->addFlag(FLAG_EXTERN);
 

--- a/compiler/include/type.h
+++ b/compiler/include/type.h
@@ -408,7 +408,6 @@ TYPE_EXTERN PrimitiveType*    dtInt[INT_SIZE_NUM];
 TYPE_EXTERN PrimitiveType*    dtUInt[INT_SIZE_NUM];
 TYPE_EXTERN PrimitiveType*    dtReal[FLOAT_SIZE_NUM];
 TYPE_EXTERN PrimitiveType*    dtImag[FLOAT_SIZE_NUM];
-TYPE_EXTERN PrimitiveType*    dtSymbol;
 TYPE_EXTERN PrimitiveType*    dtFile;
 TYPE_EXTERN PrimitiveType*    dtOpaque;
 TYPE_EXTERN PrimitiveType*    dtTaskID;

--- a/compiler/passes/ResolveScope.cpp
+++ b/compiler/passes/ResolveScope.cpp
@@ -208,7 +208,6 @@ void ResolveScope::addBuiltIns() {
   extend(dtCVoidPtr->symbol);
   extend(dtCFnPtr->symbol);
   extend(gCVoidPtr);
-  extend(dtSymbol->symbol);
 
   extend(dtFile->symbol);
   extend(gFile);


### PR DESCRIPTION
We used to have 'symbol' type, available in the user space of Chapel programs.
It was unused and unusable. So removing it now.

dtSymbol was added in a3f94884 aka r5388 to implement closures (!!), noting
that it "can be used to represent the set of functions with a particular name."

Checked with Michael. Trivial, not reviewed.