### PR TITLE
Nilable classes in spec, part 2

### DIFF
--- a/spec/Classes.tex
+++ b/spec/Classes.tex
@@ -154,7 +154,8 @@ test();
 
 The \chpl{.borrow()} method is available on all class types (including
 \chpl{unmanaged} and \chpl{borrowed}) in order to support generic
-programming.
+programming. For nilable class types, it returns a the borrowed nilable
+class type.
 
 Errors due to accessing an instance after the end of its lifetime are
 particularly difficult to debug. For this reason, the compiler includes a
@@ -277,13 +278,15 @@ create a nilable type. For example, if \chpl{C} is a class type, then
 \chpl{?} operator can be combined with memory management specifiers as
 well. For example, \chpl{borrowed C?} indicates a nilable class using the
 \chpl{borrowed} memory management strategy. Note that the \chpl{?}
-operator only applies to types.
+operator applies only to types.
 
 The postfix \chpl{!} operator applies to a type or a value. When applied
-to a type, it returns the non-nilable borrowed type. When applied to a
-value, it asserts that the value is not \chpl{nil} and returns that value
-as a non-nilable borrowed type. If the value was in fact \chpl{nil}, it
-may halt.
+to a \chpl{borrowed} or \chpl{unmanaged} type, it returns the non-nilable
+version of that type. When applied to an \chpl{owned} or \chpl{shared}
+type, it returns the non-nilable borrowed type. When applied to a value,
+it asserts that the value is not \chpl{nil} and returns that value as a
+non-nilable type.  If the value was in fact \chpl{nil}, it halts.  It
+returns the borrowed type for \chpl{owned} or \chpl{shared}.
 
 An alternative to \chpl{!} is to use a cast to a non-nilable type. Such a
 cast will throw \chpl{NilClassError} if the value was in fact \chpl{nil}.
@@ -297,8 +300,12 @@ Class methods generally expect a receiver of type \chpl{borrowed C}
 dynamic dispatch, it is a program error to call a class method on a class
 receiver storing \chpl{nil}. The language helps to identify this error in
 two different ways, depending on whether or not the module is a
-\chpl{prototype} module (recall that implicit modules are
-\chpl{prototype} modules).
+\chpl{prototype} module (\rsec{Prototype_Modules}).
+
+The \chpl{borrow()} method is an exception. Suppose it is working with a
+class \chpl{C}. It will return \chpl{borrowed C} for any non-nilable
+\chpl{C} type (e.g. \chpl{owned C}). It will return \chpl{borrowed C?}
+for any nilable \chpl{C} type (e.g. \chpl{C?}).
 
 For modules that are not prototype modules, the compiler will not
 resolve calls to such class methods if the receiver has nilable type.
@@ -355,9 +362,10 @@ class types and non-nilable class types do not have a default value.
 \begin{chapel}
 class C { }
 var c : owned C?;    // c has class type owned C?, meaning
-                     // the instance can be nil and is deleted automatically.
+                     // the instance can be nil and is deleted automatically
+                     // when it is not.
 c = new C();         // Now c refers to an initialized instance of type C.
-var c2 = c.borrow(); // The type of c2 is borrowed C.
+var c2 = c.borrow(); // The type of c2 is borrowed C?.
                      // c2 refers to the same object as c.
 class D : C {}    // Class D is derived from C.
 c = new D();      // Now c refers to an object of type D.
@@ -373,9 +381,9 @@ c = new D();      // Now c refers to an object of type D.
 When the variable \chpl{c} is declared, it initially has the value of
 \chpl{nil}.  The next statement assigned to it an instance of the class
 \chpl{C}.  The declaration of variable \chpl{c2} shows that these steps
-can be combined.  The type of \chpl{c2} is also \chpl{C}, determined
+can be combined.  The type of \chpl{c2} is also \chpl{borrowed C?}, determined
 implicitly from the the initialization expression.  Finally, an object
-of type \chpl{D} is created and assigned to \chpl{c}.
+of type \chpl{owned D} is created and assigned to \chpl{c}.
 \end{chapelexample}
 
 \subsection{Class Fields}
@@ -427,7 +435,7 @@ See the methods section~\rsec{Methods} for more information about methods.
 Within a class method, the type of \chpl{this} is generally the
 non-nilable \chpl{borrowed} variant of the class type. It is different
 for type methods (see below) and it might be a different type if the
-class method is declared with as a secondary method with a type
+class method is declared as a secondary method with a type
 expression (see~\ref{Secondary_Methods_with_Type_Expressions}).
 
 For example:
@@ -463,7 +471,7 @@ the body of the method. For example:
 \begin{chapel}
 class C {
   proc type typeMethod() {
-    writeln(this:string); // print out the type 'this'
+    writeln(this:string); // print out the type of 'this'
   }
 }
 (C).typeMethod(); // prints 'C'
@@ -1724,10 +1732,9 @@ receivers.
 
 Classes are assigned by reference.  After an assignment from one
 variable of a class type to another, both variables reference the same
-class instance.
-
-Assignment for an \chpl{owned} variable transfers ownership and leaves the
-source variable empty. For example:
+class instance. Assignments from an \chpl{owned} variable to another
+\chpl{owned} or \chpl{shared} variable are an exception. They transfer
+ownership, leaving the source variable empty i.e. storing \chpl{nil}.
 
 \begin{chapelexample}{owned-assignment.chpl}
 \begin{chapelpre}
@@ -1747,6 +1754,21 @@ nil
 
 In contrast, assignment for \chpl{shared} variables allows both
 variables to refer to the same class instance.
+
+The following assignments between variables or expressions with different
+memory management strategies are disallowed:
+
+\begin{itemize}
+\item to \chpl{owned} from \chpl{shared} or \chpl{borrowed},
+      as it would not ensure unique ownership of the instance
+
+\item to \chpl{shared} from \chpl{borrowed}, as the original owner
+      would be unaware of the shared ownership
+
+\item to \chpl{owned}, \chpl{shared}, or \chpl{borrowed} from \chpl{unmanaged},
+      as both the source and the destination would appear responsible
+      for deleting the instance
+\end{itemize}
 
 %TODO: Move memory management explanation up, closer to class initializers.
 % Perhaps make the memory management part of the introduction, and then let the

--- a/spec/Classes.tex
+++ b/spec/Classes.tex
@@ -168,13 +168,6 @@ refers to.
   probably be needed.
 \end{future}
 
-\subsection{Nilable Classes}
-\label{Nilable_Classes}
-
-This section is forthcoming.
-
-\label{Methods_On_Nilable_In_Prototype_Modules}
-
 \subsection{Class Types}
 \label{Class_Types}
 \index{classes!types}
@@ -209,6 +202,9 @@ of other class declarations.
 
 If no memory management strategy is indicated, the class will be
 considered to have generic management.
+
+Variables of class type cannot store \chpl{nil} unless the class
+type includes \chpl{?} (see~\rsec{Nilable_Classes} below).
 
 The memory management strategies have the following meaning:
 
@@ -271,6 +267,72 @@ owned C
 \end{chapelexample}
 
 
+\subsection{Nilable Classes}
+\label{Nilable_Classes}
+
+Variables of class type cannot store \chpl{nil} unless the class type is
+nilable. To declare a nilable class type, use the \chpl{?} operator to
+create a nilable type. For example, if \chpl{C} is a class type, then
+\chpl{C?} indicates nilable the class type with generic management. The
+\chpl{?} operator can be combined with memory management specifiers as
+well. For example, \chpl{borrowed C?} indicates a nilable class using the
+\chpl{borrowed} memory management strategy. Note that the \chpl{?}
+operator only applies to types.
+
+The postfix \chpl{!} operator applies to a type or a value. When applied
+to a type, it returns the non-nilable borrowed type. When applied to a
+value, it asserts that the value is not \chpl{nil} and returns that value
+as a non-nilable borrowed type. If the value was in fact \chpl{nil}, it
+may halt.
+
+An alternative to \chpl{!} is to use a cast to a non-nilable type. Such a
+cast will throw \chpl{NilClassError} if the value was in fact \chpl{nil}.
+See~\rsec{Explicit_Class_Conversions}.
+
+Non-nilable class types are implicitly convertible to nilable class
+types. See~\rsec{Implicit_Class_Conversions}.
+
+Class methods generally expect a receiver of type \chpl{borrowed C}
+(see~\rsec{Class_Methods}).  Since such a class method call might involve
+dynamic dispatch, it is a program error to call a class method on a class
+receiver storing \chpl{nil}. The language helps to identify this error in
+two different ways, depending on whether or not the module is a
+\chpl{prototype} module (recall that implicit modules are
+\chpl{prototype} modules).
+
+For modules that are not prototype modules, the compiler will not
+resolve calls to such class methods if the receiver has nilable type.
+If the programmer knows that the receiver cannot store \chpl{nil} at that
+moment, they can use \chpl{!} to assert that the reciever is not
+\chpl{nil} and to convert it to the non-nilable borrowed type. For
+example:
+
+\begin{chapelexample}{nilable-classes-bang.chpl}
+\begin{chapel}
+class C {
+  proc C.method() { }
+}
+var c: owned C? = makeMyClass();
+
+// The following call is allowed only in prototype modules,
+// in which case it is equivalent to c!.method()
+c.method();
+
+// This pattern is appropriate in libraries
+if c != nil {
+  c!.method(); // c! converts from 'owned C?' to 'borrowed C'
+}
+\end{chapel}
+\begin{chapeloutput}
+\end{chapeloutput}
+\end{chapelexample}
+
+\label{Methods_On_Nilable_In_Prototype_Modules}
+
+Within a \chpl{prototype} module, the compiler will implicitly convert
+a nilable method receiver to the non-nilable type by adding a \chpl{!}
+call.
+
 
 \subsection{Class Values}
 \label{Class_Values}
@@ -286,7 +348,8 @@ an instance of either that class or a class inheriting, directly or
 indirectly, from that class.
 \chpl{nil} is a legal value of any class type.
 
-The default value of a class type is \chpl{nil}.
+The default value of a concrete nilable class type is \chpl{nil}. Generic
+class types and non-nilable class types do not have a default value.
 
 \begin{chapelexample}{declaration.chpl}
 \begin{chapel}
@@ -307,12 +370,12 @@ c = new D();      // Now c refers to an object of type D.
 \end{chapelcompopts}
 \begin{chapeloutput}
 \end{chapeloutput}
-When the variable \chpl{c} is declared, it initially has the value
-of \chpl{nil}.  The next statement assigned to it an instance of the
-class \chpl{C}.  The declaration of variable \chpl{c2} shows that these steps can
-be combined.  The type of \chpl{c2} is also \chpl{C}, determined implicitly from
-the the initialization expression.  Finally, an object of type \chpl{D} is created and
-assigned to \chpl{c}.
+When the variable \chpl{c} is declared, it initially has the value of
+\chpl{nil}.  The next statement assigned to it an instance of the class
+\chpl{C}.  The declaration of variable \chpl{c2} shows that these steps
+can be combined.  The type of \chpl{c2} is also \chpl{C}, determined
+implicitly from the the initialization expression.  Finally, an object
+of type \chpl{D} is created and assigned to \chpl{c}.
 \end{chapelexample}
 
 \subsection{Class Fields}
@@ -359,7 +422,79 @@ with \chpl{ref} or \chpl{const ref} keywords, are an area of future work.
 \index{secondary methods}
 
 Methods on classes are referred to as to as \emph{class methods}.
-See the methods section~\rsec{Methods}.
+See the methods section~\rsec{Methods} for more information about methods.
+
+Within a class method, the type of \chpl{this} is generally the
+non-nilable \chpl{borrowed} variant of the class type. It is different
+for type methods (see below) and it might be a different type if the
+class method is declared with as a secondary method with a type
+expression (see~\ref{Secondary_Methods_with_Type_Expressions}).
+
+For example:
+
+\begin{chapelexample}{class-method-this-type.chpl}
+\begin{chapel}
+class C {
+  proc primaryMethod() {
+    assert(this.type == borrowed C);
+  }
+}
+proc C.secondaryMethod() {
+  assert(this.type == borrowed C);
+}
+proc (owned C?).secondaryMethodWithTypeExpression() {
+  assert(this.type == owned C?);
+}
+
+var x:owned C? = new owned C();
+x!.primaryMethod();   // within the method, this: borrowed C
+x!.secondaryMethod(); // within the method, this: borrowed C
+x.secondaryMethodWithTypeExpression(); // within the method, this: owned C?
+\end{chapel}
+\begin{chapeloutput}
+\end{chapeloutput}
+\end{chapelexample}
+
+For type methods on a class, \chpl{this} will accept any management or
+nilability variant of the class type and it will refer to that type in
+the body of the method. For example:
+
+\begin{chapelexample}{class-type-method-this.chpl}
+\begin{chapel}
+class C {
+  proc type typeMethod() {
+    writeln(this:string); // print out the type 'this'
+  }
+}
+(C).typeMethod(); // prints 'C'
+(owned C).typeMethod(); // prints 'owned C'
+(borrowed C?).typeMethod(); // prints 'borrowed C?'
+\end{chapel}
+\begin{chapeloutput}
+C
+owned C
+borrowed C?
+\end{chapeloutput}
+\end{chapelexample}
+
+When a type method is defined only in a parent class, the type will be
+the corresponding variant of the parent class. For example:
+
+\begin{chapelexample}{class-type-method-inherit.chpl}
+\begin{chapel}
+class Parent { }
+class Child : Parent { }
+proc type Parent.typeMethod() {
+  writeln(this:string); // print out the type 'this'
+}
+
+Child.typeMethod(); // prints 'Parent'
+(borrowed Child?).typeMethod(); // prints 'borrowed Parent?'
+\end{chapel}
+\begin{chapeloutput}
+\end{chapeloutput}
+\end{chapelexample}
+
 
 \subsection{Nested Classes}
 \label{Nested_Classes}
@@ -1612,23 +1747,6 @@ nil
 
 In contrast, assignment for \chpl{shared} variables allows both
 variables to refer to the same class instance.
-
-\subsection{Implicit Class Conversions}
-\label{Implicit_Class_Conversions}
-\index{conversions!class}
-\index{conversions!implicit!class}
-\index{classes!implicit conversion}
-
-An implicit conversion from class type \chpl{D} to
-another class type \chpl{C} is allowed when \chpl{D} is a subclass
-of \chpl{C}.
-The value \chpl{nil} can be implicitly converted to any class type.
-These conversions do not change the value.
-
-Class types other than \chpl{borrowed C}, for example \chpl{owned C}, can
-be implicitly converted to \chpl{borrowed C}. Note that \chpl{C} is
-equivalent to \chpl{borrowed C}.  This coercion is equivalent to calling
-the \chpl{.borrow()} method.  See~\rsec{Class_Lifetime_and_Borrows}.
 
 %TODO: Move memory management explanation up, closer to class initializers.
 % Perhaps make the memory management part of the introduction, and then let the

--- a/spec/Conversions.tex
+++ b/spec/Conversions.tex
@@ -179,7 +179,7 @@ explicitly-sized counterparts.
 \index{conversions!implicit!parameter}
 
 A parameter of numeric type can be implicitly converted to any other
-numeric type if the value of the parameter can be stored without loss in
+numeric type if the value of the parameter can be represented exactly
 the target type. This rule does not allow conversions from \chpl{real} to
 \chpl{imag}, or from \chpl{complex} to a non-complex type. It does allow
 conversions from \chpl{real} or \chpl{imag} to \chpl{complex}.
@@ -191,14 +191,16 @@ conversions from \chpl{real} or \chpl{imag} to \chpl{complex}.
 \index{conversions!implicit!borrow}
 \index{classes!implicit conversion}
 
-An expression of class type can implicitly converted to the borrow type;
+An expression of class type can be implicitly converted to the borrow type;
 to a nilable type; or to a parent class type. The value \chpl{nil} can be
 implicitly converted to any nilable class type.
 
-First, class types other than \chpl{borrowed C}, for example \chpl{owned
-C}, can be implicitly converted to \chpl{borrowed C}. This coercion is
-equivalent to calling the \chpl{.borrow()} method.
-See~\rsec{Class_Lifetime_and_Borrows}. For example:
+First, class types can be converted to the corresponding \chpl{borrowed}
+type. For example, \chpl{owned C} can be implicitly converted to
+\chpl{borrowed C}, and \chpl{shared C?} can be implicitly converted to
+\chpl{borrowed C?}. This coercion is equivalent to calling the
+\chpl{.borrow()} method.  See~\rsec{Class_Lifetime_and_Borrows}. For
+example:
 
 \begin{chapelexample}{implicit-conversion-to-borrow.chpl}
 \begin{chapel}
@@ -213,7 +215,7 @@ f(c); // equivalent to f(c.borrow())
 \end{chapelexample}
 
 Second, an expression of non-nilable class type can be implicitly
-converted to the nilable class type. For example, continuing the above
+converted to the nilable class type. Continuing the above
 example:
 
 \begin{chapelexample}{implicit-conversion-to-nilable.chpl}

--- a/spec/Conversions.tex
+++ b/spec/Conversions.tex
@@ -64,9 +64,9 @@ as defined in the referenced subsections:
 
 \begin{itemize}
 \item numeric and boolean types~(\rsec{Implicit_NumBool_Conversions}),
-\item class types~(\rsec{Implicit_Class_Conversions}),
-\item integral types in the special case when the expression's value
+\item numeric types in the special case when the expression's value
       is a compile-time constant~(\rsec{Implicit_Compile_Time_Constant_Conversions}), and
+\item class types~(\rsec{Implicit_Class_Conversions}),
 \item from an integral or class type to \chpl{bool}
       in certain cases~(\rsec{Implicit_Statement_Bool_Conversions}).
 \end{itemize}
@@ -178,12 +178,61 @@ explicitly-sized counterparts.
 \index{conversions!numeric!parameter}
 \index{conversions!implicit!parameter}
 
-The following implicit conversion of a parameter is allowed:
-\begin{itemize}
-\item A parameter of type \chpl{int(64)} can be implicitly converted
-to \chpl{int(8)}, \chpl{int(16)}, \chpl{int(32)}, or any unsigned integral type if the
-value of the parameter is within the range of the target type.
-\end{itemize}
+A parameter of numeric type can be implicitly converted to any other
+numeric type if the value of the parameter can be stored without loss in
+the target type. This rule does not allow conversions from \chpl{real} to
+\chpl{imag}, or from \chpl{complex} to a non-complex type. It does allow
+conversions from \chpl{real} or \chpl{imag} to \chpl{complex}.
+
+\subsection{Implicit Class Conversions}
+\label{Implicit_Class_Conversions}
+\index{conversions!implicit!class}
+\index{conversions!implicit!nilable}
+\index{conversions!implicit!borrow}
+\index{classes!implicit conversion}
+
+An expression of class type can implicitly converted to the borrow type;
+to a nilable type; or to a parent class type. The value \chpl{nil} can be
+implicitly converted to any nilable class type.
+
+First, class types other than \chpl{borrowed C}, for example \chpl{owned
+C}, can be implicitly converted to \chpl{borrowed C}. This coercion is
+equivalent to calling the \chpl{.borrow()} method.
+See~\rsec{Class_Lifetime_and_Borrows}. For example:
+
+\begin{chapelexample}{implicit-conversion-to-borrow.chpl}
+\begin{chapel}
+class C { }
+var c:owned C = new owned C();
+
+proc f(arg: borrowed C) { }
+f(c); // equivalent to f(c.borrow())
+\end{chapel}
+\begin{chapeloutput}
+\end{chapeloutput}
+\end{chapelexample}
+
+Second, an expression of non-nilable class type can be implicitly
+converted to the nilable class type. For example, continuing the above
+example:
+
+\begin{chapelexample}{implicit-conversion-to-nilable.chpl}
+\begin{chapelpre}
+class C { }
+var c:owned C = new owned C();
+\end{chapelpre}
+\begin{chapel}
+var b:borrowed C = c.borrow();
+
+proc g(arg: borrowed C?) { }
+g(b); // equivalent to g(b:borrowed C?)
+\end{chapel}
+\begin{chapeloutput}
+\end{chapeloutput}
+\end{chapelexample}
+
+Third, an implicit conversion from class type \chpl{D} to another class
+type \chpl{C} is allowed when \chpl{D} is a subclass of \chpl{C}.
 
 \subsection{Implicit Statement Bool Conversions}
 \label{Implicit_Statement_Bool_Conversions}
@@ -219,7 +268,7 @@ Such conversion does not change the value of the expression.
 Explicit conversions are allowed from any numeric type or boolean to bytes or
 string, and vice-versa.
 
-% A valid \chpl{bool} value behaves like a single unsigned bit.  
+% A valid \chpl{bool} value behaves like a single unsigned bit.
 When a \chpl{bool} is converted to a \chpl{bool}, \chpl{int}
 or \chpl{uint} of equal or larger size, its value is zero-extended to fit the
 new representation.  When a \chpl{bool} is converted to a
@@ -234,7 +283,7 @@ When a \chpl{int}, \chpl{uint}, or \chpl{real} is converted to a \chpl{bool}, th
 
 % The source type determines whether a value is zero- or sign-extended.
 When an \chpl{int} is converted to a larger \chpl{int} or \chpl{uint}, its value is
-sign-extended to fit the new representation.  
+sign-extended to fit the new representation.
 When a \chpl{uint} is converted to a larger \chpl{int} or \chpl{uint}, its value
 is zero-extended.
 When an \chpl{int} or \chpl{uint} is converted to an \chpl{int} or \chpl{uint}
@@ -347,7 +396,7 @@ of \chpl{false} and \chpl{true}, respectively.
 % encouragement to always supply a default clause in your switch statements!
 
 When the source type is a real or integer type, the value is converted to the
-target type's underlying integer type.  
+target type's underlying integer type.
 
 The conversion from \chpl{complex} and \chpl{imag} types to an enumerated type is not
 permitted.
@@ -360,6 +409,7 @@ matches value of the input is selected.  If no such enumerator exists, an
 \label{Explicit_Class_Conversions}
 \index{conversions!class}
 \index{conversions!explicit!class}
+\index{classes!explicit conversion}
 
 An expression of static class type \chpl{C} can be explicitly
 converted to a class type \chpl{D} provided that \chpl{C} is derived
@@ -372,6 +422,11 @@ the cast fails and the destination type is not nilable, the cast
 expression will throw a \chpl{classCastError}. If the cast fails and the
 destination type is nilable, as with \chpl{D?}, then the result will be
 \chpl{nil}.
+
+An expression of class type can also be converted to a different
+nilability with a cast. For conversions from a nilable class type to a
+non-nilable class type, the cast will throw a \chpl{NilClassError} if the
+value was actually \chpl{nil}.
 
 In some cases a new variant of a class type needs to be computed that has
 different nilability or memory management strategy. Supposing that

--- a/spec/Expressions.tex
+++ b/spec/Expressions.tex
@@ -297,12 +297,12 @@ example, not all \sntx{call-expression}s are lvalues.
 \verb@new@ & right & initializer call \\
 \hline
 \verb@owned@ & right & apply management strategy to a class \\
-\verb@shared@ & right & \\
-\verb@borrowed@ & right & \\
-\verb@unmanaged@ & right & \\
+\verb@shared@ &   & \\
+\verb@borrowed@ &   & \\
+\verb@unmanaged@ &   & \\
 \hline
-\verb@?@ & left & compute a nilable class type \\
-postfix \verb@!@ & left & assert non-nilable and borrow \\
+postfix \verb@?@ & left & compute a nilable class type \\
+postfix \verb@!@ &   & assert non-nilable and borrow \\
 \hline
 \verb@:@ & left & cast \\
 \hline

--- a/spec/Expressions.tex
+++ b/spec/Expressions.tex
@@ -285,9 +285,6 @@ example, not all \sntx{call-expression}s are lvalues.
 \index{expressions!precedence}
 \index{expressions!associativity}
 
-The following table summarizes operator and expression precedence and
-associativity.  Operators and expressions listed earlier have higher
-precedence than those listed later.
 \begin{center}
 \begin{tabular}{|l|l|l|}
 \hline
@@ -299,6 +296,14 @@ precedence than those listed later.
 \hline
 \verb@new@ & right & initializer call \\
 \hline
+\verb@owned@ & right & apply management strategy to a class \\
+\verb@shared@ & right & \\
+\verb@borrowed@ & right & \\
+\verb@unmanaged@ & right & \\
+\hline
+\verb@?@ & left & compute a nilable class type \\
+postfix \verb@!@ & left & assert non-nilable and borrow \\
+\hline
 \verb@:@ & left & cast \\
 \hline
 \verb@**@ & right & exponentiation \\
@@ -307,7 +312,7 @@ precedence than those listed later.
 \verb@scan@ & & scan \\
 \verb@dmapped@ & & domain map application \\
 \hline
-\verb@!@ & \multirow{2}{*}{right} & logical negation \\
+prefix \verb@!@ & \multirow{2}{*}{right} & logical negation \\
 \verb@~@ & & bitwise negation \\
 \hline
 \verb@*@ & \multirow{3}{*}{left} & multiplication \\
@@ -359,6 +364,10 @@ unary \verb@-@ & & negation \\
 \hline
 \end{tabular}
 \end{center}
+
+The above table summarizes operator and expression precedence and
+associativity.  Operators and expressions listed earlier have higher
+precedence than those listed later.
 
 \begin{rationale}
 In general, our operator precedence is based on that of the C family
@@ -1336,6 +1345,19 @@ The result of \chpl{a == b} is true if the sequence of characters
 in \chpl{a} matches exactly the sequence of characters in \chpl{b};
 otherwise the result is false.  The result of \chpl{a \!= b} is
 equivalent to \chpl{\!(a == b)}.
+
+\section{Class Operators}
+\label{Class_Operators}
+
+The keywords \chpl{owned}, \chpl{shared}, \chpl{borrowed}, and
+\chpl{unmanaged} act as a prefix unary operator when specifying the management
+strategy for a class type. See~\rsec{Class_Types}.
+
+The unary postfix operator \chpl{?} results in the nilable variant of a
+class type. See~\rsec{Nilable_Classes}.
+
+The unary postfix operator \chpl{!} asserts that the receiver is not
+storing \chpl{nil} and borrows from it. See~\rsec{Nilable_Classes}.
 
 \section{Miscellaneous Operators}
 \label{Miscellaneous_Operators}

--- a/spec/Methods.tex
+++ b/spec/Methods.tex
@@ -164,9 +164,9 @@ receivers---these are known as \emph{type methods}.
 
 Note that within a method for a class \chpl{C}, the type of \chpl{this}
 is generally \chpl{borrowed C}. Within a type method on a class \chpl{C},
-\chpl{this} refers to a class type with management and nilability matching
-the type of the receiver. Please see~\rsec{Class_Methods} for more
-details.
+\chpl{this} refers to the class type \chpl{C} with management and
+nilability matching the type of the receiver. Please
+see~\rsec{Class_Methods} for more details.
 
 The optional \sntx{this-intent} is used to specify type methods, to
 constrain a receiver argument to be a \chpl{param}, or to specify how

--- a/spec/Methods.tex
+++ b/spec/Methods.tex
@@ -47,6 +47,7 @@ simply be standalone functions rather than methods).  Note that
 secondary methods can be defined not only for classes, records, and
 unions, but also for any other type (e.g., integers, reals, strings).
 
+\label{Secondary_Methods_with_Type_Expressions}
 Secondary methods can be declared with a type expression instead of a
 type identifier. In particular, if the \sntx{type-binding} is a
 parenthesized expression, the compiler will evaluate that expression to
@@ -130,8 +131,6 @@ invoked.  The receiver's actual argument is specified by the
 \sntx{receiver-clause} of a method-call-expression as specified
 in \rsec{Method_Calls}.
 
-
-
 % TODO: specify how the receiver affects the choice of the method.
 
 \begin{chapelexample}{implicitThis.chpl}
@@ -162,6 +161,12 @@ argument is \chpl{c1}.  Within primary method \chpl{C.foo()}, the
 Methods whose receivers are objects are called \emph{instance
 methods}.  Methods may also be defined to have \chpl{type}
 receivers---these are known as \emph{type methods}.
+
+Note that within a method for a class \chpl{C}, the type of \chpl{this}
+is generally \chpl{borrowed C}. Within a type method on a class \chpl{C},
+\chpl{this} refers to a class type with management and nilability matching
+the type of the receiver. Please see~\rsec{Class_Methods} for more
+details.
 
 The optional \sntx{this-intent} is used to specify type methods, to
 constrain a receiver argument to be a \chpl{param}, or to specify how


### PR DESCRIPTION
Follow-on to PR #14002.

* Fill in the Nilable Classes section of the spec
* Add some details to an Implicit Class Conversion section
* Fix up param conversions section

Reviewed by @vasslitvinov - thanks!