### PR TITLE
Load cray-fftw module instead of fftw in common-whitebox

### DIFF
--- a/util/cron/common-whitebox.bash
+++ b/util/cron/common-whitebox.bash
@@ -165,8 +165,8 @@ if [ "${HOSTNAME:0:6}" = "esxbld" ] ; then
 fi
 
 if [ "${COMP_TYPE}" != "HOST-TARGET-no-PrgEnv" ] ; then
-    log_info "Loading fftw module."
-    module load fftw
+    log_info "Loading cray-fftw module."
+    module load cray-fftw
 fi
 
 log_info "Current loaded modules:"


### PR DESCRIPTION
The cray `fftw` module was renamed to `cray-fftw` a while ago, so 
we've been loading on old version. Start using `cray-fftw`.