### PR TITLE
Adjust Python scripts in Path module tests to use print() for compatibility 

### DIFF
--- a/test/library/standard/Path/dlongnecke/absPath/absPath.preexec
+++ b/test/library/standard/Path/dlongnecke/absPath/absPath.preexec
@@ -5,6 +5,7 @@
 # test code will mirror the ones found here.
 
 
+from __future__ import print_function
 import sys
 import os.path
 
@@ -20,7 +21,7 @@ pathSep3 = '///'
 
 
 def absolutize(name):
-    print name, 'becomes', os.path.abspath(name)
+    print(name, 'becomes', os.path.abspath(name))
 
 
 # Redirect STDOUT to the "absPath.good" file.

--- a/test/library/standard/Path/dlongnecke/absPath/fileAbsPath.preexec
+++ b/test/library/standard/Path/dlongnecke/absPath/fileAbsPath.preexec
@@ -8,6 +8,7 @@
 # Python functionality.
 
 
+from __future__ import print_function
 import sys
 import os.path
 
@@ -27,11 +28,11 @@ def do_tests(somepath):
     try:
         f = open(somepath, 'r')
     except Exception as e:
-        print 'Failed to open file!'
+        print('Failed to open file!')
         return
 
     # Print path used to open file.
-    print somepath
+    print(somepath)
 
     # NOTE: The semantics of this are different between Python/Chapel.
     # In Python, this prints the path used to OPEN the file.
@@ -40,10 +41,10 @@ def do_tests(somepath):
     # print file.name
 
     # Print the abspath of the path used to open.
-    print os.path.abspath(somepath)
+    print(os.path.abspath(somepath))
 
     # Get expected output for our test file.
-    print absolutize_file(f)
+    print(absolutize_file(f))
     f.close()
 
 

--- a/test/library/standard/Path/dlongnecke/normPath/normPath.preexec
+++ b/test/library/standard/Path/dlongnecke/normPath/normPath.preexec
@@ -3,12 +3,8 @@
 # Python (2.7) code with proper output for os.path.normpath(). Use this to
 # generate the output for "testcases_normPath.good".
 
-# NOTE: I had to revert this script back to Python 2.7 because a remote
-# testing machine did not support Python 3. It is assumed that the
-# implementation of os.path.normpath() has not changed much between Python 2.7
-# and Python 3.7 (I referenced the latter for my implementation).
 
-
+from __future__ import print_function
 import os.path
 import sys
 
@@ -32,7 +28,7 @@ pathSep2 = '//'
 
 
 def collapse(path):
-    print path, 'becomes', os.path.normpath(path)
+    print(path, 'becomes', os.path.normpath(path))
 
 
 # Redirect STDOUT to the "testcase_normPath.good" file.

--- a/test/library/standard/Path/relPath/fileRelPath.preexec
+++ b/test/library/standard/Path/relPath/fileRelPath.preexec
@@ -4,6 +4,7 @@
 # Produce the output file our test will compare itself against.
 
 
+from __future__ import print_function
 import sys
 import os.path
 
@@ -46,8 +47,8 @@ class ChplFileWrapper(object):
 
 # Perform a single test, validating the input.
 def test(chplfile, start=""):
-    print 'filepath=', chplfile.path(), 'start=', start
-    print chplfile.relpath(start)
+    print('filepath=', chplfile.path(), 'start=', start)
+    print(chplfile.relpath(start))
 
 
 # Perform tests using a given input path.
@@ -56,17 +57,17 @@ def do_tests(somepath):
     try:
         f = ChplFileWrapper(somepath, 'r')
     except Exception as e:
-        print 'Failed to open file!'
+        print('Failed to open file!')
         return
 
     # Print path used to open file.
-    print somepath
+    print(somepath)
 
     # Print the abspath of the path used to open.
-    print os.path.abspath(somepath)
+    print(os.path.abspath(somepath))
 
     # Print the path contained in this file.
-    print f.path()
+    print(f.path())
 
     # No start.
     test(f)

--- a/test/library/standard/Path/relPath/relPath.preexec
+++ b/test/library/standard/Path/relPath/relPath.preexec
@@ -4,6 +4,7 @@
 # Produce the output file our test will compare itself against.
 
 
+from __future__ import print_function
 import sys
 import os.path
 
@@ -16,8 +17,8 @@ pathSep2 = '//'
 
 
 def test(name, start=""):
-    print 'name=', name, 'start=', start
-    print os.path.relpath(name, start)
+    print('name=', name, 'start=', start)
+    print(os.path.relpath(name, start))
 
 
 # Redirect STDOUT to the output file.


### PR DESCRIPTION
Earlier today, @ben-albrecht pointed out that some of the .preexec scripts I introduced for tests covering the Path module fail when executed with Python3. 

He suggested `from __futures__ import print_function`, so I've gone ahead and substituted Python2 style print expressions with calls to print() within these scripts.

Testing:
- `ALL` on `linux64` when `CHPL_LLVM=llvm` and `CHPL_COMM=none`