### PR TITLE
Fix a minor segfault in the compiler

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -468,15 +468,21 @@ void AggregateType::addDeclaration(DefExpr* defExpr) {
       Expr* firstexpr = bs->body.first();
       INT_ASSERT(firstexpr);
 
-      UnresolvedSymExpr* sym  = toUnresolvedSymExpr(firstexpr);
-      const char*        name = sym->unresolved;
-
-      // ... then report it to the user
-      USR_FATAL_CONT(fn->_this,
+      if (UnresolvedSymExpr* sym  = toUnresolvedSymExpr(firstexpr))
+        // ... then report it to the user
+        USR_FATAL_CONT(fn->_this,
                      "Type binding clauses ('%s.' in this case) are not "
                      "supported in declarations within a class, record "
                      "or union",
-                     name);
+                     sym->unresolved);
+      else
+        // got more than just a name
+        USR_FATAL_CONT(fn->_this,
+                     "Type binding clauses (in this case, the parenthesized "
+                "expression preceding the dot before function name) are not "
+                     "supported in declarations within a class, record "
+                     "or union");
+
     } else {
       ArgSymbol* arg = new ArgSymbol(fn->thisTag, "this", this);
 

--- a/test/classes/vass/def-with-type-binding-within-class/currently-error.chpl
+++ b/test/classes/vass/def-with-type-binding-within-class/currently-error.chpl
@@ -3,6 +3,7 @@
 
 class C {
   proc C.cc() {}
+  proc (shared C).scc() {}
 }
 
 var c = new C();
@@ -10,10 +11,11 @@ writeln(c);
 
 record R {
   proc R.rr() {}
+  proc type R.trr() {}
 }
 
 var r: R;
-writeln(c);
+writeln(r);
 
 union U {
   var i:int; var r:real;

--- a/test/classes/vass/def-with-type-binding-within-class/currently-error.good
+++ b/test/classes/vass/def-with-type-binding-within-class/currently-error.good
@@ -1,3 +1,5 @@
 currently-error.chpl:5: error: Type binding clauses ('C.' in this case) are not supported in declarations within a class, record or union
-currently-error.chpl:12: error: Type binding clauses ('R.' in this case) are not supported in declarations within a class, record or union
-currently-error.chpl:20: error: Type binding clauses ('U.' in this case) are not supported in declarations within a class, record or union
+currently-error.chpl:6: error: Type binding clauses (in this case, the parenthesized expression preceding the dot before function name) are not supported in declarations within a class, record or union
+currently-error.chpl:13: error: Type binding clauses ('R.' in this case) are not supported in declarations within a class, record or union
+currently-error.chpl:14: error: Type binding clauses ('R.' in this case) are not supported in declarations within a class, record or union
+currently-error.chpl:22: error: Type binding clauses ('U.' in this case) are not supported in declarations within a class, record or union


### PR DESCRIPTION
The segfault was due to the compiler relying on the type binding clause being just the class name in a primary method. Now handle an arbitrary expression.

Background: the compiler emits a "currently not supported" error for any type binding clause in a primary method.

Trivial, not reviewed.
