### PR TITLE
Fix 16 node CS annotations

### DIFF
--- a/util/cron/test-perf.cray-cs.gasnet-ibv.fast.bash
+++ b/util/cron/test-perf.cray-cs.gasnet-ibv.fast.bash
@@ -4,7 +4,7 @@
 
 CWD=$(cd $(dirname $0) ; pwd)
 
-export CHPL_TEST_PERF_CONFIG_NAME='16-node-cs'
+export CHPL_TEST_PERF_CONFIG_NAME='16 node CS'
 
 source $CWD/common-perf.bash
 export CHPL_TEST_PERF_DIR=/cray/css/users/chapelu/NightlyPerformance/cray-cs/16-node-cs

--- a/util/cron/test-perf.cray-cs.gasnet-ibv.large.bash
+++ b/util/cron/test-perf.cray-cs.gasnet-ibv.large.bash
@@ -4,7 +4,7 @@
 
 CWD=$(cd $(dirname $0) ; pwd)
 
-export CHPL_TEST_PERF_CONFIG_NAME='16-node-cs'
+export CHPL_TEST_PERF_CONFIG_NAME='16 node CS'
 
 source $CWD/common-perf.bash
 export CHPL_TEST_PERF_DIR=/cray/css/users/chapelu/NightlyPerformance/cray-cs/16-node-cs

--- a/util/cron/test-perf.cray-cs.gasnet-mpi.bash
+++ b/util/cron/test-perf.cray-cs.gasnet-mpi.bash
@@ -4,7 +4,7 @@
 
 CWD=$(cd $(dirname $0) ; pwd)
 
-export CHPL_TEST_PERF_CONFIG_NAME='16-node-cs'
+export CHPL_TEST_PERF_CONFIG_NAME='16 node CS'
 
 source $CWD/common-perf.bash
 export CHPL_TEST_PERF_DIR=/cray/css/users/chapelu/NightlyPerformance/cray-cs/16-node-cs


### PR DESCRIPTION
The annotations were using "16 node CS", but the perf config was using
"16-node-cs". Switch to "16 node CS", which matches "16 node XC"