### PR TITLE
Fix type of param field when initialized with literal

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -853,6 +853,22 @@ AggregateType* AggregateType::getNewInstantiation(Symbol* sym) {
   retval->substitutions.copy(substitutions);
 
   if (field->hasFlag(FLAG_PARAM) == true) {
+    Type* fieldType = NULL;
+    if (field->defPoint->exprType) {
+      fieldType = field->defPoint->exprType->typeInfo();
+    }
+
+    // Sometimes 'sym' might be a different type from the field. For example,
+    // the literal '42' is an int(64), and the field might be a uint(64). In
+    // such cases, we need to coerce to a new symbol that will be placed in
+    // the substitutions map.
+    if (fieldType != NULL && fieldType != sym->getValType()) {
+      Immediate coerce = getDefaultImmediate(fieldType);
+      Immediate* from = toVarSymbol(sym)->immediate;
+      coerce_immediate(from, &coerce);
+      sym = new_ImmediateSymbol(&coerce);
+    }
+
     retval->substitutions.put(field, sym);
     retval->symbol->renameInstantiatedSingle(sym);
 

--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -862,7 +862,9 @@ AggregateType* AggregateType::getNewInstantiation(Symbol* sym) {
     // the literal '42' is an int(64), and the field might be a uint(64). In
     // such cases, we need to coerce to a new symbol that will be placed in
     // the substitutions map.
-    if (fieldType != NULL && fieldType != sym->getValType()) {
+    if (fieldType != NULL  &&
+        fieldType != dtUnknown &&
+        fieldType != sym->getValType()) {
       Immediate coerce = getDefaultImmediate(fieldType);
       Immediate* from = toVarSymbol(sym)->immediate;
       coerce_immediate(from, &coerce);

--- a/test/param/bharshbarg/paramFieldType.chpl
+++ b/test/param/bharshbarg/paramFieldType.chpl
@@ -1,0 +1,36 @@
+record Data {
+  type pt;
+  param p: pt;
+}
+
+record DataArray {
+  type pt;
+  param p: pt;
+  
+  var data: [1..10] Data(pt, p);
+}
+
+proc print(type I, type T) {
+  if I != T.p.type then compilerWarning("expecting '" + I:string + "', got '" + T.p.type:string + "'");
+}
+
+proc dosize(param w : int) {
+  print(int(w), Data(int(w), 42));
+  print(uint(w), Data(uint(w), 42));
+
+  if w == 32 || w == 64 {
+    print(real(w), Data(real(w), 42.42));
+  }
+
+  var temp : DataArray(int(w), 42);
+  print(int(w), temp.data[1].type);
+
+  var utemp : DataArray(uint(w), 42);
+  print(uint(w), utemp.data[1].type);
+}
+
+proc main() {
+  for param i in 3..6 {
+    dosize(1 << i);
+  }
+}


### PR DESCRIPTION
Before this PR the compiler could incorrectly map a param field to an immediate symbol of a different type. For example, a type expression that bound the value ``42`` to a ``uint`` param, but the compiler would map the field to an int(64) because that's the default value for literals.

This PR updates the compiler to coerce to a new immediate symbol when the field and value types differ, and use that new symbol in the AggregateType substitution map.

Before this PR, the test added by this PR fails with output like:
```
paramFieldType.chpl:17: In function 'dosize':
paramFieldType.chpl:18: warning: expecting 'int(8)', got 'int(64)'
paramFieldType.chpl:19: warning: expecting 'uint(8)', got 'int(64)'
paramFieldType.chpl:17: In function 'dosize':
paramFieldType.chpl:18: warning: expecting 'int(16)', got 'int(64)'
paramFieldType.chpl:19: warning: expecting 'uint(16)', got 'int(64)'
paramFieldType.chpl:17: In function 'dosize':
paramFieldType.chpl:18: warning: expecting 'int(32)', got 'int(64)'
paramFieldType.chpl:19: warning: expecting 'uint(32)', got 'int(64)'
paramFieldType.chpl:22: warning: expecting 'real(32)', got 'real(64)'
paramFieldType.chpl:17: In function 'dosize':
paramFieldType.chpl:19: warning: expecting 'uint(64)', got 'int(64)'
<gen compiler failures>
```

Resolves #12461

Testing:
- [x] local
- [x] gasnet