### PR TITLE
Allow HDF5 to work without LLVM

### DIFF
--- a/modules/packages/HDF5.chpl
+++ b/modules/packages/HDF5.chpl
@@ -3375,7 +3375,7 @@ module HDF5 {
     /* This module defines some wrappers for HDF5 functions that issue #9324
        makes difficult/impossible to use otherwise. The workaround wrappers are
        named the same thing as the original HDF5 name, but with a `_WAR` suffix.
-       Since this uses an `extern` block, LLVM is required. */
+     */
     pragma "no doc"
     module HDF5_WAR {
       require "HDF5Helper/hdf5_helper.h";

--- a/modules/packages/HDF5.chpl
+++ b/modules/packages/HDF5.chpl
@@ -3378,50 +3378,20 @@ module HDF5 {
        Since this uses an `extern` block, LLVM is required. */
     pragma "no doc"
     module HDF5_WAR {
-      extern {
-#include "hdf5_hl.h"
+      require "HDF5Helper/hdf5_helper.h";
 
-        /* Forward declarations for workaround wrappers */
-        herr_t H5LTget_dataset_info_WAR(hid_t loc_id,
-                                        const char* dset_name,
-                                        const void* dims,
-                                        H5T_class_t* type_class,
-                                        size_t* type_size);
+      extern proc H5LTget_dataset_info_WAR(loc_id: hid_t,
+                                           dset_name: c_string,
+                                           dims: c_void_ptr,
+                                           type_class: c_ptr(H5T_class_t),
+                                           type_size: c_ptr(size_t)): herr_t;
 
-        herr_t H5LTmake_dataset_WAR(hid_t loc_id,
-                                    const char* dset_name,
-                                    int rank,
-                                    const void* dims,
-                                    hid_t type_id,
-                                    void* buffer);
-
-        /* Wrappers for workarounds */
-        herr_t H5LTget_dataset_info_WAR(hid_t loc_id,
-                                        const char* dset_name,
-                                        const void* dims,
-                                        H5T_class_t* type_class,
-                                        size_t* type_size) {
-          return H5LTget_dataset_info(loc_id,
-                                      dset_name,
-                                      (unsigned long long*)dims,
-                                      type_class,
-                                      type_size);
-        }
-
-        herr_t H5LTmake_dataset_WAR(hid_t loc_id,
-                                    const char* dset_name,
-                                    int rank,
-                                    const void* dims,
-                                    hid_t type_id,
-                                    void* buffer) {
-          return H5LTmake_dataset(loc_id,
-                                  dset_name,
-                                  rank,
-                                  (unsigned long long*)dims,
-                                  type_id,
-                                  buffer);
-        }
-      }
+      extern proc H5LTmake_dataset_WAR(loc_id: hid_t,
+                                       dset_name: c_string,
+                                       rank: c_int,
+                                       dims: c_void_ptr,
+                                       type_id: hid_t,
+                                       buffer: c_void_ptr): herr_t;
     }
   }
 

--- a/modules/packages/HDF5Helper/hdf5_helper.h
+++ b/modules/packages/HDF5Helper/hdf5_helper.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2004-2019 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _HDF5_HELPER_H_
+#define _HDF5_HELPER_H_
+
+// This file contains workarounds for pointer type differences that
+// Chapel can run into for pointer to 64-bit integral types.
+// It works around these issues by passing the pointer to these
+// functions as a void* and casting to the appropriate type here.
+
+#include "hdf5_hl.h"
+
+
+
+/* Forward declarations for workaround wrappers */
+static herr_t H5LTget_dataset_info_WAR(hid_t loc_id,
+                                       const char* dset_name,
+                                       const void* dims,
+                                       H5T_class_t* type_class,
+                                       size_t* type_size);
+
+static herr_t H5LTmake_dataset_WAR(hid_t loc_id,
+                                   const char* dset_name,
+                                   int rank,
+                                   const void* dims,
+                                   hid_t type_id,
+                                   void* buffer);
+
+/* Wrappers for workarounds */
+static herr_t H5LTget_dataset_info_WAR(hid_t loc_id,
+                                       const char* dset_name,
+                                       const void* dims,
+                                       H5T_class_t* type_class,
+                                       size_t* type_size) {
+  return H5LTget_dataset_info(loc_id,
+                              dset_name,
+                              (unsigned long long*)dims,
+                              type_class,
+                              type_size);
+}
+
+static herr_t H5LTmake_dataset_WAR(hid_t loc_id,
+                                   const char* dset_name,
+                                   int rank,
+                                   const void* dims,
+                                   hid_t type_id,
+                                   void* buffer) {
+  return H5LTmake_dataset(loc_id,
+                          dset_name,
+                          rank,
+                          (unsigned long long*)dims,
+                          type_id,
+                          buffer);
+}
+
+
+
+#endif

--- a/test/library/packages/HDF5/HDF5Preprocessors.chpl
+++ b/test/library/packages/HDF5/HDF5Preprocessors.chpl
@@ -4,7 +4,7 @@ module HDF5Preprocessors {
   class AddNPreprocessor: HDF5Preprocessor {
     const n: int;
 
-    proc preprocess(A: []) {
+    override proc preprocess(A: []) {
       forall a in A {
         a += n;
       }
@@ -14,7 +14,7 @@ module HDF5Preprocessors {
   class ScriptPreprocessor: HDF5Preprocessor {
     const script: string;
 
-    proc preprocess(A: []) {
+    override proc preprocess(A: []) {
       use FileSystem, Path, Spawn;
 
       try! {


### PR DESCRIPTION
The `HDF5` module had been using an `extern` block to provide workarounds for
a few pointer type mismatch problems.  The `extern` blocks contained functions
written in C with `void*` and casting to avoid the issues.

Moved those functions out into a C header file as static functions and `require`
that header from the `HDF5_WAR` module.  Also declare them as `extern` functions
in `HDF5_WAR`. Moving them out to a `require`d header file allows getting
rid of the extern block, and so LLVM is no longer needed to use `HDF5`.

This resolves #12682.

Also noticed that a couple override keywords were missing in a test code, so
added them.