### PR TITLE
Make the execution limiter directory user settable

### DIFF
--- a/util/test/execution_limiter.py
+++ b/util/test/execution_limiter.py
@@ -44,7 +44,13 @@ class FileLock():
 
     def __init__(self):
         lock_name = '{0}-chpl_program_executing'.format(getpass.getuser())
-        self.lock_file = os.path.join(tempfile.gettempdir(), lock_name)
+        lock_dir = os.getenv('CHPL_TEST_LIMIT_RUNNING_EXECUTABLES_DIR', tempfile.gettempdir())
+        try:
+            os.makedirs(lock_dir)
+        except OSError as e:
+            if e.errno != os.errno.EEXIST:
+                raise
+        self.lock_file = os.path.join(lock_dir, lock_name)
         self.lock = filelock.FileLock(self.lock_file)
 
     def __enter__(self):


### PR DESCRIPTION
Previously, it was just using tmpdir, but there are cases where we want
tmpdir to be different from the execution limiter dir (e.g. if tmpdir is
based on the job name but we want the execution limiter across jobs)