### PR TITLE
Multi-locale libraries - cover corner case when link style is LS_DEFAULT on Mac

### DIFF
--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -1338,10 +1338,19 @@ static void postTaskTracking() {
 }
 
 static void postStaticLink() {
-  if (fLinkStyle == LS_STATIC) {
-    if (strcmp(CHPL_TARGET_PLATFORM, "darwin") == 0) {
+  if (!strcmp(CHPL_TARGET_PLATFORM, "darwin")) {
+    if (fLinkStyle == LS_STATIC) {
       USR_WARN("Static compilation is not supported on OS X, ignoring flag.");
       fLinkStyle = fMultiLocaleInterop ? LS_DYNAMIC : LS_DEFAULT;
+    }
+
+    //
+    // The default link style translates to static (at least for now), so we
+    // need to account for that when building a multi-locale library or else
+    // we'll get the same errors we do for static linking on `darwin`.
+    //
+    if (fMultiLocaleInterop && fLinkStyle == LS_DEFAULT) {
+      fLinkStyle = LS_DYNAMIC;
     }
   }
 }

--- a/test/interop/python/multilocale/COMPOPTS
+++ b/test/interop/python/multilocale/COMPOPTS
@@ -1,1 +1,1 @@
---library --library-python --dynamic
+--library --library-python


### PR DESCRIPTION
Rather embarrassingly, I forgot to account for a library compiled with neither `--static` or `--dynamic` in #13128. In such cases, the link style is `LS_DEFAULT`, which is currently equivalent to `LS_STATIC` for libraries when generating Makefiles.

This PR is a quick fix that makes multi-locale libraries default to `LS_DYNAMIC` when on Darwin.

Testing:

- [x] `ALL` on `linux64` when `CHPL_COMM=none`
- [x] `interop/python/multilocale` on `darwin` when `CHPL_COMM=gasnet`