### PR TITLE
Fix a type-o from PR #12539

### DIFF
--- a/compiler/resolution/cullOverReferences.cpp
+++ b/compiler/resolution/cullOverReferences.cpp
@@ -767,7 +767,7 @@ void cullOverReferences() {
       createFieldQualifiersIfNeeded(sym);
 
       // If it has ref fields, and all of them are const, do no more here
-      bool allConst = (sym->fieldQualifiers[i] != QUAL_REF);
+      bool allConst = (sym->fieldQualifiers[0] != QUAL_REF);
       int i = 1;
       for_fields(field, symAt) {
         if (field->isRef()) {

--- a/compiler/resolution/cullOverReferences.cpp
+++ b/compiler/resolution/cullOverReferences.cpp
@@ -1133,11 +1133,6 @@ void cullOverReferences() {
 
         // Check for case of creating a temporary from one tuple to
         // another tuple.
-          // PRIM_SET_MEMBER: base, field, value
-          // if the field is a ref, and the value is a ref, sets the ptr.
-          // if the field is a ref, and the value is a not ref, invalid AST
-          // if the field is not ref, and the value is a ref, derefs value first
-          // if neither are references, sets the field
         if (call->isPrimitive(PRIM_SET_MEMBER)) {
           SymExpr* base       = toSymExpr(call->get(1));
           Symbol*  baseSymbol = base->symbol();


### PR DESCRIPTION
PR #12539 inadvertently introduced a memory error into the compiler.
An array access that should have been `0` was instead using an outer
variable and generating out of bounds array accesses.

This probably also addresses #12582.

- [x] hellos pass with valgrind
- [x] bug-12282-simpler.chpl passes with valgrind
- [x] primers pass with valgrind
- [x] ptrans pass with valgrind
- [x] full local testing
- [x] gasnet testing

Reviewed by @vasslitvinov - thanks!