### PR TITLE
Drop llvm nightly testing from nodepara 8 to 2

### DIFF
--- a/util/cron/test-llvm.bash
+++ b/util/cron/test-llvm.bash
@@ -13,8 +13,7 @@ source $CWD/common-localnode-paratest.bash
 # common-llvm restricts us to extern/ferguson, but we want all the tests
 unset CHPL_NIGHTLY_TEST_DIRS
 
-# paratest with 8 nodes on localhost
-nightly_args="${nightly_args} $(set +x ; get_nightly_paratest_args 8) -asserts"
+nightly_args="${nightly_args} $(set +x ; get_nightly_paratest_args) -asserts"
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="llvm"
 


### PR DESCRIPTION
llvm testing used to run on a 16-core machine, and we ran with nodepara
8 to speed up testing (I would guess there were other jobs running on
the same machine so we needed it to finish quickly.) The llvm job was
moved to a much smaller 4-core VM, so nodepara 8 is way too much. Just
drop to nodepara 2, which should be plenty fast and avoid some timeouts
we've been seeing.