### PR TITLE
Fix memory leaks from 13869

### DIFF
--- a/modules/dists/SparseBlockDist.chpl
+++ b/modules/dists/SparseBlockDist.chpl
@@ -340,7 +340,7 @@ class LocSparseBlockDom {
   param stridable: bool;
   type sparseLayoutType;
   var parentDom: domain(rank, idxType, stridable);
-  var sparseDist = if _to_borrowed(sparseLayoutType) == DefaultDist then defaultDist
+  var sparseDist = if _to_borrowed(sparseLayoutType) == borrowed DefaultDist then defaultDist
                    else new dmap(new sparseLayoutType()); //unresolved call workaround
   var mySparseBlock: sparse subdomain(parentDom) dmapped sparseDist;
 


### PR DESCRIPTION
`modules/dists/SparseBlockDist.chpl` contained this code:
```chpl
  var sparseDist = if _to_borrowed(sparseLayoutType) == DefaultDist then defaultDist
                   else new dmap(new sparseLayoutType()); //unresolved call workaround
```
so when #13869 enacted no-legacy handling of class types in the modules,
`DefaultDist` switched to mean "anymanaged". So it started comparing
as different from its borrowed counterpart on the l.h.s. of the `==`.
So the else-branch was being taken, allocating a `new DefaultDist`.
Since DefaultDist is marked as non-deallocatable, this extra DefaultDist
would not be deallocated. Resulting in memory leaks.

This change fixes that by switching the above to `borrowed DefaultDist`.

Here is a simple reproducer I used:
```chpl
// from test/users/engin/sparse_bulk_dist/integrity.chpl
use BlockDist;
config const N = 8;
const RNG = 0..#N;
const DOM = {RNG,RNG};
const ParentDom = DOM dmapped Block(DOM);
var SparseDom: sparse subdomain(ParentDom);
```
Makes me wonder where else we started to compare differently due to
the same cause.

Trivial, not reviewed.