### PR TITLE
Remove some unused runtime string support functions

### DIFF
--- a/runtime/include/chpl-comm.h
+++ b/runtime/include/chpl-comm.h
@@ -435,17 +435,6 @@ void  chpl_comm_get_strd(void* dstaddr, size_t* dststrides, c_nodeid_t srcnode,
                      int32_t commID, int ln, int32_t fn);
 
 //
-// Get a local copy of a wide string.
-//
-// The local copy is also a wide string pointer, but its addr field points to 
-// a locally-allocated char[] and the locale field is set to "here".
-// The local char[] buffer is leaked. :(
-//
-void chpl_gen_comm_wide_string_get(void *addr, c_nodeid_t node, void *raddr,
-                                   size_t size, int32_t typeIndex,
-                                   int ln, int32_t fn);
-
-//
 // Runs a function f on a remote locale, passing it
 // arg where size of arg is stored in arg_size.
 // arg can be reused immediately after this call completes.

--- a/runtime/include/chpl-string.h
+++ b/runtime/include/chpl-string.h
@@ -32,7 +32,6 @@ extern chpl_string defaultStringValue;
 struct chpl_chpl____wide_chpl_string_s;
 
 chpl_string chpl_wide_string_copy(struct chpl_chpl____wide_chpl_string_s* x, int32_t lineno, int32_t filename);
-void chpl_string_widen(struct chpl_chpl____wide_chpl_string_s* x, chpl_string from, int32_t lineno, int32_t filename);
 void chpl_comm_wide_get_string(chpl_string* local, struct chpl_chpl____wide_chpl_string_s* x, int32_t tid, int32_t lineno, int32_t filename);
 
 #define CHPL_SHORT_STRING_SIZE 8

--- a/runtime/include/chpl-string.h
+++ b/runtime/include/chpl-string.h
@@ -32,7 +32,6 @@ extern chpl_string defaultStringValue;
 struct chpl_chpl____wide_chpl_string_s;
 
 chpl_string chpl_wide_string_copy(struct chpl_chpl____wide_chpl_string_s* x, int32_t lineno, int32_t filename);
-void chpl_comm_wide_get_string(chpl_string* local, struct chpl_chpl____wide_chpl_string_s* x, int32_t tid, int32_t lineno, int32_t filename);
 
 #define CHPL_SHORT_STRING_SIZE 8
 

--- a/runtime/src/chpl-string.c
+++ b/runtime/src/chpl-string.c
@@ -41,40 +41,6 @@ chpl_wide_string_copy(chpl____wide_chpl_string* x, int32_t lineno, int32_t filen
   }
 }
 
-// This copies the remote string data into a local wide string representation
-// of the same.
-// This routine performs a deep copy of the character array data 
-// after fetching the string descriptor from the remote node.  (The char*
-// field in the local copy of the remote descriptor has no meaning in the 
-// context of the local node, since it refers to elements in the address 
-// space on the remote node.)  
-// In chpl_comm_wide_get_string() a buffer of the right size is allocated 
-// to receive the bytes copied from the remote node.  This buffer will be leaked,
-// since no corresponding free is added to the generated code.
-void chpl_gen_comm_wide_string_get(void *addr, c_nodeid_t node, void *raddr,
-                                   size_t size, int32_t typeIndex,
-                                   int ln, int32_t fn) {
-  // This part just copies the descriptor.
-  if (chpl_nodeID == node) {
-    chpl_memmove(addr, raddr, size);
-  } else {
-    chpl_gen_comm_get(addr, node, raddr, size, typeIndex, CHPL_COMM_UNKNOWN_ID, ln, fn);
-  }
-
-  // And now we copy the bytes in the string itself.
-  {
-    struct chpl_chpl____wide_chpl_string_s* local_str =
-      (struct chpl_chpl____wide_chpl_string_s*) addr;
-    // Accessing the addr field of the incomplete struct declaration
-    // would not work in this context except that this function
-    // is always inlined.
-    chpl_comm_wide_get_string((chpl_string*) &(local_str->addr),
-                              local_str, typeIndex, ln, fn);
-    // The bytes live locally, so we have to update the locale.
-    local_str->locale = chpl_gen_getLocaleID();
-  }
-}
-
 // un-macro'd CHPL_WIDEN_STRING
 void
 chpl_string_widen(chpl____wide_chpl_string* x, chpl_string from, int32_t lineno, int32_t filename)

--- a/runtime/src/chpl-string.c
+++ b/runtime/src/chpl-string.c
@@ -30,39 +30,13 @@ typedef struct chpl_chpl____wide_chpl_string_s chpl____wide_chpl_string;
 
 chpl_string
 chpl_wide_string_copy(chpl____wide_chpl_string* x, int32_t lineno, int32_t filename) {
-  if (chpl_rt_nodeFromLocaleID(x->locale) == chpl_nodeID)
-    return string_copy(x->addr, lineno, filename);
-  else {
-    chpl_string s;
-    chpl_comm_wide_get_string(&s, x,
-                              -CHPL_TYPE_chpl_string /* this is unfortunate */,
-                              lineno, filename);
-    return s;
-  }
-}
+  if (x->addr == NULL) return NULL;
 
-// un-macro'd CHPL_COMM_WIDE_GET_STRING
-void
-chpl_comm_wide_get_string(chpl_string* local, struct chpl_chpl____wide_chpl_string_s* x, int32_t tid, int32_t lineno, int32_t filename)
-{
-  char* chpl_macro_tmp;
-
-  if (x->addr == NULL)
-  {
-    *local = NULL;
-    return;
-  }
-
-  chpl_macro_tmp =
-      chpl_mem_calloc(1, x->size, CHPL_RT_MD_GET_WIDE_STRING, lineno, filename);
-  if (chpl_nodeID == chpl_rt_nodeFromLocaleID(x->locale))
-    chpl_memmove(chpl_macro_tmp, x->addr, x->size);
-  else
-    chpl_gen_comm_get((void *)&(*chpl_macro_tmp),
-                      chpl_rt_nodeFromLocaleID(x->locale), (void *)(x->addr),
-                      sizeof(char) * x->size, tid,
-                      CHPL_COMM_UNKNOWN_ID, lineno, filename);
-  *local = chpl_macro_tmp;
+  chpl_string s = chpl_mem_alloc(x->size, CHPL_RT_MD_STR_COPY_DATA, lineno, filename);
+  chpl_gen_comm_get((void *)s, chpl_rt_nodeFromLocaleID(x->locale),
+                    (void *)(x->addr), x->size, -1, CHPL_COMM_UNKNOWN_ID,
+                    lineno, filename);
+  return s;
 }
 
 uint8_t* chpl__getInPlaceBufferData(chpl__inPlaceBuffer* buf) {

--- a/runtime/src/chpl-string.c
+++ b/runtime/src/chpl-string.c
@@ -41,26 +41,6 @@ chpl_wide_string_copy(chpl____wide_chpl_string* x, int32_t lineno, int32_t filen
   }
 }
 
-// un-macro'd CHPL_WIDEN_STRING
-void
-chpl_string_widen(chpl____wide_chpl_string* x, chpl_string from, int32_t lineno, int32_t filename)
-{
-  size_t len;
-
-  x->locale = chpl_gen_getLocaleID();
-  if (from == NULL)
-  {
-    x->addr = NULL;
-    x->size = 0;
-    return;
-  }
-    
-  len = strlen(from) + 1;
-  x->addr = chpl_mem_calloc(1, len, CHPL_RT_MD_SET_WIDE_STRING, lineno, filename);
-  strncpy((char*)x->addr, from, len);
-  x->size = len;    // This size includes the terminating NUL.
-}
-
 // un-macro'd CHPL_COMM_WIDE_GET_STRING
 void
 chpl_comm_wide_get_string(chpl_string* local, struct chpl_chpl____wide_chpl_string_s* x, int32_t tid, int32_t lineno, int32_t filename)


### PR DESCRIPTION
Remove string support functions that are no longer used. They have
likely been unused since the string-as-rec effort

 - remove chpl_string_widen
 - remove chpl_gen_comm_wide_string_get
 - inline and simplify chpl_comm_wide_get_string into the only callsite