### PR TITLE
Improve assignment from a sparse domain to an empty one of same type

### DIFF
--- a/modules/internal/DefaultSparse.chpl
+++ b/modules/internal/DefaultSparse.chpl
@@ -354,7 +354,13 @@ module DefaultSparse {
     }
 
     proc dsiAssignDomain(rhs: domain, lhsPrivate:bool) {
-      chpl_assignDomainWithIndsIterSafeForRemoving(this, rhs);
+      if this.dsiNumIndices == 0 {
+        this.dsiBulkAdd(rhs.indices[nnzDom.low..#rhs.dsiNumIndices],
+                        dataSorted=true, isUnique=true);
+      }
+      else {
+        chpl_assignDomainWithIndsIterSafeForRemoving(this, rhs);
+      }
     }
 
     proc dsiHasSingleLocalSubdomain() param return true;

--- a/modules/internal/DefaultSparse.chpl
+++ b/modules/internal/DefaultSparse.chpl
@@ -354,9 +354,11 @@ module DefaultSparse {
     }
 
     proc dsiAssignDomain(rhs: domain, lhsPrivate:bool) {
-      if this.dsiNumIndices == 0 {
-        this.dsiBulkAdd(rhs.indices[nnzDom.low..#rhs.dsiNumIndices],
-                        dataSorted=true, isUnique=true);
+      if _to_borrowed(rhs._instance.type) == this.type && this.dsiNumIndices == 0 {
+        this._nnz = rhs._nnz;
+        _bulkGrow();
+
+        this.indices = rhs.indices;
       }
       else {
         chpl_assignDomainWithIndsIterSafeForRemoving(this, rhs);

--- a/modules/internal/DefaultSparse.chpl
+++ b/modules/internal/DefaultSparse.chpl
@@ -355,8 +355,13 @@ module DefaultSparse {
 
     proc dsiAssignDomain(rhs: domain, lhsPrivate:bool) {
       if _to_borrowed(rhs._instance.type) == this.type && this.dsiNumIndices == 0 {
+
+        // ENGIN: We cannot use bulkGrow here, because rhs might be grown using
+        // grow, which has a different heuristic to grow the internal arrays.
+        // That may result in size mismatch in the following internal array
+        // assignments
         this._nnz = rhs._nnz;
-        _bulkGrow();
+        this.nnzDom = rhs.nnzDom;
 
         this.indices = rhs.indices;
       }

--- a/modules/layouts/LayoutCS.chpl
+++ b/modules/layouts/LayoutCS.chpl
@@ -152,7 +152,16 @@ class CSDom: BaseSparseDomImpl {
   override proc dsiMyDist() return dist;
 
   proc dsiAssignDomain(rhs: domain, lhsPrivate:bool) {
-    chpl_assignDomainWithIndsIterSafeForRemoving(this, rhs);
+    if _to_borrowed(rhs._instance.type) == this.type && this.dsiNumIndices == 0 {
+      this._nnz = rhs._nnz;
+      _bulkGrow();
+
+      this.startIdx = rhs.startIdx;
+      this.idx = rhs.idx;
+    }
+    else {
+      chpl_assignDomainWithIndsIterSafeForRemoving(this, rhs);
+    }
   }
 
   proc dsiBuildArray(type eltType)

--- a/modules/layouts/LayoutCS.chpl
+++ b/modules/layouts/LayoutCS.chpl
@@ -153,8 +153,13 @@ class CSDom: BaseSparseDomImpl {
 
   proc dsiAssignDomain(rhs: domain, lhsPrivate:bool) {
     if _to_borrowed(rhs._instance.type) == this.type && this.dsiNumIndices == 0 {
+
+      // ENGIN: We cannot use bulkGrow here, because rhs might be grown using
+      // grow, which has a different heuristic to grow the internal arrays.
+      // That may result in size mismatch in the following internal array
+      // assignments
       this._nnz = rhs._nnz;
-      _bulkGrow();
+      this.nnzDom = rhs.nnzDom;
 
       this.startIdx = rhs.startIdx;
       this.idx = rhs.idx;


### PR DESCRIPTION
This PR makes assignment from a sparse domain to an empty one of the same type
much faster by simply assigning internal data structures.

Resolves https://github.com/chapel-lang/chapel/issues/9344 and probably https://github.com/chapel-lang/chapel/issues/9364

The implementation is fairly straighforward and performance benefits should be
obvious. But here are some more anecdotal tests on my MBP:


DefaultSparse
--------------
| idiom                   | master | PR   |
| ------------------------| ------ | --   |
|`var spsDom= otherSps`   | 3.21   | 0.15 |
|`emptySpsDom = otherSps` | 3.12   | 0.15 |


CS(compressedRows=true)
-----------------------
| idiom                   | master | PR   |
| ------------------------| ------ | --   |
|`var spsDom= otherSps`   | 91.89  | 0.10 |
|`emptySpsDom = otherSps` | 93.83  | 0.08 |

Test:
- [x] standard
- [x] gasnet