### PR TITLE
Rename eigvals() to eig(), and keep eigvals()

### DIFF
--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -1105,19 +1105,28 @@ proc eigvals(A: [] ?t) where isRealType(t) && A.domain.rank == 2 && usingLAPACK 
 
 /* To be removed after 1.19.0 */
 pragma "no doc"
-proc eigvals(A: [] ?t, param left: bool, param right = false) where isRealType(t) && A.domain.rank == 2 && usingLAPACK {
-  if left || right then
+proc eigvals(A: [] ?t, param right = false) where isRealType(t) && A.domain.rank == 2 && usingLAPACK {
+  if right then
     compilerWarning('eigvals() will only return eigenvalues in future releases. Use eig() instead.');
-  return eig(A, left, right);
+  return eig(A, right=right);
 }
 
 /* To be removed after 1.19.0 */
 pragma "no doc"
-proc eigvals(A: [] ?t, param left: bool = false, param right: bool) where isRealType(t) && A.domain.rank == 2 && usingLAPACK {
+proc eigvals(A: [] ?t, param left: bool) where isRealType(t) && A.domain.rank == 2 && usingLAPACK {
+  if left then
+    compilerWarning('eigvals() will only return eigenvalues in future releases. Use eig() instead.');
+  return eig(A, left=left);
+}
+
+/* To be removed after 1.19.0 */
+pragma "no doc"
+proc eigvals(A: [] ?t, param left: bool, param right: bool) where isRealType(t) && A.domain.rank == 2 && usingLAPACK {
   if left || right then
     compilerWarning('eigvals() will only return eigenvalues in future releases. Use eig() instead.');
-  return eig(A, left, right);
+  return eig(A, left=left, right=right);
 }
+
 
 
 /* Find the eigenvalues and eigenvectors of matrix ``A``. ``A`` must be square.

--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -1105,7 +1105,7 @@ proc eigvals(A: [] ?t) where isRealType(t) && A.domain.rank == 2 && usingLAPACK 
 
 /* To be removed after 1.19.0 */
 pragma "no doc"
-proc eigvals(A: [] ?t, param right = false) where isRealType(t) && A.domain.rank == 2 && usingLAPACK {
+proc eigvals(A: [] ?t, param right) where isRealType(t) && A.domain.rank == 2 && usingLAPACK {
   if right then
     compilerWarning('eigvals() will only return eigenvalues in future releases. Use eig() instead.');
   return eig(A, right=right);

--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -1105,7 +1105,7 @@ proc eigvals(A: [] ?t) where isRealType(t) && A.domain.rank == 2 && usingLAPACK 
 
 /* To be removed after 1.19.0 */
 pragma "no doc"
-proc eigvals(A: [] ?t, param right) where isRealType(t) && A.domain.rank == 2 && usingLAPACK {
+proc eigvals(A: [] ?t, param right: bool) where isRealType(t) && A.domain.rank == 2 && usingLAPACK {
   if right then
     compilerWarning('eigvals() will only return eigenvalues in future releases. Use eig() instead.');
   return eig(A, right=right);

--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -67,9 +67,9 @@ headers and libraries available would result in a compilation error.
   // example2.chpl
   var A = Matrix([2.0, 1.0],
                  [1.0, 2.0]);
-  var (eigenvalues, eigenvectors) = eigvals(A, right=true);
+  var (eigenvalues, eigenvectors) = eig(A, right=true);
 
-The program above uses :proc:`eigvals`, which depends on :mod:`LAPACK`.
+The program above uses :proc:`eig`, which depends on :mod:`LAPACK`.
 Compilation without ``LAPACK`` headers and libraries available would result in
 a compilation error.
 
@@ -1091,7 +1091,35 @@ proc cholesky(A: [] ?t, lower = true)
 }
 
 
-// TODO: add example usage to docs
+/* Find the eigenvalues of matrix ``A``. ``A`` must be square.
+
+    .. note::
+
+      This procedure depends on the :mod:`LAPACK` module, and will generate a
+      compiler error if ``lapackImpl`` is ``none``.
+
+*/
+proc eigvals(A: [] ?t) where isRealType(t) && A.domain.rank == 2 && usingLAPACK {
+  return eig(A, left=false, right=false);
+}
+
+/* To be removed after 1.19.0 */
+pragma "no doc"
+proc eigvals(A: [] ?t, param left: bool, param right = false) where isRealType(t) && A.domain.rank == 2 && usingLAPACK {
+  if left || right then
+    compilerWarning('eigvals() will only return eigenvalues in future releases. Use eig() instead.');
+  return eig(A, left, right);
+}
+
+/* To be removed after 1.19.0 */
+pragma "no doc"
+proc eigvals(A: [] ?t, param left: bool = false, param right: bool) where isRealType(t) && A.domain.rank == 2 && usingLAPACK {
+  if left || right then
+    compilerWarning('eigvals() will only return eigenvalues in future releases. Use eig() instead.');
+  return eig(A, left, right);
+}
+
+
 /* Find the eigenvalues and eigenvectors of matrix ``A``. ``A`` must be square.
 
    * If ``left`` is ``true`` then the "left" eigenvectors are computed. The
@@ -1115,7 +1143,7 @@ proc cholesky(A: [] ?t, lower = true)
       compiler error if ``lapackImpl`` is ``none``.
 
  */
-proc eigvals(A: [] ?t, param left = false, param right = false)
+proc eig(A: [] ?t, param left = false, param right = false)
   where isRealType(t) && A.domain.rank == 2 && usingLAPACK {
 
   proc convertToCplx(wr: [] t, wi: [] t) {
@@ -1286,7 +1314,7 @@ proc svd(A: [?Adom] ?t) throws
 
 
 pragma "no doc"
-proc eigvals(A: [] ?t, param left = false, param right = false)
+proc eig(A: [] ?t, param left = false, param right = false)
   where isRealType(t) && A.domain.rank == 2 && !usingLAPACK {
   compilerError("eigvals() requires LAPACK");
 }

--- a/test/deprecated/old-eigvals.chpl
+++ b/test/deprecated/old-eigvals.chpl
@@ -1,0 +1,106 @@
+use LinearAlgebra, Random;
+
+config const epsilon = 0.0000000001;
+
+proc isClose(a: complex, b: complex) {
+  return abs(a.re - b.re) + abs(a.im - b.im) < epsilon;
+}
+
+var A: [1..10, 1..10] real;
+fillRandom(A);
+var cplxA: [1..10, 1..10] complex = A;
+
+{
+  var (eigenvalues, right) = eigvals(A, right=true);
+
+  // trace(A) = sum(eigenvalues)
+  {
+    var tr = trace(A);
+    var ev = + reduce eigenvalues;
+    if !isClose(tr, ev) {
+      writeln("trace(A) != sum(eigenvalues) ", tr, " != ", ev.re);
+    }
+  }
+
+  // Check that:
+  // Av = e * v
+  // Where e and v are corresponding eigenvalues and right eigenvectors
+  for (e, i) in zip(eigenvalues, 1..) {
+    var eigVec:[1..10] complex = right[.., i];
+    var Av = dot(cplxA, eigVec);
+    var ev = dot(e, eigVec);
+
+    for (a, e) in zip(Av, ev) {
+      if !isClose(a, e) then
+        writeln(a, " != ", e);
+    }
+  }
+}
+
+{
+  var (eigenvalues, left) = eigvals(A, left=true);
+
+  // trace(A) = sum(eigenvalues)
+  {
+    var tr = trace(A);
+    var ev = + reduce eigenvalues;
+    if !isClose(tr, ev) {
+      writeln("trace(A) != sum(eigenvalues) ", tr, " != ", ev.re);
+    }
+  }
+
+  // Check that
+  // u^H * A = k * u^H
+  // Where k and u are corresponding eigenvalues and left eigenvectors
+  // and ^H means conjugate transpose.
+  for (k, i) in zip(eigenvalues, 1..) {
+    var eigVec:[1..10] complex = conjg(left[.., i]);
+    var Av = dot(eigVec, cplxA);
+    var ku = dot(k, eigVec);
+
+    for (a, k) in zip(Av, ku) {
+      if !isClose(a, k) then
+        writeln(a, " != ", k);
+    }
+  }
+}
+
+{
+  var (eigenvalues, left, right) = eigvals(A, left=true, right=true);
+  // Check that the above properties hold when computing both eigenvectors
+  // at the same time.
+
+  // trace(A) = sum(eigenvalues)
+  {
+    var tr = trace(A);
+    var ev = + reduce eigenvalues;
+    if !isClose(tr, ev) {
+      writeln("trace(A) != sum(eigenvalues) ", tr, " != ", ev.re);
+    }
+  }
+
+  // Av = e * v
+  for (e, i) in zip(eigenvalues, 1..) {
+    var eigVec:[1..10] complex = right[.., i];
+    var Av = dot(cplxA, eigVec);
+    var ev = dot(e, eigVec);
+
+    for (a, e) in zip(Av, ev) {
+      if !isClose(a, e) then
+        writeln(a, " != ", e);
+    }
+  }
+
+  // u^H * A = k * u^H
+  for (k, i) in zip(eigenvalues, 1..) {
+    var eigVec:[1..10] complex = conjg(left[.., i]);
+    var Av = dot(eigVec, cplxA);
+    var ku = dot(k, eigVec);
+
+    for (a, k) in zip(Av, ku) {
+      if !isClose(a, k) then
+        writeln(a, " != ", k);
+    }
+  }
+}
+

--- a/test/deprecated/old-eigvals.good
+++ b/test/deprecated/old-eigvals.good
@@ -1,0 +1,3 @@
+old-eigvals.chpl:14: warning: eigvals() will only return eigenvalues in future releases. Use eig() instead.
+old-eigvals.chpl:41: warning: eigvals() will only return eigenvalues in future releases. Use eig() instead.
+old-eigvals.chpl:69: warning: eigvals() will only return eigenvalues in future releases. Use eig() instead.

--- a/test/library/packages/LinearAlgebra/correctness/testEigen.chpl
+++ b/test/library/packages/LinearAlgebra/correctness/testEigen.chpl
@@ -11,13 +11,13 @@ fillRandom(A);
 var cplxA: [1..10, 1..10] complex = A;
 
 {
-  var eig = eigvals(A);
+  var eigenvalues = eigvals(A);
 
   // Check that:
   // trace(A) = sum(eigenvalues)
   {
     var tr = trace(A);
-    var ev = + reduce eig;
+    var ev = + reduce eigenvalues;
     if !isClose(tr, ev) {
       writeln("trace(A) != sum(eigenvalues) ", tr, " != ", ev.re);
     }
@@ -25,12 +25,26 @@ var cplxA: [1..10, 1..10] complex = A;
 }
 
 {
-  var (eig, right) = eigvals(A, right=true);
+  var eigenvalues = eig(A);
+
+  // Check that:
+  // trace(A) = sum(eigenvalues)
+  {
+    var tr = trace(A);
+    var ev = + reduce eigenvalues;
+    if !isClose(tr, ev) {
+      writeln("trace(A) != sum(eigenvalues) ", tr, " != ", ev.re);
+    }
+  }
+}
+
+{
+  var (eigenvalues, right) = eig(A, right=true);
 
   // trace(A) = sum(eigenvalues)
   {
     var tr = trace(A);
-    var ev = + reduce eig;
+    var ev = + reduce eigenvalues;
     if !isClose(tr, ev) {
       writeln("trace(A) != sum(eigenvalues) ", tr, " != ", ev.re);
     }
@@ -39,7 +53,7 @@ var cplxA: [1..10, 1..10] complex = A;
   // Check that:
   // Av = e * v
   // Where e and v are corresponding eigenvalues and right eigenvectors
-  for (e, i) in zip(eig, 1..) {
+  for (e, i) in zip(eigenvalues, 1..) {
     var eigVec:[1..10] complex = right[.., i];
     var Av = dot(cplxA, eigVec);
     var ev = dot(e, eigVec);
@@ -52,12 +66,12 @@ var cplxA: [1..10, 1..10] complex = A;
 }
 
 {
-  var (eig, left) = eigvals(A, left=true);
+  var (eigenvalues, left) = eig(A, left=true);
 
   // trace(A) = sum(eigenvalues)
   {
     var tr = trace(A);
-    var ev = + reduce eig;
+    var ev = + reduce eigenvalues;
     if !isClose(tr, ev) {
       writeln("trace(A) != sum(eigenvalues) ", tr, " != ", ev.re);
     }
@@ -67,7 +81,7 @@ var cplxA: [1..10, 1..10] complex = A;
   // u^H * A = k * u^H
   // Where k and u are corresponding eigenvalues and left eigenvectors
   // and ^H means conjugate transpose.
-  for (k, i) in zip(eig, 1..) {
+  for (k, i) in zip(eigenvalues, 1..) {
     var eigVec:[1..10] complex = conjg(left[.., i]);
     var Av = dot(eigVec, cplxA);
     var ku = dot(k, eigVec);
@@ -80,21 +94,21 @@ var cplxA: [1..10, 1..10] complex = A;
 }
 
 {
-  var (eig, left, right) = eigvals(A, left=true, right=true);
+  var (eigenvalues, left, right) = eig(A, left=true, right=true);
   // Check that the above properties hold when computing both eigenvectors
   // at the same time.
 
   // trace(A) = sum(eigenvalues)
   {
     var tr = trace(A);
-    var ev = + reduce eig;
+    var ev = + reduce eigenvalues;
     if !isClose(tr, ev) {
       writeln("trace(A) != sum(eigenvalues) ", tr, " != ", ev.re);
     }
   }
 
   // Av = e * v
-  for (e, i) in zip(eig, 1..) {
+  for (e, i) in zip(eigenvalues, 1..) {
     var eigVec:[1..10] complex = right[.., i];
     var Av = dot(cplxA, eigVec);
     var ev = dot(e, eigVec);
@@ -106,7 +120,7 @@ var cplxA: [1..10, 1..10] complex = A;
   }
 
   // u^H * A = k * u^H
-  for (k, i) in zip(eig, 1..) {
+  for (k, i) in zip(eigenvalues, 1..) {
     var eigVec:[1..10] complex = conjg(left[.., i]);
     var Av = dot(eigVec, cplxA);
     var ku = dot(k, eigVec);


### PR DESCRIPTION
This PR renames `eigvals()` to `eig()`, and keeps `eigvals()` around as a wrapper to `eig()`, which only supports returning eigenvalues, not eigenvectors.

This change was made to be more consistent with other linear algebra interfaces out in the wild.

The 1.19.0 release will continue to support `eigvals()` returning eigenvectors, but will emit a deprecation warning when `left` or `right` arguments are set. These overloads will be removed after 1.19.0.

I've also added a deprecation test, `test/deprecated/old-eigvals.chpl`, which is a copy of the previous `testEigen.chpl` file.

Resolves https://github.com/chapel-lang/chapel/issues/11142
