### PR TITLE
Use array slice assignment to reduce communication in distributed sort

### DIFF
--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -2420,10 +2420,8 @@ module TwoArrayPartitioning {
             assert(total == localDomain.numIndices);
           }
           // Now store the counts into the global counts array
-          for bin in vectorizeOnly(0..#nBuckets) {
-            state.perLocale[0].globalCounts[bin*nTasks + tid] = localCounts[bin];
-          }
-          //state.globalCounts[tid.. by nTasks] = localCounts;
+          ref globalCounts = state.perLocale[0].globalCounts;
+          globalCounts[tid.. by nTasks] = localCounts;
         }
       }
       // Now the data is in Scratch


### PR DESCRIPTION
This greatly reduces the number of GETs from locales other than 0. However in my experiments it does not actually improve running time. However, it might enable further communication optimization.

GETs from the last locale reduced from ~91876 to ~7997 on 32 locales with the distributedRadixSort.chpl sorting 10000000000 elements.

- [x] test/library/packages/Sort/ with CHPL_COMM=gasnet