### PR TITLE
Add futures for #12323 and #12325

### DIFF
--- a/compiler/resolution/implementForallIntents2.cpp
+++ b/compiler/resolution/implementForallIntents2.cpp
@@ -105,7 +105,10 @@ static bool findCallToParallelIterator(ForLoop* forLoop, EflopiInfo& eInfo)
     return false;
 
   CallExpr* iterCall = toCallExpr(asgnToCallTemp->get(2));
-  INT_ASSERT(iterCall);
+  if (! iterCall) {
+    USR_STOP(); // do not crash if there have been user errors
+    INT_ASSERT(iterCall);
+  }
 
   if (callingParallelIterator(iterCall)) {
     // Found it. Fill in the information before returning.

--- a/test/parallel/forall/may-vs-must-par/classes-implicit-borrow-promo-1arg.bad
+++ b/test/parallel/forall/may-vs-must-par/classes-implicit-borrow-promo-1arg.bad
@@ -1,0 +1,1 @@
+classes-implicit-borrow-promo-1arg.chpl:7: error: non-lvalue actual is passed to a 'ref' formal of chpl__initCopy()

--- a/test/parallel/forall/may-vs-must-par/classes-implicit-borrow-promo-1arg.chpl
+++ b/test/parallel/forall/may-vs-must-par/classes-implicit-borrow-promo-1arg.chpl
@@ -1,0 +1,7 @@
+use datas;
+
+proc multiply(arg1: int,  arg2: int)  { writeln("mul=", arg1*arg2); }
+proc summify(arg1: int,   arg2: int)  { writeln("sum=", arg1+arg2); }
+proc tuplify(arg1: 2*int, arg2: int)  { writeln("tup=", (arg1(1)+arg1(2))*arg2); }
+
+multiply(inst1SA, 0); // bug: the compiler ignores the standalone iterator

--- a/test/parallel/forall/may-vs-must-par/classes-implicit-borrow-promo-1arg.future
+++ b/test/parallel/forall/may-vs-must-par/classes-implicit-borrow-promo-1arg.future
@@ -1,0 +1,2 @@
+feature request: implicit borrow upon these()
+#12325

--- a/test/parallel/forall/may-vs-must-par/classes-implicit-borrow-promo-1arg.good
+++ b/test/parallel/forall/may-vs-must-par/classes-implicit-borrow-promo-1arg.good
@@ -1,0 +1,3 @@
+class1SA serial
+mul=0
+mul=0

--- a/test/parallel/forall/may-vs-must-par/classes-implicit-borrow-promo-2arg.bad
+++ b/test/parallel/forall/may-vs-must-par/classes-implicit-borrow-promo-2arg.bad
@@ -1,0 +1,2 @@
+classes-implicit-borrow-promo-2arg.chpl:7: error: non-lvalue actual is passed to a 'ref' formal of chpl__initCopy()
+classes-implicit-borrow-promo-2arg.chpl:7: error: non-lvalue actual is passed to a 'ref' formal of chpl__initCopy()

--- a/test/parallel/forall/may-vs-must-par/classes-implicit-borrow-promo-2arg.chpl
+++ b/test/parallel/forall/may-vs-must-par/classes-implicit-borrow-promo-2arg.chpl
@@ -1,0 +1,10 @@
+use datas;
+
+proc multiply(arg1: int,  arg2: int)  { writeln("mul=", arg1*arg2); }
+proc summify(arg1: int,   arg2: int)  { writeln("sum=", arg1+arg2); }
+proc tuplify(arg1: 2*int, arg2: int)  { writeln("tup=", (arg1(1)+arg1(2))*arg2); }
+
+summify(inst1LF, inst2LF);
+
+// combination of the above and zippering
+tuplify(forall IND in zip(inst1LF,  inst2LF) do IND, 1);

--- a/test/parallel/forall/may-vs-must-par/classes-implicit-borrow-promo-2arg.future
+++ b/test/parallel/forall/may-vs-must-par/classes-implicit-borrow-promo-2arg.future
@@ -1,0 +1,2 @@
+feature request: implicit borrow upon these()
+#12325

--- a/test/parallel/forall/may-vs-must-par/classes-implicit-borrow-promo-2arg.good
+++ b/test/parallel/forall/may-vs-must-par/classes-implicit-borrow-promo-2arg.good
@@ -1,0 +1,7 @@
+class1LF leader
+sum=0
+sum=0
+class1LF leader
+tup=0
+tup=0
+

--- a/test/parallel/forall/may-vs-must-par/classes-implicit-borrow-stmt-zippered.bad
+++ b/test/parallel/forall/may-vs-must-par/classes-implicit-borrow-stmt-zippered.bad
@@ -1,0 +1,2 @@
+classes-implicit-borrow-stmt-zippered.chpl:10: error: argument 1 for tuple construction is const but tuple construction takes ownership
+classes-implicit-borrow-stmt-zippered.chpl:10: error: argument 2 for tuple construction is const but tuple construction takes ownership

--- a/test/parallel/forall/may-vs-must-par/classes-implicit-borrow-stmt-zippered.chpl
+++ b/test/parallel/forall/may-vs-must-par/classes-implicit-borrow-stmt-zippered.chpl
@@ -1,0 +1,11 @@
+use datas;
+
+proc multiply(arg1: int,  arg2: int)  { writeln("mul=", arg1*arg2); }
+proc summify(arg1: int,   arg2: int)  { writeln("sum=", arg1+arg2); }
+proc tuplify(arg1: 2*int, arg2: int)  { writeln("tup=", (arg1(1)+arg1(2))*arg2); }
+
+forall IND in inst1SA do // works already without explicit borrow
+  multiply(IND, 0);
+
+forall IND in zip(inst1LF, inst2LF) do
+  tuplify(IND, 0);

--- a/test/parallel/forall/may-vs-must-par/classes-implicit-borrow-stmt-zippered.future
+++ b/test/parallel/forall/may-vs-must-par/classes-implicit-borrow-stmt-zippered.future
@@ -1,0 +1,2 @@
+feature request: implicit borrow upon these()
+#12325

--- a/test/parallel/forall/may-vs-must-par/classes-implicit-borrow-stmt-zippered.good
+++ b/test/parallel/forall/may-vs-must-par/classes-implicit-borrow-stmt-zippered.good
@@ -1,0 +1,6 @@
+class1SA standalone
+mul=0
+mul=0
+class1LF leader
+tup=0
+tup=0

--- a/test/parallel/forall/may-vs-must-par/promo-use-standalone.bad
+++ b/test/parallel/forall/may-vs-must-par/promo-use-standalone.bad
@@ -1,0 +1,12 @@
+iter1SA serial
+mul=0
+mul=0
+iter1par leader
+mul=0
+mul=0
+class1SA serial
+mul=0
+mul=0
+class1par leader
+mul=0
+mul=0

--- a/test/parallel/forall/may-vs-must-par/promo-use-standalone.chpl
+++ b/test/parallel/forall/may-vs-must-par/promo-use-standalone.chpl
@@ -1,0 +1,16 @@
+use iters;
+use datas;
+
+proc multiply(arg1: int, arg2: int)   { writeln("mul=", arg1*arg2); }
+
+/* Currently these always use the serial iterator:
+var arrIter1SA  = [ IND in iter1SA()  ] IND;
+var arrIter1par = [ IND in iter1par() ] IND;
+var arrInst1SA  = [ IND in inst1SA  ] IND;
+var arrInst1par = [ IND in inst1par ] IND;
+*/
+
+multiply([ IND in iter1SA()  ] IND, 0);
+multiply([ IND in iter1par() ] IND, 0);
+multiply([ IND in inst1SA.borrow()  ] IND, 0);
+multiply([ IND in inst1par.borrow() ] IND, 0);

--- a/test/parallel/forall/may-vs-must-par/promo-use-standalone.future
+++ b/test/parallel/forall/may-vs-must-par/promo-use-standalone.future
@@ -1,0 +1,2 @@
+feature request: consider the standalone iterator during promotion
+#12323

--- a/test/parallel/forall/may-vs-must-par/promo-use-standalone.good
+++ b/test/parallel/forall/may-vs-must-par/promo-use-standalone.good
@@ -1,0 +1,12 @@
+iter1SA standalone
+mul=0
+mul=0
+iter1par standalone
+mul=0
+mul=0
+class1SA standalone
+mul=0
+mul=0
+class1par standalone
+mul=0
+mul=0


### PR DESCRIPTION
Add futures for #12323 and #12325 - related to foralls and promotion.

While there, make the compiler USR_STOP in one place when it is about to fail with an INT_ASSERT. This would otherwise happen for `classes-implicit-borrow-promo-1arg.chpl` .

Aside: our `diff-ignoring-module-line-numbers` script does not smoothen out the INT_ASSERT line number when it happens in `implementForallIntents2.chpl` because the file name contains a digit. To fix, we need to edit the corresponding line in the script to say this, for example:
```
s/internal error: \([A-Z][A-Z2\-]*\)-[0-9][0-9]* chpl version mmmm/internal error: \1-nnnn chpl version mmmm/
```
