### PR TITLE
Remove CHPL_QTHREAD_ENABLE_OVERSUBSCRIPTION

### DIFF
--- a/doc/rst/usingchapel/tasks.rst
+++ b/doc/rst/usingchapel/tasks.rst
@@ -178,20 +178,10 @@ or ``CHPL_COMM=ofi`` one can run multiple Chapel locales on a single
 system node, say for doing multilocale functional correctness testing
 with limited system resources.  (See :ref:`readme-multilocale` for more
 details.)  When this is done qthreads' optimization for performance can
-actually greatly reduce performance, due to resource starvation among
-the multiple Chapel processes.  If you need qthreads to share system
-resources more cooperatively with other processes, you can build it to
-optimize its behavior to favor load balancing over performance.  To do
-this, build qthreads with ``CHPL_QTHREAD_ENABLE_OVERSUBSCRIPTION``
-turned on like this:
-
-.. code-block:: sh
-
-  cd $CHPL_HOME/third-party/qthread
-  make CHPL_QTHREAD_ENABLE_OVERSUBSCRIPTION=yes ... clean all
-
-You should also probably have ``CHPL_RT_OVERSUBSCRIBED=yes`` set when
-you execute with overloading (see :ref:`oversubscribed-execution`).
+greatly reduce performance, due to resource starvation among multiple
+Chapel processes.  If you need qthreads to share system resources more
+cooperatively with other processes set ``CHPL_RT_OVERSUBSCRIBED=yes`` at
+execution time (see :ref:`oversubscribed-execution`).
 
 
 Hwloc

--- a/third-party/qthread/Makefile
+++ b/third-party/qthread/Makefile
@@ -85,11 +85,6 @@ ifeq ($(CFLAGS_NEEDS_RT_INCLUDES), y)
   endif
 endif
 
-# enable oversubscription for testing
-ifneq (, $(CHPL_QTHREAD_ENABLE_OVERSUBSCRIPTION))
-CHPL_QTHREAD_CFG_OPTIONS += --enable-oversubscription
-endif
-
 # enable guard pages for stack overflow detection, unless directed not to
 HAVE_GUARD_PAGES = 0
 ifeq (, $(call isTrue, $(CHPL_QTHREAD_NO_GUARD_PAGES)))

--- a/util/cron/common-oversubscribed.bash
+++ b/util/cron/common-oversubscribed.bash
@@ -3,8 +3,4 @@
 # Configure environment for testing in an oversubscribed manner (help multiple
 # chapel programs run nicer side by side)
 
-tasks=$($CHPL_HOME/util/chplenv/chpl_tasks.py)
 export CHPL_RT_OVERSUBSCRIBED=yes
-if [ "${tasks}" == "qthreads" ] ; then
-    export CHPL_QTHREAD_ENABLE_OVERSUBSCRIPTION=1
-fi


### PR DESCRIPTION
`CHPL_QTHREAD_ENABLE_OVERSUBSCRIPTION` was a build time option that
built qthreads in a manner that allegedly made it more cooperative for
oversubscribed runs. It does things like:
 - lowers the default SPINCOUNT from 300,000 to 300
 - turns atomic spinwait locks into pthread locks
 - has busy waits do sched_yield

However, it's not obvious if pthread locks and sched_yield actually help
and as of #12600 `CHPL_RT_OVERSUBSCRIBED` will lower the spincount and
disable affinity/pinning. Some quick tests (running hello4) indicate
that `CHPL_QTHREAD_ENABLE_OVERSUBSCRIPTION` doesn't really help and may
even hurt a little, so remove it since it's not helpful (and since it's
a build-time option that's not embedded in the build path and thus
requires manual rebuilds to do anything.)

Here's some quick timings of hello4 on various machines. By default
oversubscribed runs are slow, but `CHPL_QTHREAD_ENABLE_OVERSUBSCRIPTION`
doesn't get us anything over `CHPL_RT_OVERSUBSCRIBED`.

```sh
# gasnet 
export GASNET_SPAWNFN=L
export GASNET_ROUTE_OUTPUT=0
export CHPL_COMM=gasnet
export GASNET_QUIET=1

# rt oversub
export CHPL_RT_OVERSUBSCRIBED=yes

# rt+bt oversub
export CHPL_RT_OVERSUBSCRIBED=yes
export CHPL_QTHREAD_ENABLE_OVERSUBSCRIPTION=1
```

chapcs (24 cores, 48 threads):

| locales | default | rt oversub | rt+bt oversub |
| ------- | ------- | ---------- | ------------- |
|   1     |   0.5s  |   0.3s     |   0.3s        |
|   2     |   1.0s  |   0.4s     |   0.4s        |
|   4     |   2.0s  |   0.5s     |   0.5s        |
|   8     |   6.0s  |   0.8s     |   1.2s        |
|  16     |  20.0s  |   1.6s     |   1.8s        |
|  32     |  40.0s  |   3.0s     |   2.8s        |
|  64     | 120.0s  |   4.5s     |   7.0s        |
| 128     | 500.0s  |  16.0s     |  18.0s        |

chapvm (4 cores, 4 threads):

| locales | rt oversub | rb+bt oversub |
| ------- | ---------- | ------------- |
|   1     |  0.3s      |  0.3s         |
|   2     |  0.9s      |  0.9s         |
|   4     |  2.5s      |  2.5s         |
|   8     |  7.0s      |  7.0s         |
|  16     | 17.0s      | 18.5s         |
|  32     | 38.0s      | 38.5s         |

my mac (2 cores, 4 threads):

| locales | rt oversub | rb+bt oversub |
| ------- | ---------- | ------------- |
|   1     |  0.02s     |  0.03s        |
|   2     |  0.40s     |  0.40s        |
|   4     | 16.75s     | 16.50s        |
|   8     | 43.50s     | 47.50s        |