### PR TITLE
Fix INT_ASSERTs that should be INT_FATAL

### DIFF
--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -3302,7 +3302,7 @@ static void expandQueryForActual(FnSymbol*  fn,
                        new CallExpr(PRIM_IS_SUBTYPE_ALLOW_VALUES,
                                     subtype, query->copy()));
     } else {
-      INT_ASSERT("case not handled");
+      INT_FATAL("case not handled");
     }
   } else if (subcall && doesCallContainGenericActual(subcall)) {
     Expr* subtype = NULL;

--- a/compiler/resolution/cullOverReferences.cpp
+++ b/compiler/resolution/cullOverReferences.cpp
@@ -1391,7 +1391,7 @@ void lowerContextCallPreferRefConstRef(ContextCallExpr* cc)
     which = USE_CONST_REF;
   } else {
     which = USE_VALUE;
-    INT_ASSERT("lowering context call with only 1 option");
+    INT_FATAL("lowering context call with only 1 option");
   }
 
   lowerContextCall(cc, which);
@@ -1413,7 +1413,7 @@ void lowerContextCallPreferConstRefValue(ContextCallExpr* cc)
     which = USE_VALUE;
   } else {
     which = USE_REF;
-    INT_ASSERT("lowering context call with only 1 option");
+    INT_FATAL("lowering context call with only 1 option");
   }
 
   lowerContextCall(cc, which);

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -1373,7 +1373,7 @@ static numeric_type_t classifyNumericType(Type* t)
   if (is_real_type(t)) return NUMERIC_TYPE_REAL;
   if (is_imag_type(t)) return NUMERIC_TYPE_IMAG;
   if (is_complex_type(t)) return NUMERIC_TYPE_COMPLEX;
-  INT_ASSERT("Unhandled type in classifyNumericType");
+  INT_FATAL("Unhandled type in classifyNumericType");
   return NUMERIC_TYPE_BOOL;
 }
 
@@ -1503,7 +1503,7 @@ static bool fits_in_mantissa_exponent(int mantissa_width,
     else if(imm->num_index == FLOAT_SIZE_64)
       v = imm->v_float64;
     else
-      INT_ASSERT("unsupported real/imag size");
+      INT_FATAL("unsupported real/imag size");
   } else if (imm->const_kind == NUM_KIND_COMPLEX) {
     if (imm->num_index == COMPLEX_SIZE_64) {
       if (realPart)
@@ -1516,9 +1516,9 @@ static bool fits_in_mantissa_exponent(int mantissa_width,
       else
         v = imm->v_complex128.i;
     } else
-      INT_ASSERT("unsupported complex size");
+      INT_FATAL("unsupported complex size");
   } else
-    INT_ASSERT("unsupported number kind");
+    INT_FATAL("unsupported number kind");
 
   double frac = 0.0;
   int exp = 0;

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -1356,6 +1356,7 @@ static Immediate* getImmediate(Symbol* actual) {
 }
 
 typedef enum {
+  NUMERIC_TYPE_NON_NUMERIC,
   NUMERIC_TYPE_BOOL,
   NUMERIC_TYPE_ENUM,
   NUMERIC_TYPE_INT_UINT,
@@ -1373,8 +1374,8 @@ static numeric_type_t classifyNumericType(Type* t)
   if (is_real_type(t)) return NUMERIC_TYPE_REAL;
   if (is_imag_type(t)) return NUMERIC_TYPE_IMAG;
   if (is_complex_type(t)) return NUMERIC_TYPE_COMPLEX;
-  INT_FATAL("Unhandled type in classifyNumericType");
-  return NUMERIC_TYPE_BOOL;
+
+  return NUMERIC_TYPE_NON_NUMERIC;
 }
 
 

--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -799,7 +799,7 @@ static Expr* preFoldPrimOp(CallExpr* call) {
 
     for_formals(formal, iterator) {
       if (formal->name  == astrTag && formal->type == gFollowerTag->type) {
-        INT_ASSERT("tag already present in PRIM_TO_FOLLOWER");
+        INT_FATAL("tag already present in PRIM_TO_FOLLOWER");
         // Could remove it, but would have to figure out what's
         // happening with followThis and fast too.
       }


### PR DESCRIPTION
I noticed that compiling the Chapel compiler itself with PGI was giving warnings for these cases. They're clearly wrong but many of them have been there for a long time.

- [x] full local testing

Trivial and not reviewed.