### PR TITLE
Add a pragma unsafe to work around lifetime checker failures

### DIFF
--- a/test/optimizations/bulkcomm/block/exchange.chpl
+++ b/test/optimizations/bulkcomm/block/exchange.chpl
@@ -16,6 +16,7 @@ config const pat : Pattern = Elegant;
 config const report = false;
 config const time = false;
 
+pragma "unsafe" // work around until PR #11928 lands
 proc main() {
   var tmr : Timer;
 

--- a/test/studies/nbody/md.chpl
+++ b/test/studies/nbody/md.chpl
@@ -52,6 +52,7 @@ proc try1() {
 }
 
 // overlap computation and communication
+pragma "unsafe" // work around until PR #11928 lands
 proc try2() {
 
   var tm: Timer;


### PR DESCRIPTION
This workaround resolves failures with

     optimizations/bulkcomm/block/exchange
     studies/nbody/md

PR #11928 is the actual solution but it will be a little bit before I get to merging that.