### PR TITLE
LinearAlgebra: Improve array checks & keep module usage internal

### DIFF
--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -186,8 +186,9 @@ are supported through submodules, such ``LinearAlgebra.Sparse`` for the
 module LinearAlgebra {
 
 use Norm; // TODO -- merge Norm into LinearAlgebra
-use BLAS;
-use LAPACK;
+use BLAS only;
+use LAPACK only;
+use LAPACK only lapack_memory_order, isLAPACKType;
 
 /* Determines if using native Chapel implementations */
 private param usingBLAS = BLAS.header != '';
@@ -604,7 +605,7 @@ private proc matMult(A: [?Adom] ?eltType, B: [?Bdom] eltType) {
 pragma "no doc"
 /* matrix-vector multiplication */
 private proc _matvecMult(A: [?Adom] ?eltType, X: [?Xdom] eltType, trans=false)
-  where isBLASType(eltType) && usingBLAS
+  where BLAS.isBLASType(eltType) && usingBLAS
 {
   if Adom.rank != 2 || Xdom.rank != 1 then
     compilerError("Rank sizes are not 2 and 1");
@@ -632,7 +633,7 @@ private proc _matvecMult(A: [?Adom] ?eltType, X: [?Xdom] eltType, trans=false)
 pragma "no doc"
 /* matrix-matrix multiplication */
 private proc _matmatMult(A: [?Adom] ?eltType, B: [?Bdom] eltType)
-  where isBLASType(eltType) && usingBLAS
+  where BLAS.isBLASType(eltType) && usingBLAS
 {
   if Adom.rank != 2 || Bdom.rank != 2 then
     compilerError("Rank sizes are not 2");
@@ -671,7 +672,7 @@ proc outer(A: [?Adom] ?eltType, B: [?Bdom] eltType) {
 pragma "no doc"
 /* Generic matrix-vector multiplication. */
 proc _matvecMult(A: [?Adom] ?eltType, X: [?Xdom] eltType, trans=false)
-  where !usingBLAS || !isBLASType(eltType)
+  where !usingBLAS || !BLAS.isBLASType(eltType)
 {
   if Adom.rank != 2 || Xdom.rank != 1 then
     compilerError("Rank sizes are not 2 and 1");
@@ -701,7 +702,7 @@ proc _matvecMult(A: [?Adom] ?eltType, X: [?Xdom] eltType, trans=false)
 pragma "no doc"
 /* Generic matrix-matrix multiplication */
 proc _matmatMult(A: [?Adom] ?eltType, B: [?Bdom] eltType)
-  where !usingBLAS || !isBLASType(eltType)
+  where !usingBLAS || !BLAS.isBLASType(eltType)
 {
   if Adom.rank != 2 || Bdom.rank != 2 then
     compilerError("Rank sizes are not 2 and 2");

--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -1363,16 +1363,22 @@ proc kron(A: [?ADom] ?eltType, B: [?BDom] eltType) {
 // Type helpers
 //
 
+// TODO: Add this to public interface eventually
+pragma "no doc"
 /* Returns ``true`` if the array is dense N-dimensional non-distributed array. */
 proc isDenseArr(A: [?D]) param : bool {
   return isDenseDom(D);
 }
 
+// TODO: Add this to public interface eventually
+pragma "no doc"
 /* Returns ``true`` if the domain is dense N-dimensional non-distributed domain. */
 proc isDenseDom(D: domain) param : bool {
   return isRectangularDom(D) && (D.dist.type == defaultDist.type || D.dist.type < ArrayViewRankChangeDist);
 }
 
+// TODO: Add this to public interface eventually
+pragma "no doc"
 /* Returns ``true`` if the array is dense 2-dimensional non-distributed array. */
 proc isDenseMatrix(A: []) param : bool {
   return A.rank == 2 && isDenseArr(A);

--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -1378,6 +1378,8 @@ proc isDenseMatrix(A: []) param : bool {
   return A.rank == 2 && isDenseArr(A);
 }
 
+// Work-around for #8543
+pragma "no doc"
 proc type _array.rank param {
   var x: this;
   return x.rank;

--- a/test/library/packages/LinearAlgebra/correctness/no-dependencies/correctness.chpl
+++ b/test/library/packages/LinearAlgebra/correctness/no-dependencies/correctness.chpl
@@ -345,6 +345,17 @@ use TestUtils;
   assertEqual(dot(v13, v31), S, "dot(Matrix(1, 3), Matrix(3, 1))");
 }
 
+/* dot - rank-change slice */
+{
+  var M = Matrix(3, 3);
+  M = 1;
+
+  var slice = M[1..3, 1];
+
+  var result = dot(slice, slice);
+  assertEqual(result, 3, 'dot(M[1..3, 1], M[1..3, 1])');
+}
+
 /* outer */
 {
   var v = Vector(3);


### PR DESCRIPTION
- Improved array checks within LinearAlgebra library to check that array is not distributed, and allow for rank change slices.
- Switch BLAS/LAPACK usage to `use <module> only;` to prevent exposing BLAS/LAPACK to user code when using LinearAlgebra.

Eventually, we'd like for the `isMatrix` and `isVector` checks to be part of a public interface, but these should undergo a proper design review before then, so they are remaining undocumented for now.


Closes #11913