### PR TITLE
Increase the amount of oversubscription for cce whitebox testing

### DIFF
--- a/util/cron/test-xc-wb.bash
+++ b/util/cron/test-xc-wb.bash
@@ -17,8 +17,12 @@ if [ "${COMPILER}" == "pgi" ] ; then
   export QT_AFFINITY=yes
 fi
 
+if [ "${COMPILER}" == "cray" ] ; then
+  oversub=6
+fi
+
 # Run the tests!
-nightly_args="${nightly_args} -cron $(get_nightly_paratest_args)"
+nightly_args="${nightly_args} -cron $(get_nightly_paratest_args $oversub)"
 log_info "Calling nightly with args: ${nightly_args}"
 $CWD/nightly ${nightly_args}
 log_info "Finished running nightly."


### PR DESCRIPTION
Increase from running 2 paratest instances to 6 for cce testing to try
and get testing to finish before the PE update window. cce testing runs
on kay-elogin, which is beefy, but is also a shared machine. Bump the
amount of oversubscription to try to finish before PE updates, but don't
use an insane amount since it's still a shared machine. paratest `nice`'s
the start_test runs and we run with `CHPL_RT_OVERSUBSCRIBED=yes`, so
nodepara 6 shouldn't be too much.