### PR TITLE
Deprecate string.isEmptyString for string.isEmpty

### DIFF
--- a/modules/internal/ChapelError.chpl
+++ b/modules/internal/ChapelError.chpl
@@ -89,7 +89,7 @@ module ChapelError {
     }
 
     override proc message() {
-      if formal.isEmptyString() then
+      if formal.isEmpty() then
         return info;
       else
         return "illegal argument '" + formal + "': " + info;
@@ -490,7 +490,7 @@ module ChapelError {
   pragma "insert line file info"
   pragma "always propagate line file info"
   proc chpl_enum_cast_error(casted: string, enumName: string) throws {
-    if casted.isEmptyString() then
+    if casted.isEmpty() then
       throw new owned IllegalArgumentError("bad cast from empty string to " + enumName);
     else
       throw new owned IllegalArgumentError("bad cast from string '" + casted + "' to " + enumName);

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -425,7 +425,7 @@ module String {
     pragma "no doc"
     proc ref reinitString(buf: bufferType, s_len: int, size: int,
                           needToCopy:bool = true) {
-      if this.isEmptyString() && buf == nil then return;
+      if this.isEmpty() && buf == nil then return;
 
       // If the this.buff is longer than buf, then reuse the buffer if we are
       // allowed to (this.isowned == true)
@@ -434,7 +434,7 @@ module String {
           if !this.isowned || s_len+1 > this._size {
             // If the new string is too big for our current buffer or we dont
             // own our current buffer then we need a new one.
-            if this.isowned && !this.isEmptyString() then
+            if this.isowned && !this.isEmpty() then
               chpl_here_free(this.buff);
             // TODO: should I just allocate 'size' bytes?
             const allocSize = chpl_here_good_alloc_size(s_len+1);
@@ -447,7 +447,7 @@ module String {
           c_memmove(this.buff, buf, s_len);
           this.buff[s_len] = 0;
         } else {
-          if this.isowned && !this.isEmptyString() then
+          if this.isowned && !this.isEmpty() then
             chpl_here_free(this.buff);
           this.buff = buf;
           this._size = size;
@@ -455,7 +455,7 @@ module String {
       } else {
         // If s_len is 0, 'buf' may still have been allocated. Regardless, we
         // need to free the old buffer if 'this' is isowned.
-        if this.isowned && !this.isEmptyString() then chpl_here_free(this.buff);
+        if this.isowned && !this.isEmpty() then chpl_here_free(this.buff);
         this._size = 0;
 
         // If we need to copy, we can just set 'buff' to nil. Otherwise the
@@ -758,7 +758,7 @@ module String {
     // TODO: I wasn't very good about caching variables locally in this one.
     proc this(r: range(?)) : string {
       var ret: string;
-      if this.isEmptyString() then return ret;
+      if this.isEmpty() then return ret;
 
       const r2 = this._getView(r);
       if r2.size <= 0 {
@@ -808,10 +808,17 @@ module String {
     }
 
     /*
+     Deprecated, use :proc:`string.isEmpty`.
+     */
+    inline proc isEmptyString() : bool {
+      return this.isEmpty();
+    }
+
+    /*
       :returns: * `true`  -- when the string is empty
                 * `false` -- otherwise
      */
-    inline proc isEmptyString() : bool {
+    inline proc isEmpty() : bool {
       return this.len == 0; // this should be enough of a check
     }
 
@@ -834,7 +841,7 @@ module String {
       on __primitive("chpl_on_locale_num",
                      chpl_buildLocaleID(this.locale_id, c_sublocid_any)) {
         for needle in needles {
-          if needle.isEmptyString() {
+          if needle.isEmpty() {
             ret = true;
             break;
           }
@@ -1032,7 +1039,7 @@ module String {
      */
     // TODO: specifying return type leads to un-inited string?
     iter split(sep: string, maxsplit: int = -1, ignoreEmpty: bool = false) /* : string */ {
-      if !(maxsplit == 0 && ignoreEmpty && this.isEmptyString()) {
+      if !(maxsplit == 0 && ignoreEmpty && this.isEmpty()) {
         const localThis: string = this.localize();
         const localSep: string = sep.localize();
 
@@ -1063,7 +1070,7 @@ module String {
             }
           }
 
-          if !(ignoreEmpty && chunk.isEmptyString()) {
+          if !(ignoreEmpty && chunk.isEmpty()) {
             // Putting the yield inside the if prevents us from being inlined
             // in the zippered case, but I don't think there is any way to avoid
             // that easily
@@ -1085,7 +1092,7 @@ module String {
     //       single yield statement, which makes it confusing to read
     // TODO: specifying return type leads to un-inited string?
     iter split(maxsplit: int = -1) /* : string */ {
-      if !this.isEmptyString() {
+      if !this.isEmpty() {
         const localThis: string = this.localize();
         var done : bool = false;
         var yieldChunk : bool = false;
@@ -1271,8 +1278,8 @@ module String {
                 characters in `chars` removed as appropriate.
     */
     proc strip(chars: string = " \t\r\n", leading=true, trailing=true) : string {
-      if this.isEmptyString() then return "";
-      if chars.isEmptyString() then return this;
+      if this.isEmpty() then return "";
+      if chars.isEmpty() then return this;
 
       const localThis: string = this.localize();
       const localChars: string = chars.localize();
@@ -1339,7 +1346,7 @@ module String {
                 * `false` -- otherwise
      */
     proc isUpper() : bool {
-      if this.isEmptyString() then return false;
+      if this.isEmpty() then return false;
 
       var result: bool;
       on __primitive("chpl_on_locale_num",
@@ -1366,7 +1373,7 @@ module String {
                 * `false` -- otherwise
      */
     proc isLower() : bool {
-      if this.isEmptyString() then return false;
+      if this.isEmpty() then return false;
 
       var result: bool;
       on __primitive("chpl_on_locale_num",
@@ -1393,7 +1400,7 @@ module String {
                 * `false` -- otherwise
      */
     proc isSpace() : bool {
-      if this.isEmptyString() then return false;
+      if this.isEmpty() then return false;
       var result: bool = true;
 
       on __primitive("chpl_on_locale_num",
@@ -1415,7 +1422,7 @@ module String {
                 * `false` -- otherwise
      */
     proc isAlpha() : bool {
-      if this.isEmptyString() then return false;
+      if this.isEmpty() then return false;
       var result: bool = true;
 
       on __primitive("chpl_on_locale_num",
@@ -1437,7 +1444,7 @@ module String {
                 * `false` -- otherwise
      */
     proc isDigit() : bool {
-      if this.isEmptyString() then return false;
+      if this.isEmpty() then return false;
       var result: bool = true;
 
       on __primitive("chpl_on_locale_num",
@@ -1459,7 +1466,7 @@ module String {
                 * `false` -- otherwise
      */
     proc isAlnum() : bool {
-      if this.isEmptyString() then return false;
+      if this.isEmpty() then return false;
       var result: bool = true;
 
       on __primitive("chpl_on_locale_num",
@@ -1481,7 +1488,7 @@ module String {
                 * `false` -- otherwise
      */
     proc isPrintable() : bool {
-      if this.isEmptyString() then return false;
+      if this.isEmpty() then return false;
       var result: bool = true;
 
       on __primitive("chpl_on_locale_num",
@@ -1504,7 +1511,7 @@ module String {
                 * `false` -- otherwise
      */
     proc isTitle() : bool {
-      if this.isEmptyString() then return false;
+      if this.isEmpty() then return false;
       var result: bool = true;
 
       on __primitive("chpl_on_locale_num",
@@ -1549,7 +1556,7 @@ module String {
     */
     proc toLower() : string {
       var result: string = this;
-      if result.isEmptyString() then return result;
+      if result.isEmpty() then return result;
 
       var i = 0;
       while i < result.len {
@@ -1582,7 +1589,7 @@ module String {
     */
     proc toUpper() : string {
       var result: string = this;
-      if result.isEmptyString() then return result;
+      if result.isEmpty() then return result;
 
       var i = 0;
       while i < result.len {
@@ -1616,7 +1623,7 @@ module String {
      */
     proc toTitle() : string {
       var result: string = this;
-      if result.isEmptyString() then return result;
+      if result.isEmpty() then return result;
 
       param UN = 0, LETTER = 1;
       var last = UN;
@@ -1661,7 +1668,7 @@ module String {
     pragma "no doc"
     proc capitalize() : string {
       var result: string = this.toLower();
-      if result.isEmptyString() then return result;
+      if result.isEmpty() then return result;
 
       var codepoint: int(32);
       var nbytes: c_int;
@@ -2104,7 +2111,7 @@ module String {
      :returns: The byte value of the first character in `a` as an integer.
   */
   inline proc ascii(a: string) : uint(8) {
-    if a.isEmptyString() then return 0;
+    if a.isEmpty() then return 0;
 
     if _local || a.locale_id == chpl_nodeID {
       // the string must be local so we can index into buff

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -811,6 +811,7 @@ module String {
      Deprecated, use :proc:`string.isEmpty`.
      */
     inline proc isEmptyString() : bool {
+      compilerWarning("'isEmptyString' has been deprecated, use 'isEmpty' method instead");
       return this.isEmpty();
     }
 

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -811,7 +811,7 @@ module String {
      Deprecated, use :proc:`string.isEmpty`.
      */
     inline proc isEmptyString() : bool {
-      compilerWarning("'isEmptyString' has been deprecated, use 'isEmpty' method instead");
+      compilerWarning("isEmptyString is deprecated - please use isEmpty instead");
       return this.isEmpty();
     }
 

--- a/modules/internal/StringCasts.chpl
+++ b/modules/internal/StringCasts.chpl
@@ -45,7 +45,7 @@ module StringCasts {
 
   proc _cast(type t:chpl_anybool, x: string) throws {
     var str = x.strip();
-    if str.isEmptyString() {
+    if str.isEmpty() {
       throw new owned IllegalArgumentError("bad cast from empty string to bool");
     } else if (str == "true") {
       return true;
@@ -134,7 +134,7 @@ module StringCasts {
         localX = localX[1] + localX[2..].replace("_", "");
     }
 
-    if localX.isEmptyString() then
+    if localX.isEmpty() then
       throw new owned IllegalArgumentError("bad cast from empty string to " + t:string);
 
     if isIntType(t) {
@@ -196,7 +196,7 @@ module StringCasts {
   inline proc _cleanupStringForRealCast(type t, ref s: string) throws {
     var len = s.length;
 
-    if s.isEmptyString() then
+    if s.isEmpty() then
       throw new owned IllegalArgumentError("bad cast from empty string to " + t: string);
 
     if len >= 2 && s[2..].find("_") != 0 {
@@ -301,7 +301,7 @@ module StringCasts {
     var isErr: bool;
     const localX = x.localize();
 
-    if localX.isEmptyString() then
+    if localX.isEmpty() then
       throw new owned IllegalArgumentError("bad cast from empty string to complex(" + numBits(t) + ")");
 
     select numBits(t) {

--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -215,7 +215,7 @@ class LinearAlgebraError : Error {
 
     pragma "no doc"
     override proc message() {
-      if info.isEmptyString() then
+      if info.isEmpty() then
         return "LinearAlgebra error";
       else
         return "LinearAlgebra error : " + info;

--- a/modules/packages/MPI.chpl
+++ b/modules/packages/MPI.chpl
@@ -285,7 +285,7 @@ module MPI {
       coforall loc in Locales do on loc {
           // This must be done on all locales!
           var pmiGniCookie = C_Env.getenv("PMI_GNI_COOKIE") : string;
-          if !pmiGniCookie.isEmptyString() {
+          if !pmiGniCookie.isEmpty() {
             // This may be a colon separated string.
             var cookieJar = pmiGniCookie.split(":");
             const lastcookie = cookieJar.domain.last;

--- a/modules/packages/TOML.chpl
+++ b/modules/packages/TOML.chpl
@@ -240,7 +240,7 @@ module TomlParser {
       var tblname: string;
       var tblD: domain(string);
       var tbl: [tblD] unmanaged Toml;
-      if curTable.isEmptyString() {
+      if curTable.isEmpty() {
         tblname = key;
         rootTable[key] = tbl;
       }
@@ -271,7 +271,7 @@ module TomlParser {
         }
         else {
           var value = parseValue();
-          if curTable.isEmptyString() then rootTable[key] = value;
+          if curTable.isEmpty() then rootTable[key] = value;
           else rootTable[curTable][key] = value;
         }
       }

--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -619,7 +619,7 @@ proc locale.cwd(out error: syserr): string {
 proc exists(name: string): bool throws {
   extern proc chpl_fs_exists(ref result:c_int, name: c_string): syserr;
 
-  if (name.isEmptyString()) {
+  if (name.isEmpty()) {
     // chpl_fs_exists uses stat to determine if a file exists, which throws an
     // error when "" is passed to it.  Check it here early and return false
     // like Python does
@@ -1052,7 +1052,7 @@ proc isFile(out error:syserr, name:string):bool {
 proc isLink(name: string): bool throws {
   extern proc chpl_fs_is_link(ref result:c_int, name: c_string): syserr;
 
-  if (name.isEmptyString()) {
+  if (name.isEmpty()) {
     // chpl_fs_is_link uses lstat to determine if a path is a link, which throws
     // an error when "" is passed to it.  Check it here early and return false
     // like Python does

--- a/modules/standard/Path.chpl
+++ b/modules/standard/Path.chpl
@@ -421,7 +421,7 @@ proc file.getParentName(out error:syserr): string {
 */
 
 proc isAbsPath(name: string): bool {
-  if name.isEmptyString() {
+  if name.isEmpty() {
     return false;
   }
   const len: int = name.length;

--- a/modules/standard/Spawn.chpl
+++ b/modules/standard/Spawn.chpl
@@ -655,7 +655,7 @@ module Spawn {
                   executable="/bin/sh", shellarg="-c",
                   param kind=iokind.dynamic, param locking=true) throws
   {
-    if command.isEmptyString() then
+    if command.isEmpty() then
       throw new owned IllegalArgumentError('command cannot be an empty string');
 
     var args = [command];

--- a/modules/standard/SysError.chpl
+++ b/modules/standard/SysError.chpl
@@ -60,7 +60,7 @@ class SystemError : Error {
     var errstr              = sys_strerror_syserr_str(err, strerror_err);
     var err_msg             = new string(errstr, isowned=true, needToCopy=false);
 
-    if !details.isEmptyString() then
+    if !details.isEmpty() then
       err_msg += " (" + details + ")";
 
     return err_msg;

--- a/test/deprecated/string-isEmptyString.chpl
+++ b/test/deprecated/string-isEmptyString.chpl
@@ -1,1 +1,2 @@
-var b = 'deprecate me please'.isEmptyString();
+writeln('deprecate me please'.isEmptyString());
+writeln(''.isEmptyString());

--- a/test/deprecated/string-isEmptyString.chpl
+++ b/test/deprecated/string-isEmptyString.chpl
@@ -1,0 +1,1 @@
+var b = 'deprecate me please'.isEmptyString();

--- a/test/deprecated/string-isEmptyString.good
+++ b/test/deprecated/string-isEmptyString.good
@@ -1,0 +1,1 @@
+string-isEmptyString.chpl:1: warning: 'isEmptyString' has been deprecated, use 'isEmpty' method instead

--- a/test/deprecated/string-isEmptyString.good
+++ b/test/deprecated/string-isEmptyString.good
@@ -1,1 +1,4 @@
-string-isEmptyString.chpl:1: warning: 'isEmptyString' has been deprecated, use 'isEmpty' method instead
+string-isEmptyString.chpl:1: warning: isEmptyString is deprecated - please use isEmpty instead
+string-isEmptyString.chpl:2: warning: isEmptyString is deprecated - please use isEmpty instead
+false
+true

--- a/test/release/examples/primers/errorHandling.chpl
+++ b/test/release/examples/primers/errorHandling.chpl
@@ -68,7 +68,7 @@ class EmptyFilenameError : Error {
 }
 
 proc checkFilename(f_name: string) throws {
-  if f_name.isEmptyString() then
+  if f_name.isEmpty() then
     throw new owned EmptyFilenameError();
 }
 

--- a/test/types/string/methods/join-empty-domain.chpl
+++ b/test/types/string/methods/join-empty-domain.chpl
@@ -1,4 +1,4 @@
 /* Test passing an array over an empty domain to join */
 var S: [1..0] string;
 var j = ' '.join(S);
-assert(j.isEmptyString());
+assert(j.isEmpty());

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -126,7 +126,7 @@ proc SPACK_ROOT : string {
   const envHome = getEnv("SPACK_ROOT");
   const default = MASON_HOME + "/spack";
 
-  const spackRoot = if !envHome.isEmptyString() then envHome else default;
+  const spackRoot = if !envHome.isEmpty() then envHome else default;
 
   return spackRoot;
 }


### PR DESCRIPTION
This PR deprecates `string.isEmptyString` for `string.isEmpty`, standardizing the interface for methods asking "is this thing empty?" in Chapel's standard library.

Closes https://github.com/chapel-lang/chapel/issues/11437