### PR TITLE
Document isCoercible, fix isSubtype docs

### DIFF
--- a/compiler/AST/primitive.cpp
+++ b/compiler/AST/primitive.cpp
@@ -807,6 +807,7 @@ initPrimitive() {
   prim_def(PRIM_IS_PROPER_SUBTYPE, "is_proper_subtype", returnInfoBool);
   // accepts two arguments: A class/record type expression and a param string for the field name
   prim_def(PRIM_IS_BOUND, "is bound", returnInfoBool);
+  // PRIM_IS_COERCIBLE arguments are (source type, target type)
   prim_def(PRIM_IS_COERCIBLE, "is_coercible", returnInfoBool);
   // PRIM_CAST arguments are (type to cast to, value to cast)
   prim_def(PRIM_CAST, "cast", returnInfoCast, false, true);

--- a/modules/internal/UtilMisc_forDocs.chpl
+++ b/modules/internal/UtilMisc_forDocs.chpl
@@ -130,11 +130,11 @@ module UtilMisc_forDocs {
     __primitive("chpl_exit_any", status);
   }
 
-  /* Returns `true` if the type `from` is coercible to the type `super`,
+  /* Returns `true` if the type `from` is coercible to the type `to`,
      or if ``isSubtype(from, to)`` would return `true`.
    */
   proc isCoercible(type from, type to) param {
-    __primitive("is_coercible", from, to);
+    return __primitive("is_coercible", from, to);
   }
 
   /* Returns `true` if the type `sub` is a subtype of the type `super`.
@@ -148,7 +148,7 @@ module UtilMisc_forDocs {
      ``a <= b`` or ``b >= a``.
      */
   proc isSubtype(type sub, type super) param {
-    __primitive("is_subtype", super, sub);
+    return __primitive("is_subtype", super, sub);
   }
 
   /* Similar to :proc:`isSubtype` but returns `false` if
@@ -158,7 +158,7 @@ module UtilMisc_forDocs {
      as ``a < b`` or ``b > a``.
      */
   proc isProperSubtype(type sub, type super) param {
-    __primitive("is_proper_subtype", super, sub);
+    return __primitive("is_proper_subtype", super, sub);
   }
 
   /* :returns: isProperSubtype(a,b) */

--- a/modules/internal/UtilMisc_forDocs.chpl
+++ b/modules/internal/UtilMisc_forDocs.chpl
@@ -130,13 +130,19 @@ module UtilMisc_forDocs {
     __primitive("chpl_exit_any", status);
   }
 
+  /* Returns `true` if the type `from` is coercible to the type `super`,
+     or if ``isSubtype(from, to)`` would return `true`.
+   */
+  proc isCoercible(type from, type to) param {
+    __primitive("is_coercible", from, to);
+  }
+
   /* Returns `true` if the type `sub` is a subtype of the type `super`.
      In particular, returns `true` in any of these cases:
 
        * `sub` is the same type as `super`
        * `sub` is an instantiation of a generic type `super`
        * `sub` is a class type inheriting from `super`
-       * `sub` is a type that coerces to `super`
 
      Note that ``isSubtype(a,b)`` can also be written as
      ``a <= b`` or ``b >= a``.


### PR DESCRIPTION
Add isCoercible to the UtilMisc_forDocs and fix isSubtype docs.
Add a comment to primitive.cpp describing arguments for PRIM_IS_COERCIBLE.

Reviewed by @benharsh - thanks!