### PR TITLE
Move LocaleModel.writeThis to ChapelIO

### DIFF
--- a/modules/internal/ChapelIO.chpl
+++ b/modules/internal/ChapelIO.chpl
@@ -830,6 +830,13 @@ module ChapelIO {
     }
   }
 
+  override proc LocaleModel.writeThis(f) {
+      // Most classes will define it like this:
+      //      f <~> name;
+      // but here it is defined thus for backward compatibility.
+      f <~> new ioLiteral("LOCALE") <~> _node_id;
+  }
+
   //
   // Catch all
   //

--- a/modules/internal/ChapelIO.chpl
+++ b/modules/internal/ChapelIO.chpl
@@ -831,10 +831,10 @@ module ChapelIO {
   }
 
   override proc LocaleModel.writeThis(f) {
-      // Most classes will define it like this:
-      //      f <~> name;
-      // but here it is defined thus for backward compatibility.
-      f <~> new ioLiteral("LOCALE") <~> _node_id;
+    // Most classes will define it like this:
+    //      f <~> name;
+    // but here it is defined thus for backward compatibility.
+    f <~> new ioLiteral("LOCALE") <~> chpl_id();
   }
 
   //

--- a/modules/internal/localeModels/apu/LocaleModel.chpl
+++ b/modules/internal/localeModels/apu/LocaleModel.chpl
@@ -176,14 +176,6 @@ module LocaleModel {
     }
     override proc chpl_name() return local_name;
 
-
-    override proc writeThis(f) {
-      // Most classes will define it like this:
-      //      f <~> name;
-      // but here it is defined thus for backward compatibility.
-      f <~> new ioLiteral("LOCALE") <~> _node_id;
-    }
-
     proc getChildSpace() {
       halt("error!");
       return {0..#numSublocales};

--- a/modules/internal/localeModels/flat/LocaleModel.chpl
+++ b/modules/internal/localeModels/flat/LocaleModel.chpl
@@ -118,14 +118,6 @@ module LocaleModel {
       return this;
     }
 
-
-    override proc writeThis(f) {
-      // Most classes will define it like this:
-      //      f <~> name;
-      // but here it is defined thus for backward compatibility.
-      f <~> new ioLiteral("LOCALE") <~> _node_id;
-    }
-
     proc getChildSpace() return chpl_emptyLocaleSpace;
 
     override proc getChildCount() return 0;

--- a/modules/internal/localeModels/knl/LocaleModel.chpl
+++ b/modules/internal/localeModels/knl/LocaleModel.chpl
@@ -393,14 +393,6 @@ module LocaleModel {
       return hbm;
     }
 
-
-    override proc writeThis(f) {
-      // Most classes will define it like this:
-      //      f <~> name;
-      // but here it is defined thus for backward compatibility.
-      f <~> new ioLiteral("LOCALE") <~> _node_id;
-    }
-
     proc getChildSpace() return childSpace;
 
     override proc getChildCount() return numSublocales;

--- a/modules/internal/localeModels/numa/LocaleModel.chpl
+++ b/modules/internal/localeModels/numa/LocaleModel.chpl
@@ -169,14 +169,6 @@ module LocaleModel {
       return this;
     }
 
-
-    override proc writeThis(f) {
-      // Most classes will define it like this:
-      //      f <~> name;
-      // but here it is defined thus for backward compatibility.
-      f <~> new ioLiteral("LOCALE") <~> _node_id;
-    }
-
     proc getChildSpace() return childSpace;
 
     override proc getChildCount() return numSublocales;


### PR DESCRIPTION
Prior to this change, each LocaleModel would individually define identical
writeThis functions.  When I tried to make the use of ChapelStandard private,
we started encountering circular dependencies because of this, due to needing
to explicitly use IO and the IO module relying on things the LocaleModel would
define.  This change moves the writeThis function to ChapelIO to avoid this
circular dependency.

At Michael's suggestion, also change from using a field that is likely intended
to be private to using a method defined on the type.

Tested over:
- [x] full paratest with futures for CHPL_LOCALE_MODEL=flat
- [x] full paratest with futures for CHPL_LOCALE_MODEL=flat with CHPL_COMM=gasnet
- [x] spot check CHPL_LOCALE_MODEL=numa (hello.chpl and test/arrays/diten/strideBlock.chpl due to the latter being what caused me to discover this error)