### PR TITLE
Restore an improved learnChapelInYMinutes.skipif.

### DIFF
--- a/test/release/examples/primers/learnChapelInYMinutes.skipif
+++ b/test/release/examples/primers/learnChapelInYMinutes.skipif
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+
+# This test writes to both stdout and stderr and expects a particular order.
+# Most launchers buffer stdout but not stderr which defeats the prediff processing.
+
+import os
+print(os.getenv('CHPL_LAUNCHER') not in ['none', 'amudprun', 'mpirun4ofi'])


### PR DESCRIPTION
In #12236 I removed learnChapelInYMinutes.skipif because I believed
that updating sub_test to capture stdout and stderr output separately
and then combine them after the fact would resolve all the variability
in ordering for those two.  Not so.  Although sub_test is fixed there
apparently are launchers which nevertheless still combine stdout and
stderr (see issue #12259), and we can get failures that way (of note:
2019/02/11 Cray XC arm testing with the aprun launcher).

Here, restore the learnChapelInYMinutes.skipif that was there before,
but augment it to allow mpirun4ofi in addition to the other launchers
known to work.

Tested: passes on chapcs with comm=ofi, skipped on XC-arm with
comm=none.