### PR TITLE
Fix a flaw in commDiags.prediff.

### DIFF
--- a/test/parallel/taskPar/sungeun/barrier/commDiags.prediff
+++ b/test/parallel/taskPar/sungeun/barrier/commDiags.prediff
@@ -7,7 +7,7 @@
 # match.  (For configurations that use comm-none.good or na-none.good
 # all the tasks produce the same output, so this is just a long no-op.)
 #
-(   sed -n '0,/atomic remote test basic/ p' < $2 \
+(   sed -n '1 p' < $2 \
  && sed -n '/atomic remote test basic/,/atomic remote test split phase/ p' \
     < $2 | sed -e '1 d' -e '$ d'| sort \
  && sed -n '/atomic remote test split phase/,$ p' < $2) \


### PR DESCRIPTION
My PR just now made a non-portable assumption about sed(1) line
addressing, to wit: line `0` doesn't behave the same on linux64 and
Mac OSX.  Fix that.