### PR TITLE
Clean up documentation in Path module

### DIFF
--- a/modules/standard/Path.chpl
+++ b/modules/standard/Path.chpl
@@ -77,12 +77,12 @@ const parentDir = "..";
 const pathSep = "/";
 
 /*
-  Creates a normalized absolutized version of a path. On most platforms this is
-  equivalent to the code:
+  Creates a normalized absolutized version of a path. On most platforms, when
+  given a non-absolute path this function is equivalent to the following code:
 
-  .. code::
+  .. code-block:: Chapel
   
-    normPath(joinPath(here.cwd(), name)
+    return normPath(joinPath(here.cwd(), name));
   
   See :proc:`normPath()`, :proc:`joinPath()`, :proc:`~FileSystem.locale.cwd()`
   for details.
@@ -110,15 +110,16 @@ proc absPath(name: string): string throws {
 }
 
 /*
-  Creates a normalized absolutized version of the path in this :type:`~IO.file`.
-  On most platforms this is equivalent to the code:
+  Creates a normalized absolutized version of the path in this
+  :type:`~IO.file`. On most platforms, when given a non-absolute path this
+  function is equivalent to the following code:
   
-  .. code::
+  .. code-block:: Chapel
   
-      normPath(joinPath(here.cwd(), file.path))
+      return normPath(joinPath(here.cwd(), file.path));
       
-  See :proc:`normPath()`, :proc:`joinPath()`, :proc:`~FileSystem.locale.cwd()`
-  for details.
+  See :proc:`normPath()`, :proc:`joinPath()`, :proc:`~FileSystem.locale.cwd()`,
+  :proc:`~IO.file.path` for details.
 
   .. warning::
 

--- a/modules/standard/Path.chpl
+++ b/modules/standard/Path.chpl
@@ -78,10 +78,15 @@ const pathSep = "/";
 
 /*
   Creates a normalized absolutized version of a path. On most platforms this is
-  equivalent to the call :code:`normPath(joinPath(here.cwd(), name)`. See
-  :proc:`normPath()`, :proc:`joinPath()`, :proc:`~FileSystem.locale.cwd()` for
-  details.
+  equivalent to the code:
 
+  .. code::
+  
+    normPath(joinPath(here.cwd(), name)
+  
+  See :proc:`normPath()`, :proc:`joinPath()`, :proc:`~FileSystem.locale.cwd()`
+  for details.
+    
   .. warning::
 
     This function is unsafe for use in a parallel environment due to its
@@ -106,10 +111,14 @@ proc absPath(name: string): string throws {
 
 /*
   Creates a normalized absolutized version of the path in this :type:`~IO.file`.
-  On most platforms this is equivalent to the call
-  :code:`normPath(joinPath(here.cwd(), file.path))`. See :proc:`normPath()`,
-  :proc:`joinPath()`, :proc:`~FileSystem.locale.cwd()` for details.
-
+  On most platforms this is equivalent to the code:
+  
+  .. code::
+  
+      normPath(joinPath(here.cwd(), file.path))
+      
+  See :proc:`normPath()`, :proc:`joinPath()`, :proc:`~FileSystem.locale.cwd()`
+  for details.
 
   .. warning::
 

--- a/modules/standard/Path.chpl
+++ b/modules/standard/Path.chpl
@@ -78,7 +78,9 @@ const pathSep = "/";
 
 /*
   Creates a normalized absolutized version of a path. On most platforms this is
-  equivalent to the call :code:`normPath(joinPath(here.cwd(), name)`.
+  equivalent to the call :code:`normPath(joinPath(here.cwd(), name)`. See
+  :proc:`normPath()`, :proc:`joinPath()`, :proc:`~FileSystem.locale.cwd()` for
+  details.
 
   .. warning::
 
@@ -105,7 +107,9 @@ proc absPath(name: string): string throws {
 /*
   Creates a normalized absolutized version of the path in this :type:`~IO.file`.
   On most platforms this is equivalent to the call
-  :code:`normPath(joinPath(here.cwd(), file.path))`.
+  :code:`normPath(joinPath(here.cwd(), file.path))`. See :proc:`normPath()`,
+  :proc:`joinPath()`, :proc:`~FileSystem.locale.cwd()` for details.
+
 
   .. warning::
 

--- a/modules/standard/Path.chpl
+++ b/modules/standard/Path.chpl
@@ -306,7 +306,7 @@ proc commonPath(paths: []): string {
       writeln(dirname("/foo/bar/baz")); // Prints "/foo/bar"
       writeln(dirname("/foo/bar/")); // Also prints "/foo/bar"
 
-   :arg name: a string file name.  Note that this string does not have to be
+   :arg name: A string file name.  Note that this string does not have to be
               a valid file name, as the file itself will not be affected.
    :type name: `string`
 */
@@ -318,7 +318,7 @@ proc dirname(name: string): string {
    ``${<name>}`` into their values.  If ``<name>`` does not exist, they are left
    in place. Returns the path which includes these expansions.
 
-   :arg path: a string representation of a path, which may or may not include
+   :arg path: A string representation of a path, which may or may not include
               ``$<name>`` or ``${<name>}``.
    :type path: `string`
 
@@ -527,11 +527,11 @@ private proc normalizeLeadingSlashCount(name: string): int {
     Unlike its Python counterpart, this function does not (currently) change
     slashes to backslashes on Windows.
 
-  :arg name: a potential path to collapse, possibly destroying the meaning of
+  :arg name: A potential path to collapse, possibly destroying the meaning of
              the path if symbolic links were included.
   :type name: `string`
 
-  :return: the collapsed version of `name`
+  :return: The collapsed version of `name`.
   :rtype: `string`
 */
 proc normPath(name: string): string {

--- a/modules/standard/Path.chpl
+++ b/modules/standard/Path.chpl
@@ -83,8 +83,8 @@ const pathSep = "/";
   .. warning::
 
     This function is unsafe for use in a parallel environment due to its
-    reliance on :proc:`locale.cwd()`. Another task on the current locale may
-    change the current working directory at any time.
+    reliance on :proc:`~FileSystem.locale.cwd()`. Another task on the current
+    locale may change the current working directory at any time.
 
   :arg name: The path whose absolute path is desired.
   :type name: `string`
@@ -110,8 +110,8 @@ proc absPath(name: string): string throws {
   .. warning::
 
     This method is unsafe for use in a parallel environment due to its
-    reliance on :proc:`locale.cwd()`. Another task on the current locale
-    may change the current working directory at any time.
+    reliance on :proc:`~FileSystem.locale.cwd()`. Another task on the current
+    locale may change the current working directory at any time.
 
   :return: A normalized, absolutized version of the path for this file.
   :rtype: `string`

--- a/modules/standard/Path.chpl
+++ b/modules/standard/Path.chpl
@@ -82,7 +82,7 @@ const pathSep = "/";
 
   .. code-block:: Chapel
   
-    return normPath(joinPath(here.cwd(), name));
+    normPath(joinPath(here.cwd(), name))
   
   See :proc:`normPath()`, :proc:`joinPath()`, :proc:`~FileSystem.locale.cwd()`
   for details.
@@ -116,7 +116,7 @@ proc absPath(name: string): string throws {
   
   .. code-block:: Chapel
   
-      return normPath(joinPath(here.cwd(), file.path));
+      normPath(joinPath(here.cwd(), file.path))
       
   See :proc:`normPath()`, :proc:`joinPath()`, :proc:`~FileSystem.locale.cwd()`,
   :proc:`~IO.file.path` for details.


### PR DESCRIPTION
Just a few small changes to the Path module docs to correct mistakes from PRs I made earlier.

- Fix broken links in `absPath()` and `file.absPath()`
- Add links to the functions used in example code in `absPath()` and `file.absPath()`
- Adjust descriptions of `absPath()` and `file.absPath()`
- Add missing punctuation in the arg/return descriptors of some functions

In the future I would like to make a sweeping pass through the entire Path module to standardize it so it can serve as an example for others (but now is not that time).

Let me know if there's more you'd like me to change.