### PR TITLE
Push import of chpl_home_utils into new validate procedure

### DIFF
--- a/util/chplenv/chpl_compiler.py
+++ b/util/chplenv/chpl_compiler.py
@@ -5,7 +5,7 @@ import sys
 
 from distutils.spawn import find_executable
 
-import chpl_platform, overrides, chpl_home_utils
+import chpl_platform, overrides
 from utils import error, memoize
 
 
@@ -17,6 +17,7 @@ from utils import error, memoize
 #
 @memoize
 def validate(compiler_val):
+    import chpl_home_utils
     chpl_home = chpl_home_utils.get_chpl_home()
     comp_makefile = os.path.join(chpl_home, 'make', 'compiler', 'Makefile.{0}'.format(compiler_val))
     if not os.path.isfile(comp_makefile):


### PR DESCRIPTION
I didn't catch this earlier (thanks Lydia!), but I introduced an
import circularity of some sort for

  `test/runtime/configMatters/comm/atomics.suppressif`

due to my addition of `chpl_home_utils` in the `import` list of
`chpl_compiler.py`.  This is a simple fix that pushes the `import`
into the routine that needs to access `chpl_home_utils`.  Someone who
understands Python will need to explain to me how the circularity came
about after the fact (I just debugged it by thinking about what I
changed and how it could possibly break the script).

The output of the breaking run was:

```
  File "/data/cf/chapel/bradc/chapel/test/runtime/configMatters/comm/atomics.suppressif", line 14, in <module>
      from compiler_utils import CompVersion, get_compiler_version
  File "/data/cf/chapel/bradc/chapel/util/chplenv/compiler_utils.py", line 5, in <module>
      import chpl_compiler
  File "/data/cf/chapel/bradc/chapel/util/chplenv/chpl_compiler.py", line 8, in <module>
      import chpl_platform, overrides, chpl_home_utils
  File "/data/cf/chapel/bradc/chapel/util/chplenv/chpl_home_utils.py", line 7, in <module>
      import chpl_bin_subdir, chpl_python_version, overrides
  File "/data/cf/chapel/bradc/chapel/util/chplenv/chpl_bin_subdir.py", line 7, in <module>
      import chpl_platform, chpl_arch, chpl_cpu
  File "/data/cf/chapel/bradc/chapel/util/chplenv/chpl_arch.py", line 5, in <module>
      import chpl_cpu, overrides
  File "/data/cf/chapel/bradc/chapel/util/chplenv/chpl_cpu.py", line 10, in <module>
      from compiler_utils import CompVersion, target_compiler_is_prgenv, get_compiler_version
  ImportError: cannot import name CompVersion
```