### PR TITLE
Remove vestiges of `--heterogeneous` support

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -1406,7 +1406,6 @@ static void codegen_defn(std::set<const char*> & cnames, std::vector<TypeSymbol*
           return; // Nothing in remainder of function should be done twice for LLVM
     #endif
   }
-  genGlobalInt("chpl_heterogeneous", fHeterogeneous?1:0, false);
   if( hdrfile ) {
     fprintf(hdrfile, "\nconst char* chpl_mem_descs[] = {\n");
     bool first = true;
@@ -1814,7 +1813,6 @@ static void codegen_header(std::set<const char*> & cnames, std::vector<TypeSymbo
                               chpl_globals_registryGVar, GEN_PTR, true);
 #endif
   }
-  genGlobalInt("chpl_heterogeneous", fHeterogeneous?1:0, true);
   if( hdrfile ) {
       fprintf(hdrfile, "\nextern const char* chpl_mem_descs[];\n");
     } else {
@@ -2300,8 +2298,6 @@ void codegen() {
 
   if( llvmCodegen ) {
 #ifdef HAVE_LLVM
-    if( fHeterogeneous )
-      INT_FATAL("fHeterogeneous not yet supported with LLVM");
 
     if(fIncrementalCompilation)
       USR_FATAL("Incremental compilation is not yet supported with LLVM");
@@ -2397,17 +2393,6 @@ void codegen() {
     finishCodegenLLVM();
 #endif
   } else {
-    if (fHeterogeneous) {
-      codegenTypeStructureInclude(mainfile.fptr);
-      forv_Vec(TypeSymbol, ts, gTypeSymbols) {
-        if ((ts->type != dtOpaque) &&
-            (!toPrimitiveType(ts->type) ||
-             !toPrimitiveType(ts->type)->isInternalType)) {
-          registerTypeToStructurallyCodegen(ts);
-        }
-      }
-    }
-
     ChainHashMap<char*, StringHashFns, int> fileNameHashMap;
     forv_Vec(ModuleSymbol, currentModule, allModules) {
       const char* filename = NULL;
@@ -2432,9 +2417,6 @@ void codegen() {
 
     fprintf(strconfig.fptr, "#include \"chpl-string.h\"\n");
     fprintf(strconfig.fptr, "chpl_string defaultStringValue=\"\";\n");
-
-    if (fHeterogeneous)
-      codegenTypeStructures(hdrfile.fptr);
 
     info->cfile = hdrfile.fptr;
     codegen_header_addons();

--- a/compiler/codegen/expr.cpp
+++ b/compiler/codegen/expr.cpp
@@ -2634,7 +2634,6 @@ void codegenCall(const char* fnName, GenRet a1, GenRet a2, GenRet a3,
   codegenCall(fnName, args);
 }
 
-/*
 static
 void codegenCall(const char* fnName, GenRet a1, GenRet a2, GenRet a3,
                  GenRet a4, GenRet a5, GenRet a6, GenRet a7)
@@ -2649,7 +2648,6 @@ void codegenCall(const char* fnName, GenRet a1, GenRet a2, GenRet a3,
   args.push_back(a7);
   codegenCall(fnName, args);
 }
-*/
 
 static
 void codegenCall(const char* fnName, GenRet a1, GenRet a2, GenRet a3,
@@ -2667,6 +2665,7 @@ void codegenCall(const char* fnName, GenRet a1, GenRet a2, GenRet a3,
   codegenCall(fnName, args);
 }
 
+/*
 static
 void codegenCall(const char* fnName, GenRet a1, GenRet a2, GenRet a3,
                  GenRet a4, GenRet a5, GenRet a6, GenRet a7, GenRet a8,
@@ -2684,6 +2683,7 @@ void codegenCall(const char* fnName, GenRet a1, GenRet a2, GenRet a3,
   args.push_back(a9);
   codegenCall(fnName, args);
 }
+*/
 
 /*static
 void codegenCall(const char* fnName, GenRet a1, GenRet a2, GenRet a3,
@@ -2704,7 +2704,6 @@ void codegenCall(const char* fnName, GenRet a1, GenRet a2, GenRet a3,
   codegenCall(fnName, args);
 }*/
 
-/*
 static
 void codegenCall(const char* fnName, GenRet a1, GenRet a2, GenRet a3,
                  GenRet a4, GenRet a5, GenRet a6, GenRet a7, GenRet a8,
@@ -2724,8 +2723,8 @@ void codegenCall(const char* fnName, GenRet a1, GenRet a2, GenRet a3,
   args.push_back(a11);
   codegenCall(fnName, args);
 }
-*/
 
+/*
 static
 void codegenCall(const char* fnName, GenRet a1, GenRet a2, GenRet a3,
                  GenRet a4, GenRet a5, GenRet a6, GenRet a7, GenRet a8,
@@ -2746,6 +2745,7 @@ void codegenCall(const char* fnName, GenRet a1, GenRet a2, GenRet a3,
   args.push_back(a12);
   codegenCall(fnName, args);
 }
+*/
 
 static
 GenRet codegenZero()
@@ -3276,7 +3276,6 @@ void codegenAssign(GenRet to_ptr, GenRet from)
                       codegenRnode(from),
                       codegenRaddr(from),
                       codegenSizeof(type),
-                      genTypeStructureIndex(type->symbol),
                       genCommID(info),
                       info->lineno, gFilenameLookupCache[info->filename]);
         }
@@ -3299,7 +3298,6 @@ void codegenAssign(GenRet to_ptr, GenRet from)
                       codegenRnode(to_ptr),
                       codegenRaddr(to_ptr),
                       codegenSizeof(type),
-                      genTypeStructureIndex(type->symbol),
                       genCommID(info),
                       info->lineno, gFilenameLookupCache[info->filename]);
         }
@@ -4098,7 +4096,7 @@ DEFINE_PRIM(PRIM_UNORDERED_ASSIGN) {
     // do an unordered GET
     // chpl_comm_get_unordered(void *dst,
     //   c_nodeid_t src_locale, void* src_raddr,
-    //   size_t size, int32_t typeIndex, int32_t commID,
+    //   size_t size, int32_t commID,
     //   int ln, int32_t fn);
 
     dst = codegenValuePtr(dst);
@@ -4110,14 +4108,13 @@ DEFINE_PRIM(PRIM_UNORDERED_ASSIGN) {
                 codegenRnode(src),
                 codegenRaddr(src),
                 size,
-                genTypeStructureIndex(dt),
                 genCommID(gGenInfo),
                 ln, fn);
   } else if (lhsWide && !rhsWide) {
     // do an unordered PUT
     // chpl_comm_put_unordered(void *src,
     //   c_nodeid_t dst_locale, void* dst_raddr,
-    //   size_t size, int32_t typeIndex, int32_t commID,
+    //   size_t size, int32_t commID,
     //   int ln, int32_t fn);
 
     src = codegenValuePtr(src);
@@ -4129,7 +4126,6 @@ DEFINE_PRIM(PRIM_UNORDERED_ASSIGN) {
                 codegenRnode(dst),
                 codegenRaddr(dst),
                 size,
-                genTypeStructureIndex(dt),
                 genCommID(gGenInfo),
                 ln, fn);
   } else {
@@ -4137,7 +4133,7 @@ DEFINE_PRIM(PRIM_UNORDERED_ASSIGN) {
     // chpl_comm_getput_unordered(
     //   c_nodeid_t dst_locale, void* dst_raddr,
     //   c_nodeid_t src_locale, void* src_raddr,
-    //   size_t size, int32_t typeIndex, int32_t commID,
+    //   size_t size, int32_t commID,
     //   int ln, int32_t fn);
     codegenCall("chpl_comm_getput_unordered",
                 codegenRnode(dst),
@@ -4145,7 +4141,6 @@ DEFINE_PRIM(PRIM_UNORDERED_ASSIGN) {
                 codegenRnode(src),
                 codegenRaddr(src),
                 size,
-                genTypeStructureIndex(dt),
                 genCommID(gGenInfo),
                 ln, fn);
   }
@@ -4263,7 +4258,6 @@ DEFINE_PRIM(PRIM_MAX) {
 DEFINE_PRIM(PRIM_SETCID) {
     // get(1) is the object
     // (type=chpl__class_id,
-    //  tid=CHPL_TYPE_int32_t,
     //  wide=get(1),
     //  local=chpl__cid_<type>,
     //  stype=dtObject->typeInfo(),
@@ -4511,7 +4505,6 @@ static void codegenPutGet(CallExpr* call, GenRet &ret) {
                   locale,
                   remoteAddr,
                   size,
-                  genTypeStructureIndex(dt),
                   genCommID(gGenInfo),
                   call->get(5),
                   call->get(6));
@@ -4710,7 +4703,6 @@ static void codegenPutGetStrd(CallExpr* call, GenRet &ret) {
                 codegenCastToVoidStar(count),
                 stridelevels,
                 eltSize,
-                genTypeStructureIndex(dt),
                 genCommID(gGenInfo),
                 call->get(8),
                 call->get(9));
@@ -4874,8 +4866,7 @@ DEFINE_PRIM(PRIM_BROADCAST_GLOBAL_VARS) {
 DEFINE_PRIM(PRIM_PRIVATE_BROADCAST) {
     codegenCall("chpl_comm_broadcast_private",
                 call->get(1),
-                codegenSizeof(call->get(2)->typeInfo()),
-                genTypeStructureIndex(call->get(2)->typeInfo()->symbol));
+                codegenSizeof(call->get(2)->typeInfo()));
 }
 
 DEFINE_PRIM(PRIM_INT_ERROR) {

--- a/compiler/codegen/type.cpp
+++ b/compiler/codegen/type.cpp
@@ -60,23 +60,7 @@ void Type::codegenDef() {
 void Type::codegenPrototype() { }
 
 
-int Type::codegenStructure(FILE* outfile, const char* baseoffset) {
-  INT_FATAL(this, "Unexpected type in codegenStructure: %s", symbol->name);
-  return 0;
-}
-
-
 void PrimitiveType::codegenDef() {
-}
-
-int PrimitiveType::codegenStructure(FILE* outfile, const char* baseoffset) {
-  if (!isInternalType) {
-    Symbol* cgsym = symbol;
-
-    fprintf(outfile, "{CHPL_TYPE_%s, %s},\n", cgsym->cname, baseoffset);
-  } else
-    INT_FATAL(this, "Cannot codegen an internal type");
-  return 1;
 }
 
 void EnumType::codegenDef() {
@@ -139,11 +123,6 @@ void EnumType::codegenDef() {
 #endif
   }
   return;
-}
-
-int EnumType::codegenStructure(FILE* outfile, const char* baseoffset) {
-  fprintf(outfile, "{CHPL_TYPE_enum, %s},\n", baseoffset);
-  return 1;
 }
 
 #define CLASS_STRUCT_PREFIX "chpl_"
@@ -503,101 +482,6 @@ void AggregateType::codegenPrototype() {
   return;
 }
 
-int AggregateType::codegenStructure(FILE* outfile, const char* baseoffset) {
-  switch (aggregateTag) {
-  case AGGREGATE_CLASS:
-    fprintf(outfile, "{CHPL_TYPE_CLASS_REFERENCE, %s},\n", baseoffset);
-    return 1;
-  case AGGREGATE_RECORD:
-    return codegenFieldStructure(outfile, true, baseoffset);
-  case AGGREGATE_UNION:
-    INT_FATAL(this, "Don't know how to codegenStructure for unions yet");
-    return 0;
-  default:
-    INT_FATAL(this, "Unexpected case in AggregateType::codegenStructure");
-    return 0;
-  }
-}
-
-// BLC: I'm not understanding why special cases would need to be called
-// out here
-static const char* genUnderscore(Symbol* sym) {
-  AggregateType* classtype = toAggregateType(sym->type);
-  if (classtype && classtype->isClass() &&
-      !sym->hasFlag(FLAG_REF)) {
-    return "_";
-  } else {
-    return "";
-  }
-}
-
-
-static const char* genChplTypeEnumString(TypeSymbol* typesym) {
-  return astr("chpl_rt_type_id_", genUnderscore(typesym), typesym->cname);
-}
-
-
-static const char* genSizeofStr(TypeSymbol* typesym) {
-  return astr("sizeof(", genUnderscore(typesym), typesym->cname, ")");
-}
-
-
-static const char* genNewBaseOffsetString(TypeSymbol* typesym, int fieldnum,
-                                          const char* baseoffset, Symbol* field,
-                                          AggregateType* classtype) {
-  if (classtype->symbol->hasFlag(FLAG_STAR_TUPLE)) {
-    char fieldnumstr[64];
-
-    sprintf(fieldnumstr, "%d", fieldnum);
-
-    return astr(baseoffset,
-                " + (",
-                fieldnumstr, "* ",
-                genSizeofStr(field->type->symbol),
-                ")");
-  } else {
-    return astr(baseoffset,
-                " + offsetof(",
-                genUnderscore(classtype->symbol),
-                classtype->symbol->cname,
-                ", ",
-                classtype->isUnion() ? "_u." : "",
-                field->cname, ")");
-  }
-}
-
-int AggregateType::codegenFieldStructure(FILE*       outfile,
-                                         bool        nested,
-                                         const char* baseoffset) {
-  // Handle ref types as pointers
-  if (symbol->hasFlag(FLAG_REF)) {
-    fprintf(outfile, "{CHPL_TYPE_CLASS_REFERENCE, 0},\n");
-    fprintf(outfile, "{CHPL_TYPE_DONE, -1}\n");
-    return 1;
-  }
-
-  int totfields = 0;
-  int locfieldnum = 0;
-
-  for_fields(field, this) {
-    const char* newbaseoffset = genNewBaseOffsetString(symbol,
-                                                       locfieldnum,
-                                                       baseoffset,
-                                                       field,
-                                                       this);
-    int         numfields = field->type->codegenStructure(outfile, newbaseoffset);
-
-    fprintf(outfile, " /* %s */\n", field->name);
-    totfields += numfields;
-    locfieldnum++;
-  }
-  if (!nested) {
-    fprintf(outfile, "{CHPL_TYPE_DONE, -1}\n");
-    totfields += 1;
-  }
-  return totfields;
-}
-
 int AggregateType::getMemberGEP(const char *name, bool &isCArrayField) {
 #ifdef HAVE_LLVM
   if( symbol->hasFlag(FLAG_EXTERN) ) {
@@ -664,130 +548,18 @@ int AggregateType::getMemberGEP(const char *name, bool &isCArrayField) {
 *                                                                           *
 ************************************* | ************************************/
 
-static Vec<TypeSymbol*> typesToStructurallyCodegen;
-static Vec<TypeSymbol*> typesToStructurallyCodegenList;
-
-void registerTypeToStructurallyCodegen(TypeSymbol* type) {
-  //  printf("registering chpl_rt_type_id_%s\n", type->cname);
-  if (!typesToStructurallyCodegen.set_in(type)) {
-    typesToStructurallyCodegenList.add(type);
-    typesToStructurallyCodegen.set_add(type);
-  }
-}
-
+// TODO remove
 GenRet genTypeStructureIndex(TypeSymbol* typesym) {
   GenInfo* info = gGenInfo;
   GenRet ret;
-  if (fHeterogeneous) {
-    if( info->cfile )
-      ret.c = genChplTypeEnumString(typesym);
-    else {
+  if( info->cfile )
+    ret.c = "-1";
+  else {
 #ifdef HAVE_LLVM
-      ret = info->lvt->getValue(genChplTypeEnumString(typesym));
+    ret.val = llvm::ConstantInt::get(
+        llvm::Type::getInt32Ty(info->module->getContext()), -1, true);
 #endif
-    }
-  } else {
-    if( info->cfile )
-      ret.c = "-1";
-    else {
-#ifdef HAVE_LLVM
-      ret.val = llvm::ConstantInt::get(
-          llvm::Type::getInt32Ty(info->module->getContext()), -1, true);
-#endif
-    }
   }
   ret.chplType = dtInt[INT_SIZE_32];
   return ret;
-}
-
-// Compare the cnames of different types alphabetically
-static int compareCnames(const void* v1, const void* v2) {
-  int retval;
-  TypeSymbol* t1 = *(TypeSymbol* const *)v1;
-  TypeSymbol* t2 = *(TypeSymbol* const *)v2;
-  retval = strcmp(t1->cname, t2->cname);
-  if (retval > 0)
-    return 1;
-  else if (retval < 0)
-    return -1;
-  else
-    return 0;
-}
-
-#define TYPE_STRUCTURE_FILE "_type_structure.c"
-static int maxFieldsPerType = 0;
-
-void codegenTypeStructures(FILE* hdrfile) {
-  fileinfo typeStructFile;
-  openCFile(&typeStructFile, TYPE_STRUCTURE_FILE);
-  FILE* outfile = typeStructFile.fptr;
-
-  fprintf(outfile, "typedef enum {\n");
-  forv_Vec(TypeSymbol*, typesym, typesToStructurallyCodegenList) {
-    fprintf(outfile, "%s,\n", genChplTypeEnumString(typesym));
-  }
-  fprintf(outfile, "chpl_num_rt_type_ids\n");
-  fprintf(outfile, "} chpl_rt_types;\n\n");
-
-  fprintf(outfile,
-          "chpl_fieldType chpl_structType[][CHPL_MAX_FIELDS_PER_TYPE] = {\n");
-
-  qsort(typesToStructurallyCodegenList.v,
-        typesToStructurallyCodegenList.n,
-        sizeof(typesToStructurallyCodegenList.v[0]),
-        compareCnames);
-
-  int num = 0;
-
-  forv_Vec(TypeSymbol*, typesym, typesToStructurallyCodegenList) {
-    if (num) {
-      fprintf(outfile, ",\n");
-    }
-    fprintf(outfile, "/* %s (%s) */\n", typesym->name, typesym->cname);
-    fprintf(outfile, "{\n");
-    if (AggregateType* classtype = toAggregateType(typesym->type)) {
-      int numfields = classtype->codegenFieldStructure(outfile, false, "0");
-      if (numfields > maxFieldsPerType) {
-        maxFieldsPerType = numfields;
-      }
-    } else {
-      typesym->type->codegenStructure(outfile, "0");
-      fprintf(outfile, "{CHPL_TYPE_DONE, -1}\n");
-    }
-    fprintf(outfile, "}");
-    num++;
-  }
-  fprintf(outfile, "};\n\n");
-
-  fprintf(outfile, "size_t chpl_sizeType[] = {\n");
-  num = 0;
-  forv_Vec(TypeSymbol*, typesym, typesToStructurallyCodegenList) {
-    if (num) {
-      fprintf(outfile, ",\n");
-    }
-    fprintf(outfile, "%s", genSizeofStr(typesym));
-    num++;
-  }
-  fprintf(outfile, "\n};\n\n");
-
-  fprintf(outfile, "chplType chpl_getFieldType(int typeNum, int fieldNum) {\n");
-  fprintf(outfile, "return chpl_structType[typeNum][fieldNum].type;\n");
-  fprintf(outfile, "}\n\n");
-
-  fprintf(outfile, "size_t chpl_getFieldOffset(int typeNum, int fieldNum) {\n");
-  fprintf(outfile, "return chpl_structType[typeNum][fieldNum].offset;\n");
-  fprintf(outfile, "}\n\n");
-
-  fprintf(outfile, "size_t chpl_getFieldSize(int typeNum) {\n");
-  fprintf(outfile, "return chpl_sizeType[typeNum];\n");
-  fprintf(outfile, "}\n\n");
-  closeCFile(&typeStructFile);
-  fprintf(hdrfile, "#define CHPL_MAX_FIELDS_PER_TYPE %d\n", maxFieldsPerType);
-  fprintf(hdrfile, "const int chpl_max_fields_per_type = %d;\n",
-                   maxFieldsPerType);
-}
-
-
-void codegenTypeStructureInclude(FILE* outfile) {
-  fprintf(outfile, "#include \"" TYPE_STRUCTURE_FILE "\"\n");
 }

--- a/compiler/codegen/type.cpp
+++ b/compiler/codegen/type.cpp
@@ -535,31 +535,3 @@ int AggregateType::getMemberGEP(const char *name, bool &isCArrayField) {
 #endif
   return -1;
 }
-
-/************************************ | *************************************
-*                                                                           *
-*                                                                           *
-*                                                                           *
-************************************* | ************************************/
-
-/************************************ | *************************************
-*                                                                           *
-*                                                                           *
-*                                                                           *
-************************************* | ************************************/
-
-// TODO remove
-GenRet genTypeStructureIndex(TypeSymbol* typesym) {
-  GenInfo* info = gGenInfo;
-  GenRet ret;
-  if( info->cfile )
-    ret.c = "-1";
-  else {
-#ifdef HAVE_LLVM
-    ret.val = llvm::ConstantInt::get(
-        llvm::Type::getInt32Ty(info->module->getContext()), -1, true);
-#endif
-  }
-  ret.chplType = dtInt[INT_SIZE_32];
-  return ret;
-}

--- a/compiler/include/AggregateType.h
+++ b/compiler/include/AggregateType.h
@@ -110,13 +110,6 @@ public:
 
   GenRet                      codegenClassStructType();
 
-  int                         codegenStructure(FILE*       outfile,
-                                               const char* baseoffset);
-
-  int                         codegenFieldStructure(FILE*       outfile,
-                                                    bool        nested,
-                                                    const char* baseOffset);
-
   bool                        setFirstGenericField();
 
   AggregateType*              getInstantiation(Symbol* sym, int index, Expr* insnPoint = NULL);

--- a/compiler/include/driver.h
+++ b/compiler/include/driver.h
@@ -152,7 +152,6 @@ extern bool fIgnoreLocalClasses;
 extern bool fLifetimeChecking;
 extern bool fCompileTimeNilChecking;
 extern bool fOverrideChecking;
-extern bool fHeterogeneous;
 extern int  ffloatOpt;
 extern int  fMaxCIdentLen;
 

--- a/compiler/include/type.h
+++ b/compiler/include/type.h
@@ -70,11 +70,6 @@ public:
   virtual void           codegenDef();
   virtual void           codegenPrototype();
 
-  // only used for heterogeneous compilations in which we need to define
-  // what our data structures are for the point of conversions
-  virtual int            codegenStructure(FILE*       outfile,
-                                          const char* baseoffset);
-
   virtual Symbol*        getField(const char* name, bool fatal = true)   const;
 
   const char*            name()                                          const;
@@ -326,7 +321,6 @@ class EnumType : public Type {
   void replaceChild(BaseAST* old_ast, BaseAST* new_ast);
 
   void codegenDef();
-  int codegenStructure(FILE* outfile, const char* baseoffset);
 
   bool isAbstract();  // is the enum abstract?  (has no associated values)
   bool isConcrete();  // is the enum concrete?  (all have associated values)
@@ -361,7 +355,6 @@ class PrimitiveType : public Type {
   DECLARE_COPY(PrimitiveType);
   void replaceChild(BaseAST* old_ast, BaseAST* new_ast);
   void codegenDef();
-  int codegenStructure(FILE* outfile, const char* baseoffset);
 
   virtual void printDocs(std::ostream *file, unsigned int tabs);
 
@@ -500,10 +493,7 @@ bool isRecordWithInitializers(Type* type);
 
 bool needsGenericRecordInitializer(Type* type);
 
-void registerTypeToStructurallyCodegen(TypeSymbol* type);
 GenRet genTypeStructureIndex(TypeSymbol* typesym);
-void codegenTypeStructures(FILE* hdrfile);
-void codegenTypeStructureInclude(FILE* outfile);
 
 Type* getNamedType(std::string name);
 

--- a/compiler/include/type.h
+++ b/compiler/include/type.h
@@ -493,8 +493,6 @@ bool isRecordWithInitializers(Type* type);
 
 bool needsGenericRecordInitializer(Type* type);
 
-GenRet genTypeStructureIndex(TypeSymbol* typesym);
-
 Type* getNamedType(std::string name);
 
 bool needsCapture(Type* t);

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -192,7 +192,6 @@ bool fIgnoreLocalClasses = false;
 bool fLifetimeChecking = true;
 bool fCompileTimeNilChecking = true;
 bool fOverrideChecking = true;
-bool fHeterogeneous = false;
 bool fieeefloat = false;
 int ffloatOpt = 0; // 0 -> backend default; -1 -> strict; 1 -> opt
 bool report_inlining = false;
@@ -1058,7 +1057,6 @@ static ArgumentDescription arg_desc[] = {
  {"lifetime-checking", ' ', NULL, "Enable [disable] lifetime checking pass", "N", &fLifetimeChecking, NULL, NULL},
  {"legacy-nilable-classes", ' ', NULL, "Allow all variables of class type to store nil", "N", &fLegacyNilableClasses, NULL, NULL},
  {"compile-time-nil-checking", ' ', NULL, "Enable [disable] compile-time nil checking", "N", &fCompileTimeNilChecking, "CHPL_NO_COMPILE_TIME_NIL_CHECKS", NULL},
- {"heterogeneous", ' ', NULL, "Compile for heterogeneous nodes", "F", &fHeterogeneous, "", NULL},
  {"ignore-errors", ' ', NULL, "[Don't] attempt to ignore errors", "N", &ignore_errors, "CHPL_IGNORE_ERRORS", NULL},
  {"ignore-user-errors", ' ', NULL, "[Don't] attempt to ignore user errors", "N", &ignore_user_errors, "CHPL_IGNORE_USER_ERRORS", NULL},
  {"ignore-errors-for-pass", ' ', NULL, "[Don't] attempt to ignore errors until the end of the pass in which they occur", "N", &ignore_errors_for_pass, "CHPL_IGNORE_ERRORS_FOR_PASS", NULL},

--- a/runtime/include/chpl-cache.h
+++ b/runtime/include/chpl-cache.h
@@ -66,24 +66,19 @@ void chpl_cache_release(int ln, int32_t fn)
 // These are the functions that the generated code should be eventually
 // calling on a put or a get.
 void chpl_cache_comm_put(void* addr, c_nodeid_t node, void* raddr,
-                         size_t size, int32_t typeIndex,
-                         int32_t commID, int ln, int32_t fn);
+                         size_t size, int32_t commID, int ln, int32_t fn);
 void chpl_cache_comm_get(void *addr, c_nodeid_t node, void* raddr,
-                         size_t size, int32_t typeIndex,
-                         int32_t commID, int ln, int32_t fn);
+                         size_t size, int32_t commID, int ln, int32_t fn);
 void chpl_cache_comm_prefetch(c_nodeid_t node, void* raddr,
-                              size_t size, int32_t typeIndex,
-                              int ln, int32_t fn);
+                              size_t size, int ln, int32_t fn);
 void  chpl_cache_comm_get_strd(
                    void *addr, void *dststr, c_nodeid_t node, void *raddr,
                    void *srcstr, void *count, int32_t strlevels,
-                   size_t elemSize, int32_t typeIndex,
-                   int32_t commID, int ln, int32_t fn);
+                   size_t elemSize, int32_t commID, int ln, int32_t fn);
 void  chpl_cache_comm_put_strd(
                       void *addr, void *dststr, c_nodeid_t node, void *raddr,
                       void *srcstr, void *count, int32_t strlevels,
-                      size_t elemSize, int32_t typeIndex,
-                      int32_t commID, int ln, int32_t fn);
+                      size_t elemSize, int32_t commID, int ln, int32_t fn);
 
 // For debugging.
 void chpl_cache_print(void);

--- a/runtime/include/chpl-comm-compiler-llvm-support.h
+++ b/runtime/include/chpl-comm-compiler-llvm-support.h
@@ -40,7 +40,7 @@ void chpl_gen_comm_get_ctl(void *dst_addr,
                            c_nodeid_t src_node, void *src_addr,
                            uintptr_t n, int64_t ctl)
 {
-  chpl_gen_comm_get(dst_addr, src_node, src_addr, sizeof(uint8_t)*n, CHPL_TYPE_uint8_t, CHPL_COMM_UNKNOWN_ID, -1, 0);
+  chpl_gen_comm_get(dst_addr, src_node, src_addr, sizeof(uint8_t)*n, CHPL_COMM_UNKNOWN_ID, -1, 0);
 }
 
 static inline
@@ -48,7 +48,7 @@ void chpl_gen_comm_put_ctl(c_nodeid_t dst_node, void* dst_addr,
                            void *src_addr,
                            uintptr_t n, int64_t ctl)
 {
-  chpl_gen_comm_put(src_addr, dst_node, dst_addr, sizeof(uint8_t)*n, CHPL_TYPE_uint8_t, CHPL_COMM_UNKNOWN_ID, -1, 0);
+  chpl_gen_comm_put(src_addr, dst_node, dst_addr, sizeof(uint8_t)*n, CHPL_COMM_UNKNOWN_ID, -1, 0);
 }
 
 // This function implements memmove when both the source and destination

--- a/runtime/include/chpl-comm-compiler-macros.h
+++ b/runtime/include/chpl-comm-compiler-macros.h
@@ -44,24 +44,22 @@
 
 static inline
 void chpl_gen_comm_get(void *addr, c_nodeid_t node, void* raddr,
-                       size_t size, int32_t typeIndex,
-                       int32_t commID, int ln, int32_t fn)
+                       size_t size, int32_t commID, int ln, int32_t fn)
 {
   if (chpl_nodeID == node) {
     chpl_memmove(addr, raddr, size);
 #ifdef HAS_CHPL_CACHE_FNS
   } else if( chpl_cache_enabled() ) {
-    chpl_cache_comm_get(addr, node, raddr, size, typeIndex, commID, ln, fn);
+    chpl_cache_comm_get(addr, node, raddr, size, commID, ln, fn);
 #endif
   } else {
-    chpl_comm_get(addr, node, raddr, size, typeIndex, commID, ln, fn);
+    chpl_comm_get(addr, node, raddr, size, commID, ln, fn);
   }
 }
 
 static inline
 void chpl_gen_comm_prefetch(c_nodeid_t node, void* raddr,
-                            size_t size, int32_t typeIndex,
-                            int ln, int32_t fn)
+                            size_t size, int ln, int32_t fn)
 {
   const size_t MAX_BYTES_LOCAL_PREFETCH = 1024;
   size_t offset;
@@ -76,7 +74,7 @@ void chpl_gen_comm_prefetch(c_nodeid_t node, void* raddr,
     }
 #ifdef HAS_CHPL_CACHE_FNS
   } else if( chpl_cache_enabled() ) {
-    chpl_cache_comm_prefetch(node, raddr, size, typeIndex, ln, fn);
+    chpl_cache_comm_prefetch(node, raddr, size, ln, fn);
 #endif
   } else {
     // Can't do anything if we don't have a remote data cache
@@ -87,49 +85,46 @@ void chpl_gen_comm_prefetch(c_nodeid_t node, void* raddr,
 
 static inline
 void chpl_gen_comm_put(void* addr, c_nodeid_t node, void* raddr,
-                       size_t size, int32_t typeIndex,
-                       int32_t commID, int ln, int32_t fn)
+                       size_t size, int32_t commID, int ln, int32_t fn)
 {
   if (chpl_nodeID == node) {
     chpl_memmove(raddr, addr, size);
 #ifdef HAS_CHPL_CACHE_FNS
   } else if( chpl_cache_enabled() ) {
-    chpl_cache_comm_put(addr, node, raddr, size, typeIndex, commID, ln, fn);
+    chpl_cache_comm_put(addr, node, raddr, size, commID, ln, fn);
 #endif
   } else {
-    chpl_comm_put(addr, node, raddr, size, typeIndex, commID, ln, fn);
+    chpl_comm_put(addr, node, raddr, size, commID, ln, fn);
   }
 }
 
 static inline
 void chpl_gen_comm_get_strd(void *addr, void *dststr, c_nodeid_t node, void *raddr,
                        void *srcstr, void *count, int32_t strlevels, 
-                       size_t elemSize, int32_t typeIndex,
-                       int32_t commID, int ln, int32_t fn)
+                       size_t elemSize, int32_t commID, int ln, int32_t fn)
 {
   if( 0 ) {
 #ifdef HAS_CHPL_CACHE_FNS
   } else if( chpl_cache_enabled() ) {
-    chpl_cache_comm_get_strd(addr, dststr, node, raddr, srcstr, count, strlevels, elemSize, typeIndex, commID, ln, fn);
+    chpl_cache_comm_get_strd(addr, dststr, node, raddr, srcstr, count, strlevels, elemSize, commID, ln, fn);
 #endif
   } else {
-  chpl_comm_get_strd(addr, dststr, node, raddr, srcstr, count, strlevels, elemSize, typeIndex, commID, ln, fn);
+    chpl_comm_get_strd(addr, dststr, node, raddr, srcstr, count, strlevels, elemSize, commID, ln, fn);
   }
 }
 
 static inline
 void chpl_gen_comm_put_strd(void *addr, void *dststr, c_nodeid_t node, void *raddr,
                        void *srcstr, void *count, int32_t strlevels, 
-                       size_t elemSize, int32_t typeIndex,
-                       int32_t commID, int ln, int32_t fn)
+                       size_t elemSize, int32_t commID, int ln, int32_t fn)
 {
   if( 0 ) {
 #ifdef HAS_CHPL_CACHE_FNS
   } else if( chpl_cache_enabled() ) {
-    chpl_cache_comm_put_strd(addr, dststr, node, raddr, srcstr, count, strlevels, elemSize, typeIndex, commID, ln, fn);
+    chpl_cache_comm_put_strd(addr, dststr, node, raddr, srcstr, count, strlevels, elemSize, commID, ln, fn);
 #endif
   } else {
-  chpl_comm_put_strd(addr, dststr, node, raddr, srcstr, count, strlevels, elemSize, typeIndex, commID, ln, fn);
+    chpl_comm_put_strd(addr, dststr, node, raddr, srcstr, count, strlevels, elemSize, commID, ln, fn);
   }
 }
 

--- a/runtime/include/chpl-comm-internal.h
+++ b/runtime/include/chpl-comm-internal.h
@@ -71,8 +71,7 @@ void chpl_comm_init_prv_bcast_tab(void);
 static inline
 void chpl_comm_really_bcast_rt_private(int id) {
   chpl_comm_broadcast_private(chpl_private_broadcast_table_len + id,
-                              chpl_rt_priv_bcast_lens[id],
-                              -1);
+                              chpl_rt_priv_bcast_lens[id]);
 }
 
 #endif

--- a/runtime/include/chpl-comm-strd-xfer.h
+++ b/runtime/include/chpl-comm-strd-xfer.h
@@ -61,14 +61,14 @@
 static inline
 void strd_nb_helper(chpl_comm_nb_handle_t (*xferFn)(void*, int32_t, void*,
                                                     size_t,
-                                                    int32_t, int32_t,
+                                                    int32_t,
                                                     int, int32_t),
                     void* localAddr, int32_t remoteLocale, void* remoteAddr,
                     size_t cnt,
                     chpl_comm_nb_handle_t* handles, size_t* pCurrHandles,
                     size_t maxOutstandingXfers,
                     void (yieldFn)(void),
-                    int32_t typeIndex, int32_t commID, int ln, int32_t fn)
+                    int32_t commID, int ln, int32_t fn)
 {
   size_t currHandles = *pCurrHandles;
 
@@ -94,7 +94,7 @@ void strd_nb_helper(chpl_comm_nb_handle_t (*xferFn)(void*, int32_t, void*,
   }
 
   handles[currHandles] = (*xferFn)(localAddr, remoteLocale, remoteAddr, cnt,
-                                   typeIndex, commID, ln, fn);
+                                   commID, ln, fn);
   if (handles[currHandles] != NULL)
     currHandles++;
 
@@ -107,7 +107,7 @@ void put_strd_common(void* dstaddr_arg, size_t* dststrides, int32_t dstlocale,
                      void* srcaddr_arg, size_t* srcstrides,
                      size_t* count, int32_t stridelevels, size_t elemSize,
                      size_t maxOutstandingXfers, void (yieldFn)(void),
-                     int32_t typeIndex, int32_t commID, int ln, int32_t fn) {
+                     int32_t commID, int ln, int32_t fn) {
   const size_t strlvls=(size_t)stridelevels;
   size_t i,j,k,t,total,off,x,carry;
 
@@ -148,8 +148,7 @@ void put_strd_common(void* dstaddr_arg, size_t* dststrides, int32_t dstlocale,
 
   switch (strlvls) {
   case 0:
-    chpl_comm_put(srcaddr_arg, dstlocale, dstaddr_arg, cnt[0],
-                  typeIndex, commID, ln, fn);
+    chpl_comm_put(srcaddr_arg, dstlocale, dstaddr_arg, cnt[0], commID, ln, fn);
     break;
 
   case 1:
@@ -159,7 +158,7 @@ void put_strd_common(void* dstaddr_arg, size_t* dststrides, int32_t dstlocale,
       strd_nb_helper(chpl_comm_put_nb,
                      srcaddr, dstlocale, dstaddr, cnt[0],
                      handles, &currHandles, maxOutstandingXfers, yieldFn,
-                     typeIndex, commID, ln, fn);
+                     commID, ln, fn);
       srcaddr+=srcstr[0];
       dstaddr+=dststr[0];
     }
@@ -173,7 +172,7 @@ void put_strd_common(void* dstaddr_arg, size_t* dststrides, int32_t dstlocale,
         strd_nb_helper(chpl_comm_put_nb,
                        srcaddr, dstlocale, dstaddr, cnt[0],
                        handles, &currHandles, maxOutstandingXfers, yieldFn,
-                       typeIndex, commID, ln, fn);
+                       commID, ln, fn);
         srcaddr+=srcstr[0];
         dstaddr+=dststr[0];
       }
@@ -191,7 +190,7 @@ void put_strd_common(void* dstaddr_arg, size_t* dststrides, int32_t dstlocale,
           strd_nb_helper(chpl_comm_put_nb,
                          srcaddr, dstlocale, dstaddr, cnt[0],
                          handles, &currHandles, maxOutstandingXfers, yieldFn,
-                         typeIndex, commID, ln, fn);
+                         commID, ln, fn);
           srcaddr+=srcstr[0];
           dstaddr+=dststr[0];
         }
@@ -230,7 +229,7 @@ void put_strd_common(void* dstaddr_arg, size_t* dststrides, int32_t dstlocale,
                          srcaddr+srcdisp[j], dstlocale, dstaddr+dstdisp[j],
                          cnt[0],
                          handles, &currHandles, maxOutstandingXfers, yieldFn,
-                         typeIndex, commID, ln, fn);
+                         commID, ln, fn);
           break;
 
         } else { //ELSE 1
@@ -254,7 +253,7 @@ void get_strd_common(void* dstaddr_arg, size_t* dststrides, int32_t srclocale,
                      void* srcaddr_arg, size_t* srcstrides,
                      size_t* count, int32_t stridelevels, size_t elemSize,
                      size_t maxOutstandingXfers, void (yieldFn)(void),
-                     int32_t typeIndex, int32_t commID, int ln, int32_t fn) {
+                     int32_t commID, int ln, int32_t fn) {
   const size_t strlvls=(size_t)stridelevels;
   size_t i,j,k,t,total,off,x,carry;
 
@@ -298,7 +297,7 @@ void get_strd_common(void* dstaddr_arg, size_t* dststrides, int32_t srclocale,
     dstaddr=(int8_t*)dstaddr_arg;
     srcaddr=(int8_t*)srcaddr_arg;
     chpl_comm_get(dstaddr, srclocale, srcaddr, cnt[0],
-                  typeIndex, commID, ln, fn);
+                  commID, ln, fn);
     break;
 
   case 1:
@@ -308,7 +307,7 @@ void get_strd_common(void* dstaddr_arg, size_t* dststrides, int32_t srclocale,
       strd_nb_helper(chpl_comm_get_nb,
                      dstaddr, srclocale, srcaddr, cnt[0],
                      handles, &currHandles, maxOutstandingXfers, yieldFn,
-                     typeIndex, commID, ln, fn);
+                     commID, ln, fn);
       srcaddr+=srcstr[0];
       dstaddr+=dststr[0];
     }
@@ -322,7 +321,7 @@ void get_strd_common(void* dstaddr_arg, size_t* dststrides, int32_t srclocale,
         strd_nb_helper(chpl_comm_get_nb,
                        dstaddr, srclocale, srcaddr, cnt[0],
                        handles, &currHandles, maxOutstandingXfers, yieldFn,
-                       typeIndex, commID, ln, fn);
+                       commID, ln, fn);
         srcaddr+=srcstr[0];
         dstaddr+=dststr[0];
       }
@@ -340,7 +339,7 @@ void get_strd_common(void* dstaddr_arg, size_t* dststrides, int32_t srclocale,
           strd_nb_helper(chpl_comm_get_nb,
                          dstaddr, srclocale, srcaddr, cnt[0],
                          handles, &currHandles, maxOutstandingXfers, yieldFn,
-                         typeIndex, commID, ln, fn);
+                         commID, ln, fn);
           srcaddr+=srcstr[0];
           dstaddr+=dststr[0];
         }
@@ -379,7 +378,7 @@ void get_strd_common(void* dstaddr_arg, size_t* dststrides, int32_t srclocale,
                          dstaddr+dstdisp[j], srclocale, srcaddr+srcdisp[j],
                          cnt[0],
                          handles, &currHandles, maxOutstandingXfers, yieldFn,
-                         typeIndex, commID, ln, fn);
+                         commID, ln, fn);
           break;
 
         } else {  //ELSE 1

--- a/runtime/include/chpl-comm.h
+++ b/runtime/include/chpl-comm.h
@@ -118,15 +118,15 @@ void chpl_comm_taskCallFTable(chpl_fn_int_t fid,      // ftable[] entry to call
 // wait for the GET to complete. The destination buffer must not be modified
 // before the request completes (after waiting on the returned handle)
 chpl_comm_nb_handle_t chpl_comm_get_nb(void* addr, c_nodeid_t node, void* raddr,
-                                       size_t size, int32_t typeIndex,
-                                       int32_t commID, int ln, int32_t fn);
+                                       size_t size, int32_t commID,
+                                       int ln, int32_t fn);
 
 // Do a PUT in a nonblocking fashion, returning a handle which can be used to
 // wait for the PUT to complete. The source buffer must not be modified before
 // the request completes (after waiting on the returned handle)
 chpl_comm_nb_handle_t chpl_comm_put_nb(void *addr, c_nodeid_t node, void* raddr,
-                                       size_t size, int32_t typeIndex,
-                                       int32_t commID, int ln, int32_t fn);
+                                       size_t size, int32_t commID,
+                                       int ln, int32_t fn);
 
 // Returns nonzero iff the handle has already been waited for and has
 // been cleared out in a call to chpl_comm_{wait,try}_some.
@@ -339,13 +339,7 @@ void chpl_comm_broadcast_global_vars(int numGlobals);
 // values, and during execution to do things like enabling and disabling
 // memory tracking/reporting and comm diagnostics.
 //
-// The third argument, 'tid' (type ID) is intended for use when
-// targeting heterogeneous architectures where byte swapping may be
-// required rather than just copying the 'size' bytes.  It is not
-// currently in use on any platforms, but is being retained in the
-// event that we wish to re-enable this capability in the future.
-// 
-void chpl_comm_broadcast_private(int id, size_t size, int32_t tid);
+void chpl_comm_broadcast_private(int id, size_t size);
 
 //
 // Barrier for synchronization between all top-level locales; currently
@@ -391,9 +385,8 @@ void chpl_comm_exit(int all, int status);
 //   address is arbitrary
 //   size and locale are part of p
 //
-void  chpl_comm_put(void* addr, c_nodeid_t node, void* raddr,
-                    size_t size, int32_t typeIndex,
-                    int32_t commID, int ln, int32_t fn);
+void chpl_comm_put(void* addr, c_nodeid_t node, void* raddr,
+                   size_t size, int32_t commID, int ln, int32_t fn);
 
 //
 // get 'size' bytes of remote data at 'raddr' on locale 'locale' to
@@ -402,9 +395,8 @@ void  chpl_comm_put(void* addr, c_nodeid_t node, void* raddr,
 //   address is arbitrary
 //   size and locale are part of p
 //
-void  chpl_comm_get(void *addr, c_nodeid_t node, void* raddr,
-                    size_t size, int32_t typeIndex,
-                    int32_t commID, int ln, int32_t fn);
+void chpl_comm_get(void *addr, c_nodeid_t node, void* raddr,
+                    size_t size, int32_t commID, int ln, int32_t fn);
 
 //
 // put the number of elements pointed out by count array, with strides pointed
@@ -418,18 +410,18 @@ void  chpl_comm_get(void *addr, c_nodeid_t node, void* raddr,
 //   Proposal for Extending the UPC Memory Copy Library Functions and Supporting 
 //   Extensions to GASNet, Version 2.0. Author: Dan Bonachea 
 //
-void  chpl_comm_put_strd(void* dstaddr, size_t* dststrides, c_nodeid_t dstnode,
-                     void* srcaddr, size_t* srcstrides, size_t* count,
-                     int32_t stridelevels, size_t elemSize, int32_t typeIndex, 
-                     int32_t commID, int ln, int32_t fn);
+void chpl_comm_put_strd(void* dstaddr, size_t* dststrides, c_nodeid_t dstnode,
+                        void* srcaddr, size_t* srcstrides, size_t* count,
+                        int32_t stridelevels, size_t elemSize, int32_t commID,
+                        int ln, int32_t fn);
 
 //
 // same as chpl_comm_puts(), but do get instead
 //
-void  chpl_comm_get_strd(void* dstaddr, size_t* dststrides, c_nodeid_t srcnode,
-                     void* srcaddr, size_t* srcstrides, size_t* count,
-                     int32_t stridelevels, size_t elemSize, int32_t typeIndex, 
-                     int32_t commID, int ln, int32_t fn);
+void chpl_comm_get_strd(void* dstaddr, size_t* dststrides, c_nodeid_t srcnode,
+                        void* srcaddr, size_t* srcstrides, size_t* count,
+                        int32_t stridelevels, size_t elemSize, int32_t commID,
+                        int ln, int32_t fn);
 
 //
 // Runs a function f on a remote locale, passing it

--- a/runtime/include/chpl-comm.h
+++ b/runtime/include/chpl-comm.h
@@ -64,9 +64,6 @@ extern int const chpl_private_broadcast_table_len;
 
 extern void* const chpl_global_serialize_table[];
 
-extern const int chpl_heterogeneous;
-
-
 //
 // Comm layer-specific interface
 //

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -101,12 +101,4 @@ extern int64_t chpl_gen_main(chpl_main_argument* const _arg);
 /* used for config vars: */
 extern void CreateConfigVarTable(void);
 
-/* These are defined in _type_structure.c if
-   --gen-communicated-structures is true and are used by a
-   communication layer to query types of communicated buffers */
-extern chplType chpl_getFieldType(int typeNum, int fieldNum);
-extern size_t chpl_getFieldOffset(int typeNum, int fieldNum);
-extern size_t chpl_getFieldSize(int typeNum);
-extern const int chpl_max_fields_per_type;
-
 #endif

--- a/runtime/include/chpltypes.h
+++ b/runtime/include/chpltypes.h
@@ -64,45 +64,6 @@ static inline ptrdiff_t c_pointer_diff(void* a, void* b, ptrdiff_t eltSize) {
   return (((unsigned char*)a) - ((unsigned char*)b))/eltSize;
 }
 
-typedef enum {
-  CHPL_TYPE_chpl_bool,
-  CHPL_TYPE_chpl_bool8,
-  CHPL_TYPE_chpl_bool16,
-  CHPL_TYPE_chpl_bool32,
-  CHPL_TYPE_chpl_bool64,
-  CHPL_TYPE_enum,
-  CHPL_TYPE_int8_t,
-  CHPL_TYPE_int16_t,
-  CHPL_TYPE_int32_t,
-  CHPL_TYPE_int64_t,
-  CHPL_TYPE_uint8_t,
-  CHPL_TYPE_uint16_t,
-  CHPL_TYPE_uint32_t,
-  CHPL_TYPE_uint64_t,
-  CHPL_TYPE__real32,
-  CHPL_TYPE__real64,
-  CHPL_TYPE__imag32,
-  CHPL_TYPE__imag64,
-  CHPL_TYPE__complex64,
-  CHPL_TYPE__complex128,
-  CHPL_TYPE_chpl_string,
-  CHPL_TYPE_wide_string,
-  CHPL_TYPE__cfile,
-  CHPL_TYPE_chpl_task_list_p,
-  CHPL_TYPE__timevalue,
-  CHPL_TYPE_chpl_sync_aux_t,
-  CHPL_TYPE_chpl_single_aux_t,
-  CHPL_TYPE_chpl_taskID_t,
-  CHPL_TYPE__symbol,
-  CHPL_TYPE_CLASS_REFERENCE,
-  CHPL_TYPE_DONE
-} chplType;
-
-typedef struct _chpl_fieldType {
-  chplType type;
-  size_t offset;
-} chpl_fieldType;
-
 // This allocation of bits is arbitrary.
 // Seemingly, 64 bits is enough to represent both the node_id and sublocale_id
 // portions  of a locale ID, and an even split is a good first guess.

--- a/runtime/include/comm/ugni/chpl-comm-impl.h
+++ b/runtime/include/comm/ugni/chpl-comm-impl.h
@@ -62,17 +62,15 @@ chpl_bool chpl_comm_impl_regMemFree(void* p, size_t size);
 // Unordered ops
 //
 void chpl_comm_get_unordered(void *addr, c_nodeid_t node, void* raddr,
-                             size_t size, int32_t typeIndex, int32_t commID,
-                             int ln, int32_t fn);
+                             size_t size, int32_t commID, int ln, int32_t fn);
 
 void chpl_comm_put_unordered(void* addr, c_nodeid_t locale, void* raddr,
-                             size_t size, int32_t typeIndex,
-                             int32_t commID, int ln, int32_t fn);
+                             size_t size, int32_t commID, int ln, int32_t fn);
 
 void chpl_comm_getput_unordered(c_nodeid_t dst_locale, void* dst_addr,
                                 c_nodeid_t src_locale, void* src_addr,
-                                size_t size, int32_t typeIndex,
-                                int32_t commID, int ln, int32_t fn);
+                                size_t size, int32_t commID, 
+                                int ln, int32_t fn);
 
 void chpl_comm_getput_unordered_task_fence(void);
 

--- a/runtime/src/chpl-cache.c
+++ b/runtime/src/chpl-cache.c
@@ -1736,7 +1736,7 @@ void flush_entry(struct rdcache_s* cache, struct cache_entry_s* entry, int op,
             chpl_comm_put_nb(page+start, /*local addr*/
                              entry->base.node,
                              (void*)(entry->raddr+start),
-                             got_len /*size*/, -1/*typei*/,
+                             got_len /*size*/,
                              CHPL_COMM_UNKNOWN_ID, -1, 0);
 
           // Save the handle in the list of pending requests.
@@ -2475,7 +2475,7 @@ void cache_get(struct rdcache_s* cache,
     handle = 
       chpl_comm_get_nb(page+(ra_line-ra_page), /*local addr*/
                        node, (void*) ra_line,
-                       ra_line_end - ra_line /*size*/, -1/*typei*/,
+                       ra_line_end - ra_line /*size*/,
                        commID, ln, fn);
 #ifdef TIME
     clock_gettime(CLOCK_REALTIME, &start_get2);
@@ -2788,8 +2788,7 @@ void chpl_cache_fence(int acquire, int release, int ln, int32_t fn)
 }
 
 void chpl_cache_comm_put(void* addr, c_nodeid_t node, void* raddr,
-                         size_t size, int32_t typeIndex,
-                         int32_t commID, int ln, int32_t fn)
+                         size_t size, int32_t commID, int ln, int32_t fn)
 {
   //printf("put len %d node %d raddr %p\n", (int) len * elemSize, node, raddr);
   struct rdcache_s* cache = tls_cache_remote_data();
@@ -2812,8 +2811,7 @@ void chpl_cache_comm_put(void* addr, c_nodeid_t node, void* raddr,
 }
 
 void chpl_cache_comm_get(void *addr, c_nodeid_t node, void* raddr,
-                         size_t size, int32_t typeIndex,
-                         int32_t commID, int ln, int32_t fn)
+                         size_t size, int32_t commID, int ln, int32_t fn)
 {
   //printf("get len %d node %d raddr %p\n", (int) len * elemSize, node, raddr);
   struct rdcache_s* cache = tls_cache_remote_data();
@@ -2836,8 +2834,7 @@ void chpl_cache_comm_get(void *addr, c_nodeid_t node, void* raddr,
 }
 
 void chpl_cache_comm_prefetch(c_nodeid_t node, void* raddr,
-                              size_t size, int32_t typeIndex,
-                              int ln, int32_t fn)
+                              size_t size, int ln, int32_t fn)
 {
   struct rdcache_s* cache = tls_cache_remote_data();
   chpl_cache_taskPrvData_t* task_local = task_private_cache_data();
@@ -2851,8 +2848,7 @@ void chpl_cache_comm_prefetch(c_nodeid_t node, void* raddr,
 void chpl_cache_comm_get_strd(void *addr, void *dststr, c_nodeid_t node,
                               void *raddr, void *srcstr, void *count,
                               int32_t strlevels, size_t elemSize,
-                              int32_t typeIndex, int32_t commID,
-                              int ln, int32_t fn) {
+                              int32_t commID, int ln, int32_t fn) {
   TRACE_PRINT(("%d: in chpl_cache_comm_get_strd\n", chpl_nodeID));
   // do a full fence - so that:
   // 1) any pending writes are completed (in case they were to the
@@ -2864,13 +2860,12 @@ void chpl_cache_comm_get_strd(void *addr, void *dststr, c_nodeid_t node,
   chpl_cache_fence(1, 1, ln, fn);
   // do the strided get.
   chpl_comm_get_strd(addr, dststr, node, raddr, srcstr, count, strlevels,
-                     elemSize, typeIndex, commID, ln, fn);
+                     elemSize, commID, ln, fn);
 }
 void chpl_cache_comm_put_strd(void *addr, void *dststr, c_nodeid_t node,
                               void *raddr, void *srcstr, void *count,
                               int32_t strlevels, size_t elemSize,
-                              int32_t typeIndex, int32_t commID,
-                              int ln, int32_t fn) {
+                              int32_t commID, int ln, int32_t fn) {
   TRACE_PRINT(("%d: in chpl_cache_comm_put_strd\n", chpl_nodeID));
   // do a full fence - so that:
   // 1) any pending writes are completed (in case they were to the
@@ -2882,7 +2877,7 @@ void chpl_cache_comm_put_strd(void *addr, void *dststr, c_nodeid_t node,
   chpl_cache_fence(1, 1, ln, fn);
   // do the strided put.
   chpl_comm_put_strd(addr, dststr, node, raddr, srcstr, count, strlevels,
-                     elemSize, typeIndex, commID, ln, fn);
+                     elemSize, commID, ln, fn);
 }
 
 // This is for debugging.

--- a/runtime/src/chpl-comm.c
+++ b/runtime/src/chpl-comm.c
@@ -80,8 +80,7 @@ void chpl_comm_broadcast_global_vars(int numGlobals) {
     size_t size = chpl_numGlobalsOnHeap * sizeof(*buf);
     buf = (wide_ptr_t*)
           chpl_mem_alloc(size, CHPL_RT_MD_COMM_PER_LOC_INFO, 0, 0);
-    chpl_comm_get(buf, 0, buf_on_0, size,
-                  -1, CHPL_COMM_UNKNOWN_ID, 0, -1);
+    chpl_comm_get(buf, 0, buf_on_0, size, CHPL_COMM_UNKNOWN_ID, 0, -1);
     for (int i = 0; i < chpl_numGlobalsOnHeap; i++) {
       *chpl_globals_registry[i] = buf[i];
     }

--- a/runtime/src/chpl-string.c
+++ b/runtime/src/chpl-string.c
@@ -34,7 +34,7 @@ chpl_wide_string_copy(chpl____wide_chpl_string* x, int32_t lineno, int32_t filen
 
   chpl_string s = chpl_mem_alloc(x->size, CHPL_RT_MD_STR_COPY_DATA, lineno, filename);
   chpl_gen_comm_get((void *)s, chpl_rt_nodeFromLocaleID(x->locale),
-                    (void *)(x->addr), x->size, -1, CHPL_COMM_UNKNOWN_ID,
+                    (void *)(x->addr), x->size, CHPL_COMM_UNKNOWN_ID,
                     lineno, filename);
   return s;
 }

--- a/runtime/src/comm/gasnet/comm-gasnet.c
+++ b/runtime/src/comm/gasnet/comm-gasnet.c
@@ -376,7 +376,7 @@ static void fork_large_wrapper(large_fork_task_t* f) {
   // GET the bundle data
   // TODO: This could get only the payload
   chpl_comm_get(arg, caller, arg_on_caller, bundle_size_on_caller,
-                -1 /*typeIndex: unused*/, CHPL_COMM_UNKNOWN_ID, 0, CHPL_FILE_IDX_FORK_LARGE);
+                CHPL_COMM_UNKNOWN_ID, 0, CHPL_FILE_IDX_FORK_LARGE);
 
   // Call the on body function
   chpl_ftable_call(fid, arg);
@@ -456,7 +456,7 @@ static void fork_nb_large_wrapper(large_fork_task_t* f) {
 
   // GET the bundle data
   chpl_comm_get(arg, caller, arg_on_caller, bundle_size_on_caller,
-                -1 /*typeIndex: unused*/, CHPL_COMM_UNKNOWN_ID, 0, CHPL_FILE_IDX_FORK_LARGE);
+                CHPL_COMM_UNKNOWN_ID, 0, CHPL_FILE_IDX_FORK_LARGE);
 
   // Signal that the allocated region can be freed
   GASNET_Safe(gasnet_AMRequestShort2(caller, FREE,
@@ -595,8 +595,8 @@ static gasnet_handlerentry_t ftable[] = {
 // Chapel interface starts here
 //
 chpl_comm_nb_handle_t chpl_comm_put_nb(void *addr, c_nodeid_t node, void* raddr,
-                                       size_t size, int32_t typeIndex,
-                                       int32_t commID, int ln, int32_t fn)
+                                       size_t size, int32_t commID,
+                                       int ln, int32_t fn)
 {
   gasnet_handle_t ret;
   int remote_in_segment;
@@ -616,7 +616,7 @@ chpl_comm_nb_handle_t chpl_comm_put_nb(void *addr, c_nodeid_t node, void* raddr,
 #endif
 
   if(!remote_in_segment) {
-    chpl_comm_put(addr, node, raddr, size, typeIndex, commID, ln, fn);
+    chpl_comm_put(addr, node, raddr, size, commID, ln, fn);
     ret = NULL;
     return (chpl_comm_nb_handle_t) ret;
   }
@@ -629,8 +629,8 @@ chpl_comm_nb_handle_t chpl_comm_put_nb(void *addr, c_nodeid_t node, void* raddr,
 }
 
 chpl_comm_nb_handle_t chpl_comm_get_nb(void* addr, c_nodeid_t node, void* raddr,
-                                       size_t size, int32_t typeIndex,
-                                       int32_t commID, int ln, int32_t fn)
+                                       size_t size, int32_t commID,
+                                       int ln, int32_t fn)
 {
   gasnet_handle_t ret;
   int remote_in_segment;
@@ -650,7 +650,7 @@ chpl_comm_nb_handle_t chpl_comm_get_nb(void* addr, c_nodeid_t node, void* raddr,
 #endif
 
   if(!remote_in_segment) {
-    chpl_comm_get(addr, node, raddr, size, typeIndex, commID, ln, fn);
+    chpl_comm_get(addr, node, raddr, size, commID, ln, fn);
     ret = NULL;
     return (chpl_comm_nb_handle_t) ret;
   }
@@ -930,7 +930,7 @@ wide_ptr_t* chpl_comm_broadcast_global_vars_helper(void) {
   }
 }
 
-void chpl_comm_broadcast_private(int id, size_t size, int32_t tid) {
+void chpl_comm_broadcast_private(int id, size_t size) {
   int  node, offset;
   int  payloadSize = size + sizeof(priv_bcast_t);
   done_t* done;
@@ -1041,8 +1041,7 @@ void chpl_comm_exit(int all, int status) {
 }
 
 void  chpl_comm_put(void* addr, c_nodeid_t node, void* raddr,
-                    size_t size, int32_t typeIndex,
-                    int32_t commID, int ln, int32_t fn) {
+                    size_t size, int32_t commID, int ln, int32_t fn) {
   int remote_in_segment;
 
   if (chpl_nodeID == node) {
@@ -1117,8 +1116,7 @@ void  chpl_comm_put(void* addr, c_nodeid_t node, void* raddr,
 ////GASNET - define GASNET_E_ PUTGET always REMOTE
 ////GASNET - look at GASNET tools at top of README.tools has atomic counters
 void  chpl_comm_get(void* addr, c_nodeid_t node, void* raddr,
-                    size_t size, int32_t typeIndex,
-                    int32_t commID, int ln, int32_t fn) {
+                    size_t size, int32_t commID, int ln, int32_t fn) {
   int remote_in_segment;
 
   if (chpl_nodeID == node) {
@@ -1240,8 +1238,8 @@ void  chpl_comm_get(void* addr, c_nodeid_t node, void* raddr,
 //
 void  chpl_comm_get_strd(void* dstaddr, size_t* dststrides, c_nodeid_t srcnode_id, 
                          void* srcaddr, size_t* srcstrides, size_t* count,
-                         int32_t stridelevels, size_t elemSize, int32_t typeIndex, 
-                         int32_t commID, int ln, int32_t fn) {
+                         int32_t stridelevels, size_t elemSize, int32_t commID,
+                         int ln, int32_t fn) {
   int i;
   const size_t strlvls = (size_t)stridelevels;
   const gasnet_node_t srcnode = (gasnet_node_t)srcnode_id;
@@ -1286,8 +1284,8 @@ void  chpl_comm_get_strd(void* dstaddr, size_t* dststrides, c_nodeid_t srcnode_i
 // See the comment for chpl_comm_gets().
 void  chpl_comm_put_strd(void* dstaddr, size_t* dststrides, c_nodeid_t dstnode_id, 
                          void* srcaddr, size_t* srcstrides, size_t* count,
-                         int32_t stridelevels, size_t elemSize, int32_t typeIndex, 
-                         int32_t commID, int ln, int32_t fn) {
+                         int32_t stridelevels, size_t elemSize, int32_t commID, 
+                         int ln, int32_t fn) {
   int i;
   const size_t strlvls = (size_t)stridelevels;
   const gasnet_node_t dstnode = (gasnet_node_t)dstnode_id;

--- a/runtime/src/comm/none/comm-none.c
+++ b/runtime/src/comm/none/comm-none.c
@@ -58,8 +58,8 @@ static int mysystem(const char* command, const char* description,
 
 // Chapel interface
 chpl_comm_nb_handle_t chpl_comm_put_nb(void *addr, c_nodeid_t node, void* raddr,
-                                       size_t size, int32_t typeIndex,
-                                       int32_t commID, int ln, int32_t fn)
+                                       size_t size, int32_t commID,
+                                       int ln, int32_t fn)
 {
   assert(node == 0);
   chpl_memmove(raddr, addr, size);
@@ -67,8 +67,8 @@ chpl_comm_nb_handle_t chpl_comm_put_nb(void *addr, c_nodeid_t node, void* raddr,
 }
 
 chpl_comm_nb_handle_t chpl_comm_get_nb(void* addr, c_nodeid_t node, void* raddr,
-                                       size_t size, int32_t typeIndex,
-                                       int32_t commID, int ln, int32_t fn)
+                                       size_t size, int32_t commID,
+                                       int ln, int32_t fn)
 {
   assert(node == 0);
   chpl_memmove(addr, raddr, size);
@@ -135,7 +135,7 @@ void chpl_comm_rollcall(void) {
 
 wide_ptr_t* chpl_comm_broadcast_global_vars_helper(void) { return NULL; }
 
-void chpl_comm_broadcast_private(int id, size_t size, int32_t tid) { }
+void chpl_comm_broadcast_private(int id, size_t size) { }
 
 void chpl_comm_barrier(const char *msg) { }
 
@@ -144,16 +144,14 @@ void chpl_comm_pre_task_exit(int all) { }
 void chpl_comm_exit(int all, int status) { }
 
 void  chpl_comm_put(void* addr, c_nodeid_t node, void* raddr,
-                    size_t size, int32_t typeIndex,
-                    int32_t commID, int ln, int32_t fn) {
+                    size_t size, int32_t commID, int ln, int32_t fn) {
   assert(node==0);
 
   memmove(raddr, addr, size);
 }
 
 void  chpl_comm_get(void* addr, c_nodeid_t node, void* raddr,
-                    size_t size, int32_t typeIndex,
-                    int32_t commID, int ln, int32_t fn) {
+                    size_t size, int32_t commID, int ln, int32_t fn) {
   assert(node==0);
 
   memmove(addr, raddr, size);
@@ -161,28 +159,28 @@ void  chpl_comm_get(void* addr, c_nodeid_t node, void* raddr,
 
 void  chpl_comm_put_strd(void* dstaddr_arg, size_t* dststrides, c_nodeid_t dstnode,
                          void* srcaddr_arg, size_t* srcstrides, size_t* count,
-                         int32_t stridelevels, size_t elemSize, int32_t typeIndex,
-                         int32_t commID, int ln, int32_t fn)
+                         int32_t stridelevels, size_t elemSize, int32_t commID, 
+                         int ln, int32_t fn)
 {
   assert(dstnode==0);
   put_strd_common(dstaddr_arg, dststrides, dstnode,
                   srcaddr_arg, srcstrides,
                   count, stridelevels, elemSize,
                   1, NULL, // "nb" xfers block, so no need for yield
-                  typeIndex, commID, ln, fn);
+                  commID, ln, fn);
 }
 
 void  chpl_comm_get_strd(void* dstaddr_arg, size_t* dststrides, c_nodeid_t srcnode,
                          void* srcaddr_arg, size_t* srcstrides, size_t* count,
-                         int32_t stridelevels, size_t elemSize, int32_t typeIndex,
-                         int32_t commID, int ln, int32_t fn)
+                         int32_t stridelevels, size_t elemSize, int32_t commID, 
+                         int ln, int32_t fn)
 {
   assert(srcnode==0);
   get_strd_common(dstaddr_arg, dststrides, srcnode,
                   srcaddr_arg, srcstrides,
                   count, stridelevels, elemSize,
                   1, NULL, // "nb" xfers block, so no need for yield
-                  typeIndex, commID, ln, fn);
+                  commID, ln, fn);
 }
 
 typedef struct {

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -989,7 +989,7 @@ void init_broadcast_private(void) {
 }
 
 
-void chpl_comm_broadcast_private(int id, size_t size, int32_t tid) {
+void chpl_comm_broadcast_private(int id, size_t size) {
   for (int i = 0; i < chpl_numNodes; i++) {
     if (i != chpl_nodeID) {
       (void) ofi_put(chpl_rt_priv_bcast_tab[id], i,
@@ -2182,18 +2182,16 @@ void amSendDone(struct chpl_comm_bundleData_base_t* b,
 
 chpl_comm_nb_handle_t chpl_comm_put_nb(void *addr, c_nodeid_t node,
                                        void* raddr, size_t size,
-                                       int32_t typeIndex, int32_t commID,
-                                       int ln, int32_t fn) {
-  chpl_comm_put(addr, node, raddr, size, typeIndex, commID, ln, fn);
+                                       int32_t commID, int ln, int32_t fn) {
+  chpl_comm_put(addr, node, raddr, size, commID, ln, fn);
   return NULL;
 }
 
 
 chpl_comm_nb_handle_t chpl_comm_get_nb(void* addr, c_nodeid_t node,
                                        void* raddr, size_t size,
-                                       int32_t typeIndex, int32_t commID,
-                                       int ln, int32_t fn) {
-  chpl_comm_get(addr, node, raddr, size, typeIndex, commID, ln, fn);
+                                       int32_t commID, int ln, int32_t fn) {
+  chpl_comm_get(addr, node, raddr, size, commID, ln, fn);
   return NULL;
 }
 
@@ -2230,8 +2228,7 @@ int chpl_comm_try_nb_some(chpl_comm_nb_handle_t* h, size_t nhandles) {
 
 
 void chpl_comm_put(void* addr, c_nodeid_t node, void* raddr,
-                   size_t size, int32_t typeIndex, int32_t commID,
-                   int ln, int32_t fn) {
+                   size_t size, int32_t commID, int ln, int32_t fn) {
   //
   // Sanity checks, self-communication.
   //
@@ -2259,8 +2256,7 @@ void chpl_comm_put(void* addr, c_nodeid_t node, void* raddr,
 
 
 void chpl_comm_get(void* addr, int32_t node, void* raddr,
-                   size_t size, int32_t typeIndex, int32_t commID,
-                   int ln, int32_t fn) {
+                   size_t size, int32_t commID, int ln, int32_t fn) {
   //
   // Sanity checks, self-communication.
   //
@@ -2291,14 +2287,13 @@ void chpl_comm_put_strd(void* dstaddr_arg, size_t* dststrides,
                         c_nodeid_t dstnode,
                         void* srcaddr_arg, size_t* srcstrides,
                         size_t* count, int32_t stridelevels, size_t elemSize,
-                        int32_t typeIndex, int32_t commID,
-                        int ln, int32_t fn) {
+                        int32_t commID, int ln, int32_t fn) {
   put_strd_common(dstaddr_arg, dststrides,
                   dstnode,
                   srcaddr_arg, srcstrides,
                   count, stridelevels, elemSize,
                   1, NULL,
-                  typeIndex, commID, ln, fn);
+                  commID, ln, fn);
 }
 
 
@@ -2306,14 +2301,13 @@ void chpl_comm_get_strd(void* dstaddr_arg, size_t* dststrides,
                         c_nodeid_t srcnode,
                         void* srcaddr_arg, size_t* srcstrides, size_t* count,
                         int32_t stridelevels, size_t elemSize,
-                        int32_t typeIndex, int32_t commID,
-                        int ln, int32_t fn) {
+                        int32_t commID, int ln, int32_t fn) {
   get_strd_common(dstaddr_arg, dststrides,
                   srcnode,
                   srcaddr_arg, srcstrides,
                   count, stridelevels, elemSize,
                   1, NULL,
-                  typeIndex, commID, ln, fn);
+                  commID, ln, fn);
 }
 
 

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -3890,7 +3890,7 @@ wide_ptr_t* chpl_comm_broadcast_global_vars_helper() {
 }
 
 
-void chpl_comm_broadcast_private(int id, size_t size, int32_t tid)
+void chpl_comm_broadcast_private(int id, size_t size)
 {
   int i;
 
@@ -5262,8 +5262,7 @@ void consume_all_outstanding_cq_events(int cdi)
 
 
 void chpl_comm_put(void* addr, c_nodeid_t locale, void* raddr,
-                   size_t size, int32_t typeIndex,
-                   int32_t commID, int ln, int32_t fn)
+                   size_t size, int32_t commID, int ln, int32_t fn)
 {
   DBG_P_LP(DBGF_IFACE|DBGF_GETPUT, "IFACE chpl_comm_put(%p, %d, %p, %zd)",
            addr, (int) locale, raddr, size);
@@ -5746,8 +5745,8 @@ void do_nic_amo_nf_V(int v_len, uint64_t* opnd1_v, c_nodeid_t* locale_v,
 
 void chpl_comm_getput_unordered(c_nodeid_t dst_locale, void* dst_addr,
                                 c_nodeid_t src_locale, void* src_addr,
-                                size_t size, int32_t typeIndex,
-                                int32_t commID, int ln, int32_t fn)
+                                size_t size, int32_t commID,
+                                int ln, int32_t fn)
 {
   assert(dst_addr != NULL);
   assert(src_addr != NULL);
@@ -5761,30 +5760,29 @@ void chpl_comm_getput_unordered(c_nodeid_t dst_locale, void* dst_addr,
   }
 
   if (dst_locale == chpl_nodeID) {
-    chpl_comm_get_unordered(dst_addr, src_locale, src_addr, size, typeIndex, commID, ln, fn);
+    chpl_comm_get_unordered(dst_addr, src_locale, src_addr, size, commID, ln, fn);
   } else if (src_locale == chpl_nodeID) {
-    chpl_comm_put_unordered(src_addr, dst_locale, dst_addr, size, typeIndex, commID, ln, fn);
+    chpl_comm_put_unordered(src_addr, dst_locale, dst_addr, size, commID, ln, fn);
   } else {
     // TODO use unordered ops in this case? Would have to ensure we always
     // flush GET buffer before the PUT buffer
     if (size <= MAX_UNORDERED_TRANS_SZ) {
       char buf[MAX_UNORDERED_TRANS_SZ];
-      chpl_comm_get(buf, src_locale, src_addr, size, typeIndex, commID, ln, fn);
-      chpl_comm_put(buf, dst_locale, dst_addr, size, typeIndex, commID, ln, fn);
+      chpl_comm_get(buf, src_locale, src_addr, size, commID, ln, fn);
+      chpl_comm_put(buf, dst_locale, dst_addr, size, commID, ln, fn);
     } else {
       // Note, we do not expect this case to trigger, but if it does we may
       // want to do on-stmt to src locale and then transfer
       char* buf = chpl_mem_alloc(size, CHPL_RT_MD_COMM_PER_LOC_INFO, 0, 0);
-      chpl_comm_get(buf, src_locale, src_addr, size, typeIndex, commID, ln, fn);
-      chpl_comm_put(buf, dst_locale, dst_addr, size, typeIndex, commID, ln, fn);
+      chpl_comm_get(buf, src_locale, src_addr, size, commID, ln, fn);
+      chpl_comm_put(buf, dst_locale, dst_addr, size, commID, ln, fn);
       chpl_mem_free(buf, 0, 0);
     }
   }
 }
 
 void chpl_comm_get_unordered(void* addr, c_nodeid_t locale, void* raddr,
-                             size_t size, int32_t typeIndex, int32_t commID,
-                             int ln, int32_t fn)
+                             size_t size, int32_t commID, int ln, int32_t fn)
 {
   DBG_P_LP(DBGF_IFACE|DBGF_GETPUT, "IFACE chpl_comm_get_unordered(%p, %d, %p, %zd)",
            addr, (int) locale, raddr, size);
@@ -5814,8 +5812,7 @@ void chpl_comm_get_unordered(void* addr, c_nodeid_t locale, void* raddr,
 }
 
 void chpl_comm_put_unordered(void* addr, c_nodeid_t locale, void* raddr,
-                             size_t size, int32_t typeIndex,
-                             int32_t commID, int ln, int32_t fn)
+                             size_t size, int32_t commID, int ln, int32_t fn)
 
 {
   DBG_P_LP(DBGF_IFACE|DBGF_GETPUT, "IFACE chpl_comm_put_unordered(%p, %d, %p, %zd)",
@@ -5851,8 +5848,7 @@ void chpl_comm_getput_unordered_task_fence(void) {
 
 
 void chpl_comm_get(void* addr, c_nodeid_t locale, void* raddr,
-                   size_t size, int32_t typeIndex,
-                   int32_t commID, int ln, int32_t fn)
+                   size_t size, int32_t commID, int ln, int32_t fn)
 {
   DBG_P_LP(DBGF_IFACE|DBGF_GETPUT, "IFACE chpl_comm_get(%p, %d, %p, %zd)",
            addr, (int) locale, raddr, size);
@@ -6262,7 +6258,7 @@ void chpl_comm_put_strd(void* dstaddr_arg, size_t* dststrides,
                         int32_t dstlocale,
                         void* srcaddr_arg, size_t* srcstrides,
                         size_t* count, int32_t stridelevels, size_t elemSize,
-                        int32_t typeIndex, int32_t commID, int ln, int32_t fn)
+                        int32_t commID, int ln, int32_t fn)
 {
   PERFSTATS_INC(put_strd_cnt);
   put_strd_common(dstaddr_arg, dststrides,
@@ -6270,7 +6266,7 @@ void chpl_comm_put_strd(void* dstaddr_arg, size_t* dststrides,
                   srcaddr_arg, srcstrides,
                   count, stridelevels, elemSize,
                   strd_maxHandles, local_yield,
-                  typeIndex, commID, ln, fn);
+                  commID, ln, fn);
 }
 
 
@@ -6278,7 +6274,7 @@ void chpl_comm_get_strd(void* dstaddr_arg, size_t* dststrides,
                         int32_t srclocale,
                         void* srcaddr_arg, size_t* srcstrides,
                         size_t* count, int32_t stridelevels, size_t elemSize,
-                        int32_t typeIndex, int32_t commID, int ln, int32_t fn)
+                        int32_t commID, int ln, int32_t fn)
 {
   PERFSTATS_INC(get_strd_cnt);
   get_strd_common(dstaddr_arg, dststrides,
@@ -6286,7 +6282,7 @@ void chpl_comm_get_strd(void* dstaddr_arg, size_t* dststrides,
                   srcaddr_arg, srcstrides,
                   count, stridelevels, elemSize,
                   strd_maxHandles, local_yield,
-                  typeIndex, commID, ln, fn);
+                  commID, ln, fn);
 }
 
 
@@ -6295,8 +6291,7 @@ void chpl_comm_get_strd(void* dstaddr_arg, size_t* dststrides,
 //
 chpl_comm_nb_handle_t chpl_comm_get_nb(void* addr, c_nodeid_t locale,
                                        void* raddr, size_t size,
-                                       int32_t typeIndex, int32_t commID,
-                                       int ln, int32_t fn)
+                                       int32_t commID, int ln, int32_t fn)
 {
   mem_region_t*          local_mr;
   mem_region_t*          remote_mr;
@@ -6409,8 +6404,7 @@ chpl_comm_nb_handle_t chpl_comm_get_nb(void* addr, c_nodeid_t locale,
 
 chpl_comm_nb_handle_t chpl_comm_put_nb(void* addr, c_nodeid_t locale,
                                        void* raddr, size_t size,
-                                       int32_t typeIndex, int32_t commID,
-                                       int ln, int32_t fn)
+                                       int32_t commID, int ln, int32_t fn)
 {
   DBG_P_LP(DBGF_IFACE|DBGF_GETPUT, "IFACE chpl_comm_put_nb(%p, %d, %p, %zd)",
            addr, (int) locale, raddr, size);
@@ -6420,7 +6414,7 @@ chpl_comm_nb_handle_t chpl_comm_put_nb(void* addr, c_nodeid_t locale,
   // it do a real nonblocking implementation, but right now we don't
   // have time.
   //
-  chpl_comm_put(addr, locale, raddr, size, typeIndex, commID, ln, fn);
+  chpl_comm_put(addr, locale, raddr, size, commID, ln, fn);
   return NULL;
 
 #if 0
@@ -8414,7 +8408,7 @@ void chpl_comm_statsReport(chpl_bool sum_over_locales)
     sum = chpl_comm_pstats;
     for (int li = 0; li < chpl_numNodes; li++) {
       if (li != chpl_nodeID) {
-        chpl_comm_get(&ps, li, &chpl_comm_pstats, sizeof(ps), -1, CHPL_COMM_UNKNOWN_ID, 0, -1);
+        chpl_comm_get(&ps, li, &chpl_comm_pstats, sizeof(ps), CHPL_COMM_UNKNOWN_ID, 0, -1);
 #define _PSV_SUM(psv) _PSV_ADD_FUNC(&sum.psv, _PSV_LD_FUNC(&ps.psv));
         PERFSTATS_DO_ALL(_PSV_SUM);
 #undef _PSV_SUM

--- a/runtime/src/qio/bulkget.c
+++ b/runtime/src/qio/bulkget.c
@@ -39,8 +39,7 @@ qbytes_t* bulk_get_bytes(int64_t src_locale, qbytes_t* src_addr)
 
   // First, get the length and local pointer to the bytes.
   chpl_gen_comm_get(&tmp, src_locale, src_addr, sizeof(qbytes_t),
-                    CHPL_TYPE_int64_t, CHPL_COMM_UNKNOWN_ID,
-                    -1, CHPL_FILE_IDX_INTERNAL);
+                    CHPL_COMM_UNKNOWN_ID, -1, CHPL_FILE_IDX_INTERNAL);
   src_len = tmp.len;
   src_data = tmp.data;
 
@@ -54,7 +53,7 @@ qbytes_t* bulk_get_bytes(int64_t src_locale, qbytes_t* src_addr)
   // Next, get the data itself.
   if( src_data ) {
     chpl_gen_comm_get(ret->data, src_locale, src_data,
-                      sizeof(uint8_t) * src_len, CHPL_TYPE_uint8_t,
+                      sizeof(uint8_t) * src_len,
                       CHPL_COMM_UNKNOWN_ID, -1, CHPL_FILE_IDX_INTERNAL);
   }
 
@@ -91,7 +90,7 @@ qioerr bulk_put_buffer(int64_t dst_locale, void* dst_addr, int64_t dst_len,
     chpl_gen_comm_put( iov[i].iov_base,
                        dst_locale,
                        PTR_ADDBYTES(dst_addr, j),
-                       sizeof(uint8_t)*iov[i].iov_len, CHPL_TYPE_uint8_t,
+                       sizeof(uint8_t)*iov[i].iov_len,
                        CHPL_COMM_UNKNOWN_ID, -1, CHPL_FILE_IDX_INTERNAL);
 
     j += iov[i].iov_len;

--- a/util/chpl-completion.bash
+++ b/util/chpl-completion.bash
@@ -67,7 +67,6 @@ _chpl ()
 --help \
 --help-env \
 --help-settings \
---heterogeneous \
 --home \
 --html \
 --html-chpl-home \


### PR DESCRIPTION
Most of this predates me, but my understanding is that `--heterogeneous`
was only used for the PVM comm layer, which was removed years ago in
1f1abb0fb0.  Parallel Virtual Machine (PVM) supported networks of very
heterogeneous machines (mix of OS, endianness, and other differences
were possible.) To support this our `--heterogeneous` support generated
structural information about types so we could translate across machine
types. PVM itself is long since defunct and I don't know of any networks
that would require this type of support again, so remove all support for
it. Even if we wanted to support this type of heterogeneous architecture
in the future, we’d probably want to consider doing any conversions in
Chapel module code above the runtime rather than within the runtime.

This removes a decent chunk of dead compiler code, and removes
`typeIndex` from the comm API. This is a relatively invasive change
since it touches a lot of the comm API so I spent a decent amount of
time making sure all callsites of modified functions were updated.
I also tested all comm layers:

 - [x] full std testing
 - [x] full gasnet testing
 - [x] release/examples ugni testing
 - [x] release/examples ofi testing
 - [x] hellos for gasnet-llvm