### PR TITLE
Fix an accidental decapitalization that snuck in with 872b178df0

### DIFF
--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -2075,7 +2075,7 @@ module DefaultRectangular {
   private proc complexTransferComm(A, B, stridelevels:int(32), dstStride, srcStride, count, AFirst, BFirst) {
     if debugDefaultDistBulkTransfer {
       chpl_debug_writeln("BulkTransferStride with values:\n",
-                         "\tlocale        = ", stringify(here.id), "\n",
+                         "\tLocale        = ", stringify(here.id), "\n",
                          "\tStride levels = ", stringify(stridelevels), "\n",
                          "\tdstStride     = ", stringify(dstStride), "\n",
                          "\tsrcStride     = ", stringify(srcStride), "\n",


### PR DESCRIPTION
Apologies for not catching the typo earlier.  This will fix the failures on `test/optimizations/bulkcomm/bharshbarg/remote.chpl` from gasnet configurations last night.
