### PR TITLE
RVF all block and cyclic arrays

### DIFF
--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -1291,7 +1291,12 @@ proc BlockDom.dsiReprivatize(other, reprivatizeData) {
   whole = {(...reprivatizeData)};
 }
 
+proc BlockArr.chpl__rvfMe() param {
+  return true;
+}
+
 proc BlockArr.chpl__serialize() {
+  writeln("Serializing BlockArr!");
   return pid;
 }
 

--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -1296,7 +1296,7 @@ proc BlockArr.chpl__rvfMe() param {
 }
 
 proc BlockArr.chpl__serialize() {
-  writeln("Serializing BlockArr!");
+  //  writeln("Serializing BlockArr!");
   return pid;
 }
 

--- a/modules/dists/CyclicDist.chpl
+++ b/modules/dists/CyclicDist.chpl
@@ -782,6 +782,10 @@ override proc CyclicArr.dsiDestroyArr() {
   }
 }
 
+proc CyclicArr.chpl__rvfMe() param {
+  return true;
+}
+
 proc CyclicArr.chpl__serialize() {
   return pid;
 }

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -2254,7 +2254,7 @@ module ChapelArray {
     pragma "no copy return"
     proc type chpl__deserialize(data) {
       var arrinst = _to_borrowed(__primitive("static field type", this, "_instance")).chpl__deserialize(data);
-      return new _array(nullPid, arrinst, _unowned=true);
+      return new _array(arrinst.pid, arrinst, _unowned=true);
     }
 
     proc chpl__promotionType() type {


### PR DESCRIPTION
Now that arrays are always RVF'd (#12985) and Block and Cyclic arrays have serialize/deserialize methods, it's a simple matter to always serialize/deserialize them.  This doesn't present a savings over what we've done on master recently, but I believe removes the need for special-case code in the compiler to handle these cases and to lean more on RVF and the remote serialization interfaces.

TODO:
- [ ] is there compiler code that could/should now be simplified?  (or would that need to wait until all privatized distributions are RVF'd?)
- [ ] resolve failures below due to thwarting fast-ons