### PR TITLE
Add missing task yield to runningTaskCount/moved-on

### DIFF
--- a/test/parallel/taskCount/runningTaskCount/moved-on.chpl
+++ b/test/parallel/taskCount/runningTaskCount/moved-on.chpl
@@ -13,7 +13,7 @@ proc main() {
       mytask();
 
       // wait for 2nd task to migrate (if it'll actually migrate)
-      if numLocales > 1 then while (here.runningTasks() != 2) { }
+      if numLocales > 1 then while (here.runningTasks() != 2) { chpl_task_yield(); }
       writeln("\n", here.runningTasks());
       on Locales[1%numLocales] do mySpin$ = true;
       barrier.barrier();


### PR DESCRIPTION
It had an atomic spinwait loop that was missing a task yield, which
could lead to deadlock.