### PR TITLE
Fix ofi comm layer bugs shown by full testing.

### DIFF
--- a/modules/internal/comm/ofi/NetworkAtomicTypes.chpl
+++ b/modules/internal/comm/ofi/NetworkAtomicTypes.chpl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2018 Cray Inc.
+ * Copyright 2004-2019 Cray Inc.
  * Other additional copyright holders may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,

--- a/modules/internal/comm/ofi/NetworkAtomicTypes.chpl
+++ b/modules/internal/comm/ofi/NetworkAtomicTypes.chpl
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2004-2018 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module NetworkAtomicTypes {
+  use NetworkAtomics;
+
+  private proc isSupported(type T) param {
+    return T == bool     ||
+           T ==  int(32) || T ==  int(64) ||
+           T == uint(32) || T == uint(64) ||
+           T == real(32) || T == real(64);
+  }
+
+  proc chpl__networkAtomicType(type T) type {
+    if T == bool           then return RAtomicBool;
+    else if isSupported(T) then return RAtomicT(T);
+    else                        return chpl__processorAtomicType(T);
+  }
+}

--- a/runtime/include/comm/ofi/chpl-comm-task-decls.h
+++ b/runtime/include/comm/ofi/chpl-comm-task-decls.h
@@ -47,25 +47,28 @@ typedef struct {
 //
 typedef uint8_t chpl_comm_amDone_t;
 
-struct chpl_comm_bundleData_op_t {
-  uint8_t op;                   // operation; must come first
+struct chpl_comm_bundleData_base_t {
+  uint8_t op;                   // operation
+  c_nodeid_t node;              // initiator's node
+#ifdef CHPL_COMM_DEBUG
+  uint64_t seq;
+  uint32_t crc32;
+#endif
 };
 
 struct chpl_comm_bundleData_execOn_t {
-  uint8_t op;                   // operation; must come first
+  struct chpl_comm_bundleData_base_t b;
   chpl_bool fast;               // do directly in AM handler; no task
   chpl_fn_int_t fid;            // function table index to call
   uint16_t argSize;             // #bytes in whole arg bundle
-  c_nodeid_t node;              // initiator's node
   c_sublocid_t subloc;          // target sublocale
   chpl_comm_amDone_t* pDone;    // initiator's 'done' flag; nonblocking if NULL
 };
 
 struct chpl_comm_bundleData_RMA_t {
-  uint8_t op;                   // operation; must come first
+  struct chpl_comm_bundleData_base_t b;
   void* addr;                   // address on AM target node
-  c_nodeid_t node;              // initiator's node
-  void* raddr;                  // initiator's address
+  void* raddr;                  // address on AM initiator's node
   size_t size;                  // number of bytes
   chpl_comm_amDone_t* pDone;    // initiator's 'done' flag; nonblocking if NULL
 };
@@ -81,11 +84,10 @@ typedef union {
 } chpl_amo_datum_t;
 
 struct chpl_comm_bundleData_AMO_t {
-  uint8_t op;                   // operation; must come first
+  struct chpl_comm_bundleData_base_t b;
   enum fi_op ofiOp;             // ofi AMO op
   enum fi_datatype ofiType;     // ofi object type
   int8_t size;                  // object size (bytes)
-  c_nodeid_t node;              // initiator's node
   void* obj;                    // object address on target node
   chpl_amo_datum_t operand1;    // first operand, if needed
   chpl_amo_datum_t operand2;    // second operand, if needed
@@ -94,7 +96,7 @@ struct chpl_comm_bundleData_AMO_t {
 };
 
 typedef union {
-  struct chpl_comm_bundleData_op_t op;
+  struct chpl_comm_bundleData_base_t b;
   struct chpl_comm_bundleData_execOn_t xo;
   struct chpl_comm_bundleData_RMA_t rma;
   struct chpl_comm_bundleData_AMO_t amo;

--- a/runtime/src/comm/ofi/comm-ofi-internal.h
+++ b/runtime/src/comm/ofi/comm-ofi-internal.h
@@ -93,6 +93,11 @@ char* chpl_comm_ofi_dbg_val(const void*, enum fi_datatype);
 
 #define DBG_VAL(pV, typ) chpl_comm_ofi_dbg_val(pV, typ)
 
+//#define DEBUG_CRC_MSGS
+#ifdef DEBUG_CRC_MSGS
+#include <libiberty.h>
+#endif
+
 #else // CHPL_COMM_DEBUG
 
 #define DBG_INIT()

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -1823,12 +1823,15 @@ void chpl_comm_put(void* addr, c_nodeid_t node, void* raddr,
                    size_t size, int32_t typeIndex, int32_t commID,
                    int ln, int32_t fn) {
   //
-  // addr and raddr are sanity checks; node==chpl_nodeID is supposed
-  // to be handled by our caller.
+  // Sanity checks, self-communication.
   //
   CHK_TRUE(addr != NULL);
   CHK_TRUE(raddr != NULL);
-  CHK_TRUE(node != chpl_nodeID);
+
+  if (node == chpl_nodeID) {
+    memmove(raddr, addr, size);
+    return;
+  }
 
   // Communications callback support
   if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_put)) {

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -2186,8 +2186,6 @@ chpl_comm_nb_handle_t ofi_amo(struct perTxCtxInfo_t* tcip,
   CHK_TRUE(tcip->txCtxHasCQ);  // (so far) only expect AMOs from workers
   waitForTxCQ(tcip, 1, FI_ATOMIC);
 
-  tciFree(tcip);
-
   if (myRes != result) {
     memcpy(result, myRes, resSize);
     freeBounceBuf(myRes);

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -1146,6 +1146,10 @@ void chpl_comm_make_progress(void) {
 void chpl_comm_execute_on(c_nodeid_t node, c_sublocid_t subloc,
                           chpl_fn_int_t fid,
                           chpl_comm_on_bundle_t *arg, size_t argSize) {
+  DBG_PRINTF(DBG_INTERFACE,
+             "chpl_comm_execute_on(%d, %d, %d, %p, %zd)",
+             (int) node, (int) subloc, (int) fid, arg, argSize);
+
   CHK_TRUE(node != chpl_nodeID); // handled by the locale model
 
   if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_executeOn)) {
@@ -1172,6 +1176,10 @@ static void fork_nb_wrapper(chpl_comm_on_bundle_t *f) {
 void chpl_comm_execute_on_nb(c_nodeid_t node, c_sublocid_t subloc,
                              chpl_fn_int_t fid,
                              chpl_comm_on_bundle_t *arg, size_t argSize) {
+  DBG_PRINTF(DBG_INTERFACE,
+             "chpl_comm_execute_on_nb(%d, %d, %d, %p, %zd)",
+             (int) node, (int) subloc, (int) fid, arg, argSize);
+
   CHK_TRUE(node != chpl_nodeID); // handled by the locale model
 
   if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_executeOn_nb)) {
@@ -1191,6 +1199,10 @@ void chpl_comm_execute_on_nb(c_nodeid_t node, c_sublocid_t subloc,
 void chpl_comm_execute_on_fast(c_nodeid_t node, c_sublocid_t subloc,
                                chpl_fn_int_t fid,
                                chpl_comm_on_bundle_t *arg, size_t argSize) {
+  DBG_PRINTF(DBG_INTERFACE,
+             "chpl_comm_execute_on_fast(%d, %d, %d, %p, %zd)",
+             (int) node, (int) subloc, (int) fid, arg, argSize);
+
   CHK_TRUE(node != chpl_nodeID); // handled by the locale model
 
   if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_executeOn_fast)) {
@@ -1213,11 +1225,11 @@ void amRequestExecOn(c_nodeid_t node, c_sublocid_t subloc,
                      chpl_comm_on_bundle_t* arg, size_t argSize,
                      chpl_bool fast, chpl_bool blocking) {
   arg->comm.xo = (struct chpl_comm_bundleData_execOn_t)
-                   { .op = am_opCall,
+                   { .b = (struct chpl_comm_bundleData_base_t)
+                          { .op = am_opCall, .node = chpl_nodeID },
                      .fast = fast,
                      .fid = fid,
                      .argSize = argSize,
-                     .node = chpl_nodeID,
                      .subloc = subloc,
                      .pDone = NULL };
   amRequestCommon(node, arg, argSize, blocking ? &arg->comm.xo.pDone : NULL);
@@ -1229,9 +1241,9 @@ void amRequestRMA(c_nodeid_t node, amOp_t op,
                   void* addr, void* raddr, size_t size) {
   chpl_comm_on_bundle_t arg;
   arg.comm.rma = (struct chpl_comm_bundleData_RMA_t)
-                   { .op = op,
+                   { .b = (struct chpl_comm_bundleData_base_t)
+                          { .op = op, .node = chpl_nodeID },
                      .addr = raddr,
-                     .node = chpl_nodeID,
                      .raddr = addr,
                      .size = size,
                      .pDone = NULL };
@@ -1264,11 +1276,11 @@ void amRequestAMO(c_nodeid_t node, void* object,
 
   chpl_comm_on_bundle_t arg;
   arg.comm.amo = (struct chpl_comm_bundleData_AMO_t)
-                   { .op = am_opAMO,
+                   { .b = (struct chpl_comm_bundleData_base_t)
+                          { .op = am_opAMO, .node = chpl_nodeID },
                      .ofiOp = ofiOp,
                      .ofiType = ofiType,
                      .size = size,
-                     .node = chpl_nodeID,
                      .obj = object,
                      .operand1 = { 0 },
                      .operand2 = { 0 },
@@ -1312,6 +1324,28 @@ void amRequestCommon(c_nodeid_t node,
     *ppDone = pDone;
   }
 
+#ifdef CHPL_COMM_DEBUG
+  if (DBG_TEST_MASK(DBG_AM | DBG_AMSEND | DBG_AMRECV)) {
+    static atomic_uint_least64_t seq;
+
+    static chpl_bool seqInited = false;
+    if (!seqInited) {
+      static pthread_mutex_t seqLock = PTHREAD_MUTEX_INITIALIZER;
+      PTHREAD_CHK(pthread_mutex_lock(&seqLock));
+      atomic_init_uint_least64_t(&seq, 1);
+      seqInited = true;
+      PTHREAD_CHK(pthread_mutex_unlock(&seqLock));
+    }
+
+    arg->comm.b.seq = atomic_fetch_add_uint_least64_t(&seq, 1);
+
+#ifdef DEBUG_CRC_MSGS
+    arg->comm.b.crc = 0;
+    arg->comm.b.crc = xcrc32((void*) arg, argSize, 0xffffffff);
+#endif
+  }
+#endif
+
   struct perTxCtxInfo_t* tcip;
   CHK_TRUE((tcip = tciAlloc(false /*bindToAmHandler*/)) != NULL);
 
@@ -1319,7 +1353,7 @@ void amRequestCommon(c_nodeid_t node,
   void* mrDesc = NULL;
   if (mrGetLocalDesc(&mrDesc, myArg, argSize) != 0) {
     myArg = allocBounceBuf(argSize);
-    DBG_PRINTF(DBG_AMO, "AMO arg BB: %p", myArg);
+    DBG_PRINTF(DBG_AM, "AM arg BB: %p", myArg);
     CHK_TRUE(mrGetLocalDesc(NULL, myArg, argSize) == 0);
     memcpy(myArg, arg, argSize);
   }
@@ -1327,8 +1361,10 @@ void amRequestCommon(c_nodeid_t node,
   OFI_CHK(fi_send(tcip->txCtx, myArg, argSize, mrDesc, ofi_rxAddrs[node],
                   NULL));
   DBG_PRINTF(DBG_AM | DBG_AMSEND,
-             "tx AM req to %d, op %d, size %zd, pDone %p",
-             node, (int) myArg->comm.op.op, argSize, pDone);
+             "tx AM req to %d, seqId %d:%" PRIu64 ", op %d, size %zd, "
+             "pDone %p",
+             node, chpl_nodeID, myArg->comm.b.seq, (int) myArg->comm.b.op,
+             argSize, pDone);
   tcip->numAmReqsTxed++;
   tcip->numTxsOut++;
 
@@ -1486,10 +1522,22 @@ void processRxAmReq(struct perTxCtxInfo_t* tcip) {
         //
         chpl_comm_on_bundle_t* req = (chpl_comm_on_bundle_t*) cqes[i].buf;
         DBG_PRINTF(DBG_AM | DBG_AMRECV,
-                   "CQ rx AM req %p, op %d, len %zd",
-                   req, req->comm.op.op, cqes[i].len);
+                   "CQ rx AM req %p, seqId %d:%" PRIu64 ", op %d, len %zd",
+                   req, req->comm.b.node, req->comm.b.seq, req->comm.b.op,
+                   cqes[i].len);
         tcip->numAmReqsRxed++;
-        switch (req->comm.op.op) {
+
+#if defined(CHPL_COMM_DEBUG) && defined(DEBUG_CRC_MSGS)
+        if (DBG_TEST_MASK(DBG_AM)) {
+          unsigned int sent_crc = req->comm.b.crc;
+          req->comm.b.crc = 0;
+          unsigned int rcvd_crc = xcrc32((void*) req, req->comm.xo.argSize,
+                                         0xffffffff);
+          CHK_TRUE(rcvd_crc == sent_crc);
+        }
+#endif
+
+        switch (req->comm.b.op) {
         case am_opCall:
           if (req->comm.xo.fast) {
             realExecOnWrapper(req, false);
@@ -1535,7 +1583,7 @@ void processRxAmReq(struct perTxCtxInfo_t* tcip) {
           break;
 
         default:
-          INTERNAL_ERROR_V("unexpected AM op %d", req->comm.op.op);
+          INTERNAL_ERROR_V("unexpected AM op %d", req->comm.b.op);
           break;
         }
       }
@@ -1559,7 +1607,7 @@ void amHandleExecOn(chpl_comm_on_bundle_t* req) {
   struct chpl_comm_bundleData_execOn_t* xo = &req->comm.xo;
   DBG_PRINTF(DBG_AM | DBG_AMRECV,
              "amHandleExecOn() for node %d: ftable[%d]",
-             (int) xo->node, (int) xo->fid);
+             (int) xo->b.node, (int) xo->fid);
   chpl_comm_on_bundle_t* reqCopy;
   CHPL_CALLOC_SZ(reqCopy, 1, xo->argSize);
   chpl_memcpy(reqCopy, req, xo->argSize);
@@ -1581,11 +1629,12 @@ void realExecOnWrapper(void* p, chpl_bool fast) {
   struct chpl_comm_bundleData_execOn_t* xo = &req->comm.xo;
 
   DBG_PRINTF(DBG_AM | DBG_AMRECV,
-             "realExecOnWrapper(): %schpl_ftable_call(%d, %p)",
+             "execOnWrap: seqId %d:%" PRIu64 ", %schpl_ftable_call(%d, %p)",
+             req->comm.b.node, req->comm.b.seq,
              (fast ? "fast " : ""), (int) xo->fid, p);
   chpl_ftable_call(xo->fid, p);
   if (xo->pDone != NULL) {
-    amSendDone(xo->node, xo->pDone);
+    amSendDone(xo->b.node, xo->pDone);
   }
 }
 
@@ -1597,11 +1646,11 @@ void amGetWrapper(void* p) {
 
   DBG_PRINTF(DBG_AM | DBG_AMRECV,
              "amGetWrapper(): %p <-- %d:%p (%zd bytes)",
-             rma->addr, (int) rma->node, rma->raddr, rma->size);
-  CHK_TRUE(mrGetKey(NULL, rma->node, rma->raddr, rma->size) == 0); // sanity
-  (void) ofi_get(rma->addr, rma->node, rma->raddr, rma->size);
+             rma->addr, (int) rma->b.node, rma->raddr, rma->size);
+  CHK_TRUE(mrGetKey(NULL, rma->b.node, rma->raddr, rma->size) == 0); // sanity
+  (void) ofi_get(rma->addr, rma->b.node, rma->raddr, rma->size);
 
-  amSendDone(rma->node, rma->pDone);
+  amSendDone(rma->b.node, rma->pDone);
 }
 
 
@@ -1612,11 +1661,11 @@ void amPutWrapper(void* p) {
 
   DBG_PRINTF(DBG_AM | DBG_AMRECV,
              "amPutWrapper() %d:%p <-- %p (%zd bytes)",
-             (int) rma->node, rma->raddr, rma->addr, rma->size);
-  CHK_TRUE(mrGetKey(NULL, rma->node, rma->raddr, rma->size) == 0); // sanity
-  (void) ofi_put(rma->addr, rma->node, rma->raddr, rma->size);
+             (int) rma->b.node, rma->raddr, rma->addr, rma->size);
+  CHK_TRUE(mrGetKey(NULL, rma->b.node, rma->raddr, rma->size) == 0); // sanity
+  (void) ofi_put(rma->addr, rma->b.node, rma->raddr, rma->size);
 
-  amSendDone(rma->node, rma->pDone);
+  amSendDone(rma->b.node, rma->pDone);
 }
 
 
@@ -1627,7 +1676,7 @@ void amHandleAMO(chpl_comm_on_bundle_t* req) {
     DBG_PRINTF(DBG_AM | DBG_AMRECV | DBG_AMO,
                "amHandleAMO() for node %d: obj %p, opnd1 %s, opnd2 %s, "
                "res %p, ofiOp %d, ofiType %d, sz %d",
-               amo->node, amo->obj,
+               amo->b.node, amo->obj,
                DBG_VAL(&amo->operand1, amo->ofiType),
                DBG_VAL(&amo->operand2, amo->ofiType),
                amo->result, amo->ofiOp, amo->ofiType, amo->size);
@@ -1636,13 +1685,13 @@ void amHandleAMO(chpl_comm_on_bundle_t* req) {
       DBG_PRINTF(DBG_AM | DBG_AMRECV | DBG_AMO,
                  "amHandleAMO() for node %d: obj %p, "
                  "res %p, ofiOp %d, ofiType %d, sz %d",
-                 amo->node, amo->obj,
+                 amo->b.node, amo->obj,
                  amo->result, amo->ofiOp, amo->ofiType, amo->size);
     } else {
       DBG_PRINTF(DBG_AM | DBG_AMRECV | DBG_AMO,
                  "amHandleAMO() for node %d: obj %p, opnd %s, "
                  "res %p, ofiOp %d, ofiType %d, sz %d",
-                 amo->node, amo->obj,
+                 amo->b.node, amo->obj,
                  DBG_VAL(&amo->operand1, amo->ofiType),
                  amo->result, amo->ofiOp, amo->ofiType, amo->size);
     }
@@ -1650,7 +1699,7 @@ void amHandleAMO(chpl_comm_on_bundle_t* req) {
     DBG_PRINTF(DBG_AM | DBG_AMRECV | DBG_AMO,
                "amHandleAMO() for node %d: obj %p, opnd %s, "
                "ofiOp %d, ofiType %d, sz %d",
-               amo->node, amo->obj,
+               amo->b.node, amo->obj,
                DBG_VAL(&amo->operand1, amo->ofiType),
                amo->ofiOp, amo->ofiType, amo->size);
   }
@@ -1663,12 +1712,12 @@ void amHandleAMO(chpl_comm_on_bundle_t* req) {
   // AMOs can be same-node; short-circuit responses in that case.
   //
   if (amo->result != NULL) {
-    if (amo->node == chpl_nodeID) {
+    if (amo->b.node == chpl_nodeID) {
       memcpy(amo->result, &result, resSize);
       atomic_thread_fence(memory_order_release);
     } else {
-      CHK_TRUE(mrGetKey(NULL, amo->node, amo->result, resSize) == 0);
-      (void) ofi_put(&result, amo->node, amo->result, resSize);
+      CHK_TRUE(mrGetKey(NULL, amo->b.node, amo->result, resSize) == 0);
+      (void) ofi_put(&result, amo->b.node, amo->result, resSize);
 
       //
       // TODO:
@@ -1693,10 +1742,10 @@ void amHandleAMO(chpl_comm_on_bundle_t* req) {
     }
   }
 
-  if (amo->node == chpl_nodeID) {
+  if (amo->b.node == chpl_nodeID) {
     *amo->pDone = 1;
   } else {
-    amSendDone(amo->node, amo->pDone);
+    amSendDone(amo->b.node, amo->pDone);
   }
 }
 
@@ -1889,7 +1938,7 @@ struct perTxCtxInfo_t* tciAlloc(chpl_bool bindToAmHandler) {
   if (bindToAmHandler || tciTabFixedAssignments)
     tcip->bound = true;
   DBG_PRINTF(DBG_THREADS, "I have%s tciTab[%td]",
-             bindToAmHandler ? " bound" : "", tcip - tciTab);
+             tcip->bound ? " bound" : "", tcip - tciTab);
   return tcip;
 }
 
@@ -1953,8 +2002,10 @@ void tciFree(struct perTxCtxInfo_t* tcip) {
   //
   // Bound contexts stay bound.  We only release non-bound ones.
   //
-  if (!tcip->bound)
+  if (!tcip->bound) {
+    DBG_PRINTF(DBG_THREADS, "I free tciTab[%td]", tcip - tciTab);
     atomic_store_bool(&tcip->allocated, false);
+  }
 }
 
 


### PR DESCRIPTION
Fix a double-free of an allocated transmit context in network AMO processing.  Support self-PUT, which I had thought could not happen but turns out to be exercised by bulk transfer.  Add the internal module that defines network atomic types, which I failed to include in the PR that added network atomic support in the ofi comm layer.

Together these fix another 22 comm=ofi failures, all but 2 of the 24 I'd originally diagnosed as being likely due to comm layer bugs.  It also converts 1 of the remaining 2 of those into a timeout.