### PR TITLE
Give in intent to varargs formals in joinPath, commonPath

### DIFF
--- a/modules/standard/Path.chpl
+++ b/modules/standard/Path.chpl
@@ -149,8 +149,9 @@ proc basename(name: string): string {
    :return: The longest common path prefix.
    :rtype: `string`
 */
-
-proc commonPath(paths: string ...?n): string {
+// NOTE: Add in intent here to temporarily fix compiler memory leak related
+// to use of varargs.
+proc commonPath(in paths: string ...?n): string {
 
   var result: string = "";    // result string
   var inputLength = n;   // size of input array
@@ -463,7 +464,9 @@ private proc joinPathComponent(comp: string, ref result: string) {
             present.
    :rtype: `string`
 */
-proc joinPath(paths: string ...?n): string {
+// NOTE: Add in intent here to temporarily fix compiler memory leak related
+// to use of varargs.
+proc joinPath(in paths: string ...?n): string {
   var result: string;
 
   for path in paths do


### PR DESCRIPTION
These minor changes to the varargs overloads of `joinPath()` and `commonPath()` are motivated by #12506.

Many functions in the `Path` standard module are dependent on the use of `joinPath()`, which caused a cascade of memory leaks to appear during nightly testing.

After discussion, @benharsh recommended changing varargs formals to have a "in" intent as a means of temporarily fixing this bug.

After these changes, all tests in the Path module pass and report **zero** leaked memory (yay!).

All tests pass on:

- [x] linux64