### PR TITLE
Change expected intents for string arguments in multilocale libraries

### DIFF
--- a/compiler/resolution/fixupExports.cpp
+++ b/compiler/resolution/fixupExports.cpp
@@ -184,7 +184,7 @@ static bool validateFormalIntent(FnSymbol* fn, ArgSymbol* as) {
   if (t == dtString) {
     IntentTag tag = as->intent;
 
-    if (fMultiLocaleInterop) {
+    if (fMultiLocaleInterop || strcmp(CHPL_COMM, "none")) {
       // TODO: After resolution, have abstract intents been normalized?
       if (tag != INTENT_IN &&
           tag != INTENT_CONST_IN) {

--- a/compiler/resolution/fixupExports.cpp
+++ b/compiler/resolution/fixupExports.cpp
@@ -191,7 +191,7 @@ static bool validateFormalIntent(FnSymbol* fn, ArgSymbol* as) {
         SET_LINENO(fn);
         if (tag == INTENT_BLANK) {
           USR_FATAL_CONT(as,  "Formal \'%s\' of type \'%s\' in exported "
-                         "routine \'%s\' may not be passed by ref in "
+                         "routine \'%s\' may not be passed by const ref in "
                          "multilocale libraries",
                          as->name, t->name(), fn->userString);
 

--- a/compiler/resolution/fixupExports.cpp
+++ b/compiler/resolution/fixupExports.cpp
@@ -184,16 +184,38 @@ static bool validateFormalIntent(FnSymbol* fn, ArgSymbol* as) {
   if (t == dtString) {
     IntentTag tag = as->intent;
 
-    // TODO: After resolution, have abstract intents been normalized?
-    if (tag != INTENT_CONST &&
-        tag != INTENT_CONST_REF &&
-        tag != INTENT_BLANK) {
-      SET_LINENO(fn);
-      USR_FATAL_CONT(as,  "Formal \'%s\' of type \'%s\' in exported routine "
-                          "\'%s\' may only have the %s",
-                          as->name, t->name(), fn->userString,
-                          intentDescrString(INTENT_CONST_REF));
-      return false;
+    if (fMultiLocaleInterop) {
+      // TODO: After resolution, have abstract intents been normalized?
+      if (tag != INTENT_IN &&
+          tag != INTENT_CONST_IN) {
+        SET_LINENO(fn);
+        if (tag == INTENT_BLANK) {
+          USR_FATAL_CONT(as,  "Formal \'%s\' of type \'%s\' in exported "
+                         "routine \'%s\' may not be passed by ref in "
+                         "multilocale libraries",
+                         as->name, t->name(), fn->userString);
+
+        } else {
+          USR_FATAL_CONT(as,  "Formal \'%s\' of type \'%s\' in exported "
+                         "routine \'%s\' may not have the %s in "
+                         "multilocale libraries",
+                         as->name, t->name(), fn->userString,
+                         intentDescrString(tag));
+        }
+        return false;
+      }
+    } else {
+      // TODO: After resolution, have abstract intents been normalized?
+      if (tag != INTENT_CONST &&
+          tag != INTENT_CONST_REF &&
+          tag != INTENT_BLANK) {
+        SET_LINENO(fn);
+        USR_FATAL_CONT(as,  "Formal \'%s\' of type \'%s\' in exported routine "
+                       "\'%s\' may not have the %s",
+                       as->name, t->name(), fn->userString,
+                       intentDescrString(tag));
+        return false;
+      }
     }
   }
 

--- a/test/interop/C/exportString/badFormalIntent.good
+++ b/test/interop/C/exportString/badFormalIntent.good
@@ -1,5 +1,5 @@
-badFormalIntent.chpl:5: error: Formal 's' of type 'string' in exported routine 'badFormalIntentIn(in s: string)' may only have the 'const ref' intent
-badFormalIntent.chpl:7: error: Formal 's' of type 'string' in exported routine 'badFormalIntentOut(out s: string)' may only have the 'const ref' intent
-badFormalIntent.chpl:9: error: Formal 's' of type 'string' in exported routine 'badFormalIntentInOut(inout s: string)' may only have the 'const ref' intent
-badFormalIntent.chpl:11: error: Formal 's' of type 'string' in exported routine 'badFormalIntentRef(ref s: string)' may only have the 'const ref' intent
-badFormalIntent.chpl:13: error: Formal 's' of type 'string' in exported routine 'badFormalIntentConstIn(const in s: string)' may only have the 'const ref' intent
+badFormalIntent.chpl:5: error: Formal 's' of type 'string' in exported routine 'badFormalIntentIn(in s: string)' may not have the 'in' intent
+badFormalIntent.chpl:7: error: Formal 's' of type 'string' in exported routine 'badFormalIntentOut(out s: string)' may not have the 'out' intent
+badFormalIntent.chpl:9: error: Formal 's' of type 'string' in exported routine 'badFormalIntentInOut(inout s: string)' may not have the 'inout' intent
+badFormalIntent.chpl:11: error: Formal 's' of type 'string' in exported routine 'badFormalIntentRef(ref s: string)' may not have the 'ref' intent
+badFormalIntent.chpl:13: error: Formal 's' of type 'string' in exported routine 'badFormalIntentConstIn(const in s: string)' may not have the 'const in' intent

--- a/test/interop/C/multilocale/exportString/TestLibrary.chpl
+++ b/test/interop/C/multilocale/exportString/TestLibrary.chpl
@@ -7,12 +7,12 @@ export proc noArgsRetString(): string {
   return "Greetings, human!";
 }
 
-export proc stringArgsRetVoid(a: string, b: string) {
+export proc stringArgsRetVoid(in a: string, in b: string) {
   writeln(a);
   writeln(b);
 }
 
-export proc stringArgsRetString(a: string, b: string): string {
+export proc stringArgsRetString(in a: string, in b: string): string {
   return a + b;
 }
 

--- a/test/interop/C/multilocale/exportString/badFormalIntent.chpl
+++ b/test/interop/C/multilocale/exportString/badFormalIntent.chpl
@@ -1,8 +1,8 @@
 
 
+export proc badFormalIntentNone(s: string) {}
 
-
-export proc badFormalIntentIn(in s: string) {}
+export proc badFormalIntentConst(const s: string) {}
 
 export proc badFormalIntentOut(out s: string) {}
 
@@ -10,5 +10,5 @@ export proc badFormalIntentInOut(inout s: string) {}
 
 export proc badFormalIntentRef(ref s: string) {}
 
-export proc badFormalIntentConstIn(const in s: string) {}
+export proc badFormalIntentConstRef(const ref s: string) {}
 

--- a/test/interop/C/multilocale/exportString/badFormalIntent.good
+++ b/test/interop/C/multilocale/exportString/badFormalIntent.good
@@ -1,5 +1,6 @@
-badFormalIntent.chpl:5: error: Formal 's' of type 'string' in exported routine 'badFormalIntentIn(in s: string)' may only have the 'const ref' intent
-badFormalIntent.chpl:7: error: Formal 's' of type 'string' in exported routine 'badFormalIntentOut(out s: string)' may only have the 'const ref' intent
-badFormalIntent.chpl:9: error: Formal 's' of type 'string' in exported routine 'badFormalIntentInOut(inout s: string)' may only have the 'const ref' intent
-badFormalIntent.chpl:11: error: Formal 's' of type 'string' in exported routine 'badFormalIntentRef(ref s: string)' may only have the 'const ref' intent
-badFormalIntent.chpl:13: error: Formal 's' of type 'string' in exported routine 'badFormalIntentConstIn(const in s: string)' may only have the 'const ref' intent
+badFormalIntent.chpl:3: error: Formal 's' of type 'string' in exported routine 'badFormalIntentNone(s: string)' may not be passed by ref in multilocale libraries
+badFormalIntent.chpl:5: error: Formal 's' of type 'string' in exported routine 'badFormalIntentConst(const s: string)' may not have the 'const' intent in multilocale libraries
+badFormalIntent.chpl:7: error: Formal 's' of type 'string' in exported routine 'badFormalIntentOut(out s: string)' may not have the 'out' intent in multilocale libraries
+badFormalIntent.chpl:9: error: Formal 's' of type 'string' in exported routine 'badFormalIntentInOut(inout s: string)' may not have the 'inout' intent in multilocale libraries
+badFormalIntent.chpl:11: error: Formal 's' of type 'string' in exported routine 'badFormalIntentRef(ref s: string)' may not have the 'ref' intent in multilocale libraries
+badFormalIntent.chpl:13: error: Formal 's' of type 'string' in exported routine 'badFormalIntentConstRef(const ref s: string)' may not have the 'const ref' intent in multilocale libraries

--- a/test/interop/C/multilocale/exportString/badFormalIntent.good
+++ b/test/interop/C/multilocale/exportString/badFormalIntent.good
@@ -1,4 +1,4 @@
-badFormalIntent.chpl:3: error: Formal 's' of type 'string' in exported routine 'badFormalIntentNone(s: string)' may not be passed by ref in multilocale libraries
+badFormalIntent.chpl:3: error: Formal 's' of type 'string' in exported routine 'badFormalIntentNone(s: string)' may not be passed by const ref in multilocale libraries
 badFormalIntent.chpl:5: error: Formal 's' of type 'string' in exported routine 'badFormalIntentConst(const s: string)' may not have the 'const' intent in multilocale libraries
 badFormalIntent.chpl:7: error: Formal 's' of type 'string' in exported routine 'badFormalIntentOut(out s: string)' may not have the 'out' intent in multilocale libraries
 badFormalIntent.chpl:9: error: Formal 's' of type 'string' in exported routine 'badFormalIntentInOut(inout s: string)' may not have the 'inout' intent in multilocale libraries

--- a/test/interop/python/errorMessages/badFormalIntent.good
+++ b/test/interop/python/errorMessages/badFormalIntent.good
@@ -1,5 +1,5 @@
-badFormalIntent.chpl:5: error: Formal 's' of type 'string' in exported routine 'badFormalIntentIn(in s: string)' may only have the 'const ref' intent
-badFormalIntent.chpl:7: error: Formal 's' of type 'string' in exported routine 'badFormalIntentOut(out s: string)' may only have the 'const ref' intent
-badFormalIntent.chpl:9: error: Formal 's' of type 'string' in exported routine 'badFormalIntentInOut(inout s: string)' may only have the 'const ref' intent
-badFormalIntent.chpl:11: error: Formal 's' of type 'string' in exported routine 'badFormalIntentRef(ref s: string)' may only have the 'const ref' intent
-badFormalIntent.chpl:13: error: Formal 's' of type 'string' in exported routine 'badFormalIntentConstIn(const in s: string)' may only have the 'const ref' intent
+badFormalIntent.chpl:5: error: Formal 's' of type 'string' in exported routine 'badFormalIntentIn(in s: string)' may not have the 'in' intent
+badFormalIntent.chpl:7: error: Formal 's' of type 'string' in exported routine 'badFormalIntentOut(out s: string)' may not have the 'out' intent
+badFormalIntent.chpl:9: error: Formal 's' of type 'string' in exported routine 'badFormalIntentInOut(inout s: string)' may not have the 'inout' intent
+badFormalIntent.chpl:11: error: Formal 's' of type 'string' in exported routine 'badFormalIntentRef(ref s: string)' may not have the 'ref' intent
+badFormalIntent.chpl:13: error: Formal 's' of type 'string' in exported routine 'badFormalIntentConstIn(const in s: string)' may not have the 'const in' intent

--- a/test/interop/python/errorMessages/badFormalIntent.skipif
+++ b/test/interop/python/errorMessages/badFormalIntent.skipif
@@ -1,0 +1,1 @@
+CHPL_COMM != none

--- a/test/interop/python/multilocale/chapelStrings/stringArgAndReturn.chpl
+++ b/test/interop/python/multilocale/chapelStrings/stringArgAndReturn.chpl
@@ -2,10 +2,10 @@ export proc noArgsRetString(): string {
   return "boo!";
 }
 
-export proc stringArgsRetVoid(a: string) {
+export proc stringArgsRetVoid(in a: string) {
   writeln(a);
 }
 
-export proc stringArgsRetString(a: string, b: string): string {
+export proc stringArgsRetString(in a: string, in b: string): string {
   return a + b;
 }


### PR DESCRIPTION
Prior to this change, we were relying on the default intent for strings
in multilocale libraries and banning other intents.  However, the default
intent for strings is `const ref` and due to the implementation of
multilocale interoperability, `const ref` is not feasible (because the
data is copied from the client code to the library server running
remotely).  This change makes it so that we allow strings to be
passed by `in` and `const in` intent, and ban the other intents for
multilocale interoperability.

While here, also update the error message for the single locale case - more than
just the listed ones are allowed, so it doesn't make sense to only say one of
the allowed ones in the error message.

I debated about blanket allowing more intents for single locale, but ultimately
decided against it - some of them run into an internal check which was intended
to ensure only strings were used but they got tangled up in it due to the
argument type being ref(string) at the time.  Resolving that should be do-able
but was more effort than I wanted to tackle this close to the release with other
priorities.

This change updates the expected behavior of string tests to reflect the new
status quo.

Testing:
- [x] test/interop/C/multilocale darwin with gasnet
- [x] test/interop/C darwin with COMM=none
- [x] full paratest on linux with gasnet
- [x] full paratest on linux with COMM=none
- [x] test/interop/python/multilocale darwin with gasnet
- [x] test/interop/python darwin with COMM=none
- [x] test/interop/python on linux with COMM=none
- [x] test/interop/python/multilocale on linux with COMM=gasnet