### PR TITLE
Track compiler segfault when storing type of first class function directly

### DIFF
--- a/test/functions/firstClassFns/storeTheType.bad
+++ b/test/functions/firstClassFns/storeTheType.bad
@@ -1,0 +1,7 @@
+internal error: UTI-MIS-0602 chpl version 1.20.0 pre-release (3e39224b3a)
+
+Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
+and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
+please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
+the filename + line number above may be useful in working around the issue.
+

--- a/test/functions/firstClassFns/storeTheType.chpl
+++ b/test/functions/firstClassFns/storeTheType.chpl
@@ -1,0 +1,10 @@
+proc foo() {
+  writeln("in foo");
+}
+
+// The following compiles and runs
+//var tempfcf = foo;
+//type argType = tempfcf.type;
+type argType = foo.type;
+writeln(argType: string);
+

--- a/test/functions/firstClassFns/storeTheType.future
+++ b/test/functions/firstClassFns/storeTheType.future
@@ -1,0 +1,2 @@
+bug: compiler segfault with storing type of fcf directly into type variable
+#13209

--- a/test/functions/firstClassFns/storeTheType.good
+++ b/test/functions/firstClassFns/storeTheType.good
@@ -1,0 +1,1 @@
+borrowed chpl__fcf_type_void_void


### PR DESCRIPTION
When the first class function is first stored into a variable and then its type
is queried, we do not encounter an issue.  However, if the type of the fcf is
stored directly, the compiler will encounter a segfault due to trying to access
a node that has already been cleaned up.