### PR TITLE
Fix python 3 support for convert_start_test_log_to_junit_xml.py

### DIFF
--- a/util/test/convert_start_test_log_to_junit_xml.py
+++ b/util/test/convert_start_test_log_to_junit_xml.py
@@ -70,7 +70,8 @@ def _create_junit_report(test_cases, junit_file):
         system_out = XML.SubElement(case_elem, 'system-out')
         system_out.text = test_case['system-out']
 
-    xml_content = XML.tostring(test_suite)
+    encoding = "unicode" if sys.version_info[0] >= 3 else "us-ascii"
+    xml_content = XML.tostring(test_suite, encoding=encoding)
     xml_content = _clean_xml(xml_content)
     with open(junit_file, 'w') as fp:
         fp.write(xml_content)


### PR DESCRIPTION
Use unicode encoding for XML.tostring() in python 3 (us-ascii for python 2)