### PR TITLE
Fix testing failures

### DIFF
--- a/test/distributions/robust/arithmetic/modules/test_module_Sort.chpl
+++ b/test/distributions/robust/arithmetic/modules/test_module_Sort.chpl
@@ -68,27 +68,27 @@ writeln("Sort reindexed array");
 proc doSort(D: domain, A: [D], st: SortType) {
   select st {
     when SortType.BUBBLE {
-      bubbleSort(A);
+      BubbleSort.bubbleSort(A);
       if !isSorted(A) then writeln('bubbleSort failed');
     }
     when SortType.INSERTION {
-      insertionSort(A);
+      InsertionSort.insertionSort(A);
       if !isSorted(A) then writeln('insertionSort failed');
     }
     when SortType.MERGE {
-      mergeSort(A);
+      MergeSort.mergeSort(A);
       if !isSorted(A) then writeln('mergeSort failed');
     }
     when SortType.SELECTION {
-      selectionSort(A);
+      SelectionSort.selectionSort(A);
       if !isSorted(A) then writeln('selectionSort failed');
     }
     when SortType.QUICK {
-      quickSort(A);
+      QuickSort.quickSort(A);
       if !isSorted(A) then writeln('quickSort failed');
     }
     when SortType.HEAP {
-      heapSort(A);
+      HeapSort.heapSort(A);
       if !isSorted(A) then writeln('heapSort failed');
     }
   }
@@ -137,7 +137,7 @@ BubbleSort.bubbleSort(rc3DR1D);
 if !isSorted(rc3DR1D) then writeln('bubbleSort failed');
 
 rng.fillRandom(rc3DR1D);
-insertionSort(rc3DR1D);
+InsertionSort.insertionSort(rc3DR1D);
 if !isSorted(rc3DR1D) then writeln('insertionSort failed');
 
 rng.fillRandom(rc3DR1D);

--- a/test/library/standard/FileSystem/bharshbarg/filer.chpl
+++ b/test/library/standard/FileSystem/bharshbarg/filer.chpl
@@ -120,7 +120,7 @@ iter walkdirs(path: string=".", topdown=true, depth=max(int), hidden=false,
   if (depth) {
     var subdirs = listdir(path, hidden=hidden, files=false, listlinks=followlinks);
     if (sort) then
-      sort(subdirs);
+      QuickSort.quickSort(subdirs);
     for subdir in subdirs {
       const fullpath = path + "/" + subdir;
       for subdir in walkdirs(fullpath, topdown, depth-1, hidden, 

--- a/test/modules/sungeun/init/printModuleInitOrder.na-none.good
+++ b/test/modules/sungeun/init/printModuleInitOrder.na-none.good
@@ -23,6 +23,16 @@ Initializing Modules:
         DSIUtil
         ChapelArray
          Sort
+          MSBRadixSort
+           RadixSortHelp
+           ShellSort
+          QuickSort
+           InsertionSort
+          BubbleSort
+          HeapSort
+          BinaryInsertionSort
+          MergeSort
+          SelectionSort
         ExternalArray
         RangeChunk
        ChapelNumLocales


### PR DESCRIPTION
Follow-up to #13022:

Adjust resolveBuiltinCastCall to handle casts from a reference

Calling a _cast function would lead to a de-reference but
PRIM_CAST wasn't dereferencing properly. This caused hello
to fail to run in the NUMA locale model.

Follow-up to  #13000:

Fix missed test updates from deprecating bubbleSort etc. 

- [x] full local testing
- [x] full local --no-local --no-denormalize testing
- [x] primers pass with gasnet, gasnet and --llvm
- [x] hello works in numa local model
- [x] hellos work in numa+gasnet
- [x] start_test --performance test/studies/lulesh/bradc/lulesh-dense passes in standard config
- [x] functions/ferguson/coercions passes with --llvm

Reviewed by @benharsh - thanks!