### PR TITLE
In comm=ofi, adjust for the "tcp" provider.

### DIFF
--- a/runtime/include/comm/ofi/chpl-comm-task-decls.h
+++ b/runtime/include/comm/ofi/chpl-comm-task-decls.h
@@ -58,7 +58,7 @@ struct chpl_comm_bundleData_execOn_t {
   chpl_fn_int_t fid;            // function table index to call
   uint16_t argSize;             // #bytes in whole arg bundle
   c_sublocid_t subloc;          // target sublocale
-  chpl_comm_amDone_t* pDone;    // initiator's 'done' flag; nonblocking if NULL
+  chpl_comm_amDone_t* pAmDone;  // initiator's 'amDone' flag; NULL means nonblk
 };
 
 struct chpl_comm_bundleData_execOnLrg_t {
@@ -68,7 +68,7 @@ struct chpl_comm_bundleData_execOnLrg_t {
   void* arg;                    // address of arg, on initiator
   c_sublocid_t subloc;          // target sublocale
   chpl_comm_amDone_t gotArg;    // initiator's 'got large arg' flag
-  chpl_comm_amDone_t* pDone;    // initiator's 'done' flag; nonblocking if NULL
+  chpl_comm_amDone_t* pAmDone;  // initiator's 'amDone' flag; NULL means nonblk
 };
 
 struct chpl_comm_bundleData_RMA_t {
@@ -76,7 +76,7 @@ struct chpl_comm_bundleData_RMA_t {
   void* addr;                   // address on AM target node
   void* raddr;                  // address on AM initiator's node
   size_t size;                  // number of bytes
-  chpl_comm_amDone_t* pDone;    // initiator's 'done' flag; nonblocking if NULL
+  chpl_comm_amDone_t* pAmDone;  // initiator's 'amDone' flag; NULL means nonblk
 };
 
 typedef union {
@@ -98,7 +98,7 @@ struct chpl_comm_bundleData_AMO_t {
   chpl_amo_datum_t operand1;    // first operand, if needed
   chpl_amo_datum_t operand2;    // second operand, if needed
   void* result;                 // result address on initiator's node
-  chpl_comm_amDone_t* pDone;    // initiator's 'done' flag; nonblocking if NULL
+  chpl_comm_amDone_t* pAmDone;  // initiator's 'amDone' flag; NULL means nonblk
 };
 
 typedef union {

--- a/runtime/include/comm/ofi/chpl-comm-task-decls.h
+++ b/runtime/include/comm/ofi/chpl-comm-task-decls.h
@@ -29,7 +29,7 @@
 #include "chpltypes.h"
 
 typedef struct {
-  int dummy;    // structs must be nonempty
+  int numTxnsOut;    // number of transactions outstanding
 } chpl_comm_taskPrvData_t;
 
 //

--- a/runtime/src/comm/ofi/comm-ofi-internal.h
+++ b/runtime/src/comm/ofi/comm-ofi-internal.h
@@ -53,6 +53,7 @@ FILE* chpl_comm_ofi_dbg_file;
 #define DBG_CFGAV                  0x80UL
 #define DBG_THREADS               0x100UL
 #define DBG_THREADDETAILS         0x200UL
+#define DBG_TCIPS                 0x800UL
 #define DBG_INTERFACE            0x1000UL
 #define DBG_AM                  0x10000UL
 #define DBG_AMSEND              0x20000UL

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -560,6 +560,14 @@ void init_ofiFabricDomain(void) {
       DBG_PRINTF(DBG_CFGFAB, "%s", fi_tostr(ofi_info, FI_TYPE_INFO));
       DBG_PRINTF(DBG_CFGFAB, "----------");
     }
+  } else {
+    //
+    // Node 0 will take care of producing the error message.
+    //
+    if (ret == -FI_ENODATA) {
+      chpl_comm_ofi_oob_fini();
+      chpl_exit_any(0);
+    }
   }
 
   fi_freeinfo(hints);

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -2365,6 +2365,10 @@ void chpl_comm_put(void* addr, c_nodeid_t node, void* raddr,
   CHK_TRUE(addr != NULL);
   CHK_TRUE(raddr != NULL);
 
+  if (size == 0) {
+    return;
+  }
+
   if (node == chpl_nodeID) {
     memmove(raddr, addr, size);
     return;
@@ -2392,6 +2396,10 @@ void chpl_comm_get(void* addr, int32_t node, void* raddr,
   //
   CHK_TRUE(addr != NULL);
   CHK_TRUE(raddr != NULL);
+
+  if (size == 0) {
+    return;
+  }
 
   if (node == chpl_nodeID) {
     memmove(addr, raddr, size);

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -411,38 +411,9 @@ void init_ofiFabricDomain(void) {
   ret = fi_getinfo(FI_VERSION(FI_MAJOR_VERSION, FI_MINOR_VERSION),
                    NULL, NULL, 0, hints, &ofi_info);
 
-  //
-  // STOPGAP: For now, do not accept TCP-based providers unless those
-  //          are specified explicitly.  When we try use them we get
-  //          FI_ENOCQ on the first transmit context.  I don't know why.
-  //          For the time being, just skip those.  There's no harm for
-  //          now; we've never used tcp providers in the past anyway.
-  //
-  if (ret == FI_SUCCESS && provider == NULL) {
-    struct fi_info* info;
-    for (info = ofi_info; info != NULL; info = info->next) {
-      const char* pn = info->fabric_attr->prov_name;
-      if (strstr(pn, "tcp") == NULL)
-        break;
-      if (DBG_TEST_MASK(DBG_CFGFAB) && chpl_nodeID == 0) {
-        if (info == ofi_info) {
-          DBG_PRINTF(DBG_CFGFAB,
-                     "==================== skipping \"tcp\" provider(s):");
-        }
-        DBG_PRINTF(DBG_CFGFAB, "%s", fi_tostr(info, FI_TYPE_INFO));
-        DBG_PRINTF(DBG_CFGFAB, "----------");
-      }
-    }
-    if ((ofi_info = info) == NULL) {
-      ret = -FI_ENODATA;
-    }
-  }
-
   if (chpl_nodeID == 0) {
     if (ret == -FI_ENODATA) {
-      if (DBG_TEST_MASK(DBG_CFGFAB | DBG_CFGFABSALL)) {
-        DBG_PRINTF(DBG_CFGFAB, "==================== hints:");
-        DBG_PRINTF(DBG_CFGFAB, "%s", fi_tostr(hints, FI_TYPE_INFO));
+      if (DBG_TEST_MASK(DBG_CFGFABSALL)) {
         DBG_PRINTF(DBG_CFGFABSALL,
                    "==================== fi_getinfo() fabrics:");
         DBG_PRINTF(DBG_CFGFABSALL,
@@ -465,21 +436,19 @@ void init_ofiFabricDomain(void) {
                        (provider == NULL) ? "<any>" : provider);
     }
 
-    if (DBG_TEST_MASK(DBG_CFGFAB | DBG_CFGFABSALL)) {
-      if (DBG_TEST_MASK(DBG_CFGFABSALL)) {
-        DBG_PRINTF(DBG_CFGFABSALL, "====================\n"
-                   "fi_getinfo() matched fabric(s):");
-        struct fi_info* info;
-        for (info = ofi_info; info != NULL; info = info->next) {
-          DBG_PRINTF(DBG_CFGFABSALL, "%s", fi_tostr(ofi_info, FI_TYPE_INFO));
-          DBG_PRINTF(DBG_CFGFABSALL, "----------");
-        }
-      } else {
-        DBG_PRINTF(DBG_CFGFAB, "====================\n"
-                   "fi_getinfo() matched fabric:");
-        DBG_PRINTF(DBG_CFGFAB, "%s", fi_tostr(ofi_info, FI_TYPE_INFO));
-        DBG_PRINTF(DBG_CFGFAB, "----------");
+    if (DBG_TEST_MASK(DBG_CFGFABSALL)) {
+      DBG_PRINTF(DBG_CFGFABSALL, "====================\n"
+                 "fi_getinfo() matched fabric(s):");
+      struct fi_info* info;
+      for (info = ofi_info; info != NULL; info = info->next) {
+        DBG_PRINTF(DBG_CFGFABSALL, "%s", fi_tostr(ofi_info, FI_TYPE_INFO));
+        DBG_PRINTF(DBG_CFGFABSALL, "----------");
       }
+    } else {
+      DBG_PRINTF(DBG_CFGFAB, "====================\n"
+                 "fi_getinfo() matched fabric:");
+      DBG_PRINTF(DBG_CFGFAB, "%s", fi_tostr(ofi_info, FI_TYPE_INFO));
+      DBG_PRINTF(DBG_CFGFAB, "----------");
     }
   }
 

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -301,9 +301,16 @@ static chpl_bool provCtl_readAmoNeedsOpnd; // READ AMO needs operand (RxD)
 //
 static
 chpl_bool isInProviderName(const char* s) {
+  if (ofi_info->fabric_attr->prov_name == NULL) {
+    return false;
+  }
+
+  char provName[strlen(ofi_info->fabric_attr->prov_name) + 1];
+  strcpy(provName, ofi_info->fabric_attr->prov_name);
+
   char* tok;
   char* strSave;
-  for (char* pn = ofi_info->fabric_attr->prov_name;
+  for (char* pn = provName;
        (tok = strtok_r(pn, ";", &strSave)) != NULL;
        pn = NULL) {
     if (strcmp(s, tok) == 0) {

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -2450,13 +2450,12 @@ struct perTxCtxInfo_t* tciAlloc(chpl_bool bindToAmHandler) {
     // re-allocated, use that.
     //
     if (tcip->bound) {
-      DBG_PRINTF(DBG_THREADS, "I re-have bound tciTab[%td]",
-                 tcip - tciTab);
+      DBG_PRINTF(DBG_TCIPS, "realloc bound tciTab[%td]", tcip - tciTab);
       return tcip;
     }
 
     if (!atomic_exchange_bool(&tcip->allocated, true)) {
-      DBG_PRINTF(DBG_THREADS, "I re-have tciTab[%td]", tcip - tciTab);
+      DBG_PRINTF(DBG_TCIPS, "realloc tciTab[%td]", tcip - tciTab);
       return tcip;
     }
   }
@@ -2471,7 +2470,7 @@ struct perTxCtxInfo_t* tciAlloc(chpl_bool bindToAmHandler) {
       || (tciTabFixedAssignments && chpl_task_isFixedThread())) {
     tcip->bound = true;
   }
-  DBG_PRINTF(DBG_THREADS, "I have%s tciTab[%td]",
+  DBG_PRINTF(DBG_TCIPS, "alloc%s tciTab[%td]",
              tcip->bound ? " bound" : "", tcip - tciTab);
   return tcip;
 }
@@ -2536,7 +2535,7 @@ void tciFree(struct perTxCtxInfo_t* tcip) {
   // Bound contexts stay bound.  We only release non-bound ones.
   //
   if (!tcip->bound) {
-    DBG_PRINTF(DBG_THREADS, "I free tciTab[%td]", tcip - tciTab);
+    DBG_PRINTF(DBG_TCIPS, "free tciTab[%td]", tcip - tciTab);
     atomic_store_bool(&tcip->allocated, false);
   }
 }

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -3020,6 +3020,15 @@ void chpl_comm_atomic_unordered_task_fence(void) {
 
 static
 int computeAtomicValid(enum fi_datatype ofiType) {
+  //
+  // At least one provider (ofi_rxm) segfaults if the endpoint given to
+  // fi*atomicvalid() entirely lacks atomic caps.  The man page isn't
+  // clear on whether this should work, so just avoid that situation.
+  //
+  if ((ofi_info->tx_attr->caps & FI_ATOMIC) == 0) {
+    return 0;
+  }
+
   struct fid_ep* ep = tciTab[0].txCtx; // assume same answer for all endpoints
   size_t count;                        // ignored
 

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -1863,7 +1863,7 @@ void amRequestCommon(c_nodeid_t node,
 
   if (myArg->comm.b.op != am_opAMO || ordered) {
     do {
-      local_yield();
+      sched_yield();
       ensure_progress();
       if (tciTryRealloc(tcip)) {
         checkTxCQ(tcip);

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -361,6 +361,9 @@ void init_ofiFabricDomain(void) {
 
   hints->addr_format = FI_FORMAT_UNSPEC;
 
+  hints->tx_attr->op_flags = FI_DELIVERY_COMPLETE | FI_COMPLETION;
+  hints->rx_attr->op_flags = FI_MULTI_RECV        | FI_COMPLETION;
+
   hints->ep_attr->type = FI_EP_RDM;
 
   hints->domain_attr->threading = FI_THREAD_UNSPEC;


### PR DESCRIPTION
There are a variety of changes here, which taken together allow full
testing to pass (no functional failures) with the "tcp" provider.

We still get timeouts on about a dozen tests.  Which ones and how many
varies, but `distributions/bradc/assoc/userAssoc-domain-stress.chpl` is
usually in the mix, for example.  This will be addressed separately.

The specific changes are documented in each commit, but here are the
high points:
- The "ofi_rxm" utility provider which adds RDM (reliable datagram)
  support to the tcp provider does dynamic endpoint connection and this
  can cause `FI_EAGAIN` returns during the initial communication with each
  remote.  The caller needs to ride these out; we do so here.
- Reorganize provider-sensitive settings and logic, which was kind of
  spread all over even though there wasn't much of it yet.
- Adapt to a couple of quirks in "tcp;ofi_rxm" provider behavior with
  respect to zero-length transfers and atomic ops
- We were being sloppy about how we specified which completions we
  wanted to see.  Tighten that up.
- The existing completion management would not have worked if tasks
  could switch transmit contexts while allowing compute/communicate
  overlap during completion waits.  Here, revamp completion management
  so that we (or somebody else) watches the right transmit context for
  the completion(s) we're waiting for.
- Implement blocking CQ support but leave it off by default, because at
  present it doesn't seem to provide the expected performance benefit.