### PR TITLE
Modify .bad file for future with new error message

### DIFF
--- a/test/interop/C/multilocale/arrays/exportFuncWithArrayArg.bad
+++ b/test/interop/C/multilocale/arrays/exportFuncWithArrayArg.bad
@@ -1,1 +1,1 @@
-error: Multi-locale libraries do not support type
+exportFuncWithArrayArg.chpl:1: error: Multi-locale libraries do not support formal type: _ref(chpl_external_array)


### PR DESCRIPTION
This PR fixes the .bad file for the `interop/C/multilocale/arrays/exportFuncWithArrayArg.chpl` future. I recently updated error messages for multilocale libraries with https://github.com/chapel-lang/chapel/pull/13403, and forgot to adjust this future to account for the change.