### PR TITLE
Fix regressions from deprecating adding to associative domain through array

### DIFF
--- a/test/optimizations/remoteValueForwarding/serialization/globals.chpl
+++ b/test/optimizations/remoteValueForwarding/serialization/globals.chpl
@@ -1,4 +1,4 @@
-use CommDiagnostics;
+use CommDiagnostics, Map;
 
 config const n = 10;
 
@@ -27,8 +27,7 @@ record Foo {
   }
 }
 
-var commStatsDom : domain(string);
-var commStats : [commStatsDom] [LocaleSpace] commDiagnostics;
+var commStats = new map(string, [LocaleSpace] commDiagnostics);
 
 proc start() {
   startCommDiagnostics();
@@ -73,7 +72,7 @@ proc main() {
     stop("begin-on");
   }
 
-  for (msg, dat) in zip(commStatsDom, commStats) {
+  for (msg, dat) in commStats.items() {
     const sep = "===== " + msg + " =====";
     writeln(sep);
     for (loc, dat) in zip(Locales, dat) {

--- a/test/optimizations/remoteValueForwarding/serialization/staticSize.chpl
+++ b/test/optimizations/remoteValueForwarding/serialization/staticSize.chpl
@@ -1,4 +1,4 @@
-use CommDiagnostics;
+use CommDiagnostics, Map;
 
 config const n = 10;
 
@@ -27,8 +27,7 @@ record Foo {
   }
 }
 
-var commStatsDom : domain(string);
-var commStats : [commStatsDom] [LocaleSpace] commDiagnostics;
+var commStats = new map(string, [LocaleSpace] commDiagnostics);
 
 proc start() {
   startCommDiagnostics();
@@ -68,7 +67,7 @@ proc main() {
   }
   stop("begin-on");
 
-  for (msg, dat) in zip(commStatsDom, commStats) {
+  for (msg, dat) in commStats.items() {
     const sep = "===== " + msg + " =====";
     writeln(sep);
     for (loc, dat) in zip(Locales, dat) {

--- a/tools/mason/MasonExternal.chpl
+++ b/tools/mason/MasonExternal.chpl
@@ -262,6 +262,10 @@ proc getExternalPackages(exDeps: unmanaged Toml) {
             
             var dependencies = getSpkgDependencies(fullSpec);
             const pkgInfo = getSpkgInfo(fullSpec, dependencies);
+
+            if !exDom.contains(name) then
+              exDom += name;
+
             exDepTree[name] = pkgInfo;
           }
         }


### PR DESCRIPTION
The remoteValueForwarding tests only run with CHPL_COMM != none so I missed
updating them. A mason test caught one more domain that needed to be updated
in Mason.