### PR TITLE
Remove "Explicit Record Conversions" from spec

### DIFF
--- a/spec/Conversions.tex
+++ b/spec/Conversions.tex
@@ -418,16 +418,6 @@ different nilability or memory management strategy. Supposing that
 
 \end{itemize}
 
-\subsection{Explicit Record Conversions}
-\label{Explicit_Record_Conversions}
-\index{conversions!records}
-\index{conversions!explicit!records}
-
-An expression of record type \chpl{C} can be explicitly converted to
-another record type \chpl{D} provided that \chpl{C} is derived
-from \chpl{D}.  There are no explicit record conversions that are not
-also implicit record conversions.
-
 \subsection{Explicit Range Conversions}
 \label{Explicit_Range_Conversions}
 \index{conversions!range}


### PR DESCRIPTION
This subsection is as old as the spec itself.
It does not apply any longer because we do not have
the "derived" relationship between records.