### PR TITLE
Add a skipif for new test

### DIFF
--- a/test/deprecated/arch-cpu/SKIPIF
+++ b/test/deprecated/arch-cpu/SKIPIF
@@ -1,0 +1,3 @@
+# These tests assume x86-64
+CHPL_TARGET_PLATFORM != linux64
+CHPL_TARGET_ARCH != x86_64


### PR DESCRIPTION
Otherwise it fails on linux32/cygwin32.

Trivial and not reviewed.