### PR TITLE
Shasta: adapt to cray-release file unavailability.

### DIFF
--- a/util/chplenv/chpl_platform.py
+++ b/util/chplenv/chpl_platform.py
@@ -40,7 +40,7 @@ def get(flag='host'):
                     platform_val = 'cray-xc'
 
     if not platform_val:
-        network = os.environ.get('CRAYPE_NETWORK_TARGET')
+        network = os.environ.get('CRAYPE_NETWORK_TARGET', '')
         if network.startswith("slingshot") or network == "ofi":
             platform_val = 'cray-shasta'
 

--- a/util/chplenv/chpl_platform.py
+++ b/util/chplenv/chpl_platform.py
@@ -26,8 +26,6 @@ def get(flag='host'):
         cle_info_file = os.path.abspath('/etc/opt/cray/release/CLEinfo')
         if not os.path.exists(cle_info_file):
             cle_info_file = os.path.abspath('/etc/opt/cray/release/cle-release')
-            if not os.path.exists(cle_info_file):
-                cle_info_file = os.path.abspath('/etc/opt/cray/release/cray-release')
 
         if os.path.exists(cle_info_file):
             with open(cle_info_file, 'r') as fp:
@@ -40,11 +38,11 @@ def get(flag='host'):
                     platform_val = 'cray-xe'
                 elif net.lower() == 'ari':
                     platform_val = 'cray-xc'
-            if not platform_val:
-                product_pattern = re.compile(r'^PRODUCT=.*\b[Ss]hasta\b', re.MULTILINE)
-                product_match = product_pattern.search(cle_info)
-                if product_match is not None:
-                    platform_val = 'cray-shasta'
+
+    if not platform_val:
+        network = os.environ.get('CRAYPE_NETWORK_TARGET')
+        if network.startswith("slingshot") or network == "ofi":
+            platform_val = 'cray-shasta'
 
     if not platform_val:
         # uname() -> (system, node, release, version, machine, processor)


### PR DESCRIPTION
Stop insisting on finding a `/etc/opt/cray/release/cray-release` file
containing OS release information (which isn't available on Shasta login
nodes), just go by the `CRAYPE_NETWORK_TARGET` environment setting.  We
may need to revisit this later, if it turns out this isn't sufficiently
unique, but it's certainly good enough for now.  This applies to both
the modulefile and the chpl_platform script.

While here, clean up the modulefile generation a little bit.