### PR TITLE
In comm=ofi, allow for providers that lack scalable endpoints.

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -2499,8 +2499,16 @@ chpl_comm_nb_handle_t ofi_amo(struct perTxCtxInfo_t* tcip,
       freeBounceBuf(myRes);
     }
   } else if (result != NULL) {
+    //
+    // Verbs, or actually RxD, seems to expect a non-NULL buf argument
+    // for FI_ATOMIC_READ even though the man page says not needed.
+    //
+    static int64_t dummy;
+    void* bufArg = ((ofiOp == FI_ATOMIC_READ && myOpnd1 == NULL)
+                    ? &dummy
+                    : myOpnd1);
     OFI_CHK(fi_fetch_atomic(tcip->txCtx,
-                            myOpnd1, 1, mrDescOpnd1, myRes, mrDescRes,
+                            bufArg, 1, mrDescOpnd1, myRes, mrDescRes,
                             rxRmaAddr(tcip, node), (uint64_t) object, mrKey,
                             ofiType, ofiOp, NULL));
     tcip->numTxsOut++;

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -615,6 +615,9 @@ void init_ofiEpNumCtxs(void) {
   // Now we know how many transmit contexts we'll have.
   //
   numTxCtxs = numWorkerTxCtxs + numAmHandlers;
+  if (useScalableTxEp) {
+    ofi_info->ep_attr->tx_ctx_cnt = numTxCtxs;
+  }
 
   //
   // Receive contexts are much easier -- we just need one

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -304,12 +304,19 @@ void init_ofiFabricDomain(void) {
 
   hints->domain_attr->threading = FI_THREAD_UNSPEC;
 
-  chpl_bool autoProgress = (strcmp(provider, "sockets") == 0);
-  if (DBG_TEST_MASK(DBG_CFG))
-    autoProgress = chpl_env_rt_get_bool("COMM_OFI_AUTO_PROGRESS",
-                                        autoProgress);
-  const int prg = autoProgress ? FI_PROGRESS_AUTO : FI_PROGRESS_MANUAL;
-  hints->domain_attr->control_progress = prg;
+  enum fi_progress prg = FI_PROGRESS_UNSPEC;
+  if (DBG_TEST_MASK(DBG_CFG)) {
+    const char* ev = chpl_env_rt_get("COMM_OFI_PROGRESS", "");
+    if (strcmp(ev, "") != 0) {
+      if (strcasecmp(ev, "auto") == 0)
+        prg = FI_PROGRESS_AUTO;
+      else if (strcasecmp(ev, "manual") == 0)
+        prg = FI_PROGRESS_MANUAL;
+      else
+        CHK_TRUE((strcasecmp(ev, "unspec") == 0));
+    }
+  }
+  hints->domain_attr->control_progress = FI_PROGRESS_UNSPEC; // don't need
   hints->domain_attr->data_progress = prg;
 
   hints->domain_attr->av_type = FI_AV_TABLE;


### PR DESCRIPTION
The ofi comm layer was written to use a single scalable transmit
endpoint per node and multiple transmit contexts, ideally enough for
each worker thread and the AM handler to have its own.  Unfortunately,
the verbs provider, or more specifically the RxD utility provider used
to support RDM with the verbs provider, does not support scalable
endpoints.

Here, add support for multiple transmit endpoints, ideally enough for
each worker thread and the AM handler to have its own.  The decision to
use a scalable endpoint or multiple regular endpoints is based simply on
the provider's reported capabilities, not on its name.  If the provider
says it can support more than one context per endpoint then the comm
layer uses scalable endpoint, otherwise it uses regular endpoints.

The transmit context table is restructured slightly to support this.
When the scalable model is use the scalable endpoint is outside the
transmit context table and the table contains transmit contexts as it
always has.  When the multi-endpoint model is in use the scalable
endpoint outside the table is unused and the transmit "contexts" in the
table are actually endpoints.  Each endpoint needs an address vector, so
there is a similar arrangement with the AVs: when the scalable model is
in use the single AV is stored in the first transmit context table entry
and the other table entries just alias that.  When the multi-endpoint
model is in use each endpoint has its own AV.

The verbs provider seems not to support completion counters as indicated
by `ofi_info->domain_attr->cntr_cnt==0`.  We have been using completion
counters for lower overhead for the AM handler's RMA and AMOs, but the
progress-handling code in the provider actually segfaults if endpoints
do not have completion queues.  Thus here, use counters when `cntr_cnt`
indicates that the provider can support them, and otherwise use CQs.

Lastly, work around two idiosyncracies in the RxD utility provider which
supplies RDM support to the verbs provider.  First, set the address
vector attribute 'count' value to the number of transmit endpoints.  RxD
internal code seems to be storing private addresses for each transmitter
alongside the AV, and the number of such private addresses is limited by
the 'count' attribute value.  Thus we need this to be as large as the
number of transmit endpoints.  Second, supply a dummy 'buf' operand
argument for the `fi_fetch_atomic()` `FI_ATOMIC_READ` operation.  The man
page says that buf is ignored for this operation and may be NULL, but
the RxD provider expects it to be non-NULL and segfaults otherwise.

With these changes made, the ofi comm layer now passes full testing when
using the verbs provider, with just a few test-specific failures which
also fail with the sockets provider.

While here, switch from using separate address vectors for the AM and
RMA/AMO target node addresses to using a single vector containing
address pairs.  This made it easier to adapt the AV support to the
many-endpoints model.

While here, upgrade the progress hinting.  Until now we've forced use of
automatic or manual progress based on the name of the provider.  That's
dumb.  Here, default to "unspecified" and let the provider tell us which
progress model it prefers.  That done, allow forcing the choice one way
or another using an environment variable, but only when debug support is
enabled.

This resolves #11180.
