### PR TITLE
Improve task placement for local bounded coforalls

### DIFF
--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -989,6 +989,7 @@ static BlockStmt* buildLoweredCoforall(Expr* indices,
 
   BlockStmt* block = ForLoop::buildForLoop(indices, new SymExpr(iterator), taskBlk, true, zippered);
   if (bounded) {
+    if (!onBlock) { block->insertAtHead(new CallExpr("chpl_resetTaskSpawn", numTasks)); }
     block->insertAtHead(new CallExpr("_upEndCount", coforallCount, countRunningTasks, numTasks));
     block->insertAtHead(new CallExpr(PRIM_MOVE, numTasks, new CallExpr(".", iterator,  new_CStringSymbol("size"))));
     block->insertAtHead(new DefExpr(numTasks));

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -983,6 +983,22 @@ module ChapelBase {
   // sync statements and for joining coforall and cobegin tasks
   //
 
+  inline proc chpl_rt_reset_task_spawn() {
+    if CHPL_TASKS == 'qthreads' {
+      pragma "fn synchronization free"
+      extern proc qthread_chpl_reset_spawn_order();
+      qthread_chpl_reset_spawn_order();
+    }
+  }
+
+  proc chpl_resetTaskSpawn(numTasks) {
+    const dptpl = if dataParTasksPerLocale==0 then here.maxTaskPar
+                  else dataParTasksPerLocale;
+
+    if numTasks >= dptpl then
+      chpl_rt_reset_task_spawn();
+  }
+
   config param useAtomicTaskCnt =  CHPL_NETWORK_ATOMICS!="none";
 
   // Parent class for _EndCount instances so that it's easy

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -984,11 +984,9 @@ module ChapelBase {
   //
 
   inline proc chpl_rt_reset_task_spawn() {
-    if CHPL_TASKS == 'qthreads' {
-      pragma "fn synchronization free"
-      extern proc qthread_chpl_reset_spawn_order();
-      qthread_chpl_reset_spawn_order();
-    }
+    pragma "fn synchronization free"
+    extern proc chpl_task_reset_spawn_order();
+    chpl_task_reset_spawn_order();
   }
 
   proc chpl_resetTaskSpawn(numTasks) {

--- a/runtime/include/chpl-tasks.h
+++ b/runtime/include/chpl-tasks.h
@@ -219,6 +219,17 @@ void chpl_task_setSubloc(c_sublocid_t);
 c_sublocid_t chpl_task_getRequestedSubloc(void);
 #endif
 
+// For tasking layers that support task affinity/placement, this
+// resets any automatic placement order
+#ifndef CHPL_TASK_IMPL_RESET_SPAWN_ORDER
+#define CHPL_TASK_IMPL_RESET_SPAWN_ORDER()
+#endif
+static inline
+void chpl_task_reset_spawn_order(void) {
+  CHPL_TASK_IMPL_RESET_SPAWN_ORDER();
+}
+
+
 //
 // Get ID.
 //

--- a/runtime/include/tasks/qthreads/chpl-tasks-impl.h
+++ b/runtime/include/tasks/qthreads/chpl-tasks-impl.h
@@ -231,6 +231,7 @@ void chpl_task_setSubloc(c_sublocid_t full_subloc)
     }
 }
 
+#define CHPL_TASK_IMPL_RESET_SPAWN_ORDER() qthread_chpl_reset_spawn_order()
 
 #define CHPL_TASK_IMPL_GET_FIXED_NUM_THREADS() \
     chpl_task_impl_getFixedNumThreads()

--- a/third-party/qthread/README
+++ b/third-party/qthread/README
@@ -22,6 +22,9 @@ as follows:
   from us using schedulers that don't support work stealing (nemesis)
   or running with work stealing disabled (distrib w/ QT_STEAL_RATIO=0)
 
+* We added a simple mechanism to reset the automatic task spawning
+  order for better affinity between consecutive parallel loops.
+
 * We deleted the register keyword from the code because it is
   deprecated in C++, causing warnings (that get turned into errors
   with the compiler switch -Werror) when qthread.h is included from

--- a/third-party/qthread/qthread-src/include/qthread/qthread.h
+++ b/third-party/qthread/qthread-src/include/qthread/qthread.h
@@ -288,6 +288,8 @@ enum _qthread_features {
 #define QTHREAD_SPAWN_LOCAL_PRIORITY (1 << SPAWN_LOCAL_PRIORITY)
 #define QTHREAD_SPAWN_NETWORK (1 << SPAWN_NETWORK)
 
+void qthread_chpl_reset_spawn_order(void);
+
 int qthread_spawn(qthread_f             f,
                   const void           *arg,
                   size_t                arg_size,

--- a/third-party/qthread/qthread-src/src/qthread.c
+++ b/third-party/qthread/qthread-src/src/qthread.c
@@ -2403,6 +2403,19 @@ void API_FUNC qthread_flushsc(void)
  */
 #define QTHREAD_SPAWN_MASK_TEAMS (QTHREAD_SPAWN_NEW_TEAM | QTHREAD_SPAWN_NEW_SUBTEAM)
 
+void API_FUNC qthread_chpl_reset_spawn_order(void) {
+    assert(qthread_library_initialized);
+    qthread_t            *me = qthread_internal_self();
+
+    if (me) {
+        assert(me->rdata);
+        me->rdata->shepherd_ptr->sched_shepherd = 0;
+    } else {
+        qlib->sched_shepherd = 0;
+        MACHINE_FENCE;
+    }
+}
+
 int API_FUNC qthread_spawn(qthread_f             f,
                            const void           *arg,
                            size_t                arg_size,


### PR DESCRIPTION
This implements a simple task placement/resetting policy to improve task
affinity.

Task placement is currently determined by qthreads. The nemesis
scheduler (our default) does a round-robin assignment of tasks to
workers, where each worker maintains a current index to spawn to (and
there's a global counter for tasks spawned from a non-qthread.) This
task placement results in good affinity for consecutive loops that use
all the cores so long as there's no interleaving tasks, but it gets
affinity wrong when `tasks < cores` or if there's interleaving tasks
created. For a stream variant that intentionally creates tasks between
first-touch and the kernel, this results in a 2.5x performance hit.

Here we just reset the worker spawn index before spawning tasks for a
local bounded coforall when spawning at least dataParTasksPerLocale
tasks. This gives us good affinity for consecutive forall loops that
don't use all the cores, and ensures that all forall loops get the same
affinity even if there's interleaving tasks. For example:

```chpl
forall a in A do a += 1;
cobegin { something(); something();}
forall a in A do a += 1;
```

will now result in the forall loops having the same task affinity.

This improves the performance of stream with interleaving tasks:

| interleaving tasks | before perf | current perf |
| ------------------ | ----------- | ------------ |
| none               |  84 GB/s    |  84 GB/s     |
| numCores/2         |  32 GB/s    |  84 GB/s     |
| random             | ~45 GB/s    |  84 GB/s     |

This also improves prk-stencil by ~5% (and will also allow us to remove
some hacks used to prevent interleaving tasks from hurting performance):

![prk-stencil](https://user-images.githubusercontent.com/1588337/56533295-413c6200-650c-11e9-8c19-f6e9e41e073c.png)

I view this as as a stop-gap solution and I probably won't contribute
this change upstream. I think the real solution is to have a bulk/vector
task spawn API for local tasks and take care of affinity there using the
existing qthreads API to spawn to to a specific worker -- #9614.

Closes https://github.com/chapel-lang/chapel/issues/9618