### PR TITLE
Improve performance with the sockets provider.

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -298,8 +298,14 @@ void init_ofiFabricDomain(void) {
   hints->ep_attr->type = FI_EP_RDM;
 
   hints->domain_attr->threading = FI_THREAD_UNSPEC;
-  hints->domain_attr->control_progress = FI_PROGRESS_MANUAL/*FI_PROGRESS_AUTO*/;
-  hints->domain_attr->data_progress = FI_PROGRESS_MANUAL/*FI_PROGRESS_AUTO*/;
+
+  int prg = ((DBG_TEST_MASK(DBG_CFG)
+              && chpl_env_rt_get_bool("COMM_OFI_AUTO_PROGRESS", false))
+             ? FI_PROGRESS_AUTO
+             : FI_PROGRESS_MANUAL);
+  hints->domain_attr->control_progress = prg;
+  hints->domain_attr->data_progress = prg;
+
   hints->domain_attr->av_type = FI_AV_TABLE;
   hints->domain_attr->mr_mode = ((strcmp(provider, "gni") == 0)
                                  ? FI_MR_BASIC

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -1733,7 +1733,9 @@ void amHandleAMO(chpl_comm_on_bundle_t* req) {
         CHK_TRUE((tcip = tciAlloc(false /*bindToAmHandler*/)) != NULL);
         do {
           const int count = fi_cntr_read(tcip->txCntr);
-          if (count > 0) {
+          if (count == 0) {
+            sched_yield();
+          } else {
             DBG_PRINTF(DBG_ACK, "tx ack counter %d after AMO result", count);
             tcip->numTxsOut -= count;
           }
@@ -2241,7 +2243,9 @@ void waitForTxCQ(struct perTxCtxInfo_t* tcip, int numOut, uint64_t xpctFlags) {
                          err.err, bufProv);
       }
 
-      if (ret > 0) {
+      if (ret <= 0) {
+        sched_yield();
+      } else {
         const int numEvents = ret;
         numRetired += numEvents;
         for (int i = 0; i < numEvents; i++) {


### PR DESCRIPTION
We've been directing both AM request messages and RMA/AMO transactions
at the same receive endpoint, on each node.  In effect this made the AM
handler responsible not only for AMs but also for RMA progress, since we
used the manual progress model.  This didn't seem to affect things much
when the gni provider was being used, probably because that doesn't need
much processor involvement for progress.  But with the sockets provider
we were seeing a significant number of test timeouts, especially on the
chapcs cluster.  Here, resolve this problem by adding another receive
endpoint specifically for RMA and AMO traffic, and making the non-AM
handler threads primarily responsible for progress on it (with the AM
handler backing them up), but also defaulting to automatic progress when
using the sockets provider.

Also, fix something that sort of straddles the boundary between bug and
performance improvement: yield while we wait for completions.  Without
yielding we get very good latency noticing when the completion finally
arrives, but we monopolize threads/cores and may prevent progress on the
very transaction(s) we are waiting for.  This code will likely need
revisiting, since sched_yield() is probably a bigger hammer than ideal.
But avoiding monopolization is a good thing, and we're not really into
performance tuning yet.

Finally, while here, add a debug-only capability to switch between
manual and auto progress.

This resolves #12197.