### PR TITLE
Do some cleanups in comm=ofi and elsewhere.

### DIFF
--- a/runtime/include/chpltypes.h
+++ b/runtime/include/chpltypes.h
@@ -22,6 +22,7 @@
 
 #include "sys_basic.h"
 
+#include <inttypes.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -105,9 +106,11 @@ typedef struct _chpl_fieldType {
 // Seemingly, 64 bits is enough to represent both the node_id and sublocale_id
 // portions  of a locale ID, and an even split is a good first guess.
 typedef int32_t c_nodeid_t;
-#define FORMAT_c_nodeid_t PRId32
+#define PRI_c_nodeid_t PRId32
+#define SCN_c_nodeid_t SCNi32
 typedef int32_t c_sublocid_t;
-#define FORMAT_c_sublocid_t PRId32
+#define PRI_c_sublocid_t PRId32
+#define SCN_c_sublocid_t SCNi32
 typedef int64_t c_localeid_t;
 
 // These are special values that mean "no", "any", and "all sublocales",

--- a/runtime/src/chplio.c
+++ b/runtime/src/chplio.c
@@ -29,13 +29,13 @@
 // These should be moved to chpl-string.c and eventually go away.
 chpl_string chpl_refToString(void* ref) {
   char buff[32];
-  sprintf(buff, "%p", ref);
+  (void) snprintf(buff, sizeof(buff), "%p", ref);
   return string_copy(buff, 0, 0);
 }
 
 
 chpl_string chpl_wideRefToString(c_nodeid_t node, void* addr) {
   char buff[32];
-  sprintf(buff, "%" FORMAT_c_nodeid_t ":%p", node, addr);
+  (void) snprintf(buff, sizeof(buff), "%" PRI_c_nodeid_t ":%p", node, addr);
   return string_copy(buff, 0, 0);
 }

--- a/runtime/src/chplmemtrack.c
+++ b/runtime/src/chplmemtrack.c
@@ -172,7 +172,7 @@ void chpl_setMemFlags(void) {
       memLogFile = fopen(memLog, "w");
     } else {
       char* filename = (char*)sys_malloc((strlen(memLog)+10)*sizeof(char));
-      sprintf(filename, "%s.%" FORMAT_c_nodeid_t, memLog, chpl_nodeID);
+      sprintf(filename, "%s.%" PRI_c_nodeid_t, memLog, chpl_nodeID);
       memLogFile = fopen(filename, "w");
       sys_free(filename);
     }
@@ -656,7 +656,7 @@ void chpl_track_malloc(void* memAlloc, size_t number, size_t size,
       memTrack_unlock();
     }
     if (chpl_verbose_mem) {
-      fprintf(memLogFile, "%" FORMAT_c_nodeid_t ": %s:%" PRId32
+      fprintf(memLogFile, "%" PRI_c_nodeid_t ": %s:%" PRId32
                           ": allocate %zuB of %s at %p\n",
               chpl_nodeID, (filename ? chpl_lookupFilename(filename) : "--"),
               lineno, number * size, chpl_mem_descString(description),
@@ -673,7 +673,7 @@ void chpl_track_free(void* memAlloc, int32_t lineno, int32_t filename) {
     memEntry = removeMemTableEntry(memAlloc);
     if (memEntry) {
       if (chpl_verbose_mem) {
-        fprintf(memLogFile, "%" FORMAT_c_nodeid_t ": %s:%" PRId32
+        fprintf(memLogFile, "%" PRI_c_nodeid_t ": %s:%" PRId32
                             ": free %zuB of %s at %p\n",
                 chpl_nodeID, (filename ? chpl_lookupFilename(filename) : "--"),
                 lineno, memEntry->number * memEntry->size,
@@ -683,7 +683,7 @@ void chpl_track_free(void* memAlloc, int32_t lineno, int32_t filename) {
     }
     memTrack_unlock();
   } else if (chpl_verbose_mem && !memEntry) {
-    fprintf(memLogFile, "%" FORMAT_c_nodeid_t ": %s:%" PRId32 ": free at %p\n",
+    fprintf(memLogFile, "%" PRI_c_nodeid_t ": %s:%" PRId32 ": free at %p\n",
             chpl_nodeID, (filename ? chpl_lookupFilename(filename) : "--"),
             lineno, memAlloc);
   }
@@ -718,7 +718,7 @@ void chpl_track_realloc_post(void* moreMemAlloc,
       memTrack_unlock();
     }
     if (chpl_verbose_mem) {
-      fprintf(memLogFile, "%" FORMAT_c_nodeid_t ": %s:%" PRId32
+      fprintf(memLogFile, "%" PRI_c_nodeid_t ": %s:%" PRId32
                           ": reallocate %zuB of %s at %p -> %p\n",
               chpl_nodeID, (filename ? chpl_lookupFilename(filename) : "--"),
               lineno, size, chpl_mem_descString(description), memAlloc,

--- a/runtime/src/comm/ofi/comm-ofi-internal.h
+++ b/runtime/src/comm/ofi/comm-ofi-internal.h
@@ -53,6 +53,7 @@ FILE* chpl_comm_ofi_dbg_file;
 #define DBG_CFG                    0x10UL
 #define DBG_CFGFAB                 0x20UL
 #define DBG_CFGFABSALL             0x40UL
+#define DBG_CFGAV                  0x80UL
 #define DBG_THREADS               0x100UL
 #define DBG_THREADDETAILS         0x200UL
 #define DBG_INTERFACE            0x1000UL

--- a/runtime/src/comm/ofi/comm-ofi-internal.h
+++ b/runtime/src/comm/ofi/comm-ofi-internal.h
@@ -46,32 +46,31 @@
 uint64_t chpl_comm_ofi_dbg_level;
 FILE* chpl_comm_ofi_dbg_file;
 
-#define DBG_STATS                 0x1UL
-#define DBG_STATSNODES            0x2UL
-#define DBG_STATSTHREADS          0x4UL
-#define DBG_STATSPROGRESS         0x8UL
-#define DBG_CONFIG               0x10UL
-#define DBG_CONFIGMORE           0x20UL
-#define DBG_THREADS              0x40UL
-#define DBG_THREADDETAILS        0x80UL
-#define DBG_INTERFACE           0x100UL
-#define DBG_AM                 0x1000UL
-#define DBG_AMSEND             0x2000UL
-#define DBG_AMRECV             0x4000UL
-#define DBG_RMA               0x10000UL
-#define DBG_RMAWRITE          0x20000UL
-#define DBG_RMAREAD           0x40000UL
-#define DBG_AMO              0x100000UL
-#define DBG_ACK              0x200000UL
-#define DBG_MR              0x1000000UL
-#define DBG_HUGEPAGES       0x2000000UL
-#define DBG_MRDESC          0x4000000UL
-#define DBG_MRKEY           0x8000000UL
-#define DBG_FAB            0x10000000UL
-#define DBG_FABSALL        0x20000000UL
-#define DBG_FABFAIL        0x40000000UL
-#define DBG_BARRIER       0x100000000UL
-#define DBG_TSTAMP       0x1000000000UL
+#define DBG_STATS                   0x1UL
+#define DBG_STATSNODES              0x2UL
+#define DBG_STATSTHREADS            0x4UL
+#define DBG_STATSPROGRESS           0x8UL
+#define DBG_CFG                    0x10UL
+#define DBG_CFGFAB                 0x20UL
+#define DBG_CFGFABSALL             0x40UL
+#define DBG_THREADS               0x100UL
+#define DBG_THREADDETAILS         0x200UL
+#define DBG_INTERFACE            0x1000UL
+#define DBG_AM                  0x10000UL
+#define DBG_AMSEND              0x20000UL
+#define DBG_AMRECV              0x40000UL
+#define DBG_RMA                0x100000UL
+#define DBG_RMAWRITE           0x200000UL
+#define DBG_RMAREAD            0x400000UL
+#define DBG_AMO               0x1000000UL
+#define DBG_ACK               0x2000000UL
+#define DBG_MR               0x10000000UL
+#define DBG_MRDESC           0x20000000UL
+#define DBG_MRKEY            0x40000000UL
+#define DBG_HUGEPAGES        0x80000000UL
+#define DBG_BARRIER         0x100000000UL
+#define DBG_OOB            0x1000000000UL
+#define DBG_TSTAMP        0x10000000000UL
 
 void chpl_comm_ofi_dbg_init(void);
 char* chpl_comm_ofi_dbg_prefix(void);
@@ -194,7 +193,7 @@ struct gather_info {
 void chpl_comm_ofi_oob_init(void);
 void chpl_comm_ofi_oob_fini(void);
 void chpl_comm_ofi_oob_barrier(void);
-void chpl_comm_ofi_oob_allgather(void*, void*, int);
+void chpl_comm_ofi_oob_allgather(void*, void*, size_t);
 
 
 //

--- a/runtime/src/comm/ofi/comm-ofi-oob-pmi.c
+++ b/runtime/src/comm/ofi/comm-ofi-oob-pmi.c
@@ -49,25 +49,32 @@ void chpl_comm_ofi_oob_init(void) {
   if (PMI2_Initialized() != PMI_TRUE) {
     PMI_CHK(PMI2_Init(&spawned, &size, &rank, &appnum));
     assert(spawned == 0);
-    chpl_nodeID = (int32_t) rank;
+    chpl_nodeID = (c_nodeid_t) rank;
     chpl_numNodes = (int32_t) size;
   }
+
+  DBG_PRINTF(DBG_OOB, "OOB init: node %" PRI_c_nodeid_t " of %" PRId32,
+             chpl_nodeID, chpl_numNodes);
 }
 
 
 void chpl_comm_ofi_oob_fini(void) {
   if (PMI2_Initialized() == PMI_TRUE) {
+    DBG_PRINTF(DBG_OOB, "OOB finalize");
     PMI_CHK(PMI2_Finalize());
   }
 }
 
 
 void chpl_comm_ofi_oob_barrier(void) {
+  DBG_PRINTF(DBG_OOB, "OOB barrier");
   PMI_CHK(PMI_Barrier());
 }
 
 
-void chpl_comm_ofi_oob_allgather(void* mine, void* all, int size) {
+void chpl_comm_ofi_oob_allgather(void* mine, void* all, size_t size) {
+  DBG_PRINTF(DBG_OOB, "OOB allGather: %zd", size);
+
   //
   // PMI doesn't provide an ordered allGather, so we build one here
   // by concatenating the node index and the payload and using that

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -1862,6 +1862,8 @@ struct perTxCtxInfo_t* tciAlloc(chpl_bool bindToAmHandler) {
   // Find a tx context that isn't busy and use that one.
   //
   tcip = findFreeTciTabEntry(bindToAmHandler);
+  if (bindToAmHandler || tciTabFixedAssignments)
+    tcip->bound = true;
   DBG_PRINTF(DBG_THREADS, "I have%s tciTab[%td]",
              bindToAmHandler ? " bound" : "", tcip - tciTab);
   return tcip;
@@ -1887,7 +1889,6 @@ struct perTxCtxInfo_t* findFreeTciTabEntry(chpl_bool bindToAmHandler) {
     tcip = &tciTab[numWorkerTxCtxs];
     CHK_FALSE(atomic_exchange_bool(&tcip->allocated, true));
     tcip->bound = true;
-    DBG_PRINTF(DBG_THREADS, "I have bound tciTab[%td]", tcip - tciTab);
     return tcip;
   }
 
@@ -1919,7 +1920,6 @@ struct perTxCtxInfo_t* findFreeTciTabEntry(chpl_bool bindToAmHandler) {
     }
   } while (tcip == NULL);
 
-  DBG_PRINTF(DBG_THREADS, "I have tciTab[%td]", tcip - tciTab);
   return tcip;
 }
 


### PR DESCRIPTION
I started on my next step in comm=ofi and ended up first doing several other things which I'll either need in the future or just encountered while looking at other things.

Rename the `printf()` and `scanf()` format specifier macros for nodes and sublocales, to follow the naming style in `<inttypes.h>`.

In comm=ofi, fix a bug that caused us to dynamically allocate and free transmit context descriptors even when we should have been using bound ones, and add out-of-band and node addressing debugging capabilities.