### PR TITLE
Error for "for zip(myIter(tag=leader), ...)"

### DIFF
--- a/compiler/AST/foralls.cpp
+++ b/compiler/AST/foralls.cpp
@@ -518,12 +518,6 @@ static ParIterFlavor findParIter(ForallStmt* pfs, CallExpr* iterCall,
 static FnSymbol* trivialLeader          = NULL;
 static Type*     trivialLeaderYieldType = NULL;
 
-static void hzsCheckParallelIterator(ForallStmt* fs, FnSymbol* origIterFn) {
-  if (isLeaderIterator(origIterFn) || isStandaloneIterator(origIterFn)) {
-    USR_FATAL(fs->iteratedExpressions().head, "Support for this combination of zippered iterators is not currently implemented");
-  }
-}
-
 // Return a _build_tuple of fs's index variables.
 static Expr* hzsMakeIndices(ForallStmt* fs) {
   if (fs->numInductionVars() == 1) {
@@ -638,7 +632,8 @@ will be hanled by existing code.
 static CallExpr* handleZipperedSerial(ForallStmt* fs, FnSymbol* origIterFn,
                                       CallExpr* iterCall, SymExpr* origSE)
 {
-  if (origIterFn) hzsCheckParallelIterator(fs, origIterFn);
+  if (origIterFn != NULL && isParallelIterator(origIterFn))
+    USR_FATAL(fs->iteratedExpressions().head, "Support for this combination of zippered iterators is not currently implemented");
 
   hzsBuildZipperedForLoop(fs, origIterFn, iterCall, origSE);
 

--- a/compiler/include/resolveFunction.h
+++ b/compiler/include/resolveFunction.h
@@ -32,8 +32,8 @@ void  resolveSignature(FnSymbol* fn);
 
 void  resolveFunction(FnSymbol* fn, CallExpr* forCall = 0);
 
+bool  isParallelIterator(FnSymbol* fn);
 bool  isLeaderIterator(FnSymbol* fn);
-
 bool  isStandaloneIterator(FnSymbol* fn);
 
 // If yieldType is not NULL, the type yielded by an iterator will

--- a/compiler/resolution/implementForallIntents2.cpp
+++ b/compiler/resolution/implementForallIntents2.cpp
@@ -21,62 +21,33 @@
 #include "ForallStmt.h"
 #include "ForLoop.h"
 #include "resolution.h"
+#include "resolveFunction.h"
 
 #include <map>
 #include <vector>
 
-/////////// EFLOPI: Enclosing For Loop Over Parallel Iterator ///////////
+// Todo: merge this file into foralls.cpp ?
 
-// 
-// Info we gather while looking for an eflopi or an enclosing forall loop
 //
-// The contents are valid only after a call to findEnclosingParallelLoop()
-// as follows:
+// If the loop is zippered, ensure there are no parallel iterators.
+// Because it is unclear how to execute a for-loop over parallel iterator(s).
+// When/if we address that, we need to convert this ForLoop to a ForallStmt.
+// Otherwise we may get data races on the shadow variable(s) 'sum' here:
+//   forall .... with (+ reduce sum) {
+//     for idx in zip(myIter(tag=standalone), anotherIter()) do
+//       sum reduce= f(idx);
+//   }
 //
-//  * 'eflopiForall' and 'eflopiLoop' are always set up
-//   -  to the corresponding ForallStmt or ForLoop node if one is found,
-//   -  to NULL if neither is found.
+// If a zippered loop is over a single iterator, we treat is as non-zippered.
 //
-//  * the other fields are set up only if eflopiLoop != NULL.
-//
-class EflopiInfo {
-public:
-  ForallStmt* eflopiForall;
-  ForLoop*    eflopiLoop;
-  // more details if eflopiLoop
-  CallExpr*   eflopiCall;
-  CallExpr*   asgnToIter;
-  Symbol*     iterCallTemp;
-};
-
-// Is 'call' invoking a parallel iterator?
-// Since the call is not resolved, we can't use isLeaderIterator(),
-// and this implementation is a heuristic.
-static bool callingParallelIterator(CallExpr* call) {
-  // Check 'call' for an actual argument that's a parallel tag.
-  // Todo: handle the case where the actual's value is not known yet.
-  for_actuals(actual, call) {
-
-    Expr* nonameActual = actual;
-    if (NamedExpr* ne = toNamedExpr(nonameActual)) {
-      nonameActual = ne->actual;
-    }
-
-    if (SymExpr* se = toSymExpr(nonameActual)) {
-      Symbol* tag = se->symbol();
-      // a quick check first
-      if (tag->type == gLeaderTag->type) {
-        if (tag == gLeaderTag ||
-            tag == gStandaloneTag ||
-            paramMap.get(tag) == gLeaderTag ||
-            paramMap.get(tag) == gStandaloneTag)
-          // yep, most likely over parallel iterator
-          return true;
-      }
-    }
+static void checkZipperedParallelIterators(ForLoop* loop, Type* iterType) {
+  for_fields(field, toAggregateType(iterType)) {
+    if (is_arithmetic_type(field->type)) continue; // skip 'size'
+    FnSymbol* iter = getTheIteratorFn(field->type);
+    if (isParallelIterator(iter))
+      USR_FATAL_CONT(loop, "A zipered for-loop over parallel iterator(s)"
+                           " is currently not implemented");
   }
-
-  return false;
 }
 
 //
@@ -87,71 +58,16 @@ static bool callingParallelIterator(CallExpr* call) {
 // We could improve it by using for_SymbolSymExprs()
 // or by having ForLoop include the iterator call directly.
 //
-static bool findCallToParallelIterator(ForLoop* forLoop, EflopiInfo& eInfo)
+static bool invokesParallelIterator(ForLoop* forLoop)
 {
   Symbol* iterSym = forLoop->iteratorGet()->symbol();
-
-  // Find an assignment to 'iterSym'.
-  // It is usually located within a short walk before forLoop.
-  CallExpr* asgnToIter = NULL;
-  for (Expr* curr = forLoop->prev; curr; curr = curr->prev)
-    if (CallExpr* call = toCallExpr(curr))
-      if (call->isPrimitive(PRIM_MOVE))
-        if (SymExpr* lhs1 = toSymExpr(call->get(1)))
-          if (lhs1->symbol() == iterSym) {
-            asgnToIter = call;
-            break;
-          }
-  INT_ASSERT(asgnToIter);
-
-  // We have:
-  //   move( call_tmp call( ITERATOR args... ) )
-  //   move( _iterator call( _getIterator call_tmp ) )
-  // We need to see if args... contain a leader or standalone tag.
-  // 'asgnToIter' is the second of the above moves. Find the first one.
-  CallExpr* rhs1 = toCallExpr(asgnToIter->get(2));
-  if (rhs1->isNamed("_build_tuple") ||
-      rhs1->isNamed("_getIteratorZip"))
-    // This is a zippered for-loop. Currently implies not parallel.
+  if (iterSym->type->symbol->hasFlag(FLAG_TUPLE)) {
+    checkZipperedParallelIterators(forLoop, iterSym->type);
     return false;
-  INT_ASSERT(rhs1->isNamed("_getIterator"));
-
-  Symbol* calltemp = toSymExpr(rhs1->get(1))->symbol();
-  CallExpr* asgnToCallTemp = NULL;
-  for (Expr* curr = asgnToIter->prev; curr; curr = curr->prev)
-    if (CallExpr* call = toCallExpr(curr))
-      if (call->isPrimitive(PRIM_MOVE))
-        if (SymExpr* lhs2 = toSymExpr(call->get(1)))
-          if (lhs2->symbol() == calltemp) {
-            asgnToCallTemp = call;
-            break;
-          }
-
-  // Sometimes, e.g. forall over a range - ri-5-c.chpl, _getIterator is invoked
-  // on a non-temp. We notice this by the absence of asgnToCallTemp.
-  // In such a case, the iterator will be nontemp.these(),
-  // which is not a parallel iterator.
-  if (!asgnToCallTemp)
-    return false;
-
-  CallExpr* iterCall = toCallExpr(asgnToCallTemp->get(2));
-  if (! iterCall) {
-    USR_STOP(); // do not crash if there have been user errors
-    INT_ASSERT(iterCall);
   }
 
-  if (callingParallelIterator(iterCall)) {
-    // Found it. Fill in the information before returning.
-    eInfo.eflopiForall   = NULL;
-    eInfo.eflopiLoop     = forLoop;
-    eInfo.eflopiCall     = iterCall;
-    eInfo.asgnToIter     = asgnToIter;
-    eInfo.iterCallTemp   = calltemp;
-    return true;
-  }
-
-  // no signs of a parallel iterator
-  return false;
+  FnSymbol* invokedIterator = getTheIteratorFn(iterSym->type);
+  return isParallelIterator(invokedIterator);
 }
 
 // We need expr->remove().
@@ -186,11 +102,39 @@ static bool isMoveToOIOI(SymExpr* se) {
   return false;
 }
 
-static ForallStmt* replaceEflopiWithForall(EflopiInfo& eInfo)
-{
-  // the loop to be replaced
-  ForLoop* src  = eInfo.eflopiLoop;
+// The ForLoop iterates over an _iteratorClass temp.
+// The ForallStmt needs to iterate over the _iteratorRecord temp
+// from which the _iteratorClass is obtained.
+// Then, we can remove the _iteratorClass temp.
+static void transferTheIterable(ForallStmt* dest, ForLoop* src) {
+  Symbol* IC = src->iteratorGet()->symbol();
 
+  SymExpr* icDef = IC->getSingleDef();
+  CallExpr* icMove = toCallExpr(icDef->parentExpr);
+  INT_ASSERT(icMove->isPrimitive(PRIM_MOVE));
+
+  CallExpr* icSrc = toCallExpr(icMove->get(2));
+  INT_ASSERT(icSrc->isNamed("_getIterator")    ||
+             icSrc->isNamed("_getIteratorZip") );
+  INT_ASSERT(icSrc->numActuals() == 1); // a single iterable
+
+  // This is our _iteratorRecord temp.
+  Symbol* IR = toSymExpr(icSrc->get(1))->symbol();
+  dest->iteratedExpressions().insertAtHead(new SymExpr(IR));
+
+  // Remove the _iteratorClass temp.
+  src->iteratorGet()->remove(); // get it out of the way
+  icMove->remove();
+  for_SymbolSymExprs(icSE, IC)
+    removeWithEnclosing(icSE->getStmtExpr());
+  IC->defPoint->remove();
+
+  // no more uses
+  INT_ASSERT(IC->firstSymExpr() == NULL);
+}
+
+static ForallStmt* doReplaceWithForall(ForLoop* src)
+{
   // Otherwise currentAstLoc points to the forall loop
   // that invokes the iterator src->parentSymbol.
   SET_LINENO(src);
@@ -234,18 +178,7 @@ static ForallStmt* replaceEflopiWithForall(EflopiInfo& eInfo)
 
   INT_ASSERT(onlySingleUse || gotMoveToOIOI);
 
-  // set the iterator call
-  dest->iteratedExpressions().insertAtHead(new SymExpr(eInfo.iterCallTemp));
-
-  // remove _iterator that keeps the iterator class
-  Symbol* IC = src->iteratorGet()->symbol();
-  src->iteratorGet()->remove(); // get it out of the way
-  for_SymbolSymExprs(icSE, IC)
-    removeWithEnclosing(icSE->getStmtExpr());
-  IC->defPoint->remove();
-
-  // no more uses
-  INT_ASSERT(IC->firstSymExpr() == NULL);
+  transferTheIterable(dest, src);
 
   // no with-clause adjustments - the for loop does not have one
 
@@ -261,17 +194,22 @@ static ForallStmt* replaceEflopiWithForall(EflopiInfo& eInfo)
   return dest;
 }
 
-// Replace a parallel ForLoop with a ForallStmt.
+//
+// Replace a parallel ForLoop over a parallel iterator with a ForallStmt.
+// Otherwise we may get data races, ex. on shadow variable(s) 'sum' here:
+//   forall .... with (+ reduce sum) {
+//     for idx in myIter(tag=standalone) do
+//       sum reduce= f(idx);
+//   }
+//
 Expr* replaceForWithForallIfNeeded(ForLoop* forLoop) {
-  EflopiInfo eflopiInfo;
-
-  if (!findCallToParallelIterator(forLoop, eflopiInfo))
+  if (!invokesParallelIterator(forLoop))
     // Not a parallel for-loop. Leave it unchanged.
     return forLoop;
 
   // Yes, it is a parallel for-loop. Replace it.
-  // findCallToParallelIterator() filled out eflopiInfo.
-  ForallStmt* fs = replaceEflopiWithForall(eflopiInfo);
+  // invokesParallelIterator() filled out eflopiInfo.
+  ForallStmt* fs = doReplaceWithForall(forLoop);
 
   // If >1 iterated exprs, how to call resolveForallHeader?
   INT_ASSERT(fs->numIteratedExprs() == 1);

--- a/compiler/resolution/implementForallIntents2.cpp
+++ b/compiler/resolution/implementForallIntents2.cpp
@@ -169,7 +169,7 @@ static ForallStmt* doReplaceWithForall(ForLoop* src)
         if (idxSE == srcIndex->getSingleUse()) {
           // great
         } else {
-          // happens for eflopies in extendLeader()-ed iterators
+          // todo: does this ever happen?
           if (isMoveToOIOI(idxSE)) gotMoveToOIOI = true;
         }
       }
@@ -208,7 +208,6 @@ Expr* replaceForWithForallIfNeeded(ForLoop* forLoop) {
     return forLoop;
 
   // Yes, it is a parallel for-loop. Replace it.
-  // invokesParallelIterator() filled out eflopiInfo.
   ForallStmt* fs = doReplaceWithForall(forLoop);
 
   // If >1 iterated exprs, how to call resolveForallHeader?

--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -561,9 +561,9 @@ static void markIterator(FnSymbol* fn) {
   }
 
   //
-  // Mark leader and standalone parallel iterators for inlining.
+  // Mark parallel iterators for inlining.
   //
-  if (isLeaderIterator(fn) || isStandaloneIterator(fn)) {
+  if (isParallelIterator(fn)) {
     fn->addFlag(FLAG_INLINE_ITERATOR);
   }
 }
@@ -604,6 +604,21 @@ static bool isIteratorOfType(FnSymbol* fn, Symbol* iterTag) {
   }
 
   return retval;
+}
+
+// leader or standalone
+bool isParallelIterator(FnSymbol* fn) {
+  if (!fn->isIterator())
+    return false;
+
+  for_formals(formal, fn) {
+    if (formal->type == gLeaderTag->type          &&
+        (paramMap.get(formal) == gLeaderTag    ||
+         paramMap.get(formal) == gStandaloneTag )  )
+      return true;
+  }
+
+  return false;
 }
 
 /************************************* | **************************************

--- a/test/functions/iterators/elliot/isRefIter/class-isRefIter.chpl
+++ b/test/functions/iterators/elliot/isRefIter/class-isRefIter.chpl
@@ -1,5 +1,6 @@
 // Test that isRefIter() works for various non-these() iterators on classes
 
+use printrefness;
 
 //
 // class with ref and non-ref versions of serial, standalone, and l/f iters
@@ -47,9 +48,6 @@ writeln(isRefIter(c.myRefIter(tag=iterKind.follower, 0)));
 //
 // check ref-ness of iters when passed as an argument to a proc
 //
-proc printIterRefness(myIter) where  isRefIter(myIter) { writeln("ref iter"); }
-proc printIterRefness(myIter) where !isRefIter(myIter) { writeln("val iter"); }
-
 printIterRefness(c.myValIter());
 printIterRefness(c.myRefIter());
 
@@ -66,23 +64,14 @@ printIterRefness(c.myRefIter(tag=iterKind.follower, 0));
 //
 // check ref-ness of iters when passed as an argument to a wrapping iter
 //
-iter printIterRefnessWrapper(myIter) ref where isRefIter(myIter) {
-  writeln("ref iter");
-  for i in myIter do yield i;
-}
-iter printIterRefnessWrapper(myIter) where !isRefIter(myIter) {
-  writeln("val iter");
-  for i in myIter do yield i;
-}
-
 for i in printIterRefnessWrapper(c.myValIter()) do;
 for i in printIterRefnessWrapper(c.myRefIter()) do;
 
-for i in printIterRefnessWrapper(c.myValIter(tag=iterKind.standalone)) do;
-for i in printIterRefnessWrapper(c.myRefIter(tag=iterKind.standalone)) do;
+for i in printIterRefnessWrapperP(c.myValIter(tag=iterKind.standalone)) do;
+for i in printIterRefnessWrapperP(c.myRefIter(tag=iterKind.standalone)) do;
 
-for i in printIterRefnessWrapper(c.myValIter(tag=iterKind.leader)) do;
-for i in printIterRefnessWrapper(c.myRefIter(tag=iterKind.leader)) do
+for i in printIterRefnessWrapperP(c.myValIter(tag=iterKind.leader)) do;
+for i in printIterRefnessWrapperP(c.myRefIter(tag=iterKind.leader)) do
 
 for i in printIterRefnessWrapper(c.myValIter(tag=iterKind.follower, 0)) do;
 for i in printIterRefnessWrapper(c.myRefIter(tag=iterKind.follower, 0)) do;

--- a/test/functions/iterators/elliot/isRefIter/class-ref-these-isRefIter.chpl
+++ b/test/functions/iterators/elliot/isRefIter/class-ref-these-isRefIter.chpl
@@ -1,5 +1,6 @@
 // Test that isRefIter() works for ref these() iterators on classes
 
+use printrefness;
 
 //
 // class with ref versions of serial, standalone, and l/f iters
@@ -37,9 +38,6 @@ writeln(isRefIter(c.these(tag=iterKind.follower, 0)));
 // ensure iterators are correctly identified as ref iters when passed as an
 // argument to a proc
 //
-proc printIterRefness(myIter) where  isRefIter(myIter) { writeln("ref iter"); }
-proc printIterRefness(myIter) where !isRefIter(myIter) { writeln("val iter"); }
-
 printIterRefness(c.these());
 
 printIterRefness(c.these(tag=iterKind.standalone));
@@ -53,20 +51,11 @@ printIterRefness(c.these(tag=iterKind.follower, 0));
 // ensure iterators are correctly identified as ref iters when passed as an
 // argument to a wrapping iter
 //
-iter printIterRefnessWrapper(myIter) ref where isRefIter(myIter) {
-  writeln("ref iter");
-  for i in myIter do yield i;
-}
-iter printIterRefnessWrapper(myIter) where !isRefIter(myIter) {
-  writeln("val iter");
-  for i in myIter do yield i;
-}
-
 for i in printIterRefnessWrapper(c.these()) do;
 
-for i in printIterRefnessWrapper(c.these(tag=iterKind.standalone)) do;
+for i in printIterRefnessWrapperP(c.these(tag=iterKind.standalone)) do;
 
-for i in printIterRefnessWrapper(c.these(tag=iterKind.leader)) do;
+for i in printIterRefnessWrapperP(c.these(tag=iterKind.leader)) do;
 
 for i in printIterRefnessWrapper(c.these(tag=iterKind.follower, 0)) do;
 
@@ -75,13 +64,4 @@ for i in printIterRefnessWrapper(c.these(tag=iterKind.follower, 0)) do;
 // ensure iterators are correctly identified as ref iters when a class
 // implementing a these() iterator is passed as an argument to a wrapping iter
 //
-iter printIterRefnessWrapper2(myCls) ref where isRefIter(_getIterator(myCls)) {
-  writeln("ref iter");
-  for i in myCls do yield i;
-}
-iter printIterRefnessWrapper2(myCls) where !isRefIter(_getIterator(myCls)) {
-  writeln("val iter");
-  for i in myCls do yield i;
-}
-
 for i in printIterRefnessWrapper2(c) do;

--- a/test/functions/iterators/elliot/isRefIter/class-val-these-isRefIter.chpl
+++ b/test/functions/iterators/elliot/isRefIter/class-val-these-isRefIter.chpl
@@ -1,5 +1,6 @@
 // Test that isRefIter() works for non-ref (val) these() iterators on classes
 
+use printrefness;
 
 //
 // class with val versions of serial, standalone, and l/f iters
@@ -37,9 +38,6 @@ writeln(isRefIter(c.these(tag=iterKind.follower, 0)));
 // ensure iterators are correctly identified as val iters when passed as an
 // argument to a proc
 //
-proc printIterRefness(myIter) where  isRefIter(myIter) { writeln("ref iter"); }
-proc printIterRefness(myIter) where !isRefIter(myIter) { writeln("val iter"); }
-
 printIterRefness(c.these());
 
 printIterRefness(c.these(tag=iterKind.standalone));
@@ -53,20 +51,11 @@ printIterRefness(c.these(tag=iterKind.follower, 0));
 // ensure iterators are correctly identified as val iters when passed as an
 // argument to a wrapping iter
 //
-iter printIterRefnessWrapper(myIter) ref where isRefIter(myIter) {
-  writeln("ref iter");
-  for i in myIter do yield i;
-}
-iter printIterRefnessWrapper(myIter) where !isRefIter(myIter) {
-  writeln("val iter");
-  for i in myIter do yield i;
-}
-
 for i in printIterRefnessWrapper(c.these()) do;
 
-for i in printIterRefnessWrapper(c.these(tag=iterKind.standalone)) do;
+for i in printIterRefnessWrapperP(c.these(tag=iterKind.standalone)) do;
 
-for i in printIterRefnessWrapper(c.these(tag=iterKind.leader)) do;
+for i in printIterRefnessWrapperP(c.these(tag=iterKind.leader)) do;
 
 for i in printIterRefnessWrapper(c.these(tag=iterKind.follower, 0)) do;
 
@@ -75,13 +64,4 @@ for i in printIterRefnessWrapper(c.these(tag=iterKind.follower, 0)) do;
 // ensure iterators are correctly identified as val iters when a class
 // implementing a these() iterator is passed as an argument to a wrapping iter
 //
-iter printIterRefnessWrapper2(myCls) ref where isRefIter(_getIterator(myCls)) {
-  writeln("ref iter");
-  for i in myCls do yield i;
-}
-iter printIterRefnessWrapper2(myCls) where !isRefIter(_getIterator(myCls)) {
-  writeln("val iter");
-  for i in myCls do yield i;
-}
-
 for i in printIterRefnessWrapper2(c) do;

--- a/test/functions/iterators/elliot/isRefIter/printrefness.chpl
+++ b/test/functions/iterators/elliot/isRefIter/printrefness.chpl
@@ -1,0 +1,45 @@
+// Functions+iterators that report iterator-refness of the argument.
+
+//
+// the argument is an iterator call
+//
+proc printIterRefness(myIter) where  isRefIter(myIter) { writeln("ref iter"); }
+proc printIterRefness(myIter) where !isRefIter(myIter) { writeln("val iter"); }
+
+//
+// the argument is an iterator call
+//
+iter printIterRefnessWrapper(myIter) ref where isRefIter(myIter) {
+  writeln("ref iter");
+  for i in myIter do yield i;
+}
+iter printIterRefnessWrapper(myIter) where !isRefIter(myIter) {
+  writeln("val iter");
+  for i in myIter do yield i;
+}
+
+//
+// the argument is a parallel iterator call
+// avoid iterating over it
+//
+var globalVar: int;
+iter printIterRefnessWrapperP(myIter) ref where isRefIter(myIter) {
+  writeln("ref iter");
+  yield globalVar;
+}
+iter printIterRefnessWrapperP(myIter) where !isRefIter(myIter) {
+  writeln("val iter");
+  yield globalVar;
+}
+
+//
+// the argument is a record or class
+//
+iter printIterRefnessWrapper2(myRec) ref where isRefIter(_getIterator(myRec)) {
+  writeln("ref iter");
+  for i in myRec do yield i;
+}
+iter printIterRefnessWrapper2(myRec) where !isRefIter(_getIterator(myRec)) {
+  writeln("val iter");
+  for i in myRec do yield i;
+}

--- a/test/functions/iterators/elliot/isRefIter/record-isRefIter.chpl
+++ b/test/functions/iterators/elliot/isRefIter/record-isRefIter.chpl
@@ -1,5 +1,6 @@
 // Test that isRefIter() works for various non-these() iterators on records
 
+use printrefness;
 
 //
 // record with ref and non-ref versions of serial, standalone, and l/f iters
@@ -47,9 +48,6 @@ writeln(isRefIter(r.myRefIter(tag=iterKind.follower, 0)));
 //
 // check ref-ness of iters when passed as an argument to a proc
 //
-proc printIterRefness(myIter) where  isRefIter(myIter) { writeln("ref iter"); }
-proc printIterRefness(myIter) where !isRefIter(myIter) { writeln("val iter"); }
-
 printIterRefness(r.myValIter());
 printIterRefness(r.myRefIter());
 
@@ -66,23 +64,14 @@ printIterRefness(r.myRefIter(tag=iterKind.follower, 0));
 //
 // check ref-ness of iters when passed as an argument to a wrapping iter
 //
-iter printIterRefnessWrapper(myIter) ref where isRefIter(myIter) {
-  writeln("ref iter");
-  for i in myIter do yield i;
-}
-iter printIterRefnessWrapper(myIter) where !isRefIter(myIter) {
-  writeln("val iter");
-  for i in myIter do yield i;
-}
-
 for i in printIterRefnessWrapper(r.myValIter()) do;
 for i in printIterRefnessWrapper(r.myRefIter()) do;
 
-for i in printIterRefnessWrapper(r.myValIter(tag=iterKind.standalone)) do;
-for i in printIterRefnessWrapper(r.myRefIter(tag=iterKind.standalone)) do;
+for i in printIterRefnessWrapperP(r.myValIter(tag=iterKind.standalone)) do;
+for i in printIterRefnessWrapperP(r.myRefIter(tag=iterKind.standalone)) do;
 
-for i in printIterRefnessWrapper(r.myValIter(tag=iterKind.leader)) do;
-for i in printIterRefnessWrapper(r.myRefIter(tag=iterKind.leader)) do
+for i in printIterRefnessWrapperP(r.myValIter(tag=iterKind.leader)) do;
+for i in printIterRefnessWrapperP(r.myRefIter(tag=iterKind.leader)) do
 
 for i in printIterRefnessWrapper(r.myValIter(tag=iterKind.follower, 0)) do;
 for i in printIterRefnessWrapper(r.myRefIter(tag=iterKind.follower, 0)) do;

--- a/test/functions/iterators/elliot/isRefIter/record-ref-these-isRefIter.chpl
+++ b/test/functions/iterators/elliot/isRefIter/record-ref-these-isRefIter.chpl
@@ -1,5 +1,6 @@
 // Test that isRefIter() works for ref these() iterators on records
 
+use printrefness;
 
 //
 // record with ref versions of serial, standalone, and l/f iters
@@ -37,9 +38,6 @@ writeln(isRefIter(r.these(tag=iterKind.follower, 0)));
 // ensure iterators are correctly identified as ref iters when passed as an
 // argument to a proc
 //
-proc printIterRefness(myIter) where  isRefIter(myIter) { writeln("ref iter"); }
-proc printIterRefness(myIter) where !isRefIter(myIter) { writeln("val iter"); }
-
 printIterRefness(r.these());
 
 printIterRefness(r.these(tag=iterKind.standalone));
@@ -53,20 +51,11 @@ printIterRefness(r.these(tag=iterKind.follower, 0));
 // ensure iterators are correctly identified as ref iters when passed as an
 // argument to a wrapping iter
 //
-iter printIterRefnessWrapper(myIter) ref where isRefIter(myIter) {
-  writeln("ref iter");
-  for i in myIter do yield i;
-}
-iter printIterRefnessWrapper(myIter) where !isRefIter(myIter) {
-  writeln("val iter");
-  for i in myIter do yield i;
-}
-
 for i in printIterRefnessWrapper(r.these()) do;
 
-for i in printIterRefnessWrapper(r.these(tag=iterKind.standalone)) do;
+for i in printIterRefnessWrapperP(r.these(tag=iterKind.standalone)) do;
 
-for i in printIterRefnessWrapper(r.these(tag=iterKind.leader)) do;
+for i in printIterRefnessWrapperP(r.these(tag=iterKind.leader)) do;
 
 for i in printIterRefnessWrapper(r.these(tag=iterKind.follower, 0)) do;
 
@@ -75,13 +64,4 @@ for i in printIterRefnessWrapper(r.these(tag=iterKind.follower, 0)) do;
 // ensure iterators are correctly identified as ref iters when a record
 // implementing a these() iterator is passed as an argument to a wrapping iter
 //
-iter printIterRefnessWrapper2(myRec) ref where isRefIter(_getIterator(myRec)) {
-  writeln("ref iter");
-  for i in myRec do yield i;
-}
-iter printIterRefnessWrapper2(myRec) where !isRefIter(_getIterator(myRec)) {
-  writeln("val iter");
-  for i in myRec do yield i;
-}
-
 for i in printIterRefnessWrapper2(r) do;

--- a/test/functions/iterators/elliot/isRefIter/record-val-these-isRefIter.chpl
+++ b/test/functions/iterators/elliot/isRefIter/record-val-these-isRefIter.chpl
@@ -1,5 +1,6 @@
 // Test that isRefIter() works for non-ref (val) these() iterators on records
 
+use printrefness;
 
 //
 // record with val versions of serial, standalone, and l/f iters
@@ -37,9 +38,6 @@ writeln(isRefIter(r.these(tag=iterKind.follower, 0)));
 // ensure iterators are correctly identified as val iters when passed as an
 // argument to a proc
 //
-proc printIterRefness(myIter) where  isRefIter(myIter) { writeln("ref iter"); }
-proc printIterRefness(myIter) where !isRefIter(myIter) { writeln("val iter"); }
-
 printIterRefness(r.these());
 
 printIterRefness(r.these(tag=iterKind.standalone));
@@ -53,20 +51,11 @@ printIterRefness(r.these(tag=iterKind.follower, 0));
 // ensure iterators are correctly identified as val iters when passed as an
 // argument to a wrapping iter
 //
-iter printIterRefnessWrapper(myIter) ref where isRefIter(myIter) {
-  writeln("ref iter");
-  for i in myIter do yield i;
-}
-iter printIterRefnessWrapper(myIter) where !isRefIter(myIter) {
-  writeln("val iter");
-  for i in myIter do yield i;
-}
-
 for i in printIterRefnessWrapper(r.these()) do;
 
-for i in printIterRefnessWrapper(r.these(tag=iterKind.standalone)) do;
+for i in printIterRefnessWrapperP(r.these(tag=iterKind.standalone)) do;
 
-for i in printIterRefnessWrapper(r.these(tag=iterKind.leader)) do;
+for i in printIterRefnessWrapperP(r.these(tag=iterKind.leader)) do;
 
 for i in printIterRefnessWrapper(r.these(tag=iterKind.follower, 0)) do;
 
@@ -75,13 +64,4 @@ for i in printIterRefnessWrapper(r.these(tag=iterKind.follower, 0)) do;
 // ensure iterators are correctly identified as val iters when a record
 // implementing a these() iterator is passed as an argument to a wrapping iter
 //
-iter printIterRefnessWrapper2(myRec) ref where isRefIter(_getIterator(myRec)) {
-  writeln("ref iter");
-  for i in myRec do yield i;
-}
-iter printIterRefnessWrapper2(myRec) where !isRefIter(_getIterator(myRec)) {
-  writeln("val iter");
-  for i in myRec do yield i;
-}
-
 for i in printIterRefnessWrapper2(r) do;

--- a/test/functions/iterators/elliot/isRefIter/standalone-isRefIter.chpl
+++ b/test/functions/iterators/elliot/isRefIter/standalone-isRefIter.chpl
@@ -1,6 +1,7 @@
 // Test that isRefIter() works for various standalone iterators. Standalone in
 // the sense that they're not iterators on a class or record
 
+use printrefness;
 
 //
 // declare ref and non-ref versions of serial, standalone, and l/f iters
@@ -45,9 +46,6 @@ writeln(isRefIter(myRefIter(tag=iterKind.follower, 0)));
 //
 // check ref-ness of iters when passed as an argument to a proc
 //
-proc printIterRefness(myIter) where  isRefIter(myIter) { writeln("ref iter"); }
-proc printIterRefness(myIter) where !isRefIter(myIter) { writeln("val iter"); }
-
 printIterRefness(myValIter());
 printIterRefness(myRefIter());
 
@@ -64,23 +62,14 @@ printIterRefness(myRefIter(tag=iterKind.follower, 0));
 //
 // check ref-ness of iters when passed as an argument to a wrapping iter
 //
-iter printIterRefnessWrapper(myIter) ref where isRefIter(myIter) {
-  writeln("ref iter");
-  for i in myIter do yield i;
-}
-iter printIterRefnessWrapper(myIter) where !isRefIter(myIter) {
-  writeln("val iter");
-  for i in myIter do yield i;
-}
-
 for i in printIterRefnessWrapper(myValIter()) do;
 for i in printIterRefnessWrapper(myRefIter()) do;
 
-for i in printIterRefnessWrapper(myValIter(tag=iterKind.standalone)) do;
-for i in printIterRefnessWrapper(myRefIter(tag=iterKind.standalone)) do;
+for i in printIterRefnessWrapperP(myValIter(tag=iterKind.standalone)) do;
+for i in printIterRefnessWrapperP(myRefIter(tag=iterKind.standalone)) do;
 
-for i in printIterRefnessWrapper(myValIter(tag=iterKind.leader)) do;
-for i in printIterRefnessWrapper(myRefIter(tag=iterKind.leader)) do
+for i in printIterRefnessWrapperP(myValIter(tag=iterKind.leader)) do;
+for i in printIterRefnessWrapperP(myRefIter(tag=iterKind.leader)) do
 
 for i in printIterRefnessWrapper(myValIter(tag=iterKind.follower, 0)) do;
 for i in printIterRefnessWrapper(myRefIter(tag=iterKind.follower, 0)) do;

--- a/test/parallel/forall/may-vs-must-par/zippered-for-errors.chpl
+++ b/test/parallel/forall/may-vs-must-par/zippered-for-errors.chpl
@@ -1,0 +1,10 @@
+
+iter myIter()           { yield 5; }
+iter myIter(param tag)  { yield 6; }
+iter notherIter()       { yield 7; }
+
+for idx in zip(myIter(iterKind.leader), notherIter()) do
+  writeln(idx);
+
+for idx in zip(notherIter(), myIter(iterKind.standalone)) do
+  writeln(idx);

--- a/test/parallel/forall/may-vs-must-par/zippered-for-errors.good
+++ b/test/parallel/forall/may-vs-must-par/zippered-for-errors.good
@@ -1,0 +1,2 @@
+zippered-for-errors.chpl:6: error: A zipered for-loop over parallel iterator(s) is currently not implemented
+zippered-for-errors.chpl:9: error: A zipered for-loop over parallel iterator(s) is currently not implemented


### PR DESCRIPTION
### Summary

* Check for a case for which we do not have good semantics
  and which we most likely do not compile properly today.
  Background: https://github.com/chapel-lang/chapel/pull/12357#discussion_r258208652

* Adjust tests in functions/iterators/elliot/isRefIter,
  see details below.

* Simplify the code, including removal of some pattern matching
  and removal of the term "eflopi".

* Introduce `isParallelIterator()`, for convenience.

### Details

This change simplifies the code in implementForallIntents2.cpp and
strengthens checking for a corner case where we could potentially
generate racy code.

That change broke the tests in functions/iterators/elliot/isRefIter,
which reported an error whenever a leader or standalone iterator call
is passed to printIterRefnessWrapper(), which tries to iterate over it.

```chpl
// ok
for i in printIterRefnessWrapper(c.myValIter()) do;

// "unimplemented" error
for i in printIterRefnessWrapper(c.myValIter(tag=iterKind.standalone)) do;
```

I adjust the tests to pass leader/standalone iterator calls to a slight mod
of printIterRefnessWrapper(), which does not iterate over it.

While there, I factor out the helper procs+iters into a separate file.

### More details - 1

When we pass a leader or standalone iterator to printIterRefnessWrapper(),
the compiler converts its "for i in myIter" loop to a ForallStmt.
See below for the reason.

A ForallStmt needs to have a CallExpr as its iterable. For example:
```chpl
forall i in someIter() do ....
```

Because a ForallStmt is lowered by inlining that call. It is like a
ForLoop that is lowered by inlining. Except a ForallStmt currently
does not have an alternative implementation that works without inlining.

A ForallStmt over a formal argument falls into this unimplemented case.
Because there is no readily-available CallExpr to inline.

So the compiler generates an error saying that. This happens in the
`for i in myIter` case when myIter is passed a parallel iterator.

### More details - 2

Why convert a for-loop over a parallel iterator to a forall-loop?

This is needed to ensure no data races. For example:

```chpl
forall .... with (+ reduce sum) {
  writeln("sum=", sum);
  for idx in myIter(tag=iterKind.standalone) do
    sum += idx;
}
```

When compiling a forall-loop, each task gets its own shadow variable
for 'sum'. The writeln() implicitly accesses the shadow variable for its task.

Cf. when compiling a for-loop, all iterations access the same 'sum'
variable. In the above example, that would be the shadow variable
accessed by the writeln().

If `myIter(tag=iterKind.standalone)` generates concurrent tasks,
they will race for that shadow variable.

To avoid that, the compiler checks each for-loop for a parallel
iterator. When found, it converts the AST representation from ForLoop
to an equivalent ForallStmt.
