### PR TITLE
 Allow init= for network atomics

### DIFF
--- a/modules/internal/Atomics.chpl
+++ b/modules/internal/Atomics.chpl
@@ -177,30 +177,31 @@ module Atomics {
     var _v:externT(bool);
 
     pragma "no doc"
-    proc init() {
+    proc init_helper(value:bool) {
       pragma "fn synchronization free"
       extern externFunc("init", bool, explicit=false)
         proc atomic_init(ref obj:externT(bool), value:bool): void;
 
+      atomic_init(_v, value);
+    }
+
+    pragma "no doc"
+    proc init() {
       this.complete();
       const default: bool;
-      atomic_init(_v, default);
+      init_helper(default);
     }
 
     pragma "no doc"
     proc init=(other : AtomicBool) {
-      this._v = other._v;
+      this.complete();
+      init_helper(other.read());
     }
 
     pragma "no doc"
     proc init=(other : bool) {
       this.complete();
-
-      pragma "fn synchronization free"
-      extern externFunc("init", bool, explicit=false)
-        proc atomic_init(ref obj:externT(bool), value:bool): void;
-
-      atomic_init(_v, other);
+      init_helper(other);
     }
 
     pragma "no doc"
@@ -337,33 +338,34 @@ module Atomics {
     var _v:externT(T);
 
     pragma "no doc"
-    proc init(type T) {
+    proc init_helper(value:T) {
       pragma "fn synchronization free"
       extern externFunc("init", T, explicit=false)
         proc atomic_init(ref obj:externT(T), value:T): void;
 
+      atomic_init(_v, value);
+    }
+
+    pragma "no doc"
+    proc init(type T) {
       this.T = T;
       this.complete();
       const default: T;
-      atomic_init(_v, default);
+      init_helper(default);
     }
 
     pragma "no doc"
-    proc init=(other : this.type) {
+    proc init=(other:this.type) {
       this.T = other.T;
-      this._v = other._v;
+      this.complete();
+      init_helper(other.read());
     }
 
     pragma "no doc"
-    proc init=(other : this.type.T) {
+    proc init=(other:this.type.T) {
       this.T = other.type;
       this.complete();
-
-      pragma "fn synchronization free"
-      extern externFunc("init", T, explicit=false)
-        proc atomic_init(ref obj:externT(T), value:T): void;
-
-      atomic_init(_v, other);
+      init_helper(other);
     }
 
     pragma "no doc"

--- a/modules/internal/Atomics.chpl
+++ b/modules/internal/Atomics.chpl
@@ -193,13 +193,13 @@ module Atomics {
     }
 
     pragma "no doc"
-    proc init=(other : AtomicBool) {
+    proc init=(other:AtomicBool) {
       this.complete();
       init_helper(other.read());
     }
 
     pragma "no doc"
-    proc init=(other : bool) {
+    proc init=(other:bool) {
       this.complete();
       init_helper(other);
     }

--- a/modules/internal/NetworkAtomics.chpl
+++ b/modules/internal/NetworkAtomics.chpl
@@ -34,13 +34,12 @@ module NetworkAtomics {
 
     pragma "no doc"
     proc init=(other:RAtomicBool) {
-      this._v = other.read();
+      this._v = other.read():int(64);
     }
 
     pragma "no doc"
     proc init=(other:bool) {
-      this.complete();
-      this.write(other);
+      this._v = other:int(64);
     }
 
     inline proc _localeid(): int(32) {
@@ -134,17 +133,15 @@ module NetworkAtomics {
     var _v: T;
 
     pragma "no doc"
-    proc init=(other : this.type) {
+    proc init=(other:this.type) {
       this.T = other.T;
       this._v = other.read();
     }
 
     pragma "no doc"
-    proc init=(other : this.type.T) {
+    proc init=(other:this.type.T) {
       this.T = other.type;
-      this.complete();
-
-      this.write(other);
+      this._v = other;
     }
 
     inline proc _localeid(): int(32) {

--- a/modules/internal/NetworkAtomics.chpl
+++ b/modules/internal/NetworkAtomics.chpl
@@ -33,12 +33,12 @@ module NetworkAtomics {
     var _v: int(64);
 
     pragma "no doc"
-    proc init=(other : RAtomicBool) {
-      this._v = other._v;
+    proc init=(other:RAtomicBool) {
+      this._v = other.read();
     }
 
     pragma "no doc"
-    proc init=(other : bool) {
+    proc init=(other:bool) {
       this.complete();
       this.write(other);
     }
@@ -136,7 +136,7 @@ module NetworkAtomics {
     pragma "no doc"
     proc init=(other : this.type) {
       this.T = other.T;
-      this._v = other._v;
+      this._v = other.read();
     }
 
     pragma "no doc"

--- a/modules/internal/NetworkAtomics.chpl
+++ b/modules/internal/NetworkAtomics.chpl
@@ -32,6 +32,17 @@ module NetworkAtomics {
   record RAtomicBool {
     var _v: int(64);
 
+    pragma "no doc"
+    proc init=(other : RAtomicBool) {
+      this._v = other._v;
+    }
+
+    pragma "no doc"
+    proc init=(other : bool) {
+      this.complete();
+      this.write(other);
+    }
+
     inline proc _localeid(): int(32) {
       return _v.locale.id:int(32);
     }
@@ -121,6 +132,20 @@ module NetworkAtomics {
   record RAtomicT {
     type T;
     var _v: T;
+
+    pragma "no doc"
+    proc init=(other : this.type) {
+      this.T = other.T;
+      this._v = other._v;
+    }
+
+    pragma "no doc"
+    proc init=(other : this.type.T) {
+      this.T = other.type;
+      this.complete();
+
+      this.write(other);
+    }
 
     inline proc _localeid(): int(32) {
       return _v.locale.id:int(32);

--- a/test/runtime/configMatters/comm/AtomicsAPI.chpl
+++ b/test/runtime/configMatters/comm/AtomicsAPI.chpl
@@ -17,6 +17,9 @@ proc testAtomicBool(a, ref i, ref b) {
   writeln("Testing 'atomic bool':");
                                                     writea ("init    ", a);
                 var initval : a.type = true;        writeai("init=   ", a, initval);
+                var initval2 : a.type = a;          writeai("init=(a)", a, initval2);
+                var initval3 = a;                   writeai("init=(a)", a, initval3);
+                assert(initval3.type == atomic bool);
                 i = a.read();                       writeai("read    ", a, i);
                     a.write(t);                     writea ("write   ", a);
                 i = a.exchange(f);                  writeai("xchg    ", a, i);
@@ -40,6 +43,9 @@ proc testAtomicT(a, ref i, ref b, type basetype) {
                                                     writea ("init    ", a);
                 if isArray(a) == false {
                   var initval : a.type = 1;         writeai("init=   ", a, initval);
+                  var initval2 : a.type = a;        writeai("init=(a)", a, initval2);
+                  var initval3 = a;                 writeai("init=(a)", a, initval3);
+                  assert(initval3.type == atomic basetype);
                 }
                 i = a.read();                       writeai("read    ", a, i);
                     a.write(1);                     writea ("write   ", a);

--- a/test/runtime/configMatters/comm/AtomicsAPI.chpl
+++ b/test/runtime/configMatters/comm/AtomicsAPI.chpl
@@ -16,6 +16,7 @@ proc testAtomicBool(a, ref i, ref b) {
 
   writeln("Testing 'atomic bool':");
                                                     writea ("init    ", a);
+                var initval : a.type = true;        writeai("init=   ", a, initval);
                 i = a.read();                       writeai("read    ", a, i);
                     a.write(t);                     writea ("write   ", a);
                 i = a.exchange(f);                  writeai("xchg    ", a, i);
@@ -37,6 +38,9 @@ proc testAtomicT(a, ref i, ref b, type basetype) {
 
   writeln("Testing 'atomic " + basetype:string + "':");
                                                     writea ("init    ", a);
+                if isArray(a) == false {
+                  var initval : a.type = 1;         writeai("init=   ", a, initval);
+                }
                 i = a.read();                       writeai("read    ", a, i);
                     a.write(1);                     writea ("write   ", a);
                 i = a.exchange(2);                  writeai("xchg    ", a, i);

--- a/test/runtime/configMatters/comm/AtomicsAPI.chpl
+++ b/test/runtime/configMatters/comm/AtomicsAPI.chpl
@@ -17,8 +17,8 @@ proc testAtomicBool(a, ref i, ref b) {
   writeln("Testing 'atomic bool':");
                                                     writea ("init    ", a);
                 var initval : a.type = true;        writeai("init=   ", a, initval);
-                var initval2 : a.type = a;          writeai("init=(a)", a, initval2);
-                var initval3 = a;                   writeai("init=(a)", a, initval3);
+                var initval2 : a.type = initval;    writeai("init=(v)", a, initval2);
+                var initval3 = initval;             writeai("init=(v)", a, initval3);
                 assert(initval3.type == atomic bool);
                 i = a.read();                       writeai("read    ", a, i);
                     a.write(t);                     writea ("write   ", a);
@@ -43,8 +43,8 @@ proc testAtomicT(a, ref i, ref b, type basetype) {
                                                     writea ("init    ", a);
                 if isArray(a) == false {
                   var initval : a.type = 1;         writeai("init=   ", a, initval);
-                  var initval2 : a.type = a;        writeai("init=(a)", a, initval2);
-                  var initval3 = a;                 writeai("init=(a)", a, initval3);
+                  var initval2 : a.type = initval;  writeai("init=(v)", a, initval2);
+                  var initval3 = initval;           writeai("init=(v)", a, initval3);
                   assert(initval3.type == atomic basetype);
                 }
                 i = a.read();                       writeai("read    ", a, i);

--- a/test/runtime/configMatters/comm/atomics-api.good
+++ b/test/runtime/configMatters/comm/atomics-api.good
@@ -1,6 +1,8 @@
 Testing 'atomic bool':
   init        a=false
   init=       a=false, i=true
+  init=(a)    a=false, i=false
+  init=(a)    a=false, i=false
   read        a=false, i=false
   write       a=true
   xchg        a=false, i=true
@@ -17,6 +19,8 @@ Testing 'atomic bool':
 Testing 'atomic int(8)':
   init        a=0
   init=       a=0, i=1
+  init=(a)    a=0, i=0
+  init=(a)    a=0, i=0
   read        a=0, i=0
   write       a=1
   xchg        a=2, i=1
@@ -41,6 +45,8 @@ Testing 'atomic int(8)':
 Testing 'atomic int(16)':
   init        a=0
   init=       a=0, i=1
+  init=(a)    a=0, i=0
+  init=(a)    a=0, i=0
   read        a=0, i=0
   write       a=1
   xchg        a=2, i=1
@@ -65,6 +71,8 @@ Testing 'atomic int(16)':
 Testing 'atomic int(32)':
   init        a=0
   init=       a=0, i=1
+  init=(a)    a=0, i=0
+  init=(a)    a=0, i=0
   read        a=0, i=0
   write       a=1
   xchg        a=2, i=1
@@ -89,6 +97,8 @@ Testing 'atomic int(32)':
 Testing 'atomic int(64)':
   init        a=0
   init=       a=0, i=1
+  init=(a)    a=0, i=0
+  init=(a)    a=0, i=0
   read        a=0, i=0
   write       a=1
   xchg        a=2, i=1
@@ -113,6 +123,8 @@ Testing 'atomic int(64)':
 Testing 'atomic int(64)':
   init        a=0
   init=       a=0, i=1
+  init=(a)    a=0, i=0
+  init=(a)    a=0, i=0
   read        a=0, i=0
   write       a=1
   xchg        a=2, i=1
@@ -137,6 +149,8 @@ Testing 'atomic int(64)':
 Testing 'atomic uint(8)':
   init        a=0
   init=       a=0, i=1
+  init=(a)    a=0, i=0
+  init=(a)    a=0, i=0
   read        a=0, i=0
   write       a=1
   xchg        a=2, i=1
@@ -161,6 +175,8 @@ Testing 'atomic uint(8)':
 Testing 'atomic uint(16)':
   init        a=0
   init=       a=0, i=1
+  init=(a)    a=0, i=0
+  init=(a)    a=0, i=0
   read        a=0, i=0
   write       a=1
   xchg        a=2, i=1
@@ -185,6 +201,8 @@ Testing 'atomic uint(16)':
 Testing 'atomic uint(32)':
   init        a=0
   init=       a=0, i=1
+  init=(a)    a=0, i=0
+  init=(a)    a=0, i=0
   read        a=0, i=0
   write       a=1
   xchg        a=2, i=1
@@ -209,6 +227,8 @@ Testing 'atomic uint(32)':
 Testing 'atomic uint(64)':
   init        a=0
   init=       a=0, i=1
+  init=(a)    a=0, i=0
+  init=(a)    a=0, i=0
   read        a=0, i=0
   write       a=1
   xchg        a=2, i=1
@@ -233,6 +253,8 @@ Testing 'atomic uint(64)':
 Testing 'atomic uint(64)':
   init        a=0
   init=       a=0, i=1
+  init=(a)    a=0, i=0
+  init=(a)    a=0, i=0
   read        a=0, i=0
   write       a=1
   xchg        a=2, i=1
@@ -257,6 +279,8 @@ Testing 'atomic uint(64)':
 Testing 'atomic real(32)':
   init        a=0.0
   init=       a=0.0, i=1.0
+  init=(a)    a=0.0, i=0.0
+  init=(a)    a=0.0, i=0.0
   read        a=0.0, i=0.0
   write       a=1.0
   xchg        a=2.0, i=1.0
@@ -275,6 +299,8 @@ Testing 'atomic real(32)':
 Testing 'atomic real(64)':
   init        a=0.0
   init=       a=0.0, i=1.0
+  init=(a)    a=0.0, i=0.0
+  init=(a)    a=0.0, i=0.0
   read        a=0.0, i=0.0
   write       a=1.0
   xchg        a=2.0, i=1.0
@@ -293,6 +319,8 @@ Testing 'atomic real(64)':
 Testing 'atomic real(64)':
   init        a=0.0
   init=       a=0.0, i=1.0
+  init=(a)    a=0.0, i=0.0
+  init=(a)    a=0.0, i=0.0
   read        a=0.0, i=0.0
   write       a=1.0
   xchg        a=2.0, i=1.0

--- a/test/runtime/configMatters/comm/atomics-api.good
+++ b/test/runtime/configMatters/comm/atomics-api.good
@@ -1,5 +1,6 @@
 Testing 'atomic bool':
   init        a=false
+  init=       a=false, i=true
   read        a=false, i=false
   write       a=true
   xchg        a=false, i=true
@@ -15,6 +16,7 @@ Testing 'atomic bool':
 
 Testing 'atomic int(8)':
   init        a=0
+  init=       a=0, i=1
   read        a=0, i=0
   write       a=1
   xchg        a=2, i=1
@@ -38,6 +40,7 @@ Testing 'atomic int(8)':
 
 Testing 'atomic int(16)':
   init        a=0
+  init=       a=0, i=1
   read        a=0, i=0
   write       a=1
   xchg        a=2, i=1
@@ -61,6 +64,7 @@ Testing 'atomic int(16)':
 
 Testing 'atomic int(32)':
   init        a=0
+  init=       a=0, i=1
   read        a=0, i=0
   write       a=1
   xchg        a=2, i=1
@@ -84,6 +88,7 @@ Testing 'atomic int(32)':
 
 Testing 'atomic int(64)':
   init        a=0
+  init=       a=0, i=1
   read        a=0, i=0
   write       a=1
   xchg        a=2, i=1
@@ -107,6 +112,7 @@ Testing 'atomic int(64)':
 
 Testing 'atomic int(64)':
   init        a=0
+  init=       a=0, i=1
   read        a=0, i=0
   write       a=1
   xchg        a=2, i=1
@@ -130,6 +136,7 @@ Testing 'atomic int(64)':
 
 Testing 'atomic uint(8)':
   init        a=0
+  init=       a=0, i=1
   read        a=0, i=0
   write       a=1
   xchg        a=2, i=1
@@ -153,6 +160,7 @@ Testing 'atomic uint(8)':
 
 Testing 'atomic uint(16)':
   init        a=0
+  init=       a=0, i=1
   read        a=0, i=0
   write       a=1
   xchg        a=2, i=1
@@ -176,6 +184,7 @@ Testing 'atomic uint(16)':
 
 Testing 'atomic uint(32)':
   init        a=0
+  init=       a=0, i=1
   read        a=0, i=0
   write       a=1
   xchg        a=2, i=1
@@ -199,6 +208,7 @@ Testing 'atomic uint(32)':
 
 Testing 'atomic uint(64)':
   init        a=0
+  init=       a=0, i=1
   read        a=0, i=0
   write       a=1
   xchg        a=2, i=1
@@ -222,6 +232,7 @@ Testing 'atomic uint(64)':
 
 Testing 'atomic uint(64)':
   init        a=0
+  init=       a=0, i=1
   read        a=0, i=0
   write       a=1
   xchg        a=2, i=1
@@ -245,6 +256,7 @@ Testing 'atomic uint(64)':
 
 Testing 'atomic real(32)':
   init        a=0.0
+  init=       a=0.0, i=1.0
   read        a=0.0, i=0.0
   write       a=1.0
   xchg        a=2.0, i=1.0
@@ -262,6 +274,7 @@ Testing 'atomic real(32)':
 
 Testing 'atomic real(64)':
   init        a=0.0
+  init=       a=0.0, i=1.0
   read        a=0.0, i=0.0
   write       a=1.0
   xchg        a=2.0, i=1.0
@@ -279,6 +292,7 @@ Testing 'atomic real(64)':
 
 Testing 'atomic real(64)':
   init        a=0.0
+  init=       a=0.0, i=1.0
   read        a=0.0, i=0.0
   write       a=1.0
   xchg        a=2.0, i=1.0

--- a/test/runtime/configMatters/comm/atomics-api.good
+++ b/test/runtime/configMatters/comm/atomics-api.good
@@ -1,8 +1,8 @@
 Testing 'atomic bool':
   init        a=false
   init=       a=false, i=true
-  init=(a)    a=false, i=false
-  init=(a)    a=false, i=false
+  init=(v)    a=false, i=true
+  init=(v)    a=false, i=true
   read        a=false, i=false
   write       a=true
   xchg        a=false, i=true
@@ -19,8 +19,8 @@ Testing 'atomic bool':
 Testing 'atomic int(8)':
   init        a=0
   init=       a=0, i=1
-  init=(a)    a=0, i=0
-  init=(a)    a=0, i=0
+  init=(v)    a=0, i=1
+  init=(v)    a=0, i=1
   read        a=0, i=0
   write       a=1
   xchg        a=2, i=1
@@ -45,8 +45,8 @@ Testing 'atomic int(8)':
 Testing 'atomic int(16)':
   init        a=0
   init=       a=0, i=1
-  init=(a)    a=0, i=0
-  init=(a)    a=0, i=0
+  init=(v)    a=0, i=1
+  init=(v)    a=0, i=1
   read        a=0, i=0
   write       a=1
   xchg        a=2, i=1
@@ -71,8 +71,8 @@ Testing 'atomic int(16)':
 Testing 'atomic int(32)':
   init        a=0
   init=       a=0, i=1
-  init=(a)    a=0, i=0
-  init=(a)    a=0, i=0
+  init=(v)    a=0, i=1
+  init=(v)    a=0, i=1
   read        a=0, i=0
   write       a=1
   xchg        a=2, i=1
@@ -97,8 +97,8 @@ Testing 'atomic int(32)':
 Testing 'atomic int(64)':
   init        a=0
   init=       a=0, i=1
-  init=(a)    a=0, i=0
-  init=(a)    a=0, i=0
+  init=(v)    a=0, i=1
+  init=(v)    a=0, i=1
   read        a=0, i=0
   write       a=1
   xchg        a=2, i=1
@@ -123,8 +123,8 @@ Testing 'atomic int(64)':
 Testing 'atomic int(64)':
   init        a=0
   init=       a=0, i=1
-  init=(a)    a=0, i=0
-  init=(a)    a=0, i=0
+  init=(v)    a=0, i=1
+  init=(v)    a=0, i=1
   read        a=0, i=0
   write       a=1
   xchg        a=2, i=1
@@ -149,8 +149,8 @@ Testing 'atomic int(64)':
 Testing 'atomic uint(8)':
   init        a=0
   init=       a=0, i=1
-  init=(a)    a=0, i=0
-  init=(a)    a=0, i=0
+  init=(v)    a=0, i=1
+  init=(v)    a=0, i=1
   read        a=0, i=0
   write       a=1
   xchg        a=2, i=1
@@ -175,8 +175,8 @@ Testing 'atomic uint(8)':
 Testing 'atomic uint(16)':
   init        a=0
   init=       a=0, i=1
-  init=(a)    a=0, i=0
-  init=(a)    a=0, i=0
+  init=(v)    a=0, i=1
+  init=(v)    a=0, i=1
   read        a=0, i=0
   write       a=1
   xchg        a=2, i=1
@@ -201,8 +201,8 @@ Testing 'atomic uint(16)':
 Testing 'atomic uint(32)':
   init        a=0
   init=       a=0, i=1
-  init=(a)    a=0, i=0
-  init=(a)    a=0, i=0
+  init=(v)    a=0, i=1
+  init=(v)    a=0, i=1
   read        a=0, i=0
   write       a=1
   xchg        a=2, i=1
@@ -227,8 +227,8 @@ Testing 'atomic uint(32)':
 Testing 'atomic uint(64)':
   init        a=0
   init=       a=0, i=1
-  init=(a)    a=0, i=0
-  init=(a)    a=0, i=0
+  init=(v)    a=0, i=1
+  init=(v)    a=0, i=1
   read        a=0, i=0
   write       a=1
   xchg        a=2, i=1
@@ -253,8 +253,8 @@ Testing 'atomic uint(64)':
 Testing 'atomic uint(64)':
   init        a=0
   init=       a=0, i=1
-  init=(a)    a=0, i=0
-  init=(a)    a=0, i=0
+  init=(v)    a=0, i=1
+  init=(v)    a=0, i=1
   read        a=0, i=0
   write       a=1
   xchg        a=2, i=1
@@ -279,8 +279,8 @@ Testing 'atomic uint(64)':
 Testing 'atomic real(32)':
   init        a=0.0
   init=       a=0.0, i=1.0
-  init=(a)    a=0.0, i=0.0
-  init=(a)    a=0.0, i=0.0
+  init=(v)    a=0.0, i=1.0
+  init=(v)    a=0.0, i=1.0
   read        a=0.0, i=0.0
   write       a=1.0
   xchg        a=2.0, i=1.0
@@ -299,8 +299,8 @@ Testing 'atomic real(32)':
 Testing 'atomic real(64)':
   init        a=0.0
   init=       a=0.0, i=1.0
-  init=(a)    a=0.0, i=0.0
-  init=(a)    a=0.0, i=0.0
+  init=(v)    a=0.0, i=1.0
+  init=(v)    a=0.0, i=1.0
   read        a=0.0, i=0.0
   write       a=1.0
   xchg        a=2.0, i=1.0
@@ -319,8 +319,8 @@ Testing 'atomic real(64)':
 Testing 'atomic real(64)':
   init        a=0.0
   init=       a=0.0, i=1.0
-  init=(a)    a=0.0, i=0.0
-  init=(a)    a=0.0, i=0.0
+  init=(v)    a=0.0, i=1.0
+  init=(v)    a=0.0, i=1.0
   read        a=0.0, i=0.0
   write       a=1.0
   xchg        a=2.0, i=1.0


### PR DESCRIPTION
Forgot to add init= to the network atomic types. Also updates init= for atomic types to read() instead of bit-copy the "_v" field.

Testing:
- [x] runtime/configMatters/comm/ (local, gasnet, ugni)
  - [x] local
  - [x] gasnet
  - [x] ugni
- [x] full local
- [x] full gasnet