### PR TITLE
Add :throws: documentation to SysError's ioerror functions and resolve a bug

### DIFF
--- a/modules/standard/SysError.chpl
+++ b/modules/standard/SysError.chpl
@@ -383,14 +383,17 @@ private proc quote_string(s:string, len:ssize_t) {
   return new string(ret, isowned=true, needToCopy=false);
 }
 
-/* Throw a :class:`SystemError` if an error occurred, formatting a useful
-   message based on the provided arguments. Do nothing if the error argument
-   does not indicate an error occurred.
+/* Create and throw a :class:`SystemError` if an error occurred, formatting a
+   useful message based on the provided arguments. Do nothing if the error
+   argument does not indicate an error occurred.
 
    :arg error: the error code
    :arg msg: extra information to include in the thrown error
    :arg path: a path to include in the thrown error
    :arg offset: an offset to include in the thrown error
+
+   :throws SystemError: A subtype is thrown when the error argument indicates an
+                        error occurred
  */
 proc ioerror(error:syserr, msg:string, path:string, offset:int(64)) throws
 {
@@ -418,13 +421,15 @@ proc ioerror(error:syserr, msg:string) throws
   if error then throw SystemError.fromSyserr(error, msg);
 }
 
-/* Throw an :class:`IOError` and include a formatted message based on the
-   provided arguments.
+/* Create and throw an :class:`IOError` and include a formatted message based on
+   the provided arguments.
 
    :arg errstr: the error string
    :arg msg: extra information to print after the error description
    :arg path: a path to print out that is related to the error
    :arg offset: an offset to print out that is related to the error
+
+   :throws IOError: always throws an IOError
  */
 proc ioerror(errstr:string, msg:string, path:string, offset:int(64)) throws
 {

--- a/modules/standard/SysError.chpl
+++ b/modules/standard/SysError.chpl
@@ -108,6 +108,8 @@ class SystemError : Error {
       return new owned UnexpectedEOFError(details, err);
     } else if err == EFORMAT {
       return new owned BadFormatError(details, err);
+    } else if err == EIO {
+      return new owned IOError(err, details);
     }
 
     return new owned SystemError(err, details);

--- a/test/errhandling/lydia/ioerrorCheck.chpl
+++ b/test/errhandling/lydia/ioerrorCheck.chpl
@@ -1,0 +1,12 @@
+use SysError;
+
+proc main() {
+  try! {
+    ioerror("blah blah", "blah blah blah", "unknown", -1);
+  } catch e: IOError {
+    writeln("caught the right subclass");
+  } catch e : SystemError {
+    writeln("Hey, wait a minute!  That didn't throw an IOError!");
+    writeln(e.details);
+  }
+}

--- a/test/errhandling/lydia/ioerrorCheck.good
+++ b/test/errhandling/lydia/ioerrorCheck.good
@@ -1,0 +1,1 @@
+caught the right subclass

--- a/test/io/ferguson/asserteof.good
+++ b/test/io/ferguson/asserteof.good
@@ -1,4 +1,4 @@
 Past First Check
-uncaught SystemError: Input/output error (assert failed - Not at EOF with path "asserteof.test.nums" offset 3)
+uncaught IOError: Input/output error (assert failed - Not at EOF with path "asserteof.test.nums" offset 3)
   asserteof.chpl:28: thrown here
   asserteof.chpl:28: uncaught here

--- a/test/io/sungeun/ioerror.EACCES.good
+++ b/test/io/sungeun/ioerror.EACCES.good
@@ -1,3 +1,3 @@
-uncaught SystemError: Input/output error (Permission denied EACCES with path "this/is/my/path" offset -1)
+uncaught IOError: Input/output error (Permission denied EACCES with path "this/is/my/path" offset -1)
   ioerror.chpl:10: thrown here
   ioerror.chpl:10: uncaught here


### PR DESCRIPTION
Adds a `:throws:` tag to the two variants of `ioerror` that have documentation
(the other two are listed in the generated docs but don't have a comment
associated with them).

Generated documentation:
![screen shot 2019-01-25 at 11 54 15 am](https://user-images.githubusercontent.com/2454710/51769473-0014ed00-2098-11e9-93a1-bbc6df240929.png)

Resolves #11476 

The `ioerror` variant that took in a `string` instead of a `syserr` had a bug.
The documentation said an `IOError` would be thrown, but due to an oversight
in the `SystemError.fromSyserr` factory method, a `SystemError` was thrown
instead.  I added a test to track this and fixed the issue (since the fix seemed
obvious).  I also updated two tests that had used the old error name.

Ran a full paratest with futures
