### PR TITLE
Fix typos

### DIFF
--- a/compiler/include/DecoratedClasses.h
+++ b/compiler/include/DecoratedClasses.h
@@ -35,7 +35,7 @@ typedef enum {
 } ClassTypeDecorator;
 #define NUM_DECORATED_CLASS_TYPES (11)
 #define CLASS_TYPE_MANAGEMENT_MASK (0xfc)
-#define CLASS_TYPE_NILIBILITY_MASK (0x03)
+#define CLASS_TYPE_NILABILITY_MASK (0x03)
 #define NUM_PACKED_DECORATED_TYPES 3
 
 static inline ClassTypeDecorator removeNilableFromDecorator(ClassTypeDecorator d) {
@@ -54,13 +54,13 @@ static inline ClassTypeDecorator addNilableToDecorator(ClassTypeDecorator d) {
   return (ClassTypeDecorator) tmp;
 }
 static inline bool isDecoratorUnknownNilability(ClassTypeDecorator d) {
-  return (d & CLASS_TYPE_NILIBILITY_MASK) == 0;
+  return (d & CLASS_TYPE_NILABILITY_MASK) == 0;
 }
 static inline bool isDecoratorNonNilable(ClassTypeDecorator d) {
-  return (d & CLASS_TYPE_NILIBILITY_MASK) == 1;
+  return (d & CLASS_TYPE_NILABILITY_MASK) == 1;
 }
 static inline bool isDecoratorNilable(ClassTypeDecorator d) {
-  return (d & CLASS_TYPE_NILIBILITY_MASK) == 2;
+  return (d & CLASS_TYPE_NILABILITY_MASK) == 2;
 }
 
 const char* decoratedTypeAstr(ClassTypeDecorator d, const char* className);

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -2268,11 +2268,11 @@ static void resolveUnmanagedBorrows() {
 
           // Compute the decorated class type
           if (call->isPrimitive(PRIM_TO_UNMANAGED_CLASS)) {
-            int tmp = decorator & CLASS_TYPE_NILIBILITY_MASK;
+            int tmp = decorator & CLASS_TYPE_NILABILITY_MASK;
             tmp |= CLASS_TYPE_UNMANAGED;
             decorator = (ClassTypeDecorator) tmp;
           } else if (call->isPrimitive(PRIM_TO_BORROWED_CLASS)) {
-            int tmp = decorator & CLASS_TYPE_NILIBILITY_MASK;
+            int tmp = decorator & CLASS_TYPE_NILABILITY_MASK;
             tmp |= CLASS_TYPE_BORROWED;
             decorator = (ClassTypeDecorator) tmp;
           } else if (call->isPrimitive(PRIM_TO_NILABLE_CLASS)) {

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -1483,7 +1483,7 @@ static void resolveEnumeratedTypes() {
 ************************************** | *************************************/
 
 //
-// Convert each "proc type C.myProc() ..." to, roughtly:
+// Convert each "proc type C.myProc() ..." to, roughly:
 // "proc type any.myProc() where isSubtype(this.type, C) ..."
 //
 static void adjustTypeMethodsOnClasses() {

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -1054,7 +1054,7 @@ bool canCoerceTuples(Type*     actualType,
 
 /* CLASS_TYPE_BORROWED e.g. can represent any nilability,
    but this function assumes that an actual with type CLASS_TYPE_BORROWED
-   is actually the same as CLASS_TYPE_BORROWED_NOTNIL.
+   is actually the same as CLASS_TYPE_BORROWED_NONNIL.
  */
 bool canCoerceDecorators(ClassTypeDecorator actual,
                          ClassTypeDecorator formal) {
@@ -2362,7 +2362,7 @@ static bool resolveBuiltinCastCall(CallExpr* call)
     // e.g. casting pointer or numeric types.
     //
     // The following are exceptions:
-    //  * casts invoving records (e.g. owned to borrowed)
+    //  * casts involving records (e.g. owned to borrowed)
     //  * casts involving complex (e.g. imag to complex)
     //  * promoted casts
 
@@ -3318,7 +3318,7 @@ static void generateUnresolvedMsg(CallInfo& info, Vec<FnSymbol*>& visibleFns) {
       i++;
 
       if (i <= nPrintDetails)
-        continue; // already printed it in detal
+        continue; // already printed it in detail
 
       if (fPrintAllCandidates == false && i > nPrint) {
         USR_PRINT("and %i other candidates, use --print-all-candidates to see them",

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -2561,7 +2561,7 @@ static bool isTypeConstructionCall(CallExpr* call) {
       // Compiler may represent accesses of instantiated tuple components in
       // the same way as a type construction call, so skip that case here.
       //
-      // A SymExpr of dtTuple indiciates tuple type construction.
+      // A SymExpr of dtTuple indicates tuple type construction.
       // TODO: Shouldn't we see a call to 'this' as the baseExpr?
       if (se->typeInfo()->symbol->hasFlag(FLAG_TUPLE) &&
           se->typeInfo() != dtTuple) {

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -840,7 +840,7 @@ module ChapelBase {
     }
   }
 
-  pragma "unsafe" // work around problems storting non-nilable classes
+  pragma "unsafe" // work around problems storing non-nilable classes
   proc init_elts(x, s, type t) : void {
     var initMethod = chpl_getArrayInitMethod();
 

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -320,7 +320,7 @@ module DefaultRectangular {
         // TODO: The following is somewhat of an abuse of what
         // _computeBlock() was designed for (dense ranges only; I
         // multiplied by the stride as a white lie to make it work
-        // reasonabley.  We should switch to using the RangeChunk
+        // reasonably.  We should switch to using the RangeChunk
         // library...
         coforall chunk in 0..#numChunks {
           var block = ranges;

--- a/modules/internal/SharedObject.chpl
+++ b/modules/internal/SharedObject.chpl
@@ -167,7 +167,7 @@ module SharedObject {
 
     pragma "no doc"
     proc init(p : borrowed) {
-      compilerError("cannoti initialize shared from a borrow");
+      compilerError("cannot initialize shared from a borrow");
       this.init(_to_unmanaged(p));
     }
 

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -980,7 +980,7 @@ module String {
     // Converts from codepointIndex range to byte index range in the process.
     //
     // This function handles ranges of codepointIndex or of numeric types,
-    // both of which signify postions in the string measured in codepoints.
+    // both of which signify positions in the string measured in codepoints.
     //
     // Slicing by stridable codepoint ranges is unsupported because it
     // creates an irregular sequence of bytes.  We could add support in the

--- a/modules/standard/Lists.chpl
+++ b/modules/standard/Lists.chpl
@@ -349,10 +349,10 @@ module Lists {
 
       const lastArrayIdx = _getLastArrayIdx();
       const lastArrayCapacity = _getArrayCapacity(lastArrayIdx);
-      const threshhold = _totalCapacity - lastArrayCapacity;
+      const threshold = _totalCapacity - lastArrayCapacity;
       const nsize = _size - amount;
 
-      if nsize >= threshhold then
+      if nsize >= threshold then
         return;
 
       ref array = _arrays[lastArrayIdx];

--- a/runtime/include/qio/qio_plugin_api.h
+++ b/runtime/include/qio/qio_plugin_api.h
@@ -39,7 +39,7 @@ syserr chpl_qio_filelength(void* file, int64_t* length);
 syserr chpl_qio_getpath(void* file, const char** str, int64_t* len);
 // sync the file to disk
 syserr chpl_qio_fsync(void* file);
-// get the optimial i/o size for the channel
+// get the optimal i/o size for the channel
 syserr chpl_qio_get_chunk(void* file, int64_t* length);
 // get the locales for a region
 // localeNamesPtr should be a pointer to an array of char* to set on output

--- a/test/classes/delete-free/shared/shared-from-borrow.good
+++ b/test/classes/delete-free/shared/shared-from-borrow.good
@@ -1,2 +1,2 @@
 shared-from-borrow.chpl:3: In function 'testShared':
-shared-from-borrow.chpl:5: error: cannoti initialize shared from a borrow
+shared-from-borrow.chpl:5: error: cannot initialize shared from a borrow

--- a/test/release/examples/primers/replicated.chpl
+++ b/test/release/examples/primers/replicated.chpl
@@ -84,14 +84,14 @@ on Locales[numLocales-1] do
 // Similarly, when reading the array, only the local copy will be
 // accessed.  Thus, when running on more than one locale, the
 // following writeln() will not see the modification performed by the
-// loop above since the two statements executed on distinct locales:
+// loop above since the two statements are executed on distinct locales:
 //
 writeln("Locale 0's copy of RA is:\n", RA);
 
 
 //
 // To access the replicands owned by other locales, we can use the
-// replicand method, which takes a locale as an argument and return the
+// replicand method, which takes a locale as an argument and returns the
 // array local to that locale:
 //
 


### PR DESCRIPTION
Fix typos in scopeResolve.cpp, functionResolution.cpp, ChapelBase.chpl,
String.chpl, Lists.chpl, DecoratedClasses.h, scopeResolve.cpp,
and one in SharedObject.chpl and a .good file.