### PR TITLE
Stop loading a cmake module for the XC-x86 module build

### DIFF
--- a/util/build_configs/cray-internal/setenv-shasta-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-shasta-x86_64.bash
@@ -436,12 +436,6 @@ else
         ;;
     ( compiler )
         load_prgenv_gnu
-
-        if [ "$CHPL_LLVM" == llvm ]; then
-            # Chapel make compiler with LLVM requires python 2.7 and cmake >= 3.4.1
-            load_module cmake
-            use_python27
-        fi
         ;;
     ( venv )
         load_prgenv_gnu

--- a/util/build_configs/cray-internal/setenv-xc-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-xc-x86_64.bash
@@ -429,12 +429,6 @@ else
         ;;
     ( compiler )
         load_prgenv_gnu
-
-        if [ "$CHPL_LLVM" == llvm ]; then
-            # Chapel make compiler with LLVM requires python 2.7 and cmake >= 3.4.1
-            load_module cmake
-            use_python27
-        fi
         ;;
     ( venv )
         load_prgenv_gnu


### PR DESCRIPTION
When we built the module on a CLE5 machine, we needed to load a newer
cmake and python in order to build llvm. That's not needed on CLE6 or
newer, so stop loading them. Note that the arm module already stopped
doing this since it was running on a newer machine. Additionally, remove
the code from the shasta module. It isn't building llvm support yet, but
when it does this code won't be needed.