### PR TITLE
Update gcc gen compiler to 7.3.0 for cray module builds.

### DIFF
--- a/util/build_configs/cray-internal/setenv-xc-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-xc-x86_64.bash
@@ -335,7 +335,7 @@ else
     fi
 
     # Please keep the gen versions in compiler_versions.bash the same as these!
-    gen_version_gcc=6.1.0
+    gen_version_gcc=7.3.0
     gen_version_intel=16.0.3.210
     gen_version_cce=8.6.3
     if [ "$CHPL_LOCALE_MODEL" == knl ]; then

--- a/util/build_configs/cray-internal/setenv-xe-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-xe-x86_64.bash
@@ -264,7 +264,7 @@ else
     fi
 
     # Please keep the gen versions in compiler_versions.bash the same as these!
-    gen_version_gcc=6.1.0
+    gen_version_gcc=7.3.0
     gen_version_intel=16.0.3.210
     gen_version_cce=8.6.3
 


### PR DESCRIPTION
In order to stay on parity with the MPI team, we are updating the
gcc gen compiler used for the cray-xc_x86-64 and cray-xe module builds
to match with the 7.x version.

Compilation was tested manually on rosa (cray-xc) and kaibab (cray-xe) and Hello World test verified on kaibab (rosa went into dedicated time before test could be run).