### PR TITLE
Update Fortran array to Chapel DR array test

### DIFF
--- a/test/interop/fortran/fortArrayToDefaultRectangular/FortranInterop.chpl
+++ b/test/interop/fortran/fortArrayToDefaultRectangular/FortranInterop.chpl
@@ -1,0 +1,45 @@
+use ISO_Fortran_binding;
+use chapelProcs;
+
+/* Allow accessing the array using normal Chapel syntax. This uses the
+   `CFI_address` function from the `ISO_Fortran_binding` module to get
+   the address of element `idx`, then returns a dereference of that address.
+   It assumes that the array contains `real(64)` values, but hopefully we
+   can relax that assumption.
+
+   A[i,j] = ...;
+   var val = A[i,j];
+ */
+proc CFI_cdesc_t.this(idx:int...?rank) ref {
+  assert(this.rank == rank);
+  var subscripts: [0..#rank] CFI_index_t;
+  for param i in 1..rank {
+    subscripts[i-1] = idx[i]: CFI_index_t;
+  }
+  var x = CFI_address(this, c_ptrTo(subscripts)): c_ptr(real);
+  return x.deref();
+}
+
+proc fortranArrayToChapelArray(ref FA: CFI_cdesc_t, param rank, type eltType) {
+
+  assert(CFI_is_contiguous(FA) == 1);
+
+  var cumulativeLength = 1;
+  for param i in 1..rank {
+    const eltSize = c_sizeof(eltType): int;
+    assert(FA.dim[i-1].sm == cumulativeLength * eltSize);
+    cumulativeLength *= FA.dim[i-1].extent;
+  }
+
+  var dims: rank*range;
+  for param i in 1..rank {
+    dims[i] = FA.dim[i-1].lower_bound..#FA.dim[i-1].extent;
+  }
+  var D = {(...dims)};
+  var A = D.buildArrayWith(eltType,
+                          FA.base_addr: _ddata(eltType),
+                          D.numIndices);
+  A._unowned = true;
+  return A;
+}
+

--- a/test/interop/fortran/fortArrayToDefaultRectangular/FortranInterop.chpl
+++ b/test/interop/fortran/fortArrayToDefaultRectangular/FortranInterop.chpl
@@ -33,7 +33,8 @@ proc fortranArrayToChapelArray(ref FA: CFI_cdesc_t, param rank, type eltType) {
 
   var dims: rank*range;
   for param i in 1..rank {
-    dims[i] = FA.dim[i-1].lower_bound..#FA.dim[i-1].extent;
+    assert(FA.dim[i-1].lower_bound == 0);
+    dims[i] = 1..#FA.dim[i-1].extent;
   }
   var D = {(...dims)};
   var A = D.buildArrayWith(eltType,

--- a/test/interop/fortran/fortArrayToDefaultRectangular/chapelProcs.chpl
+++ b/test/interop/fortran/fortArrayToDefaultRectangular/chapelProcs.chpl
@@ -1,45 +1,11 @@
 use ISO_Fortran_binding;
+use FortranInterop;
 
 export proc chpl_library_init_ftn() {
   extern proc chpl_library_init(argc: c_int, argv: c_ptr(c_ptr(c_char)));
   var filename = c"fake";
   chpl_library_init(1, c_ptrTo(filename): c_ptr(c_ptr(c_char)));;
   chpl__init_chapelProcs();
-}
-
-/* Allow accessing the array using normal Chapel syntax. This uses the
-   `CFI_address` function from the `ISO_Fortran_binding` module to get
-   the address of element `idx`, then returns a dereference of that address.
-   It assumes that the array contains `real(64)` values, but hopefully we
-   can relax that assumption.
-
-   A[i,j] = ...;
-   var val = A[i,j];
- */
-proc CFI_cdesc_t.this(idx:int...?rank) ref {
-  assert(this.rank == rank);
-  var subscripts: [0..#rank] CFI_index_t;
-  for param i in 1..rank {
-    subscripts[i-1] = idx[i]: CFI_index_t;
-  }
-  var x = CFI_address(this, c_ptrTo(subscripts)): c_ptr(real);
-  return x.deref();
-}
-
-proc fortranArrayToChapelArray(ref FA: CFI_cdesc_t, param rank, type eltType) {
-
-  assert(CFI_is_contiguous(FA) == 1);
-
-  var dims: rank*range;
-  for param i in 1..rank {
-    dims[i] = 0..#FA.dim[i-1].extent;
-  }
-  var D = {(...dims)};
-  var A = D.buildArrayWith(eltType,
-                          FA.base_addr: _ddata(eltType),
-                          D.numIndices);
-  A._unowned = true;
-  return A;
 }
 
 export proc takesArray(ref FA: CFI_cdesc_t) {

--- a/test/interop/fortran/fortArrayToDefaultRectangular/chapelProcs.good
+++ b/test/interop/fortran/fortArrayToDefaultRectangular/chapelProcs.good
@@ -1,6 +1,6 @@
 chapelProcs.chpl:11: In function 'takesArray':
 chapelProcs.chpl:11: warning: Unknown Fortran KIND generating interface for C type: _ref_CFI_cdesc_t
 chapelProcs.chpl:11: warning: Unknown Fortran type generating interface for C type: _ref_CFI_cdesc_t
-  0.000000000000000E+000   1.00000000000000        2.00000000000000     
-   100.000000000000        101.000000000000        102.000000000000     
-   200.000000000000        201.000000000000        202.000000000000     
+   101.000000000000        102.000000000000        103.000000000000     
+   201.000000000000        202.000000000000        203.000000000000     
+   301.000000000000        302.000000000000        303.000000000000     

--- a/test/interop/fortran/fortArrayToDefaultRectangular/chapelProcs.good
+++ b/test/interop/fortran/fortArrayToDefaultRectangular/chapelProcs.good
@@ -1,6 +1,6 @@
-chapelProcs.chpl:45: In function 'takesArray':
-chapelProcs.chpl:45: warning: Unknown Fortran KIND generating interface for C type: _ref_CFI_cdesc_t
-chapelProcs.chpl:45: warning: Unknown Fortran type generating interface for C type: _ref_CFI_cdesc_t
+chapelProcs.chpl:11: In function 'takesArray':
+chapelProcs.chpl:11: warning: Unknown Fortran KIND generating interface for C type: _ref_CFI_cdesc_t
+chapelProcs.chpl:11: warning: Unknown Fortran type generating interface for C type: _ref_CFI_cdesc_t
   0.000000000000000E+000   1.00000000000000        2.00000000000000     
    100.000000000000        101.000000000000        102.000000000000     
    200.000000000000        201.000000000000        202.000000000000     


### PR DESCRIPTION
Move the functions for translating between Fortran and Chapel arrays into
their own module.

Update a domain to use a lower bound of 1 and assert that the `lower_bound` field from the `CFI_dim_t` record is 0.

Assert that the `sm` field from the `CFI_dim_t` record is what we expect for
a contiguous array. `sizeof(eltType)` in the first dimension and
`eltsInPreviousDims*sizeof(eltType)` in other dimensions.