### PR TITLE
Use a directory.skipif to avoid running these tests without LLVM

### DIFF
--- a/test/interop/C/llvm.skipif
+++ b/test/interop/C/llvm.skipif
@@ -1,0 +1,2 @@
+# Tests llvm specifically, should not run when not present
+CHPL_LLVM==none


### PR DESCRIPTION
Double checked it actually skipped them when run from test/interop/C