### PR TITLE
Optimize stencil distribution's fast-follower

### DIFF
--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -1107,21 +1107,10 @@ iter BlockArr.these(param tag: iterKind, followThis, param fast: bool = false) r
     if arrSection.locale.id != here.id then
       arrSection = myLocArr;
 
-    //
-    // Forcibly narrow the array section. We know it's narrow because we're in
-    // a fast follower, but the compiler can't determine this currently.
-    //
-    const narrowArrSection = __primitive("_wide_get_addr", arrSection):arrSection.type;
-
-    //
-    // Slicing arrSection.myElems will require reference counts to be updated.
-    // If myElems is an array of arrays, the inner array's domain or dist may
-    // live on a different locale and require communication for reference
-    // counting. Simply put: don't slice inside a local block.
-    //
-    ref chunk = narrowArrSection.myElems(myFollowThisDom);
     local {
-      for i in chunk do yield i;
+      const narrowArrSection = __primitive("_wide_get_addr", arrSection):arrSection.type;
+      ref myElems = narrowArrSection.myElems;
+      for i in myFollowThisDom do yield myElems[i];
     }
   } else {
     //

--- a/modules/dists/StencilDist.chpl
+++ b/modules/dists/StencilDist.chpl
@@ -1218,15 +1218,10 @@ iter StencilArr.these(param tag: iterKind, followThis, param fast: bool = false)
     if arrSection.locale.id != here.id then
       arrSection = myLocArr;
 
-    //
-    // Slicing arrSection.myElems will require reference counts to be updated.
-    // If myElems is an array of arrays, the inner array's domain or dist may
-    // live on a different locale and require communication for reference
-    // counting. Simply put: don't slice inside a local block.
-    //
-    ref chunk = arrSection.myElems(myFollowThisDom);
     local {
-      for i in chunk do yield i;
+      const narrowArrSection = __primitive("_wide_get_addr", arrSection):arrSection.type;
+      ref myElems = narrowArrSection.myElems;
+      for i in myFollowThisDom do yield myElems[i];
     }
   } else {
     //


### PR DESCRIPTION
The forces elements being yielded from the stencil dist fast-follower to
be narrow, which significantly improves the generated code and results
in a 1% speedup for prk-stencil at 256 nodes.

Similar to #11644 -- prevent the compiler from widening elements being
yielded from the fast follower. This is similar to #11644, but the same
approach didn't work for PRK stencil. Previously, a slice of the local
array was taken, but the updateFluff() call in prk-stencil ends up
widening the slice routine so we still had wide pointers. Here we switch
from slicing to doing direct indexing in order to avoid that problem and
get narrow pointers.

This improves the generated code and eliminates wide pointers for the
`forall i in input do i += 1.0;` step in prk-stencil. It's not quite as
optimal as the reference version because we still have our `blk` offset
for 2D arrays and some other misc generated code, but it's a lot cleaner
than it was.