### PR TITLE
Skip this test when ZMQ is not installed or when running CHPL_COMM != none

### DIFF
--- a/test/deprecated/setSockoptSubscribe.skipif
+++ b/test/deprecated/setSockoptSubscribe.skipif
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+
+"""
+ The ZMQ package requires the zmq library.
+
+ Installation of the ZMQ library is detected with the find_library function,
+ which looks for the appropriate dynamic library (e.g. libzmq.so).
+ Note that if the dynamic library is found, this test assumes that the
+ header and static library are available.
+
+ Skip CHPL_COMM != none, too
+"""
+
+from __future__ import print_function
+from ctypes.util import find_library
+from os import environ
+
+# Is ZMQ available?
+zmq_found = find_library('zmq') is not None
+
+# OK contains the conditions that must be met to run the test
+OK = zmq_found
+
+commSet = environ['CHPL_COMM'] != 'none'
+
+print(commSet or not OK)


### PR DESCRIPTION
I missed copying the skipifs when I copied this test.  Rectify that error.

Verified that the test ran locally with ZMQ and CHPL_COMM=none, and skipped when
CHPL_COMM != none and when no ZMQ was present but CHPL_COMM was none.