### PR TITLE
Add a test that passes a multidimensional array from Fortran to Chapel

### DIFF
--- a/test/interop/fortran/multidimArray/ISO_Fortran_binding.chpl
+++ b/test/interop/fortran/multidimArray/ISO_Fortran_binding.chpl
@@ -1,0 +1,167 @@
+// generated from:
+// jupiter:/opt/intel/compilers_and_libraries_2019.0.117/linux/compiler/include/ISO_Fortran_binding.h
+module ISO_Fortran_binding {
+  require "ISO_Fortran_binding.h";
+
+
+  // #define'd integer literals:
+  // Note: some of these may have been defined with an ifdef
+  extern const CFI_attribute_pointer : int;
+  extern const CFI_attribute_allocatable : int;
+  extern const CFI_attribute_other : int;
+  extern const CFI__max_attribute : int;
+
+  extern const CFI_type_int8_t : int;
+  extern const CFI_type_int16_t : int;
+  extern const CFI_type_int32_t : int;
+  extern const CFI_type_int64_t : int;
+  extern const CFI_type_signed_char : int;
+  extern const CFI_type_short : int;
+  extern const CFI_type_int : int;
+  extern const CFI_type_long : int;
+  extern const CFI_type_long_long : int;
+  extern const CFI_type_size_t : int;
+
+  extern const CFI_type_int_least8_t : int;
+  extern const CFI_type_int_least16_t : int;
+  extern const CFI_type_int_least32_t : int;
+  extern const CFI_type_int_least64_t : int;
+  extern const CFI_type_int_fast8_t : int;
+  extern const CFI_type_int_fast16_t : int;
+  extern const CFI_type_int_fast32_t : int;
+  extern const CFI_type_int_fast64_t : int;
+  extern const CFI_type_intmax_t : int;
+  extern const CFI_type_intptr_t : int;
+  extern const CFI_type_ptrdiff_t : int;
+
+  extern const CFI_type_float : int;
+  extern const CFI_type_double : int;
+  extern const CFI_type_long_double : int;
+  extern const CFI_type_double_Complex : int;
+  extern const CFI_type_long_double_Complex : int;
+  extern const CFI_type_Bool : int;
+  extern const CFI_type_char : int;
+  extern const CFI_type_cptr : int;
+  extern const CFI_type_struct : int;
+  extern const CFI_type_other : int;
+  extern const CFI__max_type : int;
+
+  extern const CFI_SUCCESS : int;
+  extern const CFI_ERROR_BASE_ADDR_NULL : int;
+  extern const CFI_ERROR_BASE_ADDR_NOT_NULL : int;
+  extern const CFI_INVALID_ELEM_LEN : int;
+  extern const CFI_INVALID_RANK : int;
+  extern const CFI_INVALID_TYPE : int;
+  extern const CFI_INVALID_ATTRIBUTE : int;
+  extern const CFI_INVALID_EXTENT : int;
+  extern const CFI_INVALID_DESCRIPTOR : int;
+  extern const CFI_ERROR_MEM_ALLOCATION : int;
+  extern const CFI_ERROR_OUT_OF_BOUNDS : int;
+  extern const CFI_INTEL_INVALID_ARGUMENT : int;
+
+  extern const CFI_MAX_RANK : int;
+  extern const CFI_VERSION : int;
+  extern const CFI__VERSION_0001 : int;
+
+  // End of #define'd integer literals
+
+  inline proc CFI_address(ref dv: CFI_cdesc_t, subscripts: c_ptr(CFI_index_t)) {
+    return for_CFI_address(dv, subscripts);
+  }
+
+  pragma "no doc"
+  extern proc for_CFI_address(ref dv : CFI_cdesc_t, subscripts : c_ptr(CFI_index_t)) : c_void_ptr;
+
+  inline proc CFI_allocate(ref dv: CFI_cdesc_t, lower_bounds: c_ptr(CFI_index_t), upper_bounds: c_ptr(CFI_index_t), elem_len: size_t): c_int {
+    return for_CFI_allocate(dv, lower_bounds, upper_bounds, elem_len);
+  }
+
+  pragma "no doc"
+  extern proc for_CFI_allocate(ref dv : CFI_cdesc_t, lower_bounds : c_ptr(CFI_index_t), upper_bounds : c_ptr(CFI_index_t), elem_len : size_t) : c_int;
+
+  inline proc CFI_deallocate(ref dv: CFI_cdesc_t): c_int {
+    return for_CFI_deallocate(dv);
+  }
+
+  pragma "no doc"
+  extern proc for_CFI_deallocate(ref dv : CFI_cdesc_t) : c_int;
+
+  inline proc CFI_establish(ref dv: CFI_cdesc_t, base_addr: c_void_ptr, attribute: CFI_attribute_t, type_arg: CFI_type_t, elem_len: size_t, rank: CFI_rank_t, extents: c_ptr(CFI_index_t)): c_int {
+    return for_CFI_establish(dv, base_addr, attribute, type_arg, elem_len, rank, extents, CFI_VERSION);
+  }
+
+  pragma "no doc"
+  extern proc for_CFI_establish(ref dv : CFI_cdesc_t, base_addr : c_void_ptr, attribute : CFI_attribute_t, type_arg : CFI_type_t, elem_len : size_t, rank : CFI_rank_t, extents : c_ptr(CFI_index_t), version : c_int) : c_int;
+
+  inline proc CFI_is_contiguous(ref dv: CFI_cdesc_t): c_int {
+    return for_CFI_is_contiguous(dv);
+  }
+
+  pragma "no doc"
+  extern proc for_CFI_is_contiguous(ref dv : CFI_cdesc_t) : c_int;
+
+  inline proc CFI_section(ref result: CFI_cdesc_t, ref source: CFI_cdesc_t, lower_bounds: c_ptr(CFI_index_t), upper_bounds: c_ptr(CFI_index_t), strides: c_ptr(CFI_index_t)): c_int {
+    return for_CFI_section(result, source, lower_bounds, upper_bounds, strides);
+  }
+
+  pragma "no doc"
+  extern proc for_CFI_section(ref result : CFI_cdesc_t, ref source : CFI_cdesc_t, lower_bounds : c_ptr(CFI_index_t), upper_bounds : c_ptr(CFI_index_t), strides : c_ptr(CFI_index_t)) : c_int;
+
+  inline proc CFI_select_part(ref result: CFI_cdesc_t, ref source: CFI_cdesc_t, displacement: size_t, elem_len: size_t): c_int {
+    return for_CFI_select_part(result, source, displacement, elem_len);
+  }
+
+  pragma "no doc"
+  extern proc for_CFI_select_part(ref result : CFI_cdesc_t, ref source : CFI_cdesc_t, displacement : size_t, elem_len : size_t) : c_int;
+
+  inline proc CFI_setpointer(ref result: CFI_cdesc_t, ref source: CFI_cdesc_t, lower_bounds: c_ptr(CFI_index_t)): c_int {
+    return for_CFI_setpointer(result, source, lower_bounds);
+  }
+
+  pragma "no doc"
+  extern proc for_CFI_setpointer(ref result : CFI_cdesc_t, ref source : CFI_cdesc_t, lower_bounds : c_ptr(CFI_index_t)) : c_int;
+
+  // ==== c2chapel typedefs ====
+
+  extern type CFI_attribute_t = c_ptrdiff;
+
+  extern record CFI_cdesc_t {
+    var base_addr: c_void_ptr;
+    var elem_len: size_t;
+    var version: c_int;
+    var attribute: CFI_attribute_t;
+    var rank: CFI_rank_t;
+    //var type: CFI_type_t;
+    var intel_flags: c_intptr;
+    var intel_reserved1: c_intptr;
+    var intel_reserved2: c_intptr;
+    var dim: c_ptr(CFI_dim_t);
+  }
+/*
+  extern record CFI_CDESC_T {
+    param r: int;
+    var base_addr: c_void_ptr;
+    var elem_len: size_t;
+    var version: c_int;
+    var attribute: CFI_attribute_t;
+    var rank: CFI_rank_t;
+    //var type: CFI_type_t;
+    var intel_flags: c_intptr;
+    var intel_reserved1: c_intptr;
+    var intel_reserved2: c_intptr;
+    var dim: [0..#r] CFI_dim_t;
+  }
+*/
+
+  extern record CFI_dim_t {
+    var extent : CFI_index_t;
+    var sm : CFI_index_t;
+    var lower_bound : CFI_index_t;
+  }
+
+  extern type CFI_index_t = c_ptrdiff;
+
+  extern type CFI_rank_t = c_ptrdiff;
+
+  extern type CFI_type_t = c_ptrdiff;
+}

--- a/test/interop/fortran/multidimArray/ISO_Fortran_binding.chpl
+++ b/test/interop/fortran/multidimArray/ISO_Fortran_binding.chpl
@@ -57,7 +57,6 @@ module ISO_Fortran_binding {
   extern const CFI_INVALID_DESCRIPTOR : int;
   extern const CFI_ERROR_MEM_ALLOCATION : int;
   extern const CFI_ERROR_OUT_OF_BOUNDS : int;
-  extern const CFI_INTEL_INVALID_ARGUMENT : int;
 
   extern const CFI_MAX_RANK : int;
   extern const CFI_VERSION : int;
@@ -132,9 +131,6 @@ module ISO_Fortran_binding {
     var attribute: CFI_attribute_t;
     var rank: CFI_rank_t;
     //var type: CFI_type_t;
-    var intel_flags: c_intptr;
-    var intel_reserved1: c_intptr;
-    var intel_reserved2: c_intptr;
     var dim: c_ptr(CFI_dim_t);
   }
 /*
@@ -146,9 +142,6 @@ module ISO_Fortran_binding {
     var attribute: CFI_attribute_t;
     var rank: CFI_rank_t;
     //var type: CFI_type_t;
-    var intel_flags: c_intptr;
-    var intel_reserved1: c_intptr;
-    var intel_reserved2: c_intptr;
     var dim: [0..#r] CFI_dim_t;
   }
 */

--- a/test/interop/fortran/multidimArray/Makefile
+++ b/test/interop/fortran/multidimArray/Makefile
@@ -1,0 +1,22 @@
+CHPL=chpl
+FTN=ifort
+MODULENAME=chapelProcs
+MODULENAME_LOWER=$(shell echo $(MODULENAME) | tr '[:upper:]' '[:lower:]')
+# disable incompatible pointer warnings
+WARNINGS=-wd167
+UNDERSCORES=
+#UNDERSCORES=-fno-underscoring
+
+$(MODULENAME): $(MODULENAME_LOWER).mod lib/libchapelProcs.a passArrayToChapel.f90
+	$(FTN) passArrayToChapel.f90 -Llib -l$(MODULENAME) `$(CHPL_HOME)/util/config/compileline --libraries` -o chapelProcs $(UNDERSCORES)
+
+$(MODULENAME_LOWER).mod: lib/$(MODULENAME).f90
+	$(FTN) -c $(UNDERSCORES) lib/$(MODULENAME).f90
+
+lib/$(MODULENAME).f90: chapelProcs.chpl
+	$(CHPL) chapelProcs.chpl --library-fortran --ccflags=$(WARNINGS)
+
+lib/libchapelProcs.a: lib/$(MODULENAME).f90
+
+clean:
+	rm -rf $(MODULENAME) $(MODULENAME_LOWER).mod lib/ $(MODULENAME).o

--- a/test/interop/fortran/multidimArray/chapelProcs.chpl
+++ b/test/interop/fortran/multidimArray/chapelProcs.chpl
@@ -1,0 +1,53 @@
+use ISO_Fortran_binding;
+
+proc toChapelArray(ref A: CFI_cdesc_t, param rank = 1) {
+  assert(A.rank == rank);
+  var D: domain(rank);
+  var dims: rank*range;
+
+  for i in 0..#rank {
+    dims(i+1) = A.dim[i].lower_bound..A.dim[i].extent /* by A.dim[i].sm ? */;
+  }
+
+  D = {(...dims)};
+  var AA: [D] int; // getChplType(A.type);
+  return AA;
+}
+
+export proc chpl_library_init_ftn() {
+  extern proc chpl_library_init(argc: c_int, argv: c_ptr(c_ptr(c_char)));
+  var filename = c"fake";
+  chpl_library_init(1, c_ptrTo(filename): c_ptr(c_ptr(c_char)));;
+  chpl__init_chapelProcs();
+}
+
+proc CFI_cdesc_t.this(idx:int...?rank) ref {
+  assert(this.rank == rank);
+  var subscripts: [0..#rank] CFI_index_t;
+  for param i in 1..rank {
+    subscripts[i-1] = idx[i]: CFI_index_t;
+  }
+  var x = CFI_address(this, c_ptrTo(subscripts)): c_ptr(real);
+  return x.deref();
+}
+
+export proc takesArray(ref A: CFI_cdesc_t) {
+
+  assert(A.rank == 2);
+  // Here 'A.type' is supposed to mean the field named type in the CFI_cdesc_t
+  // record.  But 'type' is a keyword in Chapel so that field is commented out.
+  //assert(A.type == CFI_type_double);
+
+  for k in 0..#A.dim[1].extent {
+    for i in 0..#A.dim[0].extent {
+      A[i,k] = (i*100 + k):real;
+/*
+      var subscripts: [0..1] CFI_index_t;
+      subscripts[0] = i: CFI_index_t;
+      subscripts[1] = k: CFI_index_t;
+      var x: c_ptr(real) = CFI_address(A, c_ptrTo(subscripts)): c_ptr(real);
+      x.deref() = (i*100 + k):real;
+*/
+    }
+  }
+}

--- a/test/interop/fortran/multidimArray/chapelProcs.compopts
+++ b/test/interop/fortran/multidimArray/chapelProcs.compopts
@@ -1,0 +1,1 @@
+--library-fortran --ccflags=-wd167

--- a/test/interop/fortran/multidimArray/chapelProcs.good
+++ b/test/interop/fortran/multidimArray/chapelProcs.good
@@ -1,6 +1,6 @@
-chapelProcs.chpl:34: In function 'takesArray':
-chapelProcs.chpl:34: warning: Unknown Fortran KIND generating interface for C type: _ref_CFI_cdesc_t
-chapelProcs.chpl:34: warning: Unknown Fortran type generating interface for C type: _ref_CFI_cdesc_t
+chapelProcs.chpl:29: In function 'takesArray':
+chapelProcs.chpl:29: warning: Unknown Fortran KIND generating interface for C type: _ref_CFI_cdesc_t
+chapelProcs.chpl:29: warning: Unknown Fortran type generating interface for C type: _ref_CFI_cdesc_t
   0.000000000000000E+000   100.000000000000        200.000000000000     
    1.00000000000000        101.000000000000        201.000000000000     
    2.00000000000000        102.000000000000        202.000000000000     

--- a/test/interop/fortran/multidimArray/chapelProcs.good
+++ b/test/interop/fortran/multidimArray/chapelProcs.good
@@ -1,0 +1,6 @@
+chapelProcs.chpl:34: In function 'takesArray':
+chapelProcs.chpl:34: warning: Unknown Fortran KIND generating interface for C type: _ref_CFI_cdesc_t
+chapelProcs.chpl:34: warning: Unknown Fortran type generating interface for C type: _ref_CFI_cdesc_t
+  0.000000000000000E+000   100.000000000000        200.000000000000     
+   1.00000000000000        101.000000000000        201.000000000000     
+   2.00000000000000        102.000000000000        202.000000000000     

--- a/test/interop/fortran/multidimArray/chapelProcs.prediff
+++ b/test/interop/fortran/multidimArray/chapelProcs.prediff
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+make clean

--- a/test/interop/fortran/multidimArray/chapelProcs.preexec
+++ b/test/interop/fortran/multidimArray/chapelProcs.preexec
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+make

--- a/test/interop/fortran/multidimArray/chapelProcs.skipif
+++ b/test/interop/fortran/multidimArray/chapelProcs.skipif
@@ -1,0 +1,1 @@
+CHPL_TARGET_COMPILER != cray-prgenv-intel

--- a/test/interop/fortran/multidimArray/passArrayToChapel.f90
+++ b/test/interop/fortran/multidimArray/passArrayToChapel.f90
@@ -1,0 +1,10 @@
+program PassArray
+  use chapelProcs
+  real(kind=8), dimension (3,3) :: arr
+
+  call chpl_library_init_ftn()
+  call takesArray(arr)
+
+  print *, arr
+
+end program PassArray


### PR DESCRIPTION
Add an extern interface for ISO_Fortran_binding.h using c2chapel + hand
conversion. The interface was generated from Intel's version of
ISO_Fortran_binding.h. Add a test that uses the new extern interface to pass
a multidimensional array from Fortran to Chapel and write values to it in
the Chapel procedure. The test is only run for PrgEnv-intel.

Update the --library-fortran code to handle the Fortran array record
specially and generate an array declaration for it in the Fortran interface
module.