### PR TITLE
Print instantiation information on fatal errors too

### DIFF
--- a/compiler/util/misc.cpp
+++ b/compiler/util/misc.cpp
@@ -441,6 +441,7 @@ static void printErrorFooter(bool guess) {
     // and exit if it's fatal (isn't it always?)
     //
     if (err_fatal && !(err_user && ignore_user_errors)) {
+      printInstantiationNoteForLastError();
       clean_exit(1);
     }
   }
@@ -542,6 +543,7 @@ void handleError(const char* fmt, ...) {
     if (ignore_errors_for_pass) {
       exit_end_of_pass = true;
     } else if (!ignore_errors && !(ignore_user_errors && err_user)) {
+      printInstantiationNoteForLastError();
       clean_exit(1);
     }
   }
@@ -618,6 +620,7 @@ static void vhandleError(FILE*          file,
     if (ignore_errors_for_pass) {
       exit_end_of_pass = true;
     } else if (!ignore_errors && !(ignore_user_errors && err_user)) {
+      printInstantiationNoteForLastError();
       clean_exit(1);
     }
   }

--- a/test/analysis/flowanalysis/rec_fun-1.good
+++ b/test/analysis/flowanalysis/rec_fun-1.good
@@ -1,3 +1,4 @@
 rec_fun-1.chpl:2: error: unable to resolve return type of function 'f'
 rec_fun-1.chpl:2: In function 'f':
 rec_fun-1.chpl:5: error: called recursively at this point
+rec_fun-1.chpl:8: Function 'f' instantiated as: f(x: int(64))

--- a/test/analysis/flowanalysis/rec_fun-2.good
+++ b/test/analysis/flowanalysis/rec_fun-2.good
@@ -1,3 +1,4 @@
 rec_fun-2.chpl:2: error: unable to resolve return type of function 'g'
 rec_fun-2.chpl:2: In function 'g':
 rec_fun-2.chpl:5: error: called recursively at this point
+rec_fun-2.chpl:9: Function 'g' instantiated as: g(x: int(64))

--- a/test/analysis/flowanalysis/rec_fun-3.good
+++ b/test/analysis/flowanalysis/rec_fun-3.good
@@ -1,3 +1,4 @@
 rec_fun-3.chpl:2: error: unable to resolve return type of function 'g'
 rec_fun-3.chpl:2: In function 'g':
 rec_fun-3.chpl:5: error: called recursively at this point
+rec_fun-3.chpl:10: Function 'g' instantiated as: g(x: int(64))

--- a/test/arrays/errors/domainTypeAsDomainExpr.chpl
+++ b/test/arrays/errors/domainTypeAsDomainExpr.chpl
@@ -3,7 +3,7 @@ class Child : Base {
   var s: string;
 }
 
-proc fn(vec: [domain(1,int(64),false)] _owned(Child)) {
+proc fn(vec: [domain(1,int(64),false)] owned Child) {
   return vec;
 }
 

--- a/test/arrays/errors/domainTypeAsDomainExpr.good
+++ b/test/arrays/errors/domainTypeAsDomainExpr.good
@@ -1,2 +1,3 @@
 domainTypeAsDomainExpr.chpl:6: In function 'fn':
 domainTypeAsDomainExpr.chpl:6: error: Domain expression was a type ('domain(1,int(64),false)') rather than a domain value or range list as expected
+domainTypeAsDomainExpr.chpl:12: Function 'fn' instantiated as: fn(vec: [domain(1,int(64),false)] owned Child)

--- a/test/arrays/return/returnArbitraryBadEltType.good
+++ b/test/arrays/return/returnArbitraryBadEltType.good
@@ -1,2 +1,3 @@
 returnArbitraryBadEltType.chpl:1: In function 'inc':
 returnArbitraryBadEltType.chpl:2: error: array element type mismatch in return from real(64) to int(64)
+returnArbitraryBadEltType.chpl:7: Function 'inc' instantiated as: inc(X: [domain(1,int(64),false)] real(64))

--- a/test/arrays/return/returnArbitraryCoerced.bad
+++ b/test/arrays/return/returnArbitraryCoerced.bad
@@ -1,2 +1,3 @@
 returnArbitraryCoerced.chpl:1: In function 'inc':
 returnArbitraryCoerced.chpl:2: error: array element type mismatch in return from int(64) to real(64)
+returnArbitraryCoerced.chpl:7: Function 'inc' instantiated as: inc(X: [domain(1,int(64),false)] int(64))

--- a/test/arrays/userAPI/arrayOps2D-IRV.good
+++ b/test/arrays/userAPI/arrayOps2D-IRV.good
@@ -1,2 +1,3 @@
 ./arrayAPItest.chpl:103: In function 'testArrayAPI2D':
 ./arrayAPItest.chpl:222: error: only sparse arrays have an IRV
+arrayOps2D.chpl:5: Function 'testArrayAPI2D' instantiated as: testArrayAPI2D(lbl: string, X: [domain(2,int(64),false)] real(64), sliceDom: domain(2,int(64),false), reindexDom: domain(2,int(64),true))

--- a/test/arrays/userAPI/arrayOps2D-reverse.good
+++ b/test/arrays/userAPI/arrayOps2D-reverse.good
@@ -1,2 +1,3 @@
 ./arrayAPItest.chpl:103: In function 'testArrayAPI2D':
 ./arrayAPItest.chpl:218: error: reverse() is only supported on dense 1D arrays
+arrayOps2D.chpl:5: Function 'testArrayAPI2D' instantiated as: testArrayAPI2D(lbl: string, X: [domain(2,int(64),false)] real(64), sliceDom: domain(2,int(64),false), reindexDom: domain(2,int(64),true))

--- a/test/arrays/userAPI/arrayOps2D-sorted.good
+++ b/test/arrays/userAPI/arrayOps2D-sorted.good
@@ -1,2 +1,3 @@
 ./arrayAPItest.chpl:103: In function 'testArrayAPI2D':
 ./arrayAPItest.chpl:227: error: sort() requires 1-D array
+arrayOps2D.chpl:5: Function 'testArrayAPI2D' instantiated as: testArrayAPI2D(lbl: string, X: [domain(2,int(64),false)] real(64), sliceDom: domain(2,int(64),false), reindexDom: domain(2,int(64),true))

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-borrowed-from-oknil-borrowed.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-borrowed-from-oknil-borrowed.good
@@ -1,2 +1,3 @@
 init-field-arg-nonnil-borrowed-from-oknil-borrowed.chpl:9: In initializer:
 init-field-arg-nonnil-borrowed-from-oknil-borrowed.chpl:10: error: cannot initialize field MyRecord.lhs of non-nilable type 'borrowed MyClass' from a nilable 'borrowed MyClass?'
+init-field-arg-nonnil-borrowed-from-oknil-borrowed.chpl:14: Initializer instantiated as: init(rhs: borrowed MyClass?)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-borrowed-from-oknil-nil.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-borrowed-from-oknil-nil.good
@@ -1,2 +1,3 @@
 init-field-arg-nonnil-borrowed-from-oknil-nil.chpl:9: In initializer:
 init-field-arg-nonnil-borrowed-from-oknil-nil.chpl:10: error: cannot assign to borrowed MyClass from nil
+init-field-arg-nonnil-borrowed-from-oknil-nil.chpl:14: Initializer instantiated as: init(rhs: nil)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-borrowed-from-oknil-owned.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-borrowed-from-oknil-owned.good
@@ -1,2 +1,3 @@
 init-field-arg-nonnil-borrowed-from-oknil-owned.chpl:9: In initializer:
 init-field-arg-nonnil-borrowed-from-oknil-owned.chpl:10: error: cannot initialize field MyRecord.lhs of non-nilable type 'borrowed MyClass' from a nilable 'owned MyClass?'
+init-field-arg-nonnil-borrowed-from-oknil-owned.chpl:14: Initializer instantiated as: init(rhs: owned MyClass?)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-borrowed-from-oknil-shared.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-borrowed-from-oknil-shared.good
@@ -1,2 +1,3 @@
 init-field-arg-nonnil-borrowed-from-oknil-shared.chpl:9: In initializer:
 init-field-arg-nonnil-borrowed-from-oknil-shared.chpl:10: error: cannot initialize field MyRecord.lhs of non-nilable type 'borrowed MyClass' from a nilable 'shared MyClass?'
+init-field-arg-nonnil-borrowed-from-oknil-shared.chpl:14: Initializer instantiated as: init(rhs: shared MyClass?)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-borrowed-from-oknil-unmanaged.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-borrowed-from-oknil-unmanaged.good
@@ -1,2 +1,3 @@
 init-field-arg-nonnil-borrowed-from-oknil-unmanaged.chpl:9: In initializer:
 init-field-arg-nonnil-borrowed-from-oknil-unmanaged.chpl:10: error: cannot initialize field MyRecord.lhs of non-nilable type 'borrowed MyClass' from a nilable 'unmanaged MyClass?'
+init-field-arg-nonnil-borrowed-from-oknil-unmanaged.chpl:14: Initializer instantiated as: init(rhs: unmanaged MyClass?)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-owned-from-nonnil-borrowed.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-owned-from-nonnil-borrowed.good
@@ -1,2 +1,3 @@
 init-field-arg-nonnil-owned-from-nonnil-borrowed.chpl:9: In initializer:
 init-field-arg-nonnil-owned-from-nonnil-borrowed.chpl:10: error: cannot create an owned variable from a borrowed class instance
+init-field-arg-nonnil-owned-from-nonnil-borrowed.chpl:14: Initializer instantiated as: init(rhs: borrowed MyClass)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-owned-from-nonnil-shared.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-owned-from-nonnil-shared.good
@@ -1,2 +1,3 @@
 init-field-arg-nonnil-owned-from-nonnil-shared.chpl:9: In initializer:
 init-field-arg-nonnil-owned-from-nonnil-shared.chpl:10: error: cannot create an owned variable from a shared class instance
+init-field-arg-nonnil-owned-from-nonnil-shared.chpl:14: Initializer instantiated as: init(rhs: shared MyClass)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-owned-from-nonnil-unmanaged.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-owned-from-nonnil-unmanaged.good
@@ -1,2 +1,3 @@
 init-field-arg-nonnil-owned-from-nonnil-unmanaged.chpl:9: In initializer:
 init-field-arg-nonnil-owned-from-nonnil-unmanaged.chpl:10: error: cannot create an owned variable from an unmanaged class instance
+init-field-arg-nonnil-owned-from-nonnil-unmanaged.chpl:14: Initializer instantiated as: init(rhs: unmanaged MyClass)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-owned-from-oknil-borrowed.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-owned-from-oknil-borrowed.good
@@ -1,2 +1,3 @@
 init-field-arg-nonnil-owned-from-oknil-borrowed.chpl:9: In initializer:
 init-field-arg-nonnil-owned-from-oknil-borrowed.chpl:10: error: cannot create an owned variable from a borrowed class instance
+init-field-arg-nonnil-owned-from-oknil-borrowed.chpl:14: Initializer instantiated as: init(rhs: borrowed MyClass?)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-owned-from-oknil-nil.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-owned-from-oknil-nil.good
@@ -1,2 +1,3 @@
 init-field-arg-nonnil-owned-from-oknil-nil.chpl:9: In initializer:
 init-field-arg-nonnil-owned-from-oknil-nil.chpl:10: error: Assigning non-nilable owned to nil
+init-field-arg-nonnil-owned-from-oknil-nil.chpl:14: Initializer instantiated as: init(rhs: nil)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-owned-from-oknil-owned.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-owned-from-oknil-owned.good
@@ -1,2 +1,3 @@
 init-field-arg-nonnil-owned-from-oknil-owned.chpl:9: In initializer:
 init-field-arg-nonnil-owned-from-oknil-owned.chpl:10: error: cannot create a non-nilable owned variable from a nilable class instance
+init-field-arg-nonnil-owned-from-oknil-owned.chpl:14: Initializer instantiated as: init(rhs: owned MyClass?)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-owned-from-oknil-shared.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-owned-from-oknil-shared.good
@@ -1,2 +1,3 @@
 init-field-arg-nonnil-owned-from-oknil-shared.chpl:9: In initializer:
 init-field-arg-nonnil-owned-from-oknil-shared.chpl:10: error: cannot create an owned variable from a shared class instance
+init-field-arg-nonnil-owned-from-oknil-shared.chpl:14: Initializer instantiated as: init(rhs: shared MyClass?)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-owned-from-oknil-unmanaged.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-owned-from-oknil-unmanaged.good
@@ -1,2 +1,3 @@
 init-field-arg-nonnil-owned-from-oknil-unmanaged.chpl:9: In initializer:
 init-field-arg-nonnil-owned-from-oknil-unmanaged.chpl:10: error: cannot create an owned variable from an unmanaged class instance
+init-field-arg-nonnil-owned-from-oknil-unmanaged.chpl:14: Initializer instantiated as: init(rhs: unmanaged MyClass?)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-shared-from-nonnil-borrowed.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-shared-from-nonnil-borrowed.good
@@ -1,2 +1,3 @@
 init-field-arg-nonnil-shared-from-nonnil-borrowed.chpl:9: In initializer:
 init-field-arg-nonnil-shared-from-nonnil-borrowed.chpl:10: error: cannot create a shared variable from a borrowed class instance
+init-field-arg-nonnil-shared-from-nonnil-borrowed.chpl:14: Initializer instantiated as: init(rhs: borrowed MyClass)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-shared-from-nonnil-unmanaged.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-shared-from-nonnil-unmanaged.good
@@ -1,2 +1,3 @@
 init-field-arg-nonnil-shared-from-nonnil-unmanaged.chpl:9: In initializer:
 init-field-arg-nonnil-shared-from-nonnil-unmanaged.chpl:10: error: cannot create a shared variable from an unmanaged class instance
+init-field-arg-nonnil-shared-from-nonnil-unmanaged.chpl:14: Initializer instantiated as: init(rhs: unmanaged MyClass)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-shared-from-oknil-borrowed.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-shared-from-oknil-borrowed.good
@@ -1,2 +1,3 @@
 init-field-arg-nonnil-shared-from-oknil-borrowed.chpl:9: In initializer:
 init-field-arg-nonnil-shared-from-oknil-borrowed.chpl:10: error: cannot create a shared variable from a borrowed class instance
+init-field-arg-nonnil-shared-from-oknil-borrowed.chpl:14: Initializer instantiated as: init(rhs: borrowed MyClass?)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-shared-from-oknil-nil.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-shared-from-oknil-nil.good
@@ -1,2 +1,3 @@
 init-field-arg-nonnil-shared-from-oknil-nil.chpl:9: In initializer:
 init-field-arg-nonnil-shared-from-oknil-nil.chpl:10: error: Assigning non-nilable shared to nil
+init-field-arg-nonnil-shared-from-oknil-nil.chpl:14: Initializer instantiated as: init(rhs: nil)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-shared-from-oknil-owned.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-shared-from-oknil-owned.good
@@ -1,2 +1,3 @@
 init-field-arg-nonnil-shared-from-oknil-owned.chpl:9: In initializer:
 init-field-arg-nonnil-shared-from-oknil-owned.chpl:10: error: cannot create a non-nilable shared variable from a nilable class instance
+init-field-arg-nonnil-shared-from-oknil-owned.chpl:14: Initializer instantiated as: init(rhs: owned MyClass?)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-shared-from-oknil-shared.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-shared-from-oknil-shared.good
@@ -1,2 +1,3 @@
 init-field-arg-nonnil-shared-from-oknil-shared.chpl:9: In initializer:
 init-field-arg-nonnil-shared-from-oknil-shared.chpl:10: error: cannot create a non-nilable shared variable from a nilable class instance
+init-field-arg-nonnil-shared-from-oknil-shared.chpl:14: Initializer instantiated as: init(rhs: shared MyClass?)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-shared-from-oknil-unmanaged.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-shared-from-oknil-unmanaged.good
@@ -1,2 +1,3 @@
 init-field-arg-nonnil-shared-from-oknil-unmanaged.chpl:9: In initializer:
 init-field-arg-nonnil-shared-from-oknil-unmanaged.chpl:10: error: cannot create a shared variable from an unmanaged class instance
+init-field-arg-nonnil-shared-from-oknil-unmanaged.chpl:14: Initializer instantiated as: init(rhs: unmanaged MyClass?)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-unmanaged-from-nonnil-borrowed.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-unmanaged-from-nonnil-borrowed.good
@@ -1,2 +1,3 @@
 init-field-arg-nonnil-unmanaged-from-nonnil-borrowed.chpl:9: In initializer:
 init-field-arg-nonnil-unmanaged-from-nonnil-borrowed.chpl:10: error: cannot initialize field MyRecord.lhs of type 'unmanaged MyClass' from a 'borrowed MyClass'
+init-field-arg-nonnil-unmanaged-from-nonnil-borrowed.chpl:14: Initializer instantiated as: init(rhs: borrowed MyClass)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-unmanaged-from-nonnil-owned.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-unmanaged-from-nonnil-owned.good
@@ -1,2 +1,3 @@
 init-field-arg-nonnil-unmanaged-from-nonnil-owned.chpl:9: In initializer:
 init-field-arg-nonnil-unmanaged-from-nonnil-owned.chpl:10: error: cannot initialize field MyRecord.lhs of type 'unmanaged MyClass' from a 'owned MyClass'
+init-field-arg-nonnil-unmanaged-from-nonnil-owned.chpl:14: Initializer instantiated as: init(rhs: owned MyClass)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-unmanaged-from-nonnil-shared.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-unmanaged-from-nonnil-shared.good
@@ -1,2 +1,3 @@
 init-field-arg-nonnil-unmanaged-from-nonnil-shared.chpl:9: In initializer:
 init-field-arg-nonnil-unmanaged-from-nonnil-shared.chpl:10: error: cannot initialize field MyRecord.lhs of type 'unmanaged MyClass' from a 'shared MyClass'
+init-field-arg-nonnil-unmanaged-from-nonnil-shared.chpl:14: Initializer instantiated as: init(rhs: shared MyClass)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-unmanaged-from-oknil-borrowed.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-unmanaged-from-oknil-borrowed.good
@@ -1,2 +1,3 @@
 init-field-arg-nonnil-unmanaged-from-oknil-borrowed.chpl:9: In initializer:
 init-field-arg-nonnil-unmanaged-from-oknil-borrowed.chpl:10: error: cannot initialize field MyRecord.lhs of non-nilable type 'unmanaged MyClass' from a nilable 'borrowed MyClass?'
+init-field-arg-nonnil-unmanaged-from-oknil-borrowed.chpl:14: Initializer instantiated as: init(rhs: borrowed MyClass?)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-unmanaged-from-oknil-nil.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-unmanaged-from-oknil-nil.good
@@ -1,2 +1,3 @@
 init-field-arg-nonnil-unmanaged-from-oknil-nil.chpl:9: In initializer:
 init-field-arg-nonnil-unmanaged-from-oknil-nil.chpl:10: error: cannot assign to unmanaged MyClass from nil
+init-field-arg-nonnil-unmanaged-from-oknil-nil.chpl:14: Initializer instantiated as: init(rhs: nil)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-unmanaged-from-oknil-owned.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-unmanaged-from-oknil-owned.good
@@ -1,2 +1,3 @@
 init-field-arg-nonnil-unmanaged-from-oknil-owned.chpl:9: In initializer:
 init-field-arg-nonnil-unmanaged-from-oknil-owned.chpl:10: error: cannot initialize field MyRecord.lhs of non-nilable type 'unmanaged MyClass' from a nilable 'owned MyClass?'
+init-field-arg-nonnil-unmanaged-from-oknil-owned.chpl:14: Initializer instantiated as: init(rhs: owned MyClass?)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-unmanaged-from-oknil-shared.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-unmanaged-from-oknil-shared.good
@@ -1,2 +1,3 @@
 init-field-arg-nonnil-unmanaged-from-oknil-shared.chpl:9: In initializer:
 init-field-arg-nonnil-unmanaged-from-oknil-shared.chpl:10: error: cannot initialize field MyRecord.lhs of non-nilable type 'unmanaged MyClass' from a nilable 'shared MyClass?'
+init-field-arg-nonnil-unmanaged-from-oknil-shared.chpl:14: Initializer instantiated as: init(rhs: shared MyClass?)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-unmanaged-from-oknil-unmanaged.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-nonnil-unmanaged-from-oknil-unmanaged.good
@@ -1,2 +1,3 @@
 init-field-arg-nonnil-unmanaged-from-oknil-unmanaged.chpl:9: In initializer:
 init-field-arg-nonnil-unmanaged-from-oknil-unmanaged.chpl:10: error: cannot initialize field MyRecord.lhs of non-nilable type 'unmanaged MyClass' from a nilable 'unmanaged MyClass?'
+init-field-arg-nonnil-unmanaged-from-oknil-unmanaged.chpl:14: Initializer instantiated as: init(rhs: unmanaged MyClass?)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-owned-from-nonnil-borrowed.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-owned-from-nonnil-borrowed.good
@@ -1,2 +1,3 @@
 init-field-arg-oknil-owned-from-nonnil-borrowed.chpl:9: In initializer:
 init-field-arg-oknil-owned-from-nonnil-borrowed.chpl:10: error: cannot create an owned variable from a borrowed class instance
+init-field-arg-oknil-owned-from-nonnil-borrowed.chpl:14: Initializer instantiated as: init(rhs: borrowed MyClass)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-owned-from-nonnil-shared.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-owned-from-nonnil-shared.good
@@ -1,2 +1,3 @@
 init-field-arg-oknil-owned-from-nonnil-shared.chpl:9: In initializer:
 init-field-arg-oknil-owned-from-nonnil-shared.chpl:10: error: cannot create an owned variable from a shared class instance
+init-field-arg-oknil-owned-from-nonnil-shared.chpl:14: Initializer instantiated as: init(rhs: shared MyClass)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-owned-from-nonnil-unmanaged.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-owned-from-nonnil-unmanaged.good
@@ -1,2 +1,3 @@
 init-field-arg-oknil-owned-from-nonnil-unmanaged.chpl:9: In initializer:
 init-field-arg-oknil-owned-from-nonnil-unmanaged.chpl:10: error: cannot create an owned variable from an unmanaged class instance
+init-field-arg-oknil-owned-from-nonnil-unmanaged.chpl:14: Initializer instantiated as: init(rhs: unmanaged MyClass)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-owned-from-oknil-borrowed.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-owned-from-oknil-borrowed.good
@@ -1,2 +1,3 @@
 init-field-arg-oknil-owned-from-oknil-borrowed.chpl:9: In initializer:
 init-field-arg-oknil-owned-from-oknil-borrowed.chpl:10: error: cannot create an owned variable from a borrowed class instance
+init-field-arg-oknil-owned-from-oknil-borrowed.chpl:14: Initializer instantiated as: init(rhs: borrowed MyClass?)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-owned-from-oknil-shared.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-owned-from-oknil-shared.good
@@ -1,2 +1,3 @@
 init-field-arg-oknil-owned-from-oknil-shared.chpl:9: In initializer:
 init-field-arg-oknil-owned-from-oknil-shared.chpl:10: error: cannot create an owned variable from a shared class instance
+init-field-arg-oknil-owned-from-oknil-shared.chpl:14: Initializer instantiated as: init(rhs: shared MyClass?)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-owned-from-oknil-unmanaged.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-owned-from-oknil-unmanaged.good
@@ -1,2 +1,3 @@
 init-field-arg-oknil-owned-from-oknil-unmanaged.chpl:9: In initializer:
 init-field-arg-oknil-owned-from-oknil-unmanaged.chpl:10: error: cannot create an owned variable from an unmanaged class instance
+init-field-arg-oknil-owned-from-oknil-unmanaged.chpl:14: Initializer instantiated as: init(rhs: unmanaged MyClass?)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-shared-from-nonnil-borrowed.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-shared-from-nonnil-borrowed.good
@@ -1,2 +1,3 @@
 init-field-arg-oknil-shared-from-nonnil-borrowed.chpl:9: In initializer:
 init-field-arg-oknil-shared-from-nonnil-borrowed.chpl:10: error: cannot create a shared variable from a borrowed class instance
+init-field-arg-oknil-shared-from-nonnil-borrowed.chpl:14: Initializer instantiated as: init(rhs: borrowed MyClass)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-shared-from-nonnil-owned.bad
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-shared-from-nonnil-owned.bad
@@ -1,2 +1,3 @@
 init-field-arg-oknil-shared-from-nonnil-owned.chpl:9: In initializer:
 init-field-arg-oknil-shared-from-nonnil-owned.chpl:10: error: cannot assign expression of type borrowed MyClass to field 'chpl_t' of type borrowed MyClass?
+init-field-arg-oknil-shared-from-nonnil-owned.chpl:14: Initializer instantiated as: init(rhs: owned MyClass)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-shared-from-nonnil-unmanaged.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-shared-from-nonnil-unmanaged.good
@@ -1,2 +1,3 @@
 init-field-arg-oknil-shared-from-nonnil-unmanaged.chpl:9: In initializer:
 init-field-arg-oknil-shared-from-nonnil-unmanaged.chpl:10: error: cannot create a shared variable from an unmanaged class instance
+init-field-arg-oknil-shared-from-nonnil-unmanaged.chpl:14: Initializer instantiated as: init(rhs: unmanaged MyClass)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-shared-from-oknil-borrowed.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-shared-from-oknil-borrowed.good
@@ -1,2 +1,3 @@
 init-field-arg-oknil-shared-from-oknil-borrowed.chpl:9: In initializer:
 init-field-arg-oknil-shared-from-oknil-borrowed.chpl:10: error: cannot create a shared variable from a borrowed class instance
+init-field-arg-oknil-shared-from-oknil-borrowed.chpl:14: Initializer instantiated as: init(rhs: borrowed MyClass?)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-shared-from-oknil-unmanaged.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-shared-from-oknil-unmanaged.good
@@ -1,2 +1,3 @@
 init-field-arg-oknil-shared-from-oknil-unmanaged.chpl:9: In initializer:
 init-field-arg-oknil-shared-from-oknil-unmanaged.chpl:10: error: cannot create a shared variable from an unmanaged class instance
+init-field-arg-oknil-shared-from-oknil-unmanaged.chpl:14: Initializer instantiated as: init(rhs: unmanaged MyClass?)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-unmanaged-from-nonnil-borrowed.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-unmanaged-from-nonnil-borrowed.good
@@ -1,2 +1,3 @@
 init-field-arg-oknil-unmanaged-from-nonnil-borrowed.chpl:9: In initializer:
 init-field-arg-oknil-unmanaged-from-nonnil-borrowed.chpl:10: error: cannot initialize field MyRecord.lhs of type 'unmanaged MyClass?' from a 'borrowed MyClass'
+init-field-arg-oknil-unmanaged-from-nonnil-borrowed.chpl:14: Initializer instantiated as: init(rhs: borrowed MyClass)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-unmanaged-from-nonnil-owned.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-unmanaged-from-nonnil-owned.good
@@ -1,2 +1,3 @@
 init-field-arg-oknil-unmanaged-from-nonnil-owned.chpl:9: In initializer:
 init-field-arg-oknil-unmanaged-from-nonnil-owned.chpl:10: error: cannot initialize field MyRecord.lhs of type 'unmanaged MyClass?' from a 'owned MyClass'
+init-field-arg-oknil-unmanaged-from-nonnil-owned.chpl:14: Initializer instantiated as: init(rhs: owned MyClass)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-unmanaged-from-nonnil-shared.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-unmanaged-from-nonnil-shared.good
@@ -1,2 +1,3 @@
 init-field-arg-oknil-unmanaged-from-nonnil-shared.chpl:9: In initializer:
 init-field-arg-oknil-unmanaged-from-nonnil-shared.chpl:10: error: cannot initialize field MyRecord.lhs of type 'unmanaged MyClass?' from a 'shared MyClass'
+init-field-arg-oknil-unmanaged-from-nonnil-shared.chpl:14: Initializer instantiated as: init(rhs: shared MyClass)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-unmanaged-from-oknil-borrowed.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-unmanaged-from-oknil-borrowed.good
@@ -1,2 +1,3 @@
 init-field-arg-oknil-unmanaged-from-oknil-borrowed.chpl:9: In initializer:
 init-field-arg-oknil-unmanaged-from-oknil-borrowed.chpl:10: error: cannot initialize field MyRecord.lhs of type 'unmanaged MyClass?' from a 'borrowed MyClass?'
+init-field-arg-oknil-unmanaged-from-oknil-borrowed.chpl:14: Initializer instantiated as: init(rhs: borrowed MyClass?)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-unmanaged-from-oknil-owned.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-unmanaged-from-oknil-owned.good
@@ -1,2 +1,3 @@
 init-field-arg-oknil-unmanaged-from-oknil-owned.chpl:9: In initializer:
 init-field-arg-oknil-unmanaged-from-oknil-owned.chpl:10: error: cannot initialize field MyRecord.lhs of type 'unmanaged MyClass?' from a 'owned MyClass?'
+init-field-arg-oknil-unmanaged-from-oknil-owned.chpl:14: Initializer instantiated as: init(rhs: owned MyClass?)

--- a/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-unmanaged-from-oknil-shared.good
+++ b/test/classes/errors/nilability-init-field-arg/init-field-arg-oknil-unmanaged-from-oknil-shared.good
@@ -1,2 +1,3 @@
 init-field-arg-oknil-unmanaged-from-oknil-shared.chpl:9: In initializer:
 init-field-arg-oknil-unmanaged-from-oknil-shared.chpl:10: error: cannot initialize field MyRecord.lhs of type 'unmanaged MyClass?' from a 'shared MyClass?'
+init-field-arg-oknil-unmanaged-from-oknil-shared.chpl:14: Initializer instantiated as: init(rhs: shared MyClass?)

--- a/test/classes/initializers/generics/phase1/nested-function-mods-field1.bad
+++ b/test/classes/initializers/generics/phase1/nested-function-mods-field1.bad
@@ -3,3 +3,4 @@ nested-function-mods-field1.chpl:10: error: illegal lvalue in assignment
 nested-function-mods-field1.chpl:16: Initializer instantiated as: init(param val = 13)
 nested-function-mods-field1.chpl:6: In initializer:
 nested-function-mods-field1.chpl:10: error: parameter set multiple times
+nested-function-mods-field1.chpl:16: Initializer instantiated as: init(param val = 13)

--- a/test/classes/initializers/generics/phase1/nested-function-mods-field2.bad
+++ b/test/classes/initializers/generics/phase1/nested-function-mods-field2.bad
@@ -3,3 +3,4 @@ nested-function-mods-field2.chpl:8: error: illegal lvalue in assignment
 nested-function-mods-field2.chpl:17: Initializer instantiated as: init(param val = 13)
 nested-function-mods-field2.chpl:6: In initializer:
 nested-function-mods-field2.chpl:8: error: parameter set multiple times
+nested-function-mods-field2.chpl:17: Initializer instantiated as: init(param val = 13)

--- a/test/classes/initializers/generics/phase1/nested-function-phase-2-mods-fields.bad
+++ b/test/classes/initializers/generics/phase1/nested-function-phase-2-mods-fields.bad
@@ -3,3 +3,4 @@ nested-function-phase-2-mods-fields.chpl:17: error: illegal lvalue in assignment
 nested-function-phase-2-mods-fields.chpl:23: Initializer instantiated as: init(param val = 13)
 nested-function-phase-2-mods-fields.chpl:7: In initializer:
 nested-function-phase-2-mods-fields.chpl:17: error: parameter set multiple times
+nested-function-phase-2-mods-fields.chpl:23: Initializer instantiated as: init(param val = 13)

--- a/test/classes/initializers/initequals/wrongType.bad
+++ b/test/classes/initializers/initequals/wrongType.bad
@@ -1,2 +1,3 @@
 wrongType.chpl:6: In function 'init=':
 wrongType.chpl:7: error: cannot assign expression of type 2*int(64) to field 'T' of type int(64)
+wrongType.chpl:13: Function 'init=' instantiated as: init=(this: R(int(64)))

--- a/test/domains/marybeth/test_compare_range.good
+++ b/test/domains/marybeth/test_compare_range.good
@@ -1,2 +1,3 @@
 test_compare_range.chpl:14: In function 'initMatrix':
 test_compare_range.chpl:20: error: iterator or promoted expression iterator used in if or while condition
+test_compare_range.chpl:6: Function 'initMatrix' instantiated as: initMatrix(A: [domain(2,int(64),false)] real(64))

--- a/test/domains/sungeun/assoc/expand.1.good
+++ b/test/domains/sungeun/assoc/expand.1.good
@@ -1,0 +1,3 @@
+expand.chpl:4: In function 'my_expand':
+expand.chpl:5: error: expand not supported on associative domains
+expand.chpl:11: Function 'my_expand' instantiated as: my_expand(D: DefaultAssociativeDom(int(64),true), off: int(64))

--- a/test/domains/sungeun/assoc/expand.2.good
+++ b/test/domains/sungeun/assoc/expand.2.good
@@ -1,0 +1,3 @@
+expand.chpl:4: In function 'my_expand':
+expand.chpl:5: error: expand not supported on associative domains
+expand.chpl:11: Function 'my_expand' instantiated as: my_expand(D: DefaultAssociativeDom(int(64),false), off: int(64))

--- a/test/domains/sungeun/assoc/expand.compopts
+++ b/test/domains/sungeun/assoc/expand.compopts
@@ -1,2 +1,2 @@
--sparSafe=true
--sparSafe=false
+-sparSafe=true  # expand.1.good
+-sparSafe=false # expand.2.good

--- a/test/domains/sungeun/assoc/expand.good
+++ b/test/domains/sungeun/assoc/expand.good
@@ -1,2 +1,0 @@
-expand.chpl:4: In function 'my_expand':
-expand.chpl:5: error: expand not supported on associative domains

--- a/test/domains/sungeun/assoc/exterior.1.good
+++ b/test/domains/sungeun/assoc/exterior.1.good
@@ -1,0 +1,3 @@
+exterior.chpl:4: In function 'my_exterior':
+exterior.chpl:5: error: exterior not supported on associative domains
+exterior.chpl:11: Function 'my_exterior' instantiated as: my_exterior(D: DefaultAssociativeDom(int(64),true), off: int(64))

--- a/test/domains/sungeun/assoc/exterior.2.good
+++ b/test/domains/sungeun/assoc/exterior.2.good
@@ -1,0 +1,3 @@
+exterior.chpl:4: In function 'my_exterior':
+exterior.chpl:5: error: exterior not supported on associative domains
+exterior.chpl:11: Function 'my_exterior' instantiated as: my_exterior(D: DefaultAssociativeDom(int(64),false), off: int(64))

--- a/test/domains/sungeun/assoc/exterior.compopts
+++ b/test/domains/sungeun/assoc/exterior.compopts
@@ -1,2 +1,2 @@
--sparSafe=true
--sparSafe=false
+-sparSafe=true  # exterior.1.good
+-sparSafe=false # exterior.2.good

--- a/test/domains/sungeun/assoc/exterior.good
+++ b/test/domains/sungeun/assoc/exterior.good
@@ -1,2 +1,0 @@
-exterior.chpl:4: In function 'my_exterior':
-exterior.chpl:5: error: exterior not supported on associative domains

--- a/test/domains/sungeun/assoc/interior.1.good
+++ b/test/domains/sungeun/assoc/interior.1.good
@@ -1,0 +1,3 @@
+interior.chpl:4: In function 'my_interior':
+interior.chpl:5: error: interior not supported on associative domains
+interior.chpl:11: Function 'my_interior' instantiated as: my_interior(D: DefaultAssociativeDom(int(64),true), off: int(64))

--- a/test/domains/sungeun/assoc/interior.2.good
+++ b/test/domains/sungeun/assoc/interior.2.good
@@ -1,0 +1,3 @@
+interior.chpl:4: In function 'my_interior':
+interior.chpl:5: error: interior not supported on associative domains
+interior.chpl:11: Function 'my_interior' instantiated as: my_interior(D: DefaultAssociativeDom(int(64),false), off: int(64))

--- a/test/domains/sungeun/assoc/interior.compopts
+++ b/test/domains/sungeun/assoc/interior.compopts
@@ -1,2 +1,2 @@
--sparSafe=true
--sparSafe=false
+-sparSafe=true  # interior.1.good
+-sparSafe=false # interior.2.good

--- a/test/domains/sungeun/assoc/interior.good
+++ b/test/domains/sungeun/assoc/interior.good
@@ -1,2 +1,0 @@
-interior.chpl:4: In function 'my_interior':
-interior.chpl:5: error: interior not supported on associative domains

--- a/test/domains/sungeun/assoc/translate.1.good
+++ b/test/domains/sungeun/assoc/translate.1.good
@@ -1,0 +1,3 @@
+translate.chpl:7: In function 'my_translate':
+translate.chpl:8: error: translate not supported on associative domains
+translate.chpl:14: Function 'my_translate' instantiated as: my_translate(D: DefaultAssociativeDom(int(64),true), off: int(64))

--- a/test/domains/sungeun/assoc/translate.2.good
+++ b/test/domains/sungeun/assoc/translate.2.good
@@ -1,0 +1,3 @@
+translate.chpl:7: In function 'my_translate':
+translate.chpl:8: error: translate not supported on associative domains
+translate.chpl:14: Function 'my_translate' instantiated as: my_translate(D: DefaultAssociativeDom(int(64),false), off: int(64))

--- a/test/domains/sungeun/assoc/translate.compopts
+++ b/test/domains/sungeun/assoc/translate.compopts
@@ -1,2 +1,2 @@
--sparSafe=true
--sparSafe=false
+-sparSafe=true  # translate.1.good
+-sparSafe=false # translate.2.good

--- a/test/domains/sungeun/assoc/translate.good
+++ b/test/domains/sungeun/assoc/translate.good
@@ -1,2 +1,0 @@
-translate.chpl:7: In function 'my_translate':
-translate.chpl:8: error: translate not supported on associative domains

--- a/test/domains/sungeun/sparse/expand.good
+++ b/test/domains/sungeun/sparse/expand.good
@@ -1,2 +1,3 @@
 expand.chpl:3: In function 'my_expand':
 expand.chpl:4: error: expand not supported on sparse domains
+expand.chpl:10: Function 'my_expand' instantiated as: my_expand(D: DefaultSparseDom(1,int(64),domain(1,int(64),false)), off: int(64))

--- a/test/domains/sungeun/sparse/exterior.good
+++ b/test/domains/sungeun/sparse/exterior.good
@@ -1,2 +1,3 @@
 exterior.chpl:3: In function 'my_exterior':
 exterior.chpl:4: error: exterior not supported on sparse domains
+exterior.chpl:10: Function 'my_exterior' instantiated as: my_exterior(D: DefaultSparseDom(1,int(64),domain(1,int(64),false)), off: int(64))

--- a/test/domains/sungeun/sparse/interior.good
+++ b/test/domains/sungeun/sparse/interior.good
@@ -1,2 +1,3 @@
 interior.chpl:3: In function 'my_interior':
 interior.chpl:4: error: interior not supported on sparse domains
+interior.chpl:10: Function 'my_interior' instantiated as: my_interior(D: DefaultSparseDom(1,int(64),domain(1,int(64),false)), off: int(64))

--- a/test/domains/sungeun/sparse/translate.good
+++ b/test/domains/sungeun/sparse/translate.good
@@ -1,2 +1,3 @@
 translate.chpl:6: In function 'my_translate':
 translate.chpl:7: error: translate not supported on sparse domains
+translate.chpl:13: Function 'my_translate' instantiated as: my_translate(D: DefaultSparseDom(1,int(64),domain(1,int(64),false)), off: int(64))

--- a/test/execflags/vass/print-callstack-on-error-1.good
+++ b/test/execflags/vass/print-callstack-on-error-1.good
@@ -5,3 +5,4 @@ while processing the following Chapel call chain:
   print-callstack-on-error-1.chpl:10: test2(y)
   print-callstack-on-error-1.chpl:6: test1(x)
   print-callstack-on-error-1.chpl:3: top-level module statements for print-callstack-on-error-1
+print-callstack-on-error-1.chpl:10: Function 'test3' instantiated as: test3(z: string)

--- a/test/extern/fnPtrs/passBadFnsToCChapel-cPtrToChapel.good
+++ b/test/extern/fnPtrs/passBadFnsToCChapel-cPtrToChapel.good
@@ -1,2 +1,3 @@
 passBadFnsToCChapel.chpl:11: In function 'baz':
 passBadFnsToCChapel.chpl:12: error: Can't call a C function pointer within Chapel
+passBadFnsToCChapel.chpl:16: Function 'baz' instantiated as: baz(f: c_fn_ptr)

--- a/test/functions/bradc/typeFns/myTypeFnConstKeyword.good
+++ b/test/functions/bradc/typeFns/myTypeFnConstKeyword.good
@@ -1,2 +1,3 @@
 myTypeFnConstKeyword.chpl:1: In function 'myint':
 myTypeFnConstKeyword.chpl:1: error: illegal return of type where value is expected
+myTypeFnConstKeyword.chpl:3: Function 'myint' instantiated as: myint(param x = 1)

--- a/test/functions/bradc/typeFns/myTypeFnNoKeyword.good
+++ b/test/functions/bradc/typeFns/myTypeFnNoKeyword.good
@@ -1,2 +1,3 @@
 myTypeFnNoKeyword.chpl:1: In function 'myint':
 myTypeFnNoKeyword.chpl:1: error: illegal return of type where value is expected
+myTypeFnNoKeyword.chpl:3: Function 'myint' instantiated as: myint(param x = 1)

--- a/test/functions/deitz/test_rec_infer.good
+++ b/test/functions/deitz/test_rec_infer.good
@@ -1,3 +1,4 @@
 test_rec_infer.chpl:1: error: unable to resolve return type of function 'foo'
 test_rec_infer.chpl:1: In function 'foo':
 test_rec_infer.chpl:2: error: called recursively at this point
+test_rec_infer.chpl:5: Function 'foo' instantiated as: foo(i: int(64))

--- a/test/functions/diten/badwhere.good
+++ b/test/functions/diten/badwhere.good
@@ -1,2 +1,3 @@
 badwhere.chpl:4: In function 'foo':
 badwhere.chpl:4: error: invalid where clause
+badwhere.chpl:1: Function 'foo' instantiated as: foo(x: string, y: string, z: bool)

--- a/test/functions/diten/coerce_param_imag_to_real.bad
+++ b/test/functions/diten/coerce_param_imag_to_real.bad
@@ -1,4 +1,4 @@
-coerce_param_imag_to_real.chpl:6: error: unresolved call 'foo(1.1i)'
+coerce_param_imag_to_real.chpl:6: error: unresolved call 'foo(1.1)'
 coerce_param_imag_to_real.chpl:1: note: this candidate did not match: foo(r: real)
 coerce_param_imag_to_real.chpl:6: note: because call actual argument #1 with type imag(64)
 coerce_param_imag_to_real.chpl:1: note: is passed to formal 'r: real(64)'

--- a/test/functions/diten/tupleTypeInParamCondExpr.bad
+++ b/test/functions/diten/tupleTypeInParamCondExpr.bad
@@ -1,2 +1,3 @@
 tupleTypeInParamCondExpr.chpl:3: In function 'getType':
 tupleTypeInParamCondExpr.chpl:4: error: illegal return of value where type is expected
+tupleTypeInParamCondExpr.chpl:7: Function 'getType' instantiated as: getType(type t = 2*int(64))

--- a/test/functions/whereClauses/whereClauseNonParamGeneric.good
+++ b/test/functions/whereClauses/whereClauseNonParamGeneric.good
@@ -1,2 +1,3 @@
 whereClauseNonParamGeneric.chpl:1: In function 'foo':
 whereClauseNonParamGeneric.chpl:1: error: invalid where clause
+whereClauseNonParamGeneric.chpl:1: Function 'foo' instantiated as: foo(x: int(64))

--- a/test/library/packages/UnitTest/AssertGreater/UnEqualRangeGreater.bad
+++ b/test/library/packages/UnitTest/AssertGreater/UnEqualRangeGreater.bad
@@ -1,2 +1,3 @@
 $CHPL_HOME/modules/packages/UnitTest.chpl:578: In function 'assertGreaterThan':
 $CHPL_HOME/modules/packages/UnitTest.chpl:579: error: parallel iteration is not supported over unbounded ranges
+UnEqualRangeGreater.chpl:8: Function 'assertGreaterThan' instantiated as: assertGreaterThan(first: range(int(64),boundedHigh,false), second: range(int(64),boundedHigh,false))

--- a/test/param/diten/errorDepth.depth0.good
+++ b/test/param/diten/errorDepth.depth0.good
@@ -1,2 +1,3 @@
 errorDepth.chpl:1: In function 'foo':
 errorDepth.chpl:3: error: error 0
+errorDepth.chpl:10: Function 'foo' instantiated as: foo(param d = 0)

--- a/test/param/diten/errorDepth.depth1.good
+++ b/test/param/diten/errorDepth.depth1.good
@@ -1,2 +1,3 @@
 errorDepth.chpl:10: In function 'bar':
 errorDepth.chpl:10: error: error 1
+errorDepth.chpl:11: Function 'bar' instantiated as: bar(param d = 1)

--- a/test/param/diten/errorDepth.depth2.good
+++ b/test/param/diten/errorDepth.depth2.good
@@ -1,2 +1,3 @@
 errorDepth.chpl:11: In function 'baz':
 errorDepth.chpl:11: error: error 2
+errorDepth.chpl:15: Function 'baz' instantiated as: baz(param d = 2)

--- a/test/param/ferguson/field-name-not-in-range.good
+++ b/test/param/ferguson/field-name-not-in-range.good
@@ -1,2 +1,3 @@
 $CHPL_HOME/modules/standard/Reflection.chpl:47: In function 'getFieldName':
 $CHPL_HOME/modules/standard/Reflection.chpl:48: error: '2' is not a valid field number for R
+field-name-not-in-range.chpl:7: Function 'getFieldName' instantiated as: getFieldName(type t = R, param i = 2)

--- a/test/studies/beer/bradc/beer-promoted-infer.good
+++ b/test/studies/beer/bradc/beer-promoted-infer.good
@@ -1,2 +1,3 @@
 beer-promoted-infer.chpl:53: In function 'describeBottles':
 beer-promoted-infer.chpl:54: error: type '[domain(1,int(64),false)] int(64)' used in if or while condition
+beer-promoted-infer.chpl:46: Function 'describeBottles' instantiated as: describeBottles(bottleNum: [domain(1,int(64),false)] int(64))

--- a/test/types/bool/bradc/numBitsBytesDefault.good
+++ b/test/types/bool/bradc/numBitsBytesDefault.good
@@ -1,2 +1,3 @@
 numBitsBytesDefault.chpl:3: In function 'printSizes':
 numBitsBytesDefault.chpl:4: error: default-width 'bool' does not have a well-defined size
+numBitsBytesDefault.chpl:9: Function 'printSizes' instantiated as: printSizes(type t = bool)

--- a/test/types/typeFunctions/illegalValueReturn.good
+++ b/test/types/typeFunctions/illegalValueReturn.good
@@ -1,2 +1,3 @@
 illegalValueReturn.chpl:2: In function 'helper':
 illegalValueReturn.chpl:8: error: illegal return of value where type is expected
+illegalValueReturn.chpl:11: Function 'helper' instantiated as: helper(param x = 42)

--- a/test/types/type_variables/bharshbarg/illegalFieldQuery.good
+++ b/test/types/type_variables/bharshbarg/illegalFieldQuery.good
@@ -1,2 +1,3 @@
 illegalFieldQuery.chpl:8: In function 'foo':
 illegalFieldQuery.chpl:8: error: invalid query -- queried field must be a type or parameter
+illegalFieldQuery.chpl:13: Function 'foo' instantiated as: foo(x: borrowed Foo(true,5))

--- a/test/users/jglewis/array_reindexing/desirable_syntax.bad
+++ b/test/users/jglewis/array_reindexing/desirable_syntax.bad
@@ -1,2 +1,3 @@
 desirable_syntax.chpl:35: In function 'print_A_reindexed':
 desirable_syntax.chpl:35: error: one of domain's dimensions is not a bounded range
+desirable_syntax.chpl:25: Function 'print_A_reindexed' instantiated as: print_A_reindexed(A: [domain(2,int(64),false)] 2*int(64))

--- a/test/users/lucashimizu/inferRecursive.bad
+++ b/test/users/lucashimizu/inferRecursive.bad
@@ -1,3 +1,4 @@
 inferRecursive.chpl:9: error: unable to resolve return type of function 'fibInfer'
 inferRecursive.chpl:9: In function 'fibInfer':
 inferRecursive.chpl:13: error: called recursively at this point
+inferRecursive.chpl:18: Function 'fibInfer' instantiated as: fibInfer(a: int(64))

--- a/test/users/vass/div-ceil-on-more-int-types.bad
+++ b/test/users/vass/div-ceil-on-more-int-types.bad
@@ -1,2 +1,3 @@
-$CHPL_HOME/modules/standard/Math.chpl:262: In function 'divceil':
-$CHPL_HOME/modules/standard/Math.chpl:264: error: illegal use of '+' on operands of type uint(64) and signed integer
+$CHPL_HOME/modules/standard/Math.chpl:545: In function 'divceil':
+$CHPL_HOME/modules/standard/Math.chpl:547: error: illegal use of '+' on operands of type uint(64) and signed integer
+div-ceil-on-more-int-types.chpl:3: Function 'divceil' instantiated as: divceil(m: int(32), n: uint(64))

--- a/test/users/weili/raiseType-blc.good
+++ b/test/users/weili/raiseType-blc.good
@@ -1,2 +1,3 @@
 raiseType-blc.chpl:1: In function 'raiseType':
 raiseType-blc.chpl:3: error: illegal return of type where value is expected
+raiseType-blc.chpl:7: Function 'raiseType' instantiated as: raiseType(type x = bool)


### PR DESCRIPTION
PR #13908 added some helpful information about the instantiation when an error occurs within a generic function. I recently noticed a bug in that PR where the new error was not occurring for certain fatal errors. This PR resolves the error and adjusts test .good and .bad files to match.

Reviewed by @lydia-duncan - thanks!

- [x] full local futures testing