### PR TITLE
Use bytes for paths and filenames

### DIFF
--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -1112,6 +1112,20 @@ module Bytes {
     return createBytesWithNewBuffer(x.buff, length=x.numBytes, size=x.numBytes+1);
   }
 
+  // Cast from c_string to bytes
+  pragma "no doc"
+  proc _cast(type t, cs: c_string) where t == bytes {
+    var ret: bytes;
+    ret.len = cs.length;
+    ret._size = ret.len+1;
+    ret.buff = if ret.len > 0
+      then __primitive("string_copy", cs): bufferType
+      else nil;
+    ret.isowned = true;
+
+    return ret;
+  }
+
   /*
      Appends the bytes `rhs` to the bytes `lhs`.
   */
@@ -1183,6 +1197,25 @@ module Bytes {
   pragma "no doc"
   inline proc !=(a: string, b: bytes) : bool {
     return !doEq(a,b);
+  }
+
+  pragma "no doc"
+  inline proc <(a: bytes, b: bytes) : bool {
+    return _strcmp(a.buff, a.len, a.locale_id, b.buff, b.len, b.locale_id) < 0;
+  }
+
+  pragma "no doc"
+  inline proc >(a: bytes, b: bytes) : bool {
+    return _strcmp(a.buff, a.len, a.locale_id, b.buff, b.len, b.locale_id) > 0;
+  }
+
+  pragma "no doc"
+  inline proc <=(a: bytes, b: bytes) : bool {
+    return _strcmp(a.buff, a.len, a.locale_id, b.buff, b.len, b.locale_id) <= 0;
+  }
+  pragma "no doc"
+  inline proc >=(a: bytes, b: bytes) : bool {
+    return _strcmp(a.buff, a.len, a.locale_id, b.buff, b.len, b.locale_id) >= 0;
   }
 
   // character-wise operation helpers

--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -155,7 +155,7 @@ extern const S_ISVTX: int;
 
 private proc dec(b: ?t): string {
   if t==bytes then
-    return try! b.decode(DecodePolicy.Ignore);
+    return try! b.decode(decodePolicy.ignore);
   else
     return b;
 }

--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -280,7 +280,7 @@ inline proc chown(name: bytes, uid: int, gid: int) throws {
   chownImpl(name, uid, gid);
 }
 
-private proc chown(name: ?t, uid: int, gid: int) throws {
+private proc chownImpl(name: ?t, uid: int, gid: int) throws {
   extern proc chpl_fs_chown(name: c_string, uid: c_int, gid: c_int):syserr;
 
   var err = chpl_fs_chown(name.localize().c_str(), uid:c_int, gid:c_int);
@@ -616,7 +616,8 @@ private inline proc copyTreeHelper(src: bytes, dest: bytes,
   copyTreeHelperImpl(src, dest, copySymbolically);
 }
 
-private proc copyTreeHelper(src: ?t, dest: t, copySymbolically: bool=false) throws {
+private proc copyTreeHelperImpl(src: ?t, dest: t,
+                                copySymbolically: bool=false) throws {
   // Create dest
   var oldMode = try getMode(src);
   try mkdir(dest, mode=oldMode, parents=true);
@@ -1220,7 +1221,7 @@ inline proc isFile(name:bytes):bool throws {
   return isFileImpl(name);
 }
 
-private proc isFile(name:?t):bool throws {
+private proc isFileImpl(name:?t):bool throws {
   extern proc chpl_fs_is_file(ref result:c_int, name: c_string):syserr;
 
   var ret:c_int;
@@ -1407,7 +1408,7 @@ iter listdirImpl(path: ?t, hidden: bool = false, dirs: bool = true,
   if (!is_c_nil(dir)) {
     ent = readdir(dir);
     while (!is_c_nil(ent)) {
-      const filename = ent.d_name():bytes;
+      const filename = ent.d_name():t;
       if (hidden || filename[1] != _conv(t,".")) {
         if (filename != _conv(t,".") && filename != _conv(t,"..")) {
           const fullpath = path + _conv(t,"/") + filename;
@@ -1671,7 +1672,7 @@ inline proc rmTree(root: bytes) throws {
   rmTreeImpl(root);
 }
 
-private proc rmTree(root: ?t) throws {
+private proc rmTreeImpl(root: ?t) throws {
   // root doesn't exist.  We can't remove something that isn't there
   var rootExists = try exists(root);
   if !rootExists then try ioerror(ENOENT:syserr,
@@ -1924,9 +1925,9 @@ iter walkdirs(path: bytes, topdown: bool = true, depth: int = max(int),
     yield d;
 }
 
-iter walkdirs(path: ?t, topdown: bool = true, depth: int = max(int),
-              hidden: bool = false, followlinks: bool = false,
-              sort: bool = false): t {
+iter walkdirsImpl(path: ?t, topdown: bool = true, depth: int = max(int),
+                  hidden: bool = false, followlinks: bool = false,
+                  sort: bool = false): t {
   if (topdown) then
     yield path;
 

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1644,13 +1644,18 @@ to create a channel to actually perform I/O operations
 
 :throws SystemError: Thrown if the file could not be opened.
 */
-proc open(path:string, mode:iomode, hints:iohints=IOHINT_NONE,
-          style:iostyle = defaultIOStyle()): file throws {
-  return open(path:bytes, mode, hints, style);
+inline proc open(path:string, mode:iomode, hints:iohints=IOHINT_NONE,
+                 style:iostyle = defaultIOStyle()): file throws {
+  return openImpl(path, mode, hints, style);
 }
 
-proc open(path:bytes, mode:iomode, hints:iohints=IOHINT_NONE,
-          style:iostyle = defaultIOStyle()): file throws {
+inline proc open(path:bytes, mode:iomode, hints:iohints=IOHINT_NONE,
+                 style:iostyle = defaultIOStyle()): file throws {
+  return openImpl(path, mode, hints, style);
+}
+
+private proc openImpl(path:?t, mode:iomode, hints:iohints=IOHINT_NONE,
+                      style:iostyle = defaultIOStyle()): file throws {
 
   var local_style = style;
   var error: syserr = ENOERR;
@@ -2513,20 +2518,29 @@ This function is equivalent to calling :proc:`open` and then
 // since we only will have one reference, will be right after we close this
 // channel presumably).
 // TODO: include optional iostyle argument for consistency
-proc openreader(path:string,
-                param kind=iokind.dynamic, param locking=true,
-                start:int(64) = 0, end:int(64) = max(int(64)),
-                hints:iohints = IOHINT_NONE,
-                style:iostyle = defaultIOStyle())
+inline proc openreader(path:string,
+                       param kind=iokind.dynamic, param locking=true,
+                       start:int(64) = 0, end:int(64) = max(int(64)),
+                       hints:iohints = IOHINT_NONE,
+                       style:iostyle = defaultIOStyle())
     : channel(false, kind, locking) throws {
-  return openreader(path:bytes, kind, locking, start, end, hints, style);
+  return openreaderImpl(path, kind, locking, start, end, hints, style);
 }
 
-proc openreader(path:bytes,
-                param kind=iokind.dynamic, param locking=true,
-                start:int(64) = 0, end:int(64) = max(int(64)),
-                hints:iohints = IOHINT_NONE,
-                style:iostyle = defaultIOStyle())
+inline proc openreader(path:bytes,
+                       param kind=iokind.dynamic, param locking=true,
+                       start:int(64) = 0, end:int(64) = max(int(64)),
+                       hints:iohints = IOHINT_NONE,
+                       style:iostyle = defaultIOStyle())
+    : channel(false, kind, locking) throws {
+  return openreaderImpl(path, kind, locking, start, end, hints, style);
+}
+
+private proc openreaderImpl(path:?t,
+                            param kind=iokind.dynamic, param locking=true,
+                            start:int(64) = 0, end:int(64) = max(int(64)),
+                            hints:iohints = IOHINT_NONE,
+                            style:iostyle = defaultIOStyle())
     : channel(false, kind, locking) throws {
 
   var fl:file = try open(path, iomode.r);
@@ -2560,20 +2574,29 @@ This function is equivalent to calling :proc:`open` with ``iomode.cwr`` and then
 
 :throws SystemError: Thrown if a writing channel could not be returned.
 */
-proc openwriter(path:string,
-                param kind=iokind.dynamic, param locking=true,
-                start:int(64) = 0, end:int(64) = max(int(64)),
-                hints:iohints = IOHINT_NONE,
-                style:iostyle = defaultIOStyle())
-    : channel(true, kind, locking) throws {
-  return openwriter(path:bytes, kind, locking, start, end, hints, style);
+inline proc openwriter(path:string,
+                       param kind=iokind.dynamic, param locking=true,
+                       start:int(64) = 0, end:int(64) = max(int(64)),
+                       hints:iohints = IOHINT_NONE,
+                       style:iostyle = defaultIOStyle())
+    : channel(false, kind, locking) throws {
+  return openreaderImpl(path, kind, locking, start, end, hints, style);
 }
 
-proc openwriter(path:bytes,
-                param kind=iokind.dynamic, param locking=true,
-                start:int(64) = 0, end:int(64) = max(int(64)),
-                hints:iohints = IOHINT_NONE,
-                style:iostyle = defaultIOStyle())
+inline proc openwriter(path:bytes,
+                       param kind=iokind.dynamic, param locking=true,
+                       start:int(64) = 0, end:int(64) = max(int(64)),
+                       hints:iohints = IOHINT_NONE,
+                       style:iostyle = defaultIOStyle())
+    : channel(false, kind, locking) throws {
+  return openreaderImpl(path, kind, locking, start, end, hints, style);
+}
+
+private proc openwriterImpl(path:?t,
+                            param kind=iokind.dynamic, param locking=true,
+                            start:int(64) = 0, end:int(64) = max(int(64)),
+                            hints:iohints = IOHINT_NONE,
+                            style:iostyle = defaultIOStyle())
     : channel(true, kind, locking) throws {
 
   var fl:file = try open(path, iomode.cw);

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -1551,8 +1551,8 @@ to get the path to a file.
 
 :throws SystemError: Thrown if the path could not be retrieved.
  */
-proc file.path : string throws {
-  var ret: string;
+proc file.path : bytes throws {
+  var ret: bytes;
   var err:syserr = ENOERR;
   on this.home {
     try this.checkAssumingLocal();
@@ -1564,7 +1564,7 @@ proc file.path : string throws {
     }
     chpl_free_c_string(tmp);
     if !err {
-      ret = createStringWithOwnedBuffer(tmp2);
+      ret = createBytesWithOwnedBuffer(tmp2);
     }
   }
   if err then try ioerror(err, "in file.path");
@@ -1577,11 +1577,11 @@ Get the path to an open file, or return "unknown" if there was
 a problem getting the path to the open file.
 
 */
-proc file.tryGetPath() : string {
+proc file.tryGetPath() : bytes {
   try {
     return this.path;
   } catch {
-    return "unknown";
+    return b"unknown";
   }
 }
 
@@ -1645,6 +1645,11 @@ to create a channel to actually perform I/O operations
 :throws SystemError: Thrown if the file could not be opened.
 */
 proc open(path:string, mode:iomode, hints:iohints=IOHINT_NONE,
+          style:iostyle = defaultIOStyle()): file throws {
+  return open(path:bytes, mode, hints, style);
+}
+
+proc open(path:bytes, mode:iomode, hints:iohints=IOHINT_NONE,
           style:iostyle = defaultIOStyle()): file throws {
 
   var local_style = style;
@@ -2514,6 +2519,15 @@ proc openreader(path:string,
                 hints:iohints = IOHINT_NONE,
                 style:iostyle = defaultIOStyle())
     : channel(false, kind, locking) throws {
+  return openreader(path:bytes, kind, locking, start, end, hints, style);
+}
+
+proc openreader(path:bytes,
+                param kind=iokind.dynamic, param locking=true,
+                start:int(64) = 0, end:int(64) = max(int(64)),
+                hints:iohints = IOHINT_NONE,
+                style:iostyle = defaultIOStyle())
+    : channel(false, kind, locking) throws {
 
   var fl:file = try open(path, iomode.r);
   return try fl.reader(kind, locking, start, end, hints, style);
@@ -2547,6 +2561,15 @@ This function is equivalent to calling :proc:`open` with ``iomode.cwr`` and then
 :throws SystemError: Thrown if a writing channel could not be returned.
 */
 proc openwriter(path:string,
+                param kind=iokind.dynamic, param locking=true,
+                start:int(64) = 0, end:int(64) = max(int(64)),
+                hints:iohints = IOHINT_NONE,
+                style:iostyle = defaultIOStyle())
+    : channel(true, kind, locking) throws {
+  return openwriter(path:bytes, kind, locking, start, end, hints, style);
+}
+
+proc openwriter(path:bytes,
                 param kind=iokind.dynamic, param locking=true,
                 start:int(64) = 0, end:int(64) = max(int(64)),
                 hints:iohints = IOHINT_NONE,

--- a/modules/standard/Path.chpl
+++ b/modules/standard/Path.chpl
@@ -204,7 +204,7 @@ proc commonPath(in paths: bytes ...?n): bytes {
 
   for i in 2..n do {
 
-    var tempList = new list(string);
+    var tempList = new list(bytes);
     for x in paths(i).split(pathSep, -1, false) do
       tempList.append(x);
 
@@ -330,7 +330,7 @@ proc commonPath(paths: []): bytes {
               a valid file name, as the file itself will not be affected.
    :type name: `string`
 */
-proc dirname(name: string): string {
+proc dirname(name: string): bytes {
   return dirname(name: bytes);
 }
 proc dirname(name: bytes): bytes {
@@ -500,7 +500,7 @@ private proc joinPathComponent(comp: bytes, ref result: bytes) {
 */
 // NOTE: Add in intent here to temporarily fix compiler memory leak related
 // to use of varargs.
-proc joinPath(in paths: string ...?n): string {
+proc joinPath(in paths: string ...?n): bytes {
   type castType = n*bytes;
   return joinPath((...(paths:castType)));
 }

--- a/modules/standard/SysError.chpl
+++ b/modules/standard/SysError.chpl
@@ -414,7 +414,8 @@ proc ioerror(error:syserr, msg:string, path:bytes, offset:int(64)) throws
 {
   if error {
     // TODO there should be a quote_bytes. Call to decode below is not right
-    const quotedpath = quote_string(path.decode(), path.numBytes:ssize_t);
+    const quotedpath = quote_string(path.decode(decodePolicy.ignore),
+                                    path.numBytes:ssize_t);
     var   details    = msg + " with path " + quotedpath +
                        " offset " + offset:string;
     throw SystemError.fromSyserr(error, details);

--- a/modules/standard/SysError.chpl
+++ b/modules/standard/SysError.chpl
@@ -405,8 +405,16 @@ pragma "insert line file info"
 pragma "always propagate line file info"
 proc ioerror(error:syserr, msg:string, path:string, offset:int(64)) throws
 {
+  ioerror(error:syserr, msg, path:bytes, offset:int(64));
+}
+
+pragma "insert line file info"
+pragma "always propagate line file info"
+proc ioerror(error:syserr, msg:string, path:bytes, offset:int(64)) throws
+{
   if error {
-    const quotedpath = quote_string(path, path.numBytes:ssize_t);
+    // TODO there should be a quote_bytes. Call to decode below is not right
+    const quotedpath = quote_string(path.decode(), path.numBytes:ssize_t);
     var   details    = msg + " with path " + quotedpath +
                        " offset " + offset:string;
     throw SystemError.fromSyserr(error, details);
@@ -418,8 +426,17 @@ pragma "insert line file info"
 pragma "always propagate line file info"
 proc ioerror(error:syserr, msg:string, path:string) throws
 {
+  ioerror(error, msg, path:bytes);
+}
+
+pragma "no doc" // documented in the offset version
+pragma "insert line file info"
+pragma "always propagate line file info"
+proc ioerror(error:syserr, msg:string, path:bytes) throws
+{
   if error {
-    const quotedpath = quote_string(path, path.numBytes:ssize_t);
+    // TODO there should be a quote_bytes. Call to decode below is not right
+    const quotedpath = quote_string(path.decode(), path.numBytes:ssize_t);
     var   details    = msg + " with path " + quotedpath;
     throw SystemError.fromSyserr(error, details);
   }

--- a/test/library/standard/Path/lydia/realpath/fileVersion.chpl
+++ b/test/library/standard/Path/lydia/realpath/fileVersion.chpl
@@ -6,10 +6,10 @@ var filename = "../realpath/./blahblahblah.txt";
 var openedFile = open(filename, iomode.cw);
 
 var path = openedFile.realPath();
-var shouldMatch = here.cwd() + "/blahblahblah.txt";
+var shouldMatch = here.cwd() + b"/blahblahblah.txt";
 // May want to use joinPath and basename here when available.
 if path != shouldMatch {
-  writeln("Whoops, expected " + shouldMatch + " but got " + path);
+  writeln("Whoops, expected ", shouldMatch, " but got ", path);
 } else {
   writeln("They matched!");
 }

--- a/test/library/standard/Path/lydia/realpath/onFileInDir.chpl
+++ b/test/library/standard/Path/lydia/realpath/onFileInDir.chpl
@@ -1,14 +1,14 @@
 use Path;
 use FileSystem;
 
-var unmodified = "onFileInDir.chpl";
+var unmodified = b"onFileInDir.chpl";
 var f = open(unmodified, iomode.r);
 // I know I exist (update name if changed)
 var result = f.realPath();
-var expected = here.cwd() + pathSep + unmodified;
+var expected = here.cwd() + pathSep:bytes + unmodified;
 // Will want to use joinPath here when it is implemented.
 if (result != expected) {
-  writeln("Expected " + expected + " but got " + result);
+  writeln("Expected ", expected, " but got ", result);
 } else {
   writeln("realPath on a path without symlinks, curDir, or parentDir references behaved as expected");
  }

--- a/test/library/standard/Path/lydia/realpath/resultSameAsFilePath.chpl
+++ b/test/library/standard/Path/lydia/realpath/resultSameAsFilePath.chpl
@@ -1,6 +1,6 @@
 use Path;
 
-var originalPath = "resultSameAsFilePath.chpl";
+var originalPath = b"resultSameAsFilePath.chpl";
 // Well, I know this file exists, better not rename it.
 var firstRun = realPath(originalPath);
 // firstRun will be an exact path
@@ -13,5 +13,5 @@ var secondTimeThrough = f.realPath();
 if (firstRun == secondTimeThrough) {
   writeln("Yay, realPath works on a path that has already been fixed!");
 } else {
-  writeln("Expected " + firstRun + " but was " + secondTimeThrough);
+  writeln("Expected ", firstRun, " but was ", secondTimeThrough);
  }

--- a/test/studies/labelprop/labelprop-tweets.chpl
+++ b/test/studies/labelprop/labelprop-tweets.chpl
@@ -62,6 +62,8 @@ var total_tweets_processed : atomic int;
 var total_lines_processed : atomic int;
 var max_user_id : atomic int;
 
+// TODO Engin: This test should use mostly bytes. And we need to get rid of
+// decode business
 proc main(args:[] string) {
   var files = args[1..];
   var todo:LinkedList(string);
@@ -70,7 +72,7 @@ proc main(args:[] string) {
     if isDir(arg) {
       // Go through files in directories.
       for f in findfiles(arg, true) {
-        todo.append(f);
+        todo.append(f.decode());
       }
     } else {
       todo.append(arg);


### PR DESCRIPTION
This PR switches standard modules to use bytes instead of string for filenames and paths.

Specifically:
- For a path/filename manipulating function:
```chapel
proc foo(p: string) {
  //do stuff
}
```
we now have
```chapel
proc foo(p:string) {
  foo(p:bytes);
}

proc foo(p:bytes) {
  // do stuff
}
```

- Some missing stuff is added to `bytes`:
  - procs like `bytes<bytes`
  - Ability to `c_string:bytes`

- Path-related constants, default arguments that are of type string now are bytes.

- Currently this PR also adjusts many tests that are related to the changes here to use the new
bytes-based interface as much as possible.

TODO:
- [ ] if we keep the current strategy (i.e. have both string and bytes overloads, where the former calls the latter) bunch of functions that take string arguments can be inlined.
- [ ] fix the rest of the tests to use bytes type (running 2nd round of paratest now, and expect 30-40 failing tests)
