### PR TITLE
Add 'vector' type as package

### DIFF
--- a/modules/packages/Vector.chpl
+++ b/modules/packages/Vector.chpl
@@ -1,0 +1,303 @@
+/*
+ * Copyright 2004-2019 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// TODO:
+// Design discussions:
+// - when removing, should the removed element be deinitialized?
+// - when shuffling elements around (during resize, or insertion) should we
+//   use PRIM_MOVE or assignment?
+// - how should error handling be used?
+// - name of type (e.g. 'list' vs. 'vector')
+// - use 'uint' as idxType?
+// - support slicing?
+//
+// Implementation:
+// - parallel safety
+// - lifetime clauses (encountered internal compiler error)
+// - shrink memory allocation
+// - support 'readThis'
+
+record vector {
+  type eltType;
+
+  var _dom : domain(1);
+  var _data : [_dom] eltType;
+  var _live : range = 1..0; // represents 'live' indices in '_dom'
+
+  proc init(type eltType) {
+    this.eltType = eltType;
+  }
+
+  proc init(data : [] ?T) {
+    this.eltType = T;
+    this.complete();
+    for d in data do push_back(d);
+  }
+
+  proc init(vec : vector(?T)) {
+    this.eltType = T;
+    this.complete();
+    for v in vec do push_back(v);
+  }
+
+  proc init(type eltType, capacity : integral) {
+    this.eltType = eltType;
+    this.complete();
+    this.requestCapacity(capacity);
+  }
+
+  proc chpl__promotionType() type return eltType;
+
+  inline proc size return _live.size;
+  inline proc isEmpty() : bool return _live.size == 0;
+
+  proc front() : eltType {
+    if isEmpty() then halt("front() called on empty vector");
+    return _data[_live.first];
+  }
+  proc back() : eltType {
+    if isEmpty() then halt("back() called on empty vector");
+    return _data[_live.last];
+  }
+
+  pragma "no doc"
+  proc reserveSpace(count : integral, backward : bool) {
+    if count <= 0 then halt("vector.reserveSpace called with value <= 0");
+    
+    if backward {
+      if this._live.last + count <= _dom.last then
+        return;
+    } else if this._live.first - count >= _dom.first then
+      return;
+
+    const newSize = max(_dom.size + 1, _dom.size * 1.2, _live.size + count):int;
+
+    if backward then
+      _dom = {_dom.first..#newSize};
+    else
+      _dom = {.._dom.last # -newSize};
+  }
+
+  proc push_back(in val: eltType) {
+    reserveSpace(1, true);
+    this._data[this._live.last+1] = val;
+    this._live = this._live.first..(this._live.last+1);
+  }
+
+  // TODO: allow varargs
+  // TODO: where isIterable(T)
+  proc push_back(values : ?T)
+  where isArray(T) || T == vector(eltType) {
+    reserveSpace(values.size, true);
+    const newSpace = (this._live.last + 1)..#values.size;
+    for (i, v) in zip(newSpace, values) do
+      _data[i] = v;
+    this._live = this._live.first..newSpace.last;
+  }
+
+  proc pop_back() : eltType {
+    if isEmpty() then halt("pop_back() called on empty vector");
+    this._live = this._live.first.._live.last-1;
+    return _data[_live.last + 1];
+  }
+
+  proc push_front(in val : eltType) {
+    reserveSpace(1, false);
+    _data[_live.first-1] = val;
+    _live = (_live.first-1).._live.last;
+  }
+  proc push_front(values : ?T)
+  where isArray(T) || T == vector(eltType) {
+    reserveSpace(values.size, false);
+    const newSpace = ..(this._live.first-1) # -values.size;
+    for (i, v) in zip(newSpace, values) do
+      _data[i] = v;
+    _live = newSpace.first.._live.last;
+  }
+
+  proc pop_front() : eltType {
+    if isEmpty() then halt("pop_front() called on empty vector");
+    _live = (_live.first + 1).._live.last;
+    return _data[_live.first - 1];
+  }
+
+  proc insert(idx : _dom.idxType, in val : eltType) {
+    if isEmpty() && idx == 0 {
+      push_back(val);
+      return;
+    } else if idx == this.size {
+      push_back(val);
+      return;
+    } else if idx < 0 || idx > this.size then
+      halt("vector.insert called with invalid index '" + idx:string + "' which must be in range '" + (0..this.size):string + "'");
+
+    reserveSpace(1, true);
+    const li = _live.first + idx;
+    for i in li.._live.last by -1 do
+      _data[i+1] = _data[i];
+    _live = _live.first.._live.last+1;
+    _data[li] = val;
+  }
+  proc insert(idx : _dom.idxType, values : ?T)
+  where isArray(T) || T == vector(eltType) {
+    if isEmpty() {
+      if idx != 0 then halt("calling 'insert' on empty vector only accepts '0' as a valid index");
+      push_back(values);
+      return;
+    } else if idx == this.size {
+      push_back(values);
+      return;
+    } else if idx < 0 || idx > this.size then
+      halt("vector.insert called with invalid index '" + idx:string + "' which must be in range '" + (0..this.size):string + "'");
+
+    reserveSpace(values.size, true);
+    const li = _live.first + idx;
+    for i in li.._live.last by -1 do
+      _data[i+values.size] = _data[i];
+    _live = _live.first.._live.last+values.size;
+    for (i, val) in zip(li..#values.size, values) {
+      _data[i] = val;
+    }
+  }
+
+  // TODO: Should these return something?
+  proc remove(idx : _dom.idxType) {
+    if isEmpty() then halt("cannot remove elements from an empty vector");
+    else if idx < 0 || idx >= this.size then
+      halt("vector.insert called with invalid index '" + idx:string + "' which must be in range '" + (0..#this.size):string + "'");
+    // TODO: shrink memory allocation
+    if idx != _live.last {
+      const li = _live.first + idx;
+      for i in li+1.._live.last do
+        _data[i-1] = _data[i];
+    }
+    _live = _live.first.._live.last-1;
+  }
+
+  // Supports strided and unbounded ranges
+  proc remove(rng : range(_dom.idxType, ?, ?)) {
+    const translated = _live.first + rng;
+    const actual = _live[translated]; // slice in case of unbounded rng
+    if rng.boundedType != BoundedRangeType.bounded {
+      if rng.boundedType == BoundedRangeType.boundedLow &&
+         (rng.first < 0 || rng.first >= this.size) then
+        halt("vector.remove called with invalid lower-bounded range: bound must be within '" + (0..#this.size):string + "'");
+      else if rng.boundedType == BoundedRangeType.boundedHigh &&
+        (rng.last < 0 || rng.last >= this.size) then
+        halt("vector.remove called with invalid upper-bounded range: bound must be within '" + (0..#this.size):string + "'");
+      else if actual.size == 0 then
+        halt("vector.remove called with invalid unbounded range");
+    } else if rng.size == 0 || actual.size != rng.size then
+      halt("vector.remove called with invalid range: must be within '" + (0..#this.size):string + "'");
+
+    if actual == _live {
+      clear();
+      return;
+    }
+
+    if actual.stridable == false || actual.stride == 1 {
+      for i in actual.last+1.._live.last do
+        _data[i-actual.size] = _data[i];
+    } else {
+      var cur = actual.first;
+      for i in actual {
+        for j in _live[i+1..#actual.stride-1] {
+          _data[cur] = _data[j];
+          cur += 1;
+        }
+      }
+    }
+    _live = _live.first..#(_live.size-actual.size);
+  }
+
+  proc reverse() {
+    for i in 0..#(_live.size/2) {
+      var temp = _data[_live.first+i];
+      _data[_live.first+i] = _data[_live.last-i];
+      _data[_live.last-i] = temp;
+    }
+  }
+
+  proc clear() {
+    _live = 1..0;
+  }
+
+  proc find(val : eltType) : (bool, _dom.idxType) {
+    for i in _live do
+      if _data[i] == val then return (true, i-_live.first);
+    
+    return (false, 0);
+  }
+
+  proc this(idx : _dom.idxType) ref : eltType {
+    if boundsChecking && (idx < 0 || idx >= this.size) then
+      halt("out of bounds: ", idx);
+    return _data[_live.first + idx];
+  }
+  proc this(idx : _dom.idxType) const ref : eltType
+  where shouldReturnRvalueByConstRef(eltType) {
+    if boundsChecking && (idx < 0 || idx >= this.size) then
+      halt("out of bounds");
+    return _data[_live.first + idx];
+  }
+  proc this(idx : _dom.idxType) : eltType
+  where shouldReturnRvalueByValue(eltType) {
+    if boundsChecking && (idx < 0 || idx >= this.size) then
+      halt("out of bounds");
+    return _data[_live.first + idx];
+  }
+
+  proc this(d : domain) {
+    compilerError("The vector type does not support slicing");
+  }
+  proc this(d : range(?,?,?)) {
+    compilerError("The vector type does not support slicing");
+  }
+
+  iter these() ref : eltType {
+    for i in _live do yield _data[i];
+  }
+  iter these(param tag:iterKind) ref : eltType where tag == iterKind.standalone {
+    forall i in _live do yield _data[i];
+  }
+  iter these(param tag:iterKind) where tag == iterKind.leader {
+    for follow in (0..#this.size).these(iterKind.leader) do yield follow;
+  }
+  iter these(param tag:iterKind, followThis) ref where tag == iterKind.follower {
+    for f in followThis(1) do yield _data[_live.first+f];
+  }
+
+  proc writeThis(f) {
+    _data[_live].writeThis(f);
+  }
+  proc readThis(f) {
+    halt("reading a vector is not supported");
+  }
+
+  proc requestCapacity(capacity : integral) {
+    reserveSpace(capacity, true);
+  }
+
+  proc equals(other : vector(eltType)) {
+    return && reduce (this == other);
+  }
+  proc equals(other : [] eltType) {
+    return && reduce (this == other);
+  }
+}

--- a/test/library/packages/Vector/errors.chpl
+++ b/test/library/packages/Vector/errors.chpl
@@ -1,0 +1,49 @@
+
+use Vector;
+
+config const mode = 0;
+
+var inc : int = 0;
+
+proc step() : bool {
+  const ret = inc;
+  inc += 1;
+  
+  if ret == mode {
+    writeln("MODE ", mode);
+    return true;
+  } else {
+    return false;
+  }
+}
+
+proc main() {
+  var empty : vector(int);
+
+  var ten : vector(int);
+  for i in 1..10 do ten.push_back(i);
+
+  if step() {
+    empty.front();
+  } else if step() {
+    empty.back();
+  } else if step() {
+    empty.pop_back();
+  } else if step() {
+    empty.pop_front();
+  } else if step() {
+    ten.insert(500, 11);
+  } else if step() {
+    ten.remove(ten.size);
+  } else if step() {
+    ten.remove(5..100);
+  } else if step() {
+    ten.remove(..100);
+  } else if step() {
+    ten.remove(-100..);
+  } else if step() {
+    empty[5] = 100;
+  } else {
+    halt("invalid mode");
+  }
+}

--- a/test/library/packages/Vector/errors.cleanfiles
+++ b/test/library/packages/Vector/errors.cleanfiles
@@ -1,0 +1,1 @@
+errors.good

--- a/test/library/packages/Vector/errors.execopts
+++ b/test/library/packages/Vector/errors.execopts
@@ -1,0 +1,10 @@
+--mode 0
+--mode 1
+--mode 2
+--mode 3
+--mode 4
+--mode 5
+--mode 6
+--mode 7
+--mode 8
+--mode 9

--- a/test/library/packages/Vector/errors.full
+++ b/test/library/packages/Vector/errors.full
@@ -1,0 +1,20 @@
+MODE 0
+errors.chpl:27: error: halt reached - front() called on empty vector
+MODE 1
+errors.chpl:29: error: halt reached - back() called on empty vector
+MODE 2
+errors.chpl:31: error: halt reached - pop_back() called on empty vector
+MODE 3
+errors.chpl:33: error: halt reached - pop_front() called on empty vector
+MODE 4
+errors.chpl:35: error: halt reached - vector.insert called with invalid index '500' which must be in range '0..10'
+MODE 5
+errors.chpl:37: error: halt reached - vector.insert called with invalid index '10' which must be in range '0..9'
+MODE 6
+errors.chpl:39: error: halt reached - vector.remove called with invalid range: must be within '0..9'
+MODE 7
+errors.chpl:41: error: halt reached - vector.remove called with invalid upper-bounded range: bound must be within '0..9'
+MODE 8
+errors.chpl:43: error: halt reached - vector.remove called with invalid lower-bounded range: bound must be within '0..9'
+MODE 9
+errors.chpl:45: error: halt reached - out of bounds: 5

--- a/test/library/packages/Vector/errors.prediff
+++ b/test/library/packages/Vector/errors.prediff
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+
+import sys
+
+dest = "errors.good"
+outFile = sys.argv[2]
+
+mode = ""
+good = ""
+
+with open(outFile, 'r') as f:
+    mode = f.read().split('\n')[0] + "\n"
+
+with open("errors.full", 'r') as f:
+    use = False
+    for l in f:
+        if l == mode:
+            good += l
+            use = True
+        elif use:
+            good += l
+            break
+
+
+with open(dest, 'w') as f:
+    f.write(good)

--- a/test/library/packages/Vector/init-vec.chpl
+++ b/test/library/packages/Vector/init-vec.chpl
@@ -1,0 +1,35 @@
+
+use Vector;
+
+proc main() {
+  {
+    var A : vector(int);
+    var B = new vector(int);
+    writeln("empty vector: '", A, "'");
+    writeln("empty vector: '", B, "'");
+    assert(A.size == 0 && B.size == 0);
+    assert(A.isEmpty() && B.isEmpty());
+  }
+
+  {
+    var A = [1, 2, 3, 4, 5];
+    var B = new vector(A);
+    writeln("init with array: '", B, "'");
+    assert(A.size == B.size);
+  }
+
+  {
+    var A = new vector([1, 2, 3, 4, 5]);
+    var B = A;
+    writeln("copy init: '", B, "'");
+    assert(A.size == B.size && A.size == 5);
+  }
+
+  {
+    var A = new vector(int, 100);
+    writeln("with capacity: '", A, "'");
+    writeln("  capacity = ", A._dom.size);
+    assert(A.isEmpty());
+    assert(A.size == 0);
+  }
+}

--- a/test/library/packages/Vector/init-vec.good
+++ b/test/library/packages/Vector/init-vec.good
@@ -1,0 +1,6 @@
+empty vector: ''
+empty vector: ''
+init with array: '1 2 3 4 5'
+copy init: '1 2 3 4 5'
+with capacity: ''
+  capacity = 100

--- a/test/library/packages/Vector/insert-remove.chpl
+++ b/test/library/packages/Vector/insert-remove.chpl
@@ -1,0 +1,97 @@
+
+use Vector;
+
+proc main() {
+  // Inserting into an empty vector
+  {
+    var A : vector(int);
+    A.insert(0, 10);
+    assert(A.size == 1 && A.front() == 10);
+
+    var B : vector(int);
+    B.insert(0, [1, 2, 3, 4]);
+    assert(B.size == 4 && B.front()..B.back() == 1..4);
+
+    var C : vector(int);
+    C.insert(0, B);
+    assert(C.size == 4 && C.front()..C.back() == 1..4);
+  }
+
+  // insert into populated vector
+  {
+    var A : vector(int);
+    for i in 1..10 do A.push_back(i);
+    A.insert(A.size/2, 999);
+    writeln("int in middle: ", A);
+
+    var B : vector(int);
+    for i in 1..10 do B.push_back(i);
+    B.insert(B.size/2, [0,0,0,0]);
+    writeln("array in middle: ", B);
+    
+    var C : vector(int);
+    for i in 1..10 do C.push_back(i);
+    C.insert(C.size/2, new vector([0,0,0,0]));
+    writeln("vector in middle: ", C);
+  }
+
+  // insert at end of vector
+  {
+    var A : vector(int);
+    for i in 1..4 do A.insert(A.size, i);
+    assert(A.equals([1,2,3,4]));
+  }
+
+  // remove from ends
+  {
+    var A : vector(int);
+    for i in 1..4 do A.push_back(i);
+    A.remove(0);
+    assert(A.equals([2,3,4]));
+    A.remove(A.size-1);
+    assert(A.equals([2,3]));
+
+    while A.isEmpty() == false do
+      A.remove(0);
+    assert(A.size == 0);
+  }
+
+  // remove from middle
+  {
+    var A : vector(int);
+    for i in 1..10 do A.push_back(i);
+    const mid = A.size / 2;
+    for 1..4 do A.remove(mid - 2); // remove middle few
+    assert(A.equals([1,2,3,8,9,10]), A);
+  }
+
+  // remove via ranges
+  {
+    var A : vector(int);
+    for i in 1..100 do A.push_back(i);
+    A.remove(2.. by 3); // remove every third element
+
+    var B : vector(int);
+    for i in 1..100 by 3 {
+      B.push_back(i);
+      B.push_back(i+1);
+    }
+    assert(A.equals(B));
+
+    var C : vector(int);
+    for i in 1..10 do C.push_back(i);
+    C.remove(C.size/2 ..);
+    assert(C.equals([1,2,3,4,5]));
+
+    var D : vector(int);
+    for i in 1..10 do D.push_back(i);
+    D.remove(0..#D.size/2);
+    assert(D.equals([6,7,8,9,10]), D);
+
+    var E = new vector([1,2,3,4,5]);
+    E.remove(..);
+    assert(E.isEmpty());
+  }
+    
+
+}

--- a/test/library/packages/Vector/insert-remove.good
+++ b/test/library/packages/Vector/insert-remove.good
@@ -1,0 +1,3 @@
+int in middle: 1 2 3 4 5 999 6 7 8 9 10
+array in middle: 1 2 3 4 5 0 0 0 0 6 7 8 9 10
+vector in middle: 1 2 3 4 5 0 0 0 0 6 7 8 9 10

--- a/test/library/packages/Vector/misc-ops.chpl
+++ b/test/library/packages/Vector/misc-ops.chpl
@@ -1,0 +1,93 @@
+
+use Vector;
+
+proc main() {
+  // vector.reverse()
+  {
+    var A, B : vector(int);
+    for i in 1..10 {
+      A.push_back(i);
+      B.push_front(i);
+    }
+    A.reverse();
+    assert(A.equals(B));
+  }
+
+  {
+    var A : vector(int);
+    for i in 1..10 do A.push_back(i);
+
+    A.clear();
+    assert(A.isEmpty());
+
+    for i in 1..100 do A.push_back(i);
+
+    A.clear();
+    assert(A.isEmpty());
+  }
+
+  {
+    var A : vector(int);
+    for i in 1..100 do A.push_back(i);
+
+    for i in 1..100 by 4 {
+      const (found, idx) = A.find(i);
+      assert(found == true);
+      assert(idx == i-1);
+      assert(A[idx] == i);
+    }
+
+    const (found, _) = A.find(0);
+    assert(found == false);
+  }
+
+  // promotion
+  {
+    proc test(x : int) {
+      return x + 1;
+    }
+
+    var A, B : vector(int);
+    for i in 1..100 {
+      A.push_back(i);
+      B.push_back(i + 1);
+    }
+
+    const C = test(A);
+    assert(B.equals(C));
+
+    const D = A + 1;
+    assert(B.equals(D));
+  }
+
+  // Simple indexing
+  {
+    var A : vector(int);
+    for i in 1..100 do A.push_back(i);
+
+    for i in 0..#A.size do assert(A[i] == i + 1);
+
+    for i in 0..#A.size do A[i] += 1;
+    for i in 0..#A.size do assert(A[i] == i + 2);
+  }
+
+  // Iteration
+  {
+    var A : vector(int);
+    for i in 1..100 do A.push_back(i);
+
+    var B : [1..100] int = 1..100;
+
+    for (a, b) in zip(A, B) do assert(a == b);
+    for (b, a) in zip(B, A) do assert(b == a);
+
+    forall (a, b) in zip(A, B) do assert(a == b);
+    forall (b, a) in zip(B, A) do assert(b == a);
+  }
+
+  {
+    var A : vector(int);
+    A.requestCapacity(100);
+    assert(A._dom.size >= 100);
+  }
+}

--- a/test/library/packages/Vector/push-pop.chpl
+++ b/test/library/packages/Vector/push-pop.chpl
@@ -1,0 +1,77 @@
+
+use Vector;
+
+proc main() {
+  {
+    var A = new vector(int);
+    for i in 1..10 {
+      A.push_back(i);
+      assert(A.back() == i);
+    }
+    assert(A.size == 10);
+    assert(A.front() == 1);
+  }
+  {
+    var A = new vector(int);
+    A.push_back([1, 2, 3, 4]);
+    assert(A.size == 4 && A.front() == 1 && A.back() == 4);
+
+    var B = new vector(int);
+    B.push_back(A);
+    assert(B.size == 4 && B.front() == 1 && B.back() == 4);
+
+    B.push_back([5, 6, 7, 8]);
+
+    for (i, b) in zip(B.front()..B.back(), B) do assert(i == b);
+  }
+
+  {
+    var A = new vector(int);
+    for i in 1..10 do A.push_back(i);
+
+    for i in 1..10 by -1 {
+      const b = A.back();
+      const res = A.pop_back();
+      assert(b == res);
+      assert(res == i);
+      assert(A.size == i - 1);
+    }
+  }
+
+  {
+    var A = new vector(int);
+    for i in 1..10 {
+      A.push_front(i);
+      assert(A.front() == i);
+    }
+    assert(A.size == 10);
+    assert(A.back() == 1);
+  }
+  {
+    var A = new vector(int);
+    A.push_front([1, 2, 3, 4]);
+    assert(A.size == 4 && A.front() == 1 && A.back() == 4);
+
+    var B = new vector(int);
+    B.push_front(A);
+    assert(B.size == 4 && B.front() == 1 && B.back() == 4);
+
+    B.push_front([-3, -2, -1, 0]);
+    for (i, b) in zip(B.front()..B.back(), B) do assert(i == b);
+  }
+
+  {
+    var A = new vector(int);
+    for i in 1..10 do A.push_front(i);
+
+    for i in 1..10 by -1 {
+      const f = A.front();
+      const res = A.pop_front();
+      assert(f == res);
+      assert(res == i);
+      assert(A.size == i - 1);
+    }
+  }
+
+  writeln("SUCCESS");
+}

--- a/test/library/packages/Vector/push-pop.good
+++ b/test/library/packages/Vector/push-pop.good
@@ -1,0 +1,1 @@
+SUCCESS


### PR DESCRIPTION
This PR adds a 'vector' type as a package. It supports the same functionality as the vector ops on arrays. There are a number of design topics that we may want to discuss before merging:

- name of the type: some have proposed 'list', but we already have that (as a linked list)
- method names
- error handling
- parallel safety