### PR TITLE
Fix HDF5 module to use explicit 'use' statements for HaltWrappers

### DIFF
--- a/modules/packages/HDF5.chpl
+++ b/modules/packages/HDF5.chpl
@@ -3898,6 +3898,7 @@ module HDF5 {
    */
   class HDF5Preprocessor {
     proc preprocess(A: []) {
+      use HaltWrappers only ;
       HaltWrappers.pureVirtualMethodHalt();
     }
   }


### PR DESCRIPTION
While making sure arkouda still compiled against master, I found that HDF5 didn't
include a now-necessary `use HaltWrappers` now that PR #13930 is merged.
Apparently HDF5 is not tested in nightly testing...  :'(