### PR TITLE
GSoC 2019: Do not generate C in LLVM mode when not needed

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -1170,26 +1170,26 @@ static void codegen_header_compilation_config() {
 
       std::vector<llvm::Value *> compilationCommandArgs(2);
       compilationCommandArgs[0] = gGenInfo->irBuilder->CreateLoad(
-        new_CStringSymbol("Compilation command: %%s\\n")->codegen().val);
+        new_CStringSymbol("Compilation command: %s\n")->codegen().val);
       compilationCommandArgs[1] = gGenInfo->irBuilder->CreateLoad(
         new_CStringSymbol(compileCommand)->codegen().val);
       gGenInfo->irBuilder->CreateCall(printfFunc, compilationCommandArgs);
 
       std::vector<llvm::Value *> chapelCompilerVersionArgs(2);
       chapelCompilerVersionArgs[0] = gGenInfo->irBuilder->CreateLoad(
-        new_CStringSymbol("Chapel compiler version: %%s\\n")->codegen().val);
+        new_CStringSymbol("Chapel compiler version: %s\n")->codegen().val);
       chapelCompilerVersionArgs[1] = gGenInfo->irBuilder->CreateLoad(
         new_CStringSymbol(compileVersion)->codegen().val);
       gGenInfo->irBuilder->CreateCall(printfFunc, chapelCompilerVersionArgs);
 
       std::vector<llvm::Value *> chapelEnvironmentArgs(1);
       chapelEnvironmentArgs[0] = gGenInfo->irBuilder->CreateLoad(
-        new_CStringSymbol("Chapel environment: \\n")->codegen().val);
+        new_CStringSymbol("Chapel environment:\n")->codegen().val);
       gGenInfo->irBuilder->CreateCall(printfFunc, chapelEnvironmentArgs);
 
       std::vector<llvm::Value *> chplHomeArgs(2);
       chplHomeArgs[0] = gGenInfo->irBuilder->CreateLoad(
-        new_CStringSymbol("CHPL_HOME: %%s\\n")->codegen().val);
+        new_CStringSymbol("  CHPL_HOME: %s\n")->codegen().val);
       chplHomeArgs[1] = gGenInfo->irBuilder->CreateLoad(
         new_CStringSymbol(CHPL_HOME)->codegen().val);
       gGenInfo->irBuilder->CreateCall(printfFunc, chplHomeArgs);
@@ -1198,12 +1198,12 @@ static void codegen_header_compilation_config() {
         if (env->first != "CHPL_HOME") {
           std::vector<llvm::Value *> envArgs(3);
           envArgs[0] = gGenInfo->irBuilder->CreateLoad(
-            new_CStringSymbol("  %%s: %%s\\n")->codegen().val);
+            new_CStringSymbol("  %s: %s\n")->codegen().val);
           envArgs[1] = gGenInfo->irBuilder->CreateLoad(
             new_CStringSymbol(env->first.c_str())->codegen().val);
           envArgs[2] = gGenInfo->irBuilder->CreateLoad(
             new_CStringSymbol(env->second)->codegen().val);
-          gGenInfo->irBuilder->CreateCall(printfFunc, chplHomeArgs);
+          gGenInfo->irBuilder->CreateCall(printfFunc, envArgs);
         }
       }
 

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -45,7 +45,6 @@
 #ifdef HAVE_LLVM
 // Include relevant LLVM headers
 #include "llvm/IR/Module.h"
-#include "llvm/IR/TypeBuilder.h"
 #include "llvm/Pass.h"
 #include "llvm/Support/raw_ostream.h"
 #endif
@@ -1163,7 +1162,9 @@ static void codegen_header_compilation_config() {
       );
       gGenInfo->irBuilder->SetInsertPoint(programAboutBlock);
 
-      llvm::FunctionType* printfType = llvm::TypeBuilder<int(char*, ...), false>::get(gGenInfo->module->getContext());
+      llvm::FunctionType* printfType = llvm::FunctionType::get(
+        llvm::Type::getInt32Ty(gGenInfo->module->getContext()), {}, true
+      );
       llvm::Function* printfFunc = llvm::cast<llvm::Function>(
         gGenInfo->module->getOrInsertFunction("printf", printfType)
       );

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -1121,7 +1121,7 @@ static void codegen_header_compilation_config() {
     fprintf(cfgfile.fptr, "\n#include <stdio.h>");
     fprintf(cfgfile.fptr, "\n#include \"chpltypes.h\"\n\n");
 
-    if (llvmCodegen) {
+    if (llvmCodegen && 0 == strcmp(CHPL_LAUNCHER, "none")) {
 #ifdef HAVE_LLVM
       gGenInfo->cfile = NULL;
 #endif
@@ -1150,7 +1150,7 @@ static void codegen_header_compilation_config() {
       }
     }
 
-    if (llvmCodegen) {
+    if (llvmCodegen && 0 == strcmp(CHPL_LAUNCHER, "none")) {
 #ifdef HAVE_LLVM
       llvm::FunctionType* programAboutType;
       llvm::Function* programAboutFunc;
@@ -1176,17 +1176,17 @@ static void codegen_header_compilation_config() {
       fprintf(cfgfile.fptr, "\nvoid chpl_program_about() {\n");
     }
     
-    codegenCallPrintf("Compilation command: %s\\n", compileCommand);
-    codegenCallPrintf("Chapel compiler version: %s\\n", compileVersion);
+    codegenCallPrintf(astr("Compilation command: ", compileCommand, "\\n"));
+    codegenCallPrintf(astr("Chapel compiler version: ", compileVersion, "\\n"));
     codegenCallPrintf("Chapel environment:\\n");
-    codegenCallPrintf("  CHPL_HOME: %s\\n", CHPL_HOME);  
+    codegenCallPrintf(astr("CHPL_HOME: ", CHPL_HOME, "\\n"));  
       for (std::map<std::string, const char*>::iterator env=envMap.begin(); env!=envMap.end(); ++env) {
         if (env->first != "CHPL_HOME") {
-          codegenCallPrintf("  %s: %s\\n", env->first.c_str(), env->second); 
+          codegenCallPrintf(astr(env->first.c_str(), ": ", env->second, "\\n")); 
         }
       }
 
-    if (llvmCodegen) {
+    if (llvmCodegen && 0 == strcmp(CHPL_LAUNCHER, "none")) {
 #ifdef HAVE_LLVM
       gGenInfo->irBuilder->CreateRetVoid();
       gGenInfo->cfile = cfgfile.fptr;

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -1152,6 +1152,7 @@ static void codegen_header_compilation_config() {
     }
 
     if (genConfigInLLVM) {
+#ifdef HAVE_LLVM
       llvm::FunctionType* programAboutType;
       llvm::Function* programAboutFunc;
       if ((programAboutFunc = getFunctionLLVM("chpl_program_about"))) {
@@ -1169,6 +1170,7 @@ static void codegen_header_compilation_config() {
         gGenInfo->module->getContext(), "entry", programAboutFunc
       );
       gGenInfo->irBuilder->SetInsertPoint(programAboutBlock);
+#endif
     } else {
       // generate the "about" function
       fprintf(cfgfile.fptr, "\nvoid chpl_program_about(void);\n");
@@ -1186,7 +1188,9 @@ static void codegen_header_compilation_config() {
       }
 
     if (genConfigInLLVM) {
+#ifdef HAVE_LLVM
       gGenInfo->irBuilder->CreateRetVoid();
+#endif
       gGenInfo->cfile = cfgfile.fptr;
     } else {
       fprintf(cfgfile.fptr, "}\n");

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -46,10 +46,8 @@
 // Include relevant LLVM headers
 #include "llvm/IR/Module.h"
 #include "llvm/IR/TypeBuilder.h"
-#include "llvm/IR/Attributes.h"
 #include "llvm/Pass.h"
 #include "llvm/Support/raw_ostream.h"
-#include "llvm/Support/Casting.h"
 #endif
 
 #ifndef __STDC_FORMAT_MACROS

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -1121,10 +1121,12 @@ static void codegen_header_compilation_config() {
     fprintf(cfgfile.fptr, "\n#include <stdio.h>");
     fprintf(cfgfile.fptr, "\n#include \"chpltypes.h\"\n\n");
 
-    if (!llvmCodegen) {
-#ifndef HAVE_LLVM
-      gGenInfo->cfile = cfgfile.fptr;
+    if (llvmCodegen) {
+#ifdef HAVE_LLVM
+      gGenInfo->cfile = NULL;
 #endif
+    } else {
+      gGenInfo->cfile = cfgfile.fptr;
     }
 
     genGlobalString("chpl_compileCommand", compileCommand);
@@ -1176,7 +1178,7 @@ static void codegen_header_compilation_config() {
     
     codegenCallPrintf("Compilation command: %s\\n", compileCommand);
     codegenCallPrintf("Chapel compiler version: %s\\n", compileVersion);
-    codegenCallPrintf("Chapel environment:\\n", "");
+    codegenCallPrintf("Chapel environment:\\n");
     codegenCallPrintf("  CHPL_HOME: %s\\n", CHPL_HOME);  
       for (std::map<std::string, const char*>::iterator env=envMap.begin(); env!=envMap.end(); ++env) {
         if (env->first != "CHPL_HOME") {

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -1176,14 +1176,14 @@ static void codegen_header_compilation_config() {
       fprintf(cfgfile.fptr, "\nvoid chpl_program_about(void);\n");
       fprintf(cfgfile.fptr, "\nvoid chpl_program_about() {\n");
     }
-    
+
     codegenCallPrintf(astr("Compilation command: ", compileCommand, "\\n"));
     codegenCallPrintf(astr("Chapel compiler version: ", compileVersion, "\\n"));
     codegenCallPrintf("Chapel environment:\\n");
-    codegenCallPrintf(astr("CHPL_HOME: ", CHPL_HOME, "\\n"));  
+    codegenCallPrintf(astr("  CHPL_HOME: ", CHPL_HOME, "\\n"));
       for (std::map<std::string, const char*>::iterator env=envMap.begin(); env!=envMap.end(); ++env) {
         if (env->first != "CHPL_HOME") {
-          codegenCallPrintf(astr(env->first.c_str(), ": ", env->second, "\\n")); 
+          codegenCallPrintf(astr("  ", env->first.c_str(), ": ", env->second, "\\n"));
         }
       }
 

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -1121,29 +1121,35 @@ static void codegen_header_compilation_config() {
     fprintf(cfgfile.fptr, "\n#include <stdio.h>");
     fprintf(cfgfile.fptr, "\n#include \"chpltypes.h\"\n\n");
 
+    if (!llvmCodegen) {
+#ifndef HAVE_LLVM
+      gGenInfo->cfile = cfgfile.fptr;
+#endif
+    }
+
+    genGlobalString("chpl_compileCommand", compileCommand);
+    genGlobalString("chpl_compileVersion", compileVersion);
+    genGlobalString("chpl_compileDirectory", getCwd());
+    if (strcmp(saveCDir, "") != 0) {
+      char *actualPath = realpath(saveCDir, NULL);
+      genGlobalString("chpl_saveCDir", actualPath);
+    } else {
+      genGlobalString("chpl_saveCDir", "");
+    }
+
+    genGlobalString("CHPL_HOME", CHPL_HOME);
+
+    genGlobalInt("CHPL_STACK_CHECKS", !fNoStackChecks, false);
+    genGlobalInt("CHPL_CACHE_REMOTE", fCacheRemote, false);
+
+    for (std::map<std::string, const char*>::iterator env=envMap.begin(); env!=envMap.end(); ++env) {
+      if (env->first != "CHPL_HOME") {
+        genGlobalString(env->first.c_str(), env->second);
+      }
+    }
+
     if (llvmCodegen) {
 #ifdef HAVE_LLVM
-      genGlobalString("chpl_compileCommand", compileCommand);
-      genGlobalString("chpl_compileVersion", compileVersion);
-      genGlobalString("chpl_compileDirectory", getCwd());
-      if (strcmp(saveCDir, "") != 0) {
-        char *actualPath = realpath(saveCDir, NULL);
-        genGlobalString("chpl_saveCDir", actualPath);
-      } else {
-        genGlobalString("chpl_saveCDir", "");
-      }
-
-      genGlobalString("CHPL_HOME", CHPL_HOME);
-
-      genGlobalInt("CHPL_STACK_CHECKS", !fNoStackChecks, false);
-      genGlobalInt("CHPL_CACHE_REMOTE", fCacheRemote, false);
-
-      for (std::map<std::string, const char*>::iterator env=envMap.begin(); env!=envMap.end(); ++env) {
-        if (env->first != "CHPL_HOME") {
-          genGlobalString(env->first.c_str(), env->second);
-        }
-      }
-
       llvm::FunctionType* programAboutType;
       llvm::Function* programAboutFunc;
       if ((programAboutFunc = getFunctionLLVM("chpl_program_about"))) {
@@ -1161,104 +1167,29 @@ static void codegen_header_compilation_config() {
         gGenInfo->module->getContext(), "entry", programAboutFunc
       );
       gGenInfo->irBuilder->SetInsertPoint(programAboutBlock);
-
-      llvm::FunctionType* printfType = llvm::FunctionType::get(
-        llvm::Type::getInt32Ty(gGenInfo->module->getContext()), {}, true
-      );
-      llvm::Function* printfFunc = llvm::cast<llvm::Function>(
-        gGenInfo->module->getOrInsertFunction("printf", printfType)
-      );
-
-      std::vector<llvm::Value *> compilationCommandArgs(2);
-      compilationCommandArgs[0] = gGenInfo->irBuilder->CreateLoad(
-        new_CStringSymbol("Compilation command: %s\n")->codegen().val);
-      compilationCommandArgs[1] = gGenInfo->irBuilder->CreateLoad(
-        new_CStringSymbol(compileCommand)->codegen().val);
-      gGenInfo->irBuilder->CreateCall(printfFunc, compilationCommandArgs);
-
-      std::vector<llvm::Value *> chapelCompilerVersionArgs(2);
-      chapelCompilerVersionArgs[0] = gGenInfo->irBuilder->CreateLoad(
-        new_CStringSymbol("Chapel compiler version: %s\n")->codegen().val);
-      chapelCompilerVersionArgs[1] = gGenInfo->irBuilder->CreateLoad(
-        new_CStringSymbol(compileVersion)->codegen().val);
-      gGenInfo->irBuilder->CreateCall(printfFunc, chapelCompilerVersionArgs);
-
-      std::vector<llvm::Value *> chapelEnvironmentArgs(1);
-      chapelEnvironmentArgs[0] = gGenInfo->irBuilder->CreateLoad(
-        new_CStringSymbol("Chapel environment:\n")->codegen().val);
-      gGenInfo->irBuilder->CreateCall(printfFunc, chapelEnvironmentArgs);
-
-      std::vector<llvm::Value *> chplHomeArgs(2);
-      chplHomeArgs[0] = gGenInfo->irBuilder->CreateLoad(
-        new_CStringSymbol("  CHPL_HOME: %s\n")->codegen().val);
-      chplHomeArgs[1] = gGenInfo->irBuilder->CreateLoad(
-        new_CStringSymbol(CHPL_HOME)->codegen().val);
-      gGenInfo->irBuilder->CreateCall(printfFunc, chplHomeArgs);
-      
-      for (std::map<std::string, const char*>::iterator env=envMap.begin(); env!=envMap.end(); ++env) {
-        if (env->first != "CHPL_HOME") {
-          std::vector<llvm::Value *> envArgs(3);
-          envArgs[0] = gGenInfo->irBuilder->CreateLoad(
-            new_CStringSymbol("  %s: %s\n")->codegen().val);
-          envArgs[1] = gGenInfo->irBuilder->CreateLoad(
-            new_CStringSymbol(env->first.c_str())->codegen().val);
-          envArgs[2] = gGenInfo->irBuilder->CreateLoad(
-            new_CStringSymbol(env->second)->codegen().val);
-          gGenInfo->irBuilder->CreateCall(printfFunc, envArgs);
-        }
-      }
-
-      gGenInfo->irBuilder->CreateRetVoid();
-
-      gGenInfo->cfile = cfgfile.fptr;
 #endif
     } else {
-      gGenInfo->cfile = cfgfile.fptr;
-
-      genGlobalString("chpl_compileCommand", compileCommand);
-      genGlobalString("chpl_compileVersion", compileVersion);
-      genGlobalString("chpl_compileDirectory", getCwd());
-      if (strcmp(saveCDir, "") != 0) {
-        char *actualPath = realpath(saveCDir, NULL);
-        genGlobalString("chpl_saveCDir", actualPath);
-      } else {
-        genGlobalString("chpl_saveCDir", "");
-      }
-
-      genGlobalString("CHPL_HOME",           CHPL_HOME);
-
-      genGlobalInt("CHPL_STACK_CHECKS", !fNoStackChecks, false);
-      genGlobalInt("CHPL_CACHE_REMOTE", fCacheRemote, false);
-
-      for (std::map<std::string, const char*>::iterator env=envMap.begin(); env!=envMap.end(); ++env) {
-        if (env->first != "CHPL_HOME") {
-          genGlobalString(env->first.c_str(), env->second);
-        }
-      }
-
       // generate the "about" function
       fprintf(cfgfile.fptr, "\nvoid chpl_program_about(void);\n");
       fprintf(cfgfile.fptr, "\nvoid chpl_program_about() {\n");
-
-      fprintf(cfgfile.fptr,
-              "printf(\"%%s\", \"Compilation command: %s\\n\");\n",
-              compileCommand);
-      fprintf(cfgfile.fptr,
-              "printf(\"%%s\", \"Chapel compiler version: %s\\n\");\n",
-              compileVersion);
-      fprintf(cfgfile.fptr, "printf(\"Chapel environment:\\n\");\n");
-      fprintf(cfgfile.fptr,
-              "printf(\"%%s\", \"  CHPL_HOME: %s\\n\");\n",
-              CHPL_HOME);
+    }
+    
+    codegenCallPrintf("Compilation command: %s\\n", compileCommand);
+    codegenCallPrintf("Chapel compiler version: %s\\n", compileVersion);
+    codegenCallPrintf("Chapel environment:\\n", "");
+    codegenCallPrintf("  CHPL_HOME: %s\\n", CHPL_HOME);  
       for (std::map<std::string, const char*>::iterator env=envMap.begin(); env!=envMap.end(); ++env) {
         if (env->first != "CHPL_HOME") {
-          fprintf(cfgfile.fptr,
-            "printf(\"%%s\", \"  %s: %s\\n\");\n",
-            env->first.c_str(),
-            env->second);
+          codegenCallPrintf("  %s: %s\\n", env->first.c_str(), env->second); 
         }
       }
 
+    if (llvmCodegen) {
+#ifdef HAVE_LLVM
+      gGenInfo->irBuilder->CreateRetVoid();
+      gGenInfo->cfile = cfgfile.fptr;
+#endif
+    } else {
       fprintf(cfgfile.fptr, "}\n");
     }
 

--- a/compiler/codegen/expr.cpp
+++ b/compiler/codegen/expr.cpp
@@ -2820,7 +2820,7 @@ void codegenCallMemcpy(GenRet dest, GenRet src, GenRet size,
     //types[4] = llvm::Type::getInt1Ty(info->llvmContext);
 
     llvm::Function *func = llvm::Intrinsic::getDeclaration(info->module, llvm::Intrinsic::memcpy, types);
-    //llvm::FunctionType *fnType = func->getFunctionType();
+    //llvm::FunctionType *fnType = func-> getFunctionType();
 
 #if HAVE_LLVM_VER >= 70
     // LLVM 7 and later: memcpy has no alignment argument
@@ -3086,6 +3086,23 @@ GenRet codegenCastToVoidStar(GenRet value)
 #endif
   }
   return ret;
+}
+
+void codegenCallPrintf(const char* arg1, const char* arg2) {
+  codegenCallPrintf(arg1, arg2, "");
+}
+
+void codegenCallPrintf(const char* arg1, const char* arg2, const char* arg3) {
+//   GenInfo* info = gGenInfo;
+
+//   if (info->cfile) {
+//     fprintf(info->cfile, "printf(\"%s\", \"%s\", \"%s\");\n", arg1, arg2, arg3);
+//   } else {
+// #ifdef HAVE_LLVM
+    codegenCall("printf", new_CStringSymbol(arg1)->codegen(), new_CStringSymbol(arg2)->codegen(),
+      new_CStringSymbol(arg3)->codegen());
+// #endif
+//   }
 }
 
 /* Commented out because it is not currently used.

--- a/compiler/codegen/expr.cpp
+++ b/compiler/codegen/expr.cpp
@@ -2820,7 +2820,7 @@ void codegenCallMemcpy(GenRet dest, GenRet src, GenRet size,
     //types[4] = llvm::Type::getInt1Ty(info->llvmContext);
 
     llvm::Function *func = llvm::Intrinsic::getDeclaration(info->module, llvm::Intrinsic::memcpy, types);
-    //llvm::FunctionType *fnType = func-> getFunctionType();
+    //llvm::FunctionType *fnType = func->getFunctionType();
 
 #if HAVE_LLVM_VER >= 70
     // LLVM 7 and later: memcpy has no alignment argument
@@ -3088,21 +3088,41 @@ GenRet codegenCastToVoidStar(GenRet value)
   return ret;
 }
 
+void codegenCallPrintf(const char* arg) {
+  GenInfo* info = gGenInfo;
+
+  if (info->cfile) {
+    fprintf(info->cfile, "printf(\"%s\");", arg);
+  } else {
+#ifdef HAVE_LLVM
+    codegenCallPrintf(arg, "", "");
+#endif
+  }
+}
+
 void codegenCallPrintf(const char* arg1, const char* arg2) {
-  codegenCallPrintf(arg1, arg2, "");
+  GenInfo* info = gGenInfo;
+
+  if (info->cfile) {
+    fprintf(info->cfile, "printf(\"%s\", \"%s\");", arg1, arg2);
+  } else {
+#ifdef HAVE_LLVM
+    codegenCallPrintf(arg1, arg2, "");
+#endif
+  }
 }
 
 void codegenCallPrintf(const char* arg1, const char* arg2, const char* arg3) {
-//   GenInfo* info = gGenInfo;
+  GenInfo* info = gGenInfo;
 
-//   if (info->cfile) {
-//     fprintf(info->cfile, "printf(\"%s\", \"%s\", \"%s\");\n", arg1, arg2, arg3);
-//   } else {
-// #ifdef HAVE_LLVM
+  if (info->cfile) {
+    fprintf(info->cfile, "printf(\"%s\", \"%s\", \"%s\");\n", arg1, arg2, arg3);
+  } else {
+#ifdef HAVE_LLVM
     codegenCall("printf", new_CStringSymbol(arg1)->codegen(), new_CStringSymbol(arg2)->codegen(),
       new_CStringSymbol(arg3)->codegen());
-// #endif
-//   }
+#endif
+  }
 }
 
 /* Commented out because it is not currently used.

--- a/compiler/codegen/expr.cpp
+++ b/compiler/codegen/expr.cpp
@@ -3092,35 +3092,10 @@ void codegenCallPrintf(const char* arg) {
   GenInfo* info = gGenInfo;
 
   if (info->cfile) {
-    fprintf(info->cfile, "printf(\"%s\");", arg);
+    fprintf(info->cfile, "printf(\"%%s\", \"%s\");\n", arg);
   } else {
 #ifdef HAVE_LLVM
-    codegenCallPrintf(arg, "", "");
-#endif
-  }
-}
-
-void codegenCallPrintf(const char* arg1, const char* arg2) {
-  GenInfo* info = gGenInfo;
-
-  if (info->cfile) {
-    fprintf(info->cfile, "printf(\"%s\", \"%s\");", arg1, arg2);
-  } else {
-#ifdef HAVE_LLVM
-    codegenCallPrintf(arg1, arg2, "");
-#endif
-  }
-}
-
-void codegenCallPrintf(const char* arg1, const char* arg2, const char* arg3) {
-  GenInfo* info = gGenInfo;
-
-  if (info->cfile) {
-    fprintf(info->cfile, "printf(\"%s\", \"%s\", \"%s\");\n", arg1, arg2, arg3);
-  } else {
-#ifdef HAVE_LLVM
-    codegenCall("printf", new_CStringSymbol(arg1)->codegen(), new_CStringSymbol(arg2)->codegen(),
-      new_CStringSymbol(arg3)->codegen());
+    codegenCall("printf", new_CStringSymbol("%s")->codegen(), new_CStringSymbol(arg)->codegen());
 #endif
   }
 }

--- a/compiler/include/expr.h
+++ b/compiler/include/expr.h
@@ -390,4 +390,7 @@ GenRet codegenLocalDeref(GenRet toDeref);
 GenRet codegenNullPointer();
 GenRet codegenCast(const char* typeName, GenRet value, bool Cparens = true);
 
+void codegenCallPrintf(const char* arg1, const char* arg2);
+void codegenCallPrintf(const char* arg1, const char* arg2, const char* arg3);
+
 #endif

--- a/compiler/include/expr.h
+++ b/compiler/include/expr.h
@@ -390,6 +390,7 @@ GenRet codegenLocalDeref(GenRet toDeref);
 GenRet codegenNullPointer();
 GenRet codegenCast(const char* typeName, GenRet value, bool Cparens = true);
 
+void codegenCallPrintf(const char* arg);
 void codegenCallPrintf(const char* arg1, const char* arg2);
 void codegenCallPrintf(const char* arg1, const char* arg2, const char* arg3);
 

--- a/compiler/include/expr.h
+++ b/compiler/include/expr.h
@@ -391,7 +391,5 @@ GenRet codegenNullPointer();
 GenRet codegenCast(const char* typeName, GenRet value, bool Cparens = true);
 
 void codegenCallPrintf(const char* arg);
-void codegenCallPrintf(const char* arg1, const char* arg2);
-void codegenCallPrintf(const char* arg1, const char* arg2, const char* arg3);
 
 #endif

--- a/test/execflags/sungeun/about.prediff
+++ b/test/execflags/sungeun/about.prediff
@@ -10,7 +10,14 @@ import sys, os, subprocess
 
 testname = sys.argv[1]
 outfile = sys.argv[2]
-# compflags = sys.argv[4]
+compflags = sys.argv[4].split(' ')
+genLLVM = False
+for i in range(len(compflags)):
+    if compflags[i] == '--llvm':
+        genLLVM = True
+        os.environ['CHPL_LLVM_CODEGEN'] = os.environ['CHPL_LLVM']
+        break
+
 goodfile = testname+'.good'
 compver = 'Chapel compiler version:'
 chplhomestr = '  CHPL_HOME:'
@@ -31,7 +38,10 @@ with open(outfile, 'w') as ofh:
 
 with open(goodfile, 'w') as gfh:
     # might have to leave this off if too troublesome to maintain
-    gfh.write('Compilation command: chpl -o about --cc-warnings about.chpl \n')
+    if genLLVM:
+        gfh.write('Compilation command: chpl -o about --cc-warnings --llvm about.chpl \n')
+    else:
+        gfh.write('Compilation command: chpl -o about --cc-warnings about.chpl \n')
     gfh.write('Chapel compiler version:\n')
     gfh.write('Chapel environment:\n')
     gfh.write('  CHPL_HOME: %s\n'%(chpl_home))
@@ -44,3 +54,5 @@ with open(goodfile, 'w') as gfh:
     chplenv += "CHPL_THIRD_PARTY="+chpl_home+"/third-party\n"
     for (env, val) in (e.split('=', 1) for e in sorted(chplenv.split('\n')) if e):
         gfh.write('  %s: %s\n'%(env, val))
+        if env == 'CHPL_LLVM' and genLLVM:
+            gfh.write('  CHPL_LLVM_CODEGEN: %s\n'%(os.environ['CHPL_LLVM_CODEGEN']))

--- a/test/execflags/sungeun/about.skipif
+++ b/test/execflags/sungeun/about.skipif
@@ -3,7 +3,6 @@ COMPOPTS <= --no-inline
 COMPOPTS <= --no-local
 COMPOPTS <= --fast
 COMPOPTS <= --verify
-COMPOPTS <= --llvm
 COMPOPTS <= --incremental
 COMPOPTS <= --denormalize
 COMPOPTS <= --warn-unstable


### PR DESCRIPTION
This PR is a work on https://github.com/chapel-lang/chapel/issues/12738.

When in LLVM mode, in `chpl_compilation_config.c` we no longer generate the global C strings nor the `chpl_program_about()` method since we now incorporate these in the LLVM IR.