### PR TITLE
Add a note to guard against a concern of Michael's for the ZMQ module

### DIFF
--- a/modules/packages/ZMQ.chpl
+++ b/modules/packages/ZMQ.chpl
@@ -612,7 +612,7 @@ module ZMQ {
     // Note: if we make this private but haven't exposed all the setsockopt
     // options, users will need another way to work around that lack of support.
     // Currently, they can work around it by defining their own extern version
-    // and using this field.
+    // and using this field (see #13503)
     pragma "no doc"
     var classRef: unmanaged SocketClass;
 

--- a/modules/packages/ZMQ.chpl
+++ b/modules/packages/ZMQ.chpl
@@ -609,6 +609,10 @@ module ZMQ {
     Note that this record contains private fields not listed below.
    */
   record Socket {
+    // Note: if we make this private but haven't exposed all the setsockopt
+    // options, users will need another way to work around that lack of support.
+    // Currently, they can work around it by defining their own extern version
+    // and using this field.
     pragma "no doc"
     var classRef: unmanaged SocketClass;
 


### PR DESCRIPTION
Michael wants to be certain that if we fail to provide support for a particular
ZMQ option, the user has a way to work around it until we do support it.  With
setsockopt going away, the current strategy relies on the Socket classRef field
not being private.  Leave a note on that field so we don't forget about that
benefit when the day comes where we can make it private.