### PR TITLE
Support older versions of fish for setchplenv*.fish

### DIFF
--- a/util/config/fixpath.py
+++ b/util/config/fixpath.py
@@ -7,7 +7,7 @@
 Example:
 
     ./fixpath.py "$PATH"
-    ./fixpath.py \\\\"$PATH\\\\" --shell=fish
+    ./fixpath.py \\" $PATH \\" --shell=fish
 
 This is used by the setchplenv.* scripts to reduce PATH/MANPATH pollution. It
 may be called in several situations:
@@ -57,12 +57,12 @@ def remove_chpl_from_path(path_val, delim):
     if not chpl_home or chpl_home not in path_val:
         return path_val
 
-    # Find ':'s that are not escaped
-    # Note: Fish shell still uses ':' delimiter for printing with \\"$PATH\\"
-    pattern = r'(?<!\\)\:'
+    # Find delims that are not escaped
+    pattern = r'(?<!\\)\{0}'.format(delim)
 
-    # Split path by non-escaped ':'s, and sieve chpl_home
-    newpath = [escape_path(p, delim) for p in re.split(pattern, path_val)]
+    # Split path by non-escaped delims, and sieve chpl_home
+    # Fish input includes hanging quotation marks, so we drop those here
+    newpath = [escape_path(p, delim) for p in re.split(pattern, path_val) if p != '"']
     newpath = [p for p in newpath if chpl_home not in p]
 
     return delim.join(newpath)
@@ -85,7 +85,7 @@ def main():
         parser.print_help()
         sys.exit(1)
 
-    path = args[0]
+    path = delim.join(args)
 
     newpath = remove_chpl_from_path(path, delim)
     sys.stdout.write('{0}'.format(newpath))

--- a/util/quickstart/setchplenv.fish
+++ b/util/quickstart/setchplenv.fish
@@ -14,9 +14,9 @@ if [ ! -d "$chpl_home/util" -o ! -d "$chpl_home/compiler" -o ! -d "$chpl_home/ru
 end
 
 # Remove any previously existing CHPL_HOME paths
-eval set MYPATH (eval "$chpl_home/util/config/fixpath.py \"$PATH\" \"--shell=fish\"")
+eval set MYPATH (eval "$chpl_home/util/config/fixpath.py \" $PATH \" \"--shell=fish\"")
 set exitcode $status
-eval set MYMANPATH (eval "$chpl_home/util/config/fixpath.py \"$MANPATH\" \"--shell=fish\"")
+eval set MYMANPATH (eval "$chpl_home/util/config/fixpath.py \" $MANPATH \" \"--shell=fish\"")
 
 # Double check $MYPATH before overwriting $PATH
 if [ (count $MYPATH) = 0 -o ! $exitcode = 0 ]

--- a/util/setchplenv.fish
+++ b/util/setchplenv.fish
@@ -14,9 +14,9 @@ if [ ! -d "$chpl_home/util" -o ! -d "$chpl_home/compiler" -o ! -d "$chpl_home/ru
 end
 
 # Remove any previously existing CHPL_HOME paths
-eval set MYPATH (eval "$chpl_home/util/config/fixpath.py \"$PATH\" \"--shell=fish\"")
+eval set MYPATH (eval "$chpl_home/util/config/fixpath.py \" $PATH \" \"--shell=fish\"")
 set exitcode $status
-eval set MYMANPATH (eval "$chpl_home/util/config/fixpath.py \"$MANPATH\" \"--shell=fish\"")
+eval set MYMANPATH (eval "$chpl_home/util/config/fixpath.py \" $MANPATH \" \"--shell=fish\"")
 
 # Double check $MYPATH before overwriting $PATH
 if [ (count $MYPATH) = 0 -o ! $exitcode = 0 ]


### PR DESCRIPTION
Updates how paths are passed to fixpath for fish to support older versions of fish.

fish 2.* and 3.* differ in how they print: `\"$PATH\"`

fish 2 would print with space-delimiters and fish 3 would print with
colon-delimiters.

We were relying on this output in the new fixpath.py interface, but it
led to failures on systems with older version of fish. We now rely on
the output of:` \" $PATH \"` to support both fish versions.

- [x] Tested all shells
- [x] Tested with `fish 3.0`
- [x] Tested with `fish 2.7`