### PR TITLE
Add a future to track #11816 (get type of generic var field from type variable)

### DIFF
--- a/test/classes/generic/typeOfGenericField-fromTypeVariable.bad
+++ b/test/classes/generic/typeOfGenericField-fromTypeVariable.bad
@@ -1,0 +1,4 @@
+typeOfGenericField-fromTypeVariable.chpl:12: error: unresolved call 'type [BlockDom(1,int(64),false,unmanaged DefaultDist)] int(64)._instance'
+$CHPL_HOME/modules/internal/ChapelArray.chpl:924: note: candidates are: _distribution._instance
+$CHPL_HOME/modules/internal/ChapelArray.chpl:1059: note:                 _domain._instance
+$CHPL_HOME/modules/internal/ChapelArray.chpl:2156: note:                 _array._instance

--- a/test/classes/generic/typeOfGenericField-fromTypeVariable.chpl
+++ b/test/classes/generic/typeOfGenericField-fromTypeVariable.chpl
@@ -1,0 +1,12 @@
+// This test tracks trying to get the type of a generic var field from a fully
+// instantiated type variable.  I'm using arrays here because that was the case
+// where I wanted this functionality, but it applies to other generic types
+use BlockDist;
+const D = {1..5} dmapped Block({1..5});
+type t = [D] int;
+writeln(t: string);
+// The following two lines work as expected.  The uncommented line should work
+// as well, but does not
+//var x: t;
+//writeln(x._instance.type: string);
+writeln(t._instance.type: string);

--- a/test/classes/generic/typeOfGenericField-fromTypeVariable.future
+++ b/test/classes/generic/typeOfGenericField-fromTypeVariable.future
@@ -1,0 +1,2 @@
+feature request: get type of fully generic var field from type variable
+#11816

--- a/test/classes/generic/typeOfGenericField-fromTypeVariable.good
+++ b/test/classes/generic/typeOfGenericField-fromTypeVariable.good
@@ -1,0 +1,2 @@
+[BlockDom(1,int(64),false,unmanaged DefaultDist)] int(64)
+unmanaged [BlockDom(1,int(64),false,unmanaged DefaultDist)] int(64)


### PR DESCRIPTION
In working on support for opaque pointers to Chapel arrays, I ran into a
situation where I wanted to get the type of the _instance field from an array
type without having to make an instance of the type to get it (as that would
involve creating unnecessary memory usage).  This is not currently possible
today.

Double checked a fresh checkout of the test