### PR TITLE
Update Dockerfiles and README for Chapel Release 1.19.0: Release Branch Only

### DIFF
--- a/util/dockerfiles/Dockerfile
+++ b/util/dockerfiles/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:9.5
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     wget \
@@ -21,12 +21,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     && rm -rf /var/lib/apt/lists/*
 
-ENV CHPL_VERSION master
+ENV CHPL_VERSION 1.19.0
 ENV CHPL_HOME    /opt/chapel/$CHPL_VERSION
 ENV CHPL_GMP     system
 
 RUN mkdir -p /opt/chapel \
-    && wget -q -O - https://github.com/chapel-lang/chapel/archive/$CHPL_VERSION.tar.gz | tar -xzC /opt/chapel --transform 's/chapel-//' \
+    && wget -q -O - https://github.com/chapel-lang/chapel/releases/download/$CHPL_VERSION/chapel-$CHPL_VERSION.tar.gz | tar -xzC /opt/chapel --transform 's/chapel-//' \
     && make -C $CHPL_HOME \
     && make -C $CHPL_HOME chpldoc test-venv mason \
     && make -C $CHPL_HOME cleanall

--- a/util/dockerfiles/README.md
+++ b/util/dockerfiles/README.md
@@ -11,19 +11,17 @@
 
 ## `chapel/chapel:<version>`
 Supported Chapel versions:
-* [`1.17.1`, `latest` (_1.17.1/Dockerfile_)](https://github.com/chapel-lang/chapel/blob/release/1.17/util/dockerfiles/Dockerfile/)
-* [`1.17.0` (_1.17.0/Dockerfile_)](https://github.com/chapel-lang/chapel/blob/release/1.17/util/dockerfiles/1.17.0/Dockerfile/)
-* [`1.16.0` (_1.16.0/Dockerfile_)](https://github.com/chapel-lang/chapel/blob/master/util/dockerfiles/1.16.0/Dockerfile/)
-* [`1.15.0` (_1.15.0/Dockerfile_)](https://github.com/chapel-lang/chapel/blob/master/util/dockerfiles/1.15.0/Dockerfile/)
+* [`1.19.0`, `latest` (_1.19.0/Dockerfile_)](https://github.com/chapel-lang/chapel/blob/release/1.19/util/dockerfiles/Dockerfile/)
+* [`1.18.0` (_1.18.0/Dockerfile_)](https://github.com/chapel-lang/chapel/blob/release/1.18/util/dockerfiles/Dockerfile/)
+* [`1.17.1` (_1.17.1/Dockerfile_)](https://github.com/chapel-lang/chapel/blob/release/1.17/util/dockerfiles/Dockerfile/)
 
 This is the core image for Chapel. It provides the complete Chapel compiler and runtime.  It can be used to compile and run Chapel programs inside the Docker container. On 64-bit Linux hosts, the compiled Chapel program binary can sometimes be executed outside the container (your mileage may vary). Other Chapel-based Docker images can be created from this image.
 
 ## [`chapel/chapel-gasnet:<version>`](https://hub.docker.com/r/chapel/chapel-gasnet/)
 
-* [`1.17.1`, `latest` (_1.17.1/gasnet/Dockerfile_)](https://github.com/chapel-lang/chapel/blob/release/1.17/util/dockerfiles/gasnet/Dockerfile/)
-* [`1.17.0` (_1.17.0/gasnet/Dockerfile_)](https://github.com/chapel-lang/chapel/blob/release/1.17/util/dockerfiles/1.17.0/gasnet/Dockerfile/)
-* [`1.16.0` (_1.16.0/gasnet/Dockerfile_)](https://github.com/chapel-lang/chapel/blob/master/util/dockerfiles/1.16.0/gasnet/Dockerfile/)
-* [`1.15.0` (_1.15.0/gasnet/Dockerfile_)](https://github.com/chapel-lang/chapel/blob/master/util/dockerfiles/1.15.0/gasnet/Dockerfile/)
+* [`1.19.0`, `latest` (_1.19.0/gasnet/Dockerfile_)](https://github.com/chapel-lang/chapel/blob/release/1.19/util/dockerfiles/gasnet/Dockerfile/)
+* [`1.18.0` (_1.18.0/gasnet/Dockerfile_)](https://github.com/chapel-lang/chapel/blob/release/1.18/util/dockerfiles/gasnet/Dockerfile/)
+* [`1.17.1` (_1.17.1/gasnet/Dockerfile_)](https://github.com/chapel-lang/chapel/blob/release/1.17/util/dockerfiles/gasnet/Dockerfile/)
 
 The Chapel core image (above), rebuilt with `CHPL_COMM=gasnet` and `GASNET_SPAWNFN=L`. Simulates a multilocale Chapel platform within the Docker container.
 
@@ -70,12 +68,12 @@ Hello, world!
 # Documentation
 
 Chapel's documentation is [available online](https://chapel-lang.org/docs/).
-Documentation for a specific release is also available: [1.16](https://chapel-lang.org/docs/1.16/), [1.15](https://chapel-lang.org/docs/1.15/).
+Documentation for a specific release is also available: [1.18](https://chapel-lang.org/docs/1.18/), [1.17](https://chapel-lang.org/docs/1.17/).
 
 # License
 
 View [license information](https://chapel-lang.org/license.html) for the software contained in this image.
 
-# User Feedback
+# For More Information
 
-If you have any questions about or problems with this image, please write to the [Chapel developers mailing list](https://lists.sourceforge.net/lists/listinfo/chapel-developers). To post a message to all the list members, send email to [chapel-developers@lists.sourceforge.net](mailto:chapel-developers@lists.sourceforge.net). You may also be interested in other [Chapel resources for developers](https://chapel-lang.org/developers.html), including the `#chapel-developers` IRC channel on Freenode.
+Please visit Chapel's [Home Page](https://chapel-lang.org/)

--- a/util/dockerfiles/README.md
+++ b/util/dockerfiles/README.md
@@ -13,7 +13,6 @@
 Supported Chapel versions:
 * [`1.19.0`, `latest` (_1.19.0/Dockerfile_)](https://github.com/chapel-lang/chapel/blob/release/1.19/util/dockerfiles/Dockerfile/)
 * [`1.18.0` (_1.18.0/Dockerfile_)](https://github.com/chapel-lang/chapel/blob/release/1.18/util/dockerfiles/Dockerfile/)
-* [`1.17.1` (_1.17.1/Dockerfile_)](https://github.com/chapel-lang/chapel/blob/release/1.17/util/dockerfiles/Dockerfile/)
 
 This is the core image for Chapel. It provides the complete Chapel compiler and runtime.  It can be used to compile and run Chapel programs inside the Docker container. On 64-bit Linux hosts, the compiled Chapel program binary can sometimes be executed outside the container (your mileage may vary). Other Chapel-based Docker images can be created from this image.
 
@@ -21,7 +20,6 @@ This is the core image for Chapel. It provides the complete Chapel compiler and 
 
 * [`1.19.0`, `latest` (_1.19.0/gasnet/Dockerfile_)](https://github.com/chapel-lang/chapel/blob/release/1.19/util/dockerfiles/gasnet/Dockerfile/)
 * [`1.18.0` (_1.18.0/gasnet/Dockerfile_)](https://github.com/chapel-lang/chapel/blob/release/1.18/util/dockerfiles/gasnet/Dockerfile/)
-* [`1.17.1` (_1.17.1/gasnet/Dockerfile_)](https://github.com/chapel-lang/chapel/blob/release/1.17/util/dockerfiles/gasnet/Dockerfile/)
 
 The Chapel core image (above), rebuilt with `CHPL_COMM=gasnet` and `GASNET_SPAWNFN=L`. Simulates a multilocale Chapel platform within the Docker container.
 
@@ -68,7 +66,7 @@ Hello, world!
 # Documentation
 
 Chapel's documentation is [available online](https://chapel-lang.org/docs/).
-Documentation for a specific release is also available: [1.18](https://chapel-lang.org/docs/1.18/), [1.17](https://chapel-lang.org/docs/1.17/).
+Documentation for a specific release is also available: [1.18](https://chapel-lang.org/docs/1.18/).
 
 # License
 

--- a/util/dockerfiles/gasnet/Dockerfile
+++ b/util/dockerfiles/gasnet/Dockerfile
@@ -1,4 +1,4 @@
-FROM chapel/chapel-master:latest
+FROM chapel/chapel:latest
 
 ENV CHPL_COMM gasnet
 


### PR DESCRIPTION
Updated Dockerfiles and README file to be consistent with previous release of 1.18.0.  Updated version to 1.19.0 and kept references to current and 2 previous releases.  