### PR TITLE
Fix checking for virtual iterators

### DIFF
--- a/compiler/include/passes.h
+++ b/compiler/include/passes.h
@@ -118,7 +118,7 @@ void lowerForallStmtsInline();
 void handleChplPropagateErrorCall(CallExpr* call);
 void fixupErrorHandlingExits(BlockStmt* body, bool& adjustCaller);
 void addDummyErrorArgumentToCall(CallExpr* call);
-bool isVirtualIterator(Symbol* iterator);
+bool isVirtualIterator(FnSymbol* iterFn);
 
 // normalize.cpp
 void normalize(FnSymbol* fn);

--- a/compiler/resolution/lowerForalls.cpp
+++ b/compiler/resolution/lowerForalls.cpp
@@ -1409,7 +1409,7 @@ static void lowerOneForallStmt(ForallStmt* fs) {
   CallExpr* parIterCall = toCallExpr(fs->firstIteratedExpr());
   FnSymbol* parIterFn = parIterCall->resolvedFunction();
 
-  if (isVirtualIterator(parIterFn->retType->symbol)) {
+  if (isVirtualIterator(parIterFn)) {
     USR_FATAL_CONT(fs, "virtual parallel iterators are not yet supported (see issue #6998)");
     return;
   }

--- a/test/classes/vass/no-instance-for-arg-type.bad
+++ b/test/classes/vass/no-instance-for-arg-type.bad
@@ -1,4 +1,4 @@
-no-instance-for-arg-type.chpl:3: internal error: AST-SYM-BOL-0074 chpl version 1.19.0 pre-release (cfeb6592b3)
+internal error: RES-FUN-ION-nnnn chpl version mmmm
 
 Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
 and we're sorry for the hassle.  We would appreciate your reporting this bug -- 

--- a/test/functions/iterators/elliot/dynamicDispatch/parallel-virtual-par-iters.bad
+++ b/test/functions/iterators/elliot/dynamicDispatch/parallel-virtual-par-iters.bad
@@ -1,7 +1,2 @@
-parallel-virtual-par-iters.chpl:5: internal error: AST-AGG-YPE-nnnn chpl version mmmm
-
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
-and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
-please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
-
+parallel-virtual-par-iters.chpl:20: error: virtual parallel iterators are not yet supported (see issue #6998)
+parallel-virtual-par-iters.chpl:21: error: virtual parallel iterators are not yet supported (see issue #6998)

--- a/test/functions/iterators/elliot/dynamicDispatch/parallel-virtual-par-iters.future
+++ b/test/functions/iterators/elliot/dynamicDispatch/parallel-virtual-par-iters.future
@@ -1,13 +1,2 @@
-bug: compiler crashes with an assertion
-#12123
-
-Once that is fixed, revert .bad and .future to the original intention:
-
 bug: parallel iterators don't dynamically dispatch correctly
 #6998
-
-.bad:
----------------------------------
-parallel-virtual-par-iters.chpl:20: error: virtual parallel iterators are not yet supported (see issue #6998)
-parallel-virtual-par-iters.chpl:21: error: virtual parallel iterators are not yet supported (see issue #6998)
----------------------------------

--- a/test/functions/iterators/elliot/dynamicDispatch/remote-virtual-par-iters.bad
+++ b/test/functions/iterators/elliot/dynamicDispatch/remote-virtual-par-iters.bad
@@ -1,7 +1,2 @@
-remote-virtual-par-iters.chpl:5: internal error: AST-AGG-YPE-nnnn chpl version mmmm
-
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
-and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
-please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
-
+remote-virtual-par-iters.chpl:20: error: virtual parallel iterators are not yet supported (see issue #6998)
+remote-virtual-par-iters.chpl:21: error: virtual parallel iterators are not yet supported (see issue #6998)

--- a/test/functions/iterators/elliot/dynamicDispatch/remote-virtual-par-iters.future
+++ b/test/functions/iterators/elliot/dynamicDispatch/remote-virtual-par-iters.future
@@ -1,14 +1,2 @@
-bug: compiler crashes with an assertion
-#12123
-
-Once that is fixed, revert .bad and .future to the original intention:
-
 bug: parallel iterators don't dynamically dispatch correctly
 #6998
-
-.bad:
----------------------------------
-remote-virtual-par-iters.chpl:20: error: virtual parallel iterators are not yet supported (see issue #6998)
-remote-virtual-par-iters.chpl:21: error: virtual parallel iterators are not yet supported (see issue #6998)
----------------------------------
-

--- a/test/functions/iterators/elliot/dynamicDispatch/serial-virtual-par-iters.bad
+++ b/test/functions/iterators/elliot/dynamicDispatch/serial-virtual-par-iters.bad
@@ -1,7 +1,2 @@
-serial-virtual-par-iters.chpl:5: internal error: AST-AGG-YPE-nnnn chpl version mmmm
-
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
-and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
-please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
-
+serial-virtual-par-iters.chpl:20: error: virtual parallel iterators are not yet supported (see issue #6998)
+serial-virtual-par-iters.chpl:21: error: virtual parallel iterators are not yet supported (see issue #6998)

--- a/test/functions/iterators/elliot/dynamicDispatch/serial-virtual-par-iters.future
+++ b/test/functions/iterators/elliot/dynamicDispatch/serial-virtual-par-iters.future
@@ -1,13 +1,2 @@
-bug: compiler crashes with an assertion
-#12123
-
-Once that is fixed, revert .bad and .future to the original intention:
-
 bug: parallel iterators don't dynamically dispatch correctly
 #6998
-
-.bad:
----------------------------------
-serial-virtual-par-iters.chpl:20: error: virtual parallel iterators are not yet supported (see issue #6998)
-serial-virtual-par-iters.chpl:21: error: virtual parallel iterators are not yet supported (see issue #6998)
----------------------------------

--- a/test/functions/iterators/elliot/dynamicDispatch/trivial-virtual-par-iters.bad
+++ b/test/functions/iterators/elliot/dynamicDispatch/trivial-virtual-par-iters.bad
@@ -1,2 +1,2 @@
-1
-trivial-virtual-par-iters.chpl:18: error: halt reached - Should not be called...
+trivial-virtual-par-iters.chpl:18: error: virtual parallel iterators are not yet supported (see issue #6998)
+trivial-virtual-par-iters.chpl:19: error: virtual parallel iterators are not yet supported (see issue #6998)

--- a/test/functions/iterators/elliot/dynamicDispatch/trivial-virtual-par-iters.future
+++ b/test/functions/iterators/elliot/dynamicDispatch/trivial-virtual-par-iters.future
@@ -1,13 +1,2 @@
-bug: compiler crashes with an assertion
-#12123
-
-Once that is fixed, revert .bad and .future to the original intention:
-
 bug: parallel iterators don't dynamically dispatch correctly
 #6998
-
-.bad:
----------------------------------
-trivial-virtual-par-iters.chpl:18: error: virtual parallel iterators are not yet supported (see issue #6998)
-trivial-virtual-par-iters.chpl:19: error: virtual parallel iterators are not yet supported (see issue #6998)
----------------------------------


### PR DESCRIPTION
Resolves #12123.

This restores the compiler's ability to issue the error
"virtual parallel iterators are not yet supported"
when a dynamically-dispatched iterator is used in a forall loop.

This error reporting was based on `isVirtualIterator()`,
which was passed the iterator function's return type as the argument.
In #12131, the iterator functions used in forall loops became
subject to the return-by-ref transformation. As a result, their
return type became `void` and `isVirtualIterator()` was no longer
detecting virtuality.

This modifies `isVirtualIterator()` to accept the iterator function
itself and to get the formerly-return type from its IteratorInfo.
Then proceed analyzing that type as before.
When the function is an iterator forwarder, get the formerly-return
type from its ret-arg formal.

This restores the pre-#12123 contents of the .bad and .future files
for the tests in `functions/iterators/elliot/dynamicDispatch` .

While there, adjust .bad for a change in assertion,
which was missed in #12538.

Trivial, not reviewed.