### PR TITLE
Fix two casts in tests meant to allow `nil`

### DIFF
--- a/test/localeModels/numa/basics/coforall_on.chpl
+++ b/test/localeModels/numa/basics/coforall_on.chpl
@@ -1,5 +1,5 @@
 inline proc writestuff(newLine=true) {
-  writeln((here, here:LocaleModel, here:NumaDomain));
+  writeln((here, here:LocaleModel?, here:NumaDomain?));
   if newLine then writeln();
 }
 

--- a/test/localeModels/numa/basics/on.chpl
+++ b/test/localeModels/numa/basics/on.chpl
@@ -1,5 +1,5 @@
 inline proc writestuff(newLine=true) {
-  writeln((here, here:LocaleModel, here:NumaDomain));
+  writeln((here, here:LocaleModel?, here:NumaDomain?));
   if newLine then writeln();
 }
 


### PR DESCRIPTION
Follow-on to PR #13022.

To resolve test failures in numa nightly testing,
use `instance:SomeClass?` variant when `nil` is an expected outcome.

Trivial test change only - not reviewed.