### PR TITLE
Remove pragma no prototype

### DIFF
--- a/compiler/codegen/symbol.cpp
+++ b/compiler/codegen/symbol.cpp
@@ -1730,7 +1730,6 @@ void FnSymbol::codegenPrototype() {
   GenInfo *info = gGenInfo;
 
   if (hasFlag(FLAG_EXTERN) && !hasFlag(FLAG_GENERATE_SIGNATURE)) return;
-  if (hasFlag(FLAG_NO_PROTOTYPE)) return;
   if (hasFlag(FLAG_NO_CODEGEN))   return;
 
   if( id == breakOnCodegenID ||
@@ -2033,7 +2032,6 @@ void FnSymbol::codegenFortran(int indent) {
   int beginIndent = indent;
 
   if (!hasFlag(FLAG_EXPORT)) return;
-  if (hasFlag(FLAG_NO_PROTOTYPE)) return;
   if (hasFlag(FLAG_NO_CODEGEN)) return;
 
   if (info->cfile) {
@@ -2139,7 +2137,6 @@ void FnSymbol::codegenPython(PythonFileType pxd) {
   GenInfo *info = gGenInfo;
 
   if (!hasFlag(FLAG_EXPORT)) return;
-  if (hasFlag(FLAG_NO_PROTOTYPE)) return;
   if (hasFlag(FLAG_NO_CODEGEN)) return;
 
   // Should I add the break-on-codegen-id stuff here?

--- a/compiler/include/flags_list.h
+++ b/compiler/include/flags_list.h
@@ -248,7 +248,6 @@ symbolFlag( FLAG_NO_IMPLICIT_COPY , ypr, "no implicit copy" , "function does not
 symbolFlag( FLAG_NO_INSTANTIATION_LIMIT , ypr, "no instantiation limit", "The instantiation limit is not checked for this function" )
 symbolFlag( FLAG_NO_OBJECT , ypr, "no object" , ncm )
 symbolFlag( FLAG_NO_PARENS , npr, "no parens" , "function without parentheses" )
-symbolFlag( FLAG_NO_PROTOTYPE , ypr, "no prototype" , "do not generate a prototype this symbol" )
 symbolFlag( FLAG_NO_REMOTE_MEMORY_FENCE , ypr, "no remote memory fence" , ncm)
 symbolFlag( FLAG_NO_RVF, npr, "do not RVF", ncm)
 symbolFlag( FLAG_NO_WIDE_CLASS , ypr, "no wide class" , ncm )

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1875,7 +1875,6 @@ module DefaultRectangular {
     if len == 0 then return;
 
     if debugBulkTransfer {
-      pragma "no prototype"
       pragma "fn synchronization free"
       extern proc sizeof(type x): int;
       const elemSize =sizeof(B.eltType);

--- a/modules/packages/MPI.chpl
+++ b/modules/packages/MPI.chpl
@@ -436,7 +436,6 @@ module MPI {
 
   {
     pragma "no doc"
-    pragma "no prototype"
     extern proc sizeof(type t): size_t;
     assert(sizeof(MPI_Aint) == sizeof(c_ptrdiff));
   }

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -861,7 +861,6 @@ private extern proc qio_style_init_default(ref s: iostyle);
 private extern proc qio_file_retain(f:qio_file_ptr_t);
 private extern proc qio_file_release(f:qio_file_ptr_t);
 
-pragma "no prototype" // FIXME
 private extern proc qio_file_init(ref file_out:qio_file_ptr_t, fp:_file, fd:fd_t, iohints:c_int, const ref style:iostyle, usefilestar:c_int):syserr;
 private extern proc qio_file_open_access(ref file_out:qio_file_ptr_t, path:c_string, access:c_string, iohints:c_int, const ref style:iostyle):syserr;
 private extern proc qio_file_open_tmp(ref file_out:qio_file_ptr_t, iohints:c_int, const ref style:iostyle):syserr;
@@ -888,10 +887,8 @@ private extern proc qio_channel_end_offset_unlocked(ch:qio_channel_ptr_t):int(64
 private extern proc qio_file_get_style(f:qio_file_ptr_t, ref style:iostyle);
 private extern proc qio_file_length(f:qio_file_ptr_t, ref len:int(64)):syserr;
 
-pragma "no prototype" // FIXME
 private extern proc qio_channel_create(ref ch:qio_channel_ptr_t, file:qio_file_ptr_t, hints:c_int, readable:c_int, writeable:c_int, start:int(64), end:int(64), const ref style:iostyle):syserr;
 
-pragma "no prototype" // FIXME
 private extern proc qio_channel_path_offset(threadsafe:c_int, ch:qio_channel_ptr_t, ref path:c_string, ref offset:int(64)):syserr;
 
 private extern proc qio_channel_retain(ch:qio_channel_ptr_t);
@@ -952,13 +949,9 @@ private extern proc qio_locales_for_region(fl:qio_file_ptr_t,
 private extern proc qio_get_chunk(fl:qio_file_ptr_t, ref len:int(64)):syserr;
 private extern proc qio_get_fs_type(fl:qio_file_ptr_t, ref tp:c_int):syserr;
 
-pragma "no prototype" // FIXME
 private extern proc qio_file_path_for_fd(fd:fd_t, ref path:c_string):syserr;
-pragma "no prototype" // FIXME
 private extern proc qio_file_path_for_fp(fp:_file, ref path:c_string):syserr;
-pragma "no prototype" // FIXME
 private extern proc qio_file_path(f:qio_file_ptr_t, ref path:c_string):syserr;
-pragma "no prototype" // FIXME
 private extern proc qio_shortest_path(fl: qio_file_ptr_t, ref path_out:c_string, path_in:c_string):syserr;
 
 // we don't use qio_channel_read_int/write_int since the code there is pretty
@@ -1006,16 +999,13 @@ private extern proc qio_channel_read_string(threadsafe:c_int, byteorder:c_int, s
 private extern proc qio_channel_write_string(threadsafe:c_int, byteorder:c_int, str_style:int(64), ch:qio_channel_ptr_t, const s:c_string, len:ssize_t):syserr;
 
 private extern proc qio_channel_scan_int(threadsafe:c_int, ch:qio_channel_ptr_t, ref ptr, len:size_t, issigned:c_int):syserr;
-pragma "no prototype" // FIXME
 private extern proc qio_channel_print_int(threadsafe:c_int, ch:qio_channel_ptr_t, const ref ptr, len:size_t, issigned:c_int):syserr;
 
 private extern proc qio_channel_scan_float(threadsafe:c_int, ch:qio_channel_ptr_t, ref ptr, len:size_t):syserr;
-pragma "no prototype" // FIXME
 private extern proc qio_channel_print_float(threadsafe:c_int, ch:qio_channel_ptr_t, const ref ptr, len:size_t):syserr;
 
 // These are the same as scan/print float but they assume an 'i' afterwards.
 private extern proc qio_channel_scan_imag(threadsafe:c_int, ch:qio_channel_ptr_t, ref ptr, len:size_t):syserr;
-pragma "no prototype" // FIXME
 private extern proc qio_channel_print_imag(threadsafe:c_int, ch:qio_channel_ptr_t, const ref ptr, len:size_t):syserr;
 
 

--- a/test/extern/ferguson/sizeof-extern-type/sizeof-extern-type.chpl
+++ b/test/extern/ferguson/sizeof-extern-type/sizeof-extern-type.chpl
@@ -1,6 +1,5 @@
 proc doit() {
 
-  pragma "no prototype"
   extern proc sizeof(type t): size_t;
 
   // We just want to check that this gets code

--- a/test/extern/ferguson/sizeof-extern-type/sizeof-extern-type2.chpl
+++ b/test/extern/ferguson/sizeof-extern-type/sizeof-extern-type2.chpl
@@ -1,6 +1,5 @@
 {
 
-  pragma "no prototype"
   extern proc sizeof(type t): size_t;
 
   // We just want to check that this gets code

--- a/util/config/make_sys_basic_types.py
+++ b/util/config/make_sys_basic_types.py
@@ -210,7 +210,6 @@ def get_sys_c_types(docs=False):
     #
     sys_c_types.append("""
 {
-  pragma "no prototype"
   extern proc sizeof(type t): size_t;
 """)
     for i, max_value in enumerate(max_values):


### PR DESCRIPTION
`FLAG_NO_PROTOTYPE` was added in 84bb02af5c to support the compiler flag
`--gen-extern-prototypes`. That flag was removed in 818b977bf1, so
there's no point in having the pragma anymore.

Closes https://github.com/chapel-lang/chapel/issues/12396.
