### PR TITLE
Don't try to negate the most-negative signed integer value.

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -2342,7 +2342,7 @@ DEFN_IFACE_AMO_SIMPLE_OP(add, FI_SUM, real32, FI_FLOAT, float)
 DEFN_IFACE_AMO_SIMPLE_OP(add, FI_SUM, real64, FI_DOUBLE, double)
 
 
-#define DEFN_IFACE_AMO_SUB(fnType, ofiType, Type)                       \
+#define DEFN_IFACE_AMO_SUB(fnType, ofiType, Type, negate)               \
   void chpl_comm_atomic_sub_##fnType                                    \
          (void* operand, c_nodeid_t node, void* object,                 \
           int ln, int32_t fn) {                                         \
@@ -2350,7 +2350,7 @@ DEFN_IFACE_AMO_SIMPLE_OP(add, FI_SUM, real64, FI_DOUBLE, double)
                "chpl_comm_atomic_sub_%s(<%s>, %d, %p, %d, %s)",         \
                #fnType, DBG_VAL(operand, ofiType), (int) node, object,  \
                ln, chpl_lookupFilename(fn));                            \
-    Type myOpnd = - *(Type*) operand;                                   \
+    Type myOpnd = negate(*(Type*) operand);                             \
     doAMO(node, object, &myOpnd, NULL, NULL,                            \
           FI_SUM, ofiType, sizeof(Type));                               \
   }                                                                     \
@@ -2374,17 +2374,21 @@ DEFN_IFACE_AMO_SIMPLE_OP(add, FI_SUM, real64, FI_DOUBLE, double)
                "%d, %s)",                                               \
                #fnType, DBG_VAL(operand, ofiType), (int) node, object,  \
                result, ln, chpl_lookupFilename(fn));                    \
-    Type myOpnd = - *(Type*) operand;                                   \
+    Type myOpnd = negate(*(Type*) operand);                             \
     doAMO(node, object, &myOpnd, NULL, result,                          \
           FI_SUM, ofiType, sizeof(Type));                               \
   }
 
-DEFN_IFACE_AMO_SUB(int32, FI_INT32, int32_t)
-DEFN_IFACE_AMO_SUB(int64, FI_INT64, int64_t)
-DEFN_IFACE_AMO_SUB(uint32, FI_UINT32, uint32_t)
-DEFN_IFACE_AMO_SUB(uint64, FI_UINT64, uint64_t)
-DEFN_IFACE_AMO_SUB(real32, FI_FLOAT, float)
-DEFN_IFACE_AMO_SUB(real64, FI_DOUBLE, double)
+#define NEGATE_I32(x) ((x) == INT32_MIN ? (x) : -(x))
+#define NEGATE_I64(x) ((x) == INT64_MIN ? (x) : -(x))
+#define NEGATE_U_OR_R(x) (-(x))
+
+DEFN_IFACE_AMO_SUB(int32, FI_INT32, int32_t, NEGATE_I32)
+DEFN_IFACE_AMO_SUB(int64, FI_INT64, int64_t, NEGATE_I64)
+DEFN_IFACE_AMO_SUB(uint32, FI_UINT32, uint32_t, NEGATE_U_OR_R)
+DEFN_IFACE_AMO_SUB(uint64, FI_UINT64, uint64_t, NEGATE_U_OR_R)
+DEFN_IFACE_AMO_SUB(real32, FI_FLOAT, float, NEGATE_U_OR_R)
+DEFN_IFACE_AMO_SUB(real64, FI_DOUBLE, double, NEGATE_U_OR_R)
 
 
 void chpl_comm_atomic_buff_flush(void) {

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -6774,15 +6774,16 @@ DEFINE_CHPL_COMM_ATOMIC_REAL_OP(real64, add_r64, double)
 // Atomic subtract:
 //   _f: interface function name suffix (type)
 //   _t: AMO type
+//   _negate: negation function
 //
-#define DEFINE_CHPL_COMM_ATOMIC_SUB(_f, _t)                             \
+#define DEFINE_CHPL_COMM_ATOMIC_SUB(_f, _t, _negate)                    \
         /*==============================*/                              \
         void chpl_comm_atomic_sub_##_f(void* opnd,                      \
                                        int32_t loc,                     \
                                        void* obj,                       \
                                        int ln, int32_t fn)              \
         {                                                               \
-          _t nopnd = - *(_t*) opnd;                                     \
+          _t nopnd = _negate(*(_t*) opnd);                              \
                                                                         \
           DBG_P_LP(DBGF_IFACE|DBGF_AMO,                                 \
                    "IFACE chpl_comm_atomic_sub_"#_f                     \
@@ -6798,7 +6799,7 @@ DEFINE_CHPL_COMM_ATOMIC_REAL_OP(real64, add_r64, double)
                                             void* obj,                  \
                                             int ln, int32_t fn)         \
         {                                                               \
-          _t nopnd = - *(_t*) opnd;                                     \
+          _t nopnd = _negate(*(_t*) opnd);                              \
                                                                         \
           DBG_P_LP(DBGF_IFACE|DBGF_AMO,                                 \
                    "IFACE chpl_comm_atomic_sub_buff_"#_f                \
@@ -6815,7 +6816,7 @@ DEFINE_CHPL_COMM_ATOMIC_REAL_OP(real64, add_r64, double)
                                              void* res,                 \
                                              int ln, int32_t fn)        \
         {                                                               \
-          _t nopnd = - *(_t*) opnd;                                     \
+          _t nopnd = _negate(*(_t*) opnd);                              \
                                                                         \
           DBG_P_LP(DBGF_IFACE|DBGF_AMO,                                 \
                    "IFACE chpl_comm_atomic_fetch_sub_"#_f               \
@@ -6826,12 +6827,16 @@ DEFINE_CHPL_COMM_ATOMIC_REAL_OP(real64, add_r64, double)
                                           ln, fn);                      \
         }
 
-DEFINE_CHPL_COMM_ATOMIC_SUB(int32, int_least32_t)
-DEFINE_CHPL_COMM_ATOMIC_SUB(int64, int_least64_t)
-DEFINE_CHPL_COMM_ATOMIC_SUB(uint32, int_least32_t)
-DEFINE_CHPL_COMM_ATOMIC_SUB(uint64, int_least64_t)
-DEFINE_CHPL_COMM_ATOMIC_SUB(real32, float)
-DEFINE_CHPL_COMM_ATOMIC_SUB(real64, double)
+#define NEGATE_I32(x) ((x) == INT_LEAST32_MIN ? (x) : -(x))
+#define NEGATE_I64(x) ((x) == INT_LEAST64_MIN ? (x) : -(x))
+#define NEGATE_U_OR_R(x) (-(x))
+
+DEFINE_CHPL_COMM_ATOMIC_SUB(int32, int_least32_t, NEGATE_I32)
+DEFINE_CHPL_COMM_ATOMIC_SUB(int64, int_least64_t, NEGATE_I64)
+DEFINE_CHPL_COMM_ATOMIC_SUB(uint32, int_least32_t, NEGATE_U_OR_R)
+DEFINE_CHPL_COMM_ATOMIC_SUB(uint64, int_least64_t, NEGATE_U_OR_R)
+DEFINE_CHPL_COMM_ATOMIC_SUB(real32, float, NEGATE_U_OR_R)
+DEFINE_CHPL_COMM_ATOMIC_SUB(real64, double, NEGATE_U_OR_R)
 
 #undef DEFINE_CHPL_COMM_ATOMIC_SUB
 


### PR DESCRIPTION
Negating the most-negative value of a C signed integer is undefined
behavior according to the C standard.  The positive value corresponding
to the most negative value does not exist in that type (6.2.6.2 (2)), so
the negation overflows.  The result of integer overflow is not discussed
in the standard, thus it is undefined behavior (4 (2)).

Here, stop negating the most-negative signed integer value when
arranging for signed atomic subtract operations to be done by adding the
corresponding negative value.  The bit-result will be the same on the
two's complement systems we target, so there is no change in observable
behavior.

(Problem pointed out and solution proposed by @dmk42.)

This resolves #11791.