### PR TITLE
Mason: mason adds a newline to end of mason generated files

### DIFF
--- a/test/mason/chplVersion/mason-chpl-version-new.good
+++ b/test/mason/chplVersion/mason-chpl-version-new.good
@@ -1,5 +1,4 @@
 Created new library project: newTest
-
 [brick]
 name = "newTest"
 version = "0.1.0"

--- a/test/mason/chplVersion/mason-chpl-version-new.good
+++ b/test/mason/chplVersion/mason-chpl-version-new.good
@@ -6,4 +6,3 @@ version = "0.1.0"
 chplVersion = "CHPL_CUR_FULL"
 
 [dependencies]
-

--- a/test/mason/chplVersion/mason-chpl-version-new.good
+++ b/test/mason/chplVersion/mason-chpl-version-new.good
@@ -6,3 +6,4 @@ version = "0.1.0"
 chplVersion = "CHPL_CUR_FULL"
 
 [dependencies]
+

--- a/tools/mason/MasonNew.chpl
+++ b/tools/mason/MasonNew.chpl
@@ -105,7 +105,7 @@ private proc gitInit(name: string, show: bool) {
 }
 
 private proc addGitIgnore(name: string) {
-  var toIgnore = "target/\nMason.lock" + '\n';
+  var toIgnore = "target/\nMason.lock\n";
   var gitIgnore = open(name+"/.gitignore", iomode.cw);
   var GIwriter = gitIgnore.writer();
   GIwriter.write(toIgnore);

--- a/tools/mason/MasonNew.chpl
+++ b/tools/mason/MasonNew.chpl
@@ -120,7 +120,7 @@ proc makeBasicToml(name: string) {
                      'chplVersion = "' + getChapelVersionStr() + '"\n' +
                      '\n' +
                      '[dependencies]' +
-                     '\n' + '\n';
+                     '\n';
   var tomlFile = open(name+"/Mason.toml", iomode.cw);
   var tomlWriter = tomlFile.writer();
   tomlWriter.write(baseToml);
@@ -136,6 +136,6 @@ private proc makeProjectFiles(name: string) {
     ' */\nmodule '+ name + ' {\n  writeln("New library: '+ name +'");\n}';
   var lib = open(name+'/src/'+name+'.chpl', iomode.cw);
   var libWriter = lib.writer();
-  libWriter.write(libTemplate + '\n' + '\n');
+  libWriter.write(libTemplate + '\n');
   libWriter.close();
 }

--- a/tools/mason/MasonNew.chpl
+++ b/tools/mason/MasonNew.chpl
@@ -105,7 +105,7 @@ private proc gitInit(name: string, show: bool) {
 }
 
 private proc addGitIgnore(name: string) {
-  var toIgnore = "\ntarget/\nMason.lock";
+  var toIgnore = "target/\nMason.lock" + '\n';
   var gitIgnore = open(name+"/.gitignore", iomode.cw);
   var GIwriter = gitIgnore.writer();
   GIwriter.write(toIgnore);
@@ -114,7 +114,7 @@ private proc addGitIgnore(name: string) {
 
 
 proc makeBasicToml(name: string) {
-  const baseToml = '\n[brick]\n' +
+  const baseToml = '[brick]\n' +
                      'name = "' + name + '"\n' +
                      'version = "0.1.0"\n' +
                      'chplVersion = "' + getChapelVersionStr() + '"\n' +

--- a/tools/mason/MasonNew.chpl
+++ b/tools/mason/MasonNew.chpl
@@ -119,7 +119,8 @@ proc makeBasicToml(name: string) {
                      'version = "0.1.0"\n' +
                      'chplVersion = "' + getChapelVersionStr() + '"\n' +
                      '\n' +
-                     '[dependencies]\n';
+                     '[dependencies]' +
+                     '\n' + '\n';
   var tomlFile = open(name+"/Mason.toml", iomode.cw);
   var tomlWriter = tomlFile.writer();
   tomlWriter.write(baseToml);
@@ -135,6 +136,6 @@ private proc makeProjectFiles(name: string) {
     ' */\nmodule '+ name + ' {\n  writeln("New library: '+ name +'");\n}';
   var lib = open(name+'/src/'+name+'.chpl', iomode.cw);
   var libWriter = lib.writer();
-  libWriter.write(libTemplate);
+  libWriter.write(libTemplate + '\n' + '\n');
   libWriter.close();
 }


### PR DESCRIPTION
Two Mason generated files with `mason new` were missing newline EOF characters and two files had a blank line at the top of the the file. Fixed all issues and updated tests to match. 

Files with missing newline EOF character, `.gitignore` and `/src/<package-name>.chpl`
Files with blank line at the top, `/src/<package-name>.chpl` and `Mason.toml`

Fixed test/mason/chplVersion/mason-chpl-version-new.good to reflect changes