### PR TITLE
Pin Pygments to 2.3.1, due to Pygments 2.4 failing with Python 2.6.9

### DIFF
--- a/third-party/chpl-venv/chpldoc-requirements.txt
+++ b/third-party/chpl-venv/chpldoc-requirements.txt
@@ -1,6 +1,6 @@
 Jinja2==2.8
 MarkupSafe==0.23
-Pygments>=2,<3
+Pygments==2.3.1
 Sphinx==1.3.3
 docutils==0.12
 argparse==1.3.0


### PR DESCRIPTION
This will resolve our failure on XE (we don't have a cray-python module on the
XE testing machine).

This is a temporary fix.  We would like to make chpldoc require 2.7 or later in
the future, but that's going to take a bit more effort (and as such is not a good
idea before the weekend)

Verified that pinning did not cause problems with a fresh build of chpldoc