### PR TITLE
Adapt to change in default link style on Cray systems.

### DIFF
--- a/test/compflags/link/sungeun/static_dynamic.prediff
+++ b/test/compflags/link/sungeun/static_dynamic.prediff
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-import sys, os, subprocess, string
+import sys, os, subprocess, string, re
 
 def testFailed(f, output):
     logfile = file(f, 'a')
@@ -29,7 +29,19 @@ for l in chpl_env.split('\n'):
         val = env[1].strip()
     if var == 'CHPL_TARGET_PLATFORM':
         if val.find('cray-x') == 0:
-            defaultLinkStyle = 'statically'
+            cle_info_file = os.path.abspath('/etc/opt/cray/release/CLEinfo')
+            if not os.path.exists(cle_info_file):
+                cle_info_file = os.path.abspath('/etc/opt/cray/release/cle-release')
+
+            if os.path.exists(cle_info_file):
+                with open(cle_info_file, 'r') as fp:
+                    cle_info = fp.read()
+                ver_pattern = re.compile('^[A-Z]*RELEASE=(?P<major>[0-9]+)', re.MULTILINE)
+                ver_match = ver_pattern.search(cle_info)
+                if ver_match is not None and len(ver_match.groups()) == 1:
+                    major = int(ver_match.group('major'))
+                    if major < 6:
+                        defaultLinkStyle = 'statically'
 
     if var == 'CHPL_COMM':
         chpl_comm=val


### PR DESCRIPTION
The default linking style has changed from static to dynamic for Cray X*
systems running CLE 6 and greater.  Adapt to that.