### PR TITLE
Add a LocalSpinlock wrapper to replace manual testAndSet locks

### DIFF
--- a/modules/internal/ChapelLocks.chpl
+++ b/modules/internal/ChapelLocks.chpl
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2004-2019 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Collection of mutexes/locks.
+ */
+module ChapelLocks {
+  use MemConsistency;
+  /*
+   * Local processor atomic spinlock. Intended for situations with minimal
+   * contention or very short critical sections.
+   */
+  pragma "default intent is ref"
+  record chpl_LocalSpinlock {
+    var l: chpl__processorAtomicType(bool);
+
+    inline proc lock() {
+      on this do
+        while l.testAndSet(memory_order_acquire) do
+          chpl_task_yield();
+    }
+
+    inline proc unlock() {
+      l.clear(memory_order_release);
+    }
+  }
+}

--- a/modules/internal/ChapelStandard.chpl
+++ b/modules/internal/ChapelStandard.chpl
@@ -37,6 +37,7 @@ module ChapelStandard {
   use NetworkAtomics;
   use NetworkAtomicTypes;
   use AtomicsCommon;
+  use ChapelLocks;
   use ChapelIteratorSupport;
   use ChapelThreads;
   use ChapelThreadsInternal;

--- a/modules/internal/DefaultAssociative.chpl
+++ b/modules/internal/DefaultAssociative.chpl
@@ -63,18 +63,18 @@ module DefaultAssociative {
     // We explicitly use processor atomics here since this is not
     // by design a distributed data structure
     var numEntries: chpl__processorAtomicType(int);
-    var tableLock: chpl__processorAtomicType(bool); // do not access directly
+    var tableLock: if parSafe then chpl_LocalSpinlock else nothing;
     var tableSizeNum = 1;
     var tableSize : int;
     var tableDom = {0..tableSize-1};
     var table: [tableDom] chpl_TableEntry(idxType);
   
     inline proc lockTable() {
-      while tableLock.testAndSet(memory_order_acquire) do chpl_task_yield();
+      if parSafe then tableLock.lock();
     }
   
     inline proc unlockTable() {
-      tableLock.clear(memory_order_release);
+      if parSafe then tableLock.unlock();
     }
   
     // TODO: An ugly [0..-1] domain appears several times in the code --
@@ -139,11 +139,11 @@ module DefaultAssociative {
       on this {
         postponeResize = false;
         if (numEntries.read()*8 < tableSize && tableSizeNum > 1) {
-          if parSafe then lockTable();
+          lockTable();
           if (numEntries.read()*8 < tableSize && tableSizeNum > 1) {
             _resize(grow=false);
           }
-          if parSafe then unlockTable();
+          unlockTable();
         }
       }
     }
@@ -268,12 +268,12 @@ module DefaultAssociative {
 
     override proc dsiClear() {
       on this {
-        if parSafe then lockTable();
+        lockTable();
         for slot in tableDom {
           table[slot].status = chpl__hash_status.empty;
         }
         numEntries.write(0);
-        if parSafe then unlockTable();
+        unlockTable();
       }
     }
   
@@ -305,9 +305,8 @@ module DefaultAssociative {
       const inSlot = slotNum;
       var retVal = 0;
       on this {
-        const shouldLock = needLock && parSafe;
-        if shouldLock then lockTable();
-        var findAgain = shouldLock;
+        if parSafe && needLock then lockTable();
+        var findAgain = parSafe && needLock;
         if ((numEntries.read()+1)*2 > tableSize) {
           _resize(grow=true);
           findAgain = true;
@@ -316,7 +315,7 @@ module DefaultAssociative {
           (slotNum, retVal) = _add(idx, -1);
         else
           (_, retVal) = _add(idx, inSlot);
-        if shouldLock then unlockTable();
+        if parSafe && needLock then unlockTable();
       }
       return (slotNum, retVal);
     }
@@ -354,7 +353,7 @@ module DefaultAssociative {
     proc dsiRemove(idx: idxType) {
       var retval = 1;
       on this {
-        if parSafe then lockTable();
+        lockTable();
         const (foundSlot, slotNum) = _findFilledSlot(idx, needLock=!parSafe);
         if (foundSlot) {
           for a in _arrs do
@@ -367,7 +366,7 @@ module DefaultAssociative {
         if (numEntries.read()*8 < tableSize && tableSizeNum > 1) {
           _resize(grow=false);
         }
-        if parSafe then unlockTable();
+        unlockTable();
       }
       return retval;
     }
@@ -401,7 +400,7 @@ module DefaultAssociative {
         var prime = chpl__primes(primeLoc);
 
         //Changing underlying structure, time for locking
-        if parSafe then lockTable();
+        lockTable();
         if entries > 0 {
           // Slow path: back up required
           _backupArrays();
@@ -434,8 +433,7 @@ module DefaultAssociative {
           tableDom = {0..tableSize-1};
         }
 
-        //Unlock the table
-        if parSafe then unlockTable();
+        unlockTable();
       } else if entries > numKeys {
         warning("Requested capacity (" + numKeys + ") " +
                 "is less than current size (" + entries + ")");

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -991,7 +991,7 @@ module DefaultRectangular {
     var targetLocDom: domain(rank);
     var RAD: [targetLocDom] _remoteAccessData(eltType, rank, idxType,
                                               stridable);
-    var RADLocks: [targetLocDom] chpl__processorAtomicType(bool); // only accessed locally
+    var RADLocks: [targetLocDom] chpl_LocalSpinlock;
 
     pragma "dont disable remote value forwarding"
     proc init(type eltType, param rank: int, type idxType,
@@ -1004,14 +1004,12 @@ module DefaultRectangular {
       targetLocDom=newTargetLocDom;
     }
 
-    // These functions must always be called locally, because the lock
-    // is a (local) processor one.
     inline proc lockRAD(rlocIdx) {
-      while RADLocks(rlocIdx).testAndSet(memory_order_acquire) do chpl_task_yield();
+      RADLocks[rlocIdx].lock();
     }
 
     inline proc unlockRAD(rlocIdx) {
-      RADLocks(rlocIdx).clear(memory_order_release);
+      RADLocks[rlocIdx].unlock();
     }
   }
 

--- a/modules/internal/LocaleModelHelpRuntime.chpl
+++ b/modules/internal/LocaleModelHelpRuntime.chpl
@@ -131,6 +131,7 @@ module LocaleModelHelpRuntime {
                                       ref tlist: c_void_ptr, tlist_node_id: int,
                                       is_begin: bool);
   extern proc chpl_task_executeTasksInList(ref tlist: c_void_ptr);
+  extern proc chpl_task_yield();
 
   //
   // add a task to a list of tasks being built for a begin statement

--- a/test/modules/sungeun/init/printModuleInitOrder.good
+++ b/test/modules/sungeun/init/printModuleInitOrder.good
@@ -12,6 +12,7 @@ Initializing Modules:
     MemConsistency
     Atomics
     NetworkAtomics
+    ChapelLocks
     ChapelThreads
     ChapelTuple
     ChapelRange

--- a/test/modules/sungeun/init/printModuleInitOrder.na-none.good
+++ b/test/modules/sungeun/init/printModuleInitOrder.na-none.good
@@ -11,6 +11,7 @@ Initializing Modules:
     ChapelBase
     MemConsistency
     Atomics
+    ChapelLocks
     ChapelThreads
     ChapelTuple
     ChapelRange


### PR DESCRIPTION
Add chpl_LocalSpinlock, which is a simple processor atomic testAndSet
spinlock. We used to manually implement spinlocks in a few different
modules, so add a wrapper to avoid duplicate code. This also gives us a
single place to optimize instead of always having to update all the code
using locks.

Locks replaced:
 - manual RadCache lock
 - manual ChapelDistribution lock
 - manul ChapelError lock
 - manual DefaultAssociative lock (plus some cleanup here)
 - DynamicIters.chpl vlock

I do not expect any behavior or performance differences from this, but
it is a pretty nice cleanup. This will make it easier to switch all our
internal locks to test-and-testAndSet locks (#13012)
