### PR TITLE
Fix timeout detection for qsub systems

### DIFF
--- a/util/test/chpl_launchcmd.py
+++ b/util/test/chpl_launchcmd.py
@@ -221,7 +221,9 @@ class AbstractJob(object):
         if not self.redirect_output:
             submit_command.extend(['-j', 'oe', '-o', output_file])
         else:
-            submit_command.extend(['-j', 'oe', '-R', 'oe', '-o', '{0}.more'.format(output_file)])
+            # even when redirecting output, PBS errors are sent to the e/o
+            # streams, so make sure we can find errors if they occur
+            submit_command.extend(['-j', 'oe', '-o', '{0}.more'.format(output_file)])
         if self.walltime is not None:
             submit_command.append('-l')
             submit_command.append('walltime={0}'.format(self.walltime))

--- a/util/test/chpl_launchcmd.py
+++ b/util/test/chpl_launchcmd.py
@@ -220,6 +220,8 @@ class AbstractJob(object):
         submit_command =  [self.submit_bin, '-V', '-N', self.job_name]
         if not self.redirect_output:
             submit_command.extend(['-j', 'oe', '-o', output_file])
+        else:
+            submit_command.extend(['-j', 'oe', '-R', 'oe', '-o', '{0}.more'.format(output_file)])
         if self.walltime is not None:
             submit_command.append('-l')
             submit_command.append('walltime={0}'.format(self.walltime))
@@ -361,6 +363,13 @@ class AbstractJob(object):
             logging.debug('Reading output file.')
             with open(output_file, 'r') as fp:
                 output = fp.read()
+
+            try:
+                with open('{0}.more'.format(output_file), 'r') as fp:
+                    output += fp.read()
+            except:
+                pass
+
             logging.info('The test finished with output of length {0}.'.format(len(output)))
 
         return output


### PR DESCRIPTION
When we switched to using `&> $output_file` redirection instead of using the
qsub `-o $output_file` option in #4084 / #10585 we stopped being able to detect
timeouts on qsub systems. This is because the message that we key off of for
timeouts was still being sent to the non-redirected qsub e/o files. This
updates chpl_launchcmd to send any non-redirected output to a .more file with
`-j oe -o $output_file.more`. We then concatenate that file to our normal
testing output. It will be empty for successful runs, but will contains error
messages if a qsub error occurred.

This allows us to properly detect timeouts again.  It also prevents the
temporary qsub e/o files from cluttering the workspace, since they're now sent
to an automatically deleted tmpdir.

Resolves https://github.com/chapel-lang/chapel/issues/11671
