### PR TITLE
Add an error for bad tuple expansions

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -4516,7 +4516,8 @@ static void resolveTupleExpand(CallExpr* call) {
     INT_FATAL(call, "Invalid tuple expand primitive");
 
   if (parent != NULL && parent->primitive != NULL) {
-    if (!parent->isPrimitive(PRIM_ITERATOR_RECORD_SET_SHAPE)) {
+    if (!parent->isPrimitive(PRIM_ITERATOR_RECORD_SET_SHAPE) &&
+        !parent->isPrimitive(PRIM_NEW)) {
       USR_FATAL(parent, "illegal tuple expansion context");
     }
   }

--- a/test/types/tuple/diten/badTupleExpandInMain.chpl
+++ b/test/types/tuple/diten/badTupleExpandInMain.chpl
@@ -1,0 +1,7 @@
+proc main() {
+  // Same code. No changes.
+  var x3: 5*int = (1, 2, 3, 4, 5);
+  var y3: 5*int = (...x3); // This type is wrong.
+  writeln(y3.type:string);
+  writeln(y3);
+}

--- a/test/types/tuple/diten/badTupleExpandInMain.chpl
+++ b/test/types/tuple/diten/badTupleExpandInMain.chpl
@@ -1,5 +1,4 @@
 proc main() {
-  // Same code. No changes.
   var x3: 5*int = (1, 2, 3, 4, 5);
   var y3: 5*int = (...x3); // This type is wrong.
   writeln(y3.type:string);

--- a/test/types/tuple/diten/badTupleExpandInMain.good
+++ b/test/types/tuple/diten/badTupleExpandInMain.good
@@ -1,2 +1,2 @@
 badTupleExpandInMain.chpl:1: In function 'main':
-badTupleExpandInMain.chpl:4: error: illegal tuple expansion context
+badTupleExpandInMain.chpl:3: error: illegal tuple expansion context

--- a/test/types/tuple/diten/badTupleExpandInMain.good
+++ b/test/types/tuple/diten/badTupleExpandInMain.good
@@ -1,0 +1,2 @@
+badTupleExpandInMain.chpl:1: In function 'main':
+badTupleExpandInMain.chpl:4: error: illegal tuple expansion context

--- a/test/types/tuple/diten/tupleExpandError.chpl
+++ b/test/types/tuple/diten/tupleExpandError.chpl
@@ -1,0 +1,11 @@
+var x = (1,);
+var y = (...x);
+writeln(y);
+
+var x2 = (1, 2, 3);
+var y2 = (...x2);
+writeln(y2);
+
+var x3 = (1, 2, 3, 4, 5);
+var y3 = (...x3);
+writeln(y3);

--- a/test/types/tuple/diten/tupleExpandError.good
+++ b/test/types/tuple/diten/tupleExpandError.good
@@ -1,0 +1,1 @@
+tupleExpandError.chpl:2: error: illegal tuple expansion context


### PR DESCRIPTION
Add an error for tuple expansions that aren't being used as arguments to a
function.  All of the legal places for a tuple expansion are function calls
by this point in resolution, with two exceptions:
PRIM_NEW and PRIM_ITERATOR_RECORD_SET_SHAPE.

This will resolve #11784.