### PR TITLE
Better nilability error message upon returns, yields

### DIFF
--- a/modules/internal/OwnedObject.chpl
+++ b/modules/internal/OwnedObject.chpl
@@ -381,12 +381,10 @@ module OwnedObject {
   */
   proc =(ref lhs:_owned,
          pragma "leaves arg nil"
-         ref rhs: _owned) {
-
-    if !chpl_legacyClasses && isNonNilableClass(lhs)
-                              && isNilableClass(rhs) then
-      compilerError("cannot assign to a non-nilable owned from a nilable owned");
-
+         ref rhs: _owned)
+    where chpl_legacyClasses ||
+          ! (isNonNilableClass(lhs) && isNilableClass(rhs))
+  {
     // Work around issues in associative arrays of owned
     // TODO: remove this workaround
     if lhs.chpl_p == nil && rhs.chpl_p == nil then
@@ -408,10 +406,9 @@ module OwnedObject {
   }
 
   pragma "no doc"
-  proc =(ref lhs:_owned, rhs:_nilType) {
-    if _to_nilable(lhs.chpl_t) != lhs.chpl_t && !chpl_legacyClasses {
-      compilerError("Assigning non-nilable owned to nil");
-    }
+  proc =(ref lhs:_owned, rhs:_nilType)
+    where chpl_legacyClasses || ! isNonNilableClass(lhs)
+  {
     lhs.clear();
   }
   /*

--- a/modules/internal/SharedObject.chpl
+++ b/modules/internal/SharedObject.chpl
@@ -399,11 +399,10 @@ module SharedObject {
      no other :record:`shared` referring to it. On return,
      ``lhs`` will refer to the same object as ``rhs``.
    */
-  proc =(ref lhs:_shared, rhs: _shared) {
-    if !chpl_legacyClasses && isNonNilableClass(lhs)
-                           && isNilableClass(rhs) then
-      compilerError("cannot assign to a non-nilable shared from a nilable shared");
-
+  proc =(ref lhs:_shared, rhs: _shared)
+    where chpl_legacyClasses ||
+          ! (isNonNilableClass(lhs) && isNilableClass(rhs))
+  {
     // retain-release
     if rhs.chpl_pn != nil then
       rhs.chpl_pn!.retain();
@@ -419,18 +418,16 @@ module SharedObject {
      On return, ``lhs`` will refer to the object previously
      managed by ``rhs``, and ``rhs`` will refer to `nil`.
    */
-  proc =(ref lhs:_shared, in rhs:owned) {
-    if isNonNilableClass(lhs) && isNilableClass(rhs) then
-      compilerError("cannot assign to a non-nilable shared variable from a nilable owned");
-
+  proc =(ref lhs:_shared, in rhs:owned)
+    where ! (isNonNilableClass(lhs) && isNilableClass(rhs))
+  {
     lhs.retain(rhs.release());
   }
 
   pragma "no doc"
-  proc =(ref lhs:shared, rhs:_nilType) {
-    if _to_nilable(lhs.chpl_t) != lhs.chpl_t && !chpl_legacyClasses {
-      compilerError("Assigning non-nilable shared to nil");
-    }
+  proc =(ref lhs:shared, rhs:_nilType)
+    where chpl_legacyClasses || ! isNonNilableClass(lhs)
+  {
     lhs.clear();
   }
 

--- a/test/classes/errors/nilability-assign/assign-nonnil-owned-from-oknil-nil.good
+++ b/test/classes/errors/nilability-assign/assign-nonnil-owned-from-oknil-nil.good
@@ -1,1 +1,1 @@
-assign-nonnil-owned-from-oknil-nil.chpl:8: error: Assigning non-nilable owned to nil
+assign-nonnil-owned-from-oknil-nil.chpl:8: error: type mismatch in assignment from nil to owned MyClass

--- a/test/classes/errors/nilability-assign/assign-nonnil-owned-from-oknil-owned.good
+++ b/test/classes/errors/nilability-assign/assign-nonnil-owned-from-oknil-owned.good
@@ -1,1 +1,1 @@
-assign-nonnil-owned-from-oknil-owned.chpl:8: error: cannot assign to a non-nilable owned from a nilable owned
+assign-nonnil-owned-from-oknil-owned.chpl:8: error: Cannot assign to owned MyClass from owned MyClass?

--- a/test/classes/errors/nilability-assign/assign-nonnil-shared-from-oknil-nil.good
+++ b/test/classes/errors/nilability-assign/assign-nonnil-shared-from-oknil-nil.good
@@ -1,1 +1,1 @@
-assign-nonnil-shared-from-oknil-nil.chpl:8: error: Assigning non-nilable shared to nil
+assign-nonnil-shared-from-oknil-nil.chpl:8: error: type mismatch in assignment from nil to shared MyClass

--- a/test/classes/errors/nilability-assign/assign-nonnil-shared-from-oknil-owned.good
+++ b/test/classes/errors/nilability-assign/assign-nonnil-shared-from-oknil-owned.good
@@ -1,1 +1,1 @@
-assign-nonnil-shared-from-oknil-owned.chpl:8: error: cannot assign to a non-nilable shared variable from a nilable owned
+assign-nonnil-shared-from-oknil-owned.chpl:8: error: Cannot assign to shared MyClass from owned MyClass?

--- a/test/classes/errors/nilability-assign/assign-nonnil-shared-from-oknil-shared.good
+++ b/test/classes/errors/nilability-assign/assign-nonnil-shared-from-oknil-shared.good
@@ -1,1 +1,1 @@
-assign-nonnil-shared-from-oknil-shared.chpl:8: error: cannot assign to a non-nilable shared from a nilable shared
+assign-nonnil-shared-from-oknil-shared.chpl:8: error: Cannot assign to shared MyClass from shared MyClass?

--- a/test/classes/errors/nilability-return-yield/return-borrowed.chpl
+++ b/test/classes/errors/nilability-return-yield/return-borrowed.chpl
@@ -1,0 +1,4 @@
+class C { }
+var global = new borrowed C() : borrowed C?;
+proc P(): borrowed C  return global;
+var dum = P();

--- a/test/classes/errors/nilability-return-yield/return-borrowed.good
+++ b/test/classes/errors/nilability-return-yield/return-borrowed.good
@@ -1,0 +1,2 @@
+return-borrowed.chpl:3: In function 'P':
+return-borrowed.chpl:3: error: cannot return 'borrowed C?' when the declared return type is 'borrowed C'

--- a/test/classes/errors/nilability-return-yield/return-owned.chpl
+++ b/test/classes/errors/nilability-return-yield/return-owned.chpl
@@ -1,0 +1,4 @@
+class C { }
+var global = new owned C() : owned C?;
+proc P(): owned C  return global;
+var dum = P();

--- a/test/classes/errors/nilability-return-yield/return-owned.good
+++ b/test/classes/errors/nilability-return-yield/return-owned.good
@@ -1,0 +1,2 @@
+return-owned.chpl:3: In function 'P':
+return-owned.chpl:3: error: cannot return 'owned C?' when the declared return type is 'owned C'

--- a/test/classes/errors/nilability-return-yield/return-shared.chpl
+++ b/test/classes/errors/nilability-return-yield/return-shared.chpl
@@ -1,0 +1,4 @@
+class C { }
+var global = new shared C() : shared C?;
+proc P(): shared C  return global;
+var dum = P();

--- a/test/classes/errors/nilability-return-yield/return-shared.good
+++ b/test/classes/errors/nilability-return-yield/return-shared.good
@@ -1,0 +1,2 @@
+return-shared.chpl:3: In function 'P':
+return-shared.chpl:3: error: cannot return 'shared C?' when the declared return type is 'shared C'

--- a/test/classes/errors/nilability-return-yield/return-unmanaged.chpl
+++ b/test/classes/errors/nilability-return-yield/return-unmanaged.chpl
@@ -1,0 +1,4 @@
+class C { }
+var global = new unmanaged C() : unmanaged C?;
+proc P(): unmanaged C  return global;
+var dum = P();

--- a/test/classes/errors/nilability-return-yield/return-unmanaged.good
+++ b/test/classes/errors/nilability-return-yield/return-unmanaged.good
@@ -1,0 +1,2 @@
+return-unmanaged.chpl:3: In function 'P':
+return-unmanaged.chpl:3: error: cannot return 'unmanaged C?' when the declared return type is 'unmanaged C'

--- a/test/classes/errors/nilability-return-yield/yield-borrowed.chpl
+++ b/test/classes/errors/nilability-return-yield/yield-borrowed.chpl
@@ -1,0 +1,4 @@
+class C { }
+var global = new borrowed C() : borrowed C?;
+iter I(): borrowed C  { yield global; }
+for i in I() do;

--- a/test/classes/errors/nilability-return-yield/yield-borrowed.good
+++ b/test/classes/errors/nilability-return-yield/yield-borrowed.good
@@ -1,0 +1,2 @@
+yield-borrowed.chpl:3: In iterator 'I':
+yield-borrowed.chpl:3: error: cannot yield 'borrowed C?' when the declared return type is 'borrowed C'

--- a/test/classes/errors/nilability-return-yield/yield-owned.chpl
+++ b/test/classes/errors/nilability-return-yield/yield-owned.chpl
@@ -1,0 +1,4 @@
+class C { }
+var global = new owned C() : owned C?;
+iter I(): owned C  { yield global; }
+for i in I() do;

--- a/test/classes/errors/nilability-return-yield/yield-owned.good
+++ b/test/classes/errors/nilability-return-yield/yield-owned.good
@@ -1,0 +1,2 @@
+yield-owned.chpl:3: In iterator 'I':
+yield-owned.chpl:3: error: cannot yield 'owned C?' when the declared return type is 'owned C'

--- a/test/classes/errors/nilability-return-yield/yield-shared.chpl
+++ b/test/classes/errors/nilability-return-yield/yield-shared.chpl
@@ -1,0 +1,4 @@
+class C { }
+var global = new shared C() : shared C?;
+iter I(): shared C  { yield global; }
+for i in I() do;

--- a/test/classes/errors/nilability-return-yield/yield-shared.good
+++ b/test/classes/errors/nilability-return-yield/yield-shared.good
@@ -1,0 +1,2 @@
+yield-shared.chpl:3: In iterator 'I':
+yield-shared.chpl:3: error: cannot yield 'shared C?' when the declared return type is 'shared C'

--- a/test/classes/errors/nilability-return-yield/yield-unmanaged.chpl
+++ b/test/classes/errors/nilability-return-yield/yield-unmanaged.chpl
@@ -1,0 +1,4 @@
+class C { }
+var global = new unmanaged C() : unmanaged C?;
+iter I(): unmanaged C  { yield global; }
+for i in I() do;

--- a/test/classes/errors/nilability-return-yield/yield-unmanaged.good
+++ b/test/classes/errors/nilability-return-yield/yield-unmanaged.good
@@ -1,0 +1,2 @@
+yield-unmanaged.chpl:3: In iterator 'I':
+yield-unmanaged.chpl:3: error: cannot yield 'unmanaged C?' when the declared return type is 'unmanaged C'


### PR DESCRIPTION
Before this change, the error message upon assigning to a non-nilable
owned/shared from its nilable counterpart came from the corresponding
assignment operator in the modules.

Since we implement returns and yields with assignment, the similar
error upon returning/yielding also came from that assignment operator.
Therefore the phrasing of the error talked about assignment.

This change adds where-clauses to these assignment operators so that
no operator is applicable when in the above error scenarios.
This way, the error is generated directly by the compiler.
The compiler already adjusts the phrasing of the error message upon
an unresolved call (assignment, in the above scenarios) to indicate
assignment, return, or yield as appropriate.

So, in these illegal returning and yielding scenarios, the text
of the error message now talks about returning or yielding,
not about assignment, as illustrated by the newly-added tests.
... all of which follow the same pattern.

A couple .good files for errors upon assignments needed adjustment
because of different error text between the modules and the compiler.
Some of them can be improved, too - leaving that for future work.
