### PR TITLE
Stop posting nightly test results to public lists

### DIFF
--- a/doc/rst/developer/bestPractices/ContributorInfo.rst
+++ b/doc/rst/developer/bestPractices/ContributorInfo.rst
@@ -1000,7 +1000,6 @@ Reviewer responsibilities
   level.
 
 .. _chapel-developers: chapel-developers@lists.sourceforge.net
-.. _chapel-test-results-regressions: chapel-test-results-regressions@lists.sourceforge.net
 .. _chapel-users: chapel-users@lists.sourceforge.net
 .. _chapel-lang/chapel: https://github.com/chapel-lang/chapel
 .. _Set up a github account: https://help.github.com/articles/signing-up-for-a-new-github-account

--- a/doc/rst/developer/bestPractices/TestSystem.rst
+++ b/doc/rst/developer/bestPractices/TestSystem.rst
@@ -794,13 +794,6 @@ Successful tests will not be printed after the line beginning with ``[Test
 Summary`` unless they had a ``.future`` file (see `A Test That Tracks A
 Failure`_ for information about ``.future`` files).
 
-When nightly testing is run, a mail will be sent to
-`chapel-test-results-regressions`_ for every configuration with a new failure,
-warning, passing suppression, and/or passing future.
-
-.. _chapel-test-results-regressions: chapel-test-results-regressions@lists.sourceforge.net
-
-
 Summary of Testing Files
 ========================
 

--- a/util/buildRelease/testRelease
+++ b/util/buildRelease/testRelease
@@ -8,9 +8,9 @@ $chplhomedir = abs_path("$cwd/../..");
 
 
 # Mailing lists.
-$failuremail = "chapel-test-results-regressions\@lists.sourceforge.net chapel_cronmail\@cray.com";
-$allmail = "chapel-test-results-all\@lists.sourceforge.net chapel_cronmail_all\@cray.com";
-$replymail = "chapel-developers\@lists.sourceforge.net";
+$failuremail = "chapel_cronmail\@cray.com";
+$allmail = "chapel_cronmail_all\@cray.com";
+$replymail = "chapel_dev\@cray.com";
 
 $printusage = 1;
 $debug = 1;

--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -20,9 +20,9 @@ use lib "$FindBin::Bin";
 use nightlysubs;
 
 # Mailing lists.
-$failuremail = "chapel-test-results-regressions\@lists.sourceforge.net chapel_cronmail\@cray.com";
-$allmail = "chapel-test-results-all\@lists.sourceforge.net chapel_cronmail_all\@cray.com";
-$replymail = "chapel-developers\@lists.sourceforge.net";
+$failuremail = "chapel_cronmail\@cray.com";
+$allmail = "chapel_cronmail_all\@cray.com";
+$replymail = "chapel_dev\@cray.com";
 
 $valgrind = 0;
 $interpret = 0;

--- a/util/cron/start_opt_test
+++ b/util/cron/start_opt_test
@@ -20,8 +20,8 @@ use Cwd 'abs_path';
 use File::Basename;
 
 # Mailing lists.
-$failuremail = "chapel-test-results-regressions\@lists.sourceforge.net chapel_cronmail\@cray.com";
-$allmail = "chapel-test-results-all\@lists.sourceforge.net chapel_cronmail_all\@cray.com";
+$failuremail = "chapel_cronmail\@cray.com";
+$allmail = "chapel_cronmail_all\@cray.com";
 
 while (@ARGV) {
   $flag = shift @ARGV;

--- a/util/tokencount/tokctnightly
+++ b/util/tokencount/tokctnightly
@@ -4,8 +4,8 @@ use Cwd 'abs_path';
 use File::Basename;
 
 # Mailing lists.
-$failuremail = "chapel-test-results-regressions\@lists.sourceforge.net chapel_cronmail\@cray.com";
-$replymail = "chapel-developers\@lists.sourceforge.net";
+$failuremail = "chapel_cronmail\@cray.com";
+$replymail = "chapel_dev\@cray.com";
 
 $tokctdir = abs_path(dirname(__FILE__));
 $tokctr = "$tokctdir/tokencount.cron";


### PR DESCRIPTION
* Stop posting nightly tests to public lists since a Cray person will notify external contributors of any issue with their PRs revealed by nightly testing
* Changes Reply-To to the internal Cray mailing list that Cray triagers use to make the triage job easier