### PR TITLE
Close leaks in 'overloading' test

### DIFF
--- a/test/classes/initializers/generics/overloading.chpl
+++ b/test/classes/initializers/generics/overloading.chpl
@@ -22,7 +22,7 @@ class D : C {
   }
 }
 
-var d:unmanaged C = new unmanaged D(4);
+var d: C = new D(4);
 
 writeln(d.bbox(1));
 writeln(d.bbox(2));


### PR DESCRIPTION
Switch from `unmanaged` to default allocation/free.
