### PR TITLE
Limit the number of trials for the unordered AMO stress test

### DIFF
--- a/test/runtime/configMatters/comm/buff-atomics-stress.execopts
+++ b/test/runtime/configMatters/comm/buff-atomics-stress.execopts
@@ -3,10 +3,11 @@
 import os
 
 net_atomics = os.getenv('CHPL_NETWORK_ATOMICS', 'none')
+proc_atomics = os.getenv('CHPL_ATOMICS', 'none')
 
 iters      = 10000
 flushIters = 1000
-if net_atomics == 'ugni':
+if net_atomics == 'ugni' and proc_atomics == 'cstdlib':
   iters      = 1000000
   flushIters = 5000
 


### PR DESCRIPTION
This test is timing on on cce+arm after bumping the problem size for the
concurrent flushing in ffbf2f7328. The concurrent flushing puts a lot of
stress on the local spinlocks, which are much slower under cce with
intrinsic processor atomics. Drop the problem size for that config, but
leave it higher when cstdlib atomics are being used.