### PR TITLE
Stop ignoring files that moved to the build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,6 @@ tags
 
 
 # Top level ignores.
-/BUILD_VERSION
 /Chapel.xcodeproj
 /chplconfig
 /configured-prefix
@@ -38,9 +37,6 @@ tags
 /compiler/ifa/prim_data.h
 /compiler/ifa/make_prims/make_prims
 /compiler/ifa/make_prims/cygwin
-/compiler/main/BUILD_VERSION
-/compiler/main/CLANG_SETTINGS
-/compiler/main/CONFIGURED_PREFIX
 /compiler/main/COPYRIGHT
 /compiler/main/LICENSE
 /compiler/parser/bison-chapel.output


### PR DESCRIPTION
This just updates .gitignore to stop ignoring the files that should be removed.

Trivial and not reviewed.