### PR TITLE
Fix a problem with integer division in sub_test

### DIFF
--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -268,8 +268,8 @@ def ShellEscapeCommand(arg):
 def trim_output(output):
     max_size = 256*1024 # ~1/4 MB
     if len(output) > max_size:
-        new_output = output[:max_size/2]
-        new_output += output[-max_size/2:]
+        new_output = output[:max_size//2]
+        new_output += output[-max_size//2:]
         output = new_output
     return ''.join(s if s in string.printable else "~" for s in output)
 


### PR DESCRIPTION
Problem and fix pointed out by @simoll - thanks!

In Python 3, integer division results in a floating point value.
The // operator gives the floor division, which is what / was
doing in Python 2.

Reviewed by @ronawho - thanks!