### PR TITLE
Futures regarding using module paths to disambiguate configs

### DIFF
--- a/test/compflags/configs/ambiguousNestedModules.bad
+++ b/test/compflags/configs/ambiguousNestedModules.bad
@@ -1,0 +1,1 @@
+error: Trying to set unrecognized config 'M1.Helper.debug' via -s flag

--- a/test/compflags/configs/ambiguousNestedModules.chpl
+++ b/test/compflags/configs/ambiguousNestedModules.chpl
@@ -1,0 +1,17 @@
+module M1 {
+  module Helper {
+    config param debug = false;
+  }
+}
+
+module M2 {
+  module Helper {
+    config param debug = false;
+  }
+
+  proc main() {
+    use M1;
+    use M1.Helper;
+    writeln((M1.Helper.debug, M2.Helper.debug));
+  }
+}

--- a/test/compflags/configs/ambiguousNestedModules.compopts
+++ b/test/compflags/configs/ambiguousNestedModules.compopts
@@ -1,0 +1,1 @@
+-sM1.Helper.debug=true

--- a/test/compflags/configs/ambiguousNestedModules.future
+++ b/test/compflags/configs/ambiguousNestedModules.future
@@ -1,0 +1,8 @@
+feature request: support arbitrarily nested module disambiguation
+
+Currently, we support the ability to disambiguate configs using the
+config's module name.  But we don't support disambiguation using a
+path of module symbols in the event that the ambiguity is in an inner
+module.  This is something we ultimately need to be able to do in
+order to compose large programs from different authors where the
+sources may not be within our control.

--- a/test/compflags/configs/ambiguousNestedModules.good
+++ b/test/compflags/configs/ambiguousNestedModules.good
@@ -1,0 +1,1 @@
+(true, false)

--- a/test/execflags/configs/ambiguousNestedModules.bad
+++ b/test/execflags/configs/ambiguousNestedModules.bad
@@ -1,0 +1,1 @@
+<command-line arg>:1: error: Unexpected flag:  "--M1.Helper.debug=true"

--- a/test/execflags/configs/ambiguousNestedModules.chpl
+++ b/test/execflags/configs/ambiguousNestedModules.chpl
@@ -1,0 +1,17 @@
+module M1 {
+  module Helper {
+    config const debug = false;
+  }
+}
+
+module M2 {
+  module Helper {
+    config const debug = false;
+  }
+
+  proc main() {
+    use M1;
+    use M1.Helper;
+    writeln((M1.Helper.debug, M2.Helper.debug));
+  }
+}

--- a/test/execflags/configs/ambiguousNestedModules.execopts
+++ b/test/execflags/configs/ambiguousNestedModules.execopts
@@ -1,0 +1,1 @@
+--M1.Helper.debug=true

--- a/test/execflags/configs/ambiguousNestedModules.future
+++ b/test/execflags/configs/ambiguousNestedModules.future
@@ -1,0 +1,8 @@
+feature request: support arbitrarily nested module disambiguation
+
+Currently, we support the ability to disambiguate configs using the
+config's module name.  But we don't support disambiguation using a
+path of module symbols in the event that the ambiguity is in an inner
+module.  This is something we ultimately need to be able to do in
+order to compose large programs from different authors where the
+sources may not be within our control.

--- a/test/execflags/configs/ambiguousNestedModules.good
+++ b/test/execflags/configs/ambiguousNestedModules.good
@@ -1,0 +1,1 @@
+(true, false)


### PR DESCRIPTION
These features demonstrate that while we can disambiguate configs using their parent module name, we can't do so using a full module path, which could be necessary for large code bases.  One of these shows it for the compile-line `-s` flag, the other for execution-time flags.