### PR TITLE
Fix memory leaks in test-radix-bucketizer.chpl

### DIFF
--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -445,6 +445,38 @@ void Expr::insertAfter(Expr* new_ast) {
   list->length++;
 }
 
+void Expr::insertAfter(Expr* e1, Expr* e2) {
+  insertAfter(e2);
+  insertAfter(e1);
+}
+void Expr::insertAfter(Expr* e1, Expr* e2, Expr* e3) {
+  insertAfter(e3);
+  insertAfter(e2);
+  insertAfter(e1);
+}
+void Expr::insertAfter(Expr* e1, Expr* e2, Expr* e3, Expr* e4) {
+  insertAfter(e4);
+  insertAfter(e3);
+  insertAfter(e2);
+  insertAfter(e1);
+}
+void Expr::insertAfter(Expr* e1, Expr* e2, Expr* e3, Expr* e4, Expr* e5) {
+  insertAfter(e5);
+  insertAfter(e4);
+  insertAfter(e3);
+  insertAfter(e2);
+  insertAfter(e1);
+}
+void Expr::insertAfter(Expr* e1, Expr* e2, Expr* e3, Expr* e4,
+                       Expr* e5, Expr* e6) {
+  insertAfter(e6);
+  insertAfter(e5);
+  insertAfter(e4);
+  insertAfter(e3);
+  insertAfter(e2);
+  insertAfter(e1);
+}
+
 
 void Expr::insertBefore(AList exprs) {
   Expr* curr = this;

--- a/compiler/include/expr.h
+++ b/compiler/include/expr.h
@@ -70,6 +70,16 @@ public:
   void            insertAfter(Expr* new_ast);
   void            replace(Expr* new_ast);
 
+  // Insert multiple ASTs in the order of the arguments.
+  // Todo: replace with a single varargs version.
+  void            insertAfter(Expr* e1, Expr* e2);
+  void            insertAfter(Expr* e1, Expr* e2, Expr* e3);
+  void            insertAfter(Expr* e1, Expr* e2, Expr* e3, Expr* e4);
+  void            insertAfter(Expr* e1, Expr* e2, Expr* e3, Expr* e4,
+                              Expr* e5);
+  void            insertAfter(Expr* e1, Expr* e2, Expr* e3, Expr* e4,
+                              Expr* e5, Expr* e6);
+
   void            insertBefore(AList exprs);
   void            insertAfter(AList exprs);
 

--- a/compiler/passes/createTaskFunctions.cpp
+++ b/compiler/passes/createTaskFunctions.cpp
@@ -370,16 +370,21 @@ static void addReduceIntentSupport(FnSymbol* fn, CallExpr* call,
   Expr* tailAnchor = findTailInsertionPoint(call, isCoforall);
   // Doing insertAfter() calls in reverse order.
   // Can't insertBefore() on tailAnchor->next - that can be NULL.
-  tailAnchor->insertAfter("chpl__delete(%S)",
-                         globalOp);
-  tailAnchor->insertAfter("'='(%S, generate(%S,%S))",
-                         origSym, gMethodToken, globalOp);
+  // origSym = <- globalOp.generate() (via genTemp); delete globalOp;
+  VarSymbol* genTemp = newTemp("genTemp");
+  genTemp->addFlag(FLAG_INSERT_AUTO_DESTROY);
+  tailAnchor->insertAfter(new CallExpr("chpl__delete", globalOp));
+  tailAnchor->insertAfter(new CallExpr("=", origSym, genTemp));
+  tailAnchor->insertAfter("'move'(%S,generate(%S,%S))",
+                          genTemp, gMethodToken, globalOp);
+  tailAnchor->insertAfter(new DefExpr(genTemp));
 
   ArgSymbol* parentOp = new ArgSymbol(INTENT_BLANK, "reduceParent", dtUnknown);
   newFormal = parentOp;
 
   VarSymbol* currOp = new VarSymbol("reduceCurr");
   VarSymbol* svar  = new VarSymbol(origSym->name, origSym->type);
+  svar->addFlag(FLAG_INSERT_AUTO_DESTROY);
   symReplace = svar;
 
   redRef1->insertBefore(new DefExpr(currOp));


### PR DESCRIPTION
Resolves #13569, plugging the memory leak in
```
test/library/packages/Sort/correctness/test-radix-bucketizer.chpl
```

When setting up the AST for a task reduce intent, I was using
PRIM_ASSIGN instead of calling the `=` function (which is a really bad
idea when used on an array btw) to store the result of globalOp.generate()
into the outer variable.  Also, the task-private shadow variables were not
getting autoDestroy-ed. This fixes these bugs.

While there, add multi-arg versions of `Expr::insertAfter(Expr*)`, for convenience.
A single varargs version instead would be even nicer.

Testing:
* [x] memleaks -- removes leaks in the bucketizer test, does not affect other tests
* [x] valgrind
* [x] linux64 -futures
  - modulo distributions/ferguson/dist-assoc-bulkadd.bad mismatch, to be handled post-merge
