### PR TITLE
Try some new edits to my version of revcomp

### DIFF
--- a/test/studies/shootout/reverse-complement/bradc/revcomp-blc.chpl
+++ b/test/studies/shootout/reverse-complement/bradc/revcomp-blc.chpl
@@ -1,10 +1,18 @@
 /* The Computer Language Benchmarks Game
-   http://benchmarksgame.alioth.debian.org/
+   https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
+
    contributed by Ben Harshbarger and Brad Chamberlain
    derived from the Rust #2 version by Matt Brubeck
 */
 
-const table = initTable("ATCGGCTAUAMKRYWWSSYRKMVBHDDHBVNN\n\n");
+use IO;
+
+// capture some common ASCII values as integers
+const eol = "\n".toByte(),
+      gt  = ">".toByte(),
+      up2low = "A".toByte() - "a".toByte();
+
+const table = initTable(b"ATCGGCTAUAMKRYWWSSYRKMVBHDDHBVNN");
 
 proc main(args: [] string) {
   const stdin = openfd(0),
@@ -16,24 +24,21 @@ proc main(args: [] string) {
   // if the file isn't empty, wait for all tasks to complete before continuing
   if len then sync {
     do {
-      // capture the starting offset
-      const descOffset = input.offset();
-
-      // Mark where we start scanning (keep bytes in I/O buffer in input)
-      input.mark();
+      // Mark where we start scanning and capture the starting offset
+      const descOffset = input.mark();
 
       // Scan forward until we get to '\n' (end of description)
-      input.advancePastByte("\n".toByte());
+      input.advancePastByte(eol);
       const seqOffset = input.offset();
 
       // Scan forward until we get to '>' (end of sequence) or EOF
       const (eof, nextDescOffset) = findNextDesc();
 
-      // look for the next description, returning '(eof, its offset)'
-      proc findNextDesc() throws {
+      // look for the next description, returning '(eof?, its offset)'
+      proc findNextDesc() {
         try {
-          input.advancePastByte(">".toByte());
-        } catch (e:EOFError) {
+          input.advancePastByte(gt);
+        } catch {
           return (true, len-1);
         }
         return (false, input.offset()-1);
@@ -49,7 +54,7 @@ proc main(args: [] string) {
       const rewind = if eof then 1 else 2;
 
       // fire off a task to process the data for this sequence
-      begin process(data, seqOffset, nextDescOffset-rewind);
+      begin process(data[seqOffset..nextDescOffset-rewind]);
     } while !eof;
   }
 
@@ -61,26 +66,37 @@ proc main(args: [] string) {
 
 // process a sequence from both ends, replacing each extreme element
 // with the table lookup of the opposite one
-proc process(seq, in start, in end) {
+proc process(seq: [?inds]) {
+  var start = inds.low,
+      end = inds.high;
+
   while start <= end {
-    ref d1 = seq[start], d2 = seq[end];
+    ref d1 = seq[start],
+        d2 = seq[end];
+
     (d1, d2) = (table[d2], table[d1]);
+
     advance(start, 1);
     advance(end, -1);
   }
 
   proc advance(ref cursor, dir) {
-    do { cursor += dir; } while seq[cursor] == "\n".toByte();
+    do {
+      cursor += dir;
+    } while seq[cursor] == eol;
   }
 }
 
 proc initTable(pairs) {
   var table: [1..128] uint(8);
 
-  for i in 1..pairs.numBytes by 2 {
-    table[pairs.byte(i)] = pairs.byte(i+1);
-    if pairs.byte(i) != "\n".toByte() then
-      table[pairs[i:byteIndex].toLower().toByte()] = pairs.byte(i+1);
+  table[eol] = eol;
+  for i in 1..pairs.size by 2 {
+    const src = pairs.byte[i],
+          dst = pairs.byte[i+1];
+
+    table[src] = dst;
+    table[src-up2low] = dst;
   }
 
   return table;


### PR DESCRIPTION
This is a blend of some of the best features of revcomp-fast.chpl
from the release directory and revcomp2.chpl in the submitted
shootout directory.  In addition to those changes, it also

* simplifies the creation of the original table a bit including using
  the `bytes` type rather than the `string` type
* uses a simpler catch pattern to avoid throwing an error upwards
  (what would we do with it anyway?) and simplify the code somewhat

I'm prototyping this as a candidate new submission to the CLBG site.