### PR TITLE
Fix multilocale/syncsingle.prediff

### DIFF
--- a/test/performance/sungeun/multilocale/syncsingle.prediff
+++ b/test/performance/sungeun/multilocale/syncsingle.prediff
@@ -1,51 +1,14 @@
 #!/usr/bin/env python
 
-import sys, os, string
+import sys
 
-origfile = sys.argv[2]
-newfile = origfile+'.'+str(os.getpid())+'.tmp'
+outfile = sys.argv[2]
 
-fo = open(origfile, 'r');
-single = fo.readline()
-sync = fo.readline()
+with open(outfile, 'r') as f:
+  lines = f.read()
 
-def fixForkCounts(fn, orig):
-    # forks on locale 4 may vary by 1 due to the begin syncing with main
-    counts = orig.split(')')
-    l4 = counts[-2].split()
-    if l4[0]=='(get':
-        forks = l4[26]
-        if forks >= '1,' and forks <= '2,':
-            forks = '2,'
-        for c in counts[0:-2]:
-            fn.write(c+')')
-        for e in l4[0:26]:
-            fn.write(' '+e)
-        fn.write(' '+forks)
-        for c in l4[27:]:
-            fn.write(' '+c)
-        fn.write(')\n')
-    else:
-        # leave the original line as is
-        fn.write(orig)
+# forks on locale 4 may vary by 1 due to the begin syncing with main
+lines = lines.replace('execute_on_fast = 1)\n', 'execute_on_fast = 2)\n')
 
-fn = open(newfile, 'w');
-if single[0:4] == '(get':
-    fixForkCounts(fn, single)
-else:
-    fn.write(single)
-if sync[0:4] == '(get':
-    fixForkCounts(fn, sync)
-else:
-    fn.write(sync)
-
-rest = fo.readlines()
-fo.close()
-
-for l in rest:
-    fn.write(l)
-fn.close()
-
-os.rename(newfile, origfile)
-
-
+with open(outfile, 'w') as f:
+  f.write(lines)


### PR DESCRIPTION
This prediff was outdated (and not doing anything) as of #7343, which
compressed 0 entries out of comm diagnostics. The prediff effectively accepts
either 1 or 2 fast-ons from the last locale, but it was really fragile before
in terms of hard coding how many spaces and parenthesis were in the comm diags
output. This wasn't a problem for a while because this test seems stable with 2
fast-ons for most configurations, but gasnet-numa seems to vary between 1 and
2, so the prediff is needed again now that we're running this test under
gn-numa. There's probably a better way to do this (have the test self-verify
the comm like some other comm-count tests do), but this was pretty simple.