### PR TITLE
Fixed sym links in /test/mason/mason-help-scope/ …

### DIFF
--- a/test/mason/mason-help-scope/EXECENV
+++ b/test/mason/mason-help-scope/EXECENV
@@ -1,1 +1,1 @@
-/Users/oplambeck/chapel/test/mason/EXECENV
+../EXECENV

--- a/test/mason/mason-help-scope/SKIPIF
+++ b/test/mason/mason-help-scope/SKIPIF
@@ -1,1 +1,1 @@
-/Users/oplambeck/chapel/test/mason/SKIPIF
+../SKIPIF


### PR DESCRIPTION
Two symlinks in /test/mason/mason-help-scope pointed to a path that included my home directory, instead of locally one directory up. 

EXECENV points to ../EXECENV now
SKIPIF points to ../SKIPIF