### PR TITLE
Fix memory management in intents-classes2.chpl

### DIFF
--- a/test/functions/bradc/intents/intents-classes2.chpl
+++ b/test/functions/bradc/intents/intents-classes2.chpl
@@ -63,10 +63,11 @@ proc main() {
   delete a;
 
   {
-    var aa: unmanaged pair? = a;
+    var aa: unmanaged pair?;
     callout(aa);
     writeln("back at callsite, a is: ", aa.a, " ", aa.b);
     writeln();
+    a = aa!;
   }
 
   callinout(a);


### PR DESCRIPTION
Avoid referencing an already-deleted object.
Delete a no-longer-used object.

Trivial.