### PR TITLE
Automatically fence unordered operations at task termination

### DIFF
--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1007,6 +1007,8 @@ module ChapelBase {
   pragma "down end count fn"
   proc _downEndCount(e: _EndCount, err: unmanaged Error) {
     chpl_save_task_error(e, err);
+    extern proc chpl_comm_task_end(): void;
+    chpl_comm_task_end();
     // inform anybody waiting that we're done
     e.i.sub(1, memory_order_release);
   }

--- a/runtime/include/chpl-cache.h
+++ b/runtime/include/chpl-cache.h
@@ -34,7 +34,9 @@ extern const int CHPL_CACHE_REMOTE;
 static inline
 int chpl_cache_enabled(void)
 {
-  return CHPL_CACHE_REMOTE && chpl_task_supportsRemoteCache();
+  // The remote cache uses thread local storage, so if tasks can migrate
+  // between threads we lose out ability to correctly fence.
+  return CHPL_CACHE_REMOTE && !chpl_task_canMigrateThreads();
 }
 
 

--- a/runtime/include/chpl-comm-native-atomics.h
+++ b/runtime/include/chpl-comm-native-atomics.h
@@ -163,5 +163,6 @@ DECL_CHPL_COMM_ATOMIC_BINARY(sub, real32)
 DECL_CHPL_COMM_ATOMIC_BINARY(sub, real64)
 
 void chpl_comm_atomic_unordered_fence(void);
+void chpl_comm_atomic_unordered_task_fence(void);
 
 #endif // _chpl_comm_native_atomics_h_

--- a/runtime/include/chpl-comm.h
+++ b/runtime/include/chpl-comm.h
@@ -492,6 +492,10 @@ int chpl_comm_numPollingTasks(void);
 // an atomic variable for other tasks to finish).
 void chpl_comm_make_progress(void);
 
+// This is a hook that's called when a task is ending. It allows for things
+// like say flushing task private buffers.
+void chpl_comm_task_end(void);
+
 //
 // Comm diagnostics stuff
 //

--- a/runtime/include/chpl-tasks.h
+++ b/runtime/include/chpl-tasks.h
@@ -367,6 +367,22 @@ uint32_t chpl_task_isFixedThread(void) {
 }
 
 //
+// If the tasking layer will always execute tasks on the same thread
+// they started on, this returns true.  Otherwise, it returns false.
+// For example CHPL_TASKS=fifo a task is a thread, so tasks can't
+// migrate.  For CHPL_TASKS=qthreads some schedulers support
+// work-stealing where tasks can be stolen and moved to a diferent
+// then they started on.
+//
+#ifndef CHPL_TASK_IMPL_CAN_MIGRATE_THREADS
+#define CHPL_TASK_IMPL_CAN_MIGRATE_THREADS() 1
+#endif
+static inline
+uint32_t chpl_task_canMigrateThreads(void) {
+  return CHPL_TASK_IMPL_CAN_MIGRATE_THREADS();
+}
+
+//
 // returns the total number of threads that currently exist, whether running,
 // blocked, or idle
 //

--- a/runtime/include/chpl-tasks.h
+++ b/runtime/include/chpl-tasks.h
@@ -284,20 +284,6 @@ chpl_task_ChapelData_t* chpl_task_getChapelData(void)
 
 
 //
-// Can this tasking layer support remote caching?
-//
-// (In practice this answers: "Are tasks bound to specific pthreads
-// or, if not, does the tasking layer make memory consistency calls
-// whenever it might move a task from one pthread to another?"  Remote
-// caching uses pthread-specific data (TLS) extensively, so it turns
-// itself off when it's used with a tasking layer that can't support
-// that.)
-//
-#ifndef CHPL_TASK_SUPPORTS_REMOTE_CACHE_IMPL_DECL
-int chpl_task_supportsRemoteCache(void);
-#endif
-
-//
 // Returns the maximum width of parallelism the tasking layer expects
 // to be able to provide on the calling (sub)locale.  With some
 // exceptions for uncommon cases, this is the greatest parallel

--- a/runtime/include/comm/ugni/chpl-comm-impl.h
+++ b/runtime/include/comm/ugni/chpl-comm-impl.h
@@ -66,6 +66,7 @@ void chpl_comm_get_unordered(void *addr, c_nodeid_t node, void* raddr,
                              int ln, int32_t fn);
 
 void chpl_comm_get_unordered_fence(void);
+void chpl_comm_get_unordered_task_fence(void);
 
 //
 // Internal statistics gathering and reporting.

--- a/runtime/include/tasks/fifo/chpl-tasks-impl.h
+++ b/runtime/include/tasks/fifo/chpl-tasks-impl.h
@@ -128,16 +128,6 @@ c_sublocid_t chpl_task_getRequestedSubloc(void) {
 
 #define CHPL_TASK_IMPL_CAN_MIGRATE_THREADS() 0
 
-#ifdef CHPL_TASK_SUPPORTS_REMOTE_CACHE_IMPL_DECL
-#error "CHPL_TASK_SUPPORTS_REMOTE_CACHE_IMPL_DECL is already defined!"
-#else
-#define CHPL_TASK_SUPPORTS_REMOTE_CACHE_IMPL_DECL 1
-#endif
-static inline
-int chpl_task_supportsRemoteCache(void) {
-  return 1;
-}
-
 #ifdef __cplusplus
 } // end extern "C"
 #endif

--- a/runtime/include/tasks/fifo/chpl-tasks-impl.h
+++ b/runtime/include/tasks/fifo/chpl-tasks-impl.h
@@ -126,6 +126,7 @@ c_sublocid_t chpl_task_getRequestedSubloc(void) {
   return c_sublocid_any;
 }
 
+#define CHPL_TASK_IMPL_CAN_MIGRATE_THREADS() 0
 
 #ifdef CHPL_TASK_SUPPORTS_REMOTE_CACHE_IMPL_DECL
 #error "CHPL_TASK_SUPPORTS_REMOTE_CACHE_IMPL_DECL is already defined!"

--- a/runtime/include/tasks/qthreads/chpl-tasks-impl.h
+++ b/runtime/include/tasks/qthreads/chpl-tasks-impl.h
@@ -236,8 +236,9 @@ void chpl_task_setSubloc(c_sublocid_t full_subloc)
     chpl_task_impl_getFixedNumThreads()
 uint32_t chpl_task_impl_getFixedNumThreads(void);
 
-
 #define CHPL_TASK_IMPL_IS_FIXED_THREAD() (qthread_shep() != NO_SHEPHERD)
+
+#define CHPL_TASK_IMPL_CAN_MIGRATE_THREADS() CHPL_QTHREAD_TASKS_CAN_MIGRATE_THREADS
 
 
 //

--- a/runtime/include/tasks/qthreads/chpl-tasks-impl.h
+++ b/runtime/include/tasks/qthreads/chpl-tasks-impl.h
@@ -240,20 +240,6 @@ uint32_t chpl_task_impl_getFixedNumThreads(void);
 
 #define CHPL_TASK_IMPL_CAN_MIGRATE_THREADS() CHPL_QTHREAD_TASKS_CAN_MIGRATE_THREADS
 
-
-//
-// Can we support remote caching?
-//
-#ifdef CHPL_TASK_SUPPORTS_REMOTE_CACHE_IMPL_DECL
-#error "CHPL_TASK_SUPPORTS_REMOTE_CACHE_IMPL_DECL is already defined!"
-#else
-#define CHPL_TASK_SUPPORTS_REMOTE_CACHE_IMPL_DECL 1
-#endif
-static inline
-int chpl_task_supportsRemoteCache(void) {
-  return CHPL_QTHREAD_SUPPORTS_REMOTE_CACHE;
-}
-
 #ifdef __cplusplus
 } // end extern "C"
 #endif

--- a/runtime/src/comm/gasnet/comm-gasnet.c
+++ b/runtime/src/comm/gasnet/comm-gasnet.c
@@ -1586,6 +1586,7 @@ void chpl_comm_make_progress(void)
   gasnet_AMPoll();
 }
 
+void chpl_comm_task_end(void) { }
 
 void chpl_startVerboseComm() {
   chpl_verbose_comm = 1;

--- a/runtime/src/comm/none/comm-none.c
+++ b/runtime/src/comm/none/comm-none.c
@@ -219,9 +219,9 @@ void chpl_comm_execute_on_fast(c_nodeid_t node, c_sublocid_t subloc,
 
 int chpl_comm_numPollingTasks(void) { return 0; }
 
-void chpl_comm_make_progress(void)
-{
-}
+void chpl_comm_make_progress(void) { }
+
+void chpl_comm_task_end(void) { }
 
 void chpl_startVerboseComm() { }
 void chpl_stopVerboseComm() { }

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -1140,10 +1140,9 @@ int chpl_comm_numPollingTasks(void) {
   return 1;
 }
 
+void chpl_comm_make_progress(void) { }
 
-void chpl_comm_make_progress(void) {
-}
-
+void chpl_comm_task_end(void) { }
 
 void chpl_comm_execute_on(c_nodeid_t node, c_sublocid_t subloc,
                           chpl_fn_int_t fid,

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -2487,6 +2487,10 @@ void chpl_comm_atomic_unordered_fence(void) {
   return;
 }
 
+void chpl_comm_atomic_unordered_task_fence(void) {
+  return;
+}
+
 
 //
 // internal AMO utilities

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -1942,6 +1942,10 @@ int chpl_comm_numPollingTasks(void)
   return 1;
 }
 
+void chpl_comm_task_end(void) {
+  remote_get_buff_task_flush();
+  nic_amo_nf_buff_task_flush();
+}
 
 void chpl_comm_post_task_init(void)
 {

--- a/runtime/src/tasks/massivethreads/tasks-massivethreads.c
+++ b/runtime/src/tasks/massivethreads/tasks-massivethreads.c
@@ -670,25 +670,6 @@ chpl_task_bundle_t* chpl_task_getPrvBundle(void) {
   return arg;
 }
 
-
-//
-// Can this tasking layer support remote caching?
-//
-// (In practice this answers: "Are tasks bound to specific pthreads
-// or, if not, does the tasking layer make memory consistency calls
-// whenever it might move a task from one pthread to another?"  Remote
-// caching uses pthread-specific data (TLS) extensively, so it turns
-// itself off when it's used with a tasking layer that can't support
-// that.)
-//
-#ifndef CHPL_TASK_SUPPORTS_REMOTE_CACHE_IMPL_DECL
-int chpl_task_supportsRemoteCache(void) {
-  enter_();
-  return_from_();
-  return 0;
-}
-#endif
-
 //
 // Returns the maximum width of parallelism the tasking layer expects
 // to be able to provide on the calling (sub)locale.  With some

--- a/test/release/examples/benchmarks/hpcc/variants/ra-buff-atomics.chpl
+++ b/test/release/examples/benchmarks/hpcc/variants/ra-buff-atomics.chpl
@@ -106,7 +106,6 @@ proc main() {
   //
   forall (_, r) in zip(Updates, RAStream()) do
     T(r & indexMask).xorBuff(r);
-  flushAtomicBuff();
 
   const execTime = getCurrentTime() - startTime;   // capture the elapsed time
 

--- a/test/runtime/configMatters/comm/buff-atomics-stress.chpl
+++ b/test/runtime/configMatters/comm/buff-atomics-stress.chpl
@@ -18,7 +18,6 @@ coforall loc in Locales do on loc {
     }
   }
 }
-flushAtomicBuff();
 assert(a.read() == numTasks * itersSum);
 
 coforall loc in Locales do on loc {
@@ -29,5 +28,4 @@ coforall loc in Locales do on loc {
     }
   }
 }
-flushAtomicBuff();
 assert(a.read() == 0);

--- a/test/studies/bale/histogram/histo-atomics.chpl
+++ b/test/studies/bale/histogram/histo-atomics.chpl
@@ -44,7 +44,6 @@ proc main() {
     use BufferedAtomics;
     forall r in rindex do
       A[r].addBuff(1);
-    flushAtomicBuff();
   } else {
    forall r in rindex do
     A[r].add(1);

--- a/test/studies/bale/indexgather/ig.chpl
+++ b/test/studies/bale/indexgather/ig.chpl
@@ -45,7 +45,6 @@ proc main() {
     use BufferedGets;
     forall i in D2 do
       getBuff(tmp.localAccess[i], A[rindex.localAccess[i]]);
-    flushGetBuff();
   } else {
     forall i in D2 do
       tmp.localAccess[i] = A[rindex.localAccess[i]];

--- a/third-party/qthread/Makefile
+++ b/third-party/qthread/Makefile
@@ -194,9 +194,11 @@ qthread-build: FORCE
 ifeq ($(SCHEDULER),$(findstring $(SCHEDULER),lifo mtsfifo mutexfifo nemesis))
 SUPPORTS_REMOTE_CACHE = 1
 ONE_WORKER_PER_SHEPHERD = 1
+TASKS_CAN_MIGRATE_THREADS = 0
 else ifeq ($(SCHEDULER),$(findstring $(SCHEDULER),distrib nottingham sherwood))
 SUPPORTS_REMOTE_CACHE = 0
 ONE_WORKER_PER_SHEPHERD = 0
+TASKS_CAN_MIGRATE_THREADS = 1
 else
 $(error Unrecognized Qthreads scheduler '$(SCHEDULER)')
 endif
@@ -207,6 +209,9 @@ qthread-chapel-h: FORCE
 	     > $(QTHREAD_INSTALL_DIR)/include/qthread-chapel.h
 	echo "#define CHPL_QTHREAD_SCHEDULER_ONE_WORKER_PER_SHEPHERD" \
 	     $(ONE_WORKER_PER_SHEPHERD) \
+	     >> $(QTHREAD_INSTALL_DIR)/include/qthread-chapel.h
+	echo "#define CHPL_QTHREAD_TASKS_CAN_MIGRATE_THREADS" \
+	     $(TASKS_CAN_MIGRATE_THREADS) \
 	     >> $(QTHREAD_INSTALL_DIR)/include/qthread-chapel.h
 	echo "#define CHPL_QTHREAD_HAVE_GUARD_PAGES" \
 	     $(HAVE_GUARD_PAGES) \

--- a/third-party/qthread/Makefile
+++ b/third-party/qthread/Makefile
@@ -192,11 +192,9 @@ qthread-build: FORCE
 # we'll need separate checks to set them.
 #
 ifeq ($(SCHEDULER),$(findstring $(SCHEDULER),lifo mtsfifo mutexfifo nemesis))
-SUPPORTS_REMOTE_CACHE = 1
 ONE_WORKER_PER_SHEPHERD = 1
 TASKS_CAN_MIGRATE_THREADS = 0
 else ifeq ($(SCHEDULER),$(findstring $(SCHEDULER),distrib nottingham sherwood))
-SUPPORTS_REMOTE_CACHE = 0
 ONE_WORKER_PER_SHEPHERD = 0
 TASKS_CAN_MIGRATE_THREADS = 1
 else
@@ -204,12 +202,9 @@ $(error Unrecognized Qthreads scheduler '$(SCHEDULER)')
 endif
 
 qthread-chapel-h: FORCE
-	echo "#define CHPL_QTHREAD_SUPPORTS_REMOTE_CACHE" \
-	     $(SUPPORTS_REMOTE_CACHE) \
-	     > $(QTHREAD_INSTALL_DIR)/include/qthread-chapel.h
 	echo "#define CHPL_QTHREAD_SCHEDULER_ONE_WORKER_PER_SHEPHERD" \
 	     $(ONE_WORKER_PER_SHEPHERD) \
-	     >> $(QTHREAD_INSTALL_DIR)/include/qthread-chapel.h
+	     > $(QTHREAD_INSTALL_DIR)/include/qthread-chapel.h
 	echo "#define CHPL_QTHREAD_TASKS_CAN_MIGRATE_THREADS" \
 	     $(TASKS_CAN_MIGRATE_THREADS) \
 	     >> $(QTHREAD_INSTALL_DIR)/include/qthread-chapel.h


### PR DESCRIPTION
Unordered operations must be fenced before operations are guaranteed to be
completed. Previously, the only way to do this was with explicit fences. This
adds implicit/automatic fences to task termination to simplify common cases.

For bale-hist, previously we did something like:

```chpl
forall r in rindex do
  A[r].addBuff(1);
flushAtomicBuff();
```

and now we can simply write:

```chpl
forall r in rindex do
  A[r].addBuff(1);
```

To support that, this PR adds a new comm layer routine `chpl_comm_task_end`,
which is a hook that's called on task completion. For ugni we use this to flush
any operations that were buffered as part of an unordered op, and it's
currently a no-op for other comm layers. A more elegant solution might have
been to have some sort of callback interface where module code could register
things to be done on task completion (similar to what we have in the runtime)
but I wasn't quite sure how to do that cheaply and cleanly.

Since we're now calling these fencing operations on every task join, we need
them to be as fast as possible, especially in the no-op case. To support that,
this adds very fast per-task fences. For tasking layers where tasks can't
migrate between threads, this is a non-atomic conditional in the no-op case so
there shouldn't be any noticeable overhead. If there are pending operations, we
only have to lock the current thread so there shouldn't be any contention.

Closes https://github.com/chapel-lang/chapel/issues/12065
Closes https://github.com/chapel-lang/chapel/issues/12066