### PR TITLE
Removing unused variable

### DIFF
--- a/compiler/passes/externCResolve.cpp
+++ b/compiler/passes/externCResolve.cpp
@@ -100,8 +100,8 @@ static Expr* convertFixedSizeArrayToChplType(ModuleSymbol* module, const clang::
   if (size.getMinSignedBits() > 64)
     USR_FATAL("C array is too large");
 
-  int64_t isize = size.getSExtValue();
-  Symbol* isym = new_IntSymbol(isize, INT_SIZE_64);
+  //int64_t isize = size.getSExtValue();
+  //Symbol* isym = new_IntSymbol(isize, INT_SIZE_64);
   // this would make a tuple
   //return new CallExpr("*", new SymExpr(isym), eltTypeChapel);
 


### PR DESCRIPTION
PR #12004 added an unused variable in convertFixedSizeArrayToChplType which causes `make` failure in certain configurations. This PR comments it out because I have ongoing work that will change this code.

Trivial and not reviewed.