### PR TITLE
Fix compilation error in mason

### DIFF
--- a/tools/mason/MasonEnv.chpl
+++ b/tools/mason/MasonEnv.chpl
@@ -155,7 +155,9 @@ private proc getRegNameFromLoc(location: string): string {
     exit(1);
   }
   if strippedLoc.endsWith(".git") {
-    return strippedLoc[lastSlashPos+1..strippedLoc.length-4];
+    // TODO: this should use a method to get the byte length
+    var beforeGit = (strippedLoc.length-4):byteIndex;
+    return strippedLoc[lastSlashPos+1..beforeGit];
   } else {
     return strippedLoc[lastSlashPos+1..];
   }


### PR DESCRIPTION
PR #12899 changed the unit returned by `string.rfind`,
leading to some code in Mason using a range of mixed type and
getting a compilation error. The code in question is trying to get
a substring after a certain index discovered by `rfind` and up until
an index computed by subtracting something from the length.

Reviewed by @daviditen - thanks!

- [x] full local testing