### PR TITLE
Add compiler support for Python interop using chpl_opaque_array

### DIFF
--- a/compiler/codegen/library.cpp
+++ b/compiler/codegen/library.cpp
@@ -438,7 +438,7 @@ static void makePYXFile(std::vector<FnSymbol*> functions) {
     fprintf(pyx.fptr, "from chplrt cimport chpl_library_init, ");
     fprintf(pyx.fptr, "chpl_library_finalize, chpl_external_array, ");
     fprintf(pyx.fptr, "chpl_make_external_array, chpl_make_external_array_ptr");
-    fprintf(pyx.fptr, ", chpl_free_external_array\n");
+    fprintf(pyx.fptr, ", chpl_free_external_array, chpl_opaque_array\n");
 
     std::vector<FnSymbol*> moduleInits;
     std::vector<FnSymbol*> exported;

--- a/compiler/codegen/library.cpp
+++ b/compiler/codegen/library.cpp
@@ -438,7 +438,8 @@ static void makePYXFile(std::vector<FnSymbol*> functions) {
     fprintf(pyx.fptr, "from chplrt cimport chpl_library_init, ");
     fprintf(pyx.fptr, "chpl_library_finalize, chpl_external_array, ");
     fprintf(pyx.fptr, "chpl_make_external_array, chpl_make_external_array_ptr");
-    fprintf(pyx.fptr, ", chpl_free_external_array, chpl_opaque_array\n");
+    fprintf(pyx.fptr, ", chpl_free_external_array, chpl_opaque_array,");
+    fprintf(pyx.fptr, " ChplOpaqueArray\n");
 
     std::vector<FnSymbol*> moduleInits;
     std::vector<FnSymbol*> exported;

--- a/compiler/codegen/library.cpp
+++ b/compiler/codegen/library.cpp
@@ -438,8 +438,7 @@ static void makePYXFile(std::vector<FnSymbol*> functions) {
     fprintf(pyx.fptr, "from chplrt cimport chpl_library_init, ");
     fprintf(pyx.fptr, "chpl_library_finalize, chpl_external_array, ");
     fprintf(pyx.fptr, "chpl_make_external_array, chpl_make_external_array_ptr");
-    fprintf(pyx.fptr, ", chpl_free_external_array, chpl_opaque_array,");
-    fprintf(pyx.fptr, " ChplOpaqueArray\n");
+    fprintf(pyx.fptr, ", chpl_free_external_array, chpl_opaque_array\n");
 
     std::vector<FnSymbol*> moduleInits;
     std::vector<FnSymbol*> exported;
@@ -479,6 +478,11 @@ static void makePYXFile(std::vector<FnSymbol*> functions) {
     // Necessary for supporting pointers
     fprintf(pyx.fptr, "import ctypes\n");
     fprintf(pyx.fptr, "from libc.stdint cimport intptr_t\n\n");
+
+    fprintf(pyx.fptr, "cdef class ChplOpaqueArray:\n");
+    fprintf(pyx.fptr, "\tcdef chpl_opaque_array val\n\n");
+    fprintf(pyx.fptr, "\tcdef inline setVal(self, chpl_opaque_array val):\n");
+    fprintf(pyx.fptr, "\t\tself.val = val\n\n");
 
     makePYXSetupFunctions(moduleInits);
 

--- a/compiler/codegen/symbol.cpp
+++ b/compiler/codegen/symbol.cpp
@@ -1054,6 +1054,10 @@ std::string ArgSymbol::getPythonType(PythonFileType pxd) {
     // Allow python declarations to accept anything iterable to translate to
     // an array, instead of limiting to a specific Python type
     return "";
+  } else if (t->symbol->hasFlag(FLAG_REF) &&
+             t->getValType() == dtOpaqueArray &&
+             (pxd == PYTHON_PYX || pxd == C_PYX)) {
+    return "ChplOpaqueArray ";
   } else {
     return getPythonTypeName(t, pxd) + " ";
   }
@@ -1105,6 +1109,13 @@ std::string ArgSymbol::getPythonArgTranslation() {
 
       return res;
     }
+  } else if (t->symbol->hasFlag(FLAG_REF) &&
+             t->getValType() == dtOpaqueArray) {
+    // Opaque arrays have a Python representation that stores the C contents in
+    // a field named val
+    std::string res = "\tchpl_" + strname + " = &" + strname + ".val\n";
+    return res;
+
   } else if (t->symbol->hasEitherFlag(FLAG_C_PTR_CLASS, FLAG_REF)) {
     // Lydia TODO 12/04/18: Might be good to use a template where we can
     // replace all instances of a placeholder with the argument name instead of

--- a/compiler/codegen/symbol.cpp
+++ b/compiler/codegen/symbol.cpp
@@ -2154,6 +2154,9 @@ GenRet FnSymbol::codegenPYXType() {
         exportedArrayElementType[this] != NULL) {
       funcCall += "cdef chpl_external_array ret_arr = ";
       returnStmt += getPythonArrayReturnStmts();
+    } else if (retType == dtOpaqueArray) {
+      funcCall += "ret = ChplOpaqueArray()\n\t";
+      funcCall += "ret.setVal(";
     } else {
       funcCall += "ret = ";
     }
@@ -2204,6 +2207,8 @@ GenRet FnSymbol::codegenPYXType() {
 
   } // pyx files do not take void as an argument list, just close the parens
   header += "):\n";
+  if (retType == dtOpaqueArray)
+    funcCall += ")";
   funcCall += ")\n";
   ret.c = header + argTranslate + funcCall + returnStmt;
 

--- a/runtime/include/python/chplrt.pxd
+++ b/runtime/include/python/chplrt.pxd
@@ -15,3 +15,8 @@ cdef extern from "chpl-external-array.h":
 	chpl_external_array chpl_make_external_array(uint64_t elt_size, uint64_t num_elts)
 	chpl_external_array chpl_make_external_array_ptr(void* elts, uint64_t size)
 	void chpl_free_external_array(chpl_external_array x)
+
+	ctypedef struct chpl_opaque_array:
+		int64_t _pid
+		void* _instance
+		bint _unowned

--- a/runtime/include/python/chplrt.pxd
+++ b/runtime/include/python/chplrt.pxd
@@ -20,9 +20,3 @@ cdef extern from "chpl-external-array.h":
 		int64_t _pid
 		void* _instance
 		bint _unowned
-
-cdef class ChplOpaqueArray:
-	cdef chpl_opaque_array val
-
-	cdef inline setVal(self, chpl_opaque_array val):
-		self.val = val

--- a/runtime/include/python/chplrt.pxd
+++ b/runtime/include/python/chplrt.pxd
@@ -20,3 +20,9 @@ cdef extern from "chpl-external-array.h":
 		int64_t _pid
 		void* _instance
 		bint _unowned
+
+cdef class ChplOpaqueArray:
+	cdef chpl_opaque_array val
+
+	cdef inline setVal(self, chpl_opaque_array val):
+		self.val = val

--- a/test/interop/python/arrayOpaquePointer_block.future
+++ b/test/interop/python/arrayOpaquePointer_block.future
@@ -1,2 +1,0 @@
-feature request: add compiler support for transforming other array types
-#11949

--- a/test/interop/python/arrayOpaquePointer_block.prediff
+++ b/test/interop/python/arrayOpaquePointer_block.prediff
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-sed '/from arrayOpaquePointer.c:[0-9]*[:]*$/d' $2 > $2.tmp
+sed '/from arrayOpaquePointer_block.c:[0-9]*[:]*$/d' $2 > $2.tmp
 sed '/^ *$/d' $2.tmp > $2
 rm $2.tmp
 export PYTHONPATH=lib/
-python3 use_arrayOpaquePointer.py >> $2
+python3 use_arrayOpaquePointer_block.py >> $2


### PR DESCRIPTION
#12105 adjusted the generated wrapper for array arguments and returns to
support both chpl_external_array and chpl_opaque array for C.  More work
was needed to support chpl_opaque_array for Python due to the Cython
files that must be generated.

Adds chpl_opaque_array to the list of symbols imported from the runtime,
and to the type definitions gained by chplrt.pxd from chpl-external-array.h

Generates a Python definition for ChplOpaqueArray, a Python type that
stores only a field of type chpl_opaque_array (because C types can't just
be thrown around from Cython to Python, they need a Python wrapper to
hold them).  Note that ideally this definition would be shared by all Python
libraries we generate instead of created for each one - defining it in the
shared runtime .pxd file caused Cython to look for a chplrt module, so for
now generate it on a per library basis and look for a different sharing
solution.

Adjust the type for function definitions in .pyx files that take
`chpl_opaque_array *` arguments to instead take `ChplOpaqueArray`
arguments and pass on a pointer to the val field to the C call.  Adjust
the return statement for `chpl_opaque_array` to instead make an instance
of `ChplOpaqueArray` that stores the result in its val field.

Fix the prediff for the Python test, which was accidentally not updated
after copying it from another test.  With these changes, this test now passes,
so remove the .future file.

Passed my python directory locally and a fresh checkout.