### PR TITLE
Skip NUMA testing for these tests...

### DIFF
--- a/test/arrays/slices/commCounts/sliceLocDist.skipif
+++ b/test/arrays/slices/commCounts/sliceLocDist.skipif
@@ -1,2 +1,1 @@
-CHPL_COMM==none
 CHPL_LOCALE_MODEL==numa

--- a/test/distributions/robust/arithmetic/performance/multilocale/rvfSlices/assignReindex.lm-numa.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/rvfSlices/assignReindex.lm-numa.good
@@ -1,2 +1,0 @@
-(execute_on = 12, execute_on_nb = 6) (get = 101, put = 1, execute_on = 6, execute_on_fast = 2) (get = 101, put = 1, execute_on_fast = 2) (get = 101, put = 1, execute_on_fast = 2)
-(execute_on_nb = 3) (execute_on_fast = 1) (execute_on_fast = 1) (execute_on_fast = 1)

--- a/test/distributions/robust/arithmetic/performance/multilocale/rvfSlices/assignSlice.lm-numa.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/rvfSlices/assignSlice.lm-numa.good
@@ -1,1 +1,0 @@
-(execute_on = 2, execute_on_nb = 6) (get = 38, put = 1, execute_on = 1, execute_on_fast = 2) (get = 38, put = 1, execute_on_fast = 2) (get = 38, put = 1, execute_on_fast = 2)

--- a/test/distributions/robust/arithmetic/performance/multilocale/rvfSlices/reduceSlice.lm-numa.good
+++ b/test/distributions/robust/arithmetic/performance/multilocale/rvfSlices/reduceSlice.lm-numa.good
@@ -1,1 +1,0 @@
-(get = 3, execute_on = 2, execute_on_nb = 6) (get = 38, put = 1, execute_on = 2, execute_on_fast = 2) (get = 38, put = 1, execute_on = 1, execute_on_fast = 2) (get = 38, put = 1, execute_on = 1, execute_on_fast = 2)


### PR DESCRIPTION
This fixes some test failures that came about for GASNet-NUMA due to new tests in PR #12985 with not enough .good files to cover all the cases we test.  Thinking about it a moment more, I'm realizing that I don't care about the behavior of these tests enough under NUMA enough to want to wrestle with getting all the .good files correct, so this PR skipifs the tests and removes some of the (now unnecessary) lm-numa files.
