### PR TITLE
Make the use of the Reflection and ExplicitRefCount modules private to Futures

### DIFF
--- a/modules/packages/Futures.chpl
+++ b/modules/packages/Futures.chpl
@@ -104,8 +104,8 @@ The following example demonstrate bundling of futures.
 
 module Futures {
 
-  use Reflection;
-  use ExplicitRefCount;
+  private use Reflection;
+  private use ExplicitRefCount;
 
   pragma "no doc"
   class FutureClass: RefCountBase {


### PR DESCRIPTION
Reflection is used in the implementation of some functions, while
ExplicitRefCount's type is "no doc"d and used in a "no doc"d type.  Therefore,
these do not need to be exposed to the clients of the Futures module.

Full paratest with futures passed