### PR TITLE
Task intents to operate on fields of 'this'

### DIFF
--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -154,6 +154,7 @@ FnSymbol* getTheIteratorFn(Type* icType);
 // task intents
 extern Symbol* markPruned;
 bool isReduceOp(Type* type);
+void convertFieldsOfRecordThis(FnSymbol* fn);
 
 // forall intents
 CallExpr* resolveForallHeader(ForallStmt* pfs, SymExpr* origSE);

--- a/compiler/resolution/implementForallIntents.cpp
+++ b/compiler/resolution/implementForallIntents.cpp
@@ -958,8 +958,30 @@ static Symbol* isFieldAccess(AggregateType* recType, Expr* arg) {
         // field access.
         if (UnresolvedSymExpr* base = toUnresolvedSymExpr(call->baseExpr))
           if (Symbol* fieldSym = recType->getField(base->unresolved, false))
-            return fieldSym;
+            if (! fieldSym->hasFlag(FLAG_PARAM) &&
+                ! fieldSym->hasFlag(FLAG_TYPE_VARIABLE))
+              return fieldSym;
   return NULL;
+}
+
+static VarSymbol* createFieldRef(Expr* anchor, Symbol* thisSym,
+                                 Symbol* fieldSym, bool isConst)
+{
+  VarSymbol* fieldRef = newTemp(astr(fieldSym->name, "_ref"),
+                                fieldSym->type->getRefType());
+  fieldRef->qual = isConst ? QUAL_CONST_REF : QUAL_REF;
+  if (isConst) fieldRef->addFlag(FLAG_CONST);
+  anchor->insertBefore(new DefExpr(fieldRef));
+
+  BlockStmt* holder = new BlockStmt();
+  anchor->insertBefore(holder);
+  // This is how a ref variable is currently initialized.
+  CallExpr* init = new CallExpr(fieldSym->name, gMethodToken, thisSym);
+  holder->insertAtTail(new CallExpr(PRIM_MOVE, fieldRef, init));
+  resolveBlockStmt(holder);
+  holder->flattenAndRemove();
+
+  return fieldRef;
 }
 
 // Given a field "myField", create a shadow variable myField_SV
@@ -969,19 +991,7 @@ static ShadowVarSymbol* createSVforFieldAccess(ForallStmt* fs, Symbol* ovar,
                                                Symbol* field)
 {
   bool isConst = ovar->isConstant() || field->isConstant();
-  VarSymbol* fieldRef = newTemp(astr(field->name, "_ref"),
-                                field->type->getRefType());
-  fieldRef->qual = isConst ? QUAL_CONST_REF : QUAL_REF;
-  if (isConst) fieldRef->addFlag(FLAG_CONST);
-  fs->insertBefore(new DefExpr(fieldRef));
-
-  BlockStmt* holder = new BlockStmt();
-  fs->insertBefore(holder);
-  // This is how a ref variable is currently initialized.
-  CallExpr* init = new CallExpr(field->name, gMethodToken, ovar);
-  holder->insertAtTail(new CallExpr(PRIM_MOVE, fieldRef, init));
-  resolveBlockStmt(holder);
-  holder->flattenAndRemove();
+  VarSymbol* fieldRef = createFieldRef(fs, ovar, field, isConst);
 
   // Now create the shadow variable.
   Type*           svarType   = field->type;
@@ -1019,6 +1029,7 @@ static void doConvertFieldsOfThis(ForallStmt* fs, AggregateType* recType,
     svar->defPoint->remove();
 }
 
+// See also convertFieldsOfRecordThis().
 static void convertFieldsOfRecordReceiver(ForallStmt* fs) {
   // Each access to the receiver's field will reference the ArgSymbol
   // for 'this'. Which will force us to have a shadow variable for 'this'
@@ -1036,6 +1047,83 @@ static void convertFieldsOfRecordReceiver(ForallStmt* fs) {
     if (Symbol* ovar = svar->outerVarSym())
       if (AggregateType* recType = isRecordReceiver(ovar))
         doConvertFieldsOfThis(fs, recType, svar, ovar);
+}
+
+/////////////////////////////////////////////////////////////////////////////
+// Do the same for task functions.
+// This code is invoked from elsewhere.
+
+// If 'fn' is nested in a method on a record, return its 'this' formal.
+static ArgSymbol* enclosingRecordThisArg(FnSymbol* fn)
+{
+  while (FnSymbol* parent = toFnSymbol(fn->defPoint->parentSymbol))
+  {
+    if (ArgSymbol* thisArg = toArgSymbol(parent->_this))
+      if (isRecordReceiver(thisArg))
+        return thisArg;
+
+    if (parent->hasFlag(FLAG_METHOD))
+      // A method on a non-record or a weird-o lacking _this.
+      return NULL;
+
+    fn = parent;
+  }
+
+  return NULL; // not in a method
+}
+
+// This adds a new formal to 'fn' and augments all calls to 'fn'
+// to pass a field access to that formal.
+static ArgSymbol* createArgForFieldAccess(ArgSymbol* thisArg, FnSymbol* fn,
+                                          Symbol* fieldSym)
+{
+  bool isConst = thisArg->isConstant() || fieldSym->isConstant();
+  // Create the formal.
+  IntentTag intent = isConst ? INTENT_CONST : INTENT_BLANK;
+  ArgSymbol* fieldArg = new ArgSymbol(intent, astr(fieldSym->name, "_arg"),
+                                      fieldSym->type);
+  fn->insertFormalAtTail(fieldArg);
+
+  // Pass an actual correspondingly.
+  // Btw at this point there should be just one call to 'fn'.
+  // Because it is a task function representing a syntactic task construct.
+  for_SymbolSymExprs(fnse, fn) {
+    CallExpr* fnCall = toCallExpr(fnse->parentExpr);
+    INT_ASSERT(fnCall->baseExpr == fnse); // expect a simple call to task fn
+
+    VarSymbol* fieldRef = createFieldRef(fnCall->getStmtExpr(), thisArg,
+                                         fieldSym, isConst);
+    fnCall->insertAtTail(fieldRef);
+  }
+  
+  return fieldArg;
+}
+
+// Caller to ensure that 'fn' needs task intents.
+// See also convertFieldsOfRecordReceiver().
+void convertFieldsOfRecordThis(FnSymbol* fn) {
+  // If we are past resolution, we might be adding task intents
+  // to something that is created by the compiler, rather than
+  // something that corresponds to a task construct in user code.
+  // Future work: do this during createTaskFunctions().
+  INT_ASSERT(! resolved);
+
+  ArgSymbol* thisArg = enclosingRecordThisArg(fn);
+  if (! thisArg) return; // not in a method on a record
+  AggregateType* thisType = toAggregateType(thisArg->type->getValType());
+  std::map<Symbol*, ArgSymbol*> fieldArgs;
+
+  std::vector<SymExpr*> symExprs;
+  collectSymExprs(fn, symExprs);
+  for_vector(SymExpr, se, symExprs)
+   if (se->symbol() == thisArg)
+    if (Symbol* fieldSym = isFieldAccess(thisType, se))
+     {
+       ArgSymbol*& fieldArg = fieldArgs[fieldSym];
+       if (fieldArg == NULL)
+         fieldArg = createArgForFieldAccess(thisArg, fn, fieldSym);
+       se->parentExpr->replace(new SymExpr(fieldArg));
+     }
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -483,6 +483,9 @@ void resolveFunction(FnSymbol* fn, CallExpr* forCall) {
         markIterator(fn);
       }
 
+      if (needsCapture(fn))
+        convertFieldsOfRecordThis(fn);
+
       insertFormalTemps(fn);
 
       resolveBlockStmt(fn->body);

--- a/test/multilocale/vass/this-in-taskfns-in-ctors.chpl
+++ b/test/multilocale/vass/this-in-taskfns-in-ctors.chpl
@@ -13,7 +13,7 @@ record RR {
       this.xx = 555;
     }
     begin {
-      this.yy = 666;
+      doModify(this, 666);
       done$ = true;
     }
     done$;
@@ -25,12 +25,14 @@ record RR {
       this.xx = ee;
     }
     begin {
-      this.yy = ff;
+      doModify(this, ff);
       done$ = true;
     }
     done$;
   }
 } // record RR
+
+proc doModify(ref recv: RR, newval: int) { recv.yy = newval; }
 
 record QQ {
   var aa, bb: int;
@@ -42,7 +44,7 @@ record QQ {
       this.aa = cc;
     }
     begin {
-      this.bb = dd;
+      doModify(this, dd);
       done$ = true;
     }
     done$;
@@ -54,12 +56,14 @@ record QQ {
       this.aa = 171717;
     }
     begin {
-      this.bb = 181818;
+      doModify(this, 181818);
       done$ = true;
     }
     done$;
   }
 } // record QQ
+
+proc doModify(ref recv: QQ, newval: int) { recv.bb = newval; }
 
 writeln("start");
 

--- a/test/parallel/begin/vass/this-in-begin-in-method.chpl
+++ b/test/parallel/begin/vass/this-in-begin-in-method.chpl
@@ -4,9 +4,12 @@ record RR {
   var xx: int;
   proc modify(ee: int) {
     begin {
-      this.xx = ee;
+      doModify(this, ee);
     }
   }
+}
+proc doModify(ref recv: RR, ee: int) {
+  recv.xx = ee;
 }
 
 var rr = new RR();

--- a/test/parallel/taskPar/taskIntents/fields-of-this-1-legal.chpl
+++ b/test/parallel/taskPar/taskIntents/fields-of-this-1-legal.chpl
@@ -1,0 +1,63 @@
+// writing to an array field of a 'var'
+
+const RNG = 1..4;
+
+var s$: sync int;
+
+record QQ {
+  var data: [RNG] int;
+}
+
+proc QQ.w1(factor: int) {
+  coforall i in RNG {
+    data[i] = i * factor;
+  }
+}
+
+proc QQ.w2() {
+  w1(100);
+}
+
+proc QQ.w3() {
+  coforall i in RNG {
+    data[i] = i;
+  }
+  w2();
+}
+
+proc QQ.r1(factor: int) {
+  coforall i in RNG {
+    writeln(data[i] == i * factor);
+  }
+}
+
+var rec1 = new QQ();
+rec1.w1(10);
+rec1.r1(10);
+writeln();
+
+var rec2 = new QQ();
+rec2.w3();
+rec2.r1(100);
+
+proc QQ.bgn() {
+  begin {
+    data[2] = 234;
+    s$ = 1;
+  }
+}
+
+var rec3 = new QQ();
+rec3.bgn();
+s$;
+writeln(rec3);
+
+proc QQ.cob() {
+  cobegin {
+    data[1] = 123;
+    data[3] = 321;
+  }
+}
+
+rec3.cob();
+writeln(rec3);

--- a/test/parallel/taskPar/taskIntents/fields-of-this-1-legal.good
+++ b/test/parallel/taskPar/taskIntents/fields-of-this-1-legal.good
@@ -1,0 +1,11 @@
+true
+true
+true
+true
+
+true
+true
+true
+true
+(data = 0 234 0 0)
+(data = 123 234 321 0)

--- a/test/parallel/taskPar/taskIntents/fields-of-this-2-const-var.chpl
+++ b/test/parallel/taskPar/taskIntents/fields-of-this-2-const-var.chpl
@@ -1,0 +1,39 @@
+// writing to an array field of a 'const'
+
+const RNG = 1..4;
+
+record QQ {
+  var data: [RNG] int;
+}
+
+proc QQ.w1(factor: int) {
+  coforall i in RNG {
+    data[i] = i * factor;
+  }
+}
+
+proc QQ.w2() {
+  w1(100);
+}
+
+proc QQ.w3() {
+  coforall i in RNG {
+    data[i] = i;
+  }
+  w2();
+}
+
+proc QQ.r1(factor: int) {
+  coforall i in RNG {
+    writeln(data[i] == i * factor);
+  }
+}
+
+const rec1 = new QQ();
+rec1.w1(10);   // illegal because w1() takes the receiver by ref 
+rec1.r1(10);
+writeln();
+
+const rec2 = new QQ();
+rec2.w3();     // illegal because w3() takes the receiver by ref 
+rec2.r1(100);

--- a/test/parallel/taskPar/taskIntents/fields-of-this-2-const-var.good
+++ b/test/parallel/taskPar/taskIntents/fields-of-this-2-const-var.good
@@ -1,0 +1,20 @@
+fields-of-this-2-const-var.chpl:33: error: const actual is passed to 'ref' formal 'this' of w1()
+fields-of-this-2-const-var.chpl:5: note: to formal of type QQ
+fields-of-this-2-const-var.chpl:9: note: to ref formal here
+fields-of-this-2-const-var.chpl:10: note: passed as ref here
+fields-of-this-2-const-var.chpl:6: note: to ref formal here
+fields-of-this-2-const-var.chpl:10: note: passed as ref here
+fields-of-this-2-const-var.chpl:11: note: passed as ref here
+fields-of-this-2-const-var.chpl:11: note: passed as ref here
+fields-of-this-2-const-var.chpl:38: error: const actual is passed to 'ref' formal 'this' of w3()
+fields-of-this-2-const-var.chpl:5: note: to formal of type QQ
+fields-of-this-2-const-var.chpl:19: note: to ref formal here
+fields-of-this-2-const-var.chpl:23: note: passed as ref here
+fields-of-this-2-const-var.chpl:15: note: to ref formal here
+fields-of-this-2-const-var.chpl:16: note: passed as ref here
+fields-of-this-2-const-var.chpl:9: note: to ref formal here
+fields-of-this-2-const-var.chpl:10: note: passed as ref here
+fields-of-this-2-const-var.chpl:6: note: to ref formal here
+fields-of-this-2-const-var.chpl:10: note: passed as ref here
+fields-of-this-2-const-var.chpl:11: note: passed as ref here
+fields-of-this-2-const-var.chpl:11: note: passed as ref here

--- a/test/parallel/taskPar/taskIntents/fields-of-this-3-const-fields.chpl
+++ b/test/parallel/taskPar/taskIntents/fields-of-this-3-const-fields.chpl
@@ -1,0 +1,40 @@
+// writing to a const array field of a 'var'
+// and to fields passed by const intents
+
+const RNG = 1..4;
+
+record QQ {
+  const xxx: [RNG] int;
+  var   iii: int;
+  var   ddd: domain(1);
+}
+
+proc modify(ref arg: domain(1)) {}
+
+proc QQ.w1(factor: int) {
+  coforall i in RNG {
+    xxx[i] = i * factor;  // illegal because the field is const
+    iii = 5;              // illegal because the field is passed by 'const' intent
+    modify(ddd);          // ditto
+  }
+}
+
+proc QQ.w2() {
+  w1(100);
+}
+
+proc QQ.w3() {
+  w2();
+}
+
+proc QQ.r1(factor: int) {
+  coforall i in RNG {
+    writeln(xxx[i] == i * factor);
+    writeln(iii);
+    writeln(ddd);
+  }
+}
+
+var rec2 = new QQ();
+rec2.w3();
+rec2.r1(100);

--- a/test/parallel/taskPar/taskIntents/fields-of-this-3-const-fields.good
+++ b/test/parallel/taskPar/taskIntents/fields-of-this-3-const-fields.good
@@ -1,0 +1,4 @@
+fields-of-this-3-const-fields.chpl:14: In function 'w1':
+fields-of-this-3-const-fields.chpl:16: error: illegal lvalue in assignment
+fields-of-this-3-const-fields.chpl:17: error: illegal lvalue in assignment
+fields-of-this-3-const-fields.chpl:18: error: non-lvalue actual is passed to 'ref' formal 'arg' of modify()

--- a/test/parallel/taskPar/taskIntents/fields-of-this-4-begin-cobegin.chpl
+++ b/test/parallel/taskPar/taskIntents/fields-of-this-4-begin-cobegin.chpl
@@ -1,0 +1,62 @@
+// writing to an array field of a 'const'
+
+const RNG = 1..4;
+
+var s$: sync int;
+
+record QQ {
+  var data: [RNG] int;
+}
+
+var rec3 = new QQ();
+
+proc const QQ.bgn() {
+  begin {
+    data[2] = 234;  // illegal because it is a field of a const
+    s$ = 1;
+  }
+}
+
+rec3.bgn();
+s$;
+writeln(rec3);
+
+proc const QQ.cob() {
+  cobegin {
+    data[1] = 123;  // illegal
+    data[3] = 321;  // illegal
+  }
+}
+
+rec3.cob();
+writeln(rec3);
+
+// writing to a const array field
+
+record RR {
+  const data: [RNG] int;
+}
+
+var rec4 = new RR();
+
+proc RR.bgn() {
+  begin {
+    data[2] = 234;  // illegal because it is a const field
+    s$ = 1;
+  }
+}
+
+rec4.bgn();
+s$;
+writeln(rec4);
+
+proc RR.cob() {
+  cobegin {
+    data[1] = 123;  // illegal
+    data[3] = 321;  // illegal
+  }
+}
+
+rec4.cob();
+writeln(rec4);
+

--- a/test/parallel/taskPar/taskIntents/fields-of-this-4-begin-cobegin.good
+++ b/test/parallel/taskPar/taskIntents/fields-of-this-4-begin-cobegin.good
@@ -1,0 +1,10 @@
+fields-of-this-4-begin-cobegin.chpl:13: In function 'bgn':
+fields-of-this-4-begin-cobegin.chpl:15: error: illegal lvalue in assignment
+fields-of-this-4-begin-cobegin.chpl:24: In function 'cob':
+fields-of-this-4-begin-cobegin.chpl:26: error: illegal lvalue in assignment
+fields-of-this-4-begin-cobegin.chpl:27: error: illegal lvalue in assignment
+fields-of-this-4-begin-cobegin.chpl:42: In function 'bgn':
+fields-of-this-4-begin-cobegin.chpl:44: error: illegal lvalue in assignment
+fields-of-this-4-begin-cobegin.chpl:53: In function 'cob':
+fields-of-this-4-begin-cobegin.chpl:55: error: illegal lvalue in assignment
+fields-of-this-4-begin-cobegin.chpl:56: error: illegal lvalue in assignment


### PR DESCRIPTION
Resolves #13577.

This is the counterpart for task intents to #13479, which implemented
the proposals in #13297 for forall-intents. Which is that ...

When a task construct, i.e. `coforall`, `cobegin`, or `begin`,
accesses a field of `this` that is a record, this field is treated
as a variable passed into the task function by default intent.
As opposed to passing `this` into the task function by default intent and
accessing a field off of the corresponding task-private/shadow variable.

The implementation reuses much of the code from #13479. Including
the general approach of introducing a `ref` variable aliasing
the record's field and passing that variable into the task function.

I chose to place the new code in implementForallIntents.cpp because
it is very similar to some code already there, doing similar work,
and so that I can reuse a few helpers there without making them global.

When `this` is referenced, implicitly or explicitly, in a task construct
other than for a field access, it currently refers directly to the `this`
formal, just as it does outside a task construct. Specifying a task intent
explicitly for `this` or for an individual field is currently unsupported.

The purpose of the two existing tests modified here that write
to field of `this` inside task-parallel constructs, I believe, is to
ensure that `this` inside these constructs references the outer
`this` correctly. My modifications preserve this intention.

Testing: linux64 -futures, gasnet multilocale tests, numa.
