### PR TITLE
Silence a gcc 8 warning about truncated strncat

### DIFF
--- a/runtime/src/chpl-file-utils.c
+++ b/runtime/src/chpl-file-utils.c
@@ -221,7 +221,7 @@ qioerr chpl_fs_is_mount(int* ret, const char* name) {
         // While we haven't found the end of the path (in nextTok)
         strncat(parent, "/", 1);
         // Restore the lost path separator.
-        strncat(parent, curTok, strlen(curTok));
+        strncat(parent, curTok, strlen(curTok) + 1);
         // Add the current token to the parent list
         curTok = nextTok;
         // And prepare to check if the next token is the last in the path


### PR DESCRIPTION
This change adds one byte to a `strncat()` length limit to take into account the terminating null byte.  The existing code was correct, but some installations of gcc 8 complain about string truncation because the terminating null wasn't included.  We turned those warnings into errors with `-Werror`.

So far the problem has only been observed on a Cray XC with CHPL_COMM=ugni and WARNINGS=1.