### PR TITLE
Make stdout, stderr ordering predictable in test output.

### DIFF
--- a/test/functions/iterators/elliot/dynamicIters/numTasksDynamicIters.neg.good
+++ b/test/functions/iterators/elliot/dynamicIters/numTasksDynamicIters.neg.good
@@ -1,13 +1,13 @@
-numTasksDynamicIters.chpl:11: warning: 'numTasks' < 0, defaulting to numTasks=1
-numTasksDynamicIters.chpl:12: warning: 'numTasks' < 0, defaulting to numTasks=1
-numTasksDynamicIters.chpl:15: warning: 'numTasks' < 0, defaulting to numTasks=1
-numTasksDynamicIters.chpl:16: warning: 'numTasks' < 0, defaulting to numTasks=1
-numTasksDynamicIters.chpl:19: warning: 'numTasks' < 0, defaulting to numTasks=1
-numTasksDynamicIters.chpl:20: warning: 'numTasks' < 0, defaulting to numTasks=1
-numTasksDynamicIters.chpl:11: warning: 'numTasks' < 0, defaulting to numTasks=1
-numTasksDynamicIters.chpl:12: warning: 'numTasks' < 0, defaulting to numTasks=1
-numTasksDynamicIters.chpl:15: warning: 'numTasks' < 0, defaulting to numTasks=1
-numTasksDynamicIters.chpl:16: warning: 'numTasks' < 0, defaulting to numTasks=1
-numTasksDynamicIters.chpl:19: warning: 'numTasks' < 0, defaulting to numTasks=1
-numTasksDynamicIters.chpl:20: warning: 'numTasks' < 0, defaulting to numTasks=1
 24 24 24 24 24 24 24 24 24 24
+numTasksDynamicIters.chpl:11: warning: 'numTasks' < 0, defaulting to numTasks=1
+numTasksDynamicIters.chpl:12: warning: 'numTasks' < 0, defaulting to numTasks=1
+numTasksDynamicIters.chpl:15: warning: 'numTasks' < 0, defaulting to numTasks=1
+numTasksDynamicIters.chpl:16: warning: 'numTasks' < 0, defaulting to numTasks=1
+numTasksDynamicIters.chpl:19: warning: 'numTasks' < 0, defaulting to numTasks=1
+numTasksDynamicIters.chpl:20: warning: 'numTasks' < 0, defaulting to numTasks=1
+numTasksDynamicIters.chpl:11: warning: 'numTasks' < 0, defaulting to numTasks=1
+numTasksDynamicIters.chpl:12: warning: 'numTasks' < 0, defaulting to numTasks=1
+numTasksDynamicIters.chpl:15: warning: 'numTasks' < 0, defaulting to numTasks=1
+numTasksDynamicIters.chpl:16: warning: 'numTasks' < 0, defaulting to numTasks=1
+numTasksDynamicIters.chpl:19: warning: 'numTasks' < 0, defaulting to numTasks=1
+numTasksDynamicIters.chpl:20: warning: 'numTasks' < 0, defaulting to numTasks=1

--- a/test/library/standard/FileSystem/bharshbarg/filer.good
+++ b/test/library/standard/FileSystem/bharshbarg/filer.good
@@ -1,2 +1,2 @@
-filer.chpl:144: warning: sorting has no effect for parallel invocations of walkdirs()
 .
+filer.chpl:144: warning: sorting has no effect for parallel invocations of walkdirs()

--- a/test/library/standard/Time/sleepTimeUnits.good
+++ b/test/library/standard/Time/sleepTimeUnits.good
@@ -1,2 +1,2 @@
-sleepTimeUnits.chpl:16: warning: sleep() called with negative time parameter: '-5.0'
 Done
+sleepTimeUnits.chpl:16: warning: sleep() called with negative time parameter: '-5.0'

--- a/test/memory/shannon/memstatFlag.good
+++ b/test/memory/shannon/memstatFlag.good
@@ -1,2 +1,2 @@
-memstatFlag.chpl:6: warning: invalid call to printMemAllocStats(); rerun with --memTrack
 m = 10
+memstatFlag.chpl:6: warning: invalid call to printMemAllocStats(); rerun with --memTrack

--- a/test/multilocale/gasnet/bradc/257threads.good
+++ b/test/multilocale/gasnet/bradc/257threads.good
@@ -1,3 +1,3 @@
-CHPL_RT_NUM_THREADS_PER_LOCALE = 257 is too large; limit is 255
-CHPL_RT_NUM_THREADS_PER_LOCALE = 257 is too large; limit is 255
 Running program
+CHPL_RT_NUM_THREADS_PER_LOCALE = 257 is too large; limit is 255
+CHPL_RT_NUM_THREADS_PER_LOCALE = 257 is too large; limit is 255

--- a/test/parallel/taskPool/figueroa/ManyThreads.comm-gasnet.good
+++ b/test/parallel/taskPool/figueroa/ManyThreads.comm-gasnet.good
@@ -1,2 +1,2 @@
-CHPL_RT_NUM_THREADS_PER_LOCALE = 300 is too large; limit is 255
 total is 4501500
+CHPL_RT_NUM_THREADS_PER_LOCALE = 300 is too large; limit is 255

--- a/test/release/examples/primers/learnChapelInYMinutes.prediff
+++ b/test/release/examples/primers/learnChapelInYMinutes.prediff
@@ -17,17 +17,18 @@ def writeOutput( value ):
   if DEBUG_MODE: print(value)
   fh.close()
 
-[test_serial_input, test_parallel_input] = input.split( "PARALLELISM START" )
-
-# Somewhere in the serial part this one line of stderr output
-# must occur precisely once.
+# This one line of stderr output must occur precisely once.  (sub_test
+# will put it at the end but we are concerned only with test behavior,
+# not testing system behavior, and do not depend on that.)
 line_of_stderr = 'This goes to standard error\n'
-[tsi_pre, tsi_sep, tsi_post] = test_serial_input.partition( line_of_stderr )
-if tsi_sep == line_of_stderr:
-  test_serial_input = tsi_pre + tsi_post
+[input_pre, input_sep, input_post] = input.partition( line_of_stderr )
+if input_sep == line_of_stderr and input_post.count( line_of_stderr ) == 0:
+  input = input_pre + input_post
 else:
-  writeOutput( "FAILED! " + str( line_of_stderr ) + " not seen" )
+  writeOutput( "FAILED! " + str( line_of_stderr ) + " not seen exactly 1 time" )
   exit( -1-i )
+
+[test_serial_input, test_parallel_input] = input.split( "PARALLELISM START" )
 
 [test_serial, test_parallel] = [ list(filter( remove_empty, test_serial_input.split("\n"))), \
                                  list(filter( remove_empty, test_parallel_input.split("\n") ))]

--- a/test/release/examples/primers/learnChapelInYMinutes.skipif
+++ b/test/release/examples/primers/learnChapelInYMinutes.skipif
@@ -1,7 +1,0 @@
-#!/usr/bin/env python
-
-# This test writes to both stdout and stderr and expects a particular order.
-# Most launchers buffer stdout but not stderr which defeats the prediff processing.
-
-import os
-print(os.getenv('CHPL_LAUNCHER') not in ['none', 'amudprun'])

--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -1972,8 +1972,9 @@ for testname in testsrc:
                                   env=dict(list(os.environ.items()) + list(testenv.items())),
                                   stdin=my_stdin,
                                   stdout=subprocess.PIPE,
-                                  stderr=subprocess.STDOUT)
-                        output = p.communicate()[0]
+                                  stderr=subprocess.PIPE)
+                        (stdoutOutput, stderrOutput) = p.communicate()
+                        output = stdoutOutput + stderrOutput
                         status = p.returncode
 
                         # Check for well-known failure modes
@@ -2000,8 +2001,9 @@ for testname in testsrc:
                                   env=dict(list(os.environ.items()) + list(testenv.items())),
                                   stdin=my_stdin,
                                   stdout=subprocess.PIPE,
-                                  stderr=subprocess.STDOUT)
-                        output = p.communicate()[0]
+                                  stderr=subprocess.PIPE)
+                        (stdoutOutput, stderrOutput) = p.communicate()
+                        output = stdoutOutput + stderrOutput
                         status = p.returncode
 
                         if status == 222:
@@ -2034,9 +2036,9 @@ for testname in testsrc:
                                   env=dict(list(os.environ.items()) + list(testenv.items())),
                                   stdin=my_stdin,
                                   stdout=subprocess.PIPE,
-                                  stderr=subprocess.STDOUT)
+                                  stderr=subprocess.PIPE)
                         try:
-                            output = SuckOutputWithTimeout(p.stdout, timeout)
+                            stdoutOutput = SuckOutputWithTimeout(p.stdout, timeout)
                         except ReadTimeoutException:
                             exectimeout = True
                             sys.stdout.write('%s[Error: Timed out executing program %s/%s'%
@@ -2046,6 +2048,8 @@ for testname in testsrc:
                             sys.stdout.write(']\n')
                             KillProc(p, killtimeout)
 
+                        stderrOutput = p.communicate()[1]
+                        output = stdoutOutput + stderrOutput
                         status = p.returncode
 
                 # executable is done running


### PR DESCRIPTION
We've been running tests with their stderr redirected to the same pipe
as their stdout.  As a result, for tests that produce some of both, such
as ones that test execution-time error messages, the order in which
these two are combined depends on a variety of things including libc and
launcher buffering settings and in some cases launcher pipe combining.
Here, arrange to produce stdout and stderr into separate pipes and
combine them into the test output file after the test completes, with
output from stdout preceding that from stderr.

This resolves several failures in chapcs comm=ofi full testing which
were caused by the mpirun4ofi launcher combining stdout and stderr in a
different way than did gasnet amudprun, whose output has become our
canonical "good" result).  errhandling/ferguson/throws-destroys is an
example of such a test; its .good file contains both stdout output from
the test and the stderr result of an error being thrown but not caught.