### PR TITLE
Add future for union/string memory error

### DIFF
--- a/test/classes/unions/union-string.chpl
+++ b/test/classes/unions/union-string.chpl
@@ -1,0 +1,9 @@
+union U {
+  var s: string;
+}
+
+var u: U;
+u.s = "Cogito, ergo sum";
+
+var t = u:string;
+writeln(t);

--- a/test/classes/unions/union-string.future
+++ b/test/classes/unions/union-string.future
@@ -1,0 +1,2 @@
+bug: memory error casting to string a union with an active string member
+#12405

--- a/test/classes/unions/union-string.good
+++ b/test/classes/unions/union-string.good
@@ -1,0 +1,1 @@
+(s = Cogito, ergo sum)

--- a/test/classes/unions/union-string.skipif
+++ b/test/classes/unions/union-string.skipif
@@ -1,0 +1,2 @@
+# Test output is unreliable outside of valgrind
+CHPL_TEST_VGRND_EXE != on


### PR DESCRIPTION
When a union whose active member is a string is cast to a string,
there's double-free.  This is #12405.