### PR TITLE
Revert #13111 changes to submitted benchmarks and update .good files

### DIFF
--- a/test/studies/shootout/submitted/fasta3.chpl
+++ b/test/studies/shootout/submitted/fasta3.chpl
@@ -13,11 +13,11 @@ config const n = 1000,   // controls the length of the generated strings
 // Nucleotide definitions
 //
 enum nucleotide {
-  A = "A".byte(1), C = "C".byte(1), G = "G".byte(1), T = "T".byte(1),
-  a = "a".byte(1), c = "c".byte(1), g = "g".byte(1), t = "t".byte(1),
-  B = "B".byte(1), D = "D".byte(1), H = "H".byte(1), K = "K".byte(1),
-  M = "M".byte(1), N = "N".byte(1), R = "R".byte(1), S = "S".byte(1),
-  V = "V".byte(1), W = "W".byte(1), Y = "Y".byte(1)
+  A = ascii("A"), C = ascii("C"), G = ascii("G"), T = ascii("T"),
+  a = ascii("a"), c = ascii("c"), g = ascii("g"), t = ascii("t"),
+  B = ascii("B"), D = ascii("D"), H = ascii("H"), K = ascii("K"),
+  M = ascii("M"), N = ascii("N"), R = ascii("R"), S = ascii("S"),
+  V = ascii("V"), W = ascii("W"), Y = ascii("Y")
 }
 use nucleotide;
 
@@ -85,7 +85,7 @@ proc sumProbs(alphabet: []) {
 // Redefine stdout to use lock-free binary I/O and capture a newline
 //
 const stdout = openfd(1).writer(kind=iokind.native, locking=false);
-param newline = "\n".byte(1);
+param newline = ascii("\n");
 
 //
 // Repeat sequence "alu" for n characters

--- a/test/studies/shootout/submitted/fasta3.good
+++ b/test/studies/shootout/submitted/fasta3.good
@@ -1,3 +1,23 @@
+fasta3.chpl:88: warning: ascii is deprecated - please use string.byte instead
+fasta3.chpl:16: warning: ascii is deprecated - please use string.byte instead
+fasta3.chpl:16: warning: ascii is deprecated - please use string.byte instead
+fasta3.chpl:16: warning: ascii is deprecated - please use string.byte instead
+fasta3.chpl:16: warning: ascii is deprecated - please use string.byte instead
+fasta3.chpl:17: warning: ascii is deprecated - please use string.byte instead
+fasta3.chpl:17: warning: ascii is deprecated - please use string.byte instead
+fasta3.chpl:17: warning: ascii is deprecated - please use string.byte instead
+fasta3.chpl:17: warning: ascii is deprecated - please use string.byte instead
+fasta3.chpl:18: warning: ascii is deprecated - please use string.byte instead
+fasta3.chpl:18: warning: ascii is deprecated - please use string.byte instead
+fasta3.chpl:18: warning: ascii is deprecated - please use string.byte instead
+fasta3.chpl:18: warning: ascii is deprecated - please use string.byte instead
+fasta3.chpl:19: warning: ascii is deprecated - please use string.byte instead
+fasta3.chpl:19: warning: ascii is deprecated - please use string.byte instead
+fasta3.chpl:19: warning: ascii is deprecated - please use string.byte instead
+fasta3.chpl:19: warning: ascii is deprecated - please use string.byte instead
+fasta3.chpl:20: warning: ascii is deprecated - please use string.byte instead
+fasta3.chpl:20: warning: ascii is deprecated - please use string.byte instead
+fasta3.chpl:20: warning: ascii is deprecated - please use string.byte instead
 >ONE Homo sapiens alu
 GGCCGGGCGCGGTGGCTCACGCCTGTAATCCCAGCACTTTGGGAGGCCGAGGCGGGCGGA
 TCACCTGAGGTCAGGAGTTCGAGACCAGCCTGGCCAACATGGTGAAACCCCGTCTCTACT

--- a/test/studies/shootout/submitted/fasta4.chpl
+++ b/test/studies/shootout/submitted/fasta4.chpl
@@ -23,11 +23,11 @@ config param IM = 139968,         // parameters for random number generation
 // Nucleotide definitions
 //
 enum nucleotide {
-  A = "A".byte(1), C = "C".byte(1), G = "G".byte(1), T = "T".byte(1),
-  a = "a".byte(1), c = "c".byte(1), g = "g".byte(1), t = "t".byte(1),
-  B = "B".byte(1), D = "D".byte(1), H = "H".byte(1), K = "K".byte(1),
-  M = "M".byte(1), N = "N".byte(1), R = "R".byte(1), S = "S".byte(1),
-  V = "V".byte(1), W = "W".byte(1), Y = "Y".byte(1)
+  A = ascii("A"), C = ascii("C"), G = ascii("G"), T = ascii("T"),
+  a = ascii("a"), c = ascii("c"), g = ascii("g"), t = ascii("t"),
+  B = ascii("B"), D = ascii("D"), H = ascii("H"), K = ascii("K"),
+  M = ascii("M"), N = ascii("N"), R = ascii("R"), S = ascii("S"),
+  V = ascii("V"), W = ascii("W"), Y = ascii("Y")
 }
 use nucleotide;
 
@@ -81,7 +81,7 @@ proc main() {
 // Redefine stdout to use lock-free binary I/O and capture a newline
 //
 const stdout = openfd(1).writer(kind=iokind.native, locking=false);
-param newline = "\n".byte(1);
+param newline = ascii("\n");
 
 //
 // Repeat 'alu' to generate a sequence of length 'n'

--- a/test/studies/shootout/submitted/fasta4.good
+++ b/test/studies/shootout/submitted/fasta4.good
@@ -1,3 +1,23 @@
+fasta4.chpl:84: warning: ascii is deprecated - please use string.byte instead
+fasta4.chpl:26: warning: ascii is deprecated - please use string.byte instead
+fasta4.chpl:26: warning: ascii is deprecated - please use string.byte instead
+fasta4.chpl:26: warning: ascii is deprecated - please use string.byte instead
+fasta4.chpl:26: warning: ascii is deprecated - please use string.byte instead
+fasta4.chpl:27: warning: ascii is deprecated - please use string.byte instead
+fasta4.chpl:27: warning: ascii is deprecated - please use string.byte instead
+fasta4.chpl:27: warning: ascii is deprecated - please use string.byte instead
+fasta4.chpl:27: warning: ascii is deprecated - please use string.byte instead
+fasta4.chpl:28: warning: ascii is deprecated - please use string.byte instead
+fasta4.chpl:28: warning: ascii is deprecated - please use string.byte instead
+fasta4.chpl:28: warning: ascii is deprecated - please use string.byte instead
+fasta4.chpl:28: warning: ascii is deprecated - please use string.byte instead
+fasta4.chpl:29: warning: ascii is deprecated - please use string.byte instead
+fasta4.chpl:29: warning: ascii is deprecated - please use string.byte instead
+fasta4.chpl:29: warning: ascii is deprecated - please use string.byte instead
+fasta4.chpl:29: warning: ascii is deprecated - please use string.byte instead
+fasta4.chpl:30: warning: ascii is deprecated - please use string.byte instead
+fasta4.chpl:30: warning: ascii is deprecated - please use string.byte instead
+fasta4.chpl:30: warning: ascii is deprecated - please use string.byte instead
 >ONE Homo sapiens alu
 GGCCGGGCGCGGTGGCTCACGCCTGTAATCCCAGCACTTTGGGAGGCCGAGGCGGGCGGA
 TCACCTGAGGTCAGGAGTTCGAGACCAGCCTGGCCAACATGGTGAAACCCCGTCTCTACT

--- a/test/studies/shootout/submitted/knucleotide2.chpl
+++ b/test/studies/shootout/submitted/knucleotide2.chpl
@@ -38,7 +38,7 @@ proc main(args: [] string) {
 
   // Make everything uppercase
   forall d in data do
-    d -= ("a".byte(1) - "A".byte(1));
+    d -= (ascii("a") - ascii("A"));
 
   writeFreqs(data, 1);
   writeFreqs(data, 2);
@@ -99,7 +99,7 @@ const toChar: [0..3] string = ["A", "C", "T", "G"];
 var toNum: [0..127] int;
 
 forall i in toChar.domain do
-  toNum[toChar[i].byte(1)] = i;
+  toNum[ascii(toChar[i])] = i;
 
 
 inline proc decode(in data, param nclSize) {
@@ -129,14 +129,14 @@ inline proc hash(str, beg, param size) {
 proc string.toBytes() {
   var bytes: [1..this.length] uint(8);
   for (b, i) in zip(bytes, 1..) do
-    b = this.byte(i);
+    b = ascii(this[i]);
   return bytes;
 }
 
 
 inline proc startsWithThree(data) {
-  return data[1] == ">".byte(1) &&
-         data[2] == "T".byte(1) &&
-         data[3] == "H".byte(1);
+  return data[1] == ascii(">") && 
+         data[2] == ascii("T") && 
+         data[3] == ascii("H");
 }
 

--- a/test/studies/shootout/submitted/revcomp.chpl
+++ b/test/studies/shootout/submitted/revcomp.chpl
@@ -21,7 +21,7 @@ proc main(args: [] string) {
     var numRead: int;
 
     while stdinNoLock.readline(data, numRead, idx) {
-      if data[idx] == ">".byte(1) {       // is this the start of a section?
+      if data[idx] == ascii(">") {       // is this the start of a section?
 
         // spawn a task to process the previous sequence, if there was one
         if start then
@@ -54,7 +54,7 @@ proc process(data, start, end) {
     for m in (start+extra)..(end-1) by columns {
       for i in 1..off-1 by -1 do
         data[m+i+1] = data[m+i];
-      data[m+1] = "\n".byte(1);
+      data[m+1] = ascii("\n");
     }
 
   // replace the data items with their table entries
@@ -69,9 +69,9 @@ proc initTable(pairs) {
   var table: [1..128] uint(8);
 
   for i in 1..pairs.length by 2 {
-    table[pairs.byte(i)] = pairs.byte(i+1):uint(8);
-    if pairs.byte(i) != "\n".byte(1) then
-      table[pairs[i:byteIndex].toLower().byte(1)] = pairs.byte(i+1):uint(8);
+    table[ascii(pairs[i])] = ascii(pairs[i+1]):uint(8);
+    if pairs[i] != "\n" then
+      table[ascii(pairs[i].toLower())] = ascii(pairs[i+1]):uint(8);
   }
 
   return table;

--- a/test/studies/shootout/submitted/revcomp.good
+++ b/test/studies/shootout/submitted/revcomp.good
@@ -1,3 +1,12 @@
+revcomp.chpl:68: In function 'initTable':
+revcomp.chpl:72: warning: ascii is deprecated - please use string.byte instead
+revcomp.chpl:72: warning: ascii is deprecated - please use string.byte instead
+revcomp.chpl:74: warning: ascii is deprecated - please use string.byte instead
+revcomp.chpl:74: warning: ascii is deprecated - please use string.byte instead
+revcomp.chpl:12: In function 'main':
+revcomp.chpl:24: warning: ascii is deprecated - please use string.byte instead
+revcomp.chpl:48: In function 'process':
+revcomp.chpl:57: warning: ascii is deprecated - please use string.byte instead
 >ONE Homo sapiens alu
 CGGAGTCTCGCTCTGTCGCCCAGGCTGGAGTGCAGTGGCGCGATCTCGGCTCACTGCAAC
 CTCCGCCTCCCGGGTTCAAGCGATTCTCCTGCCTCAGCCTCCCGAGTAGCTGGGATTACA

--- a/test/studies/shootout/submitted/revcomp2.chpl
+++ b/test/studies/shootout/submitted/revcomp2.chpl
@@ -22,7 +22,7 @@ proc main(args: [] string) {
       input.mark();
 
       // Scan forward until we get to '\n' (end of description)
-      input.advancePastByte("\n".byte(1));
+      input.advancePastByte(ascii("\n"));
       const seqOffset = input.offset();
 
       // Scan forward until we get to '>' (end of sequence) or EOF
@@ -31,7 +31,7 @@ proc main(args: [] string) {
       // look for the next description, returning '(eof, its offset)'
       proc findNextDesc() throws {
         try {
-          input.advancePastByte(">".byte(1));
+          input.advancePastByte(ascii(">"));
         } catch (e:EOFError) {
           return (true, len-1);
         }
@@ -70,7 +70,7 @@ proc process(seq: [?inds]) {
   }
 
   proc advance(ref cursor, dir) {
-    do { cursor += dir; } while seq[cursor] == "\n".byte(1);
+    do { cursor += dir; } while seq[cursor] == ascii("\n");
   }
 }
 
@@ -78,9 +78,9 @@ proc initTable(pairs) {
   var table: [1..128] uint(8);
 
   for i in 1..pairs.length by 2 {
-    table[pairs.byte(i)] = pairs.byte(i+1);
-    if pairs.byte(i) != "\n".byte(1) then
-      table[pairs[i:byteIndex].toLower().byte(1)] = pairs.byte(i+1);
+    table[ascii(pairs[i])] = ascii(pairs[i+1]);
+    if pairs[i] != "\n" then
+      table[ascii(pairs[i].toLower())] = ascii(pairs[i+1]);
   }
 
   return table;

--- a/test/studies/shootout/submitted/revcomp2.good
+++ b/test/studies/shootout/submitted/revcomp2.good
@@ -1,3 +1,14 @@
+revcomp2.chpl:77: In function 'initTable':
+revcomp2.chpl:81: warning: ascii is deprecated - please use string.byte instead
+revcomp2.chpl:81: warning: ascii is deprecated - please use string.byte instead
+revcomp2.chpl:83: warning: ascii is deprecated - please use string.byte instead
+revcomp2.chpl:83: warning: ascii is deprecated - please use string.byte instead
+revcomp2.chpl:9: In function 'main':
+revcomp2.chpl:25: warning: ascii is deprecated - please use string.byte instead
+revcomp2.chpl:9: In function 'main':
+revcomp2.chpl:34: warning: ascii is deprecated - please use string.byte instead
+revcomp2.chpl:63: In function 'process':
+revcomp2.chpl:73: warning: ascii is deprecated - please use string.byte instead
 >ONE Homo sapiens alu
 CGGAGTCTCGCTCTGTCGCCCAGGCTGGAGTGCAGTGGCGCGATCTCGGCTCACTGCAAC
 CTCCGCCTCCCGGGTTCAAGCGATTCTCCTGCCTCAGCCTCCCGAGTAGCTGGGATTACA


### PR DESCRIPTION
#13111 updated several benchmarks to no longer use `ascii()`.  This change reverts those updates to the CLBG submitted benchmarks, and instead accounts for the deprecated `ascii()` warnings in the .good files where needed.