### PR TITLE
Mark SumReduceScanOp's methods with 'inline'

### DIFF
--- a/modules/internal/ChapelReduce.chpl
+++ b/modules/internal/ChapelReduce.chpl
@@ -159,20 +159,20 @@ module ChapelReduce {
 
     // Rely on the default value of the desired type.
     // Todo: is this efficient when that is an array?
-    proc identity {
+    inline proc identity {
       var x: chpl__sumType(eltType); return x;
     }
-    proc accumulate(x) {
+    inline proc accumulate(x) {
       value += x;
     }
-    proc accumulateOntoState(ref state, x) {
+    inline proc accumulateOntoState(ref state, x) {
       state += x;
     }
-    proc combine(x) {
+    inline proc combine(x) {
       value += x.value;
     }
-    proc generate() return value;
-    proc clone() return new unmanaged SumReduceScanOp(eltType=eltType);
+    inline proc generate() return value;
+    inline proc clone() return new unmanaged SumReduceScanOp(eltType=eltType);
   }
 
   class ProductReduceScanOp: ReduceScanOp {


### PR DESCRIPTION
Lack of inlining of SumReduceScanOp's methods might be responsible for a minor performance regression, as conjectured in a [comment](https://github.com/chapel-lang/chapel/issues/12173#issuecomment-475908753) in #12173.

This PR marks these methods `inline` to see whether this improves performance.

I am limiting `inline` to just + reductions until we decide we want to convert other reduce ops as well. As always, inlining might potentially cause slowdown for reductions over data types whose `+` is complicated and so is best left out-lined.