### PR TITLE
Add case for cray-shasta to chpl_cpu.py

### DIFF
--- a/util/chplenv/chpl_cpu.py
+++ b/util/chplenv/chpl_cpu.py
@@ -488,7 +488,7 @@ class InvalidLocationError(ValueError):
 # cpu architecture is actually loaded. Note that this MUST be kept in sync with
 # what we have in the module build script.
 def get_module_lcd_cpu(platform_val, cpu):
-    if platform_val == "cray-xc":
+    if platform_val == "cray-xc" or platform_val == "cray-shasta":
         if is_known_arm(cpu):
             return "arm-thunderx2"
         else:


### PR DESCRIPTION
Without doing this, I was unable to get 'printchplenv --runtime --path'
to specify an arch path other than 'arch-none'...  That said, I'm not
100% confident that this is the right way to fix the problem.