### PR TITLE
Fix prototype-partial-reduction tests for numa

### DIFF
--- a/test/users/engin/partial_reduction_support/modules/dsiMethods.chpl
+++ b/test/users/engin/partial_reduction_support/modules/dsiMethods.chpl
@@ -40,7 +40,8 @@ iter DefaultRectangularDom.dsiPartialThese(param onlyDim, otherIdx,
   }
 
 iter DefaultRectangularDom.dsiPartialThese(param onlyDim, otherIdx,
-    param tag: iterKind) where tag == iterKind.standalone {
+    param tag: iterKind) where tag == iterKind.standalone &&
+      __primitive("method call resolves", ranges(onlyDim), "these", tag) {
 
     if !dsiPartialDomain(onlyDim).contains(otherIdx) then return;
     for i in ranges(onlyDim).these(tag) do yield i;
@@ -73,7 +74,9 @@ iter DefaultRectangularArr.dsiPartialThese(param onlyDim, otherIdx,
 
 iter DefaultRectangularArr.dsiPartialThese(param onlyDim,
     otherIdx=createTuple(rank-1, idxType, 0:idxType),
-    param tag: iterKind) where tag == iterKind.standalone {
+    param tag: iterKind) where tag == iterKind.standalone &&
+      __primitive("method call resolves", dom, "dsiPartialThese",
+                                          onlyDim, otherIdx, tag=tag) {
 
   for i in dom.dsiPartialThese(onlyDim, otherIdx, tag=tag) do
     yield dsiAccess(otherIdx.withIdx(onlyDim, i));
@@ -245,7 +248,9 @@ iter DefaultSparseArr.dsiPartialThese(param onlyDim, otherIdx,
 }
 
 iter DefaultSparseArr.dsiPartialThese(param onlyDim, otherIdx, 
-    param tag) where tag==iterKind.standalone {
+    param tag) where tag==iterKind.standalone &&
+      __primitive("method call resolves", dom, "dsiPartialThese",
+                                          onlyDim, otherIdx, tag=tag) {
   for i in dom.dsiPartialThese(onlyDim, otherIdx, tag=tag) {
     yield dsiAccess(otherIdx.withIdx(onlyDim, i));
   }
@@ -401,7 +406,9 @@ iter CSArr.dsiPartialThese(param onlyDim, otherIdx,
 }
 
 iter CSArr.dsiPartialThese(param onlyDim, otherIdx, 
-    param tag) where tag==iterKind.standalone {
+    param tag) where tag==iterKind.standalone &&
+      __primitive("method call resolves", dom, "dsiPartialThese",
+                                          onlyDim, otherIdx[1], tag=tag) {
   for i in dom.dsiPartialThese(onlyDim, otherIdx[1], tag=tag) {
     yield dsiAccess(otherIdx.withIdx(onlyDim, i));
   }
@@ -448,7 +455,10 @@ iter BlockDom.dsiPartialThese(param onlyDim, otherIdx, param tag,
 }
 
 iter BlockDom.dsiPartialThese(param onlyDim, otherIdx, param tag)
-    where tag==iterKind.standalone {
+    where tag==iterKind.standalone &&
+          __primitive("method call resolves",
+                      locDoms[dist.targetLocDom.first].myBlock._value,
+                      "dsiPartialThese", onlyDim, otherIdx, tag) {
 
   coforall locDom in __partialTheseLocDoms(onlyDim, otherIdx) {
     on locDom {
@@ -505,7 +515,9 @@ iter LocBlockArr.dsiPartialThese(param onlyDim, otherIdx,
 }
 
 iter LocBlockArr.dsiPartialThese(param onlyDim, otherIdx,
-    param tag: iterKind) where tag == iterKind.standalone {
+    param tag: iterKind) where tag == iterKind.standalone &&
+      __primitive("method call resolves", myElems._value, "dsiPartialThese",
+                                                    onlyDim, otherIdx, tag) {
 
   for i in myElems._value.dsiPartialThese(onlyDim, otherIdx, tag) do
     yield i;
@@ -558,10 +570,11 @@ iter LocCyclicDom.dsiPartialThese(param onlyDim, otherIdx,
 }
 
 iter LocCyclicDom.dsiPartialThese(param onlyDim, otherIdx, param tag)
-    where tag==iterKind.standalone {
+    where tag==iterKind.standalone &&
+      __primitive("method call resolves", myBlock._value, "dsiPartialThese",
+                                          onlyDim, otherIdx, tag=tag) {
 
-  for i in myBlock._value.dsiPartialThese(onlyDim, otherIdx,
-      tag=iterKind.standalone) {
+  for i in myBlock._value.dsiPartialThese(onlyDim, otherIdx, tag=tag) {
     yield i;
   }
 }
@@ -596,10 +609,11 @@ iter LocCyclicArr.dsiPartialThese(param onlyDim, otherIdx,
 }
 
 iter LocCyclicArr.dsiPartialThese(param onlyDim, otherIdx, param tag)
-    where tag==iterKind.standalone {
+    where tag==iterKind.standalone &&
+          __primitive("method call resolves", locDom, "dsiPartialThese",
+                                              onlyDim, otherIdx, tag=tag) {
 
-  for i in locDom.dsiPartialThese(onlyDim, otherIdx,
-      tag=iterKind.standalone) {
+  for i in locDom.dsiPartialThese(onlyDim, otherIdx, tag=tag) {
     yield this(otherIdx.withIdx(onlyDim,i));
   }
 }
@@ -697,7 +711,9 @@ iter LocBlockCyclicArr.dsiPartialThese(param onlyDim, otherIdx,
 }
 
 iter LocBlockCyclicArr.dsiPartialThese(param onlyDim, otherIdx,
-    param tag: iterKind) where tag == iterKind.standalone {
+    param tag: iterKind) where tag == iterKind.standalone &&
+      __primitive("method call resolves", myElems._value, "dsiPartialThese",
+                                          onlyDim, otherIdx, tag=tag) {
 
   for i in myElems._value.dsiPartialThese(onlyDim, otherIdx, tag=tag) {
     yield i;
@@ -752,7 +768,9 @@ iter LocSparseBlockArr.dsiPartialThese(param onlyDim, otherIdx,
 }
 
 iter LocSparseBlockArr.dsiPartialThese(param onlyDim, otherIdx,
-    param tag: iterKind) where tag == iterKind.standalone {
+    param tag: iterKind) where tag == iterKind.standalone &&
+      __primitive("method call resolves", myElems._value, "dsiPartialThese",
+                                          onlyDim, otherIdx, tag) {
 
   for i in myElems._value.dsiPartialThese(onlyDim, otherIdx, tag) do
     yield i;


### PR DESCRIPTION
Some standalone iterators do not work under CHPL_LOCALE_MODEL=numa in
`test/users/engin/partial_reduction_support/modules/dsiMethods.chpl`
because they rely, directly or indirectly, on the standalone these()
in ranges. The latter is not available under NUMA. So under NUMA
the standalone iterators in dsiMethods.chpl used to be "applicable",
yet do not resolve.

The corresponding resolution failures had been masked by tryToken,
redirecting the compiler to the leader/follower iterators instead,
prior to #12131.

This PR makes the standalone iterators in dsiMethods.chpl not available
when the range standalone iterator is not available, using
`where __primitive("method call resolves")`. This solution
is used in a few other places in the modules and tests.

This PR reinforces the desirability of the following features:

* Enable `Reflection.canResolve()` to accept a mix of param and non-param
actual arguments, as well as be sensitive to named, const, ref actuals etc.
See #10918.

* Language support for iterator forwarding. Lots of iterators
in dsiMethods.chpl redirect to other iterators, with the serial iterator
redirecting to a serial iterator, the leader iterator redirecting
to the corresponding leader iterator, ditto follower and standalone.
As this PR shows, this approach is unnecessarily labor-intensive and
error-prone, esp. in the face of updates to the language/implementation.
See #5255.

Trivial, not reviewed.
