### PR TITLE
Add functions for getting file information to Reflection

### DIFF
--- a/compiler/include/flags_list.h
+++ b/compiler/include/flags_list.h
@@ -149,6 +149,12 @@ symbolFlag( FLAG_GENERATE_SIGNATURE, ypr, "generate signature", "compiler should
 symbolFlag( FLAG_GENERIC , npr, "generic" , "generic types, functions and arguments" )
 symbolFlag( FLAG_DELAY_GENERIC_EXPANSION, npr, "delay instantiation", "generics instances whose instantiation  will be determined shortly")
 symbolFlag( FLAG_GEN_MAIN_FUNC, npr, "generated main", "compiler generated main function")
+
+symbolFlag( FLAG_GET_LINE_NUMBER, ypr, "get line number", "replace calls to this function with the line number of the call" )
+symbolFlag( FLAG_GET_FILE_NAME, ypr, "get file name", "replace calls to this function with the name of the file the call is in" )
+symbolFlag( FLAG_GET_FUNCTION_NAME, ypr, "get function name", "replace calls to this function with the name of the function that called it" )
+symbolFlag( FLAG_GET_MODULE_NAME, ypr, "get module name", "replace calls to this function with the name of the module the call was in" )
+
 symbolFlag( FLAG_GLOBAL_TYPE_SYMBOL, npr, "global type symbol", "is accessible through a global type variable")
 symbolFlag( FLAG_HAS_RUNTIME_TYPE , ypr, "has runtime type" , "type that has an associated runtime type" )
 symbolFlag( FLAG_RVV, npr, "RVV", "variable is the return value variable" )

--- a/compiler/resolution/postFold.cpp
+++ b/compiler/resolution/postFold.cpp
@@ -178,6 +178,20 @@ static Expr* postFoldNormal(CallExpr* call) {
     }
   }
 
+  if (fn->hasFlag(FLAG_GET_LINE_NUMBER)) {
+    retval = new SymExpr(new_IntSymbol(call->linenum()));
+    call->replace(retval);
+  } else if (fn->hasFlag(FLAG_GET_FILE_NAME)) {
+    retval = new SymExpr(new_StringSymbol(call->fname()));
+    call->replace(retval);
+  } else if (fn->hasFlag(FLAG_GET_FUNCTION_NAME)) {
+    retval = new SymExpr(new_StringSymbol(call->getFunction()->name));
+    call->replace(retval);
+  } else if (fn->hasFlag(FLAG_GET_MODULE_NAME)) {
+    retval = new SymExpr(new_StringSymbol(call->getModule()->name));
+    call->replace(retval);
+  }
+
   return retval;
 }
 

--- a/modules/standard/Reflection.chpl
+++ b/modules/standard/Reflection.chpl
@@ -229,4 +229,20 @@ proc canResolveTypeMethod(type t, param fname : string, args ...) param : bool
 
 // TODO -- do we need a different version of can resolve with ref this?
 
+/* Returns the line number of the call to this function. */
+pragma "get line number"
+proc lineNumber param : int { }
+
+/* Returns the file name this function was called from. */
+pragma "get file name"
+proc fileName param : string { }
+
+/* Returns the name of the function this function was called from. */
+pragma "get function name"
+proc functionName param : string { }
+
+/* Returns the name of the module this function was called from. */
+pragma "get module name"
+proc moduleName param : string { }
+
 } // module Reflection

--- a/test/library/standard/Reflection/fileInfo.chpl
+++ b/test/library/standard/Reflection/fileInfo.chpl
@@ -1,0 +1,8 @@
+//use Reflection;
+
+module M {
+  proc main {
+    writeln(Reflection.fileName, ":", Reflection.lineNumber, ": ",
+            Reflection.moduleName, ".", Reflection.functionName);
+  }
+}

--- a/test/library/standard/Reflection/fileInfo.good
+++ b/test/library/standard/Reflection/fileInfo.good
@@ -1,0 +1,1 @@
+fileInfo.chpl:5: M.main

--- a/test/library/standard/Reflection/fileInfoInlineFunction.chpl
+++ b/test/library/standard/Reflection/fileInfoInlineFunction.chpl
@@ -1,0 +1,10 @@
+inline proc foo() {
+  writeln(Reflection.fileName, ":", Reflection.lineNumber, " ",
+          Reflection.moduleName, ".", Reflection.functionName);
+}
+
+proc main {
+  writeln(Reflection.fileName, ":", Reflection.lineNumber, " ",
+          Reflection.moduleName, ".", Reflection.functionName);
+  foo();
+}

--- a/test/library/standard/Reflection/fileInfoInlineFunction.good
+++ b/test/library/standard/Reflection/fileInfoInlineFunction.good
@@ -1,0 +1,2 @@
+fileInfoInlineFunction.chpl:7 fileInfoInlineFunction.main
+fileInfoInlineFunction.chpl:2 fileInfoInlineFunction.foo

--- a/test/library/standard/Reflection/fileInfoNestedFunction.chpl
+++ b/test/library/standard/Reflection/fileInfoNestedFunction.chpl
@@ -1,0 +1,16 @@
+proc main {
+  proc foo() {
+    proc bar() {
+      writeln(Reflection.fileName, ":", Reflection.lineNumber, " ",
+              Reflection.moduleName, ".", Reflection.functionName);
+    }
+
+    writeln(Reflection.fileName, ":", Reflection.lineNumber, " ",
+            Reflection.moduleName, ".", Reflection.functionName);
+    bar();
+  }
+
+  writeln(Reflection.fileName, ":", Reflection.lineNumber, " ",
+          Reflection.moduleName, ".", Reflection.functionName);
+  foo();
+}

--- a/test/library/standard/Reflection/fileInfoNestedFunction.good
+++ b/test/library/standard/Reflection/fileInfoNestedFunction.good
@@ -1,0 +1,3 @@
+fileInfoNestedFunction.chpl:13 fileInfoNestedFunction.main
+fileInfoNestedFunction.chpl:8 fileInfoNestedFunction.foo
+fileInfoNestedFunction.chpl:4 fileInfoNestedFunction.bar

--- a/test/library/standard/Reflection/fileInfoNestedModule.chpl
+++ b/test/library/standard/Reflection/fileInfoNestedModule.chpl
@@ -1,0 +1,18 @@
+module Outer {
+  proc foo() {
+    writeln(Reflection.fileName, ":", Reflection.lineNumber, " ",
+            Reflection.moduleName, ".", Reflection.functionName);
+  }
+  module Inner {
+    proc main {
+      writeln(Reflection.fileName, ":", Reflection.lineNumber, " ",
+              Reflection.moduleName, ".", Reflection.functionName);
+      foo();
+      bar();
+    }
+    proc bar() {
+      writeln(Reflection.fileName, ":", Reflection.lineNumber, " ",
+              Reflection.moduleName, ".", Reflection.functionName);
+    }
+  }
+}

--- a/test/library/standard/Reflection/fileInfoNestedModule.good
+++ b/test/library/standard/Reflection/fileInfoNestedModule.good
@@ -1,0 +1,3 @@
+fileInfoNestedModule.chpl:8 Inner.main
+fileInfoNestedModule.chpl:3 Outer.foo
+fileInfoNestedModule.chpl:14 Inner.bar


### PR DESCRIPTION
Add functions `lineNumber`, `fileName`, `functionName` and `moduleName` to
the `Reflection` module. Calls to them are replaced by the appropriate
information in resolution's postFoldNormal function.

Add a test that calls each of the functions.