### PR TITLE
Add a warning to channel.readf documentation

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -6229,12 +6229,12 @@ proc channel.writef(fmtStr:string): bool throws {
    Read arguments according to a format string. See
    :ref:`about-io-formatted-io`.
 
-   .. warning::
+   .. note::
 
       Intents for all arguments except the format string are `ref`. If `readf`
       is used with formats that require an additional argument such as `%*i` and
-      `%*S`, then those arguments cannot be constants. Instead, define variables
-      and pass them.
+      `%*S`, then those arguments cannot be constants. Instead, store the value
+      into a variable and pass that.
 
    :arg fmt: the format string
    :arg args: the arguments to read

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -6229,6 +6229,13 @@ proc channel.writef(fmtStr:string): bool throws {
    Read arguments according to a format string. See
    :ref:`about-io-formatted-io`.
 
+   .. warning::
+
+      Intents for all arguments except the format string are `ref`. If `readf`
+      is used with formats that require an additional argument such as `%*i` and
+      `%*S`, then those arguments cannot be constants. Instead, define variables
+      and pass them.
+
    :arg fmt: the format string
    :arg args: the arguments to read
    :returns: true if all arguments were read according to the format string,


### PR DESCRIPTION
Add a warning against passing const arguments to `readf`.

The issue is format strings with `*` require an additional argument to specify some sort of length of reading (e.g. number of bytes). However, you cannot pass constants for those arguments because readf's all arguments are `ref`. So, you cannot really do:
```
readf("%*s", 5, myString);
```

Because `5` cannot be passed to a ref argument.

`make docs` generates docs without an issue.