### PR TITLE
Remove aarch64 cross-compile support from our GASNet Makefile

### DIFF
--- a/third-party/gasnet/Makefile
+++ b/third-party/gasnet/Makefile
@@ -65,14 +65,7 @@ XTRA_CONFIG_COMMAND=cp --update $(GASNET_SUBDIR)/other/contrib/$(CHPL_GASNET_CFG
 XTRA_POST_INSTALL_COMMAND=rm -f $(GASNET_SUBDIR)/$(CHPL_GASNET_CFG_SCRIPT)
 else
 
-ifeq ($(CHPL_MAKE_TARGET_PLATFORM),aarch64)
-CHPL_GASNET_CFG_OPTIONS += --enable-pthreads
-CHPL_GASNET_CFG_SCRIPT=cross-configure-aarch64-linux
-XTRA_CONFIG_COMMAND=cp --update $(GASNET_SUBDIR)/other/contrib/$(CHPL_GASNET_CFG_SCRIPT) $(GASNET_SUBDIR)
-XTRA_POST_INSTALL_COMMAND=rm -f $(GASNET_SUBDIR)/$(CHPL_GASNET_CFG_SCRIPT)
-else
 CHPL_GASNET_CFG_SCRIPT=configure
-endif
 endif
 
 # Build amudprun for the host platform and replace the default one that was


### PR DESCRIPTION
This code should have been removed as part of b7a062e568 (which removed
the cross configure script this code was calling) but I missed it.
Remove it now.