### PR TITLE
Disable CPU binding for slurm-gasnetrun_* launchers

### DIFF
--- a/runtime/src/launch/slurm-gasnetrun_common/slurm-gasnetrun_common.h
+++ b/runtime/src/launch/slurm-gasnetrun_common/slurm-gasnetrun_common.h
@@ -251,7 +251,7 @@ static char* chpl_launch_create_command(int argc, char* argv[],
     if (errorfn != NULL)
       fprintf(slurmFile, "#SBATCH -e %s\n", errorfn);
 
-    fprintf(slurmFile, "%s/%s/%s -n %d -N %d",
+    fprintf(slurmFile, "%s/%s/%s -n %d -N %d -c 0",
             CHPL_THIRD_PARTY, WRAP_TO_STR(LAUNCH_PATH), GASNETRUN_LAUNCHER,
             numLocales, numLocales);
 
@@ -287,7 +287,7 @@ static char* chpl_launch_create_command(int argc, char* argv[],
       len += sprintf(iCom+len, "--exclude=%s ", exclude);
     if (constraint)
       len += sprintf(iCom+len, " -C %s", constraint);
-    len += sprintf(iCom+len, " %s/%s/%s -n %d -N %d",
+    len += sprintf(iCom+len, " %s/%s/%s -n %d -N %d -c 0",
                    CHPL_THIRD_PARTY, WRAP_TO_STR(LAUNCH_PATH),
                    GASNETRUN_LAUNCHER, numLocales, numLocales);
     len += propagate_environment(iCom+len);


### PR DESCRIPTION
By default, the slurm_gasnetrun_* launchers use mpirun to launch
programs. Open MPI's mpirun will limit affinity to a single core by
default, which the Chapel process then inherits. Here we add -c 0 to
tell gasnet that we don't want any CPU affinity binding/pinning. gasnet
will map this to --bind-to none for Open MPI and whatever is appropriate
for other vendors if needed.

Same as https://github.com/chapel-lang/chapel/pull/13353 for slurm-gasnetrun*