### PR TITLE
Add a stopgap mpirun launcher for comm=ofi, and out-of-band to match.

### DIFF
--- a/runtime/etc/Makefile.comm-ofi
+++ b/runtime/etc/Makefile.comm-ofi
@@ -25,3 +25,8 @@ LIBS += -lfabric -ldl
 # code) is being linked in.
 #
 LD = $(CXX)
+
+ifneq (, $(findstring mpi,$(CHPL_MAKE_LAUNCHER)))
+GEN_LFLAGS += -L$(MPI_LIB) -Wl,-rpath,$(MPI_LIB)
+LIBS += -lmpi
+endif

--- a/runtime/src/comm/ofi/Makefile.share
+++ b/runtime/src/comm/ofi/Makefile.share
@@ -23,14 +23,18 @@ COMM_SRCS = \
 	comm-ofi.c
 
 #
-# Use PMI out-of-band support on Cray X*, "sockets" everywhere else.
-# Use hugepages only on Cray X*, so far.
+# Use PMI out-of-band support on Cray X*, else MPI when the launcher is
+# that, else "sockets".  Use hugepages only on Cray X*.
 #
-ifneq (, $(filter cray-x%,$(CHPL_MAKE_TARGET_PLATFORM)))
+ifneq (, $(findstring cray-x,$(CHPL_MAKE_TARGET_PLATFORM)))
   COMM_SRCS += comm-ofi-oob-pmi.c
   COMM_SRCS += comm-ofi-hugepages.c
 else
-  COMM_SRCS += comm-ofi-oob-sockets.c
+  ifneq (, $(findstring mpi,$(CHPL_MAKE_LAUNCHER)))
+    COMM_SRCS += comm-ofi-oob-mpi.c
+  else
+    COMM_SRCS += comm-ofi-oob-sockets.c
+  endif
   COMM_SRCS += comm-ofi-no-hugepages.c
 endif
 

--- a/runtime/src/comm/ofi/comm-ofi-oob-mpi.c
+++ b/runtime/src/comm/ofi/comm-ofi-oob-mpi.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2018 Cray Inc.
+ * Copyright 2004-2019 Cray Inc.
  * Other additional copyright holders may be indicated within.
  * 
  * The entirety of this work is licensed under the Apache License,

--- a/runtime/src/comm/ofi/comm-ofi-oob-mpi.c
+++ b/runtime/src/comm/ofi/comm-ofi-oob-mpi.c
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2004-2018 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ * 
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * 
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//
+// MPI-based out-of-band support for the OFI-based Chapel comm layer.
+//
+
+#include "chplrt.h"
+#include "chpl-env-gen.h"
+
+#include "chpl-comm.h"
+#include "chpl-mem.h"
+#include "chpl-mem-sys.h"
+#include "chpl-gen-includes.h"
+#include "chplsys.h"
+#include "error.h"
+
+#include <assert.h>
+#include <mpi.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+#include "comm-ofi-internal.h"
+
+
+#define MPI_CHK(expr) CHK_EQ_TYPED(expr, MPI_SUCCESS, int, "d")
+
+
+void chpl_comm_ofi_oob_init(void) {
+  int size, rank;
+
+  MPI_CHK(MPI_Init(NULL, NULL));
+
+  MPI_CHK(MPI_Comm_rank(MPI_COMM_WORLD, &rank));
+  chpl_nodeID = (c_nodeid_t) rank;
+
+  MPI_CHK(MPI_Comm_size(MPI_COMM_WORLD, &size));
+  chpl_numNodes = (int32_t) size;
+
+  DBG_PRINTF(DBG_OOB, "OOB init: node %" PRI_c_nodeid_t " of %" PRId32,
+             chpl_nodeID, chpl_numNodes);
+}
+
+
+void chpl_comm_ofi_oob_fini(void) {
+  DBG_PRINTF(DBG_OOB, "OOB finalize");
+
+  int inited;
+  MPI_CHK(MPI_Initialized(&inited));
+  if (inited){
+    MPI_CHK(MPI_Finalize());
+  }
+}
+
+
+void chpl_comm_ofi_oob_barrier(void) {
+  DBG_PRINTF(DBG_OOB, "OOB barrier");
+  MPI_CHK(MPI_Barrier(MPI_COMM_WORLD));
+}
+
+
+void chpl_comm_ofi_oob_allgather(void* mine, void* all, size_t size) {
+  DBG_PRINTF(DBG_OOB, "OOB allGather: %zd", size);
+
+  //
+  // MPI provides an ordered allGather, so we don't have to use the
+  // trick we use for other OOB implementations, where we build a
+  // meta-payload which includes the node index and then scatter the
+  // results ourself.  How civilized!
+  //
+  MPI_CHK(MPI_Allgather(mine, size, MPI_BYTE,
+                        all, size, MPI_BYTE,
+                        MPI_COMM_WORLD));
+}

--- a/runtime/src/launch/mpirun4ofi/Makefile
+++ b/runtime/src/launch/mpirun4ofi/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2004-2018 Cray Inc.
+# Copyright 2004-2019 Cray Inc.
 # Other additional copyright holders may be indicated within.
 # 
 # The entirety of this work is licensed under the Apache License,

--- a/runtime/src/launch/mpirun4ofi/Makefile
+++ b/runtime/src/launch/mpirun4ofi/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2004-2019 Cray Inc.
+# Copyright 2004-2018 Cray Inc.
 # Other additional copyright holders may be indicated within.
 # 
 # The entirety of this work is licensed under the Apache License,
@@ -15,10 +15,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ifneq ($(LIBFABRIC_DIR),)
-RUNTIME_INCLS += -I$(LIBFABRIC_DIR)/include
+RUNTIME_ROOT = ../../..
+RUNTIME_SUBDIR = src/launch/mpirun4ofi
+
+ifndef CHPL_MAKE_HOME
+export CHPL_MAKE_HOME=$(shell pwd)/$(RUNTIME_ROOT)/..
 endif
 
-ifneq (, $(findstring mpi,$(CHPL_MAKE_LAUNCHER)))
-RUNTIME_INCLS += -I$(MPI_INCLUDE)
-endif
+#
+# standard header
+#
+include $(RUNTIME_ROOT)/make/Makefile.runtime.head
+
+LAUNCH_OBJDIR = $(LAUNCHER_OBJDIR)
+include Makefile.share
+
+TARGETS = \
+	$(LAUNCHER_OBJS) \
+
+include $(RUNTIME_ROOT)/make/Makefile.runtime.subdirrules
+
+#
+# standard footer
+#
+include $(RUNTIME_ROOT)/make/Makefile.runtime.foot

--- a/runtime/src/launch/mpirun4ofi/Makefile.include
+++ b/runtime/src/launch/mpirun4ofi/Makefile.include
@@ -1,4 +1,4 @@
-# Copyright 2004-2018 Cray Inc.
+# Copyright 2004-2019 Cray Inc.
 # Other additional copyright holders may be indicated within.
 # 
 # The entirety of this work is licensed under the Apache License,

--- a/runtime/src/launch/mpirun4ofi/Makefile.include
+++ b/runtime/src/launch/mpirun4ofi/Makefile.include
@@ -1,4 +1,4 @@
-# Copyright 2004-2019 Cray Inc.
+# Copyright 2004-2018 Cray Inc.
 # Other additional copyright holders may be indicated within.
 # 
 # The entirety of this work is licensed under the Apache License,
@@ -15,10 +15,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ifneq ($(LIBFABRIC_DIR),)
-RUNTIME_INCLS += -I$(LIBFABRIC_DIR)/include
-endif
+LAUNCH_SUBDIR = src/launch/mpirun4ofi
 
-ifneq (, $(findstring mpi,$(CHPL_MAKE_LAUNCHER)))
-RUNTIME_INCLS += -I$(MPI_INCLUDE)
-endif
+LAUNCH_OBJDIR = $(LAUNCHER_BUILD)/$(LAUNCH_SUBDIR)
+
+ALL_SRCS += $(CURDIR)/$(LAUNCH_SUBDIR)/*.c
+
+include $(RUNTIME_ROOT)/$(LAUNCH_SUBDIR)/Makefile.share

--- a/runtime/src/launch/mpirun4ofi/Makefile.share
+++ b/runtime/src/launch/mpirun4ofi/Makefile.share
@@ -1,4 +1,4 @@
-# Copyright 2004-2018 Cray Inc.
+# Copyright 2004-2019 Cray Inc.
 # Other additional copyright holders may be indicated within.
 # 
 # The entirety of this work is licensed under the Apache License,

--- a/runtime/src/launch/mpirun4ofi/Makefile.share
+++ b/runtime/src/launch/mpirun4ofi/Makefile.share
@@ -1,4 +1,4 @@
-# Copyright 2004-2019 Cray Inc.
+# Copyright 2004-2018 Cray Inc.
 # Other additional copyright holders may be indicated within.
 # 
 # The entirety of this work is licensed under the Apache License,
@@ -15,10 +15,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ifneq ($(LIBFABRIC_DIR),)
-RUNTIME_INCLS += -I$(LIBFABRIC_DIR)/include
-endif
+LAUNCHER_SRCS = \
+        launch-mpirun4ofi.c \
 
-ifneq (, $(findstring mpi,$(CHPL_MAKE_LAUNCHER)))
-RUNTIME_INCLS += -I$(MPI_INCLUDE)
-endif
+SVN_SRCS = $(LAUNCHER_SRCS)
+SRCS = $(SVN_SRCS)
+
+RUNTIME_CFLAGS += -DMPIRUN_PATH=\"$(MPI_BIN_DIR)\" -DMPIRUN_XTRA_OPTS=\"$(MPIRUN_XTRA_OPTS)\"
+
+LAUNCHER_OBJS = \
+	$(LAUNCHER_SRCS:%.c=$(LAUNCH_OBJDIR)/%.o)

--- a/runtime/src/launch/mpirun4ofi/launch-mpirun4ofi.c
+++ b/runtime/src/launch/mpirun4ofi/launch-mpirun4ofi.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2018 Cray Inc.
+ * Copyright 2004-2019 Cray Inc.
  * Other additional copyright holders may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,

--- a/runtime/src/launch/mpirun4ofi/launch-mpirun4ofi.c
+++ b/runtime/src/launch/mpirun4ofi/launch-mpirun4ofi.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2004-2018 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include "arg.h"
+#include "chpllaunch.h"
+#include "chplcgfns.h"
+#include "error.h"
+
+static char** chpl_launch_create_argv(const char *launch_cmd,
+                                      int argc, char* argv[],
+                                      int32_t numLocales) {
+  if (strcmp(CHPL_COMM, "ofi") != 0) {
+    chpl_error("mpirun4ofi only supports CHPL_COMM=ofi", 0, 0);
+  }
+
+  static char _nlbuf[16];
+  snprintf(_nlbuf, sizeof(_nlbuf), "%d", getArgNumLocales());
+
+  char* largv[] = { (char*) launch_cmd,
+                    (char*) "-np",
+                    (char*) _nlbuf,
+                    (char*) "-mca",
+                    (char*) "rmaps_base_oversubscribe",
+                    (char*) "true",
+                    (char*) "-bind-to",
+                    (char*) "none:overload-allowed",
+                  };
+  const int largc = sizeof(largv) / sizeof(largv[0]);
+  return chpl_bundle_exec_args(argc, argv, largc, largv);
+}
+
+
+int chpl_launch(int argc, char* argv[], int32_t numLocales) {
+  const char *cmd = "mpirun";
+  return chpl_launch_using_exec(cmd,
+                                chpl_launch_create_argv(cmd, argc, argv,
+                                                        numLocales),
+                                argv[0]);
+}
+
+
+int chpl_launch_handle_arg(int argc, char* argv[], int argNum,
+                           int32_t lineno, int32_t filename) {
+  return 0;
+}
+
+
+void chpl_launch_print_help(void) {
+}


### PR DESCRIPTION
Until now we haven't had a way to launch multilocal comm=ofi programs
except on Cray X* systems.  Here, add a very simple launcher based on
OpenMPI mpirun, which allows launching on our chapcs cluster either
within or outside of a slurm job allocation.  (mpirun will auto-sense if
it's running in a slurm allocation and use the slurm-provided resources
if so.)

Related to this, add a comm=ofi out-of-band module that implements the
necessary startup, shutdown, barrier, and allgather operations in terms
of MPI calls.

This may or may not grow into something fully supported and documented.
For now it's just present so we can test the comm layer on a more accessible
platform.