### PR TITLE
Add suppressif for tests that fail with gasnet+quickstart testing on linux

### DIFF
--- a/test/interop/C/multilocale/globals/use_reliesOnGlobal-library-init.suppressif
+++ b/test/interop/C/multilocale/globals/use_reliesOnGlobal-library-init.suppressif
@@ -4,7 +4,7 @@
 # These tests fail when CHPL_TASKS=fifo on linux. For now, suppress them.
 # See: #13475
 #
-if [[ $CHPL_TARGET_PLATFORM == darwin || CHPL_TASKS != fifo ]] ; then
+if [[ $CHPL_TARGET_PLATFORM == darwin || $CHPL_TASKS != fifo ]] ; then
   echo False
 else
   echo True

--- a/test/interop/C/multilocale/globals/use_reliesOnGlobal-library-init.suppressif
+++ b/test/interop/C/multilocale/globals/use_reliesOnGlobal-library-init.suppressif
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+#
+# These tests fail when CHPL_TASKS=fifo on linux. For now, suppress them.
+# See: #13475
+#
+if [[ $CHPL_TARGET_PLATFORM == darwin || CHPL_TASKS != fifo ]] ; then
+  echo False
+else
+  echo True
+fi

--- a/test/interop/C/multilocale/globals/use_reliesOnGlobal.suppressif
+++ b/test/interop/C/multilocale/globals/use_reliesOnGlobal.suppressif
@@ -4,7 +4,7 @@
 # These tests fail when CHPL_TASKS=fifo on linux. For now, suppress them.
 # See: #13475
 #
-if [[ $CHPL_TARGET_PLATFORM == darwin || CHPL_TASKS != fifo ]] ; then
+if [[ $CHPL_TARGET_PLATFORM == darwin || $CHPL_TASKS != fifo ]] ; then
   echo False
 else
   echo True

--- a/test/interop/C/multilocale/globals/use_reliesOnGlobal.suppressif
+++ b/test/interop/C/multilocale/globals/use_reliesOnGlobal.suppressif
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+#
+# These tests fail when CHPL_TASKS=fifo on linux. For now, suppress them.
+# See: #13475
+#
+if [[ $CHPL_TARGET_PLATFORM == darwin || CHPL_TASKS != fifo ]] ; then
+  echo False
+else
+  echo True
+fi


### PR DESCRIPTION
We intend to get back to this soon, but not quite yet.