### PR TITLE
Fix a hang in the moved-on test

### DIFF
--- a/test/parallel/taskCount/runningTaskCount/moved-on.chpl
+++ b/test/parallel/taskCount/runningTaskCount/moved-on.chpl
@@ -1,27 +1,32 @@
 use Barriers;
 
+// Semi-hacky locale private var so that we don't have to wait on something
+// that lives on locale 0 since that would create an additional task. Note that
+// we need to modify/read through functions to avoid task-intents
+
+pragma "locale private"
+var doneSpinning: chpl__processorAtomicType(bool);
+proc setDoneSpinning() { doneSpinning.write(true); }
+proc spin() { doneSpinning.waitFor(true); }
+
 proc main() {
   var barrier = new Barrier(3);
 
   // show that a task moved via an on-stmt will decrement the local runningTask counter
   sync {
-    // semi-hacky locale private var so that we don't have to wait on something
-    // that lives on locale 0 since that would create an additional task
-    pragma "locale private" var mySpin$: sync bool;
-
     begin {
       mytask();
 
       // wait for 2nd task to migrate (if it'll actually migrate)
       if numLocales > 1 then while (here.runningTasks() != 2) { chpl_task_yield(); }
       writeln("\n", here.runningTasks());
-      on Locales[1%numLocales] do mySpin$ = true;
+      on Locales[1%numLocales] do setDoneSpinning();
       barrier.barrier();
     }
     begin {
       mytask();
 
-      on Locales [1%numLocales] do mySpin$;
+      on Locales [1%numLocales] do spin();
       barrier.barrier();
     }
 


### PR DESCRIPTION
This test has been sporadically hanging recently. It turns out the test
could hang since it was introduced but for some reason recent changes
have made hangs far more often, especially on low core-count machines.

The problem was that we were using a locale-private variable to wait,
but then we were using the locale-private var within a task, so
task-intents gave us a reference to locale 0's variable instead of using
the current locales. Work around that by accessing the locale-private
variable through functions instead of directly accessing it.

Resolves https://github.com/Cray/chapel-private/issues/396