### PR TITLE
Fix typos in sub_test, mandelbrot.prediff, BufferedGets.chpl, and iterator.cpp

### DIFF
--- a/compiler/AST/iterator.cpp
+++ b/compiler/AST/iterator.cpp
@@ -118,7 +118,7 @@ SERIAL / STANDALONE / LEADER
 
 * If a serial IT has no corresponding standalone or leader,
   there is still a group IG for IT, such that:
-   - IG.seral == IT
+   - IG.serial == IT
    - IG.standalone == IG.leader == NULL.
   This can be used to check availability of standalone/leader.
 

--- a/modules/packages/BufferedGets.chpl
+++ b/modules/packages/BufferedGets.chpl
@@ -49,7 +49,7 @@
    to perform and the order of those operations doesn't matter.
 
    .. note::
-     Currently, this is only optimized for ``CHPL_COMMM=ugni``. Other
+     Currently, this is only optimized for ``CHPL_COMM=ugni``. Other
      communication layers fall back to regular gets. Under ugni GETs
      are internally buffered. When the buffers are flushed, the operations are
      performed all at once. Cray Linux Environment (CLE) 5.2.UP04 or newer is

--- a/test/release/examples/benchmarks/shootout/mandelbrot.prediff
+++ b/test/release/examples/benchmarks/shootout/mandelbrot.prediff
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Compare mandlebrot program output.
+# Compare mandelbrot program output.
 
 # Due to numerical instability with different optimization
 # levels, this script tolerates a small number of bit differences

--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -168,9 +168,9 @@ class ReadTimeoutException(Exception): pass
 
 # Python 2/3 compatibility shim. We use subprocess.Popen.communicate() all
 # over sub_test. Instead of updating every call site to do the right thing with
-# regard byte to str conversations for 3 compatibility, we have opted to add
+# regard to byte to str conversions for 3 compatibility, we have opted to add
 # this wrapper. Not all things we run will produce utf-8 (i.e. catfiles for
-# thing like mandlebrot will return binary data) so we allow the conversation
+# thing like mandelbrot will return binary data) so we allow the conversion
 # to utf-8 to silently fail and we handle any issues at those call sites.
 def bytes_to_str(byte_string):
     if sys.version_info[0] >= 3 and not isinstance(byte_string, str):
@@ -252,7 +252,7 @@ def LauncherTimeoutArgs(seconds):
 
 
 #
-# Auxilliary functions
+# Auxiliary functions
 #
 
 # Escape all special characters
@@ -898,7 +898,7 @@ if os.getenv('CHPL_TEST_COMP_PERF')!=None:
     else:
         keyfile=chpl_home+'/test/performance/compiler/compilerPerformance.perfkeys'
 
-    # Check for the directory to store the tempory .dat files that will get 
+    # Check for the directory to store the temporary .dat files that will get
     # combined into one.
     if os.getenv('CHPL_TEST_COMP_PERF_TEMP_DAT_DIR')!=None:
         tempDatFilesDir = os.getenv('CHPL_TEST_COMP_PERF_TEMP_DAT_DIR')


### PR DESCRIPTION
Fix typos in sub_test, mandelbrot.prediff, BufferedGets.chpl, and iterator.cpp