### PR TITLE
Move RandomStream locking/unlocking into helper routines

### DIFF
--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -834,11 +834,9 @@ module Random {
         :returns: The next value in the random stream as type `resultType`.
        */
       proc getNext(type resultType=eltType): resultType {
-        if parSafe then
-          PCGRandomStreamPrivate_lock$ = true;
+        _lock();
         const result = PCGRandomStreamPrivate_getNext_noLock(resultType);
-        if parSafe then
-          PCGRandomStreamPrivate_lock$;
+        _unlock();
         return result;
       }
       /*
@@ -858,15 +856,12 @@ module Random {
 
        */
       proc getNext(min: eltType, max:eltType): eltType {
-        if parSafe then
-          PCGRandomStreamPrivate_lock$ = true;
-
+        _lock();
         if boundsChecking && min > max then
           HaltWrappers.boundsCheckHalt("Cannot generate random numbers within empty range: [" + min + ", " + max +  "]");
 
         const result = PCGRandomStreamPrivate_getNext_noLock(eltType,min,max);
-        if parSafe then
-          PCGRandomStreamPrivate_lock$;
+        _unlock();
         return result;
       }
 
@@ -875,15 +870,12 @@ module Random {
        */
       proc getNext(type resultType,
                    min: resultType, max:resultType): resultType {
-        if parSafe then
-          PCGRandomStreamPrivate_lock$ = true;
-
+        _lock();
         if boundsChecking && min > max then
           HaltWrappers.boundsCheckHalt("Cannot generate random numbers within empty range: [" + min + ", " + max + "]");
 
         const result = PCGRandomStreamPrivate_getNext_noLock(resultType,min,max);
-        if parSafe then
-          PCGRandomStreamPrivate_lock$;
+        _unlock();
         return result;
       }
 
@@ -898,11 +890,9 @@ module Random {
       proc skipToNth(n: integral) throws {
         if n <= 0 then
           throw new owned IllegalArgumentError("PCGRandomStream.skipToNth(n) called with non-positive 'n' value " + n);
-        if parSafe then
-          PCGRandomStreamPrivate_lock$ = true;
+        _lock();
         PCGRandomStreamPrivate_skipToNth_noLock(n);
-        if parSafe then
-          PCGRandomStreamPrivate_lock$;
+        _unlock();
       }
 
       /*
@@ -919,12 +909,10 @@ module Random {
       proc getNth(n: integral): eltType throws {
         if (n <= 0) then
           throw new owned IllegalArgumentError("PCGRandomStream.getNth(n) called with non-positive 'n' value " + n);
-        if parSafe then
-          PCGRandomStreamPrivate_lock$ = true;
+        _lock();
         PCGRandomStreamPrivate_skipToNth_noLock(n);
         const result = PCGRandomStreamPrivate_getNext_noLock(eltType);
-        if parSafe then
-          PCGRandomStreamPrivate_lock$;
+        _unlock();
         return result;
       }
 
@@ -987,8 +975,7 @@ module Random {
               high = D.high,
               stride = D.stride;
 
-        if parSafe then
-          PCGRandomStreamPrivate_lock$ = true;
+        _lock();
 
         // Fisher-Yates shuffle
         for i in 0..#D.size by -1 {
@@ -1017,8 +1004,7 @@ module Random {
 
         PCGRandomStreamPrivate_count += high - low;
 
-        if parSafe then
-          PCGRandomStreamPrivate_lock$;
+        _unlock();
       }
 
       /* Produce a random permutation, storing it in a 1-D array.
@@ -1034,8 +1020,7 @@ module Random {
         //if arr.domain.dim(1).stridable then
         //  compilerError("Permutation requires non-stridable 1-D array");
 
-        if parSafe then
-          PCGRandomStreamPrivate_lock$ = true;
+        _lock();
 
         for i in low..high {
           var j = randlc_bounded(arr.domain.idxType,
@@ -1048,8 +1033,7 @@ module Random {
 
         PCGRandomStreamPrivate_count += high-low;
 
-        if parSafe then
-          PCGRandomStreamPrivate_lock$;
+        _unlock();
       }
 
 
@@ -1076,13 +1060,11 @@ module Random {
        */
       pragma "fn returns iterator"
       proc iterate(D: domain, type resultType=eltType) {
-        if parSafe then
-          PCGRandomStreamPrivate_lock$ = true;
+        _lock();
         const start = PCGRandomStreamPrivate_count;
         PCGRandomStreamPrivate_count += D.numIndices.safeCast(int(64));
         PCGRandomStreamPrivate_skipToNth_noLock(PCGRandomStreamPrivate_count);
-        if parSafe then
-          PCGRandomStreamPrivate_lock$;
+        _unlock();
         return PCGRandomPrivate_iterate(resultType, D, seed, start);
       }
 
@@ -1119,7 +1101,17 @@ module Random {
 
 
       pragma "no doc"
-      var PCGRandomStreamPrivate_lock$: sync bool;
+      var PCGRandomStreamPrivate_lock$: if parSafe then sync bool else void;
+      pragma "no doc"
+      inline proc _lock() {
+        if parSafe then
+          PCGRandomStreamPrivate_lock$ = true;
+      }
+      pragma "no doc"
+      inline proc _unlock() {
+        if parSafe then
+          PCGRandomStreamPrivate_lock$;
+      }
       // up to 4 RNGs
       pragma "no doc"
       var PCGRandomStreamPrivate_rngs: numGenerators(eltType) * pcg_setseq_64_xsh_rr_32_rng;
@@ -2384,11 +2376,9 @@ module Random {
         :returns: The next value in the random stream as type :type:`eltType`.
        */
       proc getNext(): eltType {
-        if parSafe then
-          NPBRandomStreamPrivate_lock$ = true;
+        _lock();
         const result = NPBRandomStreamPrivate_getNext_noLock();
-        if parSafe then
-          NPBRandomStreamPrivate_lock$;
+        _unlock();
         return result;
       }
 
@@ -2403,11 +2393,9 @@ module Random {
       proc skipToNth(n: integral) throws {
         if n <= 0 then
           throw new owned IllegalArgumentError("NPBRandomStream.skipToNth(n) called with non-positive 'n' value " + n);
-        if parSafe then
-          NPBRandomStreamPrivate_lock$ = true;
+        _lock();
         NPBRandomStreamPrivate_skipToNth_noLock(n);
-        if parSafe then
-          NPBRandomStreamPrivate_lock$;
+        _unlock();
       }
 
       /*
@@ -2424,12 +2412,10 @@ module Random {
       proc getNth(n: integral): eltType throws {
         if (n <= 0) then
           throw new owned IllegalArgumentError("NPBRandomStream.getNth(n) called with non-positive 'n' value " + n);
-        if parSafe then
-          NPBRandomStreamPrivate_lock$ = true;
+        _lock(); 
         NPBRandomStreamPrivate_skipToNth_noLock(n);
         const result = NPBRandomStreamPrivate_getNext_noLock();
-        if parSafe then
-          NPBRandomStreamPrivate_lock$;
+        _unlock();
         return result;
       }
 
@@ -2478,13 +2464,11 @@ module Random {
        */
       pragma "fn returns iterator"
       proc iterate(D: domain, type resultType=real) {
-        if parSafe then
-          NPBRandomStreamPrivate_lock$ = true;
+        _lock();
         const start = NPBRandomStreamPrivate_count;
         NPBRandomStreamPrivate_count += D.numIndices.safeCast(int(64));
         NPBRandomStreamPrivate_skipToNth_noLock(NPBRandomStreamPrivate_count);
-        if parSafe then
-          NPBRandomStreamPrivate_lock$;
+        _unlock();
         return NPBRandomPrivate_iterate(resultType, D, seed, start);
       }
 
@@ -2520,7 +2504,17 @@ module Random {
       //
 
       pragma "no doc"
-      var NPBRandomStreamPrivate_lock$: sync bool;
+      var NPBRandomStreamPrivate_lock$: if parSafe then sync bool else void;
+      pragma "no doc"
+      inline proc _lock() {
+        if parSafe then
+          NPBRandomStreamPrivate_lock$ = true;
+      }
+      pragma "no doc"
+      inline proc _unlock() {
+        if parSafe then
+          NPBRandomStreamPrivate_lock$;
+      }
       pragma "no doc"
       var NPBRandomStreamPrivate_cursor: real = seed;
       pragma "no doc"


### PR DESCRIPTION
Move duplicated lock/unlock code into helper routines. Also make the locks void
when parSafe=false. An upcoming PR will prevent these sync locks from thwarting
RVF and it will be easier to do that when the logic is encapsulated. This also
makes it easier if we want to use atomic locks in the future or something.

Related to https://github.com/chapel-lang/chapel/issues/12920