### PR TITLE
Fix LLVM 8 build

### DIFF
--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2471,7 +2471,7 @@ void setupForGlobalToWide(void) {
 #if HAVE_LLVM_VER < 50
                           , NULL
 #endif
-#if HAVE_LLVM_VER < 80
+#if HAVE_LLVM_VER < 90
                           );
 #else
                           ).getCallee();

--- a/compiler/llvm/llvmGlobalToWide.cpp
+++ b/compiler/llvm/llvmGlobalToWide.cpp
@@ -1229,7 +1229,7 @@ namespace {
                                            , NULL
 #endif
                                           );
-#if HAVE_LLVM_VER < 80
+#if HAVE_LLVM_VER < 90
         Type* getFnTy = getFn->getType();
         info->getFn = getFn;
 #else
@@ -1245,7 +1245,7 @@ namespace {
                                            , NULL
 #endif
                                           );
-#if HAVE_LLVM_VER < 80
+#if HAVE_LLVM_VER < 90
         Type* putFnTy = putFn->getType();
         info->putFn = putFn;
 #else
@@ -1263,7 +1263,7 @@ namespace {
 #endif
                                              );
 
-#if HAVE_LLVM_VER < 80
+#if HAVE_LLVM_VER < 90
         Type* getPutFnTy = getPutFn->getType();
         info->getPutFn = getPutFn;
 #else
@@ -1281,7 +1281,7 @@ namespace {
 #endif
                                              );
 
-#if HAVE_LLVM_VER < 80
+#if HAVE_LLVM_VER < 90
         Type* memsetFnTy = memsetFn->getType();
         info->memsetFn = memsetFn;
 #else


### PR DESCRIPTION
#12587 made changes to the LLVM 8 build that were actually for LLVM 9, causing LLVM 8 not to build.  This change bumps the version number on the test macros to allow LLVM 8 to build again.

Tested on Mac and Ubuntu versions of LLVM 8.
