### PR TITLE
Show the variable name in the error message

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -9217,7 +9217,7 @@ static void resolvePrimInitGenericRecordVar(CallExpr* call,
 
 static bool    primInitIsUnacceptableGeneric(CallExpr* call, Type* type);
 
-static void    primInitHaltForUnacceptableGeneric(CallExpr* call, Type* type);
+static void    primInitHaltForUnacceptableGeneric(CallExpr* call, Type* type, Symbol* val);
 
 void resolvePrimInit(CallExpr* call) {
   Expr* valExpr = NULL;
@@ -9350,7 +9350,7 @@ static void resolvePrimInit(CallExpr* call, Symbol* val, Type* type) {
 
   // Generate a more specific USR_FATAL if resolution would fail
   } else if (primInitIsUnacceptableGeneric(call, type)    == true) {
-    primInitHaltForUnacceptableGeneric(call, type);
+    primInitHaltForUnacceptableGeneric(call, type, val);
 
   // These types default to nil
   } else if (isClassLikeOrNil(type)) {
@@ -9559,7 +9559,7 @@ static bool primInitIsUnacceptableGeneric(CallExpr* call, Type* type) {
 }
 
 // Generate a useful USR_FATAL for an unacceptable Generic
-static void primInitHaltForUnacceptableGeneric(CallExpr* call, Type* type) {
+static void primInitHaltForUnacceptableGeneric(CallExpr* call, Type* type, Symbol* val) {
   const char* label = "abstract";
 
   if (AggregateType* at = toAggregateType(type)) {
@@ -9570,7 +9570,7 @@ static void primInitHaltForUnacceptableGeneric(CallExpr* call, Type* type) {
 
   USR_FATAL_CONT(call,
                  "Cannot default-initialize a variable with generic type");
-  USR_PRINT(call, "'%s' has generic type '%s'", label, type->symbol->name);
+  USR_PRINT(call, "'%s' has generic type '%s'", val->name, type->symbol->name);
   USR_STOP();
 }
 

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -9560,14 +9560,6 @@ static bool primInitIsUnacceptableGeneric(CallExpr* call, Type* type) {
 
 // Generate a useful USR_FATAL for an unacceptable Generic
 static void primInitHaltForUnacceptableGeneric(CallExpr* call, Type* type, Symbol* val) {
-  const char* label = "abstract";
-
-  if (AggregateType* at = toAggregateType(type)) {
-    if (at->typeConstructor != NULL) {
-      label = "not-fully-instantiated";
-    }
-  }
-
   USR_FATAL_CONT(call,
                  "Cannot default-initialize a variable with generic type");
   USR_PRINT(call, "'%s' has generic type '%s'", val->name, type->symbol->name);

--- a/test/classes/generic/varOverBadGeneric.good
+++ b/test/classes/generic/varOverBadGeneric.good
@@ -1,2 +1,2 @@
 varOverBadGeneric.chpl:6: error: Cannot default-initialize a variable with generic type
-varOverBadGeneric.chpl:6: note: 'not-fully-instantiated' has generic type 'C'
+varOverBadGeneric.chpl:6: note: 'myC' has generic type 'C'

--- a/test/localeModels/nspark/loc-in-locales.good
+++ b/test/localeModels/nspark/loc-in-locales.good
@@ -1,2 +1,2 @@
 loc-in-locales.chpl:3: error: Cannot default-initialize a variable with generic type
-loc-in-locales.chpl:3: note: 'not-fully-instantiated' has generic type 'channel'
+loc-in-locales.chpl:3: note: 'c' has generic type 'channel'

--- a/test/types/integral/integralvariable2.good
+++ b/test/types/integral/integralvariable2.good
@@ -1,2 +1,2 @@
 integralvariable2.chpl:1: error: Cannot default-initialize a variable with generic type
-integralvariable2.chpl:1: note: 'abstract' has generic type 'integral'
+integralvariable2.chpl:1: note: 'r' has generic type 'integral'


### PR DESCRIPTION
Resolves #11436.

Instead of "not-fully-instantiated" the error message now displays the variable name.
I have also updated the test outputs.

All affected tests are updated and pass `start_test`.