### PR TITLE
Allow in-intents of POD record types in follower iterators

### DIFF
--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -1454,6 +1454,19 @@ static bool mustUseRuntimeTypeDefault(ArgSymbol* formal) {
 *                                                                             *
 ************************************** | *************************************/
 
+// Do not create copies for the bogus actuals added for PRIM_TO_FOLLOWER.
+static bool checkAnotherFunctionsFormal(FnSymbol* calleeFn, CallExpr* call,
+                                        Symbol* actualSym) {
+  bool result = isArgSymbol(actualSym) &&
+                (call->parentSymbol != actualSym->defPoint->parentSymbol);
+
+  if (result                                   &&
+      propagateNotPOD(actualSym->getValType()) &&
+      ! isLeaderIterator(calleeFn)             )
+    USR_FATAL_CONT(calleeFn, "follower iterators accepting a non-POD argument by in-intent are not implemented");
+
+  return result;
+}
 
 static void handleInIntents(FnSymbol* fn,
                             CallInfo& info) {
@@ -1485,6 +1498,7 @@ static void handleInIntents(FnSymbol* fn,
     // does not need to be copied.
     if (formalRequiresTemp(formal, fn) &&
         shouldAddFormalTempAtCallSite(formal, fn) &&
+        ! checkAnotherFunctionsFormal(fn, info.call, actualSym) &&
         actualSym->hasFlag(FLAG_DEFAULT_ACTUAL) == false) {
 
       Expr* useExpr = currActual;

--- a/test/parallel/forall/in-intents/follower-in-intents.chpl
+++ b/test/parallel/forall/in-intents/follower-in-intents.chpl
@@ -1,0 +1,55 @@
+
+/// iterator ///
+
+iter myIter(in INARG) {
+  yield 77;
+}
+
+iter myIter(in INARG, param tag) where tag==iterKind.leader
+{
+  writeln("leader ", INARG);
+  yield update(INARG, 100);
+  yield update(INARG, 200);
+}
+
+iter myIter(in INARG, param tag, followThis) where tag==iterKind.follower
+{
+  writeln("follower ", INARG, "   following ", followThis);
+  yield update(INARG, 2);
+  yield update(INARG, 5);
+}
+
+/// integer ///
+
+var globalInt = 1000;
+proc update(ref num: int, inc:int) { num += inc; return num; }
+
+writeln(); writeln("int");
+forall iidx in zip(myIter(globalInt)) do
+  writeln(iidx);
+writeln(globalInt);
+
+writeln(); writeln("int x2");
+forall iidx in zip(myIter(globalInt),myIter(globalInt)) do
+  writeln(iidx);
+writeln(globalInt);
+
+/// record ///
+
+record RR { var xx: int; }
+var globalRec = new RR(1000);
+proc update(ref rr: RR, inc:int) { rr.xx += inc; return rr.xx; }
+
+writeln(); writeln("RR");
+forall ridx in zip(myIter(globalRec)) do
+  writeln(ridx);
+writeln(globalRec);
+
+writeln(); writeln("RR x2");
+forall ridx in zip(myIter(globalRec),myIter(globalRec)) do
+  writeln(ridx);
+writeln(globalRec);
+
+/// done ///
+
+writeln();

--- a/test/parallel/forall/in-intents/follower-in-intents.good
+++ b/test/parallel/forall/in-intents/follower-in-intents.good
@@ -1,0 +1,45 @@
+
+int
+leader 1000
+follower 1000   following 1100
+1002
+1007
+follower 1000   following 1300
+1002
+1007
+1000
+
+int x2
+leader 1000
+follower 1000   following 1100
+follower 1000   following 1100
+(1002, 1002)
+(1007, 1007)
+follower 1000   following 1300
+follower 1000   following 1300
+(1002, 1002)
+(1007, 1007)
+1000
+
+RR
+leader (xx = 1000)
+follower (xx = 1000)   following 1100
+1002
+1007
+follower (xx = 1000)   following 1300
+1002
+1007
+(xx = 1000)
+
+RR x2
+leader (xx = 1000)
+follower (xx = 1000)   following 1100
+follower (xx = 1000)   following 1100
+(1002, 1002)
+(1007, 1007)
+follower (xx = 1000)   following 1300
+follower (xx = 1000)   following 1300
+(1002, 1002)
+(1007, 1007)
+(xx = 1000)
+

--- a/test/parallel/forall/in-intents/follower-in-intents.todo.bad
+++ b/test/parallel/forall/in-intents/follower-in-intents.todo.bad
@@ -1,0 +1,1 @@
+follower-in-intents.todo.chpl:15: error: follower iterators accepting a non-POD argument by in-intent are not implemented

--- a/test/parallel/forall/in-intents/follower-in-intents.todo.chpl
+++ b/test/parallel/forall/in-intents/follower-in-intents.todo.chpl
@@ -1,0 +1,38 @@
+
+/// iterator ///
+
+iter myIter(in INARG) {
+  yield 77;
+}
+
+iter myIter(in INARG, param tag) where tag==iterKind.leader
+{
+  writeln("leader ", INARG);
+  yield update(INARG, 100);
+  yield update(INARG, 200);
+}
+
+iter myIter(in INARG, param tag, followThis) where tag==iterKind.follower
+{
+  writeln("follower ", INARG, "   following ", followThis);
+  yield update(INARG, 2);
+  yield update(INARG, 5);
+}
+
+/// string ///
+
+var globalString = "1000";
+
+proc atoi(arg: string) { var result=0; for cp in arg.codepoints() do
+                           result = result*10+(cp-48); return result; }
+
+proc update(ref str: string, inc:int) { str += inc:string; return str; }
+
+writeln(); writeln("string");
+forall sidx in zip(myIter(globalString)) do
+  writeln(sidx);
+writeln(globalString);
+
+/// done ///
+
+writeln();

--- a/test/parallel/forall/in-intents/follower-in-intents.todo.future
+++ b/test/parallel/forall/in-intents/follower-in-intents.todo.future
@@ -1,0 +1,2 @@
+unimplemented feature: in-intents of non-POD types in follower iterators do not work
+#13299

--- a/test/parallel/forall/in-intents/follower-in-intents.todo.good
+++ b/test/parallel/forall/in-intents/follower-in-intents.todo.good
@@ -1,0 +1,11 @@
+
+string
+leader 1000
+follower 1000   following 1000100
+10002
+100025
+follower 1000   following 1000100200
+10002
+100025
+1000
+


### PR DESCRIPTION
Resolves #13169.  Remaining open: #13293, #13299.

Background: our _toFollower function invokes the follower iterator
passing to it the formals of the serial iterator. This gets the job
done, however it is a poor representation because it uses those
formals outside of their scope. lowerIterators removes these
references by replacing them with fields of the corresponding _iteratorClass.
This replacement was missing the formal-temp for the in-intent formal
in the case it was created.

This change turns off formal temps in this particular scenario,
resolving this issue when the in-intent formal is of a POD type.
Using it for non-POD types may result in unintended semantics
(sharing the same array/domain when that's the argument)
or in memory violations (when the argument is a string).
So for now issue a compiler error for non-POD types.
See #13299 below.

An alternative to this change is here: 43d94eee4f , where by "313299"
I meant #13299. That change is more complex and the result is not
any better, so I chose against it.

#13299 remains un-addressed. I attempted to resolve it
in 6448717747 . However, that was not a complete solution
and it became clear to me that a complete solution needs
significantly more effort. So I did not use it either.