### PR TITLE
Make modules declared in functions be a user facing error

### DIFF
--- a/compiler/AST/ModuleSymbol.cpp
+++ b/compiler/AST/ModuleSymbol.cpp
@@ -623,7 +623,7 @@ void ModuleSymbol::addDefaultUses() {
 
     if (parentModule == NULL) {
       SET_LINENO(this);
-      USR_FATAL("Modules must be declared inside modules or at file-scope");
+      USR_FATAL("Modules must be declared at module- or file-scope");
     }
 
     //

--- a/compiler/AST/ModuleSymbol.cpp
+++ b/compiler/AST/ModuleSymbol.cpp
@@ -621,7 +621,10 @@ void ModuleSymbol::addDefaultUses() {
   if (modTag != MOD_INTERNAL) {
     ModuleSymbol* parentModule = toModuleSymbol(this->defPoint->parentSymbol);
 
-    assert (parentModule != NULL);
+    if (parentModule == NULL) {
+      SET_LINENO(this);
+      USR_FATAL("Modules must be declared inside modules or at file-scope");
+    }
 
     //
     // Don't insert 'use ChapelStandard' for nested user modules.

--- a/compiler/AST/ModuleSymbol.cpp
+++ b/compiler/AST/ModuleSymbol.cpp
@@ -622,8 +622,7 @@ void ModuleSymbol::addDefaultUses() {
     ModuleSymbol* parentModule = toModuleSymbol(this->defPoint->parentSymbol);
 
     if (parentModule == NULL) {
-      SET_LINENO(this);
-      USR_FATAL("Modules must be declared at module- or file-scope");
+      USR_FATAL(this, "Modules must be declared at module- or file-scope");
     }
 
     //

--- a/test/modules/lydia/inFunc.chpl
+++ b/test/modules/lydia/inFunc.chpl
@@ -1,0 +1,8 @@
+module M {
+  proc uhoh() {
+    module realBad {
+    }
+  }
+}
+
+uhoh();

--- a/test/modules/lydia/inFunc.good
+++ b/test/modules/lydia/inFunc.good
@@ -1,2 +1,2 @@
-inFunc.chpl:3: error: Modules must be declared inside modules or at file-scope
+inFunc.chpl:3: error: Modules must be declared at module- or file-scope
 Note: This source location is a guess.

--- a/test/modules/lydia/inFunc.good
+++ b/test/modules/lydia/inFunc.good
@@ -1,2 +1,1 @@
 inFunc.chpl:3: error: Modules must be declared at module- or file-scope
-Note: This source location is a guess.

--- a/test/modules/lydia/inFunc.good
+++ b/test/modules/lydia/inFunc.good
@@ -1,0 +1,2 @@
+inFunc.chpl:3: error: Modules must be declared inside modules or at file-scope
+Note: This source location is a guess.


### PR DESCRIPTION
Prior to this change, this just caused a confusing compiler assertion.  The
spec says it should be an error, so make it a nice error message.

This PR also adds a test to lock in the behavior

Passed paratest with futures