### PR TITLE
Add skipif NUMA for lu-perf test

### DIFF
--- a/test/library/packages/LinearAlgebra/performance/lu/lu-perf.skipif
+++ b/test/library/packages/LinearAlgebra/performance/lu/lu-perf.skipif
@@ -1,0 +1,1 @@
+CHPL_LOCALE_MODEL == numa


### PR DESCRIPTION
`test/library/packages/LinearAlgebra/performance/lu/lu-perf` runs fairly fast in default performance configuration. However, it times out under NUMA config. This PR adds skipif for the test to avoid NUMA timeouts per @ronawho's suggestion.