### PR TITLE
Fix annotations for compiler performance graphs

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -1620,3 +1620,29 @@ distAdaptativeWS:
     - Bring in upstream fixes for qthreads sleep interception bug (#5446)
   03/04/17:
     - Use Time.sleep so that these tests play nice with qthreads (#5483)
+
+
+# Compiler performance annotations
+compilerAndTestingStats: &compiler-perf-base
+  07/25/19:
+    - Add two-array radix and sample sorts and a distributed sort (#13347)
+  07/30/19:
+    - Undecorated classes have generic management (#13447)
+  07/31/19:
+    - Add record _bytes to the internal modules (#13519)
+  08/25/19:
+    - Enable compile-time nil-checking for internal modules (#13843)
+  08/30/19:
+    - Add factory functions for string and bytes (#13914)
+  08/31/19:
+    - Require 'use' of top level modules rather than lexical scoping (#13930)
+  09/06/19:
+    - Turn "array-as-vec" deprecation warnings on (#13999)
+allTotalTime:
+  <<: *compiler-perf-base
+allPasses:
+  <<: *compiler-perf-base
+topTotalTime:
+  <<: *compiler-perf-base
+topPasses:
+  <<: *compiler-perf-base

--- a/util/test/genGraphs
+++ b/util/test/genGraphs
@@ -298,6 +298,24 @@ def strip_series(csvFile, numseries):
     data_to_csv(data, csvFile)
 
 
+# Find the series to attach annotations to. If there were multiple
+# configurations, attach to a series in the default (first listed)
+# configuration. Else attach to first series
+def get_annotation_series(csvFile):
+    data = parse_csv(csvFile)
+    labels = [a[0] for a in data[0]]
+    labels = labels[1:]
+
+    annotation_series = labels[0]
+    if multiConf:
+        defaultConf = multiConf[0]
+        for label in labels:
+            if label.endswith('(' + defaultConf + ')'):
+                annotation_series = label
+                break
+
+    return annotation_series
+
 
 
 ############
@@ -408,17 +426,7 @@ class GraphStuff:
         else:
             self.firstGraph = False
 
-        # find the series to attach annotations to. If there were multiple
-        # configurations, attach to a series in the default (first listed)
-        # configuration. Else attach to first series
-        series = ''
-        if multiConf:
-            defaultConf = multiConf[0]
-            for graphkey in ginfo.graphkeys:
-                if graphkey.endswith('(' + defaultConf + ')'):
-                    series = graphkey
-        else:
-            series = ginfo.graphkeys[0]
+        series = ginfo.annotationSeries
 
         # generate the annotations for this graph
         if series and annotate and self.all_annotations and not numericX:
@@ -568,6 +576,7 @@ class GraphClass:
         self.numseries = -1
         self.sort = _sort
         self.annotations = []
+        self.annotationSeries = ""
 
     def __str__(self):
         l  = 'Graph: '+str(self.name)+' (id='+str(self.id)+')\n'
@@ -782,6 +791,8 @@ class GraphClass:
 
         if self.numseries > 0:
             strip_series(fname, self.numseries)
+
+        self.annotationSeries = get_annotation_series(fname)
 
         csv_to_json(fname, self)
 

--- a/util/test/perf/perfgraph.js
+++ b/util/test/perf/perfgraph.js
@@ -408,7 +408,10 @@ function expandGraphs(graph, graphInfo, graphDivs, graphData, graphLabels) {
 
     // copy the graphInfo and add the key to the title (stripping the
     // configuration if we have multiple configurations.)
-    var newInfo = $.extend({}, graphInfo);
+    var newInfo = $.extend(true, {}, graphInfo);
+    for (var j = 0; j < newInfo.annotations.length; j++) {
+      newInfo.annotations[j].series = graphLabels[i];
+    }
     newInfo.title += ": " + graphLabels[i].replace(defaultConfiguration, '');
 
     // The new graph cannot be expanded


### PR DESCRIPTION
Compiler performance graphs use a couple of features that were breaking
annotation support. Dygraphs requires that annotations are "attached" to
a series, so in order for annotations to display we have to attach them
to a visible series. That was broken in 2 ways.

In genGraphs we build a single graph that contains all the compiler
passes and then from that graph we build another one that is only the
top ten passes. When picking the top 10 our graphkeys got out of date,
so we were trying to attach annotations to invalid series. Fix that by
pulling the annotation series directly from the generated json instead
of relying on the outdated graphkeys.

In perfgraph.js we expand the graph with all compiler passes into
multiple graphs with one pass each. When doing this we were still
attaching annotations to an old series. Fix that by deep cloning the
annotations and attaching to the series for the pass being displayed

Resolves https://github.com/Cray/chapel-private/issues/492