### PR TITLE
Have comm=ofi say which provider it's using, when we are very verbose.

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -466,6 +466,13 @@ void init_ofiFabricDomain(void) {
 
   fi_freeinfo(hints);
 
+  if (verbosity >= 2) {
+    if (chpl_nodeID == 0) {
+      printf("COMM=ofi: using \"%s\" provider\n",
+             ofi_info->fabric_attr->prov_name);
+    }
+  }
+
   //
   // Create the fabric domain and associated fabric access domain.
   //


### PR DESCRIPTION
At verbosity=2 and higher, the ofi comm layer will now tell which
provider it's using.

This closes #12474.