### PR TITLE
Compile LCALS without --legacy-classes

### DIFF
--- a/test/release/examples/benchmarks/lcals/LCALSLoops.chpl
+++ b/test/release/examples/benchmarks/lcals/LCALSLoops.chpl
@@ -25,7 +25,8 @@ module LCALSLoops {
     ia = 0;
   }
 
-  proc initData(ra: LCALS_Overlapping_Array_3D(real), id: int) {
+  proc initData(ra: LCALS_Overlapping_Array_3D, id: int) {
+    compilerAssert(ra.t == real);
     const factor: Real_type = if id % 2 != 0 then 0.1 else 0.2;
     for (r,j) in zip(ra, 0..) {
       r = factor*(j + 1.1)/(j + 1.12345);

--- a/test/release/examples/benchmarks/lcals/LCALSMain.compopts
+++ b/test/release/examples/benchmarks/lcals/LCALSMain.compopts
@@ -1,4 +1,3 @@
 # Run the abbreviated number of trials and don't print timing or
 # checksum output, or else we'd have to filter it out in testing
-# Pending #13721, run with the legacy option.
---legacy-classes -sverify_checksums_abbreviated=true -soutputFormat=OutputStyle.MINIMAL
+-sverify_checksums_abbreviated=true -soutputFormat=OutputStyle.MINIMAL

--- a/test/release/examples/benchmarks/lcals/LCALSMain.perfcompopts
+++ b/test/release/examples/benchmarks/lcals/LCALSMain.perfcompopts
@@ -1,2 +1,1 @@
---legacy-classes -soutputFormat=OutputStyle.PERF_TEST --no-ieee-float
-# Pending #13721, run with the legacy option.
+-soutputFormat=OutputStyle.PERF_TEST --no-ieee-float

--- a/test/release/examples/benchmarks/lcals/Timer.chpl
+++ b/test/release/examples/benchmarks/lcals/Timer.chpl
@@ -81,6 +81,7 @@ module Timer {
         t = new owned CycleTimer();
       } else {
         halt("Unknown timer type");
+        t = new owned TimerImpl(); //dummy
       }
     }
 


### PR DESCRIPTION
This includes a workaround for #13721 by using `LCALS_Overlapping_Array_3D`
instead of `LCALS_Overlapping_Array_3D(real)` as a formal argument type.
The lost `real` is checked with an assertion in the function body.
This latter can probably be left out safely, though.

When #13721 is resolved, this change to LCALSLoops.chpl can be reverted.

Tested it under linux64 with and without `-performance`.