### PR TITLE
Add a future for bool(?w) arguments

### DIFF
--- a/test/types/bool/resolution/resolveQueryTypeW.bad
+++ b/test/types/bool/resolution/resolveQueryTypeW.bad
@@ -1,0 +1,7 @@
+resolveQueryTypeW.chpl:6: error: unresolved call 'bar(bool)'
+resolveQueryTypeW.chpl:1: note: this candidate did not match: bar(x: bool(8))
+resolveQueryTypeW.chpl:6: note: because call actual argument #1 with type bool
+resolveQueryTypeW.chpl:1: note: is passed to formal 'const ref x: bool(8)'
+resolveQueryTypeW.chpl:1: note: candidates are: bar(x: bool(16))
+resolveQueryTypeW.chpl:1: note:                 bar(x: bool(32))
+note: and 1 other candidates, use --print-all-candidates to see them

--- a/test/types/bool/resolution/resolveQueryTypeW.chpl
+++ b/test/types/bool/resolution/resolveQueryTypeW.chpl
@@ -1,0 +1,6 @@
+proc bar(const ref x: bool(?w)) {
+  writeln("In bool(", w, ") version of bar()");
+}
+
+var b: bool;
+bar(b);

--- a/test/types/bool/resolution/resolveQueryTypeW.future
+++ b/test/types/bool/resolution/resolveQueryTypeW.future
@@ -1,0 +1,2 @@
+bug: bool(?w) argument does not match bool
+#13142

--- a/test/types/bool/resolution/resolveQueryTypeW.good
+++ b/test/types/bool/resolution/resolveQueryTypeW.good
@@ -1,0 +1,1 @@
+In bool(8) version of bar()


### PR DESCRIPTION
Adds a future that is a follow-up to #13133.

See issue #13142