### PR TITLE
Address learnChapelInYMinutes failure on arm.

### DIFF
--- a/test/release/examples/primers/learnChapelInYMinutes.prediff
+++ b/test/release/examples/primers/learnChapelInYMinutes.prediff
@@ -25,8 +25,10 @@ line_of_stderr = 'This goes to standard error\n'
 if input_sep == line_of_stderr and input_post.count( line_of_stderr ) == 0:
   input = input_pre + input_post
 else:
+  with open (outfile+'.preserved', 'w') as f:
+    f.write(input)
   writeOutput( "FAILED! " + str( line_of_stderr ) + " not seen exactly 1 time" )
-  exit( -1-i )
+  exit( 1 )
 
 [test_serial_input, test_parallel_input] = input.split( "PARALLELISM START" )
 


### PR DESCRIPTION
A recent change to `learnChapelInYMinutes` ended up breaking in two ways
in some arm testing, where it hadn't been run before because of a
.skipif.  Here, fix one problem, which was a cut+paste induced typo
introduced about 2 years ago, in an `exit()` call.  And add code to
preserve the original test output file as a diagnostic aid in the event
the failure seen in nightly testing recurs.  (The `.prediff` normally
overwrites the original output file.)