### PR TITLE
Close user leaks in linked list tests

### DIFF
--- a/test/types/type_variables/deitz/part2/test_typevar_record3.chpl
+++ b/test/types/type_variables/deitz/part2/test_typevar_record3.chpl
@@ -24,6 +24,17 @@ record foo {
     length += 1;
     return this;
   }
+
+  proc cleanup() {
+    var cursor: unmanaged node(t);
+    var next: unmanaged node(t);
+    cursor = first;
+    while (cursor != nil) {
+      next = cursor.next;
+      delete cursor;
+      cursor = next;
+    }
+  }
 }
 
 proc foo.writeThis(fp) {
@@ -45,3 +56,5 @@ f.append(1);
 f.append(2);
 
 writeln(f);
+
+f.cleanup();

--- a/test/types/type_variables/deitz/part2/test_typevar_record4.chpl
+++ b/test/types/type_variables/deitz/part2/test_typevar_record4.chpl
@@ -37,6 +37,17 @@ record foo {
     length += 1;
     return this;
   }
+
+  proc cleanup() {
+    var cursor: unmanaged node(t);
+    var next: unmanaged node(t);
+    cursor = first;
+    while (cursor != nil) {
+      next = cursor.next;
+      delete cursor;
+      cursor = next;
+    }
+  }
 }
 
 proc foo.writeThis(fp) {
@@ -60,3 +71,5 @@ f.prepend(3);
 f.prepend(4);
 
 writeln(f);
+
+f.cleanup();

--- a/test/types/type_variables/deitz/part2/test_typevar_record5.chpl
+++ b/test/types/type_variables/deitz/part2/test_typevar_record5.chpl
@@ -23,6 +23,17 @@ record foo {
     length += 1;
     return this;
   }
+
+  proc cleanup() {
+    var cursor: unmanaged node(t);
+    var next: unmanaged node(t);
+    cursor = first;
+    while (cursor != nil) {
+      next = cursor.next;
+      delete cursor;
+      cursor = next;
+    }
+  }
 }
 
 proc foo.writeThis(fp) {
@@ -51,3 +62,6 @@ g.append("one");
 g.append("two");
 
 writeln(g);
+
+g.cleanup();
+f.cleanup();

--- a/test/types/type_variables/deitz/part2/test_typevar_record6.chpl
+++ b/test/types/type_variables/deitz/part2/test_typevar_record6.chpl
@@ -39,6 +39,17 @@ record foo {
 
     return anew;
   }
+
+  proc cleanup() {
+    var cursor: unmanaged node(t);
+    var next: unmanaged node(t);
+    cursor = first;
+    while (cursor != nil) {
+      next = cursor.next;
+      delete cursor;
+      cursor = next;
+    }
+  }
 }
 
 proc foo.writeThis(fp) {
@@ -66,6 +77,9 @@ f.append(2);
 
 writeln(f);
 
-f.copy();
+var f2 = f.copy();
 
 writeln(f);
+
+f2.cleanup();
+f.cleanup();


### PR DESCRIPTION
These linked list tests were leaking memory; have them clean up after themselves.
