### PR TITLE
Fix off-by-one error in BitVec size in noAliasSets

### DIFF
--- a/compiler/optimizations/noAliasSets.cpp
+++ b/compiler/optimizations/noAliasSets.cpp
@@ -571,6 +571,8 @@ bool addAlias(std::map<Symbol*, BitVec> &map,
   bool changed = false;
   std::map<Symbol*, BitVec>::iterator it = map.find(sym);
 
+  INT_ASSERT(index < bitVecSize);
+
   if (it == map.end()) {
     it = map.insert(std::make_pair(sym, makeBitVec(bitVecSize))).first;
     changed = true;
@@ -656,6 +658,7 @@ void computeNoAliasSets() {
 
   // Now compute the global alias sets for procedure arguments
   size_t nAddrTakenGlobals = addrTakenGlobalsToIds.size();
+  nAddrTakenGlobals++; // add 1 since we count from 1
 
   // Compute the starting point for the sets,
   // don't worry about transitivity/propagating yet.


### PR DESCRIPTION
Resolves problems observed in
 distributions/robust/arithmetic/optimizations/optimizeOnClauses_basic.chpl

- [x] full local testing
- [x] full local --llvm testing

Trivial and not reviewed.