### PR TITLE
Extend gitignore for some overlooked generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -420,6 +420,8 @@ tags
 
 /test/variables/bradc/docs/pragmaMultipleVars.doc.txt
 
+/test/visibility/only/test.dat
+
 /test/users/thom/returnGenericLineno/strassen
 
 # Third party ignores.

--- a/test/interop/C/makefiles/.gitignore
+++ b/test/interop/C/makefiles/.gitignore
@@ -7,3 +7,4 @@ libfoo.a
 checkRequire
 checkRequire2
 checkCommandLineLib
+envOverrides

--- a/test/visibility/only/weirdWritefInteraction.cleanfiles
+++ b/test/visibility/only/weirdWritefInteraction.cleanfiles
@@ -1,0 +1,1 @@
+test.dat


### PR DESCRIPTION
test/visibility/only/weirdWritefInteraction.chpl and
test/interop/C/makefiles/checkEnvOverrides.chpl generate
some files as part of their operations, but failed to add them to
the relevant .gitignore.  weirdWritefInteraction.chpl also failed to
clean the file up.  Rectify that oversight.