### PR TITLE
User error for TPVs in task constructs' with-clauses

### DIFF
--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -923,7 +923,7 @@ void addTaskIntent(CallExpr* ti, ShadowVarSymbol* svar) {
     ti->insertAtTail(ri);
     ti->insertAtTail(ovar);
   } else {
-    ArgSymbol* tiMark = tiMarkForForallIntent(svar->intent);
+    ArgSymbol* tiMark = tiMarkForForallIntent(svar);
     INT_ASSERT(tiMark != NULL);
     ti->insertAtTail(tiMark);
     ti->insertAtTail(ovar);

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -124,7 +124,7 @@ enum ForallIntentTag {
 const char* forallIntentTagDescription(ForallIntentTag tfiTag);
 
 // for task intents and forall intents
-ArgSymbol* tiMarkForForallIntent(ForallIntentTag intent);
+ArgSymbol* tiMarkForForallIntent(ShadowVarSymbol* svar);
 
 // parser support
 enum ShadowVarPrefix {

--- a/compiler/passes/createTaskFunctions.cpp
+++ b/compiler/passes/createTaskFunctions.cpp
@@ -118,45 +118,28 @@ void initForTaskIntents() {
 
 // Return the tiMark symbol for the given ForallIntentTag.
 // Do not invoke on TFI_REDUCE, TPV and helper intents.
-ArgSymbol* tiMarkForForallIntent(ForallIntentTag intent) {
-  ArgSymbol* retval = NULL;
+ArgSymbol* tiMarkForForallIntent(ShadowVarSymbol* svar) {
+  switch (svar->intent) {
+    case TFI_DEFAULT:     return tiMarkBlank;
+    case TFI_CONST:       return tiMarkConstDflt;
+    case TFI_IN:          return tiMarkIn;
+    case TFI_CONST_IN:    return tiMarkConstIn;
+    case TFI_REF:         return tiMarkRef;
+    case TFI_CONST_REF:   return tiMarkConstRef;
 
-  switch (intent) {
-    case TFI_DEFAULT:
-      retval = tiMarkBlank;
-      break;
-
-    case TFI_CONST:
-      retval = tiMarkConstDflt;
-      break;
-
-    case TFI_IN:
-      retval = tiMarkIn;
-      break;
-
-    case TFI_CONST_IN:
-      retval = tiMarkConstIn;
-      break;
-
-    case TFI_REF:
-      retval = tiMarkRef;
-      break;
-
-    case TFI_CONST_REF:
-      retval = tiMarkConstRef;
+    case TFI_TASK_PRIVATE:
+      USR_FATAL_CONT(svar, "task-private variables are not supported in with-clauses for coforall/cobegin/begin blocks");
       break;
 
     case TFI_IN_PARENT:
-    case TFI_REDUCE:
+    case TFI_REDUCE:      // reduce intents are handled in addTaskIntent()
     case TFI_REDUCE_OP:
     case TFI_REDUCE_PARENT_AS:
     case TFI_REDUCE_PARENT_OP:
-    case TFI_TASK_PRIVATE:
       INT_FATAL("unexpected intent in tiMarkForForallIntent()");
       break;
   }
-
-  return retval;
+  return tiMarkBlank; //dummy
 }
 
 

--- a/test/parallel/taskPar/taskIntents/no-tpv.chpl
+++ b/test/parallel/taskPar/taskIntents/no-tpv.chpl
@@ -1,0 +1,19 @@
+
+coforall Locales with (
+                       var iii: int
+                       ) {
+  writeln(iii);
+}
+
+cobegin with (
+              var jjj: int
+              ) {
+  writeln(jjj);
+  writeln("no jjj");
+}
+
+begin with (
+            var kkk: int
+            ) {
+  writeln(kkk);
+}

--- a/test/parallel/taskPar/taskIntents/no-tpv.good
+++ b/test/parallel/taskPar/taskIntents/no-tpv.good
@@ -1,0 +1,3 @@
+no-tpv.chpl:3: error: task-private variables are not supported in with-clauses for coforall/cobegin/begin blocks
+no-tpv.chpl:9: error: task-private variables are not supported in with-clauses for coforall/cobegin/begin blocks
+no-tpv.chpl:16: error: task-private variables are not supported in with-clauses for coforall/cobegin/begin blocks


### PR DESCRIPTION
This used to be an INT_FATAL, switching it to a user error.
The issue was reported by @LouisJenkinsCS .

Trivial, not reviewed.