### PR TITLE
Add per-task fences for unordered operations

### DIFF
--- a/modules/packages/UnorderedCopy.chpl
+++ b/modules/packages/UnorderedCopy.chpl
@@ -24,9 +24,9 @@
 
    This module provides an unordered version of copy/assign for ``numeric``
    types. The results from this function are not visible until task or forall
-   termination or an explicit :proc:`unorderedCopyFence()`, but it can provide
-   a significant speedup for bulk assignment operations that do not require
-   ordering of operations:
+   termination or an explicit :proc:`unorderedCopyTaskFence()`, but it can
+   provide a significant speedup for bulk assignment operations that do not
+   require ordering of operations:
 
    .. code-block:: chapel
 
@@ -48,7 +48,7 @@
 
    It's important to be aware that unordered operations are not consistent with
    regular operations and updates may not be visible until the task or forall
-   that issued them terminates or an explicit :proc:`unorderedCopyFence()`.
+   that issued them terminates or an explicit :proc:`unorderedCopyTaskFence()`.
 
    .. code-block:: chapel
 
@@ -57,7 +57,7 @@
        var b = 1;
        unorderedCopy(b, a);
        writeln(b);        // can print 0 or 1
-       unorderedCopyFence();
+       unorderedCopyTaskFence();
        writeln(b);        // must print 0
      }
 
@@ -90,6 +90,16 @@ module UnorderedCopy {
       __primitive("unordered=", dst, src);
     } else {
       __primitive("=", dst, src);
+    }
+  }
+
+  /*
+     Fence any pending unordered copies issued by the current task.
+   */
+  inline proc unorderedCopyTaskFence(): void {
+    if CHPL_COMM == 'ugni' {
+      extern proc chpl_comm_get_unordered_fence();
+      chpl_comm_get_unordered_task_fence();
     }
   }
 

--- a/test/runtime/configMatters/comm/AtomicsAPI.chpl
+++ b/test/runtime/configMatters/comm/AtomicsAPI.chpl
@@ -72,7 +72,7 @@ proc testAtomicT(a, ref i, ref b, type basetype) {
 
 proc testUnorderedAtomicT(a, ref i, ref b, type basetype) {
   use UnorderedAtomics;
-  inline proc fence() { unorderedAtomicFence(); }
+  inline proc fence() { unorderedAtomicTaskFence(); }
   param isInt = isIntegral(basetype);
 
   writeln("Testing 'atomic " + basetype:string + "':");

--- a/test/runtime/configMatters/comm/unordered/unorderedAtomicsStress.chpl
+++ b/test/runtime/configMatters/comm/unordered/unorderedAtomicsStress.chpl
@@ -15,7 +15,7 @@ coforall loc in Locales do on loc {
   coforall 1..numTasksPerLocale {
     for i in 1..iters {
       a.unorderedAdd(i);
-      if concurrentFencing then unorderedAtomicFence();
+      if concurrentFencing then unorderedAtomicTaskFence();
     }
   }
 }
@@ -25,7 +25,7 @@ coforall loc in Locales do on loc {
   coforall 1..numTasksPerLocale {
     for i in 1..iters {
       a.unorderedSub(i);
-      if concurrentFencing then unorderedAtomicFence();
+      if concurrentFencing then unorderedAtomicTaskFence();
     }
   }
 }

--- a/test/runtime/configMatters/comm/unordered/unorderedCopyBasic.chpl
+++ b/test/runtime/configMatters/comm/unordered/unorderedCopyBasic.chpl
@@ -11,7 +11,7 @@ inline proc iniDstValue() { return 0; }
 inline proc iniSrcValue() { return 1; }
 
 proc printThem(ref dst, ref src) {
-  if unordered then unorderedCopyFence();
+  if unordered then unorderedCopyTaskFence();
   write("dst=" + dst + ", src=" + src + " -- ");
 }
 

--- a/test/runtime/configMatters/comm/unordered/unorderedCopyStress.chpl
+++ b/test/runtime/configMatters/comm/unordered/unorderedCopyStress.chpl
@@ -25,7 +25,7 @@ inline proc assign(ref dst, ref src) {
                       else dst = src;
 
   if useUnorderedCopy && concurrentFencing then
-    unorderedCopyFence();
+    unorderedCopyTaskFence();
 }
 
 var t: Timer;

--- a/test/runtime/configMatters/interop/unordered-atomics.chpl
+++ b/test/runtime/configMatters/interop/unordered-atomics.chpl
@@ -14,6 +14,7 @@ config const numTrials = 10;
 var a: atomic int;
 proc addIt(p: c_void_ptr): c_void_ptr {
   a.unorderedAdd(1);
+  unorderedAtomicTaskFence();
   return c_nil;
 }
 
@@ -31,6 +32,5 @@ proc threadsAddIt(nthreads) {
 coforall loc in Locales do on loc do
   for 1..numTrials do
     threadsAddIt(numThreadsPerLocale);
-unorderedAtomicFence();
 
 assert(a.read() == numLocales * numTrials * numThreadsPerLocale);


### PR DESCRIPTION
Previously we only exposed a global fences that fences all unordered
operations across the entire machine. This is insanely heavyweight and
isn't really the API we want to expose to users. Expose per-task fences
(unorderedAtomicTaskFence() / unorderedCopyTaskFence()) as the preferred
API for fencing and in preparation for removing the global fence.

Removing the global fence will allow us to simplify the implementation
and is a prereq for https://github.com/cray/chapel-private/issues/185.
