### PR TITLE
Revert string.c_str to avoid weird intel compiler bug

### DIFF
--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -715,7 +715,7 @@ module String {
       // 2018/08/22 ENGIN TODO: normally we'd like to be able to use get_c_str
       // from the commons module, however, this causes [hard-to-understand]
       // errors with intel compilers.  So, this method still uses old-school
-      // implementation
+      // implementation. See (#448 chapel-private)
       // return get_c_str(this);
       inline proc _cast(type t:c_string, x:bufferType) {
         return __primitive("cast", t, x);

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -712,7 +712,19 @@ module String {
           on the same locale as the string.
      */
     inline proc c_str(): c_string {
-      return getCStr(this);
+      // 2018/08/22 ENGIN TODO: normally we'd like to be able to use get_c_str
+      // from the commons module, however, this causes [hard-to-understand]
+      // errors with intel compilers.  So, this method still uses old-school
+      // implementation
+      // return get_c_str(this);
+      inline proc _cast(type t:c_string, x:bufferType) {
+        return __primitive("cast", t, x);
+      }
+
+      if _local == false && this.locale_id != chpl_nodeID then
+        halt("Cannot call .c_str() on a remote string");
+
+      return this.buff:c_string;
     }
 
     pragma "no doc"


### PR DESCRIPTION
Reverts c_str conversion of string to pre-refactor state.

This caused a failure in `test/classes/bradc/union/twounions` with intel compilers. I found the culprit to be this diff after some bisecting.

Test:
- [x] previously failing test passed on an XC with intel prgenv.
- [x] standard