### PR TITLE
Fix support for ugni under llvm

### DIFF
--- a/runtime/src/comm/ugni/Makefile.share
+++ b/runtime/src/comm/ugni/Makefile.share
@@ -42,7 +42,7 @@ COMM_LAUNCHER_OBJS = \
 
 
 ifeq ($(CHPL_MAKE_COMPILER), clang-included)
-  ifneq (, $(filter cray-prgenv-%,$(CHPL_ORIG_TARGET_COMPILER)))
+  ifneq (, $(filter cray-prgenv-%,$(CHPL_MAKE_ORIG_TARGET_COMPILER)))
     # if we're clang-included for a cray-prgenv-* build,
     # gather some extra include paths
 


### PR DESCRIPTION
In #12003 we stopped setting `CHPL_ORIG_TARGET_COMPILER` for the
runtime/3p/modules build in favor of setting `CHPL_LLVM_CODEGEN=1`.
This broke the ugni build because we used `CHPL_ORIG_TARGET_COMPILER`.
Now, instead of checking `CHPL_ORIG_TARGET_COMPILER` in our ungi
Makefile check `CHPL_MAKE_ORIG_TARGET_COMPILER`, which will be set as a
result of `CHPL_LLVM_CODEGEN=1`