### PR TITLE
fixup generic-inherit{5,6} tests

### DIFF
--- a/test/classes/ferguson/generic-inherit5.chpl
+++ b/test/classes/ferguson/generic-inherit5.chpl
@@ -13,7 +13,7 @@ class Parent {
 class Child : Parent {
   type t;
   var y:t;
-  proc overridden_method() {
+  override proc overridden_method() {
     writeln(x,y);
   }
   proc child_method() {
@@ -25,7 +25,6 @@ writeln("Parent(int)");
 var p = new Parent(int, 1);
 p.parent_method();
 p.overridden_method();
-delete p;
 
 writeln("Child(int,real)");
 var c = new Child(int, 1, real, 2.0);
@@ -34,7 +33,6 @@ c.overridden_method();
 c.child_method();
 
 writeln("Dynamic Child(int,real)");
-var pc:Parent(int) = c;
+var pc:Parent(int) = c.borrow();
 pc.parent_method();
 pc.overridden_method();
-delete pc;

--- a/test/classes/ferguson/generic-inherit5.future
+++ b/test/classes/ferguson/generic-inherit5.future
@@ -1,4 +1,0 @@
-feature request: generic inheritance with same field name
-
-I'm not sure what exactly it should look like, but you should be able to
-do something like this...

--- a/test/classes/ferguson/generic-inherit5.good
+++ b/test/classes/ferguson/generic-inherit5.good
@@ -7,4 +7,4 @@ Child(int,real)
 2.0
 Dynamic Child(int,real)
 1
-12
+12.0

--- a/test/classes/ferguson/generic-inherit6.bad
+++ b/test/classes/ferguson/generic-inherit6.bad
@@ -1,0 +1,1 @@
+generic-inherit6.chpl:13: error: Illegal super class

--- a/test/classes/ferguson/generic-inherit6.chpl
+++ b/test/classes/ferguson/generic-inherit6.chpl
@@ -25,7 +25,6 @@ writeln("Parent(int)");
 var p = new Parent(int, 1);
 p.parent_method();
 p.overridden_method();
-delete p;
 
 writeln("Child(int)");
 var c = new Child(1, int, 2);
@@ -34,7 +33,7 @@ c.overridden_method();
 c.child_method();
 
 writeln("Dynamic Child(int)");
-var pc:Parent = c;
+var pc:Parent = c.borrow();
 pc.parent_method();
 pc.overridden_method();
-delete pc;
+


### PR DESCRIPTION
generic-inherit5.chpl failed to compile due to language changes.  Fix
that up.  I believe the test actually passes, but the .good file was
wrong.  Fix that too.

generic-inherit6.chpl had the same language change problems.  Fix
those even though it still doesn't compile, and give the test a .bad
file.