### PR TITLE
Make object files generated by LLVM respect CHPL_LIB_PIC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ TAGS
 tags
 *.DS_Store
 *.vagrant
-cscope.out
 
 
 # Top level ignores.

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ TAGS
 tags
 *.DS_Store
 *.vagrant
+cscope.out
 
 
 # Top level ignores.

--- a/compiler/include/driver.h
+++ b/compiler/include/driver.h
@@ -168,6 +168,8 @@ enum { LS_DEFAULT=0, LS_STATIC, LS_DYNAMIC };
 
 extern int  fLinkStyle;
 
+extern bool fGeneratePIC;
+
 extern int  debugParserLevel;
 extern int  debugShortLoc;
 extern bool fLibraryCompile;

--- a/compiler/include/driver.h
+++ b/compiler/include/driver.h
@@ -117,6 +117,7 @@ extern const char* CHPL_REGEXP;
 extern const char* CHPL_LLVM;
 extern const char* CHPL_AUX_FILESYS;
 extern const char* CHPL_UNWIND;
+extern const char* CHPL_LIB_PIC;
 extern const char* CHPL_RUNTIME_SUBDIR;
 extern const char* CHPL_LAUNCHER_SUBDIR;
 extern const char* CHPL_LLVM_UNIQ_CFG_PATH;
@@ -167,8 +168,6 @@ extern int breakOnCodegenID;
 enum { LS_DEFAULT=0, LS_STATIC, LS_DYNAMIC };
 
 extern int  fLinkStyle;
-
-extern bool fGeneratePIC;
 
 extern int  debugParserLevel;
 extern int  debugShortLoc;

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -1581,6 +1581,7 @@ void runClang(const char* just_parse_filename) {
   const char* clang_opt = "-O3";
   const char* clang_fast_float = "-ffast-math";
   const char* clang_ieee_float = "-fno-fast-math";
+  const char* clang_fpic = "-fPIC";
 
   std::vector<std::string> args;
   std::vector<std::string> clangCCArgs;
@@ -1679,6 +1680,8 @@ void runClang(const char* just_parse_filename) {
 
   if (ffloatOpt < 0) // --ieee-float
     args.push_back(clang_ieee_float); // -fno-fast-math
+
+  // Generate object files as PIC if appropriate.
 
   // Gather information from readargsfrom into clangArgs.
 

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2771,6 +2771,12 @@ void makeBinaryLLVM(void) {
   }
 #endif
 
+  // Make sure that we are generating PIC when we need to be.
+  if (fGeneratePIC) {
+    INT_ASSERT(info->targetMachine->getRelocationModel()
+        == llvm::Reloc::Model::PIC_);
+  }
+
   // Emit the .o file for linking with clang
   // Setup and run LLVM passes to emit a .o file to outputOfile
   {

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -1304,10 +1304,8 @@ static void setupModule()
   }
 
   llvm::Reloc::Model relocModel = llvm::Reloc::Model::Static;
-  // TODO: we may need to use Reloc::PIC_ once we start
-  // interpreting, etc.
-  // Indeed we do!
-  if (fGeneratePIC) {
+  
+  if (strcmp(CHPL_LIB_PIC, "pic") == 0) {
     relocModel = llvm::Reloc::Model::PIC_;
   }
 
@@ -2772,7 +2770,7 @@ void makeBinaryLLVM(void) {
 #endif
 
   // Make sure that we are generating PIC when we need to be.
-  if (fGeneratePIC) {
+  if (strcmp(CHPL_LIB_PIC, "pic") == 0) {
     INT_ASSERT(info->targetMachine->getRelocationModel()
         == llvm::Reloc::Model::PIC_);
   }

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -1306,6 +1306,10 @@ static void setupModule()
   llvm::Reloc::Model relocModel = llvm::Reloc::Model::Static;
   // TODO: we may need to use Reloc::PIC_ once we start
   // interpreting, etc.
+  // Indeed we do!
+  if (fGeneratePIC) {
+    relocModel = llvm::Reloc::Model::PIC_;
+  }
 
   // Choose the code model
 #if HAVE_LLVM_VER >= 60
@@ -1581,7 +1585,6 @@ void runClang(const char* just_parse_filename) {
   const char* clang_opt = "-O3";
   const char* clang_fast_float = "-ffast-math";
   const char* clang_ieee_float = "-fno-fast-math";
-  const char* clang_fpic = "-fPIC";
 
   std::vector<std::string> args;
   std::vector<std::string> clangCCArgs;
@@ -1680,8 +1683,6 @@ void runClang(const char* just_parse_filename) {
 
   if (ffloatOpt < 0) // --ieee-float
     args.push_back(clang_ieee_float); // -fno-fast-math
-
-  // Generate object files as PIC if appropriate.
 
   // Gather information from readargsfrom into clangArgs.
 

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -1307,7 +1307,7 @@ static void setupChplGlobals(const char* argv0) {
     // Keep envMap updated
     envMap["CHPL_HOME"] = CHPL_HOME;
 
-~  }
+  }
 
   // tell printchplenv that we're doing an LLVM build
   if (llvmCodegen) {

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -1306,7 +1306,6 @@ static void setupChplGlobals(const char* argv0) {
 
     // Keep envMap updated
     envMap["CHPL_HOME"] = CHPL_HOME;
-
   }
 
   // tell printchplenv that we're doing an LLVM build
@@ -1322,7 +1321,7 @@ static void setupChplGlobals(const char* argv0) {
 }
 
 static void postSetGeneratePIC() {
-  fGeneratePIC = strcmp(CHPL_LIB_PIC, "pic") == 0;
+  fGeneratePIC = (strcmp(CHPL_LIB_PIC, "pic") == 0);
 }
 
 static void postStackCheck() {

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -90,6 +90,7 @@ const char* CHPL_REGEXP = NULL;
 const char* CHPL_LLVM = NULL;
 const char* CHPL_AUX_FILESYS = NULL;
 const char* CHPL_UNWIND = NULL;
+const char* CHPL_LIB_PIC = NULL;
 
 const char* CHPL_RUNTIME_SUBDIR = NULL;
 const char* CHPL_LAUNCHER_SUBDIR = NULL;

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -110,6 +110,9 @@ bool fLibraryFortran = false;
 bool fLibraryMakefile = false;
 bool fLibraryPython = false;
 
+// We need to inform LLVM codegen about PIC being set.
+bool fGeneratePIC = false;
+
 bool no_codegen = false;
 int  debugParserLevel = 0;
 bool fVerify = false;
@@ -1278,6 +1281,7 @@ static void setChapelEnvs() {
   CHPL_LLVM            = envMap["CHPL_LLVM"];
   CHPL_AUX_FILESYS     = envMap["CHPL_AUX_FILESYS"];
   CHPL_UNWIND          = envMap["CHPL_UNWIND"];
+  CHPL_LIB_PIC         = envMap["CHPL_LIB_PIC"];
 
   CHPL_RUNTIME_SUBDIR  = envMap["CHPL_RUNTIME_SUBDIR"];
   CHPL_LAUNCHER_SUBDIR = envMap["CHPL_LAUNCHER_SUBDIR"];
@@ -1302,7 +1306,8 @@ static void setupChplGlobals(const char* argv0) {
 
     // Keep envMap updated
     envMap["CHPL_HOME"] = CHPL_HOME;
-  }
+
+~  }
 
   // tell printchplenv that we're doing an LLVM build
   if (llvmCodegen) {
@@ -1314,6 +1319,10 @@ static void setupChplGlobals(const char* argv0) {
 
   // Set global CHPL_vars with updated envMap values
   setChapelEnvs();
+}
+
+static void postSetGeneratePIC() {
+  fGeneratePIC = strcmp(CHPL_LIB_PIC, "pic") == 0;
 }
 
 static void postStackCheck() {
@@ -1408,6 +1417,8 @@ static void postprocess_args() {
   postLocal();
 
   postVectorize();
+
+  postSetGeneratePIC();
 
   postTaskTracking();
 

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -110,9 +110,6 @@ bool fLibraryFortran = false;
 bool fLibraryMakefile = false;
 bool fLibraryPython = false;
 
-// We need to inform LLVM codegen about PIC being set.
-bool fGeneratePIC = false;
-
 bool no_codegen = false;
 int  debugParserLevel = 0;
 bool fVerify = false;
@@ -1320,10 +1317,6 @@ static void setupChplGlobals(const char* argv0) {
   setChapelEnvs();
 }
 
-static void postSetGeneratePIC() {
-  fGeneratePIC = (strcmp(CHPL_LIB_PIC, "pic") == 0);
-}
-
 static void postStackCheck() {
   if (!fNoStackChecks && fUserSetStackChecks) {
     if (strcmp(CHPL_TASKS, "massivethreads") == 0) {
@@ -1416,8 +1409,6 @@ static void postprocess_args() {
   postLocal();
 
   postVectorize();
-
-  postSetGeneratePIC();
 
   postTaskTracking();
 


### PR DESCRIPTION
This PR attempts to address an internal issue about LLVM not generating PIC when `CHPL_LIB_PIC=pic`. 

The code is simple enough. Admittedly, most of my time was spent trying to figure out what was going on (thanks @mppf for that). 

@ronawho Thanks for pointing out that `gsl_demo` is a known failure when Chapel is built with LLVM support (even if not compiling with `--llvm`).

https://github.com/chapel-lang/chapel/issues/9209#issuecomment-452407049

Sorry about not listing tests!

**Testing:**

- [x] On `linux64` when `CHPL_LLVM=none`
- [x] On `linux64` when `CHPL_LLVM=llvm`

