### PR TITLE
Remove duplicate decorators

### DIFF
--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -892,8 +892,8 @@ module ChapelArray {
   record dmap { }
 
   pragma "unsafe"
-  proc chpl__buildDistType(type t) type where isSubtype(borrowed t, BaseDist) {
-    var x: unmanaged t;
+  proc chpl__buildDistType(type t) type where isSubtype(_to_borrowed(t), BaseDist) {
+    var x: _to_unmanaged(t);
     var y = new _distribution(x);
     return y.type;
   }


### PR DESCRIPTION
Follow-on to PR #13899.

Trivial and not reviewed.
See the test test/distributions/deitz/test_distribution_syntax2.chpl

Passes linux64 -futures, gasnet -futures.