### PR TITLE
Fix a problem with override checking

### DIFF
--- a/compiler/resolution/virtualDispatch.cpp
+++ b/compiler/resolution/virtualDispatch.cpp
@@ -1036,8 +1036,8 @@ static void checkMethodsOverride() {
               } else if (fn->isResolved() && !pfn->isResolved()) {
                 // pfn generic
                 FnSymbol* pInst = getInstantiatedFunction(fn, ct, pfn);
-                if (signatureMatch(fn, pInst) &&
-                    evaluateWhereClause(pInst)) {
+                resolveSignature(pInst);
+                if (signatureMatch(fn, pInst) && evaluateWhereClause(pInst)) {
                   foundMatch = true;
                 }
               } else if (!fn->isResolved() && pfn->isResolved()) {
@@ -1050,8 +1050,8 @@ static void checkMethodsOverride() {
                   foundUncertainty = true;
                 } else {
                   FnSymbol* fnIns = getInstantiatedFunction(pfn, ct, fn);
-                  if (signatureMatch(pfn, fnIns) &&
-                           evaluateWhereClause(pfn)) {
+                  resolveSignature(fnIns);
+                  if (signatureMatch(pfn, fnIns) && evaluateWhereClause(pfn)) {
                     foundMatch = true;
                   }
                 }


### PR DESCRIPTION
I observed a problem in developing PR #13327 
with QioPluginFile overrides where the override
checking was trying to use an unresolved
function signature. This fixes it.

- [x] full local testing

Reviewed by @vasslitvinov - thanks!