### PR TITLE
Do not forward init= and deinit

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -4172,13 +4172,12 @@ static FnSymbol* resolveForwardedCall(CallInfo& info, bool checkOnly) {
     return NULL;
   }
 
-  // Do not forward initializers
-  if (call->isNamedAstr(astrInit) && call->numActuals() >= 1) {
-    if (SymExpr* se = toSymExpr(call->get(1))) {
-      if (se->symbol() == gMethodToken) {
-        return NULL;
-      }
-    }
+  // Do not forward de/initializers.
+  // Todo: what else to add here? Note: we cannot be here for a non-method.
+  if (call->isNamedAstr(astrInit)       ||
+      call->isNamedAstr(astrInitEquals) ||
+      call->isNamedAstr(astrDeinit)     ) {
+    return NULL;
   }
 
   // Detect cycles

--- a/test/classes/forwarding/forwarding-cycle.chpl
+++ b/test/classes/forwarding/forwarding-cycle.chpl
@@ -1,13 +1,15 @@
 // Test that forwarding cycle results in an error
 
 class A {
-  forwarding var data: unmanaged B;
+  forwarding var data: unmanaged B?;
+  proc fun(i:int) {}
 }
 class B {
-  forwarding var data: unmanaged A;
+  forwarding var data: unmanaged A?;
 }
 
 proc main() {
   var a = new unmanaged A();
+  a.fun(1.1);
   delete a;
 }

--- a/test/classes/forwarding/forwarding-cycle.compopts
+++ b/test/classes/forwarding/forwarding-cycle.compopts
@@ -1,1 +1,0 @@
---legacy-classes

--- a/test/classes/forwarding/forwarding-cycle.good
+++ b/test/classes/forwarding/forwarding-cycle.good
@@ -1,2 +1,3 @@
+forwarding-cycle.chpl:11: In function 'main':
 forwarding-cycle.chpl:4: error: forwarding cycle detected
-forwarding-cycle.chpl:6: note: for the type B
+forwarding-cycle.chpl:7: note: for the type B

--- a/test/classes/forwarding/forwarding-self.chpl
+++ b/test/classes/forwarding/forwarding-self.chpl
@@ -1,8 +1,10 @@
 // Test that forwarding to self is detected as an error
 class A {
-  forwarding var data: unmanaged A;
+  forwarding var data: unmanaged A?;
+  proc fun(i:int) {}
 }
 proc main() {
   var a = new unmanaged A();
+  a.fun(1.1);
   delete a;
 }

--- a/test/classes/forwarding/forwarding-self.compopts
+++ b/test/classes/forwarding/forwarding-self.compopts
@@ -1,1 +1,0 @@
---legacy-classes

--- a/test/classes/forwarding/forwarding-self.good
+++ b/test/classes/forwarding/forwarding-self.good
@@ -1,2 +1,3 @@
+forwarding-self.chpl:6: In function 'main':
 forwarding-self.chpl:3: error: forwarding cycle detected
 forwarding-self.chpl:2: note: for the type A


### PR DESCRIPTION
Resolves #13631.

The compiler in resolveForwardedCall() already aborted forwarding attempts
when the callee name was `init`. Now do the same also for `init=` and `deinit`.

Surprisingly, the compiler already was not forwarding `deinit`.
With the only exception of `test/classes/forwarding/forwarding-cycle.chpl`
and perhaps `test/classes/forwarding/forwarding-self.chpl`.
This is unaffected by `--legacy-classes` afaik.
So this change is less impactful than it appears.

I looked and did not see why the compiler was not forwarding `deinit`.
Below are my observations about the compiler prior to this change.

In the earlier version of `forwarding-cycle.chpl` it was forwarding `deinit`
that was invoked from `chpl__delete(arg: unmanaged A)`:
```chpl
class A {
  forwarding var data: unmanaged B;
}
class B {
  forwarding var data: unmanaged A;
}
proc main() {
  var a = new unmanaged A();
  delete a;
}
```

It is during forwarding of `deinit` that the compiler detected the forwarding
cycle, which is what this test was testing.

If we switch the type of the two `data` fields to be nilable, ex.
```chpl
forwarding var data: unmanaged B?;
```

then the compiler attempted forwarding, however it did not succeed because
`tryResolveCall(getTgt)` in adjustAndResolveForwardedCall() returned false.
This is puzzling because it appears to work just fine when forwarding
a user method, ex. in the current version of `forwarding-cycle.chpl`:

```chpl
class A {
  forwarding var data: unmanaged B?;
  proc fun(i:int) {}
}
class B {
  forwarding var data: unmanaged A?;
}
proc main() {
  var a = new unmanaged A();
  a.fun(1.1);
  delete a;
}
```

`deinit()` was not forwarded either when the user defined one.
Ex. the following code invokes B.deinit then A.deinit upon `delete c`:

```chpl
class A {
  proc init()   { writeln("A.init");   }
  proc init(arg:int) { writeln("A.init with arg"); withArg=true; }
  proc deinit() { writeln("A.deinit",
                    if withArg then " with arg" else ""); }
  const withArg=false;
}

class B: A {
  proc init()   { writeln("B.init");   }
  proc deinit() { writeln("B.deinit"); }
}

class C: B {
  // If de/init() are forwarded, they will bypass B.
  forwarding var fld = new unmanaged A(0);  // the "with arg" version
}

proc main {
  var c = new unmanaged C();
  delete c.fld;
  delete c;
}
```

Discussed with @benharsh.