### PR TITLE
Remove UgniPerfStats from the list of publicly documented modules

### DIFF
--- a/modules/Makefile
+++ b/modules/Makefile
@@ -116,7 +116,6 @@ PACKAGES_TO_DOCUMENT = \
 	packages/ReplicatedVar.chpl \
 	packages/Search.chpl \
 	packages/Sort.chpl \
-	packages/UgniPerfStats.chpl \
 	packages/VisualDebug.chpl \
 	packages/ZMQ.chpl \
 	packages/Collection.chpl \


### PR DESCRIPTION
It's a module intended for (runtime) developers and we haven't decided
where we want that sort of documentation to live yet, so remove it for
now.