### PR TITLE
Invoke GNU libtool when compiling multi-locale static libraries on platforms besides darwin

### DIFF
--- a/runtime/etc/Makefile.mli-static
+++ b/runtime/etc/Makefile.mli-static
@@ -145,7 +145,7 @@ ifneq ($(SKIP_COMPILE_LINK),skip)
 		$(LIBS) \
 		-L$(CHPL_RT_LIB_DIR) \
 		-lchpl -lm \
-		$CHPL_ZMQ_LIB_SEARCH_PATH \
+		$(CHPL_ZMQ_LIB_SEARCH_PATH) \
 		-lzmq
 endif
 

--- a/runtime/etc/Makefile.mli-static
+++ b/runtime/etc/Makefile.mli-static
@@ -31,6 +31,20 @@ CHPL_ZMQ_LIB = -lzmq
 endif
 CHPL_LN_LIB_DIR = $(CHPL_MAKE_RUNTIME_LIB)/$(CHPL_MAKE_LAUNCHER_SUBDIR)
 
+CHPL_LIBTOOL = libtool
+
+#
+# On some platforms (Darwin in particular), libtool cannot be assumed to mean
+# GNU libtool and is actually a different executable that goes by the same
+# name. Darwin's libtool has similar semantics to GNU libtool, but has to be
+# invoked differently.
+#
+ifeq ($(CHPL_MAKE_TARGET_PLATFORM),darwin)
+CHPL_LIBTOOL_CMD = $(CHPL_LIBTOOL) -static -no_warning_for_no_symbols
+else
+CHPL_LIBTOOL_CMD = $(CHPL_LIBTOOL) --quiet --mode=link $(CC) -static
+endif
+
 .PHONY: buildUserObj buildServer buildClient runTagsCommand
 
 all: buildUserObj buildServer buildClient runTagsCommand FORCE
@@ -82,12 +96,13 @@ $(TMPBINNAME): $(CHPL_CL_OBJS) FORCE
 		$(TMPBINNAME).o \
 		$(CHPL_CL_OBJS) \
 		$(TMPSERVERNAME)_launcher.o
+
 #
 # Merge the client library, launcher library, and ZMQ library together via use
 # of libtool. This makes the assumption that static library files for both
 # external libraries exist.
 #
-	libtool -static -o $(TMPBINNAME) -no_warning_for_no_symbols \
+	$(CHPL_LIBTOOL_CMD) -o $(TMPBINNAME) \
 		$(CHPL_ZMQ_LIB) \
 		$(CHPL_LN_LIB_DIR)/libchpllaunch.a \
 		$(TMPBINNAME)-tmp

--- a/runtime/etc/src/mli/client_runtime.c
+++ b/runtime/etc/src/mli/client_runtime.c
@@ -26,9 +26,10 @@
 #include <unistd.h>
 
 struct chpl_mli_context chpl_client;
-static
+
 void chpl_mli_client_init(struct chpl_mli_context* client);
 void chpl_mli_client_deinit(struct chpl_mli_context* client);
+static char* chpl_mli_pull_connection(void);
 void chpl_mli_terminate(enum chpl_mli_errors e);
 int chpl_mli_client_launch(int argc, char** argv);
 void chpl_library_init(int argc, char** argv);
@@ -57,8 +58,7 @@ void chpl_mli_client_deinit(struct chpl_mli_context* client) {
   return;
 }
 
-static
-char * chpl_mli_pull_connection() {
+char * chpl_mli_pull_connection(void) {
   int len;
   chpl_mli_debugf("Getting %s\n", "expected size");
   chpl_mli_pull(chpl_client.setup_sock, &len, sizeof(len), 0);

--- a/runtime/etc/src/mli/client_runtime.c
+++ b/runtime/etc/src/mli/client_runtime.c
@@ -29,13 +29,12 @@ struct chpl_mli_context chpl_client;
 
 void chpl_mli_client_init(struct chpl_mli_context* client);
 void chpl_mli_client_deinit(struct chpl_mli_context* client);
-static char* chpl_mli_pull_connection(void);
+char* chpl_mli_pull_connection(void);
 void chpl_mli_terminate(enum chpl_mli_errors e);
 int chpl_mli_client_launch(int argc, char** argv);
 void chpl_library_init(int argc, char** argv);
 void chpl_library_finalize(void);
 
-static
 void chpl_mli_client_init(struct chpl_mli_context* client) {
   if (client->context) { return; }
 
@@ -58,7 +57,7 @@ void chpl_mli_client_deinit(struct chpl_mli_context* client) {
   return;
 }
 
-char * chpl_mli_pull_connection(void) {
+char* chpl_mli_pull_connection(void) {
   int len;
   chpl_mli_debugf("Getting %s\n", "expected size");
   chpl_mli_pull(chpl_client.setup_sock, &len, sizeof(len), 0);


### PR DESCRIPTION
It turns out that even though `darwin` provides a program called `libtool` which has a similar functionality to GNU's `libtool`, it is _most assuredly not_ GNU `libtool`.

The code previously in `Makefile.mli-static` invoked the `darwin` version of `libtool`. Suffice it to say, GNU `libtool` was not happy with some of the flags that were unwittingly passed to it when attempting to compile a static multi-locale library on `linux64`. 

This PR adjusts the `libtool` invocation to assume GNU `libtool` unless compiling on `darwin`, in which case the previous invocation is used instead.

Testing:

- [x] `ALL` on `linux64` when `CHPL_COMM=none`
- [ ] `ALL` on `linux64` when `CHPL_COMM=gasnet`
