### PR TITLE
Fix string+value overloads in this numa-specific test

### DIFF
--- a/test/localeModels/numa/basics/hello7-taskpar-sublocs.chpl
+++ b/test/localeModels/numa/basics/hello7-taskpar-sublocs.chpl
@@ -55,7 +55,7 @@ coforall loc in Locales {
         // the message according to the task ID.
         //
         if (numSublocales > 1) then
-          message += (here:NumaDomain).sid + " of " + numSublocales + " named " + here.name + " on ";
+          message += (here:NumaDomain).sid:string + " of " + numSublocales:string + " named " + here.name + " on ";
 
         //
         // Specialize the message based on the locale we're running on:
@@ -65,7 +65,7 @@ coforall loc in Locales {
         // - '.name' queries its name (similar to UNIX `hostname`)
         // - 'numLocales' refers to the number of locales (as specified by -nl)
         //
-        message += "locale " + here.parent!.id + " of " + numLocales;
+        message += "locale " + here.parent!.id:string + " of " + numLocales:string;
         if (printLocaleName) then message += " named " + here.parent!.name;
 
         //


### PR DESCRIPTION
This test ran for the first time in numa testing last night since string+value was deprecated, so didn't get fixed as fast as the other regressions.  Insert string casts to make it work without deprecation warnings again.