### PR TITLE
Issue an error when initializing variables from 'this' inside initializers

### DIFF
--- a/compiler/passes/InitNormalize.cpp
+++ b/compiler/passes/InitNormalize.cpp
@@ -943,26 +943,34 @@ void ProcessThisUses::visitSymExpr(SymExpr* node) {
   DefExpr* field = NULL;
 
   if (node->symbol()->hasFlag(FLAG_ARG_THIS)) {
-    CallExpr* call = NULL;
-    Expr* cur = node;
-    while (call == NULL && cur->parentExpr != NULL) {
-      if (CallExpr* parent = toCallExpr(cur->parentExpr)) {
-        call = parent;
+    if (DefExpr* parentDef = toDefExpr(node->parentExpr)) {
+      if (parentDef->sym->hasFlag(FLAG_REF_VAR)) {
+        USR_FATAL_CONT(node, "cannot take a reference to \"this\" before this.complete()");
       } else {
-        cur = cur->parentExpr;
+        USR_FATAL_CONT(node, "cannot initialize a variable from \"this\" before this.complete()");
       }
-    }
-
-    if (call->isPrimitive() == false) {
-      if (state->isPhase0()) {
-        USR_FATAL_CONT(node, "cannot pass \"this\" to a function before calling super.init() or this.init()");
-      } else if (state->type()->isRecord()) {
-        USR_FATAL_CONT(node, "cannot pass a record to a function before this.complete()");
+    } else {
+      CallExpr* call = NULL;
+      Expr* cur = node;
+      while (call == NULL && cur->parentExpr != NULL) {
+        if (CallExpr* parent = toCallExpr(cur->parentExpr)) {
+          call = parent;
+        } else {
+          cur = cur->parentExpr;
+        }
       }
-    }
 
-    if (isClass(state->type())) {
-      node->setSymbol(state->getThisAsParent());
+      if (call && call->isPrimitive() == false) {
+        if (state->isPhase0()) {
+          USR_FATAL_CONT(node, "cannot pass \"this\" to a function before calling super.init() or this.init()");
+        } else if (state->type()->isRecord()) {
+          USR_FATAL_CONT(node, "cannot pass a record to a function before this.complete()");
+        }
+      }
+
+      if (isClass(state->type())) {
+        node->setSymbol(state->getThisAsParent());
+      }
     }
   } else if (DefExpr* local = state->type()->toLocalField(node)) {
     field = local;

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -2226,6 +2226,12 @@ static void normRefVar(DefExpr* defExpr) {
     if (ArgSymbol* arg = toArgSymbol(symbol)) {
       if (arg->intent == INTENT_BLANK && arg->type == dtUnknown) {
         error = false;
+      } else if (arg->hasFlag(FLAG_ARG_THIS) &&
+                 arg->intent == INTENT_BLANK &&
+                 (arg->getFunction()->isInitializer() || arg->getFunction()->isCopyInit())) {
+        // InitNormalize.cpp will handle the case of initializing a ref-var
+        // from 'this' inside an initializer.
+        error = false;
       }
     }
 

--- a/test/classes/initializers/phase1/initFromThis.chpl
+++ b/test/classes/initializers/phase1/initFromThis.chpl
@@ -1,0 +1,42 @@
+// Based on issue #12695
+
+record R {
+  var x : int;
+
+  proc init() {
+    ref A = this;
+    A.x = 10;
+    const ref B = this;
+    writeln(B);
+    var foo = this;
+    writeln(foo);
+  }
+
+  proc init=(other:R) {
+    ref A = this;
+    A.x = other.x;
+    const ref B = this;
+    writeln(B);
+    var foo = this;
+    writeln(foo);
+  }
+}
+
+class C {
+  var x : int;
+
+  proc init() {
+    ref A = this;
+    A.x = 10;
+    const ref B = this;
+    writeln(B);
+    var foo = this;
+    writeln(foo);
+  }
+}
+
+proc main() {
+  var X : R;
+  var Y = X;
+  var Z = new C();
+}

--- a/test/classes/initializers/phase1/initFromThis.good
+++ b/test/classes/initializers/phase1/initFromThis.good
@@ -1,0 +1,12 @@
+initFromThis.chpl:6: In initializer:
+initFromThis.chpl:7: error: cannot take a reference to "this" before this.complete()
+initFromThis.chpl:9: error: cannot take a reference to "this" before this.complete()
+initFromThis.chpl:11: error: cannot initialize a variable from "this" before this.complete()
+initFromThis.chpl:15: In function 'init=':
+initFromThis.chpl:16: error: cannot take a reference to "this" before this.complete()
+initFromThis.chpl:18: error: cannot take a reference to "this" before this.complete()
+initFromThis.chpl:20: error: cannot initialize a variable from "this" before this.complete()
+initFromThis.chpl:28: In initializer:
+initFromThis.chpl:29: error: cannot take a reference to "this" before this.complete()
+initFromThis.chpl:31: error: cannot take a reference to "this" before this.complete()
+initFromThis.chpl:33: error: cannot initialize a variable from "this" before this.complete()


### PR DESCRIPTION
This PR updates the compiler to issue an error when a variable is initialized with 'this' inside an initializer (before this.complete()):
```chpl
// should be errors
ref x = this;
var y = this;
```

The normalize() pass has been updated to avoid issuing an error for the same case.

Resolves #12695 

Testing:
- [x] local + futures