### PR TITLE
Eliminated memory leak in mason search

### DIFF
--- a/tools/mason/MasonSearch.chpl
+++ b/tools/mason/MasonSearch.chpl
@@ -104,10 +104,9 @@ proc findLatest(packageDir: string): VersionInfo {
     const chplVersion = getChapelVersionInfo();
 
     const manifestReader = openreader(packageDir + '/' + manifest);
-    const manifestToml = parseToml(manifestReader);
+    const manifestToml = new owned(parseToml(manifestReader));
     const brick = manifestToml['brick'];
     var (low, high) = parseChplVersion(brick);
-    delete brick;
     if chplVersion < low || chplVersion > high then continue;
 
     // Check that Chapel version is supported


### PR DESCRIPTION
Switched to owned memory management rather than manually (mis)-deleting Toml node.