### PR TITLE
Add comm=ofi large AM capability.

### DIFF
--- a/runtime/include/comm/ofi/chpl-comm-task-decls.h
+++ b/runtime/include/comm/ofi/chpl-comm-task-decls.h
@@ -65,6 +65,16 @@ struct chpl_comm_bundleData_execOn_t {
   chpl_comm_amDone_t* pDone;    // initiator's 'done' flag; nonblocking if NULL
 };
 
+struct chpl_comm_bundleData_execOnLrg_t {
+  struct chpl_comm_bundleData_base_t b;
+  chpl_fn_int_t fid;            // function table index to call
+  uint32_t argSize;             // #bytes in whole arg bundle
+  void* arg;                    // address of arg, on initiator
+  c_sublocid_t subloc;          // target sublocale
+  chpl_comm_amDone_t gotArg;    // initiator's 'got large arg' flag
+  chpl_comm_amDone_t* pDone;    // initiator's 'done' flag; nonblocking if NULL
+};
+
 struct chpl_comm_bundleData_RMA_t {
   struct chpl_comm_bundleData_base_t b;
   void* addr;                   // address on AM target node
@@ -98,6 +108,7 @@ struct chpl_comm_bundleData_AMO_t {
 typedef union {
   struct chpl_comm_bundleData_base_t b;
   struct chpl_comm_bundleData_execOn_t xo;
+  struct chpl_comm_bundleData_execOnLrg_t xol;
   struct chpl_comm_bundleData_RMA_t rma;
   struct chpl_comm_bundleData_AMO_t amo;
 } chpl_comm_bundleData_t;

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -129,7 +129,7 @@ typedef struct memEntry (memTab_t)[MAX_MEM_REGIONS];
 static memTab_t memTab;
 static memTab_t* memTabMap;
 
-#define AM_MAX_MSG_SIZE (10 * 10240) // TODO: safe (?), but awfully large
+#define AM_MAX_MSG_SIZE (sizeof(chpl_comm_on_bundle_t) + 1024)
 
 static int numAmHandlers = 1;
 
@@ -1205,7 +1205,8 @@ int mrGetLocalKey(uint64_t* pKey, void* addr, size_t size) {
 
 typedef enum {
   am_opNil = 0,                         // no-op
-  am_opCall,                            // call a function table function
+  am_opExecOn,                          // call a function table function
+  am_opExecOnLrg,                       // call fn tab fn, arg large/separate
   am_opGet,                             // do an RMA GET
   am_opPut,                             // do an RMA PUT
   am_opAMO,                             // do an AMO
@@ -1324,16 +1325,42 @@ void amRequestExecOn(c_nodeid_t node, c_sublocid_t subloc,
                      chpl_fn_int_t fid,
                      chpl_comm_on_bundle_t* arg, size_t argSize,
                      chpl_bool fast, chpl_bool blocking) {
-  CHK_TRUE(argSize <= AM_MAX_MSG_SIZE);
-  arg->comm.xo = (struct chpl_comm_bundleData_execOn_t)
-                   { .b = (struct chpl_comm_bundleData_base_t)
-                          { .op = am_opCall, .node = chpl_nodeID },
-                     .fast = fast,
-                     .fid = fid,
-                     .argSize = argSize,
-                     .subloc = subloc,
-                     .pDone = NULL };
-  amRequestCommon(node, arg, argSize, blocking ? &arg->comm.xo.pDone : NULL);
+  CHK_TRUE(!(fast && !blocking)); // handler doesn't expect fast nonblocking
+  if (argSize <= AM_MAX_MSG_SIZE) {
+    arg->comm.xo = (struct chpl_comm_bundleData_execOn_t)
+                     { .b = (struct chpl_comm_bundleData_base_t)
+                            { .op = am_opExecOn, .node = chpl_nodeID },
+                       .fast = fast,
+                       .fid = fid,
+                       .argSize = argSize,
+                       .subloc = subloc,
+                       .pDone = NULL };
+    amRequestCommon(node, arg, argSize,
+                    blocking ? &arg->comm.xo.pDone : NULL);
+  } else {
+    arg->comm.xol = (struct chpl_comm_bundleData_execOnLrg_t)
+                      { .b = (struct chpl_comm_bundleData_base_t)
+                             { .op = am_opExecOnLrg, .node = chpl_nodeID },
+                        .fid = fid,
+                        .argSize = argSize,
+                        .arg = arg,
+                        .subloc = subloc,
+                        .gotArg = 0,
+                        .pDone = NULL };
+    chpl_atomic_thread_fence(memory_order_release);
+    amRequestCommon(node, arg, sizeof(*arg),
+                    blocking ? &arg->comm.xol.pDone : NULL);
+    if (!blocking) {
+      //
+      // Even if non-blocking, we cannot return until after the target
+      // node has retrieved the argument from us.
+      //
+      while (!*(volatile chpl_comm_amDone_t*) &arg->comm.xol.gotArg) {
+        local_yield();
+        chpl_comm_make_progress();
+      }
+    }
+  }
 }
 
 
@@ -1512,10 +1539,11 @@ static pthread_mutex_t amStartStopMutex = PTHREAD_MUTEX_INITIALIZER;
 static void amHandler(void*);
 static void processRxAmReq(struct perTxCtxInfo_t*);
 static void amHandleExecOn(chpl_comm_on_bundle_t*);
-static void amExecOnWrapper(void*);
-static inline void realExecOnWrapper(void*, chpl_bool);
-static void amGetWrapper(void*);
-static void amPutWrapper(void*);
+static inline void amWrapExecOnBody(void*);
+static void amHandleExecOnLrg(chpl_comm_on_bundle_t*);
+static void amWrapExecOnLrgBody(void*);
+static void amWrapGet(void*);
+static void amWrapPut(void*);
 static void amHandleAMO(chpl_comm_on_bundle_t*);
 static void amSendDone(c_nodeid_t, chpl_comm_amDone_t*);
 
@@ -1680,12 +1708,16 @@ void processRxAmReq(struct perTxCtxInfo_t* tcip) {
 #endif
 
         switch (req->comm.b.op) {
-        case am_opCall:
+        case am_opExecOn:
           if (req->comm.xo.fast) {
-            realExecOnWrapper(req, false);
+            amWrapExecOnBody(req);
           } else {
             amHandleExecOn(req);
           }
+          break;
+
+        case am_opExecOnLrg:
+          amHandleExecOnLrg(req);
           break;
 
         case am_opGet:
@@ -1697,8 +1729,8 @@ void processRxAmReq(struct perTxCtxInfo_t* tcip) {
           // had completed.
           //
           DBG_PRINTF(DBG_AM | DBG_AMRECV,
-                     "AM req startMovedTask(amGetWrapper())");
-          chpl_task_startMovedTask(FID_NONE, (chpl_fn_p) amGetWrapper,
+                     "AM req startMovedTask(amWrapGet())");
+          chpl_task_startMovedTask(FID_NONE, (chpl_fn_p) amWrapGet,
                                    chpl_comm_on_bundle_task_bundle(req),
                                    sizeof(*req), c_sublocid_any,
                                    chpl_nullTaskID);
@@ -1713,8 +1745,8 @@ void processRxAmReq(struct perTxCtxInfo_t* tcip) {
           // had completed.
           //
           DBG_PRINTF(DBG_AM | DBG_AMRECV,
-                     "AM req startMovedTask(amPutWrapper())");
-          chpl_task_startMovedTask(FID_NONE, (chpl_fn_p) amPutWrapper,
+                     "AM req startMovedTask(amWrapPut())");
+          chpl_task_startMovedTask(FID_NONE, (chpl_fn_p) amWrapPut,
                                    chpl_comm_on_bundle_task_bundle(req),
                                    sizeof(*req), c_sublocid_any,
                                    chpl_nullTaskID);
@@ -1750,46 +1782,112 @@ static
 void amHandleExecOn(chpl_comm_on_bundle_t* req) {
   struct chpl_comm_bundleData_execOn_t* xo = &req->comm.xo;
   DBG_PRINTF(DBG_AM | DBG_AMRECV,
-             "amHandleExecOn() for node %d: ftable[%d]",
-             (int) xo->b.node, (int) xo->fid);
-  chpl_comm_on_bundle_t* reqCopy;
-  CHPL_CALLOC_SZ(reqCopy, 1, xo->argSize);
-  chpl_memcpy(reqCopy, req, xo->argSize);
-  chpl_task_startMovedTask(xo->fid, (chpl_fn_p) amExecOnWrapper,
-                           chpl_comm_on_bundle_task_bundle(reqCopy),
+             "amHandleExecOn() seqId %d:%" PRIu64,
+             (int) xo->b.node, xo->b.seq);
+
+  //
+  // We only need a wrapper if we have to send a 'done' indicator back.
+  //
+  chpl_fn_p fn = ((xo->pDone == NULL)
+                  ? chpl_ftable[xo->fid]
+                  : (chpl_fn_p) amWrapExecOnBody);
+  chpl_task_startMovedTask(xo->fid, fn, chpl_comm_on_bundle_task_bundle(req),
                            xo->argSize, xo->subloc, chpl_nullTaskID);
 }
 
 
-static
-void amExecOnWrapper(void* p) {
-  realExecOnWrapper(p, false);
-}
-
-
 static inline
-void realExecOnWrapper(void* p, chpl_bool fast) {
+void amWrapExecOnBody(void* p) {
   chpl_comm_on_bundle_t* req = (chpl_comm_on_bundle_t*) p;
   struct chpl_comm_bundleData_execOn_t* xo = &req->comm.xo;
 
   DBG_PRINTF(DBG_AM | DBG_AMRECV,
-             "execOnWrap: seqId %d:%" PRIu64 ", %schpl_ftable_call(%d, %p)",
-             req->comm.b.node, req->comm.b.seq,
-             (fast ? "fast " : ""), (int) xo->fid, p);
+             "amWrapExecOnBody(%p): "
+             "seqId %d:%" PRIu64 ", %schpl_ftable_call(%d, %p)",
+             p, xo->b.node, xo->b.seq,
+             (xo->fast ? "fast " : ""), (int) xo->fid, p);
   chpl_ftable_call(xo->fid, p);
-  if (xo->pDone != NULL) {
-    amSendDone(xo->b.node, xo->pDone);
-  }
+  amSendDone(xo->b.node, xo->pDone);
 }
 
 
 static
-void amGetWrapper(void* p) {
+void amHandleExecOnLrg(chpl_comm_on_bundle_t* req) {
+  struct chpl_comm_bundleData_execOnLrg_t* xol = &req->comm.xol;
+  DBG_PRINTF(DBG_AM | DBG_AMRECV,
+             "amHandleExecOnLrg() seqId %d:%" PRIu64,
+             (int) xol->b.node, xol->b.seq);
+
+  chpl_task_startMovedTask(xol->fid, (chpl_fn_p) amWrapExecOnLrgBody,
+                           chpl_comm_on_bundle_task_bundle(req),
+                           xol->argSize, xol->subloc, chpl_nullTaskID);
+}
+
+
+static
+void amWrapExecOnLrgBody(void* p) {
+  chpl_comm_on_bundle_t* req = (chpl_comm_on_bundle_t*) p;
+  struct chpl_comm_bundleData_execOnLrg_t* xol = &req->comm.xol;
+  c_nodeid_t node = xol->b.node;
+
+  DBG_PRINTF(DBG_AM | DBG_AMRECV,
+             "amWrapExecOnLrgBody: "
+             "seqId %d:%" PRIu64 ", chpl_ftable_call(%d, %p)",
+             node, xol->b.seq, (int) xol->fid, p);
+
+  //
+  // Create space for the full bundle and fill in the header part from
+  // what we've already received.  Retrieve the remainder, that is, the
+  // args proper, from the initiating node.  Iff this is a nonblocking
+  // executeOn, tell the initiator we've done so, because they cannot
+  // proceed until they know we have the bundle.  This prevents them
+  // freeing it before we've retrieved it.  For blocking executeOn we
+  // don't have to say we have the bundle, because the initiator won't
+  // proceed until the entire executeOn is complete anyway.
+  //
+  chpl_comm_on_bundle_t* reqCopy;
+  CHPL_CALLOC_SZ(reqCopy, 1, xol->argSize);
+  chpl_memcpy(reqCopy, req, xol->argSize);
+  req = reqCopy;
+  xol = &req->comm.xol;
+
+  chpl_comm_on_bundle_t* reqOnOrig = (chpl_comm_on_bundle_t*) xol->arg;
+  size_t remnantSize = xol->argSize - sizeof(*req);
+  CHK_TRUE(mrGetKey(NULL, node, &reqOnOrig[1], remnantSize) == 0);
+  (void) ofi_get(&req[1], node, &reqOnOrig[1], remnantSize);
+
+  if (xol->pDone == NULL) {
+    static __thread chpl_comm_amDone_t* myGotArg = NULL;
+    if (myGotArg == NULL) {
+      myGotArg = allocBounceBuf(1);
+      CHK_TRUE(mrGetLocalDesc(NULL, myGotArg, 1) == 0);
+      *myGotArg = 1;
+    }
+
+    chpl_comm_amDone_t* origGotArg = &reqOnOrig->comm.xol.gotArg;
+    CHK_TRUE(mrGetKey(NULL, node, origGotArg, sizeof(*origGotArg)) == 0);
+    (void) ofi_put(myGotArg, node, origGotArg, sizeof(*origGotArg));
+  }
+
+  //
+  // Now we can finally call the body function.
+  //
+  chpl_ftable_call(xol->fid, req);
+  if (xol->pDone != NULL) {
+    amSendDone(node, xol->pDone);
+  }
+
+  CHPL_FREE(req);
+}
+
+
+static
+void amWrapGet(void* p) {
   chpl_comm_on_bundle_t* req = (chpl_comm_on_bundle_t*) p;
   struct chpl_comm_bundleData_RMA_t* rma = &req->comm.rma;
 
   DBG_PRINTF(DBG_AM | DBG_AMRECV,
-             "amGetWrapper(): %p <-- %d:%p (%zd bytes)",
+             "amWrapGet(): %p <-- %d:%p (%zd bytes)",
              rma->addr, (int) rma->b.node, rma->raddr, rma->size);
   CHK_TRUE(mrGetKey(NULL, rma->b.node, rma->raddr, rma->size) == 0); // sanity
   (void) ofi_get(rma->addr, rma->b.node, rma->raddr, rma->size);
@@ -1799,12 +1897,12 @@ void amGetWrapper(void* p) {
 
 
 static
-void amPutWrapper(void* p) {
+void amWrapPut(void* p) {
   chpl_comm_on_bundle_t* req = (chpl_comm_on_bundle_t*) p;
   struct chpl_comm_bundleData_RMA_t* rma = &req->comm.rma;
 
   DBG_PRINTF(DBG_AM | DBG_AMRECV,
-             "amPutWrapper() %d:%p <-- %p (%zd bytes)",
+             "amWrapPut() %d:%p <-- %p (%zd bytes)",
              (int) rma->b.node, rma->raddr, rma->addr, rma->size);
   CHK_TRUE(mrGetKey(NULL, rma->b.node, rma->raddr, rma->size) == 0); // sanity
   (void) ofi_put(rma->addr, rma->b.node, rma->raddr, rma->size);


### PR DESCRIPTION
As originally coded, comm=ofi was limited to doing AMs for which the
entire request would fit into a (fairly large) maximum.  But there is no
inherent limit on the size of a request passed in to the comm layer, and
the target-side received request buffers must be of fixed size, so we
also need to be able to support so-called "large" AMs, where only the
header is sent in the initial request, and the target side retrieves the
rest of the arguments using a GET.  Here, implement such large AMs and,
having done so, reduce the size of a non-large AM to 1kb plus the size
of the header.  We have previously established that our AMs tend to run
in the 500-800 byte range, so even with this reduction the majority of
them can still be done with just a single transaction.

This resolves #12311.