### PR TITLE
Use seed for choiceTests

### DIFF
--- a/test/library/standard/Random/choiceTest.chpl
+++ b/test/library/standard/Random/choiceTest.chpl
@@ -3,9 +3,9 @@ use Random;
 config const debug = false;
 
 proc main() {
-  var pcg = makeRandomStream(real, algorithm=RNG.PCG);
+  var pcg = makeRandomStream(real, algorithm=RNG.PCG, seed=42);
   runTests(pcg);
-  var pcgInt = makeRandomStream(int, algorithm=RNG.PCG);
+  var pcgInt = makeRandomStream(int, algorithm=RNG.PCG, seed=420);
   runTests(pcgInt);
 }
 


### PR DESCRIPTION
Since the redesign of `choice()` to be a method on random streams, it makes sense to use a seed to avoid chance of a sporadic failure altogether.