### PR TITLE
Close leak in parentParamChildType test

### DIFF
--- a/test/classes/initializers/compilerGenerated/generics/parentParamChildType.chpl
+++ b/test/classes/initializers/compilerGenerated/generics/parentParamChildType.chpl
@@ -35,7 +35,7 @@ class Z : A {
   var x : unmanaged Dummy(stridable);
 }
 
-var z = new unmanaged Z(1, int, false);
+var z = new owned Z(1, int, false);
 writeln("z = ", z);
 
 //


### PR DESCRIPTION
Close a memory leak in this test by changing an unmanaged module-scope variable to owned.

tested: valgrind, memleaks, darwin