### PR TITLE
Fix union memory management

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -2380,7 +2380,7 @@ bool AggregateType::addSuperArgs(FnSymbol*                    fn,
 }
 
 void AggregateType::buildCopyInitializer() {
-  if (isRecordWithInitializers(this) == true) {
+  if (isRecordOrUnionWithInitializers(this) == true) {
     SET_LINENO(this);
 
     bool isGeneric = false;

--- a/compiler/AST/symbol.cpp
+++ b/compiler/AST/symbol.cpp
@@ -471,10 +471,6 @@ bool isBytes(Symbol* symbol) {
   return isBytes(symbol->type);
 }
 
-bool isUserDefinedRecord(Symbol* symbol) {
-  return isUserDefinedRecord(symbol->type);
-}
-
 /******************************** | *********************************
 *                                                                   *
 * Common base class for ArgSymbol and VarSymbol.                    *

--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -1342,47 +1342,16 @@ bool isBytes(Type* type) {
   return type == dtBytes;
 }
 
-//
-// Noakes 2016/02/29
-//
-// To support the merge of the string-as-rec branch we defined a
-// function, isString(), which is only true of the record that was
-// defined in the new implementation of String.  This predicate was
-// applied in cullOverReferences and callDestructors to improve
-// memory management for that particular record type.
-//
-// We seek to apply those routines to a wider set of record types but
-// are not ready to apply them to range, tuple, and the reference-counted
-// records.
-//
-// This shorter-term predicate, which has a slightly inelegant name, allows
-// most record-like types to use the new business logic.
-//
-// In the longer term we plan to further broaden the cases that the new
-// logic can handle and reduce the exceptions that are filtered out here.
-//
-//
-//
-// MPF    2016/09/15
-// This function now includes tuples, distributions, domains, and arrays.
-//
-// Noakes 2017/03/02
-// This function now includes range and atomics
-//
-// MPF    2017/08/03
-// This function now includes iterator records
-//
-// TODO: rename this to isMemoryManagedRecord or something along
-//       those lines, since it now applies to some compiler-internal records.
-//
-bool isUserDefinedRecord(Type* type) {
+// Indicates record-like memory management
+bool typeNeedsCopyInitDeinit(Type* type) {
   bool retval = false;
 
   if (AggregateType* aggr = toAggregateType(type)) {
     Symbol*     sym  = aggr->symbol;
 
     // Must be a record type
-    if (aggr->aggregateTag != AGGREGATE_RECORD) {
+    if (aggr->aggregateTag != AGGREGATE_RECORD &&
+        aggr->aggregateTag != AGGREGATE_UNION) {
       retval = false;
 
     // Not a RUNTIME_type

--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -1629,11 +1629,11 @@ bool isGenericRecordWithInitializers(Type* type) {
   return retval;
 }
 
-bool isRecordWithInitializers(Type* type) {
+bool isRecordOrUnionWithInitializers(Type* type) {
   bool retval = false;
 
   if (AggregateType* at = toAggregateType(type)) {
-    if (at->isRecord()                   == true  &&
+    if ((at->isRecord() || at->isUnion()) &&
         (at->hasUserDefinedInit == true ||
          at->wantsDefaultInitializer())) {
       retval = true;
@@ -1654,7 +1654,7 @@ bool needsGenericRecordInitializer(Type* type) {
   bool retval = false;
 
   if (AggregateType* at = toAggregateType(type)) {
-    if (isRecordWithInitializers(type)) {
+    if (isRecordOrUnionWithInitializers(type)) {
       if (at->isGeneric() == true ||
           at->symbol->hasFlag(FLAG_GENERIC) == true ||
           at->instantiatedFrom != NULL) {

--- a/compiler/codegen/expr.cpp
+++ b/compiler/codegen/expr.cpp
@@ -3738,7 +3738,7 @@ GenRet CallExpr::codegen() {
       // Handle setting LLVM invariant on const records after
       // they are initialized
       if (fn->isInitializer() || fn->isCopyInit()) {
-        if (isUserDefinedRecord(get(1)->typeInfo())) {
+        if (typeNeedsCopyInitDeinit(get(1)->typeInfo())) {
           if (SymExpr* initedSe = toSymExpr(get(1))) {
             if (initedSe->symbol()->isConstValWillNotChange()) {
               GenRet genSe = args[0];

--- a/compiler/include/symbol.h
+++ b/compiler/include/symbol.h
@@ -261,7 +261,6 @@ private:
 
 bool isString(Symbol* symbol);
 bool isBytes(Symbol* symbol);
-bool isUserDefinedRecord(Symbol* symbol);
 
 /************************************* | **************************************
 *                                                                             *

--- a/compiler/include/type.h
+++ b/compiler/include/type.h
@@ -499,7 +499,7 @@ bool isGenericClassWithInitializers (Type* type);
 bool isGenericRecordWithInitializers(Type* type);
 
 bool isClassWithInitializers (Type* type);
-bool isRecordWithInitializers(Type* type);
+bool isRecordOrUnionWithInitializers(Type* type);
 
 bool needsGenericRecordInitializer(Type* type);
 

--- a/compiler/include/type.h
+++ b/compiler/include/type.h
@@ -480,7 +480,9 @@ bool isArrayClass(Type* type);
 
 bool isString(Type* type);
 bool isBytes(Type* type);
-bool isUserDefinedRecord(Type* type);
+
+// Does it use record-style memory management?
+bool typeNeedsCopyInitDeinit(Type* type);
 
 bool isPrimitiveScalar(Type* type);
 

--- a/compiler/passes/initializerRules.cpp
+++ b/compiler/passes/initializerRules.cpp
@@ -265,7 +265,7 @@ static bool isReturnVoid(FnSymbol* fn) {
 *                                                                             *
 ************************************** | *************************************/
 
-static void          preNormalizeInitRecord(FnSymbol* fn);
+static void          preNormalizeInitRecordUnion(FnSymbol* fn);
 
 static void          preNormalizeInitClass(FnSymbol* fn);
 
@@ -285,7 +285,7 @@ static void preNormalizeInit(FnSymbol* fn) {
     USR_FATAL(fn, "initializers are not yet allowed to throw errors");
 
   } else if (at->isRecord() == true || at->isUnion()) {
-    preNormalizeInitRecord(fn);
+    preNormalizeInitRecordUnion(fn);
 
   } else if (at->isClass()  == true) {
     preNormalizeInitClass(fn);
@@ -295,7 +295,7 @@ static void preNormalizeInit(FnSymbol* fn) {
   }
 }
 
-static void preNormalizeInitRecord(FnSymbol* fn) {
+static void preNormalizeInitRecordUnion(FnSymbol* fn) {
   InitNormalize  state(fn);
 
   AggregateType* at    = toAggregateType(fn->_this->type);

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -122,7 +122,7 @@ void normalize() {
 
   forv_Vec(AggregateType, at, gAggregateTypes) {
     if (isClassWithInitializers(at)  == true ||
-        isRecordWithInitializers(at) == true) {
+        isRecordOrUnionWithInitializers(at) == true) {
       preNormalizeFields(at);
     }
 
@@ -749,7 +749,7 @@ static Symbol* theDefinedSymbol(BaseAST* ast) {
 
         // records with initializers are defined
         } else if (AggregateType* at = toAggregateType(type)) {
-          if (isRecordWithInitializers(at) == true) {
+          if (isRecordOrUnionWithInitializers(at) == true) {
             retval = var;
           }
         }

--- a/compiler/passes/resolveIntents.cpp
+++ b/compiler/passes/resolveIntents.cpp
@@ -34,7 +34,6 @@ static IntentTag constIntentForType(Type* t) {
       is_enum_type(t) ||
       isClass(t) ||
       isDecoratedClassType(t) ||
-      isUnion(t) ||
       t == dtOpaque ||
       t == dtTaskID ||
       t == dtFile ||
@@ -55,6 +54,7 @@ static IntentTag constIntentForType(Type* t) {
              isRecordWrappedType(t) ||  // domain, array, or distribution
              isManagedPtrType(t) ||
              isAtomicType(t) ||
+             isUnion(t) ||
              isRecord(t)) { // may eventually want to decide based on size
     return INTENT_CONST_REF;
 

--- a/compiler/resolution/AutoDestroyScope.cpp
+++ b/compiler/resolution/AutoDestroyScope.cpp
@@ -244,8 +244,8 @@ static VarSymbol* variableToExclude(FnSymbol* fn, Expr* refStmt) {
   // and the excluded set.
 
   if (retVar != NULL) {
-    if (isUserDefinedRecord(retVar)    == true ||
-        fn->hasFlag(FLAG_INIT_COPY_FN) == true) {
+    if (typeNeedsCopyInitDeinit(retVar->type) ||
+        fn->hasFlag(FLAG_INIT_COPY_FN)) {
       VarSymbol* needle = retVar;
       Expr*      expr   = refStmt;
 

--- a/compiler/resolution/addAutoDestroyCalls.cpp
+++ b/compiler/resolution/addAutoDestroyCalls.cpp
@@ -468,7 +468,7 @@ static void gatherIgnoredVariablesForYield(
   INT_ASSERT(yieldedVar);
   QualifiedType t = yieldedVar->qualType();
 
-  if (isUserDefinedRecord(t.type()) && ! t.isRef()) {
+  if (typeNeedsCopyInitDeinit(t.type()) && ! t.isRef()) {
 
     SymExpr* foundSe = findSourceOfYield(yield);
     VarSymbol* var = toVarSymbol(foundSe->symbol());

--- a/compiler/resolution/cullOverReferences.cpp
+++ b/compiler/resolution/cullOverReferences.cpp
@@ -1563,7 +1563,7 @@ void lowerContextCall(ContextCallExpr* cc, choose_type_t which)
       move->insertBefore(new DefExpr(tmp));
 
       if (requiresImplicitDestroy(useCall)) {
-        if (isUserDefinedRecord(useFn->retType) == false) {
+        if (typeNeedsCopyInitDeinit(useFn->retType) == false) {
           tmp->addFlag(FLAG_INSERT_AUTO_DESTROY);
         } else {
           tmp->addFlag(FLAG_INSERT_AUTO_DESTROY);

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -5923,6 +5923,27 @@ static void resolveInitVar(CallExpr* call) {
     INT_FATAL(call, "unexpected number of actuals in variable init call");
   }
 
+  // Handle noinit
+  if (srcExpr && srcExpr->symbol() == gNoInit) {
+    if (call->numActuals() < 3) {
+      // no init needs a type, cannot infer from gNoInit.
+      INT_FATAL(call, "bad no init call");
+    }
+
+    SymExpr* targetTypeExpr = toSymExpr(call->get(3)->remove());
+    targetType = targetTypeExpr->typeInfo();
+
+    if (targetType->symbol->hasFlag(FLAG_GENERIC)) {
+      // no init needs a concrete type, cannot infer from gNoInit.
+      INT_FATAL(call, "bad no init call");
+    }
+
+    // Since we are not initializing, just set the variable's type
+    dst->type = targetType;
+    call->primitive = primitives[PRIM_NOOP];
+    return;
+  }
+
   if (call->numActuals() == 3) {
     SymExpr* targetTypeExpr = toSymExpr(call->get(3)->remove());
     targetType = targetTypeExpr->typeInfo();

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -8612,7 +8612,7 @@ static void resolveAutoCopyEtc(AggregateType* at) {
 static const char* autoCopyFnForType(AggregateType* at) {
   const char* retval = "chpl__autoCopy";
 
-  if (isUserDefinedRecord(at)                == true  &&
+  if (typeNeedsCopyInitDeinit(at)            == true  &&
       at->symbol->hasFlag(FLAG_TUPLE)        == false &&
       at->symbol->hasFlag(FLAG_ITERATOR_RECORD) == false &&
       isRecordWrappedType(at)                == false &&
@@ -8847,7 +8847,7 @@ static void insertReturnTemps() {
             VarSymbol* tmp = newTemp("_return_tmp_", fn->retType);
             DefExpr*   def = new DefExpr(tmp);
 
-            if (isUserDefinedRecord(fn->retType) == true)
+            if (typeNeedsCopyInitDeinit(fn->retType) == true)
               tmp->addFlag(FLAG_INSERT_AUTO_DESTROY);
 
             contextCallOrCall->insertBefore(def);

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -6054,8 +6054,8 @@ static void resolveInitVar(CallExpr* call) {
       call->primitive = primitives[PRIM_MOVE];
 
       resolveMove(call);
-    } else if (isRecordWithInitializers(at) == false) {
-      INT_FATAL("Unable to initialize record variable with type '%s'", at->symbol->name);
+    } else if (isRecordOrUnionWithInitializers(at) == false) {
+      INT_FATAL("Unable to initialize record/union variable with type '%s'", at->symbol->name);
     } else if (targetType->getValType() == srcType->getValType() &&
                targetType->getValType()->symbol->hasFlag(FLAG_POD)) {
       dst->type = targetType->getValType();

--- a/compiler/resolution/generics.cpp
+++ b/compiler/resolution/generics.cpp
@@ -465,7 +465,7 @@ static bool fixupDefaultInitCopy(FnSymbol* fn,
   bool       retval = false;
 
   if (AggregateType* ct = toAggregateType(arg->type)) {
-    if (isUserDefinedRecord(ct) == true && ct->hasInitializers()) {
+    if (typeNeedsCopyInitDeinit(ct) == true && ct->hasInitializers()) {
       // If the user has defined any initializer,
       // initCopy function should call the copy-initializer.
       //

--- a/compiler/resolution/lowerIterators.cpp
+++ b/compiler/resolution/lowerIterators.cpp
@@ -2752,7 +2752,7 @@ static void reconstructIRAutoCopy(FnSymbol* fn)
 
     // Now auto-copy it if appropriate
     Symbol* copyResult = fieldValue;
-    if (isUserDefinedRecord(field->type) && !field->isRef() ) {
+    if (typeNeedsCopyInitDeinit(field->type) && !field->isRef() ) {
       FnSymbol* autoCopy = getAutoCopyForType(field->type);
       Symbol* valueToCopy = fieldValue;
       Type* copyArgType = autoCopy->getFormal(1)->type;
@@ -2784,7 +2784,7 @@ static void reconstructIRAutoDestroy(FnSymbol* fn)
   AggregateType* irt = toAggregateType(arg->type);
   for_fields(field, irt) {
     SET_LINENO(field);
-    if (isUserDefinedRecord(field->type) && !field->isRef() ) {
+    if (typeNeedsCopyInitDeinit(field->type) && !field->isRef() ) {
       if (FnSymbol* autoDestroy = autoDestroyMap.get(field->type)) {
         Symbol* tmp = newTemp(field->name, field->type);
         block->insertAtTail(new DefExpr(tmp));

--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -799,7 +799,7 @@ static Expr* preFoldPrimOp(CallExpr* call) {
     // call propagateNotPOD to set FLAG_POD/FLAG_NOT_POD
     propagateNotPOD(t);
 
-    bool needsDestroy = isUserDefinedRecord(t) && !isPOD(t);
+    bool needsDestroy = typeNeedsCopyInitDeinit(t) && !isPOD(t);
 
     if (needsDestroy) {
       retval = new SymExpr(gTrue);
@@ -2214,7 +2214,7 @@ static Expr* dropUnnecessaryCast(CallExpr* call) {
           Type* newType = toSe->symbol()->type->getValType();
 
           if (newType == oldType) {
-            if (isUserDefinedRecord(newType) && !getSymbolImmediate(var)) {
+            if (typeNeedsCopyInitDeinit(newType) && !getSymbolImmediate(var)) {
               result = new CallExpr("_removed_cast", var);
               call->replace(result);
             } else {

--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -1019,7 +1019,7 @@ void resolveIfExprType(CondStmt* stmt) {
       BlockStmt* refBranch = isReferenceType(thenType) ? stmt->thenStmt : stmt->elseStmt;
       CallExpr* call = toCallExpr(refBranch->body.tail);
       SymExpr* rhs = toSymExpr(call->get(2));
-      if (isUserDefinedRecord(rhs->getValType())) {
+      if (typeNeedsCopyInitDeinit(rhs->getValType())) {
         CallExpr* copy = new CallExpr("chpl__autoCopy", rhs->remove());
         call->insertAtTail(copy);
         resolveCallAndCallee(copy);

--- a/compiler/resolution/resolveFunction.cpp
+++ b/compiler/resolution/resolveFunction.cpp
@@ -1354,7 +1354,7 @@ bool shouldAddFormalTempAtCallSite(ArgSymbol* formal, FnSymbol* fn) {
   if (fn && fn->retTag == RET_PARAM)
     return false;
 
-  if (isRecord(formal->getValType())) {
+  if (isRecord(formal->getValType()) || isUnion(formal->getValType())) {
     if (formal->intent == INTENT_IN ||
         formal->intent == INTENT_CONST_IN ||
         formal->originalIntent == INTENT_IN ||

--- a/compiler/resolution/tuples.cpp
+++ b/compiler/resolution/tuples.cpp
@@ -958,7 +958,7 @@ static AggregateType* do_computeTupleWithIntent(bool           valueOnly,
 
       // Compute the result type of copying
       // (but don't apply this to references if !valueOnly)
-      if (copyWith && isUserDefinedRecord(useType) &&
+      if (copyWith && typeNeedsCopyInitDeinit(useType) &&
           (valueOnly || !isReferenceType(field->type))) {
         VarSymbol* var = newTemp("test_copy", useType);
         CallExpr* copy = new CallExpr(copyWith, var);

--- a/compiler/resolution/wrappers.cpp
+++ b/compiler/resolution/wrappers.cpp
@@ -1406,7 +1406,7 @@ static void addArgCoercion(FnSymbol*  fn,
     //
     checkAgain = true;
 
-    if (isUserDefinedRecord(at) && propagateNotPOD(at) &&
+    if (typeNeedsCopyInitDeinit(at) && propagateNotPOD(at) &&
         !fn->hasFlag(FLAG_AUTO_COPY_FN) &&
         !fn->hasFlag(FLAG_INIT_COPY_FN)) {
       castCall = new CallExpr("chpl__initCopy", prevActual);

--- a/test/classes/unions/const-an-in-basic.chpl
+++ b/test/classes/unions/const-an-in-basic.chpl
@@ -1,0 +1,17 @@
+union Union {
+  var s: string;
+}
+
+proc empty(u) { }
+
+proc nop(in u) { }
+
+proc main() {
+  var str = "string literal"*2;
+
+  var aUnion: Union;
+  aUnion.s = str;
+
+  empty(aUnion);
+  nop(aUnion);
+}

--- a/test/classes/unions/union-in-list.chpl
+++ b/test/classes/unions/union-in-list.chpl
@@ -1,0 +1,19 @@
+use List;
+
+union Union {
+    var s: string;
+}
+
+record Container {
+    var items: list(Union);
+}
+
+proc main() {
+    var aUnion: Union;
+      aUnion.s = "string literal";
+
+        var container = new Container();
+          container.items.append(aUnion);
+
+            writeln(container);
+}

--- a/test/classes/unions/union-in-list.good
+++ b/test/classes/unions/union-in-list.good
@@ -1,0 +1,1 @@
+(items = [(s = string literal)])

--- a/test/classes/unions/union-string.future
+++ b/test/classes/unions/union-string.future
@@ -1,2 +1,0 @@
-bug: memory error casting to string a union with an active string member
-#12405

--- a/test/classes/unions/union-string.skipif
+++ b/test/classes/unions/union-string.skipif
@@ -1,2 +1,0 @@
-# Test output is unreliable outside of valgrind
-CHPL_TEST_VGRND_EXE != on


### PR DESCRIPTION
Resolves #14117
Resolves #12405

* Rename isUserDefinedRecord to typeNeedsCopyInitDeinit, include unions
  in it
* Rename isRecordWithInitializers isRecordOrUnionWithInitializers, add
  unions to it
* Default intent for unions is const ref, like record (it was `in` before
  this change)
* Adjust AggregateType::buildCopyInitializer to build a union copy-init
  using gNoInit
* Adjust resolveInitVar to handle gNoInit
* Adjust shouldAddFormalTempAtCallSite to include unions
* Add tests from the issues

Future Work:
 * decide if we want to keep unions in their current form or do something
   totally different with them. For example, there have been proposals to
   add variant types (like ML or Rust) to Chapel. If we did that, the
   union type might actually be called `enum`.
 * If a union stores records of more than one type then assigning to a
   different field in the union should deinit the old value that was
   stored. This is probably not happening now.

Reviewed by @benharsh - thanks!

- [x] full local testing
