### PR TITLE
Do not promote 'these()'

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -1159,6 +1159,7 @@ bool doCanDispatch(Type*     actualType,
     if (retval == false) {
       if (fn                              != NULL        &&
           fn->name                        != astrSequals &&
+          strcmp(fn->name, "these")       != 0           &&
           actualType->scalarPromotionType != NULL        &&
           doCanDispatch(actualType->scalarPromotionType,
                         NULL,


### PR DESCRIPTION
See #11879 for discussion.

Future work: possibly allow promotion of these() when it is invoked by the user explicitly.

This change is suggested by @mppf.
