### PR TITLE
Change O(n**2) string iteration to O(n)

### DIFF
--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -789,11 +789,10 @@ module String {
         d
      */
     iter these() : string {
-      for i in 1..this.len {
+      for cp in this.codepoints() do
         // This is pretty painful from a performance perspective right now,
         // allocates w/ every yield
-        yield this[i];
-      }
+        yield codepointToString(cp);
     }
 
     /*

--- a/test/studies/shootout/k-nucleotide/bharshbarg/knucleotide-strings.chpl
+++ b/test/studies/shootout/k-nucleotide/bharshbarg/knucleotide-strings.chpl
@@ -61,7 +61,7 @@ proc calculate(data : string, size : int) {
       // Assigning to an index in an associative array will create an
       // index/element pair if one does not already exist.
       //
-      privArr[hash(data[i..#size])] += 1;
+      privArr[hash(data[i:byteIndex..#size])] += 1;
     }
 
     lock$;                                  // read to acquire lock


### PR DESCRIPTION
#12899 changed string iteration to default to codepoint units instead of byte units.  Unfortunately, this changed string iteration in at least two places into an `O(n**2)` operation.  This changes the two known locations back to `O(n)` to fix nightly testing.
