### PR TITLE
Stopgap: initialize symbols considered "common" on Mac OS X.

### DIFF
--- a/runtime/src/chpl-comm-diags.c
+++ b/runtime/src/chpl-comm-diags.c
@@ -34,8 +34,8 @@
 #include <stdlib.h>
 
 
-int chpl_verbose_comm;
-int chpl_comm_diagnostics;
+int chpl_verbose_comm = 0;
+int chpl_comm_diagnostics = 0;
 
 
 void chpl_comm_startVerbose() {


### PR DESCRIPTION
Mac OS X symbol resolution seems to have resurrected a behavior I
think I recall from long ago on BSD-based systems, in which a variable
symbol which is defined without an initializer, when there is also an
'extern' declaration for it, does not create a defining instance of
that name from the linker's point of view if the object file in
question is placed in an archive.  In order for the linker to believe
there is a definition either (A) no "extern" decl can be visible at
the point of the definition which lacks an initializer, or (B) there
must be a declaration of the variable with an initializer.

Here, add initializers to 2 runtime variables to get around this for
now while I puzzle out whether we really need the "extern" decls or
not.

This resolves a build failure on Mac, with my most recent PR.