### PR TITLE
Change runtime comm atomics interface "get/put" to "read/write".

### DIFF
--- a/modules/internal/NetworkAtomics.chpl
+++ b/modules/internal/NetworkAtomics.chpl
@@ -42,19 +42,19 @@ module NetworkAtomics {
 
     inline proc const read(order:memory_order = memory_order_seq_cst): bool {
       pragma "insert line file info" extern externFunc("read", int(64))
-        proc atomic_get(ref result:int(64), l:int(32), const obj:c_void_ptr): void;
+        proc atomic_read(ref result:int(64), l:int(32), const obj:c_void_ptr): void;
 
       var ret: int(64);
-      atomic_get(ret, _localeid(), _addr());
+      atomic_read(ret, _localeid(), _addr());
       return ret:bool;
     }
 
     inline proc write(value:bool, order:memory_order = memory_order_seq_cst): void {
       pragma "insert line file info" extern externFunc("write", int(64))
-        proc atomic_put(ref desired:int(64), l:int(32), obj:c_void_ptr): void;
+        proc atomic_write(ref desired:int(64), l:int(32), obj:c_void_ptr): void;
 
       var v = value:int(64);
-      atomic_put(v, _localeid(), _addr());
+      atomic_write(v, _localeid(), _addr());
     }
 
     inline proc exchange(value:bool, order:memory_order = memory_order_seq_cst): bool {
@@ -132,19 +132,19 @@ module NetworkAtomics {
 
     inline proc const read(order:memory_order = memory_order_seq_cst): T {
       pragma "insert line file info" extern externFunc("read", T)
-        proc atomic_get(ref result:T, l:int(32), const obj:c_void_ptr): void;
+        proc atomic_read(ref result:T, l:int(32), const obj:c_void_ptr): void;
 
       var ret:T;
-      atomic_get(ret, _localeid(), _addr());
+      atomic_read(ret, _localeid(), _addr());
       return ret;
     }
 
     inline proc write(value:T, order:memory_order = memory_order_seq_cst): void {
       pragma "insert line file info" extern externFunc("write", T)
-        proc atomic_put(ref desired:T, l:int(32), obj:c_void_ptr): void;
+        proc atomic_write(ref desired:T, l:int(32), obj:c_void_ptr): void;
 
       var v = value;
-      atomic_put(v, _localeid(), _addr());
+      atomic_write(v, _localeid(), _addr());
     }
 
     inline proc exchange(value:T, order:memory_order = memory_order_seq_cst): T {

--- a/modules/internal/NetworkAtomics.chpl
+++ b/modules/internal/NetworkAtomics.chpl
@@ -41,7 +41,7 @@ module NetworkAtomics {
     }
 
     inline proc const read(order:memory_order = memory_order_seq_cst): bool {
-      pragma "insert line file info" extern externFunc("get", int(64))
+      pragma "insert line file info" extern externFunc("read", int(64))
         proc atomic_get(ref result:int(64), l:int(32), const obj:c_void_ptr): void;
 
       var ret: int(64);
@@ -50,7 +50,7 @@ module NetworkAtomics {
     }
 
     inline proc write(value:bool, order:memory_order = memory_order_seq_cst): void {
-      pragma "insert line file info" extern externFunc("put", int(64))
+      pragma "insert line file info" extern externFunc("write", int(64))
         proc atomic_put(ref desired:int(64), l:int(32), obj:c_void_ptr): void;
 
       var v = value:int(64);
@@ -131,7 +131,7 @@ module NetworkAtomics {
     }
 
     inline proc const read(order:memory_order = memory_order_seq_cst): T {
-      pragma "insert line file info" extern externFunc("get", T)
+      pragma "insert line file info" extern externFunc("read", T)
         proc atomic_get(ref result:T, l:int(32), const obj:c_void_ptr): void;
 
       var ret:T;
@@ -140,7 +140,7 @@ module NetworkAtomics {
     }
 
     inline proc write(value:T, order:memory_order = memory_order_seq_cst): void {
-      pragma "insert line file info" extern externFunc("put", T)
+      pragma "insert line file info" extern externFunc("write", T)
         proc atomic_put(ref desired:T, l:int(32), obj:c_void_ptr): void;
 
       var v = value;

--- a/runtime/include/chpl-comm-native-atomics.h
+++ b/runtime/include/chpl-comm-native-atomics.h
@@ -31,42 +31,42 @@
 //
 
 //
-// Do a remote atomic store.  The value to be stored is *desired on the
-// local node.  The target location to be stored into is *object on the
-// given node.  This differs from a regular chpl_comm_put() in that it
-// is coherent with other chpl_comm_atomic_*() operations (but may incur
-// network overhead) even if the target is the calling node.
+// Do a remote atomic write.  The value to be written is *desired on the
+// local node.  The target location to be written into is *object on the
+// given node.  This differs from chpl_comm_put() in that it is coherent
+// with other chpl_comm_atomic_*() operations (but may incur network
+// overhead) even if the target is the calling node.
 //
-#define DECL_CHPL_COMM_ATOMIC_PUT(type)                                 \
-  void chpl_comm_atomic_put_ ## type                                    \
+#define DECL_CHPL_COMM_ATOMIC_WRITE(type)                               \
+  void chpl_comm_atomic_write_ ## type                                  \
          (void* desired, c_nodeid_t node, void* object,                 \
           int ln, int32_t fn);
 
-DECL_CHPL_COMM_ATOMIC_PUT(int32)
-DECL_CHPL_COMM_ATOMIC_PUT(int64)
-DECL_CHPL_COMM_ATOMIC_PUT(uint32)
-DECL_CHPL_COMM_ATOMIC_PUT(uint64)
-DECL_CHPL_COMM_ATOMIC_PUT(real32)
-DECL_CHPL_COMM_ATOMIC_PUT(real64)
+DECL_CHPL_COMM_ATOMIC_WRITE(int32)
+DECL_CHPL_COMM_ATOMIC_WRITE(int64)
+DECL_CHPL_COMM_ATOMIC_WRITE(uint32)
+DECL_CHPL_COMM_ATOMIC_WRITE(uint64)
+DECL_CHPL_COMM_ATOMIC_WRITE(real32)
+DECL_CHPL_COMM_ATOMIC_WRITE(real64)
 
 //
-// Do a remote atomic load.  The source location is *object on the
+// Do a remote atomic read.  The source location is *object on the
 // given node.  The value is returned in *result on the local node.
-// This differs from a regular chpl_comm_get() in that it is coherent
-// with other chpl_comm_atomic_*() operations (but may incur network
+// This differs from chpl_comm_get() in that it is coherent with
+// other chpl_comm_atomic_*() operations (but may incur network
 // overhead) even if the source is the calling node.
 //
-#define DECL_CHPL_COMM_ATOMIC_GET(type)                                 \
-  void chpl_comm_atomic_get_ ## type                                    \
+#define DECL_CHPL_COMM_ATOMIC_READ(type)                                \
+  void chpl_comm_atomic_read_ ## type                                   \
          (void* result, c_nodeid_t node, void* object,                  \
           int ln, int32_t fn);
 
-DECL_CHPL_COMM_ATOMIC_GET(int32)
-DECL_CHPL_COMM_ATOMIC_GET(int64)
-DECL_CHPL_COMM_ATOMIC_GET(uint32)
-DECL_CHPL_COMM_ATOMIC_GET(uint64)
-DECL_CHPL_COMM_ATOMIC_GET(real32)
-DECL_CHPL_COMM_ATOMIC_GET(real64)
+DECL_CHPL_COMM_ATOMIC_READ(int32)
+DECL_CHPL_COMM_ATOMIC_READ(int64)
+DECL_CHPL_COMM_ATOMIC_READ(uint32)
+DECL_CHPL_COMM_ATOMIC_READ(uint64)
+DECL_CHPL_COMM_ATOMIC_READ(real32)
+DECL_CHPL_COMM_ATOMIC_READ(real64)
 
 //
 // Do a remote atomic exchange.  The value to be stored is *desired on

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -2104,49 +2104,49 @@ static inline void doAMO(c_nodeid_t, void*, const void*, const void*, void*,
 
 
 //
-// PUT
+// WRITE
 //
-#define DEFN_CHPL_COMM_ATOMIC_PUT(fnType, ofiType, Type)                \
-  void chpl_comm_atomic_put_##fnType                                    \
+#define DEFN_CHPL_COMM_ATOMIC_WRITE(fnType, ofiType, Type)              \
+  void chpl_comm_atomic_write_##fnType                                  \
          (void* desired, c_nodeid_t node, void* object,                 \
           int ln, int32_t fn) {                                         \
     DBG_PRINTF(DBG_INTERFACE,                                           \
-               "chpl_comm_atomic_put_%s(%p, %d, %p, %d, %s)",           \
+               "chpl_comm_atomic_write_%s(%p, %d, %p, %d, %s)",         \
                #fnType, desired, (int) node, object,                    \
                ln, chpl_lookupFilename(fn));                            \
     doAMO(node, object, desired, NULL, NULL,                            \
           FI_ATOMIC_WRITE, ofiType, sizeof(Type));                      \
   }
 
-DEFN_CHPL_COMM_ATOMIC_PUT(int32, FI_INT32, int32_t)
-DEFN_CHPL_COMM_ATOMIC_PUT(int64, FI_INT64, int64_t)
-DEFN_CHPL_COMM_ATOMIC_PUT(uint32, FI_UINT32, uint32_t)
-DEFN_CHPL_COMM_ATOMIC_PUT(uint64, FI_UINT64, uint64_t)
-DEFN_CHPL_COMM_ATOMIC_PUT(real32, FI_FLOAT, float)
-DEFN_CHPL_COMM_ATOMIC_PUT(real64, FI_DOUBLE, double)
+DEFN_CHPL_COMM_ATOMIC_WRITE(int32, FI_INT32, int32_t)
+DEFN_CHPL_COMM_ATOMIC_WRITE(int64, FI_INT64, int64_t)
+DEFN_CHPL_COMM_ATOMIC_WRITE(uint32, FI_UINT32, uint32_t)
+DEFN_CHPL_COMM_ATOMIC_WRITE(uint64, FI_UINT64, uint64_t)
+DEFN_CHPL_COMM_ATOMIC_WRITE(real32, FI_FLOAT, float)
+DEFN_CHPL_COMM_ATOMIC_WRITE(real64, FI_DOUBLE, double)
 
 
 //
-// GET
+// READ
 //
-#define DEFN_CHPL_COMM_ATOMIC_GET(fnType, ofiType, Type)                \
-  void chpl_comm_atomic_get_##fnType                                    \
+#define DEFN_CHPL_COMM_ATOMIC_READ(fnType, ofiType, Type)               \
+  void chpl_comm_atomic_read_##fnType                                   \
          (void* result, c_nodeid_t node, void* object,                  \
           int ln, int32_t fn) {                                         \
     DBG_PRINTF(DBG_INTERFACE,                                           \
-               "chpl_comm_atomic_get_%s(%p, %d, %p, %d, %s)",           \
+               "chpl_comm_atomic_read_%s(%p, %d, %p, %d, %s)",          \
                #fnType, result, (int) node, object,                     \
                ln, chpl_lookupFilename(fn));                            \
     doAMO(node, object, NULL, NULL, result,                             \
           FI_ATOMIC_READ, ofiType, sizeof(Type));                       \
   }
 
-DEFN_CHPL_COMM_ATOMIC_GET(int32, FI_INT32, int32_t)
-DEFN_CHPL_COMM_ATOMIC_GET(int64, FI_INT64, int64_t)
-DEFN_CHPL_COMM_ATOMIC_GET(uint32, FI_UINT32, uint32_t)
-DEFN_CHPL_COMM_ATOMIC_GET(uint64, FI_UINT64, uint64_t)
-DEFN_CHPL_COMM_ATOMIC_GET(real32, FI_FLOAT, float)
-DEFN_CHPL_COMM_ATOMIC_GET(real64, FI_DOUBLE, double)
+DEFN_CHPL_COMM_ATOMIC_READ(int32, FI_INT32, int32_t)
+DEFN_CHPL_COMM_ATOMIC_READ(int64, FI_INT64, int64_t)
+DEFN_CHPL_COMM_ATOMIC_READ(uint32, FI_UINT32, uint32_t)
+DEFN_CHPL_COMM_ATOMIC_READ(uint64, FI_UINT64, uint64_t)
+DEFN_CHPL_COMM_ATOMIC_READ(real32, FI_FLOAT, float)
+DEFN_CHPL_COMM_ATOMIC_READ(real64, FI_DOUBLE, double)
 
 
 #define DEFN_CHPL_COMM_ATOMIC_XCHG(fnType, ofiType, Type)               \

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -4140,7 +4140,7 @@ size_t do_amo_on_cpu(fork_amo_cmd_t cmd,
   // Here we implement AMOs which the NIC cannot do, either because
   // the target object is not in registered memory or because the NIC
   // lacks native support.  For more information, see the comment
-  // before chpl_comm_atomic_put_int32().
+  // before chpl_comm_atomic_store_int32().
   //
   switch (cmd) {
   case put_32:
@@ -6290,23 +6290,23 @@ int chpl_comm_addr_gettable(c_nodeid_t node, void* start, size_t len)
   }
 
 //
-// Atomic Put functions:
+// Atomic Write functions:
 //   _f: interface function name suffix (type)
 //   _c: network AMO command
 //   _t: AMO type
 //
-#define DEFINE_CHPL_COMM_ATOMIC_PUT(_f, _c, _t)                         \
+#define DEFINE_CHPL_COMM_ATOMIC_WRITE(_f, _c, _t)                       \
         DEFINE_DO_FORK_AMO(_f, _c, _t)                                  \
                                                                         \
         /*==============================*/                              \
-        void chpl_comm_atomic_put_##_f(void* val,                       \
+        void chpl_comm_atomic_write_##_f(void* val,                     \
                                        int32_t loc,                     \
                                        void* obj,                       \
                                        int ln, int32_t fn)              \
         {                                                               \
           mem_region_t* remote_mr;                                      \
           DBG_P_LP(DBGF_IFACE|DBGF_AMO,                                 \
-                   "IFACE chpl_comm_atomic_put_"#_f"(%p, %d, %p)",      \
+                   "IFACE chpl_comm_atomic_write_"#_f"(%p, %d, %p)",    \
                    val, (int) loc, obj);                                \
                                                                         \
           if (chpl_numNodes == 1) {                                     \
@@ -6341,27 +6341,27 @@ int chpl_comm_addr_gettable(c_nodeid_t node, void* start, size_t len)
           }                                                             \
         }
 
-DEFINE_CHPL_COMM_ATOMIC_PUT(int32, put_32, int_least32_t)
-DEFINE_CHPL_COMM_ATOMIC_PUT(int64, put_64, int_least64_t)
-DEFINE_CHPL_COMM_ATOMIC_PUT(uint32, put_32, uint_least32_t)
-DEFINE_CHPL_COMM_ATOMIC_PUT(uint64, put_64, uint_least64_t)
-DEFINE_CHPL_COMM_ATOMIC_PUT(real32, put_32, int_least32_t)
-DEFINE_CHPL_COMM_ATOMIC_PUT(real64, put_64, int_least64_t)
+DEFINE_CHPL_COMM_ATOMIC_WRITE(int32, put_32, int_least32_t)
+DEFINE_CHPL_COMM_ATOMIC_WRITE(int64, put_64, int_least64_t)
+DEFINE_CHPL_COMM_ATOMIC_WRITE(uint32, put_32, uint_least32_t)
+DEFINE_CHPL_COMM_ATOMIC_WRITE(uint64, put_64, uint_least64_t)
+DEFINE_CHPL_COMM_ATOMIC_WRITE(real32, put_32, int_least32_t)
+DEFINE_CHPL_COMM_ATOMIC_WRITE(real64, put_64, int_least64_t)
 
-#undef DEFINE_CHPL_COMM_ATOMIC_PUT
+#undef DEFINE_CHPL_COMM_ATOMIC_WRITE
 
 
 //
-// Atomic Get functions:
+// Atomic Read functions:
 //   _f: interface function name suffix (type)
 //   _c: network AMO command
 //   _t: AMO type
 //
-#define DEFINE_CHPL_COMM_ATOMIC_GET(_f, _c, _t)                         \
+#define DEFINE_CHPL_COMM_ATOMIC_READ(_f, _c, _t)                        \
         DEFINE_DO_FORK_AMO(_f, _c, _t)                                  \
                                                                         \
         /*==============================*/                              \
-        void chpl_comm_atomic_get_##_f(void* res,                       \
+        void chpl_comm_atomic_read_##_f(void* res,                      \
                                        int32_t loc,                     \
                                        void* obj,                       \
                                        int ln, int32_t fn)              \
@@ -6369,7 +6369,7 @@ DEFINE_CHPL_COMM_ATOMIC_PUT(real64, put_64, int_least64_t)
           mem_region_t* remote_mr;                                      \
           mem_region_t* local_mr;                                       \
           DBG_P_LP(DBGF_IFACE|DBGF_AMO,                                 \
-                   "IFACE chpl_comm_atomic_get_"#_f"(%p, %d, %p)",      \
+                   "IFACE chpl_comm_atomic_read_"#_f"(%p, %d, %p)",     \
                    res, (int) loc, obj);                                \
                                                                         \
           if (chpl_numNodes == 1) {                                     \
@@ -6393,14 +6393,14 @@ DEFINE_CHPL_COMM_ATOMIC_PUT(real64, put_64, int_least64_t)
           }                                                             \
         }
 
-DEFINE_CHPL_COMM_ATOMIC_GET(int32, get_32, int_least32_t)
-DEFINE_CHPL_COMM_ATOMIC_GET(int64, get_64, int_least64_t)
-DEFINE_CHPL_COMM_ATOMIC_GET(uint32, get_32, uint_least32_t)
-DEFINE_CHPL_COMM_ATOMIC_GET(uint64, get_64, uint_least64_t)
-DEFINE_CHPL_COMM_ATOMIC_GET(real32, get_32, int_least32_t)
-DEFINE_CHPL_COMM_ATOMIC_GET(real64, get_64, int_least64_t)
+DEFINE_CHPL_COMM_ATOMIC_READ(int32, get_32, int_least32_t)
+DEFINE_CHPL_COMM_ATOMIC_READ(int64, get_64, int_least64_t)
+DEFINE_CHPL_COMM_ATOMIC_READ(uint32, get_32, uint_least32_t)
+DEFINE_CHPL_COMM_ATOMIC_READ(uint64, get_64, uint_least64_t)
+DEFINE_CHPL_COMM_ATOMIC_READ(real32, get_32, int_least32_t)
+DEFINE_CHPL_COMM_ATOMIC_READ(real64, get_64, int_least64_t)
 
-#undef DEFINE_CHPL_COMM_ATOMIC_GET
+#undef DEFINE_CHPL_COMM_ATOMIC_READ
 
 
 //


### PR DESCRIPTION
Reduce interface inconsistency: Change to "get" to "read" and "put" to
"write" in the function names for the runtime comm atomics.  GET and PUT
are Gemini/Aries/GNI names, but we use read and write in the `Atomics` and
`NetworkAtomics` modules and for sync and single variables.

This resolves #11653.