### PR TITLE
Fix bugs in extern array handling

### DIFF
--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -1767,29 +1767,20 @@ buildFunctionDecl(FnSymbol*   fn,
     fn->lifetimeConstraints = new BlockStmt(optLifetimeConstraints);
   }
 
-  if (optFnBody)
-  {
+  if (optFnBody) {
     if (fn->hasFlag(FLAG_EXTERN))
       USR_FATAL_CONT(fn, "Extern functions cannot have a body.");
 
-    if (fn->body->length() == 0)
-    {
+    if (fn->body->length() == 0) {
       // Copy the statements from optFnBody to the function's
       // body to preserve line numbers
-      for_alist(expr, optFnBody->body)
-      {
+      for_alist(expr, optFnBody->body) {
         fn->body->insertAtTail(expr->remove());
       }
-
-    }
-    else
-    {
+    } else {
       fn->insertAtTail(optFnBody);
     }
-
-  }
-  else
-  {
+  } else {
     fn->addFlag(FLAG_NO_FN_BODY);
   }
 

--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -1660,6 +1660,10 @@ BlockStmt* buildExternExportFunctionDecl(Flag externOrExport, Expr* paramCNameEx
   if (externOrExport == FLAG_EXTERN) {
     fn->addFlag(FLAG_LOCAL_ARGS);
     fn->addFlag(FLAG_EXTERN);
+
+    // extern functions with no declared return type will return void
+    if (fn->retExprType == NULL)
+      fn->retType = dtVoid;
   }
   if (externOrExport == FLAG_EXPORT) {
     fn->addFlag(FLAG_LOCAL_ARGS);
@@ -1747,8 +1751,6 @@ buildFunctionDecl(FnSymbol*   fn,
 
   if (optRetType)
     fn->retExprType = new BlockStmt(optRetType, BLOCK_TYPE);
-  else if (fn->hasFlag(FLAG_EXTERN))
-    fn->retType     = dtVoid;
 
   if (optThrowsError)
   {

--- a/compiler/passes/expandExternArrayCalls.cpp
+++ b/compiler/passes/expandExternArrayCalls.cpp
@@ -100,6 +100,7 @@ void expandExternArrayCalls() {
       fn->addFlag(FLAG_EXTERN_FN_WITH_ARRAY_ARG);
       fn->addFlag(FLAG_VOID_NO_RETURN_VALUE);
       fcopy->removeFlag(FLAG_EXTERN);
+      fcopy->removeFlag(FLAG_NO_FN_BODY);
       fcopy->addFlag(FLAG_INLINE);
 
       fcopy->cname = astr("chpl__extern_array_wrapper_", fcopy->cname);


### PR DESCRIPTION
Follow-up to PR #13788.

After that PR, some tests of extern arrays were failing with --baseline, for example
```
test/extern/bradc/multidimArrToExtern.chpl
```

The return type was not getting set to void, leading to errors. The FLAG_EXTERN was not set yet at the time it was checked, due to the parser changes.

This PR adjusts the logic to set the return type for extern functions to void in order to resolve the error.

Reviewed by @vasslitvinov - thanks!

- [x] full local testing
- [x] full local --baseline testing