### PR TITLE
Export chpl_opaque_array clean up function and use in --library C interop tests

### DIFF
--- a/modules/internal/ExternalArray.chpl
+++ b/modules/internal/ExternalArray.chpl
@@ -182,11 +182,9 @@ module ExternalArray {
     }
   }
 
-  // Need to export this but that requires some compiler changes due to our
-  // hiding of interal module exported functions.
   // Can't create an _array wrapper to call the cleanup function for us, so do
   // the next best thing.
-  proc cleanupOpaqueArray(arr: chpl_opaque_array) {
+  export proc cleanupOpaqueArray(arr: chpl_opaque_array) {
     var cleanup = arr._instance: unmanaged BaseArr;
     _do_destroy_arr(arr._unowned, false, cleanup);
   }

--- a/runtime/include/chpl-external-array.h
+++ b/runtime/include/chpl-external-array.h
@@ -47,4 +47,6 @@ typedef struct {
   bool _unowned;
 } chpl_opaque_array;
 
+void cleanupOpaqueArray(chpl_opaque_array * arr);
+
 #endif

--- a/test/interop/C/exportArray/callArrayOpaquePointer.test.c
+++ b/test/interop/C/exportArray/callArrayOpaquePointer.test.c
@@ -13,8 +13,8 @@ int main(int argc, char* argv[]) {
   addEltBlock(&arr, 2, 3);
   printBlock(&arr);
 
-  // Call cleanup function when exported
-  //chpl_mem_free(arr, 0, 0);
+  // Call cleanup function when done with it
+  cleanupOpaqueArray(&arr);
 
   chpl_library_finalize();
   return 0;

--- a/test/interop/C/exportArray/callWrapArrayAsOpaque_global.test.c
+++ b/test/interop/C/exportArray/callWrapArrayAsOpaque_global.test.c
@@ -24,11 +24,13 @@ int main(int argc, char* argv[]) {
   chpl_opaque_array arr4 = makeBlockArray();
   printBlock(&arr4);
 
-  // Call clean up function when exported (on how many?)
-  //chpl_mem_free(arr, 0, 0);
-  //chpl_mem_free(arr2, 0, 0);
-  //chpl_mem_free(arr3, 0, 0);
-  //chpl_mem_free(arr4, 0, 0);
+  // Call clean up function when done with them (should not cause memory
+  // errors if called on shared global, should just clean up appropriately
+  // at end of program without freeing early)
+  cleanupOpaqueArray(&arr);
+  cleanupOpaqueArray(&arr2);
+  cleanupOpaqueArray(&arr3);
+  cleanupOpaqueArray(&arr4);
 
   chpl_library_finalize();
   return 0;

--- a/test/interop/C/exportArray/callWrapArrayAsOpaque_moreComplex.test.c
+++ b/test/interop/C/exportArray/callWrapArrayAsOpaque_moreComplex.test.c
@@ -13,8 +13,8 @@ int main(int argc, char* argv[]) {
   addEltBlock(&arr, 2, 3);
   printBlock(&arr);
 
-  // Call clean up function when exported
-  //chpl_mem_free(arr, 0, 0);
+  // Call clean up function when done with it
+  cleanupOpaqueArray(&arr);
 
   chpl_library_finalize();
   return 0;


### PR DESCRIPTION
Chapel arrays that are returned via exported functions as chpl_opaque_array
pointers stop themselves from getting cleaned up, allowing the C or Python
caller to use the array and pass it to other exported Chapel functions that
may use it.  This PR allows those users to clean up the array once they are
done with it, by providing a function they can call on it.

The function was already defined in the internal modules, but due to a large
number of exported functions in the internal modules we don't generate
the declarations for them as part of the generated header file in `--library`
compilation.  This change exports the function and adds a hard-coded
declaration to the header file defining the chpl_opaque_array type, which is
in keeping with how we handle other exported internal module functions.

Note: #12132 tracks the desire to generate the declarations for all exported
functions in the internal modules.

Resolves #12138

Test:
- [x] full paratest with futures
- [x] valgrind over updated tests, double checked leaked output (possibly lost and
still reachable much much lower than on master)
- memleaks does not run on C tests