### PR TITLE
Make the use of the Path module private to FileSystem

### DIFF
--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -85,7 +85,8 @@
  */
 module FileSystem {
 
-use SysError, Path;
+  use SysError;
+  private use Path;
 
 /* S_IRUSR and the following constants are values of the form
    S_I[R | W | X][USR | GRP | OTH], S_IRWX[U | G | O], S_ISUID, S_ISGID, or


### PR DESCRIPTION
The symbols from the Path module being used are part of the implementation and
thus not something that needs to be exposed to the user.

I left the use of SysError public due to the functions throwing SystemErrors.
If the result of the conversation in email and #13495 decides that is not the
right call, I can make it private then.

I have left the uses of GlobWrappers as is for two reasons: first, they are
within the scope of the functions that need them; second, the module itself is
already private, so would not bleed into the namespace of FileSystem's clients
anyways.

I left the use of Sort as is also because it was within the scope of the
function that needs it.

Full paratest with futures passed