### PR TITLE
Use common verbose comm interface for cached comm verbose comm msgs.

### DIFF
--- a/runtime/src/chpl-cache.c
+++ b/runtime/src/chpl-cache.c
@@ -273,6 +273,7 @@ use.
 
 #include "chplrt.h"
 #include "chpl-comm.h"
+#include "chpl-comm-diags.h"
 #include "chpl-tasks.h"
 #include "chpl-mem.h"
 #include "chpl-atomics.h"
@@ -2798,9 +2799,8 @@ void chpl_cache_comm_put(void* addr, c_nodeid_t node, void* raddr,
                "from %p\n",
                chpl_nodeID, (int)chpl_task_getId(), chpl_lookupFilename(fn), ln,
                (int)size, node, raddr, addr));
-  if (chpl_verbose_comm)
-    printf("%d: %s:%d: remote get from %d, %zu bytes\n", chpl_nodeID,
-           chpl_lookupFilename(fn), ln, node, size);
+  chpl_comm_diags_verbose_printf("%s:%d: remote get from %d, %zu bytes\n",
+                                 chpl_lookupFilename(fn), ln, node, size);
 
 #ifdef DUMP
   chpl_cache_print();
@@ -2824,9 +2824,8 @@ void chpl_cache_comm_get(void *addr, c_nodeid_t node, void* raddr,
                "%d:%p to %p\n",
                chpl_nodeID, (int)chpl_task_getId(), chpl_lookupFilename(fn), ln,
                (int)size, node, raddr, addr));
-  if (chpl_verbose_comm)
-    printf("%d: %s:%d: remote put to %d, %zu bytes\n", chpl_nodeID,
-           chpl_lookupFilename(fn), ln, node, size);
+  chpl_comm_diags_verbose_printf("%s:%d: remote put to %d, %zu bytes\n",
+                                 chpl_lookupFilename(fn), ln, node, size);
 
 #ifdef DUMP
   chpl_cache_print();
@@ -2846,9 +2845,8 @@ void chpl_cache_comm_prefetch(c_nodeid_t node, void* raddr,
   struct rdcache_s* cache = tls_cache_remote_data();
   chpl_cache_taskPrvData_t* task_local = task_private_cache_data();
   TRACE_PRINT(("%d: in chpl_cache_comm_prefetch\n", chpl_nodeID));
-  if (chpl_verbose_comm)
-    printf("%d: %s:%d: remote prefetch from %d, %zu bytes\n", chpl_nodeID,
-           chpl_lookupFilename(fn), ln, node, size);
+  chpl_comm_diags_verbose_printf("%s:%d: remote prefetch from %d, %zu bytes\n",
+                                 chpl_lookupFilename(fn), ln, node, size);
   // Always use the cache for prefetches.
   //saturating_increment(&info->prefetch_since_acquire);
   cache_get(cache, NULL, node, (raddr_t)raddr, size, task_local->last_acquire,


### PR DESCRIPTION
This is a follow-on to https://github.com/chapel-lang/chapel/pull/11212 which changed the gasnet- and ugni-based comm layers to use common code for printing verbose comm messages.  Here we catch a few instances of printing verbose comm messages in the cached-comm code, which I missed before.

Testing was `optimizations/cache-remote/` and `test/performance/ferguson/`, plus several manual tests run with `start_test -compopts -sprintInitVerboseComm=true ...` using a runtime modified so that the verbose output from comm caching looked different and could be identified, just to make sure that the messages were being printed.  (Oddly enough with the little effort I put in I couldn't find a test that would fire the 'prefetch' verbose message.  Not even any of the tests with `prefetch` in their name would do it.  But I saw the other two and I'm willing to rely on inspection for the 'prefetch' one.)

This resolves #11527.
