### PR TITLE
Remove some "fn returns iterator" pragmas

### DIFF
--- a/modules/internal/ChapelIteratorSupport.chpl
+++ b/modules/internal/ChapelIteratorSupport.chpl
@@ -323,32 +323,24 @@ module ChapelIteratorSupport {
   }
 
   pragma "suppress lvalue error"
-  pragma "fn returns iterator"
   pragma "no borrow convert" // e.g. iteration over tuple of owned
   // argument is const ref for e.g. for x in (someSharedThing1, someSharedThing2)
   inline proc _getIterator(const ref x) {
     return _getIterator(x.these());
   }
 
-  inline proc _getIterator(ic: _iteratorClass)
-    return ic;
-
-  pragma "fn returns iterator"
   proc _getIterator(type t) {
     return _getIterator(t.these());
   }
 
-  pragma "fn returns iterator"
   inline proc _getIteratorZip(x) {
     return _getIterator(x);
   }
 
-  pragma "fn returns iterator"
   inline proc _getIteratorZip(type t) {
     return _getIterator(t);
   }
 
-  pragma "fn returns iterator"
   inline proc _getIteratorZip(x: _tuple) {
     inline proc _getIteratorZipInternal(x: _tuple, param dim: int) {
       if dim == x.size then
@@ -362,17 +354,14 @@ module ChapelIteratorSupport {
       return _getIteratorZipInternal(x, 1);
   }
 
-  pragma "fn returns iterator"
   inline proc _getIteratorZip(type t: _tuple) {
     inline proc _getIteratorZipInternal(type t: _tuple, param dim: int) {
-      var x : t; //have to make an instance of the tuple to query the size
-
-      if dim == x.size then // dim == t.size then
+      if dim == t.size then
         return (_getIterator(t(dim)),);
       else
         return (_getIterator(t(dim)), (..._getIteratorZipInternal(t, dim+1)));
     }
-    if t == (t(1),) then // t.size == 1 then
+    if t.size == 1 then
       return _getIterator(t(1));
     else
       return _getIteratorZipInternal(t, 1);


### PR DESCRIPTION
To me, pragma "fn returns iterator" means that the function returns an _iteratorRecord. This is not the case for _getIterator(), which returns an _iteratorClass. So remove that pragma from _getIterator functions.

While there, remove _getIterator(_iteratorClass) because it is apparently unused. Also, simplify some code on type tuples because they now define `size`.

Trivial, not reviewed.
