### PR TITLE
Improve python 3 support for test scripts

### DIFF
--- a/test/compflags/ferguson/default-binary-name/sub_test
+++ b/test/compflags/ferguson/default-binary-name/sub_test
@@ -5,7 +5,7 @@ import sys
 import os
 
 if len(sys.argv)!=2:
-  print 'usage: sub_test COMPILER'
+  print('usage: sub_test COMPILER')
   sys.exit(0)
 
 home = ""
@@ -18,7 +18,7 @@ if "CHPL_TARGET_PLATFORM" in os.environ:
 else:
   p = subprocess.Popen([home + "/util/chplenv/chpl_platform.py", "--target"],
                         stdout=subprocess.PIPE)
-  myoutput = p.communicate()[0]
+  myoutput = p.communicate()[0].decode()
   if p.returncode != 0:
     sys.stdout.write("could not run chpl_platform.py")
     sys.exit(1)
@@ -40,7 +40,7 @@ if not os.access(compiler,os.R_OK|os.X_OK):
 def run(source, exe_name, compopts, expect): 
   p = subprocess.Popen([compiler, source] + compopts,
                        stdout=subprocess.PIPE)
-  myoutput = p.communicate()[0]
+  myoutput = p.communicate()[0].decode()
   sys.stdout.write(myoutput)
   if p.returncode != 0:
     sys.stdout.write("[Error matching compiler output for %s (%s)]\n"%(source, exe_name))
@@ -63,7 +63,7 @@ def run(source, exe_name, compopts, expect):
       p = subprocess.Popen(["./%s" % exe_name, "-nl%s" % numlocales],
           stdout=subprocess.PIPE)
 
-    myoutput = p.communicate()[0]
+    myoutput = p.communicate()[0].decode()
     returncode = p.returncode
 
   myoutput = myoutput.strip()

--- a/test/compflags/link/sungeun/static_dynamic.prediff
+++ b/test/compflags/link/sungeun/static_dynamic.prediff
@@ -19,7 +19,7 @@ try:
 except:
     testFailed(logfilename, 'Prediff script: Error executing '+printchplenv);
     raise
-chpl_env = p.communicate()[0]
+chpl_env = p.communicate()[0].decode()
 
 defaultLinkStyle = 'dynamically'
 for l in chpl_env.split('\n'):
@@ -52,15 +52,14 @@ except:
     testFailed(logfilename, 'Prediff script: Error executing file command');
     raise
 
-myoutput = p.communicate()[0]
+myoutput = p.communicate()[0].decode()
 
 if p.returncode == 0:
     if myoutput.find(linkStyle+' linked')==-1:
         testFailed(logfilename, myoutput)
     else:
-        logfile = file(logfilename, 'w')
-        logfile.write('SUCCESS\n')
-        logfile.close()
+        with open(logfilename, 'w') as logfile:
+            logfile.write('SUCCESS\n')
 else:
     testFailed(logfilename, myoutput)
 

--- a/test/compflags/sungeun/configs/basic/PREDIFF
+++ b/test/compflags/sungeun/configs/basic/PREDIFF
@@ -6,13 +6,13 @@ import sys, string
 testname = sys.argv[1]
 execlog = sys.argv[2]
 
-testnum = execlog[string.find(execlog,'.')+1:string.find(execlog,'-')]
+testnum = execlog[execlog.find('.')+1:execlog.find('-')]
 
 f = open(testname+'.good', 'w');
 
-if (string.find(execlog, 'configParam')==0 or
-    string.find(execlog, 'configConst')==0 or
-    string.find(execlog, 'configVar')==0):
+if (execlog.find('configParam')==0 or
+    execlog.find('configConst')==0 or
+    execlog.find('configVar')==0):
     if testnum=='1':
         f.write('4\n');
     elif testnum=='2':

--- a/test/compflags/sungeun/configs/type_variables/PREDIFF
+++ b/test/compflags/sungeun/configs/type_variables/PREDIFF
@@ -4,12 +4,12 @@
 #
 #
 
-import sys, string
+import sys
 
 testname=sys.argv[1]
 compopts=sys.argv[4]
 
-l = string.rfind(compopts, 'myType')
+l = compopts.rfind('myType')
 
 if l != -1:
     words=compopts[l+7:].split()
@@ -20,7 +20,7 @@ if l != -1:
 else:
     myType=None
 
-l = string.rfind(compopts, 'myIdxType')
+l = compopts.rfind('myIdxType')
 if l != -1:
     myIdxType=compopts[l+10:].split()[0]
 else:
@@ -40,11 +40,11 @@ def getDefaultValue(type):
     else:
         return '0'
 
-def getNumBits(type):
-    l = string.find(type, '(')
+def getNumBits(idx_type):
+    l = idx_type.find('(')
     if l != -1:
-        return type[l+1:].split()[0].split(')')[0]
-    elif type == 'real':
+        return idx_type[l+1:].split()[0].split(')')[0]
+    elif idx_type == 'real':
         return '64'
     else:
         return '64'

--- a/test/deprecated/parentNameErr.preexec
+++ b/test/deprecated/parentNameErr.preexec
@@ -5,7 +5,7 @@ import os, stat
 parent_path = os.path.abspath(os.path.join('testFile.txt', os.pardir))
 
 f = open('parentNameErr.good', 'w')
-os.chmod("parentNameErr.good", 0777);
+os.chmod("parentNameErr.good", 0o777);
 
 f.write("parentNameErr.chpl:4: In function 'main':\n")
 f.write("parentNameErr.chpl:8: warning: This version of file.getParentName() is deprecated; please switch to a throwing version\n")

--- a/test/execflags/sungeun/about.prediff
+++ b/test/execflags/sungeun/about.prediff
@@ -38,7 +38,7 @@ with open(goodfile, 'w') as gfh:
     # printchplenv --simple
     p = subprocess.Popen([printchplenv, '--simple', '--all', '--internal', '--anonymize', '--no-tidy'],
                          stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    chplenv = p.communicate()[0]
+    chplenv = p.communicate()[0].decode()
     chplenv += "CHPL_RUNTIME_INCL="+chpl_home+"/runtime/include\n"
     chplenv += "CHPL_RUNTIME_LIB="+chpl_home+"/lib\n"
     chplenv += "CHPL_THIRD_PARTY="+chpl_home+"/third-party\n"

--- a/test/functions/ferguson/main/sub_test
+++ b/test/functions/ferguson/main/sub_test
@@ -5,7 +5,7 @@ import sys
 import os
 
 if len(sys.argv)!=2:
-  print 'usage: sub_test COMPILER'
+  print('usage: sub_test COMPILER')
   sys.exit(0)
 
 # Find the base installation
@@ -17,7 +17,7 @@ exe_name = "test_main_return"
 
 p = subprocess.Popen([compiler, "-o", exe_name, "main_return.chpl"], 
     stdout=subprocess.PIPE)
-myoutput = p.communicate()[0]
+myoutput = p.communicate()[0].decode()
 sys.stdout.write(myoutput)
 if p.returncode != 0:
   sys.stdout.write("[Error (sub_test): the compile did not exit cleanly]\n")
@@ -37,7 +37,7 @@ else:
   p = subprocess.Popen(["./%s" % exe_name, "-nl%s" % numlocales],
       stdout=subprocess.PIPE)
 
-myoutput = p.communicate()[0]
+myoutput = p.communicate()[0].decode()
 sys.stdout.write(myoutput)
 if p.returncode != 0:
   sys.stdout.write("[Error (sub_test): exe did not exit with 0]\n" % ENV_VAR)
@@ -51,7 +51,7 @@ else:
   p = subprocess.Popen(["./%s" % exe_name,"-nl%s" % numlocales,"--ret_val=42"],
                         stdout=subprocess.PIPE)
 
-myoutput = p.communicate()[0]
+myoutput = p.communicate()[0].decode()
 sys.stdout.write(myoutput)
 if p.returncode != 42:
   sys.stdout.write("[Error (sub_test): exe did not exit with 42]\n" % ENV_VAR)

--- a/test/library/packages/ZMQ/interop-py/PREEXEC
+++ b/test/library/packages/ZMQ/interop-py/PREEXEC
@@ -20,7 +20,7 @@ if [[ ! -f pyzmq-venv/bin/activate ]] ; then
     if [[ ! -f ${CHPL_VIRTUALENV} ]]; then
         which virtualenv 2> /dev/null
         if [[ $? -eq 0 ]]; then
-            CHPL_VIRTUALENV=virtualenv
+            CHPL_VIRTUALENV=$(which virtualenv)
         else
             # Abort mission if virtualenv not available
             exit 1

--- a/test/library/standard/FileSystem/lydia/chmod/changeMode.prediff
+++ b/test/library/standard/FileSystem/lydia/chmod/changeMode.prediff
@@ -5,5 +5,5 @@ import os, sys
 namedFile = os.stat('file')
 namedDir = os.stat('dir')
 with open(sys.argv[2], 'w') as fp:
-    fp.write("%o\n" % (namedFile.st_mode & 0777))
-    fp.write("%o\n" % (namedDir.st_mode & 0777))
+    fp.write("%o\n" % (namedFile.st_mode & 0o777))
+    fp.write("%o\n" % (namedDir.st_mode & 0o777))

--- a/test/library/standard/FileSystem/lydia/copy/copying.prediff
+++ b/test/library/standard/FileSystem/lydia/copy/copying.prediff
@@ -2,7 +2,7 @@
 
 import os, sys
 
-with open(sys.argv[2], 'ab') as fp:
+with open(sys.argv[2], 'a') as fp:
     # The two files should have differing executable permissions
     fooStat = os.stat("foo.txt")
     barStat = os.stat("bar.txt")

--- a/test/library/standard/FileSystem/lydia/copyFile/copyingContents.prediff
+++ b/test/library/standard/FileSystem/lydia/copyFile/copyingContents.prediff
@@ -2,7 +2,7 @@
 
 import os, sys
 
-with open(sys.argv[2], 'ab') as fp:
+with open(sys.argv[2], 'a') as fp:
     # The two files should have differing executable permissions
     if os.stat("foo.txt").st_mode != os.stat("bar.txt").st_mode:
         fp.write("didn't match\n")

--- a/test/library/standard/FileSystem/lydia/copyMode/copyingMode.prediff
+++ b/test/library/standard/FileSystem/lydia/copyMode/copyingMode.prediff
@@ -2,7 +2,7 @@
 
 import os, sys
 
-with open(sys.argv[2], 'ab') as fp:
+with open(sys.argv[2], 'a') as fp:
     # after running, the two files should match
     if os.stat("foo.txt").st_mode != os.stat("bar.txt").st_mode:
         fp.write("Expected mode of " + str(os.stat("foo.txt").st_mode) + ", was " + str(os.stat("bar.txt").st_mode) + "\n")

--- a/test/library/standard/FileSystem/lydia/mkdir/makeWithMode.prediff
+++ b/test/library/standard/FileSystem/lydia/mkdir/makeWithMode.prediff
@@ -4,4 +4,4 @@ import os, sys
 
 s = os.stat('useAMode')
 with open(sys.argv[2], 'w') as fp:
-    fp.write("%o\n" % (s.st_mode & 0777))
+    fp.write("%o\n" % (s.st_mode & 0o777))

--- a/test/library/standard/Path/saru/getParentName/parentName.preexec
+++ b/test/library/standard/Path/saru/getParentName/parentName.preexec
@@ -5,6 +5,6 @@ import os, stat
 parent_path = os.path.abspath(os.path.join('testFile.txt', os.pardir))
 
 f = open('parentName.good', 'w')
-os.chmod("parentName.good", 0777);
+os.chmod("parentName.good", 0o777);
 f.write(parent_path + '\n')
 f.close()

--- a/test/man/checkManPages
+++ b/test/man/checkManPages
@@ -7,6 +7,7 @@ chpl check that all top-level CHPL variables from $CHPL_HOME/util/printchplenv
 are included in the man page's ENVIRONMENT section.
 """
 
+from functools import reduce
 import logging
 import operator
 import os
@@ -201,7 +202,7 @@ def _run_cmd(cmd):
     """Run command then return stdout and exit code."""
     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE)
     stdout, _ = proc.communicate()
-    return stdout, proc.returncode
+    return stdout.decode(), proc.returncode
 
 
 def _msg(level, *args):

--- a/test/release/examples/primers/learnChapelInYMinutes.prediff
+++ b/test/release/examples/primers/learnChapelInYMinutes.prediff
@@ -14,7 +14,7 @@ fh.close()
 def writeOutput( value ):
   fh = open(outfile, 'w')
   fh.write(value+'\n')
-  if DEBUG_MODE: print value 
+  if DEBUG_MODE: print(value)
   fh.close()
 
 [test_serial_input, test_parallel_input] = input.split( "PARALLELISM START" )
@@ -29,8 +29,8 @@ else:
   writeOutput( "FAILED! " + str( line_of_stderr ) + " not seen" )
   exit( -1-i )
 
-[test_serial, test_parallel] = [ filter( remove_empty, test_serial_input.split("\n")), \
-                                 filter( remove_empty, test_parallel_input.split("\n") )]
+[test_serial, test_parallel] = [ list(filter( remove_empty, test_serial_input.split("\n"))), \
+                                 list(filter( remove_empty, test_parallel_input.split("\n") ))]
 
 # Check Serial section as a whole
 # Should be a 1:1 mapping of each other

--- a/test/runtime/sungeun/chpl-env-gen.precomp
+++ b/test/runtime/sungeun/chpl-env-gen.precomp
@@ -12,7 +12,7 @@ chpl_home = os.getenv('CHPL_HOME')
 printchplenv = os.path.join(chpl_home, 'util', 'printchplenv')
 printchplenv_cmd = [printchplenv, '--simple', '--runtime', '--no-tidy', '--anonymize']
 
-p = subprocess.Popen(printchplenv_cmd, stdout=subprocess.PIPE).communicate()[0]
+p = subprocess.Popen(printchplenv_cmd, stdout=subprocess.PIPE).communicate()[0].decode()
 chpl_env = dict(map(lambda l: l.split('=', 1), p.splitlines()))
 
 testname = sys.argv[1]
@@ -28,7 +28,7 @@ with open(genfile, 'w') as f:
 # copy chpl-env-gen.h to this directory, rather than just including it. On some
 # test systems the include path is too long for pgi
 runtime_path_cmd = [printchplenv, '--runtime', '--path']
-runtime_path = subprocess.Popen(runtime_path_cmd, stdout=subprocess.PIPE).communicate()[0]
+runtime_path = subprocess.Popen(runtime_path_cmd, stdout=subprocess.PIPE).communicate()[0].decode()
 runtime_path = runtime_path.strip()
 gen_env_f = os.path.join(chpl_home, 'build', 'runtime', runtime_path, 'include', 'chpl-env-gen.h')
 

--- a/test/setchplenv/verify_setchplenv_scripts.py
+++ b/test/setchplenv/verify_setchplenv_scripts.py
@@ -80,11 +80,11 @@ class SetChplEnvTests(unittest.TestCase):
             cwd=self.chpl_home,
             env=os.environ.copy()
         )
-        out, _ = proc.communicate(input=cmd)
+        out, _ = proc.communicate(input=str.encode(cmd))
         if proc.returncode != 0:
             raise ValueError('Non-zero exit code ({0}) from: {1}'.format(
                 proc.returncode, cmd))
-        return out
+        return out.decode()
 
     def test_known_shells(self):
         """Verify all known shells have equivalent setchplenv.* scripts in util/ and

--- a/third-party/chpl-venv/test-requirements.txt
+++ b/third-party/chpl-venv/test-requirements.txt
@@ -1,4 +1,4 @@
 argparse==1.3.0
-PyYAML==3.11
+PyYAML==3.13
 filelock==2.0.13
 argcomplete==1.9.4

--- a/util/buildRelease/add_license_to_sources.py
+++ b/util/buildRelease/add_license_to_sources.py
@@ -94,7 +94,7 @@ class LicenseCommenter(object):
             #  */
             # <blank line>
             license_lines = commentate_lines(' *', self.comment_text_lines)
-            comment_lines = ['/*'] + license_lines + [' */', '\n']
+            comment_lines = ['/*'] + list(license_lines) + [' */', '\n']
             return '\n'.join(comment_lines)
         else:
             raise ValueError('Cannot figure out comment style for: {0}'.format(source_filename))

--- a/util/chpltags
+++ b/util/chpltags
@@ -45,6 +45,8 @@ def check_ex_ctags():
     process = subprocess.Popen(['ctags', '--version'],
                                 stdout=subprocess.PIPE)
     out, err = process.communicate()
+    if sys.version_info[0] >= 3 and not isinstance(out, str):
+        out = str(out, 'utf-8')
 
     return bool(out and ('Exuberant Ctags' in out) and ('+regex' in out))
 

--- a/util/devel/test/extract_tests
+++ b/util/devel/test/extract_tests
@@ -180,7 +180,7 @@ def OutputTest(lineno, currTestName):
             sys.stdout.write('>>> Opening %s\n'%(testName+'.prediff'))
         fh = open(testName+'.prediff', 'w')
         WriteTestFile(fh, chapelprediff)
-        os.chmod(testName+'.prediff', 0755)
+        os.chmod(testName+'.prediff', 0o755)
 
     # write out .good files
     if len(chapeloutput) > 0 or len(chapelprintoutput) > 0:
@@ -356,9 +356,9 @@ for infile in args:
             elif line.find('execopts}', pos) == pos:
                 printToOutfile = True
                 current = chapelexecopts;
-	    elif line.find('prediff}', pos) == pos:
-		printToOutfile = True
-		current = chapelprediff;
+            elif line.find('prediff}', pos) == pos:
+                printToOutfile = True
+                current = chapelprediff;
 
             elif line.find('output}', pos) == pos:
                 printToOutfile = True

--- a/util/start_test
+++ b/util/start_test
@@ -1528,6 +1528,10 @@ def run_command(cmd):
     retcode = process.poll()
     if retcode:
         raise CommandError(retcode, cmd, output)
+
+    if sys.version_info[0] >= 3 and not isinstance(output, str):
+        output = str(output, 'utf-8')
+
     return output
 
 def printout(so):
@@ -1535,6 +1539,8 @@ def printout(so):
         line = so.readline()
         if not line:
             break
+        if sys.version_info[0] >= 3 and not isinstance(line, str):
+            line = str(line, 'utf-8')
         logger.write(line) # strip default newline
         logger.flush()
 

--- a/util/test/activate_chpl_test_venv.py
+++ b/util/test/activate_chpl_test_venv.py
@@ -44,7 +44,7 @@ def activate_venv():
             error('Activation file {0} is missing'.format(activation_file))
 
         # actually activate
-        execfile(activation_file, dict(__file__=activation_file))
+        exec(open(activation_file).read())
 
 
 activate_venv()

--- a/util/test/activate_chpl_test_venv.py
+++ b/util/test/activate_chpl_test_venv.py
@@ -44,7 +44,9 @@ def activate_venv():
             error('Activation file {0} is missing'.format(activation_file))
 
         # actually activate
-        exec(open(activation_file).read())
+        with open(activation_file) as f:
+            code = compile(f.read(), activation_file, 'exec')
+            exec(code, dict(__file__=activation_file))
 
 
 activate_venv()

--- a/util/test/annotate.py
+++ b/util/test/annotate.py
@@ -35,9 +35,8 @@ def load(path):
   # replace all of the date strings with actual time structs
   try:
     for group in data:
-      for date in data[group].keys():
-        data[group][time.strptime(date, _dat_date_format)] = data[group][date]
-        del data[group][date]
+      for date in data[group].copy().keys():
+        data[group][time.strptime(date, _dat_date_format)] = data[group].pop(date)
   except AttributeError:
     raise InputError("Invalid annotation format in {0}".format(path))
 
@@ -66,7 +65,7 @@ def get(data, graph, series, start, end, config_name):
 
 def _find_annotations(graph, matches, data, start, end, config_name):
   if graph in data:
-    for date, annotations in data[graph].iteritems():
+    for date, annotations in data[graph].items():
       if start <= date and date <= end:
         for ann in annotations:
           if isinstance(ann, dict):

--- a/util/test/check_annotations.py
+++ b/util/test/check_annotations.py
@@ -93,7 +93,7 @@ def check_configs(ann_data):
     known_configs = {'shootout', 'chap03', 'chap04', 'bradc-lnx', 'chapcs',
                      '16 node XC', 'Single node XC'}
     for graph in ann_data:
-        for _, annotations in ann_data[graph].iteritems():
+        for _, annotations in ann_data[graph].items():
             for ann in annotations:
                 if isinstance(ann, dict) and 'config' in ann:
                     configs = ann['config'].split(',')
@@ -109,6 +109,8 @@ def compute_pr_to_dates():
     git_cmd = 'git log --grep "^Merge pull request #" --date=short-local --pretty=format:"%ad ::: %s"'
     p = subprocess.Popen(git_cmd, stdout=subprocess.PIPE, shell=True)
     git_log = p.communicate()[0]
+    if sys.version_info[0] >= 3 and not isinstance(git_log, str):
+        git_log = str(git_log, 'utf-8')
     for line in git_log.splitlines():
         split_line = line.split(' ::: ')
         date = split_line[0]
@@ -124,7 +126,7 @@ def check_pr_number_dates(ann_data):
     """
     pr_to_date_dict = compute_pr_to_dates()
     for graph in ann_data:
-        for date, annotations in ann_data[graph].iteritems():
+        for date, annotations in ann_data[graph].items():
             for ann in annotations:
                 if isinstance(ann, dict):
                     text = ann.get('text')

--- a/util/test/chpl_launchcmd.py
+++ b/util/test/chpl_launchcmd.py
@@ -444,9 +444,9 @@ class AbstractJob(object):
         # that is wrapper around slurm apis.
         if srun_callable:
             return SlurmJob
-        elif qsub_callable and os.environ.has_key('MOABHOMEDIR'):
+        elif qsub_callable and 'MOABHOMEDIR' in os.environ:
             return MoabJob
-        elif qsub_callable and os.environ.has_key('CHPL_PBSPRO_USE_MPP'):
+        elif qsub_callable and 'CHPL_PBSPRO_USE_MPP' in os.environ:
             return MppPbsProJob
         elif qsub_callable:
             return PbsProJob

--- a/util/test/genGraphs
+++ b/util/test/genGraphs
@@ -199,8 +199,11 @@ def data_to_csv(data, csvFile):
 def sort_csv(csvFile):
     data = parse_csv(csvFile)
 
+    if len(data) == 1:
+        return
+
     # transpose the data so that we can sort by row
-    data = zip(*data)
+    data = list(zip(*data))
     # remove the Date perfkey and the actual dates as they screw up sorting
     dates = data.pop(0)
 
@@ -221,7 +224,7 @@ def sort_csv(csvFile):
     # add the dates back in
     data.insert(0, dates)
     # untranspose the data
-    data = zip(*data)
+    data = list(zip(*data))
 
     data_to_csv(data, csvFile)
 
@@ -242,7 +245,7 @@ def fill_sparse_csv(csvFile):
     data = parse_csv(csvFile)
     keys = data.pop(0)
     if len(data) > 1:
-        dates = zip(*data).pop(0)
+        dates = list(zip(*data)).pop(0)
         dates = [date[0] for date in dates]
         if len(dates) > 1:
             start_date = dates[0]
@@ -273,7 +276,7 @@ def strip_series(csvFile, numseries):
     data = parse_csv(csvFile)
     labels = [a[0] for a in data[0]]
     newData = []
-    data = zip(*data)
+    data = list(zip(*data))
     numFound = 0
     newData.append(data[0])
     if multiConf:
@@ -290,7 +293,7 @@ def strip_series(csvFile, numseries):
             newData.append(data[i])
 
     # untranspose the data
-    data = zip(*newData)
+    data = list(zip(*newData))
 
     data_to_csv(data, csvFile)
 
@@ -496,9 +499,9 @@ class GraphStuff:
                 if len(graphs[currgraph].perfkeys) % len(dFiles) != 0:
                     sys.stdout.write('[Warning: num .dat files did not evenly divide into num perfkeys for %s. Ignoring.]\n'%(fullFname))
                     return
-                keysRange = range(0, (len(graphs[currgraph].perfkeys) / len(dFiles)))
+                keysRange = range(0, (len(graphs[currgraph].perfkeys) // len(dFiles)))
                 for dFile in dFiles:
-		    graphs[currgraph].datfilenames += [ dFile for i in keysRange ]
+                    graphs[currgraph].datfilenames += [ dFile for i in keysRange ]
             elif key == 'graphtitle':
                 graphs[currgraph].title = rest.strip()
             elif key == 'graphname':
@@ -648,7 +651,7 @@ class GraphClass:
 
         first = True
         done = False
-        for i in xrange(numKeys):
+        for i in range(numKeys):
             # The file may be missing (in the case where only a subdirectory
             # has been tested for performance).  If so, we don't want to
             # try to access a non-existent datfile
@@ -673,7 +676,7 @@ class GraphClass:
         found_data = False
         while not done:
             done = True
-            for i in xrange(numKeys):
+            for i in range(numKeys):
                 # The file may be missing (in the case where only a subdirectory
                 # has been tested for performance).  If so, we don't want to
                 # try to access a non-existent datfile
@@ -710,7 +713,7 @@ class GraphClass:
                 try:
                     df = datfiles[self.datfilenames[i]]
                     if currLines[i] < len(df.lines):
-                        fields = zip(*df.lines[currLines[i]])
+                        fields = list(zip(*df.lines[currLines[i]]))
                         myDate = fields[0][0]
                         if myDate == minDate:
                             # consume this line
@@ -799,8 +802,8 @@ class GraphClass:
 
     def generateGraphData(self, graphInfo, gnum):
         if debug:
-            print '==='
-            print self
+            print('===')
+            print(self)
 
         if verbose:
             sys.stdout.write('Generating graph data for %s (graph #%d)\n'%(self.name, gnum))
@@ -908,7 +911,7 @@ class GraphClass:
         datfiles = {}
         for i in range(nperfkeys):
             d = self.datfilenames[i]
-            if not datfiles.has_key(d):
+            if d not in datfiles:
                 datfiles[d] = self.DatFileClass(d)
             try:
                 if hasattr(datfiles[d], 'dfile'):
@@ -929,7 +932,7 @@ class GraphClass:
         self.generateData(graphInfo, datfiles)
         graphInfo.genGraphInfo(self)
 
-        for n, d in datfiles.iteritems():
+        for n, d in datfiles.items():
             del d
 
 

--- a/util/test/send_email.py
+++ b/util/test/send_email.py
@@ -54,7 +54,7 @@ def send_email(recipients, body, subject=None, headers=None, sender=None, smtp_h
     msg['To'] = ','.join(recipients)
 
     if headers:
-        for key, value in headers.iteritems():
+        for key, value in headers.items():
             msg[key] = value
 
     if not os.environ.get('CHPL_TEST_NOMAIL', ''):

--- a/util/test/sub_clean
+++ b/util/test/sub_clean
@@ -39,7 +39,7 @@ def ReadCleanfiles(f, ignoreLeadingSpace=True):
 def cleanChapelTest(f):
     execname = getExecname(f)
     if execname:
-        print 'Cleaning test: '+execname
+        print('Cleaning test: '+execname)
         globfiles = glob.glob(execname+'.*.out.tmp')
         for g in globfiles:
             try:
@@ -69,7 +69,7 @@ def cleanCleanfiles(d, c, rmCore):
             else:
                 globfiles = glob.glob(f)
             for g in globfiles:
-                print 'Removing '+g
+                print('Removing '+g)
                 try:
                     if os.path.isdir(g):
                         shutil.rmtree(g)
@@ -92,7 +92,7 @@ else:
 
 for f in clean:
     if os.path.isdir(f):
-        print 'Cleaning directory: '+f
+        print('Cleaning directory: '+f)
         dirlist = glob.glob(f+'/*.chpl')+glob.glob(f+'/*.test.c')
         dirlist.sort()
         for file in dirlist:

--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -2051,9 +2051,12 @@ for testname in testsrc:
                     sys.stdout.write('[Concatenating extra files: %s]\n'%
                                     (test_filename+'.catfiles'))
                     sys.stdout.flush()
-                    output+=Popen(['cat']+catfiles.split(),
-                                  stdout=subprocess.PIPE,
-                                  stderr=subprocess.STDOUT).communicate()[0]
+                    cat_output = Popen(['cat']+catfiles.split(),
+                                     stdout=subprocess.PIPE,
+                                     stderr=subprocess.STDOUT).communicate()[0]
+                    if sys.version_info[0] >= 3 and isinstance(cat_output, bytes):
+                        output = bytes(output, 'utf-8')
+                    output += cat_output
 
                 # Sadly the scripts used below require an actual file
                 open_mode = 'w' if isinstance(output, str) else 'wb'

--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -273,7 +273,7 @@ def ReadFileWithComments(f, ignoreLeadingSpace=True):
 
             # execute the file and grab its output
             cmd = subprocess.Popen([os.path.abspath(f)], stdout=subprocess.PIPE, env=file_env)
-            mylines = bytes_to_string(cmd.communicate()[0].splitlines())
+            mylines = bytes_to_str(cmd.communicate()[0]).splitlines()
 
         except OSError as e:
             global localdir
@@ -1175,12 +1175,12 @@ for testname in testsrc:
 
         elif (suffix=='.lastcompopts' and os.access(f, os.R_OK)):
             lastcompoptsBytes = subprocess.Popen(['cat', f], stdout=subprocess.PIPE).communicate()[0]
-            lastcompopts+=lastcompoptsBytes.strip().split()
+            lastcompopts+=bytes_to_str(lastcompoptsBytes).strip().split()
             # sys.stdout.write("lastcompopts=%s\n"%(lastcompopts))
 
         elif (suffix=='.lastexecopts' and os.access(f, os.R_OK)):
             lastexecoptsBytes = subprocess.Popen(['cat', f], stdout=subprocess.PIPE).communicate()[0]
-            lastexecopts+=lastexecoptsBytes.strip().split()
+            lastexecopts+=bytes_to_str(lastexecoptsBytes).strip().split()
             # sys.stdout.write("lastexecopts=%s\n"%(lastexecopts))
 
         elif (suffix==PerfSfx('numlocales') and os.access(f, os.R_OK)):

--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -166,6 +166,12 @@ atexit.register(elapsed_sub_test_time)
 class ReadTimeoutException(Exception): pass
 
 
+# Python 2/3 compatibility shim. We use subprocess.Popen.communicate() all
+# over sub_test. Instead of updating every call site to do the right thing with
+# regard byte to str conversations for 3 compatibility, we have opted to add
+# this wrapper. Not all things we run will produce utf-8 (i.e. catfiles for
+# thing like mandlebrot will return binary data) so we allow the conversation
+# to utf-8 to silently fail and we handle any issues at those call sites.
 def bytes_to_str(byte_string):
     if sys.version_info[0] >= 3 and not isinstance(byte_string, str):
         try:

--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -266,14 +266,14 @@ def ReadFileWithComments(f, ignoreLeadingSpace=True):
         try:
             # grab the chplenv so it can be stuffed into the subprocess env
             env_cmd = [os.path.join(utildir, 'printchplenv'), '--all', '--simple', '--no-tidy', '--internal']
-            chpl_env = subprocess.Popen(env_cmd, stdout=subprocess.PIPE).communicate()[0]
+            chpl_env = bytes_to_str(subprocess.Popen(env_cmd, stdout=subprocess.PIPE).communicate()[0])
             chpl_env = dict(map(lambda l: l.split('=', 1), chpl_env.splitlines()))
             file_env = os.environ.copy()
             file_env.update(chpl_env)
 
             # execute the file and grab its output
             cmd = subprocess.Popen([os.path.abspath(f)], stdout=subprocess.PIPE, env=file_env)
-            mylines = cmd.communicate()[0].splitlines()
+            mylines = bytes_to_string(cmd.communicate()[0].splitlines())
 
         except OSError as e:
             global localdir
@@ -526,6 +526,8 @@ def get_exec_log_name(execname, comp_opts_count=None, exec_opts_count=None):
 def runSkipIf(skipifName):
     p = subprocess.Popen([utildir+'/test/testEnv', './'+skipifName], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     (stdout, stderr) = p.communicate()
+    stdout = bytes_to_str(stdout)
+    stderr = bytes_to_str(stderr)
     status = p.returncode
 
     stderr = stderr.strip()
@@ -584,7 +586,8 @@ utildir = os.path.realpath(utildir)
 p = subprocess.Popen([os.path.join(chpl_home,'util','config','compileline'),
                         '--compile'],
                     stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-c_compiler = p.communicate()[0].rstrip()
+c_compiler = p.communicate()[0]
+c_compiler = bytes_to_str(c_compiler).rstrip()
 if p.returncode != 0:
   Fatal('Cannot find c compiler')
 
@@ -757,12 +760,14 @@ else:
 
 globalLastcompopts=list();
 if os.access('./LASTCOMPOPTS',os.R_OK):
-    globalLastcompopts+=subprocess.Popen(['cat', './LASTCOMPOPTS'], stdout=subprocess.PIPE).communicate()[0].strip().split()
+    globalLastcompoptsBytes = subprocess.Popen(['cat', './LASTCOMPOPTS'], stdout=subprocess.PIPE).communicate()[0]
+    globalLastcompopts+=bytes_to_str(globalLastcompoptsBytes).strip().split()
 # sys.stdout.write('globalLastcompopts=%s\n'%(globalLastcompopts))
 
 globalLastexecopts=list();
 if os.access('./LASTEXECOPTS',os.R_OK):
-    globalLastexecopts+=subprocess.Popen(['cat', './LASTEXECOPTS'], stdout=subprocess.PIPE).communicate()[0].strip().split()
+    globalLastexecoptsBytes = subprocess.Popen(['cat', './LASTEXECOPTS'], stdout=subprocess.PIPE).communicate()[0]
+    globalLastexecopts+=bytes_to_str(globalLastexecoptsBytes).strip().split()
 # sys.stdout.write('globalLastexecopts=%s\n'%(globalLastexecopts))
 
 if os.access(PerfDirFile('NUMLOCALES'),os.R_OK):
@@ -781,6 +786,7 @@ if maxLocalesAvailable is not None:
 
 if os.access('./CATFILES',os.R_OK):
     globalCatfiles=subprocess.Popen(['cat', './CATFILES'], stdout=subprocess.PIPE).communicate()[0]
+    globalCatfiles = bytes_to_str(globalCatfiles)
     globalCatfiles.strip(globalCatfiles)
 else:
     globalCatfiles=None
@@ -1161,18 +1167,20 @@ for testname in testsrc:
             killtimeout=ReadIntegerValue(f, localdir)
 
         elif (suffix=='.catfiles' and os.access(f, os.R_OK)):
-            execcatfiles=subprocess.Popen(['cat', f], stdout=subprocess.PIPE).communicate()[0].strip()
+            execcatfiles=bytes_to_str(subprocess.Popen(['cat', f], stdout=subprocess.PIPE).communicate()[0]).strip()
             if catfiles:
                 catfiles+=execcatfiles
             else:
                 catfiles=execcatfiles
 
         elif (suffix=='.lastcompopts' and os.access(f, os.R_OK)):
-            lastcompopts+=subprocess.Popen(['cat', f], stdout=subprocess.PIPE).communicate()[0].strip().split()
+            lastcompoptsBytes = subprocess.Popen(['cat', f], stdout=subprocess.PIPE).communicate()[0]
+            lastcompopts+=lastcompoptsBytes.strip().split()
             # sys.stdout.write("lastcompopts=%s\n"%(lastcompopts))
 
         elif (suffix=='.lastexecopts' and os.access(f, os.R_OK)):
-            lastexecopts+=subprocess.Popen(['cat', f], stdout=subprocess.PIPE).communicate()[0].strip().split()
+            lastexecoptsBytes = subprocess.Popen(['cat', f], stdout=subprocess.PIPE).communicate()[0]
+            lastexecopts+=lastexecoptsBytes.strip().split()
             # sys.stdout.write("lastexecopts=%s\n"%(lastexecopts))
 
         elif (suffix==PerfSfx('numlocales') and os.access(f, os.R_OK)):
@@ -1378,7 +1386,7 @@ for testname in testsrc:
                                   execname,complog,compiler],
                                  stdout=subprocess.PIPE,
                                  stderr=subprocess.STDOUT)
-            sys.stdout.write(p.communicate()[0])
+            sys.stdout.write(bytes_to_str(p.communicate()[0]))
             sys.stdout.flush()
 
 
@@ -1451,7 +1459,7 @@ for testname in testsrc:
                                  stdin=open(compstdin, 'r'),
                                  stdout=subprocess.PIPE,
                                  stderr=subprocess.STDOUT)
-            output = p.communicate()[0]
+            output = bytes_to_str(p.communicate()[0])
             status = p.returncode
 
             if status == 222:
@@ -1631,14 +1639,14 @@ for testname in testsrc:
 
             # One execution output file for each of the execution opts.
             elif len(compoptslist) == 1 and len(execoptslist) > 1:
-                for i in xrange(1, len(execoptslist) + 1):
+                for i in range(1, len(execoptslist) + 1):
                     exec_log_names.append(get_exec_log_name(execname, compoptsnum, i))
 
             # This enumerates the cross product of all compiler and execution
             # opts. It's not clear whether this is actually supported elsewhere
             # (like start_test), but it's here.
             else:
-                for i in xrange(1, len(execoptslist) + 1):
+                for i in range(1, len(execoptslist) + 1):
                     exec_log_names.append(get_exec_log_name(execname, compoptsnum, i))
 
             # Write the log(s), so it/they can be modified by preexec.
@@ -1687,7 +1695,7 @@ for testname in testsrc:
                 sys.stdout.write('[Executing computePerfStats %s %s %s %s %s]\n'%(datFileName, tempDatFilesDir, keyfile, printpassesfile, 'False'))
                 sys.stdout.flush()
                 p = subprocess.Popen([utildir+'/test/computePerfStats', datFileName, tempDatFilesDir, keyfile, printpassesfile, 'False'], stdout=subprocess.PIPE)
-                compkeysOutput = p.communicate()[0]
+                compkeysOutput = bytes_to_str(p.communicate()[0])
                 datFiles = [tempDatFilesDir+'/'+datFileName+'.dat',  tempDatFilesDir+'/'+datFileName+'.error']
                 status = p.returncode
 
@@ -1755,7 +1763,7 @@ for testname in testsrc:
                                       execname,execlog,compiler],
                                      stdout=subprocess.PIPE,
                                      stderr=subprocess.STDOUT)
-                sys.stdout.write(p.communicate()[0])
+                sys.stdout.write(bytes_to_str(p.communicate()[0]))
                 sys.stdout.flush()
 
             if globalPreexec:
@@ -1765,7 +1773,7 @@ for testname in testsrc:
                                       execname,execlog,compiler],
                                      stdout=subprocess.PIPE,
                                      stderr=subprocess.STDOUT)
-                sys.stdout.write(p.communicate()[0])
+                sys.stdout.write(bytes_to_str(p.communicate()[0]))
                 sys.stdout.flush()
 
             if preexec:
@@ -1775,7 +1783,7 @@ for testname in testsrc:
                                       execname,execlog,compiler],
                                      stdout=subprocess.PIPE,
                                      stderr=subprocess.STDOUT)
-                sys.stdout.write(p.communicate()[0])
+                sys.stdout.write(bytes_to_str(p.communicate()[0]))
                 sys.stdout.flush()
 
             pre_exec_output = ''
@@ -1863,7 +1871,7 @@ for testname in testsrc:
             # Run program (with timeout)
             #
             skip_remaining_trials = False
-            for count in xrange(numTrials):
+            for count in range(numTrials):
                 if skip_remaining_trials:
                     break
 
@@ -1893,7 +1901,7 @@ for testname in testsrc:
                                             stdin=my_stdin,
                                             stdout=subprocess.PIPE,
                                             stderr=subprocess.STDOUT)
-                        output = p.communicate()[0]
+                        output = bytes_to_str(p.communicate()[0])
                         status = p.returncode
 
                         if re.search('slurmstepd: Munge decode failed: Expired credential', output, re.IGNORECASE) != None:
@@ -1940,7 +1948,7 @@ for testname in testsrc:
                                             stdin=my_stdin,
                                             stdout=subprocess.PIPE,
                                             stderr=subprocess.STDOUT)
-                        output = p.communicate()[0]
+                        output = bytes_to_str(p.communicate()[0])
                         status = p.returncode
 
                         if status == 222:
@@ -2026,9 +2034,10 @@ for testname in testsrc:
                     sys.stdout.write('[Concatenating extra files: %s]\n'%
                                     (test_filename+'.catfiles'))
                     sys.stdout.flush()
-                    output+=subprocess.Popen(['cat']+catfiles.split(),
+                    catfilesOutputBytes = subprocess.Popen(['cat']+catfiles.split(),
                                             stdout=subprocess.PIPE,
                                             stderr=subprocess.STDOUT).communicate()[0]
+                    output+=bytes_to_str(catfilesOutputBytes)
 
                 # Sadly the scripts used below require an actual file
                 with open(execlog, 'w') as execlogfile:
@@ -2039,38 +2048,41 @@ for testname in testsrc:
                     if systemPrediff:
                         sys.stdout.write('[Executing system-wide prediff]\n')
                         sys.stdout.flush()
-                        sys.stdout.write(subprocess.Popen([systemPrediff,
+                        systemPrediffBytes = subprocess.Popen([systemPrediff,
                                                           execname,execlog,compiler,
                                                           ' '.join(envCompopts)+
                                                           ' '+compopts,
                                                           ' '.join(args)],
                                                           stdout=subprocess.PIPE,
                                                           stderr=subprocess.STDOUT).
-                                        communicate()[0])
+                                        communicate()[0]
+                        sys.stdout.write(bytes_to_str(systemPrediffBytes))
 
                     if globalPrediff:
                         sys.stdout.write('[Executing ./PREDIFF]\n')
                         sys.stdout.flush()
-                        sys.stdout.write(subprocess.Popen(['./PREDIFF',
+                        globalPrediffBytes = subprocess.Popen(['./PREDIFF',
                                                           execname,execlog,compiler,
                                                           ' '.join(envCompopts)+
                                                           ' '+compopts,
                                                           ' '.join(args)],
                                                           stdout=subprocess.PIPE,
                                                           stderr=subprocess.STDOUT).
-                                        communicate()[0])
+                                        communicate()[0]
+                        sys.stdout.write(bytes_to_str(globalPrediffBytes))
 
                     if prediff:
                         sys.stdout.write('[Executing prediff ./%s]\n'%(prediff))
                         sys.stdout.flush()
-                        sys.stdout.write(subprocess.Popen(['./'+prediff,
+                        prediffBytes = subprocess.Popen(['./'+prediff,
                                                           execname,execlog,compiler,
                                                           ' '.join(envCompopts)+
                                                           ' '+compopts,
                                                           ' '.join(args)],
                                                           stdout=subprocess.PIPE,
                                                           stderr=subprocess.STDOUT).
-                                        communicate()[0])
+                                        communicate()[0]
+                        sys.stdout.write(bytes_to_str(prediffBytes))
 
                     if not perftest:
                         # find the good file 
@@ -2097,6 +2109,7 @@ for testname in testsrc:
                             sys.stdout.write('[Execution output was as follows:]\n')
                             exec_output = subprocess.Popen(['cat', execlog],
                                 stdout=subprocess.PIPE).communicate()[0]
+                            exec_output = bytes_to_str(exec_output)
                             sys.stdout.write(trim_output(exec_output))
 
                             continue # on to next execopts
@@ -2184,7 +2197,7 @@ for testname in testsrc:
                     p = subprocess.Popen([utildir+'/test/computePerfStats',
                                           perfexecname, perfdir, keyfile, execlog, str(exectimeout), perfdate],
                                          stdout=subprocess.PIPE)
-                    sys.stdout.write('%s'%(p.communicate()[0]))
+                    sys.stdout.write('%s'%(bytes_to_str(p.communicate()[0])))
                     sys.stdout.flush()
 
                     status = p.returncode

--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -173,6 +173,37 @@ def bytes_to_str(byte_string):
         return byte_string
 
 
+class Py3CompatPopen(object):
+
+    def __init__(self, popen):
+        self._popen = popen
+
+    def communicate(self):
+        c = self._popen.communicate()
+        return Py3CompatCommGetter(c)
+
+    def __getattr__(self, name):
+        return getattr(self._popen, name)
+
+
+class Py3CompatCommGetter(object):
+
+    def __init__(self, comm_result):
+        self._c = comm_result
+
+    def __getitem__(self, key):
+        val = self._c[key]
+        if key == 0 or key == 1:
+            return bytes_to_str(val)
+        else:
+            return val
+
+
+def Popen(*args, **kwargs):
+    p = subprocess.Popen(*args, **kwargs)
+    return Py3CompatPopen(p)
+
+
 def SetNonBlock(stream):
     flags = fcntl.fcntl(stream.fileno(), fcntl.F_GETFL)
     flags |= os.O_NONBLOCK
@@ -266,14 +297,14 @@ def ReadFileWithComments(f, ignoreLeadingSpace=True):
         try:
             # grab the chplenv so it can be stuffed into the subprocess env
             env_cmd = [os.path.join(utildir, 'printchplenv'), '--all', '--simple', '--no-tidy', '--internal']
-            chpl_env = bytes_to_str(subprocess.Popen(env_cmd, stdout=subprocess.PIPE).communicate()[0])
+            chpl_env = Popen(env_cmd, stdout=subprocess.PIPE).communicate()[0]
             chpl_env = dict(map(lambda l: l.split('=', 1), chpl_env.splitlines()))
             file_env = os.environ.copy()
             file_env.update(chpl_env)
 
             # execute the file and grab its output
-            cmd = subprocess.Popen([os.path.abspath(f)], stdout=subprocess.PIPE, env=file_env)
-            mylines = bytes_to_str(cmd.communicate()[0]).splitlines()
+            cmd = Popen([os.path.abspath(f)], stdout=subprocess.PIPE, env=file_env)
+            mylines = cmd.communicate()[0].splitlines()
 
         except OSError as e:
             global localdir
@@ -303,20 +334,18 @@ def ReadFileWithComments(f, ignoreLeadingSpace=True):
 # diff 2 files
 def DiffFiles(f1, f2):
     sys.stdout.write('[Executing diff %s %s]\n'%(f1, f2))
-    p = subprocess.Popen(['diff',f1,f2],
-                         stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    p = Popen(['diff',f1,f2],
+              stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     myoutput = p.communicate()[0] # grab stdout to avoid potential deadlock
-    myoutput = bytes_to_str(myoutput)
     if p.returncode != 0:
         sys.stdout.write(trim_output(myoutput))
     return p.returncode
 
 def DiffBinaryFiles(f1, f2):
     sys.stdout.write('[Executing binary diff %s %s]\n'%(f1, f2))
-    p = subprocess.Popen(['diff', '-a', f1,f2],
-                         stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    p = Popen(['diff', '-a', f1,f2],
+              stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     myoutput = p.communicate()[0] # grab stdout to avoid potential deadlock
-    myoutput = bytes_to_str(myoutput)
     if p.returncode != 0:
         sys.stdout.write(trim_output(myoutput))
     return p.returncode
@@ -325,17 +354,16 @@ def DiffBinaryFiles(f1, f2):
 # in module files.
 def DiffBadFiles(f1, f2):
     sys.stdout.write('[Executing diff-ignoring-module-line-numbers %s %s]\n'%(f1, f2))
-    p = subprocess.Popen([utildir+'/test/diff-ignoring-module-line-numbers', f1, f2],
-                         stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    p = Popen([utildir+'/test/diff-ignoring-module-line-numbers', f1, f2],
+              stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     myoutput = p.communicate()[0] # grab stdout to avoid potential deadlock
-    myoutput = bytes_to_str(myoutput)
     if p.returncode != 0:
         sys.stdout.write(myoutput)
     return p.returncode
 
 # kill process
 def KillProc(p, timeout):
-    k = subprocess.Popen(['kill',str(p.pid)])
+    k = Popen(['kill',str(p.pid)])
     k.wait()
     now = time.time()
     end_time = now + timeout # give it a little time
@@ -344,7 +372,7 @@ def KillProc(p, timeout):
             return
         now = time.time()
     # use the big hammer (and don't bother waiting)
-    subprocess.Popen(['kill','-9', str(p.pid)])
+    Popen(['kill','-9', str(p.pid)])
     return
 
 # clean up after the test has been built
@@ -364,11 +392,11 @@ def cleanup(execname):
             lsof = which('lsof')
             if handle is not None:
                 sys.stdout.write('[Inspecting open file handles with: {0}\n'.format(handle))
-                subprocess.Popen([handle]).communicate()
+                Popen([handle]).communicate()
             elif lsof is not None:
                 cmd = [lsof, execname]
                 sys.stdout.write('[Inspecting open file handles with: {0}\n'.format(' '.join(cmd)))
-                subprocess.Popen(cmd).communicate()
+                Popen(cmd).communicate()
 
         # Do not print the warning for cygwin32 when errno is 16 (Device or resource busy).
         if not (getattr(ex, 'errno', 0) == 16 and platform == 'cygwin32'):
@@ -444,7 +472,7 @@ def ReadIntegerValue(f, localdir):
             if l[0] == '#':
                 continue
             if IsInteger(l):
-                return string.atoi(l)
+                return int(l)
             else:
                 break
     Fatal('Invalid integer value in '+f+' ('+localdir+')')
@@ -524,10 +552,8 @@ def get_exec_log_name(execname, comp_opts_count=None, exec_opts_count=None):
 # Use testEnv to process skipif files, it works for executable and
 # non-executable versions
 def runSkipIf(skipifName):
-    p = subprocess.Popen([utildir+'/test/testEnv', './'+skipifName], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    p = Popen([utildir+'/test/testEnv', './'+skipifName], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     (stdout, stderr) = p.communicate()
-    stdout = bytes_to_str(stdout)
-    stderr = bytes_to_str(stderr)
     status = p.returncode
 
     stderr = stderr.strip()
@@ -583,11 +609,10 @@ utildir = os.path.realpath(utildir)
 # We open the compileline inside of CHPL_HOME rather than CHPL_TEST_UTIL_DIR on
 # purpose. compileline will not work correctly in some configurations when run
 # outside of its directory tree.
-p = subprocess.Popen([os.path.join(chpl_home,'util','config','compileline'),
+p = Popen([os.path.join(chpl_home,'util','config','compileline'),
                         '--compile'],
-                    stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-c_compiler = p.communicate()[0]
-c_compiler = bytes_to_str(c_compiler).rstrip()
+          stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+c_compiler = p.communicate()[0].rstrip()
 if p.returncode != 0:
   Fatal('Cannot find c compiler')
 
@@ -618,8 +643,7 @@ if useTimedExec:
 # sys.stdout.write('timedexec='+timedexec+'\n');
 
 # HW platform
-platform=subprocess.Popen([utildir+'/chplenv/chpl_platform.py', '--target'], stdout=subprocess.PIPE).communicate()[0]
-platform = bytes_to_str(platform)
+platform=Popen([utildir+'/chplenv/chpl_platform.py', '--target'], stdout=subprocess.PIPE).communicate()[0]
 platform = platform.strip()
 # sys.stdout.write('platform='+platform+'\n')
 
@@ -760,14 +784,12 @@ else:
 
 globalLastcompopts=list();
 if os.access('./LASTCOMPOPTS',os.R_OK):
-    globalLastcompoptsBytes = subprocess.Popen(['cat', './LASTCOMPOPTS'], stdout=subprocess.PIPE).communicate()[0]
-    globalLastcompopts+=bytes_to_str(globalLastcompoptsBytes).strip().split()
+    globalLastcompopts+=Popen(['cat', './LASTCOMPOPTS'], stdout=subprocess.PIPE).communicate()[0].strip().split()
 # sys.stdout.write('globalLastcompopts=%s\n'%(globalLastcompopts))
 
 globalLastexecopts=list();
 if os.access('./LASTEXECOPTS',os.R_OK):
-    globalLastexecoptsBytes = subprocess.Popen(['cat', './LASTEXECOPTS'], stdout=subprocess.PIPE).communicate()[0]
-    globalLastexecopts+=bytes_to_str(globalLastexecoptsBytes).strip().split()
+    globalLastexecopts+=Popen(['cat', './LASTEXECOPTS'], stdout=subprocess.PIPE).communicate()[0].strip().split()
 # sys.stdout.write('globalLastexecopts=%s\n'%(globalLastexecopts))
 
 if os.access(PerfDirFile('NUMLOCALES'),os.R_OK):
@@ -785,8 +807,7 @@ if maxLocalesAvailable is not None:
     maxLocalesAvailable = int(maxLocalesAvailable)
 
 if os.access('./CATFILES',os.R_OK):
-    globalCatfiles=subprocess.Popen(['cat', './CATFILES'], stdout=subprocess.PIPE).communicate()[0]
-    globalCatfiles = bytes_to_str(globalCatfiles)
+    globalCatfiles=Popen(['cat', './CATFILES'], stdout=subprocess.PIPE).communicate()[0]
     globalCatfiles.strip(globalCatfiles)
 else:
     globalCatfiles=None
@@ -1167,20 +1188,18 @@ for testname in testsrc:
             killtimeout=ReadIntegerValue(f, localdir)
 
         elif (suffix=='.catfiles' and os.access(f, os.R_OK)):
-            execcatfiles=bytes_to_str(subprocess.Popen(['cat', f], stdout=subprocess.PIPE).communicate()[0]).strip()
+            execcatfiles=Popen(['cat', f], stdout=subprocess.PIPE).communicate()[0].strip()
             if catfiles:
                 catfiles+=execcatfiles
             else:
                 catfiles=execcatfiles
 
         elif (suffix=='.lastcompopts' and os.access(f, os.R_OK)):
-            lastcompoptsBytes = subprocess.Popen(['cat', f], stdout=subprocess.PIPE).communicate()[0]
-            lastcompopts+=bytes_to_str(lastcompoptsBytes).strip().split()
+            lastcompopts+=Popen(['cat', f], stdout=subprocess.PIPE).communicate()[0].strip().split()
             # sys.stdout.write("lastcompopts=%s\n"%(lastcompopts))
 
         elif (suffix=='.lastexecopts' and os.access(f, os.R_OK)):
-            lastexecoptsBytes = subprocess.Popen(['cat', f], stdout=subprocess.PIPE).communicate()[0]
-            lastexecopts+=bytes_to_str(lastexecoptsBytes).strip().split()
+            lastexecopts+=Popen(['cat', f], stdout=subprocess.PIPE).communicate()[0].strip().split()
             # sys.stdout.write("lastexecopts=%s\n"%(lastexecopts))
 
         elif (suffix==PerfSfx('numlocales') and os.access(f, os.R_OK)):
@@ -1371,22 +1390,21 @@ for testname in testsrc:
         if globalPrecomp:
             sys.stdout.write('[Executing ./PRECOMP]\n')
             sys.stdout.flush()
-            p = subprocess.Popen(['./PRECOMP',
-                                  execname,complog,compiler],
-                                 stdout=subprocess.PIPE,
-                                 stderr=subprocess.STDOUT)
-            out = bytes_to_str(out)
-            sys.stdout.write(out)
+            p = Popen(['./PRECOMP',
+                       execname,complog,compiler],
+                      stdout=subprocess.PIPE,
+                      stderr=subprocess.STDOUT)
+            sys.stdout.write(p.communicate()[0])
             sys.stdout.flush()
 
         if precomp:
             sys.stdout.write('[Executing precomp %s.precomp]\n'%(test_filename))
             sys.stdout.flush()
-            p = subprocess.Popen(['./'+test_filename+'.precomp',
-                                  execname,complog,compiler],
-                                 stdout=subprocess.PIPE,
-                                 stderr=subprocess.STDOUT)
-            sys.stdout.write(bytes_to_str(p.communicate()[0]))
+            p = Popen(['./'+test_filename+'.precomp',
+                       execname,complog,compiler],
+                      stdout=subprocess.PIPE,
+                      stderr=subprocess.STDOUT)
+            sys.stdout.write(p.communicate()[0])
             sys.stdout.flush()
 
 
@@ -1454,12 +1472,12 @@ for testname in testsrc:
         sys.stdout.flush()
         if useTimedExec:
             wholecmd = cmd+' '+' '.join(map(ShellEscape, args))
-            p = subprocess.Popen([timedexec, str(comptimeout), wholecmd],
-                                 env=dict(list(os.environ.items()) + list(testcompenv.items())),
-                                 stdin=open(compstdin, 'r'),
-                                 stdout=subprocess.PIPE,
-                                 stderr=subprocess.STDOUT)
-            output = bytes_to_str(p.communicate()[0])
+            p = Popen([timedexec, str(comptimeout), wholecmd],
+                      env=dict(list(os.environ.items()) + list(testcompenv.items())),
+                      stdin=open(compstdin, 'r'),
+                      stdout=subprocess.PIPE,
+                      stderr=subprocess.STDOUT)
+            output = p.communicate()[0]
             status = p.returncode
 
             if status == 222:
@@ -1474,11 +1492,11 @@ for testname in testsrc:
                 continue # on to next compopts
 
         else:
-            p = subprocess.Popen([cmd]+args,
-                                 env=dict(list(os.environ.items()) + list(testcompenv.items())),
-                                 stdin=open(cmpstdin, 'r'),
-                                 stdout=subprocess.PIPE,
-                                 stderr=subprocess.STDOUT)
+            p = Popen([cmd]+args,
+                      env=dict(list(os.environ.items()) + list(testcompenv.items())),
+                      stdin=open(cmpstdin, 'r'),
+                      stdout=subprocess.PIPE,
+                      stderr=subprocess.STDOUT)
             try:
                 output = SuckOutputWithTimeout(p.stdout, comptimeout)
             except ReadTimeoutException:
@@ -1519,11 +1537,9 @@ for testname in testsrc:
                 sys.stdout.write('[Concatenating extra files: %s]\n'%
                                  (test_filename+'.catfiles'))
                 sys.stdout.flush()
-                output+=subprocess.Popen(['cat']+catfiles.split(),
-                                         stdout=subprocess.PIPE,
-                                         stderr=subprocess.STDOUT).communicate()[0]
-
-            output = bytes_to_str(output)
+                output+=Popen(['cat']+catfiles.split(),
+                              stdout=subprocess.PIPE,
+                              stderr=subprocess.STDOUT).communicate()[0]
 
             # Sadly these scripts require an actual file
             with open(complog, 'w') as complogfile:
@@ -1532,40 +1548,37 @@ for testname in testsrc:
             if systemPrediff:
                 sys.stdout.write('[Executing system-wide prediff]\n')
                 sys.stdout.flush()
-                p = subprocess.Popen([systemPrediff,
-                                      execname,complog,compiler,
-                                      ' '.join(envCompopts)+' '+compopts,
-                                      ' '.join(args)],
-                                     stdout=subprocess.PIPE,
-                                     stderr=subprocess.STDOUT)
-                out = bytes_to_str(p.communicate()[0])
-                sys.stdout.write(out)
+                p = Popen([systemPrediff,
+                           execname,complog,compiler,
+                           ' '.join(envCompopts)+' '+compopts,
+                           ' '.join(args)],
+                          stdout=subprocess.PIPE,
+                          stderr=subprocess.STDOUT)
+                sys.stdout.write(p.communicate()[0])
                 sys.stdout.flush()
 
             if globalPrediff:
                 sys.stdout.write('[Executing ./PREDIFF]\n')
                 sys.stdout.flush()
-                p = subprocess.Popen(['./PREDIFF',
-                                      execname,complog,compiler,
-                                      ' '.join(envCompopts)+' '+compopts,
-                                      ' '.join(args)],
-                                     stdout=subprocess.PIPE,
-                                     stderr=subprocess.STDOUT)
-                out = bytes_to_str(p.communicate()[0])
-                sys.stdout.write(out)
+                p = Popen(['./PREDIFF',
+                           execname,complog,compiler,
+                           ' '.join(envCompopts)+' '+compopts,
+                           ' '.join(args)],
+                          stdout=subprocess.PIPE,
+                          stderr=subprocess.STDOUT)
+                sys.stdout.write(p.communicate()[0])
                 sys.stdout.flush()
 
             if prediff:
                 sys.stdout.write('[Executing prediff %s.prediff]\n'%(test_filename))
                 sys.stdout.flush()
-                p = subprocess.Popen(['./'+test_filename+'.prediff',
-                                      execname,complog,compiler,
-                                      ' '.join(envCompopts)+' '+compopts,
-                                      ' '.join(args)],
-                                     stdout=subprocess.PIPE,
-                                     stderr=subprocess.STDOUT)
-                out = bytes_to_str(p.communicate()[0])
-                sys.stdout.write(out)
+                p = Popen(['./'+test_filename+'.prediff',
+                           execname,complog,compiler,
+                           ' '.join(envCompopts)+' '+compopts,
+                           ' '.join(args)],
+                          stdout=subprocess.PIPE,
+                          stderr=subprocess.STDOUT)
+                sys.stdout.write(p.communicate()[0])
                 sys.stdout.flush()
 
 
@@ -1694,8 +1707,8 @@ for testname in testsrc:
                 # computePerfStats for the current test
                 sys.stdout.write('[Executing computePerfStats %s %s %s %s %s]\n'%(datFileName, tempDatFilesDir, keyfile, printpassesfile, 'False'))
                 sys.stdout.flush()
-                p = subprocess.Popen([utildir+'/test/computePerfStats', datFileName, tempDatFilesDir, keyfile, printpassesfile, 'False'], stdout=subprocess.PIPE)
-                compkeysOutput = bytes_to_str(p.communicate()[0])
+                p = Popen([utildir+'/test/computePerfStats', datFileName, tempDatFilesDir, keyfile, printpassesfile, 'False'], stdout=subprocess.PIPE)
+                compkeysOutput = p.communicate()[0]
                 datFiles = [tempDatFilesDir+'/'+datFileName+'.dat',  tempDatFilesDir+'/'+datFileName+'.error']
                 status = p.returncode
 
@@ -1759,31 +1772,31 @@ for testname in testsrc:
             if systemPreexec:
                 sys.stdout.write('[Executing system-wide preexec]\n')
                 sys.stdout.flush()
-                p = subprocess.Popen([systemPreexec,
-                                      execname,execlog,compiler],
-                                     stdout=subprocess.PIPE,
-                                     stderr=subprocess.STDOUT)
-                sys.stdout.write(bytes_to_str(p.communicate()[0]))
+                p = Popen([systemPreexec,
+                           execname,execlog,compiler],
+                          stdout=subprocess.PIPE,
+                          stderr=subprocess.STDOUT)
+                sys.stdout.write(p.communicate()[0])
                 sys.stdout.flush()
 
             if globalPreexec:
                 sys.stdout.write('[Executing ./PREEXEC]\n')
                 sys.stdout.flush()
-                p = subprocess.Popen(['./PREEXEC',
-                                      execname,execlog,compiler],
-                                     stdout=subprocess.PIPE,
-                                     stderr=subprocess.STDOUT)
-                sys.stdout.write(bytes_to_str(p.communicate()[0]))
+                p = Popen(['./PREEXEC',
+                           execname,execlog,compiler],
+                          stdout=subprocess.PIPE,
+                          stderr=subprocess.STDOUT)
+                sys.stdout.write(p.communicate()[0])
                 sys.stdout.flush()
 
             if preexec:
                 sys.stdout.write('[Executing preexec %s.preexec]\n'%(test_filename))
                 sys.stdout.flush()
-                p = subprocess.Popen(['./'+test_filename+'.preexec',
-                                      execname,execlog,compiler],
-                                     stdout=subprocess.PIPE,
-                                     stderr=subprocess.STDOUT)
-                sys.stdout.write(bytes_to_str(p.communicate()[0]))
+                p = Popen(['./'+test_filename+'.preexec',
+                           execname,execlog,compiler],
+                          stdout=subprocess.PIPE,
+                          stderr=subprocess.STDOUT)
+                sys.stdout.write(p.communicate()[0])
                 sys.stdout.flush()
 
             pre_exec_output = ''
@@ -1896,12 +1909,12 @@ for testname in testsrc:
                         else:
                             my_stdin=open(redirectin, 'r')
                         test_command = [cmd] + args + LauncherTimeoutArgs(timeout)
-                        p = subprocess.Popen(test_command,
-                                            env=dict(list(os.environ.items()) + list(testenv.items())),
-                                            stdin=my_stdin,
-                                            stdout=subprocess.PIPE,
-                                            stderr=subprocess.STDOUT)
-                        output = bytes_to_str(p.communicate()[0])
+                        p = Popen(test_command,
+                                  env=dict(list(os.environ.items()) + list(testenv.items())),
+                                  stdin=my_stdin,
+                                  stdout=subprocess.PIPE,
+                                  stderr=subprocess.STDOUT)
+                        output = p.communicate()[0]
                         status = p.returncode
 
                         if re.search('slurmstepd: Munge decode failed: Expired credential', output, re.IGNORECASE) != None:
@@ -1943,12 +1956,12 @@ for testname in testsrc:
                             my_stdin = sys.stdin
                         else:
                             my_stdin = open(redirectin, 'r')
-                        p = subprocess.Popen([timedexec, str(timeout), wholecmd],
-                                            env=dict(list(os.environ.items()) + list(testenv.items())),
-                                            stdin=my_stdin,
-                                            stdout=subprocess.PIPE,
-                                            stderr=subprocess.STDOUT)
-                        output = bytes_to_str(p.communicate()[0])
+                        p = Popen([timedexec, str(timeout), wholecmd],
+                                  env=dict(list(os.environ.items()) + list(testenv.items())),
+                                  stdin=my_stdin,
+                                  stdout=subprocess.PIPE,
+                                  stderr=subprocess.STDOUT)
+                        output = p.communicate()[0]
                         status = p.returncode
 
                         if status == 222:
@@ -1977,11 +1990,11 @@ for testname in testsrc:
                             my_stdin = None
                         else:
                             my_stdin=open(redirectin, 'r')
-                        p = subprocess.Popen([cmd]+args,
-                                            env=dict(list(os.environ.items()) + list(testenv.items())),
-                                            stdin=my_stdin,
-                                            stdout=subprocess.PIPE,
-                                            stderr=subprocess.STDOUT)
+                        p = Popen([cmd]+args,
+                                  env=dict(list(os.environ.items()) + list(testenv.items())),
+                                  stdin=my_stdin,
+                                  stdout=subprocess.PIPE,
+                                  stderr=subprocess.STDOUT)
                         try:
                             output = SuckOutputWithTimeout(p.stdout, timeout)
                         except ReadTimeoutException:
@@ -2034,10 +2047,9 @@ for testname in testsrc:
                     sys.stdout.write('[Concatenating extra files: %s]\n'%
                                     (test_filename+'.catfiles'))
                     sys.stdout.flush()
-                    catfilesOutputBytes = subprocess.Popen(['cat']+catfiles.split(),
-                                            stdout=subprocess.PIPE,
-                                            stderr=subprocess.STDOUT).communicate()[0]
-                    output+=bytes_to_str(catfilesOutputBytes)
+                    output+=Popen(['cat']+catfiles.split(),
+                                  stdout=subprocess.PIPE,
+                                  stderr=subprocess.STDOUT).communicate()[0]
 
                 # Sadly the scripts used below require an actual file
                 with open(execlog, 'w') as execlogfile:
@@ -2048,38 +2060,35 @@ for testname in testsrc:
                     if systemPrediff:
                         sys.stdout.write('[Executing system-wide prediff]\n')
                         sys.stdout.flush()
-                        systemPrediffBytes = subprocess.Popen([systemPrediff,
-                                                          execname,execlog,compiler,
-                                                          ' '.join(envCompopts)+
-                                                          ' '+compopts,
-                                                          ' '.join(args)],
-                                                          stdout=subprocess.PIPE,
-                                                          stderr=subprocess.STDOUT).communicate()[0]
-                        sys.stdout.write(bytes_to_str(systemPrediffBytes))
+                        sys.stdout.write(Popen([systemPrediff,
+                                                execname,execlog,compiler,
+                                                ' '.join(envCompopts)+
+                                                ' '+compopts,
+                                                ' '.join(args)],
+                                               stdout=subprocess.PIPE,
+                                               stderr=subprocess.STDOUT).communicate()[0])
 
                     if globalPrediff:
                         sys.stdout.write('[Executing ./PREDIFF]\n')
                         sys.stdout.flush()
-                        globalPrediffBytes = subprocess.Popen(['./PREDIFF',
-                                                          execname,execlog,compiler,
-                                                          ' '.join(envCompopts)+
-                                                          ' '+compopts,
-                                                          ' '.join(args)],
-                                                          stdout=subprocess.PIPE,
-                                                          stderr=subprocess.STDOUT).communicate()[0]
-                        sys.stdout.write(bytes_to_str(globalPrediffBytes))
+                        sys.stdout.write(Popen(['./PREDIFF',
+                                                execname,execlog,compiler,
+                                                ' '.join(envCompopts)+
+                                                ' '+compopts,
+                                                ' '.join(args)],
+                                               stdout=subprocess.PIPE,
+                                               stderr=subprocess.STDOUT).communicate()[0])
 
                     if prediff:
                         sys.stdout.write('[Executing prediff ./%s]\n'%(prediff))
                         sys.stdout.flush()
-                        prediffBytes = subprocess.Popen(['./'+prediff,
-                                                          execname,execlog,compiler,
-                                                          ' '.join(envCompopts)+
-                                                          ' '+compopts,
-                                                          ' '.join(args)],
-                                                          stdout=subprocess.PIPE,
-                                                          stderr=subprocess.STDOUT).communicate()[0]
-                        sys.stdout.write(bytes_to_str(prediffBytes))
+                        sys.stdout.write(Popen(['./'+prediff,
+                                                execname,execlog,compiler,
+                                                ' '.join(envCompopts)+
+                                                ' '+compopts,
+                                                ' '.join(args)],
+                                               stdout=subprocess.PIPE,
+                                               stderr=subprocess.STDOUT).communicate()[0])
 
                     if not perftest:
                         # find the good file 
@@ -2104,9 +2113,8 @@ for testname in testsrc:
                         if not os.path.isfile(execgoodfile) or not os.access(execgoodfile, os.R_OK):
                             sys.stdout.write('[Error cannot locate program output comparison file %s/%s]\n'%(localdir, execgoodfile))
                             sys.stdout.write('[Execution output was as follows:]\n')
-                            exec_output = subprocess.Popen(['cat', execlog],
+                            exec_output = Popen(['cat', execlog],
                                 stdout=subprocess.PIPE).communicate()[0]
-                            exec_output = bytes_to_str(exec_output)
                             sys.stdout.write(trim_output(exec_output))
 
                             continue # on to next execopts
@@ -2191,10 +2199,10 @@ for testname in testsrc:
                     sys.stdout.write('[Executing %s/test/computePerfStats %s %s %s %s %s %s]\n'%(utildir, perfexecname, perfdir, keyfile, execlog, str(exectimeout), perfdate))
                     sys.stdout.flush()
 
-                    p = subprocess.Popen([utildir+'/test/computePerfStats',
-                                          perfexecname, perfdir, keyfile, execlog, str(exectimeout), perfdate],
-                                         stdout=subprocess.PIPE)
-                    sys.stdout.write('%s'%(bytes_to_str(p.communicate()[0])))
+                    p = Popen([utildir+'/test/computePerfStats',
+                               perfexecname, perfdir, keyfile, execlog, str(exectimeout), perfdate],
+                              stdout=subprocess.PIPE)
+                    sys.stdout.write('%s'%(p.communicate()[0]))
                     sys.stdout.flush()
 
                     status = p.returncode

--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -168,7 +168,11 @@ class ReadTimeoutException(Exception): pass
 
 def bytes_to_str(byte_string):
     if sys.version_info[0] >= 3 and not isinstance(byte_string, str):
-        return str(byte_string, 'utf-8')
+        try:
+            return str(byte_string, 'utf-8')
+        except UnicodeDecodeError as e:
+            pass
+        return byte_string
     else:
         return byte_string
 
@@ -2052,9 +2056,19 @@ for testname in testsrc:
                                   stderr=subprocess.STDOUT).communicate()[0]
 
                 # Sadly the scripts used below require an actual file
-                with open(execlog, 'w') as execlogfile:
-                    execlogfile.write(pre_exec_output)
-                    execlogfile.write(output)
+                open_mode = 'w' if isinstance(output, str) else 'wb'
+                with open(execlog, open_mode) as execlogfile:
+                    if sys.version_info[0] >= 3 and open_mode == 'wb' and not isinstance(pre_exec_output, bytes):
+                        pre_exec_output_content = bytes(pre_exec_output, 'utf-8')
+                    else:
+                        pre_exec_output_content = pre_exec_output
+                    execlogfile.write(pre_exec_output_content)
+
+                    if sys.version_info[0] >= 3 and open_mode == 'wb' and not isinstance(output, bytes):
+                        output_content = bytes(output, 'utf-8')
+                    else:
+                        output_content = output
+                    execlogfile.write(output_content)
 
                 if not exectimeout and not launcher_error:
                     if systemPrediff:

--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -2054,8 +2054,7 @@ for testname in testsrc:
                                                           ' '+compopts,
                                                           ' '.join(args)],
                                                           stdout=subprocess.PIPE,
-                                                          stderr=subprocess.STDOUT).
-                                        communicate()[0]
+                                                          stderr=subprocess.STDOUT).communicate()[0]
                         sys.stdout.write(bytes_to_str(systemPrediffBytes))
 
                     if globalPrediff:
@@ -2067,8 +2066,7 @@ for testname in testsrc:
                                                           ' '+compopts,
                                                           ' '.join(args)],
                                                           stdout=subprocess.PIPE,
-                                                          stderr=subprocess.STDOUT).
-                                        communicate()[0]
+                                                          stderr=subprocess.STDOUT).communicate()[0]
                         sys.stdout.write(bytes_to_str(globalPrediffBytes))
 
                     if prediff:
@@ -2080,8 +2078,7 @@ for testname in testsrc:
                                                           ' '+compopts,
                                                           ' '.join(args)],
                                                           stdout=subprocess.PIPE,
-                                                          stderr=subprocess.STDOUT).
-                                        communicate()[0]
+                                                          stderr=subprocess.STDOUT).communicate()[0]
                         sys.stdout.write(bytes_to_str(prediffBytes))
 
                     if not perftest:

--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -165,6 +165,14 @@ atexit.register(elapsed_sub_test_time)
 #
 class ReadTimeoutException(Exception): pass
 
+
+def bytes_to_str(byte_string):
+    if sys.version_info[0] >= 3 and not isinstance(byte_string, str):
+        return str(byte_string, 'utf-8')
+    else:
+        return byte_string
+
+
 def SetNonBlock(stream):
     flags = fcntl.fcntl(stream.fileno(), fcntl.F_GETFL)
     flags |= os.O_NONBLOCK
@@ -298,6 +306,7 @@ def DiffFiles(f1, f2):
     p = subprocess.Popen(['diff',f1,f2],
                          stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     myoutput = p.communicate()[0] # grab stdout to avoid potential deadlock
+    myoutput = bytes_to_str(myoutput)
     if p.returncode != 0:
         sys.stdout.write(trim_output(myoutput))
     return p.returncode
@@ -307,6 +316,7 @@ def DiffBinaryFiles(f1, f2):
     p = subprocess.Popen(['diff', '-a', f1,f2],
                          stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     myoutput = p.communicate()[0] # grab stdout to avoid potential deadlock
+    myoutput = bytes_to_str(myoutput)
     if p.returncode != 0:
         sys.stdout.write(trim_output(myoutput))
     return p.returncode
@@ -318,6 +328,7 @@ def DiffBadFiles(f1, f2):
     p = subprocess.Popen([utildir+'/test/diff-ignoring-module-line-numbers', f1, f2],
                          stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     myoutput = p.communicate()[0] # grab stdout to avoid potential deadlock
+    myoutput = bytes_to_str(myoutput)
     if p.returncode != 0:
         sys.stdout.write(myoutput)
     return p.returncode
@@ -534,7 +545,7 @@ def runSkipIf(skipifName):
 #
 
 if len(sys.argv)!=2:
-    print 'usage: sub_test COMPILER'
+    print('usage: sub_test COMPILER')
     sys.exit(0)
 
 # Find the base installation
@@ -605,6 +616,7 @@ if useTimedExec:
 
 # HW platform
 platform=subprocess.Popen([utildir+'/chplenv/chpl_platform.py', '--target'], stdout=subprocess.PIPE).communicate()[0]
+platform = bytes_to_str(platform)
 platform = platform.strip()
 # sys.stdout.write('platform='+platform+'\n')
 
@@ -632,13 +644,13 @@ if os.getenv('CHPL_TEST_UNIQUIFY_EXE') != None:
     uniquifyTests = True
 
 # Get the current directory (normalize for MacOS case-sort-of-sensitivity)
-localdir = string.replace(os.path.normpath(os.getcwd()), testdir, '.')
+localdir = os.path.normpath(os.getcwd()).replace(testdir, '.')
 # sys.stdout.write('localdir=%s\n'%(localdir))
 
 if localdir.find('./') == 0:
     # strip off the leading './'
-    localdir = string.lstrip(localdir, '.')
-    localdir = string.lstrip(localdir, '/')
+    localdir = localdir.lstrip('.')
+    localdir = localdir.lstrip('/')
 # sys.stdout.write('localdir=%s\n'%(localdir))
 
 # CHPL_COMM
@@ -809,7 +821,7 @@ else:
 # Misc set up
 #
 
-testfutures=string.atoi(os.getenv('CHPL_TEST_FUTURES','0'))
+testfutures=int(os.getenv('CHPL_TEST_FUTURES','0'))
 # sys.stdout.write('testfutures=%s\n'%(testfutures))
 
 testnotests=os.getenv('CHPL_TEST_NOTESTS')
@@ -1355,7 +1367,8 @@ for testname in testsrc:
                                   execname,complog,compiler],
                                  stdout=subprocess.PIPE,
                                  stderr=subprocess.STDOUT)
-            sys.stdout.write(p.communicate()[0])
+            out = bytes_to_str(out)
+            sys.stdout.write(out)
             sys.stdout.flush()
 
         if precomp:
@@ -1434,7 +1447,7 @@ for testname in testsrc:
         if useTimedExec:
             wholecmd = cmd+' '+' '.join(map(ShellEscape, args))
             p = subprocess.Popen([timedexec, str(comptimeout), wholecmd],
-                                 env=dict(os.environ.items() + testcompenv.items()),
+                                 env=dict(list(os.environ.items()) + list(testcompenv.items())),
                                  stdin=open(compstdin, 'r'),
                                  stdout=subprocess.PIPE,
                                  stderr=subprocess.STDOUT)
@@ -1454,7 +1467,7 @@ for testname in testsrc:
 
         else:
             p = subprocess.Popen([cmd]+args,
-                                 env=dict(os.environ.items() + testcompenv.items()),
+                                 env=dict(list(os.environ.items()) + list(testcompenv.items())),
                                  stdin=open(cmpstdin, 'r'),
                                  stdout=subprocess.PIPE,
                                  stderr=subprocess.STDOUT)
@@ -1502,10 +1515,11 @@ for testname in testsrc:
                                          stdout=subprocess.PIPE,
                                          stderr=subprocess.STDOUT).communicate()[0]
 
+            output = bytes_to_str(output)
+
             # Sadly these scripts require an actual file
-            complogfile=file(complog, 'w')
-            complogfile.write('%s'%(output))
-            complogfile.close()
+            with open(complog, 'w') as complogfile:
+                complogfile.write('%s'%(output))
 
             if systemPrediff:
                 sys.stdout.write('[Executing system-wide prediff]\n')
@@ -1516,7 +1530,8 @@ for testname in testsrc:
                                       ' '.join(args)],
                                      stdout=subprocess.PIPE,
                                      stderr=subprocess.STDOUT)
-                sys.stdout.write(p.communicate()[0])
+                out = bytes_to_str(p.communicate()[0])
+                sys.stdout.write(out)
                 sys.stdout.flush()
 
             if globalPrediff:
@@ -1528,7 +1543,8 @@ for testname in testsrc:
                                       ' '.join(args)],
                                      stdout=subprocess.PIPE,
                                      stderr=subprocess.STDOUT)
-                sys.stdout.write(p.communicate()[0])
+                out = bytes_to_str(p.communicate()[0])
+                sys.stdout.write(out)
                 sys.stdout.flush()
 
             if prediff:
@@ -1540,7 +1556,8 @@ for testname in testsrc:
                                       ' '.join(args)],
                                      stdout=subprocess.PIPE,
                                      stderr=subprocess.STDOUT)
-                sys.stdout.write(p.communicate()[0])
+                out = bytes_to_str(p.communicate()[0])
+                sys.stdout.write(out)
                 sys.stdout.flush()
 
 
@@ -1869,10 +1886,10 @@ for testname in testsrc:
                         if redirectin == None:
                             my_stdin = None
                         else:
-                            my_stdin=file(redirectin, 'r')
+                            my_stdin=open(redirectin, 'r')
                         test_command = [cmd] + args + LauncherTimeoutArgs(timeout)
                         p = subprocess.Popen(test_command,
-                                            env=dict(os.environ.items() + testenv.items()),
+                                            env=dict(list(os.environ.items()) + list(testenv.items())),
                                             stdin=my_stdin,
                                             stdout=subprocess.PIPE,
                                             stderr=subprocess.STDOUT)
@@ -1917,9 +1934,9 @@ for testname in testsrc:
                         if redirectin == None:
                             my_stdin = sys.stdin
                         else:
-                            my_stdin = file(redirectin, 'r')
+                            my_stdin = open(redirectin, 'r')
                         p = subprocess.Popen([timedexec, str(timeout), wholecmd],
-                                            env=dict(os.environ.items() + testenv.items()),
+                                            env=dict(list(os.environ.items()) + list(testenv.items())),
                                             stdin=my_stdin,
                                             stdout=subprocess.PIPE,
                                             stderr=subprocess.STDOUT)
@@ -1951,9 +1968,9 @@ for testname in testsrc:
                         if redirectin == None:
                             my_stdin = None
                         else:
-                            my_stdin=file(redirectin, 'r')
+                            my_stdin=open(redirectin, 'r')
                         p = subprocess.Popen([cmd]+args,
-                                            env=dict(os.environ.items() + testenv.items()),
+                                            env=dict(list(os.environ.items()) + list(testenv.items())),
                                             stdin=my_stdin,
                                             stdout=subprocess.PIPE,
                                             stderr=subprocess.STDOUT)


### PR DESCRIPTION
This fixes a bunch of python 3 incompatibilities across start_test/sub_test and
preexecs, prediffs, and other python scripts. With this I'm able to run a full
standard paratest with Python 3 (tested with 3.6.0)

Here's a summary of the changes:
- print statement is removed in python 3; use print function
- `execfile()` no longer exists; open the file and manually compile/exec
- `file()` no longer exists; use `open()` instead
 - `iteritems()` no longer exists; use `items()` (slower in py2, but oh well)
- `dict.items()` returns iterator now; convert to list before using
- `zip()` returns iterator now; convert to list before using
- Octal ints must use `0o123` format in python 3, instead of `0123` form
- `reduce()` is no longer available; use `functools.reduce()` instead
- `xrange()` no longer exists; use `range()` instead
- `string.find(s, sub)` no longer exists; use `s.find(sub)` instead
- `dict.has_key(key)` no longer exists; use `key in dict` instead
- update PyYAML to 3.13 for Python 3.7 compatibility
-  subprocess output is bytes() type in python 3. Convert output to utf-8
   string before using under python 3. We aren't always consistent about how
   this conversion is done:
   - for simple cases we just use `.decode()` on the output
   - for other cases we `use str(bytes_string, 'utf-8')` on the output
   - for sub_test we made a Python 3 compatible Popen that tries to convert
     the output of communicate to str, but will allow bytes if we can't
     convert. We also have some special case code for catfiles and writing to
     the exec_output file. This is because some of our testing output is
     actually binary (mandlebrot, c-ray, etc.) so we can't just force utf-8
     strings all the time.

Resolves https://github.com/chapel-lang/chapel/issues/8976