### PR TITLE
Skip two c_array tests in --baseline

### DIFF
--- a/test/extern/ferguson/c-array/c-array-passing.skipif
+++ b/test/extern/ferguson/c-array/c-array-passing.skipif
@@ -1,0 +1,2 @@
+# --baseline generates c_array initCopy functions that aren't legal C
+COMPOPTS <= --baseline

--- a/test/extern/ferguson/c-array/c-array-ptr-in-struct.skipif
+++ b/test/extern/ferguson/c-array/c-array-ptr-in-struct.skipif
@@ -1,0 +1,2 @@
+# --baseline generates c_array initCopy functions that aren't legal C
+COMPOPTS <= --baseline


### PR DESCRIPTION
This PR just skips two c_array tests added in PR  #12156 in --baseline.

With --baseline, these tests generate invalid C because an initCopy
function is created for c_array, among other things.

Trivial and not reviewed.