### PR TITLE
Enable Bulk-Transfer for StencilDist by default

### DIFF
--- a/modules/dists/StencilDist.chpl
+++ b/modules/dists/StencilDist.chpl
@@ -51,6 +51,8 @@ config param debugStencilDistBulkTransfer = false;
 // TODO: part of initializer?
 config param stencilDistAllowPackedUpdateFluff = true;
 
+config param disableStencilDistBulkTransfer = false;
+
 // Instructs the _packedUpdate method to only perform the optimized buffer
 // packing if the number of GETs/PUTs would be greater than or equal to the
 // value in this config const.
@@ -572,6 +574,36 @@ proc Stencil.targetLocsIdx(ind: rank*idxType) {
                              targetLocDom.dim(i).length:idxType) /
                             boundingBox.dim(i).length):int));
   return if rank == 1 then result(1) else result;
+}
+
+// TODO: This will not trigger the bounded-coforall optimization
+iter Stencil.activeTargetLocales(const space : domain = boundingBox) {
+  const locSpace = {(...space.dims())}; // make a local domain in case 'space' is distributed
+  const low = chpl__tuplify(targetLocsIdx(locSpace.first));
+  const high = chpl__tuplify(targetLocsIdx(locSpace.last));
+  var dims : rank*range(low(1).type);
+  for param i in 1..rank {
+    dims(i) = low(i)..high(i);
+  }
+
+  // In case 'locSpace' is a strided domain we need to check that the locales
+  // in 'dims' actually contain indices in 'locSpace'.
+  //
+  // Note that we cannot use a simple stride here because it is not guaranteed
+  // that each locale contains the same number of indices. For example, the
+  // domain {1..10} over four locales will split like:
+  //   L0: -max(int)..3
+  //   L1: 4..5
+  //   L2: 6..8
+  //   L3: 9..max(int)
+  //
+  // The subset {1..10 by 4} will involve locales 0, 1, and 3.
+  for i in {(...dims)} {
+    const chunk = chpl__computeBlock(i, targetLocDom, boundingBox);
+    // TODO: Want 'contains' for a domain. Slicing is a workaround.
+    if locSpace[(...chunk)].size > 0 then
+      yield i;
+  }
 }
 
 proc chpl__computeBlock(locid, targetLocBox, boundingBox) {
@@ -1721,102 +1753,6 @@ proc StencilArr.dsiPrivatize(privatizeData) {
   return c;
 }
 
-private proc _canDoSimpleStencilTransfer(Dest, destDom, Src, srcDom) {
-  if debugStencilDistBulkTransfer then
-    writeln("In StencilDist._canDoSimpleStencilTransfer");
-
-  if destDom.stridable || srcDom.stridable {
-    for param i in 1..Dest.rank {
-      if destDom.dim(i).stride != 1 ||
-         srcDom.dim(i).stride != 1 then return false;
-    }
-  }
-
-  return useBulkTransferDist;
-}
-
-proc StencilArr.doiBulkTransferToKnown(srcDom, destClass:StencilArr, destDom) : bool
-where useBulkTransferDist {
-  if _canDoSimpleStencilTransfer(destClass, destDom, this, srcDom) {
-    _doSimpleStencilTransfer(destClass, destDom, this, srcDom);
-    return true;
-  }
-  return false;
-}
-
-proc StencilArr.doiBulkTransferFromKnown(destDom, srcClass:StencilArr, srcDom) : bool
-where useBulkTransferDist {
-  if _canDoSimpleStencilTransfer(this, destDom, srcClass, srcDom) {
-    _doSimpleStencilTransfer(this, destDom, srcClass, srcDom);
-    return true;
-  }
-  return false;
-}
-
-private proc _doSimpleStencilTransfer(Dest, destDom, Src, srcDom) {
-  if debugStencilDistBulkTransfer then
-    writeln("In StencilDist._doSimpleStencilTransfer");
-
-  if debugStencilDistBulkTransfer then resetCommDiagnostics();
-
-  param rank = Dest.rank;
-
-  const equalDoms = (Dest.dom.whole == Src.dom.whole) &&
-                    (srcDom == destDom) &&
-                    (Dest.dom.dist.dsiEqualDMaps(Src.dom.dist));
-
-  // Use zippered iteration to piggyback data movement with the remote
-  //  fork.  This avoids remote gets for each access to locArr[i] and
-  //  Src.locArr[i]
-  coforall (i, destLocArr, srcLocArr, destLocDom, srcLocDom) in zip(Dest.dom.dist.targetLocDom,
-                                        Dest.locArr,
-                                        Src.locArr,
-                                        Dest.dom.locDoms,
-                                        Src.dom.locDoms) {
-    on Dest.dom.dist.targetLocales(i) {
-      if debugStencilDistBulkTransfer then startCommDiagnosticsHere();
-
-      const viewBlock = destLocDom.myBlock[destDom];
-
-      if equalDoms {
-        const theirView = srcLocDom.myBlock[srcDom];
-        destLocArr.myElems[viewBlock] = srcLocArr.myElems[theirView];
-      } else if Dest.rank == 1 {
-        var start = viewBlock.low;
-
-        for (rid, rlo, size) in ConsecutiveChunks(destDom, Src.dom, srcDom, viewBlock.size, start) {
-          destLocArr.myElems[start..#size] = Src.locArr[rid].myElems[rlo..#size];
-          start += size;
-        }
-      } else {
-        const orig = viewBlock.low(rank);
-
-        for coord in dropDims(viewBlock, viewBlock.rank) {
-          var lo = if rank == 2 then (coord, orig) else ((...coord), orig);
-
-          for (rid, rlo, size) in ConsecutiveChunksD(destDom, Src.dom, srcDom, viewBlock.dim(rank).length, lo) {
-            var LSlice, RSlice : rank*range(idxType = Dest.dom.idxType);
-
-            for param i in 1..rank-1 {
-              LSlice(i) = if rank == 2 then coord..coord else coord(i)..coord(i);
-              RSlice(i) = rlo(i)..rlo(i);
-            }
-            LSlice(rank) = lo(rank)..#size;
-            RSlice(rank) = rlo(rank)..#size;
-
-            destLocArr.myElems[(...LSlice)] = Src.locArr[rid].myElems[(...RSlice)];
-
-            lo(rank) += size;
-          }
-        }
-      }
-
-      if debugStencilDistBulkTransfer then stopCommDiagnosticsHere();
-    }
-  }
-  if debugStencilDistBulkTransfer then writeln("Comms:",getCommDiagnostics());
-}
-
 
 proc StencilArr.dsiTargetLocales() {
   return dom.dist.targetLocales;
@@ -1881,9 +1817,10 @@ proc StencilDom.numRemoteElems(viewDom, rlo, rid) {
 
   return (bhi - (rlo - 1):idxType);
 }
-
 private proc canDoAnyToStencil(Dest, destDom, Src, srcDom) param : bool {
-  if Dest.rank != Src.rank then return false;
+  if Src.doiCanBulkTransferRankChange() == false &&
+     Dest.rank != Src.rank then return false;
+
   use Reflection;
 
   // Does 'Src' support bulk transfers *to* a DefaultRectangular?
@@ -1892,48 +1829,83 @@ private proc canDoAnyToStencil(Dest, destDom, Src, srcDom) param : bool {
     return false;
   }
 
-  return useBulkTransferDist;
+  return !disableStencilDistBulkTransfer;
+}
+
+
+proc StencilArr.doiBulkTransferToKnown(srcDom, destClass:StencilArr, destDom) : bool
+where !disableStencilDistBulkTransfer {
+  _doSimpleStencilTransfer(destClass, destDom, this, srcDom);
+  return true;
+}
+
+proc StencilArr.doiBulkTransferFromKnown(destDom, srcClass:StencilArr, srcDom) : bool
+where !disableStencilDistBulkTransfer {
+  _doSimpleStencilTransfer(this, destDom, srcClass, srcDom);
+  return true;
+}
+
+private proc _doSimpleStencilTransfer(Dest, destDom, Src, srcDom) {
+  if debugStencilDistBulkTransfer then
+    writeln("In Stencil=Stencil Bulk Transfer: Dest[", destDom, "] = Src[", srcDom, "]");
+
+  // Cache to avoid GETs
+  const DestPID = Dest.pid;
+  const SrcPID = Src.pid;
+
+  coforall i in Dest.dom.dist.activeTargetLocales(destDom) {
+    on Dest.dom.dist.targetLocales[i] {
+      // Relies on the fact that we privatize across all locales in the
+      // program, not just the targetLocales of Dest/Src.
+      const dst = if _privatization then chpl_getPrivatizedCopy(Dest.type, DestPID) else Dest;
+      const src = if _privatization then chpl_getPrivatizedCopy(Src.type, SrcPID) else Src;
+
+      // Note: Currently StencilDist does not support slicing into the
+      // outermost fluff cells, so it is not possible for a BulkTransfer to
+      // involve those indices. This means we can simply use 'myBlock' instead
+      // of trying to compute something involving fluff.
+      //
+      // Compute the local portion of the destination domain, and find the
+      // corresponding indices in the source's domain.
+      const localDestBlock = dst.dom.locDoms[i].myBlock[destDom];
+      assert(localDestBlock.size > 0);
+      const corSrcBlock    = bulkCommTranslateDomain(localDestBlock, destDom, srcDom);
+      if debugStencilDistBulkTransfer then
+        writeln("  Dest[",localDestBlock,"] = Src[", corSrcBlock,"]");
+
+      // The corresponding indices in the source's domain do not necessarily
+      // all live on the same locale. This loop finds the chunks that live on a
+      // single locale, translates those back to the destination's domain, and
+      // performs the transfer.
+      for srcLoc in src.dom.dist.activeTargetLocales(corSrcBlock) {
+        const localSrcChunk  = corSrcBlock[src.dom.locDoms[srcLoc].myBlock];
+        const localDestChunk = bulkCommTranslateDomain(localSrcChunk, corSrcBlock, localDestBlock);
+        chpl__bulkTransferArray(dst.locArr[i].myElems._value, localDestChunk,
+                                src.locArr[srcLoc].myElems._value, localSrcChunk);
+      }
+    }
+  }
 }
 
 // Overload for any transfer *to* Stencil, if the RHS supports transfers to a
 // DefaultRectangular
-//
-// TODO: avoid spawning so many coforall-ons
-//   - clean up some of this range creation logic
 proc StencilArr.doiBulkTransferFromAny(destDom, Src, srcDom) : bool
 where canDoAnyToStencil(this, destDom, Src, srcDom) {
 
   if debugStencilDistBulkTransfer then
-    writeln("In StencilDist.doiBulkTransferFromAny");
+    writeln("In StencilArr.doiBulkTransferFromAny");
 
-  const Dest = this;
-  type el    = Dest.idxType;
+  coforall j in dom.dist.activeTargetLocales(destDom) {
+    on dom.dist.targetLocales(j) {
+      const Dest = if _privatization then chpl_getPrivatizedCopy(this.type, pid) else this;
 
-  coforall i in Dest.dom.dist.targetLocDom {
-    on Dest.dom.dist.targetLocales(i) {
-      const regionDest = Dest.dom.locDoms(i).myBlock[destDom];
-      const regionSrc  = Src.dom.locDoms(i).myBlock[srcDom];
-      if regionDest.numIndices > 0 {
-        const ini = bulkCommConvertCoordinate(regionDest.first, destDom, srcDom);
-        const end = bulkCommConvertCoordinate(regionDest.last, destDom, srcDom);
-        const sb  = chpl__tuplify(regionSrc.stride);
+      const inters   = Dest.dom.locDoms(j).myBlock[destDom];
+      const srcChunk = bulkCommTranslateDomain(inters, destDom, srcDom);
 
-        var r1,r2: rank * range(idxType = el,stridable = true);
-        r2 = regionDest.dims();
-         //In the case that the number of elements in dimension t for r1 and r2
-         //were different, we need to calculate the correct stride in r1
-        for param t in 1..rank {
-            r1[t] = (ini[t]:el..end[t]:el by sb[t]);
-            if r1[t].length != r2[t].length then
-              r1[t] = (ini[t]:el..end[t]:el by (end[t] - ini[t]):el/(r2[t].length-1));
-        }
+      if debugStencilDistBulkTransfer then
+        writeln("Dest.locArr[", j, "][", inters, "] = Src[", srcDom, "]");
 
-        if debugStencilDistBulkTransfer then
-          writeln("A.locArr[i][", regionDest, "] = B[", (...r1), "]");
-
-        // TODO: handle possibility that this function returns false
-        chpl__bulkTransferArray(Dest.locArr[i].myElems._value, regionDest, Src, {(...r1)});
-      }
+      chpl__bulkTransferArray(Dest.locArr[j].myElems._value, inters, Src, srcChunk);
     }
   }
 
@@ -1942,37 +1914,23 @@ where canDoAnyToStencil(this, destDom, Src, srcDom) {
 
 // For assignments of the form: DefaultRectangular = Stencil
 proc StencilArr.doiBulkTransferToKnown(srcDom, Dest:DefaultRectangularArr, destDom) : bool
-where useBulkTransferDist {
+where !disableStencilDistBulkTransfer {
 
   if debugStencilDistBulkTransfer then
-    writeln("In StencilDist.doiBulkTransferToKnown(DefaultRectangular)");
+    writeln("In StencilArr.doiBulkTransferToKnown(DefaultRectangular)");
 
-  const Src = this;
-  type el   = Src.idxType;
+  coforall j in dom.dist.activeTargetLocales(srcDom) {
+    on dom.dist.targetLocales(j) {
+      const Src = if _privatization then chpl_getPrivatizedCopy(this.type, pid) else this;
+      const inters = Src.dom.locDoms(j).myBlock[srcDom];
 
-  coforall j in Src.dom.dist.targetLocDom {
-    on Src.dom.dist.targetLocales(j) {
-      const inters = Src.dom.locDoms(j).myBlock[destDom];
-      if inters.numIndices > 0 {
-        const ini = bulkCommConvertCoordinate(inters.first, destDom, srcDom);
-        const end = bulkCommConvertCoordinate(inters.last, destDom, srcDom);
-        const sa  = chpl__tuplify(srcDom.stride);
+      const destChunk = bulkCommTranslateDomain(inters, srcDom, destDom);
 
-        var r1,r2: rank * range(idxType = el,stridable = true);
-        for param t in 1..rank
-        {
-          r2[t] = (chpl__tuplify(inters.first)[t]
-                   ..chpl__tuplify(inters.last)[t]
-                   by chpl__tuplify(inters.stride)[t]);
-          r1[t] = (ini[t]:el..end[t]:el by sa[t]);
-        }
+      if debugStencilDistBulkTransfer then
+        writeln("  A[",destChunk,"] = B[",inters,"]");
 
-        if debugStencilDistBulkTransfer then
-          writeln("A[",r1,"] = B[",r2,"]");
-
-        const elemActual = Src.locArr[j].myElems._value;
-        chpl__bulkTransferArray(Dest, {(...r1)}, elemActual, {(...r2)});
-      }
+      const elemActual = Src.locArr[j].myElems._value;
+      chpl__bulkTransferArray(Dest, destChunk, elemActual, inters);
     }
   }
 
@@ -1981,83 +1939,29 @@ where useBulkTransferDist {
 
 // For assignments of the form: Stencil = DefaultRectangular
 proc StencilArr.doiBulkTransferFromKnown(destDom, Src:DefaultRectangularArr, srcDom) : bool
-where useBulkTransferDist {
+where !disableStencilDistBulkTransfer {
   if debugStencilDistBulkTransfer then
     writeln("In StencilArr.doiBulkTransferFromKnown(DefaultRectangular)");
 
-  const Dest = this;
-  type el    = Dest.idxType;
-
-  coforall j in Dest.dom.dist.targetLocDom {
-    on Dest.dom.dist.targetLocales(j) {
+  coforall j in dom.dist.activeTargetLocales(destDom) {
+    on dom.dist.targetLocales(j) {
+      // Grab privatized copy of 'this' to avoid extra GETs
+      const Dest = if _privatization then chpl_getPrivatizedCopy(this.type, pid) else this;
       const inters = Dest.dom.locDoms(j).myBlock[destDom];
-      if inters.numIndices > 0 {
-        const ini = bulkCommConvertCoordinate(inters.first, destDom, srcDom);
-        const end = bulkCommConvertCoordinate(inters.last, destDom, srcDom);
-        const sb  = chpl__tuplify(srcDom.stride);
+      assert(inters.size > 0);
 
-        var r1,r2: rank * range(idxType = el,stridable = true);
-        for param t in 1..rank {
-          r2[t] = (chpl__tuplify(inters.first)[t]
-                   ..chpl__tuplify(inters.last)[t]
-                   by chpl__tuplify(inters.stride)[t]);
-          r1[t] = (ini[t]:el..end[t]:el by sb[t]);
-        }
+      const srcChunk = bulkCommTranslateDomain(inters, destDom, srcDom);
 
-        if debugStencilDistBulkTransfer then
-          writeln("A[",r2,"] = B[",r1,"]");
+      if debugStencilDistBulkTransfer then
+        writeln("  A[",inters,"] = B[",srcChunk,"]");
 
-        const elemActual = Dest.locArr[j].myElems._value;
-        chpl__bulkTransferArray(elemActual, {(...r2)}, Src, {(...r1)});
-      }
+      const elemActual = Dest.locArr[j].myElems._value;
+      chpl__bulkTransferArray(elemActual, inters, Src, srcChunk);
     }
   }
 
   return true;
 }
 
-//Brad's utility function. It drops from Domain D the dimensions
-//indicated by the subsequent parameters dims.
-proc dropDims(D: domain, dims...) {
-  var r = D.dims();
-  var r2: (D.rank-dims.size)*r(1).type;
-  var j = 1;
-  for i in 1..D.rank do
-    for k in 1..dims.size do
-      if dims(k) != i {
-        r2(j) = r(i);
-        j+=1;
-      }
-  var DResult = {(...r2)};
-  return DResult;
-}
-
-iter ConsecutiveChunks(LView, RDomClass, RView, len, in start) {
-  var elemsToGet = len;
-  const offset   = RView.low - LView.low;
-  var rlo        = start + offset;
-  var rid        = RDomClass.dist.targetLocsIdx(rlo);
-  while elemsToGet > 0 {
-    const size = min(RDomClass.numRemoteElems(RView, rlo, rid), elemsToGet);
-    yield (rid, rlo, size);
-    rid += 1;
-    rlo += size;
-    elemsToGet -= size;
-  }
-}
-
-iter ConsecutiveChunksD(LView, RDomClass, RView, len, in start) {
-  param rank     = LView.rank;
-  var elemsToGet = len;
-  const offset   = RView.low - LView.low;
-  var rlo        = start + offset;
-  var rid        = RDomClass.dist.targetLocsIdx(rlo);
-  while elemsToGet > 0 {
-    const size = min(RDomClass.numRemoteElems(RView, rlo(rank):int, rid(rank):int), elemsToGet);
-    yield (rid, rlo, size);
-    rid(rank) +=1;
-    rlo(rank) += size;
-    elemsToGet -= size;
-  }
-}
+proc StencilArr.doiCanBulkTransferRankChange() param return true;
 

--- a/test/optimizations/bulkcomm/block/blockToBlock.compopts
+++ b/test/optimizations/bulkcomm/block/blockToBlock.compopts
@@ -1,1 +1,2 @@
 -M ../common --no-checks
+-M ../common --no-checks -sdistType=DistType.stencil

--- a/test/optimizations/bulkcomm/block/disableBT.chpl
+++ b/test/optimizations/bulkcomm/block/disableBT.chpl
@@ -1,23 +1,32 @@
 
 use BlockDist;
+use StencilDist;
 use CyclicDist;
+
+config param distType = DistType.block;
+
+enum DistType {
+  block,
+  stencil
+}
 
 proc main() {
   var D = {1..10, 1..10};
-  var S = D dmapped Block(D);
+  var S = if distType == DistType.block then D dmapped Block(D)
+          else D dmapped Stencil(D, fluff=(1,1));
   var A, B : [S] int;
 
-  writeln("Block=Block: ", chpl__bulkTransferArray(A, B));
+  writeln("Dist=Dist: ", chpl__bulkTransferArray(A, B));
 
   {
     var C : [D] int;
-    writeln("Block=DefaultRectangular: ", chpl__bulkTransferArray(A, C));
-    writeln("DefaultRectangular=Block: ", chpl__bulkTransferArray(C, A));
+    writeln("Dist=DefaultRectangular: ", chpl__bulkTransferArray(A, C));
+    writeln("DefaultRectangular=Dist: ", chpl__bulkTransferArray(C, A));
   }
 
   {
     var CD = S dmapped Cyclic(S.low);
     var C : [CD] int;
-    writeln("Block=Cyclic: ", chpl__bulkTransferArray(A, C));
+    writeln("Dist=Cyclic: ", chpl__bulkTransferArray(A, C));
   }
 }

--- a/test/optimizations/bulkcomm/block/disableBT.compopts
+++ b/test/optimizations/bulkcomm/block/disableBT.compopts
@@ -1,1 +1,2 @@
 -sdisableBlockDistBulkTransfer -suseBulkTransferDist
+-sdisableStencilDistBulkTransfer -suseBulkTransferDist -sdistType=DistType.stencil

--- a/test/optimizations/bulkcomm/block/disableBT.good
+++ b/test/optimizations/bulkcomm/block/disableBT.good
@@ -1,4 +1,4 @@
-Block=Block: false
-Block=DefaultRectangular: false
-DefaultRectangular=Block: false
-Block=Cyclic: false
+Dist=Dist: false
+Dist=DefaultRectangular: false
+DefaultRectangular=Dist: false
+Dist=Cyclic: false

--- a/test/optimizations/bulkcomm/block/toFromDR.compopts
+++ b/test/optimizations/bulkcomm/block/toFromDR.compopts
@@ -1,1 +1,2 @@
---no-checks -M ../common/ --instantiate-max 512
+#--no-checks -M ../common/ --instantiate-max 512
+--no-checks -M ../common/ --instantiate-max 512 -sdistType=DistType.stencil

--- a/test/optimizations/bulkcomm/common/util.chpl
+++ b/test/optimizations/bulkcomm/common/util.chpl
@@ -22,12 +22,17 @@ proc stridedAssign(A : [], sa, B : [], sb, debug=debugDefault) {
   ref right = if isDomain(sb) then B[sb] else B[(...sb)];
   const ldom = left.domain;
 
+  // If 'ldom' is a Stencil-distributed domain, it can return 'true' for
+  // indices in the fluff region, but that's not really what we want in this
+  // particular case. Instead, use a DR domain.
+  const memberDom = {(...ldom.dims())};
+
   var ret = 1;
 
   proc isMember(idx) {
     if isTuple(idx) {
       if isDomain(sa) {
-        return ldom.contains(idx);
+        return memberDom.contains(idx);
       } else {
         var ret = true;
         for param i in 1..sa.size {
@@ -37,7 +42,7 @@ proc stridedAssign(A : [], sa, B : [], sb, debug=debugDefault) {
         return ret;
       }
     } else {
-      return ldom.contains(idx);
+      return memberDom.contains(idx);
     }
   }
 


### PR DESCRIPTION
This PR follows in the footsteps of #12797 and copies most of the BlockDist bulk-transfer implementation to replace StencilDist's. The existing correctness tests for BlockDist bulk-transfer have been updated to also test StencilDist.

Testing:
- [x] local + futures
- [x] gasnet + futures