### PR TITLE
Suppress exportString tests that fail with CHPL_TARGET_COMPILER=cray-prgenv-cray

### DIFF
--- a/test/interop/C/exportString/noArgsRetString.suppressif
+++ b/test/interop/C/exportString/noArgsRetString.suppressif
@@ -1,5 +1,5 @@
 #
 # The Cray CC is a bit more strict about pointer conversions and does not have
-# a flag equivalent to "-Wno-pointer-sign".
+# a flag equivalent to GCC's "-Wno-pointer-sign".
 #
 CHPL_TARGET_COMPILER==cray-prgenv-cray

--- a/test/interop/C/exportString/noArgsRetString.suppressif
+++ b/test/interop/C/exportString/noArgsRetString.suppressif
@@ -1,0 +1,5 @@
+#
+# The Cray CC is a bit more strict about pointer conversions and does not have
+# a flag equivalent to "-Wno-pointer-sign".
+#
+CHPL_TARGET_COMPILER==cray-prgenv-cray

--- a/test/interop/C/exportString/stringArgsRetString.suppressif
+++ b/test/interop/C/exportString/stringArgsRetString.suppressif
@@ -1,5 +1,5 @@
 #
 # The Cray CC is a bit more strict about pointer conversions and does not have
-# a flag equivalent to "-Wno-pointer-sign".
+# a flag equivalent to GCC's "-Wno-pointer-sign".
 #
 CHPL_TARGET_COMPILER==cray-prgenv-cray

--- a/test/interop/C/exportString/stringArgsRetString.suppressif
+++ b/test/interop/C/exportString/stringArgsRetString.suppressif
@@ -1,0 +1,5 @@
+#
+# The Cray CC is a bit more strict about pointer conversions and does not have
+# a flag equivalent to "-Wno-pointer-sign".
+#
+CHPL_TARGET_COMPILER==cray-prgenv-cray


### PR DESCRIPTION
This PR suppresses two tests that currently fail in a cray-xc environment with CHPL_TARGET_COMPILER=cray-prgenv-cray. The Chapel type `c_ptr(c_char)` currently maps to `int8_t*` on most systems, which causes the GNU compiler to emit warnings that can be suppressed with `-Wno-pointer-sign`. There is no equivalent for Cray CC, so we should suppress these tests until https://github.com/chapel-lang/chapel/issues/6041 is resolved. 
