### PR TITLE
Add throws tags to several functions in BLAS package

### DIFF
--- a/modules/packages/BLAS.chpl
+++ b/modules/packages/BLAS.chpl
@@ -655,6 +655,8 @@ module BLAS {
       B := alpha * B * op(A)
 
     where ``A`` is a triangular matrix.
+    
+    :throws IllegalArgumentError: When `B` is a non-square array.
   */
   proc trmm(A : [?Adom] ?eltType,  B : [?Bdom] eltType,
     alpha,
@@ -713,6 +715,8 @@ module BLAS {
       X * op(A) = alpha * B
 
     where ``A`` is a triangular matrix.
+    
+    :throws IllegalArgumentError: When `B` is a non-square array.
   */
   proc trsm(A : [?Adom],  B : [?Bdom],
     alpha,
@@ -1006,7 +1010,8 @@ module BLAS {
     Wrapper for the `HEMV`_ routines::
 
       y := alpha*A*x + beta*y
-
+      
+    :throws IllegalArgumentError: When `A` is a non-square array.
   */
   proc hemv(A: [?Adom] ?eltType, X: [?vDom] eltType, Y: [vDom] eltType,
             ref alpha: eltType, ref beta: eltType,
@@ -1041,7 +1046,8 @@ module BLAS {
     Wrapper for the `HER`_ routines::
 
       A := alpha*x*conjg(x') + A
-
+      
+    :throws IllegalArgumentError: When `A` is a non-square array.
   */
   proc her(A: [?Adom] ?eltType, X: [?vDom] eltType, alpha,
             order : Order = Order.Row,
@@ -1076,7 +1082,8 @@ module BLAS {
     Wrapper for `HER2`_ routines::
 
       A := alpha *x*conjg(y') + conjg(alpha)*y *conjg(x') + A
-
+      
+    :throws IllegalArgumentError: When `A` is a non-square array.
   */
   proc her2(A: [?Adom] ?eltType, X: [?vDom] eltType, Y: [vDom] eltType,
             ref alpha: eltType,
@@ -1353,7 +1360,8 @@ module BLAS {
     Wrapper for the `SYMV`_ routines::
 
       y := alpha*A*x + beta*y
-
+      
+    :throws IllegalArgumentError: When `A` is a non-square array.
   */
   proc symv(A: [?Adom] ?eltType, X: [?vDom] eltType, Y: [vDom] eltType,
             alpha, beta,
@@ -1388,7 +1396,8 @@ module BLAS {
     Wrapper for `SYR`_ routines::
 
       A := alpha*x*x' + A
-
+      
+    :throws IllegalArgumentError: When `A` is a non-square array.
   */
   proc syr(A: [?Adom] ?eltType, X: [?vDom] eltType,
            alpha,
@@ -1425,6 +1434,7 @@ module BLAS {
 
       A := alpha*x*y'+ alpha*y*x' + A
 
+    :throws IllegalArgumentError: When `A` is a non-square array.
   */
   proc syr2(A: [?Adom] ?eltType, X: [?vDom] eltType, Y: [vDom] eltType,
             alpha,
@@ -1645,6 +1655,7 @@ module BLAS {
 
       x := op(A)*x
 
+    :throws IllegalArgumentError: When `A` is a non-square array.
   */
   proc trmv(A: [?Adom] ?eltType, X: [?vDom] eltType,
             trans : Op = Op.N,
@@ -1690,6 +1701,7 @@ module BLAS {
 
       A*op(x) = b
 
+    :throws IllegalArgumentError: When `A` is a non-square array.
   */
   proc trsv(A: [?Adom] ?eltType, B: [?vDom] eltType,
             trans : Op = Op.N,
@@ -1819,7 +1831,8 @@ module BLAS {
                                  |0   1|
 
 
-
+      :throws IllegalArgumentError: When `P` does not consist of exactly five
+        elements.
   */
   proc rotmg(ref d1: ?eltType, ref d2: eltType, ref b1: eltType, b2: eltType, P: []eltType) throws {
     require header;
@@ -1922,6 +1935,8 @@ module BLAS {
       - ``X``: Vector with updated elements
       - ``Y``: Vector with updated elements
 
+      :throws IllegalArgumentError: When `P` does not consist of exactly five
+        elements.
   */
   proc rotm(X: [?D]?eltType,  Y: [D]eltType,  P: []eltType, incY: c_int = 1, incX: c_int = 1) throws
     where D.rank == 1
@@ -2668,4 +2683,3 @@ module BLAS {
 
 
 }
-


### PR DESCRIPTION
Adds throws tags to procedures that did not have them in as requested by #11417.

- **modules/internal/ChapelBase.chpl** = Nothing to add, these are internal functions
- **modules/internal/ChapelError.chpl** = Nothing to add, these are internal functions
- **modules/internal/CString.chpl** = Nothing to add, these are internal functions
- **modules/internal/StringCasts.chpl** = Nothing to add, these are internal functions
- **modules/packages/BLAS.chpl** = Added throws tags to 12 functions

The following 12 functions in the BLAS package have had throws tags added to them:

- trmm
- trsm
- hemv
- her
- her2
- symv
- syr
- syr2
- trmv
- trsv
- rotmg
- rotm