### PR TITLE
Sort improvements

### DIFF
--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -1102,6 +1102,12 @@ proc binForRecord(a, criterion, startbit:int)
   }
 }
 
+private
+proc fixedWidthType(type eltTy) param {
+  return isUintType(eltTy) || isIntType(eltTy) ||
+         isRealType(eltTy) || isImagType(eltTy);
+}
+
 // Returns a compile-time known final startbit
 // e.g. for uint(64), returns 56 (since that's 64-8 and the
 // last sort pass will sort on the last 8 bits).
@@ -1112,14 +1118,14 @@ proc msbRadixSortParamLastStartBit(Data:[], comparator) param {
   use Reflection;
 
   // Compute end_bit if it's known
+  // Default comparator on integers has fixed width
   const ref element = Data[Data.domain.low];
   if comparator.type == DefaultComparator &&
-     (isUint(element) || isInt(element)) {
-    // Default comparator on integers has fixed width
+     fixedWidthType(element.type) {
     return numBits(element.type) - RADIX_BITS;
   } else if canResolveMethod(comparator, "key", element) {
     type keyType = comparator.key(element).type;
-    if isUintType(keyType) || isIntType(keyType) then
+    if fixedWidthType(keyType) then
       return numBits(keyType) - RADIX_BITS;
   }
 

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -1473,6 +1473,15 @@ record DefaultComparator {
     var part =    if i <= len then ptr[i-1] else  0:uint(8);
     return (section, part);
   }
+
+  inline
+  proc keyPart(x:c_string, i:int):(int(8), uint(8)) {
+    var ptr = x:c_ptr(uint(8));
+    var byte = ptr[i-1];
+    var section = if byte != 0 then 0:int(8) else -1:int(8);
+    var part = byte;
+    return (section, part);
+  }
 }
 
 /* Reverse comparator built from another comparator.*/

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -1427,6 +1427,31 @@ record DefaultComparator {
     return (section, x);
   }
 
+  inline
+  proc keyPart(x: chpl_anyreal, i:int):(int(8), uint(numBits(x.type))) {
+    var section:int(8) = if i > 1 then -1:int(8) else 0:int(8);
+
+    param nbits = numBits(x.type);
+    // Convert the real bits to a uint
+    var src = x;
+    var dst: uint(nbits);
+    c_memcpy(c_ptrTo(dst), c_ptrTo(src), c_sizeof(src.type));
+
+    if (dst >> (nbits-1)) == 1 {
+      // negative bit is set, flip all bits
+      dst = ~dst;
+    } else {
+      const one: uint(nbits) = 1;
+      // negative bit is not set, flip only top bit
+      dst = dst ^ (one << (nbits-1));
+    }
+    return (section, dst);
+  }
+  inline
+  proc keyPart(x: chpl_anyimag, i:int):(int(8), uint(numBits(x.type))) {
+    return keyPart(x:real(numBits(x.type)), i);
+  }
+
   /*
    Default ``keyPart`` method for tuples of integral values.
    See also `The .keyPart method`_.

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -1274,7 +1274,7 @@ proc msbRadixSort(start_n:int, end_n:int, A:[], criterion,
 
     // Fill buf with up to max_buf records from the end of this bin.
     while i < end {
-      buf[used_buf+1] = A[i];
+      buf[used_buf+1] <=> A[i];
       used_buf += 1;
       i += 1;
     }
@@ -1299,16 +1299,15 @@ proc msbRadixSort(start_n:int, end_n:int, A:[], criterion,
       while used_buf > 0 && j <= used_buf {
         const (bin, _) = binForRecord(buf[j], criterion, startbit);
         // Swap buf[j] into its appropriate bin.
-        // Leave buf[j] with the next unsorted item.
-        // But offsets[bin] might in the region we already read.
-        if bin == curbin && offsets[curbin] >= bufstart {
-          A[offsets[bin]] = buf[j];
-          buf[j] = buf[used_buf];
-          used_buf -= 1;
-        } else {
-          A[offsets[bin]] <=> buf[j];
-        }
+        var offset = offsets[bin];
+        A[offset] <=> buf[j];
         offsets[bin] += 1;
+        // Leave buf[j] with the next unsorted item.
+        // But offsets[bin] might be in the region we already read.
+        if bin == curbin && offset >= bufstart {
+          buf[j] <=> buf[used_buf];
+          used_buf -= 1;
+        }
         j += 1;
       }
     }

--- a/test/library/packages/Sort/correctness/SortTypes.chpl
+++ b/test/library/packages/Sort/correctness/SortTypes.chpl
@@ -58,8 +58,7 @@ proc checkSorts(arr, comparator) {
   var a = arr;
   sort(a, comparator);
   assert(isSorted(a, comparator));
-  if !isFloatOrTupleOfFloat(arr[1].type) &&
-     !isTupleOfString(arr[1].type) {
+  if !isTupleOfString(arr[1].type) {
     // check msbRadixSort
     if verbose then
       writeln("radix sort");

--- a/test/library/packages/Sort/correctness/sortRealImagTuples.chpl
+++ b/test/library/packages/Sort/correctness/sortRealImagTuples.chpl
@@ -1,0 +1,6 @@
+use SortTypes;
+
+checkem(2*real);
+checkem(2*real(32));
+checkem(2*imag);
+checkem(2*imag(32));

--- a/test/library/packages/Sort/correctness/sortRealImagTuples.good
+++ b/test/library/packages/Sort/correctness/sortRealImagTuples.good
@@ -1,0 +1,4 @@
+testing sorts of 2*real(64)
+testing sorts of 2*real(32)
+testing sorts of 2*imag(64)
+testing sorts of 2*imag(32)

--- a/test/library/packages/Sort/correctness/testMsbRadixSort.chpl
+++ b/test/library/packages/Sort/correctness/testMsbRadixSort.chpl
@@ -114,13 +114,15 @@ use BitOps;
    for param i in 1..settingsTuple.size {
      var s = settingsTuple(i);
      var B = input;
-     msbRadixSort(start, end, B, comparator, 0, s);
+     msbRadixSort(start, end, B, comparator,
+                  0, max(int), s);
      if i == 1 then
        writef("radixSort  %ht\n", B);
      testSorted(B, comparator);
 
      var Br = input;
-     msbRadixSort(start, end, Br, new ReverseComparator(comparator), 0, s);
+     msbRadixSort(start, end, Br, new ReverseComparator(comparator),
+                  0, max(int), s);
      if i == 1 then
        writef("radixSort- %ht\n", Br);
      testReverseSorted(Br, comparator);
@@ -199,8 +201,8 @@ proc testSortsUnsigned(input) {
    var t: Timer;
    t.start();
 
-   msbRadixSort(1, size, array, new intCriterion(), 0, new
-       MSBRadixSortSettings());
+   msbRadixSort(1, size, array, new intCriterion(),
+                0, max(int), new MSBRadixSortSettings());
 
    t.stop();
  

--- a/test/library/packages/Sort/performance/sort-performance-explorer.chpl
+++ b/test/library/packages/Sort/performance/sort-performance-explorer.chpl
@@ -16,7 +16,9 @@ config const parallel = true;
 config param reverse = false;
 config type eltType = int;
 
-var methods = ["default", "msbRadixSort", "quickSort", "mergeSort"];
+config const seed = SeedGenerator.oddCurrentTime;
+
+var methods = ["default", "msbRadixSort", "quickSort"];//, "mergeSort"];
 
 proc testsort(input, method, parallel, cmp) {
 
@@ -76,17 +78,17 @@ proc testsize(size:int) {
     // scheme 0 : all zeros
   } else if inputDataScheme == 1 {
     // scheme 1: random ints
-    fillRandom(array);
+    fillRandom(array, seed=seed);
   } else if inputDataScheme == 2 {
     // scheme 2: random ints, only top byte set
-    fillRandom(array);
+    fillRandom(array, seed=seed);
     for a in array {
       a >>= 56;
       a <<= 56;
     }
   } else if inputDataScheme == 3 {
     // scheme 3: random ints, only a middle byte set
-    fillRandom(array);
+    fillRandom(array, seed=seed);
     for a in array {
       a >>= 56;
       a <<= 56;
@@ -94,11 +96,20 @@ proc testsize(size:int) {
     }
   } else if inputDataScheme == 4 {
     // scheme 4: random ints, only bottom byte set
-    fillRandom(array);
+    fillRandom(array, seed=seed);
     for a in array {
       a &= 0xff;
     }
+  } else if inputDataScheme == 5 {
+    // scheme 5: heavily skewed distribution,
+    // values are (1 << (random % 64))
+    fillRandom(array, seed=seed);
+    for a in array {
+      var shift = mod(a, 64);
+      a = 1 << shift;
+    }
   }
+
 
   var inputStringsDomain = {1..0};
   var inputStrings:[inputStringsDomain] string;

--- a/test/library/packages/Sort/performance/sort-performance-explorer.chpl
+++ b/test/library/packages/Sort/performance/sort-performance-explorer.chpl
@@ -14,6 +14,7 @@ config const inputDataScheme = 1;
 config const parallel = true;
 
 config param reverse = false;
+config type eltType = int;
 
 var methods = ["default", "msbRadixSort", "quickSort"];
 
@@ -82,7 +83,7 @@ proc testsize(size:int) {
   if printStats then
     writef("% 16s", sizestr);
 
-  var input = array;
+  var input = forall a in array do a:eltType;
 
   var ntrials = 1;
   if mibibytes < 1 then
@@ -94,7 +95,7 @@ proc testsize(size:int) {
     const ref cmp = if reverse then reverseComparator else defaultComparator;
     var t: Timer;
     for i in 1..ntrials {
-      input = array;
+      input = forall a in array do a:eltType;
       t.start();
       testsort(input, m, parallel, cmp);
       t.stop();
@@ -107,8 +108,10 @@ proc testsize(size:int) {
 }
 
 proc main() {
-  if printStats then
+  if printStats {
+    writeln("Note, speeds are in MiB/s");
     writef("% 16s", "size");
+  }
 
   for m in methods {
     if printStats then

--- a/test/library/packages/Sort/performance/sort-performance-explorer.chpl
+++ b/test/library/packages/Sort/performance/sort-performance-explorer.chpl
@@ -16,7 +16,7 @@ config const parallel = true;
 config param reverse = false;
 config type eltType = int;
 
-var methods = ["default", "msbRadixSort", "quickSort"];
+var methods = ["default", "msbRadixSort", "quickSort", "mergeSort"];
 
 proc testsort(input, method, parallel, cmp) {
 
@@ -37,6 +37,12 @@ proc testsort(input, method, parallel, cmp) {
       serial { quickSort(input, comparator=cmp); }
     } else {
       quickSort(input, comparator=cmp);
+    }
+  } else if method == "mergeSort" {
+    if parallel == false {
+      serial { mergeSort(input); }
+    } else {
+      mergeSort(input);
     }
   }
 }


### PR DESCRIPTION
* Radix sort count pass now parallel
* Enables radix sorting of `real` and `imag` values and tuples of the same
* Enables radix sorting of `c_string`
* Test exploring performance can now sort strings, c_strings, reals and includes a new skewed input distribution

- [x] full local testing

Reviewed by @ben-albrecht - thanks!