### PR TITLE
Fix problem with cast from real to bool with --llvm

### DIFF
--- a/compiler/codegen/expr.cpp
+++ b/compiler/codegen/expr.cpp
@@ -2990,20 +2990,15 @@ GenRet codegenCast(Type* t, GenRet value, bool Cparens)
     // cast. Engin
     if(info->cfile) {
       return codegenNotEquals(value, codegenZero());
-    }
-    else {
+    } else {
 #ifdef HAVE_LLVM
+      GenRet notZero = codegenNotEquals(value, codegenZero());
+
+      // convert the i1 result into an i8 (or appropriate bool width)
       llvm::Type* castType = t->codegen().type;
-
-      llvm::IntegerType* castTypeInt =
-        llvm::dyn_cast<llvm::IntegerType>(castType);
-
-      llvm::IntegerType* valueTypeInt =
-        llvm::dyn_cast<llvm::IntegerType>(value.val->getType());
-
-      if(castTypeInt->getBitWidth() < valueTypeInt->getBitWidth()) {
-        return codegenNotEquals(value, codegenZero());
-      }
+      ret.val = convertValueToType(notZero.val, castType, !ret.isUnsigned);
+      INT_ASSERT(ret.val);
+      return ret;
 #endif
     }
   }

--- a/test/users/ferguson/castrealbool.chpl
+++ b/test/users/ferguson/castrealbool.chpl
@@ -1,0 +1,8 @@
+var zero = 0:real(64);
+var one = 1:real(64);
+
+var zeroBool = zero:bool;
+var oneBool = one:bool;
+
+writeln(zeroBool);
+writeln(oneBool);

--- a/test/users/ferguson/castrealbool.good
+++ b/test/users/ferguson/castrealbool.good
@@ -1,0 +1,2 @@
+false
+true


### PR DESCRIPTION
Addresses a problem with programs like this:

``` chapel
var x = 1:real(64);
var y = x:bool;
writeln(y);
```

These would cause the compiler to core-dump with --llvm.

Adds a similar test to make sure this failure does not reappear.

- [x] full local --llvm testing
- [x] full local testing

Reviewed by @dmk42 - thanks!