### PR TITLE
Minor compiler code improvements

### DIFF
--- a/compiler/AST/ForallStmt.cpp
+++ b/compiler/AST/ForallStmt.cpp
@@ -256,7 +256,7 @@ void ForallStmt::setNotZippered() {
   fZippered = false;
 }
 
-// Return the enclosing forall statement for 'expr', or NULL if none.
+// Return the nearest enclosing forall statement for 'expr', or NULL if none.
 ForallStmt* enclosingForallStmt(Expr* expr) {
   for (Expr* curr = expr->parentExpr; curr; curr = curr->parentExpr)
     if (ForallStmt* fs = toForallStmt(curr))
@@ -264,42 +264,42 @@ ForallStmt* enclosingForallStmt(Expr* expr) {
   return NULL;
 }
 
-// Is 'expr' the DefExpr of an induction variable in some ForallStmt?
-bool isForallIterVarDef(Expr* expr) {
+// Return a ForallStmt* if 'expr' is the DefExpr of its induction variable.
+ForallStmt* isForallIterVarDef(Expr* expr) {
   if (expr->list != NULL)
     if (ForallStmt* pfs = toForallStmt(expr->parentExpr))
       if (expr->list == &pfs->inductionVariables())
-        return true;
-  return false;
+        return pfs;
+  return NULL;
 }
 
-// Is 'expr' an iterable-expression for some ForallStmt?
-bool isForallIterExpr(Expr* expr) {
+// Return a ForallStmt* if 'expr' is its iterable-expression.
+ForallStmt* isForallIterExpr(Expr* expr) {
   if (expr->list != NULL)
     if (ForallStmt* pfs = toForallStmt(expr->parentExpr))
       if (expr->list == &pfs->iteratedExpressions())
-        return true;
-  return false;
+        return pfs;
+  return NULL;
 }
 
-// Is 'expr' the fs->loopBody() for some 'fs' ?
-bool isForallLoopBody(Expr* expr) {
+// Return a ForallStmt* if 'expr' is its loopBody.
+ForallStmt* isForallLoopBody(Expr* expr) {
   if (ForallStmt* pfs = toForallStmt(expr->parentExpr))
     if (expr == pfs->loopBody())
-      return true;
-  return false;
+      return pfs;
+  return NULL;
 }
 
-// Is 'expr' one of fs->fRecIter* for some 'fs' ?
-bool isForallRecIterHelper(Expr* expr) {
+// Return a ForallStmt* if 'expr' is one of its fRecIter* helpers.
+ForallStmt* isForallRecIterHelper(Expr* expr) {
   if (expr->list == NULL)
     if (ForallStmt* pfs = toForallStmt(expr->parentExpr))
       if (expr == pfs->fRecIterIRdef ||
           expr == pfs->fRecIterICdef ||
           expr == pfs->fRecIterGetIterator ||
           expr == pfs->fRecIterFreeIterator)
-        return true;
-  return false;
+        return pfs;
+  return NULL;
 }
 
 // Return the index variable of the parallel loop.

--- a/compiler/AST/foralls.cpp
+++ b/compiler/AST/foralls.cpp
@@ -657,7 +657,7 @@ static CallExpr* buildForallParIterCall(ForallStmt* pfs, SymExpr* origSE,
 {
   CallExpr* iterCall = NULL;
 
-  if (origSE->symbol()->type->symbol->hasFlag(FLAG_ITERATOR_RECORD)) {
+  if (isIteratorRecord(origSE->symbol())) {
     // Our iterable expression is an iterator call.
 
     if (ArgSymbol* origArg = toArgSymbol(origSE->symbol())) {
@@ -710,7 +710,7 @@ static void checkForExplicitTagArgs(CallExpr* iterCall) {
   int cnt = 0;
   for_actuals(actual, iterCall) {
     ++cnt;
-    if ((actual->qualType().type()->getValType() == gStandaloneTag->type) ||
+    if ((actual->getValType() == gStandaloneTag->type) ||
         (isNamedExpr(actual) && toNamedExpr(actual)->name == astrTag)
     ) {
       USR_FATAL_CONT(iterCall, "user invocation of a parallel iterator should not supply tag arguments -- they are added implicitly by the compiler");

--- a/compiler/include/ForallStmt.h
+++ b/compiler/include/ForallStmt.h
@@ -159,11 +159,11 @@ inline Expr* ForallStmt::firstIteratedExpr() const { return fIterExprs.head;  }
 
 /// helpers ///
 
-bool        isForallIterVarDef(Expr* expr);
-bool        isForallIterExpr(Expr* expr);
-bool        isForallRecIterHelper(Expr* expr);
-bool        isForallLoopBody(Expr* expr);
 ForallStmt* enclosingForallStmt(Expr* expr);
+ForallStmt* isForallIterVarDef(Expr* expr);
+ForallStmt* isForallIterExpr(Expr* expr);
+ForallStmt* isForallRecIterHelper(Expr* expr);
+ForallStmt* isForallLoopBody(Expr* expr);
 VarSymbol*  parIdxVar(ForallStmt* fs);
 
 /// done ///

--- a/compiler/resolution/cullOverReferences.cpp
+++ b/compiler/resolution/cullOverReferences.cpp
@@ -779,8 +779,8 @@ void cullOverReferences() {
         ForLoop* followerForLoop = NULL;
         std::vector<IteratorDetails> detailsVector;
 
-        if (isForallIterExpr(call)) {
-          ForallStmt* pfs = toForallStmt(call->parentExpr);
+        if (ForallStmt* pfs = isForallIterExpr(call)) {
+
           gatherLoopDetails(pfs, isForall, leaderDetails,
                             followerForLoop, detailsVector);
           foundLoop = true;

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -6241,8 +6241,6 @@ void resolveBlockStmt(BlockStmt* blockStmt) {
 
 static bool        isParamResolved(FnSymbol* fn, Expr* expr);
 
-static ForallStmt* toForallForIteratedExpr(SymExpr* expr);
-
 static Expr*       resolveExprPhase2(Expr* origExpr, FnSymbol* fn, Expr* expr);
 
 static CallExpr*   toPrimToLeaderCall(Expr* expr);
@@ -6306,7 +6304,7 @@ Expr* resolveExpr(Expr* expr) {
   } else if (SymExpr* se = toSymExpr(expr)) {
     makeRefType(se->symbol()->type);
 
-    if (ForallStmt* pfs = toForallForIteratedExpr(se)) {
+    if (ForallStmt* pfs = isForallIterExpr(se)) {
       CallExpr* call = resolveForallHeader(pfs, se);
 
       if (tryFailure == false) {
@@ -6379,13 +6377,6 @@ static bool isParamResolved(FnSymbol* fn, Expr* expr) {
   }
 
   return retval;
-}
-
-static ForallStmt* toForallForIteratedExpr(SymExpr* expr) {
-  if (isForallIterExpr(expr))
-    return toForallStmt(expr->parentExpr);
-  else
-    return NULL;
 }
 
 static Expr* resolveExprPhase2(Expr* origExpr, FnSymbol* fn, Expr* expr) {


### PR DESCRIPTION
Various things I postponed while working on #12131,
which simplify the compiler code in minor ways.

* Revert parts of callDestructors.cpp to what they were prior to #8785.
That PR introduced splitParIterUses() and supporting code, which shielded,
from the return-by-ref transformation, the iterators that were used
as iterable expressions in ForallStmt nodes.
#12131 restored uniform treatment of such iterators w.r.t. return-by-ref,
removing splitParIterUses() and related code.
This PR reverts more pieces, as enabled by #12131.

* Change isForallIterVarDef() et al. to return a ForallStmt* when the answer
is "yes". While only the change to isForallIterExpr() resulted in simplifying
the client code, I changed all four of them for uniformity.

* A couple of other things.

Trivial, not reviewed.