### PR TITLE
Add _defaultOfMemoryOrder to locks chpl-atomics.h

### DIFF
--- a/runtime/include/atomics/locks/chpl-atomics.h
+++ b/runtime/include/atomics/locks/chpl-atomics.h
@@ -105,6 +105,10 @@ typedef enum {
  memory_order_seq_cst
 } memory_order;
 
+static inline memory_order _defaultOfMemoryOrder(void) {
+  return memory_order_seq_cst;
+}
+
 static inline
 void chpl_atomic_thread_fence(memory_order order)
 {


### PR DESCRIPTION
This function was added for intrinsics atomics in 
27159928237c174bc5b0d09a028497c864488112 but the version for locking 
atomics was missing. Now that we have a test of it (added in #12154) we
notice that problem.

This PR adds the missing function.

Trivial and not reviewed.

- [x] primers and memory_order_test.chpl pass with CHPL_ATOMICS=locks 
- [x] full local testing