### PR TITLE
Adjust error message format in multi-locale library codegen to be more useful

### DIFF
--- a/compiler/codegen/mli.cpp
+++ b/compiler/codegen/mli.cpp
@@ -435,7 +435,8 @@ std::string MLIContext::genMarshalRoutine(Type* t, bool out) {
   } else if (t == dtStringC) {
     gen += this->genMarshalBodyStringC(t, out);
   } else {
-    USR_FATAL("Multi-locale libraries do not support type", t);
+    USR_FATAL(t, "Multi-locale libraries do not support type: %s",
+              t->name());
   }
 
   // If we are unpacking, return our temporary.
@@ -626,13 +627,16 @@ bool MLIContext::isSupportedType(Type* t) {
 void MLIContext::verifyPrototype(FnSymbol* fn) {
 
   if (fn->retType != dtVoid && not isSupportedType(fn->retType)) {
-    USR_FATAL("Multi-locale libraries do not support type", fn->retType);
+    Type* t = fn->retType;
+    USR_FATAL(t, "Multi-locale libraries do not support return type: %s",
+              t->name());
   }
 
   for (int i = 1; i <= fn->numFormals(); i++) {
     ArgSymbol* as = fn->getFormal(i);
     if (not this->isSupportedType(as->type)) {
-      USR_FATAL("Multi-locale libraries do not support type", as->type);
+      USR_FATAL(t, "Multi-locale libraries do not support formal type: %s",
+                t->name());
     }
   }
 

--- a/compiler/codegen/mli.cpp
+++ b/compiler/codegen/mli.cpp
@@ -635,6 +635,7 @@ void MLIContext::verifyPrototype(FnSymbol* fn) {
   for (int i = 1; i <= fn->numFormals(); i++) {
     ArgSymbol* as = fn->getFormal(i);
     if (not this->isSupportedType(as->type)) {
+      Type* t = as->type;
       USR_FATAL(t, "Multi-locale libraries do not support formal type: %s",
                 t->name());
     }

--- a/compiler/codegen/mli.cpp
+++ b/compiler/codegen/mli.cpp
@@ -628,7 +628,7 @@ void MLIContext::verifyPrototype(FnSymbol* fn) {
 
   if (fn->retType != dtVoid && not isSupportedType(fn->retType)) {
     Type* t = fn->retType;
-    USR_FATAL(t, "Multi-locale libraries do not support return type: %s",
+    USR_FATAL(fn, "Multi-locale libraries do not support return type: %s",
               t->name());
   }
 
@@ -636,7 +636,7 @@ void MLIContext::verifyPrototype(FnSymbol* fn) {
     ArgSymbol* as = fn->getFormal(i);
     if (not this->isSupportedType(as->type)) {
       Type* t = as->type;
-      USR_FATAL(t, "Multi-locale libraries do not support formal type: %s",
+      USR_FATAL(fn, "Multi-locale libraries do not support formal type: %s",
                 t->name());
     }
   }


### PR DESCRIPTION
This is a small PR that adjusts the format of error messages in multi-locale library codegen so that they provide more useful information.

Currently, multi-locale libraries fail to compile due to an unsupported type. After implementing this quick adjustment, the new error message reveals...

```
$CHPL_HOME/modules/standard/IO.chpl:941: error: Multi-locale libraries do not support return type: syserr
```

Testing:

- [ ] `interop/C/multilocale` on `darwin` when `CHPL_COMM=gasnet`
- [ ] `interop/python/multilocale` on `darwin` when `CHPL_COMM=gasnet`

