### PR TITLE
Close a memory leak in linkedlist test

### DIFF
--- a/test/studies/programs/linkedList.chpl
+++ b/test/studies/programs/linkedList.chpl
@@ -131,8 +131,9 @@ class List {
   iter these() {
     var current = head;
     while current != nil {
+      const next = current.next;
       yield current.value;
-      current = current.next;
+      current = next;
     }
   }
   //

--- a/test/studies/programs/linkedList.chpl
+++ b/test/studies/programs/linkedList.chpl
@@ -106,14 +106,18 @@ class List {
       return;
 
     if head.value == value {
+      const match = head;
       head = head.next;
+      delete match;
       return;
     }
 
     var current = head;
     while current.next != nil {
       if current.next.value == value {
+        const match = current.next;
         current.next = current.next.next;
+        delete match;
         return;
       }
       current = current.next;


### PR DESCRIPTION
When "removing" nodes from the list, we weren't deleting them.