### PR TITLE
Updated docs version button for current release / made old doc versions red

### DIFF
--- a/doc/util/versionButton.php
+++ b/doc/util/versionButton.php
@@ -15,13 +15,13 @@
   background-color: #2f95d8;
 }
 
-/* Orange */
+/* Red */
 .oldVersion {
-  background-color: #f49542;
+  background-color: #ff0000;
   color: white;
 }
 .oldVersion:hover, .oldVersion:focus {
-  background-color: #d68137;
+  background-color: #ff0000;
 }
 
 /* Yellow */
@@ -87,8 +87,8 @@ if (pagePath == "") {
   pagePath = "index.html";
 }
 function dropSetup() {
-  var currentRelease = "1.18"; // what does the public have?
-  var stagedRelease = "1.19";  // is there a release staged but not yet public?
+  var currentRelease = "1.19"; // what does the public have?
+  var stagedRelease = "1.20";  // is there a release staged but not yet public?
   var nextRelease = "1.20";    // what's the next release? (on docs/master)
   var button = document.getElementById("versionButton");
   // Uses unicode down-pointing triangle


### PR DESCRIPTION
Make updates necessary to reflect that chapel-lang/docs/ is now 1.19.

While here, update the color of old docs from orange to red.  Over time, using orange to mark old versions of docs has seemed insufficiently clear at indicating "this is bad that you're here", so I thought we should try red for awhile and see how that feels.