### PR TITLE
Minor improvements for --baseline testing

### DIFF
--- a/compiler/resolution/lowerIterators.cpp
+++ b/compiler/resolution/lowerIterators.cpp
@@ -2178,9 +2178,13 @@ expandForLoop(ForLoop* forLoop) {
       // after the call to the iterator function.
       // Scroll backwards to find the error handling block.
 
-      // TODO: finish this case
+      // TODO: finish this case, see GitHub #7134
       //       I think we need to use the ForLoop's break label
-      USR_FATAL("Throwing non-inlined iterators are not yet supported");
+
+      USR_FATAL_CONT(forLoop,
+        "throwing non-inlined iterators are not yet supported");
+      USR_PRINT(iterFn, "the invoked iterator is here");
+      USR_STOP();
     }
 
     SymExpr*     se1       = toSymExpr(forLoop->indexGet());

--- a/test/errhandling/ferguson/it-throws-noinline.bad
+++ b/test/errhandling/ferguson/it-throws-noinline.bad
@@ -1,2 +1,3 @@
-it-throws-noinline.chpl:24: error: Throwing non-inlined iterators are not yet supported
-Note: This source location is a guess.
+it-throws-noinline.chpl:21: In function 'test':
+it-throws-noinline.chpl:24: error: throwing non-inlined iterators are not yet supported
+it-throws-noinline.chpl:6: note: the invoked iterator is here

--- a/test/errhandling/ferguson/it-throws-noinline.future
+++ b/test/errhandling/ferguson/it-throws-noinline.future
@@ -1,4 +1,5 @@
 bug: throwing from non-inlined iterators not yet supported
+#7134
 
 When removing this .future, also remove
 it-throws-inline.skipif and forall-iterator-throws-follower.skipif.

--- a/test/library/packages/csv/CSVtest.skipif
+++ b/test/library/packages/csv/CSVtest.skipif
@@ -1,0 +1,6 @@
+# throwing from non-inlined iterators not yet supported
+#
+# baseline makes the iterators not inlined; this code
+# pattern isn't supported yet.
+
+COMPOPTS <= --baseline


### PR DESCRIPTION
* Skipif CSVtest.chpl - it invokes throwing iterators,
  which are not supported without inlining.

* Improve line number reporting upon the "throwing not supported"
  compiler error.

* Adjust it-throws-noinline .bad correspondingly.