### PR TITLE
Make stdout, stderr ordering predictable for most launchers

### DIFF
--- a/runtime/src/launch/slurm-gasnetrun_ibv/launch-slurm-gasnetrun_ibv.c
+++ b/runtime/src/launch/slurm-gasnetrun_ibv/launch-slurm-gasnetrun_ibv.c
@@ -180,6 +180,7 @@ static char* chpl_launch_create_command(int argc, char* argv[],
   char* projectString = getenv(launcherAccountEnvvar);
   char* constraint = getenv("CHPL_LAUNCHER_CONSTRAINT");
   char* outputfn = getenv("CHPL_LAUNCHER_SLURM_OUTPUT_FILENAME");
+  char* errorfn = getenv("CHPL_LAUNCHER_SLURM_ERROR_FILENAME");
   char* basenamePtr = strrchr(argv[0], '/');
   char* nodeAccessEnv = NULL;
   pid_t mypid;
@@ -238,10 +239,13 @@ static char* chpl_launch_create_command(int argc, char* argv[],
     if (projectString && strlen(projectString) > 0)
       fprintf(slurmFile, "#SBATCH -A %s\n", projectString);
 
-    if (outputfn!=NULL) 
+    if (outputfn != NULL)
       fprintf(slurmFile, "#SBATCH -o %s\n", outputfn);
     else
       fprintf(slurmFile, "#SBATCH -o %s.%%j.out\n", argv[0]);
+
+    if (errorfn != NULL)
+      fprintf(slurmFile, "#SBATCH -e %s\n", errorfn);
 
     fprintf(slurmFile, "%s/%s/gasnetrun_ibv -n %d -N %d",
             CHPL_THIRD_PARTY, WRAP_TO_STR(LAUNCH_PATH), numLocales, numLocales);

--- a/runtime/src/launch/slurm-srun/launch-slurm-srun.c
+++ b/runtime/src/launch/slurm-srun/launch-slurm-srun.c
@@ -143,6 +143,7 @@ static char* chpl_launch_create_command(int argc, char* argv[],
   char* account = getenv("CHPL_LAUNCHER_ACCOUNT");
   char* constraint = getenv("CHPL_LAUNCHER_CONSTRAINT");
   char* outputfn = getenv("CHPL_LAUNCHER_SLURM_OUTPUT_FILENAME");
+  char* errorfn = getenv("CHPL_LAUNCHER_SLURM_ERROR_FILENAME");
   char* nodeAccessEnv = getenv("CHPL_LAUNCHER_NODE_ACCESS");
   const char* nodeAccessStr = NULL;
 
@@ -172,7 +173,6 @@ static char* chpl_launch_create_command(int argc, char* argv[],
   const char* tmpDir    = getTmpDir();
   char stdoutFile         [MAX_COM_LEN];
   char stdoutFileNoFmt    [MAX_COM_LEN];
-  char tmpStdoutFile      [MAX_COM_LEN];
   char tmpStdoutFileNoFmt [MAX_COM_LEN];
 
   // command line walltime takes precedence over env var
@@ -302,10 +302,13 @@ static char* chpl_launch_create_command(int argc, char* argv[],
     // We only redirect the program output to the tmp file
     fprintf(slurmFile, "#SBATCH --output=%s\n", stdoutFile);
 
+    if (errorfn != NULL) {
+      fprintf(slurmFile, "#SBATCH --error=%s\n", errorfn);
+    }
+
     // If we're buffering the output, set the temp output file name.
     // It's always <tmpDir>/binaryName.<jobID>.out.
     if (bufferStdout != NULL) {
-      sprintf(tmpStdoutFile,      "%s/%s.%s.out", tmpDir, argv[0], "%j");
       sprintf(tmpStdoutFileNoFmt, "%s/%s.%s.out", tmpDir, argv[0], "$SLURM_JOB_ID");
     }
 
@@ -318,9 +321,9 @@ static char* chpl_launch_create_command(int argc, char* argv[],
       fprintf(slurmFile, "'%s' ", argv[i]);
     }
 
-    // buffer program output to the tmp stdout file
+    // buffer stdout to the tmp stdout file
     if (bufferStdout != NULL) {
-      fprintf(slurmFile, "&> %s", tmpStdoutFileNoFmt);
+      fprintf(slurmFile, "> %s", tmpStdoutFileNoFmt);
     }
     fprintf(slurmFile, "\n");
 

--- a/test/runtime/configMatters/comm/ugni/overflow-nic-tlb.cray-xc.good
+++ b/test/runtime/configMatters/comm/ugni/overflow-nic-tlb.cray-xc.good
@@ -1,3 +1,3 @@
+Hello, world.
 warning: Aries TLB cache can cover 1G with 2M pages; with SIZE heap,
          cache refills may reduce performance
-Hello, world.

--- a/test/runtime/configMatters/comm/ugni/overflow-nic-tlb.cray-xe.good
+++ b/test/runtime/configMatters/comm/ugni/overflow-nic-tlb.cray-xe.good
@@ -1,2 +1,2 @@
-warning: Gemini TLB can cover 2G with 128K pages; heap reduced to SIZE to fit
 Hello, world.
+warning: Gemini TLB can cover 2G with 128K pages; heap reduced to SIZE to fit

--- a/util/test/chpl_launchcmd.py
+++ b/util/test/chpl_launchcmd.py
@@ -19,13 +19,12 @@ The high level overview of what this does:
    file designated by the script.
  * Polls qstat/squeue with the given job id every second until the status is
    complete.
- * Prints the contents of the temp file with stdout/stderr from the job to
-   stdout.
+ * Prints the contents of the temp files with stdout/stderr from the job to
+   stdout/stderr.
  * Cleans up the temp file and exits.
-
 """
 
-from __future__ import print_function, unicode_literals, with_statement
+from __future__ import unicode_literals, with_statement
 
 import argparse
 import contextlib
@@ -56,7 +55,9 @@ __all__ = ('main')
 def main():
     """Run the program!"""
     job = AbstractJob.init_from_environment()
-    print(job.run(), end='')
+    (stdout, stderr) = job.run()
+    sys.stdout.write(stdout)
+    sys.stderr.write(stderr)
 
 
 class AbstractJob(object):
@@ -87,7 +88,7 @@ class AbstractJob(object):
     processing_elems_per_node_resource = None
 
     # redirect_output decides whether we redirect output directly to the output
-    # file or whether we let the launcher and queueing system do it.
+    # files or whether we let the launcher and queueing system do it.
     redirect_output = None
 
     def __init__(self, test_command, reservation_args):
@@ -113,12 +114,18 @@ class AbstractJob(object):
                               ['test_command', 'num_locales', 'walltime', 'hostlist']))
         return '{0}({1})'.format(cls_name, attrs)
 
-    def full_test_command(self, output_file):
+    def full_test_command(self, output_file, error_file):
         """Returns instance's test_command prefixed with command to change to
         testing_dir. This is required to support both PBSPro and moab flavors
         of PBS. Whereas moab provides a -d argument when calling qsub, both
-        support the $PBS_O_WORKDIR argument. This also adds stdout/stderr
-        redirection directly to the output file to avoid using a spool file.
+        support the $PBS_O_WORKDIR argument. Optionally, this can redirect
+        stdout/stderr directly to the output files to avoid using a spool file.
+
+        :type output_file: str
+        :arg output_file: stdout output file location
+
+        :type error_file: str
+        :arg error_file: stderr output file location
 
         :rtype: list
         :returns: command to run in qsub with changedir call and redirection
@@ -137,7 +144,7 @@ class AbstractJob(object):
 
         full_test_command.extend(self.test_command)
         if self.redirect_output:
-            full_test_command.extend(['&>{0}'.format(output_file)])
+            full_test_command.extend(['>{0} 2>{1}'.format(output_file, error_file)])
         return full_test_command
 
     @property
@@ -208,39 +215,45 @@ class AbstractJob(object):
         """
         return chpl_cpu.get('target').cpu == 'mic-knl'
 
-    def _qsub_command_base(self, output_file):
+    def _qsub_command_base(self, output_file, error_file):
         """Returns base qsub command, without any resource listing.
 
         :type output_file: str
-        :arg output_file: combined stdout/stderr output file location
+        :arg output_file: stdout output file location
+
+        :type error_file: str
+        :arg error_file: stderr output file location
 
         :rtype: list
         :returns: qsub command as list of strings
         """
         submit_command =  [self.submit_bin, '-V', '-N', self.job_name]
         if not self.redirect_output:
-            submit_command.extend(['-j', 'oe', '-o', output_file])
+            submit_command.extend(['-o', output_file, '-e', error_file])
         else:
-            # even when redirecting output, PBS errors are sent to the e/o
-            # streams, so make sure we can find errors if they occur
-            submit_command.extend(['-j', 'oe', '-o', '{0}.more'.format(output_file)])
+            # even when redirecting output, PBS errors are sent to the error
+            # stream, so make sure we can find errors if they occur
+            submit_command.extend(['-j', 'oe', '-o', '{0}.more'.format(error_file)])
         if self.walltime is not None:
             submit_command.append('-l')
             submit_command.append('walltime={0}'.format(self.walltime))
 
         return submit_command
 
-    def _qsub_command(self, output_file):
+    def _qsub_command(self, output_file, error_file):
         """Returns qsub command list. This implementation is the default that works for
         standard mpp* options. Subclasses can implement versions that meet their needs.
 
         :type output_file: str
-        :arg output_file: combined stdout/stderr output file location
+        :arg output_file: stdout output file location
+
+        :type error_file: str
+        :arg error_file: stderr output file location
 
         :rtype: list
         :returns: qsub command as list of strings
         """
-        submit_command = self._qsub_command_base(output_file)
+        submit_command = self._qsub_command_base(output_file, error_file)
 
         if self.num_locales >= 0:
             submit_command.append('-l')
@@ -276,10 +289,11 @@ class AbstractJob(object):
         """
         with _temp_dir() as working_dir:
             output_file = os.path.join(working_dir, 'test_output.log')
+            error_file = os.path.join(working_dir, 'test_error_output.log')
             input_file = os.path.join(working_dir, 'test_input')
             testing_dir = os.getcwd()
 
-            job_id = self.submit_job(testing_dir, output_file, input_file)
+            job_id = self.submit_job(testing_dir, output_file, error_file, input_file)
             logging.info('Test has been queued (job id: {0}). Waiting for output...'.format(job_id))
 
             # TODO: The while condition here should look for jobs that become held,
@@ -366,27 +380,34 @@ class AbstractJob(object):
             with open(output_file, 'r') as fp:
                 output = fp.read()
 
+            logging.debug('Reading error file.')
+            with open(error_file, 'r') as fp:
+                error = fp.read()
+
             try:
-                with open('{0}.more'.format(output_file), 'r') as fp:
-                    output += fp.read()
+                with open('{0}.more'.format(error_file), 'r') as fp:
+                    error += fp.read()
             except:
                 pass
 
             logging.info('The test finished with output of length {0}.'.format(len(output)))
 
-        return output
+        return (output, error)
 
-    def submit_job(self, testing_dir, output_file, input_file):
-        """Submit a new job using ``testing_dir`` as the working dir and
-        ``output_file`` as the location for the output. Returns the job id on
-        success. AbstractJob does not implement this method. It is the
-        responsibility of the sub class.
+    def submit_job(self, testing_dir, output_file, error_file, input_file):
+        """Submit a new job using ``testing_dir`` as the working dir,
+        ``output_file`` as the location for stdout, and ``error_file`` as the
+        location for stderr. Returns the job id on success. AbstractJob does
+        not implement this method. It is the responsibility of the sub class.
 
         :type testing_dir: str
         :arg testing_dir: working directory for running test
 
         :type output_file: str
-        :arg output_file: output log filename
+        :arg output_file: stdout log filename
+
+        :type error_file: str
+        :arg error_file: stderr log filename
 
         :rtype: str
         :returns: job id
@@ -453,7 +474,7 @@ class AbstractJob(object):
         else:  # not (qsub_callable or srun_callable)
             raise RuntimeError('Could not find PBS or SLURM on system.')
 
-    def _launch_qsub(self, testing_dir, output_file):
+    def _launch_qsub(self, testing_dir, output_file, error_file):
         """Launch job using qsub and return job id. Raises RuntimeError if
         self.submit_bin is anything but qsub.
 
@@ -461,7 +482,10 @@ class AbstractJob(object):
         :arg testing_dir: working directory for running test
 
         :type output_file: str
-        :arg output_file: output log filename
+        :arg output_file: stdout log filename
+
+        :type error_file: str
+        :arg error_file: stderr log filename
 
         :rtype: str
         :returns: job id
@@ -477,7 +501,7 @@ class AbstractJob(object):
 
         logging.debug('Opening {0} subprocess.'.format(self.submit_bin))
         submit_proc = subprocess.Popen(
-            self._qsub_command(output_file),
+            self._qsub_command(output_file, error_file),
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
@@ -485,7 +509,7 @@ class AbstractJob(object):
             env=os.environ.copy()
         )
 
-        test_command_str = ' '.join(self.full_test_command(output_file))
+        test_command_str = ' '.join(self.full_test_command(output_file, error_file))
         logging.debug('Communicating with {0} subprocess. Sending test command on stdin: {1}'.format(
             self.submit_bin, test_command_str))
         stdout, stderr = submit_proc.communicate(input=test_command_str)
@@ -742,19 +766,22 @@ class MoabJob(AbstractJob):
             logging.error('XML output: {0}'.format(output))
             raise
 
-    def submit_job(self, testing_dir, output_file, input_file):
+    def submit_job(self, testing_dir, output_file, error_file, input_file):
         """Launch job using qsub and return job id.
 
         :type testing_dir: str
         :arg testing_dir: working directory for running test
 
         :type output_file: str
-        :arg output_file: output log filename
+        :arg output_file: stdout log filename
+
+        :type error_file: str
+        :arg error_file: stderr log filename
 
         :rtype: str
         :returns: job id
         """
-        return self._launch_qsub(testing_dir, output_file)
+        return self._launch_qsub(testing_dir, output_file, error_file)
 
 
 class PbsProJob(AbstractJob):
@@ -829,17 +856,20 @@ class PbsProJob(AbstractJob):
             raise ValueError('Could not find {0} pattern in header line: {1}'.format(
                 pattern.pattern, header_line))
 
-    def _qsub_command(self, output_file):
+    def _qsub_command(self, output_file, error_file):
         """Returns qsub command list using select/place syntax for resource
         lists (as opposed to the deprecated and often disabled mpp* options).
 
         :type output_file: str
-        :arg output_file: combined stdout/stderr output file location
+        :arg output_file: stdout output file location
+
+        :type error_file: str
+        :arg error_file: stderr output file location
 
         :rtype: list
         :returns: qsub command as list of strings
         """
-        submit_command = self._qsub_command_base(output_file)
+        submit_command = self._qsub_command_base(output_file, error_file)
         select_stmt = None
 
         # Always use place=scatter to get 1 PE per node (mostly). Equivalent
@@ -872,19 +902,22 @@ class PbsProJob(AbstractJob):
         logging.debug('qsub command: {0}'.format(submit_command))
         return submit_command
 
-    def submit_job(self, testing_dir, output_file, input_file):
+    def submit_job(self, testing_dir, output_file, error_file, input_file):
         """Launch job using qsub and return job id.
 
         :type testing_dir: str
         :arg testing_dir: working directory for running test
 
         :type output_file: str
-        :arg output_file: output log filename
+        :arg output_file: stdout log filename
+
+        :type error_file: str
+        :arg error_file: stderr log filename
 
         :rtype: str
         :returns: job id
         """
-        return self._launch_qsub(testing_dir, output_file)
+        return self._launch_qsub(testing_dir, output_file, error_file)
 
 
 class MppPbsProJob(PbsProJob):
@@ -898,8 +931,8 @@ class MppPbsProJob(PbsProJob):
     processing_elems_per_node_resource = 'mppnppn'
     redirect_output = False
 
-    def _qsub_command(self, output_file):
-        return AbstractJob._qsub_command(self, output_file)
+    def _qsub_command(self, output_file, error_file):
+        return AbstractJob._qsub_command(self, output_file, error_file)
 
 class SlurmJob(AbstractJob):
     """SLURM implementation of abstract job runner."""
@@ -969,7 +1002,7 @@ class SlurmJob(AbstractJob):
         else:
             raise ValueError('Could not parse output from squeue: {0}'.format(stdout))
 
-    def submit_job(self, testing_dir, output_file, input_file):
+    def submit_job(self, testing_dir, output_file, error_file, input_file):
         """Launch job using executable. Set CHPL_LAUNCHER_USE_SBATCH=true in
         environment to avoid using expect script. The executable will create a
         sbatch script and submit it. Parse and return the job id after job is
@@ -979,7 +1012,10 @@ class SlurmJob(AbstractJob):
         :arg testing_dir: working directory for running test
 
         :type output_file: str
-        :arg output_file: output log filename
+        :arg output_file: stdout log filename
+
+        :type error_file: str
+        :arg error_file: stderr log filename
 
         :rtype: str
         :returns: job id
@@ -987,6 +1023,7 @@ class SlurmJob(AbstractJob):
         env = os.environ.copy()
         env['CHPL_LAUNCHER_USE_SBATCH'] = 'true'
         env['CHPL_LAUNCHER_SLURM_OUTPUT_FILENAME'] = output_file
+        env['CHPL_LAUNCHER_SLURM_ERROR_FILENAME'] = error_file
 
         if select.select([sys.stdin,],[],[],0.0)[0]: 
             with open(input_file, 'w') as fp:


### PR DESCRIPTION
In #12236 we updated sub_test to not merge stderr into stdout so we
could get predictable ordering for by always having stderr follow stdout
in our testing infrastructure. While this worked for CHPL_LAUNCHER=none
and some launchers it did not work for qsub or slurm based launchers
where stderr was still being merged into stdout.

Here we update chpl_launchcmd and our slurm launchers to split stderr
and stdout. This adds support to the slurm launchers to redirect stderr
to a file. For chpl_launchcmd the major change is to redirect stderr to
a file either with the slurm env var or with manual redirecting for
qsub, the rest of the changes are just piping error_file through the
classes.

Closes https://github.com/chapel-lang/chapel/issues/12259

Testing:
 - [x] examples+runtime/configMatters on XC slurm w/ and w/o launchcmd
 - [x] examples+runtime/configMatters on CS slurm w/ and w/o launchcmd
 - [x] examples+runtime/configMatters on XC qsub w/ launchcmd
 - [x] examples+runtime/configMatters on XE qsub w/ launchcmd
 - [x] verified we still recognize timeouts on qsub systems