### PR TITLE
Allow LLVM to link statically

### DIFF
--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2776,6 +2776,16 @@ void makeBinaryLLVM(void) {
   if (compilingWithPrgEnv()) {
     std::string gather_prgenv(CHPL_HOME);
     gather_prgenv += "/util/config/gather-cray-prgenv-arguments.bash link '";
+
+    if (fLinkStyle == LS_DEFAULT &&
+	gather_prgenv.find("-Wl,-Bdynamic") == std::string::npos) {
+      // Cray PrgEnv defaults to static linking.  If we are asking for
+      // the default link type, and we don't find an explicit dynamic
+      // flag in the gathered PrgEnv arguments, then force static linking
+      // because LLVM's default (dynamic) is different from the PrgEnv
+      // default (static).
+      fLinkStyle = LS_STATIC;
+    }
     gather_prgenv += CHPL_COMM;
     gather_prgenv += "' '";
     gather_prgenv += CHPL_COMM_SUBSTRATE;

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2907,6 +2907,9 @@ void makeBinaryLLVM(void) {
   // linker override specified by the Makefiles (e.g. setting it to mpicxx)
   std::string command = useLinkCXX + " " + options + " " +
                         moduleFilename + " " + maino;
+  // For dynamic linking, leave it alone.  For static, append -static .
+  // See $CHPL_HOME/make/compiler/Makefile.clang (and keep this in sync
+  // with it).
   if (fLinkStyle == LS_STATIC)
     command += " -static";
   command += " -o ";

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2778,7 +2778,7 @@ void makeBinaryLLVM(void) {
     gather_prgenv += "/util/config/gather-cray-prgenv-arguments.bash link '";
 
     if (fLinkStyle == LS_DEFAULT &&
-	gather_prgenv.find("-Wl,-Bdynamic") == std::string::npos) {
+        gather_prgenv.find("-Wl,-Bdynamic") == std::string::npos) {
       // Cray PrgEnv defaults to static linking.  If we are asking for
       // the default link type, and we don't find an explicit dynamic
       // flag in the gathered PrgEnv arguments, then force static linking

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2906,8 +2906,11 @@ void makeBinaryLLVM(void) {
   // libraries are written in C++. Here we use clang++ or possibly a
   // linker override specified by the Makefiles (e.g. setting it to mpicxx)
   std::string command = useLinkCXX + " " + options + " " +
-                        moduleFilename + " " + maino +
-                        " -o " + tmpbinname;
+                        moduleFilename + " " + maino;
+  if (fLinkStyle == LS_STATIC)
+    command += " -static";
+  command += " -o ";
+  command += tmpbinname;
   for( size_t i = 0; i < dotOFiles.size(); i++ ) {
     command += " ";
     command += dotOFiles[i];

--- a/test/compflags/link/sungeun/static_dynamic.skipif
+++ b/test/compflags/link/sungeun/static_dynamic.skipif
@@ -16,10 +16,6 @@ elif $CHPL_HOME/util/printchplenv --make --all --internal \
   # a compopts-by-compopts basis, but we can't do that yet.
   #
   echo True
-elif [[ "$COMPOPTS" == *"--llvm"* ]] ; then
-  # Skip in --llvm configurations because either this test or
-  # static/dynamic linking doesn't work yet.
-  echo True
 else
   echo False
 fi


### PR DESCRIPTION
This change allows LLVM to link statically when `chpl` is supplied with the `--static` flag or on platforms where static linking is the default.

Closes #10904 

Tested with LLVM 6 and 7.