### PR TITLE
Have nightly -multilocale run all multi-locale tests

### DIFF
--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -87,7 +87,6 @@ while (@ARGV) {
     } elsif ($flag eq "-examples") {
         $examples = 1;
     } elsif ($flag eq "-multilocale") {
-        $examples = 1;
         $multilocale = 1;
     } elsif ($flag eq "-performance") {
         $performance = 1;
@@ -199,7 +198,7 @@ if ($printusage == 1) {
     print "\t-junit-xml                     : create jUnit XML style report (default is \"on\" in Jenkins environment)\n";
     print "\t-llvm                          : run tests using --llvm\n";
     print "\t-memleaks <log>                : run memleaks tests\n";
-    print "\t-multilocale                   : run multilocale suite only\n";
+    print "\t-multilocale                   : run multilocale tests only\n";
     print "\t-no-buildcheck                 : do not run `make check` before running tests\n";
     print "\t-no-futures                    : do not run future tests\n";
     print "\t-no-local                      : run tests using --no-local\n";
@@ -575,6 +574,9 @@ if (exists($ENV{'CHPL_NIGHTLY_TEST_DIRS'})) {
     $testdirs .= " $env_test_dirs";
 }
 
+if ($multilocale == 1) {
+    $testflags = "$testflags -multilocale-only";
+}
 
 #
 # don't bother making the spec tests if we're only testing hello, world programs;
@@ -585,9 +587,6 @@ if ($examples == 1) {
     print "Making spectests\n";
     mysystem("cd $chplhomedir && $make spectests", "making spec tests", 0, 1);
     $testdirs .= " release/examples";
-    if ($multilocale == 1) {
-        $testdirs .= " multilocale distributions";
-    }
     if ($parnodefile ne "") {
         mysystem("cd $testdir && find $testdirs -wholename \"*.svn\" -prune -o -type d > DIRFILE",
                  "making directory file", 1, 1);

--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -53,7 +53,6 @@ $verify = 0;
 $retaintree = 0;
 $dist = "";
 $llvm = 0;
-$localeModelSuite = 0;
 $memleaks = "";
 $multilocale = 0;
 $svnrevopt = "";
@@ -90,11 +89,6 @@ while (@ARGV) {
     } elsif ($flag eq "-multilocale") {
         $examples = 1;
         $multilocale = 1;
-    } elsif ($flag eq "-localeModel") {
-        # TODO: Allow -localeModel to run full suite (e.g. w/o setting
-        #       $examples = 1) (thomasvandoren, 2014-02-10)
-        $examples = 1;
-        $localeModelSuite = 1;
     } elsif ($flag eq "-performance") {
         $performance = 1;
     } elsif ($flag eq "-performance-description") {
@@ -204,7 +198,6 @@ if ($printusage == 1) {
     print "\t-hellos                        : run the release/examples/hello*.chpl tests only\n";
     print "\t-junit-xml                     : create jUnit XML style report (default is \"on\" in Jenkins environment)\n";
     print "\t-llvm                          : run tests using --llvm\n";
-    print "\t-localeModel                   : run localeModel suite only\n";
     print "\t-memleaks <log>                : run memleaks tests\n";
     print "\t-multilocale                   : run multilocale suite only\n";
     print "\t-no-buildcheck                 : do not run `make check` before running tests\n";
@@ -594,13 +587,6 @@ if ($examples == 1) {
     $testdirs .= " release/examples";
     if ($multilocale == 1) {
         $testdirs .= " multilocale distributions";
-    }
-    if ($localeModelSuite == 1) {
-        if ($multilocale == 1) {
-            $testdirs .= " localeModels memory";
-        } else {
-            $testdirs .= " localeModels memory distributions/robust/arithmetic";
-        }
     }
     if ($parnodefile ne "") {
         mysystem("cd $testdir && find $testdirs -wholename \"*.svn\" -prune -o -type d > DIRFILE",

--- a/util/test/paratest.server
+++ b/util/test/paratest.server
@@ -503,7 +503,7 @@ sub find_files {
 
 
 sub print_help {
-    print "Usage: paratest.server [-compopts s] [-dirfile d] [-dirs d] [-env s] [-execopts s] [-filedist] [-futures] [-futures-only] [-logfile l] [-memleaks f] [-nodefile n] [-nodepara m] [-valgrind[exe]] [-help|-h] [-timeout t]\n";
+    print "Usage: paratest.server [-compopts s] [-dirfile d] [-dirs d] [-env s] [-execopts s] [-filedist] [-futures] [-futures-only] [-logfile l] [-memleaks f] [-multilocale-only] [-nodefile n] [-nodepara m] [-valgrind[exe]] [-help|-h] [-timeout t]\n";
     print "    -compopts s: s is a string that is passed with -compopts to start_test.\n";
     print "    -dirfile  d: d is a file listing directories to test. Default is the current diretory.\n";
     print "    -dirs     d: d is a space separated list of directories to recursively search for directories to test\n";
@@ -514,6 +514,7 @@ sub print_help {
     print "    -futures-only : only run .future tests, not regular ones.\n";
     print "    -logfile  l: l is the output log file. Default is \"user\".\"platform\".log. in the Logs subdirectory.\n";
     print "    -memleaks f: pass -memleaks to start_test; aggregate all output.\n";
+    print "    -multilocale-only: pass -multilocale-only to start_test if comm!=none\n";
     print "    -nodefile n: n is a file listing nodes to run on. Default is current node.\n";
     print "    -nodepara m: Run m paratest.client tasks on each node.\n";
     print "    -valgrind[exe]  : pass -valgrind or -valgrindexe to start_test.\n";
@@ -632,6 +633,12 @@ sub main {
             } else {
                 print "missing -memleaks arg\n";
                 exit (8);
+            }
+        } elsif (/^-multilocale-only$/) {
+            $comm = `$ENV{CHPL_HOME}/util/chplenv/chpl_comm.py`; chomp $comm;
+            if ($comm ne "none") {
+              $ENV{'CHPL_TEST_MULTILOCALE_ONLY'} = "true";
+              $extra_env = "$extra_env CHPL_TEST_MULTILOCALE_ONLY=true";
             }
         } elsif (/^-valgrind$/) {
             $valgrind = 1;


### PR DESCRIPTION
Previously, -multilocale only meant "run the examples and multilocale
dirs". This updates nightly to map `-multilocale` to `-multilocale-only`,
which will run all tests that will actually use more than 1 locale.

We dropped gasnet-darwin to just -multilocale because we're pretty
heavily oversubscribed on darwin testing, but gasnet-darwin has helped
us catch ASLR issues in the past so I don't really want to skip any
multi-locale tests there.  This also gives us better test coverage of
our other gasnet configs that aren't running the entire suite
(quickstart and numa configurations.)
