### PR TITLE
Update versioning to 1.21 pre-release

### DIFF
--- a/compiler/main/version.cpp
+++ b/compiler/main/version.cpp
@@ -35,7 +35,7 @@ void
 get_version(char *v) {
   v += sprintf(v, "%d.%s.%s", MAJOR_VERSION, MINOR_VERSION, UPDATE_VERSION);
   if (strcmp(BUILD_VERSION, "0") != 0 || developer)
-    sprintf(v, ".%s", BUILD_VERSION);
+    sprintf(v, " pre-release (.%s)", BUILD_VERSION);
 }
 
 void

--- a/compiler/main/version.cpp
+++ b/compiler/main/version.cpp
@@ -35,7 +35,7 @@ void
 get_version(char *v) {
   v += sprintf(v, "%d.%s.%s", MAJOR_VERSION, MINOR_VERSION, UPDATE_VERSION);
   if (strcmp(BUILD_VERSION, "0") != 0 || developer)
-    sprintf(v, " pre-release (.%s)", BUILD_VERSION);
+    sprintf(v, " pre-release (%s)", BUILD_VERSION);
 }
 
 void

--- a/compiler/main/version_num.h
+++ b/compiler/main/version_num.h
@@ -21,7 +21,7 @@
 #define _version_num_H_
 
 #define MAJOR_VERSION 1
-#define MINOR_VERSION "20"
+#define MINOR_VERSION "21"
 #define UPDATE_VERSION "0"
 
 static const char* BUILD_VERSION =

--- a/doc/rst/conf.py
+++ b/doc/rst/conf.py
@@ -60,12 +60,12 @@ master_doc = 'index'
 # 'version' adds a redundant version number onto the top of the sidebar
 # automatically (rtd-theme). We also don't use |version| anywhere in rst
 
-chplversion = '1.20'                  # TODO -- parse from `chpl --version`
+chplversion = '1.21'                  # TODO -- parse from `chpl --version`
 shortversion = chplversion.replace('-', '&#8209') # prevent line-break at hyphen, if any
 html_context = {"chplversion":chplversion}
 
 # The full version, including alpha/beta/rc tags.
-release = '1.20.0'
+release = '1.21.0 (pre-release)'
 
 # General information about the project.
 project = u'Chapel Documentation'

--- a/man/confchpl.rst
+++ b/man/confchpl.rst
@@ -1,5 +1,5 @@
 
-:Version: 1.20.0
+:Version: 1.21.0 pre-release
 :Manual section: 1
 :Title: \\fBchpl\\fP
 :Subtitle: Compiler for the Chapel Programming Language

--- a/man/confchpldoc.rst
+++ b/man/confchpldoc.rst
@@ -1,5 +1,5 @@
 
-:Version: 1.20.0
+:Version: 1.21.0 pre-release
 :Manual section: 1
 :Title: \\fBchpldoc\\fP
 :Subtitle: the Chapel Documentation Tool

--- a/test/compflags/bradc/printstuff/version.goodstart
+++ b/test/compflags/bradc/printstuff/version.goodstart
@@ -1,1 +1,1 @@
- version 1.20.0
+ version 1.21.0

--- a/test/compflags/bradc/printstuff/versionhelp.sh
+++ b/test/compflags/bradc/printstuff/versionhelp.sh
@@ -5,4 +5,4 @@ compiler=$3
 echo -n `basename $compiler`
 cat $CWD/version.goodstart
 diff $CWD/../../../../compiler/main/BUILD_VERSION $CWD/zero.txt > /dev/null 2>&1 && echo "" || \
-    { echo -n "." && cat $CWD/../../../../compiler/main/BUILD_VERSION | tr -d \" ; }
+    { echo -n " pre-release (" && cat $CWD/../../../../compiler/main/BUILD_VERSION | tr -d \"\\n && echo ")" ; }


### PR DESCRIPTION
Update from 1.20 to 1.21 pre-release in places where 1.20 pre-release was updated to 1.20 (not in cases where 1.19 was updated to 1.20)

Compared against #12648 and #14078.