### PR TITLE
Fix a test to test bytes.join with array argument

### DIFF
--- a/test/types/bytes/basic.chpl
+++ b/test/types/bytes/basic.chpl
@@ -144,7 +144,7 @@ writeln("Test join -- homogeneous tuple of bytes");
 writeln(baseBytes.join((b"dir1", b"dir2", b"file")));
 
 writeln("Test join -- array of bytes");
-writeln(baseBytes.join(b"dir1", b"dir2", b"file"));
+writeln(baseBytes.join([b"dir1", b"dir2", b"file"]));
 
 writeln("Test strip");
 var bytesToStrip = b" \n  a \t text\n";


### PR DESCRIPTION
This test was claiming that it tests `bytes.join` with array argument, but it wasn't.
This PR fixes that.

The test passes after the change.