### PR TITLE
Fix memory leak in generic-classes-management.chpl

### DIFF
--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -1348,6 +1348,12 @@ bool formalRequiresTemp(ArgSymbol* formal, FnSymbol* fn) {
 }
 
 bool shouldAddFormalTempAtCallSite(ArgSymbol* formal, FnSymbol* fn) {
+
+  // Don't add copies at call site if function body will be removed anyway.
+  // TODO: handle RET_TYPE but not for runtime types
+  if (fn && fn->retTag == RET_PARAM)
+    return false;
+
   if (isRecord(formal->getValType())) {
     if (formal->intent == INTENT_IN ||
         formal->intent == INTENT_CONST_IN ||


### PR DESCRIPTION
Resolves https://github.com/Cray/chapel-private/issues/481

The test happened to use a `param` returning function combined with the `in` intent. This configuration resulted in memory leaks. It would also happen for `type` returning functions that do not return a run-time type, but this PR does not try to fix that.

This PR adjusts the compiler to avoid adding copies for `in` intent at the call site for functions that return a `param`. In fact no copy is necssary anywhere in that case, since the function will not exist in the compiled executable.

Reviewed by @vasslitvinov - thanks!

- [x] full local futures testing