### PR TITLE
Set intel compiler version for XC x86_64 build to 16.0.3.210.

### DIFF
--- a/util/build_configs/cray-internal/setenv-xc-x86_64.bash
+++ b/util/build_configs/cray-internal/setenv-xc-x86_64.bash
@@ -336,7 +336,7 @@ else
 
     # Please keep the gen versions in compiler_versions.bash the same as these!
     gen_version_gcc=7.3.0
-    gen_version_intel=default
+    gen_version_intel=16.0.3.210
     gen_version_cce=8.7.8
     if [ "$CHPL_LOCALE_MODEL" == knl ]; then
         gen_version_cce=8.7.8


### PR DESCRIPTION
Intel 19 is now the default supported version on the internal XCs,
but we still want to build with version 16. Now that we have it
available, go back to building with that rather than system default.