### PR TITLE
Fix linux64 issue for mason search badFileName testing

### DIFF
--- a/test/mason/search/badFileName/PREDIFF
+++ b/test/mason/search/badFileName/PREDIFF
@@ -1,0 +1,3 @@
+#!/bin/sh
+sort $2 > $2.prediff.tmp
+mv $2.prediff.tmp $2

--- a/test/mason/search/badFileName/mason-search.chpl
+++ b/test/mason/search/badFileName/mason-search.chpl
@@ -1,14 +1,8 @@
-
 use MasonSearch;
 
 use FileSystem;
 
-config const pattern = "";
-
 proc main() {
   var args: [0..2] string = ["foo", "search", "--no-update"];
-  if pattern != "" then args.push_back(pattern);
-
-
   masonSearch(args);
 }

--- a/test/mason/search/badFileName/mason-search.good
+++ b/test/mason/search/badFileName/mason-search.good
@@ -1,7 +1,7 @@
-badFileName (1.0.0)
-$CHPL_HOME/tools/mason//MasonSearch.chpl:102: warning: File without '.toml' extension encountered - skipping badFileName2 1.0.0
-$CHPL_HOME/tools/mason//MasonSearch.chpl:102: warning: File without '.toml' extension encountered - skipping badFileName2 2.0.0
+$CHPL_HOME/tools/mason//MasonSearch.chpl:102: warning: File without '.toml' extension encountered - skipping badFileName 0.5.0
+$CHPL_HOME/tools/mason//MasonSearch.chpl:102: warning: File without '.toml' extension encountered - skipping badFileName 2.0.0
 $CHPL_HOME/tools/mason//MasonSearch.chpl:102: warning: File without '.toml' extension encountered - skipping badFileName2 0.1.0
 $CHPL_HOME/tools/mason//MasonSearch.chpl:102: warning: File without '.toml' extension encountered - skipping badFileName2 0.5.0
-$CHPL_HOME/tools/mason//MasonSearch.chpl:102: warning: File without '.toml' extension encountered - skipping badFileName 2.0.0
-$CHPL_HOME/tools/mason//MasonSearch.chpl:102: warning: File without '.toml' extension encountered - skipping badFileName 0.5.0
+$CHPL_HOME/tools/mason//MasonSearch.chpl:102: warning: File without '.toml' extension encountered - skipping badFileName2 1.0.0
+$CHPL_HOME/tools/mason//MasonSearch.chpl:102: warning: File without '.toml' extension encountered - skipping badFileName2 2.0.0
+badFileName (1.0.0)


### PR DESCRIPTION
 `listDir()` can result in a different output order for OS X vs linux64. We need to sort the output of this `mason search` test, since it prints a warning as it encounters each file with a bad name.