### PR TITLE
Support the "--library-python" flag when compiling with LLVM

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -2452,10 +2452,10 @@ void makeBinary(void) {
                                makeflags,
                                getIntermediateDirName(), "/Makefile");
     mysystem(command, "compiling generated source");
+  }
 
-    if (fLibraryCompile && fLibraryPython) {
-      codegen_make_python_module();
-    }
+  if (fLibraryCompile && fLibraryPython) {
+    codegen_make_python_module();
   }
 }
 

--- a/compiler/codegen/library.cpp
+++ b/compiler/codegen/library.cpp
@@ -686,6 +686,12 @@ void codegen_make_python_module() {
   fullCythonCall += " CFLAGS=\"" + cFlags + requireIncludes + " " + includes;
   fullCythonCall += "\" LDFLAGS=\"-L. " + name + requireLibraries;
   fullCythonCall += " " + libraries;
+
+  // We might be using the GNU linker, in which case we need to do this.
+  if (llvmCodegen) {
+    fullCythonCall += " " + name;
+  }
+
   fullCythonCall +=  "\" " + cythonPortion;
 
   std::string chdirIn = "cd ";


### PR DESCRIPTION
Similarly to #12620, this PR enables the `--library-python` flag when `CHPL_LLVM=llvm`.

This felt a bit _too easy_, so let me know if there's anything that I'm missing.

**A big caveat**: the tests in `test/interop/python` only pass when compiled against the C backend `--no-llvm`. When the `--llvm` flag is set, most tests fail with segfaults or memory exhaustion. This is possibly related to an internal issue regarding C interop and opaque arrays. See #12661 for details.

**Testing**:
- [x] `interop/python` on `darwin` when `CHPL_LLVM=llvm`
- [x] `interop/python` on `darwin` when `CHPL_LLVM=none`
- [x] `ALL` on `linux64` when `CHPL_LLVM=llvm`
- [x] `ALL` on `linux64` when `CHPL_LLVM=none`

**Fails**:
- `interop/python` on `darwin` when `CHPL_LLVM=llvm` and `start_test --compopts --llvm`

(I'll check off the boxes as I get cython/numpy set up on linux64).