### PR TITLE
Add perf annotations for 2019-09-12

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -611,17 +611,15 @@ dgemm.64:
   09/06/13:
     - LICM bug fixes
 
-ep:
+ep: &ep-base
   11/18/14:
     - added -E to tests which would benefit from it
   11/22/14:
     - revert -E use for nightly on 21st (which failed, unrelatedly)
-
+  08/25/19:
+    - Min/max with NaNs and imag inequalities (#13824)
 ep-b:
-  11/18/14:
-    - added -E to tests which would benefit from it
-  11/22/14:
-    - revert -E use for nightly on 21st (which failed, unrelatedly)
+  <<: *ep-base
 
 ep.ml-perf: &ep-ml-base
   07/26/17:
@@ -632,6 +630,8 @@ ep.ml-perf: &ep-ml-base
     - Make associative domains of enums more standard (#9978)
   1/28/19:
     - Represent reduce expressions using ForallStmt (#12131)
+  08/25/19:
+    - Min/max with NaNs and imag inequalities (#13824)
 ep.ml-time:
   <<: *ep-ml-base
 
@@ -824,7 +824,7 @@ jacobi:
   04/23/19:
     - Denormalize the test in CondStmts (#12867)
 
-knucleotide:
+knucleotide: &knucleotide-base
   10/17/15:
     - text: Plain Old Data type improvement (#2752)
       config: chap04
@@ -836,6 +836,10 @@ knucleotide:
     - Clear associative array elements when created by dsiAdd (#7828)
   09/05/19:
     - Deprecate adding to associative domain by assigning to array (#13945)
+  09/11/19:
+    - Optimize the method map.this(k) (#14065)
+knucleotide-submitted:
+  <<: *knucleotide-base
 
 LCALS-raw-short: &lcals-base
   10/20/16:
@@ -847,6 +851,10 @@ LCALS-raw-short: &lcals-base
     - Throw --no-ieee-float for LCALS (#5001)
   10/24/17:
     - Fix LCALS inner_prod kernel (#7632)
+  08/25/19:
+    - Task intents to operate on fields of 'this' (#13840)
+  09/10/19:
+    - Restrict applicability of field intents (#14057)
 LCALS-raw-medium:
   <<: *lcals-base
 LCALS-raw-long:
@@ -1314,6 +1322,8 @@ regexdna: &regexdna-base
     - Update RE2 (#6024)
   06/22/17:
     - Free strings leaked by Regex.subn() / qio_regexp_replace() (#6509)
+  08/09/19:
+    - Change string.length to measure in codepoints (#13675)
 regexdna-redux:
   <<: *regexdna-base
 regexdna-submitted:
@@ -1341,7 +1351,7 @@ return-array-20000000:
 return-array-40000000:
   <<: *return-array-base
 
-revcomp:
+revcomp: &revcomp-base
   05/12/15:
     - various qio changes motivated by cygwin failures (#1943)
   10/29/15:
@@ -1364,6 +1374,12 @@ revcomp:
     - Make stdout, stderr ordering predictable in test output (#12236)
   08/30/19:
     - Add channel seek and default to pread (#13862)
+  09/06/19:
+    - Turn "array-as-vec" deprecation warnings on (#13999)
+  09/10/19:
+    - Restore reverse-complement performance with qio hint (#14045)
+revcomp-submitted:
+  <<: *revcomp-base
 
 sad:
   05/03/16:


### PR DESCRIPTION
Add annotations for:
 - [regression](https://chapel-lang.org/perf/16-node-xc/?startdate=2019/08/07&enddate=2019/09/12&suite=nasparallelbenchmarksperf) for NPB:EP from NaN support for min/max (#13824)
 - [regression](https://chapel-lang.org/perf/chapcs/?startdate=2019/06/29&enddate=2019/09/12&graphs=regexdnashootoutbenchmark) for regexdna from string.length -> codepoint change (#13675)
 - [regression and fix](https://chapel-lang.org/perf/chapcs/?startdate=2019/08/15&enddate=2019/09/12&graphs=lcalsrawompshort,lcalsrawompmedium) for lcals from task intent changes on `this` (#13840, #14057)
 - [fix](https://chapel-lang.org/perf/chapcs/?startdate=2019/09/03&enddate=2019/09/12&graphs=submittedknucleotideshootoutbenchmark) for knucleotide from optimizing map.this (#14065)
 - [regression](https://chapel-lang.org/perf/chapcs/?startdate=2019/09/03&enddate=2019/09/08&graphs=reversecomplementshootoutbenchmark,submittedknucleotideshootoutbenchmark) for slower revcomps from array-as-vec -> list change (#13999)
 - [fix](https://chapel-lang.org/perf/chapcs/?startdate=2019/09/06&enddate=2019/09/12&graphs=reversecomplementshootoutbenchmark,submittedknucleotideshootoutbenchmark) for faster revcomps by using QIO hint (#14045)