### PR TITLE
Fix fixpath for pyenv users

### DIFF
--- a/util/config/fixpath.py
+++ b/util/config/fixpath.py
@@ -1,11 +1,17 @@
 #!/usr/bin/env python
 
-"""
-Removes path components that begin with $CHPL_HOME, to reduce
-$PATH & $MANPATH pollution
+"""Removes path components that begin with $CHPL_HOME from the given path.
 
-This is used by the setchplenv.* scripts, and may be called in several
-situations:
+    ./fixpath.py path-value [--shell shell]
+
+Example:
+
+    ./fixpath.py "$PATH" --shell=fish
+
+
+This is used by the setchplenv.* scripts to reduce PATH/MANPATH pollution. It
+may be called in several situations:
+
 1. No Chapel environment settings (new shell)
 2. Same $CHPL_HOME as last time (re-running setchplenv in same dir)
 3. Different $CHPL_HOME (cd ../other-chapel-dir).
@@ -66,8 +72,6 @@ if __name__ == '__main__':
 
 
     parser = optparse.OptionParser(usage=__doc__)
-    #parser.add_arg('env_val', dest='env_val',
-    #                  help='Value of path to be split');
     parser.add_option('--shell', dest='shell', default='bash',
                       help='shell being used');
 

--- a/util/config/fixpath.py
+++ b/util/config/fixpath.py
@@ -61,7 +61,7 @@ def remove_chpl_from_path(path_val, delim):
     # Note: Fish shell still uses ':' delimiter for printing with \\"$PATH\\"
     pattern = r'(?<!\\)\:'
 
-    # Split path by non-escape delimiters and sieve chpl_home
+    # Split path by non-escaped ':'s, and sieve chpl_home
     newpath = [escape_path(p, delim) for p in re.split(pattern, path_val)]
     newpath = [p for p in newpath if chpl_home not in p]
 

--- a/util/config/fixpath.py
+++ b/util/config/fixpath.py
@@ -81,7 +81,8 @@ def main():
         delim = ':'
 
     if len(args) == 0:
-        sys.stdout.write(__doc__)
+        sys.stderr.write('Error: path-value must be supplied\n\n')
+        parser.print_help()
         sys.exit(1)
 
     path = args[0]

--- a/util/config/fixpath.py
+++ b/util/config/fixpath.py
@@ -57,7 +57,7 @@ def remove_chpl_from_path(path_val, delim):
     if not chpl_home or chpl_home not in path_val:
         return path_val
 
-    # Find delims that are not escaped
+    # Find ':'s that are not escaped
     # Note: Fish shell still uses ':' delimiter for printing with \\"$PATH\\"
     pattern = r'(?<!\\)\:'
 

--- a/util/config/fixpath.py
+++ b/util/config/fixpath.py
@@ -78,6 +78,6 @@ if __name__ == '__main__':
     else:
         delim = ':'
 
-    newpath = main(args[1], delim=delim)
+    newpath = main(args[0], delim=delim)
 
     print(newpath)

--- a/util/quickstart/setchplenv.bash
+++ b/util/quickstart/setchplenv.bash
@@ -24,9 +24,9 @@ if [ ! -d "$chpl_home/util" ] || [ ! -d "$chpl_home/compiler" ] || [ ! -d "$chpl
 fi
 
 # Remove any previously existing CHPL_HOME paths
-MYPATH=`$chpl_home/util/config/fixpath.py PATH`
+MYPATH=`$chpl_home/util/config/fixpath.py "$PATH"`
 exitcode=$?
-MYMANPATH=`$chpl_home/util/config/fixpath.py MANPATH`
+MYMANPATH=`$chpl_home/util/config/fixpath.py "$MANPATH"`
 
 # Double check $MYPATH before overwriting $PATH
 if [ -z "${MYPATH}" -o "${exitcode}" -ne 0 ]; then

--- a/util/quickstart/setchplenv.csh
+++ b/util/quickstart/setchplenv.csh
@@ -10,9 +10,9 @@ if ( ! -d "util" || ! -d "compiler" || ! -d "runtime" || ! -d "modules" ) then
 endif
 
 # Remove any previously existing CHPL_HOME paths
-set MYPATH = `./util/config/fixpath.py PATH`
+set MYPATH = `./util/config/fixpath.py "$PATH"`
 set exitcode = $?
-set MYMANPATH = `./util/config/fixpath.py MANPATH`
+set MYMANPATH = `./util/config/fixpath.py "$MANPATH"`
 
 # Double check $MYPATH before overwriting $PATH
 if ( "$MYPATH" == "" || "$exitcode" != 0) then

--- a/util/quickstart/setchplenv.fish
+++ b/util/quickstart/setchplenv.fish
@@ -14,9 +14,9 @@ if [ ! -d "$chpl_home/util" -o ! -d "$chpl_home/compiler" -o ! -d "$chpl_home/ru
 end
 
 # Remove any previously existing CHPL_HOME paths
-eval set MYPATH (eval "$chpl_home/util/config/fixpath.py \"PATH\" \"fish\"")
+eval set MYPATH (eval "$chpl_home/util/config/fixpath.py \"$PATH\" \"fish\"")
 set exitcode $status
-eval set MYMANPATH (eval "$chpl_home/util/config/fixpath.py \"MANPATH\" \"fish\"")
+eval set MYMANPATH (eval "$chpl_home/util/config/fixpath.py \"$MANPATH\" \"fish\"")
 
 # Double check $MYPATH before overwriting $PATH
 if [ (count $MYPATH) = 0 -o ! $exitcode = 0 ]

--- a/util/quickstart/setchplenv.fish
+++ b/util/quickstart/setchplenv.fish
@@ -14,9 +14,9 @@ if [ ! -d "$chpl_home/util" -o ! -d "$chpl_home/compiler" -o ! -d "$chpl_home/ru
 end
 
 # Remove any previously existing CHPL_HOME paths
-eval set MYPATH (eval "$chpl_home/util/config/fixpath.py \"$PATH\" \"fish\"")
+eval set MYPATH (eval "$chpl_home/util/config/fixpath.py \"$PATH\" \"--shell=fish\"")
 set exitcode $status
-eval set MYMANPATH (eval "$chpl_home/util/config/fixpath.py \"$MANPATH\" \"fish\"")
+eval set MYMANPATH (eval "$chpl_home/util/config/fixpath.py \"$MANPATH\" \"--shell=fish\"")
 
 # Double check $MYPATH before overwriting $PATH
 if [ (count $MYPATH) = 0 -o ! $exitcode = 0 ]

--- a/util/quickstart/setchplenv.sh
+++ b/util/quickstart/setchplenv.sh
@@ -10,9 +10,9 @@ if [ ! -d "util" ] || [ ! -d "compiler" ] || [ ! -d "runtime" ] || [ ! -d "modul
     echo "Error: You must use '. util/setchplenv.sh' from within the chapel root directory."
     return 1
 fi
-MYPATH=`./util/config/fixpath.py PATH`
+MYPATH=`./util/config/fixpath.py "$PATH"`
 exitcode=$?
-MYMANPATH=`./util/config/fixpath.py MANPATH`
+MYMANPATH=`./util/config/fixpath.py "$MANPATH"`
 
 # Double check $MYPATH before overwriting $PATH
 if [ -z "${MYPATH}" -o "${exitcode}" -ne 0 ]; then

--- a/util/setchplenv.bash
+++ b/util/setchplenv.bash
@@ -24,9 +24,9 @@ if [ ! -d "$chpl_home/util" ] || [ ! -d "$chpl_home/compiler" ] || [ ! -d "$chpl
 fi
 
 # Remove any previously existing CHPL_HOME paths
-MYPATH=`$chpl_home/util/config/fixpath.py PATH`
+MYPATH=`$chpl_home/util/config/fixpath.py "$PATH"`
 exitcode=$?
-MYMANPATH=`$chpl_home/util/config/fixpath.py MANPATH`
+MYMANPATH=`$chpl_home/util/config/fixpath.py "$MANPATH"`
 
 # Double check $MYPATH before overwriting $PATH
 if [ -z "${MYPATH}" -o "${exitcode}" -ne 0 ]; then

--- a/util/setchplenv.csh
+++ b/util/setchplenv.csh
@@ -10,9 +10,9 @@ if ( ! -d "util" || ! -d "compiler" || ! -d "runtime" || ! -d "modules" ) then
 endif
 
 # Remove any previously existing CHPL_HOME paths
-set MYPATH = `./util/config/fixpath.py PATH`
+set MYPATH = `./util/config/fixpath.py "$PATH"`
 set exitcode = $?
-set MYMANPATH = `./util/config/fixpath.py MANPATH`
+set MYMANPATH = `./util/config/fixpath.py "$MANPATH"`
 
 # Double check $MYPATH before overwriting $PATH
 if ( "$MYPATH" == "" || "$exitcode" != 0) then

--- a/util/setchplenv.fish
+++ b/util/setchplenv.fish
@@ -14,9 +14,9 @@ if [ ! -d "$chpl_home/util" -o ! -d "$chpl_home/compiler" -o ! -d "$chpl_home/ru
 end
 
 # Remove any previously existing CHPL_HOME paths
-eval set MYPATH (eval "$chpl_home/util/config/fixpath.py \"PATH\" \"fish\"")
+eval set MYPATH (eval "$chpl_home/util/config/fixpath.py \"$PATH\" \"fish\"")
 set exitcode $status
-eval set MYMANPATH (eval "$chpl_home/util/config/fixpath.py \"MANPATH\" \"fish\"")
+eval set MYMANPATH (eval "$chpl_home/util/config/fixpath.py \"$MANPATH\" \"fish\"")
 
 # Double check $MYPATH before overwriting $PATH
 if [ (count $MYPATH) = 0 -o ! $exitcode = 0 ]

--- a/util/setchplenv.fish
+++ b/util/setchplenv.fish
@@ -14,9 +14,9 @@ if [ ! -d "$chpl_home/util" -o ! -d "$chpl_home/compiler" -o ! -d "$chpl_home/ru
 end
 
 # Remove any previously existing CHPL_HOME paths
-eval set MYPATH (eval "$chpl_home/util/config/fixpath.py \"$PATH\" \"fish\"")
+eval set MYPATH (eval "$chpl_home/util/config/fixpath.py \"$PATH\" \"--shell=fish\"")
 set exitcode $status
-eval set MYMANPATH (eval "$chpl_home/util/config/fixpath.py \"$MANPATH\" \"fish\"")
+eval set MYMANPATH (eval "$chpl_home/util/config/fixpath.py \"$MANPATH\" \"--shell=fish\"")
 
 # Double check $MYPATH before overwriting $PATH
 if [ (count $MYPATH) = 0 -o ! $exitcode = 0 ]

--- a/util/setchplenv.sh
+++ b/util/setchplenv.sh
@@ -10,9 +10,9 @@ if [ ! -d "util" ] || [ ! -d "compiler" ] || [ ! -d "runtime" ] || [ ! -d "modul
     echo "Error: You must use '. util/setchplenv.sh' from within the chapel root directory."
     return 1
 fi
-MYPATH=`./util/config/fixpath.py PATH`
+MYPATH=`./util/config/fixpath.py "$PATH"`
 exitcode=$?
-MYMANPATH=`./util/config/fixpath.py MANPATH`
+MYMANPATH=`./util/config/fixpath.py "$MANPATH"`
 
 # Double check $MYPATH before overwriting $PATH
 if [ -z "${MYPATH}" -o "${exitcode}" -ne 0 ]; then


### PR DESCRIPTION
`fixpath.py` was relying on reading `PATH` from within python. For pyenv users, the `PATH` from within python would get polluted with some pyenv shims. To make fixpath more robust, I switched the interface to take the full value of `$PATH` or `$MANPATH` rather than a sentinel value `"PATH"`.

Also switched to using `optparse` for arg parsing in fixpath (recall, we can't use `argparse` in scripts used outside of the virtualenv like this due our continued support for python 2.6 still (recall, we still support python 2.6 for users stuck on legacy CLE 5 systems)).

- [x] Clean up documentation
- [x] Test with all the shells