### PR TITLE
Close some leaks of instances of 'MyClass'

### DIFF
--- a/test/classes/delete-free/borrowed/borrowed-arg.chpl
+++ b/test/classes/delete-free/borrowed/borrowed-arg.chpl
@@ -24,3 +24,5 @@ writeln("f(u)");
 f(u);
 writeln("f(i)");
 f(i);
+
+delete u;

--- a/test/classes/delete-free/lifetimes/ref-class-field-ok.chpl
+++ b/test/classes/delete-free/lifetimes/ref-class-field-ok.chpl
@@ -27,10 +27,13 @@ proc test() {
   ref rc = getC(cc);
 
   rx = 2;
-  rc = new unmanaged MyClass(3);
+  var tc = new unmanaged MyClass(3);
+  rc = tc;
 
   writeln(c);
   writeln(cc);
+
+  delete tc, cc, c;
 }
 
 test();

--- a/test/memory/psahabu/lineno-memLeaks.skipif
+++ b/test/memory/psahabu/lineno-memLeaks.skipif
@@ -1,1 +1,2 @@
 COMPOPTS <= --baseline
+CHPL_MEM_LEAK_TESTING == true


### PR DESCRIPTION
Two of these were just unmanaged classes that needed freeing.
The third was designed to leak memory so should be skipped
for memleaks testing.