### PR TITLE
Add suppressif for this test due to running as a windows service nightly

### DIFF
--- a/test/library/standard/FileSystem/chmod/chmod_noprivilege.suppressif
+++ b/test/library/standard/FileSystem/chmod/chmod_noprivilege.suppressif
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# Fails when run as a windows service, see JIRA issue 81
+
+if test "$OS" = Windows_NT -a -n "$SERVICE_ID"; then
+  echo 1
+else
+  echo 0
+fi


### PR DESCRIPTION
This test ran into a similar situation as
test/library/standard/FileSystem/fsouza/chown/permission_error.chpl, where
it would run with a permission error when tested by hand but would pass
when run by our Jenkins job server.  Solve in the same fashion as that test.