### PR TITLE
Fix quicksort to work with owned array elements

### DIFF
--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -1691,11 +1691,15 @@ module ShallowCopy {
   // TODO: move these out of the Sort module and/or consider
   // language support for it.
   inline proc shallowCopy(ref dst:?t, ref src:t) {
-    var size = c_sizeof(t);
-    c_memcpy(c_ptrTo(dst), c_ptrTo(src), size);
-    // The version moved from should never be used again,
-    // but we clear it out just in case.
-    c_memset(c_ptrTo(src), 0, size);
+    if isPODType(t) {
+      dst = src;
+    } else {
+      var size = c_sizeof(t);
+      c_memcpy(c_ptrTo(dst), c_ptrTo(src), size);
+      // The version moved from should never be used again,
+      // but we clear it out just in case.
+      c_memset(c_ptrTo(src), 0, size);
+    }
   }
 
   // returns the result of shallow copying src
@@ -1710,13 +1714,19 @@ module ShallowCopy {
   inline proc shallowSwap(ref lhs:?t, ref rhs:t) {
     pragma "no auto destroy"
     var tmp: t;
-    var size = c_sizeof(t);
-    // tmp = lhs
-    c_memcpy(c_ptrTo(tmp), c_ptrTo(lhs), size);
-    // lhs = rhs
-    c_memcpy(c_ptrTo(lhs), c_ptrTo(rhs), size);
-    // rhs = tmp
-    c_memcpy(c_ptrTo(rhs), c_ptrTo(tmp), size);
+    if isPODType(t) {
+      tmp = lhs;
+      lhs = rhs;
+      rhs = tmp;
+    } else {
+      var size = c_sizeof(t);
+      // tmp = lhs
+      c_memcpy(c_ptrTo(tmp), c_ptrTo(lhs), size);
+      // lhs = rhs
+      c_memcpy(c_ptrTo(lhs), c_ptrTo(rhs), size);
+      // rhs = tmp
+      c_memcpy(c_ptrTo(rhs), c_ptrTo(tmp), size);
+    }
   }
 
   // TODO: These shallowCopy functions should handle Block,Cyclic arrays

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -1100,13 +1100,18 @@ module QuickSort {
   proc quickSort(Data: [?Dom] ?eltType,
                  minlen=16,
                  comparator:?rec=defaultComparator,
-                 start:int = Dom.low, end:int = Dom.high)
-    where !Dom.stridable {
+                 start:int = Dom.low, end:int = Dom.high) {
 
     chpl_check_comparator(comparator, eltType);
 
     if Dom.rank != 1 {
       compilerError("quickSort() requires 1-D array");
+    }
+
+    if Dom.stridable {
+      ref reindexed = Data.reindex(Dom.alignedLow..#Dom.size);
+      quickSort(reindexed, minlen, comparator);
+      return;
     }
 
     // grab obvious indices

--- a/modules/packages/Sort.chpl
+++ b/modules/packages/Sort.chpl
@@ -1125,7 +1125,7 @@ module QuickSort {
 
     // find pivot using median-of-3 method for small arrays
     // and a "ninther" for bigger arrays
-    if hi - lo < 40 {
+    if hi - lo < 100 {
       order3(Data, lo, mid, hi, comparator);    
     } else {
       // assumes array size > 9 at the very least
@@ -1140,7 +1140,7 @@ module QuickSort {
 
     var (eqStart, eqEnd) = partition(Data, lo, mid, hi, comparator);
 
-    if hi-lo < 30 { //256 {
+    if hi-lo < 300 {
       // stay sequential
       quickSort(Data, minlen, comparator, lo, eqStart-1);
       quickSort(Data, minlen, comparator, eqEnd+1, hi);

--- a/test/library/packages/Sort/correctness/sort-array-of-owned.chpl
+++ b/test/library/packages/Sort/correctness/sort-array-of-owned.chpl
@@ -1,0 +1,165 @@
+use Sort;
+
+config const n = 100;
+config param useKeyComparator = true; 
+
+class Value {
+  var x: int;
+}
+
+
+record ValueComparator {
+  proc key(v: Value?) where useKeyComparator {
+    if v == nil then
+      return 0;
+    else
+      return v!.x;
+  }
+  proc compare(a: Value?, b: Value?) where !useKeyComparator {
+    var aNum = 0;
+    if a != nil then
+      aNum = a!.x;
+    var bNum = 0;
+    if b != nil then
+      bNum = b!.x;
+    return aNum - bNum;
+  }
+}
+
+
+// TEST 1: SORTING OWNED ELEMENTS
+{
+  writeln("Testing sorting owned");
+  var A: [1..n] owned Value?;
+  var comparator = new ValueComparator();
+  for i in 1..n {
+    A[i] = new owned Value(n-i);
+  }
+  sort(A, comparator=comparator);
+  if n <= 20 then writeln(A);
+  for i in 1..n {
+    if A[i] == nil then halt("nil was introduced");
+  }
+  assert(isSorted(A, comparator));
+
+  /*
+  for i in 1..n {
+    A[i] = new owned Value(n-i);
+  }
+  QuickSort.quickSort(A, comparator=comparator);
+  if n <= 20 then writeln(A);
+  for i in 1..n {
+    if A[i] == nil then halt("nil was introduced");
+  }
+  assert(isSorted(A, comparator));*/
+}
+
+// TEST 2: SORTING RECORD CONTAINING OWNED ELEMENTS
+
+record Wrapper {
+  var elt: owned Value?;
+}
+proc =(ref lhs: Wrapper, ref rhs: Wrapper) {
+  lhs.elt = rhs.elt;
+}
+
+record WrapperComparator {
+  proc key(v: Wrapper) where useKeyComparator {
+    if v.elt == nil then
+      return 0;
+    else
+      return v.elt!.x;
+  }
+  proc compare(a: Wrapper, b: Wrapper) where !useKeyComparator {
+    var aNum = 0;
+    if a.elt != nil then
+      aNum = a.elt!.x;
+    var bNum = 0;
+    if b.elt != nil then
+      bNum = b.elt!.x;
+    return aNum - bNum;
+  }
+
+}
+
+{
+  writeln("Testing sorting record containing owned");
+  var A: [1..n] Wrapper;
+  var comparator = new WrapperComparator();
+  for i in 1..n {
+    A[i] = new Wrapper(new owned Value(n-i));
+  }
+  sort(A, comparator=comparator);
+  if n <= 20 then writeln(A);
+  for i in 1..n {
+    if A[i].elt == nil then halt("nil was introduced");
+  }
+  assert(isSorted(A, comparator));
+
+  /*
+  for i in 1..n {
+    A[i] = new Wrapper(new owned Value(n-i));
+  }
+  QuickSort.quickSort(A, comparator=comparator);
+  if n <= 20 then writeln(A);
+  for i in 1..n {
+    if A[i].elt == nil then halt("nil was introduced");
+  }
+  assert(isSorted(A, comparator));*/
+}
+
+// TEST 3: SORTING RECORD CONTAINING ARRAY OF OWNED ELEMENTS
+
+record ArrayWrapper {
+  var elts: [1..1] owned Value?;
+  proc init() {
+    this.complete();
+  }
+  proc init(in arg: owned Value) {
+    this.complete();
+    elts[1] = arg;
+  }
+}
+record ArrayWrapperComparator {
+  proc key(v: ArrayWrapper) where useKeyComparator {
+    if v.elts[1] == nil then
+      return 0;
+    else
+      return v.elts[1]!.x;
+  }
+  proc compare(a: ArrayWrapper, b: ArrayWrapper) where !useKeyComparator {
+    var aNum = 0;
+    if a.elts[1] != nil then
+      aNum = a.elts[1]!.x;
+    var bNum = 0;
+    if b.elts[1] != nil then
+      bNum = b.elts[1]!.x;
+    return aNum - bNum;
+  }
+}
+
+{
+  writeln("Testing sorting record containing array of owned");
+  var A: [1..n] ArrayWrapper;
+  var comparator = new ArrayWrapperComparator();
+  for i in 1..n {
+    A[i] = new ArrayWrapper(new owned Value(n-i));
+  }
+  sort(A, comparator=comparator);
+  if n <= 20 then writeln(A);
+  for i in 1..n {
+    if A[i].elts[1] == nil then halt("nil was introduced");
+  }
+  assert(isSorted(A, comparator));
+
+  /*
+  for i in 1..n {
+    A[i] = new ArrayWrapper(new owned Value(n-i));
+  }
+  QuickSort.quickSort(A, comparator=comparator);
+  if n <= 20 then writeln(A);
+  for i in 1..n {
+    if A[i].elts[1] == nil then halt("nil was introduced");
+  }
+  assert(isSorted(A, comparator));*/
+}

--- a/test/library/packages/Sort/correctness/sort-array-of-owned.compopts
+++ b/test/library/packages/Sort/correctness/sort-array-of-owned.compopts
@@ -1,0 +1,2 @@
+-suseKeyComparator=true
+-suseKeyComparator=false

--- a/test/library/packages/Sort/correctness/sort-array-of-owned.good
+++ b/test/library/packages/Sort/correctness/sort-array-of-owned.good
@@ -1,0 +1,3 @@
+Testing sorting owned
+Testing sorting record containing owned
+Testing sorting record containing array of owned

--- a/test/modules/sungeun/init/printModuleInitOrder.good
+++ b/test/modules/sungeun/init/printModuleInitOrder.good
@@ -32,6 +32,7 @@ Initializing Modules:
            RadixSortHelp
            ShellSort
           QuickSort
+           ShallowCopy
            InsertionSort
           BubbleSort
           HeapSort

--- a/test/modules/sungeun/init/printModuleInitOrder.na-none.good
+++ b/test/modules/sungeun/init/printModuleInitOrder.na-none.good
@@ -31,6 +31,7 @@ Initializing Modules:
            RadixSortHelp
            ShellSort
           QuickSort
+           ShallowCopy
            InsertionSort
           BubbleSort
           HeapSort


### PR DESCRIPTION
quickSort (which is called by the default `sort` in some cases) was not
correctly handling arrays containing `owned` elements and their ownership
transfer. This PR updates the quickSort code to handle that case. It is
slightly tricky because the code was ownership-transferring the pivot to
a local variable and then sorting now empty array element... I could have
modified the quickSort to not store the pivot as a local variable or to
track the location of the pivot element through swaps. Instead, I opted
to change quickSort to a slightly different version of the algorithm,
which is described in *Engineering a Sort Function (1993) by Jon L.
Bentley , M. Douglas McIlroy*. The alternative quickSort variant
partitions into elements equal to the pivot, so I was able to fold moving
the pivot in and out of the array into the algorithm without adding O(n)
extra work.

While implementing the alternative quickSort variant, I went ahead and
addressed some other issues with quickSort:
 * it now sorts the subproblems in parallel
 * it now uses a median-of-medians (aka "ninther") for large enough
   arrays, to reduce the chance of choosing a bad pivot
 * it uses more helper functions (so as to be more understandable)

The result is faster than before this PR, even though improving the
perfomance of quickSort is not the main goal here.

Reviewed by @cassella and @ben-albrecht - thanks!

- [x] full local testing
