### PR TITLE
Make `use ChapelStandard` in most internal modules private

### DIFF
--- a/modules/internal/ArrayViewRankChange.chpl
+++ b/modules/internal/ArrayViewRankChange.chpl
@@ -40,7 +40,7 @@
 //   classes... should I?
 //
 module ArrayViewRankChange {
-  use ChapelStandard;
+  private use ChapelStandard;
 
   //
   // This class represents a distribution that knows how to create

--- a/modules/internal/ArrayViewReindex.chpl
+++ b/modules/internal/ArrayViewReindex.chpl
@@ -23,7 +23,7 @@
 // represent reindexings of another array via a domain.
 //
 module ArrayViewReindex {
-  use ChapelStandard;
+  private use ChapelStandard;
 
   //
   // This class represents a distribution that knows how to create

--- a/modules/internal/ArrayViewSlice.chpl
+++ b/modules/internal/ArrayViewSlice.chpl
@@ -23,7 +23,7 @@
 // represent slices of another array via a domain.
 //
 module ArrayViewSlice {
-  use ChapelStandard;
+  private use ChapelStandard;
 
   config param chpl_debugSerializeSlice = false,
                chpl_serializeSlices = false;

--- a/modules/internal/Atomics.chpl
+++ b/modules/internal/Atomics.chpl
@@ -82,6 +82,7 @@
 pragma "atomic module"
 module Atomics {
 
+  private use ChapelBase;
   use MemConsistency;
   use ChapelEnv;
 

--- a/modules/internal/AtomicsCommon.chpl
+++ b/modules/internal/AtomicsCommon.chpl
@@ -18,7 +18,7 @@
  */
 
 module AtomicsCommon {
-  use ChapelStandard;
+  private use ChapelStandard;
 
   record atomic_refcnt {
     // The common case seems to be local access to this class, so we

--- a/modules/internal/ByteBufferHelpers.chpl
+++ b/modules/internal/ByteBufferHelpers.chpl
@@ -18,7 +18,7 @@
  */
 
 module ByteBufferHelpers {
-  use ChapelStandard;
+  private use ChapelStandard;
 
   pragma "no doc"
   type byteType = uint(8);

--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -92,7 +92,7 @@ To learn more about handling these errors, see the
 :ref:`Error Handling technical note <readme-errorHandling>`.
  */
 module Bytes {
-  use ChapelStandard;
+  private use ChapelStandard;
   use BytesCasts;
   private use ByteBufferHelpers;
   private use BytesStringCommon;

--- a/modules/internal/CPtr.chpl
+++ b/modules/internal/CPtr.chpl
@@ -25,7 +25,7 @@
    See also :ref:`readme-extern`.
  */
 module CPtr {
-  use ChapelStandard;
+  private use ChapelStandard;
   private use SysBasic, SysError;
   private use HaltWrappers only;
 

--- a/modules/internal/CString.chpl
+++ b/modules/internal/CString.chpl
@@ -23,7 +23,7 @@
 // In terms of how they are used, c_strings are a "close to the metal"
 // representation, being in essence the common NUL-terminated C string.
 module CString {
-  use ChapelStandard;
+  private use ChapelStandard;
 
   //inline proc c_string.c_str() return this;
 

--- a/modules/internal/ChapelDebugPrint.chpl
+++ b/modules/internal/ChapelDebugPrint.chpl
@@ -26,7 +26,7 @@
  */
 
 module ChapelDebugPrint {
-  use ChapelStandard;
+  private use ChapelStandard;
 
   proc chpl_debug_stringify(args...) : string {
     var str = "";

--- a/modules/internal/ChapelEnv.chpl
+++ b/modules/internal/ChapelEnv.chpl
@@ -30,7 +30,7 @@
 
  */
 module ChapelEnv {
-  use ChapelStandard;
+  private use ChapelStandard;
 
   /* See :ref:`readme-chplenv.CHPL_HOME` for more information. */
   param CHPL_HOME:string            = __primitive("get compiler variable", "CHPL_HOME");

--- a/modules/internal/ChapelError.chpl
+++ b/modules/internal/ChapelError.chpl
@@ -24,7 +24,7 @@
 
  */
 module ChapelError {
-  use ChapelStandard;
+  private use ChapelStandard;
   private use ChapelLocks;
 
   // Base class for errors

--- a/modules/internal/ChapelIteratorSupport.chpl
+++ b/modules/internal/ChapelIteratorSupport.chpl
@@ -38,7 +38,7 @@
 pragma "error mode fatal" // avoid compiler errors here
 pragma "unsafe"
 module ChapelIteratorSupport {
-  use ChapelStandard;
+  private use ChapelStandard;
   private use Reflection;
 
   //

--- a/modules/internal/ChapelReduce.chpl
+++ b/modules/internal/ChapelReduce.chpl
@@ -20,7 +20,7 @@
 // ChapelReduce.chpl
 //
 module ChapelReduce {
-  use ChapelStandard;
+  private use ChapelStandard;
   private use ChapelLocks;
 
   config param enableParScan = false;

--- a/modules/internal/ChapelSyncvar.chpl
+++ b/modules/internal/ChapelSyncvar.chpl
@@ -889,7 +889,7 @@ module ChapelSyncvar {
 
 
 private module SyncVarRuntimeSupport {
-  use ChapelStandard;
+  private use ChapelStandard;
   use AlignedTSupport;
 
   //

--- a/modules/internal/ChapelTaskData.chpl
+++ b/modules/internal/ChapelTaskData.chpl
@@ -21,7 +21,7 @@
 //
 module ChapelTaskData {
 
-  use ChapelStandard;
+  private use ChapelStandard;
 
   // Chapel task-local data format:
   // up to 16 bytes of wide pointer for _remoteEndCountType

--- a/modules/internal/ChapelTaskDataHelp.chpl
+++ b/modules/internal/ChapelTaskDataHelp.chpl
@@ -21,7 +21,7 @@
 //
 module ChapelTaskDataHelp {
 
-  use ChapelStandard;
+  private use ChapelStandard;
 
   extern type chpl_task_ChapelData_t;
   pragma "fn synchronization free"

--- a/modules/internal/ChapelTuple.chpl
+++ b/modules/internal/ChapelTuple.chpl
@@ -38,7 +38,7 @@ The following method is also available:
 It returns the number of components of the tuple.
 */
 module ChapelTuple {
-  use ChapelStandard;
+  private use ChapelStandard;
 
   pragma "tuple" record _tuple {
     param size : int;

--- a/modules/internal/ChapelUtil.chpl
+++ b/modules/internal/ChapelUtil.chpl
@@ -22,7 +22,7 @@
 // Internal data structures module
 //
 module ChapelUtil {
-  use ChapelStandard;
+  private use ChapelStandard;
 
   //
   // safeAdd: If a and b are of type t, return true iff no

--- a/modules/internal/DefaultOpaque.chpl
+++ b/modules/internal/DefaultOpaque.chpl
@@ -20,7 +20,7 @@
 // DefaultOpaque.chpl
 //
 module DefaultOpaque {
-  use ChapelStandard;
+  private use ChapelStandard;
 
   // record _OpaqueIndex is defined in ChapelArray
 

--- a/modules/internal/DefaultSparse.chpl
+++ b/modules/internal/DefaultSparse.chpl
@@ -20,7 +20,7 @@
 // DefaultSparse.chpl
 //
 module DefaultSparse {
-  use ChapelStandard;
+  private use ChapelStandard;
   use RangeChunk only ;
 
   config param debugDefaultSparse = false;

--- a/modules/internal/ExternalArray.chpl
+++ b/modules/internal/ExternalArray.chpl
@@ -23,7 +23,7 @@
 // arrays obtained from external code to Chapel (and thus that we do not own).
 //
 module ExternalArray {
-  use ChapelStandard;
+  private use ChapelStandard;
 
   extern record chpl_opaque_array {
     var _pid: int;

--- a/modules/internal/ExternalString.chpl
+++ b/modules/internal/ExternalString.chpl
@@ -19,6 +19,7 @@
 
 module ExternalString {
   use CPtr;
+  private use SysCTypes;
 
   //
   // TODO: This shouldn't be necessary, and the compiler should figure this

--- a/modules/internal/LocaleModelHelpMem.chpl
+++ b/modules/internal/LocaleModelHelpMem.chpl
@@ -27,7 +27,7 @@
 // duplication. If necessary, a locale model using this file
 // should feel free to reimplement them in some other way.
 module LocaleModelHelpMem {
-  use ChapelStandard;
+  private use ChapelStandard;
 
   //////////////////////////////////////////
   //

--- a/modules/internal/LocaleModelHelpRuntime.chpl
+++ b/modules/internal/LocaleModelHelpRuntime.chpl
@@ -27,7 +27,7 @@
 // duplication. If necessary, a locale model using this file
 // should feel free to reimplement them in some other way.
 module LocaleModelHelpRuntime {
-  use ChapelStandard;
+  private use ChapelStandard;
 
   // The chpl_localeID_t type is used internally.  It should not be exposed to
   // the user.  The runtime defines the actual type, as well as a functional

--- a/modules/internal/LocalesArray.chpl
+++ b/modules/internal/LocalesArray.chpl
@@ -38,7 +38,7 @@
 //
 
 module LocalesArray {
-  use ChapelStandard;
+  private use ChapelStandard;
 
   // Initialize the rootLocale
   chpl_init_rootLocale();

--- a/modules/internal/MemTracking.chpl
+++ b/modules/internal/MemTracking.chpl
@@ -21,7 +21,7 @@
 //
 module MemTracking
 {
-  use ChapelStandard;
+  private use ChapelStandard;
 
   config const
     memTrack: bool = false,

--- a/modules/internal/NetworkAtomics.chpl
+++ b/modules/internal/NetworkAtomics.chpl
@@ -19,7 +19,7 @@
 
 pragma "atomic module"
 module NetworkAtomics {
-  use ChapelStandard;
+  private use ChapelStandard;
 
   private proc externFunc(param s: string, type T) param {
     if isInt(T)  then return "chpl_comm_atomic_" + s + "_int"  + numBits(T):string;

--- a/modules/internal/OwnedObject.chpl
+++ b/modules/internal/OwnedObject.chpl
@@ -174,7 +174,7 @@ supplied. For example:
 
  */
 module OwnedObject {
-  use ChapelStandard;
+  private use ChapelStandard;
 
   /*
      :record:`owned` manages the deletion of a class instance assuming

--- a/modules/internal/SharedObject.chpl
+++ b/modules/internal/SharedObject.chpl
@@ -100,6 +100,7 @@ See also :ref:`about-owned-intents-and-instantiation` which includes examples.
  */
 module SharedObject {
 
+  private use ChapelError;
   use OwnedObject;
 
   // TODO unify with RefCountBase. Even though that one is for

--- a/modules/internal/String.chpl
+++ b/modules/internal/String.chpl
@@ -132,7 +132,7 @@ and :proc:`~string.rfind()` return a :record:`byteIndex`.
 
  */
 module String {
-  use ChapelStandard;
+  private use ChapelStandard;
   use CString;
   use SysCTypes;
   use StringCasts;

--- a/modules/internal/StringCasts.chpl
+++ b/modules/internal/StringCasts.chpl
@@ -18,7 +18,7 @@
  */
 
 module StringCasts {
-  use ChapelStandard;
+  private use ChapelStandard;
 
   // TODO: I want to break all of these casts from string to T out into
   // T.parse(string), but we dont support methods on types yet. Ideally they


### PR DESCRIPTION
This converts most `use ChapelStandard` statements in `modules/internal` into `private use ChapelStandard` as part of our ongoing effort to make more uses private.  In a few cases, this necessitated putting other `use` statements into the internal modules to satisfy dependences that had previously been satisfied by a transitive `use`.

Unfortunately, two key uses were nontrivial to unravel, so remain public.

Beyond housekeeping, this effort was motivated by a hope that it would be a simple way to reduce compile-time, but I haven't seen evidence of this yet in some simple experiments.