### PR TITLE
Add mandelbrot-fast.suppressif for CCE

### DIFF
--- a/test/release/examples/benchmarks/shootout/mandelbrot-fast.suppressif
+++ b/test/release/examples/benchmarks/shootout/mandelbrot-fast.suppressif
@@ -1,0 +1,4 @@
+# Starting with #12867 (denormalize the conditional in CondStmts),
+# the output differs when compiling with classic CCE. We are unclear
+# whether this is due to a bug or to numeric instability.
+CHPL_TARGET_COMPILER==cray-prgenv-cray


### PR DESCRIPTION
Starting with #12867, the output of mandelbrot-fast differs from expected
when compiling with classic CCE. We are unclear whether this is due to a bug
or to numeric instability.

Our current thinking is to suppress this test under CCE
pending further investigation, if any.