### PR TITLE
Publish Spell fix and added check for --ci-test

### DIFF
--- a/test/mason/publish-tests/publishHelp.good
+++ b/test/mason/publish-tests/publishHelp.good
@@ -8,6 +8,7 @@ Options:
     -h, --help                   Display this message
     --dry-run                    Check to see if package is ready to be published
     --check                      Runs check to see if package can be published successfully to <registry>
+    --ci-check                   Same as --check, except omits git origin checks
     --[no-]update                [Do not] Prevent registries from being updated when a package is published.
 
 Publishing requires the mason-registry to be forked and the package to have a remote origin.

--- a/test/mason/publish-tests/publishHelpShort.good
+++ b/test/mason/publish-tests/publishHelpShort.good
@@ -8,6 +8,7 @@ Options:
     -h, --help                   Display this message
     --dry-run                    Check to see if package is ready to be published
     --check                      Runs check to see if package can be published successfully to <registry>
+    --ci-check                   Same as --check, except omits git origin checks
     --[no-]update                [Do not] Prevent registries from being updated when a package is published.
 
 Publishing requires the mason-registry to be forked and the package to have a remote origin.

--- a/tools/mason/MasonHelp.chpl
+++ b/tools/mason/MasonHelp.chpl
@@ -424,6 +424,7 @@ proc masonPublishHelp(){
   writeln("    -h, --help                   Display this message");
   writeln('    --dry-run                    Check to see if package is ready to be published');
   writeln('    --check                      Runs check to see if package can be published successfully to <registry>');
+  writeln('    --ci-check                   Same as --check, except omits git origin checks');
   writeln('    --[no-]update                [Do not] Prevent registries from being updated when a package is published.');
   writeln();
   writeln('Publishing requires the mason-registry to be forked and the package to have a remote origin.');

--- a/tools/mason/MasonPublish.chpl
+++ b/tools/mason/MasonPublish.chpl
@@ -64,7 +64,7 @@ proc masonPublish(ref args: list(string)) throws {
 
     if args.size > 2 {
       var potentialPath = args.pop();
-      if (potentialPath != '--dry-run') && (potentialPath != '--no-update') && (potentialPath != '--check') && (potentialPath != '--update') && (potenialPath != '--travis') {
+      if (potentialPath != '--dry-run') && (potentialPath != '--no-update') && (potentialPath != '--check') && (potentialPath != '--update') && (potentialPath != '--travis') {
         registryPath = potentialPath;
       }
       args.append(potentialPath);

--- a/tools/mason/MasonPublish.chpl
+++ b/tools/mason/MasonPublish.chpl
@@ -53,7 +53,7 @@ proc masonPublish(ref args: list(string)) throws {
     var registryPath = '';
     var username = getUsername();
     var isLocal = false;
-    var travis = hasOptions(args, '--travis');
+    var ci = hasOptions(args, '--ci');
     var update = hasOptions(args, '--update');
     var noUpdate = hasOptions(args, '--no-update');
 
@@ -64,7 +64,7 @@ proc masonPublish(ref args: list(string)) throws {
 
     if args.size > 2 {
       var potentialPath = args.pop();
-      if (potentialPath != '--dry-run') && (potentialPath != '--no-update') && (potentialPath != '--check') && (potentialPath != '--update') && (potentialPath != '--travis') {
+      if (potentialPath != '--dry-run') && (potentialPath != '--no-update') && (potentialPath != '--check') && (potentialPath != '--update') && (potentialPath != '--ci') {
         registryPath = potentialPath;
       }
       args.append(potentialPath);
@@ -78,7 +78,7 @@ proc masonPublish(ref args: list(string)) throws {
     }
 
     if checkFlag {
-      check(username, registryPath, isLocal, travis);
+      check(username, registryPath, isLocal, ci);
     }
     if ((MASON_OFFLINE  && !update) || noUpdate == true) && !falseIfRemotePath() {
       if !isLocal {
@@ -422,7 +422,7 @@ private proc addPackageToBricks(projectLocal: string, safeDir: string, name : st
 /* check is a function to run a quick list of checks of the package, the registry path, and other issues that may
    prevent a package from being published to a registry.
  */
-proc check(username : string, path : string, trueIfLocal : bool, travis : bool) throws {
+proc check(username : string, path : string, trueIfLocal : bool, ci : bool) throws {
   const spacer = '------------------------------------------------------';
   const package = (ensureMasonProject(here.cwd(), 'Mason.toml') == 'true');
   const projectCheckHome = here.cwd();
@@ -474,7 +474,7 @@ proc check(username : string, path : string, trueIfLocal : bool, travis : bool) 
   }
   
   writeln(spacer);
-  if package {
+  if package && !ci {
     writeln('Attempting to build package using following options:');
     writeln('   show = false');
     writeln('   release = false');
@@ -513,7 +513,7 @@ proc check(username : string, path : string, trueIfLocal : bool, travis : bool) 
 
   writeln(spacer);
 
-  if travis {
+  if ci {
     if package && moduleCheck(projectCheckHome) {
       attemptToBuild();
       exit(0);

--- a/tools/mason/MasonPublish.chpl
+++ b/tools/mason/MasonPublish.chpl
@@ -53,7 +53,7 @@ proc masonPublish(ref args: list(string)) throws {
     var registryPath = '';
     var username = getUsername();
     var isLocal = false;
-    var ci = hasOptions(args, '--ci');
+    var ci = hasOptions(args, '--ci-check');
     var update = hasOptions(args, '--update');
     var noUpdate = hasOptions(args, '--no-update');
 
@@ -64,7 +64,7 @@ proc masonPublish(ref args: list(string)) throws {
 
     if args.size > 2 {
       var potentialPath = args.pop();
-      if (potentialPath != '--dry-run') && (potentialPath != '--no-update') && (potentialPath != '--check') && (potentialPath != '--update') && (potentialPath != '--ci') {
+      if (potentialPath != '--dry-run') && (potentialPath != '--no-update') && (potentialPath != '--check') && (potentialPath != '--update') && (potentialPath != '--ci-check') {
         registryPath = potentialPath;
       }
       args.append(potentialPath);
@@ -77,8 +77,11 @@ proc masonPublish(ref args: list(string)) throws {
       isLocal = isRegistryPathLocal(registryPath);
     }
 
-    if checkFlag {
-      check(username, registryPath, isLocal, ci);
+    if checkFlag || ci {
+      if ci then check(username, registryPath, isLocal, ci);
+      else {
+        check(username, registryPath, isLocal, ci);
+      }
     }
     if ((MASON_OFFLINE  && !update) || noUpdate == true) && !falseIfRemotePath() {
       if !isLocal {
@@ -452,7 +455,7 @@ proc check(username : string, path : string, trueIfLocal : bool, ci : bool) thro
     writeln(spacer);
   }
 
-  if package {
+  if package && !ci {
     writeln('Git Remote Check:');
     if doesGitOriginExist() {
       writeln('   Package has a git remote origin and can be published to a remote registry (PASSED)');

--- a/tools/mason/MasonPublish.chpl
+++ b/tools/mason/MasonPublish.chpl
@@ -64,7 +64,7 @@ proc masonPublish(ref args: list(string)) throws {
 
     if args.size > 2 {
       var potentialPath = args.pop();
-          if (potentialPath != '--dry-run') && (potentialPath != '--no-update') && (potentialPath != '--check') && (potentialPath != '--upodate') {
+      if (potentialPath != '--dry-run') && (potentialPath != '--no-update') && (potentialPath != '--check') && (potentialPath != '--update') && (potenialPath != '--travis') {
         registryPath = potentialPath;
       }
       args.append(potentialPath);


### PR DESCRIPTION
Adds a `--ci-check` flag to mason publish that automatically triggers `--check` with a subset of the total checks designed to operate and work in a CI build environment. Namely, when you clone a package from a toml source, you do not want to check the git remote origin or any other checks that will not be present in that build.

Spelling issue with --update also fixed