### PR TITLE
Disallow forall and task intents on 'this'

### DIFF
--- a/compiler/AST/foralls.cpp
+++ b/compiler/AST/foralls.cpp
@@ -156,6 +156,8 @@ ShadowVarSymbol* ShadowVarSymbol::buildForPrefix(ShadowVarPrefix prefix,
                                     Expr* nameExp, Expr* type, Expr* init)
 {
   const char* nameString = toUnresolvedSymExpr(nameExp)->unresolved;
+  if (nameString == astrThis)
+    USR_FATAL_CONT(nameExp, "cannot apply a forall or task intent to 'this'");
 
   if (type == NULL && init == NULL)
     // non-TPV forall intent

--- a/compiler/AST/foralls.cpp
+++ b/compiler/AST/foralls.cpp
@@ -157,7 +157,7 @@ ShadowVarSymbol* ShadowVarSymbol::buildForPrefix(ShadowVarPrefix prefix,
 {
   const char* nameString = toUnresolvedSymExpr(nameExp)->unresolved;
   if (nameString == astrThis)
-    USR_FATAL_CONT(nameExp, "cannot apply a forall or task intent to 'this'");
+    USR_FATAL_CONT(nameExp, "cannot currently apply a forall or task intent to 'this'");
 
   if (type == NULL && init == NULL)
     // non-TPV forall intent

--- a/test/parallel/forall/checks/with-this.chpl
+++ b/test/parallel/forall/checks/with-this.chpl
@@ -1,0 +1,12 @@
+// Cannot have a forall intent on 'this'.
+
+record R {
+  proc p() {
+    forall Locales with (in this) {
+      writeln();
+    }
+  }
+}
+
+var r: R;
+r.p();

--- a/test/parallel/forall/checks/with-this.good
+++ b/test/parallel/forall/checks/with-this.good
@@ -1,1 +1,1 @@
-with-this.chpl:5: error: cannot apply a forall or task intent to 'this'
+with-this.chpl:5: error: cannot currently apply a forall or task intent to 'this'

--- a/test/parallel/forall/checks/with-this.good
+++ b/test/parallel/forall/checks/with-this.good
@@ -1,0 +1,1 @@
+with-this.chpl:5: error: cannot apply a forall or task intent to 'this'

--- a/test/parallel/taskPar/vass/with-this.chpl
+++ b/test/parallel/taskPar/vass/with-this.chpl
@@ -1,0 +1,12 @@
+// Cannot have a forall intent on 'this'.
+
+record R {
+  proc p() {
+    coforall Locales with (in this) {
+      writeln();
+    }
+  }
+}
+
+var r: R;
+r.p();

--- a/test/parallel/taskPar/vass/with-this.good
+++ b/test/parallel/taskPar/vass/with-this.good
@@ -1,1 +1,1 @@
-with-this.chpl:5: error: cannot apply a forall or task intent to 'this'
+with-this.chpl:5: error: cannot currently apply a forall or task intent to 'this'

--- a/test/parallel/taskPar/vass/with-this.good
+++ b/test/parallel/taskPar/vass/with-this.good
@@ -1,0 +1,1 @@
+with-this.chpl:5: error: cannot apply a forall or task intent to 'this'


### PR DESCRIPTION
As suggested in https://github.com/chapel-lang/chapel/issues/13297#issuecomment-511051126
this PR makes `this` invalid as a forall or task intent.

We can relax this restriction back if we find this unreasonable.
If so, we will need this fix: 8427a3a156
and also adjust the upcoming changes related to setupAndResolveShadowVars().

Testing: linux64 -futures
