### PR TITLE
Add tests for may- vs. must-parallel foralls

### DIFF
--- a/test/parallel/forall/may-vs-must-par/EXECOPTS
+++ b/test/parallel/forall/may-vs-must-par/EXECOPTS
@@ -1,0 +1,1 @@
+--dataParTasksPerLocale=2

--- a/test/parallel/forall/may-vs-must-par/PREDIFF
+++ b/test/parallel/forall/may-vs-must-par/PREDIFF
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# 
+case "$2" in
+  (f5-promo-e*)
+    grep -v ': note: ' $2 > $2.tmp
+    mv $2.tmp $2
+    ;;
+
+  (*) true;;
+esac

--- a/test/parallel/forall/may-vs-must-par/datas.chpl
+++ b/test/parallel/forall/may-vs-must-par/datas.chpl
@@ -1,0 +1,161 @@
+// Helper datatypes.
+
+config const nd = 2;
+const RNGd = 1..nd;
+
+const inst1ser = new owned class1ser();
+const inst1SA  = new owned class1SA();
+const inst1LF  = new owned class1LF();
+const inst1par = new owned class1par();
+
+const inst2ser = new owned class2ser();
+const inst2SA  = new owned class2SA();
+const inst2LF  = new owned class2LF();
+const inst2par = new owned class2par();
+
+var cnt1d, cnt2d: atomic int;
+proc inc1d        { cnt1d.add(1); }
+proc inc2d        { cnt2d.add(1); }
+proc resetCountsD { cnt1d.write(0); cnt2d.write(0); }
+proc showCountsD  { writeln("followers: ", cnt1d.read(), " ", cnt2d.read());
+                    writeln(); resetCountsD; }
+
+/////////// serial-only ///////////
+
+class class1ser {
+  iter these() {
+    writeln("class1ser");
+    for idx in RNGd do
+      yield idx;
+  }
+  proc chpl__promotionType() type return int;
+}
+
+class class2ser {
+  iter these() {
+    writeln("class2ser");
+    for idx in RNGd do
+      yield -idx;
+  }
+  proc chpl__promotionType() type return int;
+}
+
+/////////// serial+standalone ///////////
+
+class class1SA {
+  iter these() {
+    writeln("class1SA serial");
+    for idx in RNGd do
+      yield idx;
+  }
+  iter these(param tag) where tag == iterKind.standalone {
+    writeln("class1SA standalone");
+    for idx in RNGd.these(tag) do
+      yield idx;
+  }
+  proc chpl__promotionType() type return int;
+}
+
+class class2SA {
+  iter these() {
+    writeln("class2SA serial");
+    for idx in RNGd do
+      yield -idx;
+  }
+  iter these(param tag) where tag == iterKind.standalone {
+    writeln("class2SA standalone");
+    for idx in RNGd.these(tag) do
+      yield -idx;
+  }
+  proc chpl__promotionType() type return int;
+}
+
+/////////// serial+leader/follower ///////////
+
+class class1LF {
+  iter these() {
+    writeln("class1LF serial");
+    for idx in RNGd do
+      yield idx;
+  }
+  iter these(param tag) where tag == iterKind.leader {
+    writeln("class1LF leader");
+    for idx in RNGd.these(tag) do
+      yield idx;
+  }
+  iter these(param tag, followThis) where tag == iterKind.follower {
+    inc1d;
+    for idx in RNGd.these(tag, followThis) do
+      yield idx;
+  }
+  proc chpl__promotionType() type return int;
+}
+
+class class2LF {
+  iter these() {
+    writeln("class2LF serial");
+    for idx in RNGd do
+      yield -idx;
+  }
+  iter these(param tag) where tag == iterKind.leader {
+    writeln("class2LF leader");
+    for idx in RNGd.these(tag) do
+      yield idx;
+  }
+  iter these(param tag, followThis) where tag == iterKind.follower {
+    inc2d;
+    for idx in RNGd.these(tag, followThis) do
+      yield -idx;
+  }
+  proc chpl__promotionType() type return int;
+}
+
+/////////// serial + LF + SA ///////////
+
+class class1par {
+  iter these() {
+    writeln("class1par serial");
+    for idx in RNGd do
+      yield idx;
+  }
+  iter these(param tag) where tag == iterKind.standalone {
+    writeln("class1par standalone");
+    for idx in RNGd.these(tag) do
+      yield idx;
+  }
+  iter these(param tag) where tag == iterKind.leader {
+    writeln("class1par leader");
+    for idx in RNGd.these(tag) do
+      yield idx;
+  }
+  iter these(param tag, followThis) where tag == iterKind.follower {
+    inc1d;
+    for idx in RNGd.these(tag, followThis) do
+      yield idx;
+  }
+  proc chpl__promotionType() type return int;
+}
+
+class class2par {
+  iter these() {
+    writeln("class2par serial");
+    for idx in RNGd do
+      yield -idx;
+  }
+  iter these(param tag) where tag == iterKind.standalone {
+    writeln("class2par standalone");
+    for idx in RNGd.these(tag) do
+      yield -idx;
+  }
+  iter these(param tag) where tag == iterKind.leader {
+    writeln("class2par leader");
+    for idx in RNGd.these(tag) do
+      yield idx;
+  }
+  iter these(param tag, followThis) where tag == iterKind.follower {
+    inc2d;
+    for idx in RNGd.these(tag, followThis) do
+      yield -idx;
+  }
+  proc chpl__promotionType() type return int;
+}

--- a/test/parallel/forall/may-vs-must-par/f1-stmt-mustpar-e1-inst1ser.chpl
+++ b/test/parallel/forall/may-vs-must-par/f1-stmt-mustpar-e1-inst1ser.chpl
@@ -1,0 +1,5 @@
+use datas;
+
+// error - parallel instator is not provided
+forall IND in inst1ser do
+  writeln("forall IND in inst1ser");

--- a/test/parallel/forall/may-vs-must-par/f1-stmt-mustpar-e1-inst1ser.good
+++ b/test/parallel/forall/may-vs-must-par/f1-stmt-mustpar-e1-inst1ser.good
@@ -1,0 +1,1 @@
+f1-stmt-mustpar-e1-inst1ser.chpl:4: error: A standalone or leader iterator is not found for the iterable expression in this forall loop

--- a/test/parallel/forall/may-vs-must-par/f1-stmt-mustpar-e1-iter1ser.chpl
+++ b/test/parallel/forall/may-vs-must-par/f1-stmt-mustpar-e1-iter1ser.chpl
@@ -1,0 +1,7 @@
+// forall-statement
+
+use iters;
+
+// error - parallel iterator is not provided
+forall IND in iter1ser() do
+  writeln("forall IND in iter1ser");

--- a/test/parallel/forall/may-vs-must-par/f1-stmt-mustpar-e1-iter1ser.good
+++ b/test/parallel/forall/may-vs-must-par/f1-stmt-mustpar-e1-iter1ser.good
@@ -1,0 +1,1 @@
+f1-stmt-mustpar-e1-iter1ser.chpl:6: error: A standalone or leader iterator is not found for the iterable expression in this forall loop

--- a/test/parallel/forall/may-vs-must-par/f1-stmt-mustpar-e2-inst2ser.chpl
+++ b/test/parallel/forall/may-vs-must-par/f1-stmt-mustpar-e2-inst2ser.chpl
@@ -1,0 +1,5 @@
+use datas;
+
+// error - parallel instator is not provided
+forall IND in zip(inst1ser, inst2ser) do
+  writeln("forall IND in zip(inst1ser, inst2ser)");

--- a/test/parallel/forall/may-vs-must-par/f1-stmt-mustpar-e2-inst2ser.good
+++ b/test/parallel/forall/may-vs-must-par/f1-stmt-mustpar-e2-inst2ser.good
@@ -1,0 +1,1 @@
+f1-stmt-mustpar-e2-inst2ser.chpl:4: error: A leader iterator is not found for the iterable expression in this forall loop

--- a/test/parallel/forall/may-vs-must-par/f1-stmt-mustpar-e2-iter2ser.chpl
+++ b/test/parallel/forall/may-vs-must-par/f1-stmt-mustpar-e2-iter2ser.chpl
@@ -1,0 +1,7 @@
+// forall-statement
+
+use iters;
+
+// error - parallel iterator is not provided
+forall IND in zip(iter1ser(), iter2ser()) do
+  writeln("forall IND in zip(iter1ser(), iter2ser())");

--- a/test/parallel/forall/may-vs-must-par/f1-stmt-mustpar-e2-iter2ser.good
+++ b/test/parallel/forall/may-vs-must-par/f1-stmt-mustpar-e2-iter2ser.good
@@ -1,0 +1,1 @@
+f1-stmt-mustpar-e2-iter2ser.chpl:6: error: A leader iterator is not found for the iterable expression in this forall loop

--- a/test/parallel/forall/may-vs-must-par/f1-stmt-mustpar-e3-inst2SA.chpl
+++ b/test/parallel/forall/may-vs-must-par/f1-stmt-mustpar-e3-inst2SA.chpl
@@ -1,0 +1,5 @@
+use datas;
+
+// error - leader is not provided
+forall IND in zip(inst1SA, inst2SA) do
+  writeln("forall IND in zip(inst1SA, inst2SA)");

--- a/test/parallel/forall/may-vs-must-par/f1-stmt-mustpar-e3-inst2SA.good
+++ b/test/parallel/forall/may-vs-must-par/f1-stmt-mustpar-e3-inst2SA.good
@@ -1,0 +1,1 @@
+f1-stmt-mustpar-e3-inst2SA.chpl:4: error: A leader iterator is not found for the iterable expression in this forall loop

--- a/test/parallel/forall/may-vs-must-par/f1-stmt-mustpar-e3-iter2SA.chpl
+++ b/test/parallel/forall/may-vs-must-par/f1-stmt-mustpar-e3-iter2SA.chpl
@@ -1,0 +1,7 @@
+// forall-statement
+
+use iters;
+
+// error - leader is not provided
+forall IND in zip(iter1SA(), iter2SA()) do
+  writeln("forall IND in zip(iter1SA(), iter2SA())");

--- a/test/parallel/forall/may-vs-must-par/f1-stmt-mustpar-e3-iter2SA.good
+++ b/test/parallel/forall/may-vs-must-par/f1-stmt-mustpar-e3-iter2SA.good
@@ -1,0 +1,1 @@
+f1-stmt-mustpar-e3-iter2SA.chpl:6: error: A leader iterator is not found for the iterable expression in this forall loop

--- a/test/parallel/forall/may-vs-must-par/f1-stmt-mustpar-ok.chpl
+++ b/test/parallel/forall/may-vs-must-par/f1-stmt-mustpar-ok.chpl
@@ -1,0 +1,106 @@
+// forall-statement
+
+use iters;
+use datas;
+
+writeln();
+
+// Legend: the writeln() statements above the forall loops show:
+//  first word:  the name of the iterator, implying the available varieties,
+//  second word: which variety should be chosen.
+// Ex: "SA standalone" => available: serial+SA; chosen: SA.
+//  "par leader+followers" => available serial+SA+LF, chosen: LF.
+
+
+/*--- iterators --- */
+
+/////////// single iterable ///////////
+
+// error - parallel iterator is not provided
+//writeln("ser serial");
+//forall IND in iter1ser() do
+//  writeln("forall IND in iter1ser");
+
+writeln("SA standalone");
+forall IND in iter1SA() do
+  writeln("forall IND in iter1SA");
+showCountsI;
+
+writeln("LF leader+follower");
+forall IND in iter1LF() do
+  writeln("forall IND in iter1LF");
+showCountsI;
+
+writeln("par standalone");
+forall IND in iter1par() do
+  writeln("forall IND in iter1par");
+showCountsI;
+
+/////////// zippered ///////////
+
+// error - parallel iterator is not provided
+//writeln("ser serial");
+//forall IND in zip(iter1ser(), iter2ser()) do
+//  writeln("forall IND in zip(iter1ser(), iter2ser())");
+
+// error - leader is not provided
+//writeln("SA leader");
+//forall IND in zip(iter1SA(), iter2SA()) do
+//  writeln("forall IND in zip(iter1SA(), iter2SA())");
+
+writeln("LF leader+followers");
+forall IND in zip(iter1LF(), iter2LF()) do
+  writeln("forall IND in zip(iter1LF(), iter2LF())");
+showCountsI;
+
+writeln("par leader+followers");
+forall IND in zip(iter1par(), iter2par()) do
+  writeln("forall IND in zip(iter1par(), iter2par())");
+showCountsI;
+
+
+/*--- datatypes --- */
+
+/////////// single iterable ///////////
+
+// error - parallel iterator is not provided
+//writeln("ser serial");
+//forall IND in inst1ser do
+//  writeln("forall IND in inst1ser");
+
+writeln("SA standalone");
+forall IND in inst1SA do
+  writeln("forall IND in inst1SA");
+showCountsD;
+
+writeln("LF leader+follower");
+forall IND in inst1LF do
+  writeln("forall IND in inst1LF");
+showCountsD;
+
+writeln("par standalone");
+forall IND in inst1par do
+  writeln("forall IND in inst1par");
+showCountsD;
+
+/////////// zippered ///////////
+
+// error - parallel iterator is not provided
+//writeln("ser serial");
+//forall IND in zip(inst1ser, inst2ser) do
+//  writeln("forall IND in zip(inst1ser, inst2ser)");
+
+// error - leader is not provided
+//writeln("SA leader");
+//forall IND in zip(inst1SA, inst2SA) do
+//  writeln("forall IND in zip(inst1SA, inst2SA)");
+
+writeln("LF leader+followers");
+forall IND in zip(inst1LF.borrow(), inst2LF.borrow()) do
+  writeln("forall IND in zip(inst1LF, inst2LF)");
+showCountsD;
+
+writeln("par leader+followers");
+forall IND in zip(inst1par.borrow(), inst2par.borrow()) do
+  writeln("forall IND in zip(inst1par, inst2par)");
+showCountsD;

--- a/test/parallel/forall/may-vs-must-par/f1-stmt-mustpar-ok.good
+++ b/test/parallel/forall/may-vs-must-par/f1-stmt-mustpar-ok.good
@@ -1,0 +1,61 @@
+
+SA standalone
+iter1SA standalone
+forall IND in iter1SA
+forall IND in iter1SA
+followers: 0 0
+
+LF leader+follower
+iter1LF leader
+forall IND in iter1LF
+forall IND in iter1LF
+followers: 2 0
+
+par standalone
+iter1par standalone
+forall IND in iter1par
+forall IND in iter1par
+followers: 0 0
+
+LF leader+followers
+iter1LF leader
+forall IND in zip(iter1LF(), iter2LF())
+forall IND in zip(iter1LF(), iter2LF())
+followers: 2 2
+
+par leader+followers
+iter1par leader
+forall IND in zip(iter1par(), iter2par())
+forall IND in zip(iter1par(), iter2par())
+followers: 2 2
+
+SA standalone
+class1SA standalone
+forall IND in inst1SA
+forall IND in inst1SA
+followers: 0 0
+
+LF leader+follower
+class1LF leader
+forall IND in inst1LF
+forall IND in inst1LF
+followers: 2 0
+
+par standalone
+class1par standalone
+forall IND in inst1par
+forall IND in inst1par
+followers: 0 0
+
+LF leader+followers
+class1LF leader
+forall IND in zip(inst1LF, inst2LF)
+forall IND in zip(inst1LF, inst2LF)
+followers: 2 2
+
+par leader+followers
+class1par leader
+forall IND in zip(inst1par, inst2par)
+forall IND in zip(inst1par, inst2par)
+followers: 2 2
+

--- a/test/parallel/forall/may-vs-must-par/f2-stmt-mayserial.chpl
+++ b/test/parallel/forall/may-vs-must-par/f2-stmt-mayserial.chpl
@@ -1,0 +1,110 @@
+// []-statement
+
+use iters;
+use datas;
+
+writeln();
+
+// Legend: the writeln() statements above the []-loops show:
+//  first word:  the name of the iterator, implying the available varieties,
+//  second word: which variety should be chosen.
+// Ex: "SA standalone" => available: serial+SA; chosen: SA.
+//  "par leader+followers" => available serial+SA+LF, chosen: LF.
+
+
+/*--- iterators --- */
+
+/////////// single iterable ///////////
+
+writeln("ser serial");
+[ IND in iter1ser() ]
+  writeln("[ IND in iter1ser() ]");
+showCountsI;
+
+writeln("SA standalone");
+[ IND in iter1SA() ]
+  writeln("[ IND in iter1SA() ]");
+showCountsI;
+
+writeln("LF leader+follower");
+[ IND in iter1LF() ]
+  writeln("[ IND in iter1LF() ]");
+showCountsI;
+
+writeln("par standalone");
+[ IND in iter1par() ]
+  writeln("[ IND in iter1par() ]");
+showCountsI;
+
+/////////// zippered ///////////
+
+// bug: compiler crashes
+//writeln("ser serial");
+//[ IND in zip(iter1ser(), iter2ser()) ]
+//  writeln("[ IND in zip(iter1ser(), iter2ser()) ]");
+//showCountsI;
+
+// bug: compiler crashes
+//writeln("SA leader");
+//[ IND in zip(iter1SA(), iter2SA()) ]
+//  writeln("[ IND in zip(iter1SA(), iter2SA()) ]");
+//showCountsI;
+
+writeln("LF leader+followers");
+[ IND in zip(iter1LF(), iter2LF()) ]
+  writeln("[ IND in zip(iter1LF(), iter2LF()) ]");
+showCountsI;
+
+writeln("par leader+followers");
+[ IND in zip(iter1par(), iter2par()) ]
+  writeln("[ IND in zip(iter1par(), iter2par()) ]");
+showCountsI;
+
+
+/*--- datatypes --- */
+
+/////////// single iterable ///////////
+
+writeln("ser serial");
+[ IND in inst1ser ]
+  writeln("[ IND in inst1ser ]");
+showCountsD;
+
+writeln("SA standalone");
+[ IND in inst1SA ]
+  writeln("[ IND in inst1SA ]");
+showCountsD;
+
+writeln("LF leader+follower");
+[ IND in inst1LF ]
+  writeln("[ IND in inst1LF ]");
+showCountsD;
+
+writeln("par standalone");
+[ IND in inst1par ]
+  writeln("[ IND in inst1par ]");
+showCountsD;
+
+/////////// zippered ///////////
+
+// bug: compiler crashes
+//writeln("ser serial");
+//[ IND in zip(inst1ser.borrow(), inst2ser.borrow()) ]
+//  writeln("[ IND in zip(inst1ser, inst2ser) ]");
+//showCountsD;
+
+// bug: compiler crashes
+//writeln("SA serial");
+//[ IND in zip(inst1SA.borrow(), inst2SA.borrow()) ]
+//  writeln("[ IND in zip(inst1SA, inst2SA) ]");
+//showCountsD;
+
+writeln("LF leader+followers");
+[ IND in zip(inst1LF.borrow(), inst2LF.borrow()) ]
+  writeln("[ IND in zip(inst1LF, inst2LF) ]");
+showCountsD;
+
+writeln("par leader+followers");
+[ IND in zip(inst1par.borrow(), inst2par.borrow()) ]
+  writeln("[ IND in zip(inst1par, inst2par) ]");
+showCountsD;

--- a/test/parallel/forall/may-vs-must-par/f2-stmt-mayserial.good
+++ b/test/parallel/forall/may-vs-must-par/f2-stmt-mayserial.good
@@ -1,0 +1,73 @@
+
+ser serial
+iter1ser
+[ IND in iter1ser() ]
+[ IND in iter1ser() ]
+followers: 0 0
+
+SA standalone
+iter1SA standalone
+[ IND in iter1SA() ]
+[ IND in iter1SA() ]
+followers: 0 0
+
+LF leader+follower
+iter1LF leader
+[ IND in iter1LF() ]
+[ IND in iter1LF() ]
+followers: 2 0
+
+par standalone
+iter1par standalone
+[ IND in iter1par() ]
+[ IND in iter1par() ]
+followers: 0 0
+
+LF leader+followers
+iter1LF leader
+[ IND in zip(iter1LF(), iter2LF()) ]
+[ IND in zip(iter1LF(), iter2LF()) ]
+followers: 2 2
+
+par leader+followers
+iter1par leader
+[ IND in zip(iter1par(), iter2par()) ]
+[ IND in zip(iter1par(), iter2par()) ]
+followers: 2 2
+
+ser serial
+class1ser
+[ IND in inst1ser ]
+[ IND in inst1ser ]
+followers: 0 0
+
+SA standalone
+class1SA standalone
+[ IND in inst1SA ]
+[ IND in inst1SA ]
+followers: 0 0
+
+LF leader+follower
+class1LF leader
+[ IND in inst1LF ]
+[ IND in inst1LF ]
+followers: 2 0
+
+par standalone
+class1par standalone
+[ IND in inst1par ]
+[ IND in inst1par ]
+followers: 0 0
+
+LF leader+followers
+class1LF leader
+[ IND in zip(inst1LF, inst2LF) ]
+[ IND in zip(inst1LF, inst2LF) ]
+followers: 2 2
+
+par leader+followers
+class1par leader
+[ IND in zip(inst1par, inst2par) ]
+[ IND in zip(inst1par, inst2par) ]
+followers: 2 2
+

--- a/test/parallel/forall/may-vs-must-par/f5-promoted-exprs.chpl
+++ b/test/parallel/forall/may-vs-must-par/f5-promoted-exprs.chpl
@@ -1,0 +1,99 @@
+// promoted expression
+
+// The current code does not exercise the case
+// where the result of the promoted expression is used.
+// This is to avoid an additional dimension in the tests
+// and because the compiler code paths being tested
+// do not depend on used vs. not used.
+
+// Legend: the writeln() statements above the promoted expressions show:
+//  first word:  the name of the iterator, implying the available varieties,
+//  second word: which variety should be chosen.
+// Ex: "SA serial" => available: serial+SA; chosen: serial.
+//  "par leader+followers" => available serial+SA+LF, chosen: LF.
+
+use iters;
+use datas;
+
+proc KAM(arg1: int, arg2: int) { writeln("mul=", arg1*arg2); }
+proc KAP(arg1: int, arg2: int) { writeln("sum=", arg1+arg2); }
+
+writeln();
+
+
+/*--- iterators --- */
+
+/////////// single iterable ///////////
+
+writeln("ser serial");
+KAM(iter1ser(),0);
+showCountsI;
+
+writeln("SA standalone"); // bug: standalone iter is ignored by promotion
+KAM(iter1SA(),0);
+showCountsI;
+
+writeln("LF leader+follower");
+KAM(iter1LF(),0);
+showCountsI;
+
+writeln("par standalone"); // bug: standalone iter is ignored by promotion
+KAM(iter1par(),0);
+showCountsI;
+
+/////////// zippered ///////////
+
+writeln("ser serial");
+KAP(iter1ser(), iter2ser());
+showCountsI;
+
+writeln("SA serial");
+KAP(iter1SA(), iter2SA());
+showCountsI;
+
+writeln("LF leader+followers");
+KAP(iter1LF(), iter2LF());
+showCountsI;
+
+writeln("par leader+followers");
+KAP(iter1par(), iter2par());
+showCountsI;
+
+
+/*--- datatypes --- */
+
+/////////// single iterable ///////////
+
+writeln("ser serial");
+KAM(inst1ser.borrow(),0);
+showCountsD;
+
+writeln("SA standalone"); // bug: standalone iter is ignored by promotion
+KAM(inst1SA.borrow(),0);
+showCountsD;
+
+writeln("LF leader+follower");
+KAM(inst1LF.borrow(),0);
+showCountsD;
+
+writeln("par standalone"); // bug: standalone iter is ignored by promotion
+KAM(inst1par.borrow(),0);
+showCountsD;
+
+/////////// zippered ///////////
+
+writeln("ser serial");
+KAP(inst1ser.borrow(), inst2ser.borrow());
+showCountsD;
+
+writeln("SA serial");
+KAP(inst1SA.borrow(), inst2SA.borrow());
+showCountsD;
+
+writeln("LF leader+followers");
+KAP(inst1LF.borrow(), inst2LF.borrow());
+showCountsD;
+
+writeln("par leader+followers");
+KAP(inst1par.borrow(), inst2par.borrow());
+showCountsD;

--- a/test/parallel/forall/may-vs-must-par/f5-promoted-exprs.good
+++ b/test/parallel/forall/may-vs-must-par/f5-promoted-exprs.good
@@ -1,0 +1,101 @@
+
+ser serial
+iter1ser
+mul=0
+mul=0
+followers: 0 0
+
+SA standalone
+iter1SA serial
+mul=0
+mul=0
+followers: 0 0
+
+LF leader+follower
+iter1LF leader
+mul=0
+mul=0
+followers: 2 0
+
+par standalone
+iter1par leader
+mul=0
+mul=0
+followers: 2 0
+
+ser serial
+iter1ser
+iter2ser
+sum=0
+sum=0
+followers: 0 0
+
+SA serial
+iter1SA serial
+iter2SA serial
+sum=0
+sum=0
+followers: 0 0
+
+LF leader+followers
+iter1LF leader
+sum=0
+sum=0
+followers: 2 2
+
+par leader+followers
+iter1par leader
+sum=0
+sum=0
+followers: 2 2
+
+ser serial
+class1ser
+mul=0
+mul=0
+followers: 0 0
+
+SA standalone
+class1SA serial
+mul=0
+mul=0
+followers: 0 0
+
+LF leader+follower
+class1LF leader
+mul=0
+mul=0
+followers: 2 0
+
+par standalone
+class1par leader
+mul=0
+mul=0
+followers: 2 0
+
+ser serial
+class1ser
+class2ser
+sum=0
+sum=0
+followers: 0 0
+
+SA serial
+class1SA serial
+class2SA serial
+sum=0
+sum=0
+followers: 0 0
+
+LF leader+followers
+class1LF leader
+sum=0
+sum=0
+followers: 2 2
+
+par leader+followers
+class1par leader
+sum=0
+sum=0
+followers: 2 2
+

--- a/test/parallel/forall/may-vs-must-par/f6-reduce-exprs.chpl
+++ b/test/parallel/forall/may-vs-must-par/f6-reduce-exprs.chpl
@@ -1,0 +1,94 @@
+// reduce expression
+
+// Legend: the writeln() statements above the promoted expressions show:
+//  first word:  the name of the iterator, implying the available varieties,
+//  second word: which variety should be chosen.
+// Ex: "SA serial" => available: serial+SA; chosen: serial.
+//  "par leader+followers" => available serial+SA+LF, chosen: LF.
+
+use iters;
+use datas;
+
+writeln();
+
+
+/*--- iterators --- */
+
+/////////// single iterable ///////////
+
+writeln("ser serial");
+writeln(+reduce iter1ser());
+showCountsI;
+
+writeln("SA standalone");
+writeln(+reduce iter1SA());
+showCountsI;
+
+writeln("LF leader+follower");
+writeln(+reduce iter1LF());
+showCountsI;
+
+writeln("par standalone");
+writeln(+reduce iter1par());
+showCountsI;
+
+/////////// zippered ///////////
+
+// bug: compiler crashes
+//writeln("ser serial");
+//writeln(+reduce zip(iter1ser(), iter2ser()));
+//showCountsI;
+
+// bug: compiler crashes
+//writeln("SA serial");
+//writeln(+reduce zip(iter1SA(), iter2SA()));
+//showCountsI;
+
+writeln("LF leader+followers");
+writeln(+reduce zip(iter1LF(), iter2LF()));
+showCountsI;
+
+writeln("par leader+followers");
+writeln(+reduce zip(iter1par(), iter2par()));
+showCountsI;
+
+
+/*--- datatypes --- */
+
+/////////// single iterable ///////////
+
+writeln("ser serial");
+writeln(+reduce inst1ser.borrow());
+showCountsD;
+
+writeln("SA standalone");
+writeln(+reduce inst1SA.borrow());
+showCountsD;
+
+writeln("LF leader+follower");
+writeln(+reduce inst1LF.borrow());
+showCountsD;
+
+writeln("par standalone");
+writeln(+reduce inst1par.borrow());
+showCountsD;
+
+/////////// zippered ///////////
+
+// bug: compiler crashes
+//writeln("ser serial");
+//writeln(+reduce zip(inst1ser.borrow(), inst2ser.borrow()));
+//showCountsD;
+
+// bug: compiler crashes
+//writeln("SA serial");
+//writeln(+reduce zip(inst1SA.borrow(), inst2SA.borrow()));
+//showCountsD;
+
+writeln("LF leader+followers");
+writeln(+reduce zip(inst1LF.borrow(), inst2LF.borrow()));
+showCountsD;
+
+writeln("par leader+followers");
+writeln(+reduce zip(inst1par.borrow(), inst2par.borrow()));
+showCountsD;

--- a/test/parallel/forall/may-vs-must-par/f6-reduce-exprs.good
+++ b/test/parallel/forall/may-vs-must-par/f6-reduce-exprs.good
@@ -1,0 +1,61 @@
+
+ser serial
+iter1ser
+3
+followers: 0 0
+
+SA standalone
+iter1SA standalone
+3
+followers: 0 0
+
+LF leader+follower
+iter1LF leader
+3
+followers: 2 0
+
+par standalone
+iter1par standalone
+3
+followers: 0 0
+
+LF leader+followers
+iter1LF leader
+(3, -3)
+followers: 2 2
+
+par leader+followers
+iter1par leader
+(3, -3)
+followers: 2 2
+
+ser serial
+class1ser
+3
+followers: 0 0
+
+SA standalone
+class1SA standalone
+3
+followers: 0 0
+
+LF leader+follower
+class1LF leader
+3
+followers: 2 0
+
+par standalone
+class1par standalone
+3
+followers: 0 0
+
+LF leader+followers
+class1LF leader
+(3, -3)
+followers: 2 2
+
+par leader+followers
+class1par leader
+(3, -3)
+followers: 2 2
+

--- a/test/parallel/forall/may-vs-must-par/iters.chpl
+++ b/test/parallel/forall/may-vs-must-par/iters.chpl
@@ -1,0 +1,127 @@
+// Helper iterators.
+
+config const ni = 2;
+const RNGi = 1..ni;
+
+var cnt1i, cnt2i: atomic int;
+proc inc1i        { cnt1i.add(1); }
+proc inc2i        { cnt2i.add(1); }
+proc resetCountsI { cnt1i.write(0); cnt2i.write(0); }
+proc showCountsI  { writeln("followers: ", cnt1i.read(), " ", cnt2i.read());
+                    writeln(); resetCountsI; }
+
+/////////// serial-only ///////////
+
+iter iter1ser() {
+  writeln("iter1ser");
+  for idx in RNGi do
+    yield idx;
+}
+
+iter iter2ser() {
+  writeln("iter2ser");
+  for idx in RNGi do
+    yield -idx;
+}
+
+/////////// serial+standalone ///////////
+
+iter iter1SA() {
+  writeln("iter1SA serial");
+  for idx in RNGi do
+    yield idx;
+}
+iter iter1SA(param tag) where tag == iterKind.standalone {
+  writeln("iter1SA standalone");
+  for idx in RNGi.these(tag) do
+    yield idx;
+}
+
+iter iter2SA() {
+  writeln("iter2SA serial");
+  for idx in RNGi do
+    yield -idx;
+}
+iter iter2SA(param tag) where tag == iterKind.standalone {
+  writeln("iter2SA standalone");
+  for idx in RNGi.these(tag) do
+    yield -idx;
+}
+
+/////////// serial+leader/follower ///////////
+
+iter iter1LF() {
+  writeln("iter1LF serial");
+  for idx in RNGi do
+    yield idx;
+}
+iter iter1LF(param tag) where tag == iterKind.leader {
+  writeln("iter1LF leader");
+  for idx in RNGi.these(tag) do
+    yield idx;
+}
+iter iter1LF(param tag, followThis) where tag == iterKind.follower {
+  inc1i;
+  for idx in RNGi.these(tag, followThis) do
+    yield idx;
+}
+
+iter iter2LF() {
+  writeln("iter2LF serial");
+  for idx in RNGi do
+    yield -idx;
+}
+iter iter2LF(param tag) where tag == iterKind.leader {
+  writeln("iter2LF leader");
+  for idx in RNGi.these(tag) do
+    yield idx;
+}
+iter iter2LF(param tag, followThis) where tag == iterKind.follower {
+  inc2i;
+  for idx in RNGi.these(tag, followThis) do
+    yield -idx;
+}
+
+/////////// serial + LF + SA ///////////
+
+iter iter1par() {
+  writeln("iter1par serial");
+  for idx in RNGi do
+    yield idx;
+}
+iter iter1par(param tag) where tag == iterKind.standalone {
+  writeln("iter1par standalone");
+  for idx in RNGi.these(tag) do
+    yield idx;
+}
+iter iter1par(param tag) where tag == iterKind.leader {
+  writeln("iter1par leader");
+  for idx in RNGi.these(tag) do
+    yield idx;
+}
+iter iter1par(param tag, followThis) where tag == iterKind.follower {
+  inc1i;
+  for idx in RNGi.these(tag, followThis) do
+    yield idx;
+}
+
+iter iter2par() {
+  writeln("iter2par serial");
+  for idx in RNGi do
+    yield -idx;
+}
+iter iter2par(param tag) where tag == iterKind.standalone {
+  writeln("iter2par standalone");
+  for idx in RNGi.these(tag) do
+    yield -idx;
+}
+iter iter2par(param tag) where tag == iterKind.leader {
+  writeln("iter2par leader");
+  for idx in RNGi.these(tag) do
+    yield idx;
+}
+iter iter2par(param tag, followThis) where tag == iterKind.follower {
+  inc2i;
+  for idx in RNGi.these(tag, followThis) do
+    yield -idx;
+}


### PR DESCRIPTION
These tests check compiler's logic for selecting the parallel
flavor of the iterator(s) involved in forall-like constructs.

In particular, ensure that `forall` loops require parallel iterator(s)
whereas `[]` loops, promotion, and `reduce` expressions
allow serial iterator(s) when there are no parallel flavors.

"Parallel" means leader+follower (LF) or standalone (SA).