### PR TITLE
Minor fixes to UgniPerfStats module

### DIFF
--- a/modules/packages/UgniPerfStats.chpl
+++ b/modules/packages/UgniPerfStats.chpl
@@ -44,11 +44,10 @@ module UgniPerfStats {
 
   /* Zero performance counters on all locales */
   proc resetStats() {
-    var nonHereLocales = {0..numLocales-1}.remove(here.id);
-    coforall locid in nonHereLocales do on Locales[locid] {
-      resetCommPerfstatsHere();
+    for loc in Locales do on loc {
+      resetStatsHere();
     }
-    resetCommPerfstatsHere();
+    resetStatsHere();
   }
 
   /* Print stats on the current locale. By default it prints only the local
@@ -70,7 +69,7 @@ module UgniPerfStats {
    */
   proc printStats() {
     for loc in Locales do on loc {
-      printCommPerfstatsHere(false);
+      printStatsHere(false);
     }
   }
 }

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -8399,6 +8399,7 @@ static void _psv_print(int li, chpl_comm_pstats_t* ps)
   else
     printf("comm perfstats on locale %d (%.*s)\n", li,
            (int) buf_cnt - 2, buf);
+  fflush(stdout);
 
 #undef _PSV_PRINT
 }


### PR DESCRIPTION
Fix `resetStats` and `printStats` to call the right functions (I was only
testing with the `*StatsHere` variants and missed updating the calls.)

Also add a flush to ugni stats printing so `printStats` output shows up
in locale order.