### PR TITLE
Inline a string common function to avoid Intel bug

### DIFF
--- a/modules/internal/BytesStringCommon.chpl
+++ b/modules/internal/BytesStringCommon.chpl
@@ -32,7 +32,9 @@ module BytesStringCommon {
     }
   }
 
-  proc getCStr(const ref x: ?t): c_string {
+  // 2019/8/22 Engin: This proc needs to be inlined to avoid an Intel compiler
+  // issue (#448 chapel-private)
+  inline proc getCStr(const ref x: ?t): c_string {
     assertArgType(t, "getCStr");
     inline proc _cast(type t:c_string, b:bufferType) {
       return __primitive("cast", t, b);


### PR DESCRIPTION
The test in test/classes/bradc/union/twounions failed with Intel compilers after the string refactor. I reverted the function that fails under #13828. But @mppf noted that I should try inlining the helper instead, which seems to solve the problem. It is a better solution than reverting the refactor on a specific function.

Review: Very trivial, not necessary
Test: Waiting for standard paratest just in case.