### PR TITLE
Exit after launching server from the forked process in multilocale interop

### DIFF
--- a/runtime/etc/src/mli/client_runtime.c
+++ b/runtime/etc/src/mli/client_runtime.c
@@ -99,6 +99,7 @@ int chpl_mli_client_launch(int argc, char** argv) {
     if (pid == -1) { return - 1; }
   } else {
     chpl_launch(argc, argv, execNumLocales);
+    exit(0);
   }
 
   return 0;

--- a/runtime/etc/src/mli/client_runtime.c
+++ b/runtime/etc/src/mli/client_runtime.c
@@ -99,7 +99,7 @@ int chpl_mli_client_launch(int argc, char** argv) {
     if (pid == -1) { return - 1; }
   } else {
     chpl_launch(argc, argv, execNumLocales);
-    exit(0);
+    chpl_exit_any(0);
   }
 
   return 0;


### PR DESCRIPTION
This is not so important when the program is launched using `exec`, but when
using `system`, the process would continue to live and not realize it needs to
clean itself up when the client and server are done talking to each other,
causing zombie processes and programs like start_test to hang while tracking it.
With this change, these problems no longer occur.

Thanks to Elliot for the suggestion and diagnosis help!

Checked output of `ps` after start_test had finished.

Testing:
- [x] test/interop/C/multilocale and test/interop/python/multilocale on Mac
- [x] test/interop/C/multilocale/static on an XC (using SLURM) without chpl_launchcmd
- [x] test/interop/C/multilocale/static on an XC (using SLURM) with chpl_launchcmd
- [x] test/interop/python/multilocale on linux with CHPL_LIB_PIC=pic
- [x] test/interop/C/multilocale/static on linux