### PR TITLE
Add perf annotations for 2019-01-10

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -353,6 +353,17 @@ all:
       config: 16 node XC
   12/04/18:
     - Set up gcc 8.2 as default gcc for nightly testing (#11762)
+  12/07/18:
+    - text: Optimize remote task spawning under ugni (#11799)
+      config: 16 node XC
+  12/13/18:
+    - text: Decrement the CQ counter when we consume the CQ event in ugni (#11875)
+      config: 16 node XC
+  01/04/19:
+    - text: Improve how we align and pad comm domains in ugni (#11973)
+      config: 16 node XC
+  01/07/19:
+    - Default to cstdlib atomics for gcc >= 5 (#11963)
 
 
 AllCompTime:


### PR DESCRIPTION
Add annotations for:
 - [Task spawning improvements](https://chapel-lang.org/perf/16-node-xc/?startdate=2018/12/01&enddate=2018/12/12&configs=gnuugniqthreads&graphs=doeluleshdensetimesecsedov15oct,emptyremotetaskspawntime,remotetaskspawntime) under ugni (#11799)
 - [Misc regressions/fixes](https://chapel-lang.org/perf/16-node-xc/?startdate=2018/12/06&enddate=2019/01/08&configs=gnuugniqthreads&graphs=hpccraatomicsperfgupsn233,hpccraonperfgupsn233,hpccrarmoperfgupsn233,doeluleshdensetimesecsedov15oct,remoteamoperformance) under ugni (#11875, #11973)
 - [Misc improvements and regressions](https://chapel-lang.org/perf/chapcs/?startdate=2018/12/30&enddate=2019/01/12&graphs=hpccffttime,arrayviewcreation,chameneosreduxshootoutbenchmarkn6000000,meteorshootoutbenchmarkn2098,nbodyvariations,buildingupassociativedomains,passingandreturningstrings) from cstdlib atomics under gcc (#11963)