### PR TITLE
Fix test/io/ferguson/ctests

### DIFF
--- a/runtime/include/qio/qio_plugin_api.h
+++ b/runtime/include/qio/qio_plugin_api.h
@@ -20,7 +20,7 @@
 #ifndef _QIO_PLUGIN_API_H_
 #define _QIO_PLUGIN_API_H_
 
-#include "chpltypes.h"
+#include "qio.h"
 
 // TODO: it would be nicer if these all had "plugin" in their name
 

--- a/runtime/src/qio/qio_plugin_api_dummy.c
+++ b/runtime/src/qio/qio_plugin_api_dummy.c
@@ -17,48 +17,45 @@
  * limitations under the License.
  */
 
-syserr chpl_qio_writev(void* file, struct iovec* iov, int iovcnt, ssize_t* amtWritten) {
-  QIO_RETURN_CONSTANT_ERROR(ENOSYS, "no fd or plugin");
-}
-syserr chpl_qio_readv(void* file, struct iovec* iov, int iovcnt, ssize_t* amtRead) {
-  QIO_RETURN_CONSTANT_ERROR(ENOSYS, "no fd or plugin");
+#include "qio_plugin_api.h"
+
+syserr chpl_qio_setup_plugin_channel(void* file, void** plugin_ch, int64_t start, int64_t end, qio_channel_t* qio_ch) {
+  QIO_RETURN_CONSTANT_ERROR(ENOSYS, "no plugin");
 }
 
-syserr chpl_qio_pwritev(void* file, struct iovec* iov, int iovcnt, int64_t offset, ssize_t* amtWritten) {
-  QIO_RETURN_CONSTANT_ERROR(ENOSYS, "no fd or plugin");
-}
-syserr chpl_qio_preadv(void* file, struct iovec* iov, int iovcnt, int64_t offset, ssize_t* amtRead) {
-  QIO_RETURN_CONSTANT_ERROR(ENOSYS, "no fd or plugin");
+syserr chpl_qio_read_atleast(void* plugin_ch, int64_t amt) {
+  QIO_RETURN_CONSTANT_ERROR(ENOSYS, "no plugin");
 }
 
-syserr chpl_qio_seek(void* file, int64_t amount, int whence, int64_t* offset) {
-  QIO_RETURN_CONSTANT_ERROR(ENOSYS, "no fd or plugin");
+syserr chpl_qio_write(void* plugin_ch, int64_t amt) {
+  QIO_RETURN_CONSTANT_ERROR(ENOSYS, "no plugin");
 }
+
+syserr chpl_qio_channel_close(void* ch) {
+  QIO_RETURN_CONSTANT_ERROR(ENOSYS, "no plugin");
+}
+
 syserr chpl_qio_filelength(void* file, int64_t* length) {
-  QIO_RETURN_CONSTANT_ERROR(ENOSYS, "no fd or plugin");
-}
-syserr chpl_qio_getpath(void* file, const char** str, ssize_t* len) {
-  QIO_RETURN_CONSTANT_ERROR(ENOSYS, "no fd or plugin");
-}
-syserr chpl_qio_fsync(void* file) {
-  QIO_RETURN_CONSTANT_ERROR(ENOSYS, "no fd or plugin");
-}
-syserr chpl_qio_get_chunk(void* file, int64_t* length) {
-  QIO_RETURN_CONSTANT_ERROR(ENOSYS, "no fd or plugin");
-}
-syserr chpl_qio_chpl_qio_get_locales_for_region(void* file, int64_t start, int64_t end, const char*** localeNames, int64_t* nLocales) {
-  QIO_RETURN_CONSTANT_ERROR(ENOSYS, "no fd or plugin");
-}
-syserr chpl_qio_close(void* file) {
-  QIO_RETURN_CONSTANT_ERROR(ENOSYS, "no fd or plugin");
+  QIO_RETURN_CONSTANT_ERROR(ENOSYS, "no plugin");
 }
 
-/*syserr chpl_qio_open(void* filesystem, const char* path, ssize_t pathlen, int flags, int64_t mode, int64_t hints, void** file) {
-  QIO_RETURN_CONSTANT_ERROR(ENOSYS, "no fd or plugin");
-}*/
-syserr chpl_qio_get_cwd(void* filesystem, const char** path, ssize_t* len) {
-  QIO_RETURN_CONSTANT_ERROR(ENOSYS, "no fd or plugin");
+syserr chpl_qio_getpath(void* file, const char** str, int64_t* len) {
+  QIO_RETURN_CONSTANT_ERROR(ENOSYS, "no plugin");
 }
-syserr chpl_qio_get_fs_type(void* filesystem, int64_t* fsType) {
-  QIO_RETURN_CONSTANT_ERROR(ENOSYS, "no fd or plugin");
+
+syserr chpl_qio_fsync(void* file) {
+  QIO_RETURN_CONSTANT_ERROR(ENOSYS, "no plugin");
+}
+
+syserr chpl_qio_get_chunk(void* file, int64_t* length) {
+  QIO_RETURN_CONSTANT_ERROR(ENOSYS, "no plugin");
+}
+
+syserr chpl_qio_get_locales_for_region(void* file, int64_t start, int64_t end,
+    void **localeNamesPtr, int64_t* nLocales) {
+  QIO_RETURN_CONSTANT_ERROR(ENOSYS, "no plugin");
+}
+
+syserr chpl_qio_file_close(void* file) {
+  QIO_RETURN_CONSTANT_ERROR(ENOSYS, "no plugin");
 }

--- a/test/io/ferguson/ctests/SKIPIF
+++ b/test/io/ferguson/ctests/SKIPIF
@@ -3,6 +3,4 @@ CHPL_TARGET_COMPILER==cray-prgenv-pgi
 CHPL_TARGET_COMPILER==pgi
 # cray-prgenv-cray: extra warnings
 CHPL_TARGET_COMPILER==cray-prgenv-cray
-# I don't believe this one still exists...
-CHPL_TARGET_COMPILER==cray
-CHPL_ATOMICS!=intrinsics
+CHPL_ATOMICS==locks


### PR DESCRIPTION
This directory was accidentally being skipped
(ever since the atomics default went away from intrinsics)
which led to not noticing errors with qio_plugin_api_dummy.c
which exists to enable these C tests.

Trivial and not reviewed.

- [x] full local testing