### PR TITLE
Fix a typo, wordsmith, and add link to 1.19 documentation archives

### DIFF
--- a/doc/rst/language/archivedSpecs.rst
+++ b/doc/rst/language/archivedSpecs.rst
@@ -6,6 +6,7 @@ Documentation Archives
 Online Documentation Archives
 -----------------------------
 
+* `Chapel 1.19 <https://chapel-lang.org/docs/1.19/index.html>`_
 * `Chapel 1.18 <https://chapel-lang.org/docs/1.18/index.html>`_
 * `Chapel 1.17 <https://chapel-lang.org/docs/1.17/index.html>`_
 * `Chapel 1.16 <https://chapel-lang.org/docs/1.16/index.html>`_

--- a/doc/rst/language/spec.rst
+++ b/doc/rst/language/spec.rst
@@ -5,4 +5,5 @@ Chapel Language Specification
 
 :download:`View Language Specification [pdf] <chapelLanguageSpec.pdf>`
 
-To see language specifications of previous versions, see :ref:`Archived Languages Specifications<chapel-archived-specs>`.
+To see previous versions of the Chapel language specification, refer
+to the :ref:`Documentation Archives<chapel-archived-specs>`.


### PR DESCRIPTION
TODO: We should get in the habit of revving the archivedSpecs.rst file when we bump general
release version numbers.