### PR TITLE
Extend MPP error coverage in prediff-for-Jira-203

### DIFF
--- a/util/test/prediff-for-Jira-203
+++ b/util/test/prediff-for-Jira-203
@@ -24,5 +24,6 @@
 
 outfile=$2
 sed < $outfile > $outfile.tmp -e '/Transient MPP reservation error on create/d' \
+                              -e '/Transient MPP reservation error preparing request/d' \
                               -e '/Transient MPP reservation error on confirm/d'
 mv -f $outfile.tmp $outfile

--- a/util/test/prediff-for-Jira-203
+++ b/util/test/prediff-for-Jira-203
@@ -8,13 +8,6 @@
 # This is thought to be a system issue, caused by a miscommunication between
 # ALPS and PBS. Not a Chapel issue.
 
-# Note: start_test's error handler also recognizes the same string,
-#   "Transient MPP reservation error on create",
-# and, if found, generates a more-recognizable error msg,
-#   "Error: Jira 203 -- Transient MPP reservation error",
-# instead of the generic
-#   "Error matching program output".
-
 # See Jira #203 (https://chapel.atlassian.net/browse/CHAPEL-203) for more info.
 
 # To use this prediff file with start_test (assuming bash):
@@ -23,7 +16,5 @@
 # start_test ...
 
 outfile=$2
-sed < $outfile > $outfile.tmp -e '/Transient MPP reservation error on create/d' \
-                              -e '/Transient MPP reservation error preparing request/d' \
-                              -e '/Transient MPP reservation error on confirm/d'
+sed < $outfile > $outfile.tmp -e '/Transient MPP reservation error/d'
 mv -f $outfile.tmp $outfile


### PR DESCRIPTION
Yesterday we got a new variant of "Transient MPP reservation error"
in our nightly testing. Adding this variant to our filters to suppress it going forward.