### PR TITLE
Fix cast for c_fn_ptr to c_void_ptr

### DIFF
--- a/modules/internal/CPtr.chpl
+++ b/modules/internal/CPtr.chpl
@@ -246,6 +246,11 @@ module CPtr {
   pragma "no doc"
   inline proc =(ref a: c_ptr, b: c_void_ptr) { __primitive("=", a, b); }
 
+  pragma "no doc"
+  inline proc _cast(type t:c_void_ptr, x:c_fn_ptr) {
+    return __primitive("cast", c_void_ptr, x);
+  }
+
   // Note: we rely from nil to pointer types for ptr = nil, nil:ptr cases
 
   pragma "no doc"

--- a/test/library/packages/Curl/download-http-upload-ftp.good
+++ b/test/library/packages/Curl/download-http-upload-ftp.good
@@ -1,2 +1,1 @@
-starting server
 uploading some files to FTP

--- a/test/types/cptr/cfnptr_to_void.chpl
+++ b/test/types/cptr/cfnptr_to_void.chpl
@@ -1,0 +1,4 @@
+proc f() { }
+
+var ptr = c_ptrTo(f):c_void_ptr;
+writeln(ptr.type:string);

--- a/test/types/cptr/cfnptr_to_void.good
+++ b/test/types/cptr/cfnptr_to_void.good
@@ -1,0 +1,1 @@
+c_void_ptr


### PR DESCRIPTION
Follow-on to PR #13447

PR #13447 accidentally removed the required cast from CPtr,
which led to failures in test/library/packages/Curl/check-http.chpl.

This commit adds back in the removed _cast and also adds
a test that will run in the standard configuration and make
sure it is not accidentally disabled again.

Additionally fixes a .good file for a Curl test that is .notest'd
because it relies on having a working FTP server on localhost.

- [x] full local testing

Reviewed by @benharsh - thanks!