### PR TITLE
Added skipif's to three mason tests that were failing

### DIFF
--- a/test/mason/publish-tests/badDry.skipif
+++ b/test/mason/publish-tests/badDry.skipif
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Skip this test for SuSE 11 and earlier. It requires an OpenSSL version that
+# is newer than is available on SuSe 11 due to github requirements.
+if [ -f /etc/SuSE-release ] ; then
+  slesVersion=`sed -n -e 's/VERSION = //p' /etc/SuSE-release`
+  if [ $slesVersion -le 11 ] ; then
+    echo True
+  else
+    echo False
+  fi
+else
+  echo False
+fi

--- a/test/mason/publish-tests/badRegTest.skipif
+++ b/test/mason/publish-tests/badRegTest.skipif
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Skip this test for SuSE 11 and earlier. It requires an OpenSSL version that
+# is newer than is available on SuSe 11 due to github requirements.
+if [ -f /etc/SuSE-release ] ; then
+  slesVersion=`sed -n -e 's/VERSION = //p' /etc/SuSE-release`
+  if [ $slesVersion -le 11 ] ; then
+    echo True
+  else
+    echo False
+  fi
+else
+  echo False
+fi

--- a/test/mason/publish-tests/dryTest.skipif
+++ b/test/mason/publish-tests/dryTest.skipif
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Skip this test for SuSE 11 and earlier. It requires an OpenSSL version that
+# is newer than is available on SuSe 11 due to github requirements.
+if [ -f /etc/SuSE-release ] ; then
+  slesVersion=`sed -n -e 's/VERSION = //p' /etc/SuSE-release`
+  if [ $slesVersion -le 11 ] ; then
+    echo True
+  else
+    echo False
+  fi
+else
+  echo False
+fi


### PR DESCRIPTION
Failing tests were badDryTest, badRegTest, and dryTest in test/mason/publish-tests/
Failing due to an update registry call that fails because sles11 is not present.
Added mason skipif that checks for sles11 and skips if it is not available.