### PR TITLE
Don't load cray-fftw in PGI whitebox testing.

### DIFF
--- a/util/cron/common-whitebox.bash
+++ b/util/cron/common-whitebox.bash
@@ -169,7 +169,7 @@ if [ "${COMP_TYPE}" != "HOST-TARGET-no-PrgEnv" ] ; then
     # We want cray-fftw with PrgEnv compilers.  But that in turns loads
     # cray-mpich and our PGI target compiler is so old that bringing in
     # cray-mpich has become impossible, so skip cray-fftw with PGI.
-    if [ $COMPILER != pgi ] ; then
+    if [ "${COMPILER}" != "pgi" ] ; then
       log_info "Loading cray-fftw module."
       module load cray-fftw
     fi

--- a/util/cron/common-whitebox.bash
+++ b/util/cron/common-whitebox.bash
@@ -166,8 +166,13 @@ if [ "${HOSTNAME:0:6}" = "esxbld" ] ; then
 fi
 
 if [ "${COMP_TYPE}" != "HOST-TARGET-no-PrgEnv" ] ; then
-    log_info "Loading cray-fftw module."
-    module load cray-fftw
+    # We want cray-fftw with PrgEnv compilers.  But that in turns loads
+    # cray-mpich and our PGI target compiler is so old that bringing in
+    # cray-mpich has become impossible, so skip cray-fftw with PGI.
+    if [ $COMPILER != pgi ] ; then
+      log_info "Loading cray-fftw module."
+      module load cray-fftw
+    fi
 fi
 
 log_info "Current loaded modules:"


### PR DESCRIPTION
Recent PE (MPT) module upgrades have made it impossible for us to use
the cray-mpich module, and thus the cray-fftw module that depends on
it, with our pgi/16.10.0 target compiler.  To work around this, don't
load the cray-fftw module when we're whitebox-testing with PGI.