### PR TITLE
Update LLVM version checks for more recent versions

### DIFF
--- a/third-party/llvm/find-llvm-config.sh
+++ b/third-party/llvm/find-llvm-config.sh
@@ -12,6 +12,9 @@ command_exists()
 if command_exists llvm-config-$PREFERRED_VERSION
 then
   command -v llvm-config-$PREFERRED_VERSION
+elif command_exists llvm-config-$PREFERRED_VERSION_MAJOR
+then
+  command -v llvm-config-$PREFERRED_VERSION_MAJOR
 elif command_exists llvm-config
 then
   command -v llvm-config


### PR DESCRIPTION
On Ubuntu, LLVM version 7 is just designated as "7" instead of "7.0" in the names of its executable programs, unlike earlier versions.  This change allows for that difference.