### PR TITLE
First good draft of parallel Block-distributed scan

### DIFF
--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -1735,7 +1735,7 @@ proc BlockArr.doiScan(op, dom) where (rank == 1) &&
       // accurate state vector
       myLocArr._value.chpl__postScan(op, res, numTasks, rngs, state);
       if debugBlockScan then
-        writeln(locid, ": ", myResElems);
+        writeln(locid, ": ", myLocArr);
 
       delete myop;
     }

--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -1657,6 +1657,94 @@ where useBulkTransferDist {
   return true;
 }
 
+config param debugBlockScan = false;
+
+proc BlockArr.doiScan(op, dom) where (rank == 1) &&
+                                     chpl__scanStateResTypesMatch(op) {
+
+  // The result of this scan, which will be Block-distributed as well
+  type resType = op.generate().type;
+  var res: [dom] resType;
+
+  // Store one element per locale in order to track our local total
+  // for a cross-locale scan as well as flags to negotiate reading and
+  // writing it.  This domain really wants an easier way to express
+  // it...
+  use ReplicatedDist;
+  ref targetLocs = this.dsiTargetLocales();
+  const elemPerLocDom = {1..1} dmapped Replicated(targetLocs);
+  var elemPerLoc: [elemPerLocDom] resType;
+  var inputReady$: [elemPerLocDom] sync bool;
+  var outputReady$: [elemPerLocDom] sync bool;
+
+  // Fire up tasks per participating locale
+  coforall locid in dom.dist.targetLocDom {
+    on targetLocs[locid] {
+      const myop = op.clone(); // this will be deleted by doiScan()
+
+      // set up some references to our LocBlockArr descriptor, our
+      // local array, local domain, and local result elements
+      ref myLocArrDesc = locArr[locid];
+      ref myLocArr = myLocArrDesc.myElems;
+      const ref myLocDom = myLocArr.domain;
+
+      // Compute the local pre-scan on our local array
+      var (numTasks, rngs, state, tot) = myLocArr._value.chpl__preScan(myop, res);
+      if debugBlockScan then
+        writeln(locid, ": ", (numTasks, rngs, state, tot));
+
+      // save our local scan total away and signal that it's ready
+      elemPerLoc[1] = tot;
+      inputReady$[1] = true;
+
+      // the "first" locale scans the per-locale contributions as they
+      // become ready
+      if (locid == dom.dist.targetLocDom.low) {
+        const metaop = op.clone();
+
+        var next: resType = metaop.identity;
+        for locid in dom.dist.targetLocDom {
+          const targetloc = targetLocs[locid];
+          const locready = inputReady$.replicand(targetloc)[1];
+
+          // store the scan value and mark that it's ready
+          ref locVal = elemPerLoc.replicand(targetloc)[1];
+          locVal <=> next;
+          outputReady$.replicand(targetloc)[1] = true;
+
+          // accumulate to prep for the next iteration
+          metaop.accumulateOntoState(next, locVal);
+        }
+        delete metaop;
+      }
+
+      // block until someone tells us that our local value has been updated
+      // and then read it
+      const resready = outputReady$[1];
+      const myadjust = elemPerLoc[1];
+      if debugBlockScan then
+        writeln(locid, ": myadjust = ", myadjust);
+
+      // update our state vector with our locale's adjustment value
+      for s in state do
+        s += myadjust;
+      if debugBlockScan then
+        writeln(locid, ": state = ", state);
+
+      // have our local array compute its post scan with the globally
+      // accurate state vector
+      myLocArr._value.chpl__postScan(op, res, numTasks, rngs, state);
+      if debugBlockScan then
+        writeln(locid, ": ", myResElems);
+
+      delete myop;
+    }
+  }
+
+  delete op;
+  return res;
+}
+
 proc newBlockDom(dom: domain) {
   return dom dmapped Block(dom);
 }

--- a/test/distributions/robust/arithmetic/basics/test_scan1.block.good
+++ b/test/distributions/robust/arithmetic/basics/test_scan1.block.good
@@ -1,4 +1,5 @@
 test_scan1.chpl:8: warning: scan has been serialized (see issue #5760)
+test_scan1.chpl:8: warning: (recompile with -senableParScan to enable a prototype parallel implementation)
 test_scan1.chpl:9: warning: scan has been serialized (see issue #5760)
 test_scan1.chpl:10: warning: scan has been serialized (see issue #5760)
 test_scan1.chpl:11: warning: scan has been serialized (see issue #5760)

--- a/test/npb/is/mcahir/intsort.mtml-par.good
+++ b/test/npb/is/mcahir/intsort.mtml-par.good
@@ -1,9 +1,6 @@
-intsort.mtml.chpl:213: In function 'rank_keys':
-intsort.mtml.chpl:305: warning: scan has been serialized (see issue #5760)
 NAS Parallel Benchmarks 2.4 -- IS Benchmark
  Size:                           65536  (class S)
  Iterations:                        10
- Number of locales:                  1
  Number of tasks per locale:         2
  
 

--- a/test/npb/is/mcahir/intsort.mtml.chpl
+++ b/test/npb/is/mcahir/intsort.mtml.chpl
@@ -37,6 +37,7 @@ config const DEBUG:        bool = false; // shows progress and summary info
 config param printLoopTimings: bool = false; // prints timing info
 config param printArrays:  bool = false; // prints out arrays (can be long)
 config const printTime    = false;	 // turn off for test verification
+config const printNumLocales = true;     // print the number of locales
 
 // Standard modules
 use Time, Random, BlockDist, BlockCycDist;
@@ -143,7 +144,8 @@ proc main () {
   writef ("NAS Parallel Benchmarks 2.4 -- IS Benchmark\n" );
   writef (" Size:                       %{#########}  (class %t)\n", nkeys, probClass);
   writef (" Iterations:                 %{#########}\n",maxIterations);
-  writef (" Number of locales:          %{#########}\n",numLocales);
+  if printNumLocales then
+    writef (" Number of locales:          %{#########}\n",numLocales);
   writef (" Number of tasks per locale: %{#########}\n",dataParTasksPerLocale);
   writef (" \n");
 

--- a/test/npb/is/mcahir/intsort.mtml.compopts
+++ b/test/npb/is/mcahir/intsort.mtml.compopts
@@ -1,0 +1,2 @@
+                 # intsort.mtml.good
+-senableParScan  # intsort.mtml-par.good

--- a/test/npb/is/mcahir/intsort.mtml.execopts
+++ b/test/npb/is/mcahir/intsort.mtml.execopts
@@ -1,1 +1,1 @@
---dataParTasksPerLocale=2 --printTime=false
+--dataParTasksPerLocale=2 --printTime=false --printNumLocales=false

--- a/test/npb/is/mcahir/intsort.mtml.good
+++ b/test/npb/is/mcahir/intsort.mtml.good
@@ -1,9 +1,10 @@
-intsort.mtml.chpl:213: In function 'rank_keys':
-intsort.mtml.chpl:305: warning: scan has been serialized (see issue #5760)
+intsort.mtml.chpl:215: In function 'rank_keys':
+intsort.mtml.chpl:307: warning: scan has been serialized (see issue #5760)
+intsort.mtml.chpl:215: In function 'rank_keys':
+intsort.mtml.chpl:307: warning: (recompile with -senableParScan to enable a prototype parallel implementation)
 NAS Parallel Benchmarks 2.4 -- IS Benchmark
  Size:                           65536  (class S)
  Iterations:                        10
- Number of locales:                  4
  Number of tasks per locale:         2
  
 

--- a/test/scan/scanPerf.ml-compopts
+++ b/test/scan/scanPerf.ml-compopts
@@ -1,0 +1,1 @@
+-senableParScan


### PR DESCRIPTION
This implements a parallel 1D scan on block-distributed arrays by
refactoring the doiScan on default rectangular arrays so that we can
call its two passes as helper functions, chpl__preScan and
chpl__postScan (methods on default rectangular arrays).

For the Block distribution, it then combines this with a serial
(currently) inter-locale scan of the per-locale contributions between
the two passes in order that each locale can only touch its complete
data twice.