### PR TITLE
Fix --verify bug related to functions that return types

### DIFF
--- a/compiler/resolution/cleanups.cpp
+++ b/compiler/resolution/cleanups.cpp
@@ -96,9 +96,13 @@ static void removeUnusedFunctions() {
           // alive and returned a generic type the compiler would encounter
           // memory corruption issues. Ideally type functions could remain
           // in the AST and prevent the types they use from being removed.
+          //
+          // Skip if fatal errors were encountered because in such cases
+          // postFold will leave type-returning function calls in the AST.
           Type* type = fn->retType;
           if (type->symbol->hasFlag(FLAG_RUNTIME_TYPE_VALUE) == false &&
-              type->symbol->hasFlag(FLAG_EXTERN) == false) {
+              type->symbol->hasFlag(FLAG_EXTERN) == false &&
+              fatalErrorsEncountered() == false) {
             fn->defPoint->remove();
           }
         }


### PR DESCRIPTION
This PR fixes a bug introduced by #13904 , which updated post-resolution cleanup to remove type-returning functions from the AST. This change assumed that no calls to such functions existed, but when we issue fatal errors postFold decides to leave such calls in the AST to improve error messages. This simple fix is to not remove such functions when fatal errors are issued.

Testing:
- [x] local + futures
- [x] full --verify