### PR TITLE
Improve skipif for test

### DIFF
--- a/test/interop/C/exportArray/callArrayOpaquePointer_noArgDom.skipif
+++ b/test/interop/C/exportArray/callArrayOpaquePointer_noArgDom.skipif
@@ -1,2 +1,4 @@
-# Use gcc errors only
+# Use linux gcc errors only
 CHPL_TARGET_COMPILER != gnu
+CHPL_TARGET_PLATFORM >= linux
+CHPL_LLVM != none


### PR DESCRIPTION
This test currently locks in a failure mode that is compiler and system
specific.  I had forgotten that I needed to make it even more exclusive in that
case to avoid things like LLVM and cygwin.

Seems to still run where I want it to