### PR TITLE
Update implementation of anonymous counted range optimization for #0

### DIFF
--- a/modules/internal/ChapelRange.chpl
+++ b/modules/internal/ChapelRange.chpl
@@ -1882,7 +1882,7 @@ proc _cast(type t, r: range(?)) where isRangeType(t) {
     if boundsChecking && isIntType(count.type) && count < 0 then
       HaltWrappers.boundsCheckHalt("With a negative count, the range must have a last index.");
 
-    const (start, end) = if count == 0 then (1:low.type, 0:low.type)
+    const (start, end) = if count == 0 then (low, low - 1)
                                        else (low, low + (count:low.type - 1));
 
     for i in chpl_direct_param_stride_range_iter(start, end, 1) do yield i;

--- a/test/types/range/elliot/anonymousCountedRange.chpl
+++ b/test/types/range/elliot/anonymousCountedRange.chpl
@@ -1,7 +1,15 @@
-proc testAnonRanges(type lowT, type countT) {
+proc testAnonRanges(type lowT, type countT, param testErrors = false) {
   var zero = 0:countT;
-  for i in 0:lowT..#(0:countT)               do write(i, ' '); writeln();
-  for i in 0:lowT..#(zero)                   do write(i, ' '); writeln();
+  // Applying #0 to a 0.. uint range results in wraparound leading to an
+  // error when trying to iterate over it, so skip those cases unless we
+  // want to make sure the error is generated
+  if (isIntType(lowT) || testErrors) {
+    for i in 0:lowT..#(0:countT)               do write(i, ' '); writeln();
+    for i in 0:lowT..#(zero)                   do write(i, ' '); writeln();
+  } else {
+    writeln();
+    writeln();
+  }
   for i in 0:lowT..#(1:countT)               do write(i, ' '); writeln();
   for i in 0:lowT..#(10:countT) by 2:lowT    do write(i, ' '); writeln();
   for i in (0:lowT.. by 2:lowT) #(10:countT) do write(i, ' '); writeln();
@@ -19,3 +27,4 @@ testAnonRanges(8);
 testAnonRanges(16);
 testAnonRanges(32);
 testAnonRanges(64);
+testAnonRanges(uint(64), int(64), true);

--- a/test/types/range/elliot/anonymousCountedRange.good
+++ b/test/types/range/elliot/anonymousCountedRange.good
@@ -94,3 +94,4 @@
 0 2 4 6 8 
 0 2 4 6 8 10 12 14 16 18 
 10 11 12 13 14 15 16 17 18 19 
+anonymousCountedRange.chpl:7: error: halt reached - Iteration over a bounded range may be incorrect due to overflow.


### PR DESCRIPTION
This fixes the anonymous counted range optimization for the case of
applying #0 to make it match the module code when the optimization
does not fire.  The difference in behavior was revealed by running
--baseline on anonymousCountedRange.chpl.

In more detail, PR #13673, the definition of #0 was changed to
preserve bounds rather than returning 1..0 as it did previously.
However, in that PR, I failed to note that the anonymous range
optimization also special-cased #0 to map it to 1..0 for
consistency.  Here, I change its implementation to use lo..lo-1
(since it currently only supports unstrided ranges, otherwise it
should use lo..lo-stride) instead, making the behavior consistent
with the normal range module code.

I also updated the anonymousCountedRange test to avoid applying
Then I have it try it as a final measure to make sure that the
error message is generated consistently whether run with or without
--baseline