### PR TITLE
Add documentation for string/bytes factory functions

### DIFF
--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -75,6 +75,166 @@ module Bytes {
 
   type idxType = int; 
 
+  //
+  // createBytes* functions
+  //
+
+  /*
+    Creates a new bytes which borrows the internal buffer of another bytes. If
+    the buffer is freed before the bytes returned from this function, accessing
+    it is undefined behavior.
+
+    :arg s: Object to borrow the buffer from
+    :type s: `bytes`
+
+    :returns: A new `bytes`
+  */
+  inline proc createBytesWithBorrowedBuffer(s: bytes) {
+    var ret: bytes;
+    initWithBorrowedBuffer(ret, s);
+    return ret;
+  }
+
+  /*
+    Creates a new bytes which borrows the internal buffer of a `c_string`. If
+    the buffer is freed before the bytes returned from this function, accessing
+    it is undefined behavior.
+
+    :arg s: Object to borrow the buffer from
+    :type s: c_string
+
+    :arg length: Length of the `c_string` in bytes, excluding the terminating
+                 null byte.
+    :type length: int
+
+    :returns: A new `bytes`
+  */
+  inline proc createBytesWithBorrowedBuffer(s: c_string, length=s.length) {
+    return createBytesWithBorrowedBuffer(s:c_ptr(uint(8)), length=length,
+                                                            size=length+1);
+  }
+
+  /*
+     Creates a new bytes which borrows the memory allocated for a
+     `c_ptr(uint(8))`. If the buffer is freed before the bytes returned from
+     this function, accessing it is undefined behavior.
+
+     :arg s: Object to borrow the buffer from
+     :type s: `bufferType` (i.e. `c_ptr(uint(8))`)
+
+     :arg length: Length of the bytes stored in `s`, excluding the terminating
+                  null byte.
+     :type length: int
+
+     :arg size: Size of memory allocated for `s` in bytes
+     :type length: int
+
+     :returns: A new `bytes`
+  */
+  inline proc createBytesWithBorrowedBuffer(s: bufferType, length: int, size: int) {
+    var ret: bytes;
+    initWithBorrowedBuffer(ret, s, length,size);
+    return ret;
+  }
+
+  pragma "no doc"
+  inline proc createBytesWithOwnedBuffer(s: bytes) {
+    // should we allow stealing ownership?
+    compilerError("A bytes cannot be passed to createBytesWithOwnedBuffer");
+  }
+
+  /*
+    Creates a new bytes which takes ownership of the internal buffer of a
+    `c_string`.
+
+    :arg s: Object to take ownership of the buffer from
+    :type s: `c_string`
+
+    :arg length: Length of the bytes stored in `s`, excluding the terminating
+                 null byte.
+    :type length: int
+
+    :returns: A new `bytes`
+  */
+  inline proc createBytesWithOwnedBuffer(s: c_string, length=s.length) {
+    return createBytesWithOwnedBuffer(s: bufferType, length=length,
+                                                      size=length+1);
+  }
+
+  /*
+     Creates a new bytes which takes ownership of the memory allocated for a
+     `c_ptr(uint(8))`.
+
+     :arg s: Object to take ownership of the buffer from
+     :type s: `bufferType` (i.e. `c_ptr(uint(8))`)
+
+     :arg length: Length of the bytes stored in `s`, excluding the terminating
+                  null byte.
+     :type length: int
+
+     :arg size: Size of memory allocated for `s` in bytes
+     :type length: int
+
+     :returns: A new `bytes`
+  */
+  inline proc createBytesWithOwnedBuffer(s: bufferType, length: int, size: int) {
+    var ret: bytes;
+    initWithOwnedBuffer(ret, s, length, size);
+    return ret;
+  }
+
+  /*
+    Creates a new bytes by creating a copy of the buffer of another bytes.
+
+    :arg s: Object to copy the buffer from
+    :type s: `bytes`
+
+    :returns: A new `bytes`
+  */
+  inline proc createBytesWithNewBuffer(s: bytes) {
+    var ret: bytes;
+    initWithNewBuffer(ret, s);
+    return ret;
+  }
+
+  /*
+    Creates a new bytes by creating a copy of the buffer of a `c_string`.
+
+    :arg s: Object to copy the buffer from
+    :type s: c_string
+
+    :arg length: Length of the `c_string` in bytes, excluding the terminating
+                 null byte.
+    :type length: int
+
+    :returns: A new `bytes`
+  */
+  inline proc createBytesWithNewBuffer(s: c_string, length=s.length) {
+    return createBytesWithNewBuffer(s: bufferType, length=length,
+                                                    size=length+1);
+  }
+
+  /*
+     Creates a new bytes by creating a copy of a buffer.
+
+     :arg s: The buffer to copy
+     :type s: `bufferType` (i.e. `c_ptr(uint(8))`)
+
+     :arg length: Length of the bytes stored in `s`, excluding the terminating
+                  null byte.
+     :type length: int
+
+     :arg size: Size of memory allocated for `s` in bytes
+     :type length: int
+
+     :returns: A new `bytes`
+  */
+  inline proc createBytesWithNewBuffer(s: bufferType, length: int, size: int) {
+    var ret: bytes;
+    initWithNewBuffer(ret, s, length, size);
+    return ret;
+  }
+
   record _bytes {
     pragma "no doc"
     var len: int = 0; // length of string in bytes
@@ -970,166 +1130,6 @@ module Bytes {
     }
 
   } // end of record bytes
-
-  //
-  // createBytes* functions
-  //
-
-  /*
-    Creates a new bytes which borrows the internal buffer of another bytes. If
-    the buffer is freed before the bytes returned from this function, accessing
-    it is undefined behavior.
-
-    :arg s: Object to borrow the buffer from
-    :type s: `bytes`
-
-    :returns: A new `bytes`
-  */
-  inline proc createBytesWithBorrowedBuffer(s: bytes) {
-    var ret: bytes;
-    initWithBorrowedBuffer(ret, s);
-    return ret;
-  }
-
-  /*
-    Creates a new bytes which borrows the internal buffer of a `c_string`. If
-    the buffer is freed before the bytes returned from this function, accessing
-    it is undefined behavior.
-
-    :arg s: Object to borrow the buffer from
-    :type s: c_string
-
-    :arg length: Length of the `c_string` in bytes, excluding the terminating
-                 null byte.
-    :type length: int
-
-    :returns: A new `bytes`
-  */
-  inline proc createBytesWithBorrowedBuffer(s: c_string, length=s.length) {
-    return createBytesWithBorrowedBuffer(s:c_ptr(uint(8)), length=length,
-                                                            size=length+1);
-  }
-
-  /*
-     Creates a new bytes which borrows the memory allocated for a
-     `c_ptr(uint(8))`. If the buffer is freed before the bytes returned from
-     this function, accessing it is undefined behavior.
-
-     :arg s: Object to borrow the buffer from
-     :type s: `bufferType` (i.e. `c_ptr(uint(8))`)
-
-     :arg length: Length of the bytes stored in `s`, excluding the terminating
-                  null byte.
-     :type length: int
-
-     :arg size: Size of memory allocated for `s` in bytes
-     :type length: int
-
-     :returns: A new `bytes`
-  */
-  inline proc createBytesWithBorrowedBuffer(s: bufferType, length: int, size: int) {
-    var ret: bytes;
-    initWithBorrowedBuffer(ret, s, length,size);
-    return ret;
-  }
-
-  pragma "no doc"
-  inline proc createBytesWithOwnedBuffer(s: bytes) {
-    // should we allow stealing ownership?
-    compilerError("A bytes cannot be passed to createBytesWithOwnedBuffer");
-  }
-
-  /*
-    Creates a new bytes which takes ownership of the internal buffer of a
-    `c_string`.
-
-    :arg s: Object to take ownership of the buffer from
-    :type s: `c_string`
-
-    :arg length: Length of the bytes stored in `s`, excluding the terminating
-                 null byte.
-    :type length: int
-
-    :returns: A new `bytes`
-  */
-  inline proc createBytesWithOwnedBuffer(s: c_string, length=s.length) {
-    return createBytesWithOwnedBuffer(s: bufferType, length=length,
-                                                      size=length+1);
-  }
-
-  /*
-     Creates a new bytes which takes ownership of the memory allocated for a
-     `c_ptr(uint(8))`.
-
-     :arg s: Object to take ownership of the buffer from
-     :type s: `bufferType` (i.e. `c_ptr(uint(8))`)
-
-     :arg length: Length of the bytes stored in `s`, excluding the terminating
-                  null byte.
-     :type length: int
-
-     :arg size: Size of memory allocated for `s` in bytes
-     :type length: int
-
-     :returns: A new `bytes`
-  */
-  inline proc createBytesWithOwnedBuffer(s: bufferType, length: int, size: int) {
-    var ret: bytes;
-    initWithOwnedBuffer(ret, s, length, size);
-    return ret;
-  }
-
-  /*
-    Creates a new bytes by creating a copy of the buffer of another bytes.
-
-    :arg s: Object to copy the buffer from
-    :type s: `bytes`
-
-    :returns: A new `bytes`
-  */
-  inline proc createBytesWithNewBuffer(s: bytes) {
-    var ret: bytes;
-    initWithNewBuffer(ret, s);
-    return ret;
-  }
-
-  /*
-    Creates a new bytes by creating a copy of the buffer of a `c_string`.
-
-    :arg s: Object to copy the buffer from
-    :type s: c_string
-
-    :arg length: Length of the `c_string` in bytes, excluding the terminating
-                 null byte.
-    :type length: int
-
-    :returns: A new `bytes`
-  */
-  inline proc createBytesWithNewBuffer(s: c_string, length=s.length) {
-    return createBytesWithNewBuffer(s: bufferType, length=length,
-                                                    size=length+1);
-  }
-
-  /*
-     Creates a new bytes by creating a copy of a buffer.
-
-     :arg s: The buffer to copy
-     :type s: `bufferType` (i.e. `c_ptr(uint(8))`)
-
-     :arg length: Length of the bytes stored in `s`, excluding the terminating
-                  null byte.
-     :type length: int
-
-     :arg size: Size of memory allocated for `s` in bytes
-     :type length: int
-
-     :returns: A new `bytes`
-  */
-  inline proc createBytesWithNewBuffer(s: bufferType, length: int, size: int) {
-    var ret: bytes;
-    initWithNewBuffer(ret, s, length, size);
-    return ret;
-  }
 
   inline proc _cast(type t: bytes, x: string) {
     return createBytesWithNewBuffer(x.buff, length=x.numBytes, size=x.numBytes+1);

--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -145,7 +145,7 @@ module Bytes {
 
   /*
     Creates a new bytes which takes ownership of the internal buffer of a
-    `c_string`.
+    `c_string`.The buffer will be freed when the bytes is deinitialized.
 
     :arg s: Object to take ownership of the buffer from
     :type s: `c_string`
@@ -163,7 +163,7 @@ module Bytes {
 
   /*
      Creates a new bytes which takes ownership of the memory allocated for a
-     `c_ptr(uint(8))`.
+     `c_ptr(uint(8))`. The buffer will be freed when the bytes is deinitialized.
 
      :arg s: Object to take ownership of the buffer from
      :type s: `bufferType` (i.e. `c_ptr(uint(8))`)

--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -975,50 +975,156 @@ module Bytes {
   // createBytes* functions
   //
 
+  /*
+    Creates a new bytes which borrows the internal buffer of another bytes. If
+    the buffer is freed before the bytes returned from this function, accessing
+    it is undefined behavior.
+
+    :arg s: Object to borrow the buffer from
+    :type s: `bytes`
+
+    :returns: A new `bytes`
+  */
   inline proc createBytesWithBorrowedBuffer(s: bytes) {
     var ret: bytes;
     initWithBorrowedBuffer(ret, s);
     return ret;
   }
 
+  /*
+    Creates a new bytes which borrows the internal buffer of a `c_string`. If
+    the buffer is freed before the bytes returned from this function, accessing
+    it is undefined behavior.
+
+    :arg s: Object to borrow the buffer from
+    :type s: c_string
+
+    :arg length: Length of the `c_string` in bytes, excluding the terminating
+                 null byte.
+    :type length: int
+
+    :returns: A new `bytes`
+  */
   inline proc createBytesWithBorrowedBuffer(s: c_string, length=s.length) {
     return createBytesWithBorrowedBuffer(s:c_ptr(uint(8)), length=length,
                                                             size=length+1);
   }
 
+  /*
+     Creates a new bytes which borrows the memory allocated for a
+     `c_ptr(uint(8))`. If the buffer is freed before the bytes returned from
+     this function, accessing it is undefined behavior.
+
+     :arg s: Object to borrow the buffer from
+     :type s: `bufferType` (i.e. `c_ptr(uint(8))`)
+
+     :arg length: Length of the bytes stored in `s`, excluding the terminating
+                  null byte.
+     :type length: int
+
+     :arg size: Size of memory allocated for `s` in bytes
+     :type length: int
+
+     :returns: A new `bytes`
+  */
   inline proc createBytesWithBorrowedBuffer(s: bufferType, length: int, size: int) {
     var ret: bytes;
     initWithBorrowedBuffer(ret, s, length,size);
     return ret;
   }
 
+  pragma "no doc"
   inline proc createBytesWithOwnedBuffer(s: bytes) {
     // should we allow stealing ownership?
     compilerError("A bytes cannot be passed to createBytesWithOwnedBuffer");
   }
 
+  /*
+    Creates a new bytes which takes ownership of the internal buffer of a
+    `c_string`.
+
+    :arg s: Object to take ownership of the buffer from
+    :type s: `c_string`
+
+    :arg length: Length of the bytes stored in `s`, excluding the terminating
+                 null byte.
+    :type length: int
+
+    :returns: A new `bytes`
+  */
   inline proc createBytesWithOwnedBuffer(s: c_string, length=s.length) {
     return createBytesWithOwnedBuffer(s: bufferType, length=length,
                                                       size=length+1);
   }
 
+  /*
+     Creates a new bytes which takes ownership of the memory allocated for a
+     `c_ptr(uint(8))`.
+
+     :arg s: Object to take ownership of the buffer from
+     :type s: `bufferType` (i.e. `c_ptr(uint(8))`)
+
+     :arg length: Length of the bytes stored in `s`, excluding the terminating
+                  null byte.
+     :type length: int
+
+     :arg size: Size of memory allocated for `s` in bytes
+     :type length: int
+
+     :returns: A new `bytes`
+  */
   inline proc createBytesWithOwnedBuffer(s: bufferType, length: int, size: int) {
     var ret: bytes;
     initWithOwnedBuffer(ret, s, length, size);
     return ret;
   }
 
+  /*
+    Creates a new bytes by creating a copy of the buffer of another bytes.
+
+    :arg s: Object to copy the buffer from
+    :type s: `bytes`
+
+    :returns: A new `bytes`
+  */
   inline proc createBytesWithNewBuffer(s: bytes) {
     var ret: bytes;
     initWithNewBuffer(ret, s);
     return ret;
   }
 
+  /*
+    Creates a new bytes by creating a copy of the buffer of a `c_string`.
+
+    :arg s: Object to copy the buffer from
+    :type s: c_string
+
+    :arg length: Length of the `c_string` in bytes, excluding the terminating
+                 null byte.
+    :type length: int
+
+    :returns: A new `bytes`
+  */
   inline proc createBytesWithNewBuffer(s: c_string, length=s.length) {
     return createBytesWithNewBuffer(s: bufferType, length=length,
                                                     size=length+1);
   }
 
+  /*
+     Creates a new bytes by creating a copy of a buffer.
+
+     :arg s: The buffer to copy
+     :type s: `bufferType` (i.e. `c_ptr(uint(8))`)
+
+     :arg length: Length of the bytes stored in `s`, excluding the terminating
+                  null byte.
+     :type length: int
+
+     :arg size: Size of memory allocated for `s` in bytes
+     :type length: int
+
+     :returns: A new `bytes`
+  */
   inline proc createBytesWithNewBuffer(s: bufferType, length: int, size: int) {
     var ret: bytes;
     initWithNewBuffer(ret, s, length, size);

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -525,7 +525,7 @@ module String {
 
   /*
     Creates a new string which takes ownership of the internal buffer of a
-    `c_string`.
+    `c_string`. The buffer will be freed when the bytes is deinitialized.
 
     :arg s: Object to take ownership of the buffer from
     :type s: `c_string`
@@ -543,7 +543,7 @@ module String {
 
   /*
      Creates a new string which takes ownership of the memory allocated for a
-     `c_ptr(uint(8))`.
+     `c_ptr(uint(8))`. The buffer will be freed when the bytes is deinitialized.
 
      :arg s: Object to take ownership of the buffer from
      :type s: `bufferType` (i.e. `c_ptr(uint(8))`)

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -1804,50 +1804,156 @@ module String {
   // createString* functions
   //
 
+  /*
+    Creates a new string which borrows the internal buffer of another string. If
+    the buffer is freed before the string returned from this function, accessing
+    it is undefined behavior.
+
+    :arg s: Object to borrow the buffer from
+    :type s: `string`
+
+    :returns: A new `string`
+  */
   inline proc createStringWithBorrowedBuffer(s: string) {
     var ret: string;
     initWithBorrowedBuffer(ret, s);
     return ret;
   }
 
+  /*
+    Creates a new string which borrows the internal buffer of a `c_string`. If
+    the buffer is freed before the string returned from this function, accessing
+    it is undefined behavior.
+
+    :arg s: Object to borrow the buffer from
+    :type s: c_string
+
+    :arg length: Length of the `c_string` in bytes, excluding the terminating
+                 null byte.
+    :type length: int
+
+    :returns: A new `string`
+  */
   inline proc createStringWithBorrowedBuffer(s: c_string, length=s.length) {
     return createStringWithBorrowedBuffer(s:c_ptr(uint(8)), length=length,
                                                             size=length+1);
   }
 
+  /*
+     Creates a new string which borrows the memory allocated for a
+     `c_ptr(uint(8))`. If the buffer is freed before the string returned from
+     this function, accessing it is undefined behavior.
+
+     :arg s: Object to borrow the buffer from
+     :type s: `bufferType` (i.e. `c_ptr(uint(8))`)
+
+     :arg length: Length of the string stored in `s`, excluding the terminating
+                  null byte.
+     :type length: int
+
+     :arg size: Size of memory allocated for `s` in bytes
+     :type length: int
+
+     :returns: A new `string`
+  */
   inline proc createStringWithBorrowedBuffer(s: bufferType, length: int, size: int) {
     var ret: string;
     initWithBorrowedBuffer(ret, s, length,size);
     return ret;
   }
 
+  pragma "no doc"
   inline proc createStringWithOwnedBuffer(s: string) {
     // should we allow stealing ownership?
     compilerError("A Chapel string cannot be passed to createStringWithOwnedBuffer");
   }
 
+  /*
+    Creates a new string which takes ownership of the internal buffer of a
+    `c_string`.
+
+    :arg s: Object to take ownership of the buffer from
+    :type s: `c_string`
+
+    :arg length: Length of the string stored in `s`, excluding the terminating
+                 null byte.
+    :type length: int
+
+    :returns: A new `string`
+  */
   inline proc createStringWithOwnedBuffer(s: c_string, length=s.length) {
     return createStringWithOwnedBuffer(s: bufferType, length=length,
                                                       size=length+1);
   }
 
+  /*
+     Creates a new string which takes ownership of the memory allocated for a
+     `c_ptr(uint(8))`.
+
+     :arg s: Object to take ownership of the buffer from
+     :type s: `bufferType` (i.e. `c_ptr(uint(8))`)
+
+     :arg length: Length of the string stored in `s`, excluding the terminating
+                  null byte.
+     :type length: int
+
+     :arg size: Size of memory allocated for `s` in bytes
+     :type length: int
+
+     :returns: A new `string`
+  */
   inline proc createStringWithOwnedBuffer(s: bufferType, length: int, size: int) {
     var ret: string;
     initWithOwnedBuffer(ret, s, length, size);
     return ret;
   }
 
+  /*
+    Creates a new string by creating a copy of the buffer of another string.
+
+    :arg s: Object to copy the buffer from
+    :type s: `string`
+
+    :returns: A new `string`
+  */
   inline proc createStringWithNewBuffer(s: string) {
     var ret: string;
     initWithNewBuffer(ret, s);
     return ret;
   }
 
+  /*
+    Creates a new string by creating a copy of the buffer of a `c_string`.
+
+    :arg s: Object to copy the buffer from
+    :type s: c_string
+
+    :arg length: Length of the `c_string` in bytes, excluding the terminating
+                 null byte.
+    :type length: int
+
+    :returns: A new `string`
+  */
   inline proc createStringWithNewBuffer(s: c_string, length=s.length) {
     return createStringWithNewBuffer(s: bufferType, length=length,
                                                     size=length+1);
   }
 
+  /*
+     Creates a new string by creating a copy of a buffer.
+
+     :arg s: The buffer to copy
+     :type s: `bufferType` (i.e. `c_ptr(uint(8))`)
+
+     :arg length: Length of the string stored in `s`, excluding the terminating
+                  null byte.
+     :type length: int
+
+     :arg size: Size of memory allocated for `s` in bytes
+     :type length: int
+
+     :returns: A new `string`
+  */
   inline proc createStringWithNewBuffer(s: bufferType, length: int, size: int) {
     var ret: string;
     initWithNewBuffer(ret, s, length, size);

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -456,6 +456,166 @@ module String {
   }
 
   //
+  // createString* functions
+  //
+
+  /*
+    Creates a new string which borrows the internal buffer of another string. If
+    the buffer is freed before the string returned from this function, accessing
+    it is undefined behavior.
+
+    :arg s: Object to borrow the buffer from
+    :type s: `string`
+
+    :returns: A new `string`
+  */
+  inline proc createStringWithBorrowedBuffer(s: string) {
+    var ret: string;
+    initWithBorrowedBuffer(ret, s);
+    return ret;
+  }
+
+  /*
+    Creates a new string which borrows the internal buffer of a `c_string`. If
+    the buffer is freed before the string returned from this function, accessing
+    it is undefined behavior.
+
+    :arg s: Object to borrow the buffer from
+    :type s: c_string
+
+    :arg length: Length of the `c_string` in bytes, excluding the terminating
+                 null byte.
+    :type length: int
+
+    :returns: A new `string`
+  */
+  inline proc createStringWithBorrowedBuffer(s: c_string, length=s.length) {
+    return createStringWithBorrowedBuffer(s:c_ptr(uint(8)), length=length,
+                                                            size=length+1);
+  }
+
+  /*
+     Creates a new string which borrows the memory allocated for a
+     `c_ptr(uint(8))`. If the buffer is freed before the string returned from
+     this function, accessing it is undefined behavior.
+
+     :arg s: Object to borrow the buffer from
+     :type s: `bufferType` (i.e. `c_ptr(uint(8))`)
+
+     :arg length: Length of the string stored in `s`, excluding the terminating
+                  null byte.
+     :type length: int
+
+     :arg size: Size of memory allocated for `s` in bytes
+     :type length: int
+
+     :returns: A new `string`
+  */
+  inline proc createStringWithBorrowedBuffer(s: bufferType, length: int, size: int) {
+    var ret: string;
+    initWithBorrowedBuffer(ret, s, length,size);
+    return ret;
+  }
+
+  pragma "no doc"
+  inline proc createStringWithOwnedBuffer(s: string) {
+    // should we allow stealing ownership?
+    compilerError("A Chapel string cannot be passed to createStringWithOwnedBuffer");
+  }
+
+  /*
+    Creates a new string which takes ownership of the internal buffer of a
+    `c_string`.
+
+    :arg s: Object to take ownership of the buffer from
+    :type s: `c_string`
+
+    :arg length: Length of the string stored in `s`, excluding the terminating
+                 null byte.
+    :type length: int
+
+    :returns: A new `string`
+  */
+  inline proc createStringWithOwnedBuffer(s: c_string, length=s.length) {
+    return createStringWithOwnedBuffer(s: bufferType, length=length,
+                                                      size=length+1);
+  }
+
+  /*
+     Creates a new string which takes ownership of the memory allocated for a
+     `c_ptr(uint(8))`.
+
+     :arg s: Object to take ownership of the buffer from
+     :type s: `bufferType` (i.e. `c_ptr(uint(8))`)
+
+     :arg length: Length of the string stored in `s`, excluding the terminating
+                  null byte.
+     :type length: int
+
+     :arg size: Size of memory allocated for `s` in bytes
+     :type length: int
+
+     :returns: A new `string`
+  */
+  inline proc createStringWithOwnedBuffer(s: bufferType, length: int, size: int) {
+    var ret: string;
+    initWithOwnedBuffer(ret, s, length, size);
+    return ret;
+  }
+
+  /*
+    Creates a new string by creating a copy of the buffer of another string.
+
+    :arg s: Object to copy the buffer from
+    :type s: `string`
+
+    :returns: A new `string`
+  */
+  inline proc createStringWithNewBuffer(s: string) {
+    var ret: string;
+    initWithNewBuffer(ret, s);
+    return ret;
+  }
+
+  /*
+    Creates a new string by creating a copy of the buffer of a `c_string`.
+
+    :arg s: Object to copy the buffer from
+    :type s: c_string
+
+    :arg length: Length of the `c_string` in bytes, excluding the terminating
+                 null byte.
+    :type length: int
+
+    :returns: A new `string`
+  */
+  inline proc createStringWithNewBuffer(s: c_string, length=s.length) {
+    return createStringWithNewBuffer(s: bufferType, length=length,
+                                                    size=length+1);
+  }
+
+  /*
+     Creates a new string by creating a copy of a buffer.
+
+     :arg s: The buffer to copy
+     :type s: `bufferType` (i.e. `c_ptr(uint(8))`)
+
+     :arg length: Length of the string stored in `s`, excluding the terminating
+                  null byte.
+     :type length: int
+
+     :arg size: Size of memory allocated for `s` in bytes
+     :type length: int
+
+     :returns: A new `string`
+  */
+  inline proc createStringWithNewBuffer(s: bufferType, length: int, size: int) {
+    var ret: string;
+    initWithNewBuffer(ret, s, length, size);
+    return ret;
+  }
+
+  //
   // String Implementation
   //
   // TODO: We should be able to remove "ignore noinit", but doing so causes
@@ -1799,166 +1959,6 @@ module String {
     }
 
   } // end record string
-
-  //
-  // createString* functions
-  //
-
-  /*
-    Creates a new string which borrows the internal buffer of another string. If
-    the buffer is freed before the string returned from this function, accessing
-    it is undefined behavior.
-
-    :arg s: Object to borrow the buffer from
-    :type s: `string`
-
-    :returns: A new `string`
-  */
-  inline proc createStringWithBorrowedBuffer(s: string) {
-    var ret: string;
-    initWithBorrowedBuffer(ret, s);
-    return ret;
-  }
-
-  /*
-    Creates a new string which borrows the internal buffer of a `c_string`. If
-    the buffer is freed before the string returned from this function, accessing
-    it is undefined behavior.
-
-    :arg s: Object to borrow the buffer from
-    :type s: c_string
-
-    :arg length: Length of the `c_string` in bytes, excluding the terminating
-                 null byte.
-    :type length: int
-
-    :returns: A new `string`
-  */
-  inline proc createStringWithBorrowedBuffer(s: c_string, length=s.length) {
-    return createStringWithBorrowedBuffer(s:c_ptr(uint(8)), length=length,
-                                                            size=length+1);
-  }
-
-  /*
-     Creates a new string which borrows the memory allocated for a
-     `c_ptr(uint(8))`. If the buffer is freed before the string returned from
-     this function, accessing it is undefined behavior.
-
-     :arg s: Object to borrow the buffer from
-     :type s: `bufferType` (i.e. `c_ptr(uint(8))`)
-
-     :arg length: Length of the string stored in `s`, excluding the terminating
-                  null byte.
-     :type length: int
-
-     :arg size: Size of memory allocated for `s` in bytes
-     :type length: int
-
-     :returns: A new `string`
-  */
-  inline proc createStringWithBorrowedBuffer(s: bufferType, length: int, size: int) {
-    var ret: string;
-    initWithBorrowedBuffer(ret, s, length,size);
-    return ret;
-  }
-
-  pragma "no doc"
-  inline proc createStringWithOwnedBuffer(s: string) {
-    // should we allow stealing ownership?
-    compilerError("A Chapel string cannot be passed to createStringWithOwnedBuffer");
-  }
-
-  /*
-    Creates a new string which takes ownership of the internal buffer of a
-    `c_string`.
-
-    :arg s: Object to take ownership of the buffer from
-    :type s: `c_string`
-
-    :arg length: Length of the string stored in `s`, excluding the terminating
-                 null byte.
-    :type length: int
-
-    :returns: A new `string`
-  */
-  inline proc createStringWithOwnedBuffer(s: c_string, length=s.length) {
-    return createStringWithOwnedBuffer(s: bufferType, length=length,
-                                                      size=length+1);
-  }
-
-  /*
-     Creates a new string which takes ownership of the memory allocated for a
-     `c_ptr(uint(8))`.
-
-     :arg s: Object to take ownership of the buffer from
-     :type s: `bufferType` (i.e. `c_ptr(uint(8))`)
-
-     :arg length: Length of the string stored in `s`, excluding the terminating
-                  null byte.
-     :type length: int
-
-     :arg size: Size of memory allocated for `s` in bytes
-     :type length: int
-
-     :returns: A new `string`
-  */
-  inline proc createStringWithOwnedBuffer(s: bufferType, length: int, size: int) {
-    var ret: string;
-    initWithOwnedBuffer(ret, s, length, size);
-    return ret;
-  }
-
-  /*
-    Creates a new string by creating a copy of the buffer of another string.
-
-    :arg s: Object to copy the buffer from
-    :type s: `string`
-
-    :returns: A new `string`
-  */
-  inline proc createStringWithNewBuffer(s: string) {
-    var ret: string;
-    initWithNewBuffer(ret, s);
-    return ret;
-  }
-
-  /*
-    Creates a new string by creating a copy of the buffer of a `c_string`.
-
-    :arg s: Object to copy the buffer from
-    :type s: c_string
-
-    :arg length: Length of the `c_string` in bytes, excluding the terminating
-                 null byte.
-    :type length: int
-
-    :returns: A new `string`
-  */
-  inline proc createStringWithNewBuffer(s: c_string, length=s.length) {
-    return createStringWithNewBuffer(s: bufferType, length=length,
-                                                    size=length+1);
-  }
-
-  /*
-     Creates a new string by creating a copy of a buffer.
-
-     :arg s: The buffer to copy
-     :type s: `bufferType` (i.e. `c_ptr(uint(8))`)
-
-     :arg length: Length of the string stored in `s`, excluding the terminating
-                  null byte.
-     :type length: int
-
-     :arg size: Size of memory allocated for `s` in bytes
-     :type length: int
-
-     :returns: A new `string`
-  */
-  inline proc createStringWithNewBuffer(s: bufferType, length: int, size: int) {
-    var ret: string;
-    initWithNewBuffer(ret, s, length, size);
-    return ret;
-  }
 
   //
   // Assignment functions

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -649,6 +649,12 @@ module String {
       string may appear in ``s``. It is the responsibility of the user to
       ensure that the underlying buffer is not freed while being used as part
       of a shallow copy.
+     
+      .. warning::
+
+          String initializers are deprecated. Use `createString*` functions,
+          instead.
+        
      */
     proc init(s: string, isowned: bool = true) {
       deprWarning();
@@ -690,6 +696,12 @@ module String {
       record, otherwise it will be used directly. It is the responsibility of
       the user to ensure that the underlying buffer is not freed if the
       `c_string` is not copied in.
+     
+      .. warning::
+
+          String initializers are deprecated. Use `createString*` functions,
+          instead.
+        
      */
     proc init(cs: c_string, length: int = cs.length,
                 isowned: bool = true, needToCopy:  bool = true) {
@@ -714,6 +726,12 @@ module String {
       the `c_string` will be copied into the record, otherwise it will be used
       directly. It is the responsibility of the user to ensure that the
       underlying buffer is not freed if the `c_string` is not copied in.
+     
+      .. warning::
+
+          String initializers are deprecated. Use `createString*` functions,
+          instead.
+        
      */
     // This initializer can cause a leak if isowned = false and needToCopy = true
     proc init(buff: bufferType, length: int, size: int,


### PR DESCRIPTION
This PR:

- Adds documentation for string/bytes factory functions
- Puts those functions earlier in the module as it makes more sense seeing them earlier.
- Adds deprecation warnings for string initializers.
- Does not do anything for bytes initializers. (#13972 removes them altogether.)

`make docs` passes