### PR TITLE
Fix extern functions with ref return intent

### DIFF
--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -1747,12 +1747,6 @@ buildFunctionDecl(FnSymbol*   fn,
 {
   fn->retTag = optRetTag;
 
-  if (optRetTag == RET_REF)
-  {
-    if (fn->hasFlag(FLAG_EXTERN))
-      USR_FATAL_CONT(fn, "Extern functions cannot be setters.");
-  }
-
   if (optRetType)
     fn->retExprType = new BlockStmt(optRetType, BLOCK_TYPE);
 

--- a/compiler/passes/checkParsed.cpp
+++ b/compiler/passes/checkParsed.cpp
@@ -384,7 +384,7 @@ checkFunction(FnSymbol* fn) {
 
   if (numVoidReturns != 0 && numNonVoidReturns != 0)
     USR_FATAL_CONT(fn, "Not all returns in this function return a value");
-  if (!isIterator &&
+  if (!isIterator && !fn->hasFlag(FLAG_NO_FN_BODY) &&
       fn->returnsRefOrConstRef() &&
       numNonVoidReturns == 0) {
     USR_FATAL_CONT(fn, "function declared 'ref' but does not return anything");

--- a/test/extern/ferguson/extern-return-intent-overload.chpl
+++ b/test/extern/ferguson/extern-return-intent-overload.chpl
@@ -1,0 +1,49 @@
+proc test1() {
+  writeln("test1");
+  extern proc extern_ref_identity(ref arg: int(64)) ref :int(64);
+  var x: int(64) = 1;
+
+  ref y = extern_ref_identity(x);
+  y = 2;
+
+  writeln(x, " ", y);
+}
+test1();
+
+proc test2() {
+  writeln("test2");
+  extern proc extern_const_ref_identity(const ref arg: int(64)) const ref :int(64);
+  var x: int(64) = 1;
+
+  const ref y = extern_const_ref_identity(x);
+  x = 3;
+
+  writeln(x, " ", y);
+}
+test2();
+
+proc test3() {
+  writeln("test3");
+  extern proc extern_ref_identity(ref arg: int(64)) ref :int(64);
+  extern "extern_const_ref_identity" proc extern_ref_identity(const ref arg: int(64)) const ref :int(64);
+  var x: int(64) = 1;
+
+  ref y = extern_ref_identity(x);
+  y = 4;
+
+  writeln(x, " ", y);
+}
+test3();
+
+proc test4() {
+  writeln("test4");
+  extern proc extern_ref_identity(ref arg: int(64)) ref :int(64);
+  extern "extern_const_ref_identity" proc extern_ref_identity(const ref arg: int(64)) const ref :int(64);
+  var x: int(64) = 1;
+
+  const ref y = extern_ref_identity(x);
+  x = 5;
+
+  writeln(x, " ", y);
+}
+test4();

--- a/test/extern/ferguson/extern-return-intent-overload.compopts
+++ b/test/extern/ferguson/extern-return-intent-overload.compopts
@@ -1,0 +1,2 @@
+extern-return-ref.h --llvm
+# Passes LLVM because of C errors due to backend not generating const-ref

--- a/test/extern/ferguson/extern-return-intent-overload.good
+++ b/test/extern/ferguson/extern-return-intent-overload.good
@@ -1,0 +1,12 @@
+test1
+extern_ref_identity
+2 2
+test2
+extern_const_ref_identity
+3 3
+test3
+extern_ref_identity
+4 4
+test4
+extern_const_ref_identity
+5 5

--- a/test/extern/ferguson/extern-return-intent-overload.skipif
+++ b/test/extern/ferguson/extern-return-intent-overload.skipif
@@ -1,0 +1,1 @@
+CHPL_LLVM == none

--- a/test/extern/ferguson/extern-return-ref.chpl
+++ b/test/extern/ferguson/extern-return-ref.chpl
@@ -1,0 +1,11 @@
+proc test1() {
+  writeln("test1");
+  extern proc extern_ref_identity(ref arg: int(64)) ref :int(64);
+  var x: int(64) = 1;
+
+  ref y = extern_ref_identity(x);
+  y = 2;
+
+  writeln(x, " ", y);
+}
+test1();

--- a/test/extern/ferguson/extern-return-ref.compopts
+++ b/test/extern/ferguson/extern-return-ref.compopts
@@ -1,0 +1,1 @@
+extern-return-ref.h

--- a/test/extern/ferguson/extern-return-ref.good
+++ b/test/extern/ferguson/extern-return-ref.good
@@ -1,0 +1,3 @@
+test1
+extern_ref_identity
+2 2

--- a/test/extern/ferguson/extern-return-ref.h
+++ b/test/extern/ferguson/extern-return-ref.h
@@ -1,0 +1,12 @@
+#include <stdio.h>
+
+static inline int64_t* extern_ref_identity(int64_t* arg)
+{
+  printf("extern_ref_identity\n");
+  return arg;
+}
+static inline const int64_t* extern_const_ref_identity(const int64_t* arg)
+{
+  printf("extern_const_ref_identity\n");
+  return arg;
+}


### PR DESCRIPTION
There was an (untested) error about extern functions not being
able to be setters, but this error does not make sense any more.

Long ago, functions with `var` return intent were "setters", and
that caused them to create 2 instantiations of the function, with
`param setter` set differently depending on how they were used. These
have been replaced with return-intent-overloading. As a result,
the `ref` return intent no longer has special behavior inside of
the function body and so can apply to C functions.

Reviewed by @vasslitvinov - thanks!

- [x] full local testing