### PR TITLE
Bump docs to indicate next release is 1.21

### DIFF
--- a/doc/rst/conf.py
+++ b/doc/rst/conf.py
@@ -60,12 +60,12 @@ master_doc = 'index'
 # 'version' adds a redundant version number onto the top of the sidebar
 # automatically (rtd-theme). We also don't use |version| anywhere in rst
 
-chplversion = '1.20'                  # TODO -- parse from `chpl --version`
+chplversion = '1.21'                  # TODO -- parse from `chpl --version`
 shortversion = chplversion.replace('-', '&#8209') # prevent line-break at hyphen, if any
 html_context = {"chplversion":chplversion}
 
 # The full version, including alpha/beta/rc tags.
-release = '1.20.0'
+release = '1.21.0'
 
 # General information about the project.
 project = u'Chapel Documentation'

--- a/doc/util/versionButton.php
+++ b/doc/util/versionButton.php
@@ -89,7 +89,7 @@ if (pagePath == "") {
 function dropSetup() {
   var currentRelease = "1.19"; // what does the public have?
   var stagedRelease = "1.20";  // is there a release staged but not yet public?
-  var nextRelease = "1.20";    // what's the next release? (on docs/master)
+  var nextRelease = "1.21";    // what's the next release? (on docs/master)
   var button = document.getElementById("versionButton");
   // Uses unicode down-pointing triangle
   var arrow = " &#9660;";


### PR DESCRIPTION
This bumps the version of the docs for the next release to 1.21.