### PR TITLE
Prevent compiler crash with --verify

### DIFF
--- a/compiler/resolution/lowerIterators.cpp
+++ b/compiler/resolution/lowerIterators.cpp
@@ -2988,6 +2988,8 @@ void lowerIterators() {
     }
   }
 
+  USR_STOP();
+
   removeUncalledIterators();
 
   fixNumericalGetMemberPrims();


### PR DESCRIPTION
This change adds a USR_STOP in the middle of lowerIterators(),
due to verification code running in removeUncalledIterators().
Without this, the compiler hits an internal error when compiling
`test/functions/iterators/multilocale/zipMultiLocSerIter.chpl`
with --no-local, after correctly reporting the errors.

Trivial, not reviewed.