### PR TITLE
Update future for using file level modules with hyphenated names after old discussion

### DIFF
--- a/test/statements/lydia/use-hyphenated.future
+++ b/test/statements/lydia/use-hyphenated.future
@@ -1,2 +1,2 @@
-Can't use a module with a hyphen in its name
+Error message: Can't use a module with a hyphen in its name
 #12333

--- a/test/statements/lydia/use-hyphenated.good
+++ b/test/statements/lydia/use-hyphenated.good
@@ -1,1 +1,1 @@
-nbd
+use-hyphenated.chpl:1: error: modules names in Chapel source code must be legal identifiers


### PR DESCRIPTION
See #12333 for discussion.  Basic summary is that we don't think
such modules should be usable, but that it would be beneficial to
have a better error message for the user.

I meant to get back to this sooner, but had a lot going on.  I'm cleaning
out my inbox so finally got back to it.