### PR TITLE
Quick fix to chpl_launch_prep that makes adjusted argc visible to caller

### DIFF
--- a/runtime/etc/src/mli/client_runtime.c
+++ b/runtime/etc/src/mli/client_runtime.c
@@ -76,10 +76,10 @@ void chpl_mli_terminate(enum chpl_mli_errors e) {
 // process with the launcher's.
 //
 int chpl_mli_client_launch(int argc, char** argv) {
-  int32_t execNumLocales = 0;
+  int32_t execNumLocales;
   pid_t pid;
 
-  if (chpl_launch_prep(&argc, &argv, &execNumLocales)) {
+  if (chpl_launch_prep(&argc, argv, &execNumLocales)) {
     return -1;
   }
 

--- a/runtime/etc/src/mli/client_runtime.c
+++ b/runtime/etc/src/mli/client_runtime.c
@@ -76,10 +76,10 @@ void chpl_mli_terminate(enum chpl_mli_errors e) {
 // process with the launcher's.
 //
 int chpl_mli_client_launch(int argc, char** argv) {
-  int32_t execNumLocales;
+  int32_t execNumLocales = 0;
   pid_t pid;
 
-  if (chpl_launch_prep(argc, argv, &execNumLocales)) {
+  if (chpl_launch_prep(&argc, &argv, &execNumLocales)) {
     return -1;
   }
 

--- a/runtime/include/chpllaunch.h
+++ b/runtime/include/chpllaunch.h
@@ -44,7 +44,7 @@ int chpl_get_charset_env_args(char *argv[]);
 void chpl_compute_real_binary_name(const char* argv0);
 const char* chpl_get_real_binary_wrapper(void);
 const char* chpl_get_real_binary_name(void);
-int chpl_launch_prep(int* c_argc, char** c_argv[], int32_t* c_execNumLocales);
+int chpl_launch_prep(int* c_argc, char* argv[], int32_t* c_execNumLocales);
 int chpl_launcher_main(int argc, char* argv[]);
 
 //

--- a/runtime/include/chpllaunch.h
+++ b/runtime/include/chpllaunch.h
@@ -44,7 +44,7 @@ int chpl_get_charset_env_args(char *argv[]);
 void chpl_compute_real_binary_name(const char* argv0);
 const char* chpl_get_real_binary_wrapper(void);
 const char* chpl_get_real_binary_name(void);
-int chpl_launch_prep(int argc, char* argv[], int32_t* outExecNumLocales);
+int chpl_launch_prep(int* c_argc, char** c_argv[], int32_t* c_execNumLocales);
 int chpl_launcher_main(int argc, char* argv[]);
 
 //

--- a/runtime/src/chpl-launcher-common.c
+++ b/runtime/src/chpl-launcher-common.c
@@ -713,54 +713,15 @@ int chpl_launch_prep(int* c_argc, char* argv[], int32_t* c_execNumLocales) {
   return 0;
 }
 
-int chpl_launcher_main_old(int argc, char* argv[]);
-int chpl_launcher_main_old(int argc, char* argv[]) {
-
-  //
-  // This is a user invocation, so parse the arguments to determine
-  // the number of locales.
-  //
-  int32_t execNumLocales;
-
-  // Set up main argument parsing.
-  chpl_gen_main_arg.argv = chpl_mem_allocMany(argc, sizeof(char*),
-                                      CHPL_RT_MD_COMMAND_BUFFER, -1, 0);
-  chpl_gen_main_arg.argv[0] = argv[0];
-  chpl_gen_main_arg.argc = 1;
-  chpl_gen_main_arg.return_value = 0;
-
-  CreateConfigVarTable();
-  parseArgs(true, parse_normally, &argc, argv);
-
-  execNumLocales = getArgNumLocales();
-
-  //
-  // If the user did not specify a number of locales let the
-  // comm layer decide how many to use (or flag an error)
-  //
-  if (execNumLocales == 0) {
-    execNumLocales = chpl_comm_default_num_locales();
-  }
-  //
-  // Before proceeding, allow the comm layer to verify that the
-  // number of locales is reasonable
-  //
-  chpl_comm_verify_num_locales(execNumLocales);
-
-  //
-  // Let the comm layer do any last-minute pre-launch activities it
-  // needs to.
-  //
-  CHPL_COMM_PRELAUNCH();
-
-  return chpl_launch(argc, argv, execNumLocales);
-}
 
 int chpl_launcher_main(int argc, char* argv[]) {
   int32_t execNumLocales;
 
-  return chpl_launcher_main_old(argc, argv);
-
+  //
+  // The chpl_launch_prep function calls parseArgs, which modifies argc, so
+  // so we need to make sure those changes are visible before calling
+  // chpl_launch.
+  //
   if (chpl_launch_prep(&argc, argv, &execNumLocales)) {
     return -1;
   }

--- a/runtime/src/chpl-launcher-common.c
+++ b/runtime/src/chpl-launcher-common.c
@@ -668,12 +668,15 @@ const char* chpl_get_real_binary_name(void) {
   return &chpl_real_binary_name[0];
 }
 
-int chpl_launch_prep(int argc, char* argv[], int32_t* outExecNumLocales) {
+int chpl_launch_prep(int* c_argc, char** c_argv[], 
+                     int32_t* c_execNumLocales) {
   //
   // This is a user invocation, so parse the arguments to determine
   // the number of locales.
   //
-  int32_t execNumLocales;
+  int32_t execNumLocales = *c_execNumLocales;
+  char* argv[] = *c_argv;
+  int argc = *c_argc;
 
   // Set up main argument parsing.
   chpl_gen_main_arg.argv = chpl_mem_allocMany(argc, sizeof(char*),
@@ -706,16 +709,18 @@ int chpl_launch_prep(int argc, char* argv[], int32_t* outExecNumLocales) {
   //
   CHPL_COMM_PRELAUNCH();
 
-  *outExecNumLocales = execNumLocales;
+  *c_execNumLocales = execNumLocales;
+  *c_argv = argv;
+  *c_argc = argc;
 
   return 0;
 }
 
 
 int chpl_launcher_main(int argc, char* argv[]) {
-  int32_t execNumLocales;
+  int32_t execNumLocales = 0;
 
-  if (chpl_launch_prep(argc, argv, &execNumLocales)) {
+  if (chpl_launch_prep(&argc, &argv, &execNumLocales)) {
     return -1;
   }
 

--- a/runtime/src/chpl-launcher-common.c
+++ b/runtime/src/chpl-launcher-common.c
@@ -668,14 +668,12 @@ const char* chpl_get_real_binary_name(void) {
   return &chpl_real_binary_name[0];
 }
 
-int chpl_launch_prep(int* c_argc, char** c_argv[], 
-                     int32_t* c_execNumLocales) {
+int chpl_launch_prep(int* c_argc, char* argv[], int32_t* c_execNumLocales) {
   //
   // This is a user invocation, so parse the arguments to determine
   // the number of locales.
   //
-  int32_t execNumLocales = *c_execNumLocales;
-  char** argv = *c_argv;
+  int32_t execNumLocales;
   int argc = *c_argc;
 
   // Set up main argument parsing.
@@ -710,7 +708,6 @@ int chpl_launch_prep(int* c_argc, char** c_argv[],
   CHPL_COMM_PRELAUNCH();
 
   *c_execNumLocales = execNumLocales;
-  *c_argv = argv;
   *c_argc = argc;
 
   return 0;
@@ -718,9 +715,9 @@ int chpl_launch_prep(int* c_argc, char** c_argv[],
 
 
 int chpl_launcher_main(int argc, char* argv[]) {
-  int32_t execNumLocales = 0;
+  int32_t execNumLocales;
 
-  if (chpl_launch_prep(&argc, &argv, &execNumLocales)) {
+  if (chpl_launch_prep(&argc, argv, &execNumLocales)) {
     return -1;
   }
 

--- a/runtime/src/chpl-launcher-common.c
+++ b/runtime/src/chpl-launcher-common.c
@@ -713,8 +713,8 @@ int chpl_launch_prep(int* c_argc, char* argv[], int32_t* c_execNumLocales) {
   return 0;
 }
 
-int chpl_launcher_main_old(int argc, char* argv);
-int chpl_launcher_main_old(int argc, char* argv) {
+int chpl_launcher_main_old(int argc, char* argv[]);
+int chpl_launcher_main_old(int argc, char* argv[]) {
 
   //
   // This is a user invocation, so parse the arguments to determine

--- a/runtime/src/chpl-launcher-common.c
+++ b/runtime/src/chpl-launcher-common.c
@@ -675,7 +675,7 @@ int chpl_launch_prep(int* c_argc, char** c_argv[],
   // the number of locales.
   //
   int32_t execNumLocales = *c_execNumLocales;
-  char* argv[] = *c_argv;
+  char** argv = *c_argv;
   int argc = *c_argc;
 
   // Set up main argument parsing.


### PR DESCRIPTION
This PR attempts to fix failures caused by launcher flags (incorrectly) not being stripped from `argv` at program launch. The original code in `chpl_launcher_prep` made changes to the value of `argv` that were only visible locally, and not to the caller (which calls `chpl_launch`).

The function `chpl_launcher_prep` now takes a pointer to `argc`, which the updated value is written to before the function returns.

Testing:

- [ ] `ALL` on `linux64` when `CHPL_COMM=gasnet`