### PR TITLE
Mason: mason-publish takes a registry as an argument 

### DIFF
--- a/test/mason/publish-tests/badDry.chpl
+++ b/test/mason/publish-tests/badDry.chpl
@@ -1,0 +1,11 @@
+
+use MasonPublish;
+use MasonUtils;
+
+const dir = here.cwd();
+
+proc main() {
+  masonNew(['mason', 'new', 'publishCheck']);
+  here.chdir(dir + '/publishCheck');
+  masonPublish(['mason', 'publish', '--dry-run', '../bad-registry']);
+}

--- a/test/mason/publish-tests/badDry.compopts
+++ b/test/mason/publish-tests/badDry.compopts
@@ -1,0 +1,1 @@
+-M ../../../tools/mason

--- a/test/mason/publish-tests/badDry.good
+++ b/test/mason/publish-tests/badDry.good
@@ -1,0 +1,3 @@
+Created new library project: publishCheck
+Updating mason-registry
+../bad-registry is not a valid path to a local mason-registry.

--- a/test/mason/publish-tests/badRegTest.chpl
+++ b/test/mason/publish-tests/badRegTest.chpl
@@ -1,0 +1,11 @@
+
+use MasonPublish;
+use MasonUtils;
+
+const dir = here.cwd();
+
+proc main() {
+  masonNew(['mason','new','publishCheck']);
+  here.chdir(dir + '/publishCheck');
+  masonPublish(['mason', 'publish', '../bad-regsitry']);
+}

--- a/test/mason/publish-tests/badRegTest.compopts
+++ b/test/mason/publish-tests/badRegTest.compopts
@@ -1,0 +1,1 @@
+-M ../../../tools/mason

--- a/test/mason/publish-tests/badRegTest.good
+++ b/test/mason/publish-tests/badRegTest.good
@@ -1,0 +1,3 @@
+Created new library project: publishCheck
+Updating mason-registry
+../bad-regsitry is not a valid path to a local mason-registry.

--- a/test/mason/publish-tests/dryTest.good
+++ b/test/mason/publish-tests/dryTest.good
@@ -1,3 +1,3 @@
 Created new library project: publishCheck
 Updating mason-registry
-publish is not a valid path to a local mason-registry.
+Package does not gave a git origin

--- a/test/mason/publish-tests/dryTest.good
+++ b/test/mason/publish-tests/dryTest.good
@@ -1,2 +1,2 @@
 Created new library project: publishCheck
-Must have remote origin set up in repository to publish
+publish is not a valid path

--- a/test/mason/publish-tests/dryTest.good
+++ b/test/mason/publish-tests/dryTest.good
@@ -1,2 +1,3 @@
 Created new library project: publishCheck
-publish is not a valid path
+Updating mason-registry
+publish is not a valid path to a local mason-registry.

--- a/test/mason/publish-tests/noFork.chpl
+++ b/test/mason/publish-tests/noFork.chpl
@@ -5,7 +5,7 @@ use MasonUtils;
 
 proc badDryRun() throws {
   try! {
-    dryRun('DummyGitUserName');
+    dryRun('DummyGitUserName','DummyPath', false);
   }
   catch e : MasonError {
     writeln(e.message());

--- a/test/mason/publish-tests/noFork.chpl
+++ b/test/mason/publish-tests/noFork.chpl
@@ -5,7 +5,7 @@ use MasonUtils;
 
 proc badDryRun() throws {
   try! {
-    dryRun('DummyGitUserName','DummyPath', false);
+    dryRun('DummyGitUserName','DummyPath', true);
   }
   catch e : MasonError {
     writeln(e.message());

--- a/test/mason/publish-tests/noFork.good
+++ b/test/mason/publish-tests/noFork.good
@@ -1,1 +1,1 @@
-mason-registry is not forked on your GitHub
+DummyPath is not a local git repository.

--- a/test/mason/publish-tests/packageName.chpl
+++ b/test/mason/publish-tests/packageName.chpl
@@ -2,8 +2,13 @@
 use MasonPublish;
 use MasonUtils;
 
-proc packageName() {
-  getPackageName();
+proc packageName() throws {
+  try! {
+    getPackageName();
+  }
+  catch e : MasonError {
+    writeln(e.message());
+  }
 }
 
 packageName();

--- a/test/mason/publish-tests/packageName.good
+++ b/test/mason/publish-tests/packageName.good
@@ -1,1 +1,1 @@
-Error getting the name of your package, ensure your package is a mason project
+Issue getting the name of your package, ensure your package is a mason project.

--- a/test/mason/publish-tests/publish.chpl
+++ b/test/mason/publish-tests/publish.chpl
@@ -9,9 +9,8 @@ const dir = here.cwd();
 proc main() throws {
   try! {
     masonNew(['mason', 'new' , 'publishCheck']);
-    const args = ['mason', 'publish'];
     here.chdir(dir + '/publishCheck');
-    masonPublish(args);
+    publishPackage('dummy','dir', true);
     here.chdir(dir);
     rmTree('publishCheck');
   }

--- a/test/mason/publish-tests/publish.good
+++ b/test/mason/publish-tests/publish.good
@@ -1,2 +1,2 @@
 Created new library project: publishCheck
-publish is not a valid path
+ERROR: publishCheck already exists in the Bricks

--- a/test/mason/publish-tests/publish.good
+++ b/test/mason/publish-tests/publish.good
@@ -1,2 +1,2 @@
 Created new library project: publishCheck
-ERROR: publishCheck already exists in the Bricks
+Unable to publish your package to the registry, make sure your package is a git repository.

--- a/test/mason/publish-tests/publish.good
+++ b/test/mason/publish-tests/publish.good
@@ -1,2 +1,2 @@
 Created new library project: publishCheck
-Must have remote origin set up in repository to publish
+publish is not a valid path

--- a/test/mason/publish-tests/publishHelp.good
+++ b/test/mason/publish-tests/publishHelp.good
@@ -6,6 +6,7 @@ Usage:
 Options:
     -h, --help                   Display this message
     --dry-run                    Check to see if package is ready to be published
+    --no-update                  Prevents registrys from being updated when a package is published.
     <registry>                   Positional argument indicates the target registry. Defaults to chapel-lang/mason-registry
 
 Publishing requires the mason-registry to be forked and the package to have a remote origin.

--- a/test/mason/publish-tests/publishHelp.good
+++ b/test/mason/publish-tests/publishHelp.good
@@ -1,10 +1,11 @@
 Publish a package to the mason-registry repository
 
 Usage:
-    mason publish [options]
+    mason publish [options] <registry>
 
 Options:
     -h, --help                   Display this message
     --dry-run                    Check to see if package is ready to be published
+    <registry>                   Positional argument indicates publishing to a personal registry
 
 Publishing requires the mason-registry to be forked and the package to have a remote origin.

--- a/test/mason/publish-tests/publishHelp.good
+++ b/test/mason/publish-tests/publishHelp.good
@@ -6,6 +6,6 @@ Usage:
 Options:
     -h, --help                   Display this message
     --dry-run                    Check to see if package is ready to be published
-    <registry>                   Positional argument indicates publishing to a personal registry
+    <registry>                   Positional argument indicates the target registry. Defaults to chapel-lang/mason-registry
 
 Publishing requires the mason-registry to be forked and the package to have a remote origin.

--- a/test/mason/publish-tests/publishHelp.good
+++ b/test/mason/publish-tests/publishHelp.good
@@ -4,9 +4,9 @@ Usage:
     mason publish [options] <registry>
 
 Options:
+    <registry>                   Positional argument indicates the target registry. Defaults to chapel-lang/mason-registry
     -h, --help                   Display this message
     --dry-run                    Check to see if package is ready to be published
     --no-update                  Prevents registrys from being updated when a package is published.
-    <registry>                   Positional argument indicates the target registry. Defaults to chapel-lang/mason-registry
 
 Publishing requires the mason-registry to be forked and the package to have a remote origin.

--- a/test/mason/publish-tests/publishHelpShort.good
+++ b/test/mason/publish-tests/publishHelpShort.good
@@ -6,6 +6,7 @@ Usage:
 Options:
     -h, --help                   Display this message
     --dry-run                    Check to see if package is ready to be published
+    --no-update                  Prevents registrys from being updated when a package is published.
     <registry>                   Positional argument indicates the target registry. Defaults to chapel-lang/mason-registry
 
 Publishing requires the mason-registry to be forked and the package to have a remote origin.

--- a/test/mason/publish-tests/publishHelpShort.good
+++ b/test/mason/publish-tests/publishHelpShort.good
@@ -1,10 +1,11 @@
 Publish a package to the mason-registry repository
 
 Usage:
-    mason publish [options]
+    mason publish [options] <registry>
 
 Options:
     -h, --help                   Display this message
     --dry-run                    Check to see if package is ready to be published
+    <registry>                   Positional argument indicates publishing to a personal registry
 
 Publishing requires the mason-registry to be forked and the package to have a remote origin.

--- a/test/mason/publish-tests/publishHelpShort.good
+++ b/test/mason/publish-tests/publishHelpShort.good
@@ -6,6 +6,6 @@ Usage:
 Options:
     -h, --help                   Display this message
     --dry-run                    Check to see if package is ready to be published
-    <registry>                   Positional argument indicates publishing to a personal registry
+    <registry>                   Positional argument indicates the target registry. Defaults to chapel-lang/mason-registry
 
 Publishing requires the mason-registry to be forked and the package to have a remote origin.

--- a/test/mason/publish-tests/publishHelpShort.good
+++ b/test/mason/publish-tests/publishHelpShort.good
@@ -4,9 +4,9 @@ Usage:
     mason publish [options] <registry>
 
 Options:
+    <registry>                   Positional argument indicates the target registry. Defaults to chapel-lang/mason-registry
     -h, --help                   Display this message
     --dry-run                    Check to see if package is ready to be published
     --no-update                  Prevents registrys from being updated when a package is published.
-    <registry>                   Positional argument indicates the target registry. Defaults to chapel-lang/mason-registry
 
 Publishing requires the mason-registry to be forked and the package to have a remote origin.

--- a/tools/mason/MasonHelp.chpl
+++ b/tools/mason/MasonHelp.chpl
@@ -421,7 +421,7 @@ proc masonPublishHelp(){
   writeln("Options:");
   writeln("    -h, --help                   Display this message");
   writeln('    --dry-run                    Check to see if package is ready to be published');
-  writeln('    <registry>                   Positional argument indicates publishing to a personal registry');
+  writeln('    <registry>                   Positional argument indicates the target registry. Defaults to chapel-lang/mason-registry');
   writeln();
   writeln('Publishing requires the mason-registry to be forked and the package to have a remote origin.');
 }

--- a/tools/mason/MasonHelp.chpl
+++ b/tools/mason/MasonHelp.chpl
@@ -416,11 +416,12 @@ proc masonPublishHelp(){
   writeln("Publish a package to the mason-registry repository");
   writeln();
   writeln("Usage:");
-  writeln("    mason publish [options]");
+  writeln("    mason publish [options] <registry>");
   writeln();
   writeln("Options:");
   writeln("    -h, --help                   Display this message");
   writeln('    --dry-run                    Check to see if package is ready to be published');
+  writeln('    <registry>                   Positional argument indicates publishing to a personal registry');
   writeln();
   writeln('Publishing requires the mason-registry to be forked and the package to have a remote origin.');
 }

--- a/tools/mason/MasonHelp.chpl
+++ b/tools/mason/MasonHelp.chpl
@@ -421,6 +421,7 @@ proc masonPublishHelp(){
   writeln("Options:");
   writeln("    -h, --help                   Display this message");
   writeln('    --dry-run                    Check to see if package is ready to be published');
+  writeln('    --no-update                  Prevents registrys from being updated when a package is published.');
   writeln('    <registry>                   Positional argument indicates the target registry. Defaults to chapel-lang/mason-registry');
   writeln();
   writeln('Publishing requires the mason-registry to be forked and the package to have a remote origin.');

--- a/tools/mason/MasonHelp.chpl
+++ b/tools/mason/MasonHelp.chpl
@@ -419,10 +419,10 @@ proc masonPublishHelp(){
   writeln("    mason publish [options] <registry>");
   writeln();
   writeln("Options:");
+  writeln('    <registry>                   Positional argument indicates the target registry. Defaults to chapel-lang/mason-registry');
   writeln("    -h, --help                   Display this message");
   writeln('    --dry-run                    Check to see if package is ready to be published');
   writeln('    --no-update                  Prevents registrys from being updated when a package is published.');
-  writeln('    <registry>                   Positional argument indicates the target registry. Defaults to chapel-lang/mason-registry');
   writeln();
   writeln('Publishing requires the mason-registry to be forked and the package to have a remote origin.');
 }

--- a/tools/mason/MasonPublish.chpl
+++ b/tools/mason/MasonPublish.chpl
@@ -307,7 +307,7 @@ private proc addPackageToBricks(projectLocal: string, safeDir: string, name : st
       var newToml = open(safeDir + "/mason-registry/Bricks/" + name + "/" + versionNum + ".toml", iomode.cw);
       var tomlWriter = newToml.writer();
       const url = gitUrl();
-      baseToml["brick"]["source"] = url[1..url.length-1];
+      baseToml["brick"].set("source", url[1..url.length-1]);
       tomlWriter.write(baseToml);
       tomlWriter.close();
     }
@@ -316,7 +316,7 @@ private proc addPackageToBricks(projectLocal: string, safeDir: string, name : st
       const baseToml = tomlFile;
       var newToml = open(safeDir + "/Bricks/" + name + "/" + versionNum + ".toml", iomode.cw);
       var tomlWriter = newToml.writer();
-      baseToml["brick"]["source"] = projectLocal;
+      baseToml["brick"].set("source", projectLocal);
       tomlWriter.write(baseToml);
       tomlWriter.close();
     }

--- a/tools/mason/MasonPublish.chpl
+++ b/tools/mason/MasonPublish.chpl
@@ -283,7 +283,7 @@ proc getPackageName() throws {
   try! {
     const toParse = open("Mason.toml", iomode.r);
     var tomlFile = new owned(parseToml(toParse));
-    const name = tomlFile['brick']['name'].s;
+    const name = tomlFile['brick']['name'].s; 
     return name;
   }
   catch {

--- a/tools/mason/MasonPublish.chpl
+++ b/tools/mason/MasonPublish.chpl
@@ -150,7 +150,7 @@ proc publishPackage(username: string, path : string, isLocal : bool) throws {
     writeln('--------------------------------------------------------------------');
     writeln('Go to the above link to open up a Pull Request to the mason-registry');
    }
- 
+
   if (exists(safeDir) && !isLocal) then rmTree(safeDir + '/');
 }
 
@@ -178,7 +178,7 @@ proc dryRun(username: string, path : string, isLocal : bool) throws {
       writeln('> git commit -m [package name]');
       writeln('> git push --set-upstream origin [package name]');
       exit(0);
-    } 
+    }
     else {
       if fork == false {
         throw new owned MasonError('mason-registry is not forked on your GitHub');
@@ -283,7 +283,7 @@ proc getPackageName() throws {
   try! {
     const toParse = open("Mason.toml", iomode.r);
     var tomlFile = new owned(parseToml(toParse));
-    const name = tomlFile['brick']['name'].s; 
+    const name = tomlFile['brick']['name'].s;
     return name;
   }
   catch {

--- a/tools/mason/MasonPublish.chpl
+++ b/tools/mason/MasonPublish.chpl
@@ -131,31 +131,27 @@ proc publishPackage(username: string, path : string, isLocal : bool) throws {
     safeDir = MASON_HOME + '/tmp/' + name + '-' + uniqueDir;
   }
 
-  try! {
-    if !isLocal {
-      if !exists(path + '/tmp') then mkdir(path + '/tmp');
-      mkdir(safeDir);
-    }
-    if !isLocal {
-      cloneMasonReg(username, safeDir, path);
-      branchMasonReg(username, name, safeDir, path);
-    }
-
-    addPackageToBricks(packageLocation, safeDir, name, path, isLocal);
-
-    if !isLocal {
-      gitC(safeDir + "/mason-registry", "git add .");
-      gitC(safeDir + "/mason-registry", "git commit -m '" + name + "'");
-      gitC(safeDir + "/mason-registry", 'git push --set-upstream origin ' + name, true);
-      rmTree(safeDir + '/');
-      writeln('--------------------------------------------------------------------');
-      writeln('Go to the above link to open up a Pull Request to the mason-registry');
-    }
+  if !isLocal {
+    if !exists(MASON_HOME + '/tmp') then mkdir(MASON_HOME + '/tmp');
+    mkdir(safeDir);
   }
-  catch {
-    if exists(safeDir) then rmTree(safeDir + '/');
-    writeln('Error publishing your package to the mason-registry');
+  if !isLocal {
+    cloneMasonReg(username, safeDir, path);
+    branchMasonReg(username, name, safeDir, path);
   }
+
+  addPackageToBricks(packageLocation, safeDir, name, path, isLocal);
+
+  if !isLocal {
+    gitC(safeDir + "/mason-registry", "git add .");
+    gitC(safeDir + "/mason-registry", "git commit -m '" + name + "'");
+    gitC(safeDir + "/mason-registry", 'git push --set-upstream origin ' + name, true);
+    rmTree(safeDir + '/');
+    writeln('--------------------------------------------------------------------');
+    writeln('Go to the above link to open up a Pull Request to the mason-registry');
+   }
+ 
+  if (exists(safeDir) && !isLocal) then rmTree(safeDir + '/');
 }
 
 /* If --dry-run is passed then it takes the username and checks to see if the mason-registry is forked

--- a/tools/mason/MasonPublish.chpl
+++ b/tools/mason/MasonPublish.chpl
@@ -159,10 +159,10 @@ proc publishPackage(username: string, path : string, isLocal : bool) throws {
  */
 proc dryRun(username: string, path : string, isLocal : bool) throws {
   if !isLocal {
-    var fork = false;
+    var fork = true;
     var remoteCheck = checkIfForkExists(username: string);
-    if remoteCheck == 0 {
-      fork = true;
+    if remoteCheck == 1 {
+      fork = false;
     }
     var git = false;
     if doesGitOriginExist() {
@@ -194,7 +194,7 @@ proc dryRun(username: string, path : string, isLocal : bool) throws {
       exit(0);
     }
     else {
-      throw new owned MasonError(path + ' is not a valid path to a local registrty.');
+      throw new owned MasonError(path + ' is not a valid path to a local registry.');
     }
   }
 }

--- a/tools/mason/MasonPublish.chpl
+++ b/tools/mason/MasonPublish.chpl
@@ -59,8 +59,9 @@ proc masonPublish(ref args: list(string)) throws {
     if args.size > 2 {
       var potentialPath = args.pop();
       if (potentialPath != '--dry-run') && (potentialPath != '--no-update') {
-        registryPath = args.pop();
+        registryPath = potentialPath;
       }
+      args.append(potentialPath);
     }
 
     if registryPath.isEmpty() {

--- a/tools/mason/MasonPublish.chpl
+++ b/tools/mason/MasonPublish.chpl
@@ -81,7 +81,7 @@ proc masonPublish(args: [] string) throws {
 /* Uses the existence of a colon to see if a passed registryPath is a local or remote registryPath
  */
 proc isRegistryPathLocal(registryPath : string) throws {
-  return registryPath.find(":") == 0; 
+  return registryPath.find(":") == 0;
 }
 
 /* When passed a registryPath and whether or not that registryPath is a local or remote registryPath,
@@ -135,17 +135,17 @@ proc publishPackage(username: string, registryPath : string, isLocal : bool) thr
     else {
       safeDir = MASON_HOME + '/tmp/' + name + '-' + uniqueDir;
     }
-  
+
     if !isLocal {
       if !exists(MASON_HOME + '/tmp') then mkdir(MASON_HOME + '/tmp');
       mkdir(safeDir);
     }
- 
+
     if !isLocal {
       cloneMasonReg(username, safeDir, registryPath);
       branchMasonReg(username, name, safeDir, registryPath);
     }
-  
+
     addPackageToBricks(packageLocation, safeDir, name, registryPath, isLocal);
 
     if !isLocal {
@@ -160,7 +160,7 @@ proc publishPackage(username: string, registryPath : string, isLocal : bool) thr
       gitC(safeDir, 'git add Bricks/' + name);
       gitC(safeDir, "git commit -m '" + name + "'" );
     }
-    
+
   }
   catch e {
     writeln(e.message());

--- a/tools/mason/MasonPublish.chpl
+++ b/tools/mason/MasonPublish.chpl
@@ -72,6 +72,9 @@ proc masonPublish(ref args: list(string)) throws {
     }
 
     updateRegistry('Mason.toml', args);
+    if !isLocal && !doesGitOriginExist() && !dry {
+      throw new owned MasonError('Your package must have a git origin remote in order to publish to a remote registry.');  
+    }
 
     if checkRegistryPath(registryPath, isLocal) {
       if dry {
@@ -181,6 +184,7 @@ proc publishPackage(username: string, registryPath : string, isLocal : bool) thr
     else {
       gitC(safeDir, 'git add Bricks/' + name);
       commitSubProcess(safeDir, command);
+      writeln('Succesfully published package to ' + registryPath);
     }
 
   }
@@ -390,7 +394,7 @@ private proc addPackageToBricks(projectLocal: string, safeDir: string, name : st
       }
     }
   }
-  catch e : MasonError {
+  catch e {
     writeln(e.message());
     exit(1);
   }

--- a/tools/mason/MasonPublish.chpl
+++ b/tools/mason/MasonPublish.chpl
@@ -351,6 +351,9 @@ private proc addPackageToBricks(projectLocal: string, safeDir: string, name : st
     var tomlFile = new owned(parseToml(toParse));
     const versionNum = tomlFile['brick']['version'].s;
     if !isLocal {
+      if !exists(safeDir + '/mason-registry/Bricks/') {
+        throw new owned MasonError('Registry does not have the expected structure. Ensure your registry has a Bricks directory.');
+      }
       if !exists(safeDir + "/mason-registry/Bricks/" + name) {
         mkdir(safeDir + "/mason-registry/Bricks/" + name);
       }

--- a/tools/mason/MasonPublish.chpl
+++ b/tools/mason/MasonPublish.chpl
@@ -193,7 +193,7 @@ proc publishPackage(username: string, registryPath : string, isLocal : bool) thr
   }
 }
 
-/* Subprocess function designed to pass a message to 'git commit' without gettthe string
+/* Subprocess function designed to pass a message to 'git commit' without get the string
  split by the MasonUtils runCommand()/
  */
 private proc commitSubProcess(dir, command) throws {

--- a/tools/mason/MasonPublish.chpl
+++ b/tools/mason/MasonPublish.chpl
@@ -331,7 +331,7 @@ private proc addPackageToBricks(projectLocal: string, safeDir: string, name : st
       if !exists(safeDir + "/mason-registry/Bricks/" + name) {
         mkdir(safeDir + "/mason-registry/Bricks/" + name);
       }
-      else if !exists(safeDir + '/mason-registry/Bricks/' + name + "/" + versionNum + ".toml") {
+      if !exists(safeDir + '/mason-registry/Bricks/' + name + "/" + versionNum + ".toml") {
         const baseToml = tomlFile;
         var newToml = open(safeDir + "/mason-registry/Bricks/" + name + "/" + versionNum + ".toml", iomode.cw);
         var tomlWriter = newToml.writer();
@@ -351,7 +351,7 @@ private proc addPackageToBricks(projectLocal: string, safeDir: string, name : st
       if !exists(safeDir + '/Bricks/' + name) {
         mkdir(safeDir + "/Bricks/" + name);
       }
-      else if !exists(safeDir + "/Bricks/" + name + "/" + versionNum + ".toml") {
+      if !exists(safeDir + "/Bricks/" + name + "/" + versionNum + ".toml") {
         const baseToml = tomlFile;
         var newToml = open(safeDir + "/Bricks/" + name + "/" + versionNum + ".toml", iomode.cw);
         var tomlWriter = newToml.writer();

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -367,7 +367,7 @@ proc getChapelVersionStr() {
   return chplVersion;
 }
 
-proc gitC(newDir, command, quiet=false) {
+proc gitC(newDir, command, quiet=false) throws {
   var ret : string;
 
   const oldDir = here.cwd();


### PR DESCRIPTION
mason-publish takes a personal registry as an argument. Either remote or local path will suffice and the package will be added to the bricks of that registry. 

Users can now publish a package to a registry that is not the official `mason-registry` Allows for a development package to be used locally with the mason registry without publishing the package to the public registry. The registry passed in can either be a local path or a remote path to a git repo. 