### PR TITLE
Fully disable IPA when building jemalloc under cce

### DIFF
--- a/third-party/jemalloc/Makefile
+++ b/third-party/jemalloc/Makefile
@@ -18,14 +18,9 @@ CHPL_JEMALLOC_CFG_OPTIONS += --prefix=$(JEMALLOC_INSTALL_DIR) \
 			     --with-jemalloc-prefix=$(CHPL_JEMALLOC_PREFIX) \
 			     --with-private-namespace=chpl_
 
-# Can't build under CCE with high levels of interprocedural analysis on. We get
-# runtime errors with -hipa3 (the default) or higher so limit to -hipa2.
+# Can't build under CCE with interprocedural analysis or we get runtime errors
 ifeq ($(CHPL_MAKE_TARGET_COMPILER),cray-prgenv-cray)
-ifeq ($(OPTIMIZE), 1)
-CFLAGS += -hipa2
-else
 CFLAGS += -hipa0
-endif
 endif
 
 


### PR DESCRIPTION
We used to limit to just -hipa2, but recent versions of cce seem to have
trouble with that, so fully disable it.