### PR TITLE
Skip some interop directories for multi-locale runs

### DIFF
--- a/test/interop/C/llvm/exportArray/SKIPIF
+++ b/test/interop/C/llvm/exportArray/SKIPIF
@@ -1,0 +1,2 @@
+# Does not currently work with multilocale
+CHPL_COMM != none

--- a/test/interop/C/llvm/headerName/SKIPIF
+++ b/test/interop/C/llvm/headerName/SKIPIF
@@ -1,2 +1,3 @@
 CHPL_TARGET_PLATFORM == darwin
 CHPL_LLVM == none
+CHPL_COMM != none

--- a/test/interop/C/llvm/noLibFlag/checkHeaderSet.skipif
+++ b/test/interop/C/llvm/noLibFlag/checkHeaderSet.skipif
@@ -1,1 +1,2 @@
 CHPL_LLVM == none
+CHPL_COMM != none


### PR DESCRIPTION
Library compilation is not expected to work for multi-locale just yet, but these
directories were not being skipped.  Do so for now.

Discovered by @benharsh, thanks!