### PR TITLE
Adjust borrow-escapes.chpl for nil checkng

### DIFF
--- a/test/classes/delete-free/lifetimes/borrow-escapes.chpl
+++ b/test/classes/delete-free/lifetimes/borrow-escapes.chpl
@@ -8,15 +8,15 @@ class MyClass {
 }
 
 record R {
-  // TODO - get init with owned fields working
-  var c:owned MyClass?;// = new Owned(nil:MyClass);
+
+  var c = new owned MyClass(234);
   proc init() {
-    //var tmp = new Owned(new MyClass(data));
-    //c = tmp;
-    //c.retain(new MyClass(data));
+    // A whole lot of nothing.
+    // To preserve the line numbers
+    // in the .good file for this test
   }
   proc get(): borrowed MyClass {
-    return c!.borrow();
+    return c.borrow();
   }
 }
 


### PR DESCRIPTION
In #13574 I modified this test to pass nil checks.
As a result, the code started to invoke `!` on an empty field.
Now, instead, always initialize the field so it is non-nilable.
Also, remove a TODO comment that is now obsolete.

Note that these nilability issues are orthogonal to the purpose
of the test, which is to test certain lifetime errors.

Discussed with @mppf.