### PR TITLE
Overwrite existing memleaks log file

### DIFF
--- a/util/start_test
+++ b/util/start_test
@@ -673,8 +673,9 @@ def set_up_environment():
         memleaksfile = os.path.abspath(args.mem_leaks_log)
         args.execopts += " --memLeaksLog=" + memleaksfile
         if os.path.isfile(memleaksfile):
-            logger.write("[Error: mem leaks log file already exists: {0}]"
+            logger.write("[Removing memory leaks log file with duplicate name {0}]"
                          .format(memleaksfile))
+            os.remove(memleaksfile)
 
     # create temporary directory
     global chpl_test_tmp_dir
@@ -737,7 +738,7 @@ def set_up_logger():
         sys.exit(1)
     if os.path.isfile(log_file):
         print()
-        print("[Removing log file with duplicate name {0}".format(log_file))
+        print("[Removing log file with duplicate name {0}]".format(log_file))
         os.remove(log_file)
 
     ## START LOGGING TO FILE ##


### PR DESCRIPTION
This PR changes the start_test behavior where existing memleaks log file
was reported as a failure and results were appended to the end of the file.

See #2541 for this behavior and rationale.

Instead, with this PR, it is removed similar to duplicate log file in the
beginning of the test, while issuing an output in the logs.

While there adds a closing bracket to log output.

Test status:
I played around locally with and without existing files using start_test and
did a primers run with paratest. It looks like paratest should be oblivious
to this change but I am open to testing suggestions.