### PR TITLE
Update performance tracking with 1.19.0 release dates.

### DIFF
--- a/util/pastPerformance/testReleasesPerformance
+++ b/util/pastPerformance/testReleasesPerformance
@@ -130,6 +130,10 @@ export CHPL_TEST_PERF_DATE="09/12/18"
 export CHPL_HOME=$chpl_release_home/chapel-1.18.0
 testReleasePerformance
 
+export CHPL_TEST_PERF_DATE="03/12/19"
+export CHPL_HOME=$chpl_release_home/chapel-1.19.0
+testReleasePerformance
+
 #
 # ADD NEW RELEASES HERE AS THEY ARE CREATED.
 #

--- a/util/test/perf/perfgraph.js
+++ b/util/test/perf/perfgraph.js
@@ -94,7 +94,11 @@ var branchInfo = [
                   { "release" : "1.18",
                     "releaseDate": "2018-09-20",
                     "branchDate" : "2018-09-12",
-                    "revision" : -1}
+                    "revision" : -1},
+  				  { "release" : "1.19",
+   	 				"releaseDate": "2019-03-21",
+    				"branchDate" : "2019-03-12",
+    				"revision" : -1}
                   ];
 
 

--- a/util/test/perf/perfgraph.js
+++ b/util/test/perf/perfgraph.js
@@ -95,10 +95,10 @@ var branchInfo = [
                     "releaseDate": "2018-09-20",
                     "branchDate" : "2018-09-12",
                     "revision" : -1},
-  				  { "release" : "1.19",
-   	 				"releaseDate": "2019-03-21",
-    				"branchDate" : "2019-03-12",
-    				"revision" : -1}
+                  { "release" : "1.19",
+                    "releaseDate": "2019-03-21",
+                    "branchDate" : "2019-03-12",
+                    "revision" : -1}
                   ];
 
 


### PR DESCRIPTION
Add date of release branch cut into testReleasesPerformance and the release date and branch date into perfgraph.js after the 1.19.0 release has been cut.

I have no idea how to verify these changes, I apologize.