### PR TITLE
Add a deprecation test for adding indices to an associative array's domain

### DIFF
--- a/test/deprecated/array-as-map-add-index.chpl
+++ b/test/deprecated/array-as-map-add-index.chpl
@@ -1,0 +1,4 @@
+var D: domain(string);
+var A: [D] int;
+
+A["hello"] = 1;

--- a/test/deprecated/array-as-map-add-index.good
+++ b/test/deprecated/array-as-map-add-index.good
@@ -1,0 +1,1 @@
+array-as-map-add-index.chpl:4: warning: growing associative domains by assigning to an array is deprecated


### PR DESCRIPTION
Add a test of the deprecation warning for adding indices to an associative
array's domain.