### PR TITLE
Restrict applicability of field intents

### DIFF
--- a/compiler/resolution/implementForallIntents.cpp
+++ b/compiler/resolution/implementForallIntents.cpp
@@ -801,13 +801,7 @@ static void resolveShadowVarTypeIntent(Type*& type, ForallIntentTag& intent,
 static AggregateType* isRecordReceiver(Symbol* sym) {
   if (sym->hasFlag(FLAG_ARG_THIS))
     if (Type* type = sym->type->getValType())
-      if (isRecord(type)                      &&
-          // Array-typed 'this' could be passed by ref-intent and so "pruned",
-          // see resolveShadowVarTypeIntent(). Then, there would not be
-          // a shadow variable for it and convertFieldsOfRecordReceiver()
-          // would not see it and would not do the transformations.
-          // So, skip arrays always, for consistency.
-          ! type->symbol->hasFlag(FLAG_ARRAY) )
+      if (isUserRecord(type))
         return toAggregateType(type);
   return NULL;
 }


### PR DESCRIPTION
#13297 proposed new semantics of task/forall intents w.r.t. fields of `this` when `this` is a record. It was implemented in #13479 and #13840.

That implementation cast a wide net, applying the transformation for any type that `isRecord()` in the compiler, except arrays. However, #13297 talked only about fields of user-level records.

This change makes the implementation apply transformation only to user-level records.

Testing:
* [x] linux64 -futures
* [x] gasnet multilocale tests
* [x] numa