### PR TITLE
Add explicit types to avoid 32bit 64bit confusion on lnx32

### DIFF
--- a/modules/internal/ByteBufferHelpers.chpl
+++ b/modules/internal/ByteBufferHelpers.chpl
@@ -24,6 +24,8 @@ module ByteBufferHelpers {
   type byteType = uint(8);
   pragma "no doc"
   type bufferType = c_ptr(uint(8));
+  pragma "no doc"
+  type locIdType = chpl_nodeID.type;
 
   // Growth factor to use when extending the buffer for appends
   config param chpl_stringGrowthFactor = 1.5;
@@ -96,7 +98,7 @@ module ByteBufferHelpers {
     chpl_here_free(buf);
   }
 
-  proc bufferCopy(buf, off, len, loc) {
+  proc bufferCopy(buf: bufferType, off: int, len: int, loc: locIdType) {
     if !_local && loc != chpl_nodeID {
       var newBuf = bufferCopyRemote(loc, buf+off, len);
       return (newBuf, len);


### PR DESCRIPTION
Adds explicit types to `ByteBufferHelpers.bufferCopy` to avoid 32bit linux errors.

Without this PR we have seen (on 32bit linux)

```
/tmp/chpl-chapelu-1208.deleteme/ByteBufferHelpers.c: In function ~~~bufferCopy2~~~:
/tmp/chpl-chapelu-1208.deleteme/ByteBufferHelpers.c:303:5: error: incompatible types when assigning to type ~~~_tuple_2_c_ptr_uint8_t_int64_t {aka struct chpl__tuple_2_c_ptr_uint8_t_int64_t_s}~~~ from type ~~~_tuple_2_c_ptr_uint8_t_int32_t {aka struct chpl__tuple_2_c_ptr_uint8_t_int32_t_s}~~~
ret = ret_tmp;
```
in `release/examples/benchmarks/shootout/revcomp` and `release/examples/benchmarks/shootout/revcomp-fast`

The offending argument was `len` which was getting assigned to `int32_t` in one branch of the conditional and `int64_t` in the other.