### PR TITLE
Add future for desired wide-pointer analysis for arrays in classes

### DIFF
--- a/test/optimizations/widepointers/arrayInClasses.bad
+++ b/test/optimizations/widepointers/arrayInClasses.bad
@@ -1,0 +1,3 @@
+class is wide: true
+array is wide: true
+1 1 1 1 1 1 1 1 1 1

--- a/test/optimizations/widepointers/arrayInClasses.chpl
+++ b/test/optimizations/widepointers/arrayInClasses.chpl
@@ -20,6 +20,7 @@ proc main() {
   {
     var c = new unmanaged Chunk();
     on Locales[numLocales-1] do c.data[1] = 5;
+    delete c;
   }
 
   var chunks : [0..#numLocales] unmanaged Chunk;

--- a/test/optimizations/widepointers/arrayInClasses.chpl
+++ b/test/optimizations/widepointers/arrayInClasses.chpl
@@ -1,0 +1,41 @@
+
+class Chunk {
+  var data : [1..10] int;
+}
+
+proc main() {
+  // This test exists to measure a pattern where a user has manually chunked
+  // their computation into a class per locale, which contains arrays. When we
+  // know that the class is local, we do not want wide pointer overhead when
+  // using those arrays.
+  //
+  // Sometimes the arrays in such classes might need to be accessed remotely
+  // (e.g. exchanging array elements on edge of stencil computation). The
+  // compiler should make the static type of such arrays a wide pointer, but
+  // through optimizations should be able to localize that pointer when
+  // appropriate.
+  //
+  // This block exists to ensure that the static type of the 'data' array is
+  // a wide pointer for this test.
+  {
+    var c = new unmanaged Chunk();
+    on Locales[numLocales-1] do c.data[1] = 5;
+  }
+
+  var chunks : [0..#numLocales] unmanaged Chunk;
+
+  for loc in Locales do on loc {
+    chunks[loc.id] = new unmanaged Chunk();
+  }
+
+  coforall c in chunks do on c {
+    writeln("class is wide: ", __primitive("is wide pointer", c));
+    ref data = c.data;
+    writeln("array is wide: ", __primitive("is wide pointer", data._value.shiftedData));
+    for d in data do d += 1;
+  }
+
+  for c in chunks do writeln(c.data);
+
+  delete chunks;
+}

--- a/test/optimizations/widepointers/arrayInClasses.future
+++ b/test/optimizations/widepointers/arrayInClasses.future
@@ -1,0 +1,1 @@
+performance: compiler should identify class and stored array as local

--- a/test/optimizations/widepointers/arrayInClasses.good
+++ b/test/optimizations/widepointers/arrayInClasses.good
@@ -1,0 +1,3 @@
+class is wide: false
+array is wide: false
+1 1 1 1 1 1 1 1 1 1


### PR DESCRIPTION
This test is a distilled example from user code suffering from --no-local overhead issues.