### PR TITLE
Update specifications to include the bytes type

### DIFF
--- a/spec/Conversions.tex
+++ b/spec/Conversions.tex
@@ -216,8 +216,8 @@ Such conversion does not change the value of the expression.
 \index{conversions!numeric}
 \index{conversions!explicit!numeric}
 
-Explicit conversions are allowed from any numeric type, boolean, or
-string to any other numeric type, boolean, or string.  
+Explicit conversions are allowed from any numeric type or boolean to bytes or
+string, and vice-versa.
 
 % A valid \chpl{bool} value behaves like a single unsigned bit.  
 When a \chpl{bool} is converted to a \chpl{bool}, \chpl{int}
@@ -311,7 +311,7 @@ part of the resulting complex value.
 \index{conversions!explicit!enumeration}
 
 Explicit conversions are allowed from any enumerated type to any
-\chpl{string} and vice-versa, and include \chpl{param} conversions.
+\chpl{bytes} or \chpl{string} and vice-versa, and include \chpl{param} conversions.
 For enumerated types that are either concrete or semi-concrete
 (\rsec{Enumerated_Types}), conversions are supported between the
 enum's constants and any numeric type or \chpl{bool},
@@ -332,8 +332,8 @@ When the target type is \chpl{bool}, the value is first converted to its
 underlying integer type.  If the result is zero, the value of the \chpl{bool}
 is \chpl{false}; otherwise, it is \chpl{true}.
 
-When the target type is \chpl{string}, the value becomes the name of the
-enumerator.  % in the execution character set.
+When the target type is \chpl{bytes} or \chpl{string}, the value becomes the
+name of the enumerator.  % in the execution character set.
 
 When the source type is \chpl{bool}, enumerators corresponding to the values 0
 and 1 in the underlying integer type are selected, corresponding to input values
@@ -352,8 +352,9 @@ target type's underlying integer type.
 The conversion from \chpl{complex} and \chpl{imag} types to an enumerated type is not
 permitted.
 
-When the source type is string, the enumerator whose name matches value of the input
-string is selected.  If no such enumerator exists, a runtime error occurs.
+When the source type is \chpl{bytes} or \chpl{string}, the enumerator whose name
+matches value of the input is selected.  If no such enumerator exists, a runtime
+error occurs.
 
 \subsection{Explicit Class Conversions}
 \label{Explicit_Class_Conversions}

--- a/spec/Conversions.tex
+++ b/spec/Conversions.tex
@@ -333,7 +333,7 @@ underlying integer type.  If the result is zero, the value of the \chpl{bool}
 is \chpl{false}; otherwise, it is \chpl{true}.
 
 When the target type is \chpl{bytes} or \chpl{string}, the value becomes the
-name of the enumerator.  % in the execution character set.
+name of the enumerator.
 
 When the source type is \chpl{bool}, enumerators corresponding to the values 0
 and 1 in the underlying integer type are selected, corresponding to input values
@@ -353,8 +353,8 @@ The conversion from \chpl{complex} and \chpl{imag} types to an enumerated type i
 permitted.
 
 When the source type is \chpl{bytes} or \chpl{string}, the enumerator whose name
-matches value of the input is selected.  If no such enumerator exists, a runtime
-error occurs.
+matches value of the input is selected.  If no such enumerator exists, an
+\chpl{IllegalArgumentError} is thrown.
 
 \subsection{Explicit Class Conversions}
 \label{Explicit_Class_Conversions}
@@ -443,6 +443,16 @@ to an unstridable range type, changing the stride to 1 in the process.
 
 An expression of stridable domain type can be explicitly converted
 to an unstridable domain type, changing all strides to 1 in the process.
+
+\subsection{Explicit String to Bytes Conversions}
+\label{Explicit_String_to_Bytes_Conversions}
+\index{conversions!string to bytes}
+\index{conversions!explicit!string to bytes}
+
+An expression of \chpl{string} type can be explicitly converted to a
+\chpl{bytes}. However, the reverse is not possible as a \chpl{bytes} can contain
+arbitrary bytes. Instead, \chpl{bytes.decode()} method should be used to produce
+a \chpl{string} from a \chpl{bytes}.
 
 \subsection{Explicit Type to String Conversions}
 \label{Explicit_Type_to_String_Conversions}

--- a/spec/Expressions.tex
+++ b/spec/Expressions.tex
@@ -63,6 +63,7 @@ literal-expression:
   real-literal
   imaginary-literal
   string-literal
+  bytes-literal
   range-literal
   domain-literal
   array-literal

--- a/spec/Lexical_Structure.tex
+++ b/spec/Lexical_Structure.tex
@@ -21,8 +21,8 @@ another comment delimited by {\tt /*} and {\tt */}
 
 Comments, including the characters that delimit them, do not affect
 the behavior of the program (except in delimiting tokens).  If the
-delimiters that start the comments appear within a string literal,
-they do not start a comment but rather are part of the string literal.
+delimiters that start the comments appear within a bytes or string literal,
+they do not start a comment but rather are part of the bytes or string literal.
 
 \begin{example}
 The following program makes use of both forms of comment:
@@ -132,6 +132,7 @@ bool
 borrowed
 break
 by
+bytes
 catch
 class
 cobegin
@@ -141,8 +142,8 @@ config
 const
 continue
 defer
-delete
 \end{chapel} & \begin{chapel}
+delete
 dmapped
 do
 domain
@@ -456,6 +457,34 @@ A string literal can be either interpreted or uninterpreted.
 string-literal:
   interpreted-string-literal
   uninterpreted-string-literal
+\end{syntax}
+
+\pagebreak
+Interpreted bytes literals are designated by the following syntax:
+\begin{syntax}
+interpreted-bytes-literal:
+  b" double-quote-delimited-characters[OPT] "
+  b' single-quote-delimited-characters[OPT] '
+\end{syntax}
+
+Uninterpreted bytes literals are designated by the following syntax:
+\begin{syntax}
+uninterpreted-bytes-literal:
+  b""" uninterpreted-double-quote-delimited-characters """
+  b''' uninterpreted-single-quote-delimited-characters '''
+\end{syntax}
+
+Uninterpreted bytes literals do not interpret their contents, so for
+example \chpl{b"""$\backslash$n"""} is not a newline, but rather two
+characters `$\backslash$' and `n'.  Uninterpreted bytes literals may
+span multiple lines and the literal newline characters will be
+included in the bytes.
+
+A bytes literal can be either interpreted or uninterpreted.
+\begin{syntax}
+bytes-literal:
+  interpreted-bytes-literal
+  uninterpreted-bytes-literal
 \end{syntax}
 
 \subsection{Operators and Punctuation}

--- a/spec/Procedures.tex
+++ b/spec/Procedures.tex
@@ -547,6 +547,7 @@ The following table summarizes what these abstract intents mean for each type:
   \chpl{sync}    & \chpl{const ref}    & \chpl{ref} & \\
 \hline
   \chpl{string}  & \chpl{const ref}    & \chpl{const ref} & \\
+  \chpl{bytes}  & \chpl{const ref}    & \chpl{const ref} & \\
   \chpl{record}  & \chpl{const ref}    & \chpl{const ref}
    & see \hyperref[Default_Intent_for_Arrays_and_Record_this]{"Default Intent for Arrays and Record this"} \\
   \chpl{union}   & \chpl{const ref}    & \chpl{const ref} & \\

--- a/spec/Types.tex
+++ b/spec/Types.tex
@@ -246,17 +246,11 @@ and \chpl{2.72} respectively.
 \index{string@\chpl{string}}
 \index{types!string@\chpl{string}}
 
-Strings are a primitive type designated by the symbol \chpl{string}
-comprised of multibyte characters (normally UTF-8).  Their length is unbounded.
-
+Strings are a primitive type designated by the symbol \chpl{string} comprised of
+Unicode characters in UTF-8 encoding.  Their length is unbounded.
 
 \begin{openissue}
 There is an expectation of future support for fixed-length strings.
-\end{openissue}
-
-\begin{openissue}
-There is an expectation of future support for different character
-sets, possibly including internationalization.
 \end{openissue}
 
 \subsection{The Bytes Type}
@@ -265,11 +259,7 @@ sets, possibly including internationalization.
 \index{types!bytes@\chpl{bytes}}
 
 Bytes is a primitive type designated by the symbol \chpl{bytes} comprised of
-arbitrary bytes. Methods on bytes that interpret the data as characters assume
-that the bytes are ASCII characters.
-    
-Bytes are immutable in-place and their length is unbounded.
-
+arbitrary bytes. Bytes are immutable in-place and their length is unbounded.
 
 \begin{openissue}
 There is an expectation of future support for mutable bytes.

--- a/spec/Types.tex
+++ b/spec/Types.tex
@@ -51,7 +51,7 @@ These statements are defined in Sections \rsec{Enumerated_Types},
 
 The concrete primitive types are: \chpl{void}, \chpl{nothing}, \chpl{bool},
 \chpl{int}, \chpl{uint}, \chpl{real}, \chpl{imag}, \chpl{complex},
-and \chpl{string}.  They are defined in this section.
+\chpl{string} and \chpl{bytes}.  They are defined in this section.
 
 In addition, there are several generic primitive types that are described
 in~\rsec{Built_in_Generic_types}.
@@ -68,6 +68,7 @@ primitive-type:
   `imag' primitive-type-parameter-part[OPT]
   `complex' primitive-type-parameter-part[OPT]
   `string'
+  `bytes'
   `enum'
   `record'
   `class'
@@ -258,6 +259,21 @@ There is an expectation of future support for different character
 sets, possibly including internationalization.
 \end{openissue}
 
+\subsection{The Bytes Type}
+\label{The_Bytes_Type}
+\index{bytes@\chpl{bytes}}
+\index{types!bytes@\chpl{bytes}}
+
+Bytes is a primitive type designated by the symbol \chpl{bytes} comprised of
+arbitrary bytes. Methods on bytes that interpret the data as characters assume
+that the bytes are ASCII characters.
+    
+Bytes are immutable in-place and their length is unbounded.
+
+
+\begin{openissue}
+There is an expectation of future support for mutable bytes.
+\end{openissue}
 
 \section{Enumerated Types}
 \label{Enumerated_Types}

--- a/spec/Variables.tex
+++ b/spec/Variables.tex
@@ -131,6 +131,7 @@ are as follows:
 {\tt imag(*)} & {\tt 0.0i} \\
 {\tt complex(*)} & {\tt 0.0 + 0.0i} \\
 {\tt string} & {\tt ""} \\
+{\tt bytes} & {\tt b""} \\
 enums & first enum constant \\
 classes & {\tt nil} \\
 records & default constructed record \\

--- a/spec/chapel_listing.tex
+++ b/spec/chapel_listing.tex
@@ -2,7 +2,7 @@
   {
     morekeywords={
       align, as, atomic,
-      begin, bool, borrowed, break, by,
+      begin, bool, borrowed, break, by, bytes
       catch, class, cobegin, coforall, complex, config, const, continue,
       defer, delete, dmapped, do, domain,
       else, enum, except, export, extern,

--- a/spec/collect_syntax.pl
+++ b/spec/collect_syntax.pl
@@ -101,6 +101,7 @@ sub get_used_prefixes {
         s/\[OPT\]//g;
         s/^.*://g;
         s/one\ of//g;
+        s/b[\"\']//g;
         s/[^\-\w\ ]//g;
         s/\s-/\ /g;
         s/\s+/\ /g;


### PR DESCRIPTION
This PR updates the language specifications to include changes related to the
bytes type:

- `bytes` type itself
- `bytes` keyword
- `bytes` literals
