### PR TITLE
Only generate "no line number" fatal errors for --devel and --verify

### DIFF
--- a/compiler/AST/baseAST.cpp
+++ b/compiler/AST/baseAST.cpp
@@ -319,7 +319,12 @@ BaseAST::BaseAST(AstTag type) :
       astloc = currentAstLoc;
     } else {
       // neither yy* nor currentAstLoc are set
-      INT_FATAL("no line number available");
+      if (developer || fVerify) {
+        INT_FATAL("no line number available");
+      } else {
+        astloc.filename = "[file unknown]";
+        astloc.lineno = 0;
+      }
     }
   }
 }


### PR DESCRIPTION
Arguably, killing the user's compilation because we messed up isn't
the best policy... particularly in cases where the lack of line
numbers may not even show up in anything user-facing.  And even
if a bad filename / line number show up in an otherwise useful error
message, isn't that better than an internal error.

For that reason, this PR changes the current check that all new ASTs
have a filename / line number to only do so for developers (because
we were born to suffer and it should help us keep new code honest)
and verify mode (since it seems like the kind of thing verify should do).

Resolves #13792.