### PR TITLE
Close leak in tdata-test

### DIFF
--- a/test/runtime/ferguson/tdata-test.chpl
+++ b/test/runtime/ferguson/tdata-test.chpl
@@ -10,6 +10,10 @@ record stuff {
   var oldS: bool;
   var e: _remoteEndCountType;
   var s: bool;
+
+  proc deinit() {
+    _endCountFree(e);
+  }
 }
 
 proc saveStuff() {


### PR DESCRIPTION
This test was manually allocating, yet not manually freeing, end counts.

tested: valgrind, memleaks, darwin