### PR TITLE
Close memory leaks in bytes type and tests

### DIFF
--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -1015,6 +1015,7 @@ module Bytes {
 
         if cp == 0xfffd {  //decoder returns the replacament character
           if errors == DecodePolicy.Strict {
+            chpl_here_free(c_buf);
             throw new owned DecodeError();
           }
           else if errors == DecodePolicy.Ignore {

--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -187,6 +187,16 @@ module Bytes {
       }
     }
 
+    pragma "no doc"
+    proc ref deinit() {
+      if isowned && this.buff != nil {
+        on __primitive("chpl_on_locale_num",
+                       chpl_buildLocaleID(this.locale_id, c_sublocid_any)) {
+          chpl_here_free(this.buff);
+        }
+      }
+    }
+
 
     // this is implemented only for debugging purposes. Ideally writeThis should
     // just halt when called on bytes record

--- a/test/types/bytes/basic.chpl
+++ b/test/types/bytes/basic.chpl
@@ -180,3 +180,4 @@ writeln("word\rword":_bytes); // should print "word"
 writeln("End of writeln tests");
 writeln();
 
+c_free(c_char_arr);


### PR DESCRIPTION
This PR does the following to clean up memory associated with bytes type/tests

- Add `_bytes.deinit` to clean up the memory alloc'd with `chpl_here_alloc`
- Free memory before throwing an error
- Free a c_malloc'd memory in test.

Test status: `test/types/bytes` runs cleanly without any leak.