### PR TITLE
Close a user-level leak in this test

### DIFF
--- a/test/functions/iterators/recursive/recursive-iter-works.chpl
+++ b/test/functions/iterators/recursive/recursive-iter-works.chpl
@@ -1,7 +1,7 @@
 class Tree {
   var data: int;
-  var left: unmanaged Tree;
-  var right: unmanaged Tree;
+  var left: owned Tree;
+  var right: owned Tree;
   
   iter these(): int {
     if left then
@@ -12,7 +12,7 @@ class Tree {
   }
 }
 
-var tree = new unmanaged Tree(40, new unmanaged Tree(20, new unmanaged Tree(10), new unmanaged Tree(30)), new unmanaged Tree(60, new unmanaged Tree(50), new unmanaged Tree(70)));
+var tree = new owned Tree(40, new owned Tree(20, new owned Tree(10), new owned Tree(30)), new owned Tree(60, new owned Tree(50), new owned Tree(70)));
 
 for e in tree do
   writeln(e);


### PR DESCRIPTION
Happened to stumble across this case while looking through
current memory leak logs.  Converting from `unmanaged` to
`owned` closes the leak while seemingly preserving the original
intention of the test.