### PR TITLE
Move our python 2/3 compatibility code into a helper module

### DIFF
--- a/util/test/py3_compat.py
+++ b/util/test/py3_compat.py
@@ -1,17 +1,20 @@
 """
-Python 2/3 compatibility shim. We use subprocess.Popen.communicate() all over
-sub_test. Instead of updating every call site to do the right thing with regard
-to byte to str conversions for 3 compatibility, we have opted to add this
-wrapper. Not all things we run will produce utf-8 (i.e. catfiles for thing like
-mandelbrot will return binary data) so we allow the conversion to utf-8 to
-silently fail and we handle any issues at those call sites.
+Python 2/3 compatibility shim. We use subprocess.Popen.communicate() all over.
+Instead of updating every call site to do the right thing with regard to byte
+to str conversions for 3 compatibility, we have opted to add this wrapper. Not
+all things we run will produce utf-8 (i.e. catfiles for thing like mandelbrot
+will return binary data) so we allow the conversion to utf-8 to silently fail
+and we handle any issues at the call sites.
 """
 
 import subprocess
 import sys
 
+def instance_or_none(val, val_type):
+    return val is None or isinstance(val, val_type)
+
 def bytes_to_str(byte_string):
-    if sys.version_info[0] >= 3 and not isinstance(byte_string, str):
+    if sys.version_info[0] >= 3 and not instance_or_none(byte_string, str):
         try:
             return str(byte_string, 'utf-8')
         except UnicodeDecodeError as e:
@@ -21,7 +24,7 @@ def bytes_to_str(byte_string):
         return byte_string
 
 def str_to_bytes(str_string):
-    if sys.version_info[0] >= 3 and not isinstance(str_string, bytes):
+    if sys.version_info[0] >= 3 and not instance_or_none(str_string, bytes):
         return bytes(str_string, 'utf-8')
     else:
         return str_string
@@ -39,29 +42,24 @@ def concat_streams(stdout, stderr):
     return stdout + stderr
 
 class Py3CompatPopen(object):
+    """ Popen wrapper where communicate will convert input to bytes, and try to
+        convert output to str. Note that communicate() will try to stderr and
+        strerr to str independently (so you could end up with 1 being str and
+        the other being bytes)"""
 
     def __init__(self, popen):
         self._popen = popen
 
-    def communicate(self):
-        c = self._popen.communicate()
-        return Py3CompatCommGetter(c)
+    def communicate(self, input=None):
+        bytes_input = str_to_bytes(input)
+        stdout, stderr = self._popen.communicate(bytes_input)
+        str_stdout = bytes_to_str(stdout)
+        str_stderr = bytes_to_str(stderr)
+        return (str_stdout, str_stderr)
 
     def __getattr__(self, name):
         return getattr(self._popen, name)
 
-
-class Py3CompatCommGetter(object):
-
-    def __init__(self, comm_result):
-        self._c = comm_result
-
-    def __getitem__(self, key):
-        val = self._c[key]
-        if key == 0 or key == 1:
-            return bytes_to_str(val)
-        else:
-            return val
 
 def Popen(*args, **kwargs):
     p = subprocess.Popen(*args, **kwargs)

--- a/util/test/py3_compat.py
+++ b/util/test/py3_compat.py
@@ -1,10 +1,13 @@
 """
 Python 2/3 compatibility shim. We use subprocess.Popen.communicate() all over.
 Instead of updating every call site to do the right thing with regard to byte
-to str conversions for 3 compatibility, we have opted to add this wrapper. Not
-all things we run will produce utf-8 (i.e. catfiles for thing like mandelbrot
-will return binary data) so we allow the conversion to utf-8 to silently fail
-and we handle any issues at the call sites.
+to str conversions, we have opted to use this wrapper which assumes our
+input/output to subprocesses will always be utf-8 strings. There are some cases
+where that's not true (e.g. catfiles for Mandelbrot are binary), so we allow
+the conversion to silently fail and we handle any issues at the call site.
+
+This is probably one of the worst ways to get python 2 and 3 compatibility, but
+it is pretty straightforward. A better solution might be to use six or future.
 """
 
 import subprocess

--- a/util/test/py3_compat.py
+++ b/util/test/py3_compat.py
@@ -1,0 +1,68 @@
+"""
+Python 2/3 compatibility shim. We use subprocess.Popen.communicate() all over
+sub_test. Instead of updating every call site to do the right thing with regard
+to byte to str conversions for 3 compatibility, we have opted to add this
+wrapper. Not all things we run will produce utf-8 (i.e. catfiles for thing like
+mandelbrot will return binary data) so we allow the conversion to utf-8 to
+silently fail and we handle any issues at those call sites.
+"""
+
+import subprocess
+import sys
+
+def bytes_to_str(byte_string):
+    if sys.version_info[0] >= 3 and not isinstance(byte_string, str):
+        try:
+            return str(byte_string, 'utf-8')
+        except UnicodeDecodeError as e:
+            pass
+        return byte_string
+    else:
+        return byte_string
+
+def str_to_bytes(str_string):
+    if sys.version_info[0] >= 3 and not isinstance(str_string, bytes):
+        return bytes(str_string, 'utf-8')
+    else:
+        return str_string
+
+def concat_streams(stdout, stderr):
+    """ Concats stderr to stdout. Returns str if both are utf-8 strings, bytes otherwise """
+    if sys.version_info[0] >= 3:
+        str_stdout = bytes_to_str(stdout)
+        str_stderr = bytes_to_str(stderr)
+        if isinstance(str_stdout, str) and isinstance(str_stderr, str):
+            return str_stdout + str_stderr
+        else:
+            return str_to_bytes(stdout) + str_to_bytes(stderr)
+
+    return stdout + stderr
+
+class Py3CompatPopen(object):
+
+    def __init__(self, popen):
+        self._popen = popen
+
+    def communicate(self):
+        c = self._popen.communicate()
+        return Py3CompatCommGetter(c)
+
+    def __getattr__(self, name):
+        return getattr(self._popen, name)
+
+
+class Py3CompatCommGetter(object):
+
+    def __init__(self, comm_result):
+        self._c = comm_result
+
+    def __getitem__(self, key):
+        val = self._c[key]
+        if key == 0 or key == 1:
+            return bytes_to_str(val)
+        else:
+            return val
+
+def Popen(*args, **kwargs):
+    p = subprocess.Popen(*args, **kwargs)
+    return Py3CompatPopen(p)

--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -132,6 +132,7 @@
 from __future__ import with_statement
 
 import execution_limiter
+import py3_compat
 import sys, os, subprocess, string, signal
 import operator
 import select, fcntl
@@ -164,71 +165,6 @@ atexit.register(elapsed_sub_test_time)
 #   can be unreliable (will not respond if holding certain locks).
 #
 class ReadTimeoutException(Exception): pass
-
-
-# Python 2/3 compatibility shim. We use subprocess.Popen.communicate() all
-# over sub_test. Instead of updating every call site to do the right thing with
-# regard to byte to str conversions for 3 compatibility, we have opted to add
-# this wrapper. Not all things we run will produce utf-8 (i.e. catfiles for
-# thing like mandelbrot will return binary data) so we allow the conversion
-# to utf-8 to silently fail and we handle any issues at those call sites.
-def bytes_to_str(byte_string):
-    if sys.version_info[0] >= 3 and not isinstance(byte_string, str):
-        try:
-            return str(byte_string, 'utf-8')
-        except UnicodeDecodeError as e:
-            pass
-        return byte_string
-    else:
-        return byte_string
-
-def str_to_bytes(str_string):
-    if sys.version_info[0] >= 3 and not isinstance(str_string, bytes):
-        return bytes(str_string, 'utf-8')
-    else:
-        return str_string
-
-def concat_streams(stdout, stderr):
-    """ Concats stderr to stdout. Returns str if both are utf-8 strings, bytes otherwise """
-    if sys.version_info[0] >= 3:
-        str_stdout = bytes_to_str(stdout)
-        str_stderr = bytes_to_str(stderr)
-        if isinstance(str_stdout, str) and isinstance(str_stderr, str):
-            return str_stdout + str_stderr
-        else:
-            return str_to_bytes(stdout) + str_to_bytes(stderr)
-
-    return stdout + stderr
-
-class Py3CompatPopen(object):
-
-    def __init__(self, popen):
-        self._popen = popen
-
-    def communicate(self):
-        c = self._popen.communicate()
-        return Py3CompatCommGetter(c)
-
-    def __getattr__(self, name):
-        return getattr(self._popen, name)
-
-
-class Py3CompatCommGetter(object):
-
-    def __init__(self, comm_result):
-        self._c = comm_result
-
-    def __getitem__(self, key):
-        val = self._c[key]
-        if key == 0 or key == 1:
-            return bytes_to_str(val)
-        else:
-            return val
-
-
-def Popen(*args, **kwargs):
-    p = subprocess.Popen(*args, **kwargs)
-    return Py3CompatPopen(p)
 
 
 def SetNonBlock(stream):
@@ -324,13 +260,13 @@ def ReadFileWithComments(f, ignoreLeadingSpace=True):
         try:
             # grab the chplenv so it can be stuffed into the subprocess env
             env_cmd = [os.path.join(utildir, 'printchplenv'), '--all', '--simple', '--no-tidy', '--internal']
-            chpl_env = Popen(env_cmd, stdout=subprocess.PIPE).communicate()[0]
+            chpl_env = py3_compat.Popen(env_cmd, stdout=subprocess.PIPE).communicate()[0]
             chpl_env = dict(map(lambda l: l.split('=', 1), chpl_env.splitlines()))
             file_env = os.environ.copy()
             file_env.update(chpl_env)
 
             # execute the file and grab its output
-            cmd = Popen([os.path.abspath(f)], stdout=subprocess.PIPE, env=file_env)
+            cmd = py3_compat.Popen([os.path.abspath(f)], stdout=subprocess.PIPE, env=file_env)
             mylines = cmd.communicate()[0].splitlines()
 
         except OSError as e:
@@ -361,8 +297,8 @@ def ReadFileWithComments(f, ignoreLeadingSpace=True):
 # diff 2 files
 def DiffFiles(f1, f2):
     sys.stdout.write('[Executing diff %s %s]\n'%(f1, f2))
-    p = Popen(['diff',f1,f2],
-              stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    p = py3_compat.Popen(['diff',f1,f2],
+                         stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     myoutput = p.communicate()[0] # grab stdout to avoid potential deadlock
     if p.returncode != 0:
         sys.stdout.write(trim_output(myoutput))
@@ -370,8 +306,8 @@ def DiffFiles(f1, f2):
 
 def DiffBinaryFiles(f1, f2):
     sys.stdout.write('[Executing binary diff %s %s]\n'%(f1, f2))
-    p = Popen(['diff', '-a', f1,f2],
-              stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    p = py3_compat.Popen(['diff', '-a', f1,f2],
+                         stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     myoutput = p.communicate()[0] # grab stdout to avoid potential deadlock
     if p.returncode != 0:
         sys.stdout.write(trim_output(myoutput))
@@ -381,8 +317,8 @@ def DiffBinaryFiles(f1, f2):
 # in module files.
 def DiffBadFiles(f1, f2):
     sys.stdout.write('[Executing diff-ignoring-module-line-numbers %s %s]\n'%(f1, f2))
-    p = Popen([utildir+'/test/diff-ignoring-module-line-numbers', f1, f2],
-              stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    p = py3_compat.Popen([utildir+'/test/diff-ignoring-module-line-numbers', f1, f2],
+                         stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     myoutput = p.communicate()[0] # grab stdout to avoid potential deadlock
     if p.returncode != 0:
         sys.stdout.write(myoutput)
@@ -390,7 +326,7 @@ def DiffBadFiles(f1, f2):
 
 # kill process
 def KillProc(p, timeout):
-    k = Popen(['kill',str(p.pid)])
+    k = py3_compat.Popen(['kill',str(p.pid)])
     k.wait()
     now = time.time()
     end_time = now + timeout # give it a little time
@@ -399,7 +335,7 @@ def KillProc(p, timeout):
             return
         now = time.time()
     # use the big hammer (and don't bother waiting)
-    Popen(['kill','-9', str(p.pid)])
+    py3_compat.Popen(['kill','-9', str(p.pid)])
     return
 
 # clean up after the test has been built
@@ -419,11 +355,11 @@ def cleanup(execname):
             lsof = which('lsof')
             if handle is not None:
                 sys.stdout.write('[Inspecting open file handles with: {0}\n'.format(handle))
-                Popen([handle]).communicate()
+                py3_compat.Popen([handle]).communicate()
             elif lsof is not None:
                 cmd = [lsof, execname]
                 sys.stdout.write('[Inspecting open file handles with: {0}\n'.format(' '.join(cmd)))
-                Popen(cmd).communicate()
+                py3_compat.Popen(cmd).communicate()
 
         # Do not print the warning for cygwin32 when errno is 16 (Device or resource busy).
         if not (getattr(ex, 'errno', 0) == 16 and platform == 'cygwin32'):
@@ -584,7 +520,7 @@ def get_exec_log_name(execname, comp_opts_count=None, exec_opts_count=None):
 # Use testEnv to process skipif files, it works for executable and
 # non-executable versions
 def runSkipIf(skipifName):
-    p = Popen([utildir+'/test/testEnv', './'+skipifName], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    p = py3_compat.Popen([utildir+'/test/testEnv', './'+skipifName], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     (stdout, stderr) = p.communicate()
     status = p.returncode
 
@@ -678,9 +614,9 @@ utildir = os.path.realpath(utildir)
 # We open the compileline inside of CHPL_HOME rather than CHPL_TEST_UTIL_DIR on
 # purpose. compileline will not work correctly in some configurations when run
 # outside of its directory tree.
-p = Popen([os.path.join(chpl_home,'util','config','compileline'),
-                        '--compile'],
-          stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+compileline = os.path.join(chpl_home, 'util', 'config', 'compileline')
+p = py3_compat.Popen([compileline, '--compile'],
+                     stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 c_compiler = p.communicate()[0].rstrip()
 if p.returncode != 0:
   Fatal('Cannot find c compiler')
@@ -712,7 +648,7 @@ if useTimedExec:
 # sys.stdout.write('timedexec='+timedexec+'\n');
 
 # HW platform
-platform=Popen([utildir+'/chplenv/chpl_platform.py', '--target'], stdout=subprocess.PIPE).communicate()[0]
+platform=py3_compat.Popen([utildir+'/chplenv/chpl_platform.py', '--target'], stdout=subprocess.PIPE).communicate()[0]
 platform = platform.strip()
 # sys.stdout.write('platform='+platform+'\n')
 
@@ -858,12 +794,12 @@ else:
 
 globalLastcompopts=list();
 if os.access('./LASTCOMPOPTS',os.R_OK):
-    globalLastcompopts+=Popen(['cat', './LASTCOMPOPTS'], stdout=subprocess.PIPE).communicate()[0].strip().split()
+    globalLastcompopts+=py3_compat.Popen(['cat', './LASTCOMPOPTS'], stdout=subprocess.PIPE).communicate()[0].strip().split()
 # sys.stdout.write('globalLastcompopts=%s\n'%(globalLastcompopts))
 
 globalLastexecopts=list();
 if os.access('./LASTEXECOPTS',os.R_OK):
-    globalLastexecopts+=Popen(['cat', './LASTEXECOPTS'], stdout=subprocess.PIPE).communicate()[0].strip().split()
+    globalLastexecopts+=py3_compat.Popen(['cat', './LASTEXECOPTS'], stdout=subprocess.PIPE).communicate()[0].strip().split()
 # sys.stdout.write('globalLastexecopts=%s\n'%(globalLastexecopts))
 
 if os.access(PerfDirFile('NUMLOCALES'),os.R_OK):
@@ -881,7 +817,7 @@ if maxLocalesAvailable is not None:
     maxLocalesAvailable = int(maxLocalesAvailable)
 
 if os.access('./CATFILES',os.R_OK):
-    globalCatfiles=Popen(['cat', './CATFILES'], stdout=subprocess.PIPE).communicate()[0]
+    globalCatfiles=py3_compat.Popen(['cat', './CATFILES'], stdout=subprocess.PIPE).communicate()[0]
     globalCatfiles.strip(globalCatfiles)
 else:
     globalCatfiles=None
@@ -1262,18 +1198,18 @@ for testname in testsrc:
             killtimeout=ReadIntegerValue(f, localdir)
 
         elif (suffix=='.catfiles' and os.access(f, os.R_OK)):
-            execcatfiles=Popen(['cat', f], stdout=subprocess.PIPE).communicate()[0].strip()
+            execcatfiles=py3_compat.Popen(['cat', f], stdout=subprocess.PIPE).communicate()[0].strip()
             if catfiles:
                 catfiles+=execcatfiles
             else:
                 catfiles=execcatfiles
 
         elif (suffix=='.lastcompopts' and os.access(f, os.R_OK)):
-            lastcompopts+=Popen(['cat', f], stdout=subprocess.PIPE).communicate()[0].strip().split()
+            lastcompopts+=py3_compat.Popen(['cat', f], stdout=subprocess.PIPE).communicate()[0].strip().split()
             # sys.stdout.write("lastcompopts=%s\n"%(lastcompopts))
 
         elif (suffix=='.lastexecopts' and os.access(f, os.R_OK)):
-            lastexecopts+=Popen(['cat', f], stdout=subprocess.PIPE).communicate()[0].strip().split()
+            lastexecopts+=py3_compat.Popen(['cat', f], stdout=subprocess.PIPE).communicate()[0].strip().split()
             # sys.stdout.write("lastexecopts=%s\n"%(lastexecopts))
 
         elif (suffix==PerfSfx('numlocales') and os.access(f, os.R_OK)):
@@ -1464,20 +1400,17 @@ for testname in testsrc:
         if globalPrecomp:
             sys.stdout.write('[Executing ./PRECOMP]\n')
             sys.stdout.flush()
-            p = Popen(['./PRECOMP',
-                       execname,complog,compiler],
-                      stdout=subprocess.PIPE,
-                      stderr=subprocess.STDOUT)
+            p = py3_compat.Popen(['./PRECOMP', execname, complog, compiler],
+                                 stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
             sys.stdout.write(p.communicate()[0])
             sys.stdout.flush()
 
         if precomp:
             sys.stdout.write('[Executing precomp %s.precomp]\n'%(test_filename))
             sys.stdout.flush()
-            p = Popen(['./'+test_filename+'.precomp',
-                       execname,complog,compiler],
-                      stdout=subprocess.PIPE,
-                      stderr=subprocess.STDOUT)
+            test_precomp = './{0}.precomp'.format(test_filename)
+            p = py3_compat.Popen([test_precomp, execname, complog, compiler],
+                                 stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
             sys.stdout.write(p.communicate()[0])
             sys.stdout.flush()
 
@@ -1546,11 +1479,10 @@ for testname in testsrc:
         sys.stdout.flush()
         if useTimedExec:
             wholecmd = cmd+' '+' '.join(map(ShellEscape, args))
-            p = Popen([timedexec, str(comptimeout), wholecmd],
-                      env=dict(list(os.environ.items()) + list(testcompenv.items())),
-                      stdin=open(compstdin, 'r'),
-                      stdout=subprocess.PIPE,
-                      stderr=subprocess.STDOUT)
+            p = py3_compat.Popen([timedexec, str(comptimeout), wholecmd],
+                                 env=dict(list(os.environ.items()) + list(testcompenv.items())),
+                                 stdin=open(compstdin, 'r'),
+                                 stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
             output = p.communicate()[0]
             status = p.returncode
 
@@ -1566,13 +1498,12 @@ for testname in testsrc:
                 continue # on to next compopts
 
         else:
-            p = Popen([cmd]+args,
-                      env=dict(list(os.environ.items()) + list(testcompenv.items())),
-                      stdin=open(compstdin, 'r'),
-                      stdout=subprocess.PIPE,
-                      stderr=subprocess.STDOUT)
+            p = py3_compat.Popen([cmd]+args,
+                                 env=dict(list(os.environ.items()) + list(testcompenv.items())),
+                                 stdin=open(compstdin, 'r'),
+                                 stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
             try:
-                output = bytes_to_str(SuckOutputWithTimeout(p.stdout, comptimeout))
+                output = py3_compat.bytes_to_str(SuckOutputWithTimeout(p.stdout, comptimeout))
             except ReadTimeoutException:
                 sys.stdout.write('%s[Error: Timed out compilation for %s/%s'%
                                  (futuretest, localdir, test_filename))
@@ -1612,9 +1543,9 @@ for testname in testsrc:
                 sys.stdout.write('[Concatenating extra files: %s]\n'%
                                  (test_filename+'.catfiles'))
                 sys.stdout.flush()
-                output+=Popen(['cat']+catfiles.split(),
-                              stdout=subprocess.PIPE,
-                              stderr=subprocess.STDOUT).communicate()[0]
+                p = py3_compat.Popen(['cat']+catfiles.split(),
+                                     stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+                output += p.communicate()[0]
 
             # Sadly these scripts require an actual file
             with open(complog, 'w') as complogfile:
@@ -1623,36 +1554,28 @@ for testname in testsrc:
             if systemPrediff:
                 sys.stdout.write('[Executing system-wide prediff]\n')
                 sys.stdout.flush()
-                p = Popen([systemPrediff,
-                           execname,complog,compiler,
-                           ' '.join(envCompopts)+' '+compopts,
-                           ' '.join(args)],
-                          stdout=subprocess.PIPE,
-                          stderr=subprocess.STDOUT)
+                p = py3_compat.Popen([systemPrediff, execname, complog, compiler,
+                                     ' '.join(envCompopts)+' '+compopts, ' '.join(args)],
+                                     stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
                 sys.stdout.write(p.communicate()[0])
                 sys.stdout.flush()
 
             if globalPrediff:
                 sys.stdout.write('[Executing ./PREDIFF]\n')
                 sys.stdout.flush()
-                p = Popen(['./PREDIFF',
-                           execname,complog,compiler,
-                           ' '.join(envCompopts)+' '+compopts,
-                           ' '.join(args)],
-                          stdout=subprocess.PIPE,
-                          stderr=subprocess.STDOUT)
+                p = py3_compat.Popen(['./PREDIFF', execname, complog, compiler,
+                                     ' '.join(envCompopts)+' '+compopts, ' '.join(args)],
+                                     stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
                 sys.stdout.write(p.communicate()[0])
                 sys.stdout.flush()
 
             if prediff:
                 sys.stdout.write('[Executing prediff %s.prediff]\n'%(test_filename))
                 sys.stdout.flush()
-                p = Popen(['./'+test_filename+'.prediff',
-                           execname,complog,compiler,
-                           ' '.join(envCompopts)+' '+compopts,
-                           ' '.join(args)],
-                          stdout=subprocess.PIPE,
-                          stderr=subprocess.STDOUT)
+                test_prediff = './{0}.prediff'.format(test_filename)
+                p = py3_compat.Popen([test_prediff, execname, complog, compiler,
+                                     ' '.join(envCompopts)+' '+compopts, ' '.join(args)],
+                                     stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
                 sys.stdout.write(p.communicate()[0])
                 sys.stdout.flush()
 
@@ -1782,7 +1705,7 @@ for testname in testsrc:
                 # computePerfStats for the current test
                 sys.stdout.write('[Executing computePerfStats %s %s %s %s %s]\n'%(datFileName, tempDatFilesDir, keyfile, printpassesfile, 'False'))
                 sys.stdout.flush()
-                p = Popen([utildir+'/test/computePerfStats', datFileName, tempDatFilesDir, keyfile, printpassesfile, 'False'], stdout=subprocess.PIPE)
+                p = py3_compat.Popen([utildir+'/test/computePerfStats', datFileName, tempDatFilesDir, keyfile, printpassesfile, 'False'], stdout=subprocess.PIPE)
                 compkeysOutput = p.communicate()[0]
                 datFiles = [tempDatFilesDir+'/'+datFileName+'.dat',  tempDatFilesDir+'/'+datFileName+'.error']
                 status = p.returncode
@@ -1847,30 +1770,25 @@ for testname in testsrc:
             if systemPreexec:
                 sys.stdout.write('[Executing system-wide preexec]\n')
                 sys.stdout.flush()
-                p = Popen([systemPreexec,
-                           execname,execlog,compiler],
-                          stdout=subprocess.PIPE,
-                          stderr=subprocess.STDOUT)
+                p = py3_compat.Popen([systemPreexec, execname, execlog, compiler],
+                                     stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
                 sys.stdout.write(p.communicate()[0])
                 sys.stdout.flush()
 
             if globalPreexec:
                 sys.stdout.write('[Executing ./PREEXEC]\n')
                 sys.stdout.flush()
-                p = Popen(['./PREEXEC',
-                           execname,execlog,compiler],
-                          stdout=subprocess.PIPE,
-                          stderr=subprocess.STDOUT)
+                p = py3_compat.Popen(['./PREEXEC', execname, execlog, compiler],
+                                     stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
                 sys.stdout.write(p.communicate()[0])
                 sys.stdout.flush()
 
             if preexec:
                 sys.stdout.write('[Executing preexec %s.preexec]\n'%(test_filename))
                 sys.stdout.flush()
-                p = Popen(['./'+test_filename+'.preexec',
-                           execname,execlog,compiler],
-                          stdout=subprocess.PIPE,
-                          stderr=subprocess.STDOUT)
+                test_preexec = './{0}.preexec'.format(test_filename)
+                p = py3_compat.Popen([test_preexec, execname, execlog, compiler],
+                                     stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
                 sys.stdout.write(p.communicate()[0])
                 sys.stdout.flush()
 
@@ -1984,13 +1902,11 @@ for testname in testsrc:
                         else:
                             my_stdin=open(redirectin, 'r')
                         test_command = [cmd] + args + LauncherTimeoutArgs(timeout)
-                        p = Popen(test_command,
-                                  env=dict(list(os.environ.items()) + list(testenv.items())),
-                                  stdin=my_stdin,
-                                  stdout=subprocess.PIPE,
-                                  stderr=subprocess.PIPE)
+                        p = py3_compat.Popen(test_command,
+                                             env=dict(list(os.environ.items()) + list(testenv.items())),
+                                             stdin=my_stdin, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
                         (stdout, stderr) = p.communicate()
-                        output = concat_streams(stdout, stderr)
+                        output = py3_compat.concat_streams(stdout, stderr)
                         status = p.returncode
 
                         # Check for well-known failure modes
@@ -2013,13 +1929,11 @@ for testname in testsrc:
                             my_stdin = sys.stdin
                         else:
                             my_stdin = open(redirectin, 'r')
-                        p = Popen([timedexec, str(timeout), wholecmd],
-                                  env=dict(list(os.environ.items()) + list(testenv.items())),
-                                  stdin=my_stdin,
-                                  stdout=subprocess.PIPE,
-                                  stderr=subprocess.PIPE)
+                        p = py3_compat.Popen([timedexec, str(timeout), wholecmd],
+                                             env=dict(list(os.environ.items()) + list(testenv.items())),
+                                             stdin=my_stdin, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
                         (stdout, stderr) = p.communicate()
-                        output = concat_streams(stdout, stderr)
+                        output = py3_compat.concat_streams(stdout, stderr)
                         status = p.returncode
 
                         if status == 222:
@@ -2048,11 +1962,9 @@ for testname in testsrc:
                             my_stdin = None
                         else:
                             my_stdin=open(redirectin, 'r')
-                        p = Popen([cmd]+args,
-                                  env=dict(list(os.environ.items()) + list(testenv.items())),
-                                  stdin=my_stdin,
-                                  stdout=subprocess.PIPE,
-                                  stderr=subprocess.PIPE)
+                        p = py3_compat.Popen([cmd]+args,
+                                             env=dict(list(os.environ.items()) + list(testenv.items())),
+                                             stdin=my_stdin, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
                         try:
                             stdoutOutput = SuckOutputWithTimeout(p.stdout, timeout)
                         except ReadTimeoutException:
@@ -2065,7 +1977,7 @@ for testname in testsrc:
                             KillProc(p, killtimeout)
 
                         stderrOutput = p.stderr.read()
-                        output = concat_streams(stdoutOutput, stderrOutput)
+                        output = py3_compat.concat_streams(stdoutOutput, stderrOutput)
                         p.poll()
                         status = p.returncode
 
@@ -2108,24 +2020,24 @@ for testname in testsrc:
                     sys.stdout.write('[Concatenating extra files: %s]\n'%
                                     (test_filename+'.catfiles'))
                     sys.stdout.flush()
-                    cat_output = Popen(['cat']+catfiles.split(),
-                                     stdout=subprocess.PIPE,
-                                     stderr=subprocess.STDOUT).communicate()[0]
+                    p = py3_compat.Popen(['cat']+catfiles.split(),
+                                         stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+                    cat_output = p.communicate()[0]
                     if sys.version_info[0] >= 3 and isinstance(cat_output, bytes):
-                        output = str_to_bytes(output)
+                        output = py3_compat.str_to_bytes(output)
                     output += cat_output
 
                 # Sadly the scripts used below require an actual file
                 open_mode = 'w' if isinstance(output, str) else 'wb'
                 with open(execlog, open_mode) as execlogfile:
                     if open_mode == 'wb':
-                        pre_exec_output_content = str_to_bytes(pre_exec_output)
+                        pre_exec_output_content = py3_compat.str_to_bytes(pre_exec_output)
                     else:
                         pre_exec_output_content = pre_exec_output
                     execlogfile.write(pre_exec_output_content)
 
                     if open_mode == 'wb':
-                        output_content =str_to_bytes(output)
+                        output_content = py3_compat.str_to_bytes(output)
                     else:
                         output_content = output
                     execlogfile.write(output_content)
@@ -2134,35 +2046,26 @@ for testname in testsrc:
                     if systemPrediff:
                         sys.stdout.write('[Executing system-wide prediff]\n')
                         sys.stdout.flush()
-                        sys.stdout.write(Popen([systemPrediff,
-                                                execname,execlog,compiler,
-                                                ' '.join(envCompopts)+
-                                                ' '+compopts,
-                                                ' '.join(args)],
-                                               stdout=subprocess.PIPE,
-                                               stderr=subprocess.STDOUT).communicate()[0])
+                        p = py3_compat.Popen([systemPrediff, execname, execlog, compiler,
+                                             ' '.join(envCompopts)+' '+compopts, ' '.join(args)],
+                                             stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+                        sys.stdout.write(p.communicate()[0])
 
                     if globalPrediff:
                         sys.stdout.write('[Executing ./PREDIFF]\n')
                         sys.stdout.flush()
-                        sys.stdout.write(Popen(['./PREDIFF',
-                                                execname,execlog,compiler,
-                                                ' '.join(envCompopts)+
-                                                ' '+compopts,
-                                                ' '.join(args)],
-                                               stdout=subprocess.PIPE,
-                                               stderr=subprocess.STDOUT).communicate()[0])
+                        p = py3_compat.Popen(['./PREDIFF', execname, execlog, compiler,
+                                             ' '.join(envCompopts)+ ' '+compopts, ' '.join(args)],
+                                             stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+                        sys.stdout.write(p.communicate()[0])
 
                     if prediff:
                         sys.stdout.write('[Executing prediff ./%s]\n'%(prediff))
                         sys.stdout.flush()
-                        sys.stdout.write(Popen(['./'+prediff,
-                                                execname,execlog,compiler,
-                                                ' '.join(envCompopts)+
-                                                ' '+compopts,
-                                                ' '.join(args)],
-                                               stdout=subprocess.PIPE,
-                                               stderr=subprocess.STDOUT).communicate()[0])
+                        p = py3_compat.Popen(['./'+prediff, execname, execlog, compiler,
+                                             ' '.join(envCompopts)+' '+compopts, ' '.join(args)],
+                                             stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+                        sys.stdout.write(p.communicate()[0])
 
                     if not perftest:
                         # find the good file 
@@ -2187,8 +2090,8 @@ for testname in testsrc:
                         if not os.path.isfile(execgoodfile) or not os.access(execgoodfile, os.R_OK):
                             sys.stdout.write('[Error cannot locate program output comparison file %s/%s]\n'%(localdir, execgoodfile))
                             sys.stdout.write('[Execution output was as follows:]\n')
-                            exec_output = Popen(['cat', execlog],
-                                stdout=subprocess.PIPE).communicate()[0]
+                            p = py3_compat.Popen(['cat', execlog], stdout=subprocess.PIPE)
+                            exec_output = p.communicate()[0]
                             sys.stdout.write(trim_output(exec_output))
 
                             continue # on to next execopts
@@ -2273,10 +2176,9 @@ for testname in testsrc:
 
                     sys.stdout.write('[Executing %s/test/computePerfStats %s %s %s %s %s %s]\n'%(utildir, perfexecname, perfdir, keyfile, execlog, str(exectimeout), perfdate))
                     sys.stdout.flush()
-
-                    p = Popen([utildir+'/test/computePerfStats',
-                               perfexecname, perfdir, keyfile, execlog, str(exectimeout), perfdate],
-                              stdout=subprocess.PIPE)
+                    p = py3_compat.Popen([utildir+'/test/computePerfStats',
+                                         perfexecname, perfdir, keyfile, execlog, str(exectimeout), perfdate],
+                                         stdout=subprocess.PIPE)
                     sys.stdout.write('%s'%(p.communicate()[0]))
                     sys.stdout.flush()
 


### PR DESCRIPTION
Move our python 2/3 compatibility shim out of sub_test and into its own
module. This will allow us to use it in other scripts (I want to use it
in chpl_launchcmd.py.) This makes it more obvious in sub_test that
something special is happening and we're not just calling the standard
library's subprocess.Popen.

This also updates Py3CompatPopen.communicate() to directly convert bytes
to strings instead of only doing it when stderr/stdout are pulled out
individually. The old behavior was pretty confusing because something like
`stderr = p.communicate()[1]` would result in stderr being a str, but
`stderr, _ = p.communicate()` would result in stderr being bytes. Now we
just try to convert stderr and stdout to strings individually and return
a new tuple.

This shim assumes that our input/output to subprocesses is always utf-8
compatible, which is usually true but there are cases like mandlebrot
where our output is binary. For those cases the byte->string conversion
silently fails and we handle issues at the call site. This is probably
one of the worst ways to get python 2 and 3 compatibility, but it is
pretty straightforward. A better solution might be to use six or future.