### PR TITLE
Change bytes to nBytes in one more test

### DIFF
--- a/test/library/packages/LinearAlgebra/performance/transpose-perf.chpl
+++ b/test/library/packages/LinearAlgebra/performance/transpose-perf.chpl
@@ -19,7 +19,7 @@ config const m=1000,
 
 config type eltType = real;
 
-const bytes = numBytes(eltType);
+const nBytes = numBytes(eltType);
 
 proc main() {
   var D = {0..#m, 0..#m*2};
@@ -35,7 +35,7 @@ proc main() {
     writeln('==========================');
     writeln('iters : ', iters);
     writeln('m     : ', m);
-    writeln('MB    : ', (bytes*m*m) / 10**6);
+    writeln('MB    : ', (nBytes*m*m) / 10**6);
     writeln();
   }
 


### PR DESCRIPTION
Fix one more test with `bytes` as variable name.

This test needs LAPACK and only runs on XC systems. The test passes on XC after this PR.