### PR TITLE
Fix an apparent type mismatch between routine and its prototype

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi-oob-sockets.c
+++ b/runtime/src/comm/ofi/comm-ofi-oob-sockets.c
@@ -85,7 +85,7 @@ void chpl_comm_ofi_oob_barrier(void) {
 }
 
 
-void chpl_comm_ofi_oob_allgather(void* const in, void* out, size_t len) {
+void chpl_comm_ofi_oob_allgather(const void* in, void* out, size_t len) {
   if (chpl_numNodes == 1) {
     chpl_memcpy(out, in, len);
   } else {


### PR DESCRIPTION
There fixes a simple mismatch between the definition of chpl_comm_ofi_oob_allgather() and its prototype.  I ran into this while trying to build (potentially non-functional) configurations of ofi last week.
