### PR TITLE
Add SKIPIFs for LinearAlgebra test subdirs

### DIFF
--- a/test/library/packages/LinearAlgebra/performance/diag/SKIPIF
+++ b/test/library/packages/LinearAlgebra/performance/diag/SKIPIF
@@ -1,1 +1,0 @@
-../../../LAPACK.skipif


### PR DESCRIPTION
The LU tests were failing due to missing headers. That was because I wrongly assumed that SKIPIFs are recursive. @ben-albrecht pointed out that they aren't.

Tested in a system that these tests are supposed to be skipped and in another that they aren't.