### PR TITLE
Fix support for llvm+gasnet on Crays

### DIFF
--- a/third-party/gasnet/Makefile
+++ b/third-party/gasnet/Makefile
@@ -65,14 +65,30 @@ endif
 endif
 ifeq ($(CHPL_MAKE_TARGET_PLATFORM),cray-xc)
 CHPL_GASNET_CFG_SCRIPT=cross-configure-cray-aries-alps
+CRAY_CROSS_CONFIGURE=y
 else
 CHPL_GASNET_CFG_SCRIPT=cross-configure-cray-gemini-alps
+CRAY_CROSS_CONFIGURE=y
 endif
 XTRA_CONFIG_COMMAND=cp --update $(GASNET_SUBDIR)/other/contrib/$(CHPL_GASNET_CFG_SCRIPT) $(GASNET_SUBDIR)
 XTRA_POST_INSTALL_COMMAND=rm -f $(GASNET_SUBDIR)/$(CHPL_GASNET_CFG_SCRIPT)
 else
 
 CHPL_GASNET_CFG_SCRIPT=configure
+endif
+
+# The cross-configure scripts used on Crays ignore our CC and always use CC=cc
+# (the PrgEnv wrappers.) Use PrgEnv-gnu to produce something that is ABI and
+# compiler option compatible with clang-included.
+ifeq ($(CRAY_CROSS_CONFIGURE), y)
+ifeq ($(CHPL_MAKE_COMPILER), clang-included)
+ifneq (, $(filter cray-prgenv-%,$(CHPL_MAKE_ORIG_TARGET_COMPILER)))
+ORIG_PRGENV = $(subst cray-prgenv-,,$(CHPL_MAKE_ORIG_TARGET_COMPILER))
+ifneq ($(ORIG_PRGENV), gnu)
+ENSURE_GASNET_COMPATIBLE_COMPILER=source $$MODULESHOME/init/bash; module unload PrgEnv-$(ORIG_PRGENV); module load PrgEnv-gnu;
+endif
+endif
+endif
 endif
 
 # Build amudprun for the host platform and replace the default one that was
@@ -117,14 +133,14 @@ gasnet-config: FORCE
 	mkdir -p $(GASNET_BUILD_DIR)
 	cd $(GASNET_SUBDIR) && ./Bootstrap -T
 	$(XTRA_CONFIG_COMMAND)
-	cd $(GASNET_BUILD_DIR) && $(CHPL_GASNET_ENV_VARS) $(GASNET_SUBDIR)/$(CHPL_GASNET_CFG_SCRIPT) --prefix=$(GASNET_INSTALL_DIR) $(CHPL_GASNET_CFG_OPTIONS) --disable-seq --enable-par --disable-parsync $(CHPL_GASNET_CFG_OPTIONS)
+	$(ENSURE_GASNET_COMPATIBLE_COMPILER) cd $(GASNET_BUILD_DIR) && $(CHPL_GASNET_ENV_VARS) $(GASNET_SUBDIR)/$(CHPL_GASNET_CFG_SCRIPT) --prefix=$(GASNET_INSTALL_DIR) $(CHPL_GASNET_CFG_OPTIONS) --disable-seq --enable-par --disable-parsync $(CHPL_GASNET_CFG_OPTIONS)
 
 gasnet-build: FORCE
-	cd $(GASNET_BUILD_DIR) && $(MAKE) all
+	$(ENSURE_GASNET_COMPATIBLE_COMPILER) cd $(GASNET_BUILD_DIR) && $(MAKE) all
 	$(XTRA_POST_BUILD_COMMAND)
 
 gasnet-install: FORCE
-	cd $(GASNET_BUILD_DIR) && $(MAKE) install
+	$(ENSURE_GASNET_COMPATIBLE_COMPILER) cd $(GASNET_BUILD_DIR) && $(MAKE) install
 	$(XTRA_POST_INSTALL_COMMAND)
 
 #

--- a/third-party/gasnet/Makefile
+++ b/third-party/gasnet/Makefile
@@ -85,7 +85,7 @@ ifeq ($(CHPL_MAKE_COMPILER), clang-included)
 ifneq (, $(filter cray-prgenv-%,$(CHPL_MAKE_ORIG_TARGET_COMPILER)))
 ORIG_PRGENV = $(subst cray-prgenv-,,$(CHPL_MAKE_ORIG_TARGET_COMPILER))
 ifneq ($(ORIG_PRGENV), gnu)
-ENSURE_GASNET_COMPATIBLE_COMPILER=source $$MODULESHOME/init/bash; module unload PrgEnv-$(ORIG_PRGENV); module load PrgEnv-gnu;
+ENSURE_GASNET_COMPATIBLE_COMPILER=. $$MODULESHOME/init/sh; module unload PrgEnv-$(ORIG_PRGENV); module load PrgEnv-gnu;
 endif
 endif
 endif

--- a/util/build_configs/cray-internal/setenv-xc-aarch64.bash
+++ b/util/build_configs/cray-internal/setenv-xc-aarch64.bash
@@ -126,7 +126,7 @@ if [ -z "$BUILD_CONFIGS_CALLBACK" ]; then
     ( *runtime* )
         log_info "Building Chapel component: runtime"
 
-        compilers=cray,gnu
+        compilers=gnu,cray
         comms=none,ugni
         launchers=aprun,none,slurm-srun
         substrates=aries,mpi,none

--- a/util/build_configs/cray-internal/setenv-xc-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-xc-x86_64.bash
@@ -126,7 +126,7 @@ if [ -z "$BUILD_CONFIGS_CALLBACK" ]; then
     ( *runtime* )
         log_info "Building Chapel component: runtime"
 
-        compilers=cray,intel,gnu
+        compilers=gnu,cray,intel
         comms=gasnet,none,ugni
         launchers=pbs-aprun,aprun,none,slurm-srun
         substrates=aries,mpi,none

--- a/util/build_configs/cray-internal/setenv-xe-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-xe-x86_64.bash
@@ -125,7 +125,7 @@ if [ -z "$BUILD_CONFIGS_CALLBACK" ]; then
     ( *runtime* )
         log_info "Building Chapel component: runtime"
 
-        compilers=cray,intel,gnu
+        compilers=gnu,cray,intel
         comms=gasnet,none,ugni
         launchers=pbs-aprun,aprun,none,slurm-srun
         substrates=gemini,mpi,none

--- a/util/config/gather-cray-prgenv-arguments.bash
+++ b/util/config/gather-cray-prgenv-arguments.bash
@@ -32,12 +32,12 @@ existing_prgenv=$(module list --terse 2>&1 | grep PrgEnv-)
 if [ -z "${existing_prgenv}" ]
 then
   # No PrgEnv loaded, load PrgEnv-gnu
-  module load PrgEnv-gnu
+  module load PrgEnv-gnu 2>/dev/null
 elif [[ "${existing_prgenv}" != PrgEnv-gnu* ]]
 then
   # Replace current PrgEnv with PrgEnv-gnu
-  module unload "${existing_prgenv}"
-  module load PrgEnv-gnu
+  module unload "${existing_prgenv}" 2>/dev/null
+  module load PrgEnv-gnu 2>/dev/null
 fi
 
 # Set up the environment to make the proper libraries and include


### PR DESCRIPTION
For llvm configurations, we build the runtime with CC=clang-included in
order to have a runtime that's compatible with llvm backend. However,
the cross-configure scripts we use to build gasnet on Crays force set
CC=cc so the PrgEnv wrappers are always used. Here we make sure that we
use PrgEnv-gnu because we know it should be ABI and compiler option
compatible.

Note that we're not just forcing gasnet to use clang-included because we
haven't been able to get clang-included to compile MPI programs so we'd
lose MPI compatibility and couldn't build the gasnet-mpi config.

This also swaps the module build order so we build with PrgEnv-gnu first
so that we build gasnet-llvm with the GNU gen compiler (instead of the
default GNU compiler.)

Closes https://github.com/chapel-lang/chapel/issues/12011