### PR TITLE
Add a deprecation test for throw borrowed

### DIFF
--- a/test/deprecated/throw-borrowed.chpl
+++ b/test/deprecated/throw-borrowed.chpl
@@ -1,0 +1,9 @@
+// the warning emitted for throwing a borrow
+// should be changed to an error after 1.19.
+
+proc test() throws {
+  var x = new borrowed Error();
+  throw x;
+}
+
+try! test();

--- a/test/deprecated/throw-borrowed.good
+++ b/test/deprecated/throw-borrowed.good
@@ -1,0 +1,2 @@
+throw-borrowed.chpl:4: In function 'test':
+throw-borrowed.chpl:6: warning: Throwing borrowed error - please throw owned


### PR DESCRIPTION
it should be an error after 1.19.