### PR TITLE
Fix mason build failure introduced by #13530

### DIFF
--- a/tools/mason/MasonSearch.chpl
+++ b/tools/mason/MasonSearch.chpl
@@ -32,6 +32,15 @@ use Regexp;
 // - allow for exclusion of a pattern
 //
 
+//
+// Temporary passthrough transforming array to list to appease the compiler.
+//
+proc masonSearch(args: [?d] string) {
+  var listArgs: list(string);
+  for x in args do listArgs.append(x);
+  masonSearch(listArgs);
+}
+
 proc masonSearch(ref args: list(string)) {
   if hasOptions(args, "-h", "--help") {
     masonSearchHelp();

--- a/tools/mason/MasonSystem.chpl
+++ b/tools/mason/MasonSystem.chpl
@@ -147,7 +147,11 @@ proc printPkgPc(args) throws {
     try! {
       const pkgName = args[3];
       if pkgExists(pkgName) {
-        var pcDir = "".join(getPkgVariable(pkgName, "--variable=pcfiledir")).strip();
+        //
+        // Add a these call, since `string.join` has an iterator overload but
+        // not one for list.
+        //
+        var pcDir = "".join(getPkgVariable(pkgName, "--variable=pcfiledir").these()).strip();
         var pcFile = joinPath(pcDir, pkgName + ".pc");
         var pc = open(pcFile, iomode.r);
         writeln("\n------- " + pkgName + ".pc -------\n");

--- a/tools/mason/MasonUpdate.chpl
+++ b/tools/mason/MasonUpdate.chpl
@@ -43,6 +43,15 @@ The current resolution strategy for Mason 0.1.0 is the IVRS as described below:
 
 private var failedChapelVersion: list(string);
 
+//
+// Temporary passthrough transforming array to list to appease the compiler.
+//
+proc UpdateLock(args: [?d] string, tf="Mason.toml", lf="Mason.lock") {
+  var listArgs: list(string);
+  for x in args do listArgs.append(x);
+  return UpdateLock(listArgs, tf, lf);
+}
+
 /* Finds a Mason.toml file and updates the Mason.lock
    generating one if it doesnt exist */
 proc UpdateLock(args: list(string), tf="Mason.toml", lf="Mason.lock") {


### PR DESCRIPTION
This PR fixes compiler errors that prevented `mason` from building. The errors were introduced from the merge of #13530. Shamefully, I never thought to build mason itself before merging that PR.

I fixed the compiler errors by adding overloads of the unresolved methods that convert an array to a list before passing it on, as a temporary fix.

Testing:

- [x] `cd tools/mason && make` on `linux64` with `COMM=none`
- [x] `test/mason` on `linux64` with `COMM=none`
