### PR TITLE
Default to cstdlib atomics for clang when supported

### DIFF
--- a/util/chplenv/chpl_atomics.py
+++ b/util/chplenv/chpl_atomics.py
@@ -55,7 +55,7 @@ def get(flag='target'):
                 if has_std_atomics(compiler_val):
                     atomics_val = 'cstdlib'
                 else:
-                   atomics_val = 'intrinsics'
+                    atomics_val = 'intrinsics'
             elif compiler_val == 'clang-included':
                 atomics_val = 'intrinsics'
 


### PR DESCRIPTION
This makes cstdlib atomics the default for clang if we detect that the
default compilation mode is at least C11 and `__STDC_NO_ATOMICS__` is
not defined.

This is almost identical to #4480, which we originally had to revert
because of some problems with older system headers. Those issues have
been worked around in #12040.

Testing with `CHPL_HOST_COMPILER=clang`: 
- hellos + atomic tests (runtime/configMatters/comm/atomic*.chpl types/atomic/)
  - [x] ubuntu 14.04 (gcc 4.8.4, clang 3.8)
  - [x] ubuntu 15.04 (gcc 4.9.2, clang 3.8)
  - [x] ubuntu 16.04 (gcc 5.4.0, clang 3.8)
  - [x] darwin 10.13.6 (High Sierra) (clang-1000.11.45.5)
  - [x] chapcs (broken sys headers) (gcc 4.8.5, clang 3.8 w/ sys headers)

* Full paratest:
  * [x] chapcs (gcc 8.2.0, clang 3.8)
