### PR TITLE
Plug a memory leak in VectorList / test-pariter

### DIFF
--- a/test/library/packages/VectorList/VectorLists.chpl
+++ b/test/library/packages/VectorList/VectorLists.chpl
@@ -199,7 +199,7 @@ module VectorLists {
     const high = followRange.alignedHigh;
 
     for (s,LE) in links() {
-      if s > high then break; //done
+      if s > high then continue; //switch to 'break' when #7897 is resolved
       if s + LE.size <= low then continue;
       for idx in followRange[s..#LE.size] - s do
         yield LE.elemAt(idx);


### PR DESCRIPTION
#12791 exposed a known scenario for leaking iterator classes, namely a `break` from an iterator-driven loop #7897.

This PR plugs the leak by replacing the `break` with a `continue` that skips each of the remaining iterations. Once #7897 is resolved, this PR should be reverted.

#### Details

The iterator whose IC leaks is the follower iterator here:
```
test/library/packages/VectorList/VectorLists.chpl
```
The test that is affected as a result is:
```
test/library/packages/VectorList/test-pariter.chpl
```
While the IC itself is only 48 bytes, the follower iterator is executed lots of times so the leaks stack up. Note that the total leaking amount depends on dataParTasksPerLocale, as that determines how many times the follower is executed.

Trivial, not reviewed.

