### PR TITLE
Skip old/c-ray.chpl under valgrind

### DIFF
--- a/test/exercises/c-ray/old/c-ray.skipif
+++ b/test/exercises/c-ray/old/c-ray.skipif
@@ -1,0 +1,3 @@
+# This test takes a long time to test under valgrind
+# and is unlikely to expose unique issues. Skip it there.
+CHPL_TEST_VGRND_EXE == on


### PR DESCRIPTION
This test takes a long time to test under valgrind
and is unlikely to expose unique issues.
Skip it there.

Curiously, here are the tests that took >1000s
in valgrind testing yesterday:
```
5694 exercises/c-ray/old/c-ray
2432 release/examples/benchmarks/ssca2/SSCA2_main
2336 studies/ssca2/rachels/SSCA2_test
1902 functions/iterators/angeles/checkAdvancedIters/checkAdaptiveWSIter
1131 library/packages/Sort/correctness/sortRealImag
1072 arrays/deitz/part3/test_record_of_array_type
1070 types/records/with-runtime-types
```