### PR TITLE
Don't free things that were not allocated in the first place.

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -756,8 +756,6 @@ void fini_ofi(void) {
   CHPL_FREE(memTabMap);
 
   CHPL_FREE(memTabMap);
-  CHPL_FREE(memTab);
-  CHPL_FREE(ofiMrTab);
 
   CHPL_FREE(amLZs);
 


### PR DESCRIPTION
We were freeing a couple of data objects that were never allocated in
the first place.  Don't do this.  Interestingly, this didn't seem to
cause a problem except in an unusual configuration (comm=ofi with the
sockets provider, tasks=fifo, debug runtime).