### PR TITLE
Update c2chapel to generate two overloads for functions with pointer arguments

### DIFF
--- a/tools/c2chapel/c2chapel.py
+++ b/tools/c2chapel/c2chapel.py
@@ -182,6 +182,10 @@ def getIntentInfo(ty):
     refIntent = ""
     retType   = ""
     curType   = ty
+    ptrType = ""
+
+    if type(curType) == c_ast.PtrDecl:
+        ptrType = toChapelType(curType)
 
     if type(curType) == c_ast.PtrDecl and not (isPointerTo(curType, "char") or isPointerTo(curType, "void")):
         refIntent = "ref"
@@ -191,19 +195,22 @@ def getIntentInfo(ty):
 
     retType = toChapelType(curType)
 
-    return (refIntent, retType)
+    return (refIntent, retType, ptrType)
 
 # pl - a c_ast.ParamList
 def computeArgs(pl):
     formals = []
+    ptrFormals = []
+
     if pl is None:
-        return ""
+        return ("", "")
 
     for (i, arg) in enumerate(pl.params):
         if type(arg) == c_ast.EllipsisParam:
             formals.append(VARARGS_STR)
+            ptrFormals.append(VARARGS_STR);
         else:
-            (intent, typeName) = getIntentInfo(arg.type)
+            (intent, typeName, ptrTypeName) = getIntentInfo(arg.type)
             argName = computeArgName(arg)
             if typeName != "":
                 if intent != "":
@@ -211,7 +218,12 @@ def computeArgs(pl):
                 if argName == "":
                     argName = "arg" + str(i)
                 formals.append(intent + argName + " : " + typeName)
-    return ", ".join(formals)
+
+                if ptrTypeName != "":
+                    ptrFormals.append(argName + " : " + ptrTypeName)
+                else:
+                    ptrFormals.append(argName + " : " + typeName)
+    return (", ".join(formals), ", ".join(ptrFormals))
 
 def isPointerTo(ty, text):
     if type(ty) == c_ast.PtrDecl:
@@ -268,7 +280,7 @@ def getFunctionName(ty):
 def genFuncDecl(fn):
     retType = toChapelType(fn.type)
     fnName  = getFunctionName(fn.type)
-    args    = computeArgs(fn.args)
+    (args, ptrArgs) = computeArgs(fn.args)
 
     if fnName in chapelKeywords:
         genComment("Unable to generate function '" + fnName + "' because its name is a Chapel keyword")
@@ -284,6 +296,8 @@ def genFuncDecl(fn):
         retType = "void"
 
     print("extern proc " + fnName + "(" + args + ") : " + retType + ";\n")
+    if ptrArgs != args:
+        print("extern proc " + fnName + "(" + ptrArgs + ") : " + retType + ";\n")
 
     listArgs = args.split(", ")
     if listArgs[-1] == VARARGS_STR:


### PR DESCRIPTION
For a function with a pointer argument, c2chapel generates a declaration with
a `ref` intent argument.

int f(int* x); => extern proc f(ref x: int): int;

This doesn't resolve for an actual that is a `c_ptr(int)`, such as a pointer
returned from another extern function.  In addition to the above, generate
an overload that uses `c_ptr(*)` arguments:

extern proc f(x: c_ptr(int)): int;

This way we get both the `ref` behavior, and the ability to work directly with
`c_ptr`s.