### PR TITLE
Squash "In..." error reporting for function names starting with `chpl_`

### DIFF
--- a/compiler/util/misc.cpp
+++ b/compiler/util/misc.cpp
@@ -277,6 +277,11 @@ static bool printErrorHeader(const BaseAST* ast) {
             suppress = (strcmp(err_fn->name, "init") != 0) ? true : false;
           }
 
+          // Suppress internal function names
+          if (!developer && strncmp(err_fn->name, "chpl_", 5) == 0) {
+            suppress = true;
+          }
+
           if (suppress == false) {
             fprintf(stderr,
                     "%s:%d: In ",

--- a/test/classes/delete-free/lifetimes/forall-of-new-borrowed-escapes.bad
+++ b/test/classes/delete-free/lifetimes/forall-of-new-borrowed-escapes.bad
@@ -3,13 +3,11 @@ forall-of-new-borrowed-escapes.chpl:13: note: 'new unmanaged C' gives old behavi
 forall-of-new-borrowed-escapes.chpl:13: note: 'new borrowed C' is the new default
 forall-of-new-borrowed-escapes.chpl:13: note: 'new owned C', 'new shared C' also available
 forall-of-new-borrowed-escapes.chpl:13: note: get more help with --warn-unstable
-forall-of-new-borrowed-escapes.chpl:13: In iterator 'chpl__loopexpr_iter7':
 forall-of-new-borrowed-escapes.chpl:13: warning: result of new C is now managed by default
 forall-of-new-borrowed-escapes.chpl:13: note: 'new unmanaged C' gives old behavior
 forall-of-new-borrowed-escapes.chpl:13: note: 'new borrowed C' is the new default
 forall-of-new-borrowed-escapes.chpl:13: note: 'new owned C', 'new shared C' also available
 forall-of-new-borrowed-escapes.chpl:13: note: get more help with --warn-unstable
-forall-of-new-borrowed-escapes.chpl:13: In iterator 'chpl__loopexpr_iter7':
 forall-of-new-borrowed-escapes.chpl:13: warning: result of new C is now managed by default
 forall-of-new-borrowed-escapes.chpl:13: note: 'new unmanaged C' gives old behavior
 forall-of-new-borrowed-escapes.chpl:13: note: 'new borrowed C' is the new default

--- a/test/classes/initializers/records/array-from-for-expr.bad
+++ b/test/classes/initializers/records/array-from-for-expr.bad
@@ -1,5 +1,4 @@
 array-from-for-expr.chpl:15: error: non-lvalue actual is passed to a 'ref' formal of init=()
-$CHPL_HOME/modules/internal/ChapelArray.chpl:4258: In function 'chpl__initCopy':
 $CHPL_HOME/modules/internal/ChapelArray.chpl:4302: error: non-lvalue actual is passed to a 'ref' formal of chpl__initCopy()
 array-from-for-expr.chpl:35: In function 'main':
 array-from-for-expr.chpl:36: error: unresolved call 'RRR.init()'

--- a/test/types/records/const-checking/arrOfRecConstField.bad
+++ b/test/types/records/const-checking/arrOfRecConstField.bad
@@ -1,2 +1,1 @@
-$CHPL_HOME/modules/internal/ChapelArray.chpl:464: In function 'chpl__buildArrayExpr':
 $CHPL_HOME/modules/internal/ChapelArray.chpl:485: error: cannot assign to a record of the type R using the default assignment operator because it has 'const' field(s)

--- a/test/types/records/const-checking/initArrOfRecConstField.bad
+++ b/test/types/records/const-checking/initArrOfRecConstField.bad
@@ -1,2 +1,1 @@
-$CHPL_HOME/modules/internal/ChapelArray.chpl:464: In function 'chpl__buildArrayExpr':
 $CHPL_HOME/modules/internal/ChapelArray.chpl:485: error: cannot assign to a record of the type R using the default assignment operator because it has 'const' field(s)

--- a/test/types/records/const-checking/initArrOfRecConstField2.bad
+++ b/test/types/records/const-checking/initArrOfRecConstField2.bad
@@ -1,2 +1,1 @@
-$CHPL_HOME/modules/internal/ChapelArray.chpl:464: In function 'chpl__buildArrayExpr':
 $CHPL_HOME/modules/internal/ChapelArray.chpl:485: error: cannot assign to a record of the type R using the default assignment operator because it has 'const' field(s)

--- a/test/types/records/const-checking/scenario-1-array-of-record-with-const-fld.bad
+++ b/test/types/records/const-checking/scenario-1-array-of-record-with-const-fld.bad
@@ -1,2 +1,1 @@
-$CHPL_HOME/modules/internal/ChapelArray.chpl:235: In function 'chpl__buildArrayExpr':
 $CHPL_HOME/modules/internal/ChapelArray.chpl:256: error: cannot assign to a record of the type localInfo using the default assignment operator because it has 'const' field(s)

--- a/test/types/records/const-checking/scenario-2-init-array-of-rec-with-const-fld.bad
+++ b/test/types/records/const-checking/scenario-2-init-array-of-rec-with-const-fld.bad
@@ -1,2 +1,1 @@
-$CHPL_HOME/modules/internal/ChapelArray.chpl:235: In function 'chpl__buildArrayExpr':
 $CHPL_HOME/modules/internal/ChapelArray.chpl:256: error: cannot assign to a record of the type RECTYPE using the default assignment operator because it has 'const' field(s)

--- a/test/types/records/const-checking/scenario-3-assoc-dom-of-record-with-const-fld.bad
+++ b/test/types/records/const-checking/scenario-3-assoc-dom-of-record-with-const-fld.bad
@@ -1,4 +1,3 @@
 $CHPL_HOME/modules/internal/DefaultAssociative.chpl: In function '_add':
 $CHPL_HOME/modules/internal/DefaultAssociative.chpl: error: cannot assign to a record of the type Node using the default assignment operator because it has 'const' field(s)
-$CHPL_HOME/modules/internal/ChapelArray.chpl: In function 'chpl__buildAssociativeArrayExpr':
 $CHPL_HOME/modules/internal/ChapelArray.chpl: error: cannot assign to a record of the type Coeff using the default assignment operator because it has 'const' field(s)

--- a/test/types/records/const-checking/todo-linenumber-in-array-assignment-error.bad
+++ b/test/types/records/const-checking/todo-linenumber-in-array-assignment-error.bad
@@ -1,2 +1,1 @@
-$CHPL_HOME/modules/internal/ChapelArray.chpl:235: In function 'chpl__buildArrayExpr':
 $CHPL_HOME/modules/internal/ChapelArray.chpl:256: error: cannot assign to a record of the type RECTYPE using the default assignment operator because it has 'const' field(s)


### PR DESCRIPTION
For calls to compilerError(), compilerWarning() and the like, we
generate a prefix that says "In function..." or "In iterator..."
and then names the routine.  The compiler does this even if the
routine in question is internal, which seems not very helpful
and potentially confusing/noisy.  This PR squashes such cases for
internal functions starting with 'chpl_' when --devel is not thrown.

Notably, none of the current .good files contained such text, only
.bad files.  I removed the text in these cases.

Motivation for this:  I'm a separate PR, I'm adding compilerWarning()s
to internal modules that trigger this condition.