### PR TITLE
Change revcomp ascii consts to params

### DIFF
--- a/test/studies/shootout/reverse-complement/bradc/revcomp-blc.chpl
+++ b/test/studies/shootout/reverse-complement/bradc/revcomp-blc.chpl
@@ -8,7 +8,7 @@
 use IO;
 
 // capture some common ASCII values as integers
-const eol = "\n".toByte(),
+param eol = "\n".toByte(),
       gt  = ">".toByte(),
       up2low = "A".toByte() - "a".toByte();
 


### PR DESCRIPTION
This is part of my continuing attempt to create a clean version of revcomp that competes with revcomp-fast.chpl in the release.

In the changes I made to revcomp yesterday, I introduced some constants that could have been params.  I didn't expect the difference to have a performance impact, but my version lagged the release version in the nightly graphs, and in some quick desktop experiments, it looks as though params may (?) help.  Checking in this simple change to see how it performs in the nightlies.