### PR TITLE
findUnusedTestFiles: recognize more .good filename components

### DIFF
--- a/util/devel/test/findUnusedTestFiles
+++ b/util/devel/test/findUnusedTestFiles
@@ -50,12 +50,15 @@ for f in $(find $CHPL_HOME/test                                               \
    # Get the base name by stripping off the extensions we're looking
    # for, and extensions the test system will automatically look for
    # ("no-local" and following (order matters)).
+   # linux32, cray-xc, cray-xe are the in-use sub_test:platform values
    f=$(basename $f)
    base=$f
    for ext in good bad future prediff precomp preexec compopts execopts      \
               numlocales catfiles notest noexec cleanfiles skipif suppressif \
               timeout perfnumtrials perfcompopts perfexecopts                \
-              no-local lm-flat lm-numa comm-gasnet comm-none; do
+              no-local lm-flat lm-numa na-none na-ugni                       \
+              comm-ugni comm-ofi comm-gasnet comm-none                       \
+              linux32 cray-xc cray-xe; do
        base=${base%.${ext}}
    done
 


### PR DESCRIPTION
Update findUnusedTestFiles to handle new cases added in #11491,  #11242, and #12052
- network-atomics filenames na-none na-ugni
- comm-ugni and comm-ofi
- chpl-platform values linux32 cray-xc cray-xe