### PR TITLE
Fix testing llvm atomics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,12 @@ depend:
 	@echo "make depend has been deprecated for the time being"
 
 check:
-	@+CHPL_HOME=$(CHPL_MAKE_HOME) bash $(CHPL_MAKE_HOME)/util/test/checkChplInstall
+	@+CHPL_HOME=$(CHPL_MAKE_HOME) CHPL_LLVM_CODEGEN=0 bash $(CHPL_MAKE_HOME)/util/test/checkChplInstall
+	@+if [ ! -z `${NEEDS_LLVM_RUNTIME}` ]; then \
+	. ${CHPL_MAKE_HOME}/util/config/set_clang_included.bash && \
+	CHPL_HOME=$(CHPL_MAKE_HOME) CHPL_LLVM_CODEGEN=1 bash $(CHPL_MAKE_HOME)/util/test/checkChplInstall ; \
+	fi
+
 
 check-chpldoc: chpldoc third-party-test-venv
 	@bash $(CHPL_MAKE_HOME)/util/test/checkChplDoc

--- a/test/library/standard/Path/verma-varsha/test_expandVars.chpl
+++ b/test/library/standard/Path/verma-varsha/test_expandVars.chpl
@@ -1,6 +1,6 @@
 use Path;
 
-var x1:string = "$CHPL_HOME/bin/${CHPL_HOST_PLATFORM}";
+var x1:string = "$CHPL_HOME/bin/${TEST_HOST_PLATFORM}";
 assert(expandVars(x1) == CHPL_HOME+"/bin/"+CHPL_HOST_PLATFORM);
 
 var x2:string = "bin/$ABCD/$ABCD_DEF";

--- a/test/library/standard/Path/verma-varsha/test_expandVars.execenv
+++ b/test/library/standard/Path/verma-varsha/test_expandVars.execenv
@@ -1,5 +1,8 @@
-RIDGE=BAR
-FOOBAR=WALL
-LAKE=michigan
-ABCD=wind
-ABCD_DEF=typhoon
+#!/bin/bash
+
+echo TEST_HOST_PLATFORM=$CHPL_HOST_PLATFORM
+echo RIDGE=BAR
+echo FOOBAR=WALL
+echo LAKE=michigan
+echo ABCD=wind
+echo ABCD_DEF=typhoon

--- a/test/llvm/PREDIFF
+++ b/test/llvm/PREDIFF
@@ -6,12 +6,15 @@ TMPFILE="$outfile.prediff.tmp"
 
 FILECHECK='FileCheck'
 
-if [ "$CHPL_LLVM" = llvm ]
+USE_LLVM=`$CHPL_HOME/util/chplenv/chpl_llvm.py`
+
+if [ "$USE_LLVM" = llvm ]
 then
   tmp=`$CHPL_HOME/util/printchplenv --all --internal --simple | grep CHPL_LLVM_UNIQ_CFG_PATH`
   LLVM_UNIQUE_SUBDIR=${tmp/CHPL_LLVM_UNIQ_CFG_PATH=/}
   FILECHECK=${CHPL_HOME}/third-party/llvm/install/${LLVM_UNIQUE_SUBDIR}/bin/FileCheck
-else
+elif [ "$USE_LLVM" = system ]
+then
   PREFERRED_LLVM_VERS=`cat ${CHPL_HOME}/third-party/llvm/LLVM_VERSION`
   LLVM_CONFIG=`${CHPL_HOME}/third-party/llvm/find-llvm-config.sh $PREFERRED_LLVM_VERS`
   FILECHECK=${LLVM_CONFIG//llvm-config/FileCheck}

--- a/util/chplenv/chpl_compiler.py
+++ b/util/chplenv/chpl_compiler.py
@@ -19,8 +19,10 @@ def get(flag='host', llvm_mode='default'):
 
         if llvm_mode == 'llvm':
             compiler_val = 'clang-included'
-        elif llvm_mode == 'default' and "CHPL_LLVM_CODEGEN" in os.environ:
-            compiler_val = 'clang-included'
+        elif llvm_mode == 'default':
+            if ("CHPL_LLVM_CODEGEN" in os.environ and
+                os.environ["CHPL_LLVM_CODEGEN"] != "0"):
+                compiler_val = 'clang-included'
 
     else:
         error("Invalid flag: '{0}'".format(flag), ValueError)

--- a/util/chplenv/printchplenv.py
+++ b/util/chplenv/printchplenv.py
@@ -122,7 +122,8 @@ def compute_all_values():
     # otherwise.
     # This happens early because it modifies the environment and other
     # defaults might depend on this setting.
-    llvm_codegen = "CHPL_LLVM_CODEGEN" in os.environ
+    llvm_codegen = ("CHPL_LLVM_CODEGEN" in os.environ and
+                    os.environ["CHPL_LLVM_CODEGEN"] != "0")
     if llvm_codegen:
         new_target_compiler = chpl_compiler.get('target')
         if new_target_compiler != 'clang-included':

--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -741,12 +741,6 @@ if ($runtests == 0) {
     if ($buildcheck == 1) {
         $buildcheckcommand = "cd $ENV{'CHPL_HOME'} && . util/setchplenv.sh && CHPL_CHECK_DEBUG=1 make check";
         mysystem($buildcheckcommand, "running `make check`", 1, 1, 1);
-
-        if ($llvm == 1) {
-          # Also try make check with --llvm
-          $buildcheckcommand2 = "cd $ENV{'CHPL_HOME'} && . util/setchplenv.sh && CHPL_CHECK_DEBUG=1 CHPL_LLVM_CODEGEN=1 make check";
-          mysystem($buildcheckcommand2, "running --llvm `make check`", 1, 1, 1);
-        }
     }
 
     if ($parnodefile eq "") {

--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -741,6 +741,12 @@ if ($runtests == 0) {
     if ($buildcheck == 1) {
         $buildcheckcommand = "cd $ENV{'CHPL_HOME'} && . util/setchplenv.sh && CHPL_CHECK_DEBUG=1 make check";
         mysystem($buildcheckcommand, "running `make check`", 1, 1, 1);
+
+        if ($llvm == 1) {
+          # Also try make check with --llvm
+          $buildcheckcommand2 = "cd $ENV{'CHPL_HOME'} && . util/setchplenv.sh && CHPL_CHECK_DEBUG=1 CHPL_LLVM_CODEGEN=1 make check";
+          mysystem($buildcheckcommand2, "running --llvm `make check`", 1, 1, 1);
+        }
     }
 
     if ($parnodefile eq "") {

--- a/util/test/checkChplInstall
+++ b/util/test/checkChplInstall
@@ -164,8 +164,16 @@ chpl_launcher="$($CHPL_HOME/util/chplenv/chpl_launcher.py)"
 # Necessary to suppress warnings when WARNINGS=1 (e.g. nightly build settings)
 COMP_FLAGS="--cc-warnings"
 
+backend="C"
+if [ ${CHPL_LLVM_CODEGEN:-0} -eq 1 ]; then
+  backend="LLVM"
+fi
+
 # Compile test job into temporary directory
 log_info "Compiling \$CHPL_HOME/${REL_TEST_DIR}/${TEST_JOB}.chpl"
+
+log_info "Compiling with $backend backend"
+
 TEST_COMP_OUT=$( ${CHPL_BIN} ${TEST_DIR}/${TEST_JOB}.chpl ${COMP_FLAGS} -o ${TMP_TEST_DIR}/${TEST_JOB} 2>&1 )
 COMPILE_STATUS=$?
 

--- a/util/test/paratest.server
+++ b/util/test/paratest.server
@@ -774,7 +774,7 @@ sub main {
     }
 
     # Package up the environment
-    my $tmpchplenv = `$ENV{CHPL_HOME}/util/printchplenv --simple --all`;
+    my $tmpchplenv = `$ENV{CHPL_HOME}/util/printchplenv --simple --all --overrides`;
     my $chplenv = "";
     my @lines = split(/\n/, $tmpchplenv);
     for my $line (@lines) {


### PR DESCRIPTION
Nightly --llvm testing was showing failures to compile for every test after PR  #11963. There are two problems:

1. The `make check` that nightly testing runs doesn't check --llvm. Thus it is possible to have every test fail with the same error.
2. paratest.server packages up the environment output by printchplenv. In particular it includes CHPL_ATOMICS=cstdlib and then the paratest.client sets this variable. This prevents the default for --llvm / clang-included (which is still CHPL_ATOMICS=intrinsics) from being used and causes the build error.

To solve these issues, this PR makes the following changes:
 1. As a prerequisite, and to prepare for the possibility of `--llvm` by default, adjusts chpl_compiler.py and printchplenv.py to consider CHPL_LLVM_CODEGEN=0 in the environment to mean "use the C backend"
 2. Adjusts `make check` (in `Makefile`) to check the C backend first and then the LLVM backend if we are building a compiler with LLVM support.
 3. Adjusts `checkChplInstall` to note in output whether the C or LLVM backend is being tested by `make check`
 4. Adjusts `paratest.server` to pass `--overrides` to the printchplenv command of variables to package up.

In this PR, I opted to run checkChplInstall twice for LLVM-enabled compilers. This is consistent with a bunch of other Makefile actions that happen twice in that setting, such as building the runtime for clang-included as well as for the selected C compiler. It would alternatively be reasonable to adjust checkChplInstall to run both tests.

Note that it's possible that in nightly testing, some environment variable has its default setting computed differently on the nodes running the `paratest.client` jobs than on `paratest.server`. If this turns out to be a problem in practice I think it'd be better to be clear that the environment variable must be set to a particular value (rather than relying on the default on some nodes but not others) by explicitly setting it in the test configuration.

- [x] verified that `make check` fails for an LLVM enabled compiler if I remove lib/linux64/clang-included
- [x] verified that hello tests now pass with paratest.server -compopts --llvm
- [x] full local testing

Reviewed by @ronawho - thanks!