### PR TITLE
Improve internal messages about actual / formal mismatches to show counts

### DIFF
--- a/compiler/include/alist.h
+++ b/compiler/include/alist.h
@@ -139,8 +139,8 @@ class AList {
   if (_alist_fn) {                                                            \
     if (_alist_fn->numFormals() != (call)->argList.length) {                  \
       INT_FATAL(call,                                                         \
-                "number of actuals does not match number of formals in %s()", \
-                _alist_fn->name);                                             \
+                "number of actuals (%d) does not match number of formals (%d) in %s()", \
+                (call)->argList.length, _alist_fn->numFormals(), _alist_fn->name); \
     }                                                                         \
                                                                               \
   } else if ((call)->isPrimitive(PRIM_VIRTUAL_METHOD_CALL)) {                 \
@@ -148,8 +148,8 @@ class AList {
                                                                               \
     if (_alist_fn->numFormals() != (call)->argList.length - 2) {              \
       INT_FATAL(call,                                                         \
-                "number of actuals does not match number of formals in %s()", \
-                _alist_fn->name);                                             \
+                "number of actuals (%d) does not match number of formals (%d) in %s()", \
+                (call)->argList.length - 2, _alist_fn->numFormals(), _alist_fn->name); \
     }                                                                         \
                                                                               \
     actual = actual->next->next;                                              \


### PR DESCRIPTION
When hitting internal error messages about mismatches in formal/actual
argument counts, it can be frustrating not to know what numbers
the compiler got / thinks it got.  This simple change prints those
numbers as part of the internal errors.