### PR TITLE
Fix --llvm-wide-opt

### DIFF
--- a/compiler/llvm/llvm-global-to-wide/RUN_CONFIG
+++ b/compiler/llvm/llvm-global-to-wide/RUN_CONFIG
@@ -11,5 +11,5 @@ ln -s ../../include/llvmAggregateGlobalOps.h llvmAggregateGlobalOps.h
 ln -s ../../include/llvmVer.h llvmVer.h
 mkdir -p build
 cd build
-export CMAKE_PREFIX_PATH=$CHPL_HOME/third-party/llvm/install/linux64-gnu/
-cmake .. -DLLVM_ROOT=$CHPL_HOME/third-party/llvm/install/linux64-gnu/ -DLLVM_SRC=$CHPL_HOME/third-party/llvm/llvm -DCMAKE_BUILD_TYPE=Debug
+export CMAKE_PREFIX_PATH=$CHPL_HOME/third-party/llvm/install/linux64-x86_64-gnu/
+cmake .. -DLLVM_ROOT=$CHPL_HOME/third-party/llvm/install/linux64-x86_64-gnu/ -DLLVM_SRC=$CHPL_HOME/third-party/llvm/llvm -DCMAKE_BUILD_TYPE=Debug

--- a/compiler/llvm/llvm-global-to-wide/test/aggregate.ll
+++ b/compiler/llvm/llvm-global-to-wide/test/aggregate.ll
@@ -62,6 +62,24 @@ entry:
   ret void
 }
 
+define void @teststore4(i64 addrspace(100)* %base) {
+; CHECK: @teststore4(
+; )
+entry:
+  %p2 = getelementptr inbounds i64, i64 addrspace(100)* %base, i32 2
+  %p01 = getelementptr inbounds i64, i64 addrspace(100)* %base, i32 0
+  %p0 = getelementptr inbounds i64, i64 addrspace(100)* %base, i32 0
+; CHECK: store i64 3
+; CHECK: store i64 2
+; CHECK: store i64 1
+; CHECK: memcpy
+; CHECK: ret
+  store i64 3, i64 addrspace(100)* %p2, align 8
+  store i64 2, i64 addrspace(100)* %p01, align 8
+  store i64 1, i64 addrspace(100)* %p0, align 8
+  ret void
+}
+
 
 define i64 @testload1(i64 addrspace(100)* %base) {
 ; CHECK: @testload1(
@@ -162,6 +180,60 @@ entry:
   %sum2 = add i64 %sum1, %v3
   ret i64 %sum2
 }
+
+define i64 @testload6(i64 addrspace(100)* %base, i64 addrspace(100)* %other) {
+; CHECK: @testload6(
+; )
+; CHECK: getelementptr
+; CHECK: load
+; CHECK: getelementptr
+; CHECK: load
+; CHECK: add
+; CHECK: getelementptr
+; CHECK: load
+; CHECK: add
+; CHECK: ret
+entry:
+  %p0 = getelementptr inbounds i64, i64 addrspace(100)* %base, i32 3
+  %v1 = load i64, i64 addrspace(100)* %p0, align 8
+  %o1 = getelementptr inbounds i64, i64 addrspace(100)* %other, i32 1
+  %vo = load i64, i64 addrspace(100)* %o1, align 8
+  %sum1 = add i64 %v1, %vo
+  %p2 = getelementptr inbounds i64, i64 addrspace(100)* %base, i32 2
+  %v3 = load i64, i64 addrspace(100)* %p2, align 8
+  %sum2 = add i64 %sum1, %v3
+  ret i64 %sum2
+}
+
+define i64 @testload7(i64 addrspace(100)* %base, i64 addrspace(100)* %other) {
+; CHECK: @testload7(
+; )
+; CHECK: getelementptr
+; CHECK: getelementptr
+; CHECK: getelementptr
+; CHECK: memcpy
+; CHECK: load
+; CHECK: load
+; CHECK: add
+; CHECK: load
+; CHECK: add
+; CHECK: ret
+entry:
+  %p0 = getelementptr inbounds i64, i64 addrspace(100)* %base, i32 3
+  %v1 = load i64, i64 addrspace(100)* %p0, align 8
+  %sum0 = add i64 %v1, %v1
+  %o1 = getelementptr inbounds i64, i64 addrspace(100)* %other, i32 1
+  %p1 = getelementptr inbounds i64, i64 addrspace(100)* %base, i32 1
+  %v2 = load i64, i64 addrspace(100)* %p1, align 8
+  %vo = load i64, i64 addrspace(100)* %o1, align 8
+  %sum1 = add i64 %sum0, %vo
+  %p2 = getelementptr inbounds i64, i64 addrspace(100)* %base, i32 2
+  %v3 = load i64, i64 addrspace(100)* %p2, align 8
+  %sum2 = add i64 %sum1, %v3
+  ret i64 %sum2
+}
+
+
 
 define void @teststoreatomic(i64 addrspace(100)* %base) {
 ; CHECK: @teststoreatomic(

--- a/compiler/llvm/llvmAggregateGlobalOps.cpp
+++ b/compiler/llvm/llvmAggregateGlobalOps.cpp
@@ -516,8 +516,8 @@ Instruction *AggregateGlobalOpsOpt::tryAggregating(Instruction *StartInst, Value
   // Put the first store in since we want to preserve the order.
   Ranges.addInst(0, StartInst);
 
-  BasicBlock::iterator BI = StartInst->getIterator();
-  for (++BI; BI->isTerminator(); ++BI) {
+  BasicBlock::iterator BI(StartInst);
+  for (++BI; !BI->isTerminator(); ++BI) {
 
     Instruction& insnRef = *BI;
     Instruction* insn = &insnRef;

--- a/third-party/llvm/update-llvm.sh
+++ b/third-party/llvm/update-llvm.sh
@@ -27,9 +27,9 @@ then
 
 echo Updating LLVM
 cd llvm
-git stash save
+#git stash save
 git pull
-git stash pop
+#git stash pop
 # --rebase
 echo Updating CLANG
 cd tools/clang
@@ -71,9 +71,11 @@ fi
 echo Checking out compiler-rt $BRANCH
 git clone $CLONEARGS https://git.llvm.org/git/compiler-rt.git llvm/projects/compiler-rt
 
-echo Applying Chapel patches to LLVM
-patch -p0 < llvm-6.0.0-BasicAliasAnalysis-patch.txt
-patch -p0 < llvm-6.0.0-ValueTracking-patch.txt
+# Apply any Chapel patches to LLVM here.
+# As of LLVM 8.0, there aren't any.
+#echo Applying Chapel patches to LLVM
+#patch -p0 < llvm-6.0.0-BasicAliasAnalysis-patch.txt
+#patch -p0 < llvm-6.0.0-ValueTracking-patch.txt
 
 
 fi


### PR DESCRIPTION
Now that the patches against LLVM 8 are no longer necessary for --llvm-wide-opt, this patch adjusts update-llvm.sh to not try to apply them.

Additionally it fixes llvm-global-to-wide/RUN_CONFIG to account for the build path change in PR #11638.

Finally, in testing that the pre-release LLVM 8 functions with --llvm-wide-opt, I discovered several bugs in llvmAggregateGlobalOps, which this PR fixes.
 * PR #11673 inadvertently swapped the sense of a conditional
 * Since commit  6262b70, the aggregation pass used a reordering strategy to make sure address computations come before the aggregated loads/stores and instructions that depend on the load come after. This had a bug, however, for sequences that included an unrelated load. The code was assuming that any load was part of the aggregated group but that's not always the case. This PR adjusts it to keep track of the aggregated loads/stores in a set and use this set to decide how to reorder. In order to keep the pass focused only on relevant changes, it additionally now only considers reordering instructions between the first and last load/store for a loads/stores related by constant offset and it only reorders by moving instructions dependent on a load later.

- [x] primers pass with llvm master (pre 8.0) and --llvm --fast --llvm-wide-opt under GASNet
- [x] full local --llvm testing