### PR TITLE
Fix a use-after-delete issue in --library-fortran

### DIFF
--- a/compiler/codegen/symbol.cpp
+++ b/compiler/codegen/symbol.cpp
@@ -1944,15 +1944,16 @@ void FnSymbol::codegenFortran(int indent) {
       const char* prefix = formal->cname[0] == '_' ? "chpl" : "";
       const bool isRef = formal->intent & INTENT_FLAG_REF;
       const char* valueString = isRef ? "" : ", value";
-      const char* typeName = getFortranTypeName(formal->type, formal).c_str();
-      const char* kindName = getFortranKindName(formal->type, formal).c_str();
+      std::string typeName = getFortranTypeName(formal->type, formal);
+      std::string kindName = getFortranKindName(formal->type, formal);
 
       // declare arrays specially instead of just using the record type
-      if (!strcmp(kindName, "_ref_CFI_cdesc_t")) {
+      if (kindName == "_ref_CFI_cdesc_t") {
         fprintf(outfile, "%*sTYPE(*) :: %s(..)\n", indent, "", formal->cname);
       } else {
-        fprintf(outfile, "%*s%s(kind=%s)%s :: %s%s\n", indent, "", typeName,
-                kindName, valueString, prefix, formal->cname);
+        fprintf(outfile, "%*s%s(kind=%s)%s :: %s%s\n", indent, "",
+                typeName.c_str(), kindName.c_str(),
+                valueString, prefix, formal->cname);
       }
     }
 


### PR DESCRIPTION
@mppf ran into a problem with a --library-fortran test and helped debug it.

std::string.c_str() is a temporary and is freed at the end of the statement
it is used in, so can't be used after.