### PR TITLE
Add .mason to CLEANFILES

### DIFF
--- a/test/mason/mason-example-with-opts/CLEANFILES
+++ b/test/mason/mason-example-with-opts/CLEANFILES
@@ -1,2 +1,3 @@
 tempHome
 mason_home
+.mason


### PR DESCRIPTION
This will remove any stray `.mason` directory laying around in this test directory.