### PR TITLE
Tidy log2/logBasePow2 for int/uint

### DIFF
--- a/modules/standard/Math.chpl
+++ b/modules/standard/Math.chpl
@@ -112,7 +112,7 @@ module Math {
       var tmp:uint(64) = val:uint(64);
       lg2 = 64 - 1 - chpl_bitops_clz_64(tmp):int;
     } else {
-      compilerError("Case not handled in logBasePow2 for integers");
+      compilerError("Integer width not handled in logBasePow2");
     }
 
     return lg2 / baseLog2;

--- a/test/library/standard/Math/log-ints.chpl
+++ b/test/library/standard/Math/log-ints.chpl
@@ -1,0 +1,61 @@
+proc checkLog(x, baseLog2, expect) {
+
+  var ok = true;
+
+  if baseLog2 == 1 {
+    ok &&= (log2(x) == expect);
+  }
+  ok &&= (logBasePow2(x, baseLog2) == expect);
+
+  // Check that it matches the old way of computing it.
+  var result = -1;
+  var val = x;
+  while (val != 0) {
+    val >>= baseLog2;
+    result += 1;
+  }
+  ok &&= (result == expect);
+
+  if !ok {
+    writeln("Failed with x=", x, " :", x.type:string,
+            " baseLog2=", baseLog2,
+            " expect=", expect);
+  }
+}
+
+proc checkLogs(type t) {
+  var nbits = numBits(t);
+
+  for baseLog2 in 1..nbits {
+    for i in 0..#nbits {
+      if baseLog2 < nbits && baseLog2*i < nbits {
+        var val = (1:t) << (baseLog2*i);
+        if val > 0 {
+          /*
+          writeln("t=", t:string,
+                  " val=", val,
+                  " baseLog2=", baseLog2,
+                  " i=", i);
+           */
+
+          checkLog(val, baseLog2, i);
+          if val >= 2 {
+            checkLog(val+1, baseLog2, i);
+          }
+          if val >= 4 {
+            checkLog(val-1, baseLog2, i-1);
+          }
+        }
+      }
+    }
+  }
+}
+
+checkLogs(uint(8));
+checkLogs(uint(16));
+checkLogs(uint(32));
+checkLogs(uint(64));
+checkLogs(int(8));
+checkLogs(int(16));
+checkLogs(int(32));
+checkLogs(int(64));


### PR DESCRIPTION
* Removes superfluous `in` intent on several functions
* Changes log2 to use chpl_bitops_clz_* so it is as performant
  as it can be (a few instructions rather than a loop).
* Clarify in the documentation that it always returns `int`
  and that it is the log rounded down.
* Adds testing for logBasePow2 (this did not seem to exist)

- [x] full local testing

Reviewed by @ben-albrecht - thanks!