### PR TITLE
Change 'new C' to mean 'new owned C' rather than 'new borrowed C'

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5761,7 +5761,7 @@ static void resolveNewSetupManaged(CallExpr* newExpr, Type*& manager) {
         } else if (isUnmanagedClassType(type)) {
           manager = dtUnmanaged;
         } else if (isClass(type) && isUndecoratedClassNew(newExpr, type)) {
-          manager = dtBorrowed;
+          manager = dtOwned;
         }
       }
 

--- a/spec/Classes.tex
+++ b/spec/Classes.tex
@@ -96,12 +96,12 @@ instances, \chpl{=} and copy initialization can result in the transfer or
 sharing of ownership. See
 \\ %formatting
 \mbox{$$ $$ $$ $$ $$} %indent
-\url{https://chapel-lang.org/docs/builtins/internal/OwnedObject.html}
+\url{https://chapel-lang.org/docs/builtins/OwnedObject.html}
 \\
 and
 \\ %formatting
 \mbox{$$ $$ $$ $$ $$} %indent
-\url{https://chapel-lang.org/docs/builtins/internal/SharedObject.html}
+\url{https://chapel-lang.org/docs/builtins/SharedObject.html}
 \\
 
 When \chpl{borrowed} is used as a memory management strategy in a
@@ -220,14 +220,14 @@ The memory management strategies have the following meaning:
     See
     \\ %formatting
     \mbox{$$ $$ $$ $$ $$} %indent
-    \url{https://chapel-lang.org/docs/builtins/internal/OwnedObject.html}
+    \url{https://chapel-lang.org/docs/builtins/OwnedObject.html}
 
   \item \chpl{shared} will be deleted when all of the \chpl{shared}
     variables referring to the instance go out of scope.
     See
     \\ %formatting
     \mbox{$$ $$ $$ $$ $$} %indent
-    \url{https://chapel-lang.org/docs/builtins/internal/SharedObject.html}.
+    \url{https://chapel-lang.org/docs/builtins/SharedObject.html}.
 
   \item \chpl{borrowed} refers to a class instance that has a lifetime
     managed by another variable.
@@ -497,7 +497,7 @@ important consequences for class new expressions. In particular, suppose
 
 \begin{itemize}
 
-  \item \chpl{new C()} is the same as \chpl{new borrowed C()}
+  \item \chpl{new C()} is the same as \chpl{new owned C()}
 
   \item \chpl{new owned C()} allocates and initializes an instance that
     will be deleted at the end of the current block unless it is

--- a/spec/Input_and_Output.tex
+++ b/spec/Input_and_Output.tex
@@ -14,5 +14,5 @@ documented in the standard library documentation. See
 and
 \\ %formatting
 \mbox{$$ $$ $$ $$ $$} %indent
-\url{https://chapel-lang.org/docs/builtins/internal/ChapelIO.html}.
+\url{https://chapel-lang.org/docs/builtins/ChapelIO.html}.
 

--- a/test/classes/delete-free/default-arg-typeless.bad
+++ b/test/classes/delete-free/default-arg-typeless.bad
@@ -1,2 +1,2 @@
-default-arg-typeless.chpl:14: error: unresolved call 'bar(C)'
+default-arg-typeless.chpl:14: error: unresolved call 'bar(_owned(C))'
 default-arg-typeless.chpl:9: note: candidates are: bar(c = newC())

--- a/test/classes/delete-free/tests-from-design-overview/new-myclass.good
+++ b/test/classes/delete-free/tests-from-design-overview/new-myclass.good
@@ -4,7 +4,7 @@ in MyClass.init 3
 in MyClass.init 4
 in MyClass.init 5
 in MyClass.init 6
-MyClass
+_owned(MyClass)
 MyClass
 MyClass
 MyClass

--- a/test/classes/delete-free/undecorated-new.good
+++ b/test/classes/delete-free/undecorated-new.good
@@ -1,2 +1,2 @@
-C {}
+_owned(C) {}
 C.deinit

--- a/test/classes/ferguson/class-double-modifier.chpl
+++ b/test/classes/ferguson/class-double-modifier.chpl
@@ -37,24 +37,28 @@ proc doit4(type C)
     delete c;
 }
 
+writeln("Section 1");
 doit(unmanaged A(int));
 doit(owned A(int));
 doit(shared A(int));
 doit(borrowed A(int));
 doit(A(int));
 
+writeln("Section 2");
 doit2(unmanaged A(int));
 doit2(owned A(int));
 doit2(shared A(int));
 doit2(borrowed A(int));
 doit2(A(int));
 
+writeln("Section 3");
 doit3(unmanaged A(int));
 doit3(owned A(int));
 doit3(shared A(int));
 doit3(borrowed A(int));
 doit3(A(int));
 
+writeln("Section 4");
 doit4(unmanaged A(int));
 doit4(owned A(int));
 doit4(shared A(int));

--- a/test/classes/ferguson/class-double-modifier.good
+++ b/test/classes/ferguson/class-double-modifier.good
@@ -1,3 +1,4 @@
+Section 1
 {x = 1}
 1
 unmanaged A(int(64))
@@ -13,6 +14,7 @@ unmanaged A(int(64))
 {x = 1}
 1
 unmanaged A(int(64))
+Section 2
 {x = 2}
 2
 _owned(A(int(64)))
@@ -28,6 +30,7 @@ _owned(A(int(64)))
 {x = 2}
 2
 _owned(A(int(64)))
+Section 3
 {x = 3}
 3
 _shared(A(int(64)))
@@ -43,6 +46,7 @@ _shared(A(int(64)))
 {x = 3}
 3
 _shared(A(int(64)))
+Section 4
 {x = 4}
 4
 unmanaged A(int(64))
@@ -54,7 +58,7 @@ _owned(A(int(64)))
 _shared(A(int(64)))
 {x = 4}
 4
-A(int(64))
+_owned(A(int(64)))
 {x = 4}
 4
-A(int(64))
+_owned(A(int(64)))

--- a/test/classes/ferguson/generic-inherit5a.bad
+++ b/test/classes/ferguson/generic-inherit5a.bad
@@ -1,0 +1,3 @@
+generic-inherit5a.chpl:32: error: ambiguous call '_owned(Child(int(64),real(64))).overridden_method()'
+generic-inherit5a.chpl:7: note: candidates are: Parent.overridden_method()
+generic-inherit5a.chpl:16: note:                 Child.overridden_method()

--- a/test/classes/ferguson/generic-inherit5a.chpl
+++ b/test/classes/ferguson/generic-inherit5a.chpl
@@ -22,12 +22,12 @@ class Child : Parent {
 }
 
 writeln("Parent(int)");
-var p = new borrowed Parent(int, 1);
+var p = new owned Parent(int, 1);
 p.parent_method();
 p.overridden_method();
 
 writeln("Child(int,real)");
-var c = new borrowed Child(int, 1, real, 2.0);
+var c = new owned Child(int, 1, real, 2.0);
 c.parent_method();
 c.overridden_method();
 c.child_method();

--- a/test/classes/ferguson/generic-inherit5a.future
+++ b/test/classes/ferguson/generic-inherit5a.future
@@ -1,0 +1,2 @@
+bug: Problem with virtual dispatch and coercion from owned
+#12884 

--- a/test/classes/ferguson/generic-inherit5a.good
+++ b/test/classes/ferguson/generic-inherit5a.good
@@ -1,0 +1,10 @@
+Parent(int)
+1
+1
+Child(int,real)
+1
+12.0
+2.0
+Dynamic Child(int,real)
+1
+12.0

--- a/test/classes/lydia/staticMethodInheritance-whenField.chpl
+++ b/test/classes/lydia/staticMethodInheritance-whenField.chpl
@@ -12,8 +12,8 @@ record Wrapper {
   var x;
 }
 
-var p = new Parent();
-var c = new Child();
+var p:borrowed = new Parent();
+var c:borrowed = new Child();
 var w1 = new Wrapper(p);
 var w2 = new Wrapper(c);
 

--- a/test/errhandling/ferguson/throw-new-borrowed2.chpl
+++ b/test/errhandling/ferguson/throw-new-borrowed2.chpl
@@ -1,4 +1,4 @@
 proc main() throws {
-  var x = new Error(); // aka new borrowed Error
+  var x = new Error(); // aka new owned Error
   throw x;
 }

--- a/test/errhandling/ferguson/throw-new-borrowed2.good
+++ b/test/errhandling/ferguson/throw-new-borrowed2.good
@@ -1,2 +1,3 @@
-throw-new-borrowed2.chpl:1: In function 'main':
-throw-new-borrowed2.chpl:3: error: Throwing borrowed error - please throw owned
+uncaught Error: 
+  throw-new-borrowed2.chpl:3: thrown here
+  throw-new-borrowed2.chpl:1: uncaught here

--- a/test/library/packages/Sort/correctness/correctness.chpl
+++ b/test/library/packages/Sort/correctness/correctness.chpl
@@ -15,8 +15,8 @@ proc main() {
         tupleKey = new TupleCmp();
   const absKeyClass = new AbsKeyCmpClass(),
         absCompClass = new AbsCompCmpClass(),
-        revAbsKeyClass = new ReverseComparator(absKeyClass),
-        revAbsCompClass = new ReverseComparator(absCompClass),
+        revAbsKeyClass = new ReverseComparator(absKeyClass.borrow()),
+        revAbsCompClass = new ReverseComparator(absCompClass.borrow()),
         tupleKeyClass = new TupleCmpClass();
 
 
@@ -42,16 +42,16 @@ proc main() {
 
                 // Testing comparators
                 ([-1, 2, 3, -4], absKey),
-                ([-1, 2, 3, -4], absKeyClass),
+                ([-1, 2, 3, -4], absKeyClass.borrow()),
                 ([-1, 2, 3, -4], absComp),
-                ([-1, 2, 3, -4], absCompClass),
+                ([-1, 2, 3, -4], absCompClass.borrow()),
                 ([ 3, 2, -1, -4], reverseComparator),
                 ([ -4, 3, 2, -1], revAbsKey),
                 ([ -4, 3, 2, -1], revAbsKeyClass),
                 ([ -4, 3, 2, -1], revAbsComp),
                 ([ -4, 3, 2, -1], revAbsCompClass),
                 ([-4, -1, 2, 3], tupleKey),
-                ([-4, -1, 2, 3], tupleKeyClass)
+                ([-4, -1, 2, 3], tupleKeyClass.borrow())
               );
 
 

--- a/test/library/standard/DataFrames/DataFrames.chpl
+++ b/test/library/standard/DataFrames/DataFrames.chpl
@@ -600,7 +600,7 @@ module DataFrames {
 
     override
     proc add(rhs : Series): owned Series {
-      return rhs.uni(this, new SeriesAdd(eltType));
+      return rhs.uni(this, new borrowed SeriesAdd(eltType));
     }
 
     override
@@ -611,7 +611,7 @@ module DataFrames {
 
     override
     proc subtr(rhs): owned Series {
-      return rhs.uni(this, new SeriesSubtr(eltType));
+      return rhs.uni(this, new borrowed SeriesSubtr(eltType));
     }
 
     override
@@ -622,7 +622,7 @@ module DataFrames {
 
     override
     proc mult(rhs): owned Series {
-      return rhs.uni(this, new SeriesMult(eltType));
+      return rhs.uni(this, new borrowed SeriesMult(eltType));
     }
 
     override
@@ -633,27 +633,27 @@ module DataFrames {
 
     override
     proc lt_scalar(n): owned Series {
-      return this.map(new SeriesLessThan(n));
+      return this.map(new borrowed SeriesLessThan(n));
     }
 
     override
     proc gt_scalar(n): owned Series {
-      return this.map(new SeriesGreaterThan(n));
+      return this.map(new borrowed SeriesGreaterThan(n));
     }
 
     override
     proc eq_scalar(n): owned Series {
-      return this.map(new SeriesEqualTo(n));
+      return this.map(new borrowed SeriesEqualTo(n));
     }
 
     override
     proc lteq_scalar(n): owned Series {
-      return this.map(new SeriesLessThanEqualTo(n));
+      return this.map(new borrowed SeriesLessThanEqualTo(n));
     }
 
     override
     proc gteq_scalar(n): owned Series {
-      return this.map(new SeriesGreaterThanEqualTo(n));
+      return this.map(new borrowed SeriesGreaterThanEqualTo(n));
     }
 
     /*

--- a/test/release/examples/primers/classes.chpl
+++ b/test/release/examples/primers/classes.chpl
@@ -99,6 +99,10 @@ var own: owned C = new owned C(1, 10);
 // The instance referred to by 'own' is deleted when it is no longer in scope.
 // Only one `owned C` can refer to a given instance at a time but the
 // ownership can be transferred to another variable.
+var own2 = new C(1, 10);
+assert(own.type == own2.type);
+// The example above shows that the default behavior makes 'new C' equivalent
+// to 'new owned C'.
 
 var share: shared C = new shared C(1, 10);
 // The instance referred to by 'share' is reference counted -- that is,
@@ -119,8 +123,10 @@ var b1 = own.borrow();
 //  * use the borrow after the instance is deleted (for example if
 //    own is assigned to)
 
-// A class type without a decorator, such as ``C``, is the same
-// as ``borrowed C``. The ``this`` argument of a method is a borrow as well.
+// In most cases, a class type without a decorator, such as ``C``,
+// is the same as ``borrowed C``. The ``this`` argument of a method
+// is a borrow as well. The current exception is that ``new C`` is interpreted
+// as ``new owned C`` rather than ``new borrowed C``.
 
 // The compiler automatically adds conversion from ``owned``, ``shared``,
 // or ``unmanaged`` in the process of resolving a function call,


### PR DESCRIPTION
This PR changes the compiler to consider `new C` to be the same as `new owned C` rather than `new borrowed C` when `C` is a class type.

Having `new C` default to `new borrowed C` was chosen to make the following two statements equivalent:
``` chapel
var x = new C();
var x:C = new C();
```
It was chosen knowing that changing it to `new owned C` should have minor impact, since `owned C` coerces to `borrowed C` and the operations available on `borrowed C` are limited (e.g. you can't transfer ownership or return).

In practice, we have noticed the following cases where we would prefer for `new C` to result in an `owned C`:
 * `var x = [i in 1..3] new C(i);`
 * `record R { var field = new C(); }`
 * `proc f() { return new C(); }`
 * `throw new C()`

Treating `new C` as `new borrowed C` leads us to supporting `new borrowed C`. `new borrowed C` might be considered confusing since the meaning of `borrowed` in `new borrowed C` is not quite the same as in `var x: borrowed C`. (`new borrowed C` means to create an `owned` temporary and then borrow from it; in contrast one might view the way to create a `borrowed` value is just by borrowing from something else - and in that event it doesn't make sense to conflate it with object initialization). 

See also discussion here: https://github.com/chapel-lang/chapel/issues/8938#issuecomment-435476053

- [x] update documentation
- [x] full local testing

Reviewed by @vasslitvinov - thanks!

Future Work:
 * #12884 (bug with virtual dispatch and coercion from owned)
 * #12917 (about the meaning of undecorated class types, especially relating to type arguments)