### PR TITLE
Have FCF's print out the function's name + () when written out

### DIFF
--- a/compiler/include/buildDefaultFunctions.h
+++ b/compiler/include/buildDefaultFunctions.h
@@ -1,0 +1,10 @@
+#ifndef _BUILD_DEFAULT_FUNCTIONS_H_
+#define _BUILD_DEFAULT_FUNCTIONS_H_
+
+#include "symbol.h"
+#include "type.h"
+
+FnSymbol* buildWriteThisFnSymbol(AggregateType* ct, ArgSymbol** filearg);
+
+#endif
+

--- a/compiler/include/buildDefaultFunctions.h
+++ b/compiler/include/buildDefaultFunctions.h
@@ -1,3 +1,22 @@
+/*
+ * Copyright 2004-2019 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #ifndef _BUILD_DEFAULT_FUNCTIONS_H_
 #define _BUILD_DEFAULT_FUNCTIONS_H_
 

--- a/compiler/include/buildDefaultFunctions.h
+++ b/compiler/include/buildDefaultFunctions.h
@@ -4,6 +4,11 @@
 #include "symbol.h"
 #include "type.h"
 
+// build a hollow `writeThis` FunctionSymbol* for the given class type
+// 'ct', returning its file (channel) argument in 'filearg'.  The
+// callee is expected to fill in the body of the function and to
+// normalize the returned function before continuing.
+
 FnSymbol* buildWriteThisFnSymbol(AggregateType* ct, ArgSymbol** filearg);
 
 #endif

--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -1428,6 +1428,17 @@ FnSymbol* buildWriteThisFnSymbol(AggregateType* ct, ArgSymbol** filearg) {
 
   fn->retType = dtVoid;
 
+  DefExpr* def = new DefExpr(fn);
+
+  ct->symbol->defPoint->insertBefore(def);
+
+  fn->setMethod(true);
+  fn->addFlag(FLAG_METHOD_PRIMARY);
+
+  reset_ast_loc(def, ct->symbol);
+
+  ct->methods.add(fn);
+
   return fn;
 }
 
@@ -1486,18 +1497,7 @@ static void buildDefaultReadWriteFunctions(AggregateType* ct) {
                                     fn->_this));
     }
 
-    DefExpr* def = new DefExpr(fn);
-
-    ct->symbol->defPoint->insertBefore(def);
-
-    fn->setMethod(true);
-    fn->addFlag(FLAG_METHOD_PRIMARY);
-
-    reset_ast_loc(def, ct->symbol);
-
     normalize(fn);
-
-    ct->methods.add(fn);
   }
 
   // Make readThis when appropriate

--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -20,6 +20,7 @@
 #include "preFold.h"
 
 #include "astutil.h"
+#include "buildDefaultFunctions.h"
 #include "DecoratedClassType.h"
 #include "driver.h"
 #include "ForallStmt.h"
@@ -1941,28 +1942,8 @@ static Expr* createFunctionAsValue(CallExpr *call) {
 
   /* make writeThis for FCFs */
   {
-    FnSymbol* fn = new FnSymbol("writeThis");
-
-    fn->addFlag(FLAG_COMPILER_GENERATED);
-    fn->addFlag(FLAG_LAST_RESORT);
-    fn->addFlag(FLAG_OVERRIDE);
-
-    fn->cname = astr("_auto_", ct->symbol->name, "_write");
-    fn->_this = new ArgSymbol(INTENT_BLANK, "this", ct);
-    fn->_this->addFlag(FLAG_ARG_THIS);
-
-    ArgSymbol* fileArg = new ArgSymbol(INTENT_BLANK, "f", dtAny);
-
-    fileArg->addFlag(FLAG_MARKED_GENERIC);
-
-    fn->setMethod(true);
-
-    fn->insertFormalAtTail(new ArgSymbol(INTENT_BLANK, "_mt", dtMethodToken));
-    fn->insertFormalAtTail(fn->_this);
-    fn->insertFormalAtTail(fileArg);
-
-    fn->retType = dtVoid;
-
+    ArgSymbol* fileArg = NULL;
+    FnSymbol* fn = buildWriteThisFnSymbol(ct, &fileArg);
     // when printing out a FCF, print out the function's name
     fn->insertAtTail(new CallExpr(new CallExpr(".", fileArg,
                                                new_StringSymbol("writeIt")),

--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -1948,19 +1948,7 @@ static Expr* createFunctionAsValue(CallExpr *call) {
     fn->insertAtTail(new CallExpr(new CallExpr(".", fileArg,
                                                new_StringSymbol("writeIt")),
                                   new_StringSymbol(astr(flname, "()"))));
-                     
-    DefExpr* def = new DefExpr(fn);
-
-    ct->symbol->defPoint->insertBefore(def);
-
-    fn->setMethod(true);
-    fn->addFlag(FLAG_METHOD_PRIMARY);
-
-    reset_ast_loc(def, ct->symbol);
-
     normalize(fn);
-
-    ct->methods.add(fn);
   }
 
   return callWrapper;

--- a/test/functions/firstclass/printFCF.chpl
+++ b/test/functions/firstclass/printFCF.chpl
@@ -1,0 +1,4 @@
+proc justCheck(i: int) {
+  writeln(i);
+}
+writeln(justCheck:string);

--- a/test/functions/firstclass/printFCF.good
+++ b/test/functions/firstclass/printFCF.good
@@ -1,0 +1,1 @@
+justCheck()


### PR DESCRIPTION
This changes compiler-generated FCF types to print out the function name + parens when the FCF is printed out via a writeThis() overload.  This was very similar to the writeThis() functions we create by default for other user types, and I refactored code that was duplicated between the two cases into a new helper function defined in a new header file, buildDefaultFunctions.h.