### PR TITLE
Suppress gcc 8 spurious array-bounds warnings -> errors

### DIFF
--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -180,6 +180,7 @@ endif
 ifeq ($(shell test $(GNU_GPP_MAJOR_VERSION) -eq 8; echo "$$?"),0)
 WARN_CXXFLAGS += -Wno-class-memaccess -Walloc-size-larger-than=18446744073709551615
 RUNTIME_CFLAGS += -Wno-stringop-overflow
+SQUASH_WARN_GEN_CFLAGS += -Wno-array-bounds
 endif
 
 #


### PR DESCRIPTION
Gcc 8 added new array bounds checking that gets confused in complicated code, such as when we use `--baseline`.  Specifically, baseline code is too complicated for gcc 8 to recognize that the result of `safeCast()` is safe.

This change disables the problematic checks in gcc 8 for generated code, to allow baseline to work.
