### PR TITLE
Use ISO_Fortran_binding only for --library-fortran compilations

### DIFF
--- a/compiler/AST/ModuleSymbol.cpp
+++ b/compiler/AST/ModuleSymbol.cpp
@@ -630,8 +630,15 @@ void ModuleSymbol::addDefaultUses() {
     if (parentModule->modTag != MOD_USER) {
       SET_LINENO(this);
 
-      UnresolvedSymExpr* modRef = new UnresolvedSymExpr("ChapelStandard");
+      UnresolvedSymExpr* modRef;
 
+      // If this is a Fortran compilation, we need to use ISO_Fortran_binding
+      if (fLibraryFortran) {
+        modRef = new UnresolvedSymExpr("ISO_Fortran_binding");
+        block->insertAtHead(new UseStmt(modRef));
+      }
+
+      modRef = new UnresolvedSymExpr("ChapelStandard");
       block->insertAtHead(new UseStmt(modRef));
     }
 

--- a/compiler/AST/wellknown.cpp
+++ b/compiler/AST/wellknown.cpp
@@ -157,9 +157,13 @@ void gatherWellKnownTypes() {
       WellKnownType& wkt = sWellKnownTypes[i];
 
       if (*wkt.type_ == NULL) {
-        USR_FATAL_CONT("Type '%s' must be defined in the "
-                       "Chapel internal modules.",
-                       wkt.name);
+        if (wkt.type_ == &dtCFI_cdesc_t && !fLibraryFortran) {
+          // This should only be defined when --library-fortran is used
+        } else {
+          USR_FATAL_CONT("Type '%s' must be defined in the "
+                         "Chapel internal modules.",
+                         wkt.name);
+        }
       }
     }
 

--- a/compiler/parser/parser.cpp
+++ b/compiler/parser/parser.cpp
@@ -269,6 +269,9 @@ static void parseInternalModules() {
     baseModule            = parseMod("ChapelBase",           true);
     standardModule        = parseMod("ChapelStandard",       true);
     printModuleInitModule = parseMod("PrintModuleInitOrder", true);
+    if (fLibraryFortran) {
+                            parseMod("ISO_Fortran_binding", true);
+    }
 
     parseDependentModules(true);
 

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -2735,9 +2735,6 @@ static CondStmt* makeCondToTransformArr(ArgSymbol* formal, VarSymbol* newArr,
                                                 eltExpr->copy());
   ifBody->insertAtTail(new CallExpr(PRIM_MOVE, newArr, makeChplArrayFromExt));
 
-  CallExpr* checkFormalType2 = new CallExpr(PRIM_IS_SUBTYPE,
-                                            dtCFI_cdesc_t->symbol,
-                                            new CallExpr(PRIM_TYPEOF, formal));
   BlockStmt* elseIfBody = new BlockStmt();
   CallExpr* makeChplArrayFromFort = new CallExpr("makeArrayFromFortranArray",
                                                  new SymExpr(formal),
@@ -2765,7 +2762,16 @@ static CondStmt* makeCondToTransformArr(ArgSymbol* formal, VarSymbol* newArr,
   CallExpr* makeChplArray = new CallExpr("makeArrayFromOpaque",
                                          new SymExpr(formal), instanceType);
   elseBody->insertAtTail(new CallExpr(PRIM_MOVE, newArr, makeChplArray));
-  CondStmt* cond = new CondStmt(checkFormalType, ifBody, new CondStmt(checkFormalType2, elseIfBody, elseBody));
+  Stmt* elseStmt;
+  if (fLibraryFortran) {
+    CallExpr* checkFormalType2 = new CallExpr(PRIM_IS_SUBTYPE,
+                                              dtCFI_cdesc_t->symbol,
+                                              new CallExpr(PRIM_TYPEOF, formal));
+    elseStmt = new CondStmt(checkFormalType2, elseIfBody, elseBody);
+  } else {
+    elseStmt = elseBody;
+  }
+  CondStmt* cond = new CondStmt(checkFormalType, ifBody, elseStmt);
   return cond;
 }
 

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -28,7 +28,7 @@ module DefaultRectangular {
   if dataParMinGranularity<=0 then halt("dataParMinGranularity must be > 0");
 
   use DSIUtil, ChapelArray;
-  use ExternalArray, ISO_Fortran_binding;
+  use ExternalArray;
 
   config param debugDefaultDist = false;
   config param debugDefaultDistBulkTransfer = false;

--- a/test/distributions/ferguson/dist-assoc-bulkadd.bad
+++ b/test/distributions/ferguson/dist-assoc-bulkadd.bad
@@ -18,4 +18,3 @@ $CHPL_HOME/modules/internal/ChapelDistribution.chpl:768: note:                 B
 $CHPL_HOME/modules/internal/ChapelDistribution.chpl:768: note:                 BaseArrOverRectangularDom.rank
 $CHPL_HOME/modules/internal/ChapelDistribution.chpl:816: note:                 BaseSparseArr.rank
 $CHPL_HOME/modules/internal/ChapelDistribution.chpl:816: note:                 BaseSparseArr.rank
-$CHPL_HOME/modules/internal/ISO_Fortran_binding.chpl:152: note:                 CFI_cdesc_t.rank

--- a/test/modules/sungeun/init/printModuleInitOrder.good
+++ b/test/modules/sungeun/init/printModuleInitOrder.good
@@ -25,7 +25,6 @@ Initializing Modules:
         ChapelArray
          Sort
         ExternalArray
-        ISO_Fortran_binding
         RangeChunk
        ChapelNumLocales
        Sys

--- a/test/modules/sungeun/init/printModuleInitOrder.na-none.good
+++ b/test/modules/sungeun/init/printModuleInitOrder.na-none.good
@@ -24,7 +24,6 @@ Initializing Modules:
         ChapelArray
          Sort
         ExternalArray
-        ISO_Fortran_binding
         RangeChunk
        ChapelNumLocales
        Sys


### PR DESCRIPTION
This PR causes us to use the ISO_Fortran_binding module only when compiling with `--library-fortran`.  Doing otherwise adds unnecessary complexity to a typical vanilla Chapel compile and potentially causes issues when the related header files aren't available, as noted in issue #12556.

Here, what I'm doing is specializing the following behaviors based on whether `--library-fortran` is used:

* only parsing the `ISO_Fortran_binding.chpl` file when it is used
* only adding `use ISO_Fortran_binding` to user modules when it is used
* changing normalization to only put in a case looking for the Fortran array type when it is used
* special-casing the well-known types code to not complain about finding the Fortran cdesc type unless it is used
