### PR TITLE
Expand our remote task spawning microbenchmark

### DIFF
--- a/test/ML-GRAPHFILES
+++ b/test/ML-GRAPHFILES
@@ -114,6 +114,7 @@ studies/bale/indexgather/ig.ml-time.graph
 studies/nbody/md.ml-time.graph
 reductions/vass/reductions-perf.ml-time.graph
 parallel/taskCompare/elliot/taskSpawn.ml-time.graph
+parallel/taskCompare/elliot/taskSpawnArg.ml-time.graph
 performance/comm/barrier/empty-chpl-barrier.ml-time.graph
 performance/elliot/no-op.ml-time.graph
 performance/comm/low-level/remote-gets.ml-perf.graph

--- a/test/parallel/taskCompare/elliot/empty-chpl-remote-taskspawn.chpl
+++ b/test/parallel/taskCompare/elliot/empty-chpl-remote-taskspawn.chpl
@@ -2,22 +2,29 @@ use Time;
 
 config const numTrials = 100;
 config const printTimings = false;
+// bogus config const to prevent compiler eliminating tup copy
+config const printTup = false;
 
 enum TaskingMode {
-  coforallOnT
+  emptyCoforallOn,
+  medCoforallOn,
+  largeCoforallOn
 };
 use TaskingMode;
 
-config param taskingMode = coforallOnT;
+config param taskingMode = emptyCoforallOn;
 
 proc main() {
   var t: Timer;
 
   t.start();
   select taskingMode {
-     when coforallOnT do coforallOnTaskSpawn(numTrials);
+     when emptyCoforallOn do coforallOnTaskSpawn();
+     when medCoforallOn   do coforallOnTaskSpawnMed();
+     when largeCoforallOn do coforallOnTaskSpawnLarge();
   }
   t.stop();
+  verifyCounter();
 
   if printTimings {
     writeln("Elapsed time: ", t.elapsed());
@@ -25,8 +32,37 @@ proc main() {
 }
 
 
-proc coforallOnTaskSpawn(trials) {
+// Empty task spawn
+proc coforallOnTaskSpawn() {
   for 1..numTrials do
-    coforall loc in Locales do on loc { }
+    coforall loc in Locales do on loc { incCounter(); }
 }
 
+// 512 byte payload task spawn. At least in 2018 this represents the typical
+// size of remote forks for our multi-locale performance suite
+proc coforallOnTaskSpawnMed() {
+  var tup: 64*int;
+  for 1..numTrials do
+    coforall loc in Locales with (in tup) do on loc { 
+      if printTup then writeln(tup);
+      incCounter();
+    }
+}
+
+// 4096 byte payload task spawn.
+proc coforallOnTaskSpawnLarge() {
+  var tup: 512*int;
+  for 1..numTrials do
+    coforall loc in Locales with (in tup) do on loc { 
+      if printTup then writeln(tup);
+      incCounter();
+    }
+}
+
+pragma "locale private" var counter = 0;
+inline proc incCounter() { counter += 1; }
+inline proc getCounter() { return counter; }
+inline proc verifyCounter() {
+  coforall loc in Locales do on loc do
+    assert(getCounter() == numTrials);
+}

--- a/test/parallel/taskCompare/elliot/empty-chpl-remote-taskspawn.compopts
+++ b/test/parallel/taskCompare/elliot/empty-chpl-remote-taskspawn.compopts
@@ -1,0 +1,3 @@
+-staskingMode=emptyCoforallOn
+-staskingMode=medCoforallOn
+-staskingMode=largeCoforallOn

--- a/test/parallel/taskCompare/elliot/empty-chpl-remote-taskspawn.ml-compopts
+++ b/test/parallel/taskCompare/elliot/empty-chpl-remote-taskspawn.ml-compopts
@@ -1,2 +1,4 @@
--staskingMode=coforallOnT                        # empty-coforall-on
--staskingMode=coforallOnT --network-atomics=none # empty-coforall-on-proc-endcount
+-staskingMode=emptyCoforallOn                        # empty-coforall-on
+-staskingMode=medCoforallOn                          # med-coforall-on
+-staskingMode=largeCoforallOn                        # large-coforall-on
+-staskingMode=emptyCoforallOn --network-atomics=none # empty-coforall-on-proc-endcount

--- a/test/parallel/taskCompare/elliot/taskSpawnArg.ml-time.graph
+++ b/test/parallel/taskCompare/elliot/taskSpawnArg.ml-time.graph
@@ -1,0 +1,5 @@
+perfkeys: Elapsed time:, Elapsed time:, Elapsed time:
+graphkeys: empty coforall+on, med coforall+on, large coforall+on
+files: empty-coforall-on.dat, med-coforall-on.dat, large-coforall-on.dat
+graphtitle: Remote Task Spawn Time
+ylabel: Time (seconds)


### PR DESCRIPTION
Previously we only tested an emtpy coforall+on, but that's not really a good
representation for how we usually spawn remote tasks. This adds versions that
have a 512 byte and 4096 byte argbundle payload. 512 bytes represents the
typical argument bundle size (at least for our multi-locale benchmarks like
STREAM, RA, PRK-Stencil, SSCA and MiniMD) and 4096 is currently massive. The
largest in our multi-locale performance suite was just over 800 bytes.

This arg bundle size is important, because our runtime does different things
for "large" vs "small" forks, so it's worth having timings for different
argument bundle sizes since the performance will be different. Currently ugni
has a 64 byte threshold for small forks. Small forks only require a single put,
whereas large forks require a put, and then the target does a remote get and an
AM to free the arg on the original node. At 16 nodes, large forks are ~60%
slower than small forks (and likely to scale worse because of the AM to to the
spawning node.)