### PR TITLE
Improve how we align and pad comm domains in ugni

### DIFF
--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -707,13 +707,13 @@ typedef atomic_uint_least32_t cq_cnt_atomic_t;
 #define CACHE_LINE_ALIGN __attribute__((aligned(64)))
 
 typedef struct {
-  atomic_bool        busy;
+  atomic_bool        busy CACHE_LINE_ALIGN;
   chpl_bool          firmly_bound;
   gni_nic_handle_t   nih;
   gni_ep_handle_t*   remote_eps;
   gni_cq_handle_t    cqh;
   cq_cnt_t           cq_cnt_max;
-  cq_cnt_atomic_t    cq_cnt_curr;
+  cq_cnt_atomic_t    cq_cnt_curr CACHE_LINE_ALIGN;
 #ifdef DEBUG_STATS
   uint64_t           acqs;
   uint64_t           acqs_looks;

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -703,6 +703,9 @@ typedef atomic_uint_least32_t cq_cnt_atomic_t;
 #define CQ_CNT_DEC(cd)        \
         (void) atomic_fetch_sub_uint_least32_t(&(cd)->cq_cnt_curr, 1)
 
+// not generally true, but should be for XE/XC
+#define CACHE_LINE_ALIGN __attribute__((aligned(64)))
+
 typedef struct {
   atomic_bool        busy;
   chpl_bool          firmly_bound;
@@ -718,10 +721,7 @@ typedef struct {
   uint64_t           acqs_with_rb_looks;
   uint64_t           reacqs;
 #endif
-  uint64_t           cache_spacer[8];    // prevent comm_doms[] inter-element
-                                         //   cache line sharing; ra-atomics
-                                         //     perf suffers without this
-} comm_dom_t;
+} CACHE_LINE_ALIGN comm_dom_t;
 
 
 //
@@ -2041,8 +2041,9 @@ void chpl_comm_post_task_init(void)
   // handles, endpoints, and completion queues.
   //
   comm_doms =
-    (comm_dom_t*) chpl_mem_allocMany(comm_dom_cnt, sizeof(comm_doms[0]),
-                                     CHPL_RT_MD_COMM_PER_LOC_INFO, 0, 0);
+    (comm_dom_t*) chpl_mem_memalign(sizeof(comm_dom_t),
+                                    comm_dom_cnt * sizeof(comm_dom_t),
+                                    CHPL_RT_MD_COMM_PER_LOC_INFO, 0, 0);
 
   for (int i = 0; i < comm_dom_cnt; i++)
     gni_setup_per_comm_dom(i);


### PR DESCRIPTION
Instead of always adding 64 bytes of padding to the end of the `comm_dom_t`
structure, just make it 64-byte aligned and align the `comm_doms` array. This
maintains the previous attempt to avoid cache line sharing between elements in
the comm domain array and also makes it so a single comm domain isn't
arbitrarily split across a cache line.

This should resolve some performance regression's we've been seeing in nightly
16-node testing and close https://github.com/chapel-lang/chapel/issues/11972

Note that we'll want to revisit this padding/alignment more carefully since it
can have such a large performance impact, but in the meantime this should at
least get performance back to where it was (and hopefully stabilize timings a
little bit)