### PR TITLE
Fix gcc 9 warnings

### DIFF
--- a/compiler/ifa/num.h
+++ b/compiler/ifa/num.h
@@ -317,16 +317,16 @@ IFA_EXTERN const char *num_kind_string[4][8] IFA_EXTERN_INIT(CPP_IS_LAME);
 #undef CPP_IS_LAME
 
 inline Immediate& Immediate::operator=(const Immediate& imm) {
-  memcpy(this, &imm, sizeof(imm));
+  memcpy((void*)this, &imm, sizeof(imm));
   return *this;
 }
 
 inline Immediate::Immediate(const Immediate& imm) {
-  memcpy(this, &imm, sizeof(imm));
+  memcpy((void*)this, &imm, sizeof(imm));
 }
 
 inline Immediate::Immediate() {
-  memset(this, 0, sizeof(*this));
+  memset((void*)this, 0, sizeof(*this));
 }
 
 inline unsigned int

--- a/compiler/include/vec.h
+++ b/compiler/include/vec.h
@@ -361,7 +361,7 @@ Vec<C,S>::addx() {
   }
   if (v == e) {
     v = (C*)malloc(VEC_INITIAL_SIZE * sizeof(C));
-    memcpy(v, &e[0], n * sizeof(C));
+    memcpy((void*)v, &e[0], n * sizeof(C));
   } else {
     if ((n & (VEC_INITIAL_SIZE -1)) == 0) {
       int l = n, nl = (1 + VEC_INITIAL_SHIFT);
@@ -372,8 +372,8 @@ Vec<C,S>::addx() {
         void *vv = (void*)v;
         nl = 1 << nl;
         v = (C*)malloc(nl * sizeof(C));
-        memcpy(v, vv, n * sizeof(C));
-        memset(&v[n], 0, (nl - n) * sizeof(C));
+        memcpy((void*)v, vv, n * sizeof(C));
+        memset((void*)&v[n], 0, (nl - n) * sizeof(C));
         free(vv);
       }
     }
@@ -400,7 +400,7 @@ Vec<C,S>::set_expand() {
     i = i + 1;
   n = prime2[i];
   v = (C*)malloc(n * sizeof(C));
-  memset(v, 0, n * sizeof(C));
+  memset((void*)v, 0, n * sizeof(C));
 }
 
 template <class C, int S> C *
@@ -509,8 +509,8 @@ Vec<C,S>::copy_internal(const Vec<C,S> &vv) {
   while (l) { l = l >> 1; nl++; }
   nl = 1 << nl;
   v = (C*)malloc(nl * sizeof(C));
-  memcpy(v, vv.v, n * sizeof(C));
-  memset(v + n, 0, (nl - n) * sizeof(C)); 
+  memcpy((void*)v, vv.v, n * sizeof(C));
+  memset((void*)(v + n), 0, (nl - n) * sizeof(C));
 }
 
 void test_vec();

--- a/runtime/src/chpl-file-utils.c
+++ b/runtime/src/chpl-file-utils.c
@@ -181,7 +181,7 @@ qioerr chpl_fs_is_mount(int* ret, const char* name) {
   size_t nameLen = strlen(name);
   char* parent = (char* ) chpl_mem_allocMany(nameLen + 4, sizeof(char), CHPL_RT_MD_OS_LAYER_TMP_DATA, 0, 0);
   char* safeNameCopy = (char* ) chpl_mem_allocMany(nameLen + 1, sizeof(char), CHPL_RT_MD_OS_LAYER_TMP_DATA, 0, 0);
-  strncpy(safeNameCopy, name, nameLen + 1);
+  strcpy(safeNameCopy, name);
   // Need to copy name so that we can use it in the case of links
 
   err = chpl_fs_is_link(&exitStatus, name);
@@ -214,14 +214,14 @@ qioerr chpl_fs_is_mount(int* ret, const char* name) {
       // name includes a path longer than just the current symlink.
       // Thus, we should copy up to (but not including) the basename of the
       // path.
-      strncpy(parent, curTok, strlen(curTok) + 1);
+      strcpy(parent, curTok);
       curTok = nextTok;
       nextTok = strtok(NULL, "/");
       while (nextTok != NULL) {
         // While we haven't found the end of the path (in nextTok)
-        strncat(parent, "/", 1);
+        strcat(parent, "/");
         // Restore the lost path separator.
-        strncat(parent, curTok, strlen(curTok) + 1);
+        strcat(parent, curTok);
         // Add the current token to the parent list
         curTok = nextTok;
         // And prepare to check if the next token is the last in the path
@@ -230,12 +230,12 @@ qioerr chpl_fs_is_mount(int* ret, const char* name) {
     } else {
       // name was merely the current symlink rather than a longer path.
       // That means its parent is "." or the current directory.
-      strncpy(parent, ".", 2);
+      strcpy(parent, ".");
     }
   } else {
     // We are not referring to a link, so concatenating "/.." is fine.
-    strncpy(parent, name, nameLen + 1);
-    strncat(parent, "/..", 3);
+    strcpy(parent, name);
+    strcat(parent, "/..");
     // TODO: Using "/" is not necessarily portable, look into this
   }
 


### PR DESCRIPTION
For #12965.

This PR includes 2 fixes that address warnings in GCC 9.

### Cast to void* to avoid -Werror=class-memaccess

We see warnings with GCC 9 compilers from -Werror=class-memaccess
due to memcpy/memset on a class instance pointer. This is OK for
the types we do it on (since they have no virtual dispatch tables
and are actually POD in practice) so use a cast to quiet the warning.

See also https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Dialect-Options.html
which indicates that casting to void* can quiet the warning.


### Use strcpy/strcat instead of strncpy/strncat with src length to avoid -Werror=stringop-overflow=

GCC 9 gives a warning for this code because the length supplied for
strncpy/strncat is the *source* buffer length rather than the amount of
bytes remaining in the destination buffer. See also
https://gcc.gnu.org/bugzilla/show_bug.cgi?format=multiple&id=83106
for some discussion of this warning.

Using strncpy/strncat in this way is actually just the same as using
strcpy/strcat. So, this commit changes the code to use strcpy/strcat.
This removes the warning under GCC 9.

- [x] full local testing

Reviewed by @ronawho - thanks!