### PR TITLE
Run gen_release git commands with --no-pager

### DIFF
--- a/util/buildRelease/gen_release
+++ b/util/buildRelease/gen_release
@@ -87,7 +87,7 @@ if (exists($ENV{"CHPL_GEN_RELEASE_NO_CLONE"})) {
     }
 
     print "[gen_release] Confirm final Git source version used.\n";
-    SystemOrDie("cd $rootdir && git status && git log -1");
+    SystemOrDie("cd $rootdir && git --no-pager status && git --no-pager log -1");
 
     if ($version eq "" or $version eq "developer") {
       print "[gen_release] Create BUILD_VERSION file.\n";


### PR DESCRIPTION
Some status and log commands were added in #7243, but in some recent
testing of `testRelease` Brad and I were seeing a git prompt, which
seemed odd (and meant we had to pay attention to the build instead of
just letting it run and coming back later.) Throw `--no-pager` to avoid
the prompt.