### PR TITLE
Work around a bug in some system <atomic> headers under clang

### DIFF
--- a/runtime/include/qio/qbuffer.h
+++ b/runtime/include/qio/qbuffer.h
@@ -39,6 +39,7 @@
 
 typedef uint_least64_t qb_refcnt_base_t;
 #if defined(__cplusplus) && defined(QIO_USE_STD_ATOMICS_REF_CNT)
+// work around for issues with older GCC cstdlib atomics
 #include <atomic>
 typedef std::atomic<qb_refcnt_base_t> qbytes_refcnt_t;
 #define ATOMIC_INIT(a, val) a.store(val)

--- a/runtime/src/qio/regexp/re2/re2-interface.cc
+++ b/runtime/src/qio/regexp/re2/re2-interface.cc
@@ -24,16 +24,22 @@
 
 #include <limits>
 #include <pthread.h>
+#include <stdlib.h>
+#include <stdio.h>
 
-  #include <stdlib.h>
-  #include <stdio.h>
+// We have run into issues when using our chpl-atomics.h file from C++ code
+// under CHPL_ATOMICS=cstdlib. As a workaround, just use std::atomic and avoid
+// bringing in the Chapel implementation. We know this is safe in this case
+// because re2 itself requires std::atomics, and won't build without them.
+#define QIO_USE_STD_ATOMICS_REF_CNT 1
+
 #ifndef CHPL_RT_UNIT_TEST
-  #include "stdchplrt.h"
+#include "stdchplrt.h"
 #endif
-  #include "qio_regexp.h"
-  #include "qbuffer.h" // qio_strdup, refcount functions, qio_ptr_diff, etc
-  #include "qio.h" // for channel operations
-  #undef printf
+#include "qio_regexp.h"
+#include "qbuffer.h" // qio_strdup, refcount functions, qio_ptr_diff, etc
+#include "qio.h" // for channel operations
+#undef printf
 
 #include "re2/re2.h"
 


### PR DESCRIPTION
Clang prefers to use the system <atomic> header when possible. However,
the system headers provided by gcc<5 were incompatible with clang for
atomic_bool. This led to issues building our re2 shim and prevented us
from making `cstdlib` atomics the default under clang (#4536)

To work around this, avoid using the chpl-atomics.h shim and directly
use std::atomic to implement reference counting for the re2 shim. re2
requires std::atomic ops in order to build, so we know this is safe and
we're only using limited atomic ops that do not run into the system
header incompatibility. See #4534 for past attempts to work around this
issue.

This is a little weird, but it's relatively isolated and pretty small.
Our original plan was to use a configure-like check to see if the system
header was broken, but that got messy pretty quickly, and I find this to
be a cleaner solution. A slightly better fix might be to reimplement
reference counting in re2-interface.cc (or maybe use shared_ptr?) and
avoid bringing in C implementation.

This allows us to use cstdlib atomics under clang (and under
clang-included/llvm) when the system gcc is older than 5.0.

Resolves https://github.com/chapel-lang/chapel/issues/11956