### PR TITLE
Use GMP only in one map test, skip it if no gmp

### DIFF
--- a/test/library/standard/Map/testIterators.chpl
+++ b/test/library/standard/Map/testIterators.chpl
@@ -1,5 +1,12 @@
 use Map, BigInteger;
-use utilFunctions;
+
+proc factorial(n: int) {
+  use BigInteger;
+  var bi = new bigint(1);
+
+  for i in 2..n do bi *= i;
+  return bi;
+}
 
 var fac = new map(int, bigint);
 

--- a/test/library/standard/Map/testIterators.skipif
+++ b/test/library/standard/Map/testIterators.skipif
@@ -1,0 +1,1 @@
+CHPL_GMP==none

--- a/test/library/standard/Map/utilFunctions.chpl
+++ b/test/library/standard/Map/utilFunctions.chpl
@@ -15,11 +15,3 @@ proc intToEnglish(n: int): string {
       return tens[n / 10] + "-" + intToEnglish(n % 10);
   }
 }
-
-proc factorial(n: int) {
-  use BigInteger;
-  var bi = new bigint(1);
-
-  for i in 2..n do bi *= i;
-  return bi;
-}


### PR DESCRIPTION
To resolve nightly testing failures.