### PR TITLE
Add channel seek and default to pread

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -2329,8 +2329,11 @@ inline proc channel.commit() where this.locking == false {
   qio_channel_commit_unlocked(_channel_internal);
 }
 
-proc channel.seek(start:int, end:int = max(int)) throws
-where this.locking == false {
+proc channel.seek(start:int, end:int = max(int)) throws {
+
+  if this.locking then
+    compilerError("Cannot seek on a locking channel");
+
   const err = qio_channel_seek(_channel_internal, start, end);
 
   if err then

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1083,6 +1083,8 @@ private extern proc qio_channel_mark(threadsafe:c_int, ch:qio_channel_ptr_t):sys
 private extern proc qio_channel_revert_unlocked(ch:qio_channel_ptr_t);
 private extern proc qio_channel_commit_unlocked(ch:qio_channel_ptr_t);
 
+private extern proc qio_channel_seek(ch:qio_channel_ptr_t, start:int(64), end:int(64)):syserr;
+
 private extern proc qio_channel_write_bits(threadsafe:c_int, ch:qio_channel_ptr_t, v:uint(64), nbits:int(8)):syserr;
 private extern proc qio_channel_flush_bits(threadsafe:c_int, ch:qio_channel_ptr_t):syserr;
 private extern proc qio_channel_read_bits(threadsafe:c_int, ch:qio_channel_ptr_t, ref v:uint(64), nbits:int(8)):syserr;
@@ -1668,7 +1670,7 @@ proc open(path:string="", mode:iomode, hints:iohints=IOHINT_NONE,
 
 proc openplugin(pluginFile: QioPluginFile, mode:iomode,
                 seekable:bool, style:iostyle) throws {
-  
+
   extern proc qio_file_init_plugin(ref file_out:qio_file_ptr_t,
       file_info:c_void_ptr, flags:c_int, const ref style:iostyle):syserr;
 
@@ -2326,6 +2328,15 @@ inline proc channel.revert() where this.locking == false {
 inline proc channel.commit() where this.locking == false {
   qio_channel_commit_unlocked(_channel_internal);
 }
+
+proc channel.seek(start:int, end:int = max(int)) throws
+where this.locking == false {
+  const err = qio_channel_seek(_channel_internal, start, end);
+
+  if err then
+    throw SystemError.fromSyserr(err);
+}
+
 
 // These begin with an _ to indicated that
 // you should have a lock before you use these... there is probably

--- a/runtime/include/qio/qio.h
+++ b/runtime/include/qio/qio.h
@@ -1388,6 +1388,7 @@ qioerr qio_channel_revert(const int threadsafe, qio_channel_t* ch)
   return 0;
 }
 
+qioerr qio_channel_seek(qio_channel_t* ch, int64_t start, int64_t end);
 
 void qio_channel_commit_unlocked(qio_channel_t* ch);
 

--- a/test/io/ferguson/ctests/qio_test.test.c
+++ b/test/io/ferguson/ctests/qio_test.test.c
@@ -26,8 +26,7 @@ void fill_testdata(int64_t start, int64_t len, unsigned char* data)
 
 // unbounded_channels <= 0 means no, > 0 means yes
 // -1 means advance.
-void check_channel(char threadsafe, qio_chtype_t type, int64_t start, int64_t len, int64_t chunksz, qio_hint_t file_hints, qio_hint_t ch_hints, char unbounded_channels, char reopen)
-{
+void check_channel(char threadsafe, qio_chtype_t type, int64_t start, int64_t len, int64_t chunksz, qio_hint_t file_hints, qio_hint_t ch_hints, char unbounded_channels, char reopen, char seek) {
   qio_file_t* f;
   qio_channel_t* writing;
   qio_channel_t* reading;
@@ -77,7 +76,7 @@ void check_channel(char threadsafe, qio_chtype_t type, int64_t start, int64_t le
   fhints = qio_hints_to_string(file_hints);
   chhints = qio_hints_to_string(ch_hints);
   if( verbose ) {
-    printf("check_channel(threadsafe=%i, type=%i, start=%lli, len=%lli, chunksz=%lli, file_hints=%s, ch_hints=%s, unbounded=%i, reopen=%i)\n",
+    printf("check_channel(threadsafe=%i, type=%i, start=%lli, len=%lli, chunksz=%lli, file_hints=%s, ch_hints=%s, unbounded=%i, reopen=%i, seek=%i)\n",
          (int) threadsafe,
          (int) type,
          (long long int) start,
@@ -86,7 +85,8 @@ void check_channel(char threadsafe, qio_chtype_t type, int64_t start, int64_t le
          fhints,
          chhints,
          (int) unbounded_channels,
-         (int) reopen );
+         (int) reopen,
+         (int) seek );
   }
   qio_free(fhints);
   qio_free(chhints);
@@ -132,6 +132,13 @@ void check_channel(char threadsafe, qio_chtype_t type, int64_t start, int64_t le
 
   // Write stuff to the file.
   for( offset = start; offset < end; offset += usesz ) {
+
+    if (seek && !writefp) {
+      err = qio_channel_seek(writing, offset, ch_end);
+      assert(!err);
+      assert(qio_channel_offset_unlocked(writing) == offset);
+    }
+
     usesz = chunksz;
     if( offset + usesz > end ) usesz = end - offset;
     // Fill chunk.
@@ -142,6 +149,7 @@ void check_channel(char threadsafe, qio_chtype_t type, int64_t start, int64_t le
     } else {
       err = qio_channel_write(threadsafe, writing, chunk, usesz, &amt_written);
       assert(!err);
+      assert(qio_channel_offset_unlocked(writing) == offset+usesz);
     }
     assert(amt_written == usesz);
 
@@ -205,8 +213,8 @@ void check_channel(char threadsafe, qio_chtype_t type, int64_t start, int64_t le
 
   // That was fun. Now start at the beginning of the file
   // and read the data.
-  
-  // Rewind the file 
+
+  // Rewind the file
   if( !memory ) {
     off_t off;
     int syserr;
@@ -222,6 +230,7 @@ void check_channel(char threadsafe, qio_chtype_t type, int64_t start, int64_t le
 
   // Read stuff from the file.
   for( offset = start; offset < end; offset += usesz ) {
+
     usesz = chunksz;
     if( offset + usesz > end ) usesz = end - offset;
     // Fill chunk.
@@ -235,12 +244,19 @@ void check_channel(char threadsafe, qio_chtype_t type, int64_t start, int64_t le
       err = qio_channel_read(threadsafe, reading, got_chunk, usesz, &amt_read);
       errcode = qio_err_to_int(err);
       assert( errcode == EEOF || errcode == 0);
+      assert(qio_channel_offset_unlocked(reading) == offset+usesz);
     }
     assert(amt_read == usesz);
 
     // Compare chunk.
     for( k = 0; k < usesz; k++ ) {
       assert(got_chunk[k] == chunk[k]);
+    }
+
+    if (seek && !readfp) {
+      err = qio_channel_seek(reading, offset+usesz, ch_end);
+      assert(!err);
+      assert(qio_channel_offset_unlocked(reading) == offset+usesz);
     }
   }
 
@@ -298,6 +314,7 @@ void check_channels(void)
   int nunbounded = sizeof(unboundedness)/sizeof(char);
   int unbounded;
   char reopen;
+  char seek;
   qio_hint_t hints[] = {QIO_METHOD_DEFAULT, QIO_METHOD_READWRITE, QIO_METHOD_PREADPWRITE, QIO_METHOD_FREADFWRITE, QIO_METHOD_MEMORY, QIO_METHOD_MMAP, QIO_METHOD_MMAP|QIO_HINT_PARALLEL, QIO_METHOD_PREADPWRITE | QIO_HINT_NOFAST};
   int nhints = sizeof(hints)/sizeof(qio_hint_t);
   int file_hint, ch_hint;
@@ -314,7 +331,11 @@ void check_channels(void)
               for( threadsafe = 0; threadsafe < 2; threadsafe++ ) {
                 for( unbounded = 0; unbounded < nunbounded; unbounded++ ) {
                   for( reopen = 0; reopen < 2; reopen++ ) {
-                    check_channel(threadsafe, type, starts[s], lens[i], chunkszs[k], hints[file_hint], hints[ch_hint], unboundedness[unbounded], reopen);
+                    for( seek = 0; seek < 2; seek++ ) {
+                      check_channel(threadsafe, type, starts[s], lens[i],
+                          chunkszs[k], hints[file_hint], hints[ch_hint],
+                          unboundedness[unbounded], reopen, seek);
+                    }
                   }
                 }
               }

--- a/test/io/ferguson/seeking.chpl
+++ b/test/io/ferguson/seeking.chpl
@@ -2,7 +2,7 @@ use Random;
 
 config const path = "binary-output.bin";
 config const maxbyte = 255;
-config const maxint = 1024*1024;
+config const maxint = 32*1024;
 config const seed = SeedGenerator.oddCurrentTime;
 
 config const bufsz = 0;

--- a/test/io/ferguson/seeking.chpl
+++ b/test/io/ferguson/seeking.chpl
@@ -1,0 +1,224 @@
+use Random;
+
+config const path = "binary-output.bin";
+config const maxbyte = 255;
+config const maxint = 1024*1024;
+config const seed = SeedGenerator.oddCurrentTime;
+
+config const bufsz = 0;
+extern var qbytes_iobuf_size:size_t;
+
+if bufsz > 0 {
+  qbytes_iobuf_size = bufsz:size_t;
+}
+
+proc test1() {
+  {
+    var f = open(path, iomode.cw, style = new iostyle(binary=1));
+    var w = f.writer(locking=false);
+    w.write(1:uint(8));
+
+    w.seek(16);
+    w.write(2:uint(8));
+
+    w.seek(32);
+    w.write(3:uint(8));
+    
+    w.seek(64);
+    w.write(4:uint(8));
+  }
+
+  {
+    var f = open(path, iomode.r, style = new iostyle(binary=1));
+    var r = f.reader(locking=false);
+    var b:uint(8);
+    var got:bool;
+    
+    got = r.read(b);
+    assert(got && b == 1);
+
+    r.seek(16);
+    got = r.read(b);
+    assert(got && b == 2);
+
+    r.seek(32);
+    got = r.read(b);
+    assert(got && b == 3);
+    
+    r.seek(64);
+    got = r.read(b);
+    assert(got && b == 4);
+  }
+}
+
+proc test2() {
+  // Create a file by writing in reverse.
+  {
+    var f = open(path, iomode.cw, style = new iostyle(binary=1));
+    var w = f.writer(locking=false);
+
+    for i in 0..maxbyte by -1 {
+      w.seek(i);
+      w.write(i:uint(8));
+    }
+  }
+
+  // Check the data
+  {
+    var f = open(path, iomode.r, style = new iostyle(binary=1));
+    var r = f.reader(locking=false);
+    for i in 0..maxbyte {
+      var b:uint(8);
+      var got:bool;
+
+      got = r.read(b);
+      assert(got && b == i:uint(8));
+    }
+  }
+}
+
+proc test3() {
+  // Create a file by writing forward and read it in reverse
+  {
+    var f = open(path, iomode.cw, style = new iostyle(binary=1));
+    var w = f.writer(locking=false);
+
+    for i in 0..maxbyte {
+      w.write(i:uint(8));
+    }
+  }
+
+  // Check the data
+  {
+    var f = open(path, iomode.r, style = new iostyle(binary=1));
+    var r = f.reader(locking=false);
+    for i in 0..maxbyte by -1 {
+      var b:uint(8);
+      var got:bool;
+
+      r.seek(i);
+      got = r.read(b);
+      assert(got && b == i:uint(8));
+    }
+  }
+}
+
+proc test4() {
+  // Create a file by writing in reverse.
+  {
+    var f = open(path, iomode.cw, style = new iostyle(binary=1));
+    var w = f.writer(locking=false);
+
+    for i in 0..maxint by -1 {
+      w.seek(i*numBytes(int));
+      w.write(i);
+    }
+  }
+
+  // Check the data
+  {
+    var f = open(path, iomode.r, style = new iostyle(binary=1));
+    var r = f.reader(locking=false);
+    for i in 0..maxint {
+      var b:int;
+      var got:bool;
+
+      got = r.read(b);
+      assert(got && b == i);
+    }
+  }
+}
+
+proc test5() {
+  // Create a file by writing forward and read it in reverse
+  {
+    var f = open(path, iomode.cw, style = new iostyle(binary=1));
+    var w = f.writer(locking=false);
+
+    for i in 0..maxint {
+      w.write(i);
+    }
+  }
+
+  // Check the data
+  {
+    var f = open(path, iomode.r, style = new iostyle(binary=1));
+    var r = f.reader(locking=false);
+    for i in 0..maxint by -1 {
+      var b:int;
+      var got:bool;
+
+      r.seek(i*numBytes(int));
+      got = r.read(b);
+      assert(got && b == i);
+    }
+  }
+}
+
+proc test6() {
+  // Write 0..maxint using a permutation and then read it normally
+  var A:[0..maxint] int;
+  Random.permutation(A, seed=seed);
+
+  // Write to the permutation
+  {
+    var f = open(path, iomode.cw, style = new iostyle(binary=1));
+    var w = f.writer(locking=false);
+
+    for a in A {
+      w.seek(a*numBytes(int));
+      w.write(a);
+    }
+  }
+
+  // Check the data
+  {
+    var f = open(path, iomode.r, style = new iostyle(binary=1));
+    var r = f.reader(locking=false);
+    for i in 0..maxint {
+      var b:int;
+      var got:bool;
+
+      got = r.read(b);
+      assert(got && b == i);
+    }
+  }
+}
+
+proc test7() {
+  // Write 0..maxint and then read with a permutation
+  var A:[0..maxint] int;
+  Random.permutation(A, seed=seed);
+
+  {
+    var f = open(path, iomode.cw, style = new iostyle(binary=1));
+    var w = f.writer(locking=false);
+
+    for i in 0..maxint {
+      w.write(i);
+    }
+  }
+
+  {
+    var f = open(path, iomode.r, style = new iostyle(binary=1));
+    var r = f.reader(locking=false);
+    for a in A {
+      var b:int;
+      var got:bool;
+
+      r.seek(a*numBytes(int));
+      got = r.read(b);
+      assert(got && b == a);
+    }
+  }
+}
+
+
+
+test1();
+test2();
+test3();
+test4();
+test5();
+test6();
+test7();

--- a/test/io/ferguson/seeking.execopts
+++ b/test/io/ferguson/seeking.execopts
@@ -1,0 +1,4 @@
+--bufsz=1
+--bufsz=8
+--bufsz=16
+--bufsz=0


### PR DESCRIPTION
Resolves https://github.com/Cray/chapel-private/issues/410

Resolves #13204

Adds channel.seek that can only be called on non-locking channels.

Changes the default behavior for reading channels from using mmap to 
pread. Mmap is great in that it is 0 copy, but it can have surprising
performance implications. Mmap can still be requested with hinting, but
it's really mostly useful for the case in which the entire file is mmap'd
in one go.

Reviewed by @vasslitvinov - thanks!

- [x] full local testing