### PR TITLE
Rename a C struct in test to avoid conflicting with ctype.h

### DIFF
--- a/test/extern/rename/ccode.h
+++ b/test/extern/rename/ccode.h
@@ -2,7 +2,7 @@
 
 int64_t type = 42;
 
-typedef struct _S {
+typedef struct _testStruct {
   int okname;
   int type;
 } S;


### PR DESCRIPTION
Starting #13519, we import `ctype.h` to check whether bytes are ascii, uppercase, space etc. To my luck, cygwin's `ctype.h` does a `#define _S` and a test also defines a `struct _S`, which was causing backend compiler errors. This PR changes the name of the struct to `_testStruct`.

To my knowledge, we hit this issue only on cygwin

`test/extern/rename` passes with standard darwin and cygwin