### PR TITLE
Suppress failures for these tests with icc

### DIFF
--- a/test/classes/bradc/unions/assign.suppressif
+++ b/test/classes/bradc/unions/assign.suppressif
@@ -1,0 +1,2 @@
+CHPL_TARGET_COMPILER==cray-prgenv-intel
+CHPL_TARGET_COMPILER==intel

--- a/test/classes/bradc/unions/assign1a.suppressif
+++ b/test/classes/bradc/unions/assign1a.suppressif
@@ -1,0 +1,2 @@
+CHPL_TARGET_COMPILER==cray-prgenv-intel
+CHPL_TARGET_COMPILER==intel


### PR DESCRIPTION
The Intel C compiler produces unexpected output when used as the backend for Chapel for these tests and works with `-O0`. So use a .suppressif to quiet the failure.