### PR TITLE
Fix a typo in my last change for the ARM module build

### DIFF
--- a/util/build_configs/cray-internal/setenv-xc-aarch64.bash
+++ b/util/build_configs/cray-internal/setenv-xc-aarch64.bash
@@ -300,7 +300,7 @@ else
         # load target PrgEnv with compiler version
         load_module $target_prgenv
         # Try removing this line the next time we update compiler versions
-        load_module_version craype 2.1.6.9
+        load_module_version craype 2.6.1.9
         load_module_version $target_compiler $target_version
 
         # pin to mpich/libsci versions compatible with the gen compiler


### PR DESCRIPTION
I had accidentally swapped two parts of the version number.  This is what I
get for not copy+pasting.