### PR TITLE
Suppress interop/C/multilocale/static tests when CHPL_TASKS=fifo

### DIFF
--- a/test/interop/C/multilocale/static/use_boolArgAndReturn.suppressif
+++ b/test/interop/C/multilocale/static/use_boolArgAndReturn.suppressif
@@ -1,0 +1,5 @@
+#
+# These tests fail when CHPL_TASKS=fifo. For now, suppress them.
+# See: #13475
+#
+CHPL_TASKS==fifo

--- a/test/interop/C/multilocale/static/use_intArgAndReturn.suppressif
+++ b/test/interop/C/multilocale/static/use_intArgAndReturn.suppressif
@@ -1,0 +1,5 @@
+#
+# These tests fail when CHPL_TASKS=fifo. For now, suppress them.
+# See: #13475
+#
+CHPL_TASKS==fifo

--- a/test/interop/C/multilocale/static/use_testing.suppressif
+++ b/test/interop/C/multilocale/static/use_testing.suppressif
@@ -1,0 +1,5 @@
+#
+# These tests fail when CHPL_TASKS=fifo. For now, suppress them.
+# See: #13475
+#
+CHPL_TASKS==fifo

--- a/test/interop/C/multilocale/static/withVerify.suppressif
+++ b/test/interop/C/multilocale/static/withVerify.suppressif
@@ -1,0 +1,5 @@
+#
+# These tests fail when CHPL_TASKS=fifo. For now, suppress them.
+# See: #13475
+#
+CHPL_TASKS==fifo


### PR DESCRIPTION
See #13475. For now, suppress the tests in this directory when CHPL_TASKS=fifo. I should have a fix in the works soon.