### PR TITLE
Enable first-class-functions that throw

### DIFF
--- a/test/functions/firstClassFns/first-class-fn-throwing.chpl
+++ b/test/functions/firstClassFns/first-class-fn-throwing.chpl
@@ -1,0 +1,8 @@
+proc raiseError() throws {
+  throw new owned IllegalArgumentError();
+}
+
+var temp = raiseError;
+try { temp(); }
+catch { writeln('Caught an error'); }
+

--- a/test/functions/firstClassFns/first-class-fn-throwing.good
+++ b/test/functions/firstClassFns/first-class-fn-throwing.good
@@ -1,0 +1,1 @@
+Caught an error


### PR DESCRIPTION
Resolves #13193.

When the first-class-function type is inferred, generate a different
type for throwing functions.

This PR leaves as future work:
 * lambdas that throw
 * using the `func` function to specify the type of a throwing FCF

- [x] full local testing

Reviewed by @vasslitvinov - thanks!