### PR TITLE
Update specification

### DIFF
--- a/spec/Classes.tex
+++ b/spec/Classes.tex
@@ -168,6 +168,13 @@ refers to.
   probably be needed.
 \end{future}
 
+\subsection{Nilable Classes}
+\label{Nilable_Classes}
+
+This section is forthcoming.
+
+\label{Methods_On_Nilable_In_Prototype_Modules}
+
 \subsection{Class Types}
 \label{Class_Types}
 \index{classes!types}
@@ -200,16 +207,8 @@ A basic class type, including a generic class type that is not
 fully specified, may appear in the inheritance lists
 of other class declarations.
 
-If no memory management strategy is indicated, \chpl{borrowed} will be
-used.
-
-\begin{rationale}
-  \chpl{borrowed} is the default memory management strategy for a class
-  type because there are likely to be more variables referring to a class
-  instance than managing its memory. A further advantage of this default
-  is that \chpl{borrowed}, along with \chpl{unmanaged}, has minimal
-  performance overhead.
-\end{rationale}
+If no memory management strategy is indicated, the class will be
+considered to have generic management.
 
 The memory management strategies have the following meaning:
 
@@ -236,6 +235,41 @@ The memory management strategies have the following meaning:
     it explicitly to reclaim its memory.
 
 \end{itemize}
+
+It is an error to apply more than one memory management strategy to a
+class type. However, in some cases, generic code needs to compute a
+variant of the class type using a different memory management strategy.
+Casts from the class type to a different memory management strategy
+are available for this purpose (see~\rsec{Explicit_Class_Conversions}).
+
+\begin{chapelexample}{duplicate-management.chpl}
+\begin{chapel}
+class C { }
+var x: borrowed unmanaged C;
+\end{chapel}
+\begin{chapelpost}
+\end{chapelpost}
+\begin{chapeloutput}
+duplicate-management.chpl:2: error: Type expression uses multiple class kinds: borrowed unmanaged
+\end{chapeloutput}
+\end{chapelexample}
+
+\begin{chapelexample}{changing-management.chpl}
+\begin{chapel}
+class C { }
+type borrowedC = borrowed C;
+type ownedC = (borrowedC:owned);
+\end{chapel}
+\begin{chapelpost}
+writeln(borrowedC:string);
+writeln(ownedC:string);
+\end{chapelpost}
+\begin{chapeloutput}
+borrowed C
+owned C
+\end{chapeloutput}
+\end{chapelexample}
+
 
 
 \subsection{Class Values}

--- a/spec/Conversions.tex
+++ b/spec/Conversions.tex
@@ -374,7 +374,7 @@ destination type is nilable, as with \chpl{D?}, then the result will be
 
 In some cases a new variant of a class type needs to be computed that has
 different nilability or memory management strategy. Supposing that
-\chpl{T} represents a class type, then these casts compute a new type:
+\chpl{T} represents a class type, then these casts may compute a new type:
 
 \begin{itemize}
 \item
@@ -387,13 +387,13 @@ different nilability or memory management strategy. Supposing that
 \chpl{T:borrowed} - new management \chpl{borrowed}, nilability from \chpl{T}
 
 \item
-\chpl{T:unmanaged} - new management \chpl{borrowed}, nilability from \chpl{T}
+\chpl{T:unmanaged} - new management \chpl{unmanaged}, nilability from \chpl{T}
 
 \item
-\chpl{T:class} - non-nilable type with management from \chpl{T}
+\chpl{T:class} - non-nilable type with specific concrete or generic management from \chpl{T}
 
 \item
-\chpl{T:class?} - nilable type with management from \chpl{T}
+\chpl{T:class?} - nilable type with specific concrete or generic management from \chpl{T}
 
 \item
 \chpl{T:owned class} - non-nilable type with \chpl{owned} management

--- a/spec/Conversions.tex
+++ b/spec/Conversions.tex
@@ -364,10 +364,58 @@ An expression of static class type \chpl{C} can be explicitly
 converted to a class type \chpl{D} provided that \chpl{C} is derived
 from \chpl{D} or \chpl{D} is derived from \chpl{C}.
 
-When at run time the source expression refers to an instance of
-\chpl{D} or it subclass, its value is not changed.
-Otherwise, or when the source expression is \chpl{nil},
-the result of the conversion is \chpl{nil}.
+When at run time the source expression refers to an instance of \chpl{D}
+or it subclass, its value is not changed.  Otherwise, the cast fails and
+the result depends on whether or not the destination type is nilable. If
+the cast fails and the destination type is not nilable, the cast
+expression will throw a \chpl{classCastError}. If the cast fails and the
+destination type is nilable, as with \chpl{D?}, then the result will be
+\chpl{nil}.
+
+In some cases a new variant of a class type needs to be computed that has
+different nilability or memory management strategy. Supposing that
+\chpl{T} represents a class type, then these casts compute a new type:
+
+\begin{itemize}
+\item
+\chpl{T:owned} - new management is \chpl{owned}, nilability from \chpl{T}
+
+\item
+\chpl{T:shared} - new management \chpl{shared}, nilability from \chpl{T}
+
+\item
+\chpl{T:borrowed} - new management \chpl{borrowed}, nilability from \chpl{T}
+
+\item
+\chpl{T:unmanaged} - new management \chpl{borrowed}, nilability from \chpl{T}
+
+\item
+\chpl{T:class} - non-nilable type with management from \chpl{T}
+
+\item
+\chpl{T:class?} - nilable type with management from \chpl{T}
+
+\item
+\chpl{T:owned class} - non-nilable type with \chpl{owned} management
+\item
+\chpl{T:owned class?} - nilable type with \chpl{owned} management
+
+\item
+\chpl{T:shared class} - non-nilable type with \chpl{shared} management
+\item
+\chpl{T:shared class?} - nilable type with \chpl{shared} management
+
+\item
+\chpl{T:borrowed class} - non-nilable type with \chpl{borrowed} management
+\item
+\chpl{T:borrowed class?} - nilable type with \chpl{borrowed} management
+
+\item
+\chpl{T:unmanaged class} - non-nilable type with \chpl{unmanaged} management
+\item
+\chpl{T:unmanaged class?} - nilable type with \chpl{unmanaged} management
+
+\end{itemize}
 
 \subsection{Explicit Record Conversions}
 \label{Explicit_Record_Conversions}

--- a/spec/Errors.tex
+++ b/spec/Errors.tex
@@ -1,0 +1,10 @@
+\sekshun{Error Handling}
+\label{Error_Handling}
+\index{errors}
+\index{error handling}
+\index{throw}
+\index{throws}
+\index{catch}
+\index{try}
+
+A description of error handling features in Chapel is forthcoming.

--- a/spec/Generics.tex
+++ b/spec/Generics.tex
@@ -247,14 +247,6 @@ arguments as well.  In the example above, the formal argument's type
 could also be specified as \chpl{Stack(?t)} in which case the
 symbol \chpl{t} is equivalent to \chpl{s.itemType}.
 
-\index{integral (generic type)@\chpl{integral} (generic type)}
-\index{numeric (generic type)@\chpl{numeric} (generic type)}
-\index{enumerated (generic type)@\chpl{enumerated} (generic type)}
-The types \chpl{integral}, \chpl{numeric} and \chpl{enumerated}
-are generic types that can only be instantiated with, respectively, the
-signed and unsigned integral types, all of the numeric types, and
-all enumerated types.
-
 Note that generic types which have default values for all of their
 generic fields, \emph{e.g. range}, are not generic when simply
 specified and require a query to mark the argument as generic.  For
@@ -480,12 +472,27 @@ Generic types comprise built-in generic types, generic classes, and
 generic records.
 
 \subsubsection{Built-in Generic Types}
-There are currently 3 built-in generic types:
-\begin{itemize}
-  \item \chpl{enum} means any enum type
-  \item \chpl{record} means any record type
-  \item \chpl{class} means any class type.
-\end{itemize}
+\label{Built_in_Generic_types}
+\index{integral (generic type)@\chpl{integral} (generic type)}
+\index{numeric (generic type)@\chpl{numeric} (generic type)}
+\index{enumerated (generic type)@\chpl{enumerated} (generic type)}
+\index{enum (generic type)@\chpl{enum} (generic type)}
+\index{class (generic type)@\chpl{class} (generic type)}
+\index{record (generic type)@\chpl{record} (generic type)}
+
+The types \chpl{integral}, \chpl{numeric} and \chpl{enum}
+are generic types that can only be instantiated with, respectively, the
+signed and unsigned integral types, all of the numeric types, and
+all enumerated types. The type \chpl{enumerated} is currently available
+as a synonym for \chpl{enum}.
+
+The type \chpl{record} can be instantiated with any record type, and
+the type \chpl{class} can be instantiated with any class type.
+
+The memory management strategies described in~\rsec{Class_Types}
+are also generic types that can be instantiated with any class using
+that memory management strategy. These include \chpl{owned} \chpl{shared}
+\chpl{borrowed} and \chpl{unmanaged}.
 
 Note that the \chpl{class} type can combine with \chpl{?}
 (see~\rsec{Nilable_Classes}) and with the management decorators
@@ -493,17 +500,42 @@ Note that the \chpl{class} type can combine with \chpl{?}
 specifying its type:
 
 \begin{itemize}
-  \item \chpl{class} means any class using any memory management strategy
-  \item \chpl{class?} means any class using any memory management
-    strategy but allows the \chpl{nil} value
-  \item \chpl{owned class} and \chpl{owned class?} indicate the
-    non-nilable and nilable owned variants
-  \item \chpl{shared class} and \chpl{shared class?} indicate the
-    non-nilable and nilable shared variants
-  \item \chpl{borrowed class} and \chpl{borrowed class?} indicate the
-    non-nilable and nilable borrowed variants
-  \item \chpl{unmanaged class} and \chpl{unmanaged class?} indicate the
-    non-nilable and nilable unmanaged variants
+\item
+\chpl{class} can instantiate with any non-nilable class using any
+memory management strategy
+
+\item
+\chpl{class?} can instantiate with any class using any memory managemeent
+strategy but will use the nilable variant of that class in an
+instantiation. When used as an argument type, a value of non-nilable class
+type will be implicitly converted to the nilable type on the call. As a
+result, in practice, this type can accept any class type.
+
+\item
+\chpl{owned} can instantiate with any \chpl{owned} class - taking the
+nilability from whatever it instantiated from.
+
+\item
+\chpl{owned class} can instantiate with any non-nilable \chpl{owned} class.
+
+\item
+\chpl{owned class?} can instantiate from any nilable \chpl{owned}
+class. As with \chpl{class?}, it can also instantiate from a
+non-nilable \chpl{owned} class, in which case a implicit conversion
+would occur in a call.
+
+\item
+\chpl{shared}, \chpl{shared class}, \chpl{shared class?} behave similarly
+to the above but with \chpl{shared} management strategy.
+
+\item
+\chpl{borrowed}, \chpl{borrowed class}, \chpl{borrowed class?} behave similarly
+to the above but with \chpl{borrowed} management strategy.
+
+\item
+\chpl{unmanaged}, \chpl{unmanaged class}, \chpl{unmanaged class?} behave similarly
+to the above but with \chpl{unmanaged} management strategy.
+
 \end{itemize}
 
 

--- a/spec/Generics.tex
+++ b/spec/Generics.tex
@@ -475,12 +475,44 @@ discussion.  Comments or questions are appreciated.
 \label{Generic_Types}
 \index{generics!types}
 \index{types!generic}
+
+Generic types comprise built-in generic types, generic classes, and
+generic records.
+
+\subsubsection{Built-in Generic Types}
+There are currently 3 built-in generic types:
+\begin{itemize}
+  \item \chpl{enum} means any enum type
+  \item \chpl{record} means any record type
+  \item \chpl{class} means any class type.
+\end{itemize}
+
+Note that the \chpl{class} type can combine with \chpl{?}
+(see~\rsec{Nilable_Classes}) and with the management decorators
+(see~\rsec{Class_Types}) to specify a particular variety of class without
+specifying its type:
+
+\begin{itemize}
+  \item \chpl{class} means any class using any memory management strategy
+  \item \chpl{class?} means any class using any memory management
+    strategy but allows the \chpl{nil} value
+  \item \chpl{owned class} and \chpl{owned class?} indicate the
+    non-nilable and nilable owned variants
+  \item \chpl{shared class} and \chpl{shared class?} indicate the
+    non-nilable and nilable shared variants
+  \item \chpl{borrowed class} and \chpl{borrowed class?} indicate the
+    non-nilable and nilable borrowed variants
+  \item \chpl{unmanaged class} and \chpl{unmanaged class?} indicate the
+    non-nilable and nilable unmanaged variants
+\end{itemize}
+
+
+\subsubsection{Generic Classes and Records}
 \index{generics!classes}
 \index{classes!generic}
 \index{generics!records}
 \index{records!generic}
 
-Generic types are generic classes and generic records.
 A class or record is generic if it contains one or more
 \index{generics!fields}
 \index{fields!generic}

--- a/spec/Generics.tex
+++ b/spec/Generics.tex
@@ -471,7 +471,7 @@ discussion.  Comments or questions are appreciated.
 Generic types comprise built-in generic types, generic classes, and
 generic records.
 
-\subsubsection{Built-in Generic Types}
+\subsection{Built-in Generic Types}
 \label{Built_in_Generic_types}
 \index{integral (generic type)@\chpl{integral} (generic type)}
 \index{numeric (generic type)@\chpl{numeric} (generic type)}
@@ -486,18 +486,17 @@ signed and unsigned integral types, all of the numeric types, and
 all enumerated types. The type \chpl{enumerated} is currently available
 as a synonym for \chpl{enum}.
 
-The type \chpl{record} can be instantiated with any record type, and
-the type \chpl{class} can be instantiated with any class type.
+The type \chpl{record} can be instantiated with any record type.
 
-The memory management strategies described in~\rsec{Class_Types}
-are also generic types that can be instantiated with any class using
-that memory management strategy. These include \chpl{owned} \chpl{shared}
-\chpl{borrowed} and \chpl{unmanaged}.
+The memory management strategies \chpl{owned}, \chpl{shared},
+\chpl{borrowed}, and \chpl{unmanaged} (see~\rsec{Class_Types})
+are also generic types that can be instantiated with any class
+using that memory management strategy. These types indiciate
+generic nilability.
 
-Note that the \chpl{class} type can combine with \chpl{?}
-(see~\rsec{Nilable_Classes}) and with the management decorators
-(see~\rsec{Class_Types}) to specify a particular variety of class without
-specifying its type:
+The types \chpl{class} and \chpl{class?}, on their own or
+in combination with memory management strategies, are also
+generic types. They can be instantiated as follows:
 
 \begin{itemize}
 \item
@@ -509,7 +508,8 @@ memory management strategy
 strategy but will use the nilable variant of that class in an
 instantiation. When used as an argument type, a value of non-nilable class
 type will be implicitly converted to the nilable type on the call. As a
-result, in practice, this type can accept any class type.
+result, a formal of type \chpl{class?} can accept an actual of any
+class type.
 
 \item
 \chpl{owned} can instantiate with any \chpl{owned} class - taking the
@@ -539,11 +539,15 @@ to the above but with \chpl{unmanaged} management strategy.
 \end{itemize}
 
 
-\subsubsection{Generic Classes and Records}
+\subsection{Generic Classes and Records}
 \index{generics!classes}
 \index{classes!generic}
 \index{generics!records}
 \index{records!generic}
+
+The remainder of this section \rsec{Generic_Types} specifies generic
+class and record types that are not built-in types
+(\rsec{Built_in_Generic_types}).
 
 A class or record is generic if it contains one or more
 \index{generics!fields}

--- a/spec/Lexical_Structure.tex
+++ b/spec/Lexical_Structure.tex
@@ -241,7 +241,6 @@ The following identifiers are keywords reserved for future use:
 lambda
 pragma
 primitive
-prototype
 \end{chapel} \\
 \begin{invisible}
 otherwise

--- a/spec/Modules.tex
+++ b/spec/Modules.tex
@@ -22,11 +22,14 @@ in~\rsec{Program_Execution}.
 A module is declared with the following syntax:
 \begin{syntax}
 module-declaration-statement:
-  privacy-specifier[OPT] `module' module-identifier block-statement
+  privacy-specifier[OPT] prototype-specifier[OPT] `module' module-identifier block-statement
 
 privacy-specifier:
   `private'
   `public'
+
+prototype-specifier:
+  `prototype'
 
 module-identifier:
   identifier
@@ -41,6 +44,26 @@ defined by its \sntx{privacy-specifier}~(\rsec{Visibility_Of_A_Module}).
 Module declaration statements must be top-level statements within a
 module.  A module that is declared within another module is called a
 nested module~(\rsec{Nested_Modules}).
+
+\section{Prototype Modules}
+\label{Prototype_Modules}
+\index{modules!prototype}
+
+Modules that are declared with the \chpl{prototype} keyword use relaxed
+rules for error handling and \chpl{nil} checking. These relaxed rules are
+appropriate for programs in the early stages of development but are not
+appropriate for libraries. In particular, within a \chpl{prototype} module:
+
+\begin{itemize}
+
+  \item errors that are not handled will terminate the program
+        (see~\rsec{Error_Handling})
+
+  \item methods on nilable class instances can be called - these will
+        implicitly convert to non-nilable class instances
+        (see~\rsec{Methods_On_Nilable_In_Prototype_Modules})
+
+\end{itemize}
 
 \section{Files and Implicit Modules}
 \label{Implicit_Modules}
@@ -84,7 +107,8 @@ declarations, the file itself is treated as the module declaration.
 In this case,
 \index{implicit modules}
 \index{modules!implicit}
-the module is implicit and takes its name from the base filename.  In
+the module is implicit. Implicit modules are always \chpl{prototype}
+modules. An implicit module takes its name from the base filename.  In
 particular, the module name is defined as the remaining string after
 removing the \chpl{.chpl} suffix and any path specification from the
 specified filename.  If the resulting name is not a legal Chapel
@@ -333,7 +357,8 @@ cannot be specified in a \sntx{limitation-clause} on their own.
 
 Module initialization occurs at program start-up.  All top-level
 statements in a module other than function and type declarations are
-executed during module initialization.
+executed during module initialization. Top-level modules and submodules
+that are not referred to will not be initialized.
 
 \begin{chapelexample}{init.chpl}
 In the code,

--- a/spec/Modules.tex
+++ b/spec/Modules.tex
@@ -357,8 +357,8 @@ cannot be specified in a \sntx{limitation-clause} on their own.
 
 Module initialization occurs at program start-up.  All top-level
 statements in a module other than function and type declarations are
-executed during module initialization. Top-level modules and submodules
-that are not referred to will not be initialized.
+executed during module initialization. Modules that are not referred to,
+including both top-level modules and submodules, will not be initialized.
 
 \begin{chapelexample}{init.chpl}
 In the code,

--- a/spec/Procedures.tex
+++ b/spec/Procedures.tex
@@ -537,10 +537,8 @@ The following table summarizes what these abstract intents mean for each type:
   \chpl{complex} & \chpl{const in}     & \chpl{const in}  & \\
   \chpl{range}   & \chpl{const in}     & \chpl{const in}  & \\
 \hline
-  \chpl{owned class}     & \chpl{const in}     & \chpl{in}
-   & see \hyperref[Default_Intent_for_owned_and_shared]{"Default Intent for owned and shared"} \\
-  \chpl{shared class}    & \chpl{const in}     & \chpl{in}
-   & see \hyperref[Default_Intent_for_owned_and_shared]{"Default Intent for owned and shared"} \\
+  \chpl{owned class}     & \chpl{const ref}     & \chpl{const ref} & \\
+  \chpl{shared class}    & \chpl{const ref}     & \chpl{const ref} & \\
   \chpl{borrowed class}  & \chpl{const in}     & \chpl{const in} & \\
   \chpl{unmanaged class} & \chpl{const in}     & \chpl{const in} & \\
 \hline

--- a/spec/Types.tex
+++ b/spec/Types.tex
@@ -385,9 +385,21 @@ in~\rsec{Classes}.  The class type can also contain type aliases and
 parameters.  Such a class is generic and is defined
 in~\rsec{Generic_Types}.
 
-A class type \chpl{C} has the variants \chpl{owned C}, \chpl{shared C},
-\chpl{borrowed C} (equivalent to \chpl{C}), and \chpl{unmanaged C}. These
-variants are discussed in~\rsec{Class_Types}.
+A class type \chpl{C} has several variants:
+\begin{itemize}
+  \item \chpl{C} and \chpl{C?}
+  \item \chpl{owned C} and \chpl{owned C?}
+  \item \chpl{shared C} and \chpl{shared C?}
+  \item \chpl{borrowed C} and \chpl{borrowed C?}
+  \item \chpl{unmanaged C} and \chpl{unmanaged C?}
+\end{itemize}
+
+The variants with a question mark, such as \chpl{owned C?}, can store
+\chpl{nil} (see~\rsec{Nilable_Classes}). The keywords \chpl{owned},
+\chpl{shared}, \chpl{borrowed}, and \chpl{unmanaged} indicate the memory
+management startegy used for the class. When none is specified, as with
+\chpl{C}, the class is considered to have generic memory management
+strategy. See~\rsec{Class_Types}.
 
 \subsection{Record Types}
 \label{Types_Record_Types}

--- a/spec/Types.tex
+++ b/spec/Types.tex
@@ -49,10 +49,12 @@ These statements are defined in Sections \rsec{Enumerated_Types},
 \label{Primitive_Types}
 \index{types!primitive}
 
-The primitive types are: \chpl{void}, \chpl{nothing}, \chpl{bool},
+The concrete primitive types are: \chpl{void}, \chpl{nothing}, \chpl{bool},
 \chpl{int}, \chpl{uint}, \chpl{real}, \chpl{imag}, \chpl{complex},
-and \chpl{string}.  They are defined
-in this section.
+and \chpl{string}.  They are defined in this section.
+
+In addition, there are several generic primitive types that are described
+in~\rsec{Built_in_Generic_types}.
 
 The primitive types are summarized by the following syntax:
 \begin{syntax}
@@ -66,6 +68,13 @@ primitive-type:
   `imag' primitive-type-parameter-part[OPT]
   `complex' primitive-type-parameter-part[OPT]
   `string'
+  `enum'
+  `record'
+  `class'
+  `owned'
+  `shared'
+  `unmanaged'
+  `borrowed'
 
 primitive-type-parameter-part:
   ( integer-parameter-expression )

--- a/spec/Types.tex
+++ b/spec/Types.tex
@@ -404,10 +404,11 @@ A class type \chpl{C} has several variants:
 \end{itemize}
 
 The variants with a question mark, such as \chpl{owned C?}, can store
-\chpl{nil} (see~\rsec{Nilable_Classes}). The keywords \chpl{owned},
-\chpl{shared}, \chpl{borrowed}, and \chpl{unmanaged} indicate the memory
-management startegy used for the class. When none is specified, as with
-\chpl{C}, the class is considered to have generic memory management
+\chpl{nil} (see~\rsec{Nilable_Classes}). Variants without a question mark
+cannot store \chpl{nil}. The keywords \chpl{owned}, \chpl{shared},
+\chpl{borrowed}, and \chpl{unmanaged} indicate the memory management
+startegy used for the class. When none is specified, as with \chpl{C} or
+\chpl{C?}, the class is considered to have generic memory management
 strategy. See~\rsec{Class_Types}.
 
 \subsection{Record Types}

--- a/spec/spec.tex
+++ b/spec/spec.tex
@@ -207,6 +207,8 @@ Seattle, WA 98164}
 \cleardoublepage
 \input{Methods}
 \cleardoublepage
+\input{Errors}
+\cleardoublepage
 \input{Tuples}
 \cleardoublepage
 \input{Classes}


### PR DESCRIPTION
This PR addresses the easier spec updates I need to do but leaves as
future work the nilable types section and error handling sections.
However it adds these sections so we can start referring to them.

* Adds Error Handling placeholder section
* Adds Nilable Classes placeholder section
* Updates for undecorated-class-is-generic, describe error for multiple
  memory management strategies, casting to replace it
* Updates for default intent for owned/shared being `const ref`
* Describes enum/record/class as type
* Describes prototype modules

Reviewed by @vasslitvinov - thanks!