### PR TITLE
Add map, filter, consume on _iteratorRecord

### DIFF
--- a/modules/Makefile
+++ b/modules/Makefile
@@ -101,6 +101,7 @@ PACKAGES_TO_DOCUMENT = \
 	packages/Curl.chpl \
 	packages/FFTW.chpl \
 	packages/FFTW_MT.chpl \
+	packages/FunctionalOperations.chpl \
 	packages/Futures.chpl \
 	packages/HDF5.chpl \
 	packages/HDFS.chpl \

--- a/modules/internal/ChapelIteratorSupport.chpl
+++ b/modules/internal/ChapelIteratorSupport.chpl
@@ -620,28 +620,6 @@ module ChapelIteratorSupport {
     return iterables.size == 1 && isRefIter(_getIterator(iterables(1)));
   }
 
-  /* Apply `fn` to each element yielded by this iterator and yield the value
-     returned by `fn`.  `fn` must take a single argument and return a value.
-   */
-  iter _iteratorRecord.map(fn) {
-    for x in this do yield fn(x);
-  }
-
-  /* Apply `fn` to each element yielded by this iterator and yield the values
-     it returns `true` for.  `fn` must take a single argument and return a
-     boolean value.
-   */
-  iter _iteratorRecord.filter(fn) {
-    for x in this do if fn(x) then yield x;
-  }
-
-  /* Apply `fn` to each element yielded by this iterator and ignore the return
-     value from `fn` if any.
-   */
-  proc _iteratorRecord.consume(fn) {
-    for x in this do fn(x);
-  }
-
   /*
      Vectorize only "wrapper" iterator:
 

--- a/modules/internal/ChapelIteratorSupport.chpl
+++ b/modules/internal/ChapelIteratorSupport.chpl
@@ -620,6 +620,28 @@ module ChapelIteratorSupport {
     return iterables.size == 1 && isRefIter(_getIterator(iterables(1)));
   }
 
+  /* Apply `fn` to each element yielded by this iterator and yield the value
+     returned by `fn`.  `fn` must take a single argument and return a value.
+   */
+  iter _iteratorRecord.map(fn) {
+    for x in this do yield fn(x);
+  }
+
+  /* Apply `fn` to each element yielded by this iterator and yield the values
+     it returns `true` for.  `fn` must take a single argument and return a
+     boolean value.
+   */
+  iter _iteratorRecord.filter(fn) {
+    for x in this do if fn(x) then yield x;
+  }
+
+  /* Apply `fn` to each element yielded by this iterator and ignore the return
+     value from `fn` if any.
+   */
+  proc _iteratorRecord.consume(fn) {
+    for x in this do fn(x);
+  }
+
   /*
      Vectorize only "wrapper" iterator:
 

--- a/modules/packages/FunctionalOperations.chpl
+++ b/modules/packages/FunctionalOperations.chpl
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2004-2018 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* The `FunctionalOperations` module provides operations that act on
+   iterators in a functional programming style.
+ */
+module FunctionalOperations {
+  /* Apply `fn` to each element yielded by this iterator and yield the value
+     returned by `fn`.  `fn` must take a single argument and return a value.
+   */
+  iter _iteratorRecord.map(fn) {
+    for x in this do yield fn(x);
+  }
+
+  /* Apply `fn` to each element yielded by this iterator and yield the values
+     it returns `true` for.  `fn` must take a single argument and return a
+     boolean value.
+   */
+  iter _iteratorRecord.filter(fn) {
+    for x in this do if fn(x) then yield x;
+  }
+
+  /* Apply `fn` to each element yielded by this iterator and ignore the return
+     value from `fn` if any.
+   */
+  proc _iteratorRecord.consume(fn) {
+    for x in this do fn(x);
+  }
+}

--- a/test/functions/iterators/diten/mapFilter.chpl
+++ b/test/functions/iterators/diten/mapFilter.chpl
@@ -1,0 +1,71 @@
+proc imaginate(x: int) {
+  return x*1.0i;
+}
+
+writeln("range empty");
+for i in (1..0).these().map(imaginate) {
+  writeln(i);
+}
+
+writeln("range forward");
+for i in (1..10).these().map(imaginate) {
+  writeln(i);
+}
+
+writeln("range backward");
+for i in (1..10 by -1).these().map(imaginate) {
+  writeln(i);
+}
+
+writeln("domain empty");
+for i in {1..0}.these().map(imaginate) {
+  writeln(i);
+}
+
+writeln("domain forward");
+for i in {1..10}.these().map(imaginate) {
+  writeln(i);
+}
+
+writeln("domain backward");
+for i in {1..10 by -1}.these().map(imaginate) {
+  writeln(i);
+}
+
+writeln("array empty");
+var A: [1..0] int;
+for i in A.these().map(imaginate) {
+  writeln(i);
+}
+
+writeln("array forward");
+for i in [1,2,3,4,5,6,7,8,9,10].these().map(imaginate) {
+  writeln(i);
+}
+
+iter udIter() {
+  var i = 1;
+  while i <= 10 {
+    yield i;
+    i += 1;
+  }
+}
+
+writeln("user-defined iterator");
+for i in udIter().map(imaginate) {
+  writeln(i);
+}
+
+proc threevenPlusOne(x: int) return x%3 == 1;
+
+writeln("chained on user-defined iterator");
+for i in udIter().filter(threevenPlusOne).map(imaginate) {
+  writeln(i);
+}
+
+proc writeit(im: imag) {
+  writeln(im);
+}
+
+writeln("chained with consume");
+udIter().filter(threevenPlusOne).map(imaginate).consume(writeit);

--- a/test/functions/iterators/diten/mapFilter.chpl
+++ b/test/functions/iterators/diten/mapFilter.chpl
@@ -1,3 +1,5 @@
+use FunctionalOperations;
+
 proc imaginate(x: int) {
   return x*1.0i;
 }

--- a/test/functions/iterators/diten/mapFilter.good
+++ b/test/functions/iterators/diten/mapFilter.good
@@ -1,0 +1,79 @@
+range empty
+range forward
+1.0i
+2.0i
+3.0i
+4.0i
+5.0i
+6.0i
+7.0i
+8.0i
+9.0i
+10.0i
+range backward
+10.0i
+9.0i
+8.0i
+7.0i
+6.0i
+5.0i
+4.0i
+3.0i
+2.0i
+1.0i
+domain empty
+domain forward
+1.0i
+2.0i
+3.0i
+4.0i
+5.0i
+6.0i
+7.0i
+8.0i
+9.0i
+10.0i
+domain backward
+10.0i
+9.0i
+8.0i
+7.0i
+6.0i
+5.0i
+4.0i
+3.0i
+2.0i
+1.0i
+array empty
+array forward
+1.0i
+2.0i
+3.0i
+4.0i
+5.0i
+6.0i
+7.0i
+8.0i
+9.0i
+10.0i
+user-defined iterator
+1.0i
+2.0i
+3.0i
+4.0i
+5.0i
+6.0i
+7.0i
+8.0i
+9.0i
+10.0i
+chained on user-defined iterator
+1.0i
+4.0i
+7.0i
+10.0i
+chained with consume
+1.0i
+4.0i
+7.0i
+10.0i


### PR DESCRIPTION
Add _iteratorRecord.map, filter, consume.  These allow using these functional
style operations on iterators. Additional operators like `foldl` / `foldr` are
likely to also be valuable additions in the future.

Added a test that uses them in several different contexts.