### PR TITLE
Remove bytes from well known types and symbols in minimal modules

### DIFF
--- a/compiler/AST/wellknown.cpp
+++ b/compiler/AST/wellknown.cpp
@@ -185,6 +185,17 @@ void gatherWellKnownTypes() {
 
       dtString = NULL;
     }
+    if (dtBytes->symbol == NULL || dtBytes->symbol->defPoint == NULL) {
+      // This means there was no declaration of the bytes type.
+      if (dtBytes->symbol)
+        gTypeSymbols.remove(gTypeSymbols.index(dtBytes->symbol));
+
+      gAggregateTypes.remove(gAggregateTypes.index(dtBytes));
+
+      delete dtBytes;
+
+      dtBytes = NULL;
+    }
     if (dtLocale->symbol == NULL || dtLocale->symbol->defPoint == NULL) {
       // This means there was no declaration of the locale type.
       if (dtLocale->symbol)


### PR DESCRIPTION
This was forgotten and haven't come up until some XC nightlies were run.

Fixes issues with:
```
compflags/bradc/minimalModules/minModDeclPrint
compflags/bradc/minimalModules/minModFnRefArg
compflags/bradc/minimalModules/minModHelloWorld
compflags/bradc/minimalModules/minModVarArgs
types/coerce/ferguson/coercion-dispatch-minimal-modules
```

Test status:
- [x] above tests on XC
- [x] full standard
- [x] full gasnet