### PR TITLE
Fix string / int comparison in computePerfStats

### DIFF
--- a/util/test/computePerfStats
+++ b/util/test/computePerfStats
@@ -106,7 +106,7 @@ def validate_output(verify_keys, output_file):
         regex = m.group(3)
         if num:
             num_real = int(num)
-            if num >= 1: # line numbers are 1-indexed
+            if num_real >= 1: # line numbers are 1-indexed
                 num_real -= 1
 
         regex_real = r"(\s|\S)*" + regex

--- a/util/test/computePerfStats
+++ b/util/test/computePerfStats
@@ -105,9 +105,7 @@ def validate_output(verify_keys, output_file):
         num = m.group(2)
         regex = m.group(3)
         if num:
-            num_real = int(num)
-            if num_real >= 1: # line numbers are 1-indexed
-                num_real -= 1
+            num_real = int(num) - 1
 
         regex_real = r"(\s|\S)*" + regex
         is_reject = type == "reject"


### PR DESCRIPTION
[all real work done by @ronawho; I just did the typing and testing]

This fixes a Python2->3 incompatibility in `computePerfStats` which makes running performance tests using Python 3 work better.

Note for posterity: There is still a remaining issue that makes mandelbrot shootout tests fail under Python 3 due to reading arbitrary bytes as a string, some of which aren't legal UTF-8.  I believe that this should be changed to read raw bytes, but don't know how to do that.