### PR TITLE
Make `channel.mark()` return the offset and throw if there is an error

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -2156,11 +2156,17 @@ proc channel.advancePastByte(byte:uint(8)) throws {
     advancing to the end of the file. It is important to be aware of these
     memory space requirements.
 
-  :returns: an error code, if an error was encountered.
+  :returns: The offset that was marked
+  :throws: SystemError: if marking the channel failed
  */
-// TODO: update to `throw` on error
-inline proc channel.mark():syserr where this.locking == false {
-  return qio_channel_mark(false, _channel_internal);
+inline proc channel.mark() throws where this.locking == false {
+  const offset = this.offset();
+  const err = qio_channel_mark(false, _channel_internal);
+
+  if err then
+    throw SystemError.fromSyserr(err);
+
+  return offset;
 }
 
 /*
@@ -2211,11 +2217,17 @@ inline proc channel._offset():int(64) {
    See :proc:`channel.mark` for details other than the locking
    discipline.
 
-  :returns: an error code, if an error was encountered.
+  :returns: The offset that was marked
+  :throws: SystemError: if marking the channel failed
  */
-// TODO: update to `throw` on error
-inline proc channel._mark():syserr {
-  return qio_channel_mark(false, _channel_internal);
+inline proc channel._mark() throws {
+  const offset = channel.offset();
+  const err = qio_channel_mark(false, _channel_internal);
+
+  if err then
+    throw SystemError.fromSyserr(err);
+
+  return offset();
 }
 
 /*

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -2227,7 +2227,7 @@ inline proc channel._mark() throws {
   if err then
     throw SystemError.fromSyserr(err);
 
-  return offset();
+  return offset;
 }
 
 /*

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -2221,7 +2221,7 @@ inline proc channel._offset():int(64) {
   :throws: SystemError: if marking the channel failed
  */
 inline proc channel._mark() throws {
-  const offset = channel.offset();
+  const offset = this.offset();
   const err = qio_channel_mark(false, _channel_internal);
 
   if err then

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -6859,10 +6859,9 @@ iter channel.matches(re:regexp, param captures=0, maxmatches:int = max(int))
   param nret = captures+1;
   var ret:nret*reMatch;
 
+  // TODO should be try not try!  ditto try! _mark() below
   try! lock();
-  on this.home do error = _mark();
-  // TODO should be try not try!  ditto try! lock() above
-  if error then try! this._ch_ioerror(error, "in channel.matches mark");
+  on this.home do try! _mark();
 
   while go && i < maxmatches {
     on this.home {

--- a/test/release/examples/benchmarks/shootout/revcomp-fast.chpl
+++ b/test/release/examples/benchmarks/shootout/revcomp-fast.chpl
@@ -16,11 +16,8 @@ proc main(args: [] string) {
   // if the file isn't empty, wait for all tasks to complete before continuing
   if len then sync {
     do {
-      // capture the starting offset
-      const descOffset = input.offset();
-
-      // Mark where we start scanning (keep bytes in I/O buffer in input)
-      input.mark();
+      // Mark where we start scanning and capture the starting offset
+      const descOffset = input.mark();
 
       // Scan forward until we get to '\n' (end of description)
       input.advancePastByte("\n".byte(1));


### PR DESCRIPTION
Update `channel.mark()` and `channel._mark()` to return the marked offset
and throw if there is an error.

Update test/release/examples/benchmarks/shootout/revcomp-fast.chpl to use
the returned offset instead of calling `offset()` directly.

Resolves #8943.