### PR TITLE
Add override keywords to dsiDisplayRepresentation overrides

### DIFF
--- a/modules/dists/CyclicDist.chpl
+++ b/modules/dists/CyclicDist.chpl
@@ -330,7 +330,7 @@ proc Cyclic.getChunk(inds, locid) {
   //return inds((...distWhole));
 }
 
-proc Cyclic.dsiDisplayRepresentation() {
+override proc Cyclic.dsiDisplayRepresentation() {
   writeln("startIdx = ", startIdx);
   writeln("targetLocDom = ", targetLocDom);
   writeln("targetLocs = ", for tl in targetLocs do tl.id);
@@ -509,7 +509,7 @@ proc CyclicDom.dsiBuildArray(type eltType) {
   return arr;
 }
 
-proc CyclicDom.dsiDisplayRepresentation() {
+override proc CyclicDom.dsiDisplayRepresentation() {
   writeln("whole = ", whole);
   for tli in dist.targetLocDom do
     writeln("locDoms[", tli, "].myBlock = ", locDoms[tli].myBlock);
@@ -708,7 +708,7 @@ proc CyclicArr.dsiLocalSlice(ranges) {
   return locArr(dom.dist.targetLocsIdx(low)).myElems((...ranges));
 }
 
-proc CyclicArr.dsiDisplayRepresentation() {
+override proc CyclicArr.dsiDisplayRepresentation() {
   for tli in dom.dist.targetLocDom {
     writeln("locArr[", tli, "].myElems = ", for e in locArr[tli].myElems do e);
     writeln("locArr[", tli, "].locRAD = ", locArr[tli].locRAD.RAD);

--- a/modules/dists/HashedDist.chpl
+++ b/modules/dists/HashedDist.chpl
@@ -212,7 +212,7 @@ class Hashed : BaseDist {
 
 
   // debugging print
-  proc dsiDisplayRepresentation() {
+  override proc dsiDisplayRepresentation() {
     writeln("targetLocDom = ", targetLocDom);
     writeln("targetLocales = ", for tl in targetLocales do tl.id);
     //for tli in targetLocDom do
@@ -839,7 +839,7 @@ class UserMapAssocArr: AbsBaseArr {
     }
   }
 
-  proc dsiDisplayRepresentation() {
+  override proc dsiDisplayRepresentation() {
 
     writeln("dsiDisplayRepresentation TODO");
   }

--- a/modules/dists/SparseBlockDist.chpl
+++ b/modules/dists/SparseBlockDist.chpl
@@ -507,7 +507,7 @@ proc SparseBlockDom.dsiNewSpsSubDom(parentDomVal) {
   return new SparseBlockDom(rank, idxType, dist, parentDomVal);
 }
 
-proc SparseBlockDom.dsiDisplayRepresentation() {
+override proc SparseBlockDom.dsiDisplayRepresentation() {
   writeln("whole = ", whole);
   for tli in dist.targetLocDom do
     writeln("locDoms[", tli, "].mySparseBlock = ", locDoms[tli].mySparseBlock);
@@ -595,7 +595,7 @@ proc SparseBlockDom.dsiIndexOrder(i) {
 //
 proc LocSparseBlockDom.contains(i) return mySparseBlock.contains(i);
 
-proc SparseBlockArr.dsiDisplayRepresentation() {
+override proc SparseBlockArr.dsiDisplayRepresentation() {
   for tli in dom.dist.targetLocDom {
     writeln("locArr[", tli, "].myElems = ", for e in locArr[tli].myElems do e);
   }

--- a/modules/dists/StencilDist.chpl
+++ b/modules/dists/StencilDist.chpl
@@ -482,7 +482,7 @@ override proc Stencil.dsiDestroyDist() {
   }
 }
 
-proc Stencil.dsiDisplayRepresentation() {
+override proc Stencil.dsiDisplayRepresentation() {
   writeln("boundingBox = ", boundingBox);
   writeln("targetLocDom = ", targetLocDom);
   writeln("targetLocales = ", for tl in targetLocales do tl.id);
@@ -626,7 +626,7 @@ proc StencilDom.init(param rank : int,
 
 override proc StencilDom.dsiMyDist() return dist;
 
-proc StencilDom.dsiDisplayRepresentation() {
+override proc StencilDom.dsiDisplayRepresentation() {
   writeln("whole = ", whole);
   for tli in dist.targetLocDom do
     writeln("locDoms[", tli, "].myBlock = ", locDoms[tli].myBlock);
@@ -993,7 +993,7 @@ proc StencilDom.dsiIndexOrder(i) {
 //
 proc LocStencilDom.contains(i) return myBlock.contains(i);
 
-proc StencilArr.dsiDisplayRepresentation() {
+override proc StencilArr.dsiDisplayRepresentation() {
   for tli in dom.dist.targetLocDom {
     writeln("locArr[", tli, "].myElems = ", for e in locArr[tli].myElems do e);
     if doRADOpt then

--- a/modules/internal/ArrayViewRankChange.chpl
+++ b/modules/internal/ArrayViewRankChange.chpl
@@ -578,7 +578,7 @@ module ArrayViewRankChange {
       chpl_serialReadWriteRectangular(f, this, privDom);
     }
 
-    proc dsiDisplayRepresentation() {
+    override proc dsiDisplayRepresentation() {
       writeln("Rank Change view");
       writeln("----------");
       writeln("of domain:");

--- a/modules/internal/ArrayViewReindex.chpl
+++ b/modules/internal/ArrayViewReindex.chpl
@@ -470,7 +470,7 @@ module ArrayViewReindex {
       chpl_serialReadWriteRectangular(f, this, privDom.updom);
     }
 
-    proc dsiDisplayRepresentation() {
+    override proc dsiDisplayRepresentation() {
       writeln("Reindex view");
       writeln("------------");
       writeln("of domain:");

--- a/modules/internal/ArrayViewSlice.chpl
+++ b/modules/internal/ArrayViewSlice.chpl
@@ -212,11 +212,8 @@ module ArrayViewSlice {
 
     inline proc checkBounds(i) {
       if boundsChecking then
-        if !privDom.dsiMember(i) then {
-          writeln("privDom = ");
-          privDom.dsiDisplayRepresentation();
+        if !privDom.dsiMember(i) then
           halt("array index out of bounds: ", i);
-        }
     }
 
 

--- a/modules/internal/ArrayViewSlice.chpl
+++ b/modules/internal/ArrayViewSlice.chpl
@@ -149,7 +149,7 @@ module ArrayViewSlice {
       chpl_serialReadWriteRectangular(f, arr, privDom);
     }
 
-    proc dsiDisplayRepresentation() {
+    override proc dsiDisplayRepresentation() {
       writeln("Slice view");
       writeln("----------");
       writeln("of domain:");
@@ -212,8 +212,11 @@ module ArrayViewSlice {
 
     inline proc checkBounds(i) {
       if boundsChecking then
-        if !privDom.dsiMember(i) then
+        if !privDom.dsiMember(i) then {
+          writeln("privDom = ");
+          privDom.dsiDisplayRepresentation();
           halt("array index out of bounds: ", i);
+        }
     }
 
 

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -158,7 +158,7 @@ module DefaultRectangular {
       return dist;
     }
 
-    proc dsiDisplayRepresentation() {
+    override proc dsiDisplayRepresentation() {
       writeln("ranges = ", ranges);
     }
 
@@ -1039,7 +1039,7 @@ module DefaultRectangular {
       return chpl__idxTypeToIntIdxType(idxType);
     }
 
-    proc dsiDisplayRepresentation() {
+    override proc dsiDisplayRepresentation() {
       writeln("off=", off);
       writeln("blk=", blk);
       writeln("str=", str);


### PR DESCRIPTION
This adds the `override` keyword to subclass implementations of `dsiDisplayRepresentation()`.  These routines aren't used much beyond debugging, which has caused them to slip between the cracks until now.  I ran into this while doing some debugging of slices, and so went ahead and found (what I believe to be) the remaining cases as well.