### PR TITLE
Update modulefile to load cray-mpich only if unloaded

### DIFF
--- a/util/build_configs/cray-internal/generate-modulefile.bash
+++ b/util/build_configs/cray-internal/generate-modulefile.bash
@@ -86,21 +86,19 @@ if { [string match aarch64 $CHPL_HOST_ARCH] } {
 
         if {$mpichLoaded} {
             setenv CHPL_MODULE_KEEP_MPICH 1
-        }
-
-        if {! $mpichLoaded} {
+        } else {
             module load cray-mpich
         }
     } else {
         # Unloading or reloading chapel
 
         if {$mpichLoaded} {
-            # Was hugepages already loaded before we loaded chapel?
+            # Was mpich already loaded before we loaded chapel?
             if {[ info exists env(CHPL_MODULE_KEEP_MPICH)]} {
-                # When we are unloading, this actually unsets CHPL_MODULE_KEEP_HUGEPAGES
+                # When we are unloading, this actually unsets CHPL_MODULE_KEEP_MPICH
                 setenv CHPL_MODULE_KEEP_MPICH 1
             } else {
-                # When we are unloading, this actually unloads craype-hugepages16M
+                # When we are unloading, this actually unloads cray-mpich
                 module load cray-mpich
             }
         }


### PR DESCRIPTION
This makes our module file a little more robust to cases where a user
already has cray-mpich loaded which does not match the default version,
such as in our nightly testing.