### PR TITLE
Add note about host/target compilers

### DIFF
--- a/doc/rst/technotes/libraries.rst
+++ b/doc/rst/technotes/libraries.rst
@@ -792,6 +792,12 @@ via the generated library.
 
 Other configurations may also become supported in the future.
 
+Host and Target Compilers
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Multilocale libraries currently require the host and target compiler to be
+the same. We expect this to change in the near future.
+
 Supported Types
 ~~~~~~~~~~~~~~~
 

--- a/doc/rst/technotes/libraries.rst
+++ b/doc/rst/technotes/libraries.rst
@@ -796,7 +796,12 @@ Host and Target Compilers
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Multilocale libraries currently require the host and target compiler to be
-the same. We expect this to change in the near future.
+compatible. On Crays, a host value of i.e, ``gnu`` and a target value of
+``PrgEnv-gnu`` would be considered equivalent.
+
+In the near future, the client library (the library that a user will link
+against) will be compiled by the host compiler, while the server will be
+compiled by the target compiler.
 
 Supported Types
 ~~~~~~~~~~~~~~~

--- a/doc/rst/technotes/libraries.rst
+++ b/doc/rst/technotes/libraries.rst
@@ -793,7 +793,7 @@ via the generated library.
 Other configurations may also become supported in the future.
 
 Host and Target Compilers
-~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Multilocale libraries currently require the host and target compiler to be
 compatible. For example, on Crays, a host value of ``gnu`` and a target

--- a/doc/rst/technotes/libraries.rst
+++ b/doc/rst/technotes/libraries.rst
@@ -796,8 +796,8 @@ Host and Target Compilers
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Multilocale libraries currently require the host and target compiler to be
-compatible. On Crays, a host value of i.e, ``gnu`` and a target value of
-``cray-prgenv-gnu`` would be considered equivalent.
+compatible. For example, on Crays, a host value of ``gnu`` and a target
+value of ``cray-prgenv-gnu`` would be considered equivalent.
 
 In the near future, the client library (the library that a user will link
 against) will be compiled by the host compiler, while the server will be

--- a/doc/rst/technotes/libraries.rst
+++ b/doc/rst/technotes/libraries.rst
@@ -797,7 +797,7 @@ Host and Target Compilers
 
 Multilocale libraries currently require the host and target compiler to be
 compatible. On Crays, a host value of i.e, ``gnu`` and a target value of
-``PrgEnv-gnu`` would be considered equivalent.
+``cray-prgenv-gnu`` would be considered equivalent.
 
 In the near future, the client library (the library that a user will link
 against) will be compiled by the host compiler, while the server will be


### PR DESCRIPTION
This PR adds a note to the library technote mentioning that multilocale libraries currently do not support differing host/target compilers. 

Rendered docs up shortly.