### PR TITLE
Clean initCopy'd variables upon throw

### DIFF
--- a/compiler/resolution/addAutoDestroyCalls.cpp
+++ b/compiler/resolution/addAutoDestroyCalls.cpp
@@ -421,9 +421,11 @@ static void gatherIgnoredVariablesForErrorHandling(
       if (CallExpr* call = toCallExpr(move->get(2))) {
         if (FnSymbol* fn = call->resolvedFunction()) {
           if (fn->throwsError()) {
-            SymExpr *se = toSymExpr(move->get(1));
-            ignore = toVarSymbol(se->symbol());
-            ignoredVariables.insert(ignore);
+            if (!fn->hasFlag(FLAG_INIT_COPY_FN)) {
+              SymExpr *se = toSymExpr(move->get(1));
+              ignore = toVarSymbol(se->symbol());
+              ignoredVariables.insert(ignore);
+            }
           }
         }
       }

--- a/compiler/resolution/addAutoDestroyCalls.cpp
+++ b/compiler/resolution/addAutoDestroyCalls.cpp
@@ -421,9 +421,17 @@ static void gatherIgnoredVariablesForErrorHandling(
       if (CallExpr* call = toCallExpr(move->get(2))) {
         if (FnSymbol* fn = call->resolvedFunction()) {
           if (fn->throwsError()) {
+            // The following block is a workaround to close a memory leak in
+            // code similar to:
+            //
+            //   try {
+            //     var a = for i in 0..3 throwingFunc(i)
+            //   }
+            //   catch { ... }
+            //
             // Do not ignore if the call is chpl__initCopy(ir) because not
             // cleaning after it causes memory leaks. See the test:
-            // test/errhandling/ferguson/loopexprs-caught.chpl
+            // test/errhandling/ferguson/loopexprs-caught.chpl and PR #14192
             bool isInitCopyWithIR = false;
             if (fn->hasFlag(FLAG_INIT_COPY_FN)) {
               if (call->numActuals() >= 1) {


### PR DESCRIPTION
This PR adjusts callDestructors to stop ignoring variables initialized via
`chpl__initCopy(iteratorRecord)` that can throw. 

Currently, if the rhs of an initialization is a CallExpr that can throw, the
variable is not cleaned up, because we don't really now what to clean up.
However, `chpl__initCopy` with iterator record actual "feels" special
enough that we can still clean up variables that are created by it.

An example snippet where this pattern comes up:

```chapel
try {
  var a = for i in 0..3 do throwingFunc(i);
}
catch ... { ... }
```

This closes the leak in `errhandling/ferguson/loopexprs-caught` which is the
test that leaks the most at this moment.

Test:

- [x] valgrind in primers
- [x] valgrind in `test/errhandling`
- [x] standard
- [x] gasnet
