### PR TITLE
Adjust character set requirements documentation

### DIFF
--- a/doc/rst/usingchapel/chplenv.rst
+++ b/doc/rst/usingchapel/chplenv.rst
@@ -700,9 +700,10 @@ CHPL_LIB_PIC
 
 Character Set
 -------------
-   We have the most experience running Chapel with the Unicode
-   character set and the traditional C collating sequence using the
-   following settings.
+   Chapel works with the Unicode character set and the traditional C collating
+   sequence. Users are responsible for making sure that they are running Chapel
+   in a suitable environment. For example, for `en_US` locale, the following
+   environment variables should be set:
 
    .. code-block:: sh
 

--- a/doc/rst/usingchapel/chplenv.rst
+++ b/doc/rst/usingchapel/chplenv.rst
@@ -700,10 +700,10 @@ CHPL_LIB_PIC
 
 Character Set
 -------------
-   Chapel works with the Unicode character set and the traditional C collating
-   sequence. Users are responsible for making sure that they are running Chapel
-   in a suitable environment. For example, for `en_US` locale, the following
-   environment variables should be set:
+   Chapel works with the Unicode character set with UTF-8 encoding and the
+   traditional C collating sequence. Users are responsible for making sure that
+   they are running Chapel in a suitable environment. For example, for `en_US`
+   locale, the following environment variables should be set:
 
    .. code-block:: sh
 
@@ -712,7 +712,7 @@ Character Set
        LC_ALL=""
 
    .. note::
-       Other settings might be recommended in the future.
+       Other character sets may be supported in the future.
 
 Compiler Command Line Option Defaults
 -------------------------------------


### PR DESCRIPTION
We are currently not adjusting the environment automatically to use Unicode 
character set. So, users must be aware that they need to use suitable environment
settings. This PR adjusts the documentation to make that clear.