### PR TITLE
When using gen_release, if no version set, copy BUILD_VERSION

### DIFF
--- a/util/buildRelease/gen_release
+++ b/util/buildRelease/gen_release
@@ -88,7 +88,7 @@ if (exists($ENV{"CHPL_GEN_RELEASE_NO_CLONE"})) {
     print "[gen_release] Confirm final Git source version used.\n";
     SystemOrDie("cd $rootdir && git status && git log -1");
 
-    if ($version eq "") {
+    if ($version eq "" or $version eq "developer") {
       print "[gen_release] Create BUILD_VERSION file.\n";
       SystemOrDie("cd $rootdir/compiler && make main/BUILD_VERSION");
     }
@@ -96,7 +96,7 @@ if (exists($ENV{"CHPL_GEN_RELEASE_NO_CLONE"})) {
     print "[gen_release] Creating build workspace with git archive...\n";
     SystemOrDie("cd $rootdir && git archive --format=tar HEAD | (cd $archive_dir && tar -xf -)");
 
-    if ($version eq "") {
+    if ($version eq "" or $version eq "developer") {
       print "[gen_release] Copying BUILD_VERSION file.\n";
       SystemOrDie("cp $rootdir/compiler/main/BUILD_VERSION $archive_dir/compiler/main/BUILD_VERSION");
     }

--- a/util/buildRelease/gen_release
+++ b/util/buildRelease/gen_release
@@ -88,8 +88,18 @@ if (exists($ENV{"CHPL_GEN_RELEASE_NO_CLONE"})) {
     print "[gen_release] Confirm final Git source version used.\n";
     SystemOrDie("cd $rootdir && git status && git log -1");
 
+    if ($version eq "") {
+      print "[gen_release] Create BUILD_VERSION file.\n";
+      SystemOrDie("cd $rootdir/compiler && make main/BUILD_VERSION");
+    }
+
     print "[gen_release] Creating build workspace with git archive...\n";
     SystemOrDie("cd $rootdir && git archive --format=tar HEAD | (cd $archive_dir && tar -xf -)");
+
+    if ($version eq "") {
+      print "[gen_release] Copying BUILD_VERSION file.\n";
+      SystemOrDie("cp $rootdir/compiler/main/BUILD_VERSION $archive_dir/compiler/main/BUILD_VERSION");
+    }
 
     if (defined($ENV{"CHPL_HOME"})) {
         $resultdir = $ENV{"CHPL_HOME"};


### PR DESCRIPTION
This allows the commit used to create the release to remain in the
version output. It makes it clearer where releases built solely for
testing come from.

When gen_release is provided with a version argument, and that
version argument is not "developer", the BUILD_VERSION
will not be copied, so it is instead generated to store "0" as is
normally the case for the released version.

- [x] checked expected behavior for two calls to gen_release (with and without version)
- [x] checked ./util/buildRelease/test_rpm_module.bash still functions

Reviewed by @ronawho - thanks!