### PR TITLE
Make string this() always return a string

### DIFF
--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -649,7 +649,7 @@ module String {
       :returns: A Unicode codepoint starting at the
                 specified codepoint index from `1..string.ulength`
      */
-    proc this(cpi: codePointIndex) : int(32) {
+    proc this(cpi: codePointIndex) : string {
       const idx = cpi: int;
       if boundsChecking && idx <= 0 then
         halt("index out of bounds of string: ", idx);
@@ -657,13 +657,13 @@ module String {
       var i = 1;
       for codepoint in this.uchars() {
         if i == idx then
-          return codepoint;
+          return codePointToString(codepoint);
         i += 1;
       }
       // We have reached the end of the string without finding our index.
       if boundsChecking then
         halt("index out of bounds of string: ", idx);
-      return 0: int(32);
+      return "";
     }
 
     // Checks to see if r is inside the bounds of this and returns a finite

--- a/test/types/string/StringImpl/memLeaks/substring_codepoint.chpl
+++ b/test/types/string/StringImpl/memLeaks/substring_codepoint.chpl
@@ -18,22 +18,8 @@ module unitTest {
       checkMemLeaks(m0);
     }
 
-    proc substringHelpCPI(i) {
-      const m0 = allMemoryUsed();
-      {
-        const s: t = "sûḃstríng";
-        if useExpr {
-          writeMe(codePointToString(s[i]));
-        } else {
-          const ss = codePointToString(s[i]);
-          writeMe(ss);
-        }
-      }
-      checkMemLeaks(m0);
-    }
-
     var idx = 3:codePointIndex;
-    substringHelpCPI(idx);
+    substringHelp(idx);
 
     var slice = ..idx;
     substringHelp(slice);
@@ -73,33 +59,8 @@ module unitTest {
       checkMemLeaks(m0);
     }
 
-    proc substringHelpCPI(i) {
-      const m0 = allMemoryUsed();
-      {
-        const s0: t = "sûḃstríng";
-        on Locales[numLocales-1] {
-          if useExpr {
-            writeMe(codePointToString(s0[i]));
-          } else {
-            const ss = codePointToString(s0[i]);
-            writeMe(ss);
-          }
-          const s1: t = "sûḃstríng";
-          on Locales[0] {
-            if useExpr {
-              writeMe(codePointToString(s1[i]));
-            } else {
-              const ss = codePointToString(s1[i]);
-              writeMe(ss);
-            }
-          }
-        }
-      }
-      checkMemLeaks(m0);
-    }
-
     var idx = 3:codePointIndex;
-    substringHelpCPI(idx);
+    substringHelp(idx);
 
     var slice = ..idx;
     substringHelp(slice);

--- a/test/types/string/dmk/utf8_misc.chpl
+++ b/test/types/string/dmk/utf8_misc.chpl
@@ -5,6 +5,5 @@ writeln("Byte length = ", mystring1.length);
 writeln("Codepoint length = ", ulen1);
 
 for i in 1..ulen1 {
-  writeln("Codepoint index ", i, " = '",
-          codePointToString(mystring1[i: codePointIndex]), "'");
+  writeln("Codepoint index ", i, " = '", mystring1[i: codePointIndex], "'");
 }


### PR DESCRIPTION
String this() on a codepoint index returned an int(32), which made generic programming hard because other versions of this() returned a string.  This change makes it uniformly return a string.

Closes #11948 
Answers the part of #11061 regarding the type of this()