### PR TITLE
Fix two nilability/delete-free bugs

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -1156,9 +1156,9 @@ bool canInstantiateDecorators(ClassTypeDecorator actual,
              actual == CLASS_TYPE_MANAGED_NONNIL;
     case CLASS_TYPE_GENERIC_NILABLE:
       return actual == CLASS_TYPE_GENERIC_NILABLE ||
-             actual == CLASS_TYPE_BORROWED_NONNIL ||
-             actual == CLASS_TYPE_UNMANAGED_NONNIL ||
-             actual == CLASS_TYPE_MANAGED_NONNIL;
+             actual == CLASS_TYPE_BORROWED_NILABLE||
+             actual == CLASS_TYPE_UNMANAGED_NILABLE||
+             actual == CLASS_TYPE_MANAGED_NILABLE;
 
     // no default for compiler warnings to know when to update it
   }

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -2497,10 +2497,17 @@ static void adjustClassCastCall(CallExpr* call)
     // Now compute the target type
     Type* t = NULL;
     if (isDecoratorManaged(d) && !isDecoratorManaged(valueD)) {
+      // Don't change it, expecting an error
       t = targetType;
     } else if (isDecoratorManaged(d)) {
       AggregateType* manager = getManagedPtrManagerType(valueType);
-      t = computeDecoratedManagedType(at, d, manager, call);
+      if (isManagedPtrType(targetType) &&
+          manager != getManagedPtrManagerType(targetType)) {
+        // Don't change it, expecting an error
+        t = targetType;
+      } else {
+        t = computeDecoratedManagedType(at, d, manager, call);
+      }
     } else {
       t = at->getDecoratedClass(d);
     }

--- a/test/classes/delete-free/bug-375.chpl
+++ b/test/classes/delete-free/bug-375.chpl
@@ -1,0 +1,9 @@
+class Parent { }
+class Child : Parent { }
+
+proc main() {
+  var o = new Child(); // owned Child
+  var p = o:shared Parent; // expecting error here
+  var q = p: shared Child;
+  writeln(q.type:string);
+}

--- a/test/classes/delete-free/bug-375.good
+++ b/test/classes/delete-free/bug-375.good
@@ -1,0 +1,2 @@
+bug-375.chpl:4: In function 'main':
+bug-375.chpl:6: error: illegal cast from owned Child to shared Parent

--- a/test/classes/nilability/bug-13615.chpl
+++ b/test/classes/nilability/bug-13615.chpl
@@ -1,0 +1,11 @@
+class MyClass {	var x: int; }
+
+proc foo(in arg: MyClass?) {
+  compilerWarning("arg:", isNilableClass(arg):string);
+}
+
+var o1: owned MyClass?;
+foo(o1);
+
+var o2 = new owned MyClass();
+foo(o2);

--- a/test/classes/nilability/bug-13615.good
+++ b/test/classes/nilability/bug-13615.good
@@ -1,0 +1,2 @@
+bug-13615.chpl:8: warning: arg:true
+bug-13615.chpl:11: warning: arg:true


### PR DESCRIPTION
Resolves https://github.com/Cray/chapel-private/issues/375
Resolves #13615 

Fixes two issues with nilable/ownership types.

Note that while this PR makes a better error for casting between shared
and owned, we might consider supporting that (it would just transfer
ownership out of the owned and into the shared). If we did, we'd probably
want to support up-casting and down-casting.

Reviewed by @vasslitvinov - thanks!

- [x] full local testing