### PR TITLE
Create a compilation error for export var

### DIFF
--- a/compiler/passes/checkParsed.cpp
+++ b/compiler/passes/checkParsed.cpp
@@ -299,6 +299,10 @@ checkParsedVar(VarSymbol* var) {
     USR_FATAL_CONT(var->defPoint,
                    "Configuration %s are allowed only at module scope.", varType);
   }
+
+  // Export vars are not yet supported
+  if (var->hasFlag(FLAG_EXPORT))
+    USR_FATAL_CONT(var->defPoint, "Export variables are not yet supported");
 }
 
 

--- a/test/interop/python/defaultValues_global.bad
+++ b/test/interop/python/defaultValues_global.bad
@@ -1,1 +1,1 @@
-defaultValues_global.chpl:1: syntax error: near 'var'
+defaultValues_global.chpl:1: error: Export variables are not yet supported

--- a/test/interop/python/multilocale/defaultValues_global.bad
+++ b/test/interop/python/multilocale/defaultValues_global.bad
@@ -1,1 +1,1 @@
-defaultValues_global.chpl:1: syntax error: near 'var'
+defaultValues_global.chpl:1: error: Export variables are not yet supported

--- a/test/variables/export/export-var.chpl
+++ b/test/variables/export/export-var.chpl
@@ -1,0 +1,2 @@
+export var x: int = 1;
+export const x: int = 1;

--- a/test/variables/export/export-var.good
+++ b/test/variables/export/export-var.good
@@ -1,0 +1,2 @@
+export-var.chpl:1: error: Export variables are not yet supported
+export-var.chpl:2: error: Export variables are not yet supported


### PR DESCRIPTION
`export var x:int` now parses where it did not before, after PR #13788.
However, this is not yet supported in the rest of the compiler (or
tested), so just make it an error for now. The error should be removed
once support and testing is added.

Reviewed by @lydia-duncan - thanks!
- [x] full local testing