### PR TITLE
Allow inlining iterators with 0 yields

### DIFF
--- a/compiler/resolution/lowerIterators.cpp
+++ b/compiler/resolution/lowerIterators.cpp
@@ -1996,9 +1996,7 @@ countYieldsInFn(FnSymbol* fn)
 static bool
 canInlineIterator(FnSymbol* iterator) {
   int count = countYieldsInFn(iterator);
-
-  // count==0 e.g. in users/biesack/test_recursive_iterator.chpl
-  return (count >= 1 && count <= inline_iter_yield_limit);
+  return count <= inline_iter_yield_limit;
 }
 
 static void


### PR DESCRIPTION
Inability to inline an iterator with 0 yields bit me in my upcoming work
in the case when the iterator throws. We want to inline it because it works,
whereas we do not support iterators that throw and are not inlined.
The test in question is:
````
library/standard/FileSystem/lydia/parallelDirState/chdirAllLocales.chpl
````

where my upcoming work represents the promoted `chdir()` using iterators.
Which throw.

#### Archaeology

The check 'count == 1' was added in 2008 (821a100205) or earlier.
Things surely have changed since then.
The comment warning about "count==0" was added in 2013 in an unrelated commit.
The test mentioned there now passes.

Trivial, not reviewed.
