### PR TITLE
Delete workaround that caused memory leaks

### DIFF
--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -588,22 +588,6 @@ buildTupleVarDeclHelp(Expr* base, BlockStmt* decls, Expr* insertPoint) {
 BlockStmt*
 buildTupleVarDeclStmt(BlockStmt* tupleBlock, Expr* type, Expr* init) {
   VarSymbol* tmp = newTemp();
-  // MPF - without FLAG_NO_COPY, normalize adds an initCopy here,
-  // but that initCopy is unnecessary because each variable will
-  // be initialized with a tuple element (and initCopy called then).
-  // For the case where type==NULL, it was causing type mismatch
-  // errors; but when type!=NULL, normalize will change to
-  // defaultOf/assign anyway and there isn't a type issue
-  if (type == NULL) {
-    tmp->addFlag(FLAG_NO_COPY);
-
-    // additionally, don't auto-destroy tmp if the RHS
-    // is another variable (vs a call).
-    // This does not correctly handle certain no-parens calls. See
-    // tuple-string-bug.chpl and tuple-string-bug-noparens.chpl
-    if (!isCallExpr(init))
-      tmp->addFlag(FLAG_NO_AUTO_DESTROY);
-  }
   int count = 1;
   for_alist(expr, tupleBlock->body) {
     if (DefExpr* def = toDefExpr(expr)) {


### PR DESCRIPTION
This PR closes a leak which occurs when a tuple variable is declared with a call
to a parenless function as the initializer. For example:

```chapel
proc foo {
  return (1, "foo");
}

var (i,s) = foo;
```

Leaked the `call_tmp` tuple that captures the return value of the function.

This was due to a workaround added in #4762. The comments describe the need for
the workaround back then. However, it doesn't seem to be necessary anymore.

I made an initial attempt at closing this leak by working around the workaround
in #14091. But this is a better alternative to that.

Closes the leak in test/types/tuple/ferguson/tuple-string-bug-noparens.chpl

Test:
- [x] quickstart valgrind in `test/types/tuples`
- [x] standard memleak in `test/types/tuples`
   (`returnArrayTuple` is the only test that leaks. It is the same leak on master, and this
    PR isn't supposed to fix that anyways)
- [x] standard correctness
- [x] gasnet correctness