### PR TITLE
Fix c2chapel to emit c_int for enum variable declarations

### DIFF
--- a/tools/c2chapel/c2chapel.py
+++ b/tools/c2chapel/c2chapel.py
@@ -162,6 +162,8 @@ def getDeclName(decl):
         name = inner.name
     elif type(inner) == c_ast.Decl:
         name = inner.name
+    elif type(inner) == c_ast.Enum:
+        name = "c_int"
     else:
         raise Exception("Unhandled node type: " + str(type(inner)))
     return name

--- a/tools/c2chapel/test/enumVar.chpl
+++ b/tools/c2chapel/test/enumVar.chpl
@@ -1,0 +1,14 @@
+// Generated with c2chapel version 0.1.0
+
+// Header given to c2chapel:
+require "enumVar.h";
+
+// Note: Generated with fake std headers
+
+// Enum: E
+extern const UP :c_int;
+extern const DOWN :c_int;
+
+
+extern var tmp : c_int;
+

--- a/tools/c2chapel/test/enumVar.h
+++ b/tools/c2chapel/test/enumVar.h
@@ -1,0 +1,3 @@
+enum E {UP, DOWN};
+
+enum E tmp;


### PR DESCRIPTION
This is a quick fix for `c2chapel` to address #12000. 