### PR TITLE
Make sure we build the C backend even when CHPL_LLVM_CODEGEN is set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,17 +71,15 @@ parser: FORCE
 	cd compiler && $(MAKE) parser
 
 modules: FORCE
-	cd modules && $(MAKE)
+	cd modules && CHPL_LLVM_CODEGEN=0 $(MAKE)
 	-@if [ ! -z `${NEEDS_LLVM_RUNTIME}` ]; then \
-	. ${CHPL_MAKE_HOME}/util/config/set_clang_included.bash && \
-	cd modules && $(MAKE) ; \
+	cd modules && CHPL_LLVM_CODEGEN=1 $(MAKE) ; \
 	fi
 
 runtime: FORCE
-	cd runtime && $(MAKE)
+	cd runtime && CHPL_LLVM_CODEGEN=0 $(MAKE)
 	-@if [ ! -z `${NEEDS_LLVM_RUNTIME}` ]; then \
-	. ${CHPL_MAKE_HOME}/util/config/set_clang_included.bash && \
-	cd runtime && $(MAKE) ; \
+	cd runtime && CHPL_LLVM_CODEGEN=1 $(MAKE) ; \
 	fi
 
 third-party: FORCE
@@ -91,19 +89,17 @@ third-party-try-opt: third-party-try-re2 third-party-try-gmp
 
 third-party-try-re2: FORCE
 	-@if [ -z "$$CHPL_REGEXP" ]; then \
-	cd third-party && $(MAKE) try-re2; \
+	cd third-party && CHPL_LLVM_CODEGEN=0 $(MAKE) try-re2; \
 	if [ ! -z `${NEEDS_LLVM_RUNTIME}` ]; then \
-	. ${CHPL_MAKE_HOME}/util/config/set_clang_included.bash && \
-	$(MAKE) try-re2; \
+	CHPL_LLVM_CODEGEN=1 $(MAKE) try-re2; \
 	fi \
 	fi
 
 third-party-try-gmp: FORCE
 	-@if [ -z "$$CHPL_GMP" ]; then \
-	cd third-party && $(MAKE) try-gmp; \
+	cd third-party && CHPL_LLVM_CODEGEN=0 $(MAKE) try-gmp; \
 	if [ ! -z `${NEEDS_LLVM_RUNTIME}` ]; then \
-	. ${CHPL_MAKE_HOME}/util/config/set_clang_included.bash && \
-	$(MAKE) try-gmp; \
+	CHPL_LLVM_CODEGEN=1 $(MAKE) try-gmp; \
 	fi \
 	fi
 
@@ -189,7 +185,11 @@ depend:
 	@echo "make depend has been deprecated for the time being"
 
 check:
-	@+CHPL_HOME=$(CHPL_MAKE_HOME) bash $(CHPL_MAKE_HOME)/util/test/checkChplInstall
+	@+CHPL_HOME=$(CHPL_MAKE_HOME) CHPL_LLVM_CODEGEN=0 bash $(CHPL_MAKE_HOME)/util/test/checkChplInstall
+	@+if [ ! -z `${NEEDS_LLVM_RUNTIME}` ]; then \
+	CHPL_HOME=$(CHPL_MAKE_HOME) CHPL_LLVM_CODEGEN=1 bash $(CHPL_MAKE_HOME)/util/test/checkChplInstall ; \
+	fi
+
 
 check-chpldoc: chpldoc third-party-test-venv
 	@bash $(CHPL_MAKE_HOME)/util/test/checkChplDoc

--- a/util/config/set_clang_included.bash
+++ b/util/config/set_clang_included.bash
@@ -1,4 +1,0 @@
-# This should be sourced
-export CHPL_ORIG_TARGET_COMPILER=`$CHPL_MAKE_HOME/util/chplenv/chpl_compiler.py --target`
-export CHPL_TARGET_COMPILER=clang-included
-

--- a/util/test/checkChplInstall
+++ b/util/test/checkChplInstall
@@ -164,8 +164,16 @@ chpl_launcher="$($CHPL_HOME/util/chplenv/chpl_launcher.py)"
 # Necessary to suppress warnings when WARNINGS=1 (e.g. nightly build settings)
 COMP_FLAGS="--cc-warnings"
 
+backend="C"
+if [ ${CHPL_LLVM_CODEGEN:-0} -ne 0 ]; then
+  backend="LLVM"
+fi
+
 # Compile test job into temporary directory
 log_info "Compiling \$CHPL_HOME/${REL_TEST_DIR}/${TEST_JOB}.chpl"
+
+log_info "Compiling with $backend backend"
+
 TEST_COMP_OUT=$( ${CHPL_BIN} ${TEST_DIR}/${TEST_JOB}.chpl ${COMP_FLAGS} -o ${TMP_TEST_DIR}/${TEST_JOB} 2>&1 )
 COMPILE_STATUS=$?
 


### PR DESCRIPTION
Previously, if `CHPL_LLVM_CODEGEN` was set we would build the
runtime/third-party/modules for llvm twice and never build things for
the C backend. To fix this, do our 2 builds with `CHPL_LLVM_CODEGEN=0`
and then `CHPL_LLVM_CODEGEN=1`. This also allows us to stop using
set_clang_included since CHPL_LLVM_CODEGEN=1 has the same impact.

This also reverts #11995, now that the underlying problem is resolved (which
was originally added in #11988.)

This change should help with the transition to `--llvm` as the default
