### PR TITLE
Move deletes outside of for in test

### DIFF
--- a/test/release/examples/primers/distributions.chpl
+++ b/test/release/examples/primers/distributions.chpl
@@ -313,7 +313,7 @@ for locId1 in 0..#nl1 do on MyLocales[locId1, 0] {
   writeln(Helper);
   writeln();
 
-  delete d1;
-  delete d2;
-
 }
+
+delete d1;
+delete d2;


### PR DESCRIPTION
I have put these `delete`s in a for loop (I know, bad). To my luck the for loop iterates over locales, which doesn't cause any issue if you test COMM=none and surprisingly standard gasnet.

This PR fixes that