### PR TITLE
Fix a memcpy() that used the wrong size.

### DIFF
--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -2647,7 +2647,7 @@ void register_memory(void)
       gnr_mreg_map[node] = gdp->gnr_mreg;
       mem_regions_all_entries[node]->mreg_cnt = gdp->mreg_cnt;
       memcpy(&mem_regions_all_entries[node]->mregs, &gdp->mregs,
-             mem_regions_size);
+             gdata_mregs_size);
       mem_regions_all_my_entry_map[node] =
           (mem_region_table_t*)
           ((char*) gdp->mem_regions_all + chpl_nodeID * mem_regions_size);


### PR DESCRIPTION
When distributing all the nodes' initial memory region tables around the
job, when copying each node's initial table entries from the allgathered
data to our map we were copying enough bytes for the total size of the
entire table, including its header and all the entries allocated for it.
That's way too many; the target has that much room, by definition, but
the source doesn't have that many valid bytes.  We should instead copy
just enough bytes to cover the maximum number of table entries that are
in use on any node at this point.  That's all that was transmitted in
the allgather.

This resolves https://github.com/Cray/chapel-private/issues/91.