### PR TITLE
TaskErrors now contains owned errors

### DIFF
--- a/modules/internal/ChapelError.chpl
+++ b/modules/internal/ChapelError.chpl
@@ -171,17 +171,17 @@ module ChapelError {
       var n = 0;
       cur = head;
       while cur != nil {
-	var curnext = cur._next;
-	var asTaskErr: unmanaged TaskErrors = cur: unmanaged TaskErrors;
-	if asTaskErr == nil {
-	  n += 1;
-	} else {
-	  for e in asTaskErr {
-	    if e != nil then
-	      n += 1;
-	  }
-	}
-	cur = curnext;
+        var curnext = cur._next;
+        var asTaskErr: unmanaged TaskErrors = cur: unmanaged TaskErrors;
+        if asTaskErr == nil {
+          n += 1;
+        } else {
+          for e in asTaskErr {
+            if e != nil then
+              n += 1;
+          }
+        }
+        cur = curnext;
       }
 
       // Allocate the array to the appropriate size
@@ -194,21 +194,21 @@ module ChapelError {
       var idx = 0;
       cur = head;
       while cur != nil {
-	var curnext = cur._next;
-	cur._next = nil; // remove from any lists
-	var asTaskErr: unmanaged TaskErrors = cur: unmanaged TaskErrors;
-	if asTaskErr == nil {
-	  errorsArray[idx].retain(cur);
-	  idx += 1;
-	} else {
-	  for e in asTaskErr {
-	    if e != nil {
-	      errorsArray[idx] = e;
-	      idx += 1;
-	    }
-	  }
-	}
-	cur = curnext;
+        var curnext = cur._next;
+        cur._next = nil; // remove from any lists
+        var asTaskErr: unmanaged TaskErrors = cur: unmanaged TaskErrors;
+        if asTaskErr == nil {
+          errorsArray[idx].retain(cur);
+          idx += 1;
+        } else {
+          for e in asTaskErr {
+            if e != nil {
+              errorsArray[idx] = e;
+              idx += 1;
+            }
+          }
+        }
+        cur = curnext;
       }
     }
 
@@ -256,7 +256,7 @@ module ChapelError {
     proc first() ref : owned Error {
       var first = 0;
       for i in 0..#nErrors {
-	if errorsArray[i] != nil {
+        if errorsArray[i] != nil {
           first = i;
         }
       }

--- a/modules/internal/ChapelError.chpl
+++ b/modules/internal/ChapelError.chpl
@@ -258,6 +258,7 @@ module ChapelError {
       for i in 0..#nErrors {
         if errorsArray[i] != nil {
           first = i;
+          break;
         }
       }
       return errorsArray[first];

--- a/modules/internal/OwnedObject.chpl
+++ b/modules/internal/OwnedObject.chpl
@@ -370,11 +370,11 @@ module OwnedObject {
   // Note, coercion from _owned -> _owned.chpl_t is sometimes directly
   // supported in the compiler via a call to borrow() and
   // sometimes uses this cast.
-  pragma "no doc"
+  /*pragma "no doc"
   inline proc _cast(type t, pragma "nil from arg" const ref x:_owned)
   where isSubtype(t,x.chpl_t) {
     return x.borrow();
-  }
+  }*/
 
   // This cast supports coercion from _owned(SubClass) to _owned(ParentClass)
   // (i.e. when class SubClass : ParentClass ).

--- a/modules/internal/OwnedObject.chpl
+++ b/modules/internal/OwnedObject.chpl
@@ -367,15 +367,6 @@ module OwnedObject {
     f <~> this.chpl_p;
   }
 
-  // Note, coercion from _owned -> _owned.chpl_t is sometimes directly
-  // supported in the compiler via a call to borrow() and
-  // sometimes uses this cast.
-  /*pragma "no doc"
-  inline proc _cast(type t, pragma "nil from arg" const ref x:_owned)
-  where isSubtype(t,x.chpl_t) {
-    return x.borrow();
-  }*/
-
   // This cast supports coercion from _owned(SubClass) to _owned(ParentClass)
   // (i.e. when class SubClass : ParentClass ).
   // It only works in a value context (i.e. when the result of the

--- a/test/errhandling/parallel/forall-wrap-first-error.chpl
+++ b/test/errhandling/parallel/forall-wrap-first-error.chpl
@@ -1,0 +1,28 @@
+module ReThrown {
+class UserError: Error {
+  var x: int;
+  proc init(x: int) { this.x = x; }
+  proc deinit() { writeln("UserError.deinit(", this.x, ")"); }
+}
+proc main() {
+  try {
+    try {
+      forall i in 0..3 {
+        var ex = new owned UserError(i);
+        throw ex;
+      }
+    }
+    catch errors: TaskErrors {
+      writeln("Caught some TaskErrors");
+      for i in errors {
+        //compilerError(i.type:string);
+        throw i;
+      }
+    }
+  }
+  catch e {
+    writeln("Outer catch");
+  }
+  writeln("End of main");
+}
+} // module ReThrown

--- a/test/errhandling/parallel/forall-wrap-first-error.chpl
+++ b/test/errhandling/parallel/forall-wrap-first-error.chpl
@@ -1,14 +1,19 @@
 module ReThrown {
 class UserError: Error {
   var x: int;
-  proc init(x: int) { this.x = x; }
-  proc deinit() { writeln("UserError.deinit(", this.x, ")"); }
+  proc init(x: int) {
+    this.x = x;
+    writeln("UserError.init");
+  }
+  proc deinit() {
+    writeln("UserError.deinit");
+  }
 }
 proc main() {
   try {
     try {
       forall i in 0..3 {
-        var ex = new owned UserError(i);
+        var ex = new owned UserError(1);
         throw ex;
       }
     }

--- a/test/errhandling/parallel/forall-wrap-first-error.good
+++ b/test/errhandling/parallel/forall-wrap-first-error.good
@@ -1,0 +1,7 @@
+Caught some TaskErrors
+UserError.deinit(2)
+UserError.deinit(3)
+UserError.deinit(0)
+Outer catch
+UserError.deinit(1)
+End of main

--- a/test/errhandling/parallel/forall-wrap-first-error.good
+++ b/test/errhandling/parallel/forall-wrap-first-error.good
@@ -1,7 +1,11 @@
+UserError.init
+UserError.init
+UserError.init
+UserError.init
 Caught some TaskErrors
-UserError.deinit(2)
-UserError.deinit(3)
-UserError.deinit(0)
+UserError.deinit
+UserError.deinit
+UserError.deinit
 Outer catch
-UserError.deinit(1)
+UserError.deinit
 End of main

--- a/test/errhandling/parallel/taskerrors-first.chpl
+++ b/test/errhandling/parallel/taskerrors-first.chpl
@@ -1,8 +1,13 @@
 module ReThrown {
 class UserError: Error {
   var x: int;
-  proc init(x: int) { this.x = x; }
-  proc deinit() { writeln("UserError.deinit(", this.x, ")"); }
+  proc init(x: int) {
+    this.x = x;
+    writeln("UserError.init");
+  }
+  proc deinit() {
+    writeln("UserError.deinit");
+  }
 }
 proc main() {
   try {

--- a/test/errhandling/parallel/taskerrors-first.chpl
+++ b/test/errhandling/parallel/taskerrors-first.chpl
@@ -1,0 +1,25 @@
+module ReThrown {
+class UserError: Error {
+  var x: int;
+  proc init(x: int) { this.x = x; }
+  proc deinit() { writeln("UserError.deinit(", this.x, ")"); }
+}
+proc main() {
+  try {
+    try {
+      forall i in 0..3 {
+        var ex = new owned UserError(i);
+        throw ex;
+      }
+    }
+    catch errors: TaskErrors {
+      writeln("Caught some TaskErrors");
+      throw errors.first();
+    }
+  }
+  catch e {
+    writeln("Outer catch");
+  }
+  writeln("End of main");
+}
+} // module ReThrown

--- a/test/errhandling/parallel/taskerrors-first.good
+++ b/test/errhandling/parallel/taskerrors-first.good
@@ -1,0 +1,7 @@
+Caught some TaskErrors
+UserError.deinit(1)
+UserError.deinit(2)
+UserError.deinit(3)
+Outer catch
+UserError.deinit(0)
+End of main

--- a/test/errhandling/parallel/taskerrors-first.good
+++ b/test/errhandling/parallel/taskerrors-first.good
@@ -1,7 +1,11 @@
+UserError.init
+UserError.init
+UserError.init
+UserError.init
 Caught some TaskErrors
-UserError.deinit(1)
-UserError.deinit(2)
-UserError.deinit(3)
+UserError.deinit
+UserError.deinit
+UserError.deinit
 Outer catch
-UserError.deinit(0)
+UserError.deinit
 End of main


### PR DESCRIPTION
Resolves #10297.
  
This PR adjusts TaskErrors to contain a C-level array of `owned Error` 
instead of relying upon the linked list pointers in Error. The linked
list pointers are still used when constructing groups of errors for tasks
in parallel. Originally I used a Chapel array for this but I was seeing
order of resolution issues with that approach (array init_elts can create
parallelism which can create TaskErrors).

Additionally it removes an cast overload in OwnedObject that appears not 
to be necessary now that the compiler is doing more coercions from owned
-> borrowed. This cast was causing ambiguity errors for some of the
existing TaskErrors tests.

- [x] full local testing

Reviewed by @lydia-duncan - thanks!