### PR TITLE
Minor cleanups

### DIFF
--- a/compiler/resolution/implementForallIntents.cpp
+++ b/compiler/resolution/implementForallIntents.cpp
@@ -826,10 +826,10 @@ static void assertNotRecordReceiver(Symbol* ovar, Expr* ref) {
 // Find all symbols used in 'block' and defined outside of it.
 //
 // For each found symbol, see if it needs a ShadowVarSymbol.
-// If so, create one, add it to fs->shadowVariables() and to 'toReplace'.
-// Otherwise, map it to markPruned in 'toReplace'.
+// If so, create one, add it to fs->shadowVariables() and to 'outer2shadow'.
+// Otherwise, map it to markPruned in 'outer2shadow'.
 //
-// At the same time, perform the substitutions already in 'toReplace'
+// At the same time, perform the substitutions already in 'outer2shadow'
 // except markPruned.
 //
 static void doImplicitShadowVars(ForallStmt* fs, BlockStmt* block,

--- a/test/classes/diten/breakList.good
+++ b/test/classes/diten/breakList.good
@@ -2,6 +2,6 @@ breakList.chpl:20: In function 'bar':
 breakList.chpl:23: error: multiple overload sets are applicable to this call
 breakList.chpl:3: note: the best-matching candidate is here
 breakList.chpl:1: note: ... defined in this module
-$CHPL_HOME/modules/standard/LinkedLists.chpl:107: note: even though the candidate here is also available
-$CHPL_HOME/modules/standard/LinkedLists.chpl:27: note: ... defined in this module
+$CHPL_HOME/modules/standard/LinkedLists.chpl:nnnn: note: even though the candidate here is also available
+$CHPL_HOME/modules/standard/LinkedLists.chpl:nnnn: note: ... defined in this module
 breakList.chpl:23: note: use --no-overload-sets-checks to disable overload sets errors

--- a/test/classes/diten/breakList.prediff
+++ b/test/classes/diten/breakList.prediff
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Ignore line numbers in "note" lines for module files.
+
+outfile=$2
+regex='\|CHPL_HOME/modules|s/:[0-9:]*: note:/:nnnn: note:/'
+sed -e "$regex" $outfile > $outfile.tmp
+mv $outfile.tmp $outfile

--- a/test/release/examples/users-guide/locality/coforallPlusOn.prediff
+++ b/test/release/examples/users-guide/locality/coforallPlusOn.prediff
@@ -1,4 +1,5 @@
-#!/bin/bash                                                                     
+#!/bin/bash
+
 outfile=$2
 sort $outfile > $outfile.tmp
 mv $outfile.tmp $outfile

--- a/test/release/examples/users-guide/taskpar/begin.prediff
+++ b/test/release/examples/users-guide/taskpar/begin.prediff
@@ -1,4 +1,5 @@
-#!/bin/bash                                                                     
+#!/bin/bash
+
 outfile=$2
 sort $outfile > $outfile.tmp
 mv $outfile.tmp $outfile

--- a/test/release/examples/users-guide/taskpar/beginBiggerStatements.prediff
+++ b/test/release/examples/users-guide/taskpar/beginBiggerStatements.prediff
@@ -1,4 +1,5 @@
-#!/bin/bash                                                                     
+#!/bin/bash
+
 outfile=$2
 sort $outfile > $outfile.tmp
 mv $outfile.tmp $outfile

--- a/test/release/examples/users-guide/taskpar/cobegin+begin.prediff
+++ b/test/release/examples/users-guide/taskpar/cobegin+begin.prediff
@@ -1,4 +1,5 @@
-#!/bin/bash                                                                     
+#!/bin/bash
+
 outfile=$2
 sort $outfile > $outfile.tmp
 mv $outfile.tmp $outfile

--- a/test/release/examples/users-guide/taskpar/cobegin.prediff
+++ b/test/release/examples/users-guide/taskpar/cobegin.prediff
@@ -1,4 +1,5 @@
-#!/bin/bash                                                                     
+#!/bin/bash
+
 outfile=$2
 sort $outfile > $outfile.tmp
 mv $outfile.tmp $outfile

--- a/test/release/examples/users-guide/taskpar/coforall.prediff
+++ b/test/release/examples/users-guide/taskpar/coforall.prediff
@@ -1,4 +1,5 @@
-#!/bin/bash                                                                     
+#!/bin/bash
+
 outfile=$2
 sort $outfile > $outfile.tmp
 mv $outfile.tmp $outfile

--- a/test/release/examples/users-guide/taskpar/walkTreeUsingBegins.prediff
+++ b/test/release/examples/users-guide/taskpar/walkTreeUsingBegins.prediff
@@ -1,4 +1,5 @@
-#!/bin/bash                                                                     
+#!/bin/bash
+
 outfile=$2
 sort $outfile > $outfile.tmp
 mv $outfile.tmp $outfile

--- a/test/separate_compilation/jturner/.gitignore
+++ b/test/separate_compilation/jturner/.gitignore
@@ -1,2 +1,3 @@
 *.so.a
+*.so_server_real
 *.h

--- a/test/separate_compilation/jturner/CLEANFILES
+++ b/test/separate_compilation/jturner/CLEANFILES
@@ -1,2 +1,3 @@
 *.so.a
+*.so_server_real
 *.h


### PR DESCRIPTION
* Add breakList.prediff so the .good does not need to track
standard modules' line numbers.

* Adjust a comment in the compiler.

* Remove unnecessary white space.

* Add *.so_server_real to .gitignore and CLEANFILES
as the tests generate those when run under gasnet.

Trivial, not reviewed.