### PR TITLE
Copy directory-wide skipif for parent directory to this new one

### DIFF
--- a/test/extern/ferguson/externblock/multi-module/SKIPIF
+++ b/test/extern/ferguson/externblock/multi-module/SKIPIF
@@ -1,0 +1,2 @@
+# Tests in this directory assume LLVM/Clang support
+CHPL_LLVM == none


### PR DESCRIPTION
The tests in this new directory require LLVM, but we accidentally
missed adding a directory-wide skipif similar to the one in its
parent directory.  Rectify that mistake.

Verified that the directory was skipped after this change.