### PR TITLE
Replace use of GASNET_MASTERIP and GASNET_WORKERIP with their new counterparts

### DIFF
--- a/util/cron/common-darwin.bash
+++ b/util/cron/common-darwin.bash
@@ -2,8 +2,8 @@
 
 # 2017-11-03: needed on chapelmac since I.T. updates on 2017-10-10
 #             known to be needed on a Macbook when connected over VPN
-export GASNET_MASTERIP=127.0.0.1
-export GASNET_WORKERIP=127.0.0.0
+export CHPL_RT_MASTERIP=127.0.0.1
+export CHPL_RT_WORKERIP=127.0.0.0
 
 # We run darwin testing heavily oversubscribed, so limit the number of Chapel
 # executables that run concurrently to avoid timeouts.


### PR DESCRIPTION
This should exhibit no change in behavior, as the runtime will set them based
on the values of the environment variables that replace them, CHPL_RT_MASTERIP
and CHPL_RT_WORKERIP.