### PR TITLE
Close a memory leak in chpldev_refToString

### DIFF
--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -2442,9 +2442,12 @@ module String {
   proc chpldev_refToString(ref arg) : string {
     // print out the address of class references as well
     proc chpldev_classToString(x: object) : string
-      return " (class = " + __primitive("ref to string", x):string + ")";
+      return " (class = " +
+             createStringWithOwnedBuffer(__primitive("ref to string", arg)) +
+             ")";
     proc chpldev_classToString(x) : string return "";
 
-    return __primitive("ref to string", arg):string + chpldev_classToString(arg);
+    return createStringWithOwnedBuffer(__primitive("ref to string", arg)) +
+           chpldev_classToString(arg);
   }
 }


### PR DESCRIPTION
Close a memory leak due to casting a c_string to a string directly.

This helper in String.chpl was leaking memory and was responsible for close to
at least 300 bytes of leaks in the nightlies. I am not sure if the helper is
necessary in the long run as I couldn't find any occurence anywhere besides
tests via some grepping. Regardless, the helper should be using the factory
functions and not a cast to create a Chapel string from a c_string.

Test:
- [ ] standard (running)