### PR TITLE
Revert recent llvm makefile changes

### DIFF
--- a/third-party/llvm/Makefile
+++ b/third-party/llvm/Makefile
@@ -104,7 +104,7 @@ $(LLVM_REBUILD_FILE): $(LLVM_SRC_FILE)
 	mkdir -p $(LLVM_BUILD_DIR)
 	touch $(LLVM_REBUILD_FILE)
 
-$(LLVM_CONFIGURED_HEADER_FILE):
+$(LLVM_CONFIGURED_HEADER_FILE): $(LLVM_REBUILD_FILE)
 	mkdir -p $(LLVM_BUILD_DIR)
 	@if ./cmake-ok.sh $(CMAKE); then \
 	  cd $(LLVM_BUILD_DIR) && cmake \

--- a/third-party/llvm/Makefile
+++ b/third-party/llvm/Makefile
@@ -100,7 +100,7 @@ $(LLVM_SRC_FILE):
 # -DPOLLY_ENABLE_GPGPU_CODEGEN=ON
 # to the flags supplied below.
 
-$(LLVM_REBUILD_FILE): $(LLVM_SRC_FILE)
+$(LLVM_REBUILD_FILE):
 	mkdir -p $(LLVM_BUILD_DIR)
 	touch $(LLVM_REBUILD_FILE)
 

--- a/third-party/llvm/Makefile
+++ b/third-party/llvm/Makefile
@@ -33,7 +33,6 @@ endif
 
 LLVM_SRC_FILE := llvm/CMakeLists.txt
 LLVM_CMAKE_FILE := $(LLVM_BUILD_DIR)/CMakeCache.txt
-LLVM_REBUILD_FILE := $(LLVM_BUILD_DIR)/TOUCH_TO_REBUILD
 LLVM_CONFIGURED_HEADER_FILE := $(LLVM_BUILD_DIR)/include/llvm/Config/llvm-config.h
 LLVM_HEADER_FILE := $(LLVM_INSTALL_DIR)/include/llvm/PassSupport.h
 LLVM_SUPPORT_FILE := $(LLVM_INSTALL_DIR)/lib/libLLVMSupport.a
@@ -100,11 +99,7 @@ $(LLVM_SRC_FILE):
 # -DPOLLY_ENABLE_GPGPU_CODEGEN=ON
 # to the flags supplied below.
 
-$(LLVM_REBUILD_FILE):
-	mkdir -p $(LLVM_BUILD_DIR)
-	touch $(LLVM_REBUILD_FILE)
-
-$(LLVM_CONFIGURED_HEADER_FILE): $(LLVM_REBUILD_FILE)
+$(LLVM_CONFIGURED_HEADER_FILE): $(LLVM_SRC_FILE)
 	mkdir -p $(LLVM_BUILD_DIR)
 	@if ./cmake-ok.sh $(CMAKE); then \
 	  cd $(LLVM_BUILD_DIR) && cmake \
@@ -129,20 +124,18 @@ $(LLVM_CONFIGURED_HEADER_FILE): $(LLVM_REBUILD_FILE)
 	  echo Error: LLVM requires cmake 3.4.3 or later to build; \
 	  exit 1; \
 	fi
-	if [ -f $(LLVM_CONFIGURED_HEADER_FILE) ]; then touch $(LLVM_CONFIGURED_HEADER_FILE); fi
 
 
-$(LLVM_HEADER_FILE): $(LLVM_REBUILD_FILE)
+$(LLVM_HEADER_FILE):
 	if [ -f $(LLVM_BUILD_DIR)/Makefile ]; then \
 	  cd $(LLVM_BUILD_DIR) && $(MAKE) install-llvm-headers ; \
 	else \
 	  cd $(LLVM_BUILD_DIR) && cmake --build . --target install-llvm-headers ; \
 	fi
-	if [ -f $(LLVM_HEADER_FILE) ]; then touch $(LLVM_HEADER_FILE); fi
 
 # note: the conditional below allows parallel make to continue
 # if cmake us also using Make.
-$(LLVM_SUPPORT_FILE): $(LLVM_REBUILD_FILE)
+$(LLVM_SUPPORT_FILE):
 	if [ -f $(LLVM_BUILD_DIR)/Makefile ]; then \
 	  cd $(LLVM_BUILD_DIR) && $(MAKE) install-cmake-exports ; \
 	  cd $(LLVM_BUILD_DIR) && $(MAKE) LLVMSupport ; \
@@ -152,9 +145,8 @@ $(LLVM_SUPPORT_FILE): $(LLVM_REBUILD_FILE)
 	  cd $(LLVM_BUILD_DIR) && cmake --build . --target LLVMSupport ; \
 	  cd $(LLVM_BUILD_DIR) && cmake --build . --target install-LLVMSupport ; \
 	fi
-	if [ -f $(LLVM_SUPPORT_FILE) ]; then touch $(LLVM_SUPPORT_FILE); fi
 
-$(LLVM_CONFIG_FILE): $(LLVM_REBUILD_FILE)
+$(LLVM_CONFIG_FILE):
 	if [ -f $(LLVM_BUILD_DIR)/Makefile ]; then \
 	  cd $(LLVM_BUILD_DIR) && $(MAKE) llvm-config ; \
 	else \
@@ -162,12 +154,11 @@ $(LLVM_CONFIG_FILE): $(LLVM_REBUILD_FILE)
 	fi
 	mkdir -p $(LLVM_INSTALL_DIR)/bin
 	cp $(LLVM_BUILD_DIR)/bin/llvm-config $(LLVM_INSTALL_DIR)/bin/llvm-config
-	if [ -f $(LLVM_CONFIG_FILE) ]; then touch $(LLVM_CONFIG_FILE); fi
 
 # note: install target for config doesn't seem to exist
 #cd $(LLVM_BUILD_DIR) && cmake --build . --target install-llvm-config
 
-$(LLVM_CLANG_FILE): $(LLVM_REBUILD_FILE)
+$(LLVM_CLANG_FILE):
 	if [ -f $(LLVM_BUILD_DIR)/Makefile ]; then \
 	  cd $(LLVM_BUILD_DIR) && $(MAKE) ; \
 	  cd $(LLVM_BUILD_DIR) && $(MAKE) install ; \
@@ -175,13 +166,12 @@ $(LLVM_CLANG_FILE): $(LLVM_REBUILD_FILE)
 	  cd $(LLVM_BUILD_DIR) && cmake --build . --target clang ; \
 	  cd $(LLVM_BUILD_DIR) && cmake --build . --target install-clang ; \
 	fi
-	if [ -f $(LLVM_CLANG_FILE) ]; then touch $(LLVM_CLANG_FILE); fi
 
 # Create a file containing extra arguments for clang
 # This file is necessary on darwin where important headers are
 # not in /usr/include. This causes a problem when building another clang
 # because the new clang can't find the appropriate headers.
-$(LLVM_CLANG_CONFIG_FILE): $(LLVM_REBUILD_FILE)
+$(LLVM_CLANG_CONFIG_FILE):
 	mkdir -p $(LLVM_INSTALL_DIR)
 	if [ "clang" = "$(CHPL_MAKE_HOST_COMPILER)" ]; then \
 	  ../../util/config/gather-clang-sysroot-arguments clang > $(LLVM_CLANG_CONFIG_FILE) ; \

--- a/third-party/llvm/Makefile
+++ b/third-party/llvm/Makefile
@@ -104,7 +104,7 @@ $(LLVM_REBUILD_FILE): $(LLVM_SRC_FILE)
 	mkdir -p $(LLVM_BUILD_DIR)
 	touch $(LLVM_REBUILD_FILE)
 
-$(LLVM_CONFIGURED_HEADER_FILE): $(LLVM_SRC_FILE)
+$(LLVM_CONFIGURED_HEADER_FILE):
 	mkdir -p $(LLVM_BUILD_DIR)
 	@if ./cmake-ok.sh $(CMAKE); then \
 	  cd $(LLVM_BUILD_DIR) && cmake \


### PR DESCRIPTION
We're seeing some module build problems to do with LLVM builds.
Some build scripts assume that a second `make` call won't rebuild
anything within the compiler (or with LLVM) but that doesn't seem to be the
case after PR #11779.

This PR just reverts the third-party/llvm/Makefile changes from PR #11779.
I've verified that the resulting Makefile is the same as it was before that PR.

The Makefile changes in PR #11779 were intended as a convenience
for the case of updating LLVM sources and rebuilding Chapel to use them.
The alternative is to go into the LLVM build directory and run `make` and
`make install` and that should suffice for now.

- [x] Verified make clobber; make with LLVM; hellos work

Reviewed by @ronawho - thanks!