### PR TITLE
Deprecate string vs bytes comparisons

### DIFF
--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -1303,7 +1303,7 @@ module Bytes {
   }
 
   proc comparisonDeprWarn() {
-    compilerWarning("Comparison between bytes/string is deprecated. " +
+    compilerWarning("Comparison between bytes and string is deprecated. " +
                     "Cast the string to bytes first");
   }
 

--- a/modules/internal/Bytes.chpl
+++ b/modules/internal/Bytes.chpl
@@ -1298,27 +1298,36 @@ module Bytes {
   }
 
   pragma "no doc"
+  inline proc !=(a: bytes, b: bytes) : bool {
+    return !doEq(a,b);
+  }
+
+  proc comparisonDeprWarn() {
+    compilerWarning("Comparison between bytes/string is deprecated. " +
+                    "Cast the string to bytes first");
+  }
+
+  pragma "no doc"
   proc ==(a: bytes, b: string) : bool {
+    comparisonDeprWarn();
     return doEq(a,b);
   }
 
   pragma "no doc"
   proc ==(a: string, b: bytes) : bool {
+    comparisonDeprWarn();
     return doEq(a,b);
   }
 
   pragma "no doc"
-  inline proc !=(a: bytes, b: bytes) : bool {
-    return !doEq(a,b);
-  }
-
-  pragma "no doc"
   inline proc !=(a: bytes, b: string) : bool {
+    comparisonDeprWarn();
     return !doEq(a,b);
   }
 
   pragma "no doc"
   inline proc !=(a: string, b: bytes) : bool {
+    comparisonDeprWarn();
     return !doEq(a,b);
   }
 

--- a/modules/internal/BytesCasts.chpl
+++ b/modules/internal/BytesCasts.chpl
@@ -26,9 +26,9 @@ module BytesCasts {
   //
   inline proc _cast(type t:bytes, x: bool) {
     if (x) {
-      return "true":bytes;
+      return b"true";
     } else {
-      return "false":bytes;
+      return b"false";
     }
   }
 
@@ -37,9 +37,9 @@ module BytesCasts {
     if b.isEmpty() {
       // TODO engin: do we really need this check?
       throw new owned IllegalArgumentError("bad cast from empty bytes to bool");
-    } else if (b == "true") {
+    } else if (b == b"true") {
       return true;
-    } else if (b == "false") {
+    } else if (b == b"false") {
       return false;
     } else {
       throw new owned IllegalArgumentError("bad cast from bytes '" +
@@ -111,7 +111,7 @@ module BytesCasts {
     var isErr: bool;
     // localize the bytes and remove leading and trailing whitespace
     var localX = x.localize();
-    const hasUnderscores = localX.find("_":bytes) != 0;
+    const hasUnderscores = localX.find(b"_") != 0;
 
     if hasUnderscores {
       localX = localX.strip();
@@ -128,7 +128,7 @@ module BytesCasts {
 
       // remove underscores everywhere but the first position
       if localX.length >= 2 then
-        localX = localX[1] + localX[2..].replace("_":bytes, "":bytes);
+        localX = localX[1] + localX[2..].replace(b"_", b"");
     }
 
     if localX.isEmpty() then
@@ -202,13 +202,13 @@ module BytesCasts {
       throw new owned IllegalArgumentError("bad cast from empty bytes to " +
                                            t: string);
 
-    if len >= 2 && s[2..].find("_":bytes) != 0 {
+    if len >= 2 && s[2..].find(b"_") != 0 {
       // Don't remove a leading underscore in the string number,
       // but remove the rest.
-      if len > 2 && s[1] == "_" {
-        s = s[1] + s[2..].replace("_":bytes, "":bytes);
+      if len > 2 && s[1] == b"_" {
+        s = s[1] + s[2..].replace(b"_", b"");
       } else {
-        s = s.replace("_":bytes, "":bytes);
+        s = s.replace(b"_", b"");
       }
     }
   }
@@ -276,7 +276,7 @@ module BytesCasts {
   //
   proc _cast(type t:bytes, x: chpl_anycomplex) {
     if isnan(x.re) || isnan(x.im) then
-      return "nan":bytes;
+      return b"nan";
     var re = (x.re):bytes;
     var im: bytes;
     var op: bytes;
@@ -292,7 +292,7 @@ module BytesCasts {
     }
     const ts0 = re + op;
     const ts1 = ts0 + im;
-    const ret = ts1 + "i":bytes;
+    const ret = ts1 + b"i";
     return ret;
   }
 

--- a/test/deprecated/string-bytes-comp.chpl
+++ b/test/deprecated/string-bytes-comp.chpl
@@ -1,0 +1,7 @@
+var s = "foo";
+var b = b"foo";
+
+writeln(s == b);
+writeln(s != b);
+writeln(b == s);
+writeln(b != s);

--- a/test/deprecated/string-bytes-comp.good
+++ b/test/deprecated/string-bytes-comp.good
@@ -1,0 +1,8 @@
+string-bytes-comp.chpl:4: warning: Comparison between bytes/string is deprecated. Cast the string to bytes first
+string-bytes-comp.chpl:5: warning: Comparison between bytes/string is deprecated. Cast the string to bytes first
+string-bytes-comp.chpl:6: warning: Comparison between bytes/string is deprecated. Cast the string to bytes first
+string-bytes-comp.chpl:7: warning: Comparison between bytes/string is deprecated. Cast the string to bytes first
+true
+false
+true
+false


### PR DESCRIPTION
This PR deprecates string vs bytes comparisons and adds a deprecation test.

Resolves #14160 

Test status:
- [x] standard
- [x] gasnet