### PR TITLE
Shift function definitions from zmq_helper.h to zmq_helper.c

### DIFF
--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -650,7 +650,7 @@ static void genCFileBuildRules(FILE* makefile) {
       const char* objFilename = objectFileForCFile(inputFilename);
       fprintf(makefile, "%s: %s FORCE\n", objFilename, inputFilename);
       fprintf(makefile,
-                   "\t$(CC) -c -o $@ $(GEN_CFLAGS) $(COMP_GEN_CFLAGS) $<\n");
+              "\t$(CC) -c -o $@ $(GEN_CFLAGS) $(COMP_GEN_CFLAGS) $(CHPL_RT_INC_DIR) $<\n");
       fprintf(makefile, "\n");
     }
   }

--- a/modules/packages/ZMQ.chpl
+++ b/modules/packages/ZMQ.chpl
@@ -259,7 +259,7 @@ References
 */
 module ZMQ {
 
-  require "zmq.h", "-lzmq", "ZMQHelper/zmq_helper.h";
+  require "zmq.h", "-lzmq", "ZMQHelper/zmq_helper.h", "ZMQHelper/zmq_helper.c";
 
   use Reflection;
   use ExplicitRefCount;

--- a/modules/packages/ZMQHelper/zmq_helper.c
+++ b/modules/packages/ZMQHelper/zmq_helper.c
@@ -1,0 +1,20 @@
+#include "ZMQHelper/zmq_helper.h"
+
+// Used when the option specified for zmq_getsockopt would modify a char*,
+// due to c_strings in Chapel being const char*.
+int zmq_getsockopt_string_helper(void* s, int option, const char** res) {
+  size_t len = 256;
+  char* resbuf = (char *)chpl_calloc(len, sizeof(char));
+  int err = zmq_getsockopt(s, option, resbuf, &len);
+  *res = resbuf;
+  return err;
+}
+
+// Used when the option specified for zmq_getsockopt would modify the int
+// argument.  Mostly done for symmetry, this version could likely have been
+// called directly from Chapel.
+int zmq_getsockopt_int_helper(void* s, int option, int* res) {
+  size_t intsize = sizeof(*res);
+  int err = zmq_getsockopt(s, option, res, &intsize);
+  return err;
+}

--- a/modules/packages/ZMQHelper/zmq_helper.c
+++ b/modules/packages/ZMQHelper/zmq_helper.c
@@ -1,3 +1,22 @@
+/*
+ * Copyright 2004-2019 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ * 
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * 
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "ZMQHelper/zmq_helper.h"
 
 // Used when the option specified for zmq_getsockopt would modify a char*,

--- a/modules/packages/ZMQHelper/zmq_helper.h
+++ b/modules/packages/ZMQHelper/zmq_helper.h
@@ -36,23 +36,5 @@ int zmq_getsockopt_int_helper(void* s, int option, int* res);
 // this header, which is `require`d by the ZMQ module and thus will only be
 // included when ZMQ is present.
 
-// Used when the option specified for zmq_getsockopt would modify a char*,
-// due to c_strings in Chapel being const char*.
-int zmq_getsockopt_string_helper(void* s, int option, const char** res) {
-  size_t len = 256;
-  char* resbuf = (char *)chpl_calloc(len, sizeof(char));
-  int err = zmq_getsockopt(s, option, resbuf, &len);
-  *res = resbuf;
-  return err;
-}
-
-// Used when the option specified for zmq_getsockopt would modify the int
-// argument.  Mostly done for symmetry, this version could likely have been
-// called directly from Chapel.
-int zmq_getsockopt_int_helper(void* s, int option, int* res) {
-  size_t intsize = sizeof(*res);
-  int err = zmq_getsockopt(s, option, res, &intsize);
-  return err;
-}
 
 #endif

--- a/modules/packages/ZMQHelper/zmq_helper.h
+++ b/modules/packages/ZMQHelper/zmq_helper.h
@@ -29,12 +29,4 @@
 int zmq_getsockopt_string_helper(void* s, int option, const char** res);
 int zmq_getsockopt_int_helper(void* s, int option, int* res);
 
-// Lydia NOTE 2019-02-26: the helper function implementations need to be defined
-// in a header file.  Otherwise, we would have to wrestle with how to build the
-// .c when this theoretical .c file would need to #include zmq.h and
-// we can't guarantee that will be present on a user's system.  So keep it in
-// this header, which is `require`d by the ZMQ module and thus will only be
-// included when ZMQ is present.
-
-
 #endif


### PR DESCRIPTION
Compiling a library that uses ZMQ and linking that library to another program
runs into an issue due to the .h file having function definitions instead of
just declarations.  Move the definitions into their own .c file now that the
issue with `require` statements is fixed.

As part of this effort, I discovered that caused problems for the header file
due to it using chplrt.h (for chpl_calloc).  Also allows us to compile .c files
with chplrt.h by including the runtime include directory in the make command.
(note that we didn't have problems for the .h file before because it was only
used when linking the header to the .chpl program, when chplrt.h was already
included)

Passed a full paratest with futures, and my local testing with ZMQ, as well
as CHPL_LLVM=llvm and --llvm with futures on Linux and my local testing
with ZMQ (CHPL_LLVM=system and --llvm)