### PR TITLE
Produce verbose comm diagnostics messages in common code.

### DIFF
--- a/runtime/include/chpl-comm-diags.h
+++ b/runtime/include/chpl-comm-diags.h
@@ -90,6 +90,23 @@ void chpl_comm_diags_verbose_printf(const char* format, ...) {
   }
 }
 
+#define chpl_comm_diags_verbose_rdma(op, node, size, ln, fn)            \
+  chpl_comm_diags_verbose_printf("%s:%d: remote %s, "                   \
+                                 "node %d, %zu bytes",                  \
+                                 chpl_lookupFilename(fn), ln, op,       \
+                                 (int) node, size)
+
+#define chpl_comm_diags_verbose_rdmaStrd(op, node, ln, fn)              \
+  chpl_comm_diags_verbose_printf("%s:%d: remote strided %s, node %d",   \
+                                 chpl_lookupFilename(fn), ln, op,       \
+                                 (int) node)
+
+#define chpl_comm_diags_verbose_executeOn(kind, node)                   \
+  chpl_comm_diags_verbose_printf("remote %-*sexecuteOn, node %d",       \
+                                 ((int) strlen(kind)                    \
+                                  + ((strlen(kind) == 0) ? 0 : 1)),     \
+                                 kind, (int) node)
+
 #define chpl_comm_diags_incr(_ctr)                                      \
   do {                                                                  \
     if (chpl_comm_diagnostics && chpl_comm_diags_is_enabled()) {        \

--- a/runtime/src/chpl-cache.c
+++ b/runtime/src/chpl-cache.c
@@ -2799,8 +2799,7 @@ void chpl_cache_comm_put(void* addr, c_nodeid_t node, void* raddr,
                "from %p\n",
                chpl_nodeID, (int)chpl_task_getId(), chpl_lookupFilename(fn), ln,
                (int)size, node, raddr, addr));
-  chpl_comm_diags_verbose_printf("%s:%d: remote get from %d, %zu bytes\n",
-                                 chpl_lookupFilename(fn), ln, node, size);
+  chpl_comm_diags_verbose_rdma("get", node, size, ln, fn);
 
 #ifdef DUMP
   chpl_cache_print();
@@ -2824,8 +2823,7 @@ void chpl_cache_comm_get(void *addr, c_nodeid_t node, void* raddr,
                "%d:%p to %p\n",
                chpl_nodeID, (int)chpl_task_getId(), chpl_lookupFilename(fn), ln,
                (int)size, node, raddr, addr));
-  chpl_comm_diags_verbose_printf("%s:%d: remote put to %d, %zu bytes\n",
-                                 chpl_lookupFilename(fn), ln, node, size);
+  chpl_comm_diags_verbose_rdma("put", node, size, ln, fn);
 
 #ifdef DUMP
   chpl_cache_print();
@@ -2845,8 +2843,7 @@ void chpl_cache_comm_prefetch(c_nodeid_t node, void* raddr,
   struct rdcache_s* cache = tls_cache_remote_data();
   chpl_cache_taskPrvData_t* task_local = task_private_cache_data();
   TRACE_PRINT(("%d: in chpl_cache_comm_prefetch\n", chpl_nodeID));
-  chpl_comm_diags_verbose_printf("%s:%d: remote prefetch from %d, %zu bytes\n",
-                                 chpl_lookupFilename(fn), ln, node, size);
+  chpl_comm_diags_verbose_rdma("prefetch", node, size, ln, fn);
   // Always use the cache for prefetches.
   //saturating_increment(&info->prefetch_since_acquire);
   cache_get(cache, NULL, node, (raddr_t)raddr, size, task_local->last_acquire,

--- a/runtime/src/comm/gasnet/comm-gasnet.c
+++ b/runtime/src/comm/gasnet/comm-gasnet.c
@@ -1128,8 +1128,7 @@ void  chpl_comm_put(void* addr, c_nodeid_t node, void* raddr,
       chpl_comm_do_callbacks (&cb_data);
     }
 
-    chpl_comm_diags_verbose_printf("%s:%d: remote put to %d, %zu bytes",
-                                   chpl_lookupFilename(fn), ln, node, size);
+    chpl_comm_diags_verbose_rdma("put", node, size, ln, fn);
     chpl_comm_diags_incr(put);
 
     // Handle remote address not in remote segment.
@@ -1205,8 +1204,7 @@ void  chpl_comm_get(void* addr, c_nodeid_t node, void* raddr,
       chpl_comm_do_callbacks (&cb_data);
     }
 
-    chpl_comm_diags_verbose_printf("%s:%d: remote get from %d, %zu bytes",
-                                   chpl_lookupFilename(fn), ln, node, size);
+    chpl_comm_diags_verbose_rdma("get", node, size, ln, fn);
     chpl_comm_diags_incr(get);
 
     // Handle remote address not in remote segment.
@@ -1348,8 +1346,7 @@ void  chpl_comm_get_strd(void* dstaddr, size_t* dststrides, c_nodeid_t srcnode_i
   }
   
   // the case (chpl_nodeID == srcnode) is internally managed inside gasnet
-  chpl_comm_diags_verbose_printf("%s:%d: remote get from %d",
-                                 chpl_lookupFilename(fn), ln, srcnode);
+  chpl_comm_diags_verbose_rdmaStrd("get", srcnode, ln, fn);
   chpl_comm_diags_incr(get);
 
   // TODO -- handle strided get for non-registered memory
@@ -1392,8 +1389,7 @@ void  chpl_comm_put_strd(void* dstaddr, size_t* dststrides, c_nodeid_t dstnode_i
   }
 
   // the case (chpl_nodeID == dstnode) is internally managed inside gasnet
-  chpl_comm_diags_verbose_printf("%s:%d: remote get from %d",
-                                 chpl_lookupFilename(fn), ln, dstnode);
+  chpl_comm_diags_verbose_rdmaStrd("put", dstnode, ln, fn);
   chpl_comm_diags_incr(put);
 
   // TODO -- handle strided put for non-registered memory
@@ -1530,7 +1526,7 @@ void  chpl_comm_execute_on(c_nodeid_t node, c_sublocid_t subloc,
       chpl_comm_do_callbacks (&cb_data);
     }
 
-    chpl_comm_diags_verbose_printf("remote task created on %d", node);
+    chpl_comm_diags_verbose_executeOn("", node);
     chpl_comm_diags_incr(execute_on);
 
     execute_on_common(node, subloc, fid, arg, arg_size,
@@ -1553,8 +1549,7 @@ void  chpl_comm_execute_on_nb(c_nodeid_t node, c_sublocid_t subloc,
       chpl_comm_do_callbacks (&cb_data);
     }
 
-    chpl_comm_diags_verbose_printf("remote non-blocking task created on %d",
-                                   node);
+    chpl_comm_diags_verbose_executeOn("non-blocking", node);
     chpl_comm_diags_incr(execute_on_nb);
   
     execute_on_common(node, subloc, fid, arg, arg_size,
@@ -1578,8 +1573,7 @@ void  chpl_comm_execute_on_fast(c_nodeid_t node, c_sublocid_t subloc,
       chpl_comm_do_callbacks (&cb_data);
     }
 
-    chpl_comm_diags_verbose_printf("remote (no-fork) task created on %d",
-                                   node);
+    chpl_comm_diags_verbose_executeOn("fast", node);
     chpl_comm_diags_incr(execute_on_fast);
 
     execute_on_common(node, subloc, fid, arg, arg_size,

--- a/runtime/src/comm/ofi/comm-ofi-internal.h
+++ b/runtime/src/comm/ofi/comm-ofi-internal.h
@@ -38,10 +38,7 @@
 //
 // Debugging
 //
-
-#define DEBUG 1
-
-#ifdef DEBUG
+#ifdef CHPL_COMM_DEBUG
 
 uint64_t chpl_comm_ofi_dbg_level;
 FILE* chpl_comm_ofi_dbg_file;
@@ -96,14 +93,14 @@ char* chpl_comm_ofi_dbg_val(const void*, enum fi_datatype);
 
 #define DBG_VAL(pV, typ) chpl_comm_ofi_dbg_val(pV, typ)
 
-#else // DEBUG
+#else // CHPL_COMM_DEBUG
 
 #define DBG_INIT()
 #define DBG_DO_PRINTF(fmt, ...) do { } while (0)
 #define DBG_TEST_MASK(mask) 0
 #define DBG_PRINTF(mask, fmt, ...) do { } while (0)
 
-#endif // DEBUG
+#endif // CHPL_COMM_DEBUG
 
 
 //

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -77,10 +77,7 @@
 #include "chpl-comm-no-warning-macros.h"
 
 
-// uncomment this and change debug_flag below to enable UGNI debugging
-//#define DEBUG 1
-
-#ifdef DEBUG
+#ifdef CHPL_COMM_DEBUG
 #include <sys/types.h>
 #include <fcntl.h>
 
@@ -958,7 +955,7 @@ typedef struct {
   unsigned char op: FORK_OP_BITS;    // operation
   c_nodeid_t    caller;              // requesting locale
   rf_done_t*    rf_done;             // where to indicate completion
-#ifdef DEBUG
+#ifdef CHPL_COMM_DEBUG
   uint_least64_t seq;
 #endif
 } fork_base_info_t;
@@ -1081,7 +1078,7 @@ typedef struct {
   unsigned char buf[MAX_SMALL_CALL_PAYLOAD];
 } fork_small_call_task_t;
 
-#ifdef DEBUG
+#ifdef CHPL_COMM_DEBUG
 static int _fork_req_bufs_per_cd = 2;
 #define FORK_REQ_BUFS_PER_CD     _fork_req_bufs_per_cd
 #else
@@ -1558,7 +1555,7 @@ static void      local_yield(void);
 //
 // More debug support.
 //
-#ifdef DEBUG
+#ifdef CHPL_COMM_DEBUG
 static void dbg_init(void);
 static void dbg_init(void)
 {
@@ -1609,7 +1606,7 @@ static void dbg_init(void)
 
   debug_stats_flag = chpl_env_rt_get_int("COMM_UGNI_DEBUG_STATS", 0);
 
-#ifdef DEBUG
+#ifdef CHPL_COMM_DEBUG
   FORK_REQ_BUFS_PER_CD =
       chpl_env_rt_get_int("COMM_UGNI_FORK_REQ_BUFS_PER_CD", 1);
 #endif
@@ -3668,10 +3665,12 @@ void chpl_comm_barrier(const char *msg)
 {
   DBG_P_L(DBGF_IFACE, "IFACE chpl_comm_barrier(\"%s\")", msg);
 
+#ifdef CHPL_COMM_DEBUG
+  chpl_msg(2, "%d: enter barrier for '%s'\n", chpl_nodeID, msg);
+#endif
+
   if (chpl_numNodes == 1)
     return;
-
-  chpl_comm_diags_verbose_printf("barrier for '%s'", msg);
 
   //
   // If we can't communicate yet, just do a PMI barrier.
@@ -3788,7 +3787,7 @@ void chpl_comm_pre_task_exit(int all)
   // high water mark whether set up for debug info or not.
   //
   {
-#ifdef DEBUG
+#ifdef CHPL_COMM_DEBUG
     const int test = _DBG_DO(DBGF_MEMREG)
                      || (chpl_nodeID == 0
                          && chpl_env_rt_get_bool("COMM_UGNI_MEMREG_HWM",
@@ -3837,7 +3836,7 @@ void chpl_comm_exit(int all, int status)
   if (exit_without_cleanup)
     return;
 
-#ifdef DEBUG
+#ifdef CHPL_COMM_DEBUG
   debug_exiting = true;
 #endif
 
@@ -5046,8 +5045,7 @@ void chpl_comm_put(void* addr, c_nodeid_t locale, void* raddr,
       chpl_comm_do_callbacks (&cb_data);
   }
 
-  chpl_comm_diags_verbose_printf("%s:%d: remote put to %d, %zu bytes",
-                                 chpl_lookupFilename(fn), ln, locale, size);
+  chpl_comm_diags_verbose_rdma("put", locale, size, ln, fn);
   chpl_comm_diags_incr(put);
 
   do_remote_put(addr, locale, raddr, size, NULL, may_proxy_true);
@@ -5445,12 +5443,12 @@ void chpl_comm_buff_get(void* addr, c_nodeid_t locale, void* raddr,
       chpl_comm_do_callbacks (&cb_data);
   }
 
-  chpl_comm_diags_verbose_printf("%s:%d: remote buff get from %d",
-                                 chpl_lookupFilename(fn), ln, locale);
+  chpl_comm_diags_verbose_rdma("buff get", locale, size, ln, fn);
   chpl_comm_diags_incr(get);
 
   do_remote_buff_get(addr, locale, raddr, size, may_proxy_true);
 }
+
 
 void chpl_comm_get(void* addr, c_nodeid_t locale, void* raddr,
                    size_t size, int32_t typeIndex,
@@ -5477,8 +5475,7 @@ void chpl_comm_get(void* addr, c_nodeid_t locale, void* raddr,
       chpl_comm_do_callbacks (&cb_data);
   }
 
-  chpl_comm_diags_verbose_printf("%s:%d: remote get from %d, %zu bytes",
-                                 chpl_lookupFilename(fn), ln, locale, size);
+  chpl_comm_diags_verbose_rdma("get", locale, size, ln, fn);
   chpl_comm_diags_incr(get);
 
   do_remote_get(addr, locale, raddr, size, may_proxy_true);
@@ -5968,8 +5965,7 @@ chpl_comm_nb_handle_t chpl_comm_get_nb(void* addr, c_nodeid_t locale,
     chpl_comm_do_callbacks (&cb_data);
   }
 
-  chpl_comm_diags_verbose_printf("%s:%d: remote non-blocking get from %d, %zu bytes",
-                                 chpl_lookupFilename(fn), ln, locale, size);
+  chpl_comm_diags_verbose_rdma("non-blocking get", locale, size, ln, fn);
   chpl_comm_diags_incr(get_nb);
 
   //
@@ -6082,11 +6078,6 @@ chpl_comm_nb_handle_t chpl_comm_put_nb(void* addr, c_nodeid_t locale,
 
 int chpl_comm_test_nb_complete(chpl_comm_nb_handle_t h)
 {
-  if (chpl_verbose_comm && chpl_comm_diags_is_enabled()) {
-    int i, j;
-    nb_desc_idx_decode(&i, &j, nb_desc_handle_2_idx(h));
-    chpl_comm_diags_verbose_printf("test nb complete (%d, %d)", i, j);
-  }
   chpl_comm_diags_incr(test_nb);
 
   PERFSTATS_INC(test_nb_cnt);
@@ -6097,15 +6088,6 @@ int chpl_comm_test_nb_complete(chpl_comm_nb_handle_t h)
 
 void chpl_comm_wait_nb_some(chpl_comm_nb_handle_t* h, size_t nhandles)
 {
-  if (chpl_verbose_comm && chpl_comm_diags_is_enabled()) {
-    if (nhandles == 1) {
-      int i, j;
-      nb_desc_idx_decode(&i, &j, nb_desc_handle_2_idx(h[0]));
-      chpl_comm_diags_verbose_printf("wait nb (%d, %d)", i, j);
-    }
-    else
-      chpl_comm_diags_verbose_printf("wait nb (%zd handles)", nhandles);
-  }
   chpl_comm_diags_incr(wait_nb);
 
   PERFSTATS_INC(wait_nb_cnt);
@@ -6140,15 +6122,6 @@ int chpl_comm_try_nb_some(chpl_comm_nb_handle_t* h, size_t nhandles)
 {
   int rv = 0;
 
-  if (chpl_verbose_comm && chpl_comm_diags_is_enabled()) {
-    if (nhandles == 1) {
-      int i, j;
-      nb_desc_idx_decode(&i, &j, nb_desc_handle_2_idx(h[0]));
-      chpl_comm_diags_verbose_printf("try nb (%d, %d)", i, j);
-    }
-    else
-      chpl_comm_diags_verbose_printf("try nb (%zd handles)", nhandles);
-  }
   chpl_comm_diags_incr(try_nb);
 
   PERFSTATS_INC(try_nb_cnt);
@@ -7309,7 +7282,7 @@ void chpl_comm_execute_on(c_nodeid_t locale, c_sublocid_t subloc,
       chpl_comm_do_callbacks (&cb_data);
   }
 
-  chpl_comm_diags_verbose_printf("remote task created on %d", locale);
+  chpl_comm_diags_verbose_executeOn("", locale);
   chpl_comm_diags_incr(execute_on);
 
   PERFSTATS_INC(fork_call_cnt);
@@ -7335,8 +7308,7 @@ void chpl_comm_execute_on_nb(c_nodeid_t locale, c_sublocid_t subloc,
       chpl_comm_do_callbacks (&cb_data);
   }
 
-  chpl_comm_diags_verbose_printf("remote non-blocking task created on %d",
-                                 locale);
+  chpl_comm_diags_verbose_executeOn("non-blocking", locale);
   chpl_comm_diags_incr(execute_on_nb);
 
   PERFSTATS_INC(fork_call_nb_cnt);
@@ -7362,8 +7334,7 @@ void chpl_comm_execute_on_fast(c_nodeid_t locale, c_sublocid_t subloc,
       chpl_comm_do_callbacks (&cb_data);
   }
 
-  chpl_comm_diags_verbose_printf("remote (no-fork) task created on %d",
-                                 locale);
+  chpl_comm_diags_verbose_executeOn("fast", locale);
   chpl_comm_diags_incr(execute_on_fast);
 
   //

--- a/test/extern/diten/externfaston.good
+++ b/test/extern/diten/externfaston.good
@@ -1,2 +1,2 @@
-0: remote (no-fork) task created on 1
-0: remote task created on 1
+0: remote executeOn, node 1
+0: remote fast executeOn, node 1

--- a/test/extern/diten/externfaston.prediff
+++ b/test/extern/diten/externfaston.prediff
@@ -1,0 +1,4 @@
+#! /usr/bin/env bash
+
+# Sort output; multilocale stdout/stderr isn't deterministic.
+sort < $2 > $2.prediff.tmp && mv $2.prediff.tmp $2

--- a/test/multilocale/deitz/needMultiLocales/diagnostics/test_private_broadcast_large.good
+++ b/test/multilocale/deitz/needMultiLocales/diagnostics/test_private_broadcast_large.good
@@ -1,4 +1,4 @@
-0: remote task created on 1
+0: remote executeOn, node 1
 1
 10
 100

--- a/test/multilocale/deitz/needMultiLocales/diagnostics/test_private_broadcast_small.good
+++ b/test/multilocale/deitz/needMultiLocales/diagnostics/test_private_broadcast_small.good
@@ -1,3 +1,3 @@
-0: remote task created on 1
+0: remote executeOn, node 1
 23
 23

--- a/test/multilocale/engin/verboseComm.good
+++ b/test/multilocale/engin/verboseComm.good
@@ -1,3 +1,3 @@
-0: remote task created on 1
-1: verboseComm.chpl:6: remote put to 0, 8 bytes
+0: remote executeOn, node 1
 1
+1: verboseComm.chpl:6: remote put, node 0, 8 bytes

--- a/test/multilocale/engin/verboseComm.prediff
+++ b/test/multilocale/engin/verboseComm.prediff
@@ -1,0 +1,4 @@
+#! /usr/bin/env bash
+
+# Sort output; multilocale stdout/stderr isn't deterministic.
+sort < $2 > $2.prediff.tmp && mv $2.prediff.tmp $2


### PR DESCRIPTION
We've been using common code to check if comm diagnostics are enabled
and if verbose comm is turned on, and even to print the verbose comm
messages, but until now the formatting of those messages was up to the
individual comm layers.  Here, move the message formatting into common
code and call that from the comm layers.  Do the same with the messages
produced from the comm caching module.  For tests that are expected to
produce verbose comm diags, adjust .good files to expect the new message
phrasing and where we didn't have them already, add prediffs which sort
the output so that our .good comparisons are independent of the vagaries
of stdout collection on multinode systems.

With these changes, the few tests that check verbose comm diagnostic
messages all pass with comm=gasnet, ugni, and ofi.

There are quite a few "while here" changes that go along with this.
While here, adjust comm=ugni and comm=ofi to use CHPL_COMM_DEBUG to
enable their internal debugging, just like comm=gasnet does.  And, while
here, make comm=ugni and comm=ofi use verbosity level 2 underneath a
compile-time CHPL_COMM_DEBUG check to control producing comm barrier
messages, just like comm=gasnet does.

Also while here, remove verbose comm output from comm=ugni and comm=ofi
for test and wait operations on non-blocking GETs and PUTs.  We don't
test these messages, and from a practical standpoint, the way NB GETs
and PUTs are typically used (initiate them, then later spin while they
complete) would mean that at least the test and try operations would
generate a great deal of verbose comm output, with all but the last line
being of very little worth.

Lastly, while here, fix a bit of debugging code in comm=ofi that caused
a compiler warning when debugging was disabled.  I hadn't spotted that
before because during development I've had comm=ofi debugging enabled
all along.