### PR TITLE
Close leaks in tests of unmanaged types

### DIFF
--- a/test/classes/delete-free/unmanaged/unmanaged-forwarding.chpl
+++ b/test/classes/delete-free/unmanaged/unmanaged-forwarding.chpl
@@ -11,5 +11,7 @@ proc test() {
   var ff = new unmanaged Forwarder(new unmanaged MyClass());
 
   ff.method();
+  delete ff.x;
+  delete ff;
 }
 test();

--- a/test/classes/delete-free/unmanaged/unmanaged-generic.chpl
+++ b/test/classes/delete-free/unmanaged/unmanaged-generic.chpl
@@ -46,6 +46,7 @@ proc makeit(type t) {
 proc test2() {
   var x = makeit(unmanaged MyClass(int));
   writeln(x);
+  delete x;
 }
 
 test2();

--- a/test/classes/delete-free/unmanaged/unmanaged-override-subtype.chpl
+++ b/test/classes/delete-free/unmanaged/unmanaged-override-subtype.chpl
@@ -21,5 +21,7 @@ proc test() {
   var dom = new unmanaged MyDomain(1);
   var arr:unmanaged Array = new unmanaged MyArray(dom);
   var x = arr.foo();
+  delete arr;
+  delete dom;
 }
 test();

--- a/test/classes/delete-free/unmanaged/unmanaged-return-type-inference-subtype.chpl
+++ b/test/classes/delete-free/unmanaged/unmanaged-return-type-inference-subtype.chpl
@@ -15,5 +15,6 @@ proc makeit() {
 proc test() {
   var x = makeit();
   writeln(x.type:string);
+  delete x;
 }
 test();

--- a/test/classes/delete-free/unmanaged/unmanaged-subtyping.chpl
+++ b/test/classes/delete-free/unmanaged/unmanaged-subtyping.chpl
@@ -4,10 +4,10 @@ class MyDomain : Domain {
   var x;
 }
 class Array {
-  proc foo(arg:unmanaged Domain) {
+  proc foo(arg: unmanaged Domain) {
     writeln("In parent foo");
   }
-  proc bar(arg:borrowed Domain) {
+  proc bar(arg: borrowed Domain) {
     writeln("In parent bar");
   }
 }
@@ -15,7 +15,7 @@ class MyArray : Array {
   var x;
 }
 
-proc baz(arg:borrowed Domain) {
+proc baz(arg: borrowed Domain) {
   writeln("In bar arg:Domain");
 }
 
@@ -25,5 +25,7 @@ proc test() {
   arr.foo(dom);
   arr.bar(dom);
   baz(dom);
+  delete dom;
+  delete arr;
 }
 test();

--- a/test/classes/delete-free/unmanaged/unmanaged-where-subtype-coerce.chpl
+++ b/test/classes/delete-free/unmanaged/unmanaged-where-subtype-coerce.chpl
@@ -8,3 +8,5 @@ proc f(x) where isSubtype(x.type, Class) {
 var x = new unmanaged Class();
 
 f(x);
+
+delete x;


### PR DESCRIPTION
It was tempting to make these tests use managed types, but since they're in a directory named `unmanaged`, I inserted deletes instead.
