### PR TITLE
Remove unnecessary checking for inTree()

### DIFF
--- a/compiler/AST/LoopExpr.cpp
+++ b/compiler/AST/LoopExpr.cpp
@@ -192,9 +192,7 @@ class LowerLoopExprVisitor : public AstVisitorTraverse
 // table.
 //
 bool LowerLoopExprVisitor::enterLoopExpr(LoopExpr* node) {
-  if (! node->inTree()) {
-    // nothing to do
-  } else if (node->getStmtExpr() == NULL) {
+  if (node->getStmtExpr() == NULL) {
     // Don't touch LoopExprs in DefExprs, they should be copied later into
     // BlockStmts.
     INT_ASSERT(isDefExpr(node->parentExpr));
@@ -224,6 +222,7 @@ bool LowerLoopExprVisitor::enterLoopExpr(LoopExpr* node) {
 }
 
 void lowerLoopExprs(BaseAST* ast) {
+  INT_ASSERT(ast->inTree()); // otherwise nothing to do
   LowerLoopExprVisitor vis;
   ast->accept(&vis);
 }


### PR DESCRIPTION
This check gave me a pause "why are we checking this? shouldn't it
always be true?". Because we are traversing the ASTs to be normalized,
and I think we do not normalize ASTs that have already been deleted.

Turns out yes, it is always true as far as testing.
Adjusting the code to reflect this understanding.

This is a minor aesthetic change. Not reviewed.