### PR TITLE
Revert "make check checks --llvm also if built for it"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,12 +189,7 @@ depend:
 	@echo "make depend has been deprecated for the time being"
 
 check:
-	@+CHPL_HOME=$(CHPL_MAKE_HOME) CHPL_LLVM_CODEGEN=0 bash $(CHPL_MAKE_HOME)/util/test/checkChplInstall
-	@+if [ ! -z `${NEEDS_LLVM_RUNTIME}` ]; then \
-	. ${CHPL_MAKE_HOME}/util/config/set_clang_included.bash && \
-	CHPL_HOME=$(CHPL_MAKE_HOME) CHPL_LLVM_CODEGEN=1 bash $(CHPL_MAKE_HOME)/util/test/checkChplInstall ; \
-	fi
-
+	@+CHPL_HOME=$(CHPL_MAKE_HOME) bash $(CHPL_MAKE_HOME)/util/test/checkChplInstall
 
 check-chpldoc: chpldoc third-party-test-venv
 	@bash $(CHPL_MAKE_HOME)/util/test/checkChplDoc

--- a/util/test/checkChplInstall
+++ b/util/test/checkChplInstall
@@ -164,16 +164,8 @@ chpl_launcher="$($CHPL_HOME/util/chplenv/chpl_launcher.py)"
 # Necessary to suppress warnings when WARNINGS=1 (e.g. nightly build settings)
 COMP_FLAGS="--cc-warnings"
 
-backend="C"
-if [ ${CHPL_LLVM_CODEGEN:-0} -eq 1 ]; then
-  backend="LLVM"
-fi
-
 # Compile test job into temporary directory
 log_info "Compiling \$CHPL_HOME/${REL_TEST_DIR}/${TEST_JOB}.chpl"
-
-log_info "Compiling with $backend backend"
-
 TEST_COMP_OUT=$( ${CHPL_BIN} ${TEST_DIR}/${TEST_JOB}.chpl ${COMP_FLAGS} -o ${TMP_TEST_DIR}/${TEST_JOB} 2>&1 )
 COMPILE_STATUS=$?
 


### PR DESCRIPTION
This reverts commit fb7eb5d48daa206ac9e42abd9f301760f6350e7b.

Stop checking both the C and LLVM backends as part of `make check`. This backs
out part of #11988

We run our smoke test with `CHPL_LLVM_CODEGEN=true`, which results in always
building things for the llvm backend, and never for the C backend.  i.e.
`CHPL_LLVM_CODEGEN=true` will result in clang-included always being the target
compiler, so we never build the runtime/third-party/modules for the regular C
backend, so the C-backend `make check` fails.

Until we actually start building the runtime/third-party/modules for both
backends, revert to only testing the one that has been built. Note that this is
not a new issue, just one that was exposed by new testing.
