### PR TITLE
Speed up gasnet builds

### DIFF
--- a/third-party/gasnet/Makefile
+++ b/third-party/gasnet/Makefile
@@ -19,6 +19,7 @@ endif
 endif
 
 ifneq ($(CHPL_MAKE_COMM_SUBSTRATE),none)
+CHPL_GASNET_CFG_OPTIONS += --disable-auto-conduit-detect
 CHPL_GASNET_CFG_OPTIONS += --enable-$(CHPL_MAKE_COMM_SUBSTRATE)
 endif
 
@@ -47,13 +48,19 @@ ifneq (, $(filter $(CHPL_MAKE_TARGET_PLATFORM),cray-xe cray-xc cray-xk))
 CHPL_GASNET_CFG_OPTIONS += --enable-pthreads
 ifeq ($(CHPL_MAKE_COMM_SUBSTRATE),gemini)
 CHPL_GASNET_CFG_OPTIONS += --enable-gemini-multi-domain
+CHPL_GASNET_CFG_OPTIONS += --disable-aries --disable-mpi --disable-smp --disable-ofi
 else
 ifeq ($(CHPL_MAKE_COMM_SUBSTRATE),aries)
 CHPL_GASNET_CFG_OPTIONS += --enable-aries-multi-domain
+CHPL_GASNET_CFG_OPTIONS += --disable-gemini --disable-mpi --disable-smp --disable-ofi
+else
+ifeq ($(CHPL_MAKE_COMM_SUBSTRATE),mpi)
+CHPL_GASNET_CFG_OPTIONS += --disable-gemini --disable-aries --disable-smp --disable-ofi
 else
 # We need to do this because the auto-detect stuff for gemini is not
 # yet working as well as the portals auto-detect
 CHPL_GASNET_CFG_OPTIONS += --disable-gemini --disable-aries
+endif
 endif
 endif
 ifeq ($(CHPL_MAKE_TARGET_PLATFORM),cray-xc)


### PR DESCRIPTION
We build gasnet for a single conduit/substrate at a time, but we were
leaving gasnet's auto-detect on so it could (and usually did) build
other conduits that we'll never use since we embed the substrate in our
build/install paths.

In order to speed up build times use `--disable-auto-conduit-detect`.
For the cray build we have to explicitly disable conduits that the
cross-configure script enables.

Here's some build time improvements for a few configs/machines:

| config     | master | disable auto | configs skipped     |
| ---------- | ------ | ------------ | ------------------- |
| darwin udp | 115s   | 100s         | smp                 |
| linux ibv  |  98s   |  50s         | smp, mpi, ofi       |
| XC aries   | 114s   |  74s         | mpi, smp, ofi-probe |
| XC mpi     |  89s   |  71s         | smp, ofi-probe      |
