### PR TITLE
Factor out loops to speed qio_test.test.c execution time

### DIFF
--- a/test/io/ferguson/ctests/qio_test.test.c
+++ b/test/io/ferguson/ctests/qio_test.test.c
@@ -329,15 +329,9 @@ void check_channels(void)
           for( k = 0; k < nchunkszs; k++ ) {
             for( type = 1; type <= QIO_CH_MAX_TYPE; type++ ) {
               for( threadsafe = 0; threadsafe < 2; threadsafe++ ) {
-                for( unbounded = 0; unbounded < nunbounded; unbounded++ ) {
-                  for( reopen = 0; reopen < 2; reopen++ ) {
-                    for( seek = 0; seek < 2; seek++ ) {
-                      check_channel(threadsafe, type, starts[s], lens[i],
-                          chunkszs[k], hints[file_hint], hints[ch_hint],
-                          unboundedness[unbounded], reopen, seek);
-                    }
-                  }
-                }
+                check_channel(threadsafe, type, starts[s], lens[i],
+                    chunkszs[k], hints[file_hint], hints[ch_hint],
+                    unboundedness[0], 0, 0);
               }
             }
           }
@@ -347,6 +341,31 @@ void check_channels(void)
     // only test default chanel hints with valgrind
     // moving over file hints should still give us good coverage.
     if( valgrind ) break;
+  }
+
+  // check with reopen/seek variations while limiting other configurations
+  for( file_hint = 0; file_hint < nhints; file_hint++ ) {
+    ch_hint = file_hint;
+    for( i = 0; i < nlens; i++ ) {
+      for( s = 0; s < nstarts; s++ ) {
+        for( k = 0; k < nchunkszs; k++ ) {
+          type = QIO_CH_BUFFERED;
+          threadsafe = 0;
+          for( unbounded = 0; unbounded < nunbounded; unbounded++ ) {
+            for( reopen = 0; reopen < 2; reopen++ ) {
+              for( seek = 0; seek < 2; seek++ ) {
+                if (unbounded == 0 && reopen == 0 && seek == 0)
+                  continue; //handled in above loop
+
+                check_channel(threadsafe, type, starts[s], lens[i],
+                    chunkszs[k], hints[file_hint], hints[ch_hint],
+                    unboundedness[unbounded], reopen, seek);
+              }
+            }
+          }
+        }
+      }
+    }
   }
 
   return;


### PR DESCRIPTION
Follow-up to PR #13862.

`qio_test.test.c` was taking > 200s on a machine with local storage and
timing out in nightly Cygwin testing. This PR adjusts this test to use
two loop nests instead of one, to reduce the number of configurations
tested, which reduces the runtime significantly. I verified that
removing testing of the new `seek` calls would also keep the test from
timing out in Cygwin testing. With the loop adjustment, it no longer
times out on Cygwin and takes less time than it used to.

Test change only, not reviewed.