### PR TITLE
Fix verify_setchplenv_scripts when "quickstart" is in CHPL_HOME

### DIFF
--- a/test/setchplenv/verify_setchplenv_scripts.py
+++ b/test/setchplenv/verify_setchplenv_scripts.py
@@ -153,7 +153,7 @@ class SetChplEnvTests(unittest.TestCase):
         actual_chpl_home = get_var('CHPL_HOME')
         self.assertEqual(os.stat(self.chpl_home), os.stat(actual_chpl_home))
 
-        if 'quickstart' in setchplenv_script:
+        if 'quickstart' in os.path.relpath(setchplenv_script, self.util_dir):
             self.assertEqual('none', get_var('CHPL_COMM'))
             self.assertEqual('fifo', get_var('CHPL_TASKS'))
             self.assertEqual('none', get_var('CHPL_GMP'))


### PR DESCRIPTION
This script was previously just checking `'quickstart' in script_path`,
as a way to see if we were calling the `quickstart/setchplenv.*` script.
However, this was wrong if `CHPL_HOME` contained 'quickstart', like for
our gasnet quickstart testing. Now check for 'quickstart' with `CHPL_HOME`
stripped from the script_path.