### PR TITLE
Filter out extra messages for multilocale/local/diten/test_local2

### DIFF
--- a/test/multilocale/local/diten/test_local2.prediff
+++ b/test/multilocale/local/diten/test_local2.prediff
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+
+import sys
+
+outfile = sys.argv[2]
+
+with open (outfile, 'r') as f:
+    lines = f.readlines()
+
+with open (outfile, 'w') as f:
+    for line in lines:
+        if 'error: cannot access remote data in local block' in line:
+            f.write(line)


### PR DESCRIPTION
This test has nested on-stmts and the inner one halts. We sporadically
get warnings like: `GASNET WARNING(Node 0): AMUDP_DrainNetwork(ep_t)`
`returning an error code: AM_ERR_RESOURCE` for this test. We used to get
more errors for any test that halted from a non-zero locale, but we
don't see many of those since the GASNet-EX upgrade. This test is only
one that has seen been noisy and that's probably from the nested
on-stmt. Just add a prediff to filter out any extra messages and only
look for our expected error.
