### PR TITLE
Increased usage of initializers for domains and distributions

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5184,7 +5184,7 @@ static void resolveInitVar(CallExpr* call) {
              isParamString ||
              isSyncType(srcType->getValType()) ||
              isSingleType(srcType->getValType()) ||
-             isRecordWrappedType(targetType->getValType()) ||
+             targetType->getValType()->symbol->hasFlag(FLAG_ARRAY) ||
              srcType->getValType()->symbol->hasFlag(FLAG_TUPLE) ||
              srcType->getValType()->symbol->hasFlag(FLAG_ITERATOR_RECORD)) {
     // These cases require an initCopy to implement special initialization

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5184,7 +5184,7 @@ static void resolveInitVar(CallExpr* call) {
              isParamString ||
              isSyncType(srcType->getValType()) ||
              isSingleType(srcType->getValType()) ||
-             isRecordWrappedType(targetType->getValType()) ||
+             (isRecordWrappedType(targetType->getValType()) && targetType->getValType()->symbol->hasFlag(FLAG_DISTRIBUTION) == false) ||
              srcType->getValType()->symbol->hasFlag(FLAG_TUPLE) ||
              srcType->getValType()->symbol->hasFlag(FLAG_ITERATOR_RECORD)) {
     // These cases require an initCopy to implement special initialization

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5184,11 +5184,16 @@ static void resolveInitVar(CallExpr* call) {
              isParamString ||
              isSyncType(srcType->getValType()) ||
              isSingleType(srcType->getValType()) ||
-             targetType->getValType()->symbol->hasFlag(FLAG_ARRAY) ||
+             isRecordWrappedType(targetType->getValType()) ||
              srcType->getValType()->symbol->hasFlag(FLAG_TUPLE) ||
              srcType->getValType()->symbol->hasFlag(FLAG_ITERATOR_RECORD)) {
     // These cases require an initCopy to implement special initialization
     // semantics (e.g. reading a sync for variable initialization).
+    //
+    // For example, even though domains can leverage 'init=' for basic
+    // copy-initialization, the compiler only currently knows about calls to
+    // "chpl__initCopy" and how to turn them into something else when necessary
+    // (e.g. chpl__unalias).
 
     CallExpr* initCopy = new CallExpr("chpl__initCopy", srcExpr->remove());
     call->insertAtTail(initCopy);

--- a/modules/dists/PrivateDist.chpl
+++ b/modules/dists/PrivateDist.chpl
@@ -116,6 +116,12 @@ class PrivateDom: BaseRectangularDom {
   proc dsiStride return 0;
   proc dsiSetIndices(x: domain) { halt("cannot reassign private domain"); }
   proc dsiGetIndices() { return {0..numLocales-1}; }
+  proc dsiDim(d : int) {
+    return dsiLow..dsiHigh;
+  }
+  proc dsiDims() {
+    return (dsiLow..dsiHigh,);
+  }
 
   proc dsiAssignDomain(rhs: domain, lhsPrivate:bool) {
     halt("cannot reassign private domain");

--- a/modules/dists/StencilDist.chpl
+++ b/modules/dists/StencilDist.chpl
@@ -1425,7 +1425,7 @@ proc StencilArr.noFluffView() {
   var tempDist = new unmanaged Stencil(dom.dist.boundingBox, dom.dist.targetLocales,
                              dom.dist.dataParTasksPerLocale, dom.dist.dataParIgnoreRunningTasks,
                              dom.dist.dataParMinGranularity, ignoreFluff=true);
-  pragma "no auto destroy" var newDist = _newDistribution(tempDist);
+  pragma "no auto destroy" var newDist = new _distribution(tempDist);
   pragma "no auto destroy" var tempDom = _newDomain(newDist.newRectangularDom(rank, idxType, dom.stridable, dom.whole.dims()));
   newDist._value._free_when_no_doms = true;
 

--- a/modules/dists/StencilDist.chpl
+++ b/modules/dists/StencilDist.chpl
@@ -1426,7 +1426,7 @@ proc StencilArr.noFluffView() {
                              dom.dist.dataParTasksPerLocale, dom.dist.dataParIgnoreRunningTasks,
                              dom.dist.dataParMinGranularity, ignoreFluff=true);
   pragma "no auto destroy" var newDist = new _distribution(tempDist);
-  pragma "no auto destroy" var tempDom = _newDomain(newDist.newRectangularDom(rank, idxType, dom.stridable, dom.whole.dims()));
+  pragma "no auto destroy" var tempDom = new _domain(newDist, rank, idxType, dom.stridable, dom.whole.dims());
   newDist._value._free_when_no_doms = true;
 
   var newDom = tempDom._value;

--- a/modules/internal/ArrayViewRankChange.chpl
+++ b/modules/internal/ArrayViewRankChange.chpl
@@ -192,13 +192,8 @@ module ArrayViewRankChange {
       var upDomRec = {(...inds)};
       upDom = upDomRec._value;
 
-      var ranges: downrank*range(idxType, BoundedRangeType.bounded, stridable);
-      var downDomClass = dist.downDist.dsiNewRectangularDom(rank=downrank,
-                                                           idxType,
-                                                           stridable=stridable,
-                                                           ranges);
       pragma "no auto destroy"
-      var downDomLoc = _newDomain(downDomClass);
+      var downDomLoc = new _domain(_getDistribution(dist.downDist), downrank, idxType, stridable);
       downDomLoc = chpl_rankChangeConvertDom(inds, inds.size, collapsedDim, idx);
       downDomLoc._value._free_when_no_arrs = true;
       downDomPid = downDomLoc._pid;

--- a/modules/internal/ArrayViewRankChange.chpl
+++ b/modules/internal/ArrayViewRankChange.chpl
@@ -192,8 +192,16 @@ module ArrayViewRankChange {
       var upDomRec = {(...inds)};
       upDom = upDomRec._value;
 
+      // TODO: BHARSH 2019-05-13:
+      // Would rather use '_getDistribution' and passing args to "new _domain",
+      // see similar comment in ArrayViewReindex for more information.
+      var ranges : downrank*range(idxType, BoundedRangeType.bounded, stridable);
+      var downDomClass = dist.downDist.dsiNewRectangularDom(rank=downrank,
+                                                           idxType,
+                                                           stridable=stridable,
+                                                           ranges);
       pragma "no auto destroy"
-      var downDomLoc = new _domain(_getDistribution(dist.downDist), downrank, idxType, stridable);
+      var downDomLoc = new _domain(downDomClass);
       downDomLoc = chpl_rankChangeConvertDom(inds, inds.size, collapsedDim, idx);
       downDomLoc._value._free_when_no_arrs = true;
       downDomPid = downDomLoc._pid;

--- a/modules/internal/ArrayViewReindex.chpl
+++ b/modules/internal/ArrayViewReindex.chpl
@@ -162,8 +162,26 @@ module ArrayViewReindex {
         _delete_dom(updom, false);
       updom = updomRec._value;
 
+      // TODO: BHARSH 2019-05-13:
+      // I would rather do something like this:
+      //   new _domain(_getDistribution(dist.downDist), rank, idxType, dist.downdomInst.stridable);
+      //
+      // But that results in memory leaks. The difference is that by using a
+      // proper '_distribution' the resulting domain class is linked to that
+      // distribution. We currently (incorrectly) invoke '_delete_dom' directly
+      // instead of handling the case where the distribution needs to be
+      // updated as well.
+      //
+      // In short, before we can use the desired pattern, we need to replace
+      // the uses of '_delete_dom' with something like the contents of
+      // _domain._do_destroy().
+      var ranges : rank*range(idxType, BoundedRangeType.bounded, dist.downdomInst.stridable);
+      var downdomclass = dist.downDist.dsiNewRectangularDom(rank=rank,
+                                                           idxType=idxType,
+                                                           stridable=dist.downdomInst.stridable,
+                                                           ranges);
       pragma "no auto destroy"
-      var downdomLoc = new _domain(_getDistribution(dist.downDist), rank, idxType, dist.downdomInst.stridable);
+      var downdomLoc = new _domain(downdomclass);
       downdomLoc = chpl_reindexConvertDom(inds, updom, dist.downdomInst);
       downdomLoc._value._free_when_no_arrs = true;
 

--- a/modules/internal/ArrayViewReindex.chpl
+++ b/modules/internal/ArrayViewReindex.chpl
@@ -162,12 +162,8 @@ module ArrayViewReindex {
         _delete_dom(updom, false);
       updom = updomRec._value;
 
-      var ranges : rank*range(idxType, BoundedRangeType.bounded, dist.downdomInst.stridable);
-      var downdomclass = dist.downDist.dsiNewRectangularDom(rank=rank,
-                                                         idxType=idxType,
-                                                         stridable=dist.downdomInst.stridable, ranges);
       pragma "no auto destroy"
-      var downdomLoc = _newDomain(downdomclass);
+      var downdomLoc = new _domain(_getDistribution(dist.downDist), rank, idxType, dist.downdomInst.stridable);
       downdomLoc = chpl_reindexConvertDom(inds, updom, dist.downdomInst);
       downdomLoc._value._free_when_no_arrs = true;
 

--- a/modules/internal/DefaultSparse.chpl
+++ b/modules/internal/DefaultSparse.chpl
@@ -351,7 +351,7 @@ module DefaultSparse {
         return _getDomain(_to_unmanaged(this));
       } else {
         const copy = new unmanaged DefaultSparseDom(rank, idxType, dist, parentDom);
-        return _newDomain(copy);
+        return new _domain(copy);
       }
     }
   }

--- a/test/domains/vass/no-dom-field-error.chpl
+++ b/test/domains/vass/no-dom-field-error.chpl
@@ -18,8 +18,8 @@ class GlobalArray : BaseArr {}
 
 proc GlobalDistribution.init() {}
 
-proc GlobalDistribution.dsiClone(): GlobalDistribution {
-  return new GlobalDistribution();
+proc GlobalDistribution.dsiClone(): unmanaged GlobalDistribution {
+  return new unmanaged GlobalDistribution();
 }
 
 proc GlobalDistribution.dsiNewArithmeticDom(param rank: int,

--- a/test/reductions/partial/DR-with-shaped-exprs.chpl
+++ b/test/reductions/partial/DR-with-shaped-exprs.chpl
@@ -116,7 +116,7 @@ proc PR(const perElemOp, const resultDom, const sourceExp : _iteratorRecord) {
   if chpl_iteratorFromForExpr(sourceExp) then
    compilerError("cannot compute a partial reduction over a  for-expression");
 
-  var sourceDom = _newDomain(sourceExp._shape_);
+  var sourceDom = new _domain(sourceExp._shape_);
   sourceDom._unowned = true;
   return dsiPartialReduce(perElemOp, resultDom, sourceExp, sourceDom);
 }

--- a/test/studies/comd/elegant/arrayOfStructs/util/AccumStencilDist.chpl
+++ b/test/studies/comd/elegant/arrayOfStructs/util/AccumStencilDist.chpl
@@ -1230,8 +1230,8 @@ proc AccumStencilArr.dsiNoFluffView() {
   var tempDist = new unmanaged AccumStencil(dom.dist.boundingBox, dom.dist.targetLocales,
                              dom.dist.dataParTasksPerLocale, dom.dist.dataParIgnoreRunningTasks,
                              dom.dist.dataParMinGranularity, ignoreFluff=true);
-  pragma "no auto destroy" var newDist = _newDistribution(tempDist);
-  pragma "no auto destroy" var tempDom = _newDomain(newDist.newRectangularDom(rank, idxType, dom.stridable, dom.whole.dims()));
+  pragma "no auto destroy" var newDist = new _distribution(tempDist);
+  pragma "no auto destroy" var tempDom = new _domain(newDist, rank, idxType, dom.stridable, dom.whole.dims());
   newDist._value.add_dom(tempDom._value);
 
   var newDom = tempDom._value;

--- a/test/studies/hpcc/common/bradc/unit/leadFollowOpt.chpl
+++ b/test/studies/hpcc/common/bradc/unit/leadFollowOpt.chpl
@@ -2,8 +2,8 @@ use BlockDist;
 
 var Dist = new dmap(new Block(boundingBox={1..9}));
 
-var D1 = _newDomain(Dist.newRectangularDom(1, int(64), false));
-var D2 = _newDomain(Dist.newRectangularDom(1, int(64), false));
+var D1 = new _domain(Dist.newRectangularDom(1, int(64), false));
+var D2 = new _domain(Dist.newRectangularDom(1, int(64), false));
 D1.setIndices({1..9});
 D2.setIndices({2..10});
 

--- a/test/studies/hpcc/common/bradc/unit/parBlock1D.chpl
+++ b/test/studies/hpcc/common/bradc/unit/parBlock1D.chpl
@@ -2,8 +2,8 @@ use BlockDist;
 
 var Dist = new dmap(new Block(boundingBox={1..9}));
 
-var D1 = _newDomain(Dist.newRectangularDom(1, int(64), false));
-var D2 = _newDomain(Dist.newRectangularDom(1, int(64), false));
+var D1 = new _domain(Dist.newRectangularDom(1, int(64), false));
+var D2 = new _domain(Dist.newRectangularDom(1, int(64), false));
 D1.setIndices({1..9});
 D2.setIndices({2..10});
 


### PR DESCRIPTION
This PR adds initializers for domains and distributions, replacing the helper functions ``_newDomain`` and ``_newDistribution``. These initializer signatures match those of ``chpl__buildDomainRuntimeType``, reducing the need for manually invoking, e.g., ``newRectangularDom`` elsewhere before creating the domain.

Some basic ``init=`` implementations are also added, and replace ``chpl__initCopy`` for both types. The compiler still has specialized handling of domain initialization/copying that relies on calls to ``chpl__initCopy``, so the compiler will still in many cases invoke the compiler-generated ``chpl__initCopy`` which in turn invokes ``init=``. Future work can hopefully eliminate the reliance on calls to ``chpl__initCopy`` and solely use ``init=`` like we would for any other type.

Testing:
- [x] local + futures
- [x] gasnet + futures
- [x] memleaks
- [x] valgrind