### PR TITLE
Stop inlining a string factory function

### DIFF
--- a/compiler/optimizations/deadCodeElimination.cpp
+++ b/compiler/optimizations/deadCodeElimination.cpp
@@ -322,7 +322,7 @@ static bool isDeadStringOrBytesLiteral(VarSymbol* string) {
 //
 //   def  new_temp  : string; // defTemp
 //
-//   call createStringWithBorrowedBuffer(ret, c"literal", ...); // factoryCall
+//   call createStringWithBorrowedBuffer(new_temp,c"literal",...); //factoryCall
 //
 //   move _str_literal_NNN, new_temp;  // this is 'defn' - the single def
 //

--- a/compiler/optimizations/deadCodeElimination.cpp
+++ b/compiler/optimizations/deadCodeElimination.cpp
@@ -322,10 +322,7 @@ static bool isDeadStringOrBytesLiteral(VarSymbol* string) {
 //
 //   def  new_temp  : string; // defTemp
 //
-//   def  ret  : string;  // defFactoryTemp
-//   call init(ret);  // defaultInit
-//   call initWithBorrowedBuffer(ret, c"literal string", ...);  // factoryCall
-//   move new_temp, ret   //tmpMove
+//   call createStringWithBorrowedBuffer(ret, c"literal", ...); // factoryCall
 //
 //   move _str_literal_NNN, new_temp;  // this is 'defn' - the single def
 //
@@ -333,26 +330,17 @@ static void removeDeadStringLiteral(DefExpr* defExpr) {
   SymExpr*   defn  = toVarSymbol(defExpr->sym)->getSingleDef();
 
   // Step backwards from 'defn'
-  Expr* lastMove    = defn->getStmtExpr();
-  //Expr* tmpMove    = lastMove->prev;
-  Expr* factoryCall    = lastMove->prev;
-  //Expr* defaultInit = factoryCall->prev;
-  //Expr* defFactoryTemp = defaultInit->prev;
+  Expr* lastMove = defn->getStmtExpr();
+  Expr* factoryCall = lastMove->prev;
   Expr* defTemp = factoryCall->prev;
 
   // Simple sanity checks
-  INT_ASSERT(isDefExpr (defTemp));
-  //INT_ASSERT(isDefExpr (defFactoryTemp));
-  //INT_ASSERT(isCallExpr(defaultInit));
+  INT_ASSERT(isDefExpr(defTemp));
   INT_ASSERT(isCallExpr(factoryCall));
-  //INT_ASSERT(isCallExpr(tmpMove));
   INT_ASSERT(isCallExpr(lastMove));
 
   lastMove->remove();
-  //tmpMove->remove();
   factoryCall->remove();
-  //defaultInit->remove();
-  //defFactoryTemp->remove();
   defTemp->remove();
 
   defExpr->remove();

--- a/compiler/optimizations/deadCodeElimination.cpp
+++ b/compiler/optimizations/deadCodeElimination.cpp
@@ -334,25 +334,25 @@ static void removeDeadStringLiteral(DefExpr* defExpr) {
 
   // Step backwards from 'defn'
   Expr* lastMove    = defn->getStmtExpr();
-  Expr* tmpMove    = lastMove->prev;
-  Expr* factoryCall    = tmpMove->prev;
-  Expr* defaultInit = factoryCall->prev;
-  Expr* defFactoryTemp = defaultInit->prev;
-  Expr* defTemp = defFactoryTemp->prev;
+  //Expr* tmpMove    = lastMove->prev;
+  Expr* factoryCall    = lastMove->prev;
+  //Expr* defaultInit = factoryCall->prev;
+  //Expr* defFactoryTemp = defaultInit->prev;
+  Expr* defTemp = factoryCall->prev;
 
   // Simple sanity checks
   INT_ASSERT(isDefExpr (defTemp));
-  INT_ASSERT(isDefExpr (defFactoryTemp));
-  INT_ASSERT(isCallExpr(defaultInit));
+  //INT_ASSERT(isDefExpr (defFactoryTemp));
+  //INT_ASSERT(isCallExpr(defaultInit));
   INT_ASSERT(isCallExpr(factoryCall));
-  INT_ASSERT(isCallExpr(tmpMove));
+  //INT_ASSERT(isCallExpr(tmpMove));
   INT_ASSERT(isCallExpr(lastMove));
 
   lastMove->remove();
-  tmpMove->remove();
+  //tmpMove->remove();
   factoryCall->remove();
-  defaultInit->remove();
-  defFactoryTemp->remove();
+  //defaultInit->remove();
+  //defFactoryTemp->remove();
   defTemp->remove();
 
   defExpr->remove();

--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -155,7 +155,7 @@ module Bytes {
     :returns: A new :record:`bytes`
   */
   proc createBytesWithBorrowedBuffer(s: c_string, length=s.length) {
-    //NOTE: This functions is heavily used by the compiler to create bytes
+    //NOTE: This function is heavily used by the compiler to create bytes
     //literals. So, inlining this causes some bloat in the AST that increases
     //the compilation time slightly. Therefore, currently we are keeping this
     //one non-inlined.

--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -155,6 +155,10 @@ module Bytes {
     :returns: A new :record:`bytes`
   */
   proc createBytesWithBorrowedBuffer(s: c_string, length=s.length) {
+    //NOTE: This functions is heavily used by the compiler to create bytes
+    //literals. So, inlining this causes some bloat in the AST that increases
+    //the compilation time slightly. Therefore, currently we are keeping this
+    //one non-inlined.
     return createBytesWithBorrowedBuffer(s:c_ptr(uint(8)), length=length,
                                                             size=length+1);
   }
@@ -1231,6 +1235,7 @@ module Bytes {
 
   } // end of record bytes
 
+  pragma "no doc"
   inline proc _cast(type t: bytes, x: string) {
     return createBytesWithNewBuffer(x.buff, length=x.numBytes, size=x.numBytes+1);
   }

--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -154,7 +154,7 @@ module Bytes {
 
     :returns: A new :record:`bytes`
   */
-  inline proc createBytesWithBorrowedBuffer(s: c_string, length=s.length) {
+  proc createBytesWithBorrowedBuffer(s: c_string, length=s.length) {
     return createBytesWithBorrowedBuffer(s:c_ptr(uint(8)), length=length,
                                                             size=length+1);
   }
@@ -1231,7 +1231,6 @@ module Bytes {
 
   } // end of record bytes
 
-  pragma "no doc"
   inline proc _cast(type t: bytes, x: string) {
     return createBytesWithNewBuffer(x.buff, length=x.numBytes, size=x.numBytes+1);
   }

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -489,7 +489,7 @@ module String {
 
     :returns: A new `string`
   */
-  inline proc createStringWithBorrowedBuffer(s: c_string, length=s.length) {
+  proc createStringWithBorrowedBuffer(s: c_string, length=s.length) {
     return createStringWithBorrowedBuffer(s:c_ptr(uint(8)), length=length,
                                                             size=length+1);
   }

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -490,6 +490,10 @@ module String {
     :returns: A new `string`
   */
   proc createStringWithBorrowedBuffer(s: c_string, length=s.length) {
+    //NOTE: This functions is heavily used by the compiler to create string
+    //literals. So, inlining this causes some bloat in the AST that increases
+    //the compilation time slightly. Therefore, currently we are keeping this
+    //one non-inlined.
     return createStringWithBorrowedBuffer(s:c_ptr(uint(8)), length=length,
                                                             size=length+1);
   }

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -490,7 +490,7 @@ module String {
     :returns: A new `string`
   */
   proc createStringWithBorrowedBuffer(s: c_string, length=s.length) {
-    //NOTE: This functions is heavily used by the compiler to create string
+    //NOTE: This function is heavily used by the compiler to create string
     //literals. So, inlining this causes some bloat in the AST that increases
     //the compilation time slightly. Therefore, currently we are keeping this
     //one non-inlined.


### PR DESCRIPTION
This PR removes inlining for one of the string/bytes factory functions. The
function in question is used by the compiler to create string/bytes literals. We
have observed some compiler performance regression due to this inlining.

This keeps the rest of the factory functions inlined.

This seems to help the most with copyPropagation, inlineFunctions and 
refPropagation passes.

Test:
- [x] standard
- [x] gasnet

