### PR TITLE
Update performance tracking with 1.20.0 release dates.

### DIFF
--- a/util/pastPerformance/testReleasesPerformance
+++ b/util/pastPerformance/testReleasesPerformance
@@ -134,6 +134,10 @@ export CHPL_TEST_PERF_DATE="03/12/19"
 export CHPL_HOME=$chpl_release_home/chapel-1.19.0
 testReleasePerformance
 
+export CHPL_TEST_PERF_DATE="09/11/19"
+export CHPL_HOME=$chpl_release_home/chapel-1.20.0
+testReleasePerformance
+
 #
 # ADD NEW RELEASES HERE AS THEY ARE CREATED.
 #

--- a/util/test/perf/perfgraph.js
+++ b/util/test/perf/perfgraph.js
@@ -98,6 +98,10 @@ var branchInfo = [
                   { "release" : "1.19",
                     "releaseDate": "2019-03-21",
                     "branchDate" : "2019-03-12",
+                    "revision" : -1},
+                  { "release" : "1.20",
+                    "releaseDate": "2019-09-19",
+                    "branchDate" : "2019-09-11",
                     "revision" : -1}
                   ];
 


### PR DESCRIPTION
Add date of release branch cut into testReleasesPerformance and the release date and branch date into perfgraph.js after the 1.19.0 release has been cut.