### PR TITLE
Extend unorderedCopy() support to any bool width

### DIFF
--- a/modules/packages/UnorderedCopy.chpl
+++ b/modules/packages/UnorderedCopy.chpl
@@ -88,12 +88,12 @@ module UnorderedCopy {
     unorderedCopyPrim(dst, refSrc);
   }
 
-  inline proc unorderedCopy(ref dst:bool, const ref src:bool): void {
+  inline proc unorderedCopy(ref dst:bool(?), const ref src:bool(?)): void {
     unorderedCopyPrim(dst, src);
   }
 
   pragma "no doc"
-  inline proc unorderedCopy(ref dst:bool, param src:bool): void {
+  inline proc unorderedCopy(ref dst:bool(?), param src:bool(?)): void {
     const refSrc = src;
     unorderedCopyPrim(dst, refSrc);
   }

--- a/test/runtime/configMatters/comm/unordered/unorderedCopyBasic.compopts
+++ b/test/runtime/configMatters/comm/unordered/unorderedCopyBasic.compopts
@@ -3,3 +3,4 @@
 -scopyType=real
 -scopyType=complex
 -scopyType=bool
+-scopyType='bool(16)'


### PR DESCRIPTION
Now that PR #13133 / issue #13120 are merged / fixed, we can extend unorderedCopy() to support any-width bools.  This simple PR does so and also extends Elliot's basic test to lock in the behavior for `bool(16)` (chosen by lottery to stand in as tribute for all bool sizes).
