### PR TITLE
Improve FileSystem.listdir() error message

### DIFF
--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -1205,8 +1205,19 @@ iter listdir(path: string = ".", hidden: bool = false, dirs: bool = true,
     }
     closedir(dir);
   } else {
+    /* perror() is asks the C stdlib to print out a message specific to
+       the current value of errno */
     extern proc perror(s: c_string);
-    perror("error in listdir(): ");
+
+    // stderr.writef() would be cleaner, but it throws
+    var errorMsg: string;
+    try {
+      errorMsg = "error in listdir() with argument '%s'".format(path);
+    } catch e {
+      // Generic error message in case format fails
+      perror("Error in listdir(): ");
+    }
+    perror(errorMsg.c_str());
   }
 }
 

--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -1205,11 +1205,11 @@ iter listdir(path: string = ".", hidden: bool = false, dirs: bool = true,
     }
     closedir(dir);
   } else {
-    /* perror() is asks the C stdlib to print out a message specific to
-       the current value of errno */
+    /* perror() is used here because it asks the C stdlib to print out a
+       message specific to the current value of errno */
     extern proc perror(s: c_string);
 
-    // stderr.writef() would be cleaner, but it throws
+    // stderr.writef would be cleaner than this try/catch block, but it throws
     var errorMsg: string;
     try {
       errorMsg = "error in listdir() with argument '%s'".format(path);

--- a/test/library/standard/FileSystem/listdir/error.chpl
+++ b/test/library/standard/FileSystem/listdir/error.chpl
@@ -1,0 +1,5 @@
+use FileSystem;
+
+for f in listdir('./DOES-NOT-EXIST') {
+  writeln(f);
+}

--- a/test/library/standard/FileSystem/listdir/error.good
+++ b/test/library/standard/FileSystem/listdir/error.good
@@ -1,0 +1,1 @@
+error in listdir() with argument './DOES-NOT-EXIST': No such file or directory


### PR DESCRIPTION
Add argument name to `listdir()` error message.

Before this PR:

```
error in listdir(): No such file or directory
```

After this PR:

```
error in listdir() with argument './DOES-NOT-EXIST': No such file or directory
```