### PR TITLE
Remove transient MPP sub_test filter

### DIFF
--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -601,8 +601,6 @@ def translateOutput(output):
                'Jira 17 -- Missing output file for'),
               ('aprun: Unexpected close of the apsys control connection',
                'Jira 193 -- Unexpected close of apsys for'),
-              ('Transient MPP reservation error on create',
-               'Jira 203 -- Transient MPP reservation error for'),
               ('qsub: cannot connect to server sdb',
                'Jira 283 -- Sporadic: qstat failed to connect to server sdb'),
               ('Failed to recv data from background qsub',


### PR DESCRIPTION
There are 2 types of filters for common issues that occur in nightly testing:

- sub_test filtering - converts error message into a clean message with a reference to the internal JIRA issue
- prediff filtering (`util/test/prediff*`) - removes the error message from the output entirely, so that it makes no noise in testing

The Transient MPP error had both types of filters, which ended up interfering with each other. This PR removes the sub_test filter for transient MPP issue so that we (hopefully) no longer see this error show up in nightly testing results.