### PR TITLE
Fixes to allow for external Spack in Mason

### DIFF
--- a/tools/mason/MasonExternal.chpl
+++ b/tools/mason/MasonExternal.chpl
@@ -38,7 +38,7 @@ proc masonExternal(args: [] string) {
       exit(0);
     }
     else if args[2] == "--setup" {
-      if isDir(MASON_HOME + "/spack") then
+      if isDir(SPACK_ROOT) then
         throw new MasonError("Spack backend is already installed");
       else {
         setupSpack();
@@ -75,7 +75,7 @@ private proc specHelp() {
 }
 
 private proc spackInstalled() throws {
-  if !isDir(MASON_HOME + "/spack") {
+  if !isDir(SPACK_ROOT) {
     throw new MasonError("To use `mason external` call `mason external --setup`");
   }
   return true;

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -144,7 +144,7 @@ proc getSpackResult(cmd, quiet=false) : string throws {
     " && export PATH=\"$SPACK_ROOT/bin:$PATH\"" +
     " && . $SPACK_ROOT/share/spack/setup-env.sh && ";
     var splitCmd = prefix + cmd;
-    var process = spawnshell(splitCmd, stdout=PIPE,executable="bash");
+    var process = spawnshell(splitCmd, stdout=PIPE, executable="bash");
     
     for line in process.stdout.lines() {
       ret += line;

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -126,7 +126,7 @@ proc SPACK_ROOT : string {
   const envHome = getEnv("SPACK_ROOT");
   const default = MASON_HOME + "/.mason";
 
-  const spackRoot = if envHome != "" then envHome else default;
+  const spackRoot = if !envHome.isEmptyString() then envHome else default;
 
   return spackRoot;
 }

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -26,6 +26,8 @@ use TOML;
 use Path;
 use MasonEnv;
 
+config const useBash=false;
+
 /* Gets environment variables for spawn commands */
 extern proc getenv(name : c_string) : c_string;
 proc getEnv(name: string): string {
@@ -122,6 +124,14 @@ proc runWithStatus(command, show=true): int {
   }
 }
 
+proc SPACK_ROOT : string {
+  const envHome = getEnv("SPACK_ROOT");
+  const default = MASON_HOME + "/.mason";
+
+  const spackRoot = if envHome != "" then envHome else default;
+
+  return spackRoot;
+}
 
 /* uses spawnshell and the prefix to setup Spack before
    calling the spack command. This also returns the stdout
@@ -132,11 +142,12 @@ proc getSpackResult(cmd, quiet=false) : string throws {
   try {
 
 
-    var prefix = "export SPACK_ROOT=" + MASON_HOME + "/spack" +
-    " && export PATH=$SPACK_ROOT/bin:$PATH" +
-    " && source $SPACK_ROOT/share/spack/setup-env.sh && ";
+    var prefix = "export SPACK_ROOT=" + SPACK_ROOT +
+    " && export PATH=\"$SPACK_ROOT/bin:$PATH\"" +
+    " && . $SPACK_ROOT/share/spack/setup-env.sh && ";
     var splitCmd = prefix + cmd;
-    var process = spawnshell(splitCmd, stdout=PIPE);
+    const executable=if useBash then "/bin/bash" else "/bin/sh";
+    var process = spawnshell(splitCmd, stdout=PIPE,executable=executable);
     
     for line in process.stdout.lines() {
       ret += line;
@@ -158,12 +169,13 @@ proc getSpackResult(cmd, quiet=false) : string throws {
    TODO: get to work with Spawn */
 proc runSpackCommand(command) {
 
-  var prefix = "export SPACK_ROOT=" + MASON_HOME + "/spack" +
-    " && export PATH=$SPACK_ROOT/bin:$PATH" +
-    " && source $SPACK_ROOT/share/spack/setup-env.sh && ";
+  var prefix = "export SPACK_ROOT=" + SPACK_ROOT +
+    " && export PATH=\"$SPACK_ROOT/bin:$PATH\"" +
+    " && . $SPACK_ROOT/share/spack/setup-env.sh && ";
 
   var cmd = (prefix + command);
-  var sub = spawnshell(cmd, stderr=PIPE);
+  const executable=if useBash then "/bin/bash" else "/bin/sh";
+  var sub = spawnshell(cmd, stderr=PIPE, executable=executable);
   sub.wait();
 
   for line in sub.stderr.lines() {

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -26,8 +26,6 @@ use TOML;
 use Path;
 use MasonEnv;
 
-config const useBash=false;
-
 /* Gets environment variables for spawn commands */
 extern proc getenv(name : c_string) : c_string;
 proc getEnv(name: string): string {
@@ -146,8 +144,7 @@ proc getSpackResult(cmd, quiet=false) : string throws {
     " && export PATH=\"$SPACK_ROOT/bin:$PATH\"" +
     " && . $SPACK_ROOT/share/spack/setup-env.sh && ";
     var splitCmd = prefix + cmd;
-    const executable=if useBash then "/bin/bash" else "/bin/sh";
-    var process = spawnshell(splitCmd, stdout=PIPE,executable=executable);
+    var process = spawnshell(splitCmd, stdout=PIPE,executable="bash");
     
     for line in process.stdout.lines() {
       ret += line;
@@ -174,8 +171,7 @@ proc runSpackCommand(command) {
     " && . $SPACK_ROOT/share/spack/setup-env.sh && ";
 
   var cmd = (prefix + command);
-  const executable=if useBash then "/bin/bash" else "/bin/sh";
-  var sub = spawnshell(cmd, stderr=PIPE, executable=executable);
+  var sub = spawnshell(cmd, stderr=PIPE, executable="bash");
   sub.wait();
 
   for line in sub.stderr.lines() {


### PR DESCRIPTION
The main aim here is to allow for an external Spack installation.
If SPACK_ROOT is set, then the code uses that, instead of installing
a new version.

A few other minor fixes :
- When spawning a shell, we quote the PATH values to allow for spaces.
- Use . instead of source to run setup-env.sh to be POSIX compliant
  (especially on Ubuntu/Debian systems)
- Unfortunately, Spack's setup-env.sh uses bashisms (this is https://github.com/spack/spack/issues/4048),
  but for now, we work around this by always using bash