### PR TITLE
First crack at new List API, intended to replace "array-as-vec" operations on arrays

### DIFF
--- a/modules/Makefile
+++ b/modules/Makefile
@@ -78,7 +78,7 @@ MODULES_TO_DOCUMENT = \
 	standard/IO.chpl \
 	standard/LinkedLists.chpl \
 	standard/List.chpl \
-  standard/Lists.chpl \
+	standard/Lists.chpl \
 	standard/Math.chpl \
 	standard/Memory.chpl \
 	standard/Path.chpl \

--- a/modules/Makefile
+++ b/modules/Makefile
@@ -78,6 +78,7 @@ MODULES_TO_DOCUMENT = \
 	standard/IO.chpl \
 	standard/LinkedLists.chpl \
 	standard/List.chpl \
+  standard/Lists.chpl \
 	standard/Math.chpl \
 	standard/Memory.chpl \
 	standard/Path.chpl \

--- a/modules/standard/Lists.chpl
+++ b/modules/standard/Lists.chpl
@@ -141,7 +141,8 @@ module Lists {
     proc init=(other: List) {
       this._etype = other._etype;
     }
-  
+
+    pragma "no doc"
     proc deinit() {}
 
     /*

--- a/modules/standard/Lists.chpl
+++ b/modules/standard/Lists.chpl
@@ -184,7 +184,7 @@ module Lists {
       Insert an element at a given position in this List, shifting all elements
       following that index one to the right.
 
-      .. warn::
+      .. warning::
       
         Inserting an element into this List may invalidate existing references
         to the elements contained in this List.
@@ -200,7 +200,7 @@ module Lists {
       Remove the first item from this List whose value is equal to x, shifting
       all elements following the removed item one to the left.
 
-      .. warn::
+      .. warning::
 
         Removing an element from this List may invalidate existing references
         to the elements contained in this List.
@@ -215,7 +215,7 @@ module Lists {
       Remove the item at the given position in this List, and return it. If no
       index is specified, remove and return the last item in this List.
 
-      .. warn::
+      .. warning::
 
         Popping an element from this List will invalidate any reference to
         the element taken while it was contained in this List.
@@ -234,7 +234,7 @@ module Lists {
     /*
       Clear the contents of this List.
 
-      .. warn::
+      .. warning::
 
         Clearing the contents of this List will invalidate all existing
         references to the elements contained in this List.
@@ -270,7 +270,7 @@ module Lists {
     /*
        Sort the elements of this List in place using their default sort order.
 
-       .. warn::
+       .. warning::
 
         Sorting the contents of this List may invalidate existing references
         to the elements contained in this List.
@@ -280,7 +280,7 @@ module Lists {
     /*
       Sort the items of this List in place using a comparator.
 
-      .. warn::
+      .. warning::
 
         Sorting the elements of this List may invalidate existing references
         to the elements contained in this List.

--- a/modules/standard/Lists.chpl
+++ b/modules/standard/Lists.chpl
@@ -221,7 +221,7 @@ module Lists {
         the element taken while it was contained in this List.
 
       :arg i: The index of the element to remove. Defaults to the last item
-        in this List, or `a.remove(a.size - 1)`.
+        in this List.
 
       :return: The item removed.
 
@@ -256,7 +256,7 @@ module Lists {
     }
 
     /*
-      Return the number of times _x_ appears in this List.
+      Return the number of times a given element is found in this List.
 
       :arg x: An element to count.
 
@@ -314,7 +314,7 @@ module Lists {
     }
 
     /*
-      Write the contents of this List to a given channel.
+      Write the contents of this List to a channel.
 
       :arg ch: A channel to write to.
     */
@@ -331,8 +331,8 @@ module Lists {
     }
 
     /*
-      Returns a new DefaultRectangular array containing the elements of this
-      List.
+      Returns a new DefaultRectangular array containing a copy of each of the
+      elements contained in this List.
 
       :return: A new DefaultRectangular array.
     */

--- a/modules/standard/Lists.chpl
+++ b/modules/standard/Lists.chpl
@@ -271,7 +271,6 @@ module Lists {
       Produce a serial iterator over the elements of this List.
 
       :yields: A reference to one of the elements contained in this List.
-      :y
     */
     iter these() ref {
       yield _size;

--- a/modules/standard/Lists.chpl
+++ b/modules/standard/Lists.chpl
@@ -1,0 +1,302 @@
+/*
+ * Copyright 2004-2019 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+  (Word smithing module text below).
+
+  ---
+
+  This module contains the implementation of a list datatype, intended to
+  replace the use of arrays to perform "vector-like" operations.
+
+  A list is a lightweight container intended to mimic Python's list datatype,
+  with fast O(log n)/O(1) (whatever we end up on) indexing  and an API close
+  in spirit to its Python counterpart.
+
+  The highly parallel nature of Chapel means that great care should be taken
+  when performing operations which may trigger a move of list elements.
+  Inserts and removals into the middle of a list are example operations which
+  may trigger a move, thus invalidating all references to elements of the
+  list held by tasks before the move. Appending an element to the end of a
+  list will never cause a move.
+
+  The following operations may trigger a move:
+    - insert
+    - remove
+    - reverse
+    - sort
+    - pop
+
+  ---
+
+  (End word smithing module text).
+
+  I know that @mppf in particular is very interested in limiting the number of
+  operations that move/displace list elements.
+
+  This pertains to the general issue of invalidating references to (and also
+  iterators over) list elements.
+
+  There is also the separate, more general issue of parallel safety. I'd
+  happily appreciate any/all recommendations for the "Chapeltastic" way of
+  making this List type parallel safe.
+
+
+*/
+module ProtoLists {
+
+  // Building blocks used as backing store for lists.
+  pragma "no doc"
+  class ListBlock {
+    type _etype;
+    var data: _ddata(_etype) = nil;
+  }
+
+  /*
+    A container intended to replace the use of arrays to perform "vector-like"
+    operations.
+
+    Is not currently parallel safe.
+
+    The following operations may trigger a move:
+      - insert
+      - remove
+      - reverse
+      - sort
+      - pop
+
+    A move will invalidate any references to list elements held by tasks, as
+    well as iterators to list elements produced by tasks before the move
+    occurred.
+  */
+  class List {
+
+    pragma "no doc"
+    var _size = 0;
+    pragma "no doc"
+    var _etype;
+
+    //
+    // Michael suggested that we move from a LL of blocks to an array, which
+    // would give us constant speed indexing at the cost of more complicated
+    // indexing logic.
+    //
+    pragma "no doc"
+    var _head, _tail: unmanaged ListBlock(_etype) = nil;
+
+
+    /*
+      Initializes a new List containing elements of the given type.
+
+      :arg etype: The type of the elements of this List.
+    */
+    proc init(type etype) { _etype = etype; }
+
+
+    /*
+      Initializes a new List as a copy of another List object.
+
+      :arg other: The List object to initialize from.
+    */
+    proc init=(other: List) {
+      this._etype = other._etype;
+    }
+  
+
+    proc deinit() {}
+
+
+    /*
+      Add an element to the end of this list.
+
+      .. note::
+
+        Appending an element to a list will never invalidate references to
+        (or iterators over) the elements of the list.
+
+      :arg x: An element to append.
+    */
+    proc append(x: this._etype) {}
+
+
+    /*
+      Extend this List by appending all the elements from another List.
+
+      :arg other: A List, the elements of which are appended to this List.
+    */
+    proc extend(other: List(this._etype)) {}
+
+
+    /*
+      Extend this List by appending all the elements from an array.
+
+      :arg other: An array, the elements of which are appended to this List.
+    */
+    proc extend(other: this._etype[?d]) {}
+
+
+    /*
+      Insert an element at a given position in this List, shifting all elements
+      following that index one to the right. Note that `a.insert(a.size, x)`
+      is equivalent to `a.append(x)`.
+
+      :arg i: The index of the element at which to insert.
+      :arg x: The element to insert.
+
+      :throws IllegalArgumentError: If the given index is out of bounds.
+    */
+    proc insert(i: int, x: this._etype) throws {}
+
+
+    /*
+      Remove the first item from the list whose value is equal to _x_.
+
+      :arg x: The element to remove.
+
+      :throws IllegalArgumentError: If there is no such item.
+    */
+    proc remove(x: this._etype) throws {}
+
+
+    /*
+      Remove the item at the given position in this List, and return it. If no
+      index is specified, remove and return the last item in this List.
+
+      :arg i: The index of the element to remove. Defaults to the last item
+        in this list.
+      
+      :return: The item removed.
+
+      :throws IllegalArgumentError: If the given index is out of bounds.
+    */
+    proc pop(i: int=this._size): this._etype throws { return nil; }
+
+
+    /*
+      Clear the contents of this List.
+    */
+    proc clear() {}
+
+    /*
+      Return a zero-based index in the list of the first item whose value is
+      equal to _x_.
+
+      :arg x: An element to search for.
+
+      :return: The index of the element to search for.
+
+      :throws IllegalArgumentError: If the given element cannot be found.
+    */
+    proc indexOf(x: _etype, start: int=0, end: int=_size): int throws {
+      return 0; 
+    }
+
+    /*
+      Return the number of times _x_ appears in the list.
+
+      :arg x: An element to count.
+
+      :return: The number of times a given element is found in this List.
+      :rtype: `int`
+    */
+    proc count(x: this._etype): int {
+      return 0;
+    }
+
+    /*
+      Sort the items of this List in place. The parameters of this method are
+      holdovers from Python. This method could more closely integrate with
+      Chapel sorting APIs.
+
+      :arg key: Unused in current API.
+      :arg reverse: True if this List should be sorted in reverse order.
+
+    */
+    proc sort(key: this._etype=nil, reverse: bool=false) {}
+
+
+    /*
+      Reverse the elements of this list in place.
+    */
+    proc reverse() {}
+
+    /*
+      Index this list via subscript. Returns a reference to the element at a
+      given index in this List.
+
+      :arg i: The index of the element to access.
+
+      :return: An element from this List.
+
+      :throws IllegalArgumentError: If the given index is out of bounds.
+    */
+    proc this(i: int) ref throws { return nil; }
+
+
+    /*
+      Produce a serial iterator over the elements of this List.
+    */
+    iter these() ref { yield _size; }
+
+
+    /*
+      Write the contents of this List to a given channel.
+
+      :arg ch: A channel to write to.
+    */
+    proc writeThis(ch: channel) {}
+
+
+    /*
+      Convert the contents of this List to string form. Could be replaced by
+      an overload of the cast operation?
+
+      :return: The contents of this List, in a form suitable for printing.
+      :rtype: `string`
+    */
+    proc toString(): string {}
+
+
+    /*
+      Return the number of elements in this List.
+
+      :return: The number of elements in this List.
+      :rtype: `int`
+    */
+    proc size { return _size; }
+
+    /*
+      Returns `true` if this list contains zero elements.
+
+      :return: `true` if this list is empty.
+      :rtype: `bool`
+    */
+    proc isEmpty(): bool { return true; }
+
+
+  }
+
+
+  proc =(a: List(?t), b: List(t)) {}
+
+  proc ==(a: List(?t), b: List(t)): bool { return true; }
+
+  proc +(a: List(?t), b: List(t)): List(t) { return nil; }
+
+}

--- a/modules/standard/Lists.chpl
+++ b/modules/standard/Lists.chpl
@@ -169,7 +169,7 @@ module Lists {
 
       :arg other: An array, the elements of which are appended to this List.
     */
-    proc extend(other: this._etype[?d]) {}
+    proc extend(other: [?d] this._etype) {}
 
     /*
       Insert an element at a given position in this List, shifting all elements
@@ -321,7 +321,7 @@ module Lists {
 
       :return: A new DefaultRectangular array.
     */
-    proc toArray(): this._etype[] {
+    proc toArray(): [] this._etype {
       return nil;
     }
   }

--- a/modules/standard/Lists.chpl
+++ b/modules/standard/Lists.chpl
@@ -101,7 +101,7 @@ module Lists {
     from another List object inherits the parallel safety mode of that list
     unless otherwise specified.
   */
-  class List {
+  record List {
 
     /* The number of elements contained in this List. */
     var size = 0;

--- a/modules/standard/Lists.chpl
+++ b/modules/standard/Lists.chpl
@@ -202,7 +202,9 @@ module Lists {
 
       :throws IllegalArgumentError: If the given index is out of bounds.
     */
-    proc pop(i: int=this._size - 1): this._etype throws { return nil; }
+    proc pop(i: int=this._size - 1): this._etype throws {
+      return nil;
+    }
 
     /*
       Clear the contents of this List.
@@ -261,12 +263,19 @@ module Lists {
 
       :throws IllegalArgumentError: If the given index is out of bounds.
     */
-    proc this(i: int) ref throws { return nil; }
+    proc this(i: int) ref throws {
+      return nil;
+    }
 
     /*
       Produce a serial iterator over the elements of this List.
+
+      :yields: A reference to one of the elements contained in this List.
+      :y
     */
-    iter these() ref { yield _size; }
+    iter these() ref {
+      yield _size;
+    }
 
     /*
       Write the contents of this List to a given channel.
@@ -282,7 +291,9 @@ module Lists {
       :return: The contents of this List, in a form suitable for printing.
       :rtype: `string`
     */
-    proc toString(): string {}
+    proc toString(): string {
+      return "";
+    }
 
     /*
       Return the number of elements in this List.
@@ -290,7 +301,9 @@ module Lists {
       :return: The number of elements in this List.
       :rtype: `int`
     */
-    proc size { return _size; }
+    proc size {
+      return _size;
+    }
 
     /*
       Returns `true` if this List contains zero elements.
@@ -298,13 +311,35 @@ module Lists {
       :return: `true` if this List is empty.
       :rtype: `bool`
     */
-    proc isEmpty(): bool { return true; }
+    proc isEmpty(): bool {
+      return true;
+    }
 
+    /*
+      Returns a new DefaultRectangular array containing the elements of this
+      List.
+
+      :return: A new DefaultRectangular array.
+    */
+    proc toArray(): this._etype[] {
+      return nil;
+    }
   }
 
   proc =(a: List(?t), b: List(t)) {}
 
-  proc ==(a: List(?t), b: List(t)): bool { return true; }
+  /*
+    Returns `true` if the contents of two Lists are the same.
+
+    :arg a: A List to compare.
+    :arg b: A List to compare.
+
+    :return: `true` if the contents of two Lists are the same.
+    :rtype: `bool`
+  */
+  proc ==(a: List(?t), b: List(t)): bool {
+    return true;
+  }
 
   /*
     An important question here: do we want the semantics of addition to mirror
@@ -316,7 +351,14 @@ module Lists {
 
     Given Python semantics, `+` would be a shorthand for concatenating two
     Lists together, returning a new List as a result.
+
+    :arg a: A List to add.
+    :arg b: A List to add.
+
+    :return: A new List whose elements are the concatenation of two Lists.
   */
   proc +(a: List(?t), b: List(t)): List(t) { return nil; }
 
-}
+
+} // End module Lists!
+


### PR DESCRIPTION
This PR is intended to propose (**and not implement - not quite yet**) an API for a new `List` type, modeled in the spirit of the Python `list`. It is being written to address the concerns raised in #9452, and will partially resolve #12411 (the other half being the design of a `Deque` type).

I know that @mppf in particular has raised the idea of limiting the number of List operations that _move_ elements within the list. Moving list elements is a problem because it invalidates any references to List elements held by tasks that were taken before the move occurred.

There are three general safety issues to worry about in the design of this List type that can affect the API (and implementation):

- **Parallel safety**: Since Chapel is a highly concurrent language, this is a justified concern. Modifications of a List should be parallel safe in general.
- **Reference invalidation**: Any time list elements are moved around, references to List elements are potentially invalidated. IE, if we have a hold a reference to an element at the end of a List, and then insert at the front of the List, that reference is no longer semantically valid (it now points do a different element).
- **Iterator invalidation**: Appends to the end of a well implemented List don't invalidate freestanding references, but they can potentially (?) invalidate iterators. This may be an unfounded concern (solved by parallel safety).

I will leave this PR open after we resolve the questions raised in #12411, and use it after we decide on the direction of the implementation. 

---

Michael proposed a implementation that would avoid invalidating references on resize and maintain O(1) indexing https://github.com/chapel-lang/chapel/pull/12791/files#r275528150.

While I'm planning on using Vass's implementation used in VectorList #12791 to get myself started, it seems like a good idea to adopt a more performant indexing strategy in the long run.

If anyone else has any implementation questions/ideas/concerns, please feel free (I could use the answers as well!).

---

One avenue of debate is whether List should provide methods such as:

- `insert`
- `remove`
- `pop`

Even `pop` can be considered to invalidate references in a way (what if the element returned is dropped on the floor?). So if we _really_ wanted to limit the API in the name of safety, we could omit the `pop` method too.

But...how far will we go with this line of reasoning before a `List` object ceases to be useful at all? I feel personally that if we omit the methods `insert` and `remove`, our List ADT is really nothing more than a glorified stack.

Just my two cents. Please critique away!