### PR TITLE
Remove unneeded `.compopts` files from shootouts

### DIFF
--- a/test/release/examples/benchmarks/shootout/binarytrees.compopts
+++ b/test/release/examples/benchmarks/shootout/binarytrees.compopts
@@ -1,1 +1,0 @@
---no-warnings

--- a/test/release/examples/benchmarks/shootout/chameneosredux-fast.compopts
+++ b/test/release/examples/benchmarks/shootout/chameneosredux-fast.compopts
@@ -1,1 +1,0 @@
---no-warnings

--- a/test/release/examples/benchmarks/shootout/chameneosredux.compopts
+++ b/test/release/examples/benchmarks/shootout/chameneosredux.compopts
@@ -1,1 +1,0 @@
---no-warnings

--- a/test/release/examples/benchmarks/shootout/knucleotide.compopts
+++ b/test/release/examples/benchmarks/shootout/knucleotide.compopts
@@ -1,1 +1,0 @@
---no-warnings

--- a/test/studies/shootout/binary-trees/binarytrees-blc.compopts
+++ b/test/studies/shootout/binary-trees/binarytrees-blc.compopts
@@ -1,1 +1,0 @@
---no-warnings

--- a/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc.compopts
+++ b/test/studies/shootout/chameneos-redux/bradc/chameneosredux-blc.compopts
@@ -1,1 +1,0 @@
---no-warnings

--- a/test/studies/shootout/nbody/sidelnik/nbody_orig_1.compopts
+++ b/test/studies/shootout/nbody/sidelnik/nbody_orig_1.compopts
@@ -1,1 +1,0 @@
---no-warnings

--- a/test/studies/shootout/submitted/binarytrees2.compopts
+++ b/test/studies/shootout/submitted/binarytrees2.compopts
@@ -1,1 +1,0 @@
---no-warnings

--- a/test/studies/shootout/submitted/knucleotide2.compopts
+++ b/test/studies/shootout/submitted/knucleotide2.compopts
@@ -1,1 +1,0 @@
---no-warnings

--- a/test/studies/shootout/submitted/knucleotide2.good
+++ b/test/studies/shootout/submitted/knucleotide2.good
@@ -1,3 +1,12 @@
+knucleotide2.chpl:102: warning: ascii is deprecated - please use string.byte instead
+knucleotide2.chpl:138: warning: ascii is deprecated - please use string.byte instead
+knucleotide2.chpl:139: warning: ascii is deprecated - please use string.byte instead
+knucleotide2.chpl:140: warning: ascii is deprecated - please use string.byte instead
+knucleotide2.chpl:14: In function 'main':
+knucleotide2.chpl:41: warning: ascii is deprecated - please use string.byte instead
+knucleotide2.chpl:41: warning: ascii is deprecated - please use string.byte instead
+knucleotide2.chpl:129: In function 'toBytes':
+knucleotide2.chpl:132: warning: ascii is deprecated - please use string.byte instead
 A 30.279
 T 30.113
 G 19.835


### PR DESCRIPTION
While discussing PR #13172 with @dmk42, he pointed out that one of the submitted shootouts had `--no-warnings` flags thrown which caused me to realize that several of the variations do as well.  It seems to me that we should be at a point where most of these should no longer be necessary, or where we'd want to know about the warnings in the .good output.  Testing seemed to validate this, so here I've removed them (one .good needed to be updated to reflect warnings due to the deprecation of `ascii()` which is precisely what we were discussing in PR #13172).