### PR TITLE
Fix replaceRuntimePrimInit internal failure after #11668

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -9337,7 +9337,7 @@ static void replaceRuntimeTypeGetField(CallExpr* call) {
 static void replaceRuntimeTypePrims(std::vector<BaseAST*>& asts) {
   for_vector(BaseAST, ast, asts) {
     if (CallExpr* call = toCallExpr(ast)) {
-      FnSymbol* parent = call->getFunction();
+      FnSymbol* parent = isAlive(call) ? call->getFunction() : NULL;
 
       // Call must be in the tree and lie in a resolved function.
       if (! parent || ! parent->isResolved()) {


### PR DESCRIPTION
For whatever reason, PR #11668 changed the AST such that replaceRuntimeTypePrims operated on a removed CallExpr, resulting in an internal error. This PR sidesteps the issue by checking whether the call is alive before using it.

Tested on ``types/records/with-runtime-types.chpl``, the lone failing test.