### PR TITLE
Allow + on integer reads

### DIFF
--- a/runtime/src/qio/qio_formatted.c
+++ b/runtime/src/qio/qio_formatted.c
@@ -2127,7 +2127,7 @@ qioerr qio_channel_scan_int(const int threadsafe, qio_channel_t* restrict ch, vo
 
   st.base = style->base;
   st.allow_base = style->prefix_base;
-  st.allow_pos_sign = style->showplus == 1;
+  st.allow_pos_sign = 1;
   st.allow_neg_sign = issigned;
   if(style->showpoint || style->precision > 0) {
     st.allow_point = 1;


### PR DESCRIPTION
Resolves  #11899.

We already allow + on reading floating point numbers. This PR changes the I/O code to also allow + when reading integers (signed or unsigned).

- [ ] full local testing