### PR TITLE
Add perf annotations for 2019-02-07

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -364,6 +364,12 @@ all:
       config: 16 node XC
   01/07/19:
     - Default to cstdlib atomics for gcc >= 5 (#11963)
+  02/06/19:
+    - text: Reduce contention on ugni's comm domains (#12240)
+      config: 16 node XC
+  02/07/19:
+    - text: Simplify how we acquire comm domains in ugni (#12258)
+      config: 16 node XC
 
 
 AllCompTime:
@@ -755,7 +761,7 @@ jacobi:
     - No-alias hints for LLVM (no compiler perf impact) (#11324)
   12/14/18:
     - Allow underscores in the number when casting from string to integral (#11880)
-  01/22/18:
+  01/22/19:
     - Catch blocks catch owned, test code throws owned (#12090)
 
 knucleotide:
@@ -1240,8 +1246,10 @@ sad:
 search:
   04/20/17:
     - Update RE2 (#6024)
-  05/26/18:
+  04/26/18:
     - Update tuples to use special function instead of constructors (#9317)
+  12/14/18:
+    - Tuple iteration yields (const) refs (#11866)
 
 spectralnorm:
   01/21/15:


### PR DESCRIPTION
Add annotations for:
 - [improvements](https://chapel-lang.org/perf/chapcs/?startdate=2018/11/08&enddate=2019/01/15&graphs=searchesovernstrings) for varags string startsWith and endsWith (#11866)
 - [improvements](https://chapel-lang.org/perf/16-node-xc/?startdate=2019/01/25&enddate=2019/02/08&configs=gnuugniqthreads&graphs=hpccraatomicsperfgupsn233,hpccbufferedraatomicsperfgupsn233,balehistogramperfmbspernode) for fine-grained benchmarks under ugni (#12240, #12258)

Also corrected some incorrect annotation dates