### PR TITLE
Improve printing of some types

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -1342,6 +1342,7 @@ AggregateType* AggregateType::getCurInstantiation(Symbol* sym, Type* symType) {
 AggregateType* AggregateType::getNewInstantiation(Symbol* sym, Type* symType, Expr* insnPoint) {
   AggregateType* retval = toAggregateType(symbol->copy()->type);
   Symbol*        field  = retval->getField(genericField);
+  Symbol*     renameTo  = NULL;
 
   symbol->defPoint->insertBefore(new DefExpr(retval->symbol));
 
@@ -1384,12 +1385,12 @@ AggregateType* AggregateType::getNewInstantiation(Symbol* sym, Type* symType, Ex
     }
 
     retval->substitutions.put(field, sym);
-    retval->symbol->renameInstantiatedSingle(sym);
+    renameTo = sym;
     paramMap.put(field,sym);
 
   } else {
     retval->substitutions.put(field, symType->symbol);
-    retval->symbol->renameInstantiatedSingle(symType->symbol);
+    renameTo = symType->symbol;
   }
 
   if (field->hasFlag(FLAG_TYPE_VARIABLE) == true && givesType(sym) == true) {
@@ -1410,6 +1411,8 @@ AggregateType* AggregateType::getNewInstantiation(Symbol* sym, Type* symType, Ex
       INT_FATAL("unexpected type for field instantiation");
     }
   }
+
+  retval->symbol->renameInstantiatedSingle(renameTo);
 
   forv_Vec(AggregateType, at, dispatchParents) {
     retval->dispatchParents.add(at);

--- a/compiler/AST/DecoratedClassType.cpp
+++ b/compiler/AST/DecoratedClassType.cpp
@@ -39,6 +39,7 @@ const char* decoratedTypeAstr(ClassTypeDecorator d, const char* className) {
         return astr("borrowed ", className);
     case CLASS_TYPE_BORROWED_NILABLE:
       return astr("borrowed ", className, "?");
+
     case CLASS_TYPE_UNMANAGED:
       if (developer)
         return astr("unmanaged anynil ", className);
@@ -51,6 +52,7 @@ const char* decoratedTypeAstr(ClassTypeDecorator d, const char* className) {
         return astr("unmanaged ", className);
     case CLASS_TYPE_UNMANAGED_NILABLE:
       return astr("unmanaged ", className, "?");
+
     case CLASS_TYPE_MANAGED:
       if (developer)
         return astr("managed anynil ", className);
@@ -60,12 +62,13 @@ const char* decoratedTypeAstr(ClassTypeDecorator d, const char* className) {
       if (developer)
         return astr("managed ", className, "!");
       else
-        return astr(className, "!");
+        return astr(className);
     case CLASS_TYPE_MANAGED_NILABLE:
       if (developer)
         return astr("managed ", className, "?");
       else
         return astr(className, "?");
+
     case CLASS_TYPE_GENERIC:
       if (developer)
         return astr("anymanaged anynil ", className);
@@ -81,6 +84,7 @@ const char* decoratedTypeAstr(ClassTypeDecorator d, const char* className) {
         return astr("anymanaged ", className, "?");
       else
         return astr(className, "?");
+
     // no default for help from compilation errors
   }
   INT_FATAL("Case not handled");

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -1276,6 +1276,19 @@ void TypeSymbol::renameInstantiatedSingle(Symbol* sym) {
     renameInstantiatedIndividual(sym);
   }
   renameInstantiatedEnd();
+
+  // Fix up the user-visible name for some Chapel-defined types.
+  // If we do this in fixTypeNames(), it will not take effect for the types
+  // of the fields of a generic record. Except when the type is an array. (??)
+  if (! developer) {
+    if (isManagedPtrType(this->type)) {
+      this->name = toString(this->type, false);
+    } else if (this->hasFlag(FLAG_SYNC)) {
+      this->name = astr("sync ", sym->name);
+    } else if (this->hasFlag(FLAG_SINGLE)) {
+      this->name = astr("single ", sym->name);
+    }
+  }
 }
 
 void TypeSymbol::renameInstantiatedFromSuper(TypeSymbol* superSym) {

--- a/test/classes/bradc/syncAsClass.good
+++ b/test/classes/bradc/syncAsClass.good
@@ -1,4 +1,4 @@
-syncAsClass.chpl:7: error: unresolved call 'foo(_syncvar(int(64)))'
+syncAsClass.chpl:7: error: unresolved call 'foo(sync int(64))'
 syncAsClass.chpl:1: note: this candidate did not match: foo(o: object)
-syncAsClass.chpl:7: note: because call actual argument #1 with type _syncvar(int(64))
+syncAsClass.chpl:7: note: because call actual argument #1 with type sync int(64)
 syncAsClass.chpl:1: note: is passed to formal 'o: object'

--- a/test/classes/bradc/syncAsClass2.good
+++ b/test/classes/bradc/syncAsClass2.good
@@ -1,1 +1,1 @@
-syncAsClass2.chpl:5: error: Cannot assign to borrowed object? from _syncvar(int(64))
+syncAsClass2.chpl:5: error: Cannot assign to borrowed object? from sync int(64)

--- a/test/classes/bradc/syncAsClass3.bad
+++ b/test/classes/bradc/syncAsClass3.bad
@@ -1,1 +1,1 @@
-syncAsClass3.chpl:5: error: Cannot assign to borrowed object? from _syncvar(int(64))
+syncAsClass3.chpl:5: error: Cannot assign to borrowed object? from sync int(64)

--- a/test/classes/delete-free/owned/owned-class-instantiation-types-user-init.good
+++ b/test/classes/delete-free/owned/owned-class-instantiation-types-user-init.good
@@ -1,6 +1,6 @@
 a borrowed GenericCollection(owned MyClass) has field owned MyClass
 b borrowed GenericCollection(owned MyClass) has field owned MyClass
 (borrowed) c borrowed GenericCollection(MyClass) has field borrowed MyClass
-a borrowed GenericCollection(_owned(borrowed MyClass?))? has field owned MyClass?
-b borrowed GenericCollection(_owned(borrowed MyClass?))? has field owned MyClass?
+a borrowed GenericCollection(owned MyClass?)? has field owned MyClass?
+b borrowed GenericCollection(owned MyClass?)? has field owned MyClass?
 (borrowed) c borrowed GenericCollection(borrowed MyClass?)? has field borrowed MyClass?

--- a/test/classes/delete-free/owned/owned-class-instantiation-types.good
+++ b/test/classes/delete-free/owned/owned-class-instantiation-types.good
@@ -1,6 +1,6 @@
 a borrowed GenericCollection(owned MyClass) has field owned MyClass
 b borrowed GenericCollection(owned MyClass) has field owned MyClass
 (borrowed) c borrowed GenericCollection(MyClass) has field borrowed MyClass
-a borrowed GenericCollection(_owned(borrowed MyClass?))? has field owned MyClass?
-b borrowed GenericCollection(_owned(borrowed MyClass?))? has field owned MyClass?
+a borrowed GenericCollection(owned MyClass?)? has field owned MyClass?
+b borrowed GenericCollection(owned MyClass?)? has field owned MyClass?
 (borrowed) c borrowed GenericCollection(borrowed MyClass?)? has field borrowed MyClass?

--- a/test/classes/delete-free/owned/owned-record-instantiation-types-user-init.good
+++ b/test/classes/delete-free/owned/owned-record-instantiation-types-user-init.good
@@ -1,6 +1,6 @@
 a GenericCollection(owned MyClass) has field owned MyClass
 b GenericCollection(owned MyClass) has field owned MyClass
 (borrowed) c GenericCollection(MyClass) has field borrowed MyClass
-a GenericCollection(_owned(borrowed MyClass?)) has field owned MyClass?
-b GenericCollection(_owned(borrowed MyClass?)) has field owned MyClass?
+a GenericCollection(owned MyClass?) has field owned MyClass?
+b GenericCollection(owned MyClass?) has field owned MyClass?
 (borrowed) c GenericCollection(borrowed MyClass?) has field borrowed MyClass?

--- a/test/classes/delete-free/owned/owned-record-instantiation-types.good
+++ b/test/classes/delete-free/owned/owned-record-instantiation-types.good
@@ -1,6 +1,6 @@
 a GenericCollection(owned MyClass) has field owned MyClass
 b GenericCollection(owned MyClass) has field owned MyClass
 (borrowed) c GenericCollection(MyClass) has field borrowed MyClass
-a GenericCollection(_owned(borrowed MyClass?)) has field owned MyClass?
-b GenericCollection(_owned(borrowed MyClass?)) has field owned MyClass?
+a GenericCollection(owned MyClass?) has field owned MyClass?
+b GenericCollection(owned MyClass?) has field owned MyClass?
 (borrowed) c GenericCollection(borrowed MyClass?) has field borrowed MyClass?

--- a/test/classes/ferguson/delete-free/owned-shared-fields3.good
+++ b/test/classes/ferguson/delete-free/owned-shared-fields3.good
@@ -1,49 +1,49 @@
 owned-shared-fields3.chpl:11: In initializer:
 owned-shared-fields3.chpl:11: error: Cannot default-initialize field fo: owned MyClass
 note: non-nil class types do not support default initialization
-note: Consider using the type _owned(MyClass)? instead
+note: Consider using the type owned MyClass? instead
 owned-shared-fields3.chpl:11: error: Cannot default-initialize field fs: shared MyClass
 note: non-nil class types do not support default initialization
-note: Consider using the type _shared(MyClass)? instead
+note: Consider using the type shared MyClass? instead
 owned-shared-fields3.chpl:28: In initializer:
 owned-shared-fields3.chpl:28: error: Cannot default-initialize field fo: owned MyClass
 note: non-nil class types do not support default initialization
-note: Consider using the type _owned(MyClass)? instead
+note: Consider using the type owned MyClass? instead
 owned-shared-fields3.chpl:28: error: Cannot default-initialize field fs: shared MyClass
 note: non-nil class types do not support default initialization
-note: Consider using the type _shared(MyClass)? instead
+note: Consider using the type shared MyClass? instead
 owned-shared-fields3.chpl:18: In initializer:
 owned-shared-fields3.chpl:19: error: Cannot default-initialize field fo: owned MyClass
 note: non-nil class types do not support default initialization
-note: Consider using the type _owned(MyClass)? instead
+note: Consider using the type owned MyClass? instead
 owned-shared-fields3.chpl:19: error: Cannot default-initialize field fs: shared MyClass
 note: non-nil class types do not support default initialization
-note: Consider using the type _shared(MyClass)? instead
+note: Consider using the type shared MyClass? instead
 owned-shared-fields3.chpl:35: In initializer:
 owned-shared-fields3.chpl:36: error: Cannot default-initialize field fo: owned MyClass
 note: non-nil class types do not support default initialization
-note: Consider using the type _owned(MyClass)? instead
+note: Consider using the type owned MyClass? instead
 owned-shared-fields3.chpl:36: error: Cannot default-initialize field fs: shared MyClass
 note: non-nil class types do not support default initialization
-note: Consider using the type _shared(MyClass)? instead
+note: Consider using the type shared MyClass? instead
 owned-shared-fields3.chpl:67: error: Cannot default-initialize fo: owned MyClass
 note: non-nil class types do not support default initialization
-note: Consider using the type _owned(MyClass)? instead
+note: Consider using the type owned MyClass? instead
 owned-shared-fields3.chpl:68: error: Cannot default-initialize fs: shared MyClass
 note: non-nil class types do not support default initialization
-note: Consider using the type _shared(MyClass)? instead
+note: Consider using the type shared MyClass? instead
 owned-shared-fields3.chpl:77: error: Cannot default-initialize fo: owned MyClass
 note: non-nil class types do not support default initialization
-note: Consider using the type _owned(MyClass)? instead
+note: Consider using the type owned MyClass? instead
 owned-shared-fields3.chpl:78: error: Cannot default-initialize fs: shared MyClass
 note: non-nil class types do not support default initialization
-note: Consider using the type _shared(MyClass)? instead
+note: Consider using the type shared MyClass? instead
 owned-shared-fields3.chpl:97: error: Cannot default-initialize a tuple component of the type owned MyClass
 note: non-nil class types do not support default initialization
-note: Consider using the type _owned(MyClass)? instead
+note: Consider using the type owned MyClass? instead
 owned-shared-fields3.chpl:98: error: Cannot default-initialize a tuple component of the type owned MyClass
 note: non-nil class types do not support default initialization
-note: Consider using the type _owned(MyClass)? instead
+note: Consider using the type owned MyClass? instead
 owned-shared-fields3.chpl:99: error: Cannot default-initialize a tuple component of the type owned MyClass
 note: non-nil class types do not support default initialization
-note: Consider using the type _owned(MyClass)? instead
+note: Consider using the type owned MyClass? instead

--- a/test/functions/diten/refIntents-workaround.good
+++ b/test/functions/diten/refIntents-workaround.good
@@ -52,5 +52,5 @@ End of swap(string)
 (differently sized string number two, string number one)
 sync ints
 (1, 2)
-End of swap(_syncvar(int(64)))
+End of swap(sync int(64))
 (2, 1)

--- a/test/functions/diten/refIntents.good
+++ b/test/functions/diten/refIntents.good
@@ -52,5 +52,5 @@ End of swap(string)
 (differently sized string number two, string number one)
 sync ints
 (1, 2)
-End of swap(_syncvar(int(64)))
+End of swap(sync int(64))
 (2, 1)

--- a/test/parallel/sync/bradc/testBadSyncSingle-arr2.good
+++ b/test/parallel/sync/bradc/testBadSyncSingle-arr2.good
@@ -1,4 +1,4 @@
 testBadSyncSingle.chpl:4: In function 'main':
 testBadSyncSingle.chpl:5: error: value from coercion passed to ref formal 'this'
 $CHPL_HOME/modules/internal/ChapelArray.chpl:nnnn: error: to function 'chpl__promotionType' defined here
-testBadSyncSingle.chpl:5: error: sync/single types cannot contain type '[domain(1,int(64),false)] _syncvar(int(64))'
+testBadSyncSingle.chpl:5: error: sync/single types cannot contain type '[domain(1,int(64),false)] sync int(64)'

--- a/test/parallel/sync/bradc/testBadSyncSingle-sync.good
+++ b/test/parallel/sync/bradc/testBadSyncSingle-sync.good
@@ -1,2 +1,2 @@
 testBadSyncSingle.chpl:4: In function 'main':
-testBadSyncSingle.chpl:5: error: sync/single types cannot contain type '_syncvar(int(64))'
+testBadSyncSingle.chpl:5: error: sync/single types cannot contain type 'sync int(64)'

--- a/test/parallel/sync/diten/returnSync.good
+++ b/test/parallel/sync/diten/returnSync.good
@@ -1,1 +1,1 @@
-int(64), _syncvar(int(64))
+int(64), sync int(64)

--- a/test/types/sync/ferguson/sync-copy-init-other-sync.good
+++ b/test/types/sync/ferguson/sync-copy-init-other-sync.good
@@ -1,3 +1,3 @@
-_syncvar(int(64))
+sync int(64)
 true
 false

--- a/test/types/sync/vass/generic-sync-1.good
+++ b/test/types/sync/vass/generic-sync-1.good
@@ -1,6 +1,6 @@
 generic-sync-1.chpl:7: In function 'test':
-generic-sync-1.chpl:8: warning: _syncvar(int(64))
-generic-sync-1.chpl:5: warning: _syncvar(int(64))
+generic-sync-1.chpl:8: warning: sync int(64)
+generic-sync-1.chpl:5: warning: sync int(64)
 got lock
 isFull = true
 released lock

--- a/test/types/sync/vass/ref-sync-1.good
+++ b/test/types/sync/vass/ref-sync-1.good
@@ -1,5 +1,5 @@
 ref-sync-1.chpl:8: In function 'MYPROC':
-ref-sync-1.chpl:9: warning: _syncvar(int(64))
+ref-sync-1.chpl:9: warning: sync int(64)
 started MYPROC
 read the FORMAL
 SVAR isFull: true

--- a/test/types/sync/vass/ref-sync-3.good
+++ b/test/types/sync/vass/ref-sync-3.good
@@ -1,4 +1,4 @@
-ref-sync-3.chpl:5: error: unresolved call 'MYPROC(_syncvar(int(64)))'
+ref-sync-3.chpl:5: error: unresolved call 'MYPROC(sync int(64))'
 ref-sync-3.chpl:7: note: this candidate did not match: MYPROC(ref FORMAL: real)
-ref-sync-3.chpl:5: note: because call actual argument #1 with type _syncvar(int(64))
+ref-sync-3.chpl:5: note: because call actual argument #1 with type sync int(64)
 ref-sync-3.chpl:7: note: is passed to formal 'ref FORMAL: real(64)'

--- a/test/types/sync/vass/ref-sync-4.good
+++ b/test/types/sync/vass/ref-sync-4.good
@@ -1,4 +1,4 @@
-ref-sync-4.chpl:5: error: unresolved call 'MYPROC(_syncvar(int(64)))'
+ref-sync-4.chpl:5: error: unresolved call 'MYPROC(sync int(64))'
 ref-sync-4.chpl:7: note: this candidate did not match: MYPROC(ref FORMAL: syncreal)
-ref-sync-4.chpl:5: note: because call actual argument #1 with type _syncvar(int(64))
-ref-sync-4.chpl:7: note: is passed to formal 'ref FORMAL: _syncvar(real(64))'
+ref-sync-4.chpl:5: note: because call actual argument #1 with type sync int(64)
+ref-sync-4.chpl:7: note: is passed to formal 'ref FORMAL: sync real(64)'

--- a/test/types/sync/vass/ref-sync-5-blank.good
+++ b/test/types/sync/vass/ref-sync-5-blank.good
@@ -1,4 +1,4 @@
-ref-sync-5-blank.chpl:5: error: unresolved call 'MYPROC(_syncvar(int(64)))'
+ref-sync-5-blank.chpl:5: error: unresolved call 'MYPROC(sync int(64))'
 ref-sync-5-blank.chpl:7: note: this candidate did not match: MYPROC(FORMAL: singleint)
-ref-sync-5-blank.chpl:5: note: because call actual argument #1 with type _syncvar(int(64))
-ref-sync-5-blank.chpl:7: note: is passed to formal 'FORMAL: _singlevar(int(64))'
+ref-sync-5-blank.chpl:5: note: because call actual argument #1 with type sync int(64)
+ref-sync-5-blank.chpl:7: note: is passed to formal 'FORMAL: single int(64)'

--- a/test/types/sync/vass/ref-sync-5-ref.good
+++ b/test/types/sync/vass/ref-sync-5-ref.good
@@ -1,4 +1,4 @@
-ref-sync-5-ref.chpl:5: error: unresolved call 'MYPROC(_syncvar(int(64)))'
+ref-sync-5-ref.chpl:5: error: unresolved call 'MYPROC(sync int(64))'
 ref-sync-5-ref.chpl:7: note: this candidate did not match: MYPROC(ref FORMAL: singleint)
-ref-sync-5-ref.chpl:5: note: because call actual argument #1 with type _syncvar(int(64))
-ref-sync-5-ref.chpl:7: note: is passed to formal 'ref FORMAL: _singlevar(int(64))'
+ref-sync-5-ref.chpl:5: note: because call actual argument #1 with type sync int(64)
+ref-sync-5-ref.chpl:7: note: is passed to formal 'ref FORMAL: single int(64)'

--- a/test/types/sync/vass/ref-sync-6-blank.good
+++ b/test/types/sync/vass/ref-sync-6-blank.good
@@ -1,4 +1,4 @@
-ref-sync-6-blank.chpl:5: error: unresolved call 'MYPROC(_singlevar(int(64)))'
+ref-sync-6-blank.chpl:5: error: unresolved call 'MYPROC(single int(64))'
 ref-sync-6-blank.chpl:7: note: this candidate did not match: MYPROC(FORMAL: syncint)
-ref-sync-6-blank.chpl:5: note: because call actual argument #1 with type _singlevar(int(64))
-ref-sync-6-blank.chpl:7: note: is passed to formal 'FORMAL: _syncvar(int(64))'
+ref-sync-6-blank.chpl:5: note: because call actual argument #1 with type single int(64)
+ref-sync-6-blank.chpl:7: note: is passed to formal 'FORMAL: sync int(64)'

--- a/test/types/sync/vass/ref-sync-6-ref.good
+++ b/test/types/sync/vass/ref-sync-6-ref.good
@@ -1,4 +1,4 @@
-ref-sync-6-ref.chpl:5: error: unresolved call 'MYPROC(_singlevar(int(64)))'
+ref-sync-6-ref.chpl:5: error: unresolved call 'MYPROC(single int(64))'
 ref-sync-6-ref.chpl:7: note: this candidate did not match: MYPROC(ref FORMAL: syncint)
-ref-sync-6-ref.chpl:5: note: because call actual argument #1 with type _singlevar(int(64))
-ref-sync-6-ref.chpl:7: note: is passed to formal 'ref FORMAL: _syncvar(int(64))'
+ref-sync-6-ref.chpl:5: note: because call actual argument #1 with type single int(64)
+ref-sync-6-ref.chpl:7: note: is passed to formal 'ref FORMAL: sync int(64)'

--- a/test/types/sync/vass/sync-type-1.bad
+++ b/test/types/sync/vass/sync-type-1.bad
@@ -1,1 +1,0 @@
-sync-type-1.chpl:1: error: _syncvar(int(64))

--- a/test/types/sync/vass/sync-type-1.chpl
+++ b/test/types/sync/vass/sync-type-1.chpl
@@ -1,1 +1,0 @@
-compilerError((sync int):string);

--- a/test/types/sync/vass/sync-type-1.future
+++ b/test/types/sync/vass/sync-type-1.future
@@ -1,3 +1,0 @@
-bug: (sync XXX):string should produce 'sync XXX'
-
-Right now I get _syncvar(int(64)), which should be changed.

--- a/test/types/sync/vass/sync-type-1.good
+++ b/test/types/sync/vass/sync-type-1.good
@@ -1,1 +1,0 @@
-sync-type-1.chpl:1: error: sync int(64)

--- a/test/types/type_variables/ferguson/ispod.good
+++ b/test/types/type_variables/ferguson/ispod.good
@@ -6,8 +6,8 @@ int(32) : true
 MyClass : true
 borrowed MyClass : true
 RAtomicT(int(64)) : false
-_syncvar(int(64)) : false
-_singlevar(int(64)) : false
+sync int(64) : false
+single int(64) : false
 NotPod1 : false
 NotPod2 : false
 NotPod3 : false

--- a/test/types/type_variables/ferguson/ispod.na-none.good
+++ b/test/types/type_variables/ferguson/ispod.na-none.good
@@ -6,8 +6,8 @@ int(32) : true
 MyClass : true
 borrowed MyClass : true
 AtomicT(int(64)) : false
-_syncvar(int(64)) : false
-_singlevar(int(64)) : false
+sync int(64) : false
+single int(64) : false
 NotPod1 : false
 NotPod2 : false
 NotPod3 : false

--- a/test/users/vass/isX/isX.byBlankArgs-compWarns.good
+++ b/test/users/vass/isX/isX.byBlankArgs-compWarns.good
@@ -304,22 +304,22 @@ isArray
 isArrayValue
 isArrayType
 
-_syncvar(int(64))
+sync int(64)
 isSync
 isSyncValue
 isSyncType
 
-_syncvar(real(64))
+sync real(64)
 isSync
 isSyncValue
 isSyncType
 
-_singlevar(int(64))
+single int(64)
 isSingle
 isSingleValue
 isSingleType
 
-_singlevar(real(64))
+single real(64)
 isSingle
 isSingleValue
 isSingleType

--- a/test/users/vass/isX/isX.byBlankArgs-compWarns.na-none.good
+++ b/test/users/vass/isX/isX.byBlankArgs-compWarns.na-none.good
@@ -304,22 +304,22 @@ isArray
 isArrayValue
 isArrayType
 
-_syncvar(int(64))
+sync int(64)
 isSync
 isSyncValue
 isSyncType
 
-_syncvar(real(64))
+sync real(64)
 isSync
 isSyncValue
 isSyncType
 
-_singlevar(int(64))
+single int(64)
 isSingle
 isSingleValue
 isSingleType
 
-_singlevar(real(64))
+single real(64)
 isSingle
 isSingleValue
 isSingleType


### PR DESCRIPTION
Resolves `test/types/sync/vass/sync-type-1.future` .

* Print sync, single types ex. as `sync int(64)` .
* Print managed non-nilable class types without `!` .
* When a generic type is instantiated with managed/sync/single types,
  print the user-readable form of the latter.
* No changes in the developer mode, however.
  Staying with our tradition of printing types differently
  when `--devel` is on vs. off.

#### Implementation Note

There is subtle timing interplay between:

* AggregateType::getNewInstantiation()
* TypeSymbol::renameInstantiatedSingle()
* fixTypeNames(), which calls toString(Type*,bool)

which I do not claim to understand. Seems like the ideal place
to set the type's name is in renameInstantiatedSingle() and
getting rid of fixTypeNames(). However this may be too early
because nested types may not have been resolved yet.
I mitigate some of this by moving the call to renameInstantiatedSingle()
to a later spot in getNewInstantiation().

I am removing `test/types/sync/vass/sync-type-1.chpl` altogether
because printing of sync types is exercised in a dozen other tests.

