### PR TITLE
Quick fix that causes multi-locale library client to halt when numLocales not set

### DIFF
--- a/runtime/etc/src/mli/client_runtime.c
+++ b/runtime/etc/src/mli/client_runtime.c
@@ -21,11 +21,9 @@
 #define CHPL_RUNTIME_ETC_SRC_MLI_CLIENT_RUNTIME_C_
 
 #include "mli/common_code.c"
+#include "chpllaunch.h"
 #include <sys/types.h>
 #include <unistd.h>
-
-// We'll declare this rather than include "chpllaunch.h" directly.
-int chpl_launcher_main(int argc, char* argv[]);
 
 struct chpl_mli_context chpl_client;
 
@@ -78,13 +76,20 @@ void chpl_mli_terminate(enum chpl_mli_errors e) {
 // process with the launcher's.
 //
 int chpl_mli_client_launch(int argc, char** argv) {
-  pid_t pid = fork();
+  int32_t execNumLocales;
+  pid_t pid;
+
+  if (chpl_launch_prep(argc, argv, &execNumLocales)) {
+    return -1;
+  }
+
+  pid = fork();
 
   if (pid) {
     // TODO: Should parent wait here, or in `chpl_library_finalize`?
     if (pid == -1) { return - 1; }
   } else {
-    chpl_launcher_main(argc, argv);
+    chpl_launch(argc, argv, execNumLocales);
   }
 
   return 0;

--- a/runtime/include/chpllaunch.h
+++ b/runtime/include/chpllaunch.h
@@ -44,6 +44,7 @@ int chpl_get_charset_env_args(char *argv[]);
 void chpl_compute_real_binary_name(const char* argv0);
 const char* chpl_get_real_binary_wrapper(void);
 const char* chpl_get_real_binary_name(void);
+int chpl_launch_prep(int argc, char* argv[], int32_t* outExecNumLocales);
 int chpl_launcher_main(int argc, char* argv[]);
 
 //

--- a/runtime/src/chpl-launcher-common.c
+++ b/runtime/src/chpl-launcher-common.c
@@ -668,7 +668,7 @@ const char* chpl_get_real_binary_name(void) {
   return &chpl_real_binary_name[0];
 }
 
-int chpl_launcher_main(int argc, char* argv[]) {
+int chpl_launch_prep(int argc, char* argv[], int32_t* outExecNumLocales) {
   //
   // This is a user invocation, so parse the arguments to determine
   // the number of locales.
@@ -706,9 +706,22 @@ int chpl_launcher_main(int argc, char* argv[]) {
   //
   CHPL_COMM_PRELAUNCH();
 
+  *outExecNumLocales = execNumLocales;
+
+  return 0;
+}
+
+
+int chpl_launcher_main(int argc, char* argv[]) {
+  int32_t execNumLocales;
+
+  if (chpl_launch_prep(argc, argv, &execNumLocales)) {
+    return -1;
+  }
+
   //
-  // Launch the program
-  // This may not return (e.g., if calling chpl_launch_using_exec())
+  // Launch the program.
+  // This may not return (e.g., if calling chpl_launch_using_exec()).
   //
   return chpl_launch(argc, argv, execNumLocales);
 }


### PR DESCRIPTION
This is a quick fix suggested by @bradcray that will cause a multi-locale library client to halt when the number of locales (or other first pass flags) is not set.

This will not prevent a multi-locale library client from indefinitely blocking in all cases, but it does handle some more common ones.

Testing:

- [x] `ALL` on `linux64` when `CHPL_COMM=gasnet` and `CHPL_LLVM=llvm`
- [x] `release/examples` when `CHPL_COMM=none` and `CHPL_LLVM=llvm`