### PR TITLE
Deprecate setsockopt in favor of set* methods

### DIFF
--- a/modules/packages/ZMQ.chpl
+++ b/modules/packages/ZMQ.chpl
@@ -357,6 +357,10 @@ module ZMQ {
   private extern const ZMQ_IDENTITY: c_int;
 
   /*
+    .. warning::
+       :proc:`Socket.setsockopt()` and SUBSCRIBE have been deprecated.  Please
+       use :proc:`Socket.setSubscribe()` instead.
+
     The :proc:`Socket.setsockopt()` option value to specify the message filter
     for a :const:`SUB`-type :record:`Socket`.
    */
@@ -364,6 +368,10 @@ module ZMQ {
   private extern const ZMQ_SUBSCRIBE: c_int;
 
   /*
+    .. warning::
+       :proc:`Socket.setsockopt()` and UNSUBSCRIBE have been deprecated.  Please
+       use :proc:`Socket.setUnsubscribe()` instead.
+
     The :proc:`Socket.setsockopt()` option value to remote an existing message
     filter for a :const:`SUB`-type :record:`Socket`.
    */
@@ -380,6 +388,10 @@ module ZMQ {
   private extern const ZMQ_TYPE: c_int;
 
   /*
+    .. warning::
+       :proc:`Socket.setsockopt()` and LINGER have been deprecated.  Please use
+       :proc:`Socket.setLinger()` instead.
+
     The :proc:`Socket.setsockopt()` option value to specify the linger period
     for the associated :record:`Socket` object.
    */
@@ -699,6 +711,11 @@ module ZMQ {
     }
 
     /*
+      .. warning::
+         setsockopt(), :const:`LINGER`, :const:`SUBSCRIBE`, and
+         :const:`UNSUBSCRIBE` have been deprecated.  Please use
+         :proc:`Socket.setLinger()` instead.
+
       Set socket options;
       see `zmq_setsockopt <http://api.zeromq.org/4-0:zmq-setsockopt>`_
 
@@ -709,6 +726,8 @@ module ZMQ {
       :arg value: the socket option value
      */
     proc setsockopt(option: int, value: ?T) where isPODType(T) {
+      compilerWarning("setsockopt is deprecated - please use e.g. setLinger " +
+                      "instead");
       on classRef.home {
         var copy: T = value;
         var ret = zmq_setsockopt(classRef.socket, option:c_int,
@@ -723,6 +742,8 @@ module ZMQ {
 
     pragma "no doc"
     proc setsockopt(option: int, value: string) {
+      compilerWarning("setsockopt is deprecated - please use e.g. setLinger " +
+                      "instead");
       on classRef.home {
         var ret = zmq_setsockopt(classRef.socket, option:c_int,
                                  value.c_str():c_void_ptr,

--- a/modules/packages/ZMQ.chpl
+++ b/modules/packages/ZMQ.chpl
@@ -714,7 +714,8 @@ module ZMQ {
       .. warning::
          setsockopt(), :const:`LINGER`, :const:`SUBSCRIBE`, and
          :const:`UNSUBSCRIBE` have been deprecated.  Please use
-         :proc:`Socket.setLinger()` instead.
+         :proc:`Socket.setLinger()`, :proc:`Socket.setSubscribe()` or
+         :proc:`Socket.setUnsubscribe()` instead.
 
       Set socket options;
       see `zmq_setsockopt <http://api.zeromq.org/4-0:zmq-setsockopt>`_
@@ -829,6 +830,86 @@ module ZMQ {
           // It would be good to use a factory method for a ZMQError subclass,
           // see #12397
           throw new owned ZMQError("Error in Socket.setLinger(): " + errmsg);
+        }
+      }
+    }
+
+    /*
+      Set the message filter for the specified ZMQ_SUB socket; see
+      `zmq_setsockopt <http://api.zeromq.org/4-0:zmq-setsockopt>`_ under
+      ZMQ_SUBSCRIBE.
+
+      :arg value: The new message filter for the socket.
+
+      :throws ZMQError: Thrown when an error occurs setting the message filter.
+    */
+    proc setSubscribe(value: ?T) throws where isPODType(T) {
+      on classRef.home {
+        var copy: T = value;
+        var ret = zmq_setsockopt(classRef.socket, ZMQ_SUBSCRIBE,
+                                 c_ptrTo(copy): c_void_ptr,
+                                 numBytes(value.type)): int;
+        if ret == -1 {
+          var errmsg = zmq_strerror(errno):string;
+          // It would be good to use a factory method for a ZMQError subclass,
+          // see #12397
+          throw new owned ZMQError("Error in Socket.setSubscribe(): " + errmsg);
+        }
+      }
+    }
+
+    pragma "no doc"
+    proc setSubscribe(value: string) throws {
+      on classRef.home {
+        var ret = zmq_setsockopt(classRef.socket, ZMQ_SUBSCRIBE,
+                                 value.c_str(): c_void_ptr,
+                                 value.length:size_t): int;
+        if ret == -1 {
+          var errmsg = zmq_strerror(errno):string;
+          // It would be good to use a factory method for a ZMQError subclass,
+          // see #12397
+          throw new owned ZMQError("Error in Socket.setSubscribe(): " + errmsg);
+        }
+      }
+    }
+
+    /*
+      Remove an existing message filter for the specified ZMQ_SUB socket; see
+      `zmq_setsockopt <http://api.zeromq.org/4-0:zmq-setsockopt>`_ under
+      ZMQ_UNSUBSCRIBE.
+
+      :arg value: The message filter to remove from the socket.
+
+      :throws ZMQError: Thrown when an error occurs setting the message filter.
+    */
+    proc setUnsubscribe(value: ?T) throws where isPODType(T) {
+      on classRef.home {
+        var copy: T = value;
+        var ret = zmq_setsockopt(classRef.socket, ZMQ_UNSUBSCRIBE,
+                                 c_ptrTo(copy): c_void_ptr,
+                                 numBytes(value.type)): int;
+        if ret == -1 {
+          var errmsg = zmq_strerror(errno):string;
+          // It would be good to use a factory method for a ZMQError subclass,
+          // see #12397
+          throw new owned ZMQError("Error in Socket.setUnsubscribe(): " +
+                                   errmsg);
+        }
+      }
+    }
+
+    pragma "no doc"
+    proc setUnsubscribe(value: string) throws {
+      on classRef.home {
+        var ret = zmq_setsockopt(classRef.socket, ZMQ_UNSUBSCRIBE,
+                                 value.c_str(): c_void_ptr,
+                                 value.length:size_t): int;
+        if ret == -1 {
+          var errmsg = zmq_strerror(errno):string;
+          // It would be good to use a factory method for a ZMQError subclass,
+          // see #12397
+          throw new owned ZMQError("Error in Socket.setUnsubscribe(): " +
+                                   errmsg);
         }
       }
     }

--- a/test/deprecated/setSockoptSubscribe.chpl
+++ b/test/deprecated/setSockoptSubscribe.chpl
@@ -1,0 +1,101 @@
+use IO;
+use Help;
+use Spawn;
+use Random;
+use ZMQ;
+
+enum ExecMode {
+  Launcher,
+  Master,
+  Worker
+};
+
+config const mode = ExecMode.Launcher;
+config const numWorkers = 4;
+config const zipcode = 12345;
+
+proc main(args: [] string) {
+  if (args.size >= 2) && (args[1] == "--help" || args[1] == "-h") {
+    printUsage();
+    exit(0);
+  }
+
+  select mode {
+    when ExecMode.Launcher do Launcher(args[0]);
+    when ExecMode.Master   do Master(args[0]);
+    when ExecMode.Worker   do Worker(args[0]);
+  }
+}
+
+const env = [
+  "QTHREAD_NUM_SHEPHERDS=1",
+  "QTHREAD_NUM_WORKERS_PER_SHEPHERD=1"
+  ];
+
+iter zipcodes(num: int) {
+  var zips: [0..4] int = [10001 /* New York         */,
+                          90001 /* Los Angeles      */,
+                          60290 /* Chicago          */,
+                          20001 /* Washington, D.C. */,
+                          94101 /* San Francisco    */];
+  for i in 0..#num do
+    yield zips[i % zips.size];
+}
+
+proc Launcher(exec: string) {
+  var master = spawn(["master", "--mode=Master",
+                      "--memLeaks=" + memLeaks:string],
+                     env=env, executable=exec);
+
+  var workers: [1..numWorkers] subprocess(kind=iokind.dynamic, locking=true);
+  coforall (worker,i,zipc) in zip(workers, workers.domain,
+                                  zipcodes(numWorkers)) do
+    worker = spawn(["worker%i".format(i), "--mode=Worker",
+                    "--memLeaks=" + memLeaks:string,
+                    "--zipcode=%i".format(zipc)],
+                   env=env, executable=exec);
+
+  for worker in workers do
+    worker.communicate();
+  master.terminate();
+}
+
+proc Master(exec: string) {
+  var rand = new borrowed RandomStream(real,13); rand.getNext();
+  var ctxt: Context;
+  var sock = ctxt.socket(ZMQ.PUB);
+  sock.bind("tcp://*:5556");
+
+  record WeatherData {
+    var zipcode, temperature, humidity: int;
+  }
+
+  while true {
+    var data = new WeatherData(
+      (rand.getNext()*100000):int,
+      (rand.getNext()*215):int - 80,
+      (rand.getNext()*50):int + 10);
+    sock.send(data);
+  }
+}
+
+proc Worker(exec: string) {
+  const N = 5;
+
+  var ctxt: Context;
+  var sock = ctxt.socket(ZMQ.SUB);
+  sock.connect("tcp://localhost:5556");
+  sock.setsockopt(ZMQ.SUBSCRIBE, zipcode);
+
+  record WeatherData {
+    var zipcode, temperature, humidity: int;
+  }
+
+  var total = 0;
+  for 1..N {
+    var data = sock.recv(WeatherData);
+    total += data.temperature;
+  }
+  writef("Average temperature for zipcode '%05i' was %r F\n",
+         zipcode, total:real / N);
+}

--- a/test/deprecated/setSockoptSubscribe.good
+++ b/test/deprecated/setSockoptSubscribe.good
@@ -1,0 +1,6 @@
+Average temperature for zipcode '10001' was xx.x F
+Average temperature for zipcode '20001' was xx.x F
+Average temperature for zipcode '60290' was xx.x F
+Average temperature for zipcode '90001' was xx.x F
+setSockoptSubscribe.chpl:82: In function 'Worker':
+setSockoptSubscribe.chpl:88: warning: setsockopt is deprecated - please use e.g. setLinger instead

--- a/test/deprecated/setSockoptSubscribe.prediff
+++ b/test/deprecated/setSockoptSubscribe.prediff
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Fuzz the calculated "average temperature" values in the test output file.
+
+# The ZMQ setSockoptSubscribe example/test program uses a pub/sub communication model.
+# A ZMQ pub/sub connection is inherently unreliable (like UDP, unlike TCP).
+# If one or more messages get dropped, the values of "average temperature"
+# will come out different than usual, and Chapel's automated test harness
+# will raise an error.
+
+# This prediff fuzzes the calculated data just enough so the test will pass,
+# even if a few ZMQ messages get dropped as described above.
+
+outfile=$2
+sort $outfile | sed -e 's, [0-9.+-]* F$, xx.x F,' > $outfile.tmp
+mv $outfile.tmp $outfile
+
+# Note: the corresponding setSockoptSubscribe.good file has been fuzzed to agree
+# with the test output, after this prediff.  FYI, here is the original test
+# output from a normal setSockoptSubscribe.chpl test run with no dropped
+# messages (February, 2017)
+#
+# Average temperature for zipcode '10001' was 41 F
+# Average temperature for zipcode '60290' was 100.8 F
+# Average temperature for zipcode '90001' was 11.6 F
+# Average temperature for zipcode '20001' was 16.2 F

--- a/test/library/packages/ZMQ/weather.chpl
+++ b/test/library/packages/ZMQ/weather.chpl
@@ -85,7 +85,7 @@ proc Worker(exec: string) {
   var ctxt: Context;
   var sock = ctxt.socket(ZMQ.SUB);
   sock.connect("tcp://localhost:5556");
-  sock.setsockopt(ZMQ.SUBSCRIBE, zipcode);
+  sock.setSubscribe(zipcode);
 
   record WeatherData {
     var zipcode, temperature, humidity: int;


### PR DESCRIPTION
In #12356, we decided to deprecate setsockopt in favor of individual
setter methods on Sockets, similar to the individual getter methods.

This change adds a deprecation compiler warning to the two versions
of setsockopt, and updates the documentation of setsockopt, LINGER,
SUBSCRIBE, and UNSUBSCRIBE to note the deprecation and link to the
new alternative (as the constants are irrelevant when they are baked
into the method name).  It also adds setSubscribe and setUnsubscribe,
the only two replacement methods that were missing.

I copied the original "weather" test from the ZMQ directory to
test/deprecated (due to its reliance on `setsockopt(ZMQ.SUBSCRIBE...)`)
and altered the original to use `setSubscribe` instead.

Full std paratest with futures passed
- [x] double check documentation build
