### PR TITLE
Fix a new test that I didn't test enough

### DIFF
--- a/test/functions/iterators/multilocale/multilocSerIter-noinline.chpl
+++ b/test/functions/iterators/multilocale/multilocSerIter-noinline.chpl
@@ -1,0 +1,8 @@
+iter foo() {
+  for loc in Locales do
+    on loc do
+      yield here.id;
+}
+
+for f in foo() do
+  writeln("Got ", f, " on locale ", here.id);

--- a/test/functions/iterators/multilocale/multilocSerIter-noinline.compopts
+++ b/test/functions/iterators/multilocale/multilocSerIter-noinline.compopts
@@ -1,0 +1,1 @@
+--no-inline-iterators

--- a/test/functions/iterators/multilocale/multilocSerIter-noinline.good
+++ b/test/functions/iterators/multilocale/multilocSerIter-noinline.good
@@ -1,1 +1,1 @@
-multilocSerIter.chpl:7: error: 'yield' statements within 'on' clauses are not currently supported for iterators that are not inlined (e.g., within zippered loops)
+multilocSerIter-noinline.chpl:7: error: 'yield' statements within 'on' clauses are not currently supported for iterators that are not inlined (e.g., within zippered loops)

--- a/test/functions/iterators/multilocale/multilocSerIter-noinline.skipif
+++ b/test/functions/iterators/multilocale/multilocSerIter-noinline.skipif
@@ -1,0 +1,1 @@
+CHPL_COMM==none

--- a/test/functions/iterators/multilocale/multilocSerIter.compopts
+++ b/test/functions/iterators/multilocale/multilocSerIter.compopts
@@ -1,2 +1,0 @@
-
---no-inline-iterators  # multilocSerIter-noinline.good


### PR DESCRIPTION
Sloppy sloppy sloppy...  In reviewing PR #13595, Elliot asked a
question that caused me to add a new test case, but then I only tested
it for CHPL_COMM=gasnet, not none (though the original PR had been
tested heavily in both configurations).  This fixes it by forking
it from a compopts variation to a separate test and skipping it for comm=none
(it's not so interesting in that case).  Sorry for the mistake.