### PR TITLE
Fix NUMA after undecorated classes PR

### DIFF
--- a/compiler/codegen/expr.cpp
+++ b/compiler/codegen/expr.cpp
@@ -3188,6 +3188,10 @@ void codegenAssign(GenRet to_ptr, GenRet from)
         from = codegenWideHere(codegenNullPointer(), to_ptr.chplType);
         type = to_ptr.chplType->getValType();
         from.isLVPtr = GEN_VAL;
+      } else {
+        from = codegenNullPointer();
+        type = to_ptr.chplType->getValType();
+        from.isLVPtr = GEN_VAL;
       }
     }
   }


### PR DESCRIPTION
Follow-on to PR #13447

The code generator was emitting a memcpy with &NULL.  This commit adjusts
the code generator to generate nil with GEN_VAL to avoid that situation
in this case. The code generator already handled this case in the event
that the destination was a wide pointer.

- [x] hellos with CHPL_LOCALE_MODEL=numa
- [x] primers with CHPL_LOCALE_MODEL=numa
- [x] full local testing

Reviewed by @benharsh - thanks!