### PR TITLE
Clean up recursive-iterator code for ForallStmt

### DIFF
--- a/compiler/AST/foralls.cpp
+++ b/compiler/AST/foralls.cpp
@@ -231,6 +231,8 @@ static QualifiedType fsIterYieldType(ForallStmt* fs, FnSymbol* iterFn) {
       USR_PRINT(iterFn, "the corresponding iterator is here");
       USR_PRINT(iterFn, "try declaring its return type");
       USR_STOP();
+      QualifiedType dummy(dtUnknown);
+      return dummy;
     }
 
   } else {

--- a/compiler/AST/foralls.cpp
+++ b/compiler/AST/foralls.cpp
@@ -215,137 +215,37 @@ enum ParIterFlavor {
   PIF_LEADER
 };
 
-/////////// fsIterYieldType ///////////
+/////////// helpers ///////////
 
-static QualifiedType fsIterYieldType(ForallStmt* fs, FnSymbol* iterFn,
-                                     FnSymbol* origIterFn,
-                                     bool alreadyResolved);
+// Given an iterator or forwarder function, find the type that it yields.
+static QualifiedType fsIterYieldType(ForallStmt* fs, FnSymbol* iterFn) {
+  INT_ASSERT(iterFn->isResolved());
 
-/*
-When we are dealing with a recursive parallel iterator, we call
-fsIterYieldType() while resolving it. At that time, IteratorInfo
-has not been created yet. Also the yield type is not yet available
-anywhere, because it is the type of a tuple of the original return type
-plus one component per shadow variable.
-
-Ex. standalone iter walkdirs() in FileSystem module, as tested by:
-  test/library/standard/FileSystem/filerator/bradc/findfiles-par.chpl
-
-Therefore we compute this extended yield type manually.
-*/
-static QualifiedType buildIterYieldType(ForallStmt* fs, FnSymbol* iterFn, FnSymbol* origIterFn) {
-  if (fs->numShadowVars() == 0) {
-    // The iterator has not undergone extendLeader().
-    // It still yields whatever the user wrote.
-    // Its return symbol is still in tact.
-
-    QualifiedType result(iterFn->getReturnSymbol()->type);
-    // What is the right qualifier?
-    return result;
-  }
-
-  // Otherwise, build the tuple mocking what iterFn yields, supposedly.
-  CallExpr* constup = new CallExpr("_type_construct__tuple");
-
-  // Yield type must have been declared by user for recursive iterator,
-  // and the function that declaration is attached to is origIterFn.
-  bool alreadyResolved = origIterFn->isResolved();
-  QualifiedType origQt = fsIterYieldType(fs, origIterFn, NULL, alreadyResolved);
-  Type* origYieldedType = origQt.type();
-
-  INT_ASSERT(origYieldedType && origYieldedType != dtUnknown);
-  constup->insertAtTail(origYieldedType->symbol);
-
-  // The other tuple components are refs to shadow variables,
-  // so their types come from respective outer variables.
-  for_shadow_vars(svar, temp, fs) {
-    Symbol* ovar = NULL;
-    switch (svar->intent) {
-      case TFI_DEFAULT:
-      case TFI_CONST:
-      case TFI_IN_PARENT:
-      case TFI_IN:
-      case TFI_CONST_IN:
-      case TFI_REF:
-      case TFI_CONST_REF:
-        ovar = svar->outerVarSym();
-        break;
-
-      case TFI_REDUCE:
-        // ... except for reduce intents - they are TODO.
-        USR_FATAL_CONT(svar, "Reduce intents are currently not implemented"
-          " for forall- or for-loops over recursive parallel iterators");
-        USR_PRINT(iterFn, "the parallel iterator is here");
-        USR_STOP();
-        break;
-
-      case TFI_REDUCE_OP:
-      case TFI_REDUCE_PARENT_AS:
-      case TFI_REDUCE_PARENT_OP:
-        // The error should have been issued above upon TFI_REDUCE.
-        break;
-
-      case TFI_TASK_PRIVATE:
-        // task-private variables are TODO too.
-        USR_FATAL_CONT(svar,
-          "Task-private variables are currently not implemented"
-          " for forall- or for-loops over recursive parallel iterators");
-        USR_PRINT(iterFn, "the parallel iterator is here");
-        USR_STOP();
-        break;
-    }
-    INT_ASSERT(ovar != NULL);
-    INT_ASSERT(ovar->type != dtUnknown);
-
-    constup->insertAtTail(ovar->type->getRefType()->symbol);
-  }
-
-  int numComponents = constup->numActuals();
-  constup->insertAtHead(new_IntSymbol(numComponents));
-
-  // Resolve it now.
-  fs->insertBefore(constup);
-  resolveCall(constup);
-  constup->remove();
-
-  // What is the right qualifier?
-  QualifiedType result(constup->qualType().type());
-  return result;
-}
-
-//
-// Given an iterator function, find the type that it yields.
-// It would be fn->retType, alas protoIteratorClass() messes with that.
-// This helper is ForallStmt-specific because of the assumptions it makes.
-//
-static QualifiedType fsIterYieldType(ForallStmt* fs, FnSymbol* iterFn,
-                                     FnSymbol* origIterFn,
-                                     bool alreadyResolved)
-{
   if (iterFn->isIterator()) {
     if (IteratorInfo* ii = iterFn->iteratorInfo) {
       return ii->getValue->getReturnQualType();
     } else {
       // We are in the midst of resolving a recursive iterator.
-      INT_ASSERT(alreadyResolved);
-      return buildIterYieldType(fs, iterFn, origIterFn);
+      USR_FATAL_CONT(fs, "the recursion pattern seen in the first iterable"
+                         " in this forall loop is not supported");
+      USR_PRINT(iterFn, "the corresponding iterator is here");
+      USR_PRINT(iterFn, "try declaring its return type");
+      USR_STOP();
     }
+
   } else {
-    // e.g. "proc these() return _value.these();"
+    // An iterator forwarder, ex. "proc these() return _value.these();"
     AggregateType* retType = toAggregateType(iterFn->retType);
     INT_ASSERT(retType && retType->symbol->hasFlag(FLAG_ITERATOR_RECORD));
     FnSymbol* iterator = retType->iteratorInfo->iterator;
-    INT_ASSERT(iterator->isIterator()); // no more recursion?
-    return fsIterYieldType(fs, iterator, origIterFn, alreadyResolved);
+    INT_ASSERT(iterator->isIterator()); // 'iterator' is from an IteratorInfo
+    return fsIterYieldType(fs, iterator);
   }
 }
-
-/////////// helpers ///////////
 
 static bool isIteratorRecord(Symbol* sym) {
   return sym->type->symbol->hasFlag(FLAG_ITERATOR_RECORD);
 }
-
 
 static bool acceptUnmodifiedIterCall(ForallStmt* pfs, CallExpr* iterCall)
 {
@@ -818,15 +718,8 @@ static void resolveParallelIteratorAndIdxVar(ForallStmt* pfs,
                                              FnSymbol* origIterator,
                                              bool gotSA)
 {
-  // The par iterator probably has been extendLeader()-ed for forall intents.
-  FnSymbol* parIter = iterCall->resolvedFunction();
-  bool alreadyResolved = parIter->isResolved();
-
-  resolveFunction(parIter);
-
   // Set QualifiedType of the index variable.
-  QualifiedType iType = fsIterYieldType(pfs, parIter,
-                                        origIterator, alreadyResolved);
+  QualifiedType iType = fsIterYieldType(pfs, iterCall->resolvedFunction());
 
   VarSymbol* idxVar = parIdxVar(pfs);
   if (idxVar->id == breakOnResolveID) gdbShouldBreakHere();

--- a/test/functions/iterators/recursive/recursive-leader-errr.chpl
+++ b/test/functions/iterators/recursive/recursive-leader-errr.chpl
@@ -1,0 +1,46 @@
+// Like recursive-leader-good.chpl, except no declared return type.
+
+var firstTime = true;
+
+proc main {
+  [ idx in zip(asdf()) ]
+    writeln(idx);
+}
+
+iter asdf() {
+  writeln("asdf serial");
+  yield 555;
+}
+iter asdf(param tag) {
+  if firstTime {
+    writeln("asdf ldr/sa firstTime {");
+    firstTime = false;
+    forall xdi in zip(asdf(),jjj()) {
+      writeln("  asdf 1w: ", xdi);
+    }
+    forall xdi in zip(asdf(),jjj()) {
+      writeln("  asdf 1y: ", xdi);
+      yield xdi(1)+xdi(2);
+    }
+    writeln("  asdf 1z: 661");
+    yield 661;
+    writeln("asdf ldr/sa firstTime }");
+  } else {
+    writeln("asdf ldr/sa start");
+    yield 666;
+    writeln("asdf ldr/sa finish");
+  }
+}
+iter asdf(param tag, followThis) {
+  writeln("asdf follower ", followThis);
+  yield 777;
+}
+
+iter jjj() {
+  writeln("jjj serial");
+  yield 322;
+}
+iter jjj(param tag, followThis) {
+  writeln("jjj follower ", followThis);
+  yield 223;
+}

--- a/test/functions/iterators/recursive/recursive-leader-errr.good
+++ b/test/functions/iterators/recursive/recursive-leader-errr.good
@@ -1,0 +1,4 @@
+recursive-leader-errr.chpl:14: In iterator 'asdf':
+recursive-leader-errr.chpl:18: error: the recursion pattern seen in the first iterable in this forall loop is not supported
+recursive-leader-errr.chpl:14: note: the corresponding iterator is here
+recursive-leader-errr.chpl:14: note: try declaring its return type

--- a/test/functions/iterators/recursive/recursive-leader-good.chpl
+++ b/test/functions/iterators/recursive/recursive-leader-good.chpl
@@ -1,0 +1,46 @@
+// Leader recurses into itself.
+
+var firstTime = true;
+
+proc main {
+  [ idx in zip(asdf()) ]
+    writeln(idx);
+}
+
+iter asdf() {
+  writeln("asdf serial");
+  yield 555;
+}
+iter asdf(param tag):int {
+  if firstTime {
+    writeln("asdf ldr/sa firstTime {");
+    firstTime = false;
+    forall xdi in zip(asdf(),jjj()) {
+      writeln("  asdf 1w: ", xdi);
+    }
+    forall xdi in zip(asdf(),jjj()) {
+      writeln("  asdf 1y: ", xdi);
+      yield xdi(1)+xdi(2);
+    }
+    writeln("  asdf 1z: 661");
+    yield 661;
+    writeln("asdf ldr/sa firstTime }");
+  } else {
+    writeln("asdf ldr/sa start");
+    yield 666;
+    writeln("asdf ldr/sa finish");
+  }
+}
+iter asdf(param tag, followThis) {
+  writeln("asdf follower ", followThis);
+  yield 777;
+}
+
+iter jjj() {
+  writeln("jjj serial");
+  yield 322;
+}
+iter jjj(param tag, followThis) {
+  writeln("jjj follower ", followThis);
+  yield 223;
+}

--- a/test/functions/iterators/recursive/recursive-leader-good.good
+++ b/test/functions/iterators/recursive/recursive-leader-good.good
@@ -1,0 +1,17 @@
+asdf ldr/sa firstTime {
+asdf ldr/sa start
+asdf follower 666
+jjj follower 666
+  asdf 1w: (777, 223)
+asdf ldr/sa finish
+asdf ldr/sa start
+asdf follower 666
+jjj follower 666
+  asdf 1y: (777, 223)
+asdf follower 1000
+777
+asdf ldr/sa finish
+  asdf 1z: 661
+asdf follower 661
+777
+asdf ldr/sa firstTime }


### PR DESCRIPTION
* Remove code used by old implementForallIntents.

* Replace an INT_ASSERT with USR_FATAL("currently not implemented")
to handle recursion in leader iterators.

* Add a test of a recursive leader that illustrates that error
and its modification that dodges it.