### PR TITLE
Fix multiple waits in Spawn

### DIFF
--- a/modules/standard/Spawn.chpl
+++ b/modules/standard/Spawn.chpl
@@ -738,6 +738,9 @@ module Spawn {
     if !running {
       if this.spawn_error then
         try ioerror(this.spawn_error, "in subprocess.wait");
+
+      // Otherwise, do nothing, since the child process already ended.
+      return;
     }
 
     var stdin_err:syserr  = ENOERR;
@@ -831,6 +834,14 @@ module Spawn {
    */
   proc subprocess.communicate() throws {
     try _throw_on_launch_error();
+
+    if !running {
+      if this.spawn_error then
+        try ioerror(this.spawn_error, "in subprocess.communicate");
+
+      // Otherwise, do nothing, since the child process already ended.
+      return;
+    }
 
     var err:syserr = ENOERR;
     on home {

--- a/test/library/standard/Spawn/two-waits.chpl
+++ b/test/library/standard/Spawn/two-waits.chpl
@@ -1,0 +1,28 @@
+use Spawn;
+
+config const poll=false;
+config const pipes=true;
+config var buffer=true;
+
+if pipes then
+  buffer = true;
+
+var process = if pipes
+              then spawn(['ls', 'two-waits.chpl'], stdout=PIPE, stderr=PIPE)
+              else spawn(['ls', 'two-waits.chpl']);
+
+
+if poll {
+  while process.running {
+    process.poll();
+  }
+}
+
+process.wait(buffer=buffer);
+process.wait(buffer=buffer);
+
+if pipes {
+  var s:string;
+  process.stdout.readline(s);
+  write(s);
+}

--- a/test/library/standard/Spawn/two-waits.execopts
+++ b/test/library/standard/Spawn/two-waits.execopts
@@ -1,0 +1,6 @@
+--poll=false --pipes=true --buffer=true
+--poll=false --pipes=false --buffer=true
+--poll=false --pipes=false --buffer=false
+--poll=true --pipes=true --buffer=true
+--poll=true --pipes=false --buffer=true
+--poll=true --pipes=false --buffer=false

--- a/test/library/standard/Spawn/two-waits.good
+++ b/test/library/standard/Spawn/two-waits.good
@@ -1,0 +1,1 @@
+two-waits.chpl


### PR DESCRIPTION
Resolves #10225 by adjusting `subprocess.wait` and `subprocess.communicate`
to return without an error if the process is no longer running.

- [x] full local testing

Reviewed by @ben-albrecht - thanks!