### PR TITLE
Add AMOs to CommDiagnostics.

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -1404,16 +1404,14 @@ static void codegen_defn(std::set<const char*> & cnames, std::vector<TypeSymbol*
   //
   if( hdrfile ) {
     fprintf(hdrfile, "\nvoid* const chpl_private_broadcast_table[] = {\n");
-    fprintf(hdrfile, "&chpl_verbose_comm");
-    fprintf(hdrfile, ",\n&chpl_comm_diagnostics");
-    fprintf(hdrfile, ",\n&chpl_verbose_mem");
-    int i = 3;
+    int i = 0;
     forv_Vec(CallExpr, call, gCallExprs) {
       if (call->isPrimitive(PRIM_PRIVATE_BROADCAST)) {
         SymExpr* se = toSymExpr(call->get(1));
         INT_ASSERT(se);
         SET_LINENO(call);
-        fprintf(hdrfile, ",\n&%s", se->symbol()->cname);
+        fprintf(hdrfile, "%s\n&%s",
+                ((i == 0) ? "" : ","), se->symbol()->cname);
         // To preserve operand order, this should be insertAtTail.
         // The change must also be made below (for LLVM) and in the signature
         // of chpl_comm_broadcast_private().
@@ -1822,20 +1820,8 @@ static void codegen_header(std::set<const char*> & cnames, std::vector<TypeSymbo
       llvm::IntegerType::getInt8PtrTy(info->module->getContext());
 
     std::vector<llvm::Constant *> private_broadcastTable;
-    private_broadcastTable.push_back(llvm::cast<llvm::Constant>(
-          info->irBuilder->CreatePointerCast(
-            info->lvt->getValue("chpl_verbose_comm").val,
-            private_broadcastTableEntryType)));
-    private_broadcastTable.push_back(llvm::cast<llvm::Constant>(
-          info->irBuilder->CreatePointerCast(
-            info->lvt->getValue("chpl_comm_diagnostics").val,
-            private_broadcastTableEntryType)));
-    private_broadcastTable.push_back(llvm::cast<llvm::Constant>(
-          info->irBuilder->CreatePointerCast(
-            info->lvt->getValue("chpl_verbose_mem").val,
-            private_broadcastTableEntryType)));
 
-    int broadcastID = 3;
+    int broadcastID = 0;
     forv_Vec(CallExpr, call, gCallExprs) {
       if (call->isPrimitive(PRIM_PRIVATE_BROADCAST)) {
         SymExpr* se = toSymExpr(call->get(1));

--- a/modules/standard/CommDiagnostics.chpl
+++ b/modules/standard/CommDiagnostics.chpl
@@ -179,10 +179,6 @@ module CommDiagnostics
    */
   config param commDiagsPrintUnstable = false;
 
-  /* The runtime needs this, to get the value of the flag. */
-  pragma "no doc"
-  export proc chpl_getCommDiagsPrintUnstable() return commDiagsPrintUnstable;
-
   /* Aggregated communication operation counts.  This record type is
      defined in the same way by both the underlying comm layer(s) and
      this module, because we don't have a good way to inherit types back
@@ -261,19 +257,19 @@ module CommDiagnostics
    */
   type commDiagnostics = chpl_commDiagnostics;
 
-  private extern proc chpl_comm_startVerbose();
+  private extern proc chpl_comm_startVerbose(print_unstable: bool);
 
   private extern proc chpl_comm_stopVerbose();
 
-  private extern proc chpl_comm_startVerboseHere();
+  private extern proc chpl_comm_startVerboseHere(print_unstable: bool);
 
   private extern proc chpl_comm_stopVerboseHere();
 
-  private extern proc chpl_comm_startDiagnostics();
+  private extern proc chpl_comm_startDiagnostics(print_unstable: bool);
 
   private extern proc chpl_comm_stopDiagnostics();
 
-  private extern proc chpl_comm_startDiagnosticsHere();
+  private extern proc chpl_comm_startDiagnosticsHere(print_unstable: bool);
 
   private extern proc chpl_comm_stopDiagnosticsHere();
 
@@ -284,7 +280,9 @@ module CommDiagnostics
   /*
     Start on-the-fly reporting of communication initiated on any locale.
    */
-  proc startVerboseComm() { chpl_comm_startVerbose(); }
+  proc startVerboseComm() {
+    chpl_comm_startVerbose(commDiagsPrintUnstable);
+  }
 
   /*
     Stop on-the-fly reporting of communication initiated on any locale.
@@ -294,7 +292,9 @@ module CommDiagnostics
   /*
     Start on-the-fly reporting of communication initiated on this locale.
    */
-  proc startVerboseCommHere() { chpl_comm_startVerboseHere(); }
+  proc startVerboseCommHere() {
+    chpl_comm_startVerboseHere(commDiagsPrintUnstable);
+  }
 
   /*
     Stop on-the-fly reporting of communication initiated on this locale.
@@ -305,7 +305,7 @@ module CommDiagnostics
     Start counting communication operations across the whole program.
    */
   proc startCommDiagnostics() {
-    chpl_comm_startDiagnostics();
+    chpl_comm_startDiagnostics(commDiagsPrintUnstable);
   }
 
   /*
@@ -319,7 +319,7 @@ module CommDiagnostics
     Start counting communication operations initiated on this locale.
    */
   proc startCommDiagnosticsHere() {
-    chpl_comm_startDiagnosticsHere();
+    chpl_comm_startDiagnosticsHere(commDiagsPrintUnstable);
   }
 
   /*

--- a/modules/standard/CommDiagnostics.chpl
+++ b/modules/standard/CommDiagnostics.chpl
@@ -269,13 +269,13 @@ module CommDiagnostics
 
   private extern proc chpl_stopVerboseCommHere();
 
-  private extern proc chpl_gen_startCommDiagnostics();
+  private extern proc chpl_startCommDiagnostics();
 
-  private extern proc chpl_gen_stopCommDiagnostics();
+  private extern proc chpl_stopCommDiagnostics();
 
-  private extern proc chpl_gen_startCommDiagnosticsHere();
+  private extern proc chpl_startCommDiagnosticsHere();
 
-  private extern proc chpl_gen_stopCommDiagnosticsHere();
+  private extern proc chpl_stopCommDiagnosticsHere();
 
   private extern proc chpl_resetCommDiagnosticsHere();
 
@@ -305,28 +305,28 @@ module CommDiagnostics
     Start counting communication operations across the whole program.
    */
   proc startCommDiagnostics() {
-    chpl_gen_startCommDiagnostics();
+    chpl_startCommDiagnostics();
   }
 
   /*
     Stop counting communication operations across the whole program.
    */
   proc stopCommDiagnostics() {
-    chpl_gen_stopCommDiagnostics();
+    chpl_stopCommDiagnostics();
   }
 
   /*
     Start counting communication operations initiated on this locale.
    */
   proc startCommDiagnosticsHere() {
-    chpl_gen_startCommDiagnosticsHere();
+    chpl_startCommDiagnosticsHere();
   }
 
   /*
     Stop counting communication operations initiated on this locale.
    */
   proc stopCommDiagnosticsHere() {
-    chpl_gen_stopCommDiagnosticsHere();
+    chpl_stopCommDiagnosticsHere();
   }
 
   /*

--- a/modules/standard/CommDiagnostics.chpl
+++ b/modules/standard/CommDiagnostics.chpl
@@ -179,6 +179,10 @@ module CommDiagnostics
    */
   config param commDiagsPrintUnstable = false;
 
+  /* The runtime needs this, to get the value of the flag. */
+  pragma "no doc"
+  export proc chpl_getCommDiagsPrintUnstable() return commDiagsPrintUnstable;
+
   /* Aggregated communication operation counts.  This record type is
      defined in the same way by both the underlying comm layer(s) and
      this module, because we don't have a good way to inherit types back

--- a/modules/standard/CommDiagnostics.chpl
+++ b/modules/standard/CommDiagnostics.chpl
@@ -261,72 +261,72 @@ module CommDiagnostics
    */
   type commDiagnostics = chpl_commDiagnostics;
 
-  private extern proc chpl_startVerboseComm();
+  private extern proc chpl_comm_startVerbose();
 
-  private extern proc chpl_stopVerboseComm();
+  private extern proc chpl_comm_stopVerbose();
 
-  private extern proc chpl_startVerboseCommHere();
+  private extern proc chpl_comm_startVerboseHere();
 
-  private extern proc chpl_stopVerboseCommHere();
+  private extern proc chpl_comm_stopVerboseHere();
 
-  private extern proc chpl_startCommDiagnostics();
+  private extern proc chpl_comm_startDiagnostics();
 
-  private extern proc chpl_stopCommDiagnostics();
+  private extern proc chpl_comm_stopDiagnostics();
 
-  private extern proc chpl_startCommDiagnosticsHere();
+  private extern proc chpl_comm_startDiagnosticsHere();
 
-  private extern proc chpl_stopCommDiagnosticsHere();
+  private extern proc chpl_comm_stopDiagnosticsHere();
 
-  private extern proc chpl_resetCommDiagnosticsHere();
+  private extern proc chpl_comm_resetDiagnosticsHere();
 
-  private extern proc chpl_getCommDiagnosticsHere(out cd: commDiagnostics);
+  private extern proc chpl_comm_getDiagnosticsHere(out cd: commDiagnostics);
 
   /*
     Start on-the-fly reporting of communication initiated on any locale.
    */
-  proc startVerboseComm() { chpl_startVerboseComm(); }
+  proc startVerboseComm() { chpl_comm_startVerbose(); }
 
   /*
     Stop on-the-fly reporting of communication initiated on any locale.
    */
-  proc stopVerboseComm() { chpl_stopVerboseComm(); }
+  proc stopVerboseComm() { chpl_comm_stopVerbose(); }
 
   /*
     Start on-the-fly reporting of communication initiated on this locale.
    */
-  proc startVerboseCommHere() { chpl_startVerboseCommHere(); }
+  proc startVerboseCommHere() { chpl_comm_startVerboseHere(); }
 
   /*
     Stop on-the-fly reporting of communication initiated on this locale.
    */
-  proc stopVerboseCommHere() { chpl_stopVerboseCommHere(); }
+  proc stopVerboseCommHere() { chpl_comm_stopVerboseHere(); }
 
   /*
     Start counting communication operations across the whole program.
    */
   proc startCommDiagnostics() {
-    chpl_startCommDiagnostics();
+    chpl_comm_startDiagnostics();
   }
 
   /*
     Stop counting communication operations across the whole program.
    */
   proc stopCommDiagnostics() {
-    chpl_stopCommDiagnostics();
+    chpl_comm_stopDiagnostics();
   }
 
   /*
     Start counting communication operations initiated on this locale.
    */
   proc startCommDiagnosticsHere() {
-    chpl_startCommDiagnosticsHere();
+    chpl_comm_startDiagnosticsHere();
   }
 
   /*
     Stop counting communication operations initiated on this locale.
    */
   proc stopCommDiagnosticsHere() {
-    chpl_stopCommDiagnosticsHere();
+    chpl_comm_stopDiagnosticsHere();
   }
 
   /*
@@ -341,7 +341,7 @@ module CommDiagnostics
     Reset aggregate communication counts on the calling locale.
    */
   inline proc resetCommDiagnosticsHere() {
-    chpl_resetCommDiagnosticsHere();
+    chpl_comm_resetDiagnosticsHere();
   }
 
   /*
@@ -366,7 +366,7 @@ module CommDiagnostics
    */
   proc getCommDiagnosticsHere() {
     var cd: commDiagnostics;
-    chpl_getCommDiagnosticsHere(cd);
+    chpl_comm_getDiagnosticsHere(cd);
     return cd;
   }
 

--- a/runtime/include/chpl-comm-diags.h
+++ b/runtime/include/chpl-comm-diags.h
@@ -101,6 +101,12 @@ void chpl_comm_diags_verbose_printf(const char* format, ...) {
                                  chpl_lookupFilename(fn), ln, op,       \
                                  (int) node)
 
+#define chpl_comm_diags_verbose_amo(op, node, ln, fn)                   \
+  chpl_comm_diags_verbose_printf("%s:%d: remote %s, "                   \
+                                 "node %d",                             \
+                                 chpl_lookupFilename(fn), ln, op,       \
+                                 (int) node)
+
 #define chpl_comm_diags_verbose_executeOn(kind, node)                   \
   chpl_comm_diags_verbose_printf("remote %-*sexecuteOn, node %d",       \
                                  ((int) strlen(kind)                    \

--- a/runtime/include/chpl-comm-diags.h
+++ b/runtime/include/chpl-comm-diags.h
@@ -26,6 +26,9 @@
 #include "chpl-atomics.h"
 #include "chpl-comm.h"
 
+extern int chpl_verbose_comm;     // set via startVerboseComm
+extern int chpl_comm_diagnostics; // set via startCommDiagnostics
+
 typedef struct _chpl_atomic_commDiagnostics {
 #define _COMM_DIAGS_DECL_ATOMIC(cdv) atomic_uint_least64_t cdv;
   CHPL_COMM_DIAGS_VARS_ALL(_COMM_DIAGS_DECL_ATOMIC)

--- a/runtime/include/chpl-comm-diags.h
+++ b/runtime/include/chpl-comm-diags.h
@@ -26,9 +26,50 @@
 #include "chpl-atomics.h"
 #include "chpl-comm.h"
 
+////////////////////
+//
+// Public
+//
+
 extern int chpl_verbose_comm;     // set via startVerboseComm
 extern int chpl_comm_diagnostics; // set via startCommDiagnostics
 
+#define CHPL_COMM_DIAGS_VARS_ALL(MACRO) \
+  MACRO(get) \
+  MACRO(get_nb) \
+  MACRO(put) \
+  MACRO(put_nb) \
+  MACRO(test_nb) \
+  MACRO(wait_nb) \
+  MACRO(try_nb) \
+  MACRO(amo) \
+  MACRO(execute_on) \
+  MACRO(execute_on_fast) \
+  MACRO(execute_on_nb)
+
+typedef struct _chpl_commDiagnostics {
+#define _COMM_DIAGS_DECL(cdv) uint64_t cdv;
+  CHPL_COMM_DIAGS_VARS_ALL(_COMM_DIAGS_DECL)
+#undef _COMM_DIAGS_DECL
+} chpl_commDiagnostics;
+
+void chpl_comm_startVerbose(void);
+void chpl_comm_stopVerbose(void);
+void chpl_comm_startVerboseHere(void);
+void chpl_comm_stopVerboseHere(void);
+
+void chpl_comm_startDiagnostics(void);
+void chpl_comm_stopDiagnostics(void);
+void chpl_comm_startDiagnosticsHere(void);
+void chpl_comm_stopDiagnosticsHere(void);
+void chpl_comm_resetDiagnosticsHere(void);
+void chpl_comm_getDiagnosticsHere(chpl_commDiagnostics *cd);
+
+
+////////////////////
+//
+// Private
+//
 typedef struct _chpl_atomic_commDiagnostics {
 #define _COMM_DIAGS_DECL_ATOMIC(cdv) atomic_uint_least64_t cdv;
   CHPL_COMM_DIAGS_VARS_ALL(_COMM_DIAGS_DECL_ATOMIC)

--- a/runtime/include/chpl-comm-diags.h
+++ b/runtime/include/chpl-comm-diags.h
@@ -76,11 +76,16 @@ int chpl_comm_diags_is_enabled(void) {
 }
 
 static inline
-void chpl_comm_diags_verbose_printf(const char*, ...)
-  __attribute__((format(printf, 1, 2)));
+void chpl_comm_diags_verbose_printf(chpl_bool, const char*, ...)
+  __attribute__((format(printf, 2, 3)));
 static inline
-void chpl_comm_diags_verbose_printf(const char* format, ...) {
-  if (chpl_verbose_comm && chpl_comm_diags_is_enabled()) {
+void chpl_comm_diags_verbose_printf(chpl_bool is_unstable,
+                                    const char* format, ...) {
+  // This is in the CommDiagnostics module.
+  extern chpl_bool chpl_getCommDiagsPrintUnstable(void);
+  if (chpl_verbose_comm
+      && chpl_comm_diags_is_enabled()
+      && (!is_unstable || chpl_getCommDiagsPrintUnstable())) {
     char myFmt[100];
     snprintf(myFmt, sizeof(myFmt), "%d: %s\n", chpl_nodeID, format);
     va_list ap;
@@ -91,24 +96,26 @@ void chpl_comm_diags_verbose_printf(const char* format, ...) {
 }
 
 #define chpl_comm_diags_verbose_rdma(op, node, size, ln, fn)            \
-  chpl_comm_diags_verbose_printf("%s:%d: remote %s, "                   \
-                                 "node %d, %zu bytes",                  \
+  chpl_comm_diags_verbose_printf(false,                                 \
+                                 "%s:%d: remote %s, node %d, %zu bytes",\
                                  chpl_lookupFilename(fn), ln, op,       \
                                  (int) node, size)
 
 #define chpl_comm_diags_verbose_rdmaStrd(op, node, ln, fn)              \
-  chpl_comm_diags_verbose_printf("%s:%d: remote strided %s, node %d",   \
+  chpl_comm_diags_verbose_printf(false,                                 \
+                                 "%s:%d: remote strided %s, node %d",   \
                                  chpl_lookupFilename(fn), ln, op,       \
                                  (int) node)
 
 #define chpl_comm_diags_verbose_amo(op, node, ln, fn)                   \
-  chpl_comm_diags_verbose_printf("%s:%d: remote %s, "                   \
-                                 "node %d",                             \
+  chpl_comm_diags_verbose_printf(true,                                  \
+                                 "%s:%d: remote %s, node %d",           \
                                  chpl_lookupFilename(fn), ln, op,       \
                                  (int) node)
 
 #define chpl_comm_diags_verbose_executeOn(kind, node)                   \
-  chpl_comm_diags_verbose_printf("remote %-*sexecuteOn, node %d",       \
+  chpl_comm_diags_verbose_printf(false,                                 \
+                                 "remote %-*sexecuteOn, node %d",       \
                                  ((int) strlen(kind)                    \
                                   + ((strlen(kind) == 0) ? 0 : 1)),     \
                                  kind, (int) node)

--- a/runtime/include/chpl-comm-diags.h
+++ b/runtime/include/chpl-comm-diags.h
@@ -34,6 +34,8 @@
 extern int chpl_verbose_comm;     // set via startVerboseComm
 extern int chpl_comm_diagnostics; // set via startCommDiagnostics
 
+extern chpl_bool chpl_comm_diags_print_unstable;
+
 #define CHPL_COMM_DIAGS_VARS_ALL(MACRO) \
   MACRO(get) \
   MACRO(get_nb) \
@@ -53,14 +55,14 @@ typedef struct _chpl_commDiagnostics {
 #undef _COMM_DIAGS_DECL
 } chpl_commDiagnostics;
 
-void chpl_comm_startVerbose(void);
+void chpl_comm_startVerbose(chpl_bool);
 void chpl_comm_stopVerbose(void);
-void chpl_comm_startVerboseHere(void);
+void chpl_comm_startVerboseHere(chpl_bool);
 void chpl_comm_stopVerboseHere(void);
 
-void chpl_comm_startDiagnostics(void);
+void chpl_comm_startDiagnostics(chpl_bool);
 void chpl_comm_stopDiagnostics(void);
-void chpl_comm_startDiagnosticsHere(void);
+void chpl_comm_startDiagnosticsHere(chpl_bool);
 void chpl_comm_stopDiagnosticsHere(void);
 void chpl_comm_resetDiagnosticsHere(void);
 void chpl_comm_getDiagnosticsHere(chpl_commDiagnostics *cd);
@@ -129,7 +131,7 @@ void chpl_comm_diags_verbose_printf(chpl_bool is_unstable,
   extern chpl_bool chpl_getCommDiagsPrintUnstable(void);
   if (chpl_verbose_comm
       && chpl_comm_diags_is_enabled()
-      && (!is_unstable || chpl_getCommDiagsPrintUnstable())) {
+      && (!is_unstable || chpl_comm_diags_print_unstable)) {
     char myFmt[100];
     snprintf(myFmt, sizeof(myFmt), "%d: %s\n", chpl_nodeID, format);
     va_list ap;

--- a/runtime/include/chpl-comm-internal.h
+++ b/runtime/include/chpl-comm-internal.h
@@ -37,6 +37,7 @@ extern size_t chpl_rt_priv_bcast_lens[];
 #define CHPL_RT_PRV_BCAST_TAB_ENTRIES(MACRO) \
   MACRO(chpl_verbose_comm)                   \
   MACRO(chpl_comm_diagnostics)               \
+  MACRO(chpl_comm_diags_print_unstable)      \
   MACRO(chpl_verbose_mem)
 
 #define _RT_PRV_BCAST_M(sym)  chpl_rt_prv_tab_ ## sym ## _idx,
@@ -54,8 +55,11 @@ void chpl_comm_init_prv_bcast_tab(void);
 //
 // Broadcast one of our runtime-specific variables.
 //
+#define chpl_comm_bcast_rt_private(var) \
+  chpl_comm_really_bcast_rt_private(chpl_rt_prv_tab_ ## var ## _idx)
+
 static inline
-void chpl_comm_bcast_rt_private(int id) {
+void chpl_comm_really_bcast_rt_private(int id) {
   chpl_comm_broadcast_private(chpl_private_broadcast_table_len + id,
                               chpl_rt_priv_bcast_lens[id],
                               -1);

--- a/runtime/include/chpl-comm-internal.h
+++ b/runtime/include/chpl-comm-internal.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2004-2019 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ * 
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * 
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _chpl_comm_internal_h_
+#define _chpl_comm_internal_h_
+
+#include <stdint.h>
+#include "chpltypes.h"
+#include "chpl-mem-desc.h"
+
+//
+// These are runtime-private copies of chpl_private_broadcast_table[]
+// and chpl_private_broadcast_table_len, extended with a few more
+// addresses of runtime-specific variables we also want to be able
+// broadcast around.
+//
+extern void** chpl_rt_priv_bcast_tab;
+extern int chpl_rt_priv_bcast_tab_len;
+extern size_t chpl_rt_priv_bcast_lens[];
+
+#define CHPL_RT_PRV_BCAST_TAB_ENTRIES(MACRO) \
+  MACRO(chpl_verbose_comm)                   \
+  MACRO(chpl_comm_diagnostics)               \
+  MACRO(chpl_verbose_mem)
+
+#define _RT_PRV_BCAST_M(sym)  chpl_rt_prv_tab_ ## sym ## _idx,
+typedef enum {
+  CHPL_RT_PRV_BCAST_TAB_ENTRIES(_RT_PRV_BCAST_M)
+  chpl_rt_prv_tab_num_idxs,
+} chpl_rt_prv_bcast_tab_idx_t;
+#undef _RT_PRV_BCAST_M
+
+//
+// This is in chpl-comm.c.
+//
+void chpl_comm_init_prv_bcast_tab(void);
+
+//
+// Broadcast one of our runtime-specific variables.
+//
+static inline
+void chpl_comm_bcast_rt_private(int id) {
+  chpl_comm_broadcast_private(chpl_private_broadcast_table_len + id,
+                              chpl_rt_priv_bcast_lens[id],
+                              -1);
+}
+
+#endif

--- a/runtime/include/chpl-comm.h
+++ b/runtime/include/chpl-comm.h
@@ -491,41 +491,6 @@ void chpl_comm_make_progress(void);
 // like say flushing task private buffers.
 void chpl_comm_task_end(void);
 
-//
-// Comm diagnostics stuff
-//
-
-#define CHPL_COMM_DIAGS_VARS_ALL(MACRO) \
-  MACRO(get) \
-  MACRO(get_nb) \
-  MACRO(put) \
-  MACRO(put_nb) \
-  MACRO(test_nb) \
-  MACRO(wait_nb) \
-  MACRO(try_nb) \
-  MACRO(amo) \
-  MACRO(execute_on) \
-  MACRO(execute_on_fast) \
-  MACRO(execute_on_nb)
-
-typedef struct _chpl_commDiagnostics {
-#define _COMM_DIAGS_DECL(cdv) uint64_t cdv;
-  CHPL_COMM_DIAGS_VARS_ALL(_COMM_DIAGS_DECL)
-#undef _COMM_DIAGS_DECL
-} chpl_commDiagnostics;
-
-void chpl_startVerboseComm(void);
-void chpl_stopVerboseComm(void);
-void chpl_startVerboseCommHere(void);
-void chpl_stopVerboseCommHere(void);
-
-void chpl_startCommDiagnostics(void); // this one implemented by comm layers
-void chpl_stopCommDiagnostics(void);
-void chpl_startCommDiagnosticsHere(void);
-void chpl_stopCommDiagnosticsHere(void);
-void chpl_resetCommDiagnosticsHere(void);
-void chpl_getCommDiagnosticsHere(chpl_commDiagnostics *cd);
-
 void* chpl_get_global_serialize_table(int64_t idx);
 
 #else // LAUNCHER

--- a/runtime/include/chpl-comm.h
+++ b/runtime/include/chpl-comm.h
@@ -507,6 +507,7 @@ void chpl_comm_task_end(void);
   MACRO(test_nb) \
   MACRO(wait_nb) \
   MACRO(try_nb) \
+  MACRO(amo) \
   MACRO(execute_on) \
   MACRO(execute_on_fast) \
   MACRO(execute_on_nb)

--- a/runtime/include/chpl-comm.h
+++ b/runtime/include/chpl-comm.h
@@ -524,13 +524,9 @@ void chpl_startVerboseCommHere(void);
 void chpl_stopVerboseCommHere(void);
 
 void chpl_startCommDiagnostics(void); // this one implemented by comm layers
-void chpl_gen_startCommDiagnostics(void); // this one implemented in chpl-comm.c
 void chpl_stopCommDiagnostics(void);
-void chpl_gen_stopCommDiagnostics(void);
 void chpl_startCommDiagnosticsHere(void);
-void chpl_gen_startCommDiagnosticsHere(void);
 void chpl_stopCommDiagnosticsHere(void);
-void chpl_gen_stopCommDiagnosticsHere(void);
 void chpl_resetCommDiagnosticsHere(void);
 void chpl_getCommDiagnosticsHere(chpl_commDiagnostics *cd);
 

--- a/runtime/include/chpl-comm.h
+++ b/runtime/include/chpl-comm.h
@@ -43,10 +43,6 @@ extern c_nodeid_t chpl_nodeID; // unique ID for each node: 0, 1, 2, ...
 // (hopefully) unique to the running image, and never changed again.
 extern int32_t chpl_numNodes; // number of nodes
 
-extern int chpl_verbose_comm;     // set via startVerboseComm
-extern int chpl_comm_diagnostics; // set via startCommDiagnostics
-extern int chpl_verbose_mem;      // set via startVerboseMem
-
 size_t chpl_comm_getenvMaxHeapSize(void);
 
 

--- a/runtime/include/chplmemtrack.h
+++ b/runtime/include/chplmemtrack.h
@@ -36,6 +36,8 @@ extern "C" {
 // Memory tracking activated?
 extern chpl_bool chpl_memTrack;
 
+extern int chpl_verbose_mem;      // set via startVerboseMem
+
 ///// These entry points support the memory tracking functions provided by
 //    MemTracking.chpl, and may also be called directly from user code (or from
 //    a debugger).

--- a/runtime/include/stdchpl.h
+++ b/runtime/include/stdchpl.h
@@ -42,6 +42,7 @@
 #include "chpl-atomics.h"
 #include "chpl-bitops.h"
 #include "chpl-comm.h"
+#include "chpl-comm-diags.h"
 #include "chpldirent.h"
 #include "chplexit.h"
 #include "chpl-external-array.h"

--- a/runtime/src/chpl-comm-diags.c
+++ b/runtime/src/chpl-comm-diags.c
@@ -26,6 +26,7 @@
 
 #include "chpl-comm.h"
 #include "chpl-comm-diags.h"
+#include "chpl-mem-consistency.h"
 
 #include <stdint.h>
 #include <stdio.h>
@@ -61,6 +62,9 @@ void chpl_stopVerboseCommHere() {
 
 
 void chpl_startCommDiagnostics() {
+  // Make sure that there are no pending communication operations.
+  chpl_rmem_consist_release(0, 0);
+
   chpl_comm_diagnostics = 1;
   chpl_comm_diags_disable();
   chpl_comm_broadcast_private(1 /* &chpl_comm_diagnostics */, sizeof(int),
@@ -70,6 +74,9 @@ void chpl_startCommDiagnostics() {
 
 
 void chpl_stopCommDiagnostics() {
+  // Make sure that there are no pending communication operations.
+  chpl_rmem_consist_release(0, 0);
+
   chpl_comm_diagnostics = 0;
   chpl_comm_diags_disable();
   chpl_comm_broadcast_private(1 /* &chpl_comm_diagnostics */, sizeof(int),
@@ -79,11 +86,17 @@ void chpl_stopCommDiagnostics() {
 
 
 void chpl_startCommDiagnosticsHere() {
+  // Make sure that there are no pending communication operations.
+  chpl_rmem_consist_release(0, 0);
+
   chpl_comm_diagnostics = 1;
 }
 
 
 void chpl_stopCommDiagnosticsHere() {
+  // Make sure that there are no pending communication operations.
+  chpl_rmem_consist_release(0, 0);
+
   chpl_comm_diagnostics = 0;
 }
 

--- a/runtime/src/chpl-comm-diags.c
+++ b/runtime/src/chpl-comm-diags.c
@@ -37,7 +37,7 @@ int chpl_verbose_comm;
 int chpl_comm_diagnostics;
 
 
-void chpl_startVerboseComm() {
+void chpl_comm_startVerbose() {
   chpl_verbose_comm = 1;
   chpl_comm_diags_disable();
   chpl_comm_broadcast_private(0 /* &chpl_verbose_comm */, sizeof(int),
@@ -46,7 +46,7 @@ void chpl_startVerboseComm() {
 }
 
 
-void chpl_stopVerboseComm() {
+void chpl_comm_stopVerbose() {
   chpl_verbose_comm = 0;
   chpl_comm_diags_disable();
   chpl_comm_broadcast_private(0 /* &chpl_verbose_comm */, sizeof(int),
@@ -55,17 +55,17 @@ void chpl_stopVerboseComm() {
 }
 
 
-void chpl_startVerboseCommHere() {
+void chpl_comm_startVerboseHere() {
   chpl_verbose_comm = 1;
 }
 
 
-void chpl_stopVerboseCommHere() {
+void chpl_comm_stopVerboseHere() {
   chpl_verbose_comm = 0;
 }
 
 
-void chpl_startCommDiagnostics() {
+void chpl_comm_startDiagnostics() {
   // Make sure that there are no pending communication operations.
   chpl_rmem_consist_release(0, 0);
 
@@ -77,7 +77,7 @@ void chpl_startCommDiagnostics() {
 }
 
 
-void chpl_stopCommDiagnostics() {
+void chpl_comm_stopDiagnostics() {
   // Make sure that there are no pending communication operations.
   chpl_rmem_consist_release(0, 0);
 
@@ -89,7 +89,7 @@ void chpl_stopCommDiagnostics() {
 }
 
 
-void chpl_startCommDiagnosticsHere() {
+void chpl_comm_startDiagnosticsHere() {
   // Make sure that there are no pending communication operations.
   chpl_rmem_consist_release(0, 0);
 
@@ -97,7 +97,7 @@ void chpl_startCommDiagnosticsHere() {
 }
 
 
-void chpl_stopCommDiagnosticsHere() {
+void chpl_comm_stopDiagnosticsHere() {
   // Make sure that there are no pending communication operations.
   chpl_rmem_consist_release(0, 0);
 
@@ -105,11 +105,11 @@ void chpl_stopCommDiagnosticsHere() {
 }
 
 
-void chpl_resetCommDiagnosticsHere() {
+void chpl_comm_resetDiagnosticsHere() {
   chpl_comm_diags_reset();
 }
 
 
-void chpl_getCommDiagnosticsHere(chpl_commDiagnostics *cd) {
+void chpl_comm_getDiagnosticsHere(chpl_commDiagnostics *cd) {
   chpl_comm_diags_copy(cd);
 }

--- a/runtime/src/chpl-comm-diags.c
+++ b/runtime/src/chpl-comm-diags.c
@@ -26,6 +26,7 @@
 
 #include "chpl-comm.h"
 #include "chpl-comm-diags.h"
+#include "chpl-comm-internal.h"
 #include "chpl-mem-consistency.h"
 
 #include <stdint.h>
@@ -40,8 +41,7 @@ int chpl_comm_diagnostics;
 void chpl_comm_startVerbose() {
   chpl_verbose_comm = 1;
   chpl_comm_diags_disable();
-  chpl_comm_broadcast_private(0 /* &chpl_verbose_comm */, sizeof(int),
-                              -1 /*typeIndex: unused*/);
+  chpl_comm_bcast_rt_private(chpl_rt_prv_tab_chpl_verbose_comm_idx);
   chpl_comm_diags_enable();
 }
 
@@ -49,8 +49,7 @@ void chpl_comm_startVerbose() {
 void chpl_comm_stopVerbose() {
   chpl_verbose_comm = 0;
   chpl_comm_diags_disable();
-  chpl_comm_broadcast_private(0 /* &chpl_verbose_comm */, sizeof(int),
-                              -1 /*typeIndex: unused*/);
+  chpl_comm_bcast_rt_private(chpl_rt_prv_tab_chpl_verbose_comm_idx);
   chpl_comm_diags_enable();
 }
 
@@ -71,8 +70,7 @@ void chpl_comm_startDiagnostics() {
 
   chpl_comm_diagnostics = 1;
   chpl_comm_diags_disable();
-  chpl_comm_broadcast_private(1 /* &chpl_comm_diagnostics */, sizeof(int),
-                              -1 /*typeIndex: unused*/);
+  chpl_comm_bcast_rt_private(chpl_rt_prv_tab_chpl_comm_diagnostics_idx);
   chpl_comm_diags_enable();
 }
 
@@ -83,8 +81,7 @@ void chpl_comm_stopDiagnostics() {
 
   chpl_comm_diagnostics = 0;
   chpl_comm_diags_disable();
-  chpl_comm_broadcast_private(1 /* &chpl_comm_diagnostics */, sizeof(int),
-                              -1 /*typeIndex: unused*/);
+  chpl_comm_bcast_rt_private(chpl_rt_prv_tab_chpl_comm_diagnostics_idx);
   chpl_comm_diags_enable();
 }
 

--- a/runtime/src/chpl-comm-diags.c
+++ b/runtime/src/chpl-comm-diags.c
@@ -33,6 +33,10 @@
 #include <stdlib.h>
 
 
+int chpl_verbose_comm;
+int chpl_comm_diagnostics;
+
+
 void chpl_startVerboseComm() {
   chpl_verbose_comm = 1;
   chpl_comm_diags_disable();

--- a/runtime/src/chpl-comm.c
+++ b/runtime/src/chpl-comm.c
@@ -34,9 +34,6 @@
 int32_t chpl_nodeID = -1;
 int32_t chpl_numNodes = -1;
 
-int chpl_verbose_comm;
-int chpl_comm_diagnostics;
-int chpl_verbose_mem;
 
 static pthread_once_t maxHeapSize_once = PTHREAD_ONCE_INIT;
 static size_t maxHeapSize;

--- a/runtime/src/chpl-comm.c
+++ b/runtime/src/chpl-comm.c
@@ -25,7 +25,6 @@
 #include "chpl-comm.h"
 #include "chpl-env.h"
 #include "chpl-mem.h"
-#include "chpl-mem-consistency.h"
 
 #include <pthread.h>
 #include <stdint.h>
@@ -38,46 +37,6 @@ int32_t chpl_numNodes = -1;
 int chpl_verbose_comm;
 int chpl_comm_diagnostics;
 int chpl_verbose_mem;
-
-void chpl_startCommDiagnostics(void); // this one implemented by comm layers
-void chpl_gen_startCommDiagnostics(void); // this one implemented in chpl-comm.c
-void chpl_stopCommDiagnostics(void);
-void chpl_gen_stopCommDiagnostics(void);
-void chpl_startCommDiagnosticsHere(void);
-void chpl_gen_startCommDiagnosticsHere(void);
-void chpl_stopCommDiagnosticsHere(void);
-void chpl_gen_stopCommDiagnosticsHere(void);
-void chpl_resetCommDiagnosticsHere(void);
-void chpl_getCommDiagnosticsHere(chpl_commDiagnostics *cd);
-
-void chpl_gen_startCommDiagnostics(void) {
-  // Make sure that there are no pending communication operations.
-  chpl_rmem_consist_release(0, 0);
-  // And then start the comm diagnostics as usual.
-  chpl_startCommDiagnostics();
-}
-
-void chpl_gen_stopCommDiagnostics(void) {
-  // Make sure that there are no pending communication operations.
-  chpl_rmem_consist_release(0, 0);
-  // And then stop the comm diagnostics as usual.
-  chpl_stopCommDiagnostics();
-}
-
-void chpl_gen_startCommDiagnosticsHere(void) {
-  // Make sure that there are no pending communication operations.
-  chpl_rmem_consist_release(0, 0);
-  // And then start the comm diagnostics as usual.
-  chpl_startCommDiagnosticsHere();
-}
-
-void chpl_gen_stopCommDiagnosticsHere(void) {
-  // Make sure that there are no pending communication operations.
-  chpl_rmem_consist_release(0, 0);
-  // And then stop the comm diagnostics as usual.
-  chpl_stopCommDiagnosticsHere();
-}
-
 
 static pthread_once_t maxHeapSize_once = PTHREAD_ONCE_INIT;
 static size_t maxHeapSize;

--- a/runtime/src/chpl-comm.c
+++ b/runtime/src/chpl-comm.c
@@ -23,6 +23,8 @@
 //
 #include "chplrt.h"
 #include "chpl-comm.h"
+#include "chpl-comm-diags.h"
+#include "chpl-comm-internal.h"
 #include "chpl-env.h"
 #include "chpl-mem.h"
 
@@ -33,6 +35,41 @@
 
 int32_t chpl_nodeID = -1;
 int32_t chpl_numNodes = -1;
+
+
+void** chpl_rt_priv_bcast_tab;
+int chpl_rt_priv_bcast_tab_len;
+
+#define _RT_PRV_BCAST_M(sym) sizeof(sym),
+size_t chpl_rt_priv_bcast_lens[chpl_rt_prv_tab_num_idxs] =
+         { CHPL_RT_PRV_BCAST_TAB_ENTRIES(_RT_PRV_BCAST_M) };
+#undef _RT_PRV_BCAST_M
+
+void chpl_comm_init_prv_bcast_tab(void) {
+  //
+  // Make a copy of chpl_private_broadcast_table[], but with some more of
+  // our own entries following the compiler-emitted ones.
+  //
+  chpl_rt_priv_bcast_tab_len = chpl_private_broadcast_table_len
+                               + chpl_rt_prv_tab_num_idxs;
+  chpl_rt_priv_bcast_tab =
+    chpl_mem_allocMany(chpl_rt_priv_bcast_tab_len,
+                       sizeof(chpl_rt_priv_bcast_tab[0]),
+                       CHPL_RT_MD_COMM_UTIL, 0, 0);
+
+  // Duplicate the compiler-emitted entries.
+  memcpy(chpl_rt_priv_bcast_tab,
+         chpl_private_broadcast_table,
+         chpl_private_broadcast_table_len
+         * sizeof(chpl_private_broadcast_table[0]));
+
+  // Fill in our entries that follow those.
+#define _RT_PRV_BCAST_M(sym)                                            \
+  chpl_rt_priv_bcast_tab[chpl_private_broadcast_table_len               \
+                         + chpl_rt_prv_tab_ ## sym ## _idx] = &sym;
+  CHPL_RT_PRV_BCAST_TAB_ENTRIES(_RT_PRV_BCAST_M)
+#undef _RT_PRV_BCAST_M
+}
 
 
 static pthread_once_t maxHeapSize_once = PTHREAD_ONCE_INIT;

--- a/runtime/src/chplmemtrack.c
+++ b/runtime/src/chplmemtrack.c
@@ -733,12 +733,12 @@ void chpl_track_realloc_post(void* moreMemAlloc,
 
 void chpl_startVerboseMem() {
   chpl_verbose_mem = 1;
-  chpl_comm_bcast_rt_private(chpl_rt_prv_tab_chpl_verbose_mem_idx);
+  chpl_comm_bcast_rt_private(chpl_verbose_mem);
 }
 
 void chpl_stopVerboseMem() {
   chpl_verbose_mem = 0;
-  chpl_comm_bcast_rt_private(chpl_rt_prv_tab_chpl_verbose_mem_idx);
+  chpl_comm_bcast_rt_private(chpl_verbose_mem);
 }
 
 void chpl_startVerboseMemHere() {

--- a/runtime/src/chplmemtrack.c
+++ b/runtime/src/chplmemtrack.c
@@ -26,6 +26,7 @@
 #include "chpl-tasks.h"
 #include "chpltypes.h"
 #include "chpl-comm.h"
+#include "chpl-comm-internal.h"
 #include "chplcgfns.h"
 #include "chpl-linefile-support.h"
 #include "config.h"
@@ -732,14 +733,12 @@ void chpl_track_realloc_post(void* moreMemAlloc,
 
 void chpl_startVerboseMem() {
   chpl_verbose_mem = 1;
-  chpl_comm_broadcast_private(2 /* &chpl_verbose_mem */, sizeof(int),
-                              -1 /* typeIndex: broke for hetero */);
+  chpl_comm_bcast_rt_private(chpl_rt_prv_tab_chpl_verbose_mem_idx);
 }
 
 void chpl_stopVerboseMem() {
   chpl_verbose_mem = 0;
-  chpl_comm_broadcast_private(2 /* &chpl_verbose_mem */, sizeof(int),
-                              -1 /* typeIndex: broke for hetero */);
+  chpl_comm_bcast_rt_private(chpl_rt_prv_tab_chpl_verbose_mem_idx);
 }
 
 void chpl_startVerboseMemHere() {

--- a/runtime/src/chplmemtrack.c
+++ b/runtime/src/chplmemtrack.c
@@ -43,6 +43,9 @@
 #include <inttypes.h>
 
 
+int chpl_verbose_mem;
+
+
 static void
 printMemAllocs(chpl_mem_descInt_t description, int64_t threshold,
                int32_t lineno, int32_t filename);

--- a/runtime/src/comm/gasnet/comm-gasnet.c
+++ b/runtime/src/comm/gasnet/comm-gasnet.c
@@ -27,6 +27,7 @@
 #include "chpl-comm-diags.h"
 #include "chpl-comm-callbacks.h"
 #include "chpl-comm-callbacks-internal.h"
+#include "chpl-comm-internal.h"
 #include "chpl-env.h"
 #include "chpl-mem.h"
 #include "chplsys.h"
@@ -504,7 +505,7 @@ static void AM_signal_long(gasnet_token_t token, void *buf, size_t nbytes,
 
 static void AM_priv_bcast(gasnet_token_t token, void* buf, size_t nbytes) {
   priv_bcast_t* pbp = buf;
-  chpl_memcpy(chpl_private_broadcast_table[pbp->id], pbp->data, pbp->size);
+  chpl_memcpy(chpl_rt_priv_bcast_tab[pbp->id], pbp->data, pbp->size);
 
   // Signal that the handler has completed
   GASNET_Safe(gasnet_AMReplyShort2(token, SIGNAL,
@@ -513,7 +514,7 @@ static void AM_priv_bcast(gasnet_token_t token, void* buf, size_t nbytes) {
 
 static void AM_priv_bcast_large(gasnet_token_t token, void* buf, size_t nbytes) {
   priv_bcast_large_t* pblp = buf;
-  chpl_memcpy((char*)chpl_private_broadcast_table[pblp->id]+pblp->offset, pblp->data, pblp->size);
+  chpl_memcpy((char*)chpl_rt_priv_bcast_tab[pblp->id]+pblp->offset, pblp->data, pblp->size);
 
   // Signal that the handler has completed
   GASNET_Safe(gasnet_AMReplyShort2(token, SIGNAL,
@@ -860,7 +861,9 @@ void chpl_comm_init(int *argc_p, char ***argv_p) {
 
 }
 
-void chpl_comm_post_mem_init(void) { }
+void chpl_comm_post_mem_init(void) {
+  chpl_comm_init_prv_bcast_tab();
+}
 
 int chpl_comm_numPollingTasks(void) {
   return 1;
@@ -932,7 +935,7 @@ void chpl_comm_broadcast_private(int id, size_t size, int32_t tid) {
                                           0, 0);
   if (payloadSize <= gasnet_AMMaxMedium()) {
     priv_bcast_t* pbp = chpl_mem_allocMany(1, payloadSize, CHPL_RT_MD_COMM_PRV_BCAST_DATA, 0, 0);
-    chpl_memcpy(pbp->data, chpl_private_broadcast_table[id], size);
+    chpl_memcpy(pbp->data, chpl_rt_priv_bcast_tab[id], size);
     pbp->id = id;
     pbp->size = size;
     for (node = 0; node < chpl_numNodes; node++) {
@@ -959,7 +962,7 @@ void chpl_comm_broadcast_private(int id, size_t size, int32_t tid) {
         thissize = maxsize;
       pblp->offset = offset;
       pblp->size = thissize;
-      chpl_memcpy(pblp->data, (char*)chpl_private_broadcast_table[id]+offset, thissize);
+      chpl_memcpy(pblp->data, (char*)chpl_rt_priv_bcast_tab[id]+offset, thissize);
       for (node = 0; node < chpl_numNodes; node++) {
         if (node != chpl_nodeID) {
           pblp->ack = &done[node];

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -2720,6 +2720,8 @@ static inline void doAMO(c_nodeid_t, void*, const void*, const void*, void*,
                "chpl_comm_atomic_write_%s(%p, %d, %p, %d, %s)",         \
                #fnType, desired, (int) node, object,                    \
                ln, chpl_lookupFilename(fn));                            \
+    chpl_comm_diags_verbose_amo("amo write", node, ln, fn);             \
+    chpl_comm_diags_incr(amo);                                          \
     doAMO(node, object, desired, NULL, NULL,                            \
           FI_ATOMIC_WRITE, ofiType, sizeof(Type));                      \
   }
@@ -2743,6 +2745,8 @@ DEFN_CHPL_COMM_ATOMIC_WRITE(real64, FI_DOUBLE, double)
                "chpl_comm_atomic_read_%s(%p, %d, %p, %d, %s)",          \
                #fnType, result, (int) node, object,                     \
                ln, chpl_lookupFilename(fn));                            \
+    chpl_comm_diags_verbose_amo("amo read", node, ln, fn);              \
+    chpl_comm_diags_incr(amo);                                          \
     doAMO(node, object, NULL, NULL, result,                             \
           FI_ATOMIC_READ, ofiType, sizeof(Type));                       \
   }
@@ -2763,6 +2767,8 @@ DEFN_CHPL_COMM_ATOMIC_READ(real64, FI_DOUBLE, double)
                "chpl_comm_atomic_xchg_%s(%p, %d, %p, %p, %d, %s)",      \
                #fnType, desired, (int) node, object, result,            \
                ln, chpl_lookupFilename(fn));                            \
+    chpl_comm_diags_verbose_amo("amo xchg", node, ln, fn);              \
+    chpl_comm_diags_incr(amo);                                          \
     doAMO(node, object, desired, NULL, result,                          \
           FI_ATOMIC_WRITE, ofiType, sizeof(Type));                      \
   }
@@ -2785,6 +2791,8 @@ DEFN_CHPL_COMM_ATOMIC_XCHG(real64, FI_DOUBLE, double)
                "%d, %s)",                                               \
                #fnType, expected, desired, (int) node, object, result,  \
                ln, chpl_lookupFilename(fn));                            \
+    chpl_comm_diags_verbose_amo("amo cmpxchg", node, ln, fn);           \
+    chpl_comm_diags_incr(amo);                                          \
     doAMO(node, object, expected, desired, result,                      \
           FI_CSWAP, ofiType, sizeof(Type));                             \
   }
@@ -2805,6 +2813,8 @@ DEFN_CHPL_COMM_ATOMIC_CMPXCHG(real64, FI_DOUBLE, double)
                "chpl_comm_atomic_%s_%s(<%s>, %d, %p, %d, %s)",          \
                #fnOp, #fnType, DBG_VAL(operand, ofiType), (int) node,   \
                object, ln, chpl_lookupFilename(fn));                    \
+    chpl_comm_diags_verbose_amo("amo " #fnOp, node, ln, fn);            \
+    chpl_comm_diags_incr(amo);                                          \
     doAMO(node, object, operand, NULL, NULL,                            \
           ofiOp, ofiType, sizeof(Type));                                \
   }                                                                     \
@@ -2828,6 +2838,8 @@ DEFN_CHPL_COMM_ATOMIC_CMPXCHG(real64, FI_DOUBLE, double)
                "%d, %s)",                                               \
                #fnOp, #fnType, DBG_VAL(operand, ofiType), (int) node,   \
                object, result, ln, chpl_lookupFilename(fn));            \
+    chpl_comm_diags_verbose_amo("amo fetch_" #fnOp, node, ln, fn);      \
+    chpl_comm_diags_incr(amo);                                          \
     doAMO(node, object, operand, NULL, result,                          \
           ofiOp, ofiType, sizeof(Type));                                \
   }
@@ -2864,6 +2876,8 @@ DEFN_IFACE_AMO_SIMPLE_OP(add, FI_SUM, real64, FI_DOUBLE, double)
                #fnType, DBG_VAL(operand, ofiType), (int) node, object,  \
                ln, chpl_lookupFilename(fn));                            \
     Type myOpnd = negate(*(Type*) operand);                             \
+    chpl_comm_diags_verbose_amo("amo sub", node, ln, fn);               \
+    chpl_comm_diags_incr(amo);                                          \
     doAMO(node, object, &myOpnd, NULL, NULL,                            \
           FI_SUM, ofiType, sizeof(Type));                               \
   }                                                                     \
@@ -2889,6 +2903,8 @@ DEFN_IFACE_AMO_SIMPLE_OP(add, FI_SUM, real64, FI_DOUBLE, double)
                #fnType, DBG_VAL(operand, ofiType), (int) node, object,  \
                result, ln, chpl_lookupFilename(fn));                    \
     Type myOpnd = negate(*(Type*) operand);                             \
+    chpl_comm_diags_verbose_amo("amo fetch_sub", node, ln, fn);         \
+    chpl_comm_diags_incr(amo);                                          \
     doAMO(node, object, &myOpnd, NULL, result,                          \
           FI_SUM, ofiType, sizeof(Type));                               \
   }

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -56,6 +56,7 @@
 #include "chpl-comm-diags.h"
 #include "chpl-comm-callbacks.h"
 #include "chpl-comm-callbacks-internal.h"
+#include "chpl-comm-internal.h"
 #include "chpl-comm-strd-xfer.h"
 #include "chpl-env.h"
 #include "chplexit.h"
@@ -1952,9 +1953,7 @@ void chpl_comm_init(int *argc_p, char ***argv_p)
 
 void chpl_comm_post_mem_init(void)
 {
-  //
-  // Empty.
-  //
+  chpl_comm_init_prv_bcast_tab();
 }
 
 
@@ -3832,8 +3831,8 @@ void chpl_comm_broadcast_private(int id, size_t size, int32_t tid)
   //
   for (i = 0; i < chpl_numNodes; i++) {
     if (i != chpl_nodeID) {
-      do_remote_put(chpl_private_broadcast_table[id], i,
-                    chpl_private_broadcast_table[id], size,
+      do_remote_put(chpl_rt_priv_bcast_tab[id], i,
+                    chpl_rt_priv_bcast_tab[id], size,
                     NULL, may_proxy_true);
     }
   }

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -6635,6 +6635,8 @@ int chpl_comm_addr_gettable(c_nodeid_t node, void* start, size_t len)
             return;                                                     \
           }                                                             \
                                                                         \
+          chpl_comm_diags_verbose_amo("amo write", loc, ln, fn);        \
+          chpl_comm_diags_incr(amo);                                    \
           if (IS_32_BIT_AMO_ON_GEMINI(_t)                               \
               || (remote_mr = mreg_for_remote_addr(obj, loc)) == NULL) {\
             if (loc == chpl_nodeID)                                     \
@@ -6699,6 +6701,8 @@ DEFINE_CHPL_COMM_ATOMIC_WRITE(real64, put_64, int_least64_t)
             return;                                                     \
           }                                                             \
                                                                         \
+          chpl_comm_diags_verbose_amo("amo read", loc, ln, fn);         \
+          chpl_comm_diags_incr(amo);                                    \
           if (IS_32_BIT_AMO_ON_GEMINI(_t)                               \
               || (remote_mr = mreg_for_remote_addr(obj, loc)) == NULL) {\
             if (loc == chpl_nodeID)                                     \
@@ -6753,6 +6757,8 @@ DEFINE_CHPL_COMM_ATOMIC_READ(real64, get_64, int_least64_t)
             return;                                                     \
           }                                                             \
                                                                         \
+          chpl_comm_diags_verbose_amo("amo xchg", loc, ln, fn);         \
+          chpl_comm_diags_incr(amo);                                    \
           if (IS_32_BIT_AMO_ON_GEMINI(_t)                               \
               || (remote_mr = mreg_for_remote_addr(obj, loc)) == NULL) {\
             if (loc == chpl_nodeID)                                     \
@@ -6817,6 +6823,8 @@ DEFINE_CHPL_COMM_ATOMIC_XCHG(real64, xchg_64, int_least64_t)
             return;                                                     \
           }                                                             \
                                                                         \
+          chpl_comm_diags_verbose_amo("amo cmpxchg", loc, ln, fn);      \
+          chpl_comm_diags_incr(amo);                                    \
           if (IS_32_BIT_AMO_ON_GEMINI(_t)                               \
               || (remote_mr = mreg_for_remote_addr(obj, loc)) == NULL) {\
             if (loc == chpl_nodeID)                                     \
@@ -6871,6 +6879,8 @@ DEFINE_CHPL_COMM_ATOMIC_CMPXCHG(real64, cmpxchg_64, int_least64_t)
             return;                                                     \
           }                                                             \
                                                                         \
+          chpl_comm_diags_verbose_amo("amo " #_o, loc, ln, fn);         \
+          chpl_comm_diags_incr(amo);                                    \
           if (IS_32_BIT_AMO_ON_GEMINI(_t)                               \
               || (remote_mr = mreg_for_remote_addr(obj, loc)) == NULL) {\
             if (loc == chpl_nodeID)                                     \
@@ -6902,6 +6912,8 @@ DEFINE_CHPL_COMM_ATOMIC_CMPXCHG(real64, cmpxchg_64, int_least64_t)
             return;                                                     \
           }                                                             \
                                                                         \
+          chpl_comm_diags_verbose_amo("amo unord_" #_o, loc, ln, fn);   \
+          chpl_comm_diags_incr(amo);                                    \
           if (IS_32_BIT_AMO_ON_GEMINI(_t)                               \
               || (remote_mr = mreg_for_remote_addr(obj, loc)) == NULL) {\
             if (loc == chpl_nodeID)                                     \
@@ -6936,6 +6948,8 @@ DEFINE_CHPL_COMM_ATOMIC_CMPXCHG(real64, cmpxchg_64, int_least64_t)
             return;                                                     \
           }                                                             \
                                                                         \
+          chpl_comm_diags_verbose_amo("amo fetch_" #_o, loc, ln, fn);   \
+          chpl_comm_diags_incr(amo);                                    \
           if (IS_32_BIT_AMO_ON_GEMINI(_t)                               \
               || (remote_mr = mreg_for_remote_addr(obj, loc)) == NULL) {\
             if (loc == chpl_nodeID)                                     \
@@ -7004,6 +7018,8 @@ DEFINE_CHPL_COMM_ATOMIC_INT_OP(uint64, add, add_i64, uint_least64_t)
             return;                                                     \
           }                                                             \
                                                                         \
+          chpl_comm_diags_verbose_amo("amo add", loc, ln, fn);          \
+          chpl_comm_diags_incr(amo);                                    \
           if (sizeof(_t) == sizeof(int_least32_t)                       \
               && nic_type == GNI_DEVICE_ARIES                           \
               && (remote_mr = mreg_for_remote_addr(obj, loc)) != NULL) {\
@@ -7035,6 +7051,8 @@ DEFINE_CHPL_COMM_ATOMIC_INT_OP(uint64, add, add_i64, uint_least64_t)
             return;                                                     \
           }                                                             \
                                                                         \
+          chpl_comm_diags_verbose_amo("amo unord_add", loc, ln, fn);    \
+          chpl_comm_diags_incr(amo);                                    \
           if (sizeof(_t) == sizeof(int_least32_t)                       \
               && nic_type == GNI_DEVICE_ARIES                           \
               && (remote_mr = mreg_for_remote_addr(obj, loc)) != NULL) {\
@@ -7068,6 +7086,8 @@ DEFINE_CHPL_COMM_ATOMIC_INT_OP(uint64, add, add_i64, uint_least64_t)
             return;                                                     \
           }                                                             \
                                                                         \
+          chpl_comm_diags_verbose_amo("amo fetch_add", loc, ln, fn);    \
+          chpl_comm_diags_incr(amo);                                    \
           if (sizeof(_t) == sizeof(int_least32_t)                       \
               && nic_type == GNI_DEVICE_ARIES                           \
               && (remote_mr = mreg_for_remote_addr(obj, loc)) != NULL) {\


### PR DESCRIPTION
We've long wanted to include atomic operations in comm diagnostics.  Do
that here.  But param-disable printing atomic op counts by default,
because those counts are unstable due to our use of network atomics when
spin-waiting for parallel construct and on-stmt completion.

This is related to #10124, but doesn't resolve that because it doesn't enable
counting AMOs by default.