### PR TITLE
Update docs button to reflect staged 1.19 docs

### DIFF
--- a/doc/util/versionButton.php
+++ b/doc/util/versionButton.php
@@ -89,7 +89,7 @@ if (pagePath == "") {
 function dropSetup() {
   var currentRelease = "1.18"; // what does the public have?
   var stagedRelease = "1.19";  // is there a release staged but not yet public?
-  var nextRelease = "1.19";    // what's the next release? (on docs/master)
+  var nextRelease = "1.20";    // what's the next release? (on docs/master)
   var button = document.getElementById("versionButton");
   // Uses unicode down-pointing triangle
   var arrow = " &#9660;";


### PR DESCRIPTION
I've just pushed a snapshot of the 1.19 documentation to the website
which lets us redefine 'docs/master' as 1.20.  I think this is the
first time I've done this update since improving the button's
organization last release, so have fingers crossed that it works as
designed.