### PR TITLE
Generalize specifying oversubscribed execution.

### DIFF
--- a/doc/rst/usingchapel/executing.rst
+++ b/doc/rst/usingchapel/executing.rst
@@ -356,17 +356,26 @@ Oversubscription
 
 In multi-locale Chapel executions programs can run "oversubscribed",
 with more than one Chapel locale per system compute node.  Both the
-``gasnet`` and ``ofi`` communication layers support oversubscription.
-When running oversubscribed, performance may be improved by setting
-the following environment variable:
+``gasnet`` and ``ofi`` communication layers support this.  However,
+oversubscription can cause serious performance degradation due to
+resource contention, when multiple Chapel locales (program instances)
+all proceed as if the resources of the entire compute node are theirs
+to use.  As a result, on a single system node, a program will almost
+always run faster with just a single locale than it will with multiple
+locales.  Nevertheless, sometimes oversubscription is useful, such as
+for testing multilocale Chapel functionality when multiple system
+nodes are not actually available.
+
+As a partial workaround for the resource contention problem, setting
+the following environment variable often improves performance when
+running oversubscribed:
 
     .. code-block:: sh
 
         export CHPL_RT_OVERSUBSCRIBED=yes
 
-This indicates that oversubscription may occur, and will cause various
-software components from launchers to the runtime to adjust their
-behavior accordingly.
+This causes various software components, from launchers to the
+runtime, to be more considerate in how they use node resources.
 
 
 ----------------

--- a/doc/rst/usingchapel/executing.rst
+++ b/doc/rst/usingchapel/executing.rst
@@ -348,6 +348,27 @@ executable.
                    warnings that are printed by default.
 
 
+.. _oversubscribed-execution:
+
+----------------
+Oversubscription
+----------------
+
+In multi-locale Chapel executions programs can run "oversubscribed",
+with more than one Chapel locale per system compute node.  Both the
+``gasnet`` and ``ofi`` communication layers support oversubscription.
+When running oversubscribed, performance may be improved by setting
+the following environment variable:
+
+    .. code-block:: sh
+
+        export CHPL_RT_OVERSUBSCRIBED=yes
+
+This indicates that oversubscription may occur, and will cause various
+software components from launchers to the runtime to adjust their
+behavior accordingly.
+
+
 ----------------
 Launcher Support
 ----------------

--- a/doc/rst/usingchapel/tasks.rst
+++ b/doc/rst/usingchapel/tasks.rst
@@ -190,7 +190,7 @@ turned on like this:
   cd $CHPL_HOME/third-party/qthread
   make CHPL_QTHREAD_ENABLE_OVERSUBSCRIPTION=yes ... clean all
 
-You should also probably have ``CHPL_RT_OVERSUBSCRIBED=y`` set when
+You should also probably have ``CHPL_RT_OVERSUBSCRIBED=yes`` set when
 you execute with overloading (see :ref:`oversubscribed-execution`).
 
 

--- a/doc/rst/usingchapel/tasks.rst
+++ b/doc/rst/usingchapel/tasks.rst
@@ -190,6 +190,9 @@ turned on like this:
   cd $CHPL_HOME/third-party/qthread
   make CHPL_QTHREAD_ENABLE_OVERSUBSCRIPTION=yes ... clean all
 
+You should also probably have ``CHPL_RT_OVERSUBSCRIBED=y`` set when
+you execute with overloading (see :ref:`oversubscribed-execution`).
+
 
 Hwloc
 =====

--- a/runtime/include/chpl-env.h
+++ b/runtime/include/chpl-env.h
@@ -63,4 +63,7 @@ size_t chpl_env_rt_get_size(const char* ev, size_t dflt) {
   return chpl_env_str_to_size(ev, chpl_env_rt_get(ev, NULL), dflt);
 }
 
+void chpl_env_set(const char*, const char*, int);
+void chpl_env_set_uint(const char*, uint64_t, int);
+
 #endif

--- a/runtime/include/chpl-mem.h
+++ b/runtime/include/chpl-mem.h
@@ -187,6 +187,9 @@ void chpl_mem_layerFree(void*, int32_t lineno, int32_t filename);
 #define chpl_mem_alloc(size, description, lineno, filename)        \
   sys_malloc(size)
 
+#define chpl_mem_realloc(memAlloc, size, description, lineno, filename) \
+  sys_realloc(memAlloc, size)
+
 #define chpl_mem_free(ptr, lineno, filename)        \
   sys_free(ptr)
 

--- a/runtime/include/comm/ofi/chpl-comm-launch.h
+++ b/runtime/include/comm/ofi/chpl-comm-launch.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2004-2019 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//
+// Launch assistance for the ofi communication layer.
+//
+
+//
+// This is an optional comm layer function for the launcher to call
+// right before launching the user program.
+//
+#define CHPL_COMM_PRELAUNCH() chpl_comm_preLaunch()
+void chpl_comm_preLaunch(void);

--- a/runtime/include/comm/ofi/chpl-comm-launch.h
+++ b/runtime/include/comm/ofi/chpl-comm-launch.h
@@ -17,6 +17,9 @@
  * limitations under the License.
  */
 
+#ifndef _chpl_comm_launch_h
+#define _chpl_comm_launch_h
+
 //
 // Launch assistance for the ofi communication layer.
 //
@@ -27,3 +30,5 @@
 //
 #define CHPL_COMM_PRELAUNCH() chpl_comm_preLaunch()
 void chpl_comm_preLaunch(void);
+
+#endif

--- a/runtime/include/comm/ugni/chpl-comm-launch.h
+++ b/runtime/include/comm/ugni/chpl-comm-launch.h
@@ -17,6 +17,9 @@
  * limitations under the License.
  */
 
+#ifndef _chpl_comm_launch_h
+#define _chpl_comm_launch_h
+
 //
 // Launch assistance for the uGNI communication interface.
 //
@@ -27,3 +30,5 @@
 //
 #define CHPL_COMM_PRELAUNCH() chpl_comm_preLaunch()
 void chpl_comm_preLaunch(void);
+
+#endif

--- a/runtime/src/arg.c
+++ b/runtime/src/arg.c
@@ -36,7 +36,6 @@
 #include <errno.h>
 #include <stdint.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 
 

--- a/runtime/src/arg.c
+++ b/runtime/src/arg.c
@@ -22,6 +22,7 @@
 #include "arg.h"
 #include "chplcast.h"
 #include "chplcgfns.h"
+#include "chpl-env.h"
 #include "chplexit.h"
 #include "chplio.h"
 #include "chpl-mem.h"
@@ -107,9 +108,7 @@ static void defineEnvVar(const char* currentArg,
   }
 
   *eqp = '\0';
-  if (setenv(currentArg, eqp + 1, 0) != 0) {
-    chpl_error("Cannot setenv() -E argument", lineno, filename);
-  }
+  chpl_env_set(currentArg, eqp + 1, 0);
   *eqp = '=';
 }
 

--- a/runtime/src/chpl-env.c
+++ b/runtime/src/chpl-env.c
@@ -169,3 +169,19 @@ size_t chpl_env_str_to_size(const char* evName, const char* evVal,
 
   return val;
 }
+
+
+void chpl_env_set(const char* evName, const char* evVal, int overwrite) {
+  if (setenv(evName, evVal, overwrite) != 0) {
+    char buf[200];
+    snprintf(buf, sizeof(buf), "cannot setenv %s=\"%s\"", evName, evVal);
+    chpl_error(buf, 0, 0);
+  }
+}
+
+
+void chpl_env_set_uint(const char* evName, uint64_t evVal, int overwrite) {
+  char buf[21]; // big enough for 64-bit unsigned, plus trailing '\0'
+  snprintf(buf, sizeof(buf), "%" PRIu64, evVal);
+  chpl_env_set(evName, buf, overwrite);
+}

--- a/runtime/src/comm/gasnet/comm-gasnet.c
+++ b/runtime/src/comm/gasnet/comm-gasnet.c
@@ -27,6 +27,7 @@
 #include "chpl-comm-diags.h"
 #include "chpl-comm-callbacks.h"
 #include "chpl-comm-callbacks-internal.h"
+#include "chpl-env.h"
 #include "chpl-mem.h"
 #include "chplsys.h"
 #include "chpl-tasks.h"
@@ -747,12 +748,7 @@ static void polling(void* x) {
 }
 
 static void set_max_segsize_env_var(size_t size) {
-  char segsizeval[22]; // big enough for an unsigned 64-bit quantity
-
-  snprintf(segsizeval, sizeof(segsizeval), "%zd", size);
-  if (setenv("GASNET_MAX_SEGSIZE", segsizeval, 1) != 0) {
-    chpl_error("Cannot setenv(\"GASNET_MAX_SEGSIZE\")", 0, 0);
-  }
+  chpl_env_set_uint("GASNET_MAX_SEGSIZE", size, 1);
 }
 
 static void set_max_segsize() {
@@ -768,29 +764,15 @@ static void set_max_segsize() {
 
 static void set_num_comm_domains() {
 #if defined(GASNET_CONDUIT_GEMINI) || defined(GASNET_CONDUIT_ARIES)
-  char num_cpus_val[22]; // big enough for an unsigned 64-bit quantity
-  int num_cpus;
-
-  num_cpus = chpl_topo_getNumCPUsPhysical(true) + 1;
-
-  snprintf(num_cpus_val, sizeof(num_cpus_val), "%d", num_cpus);
-  if (setenv("GASNET_DOMAIN_COUNT", num_cpus_val, 0) != 0) {
-    chpl_error("Cannot setenv(\"GASNET_DOMAIN_COUNT\")", 0, 0);
-  }
-
-  if (setenv("GASNET_AM_DOMAIN_POLL_MASK", "3", 0) != 0) {
-    chpl_error("Cannot setenv(\"GASNET_AM_DOMAIN_POLL_MASK\")", 0, 0);
-  }
+  const int num_cpus = chpl_topo_getNumCPUsPhysical(true) + 1;
+  chpl_env_set_uint("GASNET_DOMAIN_COUNT", num_cpus, 0);
+  chpl_env_set("GASNET_AM_DOMAIN_POLL_MASK", "3", 0);
 
   // GASNET_DOMAIN_COUNT increases the shutdown time. Work around this for now.
   // See https://github.com/chapel-lang/chapel/issues/7251 and
   // https://upc-bugs.lbl.gov/bugzilla/show_bug.cgi?id=3621
-  if (setenv("GASNET_EXITTIMEOUT_FACTOR", "0.5", 0) != 0) {
-    chpl_error("Cannot setenv(\"GASNET_EXITTIMEOUT_FACTOR\")", 0, 0);
-  }
-  if (setenv("GASNET_EXITTIMEOUT_MIN", "10.0", 0) != 0) {
-    chpl_error("Cannot setenv(\"GASNET_EXITTIMEOUT_MIN\")", 0, 0);
-  }
+  chpl_env_set("GASNET_EXITTIMEOUT_FACTOR", "0.5", 0);
+  chpl_env_set("GASNET_EXITTIMEOUT_MIN", "10.0", 0);
 #endif
 }
 

--- a/runtime/src/comm/gasnet/comm-gasnet.c
+++ b/runtime/src/comm/gasnet/comm-gasnet.c
@@ -47,7 +47,6 @@
 #include <signal.h>
 #include <sched.h>
 #include <stdint.h>
-#include <stdlib.h>
 #include <string.h>
 #include <assert.h>
 #include <time.h>

--- a/runtime/src/comm/ofi/Makefile.share
+++ b/runtime/src/comm/ofi/Makefile.share
@@ -16,6 +16,7 @@
 # limitations under the License.
 
 COMM_LAUNCHER_SRCS = \
+        comm-ofi-launch.c \
         comm-ofi-locales.c \
 
 COMM_SRCS = \

--- a/runtime/src/comm/ofi/comm-ofi-launch.c
+++ b/runtime/src/comm/ofi/comm-ofi-launch.c
@@ -21,8 +21,6 @@
 // Launch assistance for the uGNI communication interface.
 //
 
-#define _POSIX_C_SOURCE 200112L  // for setenv(3) in <stdlib.h>
-
 #include <assert.h>
 #include <stdlib.h>
 
@@ -39,8 +37,6 @@ void chpl_comm_preLaunch(void) {
     // we can't tell if that will be used, but setting it superfluously
     // won't hurt anything.
     //
-    if (setenv("FI_SOCKETS_PE_WAITTIME", "0", 0) != 0) {
-      chpl_error("cannot setenv FI_SOCKETS_PE_WAITTIME=0", 0, 0);
-    }
+    chpl_env_set("FI_SOCKETS_PE_WAITTIME", "0", 0);
   }
 }

--- a/runtime/src/comm/ofi/comm-ofi-launch.c
+++ b/runtime/src/comm/ofi/comm-ofi-launch.c
@@ -21,13 +21,9 @@
 // Launch assistance for the uGNI communication interface.
 //
 
-#include <assert.h>
-#include <stdlib.h>
-
 #include "chplrt.h"
 #include "chpl-comm-launch.h"
 #include "chpl-env.h"
-#include "error.h"
 
 
 void chpl_comm_preLaunch(void) {

--- a/runtime/src/comm/ofi/comm-ofi-launch.c
+++ b/runtime/src/comm/ofi/comm-ofi-launch.c
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2004-2019 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//
+// Launch assistance for the uGNI communication interface.
+//
+
+#define _POSIX_C_SOURCE 200112L  // for setenv(3) in <stdlib.h>
+
+#include <assert.h>
+#include <stdlib.h>
+
+#include "chplrt.h"
+#include "chpl-comm-launch.h"
+#include "chpl-env.h"
+#include "error.h"
+
+
+void chpl_comm_preLaunch(void) {
+  if (chpl_env_rt_get_bool("OVERSUBSCRIBED", false)) {
+    //
+    // This only applies to the sockets provider.  Here in the launcher
+    // we can't tell if that will be used, but setting it superfluously
+    // won't hurt anything.
+    //
+    if (setenv("FI_SOCKETS_PE_WAITTIME", "0", 0) != 0) {
+      chpl_error("cannot setenv FI_SOCKETS_PE_WAITTIME=0", 0, 0);
+    }
+  }
+}

--- a/runtime/src/comm/ugni/comm-ugni-launch.c
+++ b/runtime/src/comm/ugni/comm-ugni-launch.c
@@ -23,7 +23,6 @@
 
 #include <assert.h>
 #include <math.h>
-#include <stdlib.h>
 
 #include "chplrt.h"
 #include "chpl-comm-launch.h"

--- a/runtime/src/comm/ugni/comm-ugni-launch.c
+++ b/runtime/src/comm/ugni/comm-ugni-launch.c
@@ -21,8 +21,6 @@
 // Launch assistance for the uGNI communication interface.
 //
 
-#define _POSIX_C_SOURCE 200112L  // for setenv(3) in <stdlib.h>
-
 #include <assert.h>
 #include <math.h>
 #include <stdlib.h>
@@ -91,18 +89,14 @@ void maybe_set_jemalloc_lg_chunk(void) {
     }
   }
 
-  if (setenv(chpl_comm_ugni_jemalloc_conf_ev_name(), buf, 1) != 0)
-    chpl_internal_error("cannot setenv jemalloc conf env var");
+  chpl_env_set(chpl_comm_ugni_jemalloc_conf_ev_name(), buf, 1);
 }
 
 
 void chpl_comm_preLaunch(void) {
-  if (setenv("HUGETLB_VERBOSE", "0", 1) != 0)
-    chpl_error("cannot setenv HUGETLB_VERBOSE=0", 0, 0);
-
+  chpl_env_set("HUGETLB_VERBOSE", "0", 1);
   if (chpl_env_rt_get("MAX_HEAP_SIZE", NULL) == NULL) {
-    if (setenv("HUGETLB_NO_RESERVE", "yes", 0) != 0)
-      chpl_error("cannot setenv HUGETLB_NO_RESERVE=yes", 0, 0);
+    chpl_env_set("HUGETLB_NO_RESERVE", "yes", 0);
   }
 
   maybe_set_jemalloc_lg_chunk();

--- a/runtime/src/config.c
+++ b/runtime/src/config.c
@@ -29,7 +29,6 @@
 #include "error.h"
 
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 
 

--- a/runtime/src/config.c
+++ b/runtime/src/config.c
@@ -56,10 +56,6 @@ static configVarType* ambiguousConfigVar = &_ambiguousConfigVar;
 
 static configVarType* lookupConfigVar(const char* moduleName, 
                                       const char* varName);
-static void handleDeprecatedConfig(const char* varName,
-                                   const char* value,
-                                   const char* envVarName);
-static void checkDeprecatedConfig(const char* varName, const char* value);
 
 
 static void parseModVarName(char* modVarName, const char** moduleName, 
@@ -260,34 +256,6 @@ static configVarType* lookupConfigVar(const char* moduleName,
 }
 
 
-static void handleDeprecatedConfig(const char* varName,
-                                   const char* value,
-                                   const char* envVarName) {
-  if (getenv(envVarName) == NULL) {
-    chpl_msg(0,
-             "warning: The config variable \"%s\" is deprecated.  Please use\n"
-             "         the environment variable \"%s\" instead.\n",
-             varName, envVarName);
-    if (value != NULL)
-      setenv(envVarName, value, 0);
-  }
-  else
-    chpl_msg(0,
-             "warning: The config variable \"%s\" is deprecated, and is\n"
-             "         overridden by the environment variable \"%s\".\n",
-             varName, envVarName);
-}
-
-
-static void checkDeprecatedConfig(const char* varName,
-                                  const char* value) {
-  if (strcmp(varName, "callStackSize") == 0)
-    handleDeprecatedConfig(varName, value, "CHPL_RT_CALL_STACK_SIZE");
-  else if (strcmp(varName, "numThreadsPerLocale") == 0)
-    handleDeprecatedConfig(varName, value, "CHPL_RT_NUM_THREADS_PER_LOCALE");
-}
-
-
 void initSetValue(const char* varName, const char* value, 
                   const char* moduleName, 
                   int32_t lineno, int32_t filename) {
@@ -430,7 +398,6 @@ int handlePossibleConfigVar(int* argc, char* argv[], int argnum,
     }
   } else {
     char* value = equalsSign + 1;
-    checkDeprecatedConfig(varName, equalsSign ? value : equalsSign);
     if (equalsSign && *value) {
       initSetValue(varName, value, moduleName, lineno, filename);
     } else if (!strcmp(configVar->defaultValue, "bool")) {
@@ -487,7 +454,6 @@ void parseConfigFile(const char* configFilename,
                                     CHPL_FILE_IDX_SAVED_FILENAME);
         } else {
           char* value = equalsSign + 1;
-          checkDeprecatedConfig(varName, equalsSign ? value : equalsSign);
           if (equalsSign && *value) {
             initSetValue(varName, value, moduleName, 0,
                          CHPL_FILE_IDX_SAVED_FILENAME);

--- a/runtime/src/launch/smp/launch-smp.c
+++ b/runtime/src/launch/smp/launch-smp.c
@@ -21,7 +21,6 @@
 #include <string.h>
 #include "chpl-env.h"
 #include "chpllaunch.h"
-#include "error.h"
 
 
 // Simple launcher that just sets GASNET_PSHM_NODES and launchers the _real

--- a/runtime/src/launch/smp/launch-smp.c
+++ b/runtime/src/launch/smp/launch-smp.c
@@ -19,6 +19,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include "chpl-env.h"
 #include "chpllaunch.h"
 #include "error.h"
 
@@ -26,13 +27,9 @@
 // Simple launcher that just sets GASNET_PSHM_NODES and launchers the _real
 
 int chpl_launch(int argc, char* argv[], int32_t numLocales) {
-  char numlocalesval[12]; // big enough for int32_t
   char baseCommand[4096];
 
-  snprintf(numlocalesval, sizeof(numlocalesval), "%d", (int)numLocales);
-  if (setenv("GASNET_PSHM_NODES", numlocalesval, 1) != 0) {
-    chpl_error("Cannot setenv(\"GASNET_PSHM_NODES\")", 0, 0);
-  }
+  chpl_env_set_uint("GASNET_PSHM_NODES", numLocales, 1);
 
   chpl_compute_real_binary_name(argv[0]);
   snprintf(baseCommand, sizeof(baseCommand), "%s", chpl_get_real_binary_name());

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -648,10 +648,10 @@ static void setupWorkStealing(void) {
 
 static void setupSpinWaiting(void) {
   const char *crayPlatform = "cray-x";
-  if (strncmp(crayPlatform, CHPL_TARGET_PLATFORM, strlen(crayPlatform)) == 0) {
-    chpl_qt_setenv("SPINCOUNT", "3000000", 0);
-  } else if (chpl_env_rt_get_bool("OVERSUBSCRIBED", false)) {
+  if (chpl_env_rt_get_bool("OVERSUBSCRIBED", false)) {
     chpl_qt_setenv("SPINCOUNT", "300", 0);
+  } else if (strncmp(crayPlatform, CHPL_TARGET_PLATFORM, strlen(crayPlatform)) == 0) {
+    chpl_qt_setenv("SPINCOUNT", "3000000", 0);
   }
 }
 

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -650,6 +650,14 @@ static void setupSpinWaiting(void) {
   const char *crayPlatform = "cray-x";
   if (strncmp(crayPlatform, CHPL_TARGET_PLATFORM, strlen(crayPlatform)) == 0) {
     chpl_qt_setenv("SPINCOUNT", "3000000", 0);
+  } else if (chpl_env_rt_get_bool("OVERSUBSCRIBED", false)) {
+    chpl_qt_setenv("SPINCOUNT", "300", 0);
+  }
+}
+
+static void setupAffinity(void) {
+  if (chpl_env_rt_get_bool("OVERSUBSCRIBED", false)) {
+    chpl_qt_setenv("AFFINITY", "no", 0);
   }
 }
 
@@ -669,6 +677,7 @@ void chpl_task_init(void)
     setupTasklocalStorage();
     setupWorkStealing();
     setupSpinWaiting();
+    setupAffinity();
 
     if (verbosity >= 2) { chpl_qt_setenv("INFO", "1", 0); }
 

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -26,9 +26,6 @@
  * limitations under the License.
  */
 
-// For SVID definitions (setenv)
-#define _SVID_SOURCE
-
 #ifdef HAVE_CONFIG_H
 # include "config.h"
 #endif
@@ -391,8 +388,8 @@ static void chpl_qt_setenv(const char* var, const char* val,
             printf("QTHREADS: Overriding the value of %s and %s "
                    "with %s\n", qt_env, qthread_env, val);
         }
-        (void) setenv(qt_env, val, 1);
-        (void) setenv(qthread_env, val, 1);
+        chpl_env_set(qt_env, val, 1);
+        chpl_env_set(qthread_env, val, 1);
     } else if (verbosity >= 2) {
         char* set_env = NULL;
         char* set_val = NULL;

--- a/util/cron/common-oversubscribed.bash
+++ b/util/cron/common-oversubscribed.bash
@@ -4,7 +4,7 @@
 # chapel programs run nicer side by side)
 
 tasks=$($CHPL_HOME/util/chplenv/chpl_tasks.py)
+export CHPL_RT_OVERSUBSCRIBED=yes
 if [ "${tasks}" == "qthreads" ] ; then
-    export QT_AFFINITY=no
     export CHPL_QTHREAD_ENABLE_OVERSUBSCRIPTION=1
 fi

--- a/util/test/paratest.chapcs
+++ b/util/test/paratest.chapcs
@@ -143,7 +143,7 @@ def run_paratest(args):
     nodepara = get_good_nodepara()
     num_free_nodes = get_num_non_exclusive_nodes()
     para_env = ['-env', 'CHPL_TEST_LIMIT_RUNNING_EXECUTABLES=yes', '-env',
-                'QT_AFFINITY=no', '-env', 'QT_SPINCOUNT=300']
+                'CHPL_RT_OVERSUBSCRIBED=yes']
 
     salloc_cmd = ['salloc',
                   '--nodes={0}'.format(num_free_nodes),

--- a/util/test/paratest.local
+++ b/util/test/paratest.local
@@ -71,7 +71,7 @@ def run_paratest(args):
     """
     nodepara = get_good_nodepara()
     para_env = ['-env', 'CHPL_TEST_LIMIT_RUNNING_EXECUTABLES=yes', '-env',
-                'QT_AFFINITY=no', '-env', 'QT_SPINCOUNT=300']
+                'CHPL_RT_OVERSUBSCRIBED=yes']
 
     paratest_path = os.path.join(os.path.dirname(__file__), 'paratest.server')
 


### PR DESCRIPTION
Up until now we've been dealing with oversubscribed execution in a
case by case way.  For example, when we run oversubscribed with the
Qthreads tasking layer we set `QT_AFFINITY=no` and `QT_SPINCOUNT=300`.
(We do this primarily just to support our own testing.)

Here, support oversubscribed execution in a more general way.  Add the
boolean environment variable `CHPL_RT_OVERSUBSCRIBED`.  If this is set
at execution time and the qthreads tasking layer is being used, set
`QT_AFFINITY` and `QT_SPINCOUNT` before initializing Qthreads.  If it
is set at launch time and the ofi comm layer is being used, adjust the
environment to reduce the overhead of sockets provider progress
checking.  Also, if the comm=ofi MPI-based out-of-band support is
being used, adjust the mpirun launch command arguments to reduce the
overhead of MPI communication checks.  Finally, instead of setting
`QT_AFFINITY` and `QT_SPINCOUNT` explicitly when doing oversubscribed
testing, just set `CHPL_RT_OVERSUBSCRIBED` and let the new generalized
support take care of the details.

This improves the situation described in #12390 and #12581, but does
not entirely resolve it.

This resolves https://github.com/Cray/chapel-private/issues/101.