### PR TITLE
Increment Mason 0.1.0 -> 0.1.1

### DIFF
--- a/tools/mason/mason.chpl
+++ b/tools/mason/mason.chpl
@@ -154,5 +154,5 @@ proc masonDoc(args) {
 }
 
 proc printVersion() {
-  writeln('mason 0.1.0');
+  writeln('mason 0.1.1');
 }


### PR DESCRIPTION
The mason interface with packages has not changed in this release, so we are incrementing the bugfix-version as designated by semantic versioning.