### PR TITLE
Prevent GASNet builds from triggering a qthread rebuild

### DIFF
--- a/third-party/Makefile
+++ b/third-party/Makefile
@@ -127,17 +127,12 @@ $(MASSIVETHREADS_INSTALL_DIR): $(MASSIVETHREADS_DEPEND)
 	rm -rf $(MASSIVETHREADS_INSTALL_DIR) && rm -rf $(MASSIVETHREADS_BUILD_DIR)
 	cd massivethreads && $(MAKE)
 
-# Qthreads may use hwloc and/or jemalloc, and its use of compileline
-# to get build options requires a completed GASNet build if we're
-# using that. Ensure they are built first.
+# Qthreads may use hwloc and/or jemalloc. Ensure they are built first.
 ifeq ($(CHPL_MAKE_HWLOC), hwloc)
 QTHREAD_OTHER_INSTALL_DIR_DEPS += $(HWLOC_INSTALL_DIR)
 endif
 ifeq ($(CHPL_MAKE_JEMALLOC), jemalloc)
 QTHREAD_OTHER_INSTALL_DIR_DEPS += $(JEMALLOC_INSTALL_DIR)
-endif
-ifeq ($(CHPL_MAKE_COMM), gasnet)
-QTHREAD_OTHER_INSTALL_DIR_DEPS += $(GASNET_INSTALL_DIR)
 endif
 qthread: $(QTHREAD_INSTALL_DIR)
 

--- a/third-party/qthread/Makefile
+++ b/third-party/qthread/Makefile
@@ -55,12 +55,17 @@ ifeq ($(CFLAGS_NEEDS_RT_INCLUDES), y)
   # seems to cause Chapel programs built with the result to hang during
   # exit when shutting down Qthreads.
   #
+  # Note that we call compileline with CHPL_COMM=none. Under
+  # CHPL_COMM=gasnet, compileline will fail if gasnet is not built, so
+  # in order to avoid ordering/dependencies just ignore the comm setting
+  # since it does not impact the qthreads build.
+  #
   # Throw COMPILELINE_STDERR_REDIRECT= if compileline failure is reported
   # and you want to see the stderr from that.
   #
   COMPILELINE_STDERR_REDIRECT=2> /dev/null
   INCS_DEFS := \
-    $(shell $(CHPL_MAKE_HOME)/util/config/compileline --includes-and-defines \
+    $(shell CHPL_COMM=none $(CHPL_MAKE_HOME)/util/config/compileline --includes-and-defines \
                $(COMPILELINE_STDERR_REDIRECT) \
             || echo compilelineFAILURE)
   ifneq (, $(findstring compilelineFAILURE,$(INCS_DEFS)))


### PR DESCRIPTION
In #10390 we started using `./compileline --includes-and-defines` in
order to get include paths and macro defines for qthreads build args.
Under `CHPL_COMM=gasnet`, compileline will fail if gasnet is not built,
so we set it up so that the qthreads build would depend on the gasnet
build. This resulted in building gasnet first, but as an unintentional
side-effect it also meant building different gasnet layers (or switching
from comm none to gasnet) would trigger a qthreads rebuild.

We don't actually need or want any gasnet includes paths/defines so this
updates things to just call compileline with `CHPL_COMM=none` and
removes the qthreads gasnet dependency.