### PR TITLE
Add regression related to passing `nil` to extern functions

### DIFF
--- a/test/extern/nil/passNilToExtern.chpl
+++ b/test/extern/nil/passNilToExtern.chpl
@@ -1,0 +1,7 @@
+use CPtr;
+
+require "passNilToExtern.h";
+
+extern proc foo(ptr: c_ptr(size_t));
+
+foo(nil);

--- a/test/extern/nil/passNilToExtern.good
+++ b/test/extern/nil/passNilToExtern.good
@@ -1,0 +1,1 @@
+ptr is NULL

--- a/test/extern/nil/passNilToExtern.h
+++ b/test/extern/nil/passNilToExtern.h
@@ -1,0 +1,9 @@
+#include <stdint.h>
+
+static void foo(size_t* ptr) {
+  if (ptr == NULL) {
+    printf("ptr is NULL\n");
+  } else {
+    printf("ptr is %p\n", ptr);
+  }
+}


### PR DESCRIPTION
This test worked a few days ago (e.g., as of tag
1.20.0-alpha-2019-08-20), but is not working on master now.  Since
then we've started inserting casts of nil to the expected integer
pointer type, but C doesn't like these casts.  This could probably be
fixed in the long-term by preserving type alias names through to
codegen time (a long-time good intention), but the short-term fix
would probably be to not cast 'nil's passed to extern pointer
arguments.