### PR TITLE
Adding an annotation for when I slowed down my spectralnorm

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -1221,6 +1221,8 @@ search:
 spectralnorm:
   01/21/15:
     - qthreads updated to yield every ~100 uncontested sync var locks
+  12/18/18:
+    - brad version changed to serial implementation (#11904)
 
 spectral-norm-specify-step:
   01/21/15:


### PR DESCRIPTION
This is partly good citizenship, partly to generate a test commit for Jenna.