### PR TITLE
Changes suggested by Elliot after reviewing the new CHPL_LAUNCH_MASTERIP var

### DIFF
--- a/doc/rst/platforms/aws.rst
+++ b/doc/rst/platforms/aws.rst
@@ -164,7 +164,7 @@ Some other common optional configurations are:
     # Defaults to empty, can be used instead of copying config files onto each machine
     SSH_OPTIONS='-i ~/.ssh/foo.pem'
 
-See :ref:`chpl-launch-masterip` for details on that environment variable.
+See :ref:`chpl-rt-masterip` for details on that environment variable.
 
 .. _GASNet documentation: http://gasnet.lbl.gov/dist/udp-conduit/README
 

--- a/doc/rst/platforms/aws.rst
+++ b/doc/rst/platforms/aws.rst
@@ -160,7 +160,7 @@ Some other common optional configurations are:
     # Defaults to current working directory
     GASNET_REMOTE_PATH='~/chapel-projects/'
     # Defaults to gethostname() of the launching node
-    CHPL_LAUNCH_MASTERIP='ec2-11-222-33-444.us-west-2.compute.amazonaws.com'
+    CHPL_RT_MASTERIP='ec2-11-222-33-444.us-west-2.compute.amazonaws.com'
     # Defaults to empty, can be used instead of copying config files onto each machine
     SSH_OPTIONS='-i ~/.ssh/foo.pem'
 

--- a/doc/rst/platforms/udp.rst
+++ b/doc/rst/platforms/udp.rst
@@ -154,9 +154,10 @@ I get xSocket errors when using a system with multiple IP addresses
  failed while creating a connect socket (111:Connection refused)
 
 You need to set ``CHPL_RT_MASTERIP`` (or ``GASNET_MASTERIP``), and possibly
-``GASNET_WORKERIP``.  Please refer to:
+``CHPL_RT_WORKERIP`` (or ``GASNET_WORKERIP``).  Please refer to:
 
   * :ref:`chpl-rt-masterip`
+  * :ref:`chpl-rt-workerip`
   * ``$CHPL_HOME/third-party/gasnet/gasnet-src/udp-conduit/README``
   * http://gasnet.lbl.gov/dist/udp-conduit/README .
 

--- a/doc/rst/platforms/udp.rst
+++ b/doc/rst/platforms/udp.rst
@@ -153,10 +153,10 @@ I get xSocket errors when using a system with multiple IP addresses
  *** FATAL ERROR: Got an xSocket while spawning slave process: connect()
  failed while creating a connect socket (111:Connection refused)
 
-You need to set ``CHPL_LAUNCH_MASTERIP`` (or ``GASNET_MASTERIP``), and possibly
+You need to set ``CHPL_RT_MASTERIP`` (or ``GASNET_MASTERIP``), and possibly
 ``GASNET_WORKERIP``.  Please refer to:
 
-  * :ref:`chpl-launch-masterip`
+  * :ref:`chpl-rt-masterip`
   * ``$CHPL_HOME/third-party/gasnet/gasnet-src/udp-conduit/README``
   * http://gasnet.lbl.gov/dist/udp-conduit/README .
 

--- a/doc/rst/usingchapel/launcher.rst
+++ b/doc/rst/usingchapel/launcher.rst
@@ -120,6 +120,19 @@ When ``CHPL_COMM == gasnet``, this will also be used to set the value of
 ``GASNET_MASTERIP``, which corresponds to the hostname of the master node (see
 http://gasnet.lbl.gov/dist/udp-conduit/README ).
 
+.. _chpl-rt-workerip:
+
+CHPL_RT_WORKERIP
+****************
+
+This environment variable is used to specify the IP address which should be used
+to communicate between worker nodes.  By default, worker nodes will communicate
+among themselves using the same interface used to connect to the master node
+(see :ref:`chpl-rt-masterip`, above).
+
+When ``CHPL_COMM == gasnet``, this will also be used to set the value of
+``GASNET_WORKERIP`` (see http://gasnet.lbl.gov/dist/udp-conduit/README ).
+
 .. _using-slurm:
 
 Using Slurm

--- a/doc/rst/usingchapel/launcher.rst
+++ b/doc/rst/usingchapel/launcher.rst
@@ -106,10 +106,10 @@ forwarded to worker processes. However, this strategy is not always
 reliable. The remote system may override some environment variables, and
 some launchers might not correctly forward all environment variables.
 
-.. _chpl-launch-masterip:
+.. _chpl-rt-masterip:
 
-CHPL_LAUNCH_MASTERIP
-********************
+CHPL_RT_MASTERIP
+****************
 
 This environment variable is used to specify the IP address which should be used
 to connect.  By default, the node creating the connection will pass the result

--- a/runtime/etc/src/mli/common_code.c
+++ b/runtime/etc/src/mli/common_code.c
@@ -58,6 +58,8 @@
 #   endif
 #endif
 
+#include "chpl-env.h"
+
 //
 // If this code is being run on the server, mli_malloc() is a wrapper for
 // chpl_malloc(). If this code is being run on the client, then it is a
@@ -251,7 +253,7 @@ char * chpl_mli_connection_info(void* socket) {
   traveler++;
 
   int lenConnBoilerplate = strlen("tcp://:");
-  char* chpl_rt_masterip = getenv("CHPL_RT_MASTERIP");
+  const char* chpl_rt_masterip = chpl_env_rt_get("MASTERIP", NULL);
   chpl_mli_debugf("got env var value for CHPL_RT_MASTERIP: %s\n",
                   chpl_rt_masterip);
   char* fullConnection = NULL;

--- a/runtime/etc/src/mli/common_code.c
+++ b/runtime/etc/src/mli/common_code.c
@@ -58,8 +58,6 @@
 #   endif
 #endif
 
-#include "chpl-env.h"
-
 //
 // If this code is being run on the server, mli_malloc() is a wrapper for
 // chpl_malloc(). If this code is being run on the client, then it is a
@@ -253,7 +251,7 @@ char * chpl_mli_connection_info(void* socket) {
   traveler++;
 
   int lenConnBoilerplate = strlen("tcp://:");
-  const char* chpl_rt_masterip = chpl_env_rt_get("MASTERIP", NULL);
+  char* chpl_rt_masterip = getenv("CHPL_RT_MASTERIP");
   chpl_mli_debugf("got env var value for CHPL_RT_MASTERIP: %s\n",
                   chpl_rt_masterip);
   char* fullConnection = NULL;

--- a/runtime/etc/src/mli/common_code.c
+++ b/runtime/etc/src/mli/common_code.c
@@ -251,16 +251,16 @@ char * chpl_mli_connection_info(void* socket) {
   traveler++;
 
   int lenConnBoilerplate = strlen("tcp://:");
-  char* chpl_launch_masterip = getenv("CHPL_LAUNCH_MASTERIP");
-  chpl_mli_debugf("got env var value for CHPL_LAUNCH_MASTERIP: %s\n",
-                  chpl_launch_masterip);
+  char* chpl_rt_masterip = getenv("CHPL_RT_MASTERIP");
+  chpl_mli_debugf("got env var value for CHPL_RT_MASTERIP: %s\n",
+                  chpl_rt_masterip);
   char* fullConnection = NULL;
-  if (chpl_launch_masterip != NULL) {
-    int lenMasterip = strlen(chpl_launch_masterip);
+  if (chpl_rt_masterip != NULL) {
+    int lenMasterip = strlen(chpl_rt_masterip);
     int lenFull = lenConnBoilerplate + lenMasterip + lenPort;
     fullConnection = (char*)mli_malloc(lenFull + 1);
     strcpy(fullConnection, "tcp://");
-    strcat(fullConnection, chpl_launch_masterip);
+    strcat(fullConnection, chpl_rt_masterip);
     chpl_mli_debugf("full connection before port was %s\n", fullConnection);
 
   } else {

--- a/runtime/src/comm/gasnet/comm-gasnet-launch.c
+++ b/runtime/src/comm/gasnet/comm-gasnet-launch.c
@@ -22,11 +22,11 @@
 #include "chpl-env.h"
 
 void chpl_comm_preLaunch() {
-  char* chpl_rt_masterip = getenv("CHPL_RT_MASTERIP");
+  const char* chpl_rt_masterip = chpl_env_rt_get("MASTERIP", NULL);
   if (chpl_rt_masterip != NULL) {
     chpl_env_set("GASNET_MASTERIP", chpl_rt_masterip, 1);
   }
-  char* chpl_rt_workerip = getenv("CHPL_RT_WORKERIP");
+  const char* chpl_rt_workerip = chpl_env_rt_get("WORKERIP", NULL);
   if (chpl_rt_workerip != NULL) {
     chpl_env_set("GASNET_WORKERIP", chpl_rt_workerip, 1);
   }

--- a/runtime/src/comm/gasnet/comm-gasnet-launch.c
+++ b/runtime/src/comm/gasnet/comm-gasnet-launch.c
@@ -22,8 +22,8 @@
 #include "chpl-env.h"
 
 void chpl_comm_preLaunch() {
-  char* chpl_launch_masterip = getenv("CHPL_LAUNCH_MASTERIP");
-  if (chpl_launch_masterip != NULL) {
-    chpl_env_set("GASNET_MASTERIP", chpl_launch_masterip, 1);
+  char* chpl_rt_masterip = getenv("CHPL_RT_MASTERIP");
+  if (chpl_rt_masterip != NULL) {
+    chpl_env_set("GASNET_MASTERIP", chpl_rt_masterip, 1);
   }
 }

--- a/runtime/src/comm/gasnet/comm-gasnet-launch.c
+++ b/runtime/src/comm/gasnet/comm-gasnet-launch.c
@@ -26,4 +26,8 @@ void chpl_comm_preLaunch() {
   if (chpl_rt_masterip != NULL) {
     chpl_env_set("GASNET_MASTERIP", chpl_rt_masterip, 1);
   }
+  char* chpl_rt_workerip = getenv("CHPL_RT_WORKERIP");
+  if (chpl_rt_workerip != NULL) {
+    chpl_env_set("GASNET_WORKERIP", chpl_rt_workerip, 1);
+  }
 }


### PR DESCRIPTION
Renames CHPL_LAUNCH_MASTERIP to CHPL_RT_MASTERIP, and
adds a new environment variable, CHPL_RT_WORKERIP, as the
pair for GASNET_WORKERIP (so that we support the two
consistently).

While here, changed the use of `getenv` to `chpl_env_rt_get` in the
launcher code for executables, but not for multilocale interoperability.
Doing so for multilocale interoperability caused additional runtime symbols
to be brought into the client code - we could avoid this by using an `ifdef`
to only bring it in for the server code (which must link to the runtime).

Updates the documentation for this new state of affairs.

Checked behavior of normal executable when GASNET_MASTERIP and
GASNET_WORKERIP are and are not required:
- GASNET_MASTERIP/WORKERIP are already in the environment but
CHPL_RT_MASTERIP/WORKERIP is not
(behavior: Chapel executable compiles and runs to completion)
- neither GASNET_MASTERIP/WORKERIP nor CHPL_RT_MASTERIP/WORKERIP is in
the environment (behavior: Chapel compiles and runs to completion when
GASNET_MASTERIP/WORKERIP was not required, and fails otherwise)
- only CHPL_RT_MASTERIP/WORKERIP is set (behavior: Chapel executable compiles
and runs to completion)
- CHPL_RT_MASTERIP/WORKERIP is set to a valid value and
GASNET_MASTERIP/WORKERIP is set to something bogus that would not work on
its own (behavior: CHPL_RT_MASTERIP/WORKERIP's value overrides the
GASNET_MASTERIP/WORKERIP setting, and so the program compiles and runs to
completion)

Testing:
- test/interop/C/multilocale on darwin with CHPL_RT_MASTERIP/WORKERIP set
  - [x] when GASNET_MASTERIP/WORKERIP was not necessary for successful executable runs
  - [x] when GASNET_MASTERIP/WORKERIP was necessary for successful executable runs
- test/interop/python/multilocale on darwin with CHPL_RT_MASTERIP/WORKERIP set
  - [x] when GASNET_MASTERIP/WORKERIP was not necessary for successful executable runs
  - [x] when GASNET_MASTERIP/WORKERIP was necessary for successful executable runs
- [x] full gasnet paratest with futures on linux64 (no CHPL_RT_MASTERIP/WORKERIP set)

Updated documentation is here:
http://web.us.cray.com/~lydia/launchMasterip/platforms/aws.html (you will need to search for it, there wasn't an easy link)
http://web.us.cray.com/~lydia/launchMasterip/platforms/udp.html#i-get-xsocket-errors-when-using-a-system-with-multiple-ip-addresses
http://web.us.cray.com/~lydia/launchMasterip/usingchapel/launcher.html#chpl-rt-masterip