### PR TITLE
Add error for domain expressions that are types

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -626,6 +626,12 @@ module ChapelArray {
     return chpl__buildDomainExpr((...x));
   }
 
+  pragma "compiler generated"
+  pragma "last resort"
+  proc chpl__ensureDomainExpr(type t) {
+    compilerError("Got domain expression of type '", t:string, "' rather than a domain value/range list as expected");
+  }
+
   //
   // Support for distributed domain expression e.g. {1..3, 1..3} dmapped Dist()
   //

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -629,7 +629,7 @@ module ChapelArray {
   pragma "compiler generated"
   pragma "last resort"
   proc chpl__ensureDomainExpr(type t) {
-    compilerError("Got domain expression of type '", t:string, "' rather than a domain value/range list as expected");
+    compilerError("Domain expression was a type ('", t:string, "') rather than a domain value or range list as expected");
   }
 
   //

--- a/test/arrays/errors/domainTypeAsDomainExpr.chpl
+++ b/test/arrays/errors/domainTypeAsDomainExpr.chpl
@@ -1,0 +1,15 @@
+class Base {}
+class Child : Base {
+  var s: string;
+}
+
+proc fn(vec: [domain(1,int(64),false)] _owned(Child)) {
+  return vec;
+}
+
+var x: [0..-1] owned Child;
+x.push_back(new owned Child("C"));
+writeln(x.type:string);
+var y = fn(x);
+writeln(x);
+writeln(y);

--- a/test/arrays/errors/domainTypeAsDomainExpr.good
+++ b/test/arrays/errors/domainTypeAsDomainExpr.good
@@ -1,0 +1,2 @@
+domainTypeAsDomainExpr.chpl:6: In function 'fn':
+domainTypeAsDomainExpr.chpl:6: error: Domain expression was a type ('domain(1,int(64),false)') rather than a domain value or range list as expected


### PR DESCRIPTION
This adds an error overload for the compiler's internal
`chpl__ensureDomainExpr()` routine that accepts a type in order to
generate a useful error message in the event that a type expression is
provided rather than a domain value or range list as currently expected.

With more work, additional error overloads could be added to head off
other mistakes, but I'm only handling this one for now since users
have run into it and it relates to an idea proposed in issue #5355.