### PR TITLE
Rename use of Lists in MasonPublish to use List instead

### DIFF
--- a/tools/mason/MasonPublish.chpl
+++ b/tools/mason/MasonPublish.chpl
@@ -27,7 +27,7 @@ use MasonNew;
 use MasonModify;
 use Random;
 use MasonUpdate;
-private use Lists;
+private use List;
 
 /* Top Level procedure that gets called from mason.chpl that takes in arguments from command line.
    Returns the help output in '-h' or '--help' exits in the arguments.


### PR DESCRIPTION
This PR is a quick bug fix that will enable `mason` to build once again. The driver that builds the `mason` application is not covered by testing, and I forgot to manually test it myself.

Trivial and not reviewed.