### PR TITLE
Avoid init= for POD types

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -4986,6 +4986,12 @@ static void resolveInitVar(CallExpr* call) {
       resolveMove(call);
     } else if (isRecordWithInitializers(at) == false) {
       INT_FATAL("Unable to initialize record variable with type '%s'", at->symbol->name);
+    } else if (targetType->getValType() == srcType->getValType() &&
+               targetType->getValType()->symbol->hasFlag(FLAG_POD)) {
+      dst->type = targetType->getValType();
+      call->primitive = primitives[PRIM_MOVE];
+      resolveMove(call);
+
     } else {
 
       dst->type = targetType->getValType();

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -4990,6 +4990,13 @@ static void resolveInitVar(CallExpr* call) {
                targetType->getValType()->symbol->hasFlag(FLAG_POD)) {
       dst->type = targetType->getValType();
       call->primitive = primitives[PRIM_MOVE];
+
+      // Need to dereference in order to avoid const-ness issues
+      if (srcType->isRef()) {
+        srcExpr->remove();
+        call->insertAtTail(new CallExpr(PRIM_DEREF, srcExpr));
+      }
+
       resolveMove(call);
 
     } else {


### PR DESCRIPTION
This PR adds a branch to 'resolveInitVar' that avoids inserting an "init=" call for POD types. The 'removeUnnecessaryAutoCopyCalls' optimization pass formerly took care of this sort of thing, but only recognizes initCopy and not init=.

Resolves #11730

Testing:
- [x] local
- [x] gasnet
- [x] memleaks
- [x] valgrind