### PR TITLE
Throw an IllegalArgumentError error for mkdir('')

### DIFF
--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -1245,7 +1245,7 @@ iter listdir(path: string = ".", hidden: bool = false, dirs: bool = true,
 proc mkdir(name: string, mode: int = 0o777, parents: bool=false) throws {
   extern proc chpl_fs_mkdir(name: c_string, mode: int, parents: bool):syserr;
 
-  if name.strip().isEmpty() then
+  if name.isEmpty() then
     throw new owned IllegalArgumentError("mkdir called with illegal path: '" + name + "'");
 
   var err = chpl_fs_mkdir(name.localize().c_str(), mode, parents);

--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -1240,9 +1240,13 @@ iter listdir(path: string = ".", hidden: bool = false, dirs: bool = true,
    :type parents: `bool`
 
    :throws SystemError: Thrown to describe an error if one occurs.
+   :throws IllegalArgumentError: when `name` is empty.
 */
 proc mkdir(name: string, mode: int = 0o777, parents: bool=false) throws {
   extern proc chpl_fs_mkdir(name: c_string, mode: int, parents: bool):syserr;
+
+  if name.isEmpty() then
+    throw new owned IllegalArgumentError("mkdir called with empty string");
 
   var err = chpl_fs_mkdir(name.localize().c_str(), mode, parents);
   if err then try ioerror(err, "in mkdir", name);

--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -1240,7 +1240,6 @@ iter listdir(path: string = ".", hidden: bool = false, dirs: bool = true,
    :type parents: `bool`
 
    :throws SystemError: Thrown to describe an error if one occurs.
-   :throws IllegalArgumentError: when `name` is empty.
 */
 proc mkdir(name: string, mode: int = 0o777, parents: bool=false) throws {
   extern proc chpl_fs_mkdir(name: c_string, mode: int, parents: bool):syserr;

--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -1245,8 +1245,8 @@ iter listdir(path: string = ".", hidden: bool = false, dirs: bool = true,
 proc mkdir(name: string, mode: int = 0o777, parents: bool=false) throws {
   extern proc chpl_fs_mkdir(name: c_string, mode: int, parents: bool):syserr;
 
-  if name.isEmpty() then
-    throw new owned IllegalArgumentError("mkdir called with empty string");
+  if name.strip().isEmpty() then
+    throw new owned IllegalArgumentError("mkdir called with illegal path: '" + name + "'");
 
   var err = chpl_fs_mkdir(name.localize().c_str(), mode, parents);
   if err then try ioerror(err, "in mkdir", name);

--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -1246,7 +1246,7 @@ proc mkdir(name: string, mode: int = 0o777, parents: bool=false) throws {
   extern proc chpl_fs_mkdir(name: c_string, mode: int, parents: bool):syserr;
 
   if name.isEmpty() then
-    throw new owned IllegalArgumentError("mkdir called with illegal path: '" + name + "'");
+    try ioerror(ENOENT:syserr, "mkdir called with illegal path: '" + name + "'");
 
   var err = chpl_fs_mkdir(name.localize().c_str(), mode, parents);
   if err then try ioerror(err, "in mkdir", name);

--- a/test/library/standard/FileSystem/mkdir/illegalArgs.chpl
+++ b/test/library/standard/FileSystem/mkdir/illegalArgs.chpl
@@ -3,7 +3,7 @@ use FileSystem;
 proc main() throws {
   try {
     mkdir('', parents=false);
-  } catch e: IllegalArgumentError {
+  } catch e: FileNotFoundError {
     writeln(e);
   } catch e {
     writeln('wrong error thrown for parents=false:');
@@ -12,7 +12,7 @@ proc main() throws {
 
   try {
     mkdir('', parents=true);
-  } catch e: IllegalArgumentError {
+  } catch e: FileNotFoundError {
     writeln(e);
   } catch e {
     writeln('wrong error thrown for parents=true:');

--- a/test/library/standard/FileSystem/mkdir/illegalArgs.chpl
+++ b/test/library/standard/FileSystem/mkdir/illegalArgs.chpl
@@ -11,15 +11,6 @@ proc main() throws {
   }
 
   try {
-    mkdir(' ', parents=false);
-  } catch e: IllegalArgumentError {
-    writeln(e);
-  } catch e {
-    writeln('wrong error thrown for parents=false:');
-    writeln(e);
-  }
-
-  try {
     mkdir('', parents=true);
   } catch e: IllegalArgumentError {
     writeln(e);

--- a/test/library/standard/FileSystem/mkdir/illegalArgs.chpl
+++ b/test/library/standard/FileSystem/mkdir/illegalArgs.chpl
@@ -1,0 +1,30 @@
+use FileSystem;
+
+proc main() throws {
+  try {
+    mkdir('', parents=false);
+  } catch e: IllegalArgumentError {
+    writeln(e);
+  } catch e {
+    writeln('wrong error thrown for parents=false:');
+    writeln(e);
+  }
+
+  try {
+    mkdir(' ', parents=false);
+  } catch e: IllegalArgumentError {
+    writeln(e);
+  } catch e {
+    writeln('wrong error thrown for parents=false:');
+    writeln(e);
+  }
+
+  try {
+    mkdir('', parents=true);
+  } catch e: IllegalArgumentError {
+    writeln(e);
+  } catch e {
+    writeln('wrong error thrown for parents=true:');
+    writeln(e);
+  }
+}

--- a/test/library/standard/FileSystem/mkdir/illegalArgs.chpl
+++ b/test/library/standard/FileSystem/mkdir/illegalArgs.chpl
@@ -3,7 +3,7 @@ use FileSystem;
 proc main() throws {
   try {
     mkdir('', parents=false);
-  } catch e: FileNotFoundError {
+  } catch e: SystemError {
     writeln(e);
   } catch e {
     writeln('wrong error thrown for parents=false:');
@@ -12,7 +12,7 @@ proc main() throws {
 
   try {
     mkdir('', parents=true);
-  } catch e: FileNotFoundError {
+  } catch e: SystemError {
     writeln(e);
   } catch e {
     writeln('wrong error thrown for parents=true:');

--- a/test/library/standard/FileSystem/mkdir/illegalArgs.good
+++ b/test/library/standard/FileSystem/mkdir/illegalArgs.good
@@ -1,0 +1,3 @@
+IllegalArgumentError: mkdir called with illegal path: ''
+IllegalArgumentError: mkdir called with illegal path: ' '
+IllegalArgumentError: mkdir called with illegal path: ''

--- a/test/library/standard/FileSystem/mkdir/illegalArgs.good
+++ b/test/library/standard/FileSystem/mkdir/illegalArgs.good
@@ -1,2 +1,2 @@
-IllegalArgumentError: mkdir called with illegal path: ''
-IllegalArgumentError: mkdir called with illegal path: ''
+FileNotFoundError: No such file or directory (mkdir called with illegal path: '')
+FileNotFoundError: No such file or directory (mkdir called with illegal path: '')

--- a/test/library/standard/FileSystem/mkdir/illegalArgs.good
+++ b/test/library/standard/FileSystem/mkdir/illegalArgs.good
@@ -1,3 +1,2 @@
 IllegalArgumentError: mkdir called with illegal path: ''
-IllegalArgumentError: mkdir called with illegal path: ' '
 IllegalArgumentError: mkdir called with illegal path: ''


### PR DESCRIPTION
Previously, `FileSystem.mkdir('')` resulted in a seg fault. Now it results in this message:

```
FileNotFoundError: No such file or directory (mkdir called with illegal path: '')
```
