### PR TITLE
Rework complex division to avoid overflow/underflow.

### DIFF
--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -376,16 +376,15 @@ module ChapelBase {
   inline proc /(a: real(?w), b: imag(w)) return _r2i(-a/_i2r(b));
   inline proc /(a: imag(?w), b: real(w)) return _r2i(_i2r(a)/b);
   inline proc /(a: real(?w), b: complex(w*2))
-    return let d = b.re*b.re+b.im*b.im in
-    (a*b.re/d, -a*b.im/d):complex(w*2);
+    return let d = abs(b) in
+    ((a/d)*(b.re/d), (-a/d)*(b.im/d)):complex(w*2);
   inline proc /(a: complex(?w), b: real(w/2))
-  return (a.re/b, a.im/b):complex(w);
+    return (a.re/b, a.im/b):complex(w);
   inline proc /(a: imag(?w), b: complex(w*2))
-    return let d = b.re*b.re+b.im*b.im in
-    (_i2r(a)*b.im/d, _i2r(a)*b.re/d):complex(w*2);
+    return let d = abs(b) in
+    ((_i2r(a)/d)*(b.im/d), (_i2r(a)/d)*(b.re/d)):complex(w*2);
   inline proc /(a: complex(?w), b: imag(w/2))
-    return let d = _i2r(b)*_i2r(b) in
-    (a.im/_i2r(b), -a.re/_i2r(b)):complex(w);
+    return (a.im/_i2r(b), -a.re/_i2r(b)):complex(w);
 
   inline proc *(param a: int(?w), param b: int(w)) param return __primitive("*", a, b);
   inline proc *(param a: uint(?w), param b: uint(w)) param return __primitive("*", a, b);

--- a/test/users/npadmana/complex/testComplex.chpl
+++ b/test/users/npadmana/complex/testComplex.chpl
@@ -50,6 +50,20 @@ var mag = abs(simple);
   if diff(tmp.im,unit.re/(small*mag)) then writeln("FAILED-6 im : ",tmp.re);
 }
 
+{
+  var tmp = 1.0:complex/(simple*big);
+  if diff(tmp.re,unit.re/(big*mag)) then writeln("FAILED-7 re : ",tmp.re);
+  if diff(tmp.im,-unit.im/(big*mag)) then writeln("FAILED-7 im : ",tmp.re);
+}
+
+
+{
+  var tmp = 1.0:complex/(simple*small);
+  if diff(tmp.re,unit.re/(small*mag)) then writeln("FAILED-8 re : ",tmp.re);
+  if diff(tmp.im,-unit.im/(small*mag)) then writeln("FAILED-8 im : ",tmp.re);
+}
+
+
 proc diff(actual : real, expected : real) : bool {
   return abs((actual-expected)/expected) > 1.0e-14;
 }

--- a/test/users/npadmana/complex/testComplex.chpl
+++ b/test/users/npadmana/complex/testComplex.chpl
@@ -1,0 +1,55 @@
+var big = 3.14e160;
+var small = 2.78e-160;
+var simple = 231.42 + 229.0i;
+var unit = simple/abs(simple);
+var mag = abs(simple);
+
+{
+  var tmp = 1.0/big:complex;
+  if diff(tmp.re, 1.0/big) then writeln("FAILED-1 : ",tmp.re);
+}
+
+{
+  var tmp = 1.0/small:complex;
+  if diff(tmp.re,1.0/small) then writeln("FAILED-2 : ",tmp.re);
+}
+
+{
+  var tmp = 1.0/(simple*big);
+  if diff(tmp.re,unit.re/(big*mag)) then writeln("FAILED-3 re : ",tmp.re);
+  if diff(tmp.im,-unit.im/(big*mag)) then writeln("FAILED-3 im : ",tmp.re);
+}
+
+
+{
+  var tmp = 1.0/(simple*small);
+  if diff(tmp.re,unit.re/(small*mag)) then writeln("FAILED-4 re : ",tmp.re);
+  if diff(tmp.im,-unit.im/(small*mag)) then writeln("FAILED-4 im : ",tmp.re);
+}
+
+{
+  var tmp = 1.0i/big:complex;
+  if diff(tmp.im, 1.0/big) then writeln("FAILED-5 : ",tmp.re);
+}
+
+{
+  var tmp = 1.0i/small:complex;
+  if diff(tmp.im,1.0/small) then writeln("FAILED-6 : ",tmp.re);
+}
+
+{
+  var tmp = 1.0i/(simple*big);
+  if diff(tmp.re,unit.im/(big*mag)) then writeln("FAILED-5 re : ",tmp.re);
+  if diff(tmp.im,unit.re/(big*mag)) then writeln("FAILED-5 im : ",tmp.re);
+}
+
+
+{
+  var tmp = 1.0i/(simple*small);
+  if diff(tmp.re,unit.im/(small*mag)) then writeln("FAILED-6 re : ",tmp.re);
+  if diff(tmp.im,unit.re/(small*mag)) then writeln("FAILED-6 im : ",tmp.re);
+}
+
+proc diff(actual : real, expected : real) : bool {
+  return abs((actual-expected)/expected) > 1.0e-14;
+}


### PR DESCRIPTION
Fix a few cases where dividing a real/imaginary number by a complex number
could overflow/underflow.

Also remove a redundant calculation when dividing by imaginary numbers.

Add in some test cases.