### PR TITLE
Remove deprecated bytes initializers

### DIFF
--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -75,14 +75,6 @@ module Bytes {
 
   type idxType = int; 
 
-
-  private proc deprWarning() {
-    if showStringBytesInitDeprWarnings {
-      compilerWarning("bytes.init is deprecated - "+
-                      "please use createBytesWith* instead");
-    }
-  }
-
   record _bytes {
     pragma "no doc"
     var len: int = 0; // length of string in bytes

--- a/test/deprecated/string-bytes-inits.chpl
+++ b/test/deprecated/string-bytes-inits.chpl
@@ -1,7 +1,3 @@
 var s1 = new string("some chapel string");
 var s2 = new string(c"some C string");
 var s3 = new string((c"some C string"):c_ptr(uint(8)), length=13, size=14);
-
-var b1 = new bytes(b"some bytes");
-var b2 = new bytes(c"some other C string", length=16);
-var b3 = new bytes((c"some other C string"):c_ptr(uint(8)), length=16, size=20);

--- a/test/deprecated/string-bytes-inits.good
+++ b/test/deprecated/string-bytes-inits.good
@@ -1,7 +1,3 @@
 string-bytes-inits.chpl:1: warning: string.init is deprecated - please use createStringWith* instead
 string-bytes-inits.chpl:2: warning: string.init is deprecated - please use createStringWith* instead
 string-bytes-inits.chpl:3: warning: string.init is deprecated - please use createStringWith* instead
-string-bytes-inits.chpl:5: warning: bytes.init is deprecated - please use createBytesWith* instead
-string-bytes-inits.chpl:6: warning: bytes.init is deprecated - please use createBytesWith* instead
-string-bytes-inits.chpl:7: warning: bytes.init is deprecated - please use createBytesWith* instead
-Called 2


### PR DESCRIPTION
This PR removes the deprecated bytes initializers.

Also adjusts the related deprecation test. (Wow, there was a stray writeln in the 
deprecated initializer that also ended up affecting the good file :( )

Test:
- [x] `test/types/bytes` with standard and gasnet configs
- [x] standard (I don't think we have any string/bytes initializers used on master now, but just in case)
