### PR TITLE
Change class-*generic.chpl to use auto-managed memory

### DIFF
--- a/test/classes/initializers/postInit/class-generic.chpl
+++ b/test/classes/initializers/postInit/class-generic.chpl
@@ -31,7 +31,7 @@ class MyCls {
 
 proc main() {
   // 1) A new expression at top level
-  new unmanaged MyCls(10);
+  new MyCls(10);
 
   writeln();
 
@@ -43,7 +43,7 @@ proc main() {
 
 
 // The initExpr is a block statement with the new expr.
-proc foo(x = new unmanaged MyCls(20)) {
+proc foo(x = new MyCls(20)) {
   writeln(x);
   writeln();
 }

--- a/test/classes/initializers/postInit/class-nongeneric.chpl
+++ b/test/classes/initializers/postInit/class-nongeneric.chpl
@@ -29,7 +29,7 @@ class MyCls {
 
 proc main() {
   // 1) A new expression at top level
-  new unmanaged MyCls(10);
+  new MyCls(10);
 
   writeln();
 
@@ -41,7 +41,7 @@ proc main() {
 
 
 // The initExpr is a block statement with the new expr.
-proc foo(x = new unmanaged MyCls(20)) {
+proc foo(x = new MyCls(20)) {
   writeln(x);
   writeln();
 }


### PR DESCRIPTION
These tests leaked before this change due to the use of `unmanaged`
without `delete`.  They leak after this change due to issues #11101
and #12637.