### PR TITLE
Fix initializer bug with parent field in generic child initializer

### DIFF
--- a/compiler/passes/InitNormalize.cpp
+++ b/compiler/passes/InitNormalize.cpp
@@ -1015,12 +1015,17 @@ bool ProcessThisUses::enterCallExpr(CallExpr* node) {
       USR_FATAL_CONT(node,
                      "cannot access parent field \"%s\" before super.init() or this.init()",
                      field->sym->name);
+    } else if (state->isPhase1()) {
+      node->baseExpr->remove();
+      node->baseExpr = NULL;
+      node->primitive = primitives[PRIM_GET_MEMBER];
     }
     return false;
   } else if (isAssignment(node)) {
     if (CallExpr* LHS = toCallExpr(node->get(1))) {
       if (isThisDot(LHS)) {
         if (LHS->square == false) {
+          node->get(1)->accept(this);
           // Regular 'this.x = ' , just look at the RHS
           node->get(2)->accept(this);
           return false;

--- a/compiler/passes/initializerRules.cpp
+++ b/compiler/passes/initializerRules.cpp
@@ -586,6 +586,9 @@ static InitNormalize preNormalize(AggregateType* at,
                       field->sym->name);
 
           } else {
+            if (state.isPhase1()) {
+              state.processThisUses(callExpr);
+            }
             stmt = stmt->next;
           }
         }

--- a/test/classes/initializers/generics/inheritance/badInit.bad
+++ b/test/classes/initializers/generics/inheritance/badInit.bad
@@ -1,8 +1,0 @@
-badInit.chpl:12: In initializer:
-badInit.chpl:13: internal error: RES-CAL-NFO-0124 chpl version 1.19.0 pre-release (63d96663cb)
-
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
-and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
-please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
-

--- a/test/classes/initializers/generics/inheritance/badInit.future
+++ b/test/classes/initializers/generics/inheritance/badInit.future
@@ -1,5 +1,0 @@
-bug: internal error on (illegal?) initializer
-
-This initializer tries to set a value field in its parent and then a
-type field in itself.  Something about this combination causes an
-internal error, though I'm not quite sure what.


### PR DESCRIPTION
This PR fixes a bug where the compiler would emit an internal error when a parent's field was accessed before the child was instantiated. The solution is to disable field accessor methods for parent fields in phase one.

Resolves #12026 

Testing:
- [x] local + futures
- [x] gasnet + futures