### PR TITLE
Don't set Reply-To in nightly testing emails

### DIFF
--- a/util/buildRelease/testRelease
+++ b/util/buildRelease/testRelease
@@ -10,7 +10,7 @@ $chplhomedir = abs_path("$cwd/../..");
 # Mailing lists.
 $failuremail = "chapel-test-results-regressions\@lists.sourceforge.net chapel_cronmail\@cray.com";
 $allmail = "chapel-test-results-all\@lists.sourceforge.net chapel_cronmail_all\@cray.com";
-$replymail = "chapel-developers\@lists.sourceforge.net";
+$replymail = "";
 
 $printusage = 1;
 $debug = 1;
@@ -105,7 +105,12 @@ if ($mailer eq "") {
     $chplsendemail = "$chplhomedir/util/test/send_email.py";
     `$chplsendemail --help >/dev/null 2>&1`;
     if ($? == 0) {
-        $mailer = "$chplsendemail --header=Reply-To=$replymail,Precedence=bulk";
+        $header = "";
+        if ($replymail ne "") {
+          $header = "Reply-To=$replymail,";
+        }
+        $header .= "Precedence=bulk";
+        $mailer = "$chplsendemail --header=$header";
     } else {
         print "[Error: send_email.py failed to run. Defaulting to 'mail'.]\n";
         $mailer = "mail";

--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -22,7 +22,7 @@ use nightlysubs;
 # Mailing lists.
 $failuremail = "chapel-test-results-regressions\@lists.sourceforge.net chapel_cronmail\@cray.com";
 $allmail = "chapel-test-results-all\@lists.sourceforge.net chapel_cronmail_all\@cray.com";
-$replymail = "chapel-developers\@lists.sourceforge.net";
+$replymail = "";
 
 $valgrind = 0;
 $interpret = 0;
@@ -389,7 +389,12 @@ if ($mailer eq "") {
     $chplsendemail = "$chplhomedir/util/test/send_email.py";
     `$chplsendemail --help >/dev/null 2>&1`;
     if ($? == 0) {
-        $mailer = "$chplsendemail --header=Reply-To=$replymail,Precedence=bulk";
+        $header = "";
+        if ($replymail ne "") {
+          $header = "Reply-To=$replymail,";
+        }
+        $header .= "Precedence=bulk";
+        $mailer = "$chplsendemail --header=$header";
     } else {
         print "[Error: send_email.py failed to run. Defaulting to 'mail'.]\n";
         $mailer = "mail";

--- a/util/tokencount/tokctnightly
+++ b/util/tokencount/tokctnightly
@@ -5,7 +5,7 @@ use File::Basename;
 
 # Mailing lists.
 $failuremail = "chapel-test-results-regressions\@lists.sourceforge.net chapel_cronmail\@cray.com";
-$replymail = "chapel-developers\@lists.sourceforge.net";
+$replymail = "";
 
 $tokctdir = abs_path(dirname(__FILE__));
 $tokctr = "$tokctdir/tokencount.cron";
@@ -74,7 +74,12 @@ if ($mailer eq "") {
     $chplsendemail = "$chplhomedir/util/test/send_email.py";
     `$chplsendemail --help >/dev/null 2>&1`;
     if ($? == 0) {
-        $mailer = "$chplsendemail --header=Reply-To=$replymail,Precedence=bulk";
+        $header = "";
+        if ($replymail ne "") {
+          $header = "Reply-To=$replymail,";
+        }
+        $header .= "Precedence=bulk";
+        $mailer = "$chplsendemail --header=$header";
     } else {
         print "[Error: send_email.py failed to run. Defaulting to 'mail'.]\n";
         $mailer = "mail";


### PR DESCRIPTION
Stop setting Reply-To to the sourceforge chapel-developers mailing list to
make the test triager's job easier.

Reviewed by @ronawho - thanks!