### PR TITLE
Fix support for cstdlib atomics under --llvm

### DIFF
--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2955,6 +2955,8 @@ void makeBinaryLLVM(void) {
     command += libName;
   }
 
+  // Clang doesn't automatically link against GNU's libatomic, so we need to
+  // bring it in. If we start using compiler-rt, this shouldn't be needed
   if (strcmp(CHPL_ATOMICS, "cstdlib") == 0 &&
       strcmp(CHPL_TARGET_PLATFORM, "darwin") != 0) {
     command += " -latomic";

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2955,7 +2955,8 @@ void makeBinaryLLVM(void) {
     command += libName;
   }
 
-  if (strcmp(CHPL_ATOMICS, "cstdlib") == 0) {
+  if (strcmp(CHPL_ATOMICS, "cstdlib") == 0 &&
+      strcmp(CHPL_TARGET_PLATFORM, "darwin") != 0) {
     command += " -latomic";
   }
 

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2955,6 +2955,10 @@ void makeBinaryLLVM(void) {
     command += libName;
   }
 
+  if (strcmp(CHPL_ATOMICS, "cstdlib") == 0) {
+    command += " -latomic";
+  }
+
   if( printSystemCommands ) {
     printf("%s\n", command.c_str());
     fflush(stdout); fflush(stderr);


### PR DESCRIPTION
Previously `CHPL_ATOMICS=cstdlib` with --llvm would fail at link time
with error messages like `undefined reference to 'atomic_thread_fence'`.
Here we just add `-latomic` to satisfy these references. 

Currently `-latomic` is being added manually by the compiler while assembling
llvm link args. An alternative solution would be to add it to
.lib/*/list-libraries (which the compiler already harvests link flags from)