### PR TITLE
Multi-locale libraries clean up after themselves when `chpl_library_finalize()` is called

### DIFF
--- a/compiler/codegen/mli.cpp
+++ b/compiler/codegen/mli.cpp
@@ -384,7 +384,7 @@ std::string MLIContext::genMarshalBodyStringC(Type* t, bool out) {
   gen += this->genSocketCall("skt", "mem_err", not out);
 
   // If error, terminate client/server.
-  gen += "if (mem_err) chpl_mli_terminate(CHPL_MLI_ERROR_MEMORY);\n";
+  gen += "if (mem_err) chpl_mli_terminate(CHPL_MLI_CODE_EMEMORY);\n";
 
   // Move the string over the wire, using length.
   gen += this->genSocketCallBuffer("skt", target, "bytes", out);
@@ -627,7 +627,7 @@ MLIContext::genServerDispatchSwitch(const std::vector<FnSymbol*>& fns) {
     gen += "break;\n";
   }
 
-  gen += "default: return CHPL_MLI_ERROR_NOFUNC; break;\n";
+  gen += "default: return CHPL_MLI_CODE_ENOFUNC; break;\n";
   gen += scope_end;
   gen += "return err;\n";
   gen += scope_end;

--- a/runtime/etc/mli/mli_client_runtime.c
+++ b/runtime/etc/mli/mli_client_runtime.c
@@ -120,12 +120,12 @@ void chpl_library_finalize(void) {
   finalized = 1;
 
   {
-    int64_t shutdown = CHPL_MLI_ERROR_SHUTDOWN;
+    int64_t shutdown = CHPL_MLI_CODE_SHUTDOWN;
     chpl_mli_push(chpl_client.main, &shutdown, sizeof(shutdown), 0);
     chpl_mli_pull(chpl_client.main, &shutdown, sizeof(shutdown), 0);
 
     // Can server ever respond with a different error?
-    if (shutdown != CHPL_MLI_ERROR_SHUTDOWN) { ;;; }
+    if (shutdown != CHPL_MLI_CODE_SHUTDOWN) { ;;; }
   }
 
   char server_output[256];

--- a/runtime/etc/mli/mli_client_runtime.c
+++ b/runtime/etc/mli/mli_client_runtime.c
@@ -119,10 +119,13 @@ void chpl_library_finalize(void) {
   if (finalized) { return; }
   finalized = 1;
 
-  // TODO: Shut down the server and handle errors.
-  if (0) {
-    int64_t shutdown = -1;
-    chpl_mli_push(chpl_client.main, &shutdown, sizeof(shutdown), 0);     
+  {
+    int64_t shutdown = CHPL_MLI_ERROR_SHUTDOWN;
+    chpl_mli_push(chpl_client.main, &shutdown, sizeof(shutdown), 0);
+    chpl_mli_pull(chpl_client.main, &shutdown, sizeof(shutdown), 0);
+
+    // Can server ever respond with a different error?
+    if (shutdown != CHPL_MLI_ERROR_SHUTDOWN) { ;;; }
   }
 
   char server_output[256];

--- a/runtime/etc/mli/mli_common_code.c
+++ b/runtime/etc/mli/mli_common_code.c
@@ -116,13 +116,13 @@
 //
 enum chpl_mli_errors {
 
-  CHPL_MLI_ERROR_NONE       = +0,
-  CHPL_MLI_ERROR_SHUTDOWN   = -1,
-  CHPL_MLI_ERROR_UNKNOWN    = -2,
-  CHPL_MLI_ERROR_NOFUNC     = -3,
-  CHPL_MLI_ERROR_SOCKET     = -4,
-  CHPL_MLI_ERROR_EXCEPT     = -5,
-  CHPL_MLI_ERROR_MEMORY     = -6
+  CHPL_MLI_CODE_NONE      = +0,
+  CHPL_MLI_CODE_SHUTDOWN  = -1,
+  CHPL_MLI_CODE_EUNKNOWN  = -2,
+  CHPL_MLI_CODE_ENOFUNC   = -3,
+  CHPL_MLI_CODE_ESOCKET   = -4,
+  CHPL_MLI_CODE_EEXCEPT   = -5,
+  CHPL_MLI_CODE_EMEMORY   = -6
 
 };
 
@@ -130,13 +130,14 @@ const char* chpl_mli_errstr(enum chpl_mli_errors e) {
   static const char* mli_errors_[] = {
     "NONE",
     "SHUTDOWN",
-    "UNKNOWN",
-    "NOFUNC",
-    "SOCKET",
-    "EXCEPT"
+    "EUNKNOWN",
+    "ENOFUNC",
+    "ESOCKET",
+    "EEXCEPT",
+    "EMEMORY"
   };
 
-  if (e > CHPL_MLI_ERROR_NONE || e < CHPL_MLI_ERROR_EXCEPT) {
+  if (e > CHPL_MLI_CODE_NONE || e < CHPL_MLI_CODE_EMEMORY) {
     return "INVALID_ERROR_CODE";
   }
 

--- a/runtime/etc/mli/mli_server_runtime.c
+++ b/runtime/etc/mli/mli_server_runtime.c
@@ -110,16 +110,16 @@ void chpl_mli_smain(void) {
     // TODO: Handle socket errors on inbound read.
     if (err < 0) {
       chpl_mli_debugf("Socket error on read: %d\n", err);
-      ack = CHPL_MLI_ERROR_SOCKET;
+      ack = CHPL_MLI_CODE_ESOCKET;
     }
 
     if (id < 0) {
       chpl_mli_debugf("Client sent error: %s\n", chpl_mli_errstr(id));
-      ack = CHPL_MLI_ERROR_SHUTDOWN;
+      ack = CHPL_MLI_CODE_SHUTDOWN;
       execute = 0;
     } else {
       chpl_mli_debugf("Received request for ID: %lld\n", id);
-      ack = CHPL_MLI_ERROR_NONE;
+      ack = CHPL_MLI_CODE_NONE;
     }
  
     chpl_mli_debugf("Responding with error: %s\n", chpl_mli_errstr(0));


### PR DESCRIPTION
This PR adds code which triggers a multi-locale Chapel server to terminate when `chpl_library_finalize()` is called on the client side.

Testing:

- [x] `ALL` on `linux64` when `CHPL_COMM=none` and `CHPL_LLVM=llvm`
- [x] `ALL` on `linux64` when `CHPL_COMM=gasnet` and `CHPL_LLVM=llvm`