### PR TITLE
Avoid some spurious "note: because where clause evaluated to false"

### DIFF
--- a/compiler/resolution/ResolutionCandidate.cpp
+++ b/compiler/resolution/ResolutionCandidate.cpp
@@ -686,7 +686,12 @@ bool ResolutionCandidate::checkResolveFormalsWhereClauses(CallInfo& info) {
 
   if (evaluateWhereClause(fn) == false) {
     failingArgument = NULL;
-    reason = RESOLUTION_CANDIDATE_WHERE_FAILED;
+    if (fn->hasFlag(FLAG_COMPILER_ADDED_WHERE))
+      // RESOLUTION_CANDIDATE_WHERE_FAILED is not helpful to the user
+      // if they did not write the where clause.
+      reason = RESOLUTION_CANDIDATE_OTHER;
+    else
+      reason = RESOLUTION_CANDIDATE_WHERE_FAILED;
     return false;
   }
 

--- a/test/arrays/bradc/errors/badArrArgErrMsg.good
+++ b/test/arrays/bradc/errors/badArrArgErrMsg.good
@@ -1,3 +1,2 @@
 badArrArgErrMsg.chpl:6: error: unresolved call 'foo([domain(1,int(64),false)] complex(128))'
 badArrArgErrMsg.chpl:8: note: this candidate did not match: foo(X: [?Dlocal] real)
-badArrArgErrMsg.chpl:8: note: because where clause evaluated to false

--- a/test/classes/diten/typeMethodWrongReceiverType.good
+++ b/test/classes/diten/typeMethodWrongReceiverType.good
@@ -1,3 +1,2 @@
 typeMethodWrongReceiverType.chpl:7: error: unresolved call 'type int(64).typeMethod()'
 typeMethodWrongReceiverType.chpl:2: note: this candidate did not match: C.type typeMethod()
-typeMethodWrongReceiverType.chpl:2: note: because where clause evaluated to false

--- a/test/functions/ferguson/query/query-generic-star-tuple-error.good
+++ b/test/functions/ferguson/query/query-generic-star-tuple-error.good
@@ -1,4 +1,5 @@
 query-generic-star-tuple-error.chpl:17: error: unresolved call 'f((Wrapper(int(64)),Wrapper(owned GenericClass(int(64)))))'
-query-generic-star-tuple-error.chpl:10: note: this candidate did not match: f(x: 2*Wrapper)
-query-generic-star-tuple-error.chpl:10: note: because where clause evaluated to false
-query-generic-star-tuple-error.chpl:7: note: candidates are: Wrapper.f
+query-generic-star-tuple-error.chpl:7: note: this candidate did not match: Wrapper.f
+query-generic-star-tuple-error.chpl:17: note: because call is not written as a method call
+query-generic-star-tuple-error.chpl:7: note: but candidate function is a method
+query-generic-star-tuple-error.chpl:10: note: candidates are: f(x: 2*Wrapper)

--- a/test/functions/ferguson/query/query-generic-type-leaf-borrowed.good
+++ b/test/functions/ferguson/query/query-generic-type-leaf-borrowed.good
@@ -1,4 +1,5 @@
 query-generic-type-leaf-borrowed.chpl:34: error: unresolved call 'f(Wrapper(OtherGenericClass(int(64))))'
-query-generic-type-leaf-borrowed.chpl:15: note: this candidate did not match: f(x: Wrapper(borrowed GenericClass))
-query-generic-type-leaf-borrowed.chpl:15: note: because where clause evaluated to false
-query-generic-type-leaf-borrowed.chpl:12: note: candidates are: Wrapper.f
+query-generic-type-leaf-borrowed.chpl:12: note: this candidate did not match: Wrapper.f
+query-generic-type-leaf-borrowed.chpl:34: note: because call is not written as a method call
+query-generic-type-leaf-borrowed.chpl:12: note: but candidate function is a method
+query-generic-type-leaf-borrowed.chpl:15: note: candidates are: f(x: Wrapper(borrowed GenericClass))

--- a/test/functions/ferguson/query/query-generic-type-leaf-q.good
+++ b/test/functions/ferguson/query/query-generic-type-leaf-q.good
@@ -1,3 +1,2 @@
 query-generic-type-leaf-q.chpl:35: error: unresolved call 'g(Wrapper(OtherGenericClass(int(64))))'
 query-generic-type-leaf-q.chpl:18: note: this candidate did not match: g(x: Wrapper(GenericClass(?)))
-query-generic-type-leaf-q.chpl:18: note: because where clause evaluated to false

--- a/test/functions/ferguson/query/query-generic-type-leaf.good
+++ b/test/functions/ferguson/query/query-generic-type-leaf.good
@@ -1,4 +1,5 @@
 query-generic-type-leaf.chpl:34: error: unresolved call 'f(Wrapper(OtherGenericClass(int(64))))'
-query-generic-type-leaf.chpl:15: note: this candidate did not match: f(x: Wrapper(GenericClass))
-query-generic-type-leaf.chpl:15: note: because where clause evaluated to false
-query-generic-type-leaf.chpl:12: note: candidates are: Wrapper.f
+query-generic-type-leaf.chpl:12: note: this candidate did not match: Wrapper.f
+query-generic-type-leaf.chpl:34: note: because call is not written as a method call
+query-generic-type-leaf.chpl:12: note: but candidate function is a method
+query-generic-type-leaf.chpl:15: note: candidates are: f(x: Wrapper(GenericClass))

--- a/test/functions/typeMethods/error-message-when-not-applicable.chpl
+++ b/test/functions/typeMethods/error-message-when-not-applicable.chpl
@@ -1,5 +1,5 @@
 class C {
-  proc type typeMethod() /* where this == C */ {
+  proc type typeMethod() where isInt(numLocales) {
     writeln("C.typeMethod()");
   }
 }

--- a/test/functions/typeMethods/error-message-when-not-applicable.good
+++ b/test/functions/typeMethods/error-message-when-not-applicable.good
@@ -1,4 +1,4 @@
 error-message-when-not-applicable.chpl:7: error: unresolved call 'type int(64).typeMethod()'
 error-message-when-not-applicable.chpl:2: note: this candidate did not match: C.type typeMethod()
 error-message-when-not-applicable.chpl:7: note: because method call receiver with type int(64)
-error-message-when-not-applicable.chpl:1: note: is passed to formal 'this: borrowed C'
+error-message-when-not-applicable.chpl:1: note: is passed to formal 'this' of incompatible type

--- a/test/functions/typeMethods/nilable-owned-shared.bad
+++ b/test/functions/typeMethods/nilable-owned-shared.bad
@@ -1,3 +1,2 @@
 nilable-owned-shared.chpl:8: error: unresolved call 'type owned C?.typeme()'
 nilable-owned-shared.chpl:3: note: this candidate did not match: C.type typeme()
-nilable-owned-shared.chpl:3: note: because where clause evaluated to false

--- a/test/types/type_variables/deitz/test_query_expression_error.good
+++ b/test/types/type_variables/deitz/test_query_expression_error.good
@@ -1,4 +1,3 @@
 test_query_expression_error.chpl:20: error: unresolved call 'f(borrowed C(9,3))'
 test_query_expression_error.chpl:10: note: this candidate did not match: f(c: borrowed C(1+1, ?p))
-test_query_expression_error.chpl:10: note: because where clause evaluated to false
 test_query_expression_error.chpl:14: note: candidates are: f(c: borrowed C(1+2+3, ?p))

--- a/test/types/type_variables/deitz/test_query_field11.good
+++ b/test/types/type_variables/deitz/test_query_field11.good
@@ -1,5 +1,4 @@
 test_query_field11.chpl:13: error: unresolved call 'foo(range(int(64),boundedLow,false), range(int(64),boundedLow,true))'
 test_query_field11.chpl:1: note: this candidate did not match: foo(x: range(int, BoundedRangeType.boundedLow, ?stridable) ...?k)
-test_query_field11.chpl:1: note: because where clause evaluated to false
 test_query_field11.chpl:5: note: candidates are: foo(x: range(int, BoundedRangeType.boundedHigh, ?stridable) ...?k)
 test_query_field11.chpl:9: note:                 foo(x: range(int, ?bounded, ?stridable) ...?k)

--- a/test/types/type_variables/deitz/test_query_field12.good
+++ b/test/types/type_variables/deitz/test_query_field12.good
@@ -1,5 +1,4 @@
 test_query_field12.chpl:13: error: unresolved call 'foo(range(int(64),boundedLow,false), range(int(64),boundedLow,true))'
 test_query_field12.chpl:1: note: this candidate did not match: foo(x: range(int, BoundedRangeType.boundedLow, ?stridable) ...?k)
-test_query_field12.chpl:1: note: because where clause evaluated to false
 test_query_field12.chpl:5: note: candidates are: foo(x: range(int, BoundedRangeType.boundedHigh, ?stridable) ...?k)
 test_query_field12.chpl:9: note:                 foo(x: range(?) ...?k)

--- a/test/types/type_variables/deitz/test_query_field6.good
+++ b/test/types/type_variables/deitz/test_query_field6.good
@@ -1,3 +1,2 @@
 test_query_field6.chpl:11: error: unresolved call 'foo(1.0, 2, 3)'
 test_query_field6.chpl:1: note: this candidate did not match: foo(x: ?t ...?k)
-test_query_field6.chpl:1: note: because where clause evaluated to false

--- a/test/types/type_variables/deitz/test_query_field7.good
+++ b/test/types/type_variables/deitz/test_query_field7.good
@@ -1,4 +1,3 @@
 test_query_field7.chpl:24: error: unresolved call 'foo(borrowed C(real(64),int(64)), borrowed C(real(64),real(64)))'
 test_query_field7.chpl:8: note: this candidate did not match: foo(c: borrowed C(int, ?tt) ...?k)
-test_query_field7.chpl:8: note: because where clause evaluated to false
 test_query_field7.chpl:15: note: candidates are: foo(c: borrowed C(real, ?tt) ...?k)


### PR DESCRIPTION
When the compiler reports the reason why a function did not apply
for a particular function call, it may report "because where clause
evaluated to false". This may happen when the where-clause was added
by the compiler and not written by the user. If so, this explanation
is confusing. We prefer no explanation over a confusing explanation.
This PR makes this change as a near-term solution.

The compiler still emits this confusing explanation when the compiler
augmented the user-written where-clause and the function did not apply
because of the compiler-added predicate evaluating to false even though
the user-written predicate evaluates to true. See #13155 and the test
discussed next:

**`test/functions/typeMethods/error-message-when-not-applicable.chpl`**

* For the purpose of #13155, it does not matter what the where-clause is.
That issue is illustrated with any where-clause that evaluates to `true`.

* The note "is passed to formal 'this' of incompatible type" in the `.good`
file is one option for the desired wording. There may be better ways
to phrase the note.