### PR TITLE
Add a test that passes a Fortran array to Chapel and converts it to a DR array

### DIFF
--- a/compiler/codegen/symbol.cpp
+++ b/compiler/codegen/symbol.cpp
@@ -1959,7 +1959,7 @@ void FnSymbol::codegenFortran(int indent) {
   if (info->cfile) {
     FILE* outfile = info->cfile;
     if (fGenIDS)
-      fprintf(outfile, "%*s! %d", indent, "", this->id);
+      fprintf(outfile, "%*s! %d\n", indent, "", this->id);
     const char* subOrProc = retType != dtVoid ? "function" : "subroutine";
     fprintf(outfile, "%*s%s %s(", indent, "", subOrProc, this->cname);
     bool first = true;

--- a/test/interop/fortran/fortArrayToDefaultRectangular/ISO_Fortran_binding.chpl
+++ b/test/interop/fortran/fortArrayToDefaultRectangular/ISO_Fortran_binding.chpl
@@ -1,0 +1,1 @@
+../multidimArray/ISO_Fortran_binding.chpl

--- a/test/interop/fortran/fortArrayToDefaultRectangular/Makefile
+++ b/test/interop/fortran/fortArrayToDefaultRectangular/Makefile
@@ -1,0 +1,1 @@
+../multidimArray/Makefile

--- a/test/interop/fortran/fortArrayToDefaultRectangular/chapelProcs.chpl
+++ b/test/interop/fortran/fortArrayToDefaultRectangular/chapelProcs.chpl
@@ -1,0 +1,55 @@
+use ISO_Fortran_binding;
+
+export proc chpl_library_init_ftn() {
+  extern proc chpl_library_init(argc: c_int, argv: c_ptr(c_ptr(c_char)));
+  var filename = c"fake";
+  chpl_library_init(1, c_ptrTo(filename): c_ptr(c_ptr(c_char)));;
+  chpl__init_chapelProcs();
+}
+
+/* Allow accessing the array using normal Chapel syntax. This uses the
+   `CFI_address` function from the `ISO_Fortran_binding` module to get
+   the address of element `idx`, then returns a dereference of that address.
+   It assumes that the array contains `real(64)` values, but hopefully we
+   can relax that assumption.
+
+   A[i,j] = ...;
+   var val = A[i,j];
+ */
+proc CFI_cdesc_t.this(idx:int...?rank) ref {
+  assert(this.rank == rank);
+  var subscripts: [0..#rank] CFI_index_t;
+  for param i in 1..rank {
+    subscripts[i-1] = idx[i]: CFI_index_t;
+  }
+  var x = CFI_address(this, c_ptrTo(subscripts)): c_ptr(real);
+  return x.deref();
+}
+
+proc fortranArrayToChapelArray(ref FA: CFI_cdesc_t, param rank, type eltType) {
+
+  assert(CFI_is_contiguous(FA) == 1);
+
+  var dims: rank*range;
+  for param i in 1..rank {
+    dims[i] = 0..#FA.dim[i-1].extent;
+  }
+  var D = {(...dims)};
+  var A = D.buildArrayWith(eltType,
+                          FA.base_addr: _ddata(eltType),
+                          D.numIndices);
+  A._unowned = true;
+  return A;
+}
+
+export proc takesArray(ref FA: CFI_cdesc_t) {
+
+  assert(FA.rank == 2);
+  assert(FA.ctype == CFI_type_double);
+
+  ref A = fortranArrayToChapelArray(FA, 2, real);
+
+  forall (i,j) in A.domain {
+    A[i,j] = i*100+j;
+  }
+}

--- a/test/interop/fortran/fortArrayToDefaultRectangular/chapelProcs.compopts
+++ b/test/interop/fortran/fortArrayToDefaultRectangular/chapelProcs.compopts
@@ -1,0 +1,1 @@
+--library-fortran --ccflags=-wd167

--- a/test/interop/fortran/fortArrayToDefaultRectangular/chapelProcs.good
+++ b/test/interop/fortran/fortArrayToDefaultRectangular/chapelProcs.good
@@ -1,0 +1,6 @@
+chapelProcs.chpl:45: In function 'takesArray':
+chapelProcs.chpl:45: warning: Unknown Fortran KIND generating interface for C type: _ref_CFI_cdesc_t
+chapelProcs.chpl:45: warning: Unknown Fortran type generating interface for C type: _ref_CFI_cdesc_t
+  0.000000000000000E+000   1.00000000000000        2.00000000000000     
+   100.000000000000        101.000000000000        102.000000000000     
+   200.000000000000        201.000000000000        202.000000000000     

--- a/test/interop/fortran/fortArrayToDefaultRectangular/chapelProcs.prediff
+++ b/test/interop/fortran/fortArrayToDefaultRectangular/chapelProcs.prediff
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+make clean

--- a/test/interop/fortran/fortArrayToDefaultRectangular/chapelProcs.preexec
+++ b/test/interop/fortran/fortArrayToDefaultRectangular/chapelProcs.preexec
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+make

--- a/test/interop/fortran/fortArrayToDefaultRectangular/chapelProcs.skipif
+++ b/test/interop/fortran/fortArrayToDefaultRectangular/chapelProcs.skipif
@@ -1,0 +1,1 @@
+../multidimArray/chapelProcs.skipif

--- a/test/interop/fortran/fortArrayToDefaultRectangular/passArrayToChapel.f90
+++ b/test/interop/fortran/fortArrayToDefaultRectangular/passArrayToChapel.f90
@@ -1,0 +1,1 @@
+../multidimArray/passArrayToChapel.f90

--- a/test/interop/fortran/multidimArray/ISO_Fortran_binding.chpl
+++ b/test/interop/fortran/multidimArray/ISO_Fortran_binding.chpl
@@ -130,7 +130,7 @@ module ISO_Fortran_binding {
     var version: c_int;
     var attribute: CFI_attribute_t;
     var rank: CFI_rank_t;
-    //var type: CFI_type_t;
+    extern "type" var ctype: CFI_type_t;
     var dim: c_ptr(CFI_dim_t);
   }
 /*


### PR DESCRIPTION
The test passes an array from Fortran to Chapel using the CFI_cdesc_t
descriptor and then converts it to a default rectangular array. It assigns
values to the array in a forall loop and then the Fortran code prints out
the updated values.

Fix a small bug when combining --gen-ids with --library-fortran.
Update CFI_cdesc_t record to use extern field renaming.