### PR TITLE
Propagate FLAG_NO_AUTO_DESTROY in insertFormalTemps

### DIFF
--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -1292,9 +1292,10 @@ void insertFormalTemps(FnSymbol* fn) {
 
       VarSymbol* tmp = newTemp(astr("_formal_tmp_", formal->name));
 
-      if (formal->hasFlag(FLAG_CONST_DUE_TO_TASK_FORALL_INTENT)) {
+      if (formal->hasFlag(FLAG_CONST_DUE_TO_TASK_FORALL_INTENT))
         tmp->addFlag(FLAG_CONST_DUE_TO_TASK_FORALL_INTENT);
-      }
+      if (formal->hasFlag(FLAG_NO_AUTO_DESTROY))
+        tmp->addFlag(FLAG_NO_AUTO_DESTROY);
 
       formals2vars.put(formal, tmp);
     }

--- a/test/types/records/ferguson/no-auto-destroy-arg.chpl
+++ b/test/types/records/ferguson/no-auto-destroy-arg.chpl
@@ -1,0 +1,16 @@
+record someRecord {
+  var dummy = 0;
+
+  proc deinit() {
+    writeln("Destroying record!");
+  }
+}
+
+proc someMethod(pragma "no auto destroy" in x: someRecord) {
+  return;
+}
+
+var x = new someRecord();
+
+for i in 1..8 do
+  someMethod(x);

--- a/test/types/records/ferguson/no-auto-destroy-arg.good
+++ b/test/types/records/ferguson/no-auto-destroy-arg.good
@@ -1,0 +1,1 @@
+Destroying record!


### PR DESCRIPTION
Resolves #13225

Adjusts insertFormalTemps to propagate FLAG_NO_AUTO_DESTROY from th
 argument formal to the formal temporary. This will enable certain use cases in `list`.

Reviewed by @dlongnecke-cray - thanks!

- [x] full local testing