### PR TITLE
In comm=ofi, don't assert a default provider when selecting a fabric service.

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -410,12 +410,13 @@ void init_ofiFabricDomain(void) {
                    NULL, NULL, 0, hints, &ofi_info);
 
   //
-  // STOPGAP: For now, do not accept TCP-based providers.  When we try
-  //          use them we get FI_ENOCQ on the first transmit context.
-  //          I don't know why.  For the time being, just skip those.
-  //          There's no harm for now; we've never used tcp providers.
+  // STOPGAP: For now, do not accept TCP-based providers unless those
+  //          are specified explicitly.  When we try use them we get
+  //          FI_ENOCQ on the first transmit context.  I don't know why.
+  //          For the time being, just skip those.  There's no harm for
+  //          now; we've never used tcp providers in the past anyway.
   //
-  if (ret == FI_SUCCESS) {
+  if (ret == FI_SUCCESS && provider == NULL) {
     struct fi_info* info;
     for (info = ofi_info; info != NULL; info = info->next) {
       const char* pn = info->fabric_attr->prov_name;

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -1230,6 +1230,8 @@ void emit_delayedFixedHeapMsgs(void) {
 
   //
   // Warn if the size is larger than what will fit in the TLB cache.
+  // While that may reduce performance it won't affect function, though,
+  // so don't do anything dramatic like reducing the size to fit.
   //
   if (size > nic_mem_map_limit) {
     if (chpl_nodeID == 0) {

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -210,27 +210,9 @@ static network_t network = networkUnknown;
 
 static
 void init_network(void) {
-  //
-  // This file will contain a "NETWORK=ari" line on a Cray XC.
-  //
-  FILE* f;
-  if ((f = fopen("/etc/opt/cray/release/cle-release", "r")) == NULL) {
-    return;
+  if (strcmp(CHPL_TARGET_PLATFORM, "cray-xc") == 0) {
+    network = networkAries;
   }
-
-  char buf[100];
-  int networkIsAries = 0;
-  while (fgets(buf, sizeof(buf), f) != NULL && !networkIsAries) {
-    networkIsAries = (strcmp(buf, "NETWORK=ari\n") == 0);
-  }
-
-  (void) fclose(f);
-
-  if (!networkIsAries) {
-    return;
-  }
-
-  network = networkAries;
 }
 
 

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -55,7 +55,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/stat.h>
 #include <sys/uio.h> /* for struct iovec */
 #include <time.h>
 

--- a/test/studies/comd/elegant/arrayOfStructs/CoMD.skipif
+++ b/test/studies/comd/elegant/arrayOfStructs/CoMD.skipif
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
 
 # Skip this test for gasnet+mpi performance testing.
+# Also skip this test when using MPI-based launchers in other configs,
+# because mpirun barks at the fork(2) resulting from the spawn().
 import os
 
-print(os.getenv('CHPL_TEST_PERF_LABEL') == 'ml-' and
-      os.getenv('CHPL_TEST_PERF') == 'on' and
-      os.getenv('CHPL_COMM_SUBSTRATE') == 'mpi')
+print((os.getenv('CHPL_TEST_PERF_LABEL') == 'ml-' and
+       os.getenv('CHPL_TEST_PERF') == 'on' and
+       os.getenv('CHPL_COMM_SUBSTRATE') == 'mpi') or
+      os.getenv('CHPL_LAUNCHER').startswith('mpi'))


### PR DESCRIPTION
We were slightly misusing the libfabric interface: the intent in normal
usage is that users should just set hints for the capabilities they want
when calling `fi_getinfo()` and then filter on the provider, rather than
forcing the provider up front as we were doing.  Here, stop including
any provider in the hints unless the user specifies one.  However, do
adjust the hints based on what we surmise the network to be, because it
still seems as though giving additional information in that regard may
produce a better result.

Related to this, for now skip tcp providers unless they are explicitly
requested, because we get an endpoint enable error with them.  This was
likely always a problem, but we didn't see it because sockets were the
default and we never forced tcp explicitly.  So, we're not really losing
anything compared to past behavior by skipping them now.  This does need
fixing eventually, though, because tcp providers are now/soon expected
to be the ones that are the best-performing non-proprietary ones.  But
we can get them working later.

While here, augment a .skipif for a test that doesn't work with mpi-based
launchers, which I discovered while testing the main change.

This resolves https://github.com/Cray/chapel-private/issues/132.
