### PR TITLE
Add autoDestroy for values returned by parenless function calls

### DIFF
--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -601,8 +601,12 @@ buildTupleVarDeclStmt(BlockStmt* tupleBlock, Expr* type, Expr* init) {
     // is another variable (vs a call).
     // This does not correctly handle certain no-parens calls. See
     // tuple-string-bug.chpl and tuple-string-bug-noparens.chpl
-    if (!isCallExpr(init))
+    if (!isCallExpr(init)) {
+      if(UnresolvedSymExpr *urse = toUnresolvedSymExpr(init)) {
+        urse->addAutoDestroyCandidate(tmp);
+      }
       tmp->addFlag(FLAG_NO_AUTO_DESTROY);
+    }
   }
   int count = 1;
   for_alist(expr, tupleBlock->body) {

--- a/compiler/AST/expr.cpp
+++ b/compiler/AST/expr.cpp
@@ -703,6 +703,16 @@ void UnresolvedSymExpr::accept(AstVisitor* visitor) {
   visitor->visitUsymExpr(this);
 }
 
+void UnresolvedSymExpr::addAutoDestroyCandidate(VarSymbol *candidate) {
+  this->autoDestroyCandidates.push_back(candidate);
+}
+
+void UnresolvedSymExpr::confirmAutoDestroyCandidates() {
+  forv_Vec(VarSymbol *, sym, this->autoDestroyCandidates) {
+    sym->removeFlag(FLAG_NO_AUTO_DESTROY);
+  }
+}
+
 /************************************ | *************************************
 *                                                                           *
 *                                                                           *

--- a/compiler/include/expr.h
+++ b/compiler/include/expr.h
@@ -185,6 +185,12 @@ class UnresolvedSymExpr : public Expr {
   virtual void    prettyPrint(std::ostream *o);
 
   virtual Expr*   getFirstExpr();
+
+  virtual void addAutoDestroyCandidate(VarSymbol *candidate);
+  virtual void confirmAutoDestroyCandidates();
+
+ private:
+  Vec<VarSymbol *> autoDestroyCandidates;
 };
 
 

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -989,6 +989,7 @@ static void resolveUnresolvedSymExpr(UnresolvedSymExpr* usymExpr,
   // handle function call without parentheses
   } else if (fn->hasFlag(FLAG_NO_PARENS) == true) {
     checkIdInsideWithClause(usymExpr, usymExpr);
+    usymExpr->confirmAutoDestroyCandidates();
     usymExpr->replace(new CallExpr(fn));
 
   } else if (Expr* parent = usymExpr->parentExpr) {


### PR DESCRIPTION
This is a WIP PR to close the leak in `test/types/tuple/ferguson/tuple-string-bug-noparens.chpl`

Judging by the comments this seems like a known issue (by @mppf ?)

In the below snippet:
```chapel
var myVar = f;
```
`myVar` is added `FLAG_NO_AUTO_DESTROY` assuming that `f` is a variable. However, if it is a function call that returns something that needs an `autoDestroy` call (in the above test it returns a heterogeneous tuple that include a string), the memory is leaked due to the temp variable that captures the return value.

This PR keeps track of variables like `myVar` and if `f` is resolved to a CallExpr, removes `FLAG_NO_AUTO_DESTROY` flags from those variables.

This is WIP because at the very least comments needs some adjustments. Also there may be a much better way to fix this :)

Other todo/questions:
- [ ] Look around to see if we need to keep track of more candidates besides tuples.

Test:
- [x] standard valgrind with the test above
- [x] standard
- [x] standard valgrind in `test/release/example/primers`
- [ ] gasnet (running)

