### PR TITLE
Optimize the method map.this(k)

### DIFF
--- a/modules/standard/Map.chpl
+++ b/modules/standard/Map.chpl
@@ -185,11 +185,23 @@ module Map {
     */
     proc this(k: keyType) ref {
       _enter();
-      if !keys.contains(k) then
-        keys += k;
-      ref result = vals[k];
-      _leave();
-      return result;
+      var (found, slotNum) = keys._value._findFilledSlot(k, needLock=false);
+
+      if found {
+        ref result = vals._value.data[slotNum];
+        _leave();
+        return result;
+      } else if slotNum != -1 {
+        const (newSlot, _) = keys._value._addWrapper(k, slotNum, needLock=false);
+        ref result = vals._value.data[newSlot];
+        _leave();
+        return result;
+      } else {
+        halt("map index out of bounds: ", k);
+        ref result = vals._value.data[0];
+        _leave();
+        return result;
+      }
     }
 
     pragma "no doc"


### PR DESCRIPTION
Make the map accessor do the same thing the associative array accessor did
prior to deprecating adding indices to the domain through the array.  It uses
internal functions to increase speed of checking if the index is already in
the domain and add it if not.

This should resolve the knucleotide performance regression from #13945.