### PR TITLE
Multiple nilability errors for initializers

### DIFF
--- a/compiler/resolution/initializerResolution.cpp
+++ b/compiler/resolution/initializerResolution.cpp
@@ -479,11 +479,11 @@ static void resolveInitCall(CallExpr* call, AggregateType* newExprAlias, bool fo
 
     if (best == NULL) {
       if (call->partialTag == false) {
-        if (newExprAlias != NULL) {
-          USR_FATAL_CONT(call, "Unable to resolve new-expression with type alias '%s'", newExprAlias->symbol->name);
-        }
         if (forNewExpr == true) {
           bool existingErrors = fatalErrorsEncountered();
+          if (newExprAlias != NULL) {
+            USR_FATAL_CONT(call, "Unable to resolve new-expression with type alias '%s'", newExprAlias->symbol->name);
+          }
           if (!inGenerousResolutionForErrors()) {
             startGenerousResolutionForErrors();
             resolveInitCall(call, newExprAlias, /*forNewExpr*/ false);

--- a/compiler/resolution/initializerResolution.cpp
+++ b/compiler/resolution/initializerResolution.cpp
@@ -480,6 +480,17 @@ static void resolveInitCall(CallExpr* call, AggregateType* newExprAlias, bool fo
     if (best == NULL) {
       if (call->partialTag == false) {
         if (forNewExpr == true) {
+          // This exists to enable multiple fatal error messages when an
+          // initializer fails to resolve due to nilability errors. If the
+          // compiler is able to resolve the initializer call while being
+          // more flexible with nilability rules, compilation can continue.
+          //
+          // TODO: We do not issue an error here because the compiler will
+          // later attempt to resolve the initializer call once again, in
+          // which case it would issue the same error. Instead, issue no errors
+          // in this conditional and let another part of resolution handle that.
+          // In the future, the compiler should not be attempting to resolve
+          // an already-resolved call.
           bool existingErrors = fatalErrorsEncountered();
           if (newExprAlias != NULL) {
             USR_FATAL_CONT(call, "Unable to resolve new-expression with type alias '%s'", newExprAlias->symbol->name);

--- a/compiler/resolution/postFold.cpp
+++ b/compiler/resolution/postFold.cpp
@@ -168,8 +168,10 @@ static Expr* postFoldNormal(CallExpr* call) {
 
       call->replace(retval);
 
-      // Put the call back in the AST for better errors
-      if (fatalErrorsEncountered()) {
+      // Put the call back in the AST for better errors unless we're trying
+      // to ignore multiple error messages (in which case we hope for a
+      // successful compilation).
+      if (fatalErrorsEncountered() && !inGenerousResolutionForErrors() && !fIgnoreNilabilityErrors) {
         retval->getStmtExpr()->insertBefore(call);
       }
     }

--- a/test/classes/nilability/multiple-errors.1.good
+++ b/test/classes/nilability/multiple-errors.1.good
@@ -1,13 +1,32 @@
-multiple-errors.chpl:16: In function 'main':
-multiple-errors.chpl:18: error: unresolved call 'borrowed C?.foo()'
-multiple-errors.chpl:6: note: this candidate did not match: C.foo()
-multiple-errors.chpl:18: note: because method call receiver with type borrowed C?
-multiple-errors.chpl:6: note: is passed to formal 'this: borrowed C'
-multiple-errors.chpl:19: error: unresolved call 'borrowed C?.bar()'
-multiple-errors.chpl:9: note: this candidate did not match: C.bar()
-multiple-errors.chpl:19: note: because method call receiver with type borrowed C?
-multiple-errors.chpl:9: note: is passed to formal 'this: borrowed C'
-multiple-errors.chpl:20: error: unresolved call 'baz(borrowed C?)'
-multiple-errors.chpl:12: note: this candidate did not match: baz(arg: C)
-multiple-errors.chpl:20: note: because call actual argument #1 with type borrowed C?
-multiple-errors.chpl:12: note: is passed to formal 'arg: C'
+multiple-errors.chpl:39: In function 'main':
+multiple-errors.chpl:41: error: unresolved call 'borrowed C?.foo()'
+multiple-errors.chpl:14: note: this candidate did not match: C.foo()
+multiple-errors.chpl:41: note: because method call receiver with type borrowed C?
+multiple-errors.chpl:14: note: is passed to formal 'this: borrowed C'
+multiple-errors.chpl:42: error: unresolved call 'borrowed C?.bar()'
+multiple-errors.chpl:17: note: this candidate did not match: C.bar()
+multiple-errors.chpl:42: note: because method call receiver with type borrowed C?
+multiple-errors.chpl:17: note: is passed to formal 'this: borrowed C'
+multiple-errors.chpl:24: note: candidates are: bar()
+multiple-errors.chpl:43: error: unresolved call 'baz(borrowed C?)'
+multiple-errors.chpl:20: note: this candidate did not match: baz(arg: C)
+multiple-errors.chpl:43: note: because call actual argument #1 with type borrowed C?
+multiple-errors.chpl:20: note: is passed to formal 'arg: C'
+multiple-errors.chpl:29: In function 'testInit':
+multiple-errors.chpl:32: error: unresolved call 'R.init(borrowed C?)'
+multiple-errors.chpl:6: note: this candidate did not match: R.init(c: borrowed C)
+multiple-errors.chpl:32: note: because call actual argument #1 with type borrowed C?
+multiple-errors.chpl:7: note: is passed to formal 'in c: borrowed C'
+multiple-errors.chpl:33: error: unresolved call 'R.init(borrowed C?)'
+multiple-errors.chpl:6: note: this candidate did not match: R.init(c: borrowed C)
+multiple-errors.chpl:33: note: because call actual argument #1 with type borrowed C?
+multiple-errors.chpl:7: note: is passed to formal 'in c: borrowed C'
+multiple-errors.chpl:34: error: unresolved call 'R.init(borrowed C?)'
+multiple-errors.chpl:6: note: this candidate did not match: R.init(c: borrowed C)
+multiple-errors.chpl:34: note: because call actual argument #1 with type borrowed C?
+multiple-errors.chpl:7: note: is passed to formal 'in c: borrowed C'
+multiple-errors.chpl:24: In function 'bar':
+multiple-errors.chpl:26: error: unresolved call 'R.init(borrowed C?)'
+multiple-errors.chpl:6: note: this candidate did not match: R.init(c: borrowed C)
+multiple-errors.chpl:26: note: because call actual argument #1 with type borrowed C?
+multiple-errors.chpl:7: note: is passed to formal 'in c: borrowed C'

--- a/test/classes/nilability/multiple-errors.2.good
+++ b/test/classes/nilability/multiple-errors.2.good
@@ -1,16 +1,39 @@
-multiple-errors.chpl:16: In function 'main':
-multiple-errors.chpl:18: error: unresolved call 'borrowed C?.foo()'
-multiple-errors.chpl:6: note: this candidate did not match: C.foo()
-multiple-errors.chpl:18: note: because method call receiver with type borrowed C?
-multiple-errors.chpl:6: note: is passed to formal 'this: borrowed C'
-multiple-errors.chpl:19: error: unresolved call 'borrowed C?.bar()'
-multiple-errors.chpl:9: note: this candidate did not match: C.bar()
-multiple-errors.chpl:19: note: because method call receiver with type borrowed C?
-multiple-errors.chpl:9: note: is passed to formal 'this: borrowed C'
-multiple-errors.chpl:20: error: unresolved call 'baz(borrowed C?)'
-multiple-errors.chpl:12: note: this candidate did not match: baz(arg: C)
-multiple-errors.chpl:20: note: because call actual argument #1 with type borrowed C?
-multiple-errors.chpl:12: note: is passed to formal 'arg: C'
+multiple-errors.chpl:39: In function 'main':
+multiple-errors.chpl:41: error: unresolved call 'borrowed C?.foo()'
+multiple-errors.chpl:14: note: this candidate did not match: C.foo()
+multiple-errors.chpl:41: note: because method call receiver with type borrowed C?
+multiple-errors.chpl:14: note: is passed to formal 'this: borrowed C'
+multiple-errors.chpl:42: error: unresolved call 'borrowed C?.bar()'
+multiple-errors.chpl:17: note: this candidate did not match: C.bar()
+multiple-errors.chpl:42: note: because method call receiver with type borrowed C?
+multiple-errors.chpl:17: note: is passed to formal 'this: borrowed C'
+multiple-errors.chpl:24: note: candidates are: bar()
+multiple-errors.chpl:43: error: unresolved call 'baz(borrowed C?)'
+multiple-errors.chpl:20: note: this candidate did not match: baz(arg: C)
+multiple-errors.chpl:43: note: because call actual argument #1 with type borrowed C?
+multiple-errors.chpl:20: note: is passed to formal 'arg: C'
+multiple-errors.chpl:29: In function 'testInit':
+multiple-errors.chpl:32: error: unresolved call 'R.init(borrowed C?)'
+multiple-errors.chpl:6: note: this candidate did not match: R.init(c: borrowed C)
+multiple-errors.chpl:32: note: because call actual argument #1 with type borrowed C?
+multiple-errors.chpl:7: note: is passed to formal 'in c: borrowed C'
+multiple-errors.chpl:33: error: unresolved call 'R.init(borrowed C?)'
+multiple-errors.chpl:6: note: this candidate did not match: R.init(c: borrowed C)
+multiple-errors.chpl:33: note: because call actual argument #1 with type borrowed C?
+multiple-errors.chpl:7: note: is passed to formal 'in c: borrowed C'
+multiple-errors.chpl:34: error: unresolved call 'R.init(borrowed C?)'
+multiple-errors.chpl:6: note: this candidate did not match: R.init(c: borrowed C)
+multiple-errors.chpl:34: note: because call actual argument #1 with type borrowed C?
+multiple-errors.chpl:7: note: is passed to formal 'in c: borrowed C'
+multiple-errors.chpl:24: In function 'bar':
+multiple-errors.chpl:26: error: unresolved call 'R.init(borrowed C?)'
+multiple-errors.chpl:6: note: this candidate did not match: R.init(c: borrowed C)
+multiple-errors.chpl:26: note: because call actual argument #1 with type borrowed C?
+multiple-errors.chpl:7: note: is passed to formal 'in c: borrowed C'
 foo({x = 0})
 bar({x = 0})
 baz({x = 0})
+created R: (c = {x = 42})
+created R: (c = {x = 42})
+created R: (c = {x = 42})
+created R: (c = {x = 123})

--- a/test/classes/nilability/multiple-errors.chpl
+++ b/test/classes/nilability/multiple-errors.chpl
@@ -3,6 +3,14 @@ module M {
     var x: int;
   }
 
+  record R {
+    var c : borrowed C;
+
+    proc postinit() {
+      writeln("created R: ", this);
+    }
+  }
+
   proc C.foo() {
     writeln("foo(", this, ")");
   }
@@ -13,10 +21,27 @@ module M {
     writeln("baz(", arg, ")");
   }
 
+  proc bar() {
+    var c : borrowed C? = (new owned C(123)).borrow();
+    var x = new R(c);
+  }
+
+  proc testInit() {
+    var c : borrowed C? = (new owned C(42)).borrow();
+
+    var x = new R(c);
+    var y = new R(c);
+    var z = new R(c);
+
+    bar();
+  }
+
   proc main() {
     var a: borrowed C? = (new owned C()).borrow();
     a.foo();
     a.bar();
     baz(a);
+
+    testInit();
   }
 }


### PR DESCRIPTION
This PR builds on the work in #13941 and allows for multiple fatal errors when incompatible nilability is encountered when resolving an initializer. When an initializer call fails to resolve, the compiler will try to resolve the call again while being more flexible with nilability rules and proceed with compilation. When the ``--ignore-nilability-errors`` flag is thrown these errors will be forgotten and the program should be compiled successfully.

Testing:
- [x] local + futures
- [x] gasnet + futures