### PR TITLE
Close leak in class-alias-generic-arg-concrete

### DIFF
--- a/test/classes/ferguson/class-alias-generic-arg-concrete.chpl
+++ b/test/classes/ferguson/class-alias-generic-arg-concrete.chpl
@@ -5,7 +5,7 @@ class A {
 
 proc doit(type C)
 {
-  var c = new unmanaged C(1);
+  var c = new C(1);
   writeln(c);
   writeln(c.x);
   delete c;

--- a/test/classes/ferguson/class-alias-generic-arg-concrete.chpl
+++ b/test/classes/ferguson/class-alias-generic-arg-concrete.chpl
@@ -8,6 +8,7 @@ proc doit(type C)
   var c = new unmanaged C(1);
   writeln(c);
   writeln(c.x);
+  delete c;
 }
 
 doit(unmanaged A(int));


### PR DESCRIPTION
Close a leak by adding the obvious delete.  Also removed a duplicate
`unmanaged` modifier, which seems wrong to me.

Testing: valgrind, memleaks, darwin