### PR TITLE
Launcher verbose output should include launcher-set env vars.

### DIFF
--- a/runtime/include/chpllaunch.h
+++ b/runtime/include/chpllaunch.h
@@ -28,6 +28,7 @@
 int chpl_run_utility1K(const char *command, char *const argv[],
                        char *outbuf, int outbuflen);
 int chpl_run_cmdstr(const char *commandStr, char *outbuf, int outbuflen);
+void chpl_launcher_record_env_var(const char*, const char *);
 char **chpl_bundle_exec_args(int argc, char *const argv[],
                              int largc, char *const largv[]);
 int chpl_launch_using_fork_exec(const char* command, char * const argv1[],

--- a/runtime/src/chpl-env.c
+++ b/runtime/src/chpl-env.c
@@ -23,6 +23,10 @@
 #include "chpltypes.h"
 #include "error.h"
 
+#ifdef LAUNCHER
+#include "chpllaunch.h"
+#endif
+
 #include <ctype.h>
 #include <inttypes.h>
 #include <stdint.h>
@@ -172,6 +176,11 @@ size_t chpl_env_str_to_size(const char* evName, const char* evVal,
 
 
 void chpl_env_set(const char* evName, const char* evVal, int overwrite) {
+#ifdef LAUNCHER
+  if (overwrite || getenv(evName) == NULL) {
+    chpl_launcher_record_env_var(evName, evVal);
+  }
+#endif
   if (setenv(evName, evVal, overwrite) != 0) {
     char buf[200];
     snprintf(buf, sizeof(buf), "cannot setenv %s=\"%s\"", evName, evVal);

--- a/test/multilocale/numLocales/bradc/testVFlag.launcher-amudprun.goodstart
+++ b/test/multilocale/numLocales/bradc/testVFlag.launcher-amudprun.goodstart
@@ -1,1 +1,1 @@
-amudprun  -np 1 ./testVFlag_real -v -nl 1 EXECOPTS
+EVARS=vals amudprun  -np 1 ./testVFlag_real -v -nl 1 EXECOPTS

--- a/test/multilocale/numLocales/bradc/testVFlag.launcher-aprun.goodstart
+++ b/test/multilocale/numLocales/bradc/testVFlag.launcher-aprun.goodstart
@@ -1,1 +1,1 @@
-aprun  -q -cc none -dN -n1 -N1 -j0 ./testVFlag_real -v -nl 1 EXECOPTS
+HUGETLB_VERBOSE=0 HUGETLB_NO_RESERVE=yes CHPL_JE_MALLOC_CONF=purge:decay,lg_chunk:24 aprun  -cc none -dN -n1 -N1 -j0 ./testVFlag_real -v -nl 1

--- a/test/multilocale/numLocales/bradc/testVFlag.launcher-aprun.goodstart
+++ b/test/multilocale/numLocales/bradc/testVFlag.launcher-aprun.goodstart
@@ -1,1 +1,1 @@
-HUGETLB_VERBOSE=0 HUGETLB_NO_RESERVE=yes CHPL_JE_MALLOC_CONF=purge:decay,lg_chunk:24 aprun  -cc none -dN -n1 -N1 -j0 ./testVFlag_real -v -nl 1
+EVARS=vals aprun  -cc none -dN -n1 -N1 -j0 ./testVFlag_real -v -nl 1

--- a/test/multilocale/numLocales/bradc/testVFlag.launcher-aprun.goodstart
+++ b/test/multilocale/numLocales/bradc/testVFlag.launcher-aprun.goodstart
@@ -1,1 +1,1 @@
-EVARS=vals aprun  -cc none -dN -n1 -N1 -j0 ./testVFlag_real -v -nl 1
+EVARS=vals aprun  -cc none -dN -n1 -N1 -j0 ./testVFlag_real -v -nl 1 EXECOPTS

--- a/test/multilocale/numLocales/bradc/testVFlag.launcher-mpirun4ofi.goodstart
+++ b/test/multilocale/numLocales/bradc/testVFlag.launcher-mpirun4ofi.goodstart
@@ -1,1 +1,8 @@
-mpirun  -np 1 -map-by ppr:1:node -map-by node:oversubscribe -bind-to none ./testVFlag_real -v -nl 1 EXECOPTS
+#!/bin/sh
+if [[ $CHPL_RT_OVERSUBSCRIBED =~ [1tTyY] ]] ; then
+  moreArgs="-mca mpi_yield_when_idle 1"
+fi
+echo "EVARS=vals" \
+     "mpirun  -np 1 -map-by ppr:1:node -map-by node:oversubscribe" \
+     "-bind-to none${moreArgs:+ $moreArgs}" \
+     "./testVFlag_real -v -nl 1${EXECOPTS:+ $EXECOPTS}"

--- a/test/multilocale/numLocales/bradc/testVFlag.launcher-smp.goodstart
+++ b/test/multilocale/numLocales/bradc/testVFlag.launcher-smp.goodstart
@@ -1,1 +1,1 @@
-./testVFlag_real  -v -nl 1 EXECOPTS
+EVARS=vals ./testVFlag_real  -v -nl 1 EXECOPTS

--- a/test/multilocale/numLocales/bradc/testVFlag.prediff
+++ b/test/multilocale/numLocales/bradc/testVFlag.prediff
@@ -6,16 +6,31 @@ launcher=$($CHPL_HOME/util/chplenv/chpl_launcher.py)
 target=$($CHPL_HOME/util/chplenv/chpl_platform.py --target)
 
 # Build a .good file; the lines are:
-# - .launcher-$CHPL_LAUNCHER, with ' EXECOPTS' replaced with $EXECOPTS
-#   (the leading space allows separating this from the command line in
-#   the .goodstart, for readability).  We then remove any resulting
-#   trailing space.
+# - either:
+#   - if the .launcher-$CHPL_LAUNCHER.goodstart file is executable, its
+#     output, otherwise
+#   - the .launcher-$CHPL_LAUNCHER.goodstart contents, with ' EXECOPTS'
+#     replaced with $EXECOPTS (the leading space allows separating this
+#     from the command line in the .goodstart, for readability).  We
+#     then remove any resulting trailing space.
 # - .comm-$CHPL_COMM, with 'UNAME' replaced by the result of 'uname -n'
 # - .goodstop, which is the expected program output
-sed -e "s# EXECOPTS#$EXECOPTS#" -e 's/ $//' \
-    < $1.launcher-$launcher.goodstart > $1.good
+if [[ -x $1.launcher-$launcher.goodstart ]] ; then
+  ./$1.launcher-$launcher.goodstart > $1.good
+else
+  sed -e "s# EXECOPTS#$EXECOPTS#" -e 's/ $//' \
+      < $1.launcher-$launcher.goodstart > $1.good
+fi
 sed "s/UNAME/$uname/" < $1.comm-$CHPL_COMM.goodcont >> $1.good
 cat $1.goodstop >> $1.good
+
+# For all configurations that use a launcher, replace environment
+# variable settings on the front of the 1st output line (the launcher
+# one) with a placeholder.
+if [[ $launcher != none ]] ; then
+  sed '1 s/^\([a-zA-Z0-9_]\{1,\}=[^ ]* \)*/EVARS=vals /' < $2 > $2.tmp && \
+  mv $2.tmp $2
+fi
 
 # Address program output variations peculiar to the various configuation
 # settings.
@@ -36,7 +51,7 @@ esac
 # If we use the amudprun launcher, there's a path on the front of it.
 # If we use the aprun launcher, the depth (-d) value may vary.
 case $launcher in
-  amudprun) sed -e "s/^.*amudprun/amudprun/" \
+  amudprun) sed -e "s/[^ ]*amudprun/amudprun/" \
                 -e "/QTHREADS/d" $2 > $2.tmp &&
             mv $2.tmp $2;;
   aprun) sed -e "s/ -d[1-9][0-9]* / -dN /" $2 > $2.tmp &&

--- a/test/multilocale/numLocales/bradc/testVerboseFlag.launcher-amudprun.goodstart
+++ b/test/multilocale/numLocales/bradc/testVerboseFlag.launcher-amudprun.goodstart
@@ -1,1 +1,1 @@
-amudprun  -np 1 ./testVerboseFlag_real --verbose -nl 1 EXECOPTS
+EVARS=vals amudprun  -np 1 ./testVerboseFlag_real --verbose -nl 1 EXECOPTS

--- a/test/multilocale/numLocales/bradc/testVerboseFlag.launcher-aprun.goodstart
+++ b/test/multilocale/numLocales/bradc/testVerboseFlag.launcher-aprun.goodstart
@@ -1,1 +1,1 @@
-aprun  -q -cc none -dN -n1 -N1 -j0 ./testVerboseFlag_real --verbose -nl 1 EXECOPTS
+HUGETLB_VERBOSE=0 HUGETLB_NO_RESERVE=yes CHPL_JE_MALLOC_CONF=purge:decay,lg_chunk:24 aprun  -cc none -dN -n1 -N1 -j0 ./testVerboseFlag_real --verbose -nl 1

--- a/test/multilocale/numLocales/bradc/testVerboseFlag.launcher-aprun.goodstart
+++ b/test/multilocale/numLocales/bradc/testVerboseFlag.launcher-aprun.goodstart
@@ -1,1 +1,1 @@
-HUGETLB_VERBOSE=0 HUGETLB_NO_RESERVE=yes CHPL_JE_MALLOC_CONF=purge:decay,lg_chunk:24 aprun  -cc none -dN -n1 -N1 -j0 ./testVerboseFlag_real --verbose -nl 1
+EVARS=vals aprun  -cc none -dN -n1 -N1 -j0 ./testVerboseFlag_real --verbose -nl 1

--- a/test/multilocale/numLocales/bradc/testVerboseFlag.launcher-aprun.goodstart
+++ b/test/multilocale/numLocales/bradc/testVerboseFlag.launcher-aprun.goodstart
@@ -1,1 +1,1 @@
-EVARS=vals aprun  -cc none -dN -n1 -N1 -j0 ./testVerboseFlag_real --verbose -nl 1
+EVARS=vals aprun  -cc none -dN -n1 -N1 -j0 ./testVerboseFlag_real --verbose -nl 1 EXECOPTS

--- a/test/multilocale/numLocales/bradc/testVerboseFlag.launcher-mpirun4ofi.goodstart
+++ b/test/multilocale/numLocales/bradc/testVerboseFlag.launcher-mpirun4ofi.goodstart
@@ -1,1 +1,8 @@
-mpirun  -np 1 -map-by ppr:1:node -map-by node:oversubscribe -bind-to none ./testVerboseFlag_real --verbose -nl 1 EXECOPTS
+#!/bin/sh
+if [[ $CHPL_RT_OVERSUBSCRIBED =~ [1tTyY] ]] ; then
+  moreArgs="-mca mpi_yield_when_idle 1"
+fi
+echo "EVARS=vals" \
+     "mpirun  -np 1 -map-by ppr:1:node -map-by node:oversubscribe" \
+     "-bind-to none${moreArgs:+ $moreArgs}" \
+     "./testVerboseFlag_real --verbose -nl 1${EXECOPTS:+ $EXECOPTS}"

--- a/test/multilocale/numLocales/bradc/testVerboseFlag.launcher-smp.goodstart
+++ b/test/multilocale/numLocales/bradc/testVerboseFlag.launcher-smp.goodstart
@@ -1,1 +1,1 @@
-./testVerboseFlag_real  --verbose -nl 1 EXECOPTS
+EVARS=vals ./testVerboseFlag_real  --verbose -nl 1 EXECOPTS

--- a/test/multilocale/numLocales/bradc/testVerboseFlag.prediff
+++ b/test/multilocale/numLocales/bradc/testVerboseFlag.prediff
@@ -6,16 +6,31 @@ launcher=$($CHPL_HOME/util/chplenv/chpl_launcher.py)
 target=$($CHPL_HOME/util/chplenv/chpl_platform.py --target)
 
 # Build a .good file; the lines are:
-# - .launcher-$CHPL_LAUNCHER, with ' EXECOPTS' replaced with $EXECOPTS
-#   (the leading space allows separating this from the command line in
-#   the .goodstart, for readability).  We then remove any resulting
-#   trailing space.
+# - either:
+#   - if the .launcher-$CHPL_LAUNCHER.goodstart file is executable, its
+#     output, otherwise
+#   - the .launcher-$CHPL_LAUNCHER.goodstart contents, with ' EXECOPTS'
+#     replaced with $EXECOPTS (the leading space allows separating this
+#     from the command line in the .goodstart, for readability).  We
+#     then remove any resulting trailing space.
 # - .comm-$CHPL_COMM, with 'UNAME' replaced by the result of 'uname -n'
 # - .goodstop, which is the expected program output
-sed -e "s# EXECOPTS#$EXECOPTS#" -e 's/ $//' \
-    < $1.launcher-$launcher.goodstart > $1.good
+if [[ -x $1.launcher-$launcher.goodstart ]] ; then
+  ./$1.launcher-$launcher.goodstart > $1.good
+else
+  sed -e "s# EXECOPTS#$EXECOPTS#" -e 's/ $//' \
+      < $1.launcher-$launcher.goodstart > $1.good
+fi
 sed "s/UNAME/$uname/" < $1.comm-$CHPL_COMM.goodcont >> $1.good
 cat $1.goodstop >> $1.good
+
+# For all configurations that use a launcher, replace environment
+# variable settings on the front of the 1st output line (the launcher
+# one) with a placeholder.
+if [[ $launcher != none ]] ; then
+  sed '1 s/^\([a-zA-Z0-9_]\{1,\}=[^ ]* \)*/EVARS=vals /' < $2 > $2.tmp && \
+  mv $2.tmp $2
+fi
 
 # Address program output variations peculiar to the various configuation
 # settings.
@@ -36,7 +51,7 @@ esac
 # If we use the amudprun launcher, there's a path on the front of it.
 # If we use the aprun launcher, the depth (-d) value may vary.
 case $launcher in
-  amudprun) sed -e "s/^.*amudprun/amudprun/" \
+  amudprun) sed -e "s/[^ ]*amudprun/amudprun/" \
                 -e "/QTHREADS/d" $2 > $2.tmp &&
             mv $2.tmp $2;;
   aprun) sed -e "s/ -d[1-9][0-9]* / -dN /" $2 > $2.tmp &&


### PR DESCRIPTION
When Chapel launchers set environment variables, as they do when the
compute processes need to see those before user code runs, then those
settings should be reflected in the launcher verbose output that shows
the launch command.

This closes #7841.