### PR TITLE
Remove unused variable to close sparseBulk.chpl leak

### DIFF
--- a/test/users/engin/sparse_bulk_dist/sparseBulk.chpl
+++ b/test/users/engin/sparse_bulk_dist/sparseBulk.chpl
@@ -8,7 +8,6 @@ config type sparseLayoutType = DefaultDist;
 const ParentDom = {0..#N, 0..#N} dmapped Block({0..#N, 0..#N},
     sparseLayoutType=sparseLayoutType);
 
-const layout = new unmanaged sparseLayoutType();
 var SparseDom: sparse subdomain(ParentDom);
 
 var SparseArr: [SparseDom] int;


### PR DESCRIPTION
I think this variable was leftover from the non-distributed version and is not used here, yet was leaked.
