### PR TITLE
Fix typos

### DIFF
--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -741,7 +741,7 @@ static void resolveUnresolvedSymExprs() {
   // might do that within resolveModuleCall, so we try resolving unresolved
   // symbols a second time as the extern C block support might have added some.
   //
-  // TODO: have the externCresolve call resolveUnresolved directly
+  // TODO: have the externCResolve call resolveUnresolved directly
   forv_Vec(UnresolvedSymExpr, unresolvedSymExpr, gUnresolvedSymExprs) {
     // Only try resolving symbols that are new after last attempt.
     if (i >= maxResolved) {

--- a/doc/rst/developer/bestPractices/GeneratedCode.rst
+++ b/doc/rst/developer/bestPractices/GeneratedCode.rst
@@ -62,7 +62,7 @@ How to benchmark/time it?
 
   writeln("time taken: " + mytimer.elapsed() + " seconds");
 
-.. _Time MOdule: https://chapel-lang.org/docs/modules/standard/Time.html
+.. _Time Module: https://chapel-lang.org/docs/modules/standard/Time.html
 
 * build your runtime optimized:
 

--- a/modules/internal/CPtr.chpl
+++ b/modules/internal/CPtr.chpl
@@ -637,7 +637,7 @@ module CPtr {
 
     :arg s: the destination memory area to fill
     :arg c: the byte value to use
-    :arg n: the number of bytes of b to fill
+    :arg n: the number of bytes of s to fill
 
     :returns: s
    */

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -1478,8 +1478,8 @@ record DefaultComparator {
 
    :returns: ``(0, u)`` if ``i==0``, or ``(-1, u)`` otherwise,
              where `u` is a `uint` storing the bits of the `real`
-             but with some tranformations applied to produce the
-             correct sort  order.
+             but with some transformations applied to produce the
+             correct sort order.
    */
   inline
   proc keyPart(x: chpl_anyreal, i:int):(int(8), uint(numBits(x.type))) {


### PR DESCRIPTION
Fix typos in CPtr.chpl, scopeResolve.cpp, GeneratedCode.rst, and Sort.chpl