### PR TITLE
Cleanup PR #13930

### DIFF
--- a/compiler/AST/UseStmt.cpp
+++ b/compiler/AST/UseStmt.cpp
@@ -516,8 +516,10 @@ ModuleSymbol* UseStmt::checkIfModuleNameMatches(const char* name) {
       }
     }
   } else {
-    // TODO: Need to handle matches against more general expressions here
-    // e.g. 'use M.N.O' should make 'O' available, I think
+    // It seems as though we'd need to handle matches against more general
+    // expressions here (e.g., 'use M.N.O'), yet I can't seem to construct
+    // an example that requires this.  I suppose it could be because we
+    // resolve such cases element-by-element rather than wholesale...
   }
   return NULL;
 }
@@ -554,6 +556,7 @@ bool UseStmt::skipSymbolSearch(const char* name, bool methodCall) const {
   } else if (except == true) {
     if (matchedNameOrConstructor(name) == true) {
       retval =  true;
+
     } else {
       retval = false;
     }

--- a/compiler/passes/ResolveScope.cpp
+++ b/compiler/passes/ResolveScope.cpp
@@ -500,14 +500,6 @@ Symbol* ResolveScope::lookup(UnresolvedSymExpr* usymExpr, bool isUse) const {
 Symbol* ResolveScope::lookupWithUses(UnresolvedSymExpr* usymExpr, bool isUse) const {
   const char* name   = usymExpr->unresolved;
   Symbol*     retval = lookupNameLocally(name, isUse);
-  // resolve references to ourself  TODO: is this still necessary?
-  /*
-  ModuleSymbol* thisMod = usymExpr->getModule();
-  if (retval == NULL && strcmp(name, thisMod->name) == 0) {
-    retval = thisMod;
-    printf("Got here\n");
-  }
-  */
 
   if (retval == NULL && mUseList.size() > 0) {
     UseList useList = mUseList;

--- a/compiler/passes/ResolveScope.cpp
+++ b/compiler/passes/ResolveScope.cpp
@@ -504,6 +504,7 @@ Symbol* ResolveScope::lookupWithUses(UnresolvedSymExpr* usymExpr, bool isUse) co
   ModuleSymbol* thisMod = usymExpr->getModule();
   if (retval == NULL && strcmp(name, thisMod->name) == 0) {
     retval = thisMod;
+    printf("Got here\n");
   }
 
   if (retval == NULL && mUseList.size() > 0) {

--- a/compiler/passes/ResolveScope.cpp
+++ b/compiler/passes/ResolveScope.cpp
@@ -501,11 +501,13 @@ Symbol* ResolveScope::lookupWithUses(UnresolvedSymExpr* usymExpr, bool isUse) co
   const char* name   = usymExpr->unresolved;
   Symbol*     retval = lookupNameLocally(name, isUse);
   // resolve references to ourself  TODO: is this still necessary?
+  /*
   ModuleSymbol* thisMod = usymExpr->getModule();
   if (retval == NULL && strcmp(name, thisMod->name) == 0) {
     retval = thisMod;
     printf("Got here\n");
   }
+  */
 
   if (retval == NULL && mUseList.size() > 0) {
     UseList useList = mUseList;

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -1676,7 +1676,9 @@ static void lookup(const char*           name,
       BaseAST* outerScope = getScope(scope);
       if (outerScope != NULL) {
         lookup(name, context, outerScope, visited, symbols);
-        // As a last ditch effort, see if this module's name happens to match
+        // As a last ditch effort, see if this module's name happens to match.
+        // This handles the case when we refer to the name of the module in
+        // which we are declared (e.g., `module M { ...M.xyz... }`
         if (symbols.size() == 0) {
           ModuleSymbol* thisMod = scope->getModule();
           if (strcmp(name, thisMod->name) == 0) {
@@ -1835,7 +1837,9 @@ static bool lookupThisScopeAndUses(const char*           name,
         } else {
           // we haven't found a match yet, so as a last resort, let's
           // check the names of the modules in the 'use' statements
-          // themselves...
+          // themselves...  This effectively places the module names at
+          // a scope just a bit further out than the one holding the
+          // symbols that they define.
           forv_Vec(UseStmt, use, *moduleUses) {
             if (use != NULL) {
               if (ModuleSymbol* modSym = use->checkIfModuleNameMatches(name)) {

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -200,7 +200,7 @@ static void addToSymbolTable() {
   // Extend the rootScope with every top-level definition
   for_alist(stmt, theProgram->block->body) {
     if (DefExpr* def = toDefExpr(stmt)) {
-      rootScope->extend(def->sym, /* isTopLevel= */ true); // TODO: test this
+      rootScope->extend(def->sym, /* isTopLevel= */ true);
     }
   }
 
@@ -263,6 +263,7 @@ static void scopeResolve(const AList&        alist,
 static void scopeResolve(ModuleSymbol*       module,
                          const ResolveScope* parent) {
   ResolveScope* scope = new ResolveScope(module, parent);
+
   scopeResolve(module->block->body, scope);
 }
 


### PR DESCRIPTION
This follows through on some code cleanup TODOs that I had in #13930 but couldn't get done before feature freeze.  The net result is to remove some unnecessary code (that had been necessary as the implementation of #13930 was evolving), to add/improve some comments, and to minimize some diffs against pre-#13930 master.