### PR TITLE
Add gasnet-ibv-fast and gasnet-mpi performance testing

### DIFF
--- a/util/cron/test-perf.cray-cs.gasnet-ibv.fast.bash
+++ b/util/cron/test-perf.cray-cs.gasnet-ibv.fast.bash
@@ -9,11 +9,12 @@ export CHPL_TEST_PERF_CONFIG_NAME='16-node-cs'
 source $CWD/common-perf.bash
 export CHPL_TEST_PERF_DIR=/cray/css/users/chapelu/NightlyPerformance/cray-cs/16-node-cs
 
-export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.cray-cs.gasnet-ibv.large"
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.cray-cs.gasnet-ibv.fast"
 
 module load gcc
 
 export CHPL_HOST_PLATFORM=cray-cs
+export CHPL_GASNET_SEGMENT=fast
 export GASNET_PHYSMEM_MAX=83G
 export GASNET_ODP_VERBOSE=0
 export CHPL_LAUNCHER=slurm-gasnetrun_ibv
@@ -21,7 +22,7 @@ export CHPL_LAUNCHER_PARTITION=bdw18
 export CHPL_TARGET_CPU=broadwell
 nightly_args="${nightly_args} -no-buildcheck"
 
-perf_args="-performance-description gn-ibv-large -performance-configs gn-ibv-large:v,gn-ibv-fast:v,gn-mpi"
-perf_args="${perf_args} -performance -perflabel ml- -numtrials 3 -startdate 07/01/19"
+perf_args="-performance-description gn-ibv-fast -performance-configs gn-ibv-large:v,gn-ibv-fast:v,gn-mpi"
+perf_args="${perf_args} -performance -perflabel ml- -numtrials 1 -startdate 07/01/19"
 
 $CWD/nightly -cron ${perf_args} ${nightly_args}

--- a/util/cron/test-perf.cray-cs.gasnet-mpi.bash
+++ b/util/cron/test-perf.cray-cs.gasnet-mpi.bash
@@ -9,19 +9,20 @@ export CHPL_TEST_PERF_CONFIG_NAME='16-node-cs'
 source $CWD/common-perf.bash
 export CHPL_TEST_PERF_DIR=/cray/css/users/chapelu/NightlyPerformance/cray-cs/16-node-cs
 
-export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.cray-cs.gasnet-ibv.large"
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.cray-cs.gasnet-mpi"
 
 module load gcc
+module load openmpi/gcc
 
 export CHPL_HOST_PLATFORM=cray-cs
-export GASNET_PHYSMEM_MAX=83G
-export GASNET_ODP_VERBOSE=0
-export CHPL_LAUNCHER=slurm-gasnetrun_ibv
+export CHPL_COMM_SUBSTRATE=mpi
+export GASNET_QUIET=y
+export CHPL_LAUNCHER=slurm-gasnetrun_mpi
 export CHPL_LAUNCHER_PARTITION=bdw18
 export CHPL_TARGET_CPU=broadwell
 nightly_args="${nightly_args} -no-buildcheck"
 
-perf_args="-performance-description gn-ibv-large -performance-configs gn-ibv-large:v,gn-ibv-fast:v,gn-mpi"
-perf_args="${perf_args} -performance -perflabel ml- -numtrials 3 -startdate 07/01/19"
+perf_args="-performance-description gn-mpi -performance-configs gn-ibv-large:v,gn-ibv-fast:v,gn-mpi"
+perf_args="${perf_args} -performance -perflabel ml- -numtrials 1 -startdate 07/01/19"
 
 $CWD/nightly -cron ${perf_args} ${nightly_args}


### PR DESCRIPTION
ibv-fast to compare to our existing ibv-large, and gasnet mpi just to
track over time (it's not a configuration whose performance we care
deeply about)

For both just run 1 trial since ibv-fast has a long startup time, and
mpi isn't that important.

Closes https://github.com/Cray/chapel-private/issues/321