### PR TITLE
Suppress the twounions tests with Intel compilers

### DIFF
--- a/test/classes/bradc/unions/twounions.suppressif
+++ b/test/classes/bradc/unions/twounions.suppressif
@@ -1,0 +1,4 @@
+# this test currently fails with intel compilers. fixing it will take more
+# investigation, until then the test is suppressed with intel compilers
+CHPL_TARGET_COMPILER==cray-prgenv-intel
+CHPL_TARGET_COMPILER==intel


### PR DESCRIPTION
This test has been problematic recently with Intel backend compilers. Until we figure out
what is happening, this PR suppresses the test.