### PR TITLE
Document that chapel is tested using Unicode

### DIFF
--- a/doc/rst/usingchapel/chplenv.rst
+++ b/doc/rst/usingchapel/chplenv.rst
@@ -721,9 +721,12 @@ Character Set
    Chapel is tested with the Unicode character set and the traditional
    C collating sequence using the following settings.
 
+   .. code-block:: sh
+
        LANG=en_US.UTF-8
        LC_COLLATE=C
        LC_ALL=""
+
 
 Compiler Command Line Option Defaults
 -------------------------------------

--- a/doc/rst/usingchapel/chplenv.rst
+++ b/doc/rst/usingchapel/chplenv.rst
@@ -718,8 +718,9 @@ CHPL_LIB_PIC
 
 Character Set
 -------------
-   Chapel is tested with the Unicode character set and the traditional
-   C collating sequence using the following settings.
+   We have the most experience running Chapel with the Unicode
+   character set and the traditional C collating sequence using the
+   following settings.
 
    .. code-block:: sh
 
@@ -727,6 +728,8 @@ Character Set
        LC_COLLATE=C
        LC_ALL=""
 
+   .. note::
+       This may change in the future.
 
 Compiler Command Line Option Defaults
 -------------------------------------

--- a/doc/rst/usingchapel/chplenv.rst
+++ b/doc/rst/usingchapel/chplenv.rst
@@ -723,7 +723,7 @@ Character Set
 
        LANG=en_US.UTF-8
        LC_COLLATE=C
-       LANG=""
+       LC_ALL=""
 
 Compiler Command Line Option Defaults
 -------------------------------------

--- a/doc/rst/usingchapel/chplenv.rst
+++ b/doc/rst/usingchapel/chplenv.rst
@@ -729,7 +729,7 @@ Character Set
        LC_ALL=""
 
    .. note::
-       This may change in the future.
+       Other settings might be recommended in the future.
 
 Compiler Command Line Option Defaults
 -------------------------------------

--- a/doc/rst/usingchapel/chplenv.rst
+++ b/doc/rst/usingchapel/chplenv.rst
@@ -716,6 +716,15 @@ CHPL_LIB_PIC
 
    If unset, ``CHPL_LIB_PIC`` defaults to ``none``
 
+Character Set
+-------------
+   Chapel is tested with the Unicode character set and the traditional
+   C collating sequence using the following settings.
+
+       LANG=en_US.UTF-8
+       LC_COLLATE=C
+       LANG=""
+
 Compiler Command Line Option Defaults
 -------------------------------------
 


### PR DESCRIPTION
Chapel works with many character sets, but is tested with Unicode.  This PR documents how to get the tested environment.  It is placed under the "recommended settings."

Closes #12200 