### PR TITLE
Remove support for flushing buffered AMOS with non-blocking transactions

### DIFF
--- a/modules/packages/BufferedAtomics.chpl
+++ b/modules/packages/BufferedAtomics.chpl
@@ -75,8 +75,7 @@
      buffers are flushed, the operations are performed all at once. Cray Linux
      Environment (CLE) 5.2.UP04 or newer is required for best performance. In
      our experience, buffered atomics can achieve up to a 5X performance
-     improvement over non-buffered atomics for CLE 5.2UP04 or newer and up to a
-     2.5X improvement for older versions of CLE.
+     improvement over non-buffered atomics for CLE 5.2UP04 or newer.
  */
 module BufferedAtomics {
 


### PR DESCRIPTION
For buffered atomics we internally buffer operations, and when flushed
we either use chained transactions (up to 5X performance improvement) or
we had support for issuing non-blocking transactions (up to 2.5X
performance improvement.) This removes the non-blocking transaction
fallback since it's not tested nightly and pre CLE 5.2UP04 is not an
important target for us currently. If it ever becomes important again we
can revert this change, or we could go with something more like
https://github.com/ronawho/chapel-archive/tree/cleanup-nb-amos-ugni,
which refactors code to make the nb-ops part of normal testing paths.
For buffered GETs/PUTs we could use the chpl_comm_nb{put,get} interface.

This partially reverts https://github.com/chapel-lang/chapel/pull/10857

Related to https://github.com/chapel-lang/chapel/issues/12067