### PR TITLE
Remove where-clause code after resolving it

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -9194,6 +9194,8 @@ static void insertRuntimeInitTemps() {
 
         // Collapse these through the runtimeTypeMap ...
         Type* rt = runtimeTypeMap.get(def->sym->type);
+        // This assert might fail for code that is no longer traversed
+        // after it is resolved, ex. in where-clauses.
         INT_ASSERT(rt);
         def->sym->type = rt;
 


### PR DESCRIPTION
The AST nodes in a where-clause, i.e. `FnSymbol::where`, that stay there
after it has been resolved can cause trouble (see below). Perhaps because
those nodes are not traversed by some resolution-time analyses and ARE
traversed by some others.

Therefore, remove the contents of a `FnSymbol::where` after is has been
resolved in `evaluateWhereClause()`. Do not remove the last Expr* because
it indicates the evaluation outcome - true or false.

The trouble this avoids is assertion failure in insertRuntimeInitTemps()
(the INT_ASSERT below the comment that this PR adds) for --no-local
compilations after #13158 (until this change) under start_test for:

```
test/arrays/slices/commCounts/sliceLocDist.chpl
test/distributions/robust/arithmetic/performance/multilocale/rvfSlices/assignSlice.chpl
test/distributions/robust/arithmetic/performance/multilocale/rvfSlices/reduceSlice.chpl
test/distributions/robust/arithmetic/performance/multilocale/rvfSlices/sliceOps.chpl
```

Discussed with @mppf.