### PR TITLE
Implement buffered operations in ugni with task-local-storage

### DIFF
--- a/runtime/include/comm/ugni/chpl-comm-task-decls.h
+++ b/runtime/include/comm/ugni/chpl-comm-task-decls.h
@@ -37,6 +37,7 @@ typedef struct {
   chpl_cache_taskPrvData_t cache_data;
   uint8_t num_fma;
   void* amo_nf_buff;
+  void* get_buff;
 } chpl_comm_taskPrvData_t;
 
 //

--- a/runtime/include/comm/ugni/chpl-comm-task-decls.h
+++ b/runtime/include/comm/ugni/chpl-comm-task-decls.h
@@ -36,6 +36,7 @@
 typedef struct {
   chpl_cache_taskPrvData_t cache_data;
   uint8_t num_fma;
+  void* amo_nf_buff;
 } chpl_comm_taskPrvData_t;
 
 //

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -1805,41 +1805,6 @@ static void dbg_catf(FILE* out_f, const char* in_fname, const char* match)
 
 
 
-// Simple wrapper for spinlock with more relaxed orderings and proper yielding
-// for locks. Should only be used when contention is expected to be very low.
-typedef atomic_bool spinlock;
-static inline void spinlock_init(spinlock* s) {
-  atomic_init_bool(s, false);
-}
-static inline void spinlock_lock(spinlock* s) {
-  while (atomic_exchange_explicit_bool(s, true, memory_order_acquire)) {
-    local_yield();
-  }
-}
-static inline void spinlock_unlock(spinlock* s) {
-  atomic_store_explicit_bool(s, false, memory_order_release);
-}
-static inline void spinlock_destroy(spinlock* s) {
-  atomic_destroy_bool(s);
-}
-
-
-// Simple wrapper for a pthread reader/writer lock with proper yielding for
-// locks. Use the non-blocking calls and yield instead of blocking the thread.
-typedef pthread_rwlock_t rwlock;
-static inline void rwlock_init(rwlock* l) {
-  pthread_rwlock_init(l, NULL);
-}
-static inline void rwlock_writer_lock(rwlock* l) {
-  while (pthread_rwlock_trywrlock(l) == EBUSY) { local_yield(); }
-}
-static inline void rwlock_reader_lock(rwlock* l) {
-  while (pthread_rwlock_tryrdlock(l) == EBUSY) { local_yield(); }
-}
-static inline void rwlock_unlock(rwlock* l) {
-  pthread_rwlock_unlock(l);
-}
-
 static inline
 chpl_comm_taskPrvData_t* get_comm_taskPrvdata(void) {
   chpl_task_prvData_t* task_prvData = chpl_task_getPrvData();


### PR DESCRIPTION
Switch from using locks + thread-local buffers to task-local buffers.
This significantly simplifies the implementation and eliminates a lot of
overhead for tasking layers where tasks can migrate threads. It also
replaces an atomic lock for each operation with a task-locale get which
is a little faster and allows comm+compute overlap for 2 tasks doing
buffered ops on the same thread.

This simplifies the implementation and slightly improves the performance
of unordered operations (improves serial perf from 4.69 to 4.72 Mops/s.)
The performance speedup for schedulers where tasks can migrate threads
is likely much larger, though we don't track that nightly.

There are some minor downsides:
 - Slightly increased size of task local storage (24->40 bytes for ugni)
 - We have to do an allocation for each new task doing buffered ops
   Experiments indicate this only matters for long live tasks doing less
   than 64 buffered ops. If this becomes a problem we could use special
   purpose pools.
 - We can no longer do buffered ops from non-chapel threads

Closes https://github.com/Cray/chapel-private/issues/185
