### PR TITLE
Skip in-intent-for-this.chpl under --baseline

### DIFF
--- a/test/functions/vass/in-intent-for-this.skipif
+++ b/test/functions/vass/in-intent-for-this.skipif
@@ -1,3 +1,4 @@
-# This works correctly under no-local.
+# This works correctly under nolocal and --baseline.
 CHPL_COMM != none
 COMPOPTS <= --no-local
+COMPOPTS <= --baseline


### PR DESCRIPTION
This test works correctly under --baseline as well.
I did not investigate, just skip it there.