### PR TITLE
Remove AggregateType::defaultInitializer field

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -48,6 +48,7 @@ AggregateType::AggregateType(AggregateTag initTag) :
 
   typeConstructor     = NULL;
   hasUserDefinedInit  = false;
+  builtDefaultInit    = false;
   initializerResolved = false;
   iteratorInfo        = NULL;
   doc                 = NULL;

--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -47,7 +47,6 @@ AggregateType::AggregateType(AggregateTag initTag) :
   unmanagedClass      = NULL;
 
   typeConstructor     = NULL;
-  defaultInitializer  = NULL;
   hasUserDefinedInit  = false;
   initializerResolved = false;
   iteratorInfo        = NULL;
@@ -1393,8 +1392,7 @@ ArgSymbol* AggregateType::insertGenericArg(FnSymbol*  fn,
 }
 
 void AggregateType::buildDefaultInitializer() {
-  if ((defaultInitializer                       == NULL ||
-      strcmp(defaultInitializer->name, "init") !=    0) &&
+  if (builtDefaultInit == false &&
       symbol->hasFlag(FLAG_REF) == false) {
     SET_LINENO(this);
     FnSymbol*  fn    = new FnSymbol("init");
@@ -1429,8 +1427,6 @@ void AggregateType::buildDefaultInitializer() {
 
       DefExpr* def = new DefExpr(fn);
 
-      defaultInitializer = fn;
-
       symbol->defPoint->insertBefore(def);
 
       fn->setMethod(true);
@@ -1456,6 +1452,7 @@ void AggregateType::buildDefaultInitializer() {
       USR_FATAL(this, "Unable to generate initializer for type '%s'", this->symbol->name);
     }
 
+    builtDefaultInit = true;
   }
 }
 
@@ -1605,29 +1602,28 @@ bool AggregateType::addSuperArgs(FnSymbol*                    fn,
       CallExpr* base         = new CallExpr(".", superPortion, initPortion);
       CallExpr* superCall    = new CallExpr(base);
 
-      if (parent->hasUserDefinedInit == false) {
+      if (parent->hasUserDefinedInit == false && parent != dtObject) {
         // We want to call the compiler-generated all-fields initializer
 
         // First, ensure we have a default initializer for the parent
-        if (parent->defaultInitializer == NULL) {
-          // ... but only if it is valid to do so
-          if (parent->wantsDefaultInitializer() == true) {
-            parent->buildDefaultInitializer();
+        if (parent->builtDefaultInit == false && parent->wantsDefaultInitializer()) {
+          parent->buildDefaultInitializer();
+        }
+
+        // Otherwise, we are good to go!
+        FnSymbol* defaultInit = NULL;
+        forv_Vec(FnSymbol, method, parent->methods) {
+          if (method->isDefaultInit()) {
+            defaultInit = method;
+            break;
           }
         }
 
-        if (parent->defaultInitializer == NULL) {
-          // The parent might have inherited from a class that defines
-          // any initializer but not one without arguments.
-          // In this case, we shouldn't define a default initializer
-          // for this class either.
+        if (defaultInit == NULL) {
           retval = false;
-
         } else {
-          // Otherwise, we are good to go!
-
           // Add an argument per argument in the parent initializer
-          for_formals(formal, parent->defaultInitializer) {
+          for_formals(formal, defaultInit) {
             if (formal->type                   == dtMethodToken ||
                 formal->hasFlag(FLAG_ARG_THIS) == true) {
 
@@ -1648,11 +1644,6 @@ bool AggregateType::addSuperArgs(FnSymbol*                    fn,
           }
         }
 
-      } else {
-        INT_ASSERT(parent->hasUserDefinedInit == true);
-
-        // We want to call a user-defined no-argument initializer.
-        // Insert no arguments
       }
 
       fn->body->insertAtHead(superCall);

--- a/compiler/AST/baseAST.cpp
+++ b/compiler/AST/baseAST.cpp
@@ -226,10 +226,6 @@ void cleanAst() {
       }
 
       if (AggregateType* ct = toAggregateType(ts->type)) {
-        if (ct->defaultInitializer               != NULL &&
-            isAliveQuick(ct->defaultInitializer) == false) {
-          ct->defaultInitializer = NULL;
-        }
 
         if (ct->hasDestructor()                  == true &&
             isAliveQuick(ct->getDestructor())    == false) {

--- a/compiler/include/AggregateType.h
+++ b/compiler/include/AggregateType.h
@@ -170,7 +170,7 @@ public:
 
   FnSymbol*                   typeConstructor;
 
-  FnSymbol*                   defaultInitializer;
+  bool                        builtDefaultInit;
 
   AggregateType*              instantiatedFrom;
 

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5651,7 +5651,7 @@ static void resolveNew(CallExpr* newExpr) {
 
   if (SymExpr* typeExpr = resolveNewFindTypeExpr(newExpr)) {
     if (Type* type = resolveTypeAlias(typeExpr)) {
-      if (AggregateType* at = toAggregateType(type)) {
+      if (isAggregateType(type)) {
 
         resolveNewWithInitializer(newExpr, manager);
 

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -3225,6 +3225,10 @@ static FnSymbol* resolveForwardedCall(CallInfo& info, bool checkOnly) {
   if (0 == memcmp(ignorePrefix, calledName, strlen(ignorePrefix)))
     return NULL;
 
+  if (0 == strcmp(calledName, "chpl__promotionType")) {
+    return NULL;
+  }
+
   // Detect cycles
   detectForwardingCycle(call);
 

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -1938,8 +1938,17 @@ static void markArraysOfBorrows(AggregateType* at);
 void resolveTypeWithInitializer(AggregateType* at, FnSymbol* fn) {
   at->initializerResolved = true;
 
+  // TODO: this is a hack to allow for further resolution of fields with very
+  // simple type-exprs (e.g. "var x : T"). This allows the compiler to resolve
+  // the promotion type for an owned class.
+  //
+  // Long-term, we should organize the AST such that we can immediately resolve
+  // all non-generic fields once the type is fully instantiated.
+  //
+  // An alternative would be to resolve the promotion type once all fields are
+  // initialized (and organizing the AST so that situation can be recognized).
   for_fields(field, at) {
-    if (field->type == dtUnknown) {
+    if (field->type == dtUnknown && field->defPoint->exprType != NULL) {
       field->type = field->defPoint->exprType->typeInfo();
     }
   }

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -1936,6 +1936,13 @@ static void checkForInfiniteRecord(AggregateType* at) {
 static void markArraysOfBorrows(AggregateType* at);
 
 void resolveTypeWithInitializer(AggregateType* at, FnSymbol* fn) {
+  at->initializerResolved = true;
+
+  for_fields(field, at) {
+    if (field->type == dtUnknown) {
+      field->type = field->defPoint->exprType->typeInfo();
+    }
+  }
 
   if (isRecord(at)) {
     checkForInfiniteRecord(at);
@@ -3207,12 +3214,6 @@ static FnSymbol* resolveForwardedCall(CallInfo& info, bool checkOnly) {
   // Don't forward forwarding expr (infinite loop ensues)
   const char* ignorePrefix = "chpl_forwarding_expr";
   if (0 == memcmp(ignorePrefix, calledName, strlen(ignorePrefix)))
-    return NULL;
-
-  // This is a workaround for resolvePromotionType being called
-  // when some fields have unknown type. A better solution
-  // is preferred.
-  if (0 == strcmp(calledName, "chpl__promotionType"))
     return NULL;
 
   // Detect cycles

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -3225,6 +3225,9 @@ static FnSymbol* resolveForwardedCall(CallInfo& info, bool checkOnly) {
   if (0 == memcmp(ignorePrefix, calledName, strlen(ignorePrefix)))
     return NULL;
 
+  // This is a workaround for resolvePromotionType being called
+  // when some fields have unknown type. A better solution
+  // is preferred.
   if (0 == strcmp(calledName, "chpl__promotionType")) {
     return NULL;
   }

--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -1844,19 +1844,12 @@ static Expr* createFunctionAsValue(CallExpr *call) {
 
   wrapper->addFlag(FLAG_INLINE);
 
-  if (ct->wantsDefaultInitializer()) {
-    wrapper->insertAtTail(new CallExpr(PRIM_RETURN,
-                                       new CallExpr(PRIM_CAST,
-                                                    parent->symbol,
-                                                    new CallExpr(PRIM_NEW,
-                                                                 new NamedExpr(astr_chpl_manager, new SymExpr(dtUnmanaged->symbol)),
-                                                                 new SymExpr(ct->symbol)))));
-  } else {
-    wrapper->insertAtTail(new CallExpr(PRIM_RETURN,
-                                       new CallExpr(PRIM_CAST,
-                                                    parent->symbol,
-                                                    new CallExpr(ct->defaultInitializer))));
-  }
+  wrapper->insertAtTail(new CallExpr(PRIM_RETURN,
+                                     new CallExpr(PRIM_CAST,
+                                                  parent->symbol,
+                                                  new CallExpr(PRIM_NEW,
+                                                               new NamedExpr(astr_chpl_manager, new SymExpr(dtUnmanaged->symbol)),
+                                                               new SymExpr(ct->symbol)))));
 
   call->getStmtExpr()->insertBefore(new DefExpr(wrapper));
 

--- a/test/types/records/init/nested-empty-record.bad
+++ b/test/types/records/init/nested-empty-record.bad
@@ -1,7 +1,0 @@
-nested-empty-record.chpl:29: internal error: AST-SYM-BOL-0074 chpl version 1.19.0 pre-release (cfeb6592b3)
-
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
-and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
-please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
-

--- a/test/types/records/init/nested-empty-record.future
+++ b/test/types/records/init/nested-empty-record.future
@@ -1,2 +1,0 @@
-bug: nested record type is pruned
-#9773


### PR DESCRIPTION
This field has existed due to the assumption that there will only be one compiler-generated initializer. This may change in the future, so removing this field now will save us some time going forward.

This field has been replaced by the following patterns:
- searching for an initializer in AggretateType::methods
- using type's instantiation point instead of default initializer's instantiation point

Fortunately most uses could simply be removed as dead code, having been left in place during the transition from constructors.

Testing:
- [x] local + futures
- [x] gasnet + futures
- [x] valgrind