### PR TITLE
Remove a spurious endif if testReleaseHelp

### DIFF
--- a/util/buildRelease/testReleaseHelp
+++ b/util/buildRelease/testReleaseHelp
@@ -125,7 +125,6 @@ endif
 
 ./start_test ${start_test_flags} -logfile Logs/testReleaseHelp.log
 
-endif
 set tmpstatus = $status
 if ($tmpstatus != 0) then
     echo "ERROR: testing of examples failed"


### PR DESCRIPTION
This prevented start_test errors from being seen in nightly testing
(which has been silently failing for a while.) Originally introduced in
7e856d84164