### PR TITLE
Add test for record arrays created with throwing loops

### DIFF
--- a/test/errhandling/misc/forExprReturnsRecOrThrows.chpl
+++ b/test/errhandling/misc/forExprReturnsRecOrThrows.chpl
@@ -1,0 +1,36 @@
+config const testForExpr = false;
+config const testForAllExpr = false;
+config const testBracketForAllExpr = false;
+
+record r {
+  var x: int;
+
+  proc init() { }
+
+  proc init(i: int) {
+    this.x = i;
+  }
+
+  proc deinit() { }
+
+}
+
+proc foo(i, shouldThrow=false) throws {
+  if shouldThrow && i == 0 then throw new Error();
+  else return new r(i);
+}
+
+proc main() {
+  try {
+    var a1 = for i in -5..5 do foo(i, shouldThrow=testForExpr);
+    var a2 = forall i in -5..5 do foo(i, shouldThrow=testForAllExpr);
+    var a3 = [i in -5..5] foo(i, shouldThrow=testBracketForAllExpr);
+    
+    writeln(a1);
+    writeln(a2);
+    writeln(a3);
+  }
+  catch e {
+    writeln("Error caught");
+  }
+}

--- a/test/errhandling/misc/forExprReturnsRecOrThrows.execopts
+++ b/test/errhandling/misc/forExprReturnsRecOrThrows.execopts
@@ -1,0 +1,3 @@
+--testForExpr
+# --testForAllExpr
+# --testBracketForAllExpr

--- a/test/errhandling/misc/forExprReturnsRecOrThrows.good
+++ b/test/errhandling/misc/forExprReturnsRecOrThrows.good
@@ -1,0 +1,1 @@
+Error caught


### PR DESCRIPTION
This PR adds a test for making sure that memory is alloced/dealloced properly
when initializing record arrays using loop expressions that call a throwing function.

Inspired by @mppf's [comment](https://github.com/chapel-lang/chapel/issues/14191#issuecomment-537444880) on #14191.