### PR TITLE
Inline small wrappers in string and bytes implementations

### DIFF
--- a/modules/internal/ByteBufferHelpers.chpl
+++ b/modules/internal/ByteBufferHelpers.chpl
@@ -56,7 +56,7 @@ module ByteBufferHelpers {
     __primitive("chpl_comm_get", dest, src_loc_id, src_addr, len.safeCast(size_t));
   }
 
-  proc bufferAlloc(requestedSize) {
+  inline proc bufferAlloc(requestedSize) {
     const allocSize = max(chpl_here_good_alloc_size(requestedSize),
                           chpl_stringMinAllocSize);
     var buf = chpl_here_alloc(allocSize,
@@ -86,7 +86,7 @@ module ByteBufferHelpers {
       return dest;
   }
 
-  proc bufferCopyLocal(src_addr: bufferType, len: int) {
+  inline proc bufferCopyLocal(src_addr: bufferType, len: int) {
       const (dst, allocSize) = bufferAlloc(len+1);
       bufferMemcpyLocal(dst=dst, src=src_addr, len=len);
       return (dst, allocSize);
@@ -96,7 +96,7 @@ module ByteBufferHelpers {
     chpl_here_free(buf);
   }
 
-  proc bufferCopy(buf: bufferType, off: int, len: int, loc: locIdType) {
+  inline proc bufferCopy(buf: bufferType, off: int, len: int, loc: locIdType) {
     if !_local && loc != chpl_nodeID {
       var newBuf = bufferCopyRemote(loc, buf+off, len);
       return (newBuf, len);
@@ -117,7 +117,7 @@ module ByteBufferHelpers {
 
   }
 
-  proc bufferMemcpyLocal(dst, src, len, dst_off=0, src_off=0) {
+  inline proc bufferMemcpyLocal(dst, src, len, dst_off=0, src_off=0) {
     c_memcpy(dst:bufferType+dst_off, src:bufferType+src_off, len);
   }
 

--- a/modules/internal/ByteBufferHelpers.chpl
+++ b/modules/internal/ByteBufferHelpers.chpl
@@ -92,7 +92,7 @@ module ByteBufferHelpers {
       return (dst, allocSize);
   }
 
-  proc bufferFree(buf) {
+  inline proc bufferFree(buf) {
     chpl_here_free(buf);
   }
 
@@ -107,25 +107,24 @@ module ByteBufferHelpers {
   }
 
   //dst must be local
-  proc bufferMemcpy(dst, src_loc, src, len, dst_off=0, src_off=0) {
+  inline proc bufferMemcpy(dst, src_loc, src, len, dst_off=0, src_off=0) {
     if !_local && src_loc != chpl_nodeID {
       chpl_string_comm_get(dst+dst_off, src_loc, src+src_off, len);
     }
     else {
       c_memcpy(dst+dst_off, src+src_off, len);
     }
-
   }
 
   inline proc bufferMemcpyLocal(dst, src, len, dst_off=0, src_off=0) {
     c_memcpy(dst:bufferType+dst_off, src:bufferType+src_off, len);
   }
 
-  proc bufferMemmoveLocal(dst, src, len, dst_off=0, src_off=0) {
+  inline proc bufferMemmoveLocal(dst, src, len, dst_off=0, src_off=0) {
     c_memmove(dst+dst_off, src+src_off, len);
   }
 
-  proc bufferGetByte(buf, off, loc) {
+  inline proc bufferGetByte(buf, off, loc) {
     if !_local && loc != chpl_nodeID {
       const newBuf = bufferCopyRemote(src_loc_id=loc, src_addr=buf+off, len=1);
       return newBuf[0];
@@ -135,12 +134,12 @@ module ByteBufferHelpers {
     }
   }
 
-  proc bufferEquals(buf1, off1, loc1, buf2, off2, loc2, len) {
+  inline proc bufferEquals(buf1, off1, loc1, buf2, off2, loc2, len) {
     return _strcmp(buf1=buf1+off1,len1=len,loc1=loc1,
                    buf2=buf2+off2,len2=len,loc2=loc1) == 0;
   }
 
-  proc bufferEqualsLocal(buf1, off1, buf2, off2, len) {
+  inline proc bufferEqualsLocal(buf1, off1, buf2, off2, len) {
     return _strcmp_local(buf1=buf1+off1,len1=len,
                          buf2=buf2+off2,len2=len) == 0;
   }

--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -351,7 +351,7 @@ module Bytes {
       :returns: a new bytes that is a slice within ``1..bytes.length``. If
                 the length of `r` is zero, an empty bytes is returned.
      */
-    proc this(r: range(?)) : bytes {
+    inline proc this(r: range(?)) : bytes {
       return getSlice(this, r);
     }
 
@@ -394,7 +394,7 @@ module Bytes {
       :returns: * `true`  -- when the object begins with one or more of the `needles`
                 * `false` -- otherwise
      */
-    proc startsWith(needles: bytes ...) : bool {
+    inline proc startsWith(needles: bytes ...) : bool {
       return startsEndsWith(this, needles, fromLeft=true);
     }
 
@@ -404,7 +404,7 @@ module Bytes {
       :returns: * `true`  -- when the object ends with one or more of the `needles`
                 * `false` -- otherwise
      */
-    proc endsWith(needles: bytes ...) : bool {
+    inline proc endsWith(needles: bytes ...) : bool {
       return startsEndsWith(this, needles, fromLeft=false);
     }
 
@@ -417,7 +417,7 @@ module Bytes {
       :returns: the index of the first occurrence of `needle` within a
                 the object, or 0 if the `needle` is not in the object.
      */
-    proc find(needle: bytes, region: range(?) = 1:idxType..) : idxType {
+    inline proc find(needle: bytes, region: range(?) = 1:idxType..) : idxType {
       return _search_helper(needle, region, count=false): idxType;
     }
 
@@ -430,7 +430,7 @@ module Bytes {
       :returns: the index of the first occurrence from the right of `needle`
                 within the object, or 0 if the `needle` is not in the object.
      */
-    proc rfind(needle: bytes, region: range(?) = 1:idxType..) : idxType {
+    inline proc rfind(needle: bytes, region: range(?) = 1:idxType..) : idxType {
       return _search_helper(needle, region, count=false,
                             fromLeft=false): idxType;
     }
@@ -443,7 +443,7 @@ module Bytes {
 
       :returns: the number of times `needle` occurs in the object
      */
-    proc count(needle: bytes, region: range(?) = 1..) : int {
+    inline proc count(needle: bytes, region: range(?) = 1..) : int {
       return _search_helper(needle, region, count=true);
     }
 
@@ -632,14 +632,14 @@ module Bytes {
       the :record:`bytes` objects passed in with the contents of the method
       receiver inserted between them.
     */
-    proc join(const ref S: bytes ...) : bytes {
+    inline proc join(const ref S: bytes ...) : bytes {
       return _join(S);
     }
 
     /*
       Same as the varargs version, but with a homogeneous tuple of bytes.
     */
-    proc join(const ref S) : bytes where isTuple(S) {
+    inline proc join(const ref S) : bytes where isTuple(S) {
       if !isHomogeneousTuple(S) || !isBytes(S[1]) then
         compilerError("join() on tuples only handles homogeneous tuples of strings");
       return _join(S);
@@ -648,17 +648,17 @@ module Bytes {
     /*
       Same as the varargs version, but with all the bytes in an array.
      */
-    proc join(const ref S: [] bytes) : bytes {
+    inline proc join(const ref S: [] bytes) : bytes {
       return _join(S);
     }
 
     pragma "no doc"
-    proc join(ir: _iteratorRecord): bytes {
+    inline proc join(ir: _iteratorRecord): bytes {
       return doJoinIterator(this, ir);
     }
 
     pragma "no doc"
-    proc _join(const ref S) : bytes where isTuple(S) || isArray(S) {
+    inline proc _join(const ref S) : bytes where isTuple(S) || isArray(S) {
       return doJoin(this, S);
     }
 
@@ -722,7 +722,7 @@ module Bytes {
       before `sep`, `sep`, and the section after `sep`. If `sep` is not found,
       the tuple will contain the whole bytes, and then two empty bytes.
     */
-    proc const partition(sep: bytes) : 3*bytes {
+    inline proc const partition(sep: bytes) : 3*bytes {
       return doPartition(this, sep);
     }
 

--- a/modules/internal/BytesStringCommon.chpl
+++ b/modules/internal/BytesStringCommon.chpl
@@ -510,7 +510,7 @@ module BytesStringCommon {
     return ret;
   }
 
-  proc doEq(a: ?t1, b: ?t2) {
+  inline proc doEq(a: ?t1, b: ?t2) {
     assertArgType(t1, "doEq");
     assertArgType(t2, "doEq");
 

--- a/modules/internal/BytesStringCommon.chpl
+++ b/modules/internal/BytesStringCommon.chpl
@@ -201,8 +201,6 @@ module BytesStringCommon {
       found += 1;
       result = result[..idx-1] + localReplacement +
                result[(idx + localNeedle.numBytes)..];
-      var tmp_res = result[..idx-1] + localReplacement +
-                    result[(idx + localNeedle.numBytes)..];
 
       startIdx = idx + localReplacement.numBytes;
     }

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -1084,7 +1084,7 @@ module String {
       :returns: * `true`  -- when the string begins with one or more of the `needles`
                 * `false` -- otherwise
      */
-    proc startsWith(needles: string ...) : bool {
+    inline proc startsWith(needles: string ...) : bool {
       return startsEndsWith(this, needles, fromLeft=true);
     }
 
@@ -1094,7 +1094,7 @@ module String {
       :returns: * `true`  -- when the string ends with one or more of the `needles`
                 * `false` -- otherwise
      */
-    proc endsWith(needles: string ...) : bool {
+    inline proc endsWith(needles: string ...) : bool {
       return startsEndsWith(this, needles, fromLeft=false);
     }
 
@@ -1200,7 +1200,7 @@ module String {
                 string, or 0 if the `needle` is not in the string.
      */
     // TODO: better name than region?
-    proc find(needle: string, region: range(?) = 1:byteIndex..) : byteIndex {
+    inline proc find(needle: string, region: range(?) = 1:byteIndex..) : byteIndex {
       return _search_helper(needle, region, count=false): byteIndex;
     }
 
@@ -1374,17 +1374,17 @@ module String {
           var x = "|".join(["a","10","d"]);
           writeln(x); // prints: "a|10|d"
      */
-    proc join(const ref S: [] string) : string {
+    inline proc join(const ref S: [] string) : string {
       return _join(S);
     }
 
     pragma "no doc"
-    proc join(ir: _iteratorRecord): string {
+    inline proc join(ir: _iteratorRecord): string {
       return doJoinIterator(this, ir);
     }
 
     pragma "no doc"
-    proc _join(const ref S) : string where isTuple(S) || isArray(S) {
+    inline proc _join(const ref S) : string where isTuple(S) || isArray(S) {
       return doJoin(this, S);
     }
 
@@ -1446,7 +1446,7 @@ module String {
       before `sep`, `sep`, and the section after `sep`. If `sep` is not found,
       the tuple will contain the whole string, and then two empty strings.
     */
-    proc const partition(sep: string) : 3*string {
+    inline proc const partition(sep: string) : 3*string {
       return doPartition(this, sep);
     }
 

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -1046,7 +1046,7 @@ module String {
                 the length of `r` is zero, an empty string is returned.
      */
     // TODO: I wasn't very good about caching variables locally in this one.
-    proc this(r: range(?)) : string {
+    inline proc this(r: range(?)) : string {
       return getSlice(this, r);
     }
 
@@ -1240,7 +1240,7 @@ module String {
      */
     // TODO: not ideal - count and single allocation probably faster
     //                 - can special case on replacement|needle.length (0, 1)
-    proc replace(needle: string, replacement: string, count: int = -1) : string {
+    inline proc replace(needle: string, replacement: string, count: int = -1) : string {
       return doReplace(this, needle, replacement, count);
     }
 


### PR DESCRIPTION
This PR inlines bunch of single-line wrappers in string/bytes implementations.

While there it also removes an unused variable. I left that variable there by mistake and the
dead code elimination was unable to remove it. The variable had kind of a heavy initialization
which caused performance regression in one of the string benchmarks.

Changes are trivial but I am still running some tests:
- [x] standard
- [x] gasnet