### PR TITLE
Suppress tests with warning on PGI

### DIFF
--- a/test/library/standard/Math/infinity.suppressif
+++ b/test/library/standard/Math/infinity.suppressif
@@ -1,0 +1,1 @@
+CHPL_TARGET_COMPILER==cray-prgenv-pgi

--- a/test/param/ferguson/param-inf.suppressif
+++ b/test/param/ferguson/param-inf.suppressif
@@ -1,0 +1,1 @@
+CHPL_TARGET_COMPILER==cray-prgenv-pgi

--- a/test/studies/dijkstra/driverEdgeBtw.suppressif
+++ b/test/studies/dijkstra/driverEdgeBtw.suppressif
@@ -1,0 +1,1 @@
+CHPL_TARGET_COMPILER==cray-prgenv-pgi


### PR DESCRIPTION
This is a follow-on to PR #12386.

Avoids warnings like
`PGC-W-0129-Floating point overflow. Check constants and constant expressions`

Trivial and not reviewed.