### PR TITLE
Fix problem with execution limiter in Python 3.7

### DIFF
--- a/util/test/execution_limiter.py
+++ b/util/test/execution_limiter.py
@@ -48,8 +48,13 @@ class FileLock():
         try:
             os.makedirs(lock_dir)
         except OSError as e:
-            if e.errno != os.errno.EEXIST:
-                raise
+            if "errno" in os.__dict__: # Python 2
+                if e.errno != os.errno.EEXIST:
+                    raise
+            else: # Python 3
+              if not isinstance(e, FileExistsError):
+                  raise
+
         self.lock_file = os.path.join(lock_dir, lock_name)
         self.lock = filelock.FileLock(self.lock_file)
 

--- a/util/test/execution_limiter.py
+++ b/util/test/execution_limiter.py
@@ -3,6 +3,7 @@ running chpl executables """
 
 import getpass
 import os
+import errno
 import tempfile
 
 try:
@@ -48,12 +49,8 @@ class FileLock():
         try:
             os.makedirs(lock_dir)
         except OSError as e:
-            if "errno" in os.__dict__: # Python 2
-                if e.errno != os.errno.EEXIST:
-                    raise
-            else: # Python 3
-              if not isinstance(e, FileExistsError):
-                  raise
+            if e.errno != errno.EEXIST:
+                raise
 
         self.lock_file = os.path.join(lock_dir, lock_name)
         self.lock = filelock.FileLock(self.lock_file)


### PR DESCRIPTION
This is a follow-on to #12597.
That PR added a check of an OSError's errno against os.errno.EEXIST.

But in Python 3.7, os.errno is not defined. Instead, error numbers
are moved to a top-level errno module.

This PR changes it to use `import errno` which works in Python 2 and Python 3.7.

- [x] resolves start_test failure for hello on a system using Python 3.7 as python
- [x] full local testing

Reviewed by @ronawho and @ben-albrecht - thanks!