### PR TITLE
Update some multilocale C interop tests to not use + with strings and values

### DIFF
--- a/test/interop/C/multilocale/boolArgAndReturn.chpl
+++ b/test/interop/C/multilocale/boolArgAndReturn.chpl
@@ -1,7 +1,7 @@
 // Chapel file that exports functions: one that takes an bool, one that returns
 // an bool, and one that does both.
 export proc take(x: bool) {
-  writeln("Was given x: " + x);
+  writeln("Was given x: ", x);
 }
 
 export proc give(): bool {

--- a/test/interop/C/multilocale/checkMultipleLocales.chpl
+++ b/test/interop/C/multilocale/checkMultipleLocales.chpl
@@ -7,9 +7,10 @@ export proc foo(tasksPerLocale: int) {
         var message = "Hello, world! (from ";
 
         if (tasksPerLocale > 1) then
-          message += "task " + tid + " of " + tasksPerLocale + " on ";
+          message += "task " + tid: string + " of " + tasksPerLocale:string +
+            " on ";
 
-        message += "locale " + here.id + " of " + numLocales;
+        message += "locale " + here.id:string + " of " + numLocales: string;
 
         message += ")";
         writeln(message);

--- a/test/interop/C/multilocale/intArgAndReturn.chpl
+++ b/test/interop/C/multilocale/intArgAndReturn.chpl
@@ -1,7 +1,7 @@
 // Chapel file that exports functions: one that takes an int, one that returns
 // an int, and one that does both.
 export proc take(x: int) {
-  writeln("Was given x: " + x);
+  writeln("Was given x: ", x);
 }
 
 export proc give(): int {

--- a/test/interop/C/multilocale/multipleArgs.chpl
+++ b/test/interop/C/multilocale/multipleArgs.chpl
@@ -2,15 +2,15 @@
 // nothing, one that takes multiple args of different types, and one that takes
 // multiple args and returns something
 export proc take2(x: int, y: int) {
-  writeln("Was given x: " + x + ", and y: " + y);
+  writeln("Was given x: ", x, ", and y: ", y);
 }
 
 export proc take2Diff(x: int, y: c_string) {
   writeln("string is: " + y: string);
-  writeln("int is: " + x);
+  writeln("int is: ", x);
 }
 
 export proc take2AndReturn(x: int, y: int): int {
-  writeln("x + y = " + (x + y));
+  writeln("x + y = ", (x + y));
   return x + y;
 }

--- a/test/interop/C/multilocale/realArgAndReturn.chpl
+++ b/test/interop/C/multilocale/realArgAndReturn.chpl
@@ -3,7 +3,7 @@
 export proc take(x: real) {
   var xFloor = floor(x);
   var xCeiling = ceil(x);
-  writeln("Was given x in range of: " + xFloor + " and " + xCeiling);
+  writeln("Was given x in range of: ", xFloor, " and ", xCeiling);
 }
 
 export proc give(): real {


### PR DESCRIPTION
These tests were overlooked in the initial PR and the follow up for python
interoperability because I forgot they only run on Macs.  Whoops.

Tested locally, not reviewed