### PR TITLE
Add a new environment variable, CHPL_LAUNCH_MASTERIP

### DIFF
--- a/doc/rst/platforms/aws.rst
+++ b/doc/rst/platforms/aws.rst
@@ -162,7 +162,7 @@ Some other common optional configurations are:
     # Defaults to gethostname() of the launching node
     GASNET_MASTERIP='ec2-11-222-33-444.us-west-2.compute.amazonaws.com'
     # alternatively, this variable will also set GASNET_MASTERIP to the same
-    # value if GASNET_MASTERIP was not set.
+    # value.
     CHPL_LAUNCH_MASTERIP='ec2-11-222-33-444.us-west-2.compute.amazonaws.com'
     # Defaults to empty, can be used instead of copying config files onto each machine
     SSH_OPTIONS='-i ~/.ssh/foo.pem'

--- a/doc/rst/platforms/aws.rst
+++ b/doc/rst/platforms/aws.rst
@@ -160,12 +160,11 @@ Some other common optional configurations are:
     # Defaults to current working directory
     GASNET_REMOTE_PATH='~/chapel-projects/'
     # Defaults to gethostname() of the launching node
-    GASNET_MASTERIP='ec2-11-222-33-444.us-west-2.compute.amazonaws.com'
-    # alternatively, this variable will also set GASNET_MASTERIP to the same
-    # value.
     CHPL_LAUNCH_MASTERIP='ec2-11-222-33-444.us-west-2.compute.amazonaws.com'
     # Defaults to empty, can be used instead of copying config files onto each machine
     SSH_OPTIONS='-i ~/.ssh/foo.pem'
+
+See :ref:`chpl-launch-masterip` for details on that environment variable.
 
 .. _GASNet documentation: http://gasnet.lbl.gov/dist/udp-conduit/README
 

--- a/doc/rst/platforms/aws.rst
+++ b/doc/rst/platforms/aws.rst
@@ -161,6 +161,9 @@ Some other common optional configurations are:
     GASNET_REMOTE_PATH='~/chapel-projects/'
     # Defaults to gethostname() of the launching node
     GASNET_MASTERIP='ec2-11-222-33-444.us-west-2.compute.amazonaws.com'
+    # alternatively, this variable will also set GASNET_MASTERIP to the same
+    # value if GASNET_MASTERIP was not set.
+    CHPL_LAUNCH_MASTERIP='ec2-11-222-33-444.us-west-2.compute.amazonaws.com'
     # Defaults to empty, can be used instead of copying config files onto each machine
     SSH_OPTIONS='-i ~/.ssh/foo.pem'
 

--- a/doc/rst/platforms/udp.rst
+++ b/doc/rst/platforms/udp.rst
@@ -153,9 +153,10 @@ I get xSocket errors when using a system with multiple IP addresses
  *** FATAL ERROR: Got an xSocket while spawning slave process: connect()
  failed while creating a connect socket (111:Connection refused)
 
-You need to set ``GASNET_MASTERIP`` and possibly ``GASNET_WORKERIP``.
-Please refer to:
+You need to set ``CHPL_LAUNCH_MASTERIP`` or ``GASNET_MASTERIP``, and possibly
+``GASNET_WORKERIP``.  Please refer to:
 
+  * :ref:`chpl-launch-masterip`
   * ``$CHPL_HOME/third-party/gasnet/gasnet-src/udp-conduit/README``
   * http://gasnet.lbl.gov/dist/udp-conduit/README .
 

--- a/doc/rst/platforms/udp.rst
+++ b/doc/rst/platforms/udp.rst
@@ -153,7 +153,7 @@ I get xSocket errors when using a system with multiple IP addresses
  *** FATAL ERROR: Got an xSocket while spawning slave process: connect()
  failed while creating a connect socket (111:Connection refused)
 
-You need to set ``CHPL_LAUNCH_MASTERIP`` or ``GASNET_MASTERIP``, and possibly
+You need to set ``CHPL_LAUNCH_MASTERIP`` (or ``GASNET_MASTERIP``), and possibly
 ``GASNET_WORKERIP``.  Please refer to:
 
   * :ref:`chpl-launch-masterip`

--- a/doc/rst/usingchapel/launcher.rst
+++ b/doc/rst/usingchapel/launcher.rst
@@ -116,7 +116,7 @@ to connect.  By default, the node creating the connection will pass the result
 of ``gethostname()`` on to the nodes that need to connect to it, which will
 resolve that to an IP address using ``gethostbynname()``.
 
-When ``CHPL_COMM == gasnet``, this will be used to set the value of
+When ``CHPL_COMM == gasnet``, this will also be used to set the value of
 ``GASNET_MASTERIP``, which corresponds to the hostname of the master node (see
 http://gasnet.lbl.gov/dist/udp-conduit/README ).
 

--- a/doc/rst/usingchapel/launcher.rst
+++ b/doc/rst/usingchapel/launcher.rst
@@ -111,11 +111,14 @@ some launchers might not correctly forward all environment variables.
 CHPL_LAUNCH_MASTERIP
 ********************
 
-This environment variable is intended as an expansion on ``GASNET_MASTERIP``
-(see http://gasnet.lbl.gov/dist/udp-conduit/README ).  When set, if
-``GASNET_MASTERIP`` is not already present in the environment it will be set to
-the same value.  ``CHPL_LAUNCH_MASTERIP`` will also be used by multilocale
-libraries when communicating.
+This environment variable is used to specify the IP address which should be used
+to connect.  By default, the node creating the connection will pass the result
+of ``gethostname()`` on to the nodes that need to connect to it, which will
+resolve that to an IP address using ``gethostbynname()``.
+
+When ``CHPL_COMM == gasnet``, this will be used to set the value of
+``GASNET_MASTERIP``, which corresponds to the hostname of the master node (see
+http://gasnet.lbl.gov/dist/udp-conduit/README ).
 
 .. _using-slurm:
 

--- a/doc/rst/usingchapel/launcher.rst
+++ b/doc/rst/usingchapel/launcher.rst
@@ -106,6 +106,17 @@ forwarded to worker processes. However, this strategy is not always
 reliable. The remote system may override some environment variables, and
 some launchers might not correctly forward all environment variables.
 
+.. _chpl-launch-masterip:
+
+CHPL_LAUNCH_MASTERIP
+********************
+
+This environment variable is intended as an expansion on ``GASNET_MASTERIP``
+(see http://gasnet.lbl.gov/dist/udp-conduit/README ).  When set, if
+``GASNET_MASTERIP`` is not already present in the environment it will be set to
+the same value.  ``CHPL_LAUNCH_MASTERIP`` will also be used by multilocale
+libraries when communicating.
+
 .. _using-slurm:
 
 Using Slurm

--- a/runtime/etc/src/mli/common_code.c
+++ b/runtime/etc/src/mli/common_code.c
@@ -250,19 +250,37 @@ char * chpl_mli_connection_info(void* socket) {
   traveler = strchr(traveler + 1, ':');
   traveler++;
 
-  // Determine hostname of where we are currently running
-  size_t lenHostname = 256;
-  char* hostRes = (char *)mli_malloc(lenHostname);
-  int hostErr = gethostname(hostRes, lenHostname);
+  int lenConnBoilerplate = strlen("tcp://:");
+  char* chpl_launch_masterip = getenv("CHPL_LAUNCH_MASTERIP");
+  chpl_mli_debugf("got env var value for CHPL_LAUNCH_MASTERIP: %s\n",
+                  chpl_launch_masterip);
+  char* fullConnection = NULL;
+  if (chpl_launch_masterip != NULL) {
+    int lenMasterip = strlen(chpl_launch_masterip);
+    int lenFull = lenConnBoilerplate + lenMasterip + lenPort;
+    fullConnection = (char*)mli_malloc(lenFull + 1);
+    strcpy(fullConnection, "tcp://");
+    strcat(fullConnection, chpl_launch_masterip);
+    chpl_mli_debugf("full connection before port was %s\n", fullConnection);
 
-  // Recreate the connection using the hostname instead of 0.0.0.0
-  char* fullConnection = (char *)mli_malloc(lenHostname + lenPort);
-  strcpy(fullConnection, "tcp://");
-  strcat(fullConnection, hostRes);
+  } else {
+    // Determine hostname of where we are currently running
+    size_t lenHostname = 256;
+    char* hostRes = (char *)mli_malloc(lenHostname);
+    int hostErr = gethostname(hostRes, lenHostname);
+    chpl_mli_debugf("hostname was %s\n", hostRes);
+
+    // Recreate the connection using the hostname instead of 0.0.0.0
+    int lenFull = lenHostname + lenPort + lenConnBoilerplate;
+    fullConnection = (char *)mli_malloc(lenFull + 1);
+    strcpy(fullConnection, "tcp://");
+    strcat(fullConnection, hostRes);
+    chpl_mli_debugf("full connection before port was %s\n", fullConnection);
+    mli_free(hostRes);
+  }
   strcat(fullConnection, ":");
   strcat(fullConnection, traveler);
 
-  mli_free(hostRes);
   mli_free(portRes);
   return fullConnection;
 }

--- a/runtime/include/comm/gasnet/chpl-comm-launch.h
+++ b/runtime/include/comm/gasnet/chpl-comm-launch.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2004-2019 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _chpl_comm_launch_h
+#define _chpl_comm_launch_h
+
+//
+// Launch assistance for the uGNI communication interface.
+//
+
+//
+// This is an optional comm layer function for the launcher to call
+// right before launching the user program.
+//
+#define CHPL_COMM_PRELAUNCH() chpl_comm_preLaunch()
+void chpl_comm_preLaunch(void);
+
+#endif

--- a/runtime/src/comm/gasnet/Makefile.share
+++ b/runtime/src/comm/gasnet/Makefile.share
@@ -16,13 +16,18 @@
 # limitations under the License.
 
 COMM_LAUNCHER_SRCS = \
-        comm-gasnet-locales.c
+        comm-gasnet-launch.c \
+        comm-gasnet-locales.c \
 
 COMM_SRCS = \
-	$(COMM_LAUNCHER_SRCS) \
-	comm-gasnet.c
+	comm-gasnet.c \
+	comm-gasnet-locales.c \
 
-SVN_SRCS = $(COMM_SRCS)
+SVN_SRCS = \
+  comm-gasnet.c \
+  comm-gasnet-launch.c \
+  comm-gasnet-locales.c \
+
 SRCS = $(SVN_SRCS)
 
 COMM_OBJS = \

--- a/runtime/src/comm/gasnet/comm-gasnet-launch.c
+++ b/runtime/src/comm/gasnet/comm-gasnet-launch.c
@@ -24,6 +24,6 @@
 void chpl_comm_preLaunch() {
   char* chpl_launch_masterip = getenv("CHPL_LAUNCH_MASTERIP");
   if (chpl_launch_masterip != NULL) {
-    chpl_env_set("GASNET_MASTERIP", chpl_launch_masterip, 0);
+    chpl_env_set("GASNET_MASTERIP", chpl_launch_masterip, 1);
   }
 }

--- a/runtime/src/comm/gasnet/comm-gasnet-launch.c
+++ b/runtime/src/comm/gasnet/comm-gasnet-launch.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2004-2019 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "chplrt.h"
+#include "chpl-comm-launch.h"
+#include "chpl-env.h"
+
+void chpl_comm_preLaunch() {
+  char* chpl_launch_masterip = getenv("CHPL_LAUNCH_MASTERIP");
+  if (chpl_launch_masterip != NULL) {
+    chpl_env_set("GASNET_MASTERIP", chpl_launch_masterip, 0);
+  }
+}

--- a/runtime/src/comm/gasnet/comm-gasnet.c
+++ b/runtime/src/comm/gasnet/comm-gasnet.c
@@ -771,7 +771,9 @@ static void stop_polling(chpl_bool wait) {
 
 static void set_gasnet_masterip() {
   char* chpl_launch_masterip = getenv("CHPL_LAUNCH_MASTERIP");
-  chpl_env_set("GASNET_MASTERIP", chpl_launch_masterip, 0);
+  if (chpl_launch_masterip != NULL) {
+    chpl_env_set("GASNET_MASTERIP", chpl_launch_masterip, 0);
+  }
 }
 
 static void set_max_segsize_env_var(size_t size) {

--- a/runtime/src/comm/gasnet/comm-gasnet.c
+++ b/runtime/src/comm/gasnet/comm-gasnet.c
@@ -769,13 +769,6 @@ static void stop_polling(chpl_bool wait) {
   }
 }
 
-static void set_gasnet_masterip() {
-  char* chpl_launch_masterip = getenv("CHPL_LAUNCH_MASTERIP");
-  if (chpl_launch_masterip != NULL) {
-    chpl_env_set("GASNET_MASTERIP", chpl_launch_masterip, 0);
-  }
-}
-
 static void set_max_segsize_env_var(size_t size) {
   chpl_env_set_uint("GASNET_MAX_SEGSIZE", size, 1);
 }
@@ -808,7 +801,6 @@ static void set_num_comm_domains() {
 void chpl_comm_init(int *argc_p, char ***argv_p) {
 //  int status; // Some compilers complain about unused variable 'status'.
 
-  set_gasnet_masterip();
   set_max_segsize();
   set_num_comm_domains();
   setup_polling();

--- a/runtime/src/comm/gasnet/comm-gasnet.c
+++ b/runtime/src/comm/gasnet/comm-gasnet.c
@@ -769,6 +769,11 @@ static void stop_polling(chpl_bool wait) {
   }
 }
 
+static void set_gasnet_masterip() {
+  char* chpl_launch_masterip = getenv("CHPL_LAUNCH_MASTERIP");
+  chpl_env_set("GASNET_MASTERIP", chpl_launch_masterip, 0);
+}
+
 static void set_max_segsize_env_var(size_t size) {
   chpl_env_set_uint("GASNET_MAX_SEGSIZE", size, 1);
 }
@@ -801,6 +806,7 @@ static void set_num_comm_domains() {
 void chpl_comm_init(int *argc_p, char ***argv_p) {
 //  int status; // Some compilers complain about unused variable 'status'.
 
+  set_gasnet_masterip();
   set_max_segsize();
   set_num_comm_domains();
   setup_polling();


### PR DESCRIPTION
This environment variable will set GASNET_MASTERIP when it
is present, overriding GASNET_MASTERIP if it is already defined in the
environment.  Additionally, if set, multilocale libraries will now
use its value when returning the connection information that
should be used to communicate between the server and the
client library.

Checked behavior of normal executable when GASNET_MASTERIP is and is not
required:
- GASNET_MASTERIP is already in the environment but CHPL_LAUNCH_MASTERIP is not
(behavior: Chapel executable compiles and runs to completion)
- neither GASNET_MASTERIP nor CHPL_LAUNCH_MASTERIP is in the environment
(behavior: Chapel compiles and runs to completion when GASNET_MASTERIP was not
required, and fails otherwise)
- only CHPL_LAUNCH_MASTERIP is set (behavior: Chapel executable compiles and
runs to completion)
- CHPL_LAUNCH_MASTERIP is set to a valid value and GASNET_MASTERIP is set to
something bogus that would not work on its own (behavior: CHPL_LAUNCH_MASTERIP's
value overrides the GASNET_MASTERIP setting, and so the program compiles
and runs to completion)

Also updated the documentation to reflect these changes.

Testing:
- test/interop/C/multilocale on darwin with CHPL_LAUNCH_MASTERIP set
  - [x] when GASNET_MASTERIP was not necessary for successful executable runs
  - [x] when GASNET_MASTERIP was necessary for successful executable runs
- test/interop/python/multilocale on darwin with CHPL_LAUNCH_MASTERIP set
  - [x] when GASNET_MASTERIP was not necessary for successful executable runs
  - [x] when GASNET_MASTERIP was necessary for successful executable runs
- [x] full gasnet paratest with futures on linux64 (no CHPL_LAUNCH_MASTERIP set)

TODO:
- [ ] update cron files to use CHPL_LAUNCH_MASTERIP instead
- [ ] message team to use CHPL_LAUNCH_MASTERIP instead