### PR TITLE
Update atomic documentation

### DIFF
--- a/doc/rst/platforms/cray.rst
+++ b/doc/rst/platforms/cray.rst
@@ -490,7 +490,7 @@ following operations on remote atomics are done using the network::
       read()
       write()
       exchange()
-      compareExchange()
+      compareAndSwap()
       add(), fetchAdd()
       sub(), fetchSub()
 

--- a/doc/rst/technotes/atomics.rst
+++ b/doc/rst/technotes/atomics.rst
@@ -41,17 +41,8 @@ specified, and not all implementations are available for all
 settings.  Chapel currently supports three atomics implementations:
 ``cstdlib``, ``intrinsics`` and ``locks``. This environment variable
 also specifies the atomic implementation used by the Chapel runtime.
-
-If compiler support for atomics is available, the atomic operations
-will be mapped down the appropriate compiler intrinsics which often
-map directly to processor atomics.  If intrinsics are not available,
-the atomic implementation defaults to using locks in the form of
-Pthread mutexes. As a result the locks implementation will be
-slower than the intrinsic implementation. Since Chapel's atomics
-were modeled after the C11 edition of the C standard, the cstdlib
-implementation is just a wrapper around C standard atomics.  As C11
-support becomes more prevalent and reliable, cstdlib will become the
-default in some configurations.
+``cstdlib`` provides the best performance. For information on how the
+default is chosen see :ref:`readme-chplenv.CHPL_ATOMICS`.
 
 Currently, unless using network atomics, all remote atomic
 operations will result in the calling task effectively migrating to
@@ -67,73 +58,8 @@ defined in ``$CHPL_HOME/modules/internal/Atomics.chpl``. Over time
 we will add a more principled way for explicitly requesting
 processor atomics, and this function may disappear.
 
-
 For more information about the runtime implementation see
 ``$CHPL_HOME/runtime/include/atomics/README``.
-
-
-------------------
-Memory Order Notes
-------------------
-
-As mentioned in the spec, most atomic operations optionally take a
-memory order. However, for the intrinsics and locks implementations,
-this argument is ignored. The resulting effect is that all atomic
-operations are performed with ``memory_order_seq_cst`` (sequentially
-consistent) regardless of the actual order specified. The reason for
-this is because the compiler intrinsics used in the runtime have no
-way to specify memory order.
-
-The cstdlib implementation uses the specified memory order.
-
-
------------------------------
-Variances from the C standard
------------------------------
-
-While Chapel atomics are modeled after the C standard there are some
-notable differences. The primary one is that Chapel supports
-fetch-and-add/fetch-and-subtract operations for ``real`` types. It
-should be noted that since there is virtually no hardware support for
-floating point atomics, our implementation is not very efficient.
-
-As noted in the spec there a few additional methods in Chapel that
-are not in C11. They are ``peek``, ``poke``, and ``waitFor``.
-``peek`` and ``poke`` are supposed to be relaxed versions of read
-and write that allow users to perform reads and writes with more
-relaxed memory constraints.  Currently they are implemented as reads
-and writes with ``memory_order_relaxed``. ``waitFor`` is a method that
-waits until an atomic object has a specific value.  It can yield to
-other tasks while waiting.
-
-Chapel currently does not support the memory fences or the
-``isLockFree`` method from the C11 spec. They are defined in the
-runtime but not in the modules. The primary reason that
-``isLockFree`` is not available is that it may not be accurate for
-the intrinsics. Without examining each intrinsic operation for each
-compiler it is hard to know if they actually map down to lock free
-operations. ``threadFence`` and ``signalFence`` are also in the
-runtime but not in the modules. The primary reason for this is that
-there is no need for them with the intrinsics or locks
-implementations, where all our operations use
-``memory_order_seq_cst``. They will be added for use with the cstdlib
-implementation. The fences are used with other memory_orders to allow
-you to create safe programs when atomic operations are using non
-sequential memory orders.
-
-
------------
-Open issues
------------
-
-- Atomic bools are only supported for the default size and not
-  implemented for all sizes of bools.
-
-- The ``memory_order`` is currently ignored by the intrinsics and locks
-  implementations.
-
-- The threadFence and signalFence methods need to be made available
-  for use with nonsequential memory orders.
 
 
 ---------------------

--- a/spec/Task_Parallelism_and_Synchronization.tex
+++ b/spec/Task_Parallelism_and_Synchronization.tex
@@ -556,25 +556,15 @@ Stores \chpl{v} as the new value and returns the original
 value. Defined for all atomic types.
 \end{protobody}
 
-\index{compareExchangWeak (atomic var)@\chpl{compareExchangeWeak} (atomic var)}
-\index{predefined functions!compareExchangeWeak (atomic var)@\chpl{compareExchangeWeak} (atomic var)}
-\index{compareExchangStrong (atomic var)@\chpl{compareExchangeStrong} (atomic var)}
-\index{predefined functions!compareExchangeStrong (atomic var)@\chpl{compareExchangeStrong} (atomic var)}
-\index{compareExchange (atomic var)@\chpl{compareExchange} (atomic var)}
-\index{predefined functions!compareExchange (atomic var)@\chpl{compareExchange} (atomic var)}
+\index{compareAndSwap (atomic var)@\chpl{compareAndSwap} (atomic var)}
+\index{predefined functions!compareAndSwap (atomic var)@\chpl{compareAndSwap} (atomic var)}
 \begin{protohead}
-proc (atomic T).compareExchangeWeak(e: t, v: T, order:memoryOrder = memoryOrder.seqCst): bool
-proc (atomic T).compareExchangeStrong(e: t, v: T, order:memoryOrder = memoryOrder.seqCst): bool
-proc (atomic T).compareExchange(e: t, v: T, order:memoryOrder = memoryOrder.seqCst): bool
+proc (atomic T).compareAndSwap(e: t, v: T, order:memoryOrder = memoryOrder.seqCst): bool
 \end{protohead}
 \begin{protobody}
 Stores \chpl{v} as the new value, if and only if the original value is
 equal to \chpl{e}. Returns \chpl{true} if \chpl{v} was
-stored, \chpl{false} otherwise. The 'weak' variation may
-return \chpl{false} even if the original value was equal to \chpl{e},
-if, for example, the value could not be updated
-atomically. \chpl{compareExchange} is equivalent to
-\chpl{compareExchangeStrong}.  Defined for all atomic types.
+stored, \chpl{false} otherwise.  Defined for all atomic types.
 \end{protobody}
 
 \index{add (atomic var)@\chpl{add} (atomic var)}


### PR DESCRIPTION
Misc atomic doc changes:
- Update the spec for the `compareExchange` -> `compareAndSwap` change
- Remove obsolete/wrong portions of the technote and cut out some sections