### PR TITLE
Turn off revcomp ascii() deprecation warnings in performance testing

### DIFF
--- a/test/studies/shootout/submitted/revcomp.perfcompopts
+++ b/test/studies/shootout/submitted/revcomp.perfcompopts
@@ -1,0 +1,1 @@
+--no-warnings

--- a/test/studies/shootout/submitted/revcomp2.perfcompopts
+++ b/test/studies/shootout/submitted/revcomp2.perfcompopts
@@ -1,0 +1,1 @@
+--no-warnings


### PR DESCRIPTION
#13172 went back to using the deprecated `ascii()` for CLBG submitted benchmarks.  For revcomp and revcomp2, the resulting warnings threw off the search for perfkeys.  This change adds a `.perfcompopts` file for each, containing a `--no-warnings` flag so the deprecation warnings will not get in the way.
