### PR TITLE
Workaround to fix `list` test failures on `COMM=gasnet` or `--no-local`

### DIFF
--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -956,7 +956,7 @@ module ChapelBase {
   }
 
   inline proc _ddata_allocate(type eltType, size: integral,
-                              subloc = c_sublocid_none) {
+                              subloc = c_sublocid_none, param initElts=true) {
     pragma "fn synchronization free"
     pragma "insert line file info"
     extern proc chpl_mem_array_alloc(nmemb: size_t, eltSize: size_t,
@@ -966,29 +966,8 @@ module ChapelBase {
     var callPostAlloc: bool;
     ret = chpl_mem_array_alloc(size:size_t, _ddata_sizeof_element(ret),
                                subloc, callPostAlloc):ret.type;
-    init_elts(ret, size, eltType);
-    if callPostAlloc {
-      pragma "fn synchronization free"
-      pragma "insert line file info"
-      extern proc chpl_mem_array_postAlloc(data: c_void_ptr, nmemb: size_t,
-                                           eltSize: size_t);
-      chpl_mem_array_postAlloc(ret:c_void_ptr, size:size_t,
-                               _ddata_sizeof_element(ret));
-    }
-    return ret;
-  }
-
-  inline proc _ddata_allocate_noinit(type eltType, size: integral,
-                                     subloc = c_sublocid_none) {
-    pragma "fn synchronization free"
-    pragma "insert line file info"
-    extern proc chpl_mem_array_alloc(nmemb: size_t, eltSize: size_t,
-                                     subloc: chpl_sublocID_t,
-                                     ref callPostAlloc: bool): c_void_ptr;
-    var ret: _ddata(eltType);
-    var callPostAlloc: bool;
-    ret = chpl_mem_array_alloc(size:size_t, _ddata_sizeof_element(ret),
-                               subloc, callPostAlloc):ret.type;
+    if initElts then
+      init_elts(ret, size, eltType);
     if callPostAlloc {
       pragma "fn synchronization free"
       pragma "insert line file info"

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -978,6 +978,28 @@ module ChapelBase {
     return ret;
   }
 
+  inline proc _ddata_allocate_noinit(type eltType, size: integral,
+                                     subloc = c_sublocid_none) {
+    pragma "fn synchronization free"
+    pragma "insert line file info"
+    extern proc chpl_mem_array_alloc(nmemb: size_t, eltSize: size_t,
+                                     subloc: chpl_sublocID_t,
+                                     ref callPostAlloc: bool): c_void_ptr;
+    var ret: _ddata(eltType);
+    var callPostAlloc: bool;
+    ret = chpl_mem_array_alloc(size:size_t, _ddata_sizeof_element(ret),
+                               subloc, callPostAlloc):ret.type;
+    if callPostAlloc {
+      pragma "fn synchronization free"
+      pragma "insert line file info"
+      extern proc chpl_mem_array_postAlloc(data: c_void_ptr, nmemb: size_t,
+                                           eltSize: size_t);
+      chpl_mem_array_postAlloc(ret:c_void_ptr, size:size_t,
+                               _ddata_sizeof_element(ret));
+    }
+    return ret;
+  }
+
   inline proc _ddata_free(data: _ddata, size: integral) {
     pragma "fn synchronization free"
     pragma "insert line file info"

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -956,7 +956,8 @@ module ChapelBase {
   }
 
   inline proc _ddata_allocate(type eltType, size: integral,
-                              subloc = c_sublocid_none, param initElts=true) {
+                              subloc = c_sublocid_none,
+                              initElts: bool=true) {
     pragma "fn synchronization free"
     pragma "insert line file info"
     extern proc chpl_mem_array_alloc(nmemb: size_t, eltSize: size_t,

--- a/modules/standard/Lists.chpl
+++ b/modules/standard/Lists.chpl
@@ -269,13 +269,7 @@ module Lists {
 
     pragma "no doc"
     proc _makeArray(size: int) {
-      //
-      // See https://github.com/chapel-lang/chapel/pull/13238 for why we need
-      // to avoid initialization here.
-      // See https://github.com/chapel-lang/chapel/pull/11908 for why we need
-      // to use `_ddata_allocate` instead of `c_malloc` and friends.
-      //
-      return _ddata_allocate(eltType, size, c_sublocid_none, false);
+      return _ddata_allocate(eltType, size, initElts=false);
     }
 
     pragma "no doc"

--- a/modules/standard/Lists.chpl
+++ b/modules/standard/Lists.chpl
@@ -259,25 +259,7 @@ module Lists {
 
     pragma "no doc"
     proc _makeBlockArray(size: int) {
-
-      //
-      // TODO: Casting the result of `c_calloc` to a `_ddata` is giving some
-      // very strange behavior right now that I can't explain. When repeated
-      // appends occur _after_ at least one allocation, every other append
-      // causes a sub-array in the second half of the sub-array block to
-      // become non-nil (?), which is very unsettling.
-      // A workaround that works right now is to define a second _ddata alloc
-      // method that does not default initialize its elements, and to use
-      // that to allocate instead.
-      // The memory returned by _ddata_allocate_noinit is not zeroed (we did
-      // not call malloc on it), so we have to set each sub-array slot to
-      // nil before we return it.
-      //
-
-      var result = _ddata_allocate_noinit(_ddata(eltType), size);
-      for i in 0..#size do
-        result[i] = nil;
-      return result;
+      return _ddata_allocate(_ddata(eltType), size);
     }
 
     pragma "no doc"
@@ -288,10 +270,12 @@ module Lists {
     pragma "no doc"
     proc _makeArray(size: int) {
       //
-      // We do not need to zero this memory, because the list implementation
-      // makes no assumptions about its initial state.
+      // See https://github.com/chapel-lang/chapel/pull/13238 for why we need
+      // to avoid initialization here.
+      // See https://github.com/chapel-lang/chapel/pull/11908 for why we need
+      // to use `_ddata_allocate` instead of `c_malloc` and friends.
       //
-      return _ddata_allocate_noinit(eltType, size);
+      return _ddata_allocate(eltType, size, c_sublocid_none, false);
     }
 
     pragma "no doc"

--- a/modules/standard/Lists.chpl
+++ b/modules/standard/Lists.chpl
@@ -257,12 +257,12 @@ module Lists {
     }
 
     pragma "no doc"
-    inline proc _makeBlockArray(size: int) {
+    proc _makeBlockArray(size: int) {
       return c_calloc(_ddata(eltType), size):_ddata(_ddata(eltType));
     }
 
     pragma "no doc"
-    inline proc _freeBlockArray(data: _ddata(_ddata(eltType))) {
+    proc _freeBlockArray(data: _ddata(_ddata(eltType))) {
       c_free(data:c_void_ptr);
     }
 


### PR DESCRIPTION
This PR fixes the `list` test failures that are occurring on `COMM=gasnet` or `COMM=none` with the `--no-local` flag. 

It adds a new argument to `_ddata_allocate` called `initElts`, and only performs initialization of elements when `initElts` is `true` (it is `true` by default). The calls to `c_calloc` within the `list` implementation are replaced with `_ddata_allocate`.


Testing:

- [x] `ALL` on `linux64` when `CHPL_COMM=none`

---

**(Not part of PR message).**

As for the bug itself, I'm not quite sure how to explain it other than it _seems_ to be caused by casting the result of a `c_calloc` to a `_ddata`.

The bug itself was not what I expected.

It looks like calls to `c_malloc` and company do not return the correct amount of memory for wide pointers on multi-locale modes. 

This problem is well illustrated here https://github.com/chapel-lang/chapel/pull/13238#issuecomment-501407128.