### PR TITLE
Add --legacy-classes to two perfcompopts

### DIFF
--- a/test/release/examples/benchmarks/lcals/LCALSMain.perfcompopts
+++ b/test/release/examples/benchmarks/lcals/LCALSMain.perfcompopts
@@ -1,1 +1,2 @@
--soutputFormat=OutputStyle.PERF_TEST --no-ieee-float
+--legacy-classes -soutputFormat=OutputStyle.PERF_TEST --no-ieee-float
+# Pending #13721, run with the legacy option.

--- a/test/studies/shootout/submitted/binarytrees2.perfcompopts
+++ b/test/studies/shootout/submitted/binarytrees2.perfcompopts
@@ -1,1 +1,1 @@
---no-warnings
+--no-warnings --legacy-classes


### PR DESCRIPTION
Follow-up to #13820.

This flag was already applied to the relevant .compopt files.