### PR TITLE
Change some public uses in ChapelSyncvar to private

### DIFF
--- a/modules/internal/ChapelSyncvar.chpl
+++ b/modules/internal/ChapelSyncvar.chpl
@@ -42,7 +42,7 @@ module ChapelSyncvar {
   private use ChapelStandard;
 
   use AlignedTSupport;
-  use MemConsistency;
+  private use MemConsistency;
   use SyncVarRuntimeSupport;
 
   /************************************ | *************************************

--- a/modules/internal/ChapelSyncvar.chpl
+++ b/modules/internal/ChapelSyncvar.chpl
@@ -39,7 +39,7 @@ proceed if it is a single variable.
 */
 
 module ChapelSyncvar {
-  use ChapelStandard;
+  private use ChapelStandard;
 
   use AlignedTSupport;
   use MemConsistency;


### PR DESCRIPTION
Make the use of ChapelStandard private, as has already been
done generally (there are still a few other places where
ChapelStandard is publicly used, so we may see some fallout as
those uses become private, but that will be tackled when it comes
up).

Also makes the use of MemConsistency private, as the only
symbols from it that are used are used in the implementation
rather than the private interface.

I left the other uses in this module alone - AlignedTSupport and
SyncVarRuntimeSupport are both private modules, so using them does not expose
their symbols further.  The uses in SyncVarRuntimeSupport are also not really
public due to the module itself being private - they may impact the visibility
of symbols in ChapelSyncvar, but ChapelSyncvar already uses both of these
modules so is unlikely to be impacted either way.

Passed a full paratest with futures