### PR TITLE
Elminate multi-locale leaks in DimensionalDist2D

### DIFF
--- a/modules/dists/DimensionalDist2D.chpl
+++ b/modules/dists/DimensionalDist2D.chpl
@@ -244,7 +244,7 @@ class DimensionalDist2D : BaseDist {
   proc targetIds return targetLocales.domain;
 
   // the dimension specifiers - ones being combined
-  const di1, di2;
+  var di1, di2;
 
   // for debugging/tracing (remove later)
   var name: string;
@@ -295,7 +295,7 @@ class DimensionalDom : BaseRectangularDom {
   proc indexT  type  return dist.indexT;
 
   // subordinate 1-d global domain descriptors
-  const dom1, dom2; // not reprivatized
+  var dom1, dom2;
 
   // This is our index set; we store it here so we can get to it easily.
   // Although strictly speaking it is not necessary.
@@ -346,11 +346,6 @@ class LocDimensionalDom {
 
   // subordinate 1-d local domain descriptors
   var doml1, doml2;
-
-  proc deinit() {
-    if isClass(doml2) then delete doml2;
-    if isClass(doml1) then delete doml1;
-  }
 }
 
 class DimensionalArr : BaseRectangularArr {
@@ -410,7 +405,7 @@ proc DimensionalDist2D.init(
 
   checkInvariants();
 
-  _passLocalLocIDsDist(di1, true, di2, true,
+  _passLocalLocIDsDist(this.di1, true, this.di2, true,
                      this.targetLocales, true, this.targetLocales.domain.low);
 }
 
@@ -456,6 +451,10 @@ proc DimensionalDist2D.checkInvariants(): void {
   assert(di2.numLocales == numLocs2, "DimensionalDist2D-numLocales-2");
   assert(dataParTasksPerLocale > 0, "DimensionalDist2D-dataParTasksPerLocale");
   assert(dataParMinGranularity > 0, "DimensionalDist2D-dataParMinGranularity");
+
+  ensure(!(isClass(di1) || isClass(di2)), "DimensionalDist2D does not support dimension specifiers that are classes");
+  /* If these are classes, the deinitializer should delete them if we own them.
+     Note: a privatized copy does not own them if they are not privatized. */
 }
 
 proc DimensionalDist2D.dsiClone(): _to_unmanaged(this.type) {
@@ -474,16 +473,9 @@ proc DimensionalDist2D.dsiSupportsPrivatization() param return true;
 proc DimensionalDist2D.dsiGetPrivatizeData() {
   _traceddd(this, ".dsiGetPrivatizeData");
 
-  const di1pd = if di1.dsiSupportsPrivatization1d()
-    then di1.dsiGetPrivatizeData1d()
-    else 0;
-  const di2pd = if di2.dsiSupportsPrivatization1d()
-    then di2.dsiGetPrivatizeData1d()
-    else 0;
-
   return (targetLocales, name, dataParTasksPerLocale,
           dataParIgnoreRunningTasks, dataParMinGranularity,
-          di1, di1pd, di2, di2pd);
+          di1.dsiGetPrivatizeData1d(), di2.dsiGetPrivatizeData1d());
 }
 
 proc DimensionalDist2D.dsiPrivatize(privatizeData) {
@@ -498,19 +490,10 @@ proc DimensionalDist2D.dsiPrivatize(privatizeData) {
                               ) = pdTargetLocales.domain;
   const privTargetLocales: [privTargetIds] locale = pdTargetLocales;
 
-  proc di1orig return privatizeData(6);
-  proc di1pd   return privatizeData(7);
-  const di1new = if di1.dsiSupportsPrivatization1d()
-    then di1orig.dsiPrivatize1d(di1pd) else di1orig;
-
-  proc di2orig  return privatizeData(8);
-  proc di2pd    return privatizeData(9);
-  const di2new = if di2.dsiSupportsPrivatization1d()
-    then di2orig.dsiPrivatize1d(di2pd) else di2orig;
-
+  var di1new = di1.type.dsiPrivatize1d(privatizeData(6));
+  var di2new = di2.type.dsiPrivatize1d(privatizeData(7));
   const plliddDummy: privTargetLocales.domain.low.type;
-  _passLocalLocIDsDist(di1new, di1.dsiSupportsPrivatization1d(),
-                       di2new, di2.dsiSupportsPrivatization1d(),
+  _passLocalLocIDsDist(di1new, true, di2new, true,
                        privTargetLocales, false, plliddDummy);
 
   return new unmanaged DimensionalDist2D(targetLocales = privTargetLocales,
@@ -607,7 +590,7 @@ proc _CurrentLocaleToLocIDs(targetLocales): (targetLocales.rank*locIdT, bool)
 }
 
 // How we usually invoke _CurrentLocaleToLocIDs().
-proc _passLocalLocIDsDist(d1, doD1:bool, d2, doD2:bool,
+proc _passLocalLocIDsDist(ref d1, param doD1:bool, ref d2, param doD2:bool,
                           targetLocales, gotHint:bool, hint): void
 {
  // otherwise don't bother generating any code
@@ -629,15 +612,11 @@ proc _passLocalLocIDsDist(d1, doD1:bool, d2, doD2:bool,
 }
 
 // Subordinate 1-d domains copy the local locId from their distributions.
-proc _passLocalLocIDsDom1d(dom1d, dist1d) {
+proc _passLocalLocIDsDom1d(ref dom1d, dist1d) {
   if dom1d.dsiUsesLocalLocID1d() {
 
     // ensure dist1d.dsiGetLocalLocID1d() is available
     if !dist1d.dsiUsesLocalLocID1d() then compilerError("DimensionalDist2D: currently, when a subordinate 1d distribution requires localLocID for *domain* descriptors, it must also require them for *distribution* descriptors");
-
-    // otherwise there is a mismatch: the local locID is copied
-    // from a non-privatized object to a privatized one - or visa versa
-    if dom1d.dsiSupportsPrivatization1d() != dist1d.dsiSupportsPrivatization1d() then compilerError("DimensionalDist2D: currently, when a subordinate 1d distribution requires localLocID for domain descriptors, it must support privatization for *domain* descriptors if and only if it supports privatization for *distribution* descriptors");
 
     dom1d.dsiStoreLocalLocID1d(dist1d.dsiGetLocalLocID1d());
   }
@@ -645,6 +624,20 @@ proc _passLocalLocIDsDom1d(dom1d, dist1d) {
 
 
 /// domain //////////////////////////////////////////////////////////////////
+
+proc DimensionalDom.deinit() {
+  if isClass(dom1) || isClass(dom2) then
+    compilerError("1-d domain descriptors cannot be classes");
+  /* If these are classes, the deinitializer should delete them if we own them.
+     Note: a privatized copy does not own them if they are not privatized. */
+}
+
+proc LocDimensionalDom.deinit() {
+  if isClass(doml1) | isClass(doml2) then
+    compilerError("1-d local domain descriptors cannot be classes");
+  /* If these are classes, they should probably be 'owned'
+     so they are deleted properly. */
+}
 
 
 //== privatization
@@ -654,14 +647,8 @@ proc DimensionalDom.dsiSupportsPrivatization() param return true;
 proc DimensionalDom.dsiGetPrivatizeData() {
   _traceddd(this, ".dsiGetPrivatizeData");
 
-  const dom1pd = if dom1.dsiSupportsPrivatization1d()
-    then dom1.dsiGetPrivatizeData1d()
-    else 0;
-  const dom2pd = if dom2.dsiSupportsPrivatization1d()
-    then dom2.dsiGetPrivatizeData1d()
-    else 0;
-
-  return (dist.pid, dom1, dom1pd, dom2, dom2pd, whole.dims(), localDdescs);
+  return (dist.pid, dom1.dsiGetPrivatizeData1d(), dom2.dsiGetPrivatizeData1d(),
+          whole.dims(), localDdescs);
 }
 
 proc DimensionalDom.dsiPrivatize(privatizeData) {
@@ -670,20 +657,10 @@ proc DimensionalDom.dsiPrivatize(privatizeData) {
   var privdist = chpl_getPrivatizedCopy(objectType = this.dist.type,
                                         objectPid  = privatizeData(1));
 
-  proc dom1orig  return privatizeData(2);
-  proc dom1pd    return privatizeData(3);
-  const dom1new = if dom1orig.dsiSupportsPrivatization1d()
-    then dom1orig.dsiPrivatize1d(privdist.di1, dom1pd) else dom1orig;
-
-  if dom1orig.dsiSupportsPrivatization1d() then
+    var dom1new = dom1.type.dsiPrivatize1d(privdist.di1, privatizeData(2));
     _passLocalLocIDsDom1d(dom1new, privdist.di1);
 
-  proc dom2orig  return privatizeData(4);
-  proc dom2pd    return privatizeData(5);
-  const dom2new = if dom2orig.dsiSupportsPrivatization1d()
-    then dom2orig.dsiPrivatize1d(privdist.di2, dom2pd) else dom2orig;
-
-  if dom2orig.dsiSupportsPrivatization1d() then
+    var dom2new = dom2.type.dsiPrivatize1d(privdist.di2, privatizeData(3));
     _passLocalLocIDsDom1d(dom2new, privdist.di2);
 
   const result = new unmanaged DimensionalDom(rank      = this.rank,
@@ -692,14 +669,12 @@ proc DimensionalDom.dsiPrivatize(privatizeData) {
                                     dist = privdist,
                                     dom1 = dom1new,
                                     dom2 = dom2new,
-                                    whole       = {(...privatizeData(6))},
-                                    localDdescs = privatizeData(7));
+                                    whole       = {(...privatizeData(4))},
+                                    localDdescs = privatizeData(5));
 
   // update local-to-global pointers as needed
-  param lg1 = dom1orig.dsiSupportsPrivatization1d() &&
-              dom1orig.dsiLocalDescUsesPrivatizedGlobalDesc1d();
-  param lg2 = dom2orig.dsiSupportsPrivatization1d() &&
-              dom2orig.dsiLocalDescUsesPrivatizedGlobalDesc1d();
+  param lg1 = dom1new.dsiLocalDescUsesPrivatizedGlobalDesc1d();
+  param lg2 = dom2new.dsiLocalDescUsesPrivatizedGlobalDesc1d();
   if lg1 || lg2 then
     // We are justified, sort-of, to go over the entire localDdescs
     // because we have just gone over them above, so it's only
@@ -718,14 +693,9 @@ proc DimensionalDom.dsiPrivatize(privatizeData) {
 proc DimensionalDom.dsiGetReprivatizeData() {
   _traceddd(this, ".dsiGetReprivatizeData");
 
-  const dom1rpd = if dom1.dsiSupportsPrivatization1d()
-    then dom1.dsiGetReprivatizeData1d()
-    else 0;
-  const dom2rpd = if dom2.dsiSupportsPrivatization1d()
-    then dom2.dsiGetReprivatizeData1d()
-    else 0;
-
-  return (dom1, dom1rpd, dom2, dom2rpd, whole);
+  return (dom1.dsiGetReprivatizeData1d(),
+          dom2.dsiGetReprivatizeData1d(),
+          whole);
 }
 
 proc DimensionalDom.dsiReprivatize(other, reprivatizeData) {
@@ -735,13 +705,10 @@ proc DimensionalDom.dsiReprivatize(other, reprivatizeData) {
                  this.idxType == other.idxType &&
                  this.stridable == other.stridable);
 
-  if dom1.dsiSupportsPrivatization1d() then
-    dom1.dsiReprivatize1d(other           = reprivatizeData(1),
-                          reprivatizeData = reprivatizeData(2));
-  if dom2.dsiSupportsPrivatization1d() then
-    dom2.dsiReprivatize1d(other           = reprivatizeData(3),
-                          reprivatizeData = reprivatizeData(4));
-  this.whole = reprivatizeData(5);
+  dom1.dsiReprivatize1d(reprivatizeData(1));
+  dom2.dsiReprivatize1d(reprivatizeData(2));
+
+  this.whole = reprivatizeData(3);
 }
 
 
@@ -800,10 +767,10 @@ override proc DimensionalDist2D.dsiNewRectangularDom(param rank: int,
   // need this for dsiNewRectangularDom1d()
   type stoIndexT = this.idxType;
 
-  const dom1 = di1.dsiNewRectangularDom1d(idxType, stridable, stoIndexT);
+  var dom1 = di1.dsiNewRectangularDom1d(idxType, stridable, stoIndexT);
   _passLocalLocIDsDom1d(dom1, di1);
 
-  const dom2 = di2.dsiNewRectangularDom1d(idxType, stridable, stoIndexT);
+  var dom2 = di2.dsiNewRectangularDom1d(idxType, stridable, stoIndexT);
   _passLocalLocIDsDom1d(dom2, di2);
 
   const result = new unmanaged DimensionalDom(rank=rank, idxType=idxType,

--- a/modules/dists/dims/BlockDim.chpl
+++ b/modules/dists/dims/BlockDim.chpl
@@ -33,7 +33,7 @@ that would be produced by a 1D :class:`~BlockDist.Block` distribution.
 
 **Initializer Arguments**
 
-The following ``BlockDim`` class initializers are available:
+The following ``BlockDim`` record initializers are available:
 
   .. code-block:: chapel
 
@@ -59,7 +59,7 @@ The ``idxType``, whether provided or inferred, must match
 the index type of the domains "dmapped" using the corresponding
 ``DimensionalDist2D`` distribution.
 */
-class BlockDim {
+record BlockDim {
   // the type of bbStart, bbLength
   // (also (ab)used as the idxType of the domains created over this dist.)
   // (todo - straighten that out)
@@ -74,7 +74,7 @@ class BlockDim {
   proc boundingBox return bbStart .. (bbStart + bbLength - 1);
 }
 
-class Block1dom {
+record Block1dom {
   type idxType;
   param stridable: bool;
 
@@ -90,7 +90,7 @@ class Block1dom {
   proc dsiSetIndicesUnimplementedCase param return false;
 }
 
-class Block1locdom {
+record Block1locdom {
   var myRange;
 }
 
@@ -111,14 +111,12 @@ proc BlockDim.init(numLocales: int, boundingBox: range(?),
 
 /////////// privatization - start
 
-proc BlockDim.dsiSupportsPrivatization1d() param return true;
-
 proc BlockDim.dsiGetPrivatizeData1d() {
   return (numLocales, bbStart, bbLength);
 }
 
-proc BlockDim.dsiPrivatize1d(privatizeData) {
-  return new unmanaged BlockDim(privatizeData, this.idxType);
+proc type BlockDim.dsiPrivatize1d(privatizeData) {
+  return new BlockDim(privatizeData, this.idxType);
 }
 
 // initializer for privatization
@@ -131,15 +129,13 @@ proc BlockDim.init(privatizeData, type idxType) {
 
 proc BlockDim.dsiUsesLocalLocID1d() param return false;
 
-proc Block1dom.dsiSupportsPrivatization1d() param return true;
-
 proc Block1dom.dsiGetPrivatizeData1d() {
   return (wholeR,);
 }
 
-proc Block1dom.dsiPrivatize1d(privDist, privatizeData) {
+proc type Block1dom.dsiPrivatize1d(privDist, privatizeData) {
   assert(privDist.locale == here); // sanity check
-  return new unmanaged Block1dom(idxType   = this.idxType,
+  return new Block1dom(idxType   = this.idxType,
                   stridable = this.stridable,
                   wholeR    = privatizeData(1),
                   pdist     = privDist);
@@ -149,11 +145,7 @@ proc Block1dom.dsiGetReprivatizeData1d() {
   return (wholeR,);
 }
 
-proc Block1dom.dsiReprivatize1d(other, reprivatizeData) {
-  if other.idxType   != this.idxType ||
-     other.stridable != this.stridable then
-    compilerError("inconsistent types in privatization");
-
+proc Block1dom.dsiReprivatize1d(reprivatizeData) {
   this.wholeR = reprivatizeData(1);
 }
 
@@ -180,21 +172,21 @@ proc BlockDim.toString()
   return "BlockDim(" + numLocales:string + ", " + boundingBox:string + ")";
 
 proc BlockDim.dsiNewRectangularDom1d(type idxType, param stridable: bool,
-                                  type stoIndexT)
+                                     type stoIndexT)
 {
   // ignore stoIndexT - all we need is for other places to work out
   if idxType != this.idxType then
     compilerError("The index type ", idxType:string,
                   " does not match the index type ",this.idxType:string,
                   " of the 'BlockDim' 1-d distribution");
-  return new unmanaged Block1dom(idxType = idxType, stridable = stridable, pdist = _to_unmanaged(this));
+  return new Block1dom(idxType = idxType, stridable = stridable, pdist = this);
 }
 
 proc Block1dom.dsiIsReplicated1d() param return false;
 
 proc Block1dom.dsiNewLocalDom1d(type stoIndexT, locId: locIdT) {
   var defaultVal: range(stoIndexT, stridable=this.stridable);
-  return new unmanaged Block1locdom(myRange = defaultVal);
+  return new Block1locdom(myRange = defaultVal);
 }
 
 proc BlockDim.dsiIndexToLocale1d(indexx): locIdT {

--- a/modules/dists/dims/ReplicatedDim.chpl
+++ b/modules/dists/dims/ReplicatedDim.chpl
@@ -40,7 +40,7 @@ distribution accesses all replicands in certain cases, as specified there.
 
 **Initializer Arguments**
 
-The ``ReplicatedDim`` class initializer is available as follows:
+The ``ReplicatedDim`` record initializer is available as follows:
 
   .. code-block:: chapel
 
@@ -48,7 +48,7 @@ The ``ReplicatedDim`` class initializer is available as follows:
 
 It creates a dimension specifier for replication over ``numLocales`` locales.
 */
-class ReplicatedDim {
+record ReplicatedDim {
   // REQ over how many locales
   // todo: can the Dimensional do without this one?
   const numLocales: int;
@@ -60,7 +60,7 @@ class ReplicatedDim {
   var localLocIDlegit = false;
 }
 
-class Replicated1dom {
+record Replicated1dom {
   // REQ the parameters of our dimension of the domain being created
   type idxType;
   param stridable: bool;
@@ -80,7 +80,7 @@ class Replicated1dom {
   proc dsiSetIndicesUnimplementedCase param return false;
 }
 
-class Replicated1locdom {
+record Replicated1locdom {
   type stoIndexT;
   param stridable;
   // our copy of wholeR
@@ -90,22 +90,18 @@ class Replicated1locdom {
 
 /////////// privatization - start
 
-// REQ does this class support privatization?
-proc ReplicatedDim.dsiSupportsPrivatization1d() param return true;
-
-// REQ if privatization is supported - same purpose as dsiGetPrivatizeData()
+// REQ - same purpose as dsiGetPrivatizeData(); can return 'this'
 proc ReplicatedDim.dsiGetPrivatizeData1d() {
   return (numLocales,);
 }
 
-// REQ if privatization is supported - same purpose as dsiPrivatize()
-proc ReplicatedDim.dsiPrivatize1d(privatizeData) {
-  return new unmanaged ReplicatedDim(numLocales = privatizeData(1));
+// REQ - same purpose as dsiPrivatize()
+proc type ReplicatedDim.dsiPrivatize1d(privatizeData) {
+  return new ReplicatedDim(numLocales = privatizeData(1));
 }
 
 // REQ does this class need -- and provide -- the localLocID?
 // dsiStoreLocalLocID1d() will be invoked on privatized copies
-// only when dsiSupportsPrivatization1d is true (obviously).
 proc ReplicatedDim.dsiUsesLocalLocID1d() param return true;
 
 // REQ if dsiUsesLocalLocID1d: store the localLocID
@@ -135,35 +131,27 @@ proc ReplicatedDim.dsiGetLocalLocID1d(): (locIdT, bool) {
   return (this.localLocID, this.localLocIDlegit);
 }
 
-// REQ does this class support privatization?
-proc Replicated1dom.dsiSupportsPrivatization1d() param return true;
-
-// REQ if privatization is supported - same purpose as dsiGetPrivatizeData()
+// REQ - same purpose as dsiGetPrivatizeData(); can return 'this'
 proc Replicated1dom.dsiGetPrivatizeData1d() {
   return (wholeR,);
 }
 
-// REQ if privatization is supported - same purpose as dsiPrivatize()
-// 'privDist' is the corresponding 1-d distribution descriptor,
-// privatized (if it supports privatization).
-proc Replicated1dom.dsiPrivatize1d(privDist, privatizeData) {
+// REQ - same purpose as dsiPrivatize()
+// 'privDist' is the corresponding 1-d distribution descriptor, privatized
+proc type Replicated1dom.dsiPrivatize1d(privDist, privatizeData) {
   assert(privDist.locale == here); // sanity check
-  return new unmanaged Replicated1dom(idxType   = this.idxType,
-                  stridable = this.stridable,
-                  wholeR    = privatizeData(1));
+  return new Replicated1dom(idxType   = this.idxType,
+                            stridable = this.stridable,
+                            wholeR    = privatizeData(1));
 }
 
-// REQ if privatization is supported - same purpose as dsiGetReprivatizeData()
+// REQ - same purpose as dsiGetReprivatizeData()
 proc Replicated1dom.dsiGetReprivatizeData1d() {
   return (wholeR,);
 }
 
-// REQ if privatization is supported - same purpose as dsiReprivatize()
-proc Replicated1dom.dsiReprivatize1d(other, reprivatizeData) {
-  if other.idxType   != this.idxType ||
-     other.stridable != this.stridable then
-    compilerError("inconsistent types in privatization");
-
+// REQ - same purpose as dsiReprivatize()
+proc Replicated1dom.dsiReprivatize1d(reprivatizeData) {
   this.wholeR = reprivatizeData(1);
 }
 
@@ -189,7 +177,6 @@ proc Replicated1dom.dsiGetLocalLocID1d(): (locIdT, bool) {
 
 // REQ does a local domain descriptor use a pointer
 // to the privatized global domain descriptor?
-// Consulted only when dsiSupportsPrivatization1d is true.
 proc Replicated1dom.dsiLocalDescUsesPrivatizedGlobalDesc1d() param return false;
 
 // REQ if dsiLocalDescUsesPrivatizedGlobalDesc1d: store the pointer to
@@ -212,10 +199,10 @@ proc Replicated1locdom.dsiStoreLocalDescToPrivatizedGlobalDesc1d(privGlobDesc) {
 // where our dimension is a range(idxType, bounded, stridable)
 // stoIndexT is the same as in Replicated1dom.dsiNewLocalDom1d.
 proc ReplicatedDim.dsiNewRectangularDom1d(type idxType, param stridable: bool,
-                                  type stoIndexT)
+                                          type stoIndexT)
 {
   // ignore stoIndexT - all we need is for other places to work out
-  return new unmanaged Replicated1dom(idxType, stridable);
+  return new Replicated1dom(idxType, stridable);
 }
 
 // A nicety: produce a string showing the parameters.
@@ -233,7 +220,7 @@ proc Replicated1dom.dsiIsReplicated1d() param return true;
 // stoIndexT must be the index type of the range returned by
 // dsiSetLocalIndices1d().
 proc Replicated1dom.dsiNewLocalDom1d(type stoIndexT, locId: locIdT) {
-  return new unmanaged Replicated1locdom(stoIndexT, wholeR.stridable);
+  return new Replicated1locdom(stoIndexT, wholeR.stridable);
 }
 
 // REQ given our dimension of the array index, on which locale is it located?

--- a/test/chplvis/benchmarks-hpcc/hpl-vdb.chpl
+++ b/test/chplvis/benchmarks-hpcc/hpl-vdb.chpl
@@ -77,11 +77,11 @@ proc main() {
   // is created by slicing into MatVectSpace, inheriting all of its
   // rows and its low column bound.
   //
-  const d1 = new unmanaged BlockCyclicDim(gridRows, lowIdx=1, blkSize);
-  const d2 = new unmanaged BlockCyclicDim(gridCols, lowIdx=1, blkSize);
-
   const MatVectSpace: domain(2)
-    dmapped DimensionalDist2D(targetLocales, d1, d2) = {1..n, 1..n+1},
+    dmapped DimensionalDist2D(targetLocales,
+                              new BlockCyclicDim(gridRows, lowIdx=1, blkSize),
+                              new BlockCyclicDim(gridCols, lowIdx=1, blkSize))
+                    = {1..n, 1..n+1},
         MatrixSpace = MatVectSpace[.., ..n];
 
   var Ab : [MatVectSpace] elemType,  // the matrix A and vector b
@@ -102,9 +102,6 @@ proc main() {
   // Validate the answer and print the results
   const validAnswer = verifyResults(Ab, MatrixSpace, x);
   printResults(validAnswer, execTime);
-
-  delete d1;
-  delete d2;
 }
 
 //
@@ -219,19 +216,15 @@ proc schurComplement(Ab: [?AbD] elemType, AD: domain, BD: domain, Rest: domain) 
 // Replicate a row of Ab along the first dimension
 //
 proc replicateD1(Ab, BD) {
-  const d1 = new unmanaged ReplicatedDim(gridRows);
-  const d2 = new unmanaged BlockCyclicDim(gridCols, lowIdx=1, blkSize);
-
   const replBD = {1..blkSize, 1..n+1}
-    dmapped DimensionalDist2D(targetLocales, d1, d2);
+    dmapped DimensionalDist2D(targetLocales,
+                              new ReplicatedDim(gridRows),
+                              new BlockCyclicDim(gridCols, lowIdx=1, blkSize));
   var replB: [replBD] elemType;
 
   coforall dest in targetLocales[.., 0] do
     on dest do
       replB = Ab[BD.dim(1), 1..n+1];
-
-  delete d1;
-  delete d2;
 
   return replB;
 }
@@ -240,19 +233,15 @@ proc replicateD1(Ab, BD) {
 // Replicate a column of Ab along the second dimension
 //
 proc replicateD2(Ab, AD) {
-  const d1 = new unmanaged BlockCyclicDim(gridRows, lowIdx=1, blkSize);
-  const d2 = new unmanaged ReplicatedDim(gridCols);
-
   const replAD = {1..n, 1..blkSize}
-    dmapped DimensionalDist2D(targetLocales, d1, d2);
+    dmapped DimensionalDist2D(targetLocales,
+                              new BlockCyclicDim(gridRows, lowIdx=1, blkSize),
+                              new ReplicatedDim(gridCols));
   var replA: [replAD] elemType;
 
   coforall dest in targetLocales[0, ..] do
     on dest do
       replA = Ab[1..n, AD.dim(2)];
-
-  delete d1;
-  delete d2;
 
   return replA;
 }

--- a/test/distributions/dm/s7.chpl
+++ b/test/distributions/dm/s7.chpl
@@ -25,11 +25,11 @@ const st1=1, st2=1;
 const MatVectSpace = {1..n, 1..n+1};
 
 const
-  rdim1 = new unmanaged ReplicatedDim(tl1),
-  bdim1 = new unmanaged BlockCyclicDim(lowIdx=st1, blockSize=blkSize, numLocales=tl1,
+  rdim1 = new ReplicatedDim(tl1),
+  bdim1 = new BlockCyclicDim(lowIdx=st1, blockSize=blkSize, numLocales=tl1,
                               name="D1"),
-  rdim2 = new unmanaged ReplicatedDim(tl2),
-  bdim2 = new unmanaged BlockCyclicDim(lowIdx=st2, blockSize=blkSize, numLocales=tl2,
+  rdim2 = new ReplicatedDim(tl2),
+  bdim2 = new BlockCyclicDim(lowIdx=st2, blockSize=blkSize, numLocales=tl2,
                               name="D2");
 
 const AbD: domain(2, indexType)
@@ -97,11 +97,6 @@ forall (row,col) in AbD by blkSize do {
 writeln();
 writeln(Ab);
 writeln("DONE");
-
-delete rdim1;
-delete bdim1;
-delete rdim2;
-delete bdim2;
 
 proc test(X, Y, Z) {
   for (x, y, z) in zip(X, Y, Z) do x = y + z;

--- a/test/distributions/dm/s8.chpl
+++ b/test/distributions/dm/s8.chpl
@@ -19,9 +19,9 @@ setupLocales(tl1, tl2);
 var phase = 0;
 proc leapphase() { phase += 20; fphase(phase); }
 
-const dd1 =new unmanaged BlockCyclicDim(lowIdx=st1, blockSize=blkSize, numLocales=tl1,
+const dd1 = new BlockCyclicDim(lowIdx=st1, blockSize=blkSize, numLocales=tl1,
                                name="D1");
-const dd2 =new unmanaged BlockCyclicDim(lowIdx=st2, blockSize=blkSize, numLocales=tl2,
+const dd2 = new BlockCyclicDim(lowIdx=st2, blockSize=blkSize, numLocales=tl2,
                                name="D2");
 
 const space = {1..n, 1..n+1};
@@ -73,6 +73,3 @@ proc test(A, ix1, ix2) {
 
 test(Ab[1..n, 1..3],           (1,1), (2,2));
 test(Ab[1..n by 3, 5..n by 2], (4,5), (7,7));
-
-delete dd1;
-delete dd2;

--- a/test/distributions/dm/s9.chpl
+++ b/test/distributions/dm/s9.chpl
@@ -21,9 +21,9 @@ setupLocales(tl1, tl2);
 var phase = 0;
 proc leapphase() { phase += 20; fphase(phase); }
 
-const dd1 =new unmanaged BlockDim(numLocales=tl1,
+const dd1 = new BlockDim(numLocales=tl1,
                          boundingBoxLow=start1, boundingBoxHigh=end1);
-const dd2 =new unmanaged BlockDim(numLocales=tl2,
+const dd2 = new BlockDim(numLocales=tl2,
                          boundingBoxLow=start2, boundingBoxHigh=end2);
 
 const space = {1..n, 1..n+1};
@@ -75,6 +75,3 @@ proc test(A, ix1, ix2) {
 
 test(Ab[1..n, 1..3],           (1,1), (2,2));
 test(Ab[1..n by 3, 5..n by 2], (4,5), (7,7));
-
-delete dd1;
-delete dd2;

--- a/test/distributions/dm/t1.chpl
+++ b/test/distributions/dm/t1.chpl
@@ -11,8 +11,8 @@ setupLocales(s1, s2);
 
 /////////// distribution
 
-var vdf = new unmanaged ReplicatedDim(s1);
-var sdf = new unmanaged BlockDim(s2, 1, 3);
+var vdf = new ReplicatedDim(s1);
+var sdf = new BlockDim(s2, 1, 3);
 
 hd("new DimensionalDist2D()");
 var ddf = new unmanaged DimensionalDist2D(mylocs, vdf, sdf, "ddf");
@@ -122,6 +122,3 @@ tl();
 //privTest(dmarr, (1,0), (3,1), 0);
 //privTest(dmarr, (1,1), (3,3), 0);
 //tl();
-
-delete vdf;
-delete sdf;

--- a/test/distributions/dm/t1.comm-none.good
+++ b/test/distributions/dm/t1.comm-none.good
@@ -108,9 +108,9 @@
   56   34 304  on 0
   56  dmarr, dmhelp - zippered iteration on 0
   90  
+  90  (numLocales = 2, bbStart = 1, bbLength = 3)
+  90  (numLocales = 2, localLocID = 0, localLocIDlegit = true)
   90  dmarr - dimSpecifier()
-  90  {numLocales = 2, bbStart = 1, bbLength = 3}
-  90  {numLocales = 2, localLocID = 0, localLocIDlegit = true}
   91  
   91  privatization tests
   91  skipped because of oversubscribing Locales(0)

--- a/test/distributions/dm/t1.good
+++ b/test/distributions/dm/t1.good
@@ -356,9 +356,9 @@
   77   0 304  on 3
   77  dmarr, dmhelp - zippered iteration on 3
   90  
+  90  (numLocales = 2, bbStart = 1, bbLength = 3)
+  90  (numLocales = 2, localLocID = 0, localLocIDlegit = true)
   90  dmarr - dimSpecifier()
-  90  {numLocales = 2, bbStart = 1, bbLength = 3}
-  90  {numLocales = 2, localLocID = 0, localLocIDlegit = true}
   91  
   91   mylocs(0, 0)  dmarr(1, 2)  expecting 12  on 0
   91   mylocs(0, 1)  dmarr(2, 3)  expecting 23  on 1

--- a/test/distributions/dm/t2.chpl
+++ b/test/distributions/dm/t2.chpl
@@ -48,8 +48,8 @@ proc testsuite(type T, initphase) {
   hd("testsuite(", T:string, ")");
   tl();
 
-  const vdf = new unmanaged ReplicatedDim(1);
-  const sdf = new unmanaged BlockDim(3, 1:T, 8:T);
+  const vdf = new ReplicatedDim(1);
+  const sdf = new BlockDim(3, 1:T, 8:T);
   const dm = new dmap(new unmanaged DimensionalDist2D(mylocs, vdf, sdf, "dm", idxType=T));
 
   test({1:T..1:T, 0:T..9:T       } dmapped dm);
@@ -58,9 +58,6 @@ proc testsuite(type T, initphase) {
   test({1:T..1:T, 0:T..9:T by  3 } dmapped dm);
   test({1:T..1:T, 0:T..9:T by  2 } dmapped dm);
   test({1:T..1:T, 3:T..9:T by -3 } dmapped dm);
-
-  delete vdf;
-  delete sdf;
 }
 
 testsuite(int,        0);

--- a/test/distributions/dm/t3.chpl
+++ b/test/distributions/dm/t3.chpl
@@ -7,8 +7,8 @@ config const s1 = 2;
 config const s2 = 2;
 setupLocales(s1, s2);
 
-var vdf = new unmanaged ReplicatedDim(s1);
-var sdf = new unmanaged BlockDim(s2, 1, 3);
+var vdf = new ReplicatedDim(s1);
+var sdf = new BlockDim(s2, 1, 3);
 var ddf = new unmanaged DimensionalDist2D(mylocs, vdf, sdf, "ddf");
 const dmbase = {1..3,1..4};
 var dmdom: domain(2) dmapped new dmap(ddf);

--- a/test/distributions/dm/t5a.chpl
+++ b/test/distributions/dm/t5a.chpl
@@ -40,18 +40,15 @@ proc test(message, sel, dd1, dd2) {
   } else {
     hd("not selected"); tl();
   }
-
-  delete dd1;
-  delete dd2;
 }
 
-test("ReplicatedDim,ReplicatedDim", 1, new unmanaged ReplicatedDim(s1), new unmanaged ReplicatedDim(s2));
-test("BlockDim,BlockDim", 2, new unmanaged BlockDim(s1, 1, 4), new unmanaged BlockDim(s2, 1, 4));
-test("BlockCyclicDim,BlockCyclicDim", 3, new unmanaged BlockCyclicDim(s1, 0, 2), new unmanaged BlockCyclicDim(s2, 2, 3));
+test("ReplicatedDim,ReplicatedDim", 1, new ReplicatedDim(s1), new ReplicatedDim(s2));
+test("BlockDim,BlockDim", 2, new BlockDim(s1, 1, 4), new BlockDim(s2, 1, 4));
+test("BlockCyclicDim,BlockCyclicDim", 3, new BlockCyclicDim(s1, 0, 2), new BlockCyclicDim(s2, 2, 3));
 
-test("ReplicatedDim,BlockDim", 4, new unmanaged ReplicatedDim(s1),       new unmanaged BlockDim(s2, 1, 4));
-test("ReplicatedDim,BlockCyclicDim", 5, new unmanaged ReplicatedDim(s1), new unmanaged BlockCyclicDim(s2, 2, 3));
-test("BlockDim,ReplicatedDim", 6, new unmanaged BlockDim(s1, 1, 4), new unmanaged ReplicatedDim(s2));
-test("BlockDim,BlockCyclicDim", 7, new unmanaged BlockDim(s1, 1, 4), new unmanaged BlockCyclicDim(s2, 2, 3));
-test("BlockCyclicDim,ReplicatedDim", 8, new unmanaged BlockCyclicDim(s1, 0, 2), new unmanaged ReplicatedDim(s2));
-test("BlockCyclicDim,BlockDim", 9, new unmanaged BlockCyclicDim(s1, 0, 2), new unmanaged BlockDim(s2, 1, 4));
+test("ReplicatedDim,BlockDim", 4, new ReplicatedDim(s1),       new BlockDim(s2, 1, 4));
+test("ReplicatedDim,BlockCyclicDim", 5, new ReplicatedDim(s1), new BlockCyclicDim(s2, 2, 3));
+test("BlockDim,ReplicatedDim", 6, new BlockDim(s1, 1, 4), new ReplicatedDim(s2));
+test("BlockDim,BlockCyclicDim", 7, new BlockDim(s1, 1, 4), new BlockCyclicDim(s2, 2, 3));
+test("BlockCyclicDim,ReplicatedDim", 8, new BlockCyclicDim(s1, 0, 2), new ReplicatedDim(s2));
+test("BlockCyclicDim,BlockDim", 9, new BlockCyclicDim(s1, 0, 2), new BlockDim(s2, 1, 4));

--- a/test/distributions/dm/t8.chpl
+++ b/test/distributions/dm/t8.chpl
@@ -81,8 +81,8 @@ proc testsuite(type T, initphase) {
   hd("testsuite(", T:string, ")");
   tl();
 
-  const df8 = new unmanaged BlockCyclicDim(lowIdx=100, blockSize=7, numLocales=s1, name="D1");
-  const df9 = new unmanaged BlockCyclicDim(lowIdx=-10, blockSize=5, numLocales=s2, name="D2");
+  const df8 = new BlockCyclicDim(lowIdx=100, blockSize=7, numLocales=s1, name="D1");
+  const df9 = new BlockCyclicDim(lowIdx=-10, blockSize=5, numLocales=s2, name="D2");
   const dm = new dmap(new unmanaged DimensionalDist2D(mylocs, df8, df9, "dm", idxType=T));
 
   proc tw(a, b, c, d) { test({a:T..b:T, c:T..d:T} dmapped dm); }
@@ -176,9 +176,6 @@ proc testsuite(type T, initphase) {
   tw(5,11, 47,42);
   tw(11,5, 42,47);
   tw(11,5, 47,42);
-
-  delete df8;
-  delete df9;
 }
 
 testsuite(int(64),  1000);

--- a/test/distributions/dm/t9.chpl
+++ b/test/distributions/dm/t9.chpl
@@ -11,9 +11,9 @@ setupLocales(s1, s2);
 
 /////////// distribution
 
-var vdf = new unmanaged BlockCyclicDim(lowIdx=-100, blockSize=3, numLocales=s1,
+var vdf = new BlockCyclicDim(lowIdx=-100, blockSize=3, numLocales=s1,
                               name="D1");
-var sdf = new unmanaged BlockCyclicDim(lowIdx=-10, blockSize=2, numLocales=s2,
+var sdf = new BlockCyclicDim(lowIdx=-10, blockSize=2, numLocales=s2,
                               name="D2");
 
 hd("new DimensionalDist2D()");
@@ -148,7 +148,3 @@ tl();
 //privTest(dmarr, (1,0), (3,1), 0);
 //privTest(dmarr, (1,1), (3,3), 0);
 //tl();
-
-delete vdf;
-delete sdf;
-// 'ddf' is wrapped into a 'dmap' and so is deleted automatically.

--- a/test/distributions/dm/t9.comm-none.good
+++ b/test/distributions/dm/t9.comm-none.good
@@ -247,9 +247,9 @@
   56   57 507  on 0
   56  dmarr, dmhelp - zippered iteration on 0
   90  
+  90  (numLocales = 1, lowIdx = -100, blockSize = 3, name = D1, cycleSizePos = 3)
+  90  (numLocales = 3, lowIdx = -10, blockSize = 2, name = D2, cycleSizePos = 6)
   90  dmarr - dimSpecifier()
-  90  {numLocales = 1, lowIdx = -100, blockSize = 3, name = D1, cycleSizePos = 3}
-  90  {numLocales = 3, lowIdx = -10, blockSize = 2, name = D2, cycleSizePos = 6}
   91  
   91  privatization tests
   91  skipped because of oversubscribing Locales(0)

--- a/test/distributions/dm/t9.good
+++ b/test/distributions/dm/t9.good
@@ -646,9 +646,9 @@
   70   57 507  on 2
   70  dmarr, dmhelp - zippered iteration on 2
   90  
+  90  (numLocales = 1, lowIdx = -100, blockSize = 3, name = D1, cycleSizePos = 3)
+  90  (numLocales = 3, lowIdx = -10, blockSize = 2, name = D2, cycleSizePos = 6)
   90  dmarr - dimSpecifier()
-  90  {numLocales = 1, lowIdx = -100, blockSize = 3, name = D1, cycleSizePos = 3}
-  90  {numLocales = 3, lowIdx = -10, blockSize = 2, name = D2, cycleSizePos = 6}
   91  
   91   mylocs(0, 0)  dmarr(1, 2)  expecting 12  on 0
   91   mylocs(0, 0)  dmarr(1, 3)  expecting 13  on 0

--- a/test/io/vass/writeThis-on.chpl
+++ b/test/io/vass/writeThis-on.chpl
@@ -13,8 +13,8 @@ writeln();
 
 use DimensionalDist2D, ReplicatedDim, BlockCycDim;
 
-const dim1 = new unmanaged ReplicatedDim(numLocales);
-const dim2 = new unmanaged BlockCyclicDim(1, 1, 2);
+const dim1 = new ReplicatedDim(numLocales);
+const dim2 = new BlockCyclicDim(1, 1, 2);
 const dmp = newDimensionalDist2D(dim1, dim2, Locales);
 
 const ix = (1, 1);

--- a/test/release/examples/benchmarks/hpcc/hpl.chpl
+++ b/test/release/examples/benchmarks/hpcc/hpl.chpl
@@ -74,11 +74,12 @@ proc main() {
   // is created by slicing into MatVectSpace, inheriting all of its
   // rows and its low column bound.
   //
-  const d1 = new unmanaged BlockCyclicDim(gridRows, lowIdx=1, blkSize);
-  const d2 = new unmanaged BlockCyclicDim(gridCols, lowIdx=1, blkSize);
-
-  const MatVectSpace: domain(2) dmapped DimensionalDist2D(targetLocales, d1, d2) 
-    = {1..n, 1..n+1}, MatrixSpace = MatVectSpace[.., ..n];
+  const MatVectSpace: domain(2)
+    dmapped DimensionalDist2D(targetLocales,
+                              new BlockCyclicDim(gridRows, lowIdx=1, blkSize),
+                              new BlockCyclicDim(gridCols, lowIdx=1, blkSize))
+                    = {1..n, 1..n+1},
+        MatrixSpace = MatVectSpace[.., ..n];
 
   var Ab : [MatVectSpace] elemType,  // the matrix A and vector b
       piv: [1..n] int;               // a vector of pivot values
@@ -97,9 +98,6 @@ proc main() {
   // Validate the answer and print the results
   const validAnswer = verifyResults(Ab, MatrixSpace, x);
   printResults(validAnswer, execTime);
-
-  delete d1;
-  delete d2;
 }
 
 //
@@ -214,18 +212,15 @@ proc schurComplement(Ab: [?AbD] elemType, AD: domain, BD: domain, Rest: domain) 
 // Replicate a row of Ab along the first dimension
 //
 proc replicateD1(Ab, BD) {
-  const d1 = new unmanaged ReplicatedDim(gridRows);
-  const d2 = new unmanaged BlockCyclicDim(gridCols, lowIdx=1, blkSize);
   const replBD = {1..blkSize, 1..n+1}
-    dmapped DimensionalDist2D(targetLocales, d1, d2);
+    dmapped DimensionalDist2D(targetLocales,
+                              new ReplicatedDim(gridRows),
+                              new BlockCyclicDim(gridCols, lowIdx=1, blkSize));
   var replB: [replBD] elemType;
 
   coforall dest in targetLocales[.., 0] do
     on dest do
       replB = Ab[BD.dim(1), 1..n+1];
-
-  delete d1;
-  delete d2;
 
   return replB;
 }
@@ -234,18 +229,15 @@ proc replicateD1(Ab, BD) {
 // Replicate a column of Ab along the second dimension
 //
 proc replicateD2(Ab, AD) {
-  const d1 = new unmanaged BlockCyclicDim(gridRows, lowIdx=1, blkSize);
-  const d2 = new unmanaged ReplicatedDim(gridCols); 
   const replAD = {1..n, 1..blkSize}
-    dmapped DimensionalDist2D(targetLocales, d1, d2);
+    dmapped DimensionalDist2D(targetLocales,
+                              new BlockCyclicDim(gridRows, lowIdx=1, blkSize),
+                              new ReplicatedDim(gridCols));
   var replA: [replAD] elemType;
 
   coforall dest in targetLocales[0, ..] do
     on dest do
       replA = Ab[1..n, AD.dim(2)];
-
-  delete d1;
-  delete d2;
 
   return replA;
 }

--- a/test/release/examples/primers/distributions.chpl
+++ b/test/release/examples/primers/distributions.chpl
@@ -281,11 +281,11 @@ var (nl1, nl2) = if numLocales == 1 then (1, 1) else (2, numLocales/2);
 MyLocaleView = {0..#nl1, 0..#nl2};
 MyLocales = reshape(Locales[0..#nl1*nl2], MyLocaleView);
 
-const d1 = new unmanaged ReplicatedDim(numLocales = nl1);
-const d2 = new unmanaged BlockCyclicDim(numLocales = nl2,
-                                        lowIdx = 1, blockSize = 2);
 const DimReplicatedBlockcyclicSpace = Space
-  dmapped DimensionalDist2D(MyLocales, d1, d2);
+  dmapped DimensionalDist2D(MyLocales,
+                            new ReplicatedDim(numLocales = nl1),
+                            new BlockCyclicDim(numLocales = nl2,
+                                               lowIdx = 1, blockSize = 2));
 
 var DRBA: [DimReplicatedBlockcyclicSpace] int;
 
@@ -314,6 +314,3 @@ for locId1 in 0..#nl1 do on MyLocales[locId1, 0] {
   writeln();
 
 }
-
-delete d1;
-delete d2;

--- a/test/studies/hpcc/HPL/vass/bc.dim.chpl
+++ b/test/studies/hpcc/HPL/vass/bc.dim.chpl
@@ -58,13 +58,13 @@ const MatVectSpace = {1..n, 1..n+1};
 const
   bdim1 =
 //  new BlockDim(tl1, 1, nbb1), //MBD //BD
-    new unmanaged BlockCyclicDim(lowIdx=st1, blockSize=blkSize, numLocales=tl1, name="D1"), //MBC //BC
-  rdim1 = new unmanaged ReplicatedDim(tl1),
+    new BlockCyclicDim(lowIdx=st1, blockSize=blkSize, numLocales=tl1, name="D1"), //MBC //BC
+  rdim1 = new ReplicatedDim(tl1),
 
   bdim2 =
 //  new BlockDim(tl2, 1, nbb2), //MBD //BD
-    new unmanaged BlockCyclicDim(lowIdx=st2, blockSize=blkSize, numLocales=tl2, name="D2"), //MBC //BC
-  rdim2 = new unmanaged ReplicatedDim(tl2);
+    new BlockCyclicDim(lowIdx=st2, blockSize=blkSize, numLocales=tl2, name="D2"), //MBC //BC
+  rdim2 = new ReplicatedDim(tl2);
 
 const AbD: domain(2, indexType)
 // dmapped Block(boundingBox={1..nbb1, 1..nbb2}, targetLocales=tla) //MBD
@@ -113,10 +113,6 @@ writeln(
   else "not verified"
 );
 
-delete bdim1;
-delete rdim1;
-delete bdim2;
-delete rdim2;
 
 /////////////////////////////////////////////////////////////////////////////
 

--- a/test/studies/hpcc/HPL/vass/bc.md.chpl
+++ b/test/studies/hpcc/HPL/vass/bc.md.chpl
@@ -58,13 +58,13 @@ const MatVectSpace = {1..n, 1..n+1};
 const
   bdim1 =
 //  new BlockDim(tl1, 1, nbb1), //MBD //BD
-    new unmanaged BlockCyclicDim(lowIdx=st1, blockSize=blkSize, numLocales=tl1, name="D1"), //MBC //BC
-  rdim1 = new unmanaged ReplicatedDim(tl1),
+    new BlockCyclicDim(lowIdx=st1, blockSize=blkSize, numLocales=tl1, name="D1"), //MBC //BC
+  rdim1 = new ReplicatedDim(tl1),
 
   bdim2 =
 //  new BlockDim(tl2, 1, nbb2), //MBD //BD
-    new unmanaged BlockCyclicDim(lowIdx=st2, blockSize=blkSize, numLocales=tl2, name="D2"), //MBC //BC
-  rdim2 = new unmanaged ReplicatedDim(tl2);
+    new BlockCyclicDim(lowIdx=st2, blockSize=blkSize, numLocales=tl2, name="D2"), //MBC //BC
+  rdim2 = new ReplicatedDim(tl2);
 
 const AbD: domain(2, indexType)
 // dmapped Block(boundingBox={1..nbb1, 1..nbb2}, targetLocales=tla) //MBD
@@ -112,11 +112,6 @@ writeln(
     else               "verification FAILED"
   else "not verified"
 );
-
-delete bdim1;
-delete rdim1;
-delete bdim2;
-delete rdim2;
 
 
 /////////////////////////////////////////////////////////////////////////////

--- a/test/studies/hpcc/HPL/vass/bl.dim.chpl
+++ b/test/studies/hpcc/HPL/vass/bl.dim.chpl
@@ -57,14 +57,14 @@ const MatVectSpace = {1..n, 1..n+1};
 
 const
   bdim1 =
-    new unmanaged BlockDim(tl1, 1, nbb1), //MBD //BD
+    new BlockDim(tl1, 1, nbb1), //MBD //BD
 //  new BlockCyclicDim(lowIdx=st1, blockSize=blkSize, numLocales=tl1, name="D1"), //MBC //BC
-  rdim1 = new unmanaged ReplicatedDim(tl1),
+  rdim1 = new ReplicatedDim(tl1),
 
   bdim2 =
-    new unmanaged BlockDim(tl2, 1, nbb2), //MBD //BD
+    new BlockDim(tl2, 1, nbb2), //MBD //BD
 //  new BlockCyclicDim(lowIdx=st2, blockSize=blkSize, numLocales=tl2, name="D2"), //MBC //BC
-  rdim2 = new unmanaged ReplicatedDim(tl2);
+  rdim2 = new ReplicatedDim(tl2);
 
 const AbD: domain(2, indexType)
 // dmapped Block(boundingBox={1..nbb1, 1..nbb2}, targetLocales=tla) //MBD
@@ -113,10 +113,6 @@ writeln(
   else "not verified"
 );
 
-delete bdim1;
-delete rdim1;
-delete bdim2;
-delete rdim2;
 
 /////////////////////////////////////////////////////////////////////////////
 

--- a/test/studies/hpcc/HPL/vass/bl.md.chpl
+++ b/test/studies/hpcc/HPL/vass/bl.md.chpl
@@ -57,14 +57,14 @@ const MatVectSpace = {1..n, 1..n+1};
 
 const
   bdim1 =
-    new unmanaged BlockDim(tl1, 1, nbb1), //MBD //BD
+    new BlockDim(tl1, 1, nbb1), //MBD //BD
 //  new BlockCyclicDim(lowIdx=st1, blockSize=blkSize, numLocales=tl1, name="D1"), //MBC //BC
-  rdim1 = new unmanaged ReplicatedDim(tl1),
+  rdim1 = new ReplicatedDim(tl1),
 
   bdim2 =
-    new unmanaged BlockDim(tl2, 1, nbb2), //MBD //BD
+    new BlockDim(tl2, 1, nbb2), //MBD //BD
 //  new BlockCyclicDim(lowIdx=st2, blockSize=blkSize, numLocales=tl2, name="D2"), //MBC //BC
-  rdim2 = new unmanaged ReplicatedDim(tl2);
+  rdim2 = new ReplicatedDim(tl2);
 
 const AbD: domain(2, indexType)
    dmapped Block(boundingBox={1..nbb1, 1..nbb2}, targetLocales=tla) //MBD
@@ -113,10 +113,6 @@ writeln(
   else "not verified"
 );
 
-delete bdim1;
-delete rdim1;
-delete bdim2;
-delete rdim2;
 
 /////////////////////////////////////////////////////////////////////////////
 

--- a/test/studies/hpcc/HPL/vass/bug.chpl
+++ b/test/studies/hpcc/HPL/vass/bug.chpl
@@ -49,13 +49,13 @@ const MatVectSpace = {1..n, 1..n+1};
 const
   bdim1 =
 //  new BlockDim(tl1, 1, nbb1), //BD
-    new unmanaged BlockCyclicDim(lowIdx=st1, blockSize=blkSize, numLocales=tl1, name="D1"), //BC
-  rdim1 = new unmanaged ReplicatedDim(tl1),
+    new BlockCyclicDim(lowIdx=st1, blockSize=blkSize, numLocales=tl1, name="D1"), //BC
+  rdim1 = new ReplicatedDim(tl1),
 
   bdim2 =
 //  new BlockDim(tl2, 1, nbb2), //BD
-    new unmanaged BlockCyclicDim(lowIdx=st2, blockSize=blkSize, numLocales=tl2, name="D2"), //BC
-  rdim2 = new unmanaged ReplicatedDim(tl2);
+    new BlockCyclicDim(lowIdx=st2, blockSize=blkSize, numLocales=tl2, name="D2"), //BC
+  rdim2 = new ReplicatedDim(tl2);
 
 const AbD: domain(2, indexType)
    dmapped BlockCyclic(startIdx=(st1,st2), blocksize=(blkSize,blkSize), targetLocales=tla) //MBC
@@ -104,10 +104,6 @@ writeln(
   else "not verified"
 );
 
-delete bdim1;
-delete rdim1;
-delete bdim2;
-delete rdim2;
 
 /////////////////////////////////////////////////////////////////////////////
 

--- a/test/studies/hpcc/HPL/vass/hpl.chpl
+++ b/test/studies/hpcc/HPL/vass/hpl.chpl
@@ -77,14 +77,14 @@ config var reproducible = false, verbose = false;
   // Create individual dimension descriptors
   const
     // block-cyclic for 1st dimension
-    bdim1 = new unmanaged BlockCyclicDim(lowIdx=1, blockSize=blkSize, numLocales=tl1),
+    bdim1 = new BlockCyclicDim(lowIdx=1, blockSize=blkSize, numLocales=tl1),
     // replicated for 1st dimension
-    rdim1 = new unmanaged ReplicatedDim(tl1),
+    rdim1 = new ReplicatedDim(tl1),
 
     // block-cyclic for 2nd dimension
-    bdim2 = new unmanaged BlockCyclicDim(lowIdx=1, blockSize=blkSize, numLocales=tl2),
+    bdim2 = new BlockCyclicDim(lowIdx=1, blockSize=blkSize, numLocales=tl2),
     // replicated for 2nd dimension
-    rdim2 = new unmanaged ReplicatedDim(tl2);
+    rdim2 = new ReplicatedDim(tl2);
 
   //
   // MatVectSpace is a 2D domain of type indexType that represents the
@@ -130,11 +130,6 @@ config var reproducible = false, verbose = false;
   // Validate the answer and print the results
   const validAnswer = verifyResults(x);
   printResults(validAnswer, execTime);
-
-  delete bdim1;
-  delete rdim1;
-  delete bdim2;
-  delete rdim2;
 
 //
 // blocked LU factorization with pivoting for matrix augmented with

--- a/test/studies/hpcc/HPL/vass/hpl.performance.chpl
+++ b/test/studies/hpcc/HPL/vass/hpl.performance.chpl
@@ -116,14 +116,14 @@ var tInit, tPS1iter, tUBR1iter, tSC1call, tLF1iter, tBScall, tVer: VTimer;
   // Create individual dimension descriptors
   const
     // block-cyclic for 1st dimension
-    bdim1 = new unmanaged BlockCyclicDim(lowIdx=1, blockSize=blkSize, numLocales=tl1),
+    bdim1 = new BlockCyclicDim(lowIdx=1, blockSize=blkSize, numLocales=tl1),
     // replicated for 1st dimension
-    rdim1 = new unmanaged ReplicatedDim(tl1),
+    rdim1 = new ReplicatedDim(tl1),
 
     // block-cyclic for 2nd dimension
-    bdim2 = new unmanaged BlockCyclicDim(lowIdx=1, blockSize=blkSize, numLocales=tl2),
+    bdim2 = new BlockCyclicDim(lowIdx=1, blockSize=blkSize, numLocales=tl2),
     // replicated for 2nd dimension
-    rdim2 = new unmanaged ReplicatedDim(tl2);
+    rdim2 = new ReplicatedDim(tl2);
 
   const
     dist1b2b = new unmanaged DimensionalDist2D(targetLocales, bdim1, bdim2, "dist1b2b"),

--- a/test/studies/hpcc/HPL/vass/schurComplement.chpl
+++ b/test/studies/hpcc/HPL/vass/schurComplement.chpl
@@ -52,18 +52,15 @@ const st1=1, st2=1;
 
 // 1-d descriptors for Dimensional
 const
-  bdim1 = new unmanaged BlockCyclicDim(lowIdx=st1, blockSize=blkSize, numLocales=tl1, name="D1"),
-  rdim1 = new unmanaged ReplicatedDim(tl1),
-  bdim2 = new unmanaged BlockCyclicDim(lowIdx=st2, blockSize=blkSize, numLocales=tl2, name="D2"),
-  rdim2 = new unmanaged ReplicatedDim(tl2);
+  bdim1 = new BlockCyclicDim(lowIdx=st1, blockSize=blkSize, numLocales=tl1, name="D1"),
+  rdim1 = new ReplicatedDim(tl1),
+  bdim2 = new BlockCyclicDim(lowIdx=st2, blockSize=blkSize, numLocales=tl2, name="D2"),
+  rdim2 = new ReplicatedDim(tl2);
 
 const dimdist = new dmap(new unmanaged DimensionalDist2D(tla, bdim1, bdim2, "dim"));
 
 // the distributed domain for Ab
-const AbD: domain(2, indexType)
-   dmapped dimdist
-   //DimensionalDist2D(tla, bdim1, bdim2, "dim")
-  = MatVectSpace;
+const AbD: domain(2, indexType) dmapped dimdist = MatVectSpace;
 
 // temporaries
 var Rest: domain(2, indexType) dmapped dimdist; //AbD.dist;
@@ -225,10 +222,6 @@ proc dgemm(LreplA, LreplB, LAb) {
     }
 }
 
-delete bdim1;
-delete rdim1;
-delete bdim2;
-delete rdim2;
 
 /////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
Switch the dimension specifiers from classes to records.
This simplifies their memory management and reduces the malloc/free overhead.
As a side effect, this eliminates leaks when using DimensionalDist2D
on multiple locales, when privatized copies of dimension specifies
are allocated on remote locales.

This changes the public interface of a dimension specifier:
* removes `dsiSupportsPrivatization1d()`
* always requires `dsiGetPrivatizeData1d()` and `dsiPrivatize1d()`
  - the former can simply return `this`
  - the latter is now a type method, otherwise we'd have to copy
    the original record across locales, which defeats the purpose
    of dsiGetPrivatizeData1d()
  - future work: maybe we can simply copy the original record,
    without bothering with dsiGetPrivatizeData1d and dsiPrivatize1d ?

An interesting, albeit expected, change that I made to support the above
is to replace some variables from `const` (containing a class reference)
to `var` (containing a record).

While dimensional specifies are now created using `new` without `unmanaged`,
DimensionalDist2D itself is still a class, as per DSI, and so continues
to be "unmanaged". We do not delete it explicitly because it is wrapped in
a `dmap` aka `_distribution`, which deletes it once it is no longer needed.

Testing - affected tests: linux64, gasnet, memleaks, valgrind.