### PR TITLE
Allow for address space layout randomization in comm=ofi.

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -1420,7 +1420,7 @@ static void codegen_defn(std::set<const char*> & cnames, std::vector<TypeSymbol*
       }
     }
     fprintf(hdrfile, "\n};\n");
-    fprintf(hdrfile, "const int chpl_private_broadcast_table_len = %d;\n", i);
+    genGlobalInt("chpl_private_broadcast_table_len", i, false);
   }
 }
 
@@ -1865,6 +1865,8 @@ static void codegen_header(std::set<const char*> & cnames, std::vector<TypeSymbo
           private_broadcastTableType, private_broadcastTable));
     info->lvt->addGlobalValue("chpl_private_broadcast_table",
                               private_broadcastTableGVar, GEN_PTR, true);
+    genGlobalInt("chpl_private_broadcast_table_len",
+                 private_broadcastTable.size(), false);
 #endif
   }
 

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -1420,6 +1420,7 @@ static void codegen_defn(std::set<const char*> & cnames, std::vector<TypeSymbol*
       }
     }
     fprintf(hdrfile, "\n};\n");
+    fprintf(hdrfile, "const int chpl_private_broadcast_table_len = %d;\n", i);
   }
 }
 

--- a/runtime/include/chpl-comm.h
+++ b/runtime/include/chpl-comm.h
@@ -68,6 +68,7 @@ extern const int chpl_numGlobalsOnHeap;
 extern ptr_wide_ptr_t chpl_globals_registry[];
 
 extern void* const chpl_private_broadcast_table[];
+extern int const chpl_private_broadcast_table_len;
 
 extern void* const chpl_global_serialize_table[];
 

--- a/runtime/src/comm/ofi/comm-ofi-internal.h
+++ b/runtime/src/comm/ofi/comm-ofi-internal.h
@@ -196,7 +196,8 @@ struct gather_info {
 void chpl_comm_ofi_oob_init(void);
 void chpl_comm_ofi_oob_fini(void);
 void chpl_comm_ofi_oob_barrier(void);
-void chpl_comm_ofi_oob_allgather(void*, void*, size_t);
+void chpl_comm_ofi_oob_allgather(const void*, void*, size_t);
+void chpl_comm_ofi_oob_bcast(void*, size_t);
 
 
 //

--- a/runtime/src/comm/ofi/comm-ofi-oob-mpi.c
+++ b/runtime/src/comm/ofi/comm-ofi-oob-mpi.c
@@ -76,7 +76,7 @@ void chpl_comm_ofi_oob_barrier(void) {
 }
 
 
-void chpl_comm_ofi_oob_allgather(void* mine, void* all, size_t size) {
+void chpl_comm_ofi_oob_allgather(const void* mine, void* all, size_t size) {
   DBG_PRINTF(DBG_OOB, "OOB allGather: %zd", size);
 
   //
@@ -88,4 +88,10 @@ void chpl_comm_ofi_oob_allgather(void* mine, void* all, size_t size) {
   MPI_CHK(MPI_Allgather(mine, size, MPI_BYTE,
                         all, size, MPI_BYTE,
                         MPI_COMM_WORLD));
+}
+
+
+void chpl_comm_ofi_oob_bcast(void* buf, size_t size) {
+  DBG_PRINTF(DBG_OOB, "OOB bcast: %zd", size);
+  MPI_CHK(MPI_Bcast(buf, size, MPI_BYTE, 0, MPI_COMM_WORLD));
 }

--- a/runtime/src/comm/ofi/comm-ofi-oob-pmi.c
+++ b/runtime/src/comm/ofi/comm-ofi-oob-pmi.c
@@ -72,7 +72,7 @@ void chpl_comm_ofi_oob_barrier(void) {
 }
 
 
-void chpl_comm_ofi_oob_allgather(void* mine, void* all, size_t size) {
+void chpl_comm_ofi_oob_allgather(const void* mine, void* all, size_t size) {
   DBG_PRINTF(DBG_OOB, "OOB allGather: %zd", size);
 
   //
@@ -106,4 +106,10 @@ void chpl_comm_ofi_oob_allgather(void* mine, void* all, size_t size) {
 
   sys_free(g_all);
   sys_free(g_mine);
+}
+
+
+void chpl_comm_ofi_oob_bcast(void* buf, size_t size) {
+  DBG_PRINTF(DBG_OOB, "OOB bcast: %zd", size);
+  PMI_CHK(PMI_Bcast(buf, size));
 }

--- a/runtime/src/comm/ofi/comm-ofi-oob-sockets.c
+++ b/runtime/src/comm/ofi/comm-ofi-oob-sockets.c
@@ -85,10 +85,17 @@ void chpl_comm_ofi_oob_barrier(void) {
 }
 
 
-void chpl_comm_ofi_oob_allgather(void* in, void* out, size_t len) {
+void chpl_comm_ofi_oob_allgather(void* const in, void* out, size_t len) {
   if (chpl_numNodes == 1) {
     chpl_memcpy(out, in, len);
   } else {
     INTERNAL_ERROR_V("multi-locale allgather not supported");
+  }
+}
+
+
+void chpl_comm_ofi_oob_bcast(void* buf, size_t len) {
+  if (chpl_numNodes != 1) {
+    INTERNAL_ERROR_V("multi-locale bcast not supported");
   }
 }


### PR DESCRIPTION
The ofi comm layer didn't work in the presence of address space layout
randomization (ASLR), notably on Mac OS X.  The global and private
broadcast functions assumed that their respective compiler-created
address tables were at the same address in all locales, and for the
private variable tables, that the addresses they contained were the
same across all locales.  Neither of these was actually true, leading
to various sorts of mis-addressing failures (`SIGSEGV`, `SIGBUS`, failed
`nil` checks, etc.).

Here, distribute the necessary addresses among the program instances
during initialization, so that all the nodes have the right addresses
for things they need to reach on other nodes.  As part of this, have
the compiler emit the length of `chpl_private_broadcast_table[]` into a
new `chpl_private_broadcast_table_len` variable, so the runtime can know
how long that table is.  comm=gasnet didn't need that because it uses
AMs to do private broadcasts, and comm=ugni didn't need it because
although it does broadcasts using direct PUTs it doesn't have to deal
with ASLR.  But for comm=ofi we want to use direct PUTs even with
ASLR, so we have to know how long the private broadcast table is so we
can share the nodes' copies of that around the job.

This resolves #12233.