### PR TITLE
skip localReads test for --fast testing

### DIFF
--- a/test/distributions/bharshbarg/stencil/localReads.skipif
+++ b/test/distributions/bharshbarg/stencil/localReads.skipif
@@ -1,0 +1,1 @@
+COMPOPTS <= --fast


### PR DESCRIPTION
[approved by @benharsh]

Due to my rework of this test to look for the OOB when slicing
with a normal domain, this test started failing on --fast due
to the lack of an OOB message.  To resolve, skip this test
for --fast testing.