### PR TITLE
Fix some tests that fail under gasnet-numa

### DIFF
--- a/test/modules/sungeun/init/printInitCommCounts.lm-numa.good
+++ b/test/modules/sungeun/init/printInitCommCounts.lm-numa.good
@@ -1,1 +1,1 @@
-(execute_on = 4, execute_on_fast = 4, execute_on_nb = 4) (get = 25, put = 3, execute_on_fast = 6) (get = 25, put = 3, execute_on_fast = 6) (get = 25, put = 3, execute_on_fast = 6) (get = 25, put = 3, execute_on_fast = 6)
+(execute_on = 4, execute_on_fast = 4, execute_on_nb = 4) (get = 27, put = 3, execute_on_fast = 6) (get = 27, put = 3, execute_on_fast = 6) (get = 27, put = 3, execute_on_fast = 6) (get = 27, put = 3, execute_on_fast = 6)

--- a/test/studies/bale/indexgather/ig-forall-opt.lm-numa.good
+++ b/test/studies/bale/indexgather/ig-forall-opt.lm-numa.good
@@ -1,0 +1,5 @@
+ig-forall-opt.chpl:50: note: Optimized assign to be unordered
+ig-forall-opt.chpl:50: note: Optimized assign to be unordered
+ig-forall-opt.chpl:50: note: Optimized assign to be unordered
+ig-forall-opt.chpl:50: note: Optimized assign to be unordered
+57 61 4 59 74 59 67 79 11 62 32 22 74 14 9 17 20 79 3 26 70 62 23 68 46 46 28 27 33 35 69 5 45 38 75 38 21 2 40 38 24 50 36 73 71 37 23 77 30 14 68 76 17 68 27 59 42 38 26 55 1 50 13 14 16 30 39 31 30 1 46 57 15 71 12 26 32 18 35 64 57 64 12 21 62 43 9 56 21 74 42 57 42 19 55 73 2 3 76 8 43 37 52 7 51 68 30 40 35 6 73 17 34 9 31 31 73 48 67 49 25 1 5 42 27 59 47 70 59 62 4 25 29 72 6 67 0 1 4 27 71 75 52 38 63 3 45 62 58 66 77 32 66 54 18 31 48 8 16 24


### PR DESCRIPTION
Add a gasnet-numa good file for ig-forall-opt and accept worse comm
counts for printInitCommCounts. These tests aren't currently run under
nightly gasnet-numa testing, but they will be soon.