### PR TITLE
isSubset() and isSuper() now work with Rectangular Domains

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1558,10 +1558,8 @@ module ChapelArray {
     /* Return true if this domain is a subset of ``super``. Otherwise
        returns false. */
     proc isSubset(super : domain) {
-      if !isAssociativeDom(this) {
-        if isRectangularDom(this) then
-          compilerError("isSubset not supported on rectangular domains");
-        else if isOpaqueDom(this) then
+      if !(isAssociativeDom(this) || isRectangularDom(this)) {
+        if isOpaqueDom(this) then
           compilerError("isSubset not supported on opaque domains");
         else if isSparseDom(this) then
           compilerError("isSubset not supported on sparse domains");
@@ -1577,10 +1575,8 @@ module ChapelArray {
     /* Return true if this domain is a superset of ``sub``. Otherwise
        returns false. */
     proc isSuper(sub : domain) {
-      if !isAssociativeDom(this) {
-        if isRectangularDom(this) then
-          compilerError("isSuper not supported on rectangular domains");
-        else if isOpaqueDom(this) then
+      if !(isAssociativeDom(this) || isRectangularDom(this)) {
+        if isOpaqueDom(this) then
           compilerError("isSuper not supported on opaque domains");
         else if isSparseDom(this) then
           compilerError("isSuper not supported on sparse domains");

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1569,6 +1569,10 @@ module ChapelArray {
       if super.type != this.type then
         compilerError("isSubset called with different associative domain types");
 
+      if isRectangularDom(this) then
+        return && reduce forall i in 1..this.dims().size do
+          super.dims()[i].contains(this.dims()[i]);
+
       return && reduce forall i in this do super.contains(i);
     }
 
@@ -1585,6 +1589,10 @@ module ChapelArray {
       }
       if sub.type != this.type then
         compilerError("isSuper called with different associative domain types");
+
+      if isRectangularDom(this) then
+        return && reduce forall i in 1..this.dims().size do
+          this.dims()[i].contains(sub.dims()[i]);
 
       return && reduce forall i in sub do this.contains(i);
     }

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1573,9 +1573,14 @@ module ChapelArray {
         } else
           compilerError("isSubset called with different associative domain types");
 
-      if isRectangularDom(this) then
-        return && reduce for i in 1..this.dims().size do
-          super.dims()[i].contains(this.dims()[i]);
+      if isRectangularDom(this) {
+        var contains = true;
+        for i in 1..this.dims().size {
+          contains &&= super.dims()[i].contains(this.dims()[i]);
+          if contains == false then break;
+        }
+        return contains;
+      }
 
       return && reduce forall i in this do super.contains(i);
     }
@@ -1598,9 +1603,14 @@ module ChapelArray {
         } else
           compilerError("isSuper called with different associative domain types");
 
-      if isRectangularDom(this) then
-        return && reduce for i in 1..this.dims().size do
-          this.dims()[i].contains(sub.dims()[i]);
+      if isRectangularDom(this) {
+        var contains = true;
+        for i in 1..this.dims().size {
+          contains &&= this.dims()[i].contains(sub.dims()[i]);
+          if contains == false then break;
+        }
+        return contains;
+      }
 
       return && reduce forall i in sub do this.contains(i);
     }

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1567,10 +1567,14 @@ module ChapelArray {
           compilerError("isSubset not supported on this domain type");
       }
       if super.type != this.type then
-        compilerError("isSubset called with different associative domain types");
+        if isRectangularDom(this) {
+          if super.dims().size != this.dims().size then
+            compilerError("isSubset called with different rectangular domain types");
+        } else
+          compilerError("isSubset called with different associative domain types");
 
       if isRectangularDom(this) then
-        return && reduce forall i in 1..this.dims().size do
+        return && reduce for i in 1..this.dims().size do
           super.dims()[i].contains(this.dims()[i]);
 
       return && reduce forall i in this do super.contains(i);
@@ -1588,10 +1592,14 @@ module ChapelArray {
           compilerError("isSuper not supported on the domain type ", this.type);
       }
       if sub.type != this.type then
-        compilerError("isSuper called with different associative domain types");
+        if isRectangularDom(this) {
+          if sub.dims().size != this.dims().size then
+            compilerError("isSuper called with different rectangular domain types");
+        } else
+          compilerError("isSuper called with different associative domain types");
 
       if isRectangularDom(this) then
-        return && reduce forall i in 1..this.dims().size do
+        return && reduce for i in 1..this.dims().size do
           this.dims()[i].contains(sub.dims()[i]);
 
       return && reduce forall i in sub do this.contains(i);

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1569,7 +1569,7 @@ module ChapelArray {
       if super.type != this.type then
         if isRectangularDom(this) {
           if super.rank != this.rank then
-            compilerError("rank mismatch in _domain.isSubset()");
+            compilerError("rank mismatch in domain.isSubset()");
           else if super.low.type != this.low.type then
             compilerError("isSubset called with different index types");
         } else
@@ -1601,7 +1601,7 @@ module ChapelArray {
       if sub.type != this.type then
         if isRectangularDom(this) {
           if sub.rank != this.rank then
-            compilerError("rank mismatch in _domain.isSuper()");
+            compilerError("rank mismatch in domain.isSuper()");
           else if sub.low.type != this.low.type then
             compilerError("isSuper called with different index types");
         } else

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -1568,8 +1568,10 @@ module ChapelArray {
       }
       if super.type != this.type then
         if isRectangularDom(this) {
-          if super.dims().size != this.dims().size then
-            compilerError("isSubset called with different rectangular domain types");
+          if super.rank != this.rank then
+            compilerError("rank mismatch in _domain.isSubset()");
+          else if super.low.type != this.low.type then
+            compilerError("isSubset called with different index types");
         } else
           compilerError("isSubset called with different associative domain types");
 
@@ -1598,8 +1600,10 @@ module ChapelArray {
       }
       if sub.type != this.type then
         if isRectangularDom(this) {
-          if sub.dims().size != this.dims().size then
-            compilerError("isSuper called with different rectangular domain types");
+          if sub.rank != this.rank then
+            compilerError("rank mismatch in _domain.isSuper()");
+          else if sub.low.type != this.low.type then
+            compilerError("isSuper called with different index types");
         } else
           compilerError("isSuper called with different associative domain types");
 

--- a/test/associative/bharshbarg/domains/badSubsetCall.chpl
+++ b/test/associative/bharshbarg/domains/badSubsetCall.chpl
@@ -1,3 +1,4 @@
-var d : domain(1) = 1..10;
+var a = {1..5, 10..14};
+var b = {2..6};
 
-d.isSubset({1,2,3,4,5});
+b.isSubset(a);

--- a/test/associative/bharshbarg/domains/badSubsetCall.good
+++ b/test/associative/bharshbarg/domains/badSubsetCall.good
@@ -1,1 +1,1 @@
-badSubsetCall.chpl:3: error: isSubset not supported on rectangular domains
+badSubsetCall.chpl:4: error: isSubset called with different rectangular domain types

--- a/test/associative/bharshbarg/domains/badSubsetCall.good
+++ b/test/associative/bharshbarg/domains/badSubsetCall.good
@@ -1,1 +1,1 @@
-badSubsetCall.chpl:4: error: isSubset called with different rectangular domain types
+badSubsetCall.chpl:4: error: rank mismatch in _domain.isSubset()

--- a/test/associative/bharshbarg/domains/badSubsetCall.good
+++ b/test/associative/bharshbarg/domains/badSubsetCall.good
@@ -1,1 +1,1 @@
-badSubsetCall.chpl:4: error: rank mismatch in _domain.isSubset()
+badSubsetCall.chpl:4: error: rank mismatch in domain.isSubset()

--- a/test/associative/bharshbarg/domains/rectDom.chpl
+++ b/test/associative/bharshbarg/domains/rectDom.chpl
@@ -26,3 +26,10 @@ assert(rect_all.isSuper(rect_all));
   assert(rect_all.isSuper(rect_sub));
   assert(!rect_sub.isSuper(rect_all));
 }
+
+{
+  var rect_sub = {1..n by 2 align 1};
+  assert(rect_sub.isSubset(rect_all));
+  assert(rect_all.isSuper(rect_sub));
+  assert(!rect_sub.isSuper(rect_all));
+}

--- a/test/associative/bharshbarg/domains/rectDom.chpl
+++ b/test/associative/bharshbarg/domains/rectDom.chpl
@@ -9,6 +9,7 @@ assert(rect_all.isSuper(rect_all));
   var rect_sub = {1..n by 5};
   assert(rect_sub.isSubset(rect_all));
   assert(rect_all.isSuper(rect_sub));
+  assert(!rect_all.isSubset(rect_sub));
 }
 
 {
@@ -16,6 +17,7 @@ assert(rect_all.isSuper(rect_all));
   var rect_sub_2 = {1..n-1, 2..n-2};
   assert(rect_sub_2.isSubset(rect_sub_1));
   assert(rect_sub_1.isSuper(rect_sub_2));
+  assert(!rect_sub_1.isSubset(rect_sub_2));
 }
 
 {

--- a/test/associative/bharshbarg/domains/rectDom.chpl
+++ b/test/associative/bharshbarg/domains/rectDom.chpl
@@ -1,0 +1,26 @@
+config const n = 1000;
+
+var rect_all = {1..n};
+
+assert(rect_all.isSubset(rect_all));
+assert(rect_all.isSuper(rect_all));
+
+{
+  var rect_sub = {1..n by 5};
+  assert(rect_sub.isSubset(rect_all));
+  assert(rect_all.isSuper(rect_sub));
+}
+
+{
+  var rect_sub_1 = {1..n, 1..n};
+  var rect_sub_2 = {1..n-1, 2..n-2};
+  assert(rect_sub_2.isSubset(rect_sub_1));
+  assert(rect_sub_1.isSuper(rect_sub_2));
+}
+
+{
+  var rect_sub = {1..n/2};
+  assert(rect_sub.isSubset(rect_all));
+  assert(rect_all.isSuper(rect_sub));
+  assert(!rect_sub.isSuper(rect_all));
+}


### PR DESCRIPTION
Fixes #12651 

The `isSubset()` and `isSuper()` functions didn't work with rectangular domains earlier, particularly the ones containing ranges (see [this](https://github.com/chapel-lang/chapel/issues/12651#issuecomment-478269996)).

This fix works with multidimensional domains as well, as the `forall` loop yields tuples in case of multidimensional domains, and checks if they are present in `super`.