### PR TITLE
Fixed documentation of proc string.match in RegExp module

### DIFF
--- a/modules/standard/Regexp.chpl
+++ b/modules/standard/Regexp.chpl
@@ -1097,8 +1097,7 @@ proc string.match(pattern: regexp):reMatch
 }
 
 /* Match the receiving string to a regular expression already compiled
-   by calling :proc:`regexp.match`. `string.match` is just a convenient
-   wrapper. Hence, `string.match` ends up just calling :proc:`regexp.match`.
+   by calling :proc:`regexp.match`.
 
    :arg pattern: the compiled regular expression to match
    :arg captures: (optional) what to capture from the regular expression. These

--- a/modules/standard/Regexp.chpl
+++ b/modules/standard/Regexp.chpl
@@ -1096,8 +1096,10 @@ proc string.match(pattern: regexp):reMatch
   return pattern.match(this);
 }
 
-/* Match the receiving string to a regular expression already compiled
-   by calling :proc:`regexp.match`.
+/* Match the receiving string to a regular expression already compiled by
+   calling :proc:`regexp.match`. Note that function only returns a match if
+   the start of the string matches the pattern. Use :proc:`string.search`
+   to search for the pattern at any offset.
 
    :arg pattern: the compiled regular expression to match
    :arg captures: (optional) what to capture from the regular expression. These

--- a/modules/standard/Regexp.chpl
+++ b/modules/standard/Regexp.chpl
@@ -1097,8 +1097,8 @@ proc string.match(pattern: regexp):reMatch
 }
 
 /* Match the receiving string to a regular expression already compiled
-   by calling :proc: `regexp.match`. `string.match` is just a convenient
-   wrapper. Hence, `string.match` ends up just calling `regexp.match`
+   by calling :proc:`regexp.match`. `string.match` is just a convenient
+   wrapper. Hence, `string.match` ends up just calling :proc:`regexp.match`.
 
    :arg pattern: the compiled regular expression to match
    :arg captures: (optional) what to capture from the regular expression. These

--- a/modules/standard/Regexp.chpl
+++ b/modules/standard/Regexp.chpl
@@ -1097,8 +1097,8 @@ proc string.match(pattern: regexp):reMatch
 }
 
 /* Match the receiving string to a regular expression already compiled
-   by calling :proc:`regexp.match`. Only return matches where the match
-   encompasses the entire string.
+   by calling :proc: `regexp.match`. `string.match` is just a convenient
+   wrapper. Hence, `string.match` ends up just calling `regexp.match`
 
    :arg pattern: the compiled regular expression to match
    :arg captures: (optional) what to capture from the regular expression. These


### PR DESCRIPTION
> Only return matches where the match encompasses the entire string.

was creating confusion hence changed to:
>`string.match` is just a convenient wrapper. Hence, `string.match` ends up 
just calling :proc:`regexp.match`