### PR TITLE
Use NAN and INFINITY in this test to make it more portable

### DIFF
--- a/test/types/real/nan-comparisons.chpl
+++ b/test/types/real/nan-comparisons.chpl
@@ -1,6 +1,6 @@
-var nan = 0.0 / 0.0;
-var inf = 1.0 / 0.0;
-var neginf = (-1.0) / 0.0;
+var nan = NAN;
+var inf = INFINITY;
+var neginf = -INFINITY;
 
 writeln("isnan(nan) ", isnan(nan));
 


### PR DESCRIPTION
Was seeing PGI compile time errors for divide by zero.
Using NAN and INFINITY allows the test to pass on PGI.

Trivial and not reviewed.