### PR TITLE
Even in developer mode, make assert use line number of call to assert

### DIFF
--- a/modules/standard/Assert.chpl
+++ b/modules/standard/Assert.chpl
@@ -38,6 +38,8 @@ module Assert {
   :arg test: the boolean condition
   :type test: `bool`
 */
+pragma "insert line file info"
+pragma "always propagate line file info"
 proc assert(test: bool) {
   if !test then
     __primitive("chpl_error", c"assert failed");
@@ -54,6 +56,8 @@ proc assert(test: bool) {
 
   :arg args: other arguments to print
 */
+pragma "insert line file info"
+pragma "always propagate line file info"
 proc assert(test: bool, args ...?numArgs) {
   if !test {
     var tmpstring = "assert failed - " + stringify((...args));

--- a/test/library/standard/Assert/assert-line-number.chpl
+++ b/test/library/standard/Assert/assert-line-number.chpl
@@ -1,0 +1,1 @@
+assert(false);

--- a/test/library/standard/Assert/assert-line-number.compopts
+++ b/test/library/standard/Assert/assert-line-number.compopts
@@ -1,0 +1,2 @@
+--devel
+--no-devel

--- a/test/library/standard/Assert/assert-line-number.good
+++ b/test/library/standard/Assert/assert-line-number.good
@@ -1,0 +1,1 @@
+assert-line-number.chpl:1: error: assert failed


### PR DESCRIPTION
Without this change, assert failures in programs compiled with `--developer` report
line numbers in `Assert.chpl`

Reviewed by @lydia-duncan - thanks!

- [x] full local testing