### PR TITLE
Clean up chameneos versions now that atomics can be initialized via '='

### DIFF
--- a/test/release/examples/benchmarks/shootout/chameneosredux-fast.chpl
+++ b/test/release/examples/benchmarks/shootout/chameneosredux-fast.chpl
@@ -215,8 +215,7 @@ class MeetingPlace {
   // Initialize the number of meetings that should take place
   //
   proc init(numMeetings) {
-    this.complete();
-    state.write(numMeetings << bitsPerChameneosID);
+    state = numMeetings << bitsPerChameneosID;
   }
 
   //

--- a/test/release/examples/benchmarks/shootout/chameneosredux.chpl
+++ b/test/release/examples/benchmarks/shootout/chameneosredux.chpl
@@ -233,8 +233,7 @@ class MeetingPlace {
   // Initialize the number of meetings that should take place
   //
   proc init(numMeetings) {
-    this.complete();
-    state.write(numMeetings << bitsPerChameneosID);
+    state = numMeetings << bitsPerChameneosID;
   }
 
   //


### PR DESCRIPTION
This is not a huge deal, but definitely nicer than the previous version.