### PR TITLE
Improve the quality of our graph screenshots

### DIFF
--- a/util/test/perf/index.html
+++ b/util/test/perf/index.html
@@ -13,7 +13,8 @@
         <script src="http://dygraphs.com/excanvas.js"></script>
         <![endif]-->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/0.4.1/html2canvas.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.0.0-alpha.12/dist/html2canvas.min.js"></script>
+
 
     <!-- Overrides the default Date.parse -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.18.1/moment.min.js"></script>

--- a/util/test/perf/index.html
+++ b/util/test/perf/index.html
@@ -19,7 +19,7 @@
     <!-- Overrides the default Date.parse -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.18.1/moment.min.js"></script>
 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/dygraph/2.0.0/dygraph.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/dygraph/2.1.0/dygraph.min.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/dygraph/2.0.0/dygraph.min.css" />
 
     <script src="graphdata.js"></script>

--- a/util/test/perf/perfgraph.js
+++ b/util/test/perf/perfgraph.js
@@ -302,7 +302,7 @@ function genDygraph(graphInfo, graphDivs, graphData, graphLabels, expandInfo) {
     },
     includeZero: true,
     connectSeparatedPoints: true,
-    showRoller: true,
+    showRoller: false,
     legend: 'always',
     customBars: graphInfo.displayrange,
     highlightSeriesOpts: {
@@ -628,13 +628,11 @@ function captureScreenshot(g, graphInfo) {
   var label = graphInfo.ylabel;
 
   var restoreOpts = {
-    showRoller: true,
     ylabel: label,
     valueRange: g.yAxisRange(0),
   };
 
   var tempOpts = {
-    showRoller: false,
     ylabel: '',
     valueRange: g.yAxisRange(0),
   };

--- a/util/test/perf/perfgraph.js
+++ b/util/test/perf/perfgraph.js
@@ -217,14 +217,19 @@ function getNextDivs(afterDiv) {
   container.className = 'graphContainer';
   graphPane.insertBefore(container, beforeDiv);
 
+
   // create the graph/legend divs and spacers
+  var gLDiv = document.createElement('div');
+  gLDiv.className = 'graphContainer';
+  container.appendChild(gLDiv);
+
   var div = document.createElement('div');
   div.className = 'perfGraph';
-  container.appendChild(div);
+  gLDiv.appendChild(div);
 
   var ldiv = document.createElement('div');
   ldiv.className = 'perfLegend';
-  container.appendChild(ldiv);
+  gLDiv.appendChild(ldiv);
 
   var gspacer = document.createElement('div');
   gspacer.className = 'gspacer';
@@ -251,6 +256,7 @@ function getNextDivs(afterDiv) {
   return {
     div: div,
     ldiv: ldiv,
+    gLDiv: gLDiv,
     logToggle: logToggle,
     annToggle: annToggle,
     screenshotToggle: screenshotToggle,

--- a/util/test/perf/perfgraph.js
+++ b/util/test/perf/perfgraph.js
@@ -126,11 +126,6 @@ var lastFilterVal = "";
 
 var filterBox = $("[name='filterBox']")[0];
 
-// Pixel ratio/scaling factor. dygraphs/html2canvas use the device's pixelRatio
-// by default, but this results in grainy screenshots on devices with a low
-// ratio (e.g. non-retina screens), so make it at least 2.
-var devicePixelRatio = window.devicePixelRatio || 1;
-var pixelRatio = Math.max(devicePixelRatio, 2);
 
 // redirect ctrl+f to the filter box
 $(document).keydown(function(e) {
@@ -307,7 +302,7 @@ function genDygraph(graphInfo, graphDivs, graphData, graphLabels, expandInfo) {
         axisLabelFormatter: customAxisLabelFormatter
       }
     },
-    pixelRatio: pixelRatio,
+    pixelRatio: getPixelRatio(),
     includeZero: true,
     connectSeparatedPoints: true,
     showRoller: false,
@@ -618,7 +613,7 @@ function captureScreenshot(g, graphInfo, showLegend) {
   var div = g.divs.gLDiv;
   if (showLegend === false) { div = g.divs.div; }
 
-  html2canvas(div, {scale:pixelRatio}).then(function(canvas) {
+  html2canvas(div, {scale:getPixelRatio()}).then(function(canvas) {
     var size = "width=" + div.clientWidth + " height=" + div.clientHeight;
     var img = canvas.toDataURL();
     window.open().document.write('<img src="' + img + '" ' + size + ' />');
@@ -1265,6 +1260,21 @@ function setURLFromGraphs(suite) {
 }
 
 
+// Pixel ratio/scaling factor. dygraphs/html2canvas use the device's pixelRatio
+// by default, but this results in grainy screenshots on devices with a low
+// ratio (e.g. non-retina screens), so make it at least 2 allowing the user to
+// override with URL hacking.
+function getPixelRatio() {
+  var devicePixelRatio = window.devicePixelRatio || 1;
+  var pixelRatio = Math.max(devicePixelRatio, 2);
+  var pixelRatioUrl = getOption(OptionsEnum.PIXEL_RATIO);
+  if (pixelRatioUrl) {
+    pixelRatio = pixelRatioUrl;
+  }
+  return pixelRatio;
+}
+
+
 // reset the date range
 function clearDates() {
   // clear the query string
@@ -1486,7 +1496,8 @@ OptionsEnum = {
   ENDDATE        : 'enddate',
   CONFIGURATIONS : 'configs',
   GRAPHS         : 'graphs',
-  SUITE          : 'suite'
+  SUITE          : 'suite',
+  PIXEL_RATIO    : 'pixelRatio'
 }
 
 

--- a/util/test/perf/perfgraph.js
+++ b/util/test/perf/perfgraph.js
@@ -250,10 +250,11 @@ function getNextDivs(afterDiv) {
     return button;
   }
 
-  var logToggle        = addButtonHelper('log');
-  var annToggle        = addButtonHelper('annotations');
-  var screenshotToggle = addButtonHelper('screenshot');
-  var resetY           = addButtonHelper('reset y zoom');
+  var logToggle           = addButtonHelper('log');
+  var annToggle           = addButtonHelper('annotations');
+  var screenshotToggle    = addButtonHelper('screenshot');
+  var screenshotNoLToggle = addButtonHelper('screenshot (no legend)');
+  var resetY              = addButtonHelper('reset y zoom');
 
   // We prefer this button to be last.
   var closeGraphToggle = addButtonHelper('close');
@@ -265,6 +266,7 @@ function getNextDivs(afterDiv) {
     logToggle: logToggle,
     annToggle: annToggle,
     screenshotToggle: screenshotToggle,
+    screenshotNoLToggle: screenshotNoLToggle,
     closeGraphToggle: closeGraphToggle,
     resetY: resetY,
     gspacer: gspacer,
@@ -368,7 +370,8 @@ function genDygraph(graphInfo, graphDivs, graphData, graphLabels, expandInfo) {
 
     setupLogToggle(g, graphInfo, graphDivs.logToggle);
     setupAnnToggle(g, graphInfo, graphDivs.annToggle);
-    setupScreenshotToggle(g, graphInfo, graphDivs.screenshotToggle);
+    setupScreenshotToggle(g, graphInfo, graphDivs.screenshotToggle, true);
+    setupScreenshotToggle(g, graphInfo, graphDivs.screenshotNoLToggle, false);
     setupCloseGraphToggle(g, graphInfo, graphDivs.closeGraphToggle);
     setupResetYZoom(g, graphInfo, graphDivs.resetY);
 
@@ -557,11 +560,11 @@ function setupAnnToggle(g, graphInfo, annToggle) {
 
 
 // Setup the screenshot button
-function setupScreenshotToggle(g, graphInfo, screenshotToggle) {
+function setupScreenshotToggle(g, graphInfo, screenshotToggle, showLegend) {
   screenshotToggle.style.visibility = 'visible';
 
   screenshotToggle.onclick = function() {
-    captureScreenshot(g, graphInfo);
+    captureScreenshot(g, graphInfo, showLegend);
   }
 }
 
@@ -611,8 +614,9 @@ function setupResetYZoom(g, graphInfo, resetY) {
 
 // Function to capture a screenshot of a graph and open the image in a new
 // window.
-function captureScreenshot(g, graphInfo) {
+function captureScreenshot(g, graphInfo, showLegend) {
   var div = g.divs.gLDiv;
+  if (showLegend === false) { div = g.divs.div; }
 
   html2canvas(div, {scale:pixelRatio}).then(function(canvas) {
     var size = "width=" + div.clientWidth + " height=" + div.clientHeight;

--- a/util/test/perf/perfgraph.js
+++ b/util/test/perf/perfgraph.js
@@ -305,6 +305,7 @@ function genDygraph(graphInfo, graphDivs, graphData, graphLabels, expandInfo) {
         axisLabelFormatter: customAxisLabelFormatter
       }
     },
+    pixelRatio: pixelRatio,
     includeZero: true,
     connectSeparatedPoints: true,
     showRoller: false,
@@ -1363,6 +1364,7 @@ function displaySelectedGraphs() {
 
   // Disable filtering until the jsons are done
   disableFilterBox(true);
+  var genStart = Date.now();
 
   // generate the dygraph(s) for the currently selected graphs
   for (var i = 0; i < allGraphs.length; i++) {
@@ -1373,9 +1375,10 @@ function displaySelectedGraphs() {
   }
 
   $.when.apply($, jsons).done(function() {
-      console.log("done generating graphs");
-      doFilter();
-      disableFilterBox(false);
+    var elapsed = Date.now() - genStart;
+    console.log("done generating graphs: " + elapsed + " ms");
+    doFilter();
+    disableFilterBox(false);
   });
 
   // update the url for the displayed graphs


### PR DESCRIPTION
This significantly improves the quality of our graph screenshots and they
should now be as high-quality as native captures. The screenshot functionality
is convenient but previously the graphs produced were pretty low quality
(low-res/grainy and had an opaque background) so we often ended up grabbing
manual screenshots when we needed them in slides. With this, we shouldn't have
to manually grab screenshots. If even higher resolutions are required, that can
be done with URL hacking (by adding `pixelRatio=<val>`), but I don't think that
will be needed.

This improves the quality by upgrading our dygraphs and html2canvas versions
and using new features that allow us to manually set the pixelRatio so that we
can generate higher res graphs. html2canvas also has a lot more feature
coverage so we don't have to manually add labels or anything anymore, which
simplifies the screenshot generation. Below are some before/after comparisons
(click to open in a new tab to see the differences):

- Previous screenshot (low-res, extra right-padding,  opaque background)

  ![image](https://user-images.githubusercontent.com/1588337/55595287-fb079600-56f7-11e9-97f2-c90867c574f8.png)

- Previous screenshot (manually cropped and put on white background):

  ![image](https://user-images.githubusercontent.com/1588337/55595513-10c98b00-56f9-11e9-8b3d-d782921cb5cf.png)

- Interim screenshot (just html2canvas improvements, graph lines still blurry):

  ![image](https://user-images.githubusercontent.com/1588337/55595588-7cabf380-56f9-11e9-8387-fd941358d8c1.png)

- Current screenshot (dygraphs+html2canvas improvements, the new default):

  ![image](https://user-images.githubusercontent.com/1588337/55595289-fe028680-56f7-11e9-87b3-8632328aec57.png)

- Current screenshot (with  pixelRatio=4 -- double default):

  ![image](https://user-images.githubusercontent.com/1588337/55597227-568a5180-5701-11e9-9660-556967209d52.png)
