### PR TITLE
Add file:line info for verbose comm diags executeOn output.

### DIFF
--- a/modules/internal/LocaleModelHelpRuntime.chpl
+++ b/modules/internal/LocaleModelHelpRuntime.chpl
@@ -100,10 +100,13 @@ module LocaleModelHelpRuntime {
   //
   // runtime interface
   //
+  pragma "insert line file info"
   extern proc chpl_comm_execute_on(loc_id: int, subloc_id: int, fn: int,
                                    args: chpl_comm_on_bundle_p, arg_size: size_t);
+  pragma "insert line file info"
   extern proc chpl_comm_execute_on_fast(loc_id: int, subloc_id: int, fn: int,
                                         args: chpl_comm_on_bundle_p, args_size: size_t);
+  pragma "insert line file info"
   extern proc chpl_comm_execute_on_nb(loc_id: int, subloc_id: int, fn: int,
                                       args: chpl_comm_on_bundle_p, args_size: size_t);
   pragma "insert line file info"

--- a/runtime/include/chpl-comm-callbacks.h
+++ b/runtime/include/chpl-comm-callbacks.h
@@ -162,6 +162,8 @@ typedef struct {
       chpl_fn_int_t fid;        //  Function ID
       void *arg;                //  Function arg pointer
       size_t arg_size;          //  Function arg size
+      int lineno;               // source line of communication
+      int32_t filename;         // source file of communication
     } executeOn;
 
   } iu;

--- a/runtime/include/chpl-comm-diags.h
+++ b/runtime/include/chpl-comm-diags.h
@@ -156,9 +156,10 @@ void chpl_comm_diags_verbose_printf(chpl_bool is_unstable,
                                  chpl_lookupFilename(fn), ln, op,       \
                                  (int) node)
 
-#define chpl_comm_diags_verbose_executeOn(kind, node)                   \
+#define chpl_comm_diags_verbose_executeOn(kind, node, ln, fn)           \
   chpl_comm_diags_verbose_printf(false,                                 \
-                                 "remote %-*sexecuteOn, node %d",       \
+                                 "%s:%d: remote %-*sexecuteOn, node %d", \
+                                 chpl_lookupFilename(fn), ln,           \
                                  ((int) strlen(kind)                    \
                                   + ((strlen(kind) == 0) ? 0 : 1)),     \
                                  kind, (int) node)

--- a/runtime/include/chpl-comm.h
+++ b/runtime/include/chpl-comm.h
@@ -457,7 +457,8 @@ void chpl_gen_comm_wide_string_get(void *addr, c_nodeid_t node, void *raddr,
 //
 void chpl_comm_execute_on(c_nodeid_t node, c_sublocid_t subloc,
                           chpl_fn_int_t fid,
-                          chpl_comm_on_bundle_t *arg, size_t arg_size);
+                          chpl_comm_on_bundle_t *arg, size_t arg_size,
+                          int ln, int32_t fn);
 
 //
 // non-blocking execute_on
@@ -465,15 +466,17 @@ void chpl_comm_execute_on(c_nodeid_t node, c_sublocid_t subloc,
 //
 void chpl_comm_execute_on_nb(c_nodeid_t node, c_sublocid_t subloc,
                              chpl_fn_int_t fid,
-                             chpl_comm_on_bundle_t *arg, size_t arg_size);
+                             chpl_comm_on_bundle_t *arg, size_t arg_size,
+                             int ln, int32_t fn);
 
 //
 // fast execute_on (i.e., run in handler)
 // arg can be reused immediately after this call completes.
 //
 void chpl_comm_execute_on_fast(c_nodeid_t node, c_sublocid_t subloc,
-                         chpl_fn_int_t fid,
-                         chpl_comm_on_bundle_t *arg, size_t arg_size);
+                               chpl_fn_int_t fid,
+                               chpl_comm_on_bundle_t *arg, size_t arg_size,
+                               int ln, int32_t fn);
 
 
 //

--- a/runtime/src/chpl-visual-debug.c
+++ b/runtime/src/chpl-visual-debug.c
@@ -443,7 +443,7 @@ void cb_comm_get_strd (const chpl_comm_cb_info_t *info) {
   }
 }
 
-// Record>  fork: time.sec nodeId forkNodeId subLoc funcId arg argSize forkTaskId
+// Record>  fork: time.sec nodeId forkNodeId subLoc funcId arg argSize forkTaskId lineNumber fileName
 
 void cb_comm_executeOn (const chpl_comm_cb_info_t *info) {
 
@@ -455,14 +455,15 @@ void cb_comm_executeOn (const chpl_comm_cb_info_t *info) {
     struct timeval tv;
     (void) gettimeofday (&tv, NULL);
     chpl_dprintf (chpl_vdebug_fd,
-                  "fork: %lld.%06ld %d %d %d %d %#lx %zd %s \n",
+                  "fork: %lld.%06ld %d %d %d %d %#lx %zd %s %d %d\n",
                   (long long) tv.tv_sec, (long) tv.tv_usec, info->localNodeID,
                   info->remoteNodeID, cm->subloc, cm->fid, (unsigned long) cm->arg,
-                  cm->arg_size, TID_STRING(buff, executeOnTask));
+                  cm->arg_size, TID_STRING(buff, executeOnTask),
+                  cm->lineno, cm->filename);
   }
 }
 
-// Record>  fork_nb: time.sec nodeId forkNodeId subLoc funcId arg argSize forkTaskId
+// Record>  fork_nb: time.sec nodeId forkNodeId subLoc funcId arg argSize forkTaskId lineNumber fileName
 
 
 void  cb_comm_executeOn_nb (const chpl_comm_cb_info_t *info) {
@@ -472,14 +473,15 @@ void  cb_comm_executeOn_nb (const chpl_comm_cb_info_t *info) {
     char buff[CHPL_TASK_ID_STRING_MAX_LEN];
     struct timeval tv;
     (void) gettimeofday (&tv, NULL);
-    chpl_dprintf (chpl_vdebug_fd, "fork_nb: %lld.%06ld %d %d %d %d %#lx %zd %s\n",
+    chpl_dprintf (chpl_vdebug_fd, "fork_nb: %lld.%06ld %d %d %d %d %#lx %zd %s %d %d\n",
                   (long long) tv.tv_sec, (long) tv.tv_usec, info->localNodeID,
                   info->remoteNodeID, cm->subloc, cm->fid, (unsigned long) cm->arg, 
-                  cm->arg_size, TID_STRING(buff, executeOnTask));
+                  cm->arg_size, TID_STRING(buff, executeOnTask),
+                  cm->lineno, cm->filename);
   }
 }
 
-// Record>  f_fork: time.sec nodeId forkNodeId subLoc funcId arg argSize forkTaskId
+// Record>  f_fork: time.sec nodeId forkNodeId subLoc funcId arg argSize forkTaskId lineNumber fileName
 
 void cb_comm_executeOn_fast (const chpl_comm_cb_info_t *info) {
   if (chpl_vdebug) {
@@ -489,10 +491,11 @@ void cb_comm_executeOn_fast (const chpl_comm_cb_info_t *info) {
     struct timeval tv;
     (void) gettimeofday (&tv, NULL);
     chpl_dprintf (chpl_vdebug_fd,
-                  "f_executeOn: %lld.%06ld %d %d %d %d %#lx %zd %s\n",
+                  "f_fork: %lld.%06ld %d %d %d %d %#lx %zd %s %d %d\n",
                   (long long) tv.tv_sec, (long) tv.tv_usec, info->localNodeID,
                   info->remoteNodeID, cm->subloc, cm->fid, (unsigned long)cm->arg, 
-                  cm->arg_size, TID_STRING(buff, executeOnTask));
+                  cm->arg_size, TID_STRING(buff, executeOnTask),
+                  cm->lineno, cm->filename);
   }
 }
 

--- a/runtime/src/comm/gasnet/comm-gasnet.c
+++ b/runtime/src/comm/gasnet/comm-gasnet.c
@@ -1510,8 +1510,9 @@ void  execute_on_common(c_nodeid_t node, c_sublocid_t subloc,
 ////GASNET - introduce locale-int size
 ////GASNET - is caller in chpl_comm_on_bundle_t redundant? active message can determine this.
 void  chpl_comm_execute_on(c_nodeid_t node, c_sublocid_t subloc,
-                     chpl_fn_int_t fid,
-                     chpl_comm_on_bundle_t *arg, size_t arg_size) {
+                           chpl_fn_int_t fid,
+                           chpl_comm_on_bundle_t *arg, size_t arg_size,
+                           int ln, int32_t fn) {
   if (chpl_nodeID == node) {
     assert(0);
     chpl_ftable_call(fid, arg);
@@ -1524,7 +1525,7 @@ void  chpl_comm_execute_on(c_nodeid_t node, c_sublocid_t subloc,
       chpl_comm_do_callbacks (&cb_data);
     }
 
-    chpl_comm_diags_verbose_executeOn("", node);
+    chpl_comm_diags_verbose_executeOn("", node, ln, fn);
     chpl_comm_diags_incr(execute_on);
 
     execute_on_common(node, subloc, fid, arg, arg_size,
@@ -1533,8 +1534,9 @@ void  chpl_comm_execute_on(c_nodeid_t node, c_sublocid_t subloc,
 }
 
 void  chpl_comm_execute_on_nb(c_nodeid_t node, c_sublocid_t subloc,
-                        chpl_fn_int_t fid,
-                        chpl_comm_on_bundle_t *arg, size_t arg_size) {
+                              chpl_fn_int_t fid,
+                              chpl_comm_on_bundle_t *arg, size_t arg_size,
+                              int ln, int32_t fn) {
 
   if (chpl_nodeID == node) {
     assert(0); // locale model code should prevent this...
@@ -1547,7 +1549,7 @@ void  chpl_comm_execute_on_nb(c_nodeid_t node, c_sublocid_t subloc,
       chpl_comm_do_callbacks (&cb_data);
     }
 
-    chpl_comm_diags_verbose_executeOn("non-blocking", node);
+    chpl_comm_diags_verbose_executeOn("non-blocking", node, ln, fn);
     chpl_comm_diags_incr(execute_on_nb);
   
     execute_on_common(node, subloc, fid, arg, arg_size,
@@ -1557,8 +1559,9 @@ void  chpl_comm_execute_on_nb(c_nodeid_t node, c_sublocid_t subloc,
 
 // GASNET - should only be called for "small" functions
 void  chpl_comm_execute_on_fast(c_nodeid_t node, c_sublocid_t subloc,
-                          chpl_fn_int_t fid,
-                          chpl_comm_on_bundle_t *arg, size_t arg_size) {
+                                chpl_fn_int_t fid,
+                                chpl_comm_on_bundle_t *arg, size_t arg_size,
+                                int ln, int32_t fn) {
   if (chpl_nodeID == node) {
     assert(0);
     chpl_ftable_call(fid, arg);
@@ -1571,7 +1574,7 @@ void  chpl_comm_execute_on_fast(c_nodeid_t node, c_sublocid_t subloc,
       chpl_comm_do_callbacks (&cb_data);
     }
 
-    chpl_comm_diags_verbose_executeOn("fast", node);
+    chpl_comm_diags_verbose_executeOn("fast", node, ln, fn);
     chpl_comm_diags_incr(execute_on_fast);
 
     execute_on_common(node, subloc, fid, arg, arg_size,

--- a/runtime/src/comm/gasnet/comm-gasnet.c
+++ b/runtime/src/comm/gasnet/comm-gasnet.c
@@ -1521,7 +1521,7 @@ void  chpl_comm_execute_on(c_nodeid_t node, c_sublocid_t subloc,
     if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_executeOn)) {
       chpl_comm_cb_info_t cb_data = 
         {chpl_comm_cb_event_kind_executeOn, chpl_nodeID, node,
-         .iu.executeOn={subloc, fid, arg, arg_size}};
+         .iu.executeOn={subloc, fid, arg, arg_size, ln, fn}};
       chpl_comm_do_callbacks (&cb_data);
     }
 
@@ -1545,7 +1545,7 @@ void  chpl_comm_execute_on_nb(c_nodeid_t node, c_sublocid_t subloc,
     if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_executeOn_nb)) {
       chpl_comm_cb_info_t cb_data = 
         {chpl_comm_cb_event_kind_executeOn_nb, chpl_nodeID, node,
-         .iu.executeOn={subloc, fid, arg, arg_size}};
+         .iu.executeOn={subloc, fid, arg, arg_size, ln, fn}};
       chpl_comm_do_callbacks (&cb_data);
     }
 
@@ -1570,7 +1570,7 @@ void  chpl_comm_execute_on_fast(c_nodeid_t node, c_sublocid_t subloc,
     if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_executeOn_fast)) {
       chpl_comm_cb_info_t cb_data = 
         {chpl_comm_cb_event_kind_executeOn_fast, chpl_nodeID, node,
-         .iu.executeOn={subloc, fid, arg, arg_size}};
+         .iu.executeOn={subloc, fid, arg, arg_size, ln, fn}};
       chpl_comm_do_callbacks (&cb_data);
     }
 

--- a/runtime/src/comm/none/comm-none.c
+++ b/runtime/src/comm/none/comm-none.c
@@ -192,16 +192,18 @@ typedef struct {
 } fork_t;
 
 void chpl_comm_execute_on(c_nodeid_t node, c_sublocid_t subloc,
-                    chpl_fn_int_t fid,
-                    chpl_comm_on_bundle_t *arg, size_t arg_size) {
+                          chpl_fn_int_t fid,
+                          chpl_comm_on_bundle_t *arg, size_t arg_size,
+                          int ln, int32_t fn) {
   assert(node==0);
 
   chpl_ftable_call(fid, arg);
 }
 
 void chpl_comm_execute_on_nb(c_nodeid_t node, c_sublocid_t subloc,
-                       chpl_fn_int_t fid,
-                       chpl_comm_on_bundle_t *arg, size_t arg_size) {
+                             chpl_fn_int_t fid,
+                             chpl_comm_on_bundle_t *arg, size_t arg_size,
+                             int ln, int32_t fn) {
   assert(node==0);
 
   chpl_task_startMovedTask(fid, chpl_ftable[fid],
@@ -211,8 +213,9 @@ void chpl_comm_execute_on_nb(c_nodeid_t node, c_sublocid_t subloc,
 
 // Same as chpl_comm_execute_on()
 void chpl_comm_execute_on_fast(c_nodeid_t node, c_sublocid_t subloc,
-                         chpl_fn_int_t fid,
-                         chpl_comm_on_bundle_t *arg, size_t arg_size) {
+                               chpl_fn_int_t fid,
+                               chpl_comm_on_bundle_t *arg, size_t arg_size,
+                               int ln, int32_t fn) {
   assert(node==0);
 
   chpl_ftable_call(fid, arg);

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -1421,7 +1421,8 @@ void chpl_comm_task_end(void) { }
 
 void chpl_comm_execute_on(c_nodeid_t node, c_sublocid_t subloc,
                           chpl_fn_int_t fid,
-                          chpl_comm_on_bundle_t *arg, size_t argSize) {
+                          chpl_comm_on_bundle_t *arg, size_t argSize,
+                          int ln, int32_t fn) {
   DBG_PRINTF(DBG_INTERFACE,
              "chpl_comm_execute_on(%d, %d, %d, %p, %zd)",
              (int) node, (int) subloc, (int) fid, arg, argSize);
@@ -1435,7 +1436,7 @@ void chpl_comm_execute_on(c_nodeid_t node, c_sublocid_t subloc,
     chpl_comm_do_callbacks (&cb_data);
   }
 
-  chpl_comm_diags_verbose_executeOn("", node);
+  chpl_comm_diags_verbose_executeOn("", node, ln, fn);
   chpl_comm_diags_incr(execute_on);
 
   amRequestExecOn(node, subloc, fid, arg, argSize, false, true);
@@ -1451,7 +1452,8 @@ static void fork_nb_wrapper(chpl_comm_on_bundle_t *f) {
 
 void chpl_comm_execute_on_nb(c_nodeid_t node, c_sublocid_t subloc,
                              chpl_fn_int_t fid,
-                             chpl_comm_on_bundle_t *arg, size_t argSize) {
+                             chpl_comm_on_bundle_t *arg, size_t argSize,
+                             int ln, int32_t fn) {
   DBG_PRINTF(DBG_INTERFACE,
              "chpl_comm_execute_on_nb(%d, %d, %d, %p, %zd)",
              (int) node, (int) subloc, (int) fid, arg, argSize);
@@ -1465,7 +1467,7 @@ void chpl_comm_execute_on_nb(c_nodeid_t node, c_sublocid_t subloc,
     chpl_comm_do_callbacks (&cb_data);
   }
 
-  chpl_comm_diags_verbose_executeOn("non-blocking", node);
+  chpl_comm_diags_verbose_executeOn("non-blocking", node, ln, fn);
   chpl_comm_diags_incr(execute_on_nb);
 
   amRequestExecOn(node, subloc, fid, arg, argSize, false, false);
@@ -1474,7 +1476,8 @@ void chpl_comm_execute_on_nb(c_nodeid_t node, c_sublocid_t subloc,
 
 void chpl_comm_execute_on_fast(c_nodeid_t node, c_sublocid_t subloc,
                                chpl_fn_int_t fid,
-                               chpl_comm_on_bundle_t *arg, size_t argSize) {
+                               chpl_comm_on_bundle_t *arg, size_t argSize,
+                               int ln, int32_t fn) {
   DBG_PRINTF(DBG_INTERFACE,
              "chpl_comm_execute_on_fast(%d, %d, %d, %p, %zd)",
              (int) node, (int) subloc, (int) fid, arg, argSize);
@@ -1488,7 +1491,7 @@ void chpl_comm_execute_on_fast(c_nodeid_t node, c_sublocid_t subloc,
     chpl_comm_do_callbacks (&cb_data);
   }
 
-  chpl_comm_diags_verbose_executeOn("fast", node);
+  chpl_comm_diags_verbose_executeOn("fast", node, ln, fn);
   chpl_comm_diags_incr(execute_on_fast);
 
   amRequestExecOn(node, subloc, fid, arg, argSize, true, true);

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -1432,7 +1432,7 @@ void chpl_comm_execute_on(c_nodeid_t node, c_sublocid_t subloc,
   if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_executeOn)) {
     chpl_comm_cb_info_t cb_data =
       {chpl_comm_cb_event_kind_executeOn, chpl_nodeID, node,
-       .iu.executeOn={subloc, fid, arg, argSize}};
+       .iu.executeOn={subloc, fid, arg, argSize, ln, fn}};
     chpl_comm_do_callbacks (&cb_data);
   }
 
@@ -1463,7 +1463,7 @@ void chpl_comm_execute_on_nb(c_nodeid_t node, c_sublocid_t subloc,
   if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_executeOn_nb)) {
     chpl_comm_cb_info_t cb_data =
       {chpl_comm_cb_event_kind_executeOn_nb, chpl_nodeID, node,
-       .iu.executeOn={subloc, fid, arg, argSize}};
+       .iu.executeOn={subloc, fid, arg, argSize, ln, fn}};
     chpl_comm_do_callbacks (&cb_data);
   }
 
@@ -1487,7 +1487,7 @@ void chpl_comm_execute_on_fast(c_nodeid_t node, c_sublocid_t subloc,
   if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_executeOn_fast)) {
     chpl_comm_cb_info_t cb_data =
       {chpl_comm_cb_event_kind_executeOn_fast, chpl_nodeID, node,
-       .iu.executeOn={subloc, fid, arg, argSize}};
+       .iu.executeOn={subloc, fid, arg, argSize, ln, fn}};
     chpl_comm_do_callbacks (&cb_data);
   }
 

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -7372,7 +7372,8 @@ void amo_add_real64_cpu_cmpxchg(void* result, void* object, void* operand)
 
 void chpl_comm_execute_on(c_nodeid_t locale, c_sublocid_t subloc,
                           chpl_fn_int_t fid,
-                          chpl_comm_on_bundle_t* arg, size_t arg_size)
+                          chpl_comm_on_bundle_t* arg, size_t arg_size,
+                          int ln, int32_t fn)
 {
   DBG_P_LP(DBGF_IFACE|DBGF_RF,
            "IFACE chpl_comm_execute_on(%d:%d, ftable[%d](%p, %zd))",
@@ -7388,7 +7389,7 @@ void chpl_comm_execute_on(c_nodeid_t locale, c_sublocid_t subloc,
       chpl_comm_do_callbacks (&cb_data);
   }
 
-  chpl_comm_diags_verbose_executeOn("", locale);
+  chpl_comm_diags_verbose_executeOn("", locale, ln, fn);
   chpl_comm_diags_incr(execute_on);
 
   PERFSTATS_INC(fork_call_cnt);
@@ -7398,7 +7399,8 @@ void chpl_comm_execute_on(c_nodeid_t locale, c_sublocid_t subloc,
 
 void chpl_comm_execute_on_nb(c_nodeid_t locale, c_sublocid_t subloc,
                              chpl_fn_int_t fid,
-                             chpl_comm_on_bundle_t* arg, size_t arg_size)
+                             chpl_comm_on_bundle_t* arg, size_t arg_size,
+                             int ln, int32_t fn)
 {
   DBG_P_LP(DBGF_IFACE|DBGF_RF,
            "IFACE chpl_comm_execute_on_nb(%d:%d, ftable[%d](%p, %zd))",
@@ -7414,7 +7416,7 @@ void chpl_comm_execute_on_nb(c_nodeid_t locale, c_sublocid_t subloc,
       chpl_comm_do_callbacks (&cb_data);
   }
 
-  chpl_comm_diags_verbose_executeOn("non-blocking", locale);
+  chpl_comm_diags_verbose_executeOn("non-blocking", locale, ln, fn);
   chpl_comm_diags_incr(execute_on_nb);
 
   PERFSTATS_INC(fork_call_nb_cnt);
@@ -7424,7 +7426,8 @@ void chpl_comm_execute_on_nb(c_nodeid_t locale, c_sublocid_t subloc,
 
 void chpl_comm_execute_on_fast(c_nodeid_t locale, c_sublocid_t subloc,
                                chpl_fn_int_t fid,
-                               chpl_comm_on_bundle_t* arg, size_t arg_size)
+                               chpl_comm_on_bundle_t* arg, size_t arg_size,
+                               int ln, int32_t fn)
 {
   DBG_P_LP(DBGF_IFACE|DBGF_RF,
            "IFACE chpl_comm_execute_on_fast(%d:%d, ftable[%d](%p, %zd))",
@@ -7440,7 +7443,7 @@ void chpl_comm_execute_on_fast(c_nodeid_t locale, c_sublocid_t subloc,
       chpl_comm_do_callbacks (&cb_data);
   }
 
-  chpl_comm_diags_verbose_executeOn("fast", locale);
+  chpl_comm_diags_verbose_executeOn("fast", locale, ln, fn);
   chpl_comm_diags_incr(execute_on_fast);
 
   //

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -7385,7 +7385,7 @@ void chpl_comm_execute_on(c_nodeid_t locale, c_sublocid_t subloc,
   if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_executeOn)) {
       chpl_comm_cb_info_t cb_data = 
         {chpl_comm_cb_event_kind_executeOn, chpl_nodeID, locale,
-         .iu.executeOn={subloc, fid, arg, arg_size}};
+         .iu.executeOn={subloc, fid, arg, arg_size, ln, fn}};
       chpl_comm_do_callbacks (&cb_data);
   }
 
@@ -7412,7 +7412,7 @@ void chpl_comm_execute_on_nb(c_nodeid_t locale, c_sublocid_t subloc,
   if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_executeOn_nb)) {
       chpl_comm_cb_info_t cb_data = 
         {chpl_comm_cb_event_kind_executeOn_nb, chpl_nodeID, locale,
-         .iu.executeOn={subloc, fid, arg, arg_size}};
+         .iu.executeOn={subloc, fid, arg, arg_size, ln, fn}};
       chpl_comm_do_callbacks (&cb_data);
   }
 
@@ -7439,7 +7439,7 @@ void chpl_comm_execute_on_fast(c_nodeid_t locale, c_sublocid_t subloc,
   if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_executeOn_fast)) {
       chpl_comm_cb_info_t cb_data = 
         {chpl_comm_cb_event_kind_executeOn_fast, chpl_nodeID, locale,
-         .iu.executeOn={subloc, fid, arg, arg_size}};
+         .iu.executeOn={subloc, fid, arg, arg_size, ln, fn}};
       chpl_comm_do_callbacks (&cb_data);
   }
 

--- a/test/extern/diten/externfaston.good
+++ b/test/extern/diten/externfaston.good
@@ -1,2 +1,2 @@
-0: remote executeOn, node 1
-0: remote fast executeOn, node 1
+0: externfaston.chpl:16: remote fast executeOn, node 1
+0: externfaston.chpl:20: remote executeOn, node 1

--- a/test/multilocale/deitz/needMultiLocales/diagnostics/test_private_broadcast_large.good
+++ b/test/multilocale/deitz/needMultiLocales/diagnostics/test_private_broadcast_large.good
@@ -1,4 +1,4 @@
-0: remote executeOn, node 1
+0: test_private_broadcast_large.chpl:16: remote executeOn, node 1
 1
 10
 100

--- a/test/multilocale/deitz/needMultiLocales/diagnostics/test_private_broadcast_small.good
+++ b/test/multilocale/deitz/needMultiLocales/diagnostics/test_private_broadcast_small.good
@@ -1,3 +1,3 @@
-0: remote executeOn, node 1
+0: test_private_broadcast_small.chpl:9: remote executeOn, node 1
 23
 23

--- a/test/multilocale/engin/verboseComm.good
+++ b/test/multilocale/engin/verboseComm.good
@@ -1,3 +1,3 @@
-0: remote executeOn, node 1
+0: verboseComm.chpl:5: remote executeOn, node 1
 1
 1: verboseComm.chpl:6: remote put, node 0, 8 bytes

--- a/tools/chplvis/DataModel.cxx
+++ b/tools/chplvis/DataModel.cxx
@@ -1091,7 +1091,7 @@ int DataModel::LoadFile (const char *fileToOpen, int index, double seq)
 
       case 'f':  // All the forks:
         // s.u nodeID otherNode subloc fid arg arg_size
-        if ((cvt = sscanf (&linedata[nextCh], "%d %d %*d %d 0x%*x %d %d",
+        if ((cvt = sscanf (&linedata[nextCh], "%d %d %*d %d 0x%*x %d %d %*d %*d",
                            &nid, &rnid, &fid, &dlen, &vdbTid)) != 5) {
           fprintf (stderr, "Bad fork line: (cvt %d) %s\n", cvt, fileToOpen);
           nErrs++;

--- a/tools/chplvis/TextDataFormat.txt
+++ b/tools/chplvis/TextDataFormat.txt
@@ -84,9 +84,9 @@ Lines in the file:
     communication.  Puts: data flow nid->rid, gets: data flow rid -> nid
     nb is non-blocking, st is strided.
 
-  fork: tv nid rid subLoc fid argPtr argSize tid
-  fork_nb: tv nid rid subLoc fid argPtr argSize tid
-  f_fork:  tv nid rid subLoc fid argPtr argSize tid
+  fork: tv nid rid subLoc fid argPtr argSize tid lnum fileno
+  fork_nb: tv nid rid subLoc fid argPtr argSize tid lnum fileno
+  f_fork:  tv nid rid subLoc fid argPtr argSize tid lnum fileno
      fork a task on a remote locale.   nb is non-blocking, f_fork does
      not start a remote task.  Data is sent from nid to rid.
 


### PR DESCRIPTION
In verbose comm diagnostics we print the file:line at which the
communication originated if it is a GET, PUT, or AMO, but we have not
been doing so if it is an executeOn for an on-stmt.  Start doing so.

Also send this data into the runtime comm callbacks and update
chplvis datafile production to include it.  But in the chplvis tool
itself, arrange to ignore it, because I'm not prepared to do the
work to pipe it through the input processing and into the GUI
(if indeed it's wanted there).