### PR TITLE
Improve the speed of parallel safe random streams

### DIFF
--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -1101,18 +1101,17 @@ module Random {
 
 
       pragma "no doc"
-      var PCGRandomStreamPrivate_lock$: if parSafe then sync bool else nothing;
+      var _l: if parSafe then atomic bool else nothing;
       pragma "no doc"
-      pragma "dont disable remote value forwarding"
       inline proc _lock() {
         if parSafe then
-          PCGRandomStreamPrivate_lock$ = true;
+          while _l.read() || _l.testAndSet(memory_order_acquire) do
+            chpl_task_yield();
       }
       pragma "no doc"
-      pragma "dont disable remote value forwarding"
       inline proc _unlock() {
         if parSafe then
-          PCGRandomStreamPrivate_lock$;
+          _l.clear(memory_order_release);
       }
       // up to 4 RNGs
       pragma "no doc"
@@ -2506,18 +2505,17 @@ module Random {
       //
 
       pragma "no doc"
-      var NPBRandomStreamPrivate_lock$: if parSafe then sync bool else nothing;
+      var _l: if parSafe then atomic bool else nothing;
       pragma "no doc"
-      pragma "dont disable remote value forwarding"
       inline proc _lock() {
         if parSafe then
-          NPBRandomStreamPrivate_lock$ = true;
+          while _l.read() || _l.testAndSet(memory_order_acquire) do
+            chpl_task_yield();
       }
       pragma "no doc"
-      pragma "dont disable remote value forwarding"
       inline proc _unlock() {
         if parSafe then
-          NPBRandomStreamPrivate_lock$;
+          _l.clear(memory_order_release);
       }
       pragma "no doc"
       var NPBRandomStreamPrivate_cursor: real = seed;


### PR DESCRIPTION
Previously, we used a sync lock but that's extremely slow, especially in
serial/uncontested code. Transition to using a test-and-testAndSet lock.
When contested a testAndSet lock is slower than a sync lock because of
cache contention but a test-and-testAndSet lock is faster (#13012)

For the performance test added in #13009, this results in a 17x speedup for
streams accessed serially and a 7x speedup for streams accessed in parallel.

| config               | before | after  |
| -------------------- | ------ | ------ |
| serial (not parSafe) |  0.06s |  0.06s |
| serial (parSafe)     |  8.50s |  0.50s |
| parallel (parSafe)   | 34.50s |  4.50s |

Note that when parallel safety is not needed, using `parSafe=false` is
still 10x faster, but this significantly reduces the default overhead.

Closes https://github.com/chapel-lang/chapel/issues/12943