### PR TITLE
Clean up Makefile output a bit...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,25 +72,32 @@ notcompiler: FORCE
 	@$(MAKE) modules
 
 compiler: FORCE
-	cd compiler && $(MAKE)
+	@echo "Making the compiler..."
+	@cd compiler && $(MAKE)
 
 parser: FORCE
-	cd compiler && $(MAKE) parser
+	@echo "Making the parser..."
+	@cd compiler && $(MAKE) parser
 
 modules: FORCE
-	cd modules && CHPL_LLVM_CODEGEN=0 $(MAKE)
+	@echo "Making the modules..."
+	@cd modules && CHPL_LLVM_CODEGEN=0 $(MAKE)
 	-@if [ ! -z `${NEEDS_LLVM_RUNTIME}` ]; then \
+	echo "Making the modules for LLVM..."; \
 	cd modules && CHPL_LLVM_CODEGEN=1 $(MAKE) ; \
 	fi
 
 runtime: FORCE
-	cd runtime && CHPL_LLVM_CODEGEN=0 $(MAKE)
+	@echo "Making the runtime..."
+	@cd runtime && CHPL_LLVM_CODEGEN=0 $(MAKE)
 	-@if [ ! -z `${NEEDS_LLVM_RUNTIME}` ]; then \
+	echo "Making the runtime for LLVM..."; \
 	cd runtime && CHPL_LLVM_CODEGEN=1 $(MAKE) ; \
 	fi
 
 third-party: FORCE
-	cd third-party && $(MAKE)
+	@echo "Making the third-party libraries..."
+	@cd third-party && $(MAKE)
 
 third-party-try-opt: third-party-try-re2 third-party-try-gmp
 

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -192,7 +192,8 @@ $(CHPL_OLD_BIN_DIR):
 #	done
 
 llvm: FORCE
-	$(MAKE) -C $(THIRD_PARTY_DIR) llvm
+	@echo "Making LLVM..."
+	@$(MAKE) -C $(THIRD_PARTY_DIR) llvm
 
 #
 # include standard footer for compiler

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -70,12 +70,15 @@ third-party-pkgs:
 ifneq (, $(THIRD_PARTY_PKGS))
 # Qthreads may use hwloc and/or jemalloc. Ensure they are built first
 ifneq (, $(filter $(THIRD_PARTY_PKGS),hwloc))
-	$(MAKE) -C $(THIRD_PARTY_DIR) hwloc
+	@echo "Making hwloc..."
+	@$(MAKE) -C $(THIRD_PARTY_DIR) hwloc
 endif
 ifneq (, $(filter $(THIRD_PARTY_PKGS),jemalloc))
-	$(MAKE) -C $(THIRD_PARTY_DIR) jemalloc
+	@echo "Making jemalloc..."
+	@$(MAKE) -C $(THIRD_PARTY_DIR) jemalloc
 endif
-	$(MAKE) -C $(THIRD_PARTY_DIR) $(THIRD_PARTY_PKGS)
+	@echo "Making third-party-packages..."
+	@$(MAKE) -C $(THIRD_PARTY_DIR) $(THIRD_PARTY_PKGS)
 endif
 
 .NOTPARALLEL:


### PR DESCRIPTION
For awhile, our Makefiles have been inconsistent about whether to echo
the recursive `cd ... && make ...` commands or not, and the output for
a clean build has also gotten a bit messier.  This PR tries to clean
things up a bit by adding high-level echo commands to say what we're
building (and sometimes why) and squashing the make commands
themselves.  The output for a clean GASNet + LLVM build after this,
for example, looks like:

```
Making the compiler...
Making LLVM...
make[3]: Nothing to be done for `llvm'.
***** adt/ *****
***** AST/ *****
***** backend/ *****
***** codegen/ *****
***** ifa/ *****
***** llvm/ *****
***** main/ *****
***** optimizations/ *****
***** parser/ *****
***** passes/ *****
***** resolution/ *****
***** util/ *****
***** ./ *****
Speculatively attempting to build re2
make[3]: Nothing to be done for `re2'.
Speculatively attempting to build re2
make[3]: Nothing to be done for `re2'.
make[2]: Nothing to be done for `try-gmp'.
make[2]: Nothing to be done for `try-gmp'.
Making the runtime...
Making hwloc...
make[3]: Nothing to be done for `hwloc'.
Making jemalloc...
make[3]: Nothing to be done for `jemalloc'.
Making third-party-packages...
make[3]: Nothing to be done for `re2'.
make[3]: Nothing to be done for `qthread'.
make[3]: Nothing to be done for `hwloc'.
make[3]: Nothing to be done for `jemalloc'.
make[3]: Nothing to be done for `gmp'.
***** src/comm/ *****
***** src/comm/none/ *****
***** src/mem/ *****
***** src/mem/jemalloc/ *****
***** src/tasks/ *****
***** src/tasks/qthreads/ *****
***** src/threads/ *****
***** src/threads/none/ *****
***** src/timers/ *****
***** src/timers/generic/ *****
***** src/topo/ *****
***** src/topo/hwloc/ *****
***** src/qio/regexp/re2/ *****
***** src/qio/auxFilesys/hdfs/ *****
***** src/qio/auxFilesys/curl/ *****
***** src/qio/ *****
***** src/ *****
***** ./ *****
Making the runtime for LLVM...
Making hwloc...
make[3]: Nothing to be done for `hwloc'.
Making jemalloc...
make[3]: Nothing to be done for `jemalloc'.
Making third-party-packages...
make[3]: Nothing to be done for `qthread'.
make[3]: Nothing to be done for `re2'.
make[3]: Nothing to be done for `gmp'.
make[3]: Nothing to be done for `jemalloc'.
make[3]: Nothing to be done for `hwloc'.
***** src/comm/ *****
***** src/comm/none/ *****
***** src/mem/ *****
***** src/mem/jemalloc/ *****
***** src/tasks/ *****
***** src/tasks/qthreads/ *****
***** src/threads/ *****
***** src/threads/none/ *****
***** src/timers/ *****
***** src/timers/generic/ *****
***** src/topo/ *****
***** src/topo/hwloc/ *****
***** src/qio/regexp/re2/ *****
***** src/qio/auxFilesys/hdfs/ *****
***** src/qio/auxFilesys/curl/ *****
***** src/qio/ *****
***** src/ *****
***** ./ *****
Making the modules...
Updating TAGS...
Making the modules for LLVM...
Updating TAGS...
```