### PR TITLE
Fix .bad mismatches in two tests

### DIFF
--- a/test/expressions/lydia/noinit/arg.bad
+++ b/test/expressions/lydia/noinit/arg.bad
@@ -1,3 +1,3 @@
 arg.chpl:3: In function 'foo':
 arg.chpl:7: error: illegal lvalue in assignment
-arg.chpl:3: error: Default expression not convertible to formal type
+arg.chpl:3: error: illegal use of function that does not return a value: 'foo_default_a'

--- a/test/types/void/param-return-void.bad
+++ b/test/types/void/param-return-void.bad
@@ -1,4 +1,0 @@
-T = ''
-T.type = void
-F = ''
-F.type = void

--- a/test/types/void/param-return-void.chpl
+++ b/test/types/void/param-return-void.chpl
@@ -3,7 +3,7 @@ proc helper(param cond : bool) {
   if cond {
     return (1, 2.0, "3");
   } else {
-    return _void;
+    return none;
   }
 }
 

--- a/test/types/void/param-return-void.future
+++ b/test/types/void/param-return-void.future
@@ -1,3 +1,0 @@
-bug: Returning _void from one branch causes all other branches to return _void
-
-#9152

--- a/test/types/void/param-return-void.good
+++ b/test/types/void/param-return-void.good
@@ -1,4 +1,4 @@
 T = '(1, 2.0, 3)'
 T.type = (int(64),real(64),string)
 F = ''
-F.type = void
+F.type = nothing


### PR DESCRIPTION
* Updated expressions/lydia/noinit/arg.bad to match the new bad output.
* Updated types/void/param-return-void.chpl to use 'none' instead of '_void'.
  This allowed the test to start passing, so closes #9152.