### PR TITLE
Add a resultType,min,max overload for PCG getNext

### DIFF
--- a/test/library/standard/Random/ferguson/rand-range-different-types.chpl
+++ b/test/library/standard/Random/ferguson/rand-range-different-types.chpl
@@ -1,0 +1,10 @@
+use Random;
+
+var rng = makeRandomStream(real);
+
+var expectInt = rng.getNext(int, 1, 10);
+assert(expectInt.type == int);
+assert(1 <= expectInt && expectInt <= 10);
+var expectReal = rng.getNext(real, 1.0, 10.0);
+assert(expectReal.type == real);
+assert(1.0 <= expectReal && expectReal <= 10.0);


### PR DESCRIPTION
This is to help with PR #12027 adding Random.choice().

- [x] full local testing

Reviewed by @ben-albrecht - thanks!