### PR TITLE
Remove old ugni chpl_comm_get_nb declaration

### DIFF
--- a/runtime/include/comm/gasnet/chpl-comm-task-decls.h
+++ b/runtime/include/comm/gasnet/chpl-comm-task-decls.h
@@ -20,9 +20,6 @@
 #ifndef _COMM_TASK_DECLS_H_
 #define _COMM_TASK_DECLS_H_
 
-// The type of the communication handle.
-typedef void* chpl_comm_nb_handle_t;
-
 // The type of task private data.
 #include "chpl-cache-task-decls.h"
 #define HAS_CHPL_CACHE_FNS
@@ -39,5 +36,8 @@ typedef struct {
 
   void* ack; // address on caller to post acknowledgement
 } chpl_comm_bundleData_t;
+
+// The type of the communication handle.
+typedef void* chpl_comm_nb_handle_t;
 
 #endif

--- a/runtime/include/comm/ofi/chpl-comm-task-decls.h
+++ b/runtime/include/comm/ofi/chpl-comm-task-decls.h
@@ -17,10 +17,6 @@
  * limitations under the License.
  */
 
-//
-// Tasking-related macros for the Chapel uGNI communication layer.
-//
-
 #ifndef _COMM_TASK_DECLS_H_
 #define _COMM_TASK_DECLS_H_
 
@@ -113,32 +109,7 @@ typedef union {
   struct chpl_comm_bundleData_AMO_t amo;
 } chpl_comm_bundleData_t;
 
-//
-// Nonblocking GET support.  Handle is a unique handle for the GET.
-// This value is initially returned by chpl_com_get_nb(), and can then
-// be passed to chpl_comm_test_get_nb() while polling for the GET to
-// complete.  Once chpl_comm_test_get_nb() returns true, however, the
-// handle is expired and must not be passed to it again.
-//
-// Code external to the comm layer must not assume anything about or
-// change any of the contents of a nonblocking GET handle.  The only
-// supported interface is via the functions described below.
-//
-// chpl_comm_get_nb()
-//   Get 'size' bytes of remote data at 'raddr' on locale 'locale' to
-//   local data at 'addr', nonblocking.
-//
-// chpl_comm_test_get_nb()
-//   Return nonzero if the GET associated with the given handle has
-//   completed.
-//
+// The type of the communication handle.
 typedef void* chpl_comm_nb_handle_t;
-#ifdef BLAH
 
-chpl_comm_nb_handle_t chpl_comm_get_nb(void* addr, int32_t locale, void* raddr,
-                                       size_t size, int32_t typeIndex,
-                                       int32_t commID, int ln, int32_t fn);
-chpl_bool chpl_comm_test_get_nb(chpl_comm_nb_handle_t handle,
-                                int ln, int32_t fn);
-#endif
 #endif

--- a/runtime/include/comm/ugni/chpl-comm-task-decls.h
+++ b/runtime/include/comm/ugni/chpl-comm-task-decls.h
@@ -17,10 +17,6 @@
  * limitations under the License.
  */
 
-//
-// Tasking-related macros for the Chapel uGNI communication layer.
-//
-
 #ifndef _COMM_TASK_DECLS_H_
 #define _COMM_TASK_DECLS_H_
 
@@ -50,31 +46,7 @@ typedef struct {
   void* rf_done; // where to indicate completion on caller
 } chpl_comm_bundleData_t;
 
-//
-// Nonblocking GET support.  Handle is a unique handle for the GET.
-// This value is initially returned by chpl_com_get_nb(), and can then
-// be passed to chpl_comm_test_get_nb() while polling for the GET to
-// complete.  Once chpl_comm_test_get_nb() returns true, however, the
-// handle is expired and must not be passed to it again.
-//
-// Code external to the comm layer must not assume anything about or
-// change any of the contents of a nonblocking GET handle.  The only
-// supported interface is via the functions described below.
-//
-// chpl_comm_get_nb()
-//   Get 'size' bytes of remote data at 'raddr' on locale 'locale' to
-//   local data at 'addr', nonblocking.
-//
-// chpl_comm_test_get_nb()
-//   Return nonzero if the GET associated with the given handle has
-//   completed.
-//
+// The type of the communication handle.
 typedef void* chpl_comm_nb_handle_t;
-
-chpl_comm_nb_handle_t chpl_comm_get_nb(void* addr, int32_t locale, void* raddr,
-                                       size_t size, int32_t typeIndex,
-                                       int32_t commID, int ln, int32_t fn);
-chpl_bool chpl_comm_test_get_nb(chpl_comm_nb_handle_t handle,
-                                int ln, int32_t fn);
 
 #endif


### PR DESCRIPTION
Originally chpl_comm_get_nb was only implemented in ugni, but it was
made a part of the official comm API years ago in bcf2c83d9b. Back then
ugni was still private, and it looks like we missed removing a decl and
the old style of waiting for a NB get. Remove the old decls from ugni
(and ofi since that file was originally a clone of the ugni one.)