### PR TITLE
Add User Error for unsupported type queries

### DIFF
--- a/compiler/resolution/callInfo.cpp
+++ b/compiler/resolution/callInfo.cpp
@@ -78,6 +78,12 @@ bool CallInfo::isWellFormed(CallExpr* callExpr) {
       actualNames.add(NULL);
     }
 
+    if (isDefExpr(actual)) {
+      // This implies a '?t' style query expression, which we don't currently
+      // support if we got here
+      return false;
+    }
+
     SymExpr* se = toSymExpr(actual);
 
     INT_ASSERT(se);
@@ -117,6 +123,10 @@ void CallInfo::haltNotWellFormed() const {
 
     if (NamedExpr* named = toNamedExpr(actual)) {
       actual = named->actual;
+    }
+
+    if (isDefExpr(actual)) {
+      USR_FATAL(actual, "Query expressions are not currently supported in this context");
     }
 
     SymExpr* se = toSymExpr(actual);

--- a/test/classes/generic/queryGenericField.chpl
+++ b/test/classes/generic/queryGenericField.chpl
@@ -1,0 +1,5 @@
+class R {
+  var l: LinkedList(?t);
+}
+
+var myR = new R(l = new LinkedList(real));

--- a/test/classes/generic/queryGenericField.good
+++ b/test/classes/generic/queryGenericField.good
@@ -1,0 +1,1 @@
+queryGenericField.chpl:2: error: Query expressions are not currently supported in this context

--- a/test/functions/diten/formalArrayWithQueriedEltSize.bad
+++ b/test/functions/diten/formalArrayWithQueriedEltSize.bad
@@ -1,8 +1,3 @@
-formalArrayWithQueriedEltSize.chpl:1: internal error: RES-CAL-NFO-0078 chpl version 1.19.0 pre-release (cfeb6592b3)
-Note: This source location is a guess.
-
-Internal errors indicate a bug in the Chapel compiler ("It's us, not you"),
-and we're sorry for the hassle.  We would appreciate your reporting this bug -- 
-please see https://chapel-lang.org/bugs.html for instructions.  In the meantime,
-the filename + line number above may be useful in working around the issue.
-
+formalArrayWithQueriedEltSize.chpl:1: In function 'f':
+formalArrayWithQueriedEltSize.chpl:1: error: Query expressions are not currently supported in this context
+formalArrayWithQueriedEltSize.chpl:1: Function 'f' instantiated as: f(x: [domain(1,int(64),false)] real(64))

--- a/test/functions/diten/formalArrayWithQueriedEltSize.future
+++ b/test/functions/diten/formalArrayWithQueriedEltSize.future
@@ -1,3 +1,3 @@
-bug: array formal with queried element size trips internal error
+feature request: ability to query aspects of an array formal's elements
 
 Issue #8316


### PR DESCRIPTION
Prior to this PR, certain type queries (e.g., `myRecord(?t)`) triggered internal errors in the compiler for cases where we can't yet handle them.  With this change, a user-facing error is given indicating that the given query is not yet supported.  I believe that our hope is to eventually support such queries, but this serves as a step in the right direction in the meantime, by avoiding an internal error.

Resolves #13911.
Improves the behavior for #8316.