### PR TITLE
Add AMOs to CommDiagnostics.

### DIFF
--- a/modules/standard/CommDiagnostics.chpl
+++ b/modules/standard/CommDiagnostics.chpl
@@ -167,6 +167,18 @@
  */
 module CommDiagnostics
 {
+  /*
+    If this is `false`, a written `commDiagnostics` value does not
+    include "unstable" fields even when they are non-zero.  Unstable
+    fields are those expected to have unpredictable values for multiple
+    executions of the same code sequence.  Setting this to `true` causes
+    such fields, if non-zero, to be included when a `commDiagnostics`
+    value is written.  At present the only unstable field is the `amo`
+    counter, whose instability is due to the use of atomic reads in spin
+    loops that wait for parallelism and on-statements to complete.
+   */
+  config param commDiagsPrintUnstable = false;
+
   /* Aggregated communication operation counts.  This record type is
      defined in the same way by both the underlying comm layer(s) and
      this module, because we don't have a good way to inherit types back
@@ -203,6 +215,10 @@ module CommDiagnostics
      */
     var try_nb: uint(64);
     /*
+      AMOs
+     */
+    var amo: uint(64);
+    /*
       blocking remote executions, in which initiator waits for completion
      */
     var execute_on: uint(64);
@@ -222,10 +238,13 @@ module CommDiagnostics
       var first = true;
       c <~> "(";
       for param i in 1..numFields(chpl_commDiagnostics) {
+        param name = getFieldName(this.type, i);
         const val = getField(this, i);
         if val != 0 {
-          if first then first = false; else c <~> ", ";
-          c <~> getFieldName(chpl_commDiagnostics, i) <~> " = " <~> val;
+          if commDiagsPrintUnstable || name != 'amo' {
+            if first then first = false; else c <~> ", ";
+            c <~> getFieldName(chpl_commDiagnostics, i) <~> " = " <~> val;
+          }
         }
       }
       if first then c <~> "<no communication>";
@@ -238,19 +257,19 @@ module CommDiagnostics
    */
   type commDiagnostics = chpl_commDiagnostics;
 
-  private extern proc chpl_comm_startVerbose();
+  private extern proc chpl_comm_startVerbose(print_unstable: bool);
 
   private extern proc chpl_comm_stopVerbose();
 
-  private extern proc chpl_comm_startVerboseHere();
+  private extern proc chpl_comm_startVerboseHere(print_unstable: bool);
 
   private extern proc chpl_comm_stopVerboseHere();
 
-  private extern proc chpl_comm_startDiagnostics();
+  private extern proc chpl_comm_startDiagnostics(print_unstable: bool);
 
   private extern proc chpl_comm_stopDiagnostics();
 
-  private extern proc chpl_comm_startDiagnosticsHere();
+  private extern proc chpl_comm_startDiagnosticsHere(print_unstable: bool);
 
   private extern proc chpl_comm_stopDiagnosticsHere();
 
@@ -261,7 +280,9 @@ module CommDiagnostics
   /*
     Start on-the-fly reporting of communication initiated on any locale.
    */
-  proc startVerboseComm() { chpl_comm_startVerbose(); }
+  proc startVerboseComm() {
+    chpl_comm_startVerbose(commDiagsPrintUnstable);
+  }
 
   /*
     Stop on-the-fly reporting of communication initiated on any locale.
@@ -271,7 +292,9 @@ module CommDiagnostics
   /*
     Start on-the-fly reporting of communication initiated on this locale.
    */
-  proc startVerboseCommHere() { chpl_comm_startVerboseHere(); }
+  proc startVerboseCommHere() {
+    chpl_comm_startVerboseHere(commDiagsPrintUnstable);
+  }
 
   /*
     Stop on-the-fly reporting of communication initiated on this locale.
@@ -282,7 +305,7 @@ module CommDiagnostics
     Start counting communication operations across the whole program.
    */
   proc startCommDiagnostics() {
-    chpl_comm_startDiagnostics();
+    chpl_comm_startDiagnostics(commDiagsPrintUnstable);
   }
 
   /*
@@ -296,7 +319,7 @@ module CommDiagnostics
     Start counting communication operations initiated on this locale.
    */
   proc startCommDiagnosticsHere() {
-    chpl_comm_startDiagnosticsHere();
+    chpl_comm_startDiagnosticsHere(commDiagsPrintUnstable);
   }
 
   /*

--- a/modules/standard/CommDiagnostics.chpl
+++ b/modules/standard/CommDiagnostics.chpl
@@ -243,7 +243,7 @@ module CommDiagnostics
         if val != 0 {
           if commDiagsPrintUnstable || name != 'amo' {
             if first then first = false; else c <~> ", ";
-            c <~> getFieldName(chpl_commDiagnostics, i) <~> " = " <~> val;
+            c <~> name <~> " = " <~> val;
           }
         }
       }

--- a/runtime/include/chpl-comm-diags.h
+++ b/runtime/include/chpl-comm-diags.h
@@ -33,6 +33,7 @@
 
 int chpl_verbose_comm;     // set via startVerboseComm
 int chpl_comm_diagnostics; // set via startCommDiagnostics
+int chpl_comm_diags_print_unstable;
 
 #define CHPL_COMM_DIAGS_VARS_ALL(MACRO) \
   MACRO(get) \
@@ -42,6 +43,7 @@ int chpl_comm_diagnostics; // set via startCommDiagnostics
   MACRO(test_nb) \
   MACRO(wait_nb) \
   MACRO(try_nb) \
+  MACRO(amo) \
   MACRO(execute_on) \
   MACRO(execute_on_fast) \
   MACRO(execute_on_nb)
@@ -52,14 +54,14 @@ typedef struct _chpl_commDiagnostics {
 #undef _COMM_DIAGS_DECL
 } chpl_commDiagnostics;
 
-void chpl_comm_startVerbose(void);
+void chpl_comm_startVerbose(chpl_bool);
 void chpl_comm_stopVerbose(void);
-void chpl_comm_startVerboseHere(void);
+void chpl_comm_startVerboseHere(chpl_bool);
 void chpl_comm_stopVerboseHere(void);
 
-void chpl_comm_startDiagnostics(void);
+void chpl_comm_startDiagnostics(chpl_bool);
 void chpl_comm_stopDiagnostics(void);
-void chpl_comm_startDiagnosticsHere(void);
+void chpl_comm_startDiagnosticsHere(chpl_bool);
 void chpl_comm_stopDiagnosticsHere(void);
 void chpl_comm_resetDiagnosticsHere(void);
 void chpl_comm_getDiagnosticsHere(chpl_commDiagnostics *cd);
@@ -119,11 +121,14 @@ int chpl_comm_diags_is_enabled(void) {
 }
 
 static inline
-void chpl_comm_diags_verbose_printf(const char*, ...)
-  __attribute__((format(printf, 1, 2)));
+void chpl_comm_diags_verbose_printf(chpl_bool, const char*, ...)
+  __attribute__((format(printf, 2, 3)));
 static inline
-void chpl_comm_diags_verbose_printf(const char* format, ...) {
-  if (chpl_verbose_comm && chpl_comm_diags_is_enabled()) {
+void chpl_comm_diags_verbose_printf(chpl_bool is_unstable,
+                                    const char* format, ...) {
+  if (chpl_verbose_comm
+      && chpl_comm_diags_is_enabled()
+      && (!is_unstable || chpl_comm_diags_print_unstable)) {
     char myFmt[100];
     snprintf(myFmt, sizeof(myFmt), "%d: %s\n", chpl_nodeID, format);
     va_list ap;
@@ -134,18 +139,26 @@ void chpl_comm_diags_verbose_printf(const char* format, ...) {
 }
 
 #define chpl_comm_diags_verbose_rdma(op, node, size, ln, fn)            \
-  chpl_comm_diags_verbose_printf("%s:%d: remote %s, "                   \
-                                 "node %d, %zu bytes",                  \
+  chpl_comm_diags_verbose_printf(false,                                 \
+                                 "%s:%d: remote %s, node %d, %zu bytes",\
                                  chpl_lookupFilename(fn), ln, op,       \
                                  (int) node, size)
 
 #define chpl_comm_diags_verbose_rdmaStrd(op, node, ln, fn)              \
-  chpl_comm_diags_verbose_printf("%s:%d: remote strided %s, node %d",   \
+  chpl_comm_diags_verbose_printf(false,                                 \
+                                 "%s:%d: remote strided %s, node %d",   \
+                                 chpl_lookupFilename(fn), ln, op,       \
+                                 (int) node)
+
+#define chpl_comm_diags_verbose_amo(op, node, ln, fn)                   \
+  chpl_comm_diags_verbose_printf(true,                                  \
+                                 "%s:%d: remote %s, node %d",           \
                                  chpl_lookupFilename(fn), ln, op,       \
                                  (int) node)
 
 #define chpl_comm_diags_verbose_executeOn(kind, node)                   \
-  chpl_comm_diags_verbose_printf("remote %-*sexecuteOn, node %d",       \
+  chpl_comm_diags_verbose_printf(false,                                 \
+                                 "remote %-*sexecuteOn, node %d",       \
                                  ((int) strlen(kind)                    \
                                   + ((strlen(kind) == 0) ? 0 : 1)),     \
                                  kind, (int) node)

--- a/runtime/include/chpl-comm-internal.h
+++ b/runtime/include/chpl-comm-internal.h
@@ -37,6 +37,7 @@ extern size_t chpl_rt_priv_bcast_lens[];
 #define CHPL_RT_PRV_BCAST_TAB_ENTRIES(MACRO) \
   MACRO(chpl_verbose_comm)                   \
   MACRO(chpl_comm_diagnostics)               \
+  MACRO(chpl_comm_diags_print_unstable)      \
   MACRO(chpl_verbose_mem)
 
 #define _RT_PRV_BCAST_M(sym)  chpl_rt_prv_tab_ ## sym ## _idx,

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -2730,6 +2730,8 @@ static inline void doAMO(c_nodeid_t, void*, const void*, const void*, void*,
                "chpl_comm_atomic_write_%s(%p, %d, %p, %d, %s)",         \
                #fnType, desired, (int) node, object,                    \
                ln, chpl_lookupFilename(fn));                            \
+    chpl_comm_diags_verbose_amo("amo write", node, ln, fn);             \
+    chpl_comm_diags_incr(amo);                                          \
     doAMO(node, object, desired, NULL, NULL,                            \
           FI_ATOMIC_WRITE, ofiType, sizeof(Type));                      \
   }
@@ -2753,6 +2755,8 @@ DEFN_CHPL_COMM_ATOMIC_WRITE(real64, FI_DOUBLE, double)
                "chpl_comm_atomic_read_%s(%p, %d, %p, %d, %s)",          \
                #fnType, result, (int) node, object,                     \
                ln, chpl_lookupFilename(fn));                            \
+    chpl_comm_diags_verbose_amo("amo read", node, ln, fn);              \
+    chpl_comm_diags_incr(amo);                                          \
     doAMO(node, object, NULL, NULL, result,                             \
           FI_ATOMIC_READ, ofiType, sizeof(Type));                       \
   }
@@ -2773,6 +2777,8 @@ DEFN_CHPL_COMM_ATOMIC_READ(real64, FI_DOUBLE, double)
                "chpl_comm_atomic_xchg_%s(%p, %d, %p, %p, %d, %s)",      \
                #fnType, desired, (int) node, object, result,            \
                ln, chpl_lookupFilename(fn));                            \
+    chpl_comm_diags_verbose_amo("amo xchg", node, ln, fn);              \
+    chpl_comm_diags_incr(amo);                                          \
     doAMO(node, object, desired, NULL, result,                          \
           FI_ATOMIC_WRITE, ofiType, sizeof(Type));                      \
   }
@@ -2795,6 +2801,8 @@ DEFN_CHPL_COMM_ATOMIC_XCHG(real64, FI_DOUBLE, double)
                "%d, %s)",                                               \
                #fnType, expected, desired, (int) node, object, result,  \
                ln, chpl_lookupFilename(fn));                            \
+    chpl_comm_diags_verbose_amo("amo cmpxchg", node, ln, fn);           \
+    chpl_comm_diags_incr(amo);                                          \
     doAMO(node, object, expected, desired, result,                      \
           FI_CSWAP, ofiType, sizeof(Type));                             \
   }
@@ -2815,6 +2823,8 @@ DEFN_CHPL_COMM_ATOMIC_CMPXCHG(real64, FI_DOUBLE, double)
                "chpl_comm_atomic_%s_%s(<%s>, %d, %p, %d, %s)",          \
                #fnOp, #fnType, DBG_VAL(operand, ofiType), (int) node,   \
                object, ln, chpl_lookupFilename(fn));                    \
+    chpl_comm_diags_verbose_amo("amo " #fnOp, node, ln, fn);            \
+    chpl_comm_diags_incr(amo);                                          \
     doAMO(node, object, operand, NULL, NULL,                            \
           ofiOp, ofiType, sizeof(Type));                                \
   }                                                                     \
@@ -2838,6 +2848,8 @@ DEFN_CHPL_COMM_ATOMIC_CMPXCHG(real64, FI_DOUBLE, double)
                "%d, %s)",                                               \
                #fnOp, #fnType, DBG_VAL(operand, ofiType), (int) node,   \
                object, result, ln, chpl_lookupFilename(fn));            \
+    chpl_comm_diags_verbose_amo("amo fetch_" #fnOp, node, ln, fn);      \
+    chpl_comm_diags_incr(amo);                                          \
     doAMO(node, object, operand, NULL, result,                          \
           ofiOp, ofiType, sizeof(Type));                                \
   }
@@ -2874,6 +2886,8 @@ DEFN_IFACE_AMO_SIMPLE_OP(add, FI_SUM, real64, FI_DOUBLE, double)
                #fnType, DBG_VAL(operand, ofiType), (int) node, object,  \
                ln, chpl_lookupFilename(fn));                            \
     Type myOpnd = negate(*(Type*) operand);                             \
+    chpl_comm_diags_verbose_amo("amo sub", node, ln, fn);               \
+    chpl_comm_diags_incr(amo);                                          \
     doAMO(node, object, &myOpnd, NULL, NULL,                            \
           FI_SUM, ofiType, sizeof(Type));                               \
   }                                                                     \
@@ -2899,6 +2913,8 @@ DEFN_IFACE_AMO_SIMPLE_OP(add, FI_SUM, real64, FI_DOUBLE, double)
                #fnType, DBG_VAL(operand, ofiType), (int) node, object,  \
                result, ln, chpl_lookupFilename(fn));                    \
     Type myOpnd = negate(*(Type*) operand);                             \
+    chpl_comm_diags_verbose_amo("amo fetch_sub", node, ln, fn);         \
+    chpl_comm_diags_incr(amo);                                          \
     doAMO(node, object, &myOpnd, NULL, result,                          \
           FI_SUM, ofiType, sizeof(Type));                               \
   }

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -6634,6 +6634,8 @@ int chpl_comm_addr_gettable(c_nodeid_t node, void* start, size_t len)
             return;                                                     \
           }                                                             \
                                                                         \
+          chpl_comm_diags_verbose_amo("amo write", loc, ln, fn);        \
+          chpl_comm_diags_incr(amo);                                    \
           if (IS_32_BIT_AMO_ON_GEMINI(_t)                               \
               || (remote_mr = mreg_for_remote_addr(obj, loc)) == NULL) {\
             if (loc == chpl_nodeID)                                     \
@@ -6698,6 +6700,8 @@ DEFINE_CHPL_COMM_ATOMIC_WRITE(real64, put_64, int_least64_t)
             return;                                                     \
           }                                                             \
                                                                         \
+          chpl_comm_diags_verbose_amo("amo read", loc, ln, fn);         \
+          chpl_comm_diags_incr(amo);                                    \
           if (IS_32_BIT_AMO_ON_GEMINI(_t)                               \
               || (remote_mr = mreg_for_remote_addr(obj, loc)) == NULL) {\
             if (loc == chpl_nodeID)                                     \
@@ -6752,6 +6756,8 @@ DEFINE_CHPL_COMM_ATOMIC_READ(real64, get_64, int_least64_t)
             return;                                                     \
           }                                                             \
                                                                         \
+          chpl_comm_diags_verbose_amo("amo xchg", loc, ln, fn);         \
+          chpl_comm_diags_incr(amo);                                    \
           if (IS_32_BIT_AMO_ON_GEMINI(_t)                               \
               || (remote_mr = mreg_for_remote_addr(obj, loc)) == NULL) {\
             if (loc == chpl_nodeID)                                     \
@@ -6816,6 +6822,8 @@ DEFINE_CHPL_COMM_ATOMIC_XCHG(real64, xchg_64, int_least64_t)
             return;                                                     \
           }                                                             \
                                                                         \
+          chpl_comm_diags_verbose_amo("amo cmpxchg", loc, ln, fn);      \
+          chpl_comm_diags_incr(amo);                                    \
           if (IS_32_BIT_AMO_ON_GEMINI(_t)                               \
               || (remote_mr = mreg_for_remote_addr(obj, loc)) == NULL) {\
             if (loc == chpl_nodeID)                                     \
@@ -6870,6 +6878,8 @@ DEFINE_CHPL_COMM_ATOMIC_CMPXCHG(real64, cmpxchg_64, int_least64_t)
             return;                                                     \
           }                                                             \
                                                                         \
+          chpl_comm_diags_verbose_amo("amo " #_o, loc, ln, fn);         \
+          chpl_comm_diags_incr(amo);                                    \
           if (IS_32_BIT_AMO_ON_GEMINI(_t)                               \
               || (remote_mr = mreg_for_remote_addr(obj, loc)) == NULL) {\
             if (loc == chpl_nodeID)                                     \
@@ -6901,6 +6911,8 @@ DEFINE_CHPL_COMM_ATOMIC_CMPXCHG(real64, cmpxchg_64, int_least64_t)
             return;                                                     \
           }                                                             \
                                                                         \
+          chpl_comm_diags_verbose_amo("amo unord_" #_o, loc, ln, fn);   \
+          chpl_comm_diags_incr(amo);                                    \
           if (IS_32_BIT_AMO_ON_GEMINI(_t)                               \
               || (remote_mr = mreg_for_remote_addr(obj, loc)) == NULL) {\
             if (loc == chpl_nodeID)                                     \
@@ -6935,6 +6947,8 @@ DEFINE_CHPL_COMM_ATOMIC_CMPXCHG(real64, cmpxchg_64, int_least64_t)
             return;                                                     \
           }                                                             \
                                                                         \
+          chpl_comm_diags_verbose_amo("amo fetch_" #_o, loc, ln, fn);   \
+          chpl_comm_diags_incr(amo);                                    \
           if (IS_32_BIT_AMO_ON_GEMINI(_t)                               \
               || (remote_mr = mreg_for_remote_addr(obj, loc)) == NULL) {\
             if (loc == chpl_nodeID)                                     \
@@ -7003,6 +7017,8 @@ DEFINE_CHPL_COMM_ATOMIC_INT_OP(uint64, add, add_i64, uint_least64_t)
             return;                                                     \
           }                                                             \
                                                                         \
+          chpl_comm_diags_verbose_amo("amo add", loc, ln, fn);          \
+          chpl_comm_diags_incr(amo);                                    \
           if (sizeof(_t) == sizeof(int_least32_t)                       \
               && nic_type == GNI_DEVICE_ARIES                           \
               && (remote_mr = mreg_for_remote_addr(obj, loc)) != NULL) {\
@@ -7034,6 +7050,8 @@ DEFINE_CHPL_COMM_ATOMIC_INT_OP(uint64, add, add_i64, uint_least64_t)
             return;                                                     \
           }                                                             \
                                                                         \
+          chpl_comm_diags_verbose_amo("amo unord_add", loc, ln, fn);    \
+          chpl_comm_diags_incr(amo);                                    \
           if (sizeof(_t) == sizeof(int_least32_t)                       \
               && nic_type == GNI_DEVICE_ARIES                           \
               && (remote_mr = mreg_for_remote_addr(obj, loc)) != NULL) {\
@@ -7067,6 +7085,8 @@ DEFINE_CHPL_COMM_ATOMIC_INT_OP(uint64, add, add_i64, uint_least64_t)
             return;                                                     \
           }                                                             \
                                                                         \
+          chpl_comm_diags_verbose_amo("amo fetch_add", loc, ln, fn);    \
+          chpl_comm_diags_incr(amo);                                    \
           if (sizeof(_t) == sizeof(int_least32_t)                       \
               && nic_type == GNI_DEVICE_ARIES                           \
               && (remote_mr = mreg_for_remote_addr(obj, loc)) != NULL) {\


### PR DESCRIPTION
We've long wanted to include atomic operations in comm diagnostics.  Do
that here.  But param-disable printing atomic op counts by default,
because those counts are unstable due to our use of network atomics when
spin-waiting for parallel construct and on-stmt completion.

This is related to #10124, but doesn't resolve that because it doesn't enable
counting AMOs by default.

(Note that we would prefer to use a config const to control whether AMO
counts are printed, at execution time instead of compile time, but
initialization order constraints prevent using a config const here.
Basically, the problem is that the CommDiagnostics is initialized before
the String module is.)