### PR TITLE
Fix test-venv build when already inside virtualenv

### DIFF
--- a/third-party/chpl-venv/Makefile
+++ b/third-party/chpl-venv/Makefile
@@ -36,14 +36,13 @@ $(PIP): $(CHPL_VENV_INSTALL_DIR)
 	  { echo "Failed on command: curl -O $(GETPIP)."; \
 	    echo "Try setting CHPL_PIP to $$(which pip) and trying again"; \
 	    exit 1; } && \
-	  export PYTHONUSERBASE=$(CHPL_VENV_INSTALL_DIR) && \
-	  python get-pip.py --user --no-warn-conflicts) \
+	  $(GET_PIP_COMMAND) ) \
 	fi
 
 # Install virtualenv program.
 $(CHPL_VENV_VIRTUALENV): check-exes $(PIP)
 	export PYTHONPATH="$$CHPL_PYTHONPATH:$(PIPLIBS):$$PYTHONPATH" && \
-	python -S $(PIP) install -U --force-reinstall --ignore-installed $(LOCAL_PIP_FLAGS) \
+	python $(PIP) install -U --force-reinstall --ignore-installed $(LOCAL_PIP_FLAGS) \
 	 --prefix=$(CHPL_VENV_INSTALL_DIR) $(CHPL_PIP_INSTALL_PARAMS) $(shell cat virtualenv.txt)
 
 # Phony convenience target for installing virtualenv.

--- a/third-party/chpl-venv/Makefile.include
+++ b/third-party/chpl-venv/Makefile.include
@@ -50,13 +50,20 @@ PIPLIB64=$(CHPL_VENV_INSTALL_DIR)/lib64/python/site-packages
 
 PIPLIBS=$(PIPLIB_VER):$(PIPLIB):$(PIPLIB64_VER):$(PIPLIB64)
 
+
+GET_PIP_COMMAND=export PYTHONUSERBASE=$(CHPL_VENV_INSTALL_DIR) && python get-pip.py --user --no-warn-conflicts
 # If CHPL_PIP env var is set, then don't install custom pip
 ifdef CHPL_PIP
   PIP = $(CHPL_PIP)
 else
-  PIP=$(CHPL_VENV_INSTALL_DIR)/bin/pip
-  # This must be separate from global CHPL_PIP_INSTALL_PARAMS
-  LOCAL_PIP_FLAGS=--no-warn-conflicts --no-warn-script-location
+  ifdef VIRTUAL_ENV
+    PIP=$(VIRTUAL_ENV)/bin/pip
+    GET_PIP_COMMAND=python get-pip.py --no-warn-conflicts
+  else
+    PIP=-S $(CHPL_VENV_INSTALL_DIR)/bin/pip
+    # This must be separate from global CHPL_PIP_INSTALL_PARAMS
+    LOCAL_PIP_FLAGS=--no-warn-conflicts --no-warn-script-location
+  endif
 endif
 
 


### PR DESCRIPTION
When building the test-venv within an existing virtualenv, set
`PIP=$(VIRTUAL_ENV)/bin/pip`, don't throw `--user` when installing pip,
and import site packages for the `python $(PIP)` call

Closes https://github.com/chapel-lang/chapel/issues/11753