### PR TITLE
Eliminate remaining user leaks of 'class C'

### DIFF
--- a/test/distributions/privatization/runtime/loopAccessesAndModifiesPrivatized.chpl
+++ b/test/distributions/privatization/runtime/loopAccessesAndModifiesPrivatized.chpl
@@ -46,7 +46,6 @@ for (i, first) in zip(A, First) {
     }
 
     sum += c.i + one.i;
-
   }
 }
 

--- a/test/distributions/privatization/runtime/loopAccessesAndModifiesPrivatized.chpl
+++ b/test/distributions/privatization/runtime/loopAccessesAndModifiesPrivatized.chpl
@@ -46,6 +46,7 @@ for (i, first) in zip(A, First) {
     }
 
     sum += c.i + one.i;
+
   }
 }
 
@@ -65,3 +66,5 @@ for i in A {
     clearPrivatized(i);
   }
 }
+
+delete valueOne;

--- a/test/memory/hilde/memLeaksByDesc.skipif
+++ b/test/memory/hilde/memLeaksByDesc.skipif
@@ -1,0 +1,1 @@
+CHPL_MEM_LEAK_TESTING == true


### PR DESCRIPTION
This addresses the primary remaining cases of 'class C' leaks.
In one case, it closes a leak by freeing an unmanaged class.
In the other, the test is leaking on purpose, so skip this test
for memleaks testing.

The only other one I'm aware of is `expiring-value-alias.chpl`
which Michael addressed in PR #12645.