### PR TITLE
Extend suppressifs for two of the three tests that failed last night, and add for last

### DIFF
--- a/test/interop/C/multilocale/exportString/noArgsRetString.suppressif
+++ b/test/interop/C/multilocale/exportString/noArgsRetString.suppressif
@@ -3,3 +3,8 @@
 # a flag equivalent to GCC's "-Wno-pointer-sign".
 #
 CHPL_TARGET_COMPILER==cray-prgenv-cray
+#
+# These tests fail when CHPL_TASKS=fifo. For now, suppress them.
+# See: #13475
+#
+CHPL_TASKS==fifo

--- a/test/interop/C/multilocale/exportString/stringArgsRetString.suppressif
+++ b/test/interop/C/multilocale/exportString/stringArgsRetString.suppressif
@@ -3,3 +3,8 @@
 # a flag equivalent to GCC's "-Wno-pointer-sign".
 #
 CHPL_TARGET_COMPILER==cray-prgenv-cray
+#
+# These tests fail when CHPL_TASKS=fifo. For now, suppress them.
+# See: #13475
+#
+CHPL_TASKS==fifo

--- a/test/interop/C/multilocale/exportString/stringArgsRetVoid.suppressif
+++ b/test/interop/C/multilocale/exportString/stringArgsRetVoid.suppressif
@@ -1,0 +1,5 @@
+#
+# These tests fail when CHPL_TASKS=fifo. For now, suppress them.
+# See: #13475
+#
+CHPL_TASKS==fifo


### PR DESCRIPTION
We know that CHPL_TASKS=fifo doesn't work on linux for multilocale interop, but
I had forgotten to copy the suppressifs from the other test directory.  Rectify
that, and up the priority on the fifo fix.