### PR TITLE
Fix LCALS performance test failure caused by #13530

### DIFF
--- a/modules/standard/Lists.chpl
+++ b/modules/standard/Lists.chpl
@@ -60,7 +60,7 @@ module Lists {
   private const _initialArrayCapacity = 16;
 
   pragma "no doc"
-  private param _sanityChecks = false;
+  private param _sanityChecks = true;
 
   //
   // Some asserts are useful while developing, but can be turned off when the
@@ -232,7 +232,7 @@ module Lists {
     // accesses of list elements should go through this function.
     //
     pragma "no doc"
-    inline proc _getRef(idx: int) ref {
+    proc _getRef(idx: int) ref {
       _sanity(idx >= 1 && idx <= _totalCapacity);
       const zpos = idx - 1;
       const arrayIdx = _getArrayIdx(zpos);

--- a/modules/standard/Lists.chpl
+++ b/modules/standard/Lists.chpl
@@ -60,7 +60,7 @@ module Lists {
   private const _initialArrayCapacity = 16;
 
   pragma "no doc"
-  private param _sanityChecks = true;
+  private param _sanityChecks = false;
 
   //
   // Some asserts are useful while developing, but can be turned off when the
@@ -232,7 +232,7 @@ module Lists {
     // accesses of list elements should go through this function.
     //
     pragma "no doc"
-    proc _getRef(idx: int) ref {
+    inline proc _getRef(idx: int) ref {
       _sanity(idx >= 1 && idx <= _totalCapacity);
       const zpos = idx - 1;
       const arrayIdx = _getArrayIdx(zpos);

--- a/test/release/examples/benchmarks/lcals/LCALSDataTypes.chpl
+++ b/test/release/examples/benchmarks/lcals/LCALSDataTypes.chpl
@@ -3,11 +3,20 @@ module LCALSDataTypes {
   use LCALSEnums;
   use Lists;
 
+  //
+  // This is a vector wrapper that uses 0-based indexing.
+  //
   class vector {
     type eltType;
     var A: list(eltType);
+
+    //
+    // Previously, this vector used an array with a domain that started at 0,
+    // but list indexes starting at 1. So we should add 1 to the index to
+    // prevent a logical error.
+    //
     proc this(i: int) ref {
-      return A[i];
+      return A[i + 1];
     }
     proc push_back(e: eltType) {
       A.append(e);


### PR DESCRIPTION
This PR fixes a test failure caused by the merge of #13530. 

The LCALS module relies on a vector wrapper that is 0-indexed. When originally converting this code to use `list`, I failed to notice this. Thus test runs using the new code would fire an assert due to an out of bounds index. 

This is particularly painful for `test/release/examples/benchmarks/LCALSMain.chpl` because it has a 30 minute plus execution time.

Converting from 0 to 1 based indexing in `vector.this` makes `list` happy and fixes the test failure.

Testing:

- [x] `test/release/examples/benchmarks/lcals/LCALSMain.chpl` with `-performance` on `linux64` with `COMM=none`
- [x] `test/release/examples/benchmarks/lcals/*` on `linux64` with `COMM=none`