### PR TITLE
Stop pinning the progress thread to the last CPU

### DIFF
--- a/runtime/include/chplsys.h
+++ b/runtime/include/chplsys.h
@@ -30,8 +30,6 @@ uint64_t chpl_sys_physicalMemoryBytes(void);
 int chpl_sys_getNumCPUsPhysical(chpl_bool accessible_only);
 int chpl_sys_getNumCPUsLogical(chpl_bool accessible_only);
 
-void chpl_moveToLastCPU(void);
-
 //
 // returns the name of a locale via uname -n or the like
 //

--- a/runtime/src/chplsys.c
+++ b/runtime/src/chplsys.c
@@ -763,37 +763,6 @@ int chpl_sys_getNumCPUsLogical(chpl_bool accessible_only) {
 }
 
 
-//
-// Move to the last available hardware thread.  Tasking layers use
-// this to get predictable placement for comm layer polling threads,
-// in order to help manage execution resources.
-//
-void chpl_moveToLastCPU(void) {
-  //
-  // This is currently a no-op except on Linux.
-  //
-#if defined __linux__
-  {
-    cpu_set_t mask;
-    int i, cnt;
-
-    if (pthread_getaffinity_np(pthread_self(), sizeof(mask), &mask) < 0)
-      chpl_internal_error("sched_getaffinity() failed");
-
-    for (i = cnt = 0; !CPU_ISSET(i, &mask) || ++cnt < CPU_COUNT(&mask); i++)
-      ;
-
-    CPU_ZERO(&mask);
-    CPU_SET(i, &mask);
-    if (pthread_setaffinity_np(pthread_self(), sizeof(mask), &mask) < 0)
-      chpl_internal_error("sched_setaffinity() failed");
-  }
-#endif
-
-  return;
-}
-
-
 // Using a static buffer is a bad idea from the standpoint of thread-safety.
 // However, since the node name is not expected to change it is OK to
 // initialize it once and share the singleton string.

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -782,7 +782,6 @@ typedef struct {
 static void *comm_task_wrapper(void *arg)
 {
     comm_task_wrapper_info_t *rarg = arg;
-    chpl_moveToLastCPU();
     (*(chpl_fn_p)(rarg->fn))(rarg->arg);
     return 0;
 }
@@ -824,8 +823,7 @@ int chpl_task_createCommTask(chpl_fn_p fn,
     // safe for it to be static because we will be called at most once
     // on each node.
     //
-    static
-        comm_task_wrapper_info_t wrapper_info;
+    static comm_task_wrapper_info_t wrapper_info;
     wrapper_info.fn = fn;
     wrapper_info.arg = arg;
     return pthread_create(&chpl_qthread_comm_pthread,


### PR DESCRIPTION
In #2425 we decided to pin the progress/polling thread to the last
available CPU with the thought that it would move it out of the way and
let us more fully utilize cores.

Since then (especially with spectre/meltdown patches) we have seen
significant interference from the progress thread and pinning it just
puts all the interference on one core, which makes tasks running on that
core significantly slower. Stop pinning, and let the kernel decide where
to run in hopes of spreading the pain.

We're also moving towards using blocking progress threads since there is
still non-trivial overhead from active polling even with this change. We
already do this for ugni, and are workings towards that for gasnet
configurations that support it.

I expect non-trivial performance improvements for compute heavy
benchmarks under gasnet and no major changes for ugni.

Related to https://github.com/chapel-lang/chapel/issues/9067