### PR TITLE
Speed up lowerIterators

### DIFF
--- a/compiler/include/iterator.h
+++ b/compiler/include/iterator.h
@@ -80,6 +80,8 @@ void      addIteratorBreakBlocksInline(Expr* loopRef, Symbol* IC,
                                        std::vector<Expr*>* delayedRemoval);
 BlockStmt* getAndRemoveIteratorBreakBlockForYield(std::vector<Expr*>* delayedRm,
                                                   CallExpr* yield);
+void gatherPrimIRFieldValByFormal();
+void cleanupPrimIRFieldValByFormal();
 
 void lowerIterator(FnSymbol* fn);
 

--- a/compiler/resolution/lowerIterators.cpp
+++ b/compiler/resolution/lowerIterators.cpp
@@ -2978,6 +2978,7 @@ void lowerIterators() {
   }
 
   fragmentLocalBlocks();
+  gatherPrimIRFieldValByFormal();
 
   for_alive_in_Vec(FnSymbol, fn, gFnSymbols) {
     if (fn->isIterator()) {
@@ -3000,6 +3001,7 @@ void lowerIterators() {
 
   cleanupTemporaryVectors();
   cleanupIteratorBreakToken();
+  cleanupPrimIRFieldValByFormal();
 
   iteratorsLowered = true;
 }


### PR DESCRIPTION
lowerIterator()/addLocalsToClassAndRecord() was traversing gCallExprs
each time it was invoked. Instead, traverse it once before all
lowerIterator calls and store the results.

While there, replace map.count() + map[] with map.find(),
to avoid potential duplicate work.

Testing: linux64 -futures, gasnet, numa.