### PR TITLE
Code changes submitted to CLBG site for 1.20 release

### DIFF
--- a/test/studies/shootout/submitted/binarytrees2.chpl
+++ b/test/studies/shootout/submitted/binarytrees2.chpl
@@ -38,7 +38,7 @@ proc main() {
   forall depth in dynamic(depths) {
     const iterations = 2**(maxDepth - depth + minDepth);
     var sum = 0;
-			
+
     for i in 1..iterations {
       const t = new Tree(depth);
       sum += t.sum();
@@ -64,7 +64,7 @@ proc main() {
 // A simple balanced tree node class
 //
 class Tree {
-  var left, right: unmanaged Tree;
+  var left, right: unmanaged Tree?;
 
   //
   // A Tree-building initializer
@@ -82,7 +82,7 @@ class Tree {
   proc sum(): int {
     var sum = 1;
     if left {
-      sum += left.sum() + right.sum();
+      sum += left!.sum() + right!.sum();
       delete left, right;
     }
     return sum;

--- a/test/studies/shootout/submitted/fasta3.chpl
+++ b/test/studies/shootout/submitted/fasta3.chpl
@@ -13,11 +13,11 @@ config const n = 1000,   // controls the length of the generated strings
 // Nucleotide definitions
 //
 enum nucleotide {
-  A = ascii("A"), C = ascii("C"), G = ascii("G"), T = ascii("T"),
-  a = ascii("a"), c = ascii("c"), g = ascii("g"), t = ascii("t"),
-  B = ascii("B"), D = ascii("D"), H = ascii("H"), K = ascii("K"),
-  M = ascii("M"), N = ascii("N"), R = ascii("R"), S = ascii("S"),
-  V = ascii("V"), W = ascii("W"), Y = ascii("Y")
+  A = "A".toByte(), C = "C".toByte(), G = "G".toByte(), T = "T".toByte(),
+  a = "a".toByte(), c = "c".toByte(), g = "g".toByte(), t = "t".toByte(),
+  B = "B".toByte(), D = "D".toByte(), H = "H".toByte(), K = "K".toByte(),
+  M = "M".toByte(), N = "N".toByte(), R = "R".toByte(), S = "S".toByte(),
+  V = "V".toByte(), W = "W".toByte(), Y = "Y".toByte()
 }
 use nucleotide;
 
@@ -85,7 +85,7 @@ proc sumProbs(alphabet: []) {
 // Redefine stdout to use lock-free binary I/O and capture a newline
 //
 const stdout = openfd(1).writer(kind=iokind.native, locking=false);
-param newline = ascii("\n");
+param newline = "\n".toByte();
 
 //
 // Repeat sequence "alu" for n characters
@@ -94,7 +94,7 @@ proc repeatMake(desc, alu, n) {
   stdout.writef("%s", desc);
 
   const r = alu.size,
-        s = [i in {0..r+lineLength}] alu[i % r]: int(8);
+        s = [i in 0..r+lineLength] alu[i % r]: int(8);
 
   for i in 0..n by lineLength {
     const lo = i % r,
@@ -116,8 +116,8 @@ proc randomMake(desc, a, n) {
   //
   // Add a line of random sequence
   //
-  proc addLine(bytes) {
-    for (r, i) in zip(getRands(bytes), 0..) {
+  proc addLine(numBytes) {
+    for (r, i) in zip(getRands(numBytes), 0..) {
       if r < a[1](prob) {
         line_buff[i] = a[1](nucl): int(8);
       } else {
@@ -133,9 +133,9 @@ proc randomMake(desc, a, n) {
         line_buff[i] = a[hi](nucl): int(8);
       }
     }
-    line_buff[bytes] = newline;
+    line_buff[numBytes] = newline;
 
-    stdout.write(line_buff[0..bytes]);
+    stdout.write(line_buff[0..numBytes]);
   }
 }
 

--- a/test/studies/shootout/submitted/fasta3.future
+++ b/test/studies/shootout/submitted/fasta3.future
@@ -1,1 +1,0 @@
-The benchmark uses a variable named `bytes`

--- a/test/studies/shootout/submitted/fasta3.good
+++ b/test/studies/shootout/submitted/fasta3.good
@@ -1,23 +1,3 @@
-fasta3.chpl:88: warning: ascii is deprecated - please use string.toByte or string.byte
-fasta3.chpl:16: warning: ascii is deprecated - please use string.toByte or string.byte
-fasta3.chpl:16: warning: ascii is deprecated - please use string.toByte or string.byte
-fasta3.chpl:16: warning: ascii is deprecated - please use string.toByte or string.byte
-fasta3.chpl:16: warning: ascii is deprecated - please use string.toByte or string.byte
-fasta3.chpl:17: warning: ascii is deprecated - please use string.toByte or string.byte
-fasta3.chpl:17: warning: ascii is deprecated - please use string.toByte or string.byte
-fasta3.chpl:17: warning: ascii is deprecated - please use string.toByte or string.byte
-fasta3.chpl:17: warning: ascii is deprecated - please use string.toByte or string.byte
-fasta3.chpl:18: warning: ascii is deprecated - please use string.toByte or string.byte
-fasta3.chpl:18: warning: ascii is deprecated - please use string.toByte or string.byte
-fasta3.chpl:18: warning: ascii is deprecated - please use string.toByte or string.byte
-fasta3.chpl:18: warning: ascii is deprecated - please use string.toByte or string.byte
-fasta3.chpl:19: warning: ascii is deprecated - please use string.toByte or string.byte
-fasta3.chpl:19: warning: ascii is deprecated - please use string.toByte or string.byte
-fasta3.chpl:19: warning: ascii is deprecated - please use string.toByte or string.byte
-fasta3.chpl:19: warning: ascii is deprecated - please use string.toByte or string.byte
-fasta3.chpl:20: warning: ascii is deprecated - please use string.toByte or string.byte
-fasta3.chpl:20: warning: ascii is deprecated - please use string.toByte or string.byte
-fasta3.chpl:20: warning: ascii is deprecated - please use string.toByte or string.byte
 >ONE Homo sapiens alu
 GGCCGGGCGCGGTGGCTCACGCCTGTAATCCCAGCACTTTGGGAGGCCGAGGCGGGCGGA
 TCACCTGAGGTCAGGAGTTCGAGACCAGCCTGGCCAACATGGTGAAACCCCGTCTCTACT

--- a/test/studies/shootout/submitted/fasta4.chpl
+++ b/test/studies/shootout/submitted/fasta4.chpl
@@ -23,11 +23,11 @@ config param IM = 139968,         // parameters for random number generation
 // Nucleotide definitions
 //
 enum nucleotide {
-  A = ascii("A"), C = ascii("C"), G = ascii("G"), T = ascii("T"),
-  a = ascii("a"), c = ascii("c"), g = ascii("g"), t = ascii("t"),
-  B = ascii("B"), D = ascii("D"), H = ascii("H"), K = ascii("K"),
-  M = ascii("M"), N = ascii("N"), R = ascii("R"), S = ascii("S"),
-  V = ascii("V"), W = ascii("W"), Y = ascii("Y")
+  A = "A".toByte(), C = "C".toByte(), G = "G".toByte(), T = "T".toByte(),
+  a = "a".toByte(), c = "c".toByte(), g = "g".toByte(), t = "t".toByte(),
+  B = "B".toByte(), D = "D".toByte(), H = "H".toByte(), K = "K".toByte(),
+  M = "M".toByte(), N = "N".toByte(), R = "R".toByte(), S = "S".toByte(),
+  V = "V".toByte(), W = "W".toByte(), Y = "Y".toByte()
 }
 use nucleotide;
 
@@ -81,7 +81,7 @@ proc main() {
 // Redefine stdout to use lock-free binary I/O and capture a newline
 //
 const stdout = openfd(1).writer(kind=iokind.native, locking=false);
-param newline = ascii("\n");
+param newline = "\n".toByte();
 
 //
 // Repeat 'alu' to generate a sequence of length 'n'
@@ -90,7 +90,7 @@ proc repeatMake(desc, alu, n) {
   stdout.writeln(desc);
 
   const r = alu.size,
-        s = [i in {0..(r+lineLength)}] alu[i % r]: int(8);
+        s = [i in 0..(r+lineLength)] alu[i % r]: int(8);
 
   for i in 0..n by lineLength {
     const lo = i % r,
@@ -128,18 +128,18 @@ proc randomMake(desc, nuclInfo, n) {
 
     // iterate over 0..n-1 in a round-robin fashion across tasks
     for i in tid*chunkSize..n-1 by numTasks*chunkSize {
-      const bytes = min(chunkSize, n-i);
+      const numBytes = min(chunkSize, n-i);
 
-      // Get 'bytes' random numbers in a coordinated manner
+      // Get 'numBytes' random numbers in a coordinated manner
       randGo[tid].waitFor(i);
-      getRands(bytes, myRands);
+      getRands(numBytes, myRands);
       randGo[nextTid].write(i+chunkSize);
 
-      // Compute 'bytes' nucleotides and store in 'myBuff'
+      // Compute 'numBytes' nucleotides and store in 'myBuff'
       var col = 0,
           off = 0;
 
-      for j in 0..#bytes {
+      for j in 0..#numBytes {
         const r = myRands[j];
         var nid = 1;
         for k in 1..numNucls do

--- a/test/studies/shootout/submitted/fasta4.future
+++ b/test/studies/shootout/submitted/fasta4.future
@@ -1,1 +1,0 @@
-The benchmark uses a variable named `bytes`

--- a/test/studies/shootout/submitted/fasta4.good
+++ b/test/studies/shootout/submitted/fasta4.good
@@ -1,23 +1,3 @@
-fasta4.chpl:84: warning: ascii is deprecated - please use string.toByte or string.byte
-fasta4.chpl:26: warning: ascii is deprecated - please use string.toByte or string.byte
-fasta4.chpl:26: warning: ascii is deprecated - please use string.toByte or string.byte
-fasta4.chpl:26: warning: ascii is deprecated - please use string.toByte or string.byte
-fasta4.chpl:26: warning: ascii is deprecated - please use string.toByte or string.byte
-fasta4.chpl:27: warning: ascii is deprecated - please use string.toByte or string.byte
-fasta4.chpl:27: warning: ascii is deprecated - please use string.toByte or string.byte
-fasta4.chpl:27: warning: ascii is deprecated - please use string.toByte or string.byte
-fasta4.chpl:27: warning: ascii is deprecated - please use string.toByte or string.byte
-fasta4.chpl:28: warning: ascii is deprecated - please use string.toByte or string.byte
-fasta4.chpl:28: warning: ascii is deprecated - please use string.toByte or string.byte
-fasta4.chpl:28: warning: ascii is deprecated - please use string.toByte or string.byte
-fasta4.chpl:28: warning: ascii is deprecated - please use string.toByte or string.byte
-fasta4.chpl:29: warning: ascii is deprecated - please use string.toByte or string.byte
-fasta4.chpl:29: warning: ascii is deprecated - please use string.toByte or string.byte
-fasta4.chpl:29: warning: ascii is deprecated - please use string.toByte or string.byte
-fasta4.chpl:29: warning: ascii is deprecated - please use string.toByte or string.byte
-fasta4.chpl:30: warning: ascii is deprecated - please use string.toByte or string.byte
-fasta4.chpl:30: warning: ascii is deprecated - please use string.toByte or string.byte
-fasta4.chpl:30: warning: ascii is deprecated - please use string.toByte or string.byte
 >ONE Homo sapiens alu
 GGCCGGGCGCGGTGGCTCACGCCTGTAATCCCAGCACTTTGGGAGGCCGAGGCGGGCGGA
 TCACCTGAGGTCAGGAGTTCGAGACCAGCCTGGCCAACATGGTGAAACCCCGTCTCTACT

--- a/test/studies/shootout/submitted/knucleotide2.chpl
+++ b/test/studies/shootout/submitted/knucleotide2.chpl
@@ -5,7 +5,7 @@
    derived from the GNU C++ version by Branimir Maksimovic
 */
 
-use Sort;
+use Sort, Map;
 
 config param tableSize = 2**16,
              columns = 61;
@@ -32,13 +32,13 @@ proc main(args: [] string) {
 
   while stdinNoLock.readline(data, lineSize, idx) do
     idx += lineSize - 1;
-  
+
   // Resize our array to the amount actually read
   dataDom = {1..idx};
 
   // Make everything uppercase
   forall d in data do
-    d -= (ascii("a") - ascii("A"));
+    d -= ("a".toByte() - "A".toByte());
 
   writeFreqs(data, 1);
   writeFreqs(data, 2);
@@ -54,39 +54,37 @@ proc writeFreqs(data, param nclSize) {
   const freqs = calculate(data, nclSize);
 
   // create an array of (frequency, sequence) tuples
-  var arr = for (s,f) in zip(freqs.domain, freqs) do (f,s);
+  var arr = for (s,f) in freqs.items() do (f,s);
 
   // print the array, sorted by decreasing frequency
   for (f, s) in arr.sorted(reverseComparator) do
-   writef("%s %.3dr\n", decode(s, nclSize), 
+   writef("%s %.3dr\n", decode(s, nclSize),
            (100.0 * f) / (data.size - nclSize));
   writeln();
 }
 
 
 proc writeCount(data, param str) {
-  const freqs = calculate(data, str.length),
-        d = hash(str.toBytes(), 1, str.length);
+  const freqs = calculate(data, str.numBytes),
+        d = hash(str.toBytes(), 1, str.numBytes);
 
-  writeln(freqs[d], "\t", decode(d, str.length));
+  writeln(freqs[d], "\t", decode(d, str.numBytes));
 }
 
 
 proc calculate(data, param nclSize) {
-  var freqDom: domain(int),
-      freqs: [freqDom] int;
+  var freqs = new map(int, int);
 
   var lock$: sync bool = true;
   const numTasks = here.maxTaskPar;
   coforall tid in 1..numTasks {
-    var myDom: domain(int),
-        myArr: [myDom] int;
+    var myFreqs = new map(int, int);
 
     for i in tid..(data.size-nclSize) by numTasks do
-      myArr[hash(data, i, nclSize)] += 1;
+      myFreqs[hash(data, i, nclSize)] += 1;
 
     lock$;        // acquire lock
-    for (k,v) in zip(myDom, myArr) do
+    for (k,v) in myFreqs.items() do
       freqs[k] += v;
     lock$ = true; // release lock
   }
@@ -99,7 +97,7 @@ const toChar: [0..3] string = ["A", "C", "T", "G"];
 var toNum: [0..127] int;
 
 forall i in toChar.domain do
-  toNum[ascii(toChar[i])] = i;
+  toNum[toChar[i].toByte()] = i;
 
 
 inline proc decode(in data, param nclSize) {
@@ -127,16 +125,16 @@ inline proc hash(str, beg, param size) {
 
 
 proc string.toBytes() {
-  var bytes: [1..this.length] uint(8);
-  for (b, i) in zip(bytes, 1..) do
-    b = ascii(this[i]);
-  return bytes;
+  var byteArr: [1..this.numBytes] uint(8);
+  for (b, i) in zip(byteArr, 1..) do
+    b = this.byte(i);
+  return byteArr;
 }
 
 
 inline proc startsWithThree(data) {
-  return data[1] == ascii(">") && 
-         data[2] == ascii("T") && 
-         data[3] == ascii("H");
+  return data[1] == ">".toByte() &&
+         data[2] == "T".toByte() &&
+         data[3] == "H".toByte();
 }
 

--- a/test/studies/shootout/submitted/knucleotide2.future
+++ b/test/studies/shootout/submitted/knucleotide2.future
@@ -1,1 +1,0 @@
-The benchmark uses a variable named `bytes`

--- a/test/studies/shootout/submitted/knucleotide2.good
+++ b/test/studies/shootout/submitted/knucleotide2.good
@@ -1,12 +1,3 @@
-knucleotide2.chpl:102: warning: ascii is deprecated - please use string.toByte or string.byte
-knucleotide2.chpl:138: warning: ascii is deprecated - please use string.toByte or string.byte
-knucleotide2.chpl:139: warning: ascii is deprecated - please use string.toByte or string.byte
-knucleotide2.chpl:140: warning: ascii is deprecated - please use string.toByte or string.byte
-knucleotide2.chpl:14: In function 'main':
-knucleotide2.chpl:41: warning: ascii is deprecated - please use string.toByte or string.byte
-knucleotide2.chpl:41: warning: ascii is deprecated - please use string.toByte or string.byte
-knucleotide2.chpl:129: In function 'toBytes':
-knucleotide2.chpl:132: warning: ascii is deprecated - please use string.toByte or string.byte
 A 30.279
 T 30.113
 G 19.835


### PR DESCRIPTION
This PR updates the submitted shootout benchmarks directory to match the versions that we submitted after the 1.20 release to reflect breaking changes (e.g., `bytes` now being a reserved word, strings now being UTF-8 rather than ASCII, nilability features).  These were submitted in:

* https://salsa.debian.org/benchmarksgame-team/benchmarksgame/issues/195
* https://salsa.debian.org/benchmarksgame-team/benchmarksgame/issues/196
* https://salsa.debian.org/benchmarksgame-team/benchmarksgame/issues/197

which also characterize the changes in more detail.