### PR TITLE
Skip a partial reduction test in NUMA

### DIFF
--- a/test/users/engin/partial_reduction_support/template_tests/templateTestDistBlockCyc.skipif
+++ b/test/users/engin/partial_reduction_support/template_tests/templateTestDistBlockCyc.skipif
@@ -1,0 +1,1 @@
+CHPL_LOCALE_MODEL==numa


### PR DESCRIPTION
Skip `test/users/engin/partial_reduction_support/template_tests/templateTestDistBlockCyc` when `CHPL_LOCALE_MODEL==numa`

`test/users/engin/partial_reduction_support/template_tests/templateTestDistBlockCyc` was recently un-futurized after fixing some resolution errors that were exposed after #12131 

However, there still seems to be some issue that happens only with NUMA locale model. The code uses `do_dsiLocalSubdomains` which is a private function in `BlockCycDist.chpl`. The part where that happens never resolves when `CHPL_LOCALE_MODEL!=numa`. To make things more complicated, when I test after making that function non-private, I get a compiler assertion error.

The problem seems to be a bit more complicated than it looks at a first glance. So I am skipping the test with NUMA until I know more what is happening.
