### PR TITLE
Fix python 3 support for `isinstance('str', basestring)`

### DIFF
--- a/util/build_configs/build_configs.py
+++ b/util/build_configs/build_configs.py
@@ -20,6 +20,11 @@ import subprocess
 import sys
 import time
 
+try:
+    basestring
+except NameError:
+    basestring = str
+
 class Dimension(object):
     """Encapsulate information about a single dimension."""
 

--- a/util/test/send_email.py
+++ b/util/test/send_email.py
@@ -15,6 +15,10 @@ import smtplib
 import socket
 import sys
 
+try:
+    basestring
+except NameError:
+    basestring = str
 
 def main():
     """Parse command line arguments and send email!"""


### PR DESCRIPTION
basestring isn't defined in python 3, so add:

```python
try:
    basestring
except NameError:
    basestring = str
```

kinda lame, but only way I know how to do this without using six.