### PR TITLE
Rework test prediff to match fetch/build/total times better.

### DIFF
--- a/test/mason/spack-integration/mason-external.good
+++ b/test/mason/spack-integration/mason-external.good
@@ -1,4 +1,4 @@
-  Fetch: n.ns.  Build: nm n.ns.  Total: nm n.ns.
+  Fetch: <time>.  Build: <time>.  Total: <time>.
 Installing Spack backend ...
 Updating mason-registry
 Compiling [debug] target: masonLA

--- a/test/mason/spack-integration/mason-external.prediff
+++ b/test/mason/spack-integration/mason-external.prediff
@@ -8,7 +8,7 @@ tmp_file  = out_file + ".prediff.tmp"
 with open(tmp_file, 'w') as tf:
   with open(out_file) as outf:
       for line in outf:
-        line = re.sub(r'[0-9]+', 'n', line)
+        line = re.sub(r'([0-9]+m )?[0-9]+([.][0-9]+)?s', '<time>', line)
         if not (line.startswith("[+]") or line.startswith("==>")):
           tf.write(line)
 


### PR DESCRIPTION
The mason-external prediff needs to match the fetch/build/total time
reported for a package, but without being specific about just what the
time was.  Here, allow optional minutes, followed by seconds with an
optional decimal part.