### PR TITLE
Copy mason skipif to UnitTest launcher tests

### DIFF
--- a/test/library/packages/UnitTest/Launcher_Test.skipif
+++ b/test/library/packages/UnitTest/Launcher_Test.skipif
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+
+"""
+mason requires CHPL_COMM=none (local)
+"""
+
+from __future__ import print_function
+from os import environ
+
+print(environ['CHPL_COMM'] != 'none' or environ['CHPL_REGEXP'] != 're2')


### PR DESCRIPTION
Now that UnitTest launcher tests require mason, they will require RE2 as well. This copies over the mason skipif to `UnitTest.skipif`.