### PR TITLE
Tackles additional intents error messages for library compilation

### DIFF
--- a/compiler/codegen/library.cpp
+++ b/compiler/codegen/library.cpp
@@ -85,7 +85,7 @@ void codegen_library_header(std::vector<FnSymbol*> functions) {
       // functions
       for_vector(FnSymbol, fn, functions) {
         if (fn->hasFlag(FLAG_EXPORT) &&
-            !isInternalExport(fn)) {
+            isUserRoutine(fn)) {
           fn->codegenPrototype();
         }
       }
@@ -445,7 +445,7 @@ void makeFortranModule(std::vector<FnSymbol*> functions) {
     indent += 2;
     // generate chpl_library_init and chpl_library_finalize here?
     for_vector(FnSymbol, fn, functions) {
-      if (!isInternalExport(fn)) {
+      if (isUserRoutine(fn)) {
         fn->codegenFortran(indent);
       }
     }
@@ -479,7 +479,7 @@ static void makePXDFile(std::vector<FnSymbol*> functions) {
     fprintf(pxd.fptr, "cdef extern from \"%s.h\":\n", libmodeHeadername);
 
     for_vector(FnSymbol, fn, functions) {
-      if (!isInternalExport(fn)) {
+      if (isUserRoutine(fn)) {
         fn->codegenPython(C_PXD);
       }
     }
@@ -522,7 +522,7 @@ static void makePYXFile(std::vector<FnSymbol*> functions) {
     bool first = true;
     // Make import statement at top of .pyx file for exported functions
     for_vector(FnSymbol, fn, functions) {
-      if (!isInternalExport(fn)) {
+      if (isUserRoutine(fn)) {
         if (fn->hasFlag(FLAG_EXPORT)) {
           if (first) {
             first = false;
@@ -811,8 +811,8 @@ void codegen_make_python_module() {
 
 // Skip this function if it is defined in an internal module, or if it is
 // the generated main function
-bool isInternalExport(FnSymbol* fn) {
-  return fn->getModule()->modTag == MOD_INTERNAL ||
-         fn->getModule()->modTag == MOD_STANDARD ||
-         fn->hasFlag(FLAG_GEN_MAIN_FUNC);
+bool isUserRoutine(FnSymbol* fn) {
+  return !(fn->getModule()->modTag == MOD_INTERNAL ||
+           fn->getModule()->modTag == MOD_STANDARD ||
+           fn->hasFlag(FLAG_GEN_MAIN_FUNC));
 }

--- a/compiler/codegen/library.cpp
+++ b/compiler/codegen/library.cpp
@@ -820,5 +820,5 @@ static bool isFunctionToSkip(FnSymbol* fn) {
 }
 
 bool willBePythonized(FnSymbol* fn) {
-  return !isFunctionToSkip(fn) && fLibraryPython && fn->hasFlag(FLAG_EXPORT);
+  return !isFunctionToSkip(fn) && fLibraryPython;
 }

--- a/compiler/codegen/library.cpp
+++ b/compiler/codegen/library.cpp
@@ -39,8 +39,6 @@ std::map<TypeSymbol*, std::pair<std::string, std::string> > pythonNames;
 std::map<TypeSymbol*, std::string> fortranKindNames;
 std::map<TypeSymbol*, std::string> fortranTypeNames;
 
-static bool isFunctionToSkip(FnSymbol* fn);
-
 //
 // Generates a .h file to complement the library file created using --library
 // This .h file will contain necessary #includes, any explicitly exported
@@ -87,7 +85,7 @@ void codegen_library_header(std::vector<FnSymbol*> functions) {
       // functions
       for_vector(FnSymbol, fn, functions) {
         if (fn->hasFlag(FLAG_EXPORT) &&
-            !isFunctionToSkip(fn)) {
+            !isInternalExport(fn)) {
           fn->codegenPrototype();
         }
       }
@@ -447,7 +445,7 @@ void makeFortranModule(std::vector<FnSymbol*> functions) {
     indent += 2;
     // generate chpl_library_init and chpl_library_finalize here?
     for_vector(FnSymbol, fn, functions) {
-      if (!isFunctionToSkip(fn)) {
+      if (!isInternalExport(fn)) {
         fn->codegenFortran(indent);
       }
     }
@@ -481,7 +479,7 @@ static void makePXDFile(std::vector<FnSymbol*> functions) {
     fprintf(pxd.fptr, "cdef extern from \"%s.h\":\n", libmodeHeadername);
 
     for_vector(FnSymbol, fn, functions) {
-      if (!isFunctionToSkip(fn)) {
+      if (!isInternalExport(fn)) {
         fn->codegenPython(C_PXD);
       }
     }
@@ -524,7 +522,7 @@ static void makePYXFile(std::vector<FnSymbol*> functions) {
     bool first = true;
     // Make import statement at top of .pyx file for exported functions
     for_vector(FnSymbol, fn, functions) {
-      if (!isFunctionToSkip(fn)) {
+      if (!isInternalExport(fn)) {
         if (fn->hasFlag(FLAG_EXPORT)) {
           if (first) {
             first = false;
@@ -813,12 +811,8 @@ void codegen_make_python_module() {
 
 // Skip this function if it is defined in an internal module, or if it is
 // the generated main function
-static bool isFunctionToSkip(FnSymbol* fn) {
+bool isInternalExport(FnSymbol* fn) {
   return fn->getModule()->modTag == MOD_INTERNAL ||
          fn->getModule()->modTag == MOD_STANDARD ||
          fn->hasFlag(FLAG_GEN_MAIN_FUNC);
-}
-
-bool willBePythonized(FnSymbol* fn) {
-  return !isFunctionToSkip(fn) && fLibraryPython;
 }

--- a/compiler/codegen/library.cpp
+++ b/compiler/codegen/library.cpp
@@ -818,3 +818,7 @@ static bool isFunctionToSkip(FnSymbol* fn) {
          fn->getModule()->modTag == MOD_STANDARD ||
          fn->hasFlag(FLAG_GEN_MAIN_FUNC);
 }
+
+bool willBePythonized(FnSymbol* fn) {
+  return !isFunctionToSkip(fn) && fLibraryPython && fn->hasFlag(FLAG_EXPORT);
+}

--- a/compiler/codegen/mli.cpp
+++ b/compiler/codegen/mli.cpp
@@ -72,7 +72,6 @@ private:
   fileinfo fiServerBundle;
   GenInfo* info;
 
-  bool shouldEmit(ModuleSymbol* md);
   bool shouldEmit(FnSymbol* fn);
   void setOutput(fileinfo* fi);
   void setOutputAndWrite(fileinfo* fi, const std::string& gen);
@@ -177,17 +176,12 @@ MLIContext::~MLIContext() {
   return;
 }
 
-bool MLIContext::shouldEmit(ModuleSymbol* md) {
-  return (md->modTag != MOD_INTERNAL &&
-          md->modTag != MOD_STANDARD);
-}
-
 bool MLIContext::shouldEmit(FnSymbol* fn) {
-  return (fn->hasFlag(FLAG_EXPORT) && not fn->hasFlag(FLAG_GEN_MAIN_FUNC));
+  return (fn->hasFlag(FLAG_EXPORT) && not isInternalExport(fn));
 }
 
 void MLIContext::emit(ModuleSymbol* md) {
-  if (not this->shouldEmit(md)) { return; }
+  //if (not this->shouldEmit(md)) { return; }
 
   const std::vector<FnSymbol*> fns = md->getTopLevelFunctions(true);
 

--- a/compiler/codegen/mli.cpp
+++ b/compiler/codegen/mli.cpp
@@ -181,8 +181,6 @@ bool MLIContext::shouldEmit(FnSymbol* fn) {
 }
 
 void MLIContext::emit(ModuleSymbol* md) {
-  //if (not this->shouldEmit(md)) { return; }
-
   const std::vector<FnSymbol*> fns = md->getTopLevelFunctions(true);
 
   for_vector(FnSymbol, fn, fns) {

--- a/compiler/codegen/mli.cpp
+++ b/compiler/codegen/mli.cpp
@@ -177,7 +177,7 @@ MLIContext::~MLIContext() {
 }
 
 bool MLIContext::shouldEmit(FnSymbol* fn) {
-  return (fn->hasFlag(FLAG_EXPORT) && not isInternalExport(fn));
+  return (fn->hasFlag(FLAG_EXPORT) && isUserRoutine(fn));
 }
 
 void MLIContext::emit(ModuleSymbol* md) {

--- a/compiler/include/library.h
+++ b/compiler/include/library.h
@@ -65,7 +65,7 @@ void openLibraryHelperFile(fileinfo* fi,
 void closeLibraryHelperFile(fileinfo* fi, bool beautifyIt = true);
 const char* getLibraryExtension();
 
-bool isInternalExport(FnSymbol* fn);
+bool isUserRoutine(FnSymbol* fn);
 
 std::string getPythonTypeName(Type* type, PythonFileType pxd);
 

--- a/compiler/include/library.h
+++ b/compiler/include/library.h
@@ -65,7 +65,7 @@ void openLibraryHelperFile(fileinfo* fi,
 void closeLibraryHelperFile(fileinfo* fi, bool beautifyIt = true);
 const char* getLibraryExtension();
 
-bool willBePythonized(FnSymbol* fn);
+bool isInternalExport(FnSymbol* fn);
 
 std::string getPythonTypeName(Type* type, PythonFileType pxd);
 

--- a/compiler/include/library.h
+++ b/compiler/include/library.h
@@ -65,6 +65,8 @@ void openLibraryHelperFile(fileinfo* fi,
 void closeLibraryHelperFile(fileinfo* fi, bool beautifyIt = true);
 const char* getLibraryExtension();
 
+bool willBePythonized(FnSymbol* fn);
+
 std::string getPythonTypeName(Type* type, PythonFileType pxd);
 
 #endif //LIBRARY_H

--- a/compiler/resolution/fixupExports.cpp
+++ b/compiler/resolution/fixupExports.cpp
@@ -192,21 +192,30 @@ static bool validateFormalIntent(FnSymbol* fn, ArgSymbol* as) {
       // TODO: After resolution, have abstract intents been normalized?
       if (tag != INTENT_IN &&
           tag != INTENT_CONST_IN) {
-        const char* libdesc = multiloc ? "multilocale" : "python";
+        std::string libdesc;
+        if (multiloc) {
+          if (fLibraryPython) {
+            libdesc = "multilocale python";
+          } else {
+            libdesc = "multilocale";
+          }
+        } else {
+          libdesc = "python";
+        }
         const char* typeName = (t == dtExternalArray) ? "array" : t->name();
         SET_LINENO(fn);
         if (tag == INTENT_BLANK) {
           USR_FATAL_CONT(as,  "Formal \'%s\' of type \'%s\' in exported "
                          "routine \'%s\' may not be passed by const ref in "
                          "%s libraries",
-                         as->name, typeName, fn->name, libdesc);
+                         as->name, typeName, fn->name, libdesc.c_str());
 
         } else {
           USR_FATAL_CONT(as,  "Formal \'%s\' of type \'%s\' in exported "
                          "routine \'%s\' may not have the %s in "
                          "%s libraries",
                          as->name, typeName, fn->name,
-                         intentDescrString(tag), libdesc);
+                         intentDescrString(tag), libdesc.c_str());
         }
         return false;
       }

--- a/compiler/resolution/fixupExports.cpp
+++ b/compiler/resolution/fixupExports.cpp
@@ -188,7 +188,7 @@ static bool validateFormalIntent(FnSymbol* fn, ArgSymbol* as) {
 
     bool multiloc = fMultiLocaleInterop || strcmp(CHPL_COMM, "none");
 
-    if (multiloc || willBePythonized(fn)) {
+    if ((multiloc || fLibraryPython) && !isInternalExport(fn)) {
       // TODO: After resolution, have abstract intents been normalized?
       if (tag != INTENT_IN &&
           tag != INTENT_CONST_IN) {

--- a/compiler/resolution/fixupExports.cpp
+++ b/compiler/resolution/fixupExports.cpp
@@ -184,23 +184,26 @@ static bool validateFormalIntent(FnSymbol* fn, ArgSymbol* as) {
   if (t == dtString) {
     IntentTag tag = as->intent;
 
-    if (fMultiLocaleInterop || strcmp(CHPL_COMM, "none")) {
+    bool multiloc = fMultiLocaleInterop || strcmp(CHPL_COMM, "none");
+
+    if (multiloc || fLibraryPython) {
       // TODO: After resolution, have abstract intents been normalized?
       if (tag != INTENT_IN &&
           tag != INTENT_CONST_IN) {
+        const char* libdesc = multiloc ? "multilocale" : "python";
         SET_LINENO(fn);
         if (tag == INTENT_BLANK) {
           USR_FATAL_CONT(as,  "Formal \'%s\' of type \'%s\' in exported "
                          "routine \'%s\' may not be passed by const ref in "
-                         "multilocale libraries",
-                         as->name, t->name(), fn->userString);
+                         "%s libraries",
+                         as->name, t->name(), fn->userString, libdesc);
 
         } else {
           USR_FATAL_CONT(as,  "Formal \'%s\' of type \'%s\' in exported "
                          "routine \'%s\' may not have the %s in "
-                         "multilocale libraries",
+                         "%s libraries",
                          as->name, t->name(), fn->userString,
-                         intentDescrString(tag));
+                         intentDescrString(tag), libdesc);
         }
         return false;
       }

--- a/compiler/resolution/fixupExports.cpp
+++ b/compiler/resolution/fixupExports.cpp
@@ -218,7 +218,7 @@ static bool validateFormalIntent(FnSymbol* fn, ArgSymbol* as) {
         SET_LINENO(fn);
         USR_FATAL_CONT(as,  "Formal \'%s\' of type \'%s\' in exported routine "
                        "\'%s\' may not have the %s",
-                       as->name, t->name(), fn->userString,
+                       as->name, t->name(), fn->name,
                        intentDescrString(tag));
         return false;
       }

--- a/compiler/resolution/fixupExports.cpp
+++ b/compiler/resolution/fixupExports.cpp
@@ -29,6 +29,7 @@
 #include "stmt.h"
 #include "stringutil.h"
 #include "symbol.h"
+#include "wellknown.h"
 
 #include <map>
 #include <vector>
@@ -182,7 +183,7 @@ static bool validateFormalIntent(FnSymbol* fn, ArgSymbol* as) {
   // TODO: If we ever add more types to these fixup routines, we really ought
   // to put these conditions in tables.
   //
-  if (t == dtString || t == dtStringC) {
+  if (t == dtString || t == dtStringC || t == dtExternalArray) {
     IntentTag tag = as->intent;
 
     bool multiloc = fMultiLocaleInterop || strcmp(CHPL_COMM, "none");
@@ -192,18 +193,19 @@ static bool validateFormalIntent(FnSymbol* fn, ArgSymbol* as) {
       if (tag != INTENT_IN &&
           tag != INTENT_CONST_IN) {
         const char* libdesc = multiloc ? "multilocale" : "python";
+        const char* typeName = (t == dtExternalArray) ? "array" : t->name();
         SET_LINENO(fn);
         if (tag == INTENT_BLANK) {
           USR_FATAL_CONT(as,  "Formal \'%s\' of type \'%s\' in exported "
                          "routine \'%s\' may not be passed by const ref in "
                          "%s libraries",
-                         as->name, t->name(), fn->userString, libdesc);
+                         as->name, typeName, fn->name, libdesc);
 
         } else {
           USR_FATAL_CONT(as,  "Formal \'%s\' of type \'%s\' in exported "
                          "routine \'%s\' may not have the %s in "
                          "%s libraries",
-                         as->name, t->name(), fn->userString,
+                         as->name, typeName, fn->name,
                          intentDescrString(tag), libdesc);
         }
         return false;

--- a/compiler/resolution/fixupExports.cpp
+++ b/compiler/resolution/fixupExports.cpp
@@ -188,7 +188,7 @@ static bool validateFormalIntent(FnSymbol* fn, ArgSymbol* as) {
 
     bool multiloc = fMultiLocaleInterop || strcmp(CHPL_COMM, "none");
 
-    if ((multiloc || fLibraryPython) && !isInternalExport(fn)) {
+    if ((multiloc || fLibraryPython) && isUserRoutine(fn)) {
       // TODO: After resolution, have abstract intents been normalized?
       if (tag != INTENT_IN &&
           tag != INTENT_CONST_IN) {

--- a/test/interop/C/exportString/badFormalIntent.good
+++ b/test/interop/C/exportString/badFormalIntent.good
@@ -1,5 +1,5 @@
-badFormalIntent.chpl:5: error: Formal 's' of type 'string' in exported routine 'badFormalIntentIn(in s: string)' may not have the 'in' intent
-badFormalIntent.chpl:7: error: Formal 's' of type 'string' in exported routine 'badFormalIntentOut(out s: string)' may not have the 'out' intent
-badFormalIntent.chpl:9: error: Formal 's' of type 'string' in exported routine 'badFormalIntentInOut(inout s: string)' may not have the 'inout' intent
-badFormalIntent.chpl:11: error: Formal 's' of type 'string' in exported routine 'badFormalIntentRef(ref s: string)' may not have the 'ref' intent
-badFormalIntent.chpl:13: error: Formal 's' of type 'string' in exported routine 'badFormalIntentConstIn(const in s: string)' may not have the 'const in' intent
+badFormalIntent.chpl:5: error: Formal 's' of type 'string' in exported routine 'badFormalIntentIn' may not have the 'in' intent
+badFormalIntent.chpl:7: error: Formal 's' of type 'string' in exported routine 'badFormalIntentOut' may not have the 'out' intent
+badFormalIntent.chpl:9: error: Formal 's' of type 'string' in exported routine 'badFormalIntentInOut' may not have the 'inout' intent
+badFormalIntent.chpl:11: error: Formal 's' of type 'string' in exported routine 'badFormalIntentRef' may not have the 'ref' intent
+badFormalIntent.chpl:13: error: Formal 's' of type 'string' in exported routine 'badFormalIntentConstIn' may not have the 'const in' intent

--- a/test/interop/C/multilocale/arrays/exportFuncWithArrayArg.chpl
+++ b/test/interop/C/multilocale/arrays/exportFuncWithArrayArg.chpl
@@ -1,4 +1,4 @@
-export proc foo(x: [] int) {
+export proc foo(in x: [] int) {
   writeln(x); // Note: this assumes x will have initial contents
   for i in x.domain {
     x[i] = x[i] + 1;

--- a/test/interop/C/multilocale/cstringArgAndReturn.chpl
+++ b/test/interop/C/multilocale/cstringArgAndReturn.chpl
@@ -1,6 +1,6 @@
 // Chapel file that exports functions: one that takes an c_string, one that
 // returns an c_string, and one that does both.
-export proc take(x: c_string) {
+export proc take(in x: c_string) {
   writeln(x: string);
 }
 
@@ -9,6 +9,6 @@ export proc give(): c_string {
   return ret;
 }
 
-export proc takeAndReturn(x: c_string): c_string {
+export proc takeAndReturn(in x: c_string): c_string {
   return x;
 }

--- a/test/interop/C/multilocale/exportString/badFormalIntent.good
+++ b/test/interop/C/multilocale/exportString/badFormalIntent.good
@@ -1,6 +1,6 @@
-badFormalIntent.chpl:3: error: Formal 's' of type 'string' in exported routine 'badFormalIntentNone(s: string)' may not be passed by const ref in multilocale libraries
-badFormalIntent.chpl:5: error: Formal 's' of type 'string' in exported routine 'badFormalIntentConst(const s: string)' may not have the 'const' intent in multilocale libraries
-badFormalIntent.chpl:7: error: Formal 's' of type 'string' in exported routine 'badFormalIntentOut(out s: string)' may not have the 'out' intent in multilocale libraries
-badFormalIntent.chpl:9: error: Formal 's' of type 'string' in exported routine 'badFormalIntentInOut(inout s: string)' may not have the 'inout' intent in multilocale libraries
-badFormalIntent.chpl:11: error: Formal 's' of type 'string' in exported routine 'badFormalIntentRef(ref s: string)' may not have the 'ref' intent in multilocale libraries
-badFormalIntent.chpl:13: error: Formal 's' of type 'string' in exported routine 'badFormalIntentConstRef(const ref s: string)' may not have the 'const ref' intent in multilocale libraries
+badFormalIntent.chpl:3: error: Formal 's' of type 'string' in exported routine 'badFormalIntentNone' may not be passed by const ref in multilocale libraries
+badFormalIntent.chpl:5: error: Formal 's' of type 'string' in exported routine 'badFormalIntentConst' may not have the 'const' intent in multilocale libraries
+badFormalIntent.chpl:7: error: Formal 's' of type 'string' in exported routine 'badFormalIntentOut' may not have the 'out' intent in multilocale libraries
+badFormalIntent.chpl:9: error: Formal 's' of type 'string' in exported routine 'badFormalIntentInOut' may not have the 'inout' intent in multilocale libraries
+badFormalIntent.chpl:11: error: Formal 's' of type 'string' in exported routine 'badFormalIntentRef' may not have the 'ref' intent in multilocale libraries
+badFormalIntent.chpl:13: error: Formal 's' of type 'string' in exported routine 'badFormalIntentConstRef' may not have the 'const ref' intent in multilocale libraries

--- a/test/interop/C/multilocale/multipleArgs.chpl
+++ b/test/interop/C/multilocale/multipleArgs.chpl
@@ -5,7 +5,7 @@ export proc take2(x: int, y: int) {
   writeln("Was given x: ", x, ", and y: ", y);
 }
 
-export proc take2Diff(x: int, y: c_string) {
+export proc take2Diff(x: int, in y: c_string) {
   writeln("string is: " + y: string);
   writeln("int is: ", x);
 }

--- a/test/interop/python/chapelStrings/stringArgAndReturn.chpl
+++ b/test/interop/python/chapelStrings/stringArgAndReturn.chpl
@@ -2,10 +2,10 @@ export proc noArgsRetString(): string {
   return "boo!";
 }
 
-export proc stringArgsRetVoid(a: string) {
+export proc stringArgsRetVoid(in a: string) {
   writeln(a);
 }
 
-export proc stringArgsRetString(a: string, b: string): string {
+export proc stringArgsRetString(in a: string, in b: string): string {
   return a + b;
 }

--- a/test/interop/python/defaultValues.chpl
+++ b/test/interop/python/defaultValues.chpl
@@ -1,4 +1,4 @@
-export proc cstringDefault(x: c_string = "blah") {
+export proc cstringDefault(in x: c_string = "blah") {
   writeln(x: string);
 }
 

--- a/test/interop/python/errorMessages/badFormalIntent-array.chpl
+++ b/test/interop/python/errorMessages/badFormalIntent-array.chpl
@@ -1,0 +1,14 @@
+
+
+export proc badFormalIntentNone(s: [] int) {}
+
+export proc badFormalIntentConst(const s: [] int) {}
+
+export proc badFormalIntentOut(out s: [] int) {}
+
+export proc badFormalIntentInOut(inout s: [] int) {}
+
+export proc badFormalIntentRef(ref s: [] int) {}
+
+export proc badFormalIntentConstRef(const ref s: [] int) {}
+

--- a/test/interop/python/errorMessages/badFormalIntent-array.good
+++ b/test/interop/python/errorMessages/badFormalIntent-array.good
@@ -1,0 +1,6 @@
+badFormalIntent-array.chpl:3: error: Formal 's' of type 'array' in exported routine 'badFormalIntentNone' may not be passed by const ref in python libraries
+badFormalIntent-array.chpl:5: error: Formal 's' of type 'array' in exported routine 'badFormalIntentConst' may not have the 'const' intent in python libraries
+badFormalIntent-array.chpl:7: error: Formal 's' of type 'array' in exported routine 'badFormalIntentOut' may not have the 'out' intent in python libraries
+badFormalIntent-array.chpl:9: error: Formal 's' of type 'array' in exported routine 'badFormalIntentInOut' may not have the 'inout' intent in python libraries
+badFormalIntent-array.chpl:11: error: Formal 's' of type 'array' in exported routine 'badFormalIntentRef' may not have the 'ref' intent in python libraries
+badFormalIntent-array.chpl:13: error: Formal 's' of type 'array' in exported routine 'badFormalIntentConstRef' may not have the 'const ref' intent in python libraries

--- a/test/interop/python/errorMessages/badFormalIntent-array.skipif
+++ b/test/interop/python/errorMessages/badFormalIntent-array.skipif
@@ -1,0 +1,1 @@
+CHPL_COMM != none

--- a/test/interop/python/errorMessages/badFormalIntent-cstring.chpl
+++ b/test/interop/python/errorMessages/badFormalIntent-cstring.chpl
@@ -1,0 +1,14 @@
+
+
+export proc badFormalIntentNone(s: c_string) {}
+
+export proc badFormalIntentConst(const s: c_string) {}
+
+export proc badFormalIntentOut(out s: c_string) {}
+
+export proc badFormalIntentInOut(inout s: c_string) {}
+
+export proc badFormalIntentRef(ref s: c_string) {}
+
+export proc badFormalIntentConstRef(const ref s: c_string) {}
+

--- a/test/interop/python/errorMessages/badFormalIntent-cstring.comm-none.good
+++ b/test/interop/python/errorMessages/badFormalIntent-cstring.comm-none.good
@@ -1,0 +1,6 @@
+badFormalIntent-cstring.chpl:3: error: Formal 's' of type 'c_string' in exported routine 'badFormalIntentNone' may not be passed by const ref in python libraries
+badFormalIntent-cstring.chpl:5: error: Formal 's' of type 'c_string' in exported routine 'badFormalIntentConst' may not have the 'const' intent in python libraries
+badFormalIntent-cstring.chpl:7: error: Formal 's' of type 'c_string' in exported routine 'badFormalIntentOut' may not have the 'out' intent in python libraries
+badFormalIntent-cstring.chpl:9: error: Formal 's' of type 'c_string' in exported routine 'badFormalIntentInOut' may not have the 'inout' intent in python libraries
+badFormalIntent-cstring.chpl:11: error: Formal 's' of type 'c_string' in exported routine 'badFormalIntentRef' may not have the 'ref' intent in python libraries
+badFormalIntent-cstring.chpl:13: error: Formal 's' of type 'c_string' in exported routine 'badFormalIntentConstRef' may not have the 'const ref' intent in python libraries

--- a/test/interop/python/errorMessages/badFormalIntent-cstring.good
+++ b/test/interop/python/errorMessages/badFormalIntent-cstring.good
@@ -1,6 +1,6 @@
-badFormalIntent-cstring.chpl:3: error: Formal 's' of type 'c_string' in exported routine 'badFormalIntentNone' may not be passed by const ref in python libraries
-badFormalIntent-cstring.chpl:5: error: Formal 's' of type 'c_string' in exported routine 'badFormalIntentConst' may not have the 'const' intent in python libraries
-badFormalIntent-cstring.chpl:7: error: Formal 's' of type 'c_string' in exported routine 'badFormalIntentOut' may not have the 'out' intent in python libraries
-badFormalIntent-cstring.chpl:9: error: Formal 's' of type 'c_string' in exported routine 'badFormalIntentInOut' may not have the 'inout' intent in python libraries
-badFormalIntent-cstring.chpl:11: error: Formal 's' of type 'c_string' in exported routine 'badFormalIntentRef' may not have the 'ref' intent in python libraries
-badFormalIntent-cstring.chpl:13: error: Formal 's' of type 'c_string' in exported routine 'badFormalIntentConstRef' may not have the 'const ref' intent in python libraries
+badFormalIntent-cstring.chpl:3: error: Formal 's' of type 'c_string' in exported routine 'badFormalIntentNone' may not be passed by const ref in multilocale python libraries
+badFormalIntent-cstring.chpl:5: error: Formal 's' of type 'c_string' in exported routine 'badFormalIntentConst' may not have the 'const' intent in multilocale python libraries
+badFormalIntent-cstring.chpl:7: error: Formal 's' of type 'c_string' in exported routine 'badFormalIntentOut' may not have the 'out' intent in multilocale python libraries
+badFormalIntent-cstring.chpl:9: error: Formal 's' of type 'c_string' in exported routine 'badFormalIntentInOut' may not have the 'inout' intent in multilocale python libraries
+badFormalIntent-cstring.chpl:11: error: Formal 's' of type 'c_string' in exported routine 'badFormalIntentRef' may not have the 'ref' intent in multilocale python libraries
+badFormalIntent-cstring.chpl:13: error: Formal 's' of type 'c_string' in exported routine 'badFormalIntentConstRef' may not have the 'const ref' intent in multilocale python libraries

--- a/test/interop/python/errorMessages/badFormalIntent-cstring.good
+++ b/test/interop/python/errorMessages/badFormalIntent-cstring.good
@@ -1,6 +1,6 @@
-badFormalIntent-cstring.chpl:3: error: Formal 's' of type 'c_string' in exported routine 'badFormalIntentNone(s: c_string)' may not be passed by const ref in python libraries
-badFormalIntent-cstring.chpl:5: error: Formal 's' of type 'c_string' in exported routine 'badFormalIntentConst(const s: c_string)' may not have the 'const' intent in python libraries
-badFormalIntent-cstring.chpl:7: error: Formal 's' of type 'c_string' in exported routine 'badFormalIntentOut(out s: c_string)' may not have the 'out' intent in python libraries
-badFormalIntent-cstring.chpl:9: error: Formal 's' of type 'c_string' in exported routine 'badFormalIntentInOut(inout s: c_string)' may not have the 'inout' intent in python libraries
-badFormalIntent-cstring.chpl:11: error: Formal 's' of type 'c_string' in exported routine 'badFormalIntentRef(ref s: c_string)' may not have the 'ref' intent in python libraries
-badFormalIntent-cstring.chpl:13: error: Formal 's' of type 'c_string' in exported routine 'badFormalIntentConstRef(const ref s: c_string)' may not have the 'const ref' intent in python libraries
+badFormalIntent-cstring.chpl:3: error: Formal 's' of type 'c_string' in exported routine 'badFormalIntentNone' may not be passed by const ref in python libraries
+badFormalIntent-cstring.chpl:5: error: Formal 's' of type 'c_string' in exported routine 'badFormalIntentConst' may not have the 'const' intent in python libraries
+badFormalIntent-cstring.chpl:7: error: Formal 's' of type 'c_string' in exported routine 'badFormalIntentOut' may not have the 'out' intent in python libraries
+badFormalIntent-cstring.chpl:9: error: Formal 's' of type 'c_string' in exported routine 'badFormalIntentInOut' may not have the 'inout' intent in python libraries
+badFormalIntent-cstring.chpl:11: error: Formal 's' of type 'c_string' in exported routine 'badFormalIntentRef' may not have the 'ref' intent in python libraries
+badFormalIntent-cstring.chpl:13: error: Formal 's' of type 'c_string' in exported routine 'badFormalIntentConstRef' may not have the 'const ref' intent in python libraries

--- a/test/interop/python/errorMessages/badFormalIntent-cstring.good
+++ b/test/interop/python/errorMessages/badFormalIntent-cstring.good
@@ -1,0 +1,6 @@
+badFormalIntent-cstring.chpl:3: error: Formal 's' of type 'c_string' in exported routine 'badFormalIntentNone(s: c_string)' may not be passed by const ref in python libraries
+badFormalIntent-cstring.chpl:5: error: Formal 's' of type 'c_string' in exported routine 'badFormalIntentConst(const s: c_string)' may not have the 'const' intent in python libraries
+badFormalIntent-cstring.chpl:7: error: Formal 's' of type 'c_string' in exported routine 'badFormalIntentOut(out s: c_string)' may not have the 'out' intent in python libraries
+badFormalIntent-cstring.chpl:9: error: Formal 's' of type 'c_string' in exported routine 'badFormalIntentInOut(inout s: c_string)' may not have the 'inout' intent in python libraries
+badFormalIntent-cstring.chpl:11: error: Formal 's' of type 'c_string' in exported routine 'badFormalIntentRef(ref s: c_string)' may not have the 'ref' intent in python libraries
+badFormalIntent-cstring.chpl:13: error: Formal 's' of type 'c_string' in exported routine 'badFormalIntentConstRef(const ref s: c_string)' may not have the 'const ref' intent in python libraries

--- a/test/interop/python/errorMessages/badFormalIntent-cstring.skipif
+++ b/test/interop/python/errorMessages/badFormalIntent-cstring.skipif
@@ -1,0 +1,1 @@
+CHPL_COMM != none

--- a/test/interop/python/errorMessages/badFormalIntent-cstring.skipif
+++ b/test/interop/python/errorMessages/badFormalIntent-cstring.skipif
@@ -1,1 +1,0 @@
-CHPL_COMM != none

--- a/test/interop/python/errorMessages/badFormalIntent.chpl
+++ b/test/interop/python/errorMessages/badFormalIntent.chpl
@@ -1,8 +1,8 @@
 
 
+export proc badFormalIntentNone(s: string) {}
 
-
-export proc badFormalIntentIn(in s: string) {}
+export proc badFormalIntentConst(const s: string) {}
 
 export proc badFormalIntentOut(out s: string) {}
 
@@ -10,5 +10,5 @@ export proc badFormalIntentInOut(inout s: string) {}
 
 export proc badFormalIntentRef(ref s: string) {}
 
-export proc badFormalIntentConstIn(const in s: string) {}
+export proc badFormalIntentConstRef(const ref s: string) {}
 

--- a/test/interop/python/errorMessages/badFormalIntent.comm-none.good
+++ b/test/interop/python/errorMessages/badFormalIntent.comm-none.good
@@ -1,0 +1,6 @@
+badFormalIntent.chpl:3: error: Formal 's' of type 'string' in exported routine 'badFormalIntentNone' may not be passed by const ref in python libraries
+badFormalIntent.chpl:5: error: Formal 's' of type 'string' in exported routine 'badFormalIntentConst' may not have the 'const' intent in python libraries
+badFormalIntent.chpl:7: error: Formal 's' of type 'string' in exported routine 'badFormalIntentOut' may not have the 'out' intent in python libraries
+badFormalIntent.chpl:9: error: Formal 's' of type 'string' in exported routine 'badFormalIntentInOut' may not have the 'inout' intent in python libraries
+badFormalIntent.chpl:11: error: Formal 's' of type 'string' in exported routine 'badFormalIntentRef' may not have the 'ref' intent in python libraries
+badFormalIntent.chpl:13: error: Formal 's' of type 'string' in exported routine 'badFormalIntentConstRef' may not have the 'const ref' intent in python libraries

--- a/test/interop/python/errorMessages/badFormalIntent.good
+++ b/test/interop/python/errorMessages/badFormalIntent.good
@@ -1,5 +1,6 @@
-badFormalIntent.chpl:5: error: Formal 's' of type 'string' in exported routine 'badFormalIntentIn(in s: string)' may not have the 'in' intent
-badFormalIntent.chpl:7: error: Formal 's' of type 'string' in exported routine 'badFormalIntentOut(out s: string)' may not have the 'out' intent
-badFormalIntent.chpl:9: error: Formal 's' of type 'string' in exported routine 'badFormalIntentInOut(inout s: string)' may not have the 'inout' intent
-badFormalIntent.chpl:11: error: Formal 's' of type 'string' in exported routine 'badFormalIntentRef(ref s: string)' may not have the 'ref' intent
-badFormalIntent.chpl:13: error: Formal 's' of type 'string' in exported routine 'badFormalIntentConstIn(const in s: string)' may not have the 'const in' intent
+badFormalIntent.chpl:3: error: Formal 's' of type 'string' in exported routine 'badFormalIntentNone(s: string)' may not be passed by const ref in python libraries
+badFormalIntent.chpl:5: error: Formal 's' of type 'string' in exported routine 'badFormalIntentConst(const s: string)' may not have the 'const' intent in python libraries
+badFormalIntent.chpl:7: error: Formal 's' of type 'string' in exported routine 'badFormalIntentOut(out s: string)' may not have the 'out' intent in python libraries
+badFormalIntent.chpl:9: error: Formal 's' of type 'string' in exported routine 'badFormalIntentInOut(inout s: string)' may not have the 'inout' intent in python libraries
+badFormalIntent.chpl:11: error: Formal 's' of type 'string' in exported routine 'badFormalIntentRef(ref s: string)' may not have the 'ref' intent in python libraries
+badFormalIntent.chpl:13: error: Formal 's' of type 'string' in exported routine 'badFormalIntentConstRef(const ref s: string)' may not have the 'const ref' intent in python libraries

--- a/test/interop/python/errorMessages/badFormalIntent.good
+++ b/test/interop/python/errorMessages/badFormalIntent.good
@@ -1,6 +1,6 @@
-badFormalIntent.chpl:3: error: Formal 's' of type 'string' in exported routine 'badFormalIntentNone' may not be passed by const ref in python libraries
-badFormalIntent.chpl:5: error: Formal 's' of type 'string' in exported routine 'badFormalIntentConst' may not have the 'const' intent in python libraries
-badFormalIntent.chpl:7: error: Formal 's' of type 'string' in exported routine 'badFormalIntentOut' may not have the 'out' intent in python libraries
-badFormalIntent.chpl:9: error: Formal 's' of type 'string' in exported routine 'badFormalIntentInOut' may not have the 'inout' intent in python libraries
-badFormalIntent.chpl:11: error: Formal 's' of type 'string' in exported routine 'badFormalIntentRef' may not have the 'ref' intent in python libraries
-badFormalIntent.chpl:13: error: Formal 's' of type 'string' in exported routine 'badFormalIntentConstRef' may not have the 'const ref' intent in python libraries
+badFormalIntent.chpl:3: error: Formal 's' of type 'string' in exported routine 'badFormalIntentNone' may not be passed by const ref in multilocale python libraries
+badFormalIntent.chpl:5: error: Formal 's' of type 'string' in exported routine 'badFormalIntentConst' may not have the 'const' intent in multilocale python libraries
+badFormalIntent.chpl:7: error: Formal 's' of type 'string' in exported routine 'badFormalIntentOut' may not have the 'out' intent in multilocale python libraries
+badFormalIntent.chpl:9: error: Formal 's' of type 'string' in exported routine 'badFormalIntentInOut' may not have the 'inout' intent in multilocale python libraries
+badFormalIntent.chpl:11: error: Formal 's' of type 'string' in exported routine 'badFormalIntentRef' may not have the 'ref' intent in multilocale python libraries
+badFormalIntent.chpl:13: error: Formal 's' of type 'string' in exported routine 'badFormalIntentConstRef' may not have the 'const ref' intent in multilocale python libraries

--- a/test/interop/python/errorMessages/badFormalIntent.good
+++ b/test/interop/python/errorMessages/badFormalIntent.good
@@ -1,6 +1,6 @@
-badFormalIntent.chpl:3: error: Formal 's' of type 'string' in exported routine 'badFormalIntentNone(s: string)' may not be passed by const ref in python libraries
-badFormalIntent.chpl:5: error: Formal 's' of type 'string' in exported routine 'badFormalIntentConst(const s: string)' may not have the 'const' intent in python libraries
-badFormalIntent.chpl:7: error: Formal 's' of type 'string' in exported routine 'badFormalIntentOut(out s: string)' may not have the 'out' intent in python libraries
-badFormalIntent.chpl:9: error: Formal 's' of type 'string' in exported routine 'badFormalIntentInOut(inout s: string)' may not have the 'inout' intent in python libraries
-badFormalIntent.chpl:11: error: Formal 's' of type 'string' in exported routine 'badFormalIntentRef(ref s: string)' may not have the 'ref' intent in python libraries
-badFormalIntent.chpl:13: error: Formal 's' of type 'string' in exported routine 'badFormalIntentConstRef(const ref s: string)' may not have the 'const ref' intent in python libraries
+badFormalIntent.chpl:3: error: Formal 's' of type 'string' in exported routine 'badFormalIntentNone' may not be passed by const ref in python libraries
+badFormalIntent.chpl:5: error: Formal 's' of type 'string' in exported routine 'badFormalIntentConst' may not have the 'const' intent in python libraries
+badFormalIntent.chpl:7: error: Formal 's' of type 'string' in exported routine 'badFormalIntentOut' may not have the 'out' intent in python libraries
+badFormalIntent.chpl:9: error: Formal 's' of type 'string' in exported routine 'badFormalIntentInOut' may not have the 'inout' intent in python libraries
+badFormalIntent.chpl:11: error: Formal 's' of type 'string' in exported routine 'badFormalIntentRef' may not have the 'ref' intent in python libraries
+badFormalIntent.chpl:13: error: Formal 's' of type 'string' in exported routine 'badFormalIntentConstRef' may not have the 'const ref' intent in python libraries

--- a/test/interop/python/errorMessages/badFormalIntent.skipif
+++ b/test/interop/python/errorMessages/badFormalIntent.skipif
@@ -1,1 +1,0 @@
-CHPL_COMM != none

--- a/test/interop/python/intArrays.chpl
+++ b/test/interop/python/intArrays.chpl
@@ -1,4 +1,4 @@
-export proc takesArray(x: [] int) {
+export proc takesArray(in x: [] int) {
   writeln(x); // Note: this assumes x will have initial contents
 }
 

--- a/test/interop/python/multilocale/defaultValues.chpl
+++ b/test/interop/python/multilocale/defaultValues.chpl
@@ -1,4 +1,4 @@
-export proc cstringDefault(x: c_string = "blah") {
+export proc cstringDefault(in x: c_string = "blah") {
   writeln(x: string);
 }
 

--- a/test/interop/python/multilocale/stringFunctions.chpl
+++ b/test/interop/python/multilocale/stringFunctions.chpl
@@ -1,5 +1,5 @@
 /* Tests accepting a c_string */
-export proc takesString(x: c_string) {
+export proc takesString(in x: c_string) {
   writeln(x: string);
 }
 
@@ -10,6 +10,6 @@ export proc getString(): c_string {
 }
 
 /* Tests taking and returning a c_string */
-export proc takeAndReturn(x: c_string): c_string {
+export proc takeAndReturn(in x: c_string): c_string {
   return x;
 }

--- a/test/interop/python/realArrays.chpl
+++ b/test/interop/python/realArrays.chpl
@@ -1,4 +1,4 @@
-export proc takesArray(x: [] real) {
+export proc takesArray(in x: [] real) {
   for i in x.domain {
     // Note: this assumes x will have initial contents
     if ((x[i] <= i+2) && (x[i] > i)) {

--- a/test/interop/python/stringAllocated.chpl
+++ b/test/interop/python/stringAllocated.chpl
@@ -8,6 +8,6 @@ export proc g(size: int, ptr: c_ptr(uint(8))): int {
   }
 }
 
-export proc writeStr(x: c_string) {
+export proc writeStr(in x: c_string) {
   writeln(x: string);
 }

--- a/test/interop/python/stringFunctions.chpl
+++ b/test/interop/python/stringFunctions.chpl
@@ -1,5 +1,5 @@
 /* Tests accepting a c_string */
-export proc takesString(x: c_string) {
+export proc takesString(in x: c_string) {
   writeln(x: string);
 }
 
@@ -10,6 +10,6 @@ export proc getString(): c_string {
 }
 
 /* Tests taking and returning a c_string */
-export proc takeAndReturn(x: c_string): c_string {
+export proc takeAndReturn(in x: c_string): c_string {
   return x;
 }


### PR DESCRIPTION
This is a follow up to #13905 based on things we realized after the fact.

We always copy string arguments for Python interoperability.  We also always
copy c_strings and 1 dimensional arrays in Python.  As a result, we should limit
the intents used to reflect the current behavior more accurately.

This change mildly modifies the expected error message, due to realizing that
we would not get information about the function if the function happened to
also contain an array argument.

It also unifies the check for internal and standard module exported functions
to use the same helper routine in all places where that check matters, instead
of implementing it separately.

Testing:
- [x] single locale test/interop/C and test/interop/python with futures on darwin
- [x] full paratest with futures on linux
- [x] test/interop/python with futures on linux
- [x] gasnet test/interop/C/multilocale and test/interop/python/multilocale with futures on darwin
- [x] full gasnet paratest with futures on linux
- [x] test/interop/python/multilocale with futures on linux