### PR TITLE
Allow the unordered optimization to trigger for BlockDist

### DIFF
--- a/compiler/include/flags_list.h
+++ b/compiler/include/flags_list.h
@@ -328,6 +328,7 @@ symbolFlag( FLAG_RESOLVED , npr, "resolved" , "this function has been resolved" 
 symbolFlag( FLAG_RETARG, npr, "symbol is a _retArg", ncm )
 symbolFlag( FLAG_RETURNS_ALIASING_ARRAY, ypr, "fn returns aliasing array", "array alias/slice/reindex/rank change function" )
 symbolFlag( FLAG_FN_RETURNS_ITERATOR, ypr, "fn returns iterator", "proc that can return an iterator instead of promoting it to an array")
+symbolFlag( FLAG_FN_UNORDERED_SAFE, ypr, "fn unordered safe", "function does not inhibit unordered optimization")
 symbolFlag( FLAG_FN_SYNCHRONIZATION_FREE, ypr, "fn synchronization free", "function does not include any task synchronization")
 symbolFlag( FLAG_RETURNS_INFINITE_LIFETIME, ypr, "fn returns infinite lifetime", "function returns a pointer with infinite lifetime for lifetime analysis" )
 symbolFlag( FLAG_RETURN_SCOPE, npr, "return scope", "indicates an argument that can be returned without error in lifetime checking")

--- a/compiler/optimizations/optimizeForallUnorderedOps.cpp
+++ b/compiler/optimizations/optimizeForallUnorderedOps.cpp
@@ -369,7 +369,8 @@ static bool isTaskFunOrWrapper(FnSymbol* fn) {
 static MayBlockState mayBlock(FnSymbol* fn) {
   MayBlockState& state = fnMayBlock[fn];
   if (state == STATE_UNKNOWN) {
-    if (fn->hasFlag(FLAG_FN_SYNCHRONIZATION_FREE)) {
+    if (fn->hasFlag(FLAG_FN_SYNCHRONIZATION_FREE) ||
+        fn->hasFlag(FLAG_FN_UNORDERED_SAFE)) {
       state = STATE_COMPUTED;
     } else if (fn->hasFlag(FLAG_FUNCTION_TERMINATES_PROGRAM)) {
       // No need for such a function to impede optimization

--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -998,6 +998,7 @@ inline proc BlockArr.dsiAccess(const in idx: rank*idxType) ref {
   return nonLocalAccess(idx);
 }
 
+pragma "fn unordered safe"
 proc BlockArr.nonLocalAccess(i: rank*idxType) ref {
   if doRADOpt {
     if myLocArr {


### PR DESCRIPTION
The compiler analysis special cases dsiAccess as a non-blocking call,
which we need to do because otherwise the locks used for the RAD opt
indicate synchronization. However, BlockDist has a helper nonLocalAccess
method that was thwarting the analysis. Add a pragma to be able to mark
functions that are safe for the optimization and apply it to
nonLocalAccess.

A better solution might be a pragma to indicate a critical section that
denotes internal synchronization only, but this is easy for now.