### PR TITLE
Improve how we find include and lib files for comm=ofi, mpirun4ofi.

### DIFF
--- a/runtime/etc/Makefile.comm-ofi
+++ b/runtime/etc/Makefile.comm-ofi
@@ -16,13 +16,13 @@
 # limitations under the License.
 
 ifneq ($(LIBFABRIC_DIR),)
-  LIBFAB_DIR_CACHE := $(shell if [ -d $(LIBFABRIC_DIR)/lib64 ] ; then \
-                                echo $(LIBFABRIC_DIR)/lib64 ; \
-                              elif [ -d $(LIBFABRIC_DIR)/lib ] ; then \
-                                echo $(LIBFABRIC_DIR)/lib ; \
-                              fi)
-  ifneq ($(LIBFAB_DIR_CACHE),)
-    GEN_LFLAGS += -L$(LIBFAB_DIR_CACHE) -Wl,-rpath,$(LIBFAB_DIR_CACHE)
+  ifneq ($(wildcard $(LIBFABRIC_DIR)/lib64),)
+    LIBFAB_LIB_DIR := $(LIBFABRIC_DIR)/lib64
+  else ifneq ($(wildcard $(LIBFABRIC_DIR)/lib),)
+    LIBFAB_LIB_DIR := $(LIBFABRIC_DIR)/lib
+  endif
+  ifneq ($(LIBFAB_LIB_DIR),)
+    GEN_LFLAGS += -L$(LIBFAB_LIB_DIR) -Wl,-rpath,$(LIBFAB_LIB_DIR)
   endif
 endif
 LIBS += -lfabric -ldl
@@ -34,23 +34,19 @@ LIBS += -lfabric -ldl
 LD = $(CXX)
 
 ifneq (, $(findstring mpi,$(CHPL_MAKE_LAUNCHER)))
+  MPI_LIB_NAME = mpi
   ifneq ($(MPI_DIR),)
-    MPI_DIR_CACHE := $(shell if [ -d $(MPI_DIR)/lib64 ] ; then \
-                               echo $(MPI_DIR)/lib64 ; \
-                             elif [ -d $(MPI_DIR)/lib ] ; then \
-                               echo $(MPI_DIR)/lib ; \
-                             fi)
-    ifneq ($(MPI_DIR_CACHE),)
-      GEN_LFLAGS += -L$(MPI_DIR_CACHE) -Wl,-rpath,$(MPI_DIR_CACHE)
-      LIBMPI_CACHE := \
-        $(shell if $$(ls $(MPI_DIR_CACHE)/libmpi.* >&/dev/null) ; then \
-                  echo mpi ; \
-                elif $$(ls $(MPI_DIR_CACHE)/libmpich.* >&/dev/null) ; then \
-                  echo mpich ; \
-                fi)
-      ifneq ($(LIBMPI_CACHE),)
-        LIBS += -l$(LIBMPI_CACHE)
+    ifneq ($(wildcard $(MPI_DIR)/lib64),)
+      MPI_LIB_DIR := $(MPI_DIR)/lib64
+    else ifneq ($(wildcard $(MPI_DIR)/lib),)
+      MPI_LIB_DIR := $(MPI_DIR)/lib
+    endif
+    ifneq ($(MPI_LIB_DIR),)
+      GEN_LFLAGS += -L$(MPI_LIB_DIR) -Wl,-rpath,$(MPI_LIB_DIR)
+      ifneq ($(wildcard $(MPI_LIB_DIR)/libmpich.*),)
+        MPI_LIB_NAME = mpich
       endif
     endif
   endif
+  LIBS += -l$(MPI_LIB_NAME)
 endif

--- a/runtime/etc/Makefile.comm-ofi
+++ b/runtime/etc/Makefile.comm-ofi
@@ -16,10 +16,10 @@
 # limitations under the License.
 
 ifneq ($(LIBFABRIC_DIR),)
-  LIBFAB_DIR_CACHE := $(shell if [ -d $(LIBFABRIC_DIR)/lib ] ; then \
-                                echo $(LIBFABRIC_DIR)/lib ; \
-                              elif [ -d $(LIBFABRIC_DIR)/lib64 ] ; then \
+  LIBFAB_DIR_CACHE := $(shell if [ -d $(LIBFABRIC_DIR)/lib64 ] ; then \
                                 echo $(LIBFABRIC_DIR)/lib64 ; \
+                              elif [ -d $(LIBFABRIC_DIR)/lib ] ; then \
+                                echo $(LIBFABRIC_DIR)/lib ; \
                               fi)
   ifneq ($(LIBFAB_DIR_CACHE),)
     GEN_LFLAGS += -L$(LIBFAB_DIR_CACHE) -Wl,-rpath,$(LIBFAB_DIR_CACHE)
@@ -35,16 +35,23 @@ LIBS += -lfabric -ldl
 LD = $(CC)
 
 ifneq (, $(findstring mpi,$(CHPL_MAKE_LAUNCHER)))
-  GEN_LFLAGS += -L$(MPI_DIR)/lib -Wl,-rpath,$(MPI_DIR)/lib
   ifneq ($(MPI_DIR),)
-    LIBMPI_CACHE := \
-      $(shell if $$(ls $(MPI_DIR)/lib/libmpi.* >&/dev/null) ; then \
-                echo mpi ; \
-              elif $$(ls $(MPI_DIR)/lib/libmpich.* >&/dev/null) ; then \
-                echo mpich ; \
-              fi)
-    ifneq ($(LIBMPI_CACHE),)
-      LIBS += -l$(LIBMPI_CACHE)
+    MPI_DIR_CACHE := $(shell if [ -d $(MPI_DIR)/lib64 ] ; then \
+                               echo $(MPI_DIR)/lib64 ; \
+                             elif [ -d $(MPI_DIR)/lib ] ; then \
+                               echo $(MPI_DIR)/lib ; \
+                             fi)
+    ifneq ($(MPI_DIR_CACHE),)
+      GEN_LFLAGS += -L$(MPI_DIR_CACHE) -Wl,-rpath,$(MPI_DIR_CACHE)
+      LIBMPI_CACHE := \
+        $(shell if $$(ls $(MPI_DIR_CACHE)/libmpi.* >&/dev/null) ; then \
+                  echo mpi ; \
+                elif $$(ls $(MPI_DIR_CACHE)/libmpich.* >&/dev/null) ; then \
+                  echo mpich ; \
+                fi)
+      ifneq ($(LIBMPI_CACHE),)
+        LIBS += -l$(LIBMPI_CACHE)
+      endif
     endif
   endif
 endif

--- a/runtime/etc/Makefile.comm-ofi
+++ b/runtime/etc/Makefile.comm-ofi
@@ -31,8 +31,7 @@ LIBS += -lfabric -ldl
 # Conservatively use CXX as the linker, in case regexp (or other C++
 # code) is being linked in.
 #
-#LD = $(CXX)
-LD = $(CC)
+LD = $(CXX)
 
 ifneq (, $(findstring mpi,$(CHPL_MAKE_LAUNCHER)))
   ifneq ($(MPI_DIR),)

--- a/runtime/etc/Makefile.comm-ofi
+++ b/runtime/etc/Makefile.comm-ofi
@@ -16,7 +16,14 @@
 # limitations under the License.
 
 ifneq ($(LIBFABRIC_DIR),)
-GEN_LFLAGS += -L$(LIBFABRIC_DIR)/lib -Wl,-rpath,$(LIBFABRIC_DIR)/lib
+  LIBFAB_DIR_CACHE := $(shell if [ -d $(LIBFABRIC_DIR)/lib ] ; then \
+                                echo $(LIBFABRIC_DIR)/lib ; \
+                              elif [ -d $(LIBFABRIC_DIR)/lib64 ] ; then \
+                                echo $(LIBFABRIC_DIR)/lib64 ; \
+                              fi)
+  ifneq ($(LIBFAB_DIR_CACHE),)
+    GEN_LFLAGS += -L$(LIBFAB_DIR_CACHE) -Wl,-rpath,$(LIBFAB_DIR_CACHE)
+  endif
 endif
 LIBS += -lfabric -ldl
 
@@ -24,9 +31,20 @@ LIBS += -lfabric -ldl
 # Conservatively use CXX as the linker, in case regexp (or other C++
 # code) is being linked in.
 #
-LD = $(CXX)
+#LD = $(CXX)
+LD = $(CC)
 
 ifneq (, $(findstring mpi,$(CHPL_MAKE_LAUNCHER)))
-GEN_LFLAGS += -L$(MPI_LIB) -Wl,-rpath,$(MPI_LIB)
-LIBS += -lmpi
+  GEN_LFLAGS += -L$(MPI_DIR)/lib -Wl,-rpath,$(MPI_DIR)/lib
+  ifneq ($(MPI_DIR),)
+    LIBMPI_CACHE := \
+      $(shell if $$(ls $(MPI_DIR)/lib/libmpi.* >&/dev/null) ; then \
+                echo mpi ; \
+              elif $$(ls $(MPI_DIR)/lib/libmpich.* >&/dev/null) ; then \
+                echo mpich ; \
+              fi)
+    ifneq ($(LIBMPI_CACHE),)
+      LIBS += -l$(LIBMPI_CACHE)
+    endif
+  endif
 endif

--- a/runtime/make/Makefile.runtime.comm-ofi
+++ b/runtime/make/Makefile.runtime.comm-ofi
@@ -20,5 +20,5 @@ RUNTIME_INCLS += -I$(LIBFABRIC_DIR)/include
 endif
 
 ifneq (, $(findstring mpi,$(CHPL_MAKE_LAUNCHER)))
-RUNTIME_INCLS += -I$(MPI_INCLUDE)
+RUNTIME_INCLS += -I$(MPI_DIR)/include
 endif


### PR DESCRIPTION
The smaller change here switches from separate environment variables
for the MPI include and lib directories to just a single one for the
MPI directory, under the assumption it will have `include` and `lib`
subdirs.

The larger change is to deal with some variability in paths for
libfabric and MPI libraries.  Specifically, we've encountered
systems where libfabric and MPI libs are in subdirs called `.../lib64`
instead of just `.../lib`, and also systems where the MPI is MPICH
instead of OpenMPI and the library is `libmpich.{a,so}` instead of
`libmpi.{a,so}`.  So, adjust the user program link-time command line
arguments to deal with that.