### PR TITLE
Fix ZMQ test preexec for `chpl` not in $PATH

### DIFF
--- a/test/library/packages/ZMQ/getLastEndpointMain.preexec
+++ b/test/library/packages/ZMQ/getLastEndpointMain.preexec
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-chpl getLastEndpointHelper.chpl
+$3 getLastEndpointHelper.chpl


### PR DESCRIPTION
Our testing doesn't rely on finding `chpl` via the $PATH environment variable,
which caused the .preexec for this test to fail to compile the helper program.
Make the .preexec use `chpl` from the arguments passed to it

Double checked that it worked w/ and w/o `chpl` in my `$PATH`