### PR TITLE
Adjust cullOverReferences to understand PRIM_SET_MEMBER

### DIFF
--- a/compiler/resolution/cullOverReferences.cpp
+++ b/compiler/resolution/cullOverReferences.cpp
@@ -847,7 +847,7 @@ void cullOverReferences() {
                 /*
                 printf("print working on node %i %i\n",
                        node.variable->id, node.fieldIndex);
-                
+
                 printf("for iterator %i\n", iterator->id);
                 */
 
@@ -1473,7 +1473,7 @@ void lowerContextCall(ContextCallExpr* cc, choose_type_t which)
     INT_ASSERT(constRefCall != NULL);
   if (which == USE_VALUE)
     INT_ASSERT(valueCall != NULL);
-  
+
   CallExpr* someCall = refCall;
   if (someCall == NULL) someCall = constRefCall;
   if (someCall == NULL) someCall = valueCall;

--- a/test/functions/ferguson/ref-pair/tuples/bug-12282-simpler.chpl
+++ b/test/functions/ferguson/ref-pair/tuples/bug-12282-simpler.chpl
@@ -1,0 +1,15 @@
+record R1 {
+  var x: int;
+}
+
+record R2 {
+  var x: 3*R1;
+}
+
+const myConstR2: R2;
+
+proc main() {
+  var myR2: R2;
+
+  myR2 = myConstR2;
+}

--- a/test/functions/ferguson/ref-pair/tuples/bug-12282.chpl
+++ b/test/functions/ferguson/ref-pair/tuples/bug-12282.chpl
@@ -1,0 +1,35 @@
+record item {
+  var data: int = 0;
+
+  proc writeThis(f) { f <~> data; }
+}
+
+record itemset {
+  var dataset: 3*item;
+
+  proc up() {
+    dataset(1).data += 1;
+  }
+}
+
+const zero_itemset: itemset;
+
+proc main() {
+  var is1 = zero_itemset;
+  is1.up();
+  writeln(is1);
+
+  var is2: itemset;
+  is2 = zero_itemset; // error: const actual is passed to 'ref' formal '_arg2' of =
+  is2.up();
+  writeln(is2);
+
+  var is3: itemset;
+  is3 = zero_itemset: itemset;
+  is3.up();
+  writeln(is3);
+
+  assert(is1 == new itemset((new item(1), new item(0), new item(0))),
+         is1 == is2,
+         is2 == is3);
+}

--- a/test/functions/ferguson/ref-pair/tuples/bug-12282.good
+++ b/test/functions/ferguson/ref-pair/tuples/bug-12282.good
@@ -1,0 +1,3 @@
+(dataset = (1, 0, 0))
+(dataset = (1, 0, 0))
+(dataset = (1, 0, 0))


### PR DESCRIPTION
Resolves #12282

Certain tuple patterns currently create coercions that are implemented
with PRIM_GET_MEMBER / PRIM_SET_MEMBER and temporaries. Meanwhile, the
code in cullOverReferences decides which `ref` tuple elements are used as
`ref` and which are used as `const ref` for temporaries. This PR adjusts
cullOverReferences to handle PRIM_SET_MEMBER (in addition to
PRIM_GET_MEMBER) when tracking whether tuple elements in a temporary are
modified.

- [x] passed full local futures testing
- [x] gasnet testing

Reviewed by @vasslitvinov - thanks!