### PR TITLE
Update some buffer sizes in launch-slurm-gasnetrun_ibv.c

### DIFF
--- a/runtime/src/launch/slurm-gasnetrun_ibv/launch-slurm-gasnetrun_ibv.c
+++ b/runtime/src/launch/slurm-gasnetrun_ibv/launch-slurm-gasnetrun_ibv.c
@@ -192,7 +192,7 @@ static char* chpl_launch_create_command(int argc, char* argv[],
                                         int32_t numLocales) {
   int i;
   int size;
-  char baseCommand[256];
+  char baseCommand[2*FILENAME_MAX];
   char* command;
   FILE* slurmFile, *expectFile;
   char* projectString = getenv(launcherAccountEnvvar);
@@ -339,7 +339,7 @@ static char* chpl_launch_create_command(int argc, char* argv[],
 
 static void chpl_launch_cleanup(void) {
   if (!debug) {
-    char command[1024];
+    char command[2*FILENAME_MAX];
     if (getenv("CHPL_LAUNCHER_USE_SBATCH") == NULL) {
       sprintf(command, "rm %s", expectFilename);
       system(command);


### PR DESCRIPTION
GCC 8.2 complains that these sprintf calls could overflow, which is accurate.
This PR takes the very simple step of increasing the buffer sizes for the
destination buffers. I don't think this code should be calling sprintf at all
(snprintf is a better idea in C programs) but I also think the whole thing
needs to be rewritten in Python so I didn't try to go further.

Reviewed by @ronawho - thanks!