### PR TITLE
Use --whole-archive for -lhugetlbfs to workaround clang issue

### DIFF
--- a/runtime/etc/Makefile.comm-ugni
+++ b/runtime/etc/Makefile.comm-ugni
@@ -26,7 +26,8 @@ LD = $(CXX)
 # libhugetlbfs ourselves.
 #
 ifeq (,$(findstring HUGETLB,$(PE_PRODUCT_LIST)))
-GEN_LFLAGS += -lhugetlbfs
+# --whole-archive is a workaround for issues with clang-included/--llvm
+GEN_LFLAGS += -Wl,--whole-archive,-lhugetlbfs,--no-whole-archive
 endif
 
 GEN_LFLAGS += -lpthread

--- a/third-party/gasnet/Makefile
+++ b/third-party/gasnet/Makefile
@@ -49,10 +49,14 @@ CHPL_GASNET_CFG_OPTIONS += --enable-pthreads
 ifeq ($(CHPL_MAKE_COMM_SUBSTRATE),gemini)
 CHPL_GASNET_CFG_OPTIONS += --enable-gemini-multi-domain
 CHPL_GASNET_CFG_OPTIONS += --disable-aries --disable-mpi --disable-smp --disable-ofi
+# workaround problem with clang and library constructors in hugetlbfs.
+CHPL_GASNET_CFG_OPTIONS += --enable-hugetlbfs-whole-archive
 else
 ifeq ($(CHPL_MAKE_COMM_SUBSTRATE),aries)
 CHPL_GASNET_CFG_OPTIONS += --enable-aries-multi-domain
 CHPL_GASNET_CFG_OPTIONS += --disable-gemini --disable-mpi --disable-smp --disable-ofi
+# workaround problem with clang and library constructors in hugetlbfs.
+CHPL_GASNET_CFG_OPTIONS += --enable-hugetlbfs-whole-archive
 else
 ifeq ($(CHPL_MAKE_COMM_SUBSTRATE),mpi)
 CHPL_GASNET_CFG_OPTIONS += --disable-gemini --disable-aries --disable-smp --disable-ofi


### PR DESCRIPTION
For #12011 and intended to be used with PR #12202.

* Link -lhugetlbfs with --whole-archive to work around an issue with clang finding the library constructor setup_libhugetlbfs when doing static linking. For GASNet, we do this with the --enable-hugetlbfs-whole-archive configure option.


TODOs:
 * CHPL_COMM=ugni and --llvm working with hugepages module loaded at make != hugepages module loaded at chpl invocation (the Makefile.comm-ugni -lhugetlbfs argument ends up in list-libraries for --llvm compilation, so the conditional in the makefile is unused). I think this could be fixed by moving computing this argument to the Python chplenv scripts.
 * adjust the GASNet build to use PrgEnv-gnu or clang-included.