### PR TITLE
Stop running `make check` for llvm when llvm is built

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,11 +185,7 @@ depend:
 	@echo "make depend has been deprecated for the time being"
 
 check:
-	@+CHPL_HOME=$(CHPL_MAKE_HOME) CHPL_LLVM_CODEGEN=0 bash $(CHPL_MAKE_HOME)/util/test/checkChplInstall
-	@+if [ ! -z `${NEEDS_LLVM_RUNTIME}` ]; then \
-	CHPL_HOME=$(CHPL_MAKE_HOME) CHPL_LLVM_CODEGEN=1 bash $(CHPL_MAKE_HOME)/util/test/checkChplInstall ; \
-	fi
-
+	@+CHPL_HOME=$(CHPL_MAKE_HOME) bash $(CHPL_MAKE_HOME)/util/test/checkChplInstall
 
 check-chpldoc: chpldoc third-party-test-venv
 	@bash $(CHPL_MAKE_HOME)/util/test/checkChplDoc


### PR DESCRIPTION
We tried to expand our testing coverage of llvm by doing `make check`
for llvm anytime the llvm backend is built in #11988/#12003. Revert that
here because the llvm backend doesn't currently work for GASNet on
Crays (https://github.com/chapel-lang/chapel/issues/12011)