### PR TITLE
Remove use of `Lists` in DefaultRectangular.chpl

### DIFF
--- a/modules/internal/DefaultRectangular.chpl
+++ b/modules/internal/DefaultRectangular.chpl
@@ -1945,8 +1945,6 @@ module DefaultRectangular {
 
 
   private proc complexTransferCore(LHS, LViewDom, RHS, RViewDom) {
-    use Lists;
-
     param minRank = min(LHS.rank, RHS.rank);
     type  idxType = LHS.idxType;
     type  intIdxType = LHS.intIdxType;
@@ -1961,10 +1959,10 @@ module DefaultRectangular {
 
     const (LeftActives, RightActives, inferredRank) = bulkCommComputeActiveDims(LeftDims, RightDims);
 
-    var DimSizes = new list(LeftDims(1).size.type);
+    var DimSizes: [1..inferredRank] LeftDims(1).size.type;
     for i in 1..inferredRank {
       const dimIdx = LeftActives(i);
-      DimSizes.append(LeftDims(dimIdx).size);
+      DimSizes[i] = LeftDims(dimIdx).size;
     }
 
     if debugDefaultDistBulkTransfer {

--- a/test/modules/bradc/printModStuff/foo.good
+++ b/test/modules/bradc/printModStuff/foo.good
@@ -32,7 +32,6 @@ Parsing module files:
   $CHPL_HOME/modules/standard/gen/.../SysCTypes.chpl
   $CHPL_HOME/modules/dists/DSIUtil.chpl
   $CHPL_HOME/modules/standard/IO.chpl
-  $CHPL_HOME/modules/standard/Lists.chpl
   $CHPL_HOME/modules/packages/RangeChunk.chpl
   $CHPL_HOME/modules/packages/Sort.chpl
   $CHPL_HOME/modules/standard/LinkedLists.chpl

--- a/test/modules/sungeun/init/printModuleInitOrder.na-none.good
+++ b/test/modules/sungeun/init/printModuleInitOrder.na-none.good
@@ -46,7 +46,6 @@ Initializing Modules:
           Regexp
         DefaultAssociative
         ExternalArray
-        Lists
         RangeChunk
        ChapelNumLocales
        Sys


### PR DESCRIPTION
Using an array is at least as natural and avoids requiring `Lists.chpl`
for every compilation.