### PR TITLE
Revert #10756 ("Revert 'time mergesort in sort performance testing'")

### DIFF
--- a/test/library/packages/Sort/performance/performance.perfexecopts
+++ b/test/library/packages/Sort/performance/performance.perfexecopts
@@ -1,5 +1,6 @@
 --sorts='q' --M=24 --correctness=false            # quickSort
 --sorts='h' --M=24 --correctness=false            # heapSort
+--sorts='m' --M=24 --correctness=false            # mergeSort
 --sorts='i' --M=12 --correctness=false            # insertionSort
 --sorts='s' --M=12 --correctness=false            # selectionSort
 --sorts='b' --M=12 --correctness=false            # bubbleSort

--- a/test/library/packages/Sort/performance/sorts-linearithmic.graph
+++ b/test/library/packages/Sort/performance/sorts-linearithmic.graph
@@ -1,6 +1,6 @@
-perfkeys: (seconds):, (seconds):
-files: quickSort.dat, heapSort.dat
-graphkeys: quickSort, heapSort
+perfkeys: (seconds):, (seconds):, (seconds):
+files: quickSort.dat, heapSort.dat, mergeSort.dat
+graphkeys: quickSort, heapSort, mergeSort
 graphtitle: Linearithmic sorts on 2^24 bytes of shuffled data
 ylabel: Time (seconds)
 


### PR DESCRIPTION
This re-enables performance testing of mergesort.  @mppf thought it
should be fast enough to be worth measuring now, and a spot-check on
chap04 seems to confirm this.