### PR TITLE
Setup and teardown hdfs for test in networking packages cron script.

### DIFF
--- a/util/cron/test-networking-packages.bash
+++ b/util/cron/test-networking-packages.bash
@@ -6,7 +6,25 @@ CWD=$(cd $(dirname $0) ; pwd)
 source $CWD/common.bash
 source $CWD/common-quickstart.bash
 
+export HADOOP_HOME=/data/cf/chapel/hadoop/$HOSTNAME
+export JAVA_HOME=/usr/lib64/jvm/jre
+export CLASSPATH=$(${HADOOP_HOME}/bin/hadoop classpath --glob)
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HADOOP_HOME/lib/native:$JAVA_HOME/lib:$JAVA_HOME/lib/amd64/server
+
+# remove storage directory root
+rm -rf /tmp/hadoop-chapelu/
+
+#reformat hdfs filesystem
+$HADOOP_HOME/bin/hdfs namenode -format test
+#start hdfs
+$HADOOP_HOME/sbin/start-dfs.sh
+$HADOOP_HOME/bin hdfs dfsadmin -safemode leave
+
+
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="networking-packages"
 export CHPL_NIGHTLY_TEST_DIRS="library/packages/Curl library/packages/HDFS"
 
 $CWD/nightly -cron ${nightly_args}
+
+#stop hdfs
+$HADOOP_HOME/sbin/stop-dfs.sh


### PR DESCRIPTION
Instead of setting up and tearing down HDFS inside the Jenkins configuration, as per discussion on the pull request for it we decided to move that logic into the cron script. This allows us to use the more general job format in JJB.

Verified manually on chapcs11.
```
chapelu@chapcs11 chapel (hdfs-setup) $ ./util/cron/test-networking-packages.bash 
2019-07-09 12:44:46 [INFO] gcc version: /data/cf/chapel/gcc-8.3.0/x86_64/bin/gcc
gcc (GCC) 8.3.0
Copyright (C) 2018 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

2019-07-09 12:44:46 [INFO] Starting ./util/cron/test-networking-packages.bash on chapcs11

[...]

[Test Summary - 190709.124603]
[Summary: #Successes = 18 | #Failures = 0 | #Futures = 0 | #Warnings = 0 ]
[Summary: #Passing Suppressions = 0 | #Passing Futures = 0 ]
[END]
```