### PR TITLE
Fix valgrind errors related to generic classes

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -1283,7 +1283,7 @@ AggregateType* AggregateType::instantiationWithParent(AggregateType* parent, Exp
     retval->dispatchParents.add(parent);
     parent->dispatchChildren.add_exclusive(retval);
 
-    if (retval->setFirstGenericField() == false) {
+    if (retval->genericFields.size() == 0) {
       retval->symbol->removeFlag(FLAG_GENERIC);
     }
 
@@ -1750,7 +1750,7 @@ AggregateType::getInstantiationParent(AggregateType* parentType) {
 
   newInstance->renameInstantiation();
 
-  if (newInstance->setFirstGenericField() == false) {
+  if (newInstance->genericFields.size() == 0) {
     newInstance->symbol->removeFlag(FLAG_GENERIC);
   }
 

--- a/compiler/resolution/cleanups.cpp
+++ b/compiler/resolution/cleanups.cpp
@@ -561,8 +561,9 @@ static void removeTypedefParts() {
       if (TypeSymbol* ts = toTypeSymbol(def->sym)) {
         if (DecoratedClassType* dt = toDecoratedClassType(ts->type)) {
           ClassTypeDecorator d = dt->getDecorator();
-          if (isDecoratorUnknownNilability(d) ||
-              isDecoratorUnknownManagement(d)) {
+          if ((isDecoratorUnknownNilability(d) ||
+              isDecoratorUnknownManagement(d)) &&
+              dt->getCanonicalClass()->inTree()) {
             // After resolution, can't consider it generic anymore...
             // The generic-ness will be moot though because later
             // it will all be replaced with the AggregateType.


### PR DESCRIPTION
This PR resolves two valgrind errors introduced by #13904 :

1) Some parent classes incorrectly had/lacked FLAG_GENERIC. This is resolved by looking at the number of remaining generic fields instead of the old ``setFirstGenericField`` method, which cannot handle out-of-order instantiation.

2) Adds a check to the removal of DecoratedClassType instances to ensure that their underlying AggregateType instances are removed.

Testing:
- [x] local + futures
- [x] gasnet + futures