### PR TITLE
Support the "--library-makefile" flag when compiling with LLVM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ TAGS
 tags
 *.DS_Store
 *.vagrant
-cscope.out
 
 
 # Top level ignores.

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ TAGS
 tags
 *.DS_Store
 *.vagrant
+cscope.out
 
 
 # Top level ignores.

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -2347,7 +2347,6 @@ void codegen() {
     codegen_makefile(&mainfile, NULL, false, userFileName);
   }
 
-  // Users of "--llvm" might enjoy a Makefile too!
   if (fLibraryCompile && fLibraryMakefile) {
     codegen_library_makefile();
   }

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -2345,9 +2345,11 @@ void codegen() {
     }
 
     codegen_makefile(&mainfile, NULL, false, userFileName);
-    if (fLibraryCompile && fLibraryMakefile) {
-      codegen_library_makefile();
-    }
+  }
+
+  // Users of "--llvm" might enjoy a Makefile too!
+  if (fLibraryCompile && fLibraryMakefile) {
+    codegen_library_makefile();
   }
 
   // Vectors to store different symbol names to be used while generating header

--- a/compiler/codegen/library.cpp
+++ b/compiler/codegen/library.cpp
@@ -230,19 +230,16 @@ static void printMakefileLibraries(fileinfo makefile, std::string name) {
 
   if (!llvmCodegen) {
     fprintf(makefile.fptr, " %s\n", libraries.c_str());
-    return;
-  }
-  
-  // LLVM requires a bit more work to make the GNU linker happy.
-  if (libraries.size() > 0 && *libraries.rbegin() == '\n') {
-    libraries.erase(libraries.end() -1);
-  }
+  } else { 
+    // LLVM requires a bit more work to make the GNU linker happy.
+    if (libraries.size() > 0 && *libraries.rbegin() == '\n') {
+      libraries.erase(libraries.end() -1);
+    }
 
-  // Append the Chapel library as the last linker argument.
-  fprintf(makefile.fptr, " %s %s\n\n", libraries.c_str(), libname.c_str());
+    // Append the Chapel library as the last linker argument.
+    fprintf(makefile.fptr, " %s %s\n\n", libraries.c_str(), libname.c_str());
+  }
 }
-
-
 
 const char* getLibraryExtension() {
   if (fLibraryCompile) {

--- a/compiler/codegen/library.cpp
+++ b/compiler/codegen/library.cpp
@@ -230,7 +230,7 @@ static void printMakefileLibraries(fileinfo makefile, std::string name) {
 
   if (!llvmCodegen) {
     fprintf(makefile.fptr, " %s\n", libraries.c_str());
-  } else { 
+  } else {
     // LLVM requires a bit more work to make the GNU linker happy.
     if (libraries.size() > 0 && *libraries.rbegin() == '\n') {
       libraries.erase(libraries.end() -1);

--- a/compiler/codegen/library.cpp
+++ b/compiler/codegen/library.cpp
@@ -228,9 +228,9 @@ static void printMakefileLibraries(fileinfo makefile, std::string name) {
     fprintf(makefile.fptr, "%s", requires.c_str());
   }
 
-  // For the GNU linker workaround below.
-  if (libraries.back() == '\n') {
-    libraries.pop_back();
+  // Erase trailing newline if needed for the workaround below.
+  if (libraries.size() > 0 && *libraries.rbegin() == '\n') {
+    libraries.erase(libraries.end() - 1);
   }
 
   fprintf(makefile.fptr, " %s", libraries.c_str());

--- a/compiler/codegen/library.cpp
+++ b/compiler/codegen/library.cpp
@@ -132,6 +132,7 @@ void codegen_library_makefile() {
     // "lib"
     name = executableFilename;
   }
+
   fileinfo makefile;
   openLibraryHelperFile(&makefile, "Makefile", name.c_str());
 
@@ -226,7 +227,16 @@ static void printMakefileLibraries(fileinfo makefile, std::string name) {
   if (requires != "") {
     fprintf(makefile.fptr, "%s", requires.c_str());
   }
-  fprintf(makefile.fptr, " %s\n", libraries.c_str());
+
+  // For the GNU linker workaround below.
+  if (libraries.back() == '\n') {
+    libraries.pop_back();
+  }
+
+  fprintf(makefile.fptr, " %s", libraries.c_str());
+
+  // GNU linker won't be able to see config symbols without this.
+  fprintf(makefile.fptr, " %s\n\n", libname.c_str());
 }
 
 const char* getLibraryExtension() {

--- a/compiler/codegen/library.cpp
+++ b/compiler/codegen/library.cpp
@@ -228,16 +228,21 @@ static void printMakefileLibraries(fileinfo makefile, std::string name) {
     fprintf(makefile.fptr, "%s", requires.c_str());
   }
 
-  // Erase trailing newline if needed for the workaround below.
+  if (!llvmCodegen) {
+    fprintf(makefile.fptr, " %s\n", libraries.c_str());
+    return;
+  }
+  
+  // LLVM requires a bit more work to make the GNU linker happy.
   if (libraries.size() > 0 && *libraries.rbegin() == '\n') {
-    libraries.erase(libraries.end() - 1);
+    libraries.erase(libraries.end() -1);
   }
 
-  fprintf(makefile.fptr, " %s", libraries.c_str());
-
-  // GNU linker won't be able to see config symbols without this.
-  fprintf(makefile.fptr, " %s\n\n", libname.c_str());
+  // Append the Chapel library as the last linker argument.
+  fprintf(makefile.fptr, " %s %s\n\n", libraries.c_str(), libname.c_str());
 }
+
+
 
 const char* getLibraryExtension() {
   if (fLibraryCompile) {

--- a/test/interop/C/llvm/makefiles/commandLineLib.bad
+++ b/test/interop/C/llvm/makefiles/commandLineLib.bad
@@ -1,2 +1,0 @@
-Makefile:42: lib/Makefile.commandLineLib: No such file or directory
-make: *** No rule to make target 'lib/Makefile.commandLineLib'.  Stop.

--- a/test/interop/C/llvm/makefiles/commandLineLib.future
+++ b/test/interop/C/llvm/makefiles/commandLineLib.future
@@ -1,1 +1,0 @@
-bug: support --library-makefile with LLVM

--- a/test/interop/C/llvm/makefiles/getMakefile.future
+++ b/test/interop/C/llvm/makefiles/getMakefile.future
@@ -1,1 +1,0 @@
-bug: support --library-makefile with LLVM

--- a/test/interop/C/llvm/makefiles/renamedLib.future
+++ b/test/interop/C/llvm/makefiles/renamedLib.future
@@ -1,1 +1,0 @@
-bug: support --library-makefile with LLVM

--- a/test/interop/C/llvm/makefiles/requireHeader.future
+++ b/test/interop/C/llvm/makefiles/requireHeader.future
@@ -1,1 +1,0 @@
-bug: support --library-makefile with LLVM

--- a/test/interop/C/llvm/makefiles/requireStmt.bad
+++ b/test/interop/C/llvm/makefiles/requireStmt.bad
@@ -1,2 +1,0 @@
-Makefile:22: lib/Makefile.requireStmt: No such file or directory
-make: *** No rule to make target 'lib/Makefile.requireStmt'.  Stop.

--- a/test/interop/C/llvm/makefiles/requireStmt.future
+++ b/test/interop/C/llvm/makefiles/requireStmt.future
@@ -1,1 +1,0 @@
-bug: support --library-makefile with LLVM

--- a/test/interop/C/llvm/noLibFlag/getMakefile.future
+++ b/test/interop/C/llvm/noLibFlag/getMakefile.future
@@ -1,1 +1,0 @@
-bug: support --library-makefile with LLVM


### PR DESCRIPTION
This is a simple fix which moves the branch to generate a Makefile as per `--library-makefile` so that it is common code shared by both backends.

So far all tests in `test/interop/C/llvm/makefiles` have passed, and so I've removed the futures for them.

I've placed the new code in a branch that only fires when `llvmCodegen` is `true`. I've also removed the `bad` and `future` files in `test/interop/C/llvm/makefiles`, and one in `test/interop/C/llvm/noLibFlag`. 

If tests with `CHPL_LLVM=none` and `CHPL_LLVM=llvm` both pass, then I will consider removing them from the `llvm` subdirectory and remove the `CHPL_LLVM=none` from the SKIPIF.

**Testing:**

- [x] All tests on `linux64` when `CHPL_LLVM=none`
- [x] All tests on `linux64` when `CHPL_LLVM=llvm`