### PR TITLE
Update recent anonymousCountedRange.chpl test to work with --fast

### DIFF
--- a/test/types/range/elliot/anonymousCountedRange-error.chpl
+++ b/test/types/range/elliot/anonymousCountedRange-error.chpl
@@ -1,0 +1,21 @@
+proc testAnonRanges(type lowT, type countT) {
+  var zero = 0:countT;
+  // Applying #0 to a 0.. uint range results in wraparound leading to
+  // an error when trying to iterate over it when bounds checks are
+  // on.
+  for i in 0:lowT..#(0:countT)               do write(i, ' '); writeln();
+  for i in 0:lowT..#(zero)                   do write(i, ' '); writeln();
+  for i in 0:lowT..#(1:countT)               do write(i, ' '); writeln();
+  for i in 0:lowT..#(10:countT) by 2:lowT    do write(i, ' '); writeln();
+  for i in (0:lowT.. by 2:lowT) #(10:countT) do write(i, ' '); writeln();
+  for i in 10:lowT..#10:countT               do write(i, ' '); writeln();
+}
+
+
+
+
+
+
+
+
+testAnonRanges(uint(64), int(64));

--- a/test/types/range/elliot/anonymousCountedRange-error.good
+++ b/test/types/range/elliot/anonymousCountedRange-error.good
@@ -1,0 +1,1 @@
+anonymousCountedRange-error.chpl:6: error: halt reached - Iteration over a bounded range may be incorrect due to overflow.

--- a/test/types/range/elliot/anonymousCountedRange-error.skipif
+++ b/test/types/range/elliot/anonymousCountedRange-error.skipif
@@ -1,0 +1,2 @@
+COMPOPTS <= --fast
+COMPOPTS <= --no-bounds-checks

--- a/test/types/range/elliot/anonymousCountedRange.chpl
+++ b/test/types/range/elliot/anonymousCountedRange.chpl
@@ -1,9 +1,9 @@
-proc testAnonRanges(type lowT, type countT, param testErrors = false) {
+proc testAnonRanges(type lowT, type countT) {
   var zero = 0:countT;
-  // Applying #0 to a 0.. uint range results in wraparound leading to an
-  // error when trying to iterate over it, so skip those cases unless we
-  // want to make sure the error is generated
-  if (isIntType(lowT) || testErrors) {
+  // Applying #0 to a 0.. uint range results in wraparound leading to
+  // an error when trying to iterate over it when bounds checks are
+  // on, so skip those cases here.
+  if (isIntType(lowT)) {
     for i in 0:lowT..#(0:countT)               do write(i, ' '); writeln();
     for i in 0:lowT..#(zero)                   do write(i, ' '); writeln();
   } else {
@@ -27,4 +27,3 @@ testAnonRanges(8);
 testAnonRanges(16);
 testAnonRanges(32);
 testAnonRanges(64);
-testAnonRanges(uint(64), int(64), true);

--- a/test/types/range/elliot/anonymousCountedRange.good
+++ b/test/types/range/elliot/anonymousCountedRange.good
@@ -94,4 +94,3 @@
 0 2 4 6 8 
 0 2 4 6 8 10 12 14 16 18 
 10 11 12 13 14 15 16 17 18 19 
-anonymousCountedRange.chpl:7: error: halt reached - Iteration over a bounded range may be incorrect due to overflow.


### PR DESCRIPTION
When adding an error case to anonymousCountedRange.chpl in my last
change to it, I failed to anticipate that --fast testing would skip
the maximal range overflow checking and actually try to iterate over
the maximal range, resulting in a timeout.  Here, I'm breaking the
error case back out into a test of its own that is skipped for --fast
and --no-bounds-checking flags are on.