### PR TITLE
Allow explicitly specifying the comm=ofi out-of-band support.

### DIFF
--- a/runtime/etc/Makefile.comm-ofi
+++ b/runtime/etc/Makefile.comm-ofi
@@ -33,7 +33,7 @@ LIBS += -lfabric -ldl
 #
 LD = $(CXX)
 
-ifneq (, $(findstring mpi,$(CHPL_MAKE_LAUNCHER)))
+ifneq (, $(findstring mpi, $(CHPL_MAKE_LAUNCHER) $(CHPL_COMM_OFI_OOB)))
   MPI_LIB_NAME = mpi
   ifneq ($(MPI_DIR),)
     ifneq ($(wildcard $(MPI_DIR)/lib64),)

--- a/runtime/make/Makefile.runtime.comm-ofi
+++ b/runtime/make/Makefile.runtime.comm-ofi
@@ -19,6 +19,6 @@ ifneq ($(LIBFABRIC_DIR),)
 RUNTIME_INCLS += -I$(LIBFABRIC_DIR)/include
 endif
 
-ifneq (, $(findstring mpi,$(CHPL_MAKE_LAUNCHER)))
+ifneq (, $(findstring mpi, $(CHPL_MAKE_LAUNCHER) $(CHPL_COMM_OFI_OOB)))
 RUNTIME_INCLS += -I$(MPI_DIR)/include
 endif

--- a/runtime/src/comm/ofi/Makefile.share
+++ b/runtime/src/comm/ofi/Makefile.share
@@ -24,18 +24,22 @@ COMM_SRCS = \
 	comm-ofi.c
 
 #
-# Use PMI out-of-band support on Cray X*, else MPI when the launcher is
-# that, else "sockets".  Use hugepages only on Cray X*.
+# By default, use PMI out-of-band support on Cray X*, else MPI when the
+# launcher is that, else "sockets".  Use hugepages only on Cray X*.
 #
-ifneq (, $(findstring cray-x,$(CHPL_MAKE_TARGET_PLATFORM)))
+ifneq (, $(findstring $(CHPL_COMM_OFI_OOB), mpi pmi sockets))
+  COMM_SRCS += comm-ofi-oob-$(CHPL_COMM_OFI_OOB).c
+else ifneq (, $(findstring cray-x,$(CHPL_MAKE_TARGET_PLATFORM)))
   COMM_SRCS += comm-ofi-oob-pmi.c
+else ifneq (, $(findstring mpi,$(CHPL_MAKE_LAUNCHER)))
+  COMM_SRCS += comm-ofi-oob-mpi.c
+else
+  COMM_SRCS += comm-ofi-oob-sockets.c
+endif
+
+ifneq (, $(findstring cray-x,$(CHPL_MAKE_TARGET_PLATFORM)))
   COMM_SRCS += comm-ofi-hugepages.c
 else
-  ifneq (, $(findstring mpi,$(CHPL_MAKE_LAUNCHER)))
-    COMM_SRCS += comm-ofi-oob-mpi.c
-  else
-    COMM_SRCS += comm-ofi-oob-sockets.c
-  endif
   COMM_SRCS += comm-ofi-no-hugepages.c
 endif
 


### PR DESCRIPTION
The out-of-band support is a small comm=ofi sub-interface used during
job setup and teardown, for determining the number of program instances
and the current instance's index, and for doing barrier, broadcast, and
allGather operations.  Currently there is support for PMI-, MPI-, and
sockets-based out-of-band support, although the latter is really just a
skeleton.  Up until now, out-of-band support has always been selected
automatically based on other things: PMI is used on Cray XC systems, and
MPI is used on all others (with the mpirun4ofi launcher).  Here, allow
the out-of-band support to be specified explicitly.