### PR TITLE
Fix stderr.write in chplenv/chpl_aux_filesys.py

### DIFF
--- a/util/chplenv/chpl_aux_filesys.py
+++ b/util/chplenv/chpl_aux_filesys.py
@@ -35,7 +35,7 @@ def get():
             res = sum([ os.path.exists(os.path.join(d, filename)) for d in directories ])
 
             if res < 1:
-                stderr.write(err)
+                sys.stderr.write(err)
                 return False
 
             return True


### PR DESCRIPTION
Wasn't fully qualified, and sys.stderr wasn't being imported.