### PR TITLE
Fix typos

### DIFF
--- a/modules/internal/CPtr.chpl
+++ b/modules/internal/CPtr.chpl
@@ -96,7 +96,7 @@ module CPtr {
   This class represents a C array with fixed size.  A variable of type c_array
   can coerce to a c_ptr with the same element type.  In that event, the
   pointer will be equivalent to `c_ptrTo(array[0])`.  A c_array behaves
-  similarly to a homogenous tuple except that its indices start at 0 and it is
+  similarly to a homogeneous tuple except that its indices start at 0 and it is
   guaranteed to be stored in contiguous memory.  A c_array variable has value
   semantics. Declaring one as a function local variable will create the array
   elements in the function's stack. Assigning or copy initializing will result
@@ -122,7 +122,7 @@ module CPtr {
         var default: eltType;
         // this use of primitive works around an order-of-resolution issue.
         ref eltRef = __primitive("array_get", this, i);
-        // this is a move, transfering ownership
+        // this is a move, transferring ownership
         __primitive("=", eltRef, default);
         i += 1;
       }
@@ -204,7 +204,7 @@ module CPtr {
       for i in 0..#size {
         pragma "no auto destroy"
         var value: eltType = other[i];
-        // this is a move, transfering ownership
+        // this is a move, transferring ownership
         __primitive("=", this(i), value);
       }
     }

--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -2385,7 +2385,7 @@ proc _cast(type t, r: range(?)) where isRangeType(t) {
           f <~> a;
           _alignment = a;
         } else {
-          // If the range is not strideable, it can't store an alignment.
+          // If the range is not stridable, it can't store an alignment.
           // TODO: once Channels can store Chapel errors,
           // create a more descriptive error for this case
           f.setError(EFORMAT:syserr);

--- a/runtime/include/chpl-tasks.h
+++ b/runtime/include/chpl-tasks.h
@@ -357,8 +357,8 @@ uint32_t chpl_task_isFixedThread(void) {
 // they started on, this returns true.  Otherwise, it returns false.
 // For example CHPL_TASKS=fifo a task is a thread, so tasks can't
 // migrate.  For CHPL_TASKS=qthreads some schedulers support
-// work-stealing where tasks can be stolen and moved to a diferent
-// then they started on.
+// work-stealing where tasks can be stolen and moved to a different
+// thread than they started on.
 //
 #ifndef CHPL_TASK_IMPL_CAN_MIGRATE_THREADS
 #define CHPL_TASK_IMPL_CAN_MIGRATE_THREADS() 1


### PR DESCRIPTION
Fix typos in CPtr.chpl, ChapelRange.chpl, ExternalArray.com,
and chpl-tasks.h