### PR TITLE
Fix bug in domain rank comparison for rank-variant domains

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -2063,20 +2063,28 @@ module ChapelArray {
 
   inline proc ==(d1: domain, d2: domain) where isRectangularDom(d1) &&
                                                         isRectangularDom(d2) {
-    if d1._value.rank != d2._value.rank then return false;
-    if d1._value == d2._value then return true;
-    for param i in 1..d1._value.rank do
-      if (d1.dim(i) != d2.dim(i)) then return false;
-    return true;
+    if d1._value.rank != d2._value.rank {
+      return false;
+    } else if d1._value == d2._value {
+      return true;
+    } else {
+      for param i in 1..d1._value.rank do
+        if (d1.dim(i) != d2.dim(i)) then return false;
+      return true;
+    }
   }
 
   inline proc !=(d1: domain, d2: domain) where isRectangularDom(d1) &&
                                                         isRectangularDom(d2) {
-    if d1._value.rank != d2._value.rank then return true;
-    if d1._value == d2._value then return false;
-    for param i in 1..d1._value.rank do
-      if (d1.dim(i) != d2.dim(i)) then return true;
-    return false;
+    if d1._value.rank != d2._value.rank {
+      return true;
+    } else if d1._value == d2._value {
+      return false;
+    } else {
+      for param i in 1..d1._value.rank do
+        if (d1.dim(i) != d2.dim(i)) then return true;
+      return false;
+    }
   }
 
   inline proc ==(d1: domain, d2: domain) where (isAssociativeDom(d1) &&

--- a/test/domains/operators/domainComparison.chpl
+++ b/test/domains/operators/domainComparison.chpl
@@ -1,0 +1,5 @@
+var D1 = {1..10};
+var D2 = {1..10, 1..3};
+
+writeln(D1 == D2);
+writeln(D1 != D2);

--- a/test/domains/operators/domainComparison.good
+++ b/test/domains/operators/domainComparison.good
@@ -1,0 +1,2 @@
+false
+true


### PR DESCRIPTION
Fix a bug where comparing domains with different ranks generated a compiler error.

This happens because a `dim()` comparison is made later in the comparison, and the compiler's control flow analysis does not prune this expression despite taking place after a param-conditional return. This issue is fixed by restructuring the comparisons into explicit `if/else if/ else` blocks.

Added a test for this behavior.

- [x] linux64 testing