### PR TITLE
Reduce the use of compute_call_sites()

### DIFF
--- a/compiler/AST/astutil.cpp
+++ b/compiler/AST/astutil.cpp
@@ -186,13 +186,15 @@ void reset_ast_loc(BaseAST* destNode, astlocT astlocArg) {
   AST_CHILDREN_CALL(destNode, reset_ast_loc, astlocArg);
 }
 
-void compute_fn_call_sites(FnSymbol* fn, bool allowChildren) {
+void compute_fn_call_sites(FnSymbol* fn, bool allowVirtual) {
 /* If present, fn->calledBy needs to be set up in advance.
    See the comment in compute_call_sites() */
 
   if (fn->calledBy == NULL) {
     fn->calledBy = new Vec<CallExpr*>();
   }
+
+  INT_ASSERT(allowVirtual || virtualRootsMap.get(fn) == NULL);
 
   for_SymbolSymExprs(se, fn) {
     if (CallExpr* call = toCallExpr(se->parentExpr)) {
@@ -215,7 +217,7 @@ void compute_fn_call_sites(FnSymbol* fn, bool allowChildren) {
           Vec<FnSymbol*>* children = virtualChildrenMap.get(fn);
 
           fn->calledBy->add(call);
-          INT_ASSERT(allowChildren);
+          INT_ASSERT(allowVirtual);
 
           forv_Vec(FnSymbol, child, *children) {
             if (!child->calledBy)

--- a/compiler/AST/astutil.cpp
+++ b/compiler/AST/astutil.cpp
@@ -186,7 +186,7 @@ void reset_ast_loc(BaseAST* destNode, astlocT astlocArg) {
   AST_CHILDREN_CALL(destNode, reset_ast_loc, astlocArg);
 }
 
-void compute_fn_call_sites(FnSymbol* fn) {
+void compute_fn_call_sites(FnSymbol* fn, bool allowChildren) {
 /* If present, fn->calledBy needs to be set up in advance.
    See the comment in compute_call_sites() */
 
@@ -215,6 +215,7 @@ void compute_fn_call_sites(FnSymbol* fn) {
           Vec<FnSymbol*>* children = virtualChildrenMap.get(fn);
 
           fn->calledBy->add(call);
+          INT_ASSERT(allowChildren);
 
           forv_Vec(FnSymbol, child, *children) {
             if (!child->calledBy)

--- a/compiler/include/astutil.h
+++ b/compiler/include/astutil.h
@@ -65,7 +65,7 @@ void reset_ast_loc(BaseAST* destNode, astlocT astloc);
 void reset_ast_loc(BaseAST* destNode, BaseAST* sourceNode);
 
 // compute call sites FnSymbol::calls
-void compute_fn_call_sites(FnSymbol* fn, bool allowChildren = true);
+void compute_fn_call_sites(FnSymbol* fn, bool allowVirtual = true);
 void compute_call_sites();
 
 //

--- a/compiler/include/astutil.h
+++ b/compiler/include/astutil.h
@@ -65,7 +65,7 @@ void reset_ast_loc(BaseAST* destNode, astlocT astloc);
 void reset_ast_loc(BaseAST* destNode, BaseAST* sourceNode);
 
 // compute call sites FnSymbol::calls
-void compute_fn_call_sites(FnSymbol* fn);
+void compute_fn_call_sites(FnSymbol* fn, bool allowChildren = true);
 void compute_call_sites();
 
 //

--- a/compiler/include/passes.h
+++ b/compiler/include/passes.h
@@ -102,6 +102,8 @@ void deadBlockElimination();
 
 // flattenFunctions.cpp
 void flattenNestedFunction(FnSymbol* nestedFunction);
+// When fastCCS=true, call sites are computed only for the functions that
+// are looked at. Such functions must not have dispatch parents/children.
 void flattenNestedFunctions(Vec<FnSymbol*>& nestedFunctions,
                             bool fastCCS = false);
 

--- a/compiler/include/passes.h
+++ b/compiler/include/passes.h
@@ -102,7 +102,8 @@ void deadBlockElimination();
 
 // flattenFunctions.cpp
 void flattenNestedFunction(FnSymbol* nestedFunction);
-void flattenNestedFunctions(Vec<FnSymbol*>& nestedFunctions);
+void flattenNestedFunctions(Vec<FnSymbol*>& nestedFunctions,
+                            bool fastCCS = false);
 
 // foralls.cpp
 void checkTypeParamTaskIntent(SymExpr* outerSE);


### PR DESCRIPTION
The lowerForalls sub-pass of the compiler makes extensive use of
flattenNestedFunction(FnSymbol*) to flatten newly-created clones of
task functions. This results in a significant portion of compilation
time being spent in compute_call_sites().

This is because flattenNestedFunction(FnSymbol*) invokes
flattenNestedFunctions(Vec), which invokes compute_call_sites(), which
sets up the calledBy vector on every live FnSymbol. Which, among others,
includes allocation of calledBy vectors and possibly deallocation of their
old contents, and traversing the dispatch children of dynamically-dispatched
FnSymbols. Given that flattenNestedFunction(FnSymbol*) needs to look
only at a handful of other functions, if at all, and none of those
participate in dynamic dispatch, most of compute_call_sites() work
is unused upon a flattenNestedFunction(FnSymbol*).

This change adds a `fastCCS` argument to flattenNestedFunctions(Vec).
When it is invoked from flattenNestedFunction(FnSymbol*), this
argument is enabled. This causes flattenNestedFunctions(Vec)
to avoid compute_call_sites(), instead computing `calledBy` only
for those functions that will be looked at. I added an assertion
that these functions do not participate in dynamic dispatch, because
otherwise `calledBy` computation may be incorrect.
Ideally we will replace most uses of compute_call_sites()
with a way to iterate over all call sites and virtual calls,
a-la for_SymbolSymExprs. 

Testing: linux64 -futures, gasnet multilocale tests.
