### PR TITLE
Build XC x86_64 module with CHPL_LIB_PIC=pic support.

### DIFF
--- a/util/build_configs/cray-internal/setenv-xc-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-xc-x86_64.bash
@@ -132,6 +132,7 @@ if [ -z "$BUILD_CONFIGS_CALLBACK" ]; then
         substrates=aries,mpi,none
         locale_models=flat,knl
         auxfs=none,lustre
+        libpics=none,pic
 
         log_info "Start build_configs $dry_run $verbose # no make target"
 
@@ -142,6 +143,7 @@ if [ -z "$BUILD_CONFIGS_CALLBACK" ]; then
             --substrate=$substrates \
             --locale-model=$locale_models \
             --auxfs=$auxfs \
+            --lib-pic=$libpics \
             -- notcompiler
 
         # NOTE: don't rebuild compiler above (or else problems with switching GCC versions)
@@ -266,7 +268,19 @@ else
     log_debug "with config=$BUILD_CONFIGS_CALLBACK"
 
     # Exit immediately to skip (avoid building) unwanted Chapel configs
-
+    
+    if [ "$CHPL_LIB_PIC" == pic ]; then
+      if [ "$CHPL_COMM" != none ]; then
+        log_info "Skip Chapel make for libpic=$CHPL_LIB_PIC, comm=$CHPL_COMM"
+        exit 0
+      fi
+      if [ "$CHPL_LAUNCHER" != none ]; then
+        log_info "Skip Chapel make for libpic=$CHPL_LIB_PIC, launcher=$CHPL_LAUNCHER"
+        exit 0
+      fi
+    fi
+    
+    
     if [ "$CHPL_COMM" == ugni ]; then
         if [ "$CHPL_LAUNCHER" == none ]; then
 

--- a/util/build_configs/cray-internal/setenv-xc-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-xc-x86_64.bash
@@ -270,6 +270,9 @@ else
     # Exit immediately to skip (avoid building) unwanted Chapel configs
     
     if [ "$CHPL_LIB_PIC" == pic ]; then
+      # skip Chapel make for any communication and launcher that are not none
+      # because pic support is for python interoperability which
+      # only runs on the login node at the moment.
       if [ "$CHPL_COMM" != none ]; then
         log_info "Skip Chapel make for libpic=$CHPL_LIB_PIC, comm=$CHPL_COMM"
         exit 0


### PR DESCRIPTION
Adding pic support into the module build in order to support python interoperability
on Cray XCs with x86 64 architecture. We skip builds for pic when communication
and launcher are not none since currently this only runs on the login node.

Tested manual build on Cicero and completed successfully.

> 2019-02-12 15:48:07,237 [INFO] All 864 configurations finished in 9511.975 seconds.