### PR TITLE
Move main process sleeping code into common shim

### DIFF
--- a/runtime/include/chpl-comm.h
+++ b/runtime/include/chpl-comm.h
@@ -484,6 +484,11 @@ void chpl_comm_task_end(void);
 
 void* chpl_get_global_serialize_table(int64_t idx);
 
+// Used to park and wake up the main process
+void chpl_signal_shutdown(void);
+void chpl_wait_for_shutdown(void);
+
+
 #else // LAUNCHER
 
 #define chpl_comm_barrier(x)


### PR DESCRIPTION
For ugni and gasnet we put the main process to sleep on a condition
variable in order to free up `chpl_comm_barrier()` for use in module
code and to avoid interference from the main process. This code is
duplicated across comm layers and needs to be used in ofi soon, so just
move most of the code into helper routines.