### PR TITLE
Replace manual backoff spinlock for reductions with LocalSpinlock

### DIFF
--- a/modules/internal/ChapelReduce.chpl
+++ b/modules/internal/ChapelReduce.chpl
@@ -63,9 +63,9 @@ module ChapelReduce {
 
   proc chpl__reduceCombine(globalOp, localOp) {
     on globalOp {
-      globalOp.lock();
+      globalOp.l.lock();
       globalOp.combine(localOp);
-      globalOp.unlock();
+      globalOp.l.unlock();
     }
   }
 
@@ -134,22 +134,7 @@ module ChapelReduce {
 
   pragma "ReduceScanOp"
   class ReduceScanOp {
-    var l: chpl__processorAtomicType(bool); // only accessed locally
-
-    proc lock() {
-      var lockAttempts = 0,
-          maxLockAttempts = (2**10-1);
-      while l.testAndSet(memory_order_acquire) {
-        lockAttempts += 1;
-        if (lockAttempts & maxLockAttempts) == 0 {
-          maxLockAttempts >>= 1;
-          chpl_task_yield();
-        }
-      }
-    }
-    proc unlock() {
-      l.clear(memory_order_release);
-    }
+    var l: chpl_LocalSpinlock;
   }
 
   class SumReduceScanOp: ReduceScanOp {


### PR DESCRIPTION
I'm not sure why I used a backoff lock in #4532 -- It was probably just
because it was something on my mind from experiments with meteor at the
time. In this case there's no performance advantage to spinning without
yielding at least for any of our reduction tests. I also had a hard time
coming up with a test case where spinning without yielding was faster,
which is likely due to yielding getting faster as part of #4902.