### PR TITLE
Improve performance of cast from tuple to complex

### DIFF
--- a/modules/internal/ChapelTuple.chpl
+++ b/modules/internal/ChapelTuple.chpl
@@ -333,8 +333,8 @@ module ChapelTuple {
   //
   // TODO: These could instead use 'noinit' and manually assign the fields.
   //
-  // Note: statically inlining the _chpl_complex function is necessary for
-  // good performance
+  // Note: statically inlining the _chpl_complex runtime functions is necessary
+  // for good performance
   //
   inline proc _cast(type t, x: (?,?)) where t == complex(64) {
     extern proc _chpl_complex64(re:real(32),im:real(32)) : complex(64);

--- a/modules/internal/ChapelTuple.chpl
+++ b/modules/internal/ChapelTuple.chpl
@@ -331,18 +331,19 @@ module ChapelTuple {
   //
   // tuple casts to complex(64) and complex(128)
   //
+  // TODO: These could instead use 'noinit' and manually assign the fields.
+  //
+  // Note: statically inlining the _chpl_complex function is necessary for
+  // good performance
+  //
   inline proc _cast(type t, x: (?,?)) where t == complex(64) {
-    var c: complex(64);
-    c.re = x(1):real(32);
-    c.im = x(2):real(32);
-    return c;
+    extern proc _chpl_complex64(re:real(32),im:real(32)) : complex(64);
+    return _chpl_complex64(x(1):real(32),x(2):real(32));
   }
 
   inline proc _cast(type t, x: (?,?)) where t == complex(128) {
-    var c: complex(128);
-    c.re = x(1):real(64);
-    c.im = x(2):real(64);
-    return c;
+    extern proc _chpl_complex128(re:real(64),im:real(64)):complex(128);
+    return _chpl_complex128(x(1):real(64),x(2):real(64));
   }
 
   //

--- a/runtime/include/chpltypes.h
+++ b/runtime/include/chpltypes.h
@@ -252,8 +252,12 @@ typedef struct chpl_main_argument_s {
 } chpl_main_argument;
 
 #ifndef __cplusplus
-_complex128 _chpl_complex128(_real64 re, _real64 im);
-_complex64 _chpl_complex64(_real32 re, _real32 im);
+static _complex128 _chpl_complex128(_real64 re, _real64 im) {
+  return re + im*_Complex_I;
+}
+static _complex64 _chpl_complex64(_real32 re, _real32 im) {
+  return re + im*_Complex_I;
+}
 
 static inline _real64* complex128GetRealRef(_complex128* cplx) {
   return ((_real64*)cplx) + 0;

--- a/runtime/include/chpltypes.h
+++ b/runtime/include/chpltypes.h
@@ -252,10 +252,10 @@ typedef struct chpl_main_argument_s {
 } chpl_main_argument;
 
 #ifndef __cplusplus
-static _complex128 _chpl_complex128(_real64 re, _real64 im) {
+static inline _complex128 _chpl_complex128(_real64 re, _real64 im) {
   return re + im*_Complex_I;
 }
-static _complex64 _chpl_complex64(_real32 re, _real32 im) {
+static inline _complex64 _chpl_complex64(_real32 re, _real32 im) {
   return re + im*_Complex_I;
 }
 

--- a/runtime/src/chpltypes.c
+++ b/runtime/src/chpltypes.c
@@ -36,14 +36,6 @@
 #include <stdint.h>
 #include <string.h>
 
-_complex128 _chpl_complex128(_real64 re, _real64 im) {
-  return re + im*_Complex_I;
-}
-
-_complex64 _chpl_complex64(_real32 re, _real32 im) {
-  return re + im*_Complex_I;
-}
-
 int64_t real2int( _real64 f) {
   // need to use a union here rather than a pointer cast to avoid gcc
   // warnings when compiling -O3


### PR DESCRIPTION
PR  #12154 disabled noinit, which increased overhead when casting from tuples to complexes. This PR works around that by statically inlining and invoking the _chpl_complex runtime functions which directly create a complex instead of using an initialized temporary. There is some precedent (#4033) for statically inlining complex helper functions.

Closes #12347

Testing:
- [x] local

