### PR TITLE
Update task/forall intents in spec; add overload sets technote

### DIFF
--- a/doc/rst/technotes/overloadSets.rst
+++ b/doc/rst/technotes/overloadSets.rst
@@ -8,7 +8,7 @@ The Chapel compiler provides an initial implementation of the
 Overload Sets feature. It is discussed in `CHIP 20
 <https://github.com/chapel-lang/chapel/blob/master/doc/rst/developer/chips/20.rst>`_
 as a solution to "hijacking" problems where program behavior can change
-unexpectedly when imported modules change.
+unexpectedly as libraries it uses change.
 
 An "overload set" is a group of functions with the same name declared
 in the same module. Overload sets checking is performed at each
@@ -17,8 +17,8 @@ while resolving this call are defined in the same module. See the
 "Function Resolution" section of the language spec for
 resolution-related terminology.
 
-Additionally, if the call resolves to "ref-pair" overloads,
-i.e. for ref, const-ref, and/or value return intent,
+Additionally, if the call resolves to return intent overloads,
+i.e. for ref, const-ref, and/or value return intents,
 these overloads must be defined in the same module.
 
 The current implementation does not report an error in the following cases:
@@ -46,8 +46,9 @@ to work around the overload set errors when they are undesirable.
 We are evaluating this feature and invite user feedback.
 Our open questions include:
 
-- Should an overload set contain only functions that are declared
-  in the same scope, or some other granularity than a module?
+- Should overload sets continue to consider only module scoping,
+  or should they be updated to differentiate, for example, between
+  scopes inside functions?
 
 - What should a "merge the overload sets" declaration look like?
 

--- a/doc/rst/technotes/overloadSets.rst
+++ b/doc/rst/technotes/overloadSets.rst
@@ -1,0 +1,58 @@
+.. _readme-overload-sets:
+
+======================
+Checking Overload Sets
+======================
+
+The Chapel compiler provides an initial implementation of the
+Overload Sets feature. It is discussed in `CHIP 20
+<https://github.com/chapel-lang/chapel/blob/master/doc/rst/developer/chips/20.rst>`_
+as a solution to "hijacking" problems where program behavior can change
+unexpectedly when imported modules change.
+
+An "overload set" is a group of functions with the same name declared
+in the same module. Overload sets checking is performed at each
+function call. It verifies that all candidate functions identified
+while resolving this call are defined in the same module. See the
+"Function Resolution" section of the language spec for
+resolution-related terminology.
+
+Additionally, if the call resolves to "ref-pair" overloads,
+i.e. for ref, const-ref, and/or value return intent,
+these overloads must be defined in the same module.
+
+The current implementation does not report an error in the following cases:
+
+- The best candidate is "more visible" than the other candidates.
+  That is, it shadows the other candidates along all module import paths
+  starting at the call.
+
+- If it is a method call on a class, the best candidate is defined
+  in the same module as the class of the receiver actual argument.
+
+- The call already generates an "unresolved" or "ambiguous" error.
+
+- The candidates defined in internal modules are ignored, as if
+  they are not present among the identified candidates.
+
+In some cases utilizing function definitions from multiple overload sets
+is actually desirable. To support this, we plan to provide a way
+to merge overload sets. Merging is discussed in `GitHub issue 12635
+<https://github.com/chapel-lang/chapel/issues/12635>`_.
+
+The compiler provides the option ``--no-overload-sets-checks``
+to work around the overload set errors when they are undesirable.
+
+We are evaluating this feature and invite user feedback.
+Our open questions include:
+
+- Should an overload set contain only functions that are declared
+  in the same scope, or some other granularity than a module?
+
+- What should a "merge the overload sets" declaration look like?
+
+- How to handle overload sets for a method call when dynamic dispatch
+  is possible?
+
+- What are the situations when the currently-implemented check
+  is too restrictive or too permissive?

--- a/spec/Data_Parallelism.tex
+++ b/spec/Data_Parallelism.tex
@@ -269,7 +269,7 @@ each task function created by the object or iterator leading
 the execution of the loop. If no tasks are created,
 it is considered to be an actual argument to the leader or standalone
 iterator itself. All references to the variable within the forall construct
-implicitly referto a \emph{shadow variable}, i.e.
+implicitly refer to a \emph{shadow variable}, i.e.
 the corresponding formal argument of the task function
 or the leader/standalone iterator.
 

--- a/spec/Data_Parallelism.tex
+++ b/spec/Data_Parallelism.tex
@@ -261,24 +261,29 @@ writeln(result);
 
 If a variable is referenced within the lexical scope of a
 forall statement or expression and is declared outside
-that statement or expression, it is subject to \emph{forall intents},
+that forall construct, it is subject to \emph{forall intents},
 analogously to task intents (\rsec{Task_Intents})
 for task-parallel constructs. That is, the variable is considered
 to be passed as an actual argument to
 each task function created by the object or iterator leading
 the execution of the loop. If no tasks are created,
 it is considered to be an actual argument to the leader or standalone
-iterator itself. All references to the variable
-within the forall statement or expression implicitly refer
-to a \emph{shadow variable}, i.e.
+iterator itself. All references to the variable within the forall construct
+implicitly referto a \emph{shadow variable}, i.e.
 the corresponding formal argument of the task function
 or the leader/standalone iterator.
+
+When the forall construct is inside a method on a record and accesses
+a field of \chpl{this}, the field is treated as a regular variable.
+That is, it is subject to forall intents and all references to this field
+within the forall construct implicitly refer to the corresponding
+shadow variable.
 
 Each formal argument of a task function or iterator has the default
 intent by default.  For variables of primitive, enum, and class
 types, this has the effect of capturing the value of the
 variable at task creation time.  Within the lexical scope of the
-forall statement or expression, the variable name references the
+forall construct, the variable name references the
 captured value instead of the original value.
 
 A formal can be given another intent explicitly by listing it

--- a/spec/Task_Parallelism_and_Synchronization.tex
+++ b/spec/Task_Parallelism_and_Synchronization.tex
@@ -803,24 +803,28 @@ the last line until all of the tasks have completed.
 \index{task parallelism!task functions}
 \index{task parallelism!task intents}
 
-% Would be nice to give this arrangement a name. Could say
-% "the task intent rule", although that sounds a bit like
-% a colloquialism.
 If a variable is referenced within the lexical scope of a
 \chpl{begin}, \chpl{cobegin}, or \chpl{coforall} statement
-and is declared outside that statement, it is considered
+and is declared outside that statement, it is subject to \emph{task intents}.
+That is, it is considered
 to be passed as an actual argument to the corresponding task function
 at task creation time. All references to the variable
-within the task function implicitly refer to the task function's
-corresponding formal argument.
+within the task function implicitly refer to a \emph{shadow variable}, i.e.
+the task function's corresponding formal argument.
 
-Each formal argument of a task function has the default intent by default.
+When the task construct is inside a method on a record and accesses
+a field of \chpl{this}, the field is treated as a regular variable.
+That is, it is passed as an actual argument to the task function and
+all references to the field within the task function implicitly refer
+to the corresponding shadow variable.
+
+Each formal argument of a task function has the default argument intent by default.
 For variables of primitive and class types, this has the effect
 of capturing the value of the variable at task creation time
 and referencing that value instead of the original variable
 within the lexical scope of the task construct.
 
-A formal can be given another intent explicitly by listing it
+A formal can be given another argument intent explicitly by listing it
 with that intent in the optional \sntx{task-intent-clause}.
 For example, for variables of most types, the \chpl{ref} intent allows
 the task construct to modify the corresponding original variable
@@ -857,7 +861,6 @@ in the online documentation:
 %   qualifying which intents are legal in the text of this paragraph.
 % * That's assuming we do not support 'out' and 'inout',
 %   which is still up for debate; otherwise leave as-is.
-% * Do we want to allow default intents? Current implementation allows them.
 
 The implicit treatment of outer scope variables as the task function's
 formal arguments applies to both module level and local variables.


### PR DESCRIPTION
Updates the spec now that task/forall intents operate on fields of `this`
directly. See #13840 and #13479.

While there, minor re-wording and comment cleanup.

Adds a tech note on overload sets checking. See #13442.