### PR TITLE
Add more deletes in tests

### DIFF
--- a/test/distributions/dm/s9.chpl
+++ b/test/distributions/dm/s9.chpl
@@ -75,3 +75,6 @@ proc test(A, ix1, ix2) {
 
 test(Ab[1..n, 1..3],           (1,1), (2,2));
 test(Ab[1..n by 3, 5..n by 2], (4,5), (7,7));
+
+delete dd1;
+delete dd2;

--- a/test/distributions/dm/t1.chpl
+++ b/test/distributions/dm/t1.chpl
@@ -122,3 +122,6 @@ tl();
 //privTest(dmarr, (1,0), (3,1), 0);
 //privTest(dmarr, (1,1), (3,3), 0);
 //tl();
+
+delete vdf;
+delete sdf;

--- a/test/distributions/dm/t2.chpl
+++ b/test/distributions/dm/t2.chpl
@@ -58,6 +58,9 @@ proc testsuite(type T, initphase) {
   test({1:T..1:T, 0:T..9:T by  3 } dmapped dm);
   test({1:T..1:T, 0:T..9:T by  2 } dmapped dm);
   test({1:T..1:T, 3:T..9:T by -3 } dmapped dm);
+
+  delete vdf;
+  delete sdf;
 }
 
 testsuite(int,        0);

--- a/test/distributions/dm/t5a.chpl
+++ b/test/distributions/dm/t5a.chpl
@@ -40,6 +40,9 @@ proc test(message, sel, dd1, dd2) {
   } else {
     hd("not selected"); tl();
   }
+
+  delete dd1;
+  delete dd2;
 }
 
 test("ReplicatedDim,ReplicatedDim", 1, new unmanaged ReplicatedDim(s1), new unmanaged ReplicatedDim(s2));

--- a/test/studies/hpcc/HPL/vass/bc.dim.chpl
+++ b/test/studies/hpcc/HPL/vass/bc.dim.chpl
@@ -113,6 +113,10 @@ writeln(
   else "not verified"
 );
 
+delete bdim1;
+delete rdim1;
+delete bdim2;
+delete rdim2;
 
 /////////////////////////////////////////////////////////////////////////////
 

--- a/test/studies/hpcc/HPL/vass/bc.md.chpl
+++ b/test/studies/hpcc/HPL/vass/bc.md.chpl
@@ -113,6 +113,11 @@ writeln(
   else "not verified"
 );
 
+delete bdim1;
+delete rdim1;
+delete bdim2;
+delete rdim2;
+
 
 /////////////////////////////////////////////////////////////////////////////
 

--- a/test/studies/hpcc/HPL/vass/bl.dim.chpl
+++ b/test/studies/hpcc/HPL/vass/bl.dim.chpl
@@ -113,6 +113,10 @@ writeln(
   else "not verified"
 );
 
+delete bdim1;
+delete rdim1;
+delete bdim2;
+delete rdim2;
 
 /////////////////////////////////////////////////////////////////////////////
 

--- a/test/studies/hpcc/HPL/vass/bl.md.chpl
+++ b/test/studies/hpcc/HPL/vass/bl.md.chpl
@@ -113,6 +113,10 @@ writeln(
   else "not verified"
 );
 
+delete bdim1;
+delete rdim1;
+delete bdim2;
+delete rdim2;
 
 /////////////////////////////////////////////////////////////////////////////
 

--- a/test/studies/hpcc/HPL/vass/hpl.chpl
+++ b/test/studies/hpcc/HPL/vass/hpl.chpl
@@ -133,7 +133,7 @@ config var reproducible = false, verbose = false;
 
   delete bdim1;
   delete rdim1;
-  delete bdim1;
+  delete bdim2;
   delete rdim2;
 
 //

--- a/test/studies/hpcc/HPL/vass/hpl.chpl
+++ b/test/studies/hpcc/HPL/vass/hpl.chpl
@@ -131,6 +131,11 @@ config var reproducible = false, verbose = false;
   const validAnswer = verifyResults(x);
   printResults(validAnswer, execTime);
 
+  delete bdim1;
+  delete rdim1;
+  delete bdim1;
+  delete rdim2;
+
 //
 // blocked LU factorization with pivoting for matrix augmented with
 // vector of RHS values.


### PR DESCRIPTION
Follow on to #14059 

There are similar tests to my previous PR that leaks due to unmanaged distributions.

Passing owned distributions to DimensionalDist2D doesn't seem to compile, so we have to pass unmanaged distributions. As far as I can understand that's the bug in DimensionalDist2D. So, as a workaround we have to pass unmanaged distributions. And I think for whatever reason, if we are creating unmanaged objects we need to cleanup.

Test:
- [x] standard
- [x] gasnet
- [x] standard valgrind