### PR TITLE
Add an error message for ranges over enums with just one value

### DIFF
--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -2524,7 +2524,19 @@ proc _cast(type t, r: range(?)) where isRangeType(t) {
 
   pragma "no doc"
   proc chpl__idxTypeToIntIdxType(type idxType) type {
-    if isEnumType(idxType) || isBoolType(idxType) then return int; else return idxType;
+    if isBoolType(idxType) {
+      return int;
+    } else if isEnumType(idxType) {
+      // Most range/array code currently relies on being able to store
+      // empty ranges like 1..0.  If an enum only defines a single
+      // symbol, we can't create such a range, so print the following
+      // error message to avoid going off the rails.
+      if idxType.size < 2 then
+        compilerError("ranges are not currently supported for enums with fewer than two values");
+      return int;
+    } else {
+      return idxType;
+    }
   }
 
   // convenience method for converting integers to index types in

--- a/test/types/range/enum/singleValEnum.chpl
+++ b/test/types/range/enum/singleValEnum.chpl
@@ -1,0 +1,2 @@
+enum E {A};
+const r: range(idxType=E);

--- a/test/types/range/enum/singleValEnum.good
+++ b/test/types/range/enum/singleValEnum.good
@@ -1,0 +1,1 @@
+singleValEnum.chpl:2: error: ranges are not currently supported for enums with fewer than two values

--- a/test/types/range/enum/singleValEnum2.chpl
+++ b/test/types/range/enum/singleValEnum2.chpl
@@ -1,0 +1,2 @@
+enum E {A};
+var A: [E.A..E.A] real;

--- a/test/types/range/enum/singleValEnum2.good
+++ b/test/types/range/enum/singleValEnum2.good
@@ -1,0 +1,1 @@
+singleValEnum2.chpl:2: error: ranges are not currently supported for enums with fewer than two values


### PR DESCRIPTION
At present, the range, domain, and array code relies on being able to
create empty ranges of the form 1..0 or an equivalent.  For enums,
this is done by creating a range that goes from the second enum to the
first enum.  Issue #13650 points out that this was causing a confusing
execution time error message in practice for enums that only defined a
single symbol.  Here, I'm inserting a compile-time error message to
more proactively handle such cases as a placeholder until we either
determine what to do about them (e.g., in issue #5165, Louis
proposes that we could have an `empty range` bit rather than, or in
addition to, relying on low > high values.  We could also decide more
formally not to support ranges over such enums.