### PR TITLE
Fix test helper script for path of BUILD_VERSION

### DIFF
--- a/test/compflags/bradc/printstuff/versionhelp.sh
+++ b/test/compflags/bradc/printstuff/versionhelp.sh
@@ -3,6 +3,10 @@ CWD=$(cd $(dirname $0) ; pwd)
 compiler=$3
 
 echo -n `basename $compiler`
+
+subdir=`$CWD/../../../../util/printchplenv --simple --internal --all | grep CHPL_COMPILER_SUBDIR | cut -d = -f 2`
+build_version="$CWD/../../../../build/compiler/$subdir/BUILD_VERSION"
+
 cat $CWD/version.goodstart
-diff $CWD/../../../../compiler/main/BUILD_VERSION $CWD/zero.txt > /dev/null 2>&1 && echo "" || \
-    { echo -n " pre-release (" && cat $CWD/../../../../compiler/main/BUILD_VERSION | tr -d \"\\n && echo ")" ; }
+diff $build_version $CWD/zero.txt > /dev/null 2>&1 && echo "" || \
+    { echo -n " pre-release (" && cat $build_version | tr -d \"\\n && echo ")" ; }


### PR DESCRIPTION
Follow on to #12041. Fixes test failures with e.g. compflags/bradc/printstuff/version.