### PR TITLE
Don't prepend /usr/lib64 to LD_LIBRARY_PATH any more.

### DIFF
--- a/doc/rst/platforms/cray.rst
+++ b/doc/rst/platforms/cray.rst
@@ -84,7 +84,6 @@ installed, do the following:
      export CHPL_LAUNCHER=slurm-srun
      export CRAYPE_LINK_TYPE=dynamic
      export LIBFABRIC_DIR=/opt/cray/libfabric/1.8.0a1-85f6e641a
-     export LD_LIBRARY_PATH=/usr/lib64:$LD_LIBRARY_PATH
 
 4) Compile an example program like this::
 

--- a/util/build_configs/cray-internal/generate-modulefile.bash
+++ b/util/build_configs/cray-internal/generate-modulefile.bash
@@ -164,9 +164,6 @@ if { [string match cray-shasta $CHPL_HOST_PLATFORM] } {
     # Some libraries are not yet available in static form.
     setenv CRAYPE_LINK_TYPE dynamic
 
-    # The PrgEnv stuff isn't picking up the right PMI library yet.
-    prepend-path LD_LIBRARY_PATH /usr/lib64
-
     # Work around libfabric module not setting everything we need yet:
     # set LIBFABRIC_DIR to the parent of libfabric's PATH entry.
     if { ! [info exists env(LOADEDMODULES)] ||


### PR DESCRIPTION
We used to have to prepend /usr/lib64 to LD_LIBRARY_PATH, because Shasta
slurm was running with --mpi=pmi2 by default and we needed the slurm PMI
libraries in that directory.  But Shasta slurm recently began running
with --mpi=cray-pmi by default, so we need the Cray PMI libraries.
Removing the prepended /usr/lib64 causes us to find those instead of the
slurm ones.

Note that a module built with this change will do the wrong thing if it
is used in an "old" Shasta environment built before about 2019-07-25,
but those are rapidly becoming rare.