### PR TITLE
Improve the LLVM back end's ability to find gcc header files

### DIFF
--- a/third-party/llvm/find-gcc-prefix.sh
+++ b/third-party/llvm/find-gcc-prefix.sh
@@ -2,12 +2,15 @@
 
 # If building LLVM and Clang with GCC, the built
 # LLVM should use C++ headers from the selected GCC.
+# We are looking for GCC's installation root.  In other words, we want
+# the directory specified in the --prefix argument to GCC's configure
+# script.  Clang knows how to find the C++ header files from there.
 
 # Using the LLVM project's libc++ would be a reasonable alternative.
 
 CC=$1
 
-# First look for the prefix specified when gcc was configured.
+# First look for the prefix specified when GCC was configured.
 DIR=`$CC -v 2>&1 | xargs -n 1 | egrep '^--prefix=' | sed -e 's/^--prefix=//'`
 if [ -d "$DIR" ]
 then

--- a/third-party/llvm/find-gcc-prefix.sh
+++ b/third-party/llvm/find-gcc-prefix.sh
@@ -6,6 +6,16 @@
 # Using the LLVM project's libc++ would be a reasonable alternative.
 
 CC=$1
+
+# First look for the prefix specified when gcc was configured.
+DIR=`$CC -v 2>&1 | xargs -n 1 | egrep '^--prefix=' | sed -e 's/^--prefix=//'`
+if [ -d "$DIR" ]
+then
+  echo "$DIR"
+  exit 0
+fi
+
+# We didn't find a --prefix= flag, so fall back on a heuristic.
 WHICH=`which $CC`
 DIR=${WHICH%%/bin/$CC}
 


### PR DESCRIPTION
Clang built from gcc depends on gcc's C++ header files.  Previously, we were not finding those header files when there was a compiler wrapper in place, such as ccache, or when there was a custom configuration, such as /usr/local/bin/gcc being a symbolic link to gcc in a different directory.

This change adds a more reliable way to find the right directory that will almost always work, and when it fails, we fall back to the old method.  (I have not yet been able to find a configuration where the new test does not work.)

Closes #12198 