### PR TITLE
Pin our cce module builds to cray-libsci 19.04.1.1

### DIFF
--- a/util/build_configs/cray-internal/setenv-xc-aarch64.bash
+++ b/util/build_configs/cray-internal/setenv-xc-aarch64.bash
@@ -299,8 +299,9 @@ else
         load_module $target_prgenv
         load_module_version $target_compiler $target_version
 
-        # pin to an mpich version compatible with the gen compiler
+        # pin to mpich/libsci versions compatible with the gen compiler
         load_module_version cray-mpich 7.7.7
+        load_module_version cray-libsci 19.04.1.1
     }
 
     function load_target_cpu() {

--- a/util/build_configs/cray-internal/setenv-xc-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-xc-x86_64.bash
@@ -385,8 +385,9 @@ else
         load_module $target_prgenv
         load_module_version $target_compiler $target_version
 
-        # pin to an mpich version compatible with the gen compiler
+        # pin to mpich/libsci versions compatible with the gen compiler
         load_module_version cray-mpich 7.7.7
+        load_module_version cray-libsci 19.04.1.1
     }
 
     function load_target_cpu() {


### PR DESCRIPTION
The default libsci is no longer compatible with our gen compilers. Pin to
an older version.

Similar to https://github.com/chapel-lang/chapel/pull/13126