### PR TITLE
Do not check overload sets on shadow.chpl

### DIFF
--- a/test/extern/tzakian/shadow.compopts
+++ b/test/extern/tzakian/shadow.compopts
@@ -1,1 +1,1 @@
-shadow.c
+shadow.c --no-overload-sets-checks


### PR DESCRIPTION
This test checks specifically the case with overloads from different modules.
This trips over the overload-sets error introduced in #13442.
Disable that check for this test for now.

The long-term solution is perhaps to use the "merge the overload sets"
declarations in proposed in #12635.

Trivial, not reviewed.
