### PR TITLE
Mark CHPL_LIB_PIC unique configuration path variable as LAUNCHER

### DIFF
--- a/util/chplenv/printchplenv.py
+++ b/util/chplenv/printchplenv.py
@@ -93,7 +93,7 @@ CHPL_ENVS = [
     ChapelEnv('CHPL_REGEXP', RUNTIME | DEFAULT),
     ChapelEnv('CHPL_LLVM', COMPILER | DEFAULT, 'llvm'),
     ChapelEnv('CHPL_AUX_FILESYS', RUNTIME | DEFAULT, 'fs'),
-    ChapelEnv('CHPL_LIB_PIC', RUNTIME, 'lib_pic'),
+    ChapelEnv('CHPL_LIB_PIC', RUNTIME | LAUNCHER, 'lib_pic'),
     ChapelEnv('CHPL_RUNTIME_SUBDIR', INTERNAL),
     ChapelEnv('CHPL_LAUNCHER_SUBDIR', INTERNAL),
     ChapelEnv('CHPL_COMPILER_SUBDIR', INTERNAL),


### PR DESCRIPTION
This PR will resolve #13263.

Previously, the launcher library was not marked to require a rebuild when `CHPL_LIB_PIC` changed to a value for the first time.

This caused a bunch of linker errors to occur when compiling a multi-locale shared library in the following scenario:

- The user's first runtime configuration is `CHPL_COMM!=none` and `CHPL_LIB_PIC=none`
- The user attempts to compile a shared library, and gets linker errors related to `libchpllaunch.a` as described in #13263.
- The user sets `CHPL_LIB_PIC=pic` and recompiles their program.
- The user sees a "unsupported configuration error" that requires them to rebuild the runtime.
- The user rebuilds the runtime, but `libchpllaunch.a` is not rebuilt.
- Linker errors persist.

The fix for this issue is _surprisingly_ trivial, however it was a bit of a journey to understand how the build process actually works.

**Testing:**

Run on `linux64` with `CHPL_COMM=gasnet`. Begin each test "clean slate", removing all built runtime configurations with `rm -rf bin lib build`.

- [x] Reproducer listed above.
- [x] Multi-locale executable still builds/runs correctly when `CHPL_LIB_PIC=none` -> `CHPL_LIB_PIC=pic`.
- [x] Multi-locale executable still builds/runs correctly when `CHPL_LIB_PIC=pic` -> `CHPL_LIB_PIC=none`.
- [x] Single-locale executable still builds/runs correctly when `CHPL_LIB_PIC=pic` -> `CHPL_LIB_PIC=none` and `CHPL_LAUNCHER=slurm-srun`.
- [x] Single-locale executable still builds/runs correctly when `CHPL_LIB_PIC=none` -> `CHPL_LIB_PIC=pic` and `CHPL_LAUNCHER=slurm-srun`.