### PR TITLE
Be more lenient as to what constitutes a "working" modules command.

### DIFF
--- a/util/build_configs/module-functions.bash
+++ b/util/build_configs/module-functions.bash
@@ -19,7 +19,7 @@ function ck_module_list() {
         log_error "module list=<empty>"
         exit 2
         ;;
-    ( *modules/[0-9]* )
+    ( "Currently Loaded Modulefiles:"*[a-zA-Z0-9] )
         ;;
     ( * )
         log_error "Unrecognized module list=$output"


### PR DESCRIPTION
The check for a working modules command was based on seeing
"modules/*" in the output of `module list`.  That isn't working on a
Shasta system, where there is no "modules" module loaded by default.
Check instead for the expected header in the `module list` command's
output.