### PR TITLE
Unload more unneeded modules for whitebox testing

### DIFF
--- a/util/cron/common-whitebox.bash
+++ b/util/cron/common-whitebox.bash
@@ -126,13 +126,14 @@ case $COMPILER in
         ;;
 esac
 
-if [ "${HOSTNAME:0:6}" = "esxbld" ] ; then
-    libsci_module=$(module list -t 2>&1 | grep libsci)
-    if [ -n "${libsci_module}" ] ; then
-        log_info "Unloading cray-libsci module: ${libsci_module}"
-        module unload $libsci_module
-    fi
-fi
+log_info "Unloading cray-libsci module"
+module unload cray-libsci
+
+log_info "Unloading cray-mpich module"
+module unload cray-mpich
+
+log_info "Unloading atp module"
+module unload atp
 
 export CHPL_HOME=$(cd $CWD/../.. ; pwd)
 


### PR DESCRIPTION
Make sure libsci, mpich, and atp are always unloaded. Previously
unloading some of these modules was done in jenkins to only unload them
for kay-elogin, but there's no harm in unloading them on esxbld* too.
This really simplifies what was being done in jenkins.