### PR TITLE
Change some of the uses in the TOML library to private

### DIFF
--- a/modules/packages/TOML.chpl
+++ b/modules/packages/TOML.chpl
@@ -117,7 +117,7 @@ Parser module with the Toml class for the Chapel TOML library.
 */
 module TomlParser {
 
-  use Regexp;
+  private use Regexp;
   use DateTime;
 
 
@@ -992,7 +992,7 @@ pragma "no doc"
  */
 module TomlReader {
 
- use Regexp;
+ private use Regexp;
 
  config const debugTomlReader = false;
 

--- a/modules/packages/TOML.chpl
+++ b/modules/packages/TOML.chpl
@@ -463,7 +463,7 @@ pragma "no doc"
    fieldDate,
    fieldTime,
    fieldDateTime };
- use fieldtag;
+ private use fieldtag;
 
  pragma "no doc"
  proc =(ref t: unmanaged Toml, s: string) {

--- a/modules/packages/TOML.chpl
+++ b/modules/packages/TOML.chpl
@@ -35,7 +35,7 @@ module TOML {
 
 
 use TomlParser;
-use TomlReader;
+private use TomlReader;
 
 
 /* Receives a TOML file as a parameter and outputs a Toml object.

--- a/tools/mason/MasonBuild.chpl
+++ b/tools/mason/MasonBuild.chpl
@@ -212,7 +212,7 @@ proc compileSrc(lockFile: borrowed Toml, binLoc: string, show: bool,
 proc genSourceList(lockFile: borrowed Toml) {
   var sourceList: [1..0] (string, string, string);
   for (name, package) in zip(lockFile.D, lockFile.A) {
-    if package.tag == fieldToml {
+    if package.tag == fieldtag.fieldToml {
       if name == "root" || name == "system" || name == "external" then continue;
       else {
         var version = lockFile[name]["version"].s;

--- a/tools/mason/MasonExternal.chpl
+++ b/tools/mason/MasonExternal.chpl
@@ -241,7 +241,7 @@ proc getExternalPackages(exDeps: unmanaged Toml) {
   for (name, spec) in zip(exDeps.D, exDeps.A) {
     try! {
       select spec.tag {
-          when fieldToml do continue;
+          when fieldtag.fieldToml do continue;
           otherwise {
             // Take key from toml file if not present in spec
             var tempSpec = spec.s;

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -443,7 +443,7 @@ proc isIdentifier(name:string) {
    TODO custom fields returned */
 iter allFields(tomlTbl: unmanaged Toml) {
   for (k,v) in zip(tomlTbl.D, tomlTbl.A) {
-    if v.tag == fieldToml then
+    if v.tag == fieldtag.fieldToml then
       continue;
     else yield(k,v);
   }


### PR DESCRIPTION
This changes the use of TomlReader, Regexp, and fieldtag to private.
TomlReader is a "no doc"ed submodule, Regexp is only used in the
implementation of the functions that use it, and fieldtag is a
"no doc"ed enum.

It leaves the uses of TomlParser and DateTime public.  The former is
a submodule with documented portions, while DateTime's types are
used as the type of arguments for some of its public functions.

As a result of making the use of the "no doc"ed enum private, the
Mason support files that referenced the enum constant needed to
either use the enum themselves, or add the enum name prefix.  Since
only one constant was used in each of those files once, I chose to
just add the enum name prefix.  It might be worth considering whether
this enum should be public and documented due to its use in other
places than just the TOML module . . .

Passed a full paratest with futures