### PR TITLE
Expand our Python 3 testing

### DIFF
--- a/util/cron/test-linux64-python3.bash
+++ b/util/cron/test-linux64-python3.bash
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#
+# Test default configuration on examples only, on linux64, with python 3
+
+CWD=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
+source $CWD/common.bash
+
+# Python 3 env is setup by jenkins
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-python3"
+
+$CWD/nightly -cron -examples ${nightly_args}


### PR DESCRIPTION
Previously we only did a `make && make check` to check that our core
scripts were Python 3 compatible, but other scripts should now work with
Python 3. Run release/examples under nightly, which should test building
the test-venv and chpldoc-venv as well as running chpldoc/start_test and
a majority of our python scripts.