### PR TITLE
Denormalize the test in CondStmts

### DIFF
--- a/compiler/AST/iterator.cpp
+++ b/compiler/AST/iterator.cpp
@@ -1169,17 +1169,17 @@ buildAdvance(FnSymbol* fn,
 
   // insert jump table at head of advance
   i = 2;
-  Symbol* tmp = newTemp(dtBool);
   Symbol* more = new VarSymbol("more", dtInt[INT_SIZE_DEFAULT]);
 
   forv_Vec(LabelSymbol, label, labels) {
     GotoStmt* igs = new GotoStmt(GOTO_ITER_RESUME, label);
     label->iterResumeGoto = igs;
+    Symbol* tmp = newTemp(dtBool);
     advanceBody->insertAtHead(new CondStmt(new SymExpr(tmp), igs));
     advanceBody->insertAtHead(new CallExpr(PRIM_MOVE, tmp, new CallExpr(PRIM_EQUAL, more, new_IntSymbol(i++))));
+    advanceBody->insertAtHead(new DefExpr(tmp));
   }
   advanceBody->insertAtHead(new CallExpr(PRIM_MOVE, more, new CallExpr(PRIM_GET_MEMBER_VALUE, ic, ii->iclass->getField("more"))));
-  advanceBody->insertAtHead(new DefExpr(tmp));
   advanceBody->insertAtHead(new DefExpr(more));
   advanceBody->insertAtTail(new CallExpr(PRIM_RETURN, gVoid));
 

--- a/compiler/AST/stmt.cpp
+++ b/compiler/AST/stmt.cpp
@@ -733,6 +733,15 @@ Expr* CondStmt::getNextExpr(Expr* expr) {
   return retval;
 }
 
+// If 'expr' is the condExpr in a CondStmt, return that CondStmt.
+// Otherwise, return NULL.
+CondStmt* isConditionalInCondStmt(Expr* expr) {
+  if (CondStmt* parent = toCondStmt(expr->parentExpr))
+    if (expr == parent->condExpr)
+      return parent;
+  return NULL;
+}
+
 /************************************* | **************************************
 *                                                                             *
 *                                                                             *

--- a/compiler/include/stmt.h
+++ b/compiler/include/stmt.h
@@ -300,6 +300,8 @@ public:
 extern Vec<LabelSymbol*>         removedIterResumeLabels;
 extern Map<GotoStmt*, GotoStmt*> copiedIterResumeGotos;
 
+CondStmt*    isConditionalInCondStmt(Expr* expr);
+
 // Probably belongs in Expr; doesn't really mean Stmt, but rather
 // statement-level expression.
 void         codegenStmt(Expr* stmt);

--- a/compiler/passes/denormalize.cpp
+++ b/compiler/passes/denormalize.cpp
@@ -437,6 +437,8 @@ bool isDenormalizable(Symbol* sym,
                   isFloatComparisonPrimitive(ce))) {
               use = se;
             }
+          } else if (isConditionalInCondStmt(se)) {
+            use = se;
           }
         }
         if(use) {


### PR DESCRIPTION
This extends the compiler's existing denormalization pass
to apply to CondStmt::condExpr. Previously it applied
only to pieces of a CallExpr.

While there, tweak how the jump table in an iterator's advance()
method is constructed - so that the generated code looks better
after denormalization.

Testing: linux64; gasnet.