### PR TITLE
 Apply 'local field' pragma automatically to arrays in classes

### DIFF
--- a/compiler/passes/insertWideReferences.cpp
+++ b/compiler/passes/insertWideReferences.cpp
@@ -2417,12 +2417,33 @@ insertWideReferences(void) {
   buildWideRefMap();
 
   //
-  // change arrays of classes into arrays of wide classes
+  // 1) change arrays of classes into arrays of wide classes
+  // 2) apply 'local field' pragmas to arrays in classes
   //
   forv_Vec(TypeSymbol, ts, gTypeSymbols) {
     if (ts->hasFlag(FLAG_DATA_CLASS)) {
       if (Type* nt = wideClassMap.get(getDataClassType(ts)->type)) {
         setDataClassType(ts, nt->symbol);
+      }
+
+    // Do not apply to records, for now, because IWR cannot identify RVF'd
+    // records. If the 'local field' flag was applied to an array inside an
+    // RVF'd record, then IWR could incorrectly localize the array field when
+    // accessed because it thinks the record is local.
+    } else if (isClass(ts->type)) {
+      AggregateType* at = toAggregateType(ts->type);
+
+      const char* prefix = "_class_locals";
+      bool isArgBundle = strncmp(at->symbol->name, prefix, strlen(prefix)) == 0;
+      if (isArgBundle == false &&
+          at->symbol->hasFlag(FLAG_ITERATOR_CLASS) == false &&
+          at->symbol->hasFlag(FLAG_REF) == false) {
+        for_fields(field, at) {
+          if (field->typeInfo()->symbol->hasFlag(FLAG_ARRAY) &&
+              field->isRef() == false) {
+            field->addFlag(FLAG_LOCAL_FIELD);
+          }
+        }
       }
     }
   }

--- a/test/optimizations/widepointers/arrayInClasses.bad
+++ b/test/optimizations/widepointers/arrayInClasses.bad
@@ -1,3 +1,7 @@
+----- simple class -----
+class is wide: false
+array is wide: false
+----- array of classes -----
 class is wide: true
 array is wide: true
 1 1 1 1 1 1 1 1 1 1

--- a/test/optimizations/widepointers/arrayInClasses.chpl
+++ b/test/optimizations/widepointers/arrayInClasses.chpl
@@ -3,25 +3,34 @@ class Chunk {
   var data : [1..10] int;
 }
 
-proc main() {
-  // This test exists to measure a pattern where a user has manually chunked
-  // their computation into a class per locale, which contains arrays. When we
-  // know that the class is local, we do not want wide pointer overhead when
-  // using those arrays.
-  //
-  // Sometimes the arrays in such classes might need to be accessed remotely
-  // (e.g. exchanging array elements on edge of stencil computation). The
-  // compiler should make the static type of such arrays a wide pointer, but
-  // through optimizations should be able to localize that pointer when
-  // appropriate.
-  //
-  // This block exists to ensure that the static type of the 'data' array is
-  // a wide pointer for this test.
-  {
-    var c = new unmanaged Chunk();
-    on Locales[numLocales-1] do c.data[1] = 5;
-    delete c;
-  }
+// This test exists to measure a pattern where a user has manually chunked
+// their computation into a class per locale, which contains arrays. When we
+// know that the class is local, we do not want wide pointer overhead when
+// using those arrays.
+//
+// Sometimes the arrays in such classes might need to be accessed remotely
+// (e.g. exchanging array elements on edge of stencil computation). The
+// compiler should make the static type of such arrays a wide pointer, but
+// through optimizations should be able to localize that pointer when
+// appropriate.
+//
+// This block exists to ensure that the static type of the 'data' array is
+// a wide pointer for this test.
+{
+  var c = new unmanaged Chunk();
+  on Locales[numLocales-1] do c.data[1] = 5;
+  delete c;
+}
+
+proc testSimpleClass() {
+  writeln("----- simple class -----");
+  var c = new unmanaged Chunk();
+  writeln("class is wide: ", __primitive("is wide pointer", c));
+  writeln("array is wide: ", __primitive("is wide pointer", c.data._value.shiftedData));
+}
+
+proc testArrayOfClasses() {
+  writeln("----- array of classes -----");
 
   var chunks : [0..#numLocales] unmanaged Chunk;
 
@@ -39,4 +48,9 @@ proc main() {
   for c in chunks do writeln(c.data);
 
   delete chunks;
+}
+
+proc main() {
+  testSimpleClass();
+  testArrayOfClasses();
 }

--- a/test/optimizations/widepointers/arrayInClasses.good
+++ b/test/optimizations/widepointers/arrayInClasses.good
@@ -1,3 +1,7 @@
+----- simple class -----
+class is wide: false
+array is wide: false
+----- array of classes -----
 class is wide: false
 array is wide: false
 1 1 1 1 1 1 1 1 1 1


### PR DESCRIPTION
This PR automatically applies the 'local field' pragma to arrays in classes. This is valid because the array's _instance is always allocated on the same locale as the class.

Testing:
- [x] gasnet