### PR TITLE
Find leader and standalone iterators earlier

### DIFF
--- a/compiler/AST/FnSymbol.cpp
+++ b/compiler/AST/FnSymbol.cpp
@@ -51,6 +51,7 @@ FnSymbol::FnSymbol(const char* initName) : Symbol(E_FnSymbol, initName) {
   thisTag            = INTENT_BLANK;
   retTag             = RET_VALUE;
   iteratorInfo       = NULL;
+  iteratorGroup      = NULL;
   _this              = NULL;
   instantiatedFrom   = NULL;
   _instantiationPoint = NULL;
@@ -74,26 +75,14 @@ FnSymbol::FnSymbol(const char* initName) : Symbol(E_FnSymbol, initName) {
 }
 
 FnSymbol::~FnSymbol() {
-  if (iteratorInfo && !hasFlag(FLAG_TASK_FN_FROM_ITERATOR_FN)) {
-    // Also set iterator class and iterator record iteratorInfo = NULL.
-    if (iteratorInfo->iclass) {
-      iteratorInfo->iclass->iteratorInfo = NULL;
-    }
-
-    if (iteratorInfo->irecord) {
-      iteratorInfo->irecord->iteratorInfo = NULL;
-    }
-
-    delete iteratorInfo;
-  }
+  cleanupIteratorInfo(this);
+  cleanupIteratorGroup(this);
 
   BasicBlock::clear(this);
-
   delete basicBlocks;
 
-  if (calledBy) {
+  if (calledBy)
     delete calledBy;
-  }
 }
 
 void FnSymbol::verify() {
@@ -149,6 +138,8 @@ void FnSymbol::verify() {
   verifyInTree(_backupInstantiationPoint, "FnSymbol::backupInstantiationPoint");
   verifyInTree(valueFunction,      "FnSymbol::valueFunction");
   verifyInTree(retSymbol,          "FnSymbol::retSymbol");
+
+  verifyIteratorGroup(this);
 }
 
 FnSymbol* FnSymbol::copyInner(SymbolMap* map) {

--- a/compiler/AST/foralls.cpp
+++ b/compiler/AST/foralls.cpp
@@ -622,7 +622,8 @@ static void removeOrigIterCall(SymExpr* origSE)
 }
 
 // Replaces 'origSE' in the tree with the result.
-static CallExpr* buildForallParIterCall(ForallStmt* pfs, SymExpr* origSE)
+static CallExpr* buildForallParIterCall(ForallStmt* pfs, SymExpr* origSE,
+                                        FnSymbol*& origTargetRef)
 {
   CallExpr* iterCall = NULL;
 
@@ -649,6 +650,10 @@ static CallExpr* buildForallParIterCall(ForallStmt* pfs, SymExpr* origSE)
       // a forall loop over a (possibly zippered) forall expression, ex.:
       //  test/reductions/deitz/test_maxloc_reduce_wmikanik_bug2.chpl
       targetName = astr(astr_loopexpr_iter, targetName + forallExprNameLen);
+
+      // Alternatively, find the function that origTarget redirects to.
+      origTarget = getTheIteratorFn(origTarget->retType);
+      INT_ASSERT(origTarget->name == targetName);
     }
 
     if (acceptUnmodifiedIterCall(pfs, origIterCall)) {
@@ -657,6 +662,7 @@ static CallExpr* buildForallParIterCall(ForallStmt* pfs, SymExpr* origSE)
     } else {
       iterCall = origIterCall->copy();
       iterCall->baseExpr = new UnresolvedSymExpr(targetName);
+      origTargetRef = origTarget;
     }
 
   } else {
@@ -953,7 +959,8 @@ CallExpr* resolveForallHeader(ForallStmt* pfs, SymExpr* origSE)
   // If at that time there are other elements in iterExprs(), we remove them.
   INT_ASSERT(origSE == pfs->firstIteratedExpr());
 
-  CallExpr* iterCall = buildForallParIterCall(pfs, origSE);
+  FnSymbol* origTarget = NULL; //for assertions
+  CallExpr* iterCall = buildForallParIterCall(pfs, origSE, origTarget);
 
   // So we know where iterCall is.
   INT_ASSERT(iterCall         == pfs->firstIteratedExpr());
@@ -964,6 +971,12 @@ CallExpr* resolveForallHeader(ForallStmt* pfs, SymExpr* origSE)
   resolveCallAndCallee(iterCall, false);
 
   FnSymbol* origIterFn = iterCall->resolvedFunction();
+
+  if (!tryFailure && origTarget) {
+    IteratorGroup* igroup = getIteratorGroup(origTarget);
+    if (gotSA) INT_ASSERT(origIterFn == igroup->standalone);
+    else       INT_ASSERT(origIterFn == igroup->leader);
+  }
 
   // ex. resolving the par iter failed and 'pfs' is under "if chpl__tryToken"
   if (tryFailure == false)

--- a/compiler/AST/iterator.cpp
+++ b/compiler/AST/iterator.cpp
@@ -181,7 +181,7 @@ static bool isIteratorOrForwarder(FnSymbol* it) {
 // Look for the iterator for 'iterKindTag' and update the iterator group.
 static void checkParallelIterator(FnSymbol* serial, Expr* call,
                                   Symbol* iterKindTag, IteratorGroup* igroup,
-                                  FnSymbol*& igroupPtr, bool& noniterFlag)
+                                  FnSymbol*& outParIter, bool& noniterFlag)
 {
   // Build a "representative call".
   CallExpr* repCall = new CallExpr(new UnresolvedSymExpr(serial->name));
@@ -201,7 +201,7 @@ static void checkParallelIterator(FnSymbol* serial, Expr* call,
   if (FnSymbol* parIter = tryResolveCall(repCall)) {
     // Got it.
     if (isIteratorOrForwarder(parIter)) {
-      igroupPtr = parIter;
+      outParIter = parIter;
       parIter->iteratorGroup = igroup;
 
     } else {
@@ -259,9 +259,9 @@ void verifyIteratorGroup(FnSymbol* it) {
   verifyIGfunction(igroup, igroup->follower);
 }
 
-static inline void cleanupIGfunction(FnSymbol* it, FnSymbol*& igroupPtr) {
-  if (it == igroupPtr) {
-    igroupPtr = NULL;
+static inline void cleanupIGfunction(FnSymbol* it, FnSymbol*& parIterInIG) {
+  if (it == parIterInIG) {
+    parIterInIG = NULL;
     it->iteratorGroup = NULL;
   }
 }

--- a/compiler/AST/iterator.cpp
+++ b/compiler/AST/iterator.cpp
@@ -219,12 +219,17 @@ void resolveAlsoParallelIterators(FnSymbol* serial, Expr* call) {
   if (! isIteratorOrForwarder(serial)) return;  // not of interest
   if (serial->iteratorGroup != NULL) return;  // already taken care of
 
-  // Similar to isIteratorOfType().
-  for_formals(formal, serial)
-    if (formal->name == astrTag && formal->type == gLeaderTag->type)
-      // 'serial' is actually a parallel iterator. Since we did not come
-      // from a serial iterator, we will not update iterator groups.
-      return;
+  if (serial->hasFlag(FLAG_INLINE_ITERATOR))
+    // 'serial' is actually a parallel iterator. Since we did not come
+    // from a serial iterator, we will not update iterator groups.
+    return;
+
+  if (! serial->isIterator())
+    // The above "is parallel" check does not fire on iterator forwarders.
+    // So check for 'tag' formals instead, like in isIteratorOfType().
+    for_formals(formal, serial)
+      if (formal->name == astrTag && formal->type == gLeaderTag->type)
+        return;
 
   IteratorGroup* igroup = new IteratorGroup();
   igroup->serial = serial;

--- a/compiler/include/FnSymbol.h
+++ b/compiler/include/FnSymbol.h
@@ -49,8 +49,9 @@ public:
   IntentTag                  thisTag;
   RetTag                     retTag;
 
-  // Support for iterator lowering and parallel loops.
+  // Support for iterator lowering.
   IteratorInfo*              iteratorInfo;
+  // Pointers to other iterator variants - serial, standalone, etc.
   IteratorGroup*             iteratorGroup;
 
   Symbol*                    _this;

--- a/compiler/include/FnSymbol.h
+++ b/compiler/include/FnSymbol.h
@@ -23,6 +23,8 @@
 #include "library.h"
 #include "symbol.h"
 
+class IteratorGroup;
+
 enum RetTag {
   RET_VALUE,
   RET_REF,
@@ -47,8 +49,9 @@ public:
   IntentTag                  thisTag;
   RetTag                     retTag;
 
-  // Attached original (user) iterators before lowering.
+  // Support for iterator lowering and parallel loops.
   IteratorInfo*              iteratorInfo;
+  IteratorGroup*             iteratorGroup;
 
   Symbol*                    _this;
   FnSymbol*                  instantiatedFrom;

--- a/compiler/include/iterator.h
+++ b/compiler/include/iterator.h
@@ -21,7 +21,6 @@
 #define _ITERATOR_H_
 #include "symbol.h"
 #include "vec.h"
-#include <map>
 
 class BaseAST;
 class AggregateType;

--- a/compiler/include/iterator.h
+++ b/compiler/include/iterator.h
@@ -28,19 +28,9 @@ class AggregateType;
 class FnSymbol;
 class CallExpr;
 
-enum IteratorTag { 
-  it_serial,
-  it_standalone,
-  it_leader,
-  it_follower,
-  it_undecided    // unknown so far
-};
-
 class IteratorInfo {
 public:
   IteratorInfo();
-
-  IteratorTag    tag;
 
   FnSymbol*      iterator;
   FnSymbol*      getIterator;
@@ -60,22 +50,24 @@ public:
   RetTag         iteratorRetTag;
 };
 
+void cleanupIteratorInfo(FnSymbol* host);
+
 class IteratorGroup {
 public:
   FnSymbol* serial;
   FnSymbol* standalone;
   FnSymbol* leader;
   FnSymbol* follower;
+
+  // Search for a standalone/leader gave a non-iterator/forwarder.
+  bool noniterSA, noniterL;
+
   IteratorGroup();
 };
 
-extern std::map<FnSymbol*,IteratorGroup*> iteratorGroups;
-
-IteratorGroup* getIteratorGroup(FnSymbol* it);
 void resolveAlsoParallelIterators(FnSymbol* serial, Expr* call);
+void verifyIteratorGroup(FnSymbol* it);
 void cleanupIteratorGroup(FnSymbol* it);
-IteratorTag detectIteratorTagFromGroup(FnSymbol* it);
-IteratorTag detectIteratorTagFromGroup(IteratorGroup* igroup, FnSymbol* it);
 
 void showIteratorGroup(IteratorGroup* igroup);
 void showIteratorGroup(BaseAST* ast);

--- a/compiler/include/iterator.h
+++ b/compiler/include/iterator.h
@@ -21,6 +21,7 @@
 #define _ITERATOR_H_
 #include "symbol.h"
 #include "vec.h"
+#include <map>
 
 class BaseAST;
 class AggregateType;
@@ -28,9 +29,11 @@ class FnSymbol;
 class CallExpr;
 
 enum IteratorTag { 
-  it_iterator, 
+  it_serial,
+  it_standalone,
   it_leader,
-  it_follower 
+  it_follower,
+  it_undecided    // unknown so far
 };
 
 class IteratorInfo {
@@ -56,6 +59,27 @@ public:
   Type*          yieldedType;
   RetTag         iteratorRetTag;
 };
+
+class IteratorGroup {
+public:
+  FnSymbol* serial;
+  FnSymbol* standalone;
+  FnSymbol* leader;
+  FnSymbol* follower;
+  IteratorGroup();
+};
+
+extern std::map<FnSymbol*,IteratorGroup*> iteratorGroups;
+
+IteratorGroup* getIteratorGroup(FnSymbol* it);
+void resolveAlsoParallelIterators(FnSymbol* serial, Expr* call);
+void cleanupIteratorGroup(FnSymbol* it);
+IteratorTag detectIteratorTagFromGroup(FnSymbol* it);
+IteratorTag detectIteratorTagFromGroup(IteratorGroup* igroup, FnSymbol* it);
+
+void showIteratorGroup(IteratorGroup* igroup);
+void showIteratorGroup(BaseAST* ast);
+void showIteratorGroup(int id);
 
 CallExpr* isSingleLoopIterator(FnSymbol* fn, Vec<BaseAST*>& asts);
 void lowerIterator(FnSymbol* fn);

--- a/compiler/include/preFold.h
+++ b/compiler/include/preFold.h
@@ -27,6 +27,6 @@ class SymExpr;
 
 Expr* preFold(CallExpr* expr);
 
-SymExpr* symOrParamExpr(Symbol* arg);
+SymExpr* createSymExprPropagatingParam(Symbol* arg);
 
 #endif

--- a/compiler/include/preFold.h
+++ b/compiler/include/preFold.h
@@ -22,7 +22,11 @@
 
 class CallExpr;
 class Expr;
+class Symbol;
+class SymExpr;
 
 Expr* preFold(CallExpr* expr);
+
+SymExpr* symOrParamExpr(Symbol* arg);
 
 #endif

--- a/compiler/include/resolveFunction.h
+++ b/compiler/include/resolveFunction.h
@@ -21,6 +21,7 @@
 #define _RESOLVE_FUNCTION_H_
 
 class AggregateType;
+class CallExpr;
 class FnSymbol;
 class Type;
 
@@ -29,7 +30,7 @@ void  resolveSignatureAndFunction(FnSymbol* fn);
 // Note: resolveSignature resolves declared return types
 void  resolveSignature(FnSymbol* fn);
 
-void  resolveFunction(FnSymbol* fn);
+void  resolveFunction(FnSymbol* fn, CallExpr* forCall = 0);
 
 bool  isLeaderIterator(FnSymbol* fn);
 

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -6595,6 +6595,7 @@ static Expr* resolveExprPhase2(Expr* origExpr, FnSymbol* fn, Expr* expr) {
 
       } else {
         resolveFunction(call->resolvedFunction());
+        resolveAlsoParallelIterators(call->resolvedFunction(), call);
       }
 
       resolveExprExpandGenerics(call);
@@ -6642,6 +6643,7 @@ static Expr* resolveExprResolveEachCall(ContextCallExpr* cc) {
     valueFn    = tmpCall->resolvedFunction();
 
     resolveFunction(valueFn);
+    resolveAlsoParallelIterators(valueFn, cc);
 
     n         += 1;
     nIterator += (valueFn->isIterator()    == true) ? 1 : 0;
@@ -6651,6 +6653,7 @@ static Expr* resolveExprResolveEachCall(ContextCallExpr* cc) {
     constRefFn = tmpCall->resolvedFunction();
 
     resolveFunction(constRefFn);
+    resolveAlsoParallelIterators(constRefFn, cc);
 
     n         += 1;
     nIterator += (constRefFn->isIterator() == true) ? 1 : 0;
@@ -6660,6 +6663,7 @@ static Expr* resolveExprResolveEachCall(ContextCallExpr* cc) {
     refFn      = tmpCall->resolvedFunction();
 
     resolveFunction(refFn);
+    resolveAlsoParallelIterators(refFn, cc);
 
     n         += 1;
     nIterator += (refFn->isIterator()      == true) ? 1 : 0;
@@ -8527,6 +8531,8 @@ static void removeUnusedFunctions() {
           }
 
           clearDefaultInitFns(fn);
+
+          cleanupIteratorGroup(fn);
 
           fn->defPoint->remove();
         }

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -6594,8 +6594,7 @@ static Expr* resolveExprPhase2(Expr* origExpr, FnSymbol* fn, Expr* expr) {
         expr = resolveExprResolveEachCall(cc);
 
       } else {
-        resolveFunction(call->resolvedFunction());
-        resolveAlsoParallelIterators(call->resolvedFunction(), call);
+        resolveFunction(call->resolvedFunction(), call);
       }
 
       resolveExprExpandGenerics(call);
@@ -6642,8 +6641,7 @@ static Expr* resolveExprResolveEachCall(ContextCallExpr* cc) {
   if (CallExpr* tmpCall = cc->getValueCall()) {
     valueFn    = tmpCall->resolvedFunction();
 
-    resolveFunction(valueFn);
-    resolveAlsoParallelIterators(valueFn, cc);
+    resolveFunction(valueFn, tmpCall);
 
     n         += 1;
     nIterator += (valueFn->isIterator()    == true) ? 1 : 0;
@@ -6652,8 +6650,7 @@ static Expr* resolveExprResolveEachCall(ContextCallExpr* cc) {
   if (CallExpr* tmpCall = cc->getConstRefCall()) {
     constRefFn = tmpCall->resolvedFunction();
 
-    resolveFunction(constRefFn);
-    resolveAlsoParallelIterators(constRefFn, cc);
+    resolveFunction(constRefFn, tmpCall);
 
     n         += 1;
     nIterator += (constRefFn->isIterator() == true) ? 1 : 0;
@@ -6662,8 +6659,7 @@ static Expr* resolveExprResolveEachCall(ContextCallExpr* cc) {
   if (CallExpr* tmpCall = cc->getRefCall()) {
     refFn      = tmpCall->resolvedFunction();
 
-    resolveFunction(refFn);
-    resolveAlsoParallelIterators(refFn, cc);
+    resolveFunction(refFn, tmpCall);
 
     n         += 1;
     nIterator += (refFn->isIterator()      == true) ? 1 : 0;
@@ -8531,8 +8527,6 @@ static void removeUnusedFunctions() {
           }
 
           clearDefaultInitFns(fn);
-
-          cleanupIteratorGroup(fn);
 
           fn->defPoint->remove();
         }

--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -807,7 +807,7 @@ static Expr* preFoldPrimOp(CallExpr* call) {
       // Note: this can add a use formal outside of its function
       // This is cleaned up in cleanupLeaderFollowerIteratorCalls
       followerCall->insertAtTail(new NamedExpr(formal->name,
-                                               symOrParamExpr(formal)));
+                                   createSymExprPropagatingParam(formal)));
     }
 
     // "tag", "followThis" and optionally "fast" should be placed at the end
@@ -839,7 +839,7 @@ static Expr* preFoldPrimOp(CallExpr* call) {
         // Leave out the tag since we add it in again below
       } else {
         leaderCall->insertAtTail(new NamedExpr(formal->name,
-                                               symOrParamExpr(formal)));
+                                   createSymExprPropagatingParam(formal)));
       }
     }
 
@@ -862,7 +862,7 @@ static Expr* preFoldPrimOp(CallExpr* call) {
         // Leave out the tag since we add it in again below
       } else {
         standaloneCall->insertAtTail(new NamedExpr(formal->name,
-                                                   symOrParamExpr(formal)));
+                                       createSymExprPropagatingParam(formal)));
       }
     }
 
@@ -1913,7 +1913,7 @@ static Expr* dropUnnecessaryCast(CallExpr* call) {
   return result;
 }
 
-SymExpr* symOrParamExpr(Symbol* arg) {
+SymExpr* createSymExprPropagatingParam(Symbol* arg) {
   Symbol* result = arg;
   if (Symbol* paramVal = paramMap.get(arg))
     result = paramVal;

--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -69,8 +69,6 @@ static AggregateType* createOrFindFunTypeFromAnnotation(AList&    argList,
 
 static Expr*          dropUnnecessaryCast(CallExpr* call);
 
-static SymExpr*       symOrParamExpr(Symbol* arg);
-
 static bool           isNormalField(Symbol* field);
 
 static std::string    buildParentName(AList& argList,
@@ -1915,7 +1913,7 @@ static Expr* dropUnnecessaryCast(CallExpr* call) {
   return result;
 }
 
-static SymExpr* symOrParamExpr(Symbol* arg) {
+SymExpr* symOrParamExpr(Symbol* arg) {
   Symbol* result = arg;
   if (Symbol* paramVal = paramMap.get(arg))
     result = paramVal;

--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -509,8 +509,7 @@ void resolveFunction(FnSymbol* fn, CallExpr* forCall) {
           ensureInMethodList(fn);
         }
 
-        if (forCall && fn->isIterator() &&
-            ! fn->hasFlag(FLAG_INLINE_ITERATOR)) {
+        if (forCall != NULL) {
           resolveAlsoParallelIterators(fn, forCall);
         }
 

--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -884,7 +884,7 @@ static IteratorInfo*  makeIteratorInfo(AggregateType* iClass,
   Type*         defaultInt = dtInt[INT_SIZE_DEFAULT];
   IteratorInfo* ii         = new IteratorInfo();
 
-  ii->tag         = it_iterator;
+  ii->tag         = detectIteratorTagFromGroup(fn);
 
   ii->iterator    = fn;
   ii->iclass      = iClass;

--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -884,8 +884,6 @@ static IteratorInfo*  makeIteratorInfo(AggregateType* iClass,
   Type*         defaultInt = dtInt[INT_SIZE_DEFAULT];
   IteratorInfo* ii         = new IteratorInfo();
 
-  ii->tag         = detectIteratorTagFromGroup(fn);
-
   ii->iterator    = fn;
   ii->iclass      = iClass;
   ii->irecord     = iRecord;

--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -458,7 +458,7 @@ void resolveSpecifiedReturnType(FnSymbol* fn) {
 *                                                                             *
 ************************************** | *************************************/
 
-void resolveFunction(FnSymbol* fn) {
+void resolveFunction(FnSymbol* fn, CallExpr* forCall) {
   if (fn->isResolved() == false) {
     if (fn->id == breakOnResolveID) {
       printf("breaking on resolve fn %s[%d] (%d args)\n",
@@ -507,6 +507,11 @@ void resolveFunction(FnSymbol* fn) {
 
         if (fn->isMethod() == true && fn->_this != NULL) {
           ensureInMethodList(fn);
+        }
+
+        if (forCall && fn->isIterator() &&
+            ! fn->hasFlag(FLAG_INLINE_ITERATOR)) {
+          resolveAlsoParallelIterators(fn, forCall);
         }
 
       } else {


### PR DESCRIPTION
So far we have relied on resolving _toLeader and _toStandalone
to find the parallel counterpart to a serial iterator.

With this change, the compiler seeks leader and follower immediately
after resolving the serial iterator. We record the results in an
IteratorGroup. An IteratorGroup is stored in FnSymbol::iteratorGroup
of each iterator of the group. This is similar to FnSymbol::iteratorInfo.

The bodies of the leader/standalone are not resolved at that time.
This is because they may contain resolution errors. Those errors
should not be reported yet because they (the iterators) may end up
being unused. If the leader and/or the standalone is not found, it is
not an error at that time either - again because they may not be needed.

It would be nice to store pointers to leader and standalone
FnSymbols directly in the serial iterator's IteratorInfo,
instead of creating IteratorGroups.
This does not work :( because iterator-forwarding functions
do not have the associated IteratorInfo. Creating IteratorInfo
for iterator forwarders would require non-trivial changes to the compiler
because we often rely on fn->iteratorInfo != NULL to be an indicator
of fn being an iterator.

This PR does not change the compiler to rely on this information.
However, it adds verification that the standalone or leader are found
correctly during resolution of forall loop statements.

While there:  refactor the cleanup of IteratorInfo upon ~FnSymbol
and remove the unused IteratorTag and IteratorInfo::tag.

Requires #11675.

Testing: linux64, multilocale tests under gasnet.