### PR TITLE
Fix recently introduced memory leaks

### DIFF
--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1062,10 +1062,10 @@ module DefaultRectangular {
           chpl_call_free_func(externFreeFunc, c_ptrTo(data));
         }
       } else {
+        var numElts:intIdxType = 0;
         if dom.dsiNumIndices > 0 || dataAllocRange.length > 0 {
           param needsDestroy = __primitive("needs auto destroy",
                                            __primitive("deref", data[0]));
-          var numElts:intIdxType = 0;
           // dataAllocRange may be empty or contain a meaningful value
           if rank == 1 && !stridable then
             numElts = dataAllocRange.length;
@@ -1075,8 +1075,8 @@ module DefaultRectangular {
           if needsDestroy {
             dsiDestroyDataHelper(data, numElts);
           }
-          _ddata_free(data, numElts);
         }
+        _ddata_free(data, numElts);
       }
     }
 


### PR DESCRIPTION
Free 'data' memory in dsiDestroyArr() even for 0-length arrays

Always free the 'data' memory instead of only for positive length arrays. This
should clear up some recently added memory leaks.