### PR TITLE
Fix failures in nilability tests with numa locale model

### DIFF
--- a/modules/internal/localeModels/numa/LocaleModel.chpl
+++ b/modules/internal/localeModels/numa/LocaleModel.chpl
@@ -83,8 +83,15 @@ module LocaleModel {
       halt("No children to iterate over.");
       yield -1;
     }
-    proc addChild(loc:locale) { halt("Cannot add children to this locale type."); }
-    override proc getChild(idx:int) : locale { return nil; }
+    proc addChild(loc:locale) {
+      halt("Cannot add children to this locale type.");
+    }
+    pragma "unsafe"
+    override proc getChild(idx:int) : locale {
+      halt("Cannot getChild with this locale type");
+      var ret: locale; // default-initialize
+      return ret;
+    }
 
     iter getChildren() : locale {
       halt("No children to iterate over.");

--- a/test/localeModels/numa/basics/hello7-taskpar-sublocs.chpl
+++ b/test/localeModels/numa/basics/hello7-taskpar-sublocs.chpl
@@ -65,8 +65,8 @@ coforall loc in Locales {
         // - '.name' queries its name (similar to UNIX `hostname`)
         // - 'numLocales' refers to the number of locales (as specified by -nl)
         //
-        message += "locale " + here.parent.id + " of " + numLocales;
-        if (printLocaleName) then message += " named " + here.parent.name;
+        message += "locale " + here.parent!.id + " of " + numLocales;
+        if (printLocaleName) then message += " named " + here.parent!.name;
 
         //
         // Terminate the message


### PR DESCRIPTION
Follow-on to #13050.

Enables the combination of `--no-legacy-nilable-classes` and
CHPL_LOCALE_MODEL=numa to function, at least for simple programs.

- [x] full local testing

Reviewed by @benharsh - thanks!