### PR TITLE
Improve 2 tests that didn't work in network-atomics configurations.

### DIFF
--- a/test/parallel/taskPar/sungeun/barrier/commDiags.good
+++ b/test/parallel/taskPar/sungeun/barrier/commDiags.good
@@ -2,8 +2,8 @@ atomic remote test basic
 (execute_on_nb = 4)
 (get = 1, execute_on = 2)
 (get = 1, execute_on = 2)
-(get = 2, execute_on = 1)
 (get = 1, execute_on = 2)
+(get = 2, execute_on = 1)
 atomic remote test split phase
 (execute_on_nb = 4)
 (get = 3, execute_on = 2)

--- a/test/parallel/taskPar/sungeun/barrier/commDiags.prediff
+++ b/test/parallel/taskPar/sungeun/barrier/commDiags.prediff
@@ -1,0 +1,14 @@
+#! /usr/bin/env bash
+#
+# With network atomics (using the plain .good file) the first segment of
+# the output for 'atomic remote test basic' has 2 gets and 1 execute_on
+# for one of the tasks and 1 get and 2 execute_ons for the others.  But,
+# which task differs can vary.  So, sort that first section in order to
+# match.  (For configurations that use comm-none.good or na-none.good
+# all the tasks produce the same output, so this is just a long no-op.)
+#
+(   sed -n '0,/atomic remote test basic/ p' < $2 \
+ && sed -n '/atomic remote test basic/,/atomic remote test split phase/ p' \
+    < $2 | sed -e '1 d' -e '$ d'| sort \
+ && sed -n '/atomic remote test split phase/,$ p' < $2) \
+> $2.tmp && mv $2.tmp $2

--- a/test/studies/uts/uts_deq.chpl
+++ b/test/studies/uts/uts_deq.chpl
@@ -170,6 +170,12 @@ proc AtomicT.max(other: int) {
     curMax = this.read();
 }
 
+proc RAtomicT.max(other: int) {
+  var curMax = this.read();
+  while curMax < other && !this.compareExchange(curMax, other) do
+    curMax = this.read();
+}
+
 
 /*
 ** Print out search parameters


### PR DESCRIPTION
parallel/taskPar/sungeun/barrier/commDiags didn't pass in configurations
that supported network atomics, because in the first ("atomic basic")
subtest it isn't entirely predictable which task will find itself the
last one to arrive at the barrier.  Add a .prediff to account for this
variation.

studies/uts/uts_deq didn't pass in configurations that supported network
atomics, because it didn't define a `max()` operation on network atomic
default ints.  Add one.