### PR TITLE
Make commDiags test pass with comm layers supporting network atomics.

### DIFF
--- a/test/parallel/taskPar/sungeun/barrier/commDiags.good
+++ b/test/parallel/taskPar/sungeun/barrier/commDiags.good
@@ -3,7 +3,7 @@ atomic remote test basic
 (get = 1, execute_on = 2)
 (get = 1, execute_on = 2)
 (get = 1, execute_on = 2)
-(get = 2, execute_on = 1)
+(get = N, execute_on = 3-N)
 atomic remote test split phase
 (execute_on_nb = 4)
 (get = 3, execute_on = 2)

--- a/test/parallel/taskPar/sungeun/barrier/commDiags.prediff
+++ b/test/parallel/taskPar/sungeun/barrier/commDiags.prediff
@@ -1,14 +1,28 @@
 #! /usr/bin/env bash
 #
-# With network atomics (using the plain .good file) the first segment of
-# the output for 'atomic remote test basic' has 2 gets and 1 execute_on
-# for one of the tasks and 1 get and 2 execute_ons for the others.  But,
-# which task differs can vary.  So, sort that first section in order to
-# match.  (For configurations that use comm-none.good or na-none.good
-# all the tasks produce the same output, so this is just a long no-op.)
+# With network atomics (thus using the plain .good file), in the first
+# ('atomic remote test basic') segment of the output, the last node to
+# arrive at the barrier will do 2 gets and 1 execute_on, and the others
+# will do 1 get and 2 execute_ons.  Whether it's last to arrive or not,
+# node 0 won't show any of these gets or execute_ons in its comm diags
+# because they are against a node-0 barrier variable and will be short
+# circuited.  But if some node in 1..4 is the last to arrive then its
+# comm diags will show the 2 gets and 1 execute_on.  To deal with this
+# variability, we sort the output for nodes 1..4 in the first section
+# and allow precisely one line of it to have 2 gets and 1 execute_on
+# instead of the other way around.
 #
-(   sed -n '1 p' < $2 \
+# For configurations that use comm-none.good or na-none.good the first
+# section of the output doesn't show N gets and 3-N execute_ons, so this
+# is just a long no-op.
+#
+g='get'
+x='execute_on'
+(   sed -n '1,2 p' < $2 \
  && sed -n '/atomic remote test basic/,/atomic remote test split phase/ p' \
-    < $2 | sed -e '1 d' -e '$ d'| sort \
+        < $2 \
+    | sed -e '1,2 d' -e '$ d' \
+    | sort \
+    | sed -E "\$ s/($g = 2, $x = 1)|($g = 1, $x = 2)/$g = N, $x = 3-N/" \
  && sed -n '/atomic remote test split phase/,$ p' < $2) \
 > $2.tmp && mv $2.tmp $2


### PR DESCRIPTION
The commDiags test would fail sporadically in configurations supporting
network atomics (recent runs: 2/1000 failures with comm=ofi on our Linux
IB-based cluster and 12/100 failures with comm=ugni on a Cray XC).  In
the first block of the output, variability in which task reaches the
barrier last causes variability in the comm diags output.  Here, adjust
for that variability.

1000 runs with comm=ofi and 100 runs with comm=ugni passed, with this
change.