### PR TITLE
Update whitebox gcc gen compiler version to 7.3.0.

### DIFF
--- a/util/cron/common-whitebox.bash
+++ b/util/cron/common-whitebox.bash
@@ -92,7 +92,7 @@ if [ "${COMPILER}" != "gnu" ] ; then
     ### TEMPORARY
     # Restore the following line when we can.
     # module load gcc/${CHPL_GCC_TARGET_VERSION}
-    # For now, we need to force it to gcc 6.3.0 so its libraries will
+    # For now, we need to force it to gcc 7.3.0 so its libraries will
     # link with earlier versions of the Intel compiler.
     module load gcc/7.3.0
 fi

--- a/util/cron/common-whitebox.bash
+++ b/util/cron/common-whitebox.bash
@@ -94,7 +94,7 @@ if [ "${COMPILER}" != "gnu" ] ; then
     # module load gcc/${CHPL_GCC_TARGET_VERSION}
     # For now, we need to force it to gcc 6.3.0 so its libraries will
     # link with earlier versions of the Intel compiler.
-    module load gcc/6.3.0
+    module load gcc/7.3.0
 fi
 
 # quiet libu warning about cpuid detection failure


### PR DESCRIPTION
This is to match the gcc gen compiler we updated to for the
cray-xc_x86-64 and cray-xe module builds.