### PR TITLE
Minor test adjustments

### DIFF
--- a/test/arrays/bradc/slices/reindexIndTypeMismatch.suppressif
+++ b/test/arrays/bradc/slices/reindexIndTypeMismatch.suppressif
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+
+# Currently our whiteboxes use an older version of the intel compiler,
+# which results in accessing uninitialized memory. Expect execution errors.
+
+from __future__ import print_function
+from socket import gethostname
+from os import getenv, path
+
+isWhitebox = gethostname().startswith("esxbld");
+isIntel = 'intel' in getenv('CHPL_TARGET_COMPILER', "")
+
+print(isWhitebox and isIntel)

--- a/test/arrays/deitz/part1/test_array_arg8.suppressif
+++ b/test/arrays/deitz/part1/test_array_arg8.suppressif
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+
+# Currently our whiteboxes use an older version of the intel compiler,
+# which results in accessing uninitialized memory. Expect execution errors.
+
+from __future__ import print_function
+from socket import gethostname
+from os import getenv, path
+
+isWhitebox = gethostname().startswith("esxbld");
+isIntel = 'intel' in getenv('CHPL_TARGET_COMPILER', "")
+
+print(isWhitebox and isIntel)

--- a/test/arrays/deitz/part1/test_array_arg9.suppressif
+++ b/test/arrays/deitz/part1/test_array_arg9.suppressif
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+
+# Currently our whiteboxes use an older version of the intel compiler,
+# which results in accessing uninitialized memory. Expect execution errors.
+
+from __future__ import print_function
+from socket import gethostname
+from os import getenv, path
+
+isWhitebox = gethostname().startswith("esxbld");
+isIntel = 'intel' in getenv('CHPL_TARGET_COMPILER', "")
+
+print(isWhitebox and isIntel)

--- a/test/arrays/deitz/part2/test_array_reindex_aliases.suppressif
+++ b/test/arrays/deitz/part2/test_array_reindex_aliases.suppressif
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+
+# Currently our whiteboxes use an older version of the intel compiler,
+# which results in accessing uninitialized memory. Expect execution errors.
+
+from __future__ import print_function
+from socket import gethostname
+from os import getenv, path
+
+isWhitebox = gethostname().startswith("esxbld");
+isIntel = 'intel' in getenv('CHPL_TARGET_COMPILER', "")
+
+print(isWhitebox and isIntel)

--- a/test/arrays/deitz/part3/test_slice_stride.suppressif
+++ b/test/arrays/deitz/part3/test_slice_stride.suppressif
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+
+# Currently our whiteboxes use an older version of the intel compiler,
+# which results in accessing uninitialized memory. Expect execution errors.
+
+from __future__ import print_function
+from socket import gethostname
+from os import getenv, path
+
+isWhitebox = gethostname().startswith("esxbld");
+isIntel = 'intel' in getenv('CHPL_TARGET_COMPILER', "")
+
+print(isWhitebox and isIntel)

--- a/test/arrays/deitz/part3/test_slice_stride2.suppressif
+++ b/test/arrays/deitz/part3/test_slice_stride2.suppressif
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+
+# Currently our whiteboxes use an older version of the intel compiler,
+# which results in accessing uninitialized memory. Expect execution errors.
+
+from __future__ import print_function
+from socket import gethostname
+from os import getenv, path
+
+isWhitebox = gethostname().startswith("esxbld");
+isIntel = 'intel' in getenv('CHPL_TARGET_COMPILER', "")
+
+print(isWhitebox and isIntel)

--- a/test/arrays/deitz/part3/test_slice_stride4.suppressif
+++ b/test/arrays/deitz/part3/test_slice_stride4.suppressif
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+
+# Currently our whiteboxes use an older version of the intel compiler,
+# which results in accessing uninitialized memory. Expect execution errors.
+
+from __future__ import print_function
+from socket import gethostname
+from os import getenv, path
+
+isWhitebox = gethostname().startswith("esxbld");
+isIntel = 'intel' in getenv('CHPL_TARGET_COMPILER', "")
+
+print(isWhitebox and isIntel)

--- a/test/arrays/deitz/part6/test_big_stride.suppressif
+++ b/test/arrays/deitz/part6/test_big_stride.suppressif
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+
+# Currently our whiteboxes use an older version of the intel compiler,
+# which results in accessing uninitialized memory. Expect execution errors.
+
+from __future__ import print_function
+from socket import gethostname
+from os import getenv, path
+
+isWhitebox = gethostname().startswith("esxbld");
+isIntel = 'intel' in getenv('CHPL_TARGET_COMPILER', "")
+
+print(isWhitebox and isIntel)

--- a/test/arrays/diten/arrayAliasing.suppressif
+++ b/test/arrays/diten/arrayAliasing.suppressif
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+
+# Currently our whiteboxes use an older version of the intel compiler,
+# which results in accessing uninitialized memory. Expect execution errors.
+
+from __future__ import print_function
+from socket import gethostname
+from os import getenv, path
+
+isWhitebox = gethostname().startswith("esxbld");
+isIntel = 'intel' in getenv('CHPL_TARGET_COMPILER', "")
+
+print(isWhitebox and isIntel)

--- a/test/classes/errors/newValueNotType2.compopts
+++ b/test/classes/errors/newValueNotType2.compopts
@@ -1,1 +1,2 @@
---ignore-errors-for-pass
+--ignore-errors-for-pass --no-legacy-classes  # newValueNotType2.good
+--ignore-errors-for-pass --legacy-classes     # newValueNotType2.legacy.good

--- a/test/classes/errors/newValueNotType2.legacy.good
+++ b/test/classes/errors/newValueNotType2.legacy.good
@@ -1,0 +1,4 @@
+newValueNotType2.chpl:7: error: cannot use decorator borrowed on a value
+newValueNotType2.chpl:7: error: invalid use of 'new'
+newValueNotType2.chpl:10: error: cannot use decorator unmanaged on a value
+newValueNotType2.chpl:10: error: invalid use of 'new'

--- a/test/distributions/robust/arithmetic/reindexing/test_strided_reindex2.suppressif
+++ b/test/distributions/robust/arithmetic/reindexing/test_strided_reindex2.suppressif
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+
+# Currently our whiteboxes use an older version of the intel compiler,
+# which results in accessing uninitialized memory. Expect execution errors.
+
+from __future__ import print_function
+from socket import gethostname
+from os import getenv, path
+
+isWhitebox = gethostname().startswith("esxbld");
+isIntel = 'intel' in getenv('CHPL_TARGET_COMPILER', "")
+
+print(isWhitebox and isIntel)

--- a/test/parallel/taskPar/taskIntents/fields-of-this-1-legal.chpl
+++ b/test/parallel/taskPar/taskIntents/fields-of-this-1-legal.chpl
@@ -4,13 +4,25 @@ const RNG = 1..4;
 
 var s$: sync int;
 
+class CT {
+  var fieldd: int;
+}
+
 record QQ {
   var data: [RNG] int;
+  var number: int;
+  var pointer = new owned CT();
+
+  proc init(tag:int) {
+    number = tag;
+    pointer = new owned CT(-tag);
+  }
 }
 
 proc QQ.w1(factor: int) {
   coforall i in RNG {
     data[i] = i * factor;
+    writeln(number, pointer.fieldd);
   }
 }
 
@@ -31,31 +43,35 @@ proc QQ.r1(factor: int) {
   }
 }
 
-var rec1 = new QQ();
+var rec1 = new QQ(1);
 rec1.w1(10);
 rec1.r1(10);
 writeln();
 
-var rec2 = new QQ();
+var rec2 = new QQ(2);
 rec2.w3();
 rec2.r1(100);
+writeln();
 
 proc QQ.bgn() {
   begin {
     data[2] = 234;
+    writeln(number, pointer.fieldd);
     s$ = 1;
   }
 }
 
-var rec3 = new QQ();
+var rec3 = new QQ(3);
 rec3.bgn();
 s$;
 writeln(rec3);
+writeln();
 
 proc QQ.cob() {
   cobegin {
     data[1] = 123;
     data[3] = 321;
+    writeln(number, pointer.fieldd);
   }
 }
 

--- a/test/parallel/taskPar/taskIntents/fields-of-this-1-legal.good
+++ b/test/parallel/taskPar/taskIntents/fields-of-this-1-legal.good
@@ -1,11 +1,23 @@
+1-1
+1-1
+1-1
+1-1
 true
 true
 true
 true
 
+2-2
+2-2
+2-2
+2-2
 true
 true
 true
 true
-(data = 0 234 0 0)
-(data = 123 234 321 0)
+
+3-3
+(data = 0 234 0 0, number = 3, pointer = {fieldd = -3})
+
+3-3
+(data = 123 234 321 0, number = 3, pointer = {fieldd = -3})

--- a/test/scan/scanViews.suppressif
+++ b/test/scan/scanViews.suppressif
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+
+# Currently our whiteboxes use an older version of the intel compiler,
+# which results in accessing uninitialized memory. Expect execution errors.
+
+from __future__ import print_function
+from socket import gethostname
+from os import getenv, path
+
+isWhitebox = gethostname().startswith("esxbld");
+isIntel = 'intel' in getenv('CHPL_TARGET_COMPILER', "")
+
+print(isWhitebox and isIntel)

--- a/test/types/real/nan-minmax.skipif
+++ b/test/types/real/nan-minmax.skipif
@@ -1,3 +1,5 @@
 # following the lead of nan-comparisons.skipif:
 # PGI compiler has a different idea for what nan <= nan does
 CHPL_TARGET_COMPILER<=pgi
+# CCE compiler 8.x has its quirks, too
+CHPL_TARGET_COMPILER<=cray


### PR DESCRIPTION
* Skipif `nan-minmax.chpl`under CCE. Version 8.x that we are using for testing
  takes the true branch in `if (a < b)` when b is NaN.

* Suppressif on whiteboxes under Intel for the 11 tests that started failing
  in nightly testing on 8/25, when an older Intel compiler was installed.

* Extended a test as suggested by Michael is his review of #13840.

* Provide a separate .good for `newValueNotType2.chpl` for `--legacy-classes`.

Trivial, not reviewed.