### PR TITLE
Adjust slurm-srun to request access to all memory on each node

### DIFF
--- a/runtime/src/launch/slurm-srun/launch-slurm-srun.c
+++ b/runtime/src/launch/slurm-srun/launch-slurm-srun.c
@@ -257,6 +257,9 @@ static char* chpl_launch_create_command(int argc, char* argv[],
     if (nodeAccessStr != NULL)
       fprintf(slurmFile, "#SBATCH --%s\n", nodeAccessStr);
 
+    // request access to all memory
+    fprintf(slurmFile, "#SBATCH --mem=0\n");
+
     // Set the walltime if it was specified 
     if (walltime) { 
       fprintf(slurmFile, "#SBATCH --time=%s\n", walltime);
@@ -371,6 +374,9 @@ static char* chpl_launch_create_command(int argc, char* argv[],
     // request specified node access
     if (nodeAccessStr != NULL)
       len += sprintf(iCom+len, "--%s ", nodeAccessStr);
+
+    // request access to all memory
+    len += sprintf(iCom+len, "--mem=0 ");
 
     // kill the job if any program instance halts with non-zero exit status
     len += sprintf(iCom+len, "--kill-on-bad-exit ");


### PR DESCRIPTION
Some slurm sites set a DefMemPerNode/DefMemPerCPU that prevents access
to all memory on a machine, and that doesn't seem to be impacted by us
throwing `--exclusive`. Add `--mem=0` to get access to to all memory on
each node.

Resolves https://github.com/Cray/chapel-private/issues/356