### PR TITLE
Adding ScatterGather benchmark

### DIFF
--- a/test/arrays/perf/ScatterGather.chpl
+++ b/test/arrays/perf/ScatterGather.chpl
@@ -1,0 +1,121 @@
+use CyclicDist;
+use BlockDist;
+use BlockCycDist;
+use Time;
+
+config const N = 1024 * 1024;
+var arrSpace = {1..N};
+var scatterArr : [arrSpace] int;
+var gatherArr : [arrSpace] int;
+var cyclicDom = arrSpace dmapped Cyclic(startIdx=1);
+var blockDom = arrSpace dmapped Block(boundingBox=arrSpace);
+var blockCycDom = arrSpace dmapped BlockCyclic(startIdx=1, blocksize = N / (here.maxTaskPar * numLocales * 32));
+var cyclicArr : [cyclicDom] int;
+var blockArr : [blockDom] int;
+var blockCycArr : [blockCycDom] int;
+
+var timer = new Timer();
+timer.start();
+scatterArr = 1..N;
+timer.stop();
+writeln("Assign Range into DefaultRectangular: ", timer.elapsed());
+timer.clear();
+
+timer.start();
+gatherArr = scatterArr;
+timer.stop();
+writeln("Assign DefaultRectangular into DefaultRectangular: ", timer.elapsed());
+timer.clear();
+
+
+timer.start();
+cyclicArr = 1..N;
+timer.stop();
+writeln("Scatter Range into CyclicDist: ", timer.elapsed());
+timer.clear();
+
+timer.start();
+cyclicArr = scatterArr;
+timer.stop();
+writeln("Scatter DefaultRectangular into CyclicDist: ", timer.elapsed());
+timer.clear();
+
+timer.start();
+gatherArr = cyclicArr;
+timer.stop();
+writeln("Gather CyclicDist into DefaultRectangular: ", timer.elapsed());
+timer.clear();
+
+timer.start();
+blockArr = 1..N;
+timer.stop();
+writeln("Scatter Range into BlockDist: ", timer.elapsed());
+timer.clear();
+
+timer.start();
+gatherArr = blockArr;
+timer.stop();
+writeln("Gather BlockDist into DefaultRectangular: ", timer.elapsed());
+timer.clear();
+
+timer.start();
+blockArr = scatterArr;
+timer.stop();
+writeln("Scatter DefaultRectangular into BlockDist: ", timer.elapsed());
+timer.clear();
+
+timer.start();
+blockCycArr = 1..N;
+timer.stop();
+writeln("Scatter Range into BlockCycDist: ", timer.elapsed());
+timer.clear();
+
+timer.start();
+gatherArr = blockCycArr;
+timer.stop();
+writeln("Gather BlockCycDist into DefaultRectangular: ", timer.elapsed());
+timer.clear();
+
+timer.start();
+blockCycArr = scatterArr;
+timer.stop();
+writeln("Scatter DefaultRectangular into BlockCycDist: ", timer.elapsed());
+timer.clear();
+
+// Unimplemented
+/*timer.start();
+blockCycArr = cyclicArr;
+timer.stop();
+writeln("GatherScatter CyclicDist into BlockCycDist: ", timer.elapsed());
+timer.clear();*/
+
+// Unimplemented
+/*timer.start();
+cyclicArr = blockCycArr;
+timer.stop();
+writeln("GatherScatter BlockCycDist into CyclicDist: ", timer.elapsed());
+timer.clear();*/
+
+timer.start();
+blockArr = blockCycArr;
+timer.stop();
+writeln("GatherScatter BlockCycDist into BlockDist: ", timer.elapsed());
+timer.clear();
+
+timer.start();
+blockCycArr = blockArr;
+timer.stop();
+writeln("GatherScatter BlockDist into BlockCycDist: ", timer.elapsed());
+timer.clear();
+
+timer.start();
+blockArr = cyclicArr;
+timer.stop();
+writeln("GatherScatter CyclicDist into BlockDist: ", timer.elapsed());
+timer.clear();
+
+timer.start();
+cyclicArr = blockArr;
+timer.stop();
+writeln("GatherScatter BlockDist into CyclicDist: ", timer.elapsed());
+timer.clear();


### PR DESCRIPTION
Just as an offering. Currently I have not created the `.perfkeys`, `.perfexecopts`, or even `.graph` file for this as I did not want to waste additional time on it if it will be rejected. This microbenchmark profiles the overhead of scattering, gathering, and scatter-gathering of distributed arrays and shared-memory arrays. Current performance...

**GASNet (Infiniband), Array Size 1M, 4 Nodes**
```
Assign Range into DefaultRectangular: 0.000522
Assign DefaultRectangular into DefaultRectangular: 0.002229
Scatter Range into CyclicDist: 0.002025
Scatter DefaultRectangular into CyclicDist: 2.81914
Gather CyclicDist into DefaultRectangular: 3.61649
Scatter Range into BlockDist: 0.001792
Gather BlockDist into DefaultRectangular: 2.45244
Scatter DefaultRectangular into BlockDist: 2.60533
Scatter Range into BlockCycDist: 0.02425
Gather BlockCycDist into DefaultRectangular: 20.6191
Scatter DefaultRectangular into BlockCycDist: 1.24126
GatherScatter BlockCycDist into BlockDist: 5.68651
GatherScatter BlockDist into BlockCycDist: 1.13376
GatherScatter CyclicDist into BlockDist: 1.12411
GatherScatter BlockDist into CyclicDist: 0.973012
```

**uGNI, Array Size 1M, 4 Locales**

```
Assign Range into DefaultRectangular: 0.000364
Assign DefaultRectangular into DefaultRectangular: 0.001207
Scatter Range into CyclicDist: 0.043102
Scatter DefaultRectangular into CyclicDist: 0.038987
Gather CyclicDist into DefaultRectangular: 0.050413
Scatter Range into BlockDist: 0.000457
Gather BlockDist into DefaultRectangular: 0.057287
Scatter DefaultRectangular into BlockDist: 0.039265
Scatter Range into BlockCycDist: 0.001268
Gather BlockCycDist into DefaultRectangular: 0.27209
Scatter DefaultRectangular into BlockCycDist: 0.021401
GatherScatter BlockCycDist into BlockDist: 0.088898
GatherScatter BlockDist into BlockCycDist: 0.025082
GatherScatter CyclicDist into BlockDist: 0.022753
GatherScatter BlockDist into CyclicDist: 0.021781
```

**uGNI, Array Size 64M, 4 Locales**

```
Assign Range into DefaultRectangular: 0.011722
Assign DefaultRectangular into DefaultRectangular: 0.095112
Scatter Range into CyclicDist: 0.006574
Scatter DefaultRectangular into CyclicDist: 7.1195
Gather CyclicDist into DefaultRectangular: 3.01442
Scatter Range into BlockDist: 0.00276
Gather BlockDist into DefaultRectangular: 3.71762
Scatter DefaultRectangular into BlockDist: 2.46988
Scatter Range into BlockCycDist: 0.040132
Gather BlockCycDist into DefaultRectangular: 19.4743
Scatter DefaultRectangular into BlockCycDist: 1.34502
GatherScatter BlockCycDist into BlockDist: 4.8703
GatherScatter BlockDist into BlockCycDist: 1.25031
GatherScatter CyclicDist into BlockDist: 1.02887
GatherScatter BlockDist into CyclicDist: 1.13656
```

**uGNI, Array Size 64M, 16 Locales**

```
Assign Range into DefaultRectangular: 0.009359
Assign DefaultRectangular into DefaultRectangular: 0.074217
Scatter Range into CyclicDist: 0.004119
Scatter DefaultRectangular into CyclicDist: 3.08712
Gather CyclicDist into DefaultRectangular: 36.9208
Scatter Range into BlockDist: 0.00097
Gather BlockDist into DefaultRectangular: 3.75993
Scatter DefaultRectangular into BlockDist: 2.61211
Scatter Range into BlockCycDist: 0.010724
Gather BlockCycDist into DefaultRectangular: 21.2809
Scatter DefaultRectangular into BlockCycDist: 0.879211
GatherScatter BlockCycDist into BlockDist: 2.57381
GatherScatter BlockDist into BlockCycDist: 1.2945
GatherScatter CyclicDist into BlockDist: 1.51932
GatherScatter BlockDist into CyclicDist: 0.614763
```

**Important Takeaway:** There is no scalability w.r.t scattering and gathering for distributed arrays. In fact, performance **degrades** for scattering into a shared-memory array.

**By Quadrupling the number of compute nodes...**
Gathering Cyclic into DefaultRectangular **decreased by an order of magnitude.**
Gathering BlockDist into DefaultRectangular offers **no speedup.**
Gathering BlockCycDist into DefaultRectangular offers slightly degrading performance, but it is already almost an order of magnitude slower than other distributions.

Lastly, GASNet Infiniband is *slow*.

I think that a benchmark like this may be valuable. @ronawho and @bradcray 