### PR TITLE
Change an error around deserialization to use cnames for developers

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -7317,7 +7317,11 @@ static bool resolveSerializeDeserialize(AggregateType* at) {
         if (retType == dtVoid) {
           USR_FATAL(deserializeFn, "chpl__deserialize cannot return void");
         } else if (retType != at) {
-          USR_FATAL(deserializeFn, "chpl__deserialize returning '%s' when it must return '%s'", retType->symbol->name, at->symbol->name);
+          const char* rt = (developer == false) ? retType->symbol->name
+                                                : retType->symbol->cname;
+          const char* att =  (developer == false) ? at->symbol->name
+                                                  : at->symbol->cname;
+          USR_FATAL(deserializeFn, "chpl__deserialize returning '%s' when it must return '%s'", rt, att);
         }
       }
 


### PR DESCRIPTION
I was having trouble with deserialization error messages because the
pretty versions of my array types all looked similar in their sugared
form, making it difficult to see what was wrong.  Here, I've changed
the error so that in developer mode, it uses the cnames of the types
rather than their names to aid in comparing the two.