### PR TITLE
Don't run RE2 and GMP builds at the same time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,3 +200,6 @@ install: comprt
 -include Makefile.devel
 
 FORCE:
+
+# Don't want to try building e.g. GMP and RE2 at the same time
+.NOTPARALLEL:


### PR DESCRIPTION
I noticed that in some nightly testing configurations, the RE2 and GMP builds are running at the same time. That leads to confusing output. This PR adjusts the top-level makefile to indicate that its targets shouldn't run in parallel. The sub-targets still run in parallel.

Reviewed by @ronawho - thanks!