### PR TITLE
Convert internal compiler error with partially queried domain into a user error

### DIFF
--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -2737,10 +2737,8 @@ static void fixupArrayFormal(FnSymbol* fn, ArgSymbol* formal) {
   if (!isDefExpr(domExpr)) {
     std::vector<DefExpr*> defExprs;
     collectDefExprs(domExpr, defExprs);
-    if (defExprs.size() > 0) {
-      for_vector(DefExpr, def, defExprs) {
-        USR_FATAL_CONT(def, "cannot query part of a domain");
-      }
+    for_vector(DefExpr, def, defExprs) {
+      USR_FATAL_CONT(def, "cannot query part of a domain");
     }
   }
   //

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -2732,6 +2732,17 @@ static void fixupArrayFormal(FnSymbol* fn, ArgSymbol* formal) {
 
   std::vector<SymExpr*> symExprs;
 
+  // Our AST and transformations are not set up to handle multiple query
+  // expressions inside of an array's domain.  Give the user an error for now.
+  if (!isDefExpr(domExpr)) {
+    std::vector<DefExpr*> defExprs;
+    collectDefExprs(domExpr, defExprs);
+    if (defExprs.size() > 0) {
+      for_vector(DefExpr, def, defExprs) {
+        USR_FATAL_CONT(def, "cannot query part of a domain");
+      }
+    }
+  }
   //
   // Only fix array formals with 'in' intent if there was:
   // - a type query, or

--- a/test/domains/compilerErrors/partialQueriedDomain-inIntent.chpl
+++ b/test/domains/compilerErrors/partialQueriedDomain-inIntent.chpl
@@ -1,0 +1,34 @@
+module M {
+ config const r: int = 8;
+ config const c: int = 9;
+
+ var nbr: int = r;
+ var nbc: int = c;
+ var ndr: int = r+1;
+ var ndc: int = c+1;
+
+ class gs {
+
+   var bd: [0..nbr-1, 0..nbc-1] uint(8);
+   var sf: [ 0 .. 3 * ndr * ndc - 1, 0 .. 1 ] uint(8);
+
+   proc init() {
+     bd = 0;
+   }
+ };
+
+ proc gs.c_l(
+   in ar: [?D, 0 .. 1] uint(8)) {   // <- source of the error
+
+   return ar[0];
+ }
+
+ proc gs.ic() {
+   c_l(sf);
+ }
+
+ proc main() {
+   var b = new owned gs();
+   b.ic();
+ }
+}

--- a/test/domains/compilerErrors/partialQueriedDomain-inIntent.good
+++ b/test/domains/compilerErrors/partialQueriedDomain-inIntent.good
@@ -1,0 +1,4 @@
+partialQueriedDomain-inIntent.chpl:21: In function 'c_l':
+partialQueriedDomain-inIntent.chpl:21: error: cannot query part of a domain
+partialQueriedDomain-inIntent.chpl:21: error: 'chpl__buildArrayRuntimeType' undeclared (first use this function)
+partialQueriedDomain-inIntent.chpl:21: error: 'chpl__ensureDomainExpr' undeclared (first use this function)

--- a/test/domains/compilerErrors/partialQueriedDomain-multiple.chpl
+++ b/test/domains/compilerErrors/partialQueriedDomain-multiple.chpl
@@ -1,0 +1,34 @@
+module M {
+ config const r: int = 8;
+ config const c: int = 9;
+
+ var nbr: int = r;
+ var nbc: int = c;
+ var ndr: int = r+1;
+ var ndc: int = c+1;
+
+ class gs {
+
+   var bd: [0..nbr-1, 0..nbc-1] uint(8);
+   var sf: [ 0 .. 3 * ndr * ndc - 1, 0 .. 1 ] uint(8);
+
+   proc init() {
+     bd = 0;
+   }
+ };
+
+ proc gs.c_l(
+   ref ar: [?D1, ?D2] uint(8)) {   // <- source of the error
+
+   return ar[0];
+ }
+
+ proc gs.ic() {
+   c_l(sf);
+ }
+
+ proc main() {
+   var b = new owned gs();
+   b.ic();
+ }
+}

--- a/test/domains/compilerErrors/partialQueriedDomain-multiple.good
+++ b/test/domains/compilerErrors/partialQueriedDomain-multiple.good
@@ -1,0 +1,3 @@
+partialQueriedDomain-multiple.chpl:21: In function 'c_l':
+partialQueriedDomain-multiple.chpl:21: error: cannot query part of a domain
+partialQueriedDomain-multiple.chpl:21: error: cannot query part of a domain

--- a/test/domains/compilerErrors/partialQueriedDomain.chpl
+++ b/test/domains/compilerErrors/partialQueriedDomain.chpl
@@ -1,0 +1,34 @@
+module M {
+ config const r: int = 8;
+ config const c: int = 9;
+
+ var nbr: int = r;
+ var nbc: int = c;
+ var ndr: int = r+1;
+ var ndc: int = c+1;
+
+ class gs {
+
+   var bd: [0..nbr-1, 0..nbc-1] uint(8);
+   var sf: [ 0 .. 3 * ndr * ndc - 1, 0 .. 1 ] uint(8);
+
+   proc init() {
+     bd = 0;
+   }
+ };
+
+ proc gs.c_l(
+   ref ar: [?D, 0 .. 1] uint(8)) {   // <- source of the error
+
+   return ar[0];
+ }
+
+ proc gs.ic() {
+   c_l(sf);
+ }
+
+ proc main() {
+   var b = new owned gs();
+   b.ic();
+ }
+}

--- a/test/domains/compilerErrors/partialQueriedDomain.good
+++ b/test/domains/compilerErrors/partialQueriedDomain.good
@@ -1,0 +1,2 @@
+partialQueriedDomain.chpl:21: In function 'c_l':
+partialQueriedDomain.chpl:21: error: cannot query part of a domain


### PR DESCRIPTION
We were encountering an internal compiler error for this case before, due to
CallExprs not expecting to find DefExprs inside themselves.  Instead of that,
perform a check when array formals get transformed during normalize to ensure we
don't partially query a domain.

Resolves #12299

Add three tests of the functionality.  One tracks the original motivating case (single
query but more to the array's domain), another tracks multiple queries in the same
array's domain, and the third ensures that the error message still pops up when the
array argument is declared with an in intent (since that can early exit the array
formal transformation function, which is why I placed the check where I did).

Passed a full paratest with futures