### PR TITLE
filter intel license error for runtime cases too

### DIFF
--- a/util/test/sub_test
+++ b/util/test/sub_test
@@ -619,6 +619,12 @@ def filter_errors(output, pre_exec_output, execgoodfile, execlog):
             extra_msg = '(possible JIRA 287) '
             break
 
+    err_strings = ['could not checkout FLEXlm license']
+    for s in err_strings:
+        if re.search(s, output, re.IGNORECASE) != None:
+            extra_msg = '(possible JIRA 357) '
+            break
+
     return extra_msg
 
 


### PR DESCRIPTION
Previously only filtered intel license failure for compiler failures. This PR adds the filter for runtime failures too.