### PR TITLE
Ignore exclusive jobs that have a delayed start time in paratest.chapcs

### DIFF
--- a/util/test/paratest.chapcs
+++ b/util/test/paratest.chapcs
@@ -52,18 +52,18 @@ def expand_hostnames(hostname):
 
 def get_exclusive_nodes():
     """
-    Get the nodes reserved exclusively on the chapel partition. Returns tuple
-    of (num_exclusive_nodes, exclusive_hostnames)
+    Get nodes requested for immediate exclusive access on the chapel partition.
+    Returns tuple of (num_exclusive_nodes, exclusive_hostnames)
     """
-    # Grab "OVER_SUBSCRIBE;NODES;NODELIST;REQ_NODES" info for all jobs. For
-    # each non-shared (OVER_SUBSCRIBE!=YES) job, track the allocated/requested
-    # nodes or the number of nodes requested if no specific nodes were
-    # allocated/requested. Also consider "draining" nodes as exclusively
-    # reserved since no other jobs will be able to run on them
+    # Grab "OVER_SUBSCRIBE;NODES;NODELIST;REQ_NODES;REASON" info for all jobs.
+    # For each non-shared (OVER_SUBSCRIBE!=YES) job that wants to run now
+    # (REASON!=BeginTime) track the allocated/requested nodes or the number of
+    # nodes requested if no specific nodes were requested. Consider "draining"
+    # nodes as exclusive since no other jobs will be able to run on them.
     squeue_cmd = ['squeue',
                   '--partition=chapel',
                   '--noheader',
-                  '--format="%h;%D;%N;%n"']
+                  '--format="%h;%D;%N;%n;%r"']
     squeue_out = run_command_wrapper(squeue_cmd)
 
     sinfo_cmd = ['sinfo',
@@ -77,8 +77,8 @@ def get_exclusive_nodes():
     num_exclusive_nodes = 0
     exclusive_hostnames = set()
     for line in squeue_out + sinfo_out:
-        oversub, num_nodes, nodelist, req_nodes = line.split(';')
-        if oversub.upper() != 'YES':
+        oversub, num_nodes, nodelist, req_nodes, reason = line.split(';')
+        if oversub.upper() != 'YES' and reason != 'BeginTime':
             nodes = nodelist or req_nodes
             if nodes:
                 exclusive_hostnames.update(expand_hostnames(nodes))


### PR DESCRIPTION
paratest.chapcs tries to avoid running on nodes that somebody wants to
use exclusively (this allows people doing perf testing to not get
delayed forever if there's a continuous stream of paratests. However,
all we looked at before was if somebody wanted the nodes exclusively, we
did not consider when they wanted the nodes. Here adjust that so we only
avoid nodes that somebody wants to use immediately and ignore jobs that
are scheduled for a later time.