### PR TITLE
When qbytes_iobuf_size is small, don't page align

### DIFF
--- a/runtime/src/qio/qbuffer.c
+++ b/runtime/src/qio/qbuffer.c
@@ -148,7 +148,14 @@ qioerr _qbytes_init_iobuf(qbytes_t* ret)
 {
   void* data = NULL;
 
-  data = qio_memalign(sys_page_size(), qbytes_iobuf_size);
+  // qbytes_iobuf_size is generally >= page size. However in
+  // some testing configurations, it is very small (e.g. 5 bytes).
+  size_t page_size = sys_page_size();
+  if (qbytes_iobuf_size >= page_size)
+    data = qio_memalign(page_size, qbytes_iobuf_size);
+  else
+    data = qio_malloc(qbytes_iobuf_size);
+
   if( !data ) return QIO_ENOMEM;
   memset(data, 0, qbytes_iobuf_size);
 


### PR DESCRIPTION
`qbytes_iobuf_size` is a global variable that is normally 64KB but is
sometimes set in tests to make sure the buffered I/O buffer boundaries
don't impact correctness of I/O operations. One test that was recently
updated to do this has been failing in cygwin32 because it runs out of
memory.

This PR updates `_qbytes_init_iobuf` to use the regular allocator if
`qbytes_iobuf_size` is less than a page size, instead of trying to align
e.g. 5 byte allocations to the page size. This resolves the issue on
cygwin32 testing.

- [x] full local testing

Reviewed by @ronawho - thanks!