### PR TITLE
Add memory order argument to the network atomics implementation

### DIFF
--- a/modules/internal/NetworkAtomics.chpl
+++ b/modules/internal/NetworkAtomics.chpl
@@ -42,28 +42,28 @@ module NetworkAtomics {
 
     inline proc const read(order:memory_order = memory_order_seq_cst): bool {
       pragma "insert line file info" extern externFunc("read", int(64))
-        proc atomic_read(ref result:int(64), l:int(32), const obj:c_void_ptr): void;
+        proc atomic_read(ref result:int(64), l:int(32), const obj:c_void_ptr, order:memory_order): void;
 
       var ret: int(64);
-      atomic_read(ret, _localeid(), _addr());
+      atomic_read(ret, _localeid(), _addr(), order);
       return ret:bool;
     }
 
     inline proc write(value:bool, order:memory_order = memory_order_seq_cst): void {
       pragma "insert line file info" extern externFunc("write", int(64))
-        proc atomic_write(ref desired:int(64), l:int(32), obj:c_void_ptr): void;
+        proc atomic_write(ref desired:int(64), l:int(32), obj:c_void_ptr, order:memory_order): void;
 
       var v = value:int(64);
-      atomic_write(v, _localeid(), _addr());
+      atomic_write(v, _localeid(), _addr(), order);
     }
 
     inline proc exchange(value:bool, order:memory_order = memory_order_seq_cst): bool {
       pragma "insert line file info" extern externFunc("xchg", int(64))
-        proc atomic_xchg(ref desired:int(64), l:int(32), obj:c_void_ptr, ref result:int(64)): void;
+        proc atomic_xchg(ref desired:int(64), l:int(32), obj:c_void_ptr, ref result:int(64), order:memory_order): void;
 
       var ret:int(64);
       var v = value:int(64);
-      atomic_xchg(v, _localeid(), _addr(), ret);
+      atomic_xchg(v, _localeid(), _addr(), ret, order);
       return ret:bool;
     }
 
@@ -77,12 +77,12 @@ module NetworkAtomics {
 
     inline proc compareExchangeStrong(expected:bool, desired:bool, order:memory_order = memory_order_seq_cst): bool {
       pragma "insert line file info" extern externFunc("cmpxchg", int(64))
-        proc atomic_cmpxchg(ref expected:int(64), ref desired:int(64), l:int(32), obj:c_void_ptr, ref result:bool(32)): void;
+        proc atomic_cmpxchg(ref expected:int(64), ref desired:int(64), l:int(32), obj:c_void_ptr, ref result:bool(32), order:memory_order): void;
 
       var ret:bool(32);
       var te = expected:int(64);
       var td = desired:int(64);
-      atomic_cmpxchg(te, td, _localeid(), _addr(), ret);
+      atomic_cmpxchg(te, td, _localeid(), _addr(), ret, order);
       return ret:bool;
     }
 
@@ -132,28 +132,28 @@ module NetworkAtomics {
 
     inline proc const read(order:memory_order = memory_order_seq_cst): T {
       pragma "insert line file info" extern externFunc("read", T)
-        proc atomic_read(ref result:T, l:int(32), const obj:c_void_ptr): void;
+        proc atomic_read(ref result:T, l:int(32), const obj:c_void_ptr, order:memory_order): void;
 
       var ret:T;
-      atomic_read(ret, _localeid(), _addr());
+      atomic_read(ret, _localeid(), _addr(), order);
       return ret;
     }
 
     inline proc write(value:T, order:memory_order = memory_order_seq_cst): void {
       pragma "insert line file info" extern externFunc("write", T)
-        proc atomic_write(ref desired:T, l:int(32), obj:c_void_ptr): void;
+        proc atomic_write(ref desired:T, l:int(32), obj:c_void_ptr, order:memory_order): void;
 
       var v = value;
-      atomic_write(v, _localeid(), _addr());
+      atomic_write(v, _localeid(), _addr(), order);
     }
 
     inline proc exchange(value:T, order:memory_order = memory_order_seq_cst): T {
       pragma "insert line file info" extern externFunc("xchg", T)
-        proc atomic_xchg(ref desired:T, l:int(32), obj:c_void_ptr, ref result:T): void;
+        proc atomic_xchg(ref desired:T, l:int(32), obj:c_void_ptr, ref result:T, order:memory_order): void;
 
       var ret:T;
       var v = value;
-      atomic_xchg(v, _localeid(), _addr(), ret);
+      atomic_xchg(v, _localeid(), _addr(), ret, order);
       return ret;
     }
 
@@ -167,109 +167,109 @@ module NetworkAtomics {
 
     inline proc compareExchangeStrong(expected:T, desired:T, order:memory_order = memory_order_seq_cst): bool {
       pragma "insert line file info" extern externFunc("cmpxchg", T)
-        proc atomic_cmpxchg(ref expected:T, ref desired:T, l:int(32), obj:c_void_ptr, ref result:bool(32)): void;
+        proc atomic_cmpxchg(ref expected:T, ref desired:T, l:int(32), obj:c_void_ptr, ref result:bool(32), order:memory_order): void;
 
       var ret:bool(32);
       var te = expected;
       var td = desired;
-      atomic_cmpxchg(te, td, _localeid(), _addr(), ret);
+      atomic_cmpxchg(te, td, _localeid(), _addr(), ret, order);
       return ret:bool;
     }
 
     inline proc fetchAdd(value:T, order:memory_order = memory_order_seq_cst): T {
       pragma "insert line file info" extern externFunc("fetch_add", T)
-        proc atomic_fetch_add(ref op:T, l:int(32), obj:c_void_ptr, ref result:T): void;
+        proc atomic_fetch_add(ref op:T, l:int(32), obj:c_void_ptr, ref result:T, order:memory_order): void;
 
       var ret:T;
       var v = value;
-      atomic_fetch_add(v, _localeid(), _addr(), ret);
+      atomic_fetch_add(v, _localeid(), _addr(), ret, order);
       return ret;
     }
 
     inline proc add(value:T, order:memory_order = memory_order_seq_cst): void {
       pragma "insert line file info" extern externFunc("add", T)
-        proc atomic_add(ref op:T, l:int(32), obj:c_void_ptr): void;
+        proc atomic_add(ref op:T, l:int(32), obj:c_void_ptr, order:memory_order): void;
 
       var v = value;
-      atomic_add(v, _localeid(), _addr());
+      atomic_add(v, _localeid(), _addr(), order);
     }
 
     inline proc fetchSub(value:T, order:memory_order = memory_order_seq_cst): T {
       pragma "insert line file info" extern externFunc("fetch_sub", T)
-        proc atomic_fetch_sub(ref op:T, l:int(32), obj:c_void_ptr, ref result:T): void;
+        proc atomic_fetch_sub(ref op:T, l:int(32), obj:c_void_ptr, ref result:T, order:memory_order): void;
 
       var ret:T;
       var v = value;
-      atomic_fetch_sub(v, _localeid(), _addr(), ret);
+      atomic_fetch_sub(v, _localeid(), _addr(), ret, order);
       return ret;
     }
 
     inline proc sub(value:T, order:memory_order = memory_order_seq_cst): void {
       pragma "insert line file info" extern externFunc("sub", T)
-        proc atomic_sub(ref op:T, l:int(32), obj:c_void_ptr): void;
+        proc atomic_sub(ref op:T, l:int(32), obj:c_void_ptr, order:memory_order): void;
 
       var v = value;
-      atomic_sub(v, _localeid(), _addr());
+      atomic_sub(v, _localeid(), _addr(), order);
     }
 
     inline proc fetchOr(value:T, order:memory_order = memory_order_seq_cst): T {
       if !isIntegral(T) then compilerError("fetchOr is only defined for integer atomic types");
       pragma "insert line file info" extern externFunc("fetch_or", T)
-        proc atomic_fetch_or(ref op:T, l:int(32), obj:c_void_ptr, ref result:T): void;
+        proc atomic_fetch_or(ref op:T, l:int(32), obj:c_void_ptr, ref result:T, order:memory_order): void;
 
       var ret:T;
       var v = value;
-      atomic_fetch_or(v, _localeid(), _addr(), ret);
+      atomic_fetch_or(v, _localeid(), _addr(), ret, order);
       return ret;
     }
 
     inline proc or(value:T, order:memory_order = memory_order_seq_cst): void {
       if !isIntegral(T) then compilerError("or is only defined for integer atomic types");
       pragma "insert line file info" extern externFunc("or", T)
-        proc atomic_or(ref op:T, l:int(32), obj:c_void_ptr): void;
+        proc atomic_or(ref op:T, l:int(32), obj:c_void_ptr, order:memory_order): void;
 
       var v = value;
-      atomic_or(v, _localeid(), _addr());
+      atomic_or(v, _localeid(), _addr(), order);
     }
 
     inline proc fetchAnd(value:T, order:memory_order = memory_order_seq_cst): T {
       if !isIntegral(T) then compilerError("fetchAnd is only defined for integer atomic types");
       pragma "insert line file info" extern externFunc("fetch_and", T)
-        proc atomic_fetch_and(ref op:T, l:int(32), obj:c_void_ptr, ref result:T): void;
+        proc atomic_fetch_and(ref op:T, l:int(32), obj:c_void_ptr, ref result:T, order:memory_order): void;
 
       var ret:T;
       var v = value;
-      atomic_fetch_and(v, _localeid(), _addr(), ret);
+      atomic_fetch_and(v, _localeid(), _addr(), ret, order);
       return ret;
     }
 
     inline proc and(value:T, order:memory_order = memory_order_seq_cst): void {
       if !isIntegral(T) then compilerError("and is only defined for integer atomic types");
       pragma "insert line file info" extern externFunc("and", T)
-        proc atomic_and(ref op:T, l:int(32), obj:c_void_ptr): void;
+        proc atomic_and(ref op:T, l:int(32), obj:c_void_ptr, order:memory_order): void;
 
       var v = value;
-      atomic_and(v, _localeid(), _addr());
+      atomic_and(v, _localeid(), _addr(), order);
     }
 
     inline proc fetchXor(value:T, order:memory_order = memory_order_seq_cst): T {
       if !isIntegral(T) then compilerError("fetchXor is only defined for integer atomic types");
       pragma "insert line file info" extern externFunc("fetch_xor", T)
-        proc atomic_fetch_xor(ref op:T, l:int(32), obj:c_void_ptr, ref result:T): void;
+        proc atomic_fetch_xor(ref op:T, l:int(32), obj:c_void_ptr, ref result:T, order:memory_order): void;
 
       var ret:T;
       var v = value;
-      atomic_fetch_xor(v, _localeid(), _addr(), ret);
+      atomic_fetch_xor(v, _localeid(), _addr(), ret, order);
       return ret;
     }
 
     inline proc xor(value:T, order:memory_order = memory_order_seq_cst): void {
       if !isIntegral(T) then compilerError("xor is only defined for integer atomic types");
       pragma "insert line file info" extern externFunc("xor", T)
-        proc atomic_xor(ref op:T, l:int(32), obj:c_void_ptr): void;
+        proc atomic_xor(ref op:T, l:int(32), obj:c_void_ptr, order:memory_order): void;
 
       var v = value;
-      atomic_xor(v, _localeid(), _addr());
+      atomic_xor(v, _localeid(), _addr(), order);
     }
 
     inline proc const waitFor(value:T, order:memory_order = memory_order_seq_cst): void {

--- a/runtime/include/chpl-comm-native-atomics.h
+++ b/runtime/include/chpl-comm-native-atomics.h
@@ -16,6 +16,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "chpltypes.h"
+#include "chpl-atomics.h"
 
 #ifndef _chpl_comm_native_atomics_h_
 #define _chpl_comm_native_atomics_h_
@@ -40,7 +42,7 @@
 #define DECL_CHPL_COMM_ATOMIC_WRITE(type)                               \
   void chpl_comm_atomic_write_ ## type                                  \
          (void* desired, c_nodeid_t node, void* object,                 \
-          int ln, int32_t fn);
+          memory_order order, int ln, int32_t fn);
 
 DECL_CHPL_COMM_ATOMIC_WRITE(int32)
 DECL_CHPL_COMM_ATOMIC_WRITE(int64)
@@ -59,7 +61,7 @@ DECL_CHPL_COMM_ATOMIC_WRITE(real64)
 #define DECL_CHPL_COMM_ATOMIC_READ(type)                                \
   void chpl_comm_atomic_read_ ## type                                   \
          (void* result, c_nodeid_t node, void* object,                  \
-          int ln, int32_t fn);
+          memory_order order, int ln, int32_t fn);
 
 DECL_CHPL_COMM_ATOMIC_READ(int32)
 DECL_CHPL_COMM_ATOMIC_READ(int64)
@@ -77,7 +79,7 @@ DECL_CHPL_COMM_ATOMIC_READ(real64)
 #define DECL_CHPL_COMM_ATOMIC_XCHG(type)                                \
   void chpl_comm_atomic_xchg_ ## type                                   \
          (void* desired, c_nodeid_t node, void* object, void* result,   \
-          int ln, int32_t fn);
+          memory_order order, int ln, int32_t fn);
 
 DECL_CHPL_COMM_ATOMIC_XCHG(int32)
 DECL_CHPL_COMM_ATOMIC_XCHG(int64)
@@ -96,8 +98,7 @@ DECL_CHPL_COMM_ATOMIC_XCHG(real64)
 #define DECL_CHPL_COMM_ATOMIC_CMPXCHG(type)                             \
   void chpl_comm_atomic_cmpxchg_ ## type                                \
          (void* expected, void* desired, c_nodeid_t node, void* object, \
-          chpl_bool32* result,                                          \
-          int ln, int32_t fn);
+          chpl_bool32* result, memory_order order, int ln, int32_t fn);
 
 DECL_CHPL_COMM_ATOMIC_CMPXCHG(int32)
 DECL_CHPL_COMM_ATOMIC_CMPXCHG(int64)
@@ -119,7 +120,7 @@ DECL_CHPL_COMM_ATOMIC_CMPXCHG(real64)
 #define DECL_CHPL_COMM_ATOMIC_NONFETCH_BINARY(op, type)                 \
   void chpl_comm_atomic_ ## op ## _ ## type                             \
          (void* operand, c_nodeid_t node, void* object,                 \
-          int ln, int32_t fn);
+          memory_order order, int ln, int32_t fn);
 #define DECL_CHPL_COMM_ATOMIC_NONFETCH_UNORDERED_BINARY(op, type)       \
   void chpl_comm_atomic_ ## op ## _unordered_ ## type                   \
          (void* operand, c_nodeid_t node, void* object,                 \
@@ -127,7 +128,7 @@ DECL_CHPL_COMM_ATOMIC_CMPXCHG(real64)
 #define DECL_CHPL_COMM_ATOMIC_FETCH_BINARY(op, type)                    \
   void chpl_comm_atomic_fetch_ ## op ## _ ## type                       \
          (void* operand, c_nodeid_t node, void* object, void* result,   \
-          int ln, int32_t fn);
+          memory_order order, int ln, int32_t fn);
 #define DECL_CHPL_COMM_ATOMIC_BINARY(op, type)                          \
   DECL_CHPL_COMM_ATOMIC_NONFETCH_BINARY(op, type)                       \
   DECL_CHPL_COMM_ATOMIC_NONFETCH_UNORDERED_BINARY(op, type)             \

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -2464,7 +2464,7 @@ static inline void doAMO(c_nodeid_t, void*, const void*, const void*, void*,
 #define DEFN_CHPL_COMM_ATOMIC_WRITE(fnType, ofiType, Type)              \
   void chpl_comm_atomic_write_##fnType                                  \
          (void* desired, c_nodeid_t node, void* object,                 \
-          int ln, int32_t fn) {                                         \
+          memory_order order, int ln, int32_t fn) {                     \
     DBG_PRINTF(DBG_INTERFACE,                                           \
                "chpl_comm_atomic_write_%s(%p, %d, %p, %d, %s)",         \
                #fnType, desired, (int) node, object,                    \
@@ -2487,7 +2487,7 @@ DEFN_CHPL_COMM_ATOMIC_WRITE(real64, FI_DOUBLE, double)
 #define DEFN_CHPL_COMM_ATOMIC_READ(fnType, ofiType, Type)               \
   void chpl_comm_atomic_read_##fnType                                   \
          (void* result, c_nodeid_t node, void* object,                  \
-          int ln, int32_t fn) {                                         \
+          memory_order order, int ln, int32_t fn) {                     \
     DBG_PRINTF(DBG_INTERFACE,                                           \
                "chpl_comm_atomic_read_%s(%p, %d, %p, %d, %s)",          \
                #fnType, result, (int) node, object,                     \
@@ -2507,7 +2507,7 @@ DEFN_CHPL_COMM_ATOMIC_READ(real64, FI_DOUBLE, double)
 #define DEFN_CHPL_COMM_ATOMIC_XCHG(fnType, ofiType, Type)               \
   void chpl_comm_atomic_xchg_##fnType                                   \
          (void* desired, c_nodeid_t node, void* object, void* result,   \
-          int ln, int32_t fn) {                                         \
+          memory_order order, int ln, int32_t fn) {                     \
     DBG_PRINTF(DBG_INTERFACE,                                           \
                "chpl_comm_atomic_xchg_%s(%p, %d, %p, %p, %d, %s)",      \
                #fnType, desired, (int) node, object, result,            \
@@ -2527,7 +2527,7 @@ DEFN_CHPL_COMM_ATOMIC_XCHG(real64, FI_DOUBLE, double)
 #define DEFN_CHPL_COMM_ATOMIC_CMPXCHG(fnType, ofiType, Type)            \
   void chpl_comm_atomic_cmpxchg_##fnType                                \
          (void* expected, void* desired, c_nodeid_t node, void* object, \
-          chpl_bool32* result,                                          \
+          chpl_bool32* result, memory_order order,                      \
           int ln, int32_t fn) {                                         \
     DBG_PRINTF(DBG_INTERFACE,                                           \
                "chpl_comm_atomic_cmpxchg_%s(%p, %p, %d, %p, %p, "       \
@@ -2549,7 +2549,7 @@ DEFN_CHPL_COMM_ATOMIC_CMPXCHG(real64, FI_DOUBLE, double)
 #define DEFN_IFACE_AMO_SIMPLE_OP(fnOp, ofiOp, fnType, ofiType, Type)    \
   void chpl_comm_atomic_##fnOp##_##fnType                               \
          (void* operand, c_nodeid_t node, void* object,                 \
-          int ln, int32_t fn) {                                         \
+          memory_order order, int ln, int32_t fn) {                     \
     DBG_PRINTF(DBG_INTERFACE,                                           \
                "chpl_comm_atomic_%s_%s(<%s>, %d, %p, %d, %s)",          \
                #fnOp, #fnType, DBG_VAL(operand, ofiType), (int) node,   \
@@ -2565,12 +2565,13 @@ DEFN_CHPL_COMM_ATOMIC_CMPXCHG(real64, FI_DOUBLE, double)
                "chpl_comm_atomic_%s_unordered_%s(<%s>, %d, %p, %d, %s)",\
                #fnOp, #fnType, DBG_VAL(operand, ofiType), (int) node,   \
                object, ln, chpl_lookupFilename(fn));                    \
-    chpl_comm_atomic_##fnOp##_##fnType(operand, node, object, ln, fn);  \
+    chpl_comm_atomic_##fnOp##_##fnType(operand, node, object,           \
+                                       memory_order_seq_cst, ln, fn);   \
   }                                                                     \
                                                                         \
   void chpl_comm_atomic_fetch_##fnOp##_##fnType                         \
          (void* operand, c_nodeid_t node, void* object, void* result,   \
-          int ln, int32_t fn) {                                         \
+          memory_order order, int ln, int32_t fn) {                     \
     DBG_PRINTF(DBG_INTERFACE,                                           \
                "chpl_comm_atomic_fetch_%s_%s(<%s>, %d, %p, %p, "        \
                "%d, %s)",                                               \
@@ -2606,7 +2607,7 @@ DEFN_IFACE_AMO_SIMPLE_OP(add, FI_SUM, real64, FI_DOUBLE, double)
 #define DEFN_IFACE_AMO_SUB(fnType, ofiType, Type, negate)               \
   void chpl_comm_atomic_sub_##fnType                                    \
          (void* operand, c_nodeid_t node, void* object,                 \
-          int ln, int32_t fn) {                                         \
+          memory_order order, int ln, int32_t fn) {                     \
     DBG_PRINTF(DBG_INTERFACE,                                           \
                "chpl_comm_atomic_sub_%s(<%s>, %d, %p, %d, %s)",         \
                #fnType, DBG_VAL(operand, ofiType), (int) node, object,  \
@@ -2624,12 +2625,13 @@ DEFN_IFACE_AMO_SIMPLE_OP(add, FI_SUM, real64, FI_DOUBLE, double)
                "%d, %s)",                                               \
                #fnType, DBG_VAL(operand, ofiType), (int) node, object,  \
                ln, chpl_lookupFilename(fn));                            \
-    chpl_comm_atomic_sub_##fnType(operand, node, object, ln, fn);       \
+    chpl_comm_atomic_sub_##fnType(operand, node, object,                \
+                                  memory_order_seq_cst, ln, fn);        \
   }                                                                     \
                                                                         \
   void chpl_comm_atomic_fetch_sub_##fnType                              \
          (void* operand, c_nodeid_t node, void* object, void* result,   \
-          int ln, int32_t fn) {                                         \
+          memory_order order, int ln, int32_t fn) {                     \
     DBG_PRINTF(DBG_INTERFACE,                                           \
                "chpl_comm_atomic_fetch_sub_%s(<%s>, %d, %p, %p, "       \
                "%d, %s)",                                               \

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -6474,6 +6474,7 @@ int chpl_comm_addr_gettable(c_nodeid_t node, void* start, size_t len)
         void chpl_comm_atomic_write_##_f(void* val,                     \
                                        int32_t loc,                     \
                                        void* obj,                       \
+                                       memory_order order,              \
                                        int ln, int32_t fn)              \
         {                                                               \
           mem_region_t* remote_mr;                                      \
@@ -6536,6 +6537,7 @@ DEFINE_CHPL_COMM_ATOMIC_WRITE(real64, put_64, int_least64_t)
         void chpl_comm_atomic_read_##_f(void* res,                      \
                                        int32_t loc,                     \
                                        void* obj,                       \
+                                       memory_order order,              \
                                        int ln, int32_t fn)              \
         {                                                               \
           mem_region_t* remote_mr;                                      \
@@ -6589,6 +6591,7 @@ DEFINE_CHPL_COMM_ATOMIC_READ(real64, get_64, int_least64_t)
                                         int32_t loc,                    \
                                         void* obj,                      \
                                         void* res,                      \
+                                        memory_order order,             \
                                         int ln, int32_t fn)             \
         {                                                               \
           mem_region_t* remote_mr;                                      \
@@ -6649,6 +6652,7 @@ DEFINE_CHPL_COMM_ATOMIC_XCHG(real64, xchg_64, int_least64_t)
                                            int32_t loc,                 \
                                            void* obj,                   \
                                            chpl_bool32* res,            \
+                                           memory_order order,          \
                                            int ln, int32_t fn)          \
         {                                                               \
           mem_region_t* remote_mr;                                      \
@@ -6704,6 +6708,7 @@ DEFINE_CHPL_COMM_ATOMIC_CMPXCHG(real64, cmpxchg_64, int_least64_t)
         void chpl_comm_atomic_##_o##_##_f(void* opnd,                   \
                                           int32_t loc,                  \
                                           void* obj,                    \
+                                          memory_order order,           \
                                           int ln, int32_t fn)           \
         {                                                               \
           mem_region_t* remote_mr;                                      \
@@ -6767,6 +6772,7 @@ DEFINE_CHPL_COMM_ATOMIC_CMPXCHG(real64, cmpxchg_64, int_least64_t)
                                                 int32_t loc,            \
                                                 void* obj,              \
                                                 void* res,              \
+                                                memory_order order,     \
                                                 int ln, int32_t fn)     \
         {                                                               \
           mem_region_t* remote_mr;                                      \
@@ -6836,6 +6842,7 @@ DEFINE_CHPL_COMM_ATOMIC_INT_OP(uint64, add, add_i64, uint_least64_t)
         void chpl_comm_atomic_add_##_f(void* opnd,                      \
                                        int32_t loc,                     \
                                        void* obj,                       \
+                                       memory_order order,              \
                                        int ln, int32_t fn)              \
         {                                                               \
           mem_region_t* remote_mr;                                      \
@@ -6899,6 +6906,7 @@ DEFINE_CHPL_COMM_ATOMIC_INT_OP(uint64, add, add_i64, uint_least64_t)
                                              int32_t loc,               \
                                              void* obj,                 \
                                              void* res,                 \
+                                             memory_order order,        \
                                              int ln, int32_t fn)        \
         {                                                               \
           mem_region_t* remote_mr;                                      \
@@ -6943,6 +6951,7 @@ DEFINE_CHPL_COMM_ATOMIC_REAL_OP(real64, add_r64, double)
         void chpl_comm_atomic_sub_##_f(void* opnd,                      \
                                        int32_t loc,                     \
                                        void* obj,                       \
+                                       memory_order order,              \
                                        int ln, int32_t fn)              \
         {                                                               \
           _t nopnd = _negate(*(_t*) opnd);                              \
@@ -6952,7 +6961,7 @@ DEFINE_CHPL_COMM_ATOMIC_REAL_OP(real64, add_r64, double)
                    "(%p, %d, %p)",                                      \
                    opnd, (int) loc, obj);                               \
                                                                         \
-          chpl_comm_atomic_add_##_f(&nopnd, loc, obj, ln, fn);          \
+          chpl_comm_atomic_add_##_f(&nopnd, loc, obj, order, ln, fn);   \
         }                                                               \
                                                                         \
          /*==============================*/                             \
@@ -6976,6 +6985,7 @@ DEFINE_CHPL_COMM_ATOMIC_REAL_OP(real64, add_r64, double)
                                              int32_t loc,               \
                                              void* obj,                 \
                                              void* res,                 \
+                                             memory_order order,        \
                                              int ln, int32_t fn)        \
         {                                                               \
           _t nopnd = _negate(*(_t*) opnd);                              \
@@ -6985,7 +6995,7 @@ DEFINE_CHPL_COMM_ATOMIC_REAL_OP(real64, add_r64, double)
                    "(%p, %d, %p, %p)",                                  \
                    opnd, (int) loc, obj, res);                          \
                                                                         \
-          chpl_comm_atomic_fetch_add_##_f(&nopnd, loc, obj, res,        \
+          chpl_comm_atomic_fetch_add_##_f(&nopnd, loc, obj, res, order, \
                                           ln, fn);                      \
         }
 


### PR DESCRIPTION
Previously, we dropped the memory order on the floor in module code. We now
pass it through to the runtime, which still drops it on the floor. In the
future we may be able to optimize based on the memory order, but for now we're
just passing it through so that the compiler can pluck a local memory order to
use when transforming ordered atomics into unordered atomics in #12269

Closes https://github.com/chapel-lang/chapel/issues/12250