### PR TITLE
Reduce memory leaks due to reduce expressions

### DIFF
--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -140,7 +140,7 @@ void  setReduceSVars(ShadowVarSymbol*& PRP, ShadowVarSymbol*& PAS,
 void setupAndResolveShadowVars(ForallStmt* fs);
 bool preserveShadowVar(Symbol* var);
 void adjustVoidShadowVariables();
-void lowerPrimReduce(CallExpr* call, Expr*& retval);
+Expr* lowerPrimReduce(CallExpr* call);
 
 void buildFastFollowerChecksIfNeeded(CallExpr* checkCall);
 

--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -1131,7 +1131,7 @@ static Expr* preFoldPrimOp(CallExpr* call) {
 
   case PRIM_REDUCE: {
     // Need to do this ahead of resolveCall().
-    lowerPrimReduce(call, retval);
+    retval = lowerPrimReduce(call);
     break;
   }
 

--- a/test/reductions/vass/reproducer-tuple-with-array.chpl
+++ b/test/reductions/vass/reproducer-tuple-with-array.chpl
@@ -1,0 +1,48 @@
+// This is a "minimal reproducer" for a valgrind issue
+// that workaroundForReduceIntoDetupleDecl() deals with.
+// The full versions are:
+//   test/studies/kmeans/kmeansonepassreduction-minchange.chpl
+//   test/studies/kmeans/kmeans-blc.chpl
+//
+// While this reproducer does not add testing coverage,
+// I am adding it to facilitate resolution of #12497
+// and just in case the other two tests are modified and do not exhibit
+// the problematic pattern any longer.
+
+var GLOBAL: [1..3] int;
+
+// Returns a tuple with an array.
+proc thisWorks() {
+  return (GLOBAL,);
+}
+
+proc useme(arg) {
+  writeln(arg);
+}
+
+iter dataIter() {
+  yield 55555;
+}
+
+// The role of this reduce-op class is to illustrate a generate() function
+// that returns a tuple with an array.
+class kmeans: ReduceScanOp {
+  type eltType;
+  proc identity {  return 333333; }
+  proc accumulateOntoState(ref state, datum) {}
+  proc accumulate(value) {}
+  proc combine(other: borrowed kmeans) {}
+  proc generate() { return (GLOBAL,);  }
+  proc clone() {   return new unmanaged kmeans(eltType=eltType);  }
+}
+
+proc main {
+  writeln("START MAIN -----------");
+  var (offsetsR,) = thisWorks();
+  writeln("DIVIDER 1  -----------");
+  useme((...thisWorks()));
+  writeln("DIVIDER 2  -----------");
+  // This is the case that requires workaroundForReduceIntoDetupleDecl().
+  var (offsetsI,) = kmeans reduce dataIter();
+  writeln("DONE MAIN  -----------");
+}

--- a/test/reductions/vass/reproducer-tuple-with-array.chpl
+++ b/test/reductions/vass/reproducer-tuple-with-array.chpl
@@ -6,8 +6,8 @@
 //
 // While this reproducer does not add testing coverage,
 // I am adding it to facilitate resolution of #12497
-// and just in case the other two tests are modified and do not exhibit
-// the problematic pattern any longer.
+// and just in case the other two tests are modified
+// and do not exhibit the problematic pattern any longer.
 
 var GLOBAL: [1..3] int;
 

--- a/test/reductions/vass/reproducer-tuple-with-array.good
+++ b/test/reductions/vass/reproducer-tuple-with-array.good
@@ -1,0 +1,5 @@
+START MAIN -----------
+DIVIDER 1  -----------
+0 0 0
+DIVIDER 2  -----------
+DONE MAIN  -----------

--- a/test/reductions/vass/reproducer-tuple-with-array.skipif
+++ b/test/reductions/vass/reproducer-tuple-with-array.skipif
@@ -1,2 +1,0 @@
-# Do not bother under non-valgrind configurations
-CHPL_TEST_VGRND_EXE != on

--- a/test/reductions/vass/reproducer-tuple-with-array.skipif
+++ b/test/reductions/vass/reproducer-tuple-with-array.skipif
@@ -1,0 +1,2 @@
+# Do not bother under non-valgrind configurations
+CHPL_TEST_VGRND_EXE != on


### PR DESCRIPTION
This should revert the memleaks increase due to #12131, discussed in #12125.

* Reduce the number of temporaries added by lowerPrimReduce() and
insertFinalGenerate().

* Which, together with adding FLAG_EXPR_TEMP, takes care of the memleaks,
however causes valgrind failure in two tests, see #12497.

* Remove FLAG_EXPR_TEMP, effectively do not add it, in the special case
when it causes valgrind failure. See workaroundForReduceIntoDetupleDecl()
and #12497.

* The above changes were suggested by @mppf.

* Add a minimal-reproducer test for #12497. While it is not essential,
I am adding it to facilitate resolution of #12497 and just in case
the other two failing tests are modified and do not exhibit the problematic
pattern any longer.

* While there: change lowerPrimReduce() to return the result instead of
assigning it into a ref formal.

