### PR TITLE
Make it a fatal error if nightly fails to copy the temp log file

### DIFF
--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -748,7 +748,7 @@ if ($runtests == 0) {
         print "Executing $testcommand\n";
         $status = mysystem($testcommand, "running standard tests", 0, 0);
         print "Moving the log and summary files\n";
-        mysystem("cd $testdir && cp -v $rawlog $permlog && rm $rawlog && cp -v $rawsummary $permsum && rm $rawsummary", "moving the log files", 0, 0);
+        mysystem("cd $testdir && cp -v $rawlog $permlog && rm $rawlog && cp -v $rawsummary $permsum && rm $rawsummary", "moving the log files", 1, 1);
         $rawlog = $permlog;
         $rawsummary = $permsum;
     } else {


### PR DESCRIPTION
nightly uses a local log file stored in /tmp for speed and then copies
the results to some backed-up NFS location. If this copy fails then
we'll end up processing and reporting on last weeks results, which is
really confusing. Make it a fatal error if this copy fails. It failed
once last week, which is the first we know of, but this is something
that would have been hard to notice since it was silently ignored
before.