### PR TITLE
Remove unstable message regarding associative domains of enums

### DIFF
--- a/modules/internal/DefaultAssociative.chpl
+++ b/modules/internal/DefaultAssociative.chpl
@@ -89,8 +89,6 @@ module DefaultAssociative {
       if !chpl__validDefaultAssocDomIdxType(idxType) then
         compilerError("Default Associative domains with idxType=",
                       idxType:string, " are not allowed", 2);
-      if chpl_warnUnstable && isEnumType(idxType) then
-        compilerWarning("As of Chapel 1.18, associative domains of enums are empty by default rather than full, and associative domains and arrays of enums no longer maintain order");
 
       this.idxType = idxType;
       this.parSafe = parSafe;

--- a/test/deprecated/assocOfEnumUnstable.chpl
+++ b/test/deprecated/assocOfEnumUnstable.chpl
@@ -1,6 +1,0 @@
-config param case = 1;
-
-enum color {red, green, blue};
-
-if case == 1 then var D: domain(color); if case == 2 then var D2 = {color.red, color.blue}; if case == 3 then var A = [color.red => 1, color.blue => 3];
-

--- a/test/deprecated/assocOfEnumUnstable.compopts
+++ b/test/deprecated/assocOfEnumUnstable.compopts
@@ -1,3 +1,0 @@
---warn-unstable -scase=1
---warn-unstable -scase=2
---warn-unstable -scase=3

--- a/test/deprecated/assocOfEnumUnstable.good
+++ b/test/deprecated/assocOfEnumUnstable.good
@@ -1,1 +1,0 @@
-assocOfEnumUnstable.chpl:5: warning: As of Chapel 1.18, associative domains of enums are empty by default rather than full, and associative domains and arrays of enums no longer maintain order


### PR DESCRIPTION
This removes the warning that was added to Chapel 1.18 when `--warn-unstable` was used and a program used associative domains of enums, letting them know that the behavior had changed.