### PR TITLE
Use math.h functions instead of cmath functions within compiler

### DIFF
--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -103,6 +103,8 @@ EXECS = $(CHPL) $(CHPLDOC)
 PRETARGETS = $(BUILD_VERSION_FILE) $(CONFIGURED_PREFIX_FILE) llvm $(CLANG_SETTINGS_FILE)
 TARGETS = $(CHPL) $(CHPL_OLD)
 
+LIBS = -lm
+
 # Set up variables representing paths that will be installed
 # and how to fix them (for CLANG_SETTINGS).
 # So far, this only needs to fix CHPL_THIRD_PARTY/CHPL_HOME.

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -55,7 +55,7 @@
 
 #include <algorithm>
 #include <cctype>
-#include <cmath>
+#include <math.h> // could be cmath once we assume C++11
 #include <cstring>
 #include <cstdio>
 #include <vector>
@@ -2501,15 +2501,15 @@ std::string real_to_string(double num)
 {
   char buf[32];
 
-  if (std::isfinite(num)) {
-    if (std::signbit(num)) snprintf(buf, sizeof(buf), "-%a" , -num);
-    else                   snprintf(buf, sizeof(buf), "%a" , num);
-  } else if (std::isinf(num)) {
-    if (std::signbit(num)) strncpy(buf, "-INFINITY", sizeof(buf));
-    else                   strncpy(buf, "INFINITY", sizeof(buf));
+  if (isfinite(num)) {
+    if (signbit(num)) snprintf(buf, sizeof(buf), "-%a" , -num);
+    else              snprintf(buf, sizeof(buf), "%a" , num);
+  } else if (isinf(num)) {
+    if (signbit(num)) strncpy(buf, "-INFINITY", sizeof(buf));
+    else              strncpy(buf, "INFINITY", sizeof(buf));
   } else {
-    if (std::signbit(num)) strncpy(buf, "-NAN", sizeof(buf));
-    else                   strncpy(buf, "NAN", sizeof(buf));
+    if (signbit(num)) strncpy(buf, "-NAN", sizeof(buf));
+    else              strncpy(buf, "NAN", sizeof(buf));
   }
   std::string ret(buf);
   return ret;

--- a/compiler/ifa/num.cpp
+++ b/compiler/ifa/num.cpp
@@ -21,7 +21,7 @@
 #define __STDC_FORMAT_MACROS
 #endif
 #include <inttypes.h>
-#include <cmath>
+#include <math.h> // could be cmath once we assume C++11
 #include <cstring>
 #include <cstdio>
 #include "num.h"
@@ -30,10 +30,10 @@
 
 static int
 snprint_float_val(char* buf, size_t max, double val, bool hex) {
-  if (std::isfinite(val)) {
+  if (isfinite(val)) {
     int nc = 0;
-    if (std::signbit(val)) nc = snprintf(buf, max, "-%g" , -val);
-    else                   nc = snprintf(buf, max, "%g" , val);
+    if (signbit(val)) nc = snprintf(buf, max, "-%g" , -val);
+    else              nc = snprintf(buf, max, "%g" , val);
 
     if (strchr(buf, '.') == NULL &&
         strchr(buf, 'e') == NULL &&
@@ -43,13 +43,13 @@ snprint_float_val(char* buf, size_t max, double val, bool hex) {
     } else {
       return nc;
     }
-  } else if (std::isinf(val)) {
-    if (std::signbit(val)) strncpy(buf, "-INFINITY", max);
-    else                   strncpy(buf, "INFINITY", max);
+  } else if (isinf(val)) {
+    if (signbit(val)) strncpy(buf, "-INFINITY", max);
+    else              strncpy(buf, "INFINITY", max);
     return strlen(buf);
   } else {
-    if (std::signbit(val)) strncpy(buf, "-NAN", max);
-    else                   strncpy(buf, "NAN", max);
+    if (signbit(val)) strncpy(buf, "-NAN", max);
+    else              strncpy(buf, "NAN", max);
     return strlen(buf);
   }
 }
@@ -66,7 +66,7 @@ static int
 snprint_complex_val(char* str, size_t max, double real, double imm) {
   int numchars = 0;
   numchars += snprint_float_val(str+numchars, max-numchars, real, false);
-  if (std::signbit(imm)) {
+  if (signbit(imm)) {
     numchars += snprintf(str+numchars, max-numchars, " - ");
     numchars += snprint_float_val(str+numchars, max-numchars, -imm, false);
   } else {

--- a/util/devel/grepstdchdrs
+++ b/util/devel/grepstdchdrs
@@ -14,6 +14,8 @@ else
   fi
 fi
 
+# This should also grep for math.h after we move to C++11
+
 filter=${1:+cat}
 cd $project_dir && \
-find compiler \( \( -name '*.cpp' -o -name '*.h' \) -a ! -name 'bison-chapel.cpp' -a ! -name 'flex-chapel.cpp' -a ! -name 'flex-chapel.h' \) -exec egrep ${1:--s} '^[       ]*#[    ]*include[      ][      ]*<[    ]*(assert|ctype|errno|float|iso646|limits|locale|math|setjmp|signal|stdarg|stddef|stdio|stdlib|string|time|wchar|wctype)[.]h[   ]*>' {} \; -print | `echo "${filter:-grep -v include[^/]}"`a
+find compiler \( \( -name '*.cpp' -o -name '*.h' \) -a ! -name 'bison-chapel.cpp' -a ! -name 'flex-chapel.cpp' -a ! -name 'flex-chapel.h' \) -exec egrep ${1:--s} '^[       ]*#[    ]*include[      ][      ]*<[    ]*(assert|ctype|errno|float|iso646|limits|locale|setjmp|signal|stdarg|stddef|stdio|stdlib|string|time|wchar|wctype)[.]h[   ]*>' {} \; -print | `echo "${filter:-grep -v include[^/]}"`a


### PR DESCRIPTION
PR #12386 added compile-time param operations and one of the implications 
was that the compiler needs to be able to distinguish between positive
and negative floating point zeros as well as identify infinity and nan.

It was using signbit, isfinite, and isinf from `#include <cmath>` to do 
so but these are technically C++11 features. (This is a problem because
the Chapel C++ sources are not supposed to assume C++11 yet).
Additionally these technically might require `-lm` on the compile line.

This PR:
 * adds `-lm` to the `chpl` link step
 * switches from `cmath` to `math.h`
 * adjusts grepstdchdrs to allow inclusion of `math.h`

This resolves a failure to build the compiler with some older compilers.

- [x] compiler builds and param-inf has correct output with PGI 16.10
- [x] compiler builds and param-inf has correct output with GCC 8.2
- [x] compiler builds and param-inf has correct output with GCC 4.4.7

Reviewed by @ronawho and discussed with @dmk42 - thanks!