### PR TITLE
Prevent multi-line comment complaint when g++ compiles clang

### DIFF
--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -146,7 +146,7 @@ GEN_CFLAGS += $(C_STD)
 # Flags for turning on warnings for C++/C code
 #
 WARN_COMMONFLAGS = -Wall -Werror -Wpointer-arith -Wwrite-strings -Wno-strict-aliasing
-WARN_CXXFLAGS = $(WARN_COMMONFLAGS)
+WARN_CXXFLAGS = $(WARN_COMMONFLAGS) -Wno-comment
 WARN_CFLAGS = $(WARN_COMMONFLAGS) -Wmissing-prototypes -Wstrict-prototypes -Wmissing-format-attribute
 WARN_GEN_CFLAGS = $(WARN_CFLAGS)
 SQUASH_WARN_GEN_CFLAGS = -Wno-unused -Wno-uninitialized
@@ -180,7 +180,7 @@ endif
 # On Ubuntu, gcc 8 complains about multiline comments in Clang header files.
 #
 ifeq ($(shell test $(GNU_GPP_MAJOR_VERSION) -eq 8; echo "$$?"),0)
-WARN_CXXFLAGS += -Wno-class-memaccess -Walloc-size-larger-than=18446744073709551615 -Wno-comment
+WARN_CXXFLAGS += -Wno-class-memaccess -Walloc-size-larger-than=18446744073709551615
 RUNTIME_CFLAGS += -Wno-stringop-overflow
 SQUASH_WARN_GEN_CFLAGS += -Wno-array-bounds
 endif

--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -145,6 +145,9 @@ GEN_CFLAGS += $(C_STD)
 #
 # Flags for turning on warnings for C++/C code
 #
+# On Ubuntu, gcc complains about multiline comments in some versions
+# of Clang header files.
+#
 WARN_COMMONFLAGS = -Wall -Werror -Wpointer-arith -Wwrite-strings -Wno-strict-aliasing
 WARN_CXXFLAGS = $(WARN_COMMONFLAGS) -Wno-comment
 WARN_CFLAGS = $(WARN_COMMONFLAGS) -Wmissing-prototypes -Wstrict-prototypes -Wmissing-format-attribute
@@ -177,7 +180,6 @@ endif
 # Avoid false positive warnings about class member access and string overflows.
 # The string overflow false positives occur in runtime code unlike gcc 7.
 # Also avoid false positives for allocation size, array bounds, and comments.
-# On Ubuntu, gcc 8 complains about multiline comments in Clang header files.
 #
 ifeq ($(shell test $(GNU_GPP_MAJOR_VERSION) -eq 8; echo "$$?"),0)
 WARN_CXXFLAGS += -Wno-class-memaccess -Walloc-size-larger-than=18446744073709551615


### PR DESCRIPTION
#11906 fixed a g++ complaint on Ubuntu when compiling clang header files.  However, that PR was limited to g++ 8.  It turns out that any version of g++ potentially complains about this in certain versions of clang header files.

This PR moves the `-Wno-comment` flag out of g++ 8 and into the general flags.

Verified not to disrupt compilation at least as far back as g++ 4.3.
