### PR TITLE
Close leak in stecil-setup.chpl test

### DIFF
--- a/test/classes/delete-free/lifetimes/stecil-setup.chpl
+++ b/test/classes/delete-free/lifetimes/stecil-setup.chpl
@@ -8,21 +8,15 @@ class MyLocDom {
 
 class MyStencilDom {
   var A:[1..10] borrowed MyLocDom;
-  proc deinit() {
-    for i in 1..10 {
-      var c = _to_unmanaged(A[i]);
-      delete c;
-    }
-  }
 }
 
 config const branch = true;
 
 proc MyStencilDom.setup() {
   ref elem = A[1];
-  if branch {
+  if branch then
     elem = new unmanaged MyLocDom(1);
-  } else
+  else
     elem.x += 1;
 }
 
@@ -30,6 +24,7 @@ proc test() {
   var dom = new unmanaged MyStencilDom();
   dom.setup();
   writeln(dom);
+  delete dom.A[1]:unmanaged;
   delete dom;
 }
 

--- a/test/classes/delete-free/lifetimes/stecil-setup.chpl
+++ b/test/classes/delete-free/lifetimes/stecil-setup.chpl
@@ -8,15 +8,21 @@ class MyLocDom {
 
 class MyStencilDom {
   var A:[1..10] borrowed MyLocDom;
+  proc deinit() {
+    for i in 1..10 {
+      var c = _to_unmanaged(A[i]);
+      delete c;
+    }
+  }
 }
 
 config const branch = true;
 
 proc MyStencilDom.setup() {
   ref elem = A[1];
-  if branch then
+  if branch {
     elem = new unmanaged MyLocDom(1);
-  else
+  } else
     elem.x += 1;
 }
 
@@ -24,6 +30,7 @@ proc test() {
   var dom = new unmanaged MyStencilDom();
   dom.setup();
   writeln(dom);
+  delete dom;
 }
 
 test();

--- a/test/classes/initializers/nested/unmanaged-problem-use-before-def.chpl
+++ b/test/classes/initializers/nested/unmanaged-problem-use-before-def.chpl
@@ -9,6 +9,10 @@ class Outer {
   proc init() {
     field = new unmanaged Inner(1);
   }
+
+  proc deinit() {
+    delete field;
+  }
 }
 
 var x = new owned Outer();

--- a/test/classes/initializers/nested/unmanaged-problem-use-before-def.chpl
+++ b/test/classes/initializers/nested/unmanaged-problem-use-before-def.chpl
@@ -9,10 +9,6 @@ class Outer {
   proc init() {
     field = new unmanaged Inner(1);
   }
-
-  proc deinit() {
-    delete field;
-  }
 }
 
 var x = new owned Outer();


### PR DESCRIPTION
I took the approach of using a cast to unmanaged to free a borrow that I
knew was of an unmanaged class, and also freed another class in the
obvious way.