### PR TITLE
Optimize Cyclic distribution operations

### DIFF
--- a/modules/dists/CyclicDist.chpl
+++ b/modules/dists/CyclicDist.chpl
@@ -309,25 +309,8 @@ proc Cyclic.chpl__locToLocIdx(loc: locale) {
 }
 
 proc Cyclic.getChunk(inds, locid) {
-  var sliceBy: rank*range(idxType=idxType, stridable=true);
-  var locidtup: rank*idxType;
-  // NOTE: Not bothering to check to see if these can fit into idxType
-  if rank == 1 then
-    locidtup(1) = locid:idxType;
-  else
-    for param i in 1..rank do locidtup(i) = locid(i):idxType;
-  for param i in 1..rank {
-    var distStride = targetLocDom.dim(i).length:chpl__signedType(idxType);
-    var offset = chpl__diffMod(startIdx(i) + locidtup(i), inds.dim(i).low, distStride);
-    sliceBy(i) = inds.dim(i).low + offset..inds.dim(i).high by distStride;
-    // remove alignment
-    sliceBy(i).alignHigh();
-  }
-  return inds((...sliceBy));
-  //
-  // WANT:
-  //var distWhole = locDist(locid).myChunk.getIndices();
-  //return inds((...distWhole));
+  const chunk = locDist(locid).myChunk((...inds.getIndices()));
+  return chunk;
 }
 
 override proc Cyclic.dsiDisplayRepresentation() {

--- a/test/distributions/cyclic/remoteOwnership.good
+++ b/test/distributions/cyclic/remoteOwnership.good
@@ -5,45 +5,45 @@ LOCALE2 LOCALE3
 From locale 0
   locale 0 owns: {1..11 by 2, 1..11 by 2}
   locale 0 owns: {1..11 by 2, 1..11 by 2}
-  locale 1 owns: {1..11 by 2, 2..10 by 2}
-  locale 1 owns: {1..11 by 2, 2..10 by 2}
-  locale 2 owns: {2..10 by 2, 1..11 by 2}
-  locale 2 owns: {2..10 by 2, 1..11 by 2}
-  locale 3 owns: {2..10 by 2, 2..10 by 2}
-  locale 3 owns: {2..10 by 2, 2..10 by 2}
+  locale 1 owns: {1..11 by 2, 1..11 by 2 align 0}
+  locale 1 owns: {1..11 by 2, 1..11 by 2 align 0}
+  locale 2 owns: {1..11 by 2 align 0, 1..11 by 2}
+  locale 2 owns: {1..11 by 2 align 0, 1..11 by 2}
+  locale 3 owns: {1..11 by 2 align 0, 1..11 by 2 align 0}
+  locale 3 owns: {1..11 by 2 align 0, 1..11 by 2 align 0}
 (<no communication>)
 
 From locale 1
   locale 0 owns: {1..11 by 2, 1..11 by 2}
   locale 0 owns: {1..11 by 2, 1..11 by 2}
-  locale 1 owns: {1..11 by 2, 2..10 by 2}
-  locale 1 owns: {1..11 by 2, 2..10 by 2}
-  locale 2 owns: {2..10 by 2, 1..11 by 2}
-  locale 2 owns: {2..10 by 2, 1..11 by 2}
-  locale 3 owns: {2..10 by 2, 2..10 by 2}
-  locale 3 owns: {2..10 by 2, 2..10 by 2}
+  locale 1 owns: {1..11 by 2, 1..11 by 2 align 0}
+  locale 1 owns: {1..11 by 2, 1..11 by 2 align 0}
+  locale 2 owns: {1..11 by 2 align 0, 1..11 by 2}
+  locale 2 owns: {1..11 by 2 align 0, 1..11 by 2}
+  locale 3 owns: {1..11 by 2 align 0, 1..11 by 2 align 0}
+  locale 3 owns: {1..11 by 2 align 0, 1..11 by 2 align 0}
 (<no communication>)
 
 From locale 2
   locale 0 owns: {1..11 by 2, 1..11 by 2}
   locale 0 owns: {1..11 by 2, 1..11 by 2}
-  locale 1 owns: {1..11 by 2, 2..10 by 2}
-  locale 1 owns: {1..11 by 2, 2..10 by 2}
-  locale 2 owns: {2..10 by 2, 1..11 by 2}
-  locale 2 owns: {2..10 by 2, 1..11 by 2}
-  locale 3 owns: {2..10 by 2, 2..10 by 2}
-  locale 3 owns: {2..10 by 2, 2..10 by 2}
+  locale 1 owns: {1..11 by 2, 1..11 by 2 align 0}
+  locale 1 owns: {1..11 by 2, 1..11 by 2 align 0}
+  locale 2 owns: {1..11 by 2 align 0, 1..11 by 2}
+  locale 2 owns: {1..11 by 2 align 0, 1..11 by 2}
+  locale 3 owns: {1..11 by 2 align 0, 1..11 by 2 align 0}
+  locale 3 owns: {1..11 by 2 align 0, 1..11 by 2 align 0}
 (<no communication>)
 
 From locale 3
   locale 0 owns: {1..11 by 2, 1..11 by 2}
   locale 0 owns: {1..11 by 2, 1..11 by 2}
-  locale 1 owns: {1..11 by 2, 2..10 by 2}
-  locale 1 owns: {1..11 by 2, 2..10 by 2}
-  locale 2 owns: {2..10 by 2, 1..11 by 2}
-  locale 2 owns: {2..10 by 2, 1..11 by 2}
-  locale 3 owns: {2..10 by 2, 2..10 by 2}
-  locale 3 owns: {2..10 by 2, 2..10 by 2}
+  locale 1 owns: {1..11 by 2, 1..11 by 2 align 0}
+  locale 1 owns: {1..11 by 2, 1..11 by 2 align 0}
+  locale 2 owns: {1..11 by 2 align 0, 1..11 by 2}
+  locale 2 owns: {1..11 by 2 align 0, 1..11 by 2}
+  locale 3 owns: {1..11 by 2 align 0, 1..11 by 2 align 0}
+  locale 3 owns: {1..11 by 2 align 0, 1..11 by 2 align 0}
 (<no communication>)
 
 
@@ -51,45 +51,45 @@ Testing array A (declared over D):
 From locale 0
   locale 0 owns: {1..11 by 2, 1..11 by 2}
   locale 0 owns: {1..11 by 2, 1..11 by 2}
-  locale 1 owns: {1..11 by 2, 2..10 by 2}
-  locale 1 owns: {1..11 by 2, 2..10 by 2}
-  locale 2 owns: {2..10 by 2, 1..11 by 2}
-  locale 2 owns: {2..10 by 2, 1..11 by 2}
-  locale 3 owns: {2..10 by 2, 2..10 by 2}
-  locale 3 owns: {2..10 by 2, 2..10 by 2}
+  locale 1 owns: {1..11 by 2, 1..11 by 2 align 0}
+  locale 1 owns: {1..11 by 2, 1..11 by 2 align 0}
+  locale 2 owns: {1..11 by 2 align 0, 1..11 by 2}
+  locale 2 owns: {1..11 by 2 align 0, 1..11 by 2}
+  locale 3 owns: {1..11 by 2 align 0, 1..11 by 2 align 0}
+  locale 3 owns: {1..11 by 2 align 0, 1..11 by 2 align 0}
 (<no communication>)
 
 From locale 1
   locale 0 owns: {1..11 by 2, 1..11 by 2}
   locale 0 owns: {1..11 by 2, 1..11 by 2}
-  locale 1 owns: {1..11 by 2, 2..10 by 2}
-  locale 1 owns: {1..11 by 2, 2..10 by 2}
-  locale 2 owns: {2..10 by 2, 1..11 by 2}
-  locale 2 owns: {2..10 by 2, 1..11 by 2}
-  locale 3 owns: {2..10 by 2, 2..10 by 2}
-  locale 3 owns: {2..10 by 2, 2..10 by 2}
+  locale 1 owns: {1..11 by 2, 1..11 by 2 align 0}
+  locale 1 owns: {1..11 by 2, 1..11 by 2 align 0}
+  locale 2 owns: {1..11 by 2 align 0, 1..11 by 2}
+  locale 2 owns: {1..11 by 2 align 0, 1..11 by 2}
+  locale 3 owns: {1..11 by 2 align 0, 1..11 by 2 align 0}
+  locale 3 owns: {1..11 by 2 align 0, 1..11 by 2 align 0}
 (<no communication>)
 
 From locale 2
   locale 0 owns: {1..11 by 2, 1..11 by 2}
   locale 0 owns: {1..11 by 2, 1..11 by 2}
-  locale 1 owns: {1..11 by 2, 2..10 by 2}
-  locale 1 owns: {1..11 by 2, 2..10 by 2}
-  locale 2 owns: {2..10 by 2, 1..11 by 2}
-  locale 2 owns: {2..10 by 2, 1..11 by 2}
-  locale 3 owns: {2..10 by 2, 2..10 by 2}
-  locale 3 owns: {2..10 by 2, 2..10 by 2}
+  locale 1 owns: {1..11 by 2, 1..11 by 2 align 0}
+  locale 1 owns: {1..11 by 2, 1..11 by 2 align 0}
+  locale 2 owns: {1..11 by 2 align 0, 1..11 by 2}
+  locale 2 owns: {1..11 by 2 align 0, 1..11 by 2}
+  locale 3 owns: {1..11 by 2 align 0, 1..11 by 2 align 0}
+  locale 3 owns: {1..11 by 2 align 0, 1..11 by 2 align 0}
 (<no communication>)
 
 From locale 3
   locale 0 owns: {1..11 by 2, 1..11 by 2}
   locale 0 owns: {1..11 by 2, 1..11 by 2}
-  locale 1 owns: {1..11 by 2, 2..10 by 2}
-  locale 1 owns: {1..11 by 2, 2..10 by 2}
-  locale 2 owns: {2..10 by 2, 1..11 by 2}
-  locale 2 owns: {2..10 by 2, 1..11 by 2}
-  locale 3 owns: {2..10 by 2, 2..10 by 2}
-  locale 3 owns: {2..10 by 2, 2..10 by 2}
+  locale 1 owns: {1..11 by 2, 1..11 by 2 align 0}
+  locale 1 owns: {1..11 by 2, 1..11 by 2 align 0}
+  locale 2 owns: {1..11 by 2 align 0, 1..11 by 2}
+  locale 2 owns: {1..11 by 2 align 0, 1..11 by 2}
+  locale 3 owns: {1..11 by 2 align 0, 1..11 by 2 align 0}
+  locale 3 owns: {1..11 by 2 align 0, 1..11 by 2 align 0}
 (<no communication>)
 
 Testing domain D: {1..11, 1..11}
@@ -97,45 +97,45 @@ Mapped to locales:
 LOCALE1 LOCALE3
 LOCALE0 LOCALE2
 From locale 0
-  locale 0 owns: {2..10 by 2, 2..10 by 2}
-  locale 0 owns: {2..10 by 2, 2..10 by 2}
-  locale 1 owns: {1..11 by 2, 2..10 by 2}
-  locale 1 owns: {1..11 by 2, 2..10 by 2}
-  locale 2 owns: {2..10 by 2, 1..11 by 2}
-  locale 2 owns: {2..10 by 2, 1..11 by 2}
+  locale 0 owns: {1..11 by 2 align 0, 1..11 by 2 align 0}
+  locale 0 owns: {1..11 by 2 align 0, 1..11 by 2 align 0}
+  locale 1 owns: {1..11 by 2, 1..11 by 2 align 0}
+  locale 1 owns: {1..11 by 2, 1..11 by 2 align 0}
+  locale 2 owns: {1..11 by 2 align 0, 1..11 by 2}
+  locale 2 owns: {1..11 by 2 align 0, 1..11 by 2}
   locale 3 owns: {1..11 by 2, 1..11 by 2}
   locale 3 owns: {1..11 by 2, 1..11 by 2}
 (<no communication>)
 
 From locale 1
-  locale 0 owns: {2..10 by 2, 2..10 by 2}
-  locale 0 owns: {2..10 by 2, 2..10 by 2}
-  locale 1 owns: {1..11 by 2, 2..10 by 2}
-  locale 1 owns: {1..11 by 2, 2..10 by 2}
-  locale 2 owns: {2..10 by 2, 1..11 by 2}
-  locale 2 owns: {2..10 by 2, 1..11 by 2}
+  locale 0 owns: {1..11 by 2 align 0, 1..11 by 2 align 0}
+  locale 0 owns: {1..11 by 2 align 0, 1..11 by 2 align 0}
+  locale 1 owns: {1..11 by 2, 1..11 by 2 align 0}
+  locale 1 owns: {1..11 by 2, 1..11 by 2 align 0}
+  locale 2 owns: {1..11 by 2 align 0, 1..11 by 2}
+  locale 2 owns: {1..11 by 2 align 0, 1..11 by 2}
   locale 3 owns: {1..11 by 2, 1..11 by 2}
   locale 3 owns: {1..11 by 2, 1..11 by 2}
 (<no communication>)
 
 From locale 2
-  locale 0 owns: {2..10 by 2, 2..10 by 2}
-  locale 0 owns: {2..10 by 2, 2..10 by 2}
-  locale 1 owns: {1..11 by 2, 2..10 by 2}
-  locale 1 owns: {1..11 by 2, 2..10 by 2}
-  locale 2 owns: {2..10 by 2, 1..11 by 2}
-  locale 2 owns: {2..10 by 2, 1..11 by 2}
+  locale 0 owns: {1..11 by 2 align 0, 1..11 by 2 align 0}
+  locale 0 owns: {1..11 by 2 align 0, 1..11 by 2 align 0}
+  locale 1 owns: {1..11 by 2, 1..11 by 2 align 0}
+  locale 1 owns: {1..11 by 2, 1..11 by 2 align 0}
+  locale 2 owns: {1..11 by 2 align 0, 1..11 by 2}
+  locale 2 owns: {1..11 by 2 align 0, 1..11 by 2}
   locale 3 owns: {1..11 by 2, 1..11 by 2}
   locale 3 owns: {1..11 by 2, 1..11 by 2}
 (<no communication>)
 
 From locale 3
-  locale 0 owns: {2..10 by 2, 2..10 by 2}
-  locale 0 owns: {2..10 by 2, 2..10 by 2}
-  locale 1 owns: {1..11 by 2, 2..10 by 2}
-  locale 1 owns: {1..11 by 2, 2..10 by 2}
-  locale 2 owns: {2..10 by 2, 1..11 by 2}
-  locale 2 owns: {2..10 by 2, 1..11 by 2}
+  locale 0 owns: {1..11 by 2 align 0, 1..11 by 2 align 0}
+  locale 0 owns: {1..11 by 2 align 0, 1..11 by 2 align 0}
+  locale 1 owns: {1..11 by 2, 1..11 by 2 align 0}
+  locale 1 owns: {1..11 by 2, 1..11 by 2 align 0}
+  locale 2 owns: {1..11 by 2 align 0, 1..11 by 2}
+  locale 2 owns: {1..11 by 2 align 0, 1..11 by 2}
   locale 3 owns: {1..11 by 2, 1..11 by 2}
   locale 3 owns: {1..11 by 2, 1..11 by 2}
 (<no communication>)
@@ -143,45 +143,45 @@ From locale 3
 
 Testing array A (declared over D):
 From locale 0
-  locale 0 owns: {2..10 by 2, 2..10 by 2}
-  locale 0 owns: {2..10 by 2, 2..10 by 2}
-  locale 1 owns: {1..11 by 2, 2..10 by 2}
-  locale 1 owns: {1..11 by 2, 2..10 by 2}
-  locale 2 owns: {2..10 by 2, 1..11 by 2}
-  locale 2 owns: {2..10 by 2, 1..11 by 2}
+  locale 0 owns: {1..11 by 2 align 0, 1..11 by 2 align 0}
+  locale 0 owns: {1..11 by 2 align 0, 1..11 by 2 align 0}
+  locale 1 owns: {1..11 by 2, 1..11 by 2 align 0}
+  locale 1 owns: {1..11 by 2, 1..11 by 2 align 0}
+  locale 2 owns: {1..11 by 2 align 0, 1..11 by 2}
+  locale 2 owns: {1..11 by 2 align 0, 1..11 by 2}
   locale 3 owns: {1..11 by 2, 1..11 by 2}
   locale 3 owns: {1..11 by 2, 1..11 by 2}
 (<no communication>)
 
 From locale 1
-  locale 0 owns: {2..10 by 2, 2..10 by 2}
-  locale 0 owns: {2..10 by 2, 2..10 by 2}
-  locale 1 owns: {1..11 by 2, 2..10 by 2}
-  locale 1 owns: {1..11 by 2, 2..10 by 2}
-  locale 2 owns: {2..10 by 2, 1..11 by 2}
-  locale 2 owns: {2..10 by 2, 1..11 by 2}
+  locale 0 owns: {1..11 by 2 align 0, 1..11 by 2 align 0}
+  locale 0 owns: {1..11 by 2 align 0, 1..11 by 2 align 0}
+  locale 1 owns: {1..11 by 2, 1..11 by 2 align 0}
+  locale 1 owns: {1..11 by 2, 1..11 by 2 align 0}
+  locale 2 owns: {1..11 by 2 align 0, 1..11 by 2}
+  locale 2 owns: {1..11 by 2 align 0, 1..11 by 2}
   locale 3 owns: {1..11 by 2, 1..11 by 2}
   locale 3 owns: {1..11 by 2, 1..11 by 2}
 (<no communication>)
 
 From locale 2
-  locale 0 owns: {2..10 by 2, 2..10 by 2}
-  locale 0 owns: {2..10 by 2, 2..10 by 2}
-  locale 1 owns: {1..11 by 2, 2..10 by 2}
-  locale 1 owns: {1..11 by 2, 2..10 by 2}
-  locale 2 owns: {2..10 by 2, 1..11 by 2}
-  locale 2 owns: {2..10 by 2, 1..11 by 2}
+  locale 0 owns: {1..11 by 2 align 0, 1..11 by 2 align 0}
+  locale 0 owns: {1..11 by 2 align 0, 1..11 by 2 align 0}
+  locale 1 owns: {1..11 by 2, 1..11 by 2 align 0}
+  locale 1 owns: {1..11 by 2, 1..11 by 2 align 0}
+  locale 2 owns: {1..11 by 2 align 0, 1..11 by 2}
+  locale 2 owns: {1..11 by 2 align 0, 1..11 by 2}
   locale 3 owns: {1..11 by 2, 1..11 by 2}
   locale 3 owns: {1..11 by 2, 1..11 by 2}
 (<no communication>)
 
 From locale 3
-  locale 0 owns: {2..10 by 2, 2..10 by 2}
-  locale 0 owns: {2..10 by 2, 2..10 by 2}
-  locale 1 owns: {1..11 by 2, 2..10 by 2}
-  locale 1 owns: {1..11 by 2, 2..10 by 2}
-  locale 2 owns: {2..10 by 2, 1..11 by 2}
-  locale 2 owns: {2..10 by 2, 1..11 by 2}
+  locale 0 owns: {1..11 by 2 align 0, 1..11 by 2 align 0}
+  locale 0 owns: {1..11 by 2 align 0, 1..11 by 2 align 0}
+  locale 1 owns: {1..11 by 2, 1..11 by 2 align 0}
+  locale 1 owns: {1..11 by 2, 1..11 by 2 align 0}
+  locale 2 owns: {1..11 by 2 align 0, 1..11 by 2}
+  locale 2 owns: {1..11 by 2 align 0, 1..11 by 2}
   locale 3 owns: {1..11 by 2, 1..11 by 2}
   locale 3 owns: {1..11 by 2, 1..11 by 2}
 (<no communication>)
@@ -191,93 +191,93 @@ Mapped to locales:
 LOCALE1 LOCALE3
 LOCALE0 LOCALE2
 From locale 0
-  locale 0 owns: {2..2 by 2, 2..10 by 2}
-  locale 0 owns: {2..2 by 2, 2..10 by 2}
-  locale 1 owns: {3..3 by 2, 2..10 by 2}
-  locale 1 owns: {3..3 by 2, 2..10 by 2}
-  locale 2 owns: {2..2 by 2, 1..11 by 2}
-  locale 2 owns: {2..2 by 2, 1..11 by 2}
-  locale 3 owns: {3..3 by 2, 1..11 by 2}
-  locale 3 owns: {3..3 by 2, 1..11 by 2}
+  locale 0 owns: {2..3 by 2, 1..11 by 2 align 0}
+  locale 0 owns: {2..3 by 2, 1..11 by 2 align 0}
+  locale 1 owns: {2..3 by 2 align 1, 1..11 by 2 align 0}
+  locale 1 owns: {2..3 by 2 align 1, 1..11 by 2 align 0}
+  locale 2 owns: {2..3 by 2, 1..11 by 2}
+  locale 2 owns: {2..3 by 2, 1..11 by 2}
+  locale 3 owns: {2..3 by 2 align 1, 1..11 by 2}
+  locale 3 owns: {2..3 by 2 align 1, 1..11 by 2}
 (<no communication>)
 
 From locale 1
-  locale 0 owns: {2..2 by 2, 2..10 by 2}
-  locale 0 owns: {2..2 by 2, 2..10 by 2}
-  locale 1 owns: {3..3 by 2, 2..10 by 2}
-  locale 1 owns: {3..3 by 2, 2..10 by 2}
-  locale 2 owns: {2..2 by 2, 1..11 by 2}
-  locale 2 owns: {2..2 by 2, 1..11 by 2}
-  locale 3 owns: {3..3 by 2, 1..11 by 2}
-  locale 3 owns: {3..3 by 2, 1..11 by 2}
+  locale 0 owns: {2..3 by 2, 1..11 by 2 align 0}
+  locale 0 owns: {2..3 by 2, 1..11 by 2 align 0}
+  locale 1 owns: {2..3 by 2 align 1, 1..11 by 2 align 0}
+  locale 1 owns: {2..3 by 2 align 1, 1..11 by 2 align 0}
+  locale 2 owns: {2..3 by 2, 1..11 by 2}
+  locale 2 owns: {2..3 by 2, 1..11 by 2}
+  locale 3 owns: {2..3 by 2 align 1, 1..11 by 2}
+  locale 3 owns: {2..3 by 2 align 1, 1..11 by 2}
 (<no communication>)
 
 From locale 2
-  locale 0 owns: {2..2 by 2, 2..10 by 2}
-  locale 0 owns: {2..2 by 2, 2..10 by 2}
-  locale 1 owns: {3..3 by 2, 2..10 by 2}
-  locale 1 owns: {3..3 by 2, 2..10 by 2}
-  locale 2 owns: {2..2 by 2, 1..11 by 2}
-  locale 2 owns: {2..2 by 2, 1..11 by 2}
-  locale 3 owns: {3..3 by 2, 1..11 by 2}
-  locale 3 owns: {3..3 by 2, 1..11 by 2}
+  locale 0 owns: {2..3 by 2, 1..11 by 2 align 0}
+  locale 0 owns: {2..3 by 2, 1..11 by 2 align 0}
+  locale 1 owns: {2..3 by 2 align 1, 1..11 by 2 align 0}
+  locale 1 owns: {2..3 by 2 align 1, 1..11 by 2 align 0}
+  locale 2 owns: {2..3 by 2, 1..11 by 2}
+  locale 2 owns: {2..3 by 2, 1..11 by 2}
+  locale 3 owns: {2..3 by 2 align 1, 1..11 by 2}
+  locale 3 owns: {2..3 by 2 align 1, 1..11 by 2}
 (<no communication>)
 
 From locale 3
-  locale 0 owns: {2..2 by 2, 2..10 by 2}
-  locale 0 owns: {2..2 by 2, 2..10 by 2}
-  locale 1 owns: {3..3 by 2, 2..10 by 2}
-  locale 1 owns: {3..3 by 2, 2..10 by 2}
-  locale 2 owns: {2..2 by 2, 1..11 by 2}
-  locale 2 owns: {2..2 by 2, 1..11 by 2}
-  locale 3 owns: {3..3 by 2, 1..11 by 2}
-  locale 3 owns: {3..3 by 2, 1..11 by 2}
+  locale 0 owns: {2..3 by 2, 1..11 by 2 align 0}
+  locale 0 owns: {2..3 by 2, 1..11 by 2 align 0}
+  locale 1 owns: {2..3 by 2 align 1, 1..11 by 2 align 0}
+  locale 1 owns: {2..3 by 2 align 1, 1..11 by 2 align 0}
+  locale 2 owns: {2..3 by 2, 1..11 by 2}
+  locale 2 owns: {2..3 by 2, 1..11 by 2}
+  locale 3 owns: {2..3 by 2 align 1, 1..11 by 2}
+  locale 3 owns: {2..3 by 2 align 1, 1..11 by 2}
 (<no communication>)
 
 
 Testing array A (declared over D):
 From locale 0
-  locale 0 owns: {2..2 by 2, 2..10 by 2}
-  locale 0 owns: {2..2 by 2, 2..10 by 2}
-  locale 1 owns: {3..3 by 2, 2..10 by 2}
-  locale 1 owns: {3..3 by 2, 2..10 by 2}
-  locale 2 owns: {2..2 by 2, 1..11 by 2}
-  locale 2 owns: {2..2 by 2, 1..11 by 2}
-  locale 3 owns: {3..3 by 2, 1..11 by 2}
-  locale 3 owns: {3..3 by 2, 1..11 by 2}
+  locale 0 owns: {2..3 by 2, 1..11 by 2 align 0}
+  locale 0 owns: {2..3 by 2, 1..11 by 2 align 0}
+  locale 1 owns: {2..3 by 2 align 1, 1..11 by 2 align 0}
+  locale 1 owns: {2..3 by 2 align 1, 1..11 by 2 align 0}
+  locale 2 owns: {2..3 by 2, 1..11 by 2}
+  locale 2 owns: {2..3 by 2, 1..11 by 2}
+  locale 3 owns: {2..3 by 2 align 1, 1..11 by 2}
+  locale 3 owns: {2..3 by 2 align 1, 1..11 by 2}
 (<no communication>)
 
 From locale 1
-  locale 0 owns: {2..2 by 2, 2..10 by 2}
-  locale 0 owns: {2..2 by 2, 2..10 by 2}
-  locale 1 owns: {3..3 by 2, 2..10 by 2}
-  locale 1 owns: {3..3 by 2, 2..10 by 2}
-  locale 2 owns: {2..2 by 2, 1..11 by 2}
-  locale 2 owns: {2..2 by 2, 1..11 by 2}
-  locale 3 owns: {3..3 by 2, 1..11 by 2}
-  locale 3 owns: {3..3 by 2, 1..11 by 2}
+  locale 0 owns: {2..3 by 2, 1..11 by 2 align 0}
+  locale 0 owns: {2..3 by 2, 1..11 by 2 align 0}
+  locale 1 owns: {2..3 by 2 align 1, 1..11 by 2 align 0}
+  locale 1 owns: {2..3 by 2 align 1, 1..11 by 2 align 0}
+  locale 2 owns: {2..3 by 2, 1..11 by 2}
+  locale 2 owns: {2..3 by 2, 1..11 by 2}
+  locale 3 owns: {2..3 by 2 align 1, 1..11 by 2}
+  locale 3 owns: {2..3 by 2 align 1, 1..11 by 2}
 (<no communication>)
 
 From locale 2
-  locale 0 owns: {2..2 by 2, 2..10 by 2}
-  locale 0 owns: {2..2 by 2, 2..10 by 2}
-  locale 1 owns: {3..3 by 2, 2..10 by 2}
-  locale 1 owns: {3..3 by 2, 2..10 by 2}
-  locale 2 owns: {2..2 by 2, 1..11 by 2}
-  locale 2 owns: {2..2 by 2, 1..11 by 2}
-  locale 3 owns: {3..3 by 2, 1..11 by 2}
-  locale 3 owns: {3..3 by 2, 1..11 by 2}
+  locale 0 owns: {2..3 by 2, 1..11 by 2 align 0}
+  locale 0 owns: {2..3 by 2, 1..11 by 2 align 0}
+  locale 1 owns: {2..3 by 2 align 1, 1..11 by 2 align 0}
+  locale 1 owns: {2..3 by 2 align 1, 1..11 by 2 align 0}
+  locale 2 owns: {2..3 by 2, 1..11 by 2}
+  locale 2 owns: {2..3 by 2, 1..11 by 2}
+  locale 3 owns: {2..3 by 2 align 1, 1..11 by 2}
+  locale 3 owns: {2..3 by 2 align 1, 1..11 by 2}
 (<no communication>)
 
 From locale 3
-  locale 0 owns: {2..2 by 2, 2..10 by 2}
-  locale 0 owns: {2..2 by 2, 2..10 by 2}
-  locale 1 owns: {3..3 by 2, 2..10 by 2}
-  locale 1 owns: {3..3 by 2, 2..10 by 2}
-  locale 2 owns: {2..2 by 2, 1..11 by 2}
-  locale 2 owns: {2..2 by 2, 1..11 by 2}
-  locale 3 owns: {3..3 by 2, 1..11 by 2}
-  locale 3 owns: {3..3 by 2, 1..11 by 2}
+  locale 0 owns: {2..3 by 2, 1..11 by 2 align 0}
+  locale 0 owns: {2..3 by 2, 1..11 by 2 align 0}
+  locale 1 owns: {2..3 by 2 align 1, 1..11 by 2 align 0}
+  locale 1 owns: {2..3 by 2 align 1, 1..11 by 2 align 0}
+  locale 2 owns: {2..3 by 2, 1..11 by 2}
+  locale 2 owns: {2..3 by 2, 1..11 by 2}
+  locale 3 owns: {2..3 by 2 align 1, 1..11 by 2}
+  locale 3 owns: {2..3 by 2 align 1, 1..11 by 2}
 (<no communication>)
 
 Testing domain D: {1..11, 1..11}
@@ -290,8 +290,8 @@ From locale 0
   locale 1 owns: {1..11, 1..11 by 2}
   locale 2 owns: {1..0, 1..0}
   locale 2 owns: {1..0, 1..0}
-  locale 3 owns: {1..11, 2..10 by 2}
-  locale 3 owns: {1..11, 2..10 by 2}
+  locale 3 owns: {1..11, 1..11 by 2 align 0}
+  locale 3 owns: {1..11, 1..11 by 2 align 0}
 (<no communication>)
 
 From locale 1
@@ -301,8 +301,8 @@ From locale 1
   locale 1 owns: {1..11, 1..11 by 2}
   locale 2 owns: {1..0, 1..0}
   locale 2 owns: {1..0, 1..0}
-  locale 3 owns: {1..11, 2..10 by 2}
-  locale 3 owns: {1..11, 2..10 by 2}
+  locale 3 owns: {1..11, 1..11 by 2 align 0}
+  locale 3 owns: {1..11, 1..11 by 2 align 0}
 (<no communication>)
 
 From locale 2
@@ -312,8 +312,8 @@ From locale 2
   locale 1 owns: {1..11, 1..11 by 2}
   locale 2 owns: {1..0, 1..0}
   locale 2 owns: {1..0, 1..0}
-  locale 3 owns: {1..11, 2..10 by 2}
-  locale 3 owns: {1..11, 2..10 by 2}
+  locale 3 owns: {1..11, 1..11 by 2 align 0}
+  locale 3 owns: {1..11, 1..11 by 2 align 0}
 (<no communication>)
 
 From locale 3
@@ -323,8 +323,8 @@ From locale 3
   locale 1 owns: {1..11, 1..11 by 2}
   locale 2 owns: {1..0, 1..0}
   locale 2 owns: {1..0, 1..0}
-  locale 3 owns: {1..11, 2..10 by 2}
-  locale 3 owns: {1..11, 2..10 by 2}
+  locale 3 owns: {1..11, 1..11 by 2 align 0}
+  locale 3 owns: {1..11, 1..11 by 2 align 0}
 (<no communication>)
 
 
@@ -336,8 +336,8 @@ From locale 0
   locale 1 owns: {1..11, 1..11 by 2}
   locale 2 owns: {1..0, 1..0}
   locale 2 owns: {1..0, 1..0}
-  locale 3 owns: {1..11, 2..10 by 2}
-  locale 3 owns: {1..11, 2..10 by 2}
+  locale 3 owns: {1..11, 1..11 by 2 align 0}
+  locale 3 owns: {1..11, 1..11 by 2 align 0}
 (<no communication>)
 
 From locale 1
@@ -347,8 +347,8 @@ From locale 1
   locale 1 owns: {1..11, 1..11 by 2}
   locale 2 owns: {1..0, 1..0}
   locale 2 owns: {1..0, 1..0}
-  locale 3 owns: {1..11, 2..10 by 2}
-  locale 3 owns: {1..11, 2..10 by 2}
+  locale 3 owns: {1..11, 1..11 by 2 align 0}
+  locale 3 owns: {1..11, 1..11 by 2 align 0}
 (<no communication>)
 
 From locale 2
@@ -358,8 +358,8 @@ From locale 2
   locale 1 owns: {1..11, 1..11 by 2}
   locale 2 owns: {1..0, 1..0}
   locale 2 owns: {1..0, 1..0}
-  locale 3 owns: {1..11, 2..10 by 2}
-  locale 3 owns: {1..11, 2..10 by 2}
+  locale 3 owns: {1..11, 1..11 by 2 align 0}
+  locale 3 owns: {1..11, 1..11 by 2 align 0}
 (<no communication>)
 
 From locale 3
@@ -369,7 +369,7 @@ From locale 3
   locale 1 owns: {1..11, 1..11 by 2}
   locale 2 owns: {1..0, 1..0}
   locale 2 owns: {1..0, 1..0}
-  locale 3 owns: {1..11, 2..10 by 2}
-  locale 3 owns: {1..11, 2..10 by 2}
+  locale 3 owns: {1..11, 1..11 by 2 align 0}
+  locale 3 owns: {1..11, 1..11 by 2 align 0}
 (<no communication>)
 

--- a/test/distributions/robust/arithmetic/performance/multilocale/assignReindex.cyclic.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/assignReindex.cyclic.good
@@ -1,2 +1,2 @@
-(execute_on = 14, execute_on_nb = 6) (get = 244, put = 1, execute_on = 7) (get = 244, put = 1) (get = 244, put = 1)
+(execute_on = 14, execute_on_nb = 6) (get = 166, put = 1, execute_on = 7) (get = 166, put = 1) (get = 166, put = 1)
 (execute_on_nb = 3) (get = 116) (get = 116) (get = 188)

--- a/test/distributions/robust/arithmetic/performance/multilocale/assignReindex.cyclic.na-none.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/assignReindex.cyclic.na-none.good
@@ -1,2 +1,2 @@
-(execute_on = 14, execute_on_nb = 6) (get = 244, put = 1, execute_on = 7, execute_on_fast = 2) (get = 244, put = 1, execute_on_fast = 2) (get = 244, put = 1, execute_on_fast = 2)
+(execute_on = 14, execute_on_nb = 6) (get = 166, put = 1, execute_on = 7, execute_on_fast = 2) (get = 166, put = 1, execute_on_fast = 2) (get = 166, put = 1, execute_on_fast = 2)
 (execute_on_nb = 3) (get = 116, execute_on_fast = 1) (get = 116, execute_on_fast = 1) (get = 188, execute_on_fast = 1)

--- a/test/distributions/robust/arithmetic/performance/multilocale/assignSlice.cyclic.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/assignSlice.cyclic.good
@@ -1,1 +1,1 @@
-(execute_on = 4, execute_on_nb = 6) (get = 120, put = 1, execute_on = 2) (get = 120, put = 1) (get = 120, put = 1)
+(execute_on = 4, execute_on_nb = 6) (get = 81, put = 1, execute_on = 2) (get = 81, put = 1) (get = 81, put = 1)

--- a/test/distributions/robust/arithmetic/performance/multilocale/assignSlice.cyclic.na-none.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/assignSlice.cyclic.na-none.good
@@ -1,1 +1,1 @@
-(execute_on = 4, execute_on_nb = 6) (get = 120, put = 1, execute_on = 2, execute_on_fast = 2) (get = 120, put = 1, execute_on_fast = 2) (get = 120, put = 1, execute_on_fast = 2)
+(execute_on = 4, execute_on_nb = 6) (get = 81, put = 1, execute_on = 2, execute_on_fast = 2) (get = 81, put = 1, execute_on_fast = 2) (get = 81, put = 1, execute_on_fast = 2)

--- a/test/distributions/robust/arithmetic/performance/multilocale/reduceSlice.cyclic.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/reduceSlice.cyclic.good
@@ -1,1 +1,1 @@
-(get = 3, execute_on = 4, execute_on_nb = 6) (get = 120, put = 1, execute_on = 3) (get = 120, put = 1, execute_on = 1) (get = 120, put = 1, execute_on = 1)
+(get = 3, execute_on = 4, execute_on_nb = 6) (get = 81, put = 1, execute_on = 3) (get = 81, put = 1, execute_on = 1) (get = 81, put = 1, execute_on = 1)

--- a/test/distributions/robust/arithmetic/performance/multilocale/reduceSlice.cyclic.na-none.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/reduceSlice.cyclic.na-none.good
@@ -1,1 +1,1 @@
-(get = 3, execute_on = 4, execute_on_nb = 6) (get = 120, put = 1, execute_on = 3, execute_on_fast = 2) (get = 120, put = 1, execute_on = 1, execute_on_fast = 2) (get = 120, put = 1, execute_on = 1, execute_on_fast = 2)
+(get = 3, execute_on = 4, execute_on_nb = 6) (get = 81, put = 1, execute_on = 3, execute_on_fast = 2) (get = 81, put = 1, execute_on = 1, execute_on_fast = 2) (get = 81, put = 1, execute_on = 1, execute_on_fast = 2)


### PR DESCRIPTION
This change optimizes certain paths through the Cyclic distribution related to determining which indices a given locale owns.  The approach I took here was essentially (1) to update the getChunk() routine to implement something simpler and closer to what it said it wanted to do in comments to begin with; and (2) to introduce a helper routine that determines what a locale owns, using that both when initializing Cyclic distributions and when calling dsiLocalSubdomain() for them (where this approach mimics what we do for block distributions).  I strongly believe that there are still additional optimizations that can be done, but have not investigated further than these changes so far.

One impact of this change is that our remote query used to say things like "2..12 by 2" for locale 1's portion of a "1..12 by 2" domain cyclically distributed (starting from 1), and now it says "1..12 by 2 align 0".  Though it's more verbose, I think that this is a better answer since it retains the original bounds of the domain and it's always possible to go from this version to the more compact one, but not possible to go in the opposite direction.