### PR TITLE
Revert a lexer change

### DIFF
--- a/compiler/parser/chapel.lex
+++ b/compiler/parser/chapel.lex
@@ -379,9 +379,7 @@ static int processToken(yyscan_t scanner, int t) {
 
   if (captureTokens) {
     if (t == TASSIGN ||
-        t == TDOTDOTDOT ||
-        t == TPARAM ||
-        t == TTYPE) {
+        t == TDOTDOTDOT) {
       captureString.push_back(' ');
     }
 


### PR DESCRIPTION
Reverts a lexer change that causes faulty parser to be rebuilt.

This produces a parser identical to what we have on master right now.
