### PR TITLE
Do not cast nil to pointer types

### DIFF
--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -1066,6 +1066,16 @@ static bool needToAddCoercion(Type*      actualType,
       formal->hasFlag(FLAG_TYPE_VARIABLE))
     return false;
 
+  // Avoid adding coercions from nil because these generate
+  // errors for some C compilers.
+  if (actualType == dtNil && isClassLikeOrPtr(formalType))
+    return false;
+
+  // One day, we shouldn't need coercion if canCoerceAsSubtype
+  // returns true. That would cover the above case. However,
+  // the emitted C code doesn't encode the class hierarchy in
+  // the type system. (But we could do this for LLVM, say).
+
   if (canCoerce(actualType, actualSym, formalType, formal, fn))
     return true;
 


### PR DESCRIPTION
Resolves #13854

Follow-on to PR #13813 which moved handling of nil passed to
pointer types from canDispatch to canCoerce.

Adjusts needToAddCoercion in wrappers.cpp to return `false` for
coercions from `nil` to pointer types.

Reviewed by @benharsh - thanks!

- [x] full futures local testing
- [x] primers with gasnet