### PR TITLE
Prevent a spurious complaint from gcc 8.2

### DIFF
--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -176,9 +176,11 @@ endif
 #
 # Avoid false positive warnings about class member access and string overflows.
 # The string overflow false positives occur in runtime code unlike gcc 7.
+# Also avoid false positives for allocation size, array bounds, and comments.
+# On Ubuntu, gcc 8 complains about multiline comments in Clang header files.
 #
 ifeq ($(shell test $(GNU_GPP_MAJOR_VERSION) -eq 8; echo "$$?"),0)
-WARN_CXXFLAGS += -Wno-class-memaccess -Walloc-size-larger-than=18446744073709551615
+WARN_CXXFLAGS += -Wno-class-memaccess -Walloc-size-larger-than=18446744073709551615 -Wno-comment
 RUNTIME_CFLAGS += -Wno-stringop-overflow
 SQUASH_WARN_GEN_CFLAGS += -Wno-array-bounds
 endif


### PR DESCRIPTION
Recent changes uncovered a case of gcc 8.2 giving false positive warnings on Clang header files, which we turn into errors with `-Werror`.  At least the Clang header `AST/DeclOpenMP.h` has a multiline comment in it, which gcc 8.2 complains about on Ubuntu 18.04.  This change suppresses the warning.