### PR TITLE
Fix a bug with taking the .type of a first class function

### DIFF
--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -2013,11 +2013,11 @@ static Expr* createFunctionAsValue(CallExpr *call) {
   //
   // In the longer term it might be good to generate a warning for this
   if (isBlockStmt(call->parentExpr) == true) {
-    call->insertBefore(new DefExpr(ts));
+    captured_fn->defPoint->insertBefore(new DefExpr(ts));
 
   // The common case in which the reference is within a move/assign/call
   } else {
-    call->parentExpr->insertBefore(new DefExpr(ts));
+    captured_fn->defPoint->insertBefore(new DefExpr(ts));
   }
 
   ct->dispatchParents.add(parent);

--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -2008,17 +2008,9 @@ static Expr* createFunctionAsValue(CallExpr *call) {
 
   TypeSymbol *ts = new TypeSymbol(astr(fcf_name.str().c_str()), ct);
 
-  // Allow a use of a FCF to appear at the statement level i.e.
-  //    nameOfFunc;
-  //
-  // In the longer term it might be good to generate a warning for this
-  if (isBlockStmt(call->parentExpr) == true) {
-    captured_fn->defPoint->insertBefore(new DefExpr(ts));
-
-  // The common case in which the reference is within a move/assign/call
-  } else {
-    captured_fn->defPoint->insertBefore(new DefExpr(ts));
-  }
+  // Add the definition before the definition of the captured function
+  // so that it is visible anywhere the captured function is.
+  captured_fn->defPoint->insertBefore(new DefExpr(ts));
 
   ct->dispatchParents.add(parent);
 

--- a/test/functions/firstClassFns/fcfType.chpl
+++ b/test/functions/firstClassFns/fcfType.chpl
@@ -1,0 +1,14 @@
+proc f1() { return 1; }
+proc f2 { return 2; }
+var f3 = 3;
+var f4 = lambda() { return 4; };
+
+var a = f1.type:string;
+var b = f2.type:string;
+var c = f3.type:string;
+var d = f4.type:string;
+
+writeln(a);
+writeln(b);
+writeln(c);
+writeln(d);

--- a/test/functions/firstClassFns/fcfType.good
+++ b/test/functions/firstClassFns/fcfType.good
@@ -1,0 +1,4 @@
+shared chpl__fcf_type_void_int64_t
+int(64)
+int(64)
+shared chpl__fcf_type_void_int64_t


### PR DESCRIPTION
The definition of the class created to represent a first class function was
being inserted just before the call that it was created for. In the case
of the test added in this commit, this was inside of a type block. Type blocks
get removed after type resolution, but there were still references to the
first class function and the methods associated with it.

Instead, insert it just before the definition of the function that it
represents so that it will be visible from anywhere the function is visible.