### PR TITLE
Update tests for c2chapel to include overloads for functions with pointer args

### DIFF
--- a/tools/c2chapel/c2chapel.py
+++ b/tools/c2chapel/c2chapel.py
@@ -187,7 +187,7 @@ def getIntentInfo(ty):
     if type(curType) == c_ast.PtrDecl:
         ptrType = toChapelType(curType)
 
-    if type(curType) == c_ast.PtrDecl and not (isPointerTo(curType, "char") or isPointerTo(curType, "void")):
+    if type(curType) == c_ast.PtrDecl and not (isPointerTo(curType, "char") or isPointerTo(curType, "void") or toChapelType(curType) == "c_fn_ptr"):
         refIntent = "ref"
         curType = curType.type
     else:

--- a/tools/c2chapel/test/arrayDecl.chpl
+++ b/tools/c2chapel/test/arrayDecl.chpl
@@ -11,7 +11,11 @@ extern var stringList : c_ptr(c_string);
 
 extern proc args(a : c_ptr(c_int), ref b : c_int) : void;
 
+extern proc args(a : c_ptr(c_int), b : c_ptr(c_int)) : void;
+
 extern proc sized(x : c_ptr(c_int), ref y : c_int) : void;
+
+extern proc sized(x : c_ptr(c_int), y : c_ptr(c_int)) : void;
 
 extern record foobar {
   var x : c_int;

--- a/tools/c2chapel/test/cstrvoid.chpl
+++ b/tools/c2chapel/test/cstrvoid.chpl
@@ -15,5 +15,9 @@ extern proc ret_void_ptr() : c_void_ptr;
 
 extern proc arg_ptr_to_cstr(ref out_arg : c_string) : void;
 
+extern proc arg_ptr_to_cstr(out_arg : c_ptr(c_string)) : void;
+
 extern proc arg_ptr_to_void_ptr(ref out_arg : c_void_ptr) : void;
+
+extern proc arg_ptr_to_void_ptr(out_arg : c_ptr(c_void_ptr)) : void;
 

--- a/tools/c2chapel/test/dashEye.chpl
+++ b/tools/c2chapel/test/dashEye.chpl
@@ -7,5 +7,7 @@ require "dashEye.h";
 
 extern proc otherFunction(ref arr : c_int) : void;
 
+extern proc otherFunction(arr : c_ptr(c_int)) : void;
+
 extern proc dashEyeFunction(foo : c_int, bar : c_string) : void;
 

--- a/tools/c2chapel/test/fnPointers.chpl
+++ b/tools/c2chapel/test/fnPointers.chpl
@@ -5,7 +5,7 @@ require "fnPointers.h";
 
 // Note: Generated with fake std headers
 
-extern proc fnPointerArgs(ref callback : c_fn_ptr, msg : c_string) : c_int;
+extern proc fnPointerArgs(callback : c_fn_ptr, msg : c_string) : c_int;
 
 extern proc foo(a : myFunctionPointer, b : c_int) : c_int;
 

--- a/tools/c2chapel/test/fnints.chpl
+++ b/tools/c2chapel/test/fnints.chpl
@@ -9,6 +9,8 @@ extern proc firstFunc(a : c_int, b : c_int, c : c_int) : void;
 
 extern proc secondFunc(a : c_int, ref b : c_int, ref c : c_ptr(c_int)) : void;
 
+extern proc secondFunc(a : c_int, b : c_ptr(c_int), c : c_ptr(c_ptr(c_int))) : void;
+
 extern proc thirdFunc(a : c_int, b : c_int) : c_int;
 
 extern proc fourthFunc(a : c_int, b : c_int, c : c_int) : void;

--- a/tools/c2chapel/test/miscTypedef.chpl
+++ b/tools/c2chapel/test/miscTypedef.chpl
@@ -17,6 +17,8 @@ extern proc retStruct(a : my_int, b : my_int, r : renamedStruct) : fancyStruct;
 
 extern proc tdPointer(ref a : fancyStruct, ref b : c_ptr(renamedStruct)) : void;
 
+extern proc tdPointer(a : c_ptr(fancyStruct), b : c_ptr(c_ptr(renamedStruct))) : void;
+
 
 
 extern record forwardStruct {

--- a/tools/c2chapel/test/simpleRecords.chpl
+++ b/tools/c2chapel/test/simpleRecords.chpl
@@ -29,3 +29,5 @@ extern proc retStruct(a : misc) : allInts;
 
 extern proc structPointer(ref a : misc) : void;
 
+extern proc structPointer(a : c_ptr(misc)) : void;
+

--- a/tools/c2chapel/test/sysCTypes.chpl
+++ b/tools/c2chapel/test/sysCTypes.chpl
@@ -7,9 +7,15 @@ require "sysCTypes.h";
 
 extern proc test_int(a : c_int, ref b : c_int) : c_int;
 
+extern proc test_int(a : c_int, b : c_ptr(c_int)) : c_int;
+
 extern proc test_uint(a : c_uint, b : c_int, ref c : c_uint) : c_uint;
 
+extern proc test_uint(a : c_uint, b : c_int, c : c_ptr(c_uint)) : c_uint;
+
 extern proc test_longs(a : c_long, b : c_ulong, c : c_longlong, d : c_ulonglong, ref e : c_longlong) : c_long;
+
+extern proc test_longs(a : c_long, b : c_ulong, c : c_longlong, d : c_ulonglong, e : c_ptr(c_longlong)) : c_long;
 
 extern proc test_chars(a : c_char, b : c_string, c : c_schar, d : c_uchar) : c_char;
 


### PR DESCRIPTION
Several c2chapel tests needed to be updated to include new overloads for
functions that have pointer arguments.

The fnPointers.h test was generating a 'ref' argument for a `c_fn_ptr` type
but it shouldn't.  Fix c2chapel to catch this case and update the test.