### PR TITLE
Fix failure of test/mason/spack-integration/mason-external.chpl caused by #13530

### DIFF
--- a/test/mason/spack-integration/mason-external.chpl
+++ b/test/mason/spack-integration/mason-external.chpl
@@ -8,11 +8,11 @@ proc main() {
   setupSpack();
 
   // Download and install openBLAS 0.2.20 and build with GCC
-  var args: [0..3] string = ["mason", "external", "install", "openblas@0.2.20%gcc"];
+  var args: [1..4] string = ["mason", "external", "install", "openblas@0.2.20%gcc"];
   installSpkg(args);
 
   // build library
-  var buildArgs: [0..2] string = ["mason", "build", "--force"];
+  var buildArgs: [1..3] string = ["mason", "build", "--force"];
   masonBuild(buildArgs);
 
 }

--- a/test/mason/spack-integration/mason-external.chpl
+++ b/test/mason/spack-integration/mason-external.chpl
@@ -8,11 +8,11 @@ proc main() {
   setupSpack();
 
   // Download and install openBLAS 0.2.20 and build with GCC
-  var args: [1..4] string = ["mason", "external", "install", "openblas@0.2.20%gcc"];
+  var args: [0..3] string = ["mason", "external", "install", "openblas@0.2.20%gcc"];
   installSpkg(args);
 
   // build library
-  var buildArgs: [1..3] string = ["mason", "build", "--force"];
+  var buildArgs: [0..2] string = ["mason", "build", "--force"];
   masonBuild(buildArgs);
 
 }

--- a/tools/mason/MasonBuild.chpl
+++ b/tools/mason/MasonBuild.chpl
@@ -45,11 +45,14 @@ proc masonBuild(args) throws {
     // start index is 1, however in the case of an array, the `low` element
     // is 0. The below code is a stopgap.
     //
-    var startIdx = 3;
-    if isArray(args) && args.eltType == string then
-      startIdx = args.domain.low + 2;
+    var start = 3;
+    var end = args.size; 
+    if isArray(args) && args.eltType == string {
+      start = args.domain.low + 2;
+      end = args.domain.high;
+    }
 
-    for i in startIdx..args.size {
+    for i in start..end {
       var arg = args[i];
       if opt == true {
         compopts.append(arg);

--- a/tools/mason/MasonBuild.chpl
+++ b/tools/mason/MasonBuild.chpl
@@ -36,8 +36,20 @@ proc masonBuild(args) throws {
   var compopts: list(string);
   var opt = false;
   var example = false;
+
   if args.size > 2 {
-    for i in 3..args.size {
+
+    //
+    // This function is generic and may be instantiated with either a list
+    // or an array as the type for "args". In the case of list, the
+    // start index is 1, however in the case of an array, the `low` element
+    // is 0. The below code is a stopgap.
+    //
+    var startIdx = 3;
+    if isArray(args) && args.eltType == string then
+      startIdx = args.domain.low + 2;
+
+    for i in startIdx..args.size {
       var arg = args[i];
       if opt == true {
         compopts.append(arg);


### PR DESCRIPTION
This PR fixes the failure of `test/mason/spack-integration/mason-external.chpl` that was caused by the merge of #13530. 

The function `masonBuild` is generic and is instantiated with either:

- list(string), which has a start index of 1
- [] string, which has a low of 0 and a high of size -1 (C style domain)

This PR adds a branch that adapts the start and end idx of a loop accordingly for each instantiation of `masonBuild`.

Testing:

- [x] `test/mason/spack-integration/mason-external.chpl` on `linux64` with `COMM=none`
- [x] `test/mason` on `linux64` with `COMM=none`