### PR TITLE
Remove domainMaps.suppressif

### DIFF
--- a/test/memory/sungeun/refCount/domainMaps.suppressif
+++ b/test/memory/sungeun/refCount/domainMaps.suppressif
@@ -1,3 +1,0 @@
-# baseline memory leak, see JIRA issue 77
-
-COMPOPTS <= --baseline


### PR DESCRIPTION
#12963 eliminated memory leaks in this test upon --baseline, so the .suppressif is no longer needed.