### PR TITLE
Fix masonModifyTest.skipif to skip if CHPL_REGEXP=none

### DIFF
--- a/test/mason/add-remove-tests/masonModifyTest.skipif
+++ b/test/mason/add-remove-tests/masonModifyTest.skipif
@@ -6,9 +6,14 @@ if [ -f /etc/SuSE-release ] ; then
   slesVersion=`sed -n -e 's/VERSION = //p' /etc/SuSE-release`
   if [ $slesVersion -le 11 ] ; then
     echo True
-  else
-    echo False
+    exit 0
   fi
-else
-  echo False
 fi
+
+if [ "$CHPL_REGEXP" = "none" ]; then
+  echo True
+  exit 0
+fi
+
+echo False
+exit 0


### PR DESCRIPTION
I noticed this test failing in a quickstart test run, it should be skipped there.

Trivial and not reviewed.