### PR TITLE
Pin our cce module builds to cray-mpich 8.7.7

### DIFF
--- a/util/build_configs/cray-internal/setenv-xc-aarch64.bash
+++ b/util/build_configs/cray-internal/setenv-xc-aarch64.bash
@@ -298,6 +298,9 @@ else
         # load target PrgEnv with compiler version
         load_module $target_prgenv
         load_module_version $target_compiler $target_version
+
+        # pin to an mpich version compatible with the gen compiler
+        load_module_version cray-mpich 7.7.7
     }
 
     function load_target_cpu() {

--- a/util/build_configs/cray-internal/setenv-xc-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-xc-x86_64.bash
@@ -384,6 +384,9 @@ else
         # load target PrgEnv with compiler version
         load_module $target_prgenv
         load_module_version $target_compiler $target_version
+
+        # pin to an mpich version compatible with the gen compiler
+        load_module_version cray-mpich 7.7.7
     }
 
     function load_target_cpu() {


### PR DESCRIPTION
The default mpich is no longer compatible with our gen compilers. Pin to
an older version.