### PR TITLE
Small changes in NPB MG

### DIFF
--- a/test/users/npadmana/npb-mg/mg.chpl
+++ b/test/users/npadmana/npb-mg/mg.chpl
@@ -298,8 +298,10 @@ proc stencilConvolve(dest : [?Dom] real, const ref src : []real, const w : coeff
             // Update previous and next destinations with this iteration's
             // val2 and val3
             const temp = w2 * val2 + w3 * val3;
-            dest.localAccess[i,j,k-1] += temp;
-            dest.localAccess[i,j,k+1] += temp;
+            if k-1>=klo then
+              dest.localAccess[i,j,k-1] += temp;
+            if k+1<=khi then
+              dest.localAccess[i,j,k+1] += temp;
           }
 
           dest.localAccess[i,j,khi] += w2 * valA(i,j,khi+1) +

--- a/test/users/npadmana/npb-mg/mg.chpl
+++ b/test/users/npadmana/npb-mg/mg.chpl
@@ -286,7 +286,7 @@ proc stencilConvolve(dest : [?Dom] real, const ref src : []real, const w : coeff
           dest.localAccess[i,j,klo] += w2 * valA(i,j,klo-1) +
                                        w3 * valB(i,j,klo-1);
 
-          for k in vectorizeOnly(klo..khi) {
+          for k in klo..khi {
             const val1 = locSrc[i,j,k];
             const val2 = valA(i,j,k);
             const val3 = valB(i,j,k);


### PR DESCRIPTION
This PR makes two small changess in `test/users/npadmana/npb-mg/` that were discussed under #11741:

- There was a call to `vectorizeOnly` that was a bug but never encountered possibly because it is not tested with LLVM.

- The second change is actually to clarify the implementation. This clarification (IMHO) is necessary due to the "confusing" behavior of the StencilDist that I mentioned in the issue above. The wraparound cells that are ghost zones cannot be written. This is not prevented in anyway and any writes such as the one that was there in the previous implementation are simply ignored.

(I tried unrolling the loop at the ends to avoid conditionals within the loop body, but performance got worse in my local tests. If this change is approved, I still want to go back and try it again, because I don't understand why it performed poorly)

I tested this locally with `CHPL_COMM=none` and `CHPL_COMM=gasnet`