### PR TITLE
Restore reverse-complement performance with qio hint

### DIFF
--- a/test/release/examples/benchmarks/shootout/revcomp-fast.chpl
+++ b/test/release/examples/benchmarks/shootout/revcomp-fast.chpl
@@ -9,7 +9,8 @@ const table = initTable("ATCGGCTAUAMKRYWWSSYRKMVBHDDHBVNN\n\n");
 
 proc main(args: [] string) {
   const stdin = openfd(0),
-        input = stdin.reader(iokind.native, locking=false),
+        input = stdin.reader(iokind.native, locking=false,
+                             hints=QIO_HINT_PARALLEL),
         len = stdin.length();
   var data: [0..#len] uint(8);
 

--- a/test/studies/shootout/reverse-complement/bharshbarg/revcomp-mark-skip-read-begin.chpl
+++ b/test/studies/shootout/reverse-complement/bharshbarg/revcomp-mark-skip-read-begin.chpl
@@ -10,7 +10,8 @@ config const readSize = 16 * 1024;
 
 proc main(args: [] string) {
   const stdin = openfd(0);
-  var input = stdin.reader(iokind.native, locking=false);
+  var input = stdin.reader(iokind.native, locking=false,
+                           hints=QIO_HINT_PARALLEL);
   var len = stdin.length();
   var data : [0..#len] uint(8);
   

--- a/test/studies/shootout/reverse-complement/bradc/revcomp-blc.chpl
+++ b/test/studies/shootout/reverse-complement/bradc/revcomp-blc.chpl
@@ -8,7 +8,8 @@ const table = initTable("ATCGGCTAUAMKRYWWSSYRKMVBHDDHBVNN\n\n");
 
 proc main(args: [] string) {
   const stdin = openfd(0),
-        input = stdin.reader(iokind.native, locking=false),
+        input = stdin.reader(iokind.native, locking=false,
+                             hints=QIO_HINT_PARALLEL),
         len = stdin.length();
   var data: [0..#len] uint(8);
 


### PR DESCRIPTION
Passes QIO_HINT_PARALLEL to tell runtime to use the mmap method.