### PR TITLE
Fix check-http-setpopt test for overload set checking

### DIFF
--- a/test/library/packages/Curl/check-http-setopt.chpl
+++ b/test/library/packages/Curl/check-http-setopt.chpl
@@ -9,7 +9,6 @@ use DateTime;
 extern const CURLOPT_VERBOSE: CURLoption;
 extern const CURLOPT_FILETIME: CURLoption;
 extern const CURLINFO_FILETIME: CURLINFO;
-extern proc curl_easy_getinfo(handle:c_ptr(CURL), info, arg);
 
 proc test1() {
   writeln("\ntest1\n");


### PR DESCRIPTION
Follow-on to PR #13442.
Note that in this case the overload set error had to do with
two `extern` declarations of `curl_easy_getinfo`. I suspect that
multiple overloads for an `extern` function is harmless, because
it is not up to Chapel at all to decide which overload to call
(since C functions do not have overloading).

Trivial and not reviewed.