### PR TITLE
Fix a syntax error in Search module docs

### DIFF
--- a/modules/packages/Search.chpl
+++ b/modules/packages/Search.chpl
@@ -42,7 +42,7 @@ module Search {
    General purpose searching interface for searching through a 1D array.
    For pre-sorted arrays, denoted by passing ``sorted=true`` as an argument,
    this function wraps :proc:`binarySearch`, otherwise it wraps
-   :proc`linearSearch`.
+   :proc:`linearSearch`.
 
    :arg Data: The array to be searched
    :type Data: [] `eltType`


### PR DESCRIPTION
Fixes the error shown [here](https://chapel-lang.org/docs/1.18/modules/packages/Search.html?highlight=linearsearch#Search.search).