### PR TITLE
Adjust the capitalization of Bytes.DecodePolicy enum

### DIFF
--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -54,14 +54,14 @@ module Bytes {
   private use BytesStringCommon;
 
   /*
-     ``DecodePolicy`` specifies what happens when there is malformed characters
+     ``decodePolicy`` specifies what happens when there is malformed characters
      when decoding the :record:`bytes` object into a UTF-8 `string`.
        
-       - **Strict**: default policy; raise error
-       - **Replace**: replace with UTF-8 replacement character
-       - **Ignore**: silently drop data
+       - **strict**: default policy; raise error
+       - **replace**: replace with UTF-8 replacement character
+       - **ignore**: silently drop data
   */
-  enum DecodePolicy { Strict, Replace, Ignore }
+  enum decodePolicy { strict, replace, ignore }
 
   /*
    A `DecodeError` is thrown if the `decode` method is called on a non-UTF-8
@@ -716,17 +716,17 @@ module Bytes {
       Returns a UTF-8 string from the given :record:`bytes` object. If the data
       is malformed for UTF-8, `errors` argument determines the action.
       
-      :arg errors: `DecodePolicy.Strict` raises an error, `DecodePolicy.Replace`
+      :arg errors: `decodePolicy.strict` raises an error, `decodePolicy.replace`
                    replaces the malformed character with UTF-8 replacement
-                   character, `DecodePolicy.Ignore` drops the data silently.
+                   character, `decodePolicy.ignore` drops the data silently.
       
-      :throws: `DecodeError` if `DecodePolicy.Strict` is passed to the `errors`
+      :throws: `DecodeError` if `decodePolicy.strict` is passed to the `errors`
                argument and the `bytes` object contains non-UTF-8 characters.
 
       :returns: A UTF-8 string.
     */
     // NOTE: In the future this could support more encodings.
-    proc decode(errors=DecodePolicy.Strict): string throws {
+    proc decode(errors=decodePolicy.strict): string throws {
       pragma "fn synchronization free"
       extern proc qio_decode_char_buf(ref chr:int(32), ref nbytes:c_int,
                                       buf:c_string, buflen:ssize_t):syserr;
@@ -753,10 +753,10 @@ module Bytes {
         qio_decode_char_buf(cp, nbytes, bufToDecode, maxbytes);
 
         if cp == 0xfffd {  //decoder returns the replacament character
-          if errors == DecodePolicy.Strict {
+          if errors == decodePolicy.strict {
             throw new owned DecodeError();
           }
-          else if errors == DecodePolicy.Ignore {
+          else if errors == decodePolicy.ignore {
             thisIdx += nbytes; //skip over the malformed bytes
             continue;
           }

--- a/modules/internal/BytesCasts.chpl
+++ b/modules/internal/BytesCasts.chpl
@@ -43,7 +43,7 @@ module BytesCasts {
       return false;
     } else {
       throw new owned IllegalArgumentError("bad cast from bytes '" +
-                                           x.decode(DecodePolicy.Ignore) +
+                                           x.decode(decodePolicy.ignore) +
                                            "' to bool");
     }
     return false;
@@ -123,7 +123,7 @@ module BytesCasts {
       }
       if numElements > 1 then
         throw new owned IllegalArgumentError("bad cast from bytes '" + 
-                                             x.decode(DecodePolicy.Ignore) +
+                                             x.decode(decodePolicy.ignore) +
                                              "' to " + t:string);
 
       // remove underscores everywhere but the first position
@@ -157,7 +157,7 @@ module BytesCasts {
 
     if isErr then
       throw new owned IllegalArgumentError("bad cast from bytes '" +
-                                           x.decode(DecodePolicy.Ignore) +
+                                           x.decode(decodePolicy.ignore) +
                                            "' to " + t:string);
 
     return retVal;
@@ -236,7 +236,7 @@ module BytesCasts {
 
     if isErr then
       throw new owned IllegalArgumentError("bad cast from bytes '" +
-                                           x.decode(DecodePolicy.Ignore) +
+                                           x.decode(decodePolicy.ignore) +
                                            "' to real(" + numBits(t):string + ")");
 
     return retVal;
@@ -265,7 +265,7 @@ module BytesCasts {
 
     if isErr then
       throw new owned IllegalArgumentError("bad cast from bytes '" +
-                                           x.decode(DecodePolicy.Ignore) +
+                                           x.decode(decodePolicy.ignore) +
                                            "' to imag(" + numBits(t):string + ")");
 
     return retVal;
@@ -323,7 +323,7 @@ module BytesCasts {
 
     if isErr then
       throw new owned IllegalArgumentError("bad cast from bytes '" +
-                                           x.decode(DecodePolicy.Ignore) +
+                                           x.decode(decodePolicy.ignore) +
                                            "' to complex(" + numBits(t):string + ")");
 
     return retVal;

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -5460,7 +5460,7 @@ proc _setIfPrimitive(ref lhs:?t, rhs:?t2, argi:int):syserr where t!=bool&&_isIoP
       }
     } else {
       if isBytesType(t2) && isStringType(t) {
-        lhs = rhs.decode(DecodePolicy.Strict);
+        lhs = rhs.decode(decodePolicy.strict);
       }
       else {
         lhs = rhs:t;

--- a/test/types/bytes/decode.chpl
+++ b/test/types/bytes/decode.chpl
@@ -8,14 +8,14 @@ writeln("Decoded string: ", valid_utf8.decode());
 assert(valid_utf8.decode() == unicodeStr);
 
 var invalid_utf8 = b"T\xc3\xbc\xffrk\xc3\xa7e"; // \xff is invalid
-const ignoredString = invalid_utf8.decode(errors=DecodePolicy.Ignore);
+const ignoredString = invalid_utf8.decode(errors=decodePolicy.ignore);
 writeln("String with the ignore policy: ", ignoredString,
         " (length=", ignoredString.numBytes, ")");
-const replacedString = invalid_utf8.decode(errors=DecodePolicy.Replace);
+const replacedString = invalid_utf8.decode(errors=decodePolicy.replace);
 writeln("String with the replace policy: ", replacedString,
         " (length=", replacedString.numBytes, ")");
 try! {
-  const strictString = invalid_utf8.decode(errors=DecodePolicy.Strict);
+  const strictString = invalid_utf8.decode(errors=decodePolicy.strict);
 }
 catch e:DecodeError {
   writeln(e);


### PR DESCRIPTION
Following the recent discussions, this PR changes the capitalization for the enum that 
controls the decode strategy for bytes.

```
enum DecodePolicy { Strict, Replace, Ignore }
```
becomes
```
enum decodePolicy { strict, replace, ignore }
```

Test:
- [x] standard