### PR TITLE
Update CLA docs about chapel-contributors invite

### DIFF
--- a/doc/rst/developer/contributorAgreements/README.md
+++ b/doc/rst/developer/contributorAgreements/README.md
@@ -22,5 +22,5 @@ Once completed, CLAs should be scanned as PDFs and mailed to:
 **chapel<!---deleteme-->_admin<!---deleteme-->@<!---deleteme-->cray.com**
 along with your GitHub ID.
 
-Once your CLA is received and processed, you should receive a GitHub invitation
-to the @chapel-lang/chapel-contributors team.
+Once your CLA is received and processed, you should receive a confirmation
+email and a GitHub invitation to the @chapel-lang/chapel-contributors team.

--- a/doc/rst/developer/contributorAgreements/README.md
+++ b/doc/rst/developer/contributorAgreements/README.md
@@ -21,3 +21,6 @@ There are two versions:
 Once completed, CLAs should be scanned as PDFs and mailed to:
 **chapel<!---deleteme-->_admin<!---deleteme-->@<!---deleteme-->cray.com**
 along with your GitHub ID.
+
+Once your CLA is received and processed, you should receive a GitHub invitation
+to the @chapel-lang/chapel-contributors team.


### PR DESCRIPTION
Let users know they should expect an invitation to chapel-contributors upon their CLA being processed.

Sometimes contributors do not notice this invitation for a while, so I think it seems useful to let them know about it in the documentation.