### PR TITLE
Increase buffer size found too small by gcc 8.2

### DIFF
--- a/compiler/passes/addInitGuards.cpp
+++ b/compiler/passes/addInitGuards.cpp
@@ -212,7 +212,7 @@ static void addPrintModInitOrder(FnSymbol* fn)
   const char* s1 = astr("%*s\\n");
   const char* s2 = astr(fn->getModule()->name);
   int myLen = strlen(s2);
-  char lenStr[15];
+  char lenStr[25];
   sprintf(lenStr, "%d", myLen);
   Expr *es1 = buildCStringLiteral(s1);
   Expr *es2 = buildCStringLiteral(s2);

--- a/compiler/passes/addInitGuards.cpp
+++ b/compiler/passes/addInitGuards.cpp
@@ -212,7 +212,7 @@ static void addPrintModInitOrder(FnSymbol* fn)
   const char* s1 = astr("%*s\\n");
   const char* s2 = astr(fn->getModule()->name);
   int myLen = strlen(s2);
-  char lenStr[5];
+  char lenStr[15];
   sprintf(lenStr, "%d", myLen);
   Expr *es1 = buildCStringLiteral(s1);
   Expr *es2 = buildCStringLiteral(s2);


### PR DESCRIPTION
Gcc 8.2 complains that a buffer in `compiler/passes/addInitGuards.cpp` needs to hold at least 11 bytes of results, but is only declared 5 bytes long.  This change increases the size of the buffer.

Oddly, only the 32-bit version of gcc 8.2 complained.  I do not know why.
