### PR TITLE
Mark some functions that use syncs as RVF safe

### DIFF
--- a/modules/internal/ChapelSyncvar.chpl
+++ b/modules/internal/ChapelSyncvar.chpl
@@ -111,6 +111,7 @@ module ChapelSyncvar {
     var  wrapped : getSyncClassType(valType) = nil;
     var  isOwned : bool                      = true;
 
+    pragma "dont disable remote value forwarding"
     proc init(type valType) {
       ensureFEType(valType);
       this.valType = valType;
@@ -128,18 +129,21 @@ module ChapelSyncvar {
     //
     // ``a`` needs to be a ``valType``, not a sync.
     //
+    pragma "dont disable remote value forwarding"
     proc init(const other : _syncvar) {
       this.valType = other.valType;
       this.wrapped = other.wrapped;
       this.isOwned = false;
     }
 
+    pragma "dont disable remote value forwarding"
     proc init=(const other : this.valType) {
       this.init(other.type);
       // TODO: initialize the sync class impl with 'other'
       this.writeEF(other);
     }
 
+    pragma "dont disable remote value forwarding"
     proc deinit() {
       if isOwned == true then
         delete _to_unmanaged(wrapped);
@@ -361,12 +365,14 @@ module ChapelSyncvar {
     var  value   : valType;
     var  syncAux : chpl_sync_aux_t;      // Locking, signaling, ...
 
+    pragma "dont disable remote value forwarding"
     proc init(type valType) {
       this.valType = valType;
       this.complete();
       chpl_sync_initAux(syncAux);
     }
 
+    pragma "dont disable remote value forwarding"
     proc deinit() {
       chpl_sync_destroyAux(syncAux);
     }
@@ -500,12 +506,14 @@ module ChapelSyncvar {
 
     var  alignedValue : aligned_t;
 
+    pragma "dont disable remote value forwarding"
     proc init(type valType) {
       this.valType = valType;
       this.complete();
       qthread_purge_to(alignedValue, defaultOfAlignedT(valType));
     }
 
+    pragma "dont disable remote value forwarding"
     proc deinit() {
       // There's no explicit destroy function, but qthreads reclaims memory
       // for full variables that have no pending operations
@@ -647,17 +655,20 @@ module ChapelSyncvar {
     //
     // ``a`` needs to be a ``valType``, not a single.
     //
+    pragma "dont disable remote value forwarding"
     proc init(const other : _singlevar) {
       this.valType = other.valType;
       wrapped = other.wrapped;
       isOwned = false;
     }
 
+    pragma "dont disable remote value forwarding"
     proc init=(const other : this.type.valType) {
       this.init(other.type);
       this.writeEF(other);
     }
 
+    pragma "dont disable remote value forwarding"
     proc deinit() {
       if isOwned == true then
         delete _to_unmanaged(wrapped);

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -972,6 +972,7 @@ module DefaultRectangular {
                                               stridable);
     var RADLocks: [targetLocDom] chpl__processorAtomicType(bool); // only accessed locally
 
+    pragma "dont disable remote value forwarding"
     proc init(type eltType, param rank: int, type idxType,
               param stridable: bool, newTargetLocDom: domain(rank)) {
       this.eltType = eltType;

--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -1103,11 +1103,13 @@ module Random {
       pragma "no doc"
       var PCGRandomStreamPrivate_lock$: if parSafe then sync bool else void;
       pragma "no doc"
+      pragma "dont disable remote value forwarding"
       inline proc _lock() {
         if parSafe then
           PCGRandomStreamPrivate_lock$ = true;
       }
       pragma "no doc"
+      pragma "dont disable remote value forwarding"
       inline proc _unlock() {
         if parSafe then
           PCGRandomStreamPrivate_lock$;
@@ -2506,11 +2508,13 @@ module Random {
       pragma "no doc"
       var NPBRandomStreamPrivate_lock$: if parSafe then sync bool else void;
       pragma "no doc"
+      pragma "dont disable remote value forwarding"
       inline proc _lock() {
         if parSafe then
           NPBRandomStreamPrivate_lock$ = true;
       }
       pragma "no doc"
+      pragma "dont disable remote value forwarding"
       inline proc _unlock() {
         if parSafe then
           NPBRandomStreamPrivate_lock$;


### PR DESCRIPTION
Mark some functions that use syncs that we know don't inhibit RVF. In
particular mark:
 - sync/single init/deinit since it is sync operations and not construction
   that have synchronization semantics
 - RandomStream _lock/_unlock since we know that lock is only used internally
 - LocRadCache init, which really indirectly can result in a virtual dispatch
   that could (but won't) call assignment between 2 syncs.

This allows RVF to trigger with RandomStreams and Cyclic/Block dsiAccess.

Closes https://github.com/chapel-lang/chapel/issues/12920