### PR TITLE
Performance Tests of `owned` and `shared` overheads over `unmanaged`

### DIFF
--- a/test/GRAPHFILES
+++ b/test/GRAPHFILES
@@ -242,6 +242,8 @@ performance/compiler/bradc/AllCompTime.graph
 # suite: Memory tracking
 memleaks.graph
 memleaksfull.graph
+# suite: Memory allocation
+memory/lifetime/allocation.graph
 # suite: Code size tracking
 studies/jacobi/jacobi.graph
 # suite: Startup tracking
@@ -327,5 +329,3 @@ statements/lydia/moduleVersusFunction.graph
 # suite: Samples (bogus)
 Samples/Performance/foo.graph
 Samples/Performance/cleanCopy/foobar.graph
-# suite: Lifetime Management
-memory/lifetime/allocation.graph

--- a/test/GRAPHFILES
+++ b/test/GRAPHFILES
@@ -327,3 +327,5 @@ statements/lydia/moduleVersusFunction.graph
 # suite: Samples (bogus)
 Samples/Performance/foo.graph
 Samples/Performance/cleanCopy/foobar.graph
+# suite: Lifetime Management
+memory/lifetime/allocation.graph

--- a/test/memory/lifetime/allocation.chpl
+++ b/test/memory/lifetime/allocation.chpl
@@ -4,6 +4,7 @@ use Time;
 // trial to not only 'warm up the cache' but also give jemalloc the chance to
 // warmup as well, allowing it to request more memory for the heap upfront rather
 // than on-demand.
+config const printTiming : bool;
 config const numTrials : int = 10;
 config const allocationsPerTrial : int = 1024 * 1024;
 
@@ -72,7 +73,9 @@ proc doOwnedAllocation() {
 }
 
 proc main() {
-  writeln("Unmanaged-Time:", (+ reduce doUnmanagedAllocation()) / numTrials);
-  writeln("Shared-Time:", (+ reduce doSharedAllocation()) / numTrials);
-  writeln("Owned-Time:", (+ reduce doOwnedAllocation()) / numTrials);
+  if printTiming {
+    writeln("Unmanaged-Time:", (+ reduce doUnmanagedAllocation()) / numTrials);
+    writeln("Shared-Time:", (+ reduce doSharedAllocation()) / numTrials);
+    writeln("Owned-Time:", (+ reduce doOwnedAllocation()) / numTrials);
+  } 
 }

--- a/test/memory/lifetime/allocation.chpl
+++ b/test/memory/lifetime/allocation.chpl
@@ -4,9 +4,9 @@ use Time;
 // trial to not only 'warm up the cache' but also give jemalloc the chance to
 // warmup as well, allowing it to request more memory for the heap upfront rather
 // than on-demand.
-config const printTiming : bool;
-config const numTrials : int = 10;
-config const allocationsPerTrial : int = 1024 * 1024;
+config const printTiming : bool = true;
+config const numTrials : int = 3;
+config const allocationsPerTrial : int = 16 * 1024 * 1024;
 
 proc doUnmanagedAllocation() {
   var timer = new Timer();

--- a/test/memory/lifetime/allocation.chpl
+++ b/test/memory/lifetime/allocation.chpl
@@ -1,0 +1,74 @@
+use Time;
+
+config const numTrials : int = 10;
+config const allocationsPerTrial : int = 32 * 1024 * 1024;
+
+proc doUnmanagedAllocation() {
+  var timer = new Timer();
+  
+  
+  var times : [1..numTrials] real;
+  for trial in 0..numTrials {
+    {
+      timer.start();
+      var arr : [1..allocationsPerTrial] unmanaged object;
+      for i in 1..allocationsPerTrial {
+        arr[i] = new unmanaged object();
+      }
+      for i in 1..allocationsPerTrial {
+        delete arr[i];
+      }
+    }
+    timer.stop();
+    if trial != 0 then times[trial] = timer.elapsed(TimeUnits.milliseconds);
+    timer.clear();
+  }
+  
+  return times;
+}
+
+proc doSharedAllocation() {
+  var timer = new Timer();
+  
+  var times : [1..numTrials] real;
+  for trial in 0..numTrials {
+    {
+      timer.start();
+      var arr : [1..allocationsPerTrial] shared object;
+      for i in 1..allocationsPerTrial {
+        arr[i] = new shared object();
+      }
+    }
+    timer.stop();
+    if trial != 0 then times[trial] = timer.elapsed(TimeUnits.milliseconds);
+    timer.clear();
+  }
+
+  return times;
+}
+
+proc doOwnedAllocation() {
+  var timer = new Timer();
+  
+  var times : [1..numTrials] real;
+  for trial in 0..numTrials {
+    {
+      timer.start();
+      var arr : [1..allocationsPerTrial] owned object;
+      for i in 1..allocationsPerTrial {
+        arr[i] = new owned object();
+      }
+    }
+    timer.stop();
+    if trial != 0 then times[trial] = timer.elapsed(TimeUnits.milliseconds);
+    timer.clear();
+  }
+
+  return times;
+}
+
+proc main() {
+  writeln("Unmanaged-Time:", (+ reduce doUnmanagedAllocation()) / numTrials);
+  writeln("Shared-Time:", (+ reduce doSharedAllocation()) / numTrials);
+  writeln("Owned-Time:", (+ reduce doOwnedAllocation()) / numTrials);
+}

--- a/test/memory/lifetime/allocation.chpl
+++ b/test/memory/lifetime/allocation.chpl
@@ -1,7 +1,11 @@
 use Time;
 
+// Performs multiple trial runs to obtain the average over; we skip the first
+// trial to not only 'warm up the cache' but also give jemalloc the chance to
+// warmup as well, allowing it to request more memory for the heap upfront rather
+// than on-demand.
 config const numTrials : int = 10;
-config const allocationsPerTrial : int = 32 * 1024 * 1024;
+config const allocationsPerTrial : int = 1024 * 1024;
 
 proc doUnmanagedAllocation() {
   var timer = new Timer();
@@ -20,7 +24,7 @@ proc doUnmanagedAllocation() {
       }
     }
     timer.stop();
-    if trial != 0 then times[trial] = timer.elapsed(TimeUnits.milliseconds);
+    if trial != 0 then times[trial] = timer.elapsed(TimeUnits.seconds);
     timer.clear();
   }
   
@@ -40,7 +44,7 @@ proc doSharedAllocation() {
       }
     }
     timer.stop();
-    if trial != 0 then times[trial] = timer.elapsed(TimeUnits.milliseconds);
+    if trial != 0 then times[trial] = timer.elapsed(TimeUnits.seconds);
     timer.clear();
   }
 
@@ -60,7 +64,7 @@ proc doOwnedAllocation() {
       }
     }
     timer.stop();
-    if trial != 0 then times[trial] = timer.elapsed(TimeUnits.milliseconds);
+    if trial != 0 then times[trial] = timer.elapsed(TimeUnits.seconds);
     timer.clear();
   }
 

--- a/test/memory/lifetime/allocation.execopts
+++ b/test/memory/lifetime/allocation.execopts
@@ -1,0 +1,1 @@
+--printTiming=false --allocationsPerTrial=10

--- a/test/memory/lifetime/allocation.graph
+++ b/test/memory/lifetime/allocation.graph
@@ -1,0 +1,5 @@
+perfkeys: Unmanaged-Time:, Shared-Time:, Owned-Time:
+files: allocation.dat, allocation.dat, allocation.dat
+graphkeys: Unmanaged, Shared, Owned
+ylabel: Time (milliseconds)
+graphtitle: Lifetime Management Overhead (Unmanaged as Baseline)

--- a/test/memory/lifetime/allocation.graph
+++ b/test/memory/lifetime/allocation.graph
@@ -1,5 +1,5 @@
 perfkeys: Unmanaged-Time:, Shared-Time:, Owned-Time:
 files: allocation.dat, allocation.dat, allocation.dat
 graphkeys: Unmanaged, Shared, Owned
-ylabel: Time (milliseconds)
-graphtitle: Lifetime Management Overhead (Unmanaged as Baseline)
+ylabel: Time (seconds)
+graphtitle: Serial 'object' Allocation

--- a/test/memory/lifetime/allocation.perfexecopts
+++ b/test/memory/lifetime/allocation.perfexecopts
@@ -1,0 +1,1 @@
+--printTiming

--- a/test/memory/lifetime/allocation.perfexecopts
+++ b/test/memory/lifetime/allocation.perfexecopts
@@ -1,1 +1,0 @@
---printTiming

--- a/test/memory/lifetime/allocation.perfkeys
+++ b/test/memory/lifetime/allocation.perfkeys
@@ -1,0 +1,3 @@
+Unmanaged-Time:
+Shared-Time:
+Owned-Time:

--- a/test/memory/lifetime/allocation.prediff
+++ b/test/memory/lifetime/allocation.prediff
@@ -1,0 +1,3 @@
+#!/usr/bin/env python
+
+print(0);

--- a/test/memory/lifetime/allocation.prediff
+++ b/test/memory/lifetime/allocation.prediff
@@ -1,3 +1,0 @@
-#!/usr/bin/env python
-
-print(0);


### PR DESCRIPTION
This Pull Request adds a test for serial shared-memory allocations of
`shared`/`owned`/`unmanaged` to profile the performance overheads of each.

This shows that `shared` is ~2.5x slower and that there's overhead for `owned`
under `--no-local`:

Timings on Louis's Mac-book:

| config     | Unmanaged | Shared  | Owned   |
| ---------- | --------- | ------- | ------- |
| local      | 0.919s    | 2.480s  | 0.900s  |
| --no-local | 0.938s    | 2.782s  | 1.362s  |

Timings on chapcs07:

| config     | Unmanaged | Shared  | Owned   |
| ---------- | --------- | ------- | ------- |
| local      | 0.62s     | 1.96s   | 0.64s   |
| --no-local | 0.64s     | 2.11s   | 0.89s   |


Part of https://github.com/chapel-lang/chapel/issues/11852
Related to https://github.com/chapel-lang/chapel/issues/11853
