### PR TITLE
Fix chplenv/overrides.py main()

### DIFF
--- a/util/chplenv/chpl_aux_filesys.py
+++ b/util/chplenv/chpl_aux_filesys.py
@@ -2,13 +2,13 @@
 import sys
 import os
 from glob import glob
-from sys import stderr, stdout
 
 chplenv_dir = os.path.dirname(__file__)
 sys.path.insert(0, os.path.abspath(chplenv_dir))
 
 import overrides
 from utils import memoize
+
 
 @memoize
 def get():
@@ -25,9 +25,9 @@ def get():
         found_hdfs_lib = os.path.exists(os.path.join(aux_fs_subdir, 'lib',
                                                  'native', 'libhdfs.a'))
         if not found_java:
-            stderr.write("Warning: Can't find your Java installation\n")
+            sys.stderr.write("Warning: Can't find your Java installation\n")
         if not found_hdfs or not found_hdfs_lib:
-            stderr.write("Warning: Can't find your Hadoop installation\n")
+            sys.stderr.write("Warning: Can't find your Hadoop installation\n")
 
     elif aux_fs == 'hdfs3':
         def fetchInfo(env, envtype, filename, err):
@@ -48,7 +48,7 @@ def get():
 
 def _main():
     aux_fs_val = get()
-    stdout.write("{0}\n".format(aux_fs_val))
+    sys.stdout.write("{0}\n".format(aux_fs_val))
 
 
 if __name__ == '__main__':

--- a/util/chplenv/chpl_compiler.py
+++ b/util/chplenv/chpl_compiler.py
@@ -4,14 +4,12 @@ import os
 import sys
 
 from distutils.spawn import find_executable
-from sys import stderr, stdout
 
 chplenv_dir = os.path.dirname(__file__)
 sys.path.insert(0, os.path.abspath(chplenv_dir))
 
 import chpl_platform, overrides
 from utils import error, memoize
-
 
 
 @memoize
@@ -43,7 +41,7 @@ def get(flag='host', llvm_mode='default'):
         else:
             subcompiler = os.environ.get('PE_ENV', 'none')
             if subcompiler == 'none':
-                stderr.write("Warning: Compiling on {0} without a PrgEnv loaded\n".format(platform_val))
+                sys.stderr.write("Warning: Compiling on {0} without a PrgEnv loaded\n".format(platform_val))
             compiler_val = "cray-prgenv-{0}".format(subcompiler.lower())
     elif chpl_platform.is_cross_compiling():
         if flag == 'host':
@@ -78,7 +76,7 @@ def _main():
     (options, args) = parser.parse_args()
 
     compiler_val = get(options.flag)
-    stdout.write("{0}\n".format(compiler_val))
+    sys.stdout.write("{0}\n".format(compiler_val))
 
 
 if __name__ == '__main__':

--- a/util/chplenv/chpl_hwloc.py
+++ b/util/chplenv/chpl_hwloc.py
@@ -9,7 +9,6 @@ import chpl_tasks, overrides
 from utils import memoize
 
 
-
 @memoize
 def get():
     hwloc_val = overrides.get('CHPL_HWLOC')

--- a/util/chplenv/chpl_jemalloc.py
+++ b/util/chplenv/chpl_jemalloc.py
@@ -9,7 +9,6 @@ import chpl_mem, overrides
 from utils import error, memoize
 
 
-
 @memoize
 def get():
     jemalloc_val = overrides.get('CHPL_JEMALLOC')

--- a/util/chplenv/chpl_launcher.py
+++ b/util/chplenv/chpl_launcher.py
@@ -6,9 +6,8 @@ import sys
 chplenv_dir = os.path.dirname(__file__)
 sys.path.insert(0, os.path.abspath(chplenv_dir))
 
-import chpl_comm, chpl_comm_substrate, chpl_compiler, chpl_platform, overrides
+import chpl_comm, chpl_comm_substrate, chpl_platform, overrides
 from utils import memoize
-
 
 
 @memoize
@@ -17,7 +16,6 @@ def get():
     if not launcher_val:
         comm_val = chpl_comm.get()
         platform_val = chpl_platform.get('target')
-        compiler_val = chpl_compiler.get('target')
 
         if platform_val.startswith('cray-x') or chpl_platform.is_cross_compiling():
             has_aprun = find_executable('aprun')

--- a/util/chplenv/chpl_lib_pic.py
+++ b/util/chplenv/chpl_lib_pic.py
@@ -8,6 +8,7 @@ sys.path.insert(0, os.path.abspath(chplenv_dir))
 import overrides
 from utils import memoize
 
+
 @memoize
 def get():
     lib_pic_val = overrides.get('CHPL_LIB_PIC')

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -48,7 +48,5 @@ def _main():
       sys.stdout.write("{0}\n".format(llvm_val))
 
 
-
-
 if __name__ == '__main__':
     _main()

--- a/util/chplenv/chpl_platform.py
+++ b/util/chplenv/chpl_platform.py
@@ -11,6 +11,7 @@ sys.path.insert(0, os.path.abspath(chplenv_dir))
 import overrides, utils
 from utils import error, memoize
 
+
 @memoize
 def get(flag='host'):
     if flag == 'host':
@@ -74,9 +75,11 @@ def get(flag='host'):
 
     return platform_val
 
+
 @memoize
 def is_cross_compiling():
     return get('host') != get('target')
+
 
 def _main():
     parser = optparse.OptionParser(usage='usage: %prog [--host|target])')

--- a/util/chplenv/chpl_tasks.py
+++ b/util/chplenv/chpl_tasks.py
@@ -10,6 +10,7 @@ from chpl_home_utils import using_chapel_module
 from compiler_utils import CompVersion, get_compiler_version
 from utils import memoize
 
+
 @memoize
 def get():
     tasks_val = overrides.get('CHPL_TASKS')

--- a/util/chplenv/chpl_unwind.py
+++ b/util/chplenv/chpl_unwind.py
@@ -8,6 +8,7 @@ sys.path.insert(0, os.path.abspath(chplenv_dir))
 import chpl_platform, overrides
 from utils import error, memoize
 
+
 @memoize
 def get():
     platform_val = chpl_platform.get('target')
@@ -27,6 +28,7 @@ def get():
         elif val == 'system':
             return 'system'
     return 'none'
+
 
 def _main():
     unwind_val = get()

--- a/util/chplenv/overrides.py
+++ b/util/chplenv/overrides.py
@@ -219,9 +219,8 @@ def items():
 
 def _main():
     """ Print overrides that are currently set via environment/chplconfig """
-    for var in allvars():
-        sys.stdout.write(var)
-        sys.stdout.write('\n')
+    for key, val in items():
+        sys.stdout.write('{0}={1}\n'.format(key, val))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This has been broken since d878236968, but it's not used by any current
scripts so we never noticed.

While there make some minor cleanups to chplenv scripts. Unify some spacing,
use fully qualified sys.stdout.write in places where it makes sense, and remove
an unused compiler import.