### PR TITLE
Make it easier to enable and gather ugni perfstats

### DIFF
--- a/make/compiler/Makefile.cray-prgenv
+++ b/make/compiler/Makefile.cray-prgenv
@@ -60,6 +60,11 @@ else ifeq ($(CHPL_MAKE_COMM), ofi)
 # dynamic libraries will be required at execution time, so default to
 # dynamic linking to avoid these warnings.
 RUNTIME_LFLAGS += -dynamic
+else ifeq ($(CHPL_MAKE_COMM), ugni)
+ifneq ($(UGNI_PERFSTATS),)
+# Want to use vDSO for faster timers
+RUNTIME_LFLAGS += -dynamic
+endif
 endif
 
 # Don't throw e.g. -march with a PrgEnv compiler since the PrgEnv environment

--- a/modules/Makefile
+++ b/modules/Makefile
@@ -116,6 +116,7 @@ PACKAGES_TO_DOCUMENT = \
 	packages/ReplicatedVar.chpl \
 	packages/Search.chpl \
 	packages/Sort.chpl \
+	packages/UgniPerfStats.chpl \
 	packages/VisualDebug.chpl \
 	packages/ZMQ.chpl \
 	packages/Collection.chpl \

--- a/modules/packages/UgniPerfStats.chpl
+++ b/modules/packages/UgniPerfStats.chpl
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2004-2019 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+  This module provides support for ugni performance statistics.
+
+  .. warning::
+    Intended for use by runtime developers and requires building ugni with
+    perfstats enabled. For a user-facing mechanism, see :mod:`CommDiagnostics`
+
+    For best performance it is recommended that you dynamically link to enable
+    vDSO (for faster timer calls.)
+
+    Set ``UGNI_PERFSTATS=1`` to build ugni with perfstats enabled and to
+    default to dynamic linking.
+ */
+module UgniPerfStats {
+
+  /* Zero performance counters on the current locale */
+  inline proc resetStatsHere() {
+    if CHPL_COMM == "ugni" {
+      extern proc chpl_comm_statsStartHere();
+      chpl_comm_statsStartHere();
+    } else {
+      compilerWarning("UgniPerfStats is only supported for CHPL_COMM=ugni");
+    }
+  }
+
+  /* Zero performance counters on all locales */
+  proc resetStats() {
+    var nonHereLocales = {0..numLocales-1}.remove(here.id);
+    coforall locid in nonHereLocales do on Locales[locid] {
+      resetCommPerfstatsHere();
+    }
+    resetCommPerfstatsHere();
+  }
+
+  /* Print stats on the current locale. By default it prints only the local
+     stats for events initiated on this locale. Using :var:`sumAllLocales=true`
+     will print the sum across all locales.
+   */
+  inline proc printStatsHere(sumAllLocales=false) {
+    if CHPL_COMM == "ugni" {
+      extern proc chpl_comm_statsReport(b: bool);
+      chpl_comm_statsReport(sumAllLocales);
+    } else {
+      compilerWarning("UgniPerfStats is only supported for CHPL_COMM=ugni");
+    }
+  }
+
+  /* Serially print stats for all locales in order. Each locale prints only the
+     local stats for events it initiated. To get a sum across all locales use
+     :proc:`printStatsHere` with :var:`sumAllLocales=true`.
+   */
+  proc printStats() {
+    for loc in Locales do on loc {
+      printCommPerfstatsHere(false);
+    }
+  }
+}

--- a/runtime/src/comm/ugni/Makefile.share
+++ b/runtime/src/comm/ugni/Makefile.share
@@ -56,6 +56,10 @@ endif
 # Get system headers...
 comm_ugni_CFLAGS = $(CHPL_UGNI_PRGENV_CFLAGS)
 
+ifneq ($(UGNI_PERFSTATS),)
+comm_ugni_CFLAGS += -DPERFSTATS_COMM_UGNI
+endif
+
 # Building with IPA enabled results in execution time bugs. See JIRA issue 185
 # for more details: https://chapel.atlassian.net/browse/CHAPEL-185
 ifeq ($(CHPL_MAKE_TARGET_COMPILER),cray-prgenv-cray)

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -8339,6 +8339,8 @@ void chpl_comm_statsReport(chpl_bool sum_over_locales)
   }
   else
     _psv_print(chpl_nodeID, &chpl_comm_pstats);
+#else
+  chpl_warning("ugni was not built with support for perfstats reporting", 0, 0);
 #endif
 }
 


### PR DESCRIPTION
When `UGNI_PERFSTATS` is set we will compile ugni with perfstats enabled and do
dynamic linking to get vDSO enabled for faster timers. This also adds a module
that wraps the perfstat reseting and printing routines to make them easier to
use from module code.