### PR TITLE
Add VectorList collection

### DIFF
--- a/test/library/packages/VectorList/VectorLists.chpl
+++ b/test/library/packages/VectorList/VectorLists.chpl
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2004-2019 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Support for VectorLists - collections with exponentially-growing capacity
+   and without reallocating the existing elements upon push_back().
+*/
+module VectorLists {
+
+  /* Default initial capacity of a new VectorList. */
+  config const vectorListInitCapacity = 4;
+
+  /* VectorList capacity growth factor. */
+  config const vectorListGrowFactor = 2;
+
+  /* VectorList capacity does not grow bigger than this. */
+  config const vectorListMaxCapacity = 500000;
+
+  /*
+  VectorList is a collection that grows by push_back()-ing a single element
+  at a time. It stores the elements in a linked list of contiguous regions
+  of memory of exponentially-growing sizes. When the current capacity
+  is exhausted, a new chunk of memory is appended to the list;
+  already-accumulated elements are not moved.
+
+  VectorList supports linear traversal of the entire collection
+  with close-to-DR-array asymptotic speed.
+  Supports log(size)-time random indexing.
+
+  VectorList does not support push_front() and O(1)-time random indexing.
+  These could be added in the future.
+  */
+  class VectorList {
+    /* The type of the collection's elements.*/
+    type eltType; 
+
+    /* The number of elements presently in the collection. */
+    var size = 0;
+
+    // A singly-linked list of classes that store the elements.
+    pragma "no doc"
+    const head: unmanaged VectorListElement(eltType);
+
+    // New elements are added here.
+    pragma "no doc"
+    var tail: head.type;
+
+    /* Create an empty collection with the given element type. */
+    inline proc init(type eltType, initCapacity = vectorListInitCapacity) {
+      this.eltType = eltType;
+      this.head = new unmanaged VectorListElement(eltType, initCapacity);
+      this.tail = this.head;
+    }
+
+    proc deinit() {
+      // We do not want "owned" for the VectorListElement links, i.e. this.head,
+      // this.head.next, .next.next, etc. Because with "owned" these links would
+      // be deinit-ed with recursive calls to VectorListElement.deinit(), one
+      // call per list element. A long list would lead to a lot of stack frames.
+      // Also, "owned" would not allow us to update this.tail in push_back().
+      for LE in listElements() do
+        delete LE;
+    }      
+  }
+
+  /*
+  Store 'size' elements in 'elements', with 'capacity'.
+  Currently the backing store is allocated right away and does not change.
+  */
+  pragma "no doc"
+  class VectorListElement {
+    type eltType;
+    var size: int;
+    const capacity: int;
+    const elements: _ddata(eltType);  // _ddata is not managed
+    var next: unmanaged VectorListElement(eltType);
+
+    inline proc init(type eltType, initCapacity: int) {
+      this.eltType = eltType;
+      this.size = 0;
+      this.capacity = initCapacity;
+      this.elements = _ddata_allocate(eltType, this.capacity);
+      this.next = nil;
+    }
+
+    proc deinit() {
+      // Deinit individual elements.
+      for i in 0..#size do
+        chpl__autoDestroy(elements[i]);
+
+      _ddata_free(elements, capacity);
+    }
+
+    // 0-based indexing
+    inline proc elemAt(idx: int) ref {
+      return elements.this(idx);
+    }
+  }
+
+  /* Add 'val' to the end of the collection */
+  proc VectorList.push_back(in val: this.eltType) lifetime this < val {
+    const last = this.tail;
+    if boundsChecking then assert(last.next == nil);
+    this.size += 1;
+
+    if (last.size < last.capacity) {
+      // Add to the currently-last VLE.
+      last.elemAt(last.size) = val;
+      last.size += 1;
+      return;
+    }
+
+    // Otherwise append a new VLE.
+    const nextCapacity =
+      if last.capacity * vectorListGrowFactor > vectorListMaxCapacity
+      then last.capacity else last.capacity * vectorListGrowFactor;
+
+    var next = new unmanaged VectorListElement(eltType, nextCapacity);
+    next.elemAt(0) = val;
+    next.size = 1;
+
+    // Update link pointers.
+    last.next = next;
+    this.tail = next;
+  }
+
+  /* Yields all VectorListElement. */
+  inline iter VectorList.listElements() {
+    var curr = head;
+    do { const next = curr.next; yield curr; curr = next; }
+    while curr != nil;
+  }
+
+  /* Yields pairs (starting index, VectorListElement pointer). */
+  inline iter VectorList.links(): (int,VectorListElement(eltType)) {
+    if size == 0 then return; // no vector elements
+    var currStart = 0;
+    for LE in listElements() {
+      yield (currStart, LE);
+      currStart += LE.size;
+    }
+    if boundsChecking then assert(currStart == size);
+  }
+
+  /* Indexing is O(log(size)) time. */
+  proc VectorList.this(idx: int) ref {
+    if boundsChecking && (idx < 0 || idx >= size) then
+      halt("VectorList index ", idx, " is out of bounds 0..", size-1);
+
+    for (s,LE) in links() {
+      if idx < s + LE.size then
+        return LE.elemAt(idx - s);
+    }
+
+    halt("exhausted the list");
+    return head.elemAt(0); // dummy
+  }
+
+  /* Serial iterator. */
+  iter VectorList.these() ref {
+    for (s,LE) in links() do
+      for idx in 0..#LE.size do
+        yield LE.elemAt(idx);
+  }
+
+  /* Leader iterator redirects to range leader. */
+  iter VectorList.these(param tag) where tag == iterKind.leader {
+    const rng = 0..#size;
+    for flw in rng.these(tag) do
+      yield flw;
+  }
+
+  /* Follower iterator takes O(log(size)) time to start up. */
+  iter VectorList.these(param tag, followThis: _tuple) ref
+    where tag == iterKind.follower
+  {
+    compilerAssert(followThis.size == 1,
+                   "VectorList can follow only 1-dimensional leaders");
+    ref followRange = followThis(1);
+    compilerAssert(isRange(followRange));
+    if followRange.stride < 0 then
+      halt("VectorList cannot follow negative strides");
+    const low = followRange.alignedLow;
+    const high = followRange.alignedHigh;
+
+    for (s,LE) in links() {
+      if s > high then break; //done
+      if s + LE.size <= low then continue;
+      for idx in followRange[s..#LE.size] - s do
+        yield LE.elemAt(idx);
+    }
+  }
+
+  /* Copy all elements to a new DefaultRectangular array and return it. */
+  proc VectorList.toArray() {
+    var DR: [1..size] eltType;
+    forall (dr,vl) in zip(DR,this) do  // should this be serial?
+      dr = vl;
+    return DR;
+  }
+
+}  // module VectorLists

--- a/test/library/packages/VectorList/test-ints.chpl
+++ b/test/library/packages/VectorList/test-ints.chpl
@@ -1,0 +1,41 @@
+// Test building, indexing, iterating for VectorList(int).
+
+use VectorLists;
+
+config const dr = false;
+config const s: int = 15;
+
+// test a collection of sz elements
+proc test(sz: int) {
+  if dr {
+    var arr: [0..-1] int;
+    help(arr, sz); // generate reference output
+
+  } else {
+    const VL = new owned VectorList(int);
+    help(VL, sz);
+  }
+}
+
+proc help(lst, sz) {
+  writeln("======== size ", sz);
+
+  writeln("building");
+  for i1 in 11..#sz do
+    lst.push_back(i1);
+
+  writeln("random indexing");
+  for i2 in 0..#sz by -1 do
+    write(lst[i2], " ");
+  writeln(".");
+
+  writeln("iteration");
+  for elm3 in lst do
+    write(elm3, " ");
+  writeln(".");
+
+  writeln();
+}
+
+writeln();
+for siz in 0..s do test(siz);

--- a/test/library/packages/VectorList/test-ints.execopts
+++ b/test/library/packages/VectorList/test-ints.execopts
@@ -1,0 +1,2 @@
+--dr=true
+--dr=false

--- a/test/library/packages/VectorList/test-ints.good
+++ b/test/library/packages/VectorList/test-ints.good
@@ -1,0 +1,113 @@
+
+======== size 0
+building
+random indexing
+.
+iteration
+.
+
+======== size 1
+building
+random indexing
+11 .
+iteration
+11 .
+
+======== size 2
+building
+random indexing
+12 11 .
+iteration
+11 12 .
+
+======== size 3
+building
+random indexing
+13 12 11 .
+iteration
+11 12 13 .
+
+======== size 4
+building
+random indexing
+14 13 12 11 .
+iteration
+11 12 13 14 .
+
+======== size 5
+building
+random indexing
+15 14 13 12 11 .
+iteration
+11 12 13 14 15 .
+
+======== size 6
+building
+random indexing
+16 15 14 13 12 11 .
+iteration
+11 12 13 14 15 16 .
+
+======== size 7
+building
+random indexing
+17 16 15 14 13 12 11 .
+iteration
+11 12 13 14 15 16 17 .
+
+======== size 8
+building
+random indexing
+18 17 16 15 14 13 12 11 .
+iteration
+11 12 13 14 15 16 17 18 .
+
+======== size 9
+building
+random indexing
+19 18 17 16 15 14 13 12 11 .
+iteration
+11 12 13 14 15 16 17 18 19 .
+
+======== size 10
+building
+random indexing
+20 19 18 17 16 15 14 13 12 11 .
+iteration
+11 12 13 14 15 16 17 18 19 20 .
+
+======== size 11
+building
+random indexing
+21 20 19 18 17 16 15 14 13 12 11 .
+iteration
+11 12 13 14 15 16 17 18 19 20 21 .
+
+======== size 12
+building
+random indexing
+22 21 20 19 18 17 16 15 14 13 12 11 .
+iteration
+11 12 13 14 15 16 17 18 19 20 21 22 .
+
+======== size 13
+building
+random indexing
+23 22 21 20 19 18 17 16 15 14 13 12 11 .
+iteration
+11 12 13 14 15 16 17 18 19 20 21 22 23 .
+
+======== size 14
+building
+random indexing
+24 23 22 21 20 19 18 17 16 15 14 13 12 11 .
+iteration
+11 12 13 14 15 16 17 18 19 20 21 22 23 24 .
+
+======== size 15
+building
+random indexing
+25 24 23 22 21 20 19 18 17 16 15 14 13 12 11 .
+iteration
+11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 .
+

--- a/test/library/packages/VectorList/test-pariter.chpl
+++ b/test/library/packages/VectorList/test-pariter.chpl
@@ -1,0 +1,50 @@
+// Parallel iteration for VectorList(int).
+
+use VectorLists;
+
+config param dr = false;
+config const s: int = 31;
+
+// test a collection of sz elements
+proc test(sz: int) {
+  if dr {
+    var arr: [0..-1] int;
+    help(arr, sz); // generate reference output
+
+  } else {
+    const VL = new owned VectorList(int,1); // "1" for more thorough testing
+    help(VL, sz);
+  }
+}
+
+proc help(lst, sz) {
+  writeln("======== size ", sz, "  ", isArray(lst));
+  const datarange = 1..#sz;
+
+  writeln("building");
+  for i1 in datarange do
+    lst.push_back(i1);
+
+  var bud: [0..#sz] int = datarange;
+
+  writeln("parallel leading");
+  forall (d,b) in zip(lst,bud) do
+    assert(b==d);
+  writeln("done");
+
+  writeln("parallel following");
+  forall (b,d) in zip(bud,lst) do
+    assert(b==d);
+  writeln("done");
+
+ if !dr {
+  writeln("converting");
+  const DR = lst.toArray();
+  assert(DR == datarange);
+  writeln("done");
+ }
+}
+
+writeln();
+for siz in 0..s do test(siz);
+test(1234);

--- a/test/library/packages/VectorList/test-pariter.good
+++ b/test/library/packages/VectorList/test-pariter.good
@@ -1,0 +1,265 @@
+
+======== size 0  false
+building
+parallel leading
+done
+parallel following
+done
+converting
+done
+======== size 1  false
+building
+parallel leading
+done
+parallel following
+done
+converting
+done
+======== size 2  false
+building
+parallel leading
+done
+parallel following
+done
+converting
+done
+======== size 3  false
+building
+parallel leading
+done
+parallel following
+done
+converting
+done
+======== size 4  false
+building
+parallel leading
+done
+parallel following
+done
+converting
+done
+======== size 5  false
+building
+parallel leading
+done
+parallel following
+done
+converting
+done
+======== size 6  false
+building
+parallel leading
+done
+parallel following
+done
+converting
+done
+======== size 7  false
+building
+parallel leading
+done
+parallel following
+done
+converting
+done
+======== size 8  false
+building
+parallel leading
+done
+parallel following
+done
+converting
+done
+======== size 9  false
+building
+parallel leading
+done
+parallel following
+done
+converting
+done
+======== size 10  false
+building
+parallel leading
+done
+parallel following
+done
+converting
+done
+======== size 11  false
+building
+parallel leading
+done
+parallel following
+done
+converting
+done
+======== size 12  false
+building
+parallel leading
+done
+parallel following
+done
+converting
+done
+======== size 13  false
+building
+parallel leading
+done
+parallel following
+done
+converting
+done
+======== size 14  false
+building
+parallel leading
+done
+parallel following
+done
+converting
+done
+======== size 15  false
+building
+parallel leading
+done
+parallel following
+done
+converting
+done
+======== size 16  false
+building
+parallel leading
+done
+parallel following
+done
+converting
+done
+======== size 17  false
+building
+parallel leading
+done
+parallel following
+done
+converting
+done
+======== size 18  false
+building
+parallel leading
+done
+parallel following
+done
+converting
+done
+======== size 19  false
+building
+parallel leading
+done
+parallel following
+done
+converting
+done
+======== size 20  false
+building
+parallel leading
+done
+parallel following
+done
+converting
+done
+======== size 21  false
+building
+parallel leading
+done
+parallel following
+done
+converting
+done
+======== size 22  false
+building
+parallel leading
+done
+parallel following
+done
+converting
+done
+======== size 23  false
+building
+parallel leading
+done
+parallel following
+done
+converting
+done
+======== size 24  false
+building
+parallel leading
+done
+parallel following
+done
+converting
+done
+======== size 25  false
+building
+parallel leading
+done
+parallel following
+done
+converting
+done
+======== size 26  false
+building
+parallel leading
+done
+parallel following
+done
+converting
+done
+======== size 27  false
+building
+parallel leading
+done
+parallel following
+done
+converting
+done
+======== size 28  false
+building
+parallel leading
+done
+parallel following
+done
+converting
+done
+======== size 29  false
+building
+parallel leading
+done
+parallel following
+done
+converting
+done
+======== size 30  false
+building
+parallel leading
+done
+parallel following
+done
+converting
+done
+======== size 31  false
+building
+parallel leading
+done
+parallel following
+done
+converting
+done
+======== size 1234  false
+building
+parallel leading
+done
+parallel following
+done
+converting
+done

--- a/test/library/packages/VectorList/test-string.chpl
+++ b/test/library/packages/VectorList/test-string.chpl
@@ -1,0 +1,36 @@
+// Test building, indexing, iterating for VectorList(string).
+
+use VectorLists;
+
+config param dr = false;
+config const s: int = 31;
+writeln();
+
+if dr {
+  var arr: [0..-1] string;
+  help(arr, s); // generate reference output
+
+} else {
+  const VL = new owned VectorList(string);
+  help(VL, s);
+}
+
+proc help(lst, sz) {
+  writeln("======== size ", sz, "  ", isArray(lst));
+
+  writeln("building");
+  for i1 in 11..#sz do
+    lst.push_back("e"+i1);
+
+  writeln("random indexing");
+  for i2 in 0..#sz by -1 do
+    write(lst[i2], " ");
+  writeln(".");
+
+  writeln("iteration");
+  for elm3 in lst do
+    write(elm3, " ");
+  writeln(".");
+
+  writeln();
+}

--- a/test/library/packages/VectorList/test-string.good
+++ b/test/library/packages/VectorList/test-string.good
@@ -1,0 +1,8 @@
+
+======== size 31  false
+building
+random indexing
+e41 e40 e39 e38 e37 e36 e35 e34 e33 e32 e31 e30 e29 e28 e27 e26 e25 e24 e23 e22 e21 e20 e19 e18 e17 e16 e15 e14 e13 e12 e11 .
+iteration
+e11 e12 e13 e14 e15 e16 e17 e18 e19 e20 e21 e22 e23 e24 e25 e26 e27 e28 e29 e30 e31 e32 e33 e34 e35 e36 e37 e38 e39 e40 e41 .
+


### PR DESCRIPTION
This PR adds a collection datatype `VectorList`.

A `VectorList` is a collection that grows by push_back()-ing a single element at a time. It stores the elements in a linked list of contiguous regions of memory of exponentially-growing sizes. When the current capacity is exhausted, a new chunk of memory is appended to the list; already-accumulated elements are not moved.                                                                                                                                                                                          
                                                                                                                                                                                                                                                             
VectorList supports linear traversal of the entire collection with close-to-DR-array asymptotic speed.  Supports log(size)-time random indexing.                                                                                                             
                                                                                                                                                                                                                                                             
VectorList does not support push_front() and O(1)-time random indexing.  These could be added in the future.                                                                                                                                                 

The implementation and tests are added under `test/library/packages/VectorList`, for future productization.
