### PR TITLE
Fix support for cstdlib atomics under --llvm (round 2)

### DIFF
--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2969,13 +2969,6 @@ void makeBinaryLLVM(void) {
     command += libName;
   }
 
-  // Clang doesn't automatically link against GNU's libatomic, so we need to
-  // bring it in. If we start using compiler-rt, this shouldn't be needed
-  if (strcmp(CHPL_ATOMICS, "cstdlib") == 0 &&
-      strcmp(CHPL_TARGET_PLATFORM, "darwin") != 0) {
-    command += " -latomic";
-  }
-
   if( printSystemCommands ) {
     printf("%s\n", command.c_str());
     fflush(stdout); fflush(stderr);

--- a/modules/internal/Atomics.chpl
+++ b/modules/internal/Atomics.chpl
@@ -86,18 +86,18 @@ module Atomics {
   use ChapelEnv;
 
   pragma "no doc"
-  extern proc atomic_thread_fence(order:memory_order);
+  extern proc chpl_atomic_thread_fence(order:memory_order);
   pragma "no doc"
-  extern proc atomic_signal_fence(order:memory_order);
+  extern proc chpl_atomic_signal_fence(order:memory_order);
 
   // these can be called just the way they are:
-  //extern proc atomic_thread_fence(order:memory_order);
-  //extern proc atomic_signal_fence(order:memory_order);
+  //extern proc chpl_atomic_thread_fence(order:memory_order);
+  //extern proc chpl_atomic_signal_fence(order:memory_order);
   // but they only handle the local portion of a fence.
   // To include PUTs or GETs in the fence, use atomic_fence instead:
   pragma "no doc"
   proc atomic_fence(order:memory_order = memory_order_seq_cst) {
-    atomic_thread_fence(order);
+    chpl_atomic_thread_fence(order);
     chpl_rmem_consist_fence(order);
   }
 
@@ -285,7 +285,7 @@ module Atomics {
         while (this.read(order=memory_order_relaxed) != value) {
           chpl_task_yield();
         }
-        atomic_thread_fence(order);
+        chpl_atomic_thread_fence(order);
       }
     }
 
@@ -559,7 +559,7 @@ module Atomics {
         while (this.read(order=memory_order_relaxed) != value) {
           chpl_task_yield();
         }
-        atomic_thread_fence(order);
+        chpl_atomic_thread_fence(order);
       }
     }
 

--- a/modules/internal/NetworkAtomics.chpl
+++ b/modules/internal/NetworkAtomics.chpl
@@ -99,7 +99,7 @@ module NetworkAtomics {
         while (this.read(order=memory_order_relaxed) != value) {
           chpl_task_yield();
         }
-        atomic_thread_fence(order);
+        chpl_atomic_thread_fence(order);
       }
     }
 
@@ -277,7 +277,7 @@ module NetworkAtomics {
         while (this.read(order=memory_order_relaxed) != value) {
           chpl_task_yield();
         }
-        atomic_thread_fence(order);
+        chpl_atomic_thread_fence(order);
       }
     }
 

--- a/runtime/include/atomics/cstdlib/chpl-atomics.h
+++ b/runtime/include/atomics/cstdlib/chpl-atomics.h
@@ -67,6 +67,16 @@ static inline memory_order _defaultOfMemoryOrder(void) {
   return memory_order_seq_cst;
 }
 
+static inline void chpl_atomic_thread_fence(memory_order order)
+{
+  atomic_thread_fence(order);
+}
+static inline void chpl_atomic_signal_fence(memory_order order)
+{
+  atomic_signal_fence(order);
+}
+
+
 //
 // Given an input memory order, find a memory order that can be used for
 // an atomic_load or for the compare_exchange failure case.  This is an

--- a/runtime/include/atomics/intrinsics/chpl-atomics.h
+++ b/runtime/include/atomics/intrinsics/chpl-atomics.h
@@ -81,11 +81,11 @@ static inline memory_order _defaultOfMemoryOrder(void) {
 #endif
 
 
-static inline void atomic_thread_fence(memory_order order)
+static inline void chpl_atomic_thread_fence(memory_order order)
 {
   full_memory_barrier();
 }
-static inline void atomic_signal_fence(memory_order order)
+static inline void chpl_atomic_signal_fence(memory_order order)
 {
   full_memory_barrier();
 }

--- a/runtime/include/atomics/locks/chpl-atomics.h
+++ b/runtime/include/atomics/locks/chpl-atomics.h
@@ -106,12 +106,12 @@ typedef enum {
 } memory_order;
 
 static inline
-void atomic_thread_fence(memory_order order)
+void chpl_atomic_thread_fence(memory_order order)
 {
   // No idea!
 }
 static inline
-void atomic_signal_fence(memory_order order)
+void chpl_atomic_signal_fence(memory_order order)
 {
   // No idea!
 }

--- a/runtime/include/chpl-mem-consistency.h
+++ b/runtime/include/chpl-mem-consistency.h
@@ -115,7 +115,7 @@ void chpl_rmem_consist_fence(memory_order order, int ln, int32_t fn) {
 
     if( release ) chpl_rmem_consist_release(ln, fn);
     if( acquire ) chpl_rmem_consist_acquire(ln, fn);
-    atomic_thread_fence(order);
+    chpl_atomic_thread_fence(order);
   }
 }
 

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -1307,7 +1307,7 @@ void amRequestCommon(c_nodeid_t node,
       CHK_TRUE(mrGetLocalKey(NULL, pDone, sizeof(*pDone)) == 0);
     }
     *pDone = 0;
-    atomic_thread_fence(memory_order_release);
+    chpl_atomic_thread_fence(memory_order_release);
 
     *ppDone = pDone;
   }
@@ -1665,7 +1665,7 @@ void amHandleAMO(chpl_comm_on_bundle_t* req) {
   if (amo->result != NULL) {
     if (amo->node == chpl_nodeID) {
       memcpy(amo->result, &result, resSize);
-      atomic_thread_fence(memory_order_release);
+      chpl_atomic_thread_fence(memory_order_release);
     } else {
       CHK_TRUE(mrGetKey(NULL, amo->node, amo->result, resSize) == 0);
       (void) ofi_put(&result, amo->node, amo->result, resSize);

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -2605,7 +2605,7 @@ void register_memory(void)
   }
 
   can_register_memory = true;
-  atomic_thread_fence(memory_order_release);
+  chpl_atomic_thread_fence(memory_order_release);
 }
 
 
@@ -2986,7 +2986,7 @@ void make_registered_heap(void)
     registered_heap_size  = 0;
     registered_heap_start = NULL;
     registered_heap_info_set = 1;
-    atomic_thread_fence(memory_order_release);
+    chpl_atomic_thread_fence(memory_order_release);
     return;
   }
 
@@ -3116,7 +3116,7 @@ void make_registered_heap(void)
   registered_heap_size  = size;
   registered_heap_start = start;
   registered_heap_info_set = 1;
-  atomic_thread_fence(memory_order_release);
+  chpl_atomic_thread_fence(memory_order_release);
 }
 
 
@@ -3155,7 +3155,7 @@ void set_hugepage_info(void)
   }
 
   hugepage_info_set = 1;
-  atomic_thread_fence(memory_order_release);
+  chpl_atomic_thread_fence(memory_order_release);
 
   DBG_P_L(DBGF_HUGEPAGES,
           "setting hugepage info: use hugepages %s, sz %#zx",
@@ -3219,7 +3219,7 @@ void SIGBUS_handler(int signo, siginfo_t *info, void *context)
                     chpl_mem_descString(mr_mregs_supplement[mr_i].desc));
       write(fileno(stderr), buf, strlen(buf));
       exit_without_cleanup = true;
-      atomic_thread_fence(memory_order_release);
+      chpl_atomic_thread_fence(memory_order_release);
       chpl_exit_any(1);
     }
   }
@@ -7662,7 +7662,7 @@ void do_fork_post(c_nodeid_t locale,
       p_rf_req->rf_done = rf_done_alloc();
     }
     *p_rf_req->rf_done = 0;
-    atomic_thread_fence(memory_order_release);
+    chpl_atomic_thread_fence(memory_order_release);
 
     post_desc_p = &stack_post_desc;
   } else {

--- a/test/runtime/ferguson/testatomics.test.c
+++ b/test/runtime/ferguson/testatomics.test.c
@@ -79,8 +79,8 @@ int main(int argc, char** argv)
   assert( false == atomic_exchange_bool(&flag, true) );
   assert( true == atomic_exchange_bool(&flag, true) );
 
-  atomic_thread_fence(memory_order_seq_cst);
-  atomic_signal_fence(memory_order_seq_cst);
+  chpl_atomic_thread_fence(memory_order_seq_cst);
+  chpl_atomic_signal_fence(memory_order_seq_cst);
 
   {
     atomic_uint_least8_t tmp;


### PR DESCRIPTION
In #12045 we started adding `-latomic` to llvm compiles for cstdlib
atomic configurations to try to resolve undefined references to
`atomic_thread_fence`. This ended up being a work around that didn't fix
the core issue, and it didn't work in all cases (e.g. when llvm can't
find a libatomic from gcc >=6.) Here we revert that change and fix the
core issue.

What was actually going wrong was that clang's <stdatomic.h> header has
both a macro and a function prototype for `atomic_thread_fence()` and
our llvm backend isn't able to handle the macro so we ended up using a
function with no implementation, which led to undefined references. New
enough versions of libatomic happen to have an implementation of
`atomic_thread_fence()`, so throwing `-latomic` worked in that case, but
not for older versions of libatomic. To avoid the problem this adds a
`chpl_atomic_thread_fence()` wrapper. Note that we have done similar
things in the past to avoid issues with the llvm backend and macros that
it can't process.

Testing:
 - [x] llvm built with gcc 8.2.0 (full paratest on chapcs)
 - [x] llvm built with gcc 4.8.5 (atomic tests on chapc)
 - [x] system llvm (atomic tests on chapel-ubu1604-02 -- old workaround failed in nightly)
 - [x] llvm built with clang 10.0.0 (atomic tests on High Sierra)