### PR TITLE
Handles multiple files having same name but in different directories in `mason test`

### DIFF
--- a/modules/packages/UnitTest.chpl
+++ b/modules/packages/UnitTest.chpl
@@ -1035,7 +1035,13 @@ module UnitTest {
       }
       if !canRun {
         var localesStr: string = this.dictDomain: string;
-        var localesErrorStr: string = "Required Locales = "+localesStr:string;
+        var tempLocales: list(string);
+        for loc in localesStr.split(" ") {
+          tempLocales.append(loc: string);
+        }
+        var localesErrorStr= "Required Locales = ";
+        if tempLocales.size > 1 then localesErrorStr += ",".join(tempLocales.toArray()); 
+        else localesErrorStr += localesStr:string;
         throw new owned TestIncorrectNumLocales(localesErrorStr);
       }
     }
@@ -1246,7 +1252,7 @@ module UnitTest {
         if checkCircleCount > 0 {
           testsSkipped[testName] = true;
           circleFound = true;
-          var failReason = testName + " skipped as circular dependency found";
+          var failReason = testName + " skipped because circular dependency found";
           testResult.addSkip(testName, failReason);
           testStatus[testName] = true;
           return;
@@ -1269,14 +1275,14 @@ module UnitTest {
             // if super test failed
             if testsFailed[superTest: string] {
               testsSkipped[testName] = true; // current test have failed or skipped
-              var skipReason = testName + " skipped as " + superTest: string +" failed";
+              var skipReason = testName + " skipped because " + superTest: string +" failed";
               testResult.addSkip(testName, skipReason);
               break;
             }
             // if super test failed
             if testsSkipped[superTest: string] {
               testsSkipped[testName] = true; // current test have failed or skipped
-              var skipReason = testName + " skipped as " + superTest: string +" skipped";
+              var skipReason = testName + " skipped because " + superTest: string +" skipped";
               testResult.addSkip(testName, skipReason);
               break;
             }
@@ -1291,7 +1297,7 @@ module UnitTest {
             // if superTest error then
             if testsErrored[superTest: string] {
               testsSkipped[testName] = true;
-              var skipReason = testName + " skipped as " + superTest: string +" gave an Error";
+              var skipReason = testName + " skipped because " + superTest: string +" gave an Error";
               testResult.addSkip(testName, skipReason);
               break;
             }
@@ -1300,27 +1306,27 @@ module UnitTest {
         // super test Errored
         else if testsErrored[superTest: string] {
           testsSkipped[testName] = true;
-          var skipReason = testName + " skipped as " + superTest: string +" gave an Error";
+          var skipReason = testName + " skipped because " + superTest: string +" gave an Error";
           testResult.addSkip(testName, skipReason);
           break;
         }
         // super test Skipped 
         else if testsSkipped[superTest: string] {
           testsSkipped[testName] = true;
-          var skipReason = testName + " skipped as " + superTest: string +" Skipped";
+          var skipReason = testName + " skipped because " + superTest: string +" Skipped";
           testResult.addSkip(testName, skipReason);
           break;
         }
         //super test failed
         else {
           testsSkipped[testName] = true; // current test have failed or skipped
-          var skipReason = testName + " skipped as " + superTest: string +" failed";
+          var skipReason = testName + " skipped because " + superTest: string +" failed";
           testResult.addSkip(testName, skipReason);
         }
       }
       if circleFound {
         testsSkipped[testName] = true;
-        var skipReason = testName + " skipped as circular dependency found";
+        var skipReason = testName + " skipped because circular dependency found";
         testResult.addSkip(testName, skipReason);
       }
       // Test is not having error or failures or dependency or skipped

--- a/test/library/packages/UnitTest/launcher_Test.WithModule.good
+++ b/test/library/packages/UnitTest/launcher_Test.WithModule.good
@@ -10,6 +10,6 @@ SKIPPED test_WithModule.chpl: test3()
 TestSkipped: Skipping Test 3
 
 ----------------------------------------------------------------------
-Run 3 tests in n seconds
+Ran 3 tests in n seconds
 
 FAILED (passed = 2 failures = 1 skipped = 1 )

--- a/test/library/packages/UnitTest/launcher_Test.dependency.good
+++ b/test/library/packages/UnitTest/launcher_Test.dependency.good
@@ -1,5 +1,5 @@
 
 ----------------------------------------------------------------------
-Run 4 tests in n seconds
+Ran 4 tests in n seconds
 
 OK (passed = 4 )

--- a/test/library/packages/UnitTest/launcher_Test.fail.good
+++ b/test/library/packages/UnitTest/launcher_Test.fail.good
@@ -26,6 +26,6 @@ SKIPPED test_fail.chpl: test3()
 TestSkipped: Skipping Test 3
 
 ----------------------------------------------------------------------
-Run 2 tests in n seconds
+Ran 2 tests in n seconds
 
 FAILED (failures = 2 skipped = 1 )

--- a/test/library/packages/UnitTest/launcher_Test.folder.good
+++ b/test/library/packages/UnitTest/launcher_Test.folder.good
@@ -26,6 +26,6 @@ SKIPPED test_fail.chpl: test3()
 TestSkipped: Skipping Test 3
 
 ----------------------------------------------------------------------
-Run 5 tests in n seconds
+Ran 5 tests in n seconds
 
 FAILED (passed = 3 failures = 2 skipped = 1 )

--- a/test/library/packages/UnitTest/launcher_Test.folderok.good
+++ b/test/library/packages/UnitTest/launcher_Test.folderok.good
@@ -1,5 +1,5 @@
 
 ----------------------------------------------------------------------
-Run 3 tests in n seconds
+Ran 3 tests in n seconds
 
 OK (passed = 3 )

--- a/test/library/packages/UnitTest/launcher_Test.halt.good
+++ b/test/library/packages/UnitTest/launcher_Test.halt.good
@@ -10,6 +10,6 @@ FAIL test_halt.chpl: test3()
 AssertionError: assert failed - '2' != '3.0'
 
 ----------------------------------------------------------------------
-Run 3 tests in n seconds
+Ran 3 tests in n seconds
 
 FAILED (passed = 1 failures = 1 errors = 1 )

--- a/test/library/packages/UnitTest/launcher_Test.numLocales.comm-none.good
+++ b/test/library/packages/UnitTest/launcher_Test.numLocales.comm-none.good
@@ -30,7 +30,7 @@ TestIncorrectNumLocales: Required Locales = 2
 SKIPPED test_locales.chpl: s3()
 ----------------------------------------------------------------------
 Not a MultiLocale Environment. $CHPL_COMM = none
-TestIncorrectNumLocales: Required Locales = 16 8
+TestIncorrectNumLocales: Required Locales = 16,8
 
 ======================================================================
 SKIPPED test_locales.chpl: s6()
@@ -42,35 +42,35 @@ TestIncorrectNumLocales: Required Locales = 6
 SKIPPED test_locales.chpl: s7()
 ----------------------------------------------------------------------
 Not a MultiLocale Environment. $CHPL_COMM = none
-TestIncorrectNumLocales: Required Locales = 16 8
+TestIncorrectNumLocales: Required Locales = 16,8
 
 ======================================================================
 SKIPPED test_locales.chpl: s9()
 ----------------------------------------------------------------------
 Not a MultiLocale Environment. $CHPL_COMM = none
-TestIncorrectNumLocales: Required Locales = 16 8
+TestIncorrectNumLocales: Required Locales = 16,8
 
 ======================================================================
 SKIPPED test_locales.chpl: s14()
 ----------------------------------------------------------------------
-s14() skipped as s10() gave an Error
+s14() skipped because s10() gave an Error
 
 ======================================================================
 SKIPPED test_locales.chpl: s11()
 ----------------------------------------------------------------------
-s11() skipped as s14() skipped
+s11() skipped because s14() skipped
 
 ======================================================================
 SKIPPED test_locales.chpl: s12()
 ----------------------------------------------------------------------
-s12() skipped as s2() Skipped
+s12() skipped because s2() Skipped
 
 ======================================================================
 SKIPPED test_locales.chpl: s13()
 ----------------------------------------------------------------------
-s13() skipped as s8() failed
+s13() skipped because s8() failed
 
 ----------------------------------------------------------------------
-Run 4 tests in n seconds
+Ran 4 tests in n seconds
 
 FAILED (passed = 1 failures = 2 errors = 1 skipped = 10 )

--- a/test/library/packages/UnitTest/launcher_Test.numLocales.good
+++ b/test/library/packages/UnitTest/launcher_Test.numLocales.good
@@ -22,19 +22,19 @@ UnexpectedLocales: Locales already added.
 ======================================================================
 SKIPPED test_locales.chpl: s14()
 ----------------------------------------------------------------------
-s14() skipped as s10() gave an Error
+s14() skipped because s10() gave an Error
 
 ======================================================================
 SKIPPED test_locales.chpl: s11()
 ----------------------------------------------------------------------
-s11() skipped as s14() skipped
+s11() skipped because s14() skipped
 
 ======================================================================
 SKIPPED test_locales.chpl: s13()
 ----------------------------------------------------------------------
-s13() skipped as s8() failed
+s13() skipped because s8() failed
 
 ----------------------------------------------------------------------
-Run 11 tests in n seconds
+Ran 11 tests in n seconds
 
 FAILED (passed = 7 failures = 3 errors = 1 skipped = 3 )

--- a/test/library/packages/UnitTest/launcher_Test.skipfile.good
+++ b/test/library/packages/UnitTest/launcher_Test.skipfile.good
@@ -5,6 +5,6 @@ SKIPPED test_skip.chpl: test3()
 TestSkipped: Skipping Test 3
 
 ----------------------------------------------------------------------
-Run 2 tests in n seconds
+Ran 2 tests in n seconds
 
 OK (passed = 2 skipped = 1 )

--- a/test/mason/mason-test/mason-test.good
+++ b/test/mason/mason-test/mason-test.good
@@ -6,6 +6,6 @@ FAIL shallnotpass.chpl: shallnotpass
 ----------------------------------------------------------------------
 shallnotpass returned exitCode = 255
 ----------------------------------------------------------------------
-Run 6 tests in n seconds
+Ran 6 tests in n seconds
 
 FAILED (passed = 5 failures = 1 )

--- a/tools/mason/MasonTest.chpl
+++ b/tools/mason/MasonTest.chpl
@@ -205,11 +205,9 @@ private proc runTestBinary(projectHome: string, outputLoc: string, testName: str
       erroredTestNames: list(string),
       testsPassed: list(string),
       skippedTestNames: list(string);
-  var dictDomain: domain(int);
-  var dict: [dictDomain] int;
+  var localesCountMap: map(int, int, parSafe=true);
   const exitCode = runAndLog(command, testName+".chpl", result, numLocales, testsPassed,
-            testNames, dictDomain, dict, failedTestNames, erroredTestNames,
-            skippedTestNames, show);
+            testNames, localesCountMap, failedTestNames, erroredTestNames, skippedTestNames, show);
   if exitCode != 0 {
     const newCommand = " ".join(command,"-nl","1");
     const testResult = runWithStatus(newCommand, show);
@@ -410,11 +408,9 @@ proc testFile(file, ref result, show: bool) throws {
         erroredTestNames: list(string),
         testsPassed: list(string),
         skippedTestNames: list(string);
-    var dictDomain: domain(int);
-    var dict: [dictDomain] int;
+    var localesCountMap: map(int, int, parSafe=true);
     const exitCode = runAndLog("./"+executable, fileName, result, numLocales, testsPassed,
-              testNames, dictDomain, dict, failedTestNames, erroredTestNames,
-              skippedTestNames, show);
+              testNames, localesCountMap, failedTestNames, erroredTestNames, skippedTestNames, show);
     if exitCode != 0 {
       const command = " ".join("./"+executable,"-nl","1");
       const testResult = runWithStatus(command, show);
@@ -448,7 +444,7 @@ proc testDirectory(dir, ref result, show: bool) throws {
 pragma "no doc"
 /*Docs: Todo*/
 proc runAndLog(executable, fileName, ref result, reqNumLocales: int = numLocales,
-              ref testsPassed, ref testNames, ref dictDomain, ref dict, 
+              ref testsPassed, ref testNames, ref localesCountMap, 
               ref failedTestNames, ref erroredTestNames, ref skippedTestNames, show: bool): int throws 
 {
   var separator1 = result.separator1,
@@ -492,7 +488,7 @@ proc runAndLog(executable, fileName, ref result, reqNumLocales: int = numLocales
       var testName = try! currentRunningTests.pop();
       if testNames.count(testName) != 0 then
         try! testNames.remove(testName);
-      addTestResult(result, dictDomain, dict, testNames, flavour, fileName, 
+      addTestResult(result, localesCountMap, testNames, flavour, fileName, 
                 testName, testExecMsg, failedTestNames, erroredTestNames, 
                 skippedTestNames, testsPassed, show);
       testExecMsg = "";
@@ -535,27 +531,25 @@ proc runAndLog(executable, fileName, ref result, reqNumLocales: int = numLocales
   exitCode = exec.exit_status;
   if haltOccured then
     exitCode = runAndLog(executable, fileName, result, reqNumLocales, testsPassed,
-              testNames, dictDomain, dict, failedTestNames, erroredTestNames,
-              skippedTestNames, show);
+              testNames, localesCountMap, failedTestNames, erroredTestNames, skippedTestNames, show);
   if testNames.size != 0 {
     var maxCount = -1;
-    for key in dictDomain.sorted() {
-      if maxCount < dict[key] {
+    for key in localesCountMap {
+      if maxCount < localesCountMap[key] {
         reqLocales = key;
-        maxCount = dict[key];
+        maxCount = localesCountMap[key];
       }
     }
-    dictDomain.remove(reqLocales);
+    localesCountMap.remove(reqLocales);
     exitCode = runAndLog(executable, fileName, result, reqLocales, testsPassed,
-              testNames, dictDomain, dict, failedTestNames, erroredTestNames, 
-              skippedTestNames, show);
+              testNames, localesCountMap, failedTestNames, erroredTestNames, skippedTestNames, show);
   }
   return exitCode;
 }
 
 pragma "no doc"
 /*Docs: Todo*/
-proc addTestResult(ref result, ref dictDomain, ref dict, ref testNames, 
+proc addTestResult(ref result, ref localesCountMap, ref testNames, 
                   flavour, fileName, testName, errMsg, ref failedTestNames, 
                   ref erroredTestNames, ref skippedTestNames, ref testsPassed,
                   show: bool) throws 
@@ -584,12 +578,12 @@ proc addTestResult(ref result, ref dictDomain, ref dict, ref testNames,
     when "IncorrectNumLocales" {
       if comm != "none" {
         var strSplit = errMsg.split("=");
-        var reqLocalesStr = strSplit[2].strip().split(" ");
+        var reqLocalesStr = strSplit[2].strip().split(",");
         for a in reqLocalesStr do
-          if dictDomain.contains(a: int) then
-            dict[a: int] += 1;
+          if localesCountMap.contains(a: int) then
+            localesCountMap[a: int] += 1;
           else
-            dict[a: int] = 1;
+            localesCountMap[a: int] = 1;
         testNames.append(testName);
       }
       else {

--- a/tools/mason/MasonTest.chpl
+++ b/tools/mason/MasonTest.chpl
@@ -162,7 +162,8 @@ private proc runTests(show: bool, run: bool, parallel: bool, ref cmdLineCompopts
         const masonCompopts = getMasonDependencies(sourceList, testName);
         const allCompOpts = "".join(" ".join(compopts.these()), masonCompopts);
 
-        const moveTo = "-o " + projectHome + "/target/test/" + testName;
+        const outputLoc = projectHome + "/target/test/" + stripExt(test, ".chpl");
+        const moveTo = "-o " + outputLoc;
         const compCommand = " ".join("chpl",testPath, projectPath, moveTo, allCompOpts);
         const compilation = runWithStatus(compCommand);
         
@@ -172,7 +173,7 @@ private proc runTests(show: bool, run: bool, parallel: bool, ref cmdLineCompopts
         else {
           if show || !run then writeln("Compiled '", test, "' successfully");
           if parallel {
-            runTestBinary(projectHome, testName, result, show);
+            runTestBinary(projectHome, outputLoc, testName, result, show);
           }
         }
       }
@@ -196,8 +197,9 @@ private proc runTests(show: bool, run: bool, parallel: bool, ref cmdLineCompopts
 }
 
 
-private proc runTestBinary(projectHome: string, testName: string, ref result, show: bool) {
-  const command = "".join(projectHome,'/target/test/', testName);
+private proc runTestBinary(projectHome: string, outputLoc: string, testName: string, 
+                        ref result, show: bool) {
+  const command = outputLoc;
   var testNames: list(string),
       failedTestNames: list(string),
       erroredTestNames: list(string),
@@ -226,8 +228,9 @@ private proc runTestBinaries(projectHome: string, testNames: list(string),
                              numTests: int, ref result, show: bool) {
 
   for test in testNames {
+    const outputLoc = projectHome + "/target/test/" + stripExt(test, ".chpl");
     const testName = basename(stripExt(test, ".chpl"));
-    runTestBinary(projectHome, testName, result, show);
+    runTestBinary(projectHome, outputLoc, testName, result, show);
   }
 }
 

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -55,7 +55,6 @@ proc makeTargetFiles(binLoc: string, projectHome: string) {
 
   const target = joinPath(projectHome, 'target');
   const srcBin = joinPath(target, binLoc);
-  const test = joinPath(target, 'test');
   const example = joinPath(target, 'example');
 
   if !isDir(target) {
@@ -64,11 +63,22 @@ proc makeTargetFiles(binLoc: string, projectHome: string) {
   if !isDir(srcBin) {
     mkdir(srcBin);
   }
-  if !isDir(test) {
-    mkdir(test);
-  }
   if !isDir(example) {
     mkdir(example);
+  }
+
+  const actualTest = joinPath(projectHome,'test');
+  if isDir(actualTest) {
+    for dir in walkdirs(actualTest) {
+      const internalDir = target+dir.replace(projectHome,"");
+      if !isDir(internalDir) {
+        mkdir(internalDir);
+      }
+    }
+  }
+  const test = joinPath(target, 'test');
+  if(!isDir(test)) {
+    mkdir(test);
   }
 }
 

--- a/tools/mason/TestResult.chpl
+++ b/tools/mason/TestResult.chpl
@@ -116,7 +116,7 @@ module TestResult {
       var skipped = this.numSkippedTests();
       var run = this.testsRun - skipped;
       if this.testsRun != 0 {
-        writeln("Run ", run, " ", printTest(run)," in ",timeTaken," seconds");
+        writeln("Ran ", run, " ", printTest(run)," in ",timeTaken," seconds");
         writeln();
         var infos: list((string));
         if testsPassed != 0 then 


### PR DESCRIPTION
This PR removes the bug where the test files with the same name but present in different directories (inside a mason package) were giving wrong results during mason test.

Also in this PR:

  - Removes some deprecated usage of associative array and replaces with map in `UnitTest` and `mason test`. 
  - modifies some output messages in `UnitTest` to be more clear