### PR TITLE
Remove chpl_comm_numPollingTasks from the comm API

### DIFF
--- a/runtime/include/chpl-comm.h
+++ b/runtime/include/chpl-comm.h
@@ -478,17 +478,6 @@ void chpl_comm_execute_on_fast(c_nodeid_t node, c_sublocid_t subloc,
                                chpl_comm_on_bundle_t *arg, size_t arg_size,
                                int ln, int32_t fn);
 
-
-//
-// This call specifies the number of polling tasks that the
-// communication layer will need (see just below for a definition).
-// The value it returns is passed to chpl_task_init(), in order to
-// forewarn the tasking layer whether the comm layer will need a
-// polling task.  In the current implementation, it should only
-// return 0 or 1.
-//
-int chpl_comm_numPollingTasks(void);
-
 // This is a hook that's called when a task is ending. It allows for things
 // like say flushing task private buffers.
 void chpl_comm_task_end(void);

--- a/runtime/src/comm/gasnet/comm-gasnet.c
+++ b/runtime/src/comm/gasnet/comm-gasnet.c
@@ -866,10 +866,6 @@ void chpl_comm_post_mem_init(void) {
   chpl_comm_init_prv_bcast_tab();
 }
 
-int chpl_comm_numPollingTasks(void) {
-  return 1;
-}
-
 //
 // No support for gdb for now
 //

--- a/runtime/src/comm/none/comm-none.c
+++ b/runtime/src/comm/none/comm-none.c
@@ -221,6 +221,4 @@ void chpl_comm_execute_on_fast(c_nodeid_t node, c_sublocid_t subloc,
   chpl_ftable_call(fid, arg);
 }
 
-int chpl_comm_numPollingTasks(void) { return 0; }
-
 void chpl_comm_task_end(void) { }

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -1392,11 +1392,6 @@ static void amRequestCommon(c_nodeid_t, chpl_comm_on_bundle_t*, size_t,
                             chpl_comm_amDone_t**);
 
 
-int chpl_comm_numPollingTasks(void) {
-  return 1;
-}
-
-
 static inline
 void ensure_progress(void) {
   if (ofi_info->domain_attr->data_progress == FI_PROGRESS_MANUAL) {

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -2051,12 +2051,6 @@ int chpl_comm_run_in_gdb(int argc, char* argv[], int gdbArgnum, int* status)
   return 0;
 }
 
-
-int chpl_comm_numPollingTasks(void)
-{
-  return 1;
-}
-
 void chpl_comm_task_end(void) {
   task_local_buff_end(get_buff | put_buff | amo_nf_buff);
 }


### PR DESCRIPTION
`chpl_comm_numPollingTasks()` isn't used anymore, so remove it from the
comm interface. Early on it was used to inform the tasking layer how
many polling tasks might be created, but there have been significant
changes and refactoring to the polling logic since then.