### PR TITLE
Add .skipifs for the stringToFloating tests for cygwin

### DIFF
--- a/test/functions/casts/stringToFloating.skipif
+++ b/test/functions/casts/stringToFloating.skipif
@@ -1,0 +1,3 @@
+# The version of sscanf on cygwin doesn't handle converting strings in hex
+# floating point to doubles.
+CHPL_TARGET_PLATFORM <= cygwin

--- a/test/functions/casts/stringToFloatingUnderscores.skipif
+++ b/test/functions/casts/stringToFloatingUnderscores.skipif
@@ -1,0 +1,3 @@
+# The version of sscanf on cygwin doesn't handle converting strings in hex
+# floating point to doubles.
+CHPL_TARGET_PLATFORM <= cygwin


### PR DESCRIPTION
The version of sscanf on cygwin doesn't work with strings that are hex
floating point numbers, so it fails to convert e.g. "0x12.34e5" to real(64).
Skip these tests for cygwin.