### PR TITLE
Update PREDIFF sed delimiter from `@` -> `|`

### DIFF
--- a/test/mason/env/PREDIFF
+++ b/test/mason/env/PREDIFF
@@ -3,6 +3,6 @@
 outfile=$2
 temp=$outfile.temp
 
-cat $outfile | sed "s@${PWD}@\$PWD@" > $temp
+cat $outfile | sed "s|${PWD}|\$PWD|" > $temp
 
 mv $temp $outfile


### PR DESCRIPTION
Jenkins uses `@` in the path name for concurrent builds, which causes
this the sed delimiter of `@` to fail, so `|` seems like a safer
delimiter.