### PR TITLE
Retire use of string+value overloads in tests of LAPACK and FFTW

### DIFF
--- a/test/library/packages/LAPACK/TestHelpers.chpl
+++ b/test/library/packages/LAPACK/TestHelpers.chpl
@@ -159,7 +159,7 @@ module TestHelpers {
                                else ( "  " );
                               
         for j in this.columnRange {
-          retstring += ( this[i,j] + ", " );
+          retstring += ( this[i,j]:string + ", " );
         }
         
         retstring += if i == this.rows then ( "]" )

--- a/test/release/examples/primers/FFTWlib.chpl
+++ b/test/release/examples/primers/FFTWlib.chpl
@@ -64,7 +64,7 @@ proc main() {
 proc testAllDims() {
   for param d in 1..3 {
     writeln(d, "D");
-    runtest(d, "arr"+d+"d.dat");
+    runtest(d, "arr"+d:string+"d.dat");
   }
 }
 


### PR DESCRIPTION
This removes uses of string+value overloads in tests of LAPACK and FFTW since they were deprecated in PR #13658.  I missed these when I was doing my testing because they're not tested on our linux cluster.
