### PR TITLE
Make throw someBorrowedError an error and not a warning

### DIFF
--- a/modules/internal/ChapelError.chpl
+++ b/modules/internal/ChapelError.chpl
@@ -362,7 +362,7 @@ module ChapelError {
   pragma "always propagate line file info"
   // TODO -- deprecate this version
   proc chpl_fix_thrown_error(err: borrowed Error): unmanaged Error {
-    compilerWarning("Throwing borrowed error - please throw owned", 1);
+    compilerError("Throwing borrowed error - please throw owned", 1);
 
     return chpl_do_fix_thrown_error(_to_unmanaged(err));
   }

--- a/test/deprecated/throw-borrowed.chpl
+++ b/test/deprecated/throw-borrowed.chpl
@@ -1,9 +1,12 @@
 // the warning emitted for throwing a borrow
 // should be changed to an error after 1.19.
 
+// the test throw-new-undecorated.chpl already
+// covers this case and should be updated once
+// it is changed to an error.
+
 proc test() throws {
-  var x = new borrowed Error();
-  throw x;
+  throw new Error();
 }
 
 try! test();

--- a/test/deprecated/throw-borrowed.good
+++ b/test/deprecated/throw-borrowed.good
@@ -1,2 +1,5 @@
 throw-borrowed.chpl:8: In function 'test':
 throw-borrowed.chpl:9: warning: Throwing unmanaged error - please throw owned
+uncaught Error: 
+  throw-borrowed.chpl:9: thrown here
+  throw-borrowed.chpl:12: uncaught here

--- a/test/deprecated/throw-borrowed.good
+++ b/test/deprecated/throw-borrowed.good
@@ -1,2 +1,2 @@
-throw-borrowed.chpl:4: In function 'test':
-throw-borrowed.chpl:6: warning: Throwing borrowed error - please throw owned
+throw-borrowed.chpl:8: In function 'test':
+throw-borrowed.chpl:9: warning: Throwing unmanaged error - please throw owned

--- a/test/errhandling/ferguson/double-throw-single-object.good
+++ b/test/errhandling/ferguson/double-throw-single-object.good
@@ -1,2 +1,2 @@
 double-throw-single-object.chpl:1: In function 'main':
-double-throw-single-object.chpl:5: warning: Throwing borrowed error - please throw owned
+double-throw-single-object.chpl:5: error: Throwing borrowed error - please throw owned

--- a/test/errhandling/ferguson/throw-new-borrowed.chpl
+++ b/test/errhandling/ferguson/throw-new-borrowed.chpl
@@ -1,0 +1,3 @@
+proc main() throws {
+  throw new borrowed Error();
+}

--- a/test/errhandling/ferguson/throw-new-borrowed.good
+++ b/test/errhandling/ferguson/throw-new-borrowed.good
@@ -1,0 +1,2 @@
+throw-new-borrowed.chpl:1: In function 'main':
+throw-new-borrowed.chpl:2: error: Throwing borrowed error - please throw owned

--- a/test/errhandling/ferguson/throw-new-borrowed2.chpl
+++ b/test/errhandling/ferguson/throw-new-borrowed2.chpl
@@ -1,0 +1,4 @@
+proc main() throws {
+  var x = new Error(); // aka new borrowed Error
+  throw x;
+}

--- a/test/errhandling/ferguson/throw-new-borrowed2.good
+++ b/test/errhandling/ferguson/throw-new-borrowed2.good
@@ -1,0 +1,7 @@
+throw-new-borrowed2.chpl:1: In function 'main':
+throw-new-borrowed2.chpl:2: warning: result of new Error is now managed by default
+throw-new-borrowed2.chpl:2: note: 'new unmanaged Error' gives old behavior
+throw-new-borrowed2.chpl:2: note: 'new borrowed Error' is the new default
+throw-new-borrowed2.chpl:2: note: 'new owned Error', 'new shared Error' also available
+throw-new-borrowed2.chpl:2: note: get more help with --warn-unstable
+throw-new-borrowed2.chpl:3: error: Throwing borrowed error - please throw owned

--- a/test/errhandling/ferguson/throw-new-undecorated.chpl
+++ b/test/errhandling/ferguson/throw-new-undecorated.chpl
@@ -1,0 +1,3 @@
+proc main() throws {
+  throw new Error();
+}

--- a/test/errhandling/ferguson/throw-new-undecorated.good
+++ b/test/errhandling/ferguson/throw-new-undecorated.good
@@ -1,0 +1,5 @@
+throw-new-undecorated.chpl:1: In function 'main':
+throw-new-undecorated.chpl:2: warning: Throwing unmanaged error - please throw owned
+uncaught Error: 
+  throw-new-undecorated.chpl:2: thrown here
+  throw-new-undecorated.chpl:1: uncaught here


### PR DESCRIPTION
This PR changes the compilation warning for throwing
a borrowed error into an compilation error.
That is OK for 1.19 because the pattern
``` chapel
  throw new SomeError();
```
actually ends up throwing an unmanaged error and therefore
still gives a compilation warning.

A pattern like
``` chapel
  var x = new SomeError(); // aka new borrowed SomeError()
  throw x;
```
would lead to memory errors if it compiled (both in 1.18 or presently).
So, it makes sense for this case to lead to a compilation error.

Related to #10297 and a follow-on to PR #12090.

- [x] full local testing

Reviewed by @lydia-duncan - thanks!