### PR TITLE
Add a system prediff for programs launched with OpenMPI's mpirun.

### DIFF
--- a/util/test/prediff-for-mpirun4ofi
+++ b/util/test/prediff-for-mpirun4ofi
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+#
+# This script is a system-wide prediff for use with the OpenMPI mpirun
+# launcher.  Depending on how OpenMPI is configured, when mpirun sees
+# a program it launched exit with a non-zero status, it may print either
+# messages like both of the following:
+#     -------------------------------------------------------
+#     Primary job  terminated normally, but 1 process returned
+#     a non-zero exit code.. Per user-direction, the job has been aborted.
+#     -------------------------------------------------------
+# and
+#     --------------------------------------------------------------------------
+#     mpirun detected that one or more processes exited with non-zero status, thus causing
+#     the job to be terminated. The first process to do so was:
+#
+#       Process name: [[38592,1],0]
+#       Exit code:    1
+#     --------------------------------------------------------------------------
+#
+# or a single message like this:
+#     -------------------------------------------------------
+#     While the primary job  terminated normally, 1 process returned
+#     a non-zero exit code.. Further examination may be required.
+#     -------------------------------------------------------
+#
+# This script removes such messages.
+#
+import sys, subprocess
+import re
+
+# These match the message blocks we want to remove.
+msg1aPat = re.compile(r"^(-{20,})\n"
+                      r"Primary job +terminated normally, "
+                      r"but [0-9]+ process[^ ]* returned\n"
+                      r"a non-zero exit code[.]+ "
+                      r"Per user-direction, the job has been aborted\.\n"
+                      r"\1\n",
+                      re.MULTILINE)
+msg1bPat = re.compile(r"^(-{20,})\n"
+                      r"mpirun detected that one or more processes exited "
+                      r"with non-zero status, thus causing\n"
+                      r"the job to be terminated\. "
+                      r"The first process to do so was:\n"
+                      r"\n"
+                      r" *Process name: +\[\[[0-9]+,[0-9]+],[0-9]+]\n"
+                      r" *Exit code: +[0-9]+\n"
+                      r"\1\n",
+                      re.MULTILINE)
+
+msg2Pat = re.compile(r"^(-{20,})\n"
+                     r"While the primary job +terminated normally, "
+                     r"[0-9]+ process[^ ]* returned\n"
+                     r"a non-zero exit code[.]+ "
+                     r"Further examination may be required\.\n"
+                     r"\1\n",
+                     re.MULTILINE)
+
+outfile = open(sys.argv[2], "r")
+outfileTmp = open(sys.argv[2]+".tmp" , "w")
+msg = outfile.read()
+msg = msg1aPat.sub("", msg)
+msg = msg1bPat.sub("", msg)
+msg = msg2Pat.sub("", msg)
+outfileTmp.write(msg)
+outfileTmp.close()
+outfile.close()
+
+subprocess.call("mv "+sys.argv[2]+".tmp"+" "+sys.argv[2], shell=True )

--- a/util/test/prediff-for-mpirun4ofi
+++ b/util/test/prediff-for-mpirun4ofi
@@ -20,28 +20,23 @@
 import sys, os, re
 
 # These match the message blocks we want to remove.
-msg1Pat = re.compile(r"^(-{20,})\n"
-                     r"Primary job +terminated normally, "
-                     r"but [0-9]+ process[^ ]* returned\n"
-                     r"a non-zero exit code[.]+ "
-                     r"Per user-direction, the job has been aborted\.\n"
-                     r"\1\n",
-                     re.MULTILINE)
-msg2Pat = re.compile(r"^(-{20,})\n"
-                     r"While the primary job +terminated normally, "
-                     r"[0-9]+ process[^ ]* returned\n"
-                     r"a non-zero exit code[.]+ "
-                     r"Further examination may be required\.\n"
-                     r"\1\n",
-                     re.MULTILINE)
+msgs = (
+"""^-------------------------------------------------------
+Primary job +terminated normally, but [0-9]+ process[^ ]* returned
+a non-zero exit code[.]+ Per user-direction, the job has been aborted[.]
+-------------------------------------------------------
+""",
+"""^-------------------------------------------------------
+While the primary job +terminated normally, [0-9]+ process[^ ]* returned
+a non-zero exit code[.]+ Further examination may be required[.]
+-------------------------------------------------------
+"""
+)
 
 outfname = sys.argv[2]
-outfnameTmp = outfname + '.' + str(os.getpid()) + '.tmp'
-
-with open(outfname, "r") as outfile, open(outfnameTmp, "w") as outfileTmp:
-    msg = outfile.read()
-    msg = msg1Pat.sub("", msg)
-    msg = msg2Pat.sub("", msg)
-    outfileTmp.write(msg)
-
-os.rename(outfnameTmp, outfname)
+with open(outfname, "r") as f:
+    outText = f.read()
+for m in msgs:
+    outText = re.sub(m, "", outText, flags = re.MULTILINE)
+with open(outfname, "w") as f:
+    f.write(outText)

--- a/util/test/prediff-for-mpirun4ofi
+++ b/util/test/prediff-for-mpirun4ofi
@@ -3,21 +3,13 @@
 # This script is a system-wide prediff for use with the OpenMPI mpirun
 # launcher.  Depending on how OpenMPI is configured, when mpirun sees
 # a program it launched exit with a non-zero status, it may print either
-# messages like both of the following:
+# messages like this:
 #     -------------------------------------------------------
 #     Primary job  terminated normally, but 1 process returned
 #     a non-zero exit code.. Per user-direction, the job has been aborted.
 #     -------------------------------------------------------
-# and
-#     --------------------------------------------------------------------------
-#     mpirun detected that one or more processes exited with non-zero status, thus causing
-#     the job to be terminated. The first process to do so was:
 #
-#       Process name: [[38592,1],0]
-#       Exit code:    1
-#     --------------------------------------------------------------------------
-#
-# or a single message like this:
+# or messages like this:
 #     -------------------------------------------------------
 #     While the primary job  terminated normally, 1 process returned
 #     a non-zero exit code.. Further examination may be required.
@@ -29,24 +21,13 @@ import sys, subprocess
 import re
 
 # These match the message blocks we want to remove.
-msg1aPat = re.compile(r"^(-{20,})\n"
-                      r"Primary job +terminated normally, "
-                      r"but [0-9]+ process[^ ]* returned\n"
-                      r"a non-zero exit code[.]+ "
-                      r"Per user-direction, the job has been aborted\.\n"
-                      r"\1\n",
-                      re.MULTILINE)
-msg1bPat = re.compile(r"^(-{20,})\n"
-                      r"mpirun detected that one or more processes exited "
-                      r"with non-zero status, thus causing\n"
-                      r"the job to be terminated\. "
-                      r"The first process to do so was:\n"
-                      r"\n"
-                      r" *Process name: +\[\[[0-9]+,[0-9]+],[0-9]+]\n"
-                      r" *Exit code: +[0-9]+\n"
-                      r"\1\n",
-                      re.MULTILINE)
-
+msg1Pat = re.compile(r"^(-{20,})\n"
+                     r"Primary job +terminated normally, "
+                     r"but [0-9]+ process[^ ]* returned\n"
+                     r"a non-zero exit code[.]+ "
+                     r"Per user-direction, the job has been aborted\.\n"
+                     r"\1\n",
+                     re.MULTILINE)
 msg2Pat = re.compile(r"^(-{20,})\n"
                      r"While the primary job +terminated normally, "
                      r"[0-9]+ process[^ ]* returned\n"
@@ -58,8 +39,7 @@ msg2Pat = re.compile(r"^(-{20,})\n"
 outfile = open(sys.argv[2], "r")
 outfileTmp = open(sys.argv[2]+".tmp" , "w")
 msg = outfile.read()
-msg = msg1aPat.sub("", msg)
-msg = msg1bPat.sub("", msg)
+msg = msg1Pat.sub("", msg)
 msg = msg2Pat.sub("", msg)
 outfileTmp.write(msg)
 outfileTmp.close()

--- a/util/test/prediff-for-mpirun4ofi
+++ b/util/test/prediff-for-mpirun4ofi
@@ -17,8 +17,7 @@
 #
 # This script removes such messages.
 #
-import sys, subprocess
-import re
+import sys, os, re
 
 # These match the message blocks we want to remove.
 msg1Pat = re.compile(r"^(-{20,})\n"
@@ -36,13 +35,13 @@ msg2Pat = re.compile(r"^(-{20,})\n"
                      r"\1\n",
                      re.MULTILINE)
 
-outfile = open(sys.argv[2], "r")
-outfileTmp = open(sys.argv[2]+".tmp" , "w")
-msg = outfile.read()
-msg = msg1Pat.sub("", msg)
-msg = msg2Pat.sub("", msg)
-outfileTmp.write(msg)
-outfileTmp.close()
-outfile.close()
+outfname = sys.argv[2]
+outfnameTmp = outfname + '.' + str(os.getpid()) + '.tmp'
 
-subprocess.call("mv "+sys.argv[2]+".tmp"+" "+sys.argv[2], shell=True )
+with open(outfname, "r") as outfile, open(outfnameTmp, "w") as outfileTmp:
+    msg = outfile.read()
+    msg = msg1Pat.sub("", msg)
+    msg = msg2Pat.sub("", msg)
+    outfileTmp.write(msg)
+
+os.rename(outfnameTmp, outfname)

--- a/util/test/prediff-for-mpirun4ofi
+++ b/util/test/prediff-for-mpirun4ofi
@@ -17,7 +17,7 @@
 #
 # This script removes such messages.
 #
-import sys, os, re
+import sys, re
 
 # These match the message blocks we want to remove.
 msgs = (


### PR DESCRIPTION
The OpenMPI mpirun system launcher used by the mpirun4ofi Chapel
launcher produces helpful output messages when programs exit with
nonzero status, but these messages interfere with sub_test pass/fail
analysis for such tests, even when the nonzero status is expected.
Here, add a system prediff to filter out these mpirun messages.