### PR TITLE
Fixed vim syntax highlighting for domain literals

### DIFF
--- a/highlight/vim/syntax/chpl.vim
+++ b/highlight/vim/syntax/chpl.vim
@@ -70,7 +70,7 @@ else
   " cCppParen: same as cParen but ends at end-of-line; used in cDefine
   syn region	cCppParen	transparent start='(' skip='\\$' excludenl end=')' end='$' contained contains=ALLBUT,@cParenGroup,cErrInBracket,cParen,cBracket,cString,@Spell
   syn match	cParenError	display "[\])]"
-  syn match	cErrInParen	display contained "[\]{}]\|<%\|%>"
+  syn match	cErrInParen	display contained "[\]]\|<%\|%>"
   syn region	cBracket	transparent start='\[\|<::\@!' end=']\|:>' contains=ALLBUT,@cParenGroup,cErrInParen,cCppParen,cCppBracket,cCppString,@Spell
   " cCppBracket: same as cParen but ends at end-of-line; used in cDefine
   syn region	cCppBracket	transparent start='\[\|<::\@!' skip='\\$' excludenl end=']\|:>' end='$' contained contains=ALLBUT,@cParenGroup,cErrInParen,cParen,cBracket,cString,@Spell


### PR DESCRIPTION
#11509 I'm not sure if this breaks any other highlighting, but it seemed to solve the issue for me.