### PR TITLE
Fix typo in future

### DIFF
--- a/test/parallel/forall/const-indices.chpl
+++ b/test/parallel/forall/const-indices.chpl
@@ -1,6 +1,6 @@
 var A, B: [1..10] real;
 
-forall i in {1..10} {
+forall i in 1..10 {
   ref a = A[i];
   i = i+1;
   a = i;


### PR DESCRIPTION
Oops... cut and pasted this together too quickly; change domain to range

This test was meant to show that forall loops over domains and ranges
were broken but I accidentally committed it with the same domain idiom
twice rather than making one of the loops over a range.

Thanks @cassella!