### PR TITLE
Update two futures .bad files

### DIFF
--- a/test/extern/ferguson/externblock/define-fn2.bad
+++ b/test/extern/ferguson/externblock/define-fn2.bad
@@ -1,1 +1,2 @@
 define-fn2.chpl:6: error: unresolved call 'MYFUN(1)'
+define-fn2.chpl:6: note: because no functions named MYFUN found in scope

--- a/test/extern/ferguson/externblock/extern-record-field-scope-issue.bad
+++ b/test/extern/ferguson/externblock/extern-record-field-scope-issue.bad
@@ -1,2 +1,3 @@
 extern-record-field-scope-issue.chpl:15: In function 'test':
 extern-record-field-scope-issue.chpl:17: error: unresolved call 'my_struct.my_field'
+extern-record-field-scope-issue.chpl:17: note: because no functions named my_field found in scope


### PR DESCRIPTION
This updates two futures .bad files to match newly expanded error messages.

I noticed these while testing for another PR.
