### PR TITLE
Generalize test_many_arrays_of_star_tuples.bad matching.

### DIFF
--- a/test/arrays/deitz/many/test_many_arrays_of_star_tuples.bad
+++ b/test/arrays/deitz/many/test_many_arrays_of_star_tuples.bad
@@ -1,2 +1,2 @@
-$CHPL_HOME/modules/standard/IO.chpl:2655: error: Function '_isSimpleIoType' has been instantiated too many times
+FILE:LINE: error: Symbol 'SYM' has been instantiated too many times
 note:   If this is intentional, try increasing the instantiation limit from 256

--- a/test/arrays/deitz/many/test_many_arrays_of_star_tuples.prediff
+++ b/test/arrays/deitz/many/test_many_arrays_of_star_tuples.prediff
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+prefix="[^']* '[[:alpha:]_][[:alnum:]_]*'"
+suffix=" has been instantiated too many times"
+sed "s/^${prefix}\(${suffix}\)\$/FILE:LINE: error: Symbol 'SYM'\1/" \
+    < $2 > $2.tmp
+mv $2.tmp $2


### PR DESCRIPTION
The .bad for test_many_arrays_of_star_tuples was matching a particular
file, line, and symbol for the 'has been instantiated too many times'
message.  Recent experience indicates that was too specific; PR #11908
cause all three to change.  Here, arrange to match just the message text
and ignore the file, line, and symbol.