### PR TITLE
Fix tests that run only on ugni after forall unordored PR

### DIFF
--- a/test/runtime/configMatters/forall-unordered-opt/COMPOPTS
+++ b/test/runtime/configMatters/forall-unordered-opt/COMPOPTS
@@ -1,1 +1,1 @@
---report-optimized-forall-unordered-ops
+-sPODValAccess=false --optimize-forall-unordered-ops --report-optimized-forall-unordered-ops

--- a/test/runtime/configMatters/forall-unordered-opt/check-fence/COMPOPTS
+++ b/test/runtime/configMatters/forall-unordered-opt/check-fence/COMPOPTS
@@ -1,1 +1,1 @@
---savec=output -M.. --report-optimized-forall-unordered-ops --no-cpp-lines
+--savec=output -M.. -sPODValAccess=false --optimize-forall-unordered-ops --report-optimized-forall-unordered-ops --no-cpp-lines

--- a/test/runtime/configMatters/forall-unordered-opt/check-fence/opt-check-fence.good
+++ b/test/runtime/configMatters/forall-unordered-opt/check-fence/opt-check-fence.good
@@ -1,7 +1,7 @@
 ../needsFence.chpl:14: note: Optimized atomic call to be unordered
 ../needsFence.chpl:14: note: Optimized atomic call to be unordered
-chpl_atomic_full_fence;
+atomic_fence;
 chpl_comm_atomic_add_unordered_int64;
 --
-chpl_atomic_full_fence;
+atomic_fence;
 chpl_comm_atomic_add_unordered_int64;


### PR DESCRIPTION
Follow-on to PR #12269. These tests worked in an earlier
version of that PR but needed minor adjustment to work
with the final version (and I overlooked checking them
again in my final testing).

Trivial and not reviewed.