### PR TITLE
Un-suppress two tests that now pass under --llvm

### DIFF
--- a/test/functions/iterators/diten/yieldNothingIterator.suppressif
+++ b/test/functions/iterators/diten/yieldNothingIterator.suppressif
@@ -1,7 +1,0 @@
-# Known LLVM issue with yield-nothing iterators
-#
-# This is a known issue with the interface to the LLVM back end not
-# being able to handle iterators that yield nothing.  See github issue
-# #6338.  Suppress this for now.
-
-CHPL_LLVM!=none

--- a/test/functions/vass/proc-iter/error-no-yield-in-iter-1.suppressif
+++ b/test/functions/vass/proc-iter/error-no-yield-in-iter-1.suppressif
@@ -1,7 +1,0 @@
-# Known LLVM issue with yield-nothing iterators
-#
-# This is a known issue with the interface to the LLVM back end not
-# being able to handle iterators that yield nothing.  See github issue
-# #6338.  Suppress this for now.
-
-CHPL_LLVM!=none


### PR DESCRIPTION
Closes #6338

Recent compiler changes allow these tests to pass under --llvm where before they did not.