### PR TITLE
Stop doing verbose memtracking in some tests

### DIFF
--- a/test/types/bytes/factory/basic.chpl
+++ b/test/types/bytes/factory/basic.chpl
@@ -1,21 +1,17 @@
-use Memory;
-
 const targetLocale = Locales[numLocales-1];
 
 var myBytes = b"A Chapel bytes";
-startVerboseMem();
 on targetLocale {
   // there should be 2 allocations, 2 frees
-  writelnNoMem("Initialize from bytes");
+  writeln("Initialize from bytes");
   var sNew = createBytesWithNewBuffer(myBytes);
   var sBorrowed = createBytesWithBorrowedBuffer(sNew);
   var sNewFromNew = createBytesWithNewBuffer(sNew);
 
-  writelnNoMem(sNew);
-  writelnNoMem(sBorrowed);
-  writelnNoMem(sNewFromNew);
+  writeln(sNew);
+  writeln(sBorrowed);
+  writeln(sNewFromNew);
 }
-stopVerboseMem();
 
 writeln();
 
@@ -25,20 +21,18 @@ cPtrTmp[1] = 66:uint(8);
 cPtrTmp[2] = 67:uint(8);
 cPtrTmp[3] = 0:uint(8);
 var cStr = cPtrTmp:c_string;
-startVerboseMem();
 {
   // there should be 1 allocation 1 free
-  writelnNoMem("Initialize from c_string");
+  writeln("Initialize from c_string");
   var sNew = createBytesWithNewBuffer(cStr);
   var sBorrowed = createBytesWithBorrowedBuffer(cStr);
   var sOwned = createBytesWithOwnedBuffer(cStr);
   /*var sOwned = new string(cStr, isowned=true, needToCopy=false);*/
 
-  writelnNoMem(sNew);
-  writelnNoMem(sBorrowed);
-  writelnNoMem(sOwned);
+  writeln(sNew);
+  writeln(sBorrowed);
+  writeln(sOwned);
 }
-stopVerboseMem();
 
 writeln();
 
@@ -47,36 +41,24 @@ cPtr[0] = 65:uint(8);
 cPtr[1] = 66:uint(8);
 cPtr[2] = 67:uint(8);
 cPtr[3] = 0:uint(8);
-startVerboseMem();
 {
   // there should be 1 allocate, 2 frees
-  writelnNoMem("Initialize from c_ptr");
+  writeln("Initialize from c_ptr");
 
   var sNew = createBytesWithNewBuffer(cPtr, length=3, size=4);
   var sBorrowed = createBytesWithBorrowedBuffer(cPtr, length=3, size=4);
   var sOwned = createBytesWithOwnedBuffer(cPtr, length=3, size=4);
 
-  writelnNoMem(sNew);
-  writelnNoMem(sBorrowed);
-  writelnNoMem(sOwned);
+  writeln(sNew);
+  writeln(sBorrowed);
+  writeln(sOwned);
 
   cPtr[1] = 32:uint(8);
 
-  writelnNoMem(sNew);
-  writelnNoMem(sBorrowed);
-  writelnNoMem(sOwned);
+  writeln(sNew);
+  writeln(sBorrowed);
+  writeln(sOwned);
 }
-stopVerboseMem();
 
 writeln();
 
-proc writelnNoMem() {
-  stopVerboseMem();
-  writeln();
-  startVerboseMem();
-}
-proc writelnNoMem(args ...) {
-  stopVerboseMem();
-  writeln((...args));
-  startVerboseMem();
-}

--- a/test/types/bytes/factory/basic.good
+++ b/test/types/bytes/factory/basic.good
@@ -1,28 +1,18 @@
 Initialize from bytes
-***ALLOCATE***
-***ALLOCATE***
 A Chapel bytes
 A Chapel bytes
 A Chapel bytes
-***FREE***
-***FREE***
 
 Initialize from c_string
-***ALLOCATE***
 ABC
 ABC
 ABC
-***FREE***
-***FREE***
 
 Initialize from c_ptr
-***ALLOCATE***
 ABC
 ABC
 ABC
 ABC
 A C
 A C
-***FREE***
-***FREE***
 

--- a/test/types/bytes/factory/basic.prediff
+++ b/test/types/bytes/factory/basic.prediff
@@ -1,7 +1,0 @@
-#!/bin/sh
-sed -e "s/.*allocate.*string copy.*/***ALLOCATE***/" \
-    -e "s/.*free.*/***FREE***/"\
-    -e "/.*allocate.*/d"\
-    $1.exec.out.tmp > $1.prediff.tmp
-mv $1.prediff.tmp $1.exec.out.tmp
-

--- a/test/types/string/factory/basic.chpl
+++ b/test/types/string/factory/basic.chpl
@@ -1,21 +1,17 @@
-use Memory;
-
 const targetLocale = Locales[numLocales-1];
 
 var chplStr = "A Chapel string";
-startVerboseMem();
 on targetLocale {
   // there should be 2 allocations, 2 frees
-  writelnNoMem("Initialize from string");
+  writeln("Initialize from string");
   var sNew = createStringWithNewBuffer(chplStr);
   var sBorrowed = createStringWithBorrowedBuffer(sNew);
   var sNewFromNew = createStringWithNewBuffer(sNew);
 
-  writelnNoMem(sNew);
-  writelnNoMem(sBorrowed);
-  writelnNoMem(sNewFromNew);
+  writeln(sNew);
+  writeln(sBorrowed);
+  writeln(sNewFromNew);
 }
-stopVerboseMem();
 
 writeln();
 
@@ -25,20 +21,18 @@ cPtrTmp[1] = 66:uint(8);
 cPtrTmp[2] = 67:uint(8);
 cPtrTmp[3] = 0:uint(8);
 var cStr = cPtrTmp:c_string;
-startVerboseMem();
 {
   // there should be 1 allocation 1 free
-  writelnNoMem("Initialize from c_string");
+  writeln("Initialize from c_string");
   var sNew = createStringWithNewBuffer(cStr);
   var sBorrowed = createStringWithBorrowedBuffer(cStr);
   var sOwned = createStringWithOwnedBuffer(cStr);
   /*var sOwned = new string(cStr, isowned=true, needToCopy=false);*/
 
-  writelnNoMem(sNew);
-  writelnNoMem(sBorrowed);
-  writelnNoMem(sOwned);
+  writeln(sNew);
+  writeln(sBorrowed);
+  writeln(sOwned);
 }
-stopVerboseMem();
 
 writeln();
 
@@ -47,36 +41,24 @@ cPtr[0] = 65:uint(8);
 cPtr[1] = 66:uint(8);
 cPtr[2] = 67:uint(8);
 cPtr[3] = 0:uint(8);
-startVerboseMem();
 {
   // there should be 1 allocate, 2 frees
-  writelnNoMem("Initialize from c_ptr");
+  writeln("Initialize from c_ptr");
 
   var sNew = createStringWithNewBuffer(cPtr, length=3, size=4);
   var sBorrowed = createStringWithBorrowedBuffer(cPtr, length=3, size=4);
   var sOwned = createStringWithOwnedBuffer(cPtr, length=3, size=4);
 
-  writelnNoMem(sNew);
-  writelnNoMem(sBorrowed);
-  writelnNoMem(sOwned);
+  writeln(sNew);
+  writeln(sBorrowed);
+  writeln(sOwned);
 
   cPtr[1] = 32:uint(8);
 
-  writelnNoMem(sNew);
-  writelnNoMem(sBorrowed);
-  writelnNoMem(sOwned);
+  writeln(sNew);
+  writeln(sBorrowed);
+  writeln(sOwned);
 }
-stopVerboseMem();
 
 writeln();
 
-proc writelnNoMem() {
-  stopVerboseMem();
-  writeln();
-  startVerboseMem();
-}
-proc writelnNoMem(args ...) {
-  stopVerboseMem();
-  writeln((...args));
-  startVerboseMem();
-}

--- a/test/types/string/factory/basic.good
+++ b/test/types/string/factory/basic.good
@@ -1,28 +1,18 @@
 Initialize from string
-***ALLOCATE***
-***ALLOCATE***
 A Chapel string
 A Chapel string
 A Chapel string
-***FREE***
-***FREE***
 
 Initialize from c_string
-***ALLOCATE***
 ABC
 ABC
 ABC
-***FREE***
-***FREE***
 
 Initialize from c_ptr
-***ALLOCATE***
 ABC
 ABC
 ABC
 ABC
 A C
 A C
-***FREE***
-***FREE***
 

--- a/test/types/string/factory/basic.prediff
+++ b/test/types/string/factory/basic.prediff
@@ -1,7 +1,0 @@
-#!/bin/sh
-sed -e "s/.*allocate.*string copy.*/***ALLOCATE***/" \
-    -e "s/.*free.*/***FREE***/"\
-    -e "/.*allocate.*/d"\
-    $1.exec.out.tmp > $1.prediff.tmp
-mv $1.prediff.tmp $1.exec.out.tmp
-


### PR DESCRIPTION
This PR removes verbose memtracking in string/bytes factory tests.

These tests already test the functionality without the memtracking, and if the factory functions cause any extra alloc etc, we'd see it via other tests. So, I don't think it is crucial we have these memtracking outputs here.

Tests pass with standard and gasnet configs
