### PR TITLE
Add a future w/ a bug BenA discovered with array arguments in exported functions

### DIFF
--- a/test/interop/C/exportArray/arrayArg-queriedDomain.bad
+++ b/test/interop/C/exportArray/arrayArg-queriedDomain.bad
@@ -1,0 +1,8 @@
+arrayArg-queriedDomain.chpl:1: internal error: RES-CAL-NFO-0078 chpl version 1.19.0 pre-release (d4b9b6ce6b)
+Note: This source location is a guess.
+
+Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
+please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
+the filename + line number above may be useful in working around the issue.
+

--- a/test/interop/C/exportArray/arrayArg-queriedDomain.chpl
+++ b/test/interop/C/exportArray/arrayArg-queriedDomain.chpl
@@ -1,0 +1,4 @@
+export proc foo(x: [?D] int) {
+  writeln(D);
+  writeln(x);
+}

--- a/test/interop/C/exportArray/arrayArg-queriedDomain.future
+++ b/test/interop/C/exportArray/arrayArg-queriedDomain.future
@@ -1,0 +1,2 @@
+bug: internal error for array argument with queried domain in exported function
+#12135


### PR DESCRIPTION
This is due to supporting both chpl_external_array and chpl_opaque_array (and
not testing queried domain arguments, whoops)