### PR TITLE
Silence spurious gcc 8.x warnings about alloc-size

### DIFF
--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -178,7 +178,7 @@ endif
 # The string overflow false positives occur in runtime code unlike gcc 7.
 #
 ifeq ($(shell test $(GNU_GPP_MAJOR_VERSION) -eq 8; echo "$$?"),0)
-WARN_CXXFLAGS += -Wno-class-memaccess
+WARN_CXXFLAGS += -Wno-class-memaccess -Walloc-size-larger-than=18446744073709551615
 RUNTIME_CFLAGS += -Wno-stringop-overflow
 endif
 


### PR DESCRIPTION
Gcc 8 adds new checks to make sure allocation sizes are not too large.  Unfortunately, they are currently buggy and cause false positive warning messages (which we turn into errors with `-Werror`).  The gcc bug that is triggered by Chapel compiler source code appears to be related to the following, which is being worked on for gcc 9.

https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85783

The only way to turn off the warning currently is to set the maximum alloc size to an integer value equal to at least SIZE_MAX.  (That is another gcc bug that is being addressed for gcc 9.)  This change sets it to the maximum unsigned 64-bit value.