### PR TITLE
Delete nested task errors when folding them

### DIFF
--- a/modules/internal/ChapelError.chpl
+++ b/modules/internal/ChapelError.chpl
@@ -207,6 +207,7 @@ module ChapelError {
               idx += 1;
             }
           }
+          delete asTaskErr;
         }
         cur = curnext;
       }


### PR DESCRIPTION
Addresses one memory leak mentioned in #12511.

- [x] full local testing
- [x] test/errhandling with -valgrindexe

Reviewed by @lydia-duncan - thanks!