### PR TITLE
Enable computing 'calledBy' for a single function

### DIFF
--- a/compiler/AST/FnSymbol.cpp
+++ b/compiler/AST/FnSymbol.cpp
@@ -82,8 +82,10 @@ FnSymbol::~FnSymbol() {
   BasicBlock::clear(this);
   delete basicBlocks;
 
-  if (calledBy)
+  if (calledBy) {
     delete calledBy;
+    calledBy = NULL;
+  }
 }
 
 void FnSymbol::verify() {

--- a/compiler/AST/astutil.cpp
+++ b/compiler/AST/astutil.cpp
@@ -186,15 +186,12 @@ void reset_ast_loc(BaseAST* destNode, astlocT astlocArg) {
   AST_CHILDREN_CALL(destNode, reset_ast_loc, astlocArg);
 }
 
-void compute_fn_call_sites(FnSymbol* fn, bool allowVirtual) {
-/* If present, fn->calledBy needs to be set up in advance.
-   See the comment in compute_call_sites() */
-
+void compute_fn_call_sites(FnSymbol* fn) {
   if (fn->calledBy == NULL) {
     fn->calledBy = new Vec<CallExpr*>();
   }
 
-  INT_ASSERT(allowVirtual || virtualRootsMap.get(fn) == NULL);
+  INT_ASSERT(virtualRootsMap.get(fn) == NULL);
 
   for_SymbolSymExprs(se, fn) {
     if (CallExpr* call = toCallExpr(se->parentExpr)) {
@@ -214,41 +211,50 @@ void compute_fn_call_sites(FnSymbol* fn, bool allowVirtual) {
       } else if (call->isPrimitive(PRIM_VIRTUAL_METHOD_CALL)) {
         FnSymbol* vFn = toFnSymbol(toSymExpr(call->get(1))->symbol());
         if (vFn == fn) {
-          Vec<FnSymbol*>* children = virtualChildrenMap.get(fn);
-
-          fn->calledBy->add(call);
-          INT_ASSERT(allowVirtual);
-
-          forv_Vec(FnSymbol, child, *children) {
-            if (!child->calledBy)
-              child->calledBy = new Vec<CallExpr*>();
-
-            child->calledBy->add(call);
-          }
+          INT_FATAL(call, "unexpected case calling %d", fn->name);
         }
       }
     }
   }
 }
 
-void compute_call_sites() {
-  /* Set up and clear the calledBy vector for all functions.  This cannot
-     be done one function at a time in compute_fn_call_sites(fn) because
-     compute_fn_call_sites(fn) can add calls to the calledBy vector of
-     other functions besides its argument. In particular a virtual method
-     call is considered to be calledBy all of the virtual methods in the
-     inheritance chain.
-   */
-  forv_Vec(FnSymbol, fn, gFnSymbols) {
-    if (fn->calledBy)
-      fn->calledBy->clear();
-    else
-      fn->calledBy = new Vec<CallExpr*>();
+void compute_all_fn_call_sites(FnSymbol* fn) {
+  Vec<CallExpr*>* calledBy = fn->calledBy;
+  if (calledBy == NULL)
+    fn->calledBy = calledBy = new Vec<CallExpr*>();
+  else 
+    calledBy->clear();
+  
+  for_SymbolSymExprs(se, fn) {
+    if (CallExpr* call = toCallExpr(se->parentExpr)) {
+      if (fn == call->resolvedFunction()) {
+        calledBy->add(call);
+
+      } else if (call->isPrimitive(PRIM_FTABLE_CALL)) {
+        // sjd: do we have to do anything special here?
+        //      should this call be added to some function's calledBy list?
+
+      } else if (call->isPrimitive(PRIM_VIRTUAL_METHOD_CALL)) {
+        FnSymbol* vFn = toFnSymbol(toSymExpr(call->get(1))->symbol());
+        if (vFn == fn)
+          calledBy->add(call);
+      }
+    }
   }
 
-  forv_Vec(FnSymbol, fn, gFnSymbols) {
-    compute_fn_call_sites(fn);
-  }
+  // Add all virtual calls on parents.
+  if (Vec<FnSymbol*>* parents = virtualParentsMap.get(fn))
+    forv_Vec(FnSymbol, pfn, *parents)
+      for_SymbolSymExprs(pse, pfn)
+        if (CallExpr* pcall = toCallExpr(pse->parentExpr))
+          if (pcall->isPrimitive(PRIM_VIRTUAL_METHOD_CALL) &&
+              pfn == toFnSymbol(toSymExpr(pcall->get(1))->symbol()))
+            calledBy->add(pcall);
+}
+
+void compute_call_sites() {
+  for_alive_in_Vec(FnSymbol, fn, gFnSymbols)
+    compute_all_fn_call_sites(fn);
 }
 
 // builds the def and use maps for every variable/argument

--- a/compiler/include/astutil.h
+++ b/compiler/include/astutil.h
@@ -65,7 +65,8 @@ void reset_ast_loc(BaseAST* destNode, astlocT astloc);
 void reset_ast_loc(BaseAST* destNode, BaseAST* sourceNode);
 
 // compute call sites FnSymbol::calls
-void compute_fn_call_sites(FnSymbol* fn, bool allowVirtual = true);
+void compute_fn_call_sites(FnSymbol* fn);
+void compute_all_fn_call_sites(FnSymbol* fn);
 void compute_call_sites();
 
 //

--- a/compiler/include/astutil.h
+++ b/compiler/include/astutil.h
@@ -64,10 +64,9 @@ void collectSymbols(BaseAST* ast, std::vector<Symbol*>& symbols);
 void reset_ast_loc(BaseAST* destNode, astlocT astloc);
 void reset_ast_loc(BaseAST* destNode, BaseAST* sourceNode);
 
-// compute call sites FnSymbol::calls
-void compute_fn_call_sites(FnSymbol* fn);
-void compute_all_fn_call_sites(FnSymbol* fn);
 void compute_call_sites();
+void computeNonvirtualCallSites(FnSymbol* fn);
+void computeAllCallSites(FnSymbol* fn);
 
 //
 // collect set of symbols and vector of SymExpr; can be used to

--- a/compiler/include/passes.h
+++ b/compiler/include/passes.h
@@ -102,10 +102,7 @@ void deadBlockElimination();
 
 // flattenFunctions.cpp
 void flattenNestedFunction(FnSymbol* nestedFunction);
-// When fastCCS=true, call sites are computed only for the functions that
-// are looked at. Such functions must not have dispatch parents/children.
-void flattenNestedFunctions(Vec<FnSymbol*>& nestedFunctions,
-                            bool fastCCS = false);
+void flattenNestedFunctions(Vec<FnSymbol*>& nestedFunctions);
 
 // foralls.cpp
 void checkTypeParamTaskIntent(SymExpr* outerSE);

--- a/compiler/include/virtualDispatch.h
+++ b/compiler/include/virtualDispatch.h
@@ -29,6 +29,9 @@ class Type;
 // Map a method to the set of methods being overridden
 extern Map<FnSymbol*, Vec<FnSymbol*>*> virtualRootsMap;
 
+// Map a method to the set of methods that it may override
+extern Map<FnSymbol*, Vec<FnSymbol*>*> virtualParentsMap;
+
 // Map a method to the set of methods that might be invoked
 extern Map<FnSymbol*, Vec<FnSymbol*>*> virtualChildrenMap;
 

--- a/compiler/passes/flattenFunctions.cpp
+++ b/compiler/passes/flattenFunctions.cpp
@@ -413,7 +413,7 @@ void flattenNestedFunctions(Vec<FnSymbol*>& nestedFunctions) {
 
     forv_Vec(FnSymbol, fn, nestedFunctions) {
       if (!fVerify) deleteCalledby(fn);
-      compute_all_fn_call_sites(fn);
+      computeAllCallSites(fn);
 
       std::vector<BaseAST*> asts;
       collect_top_asts(fn, asts);

--- a/compiler/passes/flattenFunctions.cpp
+++ b/compiler/passes/flattenFunctions.cpp
@@ -48,7 +48,7 @@ void flattenNestedFunction(FnSymbol* nestedFunction) {
 
     nestedFunctions.add(nestedFunction);
 
-    flattenNestedFunctions(nestedFunctions, true);
+    flattenNestedFunctions(nestedFunctions);
   }
 }
 
@@ -383,11 +383,8 @@ static void deleteAllCalledby() {
   for_alive_in_Vec(FnSymbol, fn, gFnSymbols)  deleteCalledby(fn);
 }
 
-void flattenNestedFunctions(Vec<FnSymbol*>& nestedFunctions, bool fastCCS) {
-  if (fastCCS)
-    { if (fVerify) deleteAllCalledby(); }
-  else
-    compute_call_sites();
+void flattenNestedFunctions(Vec<FnSymbol*>& nestedFunctions) {
+  if (fVerify) deleteAllCalledby();
 
   Vec<FnSymbol*> outerFunctionSet;
   Vec<FnSymbol*> nestedFunctionSet;
@@ -415,10 +412,8 @@ void flattenNestedFunctions(Vec<FnSymbol*>& nestedFunctions, bool fastCCS) {
     change = false;
 
     forv_Vec(FnSymbol, fn, nestedFunctions) {
-      if (fastCCS) {
-        if (!fVerify) deleteCalledby(fn);
-        compute_fn_call_sites(fn, false);
-      }
+      if (!fVerify) deleteCalledby(fn);
+      compute_all_fn_call_sites(fn);
 
       std::vector<BaseAST*> asts;
       collect_top_asts(fn, asts);

--- a/compiler/resolution/cleanups.cpp
+++ b/compiler/resolution/cleanups.cpp
@@ -227,16 +227,10 @@ static void removeRandomPrimitives() {
 static void replaceTypeArgsWithFormalTypeTemps() {
   compute_call_sites();
 
-  forv_Vec(FnSymbol, fn, gFnSymbols) {
+  for_alive_in_Vec(FnSymbol, fn, gFnSymbols) {
     if (! fn->isResolved())
       // Don't bother with unresolved functions.
       // They will be removed from the tree.
-      continue;
-
-    // Skip this function if it is not in the tree.
-    if (! fn->defPoint)
-      continue;
-    if (! fn->defPoint->parentSymbol)
       continue;
 
     // We do not remove type args from extern functions so that e.g.:
@@ -314,7 +308,7 @@ static void replaceTypeArgsWithFormalTypeTemps() {
 static void removeParamArgs() {
   compute_call_sites();
 
-  forv_Vec(FnSymbol, fn, gFnSymbols)
+  for_alive_in_Vec(FnSymbol, fn, gFnSymbols)
   {
     if (! fn->isResolved())
       // Don't bother with unresolved functions.
@@ -802,8 +796,7 @@ static void cleanupVoidVarsAndFields() {
 
   // Remove void formal arguments from functions.
   // Change functions that return ref(void) to just return void.
-  forv_Vec(FnSymbol, fn, gFnSymbols) {
-    if (fn->defPoint->inTree()) {
+  for_alive_in_Vec(FnSymbol, fn, gFnSymbols) {
       for_formals(formal, fn) {
         if (isVoidOrVoidTupleType(formal->type)) {
           if (formal == fn->_this) {
@@ -816,12 +809,11 @@ static void cleanupVoidVarsAndFields() {
           isVoidOrVoidTupleType(fn->retType)) {
         fn->retType = dtNothing;
       }
-    }
-    if (fn->_this) {
-      if (isVoidOrVoidTupleType(fn->_this->type)) {
-        fn->_this = NULL;
+      if (fn->_this) {
+        if (isVoidOrVoidTupleType(fn->_this->type)) {
+          fn->_this = NULL;
+        }
       }
-    }
   }
 
   // Set for loop index variables that are void to the global void value

--- a/compiler/resolution/virtualDispatch.cpp
+++ b/compiler/resolution/virtualDispatch.cpp
@@ -252,7 +252,7 @@ static void collectMethods(FnSymbol*               pfn,
         // if pfn is a filled in vararg function then cfn needs its
         // vararg stamped out here too.
         if (pfn->hasFlag(FLAG_EXPANDED_VARARGS)) {
-          compute_fn_call_sites(pfn);
+          computeNonvirtualCallSites(pfn);
           forv_Vec(CallExpr, call, *pfn->calledBy) {
             CallInfo info;
             if (info.isWellFormed(call)) {
@@ -619,10 +619,8 @@ static bool isVirtualChild(FnSymbol* child, FnSymbol* parent) {
 }
 
 static void clearOneMap(Map<FnSymbol*, Vec<FnSymbol*>*>& map) {
-  Vec<Vec<FnSymbol*>*> values;
-  map.get_values(values);
-  forv_Vec(Vec<FnSymbol*>, value, values)
-    delete value;
+  form_Map(VirtualMapElem, el, map)
+    delete el->value;
   map.clear();
 }
 

--- a/compiler/resolution/virtualDispatch.cpp
+++ b/compiler/resolution/virtualDispatch.cpp
@@ -41,8 +41,6 @@ static child type could end up calling something in the parent.
 -----------
 */
 
-
-
 #include "virtualDispatch.h"
 
 #include "astutil.h"
@@ -63,12 +61,12 @@ static child type could end up calling something in the parent.
 
 bool                            inDynamicDispatchResolution = false;
 
+typedef MapElem<FnSymbol*, Vec<FnSymbol*>*> VirtualMapElem;
 Map<FnSymbol*, Vec<FnSymbol*>*> virtualRootsMap;
-
+Map<FnSymbol*, Vec<FnSymbol*>*> virtualParentsMap;
 Map<FnSymbol*, Vec<FnSymbol*>*> virtualChildrenMap;
 
 Map<Type*,     Vec<FnSymbol*>*> virtualMethodTable;
-
 Map<FnSymbol*, int>             virtualMethodMap;
 
 static bool buildVirtualMaps();
@@ -138,9 +136,8 @@ static void resolveOverride(FnSymbol* pfn, FnSymbol* cfn);
 static void overrideIterator(FnSymbol* pfn, FnSymbol* cfn);
 
 static void virtualDispatchUpdate(FnSymbol* pfn, FnSymbol* cfn);
-
 static void virtualDispatchUpdateChildren(FnSymbol* pfn, FnSymbol* cfn);
-
+static void virtualDispatchUpdateParents(FnSymbol* pfn, FnSymbol* cfn);
 static void virtualDispatchUpdateRoots(FnSymbol* pfn, FnSymbol* cfn);
 
 static bool isVirtualChild(FnSymbol* child, FnSymbol* parent);
@@ -550,6 +547,7 @@ static void virtualDispatchUpdate(FnSymbol* pfn, FnSymbol* cfn) {
 
   // There is the potential for a data dependency between these
   virtualDispatchUpdateChildren(pfn, cfn);
+  virtualDispatchUpdateParents(pfn, cfn);
   virtualDispatchUpdateRoots(pfn, cfn);
 }
 
@@ -558,11 +556,21 @@ static void virtualDispatchUpdateChildren(FnSymbol* pfn, FnSymbol* cfn) {
 
   if (fns == NULL) {
     fns = new Vec<FnSymbol*>();
+    virtualChildrenMap.put(pfn, fns);
   }
 
   fns->add(cfn);
+}
 
-  virtualChildrenMap.put(pfn, fns);
+static void virtualDispatchUpdateParents(FnSymbol* pfn, FnSymbol* cfn) {
+  Vec<FnSymbol*>* fns = virtualParentsMap.get(cfn);
+
+  if (fns == NULL) {
+    fns = new Vec<FnSymbol*>();
+    virtualParentsMap.put(cfn, fns);
+  }
+
+  fns->add(pfn);
 }
 
 static void virtualDispatchUpdateRoots(FnSymbol* pfn, FnSymbol* cfn) {
@@ -570,6 +578,7 @@ static void virtualDispatchUpdateRoots(FnSymbol* pfn, FnSymbol* cfn) {
 
   if (fns == NULL) {
     fns = new Vec<FnSymbol*>();
+    virtualRootsMap.put(cfn, fns);
 
     fns->add(pfn);
 
@@ -591,8 +600,6 @@ static void virtualDispatchUpdateRoots(FnSymbol* pfn, FnSymbol* cfn) {
       fns->add(pfn);
     }
   }
-
-  virtualRootsMap.put(cfn, fns);
 }
 
 // return true if child overrides parent in dispatch table
@@ -611,23 +618,18 @@ static bool isVirtualChild(FnSymbol* child, FnSymbol* parent) {
   return retval;
 }
 
+static void clearOneMap(Map<FnSymbol*, Vec<FnSymbol*>*>& map) {
+  Vec<Vec<FnSymbol*>*> values;
+  map.get_values(values);
+  forv_Vec(Vec<FnSymbol*>, value, values)
+    delete value;
+  map.clear();
+}
+
 static void clearRootsAndChildren() {
-  Vec<Vec<FnSymbol*>*> rootValues;
-  Vec<Vec<FnSymbol*>*> childValues;
-
-  virtualRootsMap.get_values(rootValues);
-  virtualChildrenMap.get_values(childValues);
-
-  forv_Vec(Vec<FnSymbol*>, value, rootValues)  {
-    delete value;
-  }
-
-  forv_Vec(Vec<FnSymbol*>, value, childValues) {
-    delete value;
-  }
-
-  virtualRootsMap.clear();
-  virtualChildrenMap.clear();
+  clearOneMap(virtualRootsMap);
+  clearOneMap(virtualParentsMap);
+  clearOneMap(virtualChildrenMap);
 }
 
 /************************************* | **************************************
@@ -811,11 +813,43 @@ static void printDispatchInfo() {
 *                                                                             *
 ************************************** | *************************************/
 
+// Remove from 'toTrim' the FnSymbols not in 'fns_in_vmt'.
+static void trimVirtualMap(std::set<FnSymbol*>& fns_in_vmt,
+                           Map<FnSymbol*, Vec<FnSymbol*>*>& toTrim)
+{
+  form_Map(VirtualMapElem, el, toTrim) {
+    if (! fns_in_vmt.count(el->key)) {
+      // We should not even be looking here.
+      delete el->value;
+      el->value = NULL;
+      // Since Map does not remove entries well, keep 'el' there.
+      continue;
+    }
+
+    Vec<FnSymbol*>* oldV = el->value;
+    forv_Vec(FnSymbol, fn1, *oldV) {
+      if (fns_in_vmt.count(fn1)) {
+        // If all entries are in VMT, 'oldV' does not need adjustment.
+      } else {
+        // There is at least one entry in el->value that needs to be removed.
+        // Build a new Vec. Redo the scan from the beginning.
+        Vec<FnSymbol*>* newV = new Vec<FnSymbol*>();
+        forv_Vec(FnSymbol, fn2, *oldV) {
+          if (fns_in_vmt.count(fn2))
+            newV->add(fn2);
+        }
+        delete oldV;
+        el->value = newV;
+        break;
+      }
+    }
+  }
+}
+
 // removes entries in virtualChildrenMap that are not in virtualMethodTable.
 // such entries could not be called and should be dead-code eliminated.
 static void filterVirtualChildren() {
   typedef MapElem<Type*,     Vec<FnSymbol*>*> VmtMapElem;
-  typedef MapElem<FnSymbol*, Vec<FnSymbol*>*> ChildMapElem;
 
   std::set<FnSymbol*> fns_in_vmt;
 
@@ -827,20 +861,14 @@ static void filterVirtualChildren() {
     }
   }
 
-  form_Map(ChildMapElem, el, virtualChildrenMap) {
-    if (el->value) {
-      Vec<FnSymbol*>* oldV = el->value;
-      Vec<FnSymbol*>* newV = new Vec<FnSymbol*>();
+  trimVirtualMap(fns_in_vmt, virtualChildrenMap);
+  trimVirtualMap(fns_in_vmt, virtualParentsMap);
 
-      forv_Vec(FnSymbol, fn, *oldV) {
-        if (fns_in_vmt.count(fn)) {
-          newV->add(fn);
-        }
-      }
-
-      el->value = newV;
-
-      delete oldV;
+  // Assume all "roots" are to stay, so just trim not-to-be-used Vecs.
+  form_Map(VirtualMapElem, el, virtualRootsMap) {
+    if (! fns_in_vmt.count(el->key)) {
+      delete el->value;
+      el->value = NULL;
     }
   }
 }


### PR DESCRIPTION
This expands the work started in #13522, where `calledBy` was computed
for a single function without running `compute_call_sites()` over the entire
program. There, single-function computation of `calledBy` was done in the
limited case of flattening a task function during lowerForalls().

This change enables single-function computation of `calledBy` in the general case.
For that, it adds tracking of virtual parents in `virtualParentsMap`. Cf. previously
it was tracking virtual roots, i.e. top-most virtual parents, and virtual children.

`computeAllCallSites(fn)` is the function to compute `fn->calledBy`.

Cf. `computeNonvirtualCallSites()`, formerly `compute_fn_call_sites()`,
which was the starting point for `computeAllCallSites()`.
computeNonvirtualCallSites() is now tuned to its sole use during
resolveDynamicDispatches(). We could potentially combine the two into one
in the future.

Given this new functionality, `compute_call_sites()` simply invokes
`computeAllCallSites()` on each FnSymbol. This is primarily
to ensure that the latter works correctly. If we suspect negative impact
of this change on compilation time, we can revert.

Other changes:

* Prune entries more aggressively during filterVirtualChildren().
  Otherwise they may retain deleted FnSymbols. Which I observed when compiling
  `test/classes/initializers/postInit/where.chpl`

* Now that we have three `virtual*Map` maps, refactor filterVirtualChildren()
  and clearRootsAndChildren().

* No longer need to set up all fn->calledBy vectors at start of compute_call_sites().

* Other minor code reorg.