### PR TITLE
Ensure proper behavior when compiling a multi-locale library with --static on darwin

### DIFF
--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -1461,9 +1461,9 @@ static void postprocess_args() {
 
   postStackCheck();
 
-  postStaticLink();
-
   setMultiLocaleInterop();
+
+  postStaticLink();
 
   checkMLDebugAndLibmode();
 


### PR DESCRIPTION
The implementation of `postStaticLink` in `compiler/main/driver.cpp` assumes that the `fMultiLocaleInterop` flag has been set, but that flag is not set until after the call to `postStaticLink` completes.

This is a quick fix that swaps the call order to ensure correct behavior.

This would resolve https://github.com/Cray/chapel-private/issues/244.

Testing:

- [x] `release/examples` on `linux64` with `CHPL_COMM=none`
- [x] `interop/C` on `linux64` with `CHPL_COMM=none`
