### PR TITLE
Remove typeIndex from communication callbacks

### DIFF
--- a/runtime/include/chpl-comm-callbacks.h
+++ b/runtime/include/chpl-comm-callbacks.h
@@ -136,7 +136,6 @@ typedef struct {
       void *addr;                // Source address
       void *raddr;               // Destination address
       size_t size;               // Size of communication
-      int32_t typeIndex;         // type of the communication
       int32_t commID;            // unique identifier for this get/put
       int lineno;                // source line of communication
       int32_t filename;          // source file of communication
@@ -151,7 +150,6 @@ typedef struct {
       size_t *count;            // Counts for the above
       int32_t stridelevels;
       size_t elemSize;
-      int32_t typeIndex;
       int32_t commID;           // unique identifier for this get/put
       int lineno;               // source line of communication
       int32_t filename;         // source file of communication

--- a/runtime/include/chpl-comm-strd-xfer.h
+++ b/runtime/include/chpl-comm-strd-xfer.h
@@ -128,7 +128,7 @@ void put_strd_common(void* dstaddr_arg, size_t* dststrides, int32_t dstlocale,
       chpl_comm_cb_info_t cb_data =
         {chpl_comm_cb_event_kind_put_strd, chpl_nodeID, dstlocale,
          .iu.comm_strd={srcaddr_arg, srcstrides, dstaddr_arg, dststrides, count,
-                        stridelevels, elemSize, typeIndex, commID, ln, fn}};
+                        stridelevels, elemSize, commID, ln, fn}};
       chpl_comm_do_callbacks (&cb_data);
   }
 
@@ -275,7 +275,7 @@ void get_strd_common(void* dstaddr_arg, size_t* dststrides, int32_t srclocale,
     chpl_comm_cb_info_t cb_data =
       {chpl_comm_cb_event_kind_get_strd, chpl_nodeID, srclocale,
        .iu.comm_strd={srcaddr_arg, srcstrides, dstaddr_arg, dststrides, count,
-                      stridelevels, elemSize, typeIndex, commID, ln, fn}};
+                      stridelevels, elemSize, commID, ln, fn}};
     chpl_comm_do_callbacks (&cb_data);
   }
 

--- a/runtime/src/chpl-visual-debug.c
+++ b/runtime/src/chpl-visual-debug.c
@@ -66,8 +66,8 @@ int chpl_vdebug = 0;
 
 #define TID_STRING(buff, tid) (chpl_task_idToString(buff, CHPL_TASK_ID_STRING_MAX_LEN, tid))
 
-#define VDEBUG_GETPUT_FORMAT_NAMES "kind tv srcNodeID dstNodeID commTaskID addr raddr elemSize typeIndex length commID lineNumber fileno"
-#define VDEBUG_GETPUT_FORMAT_STRING "%s: %lld.%06ld %d %d %s %#lx %#lx %zd %d %zd %d %d %d\n"
+#define VDEBUG_GETPUT_FORMAT_NAMES "kind tv srcNodeID dstNodeID commTaskID addr raddr elemSize length commID lineNumber fileno"
+#define VDEBUG_GETPUT_FORMAT_STRING "%s: %lld.%06ld %d %d %s %#lx %#lx %zd %zd %d %d %d\n"
 
 int chpl_dprintf (int fd, const char * format, ...) {
   char buffer[2048]; 
@@ -157,7 +157,7 @@ void chpl_vdebug_start (const char *fileroot, double now) {
     ru.ru_stime.tv_usec = 0;
   }
   chpl_dprintf (chpl_vdebug_fd,
-                "ChplVdebug: ver 1.3 nodes %d nid %d tid %s seq %.3lf %lld.%06ld %ld.%06ld %ld.%06ld \n",
+                "ChplVdebug: ver 1.4 nodes %d nid %d tid %s seq %.3lf %lld.%06ld %ld.%06ld %ld.%06ld \n",
                 chpl_numNodes, chpl_nodeID, TID_STRING(buff, startTask), now,
                 (long long) tv.tv_sec, (long) tv.tv_usec,
                 (long) ru.ru_utime.tv_sec, (long) ru.ru_utime.tv_usec,
@@ -305,7 +305,7 @@ void chpl_vdebug_pause (int tagno) {
 //        relevant as well.
 
 // Record>  nb_put: time.sec srcNodeId dstNodeId commTaskId addr raddr elemsize 
-//                  typeIndex length lineNumber fileName
+//                  length lineNumber fileName
 //
 
 void cb_comm_put_nb (const chpl_comm_cb_info_t *info) {
@@ -319,13 +319,13 @@ void cb_comm_put_nb (const chpl_comm_cb_info_t *info) {
                   VDEBUG_GETPUT_FORMAT_STRING, "nb_put",
                   (long long) tv.tv_sec, (long) tv.tv_usec,  info->localNodeID,
                   info->remoteNodeID, TID_STRING(buff, commTask), (unsigned long) cm->addr,
-                  (unsigned long) cm->raddr, (size_t)1, cm->typeIndex, cm->size,
+                  (unsigned long) cm->raddr, (size_t)1, cm->size,
                   cm->commID, cm->lineno, cm->filename);
   }
 }
 
 // Record>  nb_get: time.sec dstNodeId srcNodeId commTaskId addr raddr elemsize 
-//                  typeIndex length lineNumber fileName
+//                  length lineNumber fileName
 //
 // Note: dstNodeId is node requesting Get
 
@@ -340,13 +340,13 @@ void cb_comm_get_nb (const chpl_comm_cb_info_t *info) {
                   VDEBUG_GETPUT_FORMAT_STRING, "nb_get",
                   (long long) tv.tv_sec, (long) tv.tv_usec,  info->localNodeID,
                   info->remoteNodeID, TID_STRING(buff, commTask), (unsigned long) cm->addr,
-                  (unsigned long) cm->raddr, (size_t)1, cm->typeIndex, cm->size,
+                  (unsigned long) cm->raddr, (size_t)1, cm->size,
                   cm->commID, cm->lineno, cm->filename);
   }
 }
 
 // Record>  put: time.sec srcNodeId dstNodeId commTaskId addr raddr elemsize 
-//               typeIndex length lineNumber fileName
+//               length lineNumber fileName
 
 
 void cb_comm_put (const chpl_comm_cb_info_t *info) {
@@ -360,13 +360,13 @@ void cb_comm_put (const chpl_comm_cb_info_t *info) {
                   VDEBUG_GETPUT_FORMAT_STRING, "put",
                   (long long) tv.tv_sec, (long) tv.tv_usec, info->localNodeID,
                   info->remoteNodeID, TID_STRING(buff, commTask), (unsigned long) cm->addr,
-                  (unsigned long) cm->raddr, (size_t)1, cm->typeIndex, cm->size,
+                  (unsigned long) cm->raddr, (size_t)1, cm->size,
                   cm->commID, cm->lineno, cm->filename);
   }
 }
 
 // Record>  get: time.sec dstNodeId srcNodeId commTaskId addr raddr elemsize 
-//               typeIndex length lineNumber fileName
+//               length lineNumber fileName
 //
 // Note:  dstNodeId is for the node making the request
 
@@ -381,13 +381,13 @@ void cb_comm_get (const chpl_comm_cb_info_t *info) {
                   VDEBUG_GETPUT_FORMAT_STRING, "get",
                   (long long) tv.tv_sec, (long) tv.tv_usec,  info->localNodeID,
                   info->remoteNodeID, TID_STRING(buff, commTask), (unsigned long) cm->addr,
-                  (unsigned long) cm->raddr, (size_t)1, cm->typeIndex, cm->size,
+                  (unsigned long) cm->raddr, (size_t)1, cm->size,
                   cm->commID, cm->lineno, cm->filename);
   }
 }
 
 // Record>  st_put: time.sec srcNodeId dstNodeId commTaskId addr raddr elemsize 
-//                  typeIndex length lineNumber fileName
+//                  length lineNumber fileName
 
 void cb_comm_put_strd (const chpl_comm_cb_info_t *info) {
     if (chpl_vdebug) {
@@ -408,14 +408,14 @@ void cb_comm_put_strd (const chpl_comm_cb_info_t *info) {
                   (long long) tv.tv_sec, (long) tv.tv_usec,  info->localNodeID, 
                   info->remoteNodeID, TID_STRING(buff, commTask),
                   (unsigned long) cm->srcaddr, (unsigned long) cm->dstaddr, cm->elemSize,
-                  cm->typeIndex, length, cm->commID, cm->lineno, cm->filename);
+                  length, cm->commID, cm->lineno, cm->filename);
     // printout srcstrides and dststrides and stridelevels and count?
   }
 
 }
 
 // Record>  st_get: time.sec dstNodeId srcNodeId commTaskId addr raddr elemsize 
-//                  typeIndex length lineNumber fileName
+//                  length lineNumber fileName
 //
 // Note:  dstNode is node making request for get
 
@@ -438,7 +438,7 @@ void cb_comm_get_strd (const chpl_comm_cb_info_t *info) {
                   (long long) tv.tv_sec, (long) tv.tv_usec, info->localNodeID,
                   info->remoteNodeID, TID_STRING(buff, commTask),
                   (unsigned long) cm->dstaddr, (unsigned long) cm->srcaddr, cm->elemSize,
-                  cm->typeIndex, length, cm->commID, cm->lineno, cm->filename);
+                  length, cm->commID, cm->lineno, cm->filename);
     // print out the srcstrides and dststrides and stridelevels and count?
   }
 }

--- a/runtime/src/comm/gasnet/comm-gasnet.c
+++ b/runtime/src/comm/gasnet/comm-gasnet.c
@@ -605,7 +605,7 @@ chpl_comm_nb_handle_t chpl_comm_put_nb(void *addr, c_nodeid_t node, void* raddr,
   if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_put_nb)) {
     chpl_comm_cb_info_t cb_data = 
       {chpl_comm_cb_event_kind_put_nb, chpl_nodeID, node,
-       .iu.comm={addr, raddr, size, typeIndex, commID, ln, fn}};
+       .iu.comm={addr, raddr, size, commID, ln, fn}};
     chpl_comm_do_callbacks (&cb_data);
   }
     
@@ -639,7 +639,7 @@ chpl_comm_nb_handle_t chpl_comm_get_nb(void* addr, c_nodeid_t node, void* raddr,
   if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_get_nb)) {
     chpl_comm_cb_info_t cb_data = 
       {chpl_comm_cb_event_kind_get_nb, chpl_nodeID, node,
-       .iu.comm={addr, raddr, size, typeIndex, commID, ln, fn}};
+       .iu.comm={addr, raddr, size, commID, ln, fn}};
     chpl_comm_do_callbacks (&cb_data);
   }
 
@@ -1052,7 +1052,7 @@ void  chpl_comm_put(void* addr, c_nodeid_t node, void* raddr,
     if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_put)) {
       chpl_comm_cb_info_t cb_data =
         {chpl_comm_cb_event_kind_put, chpl_nodeID, node,
-         .iu.comm={addr, raddr, size, typeIndex, commID, ln, fn}};
+         .iu.comm={addr, raddr, size, commID, ln, fn}};
       chpl_comm_do_callbacks (&cb_data);
     }
 
@@ -1128,7 +1128,7 @@ void  chpl_comm_get(void* addr, c_nodeid_t node, void* raddr,
     if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_get)) {
       chpl_comm_cb_info_t cb_data = 
         {chpl_comm_cb_event_kind_get, chpl_nodeID, node,
-         .iu.comm={addr, raddr, size, typeIndex, commID, ln, fn}};
+         .iu.comm={addr, raddr, size, commID, ln, fn}};
       chpl_comm_do_callbacks (&cb_data);
     }
 
@@ -1269,7 +1269,7 @@ void  chpl_comm_get_strd(void* dstaddr, size_t* dststrides, c_nodeid_t srcnode_i
     chpl_comm_cb_info_t cb_data =
       {chpl_comm_cb_event_kind_get_strd, chpl_nodeID, srcnode_id,
        .iu.comm_strd={srcaddr, srcstrides, dstaddr, dststrides, count,
-                      stridelevels, elemSize, typeIndex, commID, ln, fn}};
+                      stridelevels, elemSize, commID, ln, fn}};
     chpl_comm_do_callbacks (&cb_data);
   }
   
@@ -1314,7 +1314,7 @@ void  chpl_comm_put_strd(void* dstaddr, size_t* dststrides, c_nodeid_t dstnode_i
       chpl_comm_cb_info_t cb_data =
         {chpl_comm_cb_event_kind_put_strd, chpl_nodeID, dstnode_id,
          .iu.comm_strd={srcaddr, srcstrides, dstaddr, dststrides, count,
-                        stridelevels, elemSize, typeIndex, commID, ln, fn}};
+                        stridelevels, elemSize, commID, ln, fn}};
       chpl_comm_do_callbacks (&cb_data);
   }
 

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -2247,7 +2247,7 @@ void chpl_comm_put(void* addr, c_nodeid_t node, void* raddr,
   if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_put)) {
       chpl_comm_cb_info_t cb_data =
         {chpl_comm_cb_event_kind_put, chpl_nodeID, node,
-         .iu.comm={addr, raddr, size, typeIndex, commID, ln, fn}};
+         .iu.comm={addr, raddr, size, commID, ln, fn}};
       chpl_comm_do_callbacks (&cb_data);
   }
 
@@ -2276,7 +2276,7 @@ void chpl_comm_get(void* addr, int32_t node, void* raddr,
   if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_get)) {
       chpl_comm_cb_info_t cb_data =
         {chpl_comm_cb_event_kind_get, chpl_nodeID, node,
-         .iu.comm={addr, raddr, size, typeIndex, commID, ln, fn}};
+         .iu.comm={addr, raddr, size, commID, ln, fn}};
       chpl_comm_do_callbacks (&cb_data);
   }
 

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -5282,7 +5282,7 @@ void chpl_comm_put(void* addr, c_nodeid_t locale, void* raddr,
   if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_put)) {
       chpl_comm_cb_info_t cb_data =
         {chpl_comm_cb_event_kind_put, chpl_nodeID, locale,
-         .iu.comm={addr, raddr, size, typeIndex, commID, ln, fn}};
+         .iu.comm={addr, raddr, size, commID, ln, fn}};
       chpl_comm_do_callbacks (&cb_data);
   }
 
@@ -5803,7 +5803,7 @@ void chpl_comm_get_unordered(void* addr, c_nodeid_t locale, void* raddr,
   if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_get)) {
       chpl_comm_cb_info_t cb_data =
         {chpl_comm_cb_event_kind_get, chpl_nodeID, locale,
-         .iu.comm={addr, raddr, size, typeIndex, commID, ln, fn}};
+         .iu.comm={addr, raddr, size, commID, ln, fn}};
       chpl_comm_do_callbacks (&cb_data);
   }
 
@@ -5835,7 +5835,7 @@ void chpl_comm_put_unordered(void* addr, c_nodeid_t locale, void* raddr,
   if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_put)) {
       chpl_comm_cb_info_t cb_data =
         {chpl_comm_cb_event_kind_put, chpl_nodeID, locale,
-         .iu.comm={addr, raddr, size, typeIndex, commID, ln, fn}};
+         .iu.comm={addr, raddr, size, commID, ln, fn}};
       chpl_comm_do_callbacks (&cb_data);
   }
 
@@ -5871,7 +5871,7 @@ void chpl_comm_get(void* addr, c_nodeid_t locale, void* raddr,
   if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_get)) {
       chpl_comm_cb_info_t cb_data = 
         {chpl_comm_cb_event_kind_get, chpl_nodeID, locale,
-         .iu.comm={addr, raddr, size, typeIndex, commID, ln, fn}};
+         .iu.comm={addr, raddr, size, commID, ln, fn}};
       chpl_comm_do_callbacks (&cb_data);
   }
 
@@ -6325,7 +6325,7 @@ chpl_comm_nb_handle_t chpl_comm_get_nb(void* addr, c_nodeid_t locale,
   if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_get_nb)) {
     chpl_comm_cb_info_t cb_data = 
       {chpl_comm_cb_event_kind_get_nb, chpl_nodeID, locale,
-       .iu.comm={addr, raddr, size, typeIndex, commID, ln, fn}};
+       .iu.comm={addr, raddr, size, commID, ln, fn}};
     chpl_comm_do_callbacks (&cb_data);
   }
 
@@ -6432,7 +6432,7 @@ chpl_comm_nb_handle_t chpl_comm_put_nb(void* addr, c_nodeid_t locale,
   if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_put_nb)) {
     chpl_comm_cb_info_t cb_data = 
       {chpl_comm_cb_event_kind_put_nb, chpl_nodeID, locale,
-       .iu.comm={addr, raddr, size, typeIndex, commID, ln, fn}};
+       .iu.comm={addr, raddr, size, commID, ln, fn}};
     chpl_comm_do_callbacks (&cb_data);
   }
 #endif

--- a/tools/chplvis/DataModel.cxx
+++ b/tools/chplvis/DataModel.cxx
@@ -44,7 +44,7 @@
 #define MAX_LINE_LEN 1024
 
 #define EXPECTED_VMAJOR 1
-#define EXPECTED_VMINOR 3
+#define EXPECTED_VMINOR 4
 
 void DataModel::newList()
 {
@@ -884,7 +884,6 @@ int DataModel::LoadFile (const char *fileToOpen, int index, double seq)
     long locAddr;  // local address
     long remAddr;  // remote address
     int eSize;     // element size
-    int typeIx;    // type Index
     int dlen;      // data length
 
     // fork & task
@@ -1064,10 +1063,10 @@ int DataModel::LoadFile (const char *fileToOpen, int index, double seq)
       case 'g':  // regular get
       case 'p':  // regular put
         // All comm data:
-        // s.u nodeID otherNode loc-addr rem-addr elemSize typeIndex len commID lineno fileToOpen
-        if (sscanf (&linedata[nextCh], "%d %d %d 0x%lx 0x%lx %d %d %d %d %d %d",
-                    &nid, &rnid, &taskid, &locAddr, &remAddr, &eSize, & typeIx, &dlen,
-                    &commID, &nlineno, &nfileno) != 11) {
+        // s.u nodeID otherNode loc-addr rem-addr elemSize len commID lineno fileToOpen
+        if (sscanf (&linedata[nextCh], "%d %d %d 0x%lx 0x%lx %d %d %d %d %d",
+                    &nid, &rnid, &taskid, &locAddr, &remAddr, &eSize, &dlen,
+                    &commID, &nlineno, &nfileno) != 10) {
           fprintf (stderr, "Bad comm line: %s\n  '%s'\n", fileToOpen, line);
           nErrs++;
         } else {

--- a/tools/chplvis/TextDataFormat.txt
+++ b/tools/chplvis/TextDataFormat.txt
@@ -75,12 +75,12 @@ Lines in the file:
   Etask: tv nid tid
     Task has ended execution
 
-  nb_put: tv nid rid tid addr raddr elemsize typeIndex length commID lnum fileno
-  nb_get: tv nid rid tid addr raddr elemsize typeIndex length commID lnum fileno
-  put   : tv nid rid tid addr raddr elemsize typeIndex length commID lnum fileno
-  get   : tv nid rid tid addr raddr elemsize typeIndex length commID lnum fileno
-  st_put: tv nid rid tid addr raddr elemsize typeIndex length commID lnum fileno
-  st_get: tv nid rid tid addr raddr elemsize typeIndex length commID lnum fileno
+  nb_put: tv nid rid tid addr raddr elemsize length commID lnum fileno
+  nb_get: tv nid rid tid addr raddr elemsize length commID lnum fileno
+  put   : tv nid rid tid addr raddr elemsize length commID lnum fileno
+  get   : tv nid rid tid addr raddr elemsize length commID lnum fileno
+  st_put: tv nid rid tid addr raddr elemsize length commID lnum fileno
+  st_get: tv nid rid tid addr raddr elemsize length commID lnum fileno
     communication.  Puts: data flow nid->rid, gets: data flow rid -> nid
     nb is non-blocking, st is strided.
 


### PR DESCRIPTION
`typeIndex` (part of the ancient `--heterogeneous` support) is going away.
As a step towards that, remove typeIndex from the comm callbacks and
chplvis.