### PR TITLE
Nilability checking improvements #4

### DIFF
--- a/compiler/passes/createTaskFunctions.cpp
+++ b/compiler/passes/createTaskFunctions.cpp
@@ -356,6 +356,8 @@ static void addReduceIntentSupport(FnSymbol* fn, CallExpr* call,
   headAnchor->insertBefore(new DefExpr(globalOp));
 
   AggregateType* reduceAt = toAggregateType(reduceType->type);
+  if (DecoratedClassType* dt = toDecoratedClassType(reduceType->type))
+    reduceAt = dt->getCanonicalClass();
   INT_ASSERT(reduceAt);
 
   CallExpr* newOp = new CallExpr(PRIM_NEW,

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -9331,7 +9331,9 @@ static void errorIfNonNilableType(CallExpr* call, Symbol* val,
 
   // Allow default-init assign to work around current compiler oddities.
   // In a future where init= is always used, we can remove this case.
-  if (val->hasFlag(FLAG_INITIALIZED_LATER))
+  // Skip this error for a param - it will get "not of a supported param type"
+  if (val->hasFlag(FLAG_INITIALIZED_LATER) ||
+      val->hasFlag(FLAG_PARAM))
     return;
 
   const char* descr = val->name;

--- a/modules/dists/PrivateDist.chpl
+++ b/modules/dists/PrivateDist.chpl
@@ -147,7 +147,7 @@ class PrivateDom: BaseRectangularDom {
 
 class PrivateArr: BaseRectangularArr {
   var dom: unmanaged PrivateDom(rank, idxType, stridable);
-  var data: eltType;
+  var data: eltType?;
 }
 
 override proc PrivateArr.dsiGetBaseDom() return dom;

--- a/modules/dists/PrivateDist.chpl
+++ b/modules/dists/PrivateDist.chpl
@@ -147,7 +147,7 @@ class PrivateDom: BaseRectangularDom {
 
 class PrivateArr: BaseRectangularArr {
   var dom: unmanaged PrivateDom(rank, idxType, stridable);
-  var data: eltType?;
+  var data: eltType;
 }
 
 override proc PrivateArr.dsiGetBaseDom() return dom;

--- a/modules/packages/Futures.chpl
+++ b/modules/packages/Futures.chpl
@@ -141,7 +141,7 @@ module Futures {
     type retType;
 
     pragma "no doc"
-    var classRef: unmanaged FutureClass(retType) = nil;
+    var classRef: unmanaged FutureClass(retType)? = nil;
 
     pragma "no doc"
     proc init(type retType) {
@@ -162,15 +162,15 @@ module Futures {
      */
     proc get(): retType {
       if !isValid() then halt("get() called on invalid future");
-      classRef.state.waitFor(true);
-      return classRef.value;
+      classRef!.state.waitFor(true);
+      return classRef!.value;
     }
 
     pragma "no doc"
     proc set(value: retType) {
       if !isValid() then halt("set() called on invalid future");
-      classRef.value = value;
-      var oldState = classRef.state.testAndSet();
+      classRef!.value = value;
+      var oldState = classRef!.state.testAndSet();
       if oldState then halt("set() called more than once on a future");
     }
 
@@ -181,7 +181,7 @@ module Futures {
      */
     proc isReady(): bool {
       if !isValid() then halt("isReady() called on invalid future");
-      return classRef.state.peek();
+      return classRef!.state.peek();
     }
 
     /*
@@ -189,7 +189,7 @@ module Futures {
       :ref:`see above <valid-futures>`.
      */
     inline proc isValid(): bool {
-      return ((classRef != nil) && classRef.valid);
+      return ((classRef != nil) && classRef!.valid);
     }
 
     /*
@@ -213,7 +213,7 @@ module Futures {
       if !canResolveMethod(taskFn, "retType") then
         compilerError("cannot determine return type of andThen() task function");
       var f: Future(taskFn.retType);
-      f.classRef.valid = true;
+      f.classRef!.valid = true;
       begin f.set(taskFn(this.get()));
       return f;
     }
@@ -222,19 +222,19 @@ module Futures {
     proc acquire(newRef: unmanaged FutureClass) {
       if isValid() then halt("acquire(newRef) called on valid future!");
       classRef = newRef;
-      classRef.incRefCount();
+      newRef.incRefCount();
     }
 
     pragma "no doc"
     proc acquire() {
       if classRef == nil then halt("acquire() called on nil future");
-      classRef.incRefCount();
+      classRef!.incRefCount();
     }
 
     pragma "no doc"
     proc release() {
       if classRef == nil then halt("release() called on nil future");
-      var rc = classRef.decRefCount();
+      var rc = classRef!.decRefCount();
       if rc == 1 {
         delete classRef;
         classRef = nil;
@@ -262,7 +262,7 @@ module Futures {
     if lhs.classRef == rhs.classRef then return;
     if lhs.classRef != nil then
       lhs.release();
-    lhs.acquire(rhs.classRef);
+    lhs.acquire(rhs.classRef!);
   }
 
   /*
@@ -278,7 +278,7 @@ module Futures {
     if !canResolveMethod(taskFn, "retType") then
       compilerError("cannot determine return type of andThen() task function");
     var f: Future(taskFn.retType);
-    f.classRef.valid = true;
+    f.classRef!.valid = true;
     begin f.set(taskFn());
     return f;
   }
@@ -297,7 +297,7 @@ module Futures {
     if !canResolveMethod(taskFn, "retType") then
       compilerError("cannot determine return type of async() task function");
     var f: Future(taskFn.retType);
-    f.classRef.valid = true;
+    f.classRef!.valid = true;
     begin f.set(taskFn((...args)));
     return f;
   }
@@ -323,7 +323,7 @@ module Futures {
   proc waitAll(futures...?N) {
     type retTypes = getRetTypes((...futures));
     var f: Future(retTypes);
-    f.classRef.valid = true;
+    f.classRef!.valid = true;
     begin {
       var result: retTypes;
       for param i in 1..N do

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -334,6 +334,7 @@ inline proc chpl_compare(a:?t, b:t, comparator:?rec) {
 
 
 pragma "no doc"
+pragma "unsafe" // due to 'data' default-initialized to nil for class types
 /*
     Check if a comparator was passed and confirm that it will work, otherwise
     throw a compile-time error.
@@ -397,6 +398,7 @@ proc chpl_check_comparator(comparator, type eltType) param {
 
 /* Basic Functions */
 
+pragma "unsafe" // due to 'tmp' default-initialized to nil for class types
 private
 proc radixSortOk(Data: [?Dom] ?eltType, comparator) param {
   if !Dom.stridable {

--- a/spec/Classes.tex
+++ b/spec/Classes.tex
@@ -1566,8 +1566,8 @@ class C { }
 \end{chapelpre}
 \begin{chapel}
 // assume that C is a class
-var a = new owned C();
-var b:owned C; // default initialized to store `nil`
+var a:owned C? = new owned C();
+var b:owned C?; // default initialized to store `nil`
 b = a; // transfers ownership from a to b
 writeln(a); // a is left storing `nil`
 \end{chapel}
@@ -1633,7 +1633,7 @@ class C {
 }
 \end{chapelpre}
 \begin{chapel}
-var c : unmanaged C = nil;
+var c : unmanaged C? = nil;
 delete c;              // Does nothing: c is nil.
 
 c = new unmanaged C(); // Creates a new object.
@@ -1686,7 +1686,7 @@ class C {
   proc deinit() { writeln("Bye, bye ", i); }
 }
 
-var c : unmanaged C = nil;
+var c : unmanaged C? = nil;
 delete c;              // Does nothing: c is nil.
 
 c = new unmanaged C(1); // Creates a new instance.

--- a/spec/Generics.tex
+++ b/spec/Generics.tex
@@ -560,7 +560,7 @@ element contained in the linked list.
 class Node {
   type eltType;
   var data: eltType;
-  var next: unmanaged Node(eltType);
+  var next: unmanaged Node(eltType)?;
 }
 \end{chapel}
 \begin{chapelpost}
@@ -573,7 +573,7 @@ delete n;
 \begin{chapeloutput}
 3.14
 nil
-unmanaged Node(real(64))
+unmanaged Node(real(64))?
 \end{chapeloutput}
 The call \chpl{new Node(real, 3.14)} creates a node in the linked list
 that contains the value \chpl{3.14}.  The \chpl{next} field is set to
@@ -670,7 +670,7 @@ rather omits the type from the \chpl{data} field.
 \begin{chapel}
 class Node {
   var data;
-  var next: unmanaged Node(data.type) = nil;
+  var next: unmanaged Node(data.type)? = nil;
 }
 \end{chapel}
 A node with integer element type can be defined in the call to the
@@ -1018,12 +1018,12 @@ implementation can still be a generic function.  See also
 class MyNode {
   type itemType;              // type of item
   var item: itemType;         // item in node
-  var next: unmanaged MyNode(itemType); // reference to next node (same type)
+  var next: unmanaged MyNode(itemType)?; // reference to next node (same type)
 }
 
 record Stack {
   type itemType;             // type of items
-  var top: unmanaged MyNode(itemType); // top node on stack linked list
+  var top: unmanaged MyNode(itemType)?; // top node on stack linked list
 
   proc push(item: itemType) {
     top = new unmanaged MyNode(itemType, item, top);

--- a/spec/Iterators.tex
+++ b/spec/Iterators.tex
@@ -162,7 +162,7 @@ A post-order traversal of a tree data structure could be written like this:
 \begin{chapelnoprint}
 class Tree {
   var data: string;
-  var left, right: unmanaged Tree;
+  var left, right: unmanaged Tree?;
   proc deinit() {
     if left then delete left;
     if right then delete right;
@@ -172,11 +172,11 @@ class Tree {
 var tree = new unmanaged Tree("a", new unmanaged Tree("b"), new unmanaged Tree("c", new unmanaged Tree("d"), new unmanaged Tree("e")));
 \end{chapelnoprint}
 \begin{chapel}
-iter postorder(tree: Tree): string {
+iter postorder(tree: Tree?): string {
   if tree != nil {
-    for child in postorder(tree.left) do
+    for child in postorder(tree!.left) do
       yield child;
-    for child in postorder(tree.right) do
+    for child in postorder(tree!.right) do
       yield child;
     yield tree.data;
   }
@@ -186,7 +186,7 @@ iter postorder(tree: Tree): string {
 proc Tree.writeThis(x)
 {
   var first = true;
-  for node in postorder(tree) {
+  for node in postorder(this) {
     if first then first = false;
       else x.write(" ");
     write(node);

--- a/spec/Records.tex
+++ b/spec/Records.tex
@@ -279,7 +279,7 @@ record R {
     c = new unmanaged C(0);
   }
   proc deinit() {
-    delete c; c = nil;
+    delete c;
   }
 }
 

--- a/spec/Task_Parallelism_and_Synchronization.tex
+++ b/spec/Task_Parallelism_and_Synchronization.tex
@@ -194,7 +194,7 @@ The code
 \begin{chapel}
 class Tree {
   var isLeaf: bool;
-  var left, right: unmanaged Tree;
+  var left, right: unmanaged Tree?;
   var value: int;
 
   proc sum():int {

--- a/test/classes/bradc/declClassType1b.chpl
+++ b/test/classes/bradc/declClassType1b.chpl
@@ -2,7 +2,7 @@ class C {
   var x = 10;
 }
 
-var globc: unmanaged C = new unmanaged C();
+var globc: unmanaged C? = new unmanaged C();
 
 class D {
   var y = 20;

--- a/test/classes/bradc/writeclass3.chpl
+++ b/test/classes/bradc/writeclass3.chpl
@@ -3,8 +3,8 @@ class myclass {
   var y: real = 4.2;
 }
 
-var a: borrowed myclass = new borrowed myclass();
-var b: borrowed myclass = new borrowed myclass();
+var a: borrowed myclass? = new borrowed myclass();
+var b: borrowed myclass? = new borrowed myclass();
 
 writeln("a is: ", a, ", b is: ", b);
 

--- a/test/functions/iterators/sungeun/iterInClass.chpl
+++ b/test/functions/iterators/sungeun/iterInClass.chpl
@@ -1,9 +1,9 @@
 class c0 {
-  iter getChildren(): locale { yield nil; }
+  iter getChildren(): locale? { yield nil; }
 }
 
 class c1 {
-  iter getChildren(): locale { yield nil; }
+  iter getChildren(): locale? { yield nil; }
 }
 
 var c = new unmanaged c1();

--- a/test/library/packages/UnitTest/PopulateTests_PRIM/TestCount.compopts
+++ b/test/library/packages/UnitTest/PopulateTests_PRIM/TestCount.compopts
@@ -1,0 +1,1 @@
+--legacy-nilable-classes

--- a/test/library/packages/VectorList/VectorLists.chpl
+++ b/test/library/packages/VectorList/VectorLists.chpl
@@ -143,8 +143,10 @@ module VectorLists {
   inline iter VectorList.listElements() {
     var curr = head;
     while true {
-      const next = curr.next; yield curr;
-      if next then curr = next!; else break;
+      const next = curr.next;
+      yield curr;
+      if next then curr = next!;
+              else break;
     }
   }
 

--- a/test/library/packages/VectorList/VectorLists.chpl
+++ b/test/library/packages/VectorList/VectorLists.chpl
@@ -88,7 +88,7 @@ module VectorLists {
     var size: int;
     const capacity: int;
     const elements: _ddata(eltType);  // _ddata is not managed
-    var next: unmanaged VectorListElement(eltType);
+    var next: unmanaged VectorListElement(eltType)?;
 
     inline proc init(type eltType, initCapacity: int) {
       this.eltType = eltType;
@@ -142,8 +142,10 @@ module VectorLists {
   /* Yields all VectorListElement. */
   inline iter VectorList.listElements() {
     var curr = head;
-    do { const next = curr.next; yield curr; curr = next; }
-    while curr != nil;
+    while true {
+      const next = curr.next; yield curr;
+      if next then curr = next!; else break;
+    }
   }
 
   /* Yields pairs (starting index, VectorListElement pointer). */

--- a/test/modules/sungeun/no-use-class-other-file.chpl
+++ b/test/modules/sungeun/no-use-class-other-file.chpl
@@ -1,6 +1,6 @@
 module Z {
   proc f() {
-    var c: X.C;
+    var c: X.C?;
 
     writeln(c);
   }

--- a/test/modules/sungeun/no-use-class.chpl
+++ b/test/modules/sungeun/no-use-class.chpl
@@ -4,7 +4,7 @@ module X {
 
 module Y {
   proc main() {
-    var c: X.C;
+    var c: X.C?;
     writeln(c);
 
     Z.f();

--- a/test/multilocale/deitz/oneOrMoreLocales/test_dot_locale_error.chpl
+++ b/test/multilocale/deitz/oneOrMoreLocales/test_dot_locale_error.chpl
@@ -1,6 +1,6 @@
 class C {}
 
-var c: unmanaged C;
+var c: unmanaged C?;
 
 proc bar() {
   c = new unmanaged C();

--- a/test/optimizations/bulkcomm/asenjo/stencilDR/v2/stencil.chpl
+++ b/test/optimizations/bulkcomm/asenjo/stencilDR/v2/stencil.chpl
@@ -37,7 +37,7 @@ const allx = ldx * gx,
 
 // for neighbor-cache pointers
 var auxArr: [1..1, 1..1] elType;
-type cacheType = auxArr[1,..]._value.type; // a class type, so it can be nil
+type cacheType = auxArr[1,..]._value.type?; // a class type, so it can be nil
 
 ///////////
 

--- a/test/parallel/begin/deitz/test_coforall_sugar1.chpl
+++ b/test/parallel/begin/deitz/test_coforall_sugar1.chpl
@@ -6,12 +6,12 @@ var A: [1..n] int;
 
 class syncStack {
   var v: sync bool;
-  var next: unmanaged syncStack;
+  var next: unmanaged syncStack?;
 }
 
-proc pushSyncStack(s: unmanaged syncStack) return new unmanaged syncStack(next=s);
+proc pushSyncStack(s: unmanaged syncStack?) return new unmanaged syncStack(next=s);
 
-var ss: unmanaged syncStack;
+var ss: unmanaged syncStack?;
 
 for i in 1..n {
   var me = pushSyncStack(ss);

--- a/test/parallel/cobegin/bradc/varsEscape-workaround.chpl
+++ b/test/parallel/cobegin/bradc/varsEscape-workaround.chpl
@@ -1,5 +1,5 @@
 class C {
-  var left, right: unmanaged C;
+  var left, right: unmanaged C?;
   
   proc countNodes(): int {
     var lnodes, rnodes: int;

--- a/test/parallel/cobegin/waynew/locals.chpl
+++ b/test/parallel/cobegin/waynew/locals.chpl
@@ -51,7 +51,7 @@ proc function3() {
   }
 
   class D {
-    var c:unmanaged C;
+    var c:unmanaged C?;
   }
 
   var c:unmanaged C = new unmanaged C();

--- a/test/parallel/forall/task-private-vars/records.chpl
+++ b/test/parallel/forall/task-private-vars/records.chpl
@@ -9,7 +9,7 @@ record Count {
 }
 
 record Wrapper {
-  var ptr: unmanaged object;
+  var ptr: unmanaged object?;
   proc init() { ptr = new unmanaged object(); }
   proc init=(arg: Wrapper) { ptr = nil; } // do not allocate a new object
   proc deinit() { delete ptr; }

--- a/test/parallel/single/waynew/simple0b.chpl
+++ b/test/parallel/single/waynew/simple0b.chpl
@@ -4,8 +4,8 @@ class C {
   var x: int;
 }
 
-var s: single borrowed C;
-var t: borrowed C;
+var s: single borrowed C?;
+var t: borrowed C?;
 
 s = new borrowed C();
 s = t;

--- a/test/parallel/sync/bradc/syncArrInit.chpl
+++ b/test/parallel/sync/bradc/syncArrInit.chpl
@@ -6,7 +6,7 @@ class C {
   }
 }
 
-var arr: [1..3] sync borrowed C;
+var arr: [1..3] sync borrowed C?;
 
 writeln("made it past declaration of arr");
   

--- a/test/parallel/sync/bradc/syncArrInit2.chpl
+++ b/test/parallel/sync/bradc/syncArrInit2.chpl
@@ -6,7 +6,7 @@ class C {
   }
 }
 
-var arr: [1..3] sync unmanaged C;
+var arr: [1..3] sync unmanaged C?;
 
 writeln("made it past declaration of arr");
   

--- a/test/parallel/sync/deitz/test_sync3.chpl
+++ b/test/parallel/sync/deitz/test_sync3.chpl
@@ -5,12 +5,12 @@ class C {
   var a,b : int;
 }
 
-var l : sync unmanaged C = new unmanaged C(1,2);
-var m : unmanaged C = l; //compiles without any error
+var l : sync unmanaged C? = new unmanaged C(1,2);
+var m : unmanaged C? = l; //compiles without any error
 
-var n : [1..5] sync unmanaged C;
+var n : [1..5] sync unmanaged C?;
 n[1] = new unmanaged C(3,4);
-var o : unmanaged C = n[1];
+var o : unmanaged C? = n[1];
 writeln(o);
 
 delete m;

--- a/test/parallel/taskPar/sungeun/private.chpl
+++ b/test/parallel/taskPar/sungeun/private.chpl
@@ -44,7 +44,7 @@ class localePrivateData {
   }
 }
 
-var localePrivate: [PrivateSpace] unmanaged localePrivateData(taskPrivateData);
+var localePrivate: [PrivateSpace] unmanaged localePrivateData(taskPrivateData)?;
 forall l in localePrivate do l = new unmanaged localePrivateData(taskPrivateData);
 
 // an example use
@@ -66,7 +66,7 @@ forall d in D {
 
 }
 
-if printTemps then writeln(localePrivate.temps);
+if printTemps then writeln(localePrivate!.temps);
 
 const numTasks = if dataParTasksPerLocale==0 then here.maxTaskPar
   else dataParTasksPerLocale;

--- a/test/parallel/taskPar/taskIntents/01-error-global.chpl
+++ b/test/parallel/taskPar/taskIntents/01-error-global.chpl
@@ -56,7 +56,7 @@ var z128: complex(128);
 var enm: EnumType;
 /* no records for now */
 /* no unions for now */
-var cls: unmanaged ClassType;
+var cls: unmanaged ClassType?;
 /* no tuples for now */
 var dom1: DomType1;
 var dom2: DomType2;

--- a/test/parallel/taskPar/taskIntents/02-error-local.chpl
+++ b/test/parallel/taskPar/taskIntents/02-error-local.chpl
@@ -57,7 +57,7 @@ var z128: complex(128);
 var enm: EnumType;
 /* no records for now */
 /* no unions for now */
-var cls: unmanaged ClassType;
+var cls: unmanaged ClassType?;
 /* no tuples for now */
 var dom1: DomType1;
 var dom2: DomType2;

--- a/test/parallel/taskPar/taskIntents/03-error-in-fun.chpl
+++ b/test/parallel/taskPar/taskIntents/03-error-in-fun.chpl
@@ -56,7 +56,7 @@ var z128: complex(128);
 var enm: EnumType;
 /* no records for now */
 /* no unions for now */
-var cls: unmanaged ClassType;
+var cls: unmanaged ClassType?;
 /* no tuples for now */
 var dom1: DomType1;
 var dom2: DomType2;
@@ -91,7 +91,7 @@ proc funBlank(
  enm: EnumType,
 /* no records for now */
 /* no unions for now */
- cls: unmanaged ClassType,
+ cls: unmanaged ClassType?,
 /* no tuples for now */
  dom1: DomType1,
  dom2: DomType2,
@@ -261,7 +261,7 @@ const z128: complex(128),
 const enm: EnumType,
 /* no records for now */
 /* no unions for now */
-const cls: unmanaged ClassType,
+const cls: unmanaged ClassType?,
 /* no tuples for now */
 const dom1: DomType1,
 const dom2: DomType2,
@@ -431,7 +431,7 @@ const in z128: complex(128),
 const in enm: EnumType,
 /* no records for now */
 /* no unions for now */
-const in cls: unmanaged ClassType,
+const in cls: unmanaged ClassType?,
 /* no tuples for now */
 const in dom1: DomType1,
 const in dom2: DomType2,
@@ -601,7 +601,7 @@ in z128: complex(128),
 in enm: EnumType,
 /* no records for now */
 /* no unions for now */
-in cls: unmanaged ClassType,
+in cls: unmanaged ClassType?,
 /* no tuples for now */
 in dom1: DomType1,
 in dom2: DomType2,
@@ -771,7 +771,7 @@ inout z128: complex(128),
 inout enm: EnumType,
 /* no records for now */
 /* no unions for now */
-inout cls: unmanaged ClassType,
+inout cls: unmanaged ClassType?,
 /* no tuples for now */
 inout dom1: DomType1,
 inout dom2: DomType2,
@@ -941,7 +941,7 @@ out z128: complex(128),
 out enm: EnumType,
 /* no records for now */
 /* no unions for now */
-out cls: unmanaged ClassType,
+out cls: unmanaged ClassType?,
 /* no tuples for now */
 out dom1: DomType1,
 out dom2: DomType2,
@@ -1111,7 +1111,7 @@ ref z128: complex(128),
 ref enm: EnumType,
 /* no records for now */
 /* no unions for now */
-ref cls: unmanaged ClassType,
+ref cls: unmanaged ClassType?,
 /* no tuples for now */
 ref dom1: DomType1,
 ref dom2: DomType2,
@@ -1281,7 +1281,7 @@ const ref z128: complex(128),
 const ref enm: EnumType,
 /* no records for now */
 /* no unions for now */
-const ref cls: unmanaged ClassType,
+const ref cls: unmanaged ClassType?,
 /* no tuples for now */
 const ref dom1: DomType1,
 const ref dom2: DomType2,

--- a/test/parallel/taskPar/taskIntents/11-capture-in-begin.chpl
+++ b/test/parallel/taskPar/taskIntents/11-capture-in-begin.chpl
@@ -61,7 +61,7 @@ var z128: complex(128);
 var enm: EnumType;
 /* no records for now */
 /* no unions for now */
-var cls: unmanaged ClassType;
+var cls: unmanaged ClassType?;
 /* no tuples for now */
 var dom1: DomType1;
 var dom2: DomType2;
@@ -196,7 +196,7 @@ var z128: complex(128);
 var enm: EnumType;
 /* no records for now */
 /* no unions for now */
-var cls: unmanaged ClassType;
+var cls: unmanaged ClassType?;
 /* no tuples for now */
 var dom1: DomType1;
 var dom2: DomType2;
@@ -334,7 +334,7 @@ var z128: complex(128);
 var enm: EnumType;
 /* no records for now */
 /* no unions for now */
-var cls: unmanaged ClassType;
+var cls: unmanaged ClassType?;
 /* no tuples for now */
 var dom1: DomType1;
 var dom2: DomType2;
@@ -474,7 +474,7 @@ var z128: complex(128);
 var enm: EnumType;
 /* no records for now */
 /* no unions for now */
-var cls: unmanaged ClassType;
+var cls: unmanaged ClassType?;
 /* no tuples for now */
 var dom1: DomType1;
 var dom2: DomType2;
@@ -612,7 +612,7 @@ var z128: complex(128);
 var enm: EnumType;
 /* no records for now */
 /* no unions for now */
-var cls: unmanaged ClassType;
+var cls: unmanaged ClassType?;
 /* no tuples for now */
 var dom1: DomType1;
 var dom2: DomType2;

--- a/test/parallel/taskPar/taskIntents/12-no-capture-in-begin.chpl
+++ b/test/parallel/taskPar/taskIntents/12-no-capture-in-begin.chpl
@@ -61,7 +61,7 @@ var z128: complex(128);
 var enm: EnumType;
 /* no records for now */
 /* no unions for now */
-var cls: unmanaged ClassType;
+var cls: unmanaged ClassType?;
 /* no tuples for now */
 var dom1: DomType1;
 var dom2: DomType2;
@@ -227,7 +227,7 @@ var z128: complex(128);
 var enm: EnumType;
 /* no records for now */
 /* no unions for now */
-var cls: unmanaged ClassType;
+var cls: unmanaged ClassType?;
 /* no tuples for now */
 var dom1: DomType1;
 var dom2: DomType2;
@@ -396,7 +396,7 @@ var z128: complex(128);
 var enm: EnumType;
 /* no records for now */
 /* no unions for now */
-var cls: unmanaged ClassType;
+var cls: unmanaged ClassType?;
 /* no tuples for now */
 var dom1: DomType1;
 var dom2: DomType2;
@@ -567,7 +567,7 @@ var z128: complex(128);
 var enm: EnumType;
 /* no records for now */
 /* no unions for now */
-var cls: unmanaged ClassType;
+var cls: unmanaged ClassType?;
 /* no tuples for now */
 var dom1: DomType1;
 var dom2: DomType2;
@@ -736,7 +736,7 @@ var z128: complex(128);
 var enm: EnumType;
 /* no records for now */
 /* no unions for now */
-var cls: unmanaged ClassType;
+var cls: unmanaged ClassType?;
 /* no tuples for now */
 var dom1: DomType1;
 var dom2: DomType2;

--- a/test/parallel/taskPar/taskIntents/21-capture-in-cobegin.chpl
+++ b/test/parallel/taskPar/taskIntents/21-capture-in-cobegin.chpl
@@ -61,7 +61,7 @@ var z128: complex(128);
 var enm: EnumType;
 /* no records for now */
 /* no unions for now */
-var cls: borrowed ClassType;
+var cls: borrowed ClassType?;
 /* no tuples for now */
 var dom1: DomType1;
 var dom2: DomType2;
@@ -295,7 +295,7 @@ var z128: complex(128);
 var enm: EnumType;
 /* no records for now */
 /* no unions for now */
-var cls: borrowed ClassType;
+var cls: borrowed ClassType?;
 /* no tuples for now */
 var dom1: DomType1;
 var dom2: DomType2;
@@ -532,7 +532,7 @@ var z128: complex(128);
 var enm: EnumType;
 /* no records for now */
 /* no unions for now */
-var cls: borrowed ClassType;
+var cls: borrowed ClassType?;
 /* no tuples for now */
 var dom1: DomType1;
 var dom2: DomType2;
@@ -771,7 +771,7 @@ var z128: complex(128);
 var enm: EnumType;
 /* no records for now */
 /* no unions for now */
-var cls: borrowed ClassType;
+var cls: borrowed ClassType?;
 /* no tuples for now */
 var dom1: DomType1;
 var dom2: DomType2;
@@ -1008,7 +1008,7 @@ var z128: complex(128);
 var enm: EnumType;
 /* no records for now */
 /* no unions for now */
-var cls: borrowed ClassType;
+var cls: borrowed ClassType?;
 /* no tuples for now */
 var dom1: DomType1;
 var dom2: DomType2;

--- a/test/parallel/taskPar/taskIntents/22-no-capture-in-cobegin.chpl
+++ b/test/parallel/taskPar/taskIntents/22-no-capture-in-cobegin.chpl
@@ -61,7 +61,7 @@ var z128: complex(128);
 var enm: EnumType;
 /* no records for now */
 /* no unions for now */
-var cls: borrowed ClassType;
+var cls: borrowed ClassType?;
 /* no tuples for now */
 var dom1: DomType1;
 var dom2: DomType2;
@@ -228,7 +228,7 @@ var z128: complex(128);
 var enm: EnumType;
 /* no records for now */
 /* no unions for now */
-var cls: borrowed ClassType;
+var cls: borrowed ClassType?;
 /* no tuples for now */
 var dom1: DomType1;
 var dom2: DomType2;
@@ -398,7 +398,7 @@ var z128: complex(128);
 var enm: EnumType;
 /* no records for now */
 /* no unions for now */
-var cls: borrowed ClassType;
+var cls: borrowed ClassType?;
 /* no tuples for now */
 var dom1: DomType1;
 var dom2: DomType2;
@@ -570,7 +570,7 @@ var z128: complex(128);
 var enm: EnumType;
 /* no records for now */
 /* no unions for now */
-var cls: borrowed ClassType;
+var cls: borrowed ClassType?;
 /* no tuples for now */
 var dom1: DomType1;
 var dom2: DomType2;
@@ -740,7 +740,7 @@ var z128: complex(128);
 var enm: EnumType;
 /* no records for now */
 /* no unions for now */
-var cls: borrowed ClassType;
+var cls: borrowed ClassType?;
 /* no tuples for now */
 var dom1: DomType1;
 var dom2: DomType2;

--- a/test/parallel/taskPar/taskIntents/31-capture-in-coforall.chpl
+++ b/test/parallel/taskPar/taskIntents/31-capture-in-coforall.chpl
@@ -61,7 +61,7 @@ var z128: complex(128);
 var enm: EnumType;
 /* no records for now */
 /* no unions for now */
-var cls: borrowed ClassType;
+var cls: borrowed ClassType?;
 /* no tuples for now */
 var dom1: DomType1;
 var dom2: DomType2;
@@ -297,7 +297,7 @@ var z128: complex(128);
 var enm: EnumType;
 /* no records for now */
 /* no unions for now */
-var cls: borrowed ClassType;
+var cls: borrowed ClassType?;
 /* no tuples for now */
 var dom1: DomType1;
 var dom2: DomType2;
@@ -536,7 +536,7 @@ var z128: complex(128);
 var enm: EnumType;
 /* no records for now */
 /* no unions for now */
-var cls: borrowed ClassType;
+var cls: borrowed ClassType?;
 /* no tuples for now */
 var dom1: DomType1;
 var dom2: DomType2;
@@ -777,7 +777,7 @@ var z128: complex(128);
 var enm: EnumType;
 /* no records for now */
 /* no unions for now */
-var cls: borrowed ClassType;
+var cls: borrowed ClassType?;
 /* no tuples for now */
 var dom1: DomType1;
 var dom2: DomType2;
@@ -1016,7 +1016,7 @@ var z128: complex(128);
 var enm: EnumType;
 /* no records for now */
 /* no unions for now */
-var cls: borrowed ClassType;
+var cls: borrowed ClassType?;
 /* no tuples for now */
 var dom1: DomType1;
 var dom2: DomType2;

--- a/test/parallel/taskPar/taskIntents/32-no-capture-in-coforall.chpl
+++ b/test/parallel/taskPar/taskIntents/32-no-capture-in-coforall.chpl
@@ -61,7 +61,7 @@ var z128: complex(128);
 var enm: EnumType;
 /* no records for now */
 /* no unions for now */
-var cls: unmanaged ClassType;
+var cls: unmanaged ClassType?;
 /* no tuples for now */
 var dom1: DomType1;
 var dom2: DomType2;
@@ -227,7 +227,7 @@ var z128: complex(128);
 var enm: EnumType;
 /* no records for now */
 /* no unions for now */
-var cls: unmanaged ClassType;
+var cls: unmanaged ClassType?;
 /* no tuples for now */
 var dom1: DomType1;
 var dom2: DomType2;
@@ -396,7 +396,7 @@ var z128: complex(128);
 var enm: EnumType;
 /* no records for now */
 /* no unions for now */
-var cls: unmanaged ClassType;
+var cls: unmanaged ClassType?;
 /* no tuples for now */
 var dom1: DomType1;
 var dom2: DomType2;
@@ -567,7 +567,7 @@ var z128: complex(128);
 var enm: EnumType;
 /* no records for now */
 /* no unions for now */
-var cls: unmanaged ClassType;
+var cls: unmanaged ClassType?;
 /* no tuples for now */
 var dom1: DomType1;
 var dom2: DomType2;
@@ -736,7 +736,7 @@ var z128: complex(128);
 var enm: EnumType;
 /* no records for now */
 /* no unions for now */
-var cls: unmanaged ClassType;
+var cls: unmanaged ClassType?;
 /* no tuples for now */
 var dom1: DomType1;
 var dom2: DomType2;

--- a/test/release/examples/benchmarks/lcals/LCALSDataTypes.chpl
+++ b/test/release/examples/benchmarks/lcals/LCALSDataTypes.chpl
@@ -35,7 +35,7 @@ module LCALSDataTypes {
     var num_suite_passes: int;
     var loop_samp_frac: real;
 
-    var ref_loop_stat: owned LoopStat;
+    var ref_loop_stat: owned LoopStat?;
 
     var loop_weights: [weight_group_dom] real;
 

--- a/test/release/examples/benchmarks/lcals/LCALSMain.chpl
+++ b/test/release/examples/benchmarks/lcals/LCALSMain.chpl
@@ -699,20 +699,17 @@ proc getVariantNames(lvids: [] bool) {
 
 proc computeReferenceLoopTimes() {
   var suite_info = getLoopSuiteRunInfo();
-  var ref_loop_stat = suite_info.ref_loop_stat.borrow();
-
-  var lstat0: LoopStat;
+  var ref_loop_stat: LoopStat = suite_info.ref_loop_stat.borrow()!;
 
   writeln("\n computeReferenceLoopTimes...");
 
-  lstat0 = ref_loop_stat;
+  var lstat0 = ref_loop_stat;
 
   for ilen in suite_info.loop_length_dom {
     runReferenceLoop0(lstat0, ilen);
   }
 
-  var lstat1: LoopStat;
-  lstat1 = ref_loop_stat;
+  var lstat1 = ref_loop_stat;
 
   for ilen in suite_info.loop_length_dom {
     runReferenceLoop1(lstat1, ilen);

--- a/test/release/examples/benchmarks/lcals/LCALSMain.compopts
+++ b/test/release/examples/benchmarks/lcals/LCALSMain.compopts
@@ -1,3 +1,4 @@
 # Run the abbreviated number of trials and don't print timing or
 # checksum output, or else we'd have to filter it out in testing
--sverify_checksums_abbreviated=true -soutputFormat=OutputStyle.MINIMAL
+# Pending #13721, run with the legacy option.
+--legacy-nilable-classes -sverify_checksums_abbreviated=true -soutputFormat=OutputStyle.MINIMAL

--- a/test/release/examples/benchmarks/lcals/LCALSStatic.chpl
+++ b/test/release/examples/benchmarks/lcals/LCALSStatic.chpl
@@ -1,7 +1,7 @@
 module LCALSStatic {
   use LCALSDataTypes;
 
-  var s_loop_data: owned LoopData;
+  var s_loop_data: owned LoopData?;
   var s_loop_suite_run_info = new owned LoopSuiteRunInfo();
 
   proc getLoopSuiteRunInfo() {
@@ -9,6 +9,6 @@ module LCALSStatic {
   }
 
   proc getLoopData() {
-    return s_loop_data.borrow();
+    return s_loop_data.borrow()!;
   }
 }

--- a/test/release/examples/benchmarks/shootout/binarytrees.chpl
+++ b/test/release/examples/benchmarks/shootout/binarytrees.chpl
@@ -64,7 +64,7 @@ proc main() {
 // A simple balanced tree node class
 //
 class Tree {
-  var left, right: unmanaged Tree;
+  var left, right: unmanaged Tree?;
 
   //
   // A Tree-building initializer
@@ -82,7 +82,7 @@ class Tree {
   proc sum(): int {
     var sum = 1;
     if left {
-      sum += left.sum() + right.sum();
+      sum += left!.sum() + right!.sum();
       delete left, right;
     }
     return sum;

--- a/test/release/examples/benchmarks/ssca2/SSCA2_Modules/SSCA2_kernels.chpl
+++ b/test/release/examples/benchmarks/ssca2/SSCA2_Modules/SSCA2_kernels.chpl
@@ -259,11 +259,13 @@ module SSCA2_kernels
           forall v in vertex_domain do
             tpv.BCaux[v].children_list.nd = {1..G.n_Neighbors[v]};
           for loc in Locales do on loc {
-            tpv.Active_Level[here.id] = new unmanaged Level_Set (Sparse_Vertex_List);
-            tpv.Active_Level[here.id].previous = nil;
-            tpv.Active_Level[here.id].next = new unmanaged Level_Set (Sparse_Vertex_List);;
-            tpv.Active_Level[here.id].next.previous = tpv.Active_Level[here.id];
-            tpv.Active_Level[here.id].next.next = nil;
+            const curr = new unmanaged Level_Set (Sparse_Vertex_List);
+            const next = new unmanaged Level_Set (Sparse_Vertex_List);
+            tpv.Active_Level[here.id] = curr;
+            curr.previous = nil;
+            curr.next = next;
+            next.previous = curr;
+            next.next = nil;
           }
       }
       var TPVM: unmanaged TPVManager(TPV.type) = new unmanaged TPVManager(TPV);
@@ -330,7 +332,7 @@ module SSCA2_kernels
 
         coforall loc in Locales with (ref remaining, ref barrier) do on loc {
           Active_Level[here.id].Members.clear();
-          Active_Level[here.id].next.Members.clear();
+          Active_Level[here.id].next!.Members.clear();
           if vertex_domain.dist.idxToLocale(s) == here {
             // Establish the initial level sets for the breadth-first
             // traversal from s
@@ -364,7 +366,7 @@ module SSCA2_kernels
                   // --------------------------------------------
   
                   if  BCaux[v].min_distance.compareExchangeStrong(-1, current_distance_c) {
-                    Active_Level[here.id].next.Members.add (v);
+                    Active_Level[here.id].next!.Members.add (v);
                     if VALIDATE_BC then
                       dist_temp = current_distance_c;
                   }
@@ -402,12 +404,12 @@ module SSCA2_kernels
             // barrier.notify(); // This is expensive without network atomics
             //  for now, just do a normal barrier
 
-            if Active_Level[here.id].next.next == nil {
-              Active_Level[here.id].next.next = new unmanaged Level_Set (Sparse_Vertex_List);
-              Active_Level[here.id].next.next.previous = Active_Level[here.id].next;
-              Active_Level[here.id].next.next.next = nil;
+            if Active_Level[here.id].next!.next == nil {
+              Active_Level[here.id].next!.next = new unmanaged Level_Set (Sparse_Vertex_List);
+              Active_Level[here.id].next!.next!.previous = Active_Level[here.id].next;
+              Active_Level[here.id].next!.next!.next = nil;
             } else {
-              Active_Level[here.id].next.next.Members.clear();
+              Active_Level[here.id].next!.next!.Members.clear();
             }
             // barrier.wait(); // ditto
             barrier.barrier();
@@ -416,7 +418,7 @@ module SSCA2_kernels
             }
 
             barrier.barrier();
-            Active_Level[here.id] = Active_Level[here.id].next;
+            Active_Level[here.id] = Active_Level[here.id].next!;
             if Active_Level[here.id].Members.numIndices:bool then
               remaining = true;
 
@@ -451,10 +453,10 @@ module SSCA2_kernels
           }
 
           // back up to last level
-          var curr_Level =  Active_Level[here.id].previous;
+          var curr_Level =  Active_Level[here.id].previous!;
   
           for current_distance in 2 .. graph_diameter by -1 {
-            curr_Level = curr_Level.previous;
+            curr_Level = curr_Level.previous!;
 
             for u in curr_Level.Members do on vertex_domain.dist.idxToLocale(u) {
                 f4(BCaux, Between_Cent$, u);
@@ -498,15 +500,15 @@ module SSCA2_kernels
           var tpv = TPV[t];
           var al = tpv.Active_Level;
           coforall loc in Locales do on loc {
-            var level = al[here.id];
-            var prev = level.previous;
+            var level = al[here.id]?;
+            var prev = level!.previous;
             while prev != nil {
-              var p2 = prev.previous;
+              var p2 = prev!.previous;
               delete prev;
               prev = p2;
             }
             while level != nil {
-                var l2 = level.next;
+                var l2 = level!.next;
                 delete level;
                 level = l2;
             }
@@ -535,8 +537,8 @@ module SSCA2_kernels
   class Level_Set {
     type Sparse_Vertex_List;
     var Members  : Sparse_Vertex_List;
-    var previous : unmanaged Level_Set (Sparse_Vertex_List);
-    var next : unmanaged Level_Set (Sparse_Vertex_List);
+    var previous : unmanaged Level_Set (Sparse_Vertex_List)?;
+    var next : unmanaged Level_Set (Sparse_Vertex_List)?;
   }
 
   //

--- a/test/runtime/ferguson/tdata-test.chpl
+++ b/test/runtime/ferguson/tdata-test.chpl
@@ -6,13 +6,14 @@
 config const setSerial=false;
 
 record stuff {
-  var oldE: _remoteEndCountType;
+  var oldE: _remoteEndCountType?;
   var oldS: bool;
-  var e: _remoteEndCountType;
+  var e: _remoteEndCountType?;
   var s: bool;
 
   proc deinit() {
-    _endCountFree(e);
+    if e then
+      _endCountFree(e!);
   }
 }
 
@@ -22,7 +23,7 @@ proc saveStuff() {
   ret.oldS = chpl_task_getSerial();
   ret.e = _endCountAlloc(false);
   ret.s = setSerial;
-  chpl_task_setDynamicEndCount(ret.e);
+  chpl_task_setDynamicEndCount(ret.e!);
   chpl_task_setSerial(ret.s);
   return ret;
 }

--- a/test/statements/defer/defer-manual-container-throws.chpl
+++ b/test/statements/defer/defer-manual-container-throws.chpl
@@ -6,8 +6,8 @@ class Thing {
 
 }
 class Container {
-  var a: unmanaged Thing;
-  var b: unmanaged Thing;
+  var a: unmanaged Thing?;
+  var b: unmanaged Thing?;
   proc deinit() {
     writeln("in Container.deinit");
   }
@@ -49,7 +49,7 @@ proc create_thing() {
     maybeThrows(3);
     // success!
     success = true;
-    return container;
+    return container?;
   } catch {
     return nil;
   }

--- a/test/statements/defer/defer-manual-container.chpl
+++ b/test/statements/defer/defer-manual-container.chpl
@@ -6,8 +6,8 @@ class Thing {
 
 }
 class Container {
-  var a: unmanaged Thing;
-  var b: unmanaged Thing;
+  var a: unmanaged Thing?;
+  var b: unmanaged Thing?;
   proc deinit() {
     writeln("in Container.deinit");
   }
@@ -20,9 +20,9 @@ proc shouldFail(x:int) {
   return x == failOnStep;
 }
 
-proc create_thing() : unmanaged Container {
+proc create_thing() : unmanaged Container? {
   var success = false;
-  var ret:unmanaged Container = nil;
+  var ret:unmanaged Container? = nil;
 
   writeln("creating Container");
   ret = new unmanaged Container();

--- a/test/studies/590o/alaska/graph.chpl
+++ b/test/studies/590o/alaska/graph.chpl
@@ -19,7 +19,7 @@ class Node {
   var name: string;
   var pos: unmanaged position = new unmanaged position(-1,-1);
   var color : colors = colors.WHITE;
-  var pred : unmanaged Node = nil;
+  var pred : unmanaged Node? = nil;
   var disc,fini : int = -1;
 
   proc writeThis(w){
@@ -400,7 +400,7 @@ class Graph {
 	 * From the non-treeEdges, we must find one with minimum slack
 	 */
 	var delta = 256;
-	var minEdge: unmanaged Edge = nil;
+	var minEdge: unmanaged Edge? = nil;
 	for e in incident_non_tree_edge() do {
 	    if(slack(e.id) < delta){
 	      delta = slack(e.id);

--- a/test/studies/590o/blerner/xml-parse.chpl
+++ b/test/studies/590o/blerner/xml-parse.chpl
@@ -29,7 +29,7 @@ class XmlTag : XmlElement {
   }
 }
 
-var parsedElements: [AllPairs] single unmanaged XmlElement;
+var parsedElements: [AllPairs] single unmanaged XmlElement?;
 
 proc main {
   forall z in AllIndices with (ref StartIndices, ref EndIndices) do {
@@ -60,7 +60,7 @@ proc main {
     writeln("Parse failed");
   else {
     writeln("Parse succeeded!");
-    parsedElements(minindex,maxindex).print;
+    parsedElements(minindex,maxindex)!.print;
   }
 
   for i in AllPairs do
@@ -146,7 +146,7 @@ proc processTag(i,j) {
   var elt = new unmanaged XmlTag(j-i+1, tagName);
   start = min reduce ([x in StartIndices] if x > start then x);
   while (start < stop) {
-    var item : unmanaged XmlElement = nil;
+    var item : unmanaged XmlElement? = nil;
     for e in EndIndices do
       if e > start && e < stop &&
         item == nil && parsedElements(start, e) != nil {
@@ -162,7 +162,7 @@ proc processTag(i,j) {
       if curSize == elt.numChildren then
         elt.childrenValueSpace = {1..curSize*2};
       elt.numChildren += 1;
-      elt.childrenValues(elt.numChildren) = item;
+      elt.childrenValues(elt.numChildren) = item!;
       start += item.length;
     }     
   }

--- a/test/studies/amr/lib/amr/AMRHierarchy_def.chpl
+++ b/test/studies/amr/lib/amr/AMRHierarchy_def.chpl
@@ -564,7 +564,6 @@ proc AMRHierarchy.deleteBoundaryStructures( i: int )
 class PhysicalBoundary
 {
 
-  const level:        unmanaged Level;
   const grids:        domain(unmanaged Grid);
   const multidomains: [grids] unmanaged MultiDomain(dimension,stridable=true);
 
@@ -777,13 +776,13 @@ proc LevelSolution.initialFill ( coarse_solution: unmanaged LevelSolution )
 //----------------------------------------------------------------
 
 proc LevelVariable.initialFill (
-  q_old:     unmanaged LevelVariable,
+  q_old:     unmanaged LevelVariable?,
   q_coarse:  unmanaged LevelVariable)
 {
 
   //---- Safety check ----
 
-  if q_old != nil then assert(this.level.n_cells == q_old.level.n_cells);
+  if q_old != nil then assert(this.level.n_cells == q_old!.level.n_cells);
 
   
   //---- Refinement ratio ----
@@ -810,7 +809,7 @@ proc LevelVariable.initialFill (
     if q_old != nil
     {
 
-      for old_grid in q_old.level.grids
+      for old_grid in q_old!.level.grids
       {
       
         var overlap = grid.cells( old_grid.cells );
@@ -849,14 +848,16 @@ proc LevelVariable.initialFill (
       
       if refined_coarse.numIndices > 0 
       {
-        
+
+       {
         var unfilled_intersection = unfilled_region.copy();
         unfilled_intersection.intersect( refined_coarse );
         
         for D in unfilled_intersection do
           this(grid,D) = q_coarse(coarse_grid).refineValues(D, ref_ratio);
         
-        delete unfilled_intersection;  unfilled_intersection=nil;
+        delete unfilled_intersection;
+       }
         
         unfilled_region.subtract( refined_coarse );
         if unfilled_region.isEmpty() then break;
@@ -876,7 +877,7 @@ proc LevelVariable.initialFill (
       
     }
     
-    delete unfilled_region;  unfilled_region = nil;
+    delete unfilled_region;
     
     //<=== Interpolate from q_coarse everywhere else <===
 
@@ -895,7 +896,7 @@ proc LevelVariable.initialFill (
 
 proc LevelVariable.initialFill ( q_coarse: unmanaged LevelVariable )
 {
-  const q_old: unmanaged LevelVariable;
+  const q_old: unmanaged LevelVariable?;
   initialFill( q_old, q_coarse );
 }
 // /|""""""""""""""""""""""""""""""""""/|

--- a/test/studies/amr/lib/amr/BergerRigoutsosClustering.chpl
+++ b/test/studies/amr/lib/amr/BergerRigoutsosClustering.chpl
@@ -109,7 +109,7 @@ class CandidateDomain {
   const D:          domain(rank,stridable=true);
   const flags:      [D] bool;
   const min_width:  rank*int;
-  var   signatures: rank*unmanaged ArrayWrapper;
+  var   signatures: rank*unmanaged ArrayWrapper?;
 
   //|\''''''''''''''''''''|\
   //| >    constructor    | >

--- a/test/studies/amr/lib/level/Level_def.chpl
+++ b/test/studies/amr/lib/level/Level_def.chpl
@@ -414,7 +414,7 @@ iter Level.ordered_grids {
   var grid_list = grids;
   
   while grid_list.numIndices > 0 {
-    var lowest_grid: unmanaged Grid;
+    var lowest_grid: unmanaged Grid?;
     var i_lowest = possible_ghost_cells.high;
 
     for grid in grid_list {
@@ -430,8 +430,8 @@ iter Level.ordered_grids {
       }
     }
     
-    yield lowest_grid;
-    grid_list.remove(lowest_grid);
+    yield lowest_grid!;
+    grid_list.remove(lowest_grid!);
   }
 }
 // /|"""""""""""""""""""""""""""""""""""""/|

--- a/test/studies/amr/lib/misc/BasicDataStructures.chpl
+++ b/test/studies/amr/lib/misc/BasicDataStructures.chpl
@@ -46,14 +46,14 @@ class List
 {
   
   type data_type;
-  var head: unmanaged Node(data_type);
+  var head: unmanaged Node(data_type)?;
   
   
   class Node 
   {
     type data_type;
     var data: data_type;
-    var next: unmanaged Node(data_type);
+    var next: unmanaged Node(data_type)?;
   }
   
   
@@ -77,7 +77,7 @@ class List
   
   proc clear ()
   {
-    var next_node: unmanaged Node(data_type);
+    var next_node: unmanaged Node(data_type)?;
     
     while head {
       next_node = head.next;
@@ -109,13 +109,13 @@ class Stack
 {
 
   type data_type;
-  var top:  unmanaged Node(data_type);
+  var top:  unmanaged Node(data_type)?;
 
   
   class Node {
     type data_type;
     var data: data_type;
-    var next: unmanaged Node(data_type);
+    var next: unmanaged Node(data_type)?;
   }
 
 
@@ -135,8 +135,8 @@ class Stack
   {
     if isEmpty() then halt("Attempting to pop off an empty stack.");
     
-    var data_out = top.data;
-    var new_top  = top.next;
+    var data_out = top!.data;
+    var new_top  = top!.next;
     delete top;
     top = new_top;
 
@@ -166,14 +166,14 @@ class Queue
 {
   
   type data_type;
-  var head: unmanaged Node(data_type);
-  var tail: unmanaged Node(data_type);
+  var head: unmanaged Node(data_type)?;
+  var tail: unmanaged Node(data_type)?;
 
   class Node {
     type data_type;
     var data: data_type;
-    var prev: unmanaged Node(data_type);
-    var next: unmanaged Node(data_type);
+    var prev: unmanaged Node(data_type)?;
+    var next: unmanaged Node(data_type)?;
   }
 
 


### PR DESCRIPTION
Get a bunch more tests to pass with `--no-legacy-nilable-classes`,
with fixes to compiler and modules.

A couple of things of note.

* This fixes the compiler not to complain about "Cannot default-initialize"
  for params - they will get a "not of a supported param type" anyway.

* In `SSCA2`, I would replace lots of `Active_Level[here.id]` with a const.
  However that would be considered a style change and so would necessitate
  review by a wider subset of the group. This is more than I am shooting for
  in this PR. Also, some `Active_Level[here.id]` would not be replaceable
  as elegantly due to differing `here`, so I'd leave them as-is.
  At which point the replacement loses its appeal of elegance to me.

* In `Sort.chpl`, the helper functions `chpl_check_comparator()` and
  `radixSortOk()` play it loose with default-initalizing non-nilable
  variables. Given that we probably want those variables to have
  non-nilable types and that these functions are `param` so initializing
  them wouldn't help, I just marked them with `pragma "unsafe"`.
  Makes me wonder if all `param` functions should/could be considered
  "unsafe" in this regard.

* In AMR / `BergerRigoutsosClustering.chpl`, I have a better fix
  to keep the `signatures` field non-nilable. I do so by making a recursive
  function that computes the desired tuple and stores it into the field.
  This fix hits a limitation of `_createFieldDefaults()` so can't go in
  right now. I have a fix for that limitation, after which I can come back
  and revisit `signatures`.

* Wow getting AMR to pass the checks really took some work!

* There is an interesting pattern in `AMRHierarchy_def.chpl` :

```chpl
var refined_coarse = <something non-nilable>;
... lots of method calls on refined_coarse ...

var unfilled_intersection = <something else non-nilable>;
... lots of method calls on unfilled_intersection ...
delete unfilled_intersection;  unfilled_intersection = nil;

... lots more method calls on refined_coarse ...
delete unfilled_region;  unfilled_region = nil;
```

We surely want these two variables to be non-nilable, to avoid
the `!` operators every time a method is invoked on one of them.
This unfortunately conflicts with our desire to set them to `nil`
once we are done with them, to ensure they are not used afterwards.
I point this out as a familiar C-like idiom that is not smooth here.
Of course, the user should not be using `unmanaged` pointers. :)

Testing:
- [x] linux64 -futures
