### PR TITLE
Move setupRecIterFields()

### DIFF
--- a/compiler/include/foralls.h
+++ b/compiler/include/foralls.h
@@ -55,7 +55,6 @@ public:
 };
 
 bool astUnderFI(const Expr* ast, ForallIntents* fi);
-void resolveForallStmts1();
 void resolveForallStmts2();
 
 #define for_riSpecs_vector(VAL, FI) \

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -7046,7 +7046,6 @@ void resolve() {
   insertDynamicDispatchCalls();
 
   beforeLoweringForallStmts = false;
-  resolveForallStmts1();
 
   insertReturnTemps();
 


### PR DESCRIPTION
Before this change, setupRecIterFields() was performed as a separate
sub-pass in resolve(), namely resolveForallStmts1().

Now, instead, make it part of resolveForallHeader().
This removes the need to have resolveForallStmts1()
and may also come handy in my upcoming work.

Trivial, not reviewed.
