### PR TITLE
Improve lowering of if-exprs and loop-exprs inside fields

### DIFF
--- a/compiler/AST/LoopExpr.cpp
+++ b/compiler/AST/LoopExpr.cpp
@@ -549,6 +549,11 @@ static bool isOuterVar(Symbol* sym, Expr* enclosingExpr) {
 }
 
 static bool considerForOuter(Symbol* sym) {
+  if (isTypeSymbol(sym->defPoint->parentSymbol)) {
+    // Fields are considered 'outer'
+    return true;
+  }
+
   if (sym->hasFlag(FLAG_TYPE_VARIABLE) ||
       sym->hasFlag(FLAG_PARAM))
     return false;  // these will be eliminated anyway
@@ -582,7 +587,15 @@ static ArgSymbol* newOuterVarArg(Symbol* ovar) {
   if (argType == dtUnknown)
     argType = dtAny;
 
-  return new ArgSymbol(INTENT_BLANK, ovar->name, argType);
+  ArgSymbol* ret = new ArgSymbol(INTENT_BLANK, ovar->name, argType);
+
+  // An argument might need to be a type variable if the outer variable is
+  // a type field.
+  if (ovar->hasFlag(FLAG_TYPE_VARIABLE)) {
+    ret->addFlag(FLAG_TYPE_VARIABLE);
+  }
+
+  return ret;
 }
 
 //

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -858,9 +858,29 @@ class LowerIfExprVisitor : public AstVisitorTraverse
     virtual void exitIfExpr(IfExpr* node);
 };
 
+static bool isInsideDefExpr(Expr* expr) {
+  bool ret = false;
+
+  Expr* cur = expr->parentExpr;
+  while (cur != NULL) {
+    if (isDefExpr(cur)) {
+      ret = true;
+      break;
+    } else if (isBlockStmt(cur)) {
+      // OK to lower inside a BlockStmt because unlike a DefExpr we can insert
+      // temporaries.
+      break;
+    } else {
+      cur = cur->parentExpr;
+    }
+  }
+
+  return ret;
+}
+
 void LowerIfExprVisitor::exitIfExpr(IfExpr* ife) {
   if (isAlive(ife) == false) return;
-  if (isDefExpr(ife->parentExpr)) return;
+  if (isInsideDefExpr(ife)) return;
   if (isLoopExpr(ife->parentExpr)) return;
 
   SET_LINENO(ife);

--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -765,10 +765,13 @@ static Expr* preFoldPrimOp(CallExpr* call) {
 
         } else if (varSym                            != NULL &&
                    (intent & INTENT_FLAG_IN)         !=    0 &&
-                   varSym->isConstValWillNotChange() == true) {
+                   (varSym->isConstValWillNotChange() == true ||
+                    varSym->hasFlag(FLAG_TYPE_VARIABLE))) {
           // don't take address of outer variables declared to be const
           // (otherwise, after flattenFunctions, we will take the
-          //  address of a by-value argument).
+          //  address of a by-value argument). An outer variable might be a
+          //  type if the symbol represents a field, and taking the address of
+          //  a type does not make sense.
 
         } else {
           Expr* stmt = call->getStmtExpr();

--- a/test/expressions/if-expr/inside-field.chpl
+++ b/test/expressions/if-expr/inside-field.chpl
@@ -1,0 +1,37 @@
+class C {}
+
+record R1 {
+  type T;
+  var data: if isClass(T) then [1..2] owned T else [1..2] T;
+}
+
+record R2 {
+  type T;
+  var one: [1..2] if isClass(T) then owned T else T;
+  var two: [1..2] [1..2] if isClass(T) then owned T else T;
+  var three: [1..2] [1..2] [1..2] if isClass(T) then owned T else T;
+}
+
+record R3 {
+  type T;
+  var multiple: [1..2] if !isClass(T) then 2*T
+                       else [1..2] if isClass(T) then owned T else T;
+}
+
+proc test(type T) {
+  var x : T;
+  writeln(x);
+  writeln();
+}
+
+proc main() {
+  test(R1(int));
+  test(R1(C));
+
+  test(R2(int));
+  test(R2(C));
+
+  test(R3(int));
+  test(R3(C));
+}
+

--- a/test/expressions/if-expr/inside-field.good
+++ b/test/expressions/if-expr/inside-field.good
@@ -1,0 +1,12 @@
+(data = 0 0)
+
+(data = nil nil)
+
+(one = 0 0, two = 0 0 0 0, three = 0 0 0 0 0 0 0 0)
+
+(one = nil nil, two = nil nil nil nil, three = nil nil nil nil nil nil nil nil)
+
+(multiple = (0, 0) (0, 0))
+
+(multiple = nil nil nil nil)
+


### PR DESCRIPTION
This PR fixes some issues with if-expressions and loop-expressions used as a field's type-expression or default value.

The first problem was that the compiler was attempting to lower if-expressions too early, and is fixed by preventing the lowering of if-expressions when they are inside a DefExpr.

The second problem was that the compiler failed to correctly thread ``type`` and ``param`` fields through the generated "loopexpr" functions. This is resolved by considering such fields as 'outer' variables and adding appropriate intents to the threaded ArgSymbols.

Resolves #13290 

Testing:
- [x] local + futures
- [x] gasnet + futures