### PR TITLE
Fix LLVM optimizer specialization on Cray systems

### DIFF
--- a/util/chplenv/chpl_cpu.py
+++ b/util/chplenv/chpl_cpu.py
@@ -506,7 +506,7 @@ def adjust_cpu_for_compiler(cpu, flag, get_lcd):
     compiler_val = chpl_compiler.get(flag)
     platform_val = chpl_platform.get(flag)
 
-    isprgenv = flag == 'target' and target_compiler_is_prgenv()
+    isprgenv = flag == 'target' and target_compiler_is_prgenv(False)
 
     if isprgenv:
         cray_cpu = os.environ.get('CRAY_CPU_TARGET', 'none')
@@ -587,7 +587,7 @@ def verify_cpu(cpu, flag):
     check_cpu = False
     if flag == 'target':
         if comm_val == 'none':
-            if not target_compiler_is_prgenv():
+            if not target_compiler_is_prgenv(False):
                 if ('linux' in platform_val or
                      platform_val == 'darwin' or
                      platform_val.startswith('cygwin')):
@@ -659,7 +659,7 @@ def get(flag, map_to_compiler=False, get_lcd=False):
     verify_cpu(cpu, flag)
 
     compiler_val = chpl_compiler.get(flag)
-    isprgenv = flag == 'target' and target_compiler_is_prgenv()
+    isprgenv = flag == 'target' and target_compiler_is_prgenv(False)
     if map_to_compiler and not isprgenv:
         # Map cpu to compiler argument
         # Don't do this for PrgEnv compiles since the compiler driver

--- a/util/chplenv/chpl_cpu.py
+++ b/util/chplenv/chpl_cpu.py
@@ -506,7 +506,7 @@ def adjust_cpu_for_compiler(cpu, flag, get_lcd):
     compiler_val = chpl_compiler.get(flag)
     platform_val = chpl_platform.get(flag)
 
-    isprgenv = flag == 'target' and target_compiler_is_prgenv(False)
+    isprgenv = flag == 'target' and target_compiler_is_prgenv()
 
     if isprgenv:
         cray_cpu = os.environ.get('CRAY_CPU_TARGET', 'none')
@@ -587,7 +587,7 @@ def verify_cpu(cpu, flag):
     check_cpu = False
     if flag == 'target':
         if comm_val == 'none':
-            if not target_compiler_is_prgenv(False):
+            if not target_compiler_is_prgenv():
                 if ('linux' in platform_val or
                      platform_val == 'darwin' or
                      platform_val.startswith('cygwin')):
@@ -659,7 +659,7 @@ def get(flag, map_to_compiler=False, get_lcd=False):
     verify_cpu(cpu, flag)
 
     compiler_val = chpl_compiler.get(flag)
-    isprgenv = flag == 'target' and target_compiler_is_prgenv(False)
+    isprgenv = flag == 'target' and target_compiler_is_prgenv(not map_to_compiler)
     if map_to_compiler and not isprgenv:
         # Map cpu to compiler argument
         # Don't do this for PrgEnv compiles since the compiler driver

--- a/util/chplenv/compiler_utils.py
+++ b/util/chplenv/compiler_utils.py
@@ -64,12 +64,13 @@ def compiler_is_prgenv(compiler_val):
 
 
 @memoize
-def target_compiler_is_prgenv():
+def target_compiler_is_prgenv(bypass_llvm=True):
     compiler_val = chpl_compiler.get('target')
 
     # But for --llvm, look at the original target compiler
-    if compiler_val == 'clang-included':
-        compiler_val = chpl_compiler.get('target', llvm_mode="orig")
+    if bypass_llvm:
+        if compiler_val == 'clang-included':
+            compiler_val = chpl_compiler.get('target', llvm_mode="orig")
 
     isprgenv = compiler_is_prgenv(compiler_val)
     return isprgenv


### PR DESCRIPTION
The Clang CPU flag was not being computed correctly when a PrgEnv module was present.  Sometimes the PrgEnv name for a CPU is identical to the Clang CPU name, which is why this was not detected earlier.  This change computes the Clang CPU name when Clang specialization is being done, and retains the PrgEnv CPU name otherwise.