### PR TITLE
Follow up on yesterday's comm diags runtime support reorganization

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -1411,14 +1411,18 @@ static void codegen_defn(std::set<const char*> & cnames, std::vector<TypeSymbol*
         SymExpr* se = toSymExpr(call->get(1));
         INT_ASSERT(se);
         SET_LINENO(call);
-        fprintf(hdrfile, "%s\n&%s",
-                ((i == 0) ? "" : ","), se->symbol()->cname);
+        fprintf(hdrfile, "%s&%s",
+                ((i == 0) ? "" : ",\n"), se->symbol()->cname);
         // To preserve operand order, this should be insertAtTail.
         // The change must also be made below (for LLVM) and in the signature
         // of chpl_comm_broadcast_private().
         call->insertAtHead(new_IntSymbol(i));
         i++;
       }
+    }
+    if (i == 0) {
+      // Quiet PGI warning about empty initializer
+      fprintf(hdrfile, "NULL");
     }
     fprintf(hdrfile, "\n};\n");
     genGlobalInt("chpl_private_broadcast_table_len", i, false);

--- a/runtime/include/chpl-comm-diags.h
+++ b/runtime/include/chpl-comm-diags.h
@@ -31,8 +31,8 @@
 // Public
 //
 
-extern int chpl_verbose_comm;     // set via startVerboseComm
-extern int chpl_comm_diagnostics; // set via startCommDiagnostics
+int chpl_verbose_comm;     // set via startVerboseComm
+int chpl_comm_diagnostics; // set via startCommDiagnostics
 
 #define CHPL_COMM_DIAGS_VARS_ALL(MACRO) \
   MACRO(get) \

--- a/runtime/include/chpl-comm-internal.h
+++ b/runtime/include/chpl-comm-internal.h
@@ -54,8 +54,11 @@ void chpl_comm_init_prv_bcast_tab(void);
 //
 // Broadcast one of our runtime-specific variables.
 //
+#define chpl_comm_bcast_rt_private(var) \
+  chpl_comm_really_bcast_rt_private(chpl_rt_prv_tab_ ## var ## _idx)
+
 static inline
-void chpl_comm_bcast_rt_private(int id) {
+void chpl_comm_really_bcast_rt_private(int id) {
   chpl_comm_broadcast_private(chpl_private_broadcast_table_len + id,
                               chpl_rt_priv_bcast_lens[id],
                               -1);

--- a/runtime/include/chplmemtrack.h
+++ b/runtime/include/chplmemtrack.h
@@ -34,9 +34,9 @@ extern "C" {
 
 
 // Memory tracking activated?
-extern chpl_bool chpl_memTrack;
+int chpl_memTrack;
 
-extern int chpl_verbose_mem;      // set via startVerboseMem
+int chpl_verbose_mem;      // set via startVerboseMem
 
 ///// These entry points support the memory tracking functions provided by
 //    MemTracking.chpl, and may also be called directly from user code (or from

--- a/runtime/src/chpl-comm-diags.c
+++ b/runtime/src/chpl-comm-diags.c
@@ -34,10 +34,6 @@
 #include <stdlib.h>
 
 
-int chpl_verbose_comm = 0;
-int chpl_comm_diagnostics = 0;
-
-
 void chpl_comm_startVerbose() {
   chpl_verbose_comm = 1;
   chpl_comm_diags_disable();

--- a/runtime/src/chpl-comm-diags.c
+++ b/runtime/src/chpl-comm-diags.c
@@ -37,7 +37,7 @@
 void chpl_comm_startVerbose() {
   chpl_verbose_comm = 1;
   chpl_comm_diags_disable();
-  chpl_comm_bcast_rt_private(chpl_rt_prv_tab_chpl_verbose_comm_idx);
+  chpl_comm_bcast_rt_private(chpl_verbose_comm);
   chpl_comm_diags_enable();
 }
 
@@ -45,7 +45,7 @@ void chpl_comm_startVerbose() {
 void chpl_comm_stopVerbose() {
   chpl_verbose_comm = 0;
   chpl_comm_diags_disable();
-  chpl_comm_bcast_rt_private(chpl_rt_prv_tab_chpl_verbose_comm_idx);
+  chpl_comm_bcast_rt_private(chpl_verbose_comm);
   chpl_comm_diags_enable();
 }
 
@@ -66,7 +66,7 @@ void chpl_comm_startDiagnostics() {
 
   chpl_comm_diagnostics = 1;
   chpl_comm_diags_disable();
-  chpl_comm_bcast_rt_private(chpl_rt_prv_tab_chpl_comm_diagnostics_idx);
+  chpl_comm_bcast_rt_private(chpl_comm_diagnostics);
   chpl_comm_diags_enable();
 }
 
@@ -77,7 +77,7 @@ void chpl_comm_stopDiagnostics() {
 
   chpl_comm_diagnostics = 0;
   chpl_comm_diags_disable();
-  chpl_comm_bcast_rt_private(chpl_rt_prv_tab_chpl_comm_diagnostics_idx);
+  chpl_comm_bcast_rt_private(chpl_comm_diagnostics);
   chpl_comm_diags_enable();
 }
 

--- a/runtime/src/chplmemtrack.c
+++ b/runtime/src/chplmemtrack.c
@@ -727,12 +727,12 @@ void chpl_track_realloc_post(void* moreMemAlloc,
 
 void chpl_startVerboseMem() {
   chpl_verbose_mem = 1;
-  chpl_comm_bcast_rt_private(chpl_rt_prv_tab_chpl_verbose_mem_idx);
+  chpl_comm_bcast_rt_private(chpl_verbose_mem);
 }
 
 void chpl_stopVerboseMem() {
   chpl_verbose_mem = 0;
-  chpl_comm_bcast_rt_private(chpl_rt_prv_tab_chpl_verbose_mem_idx);
+  chpl_comm_bcast_rt_private(chpl_verbose_mem);
 }
 
 void chpl_startVerboseMemHere() {

--- a/runtime/src/chplmemtrack.c
+++ b/runtime/src/chplmemtrack.c
@@ -44,9 +44,6 @@
 #include <inttypes.h>
 
 
-int chpl_verbose_mem;
-
-
 static void
 printMemAllocs(chpl_mem_descInt_t description, int64_t threshold,
                int32_t lineno, int32_t filename);
@@ -64,8 +61,6 @@ extern void chpl_memTracking_returnConfigVals(chpl_bool* memTrack,
                                               size_t* memThreshold,
                                               c_string* memLog,
                                               c_string* memLeaksLog);
-
-chpl_bool chpl_memTrack = false;
 
 typedef struct memTableEntry_struct { /* table entry */
   size_t number;
@@ -159,15 +154,14 @@ void chpl_setMemFlags(void) {
                                     &memLog,
                                     &memLeaksLog);
 
-  if (local_memTrack
-      || memStats
-      || memLeaksByType
-      || (memLeaksByDesc && strcmp(memLeaksByDesc, ""))
-      || memLeaks
-      || memMax > 0
-      || memLeaksLog != NULL) {
-    chpl_memTrack = true;
-  }
+  chpl_memTrack = (local_memTrack
+                   || memStats
+                   || memLeaksByType
+                   || (memLeaksByDesc && strcmp(memLeaksByDesc, ""))
+                   || memLeaks
+                   || memMax > 0
+                   || memLeaksLog != NULL);
+  
 
   if (!memLog) {
     memLogFile = stdout;


### PR DESCRIPTION
Remove the `extern` declarators on several runtime control variables.
The BSD-like 'common' semantics they create on Mac OS X causes trouble
if they don't have initializers, but adding otherwise superfluous
initializers just to solve that problem seems artificial.  Here, get rid
of both the `extern` declarators and the initializers.

Make broadcasting runtime private variables easier to look at, by
wrapping `chpl_comm_bcast_rt_private()` so that it can take just the
variable to be broadcast rather than the corresponding and potentially
quite long `chpl_rt_prv_tab_VARNAME_idx` index value.

Don't emit an empty initializer if `chpl_private_broadcast_table[]` would
otherwise have no entries in it, because the PGI compiler doesn't like
that.