### PR TITLE
Add CHPL_HOST_MACHINE and CHPL_TARGET_MACHINE to build_configs

### DIFF
--- a/util/build_configs/build_configs.py
+++ b/util/build_configs/build_configs.py
@@ -84,8 +84,10 @@ how they will show up in the usage and what order is used in interactive mode.
 known_dimensions = [
     ( 'host_platform',      'CHPL_HOST_PLATFORM', ),
     ( 'host_compiler',      'CHPL_HOST_COMPILER', ),
+    ( 'host_machine',       'CHPL_HOST_MACHINE', ),
     ( 'target_platform',    'CHPL_TARGET_PLATFORM', ),
     ( 'target_compiler',    'CHPL_TARGET_COMPILER', ),
+    ( 'target_machine',     'CHPL_TARGET_MACHINE', ),
     ( 'arch',               'CHPL_TARGET_ARCH', ),
     ( 'locale_model',       'CHPL_LOCALE_MODEL', ),
     ( 'comm',               'CHPL_COMM', ),


### PR DESCRIPTION
Resolves #11901.

Tested with (from CHPL_HOME):

```
make clobber
./util/build_configs/build_configs.py --target-machine=x86,x86_64 -p
```

and then I verified that lib/ had both an x86 and x86_64 configuration.

```
./util/build_configs/build_configs.py --host-machine=x86,x86_64 -p
```

and then I verified that bin had both x86 and x86_64 subdirectories.

Reviewed by @gbtitus - thanks!