### PR TITLE
Edits after perf team review

### DIFF
--- a/test/studies/shootout/reverse-complement/bradc/revcomp-blc.chpl
+++ b/test/studies/shootout/reverse-complement/bradc/revcomp-blc.chpl
@@ -7,12 +7,9 @@
 
 use IO;
 
-// capture some common ASCII values as integers
-param eol = "\n".toByte(),
-      gt  = ">".toByte(),
-      up2low = "A".toByte() - "a".toByte();
+param eol = "\n".toByte();    // end-of-line, as an integer
 
-const table = initTable(b"ATCGGCTAUAMKRYWWSSYRKMVBHDDHBVNN");
+const table = createTable();  // create the table of code complements
 
 proc main(args: [] string) {
   const stdin = openfd(0),
@@ -34,8 +31,10 @@ proc main(args: [] string) {
       // Scan forward until we get to '>' (end of sequence) or EOF
       const (eof, nextDescOffset) = findNextDesc();
 
-      // look for the next description, returning '(eof?, its offset)'
+      // look for the next description, returning '(eof, its offset)'
       proc findNextDesc() {
+        param gt  = ">".toByte();
+
         try {
           input.advancePastByte(gt);
         } catch {
@@ -87,7 +86,13 @@ proc process(seq: [?inds]) {
   }
 }
 
-proc initTable(pairs) {
+proc createTable() {
+  // `pairs` compactly represents the table we're creating, where the
+  // first byte of each pair (in either case) maps to the second:
+  //   A|a -> T, C|c -> G, G|g -> C, T|t -> A, etc.
+  param pairs = b"ATCGGCTAUAMKRYWWSSYRKMVBHDDHBVNN",
+        upperToLower = "a".toByte() - "A".toByte();
+
   var table: [1..128] uint(8);
 
   table[eol] = eol;
@@ -96,7 +101,7 @@ proc initTable(pairs) {
           dst = pairs.byte[i+1];
 
     table[src] = dst;
-    table[src-up2low] = dst;
+    table[src+upperToLower] = dst;
   }
 
   return table;


### PR DESCRIPTION
In addition to localizing the global byte-oriented params as
BHarsh suggested, I also:

* pushed the bytes value that is used to initialize the table into the createTable() (formerly initTable()) routine because it was easier to explain there (and seemed odd at the global scope)
* reversed the sense of the upperToLower variable (and spelled it out better) so that it would be added in rather than subtracted (which seems a bit more logical since lowercase values are higher than uppercase (?)).