### PR TITLE
Base our static_dynamic prediff on craype version instead of CLE version

### DIFF
--- a/test/compflags/link/sungeun/static_dynamic.prediff
+++ b/test/compflags/link/sungeun/static_dynamic.prediff
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 
-import sys, os, subprocess, string, re
+import sys, os, subprocess, string
+
+from distutils.version import LooseVersion
 
 def testFailed(f, output):
     logfile = file(f, 'a')
@@ -29,19 +31,9 @@ for l in chpl_env.split('\n'):
         val = env[1].strip()
     if var == 'CHPL_TARGET_PLATFORM':
         if val.find('cray-x') == 0:
-            cle_info_file = os.path.abspath('/etc/opt/cray/release/CLEinfo')
-            if not os.path.exists(cle_info_file):
-                cle_info_file = os.path.abspath('/etc/opt/cray/release/cle-release')
-
-            if os.path.exists(cle_info_file):
-                with open(cle_info_file, 'r') as fp:
-                    cle_info = fp.read()
-                ver_pattern = re.compile('^[A-Z]*RELEASE=(?P<major>[0-9]+)', re.MULTILINE)
-                ver_match = ver_pattern.search(cle_info)
-                if ver_match is not None and len(ver_match.groups()) == 1:
-                    major = int(ver_match.group('major'))
-                    if major < 6:
-                        defaultLinkStyle = 'statically'
+            pe_ver = os.getenv('CRAYPE_VERSION', '0.0.0.0')
+            if LooseVersion(pe_ver) < LooseVersion('2.6.0.1'):
+              defaultLinkStyle = 'statically'
 
     if var == 'CHPL_COMM':
         chpl_comm=val

--- a/test/compflags/link/sungeun/static_dynamic.skipif
+++ b/test/compflags/link/sungeun/static_dynamic.skipif
@@ -15,6 +15,11 @@ elif [[ $CHPL_COMM_SUBSTRATE == mpi \
   # a compopts-by-compopts basis, but we can't do that yet.
   #
   echo True
+elif [[ $CHPL_TARGET_COMPILER == *pgi* ]] ; then
+  #
+  # We pin to an old version of pgi that causes issues for some variants
+  #
+  echo True
 elif $CHPL_HOME/util/printchplenv --make --all --internal \
      | grep CHPL_MAKE_THIRD_PARTY_LINK_ARGS \
      | grep -q -e '-lnuma' ; then


### PR DESCRIPTION
The files we were using to check the CLE version don't exist on
whitebox, so instead just base the check off the craype version (which
should have the same impact since the newer craype should never be
available on older CLEs)

Also skip under pgi to avoid new link issues that result from us pinning
to an old version of pgi and trying to use a new cray-fftw.

Follow on to https://github.com/chapel-lang/chapel/pull/12659