### PR TITLE
Remove prk-stencil workarounds to avoid task affinity problems

### DIFF
--- a/modules/dists/StencilDist.chpl
+++ b/modules/dists/StencilDist.chpl
@@ -601,29 +601,6 @@ proc LocStencil.init(param rank: int,
   myChunk = {(...inds)};
 }
 
-//
-// TODO: Remove this and go back to default initializer once task-resetting is
-// implemented.
-//
-// This initializer is introduced to work around a task-resetting performance
-// issue. In the default initializer, locDoms is first initialized then
-// assigned to in parallel. This offsets the tasks just enough to slightly hurt
-// performance.
-//
-proc StencilDom.init(param rank : int,
-                     type idxType,
-                     param stridable : bool,
-                     param ignoreFluff : bool,
-                     dist : unmanaged Stencil(rank, idxType, ignoreFluff),
-                     fluff : rank*idxType,
-                     periodic : bool = false) {
-  super.init(rank, idxType, stridable);
-  this.ignoreFluff = ignoreFluff;
-  this.dist = dist;
-  this.fluff = fluff;
-  this.periodic = periodic;
-}
-
 override proc StencilDom.dsiMyDist() return dist;
 
 override proc StencilDom.dsiDisplayRepresentation() {

--- a/test/studies/prk/Stencil/optimized/stencil-opt.ml-compopts
+++ b/test/studies/prk/Stencil/optimized/stencil-opt.ml-compopts
@@ -1,1 +1,1 @@
---set order=128000 --set iterations=3
+--set order=128000

--- a/test/studies/prk/Stencil/stencil-serial.perfcompopts
+++ b/test/studies/prk/Stencil/stencil-serial.perfcompopts
@@ -1,1 +1,1 @@
---set iterations=3 --set order=32000
+--set order=32000

--- a/test/studies/prk/Stencil/stencil.ml-compopts
+++ b/test/studies/prk/Stencil/stencil.ml-compopts
@@ -1,2 +1,2 @@
---set useBlockDist=true   --set order=128000 --set iterations=3 # stencil-blockdist
---set useStencilDist=true --set order=128000 --set iterations=3 # stencil-stencildist
+--set useBlockDist=true   --set order=128000 # stencil-blockdist
+--set useStencilDist=true --set order=128000 # stencil-stencildist

--- a/test/studies/prk/Stencil/stencil.perfcompopts
+++ b/test/studies/prk/Stencil/stencil.perfcompopts
@@ -1,3 +1,3 @@
-                          --set iterations=3 --set order=32000 # stencil-defaultdist
---set useBlockDist=true   --set iterations=3 --set order=32000 # stencil-blockdist
---set useStencilDist=true --set iterations=3 --set order=32000 # stencil-stencildist
+                          --set order=32000 # stencil-defaultdist
+--set useBlockDist=true   --set order=32000 # stencil-blockdist
+--set useStencilDist=true --set order=32000 # stencil-stencildist


### PR DESCRIPTION
These workarounds are no longer needed as of #12868

Stop limiting perf runs to 3 trials (running more used to hurt affinity
because our tasks would get more and more offset from their initial
first-touch with each trial)

Remove initializer that prevented parallel init from creating some tasks
(reverts #9231)

Closes https://github.com/chapel-lang/chapel/issues/9237