### PR TITLE
TOML Parser: Added newline to linetokens

### DIFF
--- a/modules/packages/TOML.chpl
+++ b/modules/packages/TOML.chpl
@@ -1010,7 +1010,7 @@ module TomlReader {
                                        equals));
 
       for token in pattern.split(line) {
-        var strippedToken = token.strip(" ");
+        var strippedToken = token.strip(" \t");
         if strippedToken.length != 0 {
           if debugTomlReader {
             writeln('Tokenized: ', '(', strippedToken, ')');

--- a/modules/packages/TOML.chpl
+++ b/modules/packages/TOML.chpl
@@ -173,6 +173,9 @@ module TomlParser {
             else if kv.match(token) {
               parseAssign();
             }
+            else if token == "\n" {
+              getToken(source);
+            }
             else {
               throw new owned TomlError("Line "+ debugCounter +": Unexpected Token -> " + getToken(source));
             }
@@ -986,6 +989,8 @@ module TomlReader {
 
     proc splitLine(line) {
       var linetokens: [1..0] string;
+      var nonEmptyChar: bool = false;
+
       const doubleQuotes = '(".*?")',           // ""
             singleQuotes = "('.*?')",           // ''
             bracketContents = "(\\[\\w+\\])",   // [_]
@@ -1005,13 +1010,22 @@ module TomlReader {
                                        equals));
 
       for token in pattern.split(line) {
-        var strippedToken = token.strip();
-        if strippedToken.length != 0  {
+        var strippedToken = token.strip(" ");
+        if strippedToken.length != 0 {
           if debugTomlReader {
             writeln('Tokenized: ', '(', strippedToken, ')');
           }
-          linetokens.push_back(strippedToken);}
+
+          nonEmptyChar = true;
+          linetokens.push_back(strippedToken);
+        }
       }
+
+      // If no non-empty-chars => token is a blank line
+      if(nonEmptyChar == false){
+        linetokens.push_back("\n");
+      }
+
       if !linetokens.isEmpty() {
         var tokens = new unmanaged Tokens(linetokens);
         tokenlist.push_back(tokens);

--- a/test/library/packages/TOML/test/newline.chpl
+++ b/test/library/packages/TOML/test/newline.chpl
@@ -4,7 +4,7 @@ use TOML;
 config const str: string = "[owner] \
 \
 name = \"Foo Bar\"\
-dob = 2000-04-30 ";
+dob = 2000-04-30-234-42 ";
 
 proc main() {
   var TomlData = parseToml(str);

--- a/test/library/packages/TOML/test/newline.chpl
+++ b/test/library/packages/TOML/test/newline.chpl
@@ -1,10 +1,12 @@
 
 use TOML;
 
-config const str: string = "[owner] \
-\
-name = \"Foo Bar\"\
-dob = 2000-04-30-234-42 ";
+config const str: string = """[owner]
+
+                            name = "Foo Bar"
+                            dob = 2000-04-30-234-42
+                            field = "someValue"
+                            """;
 
 proc main() {
   var TomlData = parseToml(str);

--- a/test/library/packages/TOML/test/newline.chpl
+++ b/test/library/packages/TOML/test/newline.chpl
@@ -1,0 +1,15 @@
+
+use TOML;
+
+config const str: string = "[owner] \
+\
+name = \"Foo Bar\"\
+dob = 2000-04-30 ";
+
+proc main() {
+  var TomlData = parseToml(str);
+  writeln(TomlData);
+
+  delete TomlData;
+}
+

--- a/test/library/packages/TOML/test/newline.good
+++ b/test/library/packages/TOML/test/newline.good
@@ -1,1 +1,1 @@
-Line 4: Illegal Value -> 2000-04-30
+Line 4: Illegal Value -> 2000-04-30-234-42

--- a/test/library/packages/TOML/test/newline.good
+++ b/test/library/packages/TOML/test/newline.good
@@ -1,0 +1,1 @@
+Line 4: Illegal Value -> 2000-04-30


### PR DESCRIPTION
closes #12776 where newlines were not accounted for in the line number being reported in an error message.