### PR TITLE
Update a .bad file to add another 'rank' method to the error message

### DIFF
--- a/test/distributions/ferguson/dist-assoc-bulkadd.bad
+++ b/test/distributions/ferguson/dist-assoc-bulkadd.bad
@@ -18,3 +18,4 @@ $CHPL_HOME/modules/internal/ChapelDistribution.chpl:768: note:                 B
 $CHPL_HOME/modules/internal/ChapelDistribution.chpl:768: note:                 BaseArrOverRectangularDom.rank
 $CHPL_HOME/modules/internal/ChapelDistribution.chpl:816: note:                 BaseSparseArr.rank
 $CHPL_HOME/modules/internal/ChapelDistribution.chpl:816: note:                 BaseSparseArr.rank
+$CHPL_HOME/modules/internal/ISO_Fortran_binding.chpl:152: note:                 CFI_cdesc_t.rank


### PR DESCRIPTION
PR #12378 added another 'rank' method to the modules and this .bad file
lists out all 'rank' methods. Add the new one.