### PR TITLE
Add simple fix for swapping record-wrapped owned pointers

### DIFF
--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1909,11 +1909,11 @@ module ChapelBase {
 
   /* swap operator */
   inline proc <=>(ref lhs, ref rhs) {
-    // it's tempting to make this a `const` tmp, but it causes
-    // problems for cases that self-modify, like records wrapping
-    // owned class pointers.  And it's short-lived enough that making
-    // it `var` doesn't seem likely to thwart optimization
-    // opportunities.
+    // It's tempting to make `tmp` a `const`, but it causes problems
+    // for types where the RHS of an assignment is modified, such as a
+    // record with an `owned` class field.  It's a short-lived enough
+    // variable that making it `var` doesn't seem likely to thwart
+    // optimization opportunities.
     var tmp = lhs;
     lhs = rhs;
     rhs = tmp;

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1909,7 +1909,12 @@ module ChapelBase {
 
   /* swap operator */
   inline proc <=>(ref lhs, ref rhs) {
-    const tmp = lhs;
+    // it's tempting to make this a `const` tmp, but it causes
+    // problems for cases that self-modify, like records wrapping
+    // owned class pointers.  And it's short-lived enough that making
+    // it `var` doesn't seem likely to thwart optimization
+    // opportunities.
+    var tmp = lhs;
     lhs = rhs;
     rhs = tmp;
   }

--- a/test/statements/swap/swapRecordWrappingOwned.chpl
+++ b/test/statements/swap/swapRecordWrappingOwned.chpl
@@ -1,0 +1,18 @@
+class Dog {
+  var name: string;
+}
+
+record DogOwner {
+  var pet: owned Dog?;
+
+  proc init(s: string) {
+    this.pet = new owned Dog(s);
+  }
+}
+
+var p1 = new DogOwner("Rex");
+var p2 = new DogOwner("Spot");
+
+p1 <=> p2;
+
+writeln(p1, p2);

--- a/test/statements/swap/swapRecordWrappingOwned.good
+++ b/test/statements/swap/swapRecordWrappingOwned.good
@@ -1,0 +1,1 @@
+(pet = {name = Spot})(pet = {name = Rex})


### PR DESCRIPTION
This adds a variant of a test that BenA introduced in issue #14120
and implements a simple fix for it by changing the temporary used
by the default swap operator from a `const` to a `var`.

Resolves #14120.