### PR TITLE
GSoC 2019: Do not generate chpl_compilation_config.c at all in LLVM mode without a launcher

### DIFF
--- a/compiler/include/clangUtil.h
+++ b/compiler/include/clangUtil.h
@@ -77,7 +77,6 @@ bool setAlreadyConvertedExtern(ModuleSymbol* module, const char* name);
 void checkAdjustedDataLayout();
 
 extern fileinfo gAllExternCode;
-extern fileinfo gChplCompilationConfig;
 
 #endif // HAVE_LLVM
 

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -136,7 +136,6 @@ static void adjustLayoutForGlobalToWide();
 static void setupModule();
 
 fileinfo    gAllExternCode;
-fileinfo    gChplCompilationConfig;
 
 // forward declare
 class CCodeGenConsumer;
@@ -2945,20 +2944,6 @@ void makeBinaryLLVM(void) {
   for( size_t i = 0; i < clangInfo->clangCCArgs.size(); ++i ) {
     cargs += " ";
     cargs += clangInfo->clangCCArgs[i];
-  }
-
-  // Compile any C files.
-  if (gChplCompilationConfig.pathname) {
-    // Start with configuration settings
-    const char* inputFilename = gChplCompilationConfig.pathname;
-    const char* objFilename = objectFileForCFile(inputFilename);
-
-    std::string cmd = clangCC + " -c -o " + objFilename + " " +
-                      inputFilename + " " + cargs;
-
-    mysystem(cmd.c_str(), "Compile C File");
-
-    dotOFiles.push_back(objFilename);
   }
 
   int filenum = 0;

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2948,7 +2948,7 @@ void makeBinaryLLVM(void) {
   }
 
   // Compile any C files.
-  {
+  if (gChplCompilationConfig.pathname) {
     // Start with configuration settings
     const char* inputFilename = gChplCompilationConfig.pathname;
     const char* objFilename = objectFileForCFile(inputFilename);


### PR DESCRIPTION
This PR completely removes the generation of the `chpl_compilation_config.c` file in LLVM mode when building without any launcher.