### PR TITLE
Postfix! on anymanaged and minor changes

### DIFF
--- a/compiler/AST/DecoratedClassType.cpp
+++ b/compiler/AST/DecoratedClassType.cpp
@@ -25,6 +25,13 @@
 #include "expr.h"
 #include "iterator.h"
 
+static const char* nameForUser(const char* className) {
+  if (!strcmp(className, "_owned") || !strcmp(className, "_shared"))
+    return className+1;
+
+  return className;
+}
+
 const char* decoratedTypeAstr(ClassTypeDecorator d, const char* className) {
   switch (d) {
     case CLASS_TYPE_BORROWED:
@@ -51,14 +58,17 @@ const char* decoratedTypeAstr(ClassTypeDecorator d, const char* className) {
       if (developer)
         return astr("managed anynil ", className);
       else
-        return astr(className);
+        return astr(nameForUser(className));
     case CLASS_TYPE_MANAGED_NONNIL:
-      return astr(className);
+      if (developer)
+        return astr("managed ", className);
+      else
+        return astr(nameForUser(className));
     case CLASS_TYPE_MANAGED_NILABLE:
       if (developer)
         return astr("managed ", className, "?");
       else
-        return astr(className, "?");
+        return astr(nameForUser(className), "?");
 
     case CLASS_TYPE_GENERIC:
       if (developer)
@@ -66,7 +76,10 @@ const char* decoratedTypeAstr(ClassTypeDecorator d, const char* className) {
       else
         return astr(className);
     case CLASS_TYPE_GENERIC_NONNIL:
-      return astr(className);
+      if (developer)
+        return astr("anymanaged ", className);
+      else
+        return astr(className);
     case CLASS_TYPE_GENERIC_NILABLE:
       if (developer)
         return astr("anymanaged ", className, "?");

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -3169,7 +3169,6 @@ static FnSymbol* resolveNormalCall(CallInfo& info, bool checkOnly) {
     }
   }
 
-
   if (! overloadSetsOK(info.call, checkOnly, candidates,
                        bestRef, bestCref, bestVal)) {
     return NULL; // overloadSetsOK() found an error

--- a/modules/dists/SparseBlockDist.chpl
+++ b/modules/dists/SparseBlockDist.chpl
@@ -340,7 +340,7 @@ class LocSparseBlockDom {
   param stridable: bool;
   type sparseLayoutType;
   var parentDom: domain(rank, idxType, stridable);
-  var sparseDist = if _to_borrowed(sparseLayoutType) == borrowed DefaultDist then defaultDist
+  var sparseDist = if isSubtype(_to_nonnil(sparseLayoutType), DefaultDist) then defaultDist
                    else new dmap(new sparseLayoutType()); //unresolved call workaround
   var mySparseBlock: sparse subdomain(parentDom) dmapped sparseDist;
 

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -660,11 +660,11 @@ module ChapelBase {
     }
   }
 
-  inline proc postfix!(type t:unmanaged) type {
+  inline proc postfix!(type t: class) type {
     return _to_borrowed(_to_nonnil(t));
   }
-  inline proc postfix!(type t:borrowed) type {
-    return _to_nonnil(t);
+  inline proc postfix!(type t: class?) type {
+    return _to_borrowed(_to_nonnil(t));
   }
 
   inline proc postfix!(x:unmanaged class) {

--- a/modules/internal/OwnedObject.chpl
+++ b/modules/internal/OwnedObject.chpl
@@ -580,7 +580,4 @@ module OwnedObject {
     }
     return _to_nonnil(x.chpl_p);
   }
-  inline proc postfix!(type t:_owned) type {
-    return _to_borrowed(_to_nonnil(t.chpl_t));
-  }
 }

--- a/modules/internal/SharedObject.chpl
+++ b/modules/internal/SharedObject.chpl
@@ -566,7 +566,4 @@ module SharedObject {
     }
     return _to_nonnil(x.chpl_p);
   }
-  inline proc postfix!(type t:_shared) type {
-    return _to_borrowed(_to_nonnil(t.chpl_t));
-  }
 }


### PR DESCRIPTION
Implement `C!` where C is an any-managed class type, either nilable
or non-nilable. In doing so, I removed postfix! implementations
for specific management strategies, as no longer needed.
Now we have two postfix! implementations, one for nilable, the other
for non-nilable, both are generic w.r.t. management strategy.
Future work: have a single implementation that is also generic
w.r.t. nilability.

While there:

* Implement Michael's suggestion of replacing type equality from #13928
with `isSubtype`. The new version is hardly more elegant, yet more principled.
I verified no memory leaks on the tests that leaked before 13928.

* Make `decoratedTypeAstr()` produce nicer results, both for the developer,
by including `managed` and `anymanaged` consistently, and for the user,
by printing, ex., `owned?` instead of `_owned?`.

Testing: linux64 -futures, gasnet multilocale tests.