### PR TITLE
Use cmath if the compiler reports it is C++11

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -55,7 +55,15 @@
 
 #include <algorithm>
 #include <cctype>
-#include <math.h> // could be cmath once we assume C++11
+
+// TODO: simplify this once we can rely on C++11
+#if __cplusplus > 199711L
+#include <cmath>
+using namespace std;
+#else
+#include <math.h>
+#endif
+
 #include <cstring>
 #include <cstdio>
 #include <vector>

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -20,6 +20,7 @@
 #include "codegen.h"
 
 #include "astutil.h"
+#include "chplmath.h"
 #include "clangBuiltinsWrappedSet.h"
 #include "clangUtil.h"
 #include "config.h"
@@ -55,14 +56,6 @@
 
 #include <algorithm>
 #include <cctype>
-
-// TODO: simplify this once we can rely on C++11
-#if __cplusplus > 199711L
-#include <cmath>
-using namespace std;
-#else
-#include <math.h>
-#endif
 
 #include <cstring>
 #include <cstdio>
@@ -2509,15 +2502,15 @@ std::string real_to_string(double num)
 {
   char buf[32];
 
-  if (isfinite(num)) {
-    if (signbit(num)) snprintf(buf, sizeof(buf), "-%a" , -num);
-    else              snprintf(buf, sizeof(buf), "%a" , num);
-  } else if (isinf(num)) {
-    if (signbit(num)) strncpy(buf, "-INFINITY", sizeof(buf));
-    else              strncpy(buf, "INFINITY", sizeof(buf));
+  if (chpl_isfinite(num)) {
+    if (chpl_signbit(num)) snprintf(buf, sizeof(buf), "-%a" , -num);
+    else                   snprintf(buf, sizeof(buf), "%a" , num);
+  } else if (chpl_isinf(num)) {
+    if (chpl_signbit(num)) strncpy(buf, "-INFINITY", sizeof(buf));
+    else                   strncpy(buf, "INFINITY", sizeof(buf));
   } else {
-    if (signbit(num)) strncpy(buf, "-NAN", sizeof(buf));
-    else              strncpy(buf, "NAN", sizeof(buf));
+    if (chpl_signbit(num)) strncpy(buf, "-NAN", sizeof(buf));
+    else                   strncpy(buf, "NAN", sizeof(buf));
   }
   std::string ret(buf);
   return ret;

--- a/compiler/ifa/num.cpp
+++ b/compiler/ifa/num.cpp
@@ -21,7 +21,15 @@
 #define __STDC_FORMAT_MACROS
 #endif
 #include <inttypes.h>
-#include <math.h> // could be cmath once we assume C++11
+
+// TODO: simplify this once we can rely on C++11
+#if __cplusplus > 199711L
+#include <cmath>
+using namespace std;
+#else
+#include <math.h>
+#endif
+
 #include <cstring>
 #include <cstdio>
 #include "num.h"

--- a/compiler/ifa/num.cpp
+++ b/compiler/ifa/num.cpp
@@ -22,26 +22,19 @@
 #endif
 #include <inttypes.h>
 
-// TODO: simplify this once we can rely on C++11
-#if __cplusplus > 199711L
-#include <cmath>
-using namespace std;
-#else
-#include <math.h>
-#endif
-
 #include <cstring>
 #include <cstdio>
+#include "chplmath.h"
 #include "num.h"
 #include "prim_data.h"
 #include "stringutil.h"
 
 static int
 snprint_float_val(char* buf, size_t max, double val, bool hex) {
-  if (isfinite(val)) {
+  if (chpl_isfinite(val)) {
     int nc = 0;
-    if (signbit(val)) nc = snprintf(buf, max, "-%g" , -val);
-    else              nc = snprintf(buf, max, "%g" , val);
+    if (chpl_signbit(val)) nc = snprintf(buf, max, "-%g" , -val);
+    else                   nc = snprintf(buf, max, "%g" , val);
 
     if (strchr(buf, '.') == NULL &&
         strchr(buf, 'e') == NULL &&
@@ -51,13 +44,13 @@ snprint_float_val(char* buf, size_t max, double val, bool hex) {
     } else {
       return nc;
     }
-  } else if (isinf(val)) {
-    if (signbit(val)) strncpy(buf, "-INFINITY", max);
-    else              strncpy(buf, "INFINITY", max);
+  } else if (chpl_isinf(val)) {
+    if (chpl_signbit(val)) strncpy(buf, "-INFINITY", max);
+    else                   strncpy(buf, "INFINITY", max);
     return strlen(buf);
   } else {
-    if (signbit(val)) strncpy(buf, "-NAN", max);
-    else              strncpy(buf, "NAN", max);
+    if (chpl_signbit(val)) strncpy(buf, "-NAN", max);
+    else                   strncpy(buf, "NAN", max);
     return strlen(buf);
   }
 }
@@ -74,7 +67,7 @@ static int
 snprint_complex_val(char* str, size_t max, double real, double imm) {
   int numchars = 0;
   numchars += snprint_float_val(str+numchars, max-numchars, real, false);
-  if (signbit(imm)) {
+  if (chpl_signbit(imm)) {
     numchars += snprintf(str+numchars, max-numchars, " - ");
     numchars += snprint_float_val(str+numchars, max-numchars, -imm, false);
   } else {

--- a/compiler/include/chplmath.h
+++ b/compiler/include/chplmath.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2004-2019 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ * 
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * 
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _CHPLMATH_H_
+#define _CHPLMATH_H_
+
+/* Wrappers for some math functions that aren't available before C++11.
+   This header and these functions can be removed once we assume C++11. */
+
+#if defined __cplusplus && __cplusplus >= 201103L
+#include <cmath>
+static inline bool chpl_signbit(double val) { return std::signbit(val); }
+static inline bool chpl_isinf(double val) { return std::isinf(val); }
+static inline bool chpl_isfinite(double val) { return std::isfinite(val); }
+#else
+#include <math.h>
+static inline bool chpl_signbit(double val) { return signbit(val); }
+static inline bool chpl_isinf(double val) { return isinf(val); }
+static inline bool chpl_isfinite(double val) { return isfinite(val); }
+#endif
+
+#endif


### PR DESCRIPTION
Follow-on to PR #12427 and #12386.

We're seeing testing failures on GCC 5 when using `math.h` to get `signbit`.
This PR adjusts the headers to include `cmath` if the compiler thinks it is C++11 compatible.

Verified that this works:
 * in the GCC 5 configuration that was failing
 * in the PGI configuration that was failing
 * with GCC 4
 * with GCC 8

Reviewed by @ronawho - thanks!