### PR TITLE
Add missing compopts files for --library compilation

### DIFF
--- a/test/interop/C/exportArray/arrayArg-queriedDomain.compopts
+++ b/test/interop/C/exportArray/arrayArg-queriedDomain.compopts
@@ -1,0 +1,2 @@
+--library
+ # arrayArg-queriedDomain.good

--- a/test/interop/C/exportArray/exportArrNoEltType.compopts
+++ b/test/interop/C/exportArray/exportArrNoEltType.compopts
@@ -1,0 +1,2 @@
+--library
+ # exportArrNoEltType.good


### PR DESCRIPTION
I realized belatedly that this test directory didn't have a global COMPOPTS file
to include --library for the .chpl tests, and couldn't due to #11009.  This didn't
impact all the .chpl tests but it did impact one I just added and an older test.
Add a .compopts file which checks the behavior with and without the flag.

I discovered this by looking more closely at the testing output.  Validated by
running a fresh checkout and looking closely at the compilation step for that
run.