### PR TITLE
Fix/refactor nonzero tracking in sparse domains

### DIFF
--- a/modules/dists/SparseBlockDist.chpl
+++ b/modules/dists/SparseBlockDist.chpl
@@ -113,6 +113,10 @@ class SparseBlockDom: BaseSparseDomImpl {
     }
   }
 
+  override proc getNNZ() {
+    return + reduce ([ld in locDoms] ld.mySparseBlock.size);
+  }
+
   // TODO: For some reason I have to make all the methods for these classes primary
   // rather than secondary methods.  This doesn't seem right, but I couldn't boil
   // it down to a smaller test case in the time I spent on it.

--- a/modules/dists/SparseBlockDist.chpl
+++ b/modules/dists/SparseBlockDist.chpl
@@ -125,7 +125,6 @@ class SparseBlockDom: BaseSparseDomImpl {
     on dist.dsiIndexToLocale(ind) {
       _retval = locDoms[dist.targetLocsIdx(ind)].dsiAdd(ind);
     }
-    nnz += _retval;
     return _retval;
   }
 
@@ -183,7 +182,6 @@ class SparseBlockDom: BaseSparseDomImpl {
       _totalAdded.add(_retval);
     }
     const _retval = _totalAdded.read();
-    nnz += _retval;
     return _retval;
   }
 
@@ -271,7 +269,6 @@ class SparseBlockDom: BaseSparseDomImpl {
   }
 
   override proc dsiClear() {
-    nnz = 0;
     coforall locDom in locDoms do
       on locDom do
         locDom.dsiClear();

--- a/modules/internal/ChapelDistribution.chpl
+++ b/modules/internal/ChapelDistribution.chpl
@@ -375,7 +375,7 @@ module ChapelDistribution {
 
   class BaseSparseDomImpl : BaseSparseDom {
 
-    var nnzDom = {1..nnz};
+    var nnzDom = {1..0};
 
     proc deinit() {
       // this is a bug workaround
@@ -432,6 +432,7 @@ module ChapelDistribution {
     // calculate new nnz and update it, (2) call this method, (3) add
     // indices
     inline proc _bulkGrow() {
+      const nnz  = getNNZ();
       if (nnz > nnzDom.size) {
         const _newNNZDomSize = (exp2(log2(nnz)+1.0)):int;
 
@@ -543,7 +544,11 @@ module ChapelDistribution {
     // inheritance of generic var fields.
     // var dist;
 
-    var nnz = 0; //: int;
+    /*var nnz = 0; //: int;*/
+
+    proc getNNZ(): int {
+      halt("nnz queried on base class");
+    }
 
     proc deinit() {
       // this is a bug workaround
@@ -569,8 +574,8 @@ module ChapelDistribution {
     //basic DSI functions
     proc dsiDim(d: int) { return parentDom.dim(d); }
     proc dsiDims() { return parentDom.dims(); }
-    proc dsiNumIndices { return nnz; }
-    proc dsiSize { return nnz; }
+    proc dsiNumIndices { return getNNZ(); }
+    proc dsiSize { return getNNZ(); }
     proc dsiLow { return parentDom.low; }
     proc dsiHigh { return parentDom.high; }
     proc dsiStride { return parentDom.stride; }

--- a/modules/internal/DefaultSparse.chpl
+++ b/modules/internal/DefaultSparse.chpl
@@ -27,6 +27,7 @@ module DefaultSparse {
 
   class DefaultSparseDom: BaseSparseDomImpl {
     var dist: unmanaged DefaultDist;
+    var _nnz = 0;
 
     pragma "local field"
     var indices: [nnzDom] index(rank, idxType);
@@ -41,24 +42,28 @@ module DefaultSparse {
       this.dist = dist;
     }
 
+    override proc getNNZ(): int{
+      return _nnz;
+    }
+
     proc dsiBuildArray(type eltType)
       return new unmanaged DefaultSparseArr(eltType=eltType, rank=rank, idxType=idxType,
                                   dom=_to_unmanaged(this));
 
     iter dsiIndsIterSafeForRemoving() {
-      for i in 1..nnz by -1 {
+      for i in 1.._nnz by -1 {
         yield indices(i);
       }
     }
 
     iter these() {
-      for i in 1..nnz {
+      for i in 1.._nnz {
         yield indices(i);
       }
     }
 
     iter these(param tag: iterKind) where tag == iterKind.standalone {
-      const numElems = nnz;
+      const numElems = _nnz;
       const numChunks = _computeNumChunks(numElems): numElems.type;
       if debugDefaultSparse {
         writeln("DefaultSparseDom standalone: ", numChunks, " chunks, ",
@@ -80,7 +85,7 @@ module DefaultSparse {
     }
 
     iter these(param tag: iterKind) where tag == iterKind.leader {
-      const numElems = nnz;
+      const numElems = _nnz;
       const numChunks = _computeNumChunks(numElems): numElems.type;
       if debugDefaultSparse then
         writeln("DefaultSparseDom leader: ", numChunks, " chunks, ",
@@ -120,9 +125,9 @@ module DefaultSparse {
       // sjd: unfortunate specialization for rank == 1
       //
       if rank == 1 && isTuple(ind) && ind.size == 1 then
-        return binarySearch(indices, ind(1), lo=1, hi=nnz);
+        return binarySearch(indices, ind(1), lo=1, hi=_nnz);
       else
-        return binarySearch(indices, ind, lo=1, hi=nnz);
+        return binarySearch(indices, ind, lo=1, hi=_nnz);
     }
 
     proc dsiMember(ind) { // ind should be verified to be index type
@@ -135,7 +140,7 @@ module DefaultSparse {
     }
 
     proc dsiLast {
-      return indices[nnz];
+      return indices[_nnz];
     }
 
     proc add_help(ind) {
@@ -149,14 +154,14 @@ module DefaultSparse {
         this.boundsCheck(ind);
 
       // increment number of nonzeroes
-      nnz += 1;
+      _nnz += 1;
 
       const oldNNZDomSize = nnzDom.size;
       // double nnzDom if we've outgrown it; grab current size otherwise
-      _grow(nnz);
+      _grow(_nnz);
 
       // shift indices up
-      for i in insertPt..nnz-1 by -1 {
+      for i in insertPt.._nnz-1 by -1 {
         indices(i+1) = indices(i);
       }
 
@@ -170,7 +175,7 @@ module DefaultSparse {
       // this second initialization of any new values in the array.
       // we could also eliminate the oldNNZDomSize variable
       for a in _arrs {
-        a.sparseShiftArray(insertPt..nnz-1, oldNNZDomSize+1..nnzDom.size);
+        a.sparseShiftArray(insertPt.._nnz-1, oldNNZDomSize+1..nnzDom.size);
       }
 
       return 1;
@@ -186,19 +191,19 @@ module DefaultSparse {
         halt("index not in domain: ", ind);
 
       // increment number of nonzeroes
-      nnz -= 1;
+      _nnz -= 1;
 
       // TODO: should halve nnzDom if we've outgrown it; grab current
       // size otherwise
       /*
       var oldNNZDomSize = nnzDomSize;
-      if (nnz > nnzDomSize) {
+      if (_nnz > nnzDomSize) {
         nnzDomSize = if (nnzDomSize) then 2*nnzDomSize else 1;
         nnzDom = [1..nnzDomSize];
       }
       */
       // shift indices up
-      for i in insertPt..nnz {
+      for i in insertPt.._nnz {
         indices(i) = indices(i+1);
       }
 
@@ -210,7 +215,7 @@ module DefaultSparse {
       // this second initialization of any new values in the array.
       // we could also eliminate the oldNNZDomSize variable
       for a in _arrs {
-        a.sparseShiftArrayBack(insertPt..nnz-1);
+        a.sparseShiftArrayBack(insertPt.._nnz-1);
       }
 
       return 1;
@@ -245,11 +250,11 @@ module DefaultSparse {
 
       bulkAdd_prepareInds(inds, dataSorted, isUnique, Sort.defaultComparator);
 
-      if nnz == 0 {
+      if _nnz == 0 {
 
         const dupCount = if isUnique then 0 else _countDuplicates(inds);
 
-        nnz += inds.size-dupCount;
+        _nnz += inds.size-dupCount;
         _bulkGrow();
 
         var indIdx = indices.domain.low;
@@ -274,8 +279,8 @@ module DefaultSparse {
       const (actualInsertPts, actualAddCnt) =
         __getActualInsertPts(this, inds, isUnique);
 
-      const oldnnz = nnz;
-      nnz += actualAddCnt;
+      const oldnnz = _nnz;
+      _nnz += actualAddCnt;
 
       //grow nnzDom if necessary
       _bulkGrow();
@@ -292,7 +297,7 @@ module DefaultSparse {
 
       var arrShiftMap: [{1..oldnnz}] int; //to map where data goes
 
-      for i in 1..nnz by -1 {
+      for i in 1.._nnz by -1 {
         if oldIndIdx >= 1 && i > newLoc {
           //shift from old values
           indices[i] = indices[oldIndIdx];
@@ -327,7 +332,7 @@ module DefaultSparse {
     }
 
     override proc dsiClear() {
-      nnz = 0;
+      _nnz = 0;
       // should we empty the domain too ?
       // nnzDom = {1..0};
     }
@@ -448,11 +453,11 @@ module DefaultSparse {
     }
 
     iter these() ref {
-      for i in 1..dom.nnz do yield data[i];
+      for i in 1..dom._nnz do yield data[i];
     }
 
     iter these(param tag: iterKind) ref where tag == iterKind.standalone {
-      const numElems = dom.nnz;
+      const numElems = dom._nnz;
       const numChunks = _computeNumChunks(numElems): numElems.type;
       if debugDefaultSparse {
         writeln("DefaultSparseArr standalone: ", numChunks, " chunks, ",
@@ -513,19 +518,19 @@ module DefaultSparse {
   proc DefaultSparseDom.dsiSerialWrite(f, printBrackets=true) {
     if (rank == 1) {
       if printBrackets then f <~> "{";
-      if (nnz >= 1) {
+      if (_nnz >= 1) {
         f <~> indices(1);
-        for i in 2..nnz {
+        for i in 2.._nnz {
           f <~> " " <~> indices(i);
         }
       }
       if printBrackets then f <~> "}";
     } else {
       if printBrackets then f <~> "{\n";
-      if (nnz >= 1) {
+      if (_nnz >= 1) {
         var prevInd = indices(1);
         f <~> " " <~> prevInd;
-        for i in 2..nnz {
+        for i in 2.._nnz {
           if (prevInd(1) != indices(i)(1)) {
             f <~> "\n";
           }
@@ -541,17 +546,17 @@ module DefaultSparse {
 
   proc DefaultSparseArr.dsiSerialWrite(f) {
     if (rank == 1) {
-      if (dom.nnz >= 1) {
+      if (dom._nnz >= 1) {
         f <~> data(1);
-        for i in 2..dom.nnz {
+        for i in 2..dom._nnz {
           f <~> " " <~> data(i);
         }
       }
     } else {
-      if (dom.nnz >= 1) {
+      if (dom._nnz >= 1) {
         var prevInd = dom.indices(1);
         f <~> data(1);
-        for i in 2..dom.nnz {
+        for i in 2..dom._nnz {
           if (prevInd(1) != dom.indices(i)(1)) {
             f <~> "\n";
           } else {

--- a/modules/layouts/LayoutCS.chpl
+++ b/modules/layouts/LayoutCS.chpl
@@ -113,6 +113,8 @@ class CSDom: BaseSparseDomImpl {
   /* (row|col) startIdxDom */
   var startIdxDom: domain(1, idxType);
 
+  var _nnz = 0;
+
   /* (row|col) start */
   pragma "local field"
   var startIdx: [startIdxDom] idxType;      // would like index(nnzDom)
@@ -140,10 +142,13 @@ class CSDom: BaseSparseDomImpl {
 
     this.complete();
 
-    nnzDom = {1..nnz};
+    nnzDom = {1.._nnz};
     dsiClear();
   }
 
+  override proc getNNZ(): int {
+    return _nnz;
+  }
   override proc dsiMyDist() return dist;
 
   proc dsiAssignDomain(rhs: domain, lhsPrivate:bool) {
@@ -155,7 +160,7 @@ class CSDom: BaseSparseDomImpl {
 
   iter dsiIndsIterSafeForRemoving() {
     var cursor = if this.compressRows then rowRange.high else colRange.high;
-    for i in 1..nnz by -1 {
+    for i in 1.._nnz by -1 {
       while (startIdx(cursor) > i) {
         cursor -= 1;
       }
@@ -170,7 +175,7 @@ class CSDom: BaseSparseDomImpl {
   iter these() {
     // TODO: Is it faster to start at _private_findStart(1) ?
     var cursor = if this.compressRows then rowRange.low else colRange.low;
-    for i in 1..nnz {
+    for i in 1.._nnz {
       while (startIdx(cursor+1) <= i) {
         cursor+= 1;
       }
@@ -183,7 +188,7 @@ class CSDom: BaseSparseDomImpl {
 
   iter these(param tag: iterKind) where tag == iterKind.leader {
     // same as DefaultSparseDom's leader
-    const numElems = nnz;
+    const numElems = _nnz;
     const numChunks = _computeNumChunks(numElems);
     if debugCS then
       writeln("CSDom leader: ", numChunks, " chunks, ", numElems, " elems");
@@ -292,7 +297,7 @@ class CSDom: BaseSparseDomImpl {
   }
 
   proc dsiFirst {
-    if nnz == 0 then return (parentDom.low) - (1,1);
+    if _nnz == 0 then return (parentDom.low) - (1,1);
     const _low = nnzDom.low;
     for i in startIdxDom {
       if startIdx[i] > _low {
@@ -307,7 +312,7 @@ class CSDom: BaseSparseDomImpl {
   }
 
   proc dsiLast {
-    if nnz == 0 then return (parentDom.low) - (1,1);
+    if _nnz == 0 then return (parentDom.low) - (1,1);
 
     var _last = parentDom.low[1] - 1;
     for i in startIdxDom do
@@ -315,9 +320,9 @@ class CSDom: BaseSparseDomImpl {
         _last = i-1;
 
     if this.compressRows then
-      return (_last, idx[nnz]);
+      return (_last, idx[_nnz]);
     else
-      return (idx[nnz], _last);
+      return (idx[_nnz], _last);
   }
 
   proc dsiAdd(ind: rank*idxType) {
@@ -330,16 +335,16 @@ class CSDom: BaseSparseDomImpl {
     if found then return 0;
 
     // increment number of nonzeroes
-    nnz += 1;
+    _nnz += 1;
 
     // double nnzDom if we've outgrown it; grab current size otherwise
     var oldNNZDomSize = nnzDom.size;
-    _grow(nnz);
+    _grow(_nnz);
 
     const (row,col) = ind;
 
     // shift row|column indices up
-    for i in insertPt..nnz-1 by -1 {
+    for i in insertPt.._nnz-1 by -1 {
       idx(i+1) = idx(i);
     }
 
@@ -363,7 +368,7 @@ class CSDom: BaseSparseDomImpl {
     // this second initialization of any new values in the array.
     // we could also eliminate the oldNNZDomSize variable
     for a in _arrs {
-      a.sparseShiftArray(insertPt..nnz-1, oldNNZDomSize+1..nnzDom.size);
+      a.sparseShiftArray(insertPt.._nnz-1, oldNNZDomSize+1..nnzDom.size);
     }
     return 1;
   }
@@ -377,11 +382,11 @@ class CSDom: BaseSparseDomImpl {
       bulkAdd_prepareInds(inds, dataSorted, isUnique, cmp=_columnComparator);
     }
 
-    if nnz == 0 {
+    if _nnz == 0 {
 
       const dupCount = if isUnique then 0 else _countDuplicates(inds);
 
-      nnz += inds.size-dupCount;
+      _nnz += inds.size-dupCount;
       _bulkGrow();
 
       var idxIdx = 1;
@@ -426,13 +431,13 @@ class CSDom: BaseSparseDomImpl {
       }
 
       return idxIdx-1;
-    } // if nnz == 0
+    } // if _nnz == 0
 
     const (actualInsertPts, actualAddCnt) =
       __getActualInsertPts(this, inds, isUnique);
 
-    const oldnnz = nnz;
-    nnz += actualAddCnt;
+    const oldnnz = _nnz;
+    _nnz += actualAddCnt;
 
     // Grow nnzDom if necessary
     _bulkGrow();
@@ -449,7 +454,7 @@ class CSDom: BaseSparseDomImpl {
 
     var arrShiftMap: [{1..oldnnz}] int; //to map where data goes
 
-    for i in 1..nnz by -1 {
+    for i in 1.._nnz by -1 {
       if oldIndIdx >= 1 && i > newLoc {
         // Shift from old values
         idx[i] = idx[oldIndIdx];
@@ -517,14 +522,14 @@ class CSDom: BaseSparseDomImpl {
     if (!found) then return 0;
 
     // increment number of nonzeroes
-    nnz -= 1;
+    _nnz -= 1;
 
-    _shrink(nnz);
+    _shrink(_nnz);
 
     const (row,col) = ind;
 
     // shift column indices down
-    for i in insertPt..nnz {
+    for i in insertPt.._nnz {
       idx(i) = idx(i+1);
     }
 
@@ -548,14 +553,14 @@ class CSDom: BaseSparseDomImpl {
     // this second initialization of any new values in the array.
     // we could also eliminate the oldNNZDomSize variable
     for a in _arrs {
-      a.sparseShiftArrayBack(insertPt..nnz-1);
+      a.sparseShiftArrayBack(insertPt.._nnz-1);
     }
 
     return 1;
   }
 
   override proc dsiClear() {
-    nnz = 0;
+    _nnz = 0;
     startIdx = 1;
   }
 
@@ -641,13 +646,13 @@ class CSArr: BaseSparseArrImpl {
 
 
   iter these() ref {
-    for i in 1..dom.nnz do yield data[i];
+    for i in 1..dom._nnz do yield data[i];
   }
 
   iter these(param tag: iterKind) where tag == iterKind.leader {
     // forward to the leader iterator on our domain
     // Note: this is so that arrays can be zippered with domains;
-    // otherwise just chunk up data[1..dom.nnz] a-la DefaultSparseArr.
+    // otherwise just chunk up data[1..dom._nnz] a-la DefaultSparseArr.
     for followThis in dom.these(tag) do
       yield followThis;
   }

--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -1580,9 +1580,9 @@ module Sparse {
     ADom.startIdx = indptr;
     const (hasZero, zeroIndex) = indices.find(0);
     if hasZero {
-      ADom.nnz = zeroIndex-1;
+      ADom._nnz = zeroIndex-1;
     } else {
-      ADom.nnz = indices.size;
+      ADom._nnz = indices.size;
     }
     ADom.nnzDom = {1..indices.size};
     ADom.idx = indices;

--- a/test/sparse/CS/correctness.chpl
+++ b/test/sparse/CS/correctness.chpl
@@ -397,7 +397,7 @@ proc writeInternals(A) {
   if row then writeln('Column Index:');
   else writeln('Row Index:');
 
-  for i in 1..A.domain._value.nnz {
+  for i in 1..A.domain._value.getNNZ() {
     write(A.domain._value.idx(i), ' ');
   }
   writeln();

--- a/test/users/engin/partial_reduction_support/modules/dsiMethods.chpl
+++ b/test/users/engin/partial_reduction_support/modules/dsiMethods.chpl
@@ -104,13 +104,13 @@ proc DefaultSparseDom.__private_findRowRange(r) {
   var done: atomic bool;
   begin with (ref end) {
     var found: bool;
-    (found, end) = binarySearch(indices, ((...r),endDummy), hi=nnz);
+    (found, end) = binarySearch(indices, ((...r),endDummy), hi=_nnz);
     done.write(true);
   }
   var found: bool;
-  (found, start) = binarySearch(indices, ((...r),startDummy), hi=nnz);
+  (found, start) = binarySearch(indices, ((...r),startDummy), hi=_nnz);
   done.waitFor(true);
-  return start..min(nnz,end-1);
+  return start..min(_nnz,end-1);
 }
 
 proc partialIterationDimCheck(param onlyDim, param rank) {
@@ -129,7 +129,7 @@ iter DefaultSparseDom.dsiPartialThese(param onlyDim: int, otherIdx,
   const otherIdxTup = chpl__tuplify(otherIdx);
 
   if onlyDim != this.rank {
-    for i in nnzDom.low..#nnz do
+    for i in nnzDom.low..#_nnz do
       if indices[i].withoutIdx(onlyDim) == otherIdxTup then 
         yield indices[i][onlyDim];
   }
@@ -155,11 +155,11 @@ iter DefaultSparseDom.dsiPartialThese(param onlyDim: int, otherIdx,
   if onlyDim==rank then rowRange = __private_findRowRange(otherIdxTup);
 
   const l = if onlyDim!=rank then nnzDom.low else rowRange.low;
-  const h = if onlyDim!=rank then nnzDom.low+nnz else rowRange.high;
+  const h = if onlyDim!=rank then nnzDom.low+_nnz else rowRange.high;
   const numElems = h-l+1;
   coforall t in 0..#numTasks {
     const myChunk = _computeBlock(numElems, numTasks, t, h-l, 0, 0);
-    yield (myChunk[1]..min(nnz, myChunk[2]),);
+    yield (myChunk[1]..min(_nnz, myChunk[2]),);
   }
 }
 
@@ -200,14 +200,14 @@ iter DefaultSparseDom.dsiPartialThese(param onlyDim: int, otherIdx,
   if onlyDim==rank then rowRange = __private_findRowRange(otherIdxTup);
 
   const l = if onlyDim!=rank then indices.domain.low else rowRange.low;
-  const h = if onlyDim!=rank then nnz else rowRange.high;
+  const h = if onlyDim!=rank then _nnz else rowRange.high;
   const numElems = h-l+1;
   if numElems <= -2 then return;
 
   if onlyDim != rank {
     coforall t in 0..#numTasks {
       const myChunk = _computeBlock(numElems, numTasks, t, h, l, l);
-      for i in myChunk[1]..min(nnz,myChunk[2]) do
+      for i in myChunk[1]..min(_nnz,myChunk[2]) do
         if indices[i].withoutIdx(onlyDim) == otherIdxTup then
           yield indices[i][onlyDim];
     }
@@ -276,7 +276,7 @@ iter CSDom.dsiPartialThese(param onlyDim, otherIdx,
 
   if onlyDim==1 {
     // Should we have a compiler warning about this expensive operation?
-    for i in nnzDom.low..#nnz {
+    for i in nnzDom.low..#_nnz {
       if idx[i] == otherIdx {
         const (found, loc) = binarySearch(startIdx, i);
         yield if found then loc else loc-1;
@@ -300,7 +300,7 @@ iter CSDom.dsiPartialThese(param onlyDim, otherIdx,
     tasksPerLocale;
 
   const l = if onlyDim==1 then nnzDom.low else startIdx[otherIdx];
-  const h = if onlyDim==1 then nnzDom.low+nnz-1 else stopIdx[otherIdx];
+  const h = if onlyDim==1 then nnzDom.low+_nnz-1 else stopIdx[otherIdx];
   const numElems = h-l+1;
 
   coforall t in 0..#numTasks {
@@ -344,8 +344,8 @@ iter CSDom.dsiPartialThese(param onlyDim, otherIdx,
     tasksPerLocale;
 
   if onlyDim==1 {
-    const l = nnzDom.low, h = nnzDom.low+nnz-1;
-    const numElems = nnz;
+    const l = nnzDom.low, h = nnzDom.low+_nnz-1;
+    const numElems = _nnz;
 
     coforall t in 0..#numTasks {
       const myChunk = _computeBlock(numElems, numTasks, t, h-l, 0, 0);


### PR DESCRIPTION
Resolves #13410 

- Adds `getNNZ()` to all sparse domain types via `BaseSparseDom` to get number of nonzeroes. This was necessary as it is not that straightforward to keep track of number of nonzeroes in distributed sparse domains. Instead, it needs to be calculated everytime it's queried.
- Adjusts some tests.
- Adjust the `LinearAlgebra` module. My hope is to make the `LinearAlgebra.Sparse` module independent of the internals of the sparse domains in the near future. But this keeps things functioning for now.

The diff is mostly `nnz`->`_nnz` to "prevent" this variable to be used outside of the class definition.

Test:

- [x] Full gasnet 
- [x] Full local