### PR TITLE
Move some read/writeThis methods to ChapelIO

### DIFF
--- a/modules/internal/ChapelIO.chpl
+++ b/modules/internal/ChapelIO.chpl
@@ -771,6 +771,65 @@ module ChapelIO {
     }
   }
 
+  // Moved here to avoid circular dependencies in ChapelRange
+  // Write implementation for ranges
+  pragma "no doc"
+  proc range.writeThis(f)
+  {
+    // a range with a more normalized alignment
+    // a separate variable so 'this' can be const
+    var alignCheckRange = this;
+    if f.writing {
+      alignCheckRange.normalizeAlignment();
+    }
+
+    if hasLowBound() then
+      f <~> low;
+    f <~> new ioLiteral("..");
+    if hasHighBound() then
+      f <~> high;
+    if stride != 1 then
+      f <~> new ioLiteral(" by ") <~> stride;
+
+    // Write out the alignment only if it differs from natural alignment.
+    // We take alignment modulo the stride for consistency.
+    if ! alignCheckRange.isNaturallyAligned() && aligned then
+      f <~> new ioLiteral(" align ") <~> chpl_intToIdx(chpl__mod(chpl__idxToInt(alignment), stride));
+  }
+
+  pragma "no doc"
+  proc ref range.readThis(f)
+  {
+    if hasLowBound() then
+      f <~> _low;
+    f <~> new ioLiteral("..");
+    if hasHighBound() then
+      f <~> _high;
+    if stride != 1 then
+      f <~> new ioLiteral(" by ") <~> stride;
+
+    // try reading an 'align'
+    if !f.error() {
+      f <~> new ioLiteral(" align ");
+      if f.error() == EFORMAT then {
+        // naturally aligned.
+        f.clearError();
+      } else {
+        if stridable {
+          // un-naturally aligned - read the un-natural alignment
+          var a: intIdxType;
+          f <~> a;
+          _alignment = a;
+        } else {
+          // If the range is not stridable, it can't store an alignment.
+          // TODO: once Channels can store Chapel errors,
+          // create a more descriptive error for this case
+          f.setError(EFORMAT:syserr);
+        }
+      }
+    }
+  }
+
   //
   // Catch all
   //

--- a/modules/internal/ChapelIO.chpl
+++ b/modules/internal/ChapelIO.chpl
@@ -731,6 +731,46 @@ module ChapelIO {
   proc nothing.writeThis(f) {
   }
 
+  // Moved here to avoid circular dependencies in ChapelTuple.
+  pragma "no doc"
+  proc _tuple.readWriteThis(f) {
+    var st = f.styleElement(QIO_STYLE_ELEMENT_TUPLE);
+    var start:ioLiteral;
+    var comma:ioLiteral;
+    var end:ioLiteral;
+    var binary = f.binary();
+
+    if st == QIO_TUPLE_FORMAT_SPACE {
+      start = new ioLiteral("");
+      comma = new ioLiteral(" ");
+      end = new ioLiteral("");
+    } else if st == QIO_TUPLE_FORMAT_JSON {
+      start = new ioLiteral("[");
+      comma = new ioLiteral(", ");
+      end = new ioLiteral("]");
+    } else {
+      start = new ioLiteral("(");
+      comma = new ioLiteral(", ");
+      end = new ioLiteral(")");
+    }
+
+    if !binary {
+      f <~> start;
+    }
+    if size != 0 {
+      f <~> this(1);
+      for param i in 2..size {
+        if !binary {
+          f <~> comma;
+        }
+        f <~> this(i);
+      }
+    }
+    if !binary {
+      f <~> end;
+    }
+  }
+
   //
   // Catch all
   //

--- a/modules/internal/ChapelTuple.chpl
+++ b/modules/internal/ChapelTuple.chpl
@@ -289,44 +289,6 @@ module ChapelTuple {
   //
   // tuple methods
   //
-  pragma "no doc"
-  proc _tuple.readWriteThis(f) {
-    var st = f.styleElement(QIO_STYLE_ELEMENT_TUPLE);
-    var start:ioLiteral;
-    var comma:ioLiteral;
-    var end:ioLiteral;
-    var binary = f.binary();
-
-    if st == QIO_TUPLE_FORMAT_SPACE {
-      start = new ioLiteral("");
-      comma = new ioLiteral(" ");
-      end = new ioLiteral("");
-    } else if st == QIO_TUPLE_FORMAT_JSON {
-      start = new ioLiteral("[");
-      comma = new ioLiteral(", ");
-      end = new ioLiteral("]");
-    } else {
-      start = new ioLiteral("(");
-      comma = new ioLiteral(", ");
-      end = new ioLiteral(")");
-    }
-
-    if !binary {
-      f <~> start;
-    }
-    if size != 0 {
-      f <~> this(1);
-      for param i in 2..size {
-        if !binary {
-          f <~> comma;
-        }
-        f <~> this(i);
-      }
-    }
-    if !binary {
-      f <~> end;
-    }
-  }
 
   //
   // tuple casts to complex(64) and complex(128)


### PR DESCRIPTION
When uses of ChapelStandard are private, these methods started
requiring explicit uses in order for ioLiteral to be visible to them.
However, doing so led to a circular dependency where we were trying to
access locale stuff before the locale model had been resolved.  So,
instead of trying to chase that rabbit, move these method definitions
to ChapelIO, where some other read/writeThis methods were already
defined.

Note: I could also move the array read/writeThis functions, but since
arrays are used by ChapelLocale, they don't run into the same problem
just yet.

Passed a full standard paratest with futures