### PR TITLE
Skip static_dynamic test if we need libmpi.

### DIFF
--- a/test/compflags/link/sungeun/static_dynamic.skipif
+++ b/test/compflags/link/sungeun/static_dynamic.skipif
@@ -6,6 +6,15 @@ if [[ $CHPL_HOST_PLATFORM == *cygwin* \
   # Can't do static/dynamic linking on these platforms
   #
   echo True
+elif [[ $CHPL_COMM_SUBSTRATE == mpi \
+        || ( $CHPL_COMM == ofi && $CHPL_LAUNCHER == mpirun4ofi ) ]] ; then
+  #
+  # If user programs will be linked with libmpi then skip this test,
+  # because we can't test static linking since libmpi is available
+  # only as a shared object.  Ideally we'd be able to decide this on
+  # a compopts-by-compopts basis, but we can't do that yet.
+  #
+  echo True
 elif $CHPL_HOME/util/printchplenv --make --all --internal \
      | grep CHPL_MAKE_THIRD_PARTY_LINK_ARGS \
      | grep -q -e '-lnuma' ; then


### PR DESCRIPTION
On linux64 platforms the `static_dynamic` linking test produces linker
errors for its static modes when libmpi is needed, because that is only
available as a shared object.  Skip it in those configurations.  (Note
that this will also skip it on, say, a Cray XC where there actually is a
static MPI library, but we don't run this test on that platform now and
don't seem likely to start doing so.)