### PR TITLE
Fix off-by-one errors in other pidigits versions

### DIFF
--- a/test/studies/shootout/pidigits/bradc/pidigits-iter.chpl
+++ b/test/studies/shootout/pidigits/bradc/pidigits-iter.chpl
@@ -26,7 +26,7 @@ proc main() {
   //
   const leftover = n%digitsPerLine;
   if (leftover) {
-    for leftover..digitsPerLine do
+    for leftover..digitsPerLine-1 do
       write(" ");
     writeln("\t:", n);
   }

--- a/test/studies/shootout/pidigits/bradc/pidigits-ledrug-pretty.chpl
+++ b/test/studies/shootout/pidigits/bradc/pidigits-ledrug-pretty.chpl
@@ -20,7 +20,7 @@ proc main() {
 
   const leftover = n%digitsPerLine;
   if (leftover) {
-    for leftover..digitsPerLine do
+    for leftover..digitsPerLine-1 do
       write(" ");
     writeln("\t:", n);
   }

--- a/test/studies/shootout/pidigits/bradc/pidigits-ledrug.chpl
+++ b/test/studies/shootout/pidigits/bradc/pidigits-ledrug.chpl
@@ -26,7 +26,7 @@ proc main() {
   //
   const leftover = n%digitsPerLine;
   if (leftover) {
-    for leftover..digitsPerLine do
+    for leftover..digitsPerLine-1 do
       write(" ");
     writeln("\t:", n);
   }

--- a/test/studies/shootout/pidigits/bradc/pidigits-pretty1.chpl
+++ b/test/studies/shootout/pidigits/bradc/pidigits-pretty1.chpl
@@ -20,7 +20,7 @@ proc main() {
 
   const leftover = n%digitsPerLine;
   if (leftover) {
-    for leftover..digitsPerLine do
+    for leftover..digitsPerLine-1 do
       write(" ");
     writeln("\t:", n);
   }


### PR DESCRIPTION
When updating my "blc" version of pidigits yesterday, and fixing this
off-by-one error, I completely overlooked the fact that I had other
versions in this directory that shared the same .good files.  This
brings them all up-to-date.