### PR TITLE
Add --no-legacy-classes compopts

### DIFF
--- a/test/classes/errors/nilability-return-yield/COMPOPTS
+++ b/test/classes/errors/nilability-return-yield/COMPOPTS
@@ -1,0 +1,1 @@
+--no-codegen --no-legacy-classes

--- a/test/classes/errors/nilability-return-yield/NOEXEC
+++ b/test/classes/errors/nilability-return-yield/NOEXEC
@@ -1,0 +1,1 @@
+Save some C compilation time - do not execute these tests.

--- a/test/functions/typeMethods/override.compopts
+++ b/test/functions/typeMethods/override.compopts
@@ -1,0 +1,1 @@
+--no-legacy-classes

--- a/test/types/locale/bradc/defaultLocaleVal.compopts
+++ b/test/types/locale/bradc/defaultLocaleVal.compopts
@@ -1,0 +1,1 @@
+--no-legacy-classes


### PR DESCRIPTION
Add .compopts files with `--no-legacy-classes`
to mark the tests that require this setting to pass.

After this addition, our test suite passes under
linux64 -futures even if we flip `fLegacyClasses`
back to true in the compiler.

... which implies that 1.19-based user code
is likely to work with `--legacy-classes`.

