### PR TITLE
Fix a test that leaks a c_string

### DIFF
--- a/test/types/string/thomasvandoren/int-to-c_string.chpl
+++ b/test/types/string/thomasvandoren/int-to-c_string.chpl
@@ -1,6 +1,7 @@
-const n = 5,
+var n = 5,
   cs = n: c_string,
   s = n: string;
 writeln(n, " : ", n.type:string);
 writeln(cs:string, " : ", cs.type:string);
 writeln(s, " : ", s.type:string);
+chpl_free_c_string(cs);


### PR DESCRIPTION
Makes the `c_string` a `var` and calls `chpl_free_c_string`

Come across this while doing memleaks testing on #13709 