### PR TITLE
Lock in error message for array.size-dependent tuple

### DIFF
--- a/test/types/tuple/errors/array-size-length.chpl
+++ b/test/types/tuple/errors/array-size-length.chpl
@@ -1,0 +1,2 @@
+var A: [1..2] int;
+var tup: A.size*int;

--- a/test/types/tuple/errors/array-size-length.good
+++ b/test/types/tuple/errors/array-size-length.good
@@ -1,0 +1,1 @@
+array-size-length.chpl:2: error: tuple size must be known at compile-time


### PR DESCRIPTION
This program previously generated an internal error, but now generates a sensible error. This PR adds a test to lock this behavior in.

Closes #9630