### PR TITLE
Update locale models to avoid relying on string+value overloads

### DIFF
--- a/modules/internal/localeModels/apu/LocaleModel.chpl
+++ b/modules/internal/localeModels/apu/LocaleModel.chpl
@@ -65,7 +65,7 @@ module LocaleModel {
     proc init(_sid, _parent) {
       super.init(_parent);
       sid = _sid;
-      name = _parent.chpl_name() + "-CPU" + sid;
+      name = _parent.chpl_name() + "-CPU" + sid:string;
     }
 
     override proc writeThis(f) {
@@ -109,7 +109,7 @@ module LocaleModel {
     proc init(_sid, _parent) {
       super.init(_parent);
       sid = _sid;
-      name = _parent.chpl_name() + "-GPU" + sid;
+      name = _parent.chpl_name() + "-GPU" + sid:string;
     }
 
     override proc writeThis(f) {

--- a/modules/internal/localeModels/knl/LocaleModel.chpl
+++ b/modules/internal/localeModels/knl/LocaleModel.chpl
@@ -219,7 +219,7 @@ module LocaleModel {
         kindstr = "DDR";
       else if kind == memoryKindMCDRAM() then
         kindstr = "MCDRAM";
-      mlName = kindstr+whichNuma;
+      mlName = kindstr+whichNuma:string;
     }
 
     override proc writeThis(f) {
@@ -277,7 +277,7 @@ module LocaleModel {
 
       sid = packSublocID(numSublocales, _sid, defaultMemoryKind())
               : chpl_sublocID_t;
-      ndName = "ND"+_sid;
+      ndName = "ND"+_sid:string;
 
       this.complete();
 

--- a/modules/internal/localeModels/numa/LocaleModel.chpl
+++ b/modules/internal/localeModels/numa/LocaleModel.chpl
@@ -69,7 +69,7 @@ module LocaleModel {
     proc init(_sid, _parent) {
       super.init(_parent);
       sid = _sid;
-      ndName = "ND"+sid;
+      ndName = "ND"+sid:string;
     }
 
     override proc writeThis(f) {


### PR DESCRIPTION
This updates our non-flat locale model code to avoid relying on string + value overloads which were deprecated yesterday in PR #13658.
