### PR TITLE
Fix alwaysRVFpragma test

### DIFF
--- a/test/optimizations/remoteValueForwarding/alwaysRVFpragma.chpl
+++ b/test/optimizations/remoteValueForwarding/alwaysRVFpragma.chpl
@@ -1,16 +1,12 @@
-class C {
-  var loc: locale = here;
-}
-
 pragma "always RVF"
 record R {
   var x: int;
-  var y = new shared C();;
+  var loc = here.id;
 }
 
 record S {
   var x: int;
-  var y = new shared C();
+  var loc = here.id;
 }
 
 proc main() {
@@ -24,21 +20,21 @@ proc main() {
   writeln();
 
   on Locales[numLocales-1] {
-    writeln("From locale ", here);
+    writeln("From locale ", here.id);
     writeln("------");
     writeln(myR);
-    writeln(myR.locale);
-    writeln(myR.x.locale);
+    writeln(myR.locale.id);
+    writeln(myR.x.locale.id);
     writeln(myS);
-    writeln(myS.locale);
-    writeln(myS.x.locale);
+    writeln(myS.locale.id);
+    writeln(myS.x.locale.id);
     writeln();
     writeln("Writing");
     writeln("-------");
     myR.x = 43;
-    myR.y = new shared C();
+    myR.loc = here.id;
     myS.x = 24;
-    myS.y = new shared C();
+    myS.loc = here.id;
     writeln(myR);
     writeln(myS);
     writeln();

--- a/test/optimizations/remoteValueForwarding/alwaysRVFpragma.comm-none.good
+++ b/test/optimizations/remoteValueForwarding/alwaysRVFpragma.comm-none.good
@@ -1,23 +1,23 @@
 Initially
 ---------
-(x = 42, y = {loc = LOCALE0})
-(x = 23, y = {loc = LOCALE0})
+(x = 42, loc = 0)
+(x = 23, loc = 0)
 
-From locale LOCALE0
+From locale 0
 ------
-(x = 42, y = {loc = LOCALE0})
-LOCALE0
-LOCALE0
-(x = 23, y = {loc = LOCALE0})
-LOCALE0
-LOCALE0
+(x = 42, loc = 0)
+0
+0
+(x = 23, loc = 0)
+0
+0
 
 Writing
 -------
-(x = 43, y = {loc = LOCALE0})
-(x = 24, y = {loc = LOCALE0})
+(x = 43, loc = 0)
+(x = 24, loc = 0)
 
 Back home
 ---------
-(x = 43, y = {loc = LOCALE0})
-(x = 24, y = {loc = LOCALE0})
+(x = 43, loc = 0)
+(x = 24, loc = 0)

--- a/test/optimizations/remoteValueForwarding/alwaysRVFpragma.comm-none.lm-numa.good
+++ b/test/optimizations/remoteValueForwarding/alwaysRVFpragma.comm-none.lm-numa.good
@@ -1,23 +1,23 @@
 Initially
 ---------
-(x = 42, y = {loc = LOCALE0})
-(x = 23, y = {loc = LOCALE0})
+(x = 42, loc = 0)
+(x = 23, loc = 0)
 
-From locale LOCALE0
+From locale 0
 ------
-(x = 42, y = {loc = LOCALE0})
-LOCALE0
-LOCALE0
-(x = 23, y = {loc = LOCALE0})
-LOCALE0
-LOCALE0
+(x = 42, loc = 0)
+0
+0
+(x = 23, loc = 0)
+0
+0
 
 Writing
 -------
-(x = 43, y = {loc = LOCALE0})
-(x = 24, y = {loc = LOCALE0})
+(x = 43, loc = 0)
+(x = 24, loc = 0)
 
 Back home
 ---------
-(x = 42, y = {loc = LOCALE0})
-(x = 24, y = {loc = LOCALE0})
+(x = 42, loc = 0)
+(x = 24, loc = 0)

--- a/test/optimizations/remoteValueForwarding/alwaysRVFpragma.good
+++ b/test/optimizations/remoteValueForwarding/alwaysRVFpragma.good
@@ -1,23 +1,23 @@
 Initially
 ---------
-(x = 42, y = {loc = LOCALE0})
-(x = 23, y = {loc = LOCALE0})
+(x = 42, loc = 0)
+(x = 23, loc = 0)
 
-From locale LOCALE1
+From locale 1
 ------
-(x = 42, y = {loc = LOCALE0})
-LOCALE1
-LOCALE1
-(x = 23, y = {loc = LOCALE0})
-LOCALE0
-LOCALE0
+(x = 42, loc = 0)
+1
+1
+(x = 23, loc = 0)
+0
+0
 
 Writing
 -------
-(x = 43, y = {loc = LOCALE1})
-(x = 24, y = {loc = LOCALE1})
+(x = 43, loc = 1)
+(x = 24, loc = 1)
 
 Back home
 ---------
-(x = 42, y = {loc = LOCALE0})
-(x = 24, y = {loc = LOCALE1})
+(x = 42, loc = 0)
+(x = 24, loc = 1)

--- a/test/optimizations/remoteValueForwarding/alwaysRVFpragma.no-local.good
+++ b/test/optimizations/remoteValueForwarding/alwaysRVFpragma.no-local.good
@@ -1,23 +1,23 @@
 Initially
 ---------
-(x = 42, y = {loc = LOCALE0})
-(x = 23, y = {loc = LOCALE0})
+(x = 42, loc = 0)
+(x = 23, loc = 0)
 
-From locale LOCALE0
+From locale 0
 ------
-(x = 42, y = {loc = LOCALE0})
-LOCALE0
-LOCALE0
-(x = 23, y = {loc = LOCALE0})
-LOCALE0
-LOCALE0
+(x = 42, loc = 0)
+0
+0
+(x = 23, loc = 0)
+0
+0
 
 Writing
 -------
-(x = 43, y = {loc = LOCALE0})
-(x = 24, y = {loc = LOCALE0})
+(x = 43, loc = 0)
+(x = 24, loc = 0)
 
 Back home
 ---------
-(x = 42, y = {loc = LOCALE0})
-(x = 24, y = {loc = LOCALE0})
+(x = 42, loc = 0)
+(x = 24, loc = 0)


### PR DESCRIPTION
This test was having troubles when run under valgrind for --no-local
or multilocale runs.  I believe that these related more to the default
serialization routines being bit copy routines and messing up the
shared class references than because of anything broken in the
implementation of the "always RVF" pragma itself.  For that reason, I
rewrote the test to preserve the kind of locality checks I'd written
the test to do, yet without the need to write serialization routines
by avoiding classes/special types.

Resolves https://github.com/Cray/chapel-private/issues/157.