### PR TITLE
Updates to futures for recent commits

### DIFF
--- a/test/classes/bradc/syncAsClass3.bad
+++ b/test/classes/bradc/syncAsClass3.bad
@@ -1,0 +1,1 @@
+syncAsClass3.chpl:5: error: Cannot assign to object from _syncvar(int(64))

--- a/test/classes/bradc/syncAsClass3.good
+++ b/test/classes/bradc/syncAsClass3.good
@@ -1,1 +1,1 @@
-syncAsClass3.chpl:5: error: Cannot assign to object from _syncvar(int(64))
+syncAsClass3.chpl:5: error: Cannot assign to object from sync int(64)

--- a/test/classes/deitz/class/infer_nil.bad
+++ b/test/classes/deitz/class/infer_nil.bad
@@ -1,1 +1,1 @@
-infer_nil.chpl:6: error: type mismatch in assignment from C to nil
+infer_nil.chpl:6: error: Cannot assign to nil from C

--- a/test/classes/vass/no-instance-for-arg-type.bad
+++ b/test/classes/vass/no-instance-for-arg-type.bad
@@ -1,4 +1,4 @@
-internal error: RES-FUN-ION-nnnn chpl version mmmm
+internal error: RES-CLE-UPS-nnnn chpl version mmmm
 
 Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
 and we're sorry for the hassle.  We would appreciate your reporting this bug -- 

--- a/test/expressions/bradc/reduceVsMathPrec2.bad
+++ b/test/expressions/bradc/reduceVsMathPrec2.bad
@@ -1,0 +1,1 @@
+reduceVsMathPrec2.chpl:12: error: Cannot assign to int(64) from _ir_chpl_promo1_*

--- a/test/expressions/bradc/reduceVsMathPrec2.good
+++ b/test/expressions/bradc/reduceVsMathPrec2.good
@@ -1,1 +1,1 @@
-reduceVsMathPrec2.chpl:12: error: Cannot assign to int(64) from _ir_chpl_promo1_*
+reduceVsMathPrec2.chpl:12: error: Cannot assign to int(64) from array

--- a/test/types/tuple/lydia/nonDefaultSize/tupleInt16.bad
+++ b/test/types/tuple/lydia/nonDefaultSize/tupleInt16.bad
@@ -1,2 +1,2 @@
 tupleInt16.chpl:2: error: illegal lvalue in assignment
-tupleInt16.chpl:2: error: type mismatch in assignment from int(64) to int(16)
+tupleInt16.chpl:2: error: Cannot assign to int(16) from int(64)

--- a/test/types/tuple/lydia/nonDefaultSize/tupleInt32.bad
+++ b/test/types/tuple/lydia/nonDefaultSize/tupleInt32.bad
@@ -1,2 +1,2 @@
 tupleInt32.chpl:2: error: illegal lvalue in assignment
-tupleInt32.chpl:2: error: type mismatch in assignment from int(64) to int(32)
+tupleInt32.chpl:2: error: Cannot assign to int(32) from int(64)

--- a/test/types/tuple/lydia/nonDefaultSize/tupleInt8.bad
+++ b/test/types/tuple/lydia/nonDefaultSize/tupleInt8.bad
@@ -1,2 +1,2 @@
 tupleInt8.chpl:2: error: illegal lvalue in assignment
-tupleInt8.chpl:2: error: type mismatch in assignment from int(64) to int(8)
+tupleInt8.chpl:2: error: Cannot assign to int(8) from int(64)

--- a/test/types/tuple/lydia/nonDefaultSize/tupleReal32.bad
+++ b/test/types/tuple/lydia/nonDefaultSize/tupleReal32.bad
@@ -1,2 +1,2 @@
 tupleReal32.chpl:2: error: illegal lvalue in assignment
-tupleReal32.chpl:2: error: type mismatch in assignment from real(64) to real(32)
+tupleReal32.chpl:2: error: Cannot assign to real(32) from real(64)


### PR DESCRIPTION
* update .bad files for the change in #12596
```
    test/types/tuple/lydia/nonDefaultSize/tupleInt16.bad
    test/types/tuple/lydia/nonDefaultSize/tupleInt32.bad
    test/types/tuple/lydia/nonDefaultSize/tupleInt8.bad
    test/types/tuple/lydia/nonDefaultSize/tupleReal32.bad
```
* these futures unintentionally pass since #12596 - reverting that
  adding .bad while there
```
    test/classes/bradc/syncAsClass3.bad
    test/classes/bradc/syncAsClass3.good
    test/expressions/bradc/reduceVsMathPrec2.bad
    test/expressions/bradc/reduceVsMathPrec2.good
```
* changed location of internal error due to moved code in #12602
```
    test/classes/vass/no-instance-for-arg-type.bad
```