### PR TITLE
Enable json printing for block arrays, precision for real arrays

### DIFF
--- a/modules/dists/BlockCycDist.chpl
+++ b/modules/dists/BlockCycDist.chpl
@@ -919,33 +919,15 @@ iter BlockCyclicArr.these(param tag: iterKind, followThis) ref where tag == iter
   }
 }
 
+proc BlockCyclicArr.dsiSerialRead(f) {
+  chpl_serialReadWriteRectangular(f, this);
+}
+
 //
 // output array
 //
 proc BlockCyclicArr.dsiSerialWrite(f) {
-  if dom.dsiNumIndices == 0 then return;
-  var i : rank*idxType;
-  for dim in 1..rank do
-    i(dim) = dom.dsiDim(dim).low;
-  label next while true {
-    f <~> dsiAccess(i);
-    if i(rank) <= (dom.dsiDim(rank).high - dom.dsiDim(rank).stride:idxType) {
-      f <~> " ";
-      i(rank) += dom.dsiDim(rank).stride:idxType;
-    } else {
-      for dim in 1..rank-1 by -1 {
-        if i(dim) <= (dom.dsiDim(dim).high - dom.dsiDim(dim).stride:idxType) {
-          i(dim) += dom.dsiDim(dim).stride:idxType;
-          for dim2 in dim+1..rank {
-            f <~> "\n";
-            i(dim2) = dom.dsiDim(dim2).low;
-          }
-          continue next;
-        }
-      }
-      break;
-    }
-  }
+  chpl_serialReadWriteRectangular(f, this);
 }
 
 proc BlockCyclicArr.dsiTargetLocales() {

--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -1114,31 +1114,7 @@ proc BlockArr.dsiSerialRead(f) {
 // output array
 //
 proc BlockArr.dsiSerialWrite(f) {
-  type strType = chpl__signedType(idxType);
-  var binary = f.binary();
-  if dom.dsiNumIndices == 0 then return;
-  var i : rank*idxType;
-  for dim in 1..rank do
-    i(dim) = dom.dsiDim(dim).low;
-  label next while true {
-    f <~> dsiAccess(i);
-    if i(rank) <= (dom.dsiDim(rank).high - dom.dsiDim(rank).stride:strType) {
-      if ! binary then f <~> " ";
-      i(rank) += dom.dsiDim(rank).stride:strType;
-    } else {
-      for dim in 1..rank-1 by -1 {
-        if i(dim) <= (dom.dsiDim(dim).high - dom.dsiDim(dim).stride:strType) {
-          i(dim) += dom.dsiDim(dim).stride:strType;
-          for dim2 in dim+1..rank {
-            f <~> "\n";
-            i(dim2) = dom.dsiDim(dim2).low;
-          }
-          continue next;
-        }
-      }
-      break;
-    }
-  }
+  chpl_serialReadWriteRectangular(f, this);
 }
 
 pragma "no copy return"

--- a/modules/dists/CyclicDist.chpl
+++ b/modules/dists/CyclicDist.chpl
@@ -922,34 +922,12 @@ iter CyclicArr.these(param tag: iterKind, followThis, param fast: bool = false) 
   }
 }
 
+proc CyclicArr.dsiSerialRead(f) {
+  chpl_serialReadWriteRectangular(f, this);
+}
+
 proc CyclicArr.dsiSerialWrite(f) {
-  if verboseCyclicDistWriters {
-    writeln(this.type:string);
-    writeln("------");
-  }
-  if dom.dsiNumIndices == 0 then return;
-  var i : rank*idxType;
-  for dim in 1..rank do
-    i(dim) = dom.dsiDim(dim).low;
-  label next while true {
-    f.write(dsiAccess(i));
-    if i(rank) <= (dom.dsiDim(rank).high - dom.dsiDim(rank).stride:idxType) {
-      f.write(" ");
-      i(rank) += dom.dsiDim(rank).stride:idxType;
-    } else {
-      for dim in 1..rank-1 by -1 {
-        if i(dim) <= (dom.dsiDim(dim).high - dom.dsiDim(dim).stride:idxType) {
-          i(dim) += dom.dsiDim(dim).stride:idxType;
-          for dim2 in dim+1..rank {
-            f.writeln();
-            i(dim2) = dom.dsiDim(dim2).low;
-          }
-          continue next;
-        }
-      }
-      break;
-    }
-  }
+  chpl_serialReadWriteRectangular(f, this);
 }
 
 override proc CyclicArr.dsiReallocate(bounds:rank*range(idxType,BoundedRangeType.bounded,stridable)) {

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -4734,7 +4734,8 @@ Going through each section for text conversions:
 [conversion type]
    ``t``
     means *type-based* or *thing* - uses writeThis/readThis but ignores
-    width and precision
+    width. Precision will impact any floating point values output
+    in this conversion.
    ``n``
     means type-based number, allowing width and precision
    ``i``

--- a/runtime/src/qio/qio_formatted.c
+++ b/runtime/src/qio/qio_formatted.c
@@ -4512,6 +4512,16 @@ qioerr qio_conv_parse(c_string fmt,
       style_out->realfmt = 2;
       style_out->string_format = QIO_STRING_FORMAT_CHPL;
 
+      // Handle precision
+      if( precision != WIDTH_NOT_SET ) {
+        // These settings have no effect when scanning
+        if( precision == WIDTH_IN_ARG ) {
+          spec_out->preArg2 = QIO_CONV_SET_PRECISION;
+        } else {
+          style_out->precision = precision;
+        }
+      }
+
       if( sloppy_flag ) {
         style_out->skip_unknown_fields = 1;
       }

--- a/test/io/ferguson/big-precision-t-lossless.chpl
+++ b/test/io/ferguson/big-precision-t-lossless.chpl
@@ -1,0 +1,71 @@
+config const verbose = false;
+
+{
+  writeln("Testing default array");
+  var A:[1..10] real;
+  A = sqrt(1.0 / (1..10));
+  A[5..10] = exp(-50.0 * (5..10));
+  var B = A;
+
+  if verbose then
+    writef("%.20t\n", A);
+
+  var testfile = openmem();
+  {
+    testfile.writer().writef("%.20t\n", A);
+  }
+
+  A = 0.0;
+
+  {
+    testfile.reader().readf("%t\n", A);
+  }
+
+  if verbose {
+    writeln("Expected:");
+    for x in B {
+      writef("%r %.17er %xr\n", x, x, x);
+    }
+    writeln("Got:");
+    for x in A {
+      writef("%r %.17er %xr\n", x, x, x);
+    }
+  }
+
+  writeln(B.equals(A));
+}
+
+{
+  writeln("Testing default array with json");
+  var A:[1..10] real;
+  A = sqrt(1.0 / (1..10));
+  A[5..10] = exp(-50.0 * (5..10));
+  var B = A;
+
+  if verbose then
+    writef("%.20jt\n", A);
+
+  var testfile = openmem();
+  {
+    testfile.writer().writef("%.20jt\n", A);
+  }
+
+  A = 0.0;
+
+  {
+    testfile.reader().readf("%jt\n", A);
+  }
+
+  if verbose {
+    writeln("Expected:");
+    for x in B {
+      writef("%r %.17er %xr\n", x, x, x);
+    }
+    writeln("Got:");
+    for x in A {
+      writef("%r %.17er %xr\n", x, x, x);
+    }
+  }
+
+  writeln(B.equals(A));
+}

--- a/test/io/ferguson/big-precision-t-lossless.good
+++ b/test/io/ferguson/big-precision-t-lossless.good
@@ -1,0 +1,4 @@
+Testing default array
+true
+Testing default array with json
+true

--- a/test/io/ferguson/json-distributed-arrays.chpl
+++ b/test/io/ferguson/json-distributed-arrays.chpl
@@ -1,0 +1,77 @@
+use BlockDist;
+use CyclicDist;
+use BlockCycDist;
+
+var expect = "[1, 2, 3, 4, 5]";
+
+var expectfile = openmem();
+{
+  expectfile.writer().write(expect);
+  // temporary writer flushed and closed at this curly
+}
+
+{
+  writeln("Testing default array");
+  var A:[1..5] int;
+  A = 1..5;
+
+  writef("%jt\n", A);
+  var got = "%jt".format(A);
+  assert(got == expect);
+
+  A = 0;
+  expectfile.reader().readf("%jt\n", A);
+  writef("%jt\n", A);
+  var got2 = "%jt".format(A);
+  assert(got2 == expect);
+}
+
+{
+  writeln("Testing block array");
+  var A = newBlockArr({1..5}, int);
+  A = 1..5;
+
+  writef("%jt\n", A);
+  var got = "%jt".format(A);
+  assert(got == expect);
+  
+  A = 0;
+  expectfile.reader().readf("%jt\n", A);
+  writef("%jt\n", A);
+  var got2 = "%jt".format(A);
+  assert(got2 == expect);
+}
+
+{
+  writeln("Testing cyclic array");
+  var A = newCyclicArr({1..5}, int);
+  A = 1..5;
+
+  writef("%jt\n", A);
+  var got = "%jt".format(A);
+  assert(got == expect);
+  
+  A = 0;
+  expectfile.reader().readf("%jt\n", A);
+  writef("%jt\n", A);
+  var got2 = "%jt".format(A);
+  assert(got2 == expect);
+}
+
+{
+  writeln("Testing block cyclic array");
+  const Space = {1..5};
+  var D = Space dmapped BlockCyclic(startIdx=Space.low,blocksize=2);
+  var A:[D] int;
+  A = 1..5;
+
+  writef("%jt\n", A);
+  var got = "%jt".format(A);
+  assert(got == expect);
+  
+  A = 0;
+  expectfile.reader().readf("%jt\n", A);
+  writef("%jt\n", A);
+  var got2 = "%jt".format(A);
+  assert(got2 == expect);
+}

--- a/test/io/ferguson/json-distributed-arrays.good
+++ b/test/io/ferguson/json-distributed-arrays.good
@@ -1,0 +1,12 @@
+Testing default array
+[1, 2, 3, 4, 5]
+[1, 2, 3, 4, 5]
+Testing block array
+[1, 2, 3, 4, 5]
+[1, 2, 3, 4, 5]
+Testing cyclic array
+[1, 2, 3, 4, 5]
+[1, 2, 3, 4, 5]
+Testing block cyclic array
+[1, 2, 3, 4, 5]
+[1, 2, 3, 4, 5]


### PR DESCRIPTION
This PR addresses two problems related to JSON I/O of arrays:
 * Block, Cyclic, and BlockCyclic arrays did not print properly with JSON output
 * Format strings like %jt to print an array could result in loss of precision.

To fix the first, it calls chpl_serialReadWriteRectangular for these array types.
To fix the second, it updates the format string parser to read a precision like 20 in %.20t or %.20jt into the style's precision for floating point values (so it is used when outputting them but ignored for other types and when reading). Updated the FormattedIO documentation to indicate this.

- [x] full local testing
- [x] full local gasnet testing