### PR TITLE
Delete unmanaged domain maps in tests

### DIFF
--- a/test/distributions/dm/s7.chpl
+++ b/test/distributions/dm/s7.chpl
@@ -98,6 +98,11 @@ writeln();
 writeln(Ab);
 writeln("DONE");
 
+delete rdim1;
+delete bdim1;
+delete rdim2;
+delete bdim2;
+
 proc test(X, Y, Z) {
   for (x, y, z) in zip(X, Y, Z) do x = y + z;
 }

--- a/test/distributions/dm/s8.chpl
+++ b/test/distributions/dm/s8.chpl
@@ -73,3 +73,6 @@ proc test(A, ix1, ix2) {
 
 test(Ab[1..n, 1..3],           (1,1), (2,2));
 test(Ab[1..n by 3, 5..n by 2], (4,5), (7,7));
+
+delete dd1;
+delete dd2;

--- a/test/distributions/dm/t8.chpl
+++ b/test/distributions/dm/t8.chpl
@@ -176,6 +176,9 @@ proc testsuite(type T, initphase) {
   tw(5,11, 47,42);
   tw(11,5, 42,47);
   tw(11,5, 47,42);
+
+  delete df8;
+  delete df9;
 }
 
 testsuite(int(64),  1000);

--- a/test/distributions/dm/t9.chpl
+++ b/test/distributions/dm/t9.chpl
@@ -148,3 +148,7 @@ tl();
 //privTest(dmarr, (1,0), (3,1), 0);
 //privTest(dmarr, (1,1), (3,3), 0);
 //tl();
+
+delete vdf;
+delete sdf;
+delete ddf;

--- a/test/distributions/dm/t9.chpl
+++ b/test/distributions/dm/t9.chpl
@@ -151,7 +151,4 @@ tl();
 
 delete vdf;
 delete sdf;
-// ENGIN: I think we should delete ddf, too.
-// But doing so gives a ton of valgrind errors. Happily, not
-// deleting it doesn't cause any leaks?
-//delete ddf;
+// 'ddf' is wrapped into a 'dmap' and so is deleted automatically.

--- a/test/distributions/dm/t9.chpl
+++ b/test/distributions/dm/t9.chpl
@@ -151,4 +151,7 @@ tl();
 
 delete vdf;
 delete sdf;
-delete ddf;
+// ENGIN: I think we should delete ddf, too.
+// But doing so gives a ton of valgrind errors. Happily, not
+// deleting it doesn't cause any leaks?
+//delete ddf;

--- a/test/studies/hpcc/HPL/vass/bug.chpl
+++ b/test/studies/hpcc/HPL/vass/bug.chpl
@@ -104,6 +104,10 @@ writeln(
   else "not verified"
 );
 
+delete bdim1;
+delete rdim1;
+delete bdim2;
+delete rdim2;
 
 /////////////////////////////////////////////////////////////////////////////
 

--- a/test/studies/hpcc/HPL/vass/schurComplement.chpl
+++ b/test/studies/hpcc/HPL/vass/schurComplement.chpl
@@ -225,6 +225,10 @@ proc dgemm(LreplA, LreplB, LAb) {
     }
 }
 
+delete bdim1;
+delete rdim1;
+delete bdim2;
+delete rdim2;
 
 /////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
Deletes bunch of unmanaged variables in tests.

I came across those while investigating string leaks. Overall, leaks from these
tests roughly amount to ~1500 bytes.

Tests locally pass with:
- [x] standard
- [x] standard valgrind
- [x] gasnet