### PR TITLE
Remove default-argument-param-not future which duplicates another test

### DIFF
--- a/test/functions/default-arguments/default-argument-param-not.chpl
+++ b/test/functions/default-arguments/default-argument-param-not.chpl
@@ -1,6 +1,0 @@
-var globalOne = 1;
-
-proc param_notparam(param x = globalOne) {
-}
-
-param_notparam();

--- a/test/functions/default-arguments/default-argument-param-not.future
+++ b/test/functions/default-arguments/default-argument-param-not.future
@@ -1,2 +1,0 @@
-error message: param argument with value default results in internal error
-#7956

--- a/test/functions/default-arguments/default-argument-param-not.good
+++ b/test/functions/default-arguments/default-argument-param-not.good
@@ -1,1 +1,0 @@
-default-argument-param-not.chpl:3: Default value not convertible to param formal


### PR DESCRIPTION
Remove test/functions/default-arguments/default-argument-param-not.*

The future requests a user-facing error for the bug in this test.
There is one now from #8254/#8272, but the .good file doesn't match it.

Those PRs also added
test/functions/diten/paramFormalDefaultNotParamError.chpl
which duplicates this future, so just remove it.