### PR TITLE
Support self-GET in comm=ofi.

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi-oob-sockets.c
+++ b/runtime/src/comm/ofi/comm-ofi-oob-sockets.c
@@ -85,7 +85,7 @@ void chpl_comm_ofi_oob_barrier(void) {
 }
 
 
-void chpl_comm_ofi_oob_allgather(void* in, void* out, int len) {
+void chpl_comm_ofi_oob_allgather(void* in, void* out, size_t len) {
   if (chpl_numNodes == 1) {
     chpl_memcpy(out, in, len);
   } else {

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -1807,12 +1807,15 @@ void chpl_comm_get(void* addr, int32_t node, void* raddr,
                    size_t size, int32_t typeIndex, int32_t commID,
                    int ln, int32_t fn) {
   //
-  // addr and raddr are sanity checks; node==chpl_nodeID is supposed
-  // to be handled by our caller.
+  // Sanity checks, self-communication.
   //
   CHK_TRUE(addr != NULL);
   CHK_TRUE(raddr != NULL);
-  CHK_TRUE(node != chpl_nodeID);
+
+  if (node == chpl_nodeID) {
+    memmove(addr, raddr, size);
+    return;
+  }
 
   // Communications callback support
   if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_get)) {


### PR DESCRIPTION
There was a sanity check against GET-from-self in the ofi comm layer,
but it turns out that we actually do that under certain circumstances.
An example is the test arrays/bradc/slices/fftSlice, which is run on
just a single locale.  In the future it would be nice to catch all the
cases of self-GET upstream of the comm layers, but for now since this is
supported by comm=gasnet and comm=ugni I'm enabling it in comm=ofi as
well.

While here I also fixed a mistyped function argument in the "sockets"
out-of-band support.  This changed a few weeks ago in the other (PMI)
OOB layer but I didn't catch the sockets one at the time.
