### PR TITLE
Reduce contention on ugni's comm domains

### DIFF
--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -729,7 +729,8 @@ static uint32_t     comm_dom_cnt_max;
 
 static comm_dom_t*  comm_doms;
 
-static __thread int comm_dom_free_idx;
+static atomic_int_least32_t global_init_cdi;
+static __thread int comm_dom_free_idx = -1;
 static __thread comm_dom_t* cd = NULL;
 static __thread int cd_idx = -1;
 
@@ -2092,7 +2093,8 @@ void chpl_comm_post_task_init(void)
   for (int i = 0; i < comm_dom_cnt; i++)
     gni_setup_per_comm_dom(i);
 
-  comm_dom_free_idx = 0;
+  atomic_init_int_least32_t(&global_init_cdi, 0);
+
 
   //
   // Register memory.
@@ -7894,6 +7896,10 @@ void acquire_comm_dom(void)
     return;
   }
 
+  if (comm_dom_free_idx == -1) {
+    comm_dom_free_idx = atomic_fetch_add_int_least32_t(&global_init_cdi, 1) % comm_dom_cnt;
+  }
+
   assert(cd == NULL);
 
   //
@@ -7968,6 +7974,10 @@ void acquire_comm_dom_and_req_buf(c_nodeid_t remote_locale, int* p_rbi)
 #ifdef DEBUG_STATS
   uint64_t acq_looks = 0;
 #endif
+
+  if (comm_dom_free_idx == -1) {
+    comm_dom_free_idx = atomic_fetch_add_int_least32_t(&global_init_cdi, 1) % comm_dom_cnt;
+  }
 
   assert(cd == NULL);
 

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -735,9 +735,9 @@ static __thread comm_dom_t* cd = NULL;
 static __thread int cd_idx = -1;
 
 #define INIT_CD_BUSY(cd)      atomic_init_bool(&(cd)->busy, false)
-#define CHECK_CD_BUSY(cd)     atomic_load_bool(&(cd)->busy)
-#define ACQUIRE_CD_MAYBE(cd)  (atomic_exchange_bool(&(cd)->busy, true) == false)
-#define RELEASE_CD(cd)        atomic_store_bool(&(cd)->busy, false)
+#define CHECK_CD_BUSY(cd)     atomic_load_explicit_bool(&(cd)->busy, memory_order_acquire)
+#define ACQUIRE_CD_MAYBE(cd)  (!atomic_exchange_explicit_bool(&(cd)->busy, true, memory_order_acquire))
+#define RELEASE_CD(cd)        atomic_store_explicit_bool(&(cd)->busy, false, memory_order_release)
 
 
 //


### PR DESCRIPTION
This reduces contention on ugni's communication domains (CD) by
spreading out the initial comm domain index and using more relaxed
memory orders for acquiring/releasing CDs.

Previously, all threads would start at CD 0 and then cycle through until
they found a CD that wasn't currently acquired. Once a free CD was found
we stored the index in TLS and would try to use the same CD next time we
needed one. However, since all threads stated at CD 0, this often
resulted in multiple threads having affinity for the same CD, which
would cause cycling until hopefully some steady state was achieved. For
normal runs we usually came to a steady state fairly quickly, but it
looks like this was not the case when running oversubscribed.

In order to reduce the amount of contention, use a global atomic to
spread out the initial CD index. This way the first thread to acquire a
CD will try to acquire CD 0 and the second thread to acquire a CD will
try to acquire CD 1. For tasking layers that have a fixed number of
threads (like qthreads) this eliminates contention since each worker
thread will have affinity for a different CD and there will never be any
contention that causes them to cycle.

This improves oversubscribed performance for RA-atomics and eliminates
cycling for a free CD (as tracked by the perf counter acq_cd_na_cnt)

Performance counter (acq_cd_na_cnt):

| tasksPerCore | master  | spread CD |
| ------------ | ------- | --------- |
| 1 (default)  |    380  | 0         |
| 2            |   1482  | 0         |
| 4            | 250277  | 0         |

This also switches to using acquire/release memory orders for
acquiring/releasing comm doms, similar to the work in d6ae90741e.

Combined, these commits result in a non-trivial performance improvement
for RA-atomics (and presumably other fine grain benchmarks that have to
acquire comm domains frequently).

Performance (GUPS):

| tasksPerCore | master    | spread CD | relax AMO |
| ------------ | --------- | --------- | --------- |
| 1 (default)  | ~.16 GUPS | ~.18 GUPS | ~.18 GUPS |
| 2            | ~.22 GUPS | ~.23 GUPS | ~.24 GUPS |
| 4            | ~.18 GUPS | ~.25 GUPS | ~.26 GUPS |

Related to (but does not resolve) https://github.com/chapel-lang/chapel/issues/11974