### PR TITLE
Fix a race with oversubscribed unordered operations

### DIFF
--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -5735,15 +5735,17 @@ void do_remote_get_buff(void* tgt_addr, c_nodeid_t locale, void* src_addr,
   get_buff_thread_info_t* info = &get_buff_thread_info;
 
   if (!info->inited) {
-    spinlock_init(&info->lock);
-    info->vi = 0;
-
     rwlock_writer_lock(&get_buff_global_info.lock);
-    info->next = get_buff_global_info.list;
-    get_buff_global_info.list = info;
-    rwlock_unlock(&get_buff_global_info.lock);
+    if (!info->inited) {
+      spinlock_init(&info->lock);
+      info->vi = 0;
 
-    info->inited = true;
+      info->next = get_buff_global_info.list;
+      get_buff_global_info.list = info;
+
+      info->inited = true;
+    }
+    rwlock_unlock(&get_buff_global_info.lock);
   }
 
   // grab lock for this thread
@@ -7084,15 +7086,18 @@ void do_nic_amo_nf_buff(void* opnd1, c_nodeid_t locale,
   amo_nf_buff_thread_info_t* info = &amo_nf_buff_thread_info;
 
   if (!info->inited) {
-    spinlock_init(&info->lock);
-    info->vi = 0;
-
     rwlock_writer_lock(&amo_nf_buff_global_info.lock);
-    info->next = amo_nf_buff_global_info.list;
-    amo_nf_buff_global_info.list = info;
-    rwlock_unlock(&amo_nf_buff_global_info.lock);
+    if (!info->inited) {
 
-    info->inited = true;
+      spinlock_init(&info->lock);
+      info->vi = 0;
+
+      info->next = amo_nf_buff_global_info.list;
+      amo_nf_buff_global_info.list = info;
+
+      info->inited = true;
+    }
+    rwlock_unlock(&amo_nf_buff_global_info.lock);
   }
 
   check_nic_amo(size, object, remote_mr);

--- a/test/runtime/configMatters/comm/buff-atomics-stress.chpl
+++ b/test/runtime/configMatters/comm/buff-atomics-stress.chpl
@@ -1,6 +1,7 @@
 use BufferedAtomics;
 
-config const numTasksPerLocale = here.maxTaskPar;
+config const oversubscription = 1;
+config const numTasksPerLocale = here.maxTaskPar * oversubscription;
 const numTasks = numLocales * numTasksPerLocale;
 
 config const iters = 10000;

--- a/test/runtime/configMatters/comm/buff-atomics-stress.execopts
+++ b/test/runtime/configMatters/comm/buff-atomics-stress.execopts
@@ -8,7 +8,10 @@ iters      = 10000
 flushIters = 1000
 if net_atomics == 'ugni':
   iters      = 1000000
-  flushiters = 10000
+  flushIters = 5000
 
-print('--concurrentFlushing=false --iters={0}'.format(iters))
-print('--concurrentFlushing=true  --iters={0}'.format(flushIters))
+print('--concurrentFlushing=false --iters={0} --oversubscription=1'.format(iters))
+print('--concurrentFlushing=false --iters={0} --oversubscription=2'.format(iters//2))
+print('--concurrentFlushing=true  --iters={0} --oversubscription=1'.format(flushIters))
+print('--concurrentFlushing=true  --iters={0} --oversubscription=2'.format(flushIters//2))
+print('--concurrentFlushing=true  --iters={0} --oversubscription=10'.format(flushIters//10))


### PR DESCRIPTION
Previously, if there were more tasks than threads we could get into a race
during unordered op initialization. We used to check if the current thread was
initialized, and if not we would grab the initialization lock and then proceed
to initialize. However, trying to acquire the init lock can yield, which meant
we could allow another task on the same thread to run and complete the
initialization, which would cause issues when the original task came back and
redid initialization. To resolve the problem, recheck if initialization was
done after acquiring the init lock.

This adds oversubscribed variants of the unordered atomic stress test to
lock-in the behavior. Bale histogram and indexgather don't run into this
anymore since we removed the explicit whole-node fences in #12183, but I
verified that re-adding the fences resulted in a hang when oversubscribed and
that it runs correctly now.

Closes https://github.com/chapel-lang/chapel/issues/12184
