### PR TITLE
Uniform creation of promotion iterators

### DIFF
--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -1128,6 +1128,7 @@ buildForallLoopStmt(Expr*      indices,
                     bool       zippered,
                     VarSymbol* useThisGlobalOp)
 {
+  INT_ASSERT(false); //ensure we do not use it
   checkControlFlow(loopBody, "forall statement");
   SET_LINENO(loopBody);
 

--- a/compiler/resolution/implementForallIntents.cpp
+++ b/compiler/resolution/implementForallIntents.cpp
@@ -700,6 +700,8 @@ void implementForallIntents1(DefExpr* defChplIter)
     return;
   }
   
+  INT_ASSERT(false); //ensure we do not use the rest
+
   //
   // Find the corresponding forall loop body(s).
   //
@@ -1712,6 +1714,7 @@ void implementForallIntents2(CallExpr* call, CallExpr* origToLeaderCall) {
       stashPristineCopyOfLeaderIter(origLeader, /*ignore_isResolved:*/ false);
     }
   } else {
+    INT_ASSERT(false); //ensure we do not use these
     if (isLoopExprFun(origLeader)) {
       propagateExtraArgsForLoopIter(call, origToLeaderCall, origLeader);
     } else {
@@ -1763,6 +1766,7 @@ static void unresolveWrapper(FnSymbol* wrapper) {
 // Handle the wrapper if applicable.
 void implementForallIntents2wrapper(CallExpr* call, CallExpr* eflopiHelper)
 {
+  INT_ASSERT(false); //ensure we do not use it
   FnSymbol* dest = call->resolvedFunction();
 
   if (!dest->hasFlag(FLAG_WRAPPER)) {

--- a/compiler/resolution/loopDetails.cpp
+++ b/compiler/resolution/loopDetails.cpp
@@ -107,7 +107,7 @@ ForLoop* findFollowerForLoop(BlockStmt* block) {
 static Symbol* findPrecedingChplIter(Expr* ref)
 {
   Symbol* chpl_iter = NULL;
-  Expr* e = ref;
+  Expr* e = ref->prev;
   while (e) {
     if (DefExpr* d = toDefExpr(e)) {
       Symbol* var = d->sym;
@@ -115,6 +115,10 @@ static Symbol* findPrecedingChplIter(Expr* ref)
         chpl_iter = var;
         break;
       }
+    } else if (isForallStmt(e)) {
+      // This ForallStmt has its own set of variables.
+      // Don't look at those.
+      break;
     }
     e = e->prev;
   }

--- a/test/functions/promotion/racy-arg.good
+++ b/test/functions/promotion/racy-arg.good
@@ -1,4 +1,2 @@
-racy-arg.chpl:1: error: non-lvalue actual is passed to 'ref' formal 'rcv' of increment()
-racy-arg.chpl:28: note: The shadow variable 'rcv' is constant due to forall intents in this loop
-racy-arg.chpl:41: error: non-lvalue actual is passed to 'ref' formal 'rcv' of addem()
-racy-arg.chpl:58: note: The shadow variable 'rcv' is constant due to forall intents in this loop
+racy-arg.chpl:28: error: Racy promotion of scalar argument for the formal 'rcv'
+racy-arg.chpl:58: error: Racy promotion of scalar argument for the formal 'rcv'

--- a/test/functions/promotion/thesePromotes1-serial.chpl
+++ b/test/functions/promotion/thesePromotes1-serial.chpl
@@ -9,6 +9,8 @@ class C {
     yield y;
     yield z;
   }
+
+  proc chpl__promotionType() type return int;
 }
 
 var myC = new borrowed C();

--- a/test/functions/promotion/thesePromotes1-serial.good
+++ b/test/functions/promotion/thesePromotes1-serial.good
@@ -1,0 +1,9 @@
+Calling serial iterator
+1
+2
+3
+Trying to promote foo():
+Calling serial iterator
+1
+2
+3

--- a/test/functions/promotion/thesePromotes2-standalone.bad
+++ b/test/functions/promotion/thesePromotes2-standalone.bad
@@ -1,0 +1,13 @@
+Calling serial iterator
+1
+2
+3
+Calling parallel iterator (which is actually serial)
+1
+2
+3
+Trying to promote foo():
+Calling serial iterator
+1
+2
+3

--- a/test/functions/promotion/thesePromotes2-standalone.chpl
+++ b/test/functions/promotion/thesePromotes2-standalone.chpl
@@ -9,11 +9,23 @@ class C {
     yield y;
     yield z;
   }
+
+  iter these(param tag: iterKind) where tag == iterKind.standalone {
+    writeln("Calling parallel iterator (which is actually serial)");
+    yield x;
+    yield y;
+    yield z;
+  }
+
+  proc chpl__promotionType() type return int;
 }
 
 var myC = new borrowed C();
 
 for c in myC do
+  writeln(c);
+
+forall c in myC do
   writeln(c);
 
 proc foo(x: int) {

--- a/test/functions/promotion/thesePromotes2-standalone.future
+++ b/test/functions/promotion/thesePromotes2-standalone.future
@@ -1,0 +1,6 @@
+feature request: 'these' should enable promotion
+#5114
+
+In this test:
+* chpl__promotionType() should not be needed for promotion.
+* Promotion should invoke the standalone iterator, not the serial iterator.

--- a/test/functions/promotion/thesePromotes2-standalone.good
+++ b/test/functions/promotion/thesePromotes2-standalone.good
@@ -1,0 +1,13 @@
+Calling serial iterator
+1
+2
+3
+Calling parallel iterator (which is actually serial)
+1
+2
+3
+Trying to promote foo():
+Calling parallel iterator (which is actually serial)
+1
+2
+3

--- a/test/functions/promotion/thesePromotes3-leaderfollower.chpl
+++ b/test/functions/promotion/thesePromotes3-leaderfollower.chpl
@@ -1,0 +1,39 @@
+class C {
+  var x = 1;
+  var y = 2;
+  var z = 3;
+
+  iter these() {
+    writeln("Calling serial iterator");
+    yield x;
+    yield y;
+    yield z;
+  }
+
+  iter these(param tag: iterKind) where tag == iterKind.leader {
+    writeln("Calling leader iterator (which is actually serial)");
+    yield (0..z-x,);
+  }
+
+  iter these(param tag: iterKind, followThis) where tag == iterKind.follower {
+    for i in followThis(1) do
+      yield i+x;
+  }
+
+  proc chpl__promotionType() type return int;
+}
+
+var myC = new borrowed C();
+
+for c in myC do
+  writeln(c);
+
+forall c in myC do
+  writeln(c);
+
+proc foo(x: int) {
+  writeln(x);
+}
+
+writeln("Trying to promote foo():");
+foo(myC);

--- a/test/functions/promotion/thesePromotes3-leaderfollower.good
+++ b/test/functions/promotion/thesePromotes3-leaderfollower.good
@@ -1,0 +1,13 @@
+Calling serial iterator
+1
+2
+3
+Calling leader iterator (which is actually serial)
+1
+2
+3
+Trying to promote foo():
+Calling leader iterator (which is actually serial)
+1
+2
+3

--- a/test/functions/promotion/theseShouldPromote2.bad
+++ b/test/functions/promotion/theseShouldPromote2.bad
@@ -1,1 +1,1 @@
-theseShouldPromote2.chpl:26: error: unresolved call '_toLeader(C)'
+theseShouldPromote2.chpl:24: error: unresolved call 'foo(C)'

--- a/test/functions/promotion/theseShouldPromote2.future
+++ b/test/functions/promotion/theseShouldPromote2.future
@@ -1,10 +1,7 @@
 feature request: 'these' should enable promotion
 #5114
 
-This future asks the question as to whether a serial 'these' should be
-sufficient to enable promotion or whether a parallel 'these' operator
-should be required.  See issue #5114 for details.
-
 See also:
 
-  test/functions/iterators/vass/forall-without-leaderfollower.future
+  #11819
+  test/functions/iterators/vass/forall-without-leaderfollower.chpl

--- a/test/library/standard/FileSystem/lydia/parallelDirState/chdirAllLocales.skipif
+++ b/test/library/standard/FileSystem/lydia/parallelDirState/chdirAllLocales.skipif
@@ -1,0 +1,3 @@
+# We need inlining to handle the error-throwing iterators
+# that are the result of promoting chdir().
+COMPOPTS <= --baseline

--- a/test/release/examples/users-guide/datapar/promotion.chpl
+++ b/test/release/examples/users-guide/datapar/promotion.chpl
@@ -99,15 +99,15 @@ forall (a, b, m) in zip(A, B, Mask) do
   maybeCopy(a, b, m);
 writeln(A);
 
-config param testError = false;
+config param testError = false, testError2 = false;
 
 if testError {
   var r = 0.0;
   maybeCopy(r, B, Mask);
-
+ if testError2 {
   forall (b, m) in zip(B, Mask) do
     maybeCopy(r, b, m);
-}
+} }
 
 // safe since only one mask value will modify 'r'
 Mask = [false, false, true];

--- a/test/release/examples/users-guide/datapar/promotion.compopts
+++ b/test/release/examples/users-guide/datapar/promotion.compopts
@@ -1,2 +1,3 @@
 -stestError=false   # promotion.good
--stestError=true    # promotion-error.good
+-stestError=true -stestError2=false    # promotion.error1.good
+-stestError=true -stestError2=true     # promotion.error2.good

--- a/test/release/examples/users-guide/datapar/promotion.error1.good
+++ b/test/release/examples/users-guide/datapar/promotion.error1.good
@@ -1,0 +1,1 @@
+promotion.chpl:106: error: Racy promotion of scalar argument for the formal 'x'

--- a/test/release/examples/users-guide/datapar/promotion.error2.good
+++ b/test/release/examples/users-guide/datapar/promotion.error2.good
@@ -1,4 +1,2 @@
-promotion.chpl:51: error: non-lvalue actual is passed to 'ref' formal 'x' of maybeCopy()
-promotion.chpl:106: note: The shadow variable 'x' is constant due to forall intents in this loop
 promotion.chpl:109: error: non-lvalue actual is passed to 'ref' formal 'x' of maybeCopy()
 promotion.chpl:108: note: The shadow variable 'r' is constant due to forall intents in this loop

--- a/test/users/ren/mink-blc-infer.chpl
+++ b/test/users/ren/mink-blc-infer.chpl
@@ -29,14 +29,18 @@ class mink : ReduceScanOp {
       }
   }
   
-  proc combine(s: borrowed mink(eltType))
+  proc accumulate(state: [])
   {
     for i in 1..k
       {
-        accumulate(s.v[i]);
+        accumulate(state[i]);
       }
   }
   
+  proc combine(s: borrowed mink(eltType)) {
+    accumulate(s.v);
+  }
+
   proc generate()
   {
     writeln("returning: ", v);

--- a/test/users/ren/mink-blc-workaround.chpl
+++ b/test/users/ren/mink-blc-workaround.chpl
@@ -29,14 +29,18 @@ class mink : ReduceScanOp {
       }
   }
   
-  proc combine(s: borrowed mink(eltType))
+  proc accumulate(state: [])
   {
     for i in 1..k
       {
-        accumulate(s.v[i]);
+        accumulate(state[i]);
       }
   }
   
+  proc combine(s: borrowed mink(eltType)) {
+    accumulate(s.v);
+  }
+
   proc generate()
   {
     var t = v;

--- a/test/users/ren/mink-blc.chpl
+++ b/test/users/ren/mink-blc.chpl
@@ -29,14 +29,18 @@ class mink : ReduceScanOp {
       }
   }
   
-  proc combine(s: borrowed mink(eltType))
+  proc accumulate(state: [])
   {
     for i in 1..k
       {
-        accumulate(s.v[i]);
+        accumulate(state[i]);
       }
   }
   
+  proc combine(s: borrowed mink(eltType)) {
+    accumulate(s.v);
+  }
+
   proc generate()
   {
     writeln("returning: ", v);

--- a/test/users/ren/mink-minchange.chpl
+++ b/test/users/ren/mink-minchange.chpl
@@ -28,14 +28,18 @@ class mink : ReduceScanOp {
       }
   }
   
-  proc combine(s: borrowed mink(eltType))
+  proc accumulate(state: [])
   {
     for i in 1..k
       {
-        accumulate(s.v[i]);
+        accumulate(state[i]);
       }
   }
   
+  proc combine(s: borrowed mink(eltType)) {
+    accumulate(s.v);
+  }
+
   proc generate()
   {
     return v;


### PR DESCRIPTION
#### The key change

The key change is from:
```cpp
if (fn->retType == dtVoid || fn->getReturnSymbol() == gVoid) {
  .....
  loop = buildForallLoopStmt(indices, iterator, NULL, block, zippered);
} else {
  loop = buildPromotionLoop(promotion, instantiationPt, info, fastFollowerChecks);
}
```
to simply:
```cpp
loop = buildPromotionLoop(promotion, instantiationPt, info, fastFollowerChecks);
```
That is, create the promotion iterator when its result is unused
in the same way as we have been creating it when the result IS used.

The motivation is to remove `buildForallLoopStmt`.
Because it uses tryToken, which we want to get rid of.

We could instead reimplement `buildForallLoopStmt` to generate a `ForallStmt`.
We favored to have a single code path instead of two separte cases.

The one place that still required two cases is generating the yield statement
in the promoted iterator. We now skip that when the result of the promoted
expression is not used, see insertAndSaveWrapCall(). This is to avoid yielding
the `void` value, which the compiler does not handle well.


#### Other changes

* Insert several `INT_ASSERT(false)` to indicate code that is no longer used.
  Removing that code is left for a separate PR.

* Improve the "Racy promotion of scalar argument" check to issue an error
  only when there is parallel iteration.

* Prevent infinite creation of ForallStmts in a corner case that was exercised
  by mink* tests prior to this change.

* Avoid introducing two enclosing BlockStmts in the promoted iterator body.

* Remove more autoDestroy calls while inlining ForallStmts' iterators.
  See removeAutoDestroyCallIfPresent().
  We may want to see why one autoDestroy call is not removed in callDestructors
  when its corresponding autoCopy is: `functions/promotion/forallPromotes.chpl`

* Fix the definition of the user reduction op in `mink-*` tests, adding an
  overload of `accumulate`. Its absence was causing an unexpected promotion.

* `promotion.chpl` under `users-guide` was reporting both erros in the same
  compiler pass prior to this change. Now need to run the compiler separately
  for each error. The change is a bit odd - to avoid disturbing line numbers
  for code that is included in the guide.

* The errors reported for `racy-arg.chpl` now are equivalent to the ones
  reported prior to this change. The difference is due the compiler using
  promotion iterators now where it used ForallStmts before.

* Add variants of existing tests related to #5114, to show that the promotion
  requested by that issue is already available, except:

   - This requires defining `chpl__promotionType()` .
   - The standalone iterator is not considered.
