### PR TITLE
Improve lifetime error constraint error messages

### DIFF
--- a/compiler/AST/FnSymbol.cpp
+++ b/compiler/AST/FnSymbol.cpp
@@ -1148,7 +1148,9 @@ const char* toString(FnSymbol* fn) {
           arg->type == dtModuleToken)
         continue;
 
-      // skip this formal methods in non-developer mode
+      // skip _this formal for methods in non-developer mode
+      // because in non-developer mode it has already been printed
+      // along with the method name (e.g. C.mymethod).
       if (developer == false && fn->isMethod() && arg == fn->_this)
         continue;
 

--- a/compiler/resolution/lifetime.cpp
+++ b/compiler/resolution/lifetime.cpp
@@ -294,6 +294,7 @@ static void markArgumentsReturnScope(FnSymbol* fn);
 static void checkFunction(FnSymbol* fn);
 
 static bool isCallToFunctionReturningNotOwned(CallExpr* call);
+static bool isUser(BaseAST* ast);
 
 void checkLifetimes(void) {
   // Mark all arguments with FLAG_SCOPE or FLAG_RETURN_SCOPE.
@@ -673,8 +674,16 @@ static void printOrderConstraintFromClause(Expr* expr, Symbol* a, Symbol* b)
           calledName = base->unresolved;
 
         FnSymbol* fn = call->getFunction();
-        USR_PRINT(call, "function %s includes lifetime constraint %s %s %s",
-                  fn->name, lhsName, calledName, rhsName);
+
+        if (developer || isUser(fn)) {
+          USR_PRINT(call, "called function %s", toString(fn));
+          USR_PRINT(call, "includes lifetime constraint %s %s %s",
+                    lhsName, calledName, rhsName);
+        } else {
+          USR_PRINT("called function %s", toString(fn));
+          USR_PRINT("includes lifetime constraint %s %s %s",
+                    lhsName, calledName, rhsName);
+        }
       }
     }
   }

--- a/test/classes/delete-free/lifetimes/bad-push-back-borrow.good
+++ b/test/classes/delete-free/lifetimes/bad-push-back-borrow.good
@@ -1,3 +1,4 @@
 bad-push-back-borrow.chpl:20: In function 'addone':
 bad-push-back-borrow.chpl:25: error: Actual argument does not meet called function lifetime constraint
-$CHPL_HOME/modules/internal/ChapelArray.chpl:2883: note: function push_back includes lifetime constraint this < val
+note: called function [domain(1,int(64),false)] I.push_back(val: I)
+note: includes lifetime constraint this < val

--- a/test/classes/delete-free/lifetimes/constraint-task-fns-errors.good
+++ b/test/classes/delete-free/lifetimes/constraint-task-fns-errors.good
@@ -1,20 +1,25 @@
 constraint-task-fns-errors.chpl:40: In function 'test_begin':
 constraint-task-fns-errors.chpl:44: error: Actual argument does not meet called function lifetime constraint
 constraint-task-fns-errors.chpl:43: note: consider scope of a
-constraint-task-fns-errors.chpl:4: note: function setit_begin includes lifetime constraint lhs < rhs
+constraint-task-fns-errors.chpl:4: note: called function setit_begin(ref lhs: C, rhs: C)
+constraint-task-fns-errors.chpl:4: note: includes lifetime constraint lhs < rhs
 constraint-task-fns-errors.chpl:50: In function 'test_cobegin':
 constraint-task-fns-errors.chpl:54: error: Actual argument does not meet called function lifetime constraint
 constraint-task-fns-errors.chpl:53: note: consider scope of a
-constraint-task-fns-errors.chpl:9: note: function setit_cobegin includes lifetime constraint lhs < rhs
+constraint-task-fns-errors.chpl:9: note: called function setit_cobegin(ref lhs: C, rhs: C)
+constraint-task-fns-errors.chpl:9: note: includes lifetime constraint lhs < rhs
 constraint-task-fns-errors.chpl:60: In function 'test_coforall':
 constraint-task-fns-errors.chpl:64: error: Actual argument does not meet called function lifetime constraint
 constraint-task-fns-errors.chpl:63: note: consider scope of a
-constraint-task-fns-errors.chpl:16: note: function setit_coforall includes lifetime constraint lhs < rhs
+constraint-task-fns-errors.chpl:16: note: called function setit_coforall(ref lhs: C, rhs: C)
+constraint-task-fns-errors.chpl:16: note: includes lifetime constraint lhs < rhs
 constraint-task-fns-errors.chpl:70: In function 'test_forall':
 constraint-task-fns-errors.chpl:74: error: Actual argument does not meet called function lifetime constraint
 constraint-task-fns-errors.chpl:73: note: consider scope of a
-constraint-task-fns-errors.chpl:25: note: function setit_forall includes lifetime constraint lhs < rhs
+constraint-task-fns-errors.chpl:25: note: called function setit_forall(ref lhs: C, rhs: C)
+constraint-task-fns-errors.chpl:25: note: includes lifetime constraint lhs < rhs
 constraint-task-fns-errors.chpl:80: In function 'test_on':
 constraint-task-fns-errors.chpl:84: error: Actual argument does not meet called function lifetime constraint
 constraint-task-fns-errors.chpl:83: note: consider scope of a
-constraint-task-fns-errors.chpl:34: note: function setit_on includes lifetime constraint lhs < rhs
+constraint-task-fns-errors.chpl:34: note: called function setit_on(ref lhs: C, rhs: C)
+constraint-task-fns-errors.chpl:34: note: includes lifetime constraint lhs < rhs

--- a/test/classes/delete-free/lifetimes/push-back-borrow.good
+++ b/test/classes/delete-free/lifetimes/push-back-borrow.good
@@ -1,4 +1,5 @@
 push-back-borrow.chpl:18: In function 'error7':
 push-back-borrow.chpl:19: error: Actual argument arg does not meet called function lifetime constraint
 push-back-borrow.chpl:18: note: consider scope of arg
-$CHPL_HOME/modules/internal/ChapelArray.chpl:2883: note: function push_back includes lifetime constraint this < val
+note: called function [domain(1,int(64),false)] MyClass.push_back(val: MyClass)
+note: includes lifetime constraint this < val

--- a/test/classes/delete-free/lifetimes/push_back_lifetime.good
+++ b/test/classes/delete-free/lifetimes/push_back_lifetime.good
@@ -1,8 +1,10 @@
 push_back_lifetime.chpl:3: In function 'bad1':
 push_back_lifetime.chpl:9: error: Actual argument bb does not meet called function lifetime constraint
 push_back_lifetime.chpl:7: note: consider scope of own
-$CHPL_HOME/modules/internal/ChapelArray.chpl:2883: note: function push_back includes lifetime constraint this < val
+note: called function [domain(1,int(64),false)] C.push_back(val: C)
+note: includes lifetime constraint this < val
 push_back_lifetime.chpl:14: In function 'bad2':
 push_back_lifetime.chpl:19: error: Actual argument does not meet called function lifetime constraint
 push_back_lifetime.chpl:18: note: consider scope of own
-$CHPL_HOME/modules/internal/ChapelArray.chpl:2883: note: function push_back includes lifetime constraint this < val
+note: called function [domain(1,int(64),false)] C.push_back(val: C)
+note: includes lifetime constraint this < val

--- a/test/classes/delete-free/lifetimes/specified-formal-order-array.good
+++ b/test/classes/delete-free/lifetimes/specified-formal-order-array.good
@@ -1,4 +1,5 @@
 specified-formal-order-array.chpl:8: In function 'bad3':
 specified-formal-order-array.chpl:17: error: Actual argument Ab does not meet called function lifetime constraint
 specified-formal-order-array.chpl:14: note: consider scope of Ab
-specified-formal-order-array.chpl:3: note: function setA includes lifetime constraint lhs < rhs
+specified-formal-order-array.chpl:3: note: called function setA(lhs: [domain(1,int(64),false)] C, rhs: [domain(1,int(64),false)] C)
+specified-formal-order-array.chpl:3: note: includes lifetime constraint lhs < rhs

--- a/test/classes/delete-free/lifetimes/specified-formal-order-primary-methods.chpl
+++ b/test/classes/delete-free/lifetimes/specified-formal-order-primary-methods.chpl
@@ -1,0 +1,94 @@
+class C {
+  var x: int;
+
+  proc ref setClt(rhs: C) lifetime this < rhs {
+    this = rhs;
+  }
+  proc ref setClt2(rhs: C) where true lifetime this < rhs, this < rhs {
+    this = rhs;
+  }
+  // this one never called
+  proc ref setClt2(rhs: C) where false lifetime this < rhs, this < rhs {
+    this = rhs;
+  }
+
+  proc ref setClte(rhs: C) lifetime this <= rhs where true {
+    this = rhs;
+  }
+  // this one never called
+  proc ref setClte(rhs: C) lifetime this <= rhs where false {
+    this = rhs;
+  }
+
+  proc ref setCgt(rhs: C) lifetime rhs > this {
+    this = rhs;
+  }
+  proc ref setCgte(rhs: C) lifetime rhs >= this {
+    this = rhs;
+  }
+  proc ref setCbad(rhs: C) lifetime this > rhs {
+    this = rhs;
+  }
+}
+
+proc badlt() {
+  var b: borrowed C;
+  {
+    var own = new owned C();
+    b.setClt(own.borrow());
+  }
+  writeln(b.x);
+}
+badlt();
+
+proc badlt2() {
+  var b: borrowed C;
+  {
+    var own = new owned C();
+    b.setClt2(own.borrow());
+  }
+  writeln(b.x);
+}
+badlt2();
+
+proc badlte() {
+  var b: borrowed C;
+  {
+    var own = new owned C();
+    b.setClte(own.borrow());
+  }
+  writeln(b.x);
+}
+badlte();
+
+proc badgt() {
+  var b: borrowed C;
+  {
+    var own = new owned C();
+    b.setCgt(own.borrow());
+  }
+  writeln(b.x);
+}
+badgt();
+
+proc badgte() {
+  var b: borrowed C;
+  {
+    var own = new owned C();
+    b.setCgte(own.borrow());
+  }
+  writeln(b.x);
+}
+badgte();
+
+proc callsBad() {
+  var b: borrowed C;
+  {
+    var own = new owned C();
+    b.setCbad(own.borrow());
+  }
+  writeln(b.x);
+}
+callsBad();
+
+

--- a/test/classes/delete-free/lifetimes/specified-formal-order-primary-methods.good
+++ b/test/classes/delete-free/lifetimes/specified-formal-order-primary-methods.good
@@ -1,0 +1,49 @@
+specified-formal-order-primary-methods.chpl:29: In function 'setCbad':
+specified-formal-order-primary-methods.chpl:30: error: Scoped variable this would outlive the value it is set to
+specified-formal-order-primary-methods.chpl:29: note: consider scope of rhs
+specified-formal-order-primary-methods.chpl:34: In function 'badlt':
+specified-formal-order-primary-methods.chpl:38: error: Actual argument does not meet called function lifetime constraint
+specified-formal-order-primary-methods.chpl:37: note: consider scope of own
+specified-formal-order-primary-methods.chpl:4: note: called function ref C.setClt(rhs: C)
+specified-formal-order-primary-methods.chpl:4: note: includes lifetime constraint this < rhs
+specified-formal-order-primary-methods.chpl:38: error: attempt to dereference nil
+specified-formal-order-primary-methods.chpl:38: note: variable b is nil at this point
+specified-formal-order-primary-methods.chpl:35: note: this statement may be relevant
+specified-formal-order-primary-methods.chpl:44: In function 'badlt2':
+specified-formal-order-primary-methods.chpl:48: error: Actual argument does not meet called function lifetime constraint
+specified-formal-order-primary-methods.chpl:47: note: consider scope of own
+specified-formal-order-primary-methods.chpl:7: note: called function ref C.setClt2(rhs: C)
+specified-formal-order-primary-methods.chpl:7: note: includes lifetime constraint this < rhs
+specified-formal-order-primary-methods.chpl:7: note: called function ref C.setClt2(rhs: C)
+specified-formal-order-primary-methods.chpl:7: note: includes lifetime constraint this < rhs
+specified-formal-order-primary-methods.chpl:48: error: attempt to dereference nil
+specified-formal-order-primary-methods.chpl:48: note: variable b is nil at this point
+specified-formal-order-primary-methods.chpl:45: note: this statement may be relevant
+specified-formal-order-primary-methods.chpl:54: In function 'badlte':
+specified-formal-order-primary-methods.chpl:58: error: Actual argument does not meet called function lifetime constraint
+specified-formal-order-primary-methods.chpl:57: note: consider scope of own
+specified-formal-order-primary-methods.chpl:15: note: called function ref C.setClte(rhs: C)
+specified-formal-order-primary-methods.chpl:15: note: includes lifetime constraint this <= rhs
+specified-formal-order-primary-methods.chpl:58: error: attempt to dereference nil
+specified-formal-order-primary-methods.chpl:58: note: variable b is nil at this point
+specified-formal-order-primary-methods.chpl:55: note: this statement may be relevant
+specified-formal-order-primary-methods.chpl:64: In function 'badgt':
+specified-formal-order-primary-methods.chpl:68: error: Actual argument does not meet called function lifetime constraint
+specified-formal-order-primary-methods.chpl:67: note: consider scope of own
+specified-formal-order-primary-methods.chpl:23: note: called function ref C.setCgt(rhs: C)
+specified-formal-order-primary-methods.chpl:23: note: includes lifetime constraint rhs > this
+specified-formal-order-primary-methods.chpl:68: error: attempt to dereference nil
+specified-formal-order-primary-methods.chpl:68: note: variable b is nil at this point
+specified-formal-order-primary-methods.chpl:65: note: this statement may be relevant
+specified-formal-order-primary-methods.chpl:74: In function 'badgte':
+specified-formal-order-primary-methods.chpl:78: error: Actual argument does not meet called function lifetime constraint
+specified-formal-order-primary-methods.chpl:77: note: consider scope of own
+specified-formal-order-primary-methods.chpl:26: note: called function ref C.setCgte(rhs: C)
+specified-formal-order-primary-methods.chpl:26: note: includes lifetime constraint rhs >= this
+specified-formal-order-primary-methods.chpl:78: error: attempt to dereference nil
+specified-formal-order-primary-methods.chpl:78: note: variable b is nil at this point
+specified-formal-order-primary-methods.chpl:75: note: this statement may be relevant
+specified-formal-order-primary-methods.chpl:84: In function 'callsBad':
+specified-formal-order-primary-methods.chpl:88: error: attempt to dereference nil
+specified-formal-order-primary-methods.chpl:88: note: variable b is nil at this point
+specified-formal-order-primary-methods.chpl:85: note: this statement may be relevant

--- a/test/classes/delete-free/lifetimes/specified-formal-order-secondary-methods.chpl
+++ b/test/classes/delete-free/lifetimes/specified-formal-order-secondary-methods.chpl
@@ -1,0 +1,92 @@
+class C { var x: int; }
+
+proc ref C.setClt(rhs: C) lifetime this < rhs {
+  this = rhs;
+}
+proc ref C.setClt2(rhs: C) where true lifetime this < rhs, this < rhs {
+  this = rhs;
+}
+// this one never called
+proc ref C.setClt2(rhs: C) where false lifetime this < rhs, this < rhs {
+  this = rhs;
+}
+
+proc ref C.setClte(rhs: C) lifetime this <= rhs where true {
+  this = rhs;
+}
+// this one never called
+proc ref C.setClte(rhs: C) lifetime this <= rhs where false {
+  this = rhs;
+}
+
+proc ref C.setCgt(rhs: C) lifetime rhs > this {
+  this = rhs;
+}
+proc ref C.setCgte(rhs: C) lifetime rhs >= this {
+  this = rhs;
+}
+proc ref C.setCbad(rhs: C) lifetime this > rhs {
+  this = rhs;
+}
+
+proc badlt() {
+  var b: borrowed C;
+  {
+    var own = new owned C();
+    b.setClt(own.borrow());
+  }
+  writeln(b.x);
+}
+badlt();
+
+proc badlt2() {
+  var b: borrowed C;
+  {
+    var own = new owned C();
+    b.setClt2(own.borrow());
+  }
+  writeln(b.x);
+}
+badlt2();
+
+proc badlte() {
+  var b: borrowed C;
+  {
+    var own = new owned C();
+    b.setClte(own.borrow());
+  }
+  writeln(b.x);
+}
+badlte();
+
+proc badgt() {
+  var b: borrowed C;
+  {
+    var own = new owned C();
+    b.setCgt(own.borrow());
+  }
+  writeln(b.x);
+}
+badgt();
+
+proc badgte() {
+  var b: borrowed C;
+  {
+    var own = new owned C();
+    b.setCgte(own.borrow());
+  }
+  writeln(b.x);
+}
+badgte();
+
+proc callsBad() {
+  var b: borrowed C;
+  {
+    var own = new owned C();
+    b.setCbad(own.borrow());
+  }
+  writeln(b.x);
+}
+callsBad();
+
+

--- a/test/classes/delete-free/lifetimes/specified-formal-order-secondary-methods.good
+++ b/test/classes/delete-free/lifetimes/specified-formal-order-secondary-methods.good
@@ -1,0 +1,49 @@
+specified-formal-order-secondary-methods.chpl:28: In function 'setCbad':
+specified-formal-order-secondary-methods.chpl:29: error: Scoped variable this would outlive the value it is set to
+specified-formal-order-secondary-methods.chpl:28: note: consider scope of rhs
+specified-formal-order-secondary-methods.chpl:32: In function 'badlt':
+specified-formal-order-secondary-methods.chpl:36: error: Actual argument does not meet called function lifetime constraint
+specified-formal-order-secondary-methods.chpl:35: note: consider scope of own
+specified-formal-order-secondary-methods.chpl:3: note: called function ref C.setClt(rhs: C)
+specified-formal-order-secondary-methods.chpl:3: note: includes lifetime constraint this < rhs
+specified-formal-order-secondary-methods.chpl:36: error: attempt to dereference nil
+specified-formal-order-secondary-methods.chpl:36: note: variable b is nil at this point
+specified-formal-order-secondary-methods.chpl:33: note: this statement may be relevant
+specified-formal-order-secondary-methods.chpl:42: In function 'badlt2':
+specified-formal-order-secondary-methods.chpl:46: error: Actual argument does not meet called function lifetime constraint
+specified-formal-order-secondary-methods.chpl:45: note: consider scope of own
+specified-formal-order-secondary-methods.chpl:6: note: called function ref C.setClt2(rhs: C)
+specified-formal-order-secondary-methods.chpl:6: note: includes lifetime constraint this < rhs
+specified-formal-order-secondary-methods.chpl:6: note: called function ref C.setClt2(rhs: C)
+specified-formal-order-secondary-methods.chpl:6: note: includes lifetime constraint this < rhs
+specified-formal-order-secondary-methods.chpl:46: error: attempt to dereference nil
+specified-formal-order-secondary-methods.chpl:46: note: variable b is nil at this point
+specified-formal-order-secondary-methods.chpl:43: note: this statement may be relevant
+specified-formal-order-secondary-methods.chpl:52: In function 'badlte':
+specified-formal-order-secondary-methods.chpl:56: error: Actual argument does not meet called function lifetime constraint
+specified-formal-order-secondary-methods.chpl:55: note: consider scope of own
+specified-formal-order-secondary-methods.chpl:14: note: called function ref C.setClte(rhs: C)
+specified-formal-order-secondary-methods.chpl:14: note: includes lifetime constraint this <= rhs
+specified-formal-order-secondary-methods.chpl:56: error: attempt to dereference nil
+specified-formal-order-secondary-methods.chpl:56: note: variable b is nil at this point
+specified-formal-order-secondary-methods.chpl:53: note: this statement may be relevant
+specified-formal-order-secondary-methods.chpl:62: In function 'badgt':
+specified-formal-order-secondary-methods.chpl:66: error: Actual argument does not meet called function lifetime constraint
+specified-formal-order-secondary-methods.chpl:65: note: consider scope of own
+specified-formal-order-secondary-methods.chpl:22: note: called function ref C.setCgt(rhs: C)
+specified-formal-order-secondary-methods.chpl:22: note: includes lifetime constraint rhs > this
+specified-formal-order-secondary-methods.chpl:66: error: attempt to dereference nil
+specified-formal-order-secondary-methods.chpl:66: note: variable b is nil at this point
+specified-formal-order-secondary-methods.chpl:63: note: this statement may be relevant
+specified-formal-order-secondary-methods.chpl:72: In function 'badgte':
+specified-formal-order-secondary-methods.chpl:76: error: Actual argument does not meet called function lifetime constraint
+specified-formal-order-secondary-methods.chpl:75: note: consider scope of own
+specified-formal-order-secondary-methods.chpl:25: note: called function ref C.setCgte(rhs: C)
+specified-formal-order-secondary-methods.chpl:25: note: includes lifetime constraint rhs >= this
+specified-formal-order-secondary-methods.chpl:76: error: attempt to dereference nil
+specified-formal-order-secondary-methods.chpl:76: note: variable b is nil at this point
+specified-formal-order-secondary-methods.chpl:73: note: this statement may be relevant
+specified-formal-order-secondary-methods.chpl:82: In function 'callsBad':
+specified-formal-order-secondary-methods.chpl:86: error: attempt to dereference nil
+specified-formal-order-secondary-methods.chpl:86: note: variable b is nil at this point
+specified-formal-order-secondary-methods.chpl:83: note: this statement may be relevant

--- a/test/classes/delete-free/lifetimes/specified-formal-order.good
+++ b/test/classes/delete-free/lifetimes/specified-formal-order.good
@@ -4,21 +4,27 @@ specified-formal-order.chpl:28: note: consider scope of rhs
 specified-formal-order.chpl:32: In function 'badlt':
 specified-formal-order.chpl:36: error: Actual argument does not meet called function lifetime constraint
 specified-formal-order.chpl:35: note: consider scope of own
-specified-formal-order.chpl:3: note: function setClt includes lifetime constraint lhs < rhs
+specified-formal-order.chpl:3: note: called function setClt(ref lhs: C, rhs: C)
+specified-formal-order.chpl:3: note: includes lifetime constraint lhs < rhs
 specified-formal-order.chpl:42: In function 'badlt2':
 specified-formal-order.chpl:46: error: Actual argument does not meet called function lifetime constraint
 specified-formal-order.chpl:45: note: consider scope of own
-specified-formal-order.chpl:6: note: function setClt2 includes lifetime constraint lhs < rhs
-specified-formal-order.chpl:6: note: function setClt2 includes lifetime constraint lhs < rhs
+specified-formal-order.chpl:6: note: called function setClt2(ref lhs: C, rhs: C)
+specified-formal-order.chpl:6: note: includes lifetime constraint lhs < rhs
+specified-formal-order.chpl:6: note: called function setClt2(ref lhs: C, rhs: C)
+specified-formal-order.chpl:6: note: includes lifetime constraint lhs < rhs
 specified-formal-order.chpl:52: In function 'badlte':
 specified-formal-order.chpl:56: error: Actual argument does not meet called function lifetime constraint
 specified-formal-order.chpl:55: note: consider scope of own
-specified-formal-order.chpl:14: note: function setClte includes lifetime constraint lhs <= rhs
+specified-formal-order.chpl:14: note: called function setClte(ref lhs: C, rhs: C)
+specified-formal-order.chpl:14: note: includes lifetime constraint lhs <= rhs
 specified-formal-order.chpl:62: In function 'badgt':
 specified-formal-order.chpl:66: error: Actual argument does not meet called function lifetime constraint
 specified-formal-order.chpl:65: note: consider scope of own
-specified-formal-order.chpl:22: note: function setCgt includes lifetime constraint rhs > lhs
+specified-formal-order.chpl:22: note: called function setCgt(ref lhs: C, rhs: C)
+specified-formal-order.chpl:22: note: includes lifetime constraint rhs > lhs
 specified-formal-order.chpl:72: In function 'badgte':
 specified-formal-order.chpl:76: error: Actual argument does not meet called function lifetime constraint
 specified-formal-order.chpl:75: note: consider scope of own
-specified-formal-order.chpl:25: note: function setCgte includes lifetime constraint rhs >= lhs
+specified-formal-order.chpl:25: note: called function setCgte(ref lhs: C, rhs: C)
+specified-formal-order.chpl:25: note: includes lifetime constraint rhs >= lhs

--- a/test/functions/resolution/ambig-param-overloads.good
+++ b/test/functions/resolution/ambig-param-overloads.good
@@ -1,3 +1,3 @@
 ambig-param-overloads.chpl:13: error: ambiguous call 'R(false).getX'
-ambig-param-overloads.chpl:7: note: candidates are: getX _mt: _MT, this: R
-ambig-param-overloads.chpl:8: note:                 getX _mt: _MT, this: R
+ambig-param-overloads.chpl:7: note: candidates are: R.getX
+ambig-param-overloads.chpl:8: note:                 R.getX


### PR DESCRIPTION
@bradcray pointed out that the tests for array push_back errors like test/classes/delete-free/lifetimes/bad-push-back-borrow.chpl included internal module line numbers even in --no-devel compilation mode.

This PR fixes that problem by:
 * simplifying FnSymbol::toString since it was not working for this case
 * omitting the source line for such errors for internal modules in --no-devel compilation
 * printing out the function signature (so it can say [] C.push_back rather than just push_back).

- [x] full local testing

Reviewed by @vasslitvinov - thanks!