### PR TITLE
Allow clients of multilocale C libraries to call "chpl_free" on returned values

### DIFF
--- a/compiler/codegen/library.cpp
+++ b/compiler/codegen/library.cpp
@@ -74,6 +74,13 @@ void codegen_library_header(std::vector<FnSymbol*> functions) {
         }
       }
 
+      if (fMultiLocaleInterop) {
+        // If we've created a multilocale library, memory that is returned to
+        // the client code wasn't created by chpl_mem_alloc and friends, so
+        // shouldn't be freed using the normal strategies.  But, for
+        // convenience, allow the user to still call `chpl_free`.
+        fprintf(libhdrfile.fptr, "#define chpl_free(ptr) free(ptr)\n");
+      }
       // Maybe need something here to support LLVM extern blocks?
 
       // Print out the module initialization function headers and the exported

--- a/test/interop/C/multilocale/exportString/noArgsRetString.ml-test.c
+++ b/test/interop/C/multilocale/exportString/noArgsRetString.ml-test.c
@@ -4,7 +4,7 @@ int main(int argc, char** argv) {
   chpl_library_init(argc, argv);
   char* msg = noArgsRetString();
   printf("%s\n", msg);
-  free(msg);
+  chpl_free(msg);
   chpl_library_finalize();
   return 0;
 }

--- a/test/interop/C/multilocale/exportString/stringArgsRetString.ml-test.c
+++ b/test/interop/C/multilocale/exportString/stringArgsRetString.ml-test.c
@@ -4,7 +4,7 @@ int main(int argc, char** argv) {
   chpl_library_init(argc, argv);
   char* msg = stringArgsRetString("Greetings", ", computer!");
   printf("%s\n", msg);
-  free(msg);
+  chpl_free(msg);
   chpl_library_finalize();
   return 0;
 }

--- a/test/interop/C/multilocale/use_cstringArgAndReturn.ml-test.c
+++ b/test/interop/C/multilocale/use_cstringArgAndReturn.ml-test.c
@@ -13,8 +13,8 @@ int main(int argc, char* argv[]) {
   const char* c = "The last of the strings";
   const char* d = takeAndReturn(c);
   take(d);
-  free((char*)b);
-  free((char*)d);
+  chpl_free((char*)b);
+  chpl_free((char*)d);
   // Shutdown the Chapel runtime and standard modules
   chpl_library_finalize();
 


### PR DESCRIPTION
Memory that was returned from multilocale C library functions is not allocated
using the standard Chapel allocator.  This meant that if a user switched from
using a single locale library to a multilocale version of the same library, they
would have had to switch their clean up calls to use the system free function
instead (as we would otherwise try to free memory we weren't actually tracking).

This change causes multilocale libraries to #define chpl_free appropriately in
their generated header files, so that users can call it without fear.

Updates the multilocale C c_string and string tests to use `chpl_free` instead of
`free` once again.

Passed full gasnet paratest with futures on linux, test/interop/C/multilocale directory on
Mac with gasnet, full paratest with futures on linux in progress