### PR TITLE
Adjust PRECOMP to not rely on Chapel being set in env

### DIFF
--- a/test/interop/C/exportString/PRECOMP
+++ b/test/interop/C/exportString/PRECOMP
@@ -1,2 +1,2 @@
 #!/bin/bash
-chpl --library TestLibrary.chpl
+$3 --library TestLibrary.chpl


### PR DESCRIPTION
Looks like I made a mistake when writing the `PRECOMP` for the new export string tests. I relied on `chpl` being set in the environment. Fix the `PRECOMP` file to use the `chpl` executable passed in as argument `$3`.