### PR TITLE
Fixing some simple misspellings

### DIFF
--- a/test/performance/vectorization/vectorPragmas/zipIterInFollower.chpl
+++ b/test/performance/vectorization/vectorPragmas/zipIterInFollower.chpl
@@ -7,7 +7,7 @@ module iters {
     }
   }
 
-  // zipered loop in standalone with yield should get vector pragma
+  // zippered loop in standalone with yield should get vector pragma
   // Note: requires that each iter in the zippered iter gets inlined
   iter myiter(nn: int, nt: int, param tag: iterKind) where tag == iterKind.standalone {
     coforall i in 0..#nt {
@@ -23,7 +23,7 @@ module iters {
     }
   }
 
-  // zipered loop in standalone with yield should get vector pragma
+  // zippered loop in standalone with yield should get vector pragma
   // Note: requires that each iter in the zippered iter gets inlined
   iter myiter(nn:int, nt: int, followThis, param tag: iterKind) where tag == iterKind.follower {
     for (i, j) in zip(followThis, followThis) {

--- a/test/performance/vectorization/vectorPragmas/zipIterInFollowerNoVector.chpl
+++ b/test/performance/vectorization/vectorPragmas/zipIterInFollowerNoVector.chpl
@@ -14,7 +14,7 @@ module iters {
     }
   }
 
-  // zipered loop in standalone should NOT get vector pragma since one of the
+  // zippered loop in standalone should NOT get vector pragma since one of the
   // iters being zipped can't be inlined
   iter myiter(nn: int, nt: int, param tag: iterKind) where tag == iterKind.standalone {
     coforall i in 0..#nt {
@@ -30,7 +30,7 @@ module iters {
     }
   }
 
-  // zipered loop in follower should NOT get vector pragma since one of the
+  // zippered loop in follower should NOT get vector pragma since one of the
   // iters being zipped can't be inlined
   iter myiter(nn:int, nt: int, followThis, param tag: iterKind) where tag == iterKind.follower {
     for (i, j) in zip(followThis, nonInlinableIter(followThis)) {

--- a/test/reductions/vass/reductions-perf.chpl
+++ b/test/reductions/vass/reductions-perf.chpl
@@ -29,7 +29,7 @@ config const n00perLocale =
   if perf then here.physicalMemory() / 4 / numBytes(elemType) else 1000000;
 config const n00 = numLocales * n00perLocale;
 
-// small arrays for multipe reductions
+// small arrays for multiple reductions
 config const elemsPerCore = 1024; // or 65536
 config const numCores = if perf then here.maxTaskPar else 4;
 


### PR DESCRIPTION
While grepping for instances of "ipe" for my "remove ipe" effort, I happened
to stumble across the following misspellings, so am fixing them while noticing.