### PR TITLE
Do not promote param and type functions

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -1184,6 +1184,8 @@ bool doCanDispatch(Type*     actualType,
       if (fn                              != NULL        &&
           fn->name                        != astrSequals &&
           strcmp(fn->name, "these")       != 0           &&
+          fn->retTag                      != RET_TYPE    &&
+          fn->retTag                      != RET_PARAM   &&
           actualType->scalarPromotionType != NULL        &&
           doCanDispatch(actualType->scalarPromotionType,
                         NULL,

--- a/test/param/promoted.chpl
+++ b/test/param/promoted.chpl
@@ -1,0 +1,19 @@
+// Test what happens when we promote a param or type function.
+
+config param runParam = false;
+config param runType = false;
+
+const rng = 1..3;
+
+proc valueFun(arg:int) return 777;
+proc paramFun(arg:int) param return 888;
+proc typeFun(arg:int) type return int;
+
+var arr = valueFun(rng);
+writeln(arr);
+
+if runParam then
+  param P = paramFun(rng);
+
+if runType then
+  type T =  typeFun(rng);

--- a/test/param/promoted.compopts
+++ b/test/param/promoted.compopts
@@ -1,0 +1,2 @@
+-s runParam # promoted.runParam.good
+-s runType  # promoted.runType.good

--- a/test/param/promoted.runParam.good
+++ b/test/param/promoted.runParam.good
@@ -1,0 +1,2 @@
+promoted.chpl:16: error: unresolved call 'paramFun(range(int(64),bounded,false))'
+promoted.chpl:9: note: candidates are: paramFun(arg: int)

--- a/test/param/promoted.runType.good
+++ b/test/param/promoted.runType.good
@@ -1,0 +1,2 @@
+promoted.chpl:19: error: unresolved call 'typeFun(range(int(64),bounded,false))'
+promoted.chpl:10: note: candidates are: typeFun(arg: int)


### PR DESCRIPTION
Before this change a param or type function was considered a valid candidate
for resolution even if it required promotion. If chosen, resolving such
a promoted function would cause one of these errors:

    param function cannot contain a non-param for loop
    illegal assignment of type to value
    iterators may not yield or return types

With this change, such a function will not be considered a valid candidate
at all. If the call ends up unresolved, the compiler will mention
such a function in a "note: candidates are:" message.