### PR TITLE
Resolves assertion failure in gsl_demo test

### DIFF
--- a/compiler/passes/externCResolve.cpp
+++ b/compiler/passes/externCResolve.cpp
@@ -288,7 +288,8 @@ static const char* convertTypedef(ModuleSymbol*           module,
                                                        typedef_name),
                                      NULL);
 
-    results.add(convertTypesToExtern(buildChapelStmt(type_expr)));
+    BlockStmt* typeBlock = new BlockStmt(type_expr, BLOCK_TYPE);
+    results.add(convertTypesToExtern(typeBlock));
   }
 
   setAlreadyConvertedExtern(module, typedef_name);


### PR DESCRIPTION
Follow-on to #11917.

Resolves a test failure with

    test/users/npadmana/gsl_demonstration/gsl_demo.chpl

- [x] full local --llvm testing
- [x] full local testing

Trivial and not reviewed.