### PR TITLE
Get comm=ofi working with tasks=fifo.

### DIFF
--- a/compiler/passes/parallel.cpp
+++ b/compiler/passes/parallel.cpp
@@ -1138,6 +1138,8 @@ freeHeapAllocatedVars(Vec<Symbol*> heapAllocatedVars) {
 //
 //  fLocal == true
 // or
+//  CHPL_COMM == "ofi"
+// or
 //  CHPL_COMM == "ugni"
 // or
 //  CHPL_COMM == "gasnet" && CHPL_GASNET_SEGMENT == "everything";
@@ -1158,7 +1160,8 @@ static bool
 needHeapVars() {
   if (fLocal) return false;
 
-  if (!strcmp(CHPL_COMM, "ugni") ||
+  if (!strcmp(CHPL_COMM, "ofi") ||
+      !strcmp(CHPL_COMM, "ugni") ||
       (!strcmp(CHPL_COMM, "gasnet") &&
        !strcmp(CHPL_GASNET_SEGMENT, "everything")))
     return false;

--- a/test/multilocale/engin/SKIPIF
+++ b/test/multilocale/engin/SKIPIF
@@ -1,2 +1,1 @@
 CHPL_COMM==none
-CHPL_COMM==ofi


### PR DESCRIPTION
This makes a couple of small changes that get comm=ofi working as well
with tasks=fifo as it does with tasks=qthreads.  First, in the compiler,
for comm=ofi make the same decision regarding forcing variables into the
heap that we do for comm=ugni and comm=gasnet,everything.  And in the
ofi comm layer itself, if the provider needs local source buffers for
PUT operations to be in registered memory (as gni does), then duplicate
AM request arg bundles that are not in registered memory into registered
bounce buffers.

With this change, comm=ofi,tasks=fifo passes the multilocale suite as
well as comm=ugni and comm=ofi,tasks=qthreads do.  Or in other words, it
fails the same tests for the same (typically superficial) reasons.

This resolves #11822.