### PR TITLE
Permit 'string' type to be passed to externs, just not 'string' values

### DIFF
--- a/compiler/passes/checkResolved.cpp
+++ b/compiler/passes/checkResolved.cpp
@@ -484,7 +484,8 @@ static void checkExternProcs() {
       continue;
 
     for_formals(formal, fn) {
-      if (formal->typeInfo() == dtString) {
+      if (formal->typeInfo() == dtString &&
+          !formal->hasFlag(FLAG_TYPE_VARIABLE)) {
         if (!fn->hasFlag(FLAG_INSTANTIATED_GENERIC)) {
           USR_FATAL_CONT(fn, "extern procedures should not take arguments of "
                              "type string, use c_string instead");

--- a/test/extern/kbrady/extern_string_type.chpl
+++ b/test/extern/kbrady/extern_string_type.chpl
@@ -1,0 +1,1 @@
+c_sizeof(string);


### PR DESCRIPTION
We've historically prohibited passing Chapel string values to extern
procedures, but the check that did this was also preventing the Chapel
string type from being passed to externs, which I think is an oversight /
overkill (and something Louis was wanting to do in #13264, which I
think is reasonable).

Vaguely related, note that I think in the future that we may want to start
permitting Chapel strings to be passed to external procedures, and to
have them unwrap the string as a dual to issue #12892.  But that's
a separate effort.

Resolves #13264.