### PR TITLE
List multilocale library as last link dependency to deal with GNU linker

### DIFF
--- a/test/interop/C/multilocale/static/use_boolArgAndReturn.lastcompopts
+++ b/test/interop/C/multilocale/static/use_boolArgAndReturn.lastcompopts
@@ -1,1 +1,1 @@
--Llib/ -lboolArgAndReturn `$CHPL_HOME/util/config/compileline --libraries` `$CHPL_HOME/util/config/compileline --multilocale-lib-deps`
+-Llib/ -lboolArgAndReturn `$CHPL_HOME/util/config/compileline --libraries` `$CHPL_HOME/util/config/compileline --multilocale-lib-deps` -lboolArgAndReturn

--- a/test/interop/C/multilocale/static/use_boolArgAndReturn.suppressif
+++ b/test/interop/C/multilocale/static/use_boolArgAndReturn.suppressif
@@ -1,1 +1,0 @@
-CHPL_TARGET_PLATFORM != darwin

--- a/test/interop/C/multilocale/static/use_intArgAndReturn.lastcompopts
+++ b/test/interop/C/multilocale/static/use_intArgAndReturn.lastcompopts
@@ -1,1 +1,1 @@
--Llib/ -lintArgAndReturn `$CHPL_HOME/util/config/compileline --libraries` `$CHPL_HOME/util/config/compileline --multilocale-lib-deps`
+-Llib/ -lintArgAndReturn `$CHPL_HOME/util/config/compileline --libraries` `$CHPL_HOME/util/config/compileline --multilocale-lib-deps` -lintArgAndReturn

--- a/test/interop/C/multilocale/static/use_intArgAndReturn.suppressif
+++ b/test/interop/C/multilocale/static/use_intArgAndReturn.suppressif
@@ -1,1 +1,0 @@
-CHPL_TARGET_PLATFORM != darwin

--- a/test/interop/C/multilocale/static/use_testing.lastcompopts
+++ b/test/interop/C/multilocale/static/use_testing.lastcompopts
@@ -1,1 +1,1 @@
--Llib/ -ltesting `$CHPL_HOME/util/config/compileline --libraries` `$CHPL_HOME/util/config/compileline --multilocale-lib-deps`
+-Llib/ -ltesting `$CHPL_HOME/util/config/compileline --libraries` `$CHPL_HOME/util/config/compileline --multilocale-lib-deps` -ltesting

--- a/test/interop/C/multilocale/static/use_testing.suppressif
+++ b/test/interop/C/multilocale/static/use_testing.suppressif
@@ -1,1 +1,0 @@
-CHPL_TARGET_PLATFORM != darwin


### PR DESCRIPTION
Several tests in `interop/C/multilocale/static` currently fail to link on master. Turns out the solution is very simple (and silly)...

The Chapel launcher library `libchpllaunch` relies on symbols that are injected into the multilocale client library by the compiler. The GNU linker cannot resolve these symbols to their definitions unless the multilocale client library is the both the first and last link argument.

Now that these tests compile, should we unsuppress them for `linux64`?


