### PR TITLE
Add a wrapper to the runtime for gethostname that can get called from Chapel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,6 +188,7 @@ tags
 
 /test/extern/bradc/externSystem.appendme
 /test/extern/deitz/myfile.dat
+/test/extern/lydia/checkGethostname.good
 
 /test/io/bradc/fileIO.out.txt
 /test/io/bradc/subdir/out.dat

--- a/runtime/include/qio/sys.h
+++ b/runtime/include/qio/sys.h
@@ -292,6 +292,8 @@ err_t sys_unlink(const char* path);
 // Allocates a string to store the current directory which must be freed.
 err_t sys_getcwd(const char** path_out);
 
+err_t sys_gethostname(const char** name);
+
 #ifdef __cplusplus
 } // end extern "C"
 #endif

--- a/runtime/src/qio/sys.c
+++ b/runtime/src/qio/sys.c
@@ -1854,3 +1854,11 @@ err_t sys_getcwd(const char** path_out)
 
   return err;
 }
+
+err_t sys_gethostname(const char** name) {
+  size_t len = 256;
+  char* resbuf = (char*) qio_malloc(len);
+  err_t err = gethostname(resbuf, len);
+  *name = resbuf;
+  return err;
+}

--- a/test/extern/lydia/checkGethostname.chpl
+++ b/test/extern/lydia/checkGethostname.chpl
@@ -1,0 +1,5 @@
+extern proc sys_gethostname(ref name: c_string): err_t;
+
+var x: c_string;
+sys_gethostname(x);
+writeln(x: string);

--- a/test/extern/lydia/checkGethostname.cleanfiles
+++ b/test/extern/lydia/checkGethostname.cleanfiles
@@ -1,0 +1,1 @@
+checkGethostname.good

--- a/test/extern/lydia/checkGethostname.preexec
+++ b/test/extern/lydia/checkGethostname.preexec
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+
+import socket
+
+with open("checkGethostname.good", "w+") as goodfile:
+     goodfile.write(socket.gethostname())
+     goodfile.write("\n")


### PR DESCRIPTION
We can't call gethostname directly due to `c_string`s being mapped to
`const char*`s in C.  There's precedent for exposing these sort of
functions in the Sys module, but it seems a little close to the release to
add something that user facing (even though it there is a pretty obvious
pattern to follow).  I'm opening an issue to discuss what that would look
like after the release, but we'll need something in place for multi-locale
interoperability when communicating with something that has been
launched.

Adds a test to verify the functionality against the equivalent function in
Python.  This test will need to be updated if/when we expose the extern
from library code, but that won't be hard.

Passed a std/ paratest with futures.