### PR TITLE
Fix spawn-popen-wait to be more robust

### DIFF
--- a/test/library/standard/Spawn/10.bash
+++ b/test/library/standard/Spawn/10.bash
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-for i in 1 2 3 4 5 6 7 8 9 10
-do
-  echo $i
-  sleep 1
-done
-

--- a/test/library/standard/Spawn/spawn-popen-wait.good
+++ b/test/library/standard/Spawn/spawn-popen-wait.good
@@ -1,10 +1,3 @@
-Got line: 1
-Got line: 2
-Got line: 3
-Got line: 4
-Got line: 5
-Got line: 6
-Got line: 7
-Got line: 8
-Got line: 9
-Got line: 10
+WaitingForThisFile
+Before
+After

--- a/test/library/standard/Spawn/waiting.bash
+++ b/test/library/standard/Spawn/waiting.bash
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+rm -f WaitingForThisFile
+echo WaitingForThisFile
+
+for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20
+do
+  echo Before
+done
+
+# Wait for the file to be created.
+# On linux, this could use inotify to not sleep,
+# but that wouldn't be portable.
+while [ ! -f WaitingForThisFile ]
+do
+  echo Waiting
+  sleep 1
+done
+
+
+for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20
+do
+  echo After
+done
+
+rm -f WaitingForThisFile


### PR DESCRIPTION
This test is trying to check that a process openned with popen is "live" -
that is that its output arrives at the spawning process before the
process quits.

It previously implemented this check with sleeps.

This commit changes it to signal the spawned process (by creating a file)
to change its output. If the popen implementation ran the subprocess to
completion immediately (say), then this test would timeout because the
subprocess waits for the signal to complete.

Note that the shell script waiting for the file still includes a sleep
(since this is apparently the portable way to do that in a shell script).
Nonetheless the test should now be robust against various forms of system
interruption.

Test change only - not reviewed.