### PR TITLE
Fix issue when file.check() succeeds when file is closed.

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1390,6 +1390,7 @@ proc file.close() throws {
   var err:syserr = ENOERR;
   on this.home {
     err = qio_file_close(_file_internal);
+    _file_internal = QIO_FILE_PTR_NULL;
   }
   if err then try ioerror(err, "in file.close", this.tryGetPath());
 }

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1388,6 +1388,9 @@ proc file._style:iostyle throws {
    :throws SystemError: Thrown if the file could not be closed.
  */
 proc file.close() throws {
+  if is_c_nil(_file_internal) then
+    throw SystemError.fromSyserr(EBADF, "Operation attempted on an invalid file");
+
   var err:syserr = ENOERR;
   on this.home {
     err = qio_file_close(_file_internal);

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1388,8 +1388,6 @@ proc file._style:iostyle throws {
    :throws SystemError: Thrown if the file could not be closed.
  */
 proc file.close() throws {
-  try check();
-
   var err:syserr = ENOERR;
   on this.home {
     err = qio_file_close(_file_internal);

--- a/runtime/include/qio/qio.h
+++ b/runtime/include/qio/qio.h
@@ -633,6 +633,12 @@ void qio_file_get_style(qio_file_t* f, qio_style_t* style)
   *style = f->style;
 }
 
+static inline
+bool qio_file_isopen(qio_file_t* f) 
+{
+  return !(f->closed);
+}
+
 // Return the current length of a file.
 // Calls stat for a file descriptor
 // Calls fflush on a FILE* first.

--- a/test/io/dtjong/file-close-check.chpl
+++ b/test/io/dtjong/file-close-check.chpl
@@ -1,0 +1,20 @@
+var f: file;
+
+try {
+  try {
+    f = open("foo", iomode.cw);
+    f.check();
+    writeln(f.path);
+    f.close();
+  } catch e: SystemError {
+    writeln("open error:  " + e.details);  
+  }
+  try {
+    f.check();
+    writeln("You shouldn't see this");
+  } catch e: SystemError {
+    writeln("Task failed successfully");  
+  }
+} catch {
+  halt("catchall");
+}

--- a/test/io/dtjong/file-close-check.good
+++ b/test/io/dtjong/file-close-check.good
@@ -1,0 +1,2 @@
+foo
+Task failed successfully


### PR DESCRIPTION
#12373 Seems like hacky solution, but it works. Would be interested to know if there is a better way.