### PR TITLE
Some highlighter changes for 1.20

### DIFF
--- a/highlight/source-highlight/chpl.lang
+++ b/highlight/source-highlight/chpl.lang
@@ -24,11 +24,11 @@ number = '\<([[:digit:]]([[:digit:]]|_)*)\>'
 string delim "\"" "\"" escape "\\"
 
 # double-quotes mean that parens are interpreted literally
-keyword = "as|atomic|begin|borrowed|break|by|catch|class|cobegin|coforall|config|const|continue|iter|delete|dmapped|do|domain|else|enum|except|export|extern|false|for|forall|if|in|index|inline|inout|label|lambda|let|local|module|new|nil|noinit|on|only|otherwise|out|override|owned|param|private|proc|prototype|public|record|reduce|ref|require|return|scan|select|serial|single|shared|sparse|subdomain|sync|then|throw|throws|true|try|type|union|unmanaged|use|var|when|where|while|with|yield|zip"
+keyword = "align|as|atomic|begin|borrowed|break|by|catch|class|cobegin|coforall|config|const|continue|init|init=|iter|deinit|delete|dmapped|do|domain|else|enum|except|export|extern|false|for|forall|if|in|index|inline|inout|label|lambda|let|lifetime|local|locale|module|new|nil|noinit|none|on|only|otherwise|out|override|owned|param|private|proc|prototype|public|record|reduce|ref|require|return|scan|select|serial|single|shared|sparse|subdomain|sync|then|these|this|throw|throws|true|try|type|union|unmanaged|use|var|when|where|while|with|yield|zip"
 
 
 # double-quotes mean that parens are interpreted literally
-type = "bool|complex|imag|int|opaque|range|real|string|uint"
+type = "bool|bytes|complex|imag|int|nothing|opaque|range|real|string|uint|void"
 
 
 #include "c_comment.lang"

--- a/highlight/source-highlight/chpl.lang
+++ b/highlight/source-highlight/chpl.lang
@@ -24,7 +24,7 @@ number = '\<([[:digit:]]([[:digit:]]|_)*)\>'
 string delim "\"" "\"" escape "\\"
 
 # double-quotes mean that parens are interpreted literally
-keyword = "align|as|atomic|begin|borrowed|break|by|catch|class|cobegin|coforall|config|const|continue|init|init=|iter|deinit|delete|dmapped|do|domain|else|enum|except|export|extern|false|for|forall|if|in|index|inline|inout|label|lambda|let|lifetime|local|locale|module|new|nil|noinit|none|on|only|otherwise|out|override|owned|param|private|proc|prototype|public|record|reduce|ref|require|return|scan|select|serial|single|shared|sparse|subdomain|sync|then|these|this|throw|throws|true|try|type|union|unmanaged|use|var|when|where|while|with|yield|zip"
+keyword = "align|as|atomic|begin|borrowed|break|by|catch|class|cobegin|coforall|config|const|continue||deinit|delete|dmapped|do|domain|else|enum|except|export|extern|false|for|forall|if|in|index|init|init=|inline|inout|iter|label|lambda|let|lifetime|local|locale|module|new|nil|noinit|none|on|only|otherwise|out|override|owned|param|private|proc|prototype|public|record|reduce|ref|require|return|scan|select|serial|single|shared|sparse|subdomain|sync|then|these|this|throw|throws|true|try|type|union|unmanaged|use|var|when|where|while|with|yield|zip"
 
 
 # double-quotes mean that parens are interpreted literally

--- a/highlight/vim/syntax/chpl.vim
+++ b/highlight/vim/syntax/chpl.vim
@@ -280,14 +280,6 @@ syn keyword chplRepeat		while for do coforall forall in serial
 syn keyword chplLabel	        when otherwise label
 syn keyword chplErrorHandling   throw throws try catch
 
-" ? is an either ternary condition operator or postfix nilability operator
-" so just match it no matter what
-syn match   chplOperator display "?"  
-
-" if you match ! that follows a valid type name
-syn match   chplOperator display "[a-zA-Z0-9_]\zs!\ze[^=]"   
-
-
 " Folding
 syn region scopeFold start="{" end="}" fold transparent
 

--- a/highlight/vim/syntax/chpl.vim
+++ b/highlight/vim/syntax/chpl.vim
@@ -31,6 +31,10 @@ endif
 if exists("c_no_cformat")
   syn region	cString		start=+L\="+ skip=+\\\\\|\\"+ end=+"+ contains=cSpecial,@Spell
   syn region	cString		start=+L\='+ skip=+\\\\\|\\'+ end=+'+ contains=cSpecial,@Spell
+  syn region	cString		start=+L\=b"+ skip=+\\\\\|\\"+ end=+"+ contains=cSpecial,@Spell
+  syn region	cString		start=+L\=b'+ skip=+\\\\\|\\'+ end=+'+ contains=cSpecial,@Spell
+  syn region	cString		start=+L\=c"+ skip=+\\\\\|\\"+ end=+"+ contains=cSpecial,@Spell
+  syn region	cString		start=+L\=c'+ skip=+\\\\\|\\'+ end=+'+ contains=cSpecial,@Spell
   " cCppString: same as cString, but ends at end of line
   syn region	cCppString	start=+L\="+ skip=+\\\\\|\\"\|\\$+ excludenl end=+"+ end='$' contains=cSpecial,@Spell
   syn region	cCppString	start=+L\='+ skip=+\\\\\|\\'\|\\$+ excludenl end=+'+ end='$' contains=cSpecial,@Spell
@@ -39,6 +43,10 @@ else
   syn match	cFormat		display "%%" contained
   syn region	cString		start=+L\="+ skip=+\\\\\|\\"+ end=+"+ contains=cSpecial,cFormat,@Spell
   syn region	cString		start=+L\='+ skip=+\\\\\|\\'+ end=+'+ contains=cSpecial,cFormat,@Spell
+  syn region	cString		start=+L\=b"+ skip=+\\\\\|\\"+ end=+"+ contains=cSpecial,cFormat,@Spell
+  syn region	cString		start=+L\=b'+ skip=+\\\\\|\\'+ end=+'+ contains=cSpecial,cFormat,@Spell
+  syn region	cString		start=+L\=c"+ skip=+\\\\\|\\"+ end=+"+ contains=cSpecial,cFormat,@Spell
+  syn region	cString		start=+L\=c'+ skip=+\\\\\|\\'+ end=+'+ contains=cSpecial,cFormat,@Spell
   " cCppString: same as cString, but ends at end of line
   syn region	cCppString	start=+L\="+ skip=+\\\\\|\\"\|\\$+ excludenl end=+"+ end='$' contains=cSpecial,cFormat,@Spell
   syn region	cCppString	start=+L\='+ skip=+\\\\\|\\'\|\\$+ excludenl end=+'+ end='$' contains=cSpecial,cFormat,@Spell
@@ -255,20 +263,28 @@ syn keyword chplStatement	as module yield compilerError zip
 syn keyword chplIntent		param type in out inout ref
 syn keyword chplStorageClass    const config export extern var
 syn keyword chplType            domain sparse subdomain range index imag complex int uint real bool
-syn keyword chplType            file string opaque integral numeric enumerated
+syn keyword chplType            file bytes string opaque integral numeric enumerated
 syn keyword chplType            locale sync atomic single dmapped
 syn keyword chplType            owned shared borrowed unmanaged
+syn keyword chplType            nothing void
 syn keyword chplOperator	on reduce scan by align
 syn keyword chplStructure	class record union enum
 syn keyword chplStructure	proc iter cobegin begin local sync let select where
 syn keyword chplStructure	pragma inline with private public forwarding
-syn keyword chplStructure	prototype override
+syn keyword chplStructure	prototype override lifetime
 syn keyword chplBoolean		true false
 syn keyword chplConditional	if then else
-syn keyword chplConstant	nil
+syn keyword chplConstant	nil none
 syn keyword chplRepeat		while for do coforall forall in serial
 syn keyword chplLabel	        when otherwise label
 syn keyword chplErrorHandling   throw throws try catch
+
+" ? is an either ternary condition operator or postfix nilability operator
+" so just match it no matter what
+syn match   chplOperator display "?"  
+
+" if you match ! that follows a valid type name
+syn match   chplOperator display "[a-zA-Z0-9_]\zs!\ze[^=]"   
 
 " Folding
 syn region scopeFold start="{" end="}" fold transparent

--- a/highlight/vim/syntax/chpl.vim
+++ b/highlight/vim/syntax/chpl.vim
@@ -258,7 +258,8 @@ endif
 
 " Chapel extentions
 syn keyword chplStatement	break return continue compilerWarning delete
-syn keyword chplStatement	noinit new delete this these use except only require
+syn keyword chplStatement	new delete this these use except only require
+syn keyword chplStatement	noinit init
 syn keyword chplStatement	as module yield compilerError zip
 syn keyword chplIntent		param type in out inout ref
 syn keyword chplStorageClass    const config export extern var
@@ -286,6 +287,7 @@ syn match   chplOperator display "?"
 " if you match ! that follows a valid type name
 syn match   chplOperator display "[a-zA-Z0-9_]\zs!\ze[^=]"   
 
+
 " Folding
 syn region scopeFold start="{" end="}" fold transparent
 
@@ -302,6 +304,7 @@ if version >= 508 || !exists("did_chpl_syntax_inits")
   endif
   HiLink chplCast		chplStatement
   HiLink chplErrorHandling	chplStatement
+  HiLink chplInitAssign 	chplOperator
   HiLink chplOperator		Operator
   HiLink chplStatement		Statement
   HiLink chplIntent		StorageClass

--- a/highlight/vim/syntax/chpl.vim
+++ b/highlight/vim/syntax/chpl.vim
@@ -304,7 +304,6 @@ if version >= 508 || !exists("did_chpl_syntax_inits")
   endif
   HiLink chplCast		chplStatement
   HiLink chplErrorHandling	chplStatement
-  HiLink chplInitAssign 	chplOperator
   HiLink chplOperator		Operator
   HiLink chplStatement		Statement
   HiLink chplIntent		StorageClass


### PR DESCRIPTION
This PR makes the following changes in some of the highlighters:

vim
---
- `b""`, `b''`, `c""`, `c''`
- `bytes`, `init`, `lifetime`, `none`


source-highlight
----------------
This one seems rather rudimentary, I just added bunch of missing keywords (some
of which are from earlier releases) and `bytes`, `nothing` and `void`