### PR TITLE
Annotations for week of 2019-04-18

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -610,6 +610,10 @@ empty-chpl-barrier.ml-time:
   08/02/18:
     - Optimize the atomic barrier implementation for network atomics (#10633)
 
+exchange:
+  04/18/19:
+    - Enable bulk-transfer for BlockDist by default (#12797)
+
 fannkuch-redux:
   07/22/14:
     - Error due to cleaning up file incompletely
@@ -1046,6 +1050,10 @@ memleaksfull:
     - Close a memory leak in linkedlist test (#12551)
     - Close leak in tdata-test (#12554)
     - Close leaks in CoMD (#12552)
+  04/16/19:
+    - Add VectorList collection (#12791)
+  04/17/19:
+    - Fix bugs in mason search and buildMason (#12785)
 
 meteor:
   12/18/13:

--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -1108,6 +1108,8 @@ miniMD:
     - Use zero-arg initializer in BaseDom (#9250)
   04/24/18:
     - Update miniMD problem size (#9296)
+  04/18/19:
+    - Enable bulk-transfer for BlockDist by default (#12797)
 
 miniMD.ml-time:
   09/14/17:


### PR DESCRIPTION
- Memory leak regressions due to #12791 and #12785:
  - https://chapel-lang.org/perf/chapcs/?startdate=2019/03/11&enddate=2019/04/17&graphs=memoryleaksforalltests
- BlockDist bulk transfer is now on by default:
  - Improvement: https://chapel-lang.org/perf/16-node-xc/?startdate=2019/03/10&enddate=2019/04/19&graphs=blockdisttransfern1e6
  - Improvement: https://chapel-lang.org/perf/chapcs.comm-counts/?startdate=2019/03/10&enddate=2019/04/19&suite=bulktransfer
  - no-local regression: https://chapel-lang.org/perf/chapcs/?startdate=2019/03/05&enddate=2019/04/19&graphs=minimdljsize10time