### PR TITLE
Make minimum string size a config param and 0-by-default

### DIFF
--- a/modules/internal/ByteBufferHelpers.chpl
+++ b/modules/internal/ByteBufferHelpers.chpl
@@ -33,8 +33,6 @@ module ByteBufferHelpers {
   //
   // Externs and constants used to implement strings
   //
-  private        param chpl_string_min_alloc_size: int = 16;
-
   pragma "fn synchronization free"
   private extern proc chpl_memhook_md_num(): chpl_mem_descInt_t;
 
@@ -60,7 +58,7 @@ module ByteBufferHelpers {
 
   proc bufferAlloc(requestedSize) {
     const allocSize = max(chpl_here_good_alloc_size(requestedSize),
-                          chpl_string_min_alloc_size);
+                          chplStringMinAllocSize);
     var buf = chpl_here_alloc(allocSize,
                               offset_STR_COPY_DATA): bufferType;
     return (buf, allocSize);
@@ -74,7 +72,7 @@ module ByteBufferHelpers {
 
   proc bufferRealloc(buf, requestedSize) {
     const allocSize = max(chpl_here_good_alloc_size(requestedSize+1),
-                          chpl_string_min_alloc_size);
+                          chplStringMinAllocSize);
     var newBuff = chpl_here_realloc(buf, allocSize,
                                 offset_STR_COPY_DATA): bufferType;
     return (newBuff, allocSize);

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -30,6 +30,9 @@ module ChapelBase {
   // Is the cache for remote data enabled at compile time?
   config param CHPL_CACHE_REMOTE: bool = false;
 
+  // minimum buffer size allocated for string/bytes
+  config param chplStringMinAllocSize = 0;
+
   config param warnMaximalRange = false;    // Warns if integer rollover will cause
                                             // the iterator to yield zero times.
   proc _throwOpError(param op: string) {


### PR DESCRIPTION
This PR moves `chpl_string_min_alloc_size` to ChapelBase and makes it a camelCase `config param`.

Prior to string/bytes refactor (#13709), this was a param that was used in subset of string operations that allocates buffers. The functions that used this param were the ones that are about retrieving a byte or codepoint from a string.

After the refactor, all the allocations (and reallocations) come from ByteBufferHelpers, which used this minimum size always. This caused tests that leak small strings leak even larger amounts.

It seemed like a better approach to make this a config param that is 0 by default. There may be cases where a lot of appends to smaller strings happen, in which case setting this to something reasonable can help users get rid of some of the memory allocations.

I have run some perf tests. It might help with some of the performance regressions. But I am not convinced that this'll be enought to bring us back to where we were in terms of performance.

Test:
- [x] standard
- [ ] gasnet