### PR TITLE
Allow string slices by codepoint index

### DIFF
--- a/test/types/string/StringImpl/memLeaks/substring_codepoint.chpl
+++ b/test/types/string/StringImpl/memLeaks/substring_codepoint.chpl
@@ -1,0 +1,119 @@
+module unitTest {
+  use main;
+
+  proc substringLocalCodePoint(type t, useExpr=false) {
+    writeln("=== local substring codepoint");
+
+    proc substringHelp(i) {
+      const m0 = allMemoryUsed();
+      {
+        const s: t = "sûḃstríng";
+        if useExpr {
+          writeMe(s[i]);
+        } else {
+          const ss = s[i];
+          writeMe(ss);
+        }
+      }
+      checkMemLeaks(m0);
+    }
+
+    proc substringHelpCPI(i) {
+      const m0 = allMemoryUsed();
+      {
+        const s: t = "sûḃstríng";
+        if useExpr {
+          writeMe(codePointToString(s[i]));
+        } else {
+          const ss = codePointToString(s[i]);
+          writeMe(ss);
+        }
+      }
+      checkMemLeaks(m0);
+    }
+
+    var idx = 3:codePointIndex;
+    substringHelpCPI(idx);
+
+    var slice = ..idx;
+    substringHelp(slice);
+
+    var slice2 = idx..#(idx:int);
+    substringHelp(slice2);
+
+    var slice3 = idx..;
+    substringHelp(slice3);
+  }
+
+  proc substringRemoteCodePoint(type t, useExpr=false) {
+    writeln("=== remote substring codepoint");
+
+    proc substringHelp(i) {
+      const m0 = allMemoryUsed();
+      {
+        const s0: t = "sûḃstríng";
+        on Locales[numLocales-1] {
+          if useExpr {
+            writeMe(s0[i]);
+          } else {
+            const ss = s0[i];
+            writeMe(ss);
+          }
+          const s1: t = "sûḃstríng";
+          on Locales[0] {
+            if useExpr {
+              writeMe(s1[i]);
+            } else {
+              const ss = s1[i];
+              writeMe(ss);
+            }
+          }
+        }
+      }
+      checkMemLeaks(m0);
+    }
+
+    proc substringHelpCPI(i) {
+      const m0 = allMemoryUsed();
+      {
+        const s0: t = "sûḃstríng";
+        on Locales[numLocales-1] {
+          if useExpr {
+            writeMe(codePointToString(s0[i]));
+          } else {
+            const ss = codePointToString(s0[i]);
+            writeMe(ss);
+          }
+          const s1: t = "sûḃstríng";
+          on Locales[0] {
+            if useExpr {
+              writeMe(codePointToString(s1[i]));
+            } else {
+              const ss = codePointToString(s1[i]);
+              writeMe(ss);
+            }
+          }
+        }
+      }
+      checkMemLeaks(m0);
+    }
+
+    var idx = 3:codePointIndex;
+    substringHelpCPI(idx);
+
+    var slice = ..idx;
+    substringHelp(slice);
+
+    var slice2 = idx..#(idx:int);
+    substringHelp(slice2);
+
+    var slice3 = idx..;
+    substringHelp(slice3);
+  }
+
+  proc doIt(type t) {
+    substringLocalCodePoint(t); substringLocalCodePoint(t, true);
+    substringRemoteCodePoint(t); substringRemoteCodePoint(t, true);
+  }
+
+}

--- a/test/types/string/StringImpl/memLeaks/substring_codepoint.good
+++ b/test/types/string/StringImpl/memLeaks/substring_codepoint.good
@@ -1,0 +1,28 @@
+=== local substring codepoint
+ḃ
+sûḃ
+ḃst
+ḃstríng
+=== local substring codepoint
+ḃ
+sûḃ
+ḃst
+ḃstríng
+=== remote substring codepoint
+ḃ
+ḃ
+sûḃ
+sûḃ
+ḃst
+ḃst
+ḃstríng
+ḃstríng
+=== remote substring codepoint
+ḃ
+ḃ
+sûḃ
+sûḃ
+ḃst
+ḃst
+ḃstríng
+ḃstríng

--- a/test/types/string/dmk/substring/COMPOPTS
+++ b/test/types/string/dmk/substring/COMPOPTS
@@ -1,0 +1,1 @@
+--bounds-checks

--- a/test/types/string/dmk/substring/substringBadRange-codepoint.chpl
+++ b/test/types/string/dmk/substring/substringBadRange-codepoint.chpl
@@ -1,0 +1,4 @@
+var str = "åbçdèfghíjklm";
+
+writeln("str[12:codePointIndex..13:codePointIndex] = ", str[12:codePointIndex..13:codePointIndex]);
+writeln("str[12:codePointIndex..16:codePointIndex] = ", str[12:codePointIndex..16:codePointIndex]);

--- a/test/types/string/dmk/substring/substringBadRange-codepoint.good
+++ b/test/types/string/dmk/substring/substringBadRange-codepoint.good
@@ -1,0 +1,2 @@
+str[12:codePointIndex..13:codePointIndex] = lm
+substringBadRange-codepoint.chpl:4: error: halt reached - range out of bounds of string

--- a/test/types/string/dmk/substring/substringBadRange2-codepoint.chpl
+++ b/test/types/string/dmk/substring/substringBadRange2-codepoint.chpl
@@ -1,0 +1,3 @@
+var str = "åbçdèfghíjklm";
+
+writeln("str[13:codePointIndex..(-1):codePointIndex] = ", str[13:codePointIndex..(-1):codePointIndex]);

--- a/test/types/string/dmk/substring/substringBadRange2-codepoint.good
+++ b/test/types/string/dmk/substring/substringBadRange2-codepoint.good
@@ -1,0 +1,1 @@
+substringBadRange2-codepoint.chpl:3: error: halt reached - range out of bounds of string

--- a/test/types/string/dmk/substring/substringBadRange3-codepoint.chpl
+++ b/test/types/string/dmk/substring/substringBadRange3-codepoint.chpl
@@ -1,0 +1,3 @@
+var str = "åbçdèfghíjklm";
+
+writeln("str[3:codePointIndex..2:codePointIndex] = ", str[3:codePointIndex..2:codePointIndex]);

--- a/test/types/string/dmk/substring/substringBadRange3-codepoint.good
+++ b/test/types/string/dmk/substring/substringBadRange3-codepoint.good
@@ -1,0 +1,1 @@
+str[3:codePointIndex..2:codePointIndex] = 


### PR DESCRIPTION
This change allows slicing a string by a range of codepoint indices.  Slicing by a range of byte indices was already allowed.

Tested on linux64, Mac, GASNet, and Cray XC.

Closes #11062 
