### PR TITLE
Update version of docs/master to be 1.20

### DIFF
--- a/doc/rst/conf.py
+++ b/doc/rst/conf.py
@@ -60,12 +60,12 @@ master_doc = 'index'
 # 'version' adds a redundant version number onto the top of the sidebar
 # automatically (rtd-theme). We also don't use |version| anywhere in rst
 
-chplversion = '1.19'                  # TODO -- parse from `chpl --version`
+chplversion = '1.20'                  # TODO -- parse from `chpl --version`
 shortversion = chplversion.replace('-', '&#8209') # prevent line-break at hyphen, if any
 html_context = {"chplversion":chplversion}
 
 # The full version, including alpha/beta/rc tags.
-release = '1.19.0'
+release = '1.20.0 (pre-release)'
 
 # General information about the project.
 project = u'Chapel Documentation'


### PR DESCRIPTION
This should really have gone in with my previous commit to
versionButton.php...  Tony and I were still getting the dance
w.r.t. these files correct in the last release and I forgot about the
dependence between the version that was embedded in the docs by this
configuration file.