### PR TITLE
Close leaks in forward-iterator*.chpl tests

### DIFF
--- a/test/classes/ferguson/forwarding/forward-iterator-lf.chpl
+++ b/test/classes/ferguson/forwarding/forward-iterator-lf.chpl
@@ -21,11 +21,11 @@ class Impl {
 }
 
 record R {
-  forwarding var impl:unmanaged Impl;
+  forwarding var impl:owned Impl;
 }
 
 proc test() {
-  var r = new R(new unmanaged Impl());
+  var r = new R(new owned Impl());
   forall i in r {
     writeln(i);
   }

--- a/test/classes/ferguson/forwarding/forward-iterator-modify-ref.chpl
+++ b/test/classes/ferguson/forwarding/forward-iterator-modify-ref.chpl
@@ -9,11 +9,11 @@ class Impl {
 }
 
 record R {
-  forwarding var impl:unmanaged Impl;
+  forwarding var impl:owned Impl;
 }
 
 proc test() {
-  var r = new R(new unmanaged Impl());
+  var r = new R(new owned Impl());
   for i in r.these() {
     writeln(i);
     globalOne += 1;

--- a/test/classes/ferguson/forwarding/forward-iterator-modify.chpl
+++ b/test/classes/ferguson/forwarding/forward-iterator-modify.chpl
@@ -9,11 +9,11 @@ class Impl {
 }
 
 record R {
-  forwarding var impl:unmanaged Impl;
+  forwarding var impl:owned Impl;
 }
 
 proc test() {
-  var r = new R(new unmanaged Impl());
+  var r = new R(new owned Impl());
   for i in r.these() {
     writeln(i);
     globalOne += 1;


### PR DESCRIPTION
This just required using `owned` classes rather than `unmanaged`