### PR TITLE
Add a future regarding the behavior of isClass*() on managed classes

### DIFF
--- a/test/classes/delete-free/isClassTest.bad
+++ b/test/classes/delete-free/isClassTest.bad
@@ -1,0 +1,36 @@
+isClassTest.chpl:4: In function 'testit':
+isClassTest.chpl:11: warning: result of new C is now managed by default
+isClassTest.chpl:11: note: 'new unmanaged C' gives old behavior
+isClassTest.chpl:11: note: 'new borrowed C' is the new default
+isClassTest.chpl:11: note: 'new owned C', 'new shared C' also available
+isClassTest.chpl:11: note: get more help with --warn-unstable
+C
+true
+true
+true
+true
+
+unmanaged C
+true
+true
+true
+true
+
+C
+true
+true
+true
+true
+
+_owned(C)
+false
+false
+true
+true
+
+_shared(C)
+false
+false
+true
+true
+

--- a/test/classes/delete-free/isClassTest.chpl
+++ b/test/classes/delete-free/isClassTest.chpl
@@ -1,0 +1,23 @@
+class C {
+}
+
+proc testit(type t) {
+  writeln(t:string);
+
+  writeln(isClass(t));
+  writeln(isClassType(t));
+  //  writeln(isClassValue(t));
+
+  var c: t = new t();
+  writeln(isClass(c));
+  //  writeln(isClassType(c));
+  writeln(isClassValue(c));
+
+  writeln();
+}
+
+testit(C);
+testit(unmanaged C);
+testit(borrowed C);
+testit(owned C);
+testit(shared C);

--- a/test/classes/delete-free/isClassTest.future
+++ b/test/classes/delete-free/isClassTest.future
@@ -1,0 +1,11 @@
+bug: isClass() is inconsistent on managed class types vs. values
+
+At present, isClass() queries return 'false' on 'owned' and 'shared'
+types, but 'true' on their values.  This inconsistency seems like a
+bug to me.
+
+There's arguably a question over whether these should return `true` or
+`false` given that we present the types to the user as class flavors
+but their implementation uses a record.  Personally, I believe that
+they should be `true` and that their record nature should not
+influence the impact of these queries on them.

--- a/test/classes/delete-free/isClassTest.good
+++ b/test/classes/delete-free/isClassTest.good
@@ -1,0 +1,36 @@
+isClassTest.chpl:4: In function 'testit':
+isClassTest.chpl:11: warning: result of new C is now managed by default
+isClassTest.chpl:11: note: 'new unmanaged C' gives old behavior
+isClassTest.chpl:11: note: 'new borrowed C' is the new default
+isClassTest.chpl:11: note: 'new owned C', 'new shared C' also available
+isClassTest.chpl:11: note: get more help with --warn-unstable
+C
+true
+true
+true
+true
+
+unmanaged C
+true
+true
+true
+true
+
+C
+true
+true
+true
+true
+
+_owned(C)
+true
+true
+true
+true
+
+_shared(C)
+true
+true
+true
+true
+


### PR DESCRIPTION
This test shows that isClass*() routines give inconsistent results
between managed class types and values.  This seems like a bug.