### PR TITLE
Remove array-as-vec operations from my userAPI test

### DIFF
--- a/test/arrays/userAPI/arrayAPItest.chpl
+++ b/test/arrays/userAPI/arrayAPItest.chpl
@@ -87,27 +87,9 @@ proc testArrayAPI1D(lbl, X: [], sliceDom, reindexDom) {
     writeln("reindexed X[", i, "] = ", x);
   writeln();
   // Test vector ops
-  if testError == 2 then
-    X.push_back(99.99);
-  if testError == 3 then
-    writeln(X.pop_back());
-  if testError == 4 then
-    X.push_front(99.99);
-  if testError == 5 then
-    writeln(X.pop_front());
-  if testError == 6 then
-    X.insert(3, 99.99);
-  if testError == 7 then
-    X.remove(3);
-  if testError == 8 then
-    X.remove(3, 1);
-  if testError == 9 then
-    X.remove(3..3);
+  // Test sparse-specific things
   if testError == 10 then
     X.reverse();
-  if testError == 11 then
-    X.clear();
-  // Test sparse-specific things
   if testError == 12 then
     writeln("IRV is: ", X.IRV);
   // Test sorted iterator
@@ -232,26 +214,8 @@ proc testArrayAPI2D(lbl, X: [], sliceDom, reindexDom) {
   writeln();
 
   // Test vector ops
-  if testError == 2 then
-    X.push_back(99.99);
-  if testError == 3 then
-    writeln(X.pop_back());
-  if testError == 4 then
-    X.push_front(99.99);
-  if testError == 5 then
-    writeln(X.pop_front());
-  if testError == 6 then
-    X.insert(3, 99.99);
-  if testError == 7 then
-    X.remove(3);
-  if testError == 8 then
-    X.remove(3, 1);
-  if testError == 9 then
-    X.remove(3..3);
   if testError == 10 then
     X.reverse();
-  if testError == 11 then
-    X.clear();
   
   // Test sparse-specific things
   if testError == 12 then

--- a/test/arrays/userAPI/arrayAPItest.chpl
+++ b/test/arrays/userAPI/arrayAPItest.chpl
@@ -87,9 +87,9 @@ proc testArrayAPI1D(lbl, X: [], sliceDom, reindexDom) {
     writeln("reindexed X[", i, "] = ", x);
   writeln();
   // Test vector ops
-  // Test sparse-specific things
   if testError == 10 then
     X.reverse();
+  // Test sparse-specific things
   if testError == 12 then
     writeln("IRV is: ", X.IRV);
   // Test sorted iterator

--- a/test/arrays/userAPI/arrayOps2D-IRV.good
+++ b/test/arrays/userAPI/arrayOps2D-IRV.good
@@ -1,2 +1,2 @@
-./arrayAPItest.chpl:121: In function 'testArrayAPI2D':
-./arrayAPItest.chpl:258: error: only sparse arrays have an IRV
+./arrayAPItest.chpl:103: In function 'testArrayAPI2D':
+./arrayAPItest.chpl:222: error: only sparse arrays have an IRV

--- a/test/arrays/userAPI/arrayOps2D-clear.good
+++ b/test/arrays/userAPI/arrayOps2D-clear.good
@@ -1,2 +1,0 @@
-./arrayAPItest.chpl:121: In function 'testArrayAPI2D':
-./arrayAPItest.chpl:254: error: clear() is only supported on dense 1D arrays

--- a/test/arrays/userAPI/arrayOps2D-insert.good
+++ b/test/arrays/userAPI/arrayOps2D-insert.good
@@ -1,2 +1,0 @@
-./arrayAPItest.chpl:121: In function 'testArrayAPI2D':
-./arrayAPItest.chpl:244: error: insert() is only supported on dense 1D arrays

--- a/test/arrays/userAPI/arrayOps2D-popback.good
+++ b/test/arrays/userAPI/arrayOps2D-popback.good
@@ -1,2 +1,0 @@
-./arrayAPItest.chpl:121: In function 'testArrayAPI2D':
-./arrayAPItest.chpl:238: error: pop_back() is only supported on dense 1D arrays

--- a/test/arrays/userAPI/arrayOps2D-popfront.good
+++ b/test/arrays/userAPI/arrayOps2D-popfront.good
@@ -1,2 +1,0 @@
-./arrayAPItest.chpl:121: In function 'testArrayAPI2D':
-./arrayAPItest.chpl:242: error: pop_front() is only supported on dense 1D arrays

--- a/test/arrays/userAPI/arrayOps2D-pushback.good
+++ b/test/arrays/userAPI/arrayOps2D-pushback.good
@@ -1,2 +1,0 @@
-./arrayAPItest.chpl:121: In function 'testArrayAPI2D':
-./arrayAPItest.chpl:236: error: push_back() is only supported on dense 1D arrays

--- a/test/arrays/userAPI/arrayOps2D-pushfront.good
+++ b/test/arrays/userAPI/arrayOps2D-pushfront.good
@@ -1,2 +1,0 @@
-./arrayAPItest.chpl:121: In function 'testArrayAPI2D':
-./arrayAPItest.chpl:240: error: push_front() is only supported on dense 1D arrays

--- a/test/arrays/userAPI/arrayOps2D-remove.good
+++ b/test/arrays/userAPI/arrayOps2D-remove.good
@@ -1,2 +1,0 @@
-./arrayAPItest.chpl:121: In function 'testArrayAPI2D':
-./arrayAPItest.chpl:246: error: remove() is only supported on dense 1D arrays

--- a/test/arrays/userAPI/arrayOps2D-remove2.good
+++ b/test/arrays/userAPI/arrayOps2D-remove2.good
@@ -1,2 +1,0 @@
-./arrayAPItest.chpl:121: In function 'testArrayAPI2D':
-./arrayAPItest.chpl:248: error: remove() is only supported on dense 1D arrays

--- a/test/arrays/userAPI/arrayOps2D-remove3.good
+++ b/test/arrays/userAPI/arrayOps2D-remove3.good
@@ -1,2 +1,0 @@
-./arrayAPItest.chpl:121: In function 'testArrayAPI2D':
-./arrayAPItest.chpl:250: error: remove() is only supported on dense 1D arrays

--- a/test/arrays/userAPI/arrayOps2D-reverse.good
+++ b/test/arrays/userAPI/arrayOps2D-reverse.good
@@ -1,2 +1,2 @@
-./arrayAPItest.chpl:121: In function 'testArrayAPI2D':
-./arrayAPItest.chpl:252: error: reverse() is only supported on dense 1D arrays
+./arrayAPItest.chpl:103: In function 'testArrayAPI2D':
+./arrayAPItest.chpl:218: error: reverse() is only supported on dense 1D arrays

--- a/test/arrays/userAPI/arrayOps2D-sorted.good
+++ b/test/arrays/userAPI/arrayOps2D-sorted.good
@@ -1,2 +1,2 @@
-./arrayAPItest.chpl:121: In function 'testArrayAPI2D':
-./arrayAPItest.chpl:263: error: sort() requires 1-D array
+./arrayAPItest.chpl:103: In function 'testArrayAPI2D':
+./arrayAPItest.chpl:227: error: sort() requires 1-D array

--- a/test/arrays/userAPI/arrayOps2D.compopts
+++ b/test/arrays/userAPI/arrayOps2D.compopts
@@ -1,14 +1,5 @@
                # arrayOps2D.good
--stestError=2  # arrayOps2D-pushback.good
--stestError=3  # arrayOps2D-popback.good
--stestError=4  # arrayOps2D-pushfront.good
--stestError=5  # arrayOps2D-popfront.good
--stestError=6  # arrayOps2D-insert.good
--stestError=7  # arrayOps2D-remove.good
--stestError=8  # arrayOps2D-remove2.good
--stestError=9  # arrayOps2D-remove3.good
 -stestError=10 # arrayOps2D-reverse.good
--stestError=11 # arrayOps2D-clear.good
 -stestError=12 # arrayOps2D-IRV.good
 -stestError=13 # arrayOps2D-sorted.good
 


### PR DESCRIPTION
This test was designed to try all of the routines in the user's API
for arrays, which included the array-as-vec operations.  Now that
we've moved those operations to the 'list' type, there's no need to
test those operations anymore.