### PR TITLE
Create and use py3_compat.makedirs(exist_ok)

### DIFF
--- a/util/start_test
+++ b/util/start_test
@@ -19,6 +19,7 @@ import subprocess
 import sys
 import tempfile
 import time
+from test import py3_compat
 
 # need to be able to find the util and chplenv dir even when start_test
 # doesn't live in $CHPL_HOME/util (such as for the release tarball)
@@ -615,7 +616,7 @@ def check_environment_with_args():
     global logs_dir
     logs_dir = os.path.join(test_dir, "Logs")
     if not os.path.isdir(logs_dir):
-        os.makedirs(logs_dir)
+        py3_compat.makedirs(logs_dir, exist_ok=True)
     if not os.access(logs_dir, os.W_OK):
         print("Cannot write to Logs directory {0}".format(logs_dir))
         sys.exit(-1)
@@ -941,7 +942,7 @@ def set_up_performance_testing_B():
             dat_dir = comp_perf_dir
 
         if not os.path.isdir(dat_dir):
-            os.makedirs(dat_dir)
+            py3_compat.makedirs(dat_dir, exist_ok=True)
 
         sha_pef_keys_name = os.path.join(chpl_test_tmp_dir, "sha.perf_keys")
         with open(sha_pef_keys_name, "w") as shaPerfKeys:
@@ -1096,7 +1097,7 @@ def auto_generate_tests():
                 dat_dir = os.path.join(perf_dir, args.performance_description)
                 with cd(test_dir):
                     if not os.path.isdir(dat_dir):
-                        os.makedirs(dat_dir)
+                        py3_compat.makedirs(dat_dir, exist_ok=True)
 
                     logger.write("[Computing stats for spec examples]")
                     temp_perf_path = os.path.join(home,

--- a/util/test/combineCompPerfData
+++ b/util/test/combineCompPerfData
@@ -9,6 +9,7 @@
 import sys, os, os.path
 from optparse import OptionParser
 from pprint import pprint
+import py3_compat
 
 parser = OptionParser()
 parser.add_option('-t', '--tempDatDir', dest='tempDatDir',
@@ -175,7 +176,7 @@ def main():
 def writeToDatFile (datFile, perfKeys, perfValues):
     basedir = os.path.dirname(datFile)
     if not os.path.isdir(basedir):
-        os.makedirs(basedir)
+        py3_compat.makedirs(basedir, exist_ok=True)
     try:
         if os.path.exists(datFile) :
             outfile = open(datFile, 'a+')

--- a/util/test/execution_limiter.py
+++ b/util/test/execution_limiter.py
@@ -3,8 +3,8 @@ running chpl executables """
 
 import getpass
 import os
-import errno
 import tempfile
+import py3_compat
 
 try:
     import activate_chpl_test_venv
@@ -46,11 +46,7 @@ class FileLock():
     def __init__(self):
         lock_name = '{0}-chpl_program_executing'.format(getpass.getuser())
         lock_dir = os.getenv('CHPL_TEST_LIMIT_RUNNING_EXECUTABLES_DIR', tempfile.gettempdir())
-        try:
-            os.makedirs(lock_dir)
-        except OSError as e:
-            if e.errno != errno.EEXIST:
-                raise
+        py3_compat.makedirs(lock_dir, exist_ok=True)
 
         self.lock_file = os.path.join(lock_dir, lock_name)
         self.lock = filelock.FileLock(self.lock_file)

--- a/util/test/py3_compat.py
+++ b/util/test/py3_compat.py
@@ -12,6 +12,8 @@ it is pretty straightforward. A better solution might be to use six or future.
 
 import subprocess
 import sys
+import os
+import errno
 
 def instance_or_none(val, val_type):
     return val is None or isinstance(val, val_type)
@@ -67,3 +69,15 @@ class Py3CompatPopen(object):
 def Popen(*args, **kwargs):
     p = subprocess.Popen(*args, **kwargs)
     return Py3CompatPopen(p)
+
+def makedirs(path, mode=0o777, exist_ok=False):
+    if sys.version_info[0] >= 3:
+        os.makedirs(path, mode, exist_ok)
+    else:
+        try:
+            os.makedirs(path, mode)
+        except OSError as e:
+            if exist_ok and e.errno == errno.EEXIST:
+                pass # Ignore directory already existing error
+            else:
+                raise

--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -1681,13 +1681,13 @@ for testname in testsrc:
             # make the compiler performance directories if they don't exist 
             timePasses = True
             if not os.path.isdir(compperfdir) and not os.path.isfile(compperfdir):
-                os.makedirs(compperfdir)
+                py3_compat.makedirs(compperfdir, exist_ok=True)
             if not os.access(compperfdir, os.R_OK|os.X_OK):
                 sys.stdout.write('[Error creating compiler performance test directory %s]\n'%(compperfdir))
                 timePasses = False
 
             if not os.path.isdir(tempDatFilesDir) and not os.path.isfile(tempDatFilesDir):
-                os.makedirs(tempDatFilesDir)
+                py3_compat.makedirs(tempDatFilesDir, exist_ok=True)
             if not os.access(compperfdir, os.R_OK|os.X_OK):
                 sys.stdout.write('[Error creating compiler performance temp dat file test directory %s]\n'%(tempDatFilesDir))
                 timePasses = False
@@ -2165,11 +2165,7 @@ for testname in testsrc:
 
                 if perftest:
                     if not os.path.isdir(perfdir) and not os.path.isfile(perfdir):
-                        try:
-                            os.makedirs(perfdir)
-                        except OSError as e:
-                            if e.errno != errno.EEXIST:
-                                raise
+                        py3_compat.makedirs(perfdir, exist_ok=True)
                     if not os.access(perfdir, os.R_OK|os.X_OK):
                         sys.stdout.write('[Error creating performance test directory %s]\n'%(perfdir))
                         break # on to next compopts

--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -140,6 +140,7 @@ import fnmatch, time
 import re
 import shlex
 import datetime
+import errno
 
 localdir = ''
 sub_test_start_time = time.time()
@@ -2164,7 +2165,11 @@ for testname in testsrc:
 
                 if perftest:
                     if not os.path.isdir(perfdir) and not os.path.isfile(perfdir):
-                        os.makedirs(perfdir)
+                        try:
+                            os.makedirs(perfdir)
+                        except OSError as e:
+                            if e.errno != errno.EEXIST:
+                                raise
                     if not os.access(perfdir, os.R_OK|os.X_OK):
                         sys.stdout.write('[Error creating performance test directory %s]\n'%(perfdir))
                         break # on to next compopts


### PR DESCRIPTION
We have seen nightly testing error where checking if a directory existed or not and then creating it if not resulted in errors for the directory already existing. To resolve these, add a `makedirs` function to `py3_compat` that accepts an `exist_ok` argument. Then, update `os.makedirs` calls used in testing to call the new function with `exist_ok=True`. (The exist_ok argument is already available in `os.makedirs` in Python 3 so one day the py3_compat function can be removed).

- [x] hellos pass with Python 2
- [x] hellos pass with Python 3
- [x] examples/benchmarks/shootout performance tests complete with Python 2
- [x] full local testing with paratest

Reviewed by @ronawho - thanks!