### PR TITLE
Improved memory usage of mergesort algorithm

### DIFF
--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -419,13 +419,13 @@ proc heapSort(Data: [?Dom] ?eltType, comparator:?rec=defaultComparator) {
         stride = abs(Dom.stride);
 
   // Heapify
-  var lo = if high == low then high
+  var start = if high == low then high
               else if size % 2 then low + ((size - 1)/2) * stride
               else low + (size/2 - 1) * stride;
 
-  while (high >= low) {
+  while (start >= low) {
     SiftDown(high, high, comparator);
-    high = high - stride;
+    start = start - stride;
   }
 
   // Sort, moving max element to end and re-heapifying the rest


### PR DESCRIPTION
Made the mergesort algorithm not make a copy at each level. Performs the same time-wise as the old algorithm, but takes significantly less memory.

Old:
n=128000, 15.6MB
n=256000, 31.8MB
New:
n=128000, 2.0MB
n=256000, 4.5MB

Tested with:
```chpl
use Sort;
use Random;
use Time;
use Memory;
config const n = 32000;
var data: [0..n] real;
var t: Timer;
fillRandom(data);
t.start();
mergeSort(data);
t.stop();
writeln(t.elapsed());
printMemAllocStats();
```