### PR TITLE
Add comm=ofi draft documentation.

### DIFF
--- a/doc/rst/platforms/cray.rst
+++ b/doc/rst/platforms/cray.rst
@@ -312,6 +312,8 @@ system rather than the login node's.
 Special Notes for Cray XC, XE, and XK Series Systems
 ----------------------------------------------------
 
+.. _ugni-comm-on-cray:
+
 Native ugni Communication Layer
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/rst/platforms/index.rst
+++ b/doc/rst/platforms/index.rst
@@ -23,6 +23,7 @@ Networks
    :maxdepth: 1
 
    infiniband
+   libfabric
    omnipath
    udp
 

--- a/doc/rst/platforms/infiniband.rst
+++ b/doc/rst/platforms/infiniband.rst
@@ -5,11 +5,8 @@ Using Chapel with InfiniBand
 ============================
 
 This document describes how to run Chapel across multiple machines in an
-InfiniBand cluster using GASNet-based communication.
-:ref:`readme-multilocale` describes general information about running
-Chapel in a multilocale configuration.  The ofi communication layer can
-also be used on InfiniBand-based systems; see :ref:`readme-libfabric`
-for more information.
+InfiniBand cluster.  :ref:`readme-multilocale` describes general
+information about running Chapel in a multilocale configuration.
 
 Avoiding Slow Job Launch
 ++++++++++++++++++++++++

--- a/doc/rst/platforms/infiniband.rst
+++ b/doc/rst/platforms/infiniband.rst
@@ -5,8 +5,11 @@ Using Chapel with InfiniBand
 ============================
 
 This document describes how to run Chapel across multiple machines in an
-InfiniBand cluster. The :ref:`readme-multilocale` describes general
-information about running Chapel in a multilocale configuration.
+InfiniBand cluster using GASNet-based communication.
+:ref:`readme-multilocale` describes general information about running
+Chapel in a multilocale configuration.  The ofi communication layer can
+also be used on InfiniBand-based systems; see :ref:`readme-libfabric`
+for more information.
 
 Avoiding Slow Job Launch
 ++++++++++++++++++++++++

--- a/doc/rst/platforms/libfabric.rst
+++ b/doc/rst/platforms/libfabric.rst
@@ -9,11 +9,12 @@ the OpenFabrics Interfaces libfabric-based ``ofi`` communication layer.
 :ref:`readme-multilocale` gives general information about running Chapel
 in a multilocale configuration.
 
-The ofi communication layer is new as of the Chapel 1.19 release.  It is
-complete in terms of initial development and passes Chapel testing, but
-it is still something of an early-access configuration in the sense that
-users may need to supply supporting packages and performance may leave
-something to be desired.
+.. note::
+  The ofi communication layer is new as of the Chapel 1.19 release.  It is
+  complete in terms of initial development and passes Chapel testing, but
+  it is still something of an early-access configuration in the sense that
+  users may need to supply supporting packages and performance may leave
+  something to be desired.
 
 Building Chapel with the ofi Communication Layer
 ++++++++++++++++++++++++++++++++++++++++++++++++
@@ -79,11 +80,12 @@ Building Chapel with the ofi Communication Layer
    If your system does not have those installed already, you will need
    to download OpenMPI and possibly build it.
 
-   In the future we hope both to be able to support the MPICH MPI
-   package in addition to supporting the OpenMPI MPI package, and to use
-   the regular Chapel ``mpirun`` launcher with the ofi communication
-   layer, but for now OpenMPI and mpirun4ofi are the only options on
-   platforms other than Cray XC systems.
+   .. note::
+     In the future we hope both to be able to support the MPICH MPI
+     package in addition to supporting the OpenMPI MPI package, and to use
+     the regular Chapel ``mpirun`` launcher with the ofi communication
+     layer, but for now OpenMPI and mpirun4ofi are the only options on
+     platforms other than Cray XC systems.
 
    Note: On a Mac OS X system, OpenMPI can be obtained through Homebrew_
    with the following command.
@@ -227,8 +229,9 @@ hugepage modules, and the heap size.  Note, however, that anything there
 about a dynamically sized heap does not apply to the ofi communication
 layer and the libfabric gni provider.
 
-In the future we hope to be able to reduce the user impact of memory
-registration when using the ofi communication layer.
+.. note::
+  In the future we hope to be able to reduce the user impact of memory
+  registration when using the ofi communication layer.
 
 .. _mpirun4ofi-launcher:
 

--- a/doc/rst/platforms/libfabric.rst
+++ b/doc/rst/platforms/libfabric.rst
@@ -1,0 +1,255 @@
+.. _readme-libfabric:
+
+============================
+Using Chapel with libfabric
+============================
+
+This document describes how to run Chapel across multiple machines using
+the OpenFabrics Interfaces libfabric-based ``ofi`` communication layer.
+:ref:`readme-multilocale` gives general information about running Chapel
+in a multilocale configuration.
+
+The ofi communication layer is new as of the Chapel 1.19 release.  It is
+complete in terms of initial development and passes Chapel testing, but
+it is still something of an early-access configuration in the sense that
+users may need to supply supporting packages and performance may leave
+something to be desired.
+
+Building Chapel with the ofi Communication Layer
+++++++++++++++++++++++++++++++++++++++++++++++++
+
+1. Make general, non-communication Chapel configuration settings as
+   described in :ref:`readme-chplenv`.
+
+#. Configure the Chapel runtime to select the ofi communication layer
+
+   .. code-block:: bash
+
+     export CHPL_COMM=ofi
+
+#. Set the variable indicating the path to a libfabric installation.
+   It may be possible to skip this step, if your system has libfabric
+   already installed and your target compiler can find its include and
+   library files itself.  But this is not common, so you will probably
+   need to do:
+
+   .. code-block:: bash
+
+     export LIBFABRIC_DIR=<Place where libfabric is installed>
+
+   The ``<Place where libfabric is installed>`` should be a directory with
+   an ``include/rdma`` subdirectory that contains the libfabric include
+   files and a ``lib`` subdirectory that contains the libfabric library
+   files.  If your system does not have those installed already, you will
+   need to download libfabric and possibly build it.
+
+   Note: On a Mac OS X system, libfabric can be obtained through
+   Homebrew_ with the following command.
+
+   .. code-block:: bash
+
+     brew install libfabric
+
+#. Select a launcher.  On Cray XC systems you can skip this step,
+   because on those systems the automatically-selected ``aprun`` or
+   ``srun`` launcher settings will work with the ofi communication
+   layer.  But on other systems, select the Chapel ``mpirun4ofi``
+   launcher.  For more information see `The mpirun4ofi Launcher`_,
+   below.
+
+
+   .. code-block:: bash
+
+     export CHPL_LAUNCHER=mpirun4ofi
+
+
+#. Having done this, set the variable indicating the path to an OpenMPI
+   installation.  It may be possible to skip this step, if your system
+   has OpenMPI already installed and your target compiler can find its
+   include and library files itself.  But this is not common, so you
+   will probably need to do:
+
+   .. code-block:: bash
+
+     export MPI_DIR=<Place where OpenMPI is installed>
+
+   The ``<Place where OpenMPI is installed>`` should be a directory with
+   an ``include`` subdirectory that contains the OpenMPI include files
+   and a ``lib`` subdirectory that contains the OpenMPI library files.
+   If your system does not have those installed already, you will need
+   to download OpenMPI and possibly build it.
+
+   In the future we hope both to be able to support the MPICH MPI
+   package in addition to supporting the OpenMPI MPI package, and to use
+   the regular Chapel ``mpirun`` launcher with the ofi communication
+   layer, but for now OpenMPI and mpirun4ofi are the only options on
+   platforms other than Cray XC systems.
+
+   Note: On a Mac OS X system, OpenMPI can be obtained through Homebrew_
+   with the following command.
+
+   .. code-block:: bash
+
+     brew install open-mpi
+
+#. Re-make the compiler and runtime from ``CHPL_HOME`` (see
+   :ref:`readme-building`).
+
+   .. code-block:: bash
+
+     cd $CHPL_HOME
+     make
+
+#. Now you are ready to compile and run programs.
+   Compile your Chapel program as usual.
+
+   .. code-block:: bash
+
+     chpl $CHPL_HOME/examples/hello6-taskpar-dist.chpl
+
+#. Optionally set any environment variables necessary during execution
+   (see below) and run, specifying the number of locales on the command
+   line.  For example, this runs the ``hello6-taskpar-dist`` example
+   program on 2 locales:
+
+   .. code-block:: bash
+
+     ./hello6-taskpar-dist -nl 2
+
+
+Execution Environment
++++++++++++++++++++++
+
+Libfabric Providers
+___________________
+
+
+Libfabric defines an abstract network and operations on it, and
+so-called *providers* within libfabric define the concrete instances of
+the network and operations.  The provider used by a program is selected
+at execution time.  The ofi communication layer has been tested with 3
+different providers:
+
+  gni
+    The ``gni`` provider works only on Cray XC systems.  It is built on
+    the Cray native uGNI library and communicates over the Cray
+    proprietary Aries network interface.  This is the default provider
+    on Cray XC systems.  Note that the libfabric gni provider itself is
+    something of a work-in-progress, and Chapel performance using
+    libfabric and gni will probably never match what can be achieved
+    using the native ugni communication layer.
+
+  sockets
+    The ``sockets`` provider works on all platforms.  It is built on
+    POSIX sockets and communicates over any network interface on which
+    the OS can provide sockets support.  This is the default provider on
+    all systems other than Cray XC.  The sockets provider is fully
+    functional, indeed to the extent libfabric has a reference provider
+    the sockets provider is it, but its emphasis is definitely
+    functionality rather than performance.
+
+  verbs
+    The ``verbs`` provider works on any system with verbs-based network
+    hardware (Infiniband, iWarp, etc.).  It is built on the Linux Verbs
+    API.
+
+    (Note for libfabric devotees: when the verbs provider is specified to
+    the ofi communication layer as described below, what is actually
+    used is the ``verbs;ofi_rxm`` provider, which is the verbs provider
+    plus a utility provider which supports reliable datagrams for remote
+    memory access operations.)
+
+The ``CHPL_RT_COMM_OFI_PROVIDER`` environment variable can be set to
+force use of a provider other than the default.  In particular, it can
+force use of the sockets provider on Cray XC systems, or the verbs
+provider on verbs-based systems where the default would otherwise be the
+sockets provider.  For example, the following would force use of the
+verbs provider:
+
+   .. code-block:: bash
+
+     export CHPL_RT_COMM_OFI_PROVIDER=verbs
+
+The Chapel group has done full testing both on a Cray XC system with the
+gni and sockets providers, and on an InfiniBand-based system with the
+sockets and verbs providers.  Some additional testing has been done with
+the sockets provider on a MacBook running Mac OS X.  All of these
+configurations are expected to work.  Provider settings we have not
+tested with the ofi communication layer may lead to internal errors.
+Settings which are at odds with the available networks, such as
+specifying the gni provider on a vanilla Linux cluster, will definitely
+lead to internal errors.
+
+As the ofi communication layer evolves toward completion we expect to
+move from the current name-based technique for selecting the provider to
+a more capability-based one.  Users will probably still be able to force
+use of a particular provider by naming it, but the need to do so for
+other than curiosity's (or performance comparison's) sake should be
+reduced.
+
+The gni Provider, Memory Registration, and the Heap
+___________________________________________________
+
+(Before you get any further into this section, you should probably
+re-read the note above about performance being better with the native
+ugni communication layer than with the ofi communication layer and gni
+provider.)
+
+Network technologies sometimes require *memory registration*, meaning
+that ranges of memory which will be the source or target of
+communication operations must be made known to the network before any
+such operations can occur.  When the ofi communication layer is used
+with the gni provider, memory has to be registered.  This has certain
+implications for users, the most notable being that the heap must have a
+fixed size.
+
+The *heap* is an area of memory used for dynamic allocation of
+everything from user data to task stacks to internal management data
+structures.  When memory must be registered, the ofi communication layer
+needs to know the maximum size the heap will grow to during execution.
+The default heap size is 16 GiB, but you can change this by setting the
+``CHPL_RT_MAX_HEAP_SIZE`` environment variable.  Set it to a positive
+number for the desired heap size in bytes optionally followed by ``k``
+or ``K`` for KiB, ``m`` or ``M`` for MiB, ``g`` or ``G`` for GiB, or to
+a positive integer followed by ``%`` to indicate a percentage of the
+node real memory.  Either ``CHPL_RT_MAX_HEAP_SIZE=12g`` or ``=20%``
+specifies roughly a 12 GiB heap on a 64 GiB compute node, for example.
+
+We have not yet quantified the effects, but performance with the gni
+provider may be improved if you have a ``craype-hugepages`` module
+loaded both when you build your program and when you run it.  For
+example::
+
+     module load craype-hugepages16M
+
+See :ref:`ugni-comm-on-cray` for more discussion about hugepages,
+hugepage modules, and the heap size.  Note, however, that anything there
+about a dynamically sized heap does not apply to the ofi communication
+layer and the libfabric gni provider.
+
+In the future we hope to be able to reduce the user impact of memory
+registration when using the ofi communication layer.
+
+.. _mpirun4ofi-launcher:
+
+The mpirun4ofi Launcher
+_______________________
+
+Programs built with the ofi communication layer on Cray XC systems can
+use the existing launchers.  On other systems, for now they must use the
+``mpirun4ofi`` launcher, which is a provisional, thin wrapper around
+OpenMPI ``mpirun``.
+
+The mpirun4ofi launcher can run libfabric-based Chapel programs either
+with or without slurm.  Outside of a slurm job, it will run all of the
+per-locale Chapel program instances directly on the launch node.  In
+this situation you should be sure to follow the guidance in
+:ref:`overloading-with-qthreads` if you are using Qthreads-based tasking.
+Within a slurm job, the mpirun4ofi launcher will arrange for the
+per-locale Chapel program instances to be distributed in a cyclic manner
+across the nodes assigned to the job.  Overloading can still be an issue
+if there are more Chapel locales (program instances) than nodes in the
+slurm job, however.
+
+
+.. _Homebrew: https://github.com/Homebrew/brew

--- a/doc/rst/users-guide/locality/compilingAndExecutingMultiLocalePrograms.rst
+++ b/doc/rst/users-guide/locality/compilingAndExecutingMultiLocalePrograms.rst
@@ -19,6 +19,11 @@ options for communication include:
 * ``gasnet``: specifies that communication should be implemented using
   the open-source GASNet library developed at Berkeley.
 
+* ``ofi``: specifies that communication should be implemented using
+  the open-source libfabric library component of OpenFabrics Interfaces
+  (OFI).   This configuration is preliminary; see :ref:`readme-libfabric` for
+  more information.
+
 When using the Chapel module on Cray systems, a third option is also
 available:
 

--- a/doc/rst/usingchapel/chplenv.rst
+++ b/doc/rst/usingchapel/chplenv.rst
@@ -403,11 +403,10 @@ CHPL_COMM
    If unset, ``CHPL_COMM`` defaults to ``none`` in most cases.  On Cray XE
    and XC systems it defaults to ``ugni``.  On Cray CS systems it defaults
    to ``gasnet``.  See :ref:`readme-multilocale` for more information on
-   executing Chapel programs using multiple locales.
-   See :ref:`readme-libfabric` for more information about the ofi
-   communication layer.
-   See :ref:`readme-cray` for more information about Cray-specific runtime
-   layers.
+   executing Chapel programs using multiple locales.  See
+   :ref:`readme-libfabric` for more information about the ofi communication
+   layer.  See :ref:`readme-cray` for more information about Cray-specific
+   runtime layers.
 
 
 .. _readme-chplenv.CHPL_MEM:
@@ -429,11 +428,10 @@ CHPL_MEM
 
    .. note::
      Certain ``CHPL_COMM`` settings (e.g. ugni, gasnet segment fast/large,
-     ofi with the gni provider)
-     register the heap to improve communication performance.  Registering the
-     heap requires special allocator support that not all allocators provide.
-     Currently only ``jemalloc`` is capable of supporting configurations that
-     require a registered heap.
+     ofi with the gni provider) register the heap to improve communication
+     performance.  Registering the heap requires special allocator support
+     that not all allocators provide.  Currently only ``jemalloc`` is capable
+     of supporting configurations that require a registered heap.
 
 
 .. _readme-chplenv.CHPL_LAUNCHER:

--- a/doc/rst/usingchapel/chplenv.rst
+++ b/doc/rst/usingchapel/chplenv.rst
@@ -281,7 +281,7 @@ CHPL_TARGET_CPU
           will occur.
 
         * If :ref:`readme-chplenv.CHPL_COMM` is set, no attempt to set a useful value will be
-          made, ``CHPL_TARGET_CPU`` will be ``unknown``.
+          made and ``CHPL_TARGET_CPU`` will be ``unknown``.
 
         * If :ref:`readme-chplenv.CHPL_TARGET_PLATFORM` is ``darwin``, ``linux*``, or
           ``cygwin*`` ``CHPL_TARGET_CPU`` will be ``native``, passing the
@@ -396,14 +396,18 @@ CHPL_COMM
         ======= ============================================
         none    only supports single-locale execution
         gasnet  use the GASNet-based communication layer
+        ofi     use the (preliminary) libfabric-based communication layer
         ugni    Cray-specific native communication layer
         ======= ============================================
 
    If unset, ``CHPL_COMM`` defaults to ``none`` in most cases.  On Cray XE
    and XC systems it defaults to ``ugni``.  On Cray CS systems it defaults
    to ``gasnet``.  See :ref:`readme-multilocale` for more information on
-   executing Chapel programs using multiple locales.  See :ref:`readme-cray`
-   for more information about Cray-specific runtime layers.
+   executing Chapel programs using multiple locales.
+   See :ref:`readme-libfabric` for more information about the ofi
+   communication layer.
+   See :ref:`readme-cray` for more information about Cray-specific runtime
+   layers.
 
 
 .. _readme-chplenv.CHPL_MEM:
@@ -424,7 +428,8 @@ CHPL_MEM
    If the target platform is ``cygwin*`` it defaults to ``cstdlib``
 
    .. note::
-     Certain ``CHPL_COMM`` settings (e.g. ugni and gasnet segment fast/large)
+     Certain ``CHPL_COMM`` settings (e.g. ugni, gasnet segment fast/large,
+     ofi with the gni provider)
      register the heap to improve communication performance.  Registering the
      heap requires special allocator support that not all allocators provide.
      Currently only ``jemalloc`` is capable of supporting configurations that

--- a/doc/rst/usingchapel/launcher.rst
+++ b/doc/rst/usingchapel/launcher.rst
@@ -51,6 +51,7 @@ amudprun             GASNet launcher for programs running over UDP
 aprun                Cray application launcher using aprun                
 gasnetrun_ibv        GASNet launcher for programs running over Infiniband 
 gasnetrun_mpi        GASNet launcher for programs using the MPI conduit   
+mpirun4ofi           provisional launcher for ``CHPL_COMM=ofi`` on non-Cray X* systems
 pbs-aprun            Cray application launcher using PBS (qsub) + aprun   
 pbs-gasnetrun_ibv    GASNet launcher using PBS (qsub) over Infiniband     
 slurm-gasnetrun_ibv  GASNet launcher using SLURM over Infiniband          
@@ -60,7 +61,11 @@ none                 do not use a launcher
 ===================  ====================================================
 
 A specific launcher can be explicitly requested by setting the
-``CHPL_LAUNCHER`` environment variable. If left unset, a default is picked as
+``CHPL_LAUNCHER`` environment variable.
+For the specific case of the ``mpirun4ofi`` launcher,
+please see :ref:`readme-libfabric`.
+
+``CHPL_LAUNCHER`` is left unset, a default is picked as
 follows:
 
 
@@ -117,7 +122,8 @@ To use native Slurm, set:
 On Cray systems, this will happen automatically if srun is found in your
 path, but not when both srun and aprun are found in your path. Native
 Slurm is the best option where it works, but at the time of this writing,
-there are problems with it when combined with UDP or InfiniBand conduits.
+there are problems with it when combined with ``CHPL_COMM=gasnet`` and the
+UDP or InfiniBand conduits.
 So, for these configurations please see:
 
   * :ref:`readme-infiniband` for information about using Slurm with

--- a/doc/rst/usingchapel/multilocale.rst
+++ b/doc/rst/usingchapel/multilocale.rst
@@ -4,7 +4,15 @@
 Multilocale Chapel Execution
 ============================
 
-This document outlines the steps to get started with multi-locale Chapel.
+This document outlines the steps to get started with multilocale Chapel using
+GASNet-based communication.  This configuration is fully functional on every
+platform that supports multilocale Chapel.  However, there are also other
+communication configurations that work in specific situations.  On Cray
+XC/XE/XK systems, using native communication as described in :ref:`Using
+Chapel on Cray Systems <readme-cray>` will probably give the best performance.
+For instructions on using the preliminary OpenFabrics Interfaces
+libfabric-based ``ofi`` communication layer, see :ref:`readme-libfabric`.
+
 Steps 2-3 describe how to build a multilocale Chapel, and steps 4-6 cover
 compiling and running multilocale Chapel programs.
 

--- a/doc/rst/usingchapel/tasks.rst
+++ b/doc/rst/usingchapel/tasks.rst
@@ -163,6 +163,8 @@ is set to anything larger than the number of cores, so it usually isn't
 necessary to set ``QT_WORKER_UNIT``.
 
 
+.. _overloading-with-qthreads:
+
 Overloading system nodes
 ========================
 
@@ -172,6 +174,7 @@ its process is not competing with anything else for system resources
 its internal behavior to favor performance over load balancing.  This
 works out well for Chapel programs, because normally Chapel runs with
 one process (locale) per system node.  However, with ``CHPL_COMM=gasnet``
+or ``CHPL_COMM=ofi``
 one can run multiple Chapel locales on a single system node, say for
 doing multilocale functional correctness testing with limited system
 resources.  (See :ref:`readme-multilocale` for more details.)  When this is


### PR DESCRIPTION
This a first cut at documentation changes for the libfabric-based
ofi communication layer.