### PR TITLE
Add a tech note for Fortran interop

### DIFF
--- a/doc/rst/technotes/fortranInterop.rst
+++ b/doc/rst/technotes/fortranInterop.rst
@@ -7,7 +7,11 @@ Fortran Interoperability
 ========================
 
 This README describes support for calling Chapel functions from Fortran code
-and vice-versa. The features described here are still a work in progress.
+and vice-versa.
+
+.. note::
+
+    The features described here are still a work in progress.
 
 Calling Fortran from Chapel
 ===========================
@@ -31,6 +35,6 @@ the Fortran runtime library.
 Calling Chapel from Fortran
 ===========================
 
-Chapel functions declared as 'export' can be called from Fortran by using
-the --library-fortran flag as described in
+Chapel functions declared as ``export`` can be called from Fortran by using
+the ``--library-fortran`` flag as described in
 :ref:`Using your Library in Fortran<readme-libraries.Fortran>`

--- a/doc/rst/technotes/fortranInterop.rst
+++ b/doc/rst/technotes/fortranInterop.rst
@@ -1,0 +1,36 @@
+.. _readme-fortranInterop:
+
+.. default-domain:: chpl
+
+========================
+Fortran Interoperability
+========================
+
+This README describes support for calling Chapel functions from Fortran code
+and vice-versa. The features described here are still a work in progress.
+
+Calling Fortran from Chapel
+===========================
+
+The process for calling Fortran procedures and subroutines from Chapel is
+similar to the process for calling C functions with the explicit strategy
+described in :ref:`C Interoperability <readme-extern>`.
+
+The procedures or subroutines that will be called are declared in the Chapel
+code using :ref:`extern declarations <readme-extern-extern-declarations>`.
+The Fortran code containing the procedures and subroutines should be compiled
+into an object file using a fortran compiler. Then the object file can be
+included in the Chapel compiler command line. Since the generated code will
+be linked with a C compiler, it is necessary to specify the library path for
+the Fortran runtime library.
+
+.. code-block:: bash
+
+    chpl fortranObjs.o chapelCode.chpl -LpathToFortranLib -lgfortran
+
+Calling Chapel from Fortran
+===========================
+
+Chapel functions declared as 'export' can be called from Fortran by using
+the --library-fortran flag as described in
+:ref:`Using your Library in Fortran<readme-libraries.Fortran>`


### PR DESCRIPTION
Add a tech note for Fortran interop and add --library-fortran and Fortran calling Chapel to the libraries tech note.