### PR TITLE
In comm=ofi with fixed threads, provide 1 tx context for non-workers.

### DIFF
--- a/runtime/include/chpl-tasks.h
+++ b/runtime/include/chpl-tasks.h
@@ -354,6 +354,19 @@ uint32_t chpl_task_getFixedNumThreads(void) {
 }
 
 //
+// If the tasking layer runs tasks on a fixed number of threads and
+// the calling thread is one of those, this returns true.  Otherwise,
+// it returns false.
+//
+#ifndef CHPL_TASK_IMPL_IS_FIXED_THREAD
+#define CHPL_TASK_IMPL_IS_FIXED_THREAD() 0
+#endif
+static inline
+uint32_t chpl_task_isFixedThread(void) {
+  return CHPL_TASK_IMPL_IS_FIXED_THREAD();
+}
+
+//
 // returns the total number of threads that currently exist, whether running,
 // blocked, or idle
 //

--- a/runtime/include/tasks/qthreads/chpl-tasks-impl.h
+++ b/runtime/include/tasks/qthreads/chpl-tasks-impl.h
@@ -237,6 +237,9 @@ void chpl_task_setSubloc(c_sublocid_t full_subloc)
 uint32_t chpl_task_impl_getFixedNumThreads(void);
 
 
+#define CHPL_TASK_IMPL_IS_FIXED_THREAD() (qthread_shep() != NO_SHEPHERD)
+
+
 //
 // Can we support remote caching?
 //


### PR DESCRIPTION
If the ofi comm layer finds that it's working with a tasking layer that
uses a fixed number of threads and the ofi provider can supply enough
transmit contexts for each of those to have one of its own, then it will
permanently bind transmit contexts to threads to improve performance.
When checking to see if that was possible we had been ensuring there
were enough contexts for each fixed thread plus one for the AM handler.
But under certain circumstances we may also need one for some other
thread, notably the process itself.  When that happens the context
allocator will find itself out of resources and throw an internal
error.

Here, account for needing one more transmit context, to be shared by all
threads that are neither tasking layer fixed workers nor AM handlers.

As a necessary adjunct, this adds `chpl_task_isFixedThread()` to the
tasking layer interface.  It tells whether or not the calling thread is one
of the tasking layer fixed workers.