### PR TITLE
Privately use these two enums in RangeChunk package module

### DIFF
--- a/modules/packages/RangeChunk.chpl
+++ b/modules/packages/RangeChunk.chpl
@@ -51,8 +51,8 @@ module RangeChunk {
     Pack,
     Mod
   }
-  use RemElems;
-  use BoundedRangeType;
+  private use RemElems;
+  private use BoundedRangeType;
 
   
   /*


### PR DESCRIPTION
The symbols in them are potentially names a user would want to use for their
symbols.  If they want to use these enums, they can do so themselves.

Passed full paratest with futures