### PR TITLE
Skip this test for the PGI compiler

### DIFF
--- a/test/types/real/nan-comparisons.skipif
+++ b/test/types/real/nan-comparisons.skipif
@@ -1,0 +1,2 @@
+# PGI compiler has a different idea for what nan <= nan does
+CHPL_TARGET_COMPILER<=pgi


### PR DESCRIPTION
The PGI C compiler seems to have a different idea of what nan <= nan should do than the other C compilers and than what we expect.