### PR TITLE
In comm=ofi, support sharing transmit contexts among worker threads.

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi-internal.h
+++ b/runtime/src/comm/ofi/comm-ofi-internal.h
@@ -130,6 +130,13 @@ int chpl_comm_ofi_abort_on_error;
       }                                                                 \
     } while (0)
 
+#define CHK_FALSE(expr)                                                 \
+    do {                                                                \
+      if (expr) {                                                       \
+        INTERNAL_ERROR_V("%s", #expr);                                  \
+      }                                                                 \
+    } while (0)
+
 #define CHK_EQ_TYPED(expr, wantVal, type, fmtSpec)                      \
     do {                                                                \
       type _exprVal = (expr);                                           \

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -358,7 +358,7 @@ void init_ofiFabricDomain(void) {
   OFI_CHK(fi_domain(ofi_fabric, ofi_info, &ofi_domain, NULL));
 
   //
-  // Create address vectors for each thread.
+  // Create the address vector covering the nodes.
   //
   struct fi_av_attr ofi_avAttr = { 0 };
   ofi_avAttr.type = FI_AV_TABLE;


### PR DESCRIPTION
In the past the ofi comm layer has bound transmit contexts to both AM
handler threads and worker threads for the duration of execution.  At
initialization time we made a best guess as to how many worker threads
would be present and then bound contexts to AM handler threads as those
started, and to worker threads at the time of their first transmit.  If
we ran out of transmit contexts, we took an error exit.

Here, implement sharing of transmit contexts among worker threads when
there are more of the latter than the former.  The AM handler thread
still gets its own context, as before.  And if the tasking layer says
that it uses a fixed number of threads, and we can get at least enough
transmit contexts for the AM handler and that many worker threads, then
we still bind contexts to threads throughout execution.  But if either
the tasking layer doesn't use a fixed number of threads (example: fifo)
or the ofi provider does not support as many transmit contexts as the
fixed number of threads (example: sockets, with qthreads, on a compute
node with more than 15 cores), now threads will dynamically acquire and
release transmit contexts as they need them for individual transactions.

Up until now we had to set `CHPL_RT_NUM_THREADS_PER_LOCALE` to some value
less than the provider's maximum number of transmit contexts (16, for
sockets) in order to run tests.  As of this commit that is no longer
necessary -- I tested the multilocale suite with the sockets provider on
a Cray XC system and all the same tests passed as do with comm=ugni.  We
still cannot use the ofi comm layer with tasks=fifo, but that's due to
other issues (notably memory registration), which we'll fix separately.

This resolves #11563.