### PR TITLE
Ignore exercises/c-ray/solutions/c-ray-chplvis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,6 +182,7 @@ tags
 /test/exercises/Mandelbrot/mandelbrot.bmp
 /test/exercises/Mandelbrot/mandelbrot.ppm
 /test/exercises/Mandelbrot/solutions/mandelbrot.ppm
+/test/exercises/c-ray/solutions/c-ray-chplvis
 
 /test/expressions/lydia/noinit/ccode
 

--- a/test/exercises/c-ray/solutions/CLEANFILES
+++ b/test/exercises/c-ray/solutions/CLEANFILES
@@ -1,0 +1,1 @@
+c-ray-chplvis


### PR DESCRIPTION
This directory is created while running start_test.
Add it to .gitignore and CLEANFILES.
OK-ed by Brad.