### PR TITLE
Add SKIPIF for interop/C/exportArray/arrayOpaquePointer_noArgDom

### DIFF
--- a/test/interop/C/exportArray.skipif
+++ b/test/interop/C/exportArray.skipif
@@ -1,2 +1,0 @@
-# Multi-locale libraries don't support arrays yet!
-CHPL_COMM != none

--- a/test/interop/C/exportArray.skipif
+++ b/test/interop/C/exportArray.skipif
@@ -1,0 +1,2 @@
+# Multi-locale libraries don't support arrays yet!
+CHPL_COMM != none

--- a/test/interop/C/exportArray/arrayOpaquePointer_noArgDom.skipif
+++ b/test/interop/C/exportArray/arrayOpaquePointer_noArgDom.skipif
@@ -1,0 +1,2 @@
+# Multi-locale libraries don't support this yet.
+CHPL_COMM != none


### PR DESCRIPTION
Looks like I forgot to add a SKIPIF for one of the problem tests that failed during nightly testing for gasnet.

This particular test is `interop/C/exportArray/arrayOpaquePointer_noArgDom`, and unlike other tests it fails at _compile time_ instead of with a Makefile error (finally, something intended)!

One thing I'm not sure of is whether or not we should just go ahead and blanket skip the entirety of `interop/C/exportArray` (array types aren't supported for multi-locale libraries yet).

Since I wasn't sure, I opted to just skip the single failing test.