### PR TITLE
Simplify default rectangular's standalone parallel iterator

### DIFF
--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -333,7 +333,7 @@ module DefaultRectangular {
             chpl_debug_writeln("*** DI[", chunk, "]: myChunk = ", myChunk);
           }
           for i in these_help(1, myChunk) {
-            yield chpl_intToIdx(i);
+            yield i;
           }
         }
       }

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -324,7 +324,11 @@ module DefaultRectangular {
                                         ranges(parDim)._high,
                                         ranges(parDim)._low,
                                         ranges(parDim)._low);
-          myChunk(parDim) = lo..hi;
+          if (myChunk(parDim).stridable) then
+            myChunk(parDim) = lo..hi by myChunk(parDim).stride align myChunk(parDim).alignment;
+          else {
+            myChunk(parDim) = lo..hi;
+          }
           if debugDefaultDist {
             chpl_debug_writeln("*** DI[", chunk, "]: myChunk = ", myChunk);
           }


### PR DESCRIPTION
While looking at DefaultRectangularDom this week, I noticed that its standalone iterator was essentially a glomming of its leader and follower iterators into a single routine, which results in a lot of unnecessary translation of indices into 0-based dense ranges and back again without purpose.  I tripped over this while using the debug output and trying to figure out why I got a message about 'following' for a loop that shouldn't be using a leader-follower on a type that had a standalone iterator.

Here, I'm attempting to replace it with a much more straightforward standalone iterator that just iterates over the given ranges.  It's still a little bit more complex than is probably necessary because I didn't want to mess with the _computeBlock() part of the logic too much, but it's still far simpler.

TODO:
- [ ] linux64 testing
- [ ] gasnet testing