### PR TITLE
Fix tokencount

### DIFF
--- a/util/tokencount/tokctnightly
+++ b/util/tokencount/tokctnightly
@@ -129,6 +129,7 @@ $findflags = "-name '*.cpp' -print -or -name '*.c' -print -or -name '*.h' -print
 
 $compdir = "$chplhomedir/compiler";
 $binsubdir = `$here/../chplenv/chpl_bin_subdir.py --host`;
+chomp $binsubdir;
 $bindir = "$chplhomedir/bin/$binsubdir";
 
 # remove generated files
@@ -161,7 +162,7 @@ mysystem("$tokctr `find $chplhomedir/runtime $findflags` > $chplhomedir/runtime/
 
 mysystem("cd $chplhomedir && make -j$num_procs comprt", "making compiler", 1, 1);
 $ENV{'CHPL_HOME'} = $chplhomedir;
-mysystem("$bindir/chpl --count-tokens $chplhomedir/modules/standard/*.chpl $chplhomedir/modules/internal/*.chpl $chplhomedir/modules/dists/*.chpl $chplhomedir/modules/layouts/*.chpl >& $compdir/chpcode.ntoks", "counting module tokens", 1, 1);
+mysystem("$bindir/chpl --count-tokens $chplhomedir/modules/standard/*.chpl $chplhomedir/modules/internal/*.chpl $chplhomedir/modules/dists/*.chpl $chplhomedir/modules/layouts/*.chpl > $compdir/chpcode.ntoks 2>&1", "counting module tokens", 1, 1);
 
 $asttoks = `cat $compdir/AST.ntoks`; chomp($asttoks);
 $adttoks = `cat $compdir/adt.ntoks`; chomp($adttoks);

--- a/util/tokencount/tokencount.h
+++ b/util/tokencount/tokencount.h
@@ -2,6 +2,8 @@
 #define _TOKENCOUNT_H_
 
 #include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
 
 #ifndef TOKENCOUNT_EXTERN
 #define TOKENCOUNT_EXTERN extern
@@ -26,6 +28,9 @@ TOKENCOUNT_EXTERN char line[4096];
 extern FILE* yyin;
 extern char* yytext;
 extern int yydebug;
+extern int yylex(void);
+extern int yyparse(void);
+extern int yyerror(char*);
 
 TOKENCOUNT_EXTERN int fileTokenHist[HIST_SIZE];
 TOKENCOUNT_EXTERN int totTokenHist[HIST_SIZE];


### PR DESCRIPTION
This is a follow-on to PRs #11638 and #11778.

* Fix tokencount to compile without warnings 
* Fix tokctnightly needed to remove newline from chpl_bin_subdir.py call
* Improve tokctnightly portability: >& is a bash-ism so use 2>&1 instead