### PR TITLE
Added new check flag to mason publish

### DIFF
--- a/test/mason/publish-tests/publishHelp.good
+++ b/test/mason/publish-tests/publishHelp.good
@@ -7,7 +7,7 @@ Options:
     <registry>                   Positional argument indicates the target registry. Defaults to chapel-lang/mason-registry
     -h, --help                   Display this message
     --dry-run                    Check to see if package is ready to be published
-    --no-update                  Prevents registrys from being updated when a package is published.
+    --no-update                  Prevents registries from being updated when a package is published.
     --check                      Runs check to see if package can be published successfully to <registry>
 
 Publishing requires the mason-registry to be forked and the package to have a remote origin.

--- a/test/mason/publish-tests/publishHelp.good
+++ b/test/mason/publish-tests/publishHelp.good
@@ -8,5 +8,6 @@ Options:
     -h, --help                   Display this message
     --dry-run                    Check to see if package is ready to be published
     --no-update                  Prevents registrys from being updated when a package is published.
+    --check                      Runs check to see if package can be published successfully to <registry>
 
 Publishing requires the mason-registry to be forked and the package to have a remote origin.

--- a/test/mason/publish-tests/publishHelpShort.good
+++ b/test/mason/publish-tests/publishHelpShort.good
@@ -7,7 +7,7 @@ Options:
     <registry>                   Positional argument indicates the target registry. Defaults to chapel-lang/mason-registry
     -h, --help                   Display this message
     --dry-run                    Check to see if package is ready to be published
-    --no-update                  Prevents registrys from being updated when a package is published.
+    --no-update                  Prevents registries from being updated when a package is published.
     --check                      Runs check to see if package can be published successfully to <registry>
 
 Publishing requires the mason-registry to be forked and the package to have a remote origin.

--- a/test/mason/publish-tests/publishHelpShort.good
+++ b/test/mason/publish-tests/publishHelpShort.good
@@ -8,5 +8,6 @@ Options:
     -h, --help                   Display this message
     --dry-run                    Check to see if package is ready to be published
     --no-update                  Prevents registrys from being updated when a package is published.
+    --check                      Runs check to see if package can be published successfully to <registry>
 
 Publishing requires the mason-registry to be forked and the package to have a remote origin.

--- a/tools/mason/MasonHelp.chpl
+++ b/tools/mason/MasonHelp.chpl
@@ -423,6 +423,7 @@ proc masonPublishHelp(){
   writeln("    -h, --help                   Display this message");
   writeln('    --dry-run                    Check to see if package is ready to be published');
   writeln('    --no-update                  Prevents registrys from being updated when a package is published.');
+  writeln('    --check                      Runs check to see if package can be published successfully to <registry>');
   writeln();
   writeln('Publishing requires the mason-registry to be forked and the package to have a remote origin.');
 }

--- a/tools/mason/MasonHelp.chpl
+++ b/tools/mason/MasonHelp.chpl
@@ -422,7 +422,7 @@ proc masonPublishHelp(){
   writeln('    <registry>                   Positional argument indicates the target registry. Defaults to chapel-lang/mason-registry');
   writeln("    -h, --help                   Display this message");
   writeln('    --dry-run                    Check to see if package is ready to be published');
-  writeln('    --no-update                  Prevents registrys from being updated when a package is published.');
+  writeln('    --no-update                  Prevents registries from being updated when a package is published.');
   writeln('    --check                      Runs check to see if package can be published successfully to <registry>');
   writeln();
   writeln('Publishing requires the mason-registry to be forked and the package to have a remote origin.');

--- a/tools/mason/MasonPublish.chpl
+++ b/tools/mason/MasonPublish.chpl
@@ -475,6 +475,7 @@ proc check(username : string, path : string, trueIfLocal : bool, travis : bool) 
     attemptToBuild();
   }
   writeln(spacer);
+  writeln('RESULTS');
   writeln(spacer);
 
   if packageTest && remoteTest && moduleTest && registryTest {

--- a/tools/mason/MasonPublish.chpl
+++ b/tools/mason/MasonPublish.chpl
@@ -461,6 +461,19 @@ proc check(username : string, path : string, trueIfLocal : bool, travis : bool) 
   if MASON_REGISTRY.size == 1 {
     writeln('    In order to use a local registry, ensure that MASON_REGISTRY points to the path.');
   }
+  
+  writeln(spacer);
+  writeln(spacer);
+  if package {
+    writeln('Attempting to build package using following options:');
+    writeln('    show = false');
+    writeln('    release = false');
+    writeln('    force = true');
+    writeln('    opt = false');
+    writeln('    example = false');
+    writeln('If these are different than what is required to build your package you can disregard this check');
+    attemptToBuild();
+  }
   writeln(spacer);
   writeln(spacer);
 
@@ -481,21 +494,10 @@ proc check(username : string, path : string, trueIfLocal : bool, travis : bool) 
       writeln('(FAILED) Your package has no remote origin and cannot be published');
     }
   }
-  
+
   writeln(spacer);
   writeln(spacer);
-  if package {
-    writeln('Attempting to build package using following options:');
-    writeln('    show = false');
-    writeln('    release = false');
-    writeln('    force = true');
-    writeln('    opt = false');
-    writeln('    example = false');
-    writeln('If these are different than what is required to build your package you can disregard this check');
-    attemptToBuild();
-    writeln(spacer);
-  }
-  writeln();
+
   if travis {
     if package && moduleCheck(projectCheckHome) {
       attemptToBuild();
@@ -513,8 +515,14 @@ proc check(username : string, path : string, trueIfLocal : bool, travis : bool) 
 /* Attempts to build the package/
  */
 private proc attemptToBuild() throws {
-  const buildArgs = ['mason', 'build', '--force'];
-  masonBuild(buildArgs);
+  var sub = spawn(['mason','build','--force'], stdout=PIPE);
+  sub.wait();
+  if sub.exit_status == 1 {
+  writeln('(FAILED) Please make sure your package builds');
+  }
+  else {
+    writeln('(PASSED) Package builds successfully.');
+  }
 }
 
 /* registryPathCheck accepts the path, username, and trueIfLocal in order to check whether the registry that someone

--- a/tools/mason/MasonPublish.chpl
+++ b/tools/mason/MasonPublish.chpl
@@ -420,22 +420,22 @@ proc check(username : string, path : string, trueIfLocal : bool, travis : bool) 
   var remoteTest = true;
   writeln('Mason Project Check:');
   if !package {
-    writeln('    Could not find your configuration file (Mason.toml) (FAILED)');
-    writeln('    Ensure your project is a mason package');
+    writeln('   Could not find your configuration file (Mason.toml) (FAILED)');
+    writeln('   Ensure your project is a mason package');
     packageTest = false;
     }
   else {
-    writeln('    Package is a Mason package and has a Mason.toml (PASSED)');
+    writeln('   Package is a Mason package and has a Mason.toml (PASSED)');
   }
   writeln(spacer);
 
   if package {
     writeln('Main Module Check:');
     if moduleCheck(projectCheckHome) {
-      writeln('    Your package has only one main module, can be published to a registry. (PASSED)');
+      writeln('   Your package has only one main module, can be published to a registry. (PASSED)');
     }
     else {
-      writeln('    Packages with more than one modules cannot be published. (FAILED)');
+      writeln('   Packages with more than one modules cannot be published. (FAILED)');
       moduleTest = false; 
     }
     writeln(spacer);
@@ -444,11 +444,11 @@ proc check(username : string, path : string, trueIfLocal : bool, travis : bool) 
   if package {
     writeln('Git Remote Check:');
     if doesGitOriginExist() {
-      writeln('    Package has a git remote origin and can be published to a remote registry (PASSED)');
-      writeln('    Remote Origin: ' + getRemoteOrigin());
+      writeln('   Package has a git remote origin and can be published to a remote registry (PASSED)');
+      writeln('   Remote Origin: ' + getRemoteOrigin());
     }
     else {
-      writeln('    Package has no remote origin and cannot be publish to a registry with path:' + path + ' (FAILED)');
+      writeln('   Package has no remote origin and cannot be publish to a registry with path:' + path + ' (FAILED)');
       remoteTest = false;
     }
     writeln(spacer);
@@ -459,18 +459,18 @@ proc check(username : string, path : string, trueIfLocal : bool, travis : bool) 
   writeln('The current mason environment is:');
   returnMasonEnv();
   if MASON_REGISTRY.size == 1 {
-    writeln('    In order to use a local registry, ensure that MASON_REGISTRY points to the path.');
+    writeln('   In order to use a local registry, ensure that MASON_REGISTRY points to the path.');
   }
   
   writeln(spacer);
   writeln(spacer);
   if package {
     writeln('Attempting to build package using following options:');
-    writeln('    show = false');
-    writeln('    release = false');
-    writeln('    force = true');
-    writeln('    opt = false');
-    writeln('    example = false');
+    writeln('   show = false');
+    writeln('   release = false');
+    writeln('   force = true');
+    writeln('   opt = false');
+    writeln('   example = false');
     writeln('If these are different than what is required to build your package you can disregard this check');
     attemptToBuild();
   }
@@ -533,11 +533,11 @@ private proc registryPathCheck(path : string, username : string, trueIfLocal : b
   if path == MASON_HOME {
     var forkCheck = usernameCheck(username);
     if forkCheck == 0 {
-      writeln('    The mason-registry is forked under username: ' + username + ' (PASSED)');
+      writeln('   The mason-registry is forked under username: ' + username + ' (PASSED)');
       return true;
     }
     else {
-      writeln('    You must have a fork of the mason-registry to publish a package (FAILED)');
+      writeln('   You must have a fork of the mason-registry to publish a package (FAILED)');
       return false;
     }
   }

--- a/tools/mason/MasonPublish.chpl
+++ b/tools/mason/MasonPublish.chpl
@@ -538,7 +538,7 @@ private proc registryPathCheck(path : string, username : string, trueIfLocal : b
       const hasBricks = exists(path + '/Bricks/');
       if !isLocalGit {
         writeln('   Registry with path ' + path + ' is not a git repository. (FAILED)');
-        writeln("   Local registrys must be git repositorys in order to publish");
+        writeln("   Local registries must be git repositorys in order to publish");
         return false;
       }
       else if !hasBricks {

--- a/tools/mason/MasonPublish.chpl
+++ b/tools/mason/MasonPublish.chpl
@@ -467,8 +467,7 @@ proc check(username : string, path : string, trueIfLocal) throws {
   writeln(spacer);
   writeln();
   writeln();
-
-  
+ 
   exit(0);
 }
 

--- a/tools/mason/MasonPublish.chpl
+++ b/tools/mason/MasonPublish.chpl
@@ -463,7 +463,6 @@ proc check(username : string, path : string, trueIfLocal : bool, travis : bool) 
   }
   
   writeln(spacer);
-  writeln(spacer);
   if package {
     writeln('Attempting to build package using following options:');
     writeln('   show = false');
@@ -475,6 +474,11 @@ proc check(username : string, path : string, trueIfLocal : bool, travis : bool) 
     attemptToBuild();
   }
   writeln(spacer);
+  writeln();
+  writeln();
+  writeln();
+  writeln();
+  writeln();
   writeln('RESULTS');
   writeln(spacer);
 
@@ -489,14 +493,13 @@ proc check(username : string, path : string, trueIfLocal : bool, travis : bool) 
       writeln('(FAILED) Your package has more than one main module');
     }
     if !registryTest {
-      writeln('(FAILED) Your proposed registry is not a valid registry or path to a regustry');
+      writeln('(FAILED) Your proposed registry is not a valid registry or path to a registry');
     }
     if !remoteTest {
       writeln('(FAILED) Your package has no remote origin and cannot be published');
     }
   }
 
-  writeln(spacer);
   writeln(spacer);
 
   if travis {

--- a/tools/mason/MasonPublish.chpl
+++ b/tools/mason/MasonPublish.chpl
@@ -190,7 +190,7 @@ proc publishPackage(username: string, registryPath : string, isLocal : bool) thr
     else {
       gitC(safeDir, 'git add Bricks/' + name);
       commitSubProcess(safeDir, command);
-      writeln('Succesfully published package to ' + registryPath);
+      writeln('Successfully published package to ' + registryPath);
     }
 
   }
@@ -416,81 +416,80 @@ proc check(username : string, path : string, trueIfLocal) throws {
   const package = (ensureMasonProject(here.cwd(), 'Mason.toml') == 'true');
   const projectCheckHome = here.cwd();
   writeln('Mason Project Check:');
-
   if !package {
-    writeln('    Could not find your configuration file (Mason.toml)');
+    writeln('    Could not find your configuration file (Mason.toml) (FAILED)');
     writeln('    Ensure your project is a mason package');
     }
   else {
-    writeln('    Package is a Mason package and has a Mason.toml');
+    writeln('    Package is a Mason package and has a Mason.toml (PASSED)');
   }
   writeln(spacer);
 
   if package {
     writeln('Main Module Check:');
     if moduleCheck(projectCheckHome) {
-      writeln('    Your package has only one main module, can be published to a registry.');
+      writeln('    Your package has only one main module, can be published to a registry. (PASSED)');
     }
-    else writeln('    Packages with more than one modules cannot be published.');
+    else writeln('    Packages with more than one modules cannot be published. (FAILED)');
     writeln(spacer);
   }
 
   if package {
     writeln('Git Remote Check:');
     if doesGitOriginExist() {
-      writeln('    Package has a git remote origin and can be published to a remote registry');
+      writeln('    Package has a git remote origin and can be published to a remote registry (PASSED)');
       writeln('    Remote Origin: ' + getRemoteOrigin());
     }
-    else writeln('    Package has no remote origin and cannot be publish to a registry with path:' + path);
+    else {
+      writeln('    Package has no remote origin and cannot be publish to a registry with path:' + path + ' (FAILED)');
+    }
     writeln(spacer);
   }
   writeln('Checking Registry with ' + path + ' path.');
   registryPathCheck(path, username, trueIfLocal);
   writeln(spacer);
-
-  writeln('The current mason envoirnment is:');
+  writeln('The current mason environment is:');
   returnMasonEnv();
   if MASON_REGISTRY.size == 1 {
     writeln('    In order to use a local registry, ensure that MASON_REGISTRY points to the path.');
   }
   writeln(spacer);
   if package {
-    writeln('Attmepting to build package using following options:');
+    writeln('Attempting to build package using following options:');
     writeln('    show = false');
     writeln('    release = false');
-    writeln('    force = false');
+    writeln('    force = true');
     writeln('    opt = false');
     writeln('    example = false');
     writeln('If these are different than what is required to build your package you can disregard this check');
     attemptToBuild();
   }
+  writeln(spacer);
+  writeln();
+  writeln();
+
+  
   exit(0);
 }
 
 /* Attempts to build the package/
  */
 private proc attemptToBuild() throws {
-  try! {
-    const buildArgs = ['mason', 'build'];
-    masonBuild(buildArgs);
-  }
-  catch e {
-    writeln(e.message());
-    exit(0);
-  }
+  const buildArgs = ['mason', 'build', '--force'];
+  masonBuild(buildArgs);
 }
 
-/* registryPathCheck accepts the path, userbname, and trueIfLocal in order to check whether the registry that someone
-   is trying to publish to is properly set up and has the correctr structure.
+/* registryPathCheck accepts the path, username, and trueIfLocal in order to check whether the registry that someone
+   is trying to publish to is properly set up and has the correct structure.
  */
 private proc registryPathCheck(path : string, username : string, trueIfLocal : bool) throws {
   if path == MASON_HOME {
     var forkCheck = usernameCheck(username);
     if forkCheck == 0 {
-      writeln('    The mason-registry is forked under username: ' + username);
+      writeln('    The mason-registry is forked under username: ' + username + ' (PASSED)');
     }
     else {
-      writeln('    You must have a fork of the mason-registry to publish a package');
+      writeln('    You must have a fork of the mason-registry to publish a package (FAILED)');
     }
   }
   else {
@@ -498,15 +497,15 @@ private proc registryPathCheck(path : string, username : string, trueIfLocal : b
       const isLocalGit = exists(path + '/.git');
       const hasBricks = exists(path + '/Bricks/');
       if !isLocalGit {
-        writeln('   Registry with path ' + path + ' is not a git repository.');
+        writeln('   Registry with path ' + path + ' is not a git repository. (FAILED)');
         writeln("   Local registrys must be git repositorys in order to publish");
       }
       else if !hasBricks {
-        writeln('   The registry with path ' + path + ' does not have proper registry structure');
+        writeln('   The registry with path ' + path + ' does not have proper registry structure (FAILED)');
         writeln("   A registry must have a /Bricks/ directory to be a valid registry");
       }
       else {
-        writeln('   The local registry with path ' + path + ' is a valid registry to be publish too');
+        writeln('   The local registry with path ' + path + ' is a valid registry to be publish too (PASSED)');
       }
     }
   }


### PR DESCRIPTION
Checks ability to publish package to a registry, either registry passed in or the default mason-registry. Checks git issues, package structure, registry structure, whether package builds and other issues. 
Updated tests and help output