### PR TITLE
Add warning about HDFS modules

### DIFF
--- a/modules/packages/HDFS.chpl
+++ b/modules/packages/HDFS.chpl
@@ -21,6 +21,14 @@
 
 Support for Hadoop Distributed Filesystem
 
+.. warning::
+
+  This module is currently not working. See
+  `#12627 <https://github.com/chapel-lang/chapel/issues/12627>`_
+  to track progress.
+
+
+
 This module implements support for the
 `Hadoop <http://hadoop.apache.org/>`_
 `Distributed Filesystem <http://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-hdfs/HdfsUserGuide.html>`_ (HDFS).

--- a/modules/packages/HDFSiterator.chpl
+++ b/modules/packages/HDFSiterator.chpl
@@ -20,6 +20,12 @@
 /*
    Iterators for distributed iteration over Hadoop Distributed Filesystem
 
+   .. warning::
+
+     This module is currently not working. See
+     `#12627 <https://github.com/chapel-lang/chapel/issues/12627>`_
+     to track progress.
+
    Iterators that can iterate over distributed data in an HDFS filesystem
    in a distributed manner. See :mod:`HDFS`.
  */


### PR DESCRIPTION
HDFS & HDFSIterator modules are not going to be working until they are migrated over to the new IO plugin.

This adds a warning to the top of each module doc pointing to https://github.com/chapel-lang/chapel/issues/12627 for progress updates.