### PR TITLE
Fix unittest launcher tests

### DIFF
--- a/test/library/packages/UnitTest/EXECENV
+++ b/test/library/packages/UnitTest/EXECENV
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+bin_subdir=`$CHPL_HOME/util/chplenv/chpl_bin_subdir.py`
+echo "PATH=\$CHPL_HOME/bin/$bin_subdir:\$PATH"


### PR DESCRIPTION
UnitTest launcher invokes chpl compiler, so requires chpl in path. Added an `EXECENV` for this.