### PR TITLE
Update the copyright year in this new file to include 2019

### DIFF
--- a/modules/packages/FunctionalOperations.chpl
+++ b/modules/packages/FunctionalOperations.chpl
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2018 Cray Inc.
+ * Copyright 2004-2019 Cray Inc.
  * Other additional copyright holders may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,


### PR DESCRIPTION
I added the standard copyright to this file in 2018, and forgot to update
it now that it is 2019.