### PR TITLE
Issue a compiler error instead of a segfault

### DIFF
--- a/compiler/AST/foralls.cpp
+++ b/compiler/AST/foralls.cpp
@@ -155,6 +155,13 @@ static ShadowVarSymbol* buildTaskPrivateVariable(ShadowVarPrefix prefix,
 ShadowVarSymbol* ShadowVarSymbol::buildForPrefix(ShadowVarPrefix prefix,
                                     Expr* nameExp, Expr* type, Expr* init)
 {
+  if (SymExpr* nameSE = toSymExpr(nameExp)) {
+    checkTypeParamOuterVar(nameSE);
+    // when can this happen?
+    USR_FATAL(nameSE, "forall and task intents on '%s' are not implemented",
+              nameSE->symbol()->name);
+  }
+
   const char* nameString = toUnresolvedSymExpr(nameExp)->unresolved;
 
   if (type == NULL && init == NULL)
@@ -176,6 +183,12 @@ ShadowVarSymbol* ShadowVarSymbol::buildFromReduceIntent(Expr* ovar,
 
 void addForallIntent(CallExpr* call, ShadowVarSymbol* svar) {
   call->insertAtTail(svar->defPoint);
+}
+
+void checkTypeParamOuterVar(SymExpr* outerSE) {
+  Symbol* outerSym = outerSE->symbol();
+  if (outerSym->hasFlag(FLAG_TYPE_VARIABLE) || outerSym->hasFlag(FLAG_PARAM))
+    USR_FATAL(outerSE, "cannot apply a forall or task intent to a type or a param, here '%s'", outerSym->name);
 }
 
 

--- a/compiler/AST/foralls.cpp
+++ b/compiler/AST/foralls.cpp
@@ -156,7 +156,7 @@ ShadowVarSymbol* ShadowVarSymbol::buildForPrefix(ShadowVarPrefix prefix,
                                     Expr* nameExp, Expr* type, Expr* init)
 {
   if (SymExpr* nameSE = toSymExpr(nameExp)) {
-    checkTypeParamOuterVar(nameSE);
+    checkTypeParamTaskIntent(nameSE);
     // when can this happen?
     USR_FATAL(nameSE, "forall and task intents on '%s' are not implemented",
               nameSE->symbol()->name);
@@ -185,7 +185,7 @@ void addForallIntent(CallExpr* call, ShadowVarSymbol* svar) {
   call->insertAtTail(svar->defPoint);
 }
 
-void checkTypeParamOuterVar(SymExpr* outerSE) {
+void checkTypeParamTaskIntent(SymExpr* outerSE) {
   Symbol* outerSym = outerSE->symbol();
   if (outerSym->hasFlag(FLAG_TYPE_VARIABLE) || outerSym->hasFlag(FLAG_PARAM))
     USR_FATAL(outerSE, "cannot apply a forall or task intent to a type or a param, here '%s'", outerSym->name);

--- a/compiler/include/passes.h
+++ b/compiler/include/passes.h
@@ -105,7 +105,7 @@ void flattenNestedFunction(FnSymbol* nestedFunction);
 void flattenNestedFunctions(Vec<FnSymbol*>& nestedFunctions);
 
 // foralls.cpp
-void checkTypeParamOuterVar(SymExpr* outerSE);
+void checkTypeParamTaskIntent(SymExpr* outerSE);
 
 // inlineFunctions.cpp
 BlockStmt* copyFnBodyForInlining(CallExpr* call, FnSymbol* fn, Expr* anchor);

--- a/compiler/include/passes.h
+++ b/compiler/include/passes.h
@@ -104,6 +104,9 @@ void deadBlockElimination();
 void flattenNestedFunction(FnSymbol* nestedFunction);
 void flattenNestedFunctions(Vec<FnSymbol*>& nestedFunctions);
 
+// foralls.cpp
+void checkTypeParamOuterVar(SymExpr* outerSE);
+
 // inlineFunctions.cpp
 BlockStmt* copyFnBodyForInlining(CallExpr* call, FnSymbol* fn, Expr* anchor);
 

--- a/compiler/passes/createTaskFunctions.cpp
+++ b/compiler/passes/createTaskFunctions.cpp
@@ -513,7 +513,7 @@ static void markOuterVarsWithIntents(CallExpr* byrefVars, SymbolMap& uses) {
                     //                 or over chpl__reduceGlob
     Symbol* var = se->symbol();
     if (marker) {
-      checkTypeParamOuterVar(se);
+      checkTypeParamTaskIntent(se);
       SymbolMapElem* elem = uses.get_record(var);
       if (elem) {
         elem->value = marker;

--- a/compiler/passes/createTaskFunctions.cpp
+++ b/compiler/passes/createTaskFunctions.cpp
@@ -513,6 +513,7 @@ static void markOuterVarsWithIntents(CallExpr* byrefVars, SymbolMap& uses) {
                     //                 or over chpl__reduceGlob
     Symbol* var = se->symbol();
     if (marker) {
+      checkTypeParamOuterVar(se);
       SymbolMapElem* elem = uses.get_record(var);
       if (elem) {
         elem->value = marker;

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -1301,6 +1301,7 @@ static void setupOuterVar(ForallStmt* fs, ShadowVarSymbol* svar) {
       // The desired case.
       svar->outerVarSE = new SymExpr(ovar);
       insert_help(svar->outerVarSE, NULL, svar);
+      checkTypeParamOuterVar(svar->outerVarSE);
     }
   } else {
     USR_FATAL_CONT(svar,

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -1301,7 +1301,7 @@ static void setupOuterVar(ForallStmt* fs, ShadowVarSymbol* svar) {
       // The desired case.
       svar->outerVarSE = new SymExpr(ovar);
       insert_help(svar->outerVarSE, NULL, svar);
-      checkTypeParamOuterVar(svar->outerVarSE);
+      checkTypeParamTaskIntent(svar->outerVarSE);
     }
   } else {
     USR_FATAL_CONT(svar,

--- a/test/parallel/forall/checks/with-bool.chpl
+++ b/test/parallel/forall/checks/with-bool.chpl
@@ -1,0 +1,5 @@
+// Ensure the compiler produces a graceful error.
+
+forall Locales with (in bool) {
+  writeln();
+}

--- a/test/parallel/forall/checks/with-bool.good
+++ b/test/parallel/forall/checks/with-bool.good
@@ -1,0 +1,1 @@
+with-bool.chpl:3: error: cannot apply a forall or task intent to a type or a param, here 'bool'

--- a/test/parallel/forall/checks/with-false.chpl
+++ b/test/parallel/forall/checks/with-false.chpl
@@ -1,0 +1,5 @@
+// Ensure the compiler produces a graceful error.
+
+forall Locales with (in false) {
+  writeln();
+}

--- a/test/parallel/forall/checks/with-false.good
+++ b/test/parallel/forall/checks/with-false.good
@@ -1,0 +1,1 @@
+with-false.chpl:3: syntax error: near 'false'

--- a/test/parallel/forall/checks/with-param.chpl
+++ b/test/parallel/forall/checks/with-param.chpl
@@ -1,0 +1,7 @@
+// Ensure the compiler produces a graceful error.
+
+param T = "hi";
+
+forall Locales with (in T) {
+  writeln();
+}

--- a/test/parallel/forall/checks/with-param.good
+++ b/test/parallel/forall/checks/with-param.good
@@ -1,0 +1,1 @@
+with-param.chpl:5: error: cannot apply a forall or task intent to a type or a param, here 'T'

--- a/test/parallel/forall/checks/with-type.chpl
+++ b/test/parallel/forall/checks/with-type.chpl
@@ -1,0 +1,7 @@
+// Ensure the compiler produces a graceful error.
+
+type T = int;
+
+forall Locales with (in T) {
+  writeln();
+}

--- a/test/parallel/forall/checks/with-type.good
+++ b/test/parallel/forall/checks/with-type.good
@@ -1,0 +1,1 @@
+with-type.chpl:5: error: cannot apply a forall or task intent to a type or a param, here 'T'

--- a/test/parallel/taskPar/vass/with-bool.chpl
+++ b/test/parallel/taskPar/vass/with-bool.chpl
@@ -1,0 +1,5 @@
+// Ensure the compiler produces a graceful error.
+
+coforall Locales with (in bool) {
+  writeln();
+}

--- a/test/parallel/taskPar/vass/with-bool.good
+++ b/test/parallel/taskPar/vass/with-bool.good
@@ -1,0 +1,1 @@
+with-bool.chpl:3: error: cannot apply a forall or task intent to a type or a param, here 'bool'

--- a/test/parallel/taskPar/vass/with-false.chpl
+++ b/test/parallel/taskPar/vass/with-false.chpl
@@ -1,0 +1,5 @@
+// Ensure the compiler produces a graceful error.
+
+coforall Locales with (in false) {
+  writeln();
+}

--- a/test/parallel/taskPar/vass/with-false.good
+++ b/test/parallel/taskPar/vass/with-false.good
@@ -1,0 +1,1 @@
+with-false.chpl:3: syntax error: near 'false'

--- a/test/parallel/taskPar/vass/with-param.chpl
+++ b/test/parallel/taskPar/vass/with-param.chpl
@@ -1,0 +1,7 @@
+// Ensure the compiler produces a graceful error.
+
+param T = "hi";
+
+coforall Locales with (in T) {
+  writeln();
+}

--- a/test/parallel/taskPar/vass/with-param.good
+++ b/test/parallel/taskPar/vass/with-param.good
@@ -1,0 +1,1 @@
+with-param.chpl:5: error: cannot apply a forall or task intent to a type or a param, here 'T'

--- a/test/parallel/taskPar/vass/with-type.chpl
+++ b/test/parallel/taskPar/vass/with-type.chpl
@@ -1,0 +1,7 @@
+// Ensure the compiler produces a graceful error.
+
+type T = int;
+
+coforall Locales with (in T) {
+  writeln();
+}

--- a/test/parallel/taskPar/vass/with-type.good
+++ b/test/parallel/taskPar/vass/with-type.good
@@ -1,0 +1,1 @@
+with-type.chpl:5: error: cannot apply a forall or task intent to a type or a param, here 'T'


### PR DESCRIPTION
Tend to a case, discovered by Brad, that a user might bump into
where the compiler used to crash with a segfault.
While there, report user error in some other cases.

The "syntax error" outcomes are not new with this change.
I am adding a couple of tests to make sure that the compiler behavior
remains reasonable in those cases, i.e. issuing a user error.

Testing: linux64 -futures.