### PR TITLE
Take advantage of known UTF-8 encoding to speed up strings

### DIFF
--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -216,7 +216,7 @@ module String {
     encoded multibyte character.
   */
   pragma "no doc"
-  inline proc _isInitialByte(b: uint(8)) : bool {
+  private inline proc _isInitialByte(b: uint(8)) : bool {
     return (b & 0xc0) != 0x80;
   }
 

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -854,7 +854,7 @@ module String {
       Iterates over the string Unicode character by Unicode character,
       and includes the byte index and byte length of each character.
       Skip characters that begin prior to the specified starting byte index.
-      Assume we accidentally start in the middle of a multibyte character,
+      Assume we may accidentally start in the middle of a multibyte character,
       but the string is correctly encoded UTF-8.
     */
     pragma "no doc"
@@ -880,7 +880,7 @@ module String {
       Iterates over the string Unicode character by Unicode character,
       and returns the byte index and byte length of each character.
       Skip characters that begin prior to the specified starting byte index.
-      Assume we accidentally start in the middle of a multibyte character,
+      Assume we may accidentally start in the middle of a multibyte character,
       but the string is correctly encoded UTF-8.
     */
     pragma "no doc"

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -501,6 +501,8 @@ module String {
     pragma "no doc"
     var len: int = 0; // length of string in bytes
     pragma "no doc"
+    var _numCodepoints: int = -1; // length in codepoints, -1 if not known
+    pragma "no doc"
     var _size: int = 0; // size of the buffer we own
     pragma "no doc"
     var buff: bufferType = nil;
@@ -694,13 +696,23 @@ module String {
     inline proc size return len;
 
     /*
-      :returns: The number of codepoints in the string.
+      :returns: The number of codepoints in the string, assuming the
+                string is correctly-encoded UTF-8.
       */
     proc numCodepoints {
-      var n = 0;
-      for cp in this.codepoints() do
-        n += 1;
-      return n;
+      if _numCodepoints < 0 {
+        var localThis: string = this.localize();
+        var n = 0;
+        var i = 0;
+        while i < localThis.len {
+          i += 1;
+          while i < localThis.len && !_isInitialByte(localThis.buff[i]) do
+            i += 1;
+          n += 1;
+        }
+        _numCodepoints = n;
+      }
+      return _numCodepoints;
     }
 
     /*
@@ -835,24 +847,61 @@ module String {
     }
 
     /*
+      Returns true if the argument is a valid initial byte of a UTF-8
+      encoded multibyte character.
+    */
+    pragma "no doc"
+    inline proc _isInitialByte(b: uint(8)) : bool {
+      return (b & 0xc0) != 0x80;
+    }
+
+    /*
       Iterates over the string Unicode character by Unicode character,
       and includes the byte index and byte length of each character.
       Skip characters that begin prior to the specified starting byte index.
+      Assume we accidentally start in the middle of a multibyte character,
+      but the string is correctly encoded UTF-8.
     */
     pragma "no doc"
     iter _cpIndexLen(start = 1:byteIndex) {
       var localThis: string = this.localize();
 
-      var i = 0;
+      var i = start:int - 1;
+      if i > 0 then
+        while i < localThis.len && !_isInitialByte(localThis.buff[i]) do
+          i += 1; // in case `start` is in the middle of a multibyte character
       while i < localThis.len {
         var cp: int(32);
         var nbytes: c_int;
         var multibytes = (localThis.buff + i): c_string;
         var maxbytes = (localThis.len - i): ssize_t;
         qio_decode_char_buf(cp, nbytes, multibytes, maxbytes);
-        if i + 1 >= start then
-          yield (cp:int(32), (i + 1):byteIndex, nbytes:int);
+        yield (cp:int(32), (i + 1):byteIndex, nbytes:int);
         i += nbytes;
+      }
+    }
+
+    /*
+      Iterates over the string Unicode character by Unicode character,
+      and returns the byte index and byte length of each character.
+      Skip characters that begin prior to the specified starting byte index.
+      Assume we accidentally start in the middle of a multibyte character,
+      but the string is correctly encoded UTF-8.
+    */
+    pragma "no doc"
+    iter _indexLen(start = 1:byteIndex) {
+      var localThis: string = this.localize();
+
+      var i = start:int - 1;
+      if i > 0 then
+        while i < localThis.len && !_isInitialByte(localThis.buff[i]) do
+          i += 1; // in case `start` is in the middle of a multibyte character
+      while i < localThis.len {
+        var j = i + 1;
+        while j < localThis.len && !_isInitialByte(localThis.buff[j]) do
+          j += 1;
+        yield ((i + 1):byteIndex, j - i);
+        i = j;
       }
     }
 
@@ -1039,7 +1088,7 @@ module String {
       var byte_low = this.len + 1;  // empty range if bounds outside string
       var byte_high = this.len;
       if cp_high > 0 {
-        for (c, i, nbytes) in this._cpIndexLen() {
+        for (i, nbytes) in this._indexLen() {
           if cp_count == cp_low {
             byte_low = i:int;
             if !r.hasHighBound() then

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -216,7 +216,7 @@ module String {
     encoded multibyte character.
   */
   pragma "no doc"
-  private inline proc _isInitialByte(b: uint(8)) : bool {
+  private inline proc isInitialByte(b: uint(8)) : bool {
     return (b & 0xc0) != 0x80;
   }
 
@@ -712,7 +712,7 @@ module String {
       var i = 0;
       while i < localThis.len {
         i += 1;
-        while i < localThis.len && !_isInitialByte(localThis.buff[i]) do
+        while i < localThis.len && !isInitialByte(localThis.buff[i]) do
           i += 1;
         n += 1;
       }
@@ -863,7 +863,7 @@ module String {
 
       var i = start:int - 1;
       if i > 0 then
-        while i < localThis.len && !_isInitialByte(localThis.buff[i]) do
+        while i < localThis.len && !isInitialByte(localThis.buff[i]) do
           i += 1; // in case `start` is in the middle of a multibyte character
       while i < localThis.len {
         var cp: int(32);
@@ -889,11 +889,11 @@ module String {
 
       var i = start:int - 1;
       if i > 0 then
-        while i < localThis.len && !_isInitialByte(localThis.buff[i]) do
+        while i < localThis.len && !isInitialByte(localThis.buff[i]) do
           i += 1; // in case `start` is in the middle of a multibyte character
       while i < localThis.len {
         var j = i + 1;
-        while j < localThis.len && !_isInitialByte(localThis.buff[j]) do
+        while j < localThis.len && !isInitialByte(localThis.buff[j]) do
           j += 1;
         yield ((i + 1):byteIndex, j - i);
         i = j;

--- a/test/types/string/dmk/string_internals.chpl
+++ b/test/types/string/dmk/string_internals.chpl
@@ -1,0 +1,25 @@
+// The routines tested here are not part of the public interface,
+// but their correct operation is necessary to make strings work.
+//
+// This test may need to change more often than tests that exercise
+// the public interface.
+const s: string = "événement";
+
+writeln("_cpIndexLen full traversal:");
+for (ch, idx, nbytes) in s._cpIndexLen() do
+  writeln(ch, ", ", idx, ", ", nbytes);
+write("\n");
+
+writeln("_cpIndexLen starting inside a multibyte char:");
+for (ch, idx, nbytes) in s._cpIndexLen(5:byteIndex) do
+  writeln(ch, ", ", idx, ", ", nbytes);
+write("\n");
+
+writeln("_indexLen full traversal:");
+for (idx, nbytes) in s._indexLen() do
+  writeln(idx, ", ", nbytes);
+write("\n");
+
+writeln("_indexLen starting inside a multibyte char:");
+for (idx, nbytes) in s._indexLen(5:byteIndex) do
+  writeln(idx, ", ", nbytes);

--- a/test/types/string/dmk/string_internals.good
+++ b/test/types/string/dmk/string_internals.good
@@ -1,0 +1,37 @@
+_cpIndexLen full traversal:
+233, 1, 2
+118, 3, 1
+233, 4, 2
+110, 6, 1
+101, 7, 1
+109, 8, 1
+101, 9, 1
+110, 10, 1
+116, 11, 1
+
+_cpIndexLen starting inside a multibyte char:
+110, 6, 1
+101, 7, 1
+109, 8, 1
+101, 9, 1
+110, 10, 1
+116, 11, 1
+
+_indexLen full traversal:
+1, 2
+3, 1
+4, 2
+6, 1
+7, 1
+8, 1
+9, 1
+10, 1
+11, 1
+
+_indexLen starting inside a multibyte char:
+6, 1
+7, 1
+8, 1
+9, 1
+10, 1
+11, 1


### PR DESCRIPTION
This change speeds up the substring operation by more than 3x to address string performance regressions discussed in #13130 .

The String module was originally updated in a character-set-agnostic way.  Now that we know the character set is guaranteed to be UTF-8, we can take advantage of that fact not just to speed up individual operations, but to choose faster algorithms.  For example, there are now some cases where a multibyte character does not have to be decoded, where it was before.

The 3x performance benefit was observed in the substring portion of `test/types/string/psahabu/perf/substring.chpl`.

Passes full local and GASNet testing.
