### PR TITLE
Two resolution fixes

### DIFF
--- a/compiler/resolution/ResolutionCandidate.cpp
+++ b/compiler/resolution/ResolutionCandidate.cpp
@@ -352,30 +352,6 @@ void ResolutionCandidate::computeSubstitutionForDefaultExpr(ArgSymbol* formal,
     }
   }
 
-  /*
-  if (tail == NULL) {
-    // Handle the more complex case that might depend on substitutions
-
-    // We need to resolve formal->defaultExpr with the appropriate
-    // substitutions. At the same time, we don't want to modify
-    // formal->defaultExpr, since this is the generic function symbol before
-    // instantiation. So, make a copy of formal->defaultExpr,
-    // swap it in, do the substitutions and resolve it, and then
-    // put the original back.
-
-    BlockStmt* origDefault = formal->defaultExpr;
-    BlockStmt* defaultCopy = formal->defaultExpr->copy();
-    // Swap the new version in
-    origDefault->replace(defaultCopy);
-    // Update the symbols that refer to previous arguments
-    update_symbols(defaultCopy, &substitutions);
-    // Resolve it
-    resolveBlockStmt(formal->defaultExpr);
-    // Swap the original back in
-    defaultCopy->replace(origDefault);
-    tail = defaultCopy->body.tail;
-  }*/
-
   if (tail != NULL) {
     if (formal->intent == INTENT_PARAM) {
       if (SymExpr* se = toSymExpr(tail)) {

--- a/compiler/resolution/generics.cpp
+++ b/compiler/resolution/generics.cpp
@@ -395,10 +395,13 @@ FnSymbol* instantiateSignature(FnSymbol*  fn,
         newFn->getFormal(2)->type->methods.add(newFn);
       }
 
-      newFn->tagIfGeneric(&subs);
       if (fn->throwsError() == true) {
         newFn->throwsErrorInit();
       }
+
+      // Resolve formal type-exprs before checking if formals are generic
+      resolveSignature(newFn);
+      newFn->tagIfGeneric(&subs);
 
       explainAndCheckInstantiation(newFn, fn);
 

--- a/compiler/resolution/initializerResolution.cpp
+++ b/compiler/resolution/initializerResolution.cpp
@@ -175,7 +175,7 @@ static FnSymbol* buildNewWrapper(FnSymbol* initFn) {
   VarSymbol* result = newTemp();
   Expr* resultExpr = NULL;
   if (isClass(type)) {
-    Type* uct = type->getDecoratedClass(CLASS_TYPE_UNMANAGED);
+    Type* uct = type->getDecoratedClass(CLASS_TYPE_UNMANAGED_NONNIL);
     resultExpr = new CallExpr(PRIM_CAST, uct->symbol, initTemp);
   } else {
     resultExpr = new SymExpr(initTemp);

--- a/test/types/typeFunctions/isSubtype-12130.chpl
+++ b/test/types/typeFunctions/isSubtype-12130.chpl
@@ -5,3 +5,6 @@ class Generic {
 var inst = new borrowed Generic(10);
 writeln(inst.type < Generic);
 writeln(inst.type > Generic);
+
+writeln(inst.type < borrowed Generic);
+writeln(inst.type > borrowed Generic);

--- a/test/types/typeFunctions/isSubtype-12130.good
+++ b/test/types/typeFunctions/isSubtype-12130.good
@@ -1,2 +1,4 @@
 true
+false
 true
+false

--- a/test/types/type_variables/ferguson/generic-type-actual-used-next.chpl
+++ b/test/types/type_variables/ferguson/generic-type-actual-used-next.chpl
@@ -1,0 +1,8 @@
+record GenericRecord { var field; }
+
+proc f(type t, x: t) {
+  writeln(t:string, " ", x.type:string);
+}
+
+var x = new GenericRecord(1);
+f(GenericRecord, x);

--- a/test/types/type_variables/ferguson/generic-type-actual-used-next.good
+++ b/test/types/type_variables/ferguson/generic-type-actual-used-next.good
@@ -1,0 +1,1 @@
+GenericRecord GenericRecord(int(64))


### PR DESCRIPTION
Addresses problems with
```
types/type_variables/ferguson/generic-type-actual-used-next.chpl
test/types/typeFunctions/isSubtype-12130.chpl
```

when compiling with `--no-legacy-nilable-classes`.

The isSubtype test was getting confused by some old logic added in
PR #5424 which used to be specific to initializers but was no longer. This
PR adjusts the check for isGenericInstantiation in doCanDispatch to only
apply for initializers and adjusts the argument names / ordering to be
less confusing.

The second fix is for a pattern such as
``` chapel
record GenericRecord { var field; }
proc f(type t, x: t) { }
var x = new GenericRecord(1);
f(GenericRecord, x);
```

Previous to this PR, the function call would not resolve, because the
type expression was not resolved when tagIfGeneric ran. This PR adjusts
instantiateSignature to call resolveSignature before calling tagIfGeneric
in order to make the version with the generic `GenericRecord` type actual
still be a generic function.

Reviewed by @benharsh - thanks!

- [x] full local --verify testing
