### PR TITLE
Fix 'new' as a default expression

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -6701,12 +6701,17 @@ static void handleUnstableNewError(CallExpr* newExpr, Type* newType) {
 }
 
 static bool isUndecoratedClassNew(CallExpr* newExpr, Type* newType) {
+  bool isUndecorated = false;
+
   INT_ASSERT(newExpr->parentSymbol);
   if (isClass(newType) &&
       !isReferenceType(newType) &&
       !newType->symbol->hasFlag(FLAG_DATA_CLASS) &&
       !newType->symbol->hasFlag(FLAG_NO_OBJECT) &&
       !newType->symbol->hasFlag(FLAG_NO_DEFAULT_FUNCTIONS)) {
+
+    // Assume it is undecorated and below we will determine if otherwise
+    isUndecorated = true;
 
     SymExpr* checkSe = NULL;
     if (CallExpr* parentCall = toCallExpr(newExpr->parentExpr))
@@ -6718,29 +6723,32 @@ static bool isUndecoratedClassNew(CallExpr* newExpr, Type* newType) {
     if (checkSe) {
       for_SymbolSymExprs(se, checkSe->symbol()) {
         // Check that 'new' was used either in
-        // chpl__toraw or in an initialization of Owned/Shared/etc.
+        // PRIM_TO_UNMANAGED_CLASS or in an initialization of Owned/Shared/etc.
         if (se == checkSe) {
-          // OK
+          // do nothing
         } else if (CallExpr* parentCall = toCallExpr(se->parentExpr)) {
           if (parentCall->isNamed("chpl__tounmanaged") || // TODO -- remove case
               parentCall->isNamed("chpl__delete") || // TODO -- remove case
               parentCall->isNamed("chpl__buildDistValue") ||
               parentCall->isNamed("chpl_fix_thrown_error")) {
-            // OK
+            // treat these as decorated
+            isUndecorated = false;
           } else if (parentCall->isPrimitive(PRIM_NEW) &&
                      parentCall->get(1)->typeInfo()->symbol->hasFlag(FLAG_MANAGED_POINTER)) {
             // OK e.g. new Owned(new MyClass())
+            isUndecorated = false;
           } else if (parentCall->isPrimitive(PRIM_TO_UNMANAGED_CLASS)) {
             // OK e.g. new raw MyClass() / new owned MyClass()
+            isUndecorated = false;
           } else {
-            return true;
+            // do nothing (this use is undecorated)
           }
         }
       }
     }
   }
 
-  return false;
+  return isUndecorated;
 }
 
 static void warnForThrowNotOwned(CallExpr* newExpr, Type* newType, Type* manager) {

--- a/test/classes/delete-free/default-arg-typeless-error.chpl
+++ b/test/classes/delete-free/default-arg-typeless-error.chpl
@@ -1,0 +1,14 @@
+class C {
+  var x: int;
+}
+
+proc bar(c = new C()) {
+  writeln(c.type:string);
+  writeln(c);
+}
+
+writeln("Default bar");
+bar();
+
+writeln("Supplied unmanaged C");
+bar(new unmanaged C());

--- a/test/classes/delete-free/default-arg-typeless-error.compopts
+++ b/test/classes/delete-free/default-arg-typeless-error.compopts
@@ -1,0 +1,1 @@
+--legacy-nilable-classes

--- a/test/classes/delete-free/default-arg-typeless-error.good
+++ b/test/classes/delete-free/default-arg-typeless-error.good
@@ -1,0 +1,4 @@
+default-arg-typeless-error.chpl:14: error: unresolved call 'bar(unmanaged C)'
+default-arg-typeless-error.chpl:5: note: this candidate did not match: bar(c = newC())
+default-arg-typeless-error.chpl:14: note: because call actual argument #1 with type unmanaged C
+default-arg-typeless-error.chpl:5: note: is passed to formal 'c: owned C'

--- a/test/classes/delete-free/default-arg-typeless-legacy.chpl
+++ b/test/classes/delete-free/default-arg-typeless-legacy.chpl
@@ -1,0 +1,1 @@
+default-arg-typeless.chpl

--- a/test/classes/delete-free/default-arg-typeless-legacy.compopts
+++ b/test/classes/delete-free/default-arg-typeless-legacy.compopts
@@ -1,0 +1,1 @@
+--legacy-nilable-classes

--- a/test/classes/delete-free/default-arg-typeless-legacy.good
+++ b/test/classes/delete-free/default-arg-typeless-legacy.good
@@ -1,5 +1,5 @@
 Calling foo
-owned C
+borrowed C
 {x = 0}
 Calling bar
 owned C

--- a/test/classes/delete-free/default-arg-typeless.chpl
+++ b/test/classes/delete-free/default-arg-typeless.chpl
@@ -3,12 +3,23 @@ class C {
 }
 
 proc foo(c: C = new C()) {
+  writeln(c.type:string);
   writeln(c);
 }
+writeln("Calling foo");
+foo(new C());
 
 proc bar(c = new C()) {
+  writeln(c.type:string);
   writeln(c);
 }
 
-writeln("Supplied bar");
+writeln("Calling bar");
 bar(new C());
+
+proc baz(c: borrowed C = new C()) {
+  writeln(c.type:string);
+  writeln(c);
+}
+writeln("Calling baz");
+baz(new owned C());


### PR DESCRIPTION
Resolves #12638

The problem with the tests shown in that issue was that some of the logic
detecting undecorated `new` was not handling the case of the `new` being
the defaultExpr for an ArgSymbol. The problem was only present with
`--no-legacy-nilable-classes` for other reasons.

Reviewed by @benharsh - thanks!

- [x] full local testing