### PR TITLE
Move extra empty locales from ChapelDistribution to LocaleModels where missing

### DIFF
--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -959,13 +959,6 @@ module ChapelDistribution {
     delete arr;
   }
 
-  // These are used in ChapelLocale.chpl. They are here to
-  // prevent an order-of-resolution issue.
-  pragma "no doc"
-  const chpl_emptyLocaleSpace: domain(1) = {1..0};
-  pragma "no doc"
-  const chpl_emptyLocales: [chpl_emptyLocaleSpace] locale;
-
   // domain assignment helpers
 
   // Implement simple reallocate/set indices/post reallocate

--- a/modules/internal/localeModels/knl/LocaleModel.chpl
+++ b/modules/internal/localeModels/knl/LocaleModel.chpl
@@ -323,6 +323,9 @@ module LocaleModel {
     }
   }
 
+  const chpl_emptyLocaleSpace: domain(1) = {1..0};
+  const chpl_emptyLocales: [chpl_emptyLocaleSpace] locale;
+
   //
   // The node model
   //

--- a/modules/internal/localeModels/numa/LocaleModel.chpl
+++ b/modules/internal/localeModels/numa/LocaleModel.chpl
@@ -99,6 +99,9 @@ module LocaleModel {
     }
   }
 
+  const chpl_emptyLocaleSpace: domain(1) = {1..0};
+  const chpl_emptyLocales: [chpl_emptyLocaleSpace] locale;
+
   //
   // The node model
   //

--- a/test/modules/vass/deinit-order-modules.verbose.good
+++ b/test/modules/vass/deinit-order-modules.verbose.good
@@ -28,7 +28,6 @@ uv4ae.deinit UC
   MemTracking
   LocaleTree
   IO
-  ChapelDistribution
   LocalesArray
   LocaleModel
   DefaultRectangular


### PR DESCRIPTION
ChapelDistribution defined `chpl_emptyLocaleSpace` and `chpl_emptyLocales`,
but these constants were also defined in the LocaleModel for flat and apu.  Having
them in ChapelDistribution led to a circular dependency resolution error when I
tried to make the default use of ChapelStandard private.

This PR removes them from ChapelDistribution and inserts them into the
LocaleModels that didn't already have a definition (numa and knl).  I verified that
removing them without moving them to numa's LocaleModel caused failures for
hello world (so adding them there was necessary and that it would be immediately
visible if a problem occurred).

Testing:
- [x] full paratest with futures for flat
- [x] full gasnet paratest with futures for flat
- [x] test/release/examples/benchmarks/shootout for numa