### PR TITLE
Updates to testing multilocale interoperability

### DIFF
--- a/test/interop/C/multilocale.skipif
+++ b/test/interop/C/multilocale.skipif
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+
+"""
+ Multilocale interoperability requires ZMQ
+ Installation of the ZMQ library is detected with the find_library function,
+ which looks for the appropriate dynamic library (e.g. libzmq.so).
+ Note that if the dynamic library is found, this test assumes that the
+ header and static library are available.
+"""
+
+from __future__ import print_function
+from ctypes.util import find_library
+import os
+
+# Is ZMQ available?
+zmq_found = find_library('zmq') is not None
+
+# Are we configured for multilocale?
+is_not_local = os.getenv('CHPL_COMM', 'none') != 'none'
+
+# OK contains the conditions that must be met to run the test
+OK = is_not_local and zmq_found
+
+# Skip if not OK
+print(not OK)

--- a/test/interop/python/multilocale.skipif
+++ b/test/interop/python/multilocale.skipif
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+
+"""
+ Multilocale interoperability requires ZMQ
+ Installation of the ZMQ library is detected with the find_library function,
+ which looks for the appropriate dynamic library (e.g. libzmq.so).
+ Note that if the dynamic library is found, this test assumes that the
+ header and static library are available.
+"""
+
+from __future__ import print_function
+from ctypes.util import find_library
+import os
+
+# Is ZMQ available?
+zmq_found = find_library('zmq') is not None
+
+# OK contains the conditions that must be met to run the test
+OK = zmq_found
+
+# Skip if not OK
+print(not OK)

--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -1288,7 +1288,7 @@ for testname in testsrc:
                                  .format(os.path.join(localdir, test_filename),
                                          numlocales, maxLocalesAvailable))
                 continue
-        if os.getenv('CHPL_TEST_MULTILOCALE_ONLY') and (numlocales <= 1):
+        if os.getenv('CHPL_TEST_MULTILOCALE_ONLY') and (numlocales <= 1) and not is_ml_c_test:
             sys.stdout.write('[Skipping {0} because it does not '
                              'use more than one locale]\n'
                              .format(os.path.join(localdir, test_filename)))


### PR DESCRIPTION
- Allow 1 locale interop tests to run when --multilocale-only passed to start_test
- Skip the python and C multilocale directories wholesale when ZMQ is not installed
on the system.