### PR TITLE
Fix use-after-free in new test

### DIFF
--- a/test/classes/delete-free/generic-classes-management.chpl
+++ b/test/classes/delete-free/generic-classes-management.chpl
@@ -88,8 +88,8 @@ module testmodule {
     var myOwnedNilable:owned MyClass? = new owned MyClass();
     var mySharedNonNilable:shared MyClass = new shared MyClass();
     var mySharedNilable:shared MyClass? = new shared MyClass();
-    var myBorrowedNonNilable:borrowed MyClass = myOwnedNonNilable.borrow();
-    var myBorrowedNilable:borrowed MyClass? = myOwnedNilable.borrow();
+    var myBorrowedNonNilable:borrowed MyClass = (new owned MyClass()).borrow();
+    var myBorrowedNilable:borrowed MyClass? = (new owned MyClass()).borrow();
     var myUnmanagedNonNilable:unmanaged MyClass = myBorrowedNonNilable:unmanaged;
     var myUnmanagedNilable:unmanaged MyClass? = myBorrowedNilable:unmanaged;
     var myInt = 1;


### PR DESCRIPTION
Follow-on to PR #13788.

Resolves a use-after-free in the test

classes/delete-free/generic-classes-management.chpl

reported by valgrind. This type of error is not detected by the lifetime
checker, as noted in #8382.

Test change only, not reviewed.
