### PR TITLE
Mason testing fixes

### DIFF
--- a/test/mason/env/EXECENV
+++ b/test/mason/env/EXECENV
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+bin_subdir=`$CHPL_HOME/util/chplenv/chpl_bin_subdir.py`
+echo "PATH=\$CHPL_HOME/bin/$bin_subdir:\$PATH"

--- a/test/mason/mason-example/CLEANFILES
+++ b/test/mason/mason-example/CLEANFILES
@@ -1,2 +1,3 @@
 tempHome
 mason_home
+.mason

--- a/test/mason/mason-test/CLEANFILES
+++ b/test/mason/mason-test/CLEANFILES
@@ -1,2 +1,3 @@
 tempHome
 mason_home
+.mason

--- a/test/mason/search/badFileName/mason_home/mason-registry/Bricks/badFileName/0.1.0.toml
+++ b/test/mason/search/badFileName/mason_home/mason-registry/Bricks/badFileName/0.1.0.toml
@@ -1,5 +1,5 @@
 [brick]
-name = "badeFileName"
+name = "badFileName"
 version = "0.1.0"
 chplVersion = "1.19.0"
 source = "nil"

--- a/test/mason/search/badFileName/mason_home/mason-registry/Bricks/badFileName/1.0.0.toml
+++ b/test/mason/search/badFileName/mason_home/mason-registry/Bricks/badFileName/1.0.0.toml
@@ -1,5 +1,5 @@
 [brick]
-name = "badeFileName"
+name = "badFileName"
 version = "1.0.0"
 chplVersion = "1.19.0"
 source = "nil"

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -287,6 +287,10 @@ proc getChapelVersionInfo(): VersionInfo {
 
   if chplVersionInfo(1) == -1 {
     try {
+      if !isCmd('chpl') {
+        throw new owned MasonError('chpl command not found');
+      }
+
       var ret : VersionInfo;
 
       var process = spawn(["chpl", "--version"], stdout=PIPE);
@@ -330,6 +334,13 @@ proc getChapelVersionStr() {
     chplVersion = version(1) + "." + version(2) + "." + version(3);
   }
   return chplVersion;
+}
+
+/* Determine if a string can be called as a command */
+proc isCmd(cmd: string): bool throws {
+  var sub = spawn(['command', '-v', cmd], stdout=PIPE, stderr=PIPE);
+  sub.wait();
+  return sub.exit_status == 0;
 }
 
 proc gitC(newDir, command, quiet=false) {

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -287,14 +287,15 @@ proc getChapelVersionInfo(): VersionInfo {
 
   if chplVersionInfo(1) == -1 {
     try {
-      if !isCmd('chpl') {
-        throw new owned MasonError('chpl command not found');
-      }
 
       var ret : VersionInfo;
 
       var process = spawn(["chpl", "--version"], stdout=PIPE);
       process.wait();
+      if process.exit_status != 0 {
+        throw new owned MasonError("Failed to run 'chpl --version'");
+      }
+
 
       var output : string;
       for line in process.stdout.lines() {
@@ -334,13 +335,6 @@ proc getChapelVersionStr() {
     chplVersion = version(1) + "." + version(2) + "." + version(3);
   }
   return chplVersion;
-}
-
-/* Determine if a string can be called as a command */
-proc isCmd(cmd: string): bool throws {
-  var sub = spawn(['command', '-v', cmd], stdout=PIPE, stderr=PIPE);
-  sub.wait();
-  return sub.exit_status == 0;
 }
 
 proc gitC(newDir, command, quiet=false) {


### PR DESCRIPTION
This PR addresses 2 nightly failures:

1. Some tests now depends on `chpl --version` and didn't have the `EXECENV` to add `chpl` to the `PATH`.

2. Some `.mason` directories were leftover in the testing workspace, since they contain git repositories and `git clean -fdx` didn't wipe them. Adding this directory back to `CLEANFILES` for the cases that made noise, as a quick fix. 

A more principled solution would involve updating our Jenkins testing to do `git clean -ffdx` before runs (https://github.com/chapel-lang/chapel/issues/12827).

Other changes:

- Added a better error message for when `chpl --version` fails in `mason`.
- Fixed a minor typo in a test (which had no consequence on testing results, fortunately).