### PR TITLE
Rename chpl_external_array "size" field to "num_elts"

### DIFF
--- a/compiler/codegen/symbol.cpp
+++ b/compiler/codegen/symbol.cpp
@@ -2233,13 +2233,13 @@ std::string FnSymbol::getPythonArrayReturnStmts() {
   std::string typeStrCDefs = getPythonTypeName(eltType->type, C_PYX);
   // Create the numpy array to return
   // E.g. cdef numpy.ndarray [C element type, ndim=1] ret =
-  //          numpy.zeros(shape = ret_arr.size, dtype = Python element type)
+  //          numpy.zeros(shape = ret_arr.num_elts, dtype = Python element type)
   std::string res = "\tcdef numpy.ndarray [" + typeStrCDefs + ", ndim=1] ret";
-  res += " = numpy.zeros(shape = ret_arr.size, dtype = " + typeStr + ")\n";
+  res += " = numpy.zeros(shape = ret_arr.num_elts, dtype = " + typeStr + ")\n";
 
   // Populate it with the contents we return (which translated C types into
   // Python types)
-  res += "\tfor i in range(ret_arr.size):\n";
+  res += "\tfor i in range(ret_arr.num_elts):\n";
   res += "\t\tret[i] = (<" + typeStrCDefs + "*>ret_arr.elts)[i]\n";
 
   // Free the returned array now that its contents have been stored elsewhere

--- a/modules/internal/ExternalArray.chpl
+++ b/modules/internal/ExternalArray.chpl
@@ -33,7 +33,7 @@ module ExternalArray {
 
   extern record chpl_external_array {
     var elts: c_void_ptr;
-    var size: uint;
+    var num_elts: uint;
 
     var freer: c_void_ptr;
   }
@@ -42,19 +42,19 @@ module ExternalArray {
   chpl_make_external_array(elt_size: uint, num_elts: uint): chpl_external_array;
 
   extern proc chpl_make_external_array_ptr(elts: c_void_ptr,
-                                           size: uint): chpl_external_array;
+                                           num_elts: uint): chpl_external_array;
 
   extern proc
   chpl_make_external_array_ptr_free(elts: c_void_ptr,
-                                    size: uint): chpl_external_array;
+                                    num_elts: uint): chpl_external_array;
 
   extern proc chpl_free_external_array(x: chpl_external_array);
   extern proc chpl_call_free_func(func: c_void_ptr, elts: c_void_ptr);
 
   // Creates an instance of our new array type
   pragma "no copy return"
-  proc makeArrayFromPtr(value: c_ptr, size: uint) {
-    var data = chpl_make_external_array_ptr(value : c_void_ptr, size);
+  proc makeArrayFromPtr(value: c_ptr, num_elts: uint) {
+    var data = chpl_make_external_array_ptr(value : c_void_ptr, num_elts);
     return makeArrayFromExternArray(data, value.eltType);
   }
 
@@ -63,7 +63,7 @@ module ExternalArray {
     var dom = defaultDist.dsiNewRectangularDom(rank=1,
                                                idxType=int,
                                                stridable=false,
-                                               inds=(0..#value.size,));
+                                               inds=(0..#value.num_elts,));
     dom._free_when_no_arrs = true;
     var arr = new unmanaged DefaultRectangularArr(eltType=eltType,
                                                   rank=1,

--- a/runtime/include/chpl-external-array.h
+++ b/runtime/include/chpl-external-array.h
@@ -27,7 +27,7 @@ typedef void (*chpl_free_func)(void*);
 
 typedef struct {
   void* elts;
-  uint64_t size;
+  uint64_t num_elts;
 
   void* freer;
 } chpl_external_array;
@@ -35,9 +35,9 @@ typedef struct {
 chpl_external_array chpl_make_external_array(uint64_t elt_size,
                                              uint64_t num_elts);
 chpl_external_array chpl_make_external_array_ptr(void* elts,
-                                                 uint64_t size);
+                                                 uint64_t num_elts);
 chpl_external_array chpl_make_external_array_ptr_free(void* elts,
-                                                      uint64_t size);
+                                                      uint64_t num_elts);
 void chpl_free_external_array(chpl_external_array x);
 void chpl_call_free_func(void* func, void* elts);
 

--- a/runtime/include/python/chplrt.pxd
+++ b/runtime/include/python/chplrt.pxd
@@ -10,10 +10,10 @@ cdef extern from "chpl-init.h":
 cdef extern from "chpl-external-array.h":
 	ctypedef struct chpl_external_array:
 		void* elts
-		uint64_t size
+		uint64_t num_elts
 
 	chpl_external_array chpl_make_external_array(uint64_t elt_size, uint64_t num_elts)
-	chpl_external_array chpl_make_external_array_ptr(void* elts, uint64_t size)
+	chpl_external_array chpl_make_external_array_ptr(void* elts, uint64_t num_elts)
 	void chpl_free_external_array(chpl_external_array x)
 
 	ctypedef struct chpl_opaque_array:

--- a/runtime/src/chpl-external-array.c
+++ b/runtime/src/chpl-external-array.c
@@ -33,25 +33,25 @@ chpl_external_array chpl_make_external_array(uint64_t elt_size,
                                 0);
   chpl_external_array ret;
   ret.elts = my_mem;
-  ret.size = num_elts;
+  ret.num_elts = num_elts;
   ret.freer = chpl_wrap_chapel_free_call;
   return ret;
 }
 
 chpl_external_array chpl_make_external_array_ptr(void* elts,
-                                                 uint64_t size) {
+                                                 uint64_t num_elts) {
   chpl_external_array ret;
   ret.elts = elts;
-  ret.size = size;
+  ret.num_elts = num_elts;
   ret.freer = NULL;
   return ret;
 }
 
 chpl_external_array chpl_make_external_array_ptr_free(void* elts,
-                                                      uint64_t size) {
+                                                      uint64_t num_elts) {
   chpl_external_array ret;
   ret.elts = elts;
-  ret.size = size;
+  ret.num_elts = num_elts;
   ret.freer = chpl_wrap_chapel_free_call;
   return ret;
 }

--- a/test/interop/C/exportArray/returningArr/callFuncReturnsArrayTakesArg.test.c
+++ b/test/interop/C/exportArray/returningArr/callFuncReturnsArrayTakesArg.test.c
@@ -14,7 +14,7 @@ int main(int argc, char* argv[]) {
   int64_t* actual = (int64_t*)arr.elts;
 
   // Write its elements
-  for (int i = 0; i < arr.size; i++) {
+  for (int i = 0; i < arr.num_elts; i++) {
     printf("Element[%d] = %" PRId64 "\n", i, actual[i]);
   }
 

--- a/test/interop/C/exportArray/returningArr/callFuncReturnsArrayTakesArg2.test.c
+++ b/test/interop/C/exportArray/returningArr/callFuncReturnsArrayTakesArg2.test.c
@@ -14,7 +14,7 @@ int main(int argc, char* argv[]) {
   int64_t* actual = (int64_t*)arr.elts;
 
   // Write its elements
-  for (int i = 0; i < arr.size; i++) {
+  for (int i = 0; i < arr.num_elts; i++) {
     printf("Element[%d] = %" PRId64 "\n", i, actual[i]);
   }
 

--- a/test/interop/C/exportArray/returningArr/callFuncReturnsArrayTakesArrayArg.test.c
+++ b/test/interop/C/exportArray/returningArr/callFuncReturnsArrayTakesArrayArg.test.c
@@ -15,12 +15,12 @@ int main(int argc, char* argv[]) {
   chpl_external_array arr = foo(&arg);
   int64_t* actual = (int64_t*)arr.elts;
 
-  if (arr.size != arg.size) {
+  if (arr.num_elts != arg.num_elts) {
     printf("Uh oh!");
   }
 
   // Write its elements
-  for (int i = 0; i < arr.size; i++) {
+  for (int i = 0; i < arr.num_elts; i++) {
     printf("Element[%d] = %" PRId64 "\n", i, actual[i]);
   }
 

--- a/test/interop/C/exportArray/returningArr/callFuncReturnsArrayTakesArrayArg2.test.c
+++ b/test/interop/C/exportArray/returningArr/callFuncReturnsArrayTakesArrayArg2.test.c
@@ -15,12 +15,12 @@ int main(int argc, char* argv[]) {
   chpl_external_array arr = foo(&arg);
   int64_t* actual = (int64_t*)arr.elts;
 
-  if (arr.size != arg.size) {
+  if (arr.num_elts != arg.num_elts) {
     printf("Uh oh!");
   }
 
   // Write its elements
-  for (int i = 0; i < arr.size; i++) {
+  for (int i = 0; i < arr.num_elts; i++) {
     printf("Element[%d] = %" PRId64 "\n", i, actual[i]);
   }
 

--- a/test/interop/C/exportArray/returningArr/callFuncReturnsArrayTakesArrayArg3.test.c
+++ b/test/interop/C/exportArray/returningArr/callFuncReturnsArrayTakesArrayArg3.test.c
@@ -15,12 +15,12 @@ int main(int argc, char* argv[]) {
   chpl_external_array arr = foo(&arg);
   int64_t* actual = (int64_t*)arr.elts;
 
-  if (arr.size != arg.size) {
+  if (arr.num_elts != arg.num_elts) {
     printf("Uh oh!");
   }
 
   // Write its elements
-  for (int i = 0; i < arr.size; i++) {
+  for (int i = 0; i < arr.num_elts; i++) {
     printf("Element[%d] = %" PRId64 "\n", i, actual[i]);
   }
 

--- a/test/interop/C/exportArray/returningArr/callFuncReturnsArrayTakesArrayArg4.test.c
+++ b/test/interop/C/exportArray/returningArr/callFuncReturnsArrayTakesArrayArg4.test.c
@@ -15,12 +15,12 @@ int main(int argc, char* argv[]) {
   chpl_external_array arr = foo(&arg);
   int64_t* actual = (int64_t*)arr.elts;
 
-  if (arr.size != arg.size) {
+  if (arr.num_elts != arg.num_elts) {
     printf("Uh oh!");
   }
 
   // Write its elements
-  for (int i = 0; i < arr.size; i++) {
+  for (int i = 0; i < arr.num_elts; i++) {
     printf("Element[%d] = %" PRId64 "\n", i, actual[i]);
   }
 


### PR DESCRIPTION
In the library deep dive back at the end of September, I was asked to rename
this field and unify the arguments that set it.  This PR accomplishes that.

Passed a full paratest, and checked the python tests locally