### PR TITLE
Don't localize global extern consts

### DIFF
--- a/compiler/optimizations/localizeGlobals.cpp
+++ b/compiler/optimizations/localizeGlobals.cpp
@@ -63,6 +63,7 @@ void localizeGlobals() {
             !inAddrOf &&
             !lhsOfMove &&
             var->hasFlag(FLAG_CONST) &&
+            !var->hasFlag(FLAG_EXTERN) &&
             var->defPoint->parentSymbol != rootModule) {
           VarSymbol* local_global = globals.get(var);
           SET_LINENO(se); // Set the se line number for output


### PR DESCRIPTION
localizeGlobals attempts to localize global consts to avoid repeated
comms in a loop. However, doing so for externs is wrong since we might
now always know how to copy externs. This also created problems when
passing something like `c_nil` multiple times to extern functions with
restrict qualifiers because localizing `c_nil` can create aliasing.

For something like:

```chpl
// void foo(int* restrict a, int* restrict b) { }
extern proc foo(a:c_ptr(c_int), b:c_ptr(c_int));
foo(c_nil, c_nil);
````

localize globals would incorrectly adjust this to be:

```chpl
var local_c_nil = c_nil;
foo(local_c_nil, local_c_nil);
```