### PR TITLE
Nil checking for owned, shared types

### DIFF
--- a/test/arrays/diten/timeVectorArray.chpl
+++ b/test/arrays/diten/timeVectorArray.chpl
@@ -163,7 +163,7 @@ proc output(name: string, time: real) {
 
 proc main {
   var A: [1..0] int;
-  var r: owned Runner;
+  var r = new Runner(); // dummy initialization
 
   r = new owned PushBack(n); output("PushBack", timeRun(r, A));
   r = new owned SumElements(n); output("SumElements", timeRun(r, A));

--- a/test/classes/bradc/callMethodOnClass.chpl
+++ b/test/classes/bradc/callMethodOnClass.chpl
@@ -9,7 +9,7 @@ proc newC() {
 }
 
 class D {
-  var y: owned C;
+  var y: owned C?;
 
   proc start {
     y = newC();

--- a/test/classes/delete-free/bug-13468.chpl
+++ b/test/classes/delete-free/bug-13468.chpl
@@ -1,9 +1,9 @@
 class MyClass { var x: int; }
 
-var x : (shared MyClass, shared MyClass);
+var x : (shared MyClass?, shared MyClass?);
 x = (new shared MyClass(1), new shared MyClass(2));
 writeln(x);
 
-var y : (owned MyClass, owned MyClass);
+var y : (owned MyClass?, owned MyClass?);
 y = (new owned MyClass(3), new owned MyClass(4));
 writeln(y);

--- a/test/classes/delete-free/lifetimes/borrow-escapes.chpl
+++ b/test/classes/delete-free/lifetimes/borrow-escapes.chpl
@@ -9,14 +9,14 @@ class MyClass {
 
 record R {
   // TODO - get init with owned fields working
-  var c:owned MyClass;// = new Owned(nil:MyClass);
+  var c:owned MyClass?;// = new Owned(nil:MyClass);
   proc init() {
     //var tmp = new Owned(new MyClass(data));
     //c = tmp;
     //c.retain(new MyClass(data));
   }
   proc get(): borrowed MyClass {
-    return c.borrow();
+    return c!.borrow();
   }
 }
 

--- a/test/classes/delete-free/lifetimes/record-owns.chpl
+++ b/test/classes/delete-free/lifetimes/record-owns.chpl
@@ -40,7 +40,7 @@ proc =(ref lhs:RMyClass, ref rhs:RMyClass) {
 }
 
 // Globals
-var globalMyClass:owned MyClass;
+var globalMyClass:owned MyClass?;
 var globalRMyClass:RMyClass;
 
 // Test initialization block

--- a/test/classes/delete-free/nil-checking/nil-check-forall.chpl
+++ b/test/classes/delete-free/nil-checking/nil-check-forall.chpl
@@ -32,7 +32,7 @@ badNilInCoforallLoop();
 
 proc badNilInForallLoop2() {
   forall i in 1..n {
-    var x:owned MyClass;
+    var x:owned MyClass?;
     x.method();
   }
 }

--- a/test/classes/delete-free/nil-checking/nilcheck-ok-set-ref.chpl
+++ b/test/classes/delete-free/nil-checking/nilcheck-ok-set-ref.chpl
@@ -6,7 +6,7 @@ class MyClass {
 }
 
 proc okSetByRef() {
-  var x: owned MyClass;
+  var x: owned MyClass?;
   ref r = x;
   r = new owned MyClass(1);
   x.method();
@@ -18,7 +18,7 @@ proc returnRefArg(ref arg) ref {
 }
 
 proc okSetByObscuredRef() {
-  var x: owned MyClass;
+  var x: owned MyClass?;
   ref r = returnRefArg(x);
   r = new owned MyClass(1);
   x.method();
@@ -28,8 +28,8 @@ okSetByObscuredRef();
 config const option = true;
 
 proc okSetByUncertainRef() {
-  var x: owned MyClass;
-  var y: owned MyClass = new owned MyClass(1);
+  var x: owned MyClass?;
+  var y: owned MyClass? = new owned MyClass(1);
   ref r = if option then x else y;
   r = new owned MyClass(1);
   x.method();

--- a/test/classes/delete-free/nil-checking/nilcheck-ok-set.chpl
+++ b/test/classes/delete-free/nil-checking/nilcheck-ok-set.chpl
@@ -6,7 +6,7 @@ class MyClass {
 }
 
 proc okSetInInner() {
-  var x: owned MyClass;
+  var x: owned MyClass?;
   proc inner() {
     x = new owned MyClass(1);
   }
@@ -16,7 +16,7 @@ proc okSetInInner() {
 okSetInInner();
 
 proc okSetInTask() {
-  var x: owned MyClass;
+  var x: owned MyClass?;
   var s$: sync int;
 
   begin with (ref x) {

--- a/test/classes/delete-free/owned/owned-in-tuple.chpl
+++ b/test/classes/delete-free/owned/owned-in-tuple.chpl
@@ -3,7 +3,7 @@ class Foo {
   var x: int;
 };
 
-type Bar = (owned Foo, int); // <-- Error here?
+type Bar = (owned Foo?, int); // <-- Error here?
 
 proc test() {
   var x:Bar;

--- a/test/classes/delete-free/owned/owned-on.chpl
+++ b/test/classes/delete-free/owned/owned-on.chpl
@@ -2,7 +2,7 @@ class MyClass {
   var x:int;
 }
 
-var a:owned MyClass;
+var a:owned MyClass?;
 
 on Locales[numLocales-1] {
   a = new owned MyClass(1);

--- a/test/classes/delete-free/shared/shared-assign-owned.chpl
+++ b/test/classes/delete-free/shared/shared-assign-owned.chpl
@@ -10,7 +10,7 @@ proc test() {
 
   var s1:shared MyClass = o1;
   var s2 = new shared(o2);
-  var s3:shared MyClass;
+  var s3:shared MyClass?;
   s3 = o3;
 
   writeln(s1, " ", o1);

--- a/test/classes/delete-free/shared/shared-on.chpl
+++ b/test/classes/delete-free/shared/shared-on.chpl
@@ -2,7 +2,7 @@ class MyClass {
   var x:int;
 }
 
-var a:shared MyClass;
+var a:shared MyClass?;
 
 on Locales[numLocales-1] {
   a = new shared MyClass(1);

--- a/test/classes/delete-free/shared/sharedClassInRecord.chpl
+++ b/test/classes/delete-free/shared/sharedClassInRecord.chpl
@@ -3,7 +3,7 @@
 class C { }
 
 record R {
-  var sc: shared C;
+  var sc: shared C?;
 }
 
 proc main {

--- a/test/classes/delete-free/tests-from-design-overview/generic-collection-unspecified-with-type.chpl
+++ b/test/classes/delete-free/tests-from-design-overview/generic-collection-unspecified-with-type.chpl
@@ -10,7 +10,7 @@ proc Collection.addElement(in arg: elementType) lifetime this < arg {
 }
 
 proc test() {
-  var c: Collection(owned MyClass);
+  var c: Collection(owned MyClass?);
   c.addElement( new owned MyClass() ); // transferred to element
 
   var global = new owned MyClass();

--- a/test/classes/delete-free/tests-from-design-overview/owned-shared-arguments.chpl
+++ b/test/classes/delete-free/tests-from-design-overview/owned-shared-arguments.chpl
@@ -8,7 +8,7 @@ class MyClass {
   }
 }
 
-var global: owned MyClass;
+var global: owned MyClass?;
 proc saveit(in arg: owned MyClass) {
   global = arg; // OK! Transfers ownership from 'arg' to 'global'
   // now instance will be deleted at end of program

--- a/test/classes/ferguson/delete-free/PREDIFF
+++ b/test/classes/ferguson/delete-free/PREDIFF
@@ -15,4 +15,4 @@ fi
 
 rm $2.prediff.g.tmp
 mv $2.prediff.tmp $2
-rm memlog
+rm -f memlog

--- a/test/classes/ferguson/delete-free/owned-demo.chpl
+++ b/test/classes/ferguson/delete-free/owned-demo.chpl
@@ -12,7 +12,7 @@ proc examples() {
 
   writeln("declaring owned2 storing nil");
   // it's OK to have owned initially empty. It will point to 'nil'.
-  var owned2: owned C;
+  var owned2: owned C?;
   writeln("owned2 = ", owned2.borrow());
 
   // Assignment is supported, but it empties the RHS

--- a/test/classes/ferguson/delete-free/owned-shared-fields.chpl
+++ b/test/classes/ferguson/delete-free/owned-shared-fields.chpl
@@ -8,8 +8,8 @@ class MyClass {
 }
 
 record R1 {
-  var fo:owned MyClass;
-  var fs:shared MyClass;
+  var fo:owned MyClass?;
+  var fs:shared MyClass?;
   proc init() {
   }
 }
@@ -31,8 +31,8 @@ record R3 {
 }
 
 record R4 {
-  var fo:owned MyClass;
-  var fs:shared MyClass;
+  var fo:owned MyClass?;
+  var fs:shared MyClass?;
   proc init(a:unmanaged MyClass, b:unmanaged MyClass) {
     this.complete();
     fo = new owned(a);
@@ -41,8 +41,8 @@ record R4 {
 }
 
 class C1 {
-  var fo:owned MyClass;
-  var fs:shared MyClass;
+  var fo:owned MyClass?;
+  var fs:shared MyClass?;
   proc init() {
   }
 }

--- a/test/classes/ferguson/delete-free/owned-shared-fields2.chpl
+++ b/test/classes/ferguson/delete-free/owned-shared-fields2.chpl
@@ -8,8 +8,8 @@ record R5 {
 }
 
 record R6 {
-  var fo:owned MyClass;
-  var fs:shared MyClass;
+  var fo:owned MyClass?;
+  var fs:shared MyClass?;
 }
 
 class C5 {
@@ -18,8 +18,8 @@ class C5 {
 }
 
 class C6 {
-  var fo:owned MyClass;
-  var fs:shared MyClass;
+  var fo:owned MyClass?;
+  var fs:shared MyClass?;
 }
 
 proc test5a() {

--- a/test/classes/ferguson/delete-free/owned-shared-fields3.chpl
+++ b/test/classes/ferguson/delete-free/owned-shared-fields3.chpl
@@ -1,0 +1,99 @@
+// Ensure that errors are issued properly.
+
+class MyClass {
+  var x:int;
+}
+
+
+record R1 {
+  var fo:owned MyClass;
+  var fs:shared MyClass;
+  proc init() {
+  }
+}
+
+record R4 {
+  var fo:owned MyClass;
+  var fs:shared MyClass;
+  proc init(a:unmanaged MyClass, b:unmanaged MyClass) {
+    this.complete();
+    fo = new owned(a);
+    fs = new shared(b);
+  }
+}
+
+class C1 {
+  var fo:owned MyClass;
+  var fs:shared MyClass;
+  proc init() {
+  }
+}
+
+class C4 {
+  var fo:owned MyClass;
+  var fs:shared MyClass;
+  proc init(a:unmanaged MyClass, b:unmanaged MyClass) {
+    this.complete();
+    fo = new owned(a);
+    fs = new shared(b);
+  }
+}
+
+proc test1() {
+  var r = new R1();
+  var cc = new unmanaged C1();
+  delete cc;
+}
+proc test4() {
+  var a = new unmanaged MyClass(1);
+  var b = new unmanaged MyClass(2);
+  var c = new unmanaged MyClass(3);
+  var d = new unmanaged MyClass(4);
+  var r = new R4(a,b);
+  var cc = new unmanaged C4(c,d);
+  delete cc;
+}
+
+test1();
+test4();
+
+
+record R5 {
+  var fo:owned MyClass = nil;
+  var fs:shared MyClass = nil;
+}
+
+record R6 {
+  var fo:owned MyClass;
+  var fs:shared MyClass;
+}
+
+class C5 {
+  var fo:owned MyClass = nil;
+  var fs:shared MyClass = nil;
+}
+
+class C6 {
+  var fo:owned MyClass;
+  var fs:shared MyClass;
+}
+
+// TODO: this test should also issue errors
+proc test5a() {
+  var r = new R5();
+  var cc = new unmanaged C5();
+  delete cc;
+}
+proc test6a() {
+  var r = new R6();
+  var cc = new unmanaged C6();
+  delete cc;
+}
+
+test5a();
+test6a();
+
+
+var xxx: (int, owned MyClass);
+var yyy: (int, (owned MyClass, int));
+var zzz: (int, ((owned MyClass, real), real));

--- a/test/classes/ferguson/delete-free/owned-shared-fields3.good
+++ b/test/classes/ferguson/delete-free/owned-shared-fields3.good
@@ -1,0 +1,49 @@
+owned-shared-fields3.chpl:11: In initializer:
+owned-shared-fields3.chpl:11: error: Cannot default-initialize field fo: owned MyClass
+note: non-nil class types do not support default initialization
+note: Consider using the type _owned(MyClass)? instead
+owned-shared-fields3.chpl:11: error: Cannot default-initialize field fs: shared MyClass
+note: non-nil class types do not support default initialization
+note: Consider using the type _shared(MyClass)? instead
+owned-shared-fields3.chpl:28: In initializer:
+owned-shared-fields3.chpl:28: error: Cannot default-initialize field fo: owned MyClass
+note: non-nil class types do not support default initialization
+note: Consider using the type _owned(MyClass)? instead
+owned-shared-fields3.chpl:28: error: Cannot default-initialize field fs: shared MyClass
+note: non-nil class types do not support default initialization
+note: Consider using the type _shared(MyClass)? instead
+owned-shared-fields3.chpl:18: In initializer:
+owned-shared-fields3.chpl:19: error: Cannot default-initialize field fo: owned MyClass
+note: non-nil class types do not support default initialization
+note: Consider using the type _owned(MyClass)? instead
+owned-shared-fields3.chpl:19: error: Cannot default-initialize field fs: shared MyClass
+note: non-nil class types do not support default initialization
+note: Consider using the type _shared(MyClass)? instead
+owned-shared-fields3.chpl:35: In initializer:
+owned-shared-fields3.chpl:36: error: Cannot default-initialize field fo: owned MyClass
+note: non-nil class types do not support default initialization
+note: Consider using the type _owned(MyClass)? instead
+owned-shared-fields3.chpl:36: error: Cannot default-initialize field fs: shared MyClass
+note: non-nil class types do not support default initialization
+note: Consider using the type _shared(MyClass)? instead
+owned-shared-fields3.chpl:67: error: Cannot default-initialize fo: owned MyClass
+note: non-nil class types do not support default initialization
+note: Consider using the type _owned(MyClass)? instead
+owned-shared-fields3.chpl:68: error: Cannot default-initialize fs: shared MyClass
+note: non-nil class types do not support default initialization
+note: Consider using the type _shared(MyClass)? instead
+owned-shared-fields3.chpl:77: error: Cannot default-initialize fo: owned MyClass
+note: non-nil class types do not support default initialization
+note: Consider using the type _owned(MyClass)? instead
+owned-shared-fields3.chpl:78: error: Cannot default-initialize fs: shared MyClass
+note: non-nil class types do not support default initialization
+note: Consider using the type _shared(MyClass)? instead
+owned-shared-fields3.chpl:97: error: Cannot default-initialize a tuple component of the type owned MyClass
+note: non-nil class types do not support default initialization
+note: Consider using the type _owned(MyClass)? instead
+owned-shared-fields3.chpl:98: error: Cannot default-initialize a tuple component of the type owned MyClass
+note: non-nil class types do not support default initialization
+note: Consider using the type _owned(MyClass)? instead
+owned-shared-fields3.chpl:99: error: Cannot default-initialize a tuple component of the type owned MyClass
+note: non-nil class types do not support default initialization
+note: Consider using the type _owned(MyClass)? instead

--- a/test/classes/ferguson/delete-free/owned3.chpl
+++ b/test/classes/ferguson/delete-free/owned3.chpl
@@ -5,7 +5,7 @@ class C {
 }
 
 proc foo() {
-  var x:owned C;
+  var x:owned C?;
   var y = new owned C();
 
   x = y;

--- a/test/classes/ferguson/delete-free/owned4.chpl
+++ b/test/classes/ferguson/delete-free/owned4.chpl
@@ -6,7 +6,7 @@ class C {
 }
 
 proc foo() {
-  var x:owned C;
+  var x:owned C?;
   var y = new owned C(2);
 
   x.retain(y.release());

--- a/test/classes/ferguson/delete-free/shared-demo.chpl
+++ b/test/classes/ferguson/delete-free/shared-demo.chpl
@@ -14,7 +14,7 @@ proc examples() {
 
   writeln("declaring shared2 storing nil");
   // it's OK to have shared initially empty. It will point to 'nil'.
-  var shared2: shared C;
+  var shared2: shared C?;
   writeln("shared2 = ", shared2.borrow());
 
   // Assignment is supported. The LHS and RHS will both point

--- a/test/classes/ferguson/delete-free/shared3.chpl
+++ b/test/classes/ferguson/delete-free/shared3.chpl
@@ -14,7 +14,7 @@ class Impl {
 
 proc run() {
   var x = new shared Impl(1);
-  var y: shared Impl;
+  var y: shared Impl?;
 
   // check assignment
   y = x;

--- a/test/classes/ferguson/delete-free/shared4.chpl
+++ b/test/classes/ferguson/delete-free/shared4.chpl
@@ -12,7 +12,7 @@ class Impl {
   }
 }
 
-var globalSharedObject:shared Impl;
+var globalSharedObject:shared Impl?;
 
 proc makeGlobalSharedObject() {
   var x = new shared Impl(1);

--- a/test/classes/initializers/nested/nested.chpl
+++ b/test/classes/initializers/nested/nested.chpl
@@ -1,6 +1,6 @@
 class C {
   param rank: int;
-  var x: owned D;
+  var x: owned D?;
 
   class D {
   }

--- a/test/classes/sungeun/inheritance_noUse_param1.chpl
+++ b/test/classes/sungeun/inheritance_noUse_param1.chpl
@@ -7,8 +7,8 @@ class B: A {
 }
 
 var a = new owned A();
-var b: owned B;
-var c: owned B;
+var b: owned B?;
+var c: owned B?;
 
 writeln(a);
 writeln("{x = ", a.x, "}");

--- a/test/classes/sungeun/inheritance_param2.chpl
+++ b/test/classes/sungeun/inheritance_param2.chpl
@@ -10,4 +10,4 @@ class B: A {
 }
 
 var a = new shared A();
-var b: shared B;
+var b: shared B?;

--- a/test/expressions/ferguson/make-wide.chpl
+++ b/test/expressions/ferguson/make-wide.chpl
@@ -4,13 +4,13 @@ class C {
 
 proc test() {
 
-  var c:unmanaged C;
+  var c:unmanaged C?;
   
   on Locales[numLocales-1] {
     c = new unmanaged C(1);
   }
 
-  var cc:unmanaged C = c;
+  var cc:unmanaged C? = c;
 
   var loc = __primitive("_wide_get_locale", cc);
   var adr = __primitive("_wide_get_addr", cc);
@@ -23,15 +23,15 @@ proc test() {
 }
 
 proc test2() {
-  var own:owned C;
-  var c:borrowed C;
+  var own:owned C?;
+  var c:borrowed C?;
   
   on Locales[numLocales-1] {
     own = new owned C(1);
     c = own:borrowed C;
   }
 
-  var cc:borrowed C = c;
+  var cc:borrowed C? = c;
 
   var loc = __primitive("_wide_get_locale", cc);
   var adr = __primitive("_wide_get_addr", cc);

--- a/test/functions/ferguson/hijacking/DuplicateType.chpl
+++ b/test/functions/ferguson/hijacking/DuplicateType.chpl
@@ -4,7 +4,7 @@ module LibraryX1 {
     var x:int;
   }
 
-  var global:owned MyClass;
+  var global:owned MyClass?;
   proc setup() {
     writeln("In LibraryX1.setup");
     global = new owned MyClass(10);
@@ -23,7 +23,7 @@ module LibraryY1 {
   }
 
 
-  var global:owned MyClass;
+  var global:owned MyClass?;
   proc setup() {
     writeln("In LibraryY1.setup");
     global = new owned MyClass(1,2);

--- a/test/functions/iterators/recursive/follow-record-updates.chpl
+++ b/test/functions/iterators/recursive/follow-record-updates.chpl
@@ -4,16 +4,16 @@
 
 class Tree {
   var first: bool;
-  var left: owned Tree;
+  var left: owned Tree?;
 }
 
-iter postorder(tree: borrowed Tree): borrowed Tree {
+iter postorder(tree: borrowed Tree?): borrowed Tree {
   if tree != nil {
 
     for child in postorder(tree.left) do
       yield child;
 
-    yield tree;
+    yield tree!;
   }
 }
 

--- a/test/functions/iterators/recursive/recursive-iter-works.chpl
+++ b/test/functions/iterators/recursive/recursive-iter-works.chpl
@@ -1,7 +1,7 @@
 class Tree {
   var data: int;
-  var left: owned Tree;
-  var right: owned Tree;
+  var left: owned Tree?;
+  var right: owned Tree?;
   
   iter these(): int {
     if left then
@@ -12,7 +12,8 @@ class Tree {
   }
 }
 
-var tree = new owned Tree(40, new owned Tree(20, new owned Tree(10), new owned Tree(30)), new owned Tree(60, new owned Tree(50), new owned Tree(70)));
+var tree = new Tree(40, new Tree(20, new Tree(10), new Tree(30)),
+                        new Tree(60, new Tree(50), new Tree(70)));
 
 for e in tree do
   writeln(e);

--- a/test/functions/iterators/recursive/recursive-iter.bad
+++ b/test/functions/iterators/recursive/recursive-iter.bad
@@ -1,3 +1,0 @@
-$CHPL_HOME/modules/internal/ChapelIteratorSupport.chpl:94: error: unable to resolve return type of function '_getIterator'
-recursive-iter.chpl:6: In iterator 'these':
-recursive-iter.chpl:8: error: called recursively at this point

--- a/test/functions/iterators/recursive/recursive-iter.chpl
+++ b/test/functions/iterators/recursive/recursive-iter.chpl
@@ -1,20 +1,19 @@
 class Tree {
   var data: int;
-  var left: owned Tree;
-  var right: owned Tree;
+  var left: owned Tree?;
+  var right: owned Tree?;
   
   iter these(): int {
     if left then
-      for e in left do yield e.borrow();
+      for e in left! do yield e;
     yield data;
     if right then
-      for e in right do yield e.borrow();
+      for e in right! do yield e;
   }
 }
 
-var tree = new owned Tree(40, new owned Tree(20, new owned Tree(10), new owned
-      Tree(30)), new
-                    owned Tree(60, new owned Tree(50), new owned Tree(70)));
+var tree = new Tree(40, new Tree(20, new Tree(10), new Tree(30)),
+                        new Tree(60, new Tree(50), new Tree(70)));
 
 for e in tree do
   writeln(e);

--- a/test/functions/iterators/recursive/recursive-iter.future
+++ b/test/functions/iterators/recursive/recursive-iter.future
@@ -1,6 +1,0 @@
-bug: compiler can't resolve recursive implicit calls to these()
-
-This test shows that the compiler has trouble resolving recurisve
-iterators that implicitly call these().  If the call to these() is
-made explicit, as shown in recursive-iter-works.chpl, then things work
-as expected.

--- a/test/library/packages/SharedObject/shared-nil-assign.chpl
+++ b/test/library/packages/SharedObject/shared-nil-assign.chpl
@@ -1,5 +1,5 @@
 class C { }
 
-var sc1: shared C;
-var sc2: shared C;
+var sc1: shared C?;
+var sc2: shared C?;
 sc1 = sc2;

--- a/test/library/packages/SharedObject/shared-nil-return.chpl
+++ b/test/library/packages/SharedObject/shared-nil-return.chpl
@@ -1,7 +1,7 @@
 class C { }
 
 class D {
-  var sc: shared C;
+  var sc: shared C?;
   proc foo() {
     return sc;
   }

--- a/test/library/standard/DateTime/testDatetime.chpl
+++ b/test/library/standard/DateTime/testDatetime.chpl
@@ -212,7 +212,7 @@ proc test_combine() {
 proc test_replace() {
   var args = (1, 2, 3, 4, 5, 6, 7);
   var base = new datetime((...args));
-  var nilTZ:shared TZInfo;
+  var nilTZ:shared TZInfo?;
 
   assert(base == base.replace(tzinfo=nilTZ));
 

--- a/test/library/standard/Types/is-owned-shared-unmanaged.chpl
+++ b/test/library/standard/Types/is-owned-shared-unmanaged.chpl
@@ -8,10 +8,10 @@ record MyRecord {
 
 var i:int;
 var r:MyRecord;
-var o:owned MyClass;
-var s:shared MyClass;
-var u:unmanaged MyClass;
-var b:borrowed MyClass;
+var o:owned MyClass?;
+var s:shared MyClass?;
+var u:unmanaged MyClass?;
+var b:borrowed MyClass?;
 var c:MyClass = new borrowed MyClass(1);
 
 proc myassert(param got) {

--- a/test/optimizations/widepointers/refOverride.chpl
+++ b/test/optimizations/widepointers/refOverride.chpl
@@ -16,7 +16,7 @@ class SubPrinter : SuperPrinter {
 class Foo { var x = 10; }
 
 proc main() {
-  var printer: owned SuperPrinter;
+  var printer: owned SuperPrinter?;
   printer = new owned SubPrinter();
 
   //

--- a/test/release/examples/benchmarks/miniMD/helpers/forces.chpl
+++ b/test/release/examples/benchmarks/miniMD/helpers/forces.chpl
@@ -46,7 +46,7 @@ class ForceEAM : Force  {
 
   var FP: [DistSpace] [perBinSpace] real;
               
-  var funcfl : owned Funcfl;
+  var funcfl = new owned Funcfl();
 
   proc init(cf : real) {
     this.complete();
@@ -57,7 +57,6 @@ class ForceEAM : Force  {
   }
 
   proc coeff(fname : string) {
-    funcfl = new owned Funcfl();
     funcfl.eamFile = fname;
     var fchan = open(fname, iomode.r);
     var rd = fchan.reader();

--- a/test/release/examples/benchmarks/miniMD/helpers/initMD.chpl
+++ b/test/release/examples/benchmarks/miniMD/helpers/initMD.chpl
@@ -241,14 +241,12 @@ var Dest, Src: [NeighDom] domain(3);
 
 setupComms();
 
-var fobj : owned Force;
+var fobj : owned Force =
+  if force == "lj" then new owned ForceLJ(force_cut): owned Force
+                   else new owned ForceEAM(force_cut);
 
-if force == "lj" {
-  fobj = new owned ForceLJ(force_cut);
-} else {
-  fobj = new owned ForceEAM(force_cut);
+if force != "lj" then
   mass = fobj.mass;
-}
 
 if printOriginal then writeln("# Create System:");
 

--- a/test/release/examples/users-guide/taskpar/walkTreeUsingBegins.chpl
+++ b/test/release/examples/users-guide/taskpar/walkTreeUsingBegins.chpl
@@ -1,23 +1,23 @@
 class Node {
   var data: int;
-  var left, right: owned Node;
+  var left, right: owned Node?;
 
   proc processNode() {
     writeln(data);
   }
 }
 
-const tree = new owned Node(5,
-               new owned Node(2,
-                 new owned Node(1, nil, nil),
-                 new owned Node(4,
-                   new owned Node(3, nil, nil),
-                   nil)),
-               new owned Node(8,
-                 new owned Node(6,
-                   nil,
-                   new owned Node(7, nil, nil)),
-                   new owned Node(9, nil, nil)));
+const tree = new Node(5,
+                      new Node(2,
+                               new Node(1, nil, nil),
+                               new Node(4,
+                                        new Node(3, nil, nil),
+                                        nil)),
+                      new Node(8,
+                               new Node(6,
+                                        nil,
+                                        new Node(7, nil, nil)),
+                               new Node(9, nil, nil)));
 
 
 sync begin walkTree(tree);

--- a/test/studies/shootout/binary-trees/binary-trees.chpl
+++ b/test/studies/shootout/binary-trees/binary-trees.chpl
@@ -7,7 +7,7 @@ use DynamicIters;
 config const n = 10;
 
 class Tree {
-  const left, right: owned Tree;
+  const left, right: owned Tree?;
 }
 
 proc main() {
@@ -49,5 +49,5 @@ proc bottomUpTree(const depth: int): owned Tree {
 
 proc itemCheck(const T: borrowed Tree): int {
   if (T.left==nil) then return 1; 
-  else return (1 + itemCheck(T.left) + itemCheck(T.right));
+  else return (1 + itemCheck(T.left!) + itemCheck(T.right!));
 }

--- a/test/studies/shootout/spectral-norm/lydia/spectral-norm-barrier.chpl
+++ b/test/studies/shootout/spectral-norm/lydia/spectral-norm-barrier.chpl
@@ -10,7 +10,7 @@
 config const n = 500;
 
 use barrierWF;
-var b: owned BarrierWF;
+var b: owned BarrierWF?;
 
 /* Return: 1.0 / (i + j) * (i + j +1) / 2 + i + 1; */
 inline proc eval_A(i,j : int) : real

--- a/test/studies/shootout/spectral-norm/sidelnik/spectralnorm.chpl
+++ b/test/studies/shootout/spectral-norm/sidelnik/spectralnorm.chpl
@@ -9,7 +9,7 @@
 config const n = 500;
 
 use barrierWF;
-var b: owned BarrierWF;
+var b: owned BarrierWF?;
 
 /* Return: 1.0 / (i + j) * (i + j +1) / 2 + i + 1; */
 proc eval_A(i,j : int) : real

--- a/test/users/npadmana/twopt/do_smu_aos.chpl
+++ b/test/users/npadmana/twopt/do_smu_aos.chpl
@@ -141,7 +141,7 @@ class KDNode {
   var dom : domain(1);
   var xcen : NDIM*real;
   var rcell : real;
-  var left, right : owned KDNode;
+  var left, right : owned KDNode?;
 
   proc isLeaf() : bool {
     return (left==nil) && (right==nil);
@@ -216,24 +216,24 @@ proc TreeAccumulate(hh : UniformBins, p1, p2 : []WeightedParticle3D, node1, node
 
   // If one node is a leaf 
   if (node1.isLeaf()) {
-    TreeAccumulate(hh, p1, p2, node1, node2.left);
-    TreeAccumulate(hh, p1, p2, node1, node2.right);
+    TreeAccumulate(hh, p1, p2, node1, node2.left!);
+    TreeAccumulate(hh, p1, p2, node1, node2.right!);
     return;
   }
   if (node2.isLeaf()) {
-    TreeAccumulate(hh, p1, p2, node1.left, node2);
-    TreeAccumulate(hh, p1, p2, node1.right, node2);
+    TreeAccumulate(hh, p1, p2, node1.left!, node2);
+    TreeAccumulate(hh, p1, p2, node1.right!, node2);
     return;
   }
 
   // Split the larger case;
   if (node1.npart > node2.npart) {
-    TreeAccumulate(hh, p1, p2, node1.left, node2);
-    TreeAccumulate(hh, p1, p2, node1.right, node2);
+    TreeAccumulate(hh, p1, p2, node1.left!, node2);
+    TreeAccumulate(hh, p1, p2, node1.right!, node2);
     return;
   } else {
-    TreeAccumulate(hh, p1, p2, node1, node2.left);
-    TreeAccumulate(hh, p1, p2, node1, node2.right);
+    TreeAccumulate(hh, p1, p2, node1, node2.left!);
+    TreeAccumulate(hh, p1, p2, node1, node2.right!);
     return;
   }
 

--- a/test/users/npadmana/twopt/do_smu_soa.chpl
+++ b/test/users/npadmana/twopt/do_smu_soa.chpl
@@ -171,7 +171,7 @@ class KDNode {
   var dom : domain(1);
   var xcen : [DimSpace]real;
   var rcell : real;
-  var left, right : owned KDNode;
+  var left, right : owned KDNode?;
 
   proc isLeaf() : bool {
     return (left==nil) && (right==nil);
@@ -239,24 +239,24 @@ proc TreeAccumulate(hh : UniformBins, p1, p2 : Particle3D, node1, node2 :  KDNod
 
   // If one node is a leaf 
   if (node1.isLeaf()) {
-    TreeAccumulate(hh, p1, p2, node1, node2.left);
-    TreeAccumulate(hh, p1, p2, node1, node2.right);
+    TreeAccumulate(hh, p1, p2, node1, node2.left!);
+    TreeAccumulate(hh, p1, p2, node1, node2.right!);
     return;
   }
   if (node2.isLeaf()) {
-    TreeAccumulate(hh, p1, p2, node1.left, node2);
-    TreeAccumulate(hh, p1, p2, node1.right, node2);
+    TreeAccumulate(hh, p1, p2, node1.left!, node2);
+    TreeAccumulate(hh, p1, p2, node1.right!, node2);
     return;
   }
 
   // Split the larger case;
   if (node1.npart > node2.npart) {
-    TreeAccumulate(hh, p1, p2, node1.left, node2);
-    TreeAccumulate(hh, p1, p2, node1.right, node2);
+    TreeAccumulate(hh, p1, p2, node1.left!, node2);
+    TreeAccumulate(hh, p1, p2, node1.right!, node2);
     return;
   } else {
-    TreeAccumulate(hh, p1, p2, node1, node2.left);
-    TreeAccumulate(hh, p1, p2, node1, node2.right);
+    TreeAccumulate(hh, p1, p2, node1, node2.left!);
+    TreeAccumulate(hh, p1, p2, node1, node2.right!);
     return;
   }
 
@@ -295,18 +295,23 @@ proc doPairs() {
 
   // Read in the file
   tt.clear(); tt.start();
-  var pp1, pp2 : owned Particle3D;
+  var (pp1, pp2) = initialPP12();
+
+proc initialPP12() {
   if isPerf {
-    pp1 = new owned Particle3D(nParticles, true);
-    pp2 = new owned Particle3D(nParticles, true);
+    return (new Particle3D(nParticles, true),
+            new Particle3D(nParticles, true));
   } else {
-    pp1 = readFile(fn1);
-    pp2 = readFile(fn2);
+    var pp1 = readFile(fn1);
+    var pp2 = readFile(fn2);
     if !isTest {
       writef("Read in %i lines from file %s \n", pp1.npart, fn1);
       writef("Read in %i lines from file %s \n", pp2.npart, fn2);
     }
+    return (pp1, pp2);
   }
+}
+
   tt.stop();
   if !isTest {
     writef("Time to read : %r \n", tt.elapsed());


### PR DESCRIPTION
This generates an error when default-initializing a variable
of a non-nilable owned or shared class type:
```chpl
var x: owned MyClass;
var y: shared MyClass;
```

I also adjusted most tests where this new error would be triggered
when run with `--no-legacy-nilable-classes`.
I added a test to lock in the error message.

The following test now works, so I removed the .future:
```
functions/iterators/recursive/recursive-iter.chpl 
```

The implementation refactors and reuses compiler code that issues error
for similar cases with borrowed/unmanaged types. A special case for an
owned/shared type within a tuple type is needed so that the line number
in the error message points into the user code, rather than ChapelTuple.chpl.

I considered implementing this error by extending the default initializer
for _owned/_shared in the module code. I chose to do it in the compiler
because we can generate nicer error message in that case.

Things that came up and not addressed in this PR:

* Checking is not done on the element type of a default-initialized array.
This is the same as when the element type is borrowed/unmanaged.

* Weird compiler behavior and/or errors:
```
classes/delete-free/lifetimes/borrow-escapes.chpl  // if we remove '!' in c!.borrow()
expressions/ferguson/make-wide.chpl
studies/bale/toposort/toposort.chpl
release/examples/spec/Classes/owned-assignment.chpl
```

* Missed checking in this case:
```chpl
// classes/ferguson/delete-free/owned-shared-fields2.chpl
record R5 {
  var fo:owned MyClass = nil;
  var fs:shared MyClass = nil;
}
var r = new R5();
```

* Missed checking in this case:
```chpl
// optimizations/widepointers/refOverride.chpl
  var printer: owned SuperPrinter?;
  printer = new owned SubPrinter();
  printer.print(data);
```

* Spurious warnings "undecorated class type MyGenericClass is unstable"
```chpl
// compflags/ferguson/unstable-class.chpl
var eg:owned MyGenericClass(int)?;
var fg:shared MyGenericClass(int)?;
```

* It seems desirable for the user to request that the runtime check
performed upon a '!' be skipped upon `--fast`. For example, if I want
to get maximum performance out of:

```
users/npadmana/twopt/do_smu_aos
users/npadmana/twopt/do_smu_soa
```

there seems to be an invariant that if a node is not "isLeaf", then
its both 'left' and 'right' fields are non-nil, so I would like to skip
the runtime check for '!' in arguments to the recursive calls to
TreeAccumulate().

* There is a surprisingly high number of cases where the default initialization
is immediately followed by an assignment, after which the variable is assumed
to be non-nilable. A few of those cases are perhaps intentional for testing
and/or convertable to non-default initialization in a straightforward
way. However, there are a couple of more interesting cases:

```chpl
  // users/npadmana/twopt/do_smu_soa.chpl
  var pp1, pp2 : owned Particle3D;
  if isPerf {
    pp1 = new owned Particle3D(nParticles, true);
    pp2 = new owned Particle3D(nParticles, true);
  } else {
    pp1 = readFile(fn1);
    pp2 = readFile(fn2);
    if !isTest {
      writef("Read in %i lines from file %s \n", pp1.npart, fn1);
      writef("Read in %i lines from file %s \n", pp2.npart, fn2);
    }
  }
```
```chpl
  // studies/bale/toposort/toposort.chpl
  var topoResult : shared TopoSortResult(D.idxType);

  select implementation {
    when ToposortImplementation.Serial {
       if !silentMode then writeln("Converting to CSC domain");

      var dmappedPermutedSparseD : sparse subdomain(D) dmapped CS(compressRows=false);
      dmappedPermutedSparseD.bulkAdd( permutedSparseUpperTriangularIndexList );

      if !silentMode then writeln("Toposorting permuted upper triangluar domain using Serial implementation.");
      topoResult = toposortSerial( dmappedPermutedSparseD );
    }
    ... other cases are similar ...
    otherwise {
      writeln( "Unknown implementation: ", implementation );
      exit(-1);
    }
  }
```

also the former `var r: owned Runner;` in `arrays/diten/timeVectorArray.chpl`

Testing: linux64 -futures.
