### PR TITLE
Enable downcast of owned and shared

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -2496,7 +2496,9 @@ static void adjustClassCastCall(CallExpr* call)
 
     // Now compute the target type
     Type* t = NULL;
-    if (isDecoratorManaged(d)) {
+    if (isDecoratorManaged(d) && !isDecoratorManaged(valueD)) {
+      t = targetType;
+    } else if (isDecoratorManaged(d)) {
       AggregateType* manager = getManagedPtrManagerType(valueType);
       t = computeDecoratedManagedType(at, d, manager, call);
     } else {

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1373,7 +1373,7 @@ module ChapelBase {
 
   // this version handles downcast to non-nil borrowed
   inline proc _cast(type t:borrowed!, x:borrowed?) throws
-    where isSubtype(t,_to_nonnil(x.type)) && (_to_nonnil(x.type) != t)
+    where isProperSubtype(t,_to_nonnil(x.type))
   {
     if x == nil {
       throw new owned NilClassError();
@@ -1388,7 +1388,7 @@ module ChapelBase {
 
   // this version handles downcast to nilable borrowed
   inline proc _cast(type t:borrowed?, x:borrowed?)
-    where isSubtype(t,x.type) && (x.type != t)
+    where isProperSubtype(t,x.type)
   {
     if x == nil {
       return nil;

--- a/modules/internal/OwnedObject.chpl
+++ b/modules/internal/OwnedObject.chpl
@@ -478,34 +478,47 @@ module OwnedObject {
   }
 
   // this version handles downcast to non-nil owned
-  // TODO: Should this clear out `x` if it is not a subclass?
-  inline proc _cast(type t:owned!, in x:owned?) throws
+  inline proc _cast(type t:owned!, ref x:owned?) throws
     where isProperSubtype(t.chpl_t,_to_nonnil(x.chpl_t))
   {
     if x.chpl_p == nil {
       throw new owned NilClassError();
     }
+    // the following line can throw ClassCastError
+    var castPtr = try x.chpl_p:_to_nonnil(_to_unmanaged(t.chpl_t));
+    x.chpl_p = nil;
+    return new _owned(castPtr);
+  }
+  inline proc _cast(type t:owned!, ref x:owned!) throws
+    where isProperSubtype(t.chpl_t,x.chpl_t)
+  {
+    // the following line can throw ClassCastError
     var castPtr = try x.chpl_p:_to_nonnil(_to_unmanaged(t.chpl_t));
     x.chpl_p = nil;
     return new _owned(castPtr);
   }
 
+
   // this version handles downcast to nilable owned
-  // TODO: Should this clear out `x` if it is not a subclass?
-  inline proc _cast(type t:owned?, in x:owned?)
+  inline proc _cast(type t:owned?, ref x:owned?)
     where isProperSubtype(t.chpl_t,x.chpl_t)
   {
+    // this cast returns nil if the dynamic type is not compatible
     var castPtr = x.chpl_p:_to_nilable(_to_unmanaged(t.chpl_t));
-    x.chpl_p = nil;
+    if castPtr != nil {
+      x.chpl_p = nil;
+    }
     return new _owned(castPtr);
   }
   // this version handles downcast to nilable owned
-  // TODO: Should this clear out `x` if it is not a subclass?
-  inline proc _cast(type t:owned?, in x:owned!)
+  inline proc _cast(type t:owned?, ref x:owned!)
     where isProperSubtype(_to_nonnil(t.chpl_t),x.chpl_t)
   {
+    // this cast returns nil if the dynamic type is not compatible
     var castPtr = x.chpl_p:_to_nilable(_to_unmanaged(t.chpl_t));
-    x.chpl_p = nil;
+    if castPtr != nil {
+      x.chpl_p = nil;
+    }
     return new _owned(castPtr);
   }
 

--- a/modules/internal/OwnedObject.chpl
+++ b/modules/internal/OwnedObject.chpl
@@ -477,6 +477,41 @@ module OwnedObject {
     return new _owned(castPtr!);
   }
 
+  // this version handles downcast to non-nil owned
+  // TODO: Should this clear out `x` if it is not a subclass?
+  inline proc _cast(type t:owned!, in x:owned?) throws
+    where isProperSubtype(t.chpl_t,_to_nonnil(x.chpl_t))
+  {
+    if x.chpl_p == nil {
+      throw new owned NilClassError();
+    }
+    var castPtr = try x.chpl_p:_to_nonnil(_to_unmanaged(t.chpl_t));
+    x.chpl_p = nil;
+    return new _owned(castPtr);
+  }
+
+  // this version handles downcast to nilable owned
+  // TODO: Should this clear out `x` if it is not a subclass?
+  inline proc _cast(type t:owned?, in x:owned?)
+    where isProperSubtype(t.chpl_t,x.chpl_t)
+  {
+    var castPtr = x.chpl_p:_to_nilable(_to_unmanaged(t.chpl_t));
+    x.chpl_p = nil;
+    return new _owned(castPtr);
+  }
+  // this version handles downcast to nilable owned
+  // TODO: Should this clear out `x` if it is not a subclass?
+  inline proc _cast(type t:owned?, in x:owned!)
+    where isProperSubtype(_to_nonnil(t.chpl_t),x.chpl_t)
+  {
+    var castPtr = x.chpl_p:_to_nilable(_to_unmanaged(t.chpl_t));
+    x.chpl_p = nil;
+    return new _owned(castPtr);
+  }
+
+
+
+
   // cast from nil to owned
   pragma "no doc"
   inline proc _cast(type t:_owned, pragma "nil from arg" x:_nilType) {

--- a/modules/internal/SharedObject.chpl
+++ b/modules/internal/SharedObject.chpl
@@ -250,11 +250,23 @@ module SharedObject {
       src.chpl_pn = nil;
     }
 
+    /* Private initializer for casts. This one increments the reference
+       count if the stored pointer is not nil. */
     pragma "no doc"
     proc init(_private: bool, type t, p, pn) {
+      var ptr = p:_to_nilable(_to_unmanaged(t));
+      var count = pn;
+      if ptr != nil {
+        // increment the reference count
+        count!.retain();
+      } else {
+        // don't store a count for the nil pointer
+        count = nil;
+      }
+
       this.chpl_t = t;
-      this.chpl_p = p:_to_nilable(_to_unmanaged(t));
-      this.chpl_pn = pn;
+      this.chpl_p = ptr;
+      this.chpl_pn = count;
     }
 
 
@@ -461,28 +473,41 @@ module SharedObject {
   }
 
   // this version handles downcast to non-nil shared
-  inline proc _cast(type t:shared!, in x:shared?) throws
+  inline proc _cast(type t:shared!, const ref x:shared?) throws
     where isProperSubtype(t.chpl_t,_to_nonnil(x.chpl_t))
   {
     if x.chpl_p == nil {
       throw new owned NilClassError();
     }
+    // the following line can throw ClassCastError
     var p = try x.chpl_p:_to_nonnil(_to_unmanaged(t.chpl_t));
-    var pn = x.chpl_pn;
-    x.chpl_p = nil;
-    x.chpl_pn = nil;
-    return new _shared(true, _to_borrowed(p.type), p, pn);
-  }
 
-  // this version handles downcast to nilable shared
-  inline proc _cast(type t:shared?, in x:shared?)
+    return new _shared(true, _to_borrowed(p.type), p, x.chpl_pn);
+  }
+  inline proc _cast(type t:shared!, const ref x:shared!) throws
     where isProperSubtype(t.chpl_t,x.chpl_t)
   {
+    // the following line can throw ClassCastError
+    var p = try x.chpl_p:_to_nonnil(_to_unmanaged(t.chpl_t));
+
+    return new _shared(true, _to_borrowed(p.type), p, x.chpl_pn);
+  }
+
+
+  // this version handles downcast to nilable shared
+  inline proc _cast(type t:shared?, const ref x:shared?)
+    where isProperSubtype(t.chpl_t,x.chpl_t)
+  {
+    // this cast returns nil if the dynamic type is not compatible
     var p = x.chpl_p:_to_nilable(_to_unmanaged(t.chpl_t));
-    var pn = x.chpl_pn;
-    x.chpl_p = nil;
-    x.chpl_pn = nil;
-    return new _shared(true, _to_borrowed(p.type), p, pn);
+    return new _shared(true, _to_borrowed(p.type), p, x.chpl_pn);
+  }
+  inline proc _cast(type t:shared?, const ref x:shared!)
+    where isProperSubtype(t.chpl_t,_to_nilable(x.chpl_t))
+  {
+    // this cast returns nil if the dynamic type is not compatible
+    var p = x.chpl_p:_to_nilable(_to_unmanaged(t.chpl_t));
+    return new _shared(true, _to_borrowed(p.type), p, x.chpl_pn);
   }
 
   // cast from nil to shared

--- a/test/classes/nilability/nilability-downcasting-owned-shared.chpl
+++ b/test/classes/nilability/nilability-downcasting-owned-shared.chpl
@@ -27,6 +27,7 @@ module test {
         writeln("co:borrowed Child");
         var x = co:borrowed Child;
         writeln(x.type:string, " ", x);
+        assert(co != nil);
       } catch e {
         writeln(e);
         halt("fail");
@@ -36,6 +37,7 @@ module test {
         writeln("coq:borrowed Child");
         var x = coq:borrowed Child;
         writeln(x.type:string, " ", x);
+        assert(coq != nil);
       } catch e {
         writeln(e);
         halt("fail");
@@ -45,6 +47,7 @@ module test {
         writeln("cs:borrowed Child");
         var x = cs:borrowed Child;
         writeln(x.type:string, " ", x);
+        assert(cs != nil);
       } catch e {
         writeln(e);
         halt("fail");
@@ -66,6 +69,7 @@ module test {
         halt("fail");
       } catch e {
         writeln(e);
+        assert(po != nil);
       }
       // from poq
       try {
@@ -75,6 +79,7 @@ module test {
         halt("fail");
       } catch e {
         writeln(e);
+        assert(poq != nil);
       }
       // from ps
       try {
@@ -84,6 +89,7 @@ module test {
         halt("fail");
       } catch e {
         writeln(e);
+        assert(ps != nil);
       }
       // from psq
       try {
@@ -93,6 +99,7 @@ module test {
         halt("fail");
       } catch e {
         writeln(e);
+        assert(psq != nil);
       }
       // from noq
       try {
@@ -125,6 +132,7 @@ module test {
         var x = co:borrowed Child?;
         writeln(x.type:string, " ", x);
         assert(x != nil);
+        assert(co != nil);
       }
       // from coq
       {
@@ -132,6 +140,7 @@ module test {
         var x = coq:borrowed Child?;
         writeln(x.type:string, " ", x);
         assert(x != nil);
+        assert(coq != nil);
       }
       // from cs
       {
@@ -139,6 +148,7 @@ module test {
         var x = cs:borrowed Child?;
         writeln(x.type:string, " ", x);
         assert(x != nil);
+        assert(cs != nil);
       }
       // from csq
       {
@@ -146,6 +156,7 @@ module test {
         var x = csq:borrowed Child?;
         writeln(x.type:string, " ", x);
         assert(x != nil);
+        assert(csq != nil);
       }
       // from po
       {
@@ -153,6 +164,7 @@ module test {
         var x = po:borrowed Child?;
         writeln(x.type:string, " ", x);
         assert(x == nil);
+        assert(po != nil);
       }
       // from poq
       {
@@ -160,6 +172,7 @@ module test {
         var x = poq:borrowed Child?;
         writeln(x.type:string, " ", x);
         assert(x == nil);
+        assert(poq != nil);
       }
       // from ps
       {
@@ -167,6 +180,7 @@ module test {
         var x = ps:borrowed Child?;
         writeln(x.type:string, " ", x);
         assert(x == nil);
+        assert(ps != nil);
       }
       // from psq
       {
@@ -174,6 +188,7 @@ module test {
         var x = psq:borrowed Child?;
         writeln(x.type:string, " ", x);
         assert(x == nil);
+        assert(psq != nil);
       }
       // from noq
       {
@@ -191,9 +206,6 @@ module test {
       }
     }
 
-    // the below are not currently supported
-
-    /*
     // casting to owned Child
     {
       writeln();
@@ -227,6 +239,7 @@ module test {
         halt("fail");
       } catch e {
         writeln(e);
+        po = new owned Parent(3);
       }
       // from poq
       try {
@@ -236,6 +249,7 @@ module test {
         halt("fail");
       } catch e {
         writeln(e);
+        poq = new owned Parent(3);
       }
       // from noq
       try {
@@ -268,7 +282,7 @@ module test {
         var x = coq:owned Child?;
         writeln(x.type:string, " ", x);
         assert(x != nil);
-        co = new owned Child(1,2); // since we did ownership transfer
+        coq = new owned Child(1,2); // since we did ownership transfer
       }
       // from po
       {
@@ -276,6 +290,7 @@ module test {
         var x = po:owned Child?;
         writeln(x.type:string, " ", x);
         assert(x == nil);
+        po = new owned Parent(3);
       }
       // from poq
       {
@@ -283,6 +298,7 @@ module test {
         var x = poq:owned Child?;
         writeln(x.type:string, " ", x);
         assert(x == nil);
+        poq = new owned Parent(3);
       }
       // from noq
       {
@@ -303,6 +319,7 @@ module test {
         writeln("cs:shared Child");
         var x = cs:shared Child;
         writeln(x.type:string, " ", x);
+        assert(cs != nil);
       } catch e {
         writeln(e);
         halt("fail");
@@ -312,6 +329,7 @@ module test {
         writeln("csq:shared Child");
         var x = csq:shared Child;
         writeln(x.type:string, " ", x);
+        assert(csq != nil);
       } catch e {
         writeln(e);
         halt("fail");
@@ -324,6 +342,7 @@ module test {
         halt("fail");
       } catch e {
         writeln(e);
+        assert(ps != nil);
       }
       // from psq
       try {
@@ -333,6 +352,7 @@ module test {
         halt("fail");
       } catch e {
         writeln(e);
+        assert(psq != nil);
       }
       // from nsq
       try {
@@ -370,14 +390,14 @@ module test {
         writeln("ps:shared Child?");
         var x = ps:shared Child?;
         writeln(x.type:string, " ", x);
-        assert(x != nil);
+        assert(x == nil);
       }
       // from psq
       {
         writeln("psq:shared Child?");
         var x = psq:shared Child?;
         writeln(x.type:string, " ", x);
-        assert(x != nil);
+        assert(x == nil);
       }
       // from nsq
       {
@@ -387,7 +407,5 @@ module test {
         assert(x == nil);
       }
     }
-    */
- 
   }
 }

--- a/test/classes/nilability/nilability-downcasting-owned-shared.chpl
+++ b/test/classes/nilability/nilability-downcasting-owned-shared.chpl
@@ -239,6 +239,7 @@ module test {
         halt("fail");
       } catch e {
         writeln(e);
+        assert(po != nil); // should not transfer if cast failed
         po = new owned Parent(3);
       }
       // from poq
@@ -249,6 +250,7 @@ module test {
         halt("fail");
       } catch e {
         writeln(e);
+        assert(poq != nil); // should not transfer if cast failed
         poq = new owned Parent(3);
       }
       // from noq
@@ -290,6 +292,7 @@ module test {
         var x = po:owned Child?;
         writeln(x.type:string, " ", x);
         assert(x == nil);
+        assert(po != nil); // should not transfer if cast failed
         po = new owned Parent(3);
       }
       // from poq
@@ -298,6 +301,7 @@ module test {
         var x = poq:owned Child?;
         writeln(x.type:string, " ", x);
         assert(x == nil);
+        assert(poq != nil); // should not transfer if cast failed
         poq = new owned Parent(3);
       }
       // from noq
@@ -391,6 +395,7 @@ module test {
         var x = ps:shared Child?;
         writeln(x.type:string, " ", x);
         assert(x == nil);
+        assert(ps != nil);
       }
       // from psq
       {
@@ -398,6 +403,7 @@ module test {
         var x = psq:shared Child?;
         writeln(x.type:string, " ", x);
         assert(x == nil);
+        assert(psq != nil);
       }
       // from nsq
       {

--- a/test/classes/nilability/nilability-downcasting-owned-shared.good
+++ b/test/classes/nilability/nilability-downcasting-owned-shared.good
@@ -42,3 +42,51 @@ noq:borrowed Child?
 borrowed Child? nil
 nsq:borrowed Child?
 borrowed Child? nil
+
+casts to owned Child
+co:owned Child
+owned Child {p = 1, c = 2}
+coq:owned Child
+owned Child {p = 1, c = 2}
+po:owned Child
+ClassCastError: cannot cast class to type - runtime types not compatible
+poq:owned Child
+ClassCastError: cannot cast class to type - runtime types not compatible
+noq:owned Child
+NilClassError: cannot convert nil class to non nilable type
+
+casts to owned Child?
+co:owned Child?
+owned Child? {p = 1, c = 2}
+coq:owned Child?
+owned Child? {p = 1, c = 2}
+po:owned Child?
+owned Child? nil
+poq:owned Child?
+owned Child? nil
+noq:owned Child?
+owned Child? nil
+
+casts to shared Child
+cs:shared Child
+shared Child {p = 1, c = 2}
+csq:shared Child
+shared Child {p = 1, c = 2}
+ps:shared Child
+ClassCastError: cannot cast class to type - runtime types not compatible
+psq:shared Child
+ClassCastError: cannot cast class to type - runtime types not compatible
+nsq:shared Child
+NilClassError: cannot convert nil class to non nilable type
+
+casts to shared Child?
+cs:shared Child?
+shared Child? {p = 1, c = 2}
+csq:shared Child?
+shared Child? {p = 1, c = 2}
+ps:shared Child?
+shared Child? nil
+psq:shared Child?
+shared Child? nil
+nsq:shared Child?
+shared Child? nil


### PR DESCRIPTION
Resolves #13539
Resolves #12887

* Makes a minor change in adjustClassCastCall to avoid updating the type 
  if it's a cast from non-managed to managed. This should generate an
  error.
* Adds casts overloads for owned and shared downcasting. For non-nilable
  types, these throw ClassCastError, continuing #13022.
* Simplifies downcasting in ChapelBase by using isProperSubtype.
 
- [x] full local testing

Reviewed by @vasslitvinov - thanks!