### PR TITLE
Restore mysystem to its former glory

### DIFF
--- a/compiler/backend/beautify.cpp
+++ b/compiler/backend/beautify.cpp
@@ -190,9 +190,6 @@ void beautify(fileinfo* origfile) {
   char* znptr;
   fileinfo* tmpfile;
 
-  mysystem(astr("# beautifying ", origfile->filename),
-           "generating comment for --print-commands option");
-
   zline = -1;
   
   openfile(origfile, "r");
@@ -275,7 +272,7 @@ void beautify(fileinfo* origfile) {
   closefile(origfile);
 
   command = astr("mv ", tmpfile->pathname, " ", origfile->pathname);
-  mysystem(command, "moving beautified file");
+  mysystem(command, "moving beautified file", false, true);
   
   if (justification.size() != 0) {
     INT_FATAL( "Parentheses or curly braces are not balanced "

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -2365,8 +2365,6 @@ void codegen() {
 #ifdef HAVE_LLVM
     checkAdjustedDataLayout();
     forv_Vec(ModuleSymbol, currentModule, allModules) {
-      mysystem(astr("# codegen-ing module", currentModule->name),
-               "generating comment for --print-commands option");
       currentModule->codegenDef();
     }
 
@@ -2386,9 +2384,6 @@ void codegen() {
 
     ChainHashMap<char*, StringHashFns, int> fileNameHashMap;
     forv_Vec(ModuleSymbol, currentModule, allModules) {
-      mysystem(astr("# codegen-ing module", currentModule->name),
-               "generating comment for --print-commands option");
-
       const char* filename = NULL;
       filename = generateFileName(fileNameHashMap, filename,currentModule->name);
 

--- a/compiler/include/mysystem.h
+++ b/compiler/include/mysystem.h
@@ -24,6 +24,7 @@ extern bool printSystemCommands;
 
 int mysystem(const char* command, 
              const char* description, 
-             bool        ignorestatus = false);
+             bool        ignorestatus = false,
+             bool        quiet = false);
 
 #endif

--- a/compiler/util/mysystem.cpp
+++ b/compiler/util/mysystem.cpp
@@ -30,13 +30,22 @@ bool printSystemCommands = false;
 
 int mysystem(const char* command, 
              const char* description,
-             bool        ignoreStatus) {
+             bool        ignoreStatus,
+             bool        quiet) {
   int status = 0;
 
-  // Treat a '#' at the start of a line as a comment
-  if (command[0] != '#') {
-    status = system(command);
+  if (printSystemCommands && !quiet) {
+    printf("\n# %s\n", description);
+    printf("%s\n", command);
+    fflush(stdout);
+    fflush(stderr);
   }
+
+  // Treat a '#' at the start of a line as a comment
+  if (command[0] == '#')
+    return 0;
+
+  status = system(command);
 
   if (status == -1) {
     USR_FATAL("system() fork failed: %s", strerror(errno));


### PR DESCRIPTION
mysystem used to print commands being run until commit
0f435805b969b8fc1631a74f845c2546e5db591d at which point this
functionality was removed (possibly accidentally).

In the meantime, clangUtil.cpp has grown a tryPrintSystemCommand call
that should be called before every mysystem. I noticed several commands
that were missing the corresponding call.

To reduce maintenance burden, this commit once again makes mysystem
print the commands being run. Additionally, it now prints out the
description as a comment first.

Since the "beautify" move commands create quite a bit of noise in the
output, created an option argument to mysystem to quiet --print-commands
output. The commands supporting beautify aren't normally what one is
looking for when running --print-commands.

Lastly, migrated a few --llvm specific calls to mysystem to use
std::string when constructing the command (instead of astr) and made some
of the more esoteric --llvm --print-commands off unless compiling with
--devel / CHPL_DEVELOPER=1.

Reviewed by @lydia-duncan - thanks!

- [x] passed full local testing
