### PR TITLE
Minor improvements for debugging the compiler

### DIFF
--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -131,7 +131,6 @@ void parseExplainFlag(char* flag, int* line, ModuleSymbol** module);
 FnSymbol* findCopyInit(AggregateType* ct);
 
 FnSymbol* getTheIteratorFn(Symbol* ic);
-FnSymbol* getTheIteratorFn(CallExpr* call);
 FnSymbol* getTheIteratorFn(Type* icType);
 
 // forall intents

--- a/compiler/include/view.h
+++ b/compiler/include/view.h
@@ -92,7 +92,6 @@ void        whocalls(BaseAST* ast);
 
 FnSymbol*   debugGetTheIteratorFn(int id);
 FnSymbol*   debugGetTheIteratorFn(BaseAST* ast);
-FnSymbol*   debugGetTheIteratorFn(Symbol* sym);
 FnSymbol*   debugGetTheIteratorFn(Type* type);
 FnSymbol*   debugGetTheIteratorFn(ForLoop* forLoop);
 

--- a/compiler/resolution/lowerIterators.cpp
+++ b/compiler/resolution/lowerIterators.cpp
@@ -51,10 +51,6 @@ FnSymbol* getTheIteratorFn(Symbol* ic) {
   return getTheIteratorFn(ic->type);
 }
 
-FnSymbol* getTheIteratorFn(CallExpr* call) {
-  return getTheIteratorFn(call->get(1)->typeInfo());
-}
-
 // icType is either an _iteratorClass type or a tuple thereof
 // When icType is a tuple, this function returns
 //  the getIterator function for the first tuple element.
@@ -78,6 +74,7 @@ FnSymbol* getTheIteratorFn(Type* icType)
   return icTypeAgg->iteratorInfo->iterator;
 }
 
+// When debugging, avoid assertion failures of the production version.
 FnSymbol* debugGetTheIteratorFn(Type* type) {
   FnSymbol* result = NULL;
   if (AggregateType* agg = toAggregateType(type)) {
@@ -95,10 +92,6 @@ FnSymbol* debugGetTheIteratorFn(Type* type) {
       if (IteratorInfo* ii = agg->iteratorInfo)
         result = ii->iterator;
   }
-  if (result && result->hasFlag(FLAG_AUTO_II))
-    if (AggregateType* rettype = toAggregateType(result->retType))
-      if (FnSymbol* newresult = debugGetTheIteratorFn(rettype))
-        result = newresult;
   return result;
 }
 

--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -807,7 +807,7 @@ static Expr* preFoldPrimOp(CallExpr* call) {
     call->replace(retval);
 
   } else if (call->isPrimitive(PRIM_TO_FOLLOWER)) {
-    FnSymbol* iterator     = getTheIteratorFn(call);
+    FnSymbol* iterator     = getTheIteratorFn(call->get(1)->typeInfo());
     CallExpr* followerCall = NULL;
 
     if (FnSymbol* f2 = findForallexprFollower(iterator)) {
@@ -870,7 +870,7 @@ static Expr* preFoldPrimOp(CallExpr* call) {
     retval = leaderCall;
 
   } else if (call->isPrimitive(PRIM_TO_STANDALONE)) {
-    FnSymbol* iterator       = getTheIteratorFn(call);
+    FnSymbol* iterator       = getTheIteratorFn(call->get(1)->typeInfo());
     CallExpr* standaloneCall = new CallExpr(iterator->name);
 
     for_formals(formal, iterator) {

--- a/compiler/resolution/visibleFunctions.cpp
+++ b/compiler/resolution/visibleFunctions.cpp
@@ -28,6 +28,7 @@
 #include "stmt.h"
 #include "stringutil.h"
 #include "symbol.h"
+#include "view.h"
 
 #include <map>
 #include <set>
@@ -224,22 +225,18 @@ static void getVisibleFunctions(const char*           name,
 
     if (call->id == breakOnResolveID) {
       if (moduleBlock)
-        printf("visible fns: block %i module %s %s:%i\n",
-               block->id, inMod->name,
-               block->fname(), block->linenum());
+        printf("visible fns: block %i  module %s  %s\n",
+               block->id, inMod->name, debugLoc(block));
       else if (fnBlock)
-        printf("visible fns: block %i fn %s %s:%i\n",
-               block->id, inFn->name,
-               block->fname(), block->linenum());
+        printf("visible fns: block %i  fn %s  %s\n",
+               block->id, inFn->name, debugLoc(block));
       else
-        printf("visible fns: block %i %s:%i\n",
-               block->id,
-               block->fname(), block->linenum());
+        printf("visible fns: block %i  %s\n",
+               block->id, debugLoc(block));
 
       if (instantiationPt) {
-        printf("  instantiated from block %i %s:%i\n",
-               instantiationPt->id,
-               instantiationPt->fname(), instantiationPt->linenum());
+        printf("  instantiated from block %i  %s\n",
+               instantiationPt->id, debugLoc(instantiationPt));
       }
     }
 


### PR DESCRIPTION
Developed while working on #12131.

* Improvements to list_ast(). Most notably, print out an empty BlockStmt
  on 1 line, not two. Which helps when printing shadow variables.

* Cleanups to getTheIteratorFn() and debugGetTheIteratorFn().

* When printing out "visible fns", by default show the file names
  without paths. This makes the output tidier. (OK-ed by @mppf.)

Trivial, not reviewed.
