### PR TITLE
Enable --no-legacy-classes on internal modules

### DIFF
--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -960,10 +960,6 @@ static void resolveUnresolvedSymExpr(UnresolvedSymExpr* usymExpr,
         sym = t->symbol;
       } else if (isClass(sym->type)) {
         // e.g. 'MyClass' becomes 'MyClass with any management'
-
-        // TODO: remove constraint for user code only
-        if (usymExpr->getModule()->modTag == MOD_USER) {
-
           // make MyClass mean generic-management unless
           // --legacy-classes is passed.
           bool defaultIsGenericHere = !fLegacyClasses;
@@ -973,7 +969,6 @@ static void resolveUnresolvedSymExpr(UnresolvedSymExpr* usymExpr,
             Type* t = getDecoratedClass(sym->type, d);
             sym = t->symbol;
           }
-        }
       }
     }
 

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -266,9 +266,9 @@ module ChapelArray {
     }
 
     proc _freePrivatizedClassHelp(pid, original) {
-      var prv = chpl_getPrivatizedCopy(object, pid);
+      var prv = chpl_getPrivatizedCopy(unmanaged object, pid);
       if prv != original then
-        delete _to_unmanaged(prv);
+        delete prv;
 
       extern proc chpl_clearPrivatizedClass(pid:int);
       chpl_clearPrivatizedClass(pid);

--- a/modules/internal/ChapelLocale.chpl
+++ b/modules/internal/ChapelLocale.chpl
@@ -378,7 +378,7 @@ module ChapelLocale {
   // initialized until LocaleModel is initialized.  To disable this
   // replication, set replicateRootLocale to false.
   pragma "no doc"
-  pragma "locale private" var rootLocale : locale? = nil;
+  pragma "locale private" var rootLocale : unmanaged locale? = nil;
   pragma "no doc"
   pragma "locale private" var rootLocaleInitialized = false;
 
@@ -397,7 +397,7 @@ module ChapelLocale {
   // module.
   //
   pragma "no doc"
-  var origRootLocale : locale? = nil;
+  var origRootLocale : unmanaged locale? = nil;
 
   pragma "no doc"
   class AbstractRootLocale : locale {
@@ -727,6 +727,6 @@ module ChapelLocale {
   //
   pragma "no doc"
   proc deinit() {
-    delete _to_unmanaged(origRootLocale);
+    delete origRootLocale;
   }
 }

--- a/modules/internal/ChapelSyncvar.chpl
+++ b/modules/internal/ChapelSyncvar.chpl
@@ -93,9 +93,9 @@ module ChapelSyncvar {
   // use native sync vars if they're enabled and supported for the valType
   private proc getSyncClassType(type valType) type {
     if useNativeSyncVar && supportsNativeSyncVar(valType) {
-      return _qthreads_synccls(valType);
+      return unmanaged _qthreads_synccls(valType);
     } else {
-      return _synccls(valType);
+      return unmanaged _synccls(valType);
     }
   }
 
@@ -114,7 +114,7 @@ module ChapelSyncvar {
   record _syncvar {
     type valType;                              // The compiler knows this name
 
-    var  wrapped : getSyncClassType(valType) = nil;
+    var  wrapped : unmanaged getSyncClassType(valType);
     var  isOwned : bool                      = true;
 
     pragma "dont disable remote value forwarding"
@@ -152,7 +152,7 @@ module ChapelSyncvar {
     pragma "dont disable remote value forwarding"
     proc deinit() {
       if isOwned == true then
-        delete _to_unmanaged(wrapped);
+        delete wrapped;
     }
 
     // Do not allow implicit reads of sync vars.
@@ -328,7 +328,7 @@ module ChapelSyncvar {
   // This version has to be available to take precedence
   inline proc chpl__autoDestroy(x : _syncvar(?)) {
     if x.isOwned == true then
-      delete _to_unmanaged(x.wrapped);
+      delete x.wrapped;
   }
 
   pragma "no doc"
@@ -641,7 +641,7 @@ module ChapelSyncvar {
   record _singlevar {
     type valType;                              // The compiler knows this name
 
-    var  wrapped : _singlecls(valType) = nil;
+    var  wrapped : unmanaged _singlecls(valType);
     var  isOwned : bool                = true;
 
     proc init(type valType) {
@@ -677,7 +677,7 @@ module ChapelSyncvar {
     pragma "dont disable remote value forwarding"
     proc deinit() {
       if isOwned == true then
-        delete _to_unmanaged(wrapped);
+        delete wrapped;
     }
 
     // Do not allow implicit reads of single vars.
@@ -771,7 +771,7 @@ module ChapelSyncvar {
   // This version has to be available to take precedence
   inline proc chpl__autoDestroy(x : _singlevar(?)) {
     if x.isOwned == true then
-      delete _to_unmanaged(x.wrapped);
+      delete x.wrapped;
   }
 
   pragma "no doc"

--- a/modules/internal/localeModels/numa/LocaleModel.chpl
+++ b/modules/internal/localeModels/numa/LocaleModel.chpl
@@ -110,7 +110,7 @@ module LocaleModel {
 
     var numSublocales: int; // should never be modified after first assignment
     var childSpace: domain(1);
-    var childLocales: [childSpace] NumaDomain;
+    var childLocales: [childSpace] unmanaged NumaDomain;
 
     // This constructor must be invoked "on" the node
     // that it is intended to represent.  This trick is used
@@ -203,7 +203,7 @@ module LocaleModel {
 
     proc deinit() {
       for loc in childLocales do
-        delete _to_unmanaged(loc);
+        delete loc;
     }
  }
 

--- a/modules/packages/DistributedBag.chpl
+++ b/modules/packages/DistributedBag.chpl
@@ -227,7 +227,7 @@ module DistributedBag {
       documentation.
     */
     // This is unused, and merely for documentation purposes. See '_value'.
-    var _impl : DistributedBagImpl(eltType)?;
+    var _impl : unmanaged DistributedBagImpl(eltType)?;
 
     // Privatized id...
     pragma "no doc"
@@ -249,7 +249,7 @@ module DistributedBag {
       if _pid == -1 {
         halt("DistBag is uninitialized...");
       }
-      return chpl_getPrivatizedCopy(DistributedBagImpl(eltType), _pid);
+      return chpl_getPrivatizedCopy(unmanaged DistributedBagImpl(eltType), _pid);
     }
 
     forwarding _value;
@@ -901,7 +901,7 @@ module DistributedBag {
     type eltType;
 
     // A handle to our parent 'distributed' bag, which is needed for work stealing.
-    var parentHandle : DistributedBagImpl(eltType);
+    var parentHandle : borrowed DistributedBagImpl(eltType);
 
     /*
       Helps evenly distribute and balance placement of elements in a best-effort

--- a/modules/packages/DistributedDeque.chpl
+++ b/modules/packages/DistributedDeque.chpl
@@ -209,7 +209,7 @@ module DistributedDeque {
       documentation.
     */
     // This is unused, and merely for documentation purposes. See '_value'.
-    var _impl : DistributedDequeImpl(eltType)?;
+    var _impl : unmanaged DistributedDequeImpl(eltType)?;
 
     // Privatization id
     pragma "no doc"
@@ -229,7 +229,7 @@ module DistributedDeque {
       if _pid == -1 {
         halt("DistDeque is uninitialized...");
       }
-      return chpl_getPrivatizedCopy(DistributedDequeImpl(eltType), _pid);
+      return chpl_getPrivatizedCopy(unmanaged DistributedDequeImpl(eltType), _pid);
     }
 
     forwarding _value;
@@ -630,7 +630,7 @@ module DistributedDeque {
       for slot in slots do slot.lock$ = true;
 
       // We iterate directly over the heads of each slot, so we capture them in advance.
-      var nodes : [{0..#nSlots}] (int, int, LocalDequeNode(eltType)?);
+      var nodes : [{0..#nSlots}] (int, int, unmanaged LocalDequeNode(eltType)?);
       for i in 0 .. #nSlots {
         var node = slots[i].head;
         if node == nil {
@@ -693,7 +693,7 @@ module DistributedDeque {
       for slot in slots do slot.lock$ = true;
 
       // We iterate directly over the heads of each slot, so we capture them in advance.
-      var nodes : [{0..#nSlots}] (int, int, LocalDequeNode(eltType)?);
+      var nodes : [{0..#nSlots}] (int, int, unmanaged LocalDequeNode(eltType)?);
       for i in 0 .. #nSlots {
         var node = slots[i].tail;
         nodes[i] = (node!.size, node!.tailIdx, node);


### PR DESCRIPTION
Resolves https://github.com/Cray/chapel-private/issues/350.

#13447 applied the class type changes only to user code to get started.
Enabling it also for internal and standard modules.

In my experience adjusting the modules, it was sometimes difficult
to figure out what needs adjustment. For example, to figure out that
the management decoration was missing on `parentHandle`, I cloned
the code then was reducing it step by step until about 50 lines of
decorations, when I finally saw it. Another example was the missing
decoration in `var nodes : [{0..#nSlots}] (int, int, LocalDequeNode(eltType)?);`
Also, none of the error pointed me directly to the missing decorations
on `DistDeque._impl` and in the return expression for `DistDeque._value`.

Looking through the module code, I feels that `unmanaged` is more common
than we expected when making the default decoration be `borrowed`.

I was surprised to observe that this declaration:
```chpl
var rootLocale : locale? = nil;
```
inferred the `borrowed` decoration on `rootLocale` instead of issuing a
"generic management" error.

When adding a management decoration on `var x: SomeClass`, I used
`unmanaged` where I saw `x` being `delete`-ed manually.
