### PR TITLE
In cleanupAfterRemoves, set removed substitutions to NULL

### DIFF
--- a/compiler/resolution/cleanups.cpp
+++ b/compiler/resolution/cleanups.cpp
@@ -638,6 +638,11 @@ static void cleanupAfterRemoves() {
     fn->instantiatedFrom = NULL;
     fn->setInstantiationPoint(NULL);
     // How about fn->substitutions, basicBlocks, calledBy ?
+    form_Map(SymbolMapElem, e, fn->substitutions) {
+      if (e->value && !e->value->inTree()) {
+        e->value = NULL;
+      }
+    }
   }
 
   forv_Vec(ModuleSymbol, mod, gModuleSymbols) {

--- a/compiler/resolution/cleanups.cpp
+++ b/compiler/resolution/cleanups.cpp
@@ -637,12 +637,12 @@ static void cleanupAfterRemoves() {
       fn->addFlag(FLAG_INSTANTIATED_GENERIC);
     fn->instantiatedFrom = NULL;
     fn->setInstantiationPoint(NULL);
-    // How about fn->substitutions, basicBlocks, calledBy ?
     form_Map(SymbolMapElem, e, fn->substitutions) {
       if (e->value && !e->value->inTree()) {
         e->value = NULL;
       }
     }
+    // How about basicBlocks, calledBy ?
   }
 
   forv_Vec(ModuleSymbol, mod, gModuleSymbols) {


### PR DESCRIPTION
PR #13555 updated the way that substitutions
are computed and after PR #13447 it is possible that some of the
substitutions for type arguments are in fact generic types.
In that event, the types are removed from the tree by resolution
cleanup functions. However, they were not being removed from
fn->substitutions, causing use-after-free errors in
convertClassTypes.

This PR adjusts cleanupAfterRemoves() to put a NULL in any
substitution value that has been removed from the tree.

- [x] tests failing in valgrind now pass
- [x] full local testing

Reviewed by @vasslitvinov - thanks!