### PR TITLE
Stop ignoring test-venv errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,12 +118,12 @@ third-party-try-gmp: FORCE
 	fi
 
 third-party-test-venv: FORCE
-	-@if [ -z "$$CHPL_DONT_BUILD_TEST_VENV" ]; then \
+	@if [ -z "$$CHPL_DONT_BUILD_TEST_VENV" ]; then \
 	cd third-party && $(MAKE) test-venv; \
 	fi
 
 third-party-chpldoc-venv: FORCE
-	-@if [ -z "$$CHPL_DONT_BUILD_CHPLDOC_VENV" ]; then \
+	@if [ -z "$$CHPL_DONT_BUILD_CHPLDOC_VENV" ]; then \
 	cd third-party && $(MAKE) chpldoc-venv; \
 	fi
 


### PR DESCRIPTION
The test-venv rule invokes the third-party-test-venv rule which
ignores errors.  For nightly testing, this means that when the
`make test-venv` command works, we postpone issuing an error
until we try to run testing and fail to do so.  Here, I'm
removing the `-` that ignores errors on this rule and its
sibling so that we get errors closer to the point of failure.