### PR TITLE
Fix missing lambda keyword

### DIFF
--- a/tools/c2chapel/c2chapel.py
+++ b/tools/c2chapel/c2chapel.py
@@ -111,7 +111,7 @@ foundTypes = set()
 chapelKeywords = set(["align","as","atomic","begin","break","by","class",
     "cobegin","coforall","config","const","continue","delete","dmapped","do",
     "domain","else","enum","except","export","extern","for","forall","if",
-    "in","index","inline","inout","iter","label","let","local","module","new",
+    "in","index","inline","inout","iter","label","lambda","let","local","module","new",
     "nil","noinit","on","only","otherwise","out","param","private","proc",
     "public","record","reduce","ref","require","return","scan","select",
     "serial","single","sparse","subdomain","sync","then","type","union","use",

--- a/tools/c2chapel/test/chapelKeywords.chpl
+++ b/tools/c2chapel/test/chapelKeywords.chpl
@@ -9,6 +9,8 @@ extern proc foo(out_arg : c_int, ref_arg : c_char) : c_int;
 
 // Unable to generate function 'coforall' because its name is a Chapel keyword
 
+extern proc foo2(lambda_arg : c_double) : c_int;
+
 // ==== c2chapel typedefs ====
 
 // Fields omitted because one or more of the identifiers is a Chapel keyword

--- a/tools/c2chapel/test/chapelKeywords.h
+++ b/tools/c2chapel/test/chapelKeywords.h
@@ -12,3 +12,5 @@ typedef struct {
 typedef struct {
   int index;
 } bar;
+
+int foo2(double lambda);


### PR DESCRIPTION
c2chapel was missing the `lambda` keyword. This simple PR adds this in, and validates with a simple test.