### PR TITLE
Simplify standalone iterator for DefaultRectangular domains/arrays

### DIFF
--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -317,9 +317,14 @@ module DefaultRectangular {
         if debugDefaultDist {
           chpl_debug_writeln("*** DI: ranges = ", ranges);
         }
+        // TODO: The following is somewhat of an abuse of what
+        // _computeBlock() was designed for (dense ranges only; I
+        // multiplied by the stride as a white lie to make it work
+        // reasonabley.  We should switch to using the RangeChunk
+        // library...
         coforall chunk in 0..#numChunks {
           var myChunk = ranges;
-          const (lo,hi) = _computeBlock(ranges(parDim).length,
+          const (lo,hi) = _computeBlock(ranges(parDim).length*ranges(parDim).stride,
                                         numChunks, chunk,
                                         ranges(parDim)._high,
                                         ranges(parDim)._low,

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -295,26 +295,18 @@ module DefaultRectangular {
                                                      ignoreRunning,
                                                      minIndicesPerTask,
                                                      ranges);
-      if debugDefaultDist {
-        chpl_debug_writeln("    numChunks=", numChunks, " parDim=", parDim,
-                " ranges(", parDim, ").length=", ranges(parDim).length);
-      }
-
-      if debugDataPar {
-        chpl_debug_writeln("### numTasksPerLoc = ", numTasks, "\n" +
-                "### ignoreRunning = ", ignoreRunning, "\n" +
-                "### minIndicesPerTask = ", minIndicesPerTask, "\n" +
-                "### numChunks = ", numChunks, " (parDim = ", parDim, ")\n" +
-                "### nranges = ", ranges);
-      }
-
       if numChunks <= 1 {
         for i in these_help(1) {
           yield i;
         }
       } else {
-
         if debugDefaultDist {
+          chpl_debug_writeln("    numChunks=", numChunks, " parDim=", parDim,
+                             " ranges(", parDim, ").length=", ranges(parDim).length);
+          chpl_debug_writeln("### numTasksPerLoc = ", numTasks, "\n" +
+                             "### ignoreRunning = ", ignoreRunning, "\n" +
+                             "### minIndicesPerTask = ", minIndicesPerTask, "\n" +
+                             "### numChunks = ", numChunks, " (parDim = ", parDim, ")\n");
           chpl_debug_writeln("*** DI: ranges = ", ranges);
         }
         // TODO: The following is somewhat of an abuse of what

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -324,7 +324,9 @@ module DefaultRectangular {
         // library...
         coforall chunk in 0..#numChunks {
           var myChunk = ranges;
-          const (lo,hi) = _computeBlock(ranges(parDim).length*ranges(parDim).stride,
+          const len = if (ranges(parDim).stridable) then ranges(parDim).length
+              else ranges(parDim).length:uint * abs(ranges(parDim).stride):uint;
+          const (lo,hi) = _computeBlock(len,
                                         numChunks, chunk,
                                         ranges(parDim)._high,
                                         ranges(parDim)._low,

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -332,7 +332,7 @@ module DefaultRectangular {
                                         ranges(parDim)._low,
                                         ranges(parDim)._low);
           if (myChunk(parDim).stridable) then
-            myChunk(parDim) = lo..hi by myChunk(parDim).stride align myChunk(parDim).alignment;
+            myChunk(parDim) = lo..hi by myChunk(parDim).stride align chpl__idxToInt(myChunk(parDim).alignment);
           else {
             myChunk(parDim) = lo..hi;
           }

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -333,7 +333,7 @@ module DefaultRectangular {
             chpl_debug_writeln("*** DI[", chunk, "]: myChunk = ", myChunk);
           }
           for i in these_help(1, myChunk) {
-            yield chpl_intToIdx(i);
+            yield i;
           }
         }
       }

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -287,7 +287,7 @@ module DefaultRectangular {
                        else tasksPerLocale;
       if debugDefaultDist {
         chpl_debug_writeln("    numTasks=", numTasks, " (", ignoreRunning,
-                           "), minIndicesPerTask=", minIndicesPerTask);
+                "), minIndicesPerTask=", minIndicesPerTask);
       }
       const (numChunks, parDim) = if __primitive("task_get_serial") then
                                   (1, -1) else
@@ -297,7 +297,7 @@ module DefaultRectangular {
                                                      ranges);
       if debugDefaultDist {
         chpl_debug_writeln("    numChunks=", numChunks, " parDim=", parDim,
-                           " ranges(", parDim, ").length=", ranges(parDim).length);
+                " ranges(", parDim, ").length=", ranges(parDim).length);
       }
 
       if debugDataPar {
@@ -323,7 +323,7 @@ module DefaultRectangular {
         // reasonabley.  We should switch to using the RangeChunk
         // library...
         coforall chunk in 0..#numChunks {
-          var myChunk = ranges;
+          var block = ranges;
           const len = if (!ranges(parDim).stridable) then ranges(parDim).length
               else ranges(parDim).length:uint * abs(ranges(parDim).stride):uint;
           const (lo,hi) = _computeBlock(len,
@@ -331,15 +331,15 @@ module DefaultRectangular {
                                         ranges(parDim)._high,
                                         ranges(parDim)._low,
                                         ranges(parDim)._low);
-          if (myChunk(parDim).stridable) then
-            myChunk(parDim) = lo..hi by myChunk(parDim).stride align chpl__idxToInt(myChunk(parDim).alignment);
+          if (block(parDim).stridable) then
+            block(parDim) = lo..hi by block(parDim).stride align chpl__idxToInt(block(parDim).alignment);
           else {
-            myChunk(parDim) = lo..hi;
+            block(parDim) = lo..hi;
           }
           if debugDefaultDist {
-            chpl_debug_writeln("*** DI[", chunk, "]: myChunk = ", myChunk);
+            chpl_debug_writeln("*** DI[", chunk, "]: block = ", block);
           }
-          for i in these_help(1, myChunk) {
+          for i in these_help(1, block) {
             yield i;
           }
         }

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -324,7 +324,7 @@ module DefaultRectangular {
         // library...
         coforall chunk in 0..#numChunks {
           var myChunk = ranges;
-          const len = if (ranges(parDim).stridable) then ranges(parDim).length
+          const len = if (!ranges(parDim).stridable) then ranges(parDim).length
               else ranges(parDim).length:uint * abs(ranges(parDim).stride):uint;
           const (lo,hi) = _computeBlock(len,
                                         numChunks, chunk,

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -324,7 +324,11 @@ module DefaultRectangular {
                                         ranges(parDim)._high,
                                         ranges(parDim)._low,
                                         ranges(parDim)._low);
-          myChunk(parDim) = lo..hi;
+          if (myChunk(parDim).stridable) then
+            myChunk(parDim) = lo..hi by myChunk(parDim).stride align myChunk(parDim).alignment;
+          else {
+            myChunk(parDim) = lo..hi;
+          }
           if debugDefaultDist {
             chpl_debug_writeln("*** DI[", chunk, "]: myChunk = ", myChunk);
           }


### PR DESCRIPTION
While debugging behavior for a user, I noticed that the standalone iterator for DefaultRectangular domains (also used by DefaultRectangular arrays and everything else that's built from them) was essentially the combination of the historical leader and follower iterators into a single iterator.  The result is that we did a lot of work to translate indices into 0-based dense ranges as required by the leader-follower interface by convention, only to then reverse that translation immediately into more native indices.  This defeats a lot of the purpose of having standalone iterators.

This PR pares the code in the standalone iterator down to something much more straightforward, though further cleanup opportunities still remain (most notably, we should really put more weight on the `RangeChunk()` library by using it in situations like this...  I've added a TODO to that effect in the comments here, but didn't have the time to take that on this time around).

In the performance playground, this seems to have mostly been modestly beneficial or a wash; in some cases it has resulted in very slight degradations of performance, but nothing major, and I believe that the cause is due to minor differences in generated code patterns rather than anything fundamental (some of my earlier drafts did have much more significant bugs that caused major differences).