### PR TITLE
Fix the copy of start_test we put in the tarball examples directory

### DIFF
--- a/util/start_test
+++ b/util/start_test
@@ -19,7 +19,6 @@ import subprocess
 import sys
 import tempfile
 import time
-from test import py3_compat
 
 # need to be able to find the util and chplenv dir even when start_test
 # doesn't live in $CHPL_HOME/util (such as for the release tarball)
@@ -31,6 +30,7 @@ sys.path.insert(0, os.path.abspath(chplenv_dir))
 from chplenv import *
 
 from test import activate_chpl_test_venv
+from test import py3_compat
 from test import re2_supports_valgrind
 import argparse
 try:


### PR DESCRIPTION
In the release tarball we have $CHPL_HOME/util/start_test and we also
make a copy and put it in $CHPL_HOME/examples/start_test. The examples
copy was broken because we were trying to import a module from the
`test` dir, before ensuring the test dir is in our PATH. This was
introduced in https://github.com/chapel-lang/chapel/pull/12960