### PR TITLE
Remove string + value overloads in calls to chpl_debug_writeln()

### DIFF
--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -2133,10 +2133,10 @@ proc _cast(type t, r: range(?)) where isRangeType(t) {
                                                   minIndicesPerTask,
                                                   len);
       if debugDataParNuma {
-        chpl_debug_writeln("### numSublocs = ", numSublocs, "\n" +
-                           "### numTasksPerSubloc = ", numSublocTasks, "\n" +
-                           "### ignoreRunning = ", ignoreRunning, "\n" +
-                           "### minIndicesPerTask = ", minIndicesPerTask, "\n" +
+        chpl_debug_writeln("### numSublocs = ", numSublocs, "\n",
+                           "### numTasksPerSubloc = ", numSublocTasks, "\n",
+                           "### ignoreRunning = ", ignoreRunning, "\n",
+                           "### minIndicesPerTask = ", minIndicesPerTask, "\n",
                            "### numChunks = ", numChunks);
       }
 
@@ -2147,8 +2147,8 @@ proc _cast(type t, r: range(?)) where isRangeType(t) {
           local do on here.getChild(chunk) {
             if debugDataParNuma {
               if chunk!=chpl_getSubloc() then
-                chpl_debug_writeln("*** ERROR: ON WRONG SUBLOC (should be "+
-                                   chunk+", on "+chpl_getSubloc()+") ***");
+                chpl_debug_writeln("*** ERROR: ON WRONG SUBLOC (should be ",
+                                   chunk, ", on ", chpl_getSubloc(), ") ***");
             }
             const (lo,hi) = _computeBlock(len, numChunks, chunk, len-1);
             const locRange = lo..hi;
@@ -2165,7 +2165,7 @@ proc _cast(type t, r: range(?)) where isRangeType(t) {
             coforall core in 0..#numTasks {
               const (low, high) = _computeBlock(locLen, numTasks, core, hi, lo, lo);
               if debugDataParNuma {
-                chpl_debug_writeln("### chunk = ", chunk, "  core = ", core, "  " +
+                chpl_debug_writeln("### chunk = ", chunk, "  core = ", core, "  ",
                                    "locRange = ", locRange, "  coreRange = ", low..high);
               }
               yield (low..high,);

--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -303,10 +303,10 @@ module DefaultRectangular {
                            " ranges(", parDim, ").length=", ranges(parDim).length);
       }
       if debugDataPar {
-        chpl_debug_writeln("### numTasksPerLoc = ", numTasks, "\n" +
-                           "### ignoreRunning = ", ignoreRunning, "\n" +
-                           "### minIndicesPerTask = ", minIndicesPerTask, "\n" +
-                           "### numChunks = ", numChunks, " (parDim = ", parDim, ")\n" +
+        chpl_debug_writeln("### numTasksPerLoc = ", numTasks, "\n",
+                           "### ignoreRunning = ", ignoreRunning, "\n",
+                           "### minIndicesPerTask = ", minIndicesPerTask, "\n",
+                           "### numChunks = ", numChunks, " (parDim = ", parDim, ")\n",
                            "### nranges = ", ranges);
       }
       if numChunks <= 1 {
@@ -372,11 +372,11 @@ module DefaultRectangular {
                                                        minIndicesPerTask,
                                                        ranges);
         if debugDataParNuma {
-          chpl_debug_writeln("### numSublocs = ", numSublocs, "\n" +
-                  "### numTasksPerSubloc = ", numSublocTasks, "\n" +
-                  "### ignoreRunning = ", ignoreRunning, "\n" +
-                  "### minIndicesPerTask = ", minIndicesPerTask, "\n" +
-                  "### numChunks = ", numChunks, " (parDim = ", parDim, ")\n" +
+          chpl_debug_writeln("### numSublocs = ", numSublocs, "\n",
+                 "### numTasksPerSubloc = ", numSublocTasks, "\n",
+                  "### ignoreRunning = ", ignoreRunning, "\n",
+                  "### minIndicesPerTask = ", minIndicesPerTask, "\n",
+                  "### numChunks = ", numChunks, " (parDim = ", parDim, ")\n",
                   "### nranges = ", ranges);
         }
 
@@ -394,8 +394,8 @@ module DefaultRectangular {
             local do on here.getChild(chunk) {
               if debugDataParNuma {
                 if chunk!=chpl_getSubloc() then
-                  chpl_debug_writeln("*** ERROR: ON WRONG SUBLOC (should be "+chunk+
-                          ", on "+chpl_getSubloc()+") ***");
+                  chpl_debug_writeln("*** ERROR: ON WRONG SUBLOC (should be ", chunk,
+                                     ", on ", chpl_getSubloc(), ") ***");
               }
               // Divide the locale's tasks approximately evenly
               // among the sublocales
@@ -428,7 +428,7 @@ module DefaultRectangular {
                                               high, low, low);
                 followMe2(parDim2) = lo..hi;
                 if debugDataParNuma {
-                  chpl_debug_writeln("### chunk = ", chunk, "  chunk2 = ", chunk2, "  " +
+                  chpl_debug_writeln("### chunk = ", chunk, "  chunk2 = ", chunk2, "  ",
                           "followMe = ", followMe, "  followMe2 = ", followMe2);
                 }
                 yield followMe2;
@@ -458,10 +458,10 @@ module DefaultRectangular {
                   " ranges(", parDim, ").length=", ranges(parDim).length);
 
         if debugDataPar {
-          chpl_debug_writeln("### numTasksPerLoc = ", numTasks, "\n" +
-                  "### ignoreRunning = ", ignoreRunning, "\n" +
-                  "### minIndicesPerTask = ", minIndicesPerTask, "\n" +
-                  "### numChunks = ", numChunks, " (parDim = ", parDim, ")\n" +
+          chpl_debug_writeln("### numTasksPerLoc = ", numTasks, "\n",
+                 "### ignoreRunning = ", ignoreRunning, "\n",
+                 "### minIndicesPerTask = ", minIndicesPerTask, "\n",
+                 "### numChunks = ", numChunks, " (parDim = ", parDim, ")\n",
                   "### nranges = ", ranges);
         }
 
@@ -2074,12 +2074,12 @@ module DefaultRectangular {
   //
   private proc complexTransferComm(A, B, stridelevels:int(32), dstStride, srcStride, count, AFirst, BFirst) {
     if debugDefaultDistBulkTransfer {
-      chpl_debug_writeln("BulkTransferStride with values:\n" +
-                         "\tLocale        = " + stringify(here.id) + "\n" +
-                         "\tStride levels = " + stringify(stridelevels) + "\n" +
-                         "\tdstStride     = " + stringify(dstStride) + "\n" +
-                         "\tsrcStride     = " + stringify(srcStride) + "\n" +
-                         "\tcount         = " + stringify(count));
+      chpl_debug_writeln("BulkTransferStride with values:\n",
+                         "\tlocale        = ", stringify(here.id), "\n",
+                         "\tStride levels = ", stringify(stridelevels), "\n",
+                         "\tdstStride     = ", stringify(dstStride), "\n",
+                         "\tsrcStride     = ", stringify(srcStride), "\n",
+                         "\tcount         = ", stringify(count));
     }
 
     const AO = A.getDataIndex(AFirst, getShifted = false);


### PR DESCRIPTION
While testing, I accidentally enabled some debugging output and
noticed that in deprecating string + value overloads, I missed
a class of uses that occurred in chpl_debug_writeln().  Here,
I've rewritten those to use varargs calls (though I may have
missed some since these are disabled by default).