### PR TITLE
Use acquire and release memory orders for testAndSet locks

### DIFF
--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -422,11 +422,11 @@ class LocBlockArr {
   // not have an on statement around the while loop below (to avoid
   // the repeated on's from calling testAndSet()).
   inline proc lockLocRAD() {
-    while locRADLock.testAndSet() do chpl_task_yield();
+    while locRADLock.testAndSet(memory_order_acquire) do chpl_task_yield();
   }
 
   inline proc unlockLocRAD() {
-    locRADLock.clear();
+    locRADLock.clear(memory_order_release);
   }
 
   proc deinit() {

--- a/modules/dists/CyclicDist.chpl
+++ b/modules/dists/CyclicDist.chpl
@@ -977,11 +977,11 @@ class LocCyclicArr {
   // not have an on statement around the while loop below (to avoid
   // the repeated on's from calling testAndSet()).
   inline proc lockLocRAD() {
-    while locRADLock.testAndSet() do chpl_task_yield();
+    while locRADLock.testAndSet(memory_order_acquire) do chpl_task_yield();
   }
 
   inline proc unlockLocRAD() {
-    locRADLock.clear();
+    locRADLock.clear(memory_order_release);
   }
 
   proc deinit() {

--- a/modules/dists/StencilDist.chpl
+++ b/modules/dists/StencilDist.chpl
@@ -362,11 +362,11 @@ class LocStencilArr {
   // not have an on statement around the while loop below (to avoid
   // the repeated on's from calling testAndSet()).
   inline proc lockLocRAD() {
-    while locRADLock.testAndSet() do chpl_task_yield();
+    while locRADLock.testAndSet(memory_order_acquire) do chpl_task_yield();
   }
 
   inline proc unlockLocRAD() {
-    locRADLock.clear();
+    locRADLock.clear(memory_order_release);
   }
 
   proc deinit() {

--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -114,11 +114,11 @@ module ChapelDistribution {
       // a remote locale, you should consider wrapping the call in
       // an on clause to avoid excessive remote forks due to the
       // testAndSet()
-      while (_domsLock.testAndSet()) do chpl_task_yield();
+      while (_domsLock.testAndSet(memory_order_acquire)) do chpl_task_yield();
     }
 
     inline proc _unlock_doms() {
-      _domsLock.clear();
+      _domsLock.clear(memory_order_release);
     }
 
     proc dsiNewRectangularDom(param rank: int, type idxType, param stridable: bool, inds) {
@@ -291,11 +291,11 @@ module ChapelDistribution {
       // a remote locale, you should consider wrapping the call in
       // an on clause to avoid excessive remote forks due to the
       // testAndSet()
-      while (_arrsLock.testAndSet()) do chpl_task_yield();
+      while (_arrsLock.testAndSet(memory_order_acquire)) do chpl_task_yield();
     }
 
     inline proc _unlock_arrs() {
-      _arrsLock.clear();
+      _arrsLock.clear(memory_order_release);
     }
 
     // used for associative domains/arrays

--- a/modules/internal/ChapelError.chpl
+++ b/modules/internal/ChapelError.chpl
@@ -115,10 +115,10 @@ module ChapelError {
       // a remote locale, you should consider wrapping the call in
       // an on clause to avoid excessive remote forks due to the
       // testAndSet()
-      while (_errorsLock.testAndSet()) do chpl_task_yield();
+      while (_errorsLock.testAndSet(memory_order_acquire)) do chpl_task_yield();
     }
     inline proc _unlockErrors() {
-      _errorsLock.clear();
+      _errorsLock.clear(memory_order_release);
     }
     proc append(err: unmanaged Error) {
       on this {

--- a/modules/internal/ChapelReduce.chpl
+++ b/modules/internal/ChapelReduce.chpl
@@ -116,7 +116,7 @@ module ChapelReduce {
     proc lock() {
       var lockAttempts = 0,
           maxLockAttempts = (2**10-1);
-      while l.testAndSet() {
+      while l.testAndSet(memory_order_acquire) {
         lockAttempts += 1;
         if (lockAttempts & maxLockAttempts) == 0 {
           maxLockAttempts >>= 1;
@@ -125,7 +125,7 @@ module ChapelReduce {
       }
     }
     proc unlock() {
-      l.clear();
+      l.clear(memory_order_release);
     }
   }
 

--- a/modules/internal/DefaultAssociative.chpl
+++ b/modules/internal/DefaultAssociative.chpl
@@ -69,11 +69,11 @@ module DefaultAssociative {
     var table: [tableDom] chpl_TableEntry(idxType);
   
     inline proc lockTable() {
-      while tableLock.testAndSet() do chpl_task_yield();
+      while tableLock.testAndSet(memory_order_acquire) do chpl_task_yield();
     }
   
     inline proc unlockTable() {
-      tableLock.clear();
+      tableLock.clear(memory_order_release);
     }
   
     // TODO: An ugly [0..-1] domain appears several times in the code --

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -979,11 +979,11 @@ module DefaultRectangular {
     // These functions must always be called locally, because the lock
     // is a (local) processor one.
     inline proc lockRAD(rlocIdx) {
-      while RADLocks(rlocIdx).testAndSet() do chpl_task_yield();
+      while RADLocks(rlocIdx).testAndSet(memory_order_acquire) do chpl_task_yield();
     }
 
     inline proc unlockRAD(rlocIdx) {
-      RADLocks(rlocIdx).clear();
+      RADLocks(rlocIdx).clear(memory_order_release);
     }
   }
 

--- a/modules/standard/DynamicIters.chpl
+++ b/modules/standard/DynamicIters.chpl
@@ -33,12 +33,12 @@ module DynamicIters {
 */
 pragma "no doc"
 record vlock {
-  var l: atomic bool;
+  var l: chpl__processorAtomicType(bool);
   proc lock() {
-    on this do while l.testAndSet() != false do chpl_task_yield();
+    on this do while l.testAndSet(memory_order_acquire) do chpl_task_yield();
   }
   proc unlock() {
-    l.write(false);
+    l.clear(memory_order_release);
   }
 }
 


### PR DESCRIPTION
Use acquire and release memory orderings for our internal module
testAndSet locks. We were seeing some performance regressions with using
cstdlib atomics over intrinsics for array view microbenchmarks. The root
cause of these ended up being from base domain and distribution locking
where the backend compiler was (correctly) being more conservative about
some optimizations because of the presence of C11 style atomics instead
of the intrinsics.

Drop our testAndSet locks down to acquire/release semantics which is all
that's needed for locks (you do not need seq_cst when acquiring the lock)

For a slicing microbenchmark:

```chpl
use Time;
config const n = 100,
             numTrials = 25_000_000;
proc main() {
  var A : [1..n] int;

  var t : Timer; t.start();
  for 1..numTrials {
    ref s = A[1..n/2];
    if s.size > A.size then halt();
  }
  t.stop();

  writeln(t.elapsed());
}
```

This brings cstdlib performance very close to intrinsics performance;

| config          | time  |
| --------------- | ----- |
| intrinsics      | 2.07s |
| cstdlib         | 3.15s |
| cstdlib acq/rel | 2.13s |