### PR TITLE
Update Sort documentation and errors

### DIFF
--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -1534,6 +1534,7 @@ record ReverseComparator {
     return false;
   }
 
+  /*
   pragma "no doc"
   proc hasReversibleKey(a) param {
     use Reflection;
@@ -1542,7 +1543,8 @@ record ReverseComparator {
       return typeIsBitReversible(t) || typeIsNegateReversible(t);
     }
     return false;
-  }
+  }*/
+
   pragma "no doc"
   proc hasKeyPart(a) param {
     use Reflection;
@@ -1575,6 +1577,7 @@ record ReverseComparator {
     return false;
   }
 
+  /*
   inline
   proc key(a) where hasReversibleKey(a) {
     chpl_check_comparator(this.comparator, a.type);
@@ -1587,7 +1590,7 @@ record ReverseComparator {
     } else {
       compilerError("internal error: please update hasReversibleKey");
     }
-  }
+  }*/
 
   pragma "no doc"
   inline

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -36,7 +36,7 @@ an instance of it to the sort function. Examples are shown below.
 Comparators need to include at least one of the following methods:
 
  * ``key(a)``  -- see `The .key method`_
- * ``compare(a,b)``  -- see `The .compare method`_
+ * ``compare(a, b)``  -- see `The .compare method`_
  * ``keyPart(a, i)`` -- see `The .keyPart method`_
 
 See the section below for discussion of each of these methods.
@@ -420,11 +420,14 @@ proc radixSortOk(Data: [?Dom] ?eltType, comparator) param {
 
 /*
 
-Sort the elements in an array.
+Sort the elements in an array. It is up to the implementation to choose
+the sorting algorithm.
 
 .. note::
-  This function currently uses parallel radix sort if the following
-  conditions are met:
+  This function currently either uses a parallel radix sort or a serial
+  quickSort. The algorithms used will change over time.
+
+  It currently uses parallel radix sort if the following conditions are met:
 
     * the array being sorted is over a non-strided domain
     * ``comparator`` includes a ``keyPart`` method for ``eltType``

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -364,10 +364,10 @@ proc chpl_check_comparator(comparator, type eltType) param {
 
     // Check that there isn't also a compare or keyPart
     if canResolveMethod(comparator, "compare", data, data) {
-      compilerError(errorDepth=errorDepth, "The key method cannot be provided in a comparator that provides a compare method");
+      compilerError(errorDepth=errorDepth, comparator.type:string, " contains both a key method and a compare method");
     }
     if canResolveMethod(comparator, "keyPart", data, 1) {
-      compilerError(errorDepth=errorDepth, "The key method cannot be provided in a comparator that provides a keyPart method");
+      compilerError(errorDepth=errorDepth, comparator.type:string, " contains both a key method and a keyPart method");
     }
   }
   else if canResolveMethod(comparator, "compare", data, data) {

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -177,7 +177,7 @@ A ``keyPart`` method should return a tuple consisting of *section* and a *part*.
 
 Let's consider several example ``keyPart`` methods. All of these are
 simplifications of ``keyPart`` methods already available in the
-DefaultComparator.
+``DefaultComparator``.
 
 This ``keyPart`` method supports sorting tuples of 2 integers:
 
@@ -1404,7 +1404,7 @@ record DefaultComparator {
   }
 
   /*
-   Default keyPart method for integral values.
+   Default ``keyPart`` method for integral values.
    See also `The .keyPart method`_.
 
    :arg x: the `int` or `uint` of any size to sort
@@ -1419,7 +1419,7 @@ record DefaultComparator {
   }
 
   /*
-   Default keyPart method for tuples of integral values.
+   Default ``keyPart`` method for tuples of integral values.
    See also `The .keyPart method`_.
 
    :arg x: tuple of the `int` or `uint` (of any bit width) to sort
@@ -1439,7 +1439,7 @@ record DefaultComparator {
   }
 
   /*
-   Default keyPart method for sorting strings. See also `The .keyPart method`_.
+   Default ``keyPart`` method for sorting strings. See also `The .keyPart method`_.
 
    .. note::
      Currently assumes that the string is local.
@@ -1579,7 +1579,7 @@ record ReverseComparator {
   }
 
   /*
-   Reverses comparator.keyPart. See also `The .keyPart method`_.
+   Reverses ``comparator.keyPart``. See also `The .keyPart method`_.
    */
   inline
   proc keyPart(a, i) where hasKeyPart(a) || hasKeyPartFromKey(a) {

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -1533,17 +1533,6 @@ record ReverseComparator {
     return false;
   }
 
-  /*
-  pragma "no doc"
-  proc hasReversibleKey(a) param {
-    use Reflection;
-    if canResolveMethod(this.comparator, "key", a) {
-      type t = this.comparator.key(a).type;
-      return typeIsBitReversible(t) || typeIsNegateReversible(t);
-    }
-    return false;
-  }*/
-
   pragma "no doc"
   proc hasKeyPart(a) param {
     use Reflection;
@@ -1575,21 +1564,6 @@ record ReverseComparator {
     }
     return false;
   }
-
-  /*
-  inline
-  proc key(a) where hasReversibleKey(a) {
-    chpl_check_comparator(this.comparator, a.type);
-
-    const k = this.comparator.key(a);
-    if typeIsBitReversible(k.type) {
-      return ~k;
-    } else if typeIsNegateReversible(k.type) {
-      return -k;
-    } else {
-      compilerError("internal error: please update hasReversibleKey");
-    }
-  }*/
 
   pragma "no doc"
   inline

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -1389,15 +1389,12 @@ record DefaultComparator {
 
   /*
    Default compare method used in sort functions.
+   Uses the `<` operator to compute the ordering between ``a`` and ``b``.
+   See also `The .compare method`_.
 
-   :arg a: Array element
-   :type a: `eltType`
-   :arg b: Array element
-   :type b: `eltType`
    :returns: 1 if ``b < a``
    :returns: 0 if ``a == b``
    :returns: -1 if ``a < b``
-
    */
   inline
   proc compare(a, b) {
@@ -1408,11 +1405,12 @@ record DefaultComparator {
 
   /*
    Default keyPart method for integral values.
+   See also `The .keyPart method`_.
 
    :arg x: the `int` or `uint` of any size to sort
    :arg i: the part number requested
 
-   :returns: (0, x) if i==0, or (-1, x) otherwise
+   :returns: ``(0, x)`` if ``i==0``, or ``(-1, x)`` otherwise
    */
   inline
   proc keyPart(x: integral, i:int):(int(8), x.type) {
@@ -1422,11 +1420,12 @@ record DefaultComparator {
 
   /*
    Default keyPart method for tuples of integral values.
+   See also `The .keyPart method`_.
 
    :arg x: tuple of the `int` or `uint` (of any bit width) to sort
    :arg i: the part number requested
 
-   :returns: (0, x(i)) if i <= x.size, or (-1, 0) otherwise
+   :returns: ``(0, x(i))`` if ``i <= x.size``, or ``(-1, 0)`` otherwise
    */
   inline
   proc keyPart(x: _tuple, i:int) where isHomogeneousTuple(x) &&
@@ -1440,7 +1439,7 @@ record DefaultComparator {
   }
 
   /*
-   Default keyPart method for sorting strings
+   Default keyPart method for sorting strings. See also `The .keyPart method`_.
 
    .. note::
      Currently assumes that the string is local.
@@ -1448,7 +1447,7 @@ record DefaultComparator {
    :arg x: the string to sort
    :arg i: the part number requested
 
-   :returns: (0, byte i of string) or (-1, 0) if i > x.size
+   :returns: ``(0, byte i of string)`` or ``(-1, 0)`` if ``i > x.size``
    */
   inline
   proc keyPart(x:string, i:int):(int(8), uint(8)) {
@@ -1605,6 +1604,9 @@ record ReverseComparator {
     }
   }
 
+  /*
+   Reverses comparator.keyPart. See also `The .keyPart method`_.
+   */
   inline
   proc keyPart(a, i) where hasKeyPart(a) || hasKeyPartFromKey(a) {
     chpl_check_comparator(this.comparator, a.type);
@@ -1624,15 +1626,7 @@ record ReverseComparator {
   }
 
   /*
-   Reverses ``comparator.compare``.
-
-   :arg a: Array element
-   :type a: `eltType`
-   :arg b: Array element
-   :type b: `eltType`
-   :returns: -1 if ``b < a``
-   :returns: 0 if ``a == b``
-   :returns: 1 if ``a < b``
+   Reverses ``comparator.compare``. See also `The .compare method`_.
    */
   inline
   proc compare(a, b) where hasCompare(a, b) || hasCompareFromKey(a) {

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -402,6 +402,8 @@ proc chpl_check_comparator(comparator, type eltType) param {
 
 private
 proc radixSortOk(Data: [?Dom] ?eltType, comparator) param {
+  use Reflection;
+
   if !Dom.stridable {
     var tmp:Data[Dom.low].type;
     if canResolveMethod(comparator, "keyPart", tmp, 1) {

--- a/test/library/packages/Sort/correctness/correctness.chpl
+++ b/test/library/packages/Sort/correctness/correctness.chpl
@@ -10,13 +10,11 @@ proc main() {
   // Comparators
   const absKey = new AbsKeyCmp(),
         absComp = new AbsCompCmp(),
-        absKeyComp = new AbsKeyCompCmp(),
         revAbsKey = new ReverseComparator(absKey),
         revAbsComp = new ReverseComparator(absComp),
         tupleKey = new TupleCmp();
   const absKeyClass = new AbsKeyCmpClass(),
         absCompClass = new AbsCompCmpClass(),
-        absKeyCompClass = new AbsKeyCompCmpClass(),
         revAbsKeyClass = new ReverseComparator(absKeyClass),
         revAbsCompClass = new ReverseComparator(absCompClass),
         tupleKeyClass = new TupleCmpClass();
@@ -47,8 +45,6 @@ proc main() {
                 ([-1, 2, 3, -4], absKeyClass),
                 ([-1, 2, 3, -4], absComp),
                 ([-1, 2, 3, -4], absCompClass),
-                ([-1, 2, 3, -4], absKeyComp),
-                ([-1, 2, 3, -4], absKeyCompClass),
                 ([ 3, 2, -1, -4], reverseComparator),
                 ([ -4, 3, 2, -1], revAbsKey),
                 ([ -4, 3, 2, -1], revAbsKeyClass),
@@ -228,18 +224,6 @@ class AbsCompCmpClass {
 }
 
 
-
-/* Key method should take priority over compare method */
-record AbsKeyCompCmp {
-  proc key(a) { return abs(a); }
-  proc compare(a, b) { return a - b; }
-  proc name() { return 'AbsKeyCompCmp'; }
-}
-class AbsKeyCompCmpClass {
-  proc key(a) { return abs(a); }
-  proc compare(a, b) { return a - b; }
-  proc name() { return 'AbsKeyCompCmpClass'; }
-}
 
 /* Key method can return a non-numerical/string type, such as tuple */
 record TupleCmp {

--- a/test/library/packages/Sort/correctness/correctness.chpl
+++ b/test/library/packages/Sort/correctness/correctness.chpl
@@ -14,6 +14,13 @@ proc main() {
         revAbsKey = new ReverseComparator(absKey),
         revAbsComp = new ReverseComparator(absComp),
         tupleKey = new TupleCmp();
+  const absKeyClass = new AbsKeyCmpClass(),
+        absCompClass = new AbsCompCmpClass(),
+        absKeyCompClass = new AbsKeyCompCmpClass(),
+        revAbsKeyClass = new ReverseComparator(absKeyClass),
+        revAbsCompClass = new ReverseComparator(absCompClass),
+        tupleKeyClass = new TupleCmpClass();
+
 
   // Arrays and Domains
   const largeD = {1..20}, // quickSort requires domain.size > 16
@@ -37,12 +44,18 @@ proc main() {
 
                 // Testing comparators
                 ([-1, 2, 3, -4], absKey),
+                ([-1, 2, 3, -4], absKeyClass),
                 ([-1, 2, 3, -4], absComp),
+                ([-1, 2, 3, -4], absCompClass),
                 ([-1, 2, 3, -4], absKeyComp),
+                ([-1, 2, 3, -4], absKeyCompClass),
                 ([ 3, 2, -1, -4], reverseComparator),
                 ([ -4, 3, 2, -1], revAbsKey),
+                ([ -4, 3, 2, -1], revAbsKeyClass),
                 ([ -4, 3, 2, -1], revAbsComp),
-                ([-4, -1, 2, 3], tupleKey)
+                ([ -4, 3, 2, -1], revAbsCompClass),
+                ([-4, -1, 2, 3], tupleKey),
+                ([-4, -1, 2, 3], tupleKeyClass)
               );
 
 
@@ -197,6 +210,11 @@ record AbsKeyCmp {
   proc key(a) { return abs(a); }
   proc name() { return 'AbsKeyCmp'; }
 }
+class AbsKeyCmpClass {
+  proc key(a) { return abs(a); }
+  proc name() { return 'AbsKeyCmpClass'; }
+}
+
 
 
 /* Compare Sort by absolute value */
@@ -204,6 +222,11 @@ record AbsCompCmp {
   proc compare(a, b) { return abs(a) - abs(b); }
   proc name() { return 'AbsCompCmp'; }
 }
+class AbsCompCmpClass {
+  proc compare(a, b) { return abs(a) - abs(b); }
+  proc name() { return 'AbsCompCmpClass'; }
+}
+
 
 
 /* Key method should take priority over compare method */
@@ -212,11 +235,19 @@ record AbsKeyCompCmp {
   proc compare(a, b) { return a - b; }
   proc name() { return 'AbsKeyCompCmp'; }
 }
-
+class AbsKeyCompCmpClass {
+  proc key(a) { return abs(a); }
+  proc compare(a, b) { return a - b; }
+  proc name() { return 'AbsKeyCompCmpClass'; }
+}
 
 /* Key method can return a non-numerical/string type, such as tuple */
 record TupleCmp {
   proc key(a) { return (a, a); }
   proc name() { return 'TupleCmp'; }
+}
+class TupleCmpClass {
+  proc key(a) { return (a, a); }
+  proc name() { return 'TupleCmpClass'; }
 }
 

--- a/test/library/packages/Sort/errors/errors-comparator.chpl
+++ b/test/library/packages/Sort/errors/errors-comparator.chpl
@@ -40,3 +40,27 @@ record compareargs { }
 proc compareargs.compare(a) {
   return a;
 }
+
+// Bad keyPart args -- need 2 args
+record keyPartArgs { }
+proc keyAndCompare.keyPart(a) {
+  return a;
+}
+
+// Both key and compare
+record keyAndCompare { }
+proc keyAndCompare.key(a) {
+  return a;
+}
+proc keyAndCompare.compare(a, b) {
+  return 0;
+}
+
+// Both key and keyPart
+record keyAndKeyPart { }
+proc keyAndKeyPart.key(a) {
+  return a;
+}
+proc keyAndKeyPart.keyPart(a, i) {
+  return (0, 0);
+}

--- a/test/library/packages/Sort/errors/errors-comparator.compareargs.good
+++ b/test/library/packages/Sort/errors/errors-comparator.compareargs.good
@@ -1,2 +1,2 @@
-$CHPL_HOME/modules/packages/Sort.chpl:nnnn: In function 'quickSort':
-$CHPL_HOME/modules/packages/Sort.chpl:nnnn: error: The comparator compareargs requires a 'key(a)', 'compare(a, b)', or 'keyPart(a, i)' method  for element type int(64)
+errors-comparator.chpl:9: In function 'main':
+errors-comparator.chpl:17: error: The comparator compareargs requires a 'key(a)', 'compare(a, b)', or 'keyPart(a, i)' method  for element type int(64)

--- a/test/library/packages/Sort/errors/errors-comparator.compopts
+++ b/test/library/packages/Sort/errors/errors-comparator.compopts
@@ -1,4 +1,7 @@
--scomparator=empty        # errors-comparator.empty.good
--scomparator=wrong        # errors-comparator.wrong.good
--scomparator=keyargs      # errors-comparator.keyargs.good
--scomparator=compareargs  # errors-comparator.compareargs.good
+-scomparator=compareargs    # errors-comparator.compareargs.good
+-scomparator=empty          # errors-comparator.empty.good
+-scomparator=keyAndCompare  # errors-comparator.keyandcompare.good
+-scomparator=keyAndKeyPart  # errors-comparator.keyandkeypart.good
+-scomparator=keyargs        # errors-comparator.keyargs.good
+-scomparator=keyPartArgs    # errors-comparator.keypartargs.good
+-scomparator=wrong          # errors-comparator.wrong.good

--- a/test/library/packages/Sort/errors/errors-comparator.empty.good
+++ b/test/library/packages/Sort/errors/errors-comparator.empty.good
@@ -1,2 +1,2 @@
-$CHPL_HOME/modules/packages/Sort.chpl:nnnn: In function 'quickSort':
-$CHPL_HOME/modules/packages/Sort.chpl:nnnn: error: The comparator empty requires a 'key(a)', 'compare(a, b)', or 'keyPart(a, i)' method  for element type int(64)
+errors-comparator.chpl:9: In function 'main':
+errors-comparator.chpl:17: error: The comparator empty requires a 'key(a)', 'compare(a, b)', or 'keyPart(a, i)' method  for element type int(64)

--- a/test/library/packages/Sort/errors/errors-comparator.keyandcompare.good
+++ b/test/library/packages/Sort/errors/errors-comparator.keyandcompare.good
@@ -1,0 +1,2 @@
+errors-comparator.chpl:9: In function 'main':
+errors-comparator.chpl:17: error: The key method cannot be provided in a comparator that provides a compare method

--- a/test/library/packages/Sort/errors/errors-comparator.keyandcompare.good
+++ b/test/library/packages/Sort/errors/errors-comparator.keyandcompare.good
@@ -1,2 +1,2 @@
 errors-comparator.chpl:9: In function 'main':
-errors-comparator.chpl:17: error: The key method cannot be provided in a comparator that provides a compare method
+errors-comparator.chpl:17: error: keyAndCompare contains both a key method and a compare method

--- a/test/library/packages/Sort/errors/errors-comparator.keyandkeypart.good
+++ b/test/library/packages/Sort/errors/errors-comparator.keyandkeypart.good
@@ -1,2 +1,2 @@
 errors-comparator.chpl:9: In function 'main':
-errors-comparator.chpl:17: error: The key method cannot be provided in a comparator that provides a keyPart method
+errors-comparator.chpl:17: error: keyAndKeyPart contains both a key method and a keyPart method

--- a/test/library/packages/Sort/errors/errors-comparator.keyandkeypart.good
+++ b/test/library/packages/Sort/errors/errors-comparator.keyandkeypart.good
@@ -1,0 +1,2 @@
+errors-comparator.chpl:9: In function 'main':
+errors-comparator.chpl:17: error: The key method cannot be provided in a comparator that provides a keyPart method

--- a/test/library/packages/Sort/errors/errors-comparator.keyargs.good
+++ b/test/library/packages/Sort/errors/errors-comparator.keyargs.good
@@ -1,2 +1,2 @@
-$CHPL_HOME/modules/packages/Sort.chpl:nnnn: In function 'quickSort':
-$CHPL_HOME/modules/packages/Sort.chpl:nnnn: error: The comparator keyargs requires a 'key(a)', 'compare(a, b)', or 'keyPart(a, i)' method  for element type int(64)
+errors-comparator.chpl:9: In function 'main':
+errors-comparator.chpl:17: error: The comparator keyargs requires a 'key(a)', 'compare(a, b)', or 'keyPart(a, i)' method  for element type int(64)

--- a/test/library/packages/Sort/errors/errors-comparator.keypartargs.good
+++ b/test/library/packages/Sort/errors/errors-comparator.keypartargs.good
@@ -1,0 +1,2 @@
+errors-comparator.chpl:9: In function 'main':
+errors-comparator.chpl:17: error: The comparator keyPartArgs requires a 'key(a)', 'compare(a, b)', or 'keyPart(a, i)' method  for element type int(64)

--- a/test/library/packages/Sort/errors/errors-comparator.wrong.good
+++ b/test/library/packages/Sort/errors/errors-comparator.wrong.good
@@ -1,2 +1,2 @@
-$CHPL_HOME/modules/packages/Sort.chpl:nnnn: In function 'quickSort':
-$CHPL_HOME/modules/packages/Sort.chpl:nnnn: error: The comparator wrong requires a 'key(a)', 'compare(a, b)', or 'keyPart(a, i)' method  for element type int(64)
+errors-comparator.chpl:9: In function 'main':
+errors-comparator.chpl:17: error: The comparator wrong requires a 'key(a)', 'compare(a, b)', or 'keyPart(a, i)' method  for element type int(64)

--- a/test/library/packages/Sort/errors/errors-compare.boolean.good
+++ b/test/library/packages/Sort/errors/errors-compare.boolean.good
@@ -1,2 +1,2 @@
-$CHPL_HOME/modules/packages/Sort.chpl:nnnn: In function 'quickSort':
-$CHPL_HOME/modules/packages/Sort.chpl:nnnn: error: The compare method in boolean must return a numeric type when used with int(64) elements
+errors-comparator.chpl:9: In function 'main':
+errors-comparator.chpl:17: error: The comparator wrong requires a 'key(a)', 'compare(a, b)', or 'keyPart(a, i)' method  for element type int(64)

--- a/test/library/packages/Sort/errors/errors-compare.boolean.good
+++ b/test/library/packages/Sort/errors/errors-compare.boolean.good
@@ -1,2 +1,2 @@
-errors-comparator.chpl:9: In function 'main':
-errors-comparator.chpl:17: error: The comparator wrong requires a 'key(a)', 'compare(a, b)', or 'keyPart(a, i)' method  for element type int(64)
+errors-compare.chpl:9: In function 'main':
+errors-compare.chpl:17: error: The compare method in boolean must return a numeric type when used with int(64) elements

--- a/test/library/packages/Sort/errors/errors-compare.rec.good
+++ b/test/library/packages/Sort/errors/errors-compare.rec.good
@@ -1,2 +1,2 @@
-$CHPL_HOME/modules/packages/Sort.chpl:nnnn: In function 'quickSort':
-$CHPL_HOME/modules/packages/Sort.chpl:nnnn: error: The compare method in rec must return a numeric type when used with int(64) elements
+errors-compare.chpl:9: In function 'main':
+errors-compare.chpl:17: error: The compare method in rec must return a numeric type when used with int(64) elements

--- a/test/library/packages/Sort/errors/errors-compare.str.good
+++ b/test/library/packages/Sort/errors/errors-compare.str.good
@@ -1,2 +1,2 @@
-$CHPL_HOME/modules/packages/Sort.chpl:nnnn: In function 'quickSort':
-$CHPL_HOME/modules/packages/Sort.chpl:nnnn: error: The compare method in str must return a numeric type when used with int(64) elements
+errors-compare.chpl:9: In function 'main':
+errors-compare.chpl:17: error: The compare method in str must return a numeric type when used with int(64) elements

--- a/test/library/packages/Sort/errors/errors-key.good
+++ b/test/library/packages/Sort/errors/errors-key.good
@@ -1,2 +1,2 @@
-$CHPL_HOME/modules/packages/Sort.chpl:nnnn: In function 'quickSort':
-$CHPL_HOME/modules/packages/Sort.chpl:nnnn: error: The key method in rec must return an object that supports the '<' function when used with int(64) elements
+errors-key.chpl:9: In function 'main':
+errors-key.chpl:17: error: The key method in rec must return an object that supports the '<' function when used with int(64) elements

--- a/test/library/packages/Sort/errors/errors-keyPart.chpl
+++ b/test/library/packages/Sort/errors/errors-keyPart.chpl
@@ -1,0 +1,47 @@
+/*
+ *  Tests compile errors upon passing a non-string/numeric comparator.compare(a, b)
+ */
+
+use Sort;
+
+config type comparator;
+
+proc main() {
+
+  // Array to sort
+  var Arr = [-1,-4, 2, 3];
+
+  var comp = new comparator();
+
+  // Test fails if this compiles
+  sort(Arr, comparator=comp);
+
+}
+
+
+/* Broken keyPart */
+
+record str { }
+
+proc str.keyPart(a, i) {
+  return 'foobar';
+}
+
+
+record tStrStr { }
+
+proc tStrStr.keyPart(a, b) {
+  return ("a", "b");
+}
+
+record tUintInt { }
+
+proc tUintInt.keyPart(a, b) {
+  return (0:uint, 0);
+}
+
+record tIntReal { }
+
+proc tIntReal.keyPart(a, b) {
+  return (0, 0.0);
+}

--- a/test/library/packages/Sort/errors/errors-keyPart.compopts
+++ b/test/library/packages/Sort/errors/errors-keyPart.compopts
@@ -1,0 +1,4 @@
+-scomparator=str      # errors-keyPart.str.good
+-scomparator=tIntReal # errors-keyPart.tIntReal.good
+-scomparator=tStrStr  # errors-keyPart.tStrStr.good
+-scomparator=tUintInt # errors-keyPart.tUintInt.good

--- a/test/library/packages/Sort/errors/errors-keyPart.str.good
+++ b/test/library/packages/Sort/errors/errors-keyPart.str.good
@@ -1,0 +1,2 @@
+errors-keyPart.chpl:9: In function 'main':
+errors-keyPart.chpl:17: error: The keyPart method in str must return a tuple when used with int(64) elements

--- a/test/library/packages/Sort/errors/errors-keyPart.tIntReal.good
+++ b/test/library/packages/Sort/errors/errors-keyPart.tIntReal.good
@@ -1,0 +1,2 @@
+errors-keyPart.chpl:9: In function 'main':
+errors-keyPart.chpl:17: error: The keyPart method in tIntReal must return a tuple with 2nd element int(?) or uint(?) when used with int(64) elements

--- a/test/library/packages/Sort/errors/errors-keyPart.tStrStr.good
+++ b/test/library/packages/Sort/errors/errors-keyPart.tStrStr.good
@@ -1,0 +1,2 @@
+errors-keyPart.chpl:9: In function 'main':
+errors-keyPart.chpl:17: error: The keyPart method in tStrStr must return a tuple with 1st element int(?) when used with int(64) elements

--- a/test/library/packages/Sort/errors/errors-keyPart.tUintInt.good
+++ b/test/library/packages/Sort/errors/errors-keyPart.tUintInt.good
@@ -1,0 +1,2 @@
+errors-keyPart.chpl:9: In function 'main':
+errors-keyPart.chpl:17: error: The keyPart method in tUintInt must return a tuple with 1st element int(?) when used with int(64) elements

--- a/test/library/packages/Sort/performance/sort-performance-explorer.chpl
+++ b/test/library/packages/Sort/performance/sort-performance-explorer.chpl
@@ -13,26 +13,29 @@ config const inputDataScheme = 1;
 
 config const parallel = true;
 
+config param reverse = false;
+
 var methods = ["default", "msbRadixSort", "quickSort"];
 
-proc testsort(input, method, parallel) {
+proc testsort(input, method, parallel, cmp) {
+
   if method == "default" {
     if parallel == false {
-      serial { sort(input); }
+      serial { sort(input, cmp); }
     } else {
-      sort(input);
+      sort(input, cmp);
     }
   } else if method == "msbRadixSort" {
     if parallel == false {
-      serial { msbRadixSort(input, defaultComparator); }
+      serial { msbRadixSort(input, cmp); }
     } else {
-      msbRadixSort(input, defaultComparator);
+      msbRadixSort(input, cmp);
     }
   } else if method == "quickSort" {
     if parallel == false {
-      serial { quickSort(input); }
+      serial { quickSort(input, comparator=cmp); }
     } else {
-      quickSort(input);
+      quickSort(input, comparator=cmp);
     }
   }
 }
@@ -88,16 +91,17 @@ proc testsize(size:int) {
     ntrials = 100;
 
   for m in methods {
+    const ref cmp = if reverse then reverseComparator else defaultComparator;
     var t: Timer;
     for i in 1..ntrials {
       input = array;
       t.start();
-      testsort(input, m, parallel);
+      testsort(input, m, parallel, cmp);
       t.stop();
     }
     var mibs = mibibytes * ntrials / t.elapsed();
     if printStats then writef(" % 12s", mibs:string);
-    assert(isSorted(input));
+    assert(isSorted(input, cmp));
   }
   if printStats then writeln();
 }


### PR DESCRIPTION
Follow-on to PR #12452
Resolves #12478

* Improves the Sort documentation to describe radix sorting and the keyPart comparator interface
* Adjusts the Sort comparator checking function to make having a `key` and one of the other methods (`compare`, `keyPart`) an error. The rationale for this is that it might be confusing otherwise - we'd have to make rules for which we prefer, when there isn't a natural choice there. But `key` is meant to be a convenience, so there isn't a good reason one would need to supply `key` and one of the others. (Supplying `keyPart` and `compare` in contrast is expected and useful in many cases).
* Improves other compile-time error messages from the Sort module

- [x] full local testing

Reviewed by @ben-albrecht - thanks!