### PR TITLE
Fix linker errors after 12950

### DIFF
--- a/runtime/include/chpl-comm-diags.h
+++ b/runtime/include/chpl-comm-diags.h
@@ -31,9 +31,9 @@
 // Public
 //
 
-int chpl_verbose_comm;     // set via startVerboseComm
-int chpl_comm_diagnostics; // set via startCommDiagnostics
-int chpl_comm_diags_print_unstable;
+extern int chpl_verbose_comm;     // set via startVerboseComm
+extern int chpl_comm_diagnostics; // set via startCommDiagnostics
+extern int chpl_comm_diags_print_unstable;
 
 #define CHPL_COMM_DIAGS_VARS_ALL(MACRO) \
   MACRO(get) \

--- a/runtime/include/chplmemtrack.h
+++ b/runtime/include/chplmemtrack.h
@@ -34,9 +34,8 @@ extern "C" {
 
 
 // Memory tracking activated?
-int chpl_memTrack;
-
-int chpl_verbose_mem;      // set via startVerboseMem
+extern int chpl_memTrack;
+extern int chpl_verbose_mem;      // set via startVerboseMem
 
 ///// These entry points support the memory tracking functions provided by
 //    MemTracking.chpl, and may also be called directly from user code (or from

--- a/runtime/src/chpl-comm-diags.c
+++ b/runtime/src/chpl-comm-diags.c
@@ -34,6 +34,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+int chpl_verbose_comm = 0;
+int chpl_comm_diagnostics = 0;
+int chpl_comm_diags_print_unstable = 0;
 
 static pthread_once_t bcastPrintUnstable_once = PTHREAD_ONCE_INIT;
 

--- a/runtime/src/chplmemtrack.c
+++ b/runtime/src/chplmemtrack.c
@@ -43,6 +43,8 @@
 #include <stdlib.h>
 #include <inttypes.h>
 
+int chpl_verbose_mem = 0;
+int chpl_memTrack = 0;
 
 static void
 printMemAllocs(chpl_mem_descInt_t description, int64_t threshold,


### PR DESCRIPTION
PR #12950 moved some runtime global variables to only declaring
them in .h files instead of using an extern declaration and then
also defining them in a .c file.

This caused testing falures with many library tests, for example
test/interop/withMain/cmain.test.c, when RE2 was enabled.

The problem PR #12950 was solving by moving these global variables
around was actually already solved by PR #12947. Therefore, this PR
goes back to the strategy from PR #12947 to fix failing tests.

- [x] make check with target compiler PrgEnv-PGI
- [x] make check on a mac
- [x] full local testing

Reviewed by @ronawho - thanks!