### PR TITLE
Remove chpl_comm_make_progress from the comm API

### DIFF
--- a/runtime/include/chpl-comm.h
+++ b/runtime/include/chpl-comm.h
@@ -489,13 +489,6 @@ void chpl_comm_execute_on_fast(c_nodeid_t node, c_sublocid_t subloc,
 //
 int chpl_comm_numPollingTasks(void);
 
-// Some communication layers need to be periodically invoked
-// in order to make progress. This call gives the comm layer
-// an opportunity to move puts,gets, etc along while the
-// current thread is idle (e.g. when we are waiting on
-// an atomic variable for other tasks to finish).
-void chpl_comm_make_progress(void);
-
 // This is a hook that's called when a task is ending. It allows for things
 // like say flushing task private buffers.
 void chpl_comm_task_end(void);

--- a/runtime/src/comm/gasnet/comm-gasnet.c
+++ b/runtime/src/comm/gasnet/comm-gasnet.c
@@ -1582,9 +1582,4 @@ void  chpl_comm_execute_on_fast(c_nodeid_t node, c_sublocid_t subloc,
   }
 }
 
-void chpl_comm_make_progress(void)
-{
-  gasnet_AMPoll();
-}
-
 void chpl_comm_task_end(void) { }

--- a/runtime/src/comm/none/comm-none.c
+++ b/runtime/src/comm/none/comm-none.c
@@ -223,6 +223,4 @@ void chpl_comm_execute_on_fast(c_nodeid_t node, c_sublocid_t subloc,
 
 int chpl_comm_numPollingTasks(void) { return 0; }
 
-void chpl_comm_make_progress(void) { }
-
 void chpl_comm_task_end(void) { }


### PR DESCRIPTION
There are no uses of the API (it was added in an early prototype of the
remote cache work, but is no longer needed.)

Closes https://github.com/chapel-lang/chapel/issues/6349