### PR TITLE
Close two leaks in release tests

### DIFF
--- a/test/release/examples/benchmarks/hpcc/hpl.chpl
+++ b/test/release/examples/benchmarks/hpcc/hpl.chpl
@@ -74,12 +74,11 @@ proc main() {
   // is created by slicing into MatVectSpace, inheriting all of its
   // rows and its low column bound.
   //
-  const MatVectSpace: domain(2)
-    dmapped DimensionalDist2D(targetLocales,
-                              new unmanaged BlockCyclicDim(gridRows, lowIdx=1, blkSize),
-                              new unmanaged BlockCyclicDim(gridCols, lowIdx=1, blkSize))
-                    = {1..n, 1..n+1},
-        MatrixSpace = MatVectSpace[.., ..n];
+  const d1 = new unmanaged BlockCyclicDim(gridRows, lowIdx=1, blkSize);
+  const d2 = new unmanaged BlockCyclicDim(gridCols, lowIdx=1, blkSize);
+
+  const MatVectSpace: domain(2) dmapped DimensionalDist2D(targetLocales, d1, d2) 
+    = {1..n, 1..n+1}, MatrixSpace = MatVectSpace[.., ..n];
 
   var Ab : [MatVectSpace] elemType,  // the matrix A and vector b
       piv: [1..n] int;               // a vector of pivot values
@@ -98,6 +97,9 @@ proc main() {
   // Validate the answer and print the results
   const validAnswer = verifyResults(Ab, MatrixSpace, x);
   printResults(validAnswer, execTime);
+
+  delete d1;
+  delete d2;
 }
 
 //
@@ -212,15 +214,18 @@ proc schurComplement(Ab: [?AbD] elemType, AD: domain, BD: domain, Rest: domain) 
 // Replicate a row of Ab along the first dimension
 //
 proc replicateD1(Ab, BD) {
+  const d1 = new unmanaged ReplicatedDim(gridRows);
+  const d2 = new unmanaged BlockCyclicDim(gridCols, lowIdx=1, blkSize);
   const replBD = {1..blkSize, 1..n+1}
-    dmapped DimensionalDist2D(targetLocales,
-                              new unmanaged ReplicatedDim(gridRows),
-                              new unmanaged BlockCyclicDim(gridCols, lowIdx=1, blkSize));
+    dmapped DimensionalDist2D(targetLocales, d1, d2);
   var replB: [replBD] elemType;
 
   coforall dest in targetLocales[.., 0] do
     on dest do
       replB = Ab[BD.dim(1), 1..n+1];
+
+  delete d1;
+  delete d2;
 
   return replB;
 }
@@ -229,15 +234,18 @@ proc replicateD1(Ab, BD) {
 // Replicate a column of Ab along the second dimension
 //
 proc replicateD2(Ab, AD) {
+  const d1 = new unmanaged BlockCyclicDim(gridRows, lowIdx=1, blkSize);
+  const d2 = new unmanaged ReplicatedDim(gridCols); 
   const replAD = {1..n, 1..blkSize}
-    dmapped DimensionalDist2D(targetLocales,
-                              new unmanaged BlockCyclicDim(gridRows, lowIdx=1, blkSize),
-                              new unmanaged ReplicatedDim(gridCols));
+    dmapped DimensionalDist2D(targetLocales, d1, d2);
   var replA: [replAD] elemType;
 
   coforall dest in targetLocales[0, ..] do
     on dest do
       replA = Ab[1..n, AD.dim(2)];
+
+  delete d1;
+  delete d2;
 
   return replA;
 }

--- a/test/release/examples/primers/distributions.chpl
+++ b/test/release/examples/primers/distributions.chpl
@@ -281,11 +281,11 @@ var (nl1, nl2) = if numLocales == 1 then (1, 1) else (2, numLocales/2);
 MyLocaleView = {0..#nl1, 0..#nl2};
 MyLocales = reshape(Locales[0..#nl1*nl2], MyLocaleView);
 
+const d1 = new unmanaged ReplicatedDim(numLocales = nl1);
+const d2 = new unmanaged BlockCyclicDim(numLocales = nl2,
+                                        lowIdx = 1, blockSize = 2);
 const DimReplicatedBlockcyclicSpace = Space
-  dmapped DimensionalDist2D(MyLocales,
-                            new unmanaged ReplicatedDim(numLocales = nl1),
-                            new unmanaged BlockCyclicDim(numLocales = nl2,
-                                               lowIdx = 1, blockSize = 2));
+  dmapped DimensionalDist2D(MyLocales, d1, d2);
 
 var DRBA: [DimReplicatedBlockcyclicSpace] int;
 
@@ -312,5 +312,8 @@ for locId1 in 0..#nl1 do on MyLocales[locId1, 0] {
   const Helper: [Space] int = DRBA;
   writeln(Helper);
   writeln();
+
+  delete d1;
+  delete d2;
 
 }


### PR DESCRIPTION
Follow on to #14059 and #14079 

Deletes unmanaged stuff in two more tests that I avoided because they are in `test/release`

Tests pass with standard, standard valgrind and gasnet.