### PR TITLE
Use .notest for submitted shootout, update README

### DIFF
--- a/test/studies/shootout/submitted/README.md
+++ b/test/studies/shootout/submitted/README.md
@@ -1,5 +1,12 @@
 # Submitted Chapel Computer Language Benchmarks Game Codes
 
+Developer Note:
+
+ *This directory is intended to reflect the code submitted to the
+  benchmarks game website. If tests in this directory start failing,
+  DO NOT update the tests. Instead, give them a .notest or .future
+  file to disable them causing testing noise.*
+
 This directory contains
 [Chapel versions](http://benchmarksgame.alioth.debian.org/u64q/chapel.html)
 of the

--- a/test/studies/shootout/submitted/binarytrees2.compopts
+++ b/test/studies/shootout/submitted/binarytrees2.compopts
@@ -1,1 +1,0 @@
---legacy-classes

--- a/test/studies/shootout/submitted/binarytrees2.perfcompopts
+++ b/test/studies/shootout/submitted/binarytrees2.perfcompopts
@@ -1,1 +1,1 @@
---no-warnings --legacy-classes
+--no-warnings


### PR DESCRIPTION
Follow-on to PR #13848 and #13820.

Tests in `test/studies/shootout/submitted/` should not be modified, nor 
their compopts changed. Instead they should be skipped if they start
failing. That way, we know to update the submissions at the CLBG website.

This PR skips one test where I had been modifying .compopts by adding a 
.notest. It additionally updates the README.md in that directory to 
reflect the proper practice.

Reviewed by @bradcray - thanks!

- [x] regular testing in test/studies/shootout/submitted/ passes
- [x] performance testing in test/studies/shootout/submitted/ passes