### PR TITLE
Minor nilability fixes

### DIFF
--- a/compiler/AST/DecoratedClassType.cpp
+++ b/compiler/AST/DecoratedClassType.cpp
@@ -123,6 +123,7 @@ DecoratedClassType::DecoratedClassType(AggregateType* cls, ClassTypeDecorator d)
 
   canonicalClass = cls;
   decorator = d;
+  gDecoratedClassTypes.add(this);
 }
 
 
@@ -216,11 +217,45 @@ Type* canonicalClassType(Type* t) {
   return canonicalDecoratedClassType(t);
 }
 
-/* If t is a class like type or a managed type, this returns the
+/* If 't' is a class like type or a managed type, this returns
    the DecoratedClassType or AggregateType that represents
-   overriding the decorator (if any) with d.
+   overriding the decorator in 't' (if any) with 'd'.
 
-   Note that a plain AggregateType representing a class means a borrowed class.
+   (A) When 't' is or wraps some MyClass, the result is:
+
+    (a1) owned or shared, non-nilable:
+           // owned non-nilable MyClass
+           _owned(MyClass)
+
+    (a2) owned or shared, nilable or generic nilability:
+           // owned nilable MyClass
+           _owned(DecoratedClassType(CLASS_TYPE_BORROWED_NILABLE, MyClass))
+
+    (a3) borrowed or unmanaged or generic management, any nilability:
+           // unmanaged, generic nilability
+           DecoratedClassType(CLASS_TYPE_UNMANAGED, MyClass)
+           // generic management, non-nilable
+           DecoratedClassType(CLASS_TYPE_GENERIC_NONNIL, MyClass)
+
+    (a4) ... except the canonical type:
+           // borrowed, non-nilable
+           MyClass
+
+    where 'MyClass' denotes its AggregateType.
+
+   (B) When 't' is generic w.r.t. the underlying class, the result is:
+
+    (b1) owned or shared, any nilability:
+           // owned, nilable
+           DecoratedClassType(CLASS_TYPE_MANAGED_NILABLE, dtOwned)
+
+    (b2) borrowed or unmanaged or generic management, any nilability:
+           // borrowed, generic nilability
+           dtBorrowed
+           // unmanaged, non-nilable
+           dtUnmanagedNonNilable
+           // generic management, generic nilability
+           dtAnyManagementAnyNilable
 
    This function will transform generic class types, e.g.
      dtUnmanagedNonNilable + BORROWED_NILABLE -> dtBorrowedNilable
@@ -228,10 +263,7 @@ Type* canonicalClassType(Type* t) {
    Note that for owned/shared types, they represent the decorator in two
    ways, depending on whether or not the contained class is specified.
 
-   e.g.
-
-   owned class? -> DecoratedClassType(MANAGED_NILABLE, _owned)
-   owned MyClass? -> _owned(DecoratedClassType(BORROWED_NILABLE, MyClass)
+   A plain AggregateType represents a non-nilable borrowed class.
 
  */
 Type* getDecoratedClass(Type* t, ClassTypeDecorator d) {

--- a/compiler/include/DecoratedClassType.h
+++ b/compiler/include/DecoratedClassType.h
@@ -25,24 +25,21 @@
 
 /************************************* | **************************************
 
-  A type for class types with explicit memory management strategy.
-  Implements the variety of ways a class type can be decorated:
+  The representation of Chapel class types specifying the following properties:
    * nilable/non-nilable
-   * borrowed/unmanaged
+   * borrowed/unmanaged/managed (i.e. shared or owned)
+   * fully generic w.r.t. either or both of the above
 
-  owned/shared/etc are represented as instantiations of those types,
-  but owned? owned! is represented with this type.
-
-  Each DecoratedClassType refers to an AggregateType for the actual class
-  or, for owned? shared!, it refers to the generic _owned / _shared record.
+  See the comment for getDecoratedClass() for specifics.
 
   The AggregateType for each class to stores the dispatch parents and other
   important fields, and since each can have multiple DecoratedClassType
   variants, the DecoratedClassType is not an AggregateType but rather a Type
   that points to the canonical class type (i.e. the AggregateType).
 
-  Currently, borrowed MyClass!, MyClass!, MyClass are all represented
-  directly with the AggregateType for MyClass.
+  The canonical class type for MyClass is the non-nilable borrowed MyClass
+  variant. It is represented directly with the AggregateType for MyClass,
+  without a DecoratedClassType wrapper.
 
 ************************************** | *************************************/
 

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -6762,8 +6762,7 @@ static void resolveNewSetupManaged(CallExpr* newExpr, Type*& manager) {
     if (SymExpr* arg1 = toSymExpr(newExpr->get(1)))
       if (DecoratedClassType* dt1 = toDecoratedClassType(arg1->symbol()->type))
         if (dt1->getDecorator() == CLASS_TYPE_GENERIC_NILABLE)
-          newExpr->insertAtHead(dtOwned->symbol), gdbShouldBreakHere();
-    
+          newExpr->insertAtHead(dtOwned->symbol);
   }
   
   // adjust the type to initialize for managed new cases

--- a/compiler/resolution/lifetime.cpp
+++ b/compiler/resolution/lifetime.cpp
@@ -342,11 +342,7 @@ static void checkFunction(FnSymbol* fn) {
   if (fCompileTimeNilChecking) {
     // Determine cases where the compiler can prove
     // a reference-type variable is 'nil'
-    // TODO: enable this for internal modules as well.
-    // It was initially enabled only for user code
-    // as a convenience during development.
-    if (fn->getModule()->modTag == MOD_USER)
-      findNilDereferences(fn);
+    findNilDereferences(fn);
 
     // TODO:
     // Determine cases where the compiler can prove

--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -511,7 +511,7 @@ module ChapelLocale {
         // expose my flag to locale 0
         flags[locIdx] = f;
         // wait (locally) for locale 0 to set my flag
-        f!.s.waitFor(true);
+        f.s.waitFor(true);
         // clean up
         delete f;
       }

--- a/test/classes/initializers/generics/explicitAssignment.compopts
+++ b/test/classes/initializers/generics/explicitAssignment.compopts
@@ -1,1 +1,0 @@
---legacy-classes


### PR DESCRIPTION
Resolves #13632. Resolves #13601. Resolves #11305. Resolves https://github.com/Cray/chapel-private/issues/415.

* Enable compile-time nil checking for internal modules
  that was initially disabled in #11238.

* Adjust comments in DecoratedClassType.h,cpp .

* Remove an unnecssary postfix`!` in ChapelLocale.chpl.

* Add newly-created DecoratedClassTypes to `gDecoratedClassTypes`.

* Make `new C()?` return a nilable owned C.
