### PR TITLE
Fix Chapel-LLVM build with LLVM master

### DIFF
--- a/third-party/Makefile
+++ b/third-party/Makefile
@@ -121,7 +121,7 @@ $(LIBUNWIND_INSTALL_DIR): $(LIBUNWIND_DEPEND)
 
 llvm: $(LLVM_INSTALL_DIR)
 $(LLVM_INSTALL_DIR): $(LLVM_DEPEND)
-	rm -rf $(LLVM_INSTALL_DIR) && rm -rf $(LLVM_BUILD_DIR)
+	rm -rf $(LLVM_INSTALL_DIR)
 	cd llvm && $(MAKE)
 
 # Qthreads may use hwloc and/or jemalloc. Ensure they are built first.

--- a/third-party/llvm/Makefile.include-llvm
+++ b/third-party/llvm/Makefile.include-llvm
@@ -15,7 +15,12 @@ ifndef LLVM_LLVM_LIBS
   export LLVM_LLVM_LIBS=$(shell test -x $(LLVM_CONFIG) && $(LLVM_CONFIG) --ldflags --system-libs --libs bitreader bitwriter ipo instrumentation option objcarcopts profiledata all-targets coverage coroutines lto)
 endif
 
-LLVM_CLANG_LIBS=-lclangFrontend -lclangSerialization -lclangDriver -lclangCodeGen -lclangParse -lclangSema -lclangAnalysis -lclangEdit -lclangAST -lclangLex -lclangBasic
+ifeq ($(LLVM_MAJOR_VERSION),9)
+  # -lclangASTMatchers needed for LLVM 9 but not earlier
+  LLVM_CLANG_LIBS=-lclangFrontend -lclangSerialization -lclangDriver -lclangCodeGen -lclangParse -lclangSema -lclangAnalysis -lclangEdit -lclangASTMatchers -lclangAST -lclangLex -lclangBasic
+else
+  LLVM_CLANG_LIBS=-lclangFrontend -lclangSerialization -lclangDriver -lclangCodeGen -lclangParse -lclangSema -lclangAnalysis -lclangEdit -lclangAST -lclangLex -lclangBasic
+endif
 
 
 ifdef CHPL_RV

--- a/third-party/llvm/Makefile.include-llvm
+++ b/third-party/llvm/Makefile.include-llvm
@@ -15,7 +15,7 @@ ifndef LLVM_LLVM_LIBS
   export LLVM_LLVM_LIBS=$(shell test -x $(LLVM_CONFIG) && $(LLVM_CONFIG) --ldflags --system-libs --libs bitreader bitwriter ipo instrumentation option objcarcopts profiledata all-targets coverage coroutines lto)
 endif
 
-ifeq ($(LLVM_MAJOR_VERSION),9)
+ifeq ($(LLVM_MAJOR_VERSION_9PLUS),9)
   # -lclangASTMatchers needed for LLVM 9 but not earlier
   LLVM_CLANG_LIBS=-lclangFrontend -lclangSerialization -lclangDriver -lclangCodeGen -lclangParse -lclangSema -lclangAnalysis -lclangEdit -lclangASTMatchers -lclangAST -lclangLex -lclangBasic
 else

--- a/third-party/llvm/Makefile.include-system
+++ b/third-party/llvm/Makefile.include-system
@@ -4,7 +4,7 @@ ifndef LLVM_LLVM_LIBS
   export LLVM_LLVM_LIBS=$(shell test -x $(LLVM_CONFIG) && $(LLVM_CONFIG) --ldflags --system-libs --libs bitreader bitwriter ipo instrumentation option objcarcopts profiledata all-targets coverage coroutines lto)
 endif
 
-ifeq ($(LLVM_MAJOR_VERSION),9)
+ifeq ($(LLVM_MAJOR_VERSION_9PLUS),9)
   # -lclangASTMatchers needed for LLVM 9 but not earlier
   LLVM_CLANG_LIBS=-lclangFrontend -lclangSerialization -lclangDriver -lclangCodeGen -lclangParse -lclangSema -lclangAnalysis -lclangEdit -lclangASTMatchers -lclangAST -lclangLex -lclangBasic
 else

--- a/third-party/llvm/Makefile.include-system
+++ b/third-party/llvm/Makefile.include-system
@@ -4,7 +4,13 @@ ifndef LLVM_LLVM_LIBS
   export LLVM_LLVM_LIBS=$(shell test -x $(LLVM_CONFIG) && $(LLVM_CONFIG) --ldflags --system-libs --libs bitreader bitwriter ipo instrumentation option objcarcopts profiledata all-targets coverage coroutines lto)
 endif
 
-LLVM_CLANG_LIBS=-lclangFrontend -lclangSerialization -lclangDriver -lclangCodeGen -lclangParse -lclangSema -lclangAnalysis -lclangEdit -lclangAST -lclangLex -lclangBasic
+ifeq ($(LLVM_MAJOR_VERSION),9)
+  # -lclangASTMatchers needed for LLVM 9 but not earlier
+  LLVM_CLANG_LIBS=-lclangFrontend -lclangSerialization -lclangDriver -lclangCodeGen -lclangParse -lclangSema -lclangAnalysis -lclangEdit -lclangASTMatchers -lclangAST -lclangLex -lclangBasic
+else
+  LLVM_CLANG_LIBS=-lclangFrontend -lclangSerialization -lclangDriver -lclangCodeGen -lclangParse -lclangSema -lclangAnalysis -lclangEdit -lclangAST -lclangLex -lclangBasic
+endif
+
 
 # Ubuntu 16.04 needed -fno-rtti for LLVM 3.7
 # tested on that system after installing

--- a/third-party/llvm/Makefile.share-included
+++ b/third-party/llvm/Makefile.share-included
@@ -11,10 +11,5 @@ ifndef LLVM_CONFIG_CFLAGS
   export LLVM_CONFIG_CFLAGS:=$(shell test -x $(LLVM_CONFIG) && $(LLVM_CONFIG) --cflags | awk -f $(THIRD_PARTY_DIR)/llvm/filter-llvm-config.awk)
 endif
 
-ifndef LLVM_VERSION
-  export LLVM_VERSION:=$(shell test -x $(LLVM_CONFIG) && $(LLVM_CONFIG) --version)
-endif
-
-ifndef LLVM_MAJOR_VERSION
-  export LLVM_MAJOR_VERSION:=$(firstword $(subst ., ,$(LLVM_VERSION)))
-endif
+# LLVM_VERSION, LLVM_MAJOR_VERSION, etc
+include $(THIRD_PARTY_DIR)/llvm/Makefile.version

--- a/third-party/llvm/Makefile.share-included
+++ b/third-party/llvm/Makefile.share-included
@@ -4,10 +4,17 @@ LLVM_CONFIG=$(LLVM_INSTALL_DIR)/bin/llvm-config
 
 # LLVM preprocessor flags (ie -Dbla and -Ibla) 
 ifndef LLVM_CONFIG_CXXFLAGS
-  export LLVM_CONFIG_CXXFLAGS=$(shell test -x $(LLVM_CONFIG) && $(LLVM_CONFIG) --cxxflags | awk -f $(THIRD_PARTY_DIR)/llvm/filter-llvm-config.awk)
+  export LLVM_CONFIG_CXXFLAGS:=$(shell test -x $(LLVM_CONFIG) && $(LLVM_CONFIG) --cxxflags | awk -f $(THIRD_PARTY_DIR)/llvm/filter-llvm-config.awk)
 endif
 
 ifndef LLVM_CONFIG_CFLAGS
-  export LLVM_CONFIG_CFLAGS=$(shell test -x $(LLVM_CONFIG) && $(LLVM_CONFIG) --cflags | awk -f $(THIRD_PARTY_DIR)/llvm/filter-llvm-config.awk)
+  export LLVM_CONFIG_CFLAGS:=$(shell test -x $(LLVM_CONFIG) && $(LLVM_CONFIG) --cflags | awk -f $(THIRD_PARTY_DIR)/llvm/filter-llvm-config.awk)
 endif
 
+ifndef LLVM_VERSION
+  export LLVM_VERSION:=$(shell test -x $(LLVM_CONFIG) && $(LLVM_CONFIG) --version)
+endif
+
+ifndef LLVM_MAJOR_VERSION
+  export LLVM_MAJOR_VERSION:=$(firstword $(subst ., ,$(LLVM_VERSION)))
+endif

--- a/third-party/llvm/Makefile.share-system
+++ b/third-party/llvm/Makefile.share-system
@@ -1,28 +1,35 @@
 include $(THIRD_PARTY_DIR)/llvm/Makefile.share
 
 ifndef PREFERRED_LLVM_VERS
-  export PREFERRED_LLVM_VERS=$(shell cat $(THIRD_PARTY_DIR)/llvm/LLVM_VERSION)
+  export PREFERRED_LLVM_VERS:=$(shell cat $(THIRD_PARTY_DIR)/llvm/LLVM_VERSION)
 endif
 
 ifndef LLVM_CONFIG
-  export LLVM_CONFIG=$(shell $(THIRD_PARTY_DIR)/llvm/find-llvm-config.sh $(PREFERRED_LLVM_VERS))
+  export LLVM_CONFIG:=$(shell $(THIRD_PARTY_DIR)/llvm/find-llvm-config.sh $(PREFERRED_LLVM_VERS))
 endif
 
 ifndef LLVM_CONFIG_INCLUDE_DIR
-  export LLVM_CONFIG_INCLUDE_DIR=$(shell test -x $(LLVM_CONFIG) && $(LLVM_CONFIG) --includedir)
+  export LLVM_CONFIG_INCLUDE_DIR:=$(shell test -x $(LLVM_CONFIG) && $(LLVM_CONFIG) --includedir)
 endif
 
 ifndef LLVM_CONFIG_LIB_DIR
-  export LLVM_CONFIG_LIB_DIR=$(shell test -x $(LLVM_CONFIG) && $(LLVM_CONFIG) --libdir)
+  export LLVM_CONFIG_LIB_DIR:=$(shell test -x $(LLVM_CONFIG) && $(LLVM_CONFIG) --libdir)
 endif
 
 # LLVM preprocessor flags (ie -Dbla and -Ibla) 
 ifndef LLVM_CONFIG_CXXFLAGS
-  export LLVM_CONFIG_CXXFLAGS=$(shell test -x $(LLVM_CONFIG) && $(LLVM_CONFIG) --cxxflags | awk -f $(THIRD_PARTY_DIR)/llvm/filter-llvm-config.awk)
+  export LLVM_CONFIG_CXXFLAGS:=$(shell test -x $(LLVM_CONFIG) && $(LLVM_CONFIG) --cxxflags | awk -f $(THIRD_PARTY_DIR)/llvm/filter-llvm-config.awk)
 endif
 
 ifndef LLVM_CONFIG_CFLAGS
-  export LLVM_CONFIG_CFLAGS=$(shell test -x $(LLVM_CONFIG) && $(LLVM_CONFIG) --cflags | awk -f $(THIRD_PARTY_DIR)/llvm/filter-llvm-config.awk)
+  export LLVM_CONFIG_CFLAGS:=$(shell test -x $(LLVM_CONFIG) && $(LLVM_CONFIG) --cflags | awk -f $(THIRD_PARTY_DIR)/llvm/filter-llvm-config.awk)
+endif
+
+ifndef LLVM_VERSION
+  export LLVM_VERSION:=$(shell test -x $(LLVM_CONFIG) && $(LLVM_CONFIG) --version)
+endif
+ifndef LLVM_MAJOR_VERSION
+  export LLVM_MAJOR_VERSION:=$(firstword $(subst ., ,$(LLVM_VERSION)))
 endif
 
 # Figure out which clang we are using

--- a/third-party/llvm/Makefile.share-system
+++ b/third-party/llvm/Makefile.share-system
@@ -25,12 +25,8 @@ ifndef LLVM_CONFIG_CFLAGS
   export LLVM_CONFIG_CFLAGS:=$(shell test -x $(LLVM_CONFIG) && $(LLVM_CONFIG) --cflags | awk -f $(THIRD_PARTY_DIR)/llvm/filter-llvm-config.awk)
 endif
 
-ifndef LLVM_VERSION
-  export LLVM_VERSION:=$(shell test -x $(LLVM_CONFIG) && $(LLVM_CONFIG) --version)
-endif
-ifndef LLVM_MAJOR_VERSION
-  export LLVM_MAJOR_VERSION:=$(firstword $(subst ., ,$(LLVM_VERSION)))
-endif
+# LLVM_VERSION, LLVM_MAJOR_VERSION, etc
+include $(THIRD_PARTY_DIR)/llvm/Makefile.version
 
 # Figure out which clang we are using
 # if LLVM_CONFIG is e.g. llvm-config-3.7, we should use clang-3.7

--- a/third-party/llvm/Makefile.version
+++ b/third-party/llvm/Makefile.version
@@ -1,0 +1,15 @@
+ifndef LLVM_VERSION
+  export LLVM_VERSION:=$(shell test -x $(LLVM_CONFIG) && $(LLVM_CONFIG) --version)
+endif
+
+ifneq ($(LLVM_VERSION),)
+  ifndef LLVM_MAJOR_VERSION
+    export LLVM_MAJOR_VERSION:=$(firstword $(subst ., ,$(LLVM_VERSION)))
+  endif
+else
+  export LLVM_MAJOR_VERSION:=0
+endif
+
+# LLVM_MAJOR_VERSION_9PLUS will store 9 if the version is >= 9 or
+# be the empty string otherwise.
+export LLVM_MAJOR_VERSION_9PLUS := $(shell test $(LLVM_MAJOR_VERSION) -ge 9 && echo 9)

--- a/third-party/llvm/update-llvm.sh
+++ b/third-party/llvm/update-llvm.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 BRANCH=unknown
-ENABLE_RV=1
+ENABLE_RV=0
 
 if [ "$#" -eq 0 ]
 then


### PR DESCRIPTION
### Update Makefiles to support LLVM 9 and 10

Resolves a build-time error. Since the list of libraries we need to work with clang changed, add some Makefile logic to track the LLVM major version number.

### Do not force full LLVM rebuild when relevant Makefiles change

Since PR #7004, we have been rebuilding third-party libraries
when relevant Makefiles change. This has also applied to LLVM
builds since #12102.

However, this presents challenges to developers modifying these
Makefiles since the LLVM build can take more than 10 minutes.

At the same time, LLVM's cmake-based build system should generally manage
dependencies (and for example, do a rebuild if we try to `make install`
after upgrading all of the source code files).

Therefore, this commit adjusts the 3p-rebuild for LLVM to only
remove the install directory and to let LLVM's cmake manage the
build directory.

Reviewed by @dmk42 - thanks!

Passed full local --llvm testing.