### PR TITLE
Close leaks in mod-init.chpl by running with default compiler flags

### DIFF
--- a/test/classes/moduleScope/mod-init.compopts
+++ b/test/classes/moduleScope/mod-init.compopts
@@ -1,1 +1,0 @@
---no-warn-unstable --legacy-new


### PR DESCRIPTION
This test had a compopts file that caused it to use old-style new
semantics for reasons that aren't clear to me.  Removing it closes
a leak and keeps the test working (including under valgrind).