### PR TITLE
Add :throw:/:throws: to the chpldoc technote

### DIFF
--- a/doc/rst/tools/chpldoc/chpldoc.rst
+++ b/doc/rst/tools/chpldoc/chpldoc.rst
@@ -164,6 +164,42 @@ types. A link to the type will be created, if possible. For example:
 For more information see the `Documenting argument, return, and yield values
 and types <#documenting-argument-return-and-yield-values-and-types>`_ section.
 
+Documenting functions that throw
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Errors that are thrown from functions can be documented using the ``:throw:`` or
+``:throws:`` field.  The field will include the ``Error`` subtype being thrown,
+for example ``:throws FileNotFoundError:``.  The description should be a short
+summary of when that error could occur, using a sentence, or two.  For example:
+
+.. code-block:: chapel
+
+   /* Set the permissions of the file or directory specified by the argument
+      `name` to that indicated by the argument `mode`.
+
+      Will throw an error message if one occurs.
+
+      :arg name: The name of the file or directory whose permissions should be
+                 altered.
+      :type name: `string`
+      :arg mode: The permissions desired for the file or directory in question.
+                 See description of :const:`S_IRUSR`, for instance, for
+                 potential values.
+      :type mode: `int`
+
+      :throws FileNotFoundError: Thrown when the name specified does not
+                                 correspond to a file or directory that exists.
+      :throws PermissionError: Thrown when the current user does not have
+                               permission to change the permissions
+   */
+   proc chmod(name: string, mode: int) throws {
+     ...
+
+.. note::
+
+   * Leave an empty line above and below all these fields for best results.
+   * All of these fields must be left-aligned with the outer most paragraph(s).
+
 
 Stifling documentation
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/rst/tools/chpldoc/chpldoc.rst
+++ b/doc/rst/tools/chpldoc/chpldoc.rst
@@ -177,8 +177,6 @@ summary of when that error could occur, using a sentence, or two.  For example:
    /* Set the permissions of the file or directory specified by the argument
       `name` to that indicated by the argument `mode`.
 
-      Will throw an error message if one occurs.
-
       :arg name: The name of the file or directory whose permissions should be
                  altered.
       :type name: `string`
@@ -187,13 +185,31 @@ summary of when that error could occur, using a sentence, or two.  For example:
                  potential values.
       :type mode: `int`
 
-      :throws FileNotFoundError: Thrown when the name specified does not
-                                 correspond to a file or directory that exists.
-      :throws PermissionError: Thrown when the current user does not have
-                               permission to change the permissions
+      :throws FileNotFoundError: If :arg:`name` does not correspond to a file
+                                 or directory that exists.
+      :throws PermissionError: If the current user does not have permission to
+                               change the permissions.
    */
    proc chmod(name: string, mode: int) throws {
      ...
+
+chpldoc will not validate the list of Errors documented for a function.
+Documentation writers are responsible for keeping their documentation in line
+with the behavior of their function.
+
+When writing ``:throws:`` fields, developers do not need to list every possible
+error that could be thrown - however, specificity will allow users to
+appropriately anticipate and respond to exceptional situations. Their response
+to a ``PermissionError`` when accessing a remote file will be different than
+their response to a ``ConnectionResetError``, for instance. Documenting such
+errors ahead of time will allow users to write appropriate ``try`` - ``catch``
+branches.
+
+In some cases, it may be unreasonable to list all the possible Error subclasses
+that could be thrown. Developers should feel free to only list a common
+superclass instead - for instance, ``:throws SystemError:`` as opposed to
+``ConnectionAbortedError``, ``ConnectionRefusedError``, and
+``ConnectionResetError``.
 
 .. note::
 

--- a/test/release/examples/primers/chpldoc.doc.chpl
+++ b/test/release/examples/primers/chpldoc.doc.chpl
@@ -11,8 +11,7 @@
 // Creating and accessing the documentation:
 
 // To generate the documentation for this and any source file, you may either
-// compile using the command 'chpldoc <sourceName.chpl>' or using the command
-// 'chpl --docs <sourceName.chpl>'.
+// compile using the command 'chpldoc <sourceName.chpl>'.
 
 // The documentation files will be found in a special folder created by the
 // chpldoc tool.  If you are compiling a Chapel file that is deeper than your


### PR DESCRIPTION
It looks like we don't document the other fields like :arg: or :rtype: in the
chpldoc primer, but we do document them in the technote.  Follow that precedent
and update the technote for :throws: