### PR TITLE
Use buffered index addition in CSR transpose

### DIFF
--- a/modules/packages/LinearAlgebra.chpl
+++ b/modules/packages/LinearAlgebra.chpl
@@ -2179,17 +2179,12 @@ module Sparse {
 
   /* Transpose CSR domain */
   proc transpose(D: domain) where isCSDom(D) {
-    use List;
-    var indices: list(2*D.idxType);
-    for i in D.dim(1) {
-      for j in D.dimIter(2, i) {
-        indices.append((j, i));
-      }
-    }
-
     const parentDT = transpose(D.parentDom);
     var Dom: sparse subdomain(parentDT) dmapped CS(sortedIndices=false);
-    Dom += indices.toArray();
+
+    var idxBuffer = Dom.makeIndexBuffer(size=D.numIndices);
+    for (i,j) in D do idxBuffer.add((j,i));
+    idxBuffer.commit();
     return Dom;
   }
 


### PR DESCRIPTION
This PR changes CSR transpose to use the relatively new buffered index addition in
sparse domains. 

This way:
- The implementation is much simpler
- It takes much less memory.
- It delivers some performance improvements
  I only tested on my MBP and the data sizes that I can run were already pretty fast and 
most of the time was spent on the actual bulk addition either way. It **looked** like it 
was faster, but the difference could easily be the background noise.

Testing:
- [x] `LinearAlgebra/correctness` passes with standard and gasnet configs locally
- [x] A just-in-case standard
