### PR TITLE
Add --bounds-checks to tests that currently fail when `--fast`

### DIFF
--- a/test/library/standard/List/first/COMPOPTS
+++ b/test/library/standard/List/first/COMPOPTS
@@ -1,0 +1,1 @@
+--bounds-checks

--- a/test/library/standard/List/indexOf/COMPOPTS
+++ b/test/library/standard/List/indexOf/COMPOPTS
@@ -1,0 +1,1 @@
+--bounds-checks

--- a/test/library/standard/List/last/COMPOPTS
+++ b/test/library/standard/List/last/COMPOPTS
@@ -1,0 +1,1 @@
+--bounds-checks

--- a/test/library/standard/List/pop/COMPOPTS
+++ b/test/library/standard/List/pop/COMPOPTS
@@ -1,0 +1,1 @@
+--bounds-checks

--- a/test/library/standard/List/this/COMPOPTS
+++ b/test/library/standard/List/this/COMPOPTS
@@ -1,0 +1,1 @@
+--bounds-checks


### PR DESCRIPTION
This PR is a quick fix to make some list tests perform bounds checks even when `--fast` is used. It fixes test failures in `.fast` configurations.

Trivial and not reviewed.