### PR TITLE
Remove note about record assignment between types in extern.rst

### DIFF
--- a/doc/rst/technotes/extern.rst
+++ b/doc/rst/technotes/extern.rst
@@ -591,12 +591,6 @@ for the type is ``struct stat``:
 
   writeln(getFileSize("stat-example.chpl"));
 
-Note that external record types only support assignment from records
-of matching type.  In particular, Chapel's normal mechanisms that
-perform record assignment by field name are not used for external
-records.  This restriction could be lifted in the future if considered
-useful to users.
-
 
 Opaque Types
 ------------


### PR DESCRIPTION
The assignment between records of different types was removed
in PR #10873 / discussed in #10872. This commit just removes
an old reference to that behavior from the C interop technote.

Trivial and not reviewed.