### PR TITLE
Add .bad for new failure mode of scope-param-offset-concrete.chpl

### DIFF
--- a/test/types/enum/scope-param-offset-concrete.bad
+++ b/test/types/enum/scope-param-offset-concrete.bad
@@ -1,0 +1,7 @@
+scope-param-offset-concrete.chpl:4: internal error: RES-FUN-ION-6183 chpl version 1.19.0.2c1fa77
+
+Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
+please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
+the filename + line number above may be useful in working around the issue.
+

--- a/test/types/enum/scope-param-offset-concrete.future
+++ b/test/types/enum/scope-param-offset-concrete.future
@@ -1,2 +1,7 @@
 bug: function-scoped enum can't be initialized with global param
 #7681
+
+The error in the .bad file corresponds to this in
+ensureEnumTypeResolved():
+
+test/types/enum/scope-param-offset-concrete.chpl:4: internal error: Unable to resolve enumerator type expression [resolution/functionResolution.cpp:6183]

--- a/test/types/enum/scope-param-offset-concrete.skipif
+++ b/test/types/enum/scope-param-offset-concrete.skipif
@@ -1,1 +1,0 @@
-CHPL_TEST_VGRND_COMP != on


### PR DESCRIPTION
The original failure mode of this part of #7681 was a compiler
segfault.  Due to the segfault manifesting only sporadically, #10166
added a .skipif to test only with valgrind.

The error now seems to be a reliable INT_FATAL(), so add a .bad
file with this error, and remove the .skipif.