### PR TITLE
Remove support for global unordered operation fences

### DIFF
--- a/modules/packages/UnorderedAtomics.chpl
+++ b/modules/packages/UnorderedAtomics.chpl
@@ -162,15 +162,16 @@ module UnorderedAtomics {
   }
 
   /*
-     Fence any pending unordered atomics. Note that this is a global fence
-     across all locales.
+     .. warning::
+       This function has been deprecated - please use
+       :proc:`unorderedAtomicTaskFence()` instead. Note that this function has
+       been deprecated without a full release of support because the previous
+       global fence semantics imposed expensive implementation requirements and
+       is not expected to be needed now that operations are implicitly fenced at
+       task/forall termination.
    */
   inline proc unorderedAtomicFence(): void {
-    if CHPL_NETWORK_ATOMICS != "none" {
-      extern proc chpl_comm_atomic_unordered_fence();
-      coforall loc in Locales do on loc {
-        chpl_comm_atomic_unordered_fence();
-      }
-    }
+    compilerError("unorderedAtomicFence() is no longer supported - please use unorderedAtomicTaskFence() instead");
+    unorderedAtomicTaskFence();
   }
 }

--- a/modules/packages/UnorderedCopy.chpl
+++ b/modules/packages/UnorderedCopy.chpl
@@ -104,15 +104,16 @@ module UnorderedCopy {
   }
 
   /*
-     Fence any pending unordered copies. Note that this is a global fence
-     across all locales.
-   */
+   .. warning::
+     This function has been deprecated - please use
+     :proc:`unorderedCopyTaskFence()` instead. Note that this function has
+     been deprecated without a full release of support because the previous
+     global fence semantics imposed expensive implementation requirements and
+     is not expected to be needed now that operations are implicitly fenced at
+     task/forall termination.
+  */
   inline proc unorderedCopyFence(): void {
-    if CHPL_COMM == 'ugni' {
-      extern proc chpl_comm_get_unordered_fence();
-      coforall loc in Locales do on loc {
-        chpl_comm_get_unordered_fence();
-      }
-    }
+    compilerError("unorderedCopyFence() is no longer supported - please use unorderedCopyTaskFence() instead");
+    unorderedCopyTaskFence();
   }
 }

--- a/runtime/include/chpl-comm-native-atomics.h
+++ b/runtime/include/chpl-comm-native-atomics.h
@@ -163,7 +163,6 @@ DECL_CHPL_COMM_ATOMIC_BINARY(sub, uint64)
 DECL_CHPL_COMM_ATOMIC_BINARY(sub, real32)
 DECL_CHPL_COMM_ATOMIC_BINARY(sub, real64)
 
-void chpl_comm_atomic_unordered_fence(void);
 void chpl_comm_atomic_unordered_task_fence(void);
 
 #endif // _chpl_comm_native_atomics_h_

--- a/runtime/include/comm/ugni/chpl-comm-impl.h
+++ b/runtime/include/comm/ugni/chpl-comm-impl.h
@@ -70,7 +70,6 @@ void chpl_comm_getput_unordered(c_nodeid_t dst_locale, void* dst_addr,
                                 size_t size, int32_t typeIndex,
                                 int32_t commID, int ln, int32_t fn);
 
-void chpl_comm_get_unordered_fence(void);
 void chpl_comm_get_unordered_task_fence(void);
 
 //

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -2930,11 +2930,6 @@ DEFN_IFACE_AMO_SUB(uint64, FI_UINT64, uint64_t, NEGATE_U_OR_R)
 DEFN_IFACE_AMO_SUB(real32, FI_FLOAT, float, NEGATE_U_OR_R)
 DEFN_IFACE_AMO_SUB(real64, FI_DOUBLE, double, NEGATE_U_OR_R)
 
-
-void chpl_comm_atomic_unordered_fence(void) {
-  return;
-}
-
 void chpl_comm_atomic_unordered_task_fence(void) {
   return;
 }

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -5752,10 +5752,6 @@ void chpl_comm_get_unordered(void* addr, c_nodeid_t locale, void* raddr,
   do_remote_get_buff(addr, locale, raddr, size, may_proxy_true);
 }
 
-void chpl_comm_get_unordered_fence(void) {
-  remote_get_buff_flush();
-}
-
 void chpl_comm_get_unordered_task_fence(void) {
   remote_get_buff_task_flush();
 }
@@ -7178,10 +7174,6 @@ DEFINE_CHPL_COMM_ATOMIC_SUB(real32, float, NEGATE_U_OR_R)
 DEFINE_CHPL_COMM_ATOMIC_SUB(real64, double, NEGATE_U_OR_R)
 
 #undef DEFINE_CHPL_COMM_ATOMIC_SUB
-
-void chpl_comm_atomic_unordered_fence(void) {
-  nic_amo_nf_buff_flush();
-}
 
 void chpl_comm_atomic_unordered_task_fence(void) {
   nic_amo_nf_buff_task_flush();

--- a/test/deprecated/global-unordered-fences.chpl
+++ b/test/deprecated/global-unordered-fences.chpl
@@ -1,0 +1,5 @@
+use UnorderedAtomics;
+use UnorderedCopy;
+
+unorderedAtomicFence();
+unorderedCopyFence();

--- a/test/deprecated/global-unordered-fences.compopts
+++ b/test/deprecated/global-unordered-fences.compopts
@@ -1,0 +1,1 @@
+--ignore-errors-for-pass

--- a/test/deprecated/global-unordered-fences.good
+++ b/test/deprecated/global-unordered-fences.good
@@ -1,0 +1,2 @@
+global-unordered-fences.chpl:4: error: unorderedAtomicFence() is no longer supported - please use unorderedAtomicTaskFence() instead
+global-unordered-fences.chpl:5: error: unorderedCopyFence() is no longer supported - please use unorderedCopyTaskFence() instead


### PR DESCRIPTION
A global fence effectively requires the runtime to store a list of all
threads/tasks that have initiated unordered operations. This complicates
the implementation when all users really need is a per-task fence. This
PR removes support for the global fences unorderedAtomicFence() and
unorderedCopyFence()

Normally we would keep this support for a release, but since it's not
behavior anybody would want, and unordered ops are implicitly fenced at
task termination (the common case) I don't feel so bad about removing
instead of deprecating. Additionally, unordered ops are in package
modules with explicit warnings about API instability.

Note that we originally had a global fence because the initial
implementation didn't have implicit fences at task termination so you
needed some global fence that you could call after a forall. Now that we
have implicit fences and we're trying to switch our implementation from
using thread-local storage to task-locale storage, this global fence
would prevent us from simplifying and speeding up our implementation.

Required for https://github.com/cray/chapel-private/issues/185