### PR TITLE
Adjust path of deprecated/arrayAsVec/timeVectorArray.chpl in GRAPHFILES

### DIFF
--- a/test/GRAPHFILES
+++ b/test/GRAPHFILES
@@ -67,7 +67,7 @@ users/npadmana/npb-mg/mg-b.graph
 arrays/diten/time_iterate.graph
 arrays/diten/time_array_vs_tuple.graph
 arrays/diten/time_array_vs_ddata.graph
-arrays/diten/timeVectorArray.graph
+deprecated/arrayAsVec/timeVectorArray.graph
 arrays/ferguson/return-array-40000000.graph
 arrays/lydia/time_access.graph
 domains/ferguson/build-associative.graph


### PR DESCRIPTION
The old path for this was still set to `arrays/diten/timeVectorArray.graph`, causing warnings in nightly testing. It is now set as `deprecated/arrayAsVec/timeVectorArray.graph`. 

Trivial and not reviewed. Tested locally.