### PR TITLE
Fix a failure to report an error when a default argument value throws

### DIFF
--- a/compiler/include/flags_list.h
+++ b/compiler/include/flags_list.h
@@ -103,6 +103,7 @@ symbolFlag( FLAG_DATA_CLASS , ypr, "data class" , ncm )
 
 // Flag for temporaries created for default values
 symbolFlag( FLAG_DEFAULT_ACTUAL, npr, "default actual temp", ncm)
+symbolFlag( FLAG_DEFAULT_ACTUAL_FUNCTION, npr, "default actual function", "applied to functions created for formal default values")
 
 // Enable override for default-intent for types defined in terms of record/class
 symbolFlag( FLAG_DEFAULT_INTENT_IS_REF, ypr, "default intent is ref", "The default intent for this type is ref")

--- a/compiler/passes/errorHandling.cpp
+++ b/compiler/passes/errorHandling.cpp
@@ -631,15 +631,18 @@ static bool catchesNotExhaustive(TryStmt* tryStmt) {
 static bool shouldEnforceStrict(CallExpr* node, int taskFunctionDepth) {
   if (FnSymbol* calledFn = node->resolvedFunction()) {
     bool inCompilerGeneratedFn = false;
+    bool inDefaultActualFn = false;
     if (FnSymbol* parentFn = toFnSymbol(node->parentSymbol)) {
       // Don't check wrapper functions in strict mode, unless they are task
       // functions and we know the caller of the task function is not declared
       // as throws.
       inCompilerGeneratedFn = isCompilerGeneratedFunction(parentFn) &&
         !(isTaskFun(parentFn) && taskFunctionDepth > 0);
+      inDefaultActualFn = parentFn->hasFlag(FLAG_DEFAULT_ACTUAL_FUNCTION);
     }
     bool callsUncheckedThrowsFn = isUncheckedThrowsFunction(calledFn);
-    bool strictError = !(inCompilerGeneratedFn || callsUncheckedThrowsFn);
+    bool strictError = !((inCompilerGeneratedFn && !inDefaultActualFn) ||
+                         callsUncheckedThrowsFn);
 
     return strictError;
   }

--- a/compiler/passes/normalizeErrors.cpp
+++ b/compiler/passes/normalizeErrors.cpp
@@ -58,7 +58,10 @@ bool NormalizeTryExprsVisitor::enterCallExpr(CallExpr* call) {
     parentTag = stack.top();
   }
 
-  if (isTryBang || parentTag == TRY_TAG_IN_TRYBANG) {
+  if (call->tryTag != TRY_TAG_NONE) {
+    // if this expr is already marked with try or try! leave it alone
+    tag = call->tryTag;
+  } else if (isTryBang || parentTag == TRY_TAG_IN_TRYBANG) {
     // try! on this expr or a parent always makes it try!
     tag = TRY_TAG_IN_TRYBANG;
   } else if (isTry || parentTag == TRY_TAG_IN_TRY) {

--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -431,6 +431,7 @@ static DefaultExprFnEntry buildDefaultedActualFn(FnSymbol*  fn,
     wrapper->addFlag(FLAG_WAS_COMPILER_GENERATED);
   }
 
+  wrapper->addFlag(FLAG_DEFAULT_ACTUAL_FUNCTION);
   wrapper->addFlag(FLAG_COMPILER_GENERATED);
   wrapper->addFlag(FLAG_MAYBE_PARAM);
   wrapper->addFlag(FLAG_MAYBE_TYPE);

--- a/test/errhandling/diten/defaultArgThrowsUncaught.chpl
+++ b/test/errhandling/diten/defaultArgThrowsUncaught.chpl
@@ -1,0 +1,16 @@
+module M {
+  config var cond = false;
+  
+  proc myproc(x = thrower()) {
+    return x;
+  }
+
+  proc thrower() throws {
+    if cond then
+      throw new owned Error();
+    return 1;
+  }
+
+  var a = myproc();
+  writeln(a);
+}

--- a/test/errhandling/diten/defaultArgThrowsUncaught.good
+++ b/test/errhandling/diten/defaultArgThrowsUncaught.good
@@ -1,0 +1,2 @@
+defaultArgThrowsUncaught.chpl:4: error: call to throwing function thrower without throws, try, or try! (relaxed mode)
+defaultArgThrowsUncaught.chpl:8: note: throwing function thrower defined here

--- a/test/errhandling/diten/throwDefaultArgTry.chpl
+++ b/test/errhandling/diten/throwDefaultArgTry.chpl
@@ -8,7 +8,7 @@ module M {
     return 1;
   }
 
-  proc myproc(arg = thrower()) throws {
+  proc myproc(arg = try thrower()) throws {
     writeln(arg);
     return arg;
   }


### PR DESCRIPTION
When a function has a default argument that throws but the function is not
marked 'throws', it should be reported as a compile time error. Default
argument values are pulled out into wrapper functions that are called before
the original function. When creating this wrapper, mark it with a new flag
FLAG_DEFAULT_ACTUAL_FUNCTION. When issuing errors about throwing from
functions not marked with 'throws', include functions with this flag even
though they also have FLAG_COMPILER_GENERATED.

If a CallExpr already has its tryTag set to something other than TRY_TAG_NONE,
don't clear it in NormalizeTryExprsVisitor::enterCallExpr.

Added a test that previously failed to issue the desired error, but now does.

Update a test to use a try expression in a test using strict mode.

Resolves issue #13477.