### PR TITLE
Present multiple nilability errors in a single compilation

### DIFF
--- a/compiler/AST/DecoratedClassType.cpp
+++ b/compiler/AST/DecoratedClassType.cpp
@@ -66,10 +66,7 @@ const char* decoratedTypeAstr(ClassTypeDecorator d, const char* className) {
       else
         return astr(className);
     case CLASS_TYPE_GENERIC_NONNIL:
-      if (developer)
-        return astr("anymanaged ", className, "!");
-      else
-        return astr(className);
+      return astr(className);
     case CLASS_TYPE_GENERIC_NILABLE:
       if (developer)
         return astr("anymanaged ", className, "?");

--- a/compiler/include/driver.h
+++ b/compiler/include/driver.h
@@ -47,6 +47,7 @@ extern bool fNoFormalDomainChecks;
 extern bool fNoLocalChecks;
 extern bool fNoNilChecks;
 extern bool fLegacyClasses;
+extern bool fIgnoreNilabilityErrors;
 extern bool fOverloadSetsChecks;
 extern bool fNoStackChecks;
 extern bool fNoCastChecks;

--- a/compiler/include/misc.h
+++ b/compiler/include/misc.h
@@ -105,6 +105,7 @@ void        printCallStack();
 void        printCallStackCalls();
 
 bool        fatalErrorsEncountered();
+void        clearFatalErrors();
 
 // must be exported to avoid dead-code elimination by C++ compiler
 void        gdbShouldBreakHere();

--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -234,6 +234,8 @@ FnSymbol* getUnalias(Type* t);
 bool isPOD(Type* t);
 
 // resolution errors and warnings
+
+// This one does not call USR_STOP
 void printResolutionErrorUnresolved(CallInfo&                  info,
                                     Vec<FnSymbol*>&            visibleFns);
 
@@ -318,5 +320,12 @@ Type* computeDecoratedManagedType(AggregateType* canonicalClassType,
                                   Expr* ctx);
 
 void checkDuplicateDecorators(Type* decorator, Type* decorated, Expr* ctx);
+
+// These enable resolution for functions that don't really match
+// according to the language definition in order to get more errors
+// reported at once. E.g. C? can pass to C.
+void startGenerousResolutionForErrors();
+bool inGenerousResolutionForErrors();
+void stopGenerousResolutionForErrors();
 
 #endif

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -145,6 +145,7 @@ bool fNoFormalDomainChecks = false;
 bool fNoLocalChecks = false;
 bool fNoNilChecks = false;
 bool fLegacyClasses = false;
+bool fIgnoreNilabilityErrors = false;
 bool fOverloadSetsChecks = true;
 bool fNoStackChecks = false;
 bool fNoInferLocalFields = false;
@@ -1060,6 +1061,7 @@ static ArgumentDescription arg_desc[] = {
  {"interprocedural-alias-analysis", ' ', NULL, "Enable [disable] interprocedural alias analysis", "n", &fNoInterproceduralAliasAnalysis, NULL, NULL},
  {"lifetime-checking", ' ', NULL, "Enable [disable] lifetime checking pass", "N", &fLifetimeChecking, NULL, NULL},
  {"legacy-classes", ' ', NULL, "Class variables match 1.19 - borrowed by default, can store nil", "N", &fLegacyClasses, NULL, NULL},
+ {"ignore-nilability-errors", ' ', NULL, "Allow compilation to continue by coercing away nilability", "N", &fIgnoreNilabilityErrors, NULL, NULL},
  {"overload-sets-checks", ' ', NULL, "Report potentially hijacked calls", "N", &fOverloadSetsChecks, NULL, NULL},
  {"compile-time-nil-checking", ' ', NULL, "Enable [disable] compile-time nil checking", "N", &fCompileTimeNilChecking, "CHPL_NO_COMPILE_TIME_NIL_CHECKS", NULL},
  {"ignore-errors", ' ', NULL, "[Don't] attempt to ignore errors", "N", &ignore_errors, "CHPL_IGNORE_ERRORS", NULL},

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -3179,14 +3179,17 @@ static FnSymbol* resolveNormalCall(CallInfo& info, bool checkOnly) {
     if (info.call->partialTag == false) {
       if (checkOnly == false) {
         if (candidates.n == 0) {
+          bool existingErrors = fatalErrorsEncountered();
           printResolutionErrorUnresolved(info, mostApplicable);
 
           if (generousNilabilityForErrors == 0) {
             gdbShouldBreakHere();
-
             generousNilabilityForErrors++;
             FnSymbol* retry = resolveNormalCall(info, /*checkOnly*/ true);
             generousNilabilityForErrors--;
+
+            if (fIgnoreNilabilityErrors && existingErrors == false && retry)
+              clearFatalErrors();
 
             if (retry != NULL)
               return retry;

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -144,6 +144,8 @@ static CapturedValueMap            capturedValues;
 // Used to ensure we only issue the warning once per instantiation
 static std::set<FnSymbol*> oldStyleInitCopyFns;
 
+// Enable coercions from nilable -> non-nilable to have easier errors
+static int generousNilabilityForErrors;
 
 //#
 //# Static Function Declarations
@@ -1284,6 +1286,11 @@ bool allowImplicitNilabilityRemoval(Type* actualType,
                                     Symbol* actualSym,
                                     Type* formalType,
                                     Symbol* formalSym) {
+
+  // If we are trying again for better nilability errors,
+  // implicit nilability removal is OK.
+  if (generousNilabilityForErrors > 0)
+    return true;
 
   // Currently only applies to this arguments (method receivers)
   if (formalSym && actualSym && actualSym->defPoint &&
@@ -3162,6 +3169,7 @@ static FnSymbol* resolveNormalCall(CallInfo& info, bool checkOnly) {
     }
   }
 
+
   if (! overloadSetsOK(info.call, checkOnly, candidates,
                        bestRef, bestCref, bestVal)) {
     return NULL; // overloadSetsOK() found an error
@@ -3170,10 +3178,27 @@ static FnSymbol* resolveNormalCall(CallInfo& info, bool checkOnly) {
   if (numMatches == 0) {
     if (info.call->partialTag == false) {
       if (checkOnly == false) {
-        if (candidates.n == 0)
+        if (candidates.n == 0) {
           printResolutionErrorUnresolved(info, mostApplicable);
-        else
+
+          if (generousNilabilityForErrors == 0) {
+            gdbShouldBreakHere();
+
+            generousNilabilityForErrors++;
+            FnSymbol* retry = resolveNormalCall(info, /*checkOnly*/ true);
+            generousNilabilityForErrors--;
+
+            if (retry != NULL)
+              return retry;
+          }
+
+          // TODO: we could try e.g. removing the bad call
+          // and checking other funtions instead of giving up here.
+          USR_STOP();
+
+        } else {
           printResolutionErrorAmbiguous (info, candidates);
+        }
       }
     }
 
@@ -3605,8 +3630,6 @@ void printResolutionErrorUnresolved(CallInfo&       info,
     if (developer == true) {
       USR_PRINT(call, "unresolved call had id %i", call->id);
     }
-
-    USR_STOP();
   }
 }
 

--- a/compiler/resolution/initializerResolution.cpp
+++ b/compiler/resolution/initializerResolution.cpp
@@ -484,6 +484,7 @@ static void resolveInitCall(CallExpr* call, AggregateType* newExprAlias) {
         }
         if (candidates.n == 0) {
           printResolutionErrorUnresolved(info, mostApplicable);
+          USR_STOP();
         } else {
           printResolutionErrorAmbiguous (info, candidates);
         }

--- a/compiler/util/misc.cpp
+++ b/compiler/util/misc.cpp
@@ -652,6 +652,11 @@ bool fatalErrorsEncountered() {
   return exit_eventually || exit_end_of_pass;
 }
 
+void clearFatalErrors() {
+  exit_eventually = false;
+  exit_end_of_pass = false;
+}
+
 static void handleInterrupt(int sig) {
   stopCatchingSignals();
   fprintf(stderr, "error: received interrupt\n");

--- a/test/classes/errors/nilability-assign/assign-nonnil-borrowed-from-oknil-borrowed.good
+++ b/test/classes/errors/nilability-assign/assign-nonnil-borrowed-from-oknil-borrowed.good
@@ -1,1 +1,2 @@
 assign-nonnil-borrowed-from-oknil-borrowed.chpl:8: error: Cannot assign to borrowed MyClass from borrowed MyClass?
+assign-nonnil-borrowed-from-oknil-borrowed.chpl:10: error: done

--- a/test/classes/errors/nilability-assign/assign-nonnil-borrowed-from-oknil-owned.good
+++ b/test/classes/errors/nilability-assign/assign-nonnil-borrowed-from-oknil-owned.good
@@ -1,1 +1,2 @@
 assign-nonnil-borrowed-from-oknil-owned.chpl:8: error: Cannot assign to borrowed MyClass from owned MyClass?
+assign-nonnil-borrowed-from-oknil-owned.chpl:10: error: done

--- a/test/classes/errors/nilability-assign/assign-nonnil-borrowed-from-oknil-shared.good
+++ b/test/classes/errors/nilability-assign/assign-nonnil-borrowed-from-oknil-shared.good
@@ -1,1 +1,2 @@
 assign-nonnil-borrowed-from-oknil-shared.chpl:8: error: Cannot assign to borrowed MyClass from shared MyClass?
+assign-nonnil-borrowed-from-oknil-shared.chpl:10: error: done

--- a/test/classes/errors/nilability-assign/assign-nonnil-borrowed-from-oknil-unmanaged.good
+++ b/test/classes/errors/nilability-assign/assign-nonnil-borrowed-from-oknil-unmanaged.good
@@ -1,1 +1,2 @@
 assign-nonnil-borrowed-from-oknil-unmanaged.chpl:8: error: Cannot assign to borrowed MyClass from unmanaged MyClass?
+assign-nonnil-borrowed-from-oknil-unmanaged.chpl:10: error: done

--- a/test/classes/errors/nilability-assign/assign-nonnil-unmanaged-from-oknil-unmanaged.good
+++ b/test/classes/errors/nilability-assign/assign-nonnil-unmanaged-from-oknil-unmanaged.good
@@ -1,1 +1,2 @@
 assign-nonnil-unmanaged-from-oknil-unmanaged.chpl:8: error: Cannot assign to unmanaged MyClass from unmanaged MyClass?
+assign-nonnil-unmanaged-from-oknil-unmanaged.chpl:10: error: done

--- a/test/classes/nilability/multiple-errors.1.good
+++ b/test/classes/nilability/multiple-errors.1.good
@@ -1,0 +1,13 @@
+multiple-errors.chpl:16: In function 'main':
+multiple-errors.chpl:18: error: unresolved call 'borrowed C?.foo()'
+multiple-errors.chpl:6: note: this candidate did not match: C.foo()
+multiple-errors.chpl:18: note: because method call receiver with type borrowed C?
+multiple-errors.chpl:6: note: is passed to formal 'this: borrowed C'
+multiple-errors.chpl:19: error: unresolved call 'borrowed C?.bar()'
+multiple-errors.chpl:9: note: this candidate did not match: C.bar()
+multiple-errors.chpl:19: note: because method call receiver with type borrowed C?
+multiple-errors.chpl:9: note: is passed to formal 'this: borrowed C'
+multiple-errors.chpl:20: error: unresolved call 'baz(borrowed C?)'
+multiple-errors.chpl:12: note: this candidate did not match: baz(arg: C)
+multiple-errors.chpl:20: note: because call actual argument #1 with type borrowed C?
+multiple-errors.chpl:12: note: is passed to formal 'arg: C'

--- a/test/classes/nilability/multiple-errors.2.good
+++ b/test/classes/nilability/multiple-errors.2.good
@@ -1,0 +1,16 @@
+multiple-errors.chpl:16: In function 'main':
+multiple-errors.chpl:18: error: unresolved call 'borrowed C?.foo()'
+multiple-errors.chpl:6: note: this candidate did not match: C.foo()
+multiple-errors.chpl:18: note: because method call receiver with type borrowed C?
+multiple-errors.chpl:6: note: is passed to formal 'this: borrowed C'
+multiple-errors.chpl:19: error: unresolved call 'borrowed C?.bar()'
+multiple-errors.chpl:9: note: this candidate did not match: C.bar()
+multiple-errors.chpl:19: note: because method call receiver with type borrowed C?
+multiple-errors.chpl:9: note: is passed to formal 'this: borrowed C'
+multiple-errors.chpl:20: error: unresolved call 'baz(borrowed C?)'
+multiple-errors.chpl:12: note: this candidate did not match: baz(arg: C)
+multiple-errors.chpl:20: note: because call actual argument #1 with type borrowed C?
+multiple-errors.chpl:12: note: is passed to formal 'arg: C'
+foo({x = 0})
+bar({x = 0})
+baz({x = 0})

--- a/test/classes/nilability/multiple-errors.chpl
+++ b/test/classes/nilability/multiple-errors.chpl
@@ -1,20 +1,22 @@
 module M {
-  class C { }
+  class C {
+    var x: int;
+  }
 
-  proc C.foo() { }
-  proc C.bar() { }
-
-  proc baz(arg:C) { }
+  proc C.foo() {
+    writeln("foo(", this, ")");
+  }
+  proc C.bar() {
+    writeln("bar(", this, ")");
+  }
+  proc baz(arg:C) {
+    writeln("baz(", arg, ")");
+  }
 
   proc main() {
-    var a: borrowed C?;
-
-    var b: borrowed C?;
-
+    var a: borrowed C? = (new owned C()).borrow();
     a.foo();
-
-    b.bar();
-
-    baz(b);
+    a.bar();
+    baz(a);
   }
 }

--- a/test/classes/nilability/multiple-errors.chpl
+++ b/test/classes/nilability/multiple-errors.chpl
@@ -1,0 +1,20 @@
+module M {
+  class C { }
+
+  proc C.foo() { }
+  proc C.bar() { }
+
+  proc baz(arg:C) { }
+
+  proc main() {
+    var a: borrowed C?;
+
+    var b: borrowed C?;
+
+    a.foo();
+
+    b.bar();
+
+    baz(b);
+  }
+}

--- a/test/classes/nilability/multiple-errors.compopts
+++ b/test/classes/nilability/multiple-errors.compopts
@@ -1,0 +1,2 @@
+--no-ignore-nilability-errors  # multiple-errors.1.good
+--ignore-nilability-errors     # multiple-errors.2.good

--- a/test/classes/nilability/multiple-errors.good
+++ b/test/classes/nilability/multiple-errors.good
@@ -1,0 +1,13 @@
+multiple-errors.chpl:9: In function 'main':
+multiple-errors.chpl:14: error: unresolved call 'borrowed C?.foo()'
+multiple-errors.chpl:4: note: this candidate did not match: C.foo()
+multiple-errors.chpl:14: note: because method call receiver with type borrowed C?
+multiple-errors.chpl:4: note: is passed to formal 'this: borrowed C'
+multiple-errors.chpl:16: error: unresolved call 'borrowed C?.bar()'
+multiple-errors.chpl:5: note: this candidate did not match: C.bar()
+multiple-errors.chpl:16: note: because method call receiver with type borrowed C?
+multiple-errors.chpl:5: note: is passed to formal 'this: borrowed C'
+multiple-errors.chpl:18: error: unresolved call 'baz(borrowed C?)'
+multiple-errors.chpl:7: note: this candidate did not match: baz(arg: C)
+multiple-errors.chpl:18: note: because call actual argument #1 with type borrowed C?
+multiple-errors.chpl:7: note: is passed to formal 'arg: C'

--- a/util/chpl-completion.bash
+++ b/util/chpl-completion.bash
@@ -78,6 +78,7 @@ _chpl ()
 --ignore-errors \
 --ignore-errors-for-pass \
 --ignore-local-classes \
+--ignore-nilability-errors \
 --ignore-user-errors \
 --incremental \
 --infer-const-refs \
@@ -160,6 +161,7 @@ _chpl ()
 --no-ignore-errors \
 --no-ignore-errors-for-pass \
 --no-ignore-local-classes \
+--no-ignore-nilability-errors \
 --no-ignore-user-errors \
 --no-incremental \
 --no-infer-const-refs \


### PR DESCRIPTION
Resolves https://github.com/Cray/chapel-private/issues/456
Resolves #13873

This PR allows function resolution to produce multiple nilability-related
errors if they can be fixed by allowing coercions from nilable -> not
nilable. Additionally, it adds a flag `--ignore-nilability-errors` which
allows compilation to continue to producing an executable in the event
there are no further errors. Note that the nilability errors are still
reported as `error` rather than `warning`.

Note that the continuation of compilation does not currently work with
initializers. I ran into more challenges there than I was ready to solve
today, but perhaps it can be addressed as a bug fix.

Reviewed by @vasslitvinov - thanks!

- [x] full local testing
