### PR TITLE
Private uses for modules/dists

### DIFF
--- a/modules/dists/BlockCycDist.chpl
+++ b/modules/dists/BlockCycDist.chpl
@@ -25,7 +25,7 @@
 //   LocBlockCyclic    LocBlockCyclicDom  LocBlockCyclicArr
 //
 
-use DSIUtil;
+private use DSIUtil;
 
 //
 // TODO List

--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -41,8 +41,9 @@
 private use DSIUtil;
 private use ChapelUtil;
 private use CommDiagnostics;
-private use SparseBlockDist;
-private use LayoutCS;
+
+use SparseBlockDist;
+use LayoutCS;
 //
 // These flags are used to output debug information and run extra
 // checks when using Block.  Should these be promoted so that they can

--- a/modules/dists/BlockDist.chpl
+++ b/modules/dists/BlockDist.chpl
@@ -38,11 +38,11 @@
 // 1. refactor pid fields from distribution, domain, and array classes
 //
 
-use DSIUtil;
-use ChapelUtil;
-use CommDiagnostics;
-use SparseBlockDist;
-use LayoutCS;
+private use DSIUtil;
+private use ChapelUtil;
+private use CommDiagnostics;
+private use SparseBlockDist;
+private use LayoutCS;
 //
 // These flags are used to output debug information and run extra
 // checks when using Block.  Should these be promoted so that they can

--- a/modules/dists/CyclicDist.chpl
+++ b/modules/dists/CyclicDist.chpl
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-use DSIUtil;
+private use DSIUtil;
 
 proc _determineRankFromStartIdx(startIdx) param {
   return if isTuple(startIdx) then startIdx.size else 1;

--- a/modules/dists/SparseBlockDist.chpl
+++ b/modules/dists/SparseBlockDist.chpl
@@ -31,9 +31,9 @@
 // mapped to by the distribution.
 //
 
-use DSIUtil;
-use ChapelUtil;
-use BlockDist;
+private use DSIUtil;
+private use ChapelUtil;
+private use BlockDist;
 //
 // These flags are used to output debug information and run extra
 // checks when using SparseBlock.  Should these be promoted so that they can

--- a/modules/dists/StencilDist.chpl
+++ b/modules/dists/StencilDist.chpl
@@ -32,10 +32,10 @@
 // mapped to by the distribution.
 //
 
-use BlockDist;
-use DSIUtil;
-use ChapelUtil;
-use CommDiagnostics;
+private use BlockDist;
+private use DSIUtil;
+private use ChapelUtil;
+private use CommDiagnostics;
 
 
 //

--- a/modules/dists/dims/BlockCycDim.chpl
+++ b/modules/dists/dims/BlockCycDim.chpl
@@ -21,8 +21,8 @@
 // Block-cyclic dimension specifier - for use with DimensionalDist2D.
 //
 
-use DimensionalDist2D;
-use RangeChunk only ;
+private use DimensionalDist2D;
+private use RangeChunk only ;
 
 config const BlockCyclicDim_allowParLeader = true;
 config param BlockCyclicDim_enableArrayIterWarning = false;  // 'false' for testing

--- a/modules/dists/dims/BlockDim.chpl
+++ b/modules/dists/dims/BlockDim.chpl
@@ -21,7 +21,7 @@
 // Block dimension specifier - for use with DimensionalDist2D.
 //
 
-use DimensionalDist2D;
+private use DimensionalDist2D;
 
 
 /*

--- a/modules/dists/dims/ReplicatedDim.chpl
+++ b/modules/dists/dims/ReplicatedDim.chpl
@@ -24,8 +24,8 @@
 // The required methods are marked with 'REQ' followed by a brief description.
 //
 
-use DimensionalDist2D;
-use RangeChunk only ;
+private use DimensionalDist2D;
+private use RangeChunk only ;
 
 /*
 This Replicated dimension specifier is for use with the


### PR DESCRIPTION
Make module uses private in the modules/dists/ directory where possible.

Most uses of other modules within the distribution modules were internal
and don't need to be exposed to the modules that use the dists. Make the
'use's private to avoid leaking out all of the symbols.

In some cases modules were 'use'd inside of a single function; I left them
alone.

BlockDist is intentionally exposing some symbols from 'use'd modules, so
leave those 'use's non-private.

Passed CHPL_COMM=gasnet paratest.