### PR TITLE
Deprecate c_string to string casts

### DIFF
--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1283,7 +1283,7 @@ module ChapelBase {
     if isAtomicType(t) then
       compilerError("config variables of atomic type are not supported");
 
-    var str = x:string;
+    var str = createStringWithNewBuffer(x);
     if t == string {
       return str;
     } else {
@@ -2252,7 +2252,8 @@ module ChapelBase {
     const moduleName: c_string;          // for debugging; non-null, not owned
     const deinitFun:  c_fn_ptr;          // module deinit function
     const prevModule: unmanaged chpl_ModuleDeinit?; // singly-linked list / LIFO queue
-    proc writeThis(ch) {ch.writef("chpl_ModuleDeinit(%s)",moduleName:string);}
+    proc writeThis(ch) {ch.writef("chpl_ModuleDeinit(%s)",
+                                  createStringWithBorrowedBuffer(moduleName));}
   }
   var chpl_moduleDeinitFuns = nil: unmanaged chpl_ModuleDeinit?;
 

--- a/modules/internal/ChapelDebugPrint.chpl
+++ b/modules/internal/ChapelDebugPrint.chpl
@@ -97,7 +97,7 @@ module ChapelDebugPrint {
     if chpl__testParFlag && chpl__testParOn {
       const file_cs : c_string = __primitive("chpl_lookupFilename",
                                         __primitive("_get_user_file"));
-      const file = file_cs:string;
+      const file = createStringWithBorrowedBuffer(file_cs);
       const line = __primitive("_get_user_line");
       writeln("CHPL TEST PAR (", file, ":", line, "): ", (...args));
     }

--- a/modules/internal/ChapelError.chpl
+++ b/modules/internal/ChapelError.chpl
@@ -350,7 +350,7 @@ module ChapelError {
   proc chpl_error_type_name(err: borrowed Error) : string {
     var cid =  __primitive("getcid", err);
     var nameC: c_string = __primitive("class name by id", cid);
-    var nameS = nameC:string;
+    var nameS = createStringWithNewBuffer(nameC);
     return nameS;
   }
   pragma "no doc"
@@ -436,12 +436,12 @@ module ChapelError {
 
     const myFileC:c_string = __primitive("chpl_lookupFilename",
                                          __primitive("_get_user_file"));
-    const myFileS = myFileC:string;
+    const myFileS = createStringWithBorrowedBuffer(myFileC);
     const myLine = __primitive("_get_user_line");
 
     const thrownFileC:c_string = __primitive("chpl_lookupFilename",
                                              err.thrownFileId);
-    const thrownFileS = thrownFileC:string;
+    const thrownFileS = createStringWithBorrowedBuffer(thrownFileC);
     const thrownLine = err.thrownLine;
 
     var s = "uncaught " + chpl_describe_error(err) +

--- a/modules/internal/LocaleModelHelpSetup.chpl
+++ b/modules/internal/LocaleModelHelpSetup.chpl
@@ -124,7 +124,7 @@ module LocaleModelHelpSetup {
     // at least this setup method) must be run on the node it is
     // intended to describe.
     extern proc chpl_nodeName(): c_string;
-    const _node_name = chpl_nodeName(): string;
+    const _node_name = createStringWithNewBuffer(chpl_nodeName());
     const _node_id = (chpl_nodeID: int): string;
 
     return if localSpawn() then _node_name + "-" + _node_id else _node_name;

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -2244,6 +2244,8 @@ module String {
   // Cast from c_string to string
   pragma "no doc"
   proc _cast(type t, cs: c_string) where t == string {
+    compilerWarning("Cast from c_string to string is deprecated - "+
+                    "please use createString* functions instead");
     var ret: string;
     ret.len = cs.length;
     ret._size = ret.len+1;

--- a/modules/packages/ZMQ.chpl
+++ b/modules/packages/ZMQ.chpl
@@ -492,7 +492,7 @@ module ZMQ {
       this.home = here;
       this.complete();
       if this.ctx == nil {
-        var errmsg = zmq_strerror(errno):string;
+        var errmsg = createStringWithBorrowedBuffer(zmq_strerror(errno));
         halt("Error in ContextClass.init(): %s\n", errmsg);
       }
     }
@@ -501,7 +501,7 @@ module ZMQ {
       on this.home {
         var ret = zmq_ctx_term(this.ctx):int;
         if ret == -1 {
-          var errmsg = zmq_strerror(errno):string;
+          var errmsg = createStringWithBorrowedBuffer(zmq_strerror(errno));
           halt("Error in ContextClass.deinit(): %s\n", errmsg);
         }
       }
@@ -578,7 +578,7 @@ module ZMQ {
       this.home = here;
       this.complete();
       if this.socket == nil {
-        var errmsg = zmq_strerror(errno):string;
+        var errmsg = createStringWithBorrowedBuffer(zmq_strerror(errno));
         halt("Error in SocketClass.init(): %s\n", errmsg);
       }
     }
@@ -587,7 +587,7 @@ module ZMQ {
       on this.home {
         var ret = zmq_close(socket):int;
         if ret == -1 {
-          var errmsg = zmq_strerror(errno):string;
+          var errmsg = createStringWithBorrowedBuffer(zmq_strerror(errno));
           halt("Error in SocketClass.deinit(): %s\n", errmsg);
         }
         socket = c_nil;
@@ -688,7 +688,7 @@ module ZMQ {
         var tmp = endpoint;
         var ret = zmq_bind(classRef.socket, tmp.c_str());
         if ret == -1 {
-          var errmsg = zmq_strerror(errno):string;
+          var errmsg = createStringWithBorrowedBuffer(zmq_strerror(errno));
           halt("Error in Socket.bind(): ", errmsg);
         }
       }
@@ -702,7 +702,7 @@ module ZMQ {
         var tmp = endpoint;
         var ret = zmq_connect(classRef.socket, tmp.c_str());
         if ret == -1 {
-          var errmsg = zmq_strerror(errno):string;
+          var errmsg = createStringWithBorrowedBuffer(zmq_strerror(errno));
           writef("Error in Socket.connect(): %s\n", errmsg);
         }
       }
@@ -733,7 +733,7 @@ module ZMQ {
                                  c_ptrTo(copy):c_void_ptr,
                                  numBytes(T)): int;
         if ret == -1 {
-          var errmsg = zmq_strerror(errno):string;
+          var errmsg = createStringWithBorrowedBuffer(zmq_strerror(errno));
           halt("Error in Socket.setsockopt(): ", errmsg);
         }
       }
@@ -771,7 +771,7 @@ module ZMQ {
         var err = zmq_getsockopt_string_helper(classRef.socket,
                                                ZMQ_LAST_ENDPOINT, str);
         if err == -1 {
-          var errmsg = zmq_strerror(errno):string;
+          var errmsg = createStringWithBorrowedBuffer(zmq_strerror(errno));
           // It would be good to use a factory method for a ZMQError subclass,
           // see #12397
           throw new owned ZMQError("Error in Socket.getLastEndpoint(): " +
@@ -798,7 +798,7 @@ module ZMQ {
         var ret = zmq_getsockopt_int_helper(classRef.socket, ZMQ_LINGER,
                                             copy);
         if ret == -1 {
-          var errmsg = zmq_strerror(errno):string;
+          var errmsg = createStringWithBorrowedBuffer(zmq_strerror(errno));
           // It would be good to use a factory method for a ZMQError subclass,
           // see #12397
           throw new owned ZMQError("Error in Socket.getLinger(): " + errmsg);
@@ -824,7 +824,7 @@ module ZMQ {
                                  c_ptrTo(copy): c_void_ptr,
                                  numBytes(value.type)): int;
         if ret == -1 {
-          var errmsg = zmq_strerror(errno):string;
+          var errmsg = createStringWithBorrowedBuffer(zmq_strerror(errno));
           // It would be good to use a factory method for a ZMQError subclass,
           // see #12397
           throw new owned ZMQError("Error in Socket.setLinger(): " + errmsg);
@@ -848,7 +848,7 @@ module ZMQ {
                                  c_ptrTo(copy): c_void_ptr,
                                  numBytes(value.type)): int;
         if ret == -1 {
-          var errmsg = zmq_strerror(errno):string;
+          var errmsg = createStringWithBorrowedBuffer(zmq_strerror(errno));
           // It would be good to use a factory method for a ZMQError subclass,
           // see #12397
           throw new owned ZMQError("Error in Socket.setSubscribe(): " + errmsg);
@@ -1102,7 +1102,8 @@ module ZMQ {
 
     pragma "no doc"
     proc throw_socket_error(socket_errno: c_int, err_fn: string) throws {
-      var errmsg_zmq = zmq_strerror(socket_errno):string;
+      var errmsg_zmq =
+        createStringWithBorrowedBuffer(zmq_strerror(socket_errno));
       var errmsg_fmt = "Error in Socket.%s(%s): %s\n";
       var errmsg_str = errmsg_fmt.format(err_fn, string:string, errmsg_zmq);
 

--- a/modules/standard/DateTime.chpl
+++ b/modules/standard/DateTime.chpl
@@ -431,7 +431,8 @@ module DateTime {
     timeStruct.tm_yday = (this - new date(year, 1, 1)).days: int(32);
 
     strftime(c_ptrTo(buf), bufLen, fmt.c_str(), timeStruct);
-    var str = __primitive("cast", c_string, c_ptrTo(buf)): string;
+    var str = createStringWithNewBuffer( __primitive("cast",
+                                                     c_string, c_ptrTo(buf)));
 
     return str;
   }
@@ -677,7 +678,8 @@ module DateTime {
     }
 
     strftime(c_ptrTo(buf), bufLen, fmt.c_str(), timeStruct);
-    var str = __primitive("cast", c_string, c_ptrTo(buf)): string;
+    var str = createStringWithNewBuffer(__primitive("cast",
+                                                    c_string, c_ptrTo(buf)));
 
     return str;
   }
@@ -1186,7 +1188,8 @@ module DateTime {
     timeStruct.tm_yday = (this.replace(tzinfo=nil) - new datetime(year, 1, 1)).days: int(32);
 
     strftime(c_ptrTo(buf), bufLen, fmt.c_str(), timeStruct);
-    var str = __primitive("cast", c_string, c_ptrTo(buf)): string;
+    var str = createStringWithNewBuffer(__primitive("cast",
+                                                    c_string, c_ptrTo(buf)));
 
     return str;
   }

--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -875,7 +875,8 @@ private module GlobWrappers {
   // glob_index wrapper that takes care of casting
   inline proc glob_index_w(glb: glob_t, idx: int): string {
     extern proc chpl_glob_index(glb: glob_t, idx: size_t): c_string;
-    return chpl_glob_index(glb, idx.safeCast(size_t)): string;
+    return createStringWithNewBuffer(chpl_glob_index(glb,
+                                                       idx.safeCast(size_t)));
   }
 
   // globfree wrapper that exists only for symmetry in the routine names
@@ -1180,7 +1181,7 @@ iter listdir(path: string = ".", hidden: bool = false, dirs: bool = true,
   if (!is_c_nil(dir)) {
     ent = readdir(dir);
     while (!is_c_nil(ent)) {
-      const filename = ent.d_name():string;
+      const filename = createStringWithBorrowedBuffer(ent.d_name());
       if (hidden || filename[1] != '.') {
         if (filename != "." && filename != "..") {
           const fullpath = path + "/" + filename;

--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -3395,7 +3395,12 @@ proc _stringify_tuple(tup:?t) where isTuple(t)
 
   for param i in 1..tup.size {
     if i != 1 then str += ", ";
-    str += tup[i]:string;
+    if tup[i].type == c_string {
+      str += createStringWithBorrowedBuffer(tup[i]);
+    }
+    else {
+      str += tup[i]:string;
+    }
   }
 
  str += ")";
@@ -3422,9 +3427,10 @@ proc stringify(const args ...?k):string {
     var str = "";
 
     for param i in 1..k {
-      if args[i].type == string ||
-         args[i].type == c_string {
-        str += args[i]:string;
+      if args[i].type == string {
+        str += args[i];
+      } else if args[i].type == c_string {
+        str += createStringWithBorrowedBuffer(args[i]);
       } else if isRangeType(args[i].type) ||
                 isPrimitiveType(args[i].type) {
         str += args[i]:string;

--- a/modules/standard/Path.chpl
+++ b/modules/standard/Path.chpl
@@ -360,7 +360,7 @@ proc dirname(name: string): string {
            if (h != 1) {
              value = "${" + env_var + "}";
            } else {
-             value = value_c: string;
+             value = createStringWithBorrowedBuffer(value_c);
            }
            res += value;
          }
@@ -377,7 +377,7 @@ proc dirname(name: string): string {
          if (h != 1) {
            value = "$" + env_var;
          } else {
-           value = value_c: string;
+           value = createStringWithBorrowedBuffer(value_c);
          }
          res += value;
          if (ind <= path_p.numBytes) {

--- a/modules/standard/Regexp.chpl
+++ b/modules/standard/Regexp.chpl
@@ -468,7 +468,8 @@ proc compile(pattern: string, utf8=true, posix=false, literal=false, nocapture=f
   qio_regexp_create_compile(pattern.localize().c_str(), pattern.numBytes, opts, ret._regexp);
   if !qio_regexp_ok(ret._regexp) {
     var err_str = qio_regexp_error(ret._regexp);
-    var err_msg = err_str:string + " when compiling regexp '" + pattern + "'";
+    var err_msg = createStringWithNewBuffer(err_str) + 
+                  " when compiling regexp '" + pattern + "'";
     throw new owned BadRegexpError(err_msg);
   }
   return ret;


### PR DESCRIPTION
This is a WIP PR that deprecates c_string to string casts.

Currently, this should remove most (if not all) module usage of the `c_string:string` cast. In my initial paratest there were 117 tests failing with warnings coming from the test (and not from any module). I am currently running another paratest, but if the amount of tests that need to change is that much, then maybe the deprecation warning can be mode off-by-default until the tests are fixed.