### PR TITLE
More attempts to fix XC-x86 module

### DIFF
--- a/util/build_configs/cray-internal/setenv-xc-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-xc-x86_64.bash
@@ -387,7 +387,7 @@ else
 
         # pin to mpich/libsci versions compatible with the gen compiler
         load_module_version cray-mpich 7.7.7
-        load_module_version cray-libsci 18.07.1
+        load_module_version cray-libsci 19.04.1.1
     }
 
     function load_target_cpu() {

--- a/util/build_configs/module-functions.bash
+++ b/util/build_configs/module-functions.bash
@@ -178,8 +178,10 @@ function load_module_version() {
         bashDebugPop
         found=$( get_module_version $target_module )
     fi
-    if [ -z "$found" -o "$found" != $target_version ]; then
-        log_error "Failed: $bug_msg"
-        exit 2
+    if [ "$target_version" != "default" ] ; then
+        if [ -z "$found" -o "$found" != $target_version ]; then
+            log_error "Failed: $bug_msg"
+            exit 2
+        fi
     fi
 }


### PR DESCRIPTION
Allow loading a default module, and change what version of libsci is
being pinned to for cce