### PR TITLE
Update chpl2rst to only remove initial // in comments

### DIFF
--- a/doc/util/chpl2rst.py
+++ b/doc/util/chpl2rst.py
@@ -184,7 +184,7 @@ def gen_rst(handle):
             rstline = line
             if state == 'linecomment':
                 # Strip white space for line comments
-                rstline = rstline.replace('//', '  ')
+                rstline = rstline.replace('//', '  ', 1)
                 rstline = rstline.strip()
             else:
                 # Preserve white space for block comments, for indent purposes


### PR DESCRIPTION
`chpl2rst.py` was removing `//` from places it shouldn't such as URLs. This updates `chpl2rst` to only remove first instance of `//` in comments.