### PR TITLE
Clean up a couple of old futures

### DIFF
--- a/test/functions/vass/return-type-function-failure.future
+++ b/test/functions/vass/return-type-function-failure.future
@@ -1,8 +1,0 @@
-bug: compiler internal error
-
-Right now I am getting:
-
-return-type-function-failure.chpl:4: In function 'valfun':
-return-type-function-failure.chpl:4: error: Cannot call insertBefore on Expr not in a list [expr.cpp:125]
-
-The compiler should emit an user error instead.

--- a/test/functions/vass/return-type-function-failure.good
+++ b/test/functions/vass/return-type-function-failure.good
@@ -1,1 +1,2 @@
-return-type-function-failure.chpl:4: error: cannot use a function as a type, unless it is an invocation of a type function
+return-type-function-failure.chpl:4: In function 'valfun':
+return-type-function-failure.chpl:5: error: invalid type specification

--- a/test/trivial/vass/type-fun-as-type-error-message.bad
+++ b/test/trivial/vass/type-fun-as-type-error-message.bad
@@ -1,0 +1,1 @@
+type-fun-as-type-error-message.chpl:2: error: invalid type specification

--- a/test/trivial/vass/val-fun-as-type-error-message.bad
+++ b/test/trivial/vass/val-fun-as-type-error-message.bad
@@ -1,0 +1,1 @@
+val-fun-as-type-error-message.chpl:2: error: invalid type specification


### PR DESCRIPTION
* `test/functions/vass/return-type-function-failure.chpl`

  - No longer fails. Defuturized.
  - There is a proposal to improve the compiler error message in this case:
     test/trivial/vass/val-fun-as-type-error-message.chpl

* `test/trivial/vass/type-fun-as-type-error-message.chpl`
` test/trivial/vass/val-fun-as-type-error-message.chpl`

  - Added .bad files.

Trivial.
