### PR TITLE
Partially revert a change to how we find pip/python.

### DIFF
--- a/util/build_configs/cray-internal/setenv-shasta-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-shasta-x86_64.bash
@@ -444,10 +444,14 @@ else
         # enable building Chapel python-venv tools anyway.
         # For example, the following gives a URL to a local PyPI mirror that accepts http,
         # and the location of a pre-installed "pip" on the host machine.
-        #export CHPL_EASY_INSTALL_PARAMS="-i http://slemaster.us.cray.com/pypi/simple"
-        #export CHPL_PIP_INSTALL_PARAMS="-i http://slemaster.us.cray.com/pypi/simple --trusted-host slemaster.us.cray.com"
-        export CHPL_PIP=/usr/bin/pip
-        #export CHPL_PYTHONPATH=/cray/css/users/chapelu/opt/lib
+        if [[ -f /cray/css/users/chapelu/opt/lib/pip/__main__.py ]] ; then
+          export CHPL_EASY_INSTALL_PARAMS="-i http://slemaster.us.cray.com/pypi/simple"
+          export CHPL_PIP_INSTALL_PARAMS="-i http://slemaster.us.cray.com/pypi/simple --trusted-host slemaster.us.cray.com"
+          export CHPL_PIP=/cray/css/users/chapelu/opt/lib/pip/__main__.py
+          export CHPL_PYTHONPATH=/cray/css/users/chapelu/opt/lib
+        else
+          export CHPL_PIP=/usr/bin/pip
+        fi
         ;;
     ( venv_py27 )
         load_prgenv_gnu


### PR DESCRIPTION
In 2a65c9e we switched from Chapel's own pip/python support to the
system stuff for Shasta builds because the former wasn't reachable from
where we were doing the build, but the system had 2.7 pip/python anyway.
Now, in a different build environment, we have the opposite problem!
Here, support either one, which is what I should have done in the first
place.