### PR TITLE
Skip lcals under valgrind

### DIFF
--- a/test/release/examples/benchmarks/lcals/LCALSMain.skipif
+++ b/test/release/examples/benchmarks/lcals/LCALSMain.skipif
@@ -1,0 +1,2 @@
+# Takes to long under valgrind
+CHPL_TEST_VGRND_EXE == on


### PR DESCRIPTION
Skipif for valgrind was removed in #12811, but lcals is still too slow
under valgrind even with those changes, so go back to skipping.