### PR TITLE
Improve warning for `throw new SomeError()`

### DIFF
--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -231,6 +231,8 @@ void checkForStoringIntoTuple(CallExpr* call, FnSymbol* resolvedFn);
 
 bool signatureMatch(FnSymbol* fn, FnSymbol* gn);
 
+bool isSubTypeOrInstantiation(Type* sub, Type* super);
+
 void printTaskOrForallConstErrorNote(Symbol* aVar);
 
 // tuples

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -906,6 +906,7 @@ static Expr* handleUnstableClassType(SymExpr* se) {
           } else if (outerOuterCall &&
                      outerOuterCall->isPrimitive(PRIM_THROW)) {
             // throw new Error()
+            USR_WARN(outerOuterCall, "throw new SomeError is unstable");
             ok = true;
           } else if (outerCall && outerCall->isPrimitive(PRIM_NEW) &&
                      pCall == outerCall->get(1)) {

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5874,9 +5874,14 @@ static bool isUndecoratedClassNew(CallExpr* newExpr, Type* newType) {
         } else if (CallExpr* parentCall = toCallExpr(se->parentExpr)) {
           if (parentCall->isNamed("chpl__tounmanaged") || // TODO -- remove case
               parentCall->isNamed("chpl__delete") || // TODO -- remove case
-              parentCall->isNamed("chpl__buildDistValue") ||
-              parentCall->isNamed("chpl_fix_thrown_error")) {
+              parentCall->isNamed("chpl__buildDistValue")) {
             // OK
+          } else if (parentCall->isNamed("chpl_fix_thrown_error")) {
+            // OK, but warn for throw new SomeError()
+            USR_WARN(parentCall,
+                     "please use 'throw new owned %s' "
+                     "instead of 'throw new %s'",
+                     newType->symbol->name, newType->symbol->name);
           } else if (parentCall->isPrimitive(PRIM_NEW) &&
                      parentCall->get(1)->typeInfo()->symbol->hasFlag(FLAG_MANAGED_POINTER)) {
             // OK e.g. new Owned(new MyClass())

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5790,7 +5790,6 @@ static void resolveNewSetupManaged(CallExpr* newExpr, Type*& manager) {
         }
       }
 
-
       // if manager is set, and we're not calling the manager's init function,
       // use the canonical class type instead of the managed type, since
       // the rest of the compiler (e.g. initializer resolution) uses
@@ -5900,7 +5899,7 @@ static bool isUndecoratedClassNew(CallExpr* newExpr, Type* newType) {
 
 static void warnForThrowNotOwned(CallExpr* newExpr, Type* newType, Type* manager) {
   // This function implements a warning that should be removed in 1.20
-  // in favor e.g. calling compilerError in chpl_fix_thrown_error.
+  // in favor of e.g. calling compilerError in chpl_fix_thrown_error.
   INT_ASSERT(newExpr->parentSymbol);
   Type* cType = canonicalClassType(newType);
 
@@ -5938,16 +5937,16 @@ static void warnForThrowNotOwned(CallExpr* newExpr, Type* newType, Type* manager
           if (parentCall->isNamed("chpl_fix_thrown_error")) {
             if (undecorated)
               USR_WARN(parentCall,
-                       "please use 'throw new owned %s "
+                       "please use 'throw new owned %s' "
                        "instead of 'throw new %s'",
                        cType->symbol->name, cType->symbol->name);
             else if (unmanaged)
               USR_WARN(parentCall,
-                       "please throw owned %s instead of unmanaged %s",
+                       "please throw 'owned %s' instead of 'unmanaged %s'",
                        cType->symbol->name, cType->symbol->name);
             else if (borrowed)
               USR_FATAL(parentCall,
-                       "please throw owned %s instead borrowed %s",
+                       "please throw 'owned %s' instead of 'borrowed %s'",
                        cType->symbol->name, cType->symbol->name);
             else
               USR_FATAL(parentCall, "only owned Errors can be thrown");

--- a/compiler/resolution/postFold.cpp
+++ b/compiler/resolution/postFold.cpp
@@ -183,8 +183,6 @@ static Expr* postFoldNormal(CallExpr* call) {
 *                                                                             *
 ************************************** | *************************************/
 
-static bool  isSubTypeOrInstantiation(Type* sub, Type* super);
-
 static void  insertValueTemp(Expr* insertPoint, Expr* actual);
 
 static Expr* postFoldPrimop(CallExpr* call) {
@@ -499,7 +497,7 @@ static Expr* postFoldPrimop(CallExpr* call) {
 }
 
 // This function implements PRIM_IS_SUBTYPE
-static bool isSubTypeOrInstantiation(Type* sub, Type* super) {
+bool isSubTypeOrInstantiation(Type* sub, Type* super) {
 
   // Consider instantiation
   if (super->symbol->hasFlag(FLAG_GENERIC))

--- a/modules/internal/ChapelError.chpl
+++ b/modules/internal/ChapelError.chpl
@@ -361,7 +361,6 @@ module ChapelError {
   pragma "no doc"
   pragma "insert line file info"
   pragma "always propagate line file info"
-  // TODO -- deprecate this version
   proc chpl_fix_thrown_error(err: borrowed Error): unmanaged Error {
     compilerError("Throwing borrowed error - please throw owned", 1);
 
@@ -395,7 +394,9 @@ module ChapelError {
   pragma "insert line file info"
   pragma "always propagate line file info"
   proc chpl_fix_thrown_error(err: unmanaged Error): unmanaged Error {
-    compilerWarning("Throwing unmanaged error - please throw owned", 1);
+    // TODO: This should be an error in the future,
+    // for now the compiler already adds a warning in this case.
+    //compilerWarning("Throwing unmanaged error - please throw owned", 1);
 
     return chpl_do_fix_thrown_error(err);
   }

--- a/test/deprecated/throw-borrowed.good
+++ b/test/deprecated/throw-borrowed.good
@@ -1,5 +1,5 @@
 throw-borrowed.chpl:8: In function 'test':
-throw-borrowed.chpl:9: warning: please use 'throw new owned Error instead of 'throw new Error'
+throw-borrowed.chpl:9: warning: please use 'throw new owned Error' instead of 'throw new Error'
 uncaught Error: 
   throw-borrowed.chpl:9: thrown here
   throw-borrowed.chpl:12: uncaught here

--- a/test/deprecated/throw-borrowed.good
+++ b/test/deprecated/throw-borrowed.good
@@ -1,6 +1,5 @@
 throw-borrowed.chpl:8: In function 'test':
-throw-borrowed.chpl:9: warning: please use 'throw new owned Error' instead of 'throw new Error'
-throw-borrowed.chpl:9: warning: Throwing unmanaged error - please throw owned
+throw-borrowed.chpl:9: warning: please use 'throw new owned Error instead of 'throw new Error'
 uncaught Error: 
   throw-borrowed.chpl:9: thrown here
   throw-borrowed.chpl:12: uncaught here

--- a/test/deprecated/throw-borrowed.good
+++ b/test/deprecated/throw-borrowed.good
@@ -1,4 +1,5 @@
 throw-borrowed.chpl:8: In function 'test':
+throw-borrowed.chpl:9: warning: please use 'throw new owned Error' instead of 'throw new Error'
 throw-borrowed.chpl:9: warning: Throwing unmanaged error - please throw owned
 uncaught Error: 
   throw-borrowed.chpl:9: thrown here

--- a/test/errhandling/ferguson/throw-new-borrowed.good
+++ b/test/errhandling/ferguson/throw-new-borrowed.good
@@ -1,2 +1,2 @@
 throw-new-borrowed.chpl:1: In function 'main':
-throw-new-borrowed.chpl:2: error: please throw owned Error instead borrowed Error
+throw-new-borrowed.chpl:2: error: please throw 'owned Error' instead of 'borrowed Error'

--- a/test/errhandling/ferguson/throw-new-borrowed.good
+++ b/test/errhandling/ferguson/throw-new-borrowed.good
@@ -1,2 +1,2 @@
 throw-new-borrowed.chpl:1: In function 'main':
-throw-new-borrowed.chpl:2: error: Throwing borrowed error - please throw owned
+throw-new-borrowed.chpl:2: error: please throw owned Error instead borrowed Error

--- a/test/errhandling/ferguson/throw-new-undecorated.good
+++ b/test/errhandling/ferguson/throw-new-undecorated.good
@@ -1,5 +1,5 @@
 throw-new-undecorated.chpl:1: In function 'main':
-throw-new-undecorated.chpl:2: warning: please use 'throw new owned Error instead of 'throw new Error'
+throw-new-undecorated.chpl:2: warning: please use 'throw new owned Error' instead of 'throw new Error'
 uncaught Error: 
   throw-new-undecorated.chpl:2: thrown here
   throw-new-undecorated.chpl:1: uncaught here

--- a/test/errhandling/ferguson/throw-new-undecorated.good
+++ b/test/errhandling/ferguson/throw-new-undecorated.good
@@ -1,4 +1,5 @@
 throw-new-undecorated.chpl:1: In function 'main':
+throw-new-undecorated.chpl:2: warning: please use 'throw new owned Error' instead of 'throw new Error'
 throw-new-undecorated.chpl:2: warning: Throwing unmanaged error - please throw owned
 uncaught Error: 
   throw-new-undecorated.chpl:2: thrown here

--- a/test/errhandling/ferguson/throw-new-undecorated.good
+++ b/test/errhandling/ferguson/throw-new-undecorated.good
@@ -1,6 +1,5 @@
 throw-new-undecorated.chpl:1: In function 'main':
-throw-new-undecorated.chpl:2: warning: please use 'throw new owned Error' instead of 'throw new Error'
-throw-new-undecorated.chpl:2: warning: Throwing unmanaged error - please throw owned
+throw-new-undecorated.chpl:2: warning: please use 'throw new owned Error instead of 'throw new Error'
 uncaught Error: 
   throw-new-undecorated.chpl:2: thrown here
   throw-new-undecorated.chpl:1: uncaught here

--- a/test/errhandling/ferguson/throw-shared.chpl
+++ b/test/errhandling/ferguson/throw-shared.chpl
@@ -1,0 +1,6 @@
+proc foo() throws {
+  // Error
+  throw new shared IllegalArgumentError("Error message.");
+}
+
+foo();

--- a/test/errhandling/ferguson/throw-shared.good
+++ b/test/errhandling/ferguson/throw-shared.good
@@ -1,0 +1,2 @@
+throw-shared.chpl:1: In function 'foo':
+throw-shared.chpl:3: error: only owned Errors can be thrown

--- a/test/errhandling/ferguson/throw-unmanaged.chpl
+++ b/test/errhandling/ferguson/throw-unmanaged.chpl
@@ -1,0 +1,6 @@
+proc foo() throws {
+  // Warning
+  throw new unmanaged IllegalArgumentError("Error message.");
+}
+
+foo();

--- a/test/errhandling/ferguson/throw-unmanaged.good
+++ b/test/errhandling/ferguson/throw-unmanaged.good
@@ -1,5 +1,5 @@
 throw-unmanaged.chpl:1: In function 'foo':
-throw-unmanaged.chpl:3: warning: please throw owned IllegalArgumentError instead of unmanaged IllegalArgumentError
+throw-unmanaged.chpl:3: warning: please throw 'owned IllegalArgumentError' instead of 'unmanaged IllegalArgumentError'
 uncaught IllegalArgumentError: Error message.
   throw-unmanaged.chpl:3: thrown here
   throw-unmanaged.chpl:6: uncaught here

--- a/test/errhandling/ferguson/throw-unmanaged.good
+++ b/test/errhandling/ferguson/throw-unmanaged.good
@@ -1,0 +1,5 @@
+throw-unmanaged.chpl:1: In function 'foo':
+throw-unmanaged.chpl:3: warning: please throw owned IllegalArgumentError instead of unmanaged IllegalArgumentError
+uncaught IllegalArgumentError: Error message.
+  throw-unmanaged.chpl:3: thrown here
+  throw-unmanaged.chpl:6: uncaught here


### PR DESCRIPTION
Resolves #12529.

Improves the error for `throw new SomeError()` from e.g.
```
foo.chpl:3: warning: Throwing unmanaged error - please throw owned
```

to

```
foo.chpl:3: warning: please use 'throw new owned IllegalArgumentError instead of 'throw new IllegalArgumentError'
```

Additionally adds testing for various invalid cases of `throw`.

- [x] full local testing

Reviewed by @lydia-duncan - thanks!