### PR TITLE
Load the correct python module before building on cs-perf cron job

### DIFF
--- a/util/cron/test-perf.cray-cs.gasnet-ibv.fast.bash
+++ b/util/cron/test-perf.cray-cs.gasnet-ibv.fast.bash
@@ -12,6 +12,7 @@ export CHPL_TEST_PERF_DIR=/cray/css/users/chapelu/NightlyPerformance/cray-cs/16-
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.cray-cs.gasnet-ibv.fast"
 
 module load gcc
+module load python/2.7.6
 
 export CHPL_HOST_PLATFORM=cray-cs
 export CHPL_GASNET_SEGMENT=fast

--- a/util/cron/test-perf.cray-cs.gasnet-ibv.large.bash
+++ b/util/cron/test-perf.cray-cs.gasnet-ibv.large.bash
@@ -12,6 +12,7 @@ export CHPL_TEST_PERF_DIR=/cray/css/users/chapelu/NightlyPerformance/cray-cs/16-
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.cray-cs.gasnet-ibv.large"
 
 module load gcc
+module load python/2.7.6
 
 export CHPL_HOST_PLATFORM=cray-cs
 export GASNET_PHYSMEM_MAX=83G

--- a/util/cron/test-perf.cray-cs.gasnet-mpi.bash
+++ b/util/cron/test-perf.cray-cs.gasnet-mpi.bash
@@ -13,6 +13,7 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.cray-cs.gasnet-mpi"
 
 module load gcc
 module load openmpi/gcc
+module load python/2.7.6
 
 export CHPL_HOST_PLATFORM=cray-cs
 export CHPL_COMM_SUBSTRATE=mpi


### PR DESCRIPTION
We have seen build failures on a CS system after an upgrade. This was due to not being able to install PyYAML. This PR loads the python module before build to fix that.