### PR TITLE
Add compiler support for C interop using chpl_opaque_array

### DIFF
--- a/compiler/AST/wellknown.cpp
+++ b/compiler/AST/wellknown.cpp
@@ -33,6 +33,7 @@ AggregateType* dtExternalArray;
 AggregateType* dtLocaleID;
 AggregateType* dtMainArgument;
 AggregateType* dtOnBundleRecord;
+AggregateType* dtOpaqueArray;
 AggregateType* dtOwned;
 AggregateType* dtTaskBundleRecord;
 AggregateType* dtTuple;
@@ -107,6 +108,7 @@ static WellKnownType sWellKnownTypes[] = {
   { "chpl_localeID_t",       &dtLocaleID,         false },
   { "chpl_main_argument",    &dtMainArgument,     false },
   { "chpl_comm_on_bundle_t", &dtOnBundleRecord,   false },
+  { "chpl_opaque_array",     &dtOpaqueArray,      false },
   { "_owned",                &dtOwned,            false },
   { "chpl_task_bundle_t",    &dtTaskBundleRecord, false },
   { "_tuple",                &dtTuple,            false },

--- a/compiler/include/wellknown.h
+++ b/compiler/include/wellknown.h
@@ -42,6 +42,7 @@ extern AggregateType* dtExternalArray;
 extern AggregateType* dtLocaleID;
 extern AggregateType* dtMainArgument;
 extern AggregateType* dtOnBundleRecord;
+extern AggregateType* dtOpaqueArray;
 extern AggregateType* dtOwned;
 extern AggregateType* dtTaskBundleRecord;
 extern AggregateType* dtTuple;

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -1323,22 +1323,8 @@ static void fixupExportedArrayReturns(FnSymbol* fn) {
                      " for Python compilation");
     }
 
-    SymExpr* dom = toSymExpr(call->get(1));
-    if ((dom != NULL && dom->symbol() == gNil) || eltExpr == NULL) {
-      // The domain/eltType is nil.  Try to make a chpl_external_array with it.
-      // If that doesn't work, the user must be more explicit with their
-      // return type
-      fn->retExprType->replace(new BlockStmt(new SymExpr(dtExternalArray->symbol)));
-    } else {
-      // Create a representation of the array return type that is accessible
-      // outside of Chapel, depending on the type of the array.  If the array
-      // is supported by our C/Python interop, it will be represented as a
-      // chpl_external_array.  Otherwise, it will be a chpl_opaque_array
-      CallExpr* newRetType = new CallExpr("getExternalArrayType",
-                                          call->copy());
-      fn->retExprType->insertAtTail(newRetType);
-    }
-
+    // Let the return type get determined by the result of the conversion call
+    fn->retExprType->remove();
     CallExpr* retCall = toCallExpr(fn->body->body.tail);
     INT_ASSERT(retCall && retCall->isPrimitive(PRIM_RETURN));
 

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -2861,7 +2861,7 @@ static void fixupExportedArrayFormals(FnSymbol* fn) {
       // Transform the outside representation into a Chapel array, and send that
       // in the call to the original function.
 
-      // if (formal.type == dtExternalArray) then
+      // if (formal.type is dtExternalArray) then
       //    formalname_arr = makeArrayFromExternArray(formal, eltExpr)
       //    else formalname_arr = makeArrayFromOpaque(formal, oldTypeExpr)
       CallExpr* checkFormalType = new CallExpr(PRIM_IS_SUBTYPE,

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -1324,10 +1324,10 @@ static void fixupExportedArrayReturns(FnSymbol* fn) {
     }
 
     SymExpr* dom = toSymExpr(call->get(1));
-    if (dom != NULL && dom->symbol() == gNil) {
-      // The domain is nil.  Try to make a chpl_external_array with it.
+    if ((dom != NULL && dom->symbol() == gNil) || eltExpr == NULL) {
+      // The domain/eltType is nil.  Try to make a chpl_external_array with it.
       // If that doesn't work, the user must be more explicit with their
-      // domain
+      // return type
       fn->retExprType->replace(new BlockStmt(new SymExpr(dtExternalArray->symbol)));
     } else {
       // Create a representation of the array return type that is accessible

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -1323,7 +1323,8 @@ static void fixupExportedArrayReturns(FnSymbol* fn) {
                      " for Python compilation");
     }
 
-    fn->retExprType->replace(new BlockStmt(new SymExpr(dtExternalArray->symbol)));
+    //fn->retExprType->replace(new BlockStmt(new SymExpr(dtExternalArray->symbol)));
+    fn->retExprType->replace(new BlockStmt(new SymExpr(dtOpaqueArray->symbol)));
 
     CallExpr* retCall = toCallExpr(fn->body->body.tail);
     INT_ASSERT(retCall && retCall->isPrimitive(PRIM_RETURN));

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -1323,8 +1323,13 @@ static void fixupExportedArrayReturns(FnSymbol* fn) {
                      " for Python compilation");
     }
 
-    //fn->retExprType->replace(new BlockStmt(new SymExpr(dtExternalArray->symbol)));
-    fn->retExprType->replace(new BlockStmt(new SymExpr(dtOpaqueArray->symbol)));
+    // Create a representation of the array return type that is accessible
+    // outside of Chapel, depending on the type of the array.  If the array
+    // is supported by our C/Python interop, it will be represented as a
+    // chpl_external_array.  Otherwise, it will be a chpl_opaque_array
+    CallExpr* newRetType = new CallExpr("getExternalArrayType",
+                                        call->copy());
+    fn->retExprType->insertAtTail(newRetType);
 
     CallExpr* retCall = toCallExpr(fn->body->body.tail);
     INT_ASSERT(retCall && retCall->isPrimitive(PRIM_RETURN));

--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -330,6 +330,7 @@ module ChapelDistribution {
 
     proc dsiDisplayRepresentation() { writeln("<no way to display representation>"); }
 
+    proc type isDefaultRectangular() param return false;
     proc isDefaultRectangular() param return false;
 
     proc isSliceDomainView() param return false; // likely unnecessary?
@@ -749,6 +750,7 @@ module ChapelDistribution {
     proc dsiRequiresPrivatization() param return false;
 
     proc dsiDisplayRepresentation() { writeln("<no way to display representation>"); }
+    proc type isDefaultRectangular() param return false;
     proc isDefaultRectangular() param return false;
 
     proc doiCanBulkTransferRankChange() param return false;

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -142,6 +142,7 @@ module DefaultRectangular {
     proc linksDistribution() param return false;
     override proc dsiLinksDistribution()     return false;
 
+    proc type isDefaultRectangular() param return true;
     proc isDefaultRectangular() param return true;
 
     proc init(param rank, type idxType, param stridable, dist) {
@@ -2172,6 +2173,7 @@ module DefaultRectangular {
   }
 
   proc DefaultRectangularArr.isDefaultRectangular() param return true;
+  proc type DefaultRectangularArr.isDefaultRectangular() param return true;
 
   /*
   The runtime implementation's loop over the current stride level will look

--- a/modules/internal/ExternalArray.chpl
+++ b/modules/internal/ExternalArray.chpl
@@ -166,6 +166,22 @@ module ExternalArray {
     }
   }
 
+  proc getExternalArrayType(type arg) type {
+    if (!isArrayType(arg))  {
+      compilerError("must call with an array");
+    } else {
+      type _instanceType = __primitive("static field type", arg, "_instance");
+      // Workaround until #12095 is resolved (problem calling static method on
+      // type of unmanaged field)
+      type borrowedAlt = _to_borrowed(_instanceType);
+      if (borrowedAlt.isDefaultRectangular()) {
+        return chpl_external_array;
+      } else {
+        return chpl_opaque_array;
+      }
+    }
+  }
+
   // Need to export this but that requires some compiler changes due to our
   // hiding of interal module exported functions.
   // Can't create an _array wrapper to call the cleanup function for us, so do

--- a/test/interop/C/exportArray/arrayOpaquePointer.chpl
+++ b/test/interop/C/exportArray/arrayOpaquePointer.chpl
@@ -1,12 +1,12 @@
 use BlockDist;
 const D = {1..5} dmapped Block({1..5});
 
-export proc makeBlockArray_chpl(): [D] int {
+export proc makeBlockArray(): [D] int {
   var x: [D] int;
   return x;
 }
 
-export proc printBlock_chpl(x: [D] int) {
+export proc printBlock(x: [D] int) {
   var output = "";
   var first = true;
   for idx in x.dom {

--- a/test/interop/C/exportArray/arrayOpaquePointer_noArgDom.chpl
+++ b/test/interop/C/exportArray/arrayOpaquePointer_noArgDom.chpl
@@ -1,0 +1,24 @@
+use BlockDist;
+const D = {1..5} dmapped Block({1..5});
+
+export proc makeBlockArray(): [D] int {
+  var x: [D] int;
+  return x;
+}
+
+// Will generate a different signature than the return type for the previous
+// function
+export proc printBlock(x: [] int) {
+  var output = "";
+  var first = true;
+  for idx in x.dom {
+    if (first) {
+      first = false;
+    } else {
+      output += ", ";
+    }
+    output += idx: string + "=";
+    output += x[idx]: string;
+  }
+  writeln(output);
+}

--- a/test/interop/C/exportArray/callArrayOpaquePointer.future
+++ b/test/interop/C/exportArray/callArrayOpaquePointer.future
@@ -1,2 +1,0 @@
-feature request: add compiler support for transforming other array types
-#11949

--- a/test/interop/C/exportArray/callArrayOpaquePointer.test.c
+++ b/test/interop/C/exportArray/callArrayOpaquePointer.test.c
@@ -9,9 +9,9 @@ int main(int argc, char* argv[]) {
   chpl__init_arrayOpaquePointer(0, 0);
 
   chpl_opaque_array arr = makeBlockArray();
-  printBlock(arr);
-  addEltBlock(arr, 2, 3);
-  printBlock(arr);
+  printBlock(&arr);
+  addEltBlock(&arr, 2, 3);
+  printBlock(&arr);
 
   // Call cleanup function when exported
   //chpl_mem_free(arr, 0, 0);

--- a/test/interop/C/exportArray/callArrayOpaquePointer.test.c
+++ b/test/interop/C/exportArray/callArrayOpaquePointer.test.c
@@ -8,10 +8,10 @@ int main(int argc, char* argv[]) {
   chpl_library_init(argc, argv);
   chpl__init_arrayOpaquePointer(0, 0);
 
-  chpl_opaque_array arr = makeSqrArray();
-  printSqr(arr);
-  addEltSqr(arr, 2, 3);
-  printSqr(arr);
+  chpl_opaque_array arr = makeBlockArray();
+  printBlock(arr);
+  addEltBlock(arr, 2, 3);
+  printBlock(arr);
 
   // Call cleanup function when exported
   //chpl_mem_free(arr, 0, 0);

--- a/test/interop/C/exportArray/callArrayOpaquePointer_noArgDom.cleanfiles
+++ b/test/interop/C/exportArray/callArrayOpaquePointer_noArgDom.cleanfiles
@@ -1,0 +1,2 @@
+lib/libarrayOpaquePointer_noArgDom.a
+lib/arrayOpaquePointer_noArgDom.h

--- a/test/interop/C/exportArray/callArrayOpaquePointer_noArgDom.good
+++ b/test/interop/C/exportArray/callArrayOpaquePointer_noArgDom.good
@@ -1,0 +1,8 @@
+callArrayOpaquePointer_noArgDom.test.c:12:14: warning: incompatible pointer types passing 'chpl_opaque_array *' to parameter of type 'chpl_external_array *' [-Wincompatible-pointer-types]
+  printBlock(&arr); // Expected to fail
+             ^~~~
+./lib/arrayOpaquePointer_noArgDom.h:6:39: note: passing argument to parameter 'x' here
+void printBlock(chpl_external_array * x);
+                                      ^
+1 warning generated.
+timedexec: target program died with signal 11, without coredump

--- a/test/interop/C/exportArray/callArrayOpaquePointer_noArgDom.good
+++ b/test/interop/C/exportArray/callArrayOpaquePointer_noArgDom.good
@@ -1,8 +1,9 @@
-callArrayOpaquePointer_noArgDom.test.c:12:14: warning: incompatible pointer types passing 'chpl_opaque_array *' to parameter of type 'chpl_external_array *' [-Wincompatible-pointer-types]
-  printBlock(&arr); // Expected to fail
-             ^~~~
-./lib/arrayOpaquePointer_noArgDom.h:6:39: note: passing argument to parameter 'x' here
-void printBlock(chpl_external_array * x);
-                                      ^
-1 warning generated.
+callArrayOpaquePointer_noArgDom.test.c: In function ‘main’:
+callArrayOpaquePointer_noArgDom.test.c:12:14: warning: passing argument 1 of ‘printBlock’ from incompatible pointer type [-Wincompatible-pointer-types]
+   printBlock(&arr); // Expected to fail
+              ^~~~
+In file included from callArrayOpaquePointer_noArgDom.test.c:3:
+lib/arrayOpaquePointer_noArgDom.h:6:39: note: expected ‘chpl_external_array *’ {aka ‘struct <anonymous> *’} but argument is of type ‘chpl_opaque_array *’ {aka ‘struct <anonymous> *’}
+ void printBlock(chpl_external_array * x);
+                 ~~~~~~~~~~~~~~~~~~~~~~^
 timedexec: target program died with signal 11, without coredump

--- a/test/interop/C/exportArray/callArrayOpaquePointer_noArgDom.lastcompopts
+++ b/test/interop/C/exportArray/callArrayOpaquePointer_noArgDom.lastcompopts
@@ -1,0 +1,1 @@
+-Llib/ -larrayOpaquePointer_noArgDom `$CHPL_HOME/util/config/compileline --libraries`

--- a/test/interop/C/exportArray/callArrayOpaquePointer_noArgDom.precomp
+++ b/test/interop/C/exportArray/callArrayOpaquePointer_noArgDom.precomp
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo Compiling arrayOpaquePointer_noArgDom.chpl
+$3 --library --static arrayOpaquePointer_noArgDom.chpl

--- a/test/interop/C/exportArray/callArrayOpaquePointer_noArgDom.skipif
+++ b/test/interop/C/exportArray/callArrayOpaquePointer_noArgDom.skipif
@@ -1,0 +1,2 @@
+# Use gcc errors only
+CHPL_TARGET_COMPILER != gnu

--- a/test/interop/C/exportArray/callArrayOpaquePointer_noArgDom.test.c
+++ b/test/interop/C/exportArray/callArrayOpaquePointer_noArgDom.test.c
@@ -1,0 +1,16 @@
+#include <inttypes.h>
+
+#include "lib/arrayOpaquePointer_noArgDom.h"
+
+// Test of calling an exported function that takes an array
+int main(int argc, char* argv[]) {
+  // Initialize the Chapel runtime and standard modules
+  chpl_library_init(argc, argv);
+  chpl__init_arrayOpaquePointer_noArgDom(0, 0);
+
+  chpl_opaque_array arr = makeBlockArray();
+  printBlock(&arr); // Expected to fail
+
+  chpl_library_finalize();
+  return 0;
+}


### PR DESCRIPTION
Adjust the generated wrapper for exported functions that take and/or
return arrays so that it will support both chpl_external_array and
chpl_opaque_array transformations.  Note that this only supports
C interoperability, as the Python support will also involve modifying
the Cython files.  I will do that next

When returning arrays, stop explicitly declaring the return type and
instead let it get inferred from the result of the conversion.  This
allowed us to still support exporting functions when the array's
return type was determined by the type of an argument without
overly complicating the code.

For array arguments, if the type is fully specified then call the helper
function getExternalArrayType using the old argument type.  Otherwise,
we make a simplifying assumption and use chpl_external_array as the
type.  This will force the user to be more explicit with their argument
types if they are trying to use an array type that is only supported via
opaque arrays.  Also, without the domain, we would not be able to
appropriately transform the chpl_opaque_array into a Chapel array (as
we wouldn't know what child of BaseArr to use).  The user can work
around this by explicitly requesting chpl_opaque_array as the argument
type and performing the conversion themself or by explicitly specifying
the domain.

To support getExternalArrayType with a type argument instead of an
instance of an array, I added a new overload of the function.  This
caused me to add a variation of isDefaultRectangular defined on the
BaseArr type itself rather than just an instance, and as a result I found
a bug with static methods and unmanaged fields (see #12095).  I
worked around this bug in the new function, but that work-around should
get removed once the bug is fixed.

I had to make some minor modifications to the C test (I thought I had
cleaned it up before committing it earlier, but I guess I didn't), but now it
works.

I made a test where we send a chpl_opaque array to a function that
expects a chpl_external_array (because the array argument type is missing
the domain).  This demonstrates the error which will occur when compiling
a program that uses the library - we cannot protect the user against that
problem.  I intend to add documentation on what to do if the user
encounters that error (explicitly provide a domain, or take chpl_opaque_array
as the argument type and transform it in Chapel code yourself).

Testing:
- [x] full paratest with futures
- [x] checked the Python tests locally to be certain I didn't break them