### PR TITLE
Remove chpl_task_comm_{put, get}

### DIFF
--- a/runtime/include/chpl-comm-compiler-macros.h
+++ b/runtime/include/chpl-comm-compiler-macros.h
@@ -54,11 +54,7 @@ void chpl_gen_comm_get(void *addr, c_nodeid_t node, void* raddr,
     chpl_cache_comm_get(addr, node, raddr, size, typeIndex, commID, ln, fn);
 #endif
   } else {
-#ifdef CHPL_TASK_COMM_GET
-    chpl_task_comm_get(addr, node, raddr, size, typeIndex, commID, ln, fn);
-#else
     chpl_comm_get(addr, node, raddr, size, typeIndex, commID, ln, fn);
-#endif
   }
 }
 
@@ -101,11 +97,7 @@ void chpl_gen_comm_put(void* addr, c_nodeid_t node, void* raddr,
     chpl_cache_comm_put(addr, node, raddr, size, typeIndex, commID, ln, fn);
 #endif
   } else {
-#ifdef CHPL_TASK_COMM_PUT
-    chpl_task_comm_put(addr, node, raddr, size, typeIndex, commID, ln, fn);
-#else
     chpl_comm_put(addr, node, raddr, size, typeIndex, commID, ln, fn);
-#endif
   }
 }
 
@@ -121,11 +113,7 @@ void chpl_gen_comm_get_strd(void *addr, void *dststr, c_nodeid_t node, void *rad
     chpl_cache_comm_get_strd(addr, dststr, node, raddr, srcstr, count, strlevels, elemSize, typeIndex, commID, ln, fn);
 #endif
   } else {
-#ifdef CHPL_TASK_COMM_GET_STRD
-  chpl_task_comm_get_strd(addr, dststr, node, raddr, srcstr, count, strlevels, elemSize, typeIndex, commID, ln, fn);
-#else
   chpl_comm_get_strd(addr, dststr, node, raddr, srcstr, count, strlevels, elemSize, typeIndex, commID, ln, fn);
-#endif
   }
 }
 
@@ -141,11 +129,7 @@ void chpl_gen_comm_put_strd(void *addr, void *dststr, c_nodeid_t node, void *rad
     chpl_cache_comm_put_strd(addr, dststr, node, raddr, srcstr, count, strlevels, elemSize, typeIndex, commID, ln, fn);
 #endif
   } else {
-#ifdef CHPL_TASK_COMM_PUT_STRD
-  chpl_task_comm_put_strd(addr, dststr, node, raddr, srcstr, count, strlevels, elemSize, typeIndex, commID, ln, fn);
-#else
   chpl_comm_put_strd(addr, dststr, node, raddr, srcstr, count, strlevels, elemSize, typeIndex, commID, ln, fn);
-#endif
   }
 }
 

--- a/runtime/src/chpl-cache.c
+++ b/runtime/src/chpl-cache.c
@@ -2864,13 +2864,8 @@ void chpl_cache_comm_get_strd(void *addr, void *dststr, c_nodeid_t node,
   // system. This is just the current (possibly temporary) solution.
   chpl_cache_fence(1, 1, ln, fn);
   // do the strided get.
-#ifdef CHPL_TASK_COMM_GET_STRD
-  chpl_task_comm_get_strd(addr, dststr, node, raddr, srcstr, count, strlevels,
-                          elemSize, typeIndex, commID, ln, fn);
-#else
   chpl_comm_get_strd(addr, dststr, node, raddr, srcstr, count, strlevels,
                      elemSize, typeIndex, commID, ln, fn);
-#endif
 }
 void chpl_cache_comm_put_strd(void *addr, void *dststr, c_nodeid_t node,
                               void *raddr, void *srcstr, void *count,
@@ -2887,13 +2882,8 @@ void chpl_cache_comm_put_strd(void *addr, void *dststr, c_nodeid_t node,
   // system. This is just the current (possibly temporary) solution.
   chpl_cache_fence(1, 1, ln, fn);
   // do the strided put.
-#ifdef CHPL_TASK_COMM_PUT_STRD
-  chpl_task_comm_put_strd(addr, dststr, node, raddr, srcstr, count, strlevels,
-                          elemSize, typeIndex, commID, ln, fn);
-#else
   chpl_comm_put_strd(addr, dststr, node, raddr, srcstr, count, strlevels,
                      elemSize, typeIndex, commID, ln, fn);
-#endif
 }
 
 // This is for debugging.


### PR DESCRIPTION
These don't exist since muxed was retired years ago, and it's easy
enough to bring the code back if we ever need them again.