### PR TITLE
Update getCurInstantiation to compare param values when types do not match

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -838,7 +838,15 @@ AggregateType* AggregateType::getCurInstantiation(Symbol* sym) {
       }
 
     } else if (field->hasFlag(FLAG_PARAM) == true) {
-      if (field->type != sym->type) {
+      Type* expected = NULL;
+      if (field->defPoint->exprType != NULL) {
+        expected = field->defPoint->exprType->typeInfo();
+      }
+      // Only check when the field has a type expression
+      //
+      // See param/ferguson/mismatched-param-type-error.chpl for an example
+      // where this check is necessary.
+      if (expected != NULL && expected != sym->type) {
         Immediate result;
         Immediate* lhs = getSymbolImmediate(at->substitutions.get(field));
         Immediate* rhs = getSymbolImmediate(sym);

--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -825,6 +825,12 @@ AggregateType* AggregateType::getInstantiation(Symbol* sym, int index) {
   return retval;
 }
 
+//
+// This method tries to find a pre-existing AggregateType instance that
+// represents the resulting instantiation of binding 'sym' to the current
+// generic field. This way there is only ever one instance of AggregateType for
+// a particular instantiation.
+//
 AggregateType* AggregateType::getCurInstantiation(Symbol* sym) {
   AggregateType* retval = NULL;
 
@@ -842,10 +848,19 @@ AggregateType* AggregateType::getCurInstantiation(Symbol* sym) {
       if (field->defPoint->exprType != NULL) {
         expected = field->defPoint->exprType->typeInfo();
       }
-      // Only check when the field has a type expression
+
+      //
+      // The types of 'sym' and 'field' might by different if the user
+      // specified a literal that will eventually be coerced into the correct
+      // field type.  For example '42' is an 'int(64)' but could be coerced to
+      // a 'uint(64)'. In such cases we should compare the values of 'sym'
+      // and the current instantiation's field.
+      //
+      // Note: only check when the field has a type expression
       //
       // See param/ferguson/mismatched-param-type-error.chpl for an example
       // where this check is necessary.
+      //
       if (expected != NULL && expected != sym->type) {
         Immediate result;
         Immediate* lhs = getSymbolImmediate(at->substitutions.get(field));

--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -35,6 +35,7 @@
 #include "stmt.h"
 #include "stringutil.h"
 #include "symbol.h"
+#include "../ifa/prim_data.h"
 
 AggregateType* dtObject = NULL;
 AggregateType* dtString = NULL;
@@ -837,7 +838,15 @@ AggregateType* AggregateType::getCurInstantiation(Symbol* sym) {
       }
 
     } else if (field->hasFlag(FLAG_PARAM) == true) {
-      if (at->substitutions.get(field) == sym) {
+      if (field->type != sym->type) {
+        Immediate result;
+        Immediate* lhs = getSymbolImmediate(at->substitutions.get(field));
+        Immediate* rhs = getSymbolImmediate(sym);
+        fold_constant(P_prim_equal, lhs, rhs, &result);
+        if (result.v_bool) {
+          retval = at;
+        }
+      } else if (at->substitutions.get(field) == sym) {
         retval = at;
         break;
       }

--- a/test/types/records/bharshbarger/coercedImmediate.chpl
+++ b/test/types/records/bharshbarger/coercedImmediate.chpl
@@ -1,0 +1,61 @@
+
+// From user issue #12462
+
+record Concrete {
+  param size: uint;
+}
+
+record SingleData {
+  type t;
+  var data: t;
+}
+
+record SingleDataArray {
+  type t;
+  var data: [1..4] SingleData(t);
+}
+
+record TupleData {
+  param p: int;
+  
+  type t;
+  var data: p*t;
+}
+
+record TupleDataArray {
+  param p: int;
+  
+  type t;
+  var data: [1..4] TupleData(p, t);
+}
+
+record R {
+  type ut;
+  param u: ut;
+}
+
+proc main() {
+  var r: Concrete(64) = new Concrete(64);
+  writeln(r);
+
+  {
+    var A : SingleDataArray(R(int, 42));
+    var B : SingleDataArray(R(uint, 42:uint));
+    var C : SingleDataArray(R(uint, 42));
+
+    writeln(A);
+    writeln(B);
+    writeln(C);
+  }
+  
+  
+  {
+    var A : TupleDataArray(2, R(int, 42));
+    var B : TupleDataArray(2, R(uint, 42:uint));
+    var C : TupleDataArray(2, R(uint,42));
+
+    writeln(A);
+    writeln(B);
+    writeln(C);
+  }
+}

--- a/test/types/records/bharshbarger/coercedImmediate.good
+++ b/test/types/records/bharshbarger/coercedImmediate.good
@@ -1,0 +1,7 @@
+()
+(data = (data = ()) (data = ()) (data = ()) (data = ()))
+(data = (data = ()) (data = ()) (data = ()) (data = ()))
+(data = (data = ()) (data = ()) (data = ()) (data = ()))
+(data = (data = ((), ())) (data = ((), ())) (data = ((), ())) (data = ((), ())))
+(data = (data = ((), ())) (data = ((), ())) (data = ((), ())) (data = ((), ())))
+(data = (data = ((), ())) (data = ((), ())) (data = ((), ())) (data = ((), ())))


### PR DESCRIPTION
Prior to this PR, AggregateType::getCurInstantiation would fail to take into account whether a given param would be coerced into a different type when instantiating later on. For example, consider the following record ``R`` and two identical instantiations:

```chpl
record R {
  type T;
  param p : T;
}

type A = R(uint, 42:uint);
type B = R(uint, 42);
```

The compiler would pass ``42:uint`` as a ``uint(64)`` to ``getCurInstantiation``, and ``42`` as an ``int(64)``. When attempting to determine whether a pre-existing instantiation existed, ``getCurInstantiation`` would return false for the second instantiation because it was expecting a ``uint(64)`` and not an ``int(64)``.

This PR updates ``getCurInstantiation`` to compare the values of the given param when the field has a type expression.

Resolves #12462

Testing:
- [x] local + futures
- [x] gasnet + futures