### PR TITLE
GSoC 2019: Generate llvm.lifetime.start instrinsics for variables right after their alloca instruction

### DIFF
--- a/compiler/codegen/expr.cpp
+++ b/compiler/codegen/expr.cpp
@@ -242,12 +242,12 @@ void codegenLifetimeStart(llvm::Type *valType, llvm::Value *addr)
 
   info->irBuilder->CreateLifetimeStart(addr, size);
 }
-
+git stat
 llvm::Value* createVarLLVM(llvm::Type* type, const char* name)
 {
   GenInfo* info = gGenInfo;
   llvm::Value* val = createTempVarLLVM(info->irBuilder, type, name);
-  info->currentStackVariables.push_back(val);
+  info->currentStackVariables.push_back(std::pair<llvm::Value*, llvm::Type*>(val, type));
   codegenLifetimeStart(type, val);
   return val;
 }

--- a/compiler/codegen/expr.cpp
+++ b/compiler/codegen/expr.cpp
@@ -242,7 +242,7 @@ void codegenLifetimeStart(llvm::Type *valType, llvm::Value *addr)
 
   info->irBuilder->CreateLifetimeStart(addr, size);
 }
-git stat
+
 llvm::Value* createVarLLVM(llvm::Type* type, const char* name)
 {
   GenInfo* info = gGenInfo;

--- a/compiler/codegen/stmt.cpp
+++ b/compiler/codegen/stmt.cpp
@@ -164,8 +164,10 @@ GenRet BlockStmt::codegen() {
       node->codegen();
       if (CallExpr* call = toCallExpr(node)) {
         if (call->isPrimitive(PRIM_RETURN)) {
-          for_vector(llvm::Value, var, info->currentStackVariables) {
-            codegenLifetimeEnd(var->getType(), var);
+          for (std::size_t i = 0; i < info->currentStackVariables.size(); ++i) {
+            llvm::Value* val = info->currentStackVariables.at(i).first;
+            llvm::Type* type = info->currentStackVariables.at(i).second;
+            codegenLifetimeEnd(type, val);
           };
         }
       }

--- a/compiler/codegen/symbol.cpp
+++ b/compiler/codegen/symbol.cpp
@@ -884,7 +884,7 @@ void VarSymbol::codegenDef() {
       info->lvt->addGlobalValue(cname, globalValue, GEN_VAL, ! is_signed(type));
     }
     llvm::Type *varType = type->codegen().type;
-    llvm::Value *varAlloca = createTempVarLLVM(varType, cname);
+    llvm::Value *varAlloca = createVarLLVM(varType, cname);
     info->lvt->addValue(cname, varAlloca, GEN_PTR, ! is_signed(type));
 
     if(AggregateType *ctype = toAggregateType(type)) {
@@ -1909,6 +1909,7 @@ void FnSymbol::codegenDef() {
 
   body->codegen();
   flushStatements();
+  info->currentStackVariables.clear();
 
   if( outfile ) {
     fprintf(outfile, "}\n\n");

--- a/compiler/codegen/symbol.cpp
+++ b/compiler/codegen/symbol.cpp
@@ -1909,7 +1909,9 @@ void FnSymbol::codegenDef() {
 
   body->codegen();
   flushStatements();
+#ifdef HAVE_LLVM
   info->currentStackVariables.clear();
+#endif
 
   if( outfile ) {
     fprintf(outfile, "}\n\n");

--- a/compiler/include/codegen.h
+++ b/compiler/include/codegen.h
@@ -103,7 +103,7 @@ struct GenInfo {
   llvm::TargetMachine* targetMachine;
 
   std::stack<LoopData> loopStack;
-  std::vector<llvm::Value*> currentStackVariables;
+  std::vector<std::pair<llvm::Value*, llvm::Type*> > currentStackVariables;
 
   llvm::LLVMContext llvmContext;
   llvm::MDNode* tbaaRootNode;

--- a/compiler/include/codegen.h
+++ b/compiler/include/codegen.h
@@ -103,7 +103,7 @@ struct GenInfo {
   llvm::TargetMachine* targetMachine;
 
   std::stack<LoopData> loopStack;
-  std::vector<std::set<Symbol*> > currentStackVariables;
+  std::vector<llvm::Value*> currentStackVariables;
 
   llvm::LLVMContext llvmContext;
   llvm::MDNode* tbaaRootNode;

--- a/compiler/include/expr.h
+++ b/compiler/include/expr.h
@@ -376,6 +376,7 @@ bool hasOptimizationFlag(Expr* anchor, Flag flag);
 
 
 #ifdef HAVE_LLVM
+llvm::Value* createVarLLVM(llvm::Type* type, const char* name);
 llvm::Value* createTempVarLLVM(llvm::Type* type, const char* name);
 llvm::Value* createTempVarLLVM(llvm::Type* type);
 #endif

--- a/compiler/include/expr.h
+++ b/compiler/include/expr.h
@@ -377,8 +377,7 @@ bool hasOptimizationFlag(Expr* anchor, Flag flag);
 
 #ifdef HAVE_LLVM
 llvm::Value* createVarLLVM(llvm::Type* type, const char* name);
-llvm::Value* createTempVarLLVM(llvm::Type* type, const char* name);
-llvm::Value* createTempVarLLVM(llvm::Type* type);
+llvm::Value* createVarLLVM(llvm::Type* type);
 #endif
 
 GenRet codegenValue(GenRet r);

--- a/compiler/include/llvmUtil.h
+++ b/compiler/include/llvmUtil.h
@@ -38,11 +38,11 @@ struct PromotedPair {
   }
 };
 
+bool isArrayVecOrStruct(llvm::Type* t);
 llvm::Constant* codegenSizeofLLVM(llvm::Type* type);
 llvm::AllocaInst* makeAlloca(llvm::Type* type, const char* name, llvm::Instruction* insertBefore, unsigned n=1, unsigned align=0);
 
 llvm::Value* createLLVMAlloca(llvm::IRBuilder<>* irBuilder, llvm::Type* type, const char* name);
-llvm::Value *convertValueToType(llvm::IRBuilder<> *irBuilder, const llvm::DataLayout& targetData, llvm::Value *value, llvm::Type *newType, bool isSigned = false, bool force = false);
 PromotedPair convertValuesToLarger(llvm::IRBuilder<> *irBuilder, llvm::Value *value1, llvm::Value *value2, bool isSigned1 = false, bool isSigned2 = false);
 
 int64_t getTypeSizeInBytes(const llvm::DataLayout& layout, llvm::Type* ty);

--- a/compiler/include/llvmUtil.h
+++ b/compiler/include/llvmUtil.h
@@ -41,7 +41,7 @@ struct PromotedPair {
 llvm::Constant* codegenSizeofLLVM(llvm::Type* type);
 llvm::AllocaInst* makeAlloca(llvm::Type* type, const char* name, llvm::Instruction* insertBefore, unsigned n=1, unsigned align=0);
 
-llvm::Value* createTempVarLLVM(llvm::IRBuilder<>* irBuilder, llvm::Type* type, const char* name);
+llvm::Value* createLLVMAlloca(llvm::IRBuilder<>* irBuilder, llvm::Type* type, const char* name);
 llvm::Value *convertValueToType(llvm::IRBuilder<> *irBuilder, const llvm::DataLayout& targetData, llvm::Value *value, llvm::Type *newType, bool isSigned = false, bool force = false);
 PromotedPair convertValuesToLarger(llvm::IRBuilder<> *irBuilder, llvm::Value *value1, llvm::Value *value2, bool isSigned1 = false, bool isSigned2 = false);
 

--- a/compiler/llvm/llvmUtil.cpp
+++ b/compiler/llvm/llvmUtil.cpp
@@ -157,7 +157,7 @@ llvm::AllocaInst* makeAlloca(llvm::Type* type,
   return tempVar;
 }
 
-llvm::Value* createTempVarLLVM(llvm::IRBuilder<>* irBuilder, llvm::Type* type, const char* name)
+llvm::Value* createLLVMAlloca(llvm::IRBuilder<>* irBuilder, llvm::Type* type, const char* name)
 {
   // It's important to alloca at the front of the function in order
   // to avoid having an alloca in a loop which is a good way to achieve
@@ -258,9 +258,9 @@ llvm::Value *convertValueToType(
       llvm::Value* tmp_alloc;
       if( layout.getTypeStoreSize(newType) >=
           layout.getTypeStoreSize(curType) )
-        tmp_alloc = createTempVarLLVM(irBuilder, newType, "");
+        tmp_alloc = createLLVMAlloca(irBuilder, newType, "");
       else {
-        tmp_alloc = createTempVarLLVM(irBuilder, curType, "");
+        tmp_alloc = createLLVMAlloca(irBuilder, curType, "");
       }
       // Now cast the allocation to both fromType and toType.
       llvm::Type* curPtrType = curType->getPointerTo();

--- a/test/llvm/lifetime-intrinsics/lifetime-multi-blocks.chpl
+++ b/test/llvm/lifetime-intrinsics/lifetime-multi-blocks.chpl
@@ -5,34 +5,39 @@
 proc refidentity(const ref a) const ref { return a; }
 
 proc mytest_multi_blocks() {
-  var a = 1.09;
-  // CHECK: %[[REG1:[0-9]+]] = bitcast double* %a_chpl to i8*
+  // CHECK: %a_chpl = alloca double
+  // CHECK-NEXT: %[[REG1:[0-9]+]] = bitcast double* %a_chpl to i8*
   // CHECK-NEXT: call void @llvm.lifetime.start.p0i8(i64 8, i8* %[[REG1]])
+  // CHECK: %b_chpl = alloca double
+  // CHECK-NEXT: %[[REG2:[0-9]+]] = bitcast double* %b_chpl to i8*
+  // CHECK-NEXT: call void @llvm.lifetime.start.p0i8(i64 8, i8* %[[REG2]])
+  // CHECK: %c_chpl = alloca double
+  // CHECK-NEXT: %[[REG3:[0-9]+]] = bitcast double* %c_chpl to i8*
+  // CHECK-NEXT: call void @llvm.lifetime.start.p0i8(i64 8, i8* %[[REG3]])
+  // CHECK: %e_chpl = alloca i64
+  // CHECK-NEXT: %[[REG4:[0-9]+]] = bitcast i64* %e_chpl to i8*
+  // CHECK-NEXT: call void @llvm.lifetime.start.p0i8(i64 8, i8* %[[REG4]])
+  // CHECK: %test1_chpl = alloca double
+  // CHECK-NEXT: %[[REG5:[0-9]+]] = bitcast double* %test1_chpl to i8*
+  // CHECK-NEXT: call void @llvm.lifetime.start.p0i8(i64 8, i8* %[[REG5]])
   // CHECK: %{{[0-9]+}} = bitcast double* %a_chpl to i8*
+  // CHECK: %{{[0-9]+}} = bitcast double* %b_chpl to i8*
+  // CHECK: %{{[0-9]+}} = bitcast double* %test1_chpl to i8*
+  var a = 1.09;
   refidentity(a);
   var b = 11.11;
-  // CHECK: %[[REG2:[0-9]+]] = bitcast double* %b_chpl to i8*
-  // CHECK-NEXT: call void @llvm.lifetime.start.p0i8(i64 8, i8* %[[REG2]])
-  // CHECK: %{{[0-9]+}} = bitcast double* %b_chpl to i8*
   refidentity(b);
   {
     var c = 4.0;
-    // CHECK: %[[REG3:[0-9]+]] = bitcast double* %c_chpl to i8*
-    // CHECK-NEXT: call void @llvm.lifetime.start.p0i8(i64 8, i8* %[[REG3]])
     refidentity(c);
     c = a + b + 22.2;
     {
       var e = 42;
-      // CHECK: %[[REG4:[0-9]+]] = bitcast i64* %e_chpl to i8*
-      // CHECK-NEXT: call void @llvm.lifetime.start.p0i8(i64 8, i8* %[[REG4]])
       e += e * 2;
     }
   }
   {
     var test1 = 41.0 + b;
-    // CHECK: %[[REG5:[0-9]+]] = bitcast double* %test1_chpl to i8*
-    // CHECK-NEXT: call void @llvm.lifetime.start.p0i8(i64 8, i8* %[[REG5]])
-    // CHECK: %{{[0-9]+}} = bitcast double* %test1_chpl to i8*
     refidentity(test1);
   }
   // CHECK: %[[REG6:[0-9]+]] = bitcast double* %a_chpl to i8*

--- a/test/llvm/lifetime-intrinsics/lifetime-multi-return.chpl
+++ b/test/llvm/lifetime-intrinsics/lifetime-multi-return.chpl
@@ -5,21 +5,26 @@
 proc refidentity(const ref a) const ref { return a; }
 
 proc mytest_multi_return() {
-  const x = 1.09;
-  // CHECK: %[[REG1:[0-9]+]] = bitcast double* %x_chpl to i8*
+  // CHECK: %x_chpl = alloca double
+  // CHECK-NEXT: %[[REG1:[0-9]+]] = bitcast double* %x_chpl to i8*
   // CHECK-NEXT: call void @llvm.lifetime.start.p0i8(i64 8, i8* %[[REG1]])
+  // CHECK: %a_chpl = alloca double
+  // CHECK-NEXT: %[[REG2:[0-9]+]] = bitcast double* %a_chpl to i8*
+  // CHECK-NEXT: call void @llvm.lifetime.start.p0i8(i64 8, i8* %[[REG2]])
+  // CHECK: %y_chpl = alloca double
+  // CHECK-NEXT: %[[REG3:[0-9]+]] = bitcast double* %y_chpl to i8*
+  // CHECK-NEXT: call void @llvm.lifetime.start.p0i8(i64 8, i8* %[[REG3]])
+  // CHECK: %z_chpl = alloca double
+  // CHECK-NEXT: %[[REG4:[0-9]+]] = bitcast double* %z_chpl to i8*
+  // CHECK-NEXT: call void @llvm.lifetime.start.p0i8(i64 8, i8* %[[REG4]])
+  // CHECK: %{{[0-9]+}} = bitcast double* %a_chpl to i8*
+  const x = 1.09;
   refidentity(x);
   const a = 1.22;
-  // CHECK: %[[REG2:[0-9]+]] = bitcast double* %a_chpl to i8*
-  // CHECK-NEXT: call void @llvm.lifetime.start.p0i8(i64 8, i8* %[[REG2]])
   refidentity(a);
   if (x == 1.09) {
     var y: real = 1.99;
-    // CHECK: %[[REG3:[0-9]+]] = bitcast double* %y_chpl to i8*
-    // CHECK-NEXT: call void @llvm.lifetime.start.p0i8(i64 8, i8* %[[REG3]])
     var z: real = 1.22;
-    // CHECK: %[[REG4:[0-9]+]] = bitcast double* %z_chpl to i8*
-    // CHECK-NEXT: call void @llvm.lifetime.start.p0i8(i64 8, i8* %[[REG4]])
     z += 0.02 + x;
     y += 0.003 + a;
     if x > 1 {
@@ -28,13 +33,13 @@ proc mytest_multi_return() {
       return z;
     }
   }
-  // CHECK: %[[REG5:[0-9]+]] = bitcast double* %y_chpl to i8*
+  // CHECK: %[[REG5:[0-9]+]] = bitcast double* %x_chpl to i8*
   // CHECK-NEXT: call void @llvm.lifetime.end.p0i8(i64 8, i8* %[[REG5]])
-  // CHECK: %[[REG6:[0-9]+]] = bitcast double* %z_chpl to i8*
+  // CHECK: %[[REG6:[0-9]+]] = bitcast double* %a_chpl to i8*
   // CHECK-NEXT: call void @llvm.lifetime.end.p0i8(i64 8, i8* %[[REG6]])
-  // CHECK: %[[REG7:[0-9]+]] = bitcast double* %x_chpl to i8*
+  // CHECK: %[[REG7:[0-9]+]] = bitcast double* %y_chpl to i8*
   // CHECK-NEXT: call void @llvm.lifetime.end.p0i8(i64 8, i8* %[[REG7]])
-  // CHECK: %[[REG8:[0-9]+]] = bitcast double* %a_chpl to i8*
+  // CHECK: %[[REG8:[0-9]+]] = bitcast double* %z_chpl to i8*
   // CHECK-NEXT: call void @llvm.lifetime.end.p0i8(i64 8, i8* %[[REG8]])
   return a;
 }

--- a/test/llvm/lifetime-intrinsics/lifetime-no-return.chpl
+++ b/test/llvm/lifetime-intrinsics/lifetime-no-return.chpl
@@ -5,18 +5,21 @@
 proc refidentity(const ref a) const ref { return a; }
 
 proc mytest_no_return() {
-  const a : int = 32;
-  // CHECK: %[[REG1:[0-9]+]] = bitcast i64* %a_chpl to i8*
+  // CHECK: %a_chpl = alloca i64
+  // CHECK-NEXT: %[[REG1:[0-9]+]] = bitcast i64* %a_chpl to i8*
   // CHECK-NEXT: call void @llvm.lifetime.start.p0i8(i64 8, i8* %[[REG1]])
+  // CHECK: %b_chpl = alloca double
+  // CHECK-NEXT: %[[REG2:[0-9]+]] = bitcast double* %b_chpl to i8*
+  // CHECK-NEXT: call void @llvm.lifetime.start.p0i8(i64 8, i8* %[[REG2]])
+  // CHECK: %c_chpl = alloca double
+  // CHECK-NEXT: %[[REG3:[0-9]+]] = bitcast double* %c_chpl to i8*
+  // CHECK-NEXT: call void @llvm.lifetime.start.p0i8(i64 8, i8* %[[REG3]])
   // CHECK: {{[0-9]+}} = bitcast i64* %a_chpl to i8*
+  const a : int = 32;
   refidentity(a);
   var b : real = 3.99;
-  // CHECK: %[[REG2:[0-9]+]] = bitcast double* %b_chpl to i8*
-  // CHECK-NEXT: call void @llvm.lifetime.start.p0i8(i64 8, i8* %[[REG2]])
   refidentity(b);
   var c = b * 2 + a;
-  // CHECK: %[[REG3:[0-9]+]] = bitcast double* %c_chpl to i8*
-  // CHECK-NEXT: call void @llvm.lifetime.start.p0i8(i64 8, i8* %[[REG3]])
   refidentity(c);
   if c > 2 {
     b = 2;

--- a/test/llvm/lifetime-intrinsics/lifetime-proc.chpl
+++ b/test/llvm/lifetime-intrinsics/lifetime-proc.chpl
@@ -7,19 +7,22 @@ proc mutate(ref arg) {
 }
 
 proc mytest_proc() {
-  var x: int(64);
-  // CHECK: %[[REG1:[0-9]+]] = bitcast i64* %x_chpl to i8*
+  // CHECK: %x_chpl = alloca i64
+  // CHECK-NEXT: %[[REG1:[0-9]+]] = bitcast i64* %x_chpl to i8*
   // CHECK-NEXT: call void @llvm.lifetime.start.p0i8(i64 8, i8* %[[REG1]])
+  // CHECK: %y_chpl = alloca i32
+  // CHECK-NEXT: %[[REG2:[0-9]+]] = bitcast i32* %y_chpl to i8*
+  // CHECK-NEXT: call void @llvm.lifetime.start.p0i8(i64 4, i8* %[[REG2]])
+  // CHECK: %z_chpl = alloca i16
+  // CHECK-NEXT: %[[REG3:[0-9]+]] = bitcast i16* %z_chpl to i8*
+  // CHECK-NEXT: call void @llvm.lifetime.start.p0i8(i64 2, i8* %[[REG3]])
+  var x: int(64);
   mutate(x);
   {
     var y: int(32);
-    // CHECK: %[[REG2:[0-9]+]] = bitcast i32* %y_chpl to i8*
-    // CHECK-NEXT: call void @llvm.lifetime.start.p0i8(i64 4, i8* %[[REG2]])
     mutate(y);
   }
   var z: int(16);
-  // CHECK: %[[REG3:[0-9]+]] = bitcast i16* %z_chpl to i8*
-  // CHECK-NEXT: call void @llvm.lifetime.start.p0i8(i64 2, i8* %[[REG3]])
   mutate(z);
   // CHECK: %[[REG4:[0-9]+]] = bitcast i64* %x_chpl to i8*
   // CHECK-NEXT: call void @llvm.lifetime.end.p0i8(i64 8, i8* %[[REG4]])

--- a/test/llvm/lifetime-intrinsics/lifetime-record.chpl
+++ b/test/llvm/lifetime-intrinsics/lifetime-record.chpl
@@ -8,13 +8,13 @@ record R {}
 
 proc mytest_record() {
   var r = new R();
-  // CHECK: %[[REG1:[0-9]+]] = bitcast %R_chpl* %r_chpl to i8*
+  // CHECK: %r_chpl = alloca %R_chpl
+  // CHECK-NEXT: %[[REG1:[0-9]+]] = bitcast %R_chpl* %r_chpl to i8*
   // CHECK-NEXT: call void @llvm.lifetime.start.p0i8(i64 4, i8* %[[REG1]])
   // CHECK: %{{[0-9]+}} = bitcast %R_chpl* %r_chpl to i8*
+  refidentity(r);
   // CHECK: %[[REG2:[0-9]+]] = bitcast %R_chpl* %r_chpl to i8*
   // CHECK-NEXT: call void @llvm.lifetime.end.p0i8(i64 4, i8* %[[REG2]])
-  refidentity(r);
 }
 
 mytest_record();
-

--- a/test/llvm/lifetime-intrinsics/lifetime-throws.chpl
+++ b/test/llvm/lifetime-intrinsics/lifetime-throws.chpl
@@ -10,15 +10,17 @@ class EmptyStringError : Error {
 
 proc mytest_throws(f: string) throws {
   var a = 42;
-  // CHECK: %[[REG1:[0-9]+]] = bitcast i64* %a_chpl to i8*
+  // CHECK: %a_chpl = alloca i64
+  // CHECK-NEXT: %[[REG1:[0-9]+]] = bitcast i64* %a_chpl to i8*
   // CHECK-NEXT: call void @llvm.lifetime.start.p0i8(i64 8, i8* %[[REG1]])
-  // CHECK: %{{[0-9]+}} = bitcast i64* %a_chpl to i8*
   refidentity(a);
   var b = a + 42;
-  // CHECK: %[[REG2:[0-9]+]] = bitcast i64* %b_chpl to i8*
+  // CHECK: %b_chpl = alloca i64
+  // CHECK-NEXT: %[[REG2:[0-9]+]] = bitcast i64* %b_chpl to i8*
   // CHECK-NEXT: call void @llvm.lifetime.start.p0i8(i64 8, i8* %[[REG2]])
-  // CHECK: %{{[0-9]+}} = bitcast i64* %b_chpl to i8*
   refidentity(b);
+  // CHECK: %{{[0-9]+}} = bitcast i64* %a_chpl to i8*
+  // CHECK: %{{[0-9]+}} = bitcast i64* %b_chpl to i8*
   if f.isEmpty() then
     throw new owned EmptyStringError();
   if b != 42 * 2 {


### PR DESCRIPTION
This PR builds upon the previous https://github.com/chapel-lang/chapel/pull/12721 PR that implemented `llvm.lifetime` instrinsics. We now generate the `llvm.lifetime.start` instrinsic right after a variable's `alloca` instruction.