### PR TITLE
Change LocalSpinLock to a test-and-testAndSet lock

### DIFF
--- a/modules/internal/ChapelLocks.chpl
+++ b/modules/internal/ChapelLocks.chpl
@@ -32,7 +32,7 @@ module ChapelLocks {
 
     inline proc lock() {
       on this do
-        while l.testAndSet(memory_order_acquire) do
+        while l.read() || l.testAndSet(memory_order_acquire) do
           chpl_task_yield();
     }
 

--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -1101,17 +1101,14 @@ module Random {
 
 
       pragma "no doc"
-      var _l: if parSafe then atomic bool else nothing;
+      var _l: if parSafe then chpl_LocalSpinlock else nothing;
       pragma "no doc"
       inline proc _lock() {
-        if parSafe then
-          while _l.read() || _l.testAndSet(memory_order_acquire) do
-            chpl_task_yield();
+        if parSafe then _l.lock();
       }
       pragma "no doc"
       inline proc _unlock() {
-        if parSafe then
-          _l.clear(memory_order_release);
+        if parSafe then _l.unlock();
       }
       // up to 4 RNGs
       pragma "no doc"


### PR DESCRIPTION
test-and-testAndTest spinlocks perform significantly better under
contention compared to testAndSet locks. This is because testAndSet will
always flush/invalidate cache, but reads don't so we can avoid a lot of
cache contention/thrashing. The extra read adds no noticeable overhead
under cstdlib atomics.

Closes https://github.com/chapel-lang/chapel/issues/13012