### PR TITLE
Convert AtomicObjects to use compareAndSwap instead of compareExchange

### DIFF
--- a/modules/packages/AtomicObjects.chpl
+++ b/modules/packages/AtomicObjects.chpl
@@ -77,7 +77,7 @@
   To make this more concrete, think of *A* and *B* both as a node in a linked list; 
   *T1* reads *A*, *T2* allocates a new node *B* and writes it to *L* and deletes *A*, 
   and *T3* allocates a new node which just so happens to be the same piece of memory that 
-  *A* had before and writes it to *L*. Atomic operations such the ``compareExchange`` 
+  *A* had before and writes it to *L*. Atomic operations such the ``compareAndSwap`` 
   will succeed despite the fact that the nodes are not the same as it will perform 
   the operation based on the virtual address.
 
@@ -97,7 +97,7 @@
     var a = atomicVar.readABA();
     var b = atomicVar.writeABA(obj2);
     atomicVar.writeABA(obj1);
-    assert(atomicVar.compareExchange(obj1, obj2) == false, "This should always fail!");
+    assert(atomicVar.compareAndSwap(obj1, obj2) == false, "This should always fail!");
 
   .. note::
 
@@ -525,11 +525,11 @@ prototype module AtomicObjects {
       return fromPointer(atomicVariable.read());
     }
 
-    proc compareExchange(expectedObj : objType?, newObj : objType?) : bool {
+    proc compareAndSwap(expectedObj : objType?, newObj : objType?) : bool {
       return atomicVariable.compareAndSwap(toPointer(expectedObj), toPointer(newObj));
     }
 
-    proc compareExchangeABA(expectedObj : ABA(objType?), newObj : objType?) : bool {
+    proc compareAndSwapABA(expectedObj : ABA(objType?), newObj : objType?) : bool {
       doABACheck();
       var ret : bool;
       on this {
@@ -542,8 +542,8 @@ prototype module AtomicObjects {
       return ret;
     }
 
-    proc compareExchangeABA(expectedObj : ABA(objType?), newObj : ABA(objType?)) : bool {
-      compareExchangeABA(expectedObj, newObj.getObject());
+    proc compareAndSwapABA(expectedObj : ABA(objType?), newObj : ABA(objType?)) : bool {
+      compareAndSwapABA(expectedObj, newObj.getObject());
     }
 
     proc write(newObj:objType?) {

--- a/modules/packages/EpochManager.chpl
+++ b/modules/packages/EpochManager.chpl
@@ -146,7 +146,7 @@ prototype module EpochManager {
         do {
           var oldHead = _head.readABA();
           _node.next = oldHead.getObject();
-        } while(!_head.compareExchangeABA(oldHead, _node));
+        } while(!_head.compareAndSwapABA(oldHead, _node));
       }
 
       iter these() : objType? {
@@ -219,7 +219,7 @@ prototype module EpochManager {
             return new unmanaged Node(objType?);
           }
           var newTop = n!.freeListNext;
-        } while (!_freeListHead.compareExchangeABA(oldTop, newTop));
+        } while (!_freeListHead.compareAndSwapABA(oldTop, newTop));
         n!.next.write(nil);
         n!.freeListNext = nil;
         return n!;
@@ -239,15 +239,15 @@ prototype module EpochManager {
           // Check if tail and next are consistent
           if (tail == curr_tail) {
             if (next_node == nil) {
-              if (curr_tail.next.compareExchangeABA(next, n)) {
+              if (curr_tail.next.compareAndSwapABA(next, n)) {
 
                 // Enqueue is done. Try to swing Tail to the inserted node
-                _tail.compareExchangeABA(curr_tail, n);
+                _tail.compareAndSwapABA(curr_tail, n);
                 break;
               }
             }
             else {
-              _tail.compareExchangeABA(curr_tail, next_node);
+              _tail.compareAndSwapABA(curr_tail, next_node);
             }
           }
         }
@@ -267,11 +267,11 @@ prototype module EpochManager {
             if (head_node == tail_node) {
               if (next_node == nil) then
                 return nil;
-              _tail.compareExchangeABA(curr_tail, next_node);
+              _tail.compareAndSwapABA(curr_tail, next_node);
             }
             else {
               var ret_val = next_node!.val;
-              if (_head.compareExchangeABA(curr_head, next_node)) {
+              if (_head.compareAndSwapABA(curr_head, next_node)) {
                 retireNode(head_node!);
                 return ret_val;
               }
@@ -288,7 +288,7 @@ prototype module EpochManager {
         do {
           var oldTop = _freeListHead.readABA();
           nextObj.freeListNext = oldTop.getObject();
-        } while (!_freeListHead.compareExchangeABA(oldTop, nextObj));
+        } while (!_freeListHead.compareAndSwapABA(oldTop, nextObj));
       }
 
       iter these() : objType {
@@ -365,7 +365,7 @@ prototype module EpochManager {
             return new unmanaged Node(obj);
           }
           var newTop = n.next;
-        } while (!_freeListHead.compareExchangeABA(oldTop, newTop));
+        } while (!_freeListHead.compareAndSwapABA(oldTop, newTop));
         n.val = obj;
         return n!;
       }
@@ -375,7 +375,7 @@ prototype module EpochManager {
         do {
           var oldTop = _freeListHead.readABA();
           nextObj.next = oldTop.getObject();
-        } while (!_freeListHead.compareExchangeABA(oldTop, nextObj));
+        } while (!_freeListHead.compareAndSwapABA(oldTop, nextObj));
       }
 
       proc pop() {

--- a/modules/packages/LockFreeQueue.chpl
+++ b/modules/packages/LockFreeQueue.chpl
@@ -134,13 +134,13 @@ prototype module LockFreeQueue {
         var curr_tail = _tail.read();
         var next = curr_tail.next.read();
         if (next == nil) {
-          if (curr_tail.next.compareExchange(next, n)) {
-            _tail.compareExchange(curr_tail, n);
+          if (curr_tail.next.compareAndSwap(next, n)) {
+            _tail.compareAndSwap(curr_tail, n);
             break;
           }
         }
         else {
-          _tail.compareExchange(curr_tail, next);
+          _tail.compareAndSwap(curr_tail, next);
         }
         chpl_task_yield();
       }
@@ -160,11 +160,11 @@ prototype module LockFreeQueue {
             var retval : objType?;
             return (false, retval);
           }
-          _tail.compareExchange(curr_tail, next_node);
+          _tail.compareAndSwap(curr_tail, next_node);
         }
         else {
           var ret_val = next_node.val;
-          if (_head.compareExchange(curr_head, next_node)) {
+          if (_head.compareAndSwap(curr_head, next_node)) {
             tok.deferDelete(curr_head);
             tok.unpin();
             return (true, ret_val);

--- a/modules/packages/LockFreeStack.chpl
+++ b/modules/packages/LockFreeStack.chpl
@@ -132,7 +132,7 @@ prototype module LockFreeStack {
         n.next = oldTop;
         if shouldYield then chpl_task_yield();
         shouldYield = true;
-      } while (!_top.compareExchange(oldTop, n));
+      } while (!_top.compareAndSwap(oldTop, n));
       tok.unpin();
     }
 
@@ -150,7 +150,7 @@ prototype module LockFreeStack {
         var newTop = oldTop.next;
         if shouldYield then chpl_task_yield();
         shouldYield = true;
-      } while (!_top.compareExchange(oldTop, newTop));
+      } while (!_top.compareAndSwap(oldTop, newTop));
       var retval = oldTop.val;
       tok.deferDelete(oldTop);
       tok.unpin();

--- a/test/library/packages/EpochManager/atomicObjects/atomicObjectsTest.chpl
+++ b/test/library/packages/EpochManager/atomicObjects/atomicObjectsTest.chpl
@@ -13,13 +13,13 @@ proc main() {
   var z = atomicObj.readABA();
   writeln(z);
   var w = new unmanaged C(2);
-  writeln(atomicObj.compareExchange(x, z.getObject()));
+  writeln(atomicObj.compareAndSwap(x, z.getObject()));
   writeln(atomicObj.read());
   writeln(atomicObj.readABA());
-  writeln(atomicObj.compareExchangeABA(z, w));
+  writeln(atomicObj.compareAndSwapABA(z, w));
   writeln(atomicObj.read());
   writeln(atomicObj.readABA());
-  writeln(atomicObj.compareExchange(w, x));
+  writeln(atomicObj.compareAndSwap(w, x));
   writeln(atomicObj.read());
   writeln(atomicObj.readABA());
   writeln(atomicObj.exchange(nil));
@@ -32,7 +32,7 @@ proc main() {
   var b = atomicObj.readABA();
 
   writeln(a==b);
-  atomicObj.compareExchangeABA(a, x);
+  atomicObj.compareAndSwapABA(a, x);
   writeln(a==b);
 
   var c = atomicObj.readABA();


### PR DESCRIPTION
Update AtomicObjects to match the new Chapel API (changed in https://github.com/chapel-lang/chapel/pull/13934)

This change was discussed a little in https://github.com/chapel-lang/chapel/issues/13836#issuecomment-526393263 