### PR TITLE
Reduce darwin testing

### DIFF
--- a/util/cron/test-gasnet.darwin.bash
+++ b/util/cron/test-gasnet.darwin.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Test gasnet (segment everything) against full suite on darwin
+# Test gasnet (segment everything) against multilocale tests
 
 CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common-gasnet.bash
@@ -8,4 +8,4 @@ source $CWD/common-darwin.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gasnet.darwin"
 
-$CWD/nightly -cron
+$CWD/nightly -cron -multilocale

--- a/util/cron/test-gnu.darwin.bash
+++ b/util/cron/test-gnu.darwin.bash
@@ -9,4 +9,4 @@ source $CWD/common-darwin.bash
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="gnu.darwin"
 
 export CHPL_HOST_COMPILER=gnu
-$CWD/nightly -cron -examples
+$CWD/nightly -cron -hellos


### PR DESCRIPTION
Darwin testing is taking too long, so reduce some testing:
 - drop gasnet to just testing multilocale
 - drop gnu testing to just test hellos