### PR TITLE
Update generic init= to use "this.type"

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -1679,7 +1679,7 @@ bool AggregateType::addSuperArgs(FnSymbol*                    fn,
 }
 
 void AggregateType::buildCopyInitializer() {
-  if (isRecordWithInitializers(this) == true && hasUserDefinedInitEquals() == false) {
+  if (isRecordWithInitializers(this) == true) {
     SET_LINENO(this);
 
     bool isGeneric = false;

--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -1679,7 +1679,7 @@ bool AggregateType::addSuperArgs(FnSymbol*                    fn,
 }
 
 void AggregateType::buildCopyInitializer() {
-  if (isRecordWithInitializers(this) == true) {
+  if (isRecordWithInitializers(this) == true && hasUserDefinedInitEquals() == false) {
     SET_LINENO(this);
 
     bool isGeneric = false;
@@ -1707,9 +1707,7 @@ void AggregateType::buildCopyInitializer() {
     ArgSymbol* ThisType = NULL;
     ArgSymbol* other = NULL;
     if (isGeneric) {
-      ThisType = new ArgSymbol(INTENT_TYPE, "ThisType", dtAny);
-      ThisType->addFlag(FLAG_TYPE_VARIABLE);
-      other = new ArgSymbol(INTENT_BLANK, "other", dtUnknown, new SymExpr(ThisType));
+      other = new ArgSymbol(INTENT_BLANK, "other", dtUnknown, new CallExpr(PRIM_TYPEOF, new SymExpr(_this)));
       other->addFlag(FLAG_MARKED_GENERIC);
     } else {
       other = new ArgSymbol(INTENT_BLANK, "other", this);

--- a/compiler/AST/FnSymbol.cpp
+++ b/compiler/AST/FnSymbol.cpp
@@ -764,8 +764,6 @@ int FnSymbol::hasGenericFormals() const {
   bool hasGenericDefaults =  true;
   int  retval             =     0;
 
-  bool isInit = isInitializer() || isCopyInit();
-
   for_formals(formal, this) {
     bool isGeneric = false;
 
@@ -786,7 +784,8 @@ int FnSymbol::hasGenericFormals() const {
       }
 
     // Mark initializer formals using 'this' as generic
-    } else if (isInit && _this->type->symbol->hasFlag(FLAG_GENERIC)) {
+    } else if (isCopyInit() && _this->type->symbol->hasFlag(FLAG_GENERIC)) {
+      isGeneric = true;
       if (formal->typeExpr) {
         std::vector<SymExpr*> syms;
         collectSymExprs(formal->typeExpr, syms);

--- a/compiler/AST/FnSymbol.cpp
+++ b/compiler/AST/FnSymbol.cpp
@@ -783,19 +783,10 @@ int FnSymbol::hasGenericFormals() const {
         }
       }
 
-    // Mark initializer formals using 'this' as generic
+    // init= on generic types need to be considered generic so that 'this.type'
+    // stuff will resolve.
     } else if (isCopyInit() && _this->type->symbol->hasFlag(FLAG_GENERIC)) {
       isGeneric = true;
-      if (formal->typeExpr) {
-        std::vector<SymExpr*> syms;
-        collectSymExprs(formal->typeExpr, syms);
-
-        for_vector(SymExpr, se, syms) {
-          if (se->symbol() == _this) {
-            isGeneric = true;
-          }
-        }
-      }
     }
 
     if (isGeneric == true) {

--- a/compiler/passes/initializerRules.cpp
+++ b/compiler/passes/initializerRules.cpp
@@ -202,15 +202,17 @@ void errorOnFieldsInArgList(FnSymbol* fn) {
     for_vector(SymExpr, se, symExprs) {
       if (se->symbol() == fn->_this) {
         bool error = true;
-        if (CallExpr* call = toCallExpr(se->parentExpr)) {
-          AggregateType* at = toAggregateType(fn->_this->getValType());
-          if (call->isPrimitive(PRIM_TYPEOF)) {
-            error = false;
-          } else if (DefExpr* def = toLocalField(at, call)) {
-            Symbol* sym = def->sym;
-            if (sym->hasFlag(FLAG_TYPE_VARIABLE) ||
-                sym->hasFlag(FLAG_PARAM)) {
+        if (fn->isCopyInit()) {
+          if (CallExpr* call = toCallExpr(se->parentExpr)) {
+            AggregateType* at = toAggregateType(fn->_this->getValType());
+            if (call->isPrimitive(PRIM_TYPEOF)) {
               error = false;
+            } else if (DefExpr* def = toLocalField(at, call)) {
+              Symbol* sym = def->sym;
+              if (sym->hasFlag(FLAG_TYPE_VARIABLE) ||
+                  sym->hasFlag(FLAG_PARAM)) {
+                error = false;
+              }
             }
           }
         }

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -4977,14 +4977,6 @@ static void resolveInitVar(CallExpr* call) {
 
       if (foundOldStyleInit == false) {
         call->setUnresolvedFunction(astrInitEquals);
-        if (at->symbol->hasFlag(FLAG_GENERIC) == false &&
-            at->instantiatedFrom != NULL &&
-            at != at->instantiatedFrom) {
-          // Initializing a genric type, need to pass the type as an argument
-          Expr* last = call->argList.tail->remove();
-          call->insertAtTail(new SymExpr(at->symbol));
-          call->insertAtTail(last);
-        }
 
         resolveCall(call);
       }
@@ -5023,11 +5015,8 @@ FnSymbol* findCopyInit(AggregateType* at) {
 
   if (ret == NULL) {
     CallExpr* call = NULL;
-    if (at->getRootInstantiation()->symbol->hasFlag(FLAG_GENERIC)) {
-      call = new CallExpr(astrInitEquals, gMethodToken, tmpAt, new SymExpr(at->symbol), tmpAt);
-    } else {
-      call = new CallExpr(astrInitEquals, gMethodToken, tmpAt, tmpAt);
-    }
+
+    call = new CallExpr(astrInitEquals, gMethodToken, tmpAt, tmpAt);
 
     ret = resolveUninsertedCall(at, call, false);
   }

--- a/compiler/resolution/generics.cpp
+++ b/compiler/resolution/generics.cpp
@@ -594,8 +594,6 @@ static bool fixupDefaultInitCopy(FnSymbol* fn,
 
         if (initFn->name == astrInit) {
           initCall = new CallExpr(initFn, gMethodToken, thisTmp, arg);
-        } else if (ct->getRootInstantiation()->symbol->hasFlag(FLAG_GENERIC)) {
-          initCall = new CallExpr(initFn, gMethodToken, thisTmp, new SymExpr(ct->symbol), arg);
         } else {
           initCall = new CallExpr(initFn, gMethodToken, thisTmp, arg);
         }

--- a/modules/internal/Atomics.chpl
+++ b/modules/internal/Atomics.chpl
@@ -346,14 +346,14 @@ module Atomics {
     }
 
     pragma "no doc"
-    proc init=(type ThisType, other : ThisType) {
+    proc init=(other : this.type) {
       this.T = other.T;
       this._v = other._v;
     }
 
     pragma "no doc"
-    proc init=(type ThisType, other : ThisType.T) {
-      this.T = ThisType.T;
+    proc init=(other : this.type.T) {
+      this.T = other.type;
       this.complete();
 
       extern externFunc("init", T, explicit=false)

--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -289,18 +289,18 @@ module ChapelRange {
   }
 
   pragma "no doc"
-  proc range.init=(type ThisType, other : range(?i,?b,?s)) {
-    type idxType = ThisType.idxType;
-    if ThisType.boundedType != b {
-      compilerError("range(boundedType=" + ThisType.boundedType:string + ") cannot be initialized from range(boundedType=" + b:string + ")");
+  proc range.init=(other : range(?i,?b,?s)) {
+    type idxType = this.type.idxType;
+    if this.type.boundedType != b {
+      compilerError("range(boundedType=" + this.type.boundedType:string + ") cannot be initialized from range(boundedType=" + b:string + ")");
     }
 
-    if !ThisType.stridable && s then
+    if !this.type.stridable && s then
       compilerError("cannot initialize a non-stridable range from a stridable range");
 
-    const str = if ThisType.stridable && s then other.stride else 1:chpl__rangeStrideType(idxType);
+    const str = if this.type.stridable && s then other.stride else 1:chpl__rangeStrideType(idxType);
 
-    this.init(idxType, ThisType.boundedType, ThisType.stridable,
+    this.init(idxType, this.type.boundedType, this.type.stridable,
               chpl__intToIdx(idxType, other._low), chpl__intToIdx(idxType, other._high),
               str,
               chpl__intToIdx(idxType, chpl__idxToInt(other.alignment)),

--- a/modules/internal/ChapelSyncvar.chpl
+++ b/modules/internal/ChapelSyncvar.chpl
@@ -134,8 +134,8 @@ module ChapelSyncvar {
       this.isOwned = false;
     }
 
-    proc init=(type ThisType, const other : ThisType.valType) {
-      this.init(ThisType.valType);
+    proc init=(const other : this.valType) {
+      this.init(other.type);
       // TODO: initialize the sync class impl with 'other'
       this.writeEF(other);
     }
@@ -653,8 +653,8 @@ module ChapelSyncvar {
       isOwned = false;
     }
 
-    proc init=(type ThisType, const other : ThisType.valType) {
-      this.init(ThisType.valType);
+    proc init=(const other : this.type.valType) {
+      this.init(other.type);
       this.writeEF(other);
     }
 

--- a/modules/internal/OwnedObject.chpl
+++ b/modules/internal/OwnedObject.chpl
@@ -240,15 +240,15 @@ module OwnedObject {
        that takes over ownership from `src`. `src` will
        refer to `nil` after this call.
      */
-    proc init=(type ThisType, pragma "leaves arg nil" pragma "nil from arg" ref src:_owned) {
-      // Use 'ThisType.chpl_t' in case RHS is a subtype
-      this.chpl_t = ThisType.chpl_t;
+    proc init=(pragma "leaves arg nil" pragma "nil from arg" ref src:_owned) {
+      // Use 'this.type.chpl_t' in case RHS is a subtype
+      this.chpl_t = this.type.chpl_t;
       this.chpl_p = src.release();
     }
 
     pragma "no doc"
-    proc init=(type ThisType, src : _nilType) {
-      this.init(ThisType.chpl_t);
+    proc init=(src : _nilType) {
+      this.init(this.type.chpl_t);
     }
 
     // Copy-init implementation to allow for 'new _owned(foo)' in module code

--- a/modules/internal/SharedObject.chpl
+++ b/modules/internal/SharedObject.chpl
@@ -235,10 +235,6 @@ module SharedObject {
       this.complete();
     }
 
-    proc init=(pragma "nil from arg" in take:owned) {
-      this.init(take);
-    }
-
     // Initialize generic 'shared' var-decl from owned:
     //   var s : shared = ownedThing;
     pragma "no doc"
@@ -260,6 +256,10 @@ module SharedObject {
 
       if this.chpl_pn != nil then
         this.chpl_pn.retain();
+    }
+
+    proc init=(src : _nilType) {
+      this.init(this.type.chpl_t);
     }
 
     /*

--- a/modules/internal/SharedObject.chpl
+++ b/modules/internal/SharedObject.chpl
@@ -235,7 +235,7 @@ module SharedObject {
       this.complete();
     }
 
-    proc init=(type ThisType, pragma "nil from arg" in take:owned) {
+    proc init=(pragma "nil from arg" in take:owned) {
       this.init(take);
     }
 
@@ -251,8 +251,8 @@ module SharedObject {
        that refers to the same class instance as `src`.
        These will share responsibility for managing the instance.
      */
-    proc init=(type ThisType, pragma "nil from arg" const ref src:_shared(?)) {
-      this.chpl_t = ThisType.chpl_t;
+    proc init=(pragma "nil from arg" const ref src:_shared(?)) {
+      this.chpl_t = this.type.chpl_t;
       this.chpl_p = src.chpl_p;
       this.chpl_pn = src.chpl_pn;
 

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -860,7 +860,7 @@ record ReverseComparator {
    :arg revcomp: :ref:`ReverseComparator <reverse-comparator>` to copy.
    */
   pragma "no doc"
-  proc init=(type ThisType, revcomp: ReverseComparator(?)) {
+  proc init=(revcomp: ReverseComparator(?)) {
     this.comparator = revcomp.comparator;
   }
 

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1974,8 +1974,7 @@ proc channel.init(x: channel) {
   }
 }
 
-proc channel.init=(type ThisType, x: channel) {
-  if x.type != ThisType then compilerError("init= error");
+proc channel.init=(x: this.type) {
   this.init(x);
 }
 

--- a/modules/standard/List.chpl
+++ b/modules/standard/List.chpl
@@ -74,9 +74,8 @@ record list {
   }
 
   pragma "no doc"
-  proc init=(type ThisType, l : list(?t)) {
-    if l.type != ThisType then compilerError("init= error");
-    this.eltType = t;
+  proc init=(l : this.type) {
+    this.eltType = l.eltType;
     this.complete();
     for i in l do
       this.append(i);

--- a/test/classes/delete-free/owned/owned-record-instantiation-types-user-init-borrows-error.good
+++ b/test/classes/delete-free/owned/owned-record-instantiation-types-user-init-borrows-error.good
@@ -1,2 +1,2 @@
-owned-record-instantiation-types-user-init-borrows-error.chpl:17: error: unresolved call 'GenericCollection(_owned(MyClass)).init=(type GenericCollection(_owned(MyClass)), GenericCollection(MyClass))'
-owned-record-instantiation-types-user-init-borrows-error.chpl:5: note: candidates are: GenericCollection.init=(type ThisType, other: ThisType)
+owned-record-instantiation-types-user-init-borrows-error.chpl:17: error: unresolved call 'GenericCollection(_owned(MyClass)).init=(GenericCollection(MyClass))'
+owned-record-instantiation-types-user-init-borrows-error.chpl:5: note: candidates are: GenericCollection.init=(other: this.type)

--- a/test/classes/initializers/initequals/generics.chpl
+++ b/test/classes/initializers/initequals/generics.chpl
@@ -18,7 +18,7 @@ record R {
 
 writeln("----- User-Defined Copy Initialization -----");
 
-proc R.init=(type ThisType, other : ThisType) {
+proc R.init=(other : this.type) {
   writeln("copy-init from: ", other.type:string);
   this.T = other.T;
   this.x = other.x;
@@ -34,9 +34,9 @@ writeln("\n\n");
 
 writeln("----- Init= from non-record -----");
 
-proc R.init=(type ThisType, other : ThisType.T) {
+proc R.init=(other : this.type.T) {
   writeln("init= from ", other.type:string);
-  this.T = ThisType.T;
+  this.T = this.type.T;
   this.x = other;
 }
 

--- a/test/classes/initializers/initequals/temp-destroyed.chpl
+++ b/test/classes/initializers/initequals/temp-destroyed.chpl
@@ -6,8 +6,8 @@ record R {
   type T;
   var x : T;
 
-  proc init=(type ThisType, other: ThisType.T) {
-    this.T = ThisType.T;
+  proc init=(other: this.type.T) {
+    this.T = this.type.T;
     this.x = other;
   }
 }

--- a/test/classes/initializers/initequals/vector.chpl
+++ b/test/classes/initializers/initequals/vector.chpl
@@ -17,7 +17,7 @@ record Vector {
   }
 
   // Classic copy-initializer
-  proc init=(type ThisType, other : ThisType) {
+  proc init=(other : this.type) {
     writeln("classic copy init");
     this.T = other.T;
     this.D = other.D;
@@ -35,9 +35,9 @@ writeln("----- Classic Initialization -----");
 writeln("\n\n\n");
 
 // Initialize a particular Vector type from an array of the same eltType
-proc Vector.init=(type ThisType, data : [] ThisType.T) {
+proc Vector.init=(data : [] this.type.T) {
   writeln("typed init= from array");
-  this.T = ThisType.T;
+  this.T = this.type.T;
   this.D = data.domain;
   this.A = data;
 }

--- a/test/classes/initializers/initequals/wrongType.chpl
+++ b/test/classes/initializers/initequals/wrongType.chpl
@@ -3,7 +3,7 @@ record R {
   type T;
   var x : T;
 
-  proc init=(type ThisType, other: int) {
+  proc init=(other: int) {
     this.T = (int, int);
     this.x = (other, other);
   }

--- a/test/classes/initializers/records/generics/explicitAssignment.good
+++ b/test/classes/initializers/records/generics/explicitAssignment.good
@@ -1,3 +1,3 @@
 explicitAssignment.chpl:15: In function 'main':
-explicitAssignment.chpl:16: error: unresolved call 'Foo(real(64)).init=(type Foo(real(64)), Foo(int(64)))'
-explicitAssignment.chpl:3: note: candidates are: Foo.init=(type ThisType, other: ThisType)
+explicitAssignment.chpl:16: error: unresolved call 'Foo(real(64)).init=(Foo(int(64)))'
+explicitAssignment.chpl:3: note: candidates are: Foo.init=(other: this.type)

--- a/test/demo/review_060130/history_accumulator.chpl
+++ b/test/demo/review_060130/history_accumulator.chpl
@@ -10,8 +10,8 @@ record history_real {
     f = r;
   }
 
-  proc init=(type ThisType, r : real) {
-    this.size = ThisType.size;
+  proc init=(r : real) {
+    this.size = this.type.size;
     this.complete();
     add(r);
   }

--- a/test/library/standard/List/bradc/emptySeq3.good
+++ b/test/library/standard/List/bradc/emptySeq3.good
@@ -1,3 +1,2 @@
-emptySeq3.chpl:3: error: unresolved call 'list(int(64)).init=(type list(int(64)), nil)'
-$CHPL_HOME/modules/standard/List.chpl:77: note: candidates are: list.init=(type ThisType, l: list(?t))
-$CHPL_HOME/modules/standard/List.chpl:53: note:                 list.init=(type ThisType, other: ThisType)
+emptySeq3.chpl:3: error: unresolved call 'list(int(64)).init=(nil)'
+$CHPL_HOME/modules/standard/List.chpl:77: note: candidates are: list.init=(l: this.type )

--- a/test/library/standard/List/bradc/emptySeq3.good
+++ b/test/library/standard/List/bradc/emptySeq3.good
@@ -1,2 +1,3 @@
 emptySeq3.chpl:3: error: unresolved call 'list(int(64)).init=(nil)'
 $CHPL_HOME/modules/standard/List.chpl:77: note: candidates are: list.init=(l: this.type )
+$CHPL_HOME/modules/standard/List.chpl:53: note:                 list.init=(other: this.type)

--- a/test/types/records/init/generic/mismatch.good
+++ b/test/types/records/init/generic/mismatch.good
@@ -1,2 +1,2 @@
-mismatch.chpl:16: error: unresolved call 'A(int(64)).init=(type A(int(64)), A(real(64)))'
-mismatch.chpl:1: note: candidates are: A.init=(type ThisType, other: ThisType)
+mismatch.chpl:16: error: unresolved call 'A(int(64)).init=(A(real(64)))'
+mismatch.chpl:1: note: candidates are: A.init=(other: this.type)

--- a/test/types/records/init/generic/mismatch2.good
+++ b/test/types/records/init/generic/mismatch2.good
@@ -1,2 +1,2 @@
-mismatch2.chpl:20: error: unresolved call 'A(int(64)).init=(type A(int(64)), A(real(64)))'
-mismatch2.chpl:1: note: candidates are: A.init=(type ThisType, other: ThisType)
+mismatch2.chpl:20: error: unresolved call 'A(int(64)).init=(A(real(64)))'
+mismatch2.chpl:1: note: candidates are: A.init=(other: this.type)


### PR DESCRIPTION
This PR implements the init= portion of the "this.type" design proposal (#12318). The changes are essentially to:
- allow "this.type" in init= formals
- treat init= for a generic type as a generic function during resolution
- change the way a generic init= is invoked
- update relevant module and test code

Testing:
- [x] local
- [x] gasnet