### PR TITLE
Explicitly set the craype version

### DIFF
--- a/util/build_configs/cray-internal/setenv-xc-aarch64.bash
+++ b/util/build_configs/cray-internal/setenv-xc-aarch64.bash
@@ -268,6 +268,8 @@ else
 
     # Please keep the gen versions in compiler_versions.bash the same as these!
     gen_version_gcc=7.3.0
+    # Also, the next time this gets updated, try removing the craype pin in
+    # load_prgenv_cray
     gen_version_cce=8.7.7
 
     target_cpu_module=craype-arm-thunderx2
@@ -297,6 +299,8 @@ else
 
         # load target PrgEnv with compiler version
         load_module $target_prgenv
+        # Try removing this line the next time we update compiler versions
+        load_module_version craype 2.1.6.9
         load_module_version $target_compiler $target_version
 
         # pin to mpich/libsci versions compatible with the gen compiler


### PR DESCRIPTION
We were seeing a hang while building (or rather, failing to build) gmp with
the cray compiler for the xc-arm module.  This seems to be due to a small
bug introduced in craype/2.1.6.11, at least with the older versions of cce
that we've pinned to.  I think we can stop performing this fix when we update
compiler versions again, since I didn't see the issue with those.  I left some
comments to that effect in the file.