### PR TITLE
Avoid calling Spawn for CoMD under gasnet-ibv

### DIFF
--- a/test/studies/comd/elegant/arrayOfStructs/CoMD.chpl
+++ b/test/studies/comd/elegant/arrayOfStructs/CoMD.chpl
@@ -61,7 +61,12 @@ proc printProgress(step : int, elapsed : real) {
 
 proc printSystemInfo() {
   proc uname(cmd : string) {
-    if CHPL_COMM == "ugni" then return "unknown";
+    // Spawn doesn't work correctly under ugni or gn-ibv:
+    //  - https://github.com/chapel-lang/chapel/issues/7550
+    //  - https://github.com/chapel-lang/chapel/issues/13387
+    const ugni = CHPL_COMM == "ugni";
+    const gn_ibv = CHPL_COMM == "gasnet" && CHPL_COMM_SUBSTRATE == "ibv";
+    if ugni || gn_ibv then return "unknown";
 
     use Spawn;
     var sub = spawn(["uname", cmd], stdout=PIPE);

--- a/test/studies/comd/elegant/arrayOfStructs/CoMD.skipif
+++ b/test/studies/comd/elegant/arrayOfStructs/CoMD.skipif
@@ -1,11 +1,19 @@
 #!/usr/bin/env python
 
-# Skip this test for gasnet+mpi performance testing.
+# Skip this test for gasnet+mpi and gasnet+ibv-large performance testing.
 # Also skip this test when using MPI-based launchers in other configs,
 # because mpirun barks at the fork(2) resulting from the spawn().
 import os
 
-print((os.getenv('CHPL_TEST_PERF_LABEL') == 'ml-' and
-       os.getenv('CHPL_TEST_PERF') == 'on' and
-       os.getenv('CHPL_COMM_SUBSTRATE') == 'mpi') or
-      os.getenv('CHPL_LAUNCHER').startswith('mpi'))
+comm = os.getenv('CHPL_COMM')
+substrate = os.getenv('CHPL_COMM_SUBSTRATE')
+segment = os.getenv('CHPL_GASNET_SEGMENT')
+launcher = os.getenv('CHPL_LAUNCHER')
+ml_perf = (os.getenv('CHPL_TEST_PERF') == 'on' and
+           os.getenv('CHPL_TEST_PERF_LABEL') == 'ml-')
+
+gn_mpi_perf = ml_perf and comm == 'gasnet' and substrate == 'mpi'
+gn_ibv_lg_perf = ml_perf and comm == 'gasnet' and substrate == 'ibv' and segment == 'large'
+mpi_config = launcher.startswith('mpi')
+
+print(gn_mpi_perf or gn_ibv_lg_perf or mpi_config)


### PR DESCRIPTION
Spawn doesn't currently work under gasnet-ibv, so avoid calling it like
we do for ugni. See #13387 for more info. 

Also skip CoMD for gasnet-ibv segment large perf runs, since it times out.