### PR TITLE
Fix cross-compilation for GMP builds

### DIFF
--- a/make/Makefile.base
+++ b/make/Makefile.base
@@ -208,6 +208,7 @@ printplatform:
 # use: make print-X to print the value of the variable X
 #
 print-%: ; @echo "$*" is "$($*)"
+printQ-%: ; @echo "$($*)"
 
 
 # OBJ_SUBDIR is used in compiler/

--- a/third-party/gmp/Makefile
+++ b/third-party/gmp/Makefile
@@ -5,6 +5,10 @@ endif
 CHPL_MAKE_HOST_TARGET = --target
 include $(CHPL_MAKE_HOME)/make/Makefile.base
 
+# Get the host compiler (some build-time programs are compiled and run to
+# generate host-specific data table, and these run on the host/build node)
+HOST_CC=$(shell CHPL_MAKE_HOME=$(CHPL_MAKE_HOME) CHPL_MAKE_HOST_TARGET=--host make -f $(CHPL_MAKE_HOME)/make/Makefile.base printQ-CC)
+
 #
 # Cray X* builds are cross-compilations
 #
@@ -69,7 +73,7 @@ $(GMP_BUILD_SUBDIR):
 $(GMP_H_FILE): $(GMP_BUILD_SUBDIR)
 	touch $(GMP_SUBDIR)/doc/gmp.info*
 	touch $(GMP_SUBDIR)/demos/calc/calc*.c
-	cd $(GMP_BUILD_DIR) && $(GMP_SUBDIR)/configure CC='$(CC)' CFLAGS='$(CFLAGS) $(CHPL_GMP_CFLAGS)' CXX='$(CXX)' CXXFLAGS='$(CXXFLAGS) $(CHPL_GMP_CXXFLAGS)' $(CHPL_GMP_ABI_ARG) --prefix=$(GMP_INSTALL_DIR) $(CHPL_GMP_CFG_OPTIONS)
+	cd $(GMP_BUILD_DIR) && $(GMP_SUBDIR)/configure CC_FOR_BUILD='$(HOST_CC)' CC='$(CC)' CFLAGS='$(CFLAGS) $(CHPL_GMP_CFLAGS)' CXX='$(CXX)' CXXFLAGS='$(CXXFLAGS) $(CHPL_GMP_CXXFLAGS)' $(CHPL_GMP_ABI_ARG) --prefix=$(GMP_INSTALL_DIR) $(CHPL_GMP_CFG_OPTIONS)
 	cd $(GMP_BUILD_DIR) && $(MAKE)
 ifeq ($(GMP_CROSS_COMPILED),no)
 	cd $(GMP_BUILD_DIR) && $(MAKE) check


### PR DESCRIPTION
This fixes GMP build issues when cross-compiling (for example when
building on a Cray with the craype-broadwell CPU targeting module on a
sandybridge login node.)

GMP has a `CC_FOR_BUILD` parameter. From the docs:
"""
Some build-time programs are compiled and run to generate host-specific
data tables. ‘CC_FOR_BUILD’ is the compiler used for this. It doesn’t
need to be in any particular ABI or mode, it merely needs to generate
executables that can run.
"""

We weren't aware of this before, but ran into some issues when trying to
cross-compile that exposed this. Since GMP will compile/run programs on
the host/build/login node, set `CC_FOR_BUILD` to `CHPL_HOST_COMPILER`.